### PR TITLE
feat: add OpenCode slash commands for career-ops

### DIFF
--- a/.opencode/commands/career-ops-apply.md
+++ b/.opencode/commands/career-ops-apply.md
@@ -1,0 +1,12 @@
+---
+description: Live application assistant
+---
+
+Application assistant using career-ops apply mode. Form data/context:
+
+$ARGUMENTS
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-batch.md
+++ b/.opencode/commands/career-ops-batch.md
@@ -1,0 +1,12 @@
+---
+description: Batch processing with parallel workers
+---
+
+Batch processing using career-ops batch mode.
+
+$ARGUMENTS
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-compare.md
+++ b/.opencode/commands/career-ops-compare.md
@@ -1,0 +1,12 @@
+---
+description: Compare and rank multiple job offers
+---
+
+Compare the following job offers using career-ops ofertas mode:
+
+$ARGUMENTS
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-contact.md
+++ b/.opencode/commands/career-ops-contact.md
@@ -1,0 +1,12 @@
+---
+description: LinkedIn power move - find contacts and draft message
+---
+
+LinkedIn outreach for company/role using career-ops contacto mode:
+
+$ARGUMENTS
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-deep.md
+++ b/.opencode/commands/career-ops-deep.md
@@ -1,0 +1,12 @@
+---
+description: Deep research about a company
+---
+
+Deep research about company using career-ops deep mode:
+
+$ARGUMENTS
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-evaluate.md
+++ b/.opencode/commands/career-ops-evaluate.md
@@ -1,0 +1,12 @@
+---
+description: Evaluate job offer (A-F scoring, no auto PDF)
+---
+
+Evaluate the following job description using career-ops oferta mode:
+
+$ARGUMENTS
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-pdf.md
+++ b/.opencode/commands/career-ops-pdf.md
@@ -1,0 +1,10 @@
+---
+description: Generate ATS-optimized CV PDF
+---
+
+Generate ATS-optimized CV using career-ops pdf mode.
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-pipeline.md
+++ b/.opencode/commands/career-ops-pipeline.md
@@ -1,0 +1,10 @@
+---
+description: Process pending URLs from pipeline inbox
+---
+
+Process pending job URLs from data/pipeline.md using career-ops pipeline mode.
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-project.md
+++ b/.opencode/commands/career-ops-project.md
@@ -1,0 +1,12 @@
+---
+description: Evaluate portfolio project idea
+---
+
+Evaluate the following portfolio project using career-ops project mode:
+
+$ARGUMENTS
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-scan.md
+++ b/.opencode/commands/career-ops-scan.md
@@ -1,0 +1,10 @@
+---
+description: Scan job portals and discover new offers
+---
+
+Scan job portals for new offers using career-ops scan mode.
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-tracker.md
+++ b/.opencode/commands/career-ops-tracker.md
@@ -1,0 +1,10 @@
+---
+description: Application status overview
+---
+
+Show application tracker status using career-ops tracker mode.
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-training.md
+++ b/.opencode/commands/career-ops-training.md
@@ -1,0 +1,12 @@
+---
+description: Evaluate course/cert against North Star
+---
+
+Evaluate the following training/course using career-ops training mode:
+
+$ARGUMENTS
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops.md
+++ b/.opencode/commands/career-ops.md
@@ -1,0 +1,14 @@
+---
+description: AI job search command center -- show menu or evaluate job description
+---
+
+Career-ops router. Arguments provided: "$ARGUMENTS"
+
+If arguments contain a job description or URL (keywords like "responsibilities", "requirements", "qualifications", "about the role", "http", "https"), the skill will execute auto-pipeline mode.
+
+Otherwise, the discovery menu will be shown.
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This system was built and used by [santifer](https://santifer.io) to evaluate 74
 
 The portfolio that goes with this system is also open source: [cv-santiago](https://github.com/santifer/cv-santiago).
 
-**It will work out of the box, but it's designed to be made yours.** If the archetypes don't match your career, the modes are in the wrong language, or the scoring doesn't fit your priorities -- just ask. You (Claude) can edit the user's files. The user says "change the archetypes to data engineering roles" and you do it. That's the whole point.
+**It will work out of the box, but it's designed to be made yours.** If the archetypes don't match your career, the modes are in the wrong language, or the scoring doesn't fit your priorities -- just ask. You (AI Agent) can edit the user's files. The user says "change the archetypes to data engineering roles" and you do it. That's the whole point.
 
 ## Data Contract (CRITICAL)
 
@@ -58,6 +58,28 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `article-digest.md` | Compact proof points from portfolio (optional) |
 | `interview-prep/story-bank.md` | Accumulated STAR+R stories across evaluations |
 | `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`) |
+
+### OpenCode Commands
+
+When using [OpenCode](https://opencode.ai), the following slash commands are available (defined in `.opencode/commands/`):
+
+| Command | Claude Code Equivalent | Description |
+|---------|------------------------|-------------|
+| `/career-ops` | `/career-ops` | Show menu or evaluate JD with args |
+| `/career-ops-pipeline` | `/career-ops pipeline` | Process pending URLs from inbox |
+| `/career-ops-evaluate` | `/career-ops oferta` | Evaluate job offer (A-F scoring) |
+| `/career-ops-compare` | `/career-ops ofertas` | Compare and rank multiple offers |
+| `/career-ops-contact` | `/career-ops contacto` | LinkedIn outreach (find contacts + draft) |
+| `/career-ops-deep` | `/career-ops deep` | Deep company research |
+| `/career-ops-pdf` | `/career-ops pdf` | Generate ATS-optimized CV |
+| `/career-ops-training` | `/career-ops training` | Evaluate course/cert against goals |
+| `/career-ops-project` | `/career-ops project` | Evaluate portfolio project idea |
+| `/career-ops-tracker` | `/career-ops tracker` | Application status overview |
+| `/career-ops-apply` | `/career-ops apply` | Live application assistant |
+| `/career-ops-scan` | `/career-ops scan` | Scan portals for new offers |
+| `/career-ops-batch` | `/career-ops batch` | Batch processing with parallel workers |
+
+**Note:** OpenCode commands invoke the same `.claude/skills/career-ops/SKILL.md` skill used by Claude Code. The `modes/*` files are shared between both platforms.
 
 ### First Run — Onboarding (IMPORTANT)
 
@@ -131,7 +153,7 @@ Store any insights the user shares in `config/profile.yml` (under narrative) or 
 Once all files exist, confirm:
 > "You're all set! You can now:
 > - Paste a job URL to evaluate it
-> - Run `/career-ops scan` to search portals
+> - Run `/career-ops scan` (or `/career-ops-scan` if using OpenCode) to search portals
 > - Run `/career-ops` to see all commands
 >
 > Everything is customizable — just ask me to change anything.
@@ -141,11 +163,11 @@ Once all files exist, confirm:
 Then suggest automation:
 > "Want me to scan for new offers automatically? I can set up a recurring scan every few days so you don't miss anything. Just say 'scan every 3 days' and I'll configure it."
 
-If the user accepts, use the `/loop` or `/schedule` skill (if available) to set up a recurring `/career-ops scan`. If those aren't available, suggest adding a cron job or remind them to run `/career-ops scan` periodically.
+If the user accepts, use the `/loop` or `/schedule` skill (if available) to set up a recurring `/career-ops scan` (or `/career-ops-scan` if using OpenCode). If those aren't available, suggest adding a cron job or remind them to run `/career-ops scan` (or `/career-ops-scan` if using OpenCode) periodically.
 
 ### Personalization
 
-This system is designed to be customized by YOU (Claude). When the user asks you to change archetypes, translate modes, adjust scoring, add companies, or modify negotiation scripts -- do it directly. You read the same files you use, so you know exactly what to edit.
+This system is designed to be customized by YOU (AI Agent). When the user asks you to change archetypes, translate modes, adjust scoring, add companies, or modify negotiation scripts -- do it directly. You read the same files you use, so you know exactly what to edit.
 
 **Common customization requests:**
 - "Change the archetypes to [backend/frontend/data/devops] roles" → edit `modes/_shared.md`


### PR DESCRIPTION
Fixes https://github.com/santifer/career-ops/issues/66

Add .opencode/commands/ directory with 14 command files that map to career-ops skill modes:

- /career-ops: Main router (discovery + auto-pipeline)
- /career-ops-pipeline: Process pending URLs
- /career-ops-evaluate: Evaluate job offer (oferta mode)
- /career-ops-compare: Compare offers (ofertas mode)
- /career-ops-contact: LinkedIn outreach (contacto mode)
- /career-ops-deep: Deep research (deep mode)
- /career-ops-pdf: Generate CV (pdf mode)
- /career-ops-training: Evaluate training (training mode)
- /career-ops-project: Evaluate project (project mode)
- /career-ops-tracker: Application tracker (tracker mode)
- /career-ops-apply: Application assistant (apply mode)
- /career-ops-scan: Scan portals (scan mode)
- /career-ops-batch: Batch processing (batch mode)

Update CLAUDE.md with OpenCode command documentation.