### PR TITLE
fix: translate modes to English, unify scoring, fix critical gaps

### DIFF
--- a/.claude/skills/career-ops/SKILL.md
+++ b/.claude/skills/career-ops/SKILL.md
@@ -28,6 +28,7 @@ Determine the mode from `{{mode}}`:
 | `scan` | `scan` |
 | `batch` | `batch` |
 | `patterns` | `patterns` |
+| `interview-prep` | `interview-prep` |
 
 **Auto-pipeline detection:** If `{{mode}}` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
 
@@ -56,7 +57,8 @@ Available commands:
   /career-ops apply     → Live application assistant (reads form + generates answers)
   /career-ops scan      → Scan portals and discover new offers
   /career-ops batch     → Batch processing with parallel workers
-  /career-ops patterns  → Analyze rejection patterns and improve targeting
+  /career-ops patterns       → Analyze rejection patterns and improve targeting
+  /career-ops interview-prep → Company-specific interview intelligence
 
 Inbox: add URLs to data/pipeline.md → /career-ops pipeline
 Or paste a JD directly to run the full pipeline.
@@ -76,7 +78,7 @@ Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `p
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`
 
-Applies to: `tracker`, `deep`, `training`, `project`, `patterns`
+Applies to: `tracker`, `deep`, `training`, `project`, `patterns`, `interview-prep`
 
 ### Modes delegated to subagent:
 For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as Agent with the content of `_shared.md` + `modes/{mode}.md` injected into the subagent prompt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,7 @@ Write one TSV file per evaluation to `batch/tracker-additions/{num}-{company-slu
 | `Evaluated` | Report completed, pending decision |
 | `Applied` | Application sent |
 | `Responded` | Company responded |
+| `Contacted` | Candidate proactively reached out (outbound) |
 | `Interview` | In interview process |
 | `Offer` | Offer received |
 | `Rejected` | Rejected by company |

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -42,9 +42,18 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/tracker.md` | Tracker instructions |
 | `modes/training.md` | Training evaluation instructions |
 | `modes/de/*` | German language modes |
+| `modes/fr/*` | French language modes |
+| `modes/pt/*` | Portuguese language modes |
+| `modes/es/*` | Spanish language modes (original translations) |
+| `modes/interview-prep.md` | Interview intelligence mode |
+| `modes/patterns.md` | Rejection pattern analysis mode |
 | `CLAUDE.md` | Agent instructions |
 | `AGENTS.md` | Codex instructions |
-| `*.mjs` | Utility scripts |
+| `analyze-patterns.mjs` | Pattern analysis script |
+| `check-liveness.mjs` | Offer URL liveness checker |
+| `doctor.mjs` | Setup validator |
+| `test-all.mjs` | Test suite |
+| `*.mjs` | Other utility scripts |
 | `batch/batch-prompt.md` | Batch worker prompt |
 | `batch/batch-runner.sh` | Batch orchestrator |
 | `dashboard/*` | Go TUI dashboard |
@@ -53,6 +62,9 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `.claude/skills/*` | Skill definitions |
 | `docs/*` | Documentation |
 | `VERSION` | Current version number |
+| `LEGAL_DISCLAIMER.md` | Legal disclaimer |
+| `README.es.md` | Spanish README |
+| `AGENTS.md` | Codex agent instructions |
 | `DATA_CONTRACT.md` | This file |
 
 ## The Rule

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -138,16 +138,23 @@ Top 5 cambios al CV + Top 5 cambios a LinkedIn.
 - 1 case study recomendado (cuál proyecto presentar y cómo)
 - Preguntas red-flag y cómo responderlas
 
-#### Score Global
+#### Global Score
 
-| Dimensión | Score |
-|-----------|-------|
-| Match con CV | X/5 |
-| Alineación North Star | X/5 |
-| Comp | X/5 |
-| Señales culturales | X/5 |
-| Red flags | -X (si hay) |
-| **Global** | **X/5** |
+10 weighted dimensions (same system used in single and multi-offer comparisons):
+
+| Dimension | Weight | Score |
+|-----------|--------|-------|
+| North Star alignment | 25% | X/5 |
+| CV match | 15% | X/5 |
+| Level (senior+) | 15% | X/5 |
+| Estimated comp | 10% | X/5 |
+| Growth trajectory | 10% | X/5 |
+| Remote quality | 5% | X/5 |
+| Company reputation | 5% | X/5 |
+| Tech stack modernity | 5% | X/5 |
+| Speed to offer | 5% | X/5 |
+| Cultural signals | 5% | X/5 |
+| **Global** | **100%** | **X.X/5** |
 
 ### Paso 3 — Guardar Report .md
 
@@ -298,7 +305,7 @@ Formato TSV (una sola línea, sin header, 9 columnas tab-separated):
 
 **IMPORTANTE:** El orden TSV tiene status ANTES de score (col 5→status, col 6→score). En applications.md el orden es inverso (col 5→score, col 6→status). merge-tracker.mjs maneja la conversión.
 
-**Estados canónicos válidos:** `Evaluada`, `Aplicado`, `Respondido`, `Entrevista`, `Oferta`, `Rechazado`, `Descartado`, `NO APLICAR`
+**Valid canonical states:** `Evaluated`, `Applied`, `Responded`, `Contacted`, `Interview`, `Offer`, `Rejected`, `Discarded`, `SKIP`
 
 Donde `{next_num}` se calcula leyendo la última línea de `data/applications.md`.
 

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -25,16 +25,22 @@
 
 ## Scoring System
 
-The evaluation uses 6 blocks (A-F) with a global score of 1-5:
+The evaluation uses 6 blocks (A-F) with a global score of 1-5, calculated from 10 weighted dimensions. This is the same scoring used in single evaluations and multi-offer comparisons, so scores are always comparable.
 
-| Dimension | What it measures |
-|-----------|-----------------|
-| Match con CV | Skills, experience, proof points alignment |
-| North Star alignment | How well the role fits the user's target archetypes (from _profile.md) |
-| Comp | Salary vs market (5=top quartile, 1=well below) |
-| Cultural signals | Company culture, growth, stability, remote policy |
-| Red flags | Blockers, warnings (negative adjustments) |
-| **Global** | Weighted average of above |
+| Dimension | Weight | Criteria 1-5 |
+|-----------|--------|--------------|
+| North Star alignment | 25% | 5=exact target role, 1=unrelated |
+| CV match | 15% | 5=90%+ match, 1=<40% match |
+| Level (senior+) | 15% | 5=staff+, 4=senior, 3=mid-senior, 2=mid, 1=junior |
+| Estimated comp | 10% | 5=top quartile, 1=below market |
+| Growth trajectory | 10% | 5=clear path to next level, 1=dead end |
+| Remote quality | 5% | 5=full remote async, 1=onsite only |
+| Company reputation | 5% | 5=top employer, 1=red flags |
+| Tech stack modernity | 5% | 5=cutting edge AI/ML, 1=legacy |
+| Speed to offer | 5% | 5=fast process, 1=6+ months |
+| Cultural signals | 5% | 5=builder culture, 1=bureaucratic |
+
+**Global score** = weighted average of all 10 dimensions (1-5 scale).
 
 **Score interpretation:**
 - 4.5+ → Strong match, recommend applying immediately

--- a/modes/apply.md
+++ b/modes/apply.md
@@ -1,107 +1,107 @@
-# Modo: apply — Asistente de Aplicación en Vivo
+# Mode: apply -- Live Application Assistant
 
-Modo interactivo para cuando el candidato está rellenando un formulario de aplicación en Chrome. Lee lo que hay en pantalla, carga el contexto previo de la oferta, y genera respuestas personalizadas para cada pregunta del formulario.
+Interactive mode for when the candidate is filling out an application form in Chrome. Reads what is on screen, loads prior offer context, and generates personalised answers for each form question.
 
-## Requisitos
+## Requirements
 
-- **Mejor con Playwright visible**: En modo visible, el candidato ve el navegador y Claude puede interactuar con la página.
-- **Sin Playwright**: el candidato comparte un screenshot o pega las preguntas manualmente.
+- **Best with visible Playwright**: In visible mode, the candidate sees the browser and Claude can interact with the page.
+- **Without Playwright**: the candidate shares a screenshot or pastes the questions manually.
 
 ## Workflow
 
 ```
-1. DETECTAR    → Leer Chrome tab activa (screenshot/URL/título)
-2. IDENTIFICAR → Extraer empresa + rol de la página
-3. BUSCAR      → Match contra reports existentes en reports/
-4. CARGAR      → Leer report completo + Section G (si existe)
-5. COMPARAR    → ¿El rol en pantalla coincide con el evaluado? Si cambió → avisar
-6. ANALIZAR    → Identificar TODAS las preguntas del formulario visibles
-7. GENERAR     → Para cada pregunta, generar respuesta personalizada
-8. PRESENTAR   → Mostrar respuestas formateadas para copy-paste
+1. DETECT    → Read active Chrome tab (screenshot/URL/title)
+2. IDENTIFY  → Extract company + role from the page
+3. SEARCH    → Match against existing reports in reports/
+4. LOAD      → Read full report + Section G (if exists)
+5. COMPARE   → Does the on-screen role match the evaluated one? If changed → warn
+6. ANALYSE   → Identify ALL visible form questions
+7. GENERATE  → For each question, generate a personalised answer
+8. PRESENT   → Show formatted answers for copy-paste
 ```
 
-## Paso 1 — Detectar la oferta
+## Step 1 -- Detect the offer
 
-**Con Playwright:** Tomar snapshot de la página activa. Leer título, URL, y contenido visible.
+**With Playwright:** Take a snapshot of the active page. Read title, URL, and visible content.
 
-**Sin Playwright:** Pedir al candidato que:
-- Comparta un screenshot del formulario (Read tool lee imágenes)
-- O pegue las preguntas del formulario como texto
-- O diga empresa + rol para que lo busquemos
+**Without Playwright:** Ask the candidate to:
+- Share a screenshot of the form (Read tool reads images)
+- Or paste the form questions as text
+- Or state company + role so we can look it up
 
-## Paso 2 — Identificar y buscar contexto
+## Step 2 -- Identify and search for context
 
-1. Extraer nombre de empresa y título del rol de la página
-2. Buscar en `reports/` por nombre de empresa (Grep case-insensitive)
-3. Si hay match → cargar el report completo
-4. Si hay Section G → cargar los draft answers previos como base
-5. Si NO hay match → avisar y ofrecer ejecutar auto-pipeline rápido
+1. Extract company name and role title from the page
+2. Search in `reports/` by company name (Grep case-insensitive)
+3. If match → load the full report
+4. If Section G exists → load the draft answers as a base
+5. If NO match → warn and offer to run a quick auto-pipeline
 
-## Paso 3 — Detectar cambios en el rol
+## Step 3 -- Detect changes in the role
 
-Si el rol en pantalla difiere del evaluado:
-- **Avisar al candidato**: "El rol ha cambiado de [X] a [Y]. ¿Quieres que re-evalúe o adapto las respuestas al nuevo título?"
-- **Si adaptar**: Ajustar las respuestas al nuevo rol sin re-evaluar
-- **Si re-evaluar**: Ejecutar evaluación A-F completa, actualizar report, regenerar Section G
-- **Actualizar tracker**: Cambiar título del rol en applications.md si procede
+If the on-screen role differs from the evaluated one:
+- **Warn the candidate**: "The role has changed from [X] to [Y]. Do you want me to re-evaluate or adapt the answers to the new title?"
+- **If adapt**: Adjust answers to the new role without re-evaluating
+- **If re-evaluate**: Run full A-F evaluation, update report, regenerate Section G
+- **Update tracker**: Change the role title in applications.md if appropriate
 
-## Paso 4 — Analizar preguntas del formulario
+## Step 4 -- Analyse form questions
 
-Identificar TODAS las preguntas visibles:
-- Campos de texto libre (cover letter, why this role, etc.)
-- Dropdowns (how did you hear, work authorization, etc.)
+Identify ALL visible questions:
+- Free text fields (cover letter, why this role, etc.)
+- Dropdowns (how did you hear, work authorisation, etc.)
 - Yes/No (relocation, visa, etc.)
-- Campos de salario (range, expectation)
+- Salary fields (range, expectation)
 - Upload fields (resume, cover letter PDF)
 
-Clasificar cada pregunta:
-- **Ya respondida en Section G** → adaptar la respuesta existente
-- **Nueva pregunta** → generar respuesta desde el report + cv.md
+Classify each question:
+- **Already answered in Section G** → adapt the existing answer
+- **New question** → generate answer from the report + cv.md
 
-## Paso 5 — Generar respuestas
+## Step 5 -- Generate answers
 
-Para cada pregunta, generar la respuesta siguiendo:
+For each question, generate the answer following:
 
-1. **Contexto del report**: Usar proof points del bloque B, historias STAR del bloque F
-2. **Section G previa**: Si existe una respuesta draft, usarla como base y refinar
-3. **Tono "I'm choosing you"**: Mismo framework del auto-pipeline
-4. **Especificidad**: Referenciar algo concreto del JD visible en pantalla
-5. **career-ops proof point**: Incluir en "Additional info" si hay campo para ello
+1. **Report context**: Use proof points from block B, STAR stories from block F
+2. **Prior Section G**: If a draft answer exists, use it as a base and refine
+3. **"I'm choosing you" tone**: Same framework as auto-pipeline
+4. **Specificity**: Reference something concrete from the JD visible on screen
+5. **career-ops proof point**: Include in "Additional info" if there is a field for it
 
-**Formato de output:**
+**Output format:**
 
 ```
-## Respuestas para [Empresa] — [Rol]
+## Answers for [Company] -- [Role]
 
-Basado en: Report #NNN | Score: X.X/5 | Arquetipo: [tipo]
+Based on: Report #NNN | Score: X.X/5 | Archetype: [type]
 
 ---
 
-### 1. [Pregunta exacta del formulario]
-> [Respuesta lista para copy-paste]
+### 1. [Exact form question]
+> [Answer ready for copy-paste]
 
-### 2. [Siguiente pregunta]
-> [Respuesta]
+### 2. [Next question]
+> [Answer]
 
 ...
 
 ---
 
-Notas:
-- [Cualquier observación sobre el rol, cambios, etc.]
-- [Sugerencias de personalización que el candidato debería revisar]
+Notes:
+- [Any observations about the role, changes, etc.]
+- [Personalisation suggestions the candidate should review]
 ```
 
-## Paso 6 — Post-apply (opcional)
+## Step 6 -- Post-apply (optional)
 
-Si el candidato confirma que envió la aplicación:
-1. Actualizar estado en `applications.md` de "Evaluada" a "Aplicado"
-2. Actualizar Section G del report con las respuestas finales
-3. Sugerir siguiente paso: `/career-ops contacto` para LinkedIn outreach
+If the candidate confirms they submitted the application:
+1. Update status in `applications.md` from "Evaluated" to "Applied"
+2. Update Section G of the report with the final answers
+3. Suggest next step: `/career-ops contacto` for LinkedIn outreach
 
 ## Scroll handling
 
-Si el formulario tiene más preguntas que las visibles:
-- Pedir al candidato que haga scroll y comparta otro screenshot
-- O que pegue las preguntas restantes
-- Procesar en iteraciones hasta cubrir todo el formulario
+If the form has more questions than what is visible:
+- Ask the candidate to scroll and share another screenshot
+- Or paste the remaining questions
+- Process in iterations until the entire form is covered

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -1,39 +1,39 @@
-# Modo: auto-pipeline — Pipeline Completo Automático
+# Mode: auto-pipeline -- Full Automatic Pipeline
 
-Cuando el usuario pega un JD (texto o URL) sin sub-comando explícito, ejecutar TODO el pipeline en secuencia:
+When the user pastes a JD (text or URL) without an explicit sub-command, execute the FULL pipeline in sequence:
 
-## Paso 0 — Extraer JD
+## Step 0 -- Extract JD
 
-Si el input es una **URL** (no texto de JD pegado), seguir esta estrategia para extraer el contenido:
+If the input is a **URL** (not pasted JD text), follow this strategy to extract the content:
 
-**Orden de prioridad:**
+**Priority order:**
 
-1. **Playwright (preferido):** La mayoría de portales de empleo (Lever, Ashby, Greenhouse, Workday) son SPAs. Usar `browser_navigate` + `browser_snapshot` para renderizar y leer el JD.
-2. **WebFetch (fallback):** Para páginas estáticas (ZipRecruiter, WeLoveProduct, company career pages).
-3. **WebSearch (último recurso):** Buscar título del rol + empresa en portales secundarios que indexan el JD en HTML estático.
+1. **Playwright (preferred):** Most job portals (Lever, Ashby, Greenhouse, Workday) are SPAs. Use `browser_navigate` + `browser_snapshot` to render and read the JD.
+2. **WebFetch (fallback):** For static pages (ZipRecruiter, WeLoveProduct, company career pages).
+3. **WebSearch (last resort):** Search for the role title + company on secondary portals that index the JD in static HTML.
 
-**Si ningún método funciona:** Pedir al candidato que pegue el JD manualmente o comparta un screenshot.
+**If no method works:** Ask the candidate to paste the JD manually or share a screenshot.
 
-**Si el input es texto de JD** (no URL): usar directamente, sin necesidad de fetch.
+**If the input is JD text** (not a URL): use directly, no need to fetch.
 
-## Paso 1 — Evaluación A-F
-Ejecutar exactamente igual que el modo `oferta` (leer `modes/oferta.md` para todos los bloques A-F).
+## Step 1 -- A-F Evaluation
+Execute exactly as in `oferta` mode (read `modes/oferta.md` for all blocks A-F).
 
-## Paso 2 — Guardar Report .md
-Guardar la evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (ver formato en `modes/oferta.md`).
+## Step 2 -- Save Report .md
+Save the complete evaluation to `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (see format in `modes/oferta.md`).
 
-## Paso 3 — Generar PDF
-Ejecutar el pipeline completo de `pdf` (leer `modes/pdf.md`).
+## Step 3 -- Generate PDF
+Execute the full `pdf` pipeline (read `modes/pdf.md`).
 
-## Paso 4 — Draft Application Answers (solo si score >= 4.5)
+## Step 4 -- Draft Application Answers (only if score >= 4.5)
 
-Si el score final es >= 4.5, generar borrador de respuestas para el formulario de aplicación:
+If the final score is >= 4.5, generate draft answers for the application form:
 
-1. **Extraer preguntas del formulario**: Usar Playwright para navegar al formulario y hacer snapshot. Si no se pueden extraer, usar las preguntas genéricas.
-2. **Generar respuestas** siguiendo el tono (ver abajo).
-3. **Guardar en el report** como sección `## G) Draft Application Answers`.
+1. **Extract form questions**: Use Playwright to navigate to the form and take a snapshot. If questions cannot be extracted, use the generic questions.
+2. **Generate answers** following the tone (see below).
+3. **Save in the report** as section `## G) Draft Application Answers`.
 
-### Preguntas genéricas (usar si no se pueden extraer del formulario)
+### Generic questions (use if form questions cannot be extracted)
 
 - Why are you interested in this role?
 - Why do you want to work at [Company]?
@@ -41,27 +41,27 @@ Si el score final es >= 4.5, generar borrador de respuestas para el formulario d
 - What makes you a good fit for this position?
 - How did you hear about this role?
 
-### Tono para Form Answers
+### Tone for Form Answers
 
-**Posición: "I'm choosing you."** el candidato tiene opciones y está eligiendo esta empresa por razones concretas.
+**Position: "I'm choosing you."** The candidate has options and is choosing this company for concrete reasons.
 
-**Reglas de tono:**
-- **Confiado sin arrogancia**: "I've spent the past year building production AI agent systems — your role is where I want to apply that experience next"
-- **Selectivo sin soberbia**: "I've been intentional about finding a team where I can contribute meaningfully from day one"
-- **Específico y concreto**: Siempre referenciar algo REAL del JD o de la empresa, y algo REAL de la experiencia del candidato
-- **Directo, sin fluff**: 2-4 frases por respuesta. Sin "I'm passionate about..." ni "I would love the opportunity to..."
-- **El hook es la prueba, no la afirmación**: En vez de "I'm great at X", decir "I built X that does Y"
+**Tone rules:**
+- **Confident without arrogance**: "I've spent the past year building production AI agent systems -- your role is where I want to apply that experience next"
+- **Selective without pretension**: "I've been intentional about finding a team where I can contribute meaningfully from day one"
+- **Specific and concrete**: Always reference something REAL from the JD or company, and something REAL from the candidate's experience
+- **Direct, no fluff**: 2-4 sentences per answer. No "I'm passionate about..." or "I would love the opportunity to..."
+- **The hook is the proof, not the claim**: Instead of "I'm great at X", say "I built X that does Y"
 
-**Framework por pregunta:**
+**Framework per question:**
 - **Why this role?** → "Your [specific thing] maps directly to [specific thing I built]."
-- **Why this company?** → Mencionar algo concreto sobre la empresa. "I've been using [product] for [time/purpose]."
-- **Relevant experience?** → Un proof point cuantificado. "Built [X] that [metric]. Sold the company in 2025."
+- **Why this company?** → Mention something concrete about the company. "I've been using [product] for [time/purpose]."
+- **Relevant experience?** → A quantified proof point. "Built [X] that [metric]. Sold the company in 2025."
 - **Good fit?** → "I sit at the intersection of [A] and [B], which is exactly where this role lives."
-- **How did you hear?** → Honesto: "Found through [portal/scan], evaluated against my criteria, and it scored highest."
+- **How did you hear?** → Honest: "Found through [portal/scan], evaluated against my criteria, and it scored highest."
 
-**Idioma**: Siempre en el idioma del JD (EN default). Aplicar `/tech-translate`.
+**Language**: Always in the language of the JD (EN default).
 
-## Paso 5 — Actualizar Tracker
-Registrar en `data/applications.md` con todas las columnas incluyendo Report y PDF en ✅.
+## Step 5 -- Update Tracker
+Register in `data/applications.md` with all columns including Report and PDF as ✅.
 
-**Si algún paso falla**, continuar con los siguientes y marcar el paso fallido como pendiente en el tracker.
+**If any step fails**, continue with the remaining steps and mark the failed step as pending in the tracker.

--- a/modes/batch.md
+++ b/modes/batch.md
@@ -1,73 +1,73 @@
-# Modo: batch — Procesamiento Masivo de Ofertas
+# Mode: batch -- Bulk Offer Processing
 
-Dos modos de uso: **conductor --chrome** (navega portales en tiempo real) o **standalone** (script para URLs ya recolectadas).
+Two usage modes: **conductor --chrome** (navigates portals in real time) or **standalone** (script for pre-collected URLs).
 
-## Arquitectura
+## Architecture
 
 ```
 Claude Conductor (claude --chrome --dangerously-skip-permissions)
   │
-  │  Chrome: navega portales (sesiones logueadas)
-  │  Lee DOM directo — el usuario ve todo en tiempo real
+  │  Chrome: navigates portals (logged-in sessions)
+  │  Reads DOM directly -- the user sees everything in real time
   │
-  ├─ Oferta 1: lee JD del DOM + URL
+  ├─ Offer 1: reads JD from DOM + URL
   │    └─► claude -p worker → report .md + PDF + tracker-line
   │
-  ├─ Oferta 2: click siguiente, lee JD + URL
+  ├─ Offer 2: click next, reads JD + URL
   │    └─► claude -p worker → report .md + PDF + tracker-line
   │
-  └─ Fin: merge tracker-additions → applications.md + resumen
+  └─ End: merge tracker-additions → applications.md + summary
 ```
 
-Cada worker es un `claude -p` hijo con contexto limpio de 200K tokens. El conductor solo orquesta.
+Each worker is a `claude -p` child with a clean 200K token context. The conductor only orchestrates.
 
-## Archivos
+## Files
 
 ```
 batch/
-  batch-input.tsv               # URLs (por conductor o manual)
-  batch-state.tsv               # Progreso (auto-generado, gitignored)
-  batch-runner.sh               # Script orquestador standalone
-  batch-prompt.md               # Prompt template para workers
-  logs/                         # Un log por oferta (gitignored)
-  tracker-additions/            # Líneas de tracker (gitignored)
+  batch-input.tsv               # URLs (from conductor or manual)
+  batch-state.tsv               # Progress (auto-generated, gitignored)
+  batch-runner.sh               # Standalone orchestrator script
+  batch-prompt.md               # Prompt template for workers
+  logs/                         # One log per offer (gitignored)
+  tracker-additions/            # Tracker lines (gitignored)
 ```
 
-## Modo A: Conductor --chrome
+## Mode A: Conductor --chrome
 
-1. **Leer estado**: `batch/batch-state.tsv` → saber qué ya se procesó
-2. **Navegar portal**: Chrome → URL de búsqueda
-3. **Extraer URLs**: Leer DOM de resultados → extraer lista de URLs → append a `batch-input.tsv`
-4. **Para cada URL pendiente**:
-   a. Chrome: click en la oferta → leer JD text del DOM
-   b. Guardar JD a `/tmp/batch-jd-{id}.txt`
-   c. Calcular siguiente REPORT_NUM secuencial
-   d. Ejecutar via Bash:
+1. **Read state**: `batch/batch-state.tsv` → know what was already processed
+2. **Navigate portal**: Chrome → search URL
+3. **Extract URLs**: Read DOM of results → extract URL list → append to `batch-input.tsv`
+4. **For each pending URL**:
+   a. Chrome: click on the offer → read JD text from DOM
+   b. Save JD to `/tmp/batch-jd-{id}.txt`
+   c. Calculate next sequential REPORT_NUM
+   d. Execute via Bash:
       ```bash
       claude -p --dangerously-skip-permissions \
         --append-system-prompt-file batch/batch-prompt.md \
-        "Procesa esta oferta. URL: {url}. JD: /tmp/batch-jd-{id}.txt. Report: {num}. ID: {id}"
+        "Process this offer. URL: {url}. JD: /tmp/batch-jd-{id}.txt. Report: {num}. ID: {id}"
       ```
-   e. Actualizar `batch-state.tsv` (completed/failed + score + report_num)
-   f. Log a `logs/{report_num}-{id}.log`
-   g. Chrome: volver atrás → siguiente oferta
-5. **Paginación**: Si no hay más ofertas → click "Next" → repetir
-6. **Fin**: Merge `tracker-additions/` → `applications.md` + resumen
+   e. Update `batch-state.tsv` (completed/failed + score + report_num)
+   f. Log to `logs/{report_num}-{id}.log`
+   g. Chrome: go back → next offer
+5. **Pagination**: If no more offers → click "Next" → repeat
+6. **End**: Merge `tracker-additions/` → `applications.md` + summary
 
-## Modo B: Script standalone
+## Mode B: Standalone script
 
 ```bash
 batch/batch-runner.sh [OPTIONS]
 ```
 
-Opciones:
-- `--dry-run` — lista pendientes sin ejecutar
-- `--retry-failed` — solo reintenta fallidas
-- `--start-from N` — empieza desde ID N
-- `--parallel N` — N workers en paralelo
-- `--max-retries N` — intentos por oferta (default: 2)
+Options:
+- `--dry-run` — list pending without executing
+- `--retry-failed` — only retry failed ones
+- `--start-from N` — start from ID N
+- `--parallel N` — N workers in parallel
+- `--max-retries N` — attempts per offer (default: 2)
 
-## Formato batch-state.tsv
+## batch-state.tsv format
 
 ```
 id	url	status	started_at	completed_at	report_num	score	error	retries
@@ -76,29 +76,29 @@ id	url	status	started_at	completed_at	report_num	score	error	retries
 3	https://...	pending	-	-	-	-	-	0
 ```
 
-## Resumabilidad
+## Resumability
 
-- Si muere → re-ejecutar → lee `batch-state.tsv` → skip completadas
-- Lock file (`batch-runner.pid`) previene ejecución doble
-- Cada worker es independiente: fallo en oferta #47 no afecta a las demás
+- If it dies → re-run → reads `batch-state.tsv` → skips completed
+- Lock file (`batch-runner.pid`) prevents double execution
+- Each worker is independent: failure on offer #47 does not affect the rest
 
 ## Workers (claude -p)
 
-Cada worker recibe `batch-prompt.md` como system prompt. Es self-contained.
+Each worker receives `batch-prompt.md` as system prompt. It is self-contained.
 
-El worker produce:
-1. Report `.md` en `reports/`
-2. PDF en `output/`
-3. Línea de tracker en `batch/tracker-additions/{id}.tsv`
-4. JSON de resultado por stdout
+The worker produces:
+1. Report `.md` in `reports/`
+2. PDF in `output/`
+3. Tracker line in `batch/tracker-additions/{id}.tsv`
+4. JSON result via stdout
 
-## Gestión de errores
+## Error handling
 
 | Error | Recovery |
 |-------|----------|
-| URL inaccesible | Worker falla → conductor marca `failed`, siguiente |
-| JD detrás de login | Conductor intenta leer DOM. Si falla → `failed` |
-| Portal cambia layout | Conductor razona sobre HTML, se adapta |
-| Worker crashea | Conductor marca `failed`, siguiente. Retry con `--retry-failed` |
-| Conductor muere | Re-ejecutar → lee state → skip completadas |
-| PDF falla | Report .md se guarda. PDF queda pendiente |
+| URL inaccessible | Worker fails → conductor marks `failed`, next |
+| JD behind login | Conductor tries to read DOM. If fails → `failed` |
+| Portal changes layout | Conductor reasons about HTML, adapts |
+| Worker crashes | Conductor marks `failed`, next. Retry with `--retry-failed` |
+| Conductor dies | Re-run → reads state → skips completed |
+| PDF fails | Report .md is saved. PDF remains pending |

--- a/modes/contacto.md
+++ b/modes/contacto.md
@@ -1,26 +1,35 @@
-# Modo: contacto — LinkedIn Power Move
+# Mode: contacto -- LinkedIn Power Move
 
-1. **Identificar targets** via WebSearch:
-   - Hiring manager del equipo
-   - Recruiter asignado
-   - 2-3 peers del equipo (gente con rol similar)
+1. **Identify targets** via WebSearch:
+   - Hiring manager for the team
+   - Assigned recruiter
+   - 2-3 team peers (people in a similar role)
 
-2. **Seleccionar target primario**: la persona que más se beneficiaría de que el candidato estuviera allí
+2. **Select primary target**: the person who would benefit most from the candidate being there
 
-3. **Generar mensaje** con framework de 3 frases:
-   - **Frase 1 (Gancho)**: Algo específico sobre su empresa o reto actual con IA (NO genérico)
-   - **Frase 2 (Prueba)**: Mayor logro cuantificable del candidato relevante para ESE rol (ej: "I built an AI agent handling 90% of customer service at my company before selling it")
-   - **Frase 3 (Propuesta)**: Charla rápida, sin presión ("Would love to chat about [tema específico] for 15 min")
+3. **Generate message** with 3-phrase framework:
+   - **Phrase 1 (Hook)**: Something specific about their company or current AI challenge (NOT generic)
+   - **Phrase 2 (Proof)**: Candidate's top quantifiable achievement relevant to THAT role (e.g. "I built an AI agent handling 90% of customer service at my company before selling it")
+   - **Phrase 3 (Proposal)**: Quick chat, no pressure ("Would love to chat about [specific topic] for 15 min")
 
-4. **Versiones**:
-   - EN (default)
-   - ES (si empresa española)
+4. **Variants**:
+   - **Connection request** (max 300 characters): Ultra-concise version -- hook + one proof + proposal
+   - **InMail** (max 2000 characters): Extended version with more context, a second proof point, and specific ask
+   - **Email** (if address found): Same as InMail but with subject line
 
-5. **Targets alternativos** con justificación de por qué son buenos second choices
+5. **Follow-up template** (if no response after 5-7 days):
+   - Reference original message briefly
+   - Add a new angle or recent proof point
+   - Lower the ask ("Even a 5-min async reply would be valuable")
+   - Max 2 follow-ups total -- respect their time
 
-**Reglas del mensaje:**
-- Máximo 300 caracteres (LinkedIn connection request limit)
+6. **Alternative targets** with justification for why they are good second choices
+
+7. **Update tracker**: After outreach is sent, update status in `applications.md` to "Contacted" with note on who was contacted
+
+**Message rules:**
 - NO corporate-speak
 - NO "I'm passionate about..."
-- Algo que haga que quieran responder
-- NUNCA compartir teléfono
+- Something that makes them want to respond
+- NEVER share phone number
+- Match the language of the JD/company (EN default)

--- a/modes/deep.md
+++ b/modes/deep.md
@@ -1,47 +1,126 @@
-# Modo: deep — Deep Research Prompt
+# Mode: deep -- Deep Company Research
 
-Genera un prompt estructurado para Perplexity/Claude/ChatGPT con 6 ejes:
+Executes structured research across 6 axes using WebSearch, compiles findings into a report, and highlights actionable insights for interviews.
+
+## Inputs
+
+- Company name (required)
+- Role title (optional -- if provided, personalise axis 6)
+- Existing report number (optional -- if provided, load context from that evaluation)
+
+## Execution
+
+Read `cv.md` and `config/profile.yml` for candidate context before starting.
+
+### Axis 1 -- AI Strategy
+WebSearch queries:
+- `"{company}" AI strategy OR AI roadmap OR machine learning`
+- `"{company}" engineering blog AI`
+- `"{company}" AI papers OR talks OR conference`
+
+Compile:
+- What products/features use AI/ML?
+- What is their AI stack? (models, infra, tools)
+- Do they have an engineering blog? What do they publish?
+- What papers or talks have they given about AI?
+
+### Axis 2 -- Recent Moves (last 6 months)
+WebSearch queries:
+- `"{company}" hiring AI OR ML site:linkedin.com`
+- `"{company}" acquisition OR partnership 2026`
+- `"{company}" product launch OR funding OR leadership`
+
+Compile:
+- Relevant hires in AI/ML/product?
+- Acquisitions or partnerships?
+- Product launches or pivots?
+- Funding rounds or leadership changes?
+
+### Axis 3 -- Engineering Culture
+WebSearch queries:
+- `"{company}" engineering culture site:glassdoor.com`
+- `"{company}" engineering culture site:blind`
+- `"{company}" tech stack OR developer experience`
+
+Compile:
+- How do they ship? (deploy cadence, CI/CD)
+- Mono-repo or multi-repo?
+- What languages/frameworks do they use?
+- Remote-first or office-first?
+- Glassdoor/Blind reviews on engineering culture?
+
+### Axis 4 -- Probable Challenges
+WebSearch queries:
+- `"{company}" scaling challenges OR reliability OR technical debt`
+- `"{company}" engineering problems`
+
+Compile:
+- What scaling problems do they have?
+- Reliability, cost, latency challenges?
+- Are they migrating something? (infra, models, platforms)
+- What pain points do people mention in reviews?
+
+### Axis 5 -- Competitors and Differentiation
+WebSearch queries:
+- `"{company}" vs OR competitors OR alternatives`
+- `"{company}" market position OR differentiation`
+
+Compile:
+- Who are their main competitors?
+- What is their moat/differentiator?
+- How do they position themselves vs competition?
+
+### Axis 6 -- Candidate Angle
+Using cv.md and profile.yml:
+- What unique value does the candidate bring to this team?
+- Which candidate projects are most relevant?
+- What story should they tell in the interview?
+- What questions should the candidate ask that show deep understanding?
+
+## Output
+
+Save the compiled research to `reports/deep-{company-slug}-{YYYY-MM-DD}.md`:
+
+```markdown
+# Deep Research: {Company} -- {Role}
+
+**Date:** {YYYY-MM-DD}
+**Sources:** {N} unique sources consulted
+
+---
+
+## 1. AI Strategy
+(findings with source links)
+
+## 2. Recent Moves
+(findings with source links)
+
+## 3. Engineering Culture
+(findings with source links)
+
+## 4. Probable Challenges
+(findings with source links)
+
+## 5. Competitors and Differentiation
+(findings with source links)
+
+## 6. Candidate Angle
+(personalised analysis)
+
+---
+
+## Key Talking Points for Interview
+- (3-5 bullet points the candidate should weave into conversation)
+
+## Questions to Ask the Interviewer
+- (3-5 questions that demonstrate research depth)
+```
+
+## Fallback
+
+If WebSearch yields thin results for any axis, include a pre-formatted prompt the user can paste into Perplexity or ChatGPT for deeper digging:
 
 ```
-## Deep Research: [Empresa] — [Rol]
-
-Contexto: Estoy evaluando una candidatura para [rol] en [empresa]. Necesito información accionable para la entrevista.
-
-### 1. Estrategia AI
-- ¿Qué productos/features usan AI/ML?
-- ¿Cuál es su stack de AI? (modelos, infra, tools)
-- ¿Tienen blog de engineering? ¿Qué publican?
-- ¿Qué papers o talks han dado sobre AI?
-
-### 2. Movimientos recientes (últimos 6 meses)
-- ¿Contrataciones relevantes en AI/ML/product?
-- ¿Acquisitions o partnerships?
-- ¿Product launches o pivots?
-- ¿Rondas de funding o cambios de liderazgo?
-
-### 3. Cultura de engineering
-- ¿Cómo shipean? (cadencia de deploy, CI/CD)
-- ¿Mono-repo o multi-repo?
-- ¿Qué lenguajes/frameworks usan?
-- ¿Remote-first o office-first?
-- ¿Glassdoor/Blind reviews sobre eng culture?
-
-### 4. Retos probables
-- ¿Qué problemas de scaling tienen?
-- ¿Reliability, cost, latency challenges?
-- ¿Están migrando algo? (infra, models, platforms)
-- ¿Qué pain points menciona la gente en reviews?
-
-### 5. Competidores y diferenciación
-- ¿Quiénes son sus main competitors?
-- ¿Cuál es su moat/diferenciador?
-- ¿Cómo se posicionan vs competencia?
-
-### 6. Ángulo del candidato
-Dado mi perfil (read from cv.md and profile.yml for specific experience):
-- ¿Qué valor único aporto a este equipo?
-- ¿Qué proyectos míos son más relevantes?
-- ¿Qué historia debería contar en la entrevista?
+Thin results for Axis {N}. Try this in Perplexity:
+> "{formatted search prompt}"
 ```
-
-Personalizar cada sección con el contexto específico de la oferta evaluada.

--- a/modes/es/apply.md
+++ b/modes/es/apply.md
@@ -1,0 +1,107 @@
+# Modo: apply — Asistente de Aplicación en Vivo
+
+Modo interactivo para cuando el candidato está rellenando un formulario de aplicación en Chrome. Lee lo que hay en pantalla, carga el contexto previo de la oferta, y genera respuestas personalizadas para cada pregunta del formulario.
+
+## Requisitos
+
+- **Mejor con Playwright visible**: En modo visible, el candidato ve el navegador y Claude puede interactuar con la página.
+- **Sin Playwright**: el candidato comparte un screenshot o pega las preguntas manualmente.
+
+## Workflow
+
+```
+1. DETECTAR    → Leer Chrome tab activa (screenshot/URL/título)
+2. IDENTIFICAR → Extraer empresa + rol de la página
+3. BUSCAR      → Match contra reports existentes en reports/
+4. CARGAR      → Leer report completo + Section G (si existe)
+5. COMPARAR    → ¿El rol en pantalla coincide con el evaluado? Si cambió → avisar
+6. ANALIZAR    → Identificar TODAS las preguntas del formulario visibles
+7. GENERAR     → Para cada pregunta, generar respuesta personalizada
+8. PRESENTAR   → Mostrar respuestas formateadas para copy-paste
+```
+
+## Paso 1 — Detectar la oferta
+
+**Con Playwright:** Tomar snapshot de la página activa. Leer título, URL, y contenido visible.
+
+**Sin Playwright:** Pedir al candidato que:
+- Comparta un screenshot del formulario (Read tool lee imágenes)
+- O pegue las preguntas del formulario como texto
+- O diga empresa + rol para que lo busquemos
+
+## Paso 2 — Identificar y buscar contexto
+
+1. Extraer nombre de empresa y título del rol de la página
+2. Buscar en `reports/` por nombre de empresa (Grep case-insensitive)
+3. Si hay match → cargar el report completo
+4. Si hay Section G → cargar los draft answers previos como base
+5. Si NO hay match → avisar y ofrecer ejecutar auto-pipeline rápido
+
+## Paso 3 — Detectar cambios en el rol
+
+Si el rol en pantalla difiere del evaluado:
+- **Avisar al candidato**: "El rol ha cambiado de [X] a [Y]. ¿Quieres que re-evalúe o adapto las respuestas al nuevo título?"
+- **Si adaptar**: Ajustar las respuestas al nuevo rol sin re-evaluar
+- **Si re-evaluar**: Ejecutar evaluación A-F completa, actualizar report, regenerar Section G
+- **Actualizar tracker**: Cambiar título del rol en applications.md si procede
+
+## Paso 4 — Analizar preguntas del formulario
+
+Identificar TODAS las preguntas visibles:
+- Campos de texto libre (cover letter, why this role, etc.)
+- Dropdowns (how did you hear, work authorization, etc.)
+- Yes/No (relocation, visa, etc.)
+- Campos de salario (range, expectation)
+- Upload fields (resume, cover letter PDF)
+
+Clasificar cada pregunta:
+- **Ya respondida en Section G** → adaptar la respuesta existente
+- **Nueva pregunta** → generar respuesta desde el report + cv.md
+
+## Paso 5 — Generar respuestas
+
+Para cada pregunta, generar la respuesta siguiendo:
+
+1. **Contexto del report**: Usar proof points del bloque B, historias STAR del bloque F
+2. **Section G previa**: Si existe una respuesta draft, usarla como base y refinar
+3. **Tono "I'm choosing you"**: Mismo framework del auto-pipeline
+4. **Especificidad**: Referenciar algo concreto del JD visible en pantalla
+5. **career-ops proof point**: Incluir en "Additional info" si hay campo para ello
+
+**Formato de output:**
+
+```
+## Respuestas para [Empresa] — [Rol]
+
+Basado en: Report #NNN | Score: X.X/5 | Arquetipo: [tipo]
+
+---
+
+### 1. [Pregunta exacta del formulario]
+> [Respuesta lista para copy-paste]
+
+### 2. [Siguiente pregunta]
+> [Respuesta]
+
+...
+
+---
+
+Notas:
+- [Cualquier observación sobre el rol, cambios, etc.]
+- [Sugerencias de personalización que el candidato debería revisar]
+```
+
+## Paso 6 — Post-apply (opcional)
+
+Si el candidato confirma que envió la aplicación:
+1. Actualizar estado en `applications.md` de "Evaluada" a "Aplicado"
+2. Actualizar Section G del report con las respuestas finales
+3. Sugerir siguiente paso: `/career-ops contacto` para LinkedIn outreach
+
+## Scroll handling
+
+Si el formulario tiene más preguntas que las visibles:
+- Pedir al candidato que haga scroll y comparta otro screenshot
+- O que pegue las preguntas restantes
+- Procesar en iteraciones hasta cubrir todo el formulario

--- a/modes/es/auto-pipeline.md
+++ b/modes/es/auto-pipeline.md
@@ -1,0 +1,67 @@
+# Modo: auto-pipeline — Pipeline Completo Automático
+
+Cuando el usuario pega un JD (texto o URL) sin sub-comando explícito, ejecutar TODO el pipeline en secuencia:
+
+## Paso 0 — Extraer JD
+
+Si el input es una **URL** (no texto de JD pegado), seguir esta estrategia para extraer el contenido:
+
+**Orden de prioridad:**
+
+1. **Playwright (preferido):** La mayoría de portales de empleo (Lever, Ashby, Greenhouse, Workday) son SPAs. Usar `browser_navigate` + `browser_snapshot` para renderizar y leer el JD.
+2. **WebFetch (fallback):** Para páginas estáticas (ZipRecruiter, WeLoveProduct, company career pages).
+3. **WebSearch (último recurso):** Buscar título del rol + empresa en portales secundarios que indexan el JD en HTML estático.
+
+**Si ningún método funciona:** Pedir al candidato que pegue el JD manualmente o comparta un screenshot.
+
+**Si el input es texto de JD** (no URL): usar directamente, sin necesidad de fetch.
+
+## Paso 1 — Evaluación A-F
+Ejecutar exactamente igual que el modo `oferta` (leer `modes/oferta.md` para todos los bloques A-F).
+
+## Paso 2 — Guardar Report .md
+Guardar la evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (ver formato en `modes/oferta.md`).
+
+## Paso 3 — Generar PDF
+Ejecutar el pipeline completo de `pdf` (leer `modes/pdf.md`).
+
+## Paso 4 — Draft Application Answers (solo si score >= 4.5)
+
+Si el score final es >= 4.5, generar borrador de respuestas para el formulario de aplicación:
+
+1. **Extraer preguntas del formulario**: Usar Playwright para navegar al formulario y hacer snapshot. Si no se pueden extraer, usar las preguntas genéricas.
+2. **Generar respuestas** siguiendo el tono (ver abajo).
+3. **Guardar en el report** como sección `## G) Draft Application Answers`.
+
+### Preguntas genéricas (usar si no se pueden extraer del formulario)
+
+- Why are you interested in this role?
+- Why do you want to work at [Company]?
+- Tell us about a relevant project or achievement
+- What makes you a good fit for this position?
+- How did you hear about this role?
+
+### Tono para Form Answers
+
+**Posición: "I'm choosing you."** el candidato tiene opciones y está eligiendo esta empresa por razones concretas.
+
+**Reglas de tono:**
+- **Confiado sin arrogancia**: "I've spent the past year building production AI agent systems — your role is where I want to apply that experience next"
+- **Selectivo sin soberbia**: "I've been intentional about finding a team where I can contribute meaningfully from day one"
+- **Específico y concreto**: Siempre referenciar algo REAL del JD o de la empresa, y algo REAL de la experiencia del candidato
+- **Directo, sin fluff**: 2-4 frases por respuesta. Sin "I'm passionate about..." ni "I would love the opportunity to..."
+- **El hook es la prueba, no la afirmación**: En vez de "I'm great at X", decir "I built X that does Y"
+
+**Framework por pregunta:**
+- **Why this role?** → "Your [specific thing] maps directly to [specific thing I built]."
+- **Why this company?** → Mencionar algo concreto sobre la empresa. "I've been using [product] for [time/purpose]."
+- **Relevant experience?** → Un proof point cuantificado. "Built [X] that [metric]. Sold the company in 2025."
+- **Good fit?** → "I sit at the intersection of [A] and [B], which is exactly where this role lives."
+- **How did you hear?** → Honesto: "Found through [portal/scan], evaluated against my criteria, and it scored highest."
+
+**Idioma**: Siempre en el idioma del JD (EN default). Aplicar `/tech-translate`.
+
+## Paso 5 — Actualizar Tracker
+Registrar en `data/applications.md` con todas las columnas incluyendo Report y PDF en ✅.
+
+**Si algún paso falla**, continuar con los siguientes y marcar el paso fallido como pendiente en el tracker.

--- a/modes/es/batch.md
+++ b/modes/es/batch.md
@@ -1,0 +1,104 @@
+# Modo: batch — Procesamiento Masivo de Ofertas
+
+Dos modos de uso: **conductor --chrome** (navega portales en tiempo real) o **standalone** (script para URLs ya recolectadas).
+
+## Arquitectura
+
+```
+Claude Conductor (claude --chrome --dangerously-skip-permissions)
+  │
+  │  Chrome: navega portales (sesiones logueadas)
+  │  Lee DOM directo — el usuario ve todo en tiempo real
+  │
+  ├─ Oferta 1: lee JD del DOM + URL
+  │    └─► claude -p worker → report .md + PDF + tracker-line
+  │
+  ├─ Oferta 2: click siguiente, lee JD + URL
+  │    └─► claude -p worker → report .md + PDF + tracker-line
+  │
+  └─ Fin: merge tracker-additions → applications.md + resumen
+```
+
+Cada worker es un `claude -p` hijo con contexto limpio de 200K tokens. El conductor solo orquesta.
+
+## Archivos
+
+```
+batch/
+  batch-input.tsv               # URLs (por conductor o manual)
+  batch-state.tsv               # Progreso (auto-generado, gitignored)
+  batch-runner.sh               # Script orquestador standalone
+  batch-prompt.md               # Prompt template para workers
+  logs/                         # Un log por oferta (gitignored)
+  tracker-additions/            # Líneas de tracker (gitignored)
+```
+
+## Modo A: Conductor --chrome
+
+1. **Leer estado**: `batch/batch-state.tsv` → saber qué ya se procesó
+2. **Navegar portal**: Chrome → URL de búsqueda
+3. **Extraer URLs**: Leer DOM de resultados → extraer lista de URLs → append a `batch-input.tsv`
+4. **Para cada URL pendiente**:
+   a. Chrome: click en la oferta → leer JD text del DOM
+   b. Guardar JD a `/tmp/batch-jd-{id}.txt`
+   c. Calcular siguiente REPORT_NUM secuencial
+   d. Ejecutar via Bash:
+      ```bash
+      claude -p --dangerously-skip-permissions \
+        --append-system-prompt-file batch/batch-prompt.md \
+        "Procesa esta oferta. URL: {url}. JD: /tmp/batch-jd-{id}.txt. Report: {num}. ID: {id}"
+      ```
+   e. Actualizar `batch-state.tsv` (completed/failed + score + report_num)
+   f. Log a `logs/{report_num}-{id}.log`
+   g. Chrome: volver atrás → siguiente oferta
+5. **Paginación**: Si no hay más ofertas → click "Next" → repetir
+6. **Fin**: Merge `tracker-additions/` → `applications.md` + resumen
+
+## Modo B: Script standalone
+
+```bash
+batch/batch-runner.sh [OPTIONS]
+```
+
+Opciones:
+- `--dry-run` — lista pendientes sin ejecutar
+- `--retry-failed` — solo reintenta fallidas
+- `--start-from N` — empieza desde ID N
+- `--parallel N` — N workers en paralelo
+- `--max-retries N` — intentos por oferta (default: 2)
+
+## Formato batch-state.tsv
+
+```
+id	url	status	started_at	completed_at	report_num	score	error	retries
+1	https://...	completed	2026-...	2026-...	002	4.2	-	0
+2	https://...	failed	2026-...	2026-...	-	-	Error msg	1
+3	https://...	pending	-	-	-	-	-	0
+```
+
+## Resumabilidad
+
+- Si muere → re-ejecutar → lee `batch-state.tsv` → skip completadas
+- Lock file (`batch-runner.pid`) previene ejecución doble
+- Cada worker es independiente: fallo en oferta #47 no afecta a las demás
+
+## Workers (claude -p)
+
+Cada worker recibe `batch-prompt.md` como system prompt. Es self-contained.
+
+El worker produce:
+1. Report `.md` en `reports/`
+2. PDF en `output/`
+3. Línea de tracker en `batch/tracker-additions/{id}.tsv`
+4. JSON de resultado por stdout
+
+## Gestión de errores
+
+| Error | Recovery |
+|-------|----------|
+| URL inaccesible | Worker falla → conductor marca `failed`, siguiente |
+| JD detrás de login | Conductor intenta leer DOM. Si falla → `failed` |
+| Portal cambia layout | Conductor razona sobre HTML, se adapta |
+| Worker crashea | Conductor marca `failed`, siguiente. Retry con `--retry-failed` |
+| Conductor muere | Re-ejecutar → lee state → skip completadas |
+| PDF falla | Report .md se guarda. PDF queda pendiente |

--- a/modes/es/contacto.md
+++ b/modes/es/contacto.md
@@ -1,0 +1,26 @@
+# Modo: contacto — LinkedIn Power Move
+
+1. **Identificar targets** via WebSearch:
+   - Hiring manager del equipo
+   - Recruiter asignado
+   - 2-3 peers del equipo (gente con rol similar)
+
+2. **Seleccionar target primario**: la persona que más se beneficiaría de que el candidato estuviera allí
+
+3. **Generar mensaje** con framework de 3 frases:
+   - **Frase 1 (Gancho)**: Algo específico sobre su empresa o reto actual con IA (NO genérico)
+   - **Frase 2 (Prueba)**: Mayor logro cuantificable del candidato relevante para ESE rol (ej: "I built an AI agent handling 90% of customer service at my company before selling it")
+   - **Frase 3 (Propuesta)**: Charla rápida, sin presión ("Would love to chat about [tema específico] for 15 min")
+
+4. **Versiones**:
+   - EN (default)
+   - ES (si empresa española)
+
+5. **Targets alternativos** con justificación de por qué son buenos second choices
+
+**Reglas del mensaje:**
+- Máximo 300 caracteres (LinkedIn connection request limit)
+- NO corporate-speak
+- NO "I'm passionate about..."
+- Algo que haga que quieran responder
+- NUNCA compartir teléfono

--- a/modes/es/deep.md
+++ b/modes/es/deep.md
@@ -1,0 +1,47 @@
+# Modo: deep — Deep Research Prompt
+
+Genera un prompt estructurado para Perplexity/Claude/ChatGPT con 6 ejes:
+
+```
+## Deep Research: [Empresa] — [Rol]
+
+Contexto: Estoy evaluando una candidatura para [rol] en [empresa]. Necesito información accionable para la entrevista.
+
+### 1. Estrategia AI
+- ¿Qué productos/features usan AI/ML?
+- ¿Cuál es su stack de AI? (modelos, infra, tools)
+- ¿Tienen blog de engineering? ¿Qué publican?
+- ¿Qué papers o talks han dado sobre AI?
+
+### 2. Movimientos recientes (últimos 6 meses)
+- ¿Contrataciones relevantes en AI/ML/product?
+- ¿Acquisitions o partnerships?
+- ¿Product launches o pivots?
+- ¿Rondas de funding o cambios de liderazgo?
+
+### 3. Cultura de engineering
+- ¿Cómo shipean? (cadencia de deploy, CI/CD)
+- ¿Mono-repo o multi-repo?
+- ¿Qué lenguajes/frameworks usan?
+- ¿Remote-first o office-first?
+- ¿Glassdoor/Blind reviews sobre eng culture?
+
+### 4. Retos probables
+- ¿Qué problemas de scaling tienen?
+- ¿Reliability, cost, latency challenges?
+- ¿Están migrando algo? (infra, models, platforms)
+- ¿Qué pain points menciona la gente en reviews?
+
+### 5. Competidores y diferenciación
+- ¿Quiénes son sus main competitors?
+- ¿Cuál es su moat/diferenciador?
+- ¿Cómo se posicionan vs competencia?
+
+### 6. Ángulo del candidato
+Dado mi perfil (read from cv.md and profile.yml for specific experience):
+- ¿Qué valor único aporto a este equipo?
+- ¿Qué proyectos míos son más relevantes?
+- ¿Qué historia debería contar en la entrevista?
+```
+
+Personalizar cada sección con el contexto específico de la oferta evaluada.

--- a/modes/es/oferta.md
+++ b/modes/es/oferta.md
@@ -1,0 +1,157 @@
+# Modo: oferta — Evaluación Completa A-F
+
+Cuando el candidato pega una oferta (texto o URL), entregar SIEMPRE los 6 bloques:
+
+## Paso 0 — Detección de Arquetipo
+
+Clasificar la oferta en uno de los 6 arquetipos (ver `_shared.md`). Si es híbrido, indicar los 2 más cercanos. Esto determina:
+- Qué proof points priorizar en bloque B
+- Cómo reescribir el summary en bloque E
+- Qué historias STAR preparar en bloque F
+
+## Bloque A — Resumen del Rol
+
+Tabla con:
+- Arquetipo detectado
+- Domain (platform/agentic/LLMOps/ML/enterprise)
+- Function (build/consult/manage/deploy)
+- Seniority
+- Remote (full/hybrid/onsite)
+- Team size (si se menciona)
+- TL;DR en 1 frase
+
+## Bloque B — Match con CV
+
+Lee `cv.md`. Crea tabla con cada requisito del JD mapeado a líneas exactas del CV.
+
+**Adaptado al arquetipo:**
+- Si FDE → priorizar proof points de delivery rápida y client-facing
+- Si SA → priorizar diseño de sistemas e integrations
+- Si PM → priorizar product discovery y métricas
+- Si LLMOps → priorizar evals, observability, pipelines
+- Si Agentic → priorizar multi-agent, HITL, orchestration
+- Si Transformation → priorizar change management, adoption, scaling
+
+Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
+1. ¿Es un hard blocker o un nice-to-have?
+2. ¿Puede el candidato demostrar experiencia adyacente?
+3. ¿Hay un proyecto portfolio que cubra este gap?
+4. Plan de mitigación concreto (frase para cover letter, proyecto rápido, etc.)
+
+## Bloque C — Nivel y Estrategia
+
+1. **Nivel detectado** en el JD vs **nivel natural del candidato para ese arquetipo**
+2. **Plan "vender senior sin mentir"**: frases específicas adaptadas al arquetipo, logros concretos a destacar, cómo posicionar la experiencia de founder como ventaja
+3. **Plan "si me downlevelan"**: aceptar si comp es justa, negociar review a 6 meses, criterios de promoción claros
+
+## Bloque D — Comp y Demanda
+
+Usar WebSearch para:
+- Salarios actuales del rol (Glassdoor, Levels.fyi, Blind)
+- Reputación de compensación de la empresa
+- Tendencia de demanda del rol
+
+Tabla con datos y fuentes citadas. Si no hay datos, decirlo en vez de inventar.
+
+## Bloque E — Plan de Personalización
+
+| # | Sección | Estado actual | Cambio propuesto | Por qué |
+|---|---------|---------------|------------------|---------|
+| 1 | Summary | ... | ... | ... |
+| ... | ... | ... | ... | ... |
+
+Top 5 cambios al CV + Top 5 cambios a LinkedIn para maximizar match.
+
+## Bloque F — Plan de Entrevistas
+
+6-10 historias STAR+R mapeadas a requisitos del JD (STAR + **Reflection**):
+
+| # | Requisito del JD | Historia STAR+R | S | T | A | R | Reflection |
+|---|-----------------|-----------------|---|---|---|---|------------|
+
+The **Reflection** column captures what was learned or what would be done differently. This signals seniority — junior candidates describe what happened, senior candidates extract lessons.
+
+**Story Bank:** If `interview-prep/story-bank.md` exists, check if any of these stories are already there. If not, append new ones. Over time this builds a reusable bank of 5-10 master stories that can be adapted to any interview question.
+
+**Seleccionadas y enmarcadas según el arquetipo:**
+- FDE → enfatizar velocidad de entrega y client-facing
+- SA → enfatizar decisiones de arquitectura
+- PM → enfatizar discovery y trade-offs
+- LLMOps → enfatizar métricas, evals, production hardening
+- Agentic → enfatizar orchestration, error handling, HITL
+- Transformation → enfatizar adopción, cambio organizacional
+
+Incluir también:
+- 1 case study recomendado (cuál de sus proyectos presentar y cómo)
+- Preguntas red-flag y cómo responderlas (ej: "¿por qué vendiste tu empresa?", "¿tienes equipo de reports?")
+
+---
+
+## Post-evaluación
+
+**SIEMPRE** después de generar los bloques A-F:
+
+### 1. Guardar report .md
+
+Guardar evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+
+- `{###}` = siguiente número secuencial (3 dígitos, zero-padded)
+- `{company-slug}` = nombre de empresa en lowercase, sin espacios (usar guiones)
+- `{YYYY-MM-DD}` = fecha actual
+
+**Formato del report:**
+
+```markdown
+# Evaluación: {Empresa} — {Rol}
+
+**Fecha:** {YYYY-MM-DD}
+**Arquetipo:** {detectado}
+**Score:** {X/5}
+**PDF:** {ruta o pendiente}
+
+---
+
+## A) Resumen del Rol
+(contenido completo del bloque A)
+
+## B) Match con CV
+(contenido completo del bloque B)
+
+## C) Nivel y Estrategia
+(contenido completo del bloque C)
+
+## D) Comp y Demanda
+(contenido completo del bloque D)
+
+## E) Plan de Personalización
+(contenido completo del bloque E)
+
+## F) Plan de Entrevistas
+(contenido completo del bloque F)
+
+## G) Draft Application Answers
+(solo si score >= 4.5 — borradores de respuestas para el formulario de aplicación)
+
+---
+
+## Keywords extraídas
+(lista de 15-20 keywords del JD para ATS optimization)
+```
+
+### 2. Registrar en tracker
+
+**SIEMPRE** registrar en `data/applications.md`:
+- Siguiente número secuencial
+- Fecha actual
+- Empresa
+- Rol
+- Score: promedio de match (1-5)
+- Estado: `Evaluada`
+- PDF: ❌ (o ✅ si auto-pipeline generó PDF)
+- Report: link relativo al report .md (ej: `[001](reports/001-company-2026-01-01.md)`)
+
+**Formato del tracker:**
+
+```markdown
+| # | Fecha | Empresa | Rol | Score | Estado | PDF | Report |
+```

--- a/modes/es/ofertas.md
+++ b/modes/es/ofertas.md
@@ -1,0 +1,21 @@
+# Modo: ofertas — Comparación Multi-Oferta
+
+Scoring matrix de 10 dimensiones ponderadas:
+
+| Dimensión | Peso | Criterios 1-5 |
+|-----------|------|----------------|
+| Alineación North Star | 25% | 5=rol target exacto, 1=no relacionado |
+| Match CV | 15% | 5=90%+ match, 1=<40% match |
+| Nivel (senior+) | 15% | 5=staff+, 4=senior, 3=mid-senior, 2=mid, 1=junior |
+| Comp estimada | 10% | 5=top quartile, 1=below market |
+| Trayectoria crecimiento | 10% | 5=clear path to next level, 1=dead end |
+| Calidad remoto | 5% | 5=full remote async, 1=onsite only |
+| Reputación empresa | 5% | 5=top employer, 1=red flags |
+| Modernidad tech stack | 5% | 5=cutting edge AI/ML, 1=legacy |
+| Velocidad a oferta | 5% | 5=fast process, 1=6+ months |
+| Señales culturales | 5% | 5=builder culture, 1=bureaucratic |
+
+Para cada oferta: score en cada dimensión, score ponderado total.
+Ranking final + recomendación con consideraciones de time-to-offer.
+
+Pedir al usuario las ofertas si no están en contexto. Puede ser texto, URLs, o referencias a ofertas ya evaluadas en el tracker.

--- a/modes/es/pipeline.md
+++ b/modes/es/pipeline.md
@@ -1,0 +1,57 @@
+# Modo: pipeline — Inbox de URLs (Second Brain)
+
+Procesa URLs de ofertas acumuladas en `data/pipeline.md`. El usuario agrega URLs cuando quiera y luego ejecuta `/career-ops pipeline` para procesarlas todas.
+
+## Workflow
+
+1. **Leer** `data/pipeline.md` → buscar items `- [ ]` en la sección "Pendientes"
+2. **Para cada URL pendiente**:
+   a. Calcular siguiente `REPORT_NUM` secuencial (leer `reports/`, tomar el número más alto + 1)
+   b. **Extraer JD** usando Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
+   c. Si la URL no es accesible → marcar como `- [!]` con nota y continuar
+   d. **Ejecutar auto-pipeline completo**: Evaluación A-F → Report .md → PDF (si score >= 3.0) → Tracker
+   e. **Mover de "Pendientes" a "Procesadas"**: `- [x] #NNN | URL | Empresa | Rol | Score/5 | PDF ✅/❌`
+3. **Si hay 3+ URLs pendientes**, lanzar agentes en paralelo (Agent tool con `run_in_background`) para maximizar velocidad.
+4. **Al terminar**, mostrar tabla resumen:
+
+```
+| # | Empresa | Rol | Score | PDF | Acción recomendada |
+```
+
+## Formato de pipeline.md
+
+```markdown
+## Pendientes
+- [ ] https://jobs.example.com/posting/123
+- [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
+- [!] https://private.url/job — Error: login required
+
+## Procesadas
+- [x] #143 | https://jobs.example.com/posting/789 | Acme Corp | AI PM | 4.2/5 | PDF ✅
+- [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF ❌
+```
+
+## Detección inteligente de JD desde URL
+
+1. **Playwright (preferido):** `browser_navigate` + `browser_snapshot`. Funciona con todas las SPAs.
+2. **WebFetch (fallback):** Para páginas estáticas o cuando Playwright no está disponible.
+3. **WebSearch (último recurso):** Buscar en portales secundarios que indexan el JD.
+
+**Casos especiales:**
+- **LinkedIn**: Puede requerir login → marcar `[!]` y pedir al usuario que pegue el texto
+- **PDF**: Si la URL apunta a un PDF, leerlo directamente con Read tool
+- **`local:` prefix**: Leer el archivo local. Ejemplo: `local:jds/linkedin-pm-ai.md` → leer `jds/linkedin-pm-ai.md`
+
+## Numeración automática
+
+1. Listar todos los archivos en `reports/`
+2. Extraer el número del prefijo (e.g., `142-medispend...` → 142)
+3. Nuevo número = máximo encontrado + 1
+
+## Sincronización de fuentes
+
+Antes de procesar cualquier URL, verificar sync:
+```bash
+node cv-sync-check.mjs
+```
+Si hay desincronización, advertir al usuario antes de continuar.

--- a/modes/es/project.md
+++ b/modes/es/project.md
@@ -1,0 +1,30 @@
+# Modo: project — Evaluación de Proyecto Portfolio
+
+Scoring 6 dimensiones (1-5):
+
+| Dimensión | Peso | 5 = ... | 1 = ... |
+|-----------|------|---------|---------|
+| Señal para roles target | 25% | Directamente demuestra skill del JD | No relacionado |
+| Unicidad | 20% | Nadie ha hecho esto | Todo el mundo lo tiene |
+| Demo-ability | 20% | Live demo en 2 min | Solo código, no visual |
+| Potencial de métricas | 15% | Métricas claras (latency, cost, accuracy) | Sin métricas posibles |
+| Tiempo a MVP | 10% | 1 semana | 3+ meses |
+| Potencial de historia STAR | 10% | Historia rica con trade-offs | Solo implementación |
+
+## Requisitos de "Interview Pack"
+
+Para cada proyecto aprobado:
+1. **One-pager**: producto + arquitectura + métricas + plan de evaluación
+2. **Demo**: URL live o walkthrough grabado de 2 min
+3. **Postmortem**: qué funcionó, qué no, mitigaciones
+
+## Plan 80/20
+
+- Semana 1 → MVP con métrica core
+- Semana 2 → polish + interview pack
+
+## Veredictos
+
+- **CONSTRUIR** → plan con milestones semanales
+- **SKIP** → por qué y qué hacer en su lugar
+- **PIVOTAR A [alternativa]** → variante más impactante

--- a/modes/es/scan.md
+++ b/modes/es/scan.md
@@ -1,0 +1,193 @@
+# Modo: scan — Portal Scanner (Descubrimiento de Ofertas)
+
+Escanea portales de empleo configurados, filtra por relevancia de título, y añade nuevas ofertas al pipeline para evaluación posterior.
+
+## Ejecución recomendada
+
+Ejecutar como subagente para no consumir contexto del main:
+
+```
+Agent(
+    subagent_type="general-purpose",
+    prompt="[contenido de este archivo + datos específicos]",
+    run_in_background=True
+)
+```
+
+## Configuración
+
+Leer `portals.yml` que contiene:
+- `search_queries`: Lista de queries WebSearch con `site:` filters por portal (descubrimiento amplio)
+- `tracked_companies`: Empresas específicas con `careers_url` para navegación directa
+- `title_filter`: Keywords positive/negative/seniority_boost para filtrado de títulos
+
+## Estrategia de descubrimiento (3 niveles)
+
+### Nivel 1 — Playwright directo (PRINCIPAL)
+
+**Para cada empresa en `tracked_companies`:** Navegar a su `careers_url` con Playwright (`browser_navigate` + `browser_snapshot`), leer TODOS los job listings visibles, y extraer título + URL de cada uno. Este es el método más fiable porque:
+- Ve la página en tiempo real (no resultados cacheados de Google)
+- Funciona con SPAs (Ashby, Lever, Workday)
+- Detecta ofertas nuevas al instante
+- No depende de la indexación de Google
+
+**Cada empresa DEBE tener `careers_url` en portals.yml.** Si no la tiene, buscarla una vez, guardarla, y usar en futuros scans.
+
+### Nivel 2 — Greenhouse API (COMPLEMENTARIO)
+
+Para empresas con Greenhouse, la API JSON (`boards-api.greenhouse.io/v1/boards/{slug}/jobs`) devuelve datos estructurados limpios. Usar como complemento rápido de Nivel 1 — es más rápido que Playwright pero solo funciona con Greenhouse.
+
+### Nivel 3 — WebSearch queries (DESCUBRIMIENTO AMPLIO)
+
+Los `search_queries` con `site:` filters cubren portales de forma transversal (todos los Ashby, todos los Greenhouse, etc.). Útil para descubrir empresas NUEVAS que aún no están en `tracked_companies`, pero los resultados pueden estar desfasados.
+
+**Prioridad de ejecución:**
+1. Nivel 1: Playwright → todas las `tracked_companies` con `careers_url`
+2. Nivel 2: API → todas las `tracked_companies` con `api:`
+3. Nivel 3: WebSearch → todos los `search_queries` con `enabled: true`
+
+Los niveles son aditivos — se ejecutan todos, los resultados se mezclan y deduplicar.
+
+## Workflow
+
+1. **Leer configuración**: `portals.yml`
+2. **Leer historial**: `data/scan-history.tsv` → URLs ya vistas
+3. **Leer dedup sources**: `data/applications.md` + `data/pipeline.md`
+
+4. **Nivel 1 — Playwright scan** (paralelo en batches de 3-5):
+   Para cada empresa en `tracked_companies` con `enabled: true` y `careers_url` definida:
+   a. `browser_navigate` a la `careers_url`
+   b. `browser_snapshot` para leer todos los job listings
+   c. Si la página tiene filtros/departamentos, navegar las secciones relevantes
+   d. Para cada job listing extraer: `{title, url, company}`
+   e. Si la página pagina resultados, navegar páginas adicionales
+   f. Acumular en lista de candidatos
+   g. Si `careers_url` falla (404, redirect), intentar `scan_query` como fallback y anotar para actualizar la URL
+
+5. **Nivel 2 — Greenhouse APIs** (paralelo):
+   Para cada empresa en `tracked_companies` con `api:` definida y `enabled: true`:
+   a. WebFetch de la URL de API → JSON con lista de jobs
+   b. Para cada job extraer: `{title, url, company}`
+   c. Acumular en lista de candidatos (dedup con Nivel 1)
+
+6. **Nivel 3 — WebSearch queries** (paralelo si posible):
+   Para cada query en `search_queries` con `enabled: true`:
+   a. Ejecutar WebSearch con el `query` definido
+   b. De cada resultado extraer: `{title, url, company}`
+      - **title**: del título del resultado (antes del " @ " o " | ")
+      - **url**: URL del resultado
+      - **company**: después del " @ " en el título, o extraer del dominio/path
+   c. Acumular en lista de candidatos (dedup con Nivel 1+2)
+
+6. **Filtrar por título** usando `title_filter` de `portals.yml`:
+   - Al menos 1 keyword de `positive` debe aparecer en el título (case-insensitive)
+   - 0 keywords de `negative` deben aparecer
+   - `seniority_boost` keywords dan prioridad pero no son obligatorios
+
+7. **Deduplicar** contra 3 fuentes:
+   - `scan-history.tsv` → URL exacta ya vista
+   - `applications.md` → empresa + rol normalizado ya evaluado
+   - `pipeline.md` → URL exacta ya en pendientes o procesadas
+
+7.5. **Verificar liveness de resultados de WebSearch (Nivel 3)** — ANTES de añadir a pipeline:
+
+   Los resultados de WebSearch pueden estar desactualizados (Google cachea resultados durante semanas o meses). Para evitar evaluar ofertas expiradas, verificar con Playwright cada URL nueva que provenga del Nivel 3. Los Niveles 1 y 2 son inherentemente en tiempo real y no requieren esta verificación.
+
+   Para cada URL nueva de Nivel 3 (secuencial — NUNCA Playwright en paralelo):
+   a. `browser_navigate` a la URL
+   b. `browser_snapshot` para leer el contenido
+   c. Clasificar:
+      - **Activa**: título del puesto visible + descripción del rol + botón Apply/Submit/Solicitar
+      - **Expirada** (cualquiera de estas señales):
+        - URL final contiene `?error=true` (Greenhouse redirige así cuando la oferta está cerrada)
+        - Página contiene: "job no longer available" / "no longer open" / "position has been filled" / "this job has expired" / "page not found"
+        - Solo navbar y footer visibles, sin contenido JD (contenido < ~300 chars)
+   d. Si expirada: registrar en `scan-history.tsv` con status `skipped_expired` y descartar
+   e. Si activa: continuar al paso 8
+
+   **No interrumpir el scan entero si una URL falla.** Si `browser_navigate` da error (timeout, 403, etc.), marcar como `skipped_expired` y continuar con la siguiente.
+
+8. **Para cada oferta nueva verificada que pase filtros**:
+   a. Añadir a `pipeline.md` sección "Pendientes": `- [ ] {url} | {company} | {title}`
+   b. Registrar en `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
+
+9. **Ofertas filtradas por título**: registrar en `scan-history.tsv` con status `skipped_title`
+10. **Ofertas duplicadas**: registrar con status `skipped_dup`
+11. **Ofertas expiradas (Nivel 3)**: registrar con status `skipped_expired`
+
+## Extracción de título y empresa de WebSearch results
+
+Los resultados de WebSearch vienen en formato: `"Job Title @ Company"` o `"Job Title | Company"` o `"Job Title — Company"`.
+
+Patrones de extracción por portal:
+- **Ashby**: `"Senior AI PM (Remote) @ EverAI"` → title: `Senior AI PM`, company: `EverAI`
+- **Greenhouse**: `"AI Engineer at Anthropic"` → title: `AI Engineer`, company: `Anthropic`
+- **Lever**: `"Product Manager - AI @ Temporal"` → title: `Product Manager - AI`, company: `Temporal`
+
+Regex genérico: `(.+?)(?:\s*[@|—–-]\s*|\s+at\s+)(.+?)$`
+
+## URLs privadas
+
+Si se encuentra una URL no accesible públicamente:
+1. Guardar el JD en `jds/{company}-{role-slug}.md`
+2. Añadir a pipeline.md como: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title}`
+
+## Scan History
+
+`data/scan-history.tsv` trackea TODAS las URLs vistas:
+
+```
+url	first_seen	portal	title	company	status
+https://...	2026-02-10	Ashby — AI PM	PM AI	Acme	added
+https://...	2026-02-10	Greenhouse — SA	Junior Dev	BigCo	skipped_title
+https://...	2026-02-10	Ashby — AI PM	SA AI	OldCo	skipped_dup
+https://...	2026-02-10	WebSearch — AI PM	PM AI	ClosedCo	skipped_expired
+```
+
+## Resumen de salida
+
+```
+Portal Scan — {YYYY-MM-DD}
+━━━━━━━━━━━━━━━━━━━━━━━━━━
+Queries ejecutados: N
+Ofertas encontradas: N total
+Filtradas por título: N relevantes
+Duplicadas: N (ya evaluadas o en pipeline)
+Expiradas descartadas: N (links muertos, Nivel 3)
+Nuevas añadidas a pipeline.md: N
+
+  + {company} | {title} | {query_name}
+  ...
+
+→ Ejecuta /career-ops pipeline para evaluar las nuevas ofertas.
+```
+
+## Gestión de careers_url
+
+Cada empresa en `tracked_companies` debe tener `careers_url` — la URL directa a su página de ofertas. Esto evita buscarlo cada vez.
+
+**Patrones conocidos por plataforma:**
+- **Ashby:** `https://jobs.ashbyhq.com/{slug}`
+- **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` o `https://job-boards.eu.greenhouse.io/{slug}`
+- **Lever:** `https://jobs.lever.co/{slug}`
+- **Custom:** La URL propia de la empresa (ej: `https://openai.com/careers`)
+
+**Si `careers_url` no existe** para una empresa:
+1. Intentar el patrón de su plataforma conocida
+2. Si falla, hacer un WebSearch rápido: `"{company}" careers jobs`
+3. Navegar con Playwright para confirmar que funciona
+4. **Guardar la URL encontrada en portals.yml** para futuros scans
+
+**Si `careers_url` devuelve 404 o redirect:**
+1. Anotar en el resumen de salida
+2. Intentar scan_query como fallback
+3. Marcar para actualización manual
+
+## Mantenimiento del portals.yml
+
+- **SIEMPRE guardar `careers_url`** cuando se añade una empresa nueva
+- Añadir nuevos queries según se descubran portales o roles interesantes
+- Desactivar queries con `enabled: false` si generan demasiado ruido
+- Ajustar keywords de filtrado según evolucionen los roles target
+- Añadir empresas a `tracked_companies` cuando interese seguirlas de cerca
+- Verificar `careers_url` periódicamente — las empresas cambian de plataforma ATS

--- a/modes/es/training.md
+++ b/modes/es/training.md
@@ -1,0 +1,27 @@
+# Modo: training — Evaluación de Formación
+
+Para cada curso/cert que el candidato pregunte, evaluar 6 dimensiones:
+
+| Dimensión | Qué evalúa |
+|-----------|------------|
+| Alineación North Star | ¿Acerca o aleja del objetivo? |
+| Señal recruiter | ¿Qué piensan HMs al ver esto en un CV? |
+| Tiempo y esfuerzo | Semanas × horas/semana |
+| Coste de oportunidad | ¿Qué no puede hacer durante ese tiempo? |
+| Riesgos | ¿Contenido outdated? ¿Brand débil? ¿Demasiado básico? |
+| Entregable portfolio | ¿Produce un artefacto demostrable? |
+
+## Veredictos
+
+- **HACER** → plan de 4-12 semanas con entregables semanales y scoreboard
+- **NO HACER** → alternativa mejor con justificación
+- **HACER CON TIMEBOX** (máx X semanas) → plan condensado, solo lo esencial
+
+## Prioridad
+
+Formación que mejore credibilidad en "production-grade AI":
+1. Evals y testing de LLMs
+2. Observability y monitoring
+3. Cost/reliability trade-offs
+4. AI governance y safety
+5. Enterprise AI architecture

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -1,157 +1,158 @@
-# Modo: oferta — Evaluación Completa A-F
+# Mode: oferta -- Full A-F Evaluation
 
-Cuando el candidato pega una oferta (texto o URL), entregar SIEMPRE los 6 bloques:
+When the candidate pastes an offer (text or URL), ALWAYS deliver all 6 blocks:
 
-## Paso 0 — Detección de Arquetipo
+## Step 0 -- Archetype Detection
 
-Clasificar la oferta en uno de los 6 arquetipos (ver `_shared.md`). Si es híbrido, indicar los 2 más cercanos. Esto determina:
-- Qué proof points priorizar en bloque B
-- Cómo reescribir el summary en bloque E
-- Qué historias STAR preparar en bloque F
+Classify the offer into one of the 6 archetypes (see `_shared.md`). If hybrid, indicate the 2 closest. This determines:
+- Which proof points to prioritise in block B
+- How to rewrite the summary in block E
+- Which STAR stories to prepare in block F
 
-## Bloque A — Resumen del Rol
+## Block A -- Role Summary
 
-Tabla con:
-- Arquetipo detectado
+Table with:
+- Detected archetype
 - Domain (platform/agentic/LLMOps/ML/enterprise)
 - Function (build/consult/manage/deploy)
 - Seniority
 - Remote (full/hybrid/onsite)
-- Team size (si se menciona)
-- TL;DR en 1 frase
+- Team size (if mentioned)
+- TL;DR in 1 sentence
 
-## Bloque B — Match con CV
+## Block B -- CV Match
 
-Lee `cv.md`. Crea tabla con cada requisito del JD mapeado a líneas exactas del CV.
+Read `cv.md`. Create a table mapping each JD requirement to exact lines from the CV.
 
-**Adaptado al arquetipo:**
-- Si FDE → priorizar proof points de delivery rápida y client-facing
-- Si SA → priorizar diseño de sistemas e integrations
-- Si PM → priorizar product discovery y métricas
-- Si LLMOps → priorizar evals, observability, pipelines
-- Si Agentic → priorizar multi-agent, HITL, orchestration
-- Si Transformation → priorizar change management, adoption, scaling
+**Adapted by archetype:**
+- If FDE → prioritise proof points of fast delivery and client-facing
+- If SA → prioritise system design and integrations
+- If PM → prioritise product discovery and metrics
+- If LLMOps → prioritise evals, observability, pipelines
+- If Agentic → prioritise multi-agent, HITL, orchestration
+- If Transformation → prioritise change management, adoption, scaling
 
-Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
-1. ¿Es un hard blocker o un nice-to-have?
-2. ¿Puede el candidato demostrar experiencia adyacente?
-3. ¿Hay un proyecto portfolio que cubra este gap?
-4. Plan de mitigación concreto (frase para cover letter, proyecto rápido, etc.)
+**Gaps** section with mitigation strategy for each one. For each gap:
+1. Is it a hard blocker or a nice-to-have?
+2. Can the candidate demonstrate adjacent experience?
+3. Is there a portfolio project that covers this gap?
+4. Concrete mitigation plan (cover letter phrase, quick project, etc.)
 
-## Bloque C — Nivel y Estrategia
+## Block C -- Level and Strategy
 
-1. **Nivel detectado** en el JD vs **nivel natural del candidato para ese arquetipo**
-2. **Plan "vender senior sin mentir"**: frases específicas adaptadas al arquetipo, logros concretos a destacar, cómo posicionar la experiencia de founder como ventaja
-3. **Plan "si me downlevelan"**: aceptar si comp es justa, negociar review a 6 meses, criterios de promoción claros
+1. **Detected level** in the JD vs **candidate's natural level for that archetype**
+2. **"Sell senior without lying" plan**: specific phrases adapted to the archetype, concrete achievements to highlight, how to position founder experience as an advantage
+3. **"If downlevelled" plan**: accept if comp is fair, negotiate 6-month review, clear promotion criteria
 
-## Bloque D — Comp y Demanda
+## Block D -- Comp and Demand
 
-Usar WebSearch para:
-- Salarios actuales del rol (Glassdoor, Levels.fyi, Blind)
-- Reputación de compensación de la empresa
-- Tendencia de demanda del rol
+Use WebSearch for:
+- Current salaries for the role (Glassdoor, Levels.fyi, Blind)
+- Company's compensation reputation
+- Demand trend for the role
 
-Tabla con datos y fuentes citadas. Si no hay datos, decirlo en vez de inventar.
+Table with data and cited sources. If no data available, say so instead of inventing.
 
-## Bloque E — Plan de Personalización
+## Block E -- Personalisation Plan
 
-| # | Sección | Estado actual | Cambio propuesto | Por qué |
-|---|---------|---------------|------------------|---------|
+| # | Section | Current state | Proposed change | Why |
+|---|---------|---------------|-----------------|-----|
 | 1 | Summary | ... | ... | ... |
 | ... | ... | ... | ... | ... |
 
-Top 5 cambios al CV + Top 5 cambios a LinkedIn para maximizar match.
+Top 5 CV changes + Top 5 LinkedIn changes to maximise match.
 
-## Bloque F — Plan de Entrevistas
+## Block F -- Interview Plan
 
-6-10 historias STAR+R mapeadas a requisitos del JD (STAR + **Reflection**):
+6-10 STAR+R stories mapped to JD requirements (STAR + **Reflection**):
 
-| # | Requisito del JD | Historia STAR+R | S | T | A | R | Reflection |
-|---|-----------------|-----------------|---|---|---|---|------------|
+| # | JD Requirement | STAR+R Story | S | T | A | R | Reflection |
+|---|----------------|--------------|---|---|---|---|------------|
 
-The **Reflection** column captures what was learned or what would be done differently. This signals seniority — junior candidates describe what happened, senior candidates extract lessons.
+The **Reflection** column captures what was learned or what would be done differently. This signals seniority -- junior candidates describe what happened, senior candidates extract lessons.
 
 **Story Bank:** If `interview-prep/story-bank.md` exists, check if any of these stories are already there. If not, append new ones. Over time this builds a reusable bank of 5-10 master stories that can be adapted to any interview question.
 
-**Seleccionadas y enmarcadas según el arquetipo:**
-- FDE → enfatizar velocidad de entrega y client-facing
-- SA → enfatizar decisiones de arquitectura
-- PM → enfatizar discovery y trade-offs
-- LLMOps → enfatizar métricas, evals, production hardening
-- Agentic → enfatizar orchestration, error handling, HITL
-- Transformation → enfatizar adopción, cambio organizacional
+**Selected and framed by archetype:**
+- FDE → emphasise delivery speed and client-facing
+- SA → emphasise architecture decisions
+- PM → emphasise discovery and trade-offs
+- LLMOps → emphasise metrics, evals, production hardening
+- Agentic → emphasise orchestration, error handling, HITL
+- Transformation → emphasise adoption, organisational change
 
-Incluir también:
-- 1 case study recomendado (cuál de sus proyectos presentar y cómo)
-- Preguntas red-flag y cómo responderlas (ej: "¿por qué vendiste tu empresa?", "¿tienes equipo de reports?")
+Also include:
+- 1 recommended case study (which project to present and how)
+- Red-flag questions and how to answer them (e.g. "Why did you sell your company?", "Do you have direct reports?")
 
 ---
 
-## Post-evaluación
+## Post-evaluation
 
-**SIEMPRE** después de generar los bloques A-F:
+**ALWAYS** after generating blocks A-F:
 
-### 1. Guardar report .md
+### 1. Save report .md
 
-Guardar evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+Save the complete evaluation to `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 
-- `{###}` = siguiente número secuencial (3 dígitos, zero-padded)
-- `{company-slug}` = nombre de empresa en lowercase, sin espacios (usar guiones)
-- `{YYYY-MM-DD}` = fecha actual
+- `{###}` = next sequential number (3 digits, zero-padded)
+- `{company-slug}` = company name in lowercase, no spaces (use hyphens)
+- `{YYYY-MM-DD}` = current date
 
-**Formato del report:**
+**Report format:**
 
 ```markdown
-# Evaluación: {Empresa} — {Rol}
+# Evaluation: {Company} -- {Role}
 
-**Fecha:** {YYYY-MM-DD}
-**Arquetipo:** {detectado}
+**Date:** {YYYY-MM-DD}
+**Archetype:** {detected}
 **Score:** {X/5}
-**PDF:** {ruta o pendiente}
+**URL:** {job listing URL}
+**PDF:** {path or pending}
 
 ---
 
-## A) Resumen del Rol
-(contenido completo del bloque A)
+## A) Role Summary
+(full content of block A)
 
-## B) Match con CV
-(contenido completo del bloque B)
+## B) CV Match
+(full content of block B)
 
-## C) Nivel y Estrategia
-(contenido completo del bloque C)
+## C) Level and Strategy
+(full content of block C)
 
-## D) Comp y Demanda
-(contenido completo del bloque D)
+## D) Comp and Demand
+(full content of block D)
 
-## E) Plan de Personalización
-(contenido completo del bloque E)
+## E) Personalisation Plan
+(full content of block E)
 
-## F) Plan de Entrevistas
-(contenido completo del bloque F)
+## F) Interview Plan
+(full content of block F)
 
 ## G) Draft Application Answers
-(solo si score >= 4.5 — borradores de respuestas para el formulario de aplicación)
+(only if score >= 4.5 -- draft answers for the application form)
 
 ---
 
-## Keywords extraídas
-(lista de 15-20 keywords del JD para ATS optimization)
+## Extracted Keywords
+(list of 15-20 keywords from JD for ATS optimisation)
 ```
 
-### 2. Registrar en tracker
+### 2. Register in tracker
 
-**SIEMPRE** registrar en `data/applications.md`:
-- Siguiente número secuencial
-- Fecha actual
-- Empresa
-- Rol
-- Score: promedio de match (1-5)
-- Estado: `Evaluada`
-- PDF: ❌ (o ✅ si auto-pipeline generó PDF)
-- Report: link relativo al report .md (ej: `[001](reports/001-company-2026-01-01.md)`)
+**ALWAYS** register in `data/applications.md`:
+- Next sequential number
+- Current date
+- Company
+- Role
+- Score: match average (1-5)
+- Status: `Evaluated`
+- PDF: ❌ (or ✅ if auto-pipeline generated PDF)
+- Report: relative link to the report .md (e.g. `[001](reports/001-company-2026-01-01.md)`)
 
-**Formato del tracker:**
+**Tracker format:**
 
 ```markdown
-| # | Fecha | Empresa | Rol | Score | Estado | PDF | Report |
+| # | Date | Company | Role | Score | Status | PDF | Report |
 ```

--- a/modes/ofertas.md
+++ b/modes/ofertas.md
@@ -1,21 +1,53 @@
-# Modo: ofertas — Comparación Multi-Oferta
+# Mode: ofertas -- Multi-Offer Comparison
 
-Scoring matrix de 10 dimensiones ponderadas:
+Scoring matrix of 10 weighted dimensions:
 
-| Dimensión | Peso | Criterios 1-5 |
-|-----------|------|----------------|
-| Alineación North Star | 25% | 5=rol target exacto, 1=no relacionado |
-| Match CV | 15% | 5=90%+ match, 1=<40% match |
-| Nivel (senior+) | 15% | 5=staff+, 4=senior, 3=mid-senior, 2=mid, 1=junior |
-| Comp estimada | 10% | 5=top quartile, 1=below market |
-| Trayectoria crecimiento | 10% | 5=clear path to next level, 1=dead end |
-| Calidad remoto | 5% | 5=full remote async, 1=onsite only |
-| Reputación empresa | 5% | 5=top employer, 1=red flags |
-| Modernidad tech stack | 5% | 5=cutting edge AI/ML, 1=legacy |
-| Velocidad a oferta | 5% | 5=fast process, 1=6+ months |
-| Señales culturales | 5% | 5=builder culture, 1=bureaucratic |
+| Dimension | Weight | Criteria 1-5 |
+|-----------|--------|--------------|
+| North Star alignment | 25% | 5=exact target role, 1=unrelated |
+| CV match | 15% | 5=90%+ match, 1=<40% match |
+| Level (senior+) | 15% | 5=staff+, 4=senior, 3=mid-senior, 2=mid, 1=junior |
+| Estimated comp | 10% | 5=top quartile, 1=below market |
+| Growth trajectory | 10% | 5=clear path to next level, 1=dead end |
+| Remote quality | 5% | 5=full remote async, 1=onsite only |
+| Company reputation | 5% | 5=top employer, 1=red flags |
+| Tech stack modernity | 5% | 5=cutting edge AI/ML, 1=legacy |
+| Speed to offer | 5% | 5=fast process, 1=6+ months |
+| Cultural signals | 5% | 5=builder culture, 1=bureaucratic |
 
-Para cada oferta: score en cada dimensión, score ponderado total.
-Ranking final + recomendación con consideraciones de time-to-offer.
+For each offer: score on each dimension, weighted total score.
+Final ranking + recommendation with time-to-offer considerations.
 
-Pedir al usuario las ofertas si no están en contexto. Puede ser texto, URLs, o referencias a ofertas ya evaluadas en el tracker.
+Ask the user for the offers if not in context. Can be text, URLs, or references to offers already evaluated in the tracker.
+
+---
+
+## Post-comparison
+
+**ALWAYS** save the comparison results:
+
+### Save to report
+
+Save the ranking to `reports/comparison-{YYYY-MM-DD}.md`:
+
+```markdown
+# Offer Comparison -- {YYYY-MM-DD}
+
+**Offers compared:** {N}
+
+## Scoring Matrix
+
+| Offer | North Star | CV Match | Level | Comp | Growth | Remote | Reputation | Tech | Speed | Culture | **Total** |
+|-------|-----------|----------|-------|------|--------|--------|------------|------|-------|---------|-----------|
+| {Company A} -- {Role} | X | X | X | X | X | X | X | X | X | X | **X.X** |
+| ... | ... | ... | ... | ... | ... | ... | ... | ... | ... | ... | **...** |
+
+## Ranking
+
+1. **{Company A} -- {Role}** (X.X/5) -- {one-line rationale}
+2. ...
+
+## Recommendation
+
+{Which to prioritise and why, considering time-to-offer and total fit}
+```

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -1,57 +1,57 @@
-# Modo: pipeline — Inbox de URLs (Second Brain)
+# Mode: pipeline -- URL Inbox (Second Brain)
 
-Procesa URLs de ofertas acumuladas en `data/pipeline.md`. El usuario agrega URLs cuando quiera y luego ejecuta `/career-ops pipeline` para procesarlas todas.
+Processes offer URLs accumulated in `data/pipeline.md`. The user adds URLs whenever they want and then runs `/career-ops pipeline` to process them all.
 
 ## Workflow
 
-1. **Leer** `data/pipeline.md` → buscar items `- [ ]` en la sección "Pendientes"
-2. **Para cada URL pendiente**:
-   a. Calcular siguiente `REPORT_NUM` secuencial (leer `reports/`, tomar el número más alto + 1)
-   b. **Extraer JD** usando Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
-   c. Si la URL no es accesible → marcar como `- [!]` con nota y continuar
-   d. **Ejecutar auto-pipeline completo**: Evaluación A-F → Report .md → PDF (si score >= 3.0) → Tracker
-   e. **Mover de "Pendientes" a "Procesadas"**: `- [x] #NNN | URL | Empresa | Rol | Score/5 | PDF ✅/❌`
-3. **Si hay 3+ URLs pendientes**, lanzar agentes en paralelo (Agent tool con `run_in_background`) para maximizar velocidad.
-4. **Al terminar**, mostrar tabla resumen:
+1. **Read** `data/pipeline.md` → find items `- [ ]` in the "Pending" section
+2. **For each pending URL**:
+   a. Calculate next `REPORT_NUM` sequentially (read `reports/`, take the highest number + 1)
+   b. **Extract JD** using Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
+   c. If the URL is not accessible → mark as `- [!]` with a note and continue
+   d. **Execute full auto-pipeline**: Evaluation A-F → Report .md → PDF (if score >= 3.0) → Tracker
+   e. **Move from "Pending" to "Processed"**: `- [x] #NNN | URL | Company | Role | Score/5 | PDF ✅/❌`
+3. **If there are 3+ pending URLs**, launch agents in parallel (Agent tool with `run_in_background`) to maximise speed.
+4. **When finished**, show summary table:
 
 ```
-| # | Empresa | Rol | Score | PDF | Acción recomendada |
+| # | Company | Role | Score | PDF | Recommended action |
 ```
 
-## Formato de pipeline.md
+## pipeline.md format
 
 ```markdown
-## Pendientes
+## Pending
 - [ ] https://jobs.example.com/posting/123
 - [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
-- [!] https://private.url/job — Error: login required
+- [!] https://private.url/job -- Error: login required
 
-## Procesadas
+## Processed
 - [x] #143 | https://jobs.example.com/posting/789 | Acme Corp | AI PM | 4.2/5 | PDF ✅
 - [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF ❌
 ```
 
-## Detección inteligente de JD desde URL
+## Smart JD detection from URL
 
-1. **Playwright (preferido):** `browser_navigate` + `browser_snapshot`. Funciona con todas las SPAs.
-2. **WebFetch (fallback):** Para páginas estáticas o cuando Playwright no está disponible.
-3. **WebSearch (último recurso):** Buscar en portales secundarios que indexan el JD.
+1. **Playwright (preferred):** `browser_navigate` + `browser_snapshot`. Works with all SPAs.
+2. **WebFetch (fallback):** For static pages or when Playwright is not available.
+3. **WebSearch (last resort):** Search on secondary portals that index the JD.
 
-**Casos especiales:**
-- **LinkedIn**: Puede requerir login → marcar `[!]` y pedir al usuario que pegue el texto
-- **PDF**: Si la URL apunta a un PDF, leerlo directamente con Read tool
-- **`local:` prefix**: Leer el archivo local. Ejemplo: `local:jds/linkedin-pm-ai.md` → leer `jds/linkedin-pm-ai.md`
+**Special cases:**
+- **LinkedIn**: May require login → mark `[!]` and ask the user to paste the text
+- **PDF**: If the URL points to a PDF, read it directly with Read tool
+- **`local:` prefix**: Read the local file. Example: `local:jds/linkedin-pm-ai.md` → read `jds/linkedin-pm-ai.md`
 
-## Numeración automática
+## Automatic numbering
 
-1. Listar todos los archivos en `reports/`
-2. Extraer el número del prefijo (e.g., `142-medispend...` → 142)
-3. Nuevo número = máximo encontrado + 1
+1. List all files in `reports/`
+2. Extract the number from the prefix (e.g. `142-medispend...` → 142)
+3. New number = highest found + 1
 
-## Sincronización de fuentes
+## Source synchronisation
 
-Antes de procesar cualquier URL, verificar sync:
+Before processing any URL, verify sync:
 ```bash
 node cv-sync-check.mjs
 ```
-Si hay desincronización, advertir al usuario antes de continuar.
+If out of sync, warn the user before continuing.

--- a/modes/project.md
+++ b/modes/project.md
@@ -1,30 +1,30 @@
-# Modo: project — Evaluación de Proyecto Portfolio
+# Mode: project -- Portfolio Project Evaluation
 
-Scoring 6 dimensiones (1-5):
+Scoring across 6 dimensions (1-5):
 
-| Dimensión | Peso | 5 = ... | 1 = ... |
-|-----------|------|---------|---------|
-| Señal para roles target | 25% | Directamente demuestra skill del JD | No relacionado |
-| Unicidad | 20% | Nadie ha hecho esto | Todo el mundo lo tiene |
-| Demo-ability | 20% | Live demo en 2 min | Solo código, no visual |
-| Potencial de métricas | 15% | Métricas claras (latency, cost, accuracy) | Sin métricas posibles |
-| Tiempo a MVP | 10% | 1 semana | 3+ meses |
-| Potencial de historia STAR | 10% | Historia rica con trade-offs | Solo implementación |
+| Dimension | Weight | 5 = ... | 1 = ... |
+|-----------|--------|---------|---------|
+| Signal for target roles | 25% | Directly demonstrates JD skill | Unrelated |
+| Uniqueness | 20% | Nobody has done this | Everyone has it |
+| Demo-ability | 20% | Live demo in 2 min | Code only, not visual |
+| Metrics potential | 15% | Clear metrics (latency, cost, accuracy) | No possible metrics |
+| Time to MVP | 10% | 1 week | 3+ months |
+| STAR story potential | 10% | Rich story with trade-offs | Just implementation |
 
-## Requisitos de "Interview Pack"
+## "Interview Pack" requirements
 
-Para cada proyecto aprobado:
-1. **One-pager**: producto + arquitectura + métricas + plan de evaluación
-2. **Demo**: URL live o walkthrough grabado de 2 min
-3. **Postmortem**: qué funcionó, qué no, mitigaciones
+For each approved project:
+1. **One-pager**: product + architecture + metrics + evaluation plan
+2. **Demo**: live URL or 2-min recorded walkthrough
+3. **Postmortem**: what worked, what didn't, mitigations
 
-## Plan 80/20
+## 80/20 Plan
 
-- Semana 1 → MVP con métrica core
-- Semana 2 → polish + interview pack
+- Week 1 → MVP with core metric
+- Week 2 → polish + interview pack
 
-## Veredictos
+## Verdicts
 
-- **CONSTRUIR** → plan con milestones semanales
-- **SKIP** → por qué y qué hacer en su lugar
-- **PIVOTAR A [alternativa]** → variante más impactante
+- **BUILD** → plan with weekly milestones
+- **SKIP** → why and what to do instead
+- **PIVOT TO [alternative]** → more impactful variant

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -1,140 +1,140 @@
-# Modo: scan — Portal Scanner (Descubrimiento de Ofertas)
+# Mode: scan -- Portal Scanner (Offer Discovery)
 
-Escanea portales de empleo configurados, filtra por relevancia de título, y añade nuevas ofertas al pipeline para evaluación posterior.
+Scans configured job portals, filters by title relevance, and adds new offers to the pipeline for later evaluation.
 
-## Ejecución recomendada
+## Recommended execution
 
-Ejecutar como subagente para no consumir contexto del main:
+Run as a subagent to avoid consuming main context:
 
 ```
 Agent(
     subagent_type="general-purpose",
-    prompt="[contenido de este archivo + datos específicos]",
+    prompt="[contents of this file + specific data]",
     run_in_background=True
 )
 ```
 
-## Configuración
+## Configuration
 
-Leer `portals.yml` que contiene:
-- `search_queries`: Lista de queries WebSearch con `site:` filters por portal (descubrimiento amplio)
-- `tracked_companies`: Empresas específicas con `careers_url` para navegación directa
-- `title_filter`: Keywords positive/negative/seniority_boost para filtrado de títulos
+Read `portals.yml` which contains:
+- `search_queries`: List of WebSearch queries with `site:` filters per portal (broad discovery)
+- `tracked_companies`: Specific companies with `careers_url` for direct navigation
+- `title_filter`: Positive/negative/seniority_boost keywords for title filtering
 
-## Estrategia de descubrimiento (3 niveles)
+## Discovery strategy (3 levels)
 
-### Nivel 1 — Playwright directo (PRINCIPAL)
+### Level 1 -- Direct Playwright (PRIMARY)
 
-**Para cada empresa en `tracked_companies`:** Navegar a su `careers_url` con Playwright (`browser_navigate` + `browser_snapshot`), leer TODOS los job listings visibles, y extraer título + URL de cada uno. Este es el método más fiable porque:
-- Ve la página en tiempo real (no resultados cacheados de Google)
-- Funciona con SPAs (Ashby, Lever, Workday)
-- Detecta ofertas nuevas al instante
-- No depende de la indexación de Google
+**For each company in `tracked_companies`:** Navigate to their `careers_url` with Playwright (`browser_navigate` + `browser_snapshot`), read ALL visible job listings, and extract title + URL from each one. This is the most reliable method because:
+- Sees the page in real time (not cached Google results)
+- Works with SPAs (Ashby, Lever, Workday)
+- Detects new offers instantly
+- Does not depend on Google indexing
 
-**Cada empresa DEBE tener `careers_url` en portals.yml.** Si no la tiene, buscarla una vez, guardarla, y usar en futuros scans.
+**Each company MUST have `careers_url` in portals.yml.** If missing, search for it once, save it, and use in future scans.
 
-### Nivel 2 — Greenhouse API (COMPLEMENTARIO)
+### Level 2 -- Greenhouse API (COMPLEMENTARY)
 
-Para empresas con Greenhouse, la API JSON (`boards-api.greenhouse.io/v1/boards/{slug}/jobs`) devuelve datos estructurados limpios. Usar como complemento rápido de Nivel 1 — es más rápido que Playwright pero solo funciona con Greenhouse.
+For companies on Greenhouse, the JSON API (`boards-api.greenhouse.io/v1/boards/{slug}/jobs`) returns clean structured data. Use as a fast complement to Level 1 -- faster than Playwright but only works with Greenhouse.
 
-### Nivel 3 — WebSearch queries (DESCUBRIMIENTO AMPLIO)
+### Level 3 -- WebSearch queries (BROAD DISCOVERY)
 
-Los `search_queries` con `site:` filters cubren portales de forma transversal (todos los Ashby, todos los Greenhouse, etc.). Útil para descubrir empresas NUEVAS que aún no están en `tracked_companies`, pero los resultados pueden estar desfasados.
+The `search_queries` with `site:` filters cover portals broadly (all Ashby, all Greenhouse, etc.). Useful for discovering NEW companies not yet in `tracked_companies`, but results may be stale.
 
-**Prioridad de ejecución:**
-1. Nivel 1: Playwright → todas las `tracked_companies` con `careers_url`
-2. Nivel 2: API → todas las `tracked_companies` con `api:`
-3. Nivel 3: WebSearch → todos los `search_queries` con `enabled: true`
+**Execution priority:**
+1. Level 1: Playwright → all `tracked_companies` with `careers_url`
+2. Level 2: API → all `tracked_companies` with `api:`
+3. Level 3: WebSearch → all `search_queries` with `enabled: true`
 
-Los niveles son aditivos — se ejecutan todos, los resultados se mezclan y deduplicar.
+Levels are additive -- all are executed, results are merged and deduplicated.
 
 ## Workflow
 
-1. **Leer configuración**: `portals.yml`
-2. **Leer historial**: `data/scan-history.tsv` → URLs ya vistas
-3. **Leer dedup sources**: `data/applications.md` + `data/pipeline.md`
+1. **Read configuration**: `portals.yml`
+2. **Read history**: `data/scan-history.tsv` → URLs already seen
+3. **Read dedup sources**: `data/applications.md` + `data/pipeline.md`
 
-4. **Nivel 1 — Playwright scan** (paralelo en batches de 3-5):
-   Para cada empresa en `tracked_companies` con `enabled: true` y `careers_url` definida:
-   a. `browser_navigate` a la `careers_url`
-   b. `browser_snapshot` para leer todos los job listings
-   c. Si la página tiene filtros/departamentos, navegar las secciones relevantes
-   d. Para cada job listing extraer: `{title, url, company}`
-   e. Si la página pagina resultados, navegar páginas adicionales
-   f. Acumular en lista de candidatos
-   g. Si `careers_url` falla (404, redirect), intentar `scan_query` como fallback y anotar para actualizar la URL
+4. **Level 1 -- Playwright scan** (parallel in batches of 3-5):
+   For each company in `tracked_companies` with `enabled: true` and `careers_url` defined:
+   a. `browser_navigate` to the `careers_url`
+   b. `browser_snapshot` to read all job listings
+   c. If the page has filters/departments, navigate relevant sections
+   d. For each job listing extract: `{title, url, company}`
+   e. If the page paginates results, navigate additional pages
+   f. Accumulate in candidate list
+   g. If `careers_url` fails (404, redirect), try `scan_query` as fallback and note for URL update
 
-5. **Nivel 2 — Greenhouse APIs** (paralelo):
-   Para cada empresa en `tracked_companies` con `api:` definida y `enabled: true`:
-   a. WebFetch de la URL de API → JSON con lista de jobs
-   b. Para cada job extraer: `{title, url, company}`
-   c. Acumular en lista de candidatos (dedup con Nivel 1)
+5. **Level 2 -- Greenhouse APIs** (parallel):
+   For each company in `tracked_companies` with `api:` defined and `enabled: true`:
+   a. WebFetch the API URL → JSON with job list
+   b. For each job extract: `{title, url, company}`
+   c. Accumulate in candidate list (dedup with Level 1)
 
-6. **Nivel 3 — WebSearch queries** (paralelo si posible):
-   Para cada query en `search_queries` con `enabled: true`:
-   a. Ejecutar WebSearch con el `query` definido
-   b. De cada resultado extraer: `{title, url, company}`
-      - **title**: del título del resultado (antes del " @ " o " | ")
-      - **url**: URL del resultado
-      - **company**: después del " @ " en el título, o extraer del dominio/path
-   c. Acumular en lista de candidatos (dedup con Nivel 1+2)
+6. **Level 3 -- WebSearch queries** (parallel if possible):
+   For each query in `search_queries` with `enabled: true`:
+   a. Execute WebSearch with the defined `query`
+   b. From each result extract: `{title, url, company}`
+      - **title**: from the result title (before " @ " or " | ")
+      - **url**: result URL
+      - **company**: after " @ " in the title, or extract from domain/path
+   c. Accumulate in candidate list (dedup with Level 1+2)
 
-6. **Filtrar por título** usando `title_filter` de `portals.yml`:
-   - Al menos 1 keyword de `positive` debe aparecer en el título (case-insensitive)
-   - 0 keywords de `negative` deben aparecer
-   - `seniority_boost` keywords dan prioridad pero no son obligatorios
+7. **Filter by title** using `title_filter` from `portals.yml`:
+   - At least 1 keyword from `positive` must appear in the title (case-insensitive)
+   - 0 keywords from `negative` must appear
+   - `seniority_boost` keywords give priority but are not mandatory
 
-7. **Deduplicar** contra 3 fuentes:
-   - `scan-history.tsv` → URL exacta ya vista
-   - `applications.md` → empresa + rol normalizado ya evaluado
-   - `pipeline.md` → URL exacta ya en pendientes o procesadas
+8. **Deduplicate** against 3 sources:
+   - `scan-history.tsv` → exact URL already seen
+   - `applications.md` → normalised company + role already evaluated
+   - `pipeline.md` → exact URL already in pending or processed
 
-7.5. **Verificar liveness de resultados de WebSearch (Nivel 3)** — ANTES de añadir a pipeline:
+8.5. **Verify liveness of WebSearch results (Level 3)** -- BEFORE adding to pipeline:
 
-   Los resultados de WebSearch pueden estar desactualizados (Google cachea resultados durante semanas o meses). Para evitar evaluar ofertas expiradas, verificar con Playwright cada URL nueva que provenga del Nivel 3. Los Niveles 1 y 2 son inherentemente en tiempo real y no requieren esta verificación.
+   WebSearch results can be outdated (Google caches results for weeks or months). To avoid evaluating expired offers, verify each new URL from Level 3 with Playwright. Levels 1 and 2 are inherently real-time and do not require this verification.
 
-   Para cada URL nueva de Nivel 3 (secuencial — NUNCA Playwright en paralelo):
-   a. `browser_navigate` a la URL
-   b. `browser_snapshot` para leer el contenido
-   c. Clasificar:
-      - **Activa**: título del puesto visible + descripción del rol + botón Apply/Submit/Solicitar
-      - **Expirada** (cualquiera de estas señales):
-        - URL final contiene `?error=true` (Greenhouse redirige así cuando la oferta está cerrada)
-        - Página contiene: "job no longer available" / "no longer open" / "position has been filled" / "this job has expired" / "page not found"
-        - Solo navbar y footer visibles, sin contenido JD (contenido < ~300 chars)
-   d. Si expirada: registrar en `scan-history.tsv` con status `skipped_expired` y descartar
-   e. Si activa: continuar al paso 8
+   For each new URL from Level 3 (sequential -- NEVER Playwright in parallel):
+   a. `browser_navigate` to the URL
+   b. `browser_snapshot` to read the content
+   c. Classify:
+      - **Active**: job title visible + role description + Apply/Submit button
+      - **Expired** (any of these signals):
+        - Final URL contains `?error=true` (Greenhouse redirects this way when the offer is closed)
+        - Page contains: "job no longer available" / "no longer open" / "position has been filled" / "this job has expired" / "page not found"
+        - Only navbar and footer visible, no JD content (content < ~300 chars)
+   d. If expired: register in `scan-history.tsv` with status `skipped_expired` and discard
+   e. If active: continue to step 9
 
-   **No interrumpir el scan entero si una URL falla.** Si `browser_navigate` da error (timeout, 403, etc.), marcar como `skipped_expired` y continuar con la siguiente.
+   **Do not interrupt the entire scan if a URL fails.** If `browser_navigate` errors (timeout, 403, etc.), mark as `skipped_expired` and continue with the next one.
 
-8. **Para cada oferta nueva verificada que pase filtros**:
-   a. Añadir a `pipeline.md` sección "Pendientes": `- [ ] {url} | {company} | {title}`
-   b. Registrar en `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
+9. **For each new verified offer that passes filters**:
+   a. Add to `pipeline.md` "Pending" section: `- [ ] {url} | {company} | {title}`
+   b. Register in `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
 
-9. **Ofertas filtradas por título**: registrar en `scan-history.tsv` con status `skipped_title`
-10. **Ofertas duplicadas**: registrar con status `skipped_dup`
-11. **Ofertas expiradas (Nivel 3)**: registrar con status `skipped_expired`
+10. **Offers filtered by title**: register in `scan-history.tsv` with status `skipped_title`
+11. **Duplicate offers**: register with status `skipped_dup`
+12. **Expired offers (Level 3)**: register with status `skipped_expired`
 
-## Extracción de título y empresa de WebSearch results
+## Title and company extraction from WebSearch results
 
-Los resultados de WebSearch vienen en formato: `"Job Title @ Company"` o `"Job Title | Company"` o `"Job Title — Company"`.
+WebSearch results come in format: `"Job Title @ Company"` or `"Job Title | Company"` or `"Job Title -- Company"`.
 
-Patrones de extracción por portal:
+Extraction patterns by portal:
 - **Ashby**: `"Senior AI PM (Remote) @ EverAI"` → title: `Senior AI PM`, company: `EverAI`
 - **Greenhouse**: `"AI Engineer at Anthropic"` → title: `AI Engineer`, company: `Anthropic`
 - **Lever**: `"Product Manager - AI @ Temporal"` → title: `Product Manager - AI`, company: `Temporal`
 
-Regex genérico: `(.+?)(?:\s*[@|—–-]\s*|\s+at\s+)(.+?)$`
+Generic regex: `(.+?)(?:\s*[@|—–-]\s*|\s+at\s+)(.+?)$`
 
-## URLs privadas
+## Private URLs
 
-Si se encuentra una URL no accesible públicamente:
-1. Guardar el JD en `jds/{company}-{role-slug}.md`
-2. Añadir a pipeline.md como: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title}`
+If a non-publicly-accessible URL is found:
+1. Save the JD to `jds/{company}-{role-slug}.md`
+2. Add to pipeline.md as: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title}`
 
 ## Scan History
 
-`data/scan-history.tsv` trackea TODAS las URLs vistas:
+`data/scan-history.tsv` tracks ALL URLs seen:
 
 ```
 url	first_seen	portal	title	company	status
@@ -144,50 +144,50 @@ https://...	2026-02-10	Ashby — AI PM	SA AI	OldCo	skipped_dup
 https://...	2026-02-10	WebSearch — AI PM	PM AI	ClosedCo	skipped_expired
 ```
 
-## Resumen de salida
+## Output summary
 
 ```
-Portal Scan — {YYYY-MM-DD}
+Portal Scan -- {YYYY-MM-DD}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━
-Queries ejecutados: N
-Ofertas encontradas: N total
-Filtradas por título: N relevantes
-Duplicadas: N (ya evaluadas o en pipeline)
-Expiradas descartadas: N (links muertos, Nivel 3)
-Nuevas añadidas a pipeline.md: N
+Queries executed: N
+Offers found: N total
+Filtered by title: N relevant
+Duplicates: N (already evaluated or in pipeline)
+Expired discarded: N (dead links, Level 3)
+New added to pipeline.md: N
 
   + {company} | {title} | {query_name}
   ...
 
-→ Ejecuta /career-ops pipeline para evaluar las nuevas ofertas.
+→ Run /career-ops pipeline to evaluate the new offers.
 ```
 
-## Gestión de careers_url
+## careers_url management
 
-Cada empresa en `tracked_companies` debe tener `careers_url` — la URL directa a su página de ofertas. Esto evita buscarlo cada vez.
+Each company in `tracked_companies` should have `careers_url` -- the direct URL to their jobs page. This avoids searching for it every time.
 
-**Patrones conocidos por plataforma:**
+**Known patterns by platform:**
 - **Ashby:** `https://jobs.ashbyhq.com/{slug}`
-- **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` o `https://job-boards.eu.greenhouse.io/{slug}`
+- **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` or `https://job-boards.eu.greenhouse.io/{slug}`
 - **Lever:** `https://jobs.lever.co/{slug}`
-- **Custom:** La URL propia de la empresa (ej: `https://openai.com/careers`)
+- **Custom:** The company's own URL (e.g. `https://openai.com/careers`)
 
-**Si `careers_url` no existe** para una empresa:
-1. Intentar el patrón de su plataforma conocida
-2. Si falla, hacer un WebSearch rápido: `"{company}" careers jobs`
-3. Navegar con Playwright para confirmar que funciona
-4. **Guardar la URL encontrada en portals.yml** para futuros scans
+**If `careers_url` does not exist** for a company:
+1. Try the pattern of its known platform
+2. If that fails, do a quick WebSearch: `"{company}" careers jobs`
+3. Navigate with Playwright to confirm it works
+4. **Save the found URL in portals.yml** for future scans
 
-**Si `careers_url` devuelve 404 o redirect:**
-1. Anotar en el resumen de salida
-2. Intentar scan_query como fallback
-3. Marcar para actualización manual
+**If `careers_url` returns 404 or redirect:**
+1. Note in the output summary
+2. Try scan_query as fallback
+3. Mark for manual update
 
-## Mantenimiento del portals.yml
+## portals.yml maintenance
 
-- **SIEMPRE guardar `careers_url`** cuando se añade una empresa nueva
-- Añadir nuevos queries según se descubran portales o roles interesantes
-- Desactivar queries con `enabled: false` si generan demasiado ruido
-- Ajustar keywords de filtrado según evolucionen los roles target
-- Añadir empresas a `tracked_companies` cuando interese seguirlas de cerca
-- Verificar `careers_url` periódicamente — las empresas cambian de plataforma ATS
+- **ALWAYS save `careers_url`** when adding a new company
+- Add new queries as interesting portals or roles are discovered
+- Disable queries with `enabled: false` if they generate too much noise
+- Adjust filter keywords as target roles evolve
+- Add companies to `tracked_companies` when you want to follow them closely
+- Verify `careers_url` periodically -- companies change ATS platforms

--- a/modes/tracker.md
+++ b/modes/tracker.md
@@ -1,23 +1,24 @@
-# Modo: tracker — Tracker de Aplicaciones
+# Mode: tracker -- Application Tracker
 
-Lee y muestra `data/applications.md`.
+Read and display `data/applications.md`.
 
-**Formato del tracker:**
+**Tracker format:**
 ```markdown
-| # | Fecha | Empresa | Rol | Score | Estado | PDF | Report |
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
 ```
 
-Estados posibles: `Evaluada` → `Aplicado` → `Respondido` → `Contacto` → `Entrevista` → `Oferta` / `Rechazada` / `Descartada` / `NO APLICAR`
+Canonical states (from `templates/states.yml`):
+`Evaluated` → `Applied` → `Responded` / `Contacted` → `Interview` → `Offer` / `Rejected` / `Discarded` / `SKIP`
 
-- `Aplicado` = el candidato envió su candidatura
-- `Respondido` = Un recruiter/empresa contactó y el candidato respondió (inbound)
-- `Contacto` = El candidato contactó proactivamente a alguien de la empresa (outbound, ej: LinkedIn power move)
+- `Applied` = candidate submitted their application
+- `Responded` = a recruiter/company reached out and the candidate replied (inbound)
+- `Contacted` = candidate proactively reached out to someone at the company (outbound, e.g. LinkedIn power move)
 
-Si el usuario pide actualizar un estado, editar la fila correspondiente.
+If the user asks to update a status, edit the corresponding row.
 
-Mostrar también estadísticas:
-- Total de aplicaciones
-- Por estado
-- Score promedio
-- % con PDF generado
-- % con report generado
+Also show statistics:
+- Total applications
+- By status
+- Average score
+- % with PDF generated
+- % with report generated

--- a/modes/training.md
+++ b/modes/training.md
@@ -1,27 +1,27 @@
-# Modo: training — Evaluación de Formación
+# Mode: training -- Training Evaluation
 
-Para cada curso/cert que el candidato pregunte, evaluar 6 dimensiones:
+For each course/cert the candidate asks about, evaluate 6 dimensions:
 
-| Dimensión | Qué evalúa |
-|-----------|------------|
-| Alineación North Star | ¿Acerca o aleja del objetivo? |
-| Señal recruiter | ¿Qué piensan HMs al ver esto en un CV? |
-| Tiempo y esfuerzo | Semanas × horas/semana |
-| Coste de oportunidad | ¿Qué no puede hacer durante ese tiempo? |
-| Riesgos | ¿Contenido outdated? ¿Brand débil? ¿Demasiado básico? |
-| Entregable portfolio | ¿Produce un artefacto demostrable? |
+| Dimension | What it evaluates |
+|-----------|-------------------|
+| North Star alignment | Does it bring you closer or further from your goal? |
+| Recruiter signal | What do HMs think when they see this on a CV? |
+| Time and effort | Weeks × hours/week |
+| Opportunity cost | What can't you do during that time? |
+| Risks | Outdated content? Weak brand? Too basic? |
+| Portfolio deliverable | Does it produce a demonstrable artefact? |
 
-## Veredictos
+## Verdicts
 
-- **HACER** → plan de 4-12 semanas con entregables semanales y scoreboard
-- **NO HACER** → alternativa mejor con justificación
-- **HACER CON TIMEBOX** (máx X semanas) → plan condensado, solo lo esencial
+- **DO IT** → plan of 4-12 weeks with weekly deliverables and scoreboard
+- **DON'T** → better alternative with justification
+- **DO IT WITH TIMEBOX** (max X weeks) → condensed plan, essentials only
 
-## Prioridad
+## Priority
 
-Formación que mejore credibilidad en "production-grade AI":
-1. Evals y testing de LLMs
-2. Observability y monitoring
+Training that improves credibility in "production-grade AI":
+1. LLM evals and testing
+2. Observability and monitoring
 3. Cost/reliability trade-offs
-4. AI governance y safety
+4. AI governance and safety
 5. Enterprise AI architecture

--- a/templates/states.yml
+++ b/templates/states.yml
@@ -25,6 +25,12 @@ states:
     description: Company has responded (not yet interview)
     dashboard_group: responded
 
+  - id: contacted
+    label: Contacted
+    aliases: [contacto, contactado]
+    description: Candidate proactively reached out (outbound, e.g. LinkedIn)
+    dashboard_group: contacted
+
   - id: interview
     label: Interview
     aliases: [entrevista]

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -45,6 +45,11 @@ const SYSTEM_PATHS = [
   'modes/tracker.md',
   'modes/training.md',
   'modes/de/',
+  'modes/fr/',
+  'modes/pt/',
+  'modes/es/',
+  'modes/interview-prep.md',
+  'modes/patterns.md',
   'CLAUDE.md',
   'AGENTS.md',
   'generate-pdf.mjs',
@@ -54,6 +59,10 @@ const SYSTEM_PATHS = [
   'normalize-statuses.mjs',
   'cv-sync-check.mjs',
   'update-system.mjs',
+  'analyze-patterns.mjs',
+  'check-liveness.mjs',
+  'doctor.mjs',
+  'test-all.mjs',
   'batch/batch-prompt.md',
   'batch/batch-runner.sh',
   'dashboard/',
@@ -69,6 +78,8 @@ const SYSTEM_PATHS = [
   'CITATION.cff',
   '.github/',
   'package.json',
+  'LEGAL_DISCLAIMER.md',
+  'README.es.md',
 ];
 
 // User layer paths — NEVER touch these (safety check)


### PR DESCRIPTION
## Summary

- **Translate 12 Spanish mode files to English** — default modes now match the language of CLAUDE.md, _shared.md, and the README. Spanish originals preserved in `modes/es/` following the existing `de/`, `fr/`, `pt/` pattern
- **Unify scoring to 10 weighted dimensions** across `_shared.md`, `ofertas.md`, and `batch-prompt.md` so single-evaluation and multi-offer comparison scores are always comparable
- **Fix `update-system.mjs`** — add 11 missing SYSTEM_PATHS (`fr/`, `pt/`, `es/`, `interview-prep.md`, `patterns.md`, `analyze-patterns.mjs`, `check-liveness.mjs`, `doctor.mjs`, `test-all.mjs`, `LEGAL_DISCLAIMER.md`, `README.es.md`)
- **Fix SKILL.md router** — add `interview-prep` to routing table, discovery menu, and context loading
- **Fix `tracker.md`** — use canonical English states from `states.yml`; add `Contacted` state for outbound outreach tracking
- **Update `DATA_CONTRACT.md`** with all missing system-layer entries
- **Rewrite `deep.md`** to execute 6-axis WebSearch research directly instead of generating a prompt for Perplexity
- **Expand `contacto.md`** with InMail/email variants, follow-up template, and tracker integration
- **Add `ofertas.md` post-comparison save** to `reports/comparison-{date}.md`

## Motivation

The Ultraplan audit identified 9 gaps (2 critical, 2 high, 3 medium, 2 low). The critical ones: `update-system.mjs` silently skipped ~40% of added functionality, and `interview-prep` was unreachable via the SKILL.md router. The high-impact ones: default modes were in Spanish despite the rest of the system being in English, and tracker states diverged from the canonical `states.yml`.

## Test plan

- [ ] `node update-system.mjs check` — updater includes all new paths
- [ ] Trigger each SKILL.md route to confirm routing works (especially `interview-prep`)
- [ ] `node verify-pipeline.mjs` — pipeline clean
- [ ] Compare a single eval score with the same offer in comparison mode — scores should use same 10 dimensions
- [ ] Verify `modes/es/` contains all 11 Spanish originals

🤖 Generated with [Claude Code](https://claude.com/claude-code)