### PR TITLE
Add followup, rejection, and negotiation modes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,9 @@ This system is designed to be customized by YOU (Claude). When the user asks you
 | Searches for new offers | `scan` |
 | Processes pending URLs | `pipeline` |
 | Batch processes offers | `batch` |
+| Asks what needs follow-up | `followup` |
+| Reports a rejection | `rejection` |
+| Receives a job offer | `negotiation` |
 
 ### CV Source of Truth
 

--- a/modes/followup.md
+++ b/modes/followup.md
@@ -1,0 +1,65 @@
+# Mode: followup — Follow-Up Timing & Nudge System
+
+Scans `data/applications.md` for entries that need follow-up action based on their current state and how long they've been in that state.
+
+**This mode is read-only on existing pipeline logic.** It reads the tracker and suggests actions — it never changes scores, reports, or pipeline behavior.
+
+## Timing Rules
+
+| Current State | Days Since | Action |
+|---------------|-----------|--------|
+| Applied | 7-10 days | Nudge: LinkedIn outreach via `/career-ops contacto` if not already Contacted |
+| Applied | 14+ days | Flag as stale. Suggest: nudge or archive to Discarded |
+| Contacted | 5-7 days | Follow-up message (shorter, reference first message) |
+| Contacted | 14+ days | Flag as stale. Likely no response — move on |
+| Responded | 5 days | If no next step scheduled, ask: "Did they propose a call?" |
+| Interview | 1 day after | Send thank-you note (generate draft) |
+| Interview | 7+ days no update | Nudge recruiter: "Following up on our conversation last week" |
+| Evaluated | 14+ days | Stale evaluation. Offer may be closed — suggest verifying or archiving |
+
+## Workflow
+
+1. **Read** `data/applications.md` — parse all entries with dates
+2. **Compute** days since the date column for each entry (using today's date)
+3. **Filter** to entries matching timing rules above
+4. **Sort** by urgency (most overdue first)
+5. **Present** action list:
+
+```
+## Follow-Up Actions — {today's date}
+
+### Urgent (overdue)
+- #045 Anthropic — AI Engineer | Applied 12 days ago → Nudge via LinkedIn
+- #078 Datadog — Staff PM | Interviewed 8 days ago → Follow up with recruiter
+
+### Coming Up (next 3 days)
+- #102 Stripe — AI Platform | Applied 6 days ago → Nudge window opens in 1 day
+
+### Stale (consider archiving)
+- #023 OldCo — Senior Eng | Evaluated 21 days ago → Verify if still open or Discard
+```
+
+## Nudge Message Generation
+
+When the user selects an entry to nudge:
+
+1. Read the existing report from `reports/`
+2. Use the **contacto** mode logic to generate a follow-up message (not a first outreach)
+3. Follow-up messages are shorter and reference the application:
+   - "I applied to [role] [N days] ago and wanted to follow up..."
+   - Reference one specific proof point from Block B
+   - Keep it under 200 characters for LinkedIn
+
+## Thank-You Note Generation
+
+After interviews, generate a thank-you note:
+1. Read the report + Block F STAR stories
+2. Reference something specific discussed in the interview (ask the user what stood out)
+3. Reinforce one proof point
+4. 3-4 sentences max, send within 24 hours
+
+## Automation
+
+This mode works well with `/loop` or `/schedule`:
+- Run `/career-ops followup` every 2-3 days to catch nudge windows
+- Suggest this to the user after their first batch of applications

--- a/modes/negotiation.md
+++ b/modes/negotiation.md
@@ -1,0 +1,142 @@
+# Mode: negotiation — Offer Negotiation
+
+Structured mode for when the user receives an actual job offer. Completely separate from `oferta` (which evaluates job postings).
+
+**This mode is standalone.** It reads existing data (reports, tracker, profile.yml) but creates its own output. No changes to existing pipeline behavior.
+
+## When to Trigger
+
+- User says "I got an offer from [company]"
+- User updates a tracker entry to Offer
+- User runs `/career-ops negotiation`
+
+## Step 1 — Capture the Offer
+
+Ask the user for the offer details (or read from a document/screenshot):
+
+| Field | Example | Notes |
+|-------|---------|-------|
+| Base salary | $180,000 | Annual |
+| Equity/RSUs | $50,000/yr (4yr vest) | Total grant ÷ vesting period |
+| Signing bonus | $20,000 | One-time |
+| Annual bonus | 15% target | As % of base |
+| Benefits | Standard | Healthcare, 401k match, etc. |
+| PTO | Unlimited / 20 days | |
+| Remote policy | Full remote | |
+| Start date | YYYY-MM-DD | |
+| Deadline to respond | YYYY-MM-DD | Critical — drives urgency |
+| Level/title | Senior Engineer | |
+| Other perks | $5K learning budget | Anything else |
+
+## Step 2 — Total Comp Calculation
+
+Compute total annual comp:
+
+```
+Base:           $180,000
+Equity (annual): $50,000   (total grant ÷ vesting years)
+Bonus (target):  $27,000   (base × bonus %)
+Signing (annual): $10,000   (signing ÷ 2, amortized over first 2 years)
+───────────────────────────
+Total Year 1:   $267,000
+Total Ongoing:  $257,000   (without signing bonus amortization)
+```
+
+**For equity at private companies:**
+- Apply a discount: pre-IPO equity is illiquid. Common: 50-70% discount for early stage, 20-30% for late stage.
+- Note the strike price if options (not RSUs). Compute current spread if possible.
+- Flag if there's no secondary market.
+
+## Step 3 — Compare Against Target & Pipeline
+
+Read from `config/profile.yml`:
+- `compensation.target_range` — is the offer within, above, or below?
+- `compensation.minimum` — is it above the walk-away number?
+
+Read from `data/applications.md`:
+- How many other offers are at Interview or Offer stage? (This is your leverage.)
+- What scores did those have? (Higher-scored alternatives = stronger negotiating position.)
+
+```
+## Leverage Assessment
+
+Active pipeline:
+- Offer: [this one] + N others
+- Interview stage: N companies
+- Applied (awaiting): N companies
+
+Leverage: [Strong/Moderate/Weak]
+- Strong: 2+ competing offers or 3+ active interviews
+- Moderate: 1 other offer or 2+ interviews
+- Weak: this is the only active opportunity
+```
+
+## Step 4 — Counter-Offer Strategy
+
+Based on leverage and gap to target:
+
+**If offer is below target range:**
+```
+Recommended counter: [target midpoint + 10%]
+Justification: "Based on market data for [role] at [level], 
+and given [competing offers / pipeline activity], I'm targeting [range]."
+```
+
+**If offer is within target range:**
+```
+Recommended counter: [target top end]
+Justification: "I'm excited about this role. To make the decision 
+straightforward, [specific ask — e.g., bump equity, signing bonus, level]."
+```
+
+**If offer is above target range:**
+```
+Focus negotiation on non-comp factors: level/title, scope, 
+team choice, start date flexibility, remote policy.
+```
+
+### Negotiation Scripts (adapted from _shared.md)
+
+Generate 3 scripts ready for use:
+
+1. **Initial response** (buy time): "Thank you for the offer. I'm very interested and want to give this proper consideration. Can I have until [deadline or +3 days] to review the full package?"
+
+2. **Counter-offer** (if needed): Specific to the gap. Reference market data from Block D if available. Never give a single number — always a range.
+
+3. **Acceptance** (when ready): Confirm all terms in writing. Ask for the offer letter with the agreed terms before giving verbal acceptance.
+
+### What NOT to Do
+- Never counter before understanding the full package
+- Never reveal your current comp or other offer amounts
+- Never give an ultimatum unless you're prepared to walk
+- Never negotiate via email if you can do it via call (nuance matters)
+
+## Step 5 — Decision Framework
+
+If the user has multiple offers, build a decision matrix using the same scoring dimensions from `_shared.md`:
+
+```
+| Dimension | Offer A | Offer B |
+|-----------|---------|---------|
+| Total comp (Year 1) | $267K | $245K |
+| Equity upside | Moderate (Series C) | High (Series A) |
+| Role match (from eval) | 4.5/5 | 3.8/5 |
+| Growth trajectory | Clear path to Staff | Flat org |
+| Remote quality | Full remote | Hybrid 2x/week |
+| Gut feeling | High | Medium |
+```
+
+Include a "gut feeling" row — quantitative analysis doesn't capture everything.
+
+## Step 6 — Save & Update Tracker
+
+1. Update `data/applications.md`: status → `Offer`, notes → comp summary
+2. Append `## Offer Details` section to the existing report with full comp breakdown and negotiation outcome
+3. If the user accepts: status → a new note like `Accepted YYYY-MM-DD`
+
+## Deadline Management
+
+If the user has a response deadline:
+- Calculate business days remaining
+- If < 3 business days and other interviews are active, suggest: "Ask [company] for an extension — 'I want to make a thoughtful decision and have a final interview scheduled this week. Could we extend to [date]?'"
+- If the deadline is firm and leverage is weak, help the user decide with what they have

--- a/modes/rejection.md
+++ b/modes/rejection.md
@@ -1,0 +1,92 @@
+# Mode: rejection — Rejection Analysis & Learning Loop
+
+When the user reports a rejection, capture structured data and surface patterns over time.
+
+**This mode is additive.** It uses the existing notes column in applications.md (no new columns) and appends a section to existing reports (no changes to report format).
+
+## When to Trigger
+
+- User says "I got rejected from [company]"
+- User updates a tracker entry to Rejected
+- User runs `/career-ops rejection` to review patterns
+
+## Step 1 — Record the Rejection
+
+Update the entry in `data/applications.md`:
+- Status → `Rejected`
+- Notes → append rejection info in compact format: `REJ@{stage}:{reason}`
+
+**Stages** (ask the user which applies):
+| Stage | Code | Meaning |
+|-------|------|---------|
+| Resume screen | `resume` | Rejected before any human contact |
+| Phone screen | `phone` | Rejected after initial call |
+| Technical interview | `tech` | Rejected after technical assessment |
+| Hiring manager | `hm` | Rejected after HM interview |
+| Final round | `final` | Rejected at final stage |
+| Offer pulled | `offer` | Offer was extended then retracted |
+| Unknown | `unk` | User doesn't know |
+
+**Reasons** (ask the user if they have signal, otherwise `unk`):
+- `exp` — not enough experience / seniority
+- `skill` — missing specific technical skill
+- `culture` — culture/team fit
+- `comp` — comp expectations too high
+- `geo` — location/timezone mismatch
+- `internal` — went with internal candidate
+- `closed` — role was closed/frozen
+- `unk` — no feedback given
+
+Example notes: `REJ@tech:skill — failed system design round`
+
+## Step 2 — Append to Report
+
+If a report exists in `reports/`, append a `## Rejection` section:
+
+```markdown
+## Rejection
+**Date:** YYYY-MM-DD
+**Stage:** Technical interview
+**Reason:** Missing specific skill (system design at scale)
+**Signal:** What this tells us about future applications for this archetype
+```
+
+## Step 3 — Pattern Analysis
+
+When the user runs `/career-ops rejection` (without a specific company), analyze ALL rejected entries:
+
+1. **Read** `data/applications.md` — filter to Rejected entries
+2. **Parse** `REJ@{stage}:{reason}` from notes column
+3. **Aggregate** patterns:
+
+```
+## Rejection Patterns — {date}
+
+### By Stage
+- Resume screen: N rejections (N% of all rejections)
+- Technical: N rejections
+- ...
+
+### By Archetype
+- LLMOps roles: N/M rejected (N% rejection rate)
+- Platform roles: N/M rejected
+- ...
+
+### By Score Range
+- Score 4.0+: N/M rejected (should be low — if high, scoring model needs recalibration)
+- Score 3.0-3.9: N/M rejected
+- Score <3.0: N/M rejected (expected to be high)
+
+### Signals
+- [If 3+ resume-screen rejections for same archetype]: "Consider stronger keyword injection for {archetype} roles — see pdf.md anti-AI-detection rules"
+- [If high-score offers getting rejected]: "Scoring model may be inflated — review calibration anchors in _shared.md"
+- [If rejections cluster at tech stage]: "Story bank may need stronger technical stories for {archetype} — review interview-prep/story-bank.md"
+- [If comp rejections]: "Consider adjusting target range in config/profile.yml"
+```
+
+## What This Mode Does NOT Do
+
+- Does NOT change the scoring model or thresholds automatically
+- Does NOT modify reports retroactively (only appends Rejection section)
+- Does NOT add new columns to applications.md (uses notes column)
+- Does NOT require any changes to merge-tracker, dedup, or verify scripts

--- a/modes/tracker.md
+++ b/modes/tracker.md
@@ -21,3 +21,8 @@ Mostrar también estadísticas:
 - Score promedio
 - % con PDF generado
 - % con report generado
+
+If any entries look overdue for follow-up (Applied 7+ days ago, Contacted 5+ days ago, Interviewed with no update 7+ days), mention it:
+> "3 entries may need follow-up. Run `/career-ops followup` for details."
+
+This is a passive hint — it does NOT change tracker behavior or output format.


### PR DESCRIPTION
## Summary

Three new modes covering the post-application phase:

- **`followup`** — Scans tracker for entries needing action based on timing rules (Applied 7+ days → nudge, Interviewed 1 day → thank-you, etc.). Generates messages using existing report context.
- **`rejection`** — Captures rejection stage and reason in the notes column, appends to reports, surfaces patterns across all rejections (by stage, archetype, score range).
- **`negotiation`** — Structured offer evaluation: total comp breakdown, equity valuation, counter-offer strategy with leverage assessment from pipeline, multi-offer decision matrix.

## Zero impact on existing functionality

This PR is **entirely additive**:
- 3 new files in `modes/` (no existing mode files changed in behavior)
- 3 new rows in CLAUDE.md mode table
- 1 passive hint in `tracker.md` ("3 entries may need follow-up")
- No changes to scoring, reports, column formats, or scripts
- `rejection` uses the existing notes column (`REJ@stage:reason` format) — no new columns
- `negotiation` reads profile.yml and tracker but only writes to reports and notes

### Files changed
| File | Change type |
|------|------------|
| `modes/followup.md` | **New file** |
| `modes/rejection.md` | **New file** |
| `modes/negotiation.md` | **New file** |
| `CLAUDE.md` | 3 rows added to mode table |
| `modes/tracker.md` | Passive follow-up hint at end of stats |

## Why these matter

The existing pipeline is strong at the front half of a job search (discover → evaluate → apply → outreach). But the back half — following up, learning from rejections, and negotiating offers — was unstructured. These are the highest-leverage moments:

- **Follow-up timing**: Most candidates either never follow up or follow up at the wrong time. A 10-day-old application with no nudge is a missed opportunity.
- **Rejection learning**: Without capturing where and why rejections happen, you keep making the same mistakes. If 3/4 rejections are at resume screen for one archetype, the CV framing needs work.
- **Offer negotiation**: The highest-stakes moment in the pipeline had the least support — just generic scripts in _shared.md.

## Test plan

- [ ] Run `/career-ops followup` with entries at various ages — verify timing rules trigger correctly
- [ ] Report a rejection — verify `REJ@stage:reason` appears in notes, Rejection section appended to report
- [ ] Run `/career-ops rejection` with no company — verify pattern analysis runs across all rejected entries
- [ ] Run `/career-ops negotiation` with an offer — verify comp breakdown and leverage assessment
- [ ] Run `/career-ops tracker` — verify follow-up hint appears when entries are overdue
- [ ] Run existing pipeline (evaluate, scan, batch) — verify zero behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)