### PR TITLE
Add Block G: posting legitimacy assessment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `interview-prep/story-bank.md` | Accumulated STAR+R stories across evaluations |
 | `interview-prep/{company}-{role}.md` | Company-specific interview intel reports |
 | `analyze-patterns.mjs` | Pattern analysis script (JSON output) |
-| `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`) |
+| `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`). Blocks A-F + G (Posting Legitimacy). Header includes `**Legitimacy:** {tier}`. |
 
 ### OpenCode Commands
 
@@ -291,7 +291,7 @@ Write one TSV file per evaluation to `batch/tracker-additions/{num}-{company-slu
 
 1. **NEVER edit applications.md to ADD new entries** -- Write TSV in `batch/tracker-additions/` and `merge-tracker.mjs` handles the merge.
 2. **YES you can edit applications.md to UPDATE status/notes of existing entries.**
-3. All reports MUST include `**URL:**` in the header (between Score and PDF).
+3. All reports MUST include `**URL:**` in the header (between Score and PDF). Include `**Legitimacy:** {tier}` (see Block G in `modes/oferta.md`).
 4. All statuses MUST be canonical (see `templates/states.yml`).
 5. Health check: `node verify-pipeline.mjs`
 6. Normalize statuses: `node normalize-statuses.mjs`

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -2,7 +2,7 @@
 
 Eres un worker de evaluación de ofertas de empleo for the candidate (read name from config/profile.yml). Recibes una oferta (URL + JD text) y produces:
 
-1. Evaluación completa A-F (report .md)
+1. Evaluación completa A-G (report .md)
 2. PDF personalizado ATS-optimizado
 3. Línea de tracker para merge posterior
 
@@ -47,7 +47,7 @@ Eres un worker de evaluación de ofertas de empleo for the candidate (read name 
 2. Si el archivo está vacío o no existe, intenta obtener el JD desde `{{URL}}` con WebFetch
 3. Si ambos fallan, reporta error y termina
 
-### Paso 2 — Evaluación A-F
+### Paso 2 — Evaluación A-G
 
 Read `cv.md`. Ejecuta TODOS los bloques:
 
@@ -138,6 +138,22 @@ Top 5 cambios al CV + Top 5 cambios a LinkedIn.
 - 1 case study recomendado (cuál proyecto presentar y cómo)
 - Preguntas red-flag y cómo responderlas
 
+#### Bloque G — Posting Legitimacy
+
+Analyze posting signals to assess whether this is a real, active opening.
+
+**Batch mode limitations:** Playwright is not available, so posting freshness signals (exact days posted, apply button state) cannot be directly verified. Mark these as "unverified (batch mode)."
+
+**What IS available in batch mode:**
+1. **Description quality analysis** -- Full JD text is available. Analyze specificity, requirements realism, salary transparency, boilerplate ratio.
+2. **Company hiring signals** -- WebSearch queries for layoff/freeze news (combine with Block D comp research).
+3. **Reposting detection** -- Read `data/scan-history.tsv` to check for prior appearances.
+4. **Role market context** -- Qualitative assessment from JD content.
+
+**Output format:** Same as interactive mode (Assessment tier + Signals table + Context Notes), but with a note that posting freshness is unverified.
+
+**Assessment:** Apply the same three tiers (High Confidence / Proceed with Caution / Suspicious), weighting available signals more heavily. If insufficient signals are available to make a determination, default to "Proceed with Caution" with a note about limited data.
+
 #### Score Global
 
 | Dimensión | Score |
@@ -166,6 +182,7 @@ Donde `{company-slug}` es el nombre de empresa en lowercase, sin espacios, con g
 **Fecha:** {{DATE}}
 **Arquetipo:** {detectado}
 **Score:** {X/5}
+**Legitimacy:** {High Confidence | Proceed with Caution | Suspicious}
 **URL:** {URL de la oferta original}
 **PDF:** career-ops/output/cv-candidate-{company-slug}-{{DATE}}.pdf
 **Batch ID:** {{ID}}
@@ -188,6 +205,9 @@ Donde `{company-slug}` es el nombre de empresa en lowercase, sin espacios, con g
 (contenido completo)
 
 ## F) Plan de Entrevistas
+(contenido completo)
+
+## G) Posting Legitimacy
 (contenido completo)
 
 ---
@@ -314,6 +334,7 @@ Al terminar, imprime por stdout un resumen JSON para que el orquestador lo parse
   "company": "{empresa}",
   "role": "{rol}",
   "score": {score_num},
+  "legitimacy": "{High Confidence|Proceed with Caution|Suspicious}",
   "pdf": "{ruta_pdf}",
   "report": "{ruta_report}",
   "error": null

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -42,6 +42,34 @@ The evaluation uses 6 blocks (A-F) with a global score of 1-5:
 - 3.5-3.9 → Decent but not ideal, apply only if specific reason
 - Below 3.5 → Recommend against applying (see Ethical Use in CLAUDE.md)
 
+## Posting Legitimacy (Block G)
+
+Block G assesses whether a posting is likely a real, active opening. It does NOT affect the 1-5 global score -- it is a separate qualitative assessment.
+
+**Three tiers:**
+- **High Confidence** -- Real, active opening (most signals positive)
+- **Proceed with Caution** -- Mixed signals, worth noting (some concerns)
+- **Suspicious** -- Multiple ghost indicators, user should investigate first
+
+**Key signals (weighted by reliability):**
+
+| Signal | Source | Reliability | Notes |
+|--------|--------|-------------|-------|
+| Posting age | Page snapshot | High | Under 30d=good, 30-60d=mixed, 60d+=concerning (adjusted for role type) |
+| Apply button active | Page snapshot | High | Direct observable fact |
+| Tech specificity in JD | JD text | Medium | Generic JDs correlate with ghost postings but also with poor writing |
+| Requirements realism | JD text | Medium | Contradictions are a strong signal, vagueness is weaker |
+| Recent layoff news | WebSearch | Medium | Must consider department, timing, and company size |
+| Reposting pattern | scan-history.tsv | Medium | Same role reposted 2+ times in 90 days is concerning |
+| Salary transparency | JD text | Low | Jurisdiction-dependent, many legitimate reasons to omit |
+| Role-company fit | Qualitative | Low | Subjective, use only as supporting signal |
+
+**Ethical framing (MANDATORY):**
+- This helps users prioritize time on real opportunities
+- NEVER present findings as accusations of dishonesty
+- Present signals and let the user decide
+- Always note legitimate explanations for concerning signals
+
 ## Archetype Detection
 
 Classify every offer into one of these types (or hybrid of 2):

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -16,11 +16,12 @@ Si el input es una **URL** (no texto de JD pegado), seguir esta estrategia para 
 
 **Si el input es texto de JD** (no URL): usar directamente, sin necesidad de fetch.
 
-## Paso 1 — Evaluación A-F
-Ejecutar exactamente igual que el modo `oferta` (leer `modes/oferta.md` para todos los bloques A-F).
+## Paso 1 — Evaluación A-G
+Ejecutar exactamente igual que el modo `oferta` (leer `modes/oferta.md` para todos los bloques A-F + Block G Posting Legitimacy).
 
 ## Paso 2 — Guardar Report .md
 Guardar la evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (ver formato en `modes/oferta.md`).
+Include Block G in the saved report. Add `**Legitimacy:** {tier}` to the report header.
 
 ## Paso 3 — Generar PDF
 Ejecutar el pipeline completo de `pdf` (leer `modes/pdf.md`).
@@ -31,7 +32,7 @@ Si el score final es >= 4.5, generar borrador de respuestas para el formulario d
 
 1. **Extraer preguntas del formulario**: Usar Playwright para navegar al formulario y hacer snapshot. Si no se pueden extraer, usar las preguntas genéricas.
 2. **Generar respuestas** siguiendo el tono (ver abajo).
-3. **Guardar en el report** como sección `## G) Draft Application Answers`.
+3. **Guardar en el report** como sección `## H) Draft Application Answers`.
 
 ### Preguntas genéricas (usar si no se pueden extraer del formulario)
 

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -1,6 +1,6 @@
-# Modo: oferta — Evaluación Completa A-F
+# Modo: oferta — Evaluación Completa A-G
 
-Cuando el candidato pega una oferta (texto o URL), entregar SIEMPRE los 6 bloques:
+Cuando el candidato pega una oferta (texto o URL), entregar SIEMPRE los 7 bloques (A-F evaluation + G legitimacy):
 
 ## Paso 0 — Detección de Arquetipo
 
@@ -85,11 +85,66 @@ Incluir también:
 - 1 case study recomendado (cuál de sus proyectos presentar y cómo)
 - Preguntas red-flag y cómo responderlas (ej: "¿por qué vendiste tu empresa?", "¿tienes equipo de reports?")
 
+## Bloque G — Posting Legitimacy
+
+Analyze the job posting for signals that indicate whether this is a real, active opening. This helps the user prioritize their effort on opportunities most likely to result in a hiring process.
+
+**Ethical framing:** Present observations, not accusations. Every signal has legitimate explanations. The user decides how to weigh them.
+
+### Signals to analyze (in order):
+
+**1. Posting Freshness** (from Playwright snapshot, already captured in Paso 0):
+- Date posted or "X days ago" -- extract from page
+- Apply button state (active / closed / missing / redirects to generic page)
+- If URL redirected to generic careers page, note it
+
+**2. Description Quality** (from JD text):
+- Does it name specific technologies, frameworks, tools?
+- Does it mention team size, reporting structure, or org context?
+- Are requirements realistic? (years of experience vs technology age)
+- Is there a clear scope for the first 6-12 months?
+- Is salary/compensation mentioned?
+- What ratio of the JD is role-specific vs generic boilerplate?
+- Any internal contradictions? (entry-level title + staff requirements, etc.)
+
+**3. Company Hiring Signals** (2-3 WebSearch queries, combine with Block D research):
+- Search: `"{company}" layoffs {year}` -- note date, scale, departments
+- Search: `"{company}" hiring freeze {year}` -- note any announcements
+- If layoffs found: are they in the same department as this role?
+
+**4. Reposting Detection** (from scan-history.tsv):
+- Check if company + similar role title appeared before with a different URL
+- Note how many times and over what period
+
+**5. Role Market Context** (qualitative, no additional queries):
+- Is this a common role that typically fills in 4-6 weeks?
+- Does the role make sense for this company's business?
+- Is the seniority level one that legitimately takes longer to fill?
+
+### Output format:
+
+**Assessment:** One of three tiers:
+- **High Confidence** -- Multiple signals suggest a real, active opening
+- **Proceed with Caution** -- Mixed signals worth noting
+- **Suspicious** -- Multiple ghost job indicators, investigate before investing time
+
+**Signals table:** Each signal observed with its finding and weight (Positive / Neutral / Concerning).
+
+**Context Notes:** Any caveats (niche role, government job, evergreen position, etc.) that explain potentially concerning signals.
+
+### Edge case handling:
+- **Government/academic postings:** Longer timelines are standard. Adjust thresholds (60-90 days is normal).
+- **Evergreen/continuous hire postings:** If the JD explicitly says "ongoing" or "rolling," note it as context -- this is not a ghost job, it is a pipeline role.
+- **Niche/executive roles:** Staff+, VP, Director, or highly specialized roles legitimately stay open for months. Adjust age thresholds accordingly.
+- **Startup / pre-revenue:** Early-stage companies may have vague JDs because the role is genuinely undefined. Weight description vagueness less heavily.
+- **No date available:** If posting age cannot be determined and no other signals are concerning, default to "Proceed with Caution" with a note that limited data was available. NEVER default to "Suspicious" without evidence.
+- **Recruiter-sourced (no public posting):** Freshness signals unavailable. Note that active recruiter contact is itself a positive legitimacy signal.
+
 ---
 
 ## Post-evaluación
 
-**SIEMPRE** después de generar los bloques A-F:
+**SIEMPRE** después de generar los bloques A-G:
 
 ### 1. Guardar report .md
 
@@ -107,6 +162,7 @@ Guardar evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 **Fecha:** {YYYY-MM-DD}
 **Arquetipo:** {detectado}
 **Score:** {X/5}
+**Legitimacy:** {High Confidence | Proceed with Caution | Suspicious}
 **PDF:** {ruta o pendiente}
 
 ---
@@ -129,7 +185,10 @@ Guardar evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 ## F) Plan de Entrevistas
 (contenido completo del bloque F)
 
-## G) Draft Application Answers
+## G) Posting Legitimacy
+(contenido completo del bloque G)
+
+## H) Draft Application Answers
 (solo si score >= 4.5 — borradores de respuestas para el formulario de aplicación)
 
 ---


### PR DESCRIPTION
## Summary

Closes #37

Adds **Block G — Posting Legitimacy** to the evaluation pipeline, helping users identify ghost jobs and prioritize real opportunities using free, observable signals only.

Produces a qualitative 3-tier assessment (High Confidence / Proceed with Caution / Suspicious) — does **NOT** modify the A-F blocks or 1-5 scoring system.

## Changes

| File | Change |
|------|--------|
| `modes/_shared.md` | Signal reference table (8 signals with reliability ratings), ethical framing rules |
| `modes/oferta.md` | Block G instructions (5 signal categories), edge case handling, updated report template |
| `modes/auto-pipeline.md` | A-F → A-G reference, legitimacy header in report |
| `batch/batch-prompt.md` | Block G for batch workers (freshness marked "unverified"), `legitimacy` field in JSON output |
| `CLAUDE.md` | Report format description updated |

**5 files modified. 0 files created. 0 files deleted. No paid APIs. No new dependencies.**

### Signal categories (all free)
1. **Posting Freshness** — Piggybacks on existing Playwright snapshot (zero extra navigation)
2. **Description Quality** — Pure text analysis of JD already in hand
3. **Company Hiring Signals** — 2-3 WebSearch queries combined with Block D comp research
4. **Reposting Detection** — Reads existing `scan-history.tsv` (no scanner changes)
5. **Role Market Context** — Qualitative assessment, no additional queries

### Ethical framing
- Presents observations, never accusations
- Conservative defaults: insufficient data → "Proceed with Caution"
- Every signal includes legitimate explanations
- Edge cases: government (longer timelines standard), evergreen, niche, startups

### Edge cases handled
- Government/academic postings (2x time thresholds)
- Evergreen/continuous hire roles (noted as context, not flagged)
- Niche/executive roles (adjusted age expectations)
- Startups (description vagueness weighted less)
- No posting date available (no default to Suspicious)
- Recruiter-sourced roles (active recruiter = positive signal)

## Test plan

- [ ] Verify A-F blocks are byte-identical to main (no scoring changes)
- [ ] Verify Block G appears in report between Block F and Keywords
- [ ] Verify batch workers mark freshness as "unverified (batch mode)"
- [ ] Grep for "accuse", "fraud", "fake" in diff — should find none
- [ ] Run with a known-real job posting: verify no false "Suspicious"
- [ ] Run `node verify-pipeline.mjs` — should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)