### PR TITLE
Add knowledge base system for deep career context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,13 @@ node_modules/
 *.mov
 *.mp4
 
+# Knowledge base (user career docs, populated via voice-to-knowledge)
+knowledge/*
+!knowledge/.gitkeep
+!knowledge/_index.example.md
+!knowledge/example-project/
+!knowledge/example-project/*
+
 # Claude Code local
 .claude/settings.local.json
 .claude/memory/

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -13,6 +13,7 @@ These files contain your personal data, customizations, and work product. Update
 | `modes/_profile.md` | Your archetypes, narrative, negotiation scripts |
 | `article-digest.md` | Your proof points from portfolio |
 | `interview-prep/story-bank.md` | Your accumulated STAR+R stories |
+| `knowledge/` | Your deep career documentation (project details, STAR frameworks, index) |
 | `portals.yml` | Your customized company list |
 | `data/applications.md` | Your application tracker |
 | `data/pipeline.md` | Your URL inbox |

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -16,7 +16,10 @@ Eres un worker de evaluación de ofertas de empleo for the candidate (read name 
 |---------|---------------|--------|
 | cv.md | `cv.md (project root)` | SIEMPRE |
 | llms.txt | `llms.txt (if exists)` | SIEMPRE |
-| article-digest.md | `article-digest.md (project root)` | SIEMPRE (proof points) |
+| article-digest.md | `article-digest.md (project root)` | SIEMPRE (compact proof points per project) |
+| knowledge/_index.md | `knowledge/_index.md` | ON-DEMAND (archetype→project map for deeper context) |
+| knowledge/*/project.md | `knowledge/{project}/project.md` | ON-DEMAND (full project details when article-digest isn't enough) |
+| story-bank.md | `interview-prep/story-bank.md` | ON-DEMAND for Block F (accumulated STAR+R stories, if populated) |
 | i18n.ts | `i18n.ts (if exists, optional)` | Solo entrevistas/deep |
 | cv-template.html | `templates/cv-template.html` | Para PDF |
 | generate-pdf.mjs | `generate-pdf.mjs` | Para PDF |

--- a/knowledge/_index.example.md
+++ b/knowledge/_index.example.md
@@ -1,0 +1,67 @@
+# Knowledge Index
+
+Maps your career archetypes (from `modes/_shared.md`) to project folders for targeted context loading during evaluations, CV generation, and interview prep.
+
+## How It Works
+
+Each project in this folder has two files:
+
+- `project.md` — Deep technical details, business context, architecture, and metrics
+- `star.md` — STAR+R framework version optimized for interviews and external positioning
+
+When the agent evaluates a job offer, it reads `_index.md` to find which projects map to the detected archetype, then loads those project files for richer CV personalization and interview story selection.
+
+## Recommended Workflow: Voice-to-Knowledge
+
+The fastest way to populate these files is a **2-3 minute voice session** per project:
+
+1. **Start a voice conversation** with the agent (Cursor voice, Claude voice, or any voice input)
+2. **Talk for 2-3 minutes** about the project — what the situation was, what you did, what you built, what the results were, and any technical details you remember
+3. **The agent structures your narration** into the `project.md` and `star.md` formats below, extracting metrics, capabilities, and archetype mappings automatically
+
+This approach captures details you might skip when writing — technical decisions, team dynamics, metrics you remember verbally but wouldn't bother typing. The agent does the structuring work.
+
+## Index Structure
+
+Organize by archetype first (for lookup during evaluations), then by company (for chronological reference):
+
+```markdown
+## By Archetype
+
+### [Archetype Name from _shared.md]
+- [project-slug](project-slug/) — one-line summary with hero metric
+
+### [Another Archetype]
+- [project-slug](project-slug/) — summary
+- [another-project](another-project/) — summary
+
+## By Company (chronological)
+
+### Company Name (Start Date - End Date)
+- [project-slug](project-slug/)
+```
+
+Projects can (and should) appear under multiple archetypes if they demonstrate different capabilities.
+
+## Example
+
+```markdown
+## By Archetype
+
+### Backend Engineer
+- [acme-api-migration](acme-api-migration/) — migrated monolith to microservices, 40ms p99 latency
+- [acme-event-pipeline](acme-event-pipeline/) — Kafka event pipeline, 2M events/day
+
+### Technical Lead
+- [acme-api-migration](acme-api-migration/) — led 4-person team through 6-month migration
+- [startup-mvp-launch](startup-mvp-launch/) — architected and shipped MVP in 8 weeks
+
+## By Company (chronological)
+
+### Acme Corp (Jan 2020 - Dec 2023)
+- [acme-api-migration](acme-api-migration/)
+- [acme-event-pipeline](acme-event-pipeline/)
+
+### Startup Inc (Jan 2024 - Present)
+- [startup-mvp-launch](startup-mvp-launch/)
+```

--- a/knowledge/example-project/project.md
+++ b/knowledge/example-project/project.md
@@ -1,0 +1,91 @@
+---
+company: Acme Corp
+project: API Platform Migration
+dates: 2021-Q1 to 2021-Q4
+archetypes:
+  - Backend Engineer
+  - Technical Lead
+capabilities:
+  - microservices
+  - api-design
+  - system-migration
+  - team-leadership
+hero_metrics:
+  - 40ms p99 latency (from 450ms)
+  - 12 microservices extracted
+  - zero-downtime cutover
+  - 4-person team
+---
+
+# Acme Corp API Platform Migration — Project Details
+
+## Overview
+
+Led the migration of Acme's monolithic REST API (Rails, 200K LOC) to a
+microservices architecture on Kubernetes. The legacy API served 15M
+requests/day but had become a deployment bottleneck — a single change
+required a full regression cycle and 4-hour deploy window.
+
+**Duration:** January 2021 – December 2021
+**Role:** Technical Lead / Backend Engineer
+**Team:** 4 engineers (2 senior, 1 mid, 1 junior)
+
+---
+
+## Business Context
+
+Acme's B2B SaaS platform had grown to 800+ enterprise customers. The
+monolith's deploy cadence (weekly, with 4-hour windows) was blocking
+feature velocity. Customer-facing latency had crept to 450ms p99 as the
+codebase grew. The VP of Engineering approved a migration initiative after
+two major outages traced to deployment coupling.
+
+---
+
+## What Was Built
+
+### Strangler Fig Migration Pattern
+
+Rather than a big-bang rewrite, used a strangler fig pattern with an API
+gateway (Kong) routing traffic progressively from the monolith to new
+services:
+
+1. **Domain decomposition** — mapped the monolith into 12 bounded contexts
+   using event storming workshops with product and engineering
+2. **Shared-nothing services** — each service owns its database (Postgres),
+   communicates via async events (Kafka) for eventual consistency
+3. **Progressive traffic shifting** — Kong gateway with canary rules,
+   0.1% → 1% → 10% → 50% → 100% per service over 2-3 weeks
+
+### Key Technical Decisions
+
+- **Kafka for inter-service communication** — chose over synchronous REST
+  to decouple services and handle backpressure during migration
+- **Schema registry** — Avro schemas with compatibility checks to prevent
+  breaking changes across teams
+- **Distributed tracing** — Jaeger instrumentation from day one; critical
+  for debugging cross-service latency during the hybrid monolith phase
+
+---
+
+## Scale & Metrics
+
+- **12 microservices** extracted from monolith over 10 months
+- **40ms p99 latency** (down from 450ms — 11x improvement)
+- **15M requests/day** served through the new architecture
+- **Zero-downtime cutover** — progressive migration, no maintenance windows
+- **Deploy cadence** went from weekly/4-hour to multiple daily/2-minute
+- **4-person team** delivered on schedule with no production incidents
+
+---
+
+## Notes for Context
+
+This project is best positioned for roles requiring:
+- Hands-on backend/infra migration experience at scale
+- Technical leadership of small, high-output teams
+- Architectural decision-making under production constraints
+- Comfort with distributed systems complexity (eventual consistency, tracing)
+
+The "strangler fig" story resonates particularly well in interviews —
+it shows pragmatic migration thinking vs. risky big-bang rewrites.

--- a/knowledge/example-project/star.md
+++ b/knowledge/example-project/star.md
@@ -1,0 +1,109 @@
+---
+company: Acme Corp
+project: API Platform Migration
+dates: 2021-Q1 to 2021-Q4
+archetypes:
+  - Backend Engineer
+  - Technical Lead
+capabilities:
+  - microservices
+  - api-design
+  - system-migration
+  - team-leadership
+hero_metrics:
+  - 40ms p99 latency (from 450ms)
+  - 12 microservices extracted
+  - zero-downtime cutover
+  - 4-person team
+---
+
+# Acme Corp API Platform Migration — STAR+R Framework
+
+## SITUATION
+
+Acme's monolithic Rails API (200K LOC, 15M requests/day) had become a
+deployment bottleneck for 800+ enterprise customers. P99 latency had crept
+to 450ms. Deploys required weekly 4-hour windows with full regression. Two
+major outages in Q4 2020 — both traced to deployment coupling — triggered
+VP-level approval for a migration initiative.
+
+The core tension: the API was generating revenue and couldn't go down, but
+every week it stayed monolithic made the problem harder to fix.
+
+---
+
+## TASK
+
+Lead a 4-person team to migrate the monolith to microservices without
+disrupting the 800+ customers relying on 15M daily requests. Constraints:
+zero-downtime (no maintenance windows), no feature freezes (product
+couldn't pause for 10 months), and the junior engineer needed to ship
+production code within the first month.
+
+---
+
+## ACTION
+
+**Chose the strangler fig pattern over big-bang rewrite.** Ran event
+storming workshops with product and engineering to decompose the monolith
+into 12 bounded contexts. Set up a Kong API gateway for progressive traffic
+shifting — 0.1% canary, then 1%, 10%, 50%, 100% over 2-3 weeks per
+service. Each service got its own Postgres database and communicated via
+Kafka events for eventual consistency.
+
+**Built the observability layer first.** Instrumented Jaeger distributed
+tracing before extracting the first service. This was the decision that
+saved us — during the hybrid phase (monolith + services running in
+parallel), tracing was the only way to debug cross-service latency spikes.
+
+**Invested in developer experience.** Schema registry with Avro
+compatibility checks prevented breaking changes. Standardized service
+templates (Dockerfile, CI pipeline, health checks, Kafka consumer patterns)
+so the team could spin up a new service in under a day.
+
+**Mentored the junior engineer through production ownership.** Paired on
+the first two service extractions, then gave her full ownership of
+services 3-5 with code review support. She shipped all three on schedule.
+
+---
+
+## RESULT
+
+- **40ms p99 latency** — down from 450ms (11x improvement)
+- **12 microservices** extracted over 10 months, on schedule
+- **Zero-downtime cutover** — progressive migration, no maintenance windows
+- **Deploy cadence** improved from weekly/4-hour to multiple daily/2-minute
+- **Zero production incidents** during the entire migration
+- **Junior engineer** promoted to mid-level 6 months later, citing the
+  migration as her strongest growth period
+
+---
+
+## REFLECTION
+
+The biggest lesson: **the observability investment paid for itself 10x.**
+Every instinct said "start extracting services immediately" — but spending
+the first 3 weeks on tracing, logging, and canary infrastructure meant we
+caught problems at 0.1% traffic instead of 100%. The two times we found
+latency regressions, they affected fewer than 1,000 requests total.
+
+The strangler fig pattern also taught me that **migration is a product
+problem, not just an engineering problem.** The event storming workshops
+with product managers were essential — they identified which bounded
+contexts had the highest coupling to revenue features, which determined
+our extraction order. We migrated the lowest-risk, highest-pain services
+first, building confidence and tooling before tackling the critical path.
+
+---
+
+## Interview Positioning
+
+- **"Led a zero-downtime migration of a 200K LOC monolith serving 15M
+  requests/day to 12 microservices. P99 latency dropped from 450ms to
+  40ms. No production incidents across the 10-month migration."**
+- **"The key decision was investing 3 weeks in observability before
+  extracting the first service. Distributed tracing caught regressions
+  at 0.1% canary traffic instead of 100%."**
+- **"Used a strangler fig pattern with progressive traffic shifting —
+  started at 0.1% canary per service, scaled to 100% over 2-3 weeks.
+  Zero maintenance windows."**

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -13,13 +13,18 @@
 | File | Path | When |
 |------|------|------|
 | cv.md | `cv.md` (project root) | ALWAYS |
-| article-digest.md | `article-digest.md` (if exists) | ALWAYS (detailed proof points) |
+| article-digest.md | `article-digest.md` (project root) | ALWAYS (compact proof points per project) |
+| knowledge/_index.md | `knowledge/_index.md` | ON-DEMAND (archetype → project mapping for deep context) |
+| knowledge/*/project.md | `knowledge/{project}/project.md` | ON-DEMAND (full project details when deeper context needed) |
+| knowledge/*/star.md | `knowledge/{project}/star.md` | ON-DEMAND (STAR frameworks for interview prep) |
+| story-bank.md | `interview-prep/story-bank.md` | ON-DEMAND for Block F (accumulated STAR+R stories, if populated) |
 | profile.yml | `config/profile.yml` | ALWAYS (candidate identity and targets) |
 | _profile.md | `modes/_profile.md` | ALWAYS (user archetypes, narrative, negotiation) |
 
 **RULE: NEVER hardcode metrics from proof points.** Read them from cv.md + article-digest.md at evaluation time.
 **RULE: For article/project metrics, article-digest.md takes precedence over cv.md.**
 **RULE: Read _profile.md AFTER this file. User customizations in _profile.md override defaults here.**
+**RULE: For deep project context during evals, search `knowledge/_index.md` for projects matching the detected archetype, then read relevant `project.md` and `star.md` files.**
 
 ---
 

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -22,7 +22,9 @@ Tabla con:
 
 ## Bloque B — Match con CV
 
-Lee `cv.md`. Crea tabla con cada requisito del JD mapeado a líneas exactas del CV.
+Lee `cv.md` y `article-digest.md`. Crea tabla con cada requisito del JD mapeado a líneas exactas del CV o proof points del digest.
+
+**Deep context:** After mapping CV, search `knowledge/_index.md` for projects matching the detected archetype. Read relevant `knowledge/{project}/project.md` files for deeper proof points, specific metrics, and architectural decisions that strengthen the match.
 
 **Adaptado al arquetipo:**
 - Si FDE → priorizar proof points de delivery rápida y client-facing
@@ -35,7 +37,7 @@ Lee `cv.md`. Crea tabla con cada requisito del JD mapeado a líneas exactas del 
 Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
 1. ¿Es un hard blocker o un nice-to-have?
 2. ¿Puede el candidato demostrar experiencia adyacente?
-3. ¿Hay un proyecto portfolio que cubra este gap?
+3. ¿Hay un proyecto portfolio que cubra este gap? Check `knowledge/` for deeper evidence.
 4. Plan de mitigación concreto (frase para cover letter, proyecto rápido, etc.)
 
 ## Bloque C — Nivel y Estrategia
@@ -71,7 +73,9 @@ Top 5 cambios al CV + Top 5 cambios a LinkedIn para maximizar match.
 
 The **Reflection** column captures what was learned or what would be done differently. This signals seniority — junior candidates describe what happened, senior candidates extract lessons.
 
-**Story Bank:** If `interview-prep/story-bank.md` exists, check if any of these stories are already there. If not, append new ones. Over time this builds a reusable bank of 5-10 master stories that can be adapted to any interview question.
+**Story Bank:** If `interview-prep/story-bank.md` has stories, match them to JD requirements using archetype and JD signal tags. Stories accumulate over time as you evaluate offers and populate the knowledge base.
+
+**Deep STAR context:** For stories needing more depth than the story bank provides, read the corresponding `knowledge/{project}/star.md` file for full STAR framework details including specific metrics, technical decisions, and narrative context.
 
 **Seleccionadas y enmarcadas según el arquetipo:**
 - FDE → enfatizar velocidad de entrega y client-facing


### PR DESCRIPTION
## Summary

- Adds a knowledge/ directory system for deep career documentation with per-project project.md (technical details, metrics, architecture) and star.md (STAR+R interview framework) files
- Integrates knowledge sources into evaluation pipeline: _shared.md sources of truth table, oferta.md Blocks B and F, and atch-prompt.md worker prompt
- Ships example files (_index.example.md, example-project/) with voice-to-knowledge workflow guidance so users can populate via 2-3 minute voice sessions
- Adds knowledge/ to Data Contract user layer and .gitignore (personal content excluded, examples tracked)
- Genericizes story-bank references across all mode files for broader applicability

## Files Changed

| File | Change |
|------|--------|
| modes/_shared.md | Added knowledge sources to truth table + deep context rule |
| modes/oferta.md | Knowledge integration in Block B (CV match) and Block F (interview prep) |
| atch/batch-prompt.md | Added knowledge sources + genericized story-bank description |
| DATA_CONTRACT.md | Added knowledge/ to user layer |
| .gitignore | Exclude user knowledge content, track examples |
| knowledge/_index.example.md | Example index with voice-to-knowledge workflow docs |
| knowledge/example-project/project.md | Example project documentation template |
| knowledge/example-project/star.md | Example STAR+R framework template |
| knowledge/.gitkeep | Preserve directory structure |

## Test plan

- [ ] Verify knowledge/ gitignore rules: examples tracked, user content excluded
- [ ] Confirm original archetypes in _shared.md are unchanged
- [ ] Run an evaluation with populated knowledge files to validate deep context loading
- [ ] Verify voice-to-knowledge workflow instructions are clear in example files