### PR TITLE
Add Copilot CLI support to Career-Ops

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,9 @@ When mode files reference Claude Code tools, use the Copilot CLI equivalents:
 | Playwright (`browser_navigate` + `browser_snapshot`) | `chrome-devtools-navigate_page` + `chrome-devtools-take_snapshot` | Career pages, SPAs, offer verification |
 | `Read` / `Write` / `Edit` | `view` / `create` / `edit` | File operations |
 | `Bash` | `bash` | Run Node scripts |
-| `claude -p` (pipe workers) | `task(agent_type="general-purpose", mode="background")` | Parallel evaluation, scanning |
+| `claude -p` (pipe workers) | `task` tool with `agent_type: general-purpose`, `mode: background` | Parallel evaluation, scanning |
+
+> **Note:** The left column lists Claude Code CLI commands; the right column lists Copilot CLI agent tool names (invoked via the agent's tool calls, not as shell commands). `chrome-devtools-*` tools require the `chrome-devtools-mcp` MCP server; `task` is the built-in subagent tool.
 
 **Browser is a shared resource — never run 2+ browser agents in parallel.**
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,25 @@
+# Career-Ops for GitHub Copilot CLI
+
+Read `CLAUDE.md` for all project instructions, routing, and behavioral rules. They apply equally to Copilot CLI.
+
+Key points:
+- Reuse the existing modes, scripts, templates, and tracker flow — do not create parallel logic.
+- Store user-specific customization in `config/profile.yml`, `modes/_profile.md`, or `article-digest.md` — never in `modes/_shared.md`.
+- Never submit an application on the user's behalf.
+
+## Copilot-specific tool mapping
+
+When mode files reference Claude Code tools, use the Copilot CLI equivalents:
+
+| Claude Code | Copilot CLI | Notes |
+|-------------|-------------|-------|
+| `WebSearch` | `web_search` | Comp research, company data |
+| `WebFetch` | `web_fetch` | Static page JD extraction |
+| Playwright (`browser_navigate` + `browser_snapshot`) | `chrome-devtools-navigate_page` + `chrome-devtools-take_snapshot` | Career pages, SPAs, offer verification |
+| `Read` / `Write` / `Edit` | `view` / `create` / `edit` | File operations |
+| `Bash` | `bash` | Run Node scripts |
+| `claude -p` (pipe workers) | `task(agent_type="general-purpose", mode="background")` | Parallel evaluation, scanning |
+
+**Browser is a shared resource — never run 2+ browser agents in parallel.**
+
+For Copilot CLI setup, see `docs/COPILOT_CLI.md`.

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -51,6 +51,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/ru/*` | Russian language modes |
 | `CLAUDE.md` | Agent instructions |
 | `AGENTS.md` | Codex instructions |
+| `.github/copilot-instructions.md` | Copilot CLI instructions |
 | `*.mjs` | Utility scripts |
 | `batch/batch-prompt.md` | Batch worker prompt |
 | `batch/batch-runner.sh` | Batch orchestrator |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <img src="https://img.shields.io/badge/Claude_Code-000?style=flat&logo=anthropic&logoColor=white" alt="Claude Code">
   <img src="https://img.shields.io/badge/OpenCode-111827?style=flat&logo=terminal&logoColor=white" alt="OpenCode">
   <img src="https://img.shields.io/badge/Gemini_CLI-4285F4?style=flat&logo=google&logoColor=white" alt="Gemini CLI">
+  <img src="https://img.shields.io/badge/Copilot_CLI-000?style=flat&logo=github&logoColor=white" alt="Copilot CLI">
   <img src="https://img.shields.io/badge/Codex_(soon)-6B7280?style=flat&logo=openai&logoColor=white" alt="Codex">
   <img src="https://img.shields.io/badge/Node.js-339933?style=flat&logo=node.js&logoColor=white" alt="Node.js">
   <img src="https://img.shields.io/badge/Go-00ADD8?style=flat&logo=go&logoColor=white" alt="Go">

--- a/docs/COPILOT_CLI.md
+++ b/docs/COPILOT_CLI.md
@@ -46,6 +46,11 @@ Copilot CLI uses natural language instead of slash commands:
 | Deep company research | `modes/deep.md` |
 | Training / certification review | `modes/training.md` |
 | Project evaluation | `modes/project.md` |
+| LinkedIn outreach | `modes/_shared.md` + `modes/contacto.md` |
+| Interview prep | `modes/_shared.md` + `modes/interview-prep.md` |
+| Batch evaluation | `modes/_shared.md` + `modes/batch.md` |
+| Rejection pattern analysis | `modes/_shared.md` + `modes/patterns.md` |
+| Follow-up tracking | `modes/_shared.md` + `modes/followup.md` |
 
 ## Behavioral Rules
 

--- a/docs/COPILOT_CLI.md
+++ b/docs/COPILOT_CLI.md
@@ -1,0 +1,65 @@
+# Copilot CLI Setup
+
+Career-Ops supports GitHub Copilot CLI through `.github/copilot-instructions.md`.
+
+If your Copilot CLI reads project instructions automatically,
+`.github/copilot-instructions.md` is enough for routing and behavior.
+Copilot CLI should reuse the same checked-in mode files, templates, tracker
+flow, and scripts that already power the Claude workflow.
+
+## Prerequisites
+
+- [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) installed and configured
+- Node.js 18+
+- Playwright Chromium installed for PDF generation and reliable job verification
+- Go 1.21+ if you want the TUI dashboard
+
+## Install
+
+```bash
+npm install
+npx playwright install chromium
+```
+
+## Recommended Starting Prompts
+
+Copilot CLI uses natural language instead of slash commands:
+
+- `Evaluate this job URL with Career-Ops and run the full pipeline.`
+- `Scan my configured portals for new roles that match my profile.`
+- `Generate the tailored ATS PDF for this role using Career-Ops.`
+- `Compare these three offers and rank them.`
+- `Show my application tracker status.`
+
+## Routing Map
+
+| User intent | Files Copilot CLI should read |
+|-------------|-------------------------------|
+| Raw JD text or job URL | `modes/_shared.md` + `modes/auto-pipeline.md` |
+| Single evaluation only | `modes/_shared.md` + `modes/oferta.md` |
+| Multiple offers | `modes/_shared.md` + `modes/ofertas.md` |
+| Portal scan | `modes/_shared.md` + `modes/scan.md` |
+| PDF generation | `modes/_shared.md` + `modes/pdf.md` |
+| Live application help | `modes/_shared.md` + `modes/apply.md` |
+| Pipeline inbox processing | `modes/_shared.md` + `modes/pipeline.md` |
+| Tracker status | `modes/tracker.md` |
+| Deep company research | `modes/deep.md` |
+| Training / certification review | `modes/training.md` |
+| Project evaluation | `modes/project.md` |
+
+## Behavioral Rules
+
+- Treat raw JD text or a job URL as the full auto-pipeline path unless the user explicitly asks for evaluation only.
+- Keep all personalization in `config/profile.yml`, `modes/_profile.md`, `article-digest.md`, or `portals.yml`.
+- Never verify a job's live status with generic web fetch when browser DevTools are available.
+- Never submit an application for the user.
+- Never add new tracker rows directly to `data/applications.md`; use the TSV addition flow and `merge-tracker.mjs`.
+
+## Verification
+
+```bash
+npm run verify
+
+# optional dashboard build
+cd dashboard && go build ./...
+```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -3,6 +3,7 @@
 ## Prerequisites
 
 - [Claude Code](https://claude.ai/code) installed and configured
+- (Optional) [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) — see [docs/COPILOT_CLI.md](COPILOT_CLI.md)
 - Node.js 18+ (for PDF generation and utility scripts)
 - (Optional) Go 1.21+ (for the dashboard TUI)
 


### PR DESCRIPTION
Preserve the upstream Career-Ops workflow while adding GitHub Copilot CLI instructions, a setup guide, and shared doc updates so Claude and Copilot CLI follow the same operational boundaries and upgrade path.

## What this PR adds

**New files:**
- `.github/copilot-instructions.md` — Copilot CLI entry point with mode routing, tool mapping (Playwright → Chrome DevTools, WebSearch → web_search, Agent() → task()), onboarding flow, data contract rules, and ethical boundaries
- `docs/COPILOT_CLI.md` — setup guide with natural language prompt reference (Copilot CLI doesn't have slash commands)

**Updated files:**
- `CLAUDE.md` — redirect personalization to `_profile.md`/`profile.yml` instead of `_shared.md` (genuine improvement regardless of Copilot CLI)
- `DATA_CONTRACT.md` — include `.github/copilot-instructions.md` in the system layer
- `README.md` — add Copilot CLI badge and quick start section
- `docs/SETUP.md` — add Copilot CLI prerequisites and usage section
- `package.json` — update description and keywords

## Design decisions

Followed the same slim pattern discussed in #41:

- **7 files, not 36.** Copilot CLI reads `.github/copilot-instructions.md` automatically — just like Claude reads `CLAUDE.md`. If the routing instructions are good, it doesn't need plugin wrappers or duplicate mode files.
- **No mode files modified.** The routing file tells Copilot CLI which mode files to load and maps Claude tool names to Copilot CLI equivalents in a single table.
- **Additive only.** No parallel logic, same modes, same scripts. The CLAUDE.md changes (redirecting personalization away from `_shared.md`) are improvements that benefit all platforms.
- **No verification scripts.** Without a plugin layer, there's nothing to verify parity against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added GitHub Copilot CLI support with a comprehensive configuration and usage guide, including operational rules and verification steps.
  * Updated README to show Copilot CLI support via a new badge.
  * Added Copilot CLI as an optional setup prerequisite in the setup docs.
  * Registered the Copilot guidance in the project data contract/inventory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->