### PR TITLE
fix: add data/ fallback to UpdateApplicationStatus

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -540,7 +540,11 @@ func UpdateApplicationStatus(careerOpsPath string, app model.CareerApplication, 
 	filePath := filepath.Join(careerOpsPath, "applications.md")
 	content, err := os.ReadFile(filePath)
 	if err != nil {
-		return err
+		filePath = filepath.Join(careerOpsPath, "data", "applications.md")
+		content, err = os.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
 	}
 
 	lines := strings.Split(string(content), "\n")


### PR DESCRIPTION
## Summary

- Add `data/` directory fallback to `UpdateApplicationStatus` in `dashboard/internal/data/career.go`
- Matches the existing fallback pattern in `ParseApplications`
- Fixes dashboard `c` key (change status) silently failing when `applications.md` is in `data/`

## Root cause

`ParseApplications` tries both `{path}/applications.md` and `{path}/data/applications.md`, but `UpdateApplicationStatus` only tried the root path. Since `data/applications.md` is the documented default (per CLAUDE.md), status changes silently failed for most users.

## Test plan

- [x] `go build` passes
- [x] Tested manually: dashboard `c` key now updates status in `data/applications.md`

Fixes #54