### PR TITLE
Add progress analytics screen to dashboard TUI

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/santifer/career-ops/dashboard/internal/model"
 )
@@ -605,4 +607,130 @@ func StatusPriority(status string) int {
 	default:
 		return 8
 	}
+}
+
+// ComputeProgressMetrics computes progress-oriented analytics from applications.
+func ComputeProgressMetrics(apps []model.CareerApplication) model.ProgressMetrics {
+	pm := model.ProgressMetrics{}
+
+	// Count by normalized status
+	statusCounts := make(map[string]int)
+	var totalScore float64
+	var scored int
+
+	for _, app := range apps {
+		norm := NormalizeStatus(app.Status)
+		statusCounts[norm]++
+
+		if app.Score > 0 {
+			totalScore += app.Score
+			scored++
+			if app.Score > pm.TopScore {
+				pm.TopScore = app.Score
+			}
+		}
+
+		if norm == "offer" {
+			pm.TotalOffers++
+		}
+		if norm != "skip" && norm != "rejected" && norm != "discarded" {
+			pm.ActiveApps++
+		}
+	}
+
+	if scored > 0 {
+		pm.AvgScore = totalScore / float64(scored)
+	}
+
+	// Funnel: each stage counts all apps that reached at least that stage.
+	// An app in "interview" has passed through evaluated -> applied -> responded -> interview.
+	total := len(apps)
+	applied := statusCounts["applied"] + statusCounts["responded"] + statusCounts["interview"] + statusCounts["offer"] + statusCounts["rejected"]
+	responded := statusCounts["responded"] + statusCounts["interview"] + statusCounts["offer"]
+	interview := statusCounts["interview"] + statusCounts["offer"]
+	offer := statusCounts["offer"]
+
+	pm.FunnelStages = []model.FunnelStage{
+		{Label: "Evaluated", Count: total, Pct: 100.0},
+		{Label: "Applied", Count: applied, Pct: safePct(applied, total)},
+		{Label: "Responded", Count: responded, Pct: safePct(responded, applied)},
+		{Label: "Interview", Count: interview, Pct: safePct(interview, applied)},
+		{Label: "Offer", Count: offer, Pct: safePct(offer, applied)},
+	}
+
+	// Rates (relative to applied)
+	if applied > 0 {
+		pm.ResponseRate = float64(responded) / float64(applied) * 100
+		pm.InterviewRate = float64(interview) / float64(applied) * 100
+		pm.OfferRate = float64(offer) / float64(applied) * 100
+	}
+
+	// Score distribution
+	buckets := [5]int{} // 0: 4.5-5.0, 1: 4.0-4.4, 2: 3.5-3.9, 3: 3.0-3.4, 4: <3.0
+	for _, app := range apps {
+		if app.Score <= 0 {
+			continue
+		}
+		switch {
+		case app.Score >= 4.5:
+			buckets[0]++
+		case app.Score >= 4.0:
+			buckets[1]++
+		case app.Score >= 3.5:
+			buckets[2]++
+		case app.Score >= 3.0:
+			buckets[3]++
+		default:
+			buckets[4]++
+		}
+	}
+	pm.ScoreBuckets = []model.ScoreBucket{
+		{Label: "4.5-5.0", Count: buckets[0]},
+		{Label: "4.0-4.4", Count: buckets[1]},
+		{Label: "3.5-3.9", Count: buckets[2]},
+		{Label: "3.0-3.4", Count: buckets[3]},
+		{Label: "  <3.0", Count: buckets[4]},
+	}
+
+	// Weekly activity: group by ISO week from Date field, show last 8 weeks.
+	weekCounts := make(map[string]int)
+	for _, app := range apps {
+		if app.Date == "" {
+			continue
+		}
+		t, err := time.Parse("2006-01-02", app.Date)
+		if err != nil {
+			continue
+		}
+		year, week := t.ISOWeek()
+		key := fmt.Sprintf("%d-W%02d", year, week)
+		weekCounts[key]++
+	}
+
+	// Sort weeks and take last 8
+	var weeks []string
+	for w := range weekCounts {
+		weeks = append(weeks, w)
+	}
+	sort.Strings(weeks)
+	if len(weeks) > 8 {
+		weeks = weeks[len(weeks)-8:]
+	}
+
+	for _, w := range weeks {
+		pm.WeeklyActivity = append(pm.WeeklyActivity, model.WeekActivity{
+			Week:  w,
+			Count: weekCounts[w],
+		})
+	}
+
+	return pm
+}
+
+// safePct returns the percentage of part/whole, or 0 if whole is 0.
+func safePct(part, whole int) float64 {
+	if whole == 0 {
+		return 0
+	}
+	return float64(part) / float64(whole) * 100
 }

--- a/dashboard/internal/model/career.go
+++ b/dashboard/internal/model/career.go
@@ -30,3 +30,45 @@ type PipelineMetrics struct {
 	WithPDF    int
 	Actionable int
 }
+
+// ProgressMetrics holds job search progress analytics.
+type ProgressMetrics struct {
+	// Funnel
+	FunnelStages []FunnelStage
+
+	// Score distribution
+	ScoreBuckets []ScoreBucket
+
+	// Timeline (weekly activity)
+	WeeklyActivity []WeekActivity
+
+	// Rates
+	ResponseRate  float64 // Responded / Applied
+	InterviewRate float64 // Interview / Applied
+	OfferRate     float64 // Offer / Applied
+
+	// Averages
+	AvgScore     float64
+	TopScore     float64
+	TotalOffers  int
+	ActiveApps int // not skip/rejected/discarded
+}
+
+// FunnelStage represents one stage of the application funnel.
+type FunnelStage struct {
+	Label string
+	Count int
+	Pct   float64 // percentage of total
+}
+
+// ScoreBucket represents a score range and its count.
+type ScoreBucket struct {
+	Label string // e.g., "4.5-5.0", "4.0-4.4", "3.5-3.9", "3.0-3.4", "<3.0"
+	Count int
+}
+
+// WeekActivity represents application activity for a given ISO week.
+type WeekActivity struct {
+	Week  string // e.g., "2026-W14", "2026-W13"
+	Count int
+}

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -42,6 +42,9 @@ type PipelineUpdateStatusMsg struct {
 	NewStatus     string
 }
 
+// PipelineOpenProgressMsg is emitted when the progress screen should open.
+type PipelineOpenProgressMsg struct{}
+
 type reportSummary struct {
 	archetype string
 	tldr      string
@@ -261,6 +264,9 @@ func (m PipelineModel) handleKey(msg tea.KeyMsg) (PipelineModel, tea.Cmd) {
 				return PipelineOpenURLMsg{URL: app.JobURL}
 			}
 		}
+
+	case "p":
+		return m, func() tea.Msg { return PipelineOpenProgressMsg{} }
 
 	case "c":
 		if len(m.filtered) > 0 {
@@ -769,6 +775,7 @@ func (m PipelineModel) renderHelp() string {
 		keyStyle.Render("o") + descStyle.Render(" open URL  ") +
 		keyStyle.Render("c") + descStyle.Render(" change  ") +
 		keyStyle.Render("v") + descStyle.Render(" view  ") +
+		keyStyle.Render("p") + descStyle.Render(" progress  ") +
 		keyStyle.Render("Esc") + descStyle.Render(" quit")
 
 	gap := m.width - lipgloss.Width(keys) - lipgloss.Width(brand) - 2

--- a/dashboard/internal/ui/screens/progress.go
+++ b/dashboard/internal/ui/screens/progress.go
@@ -1,0 +1,412 @@
+package screens
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/santifer/career-ops/dashboard/internal/model"
+	"github.com/santifer/career-ops/dashboard/internal/theme"
+)
+
+// ProgressClosedMsg is emitted when the progress screen is dismissed.
+type ProgressClosedMsg struct{}
+
+// ProgressModel implements the progress analytics screen.
+type ProgressModel struct {
+	metrics      model.ProgressMetrics
+	scrollOffset int
+	width        int
+	height       int
+	theme        theme.Theme
+}
+
+// NewProgressModel creates a new progress screen.
+func NewProgressModel(t theme.Theme, metrics model.ProgressMetrics, width, height int) ProgressModel {
+	return ProgressModel{
+		metrics: metrics,
+		width:   width,
+		height:  height,
+		theme:   t,
+	}
+}
+
+// Init implements tea.Model.
+func (m ProgressModel) Init() tea.Cmd {
+	return nil
+}
+
+// Resize updates dimensions.
+func (m *ProgressModel) Resize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+// Update handles input for the progress screen.
+func (m ProgressModel) Update(msg tea.Msg) (ProgressModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc":
+			return m, func() tea.Msg { return ProgressClosedMsg{} }
+		case "down", "j":
+			m.scrollOffset++
+		case "up", "k":
+			if m.scrollOffset > 0 {
+				m.scrollOffset--
+			}
+		case "pgdown", "ctrl+d":
+			m.scrollOffset += m.height / 2
+		case "pgup", "ctrl+u":
+			m.scrollOffset -= m.height / 2
+			if m.scrollOffset < 0 {
+				m.scrollOffset = 0
+			}
+		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	}
+	return m, nil
+}
+
+// View renders the progress screen.
+func (m ProgressModel) View() string {
+	header := m.renderHeader()
+	funnel := m.renderFunnel()
+	scores := m.renderScoreDistribution()
+	rates := m.renderRates()
+	weekly := m.renderWeeklyActivity()
+	help := m.renderHelp()
+
+	// Combine panels
+	body := lipgloss.JoinVertical(lipgloss.Left,
+		funnel,
+		"",
+		scores,
+		"",
+		rates,
+		"",
+		weekly,
+	)
+
+	// Apply scroll
+	bodyLines := strings.Split(body, "\n")
+	offset := m.scrollOffset
+	if offset >= len(bodyLines) {
+		offset = len(bodyLines) - 1
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > 0 {
+		bodyLines = bodyLines[offset:]
+	}
+
+	// Clamp to available height
+	availHeight := m.height - 4 // header + help + padding
+	if availHeight < 3 {
+		availHeight = 3
+	}
+	if len(bodyLines) > availHeight {
+		bodyLines = bodyLines[:availHeight]
+	}
+
+	body = strings.Join(bodyLines, "\n")
+
+	return lipgloss.JoinVertical(lipgloss.Left, header, body, help)
+}
+
+func (m ProgressModel) renderHeader() string {
+	style := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(m.theme.Text).
+		Background(m.theme.Surface).
+		Width(m.width).
+		Padding(0, 2)
+
+	title := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Mauve).Render("SEARCH PROGRESS")
+
+	right := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+	total := len(m.metrics.FunnelStages)
+	totalCount := 0
+	if total > 0 {
+		totalCount = m.metrics.FunnelStages[0].Count
+	}
+	info := right.Render(fmt.Sprintf("%d evaluated | %.1f avg score", totalCount, m.metrics.AvgScore))
+
+	gap := m.width - lipgloss.Width(title) - lipgloss.Width(info) - 4
+	if gap < 1 {
+		gap = 1
+	}
+
+	return style.Render(title + strings.Repeat(" ", gap) + info)
+}
+
+func (m ProgressModel) renderFunnel() string {
+	padStyle := lipgloss.NewStyle().Padding(0, 2)
+	sectionTitle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Sky)
+
+	var lines []string
+	lines = append(lines, padStyle.Render(sectionTitle.Render("Pipeline Funnel")))
+
+	if len(m.metrics.FunnelStages) == 0 {
+		dimStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+		lines = append(lines, padStyle.Render(dimStyle.Render("No data")))
+		return strings.Join(lines, "\n")
+	}
+
+	// Find max count for bar scaling
+	maxCount := 0
+	for _, s := range m.metrics.FunnelStages {
+		if s.Count > maxCount {
+			maxCount = s.Count
+		}
+	}
+
+	labelW := 10
+	barMaxW := m.width - labelW - 20 // room for label, count, pct
+	if barMaxW < 10 {
+		barMaxW = 10
+	}
+
+	// Colors for funnel stages (gradient from cool to warm)
+	stageColors := []lipgloss.Color{
+		m.theme.Blue,
+		m.theme.Sky,
+		m.theme.Green,
+		m.theme.Yellow,
+		m.theme.Peach,
+	}
+
+	for i, stage := range m.metrics.FunnelStages {
+		barW := 0
+		if maxCount > 0 {
+			barW = stage.Count * barMaxW / maxCount
+		}
+		if barW < 1 && stage.Count > 0 {
+			barW = 1
+		}
+
+		color := m.theme.Text
+		if i < len(stageColors) {
+			color = stageColors[i]
+		}
+
+		barStyle := lipgloss.NewStyle().Foreground(color)
+		labelStyle := lipgloss.NewStyle().Foreground(m.theme.Text).Width(labelW)
+		countStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+
+		bar := barStyle.Render(strings.Repeat("\u2588", barW))
+		label := labelStyle.Render(stage.Label)
+
+		pctStr := ""
+		if i > 0 {
+			pctStr = fmt.Sprintf(" (%.0f%%)", stage.Pct)
+		}
+		count := countStyle.Render(fmt.Sprintf("  %d%s", stage.Count, pctStr))
+
+		lines = append(lines, padStyle.Render(label+bar+count))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (m ProgressModel) renderScoreDistribution() string {
+	padStyle := lipgloss.NewStyle().Padding(0, 2)
+	sectionTitle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Sky)
+
+	var lines []string
+	lines = append(lines, padStyle.Render(sectionTitle.Render("Score Distribution")))
+
+	if len(m.metrics.ScoreBuckets) == 0 {
+		dimStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+		lines = append(lines, padStyle.Render(dimStyle.Render("No data")))
+		return strings.Join(lines, "\n")
+	}
+
+	// Find max count for bar scaling
+	maxCount := 0
+	for _, b := range m.metrics.ScoreBuckets {
+		if b.Count > maxCount {
+			maxCount = b.Count
+		}
+	}
+
+	labelW := 8
+	barMaxW := m.width - labelW - 14
+	if barMaxW < 10 {
+		barMaxW = 10
+	}
+
+	// Colors for score ranges (green to red)
+	bucketColors := []lipgloss.Color{
+		m.theme.Green,
+		m.theme.Green,
+		m.theme.Yellow,
+		m.theme.Peach,
+		m.theme.Red,
+	}
+
+	for i, bucket := range m.metrics.ScoreBuckets {
+		barW := 0
+		if maxCount > 0 {
+			barW = bucket.Count * barMaxW / maxCount
+		}
+		if barW < 1 && bucket.Count > 0 {
+			barW = 1
+		}
+
+		color := m.theme.Text
+		if i < len(bucketColors) {
+			color = bucketColors[i]
+		}
+
+		barStyle := lipgloss.NewStyle().Foreground(color)
+		labelStyle := lipgloss.NewStyle().Foreground(m.theme.Text).Width(labelW)
+		countStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+
+		bar := barStyle.Render(strings.Repeat("\u2588", barW))
+		label := labelStyle.Render(bucket.Label)
+		count := countStyle.Render(fmt.Sprintf("  %d", bucket.Count))
+
+		lines = append(lines, padStyle.Render(label+bar+count))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (m ProgressModel) renderRates() string {
+	padStyle := lipgloss.NewStyle().Padding(0, 2)
+	sectionTitle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Sky)
+
+	var lines []string
+	lines = append(lines, padStyle.Render(sectionTitle.Render("Conversion Rates")))
+
+	labelStyle := lipgloss.NewStyle().Foreground(m.theme.Text)
+	valueStyle := lipgloss.NewStyle().Bold(true)
+	sepStyle := lipgloss.NewStyle().Foreground(m.theme.Overlay)
+
+	responseColor := m.rateColor(m.metrics.ResponseRate)
+	interviewColor := m.rateColor(m.metrics.InterviewRate)
+	offerColor := m.rateColor(m.metrics.OfferRate)
+
+	sep := sepStyle.Render("  |  ")
+
+	rates := labelStyle.Render("Response Rate: ") +
+		valueStyle.Foreground(responseColor).Render(fmt.Sprintf("%.1f%%", m.metrics.ResponseRate)) +
+		sep +
+		labelStyle.Render("Interview Rate: ") +
+		valueStyle.Foreground(interviewColor).Render(fmt.Sprintf("%.1f%%", m.metrics.InterviewRate)) +
+		sep +
+		labelStyle.Render("Offer Rate: ") +
+		valueStyle.Foreground(offerColor).Render(fmt.Sprintf("%.1f%%", m.metrics.OfferRate))
+
+	lines = append(lines, padStyle.Render(rates))
+
+	// Active summary
+	dimStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+	activeInfo := dimStyle.Render(fmt.Sprintf(
+		"%d active applications | %d total offers",
+		m.metrics.ActiveApps, m.metrics.TotalOffers,
+	))
+	lines = append(lines, padStyle.Render(activeInfo))
+
+	return strings.Join(lines, "\n")
+}
+
+func (m ProgressModel) renderWeeklyActivity() string {
+	padStyle := lipgloss.NewStyle().Padding(0, 2)
+	sectionTitle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Sky)
+
+	var lines []string
+	lines = append(lines, padStyle.Render(sectionTitle.Render("Weekly Activity")))
+
+	if len(m.metrics.WeeklyActivity) == 0 {
+		dimStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+		lines = append(lines, padStyle.Render(dimStyle.Render("No data")))
+		return strings.Join(lines, "\n")
+	}
+
+	// Find max count for bar scaling
+	maxCount := 0
+	for _, w := range m.metrics.WeeklyActivity {
+		if w.Count > maxCount {
+			maxCount = w.Count
+		}
+	}
+
+	labelW := 10
+	barMaxW := m.width - labelW - 12
+	if barMaxW < 10 {
+		barMaxW = 10
+	}
+
+	for _, week := range m.metrics.WeeklyActivity {
+		barW := 0
+		if maxCount > 0 {
+			barW = week.Count * barMaxW / maxCount
+		}
+		if barW < 1 && week.Count > 0 {
+			barW = 1
+		}
+
+		barStyle := lipgloss.NewStyle().Foreground(m.theme.Blue)
+		labelStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext).Width(labelW)
+		countStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+
+		// Show short week label (e.g., "W14" from "2026-W14")
+		shortWeek := week.Week
+		if idx := strings.Index(shortWeek, "-"); idx >= 0 {
+			shortWeek = shortWeek[idx+1:]
+		}
+
+		bar := barStyle.Render(strings.Repeat("\u2588", barW))
+		label := labelStyle.Render(shortWeek)
+		count := countStyle.Render(fmt.Sprintf("  %d", week.Count))
+
+		lines = append(lines, padStyle.Render(label+bar+count))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (m ProgressModel) renderHelp() string {
+	style := lipgloss.NewStyle().
+		Foreground(m.theme.Subtext).
+		Background(m.theme.Surface).
+		Width(m.width).
+		Padding(0, 1)
+
+	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Text)
+	descStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+
+	brand := lipgloss.NewStyle().Foreground(m.theme.Overlay).Render("career-ops by santifer.io")
+
+	keys := keyStyle.Render("\u2191\u2193") + descStyle.Render(" scroll  ") +
+		keyStyle.Render("PgUp/Dn") + descStyle.Render(" page  ") +
+		keyStyle.Render("Esc") + descStyle.Render(" back")
+
+	gap := m.width - lipgloss.Width(keys) - lipgloss.Width(brand) - 2
+	if gap < 1 {
+		gap = 1
+	}
+
+	return style.Render(keys + strings.Repeat(" ", gap) + brand)
+}
+
+// rateColor returns a color based on the rate value.
+func (m ProgressModel) rateColor(rate float64) lipgloss.Color {
+	switch {
+	case rate >= 30:
+		return m.theme.Green
+	case rate >= 15:
+		return m.theme.Yellow
+	case rate >= 5:
+		return m.theme.Peach
+	default:
+		return m.theme.Red
+	}
+}

--- a/dashboard/main.go
+++ b/dashboard/main.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/santifer/career-ops/dashboard/internal/data"
+	"github.com/santifer/career-ops/dashboard/internal/model"
 	"github.com/santifer/career-ops/dashboard/internal/theme"
 	"github.com/santifer/career-ops/dashboard/internal/ui/screens"
 )
@@ -19,13 +20,16 @@ type viewState int
 const (
 	viewPipeline viewState = iota
 	viewReport
+	viewProgress
 )
 
 type appModel struct {
-	pipeline      screens.PipelineModel
-	viewer        screens.ViewerModel
-	state         viewState
-	careerOpsPath string
+	pipeline        screens.PipelineModel
+	viewer          screens.ViewerModel
+	progress        screens.ProgressModel
+	state           viewState
+	careerOpsPath   string
+	progressMetrics model.ProgressMetrics
 }
 
 func (m appModel) Init() tea.Cmd {
@@ -38,6 +42,9 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pipeline.Resize(msg.Width, msg.Height)
 		if m.state == viewReport {
 			m.viewer.Resize(msg.Width, msg.Height)
+		}
+		if m.state == viewProgress {
+			m.progress.Resize(msg.Width, msg.Height)
 		}
 		pm, cmd := m.pipeline.Update(msg)
 		m.pipeline = pm
@@ -58,6 +65,7 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		apps := data.ParseApplications(m.careerOpsPath)
 		metrics := data.ComputeMetrics(apps)
+		m.progressMetrics = data.ComputeProgressMetrics(apps)
 		old := m.pipeline
 		m.pipeline = screens.NewPipelineModel(
 			theme.NewTheme("catppuccin-mocha"),
@@ -77,6 +85,19 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case screens.ViewerClosedMsg:
+		m.state = viewPipeline
+		return m, nil
+
+	case screens.PipelineOpenProgressMsg:
+		m.progress = screens.NewProgressModel(
+			theme.NewTheme("catppuccin-mocha"),
+			m.progressMetrics,
+			m.pipeline.Width(), m.pipeline.Height(),
+		)
+		m.state = viewProgress
+		return m, nil
+
+	case screens.ProgressClosedMsg:
 		m.state = viewPipeline
 		return m, nil
 
@@ -104,6 +125,11 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.viewer = vm
 			return m, cmd
 		}
+		if m.state == viewProgress {
+			pg, cmd := m.progress.Update(msg)
+			m.progress = pg
+			return m, cmd
+		}
 		pm, cmd := m.pipeline.Update(msg)
 		m.pipeline = pm
 		return m, cmd
@@ -111,10 +137,14 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m appModel) View() string {
-	if m.state == viewReport {
+	switch m.state {
+	case viewReport:
 		return m.viewer.View()
+	case viewProgress:
+		return m.progress.View()
+	default:
+		return m.pipeline.View()
 	}
-	return m.pipeline.View()
 }
 
 func main() {
@@ -132,6 +162,7 @@ func main() {
 
 	// Compute metrics
 	metrics := data.ComputeMetrics(apps)
+	progressMetrics := data.ComputeProgressMetrics(apps)
 
 	// Batch-load all report summaries
 	t := theme.NewTheme("catppuccin-mocha")
@@ -148,8 +179,9 @@ func main() {
 	}
 
 	m := appModel{
-		pipeline:      pm,
-		careerOpsPath: careerOpsPath,
+		pipeline:        pm,
+		careerOpsPath:   careerOpsPath,
+		progressMetrics: progressMetrics,
 	}
 
 	p := tea.NewProgram(m, tea.WithAltScreen())


### PR DESCRIPTION
## Summary

Closes #42

Adds a new progress analytics screen to the Go TUI dashboard, accessible via the `p` key from the pipeline view. Shows job search funnel, score distribution, conversion rates, and weekly activity.

## Changes

| File | Change |
|------|--------|
| `dashboard/internal/model/career.go` | Add `ProgressMetrics`, `FunnelStage`, `ScoreBucket`, `WeekActivity` types |
| `dashboard/internal/data/career.go` | Add `ComputeProgressMetrics()` — funnel, scores, rates, weekly activity |
| `dashboard/internal/ui/screens/progress.go` | **New** — Progress screen with 4 independent render panels |
| `dashboard/internal/ui/screens/pipeline.go` | Add `p` key handler + `PipelineOpenProgressMsg` + help bar entry |
| `dashboard/main.go` | Add `viewProgress` state, routing, metrics recomputation on status change |

**629 lines added, 8 modified. 1 new file. No new dependencies. Build verified.**

## Extensibility (designed for the maintainer)

Each metric panel is a **separate, independent render function**:
- `renderFunnel()` — Pipeline conversion visualization
- `renderScoreDistribution()` — Score histogram
- `renderRates()` — Response/interview/offer conversion rates
- `renderWeeklyActivity()` — Last 8 weeks timeline

Adding/removing/reordering panels requires only editing `View()`. Data computation is cleanly separated in `data/career.go`. All styling uses the existing Catppuccin theme system — no hardcoded colors.

## Screenshots

The screen displays:
- **Funnel**: Evaluated → Applied → Responded → Interview → Offer with horizontal bars and conversion %
- **Scores**: 5-bucket histogram (4.5-5.0 down to <3.0) with color gradient
- **Rates**: Response rate, interview rate, offer rate inline
- **Weekly**: Last 8 ISO weeks activity bars

Navigation: `↑↓` scroll, `PgUp/Dn` page, `Esc` back to pipeline.

## Test plan

- [ ] `cd dashboard && go build -o career-dashboard .` — compiles clean
- [ ] Run dashboard with real `applications.md` data — all panels render
- [ ] Press `p` from pipeline — progress screen opens
- [ ] Press `Esc` from progress — returns to pipeline
- [ ] Verify colors match Catppuccin Mocha theme
- [ ] Verify empty data case — shows "No data yet" gracefully
- [ ] Window resize — panels adapt to terminal width

🤖 Generated with [Claude Code](https://claude.com/claude-code)