### PR TITLE
scope update-system file changes

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -15,7 +15,7 @@
  * See DATA_CONTRACT.md for the full system/user layer definitions.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -100,8 +100,30 @@ function compareVersions(a, b) {
   return 0;
 }
 
-function git(cmd) {
-  return execSync(`git ${cmd}`, { cwd: ROOT, encoding: 'utf-8', timeout: 30000 }).trim();
+function git(...args) {
+  return execFileSync('git', args, { cwd: ROOT, encoding: 'utf-8', timeout: 30000 }).trim();
+}
+
+function gitStatusEntries() {
+  const status = git('status', '--porcelain');
+  if (!status) return [];
+
+  return status.split('\n')
+    .filter(Boolean)
+    .map(line => ({
+      code: line.slice(0, 2),
+      path: line.slice(3),
+    }));
+}
+
+function revertPaths(paths) {
+  if (paths.length === 0) return;
+  git('checkout', '--', ...paths);
+}
+
+function addPaths(paths) {
+  if (paths.length === 0) return;
+  git('add', '--', ...paths);
 }
 
 // ── CHECK ───────────────────────────────────────────────────────
@@ -156,6 +178,7 @@ async function check() {
 
 async function apply() {
   const local = localVersion();
+  const initialStatusPaths = new Set(gitStatusEntries().map(entry => entry.path));
 
   // Check for lock
   const lockFile = join(ROOT, '.update-lock');
@@ -171,7 +194,7 @@ async function apply() {
     // 1. Backup: create branch
     const backupBranch = `backup-pre-update-${local}`;
     try {
-      git(`branch ${backupBranch}`);
+      git('branch', backupBranch);
       console.log(`Backup branch created: ${backupBranch}`);
     } catch {
       console.log(`Backup branch already exists (${backupBranch}), continuing...`);
@@ -179,14 +202,14 @@ async function apply() {
 
     // 2. Fetch from canonical repo
     console.log('Fetching latest from upstream...');
-    git(`fetch ${CANONICAL_REPO} main`);
+    git('fetch', CANONICAL_REPO, 'main');
 
     // 3. Checkout system files only
     console.log('Updating system files...');
     const updated = [];
     for (const path of SYSTEM_PATHS) {
       try {
-        git(`checkout FETCH_HEAD -- ${path}`);
+        git('checkout', 'FETCH_HEAD', '--', path);
         updated.push(path);
       } catch {
         // File may not exist in remote (new additions), skip
@@ -196,10 +219,9 @@ async function apply() {
     // 4. Validate: check NO user files were touched
     let userFileTouched = false;
     try {
-      const status = git('status --porcelain');
-      for (const line of status.split('\n')) {
-        if (!line.trim()) continue;
-        const file = line.slice(3);
+      for (const entry of gitStatusEntries()) {
+        const file = entry.path;
+        if (initialStatusPaths.has(file)) continue;
         for (const userPath of USER_PATHS) {
           if (file.startsWith(userPath)) {
             console.error(`SAFETY VIOLATION: User file was modified: ${file}`);
@@ -213,8 +235,7 @@ async function apply() {
 
     if (userFileTouched) {
       console.error('Aborting: user files were touched. Rolling back...');
-      git('checkout .');
-      unlinkSync(lockFile);
+      revertPaths(updated);
       process.exit(1);
     }
 
@@ -228,15 +249,17 @@ async function apply() {
     // 6. Commit the update
     const remote = localVersion(); // Re-read after checkout updated VERSION
     try {
-      git('add .');
-      git(`commit -m "chore: auto-update system files to v${remote}"`);
+      const pathsToStage = [...updated];
+      const dismissFile = join(ROOT, '.update-dismissed');
+      if (existsSync(dismissFile)) {
+        unlinkSync(dismissFile);
+        pathsToStage.push('.update-dismissed');
+      }
+      addPaths(pathsToStage);
+      git('commit', '-m', `chore: auto-update system files to v${remote}`);
     } catch {
       // Nothing to commit (already up to date)
     }
-
-    // 7. Clean up dismiss flag if it exists
-    const dismissFile = join(ROOT, '.update-dismissed');
-    if (existsSync(dismissFile)) unlinkSync(dismissFile);
 
     console.log(`\nUpdate complete: v${local} → v${remote}`);
     console.log(`Updated ${updated.length} system paths.`);
@@ -251,32 +274,30 @@ async function apply() {
 // ── ROLLBACK ────────────────────────────────────────────────────
 
 function rollback() {
-  const local = localVersion();
-
   // Find most recent backup branch
   try {
-    const branches = git('branch --list "backup-pre-update-*"');
-    const branchList = branches.split('\n').map(b => b.trim().replace('* ', '')).filter(Boolean);
+    const branches = git('for-each-ref', '--sort=-committerdate', '--format=%(refname:short)', 'refs/heads/backup-pre-update-*');
+    const branchList = branches.split('\n').map(b => b.trim()).filter(Boolean);
 
     if (branchList.length === 0) {
       console.error('No backup branches found. Nothing to rollback.');
       process.exit(1);
     }
 
-    const latest = branchList[branchList.length - 1];
+    const latest = branchList[0];
     console.log(`Rolling back to: ${latest}`);
 
     // Checkout system files from backup branch
     for (const path of SYSTEM_PATHS) {
       try {
-        git(`checkout ${latest} -- ${path}`);
+        git('checkout', latest, '--', path);
       } catch {
         // File may not have existed in backup
       }
     }
 
-    git('add .');
-    git(`commit -m "chore: rollback system files from ${latest}"`);
+    addPaths(SYSTEM_PATHS);
+    git('commit', '-m', `chore: rollback system files from ${latest}`);
 
     console.log(`Rollback complete. System files restored from ${latest}.`);
     console.log('Your data (CV, profile, tracker, reports) was not affected.');


### PR DESCRIPTION
## What changed

- scope updater rollback to only the paths touched by the updater
- stage only updater-owned paths instead of `git add .`
- ignore pre-existing dirty files when checking whether user data was touched
- pick the newest backup branch correctly during rollback
- switch helper git calls to argument-based execution for safer path handling

## Why

`update-system.mjs` is meant to update only the system layer, but it had a few unsafe git behaviors:

- on safety abort it ran `git checkout .`, which can revert unrelated local work
- on apply/rollback it used `git add .`, which can stage unrelated changes into the updater commit
- rollback sorted backup branches newest-first but selected the last entry, which can restore the wrong backup branch

That makes the updater risky in a dirty worktree, which is exactly where users are most likely to run it.

## Impact

This keeps the updater aligned with its contract:

- only system-layer files are reverted or committed
- unrelated local edits are left alone
- rollback restores from the most recent backup branch instead of an older one

## Validation

- `node --check update-system.mjs`
- source audit of apply/rollback paths and staging behavior
