### PR TITLE
Fix dashboard crash on empty applications.md

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -39,7 +39,7 @@ func ParseApplications(careerOpsPath string) []model.CareerApplication {
 	}
 
 	lines := strings.Split(string(content), "\n")
-	var apps []model.CareerApplication
+	apps := make([]model.CareerApplication, 0)
 	num := 0
 
 	for _, line := range lines {


### PR DESCRIPTION
## Summary
- `ParseApplications()` returned `nil` for a valid but empty `applications.md` (headers only, no data rows), causing `main.go` to treat it as "file not found"
- Changed `var apps []model.CareerApplication` → `apps := make([]model.CareerApplication, 0)` so a valid empty file returns a non-nil empty slice

Fixes #24

## Test plan
- [x] `go build` succeeds (fresh clone)
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `node verify-pipeline.mjs` and `node cv-sync-check.mjs` pass
- [x] Only `dashboard/internal/data/career.go` changed (1 line) — no personal data committed
- [ ] Run `./career-dashboard --path ..` with empty `data/applications.md` — shows empty dashboard instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)