### PR TITLE
Unify scoring model across all evaluation modes

### DIFF
--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -140,14 +140,21 @@ Top 5 cambios al CV + Top 5 cambios a LinkedIn.
 
 #### Score Global
 
-| Dimensión | Score |
-|-----------|-------|
-| Match con CV | X/5 |
-| Alineación North Star | X/5 |
-| Comp | X/5 |
-| Señales culturales | X/5 |
-| Red flags | -X (si hay) |
-| **Global** | **X/5** |
+**Use the Canonical Scoring Model from `modes/_shared.md`.** All 10 dimensions, weighted exactly as defined there. This ensures scores from batch workers are directly comparable to scores from interactive evaluations and the `ofertas` comparison mode.
+
+| # | Dimension | Weight | Score |
+|---|-----------|--------|-------|
+| 1 | North Star alignment | 25% | X/5 |
+| 2 | CV match | 15% | X/5 |
+| 3 | Seniority fit | 15% | X/5 |
+| 4 | Comp estimate | 10% | X/5 |
+| 5 | Growth trajectory | 10% | X/5 |
+| 6 | Remote quality | 5% | X/5 |
+| 7 | Company reputation | 5% | X/5 |
+| 8 | Tech stack modernity | 5% | X/5 |
+| 9 | Speed to offer | 5% | X/5 |
+| 10 | Cultural signals | 5% | X/5 |
+| | **Weighted total** | | **X.X/5** |
 
 ### Paso 3 — Guardar Report .md
 

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -137,6 +137,36 @@ If the candidate has a live demo/dashboard (check profile.yml), offer access in 
 
 ---
 
+## Canonical Scoring Model (SINGLE SOURCE OF TRUTH)
+
+**ALL evaluation modes MUST use this exact model.** Whether the offer is evaluated via `oferta`, `auto-pipeline`, `batch`, or compared via `ofertas`, the score is computed the same way. This ensures scores are comparable across the entire pipeline.
+
+| # | Dimension | Weight | 1 | 3 | 5 |
+|---|-----------|--------|---|---|---|
+| 1 | North Star alignment | 25% | Unrelated to any target archetype | Adjacent — transferable skills apply | Exact target archetype match |
+| 2 | CV match | 15% | <40% requirements covered | 60-75% covered, gaps are soft | 90%+ covered with proof points |
+| 3 | Seniority fit | 15% | Junior / 2+ levels below | Mid-senior, manageable positioning | Staff+ or exact level match |
+| 4 | Comp estimate | 10% | Well below market / no data | Median for role+location | Top quartile or above target |
+| 5 | Growth trajectory | 10% | Dead end, no progression path | Some growth, unclear timeline | Clear path to next level |
+| 6 | Remote quality | 5% | On-site only, no flexibility | Hybrid with some flexibility | Full remote, async-friendly |
+| 7 | Company reputation | 5% | Red flags, poor reviews | Average employer, neutral signals | Top employer, strong brand |
+| 8 | Tech stack modernity | 5% | Legacy, no AI/ML relevance | Some modern tooling | Cutting-edge AI/ML stack |
+| 9 | Speed to offer | 5% | 6+ month process, bureaucratic | Standard 4-6 week process | Fast-track, <4 weeks typical |
+| 10 | Cultural signals | 5% | Bureaucratic, risk-averse | Mixed signals | Builder culture, high ownership |
+
+**Final score** = weighted sum, rounded to 1 decimal (e.g., 4.2/5).
+
+**Score interpretation (use consistently everywhere):**
+- **4.5-5.0** — Strong match. Generate PDF + draft answers. Apply promptly.
+- **3.5-4.4** — Good match. Generate PDF + draft answers. Worth applying with tailored CV.
+- **3.0-3.4** — Moderate match. Generate PDF. Flag gaps to candidate before applying.
+- **< 3.0** — Weak match. Report only. Explicitly discourage applying unless candidate has a specific reason.
+
+**PDF generation threshold:** >= 3.0 (consistent across all modes).
+**Draft answer threshold:** >= 3.5 (consistent across all modes).
+
+---
+
 ## Global Rules
 
 ### NEVER

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -25,9 +25,9 @@ Guardar la evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md
 ## Paso 3 — Generar PDF
 Ejecutar el pipeline completo de `pdf` (leer `modes/pdf.md`).
 
-## Paso 4 — Draft Application Answers (solo si score >= 4.5)
+## Paso 4 — Draft Application Answers (si score >= 3.5)
 
-Si el score final es >= 4.5, generar borrador de respuestas para el formulario de aplicación:
+Si el score final es >= 3.5 (per Canonical Scoring Model thresholds in `_shared.md`), generar borrador de respuestas para el formulario de aplicación:
 
 1. **Extraer preguntas del formulario**: Usar Playwright para navegar al formulario y hacer snapshot. Si no se pueden extraer, usar las preguntas genéricas.
 2. **Generar respuestas** siguiendo el tono (ver abajo).

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -138,6 +138,10 @@ Guardar evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 (lista de 15-20 keywords del JD para ATS optimization)
 ```
 
+### Score Global
+
+**Use the Canonical Scoring Model from `modes/_shared.md`.** All 10 weighted dimensions. Show the per-dimension breakdown in the report, then compute the weighted total as the final score.
+
 ### 2. Registrar en tracker
 
 **SIEMPRE** registrar en `data/applications.md`:
@@ -145,7 +149,7 @@ Guardar evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 - Fecha actual
 - Empresa
 - Rol
-- Score: promedio de match (1-5)
+- Score: weighted total from the Canonical Scoring Model (1-5)
 - Estado: `Evaluada`
 - PDF: ❌ (o ✅ si auto-pipeline generó PDF)
 - Report: link relativo al report .md (ej: `[001](reports/001-company-2026-01-01.md)`)

--- a/modes/ofertas.md
+++ b/modes/ofertas.md
@@ -1,21 +1,23 @@
 # Modo: ofertas — Comparación Multi-Oferta
 
-Scoring matrix de 10 dimensiones ponderadas:
+**Uses the Canonical Scoring Model from `modes/_shared.md`** — the same 10 weighted dimensions used in `oferta`, `auto-pipeline`, and `batch` evaluations. This means scores from prior evaluations are directly comparable. No need to re-score unless the user explicitly requests it.
 
-| Dimensión | Peso | Criterios 1-5 |
-|-----------|------|----------------|
-| Alineación North Star | 25% | 5=rol target exacto, 1=no relacionado |
-| Match CV | 15% | 5=90%+ match, 1=<40% match |
-| Nivel (senior+) | 15% | 5=staff+, 4=senior, 3=mid-senior, 2=mid, 1=junior |
-| Comp estimada | 10% | 5=top quartile, 1=below market |
-| Trayectoria crecimiento | 10% | 5=clear path to next level, 1=dead end |
-| Calidad remoto | 5% | 5=full remote async, 1=onsite only |
-| Reputación empresa | 5% | 5=top employer, 1=red flags |
-| Modernidad tech stack | 5% | 5=cutting edge AI/ML, 1=legacy |
-| Velocidad a oferta | 5% | 5=fast process, 1=6+ months |
-| Señales culturales | 5% | 5=builder culture, 1=bureaucratic |
+## Workflow
 
-Para cada oferta: score en cada dimensión, score ponderado total.
-Ranking final + recomendación con consideraciones de time-to-offer.
+1. **Gather offers**: Ask the user for offers if not in context. Can be text, URLs, or references to already-evaluated offers in the tracker.
+2. **Score each offer**: If an offer was already evaluated (has a report in `reports/`), read the existing per-dimension scores from the report. If not yet evaluated, score using the full Canonical Scoring Model.
+3. **Build comparison matrix**: Show all 10 dimensions side-by-side across offers, with the weighted total.
+4. **Rank and recommend**: Final ranking with recommendation. Highlight where offers differ most (the dimensions that actually discriminate). Include time-to-offer as a tiebreaker when scores are close (within 0.3).
 
-Pedir al usuario las ofertas si no están en contexto. Puede ser texto, URLs, o referencias a ofertas ya evaluadas en el tracker.
+## Output format
+
+```
+| Dimension (weight) | Offer A | Offer B | Offer C |
+|---------------------|---------|---------|---------|
+| North Star (25%) | X/5 | X/5 | X/5 |
+| CV match (15%) | ... | ... | ... |
+| ... | ... | ... | ... |
+| **Weighted total** | **X.X** | **X.X** | **X.X** |
+```
+
+Then: narrative recommendation explaining which offer to prioritize and why, considering both score and practical factors (timeline, leverage for negotiation, etc.).

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -9,7 +9,7 @@ Procesa URLs de ofertas acumuladas en `data/pipeline.md`. El usuario agrega URLs
    a. Calcular siguiente `REPORT_NUM` secuencial (leer `reports/`, tomar el número más alto + 1)
    b. **Extraer JD** usando Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
    c. Si la URL no es accesible → marcar como `- [!]` con nota y continuar
-   d. **Ejecutar auto-pipeline completo**: Evaluación A-F → Report .md → PDF (si score >= 3.0) → Tracker
+   d. **Ejecutar auto-pipeline completo**: Evaluación A-F → Report .md → PDF (si score >= 3.0, per `_shared.md` thresholds) → Draft answers (si score >= 3.5) → Tracker
    e. **Mover de "Pendientes" a "Procesadas"**: `- [x] #NNN | URL | Empresa | Rol | Score/5 | PDF ✅/❌`
 3. **Si hay 3+ URLs pendientes**, lanzar agentes en paralelo (Agent tool con `run_in_background`) para maximizar velocidad.
 4. **Al terminar**, mostrar tabla resumen:


### PR DESCRIPTION
## Summary

- Adds a **Canonical Scoring Model** in `_shared.md` — one 10-dimension weighted model that all modes reference
- Updates `batch-prompt.md`, `oferta.md`, `ofertas.md`, `auto-pipeline.md`, and `pipeline.md` to use it
- Lowers draft-answer threshold from 4.5 → 3.5 to close a gap in the workflow

## Why this matters

The pipeline had two incompatible scoring systems:

| Mode | Dimensions | Weighted? |
|------|-----------|-----------|
| `batch-prompt.md` | 6 (CV match, North Star, Comp, Cultural, Red flags) | No |
| `ofertas.md` | 10 (North Star, CV, Level, Comp, Growth, Remote, Reputation, Stack, Speed, Culture) | Yes |

A 4.2/5 from a batch worker measured something completely different than a 4.2/5 from the comparison mode. Every downstream decision — which offers get PDFs, which get draft answers, which get flagged as "don't apply" — was based on scores that weren't comparable across entry points. Over hundreds of evaluations, this means the ranking and filtering is unreliable.

This PR defines the model once in `_shared.md` and has all modes reference it, so a score means the same thing regardless of how the offer was evaluated.

The draft-answer threshold change (4.5 → 3.5) addresses a related gap: offers scoring 3.0-4.4 were generating PDFs but no draft answers, even though those medium-fit roles are exactly where good framing makes the difference between applying or not.

## Test plan

- [ ] Evaluate an offer via `oferta` mode — verify report includes 10-dimension breakdown
- [ ] Run a batch evaluation — verify worker uses same 10 dimensions
- [ ] Compare two previously-evaluated offers via `ofertas` — verify it reads existing per-dimension scores from reports
- [ ] Evaluate an offer scoring ~3.8 via `auto-pipeline` — verify draft answers are generated (previously required 4.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)