### PR TITLE
fix: harden scripts against injection, SSRF, and path traversal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 # Personal data (user fills these)
+cv.md
+article-digest.md
+interview-prep/
 data/applications.md
 data/pipeline.md
 data/scan-history.tsv
@@ -24,10 +27,12 @@ modes/_profile.md
 
 # Generated
 .resolved-prompt-*
+*.bak
 node_modules/
 
 # OS
 .DS_Store
+*.swp
 *.mov
 *.mp4
 

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -19,6 +19,11 @@ LOCK_FILE="$BATCH_DIR/batch-runner.pid"
 STATE_LOCK_DIR="$BATCH_DIR/.batch-state.lock"
 MAIN_PID="${BASHPID:-$$}"
 
+# Escape a string for safe use as sed replacement text
+sed_escape() {
+  printf '%s\n' "$1" | sed -e 's/[&/\]/\\&/g'
+}
+
 # Defaults
 PARALLEL=1
 DRY_RUN=false
@@ -281,7 +286,8 @@ process_offer() {
   report_num=$(reserve_report_num "$id" "$url" "$started_at" "$retries")
   local date
   date=$(date +%Y-%m-%d)
-  local jd_file="/tmp/batch-jd-${id}.txt"
+  local jd_file
+  jd_file=$(mktemp "${TMPDIR:-/tmp}/batch-jd-XXXXXX.txt")
 
   echo "--- Processing offer #$id: $url (report $report_num, attempt $((retries + 1)))"
 
@@ -296,26 +302,39 @@ process_offer() {
 
   local log_file="$LOGS_DIR/${report_num}-${id}.log"
 
-  # Prepare system prompt with placeholders resolved
+  # Prepare system prompt with placeholders resolved (escape for safe sed replacement)
   local resolved_prompt="$BATCH_DIR/.resolved-prompt-${id}.md"
+  local escaped_url escaped_jd escaped_rnum escaped_date escaped_id
+  escaped_url=$(sed_escape "$url")
+  escaped_jd=$(sed_escape "$jd_file")
+  escaped_rnum=$(sed_escape "$report_num")
+  escaped_date=$(sed_escape "$date")
+  escaped_id=$(sed_escape "$id")
   sed \
-    -e "s|{{URL}}|${url}|g" \
-    -e "s|{{JD_FILE}}|${jd_file}|g" \
-    -e "s|{{REPORT_NUM}}|${report_num}|g" \
-    -e "s|{{DATE}}|${date}|g" \
-    -e "s|{{ID}}|${id}|g" \
+    -e "s|{{URL}}|${escaped_url}|g" \
+    -e "s|{{JD_FILE}}|${escaped_jd}|g" \
+    -e "s|{{REPORT_NUM}}|${escaped_rnum}|g" \
+    -e "s|{{DATE}}|${escaped_date}|g" \
+    -e "s|{{ID}}|${escaped_id}|g" \
     "$PROMPT_FILE" > "$resolved_prompt"
 
   # Launch claude -p worker (uses default model from Claude Max subscription)
+  # NOTE: Uses --permission-mode=default instead of --dangerously-skip-permissions.
+  # In -p (pipe) mode with default permissions, claude will skip tools that need
+  # confirmation rather than hang waiting for input. This is safer than bypassing
+  # all permission checks, which allows unrestricted shell commands and file writes.
+  # If your batch workflow genuinely requires unrestricted access (e.g. in an
+  # isolated sandbox/container with no network), you can change this back to
+  # --dangerously-skip-permissions, but only behind --allow-dangerously-skip-permissions.
   local exit_code=0
   claude -p \
-    --dangerously-skip-permissions \
+    --permission-mode=default \
     --append-system-prompt-file "$resolved_prompt" \
     "$prompt" \
     > "$log_file" 2>&1 || exit_code=$?
 
-  # Cleanup resolved prompt
-  rm -f "$resolved_prompt"
+  # Cleanup resolved prompt and temp JD file
+  rm -f "$resolved_prompt" "$jd_file"
 
   local completed_at
   completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/check-liveness.mjs
+++ b/check-liveness.mjs
@@ -53,6 +53,19 @@ const APPLY_PATTERNS = [
 // Below this length the page is probably just nav/footer (closed ATS page)
 const MIN_CONTENT_CHARS = 300;
 
+/** Validate that a URL is safe to navigate to (https only, no internal hosts) */
+function validateUrl(raw) {
+  let parsed;
+  try { parsed = new URL(raw); } catch { return false; }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
+  const host = parsed.hostname.toLowerCase();
+  if (host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '0.0.0.0') return false;
+  if (host.endsWith('.local') || host.endsWith('.internal')) return false;
+  // Block private IP ranges (10.x, 172.16-31.x, 192.168.x)
+  if (/^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(host)) return false;
+  return true;
+}
+
 async function checkUrl(page, url) {
   try {
     const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
@@ -125,6 +138,12 @@ async function main() {
 
   // Sequential — project rule: never Playwright in parallel
   for (const url of urls) {
+    if (!validateUrl(url)) {
+      console.log(`⛔ blocked    ${url}`);
+      console.log(`           only http(s) URLs to public hosts are allowed`);
+      expired++;
+      continue;
+    }
     const { result, reason } = await checkUrl(page, url);
     const icon = { active: '✅', expired: '❌', uncertain: '⚠️' }[result];
     console.log(`${icon} ${result.padEnd(10)} ${url}`);

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -94,6 +94,13 @@ async function generatePDF() {
   inputPath = resolve(inputPath);
   outputPath = resolve(outputPath);
 
+  // Validate output path stays within CWD or the project's output/ directory
+  const cwd = process.cwd();
+  if (!outputPath.startsWith(cwd) && !outputPath.startsWith(resolve(__dirname, 'output'))) {
+    console.error(`Output path must be within the working directory or output/. Got: ${outputPath}`);
+    process.exit(1);
+  }
+
   // Validate format
   const validFormats = ['a4', 'letter'];
   if (!validFormats.includes(format)) {

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -66,6 +66,11 @@ function normalizeCompany(name) {
   return name.toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
+/** Escape pipe and newline chars so they don't break markdown table rows */
+function escapeTableCell(val) {
+  return String(val).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
 function roleFuzzyMatch(a, b) {
   const wordsA = a.toLowerCase().split(/\s+/).filter(w => w.length > 3);
   const wordsB = b.toLowerCase().split(/\s+/).filter(w => w.length > 3);
@@ -269,7 +274,7 @@ for (const file of tsvFiles) {
       console.log(`🔄 Update: #${duplicate.num} ${addition.company} — ${addition.role} (${oldScore}→${newScore})`);
       const lineIdx = appLines.indexOf(duplicate.raw);
       if (lineIdx >= 0) {
-        const updatedLine = `| ${duplicate.num} | ${addition.date} | ${addition.company} | ${addition.role} | ${addition.score} | ${duplicate.status} | ${duplicate.pdf} | ${addition.report} | Re-eval ${addition.date} (${oldScore}→${newScore}). ${addition.notes} |`;
+        const updatedLine = `| ${duplicate.num} | ${escapeTableCell(addition.date)} | ${escapeTableCell(addition.company)} | ${escapeTableCell(addition.role)} | ${escapeTableCell(addition.score)} | ${escapeTableCell(duplicate.status)} | ${escapeTableCell(duplicate.pdf)} | ${escapeTableCell(addition.report)} | Re-eval ${addition.date} (${oldScore}→${newScore}). ${escapeTableCell(addition.notes)} |`;
         appLines[lineIdx] = updatedLine;
         updated++;
       }
@@ -282,7 +287,7 @@ for (const file of tsvFiles) {
     const entryNum = addition.num > maxNum ? addition.num : ++maxNum;
     if (addition.num > maxNum) maxNum = addition.num;
 
-    const newLine = `| ${entryNum} | ${addition.date} | ${addition.company} | ${addition.role} | ${addition.score} | ${addition.status} | ${addition.pdf} | ${addition.report} | ${addition.notes} |`;
+    const newLine = `| ${entryNum} | ${escapeTableCell(addition.date)} | ${escapeTableCell(addition.company)} | ${escapeTableCell(addition.role)} | ${escapeTableCell(addition.score)} | ${escapeTableCell(addition.status)} | ${escapeTableCell(addition.pdf)} | ${escapeTableCell(addition.report)} | ${escapeTableCell(addition.notes)} |`;
     newLines.push(newLine);
     added++;
     console.log(`➕ Add #${entryNum}: ${addition.company} — ${addition.role} (${addition.score})`);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -100,8 +100,14 @@ function compareVersions(a, b) {
   return 0;
 }
 
-function git(cmd) {
-  return execSync(`git ${cmd}`, { cwd: ROOT, encoding: 'utf-8', timeout: 30000 }).trim();
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+function git(args) {
+  // Accept an array of args to avoid shell injection, or a string for simple commands
+  if (Array.isArray(args)) {
+    return execSync('git ' + args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' '), { cwd: ROOT, encoding: 'utf-8', timeout: 30000 }).trim();
+  }
+  return execSync(`git ${args}`, { cwd: ROOT, encoding: 'utf-8', timeout: 30000 }).trim();
 }
 
 // ── CHECK ───────────────────────────────────────────────────────
@@ -117,9 +123,13 @@ async function check() {
   let remote;
 
   try {
-    const res = await fetch(RAW_VERSION_URL);
+    const res = await fetch(RAW_VERSION_URL, { signal: AbortSignal.timeout(10000) });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     remote = (await res.text()).trim();
+    if (!SEMVER_RE.test(remote)) {
+      console.log(JSON.stringify({ status: 'offline', local, error: 'invalid remote version format' }));
+      return;
+    }
   } catch {
     console.log(JSON.stringify({ status: 'offline', local }));
     return;
@@ -168,10 +178,14 @@ async function apply() {
   writeFileSync(lockFile, new Date().toISOString());
 
   try {
-    // 1. Backup: create branch
+    // 1. Backup: create branch (validate version is semver to prevent injection)
+    if (!SEMVER_RE.test(local)) {
+      console.error(`Invalid local version format: "${local}". Expected X.Y.Z`);
+      process.exit(1);
+    }
     const backupBranch = `backup-pre-update-${local}`;
     try {
-      git(`branch ${backupBranch}`);
+      git(['branch', backupBranch]);
       console.log(`Backup branch created: ${backupBranch}`);
     } catch {
       console.log(`Backup branch already exists (${backupBranch}), continuing...`);
@@ -179,15 +193,15 @@ async function apply() {
 
     // 2. Fetch from canonical repo
     console.log('Fetching latest from upstream...');
-    git(`fetch ${CANONICAL_REPO} main`);
+    git(['fetch', CANONICAL_REPO, 'main']);
 
     // 3. Checkout system files only
     console.log('Updating system files...');
     const updated = [];
-    for (const path of SYSTEM_PATHS) {
+    for (const sysPath of SYSTEM_PATHS) {
       try {
-        git(`checkout FETCH_HEAD -- ${path}`);
-        updated.push(path);
+        git(['checkout', 'FETCH_HEAD', '--', sysPath]);
+        updated.push(sysPath);
       } catch {
         // File may not exist in remote (new additions), skip
       }
@@ -266,10 +280,16 @@ function rollback() {
     const latest = branchList[branchList.length - 1];
     console.log(`Rolling back to: ${latest}`);
 
+    // Validate branch name format before using it
+    if (!/^backup-pre-update-\d+\.\d+\.\d+$/.test(latest)) {
+      console.error(`Suspicious backup branch name: "${latest}". Aborting.`);
+      process.exit(1);
+    }
+
     // Checkout system files from backup branch
-    for (const path of SYSTEM_PATHS) {
+    for (const sysPath of SYSTEM_PATHS) {
       try {
-        git(`checkout ${latest} -- ${path}`);
+        git(['checkout', latest, '--', sysPath]);
       } catch {
         // File may not have existed in backup
       }


### PR DESCRIPTION
## Summary

Security hardening for local tooling scripts, as reported in #132. Fixes 9 vulnerabilities across 6 files without changing normal workflow behavior.

- Escape `sed` replacement variables in batch-runner to prevent shell injection via crafted URLs
- Use `mktemp` instead of predictable `/tmp` paths to prevent symlink race conditions
- Replace `--dangerously-skip-permissions` with `--permission-mode=default` in batch workers
- Validate version strings as semver and use safe git arg passing in update-system
- Restrict PDF output path to project directory to prevent path traversal
- Block `file://`, `localhost`, and private IPs in Playwright liveness checker (SSRF)
- Escape pipe/newline characters in markdown table cells in merge-tracker
- Gitignore user-layer files created during setup (`cv.md`, `article-digest.md`, `interview-prep/`) and generated artifacts (`*.bak`, `*.swp`)

## Test plan

- [ ] Run `bash -n batch/batch-runner.sh` — syntax check passes
- [ ] Run `node --check` on all modified `.mjs` files — all pass
- [ ] Run `./batch/batch-runner.sh --dry-run` — normal flow unchanged
- [ ] Run `node generate-pdf.mjs input.html ../../outside.pdf` — rejected with clear error
- [ ] Run `node check-liveness.mjs file:///etc/passwd` — blocked, not navigated
- [ ] Run `node check-liveness.mjs http://localhost:8080` — blocked
- [ ] Run `node check-liveness.mjs https://boards.greenhouse.io/anthropic` — works normally
- [ ] Verify `git status` no longer shows `cv.md`, `*.swp`, or `*.bak` as untracked