### PR TITLE
Add Contacted as canonical state, align scripts to English labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,7 @@ Write one TSV file per evaluation to `batch/tracker-additions/{num}-{company-slu
 | `Evaluated` | Report completed, pending decision |
 | `Applied` | Application sent |
 | `Responded` | Company responded |
+| `Contacted` | Candidate proactively reached out (LinkedIn, email) — awaiting response |
 | `Interview` | In interview process |
 | `Offer` | Offer received |
 | `Rejected` | Rejected by company |

--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -22,14 +22,15 @@ const DRY_RUN = process.argv.includes('--dry-run');
 // Status advancement order (higher = more advanced in pipeline)
 // Aplicado > Rechazado because active application > terminal state
 const STATUS_RANK = {
-  'no aplicar': 0,
-  'descartado': 0,
-  'rechazado': 1,  // Terminal — below active states
-  'evaluada': 2,
-  'aplicado': 3,
-  'respondido': 4,
-  'entrevista': 5,
-  'oferta': 6,
+  'skip': 0, 'no aplicar': 0,
+  'discarded': 0, 'descartado': 0,
+  'rejected': 1, 'rechazado': 1,  // Terminal — below active states
+  'evaluated': 2, 'evaluada': 2,
+  'applied': 3, 'aplicado': 3,
+  'contacted': 3.5, 'contacto': 3.5, 'contactado': 3.5,
+  'responded': 4, 'respondido': 4,
+  'interview': 5, 'entrevista': 5,
+  'offer': 6, 'oferta': 6,
 };
 
 function normalizeCompany(name) {

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -28,7 +28,7 @@ const DRY_RUN = process.argv.includes('--dry-run');
 const VERIFY = process.argv.includes('--verify');
 
 // Canonical states and aliases
-const CANONICAL_STATES = ['Evaluada', 'Aplicado', 'Respondido', 'Entrevista', 'Oferta', 'Rechazado', 'Descartado', 'NO APLICAR'];
+const CANONICAL_STATES = ['Evaluated', 'Applied', 'Contacted', 'Responded', 'Interview', 'Offer', 'Rejected', 'Discarded', 'SKIP'];
 
 function validateStatus(status) {
   const clean = status.replace(/\*\*/g, '').replace(/\s+\d{4}-\d{2}-\d{2}.*$/, '').trim();
@@ -38,14 +38,18 @@ function validateStatus(status) {
     if (valid.toLowerCase() === lower) return valid;
   }
 
-  // Aliases
+  // Aliases (maps legacy Spanish + variations → canonical English)
   const aliases = {
-    'enviada': 'Aplicado', 'aplicada': 'Aplicado', 'applied': 'Aplicado', 'sent': 'Aplicado',
-    'cerrada': 'Descartado', 'descartada': 'Descartado', 'cancelada': 'Descartado',
-    'rechazada': 'Rechazado',
-    'no aplicar': 'NO APLICAR', 'no_aplicar': 'NO APLICAR', 'skip': 'NO APLICAR', 'monitor': 'NO APLICAR',
-    'condicional': 'Evaluada', 'hold': 'Evaluada', 'evaluar': 'Evaluada', 'verificar': 'Evaluada',
-    'geo blocker': 'NO APLICAR',
+    'evaluada': 'Evaluated', 'condicional': 'Evaluated', 'hold': 'Evaluated', 'evaluar': 'Evaluated', 'verificar': 'Evaluated',
+    'enviada': 'Applied', 'aplicada': 'Applied', 'aplicado': 'Applied', 'applied': 'Applied', 'sent': 'Applied',
+    'contacto': 'Contacted', 'contactado': 'Contacted',
+    'respondido': 'Responded',
+    'entrevista': 'Interview',
+    'oferta': 'Offer',
+    'cerrada': 'Discarded', 'descartada': 'Discarded', 'descartado': 'Discarded', 'cancelada': 'Discarded',
+    'rechazada': 'Rejected', 'rechazado': 'Rejected',
+    'no aplicar': 'SKIP', 'no_aplicar': 'SKIP', 'skip': 'SKIP', 'monitor': 'SKIP',
+    'geo blocker': 'SKIP',
   };
 
   if (aliases[lower]) return aliases[lower];
@@ -134,8 +138,8 @@ function parseTsvContent(content, filename) {
     const col5 = parts[5].trim();
     const col4LooksLikeScore = /^\d+\.?\d*\/5$/.test(col4) || col4 === 'N/A' || col4 === 'DUP';
     const col5LooksLikeScore = /^\d+\.?\d*\/5$/.test(col5) || col5 === 'N/A' || col5 === 'DUP';
-    const col4LooksLikeStatus = /^(evaluada|aplicado|respondido|entrevista|oferta|rechazado|descartado|no aplicar|cerrada|duplicado|repost|condicional|hold|monitor)/i.test(col4);
-    const col5LooksLikeStatus = /^(evaluada|aplicado|respondido|entrevista|oferta|rechazado|descartado|no aplicar|cerrada|duplicado|repost|condicional|hold|monitor)/i.test(col5);
+    const col4LooksLikeStatus = /^(evaluated|applied|contacted|responded|interview|offer|rejected|discarded|skip|evaluada|aplicado|contacto|contactado|respondido|entrevista|oferta|rechazado|descartado|no aplicar|cerrada|duplicado|repost|condicional|hold|monitor)/i.test(col4);
+    const col5LooksLikeStatus = /^(evaluated|applied|contacted|responded|interview|offer|rejected|discarded|skip|evaluada|aplicado|contacto|contactado|respondido|entrevista|oferta|rechazado|descartado|no aplicar|cerrada|duplicado|repost|condicional|hold|monitor)/i.test(col5);
 
     let statusCol, scoreCol;
     if (col4LooksLikeStatus && !col4LooksLikeScore) {

--- a/modes/tracker.md
+++ b/modes/tracker.md
@@ -7,11 +7,13 @@ Lee y muestra `data/applications.md`.
 | # | Fecha | Empresa | Rol | Score | Estado | PDF | Report |
 ```
 
-Estados posibles: `Evaluada` → `Aplicado` → `Respondido` → `Contacto` → `Entrevista` → `Oferta` / `Rechazada` / `Descartada` / `NO APLICAR`
+Estados posibles (canonical, per `templates/states.yml`):
 
-- `Aplicado` = el candidato envió su candidatura
-- `Respondido` = Un recruiter/empresa contactó y el candidato respondió (inbound)
-- `Contacto` = El candidato contactó proactivamente a alguien de la empresa (outbound, ej: LinkedIn power move)
+`Evaluated` → `Applied` → `Contacted` → `Responded` → `Interview` → `Offer` / `Rejected` / `Discarded` / `SKIP`
+
+- `Applied` = the candidate submitted their application
+- `Contacted` = the candidate proactively reached out to someone at the company (outbound, e.g., LinkedIn power move via `/career-ops contacto`)
+- `Responded` = a recruiter/company contacted back and the candidate responded (inbound)
 
 Si el usuario pide actualizar un estado, editar la fila correspondiente.
 

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -27,66 +27,75 @@ function normalizeStatus(raw) {
   let s = raw.replace(/\*\*/g, '').trim();
   const lower = s.toLowerCase();
 
-  // DUPLICADO variants → Descartado
+  // DUPLICADO variants → Discarded
   if (/^duplicado/i.test(s) || /^dup\b/i.test(s)) {
-    return { status: 'Descartado', moveToNotes: raw.trim() };
+    return { status: 'Discarded', moveToNotes: raw.trim() };
   }
 
-  // CERRADA → Descartado
-  if (/^cerrada$/i.test(s)) return { status: 'Descartado' };
+  // CERRADA → Discarded
+  if (/^cerrada$/i.test(s)) return { status: 'Discarded' };
 
-  // Cancelada (possibly with date) → Descartado
-  if (/^cancelada/i.test(s)) return { status: 'Descartado' };
+  // Cancelada (possibly with date) → Discarded
+  if (/^cancelada/i.test(s)) return { status: 'Discarded' };
 
-  // Descartada → Descartado
-  if (/^descartada$/i.test(s)) return { status: 'Descartado' };
+  // Descartada/Descartado → Discarded
+  if (/^descartad[ao]$/i.test(s)) return { status: 'Discarded' };
 
-  // Rechazada → Rechazado
-  if (/^rechazada$/i.test(s)) return { status: 'Rechazado' };
+  // Rechazada/Rechazado → Rejected
+  if (/^rechazad[ao]$/i.test(s)) return { status: 'Rejected' };
 
-  // Rechazado with date → Rechazado (strip date)
-  if (/^rechazado\s+\d{4}/i.test(s)) return { status: 'Rechazado' };
+  // Rechazado with date → Rejected (strip date)
+  if (/^rechazado\s+\d{4}/i.test(s)) return { status: 'Rejected' };
 
-  // Aplicado with date → Aplicado (strip date)
-  if (/^aplicado\s+\d{4}/i.test(s)) return { status: 'Aplicado' };
+  // Aplicado with date → Applied (strip date)
+  if (/^aplicado\s+\d{4}/i.test(s)) return { status: 'Applied' };
 
-  // CONDICIONAL → Evaluada
-  if (/^condicional$/i.test(s)) return { status: 'Evaluada' };
+  // Contacto/Contactado → Contacted
+  if (/^contacto$/i.test(s) || /^contactado$/i.test(s)) return { status: 'Contacted' };
 
-  // HOLD → Evaluada
-  if (/^hold$/i.test(s)) return { status: 'Evaluada' };
+  // CONDICIONAL → Evaluated
+  if (/^condicional$/i.test(s)) return { status: 'Evaluated' };
 
-  // MONITOR → Evaluada
-  if (/^monitor$/i.test(s)) return { status: 'Evaluada' };
+  // HOLD → Evaluated
+  if (/^hold$/i.test(s)) return { status: 'Evaluated' };
 
-  // EVALUAR → Evaluada
-  if (/^evaluar$/i.test(s)) return { status: 'Evaluada' };
+  // MONITOR → Evaluated
+  if (/^monitor$/i.test(s)) return { status: 'Evaluated' };
 
-  // Verificar → Evaluada
-  if (/^verificar$/i.test(s)) return { status: 'Evaluada' };
+  // EVALUAR → Evaluated
+  if (/^evaluar$/i.test(s)) return { status: 'Evaluated' };
 
-  // GEO BLOCKER → NO APLICAR
-  if (/geo.?blocker/i.test(s)) return { status: 'NO APLICAR' };
+  // Verificar → Evaluated
+  if (/^verificar$/i.test(s)) return { status: 'Evaluated' };
 
-  // Repost #NNN → Descartado
-  if (/^repost/i.test(s)) return { status: 'Descartado', moveToNotes: raw.trim() };
+  // GEO BLOCKER → SKIP
+  if (/geo.?blocker/i.test(s)) return { status: 'SKIP' };
+
+  // Repost #NNN → Discarded
+  if (/^repost/i.test(s)) return { status: 'Discarded', moveToNotes: raw.trim() };
 
   // "—" (em dash, no status) → Descartado
   if (s === '—' || s === '-' || s === '') return { status: 'Descartado' };
 
   // Already canonical — just fix casing/bold
   const canonical = [
-    'Evaluada', 'Aplicado', 'Respondido', 'Entrevista',
-    'Oferta', 'Rechazado', 'Descartado', 'NO APLICAR',
+    'Evaluated', 'Applied', 'Contacted', 'Responded', 'Interview',
+    'Offer', 'Rejected', 'Discarded', 'SKIP',
   ];
   for (const c of canonical) {
     if (lower === c.toLowerCase()) return { status: c };
   }
 
   // Aliases from states.yml
-  if (['enviada', 'aplicada', 'applied', 'sent'].includes(lower)) return { status: 'Aplicado' };
-  if (['cerrada', 'descartada'].includes(lower)) return { status: 'Descartado' };
-  if (['no aplicar', 'no_aplicar', 'skip'].includes(lower)) return { status: 'NO APLICAR' };
+  if (['enviada', 'aplicada', 'aplicado', 'applied', 'sent'].includes(lower)) return { status: 'Applied' };
+  if (['contacto', 'contactado'].includes(lower)) return { status: 'Contacted' };
+  if (['respondido'].includes(lower)) return { status: 'Responded' };
+  if (['evaluada'].includes(lower)) return { status: 'Evaluated' };
+  if (['entrevista'].includes(lower)) return { status: 'Interview' };
+  if (['oferta'].includes(lower)) return { status: 'Offer' };
+  if (['cerrada', 'descartada', 'descartado'].includes(lower)) return { status: 'Discarded' };
+  if (['rechazado', 'rechazada'].includes(lower)) return { status: 'Rejected' };
+  if (['no aplicar', 'no_aplicar', 'skip'].includes(lower)) return { status: 'SKIP' };
 
   // Unknown — flag it
   return { status: null, unknown: true };

--- a/templates/states.yml
+++ b/templates/states.yml
@@ -25,6 +25,12 @@ states:
     description: Company has responded (not yet interview)
     dashboard_group: responded
 
+  - id: contacted
+    label: Contacted
+    aliases: [contacto, contactado]
+    description: Candidate proactively reached out (LinkedIn, email) — not yet a response
+    dashboard_group: contacted
+
   - id: interview
     label: Interview
     aliases: [entrevista]

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -29,15 +29,23 @@ const STATES_FILE = existsSync(join(CAREER_OPS, 'templates/states.yml'))
   : join(CAREER_OPS, 'states.yml');
 
 const CANONICAL_STATUSES = [
-  'evaluada', 'aplicado', 'respondido', 'entrevista',
+  'evaluated', 'applied', 'contacted', 'responded', 'interview',
+  'offer', 'rejected', 'discarded', 'skip',
+  // Legacy Spanish aliases (still accepted)
+  'evaluada', 'aplicado', 'contacto', 'contactado', 'respondido', 'entrevista',
   'oferta', 'rechazado', 'descartado', 'no aplicar',
 ];
 
 const ALIASES = {
-  'enviada': 'aplicado', 'aplicada': 'aplicado', 'applied': 'aplicado', 'sent': 'aplicado',
-  'cerrada': 'descartado', 'descartada': 'descartado', 'cancelada': 'descartado',
-  'rechazada': 'rechazado',
-  'no_aplicar': 'no aplicar', 'skip': 'no aplicar', 'monitor': 'no aplicar',
+  'enviada': 'applied', 'aplicada': 'applied', 'aplicado': 'applied', 'sent': 'applied',
+  'contacto': 'contacted', 'contactado': 'contacted',
+  'respondido': 'responded',
+  'evaluada': 'evaluated',
+  'entrevista': 'interview',
+  'oferta': 'offer',
+  'cerrada': 'discarded', 'descartada': 'discarded', 'descartado': 'discarded', 'cancelada': 'discarded',
+  'rechazada': 'rejected', 'rechazado': 'rejected',
+  'no_aplicar': 'skip', 'no aplicar': 'skip', 'monitor': 'skip',
 };
 
 let errors = 0;


### PR DESCRIPTION
## Summary

- Adds `Contacted` state to `templates/states.yml` between Applied and Responded
- Updates `CLAUDE.md` canonical states table
- Fixes `tracker.md` to use canonical English labels
- Aligns all Node scripts (`verify-pipeline.mjs`, `merge-tracker.mjs`, `normalize-statuses.mjs`, `dedup-tracker.mjs`) to English canonical labels with Spanish aliases for backwards compatibility

## Why this matters

`tracker.md` defined a `Contacto` state for tracking LinkedIn outreach (via `/career-ops contacto`), but it wasn't in `states.yml`. The verify and normalize scripts would flag it as non-canonical and either error or normalize it away. This meant the pipeline couldn't reliably track whether outreach had been done for a given application — which is a meaningful signal for deciding follow-up actions.

The state progression is now: `Evaluated → Applied → Contacted → Responded → Interview → Offer`

Where `Contacted` means "candidate proactively reached out (LinkedIn, email) — awaiting response." This sits naturally between Applied (application sent) and Responded (company replied), since outreach often happens after applying but before hearing back.

### Script alignment

The scripts also had hardcoded Spanish state names that didn't match `states.yml` (which uses English labels). This PR aligns everything to English as the canonical form with Spanish aliases preserved, preventing the verify script from incorrectly flagging entries.

## Test plan

- [ ] Run `node verify-pipeline.mjs` — verify no false errors for `Contacted` entries
- [ ] Run `node normalize-statuses.mjs --dry-run` — verify `Contacto` normalizes to `Contacted`
- [ ] After running `/career-ops contacto`, update tracker to `Contacted` — verify it persists through merge and dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)