### PR TITLE
Add progressive onboarding with /career-ops status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,20 +59,31 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `interview-prep/story-bank.md` | Accumulated STAR+R stories across evaluations |
 | `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`) |
 
-### First Run — Onboarding (IMPORTANT)
+### First Run -- Onboarding (IMPORTANT)
 
-**Before doing ANYTHING else, check if the system is set up.** Run these checks silently every time a session starts:
+**On every session start, silently check setup state.** Run these checks without narrating them:
 
 1. Does `cv.md` exist?
 2. Does `config/profile.yml` exist (not just profile.example.yml)?
 3. Does `modes/_profile.md` exist (not just _profile.template.md)?
 4. Does `portals.yml` exist (not just templates/portals.example.yml)?
 
-If `modes/_profile.md` is missing, copy from `modes/_profile.template.md` silently. This is the user's customization file — it will never be overwritten by updates.
+If `modes/_profile.md` is missing, copy from `modes/_profile.template.md` silently.
 
-**If ANY of these is missing, enter onboarding mode.** Do NOT proceed with evaluations, scans, or any other mode until the basics are in place. Guide the user step by step:
+**Progressive onboarding -- never block the user.** If files are missing:
+- If the user pastes a JD or URL and `cv.md` exists: proceed with evaluation, even if other files are missing. Note what is degraded (e.g., "PDF will use placeholder contact info until you set up profile.yml").
+- If the user pastes a JD or URL and `cv.md` is missing: explain that you need their CV first to evaluate match, then guide them through Step 1 only.
+- If the user says "scan" and `portals.yml` is missing: explain that scanning requires portal configuration, then guide them through Step 3 only.
+- If ALL core files are missing (first-time user): enter full onboarding flow (Steps 1-6 below).
+- In all cases, tell the user what they can do NOW and what requires additional setup.
+
+**After completing any onboarding step, briefly show what it unlocked:**
+> "cv.md created. You can now evaluate offers, generate PDFs, and draft application answers."
 
 #### Step 1: CV (required)
+**Unlocks:** Offer evaluation (Block B match), PDF generation, form answer drafting, LinkedIn outreach, offer comparison, batch processing.
+**Without it:** Only company research, training evaluation, and portal scanning (discovery only) work.
+
 If `cv.md` is missing, ask:
 > "I don't have your CV yet. You can either:
 > 1. Paste your CV here and I'll convert it to markdown
@@ -84,6 +95,9 @@ If `cv.md` is missing, ask:
 Create `cv.md` from whatever they provide. Make it clean markdown with standard sections (Summary, Experience, Projects, Education, Skills).
 
 #### Step 2: Profile (required)
+**Unlocks:** Real contact info in PDFs (name, email, LinkedIn, portfolio), comp target benchmarking, archetype-to-role mapping.
+**Without it:** PDFs show placeholder data. Comp analysis has no reference point for your salary range.
+
 If `config/profile.yml` is missing, copy from `config/profile.example.yml` and then ask:
 > "I need a few details to personalize the system:
 > - Your full name and email
@@ -96,10 +110,15 @@ If `config/profile.yml` is missing, copy from `config/profile.example.yml` and t
 Fill in `config/profile.yml` with their answers. For archetypes, map their target roles to the closest matches and update `modes/_shared.md` if needed.
 
 #### Step 3: Portals (recommended)
+**Unlocks:** Automated portal scanning (`/career-ops scan`), batch discovery from 45+ company career pages, title-based filtering.
+**Without it:** You can still paste individual URLs or JDs for evaluation. Only automated discovery is unavailable.
+
 If `portals.yml` is missing:
 > "I'll set up the job scanner with 45+ pre-configured companies. Want me to customize the search keywords for your target roles?"
 
 Copy `templates/portals.example.yml` → `portals.yml`. If they gave target roles in Step 2, update `title_filter.positive` to match.
+
+**Cross-validation:** If profile.yml already exists, check that `title_filter.positive` in portals.yml includes keywords matching the user's `target_roles.primary`. If a target role keyword is not in positive keywords, suggest adding it.
 
 #### Step 4: Tracker
 If `data/applications.md` doesn't exist, create it:
@@ -111,6 +130,8 @@ If `data/applications.md` doesn't exist, create it:
 ```
 
 #### Step 5: Get to know the user (important for quality)
+**Unlocks:** Personalized archetype framing, tailored negotiation scripts, exit narrative in PDF summaries, proof-point-backed STAR stories.
+**Without it:** Evaluations use generic framing from `_shared.md` defaults. Still functional, but less tailored.
 
 After the basics are set up, proactively ask for more context. The more you know, the better your evaluations will be:
 
@@ -128,15 +149,23 @@ Store any insights the user shares in `config/profile.yml` (under narrative) or 
 **After every evaluation, learn.** If the user says "this score is too high, I wouldn't apply here" or "you missed that I have experience in X", update your understanding. Adjust the framing in `_shared.md` or add notes to `profile.yml`. The system should get smarter with every interaction.
 
 #### Step 6: Ready
-Once all files exist, confirm:
-> "You're all set! You can now:
-> - Paste a job URL to evaluate it
-> - Run `/career-ops scan` to search portals
-> - Run `/career-ops` to see all commands
+Once core files exist, show the setup confirmation:
+
+> **Setup complete.** Here's what you can do:
 >
-> Everything is customizable — just ask me to change anything.
+> | Capability | Status |
+> |---|---|
+> | Evaluate offers | Ready (cv.md + profile.yml) |
+> | Generate PDFs | Ready (cv.md + profile.yml + template) |
+> | Scan portals | {Ready / Needs portals.yml} |
+> | Personalized framing | {Ready / Needs _profile.md customization} |
+> | Proof-point enrichment | {Ready / Needs article-digest.md} |
 >
-> Tip: Having a personal portfolio dramatically improves your job search. If you don't have one yet, the author's portfolio is also open source: github.com/santifer/cv-santiago — feel free to fork it and make it yours."
+> **Quick start:** Paste a job posting URL and I'll evaluate it, generate a tailored PDF, and register it in your tracker -- all in one step.
+>
+> Run `/career-ops status` anytime to check your setup.
+>
+> Tip: Having a personal portfolio dramatically improves your job search. If you don't have one yet, the author's portfolio is also open source: github.com/santifer/cv-santiago -- feel free to fork it and make it yours.
 
 Then suggest automation:
 > "Want me to scan for new offers automatically? I can set up a recurring scan every few days so you don't miss anything. Just say 'scan every 3 days' and I'll configure it."
@@ -185,6 +214,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Searches for new offers | `scan` |
 | Processes pending URLs | `pipeline` |
 | Batch processes offers | `batch` |
+| Asks about setup status / readiness | `status` |
 
 ### CV Source of Truth
 

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -41,6 +41,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/project.md` | Project evaluation instructions |
 | `modes/tracker.md` | Tracker instructions |
 | `modes/training.md` | Training evaluation instructions |
+| `modes/status.md` | Setup status and readiness check |
 | `modes/de/*` | German language modes |
 | `CLAUDE.md` | Agent instructions |
 | `*.mjs` | Utility scripts |

--- a/modes/status.md
+++ b/modes/status.md
@@ -1,0 +1,86 @@
+# Mode: status -- Setup Completeness and System Readiness
+
+When the user asks "how ready am I?", "what's my setup status?", "career-ops status",
+or any variant, show the current state of their career-ops installation.
+
+## Step 1 -- Check All Setup Files
+
+Check existence of each file silently. For profile.yml and _profile.md,
+also check whether they contain example/template data vs real user data.
+
+| File | Check | How to verify |
+|------|-------|---------------|
+| `cv.md` | exists + length > 100 chars | `existsSync` + content length |
+| `config/profile.yml` | exists + not example data | exists + does NOT contain `"Jane Smith"` |
+| `modes/_profile.md` | exists + customized | exists + has user-specific content (not just template) |
+| `portals.yml` | exists | `existsSync` in project root |
+| `article-digest.md` | exists (optional) | `existsSync` |
+| `interview-prep/story-bank.md` | exists (optional) | `existsSync` |
+| `data/applications.md` | exists | `existsSync` |
+| `data/pipeline.md` | exists (optional) | `existsSync` |
+
+## Step 2 -- Cross-Validation
+
+If both `portals.yml` and `config/profile.yml` exist, check consistency:
+- Do `title_filter.positive` keywords in portals.yml align with
+  `target_roles.primary` in profile.yml?
+- If target roles mention "Backend Engineer" but title_filter has no
+  "Backend" keyword, warn: "Your portal scanner may miss roles matching
+  your target. Consider adding 'Backend' to title_filter.positive in portals.yml."
+
+## Step 3 -- Display Status Table
+
+Format the output as:
+
+```
+career-ops setup status
+========================
+
+CORE (required for full pipeline)
+  [checkmark] cv.md                    -- Enables: evaluations, PDFs, form answers
+  [checkmark] config/profile.yml       -- Enables: PDF personalization, comp benchmarks
+  [  ] modes/_profile.md          -- Enables: archetype framing, negotiation scripts
+                                     Impact: evaluations use generic framing
+
+DISCOVERY
+  [checkmark] portals.yml              -- Enables: portal scanning, batch discovery
+  [  ] data/pipeline.md           -- Enables: URL inbox processing
+                                     Impact: no URL inbox (paste URLs directly instead)
+
+ENRICHMENT (optional, improves quality)
+  [  ] article-digest.md          -- Enables: detailed proof points, richer PDFs
+  [  ] interview-prep/story-bank.md -- Enables: STAR+R story accumulation
+
+TRACKING
+  [checkmark] data/applications.md     -- Enables: application history, scan dedup
+
+CROSS-VALIDATION
+  [!] portals.yml title_filter does not include "Backend" from your target roles.
+      Consider adding it to title_filter.positive.
+
+READINESS: 5/8 files present. Core pipeline ready.
+Next step: Create article-digest.md to improve evaluation quality.
+            Run: "I want to add my proof points" and I'll help you build it.
+```
+
+Use [checkmark] for present files, [  ] for missing, [!] for warnings.
+
+## Step 4 -- Suggest Next Action
+
+Based on what is missing, suggest the single highest-impact next step:
+
+1. If cv.md missing: "Create your CV first -- everything depends on it."
+2. If profile.yml missing: "Set up your profile so PDFs have your real contact info."
+3. If _profile.md is template-only: "Tell me about your career and I'll personalize your archetypes."
+4. If portals.yml missing: "Set up portal scanning to discover jobs automatically."
+5. If article-digest.md missing: "Share your portfolio articles and I'll extract proof points."
+6. If story-bank.md missing: "This builds automatically as you evaluate offers. Run your first evaluation!"
+7. If cross-validation warning: surface the specific mismatch.
+8. All present: "You're fully set up. Paste a job URL to evaluate, or run /career-ops scan."
+
+## Rules
+
+- Run this check silently (no verbose file-by-file narration)
+- Show the table, then the suggestion
+- Do NOT re-enter onboarding mode -- just show status and suggest
+- If user asks to fix something from the status, help them directly


### PR DESCRIPTION
## Summary

Closes #36

- Replaces the binary onboarding gate ("if ANY file missing, block everything") with a progressive model that never blocks users
- Each onboarding step now shows what capabilities it unlocks and what degrades when skipped (qualitative impact, no percentages)
- Adds `/career-ops status` command for checking setup completeness with cross-validation between portals.yml and profile.yml target roles

## Changes

| File | Change |
|------|--------|
| `modes/status.md` | **New** — Setup status mode (System Layer) with 4-step workflow: check files, cross-validate, display table, suggest next action |
| `CLAUDE.md` | Progressive onboarding model, Unlocks/Without-it impact messages on Steps 1/2/3/5, dynamic capability table in Step 6, status routing |
| `DATA_CONTRACT.md` | Add `modes/status.md` to System Layer table |

**1 new file (System Layer), 2 files modified. No User Layer changes. No new scripts.**

### Key behavior change

| Scenario | Before | After |
|----------|--------|-------|
| cv.md exists, no portals.yml, user pastes JD | Blocked ("enter onboarding") | Evaluates, notes "scanning unavailable" |
| Nothing exists, first-time user | Full onboarding | Same — full onboarding with impact visibility |
| User asks "how ready am I?" | No response | Shows setup completeness table |

## Note on CLAUDE.md overlap

This PR modifies the onboarding section of CLAUDE.md. PR #38 (memory system) also modifies CLAUDE.md but in different sections. If both are merged, a minor merge conflict in the onboarding checks is expected and straightforward to resolve.

## Test plan

- [ ] Fresh install: verify full onboarding flow still works with impact messages
- [ ] CV-only setup: verify user can paste JD and get evaluation
- [ ] Missing portals: verify only scanning is blocked, not evaluation
- [ ] Run `/career-ops status` with partial setup: verify table and suggestions
- [ ] Verify no percentages in impact messages (qualitative only)
- [ ] Run `node verify-pipeline.mjs` — should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)