### PR TITLE
Customize system: English modes, Pandoc PDF pipeline, thesis defence …

### DIFF
--- a/modes/apply.md
+++ b/modes/apply.md
@@ -1,107 +1,107 @@
-# Modo: apply — Asistente de Aplicación en Vivo
+# Mode: apply — Live Application Assistant
 
-Modo interactivo para cuando el candidato está rellenando un formulario de aplicación en Chrome. Lee lo que hay en pantalla, carga el contexto previo de la oferta, y genera respuestas personalizadas para cada pregunta del formulario.
+Interactive mode for when the candidate is filling out an application form in Chrome. Reads what's on screen, loads prior context from the offer evaluation, and generates personalized answers for each form question.
 
-## Requisitos
+## Requirements
 
-- **Mejor con Playwright visible**: En modo visible, el candidato ve el navegador y Claude puede interactuar con la página.
-- **Sin Playwright**: el candidato comparte un screenshot o pega las preguntas manualmente.
+- **Best with visible Playwright**: In visible mode, the candidate sees the browser and Claude can interact with the page.
+- **Without Playwright**: the candidate shares a screenshot or pastes the questions manually.
 
 ## Workflow
 
 ```
-1. DETECTAR    → Leer Chrome tab activa (screenshot/URL/título)
-2. IDENTIFICAR → Extraer empresa + rol de la página
-3. BUSCAR      → Match contra reports existentes en reports/
-4. CARGAR      → Leer report completo + Section G (si existe)
-5. COMPARAR    → ¿El rol en pantalla coincide con el evaluado? Si cambió → avisar
-6. ANALIZAR    → Identificar TODAS las preguntas del formulario visibles
-7. GENERAR     → Para cada pregunta, generar respuesta personalizada
-8. PRESENTAR   → Mostrar respuestas formateadas para copy-paste
+1. DETECT     → Read active Chrome tab (screenshot/URL/title)
+2. IDENTIFY   → Extract company + role from the page
+3. SEARCH     → Match against existing reports in reports/
+4. LOAD       → Read full report + Section G (if it exists)
+5. COMPARE    → Does the on-screen role match the evaluated one? If changed → alert
+6. ANALYZE    → Identify ALL visible form questions
+7. GENERATE   → For each question, generate a personalized answer
+8. PRESENT    → Show formatted answers ready for copy-paste
 ```
 
-## Paso 1 — Detectar la oferta
+## Step 1 — Detect the offer
 
-**Con Playwright:** Tomar snapshot de la página activa. Leer título, URL, y contenido visible.
+**With Playwright:** Take a snapshot of the active page. Read the title, URL, and visible content.
 
-**Sin Playwright:** Pedir al candidato que:
-- Comparta un screenshot del formulario (Read tool lee imágenes)
-- O pegue las preguntas del formulario como texto
-- O diga empresa + rol para que lo busquemos
+**Without Playwright:** Ask the candidate to:
+- Share a screenshot of the form (Read tool can read images)
+- Or paste the form questions as text
+- Or provide company + role so we can look it up
 
-## Paso 2 — Identificar y buscar contexto
+## Step 2 — Identify and search for context
 
-1. Extraer nombre de empresa y título del rol de la página
-2. Buscar en `reports/` por nombre de empresa (Grep case-insensitive)
-3. Si hay match → cargar el report completo
-4. Si hay Section G → cargar los draft answers previos como base
-5. Si NO hay match → avisar y ofrecer ejecutar auto-pipeline rápido
+1. Extract company name and role title from the page
+2. Search `reports/` by company name (Grep case-insensitive)
+3. If there's a match → load the full report
+4. If Section G exists → load previous draft answers as a starting point
+5. If NO match → notify and offer to run a quick auto-pipeline
 
-## Paso 3 — Detectar cambios en el rol
+## Step 3 — Detect role changes
 
-Si el rol en pantalla difiere del evaluado:
-- **Avisar al candidato**: "El rol ha cambiado de [X] a [Y]. ¿Quieres que re-evalúe o adapto las respuestas al nuevo título?"
-- **Si adaptar**: Ajustar las respuestas al nuevo rol sin re-evaluar
-- **Si re-evaluar**: Ejecutar evaluación A-F completa, actualizar report, regenerar Section G
-- **Actualizar tracker**: Cambiar título del rol en applications.md si procede
+If the on-screen role differs from the evaluated one:
+- **Alert the candidate**: "The role has changed from [X] to [Y]. Do you want me to re-evaluate or adapt the answers to the new title?"
+- **If adapting**: Adjust answers to the new role without re-evaluating
+- **If re-evaluating**: Run the full A-F evaluation, update the report, regenerate Section G
+- **Update tracker**: Change the role title in applications.md if appropriate
 
-## Paso 4 — Analizar preguntas del formulario
+## Step 4 — Analyze form questions
 
-Identificar TODAS las preguntas visibles:
-- Campos de texto libre (cover letter, why this role, etc.)
+Identify ALL visible questions:
+- Free text fields (cover letter, why this role, etc.)
 - Dropdowns (how did you hear, work authorization, etc.)
 - Yes/No (relocation, visa, etc.)
-- Campos de salario (range, expectation)
+- Salary fields (range, expectation)
 - Upload fields (resume, cover letter PDF)
 
-Clasificar cada pregunta:
-- **Ya respondida en Section G** → adaptar la respuesta existente
-- **Nueva pregunta** → generar respuesta desde el report + cv.md
+Classify each question:
+- **Already answered in Section G** → adapt the existing answer
+- **New question** → generate answer from the report + cv.md
 
-## Paso 5 — Generar respuestas
+## Step 5 — Generate answers
 
-Para cada pregunta, generar la respuesta siguiendo:
+For each question, generate the answer following:
 
-1. **Contexto del report**: Usar proof points del bloque B, historias STAR del bloque F
-2. **Section G previa**: Si existe una respuesta draft, usarla como base y refinar
-3. **Tono "I'm choosing you"**: Mismo framework del auto-pipeline
-4. **Especificidad**: Referenciar algo concreto del JD visible en pantalla
-5. **career-ops proof point**: Incluir en "Additional info" si hay campo para ello
+1. **Report context**: Use proof points from block B, STAR stories from block F
+2. **Previous Section G**: If a draft answer exists, use it as a base and refine
+3. **"I'm choosing you" tone**: Same framework as auto-pipeline
+4. **Specificity**: Reference something concrete from the visible JD
+5. **career-ops proof point**: Include in "Additional info" if there's a field for it
 
-**Formato de output:**
+**Output format:**
 
 ```
-## Respuestas para [Empresa] — [Rol]
+## Answers for [Company] — [Role]
 
-Basado en: Report #NNN | Score: X.X/5 | Arquetipo: [tipo]
+Based on: Report #NNN | Score: X.X/5 | Archetype: [type]
 
 ---
 
-### 1. [Pregunta exacta del formulario]
-> [Respuesta lista para copy-paste]
+### 1. [Exact form question]
+> [Answer ready for copy-paste]
 
-### 2. [Siguiente pregunta]
-> [Respuesta]
+### 2. [Next question]
+> [Answer]
 
 ...
 
 ---
 
-Notas:
-- [Cualquier observación sobre el rol, cambios, etc.]
-- [Sugerencias de personalización que el candidato debería revisar]
+Notes:
+- [Any observations about the role, changes, etc.]
+- [Personalization suggestions the candidate should review]
 ```
 
-## Paso 6 — Post-apply (opcional)
+## Step 6 — Post-apply (optional)
 
-Si el candidato confirma que envió la aplicación:
-1. Actualizar estado en `applications.md` de "Evaluada" a "Aplicado"
-2. Actualizar Section G del report con las respuestas finales
-3. Sugerir siguiente paso: `/career-ops contacto` para LinkedIn outreach
+If the candidate confirms the application was submitted:
+1. Update status in `applications.md` from "Evaluated" to "Applied"
+2. Update Section G of the report with the final answers
+3. Suggest next step: `/career-ops contacto` for LinkedIn outreach
 
 ## Scroll handling
 
-Si el formulario tiene más preguntas que las visibles:
-- Pedir al candidato que haga scroll y comparta otro screenshot
-- O que pegue las preguntas restantes
-- Procesar en iteraciones hasta cubrir todo el formulario
+If the form has more questions than are visible:
+- Ask the candidate to scroll and share another screenshot
+- Or paste the remaining questions
+- Process in iterations until the entire form is covered

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -1,39 +1,39 @@
-# Modo: auto-pipeline — Pipeline Completo Automático
+# Mode: auto-pipeline — Full Automatic Pipeline
 
-Cuando el usuario pega un JD (texto o URL) sin sub-comando explícito, ejecutar TODO el pipeline en secuencia:
+When the user pastes a JD (text or URL) without an explicit sub-command, execute the ENTIRE pipeline in sequence:
 
-## Paso 0 — Extraer JD
+## Step 0 — Extract JD
 
-Si el input es una **URL** (no texto de JD pegado), seguir esta estrategia para extraer el contenido:
+If the input is a **URL** (not pasted JD text), follow this strategy to extract the content:
 
-**Orden de prioridad:**
+**Priority order:**
 
-1. **Playwright (preferido):** La mayoría de portales de empleo (Lever, Ashby, Greenhouse, Workday) son SPAs. Usar `browser_navigate` + `browser_snapshot` para renderizar y leer el JD.
-2. **WebFetch (fallback):** Para páginas estáticas (ZipRecruiter, WeLoveProduct, company career pages).
-3. **WebSearch (último recurso):** Buscar título del rol + empresa en portales secundarios que indexan el JD en HTML estático.
+1. **Playwright (preferred):** Most job portals (Lever, Ashby, Greenhouse, Workday) are SPAs. Use `browser_navigate` + `browser_snapshot` to render and read the JD.
+2. **WebFetch (fallback):** For static pages (ZipRecruiter, WeLoveProduct, company career pages).
+3. **WebSearch (last resort):** Search for the role title + company on secondary portals that index the JD in static HTML.
 
-**Si ningún método funciona:** Pedir al candidato que pegue el JD manualmente o comparta un screenshot.
+**If no method works:** Ask the candidate to paste the JD manually or share a screenshot.
 
-**Si el input es texto de JD** (no URL): usar directamente, sin necesidad de fetch.
+**If the input is JD text** (not a URL): use directly, no fetch needed.
 
-## Paso 1 — Evaluación A-F
-Ejecutar exactamente igual que el modo `oferta` (leer `modes/oferta.md` para todos los bloques A-F).
+## Step 1 — Evaluation A-F
+Execute exactly as in the `oferta` mode (read `modes/oferta.md` for all blocks A-F).
 
-## Paso 2 — Guardar Report .md
-Guardar la evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (ver formato en `modes/oferta.md`).
+## Step 2 — Save Report .md
+Save the full evaluation to `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (see format in `modes/oferta.md`).
 
-## Paso 3 — Generar PDF
-Ejecutar el pipeline completo de `pdf` (leer `modes/pdf.md`).
+## Step 3 — Generate PDF
+Execute the full `pdf` pipeline (read `modes/pdf.md`).
 
-## Paso 4 — Draft Application Answers (solo si score >= 4.5)
+## Step 4 — Draft Application Answers (only if score >= 4.5)
 
-Si el score final es >= 4.5, generar borrador de respuestas para el formulario de aplicación:
+If the final score is >= 4.5, generate draft answers for the application form:
 
-1. **Extraer preguntas del formulario**: Usar Playwright para navegar al formulario y hacer snapshot. Si no se pueden extraer, usar las preguntas genéricas.
-2. **Generar respuestas** siguiendo el tono (ver abajo).
-3. **Guardar en el report** como sección `## G) Draft Application Answers`.
+1. **Extract form questions**: Use Playwright to navigate to the form and take a snapshot. If questions can't be extracted, use the generic questions.
+2. **Generate answers** following the tone guidelines (see below).
+3. **Save in the report** as a `## G) Draft Application Answers` section.
 
-### Preguntas genéricas (usar si no se pueden extraer del formulario)
+### Generic questions (use if form questions can't be extracted)
 
 - Why are you interested in this role?
 - Why do you want to work at [Company]?
@@ -41,27 +41,27 @@ Si el score final es >= 4.5, generar borrador de respuestas para el formulario d
 - What makes you a good fit for this position?
 - How did you hear about this role?
 
-### Tono para Form Answers
+### Tone for Form Answers
 
-**Posición: "I'm choosing you."** el candidato tiene opciones y está eligiendo esta empresa por razones concretas.
+**Position: "I'm choosing you."** The candidate has options and is choosing this company for specific reasons.
 
-**Reglas de tono:**
-- **Confiado sin arrogancia**: "I've spent the past year building production AI agent systems — your role is where I want to apply that experience next"
-- **Selectivo sin soberbia**: "I've been intentional about finding a team where I can contribute meaningfully from day one"
-- **Específico y concreto**: Siempre referenciar algo REAL del JD o de la empresa, y algo REAL de la experiencia del candidato
-- **Directo, sin fluff**: 2-4 frases por respuesta. Sin "I'm passionate about..." ni "I would love the opportunity to..."
-- **El hook es la prueba, no la afirmación**: En vez de "I'm great at X", decir "I built X that does Y"
+**Tone rules:**
+- **Confident without arrogance**: "I've spent the past year building production AI agent systems — your role is where I want to apply that experience next"
+- **Selective without pretension**: "I've been intentional about finding a team where I can contribute meaningfully from day one"
+- **Specific and concrete**: Always reference something REAL from the JD or the company, and something REAL from the candidate's experience
+- **Direct, no fluff**: 2-4 sentences per answer. No "I'm passionate about..." or "I would love the opportunity to..."
+- **The hook is the proof, not the claim**: Instead of "I'm great at X", say "I built X that does Y"
 
-**Framework por pregunta:**
+**Framework per question:**
 - **Why this role?** → "Your [specific thing] maps directly to [specific thing I built]."
-- **Why this company?** → Mencionar algo concreto sobre la empresa. "I've been using [product] for [time/purpose]."
-- **Relevant experience?** → Un proof point cuantificado. "Built [X] that [metric]. Sold the company in 2025."
+- **Why this company?** → Mention something concrete about the company. "I've been using [product] for [time/purpose]."
+- **Relevant experience?** → A quantified proof point. "Built [X] that [metric]. Sold the company in 2025."
 - **Good fit?** → "I sit at the intersection of [A] and [B], which is exactly where this role lives."
-- **How did you hear?** → Honesto: "Found through [portal/scan], evaluated against my criteria, and it scored highest."
+- **How did you hear?** → Honest: "Found through [portal/scan], evaluated against my criteria, and it scored highest."
 
-**Idioma**: Siempre en el idioma del JD (EN default). Aplicar `/tech-translate`.
+**Language**: Always in the language of the JD (EN default). Apply `/tech-translate`.
 
-## Paso 5 — Actualizar Tracker
-Registrar en `data/applications.md` con todas las columnas incluyendo Report y PDF en ✅.
+## Step 5 — Update Tracker
+Register in `data/applications.md` with all columns including Report and PDF as ✅.
 
-**Si algún paso falla**, continuar con los siguientes y marcar el paso fallido como pendiente en el tracker.
+**If any step fails**, continue with the remaining steps and mark the failed step as pending in the tracker.

--- a/modes/batch.md
+++ b/modes/batch.md
@@ -1,73 +1,73 @@
-# Modo: batch — Procesamiento Masivo de Ofertas
+# Mode: batch — Bulk Offer Processing
 
-Dos modos de uso: **conductor --chrome** (navega portales en tiempo real) o **standalone** (script para URLs ya recolectadas).
+Two usage modes: **conductor --chrome** (navigates portals in real time) or **standalone** (script for already-collected URLs).
 
-## Arquitectura
+## Architecture
 
 ```
 Claude Conductor (claude --chrome --dangerously-skip-permissions)
   │
-  │  Chrome: navega portales (sesiones logueadas)
-  │  Lee DOM directo — el usuario ve todo en tiempo real
+  │  Chrome: navigates portals (logged-in sessions)
+  │  Reads DOM directly — the user sees everything in real time
   │
-  ├─ Oferta 1: lee JD del DOM + URL
+  ├─ Offer 1: reads JD from DOM + URL
   │    └─► claude -p worker → report .md + PDF + tracker-line
   │
-  ├─ Oferta 2: click siguiente, lee JD + URL
+  ├─ Offer 2: click next, reads JD + URL
   │    └─► claude -p worker → report .md + PDF + tracker-line
   │
-  └─ Fin: merge tracker-additions → applications.md + resumen
+  └─ End: merge tracker-additions → applications.md + summary
 ```
 
-Cada worker es un `claude -p` hijo con contexto limpio de 200K tokens. El conductor solo orquesta.
+Each worker is a `claude -p` child with a clean 200K token context. The conductor only orchestrates.
 
-## Archivos
+## Files
 
 ```
 batch/
-  batch-input.tsv               # URLs (por conductor o manual)
-  batch-state.tsv               # Progreso (auto-generado, gitignored)
-  batch-runner.sh               # Script orquestador standalone
-  batch-prompt.md               # Prompt template para workers
-  logs/                         # Un log por oferta (gitignored)
-  tracker-additions/            # Líneas de tracker (gitignored)
+  batch-input.tsv               # URLs (from conductor or manual)
+  batch-state.tsv               # Progress (auto-generated, gitignored)
+  batch-runner.sh               # Standalone orchestrator script
+  batch-prompt.md               # Prompt template for workers
+  logs/                         # One log per offer (gitignored)
+  tracker-additions/            # Tracker lines (gitignored)
 ```
 
-## Modo A: Conductor --chrome
+## Mode A: Conductor --chrome
 
-1. **Leer estado**: `batch/batch-state.tsv` → saber qué ya se procesó
-2. **Navegar portal**: Chrome → URL de búsqueda
-3. **Extraer URLs**: Leer DOM de resultados → extraer lista de URLs → append a `batch-input.tsv`
-4. **Para cada URL pendiente**:
-   a. Chrome: click en la oferta → leer JD text del DOM
-   b. Guardar JD a `/tmp/batch-jd-{id}.txt`
-   c. Calcular siguiente REPORT_NUM secuencial
-   d. Ejecutar via Bash:
+1. **Read state**: `batch/batch-state.tsv` → check what's already been processed
+2. **Navigate portal**: Chrome → search URL
+3. **Extract URLs**: Read DOM from results → extract URL list → append to `batch-input.tsv`
+4. **For each pending URL**:
+   a. Chrome: click on the offer → read JD text from DOM
+   b. Save JD to `/tmp/batch-jd-{id}.txt`
+   c. Calculate next sequential REPORT_NUM
+   d. Execute via Bash:
       ```bash
       claude -p --dangerously-skip-permissions \
         --append-system-prompt-file batch/batch-prompt.md \
-        "Procesa esta oferta. URL: {url}. JD: /tmp/batch-jd-{id}.txt. Report: {num}. ID: {id}"
+        "Process this offer. URL: {url}. JD: /tmp/batch-jd-{id}.txt. Report: {num}. ID: {id}"
       ```
-   e. Actualizar `batch-state.tsv` (completed/failed + score + report_num)
-   f. Log a `logs/{report_num}-{id}.log`
-   g. Chrome: volver atrás → siguiente oferta
-5. **Paginación**: Si no hay más ofertas → click "Next" → repetir
-6. **Fin**: Merge `tracker-additions/` → `applications.md` + resumen
+   e. Update `batch-state.tsv` (completed/failed + score + report_num)
+   f. Log to `logs/{report_num}-{id}.log`
+   g. Chrome: go back → next offer
+5. **Pagination**: If no more offers → click "Next" → repeat
+6. **End**: Merge `tracker-additions/` → `applications.md` + summary
 
-## Modo B: Script standalone
+## Mode B: Standalone script
 
 ```bash
 batch/batch-runner.sh [OPTIONS]
 ```
 
-Opciones:
-- `--dry-run` — lista pendientes sin ejecutar
-- `--retry-failed` — solo reintenta fallidas
-- `--start-from N` — empieza desde ID N
-- `--parallel N` — N workers en paralelo
-- `--max-retries N` — intentos por oferta (default: 2)
+Options:
+- `--dry-run` — list pending items without executing
+- `--retry-failed` — only retry failed ones
+- `--start-from N` — start from ID N
+- `--parallel N` — N workers in parallel
+- `--max-retries N` — attempts per offer (default: 2)
 
-## Formato batch-state.tsv
+## batch-state.tsv Format
 
 ```
 id	url	status	started_at	completed_at	report_num	score	error	retries
@@ -76,29 +76,29 @@ id	url	status	started_at	completed_at	report_num	score	error	retries
 3	https://...	pending	-	-	-	-	-	0
 ```
 
-## Resumabilidad
+## Resumability
 
-- Si muere → re-ejecutar → lee `batch-state.tsv` → skip completadas
-- Lock file (`batch-runner.pid`) previene ejecución doble
-- Cada worker es independiente: fallo en oferta #47 no afecta a las demás
+- If it dies → re-run → reads `batch-state.tsv` → skips completed ones
+- Lock file (`batch-runner.pid`) prevents double execution
+- Each worker is independent: failure on offer #47 doesn't affect the rest
 
 ## Workers (claude -p)
 
-Cada worker recibe `batch-prompt.md` como system prompt. Es self-contained.
+Each worker receives `batch-prompt.md` as its system prompt. It is self-contained.
 
-El worker produce:
-1. Report `.md` en `reports/`
-2. PDF en `output/`
-3. Línea de tracker en `batch/tracker-additions/{id}.tsv`
-4. JSON de resultado por stdout
+The worker produces:
+1. Report `.md` in `reports/`
+2. PDF in `output/`
+3. Tracker line in `batch/tracker-additions/{id}.tsv`
+4. JSON result via stdout
 
-## Gestión de errores
+## Error handling
 
 | Error | Recovery |
 |-------|----------|
-| URL inaccesible | Worker falla → conductor marca `failed`, siguiente |
-| JD detrás de login | Conductor intenta leer DOM. Si falla → `failed` |
-| Portal cambia layout | Conductor razona sobre HTML, se adapta |
-| Worker crashea | Conductor marca `failed`, siguiente. Retry con `--retry-failed` |
-| Conductor muere | Re-ejecutar → lee state → skip completadas |
-| PDF falla | Report .md se guarda. PDF queda pendiente |
+| URL inaccessible | Worker fails → conductor marks `failed`, moves on |
+| JD behind login | Conductor tries reading DOM. If it fails → `failed` |
+| Portal layout changes | Conductor reasons about HTML, adapts |
+| Worker crashes | Conductor marks `failed`, moves on. Retry with `--retry-failed` |
+| Conductor dies | Re-run → reads state → skips completed |
+| PDF fails | Report .md is saved. PDF remains pending |

--- a/modes/contacto.md
+++ b/modes/contacto.md
@@ -1,26 +1,26 @@
-# Modo: contacto — LinkedIn Power Move
+# Mode: contacto — LinkedIn Power Move
 
-1. **Identificar targets** via WebSearch:
-   - Hiring manager del equipo
-   - Recruiter asignado
-   - 2-3 peers del equipo (gente con rol similar)
+1. **Identify targets** via WebSearch:
+   - Hiring manager of the team
+   - Assigned recruiter
+   - 2-3 team peers (people in a similar role)
 
-2. **Seleccionar target primario**: la persona que más se beneficiaría de que el candidato estuviera allí
+2. **Select primary target**: the person who would benefit most from having the candidate on the team
 
-3. **Generar mensaje** con framework de 3 frases:
-   - **Frase 1 (Gancho)**: Algo específico sobre su empresa o reto actual con IA (NO genérico)
-   - **Frase 2 (Prueba)**: Mayor logro cuantificable del candidato relevante para ESE rol (ej: "I built an AI agent handling 90% of customer service at my company before selling it")
-   - **Frase 3 (Propuesta)**: Charla rápida, sin presión ("Would love to chat about [tema específico] for 15 min")
+3. **Generate message** using the 3-sentence framework:
+   - **Sentence 1 (Hook)**: Something specific about their company or current AI challenge (NOT generic)
+   - **Sentence 2 (Proof)**: The candidate's most quantifiable achievement relevant to THAT role (e.g., "I built an AI agent handling 90% of customer service at my company before selling it")
+   - **Sentence 3 (Proposal)**: A quick, no-pressure chat ("Would love to chat about [specific topic] for 15 min")
 
-4. **Versiones**:
+4. **Versions**:
    - EN (default)
-   - ES (si empresa española)
+   - ES (if Spanish company)
 
-5. **Targets alternativos** con justificación de por qué son buenos second choices
+5. **Alternative targets** with justification for why they are good second choices
 
-**Reglas del mensaje:**
-- Máximo 300 caracteres (LinkedIn connection request limit)
+**Message rules:**
+- Maximum 300 characters (LinkedIn connection request limit)
 - NO corporate-speak
 - NO "I'm passionate about..."
-- Algo que haga que quieran responder
-- NUNCA compartir teléfono
+- Something that makes them want to respond
+- NEVER share phone number

--- a/modes/deep.md
+++ b/modes/deep.md
@@ -1,47 +1,47 @@
-# Modo: deep — Deep Research Prompt
+# Mode: deep — Deep Research Prompt
 
-Genera un prompt estructurado para Perplexity/Claude/ChatGPT con 6 ejes:
+Generates a structured prompt for Perplexity/Claude/ChatGPT across 6 axes:
 
 ```
-## Deep Research: [Empresa] — [Rol]
+## Deep Research: [Company] — [Role]
 
-Contexto: Estoy evaluando una candidatura para [rol] en [empresa]. Necesito información accionable para la entrevista.
+Context: I'm evaluating a candidacy for [role] at [company]. I need actionable information for the interview.
 
-### 1. Estrategia AI
-- ¿Qué productos/features usan AI/ML?
-- ¿Cuál es su stack de AI? (modelos, infra, tools)
-- ¿Tienen blog de engineering? ¿Qué publican?
-- ¿Qué papers o talks han dado sobre AI?
+### 1. AI Strategy
+- What products/features use AI/ML?
+- What is their AI stack? (models, infra, tools)
+- Do they have an engineering blog? What do they publish?
+- What papers or talks have they given about AI?
 
-### 2. Movimientos recientes (últimos 6 meses)
-- ¿Contrataciones relevantes en AI/ML/product?
-- ¿Acquisitions o partnerships?
-- ¿Product launches o pivots?
-- ¿Rondas de funding o cambios de liderazgo?
+### 2. Recent Moves (last 6 months)
+- Relevant hires in AI/ML/product?
+- Acquisitions or partnerships?
+- Product launches or pivots?
+- Funding rounds or leadership changes?
 
-### 3. Cultura de engineering
-- ¿Cómo shipean? (cadencia de deploy, CI/CD)
-- ¿Mono-repo o multi-repo?
-- ¿Qué lenguajes/frameworks usan?
-- ¿Remote-first o office-first?
-- ¿Glassdoor/Blind reviews sobre eng culture?
+### 3. Engineering Culture
+- How do they ship? (deploy cadence, CI/CD)
+- Mono-repo or multi-repo?
+- What languages/frameworks do they use?
+- Remote-first or office-first?
+- Glassdoor/Blind reviews on eng culture?
 
-### 4. Retos probables
-- ¿Qué problemas de scaling tienen?
-- ¿Reliability, cost, latency challenges?
-- ¿Están migrando algo? (infra, models, platforms)
-- ¿Qué pain points menciona la gente en reviews?
+### 4. Likely Challenges
+- What scaling problems do they have?
+- Reliability, cost, latency challenges?
+- Are they migrating anything? (infra, models, platforms)
+- What pain points do people mention in reviews?
 
-### 5. Competidores y diferenciación
-- ¿Quiénes son sus main competitors?
-- ¿Cuál es su moat/diferenciador?
-- ¿Cómo se posicionan vs competencia?
+### 5. Competitors and Differentiation
+- Who are their main competitors?
+- What is their moat/differentiator?
+- How do they position themselves vs the competition?
 
-### 6. Ángulo del candidato
-Dado mi perfil (read from cv.md and profile.yml for specific experience):
-- ¿Qué valor único aporto a este equipo?
-- ¿Qué proyectos míos son más relevantes?
-- ¿Qué historia debería contar en la entrevista?
+### 6. Candidate Angle
+Given my profile (read from cv.md and profile.yml for specific experience):
+- What unique value do I bring to this team?
+- Which of my projects are most relevant?
+- What story should I tell in the interview?
 ```
 
-Personalizar cada sección con el contexto específico de la oferta evaluada.
+Customize each section with the specific context from the evaluated offer.

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -1,157 +1,157 @@
-# Modo: oferta — Evaluación Completa A-F
+# Mode: oferta — Full Evaluation A-F
 
-Cuando el candidato pega una oferta (texto o URL), entregar SIEMPRE los 6 bloques:
+When the candidate pastes an offer (text or URL), ALWAYS deliver all 6 blocks:
 
-## Paso 0 — Detección de Arquetipo
+## Step 0 — Archetype Detection
 
-Clasificar la oferta en uno de los 6 arquetipos (ver `_shared.md`). Si es híbrido, indicar los 2 más cercanos. Esto determina:
-- Qué proof points priorizar en bloque B
-- Cómo reescribir el summary en bloque E
-- Qué historias STAR preparar en bloque F
+Classify the offer into one of the 6 archetypes (see `_shared.md`). If it's a hybrid, indicate the 2 closest. This determines:
+- Which proof points to prioritize in block B
+- How to rewrite the summary in block E
+- Which STAR stories to prepare in block F
 
-## Bloque A — Resumen del Rol
+## Block A — Role Summary
 
-Tabla con:
-- Arquetipo detectado
+Table with:
+- Detected archetype
 - Domain (platform/agentic/LLMOps/ML/enterprise)
 - Function (build/consult/manage/deploy)
 - Seniority
 - Remote (full/hybrid/onsite)
-- Team size (si se menciona)
-- TL;DR en 1 frase
+- Team size (if mentioned)
+- TL;DR in 1 sentence
 
-## Bloque B — Match con CV
+## Block B — CV Match
 
-Lee `cv.md`. Crea tabla con cada requisito del JD mapeado a líneas exactas del CV.
+Read `cv.md`. Create a table mapping each JD requirement to exact lines from the CV.
 
-**Adaptado al arquetipo:**
-- Si FDE → priorizar proof points de delivery rápida y client-facing
-- Si SA → priorizar diseño de sistemas e integrations
-- Si PM → priorizar product discovery y métricas
-- Si LLMOps → priorizar evals, observability, pipelines
-- Si Agentic → priorizar multi-agent, HITL, orchestration
-- Si Transformation → priorizar change management, adoption, scaling
+**Adapted to the archetype:**
+- If FDE → prioritize proof points about fast delivery and client-facing work
+- If SA → prioritize system design and integrations
+- If PM → prioritize product discovery and metrics
+- If LLMOps → prioritize evals, observability, pipelines
+- If Agentic → prioritize multi-agent, HITL, orchestration
+- If Transformation → prioritize change management, adoption, scaling
 
-Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
-1. ¿Es un hard blocker o un nice-to-have?
-2. ¿Puede el candidato demostrar experiencia adyacente?
-3. ¿Hay un proyecto portfolio que cubra este gap?
-4. Plan de mitigación concreto (frase para cover letter, proyecto rápido, etc.)
+**Gaps** section with mitigation strategy for each one. For each gap:
+1. Is it a hard blocker or a nice-to-have?
+2. Can the candidate demonstrate adjacent experience?
+3. Is there a portfolio project that covers this gap?
+4. Concrete mitigation plan (phrase for cover letter, quick project, etc.)
 
-## Bloque C — Nivel y Estrategia
+## Block C — Level and Strategy
 
-1. **Nivel detectado** en el JD vs **nivel natural del candidato para ese arquetipo**
-2. **Plan "vender senior sin mentir"**: frases específicas adaptadas al arquetipo, logros concretos a destacar, cómo posicionar la experiencia de founder como ventaja
-3. **Plan "si me downlevelan"**: aceptar si comp es justa, negociar review a 6 meses, criterios de promoción claros
+1. **Detected level** in the JD vs **candidate's natural level for that archetype**
+2. **"Sell senior without lying" plan**: specific phrases adapted to the archetype, concrete achievements to highlight, how to position founder experience as an advantage
+3. **"If I get downleveled" plan**: accept if comp is fair, negotiate a 6-month review, clear promotion criteria
 
-## Bloque D — Comp y Demanda
+## Block D — Comp and Demand
 
-Usar WebSearch para:
-- Salarios actuales del rol (Glassdoor, Levels.fyi, Blind)
-- Reputación de compensación de la empresa
-- Tendencia de demanda del rol
+Use WebSearch for:
+- Current salaries for the role (Glassdoor, Levels.fyi, Blind)
+- Company's compensation reputation
+- Demand trend for the role
 
-Tabla con datos y fuentes citadas. Si no hay datos, decirlo en vez de inventar.
+Table with data and cited sources. If no data is available, say so instead of making things up.
 
-## Bloque E — Plan de Personalización
+## Block E — Personalization Plan
 
-| # | Sección | Estado actual | Cambio propuesto | Por qué |
-|---|---------|---------------|------------------|---------|
+| # | Section | Current state | Proposed change | Why |
+|---|---------|---------------|-----------------|-----|
 | 1 | Summary | ... | ... | ... |
 | ... | ... | ... | ... | ... |
 
-Top 5 cambios al CV + Top 5 cambios a LinkedIn para maximizar match.
+Top 5 CV changes + Top 5 LinkedIn changes to maximize match.
 
-## Bloque F — Plan de Entrevistas
+## Block F — Interview Plan
 
-6-10 historias STAR+R mapeadas a requisitos del JD (STAR + **Reflection**):
+6-10 STAR+R stories mapped to JD requirements (STAR + **Reflection**):
 
-| # | Requisito del JD | Historia STAR+R | S | T | A | R | Reflection |
-|---|-----------------|-----------------|---|---|---|---|------------|
+| # | JD Requirement | STAR+R Story | S | T | A | R | Reflection |
+|---|----------------|--------------|---|---|---|---|------------|
 
 The **Reflection** column captures what was learned or what would be done differently. This signals seniority — junior candidates describe what happened, senior candidates extract lessons.
 
 **Story Bank:** If `interview-prep/story-bank.md` exists, check if any of these stories are already there. If not, append new ones. Over time this builds a reusable bank of 5-10 master stories that can be adapted to any interview question.
 
-**Seleccionadas y enmarcadas según el arquetipo:**
-- FDE → enfatizar velocidad de entrega y client-facing
-- SA → enfatizar decisiones de arquitectura
-- PM → enfatizar discovery y trade-offs
-- LLMOps → enfatizar métricas, evals, production hardening
-- Agentic → enfatizar orchestration, error handling, HITL
-- Transformation → enfatizar adopción, cambio organizacional
+**Selected and framed according to the archetype:**
+- FDE → emphasize delivery speed and client-facing work
+- SA → emphasize architecture decisions
+- PM → emphasize discovery and trade-offs
+- LLMOps → emphasize metrics, evals, production hardening
+- Agentic → emphasize orchestration, error handling, HITL
+- Transformation → emphasize adoption, organizational change
 
-Incluir también:
-- 1 case study recomendado (cuál de sus proyectos presentar y cómo)
-- Preguntas red-flag y cómo responderlas (ej: "¿por qué vendiste tu empresa?", "¿tienes equipo de reports?")
+Also include:
+- 1 recommended case study (which project to present and how)
+- Red-flag questions and how to answer them (e.g., "Why did you sell your company?", "Do you have direct reports?")
 
 ---
 
-## Post-evaluación
+## Post-evaluation
 
-**SIEMPRE** después de generar los bloques A-F:
+**ALWAYS** after generating blocks A-F:
 
-### 1. Guardar report .md
+### 1. Save report .md
 
-Guardar evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+Save the full evaluation to `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 
-- `{###}` = siguiente número secuencial (3 dígitos, zero-padded)
-- `{company-slug}` = nombre de empresa en lowercase, sin espacios (usar guiones)
-- `{YYYY-MM-DD}` = fecha actual
+- `{###}` = next sequential number (3 digits, zero-padded)
+- `{company-slug}` = company name in lowercase, no spaces (use hyphens)
+- `{YYYY-MM-DD}` = current date
 
-**Formato del report:**
+**Report format:**
 
 ```markdown
-# Evaluación: {Empresa} — {Rol}
+# Evaluation: {Company} — {Role}
 
-**Fecha:** {YYYY-MM-DD}
-**Arquetipo:** {detectado}
+**Date:** {YYYY-MM-DD}
+**Archetype:** {detected}
 **Score:** {X/5}
-**PDF:** {ruta o pendiente}
+**PDF:** {path or pending}
 
 ---
 
-## A) Resumen del Rol
-(contenido completo del bloque A)
+## A) Role Summary
+(full content of block A)
 
-## B) Match con CV
-(contenido completo del bloque B)
+## B) CV Match
+(full content of block B)
 
-## C) Nivel y Estrategia
-(contenido completo del bloque C)
+## C) Level and Strategy
+(full content of block C)
 
-## D) Comp y Demanda
-(contenido completo del bloque D)
+## D) Comp and Demand
+(full content of block D)
 
-## E) Plan de Personalización
-(contenido completo del bloque E)
+## E) Personalization Plan
+(full content of block E)
 
-## F) Plan de Entrevistas
-(contenido completo del bloque F)
+## F) Interview Plan
+(full content of block F)
 
 ## G) Draft Application Answers
-(solo si score >= 4.5 — borradores de respuestas para el formulario de aplicación)
+(only if score >= 4.5 — draft answers for the application form)
 
 ---
 
-## Keywords extraídas
-(lista de 15-20 keywords del JD para ATS optimization)
+## Extracted Keywords
+(list of 15-20 JD keywords for ATS optimization)
 ```
 
-### 2. Registrar en tracker
+### 2. Register in tracker
 
-**SIEMPRE** registrar en `data/applications.md`:
-- Siguiente número secuencial
-- Fecha actual
-- Empresa
-- Rol
-- Score: promedio de match (1-5)
-- Estado: `Evaluada`
-- PDF: ❌ (o ✅ si auto-pipeline generó PDF)
-- Report: link relativo al report .md (ej: `[001](reports/001-company-2026-01-01.md)`)
+**ALWAYS** register in `data/applications.md`:
+- Next sequential number
+- Current date
+- Company
+- Role
+- Score: match average (1-5)
+- Status: `Evaluated`
+- PDF: ❌ (or ✅ if auto-pipeline generated a PDF)
+- Report: relative link to the report .md (e.g., `[001](reports/001-company-2026-01-01.md)`)
 
-**Formato del tracker:**
+**Tracker format:**
 
 ```markdown
-| # | Fecha | Empresa | Rol | Score | Estado | PDF | Report |
+| # | Date | Company | Role | Score | Status | PDF | Report |
 ```

--- a/modes/ofertas.md
+++ b/modes/ofertas.md
@@ -1,21 +1,21 @@
-# Modo: ofertas — Comparación Multi-Oferta
+# Mode: ofertas — Multi-Offer Comparison
 
-Scoring matrix de 10 dimensiones ponderadas:
+Weighted scoring matrix across 10 dimensions:
 
-| Dimensión | Peso | Criterios 1-5 |
-|-----------|------|----------------|
-| Alineación North Star | 25% | 5=rol target exacto, 1=no relacionado |
-| Match CV | 15% | 5=90%+ match, 1=<40% match |
-| Nivel (senior+) | 15% | 5=staff+, 4=senior, 3=mid-senior, 2=mid, 1=junior |
-| Comp estimada | 10% | 5=top quartile, 1=below market |
-| Trayectoria crecimiento | 10% | 5=clear path to next level, 1=dead end |
-| Calidad remoto | 5% | 5=full remote async, 1=onsite only |
-| Reputación empresa | 5% | 5=top employer, 1=red flags |
-| Modernidad tech stack | 5% | 5=cutting edge AI/ML, 1=legacy |
-| Velocidad a oferta | 5% | 5=fast process, 1=6+ months |
-| Señales culturales | 5% | 5=builder culture, 1=bureaucratic |
+| Dimension | Weight | Criteria 1-5 |
+|-----------|--------|--------------|
+| North Star Alignment | 25% | 5=exact target role, 1=unrelated |
+| CV Match | 15% | 5=90%+ match, 1=<40% match |
+| Level (senior+) | 15% | 5=staff+, 4=senior, 3=mid-senior, 2=mid, 1=junior |
+| Estimated Comp | 10% | 5=top quartile, 1=below market |
+| Growth Trajectory | 10% | 5=clear path to next level, 1=dead end |
+| Remote Quality | 5% | 5=full remote async, 1=onsite only |
+| Company Reputation | 5% | 5=top employer, 1=red flags |
+| Tech Stack Modernity | 5% | 5=cutting edge AI/ML, 1=legacy |
+| Speed to Offer | 5% | 5=fast process, 1=6+ months |
+| Cultural Signals | 5% | 5=builder culture, 1=bureaucratic |
 
-Para cada oferta: score en cada dimensión, score ponderado total.
-Ranking final + recomendación con consideraciones de time-to-offer.
+For each offer: score on each dimension, weighted total score.
+Final ranking + recommendation with time-to-offer considerations.
 
-Pedir al usuario las ofertas si no están en contexto. Puede ser texto, URLs, o referencias a ofertas ya evaluadas en el tracker.
+Ask the user for the offers if they're not in context. They can be text, URLs, or references to offers already evaluated in the tracker.

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -1,177 +1,231 @@
-# Modo: pdf — Generación de PDF ATS-Optimizado
+# Mode: pdf — ATS-Optimized PDF Generation (Pandoc)
 
-## Pipeline completo
+## Full Pipeline
 
-1. Lee `cv.md` como fuentes de verdad
-2. Pide al usuario el JD si no está en contexto (texto o URL)
-3. Extrae 15-20 keywords del JD
-4. Detecta idioma del JD → idioma del CV (EN default)
-5. Detecta ubicación empresa → formato papel:
-   - US/Canada → `letter`
-   - Resto del mundo → `a4`
-6. Detecta arquetipo del rol → adapta framing
-7. Reescribe Professional Summary inyectando keywords del JD + exit narrative bridge ("Built and sold a business. Now applying systems thinking to [domain del JD].")
-8. Selecciona top 3-4 proyectos más relevantes para la oferta
-9. Reordena bullets de experiencia por relevancia al JD
-10. Construye competency grid desde requisitos del JD (6-8 keyword phrases)
-11. Inyecta keywords naturalmente en logros existentes (NUNCA inventa)
-12. Genera HTML completo desde template + contenido personalizado
-13. Escribe HTML a `/tmp/cv-candidate-{company}.html`
-14. Ejecuta: `node generate-pdf.mjs /tmp/cv-candidate-{company}.html output/cv-candidate-{company}-{YYYY-MM-DD}.pdf --format={letter|a4}`
-15. Reporta: ruta del PDF, nº páginas, % cobertura de keywords
+1. Read `cv.md` as the source of truth
+2. Ask the user for the JD if not already in context (text or URL)
+3. Extract 15-20 keywords from the JD
+4. Detect JD language → CV language (EN default)
+5. Detect role archetype → adapt framing
+6. Rewrite Professional Summary injecting JD keywords + exit narrative bridge
+7. Select and reorder content by relevance to the JD
+8. Generate a tailored CV as **markdown** (`.md`) + **Evidence Brief** (see Thesis Defence below)
+9. **THESIS DEFENCE — Judge validates grounding** (see Thesis Defence below)
+10. Apply any AMEND/STRIKE fixes to the markdown
+11. Write final markdown to `/tmp/cv-{candidate}-{company}.md`
+12. Compile with Pandoc:
+    ```
+    pandoc /tmp/cv-{candidate}-{company}.md \
+      -o output/cv-{candidate}-{company}-{YYYY-MM-DD}.pdf \
+      --pdf-engine=pdflatex \
+      --template=templates/cv-template.tex
+    ```
+13. Check page count: `pdfinfo output/cv-....pdf | grep Pages`
+14. If >1 page, trim content and recompile
+15. Report: PDF path, page count, keyword coverage %, grounding summary
 
-## Reglas ATS (parseo limpio)
+## PAGE LIMIT — CRITICAL
 
-- Layout single-column (sin sidebars, sin columnas paralelas)
-- Headers estándar: "Professional Summary", "Work Experience", "Education", "Skills", "Certifications", "Projects"
-- Sin texto en imágenes/SVGs
-- Sin info crítica en headers/footers del PDF (ATS los ignora)
-- UTF-8, texto seleccionable (no rasterizado)
-- Sin tablas anidadas
-- Keywords del JD distribuidas: Summary (top 5), primer bullet de cada rol, Skills section
+**CVs MUST be 1 page.** This is the single most important constraint. To achieve 1 page:
 
-## Diseño del PDF
+1. **Be ruthless with content selection.** Only include experience and bullets directly relevant to the JD.
+2. **Consolidate older roles** into 1-2 lines max (e.g., Competentum: one bullet).
+3. **Limit bullets per role**: current role 4-6 bullets, previous role 3-5 bullets, older roles 1-2 bullets.
+4. **Sub-sections within a role** (e.g., "Team Building", "Product Delivery"): use bold inline headers instead of heading levels to save vertical space.
+5. **Skills section**: one line per category, comma-separated. No bullet lists for skills.
+6. **Publications**: 1-2 lines max. Combine into a single paragraph if needed.
+7. **Open Source**: 1-2 projects max, 1-2 lines each.
+8. **Education**: single line.
+9. **Languages**: single line, can be merged with Education section.
+10. After compiling, check page count. If >1 page, apply these fixes IN ORDER (never remove facts if formatting can save space):
+    a. Merge Education + Languages onto a single line
+    b. Reduce bottom margin (`-V geometry:bottom=0.3in`)
+    c. Shorten verbose bullets (tighten wording, not remove)
+    d. Only as last resort: remove the least relevant bullet
 
-- **Fonts**: Space Grotesk (headings, 600-700) + DM Sans (body, 400-500)
-- **Fonts self-hosted**: `fonts/`
-- **Header**: nombre en Space Grotesk 24px bold + línea gradiente `linear-gradient(to right, hsl(187,74%,32%), hsl(270,70%,45%))` 2px + fila de contacto
-- **Section headers**: Space Grotesk 13px, uppercase, letter-spacing 0.05em, color cyan primary
-- **Body**: DM Sans 11px, line-height 1.5
-- **Company names**: color accent purple `hsl(270,70%,45%)`
-- **Márgenes**: 0.6in
-- **Background**: blanco puro
+**The reference CVs in `/Users/Igor.Gerasimov/IdeaProjects/cv-tailor/data/` show the target style and density.** When in doubt, match that format.
 
-## Orden de secciones (optimizado "6-second recruiter scan")
+## Markdown Output Format
 
-1. Header (nombre grande, gradiente, contacto, link portfolio)
-2. Professional Summary (3-4 líneas, keyword-dense)
-3. Core Competencies (6-8 keyword phrases en flex-grid)
-4. Work Experience (cronológico inverso)
-5. Projects (top 3-4 más relevantes)
-6. Education & Certifications
-7. Skills (idiomas + técnicos)
+The tailored CV is written as standard markdown. Pandoc + the LaTeX template handle all formatting. Follow this structure (derived from cv-tailor reference CVs):
 
-## Estrategia de keyword injection (ético, basado en verdad)
+```markdown
+# Candidate Name
 
-Ejemplos de reformulación legítima:
-- JD dice "RAG pipelines" y CV dice "LLM workflows with retrieval" → cambiar a "RAG pipeline design and LLM orchestration workflows"
-- JD dice "MLOps" y CV dice "observability, evals, error handling" → cambiar a "MLOps and observability: evals, error handling, cost monitoring"
-- JD dice "stakeholder management" y CV dice "collaborated with team" → cambiar a "stakeholder management across engineering, operations, and business"
+**Location:** ... **Email:** ... **LinkedIn:** [display](url) **GitHub:** [display](url)
 
-**NUNCA añadir skills que el candidato no tiene. Solo reformular experiencia real con el vocabulario exacto del JD.**
+---
 
-## Template HTML
+## PROFESSIONAL SUMMARY
 
-Usar el template en `cv-template.html`. Reemplazar los placeholders `{{...}}` con contenido personalizado:
+3-4 lines, keyword-dense, bridging past experience to target role.
 
-| Placeholder | Contenido |
-|-------------|-----------|
-| `{{LANG}}` | `en` o `es` |
-| `{{PAGE_WIDTH}}` | `8.5in` (letter) o `210mm` (A4) |
-| `{{NAME}}` | (from profile.yml) |
-| `{{EMAIL}}` | (from profile.yml) |
-| `{{LINKEDIN_URL}}` | [from profile.yml] |
-| `{{LINKEDIN_DISPLAY}}` | [from profile.yml] |
-| `{{PORTFOLIO_URL}}` | [from profile.yml] (o /es según idioma) |
-| `{{PORTFOLIO_DISPLAY}}` | [from profile.yml] (o /es según idioma) |
-| `{{LOCATION}}` | [from profile.yml] |
-| `{{SECTION_SUMMARY}}` | Professional Summary / Resumen Profesional |
-| `{{SUMMARY_TEXT}}` | Summary personalizado con keywords |
-| `{{SECTION_COMPETENCIES}}` | Core Competencies / Competencias Core |
-| `{{COMPETENCIES}}` | `<span class="competency-tag">keyword</span>` × 6-8 |
-| `{{SECTION_EXPERIENCE}}` | Work Experience / Experiencia Laboral |
-| `{{EXPERIENCE}}` | HTML de cada trabajo con bullets reordenados |
-| `{{SECTION_PROJECTS}}` | Projects / Proyectos |
-| `{{PROJECTS}}` | HTML de top 3-4 proyectos |
-| `{{SECTION_EDUCATION}}` | Education / Formación |
-| `{{EDUCATION}}` | HTML de educación |
-| `{{SECTION_CERTIFICATIONS}}` | Certifications / Certificaciones |
-| `{{CERTIFICATIONS}}` | HTML de certificaciones |
-| `{{SECTION_SKILLS}}` | Skills / Competencias |
-| `{{SKILLS}}` | HTML de skills |
+---
 
-## Canva CV Generation (optional)
+## PROFESSIONAL EXPERIENCE
 
-If `config/profile.yml` has `canva_resume_design_id` set, offer the user a choice before generating:
-- **"HTML/PDF (fast, ATS-optimized)"** — existing flow above
-- **"Canva CV (visual, design-preserving)"** — new flow below
+### JetBrains GmbH — Engagement Manager & Team Lead, Professional Services
+**Berlin, Germany** | Sep 2025 – Present
 
-If the user has no `canva_resume_design_id`, skip this prompt and use the HTML/PDF flow.
+- **Team Leadership:** bullet about managing the team
+- **Enterprise Delivery:** bullet about enterprise engagements
+- **AI & Tooling:** bullet about AI/technical work
 
-### Canva workflow
+### JetBrains GmbH — Team Lead & Developer, JetBrains Academy (Education)
+**Berlin, Germany** | Jul 2018 – Sep 2025
 
-#### Step 1 — Duplicate the base design
+- **Team Scaling:** bullet about scaling the team
+- **Product Growth:** bullet about user growth metrics
+- **AI Systems:** bullet about multi-agent AI work
+- **LLM Evaluation:** bullet about evaluation framework (if relevant to JD)
 
-a. `export-design` the base design (using `canva_resume_design_id`) as PDF → get download URL
-b. `import-design-from-url` using that download URL → creates a new editable design (the duplicate)
-c. Note the new `design_id` for the duplicate
+### Competentum (acquired by EPAM) — Engineering Team Lead / Software Developer
+**St. Petersburg, Russia** | Oct 2016 – Jan 2018
 
-#### Step 2 — Read the design structure
+- Single bullet about team leadership and delivery
 
-a. `get-design-content` on the new design → returns all text elements (richtexts) with their content
-b. Map text elements to CV sections by content matching:
-   - Look for the candidate's name → header section
-   - Look for "Summary" or "Professional Summary" → summary section
-   - Look for company names from cv.md → experience sections
-   - Look for degree/school names → education section
-   - Look for skill keywords → skills section
-c. If mapping fails, show the user what was found and ask for guidance
+---
 
-#### Step 3 — Generate tailored content
+## OPEN SOURCE
 
-Same content generation as the HTML flow (Steps 1-11 above):
-- Rewrite Professional Summary with JD keywords + exit narrative
-- Reorder experience bullets by JD relevance
-- Select top competencies from JD requirements
-- Inject keywords naturally (NEVER invent)
+**[Project](url)** — 1-line description
 
-**IMPORTANT — Character budget rule:** Each replacement text MUST be approximately the same length as the original text it replaces (within ±15% character count). If tailored content is longer, condense it. The Canva design has fixed-size text boxes — longer text causes overlapping with adjacent elements. Count the characters in each original element from Step 2 and enforce this budget when generating replacements.
+---
 
-#### Step 4 — Apply edits
+## TECHNICAL SKILLS
 
-a. `start-editing-transaction` on the duplicate design
-b. `perform-editing-operations` with `find_and_replace_text` for each section:
-   - Replace summary text with tailored summary
-   - Replace each experience bullet with reordered/rewritten bullets
-   - Replace competency/skills text with JD-matched terms
-   - Replace project descriptions with top relevant projects
-c. **Reflow layout after text replacement:**
-   After applying all text replacements, the text boxes auto-resize but neighboring elements stay in place. This causes uneven spacing between work experience sections. Fix this:
-   1. Read the updated element positions and dimensions from the `perform-editing-operations` response
-   2. For each work experience section (top to bottom), calculate where the bullets text box ends: `end_y = top + height`
-   3. The next section's header should start at `end_y + consistent_gap` (use the original gap from the template, typically ~30px)
-   4. Use `position_element` to move the next section's date, company name, role title, and bullets elements to maintain even spacing
-   5. Repeat for all work experience sections
-d. **Verify layout before commit:**
-   - `get-design-thumbnail` with the transaction_id and page_index=1
-   - Visually inspect the thumbnail for: text overlapping, uneven spacing, text cut off, text too small
-   - If issues remain, adjust with `position_element`, `resize_element`, or `format_text`
-   - Repeat until layout is clean
-d. Show the user the final preview and ask for approval
-e. `commit-editing-transaction` to save (ONLY after user approval)
+- **Languages:** TypeScript · Python · Kotlin · Java · Node.js
+- **AI/ML:** Multi-agent systems · LLM · RAG · LangChain · MCP
+- **Cloud & Infra:** AWS · GCP · Docker · Kubernetes · CI/CD
+- **Leadership:** Team scaling · Hiring · OKR planning · Agile
 
-#### Step 5 — Export and download PDF
+---
 
-a. `export-design` the duplicate as PDF (format: a4 or letter based on JD location)
-b. **IMMEDIATELY** download the PDF using Bash:
-   ```bash
-   curl -sL -o "output/cv-{candidate}-{company}-canva-{YYYY-MM-DD}.pdf" "{download_url}"
+## PUBLICATIONS
+
+"Title," venue, year
+
+---
+
+## EDUCATION
+
+**Degree**, University
+
+---
+
+## LANGUAGES
+
+English (fluent) · German (A2) · Russian (native)
+```
+
+## Content Structure
+
+### Professional Summary
+- 3-4 lines max. Keyword-dense, tailored to JD.
+- Bridge from past experience to the target role.
+- No generic fluff — every sentence must map to a JD requirement.
+
+### Professional Experience
+- **Current role (JetBrains PS)**: Title: "Engagement Manager & Team Lead, Professional Services". Use bold inline sub-headers for bullets just like JBA (e.g., **Team Leadership:**, **Enterprise Delivery:**, **AI & Tooling:**). 3-5 bullets.
+- **Previous role (JetBrains Academy)**: Title: "Team Lead & Developer, JetBrains Academy (Education)". Use bold inline sub-headers (e.g., **Team Scaling:**, **Product Growth:**, **AI Systems:**, **LLM Evaluation:**). 3-5 bullets — only include sub-sections relevant to the JD.
+- **Oldest role (Competentum)**: Title must include BOTH positions from cv.md: "Engineering Team Lead / Software Developer". 1-2 bullets max.
+- **Consistency rule**: If one role uses bold inline sub-headers, ALL roles must use them. Never mix styles.
+
+### Open Source
+- 1-2 projects, 1-2 lines each with tech stack and key differentiator.
+
+### Technical Skills
+- Use a bullet list with one item per category: `- **Category:** item · item · item`
+- This ensures clear visual separation between categories in the PDF
+- Keep each category to one line if possible
+
+### Publications, Education, Languages
+- Minimal — 1-2 lines each.
+
+## Thesis Defence — Grounding Validation
+
+Every tailored CV must pass a two-step grounding check before compilation. The composer must **prove** each claim; the judge **cross-examines** the evidence.
+
+### Step A — Composer: Generate CV + Evidence Brief
+
+When generating the tailored markdown (step 8), ALSO produce an **Evidence Brief** — a table mapping every claim in the tailored CV back to its source in `cv.md`.
+
+For each bullet point, summary sentence, skill, or metric in the tailored CV:
+
+```markdown
+## Evidence Brief
+
+| # | Tailored claim (first 80 chars) | cv.md source (line #, quote) | Transformation |
+|---|------|------|------|
+| 1 | "Scaled team from 7 to 32 contributors" | L49: "Scaled the engineering team from 7 to 32" | Verbatim |
+| 2 | "Built production RAG pipelines for content generation" | L53: "multi-agent AI system (Python, LangChain, RAG)" | Reformulated — "RAG" extracted to match JD keyword |
+| 3 | "12x user growth (5K → 60K MAU)" | L51: "Drove 12x user growth (5K → 60K MAU)" | Verbatim metric |
+| 4 | "Kubernetes" in skills | L81: "Docker · Kubernetes" | Verbatim |
+```
+
+**Rules for the composer:**
+- Every bullet, metric, skill, and summary claim MUST have a row in the evidence brief
+- The `cv.md source` column must reference a real line with a direct quote
+- `Transformation` must be one of: `Verbatim`, `Condensed`, `Reformulated — {explain}`, `Merged — {lines}`
+- If you cannot find a source for a claim → **do not include the claim in the CV**
+- The Professional Summary is checked claim-by-claim (split into individual assertions)
+
+**Anti-inflation rules (CRITICAL):**
+- **No fabricated qualifiers.** Never add adjectives or scope words not in cv.md: "C-level", "senior leadership", "global", "strategic", "world-class", etc. If cv.md says "stakeholder communication", do NOT write "C-level stakeholder management". If cv.md says "enterprise customers", do NOT write "Fortune 500 clients" (unless cv.md actually says Fortune 500).
+- **No scope inflation.** If cv.md says you did X that contributed to outcome Y, do NOT claim you led/owned Y. Example: cv.md says "Secured a ~$5M enterprise agreement by unblocking a stalled license migration" → this means you led the engagement that unblocked the deal, NOT that you led the $5M deal itself. Write: "Unblocked a stalled migration that enabled a ~$5M enterprise agreement" — NOT "Led a ~$5M enterprise deal".
+- **No causal inflation.** If cv.md says A happened and B happened, do NOT imply A caused B unless cv.md explicitly states the causal link.
+- **The Professional Summary is the highest-risk section.** It compresses everything, which is where overstatement creeps in. Every single assertion in the summary must have a direct, verifiable source in cv.md. Split the summary into individual claims and cite each one.
+
+### Step B — Judge: Cross-Examine
+
+After the composer produces the CV + evidence brief, switch to **judge role**. Re-read `cv.md` fresh and verify each evidence row:
+
+| Check | What it catches | Verdict |
+|-------|----------------|---------|
+| **Citation exists** | Does the cited cv.md line actually exist and contain the quoted text? | `STRIKE` if citation is fabricated or misquoted |
+| **Metric accuracy** | Do all numbers, percentages, and quantities match the source exactly? | `AMEND` if any number is inflated, rounded up, or changed |
+| **Verb fidelity** | Is the action verb at the same level or below the source? "contributed" must not become "led"; "supported" must not become "drove"; "unblocked" must not become "led/secured" | `AMEND` with corrected verb |
+| **Scope fidelity** | Is the scope of involvement accurately represented? If cv.md says you did X that contributed to Y, the tailored CV must not claim you led/owned Y. Example: "unblocked a migration enabling a $5M deal" ≠ "led a $5M deal" | `AMEND` with corrected framing |
+| **Fabricated qualifiers** | Does the tailored CV add adjectives or scope words not in cv.md? "C-level", "senior leadership", "global scale", "world-class", "strategic" — if the exact qualifier isn't in cv.md, it's fabricated | `STRIKE` the qualifier |
+| **Causal inflation** | Does the tailored CV imply a causal link that cv.md doesn't state? Two things happening doesn't mean one caused the other | `AMEND` to remove implied causation |
+| **Skills audit** | Every technology, tool, or framework in the tailored CV must appear in cv.md (in skills section or experience bullets) | `STRIKE` if skill is not in master CV |
+| **Uncited claims** | Any claim in the tailored CV that has no corresponding evidence row | `STRIKE` — remove entirely |
+
+**Verdict format:**
+```
+| # | Verdict | Issue (if any) | Correction |
+|---|---------|---------------|------------|
+| 1 | PASS | — | — |
+| 2 | PASS | — | — |
+| 3 | AMEND | "40%" in source but "80%" in tailored | Change to "40%" |
+| 4 | STRIKE | "GraphQL" not found in cv.md | Remove from skills |
+```
+
+### Step C — Apply Fixes
+
+1. Apply all AMEND corrections to the tailored markdown
+2. Remove all STRIKE'd claims from the tailored markdown
+3. Re-check that the CV still flows naturally after removals
+4. Record the grounding summary for the report:
    ```
-   The export URL is a pre-signed S3 link that expires in ~2 hours. Download it right away.
-c. Verify the download:
-   ```bash
-   file output/cv-{candidate}-{company}-canva-{YYYY-MM-DD}.pdf
+   Grounding: {N} claims — {P} PASS, {A} AMEND, {S} STRIKE
    ```
-   Must show "PDF document". If it shows XML or HTML, the URL expired — re-export and retry.
-d. Report: PDF path, file size, Canva design URL (for manual tweaking)
 
-#### Error handling
+### Key Principle
 
-- If `import-design-from-url` fails → fall back to HTML/PDF pipeline with message
-- If text elements can't be mapped → warn user, show what was found, ask for manual mapping
-- If `find_and_replace_text` finds no matches → try broader substring matching
-- Always provide the Canva design URL so the user can edit manually if auto-edit fails
+Building the evidence map **during generation** is the primary guardrail — you can't cite what doesn't exist. The judge pass is the safety net, not the primary mechanism. If the composer does its job well, the judge should find zero issues.
 
-## Post-generación
+---
 
-Actualizar tracker si la oferta ya está registrada: cambiar PDF de ❌ a ✅.
+## Keyword Injection (ethical, truth-based)
+
+Examples of legitimate reformulation:
+- JD says "RAG pipelines" and CV says "LLM workflows with retrieval" → change to "RAG pipeline design and LLM orchestration workflows"
+- JD says "MLOps" and CV says "observability, evals, error handling" → change to "MLOps and observability: evals, error handling, cost monitoring"
+- JD says "stakeholder management" and CV says "collaborated with team" → change to "stakeholder management across engineering, operations, and business"
+
+**NEVER add skills the candidate doesn't have. Only reformulate real experience using the exact vocabulary of the JD.**
+
+## Post-generation
+
+Update tracker if the offer is already registered: change PDF from ❌ to ✅.

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -1,57 +1,57 @@
-# Modo: pipeline — Inbox de URLs (Second Brain)
+# Mode: pipeline — URL Inbox (Second Brain)
 
-Procesa URLs de ofertas acumuladas en `data/pipeline.md`. El usuario agrega URLs cuando quiera y luego ejecuta `/career-ops pipeline` para procesarlas todas.
+Processes offer URLs accumulated in `data/pipeline.md`. The user adds URLs whenever they want and then runs `/career-ops pipeline` to process them all.
 
 ## Workflow
 
-1. **Leer** `data/pipeline.md` → buscar items `- [ ]` en la sección "Pendientes"
-2. **Para cada URL pendiente**:
-   a. Calcular siguiente `REPORT_NUM` secuencial (leer `reports/`, tomar el número más alto + 1)
-   b. **Extraer JD** usando Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
-   c. Si la URL no es accesible → marcar como `- [!]` con nota y continuar
-   d. **Ejecutar auto-pipeline completo**: Evaluación A-F → Report .md → PDF (si score >= 3.0) → Tracker
-   e. **Mover de "Pendientes" a "Procesadas"**: `- [x] #NNN | URL | Empresa | Rol | Score/5 | PDF ✅/❌`
-3. **Si hay 3+ URLs pendientes**, lanzar agentes en paralelo (Agent tool con `run_in_background`) para maximizar velocidad.
-4. **Al terminar**, mostrar tabla resumen:
+1. **Read** `data/pipeline.md` → find `- [ ]` items in the "Pending" section
+2. **For each pending URL**:
+   a. Calculate the next sequential `REPORT_NUM` (read `reports/`, take the highest number + 1)
+   b. **Extract JD** using Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
+   c. If the URL is not accessible → mark as `- [!]` with a note and continue
+   d. **Run the full auto-pipeline**: Evaluation A-F → Report .md → PDF (if score >= 3.0) → Tracker
+   e. **Move from "Pending" to "Processed"**: `- [x] #NNN | URL | Company | Role | Score/5 | PDF ✅/❌`
+3. **If there are 3+ pending URLs**, launch agents in parallel (Agent tool with `run_in_background`) to maximize speed.
+4. **When finished**, show a summary table:
 
 ```
-| # | Empresa | Rol | Score | PDF | Acción recomendada |
+| # | Company | Role | Score | PDF | Recommended Action |
 ```
 
-## Formato de pipeline.md
+## pipeline.md Format
 
 ```markdown
-## Pendientes
+## Pending
 - [ ] https://jobs.example.com/posting/123
 - [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
 - [!] https://private.url/job — Error: login required
 
-## Procesadas
+## Processed
 - [x] #143 | https://jobs.example.com/posting/789 | Acme Corp | AI PM | 4.2/5 | PDF ✅
 - [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF ❌
 ```
 
-## Detección inteligente de JD desde URL
+## Smart JD Detection from URL
 
-1. **Playwright (preferido):** `browser_navigate` + `browser_snapshot`. Funciona con todas las SPAs.
-2. **WebFetch (fallback):** Para páginas estáticas o cuando Playwright no está disponible.
-3. **WebSearch (último recurso):** Buscar en portales secundarios que indexan el JD.
+1. **Playwright (preferred):** `browser_navigate` + `browser_snapshot`. Works with all SPAs.
+2. **WebFetch (fallback):** For static pages or when Playwright is unavailable.
+3. **WebSearch (last resort):** Search on secondary portals that index the JD.
 
-**Casos especiales:**
-- **LinkedIn**: Puede requerir login → marcar `[!]` y pedir al usuario que pegue el texto
-- **PDF**: Si la URL apunta a un PDF, leerlo directamente con Read tool
-- **`local:` prefix**: Leer el archivo local. Ejemplo: `local:jds/linkedin-pm-ai.md` → leer `jds/linkedin-pm-ai.md`
+**Special cases:**
+- **LinkedIn**: May require login → mark `[!]` and ask the user to paste the text
+- **PDF**: If the URL points to a PDF, read it directly with the Read tool
+- **`local:` prefix**: Read the local file. Example: `local:jds/linkedin-pm-ai.md` → read `jds/linkedin-pm-ai.md`
 
-## Numeración automática
+## Automatic Numbering
 
-1. Listar todos los archivos en `reports/`
-2. Extraer el número del prefijo (e.g., `142-medispend...` → 142)
-3. Nuevo número = máximo encontrado + 1
+1. List all files in `reports/`
+2. Extract the number from the prefix (e.g., `142-medispend...` → 142)
+3. New number = highest found + 1
 
-## Sincronización de fuentes
+## Source Synchronization
 
-Antes de procesar cualquier URL, verificar sync:
+Before processing any URL, verify sync:
 ```bash
 node cv-sync-check.mjs
 ```
-Si hay desincronización, advertir al usuario antes de continuar.
+If there's a desynchronization, warn the user before continuing.

--- a/modes/project.md
+++ b/modes/project.md
@@ -1,30 +1,30 @@
-# Modo: project — Evaluación de Proyecto Portfolio
+# Mode: project — Portfolio Project Evaluation
 
-Scoring 6 dimensiones (1-5):
+Scoring across 6 dimensions (1-5):
 
-| Dimensión | Peso | 5 = ... | 1 = ... |
-|-----------|------|---------|---------|
-| Señal para roles target | 25% | Directamente demuestra skill del JD | No relacionado |
-| Unicidad | 20% | Nadie ha hecho esto | Todo el mundo lo tiene |
-| Demo-ability | 20% | Live demo en 2 min | Solo código, no visual |
-| Potencial de métricas | 15% | Métricas claras (latency, cost, accuracy) | Sin métricas posibles |
-| Tiempo a MVP | 10% | 1 semana | 3+ meses |
-| Potencial de historia STAR | 10% | Historia rica con trade-offs | Solo implementación |
+| Dimension | Weight | 5 = ... | 1 = ... |
+|-----------|--------|---------|---------|
+| Signal for target roles | 25% | Directly demonstrates a JD skill | Unrelated |
+| Uniqueness | 20% | Nobody has done this | Everyone has it |
+| Demo-ability | 20% | Live demo in 2 min | Code only, not visual |
+| Metrics potential | 15% | Clear metrics (latency, cost, accuracy) | No measurable metrics |
+| Time to MVP | 10% | 1 week | 3+ months |
+| STAR story potential | 10% | Rich story with trade-offs | Just implementation |
 
-## Requisitos de "Interview Pack"
+## "Interview Pack" Requirements
 
-Para cada proyecto aprobado:
-1. **One-pager**: producto + arquitectura + métricas + plan de evaluación
-2. **Demo**: URL live o walkthrough grabado de 2 min
-3. **Postmortem**: qué funcionó, qué no, mitigaciones
+For each approved project:
+1. **One-pager**: product + architecture + metrics + evaluation plan
+2. **Demo**: live URL or 2-min recorded walkthrough
+3. **Postmortem**: what worked, what didn't, mitigations
 
-## Plan 80/20
+## 80/20 Plan
 
-- Semana 1 → MVP con métrica core
-- Semana 2 → polish + interview pack
+- Week 1 → MVP with core metric
+- Week 2 → polish + interview pack
 
-## Veredictos
+## Verdicts
 
-- **CONSTRUIR** → plan con milestones semanales
-- **SKIP** → por qué y qué hacer en su lugar
-- **PIVOTAR A [alternativa]** → variante más impactante
+- **BUILD** → plan with weekly milestones
+- **SKIP** → why, and what to do instead
+- **PIVOT TO [alternative]** → more impactful variant

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -1,193 +1,172 @@
-# Modo: scan — Portal Scanner (Descubrimiento de Ofertas)
+# Mode: scan — Portal Scanner (Offer Discovery)
 
-Escanea portales de empleo configurados, filtra por relevancia de título, y añade nuevas ofertas al pipeline para evaluación posterior.
+Scans configured job portals, filters by title relevance, and adds new offers to the pipeline for later evaluation.
 
-## Ejecución recomendada
+## Recommended Execution
 
-Ejecutar como subagente para no consumir contexto del main:
+Run as a subagent to avoid consuming main context:
 
 ```
 Agent(
     subagent_type="general-purpose",
-    prompt="[contenido de este archivo + datos específicos]",
+    prompt="[contents of this file + specific data]",
     run_in_background=True
 )
 ```
 
-## Configuración
+## Configuration
 
-Leer `portals.yml` que contiene:
-- `search_queries`: Lista de queries WebSearch con `site:` filters por portal (descubrimiento amplio)
-- `tracked_companies`: Empresas específicas con `careers_url` para navegación directa
-- `title_filter`: Keywords positive/negative/seniority_boost para filtrado de títulos
+Read `portals.yml` which contains:
+- `search_queries`: List of WebSearch queries with `site:` filters per portal (broad discovery)
+- `tracked_companies`: Specific companies with `careers_url` for direct navigation
+- `title_filter`: Positive/negative/seniority_boost keywords for title filtering
 
-## Estrategia de descubrimiento (3 niveles)
+## Discovery Strategy (3 levels)
 
-### Nivel 1 — Playwright directo (PRINCIPAL)
+### Level 1 — Direct Playwright (PRIMARY)
 
-**Para cada empresa en `tracked_companies`:** Navegar a su `careers_url` con Playwright (`browser_navigate` + `browser_snapshot`), leer TODOS los job listings visibles, y extraer título + URL de cada uno. Este es el método más fiable porque:
-- Ve la página en tiempo real (no resultados cacheados de Google)
-- Funciona con SPAs (Ashby, Lever, Workday)
-- Detecta ofertas nuevas al instante
-- No depende de la indexación de Google
+**For each company in `tracked_companies`:** Navigate to its `careers_url` with Playwright (`browser_navigate` + `browser_snapshot`), read ALL visible job listings, and extract the title + URL of each one. This is the most reliable method because:
+- It sees the page in real time (not cached Google results)
+- Works with SPAs (Ashby, Lever, Workday)
+- Detects new offers instantly
+- Doesn't depend on Google indexing
 
-**Cada empresa DEBE tener `careers_url` en portals.yml.** Si no la tiene, buscarla una vez, guardarla, y usar en futuros scans.
+**Every company MUST have a `careers_url` in portals.yml.** If it doesn't have one, look it up once, save it, and use it in future scans.
 
-### Nivel 2 — Greenhouse API (COMPLEMENTARIO)
+### Level 2 — Greenhouse API (COMPLEMENTARY)
 
-Para empresas con Greenhouse, la API JSON (`boards-api.greenhouse.io/v1/boards/{slug}/jobs`) devuelve datos estructurados limpios. Usar como complemento rápido de Nivel 1 — es más rápido que Playwright pero solo funciona con Greenhouse.
+For companies using Greenhouse, the JSON API (`boards-api.greenhouse.io/v1/boards/{slug}/jobs`) returns clean structured data. Use as a quick complement to Level 1 — it's faster than Playwright but only works with Greenhouse.
 
-### Nivel 3 — WebSearch queries (DESCUBRIMIENTO AMPLIO)
+### Level 3 — WebSearch Queries (BROAD DISCOVERY)
 
-Los `search_queries` con `site:` filters cubren portales de forma transversal (todos los Ashby, todos los Greenhouse, etc.). Útil para descubrir empresas NUEVAS que aún no están en `tracked_companies`, pero los resultados pueden estar desfasados.
+The `search_queries` with `site:` filters cover portals broadly (all Ashby, all Greenhouse, etc.). Useful for discovering NEW companies not yet in `tracked_companies`, but results may be stale.
 
-**Prioridad de ejecución:**
-1. Nivel 1: Playwright → todas las `tracked_companies` con `careers_url`
-2. Nivel 2: API → todas las `tracked_companies` con `api:`
-3. Nivel 3: WebSearch → todos los `search_queries` con `enabled: true`
+**Execution priority:**
+1. Level 1: Playwright → all `tracked_companies` with `careers_url`
+2. Level 2: API → all `tracked_companies` with `api:`
+3. Level 3: WebSearch → all `search_queries` with `enabled: true`
 
-Los niveles son aditivos — se ejecutan todos, los resultados se mezclan y deduplicar.
+The levels are additive — all are executed, results are merged and deduplicated.
 
 ## Workflow
 
-1. **Leer configuración**: `portals.yml`
-2. **Leer historial**: `data/scan-history.tsv` → URLs ya vistas
-3. **Leer dedup sources**: `data/applications.md` + `data/pipeline.md`
+1. **Read configuration**: `portals.yml`
+2. **Read history**: `data/scan-history.tsv` → already-seen URLs
+3. **Read dedup sources**: `data/applications.md` + `data/pipeline.md`
 
-4. **Nivel 1 — Playwright scan** (paralelo en batches de 3-5):
-   Para cada empresa en `tracked_companies` con `enabled: true` y `careers_url` definida:
-   a. `browser_navigate` a la `careers_url`
-   b. `browser_snapshot` para leer todos los job listings
-   c. Si la página tiene filtros/departamentos, navegar las secciones relevantes
-   d. Para cada job listing extraer: `{title, url, company}`
-   e. Si la página pagina resultados, navegar páginas adicionales
-   f. Acumular en lista de candidatos
-   g. Si `careers_url` falla (404, redirect), intentar `scan_query` como fallback y anotar para actualizar la URL
+4. **Level 1 — Playwright scan** (parallel in batches of 3-5):
+   For each company in `tracked_companies` with `enabled: true` and `careers_url` defined:
+   a. `browser_navigate` to the `careers_url`
+   b. `browser_snapshot` to read all job listings
+   c. If the page has filters/departments, navigate the relevant sections
+   d. For each job listing extract: `{title, url, company}`
+   e. If the page paginates results, navigate additional pages
+   f. Accumulate in the candidates list
+   g. If `careers_url` fails (404, redirect), try `scan_query` as fallback and note the URL needs updating
 
-5. **Nivel 2 — Greenhouse APIs** (paralelo):
-   Para cada empresa en `tracked_companies` con `api:` definida y `enabled: true`:
-   a. WebFetch de la URL de API → JSON con lista de jobs
-   b. Para cada job extraer: `{title, url, company}`
-   c. Acumular en lista de candidatos (dedup con Nivel 1)
+5. **Level 2 — Greenhouse APIs** (parallel):
+   For each company in `tracked_companies` with `api:` defined and `enabled: true`:
+   a. WebFetch the API URL → JSON with job list
+   b. For each job extract: `{title, url, company}`
+   c. Accumulate in the candidates list (dedup with Level 1)
 
-6. **Nivel 3 — WebSearch queries** (paralelo si posible):
-   Para cada query en `search_queries` con `enabled: true`:
-   a. Ejecutar WebSearch con el `query` definido
-   b. De cada resultado extraer: `{title, url, company}`
-      - **title**: del título del resultado (antes del " @ " o " | ")
-      - **url**: URL del resultado
-      - **company**: después del " @ " en el título, o extraer del dominio/path
-   c. Acumular en lista de candidatos (dedup con Nivel 1+2)
+6. **Level 3 — WebSearch queries** (parallel if possible):
+   For each query in `search_queries` with `enabled: true`:
+   a. Execute WebSearch with the defined `query`
+   b. From each result extract: `{title, url, company}`
+      - **title**: from the result title (before " @ " or " | ")
+      - **url**: URL of the result
+      - **company**: after " @ " in the title, or extract from domain/path
+   c. Accumulate in the candidates list (dedup with Level 1+2)
 
-6. **Filtrar por título** usando `title_filter` de `portals.yml`:
-   - Al menos 1 keyword de `positive` debe aparecer en el título (case-insensitive)
-   - 0 keywords de `negative` deben aparecer
-   - `seniority_boost` keywords dan prioridad pero no son obligatorios
+6. **Filter by title** using `title_filter` from `portals.yml`:
+   - At least 1 keyword from `positive` must appear in the title (case-insensitive)
+   - 0 keywords from `negative` must appear
+   - `seniority_boost` keywords give priority but are not required
 
-7. **Deduplicar** contra 3 fuentes:
-   - `scan-history.tsv` → URL exacta ya vista
-   - `applications.md` → empresa + rol normalizado ya evaluado
-   - `pipeline.md` → URL exacta ya en pendientes o procesadas
+7. **Deduplicate** against 3 sources:
+   - `scan-history.tsv` → exact URL already seen
+   - `applications.md` → normalized company + role already evaluated
+   - `pipeline.md` → exact URL already in pending or processed
 
-7.5. **Verificar liveness de resultados de WebSearch (Nivel 3)** — ANTES de añadir a pipeline:
+8. **For each new offer that passes filters**:
+   a. Add to `pipeline.md` "Pending" section: `- [ ] {url} | {company} | {title}`
+   b. Register in `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
 
-   Los resultados de WebSearch pueden estar desactualizados (Google cachea resultados durante semanas o meses). Para evitar evaluar ofertas expiradas, verificar con Playwright cada URL nueva que provenga del Nivel 3. Los Niveles 1 y 2 son inherentemente en tiempo real y no requieren esta verificación.
+9. **Offers filtered by title**: register in `scan-history.tsv` with status `skipped_title`
+10. **Duplicate offers**: register with status `skipped_dup`
 
-   Para cada URL nueva de Nivel 3 (secuencial — NUNCA Playwright en paralelo):
-   a. `browser_navigate` a la URL
-   b. `browser_snapshot` para leer el contenido
-   c. Clasificar:
-      - **Activa**: título del puesto visible + descripción del rol + botón Apply/Submit/Solicitar
-      - **Expirada** (cualquiera de estas señales):
-        - URL final contiene `?error=true` (Greenhouse redirige así cuando la oferta está cerrada)
-        - Página contiene: "job no longer available" / "no longer open" / "position has been filled" / "this job has expired" / "page not found"
-        - Solo navbar y footer visibles, sin contenido JD (contenido < ~300 chars)
-   d. Si expirada: registrar en `scan-history.tsv` con status `skipped_expired` y descartar
-   e. Si activa: continuar al paso 8
+## Extracting Title and Company from WebSearch Results
 
-   **No interrumpir el scan entero si una URL falla.** Si `browser_navigate` da error (timeout, 403, etc.), marcar como `skipped_expired` y continuar con la siguiente.
+WebSearch results come in the format: `"Job Title @ Company"` or `"Job Title | Company"` or `"Job Title — Company"`.
 
-8. **Para cada oferta nueva verificada que pase filtros**:
-   a. Añadir a `pipeline.md` sección "Pendientes": `- [ ] {url} | {company} | {title}`
-   b. Registrar en `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
-
-9. **Ofertas filtradas por título**: registrar en `scan-history.tsv` con status `skipped_title`
-10. **Ofertas duplicadas**: registrar con status `skipped_dup`
-11. **Ofertas expiradas (Nivel 3)**: registrar con status `skipped_expired`
-
-## Extracción de título y empresa de WebSearch results
-
-Los resultados de WebSearch vienen en formato: `"Job Title @ Company"` o `"Job Title | Company"` o `"Job Title — Company"`.
-
-Patrones de extracción por portal:
+Extraction patterns by portal:
 - **Ashby**: `"Senior AI PM (Remote) @ EverAI"` → title: `Senior AI PM`, company: `EverAI`
 - **Greenhouse**: `"AI Engineer at Anthropic"` → title: `AI Engineer`, company: `Anthropic`
 - **Lever**: `"Product Manager - AI @ Temporal"` → title: `Product Manager - AI`, company: `Temporal`
 
-Regex genérico: `(.+?)(?:\s*[@|—–-]\s*|\s+at\s+)(.+?)$`
+Generic regex: `(.+?)(?:\s*[@|—–-]\s*|\s+at\s+)(.+?)$`
 
-## URLs privadas
+## Private URLs
 
-Si se encuentra una URL no accesible públicamente:
-1. Guardar el JD en `jds/{company}-{role-slug}.md`
-2. Añadir a pipeline.md como: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title}`
+If a publicly inaccessible URL is found:
+1. Save the JD to `jds/{company}-{role-slug}.md`
+2. Add to pipeline.md as: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title}`
 
 ## Scan History
 
-`data/scan-history.tsv` trackea TODAS las URLs vistas:
+`data/scan-history.tsv` tracks ALL seen URLs:
 
 ```
 url	first_seen	portal	title	company	status
 https://...	2026-02-10	Ashby — AI PM	PM AI	Acme	added
 https://...	2026-02-10	Greenhouse — SA	Junior Dev	BigCo	skipped_title
 https://...	2026-02-10	Ashby — AI PM	SA AI	OldCo	skipped_dup
-https://...	2026-02-10	WebSearch — AI PM	PM AI	ClosedCo	skipped_expired
 ```
 
-## Resumen de salida
+## Output Summary
 
 ```
 Portal Scan — {YYYY-MM-DD}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━
-Queries ejecutados: N
-Ofertas encontradas: N total
-Filtradas por título: N relevantes
-Duplicadas: N (ya evaluadas o en pipeline)
-Expiradas descartadas: N (links muertos, Nivel 3)
-Nuevas añadidas a pipeline.md: N
+Queries executed: N
+Offers found: N total
+Filtered by title: N relevant
+Duplicates: N (already evaluated or in pipeline)
+New additions to pipeline.md: N
 
   + {company} | {title} | {query_name}
   ...
 
-→ Ejecuta /career-ops pipeline para evaluar las nuevas ofertas.
+→ Run /career-ops pipeline to evaluate the new offers.
 ```
 
-## Gestión de careers_url
+## Managing careers_url
 
-Cada empresa en `tracked_companies` debe tener `careers_url` — la URL directa a su página de ofertas. Esto evita buscarlo cada vez.
+Every company in `tracked_companies` should have a `careers_url` — the direct URL to their job listings page. This avoids looking it up each time.
 
-**Patrones conocidos por plataforma:**
+**Known patterns by platform:**
 - **Ashby:** `https://jobs.ashbyhq.com/{slug}`
-- **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` o `https://job-boards.eu.greenhouse.io/{slug}`
+- **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` or `https://job-boards.eu.greenhouse.io/{slug}`
 - **Lever:** `https://jobs.lever.co/{slug}`
-- **Custom:** La URL propia de la empresa (ej: `https://openai.com/careers`)
+- **Custom:** The company's own URL (e.g., `https://openai.com/careers`)
 
-**Si `careers_url` no existe** para una empresa:
-1. Intentar el patrón de su plataforma conocida
-2. Si falla, hacer un WebSearch rápido: `"{company}" careers jobs`
-3. Navegar con Playwright para confirmar que funciona
-4. **Guardar la URL encontrada en portals.yml** para futuros scans
+**If `careers_url` doesn't exist** for a company:
+1. Try its known platform pattern
+2. If that fails, do a quick WebSearch: `"{company}" careers jobs`
+3. Navigate with Playwright to confirm it works
+4. **Save the found URL in portals.yml** for future scans
 
-**Si `careers_url` devuelve 404 o redirect:**
-1. Anotar en el resumen de salida
-2. Intentar scan_query como fallback
-3. Marcar para actualización manual
+**If `careers_url` returns a 404 or redirect:**
+1. Note it in the output summary
+2. Try scan_query as fallback
+3. Flag for manual update
 
-## Mantenimiento del portals.yml
+## portals.yml Maintenance
 
-- **SIEMPRE guardar `careers_url`** cuando se añade una empresa nueva
-- Añadir nuevos queries según se descubran portales o roles interesantes
-- Desactivar queries con `enabled: false` si generan demasiado ruido
-- Ajustar keywords de filtrado según evolucionen los roles target
-- Añadir empresas a `tracked_companies` cuando interese seguirlas de cerca
-- Verificar `careers_url` periódicamente — las empresas cambian de plataforma ATS
+- **ALWAYS save `careers_url`** when adding a new company
+- Add new queries as new portals or interesting roles are discovered
+- Disable queries with `enabled: false` if they generate too much noise
+- Adjust filtering keywords as target roles evolve
+- Add companies to `tracked_companies` when they're worth following closely
+- Verify `careers_url` periodically — companies change ATS platforms

--- a/modes/tracker.md
+++ b/modes/tracker.md
@@ -1,23 +1,23 @@
-# Modo: tracker — Tracker de Aplicaciones
+# Mode: tracker — Application Tracker
 
-Lee y muestra `data/applications.md`.
+Reads and displays `data/applications.md`.
 
-**Formato del tracker:**
+**Tracker format:**
 ```markdown
-| # | Fecha | Empresa | Rol | Score | Estado | PDF | Report |
+| # | Date | Company | Role | Score | Status | PDF | Report |
 ```
 
-Estados posibles: `Evaluada` → `Aplicado` → `Respondido` → `Contacto` → `Entrevista` → `Oferta` / `Rechazada` / `Descartada` / `NO APLICAR`
+Possible statuses: `Evaluated` → `Applied` → `Responded` → `Contact` → `Interview` → `Offer` / `Rejected` / `Discarded` / `DO NOT APPLY`
 
-- `Aplicado` = el candidato envió su candidatura
-- `Respondido` = Un recruiter/empresa contactó y el candidato respondió (inbound)
-- `Contacto` = El candidato contactó proactivamente a alguien de la empresa (outbound, ej: LinkedIn power move)
+- `Applied` = the candidate submitted their application
+- `Responded` = a recruiter/company reached out and the candidate replied (inbound)
+- `Contact` = the candidate proactively reached out to someone at the company (outbound, e.g., LinkedIn power move)
 
-Si el usuario pide actualizar un estado, editar la fila correspondiente.
+If the user asks to update a status, edit the corresponding row.
 
-Mostrar también estadísticas:
-- Total de aplicaciones
-- Por estado
-- Score promedio
-- % con PDF generado
-- % con report generado
+Also show statistics:
+- Total applications
+- By status
+- Average score
+- % with PDF generated
+- % with report generated

--- a/modes/training.md
+++ b/modes/training.md
@@ -1,27 +1,27 @@
-# Modo: training — Evaluación de Formación
+# Mode: training — Training Evaluation
 
-Para cada curso/cert que el candidato pregunte, evaluar 6 dimensiones:
+For each course/certification the candidate asks about, evaluate across 6 dimensions:
 
-| Dimensión | Qué evalúa |
-|-----------|------------|
-| Alineación North Star | ¿Acerca o aleja del objetivo? |
-| Señal recruiter | ¿Qué piensan HMs al ver esto en un CV? |
-| Tiempo y esfuerzo | Semanas × horas/semana |
-| Coste de oportunidad | ¿Qué no puede hacer durante ese tiempo? |
-| Riesgos | ¿Contenido outdated? ¿Brand débil? ¿Demasiado básico? |
-| Entregable portfolio | ¿Produce un artefacto demostrable? |
+| Dimension | What it evaluates |
+|-----------|-------------------|
+| North Star Alignment | Does it move closer to or further from the goal? |
+| Recruiter Signal | What do HMs think when they see this on a CV? |
+| Time and Effort | Weeks x hours/week |
+| Opportunity Cost | What can't be done during that time? |
+| Risks | Outdated content? Weak brand? Too basic? |
+| Portfolio Deliverable | Does it produce a demonstrable artifact? |
 
-## Veredictos
+## Verdicts
 
-- **HACER** → plan de 4-12 semanas con entregables semanales y scoreboard
-- **NO HACER** → alternativa mejor con justificación
-- **HACER CON TIMEBOX** (máx X semanas) → plan condensado, solo lo esencial
+- **DO IT** → 4-12 week plan with weekly deliverables and scoreboard
+- **DON'T DO IT** → better alternative with justification
+- **DO IT WITH TIMEBOX** (max X weeks) → condensed plan, essentials only
 
-## Prioridad
+## Priority
 
-Formación que mejore credibilidad en "production-grade AI":
-1. Evals y testing de LLMs
-2. Observability y monitoring
+Training that improves credibility in "production-grade AI":
+1. LLM evals and testing
+2. Observability and monitoring
 3. Cost/reliability trade-offs
-4. AI governance y safety
+4. AI governance and safety
 5. Enterprise AI architecture

--- a/templates/cv-template.tex
+++ b/templates/cv-template.tex
@@ -1,0 +1,57 @@
+\documentclass[10pt,a4paper]{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+\usepackage[margin=0.5in]{geometry}
+\usepackage{enumitem}
+\usepackage{titlesec}
+\usepackage{hyperref}
+\usepackage{xcolor}
+\usepackage{longtable,booktabs}
+
+% Colors — all black, no blue
+\definecolor{text}{HTML}{000000}
+\definecolor{muted}{HTML}{444444}
+
+% No section numbering
+\setcounter{secnumdepth}{0}
+
+% Section formatting
+\titleformat{\section}{\large\bfseries\color{text}}{}{0em}{}[\titlerule]
+\titleformat{\subsection}{\normalsize\bfseries\color{text}}{}{0em}{}
+\titleformat{\subsubsection}{\normalsize\bfseries\color{text}}{}{0em}{}
+\titlespacing{\section}{0pt}{8pt}{4pt}
+\titlespacing{\subsection}{0pt}{6pt}{3pt}
+\titlespacing{\subsubsection}{0pt}{4pt}{2pt}
+
+% Remove page numbers
+\pagestyle{empty}
+
+% Hyperlink setup — no colored links, just black text
+\hypersetup{
+    colorlinks=true,
+    linkcolor=text,
+    urlcolor=text
+}
+
+% Allow URL line breaks at any character
+\expandafter\def\expandafter\UrlBreaks\expandafter{\UrlBreaks\do\/\do\-\do\.}
+
+% List styling
+\setlist[itemize]{nosep, leftmargin=1.5em}
+
+% Tight spacing
+\setlength{\parskip}{2pt}
+\setlength{\parindent}{0pt}
+
+% Pandoc tightlist support
+\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
+\color{text}
+
+\begin{document}
+
+$body$
+
+\end{document}


### PR DESCRIPTION
…grounding

- Translate all 14 mode files from Spanish to English
- Replace HTML/Puppeteer PDF pipeline with Pandoc + pdflatex
- Add LaTeX template (cv-template.tex) with clean academic styling
- Add thesis defence grounding validation: composer must prove each claim with cv.md line citations, judge cross-examines for fabricated qualifiers, scope inflation, verb escalation
- Enforce 1-page CV constraint with fallback hierarchy (merge edu+lang → reduce margins → shorten wording → last resort: cut)
- Update archetypes for EM/Head of AI/AI Adoption Lead/Founder roles
- Add anti-inflation rules: no fabricated qualifiers (C-level etc.), no scope inflation (contributing ≠ leading), no causal inflation