### PR TITLE
Add Brazilian Portuguese language modes (modes/pt/)

### DIFF
--- a/modes/pt/README.md
+++ b/modes/pt/README.md
@@ -1,0 +1,111 @@
+# career-ops -- Modos em Portugues BR (`modes/pt/`)
+
+Esta pasta contem as traducoes em portugues brasileiro dos principais modos do career-ops para candidatos que buscam vagas no mercado brasileiro ou em empresas que operam em portugues.
+
+## Quando usar estes modos?
+
+Use `modes/pt/` se pelo menos uma das condicoes abaixo for verdadeira:
+
+- Voce se candidata principalmente a **vagas em portugues** (Gupy, Greenhouse BR, LinkedIn BR, Vagas.com.br, Catho, InfoJobs)
+- Sua **lingua do curriculo** e portugues ou voce alterna entre PT-BR e EN conforme a vaga
+- Voce precisa de respostas e cartas de apresentacao em **portugues tech natural**, nao traduzido por maquina
+- Voce precisa lidar com **especificidades do mercado brasileiro**: CLT vs PJ, 13o salario, FGTS, PLR, vale-refeicao, plano de saude, aviso previo, periodo de experiencia
+
+Se a maioria das suas vagas e em ingles, fique com os modos padrao em `modes/`. Os modos em ingles funcionam automaticamente quando Claude detecta uma vaga em portugues — mas nao conhecem as particularidades do mercado brasileiro no mesmo nivel de detalhe.
+
+## Como ativar?
+
+O career-ops nao tem um "switch de idioma" como flag de codigo. Em vez disso, existem dois caminhos:
+
+### Caminho 1 -- Por sessao, via comando
+
+Diga ao Claude no inicio da sessao:
+
+> "Use os modos em portugues de `modes/pt/`."
+
+ou
+
+> "Avaliar e candidaturas em portugues -- use `modes/pt/_shared.md` e `modes/pt/oferta.md`."
+
+Claude vai ler os arquivos desta pasta em vez de `modes/`.
+
+### Caminho 2 -- Permanente, via perfil
+
+Adicione em `config/profile.yml` uma preferencia de idioma:
+
+```yaml
+language:
+  primary: pt-br
+  modes_dir: modes/pt
+```
+
+Lembre o Claude na primeira sessao de respeitar esse campo ("Olha no `profile.yml`, eu configurei `language.modes_dir`"). A partir dai, Claude usa automaticamente os modos em portugues.
+
+> Nota: O campo `language.modes_dir` e uma convencao, nao um schema rigido. Se os mantenedores quiserem estruturar diferente, o campo pode ser renomeado a qualquer momento.
+
+## O que foi traduzido?
+
+Esta primeira iteracao cobre os quatro modos com maior impacto:
+
+| Arquivo | Traduzido de | Finalidade |
+|---------|-------------|------------|
+| `_shared.md` | `modes/_shared.md` (EN) | Contexto compartilhado, arquetipos, regras globais, especificidades do mercado BR |
+| `oferta.md` | `modes/oferta.md` (ES) | Avaliacao completa de uma vaga (Blocos A-F) |
+| `aplicar.md` | `modes/apply.md` (EN) | Assistente ao vivo para formularios de candidatura |
+| `pipeline.md` | `modes/pipeline.md` (ES) | Inbox de URLs / Second Brain para vagas acumuladas |
+
+Os demais modos (`scan`, `batch`, `pdf`, `tracker`, `auto-pipeline`, `deep`, `contacto`, `ofertas`, `project`, `training`) nao estao neste PR de proposito. Eles continuam funcionando via os originais em EN/ES, pois seu conteudo e majoritariamente tooling, caminhos e comandos de configuracao — que devem ser independentes de idioma.
+
+Se a comunidade adotar os modos em portugues, mais modos serao traduzidos em PRs futuros.
+
+## O que continua em ingles?
+
+Propositalmente nao traduzido, porque e vocabulario padrao de tech:
+
+- `cv.md`, `pipeline`, `tracker`, `report`, `score`, `archetype`, `proof point`
+- Nomes de tools (`Playwright`, `WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`)
+- Valores de status no tracker (`Evaluated`, `Applied`, `Interview`, `Offer`, `Rejected`)
+- Code snippets, caminhos de arquivo, comandos
+
+Os modos usam portugues tech brasileiro, como se fala em times de engenharia reais em Sao Paulo, Florianopolis ou Belo Horizonte: texto corrido em portugues, termos tecnicos em ingles onde sao de uso comum. Nada de traduzir "pipeline" para "tubulacao" ou "cv.md" para "curriculo.md".
+
+## Vocabulario de Referencia
+
+Se voce for adaptar ou expandir os modos, siga este vocabulario para manter a consistencia de tom:
+
+| Ingles | Portugues BR (nesta codebase) |
+|--------|-------------------------------|
+| Job posting | Vaga / Descricao da vaga |
+| Application | Candidatura |
+| Cover letter | Carta de apresentacao |
+| Resume / CV | Curriculo |
+| Salary | Salario / Remuneracao |
+| Compensation | Remuneracao |
+| Skills | Habilidades / Competencias |
+| Interview | Entrevista |
+| Hiring manager | Gestor da vaga / Hiring manager |
+| Recruiter | Recrutador(a) |
+| AI | IA (Inteligencia Artificial) |
+| Requirements | Requisitos |
+| Career history | Trajetoria profissional / Experiencia |
+| Notice period | Aviso previo |
+| Probation | Periodo de experiencia |
+| Vacation | Ferias |
+| 13th month salary | 13o salario |
+| Formal employment (CLT) | CLT / Carteira assinada |
+| Contractor (PJ) | PJ (Pessoa Juridica) |
+| Profit sharing | PLR (Participacao nos Lucros e Resultados) |
+| Health insurance | Plano de saude |
+| Meal voucher | Vale-refeicao / Vale-alimentacao |
+| Severance fund | FGTS (Fundo de Garantia) |
+| Stock options | Stock options (termo ja usado em PT-BR) |
+
+## Contribuir
+
+Se quiser melhorar uma traducao ou traduzir um modo adicional:
+
+1. Abra uma issue com a proposta (conforme `CONTRIBUTING.md`)
+2. Siga o vocabulario acima para manter o tom consistente
+3. Traduza de forma natural e idiomatica — nada de traducao literal palavra por palavra
+4. Mantenha os elementos estruturais (Bloco A-F, tabelas, blocos de codigo, instrucoes de tools) exatamente iguais
+5. Teste com uma vaga real brasileira (ex: do Gupy ou LinkedIn BR) antes de abrir o PR

--- a/modes/pt/_shared.md
+++ b/modes/pt/_shared.md
@@ -1,0 +1,218 @@
+# Contexto Compartilhado -- career-ops (Portugues BR)
+
+<!-- ============================================================
+     THIS FILE IS AUTO-UPDATABLE. Don't put personal data here.
+     
+     Your customizations go in modes/_profile.md (never auto-updated).
+     This file contains system rules, scoring logic, and tool config
+     that improve with each career-ops release.
+     ============================================================ -->
+
+## Fontes da Verdade (SEMPRE ler antes de cada avaliacao)
+
+| Arquivo | Caminho | Quando |
+|---------|---------|--------|
+| cv.md | `cv.md` (raiz do projeto) | SEMPRE |
+| article-digest.md | `article-digest.md` (se existir) | SEMPRE (proof points detalhados) |
+| profile.yml | `config/profile.yml` | SEMPRE (identidade e vagas-alvo) |
+| _profile.md | `modes/_profile.md` | SEMPRE (arquetipos, narrativa, negociacao do usuario) |
+
+**REGRA: NUNCA fazer hardcode de metricas de proof points.** Leia-as de `cv.md` e `article-digest.md` no momento da avaliacao.
+**REGRA: Para metricas de artigos/projetos, `article-digest.md` tem prioridade sobre `cv.md`** (`cv.md` pode conter numeros desatualizados).
+**REGRA: Leia `_profile.md` DEPOIS deste arquivo. As personalizacoes do usuario em `_profile.md` sobrescrevem os valores padrao aqui.**
+
+---
+
+## Sistema de Pontuacao
+
+A avaliacao usa 6 blocos (A-F) com uma nota global de 1-5:
+
+| Dimensao | O que mede |
+|----------|------------|
+| Match com CV | Habilidades, experiencia, alinhamento de proof points |
+| Alinhamento North Star | Quao bem a vaga encaixa nos arquetipos-alvo do usuario (de `_profile.md`) |
+| Remuneracao | Salario vs mercado (5=quartil superior, 1=bem abaixo) |
+| Sinais culturais | Cultura da empresa, crescimento, estabilidade, politica de trabalho remoto |
+| Red flags | Bloqueadores, alertas (ajustes negativos) |
+| **Global** | Media ponderada dos itens acima |
+
+**Interpretacao da nota:**
+- 4.5+ → Match forte, recomendado aplicar imediatamente
+- 4.0-4.4 → Bom match, vale a pena aplicar
+- 3.5-3.9 → Razoavel mas nao ideal, aplicar apenas se houver motivo especifico
+- Abaixo de 3.5 → Recomendado nao aplicar (veja Ethical Use no CLAUDE.md)
+
+## North Star -- Vagas-Alvo
+
+O skill trata TODAS as vagas-alvo com o mesmo cuidado. Nenhuma e primaria ou secundaria — qualquer uma e uma vitoria, desde que a remuneracao e a perspectiva de crescimento estejam adequadas:
+
+| Arquetipo | Eixos tematicos | O que estao comprando |
+|-----------|-----------------|----------------------|
+| **AI Platform / LLMOps Engineer** | Avaliacao, Observability, Confiabilidade, Pipelines | Alguem que coloca IA em producao com metricas |
+| **Agentic Workflows / Automation** | HITL, Tooling, Orquestracao, Multi-Agent | Alguem que constroi sistemas de agentes confiaveis |
+| **Technical AI Product Manager** | GenAI/Agents, PRDs, Discovery, Delivery | Alguem que traduz negocios em produtos de IA |
+| **AI Solutions Architect** | Hiperautomacao, Enterprise, Integracoes | Alguem que projeta arquiteturas de IA de ponta a ponta |
+| **AI Forward Deployed Engineer** | Cliente-proximo, entrega rapida, Prototipagem | Alguem que implanta solucoes de IA rapidamente no cliente |
+| **AI Transformation Lead** | Gestao de mudanca, Adocao, Enablement organizacional | Alguem que lidera transformacao de IA em organizacoes |
+
+<!-- [PERSONALIZAR] Adapte os arquetipos acima para suas vagas-alvo.
+     Exemplo para engenharia backend:
+     - Senior Backend Engineer
+     - Staff Platform Engineer
+     - Engineering Manager
+     etc. -->
+
+### Framing Adaptativo por Arquetipo
+
+> **Metricas concretas: ler de `cv.md` e `article-digest.md` no momento da avaliacao. NUNCA fazer hardcode aqui.**
+
+| Se a vaga e... | Enfatizar no candidato... | Fontes de Proof Points |
+|----------------|--------------------------|------------------------|
+| Platform / LLMOps | Experiencia em producao, Observability, Evals, Closed-Loop | article-digest.md + cv.md |
+| Agentic / Automation | Orquestracao multi-agent, HITL, Confiabilidade, Custos | article-digest.md + cv.md |
+| Technical AI PM | Product Discovery, PRDs, Metricas, Gestao de stakeholders | cv.md + article-digest.md |
+| Solutions Architect | Design de sistemas, Integracoes, Enterprise-ready | article-digest.md + cv.md |
+| Forward Deployed Engineer | Entrega rapida, proximo do cliente, Prototipo a producao | cv.md + article-digest.md |
+| AI Transformation Lead | Gestao de mudanca, Enablement de equipe, Adocao | cv.md + article-digest.md |
+
+<!-- [PERSONALIZAR] Mapeie seus projetos/artigos concretos para os arquetipos acima -->
+
+### Narrativa de Transicao (usar em TODOS os framings)
+
+<!-- [PERSONALIZAR] Substitua pela sua propria narrativa. Exemplos:
+     - "Construi e vendi minha propria SaaS em 5 anos. Agora foco total em IA aplicada no Enterprise."
+     - "Lead de engenharia em uma Series-B durante crescimento 10x. Buscando o proximo desafio."
+     - "Transicao de consultoria para produto. Buscando vagas com alta responsabilidade."
+     Lido de config/profile.yml -> narrative.exit_story -->
+
+Use a narrativa de transicao de `config/profile.yml` para enquadrar TODO o conteudo:
+- **Em PDF Summaries:** Construir a ponte do passado para o futuro — "Aplico as mesmas [habilidades] agora em [dominio do JD]."
+- **Em historias STAR:** Referenciar proof points de `article-digest.md`.
+- **Em respostas rascunho (Bloco G):** A narrativa de transicao vai na primeira resposta.
+- **Quando a vaga menciona "empreendedor", "ownership", "builder", "end-to-end":** Esse e o diferencial numero 1. Aumentar peso de match.
+
+### Vantagem Transversal
+
+Enquadrar o perfil como **"Builder tecnico com pratica comprovada"**, adaptando o framing a vaga:
+- Para PM: "Builder que reduz incerteza com prototipos e depois leva a producao com disciplina"
+- Para FDE: "Builder que entrega desde o dia 1 com observability e metricas"
+- Para SA: "Builder que projeta sistemas end-to-end com experiencia real de integracao"
+- Para LLMOps: "Builder que coloca IA em producao com sistemas de qualidade closed-loop"
+
+Posicionar "Builder" como sinal profissional — nao como "hobbyista". Proof points reais tornam isso credivel.
+
+### Portfolio como Proof Point (usar em candidaturas de alto valor)
+
+<!-- [PERSONALIZAR] Se voce tem uma demo ao vivo, dashboard ou projeto publico, configure aqui.
+     Exemplo:
+     dashboard:
+       url: "https://seudominio.dev/demo"
+       password: "demo-2026"
+       when_to_share: "LLMOps, AI-Platform, vagas de Observability"
+     Lido de config/profile.yml -> narrative.proof_points e narrative.dashboard -->
+
+Quando o candidato tem uma demo ao vivo / dashboard (verificar `profile.yml`), oferecer acesso em candidaturas relevantes.
+
+### Inteligencia de Remuneracao (Comp Intelligence)
+
+<!-- [PERSONALIZAR] Pesquise faixas salariais para suas vagas-alvo e ajuste os valores -->
+
+**Orientacoes gerais:**
+- WebSearch para dados atuais de mercado (Glassdoor, Levels.fyi, Blind)
+- Enquadrar por titulo da vaga, nao por skills — titulos definem as faixas salariais
+- Taxas de freelance geralmente ficam 30-60% acima da hora bruta de CLT (encargos, ferias, FGTS, INSS, contador)
+- Geo-arbitragem funciona em vagas remotas: custo de vida menor = melhor liquido
+
+### Mercado Brasileiro -- Especificidades (IMPORTANTE)
+
+Em vagas e negociacoes brasileiras, existem termos e praticas que nao aparecem nos mercados EN/ES/DE. Eles DEVEM ser avaliados corretamente:
+
+| Termo | Significado | Impacto na Avaliacao |
+|-------|-------------|----------------------|
+| **CLT** (Consolidacao das Leis do Trabalho) | Contrato formal com carteira assinada | Inclui FGTS, INSS, ferias, 13o, aviso previo. Na comparacao, considerar o custo total empregador |
+| **PJ** (Pessoa Juridica) | Contratacao como prestador de servicos (nota fiscal) | Valor mensal mais alto, mas sem beneficios CLT. Calcular equivalente CLT para comparacao justa |
+| **13o Salario** | Pagamento extra obrigatorio para CLT | Comp CLT = salario x 13 (ou 13,33 com 1/3 de ferias). NUNCA esquecer na comparacao |
+| **FGTS** (Fundo de Garantia) | 8% do salario depositado pelo empregador | Beneficio CLT, nao aparece no contra-cheque mas e remuneracao real |
+| **Vale-Refeicao / Vale-Alimentacao** | Beneficio alimentacao (iFood, Sodexo, Alelo) | Comum em vagas CLT, pode chegar a R$ 1.500+/mes. Incluir na comp total |
+| **PLR** (Participacao nos Lucros e Resultados) | Bonus atrelado a resultados da empresa | Pode ser 1-3 salarios extras/ano. Variavel — ponderar com cautela |
+| **Stock Options / VSOP** | Equity em startups | Comum em startups brasileiras. Avaliar vesting, cliff e liquidez |
+| **Periodo de Experiencia** | 45+45 dias (CLT) ou conforme contrato (PJ) | Padrao de mercado, nao e red flag |
+| **Aviso Previo** | 30 dias (CLT) + 3 dias por ano trabalhado | Planejar data de inicio conforme vinculo atual |
+| **Plano de Saude** | Beneficio medico (Amil, SulAmerica, Bradesco Saude) | Muito valorizado no Brasil. Sem plano = red flag em vagas CLT |
+| **Cooperativa / MEI** | Formas alternativas de contratacao | Avaliar com cautela — pode indicar precarizacao trabalhista |
+
+### Scripts de Negociacao
+
+<!-- [PERSONALIZAR] Adapte para sua situacao -->
+
+**Pretensao salarial (framework geral):**
+> "Com base em dados atuais de mercado para essa vaga, minha expectativa esta na faixa de [FAIXA do profile.yml]. Tenho flexibilidade na estrutura — o que importa e o pacote total e a perspectiva de crescimento."
+
+**Pushback contra desconto geografico:**
+> "As vagas em que estou concorrendo sao orientadas a resultados, nao a localizacao. Meu track record nao muda com o CEP."
+
+**Quando a oferta esta abaixo do alvo:**
+> "Estou comparando com ofertas na faixa de [faixa mais alta]. [Empresa] me atrai por [motivo]. E possivel chegarmos em [valor-alvo] juntos?"
+
+**CLT vs PJ:**
+> "Para comparar de forma justa, preciso entender a composicao completa: salario-base, 13o, ferias, FGTS, vale-refeicao, plano de saude e PLR. Se for PJ, qual o valor mensal equivalente considerando esses itens?"
+
+### Politica de Localizacao (Location Policy)
+
+<!-- [PERSONALIZAR] Adapte para sua situacao. Lido de config/profile.yml -> location -->
+
+**Em formularios:**
+- Perguntas binarias "Voce pode trabalhar presencialmente?": responder conforme disponibilidade real de `profile.yml`
+- Em campos de texto livre: informar fuso horario e disponibilidade explicitamente
+
+**Em avaliacoes (Scoring):**
+- Dimensao remoto em hibrido fora do seu estado/pais: Score **3.0** (nao 1.0)
+- Score 1.0 apenas se a vaga diz explicitamente "deve estar presencial 4-5 dias/semana, sem excecoes"
+
+### Prioridade Time-to-Offer
+- Demo funcional + metricas > perfeicao
+- Aplicar mais rapido > aprender mais
+- Abordagem 80/20, tudo com prazo definido
+
+---
+
+## Regras Globais
+
+### NUNCA
+
+1. Inventar experiencia ou metricas
+2. Modificar `cv.md` ou arquivos do portfolio
+3. Enviar candidaturas em nome do candidato
+4. Compartilhar numero de telefone em mensagens geradas
+5. Recomendar remuneracao abaixo do mercado
+6. Gerar PDF sem ter lido a descricao da vaga antes
+7. Usar jargao corporativo ou "corporates"
+8. Ignorar o tracker (toda vaga avaliada e registrada)
+
+### SEMPRE
+
+0. **Carta de apresentacao:** Se o formulario permite anexar ou escrever uma carta, SEMPRE inclua uma. PDF no mesmo design visual do curriculo. Conteudo: citacoes da descricao da vaga mapeadas para proof points, links para case studies relevantes. Maximo 1 pagina.
+1. Ler `cv.md`, `_profile.md` e `article-digest.md` (se existir) antes de avaliar qualquer vaga
+1b. **Na primeira avaliacao de cada sessao:** Executar `node cv-sync-check.mjs` via Bash. Se houver avisos, informar o candidato antes de continuar
+2. Detectar o arquetipo da vaga e adaptar o framing conforme `_profile.md`
+3. Ao fazer matching, citar linhas exatas do curriculo
+4. Usar WebSearch para dados de remuneracao e empresa
+5. Registrar no tracker apos cada avaliacao
+6. Gerar conteudo na lingua da descricao da vaga (PT-BR padrao)
+7. Ser direto e pratico — sem enrolacao
+8. Ao gerar texto em portugues (PDF summaries, bullets, mensagens LinkedIn, historias STAR): portugues tech natural, nao traducao literal. Frases curtas, verbos de acao, evitar voz passiva. Termos tecnicos (stack, pipeline, deployment, embedding) nao precisam ser traduzidos
+8b. **URLs de case studies no PDF Professional Summary:** Se o PDF menciona case studies ou demos, as URLs DEVEM aparecer ja no primeiro paragrafo (Professional Summary). Recrutadores frequentemente so leem o resumo. Todos os URLs no HTML com `white-space: nowrap`
+9. **Entradas no tracker como TSV** — NUNCA editar `applications.md` diretamente para novos registros. Escrever TSV em `batch/tracker-additions/`, `merge-tracker.mjs` cuida do merge
+10. **Incluir `**URL:**` em todo header de report** — entre Score e PDF
+
+### Tools
+
+| Tool | Uso |
+|------|-----|
+| WebSearch | Pesquisa de remuneracao, tendencias, cultura da empresa, contatos LinkedIn, fallback para descricoes de vagas |
+| WebFetch | Fallback para extrair descricoes de vagas de paginas estaticas |
+| Playwright | Verificar se vagas ainda estao ativas (browser_navigate + browser_snapshot), extrair descricoes de SPAs. **CRITICO: NUNCA iniciar 2+ agentes com Playwright em paralelo — eles compartilham a mesma instancia do navegador** |
+| Read | cv.md, _profile.md, article-digest.md, cv-template.html |
+| Write | HTML temporario para PDF, applications.md, reports .md |
+| Edit | Atualizar tracker |
+| Bash | `node generate-pdf.mjs` |

--- a/modes/pt/aplicar.md
+++ b/modes/pt/aplicar.md
@@ -1,0 +1,114 @@
+# Modo: aplicar -- Assistente de Candidatura ao Vivo
+
+Modo interativo para quando o candidato esta preenchendo um formulario de candidatura no Chrome. Le o que esta na tela, carrega o contexto da avaliacao previa da vaga e gera respostas personalizadas para cada pergunta do formulario.
+
+## Requisitos
+
+- **Melhor com Playwright visivel**: No modo visivel, o candidato ve o navegador e Claude pode interagir com a pagina.
+- **Sem Playwright**: o candidato compartilha um screenshot ou cola as perguntas manualmente.
+
+## Workflow
+
+```
+1. DETECTAR    → Ler aba ativa do Chrome (screenshot/URL/titulo)
+2. IDENTIFICAR → Extrair empresa + vaga da pagina
+3. BUSCAR      → Match contra reports existentes em reports/
+4. CARREGAR    → Ler report completo + Bloco G (se existir)
+5. COMPARAR    → A vaga na tela coincide com a avaliada? Se mudou → avisar
+6. ANALISAR    → Identificar TODAS as perguntas visiveis do formulario
+7. GERAR       → Para cada pergunta, gerar resposta personalizada
+8. APRESENTAR  → Mostrar respostas formatadas para copy-paste
+```
+
+## Passo 1 -- Detectar a vaga
+
+**Com Playwright:** Tirar snapshot da pagina ativa. Ler titulo, URL e conteudo visivel.
+
+**Sem Playwright:** Pedir ao candidato que:
+- Compartilhe um screenshot do formulario (o Read tool le imagens)
+- Ou cole as perguntas do formulario como texto
+- Ou diga empresa + vaga para buscarmos o contexto
+
+## Passo 2 -- Identificar e buscar contexto
+
+1. Extrair nome da empresa e titulo da vaga da pagina
+2. Buscar em `reports/` pelo nome da empresa (Grep case-insensitive)
+3. Se houver match → carregar o report completo
+4. Se houver Bloco G → carregar os rascunhos de respostas anteriores como base
+5. Se NAO houver match → avisar e oferecer executar auto-pipeline rapida
+
+## Passo 3 -- Detectar mudancas na vaga
+
+Se a vaga na tela difere da avaliada:
+- **Avisar o candidato**: "A vaga mudou de [X] para [Y]. Quer que eu reavalie ou adapto as respostas ao novo titulo?"
+- **Se adaptar**: Ajustar as respostas ao novo titulo sem reavaliar
+- **Se reavaliar**: Executar avaliacao completa A-F, atualizar report, regenerar Bloco G
+- **Atualizar tracker**: Alterar titulo da vaga em `applications.md` se necessario
+
+## Passo 4 -- Analisar perguntas do formulario
+
+Identificar TODAS as perguntas visiveis:
+- Campos de texto livre (carta de apresentacao, por que essa vaga, motivacao, etc.)
+- Dropdowns (como ficou sabendo da vaga, autorizacao de trabalho, etc.)
+- Sim/Nao (mudanca de cidade, visto, disponibilidade, etc.)
+- Campos de salario (faixa, pretensao salarial)
+- Campos de upload (curriculo, carta de apresentacao em PDF)
+
+Classificar cada pergunta:
+- **Ja respondida no Bloco G** → adaptar a resposta existente
+- **Pergunta nova** → gerar resposta a partir do report + `cv.md`
+
+## Passo 5 -- Gerar respostas
+
+Para cada pergunta, gerar a resposta seguindo:
+
+1. **Contexto do report**: Usar proof points do Bloco B, historias STAR do Bloco F
+2. **Bloco G anterior**: Se existe um rascunho, usar como base e refinar
+3. **Tom "Estou escolhendo voces"**: Mesmo framework da auto-pipeline — confiante, nao suplicante
+4. **Especificidade**: Referenciar algo concreto do JD visivel na tela
+5. **career-ops proof point**: Incluir em "Informacoes adicionais" se houver campo para isso
+
+**Campos especificos do mercado brasileiro que aparecem com frequencia:**
+- **Pretensao salarial (bruto, mensal ou anual)** → Faixa de `profile.yml`, em BRL, com nota "negociavel conforme pacote total"
+- **Regime de contratacao preferido (CLT/PJ)** → Responder conforme `profile.yml`, ou "aberto a ambos" se aplicavel
+- **Disponibilidade / prazo para inicio** → Data realista considerando aviso previo atual (CLT: 30 dias + 3 dias/ano)
+- **Autorizacao de trabalho** → Responder com clareza; se brasileiro: "Cidadao brasileiro, nao necessita autorizacao"
+- **Idiomas** → Informar nivel por idioma (nativo, fluente, intermediario, basico)
+
+**Formato de output:**
+
+```
+## Respostas para [Empresa] -- [Vaga]
+
+Base: Report #NNN | Score: X.X/5 | Arquetipo: [tipo]
+
+---
+
+### 1. [Pergunta exata do formulario]
+> [Resposta pronta para copy-paste]
+
+### 2. [Proxima pergunta]
+> [Resposta]
+
+...
+
+---
+
+Notas:
+- [Qualquer observacao sobre a vaga, mudancas, etc.]
+- [Sugestoes de personalizacao que o candidato deveria revisar]
+```
+
+## Passo 6 -- Pos-candidatura (opcional)
+
+Se o candidato confirmar que enviou a candidatura:
+1. Atualizar status em `applications.md` de "Evaluated" para "Applied"
+2. Atualizar Bloco G do report com as respostas finais
+3. Sugerir proximo passo: `/career-ops contacto` para LinkedIn outreach
+
+## Scroll handling
+
+Se o formulario tem mais perguntas do que as visiveis:
+- Pedir ao candidato para dar scroll e compartilhar outro screenshot
+- Ou colar as perguntas restantes
+- Processar em iteracoes ate cobrir todo o formulario

--- a/modes/pt/oferta.md
+++ b/modes/pt/oferta.md
@@ -1,0 +1,166 @@
+# Modo: oferta -- Avaliacao Completa A-F
+
+Quando o candidato cola uma vaga (texto ou URL), entregar SEMPRE os 6 blocos:
+
+## Passo 0 -- Deteccao de Arquetipo
+
+Classificar a vaga em um dos 6 arquetipos (ver `_shared.md`). Se for hibrido, indicar os 2 mais proximos. Isso determina:
+- Quais proof points priorizar no bloco B
+- Como reescrever o summary no bloco E
+- Quais historias STAR preparar no bloco F
+
+## Bloco A -- Resumo da Vaga
+
+Tabela com:
+- Arquetipo detectado
+- Domain (platform/agentic/LLMOps/ML/enterprise)
+- Funcao (build/consult/manage/deploy)
+- Senioridade
+- Remoto (full/hibrido/presencial)
+- Tamanho do time (se mencionado)
+- TL;DR em 1 frase
+
+## Bloco B -- Match com o Curriculo
+
+Ler `cv.md`. Criar tabela com cada requisito do JD mapeado para linhas exatas do curriculo.
+
+**Adaptado ao arquetipo:**
+- Se FDE → priorizar proof points de entrega rapida e proximidade com cliente
+- Se SA → priorizar design de sistemas e integracoes
+- Se PM → priorizar product discovery e metricas
+- Se LLMOps → priorizar evals, observability, pipelines
+- Se Agentic → priorizar multi-agent, HITL, orquestracao
+- Se Transformation → priorizar gestao de mudanca, adocao, escalabilidade
+
+Secao de **gaps** com estrategia de mitigacao para cada um. Para cada gap:
+1. E um hard blocker ou um nice-to-have?
+2. O candidato consegue demonstrar experiencia adjacente?
+3. Existe um projeto do portfolio que cubra esse gap?
+4. Plano de mitigacao concreto (frase para carta de apresentacao, projeto rapido, etc.)
+
+## Bloco C -- Nivel e Estrategia
+
+1. **Nivel detectado** no JD vs **nivel natural do candidato para esse arquetipo**
+2. **Plano "vender senior sem mentir"**: frases especificas adaptadas ao arquetipo, conquistas concretas a destacar, como posicionar experiencia de founder como vantagem
+3. **Plano "se me downlevelearem"**: aceitar se a remuneracao for justa, negociar revisao em 6 meses, criterios claros de promocao
+
+## Bloco D -- Remuneracao e Demanda
+
+Usar WebSearch para:
+- Salarios atuais da vaga (Glassdoor, Levels.fyi, Blind, Glassdoor BR)
+- Reputacao de remuneracao da empresa
+- Tendencia de demanda da vaga
+
+Tabela com dados e fontes citadas. Se nao houver dados, dizer isso em vez de inventar.
+
+**Mercado Brasileiro -- Checks obrigatorios:**
+- CLT ou PJ? Se CLT: considerar 13o, ferias, FGTS, plano de saude, VR/VA na comparacao.
+- Se PJ: qual o valor mensal? Calcular equivalente CLT.
+- PLR mencionado? Quantos salarios extras?
+- Stock options / VSOP? Avaliar vesting, cliff e liquidez.
+- Vale-refeicao / vale-alimentacao? Valor mensal?
+- Plano de saude? Coparticipacao ou integral?
+
+## Bloco E -- Plano de Personalizacao
+
+| # | Secao | Estado atual | Mudanca proposta | Por que |
+|---|-------|-------------|------------------|---------|
+| 1 | Summary | ... | ... | ... |
+| ... | ... | ... | ... | ... |
+
+Top 5 mudancas no curriculo + Top 5 mudancas no LinkedIn para maximizar o match.
+
+## Bloco F -- Plano de Entrevistas
+
+6-10 historias STAR+R mapeadas para requisitos do JD (STAR + **Reflection**):
+
+| # | Requisito do JD | Historia STAR+R | S | T | A | R | Reflection |
+|---|----------------|-----------------|---|---|---|---|------------|
+
+A coluna **Reflection** captura o que foi aprendido ou o que seria feito diferente. Isso sinaliza senioridade — candidatos juniores descrevem o que aconteceu, candidatos seniores extraem licoes.
+
+**Story Bank:** Se `interview-prep/story-bank.md` existir, verificar se alguma dessas historias ja esta la. Se nao, adicionar as novas. Com o tempo, isso constroi um banco reutilizavel de 5-10 historias-mestre que podem ser adaptadas para qualquer pergunta de entrevista.
+
+**Selecionadas e enquadradas conforme o arquetipo:**
+- FDE → enfatizar velocidade de entrega e proximidade com cliente
+- SA → enfatizar decisoes de arquitetura
+- PM → enfatizar discovery e trade-offs
+- LLMOps → enfatizar metricas, evals, production hardening
+- Agentic → enfatizar orquestracao, tratamento de erros, HITL
+- Transformation → enfatizar adocao e mudanca organizacional
+
+Incluir tambem:
+- 1 case study recomendado (qual projeto apresentar e como)
+- Perguntas red-flag e como responde-las (ex: "Por que voce vendeu sua empresa?", "Voce tinha reports diretos?")
+
+---
+
+## Pos-avaliacao
+
+**SEMPRE** apos gerar os blocos A-F:
+
+### 1. Salvar report .md
+
+Salvar avaliacao completa em `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+
+- `{###}` = proximo numero sequencial (3 digitos, zero-padded)
+- `{company-slug}` = nome da empresa em lowercase, sem espacos (usar hifens)
+- `{YYYY-MM-DD}` = data atual
+
+**Formato do report:**
+
+```markdown
+# Avaliacao: {Empresa} -- {Vaga}
+
+**Data:** {YYYY-MM-DD}
+**Arquetipo:** {detectado}
+**Score:** {X/5}
+**URL:** {URL da vaga}
+**PDF:** {caminho ou pendente}
+
+---
+
+## A) Resumo da Vaga
+(conteudo completo do bloco A)
+
+## B) Match com o Curriculo
+(conteudo completo do bloco B)
+
+## C) Nivel e Estrategia
+(conteudo completo do bloco C)
+
+## D) Remuneracao e Demanda
+(conteudo completo do bloco D)
+
+## E) Plano de Personalizacao
+(conteudo completo do bloco E)
+
+## F) Plano de Entrevistas
+(conteudo completo do bloco F)
+
+## G) Rascunhos de Respostas para Candidatura
+(apenas se score >= 4.5 -- rascunhos de respostas para o formulario de candidatura)
+
+---
+
+## Keywords extraidas
+(lista de 15-20 keywords do JD para otimizacao ATS)
+```
+
+### 2. Registrar no tracker
+
+**SEMPRE** registrar em `data/applications.md`:
+- Proximo numero sequencial
+- Data atual
+- Empresa
+- Vaga
+- Score: media do match (1-5)
+- Status: `Evaluated`
+- PDF: ❌ (ou ✅ se a auto-pipeline gerou PDF)
+- Report: link relativo ao report .md (ex: `[001](reports/001-company-2026-01-01.md)`)
+
+**Formato do tracker:**
+
+```markdown
+| # | Data | Empresa | Vaga | Score | Status | PDF | Report |
+```

--- a/modes/pt/pipeline.md
+++ b/modes/pt/pipeline.md
@@ -1,0 +1,64 @@
+# Modo: pipeline -- Inbox de URLs (Second Brain)
+
+Processa URLs de vagas acumuladas em `data/pipeline.md`. O candidato adiciona URLs quando quiser e depois executa `/career-ops pipeline` para processar todas de uma vez.
+
+## Workflow
+
+1. **Ler** `data/pipeline.md` → buscar itens `- [ ]` na secao "Pendentes"
+2. **Para cada URL pendente**:
+   a. Calcular proximo `REPORT_NUM` sequencial (ler `reports/`, pegar o numero mais alto + 1)
+   b. **Extrair JD** usando Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
+   c. Se a URL nao for acessivel → marcar como `- [!]` com nota e continuar
+   d. **Executar auto-pipeline completa**: Avaliacao A-F → Report .md → PDF (se score >= 3.0) → Tracker
+   e. **Mover de "Pendentes" para "Processadas"**: `- [x] #NNN | URL | Empresa | Vaga | Score/5 | PDF ✅/❌`
+3. **Se houver 3+ URLs pendentes**, lancar agentes em paralelo (Agent tool com `run_in_background`) para maximizar velocidade.
+4. **Ao terminar**, mostrar tabela resumo:
+
+```
+| # | Empresa | Vaga | Score | PDF | Acao recomendada |
+```
+
+## Formato de pipeline.md
+
+```markdown
+## Pendentes
+- [ ] https://jobs.example.com/posting/123
+- [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
+- [!] https://private.url/job — Erro: login necessario
+
+## Processadas
+- [x] #143 | https://jobs.example.com/posting/789 | Acme Corp | AI PM | 4.2/5 | PDF ✅
+- [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF ❌
+```
+
+> Nota: Os titulos das secoes podem estar em EN ("Pending"/"Processed"), ES ("Pendientes"/"Procesadas"), DE ("Offen"/"Verarbeitet") ou PT-BR ("Pendentes"/"Processadas"). Ao ler, ser flexivel; ao escrever, manter o estilo da arquivo existente.
+
+## Deteccao inteligente de JD a partir da URL
+
+1. **Playwright (preferido):** `browser_navigate` + `browser_snapshot`. Funciona com todas as SPAs.
+2. **WebFetch (fallback):** Para paginas estaticas ou quando Playwright nao esta disponivel.
+3. **WebSearch (ultimo recurso):** Buscar em portais secundarios que indexam o JD.
+
+**Casos especiais:**
+- **LinkedIn**: Pode exigir login → marcar com `[!]` e pedir ao candidato para colar o texto
+- **PDF**: Se a URL aponta para um PDF, ler diretamente com o Read tool
+- **`local:` prefix**: Ler arquivo local. Exemplo: `local:jds/linkedin-pm-ai.md` → ler `jds/linkedin-pm-ai.md`
+- **Gupy / Greenhouse / Lever**: Plataformas comuns no Brasil. Playwright funciona bem com todas
+- **Vagas.com.br / InfoJobs / Catho**: Portais brasileiros, geralmente acessiveis via WebFetch
+- **LinkedIn BR**: Mesmas restricoes do LinkedIn global — pode exigir login
+
+## Numeracao automatica
+
+1. Listar todos os arquivos em `reports/`
+2. Extrair o numero do prefixo (ex: `142-medispend...` → 142)
+3. Novo numero = maximo encontrado + 1
+
+## Sincronizacao de fontes
+
+Antes de processar qualquer URL, verificar sincronizacao:
+
+```bash
+node cv-sync-check.mjs
+```
+
+Se houver dessincronizacao, avisar o candidato antes de continuar.


### PR DESCRIPTION
## Summary
- Native PT-BR translations following the same structure as `modes/de/` and `modes/fr/`
- 5 files: `_shared.md`, `oferta.md`, `aplicar.md`, `pipeline.md`, `README.md`
- Brazil-specific vocabulary: CLT/PJ, 13o salário, FGTS, PLR, vale-refeição, plano de saúde, período de experiência, aviso prévio
- Brazilian job portal support: Gupy, Vagas.com.br, Catho, InfoJobs
- Technical terms kept in English (LLM, RAG, MCP, AGENTS.md, Claude Code, etc.)

## Test plan
- [ ] Verify `modes/pt/` files load correctly when `language.modes_dir: modes/pt` is set in `config/profile.yml`
- [ ] Run evaluation in PT-BR mode with a sample JD
- [ ] Confirm Brazilian comp fields (CLT/PJ, 13o, FGTS) appear in Block D

🤖 Generated with [Claude Code](https://claude.com/claude-code)