### PR TITLE
Add French language modes (modes/fr/)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,13 +160,19 @@ This system is designed to be customized by YOU (Claude). When the user asks you
 Default modes are in `modes/` (English). Additional language-specific modes are available:
 
 - **German (DACH market):** `modes/de/` — native German translations with DACH-specific vocabulary (13. Monatsgehalt, Probezeit, Kündigungsfrist, AGG, Tarifvertrag, etc.). Includes `_shared.md`, `angebot.md` (evaluation), `bewerben.md` (apply), `pipeline.md`.
+- **French (Francophone market):** `modes/fr/` — native French translations with France/Belgium/Switzerland/Luxembourg-specific vocabulary (CDI/CDD, convention collective SYNTEC, RTT, mutuelle, prévoyance, 13e mois, intéressement/participation, titres-restaurant, CSE, portage salarial, etc.). Includes `_shared.md`, `offre.md` (evaluation), `postuler.md` (apply), `pipeline.md`.
 
 **When to use German modes:** If the user is targeting German-language job postings, lives in DACH, or asks for German output. Either:
 1. User says "use German modes" → read from `modes/de/` instead of `modes/`
 2. User sets `language.modes_dir: modes/de` in `config/profile.yml` → always use German modes
 3. You detect a German JD → suggest switching to German modes
 
-**When NOT to:** If the user applies to English-language roles, even at German companies, use the default English modes.
+**When to use French modes:** If the user is targeting French-language job postings, lives in France/Belgium/Switzerland/Luxembourg/Quebec, or asks for French output. Either:
+1. User says "use French modes" → read from `modes/fr/` instead of `modes/`
+2. User sets `language.modes_dir: modes/fr` in `config/profile.yml` → always use French modes
+3. You detect a French JD → suggest switching to French modes
+
+**When NOT to:** If the user applies to English-language roles, even at French or German companies, use the default English modes.
 
 ### Skill Modes
 

--- a/modes/fr/README.md
+++ b/modes/fr/README.md
@@ -1,0 +1,106 @@
+# career-ops -- Modes francophones (`modes/fr/`)
+
+Ce dossier contient les traductions francaises des principaux modes career-ops pour les candidats qui ciblent le marche francophone (France, Belgique, Suisse romande, Luxembourg, Quebec).
+
+## Quand utiliser ces modes ?
+
+Utilise `modes/fr/` si au moins une de ces conditions est remplie :
+
+- Tu postules principalement a des **offres d'emploi en francais** (Welcome to the Jungle, Indeed FR, APEC, Pole emploi / France Travail, LinkedIn FR, sites carrieres)
+- Ton **CV est en francais** ou tu alternes entre FR et EN selon l'offre
+- Tu as besoin de reponses et lettres de motivation en **francais tech naturel**, pas traduit par une machine
+- Tu dois gerer des **specificites contractuelles francophones** : convention collective, RTT, mutuelle, prevoyance, 13e mois, periode d'essai, preavis, cheques-dejeuner, interessement/participation
+
+Si la plupart de tes offres sont en anglais, reste sur les modes standard dans `modes/`. Les modes anglais fonctionnent pour les offres francophones, mais ne connaissent pas les specificites du marche francophone en detail.
+
+## Comment activer ?
+
+### Option 1 -- Par session
+
+Dis a Claude en debut de session :
+
+> "Utilise les modes francais sous `modes/fr/`."
+
+Claude lira alors les fichiers de ce dossier au lieu de `modes/`.
+
+### Option 2 -- En permanence
+
+Ajoute dans `config/profile.yml` :
+
+```yaml
+language:
+  primary: fr
+  modes_dir: modes/fr
+```
+
+Rappelle-le a Claude lors de ta premiere session ("Regarde dans `profile.yml`, j'ai configure `language.modes_dir`"). Claude utilisera automatiquement les modes francais.
+
+## Quels modes sont traduits ?
+
+Cette premiere iteration couvre les quatre modes a plus fort impact :
+
+| Fichier | Traduit depuis | Role |
+|---------|----------------|------|
+| `_shared.md` | `modes/_shared.md` (EN) | Contexte partage, archetypes, regles globales, specificites marche francophone |
+| `offre.md` | `modes/oferta.md` (ES) | Evaluation complete d'une offre (Blocs A-F) |
+| `postuler.md` | `modes/apply.md` (EN) | Assistant live pour remplir les formulaires de candidature |
+| `pipeline.md` | `modes/pipeline.md` (ES) | Inbox d'URLs / Second Brain pour les offres collectees |
+
+Les autres modes (`scan`, `batch`, `pdf`, `tracker`, `auto-pipeline`, `deep`, `contacto`, `ofertas`, `project`, `training`) restent en EN/ES. Leur contenu est surtout du tooling, des chemins et des commandes -- il doit rester independant de la langue.
+
+## Ce qui reste en anglais
+
+Volontairement non traduit car vocabulaire tech standard :
+
+- `cv.md`, `pipeline`, `tracker`, `report`, `score`, `archetype`, `proof point`
+- Noms d'outils (`Playwright`, `WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`)
+- Valeurs de statut dans le tracker (`Evaluated`, `Applied`, `Interview`, `Offer`, `Rejected`)
+- Extraits de code, chemins, commandes
+
+Les modes utilisent du francais tech naturel, tel qu'il est parle dans les equipes engineering a Paris, Lyon ou Geneve : texte courant en francais, termes techniques en anglais la ou c'est l'usage. Pas de traduction forcee de "Pipeline" en "Canalisation" ni de "Deploy" en "Deploiement applicatif".
+
+## Lexique de reference
+
+Pour garder un ton coherent si tu modifies ou etends les modes :
+
+| Anglais | Francais (dans cette codebase) |
+|---------|-------------------------------|
+| Job posting | Offre d'emploi / Annonce |
+| Application | Candidature |
+| Cover letter | Lettre de motivation |
+| Resume / CV | CV |
+| Salary | Salaire / Remuneration |
+| Compensation | Remuneration / Package |
+| Skills | Competences |
+| Interview | Entretien |
+| Hiring manager | Manager recruteur / Hiring manager |
+| Recruiter | Recruteur (ou Recruiter) |
+| AI | IA (Intelligence Artificielle) |
+| Requirements | Prerequis / Exigences |
+| Career history | Parcours professionnel |
+| Notice period | Preavis |
+| Probation | Periode d'essai |
+| Vacation | Conges payes (CP) |
+| 13th month salary | 13e mois / Prime de fin d'annee |
+| Permanent employment | CDI (Contrat a Duree Indeterminee) |
+| Fixed-term contract | CDD (Contrat a Duree Determinee) |
+| Freelance | Freelance / Independant / Auto-entrepreneur |
+| Collective agreement | Convention collective |
+| Works council | CSE (Comite Social et Economique) |
+| Profit sharing | Interessement / Participation |
+| Meal vouchers | Titres-restaurant / Cheques-dejeuner |
+| Health insurance | Mutuelle d'entreprise |
+| Disability/life insurance | Prevoyance |
+| RTT | RTT (Reduction du Temps de Travail) |
+| Cadre status | Statut cadre |
+| SYNTEC | Convention SYNTEC (IT/consulting) |
+
+## Contribuer
+
+Pour ameliorer une traduction ou ajouter un mode :
+
+1. Ouvre une Issue avec ta proposition (voir `CONTRIBUTING.md`)
+2. Respecte le lexique ci-dessus pour garder le ton coherent
+3. Traduis de maniere idiomatique -- pas de traduction mot a mot
+4. Conserve les elements structurels (Blocs A-F, tableaux, blocs de code, instructions outils) a l'identique
+5. Teste avec une vraie offre francophone (Welcome to the Jungle, APEC, Indeed FR) avant de soumettre la PR

--- a/modes/fr/_shared.md
+++ b/modes/fr/_shared.md
@@ -1,0 +1,205 @@
+# Contexte partage -- career-ops (Francais)
+
+<!-- ============================================================
+     PERSONNALISATION DE CE FICHIER
+     ============================================================
+     Ce fichier contient le contexte partage pour tous les modes
+     career-ops en version francaise. Avant d'utiliser career-ops, tu DOIS :
+     1. Remplir config/profile.yml avec tes informations personnelles
+     2. Creer cv.md a la racine du projet (CV en Markdown)
+     3. (Optionnel) Creer article-digest.md avec tes proof points
+     4. Adapter les sections marquees [PERSONNALISER] ci-dessous
+     ============================================================ -->
+
+## Sources de verite (TOUJOURS lire avant chaque evaluation)
+
+| Fichier | Chemin | Quand |
+|---------|--------|-------|
+| cv.md | `cv.md` (racine du projet) | TOUJOURS |
+| article-digest.md | `article-digest.md` (si existant) | TOUJOURS (proof points detailles) |
+| profile.yml | `config/profile.yml` | TOUJOURS (identite et roles cibles) |
+
+**REGLE : Ne JAMAIS coder en dur des metriques issues des proof points.** Les lire depuis `cv.md` et `article-digest.md` au moment de l'evaluation.
+**REGLE : Pour les metriques d'articles/projets, `article-digest.md` a priorite sur `cv.md`** (`cv.md` peut contenir des chiffres plus anciens).
+
+---
+
+## North Star -- Roles cibles
+
+Le skill traite TOUS les roles cibles avec le meme soin. Aucun n'est primaire ou secondaire -- chacun est un succes si la remuneration et les perspectives d'evolution sont au rendez-vous :
+
+| Archetype | Axes thematiques | Ce que l'entreprise achete |
+|-----------|------------------|----------------------------|
+| **AI Platform / LLMOps Engineer** | Evaluation, Observability, Fiabilite, Pipelines | Quelqu'un qui met l'IA en production avec des metriques |
+| **Agentic Workflows / Automation** | HITL, Tooling, Orchestration, Multi-Agent | Quelqu'un qui construit des systemes agents fiables |
+| **Technical AI Product Manager** | GenAI/Agents, PRDs, Discovery, Delivery | Quelqu'un qui traduit le business en produits IA |
+| **AI Solutions Architect** | Hyperautomation, Enterprise, Integrations | Quelqu'un qui concoit des architectures IA end-to-end |
+| **AI Forward Deployed Engineer** | Client-facing, Livraison rapide, Prototypage | Quelqu'un qui deploie des solutions IA rapidement chez le client |
+| **AI Transformation Lead** | Conduite du changement, Adoption, Enablement | Quelqu'un qui pilote la transformation IA dans les organisations |
+
+<!-- [PERSONNALISER] Adapte les archetypes ci-dessus a tes roles cibles.
+     Exemple pour le backend engineering :
+     - Senior Backend Engineer
+     - Staff Platform Engineer
+     - Engineering Manager
+     etc. -->
+
+### Framing adaptatif par archetype
+
+> **Metriques concretes : les lire depuis `cv.md` et `article-digest.md` au moment de l'evaluation. JAMAIS les coder en dur ici.**
+
+| Si le role est... | Mettre en avant chez le candidat... | Sources de proof points |
+|-------------------|-------------------------------------|-------------------------|
+| Platform / LLMOps | Experience production, observability, evals, closed-loop | article-digest.md + cv.md |
+| Agentic / Automation | Orchestration multi-agent, HITL, fiabilite, couts | article-digest.md + cv.md |
+| Technical AI PM | Product discovery, PRDs, metriques, gestion des parties prenantes | cv.md + article-digest.md |
+| Solutions Architect | Conception systeme, integrations, pret pour l'entreprise | article-digest.md + cv.md |
+| Forward Deployed Engineer | Livraison rapide, proximite client, prototype a production | cv.md + article-digest.md |
+| AI Transformation Lead | Conduite du changement, enablement d'equipe, adoption | cv.md + article-digest.md |
+
+<!-- [PERSONNALISER] Associe tes projets/articles concrets aux archetypes ci-dessus -->
+
+### Narratif de transition (a utiliser dans TOUS les framings)
+
+<!-- [PERSONNALISER] Remplace par ton propre narratif. Exemples :
+     - "SaaS construite et vendue apres 5 ans. Desormais 100% focus sur l'IA appliquee en entreprise."
+     - "Lead engineering dans une Series-B pendant une croissance x10. En quete du prochain defi."
+     - "Transition du conseil vers le produit. Recherche de roles a forte responsabilite."
+     Lu depuis config/profile.yml -> narrative.exit_story -->
+
+Utiliser le narratif de transition depuis `config/profile.yml` pour cadrer TOUS les contenus :
+- **Dans les summaries PDF :** Faire le pont entre le passe et le futur -- "Applique desormais les memes [competences] au domaine [de l'offre]."
+- **Dans les stories STAR :** Faire reference aux proof points de `article-digest.md`.
+- **Dans les reponses draft (Bloc G) :** Le narratif de transition va dans la premiere reponse.
+- **Quand l'offre mentionne "entrepreneurial", "autonomie", "builder", "end-to-end" :** C'est LE differenciateur n.1. Augmenter le poids du match.
+
+### Avantage transversal
+
+Cadrer le profil comme **"Builder technique avec une pratique demontrable"**, en adaptant le framing au role :
+- Pour PM : "Builder qui reduit l'incertitude avec des prototypes puis livre en production de maniere disciplinee"
+- Pour FDE : "Builder qui livre des le jour 1 avec observability et metriques"
+- Pour SA : "Builder qui concoit des systemes end-to-end avec une vraie experience d'integration"
+- Pour LLMOps : "Builder qui met l'IA en production avec des systemes qualite en boucle fermee"
+
+Positionner "Builder" comme signal professionnel -- pas comme "bricoleur". Les proof points reels rendent ca credible.
+
+### Portfolio comme proof point (utiliser dans les candidatures a fort enjeu)
+
+<!-- [PERSONNALISER] Si tu as une demo live, un dashboard ou un projet public, configure-le ici.
+     Exemple :
+     dashboard:
+       url: "https://tondomaine.dev/demo"
+       password: "demo-2026"
+       when_to_share: "Roles LLMOps, AI Platform, Observability"
+     Lu depuis config/profile.yml -> narrative.proof_points et narrative.dashboard -->
+
+Si le candidat a une demo live / un dashboard (verifier `profile.yml`), proposer l'acces dans les candidatures pertinentes.
+
+### Intelligence remuneration (Comp Intelligence)
+
+<!-- [PERSONNALISER] Recherche les fourchettes de remuneration pour tes roles cibles et adapte les valeurs -->
+
+**Conseils generaux :**
+- WebSearch pour les donnees marche actuelles (Glassdoor, Levels.fyi, Welcome to the Jungle, APEC, Talent.io, Indeed Salaires)
+- Cadrer par titre de poste, pas par competences -- les titres definissent les bandes salariales
+- Les taux freelance en France sont generalement 30-50% au-dessus du brut horaire equivalent CDI (charges sociales, conges, maladie, prospection)
+- Le geo-arbitrage fonctionne en remote : cout de la vie plus bas = meilleur net
+
+### Marche francophone -- Specificites (IMPORTANT)
+
+Dans les offres et negociations francophones, certains termes n'existent pas sur les marches EN/ES. Ils DOIVENT etre correctement pris en compte :
+
+| Terme | Signification | Impact sur l'evaluation |
+|-------|---------------|-------------------------|
+| **CDI** (Contrat a Duree Indeterminee) | Equivalent du "permanent employment". Le graal en France | Standard attendu. Un CDD pour un senior est un signal d'alerte |
+| **CDD** (Contrat a Duree Determinee) | Contrat temporaire, duree fixe | Acceptable pour des missions specifiques. Sinon, questionner pourquoi pas CDI |
+| **Periode d'essai** | 3-4 mois cadre (renouvelable 1 fois, max 8 mois total) | Standard marche. Flaguer si > 4 mois initial |
+| **Preavis** | 1-3 mois selon convention collective et anciennete | Planifier la date de demarrage en consequence |
+| **Statut cadre** | Categorie socio-professionnelle specifique a la France. Implique forfait jours, cotisations differentes | La quasi-totalite des postes tech sont cadre. Verifier si mentionne |
+| **Convention collective SYNTEC** | Convention la plus courante en IT/conseil. Definit minima salariaux, classifications | Verifier la classification (position + coefficient) pour valider le salaire |
+| **RTT** (Reduction du Temps de Travail) | Jours de repos supplementaires (8-12/an en general) pour les cadres au forfait | Un vrai plus. Equivalent a 1-2 semaines de conges en plus |
+| **13e mois** | Mois de salaire supplementaire, souvent verse en decembre | Inclure dans le calcul : brut annuel = brut mensuel x 13. NE JAMAIS oublier dans la comparaison |
+| **Interessement / Participation** | Partage des benefices. Participation obligatoire > 50 salaries | Peut representer 1-3 mois de salaire. Verifier l'historique |
+| **Titres-restaurant** | Cheques-dejeuner (Swile, Edenred). Part employeur ~60% | Petit avantage mais courant. ~1000-1500 EUR/an d'economie |
+| **Mutuelle** | Complementaire sante obligatoire. Part employeur >= 50% | Standard. Verifier si la couverture est bonne (famille, optique, dentaire) |
+| **Prevoyance** | Assurance deces/invalidite/incapacite | Plus rare comme argument de vente, mais important a verifier |
+| **CSE** (Comite Social et Economique) | Instance representative du personnel | Avantages CSE (cheques vacances, culture, sport) = bonus non negligeable dans les grands groupes |
+| **Conges payes** | 25 jours legaux (5 semaines). Certaines conventions donnent plus | < 25 jours = illegal en France. 25 + RTT = standard tech. > 30 jours = excellent |
+| **Portage salarial** | Statut hybride entre salariat et freelance | Alternative au freelance pur. Simplifie l'administratif mais cout ~10% |
+| **Auto-entrepreneur / Micro-entreprise** | Statut freelance simplifie, plafond de CA | Pour les missions courtes. Attention au plafond et aux charges |
+
+### Scripts de negociation
+
+<!-- [PERSONNALISER] Adapte a ta situation -->
+
+**Pretentions salariales (framework general) :**
+> "Sur la base des donnees marche actuelles pour ce type de poste, je vise une fourchette de [FOURCHETTE depuis profile.yml]. Je reste flexible sur la structure -- c'est le package global et les perspectives d'evolution qui comptent."
+
+**Reponse a une decote geographique :**
+> "Les roles sur lesquels je suis en concurrence sont axes sur les resultats, pas sur la localisation. Mon track record ne change pas avec le code postal."
+
+**Si l'offre est en dessous de la cible :**
+> "Je suis actuellement en discussion sur des packages dans la fourchette [fourchette superieure]. [Entreprise] m'attire pour [raison]. Est-il possible d'atteindre [cible] ?"
+
+**Negociation sur le 13e mois / variable :**
+> "Pour comparer les packages de maniere equitable, pourriez-vous detailler le fixe brut annuel, le 13e mois eventuel, et la part variable separement ?"
+
+### Politique de localisation (Location Policy)
+
+<!-- [PERSONNALISER] Adapte a ta situation. Lu depuis config/profile.yml -> location -->
+
+**Dans les formulaires :**
+- Questions binaires "Pouvez-vous etre sur site ?" : repondre selon la disponibilite reelle dans `profile.yml`
+- Champs libres : indiquer le chevauchement horaire et la disponibilite explicitement
+
+**Dans les evaluations (scoring) :**
+- Dimension remote pour du hybride hors de ton pays : Score **3.0** (pas 1.0)
+- Score 1.0 uniquement si l'offre dit explicitement "presence obligatoire 4-5 jours/semaine, aucune exception"
+
+### Priorite time-to-offer
+- Demo fonctionnelle + metriques > perfection
+- Postuler vite > apprendre davantage
+- Approche 80/20, tout est timebox
+
+---
+
+## Regles globales
+
+### JAMAIS
+
+1. Inventer de l'experience ou des metriques
+2. Modifier `cv.md` ou les fichiers portfolio
+3. Soumettre des candidatures au nom du candidat
+4. Partager un numero de telephone dans les messages generes
+5. Recommander une remuneration en dessous du marche
+6. Generer un PDF sans avoir lu l'offre avant
+7. Utiliser du jargon corporate ou des formules creuses
+8. Ignorer le tracker (chaque offre evaluee est enregistree)
+
+### TOUJOURS
+
+0. **Lettre de motivation :** Si le formulaire le permet, TOUJOURS en inclure une. PDF dans le meme design visuel que le CV. Citations de l'offre mappees sur les proof points. 1 page max.
+1. Lire `cv.md` et `article-digest.md` (si existant) avant d'evaluer une offre
+1b. **Premiere evaluation de chaque session :** Lancer `node cv-sync-check.mjs` via Bash. En cas d'alertes, prevenir le candidat
+2. Detecter l'archetype du role et adapter le framing
+3. Citer des lignes exactes du CV lors du matching
+4. Utiliser WebSearch pour les donnees de remuneration et d'entreprise
+5. Enregistrer dans le tracker apres chaque evaluation
+6. Generer le contenu dans la langue de l'offre (francais si l'offre est en francais, anglais sinon)
+7. Etre direct et concret -- pas de blabla
+8. Francais tech naturel pour les textes generes. Phrases courtes, verbes d'action, eviter le passif. Ne pas traduire de force les termes techniques (stack, pipeline, deployment, embedding)
+8b. **URLs de case studies dans le Professional Summary du PDF :** Si le PDF mentionne des case studies ou demos, les URLs DOIVENT apparaitre dans le premier paragraphe (Professional Summary). Les recruteurs ne lisent souvent que le summary. Toutes les URLs en HTML avec `white-space: nowrap`
+9. **Entrees tracker en TSV** -- NE JAMAIS editer applications.md directement pour de nouveaux ajouts. Ecrire le TSV dans `batch/tracker-additions/`, `merge-tracker.mjs` gere la fusion
+10. **`**URL:**` dans chaque en-tete de report** -- entre Score et PDF
+
+### Outils
+
+| Outil | Usage |
+|-------|-------|
+| WebSearch | Recherche remuneration, tendances, culture d'entreprise, contacts LinkedIn, fallback offres |
+| WebFetch | Fallback pour extraire les offres depuis des pages statiques |
+| Playwright | Verifier si les offres sont actives (browser_navigate + browser_snapshot), extraire les offres depuis des SPAs. **CRITIQUE : JAMAIS 2+ agents en parallele avec Playwright -- ils partagent la meme instance navigateur** |
+| Read | cv.md, article-digest.md, cv-template.html |
+| Write | HTML temporaire pour PDF, applications.md, reports .md |
+| Edit | Mettre a jour le tracker |
+| Bash | `node generate-pdf.mjs` |

--- a/modes/fr/offre.md
+++ b/modes/fr/offre.md
@@ -1,0 +1,166 @@
+# Mode : offre -- Evaluation complete A-F
+
+Quand le candidat colle une offre (texte ou URL), TOUJOURS livrer les 6 blocs.
+
+## Etape 0 -- Detection d'archetype
+
+Classer l'offre dans l'un des 6 archetypes (voir `_shared.md`). Si hybride, indiquer les 2 plus proches. Cela determine :
+- Quels proof points prioriser dans le bloc B
+- Comment reecrire le summary dans le bloc E
+- Quelles stories STAR preparer dans le bloc F
+
+## Bloc A -- Resume du role
+
+Tableau avec :
+- Archetype detecte
+- Domaine (Platform / Agentic / LLMOps / ML / Enterprise)
+- Fonction (Build / Conseil / Management / Deploy)
+- Seniorite
+- Remote (Full remote / Hybride / Sur site)
+- Taille d'equipe (si mentionnee)
+- TL;DR en 1 phrase
+
+## Bloc B -- Match avec le CV
+
+Lire `cv.md`. Creer un tableau ou chaque prerequis de l'offre est mappe sur des lignes exactes du CV.
+
+**Adapte a l'archetype :**
+- FDE -> prioriser les proof points de livraison rapide et proximite client
+- SA -> prioriser la conception systeme et les integrations
+- PM -> prioriser la product discovery et les metriques
+- LLMOps -> prioriser evals, observability, pipelines
+- Agentic -> prioriser multi-agent, HITL, orchestration
+- Transformation -> prioriser conduite du changement, adoption, passage a l'echelle
+
+Section **Lacunes (Gaps)** avec strategie de mitigation pour chacune. Pour chaque lacune :
+1. Est-ce un bloqueur dur ou un nice-to-have ?
+2. Le candidat peut-il demontrer une experience adjacente ?
+3. Y a-t-il un projet portfolio qui couvre cette lacune ?
+4. Plan de mitigation concret (phrase pour la lettre de motivation, mini-projet rapide, etc.)
+
+## Bloc C -- Niveau et strategie
+
+1. **Niveau detecte** dans l'offre vs **niveau naturel du candidat pour cet archetype**
+2. **Plan "vendre senior sans mentir"** : formulations specifiques adaptees a l'archetype, realisations concretes a mettre en avant, comment positionner l'experience de fondateur comme un atout
+3. **Plan "si je suis downlevel"** : accepter si la remuneration est juste, negocier une revue a 6 mois, criteres de promotion clairs
+
+## Bloc D -- Remuneration et demande
+
+Utiliser WebSearch pour :
+- Salaires actuels du role (Glassdoor, Levels.fyi, Welcome to the Jungle, APEC, Talent.io, Indeed Salaires)
+- Reputation de remuneration de l'entreprise (Glassdoor, WTTJ)
+- Tendance de demande du role sur le marche francophone
+
+Tableau avec donnees et sources citees. Si pas de donnees, le dire clairement -- ne rien inventer.
+
+**Marche francais -- Verifications obligatoires :**
+- 13e mois / prime de fin d'annee mentionne ? L'inclure dans le calcul brut annuel.
+- Part variable (bonus, commission, BSPCE / stock-options) ?
+- Interessement / Participation mentionnes ? Historique disponible ?
+- Convention collective (SYNTEC, Metallurgie, etc.) applicable ? Si oui, verifier la classification.
+- CDI ou CDD ? Si CDD : duree, motif, possibilite de CDI-isation.
+- Freelance / Portage salarial ? TJM, duree de mission, risque de requalification.
+
+## Bloc E -- Plan de personnalisation
+
+| # | Section | Etat actuel | Changement propose | Justification |
+|---|---------|-------------|--------------------|----- ---------|
+| 1 | Summary | ... | ... | ... |
+| ... | ... | ... | ... | ... |
+
+Top 5 modifications du CV + Top 5 modifications LinkedIn pour maximiser le match.
+
+## Bloc F -- Plan d'entretiens
+
+6-10 stories STAR+R mappees sur les prerequis de l'offre (STAR + **Reflection**) :
+
+| # | Prerequis de l'offre | Story STAR+R | S | T | A | R | Reflection |
+|---|---------------------|--------------|---|---|---|---|------------|
+
+La colonne **Reflection** capture ce qui a ete appris ou ce qui serait fait differemment. Cela signale la seniorite -- les juniors decrivent ce qui s'est passe, les seniors en tirent des enseignements.
+
+**Story Bank :** Si `interview-prep/story-bank.md` existe, verifier si ces stories y sont deja. Sinon, ajouter les nouvelles. Avec le temps, cela construit une banque reutilisable de 5-10 stories maitre adaptables a n'importe quelle question d'entretien.
+
+**Selectionnees et cadrees selon l'archetype :**
+- FDE -> mettre en avant la vitesse de livraison et la proximite client
+- SA -> mettre en avant les decisions d'architecture
+- PM -> mettre en avant la discovery et les arbitrages
+- LLMOps -> mettre en avant les metriques, evals, hardening en production
+- Agentic -> mettre en avant l'orchestration, la gestion d'erreurs, le HITL
+- Transformation -> mettre en avant l'adoption et le changement organisationnel
+
+Inclure aussi :
+- 1 case study recommandee (quel projet presenter et comment)
+- Questions red-flag et comment y repondre (ex : "Pourquoi avez-vous vendu votre entreprise ?", "Aviez-vous une equipe sous votre responsabilite ?", "Pourquoi un changement apres si peu de temps ?")
+
+---
+
+## Post-evaluation
+
+**TOUJOURS** executer apres les blocs A-F :
+
+### 1. Sauvegarder le report .md
+
+Sauvegarder l'evaluation complete dans `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+
+- `{###}` = prochain numero sequentiel (3 chiffres, zero-padded)
+- `{company-slug}` = nom d'entreprise en minuscules, sans espaces (utiliser des tirets)
+- `{YYYY-MM-DD}` = date du jour
+
+**Format du report :**
+
+```markdown
+# Evaluation : {Entreprise} -- {Role}
+
+**Date :** {YYYY-MM-DD}
+**Archetype :** {detecte}
+**Score :** {X/5}
+**URL :** {URL de l'offre}
+**PDF :** {chemin ou en attente}
+
+---
+
+## A) Resume du role
+(contenu complet du bloc A)
+
+## B) Match avec le CV
+(contenu complet du bloc B)
+
+## C) Niveau et strategie
+(contenu complet du bloc C)
+
+## D) Remuneration et demande
+(contenu complet du bloc D)
+
+## E) Plan de personnalisation
+(contenu complet du bloc E)
+
+## F) Plan d'entretiens
+(contenu complet du bloc F)
+
+## G) Brouillons de reponses pour la candidature
+(uniquement si score >= 4.5 -- brouillons de reponses pour le formulaire de candidature)
+
+---
+
+## Mots-cles extraits
+(liste de 15-20 mots-cles de l'offre pour l'optimisation ATS)
+```
+
+### 2. Enregistrer dans le tracker
+
+**TOUJOURS** enregistrer dans `data/applications.md` :
+- Prochain numero sequentiel
+- Date du jour
+- Entreprise
+- Role
+- Score : moyenne du match (1-5)
+- Statut : `Evaluated`
+- PDF : non (ou oui si l'auto-pipeline a genere un PDF)
+- Report : lien relatif vers le fichier report (ex : `[001](reports/001-company-2026-01-01.md)`)
+
+**Format du tracker :**
+
+```markdown
+| # | Date | Entreprise | Role | Score | Statut | PDF | Report |
+```

--- a/modes/fr/pipeline.md
+++ b/modes/fr/pipeline.md
@@ -1,0 +1,63 @@
+# Mode : pipeline -- Inbox d'URLs (Second Brain)
+
+Traite les URLs d'offres accumulees dans `data/pipeline.md`. Le candidat ajoute des URLs quand il veut et lance ensuite `/career-ops pipeline` pour toutes les traiter d'un coup.
+
+## Workflow
+
+1. **Lire** `data/pipeline.md` -> trouver les items `- [ ]` dans la section "En attente" / "Pending" / "Pendientes"
+2. **Pour chaque URL en attente** :
+   a. Calculer le prochain `REPORT_NUM` sequentiel (lire `reports/`, prendre le numero le plus eleve + 1)
+   b. **Extraire l'offre** avec Playwright (`browser_navigate` + `browser_snapshot`) -> WebFetch -> WebSearch
+   c. Si l'URL n'est pas accessible -> marquer comme `- [!]` avec une note et continuer
+   d. **Executer l'auto-pipeline complet** : Evaluation A-F -> Report .md -> PDF (si score >= 3.0) -> Tracker
+   e. **Deplacer de "En attente" vers "Traitees"** : `- [x] #NNN | URL | Entreprise | Role | Score/5 | PDF oui/non`
+3. **Si 3+ URLs en attente**, lancer des agents en parallele (Agent tool avec `run_in_background`) pour maximiser la vitesse.
+4. **A la fin**, afficher un tableau recapitulatif :
+
+```
+| # | Entreprise | Role | Score | PDF | Action recommandee |
+```
+
+## Format de pipeline.md
+
+```markdown
+## En attente
+- [ ] https://jobs.example.com/posting/123
+- [ ] https://boards.greenhouse.io/company/jobs/456 | Company SAS | Senior PM
+- [!] https://private.url/job -- Erreur : login requis
+
+## Traitees
+- [x] #143 | https://jobs.example.com/posting/789 | Acme SAS | AI PM | 4.2/5 | PDF oui
+- [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF non
+```
+
+> Note : Les en-tetes de section peuvent etre en EN ("Pending"/"Processed"), ES ("Pendientes"/"Procesadas"), DE ("Offen"/"Verarbeitet") ou FR ("En attente"/"Traitees"). Etre flexible a la lecture, fidele au style existant a l'ecriture.
+
+## Detection intelligente de l'offre depuis l'URL
+
+1. **Playwright (prefere) :** `browser_navigate` + `browser_snapshot`. Fonctionne avec toutes les SPAs.
+2. **WebFetch (fallback) :** Pour les pages statiques ou quand Playwright n'est pas disponible.
+3. **WebSearch (dernier recours) :** Chercher sur des portails secondaires qui indexent l'offre.
+
+**Cas particuliers :**
+- **LinkedIn** : Peut necessiter un login -> marquer `[!]` et demander au candidat de coller le texte
+- **PDF** : Si l'URL pointe vers un PDF, le lire directement avec le Read tool
+- **Prefixe `local:`** : Lire le fichier local. Exemple : `local:jds/linkedin-pm-ai.md` -> lire `jds/linkedin-pm-ai.md`
+- **Welcome to the Jungle / Indeed FR / APEC** : Portails francophones courants. Playwright gere bien les cookie banners
+- **France Travail (ex-Pole emploi)** : Offres structurees, bien lisibles par machine. WebFetch suffit generalement
+
+## Numerotation automatique
+
+1. Lister tous les fichiers dans `reports/`
+2. Extraire le numero du prefixe (ex : `142-medispend...` -> 142)
+3. Nouveau numero = maximum trouve + 1
+
+## Synchronisation des sources
+
+Avant de traiter une URL, verifier la sync :
+
+```bash
+node cv-sync-check.mjs
+```
+
+En cas de desynchronisation, alerter le candidat avant de continuer.

--- a/modes/fr/postuler.md
+++ b/modes/fr/postuler.md
@@ -1,0 +1,114 @@
+# Mode : postuler -- Assistant live pour les formulaires de candidature
+
+Mode interactif pour le moment ou le candidat remplit un formulaire de candidature dans Chrome. Lit ce qui est a l'ecran, charge le contexte de l'evaluation precedente de l'offre et genere des reponses personnalisees pour chaque question du formulaire.
+
+## Prerequis
+
+- **Ideal avec Playwright visible** : En mode visible, le candidat voit le navigateur et Claude peut interagir avec la page.
+- **Sans Playwright** : le candidat partage une capture d'ecran ou colle les questions manuellement.
+
+## Workflow
+
+```
+1. DETECTER     -> Lire l'onglet Chrome actif (capture/URL/titre)
+2. IDENTIFIER   -> Extraire entreprise + role depuis la page
+3. RECHERCHER   -> Matcher avec les reports existants dans reports/
+4. CHARGER      -> Lire le report complet + Bloc G (si existant)
+5. COMPARER     -> Le role a l'ecran correspond-il a celui evalue ? Si changement -> alerter
+6. ANALYSER     -> Identifier TOUTES les questions visibles du formulaire
+7. GENERER      -> Pour chaque question, generer une reponse personnalisee
+8. PRESENTER    -> Afficher les reponses formatees pour copier-coller
+```
+
+## Etape 1 -- Detecter l'offre
+
+**Avec Playwright :** Snapshot de la page active. Lire titre, URL et contenu visible.
+
+**Sans Playwright :** Demander au candidat de :
+- Partager une capture d'ecran du formulaire (le Read tool lit les images)
+- Ou coller les questions du formulaire en texte
+- Ou indiquer entreprise + role pour qu'on cherche le contexte
+
+## Etape 2 -- Identifier et charger le contexte
+
+1. Extraire le nom de l'entreprise et le titre du poste depuis la page
+2. Chercher dans `reports/` par nom d'entreprise (Grep case-insensitive)
+3. Si match -> charger le report complet
+4. Si Bloc G present -> charger les brouillons de reponses precedents comme base
+5. Si PAS de match -> alerter le candidat et proposer un auto-pipeline rapide
+
+## Etape 3 -- Detecter les changements de role
+
+Si le role a l'ecran differe de celui evalue :
+- **Alerter le candidat** : "Le role a change de [X] a [Y]. Souhaites-tu que je reevalue ou que j'adapte les reponses au nouveau titre ?"
+- **Si adapter** : Ajuster les reponses au nouveau role sans reevaluer
+- **Si reevaluer** : Lancer l'evaluation complete A-F, mettre a jour le report, regenerer le Bloc G
+- **Mettre a jour le tracker** : Modifier le titre du role dans applications.md si necessaire
+
+## Etape 4 -- Analyser les questions du formulaire
+
+Identifier TOUTES les questions visibles :
+- Champs de texte libre (lettre de motivation, "pourquoi ce poste", motivation, etc.)
+- Listes deroulantes (comment avez-vous connu l'entreprise, autorisation de travail, etc.)
+- Oui/Non (mobilite, visa, disponibilite, etc.)
+- Champs de salaire (fourchette, pretentions salariales -- en brut annuel pour la France)
+- Champs d'upload (CV, lettre de motivation PDF, references)
+
+Classifier chaque question :
+- **Deja repondue dans le Bloc G** -> reprendre la reponse existante
+- **Nouvelle question** -> generer la reponse depuis le report + `cv.md`
+
+## Etape 5 -- Generer les reponses
+
+Pour chaque question, construire la reponse selon ce schema :
+
+1. **Contexte du report** : Utiliser les proof points du bloc B, les stories STAR du bloc F
+2. **Bloc G precedent** : Si un brouillon existe, le prendre comme base et affiner
+3. **Ton "Je vous choisis"** : meme framework que dans l'auto-pipeline -- confiant, pas suppliant
+4. **Specificite** : citer quelque chose de concret de l'offre visible a l'ecran
+5. **career-ops proof point** : inclure dans "Informations complementaires" si un tel champ existe
+
+**Champs specifiques aux formulaires francais courants :**
+- **Pretentions salariales (brut annuel)** -> Fourchette depuis `profile.yml`, en EUR, avec mention "negociable selon le package global"
+- **Date de disponibilite** -> Date realiste tenant compte du preavis (souvent 1-3 mois)
+- **Autorisation de travail / Nationalite** -> Honnete et concis ; pour les citoyens UE : "Aucun titre de sejour requis (citoyen UE)"
+- **Langues** -> Niveaux selon le CECRL (A1-C2)
+- **Mobilite** -> Preciser la zone geographique acceptable et la frequence de deplacement
+
+**Format de sortie :**
+
+```
+## Reponses pour [Entreprise] -- [Role]
+
+Base : Report #NNN | Score : X.X/5 | Archetype : [type]
+
+---
+
+### 1. [Question exacte du formulaire]
+> [Reponse prete a copier-coller]
+
+### 2. [Question suivante]
+> [Reponse]
+
+...
+
+---
+
+Notes :
+- [Observations sur le role, changements, etc.]
+- [Suggestions de personnalisation que le candidat devrait verifier]
+```
+
+## Etape 6 -- Apres la candidature (optionnel)
+
+Si le candidat confirme que la candidature est envoyee :
+1. Mettre a jour le statut dans `applications.md` de "Evaluated" a "Applied"
+2. Mettre a jour le Bloc G du report avec les reponses finales
+3. Suggerer l'etape suivante : `/career-ops contacto` pour du LinkedIn outreach vers le hiring manager
+
+## Gestion du defilement
+
+Si le formulaire a plus de questions que ce qui est visible :
+- Demander au candidat de defiler et de partager une autre capture d'ecran
+- Ou de coller les questions restantes
+- Traiter par iterations jusqu'a couvrir tout le formulaire


### PR DESCRIPTION
## Summary
- Native French translations of the 4 highest-impact modes: `_shared.md`, `offre.md` (evaluation), `postuler.md` (apply), `pipeline.md`
- Full coverage of francophone job market specifics: CDI/CDD, convention collective SYNTEC, RTT, 13e mois, mutuelle, prévoyance, intéressement/participation, titres-restaurant, CSE, portage salarial, etc.
- Updated `CLAUDE.md` with French mode documentation and activation instructions

## What's included

| File | Translated from | Purpose |
|------|----------------|---------|
| `modes/fr/_shared.md` | `modes/_shared.md` (EN) | Shared context, archetypes, global rules, francophone market specifics |
| `modes/fr/offre.md` | `modes/oferta.md` (ES) | Full A-F evaluation of a job offer |
| `modes/fr/postuler.md` | `modes/apply.md` (EN) | Live assistant for filling application forms |
| `modes/fr/pipeline.md` | `modes/pipeline.md` (ES) | URL inbox / Second Brain for collected offers |
| `modes/fr/README.md` | — | Documentation, vocabulary reference, activation guide |

## How to activate

```yaml
# config/profile.yml
language:
  primary: fr
  modes_dir: modes/fr
```

Or per-session: tell Claude "Utilise les modes français sous `modes/fr/`"

## Test plan
- [ ] Evaluate a French job posting (e.g. from Welcome to the Jungle or APEC) using `modes/fr/offre.md`
- [ ] Fill a French application form using `modes/fr/postuler.md`
- [ ] Process a pipeline with French URLs using `modes/fr/pipeline.md`
- [ ] Verify `language.modes_dir: modes/fr` in profile.yml triggers French modes automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)