### PR TITLE
fix: stop liveness checks from accepting ATS listing pages

### DIFF
--- a/check-liveness.mjs
+++ b/check-liveness.mjs
@@ -16,83 +16,53 @@
 
 import { chromium } from 'playwright';
 import { readFile } from 'fs/promises';
-
-const EXPIRED_PATTERNS = [
-  /job (is )?no longer available/i,
-  /job.*no longer open/i,           // Greenhouse: "The job you are looking for is no longer open."
-  /position has been filled/i,
-  /this job has expired/i,
-  /job posting has expired/i,
-  /no longer accepting applications/i,
-  /this (position|role|job) (is )?no longer/i,
-  /this job (listing )?is closed/i,
-  /job (listing )?not found/i,
-  /the page you are looking for doesn.t exist/i, // Workday /job/ 404
-  /\d+\s+jobs?\s+found/i,           // Workday: landed on listing page ("663 JOBS FOUND") instead of a specific job
-  /search for jobs page is loaded/i, // Workday SPA indicator for listing page
-  /diese stelle (ist )?(nicht mehr|bereits) besetzt/i,
-  /offre (expirée|n'est plus disponible)/i,
-];
-
-// URL patterns that indicate an ATS has redirected away from the job (closed/expired)
-const EXPIRED_URL_PATTERNS = [
-  /[?&]error=true/i,   // Greenhouse redirect on closed jobs
-];
-
-const APPLY_PATTERNS = [
-  /\bapply\b/i,          // catches "Apply", "Apply Now", "Apply for this Job"
-  /\bsolicitar\b/i,
-  /\bbewerben\b/i,
-  /\bpostuler\b/i,
-  /submit application/i,
-  /easy apply/i,
-  /start application/i,  // Ashby
-  /ich bewerbe mich/i,   // German Greenhouse
-];
-
-// Below this length the page is probably just nav/footer (closed ATS page)
-const MIN_CONTENT_CHARS = 300;
+import { classifyLiveness } from './liveness-core.mjs';
 
 async function checkUrl(page, url) {
   try {
     const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
 
     const status = response?.status() ?? 0;
-    if (status === 404 || status === 410) {
-      return { result: 'expired', reason: `HTTP ${status}` };
-    }
 
     // Give SPAs (Ashby, Lever, Workday) time to hydrate
     await page.waitForTimeout(2000);
 
-    // Check if the ATS redirected to an error/listing page (e.g. Greenhouse ?error=true)
     const finalUrl = page.url();
-    for (const pattern of EXPIRED_URL_PATTERNS) {
-      if (pattern.test(finalUrl)) {
-        return { result: 'expired', reason: `redirect to ${finalUrl}` };
-      }
-    }
-
     const bodyText = await page.evaluate(() => document.body?.innerText ?? '');
+    const applyControls = await page.evaluate(() => {
+      const controls = document.querySelectorAll(
+        'a, button, input[type="submit"], input[type="button"], [role="button"]'
+      );
 
-    // Apply button is the strongest positive signal — check it first.
-    // This short-circuits before expired patterns that can appear on active pages
-    // (e.g. Workday's split-view layout shows "N JOBS FOUND" even on active job pages).
-    if (APPLY_PATTERNS.some(p => p.test(bodyText))) {
-      return { result: 'active', reason: 'apply button detected' };
-    }
+      return Array.from(controls)
+        .filter((element) => {
+          if (element.closest('nav, header, footer')) return false;
+          if (element.closest('[aria-hidden="true"]')) return false;
 
-    for (const pattern of EXPIRED_PATTERNS) {
-      if (pattern.test(bodyText)) {
-        return { result: 'expired', reason: `pattern matched: ${pattern.source}` };
-      }
-    }
+          const style = window.getComputedStyle(element);
+          if (style.display === 'none' || style.visibility === 'hidden') return false;
+          if (!element.getClientRects().length) return false;
 
-    if (bodyText.trim().length < MIN_CONTENT_CHARS) {
-      return { result: 'expired', reason: 'insufficient content — likely nav/footer only' };
-    }
+          return Array.from(element.getClientRects()).some((rect) => rect.width > 0 && rect.height > 0);
+        })
+        .map((element) => {
+          const label = [
+            element.innerText,
+            element.value,
+            element.getAttribute('aria-label'),
+            element.getAttribute('title'),
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .replace(/\s+/g, ' ')
+            .trim();
 
-    return { result: 'uncertain', reason: 'content present but no apply button found' };
+          return label;
+        })
+        .filter(Boolean);
+    });
+
+    return classifyLiveness({ status, finalUrl, bodyText, applyControls });
 
   } catch (err) {
     return { result: 'expired', reason: `navigation error: ${err.message.split('\n')[0]}` };

--- a/liveness-core.mjs
+++ b/liveness-core.mjs
@@ -1,0 +1,83 @@
+const EXPIRED_PATTERNS = [
+  /job (is )?no longer available/i,
+  /job.*no longer open/i,           // Greenhouse: "The job you are looking for is no longer open."
+  /position has been filled/i,
+  /this job has expired/i,
+  /job posting has expired/i,
+  /no longer accepting applications/i,
+  /this (position|role|job) (is )?no longer/i,
+  /this job (listing )?is closed/i,
+  /job (listing )?not found/i,
+  /the page you are looking for doesn.t exist/i, // Workday /job/ 404
+  /\d+\s+jobs?\s+found/i,           // Workday: landed on listing page ("663 JOBS FOUND") instead of a specific job
+  /search for jobs page is loaded/i, // Workday SPA indicator for listing page
+  /diese stelle (ist )?(nicht mehr|bereits) besetzt/i,
+  /offre (expirée|n'est plus disponible)/i,
+];
+
+const LISTING_PAGE_PATTERNS = [
+  /\d+\s+jobs?\s+found/i,
+  /search for jobs page is loaded/i,
+];
+
+const EXPIRED_URL_PATTERNS = [
+  /[?&]error=true/i,   // Greenhouse redirect on closed jobs
+];
+
+const APPLY_PATTERNS = [
+  /\bapply\b/i,          // catches "Apply", "Apply Now", "Apply for this Job"
+  /\bsolicitar\b/i,
+  /\bbewerben\b/i,
+  /\bpostuler\b/i,
+  /submit application/i,
+  /easy apply/i,
+  /start application/i,  // Ashby
+  /ich bewerbe mich/i,   // German Greenhouse
+];
+
+const MIN_CONTENT_CHARS = 300;
+
+function matchesAnyPattern(value, patterns) {
+  return patterns.find((pattern) => pattern.test(value));
+}
+
+function countApplyControls(applyControls = []) {
+  return applyControls.filter((label) => matchesAnyPattern(label, APPLY_PATTERNS)).length;
+}
+
+export function classifyLiveness({
+  status = 0,
+  finalUrl = '',
+  bodyText = '',
+  applyControls = [],
+}) {
+  if (status === 404 || status === 410) {
+    return { result: 'expired', reason: `HTTP ${status}` };
+  }
+
+  const expiredUrlPattern = matchesAnyPattern(finalUrl, EXPIRED_URL_PATTERNS);
+  if (expiredUrlPattern) {
+    return { result: 'expired', reason: `redirect to ${finalUrl}` };
+  }
+
+  const visibleApplyControls = countApplyControls(applyControls);
+  const listingPattern = matchesAnyPattern(bodyText, LISTING_PAGE_PATTERNS);
+  if (listingPattern && visibleApplyControls > 1) {
+    return { result: 'expired', reason: `listing page matched: ${listingPattern.source}` };
+  }
+
+  if (visibleApplyControls > 0) {
+    return { result: 'active', reason: 'visible apply control detected' };
+  }
+
+  const expiredBodyPattern = matchesAnyPattern(bodyText, EXPIRED_PATTERNS);
+  if (expiredBodyPattern) {
+    return { result: 'expired', reason: `pattern matched: ${expiredBodyPattern.source}` };
+  }
+
+  if (bodyText.trim().length < MIN_CONTENT_CHARS) {
+    return { result: 'expired', reason: 'insufficient content — likely nav/footer only' };
+  }
+
+  return { result: 'uncertain', reason: 'content present but no visible apply control found' };
+}

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -97,7 +97,7 @@ Los niveles son aditivos — se ejecutan todos, los resultados se mezclan y dedu
    a. `browser_navigate` a la URL
    b. `browser_snapshot` para leer el contenido
    c. Clasificar:
-      - **Activa**: título del puesto visible + descripción del rol + botón Apply/Submit/Solicitar
+      - **Activa**: título del puesto visible + descripción del rol + control visible de Apply/Submit/Solicitar dentro del contenido principal. No contar texto genérico de header/navbar/footer.
       - **Expirada** (cualquiera de estas señales):
         - URL final contiene `?error=true` (Greenhouse redirige así cuando la oferta está cerrada)
         - Página contiene: "job no longer available" / "no longer open" / "position has been filled" / "this job has expired" / "page not found"

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -14,7 +14,7 @@
 import { execSync } from 'child_process';
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = __dirname;
@@ -79,10 +79,57 @@ for (const { name, allowFail } of scripts) {
   }
 }
 
-// ── 3. DASHBOARD BUILD ──────────────────────────────────────────
+// ── 3. LIVENESS CLASSIFICATION ──────────────────────────────────
+
+console.log('\n3. Liveness classification');
+
+try {
+  const { classifyLiveness } = await import(pathToFileURL(join(ROOT, 'liveness-core.mjs')).href);
+
+  const listingPage = classifyLiveness({
+    finalUrl: 'https://example.com/jobs',
+    bodyText: '663 JOBS FOUND\nSearch for jobs page is loaded\nAI Engineer\nML Engineer',
+    applyControls: ['Apply', 'Apply'],
+  });
+  if (listingPage.result === 'expired') {
+    pass('Listing pages with multiple apply controls are treated as expired');
+  } else {
+    fail(`Listing page misclassified as ${listingPage.result}`);
+  }
+
+  const expiredChromeApply = classifyLiveness({
+    finalUrl: 'https://example.com/jobs/closed-role',
+    bodyText: 'Company Careers\nApply\nThe job you are looking for is no longer open.',
+    applyControls: [],
+  });
+  if (expiredChromeApply.result === 'expired') {
+    pass('Expired pages are not revived by generic body-text apply labels');
+  } else {
+    fail(`Expired page misclassified as ${expiredChromeApply.result}`);
+  }
+
+  const activeWorkdayPage = classifyLiveness({
+    finalUrl: 'https://example.workday.com/job/123',
+    bodyText: [
+      '663 JOBS FOUND',
+      'Senior AI Engineer',
+      'Join our applied AI team to ship production systems, partner with customers, and own delivery across evaluation, deployment, and reliability.',
+    ].join('\n'),
+    applyControls: ['Apply for this Job'],
+  });
+  if (activeWorkdayPage.result === 'active') {
+    pass('Real job pages stay active when there is a single visible apply control');
+  } else {
+    fail(`Active job page misclassified as ${activeWorkdayPage.result}`);
+  }
+} catch (e) {
+  fail(`Liveness classification tests crashed: ${e.message}`);
+}
+
+// ── 4. DASHBOARD BUILD ──────────────────────────────────────────
 
 if (!QUICK) {
-  console.log('\n3. Dashboard build');
+  console.log('\n4. Dashboard build');
   const goBuild = run('cd dashboard && go build -o /tmp/career-dashboard-test . 2>&1');
   if (goBuild !== null) {
     pass('Dashboard compiles');
@@ -90,12 +137,12 @@ if (!QUICK) {
     fail('Dashboard build failed');
   }
 } else {
-  console.log('\n3. Dashboard build (skipped --quick)');
+  console.log('\n4. Dashboard build (skipped --quick)');
 }
 
-// ── 4. DATA CONTRACT ────────────────────────────────────────────
+// ── 5. DATA CONTRACT ────────────────────────────────────────────
 
-console.log('\n4. Data contract validation');
+console.log('\n5. Data contract validation');
 
 // Check system files exist
 const systemFiles = [
@@ -129,9 +176,9 @@ for (const f of userFiles) {
   }
 }
 
-// ── 5. PERSONAL DATA LEAK CHECK ─────────────────────────────────
+// ── 6. PERSONAL DATA LEAK CHECK ─────────────────────────────────
 
-console.log('\n5. Personal data leak check');
+console.log('\n6. Personal data leak check');
 
 const leakPatterns = [
   'Santiago', 'santifer.io', 'Santifer iRepair', 'Zinkee', 'ALMAS',
@@ -162,9 +209,9 @@ if (!leakFound) {
   pass('No personal data leaks outside allowed files');
 }
 
-// ── 6. ABSOLUTE PATH CHECK ──────────────────────────────────────
+// ── 7. ABSOLUTE PATH CHECK ──────────────────────────────────────
 
-console.log('\n6. Absolute path check');
+console.log('\n7. Absolute path check');
 
 const absPathResult = run(
   `grep -rn "/Users/" --include="*.mjs" --include="*.sh" --include="*.md" --include="*.go" --include="*.yml" . 2>/dev/null | grep -v node_modules | grep -v ".git/" | grep -v README.md | grep -v LICENSE | grep -v go.sum | grep -v CLAUDE.md | grep -v test-all.mjs`
@@ -177,9 +224,9 @@ if (!absPathResult) {
   }
 }
 
-// ── 7. MODE FILE INTEGRITY ──────────────────────────────────────
+// ── 8. MODE FILE INTEGRITY ──────────────────────────────────────
 
-console.log('\n7. Mode file integrity');
+console.log('\n8. Mode file integrity');
 
 const expectedModes = [
   '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'scan.md',
@@ -203,9 +250,9 @@ if (shared.includes('_profile.md')) {
   fail('_shared.md does NOT reference _profile.md');
 }
 
-// ── 8. CLAUDE.md INTEGRITY ──────────────────────────────────────
+// ── 9. CLAUDE.md INTEGRITY ──────────────────────────────────────
 
-console.log('\n8. CLAUDE.md integrity');
+console.log('\n9. CLAUDE.md integrity');
 
 const claude = readFile('CLAUDE.md');
 const requiredSections = [
@@ -222,9 +269,9 @@ for (const section of requiredSections) {
   }
 }
 
-// ── 9. VERSION FILE ─────────────────────────────────────────────
+// ── 10. VERSION FILE ─────────────────────────────────────────────
 
-console.log('\n9. Version file');
+console.log('\n10. Version file');
 
 if (fileExists('VERSION')) {
   const version = readFile('VERSION').trim();


### PR DESCRIPTION
Fixes #129.

When an expired job URL lands on a generic ATS listing page, the current liveness check can still return `active` if that page contains visible `Apply` controls. That lets dead links survive the scan step and reach the user as if they were still open.

This patch makes the liveness classifier look at visible apply controls instead of raw body text, and it treats listing pages with multiple apply controls as expired. It also keeps the intended Workday split-view case working by still accepting pages that have a single visible apply control tied to the current job.

I also aligned `modes/scan.md` with the stricter rule and added regression coverage in `test-all.mjs` for three cases: listing pages with multiple apply controls, expired pages that still contain generic `Apply` text in the body, and real job pages that should stay active.

Checks run:
- `npm install`
- `node test-all.mjs --quick`
- `node check-liveness.mjs file:///tmp/career-ops-fixtures/listing-with-apply.html`
- `node check-liveness.mjs file:///tmp/career-ops-fixtures/active-job.html`

Before this change, the listing-page fixture above returned `active`. After the patch, it returns `expired` while the active-job fixture still returns `active`.