### PR TITLE
fix: correct dashboard launch path in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ node cv-sync-check.mjs        # Config check
 
 # Dashboard
 cd dashboard && go build -o career-dashboard .
-./career-dashboard --path .
+./career-dashboard --path ..
 ```
 
 ## Need Help?

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The built-in terminal dashboard lets you browse your pipeline visually:
 ```bash
 cd dashboard
 go build -o career-dashboard .
-./career-dashboard
+./career-dashboard --path ..
 ```
 
 Features: 6 filter tabs, 4 sort modes, grouped/flat view, lazy-loaded previews, inline status changes.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -76,5 +76,5 @@ node verify-pipeline.mjs     # Check pipeline integrity
 ```bash
 cd dashboard
 go build -o career-dashboard .
-./career-dashboard            # Opens TUI pipeline viewer
+./career-dashboard --path ..  # Opens TUI pipeline viewer
 ```


### PR DESCRIPTION
## Summary

This PR fixes the documented dashboard launch commands.

The dashboard binary expects `--path` to point at the `career-ops` repository root, where `applications.md` or `data/applications.md` lives. The docs currently show commands that run the
binary from `dashboard/` with either no `--path` or `--path .`, which points at the wrong directory and can fail with:

`Error: could not find applications.md in . or ./data/`

This PR updates the docs to use:

```bash
cd dashboard
./career-dashboard --path ..
```

## Why

This keeps the documentation aligned with the current dashboard behavior and removes a confusing setup/runtime mismatch for contributors and users following the docs verbatim.