### PR TITLE
harden batch state lock recovery

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -17,6 +17,8 @@ REPORTS_DIR="$PROJECT_DIR/reports"
 APPLICATIONS_FILE="$PROJECT_DIR/data/applications.md"
 LOCK_FILE="$BATCH_DIR/batch-runner.pid"
 STATE_LOCK_DIR="$BATCH_DIR/.batch-state.lock"
+STATE_LOCK_PID_FILE="$STATE_LOCK_DIR/pid"
+STATE_LOCK_TIMEOUT_SECONDS=30
 MAIN_PID="${BASHPID:-$$}"
 
 # Defaults
@@ -130,13 +132,65 @@ init_state() {
 }
 
 acquire_state_lock() {
-  while ! mkdir "$STATE_LOCK_DIR" 2>/dev/null; do
+  local waited=0
+  local max_waits=$((STATE_LOCK_TIMEOUT_SECONDS * 10))
+
+  while true; do
+    if mkdir "$STATE_LOCK_DIR" 2>/dev/null; then
+      if printf '%s\n' "${BASHPID:-$$}" > "$STATE_LOCK_PID_FILE"; then
+        return 0
+      fi
+      rm -f "$STATE_LOCK_PID_FILE" 2>/dev/null || true
+      rmdir "$STATE_LOCK_DIR" 2>/dev/null || true
+      echo "ERROR: Failed to initialize state lock metadata at $STATE_LOCK_DIR"
+      return 1
+    fi
+
+    if [[ ! -d "$STATE_LOCK_DIR" ]]; then
+      echo "ERROR: Failed to create state lock directory $STATE_LOCK_DIR"
+      return 1
+    fi
+
+    if [[ -f "$STATE_LOCK_PID_FILE" ]]; then
+      local lock_pid
+      lock_pid=$(cat "$STATE_LOCK_PID_FILE" 2>/dev/null || true)
+      if [[ -n "$lock_pid" ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
+        rm -f "$STATE_LOCK_PID_FILE"
+        if rmdir "$STATE_LOCK_DIR" 2>/dev/null; then
+          echo "WARN: Recovered stale state lock (PID $lock_pid not running)."
+          continue
+        fi
+      fi
+    fi
+
+    if (( waited >= max_waits )); then
+      echo "ERROR: Timed out waiting for state lock at $STATE_LOCK_DIR"
+      echo "If no batch-runner worker is active, remove the stale lock directory."
+      return 1
+    fi
+
     sleep 0.1
+    ((waited += 1))
   done
 }
 
 release_state_lock() {
+  rm -f "$STATE_LOCK_PID_FILE" 2>/dev/null || true
   rmdir "$STATE_LOCK_DIR" 2>/dev/null || true
+}
+
+run_with_state_lock() {
+  acquire_state_lock || return $?
+
+  local status=0
+  if "$@"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  release_state_lock
+  return "$status"
 }
 
 # Get status of an offer from state file
@@ -229,44 +283,22 @@ update_state_unlocked() {
 }
 
 update_state() {
-  acquire_state_lock
-
-  local status=0
-  if update_state_unlocked "$@"; then
-    status=0
-  else
-    status=$?
-  fi
-
-  release_state_lock
-  return "$status"
+  run_with_state_lock update_state_unlocked "$@"
 }
 
-reserve_report_num() {
+reserve_report_num_unlocked() {
   local id="$1" url="$2" started="$3" retries="$4"
 
-  acquire_state_lock
-
   local report_num=""
-  local status=0
-
   if report_num=$(next_report_num_unlocked); then
-    if update_state_unlocked "$id" "$url" "processing" "$started" "-" "$report_num" "-" "-" "$retries"; then
-      status=0
-    else
-      status=$?
-    fi
-  else
-    status=$?
-  fi
-
-  release_state_lock
-
-  if (( status != 0 )); then
-    return "$status"
+    update_state_unlocked "$id" "$url" "processing" "$started" "-" "$report_num" "-" "-" "$retries"
   fi
 
   printf '%s\n' "$report_num"
+}
+
+reserve_report_num() {
+  run_with_state_lock reserve_report_num_unlocked "$@"
 }
 
 # Process a single offer


### PR DESCRIPTION
## What changed

- add PID metadata to the batch state lock directory
- recover stale state locks when the recorded PID is no longer running
- add a timeout and clear error when waiting for the state lock
- route state-file critical sections through a shared helper

## Why

`batch/batch-runner.sh` previously used:

```sh
while ! mkdir "$STATE_LOCK_DIR" 2>/dev/null; do
  sleep 0.1
done
