### PR TITLE
fix: filter expired WebSearch links before they reach the pipeline

### DIFF
--- a/check-liveness.mjs
+++ b/check-liveness.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+/**
+ * check-liveness.mjs — Playwright job link liveness checker
+ *
+ * Tests whether job posting URLs are still active or have expired.
+ * Uses the same detection logic as scan.md step 7.5.
+ * Zero Claude API tokens — pure Playwright.
+ *
+ * Usage:
+ *   node check-liveness.mjs <url1> [url2] ...
+ *   node check-liveness.mjs --file urls.txt
+ *
+ * Exit code: 0 if all active, 1 if any expired or uncertain
+ */
+
+import { chromium } from 'playwright';
+import { readFile } from 'fs/promises';
+
+const EXPIRED_PATTERNS = [
+  /job (is )?no longer available/i,
+  /job.*no longer open/i,           // Greenhouse: "The job you are looking for is no longer open."
+  /position has been filled/i,
+  /this job has expired/i,
+  /job posting has expired/i,
+  /no longer accepting applications/i,
+  /this (position|role|job) (is )?no longer/i,
+  /this job (listing )?is closed/i,
+  /job (listing )?not found/i,
+  /the page you are looking for doesn.t exist/i, // Workday /job/ 404
+  /\d+\s+jobs?\s+found/i,           // Workday: landed on listing page ("663 JOBS FOUND") instead of a specific job
+  /search for jobs page is loaded/i, // Workday SPA indicator for listing page
+  /diese stelle (ist )?(nicht mehr|bereits) besetzt/i,
+  /offre (expirée|n'est plus disponible)/i,
+];
+
+// URL patterns that indicate an ATS has redirected away from the job (closed/expired)
+const EXPIRED_URL_PATTERNS = [
+  /[?&]error=true/i,   // Greenhouse redirect on closed jobs
+];
+
+const APPLY_PATTERNS = [
+  /\bapply\b/i,          // catches "Apply", "Apply Now", "Apply for this Job"
+  /\bsolicitar\b/i,
+  /\bbewerben\b/i,
+  /\bpostuler\b/i,
+  /submit application/i,
+  /easy apply/i,
+  /start application/i,  // Ashby
+  /ich bewerbe mich/i,   // German Greenhouse
+];
+
+// Below this length the page is probably just nav/footer (closed ATS page)
+const MIN_CONTENT_CHARS = 300;
+
+async function checkUrl(page, url) {
+  try {
+    const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
+
+    const status = response?.status() ?? 0;
+    if (status === 404 || status === 410) {
+      return { result: 'expired', reason: `HTTP ${status}` };
+    }
+
+    // Give SPAs (Ashby, Lever, Workday) time to hydrate
+    await page.waitForTimeout(2000);
+
+    // Check if the ATS redirected to an error/listing page (e.g. Greenhouse ?error=true)
+    const finalUrl = page.url();
+    for (const pattern of EXPIRED_URL_PATTERNS) {
+      if (pattern.test(finalUrl)) {
+        return { result: 'expired', reason: `redirect to ${finalUrl}` };
+      }
+    }
+
+    const bodyText = await page.evaluate(() => document.body?.innerText ?? '');
+
+    // Apply button is the strongest positive signal — check it first.
+    // This short-circuits before expired patterns that can appear on active pages
+    // (e.g. Workday's split-view layout shows "N JOBS FOUND" even on active job pages).
+    if (APPLY_PATTERNS.some(p => p.test(bodyText))) {
+      return { result: 'active', reason: 'apply button detected' };
+    }
+
+    for (const pattern of EXPIRED_PATTERNS) {
+      if (pattern.test(bodyText)) {
+        return { result: 'expired', reason: `pattern matched: ${pattern.source}` };
+      }
+    }
+
+    if (bodyText.trim().length < MIN_CONTENT_CHARS) {
+      return { result: 'expired', reason: 'insufficient content — likely nav/footer only' };
+    }
+
+    return { result: 'uncertain', reason: 'content present but no apply button found' };
+
+  } catch (err) {
+    return { result: 'expired', reason: `navigation error: ${err.message.split('\n')[0]}` };
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0) {
+    console.error('Usage: node check-liveness.mjs <url1> [url2] ...');
+    console.error('       node check-liveness.mjs --file urls.txt');
+    process.exit(1);
+  }
+
+  let urls;
+  if (args[0] === '--file') {
+    const text = await readFile(args[1], 'utf-8');
+    urls = text.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+  } else {
+    urls = args;
+  }
+
+  console.log(`Checking ${urls.length} URL(s)...\n`);
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  let active = 0, expired = 0, uncertain = 0;
+
+  // Sequential — project rule: never Playwright in parallel
+  for (const url of urls) {
+    const { result, reason } = await checkUrl(page, url);
+    const icon = { active: '✅', expired: '❌', uncertain: '⚠️' }[result];
+    console.log(`${icon} ${result.padEnd(10)} ${url}`);
+    if (result !== 'active') console.log(`           ${reason}`);
+    if (result === 'active') active++;
+    else if (result === 'expired') expired++;
+    else uncertain++;
+  }
+
+  await browser.close();
+
+  console.log(`\nResults: ${active} active  ${expired} expired  ${uncertain} uncertain`);
+  if (expired > 0 || uncertain > 0) process.exit(1);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err.message);
+  process.exit(1);
+});

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -89,12 +89,31 @@ Los niveles son aditivos — se ejecutan todos, los resultados se mezclan y dedu
    - `applications.md` → empresa + rol normalizado ya evaluado
    - `pipeline.md` → URL exacta ya en pendientes o procesadas
 
-8. **Para cada oferta nueva que pase filtros**:
+7.5. **Verificar liveness de resultados de WebSearch (Nivel 3)** — ANTES de añadir a pipeline:
+
+   Los resultados de WebSearch pueden estar desactualizados (Google cachea resultados durante semanas o meses). Para evitar evaluar ofertas expiradas, verificar con Playwright cada URL nueva que provenga del Nivel 3. Los Niveles 1 y 2 son inherentemente en tiempo real y no requieren esta verificación.
+
+   Para cada URL nueva de Nivel 3 (secuencial — NUNCA Playwright en paralelo):
+   a. `browser_navigate` a la URL
+   b. `browser_snapshot` para leer el contenido
+   c. Clasificar:
+      - **Activa**: título del puesto visible + descripción del rol + botón Apply/Submit/Solicitar
+      - **Expirada** (cualquiera de estas señales):
+        - URL final contiene `?error=true` (Greenhouse redirige así cuando la oferta está cerrada)
+        - Página contiene: "job no longer available" / "no longer open" / "position has been filled" / "this job has expired" / "page not found"
+        - Solo navbar y footer visibles, sin contenido JD (contenido < ~300 chars)
+   d. Si expirada: registrar en `scan-history.tsv` con status `skipped_expired` y descartar
+   e. Si activa: continuar al paso 8
+
+   **No interrumpir el scan entero si una URL falla.** Si `browser_navigate` da error (timeout, 403, etc.), marcar como `skipped_expired` y continuar con la siguiente.
+
+8. **Para cada oferta nueva verificada que pase filtros**:
    a. Añadir a `pipeline.md` sección "Pendientes": `- [ ] {url} | {company} | {title}`
    b. Registrar en `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
 
 9. **Ofertas filtradas por título**: registrar en `scan-history.tsv` con status `skipped_title`
 10. **Ofertas duplicadas**: registrar con status `skipped_dup`
+11. **Ofertas expiradas (Nivel 3)**: registrar con status `skipped_expired`
 
 ## Extracción de título y empresa de WebSearch results
 
@@ -122,6 +141,7 @@ url	first_seen	portal	title	company	status
 https://...	2026-02-10	Ashby — AI PM	PM AI	Acme	added
 https://...	2026-02-10	Greenhouse — SA	Junior Dev	BigCo	skipped_title
 https://...	2026-02-10	Ashby — AI PM	SA AI	OldCo	skipped_dup
+https://...	2026-02-10	WebSearch — AI PM	PM AI	ClosedCo	skipped_expired
 ```
 
 ## Resumen de salida
@@ -133,6 +153,7 @@ Queries ejecutados: N
 Ofertas encontradas: N total
 Filtradas por título: N relevantes
 Duplicadas: N (ya evaluadas o en pipeline)
+Expiradas descartadas: N (links muertos, Nivel 3)
 Nuevas añadidas a pipeline.md: N
 
   + {company} | {title} | {query_name}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "sync-check": "node cv-sync-check.mjs",
     "update:check": "node update-system.mjs check",
     "update": "node update-system.mjs apply",
-    "rollback": "node update-system.mjs rollback"
+    "rollback": "node update-system.mjs rollback",
+    "liveness": "node check-liveness.mjs"
   },
   "keywords": ["ai", "job-search", "claude-code", "career", "automation"],
   "author": "Santiago Fernández de Valderrama <hi@santifer.io> (https://santifer.io)",


### PR DESCRIPTION
Fixes #49.

WebSearch results (scan level 3) can be weeks or months stale — Google caches job postings long after they close. Levels 1 and 2 (Playwright direct + Greenhouse API) are live by definition and don't need this.

`modes/scan.md` adds step 7.5: after dedup, before writing to pipeline.md, each level 3 URL gets a Playwright liveness check. Active links proceed; expired ones are logged as skipped_expired in scan-history.tsv and dropped. Doesn't consume Claude API tokens

`check-liveness.mjs` is a standalone script with the same detection logic. Useful for testing URLs outside of a full scan and for adding new ATS patterns.

eg:
```
  node check-liveness.mjs <url1> [url2] ...
  node check-liveness.mjs --file urls.txt
  npm run liveness -- <url>
```

  Detection order (apply button is checked first to avoid false positives on pages that mix listing content with job details, e.g. Workday's split-view layout):
  1. Apply button present -- active, stop
  2. URL redirected to error page (e.g. Greenhouse ?error=true) -- expired
  3. Page text matches known closed-job phrases -- expired
  4. Page content under 300 chars (nav/footer only) -- expired
  5. No apply button, enough content -- uncertain (conservative, skip it)

  Patterns tested and confirmed:
  - Greenhouse: redirect to ?error=true, "The job you are looking for is no longer open."
  - Ashby: "Job not found"
  - Lever: HTTP 404
  - Workday /job/: "The page you are looking for doesn't exist."
  - Workday /details/: "N JOBS FOUND" (landed on listing, no job selected)


