### PR TITLE
Scope Playwright verification rule for batch workers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,10 +141,18 @@ This system is designed to be customized by YOU (Claude). When the user asks you
 
 ## Offer Verification -- MANDATORY
 
-**NEVER trust WebSearch/WebFetch to verify if an offer is still active.** ALWAYS use Playwright:
+**When Playwright is available** (interactive sessions, `--chrome` mode), ALWAYS use it to verify offers:
 1. `browser_navigate` to the URL
 2. `browser_snapshot` to read content
 3. Only footer/navbar without JD = closed. Title + description + Apply = active.
+
+**When Playwright is NOT available** (batch workers via `claude -p`, headless environments):
+1. Use WebFetch to retrieve the page content
+2. Check for JD text, job title, and apply button/link in the response
+3. If WebFetch returns only a shell/navbar (no JD content), mark the offer as `**Verification: unconfirmed**` in the report header
+4. Do NOT skip the evaluation — proceed but flag the uncertainty so the user can verify manually before applying
+
+The goal is to never waste time on closed offers, but also never silently assume a role is active when verification was incomplete.
 
 ---
 

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -43,9 +43,12 @@ Eres un worker de evaluación de ofertas de empleo for the candidate (read name 
 
 ### Paso 1 — Obtener JD
 
+**Note: Batch workers do NOT have Playwright/browser access.** Use WebFetch only.
+
 1. Lee el archivo JD en `{{JD_FILE}}`
 2. Si el archivo está vacío o no existe, intenta obtener el JD desde `{{URL}}` con WebFetch
-3. Si ambos fallan, reporta error y termina
+3. If WebFetch returns content but it looks like a shell page (no JD text, just navbar/footer), add `**Verification: unconfirmed**` to the report header and proceed — the conductor or user will verify later
+4. Si ambos fallan, reporta error y termina
 
 ### Paso 2 — Evaluación A-F
 


### PR DESCRIPTION
## Summary

- CLAUDE.md verification rule now distinguishes interactive (use Playwright) vs batch (use WebFetch + flag)
- Batch workers add `**Verification: unconfirmed**` to report header when they can't fully verify an offer
- batch-prompt.md explicitly documents the no-Playwright constraint

## Why this matters

CLAUDE.md says "NEVER trust WebSearch/WebFetch to verify if an offer is still active — ALWAYS use Playwright." But batch workers (`claude -p`) don't have browser access. They silently fell back to WebFetch, which contradicts the mandatory rule and produces reports with no indication that verification was incomplete.

This means a batch-evaluated offer might be closed, and the user wouldn't know the verification was weaker than usual. The fix makes the verification quality transparent: batch reports say "unconfirmed" so the user knows to check before investing time in an application.

## Test plan

- [ ] Run a batch evaluation — verify report header includes `**Verification: unconfirmed**` when WebFetch was used
- [ ] Run an interactive evaluation with Playwright — verify it still uses browser_navigate + browser_snapshot (no change)
- [ ] Verify a batch worker encountering a shell page (no JD) flags it but still proceeds with evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)