### PR TITLE
Feat/interview intel mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Asks to compare offers | `ofertas` |
 | Wants LinkedIn outreach | `contacto` |
 | Asks for company research | `deep` |
-| Preps for interview at specific company | `interview-intel` |
+| Preps for interview at specific company | `interview-prep` |
 | Wants to generate CV/PDF | `pdf` |
 | Evaluates a course/cert | `training` |
 | Evaluates portfolio project | `project` |

--- a/modes/interview-prep.md
+++ b/modes/interview-prep.md
@@ -1,4 +1,4 @@
-# Mode: interview-intel — Company-Specific Interview Intelligence
+# Mode: interview-prep — Company-Specific Interview Intelligence
 
 When the user asks to prep for an interview at a specific company+role, or when an evaluation scores 4.0+ and the user updates status to `Interview`, run this mode.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "career-ops",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "career-ops",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "playwright": "^1.58.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}


### PR DESCRIPTION
re #76 

New mode (`modes/interview-prep.md`) that researches actual interview processes for a specific company+role via WebSearch and produces a structured prep package.

- Researches Glassdoor interview reviews, Blind, LeetCode Discuss, and engineering blogs
- Produces: process overview, round-by-round breakdown, sourced questions by category, story bank gap analysis, technical prep checklist, company-specific signals
- Fills the gap between Block F (JD-based prep) and `deep` mode (broad company research)
- Writes output to `interview-prep/{company-slug}-{role-slug}.md`
- No scripts or new dependencies — pure mode instructions using existing tools

## What changed

- `modes/interview-prep.md` — new mode file
- `CLAUDE.md` — added to skill routing table and main files table

## Test

- Run for a well-known company and verify sourced questions appear with citations
- Run for an obscure company and verify graceful degradation
- Verify story bank mapping works with existing `story-bank.md` entries
- Verify output saves to `interview-prep/`