### PR TITLE
Add scoring calibration anchors to prevent score drift

### DIFF
--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -137,6 +137,29 @@ If the candidate has a live demo/dashboard (check profile.yml), offer access in 
 
 ---
 
+## Scoring Calibration Anchors
+
+**Use these reference profiles to anchor scores and prevent drift over time.** When evaluating an offer, mentally compare it to these anchors before assigning a final score. Scores should be relative to the candidate's actual profile, not absolute.
+
+<!-- [CUSTOMIZE] Replace these with real offers you've evaluated, or archetypes
+     that represent clear score levels for YOUR situation. The examples below
+     are generic starting points — after 10-20 evaluations, replace them with
+     actual reports from your pipeline (e.g., "Report #045 — Anthropic — 4.7/5"). -->
+
+| Score | What it looks like | Example anchor |
+|-------|--------------------|----------------|
+| **5.0** | Dream role. Exact archetype, 90%+ CV match, top-quartile comp, remote, strong brand, fast process. You'd accept immediately. | _Replace with your highest-scored report once you have one_ |
+| **4.0** | Strong match. Right archetype, 75%+ match, fair comp, minor gaps that are easy to frame. Worth a tailored application. | _Replace with a real ~4.0 report_ |
+| **3.0** | Moderate match. Adjacent archetype, 50-60% match, some hard gaps, comp unknown or median. Worth evaluating but not a priority. | _Replace with a real ~3.0 report_ |
+| **2.0** | Weak match. Wrong seniority or archetype, major gaps, below-market comp signals. Discourage unless specific reason. | _Replace with a real ~2.0 report_ |
+| **1.0** | No fit. Unrelated domain, entry-level, relocation-only, or red flags. Skip. | _Replace with a real ~1.0 report_ |
+
+**Recalibration trigger:** After every 50 evaluations (or when you notice scores clustering — e.g., everything is 3.5-4.2), review the anchors table. Replace generic descriptions with actual reports. If your best offer so far is a 4.3, that's your effective ceiling — adjust the 5.0 anchor to reflect what a true dream role would actually look like for you.
+
+**How to use during evaluation:** After computing the weighted score, sanity-check it against the anchors. "Is this really a 4.5? Is it as strong as [anchor report]?" If not, adjust. The anchors prevent both inflation (everything is 4+) and deflation (nothing breaks 3.5).
+
+---
+
 ## Global Rules
 
 ### NEVER


### PR DESCRIPTION
## Summary

- Adds a calibration anchors table in `_shared.md` with reference profiles for score levels 1.0 through 5.0
- Users replace generic descriptions with actual reports from their pipeline over time
- Includes a recalibration trigger every 50 evaluations to review and update anchors

## Why this matters

After many evaluations, scores cluster in a narrow range with no external reference point. Without anchors, a 4.2 means "somewhat good" but there's no way to tell if that's inflated (everything is 4+) or deflated (nothing breaks 4.5). The scoring model defines what each dimension means, but not what the overall result should feel like.

Calibration anchors give concrete benchmarks: "Is this offer really as strong as Report #045?" This is the same principle used in performance review calibration — you need reference cases to keep ratings consistent across time.

The anchors are designed to be customized: start with generic descriptions, then replace them with real reports as the user builds their pipeline. After 50+ evaluations, every anchor should point to an actual report.

## Test plan

- [ ] Evaluate an offer — verify the sanity-check step references the anchor table
- [ ] After 10+ evaluations, replace a generic anchor with a real report reference
- [ ] Verify scores don't cluster when using anchors as comparison points

🤖 Generated with [Claude Code](https://claude.com/claude-code)