### PR TITLE
Add anti-AI-detection writing rules for CV generation

### DIFF
--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -242,6 +242,16 @@ node generate-pdf.mjs \
 - NUNCA añadir skills the candidate doesn't have
 - Ejemplo: JD dice "RAG pipelines" y CV dice "LLM workflows with retrieval" → "RAG pipeline design and LLM orchestration workflows"
 
+**Writing style — Anti-AI-detection (CRITICAL):**
+ATS platforms (Indeed, LinkedIn, Workday) flag AI-generated CVs. All generated text MUST read as human-written:
+- **Vary sentence length.** Mix short fragments with longer sentences. Don't make every bullet the same length.
+- **Start bullets differently.** Not every bullet should begin with a past-tense action verb.
+- **Use the candidate's own phrasing from cv.md when possible.** Reformulate for keywords, but preserve their voice.
+- **NEVER use these AI-hallmark words:** "leveraged", "utilized", "spearheaded", "orchestrated" (as metaphor), "cutting-edge", "passionate about", "drive innovation", "synergy", "holistic approach", "navigate complex", "foster collaboration".
+- **Use plain, specific verbs.** "Built" not "architected". "Ran" not "orchestrated". "Fixed" not "remediated".
+- **Don't over-polish.** Real CVs have minor asymmetries — one job has 4 bullets, another has 3. Don't normalize everything.
+- **Self-check before generating HTML:** (1) Do 3+ bullets start with same word? Fix. (2) Are all bullets same length? Vary. (3) Any AI-hallmark words? Rewrite.
+
 **Template placeholders (en cv-template.html):**
 
 | Placeholder | Contenido |
@@ -346,6 +356,7 @@ Si algo falla:
 4. Recomendar comp por debajo de mercado
 5. Generar PDF sin leer primero el JD
 6. Usar corporate-speak
+7. Use AI-hallmark words: "leveraged", "utilized", "spearheaded", "orchestrated" (as metaphor), "cutting-edge", "passionate about", "drive innovation", "synergy", "holistic approach". ATS platforms flag these.
 
 ### SIEMPRE
 1. Leer cv.md, llms.txt y article-digest.md antes de evaluar

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -149,6 +149,7 @@ If the candidate has a live demo/dashboard (check profile.yml), offer access in 
 6. Generate a PDF without reading the JD first
 7. Use corporate-speak
 8. Ignore the tracker (every evaluated offer gets registered)
+9. Use AI-hallmark words: "leveraged", "utilized", "spearheaded", "orchestrated" (as metaphor), "cutting-edge", "passionate about", "drive innovation", "synergy", "holistic approach", "navigate complex", "foster collaboration". ATS platforms flag these. Use plain, specific verbs instead.
 
 ### ALWAYS
 

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -60,6 +60,32 @@ Ejemplos de reformulación legítima:
 
 **NUNCA añadir skills que el candidato no tiene. Solo reformular experiencia real con el vocabulario exacto del JD.**
 
+## Writing Style — Anti-AI-Detection (CRITICAL)
+
+ATS platforms (Indeed, LinkedIn, Workday) increasingly flag AI-generated CVs. The PDF generation MUST produce text that reads as human-written. This is not about deception — it's about ensuring the candidate's real experience isn't filtered out by an automated detector before a human ever sees it.
+
+### Sentence structure
+- **Vary sentence length deliberately.** Mix short punchy fragments ("Shipped in 3 weeks.") with longer compound sentences. AI text tends toward uniform medium-length sentences.
+- **Start bullets differently.** Don't begin every bullet with a past-tense action verb. Mix structures: "Led...", "The team needed X, so I...", "After discovering Y, rebuilt Z to..."
+- **Use the candidate's actual phrasing from cv.md when possible.** The candidate's own words have natural irregularities that AI-generated text lacks. Preserve their voice — reformulate for keywords, but don't rewrite the whole sentence.
+
+### Word choice
+- **Avoid AI-hallmark phrases.** Never use: "leveraged", "utilized", "spearheaded", "orchestrated" (as a metaphor for "managed"), "cutting-edge", "passionate about", "drive innovation", "synergy", "holistic approach", "navigate complex", "foster collaboration". These are the first things detectors look for.
+- **Use plain, specific verbs.** "Built" not "architected". "Ran" not "orchestrated". "Fixed" not "remediated". "Cut costs by" not "optimized cost efficiency". The more specific and concrete, the more human it reads.
+- **Preserve technical jargon as-is.** Real engineers say "k8s" not "Kubernetes orchestration platform". Keep the candidate's natural shorthand.
+
+### Structure
+- **Don't over-polish.** A real CV has minor asymmetries — one job has 4 bullets, another has 3. One bullet is 2 lines, the next is 1. Don't normalize everything to uniform length.
+- **Keep the Professional Summary under 4 sentences.** AI-generated summaries tend to be dense paragraphs that try to cover everything. A human writes a tighter summary and lets the experience section do the work.
+- **Don't repeat the same metric in both the summary and a bullet.** Humans don't do this. Pick the best place for each number.
+
+### Self-check before generating HTML
+After drafting all CV content, review it once for:
+1. Do 3+ bullets start with the same word? → Rewrite the openings.
+2. Are all bullets the same length (± 5 words)? → Vary them.
+3. Does any sentence contain 2+ words from the AI-hallmark list above? → Rewrite.
+4. Does the summary read like a paragraph from a cover letter? → Make it more telegraphic.
+
 ## Template HTML
 
 Usar el template en `cv-template.html`. Reemplazar los placeholders `{{...}}` con contenido personalizado:


### PR DESCRIPTION
Fixes #1

## Summary

- Adds a banned word list of AI-hallmark phrases that ATS detectors flag first ("leveraged", "spearheaded", "utilized", "cutting-edge", etc.)
- Adds sentence variation rules: vary bullet length, don't start every bullet with a past-tense verb, allow natural asymmetry
- Requires preserving the candidate's own phrasing from cv.md instead of rewriting entire sentences
- Adds a self-check step before HTML generation (repeated openings, uniform length, hallmark words)
- Applied to `modes/pdf.md`, `modes/_shared.md` NEVER list, and `batch/batch-prompt.md` (since batch workers are self-contained)

## Why this matters

As reported in #1, Indeed, LinkedIn, and other platforms are filtering out AI-generated resumes before a recruiter sees them. The pipeline had no guidance on avoiding detectable patterns, so generated CVs had the classic AI tells:

1. **Uniform sentence length** — every bullet roughly the same word count
2. **Repetitive structure** — every bullet starts with "[Past verb] [noun]..."
3. **AI-hallmark vocabulary** — "leveraged", "spearheaded", "utilized" appear nowhere in how real engineers describe their work, but appear in nearly every AI-generated CV
4. **Over-polished symmetry** — every job has exactly the same number of bullets, same length

The fix addresses each of these with concrete, actionable rules rather than vague "write naturally" guidance. The self-check step at the end catches anything that slips through.

## Test plan

- [ ] Generate a PDF via `auto-pipeline` — verify no banned words appear in output
- [ ] Compare bullet structures across jobs — verify they vary in length and opening word
- [ ] Check that candidate's original phrasing from cv.md is preserved where possible
- [ ] Run a batch worker — verify the same rules apply (batch-prompt.md is self-contained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)