### PR TITLE
Add story bank pruning and match tracking

### DIFF
--- a/interview-prep/story-bank.md
+++ b/interview-prep/story-bank.md
@@ -11,12 +11,14 @@ This file accumulates your best interview stories over time. Each evaluation (Bl
    - "Tell me about your most impactful project" → pick your highest-impact story
    - "Tell me about a conflict you resolved" → find a story with a Reflection
 
-## Stories
+## Stories (max 10-12 — curated, not logged)
 
 <!-- Stories will be added here as you evaluate offers -->
 <!-- Format:
 ### [Theme] Story Title
 **Source:** Report #NNN — Company — Role
+**Archetypes:** LLMOps, Platform, FDE (which role archetypes this story fits best)
+**Matched N evaluations:** #NNN, #NNN, ... (updated each time this story maps to a new JD)
 **S (Situation):** ...
 **T (Task):** ...
 **A (Action):** ...
@@ -24,3 +26,16 @@ This file accumulates your best interview stories over time. Each evaluation (Bl
 **Reflection:** What I learned / what I'd do differently
 **Best for questions about:** [list of question types this story answers]
 -->
+
+<!-- Management rules (enforced by oferta mode Block F):
+- Before adding: check if an existing story covers the same theme
+- If overlap: keep the stronger story, update its match count, remove the weaker
+- If new theme: append
+- Cap at 12. If over: retire lowest-match story to ## Retired section below
+- Stories with most matches = most versatile = practice first
+-->
+
+## Retired
+
+<!-- Stories moved here when replaced by stronger alternatives or when the bank exceeds 12.
+     Not deleted — may be useful for niche roles. -->

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -71,7 +71,16 @@ Top 5 cambios al CV + Top 5 cambios a LinkedIn para maximizar match.
 
 The **Reflection** column captures what was learned or what would be done differently. This signals seniority — junior candidates describe what happened, senior candidates extract lessons.
 
-**Story Bank:** If `interview-prep/story-bank.md` exists, check if any of these stories are already there. If not, append new ones. Over time this builds a reusable bank of 5-10 master stories that can be adapted to any interview question.
+**Story Bank:** If `interview-prep/story-bank.md` exists, manage it actively — not just append:
+
+1. **Check for existing stories** that cover the same theme (e.g., "technical leadership", "delivery under pressure"). Use the `**Best for questions about:**` tags to match.
+2. **If a new story covers the same theme as an existing one**, compare them. Keep the one with stronger quantified results and broader applicability. Update the match count on the keeper. Remove the weaker one.
+3. **If a new story covers a NEW theme**, append it.
+4. **Update match counts**: Each story should have a `**Matched N evaluations:**` line listing which reports used it (e.g., `Matched 5 evaluations: #012, #045, #078, #102, #115`). Stories that match many JDs are the most versatile — they should be practiced first.
+5. **Cap at 10-12 stories max.** If adding a new story would exceed 12, retire the story with the fewest matches and narrowest applicability. Move retired stories to a `## Retired` section at the bottom (don't delete — they might be useful for niche roles).
+6. **Tag archetypes**: Each story should have `**Archetypes:**` listing which role archetypes it's strongest for (e.g., `LLMOps, Platform`).
+
+The goal is a curated bank of 10 versatile stories, not an ever-growing log.
 
 **Seleccionadas y enmarcadas según el arquetipo:**
 - FDE → enfatizar velocidad de entrega y client-facing


### PR DESCRIPTION
## Summary

- Story bank is now actively managed: theme-based dedup, match counting, cap at 12, retirement of weak stories
- Each story tracks which evaluations it matched and which archetypes it fits
- Updated `story-bank.md` template with new fields and a Retired section

## Why this matters

The story bank instruction was "if stories aren't there, append them." Over 100+ evaluations this creates an unbounded list of overlapping stories — multiple variations of "delivered under pressure" or "led a technical decision" with no way to know which is strongest.

Interview prep is most effective with 8-10 well-practiced stories that cover the widest range of questions. A story that mapped to 15 different JD requirements is far more valuable than one that matched once. Match counting surfaces this signal, and the 12-story cap forces curation rather than accumulation.

### Before
```
Evaluation #1 → append 6 stories
Evaluation #2 → append 6 more (some overlap with #1)
Evaluation #50 → 200+ stories, no ranking, no pruning
```

### After
```
Evaluation #1 → add 6 stories, tag archetypes
Evaluation #2 → 3 overlap existing themes → keep stronger version, update match count. 3 new → append.
Evaluation #50 → 10-12 curated stories, each with match counts, weakest retired
```

## Test plan

- [ ] Run `/career-ops oferta` on a new role — verify Block F checks existing stories before appending
- [ ] Evaluate a second role with overlapping requirements — verify stories are deduplicated by theme, not duplicated
- [ ] After 12+ evaluations — verify the bank stays at ≤12 active stories with a Retired section

🤖 Generated with [Claude Code](https://claude.com/claude-code)