### PR TITLE
Feat: follow-up cadence tracker mode

### DIFF
--- a/.claude/skills/career-ops/SKILL.md
+++ b/.claude/skills/career-ops/SKILL.md
@@ -28,6 +28,7 @@ Determine the mode from `{{mode}}`:
 | `scan` | `scan` |
 | `batch` | `batch` |
 | `patterns` | `patterns` |
+| `followup` | `followup` |
 
 **Auto-pipeline detection:** If `{{mode}}` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
 
@@ -57,6 +58,7 @@ Available commands:
   /career-ops scan      → Scan portals and discover new offers
   /career-ops batch     → Batch processing with parallel workers
   /career-ops patterns  → Analyze rejection patterns and improve targeting
+  /career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
 
 Inbox: add URLs to data/pipeline.md → /career-ops pipeline
 Or paste a JD directly to run the full pipeline.
@@ -76,7 +78,7 @@ Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `p
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`
 
-Applies to: `tracker`, `deep`, `training`, `project`, `patterns`
+Applies to: `tracker`, `deep`, `training`, `project`, `patterns`, `followup`
 
 ### Modes delegated to subagent:
 For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as Agent with the content of `_shared.md` + `modes/{mode}.md` injected into the subagent prompt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `interview-prep/story-bank.md` | Accumulated STAR+R stories across evaluations |
 | `interview-prep/{company}-{role}.md` | Company-specific interview intel reports |
 | `analyze-patterns.mjs` | Pattern analysis script (JSON output) |
+| `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
+| `data/follow-ups.md` | Follow-up history tracker |
 | `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`) |
 
 ### OpenCode Commands
@@ -81,6 +83,7 @@ When using [OpenCode](https://opencode.ai), the following slash commands are ava
 | `/career-ops-scan` | `/career-ops scan` | Scan portals for new offers |
 | `/career-ops-batch` | `/career-ops batch` | Batch processing with parallel workers |
 | `/career-ops-patterns` | `/career-ops patterns` | Analyze rejection patterns and improve targeting |
+| `/career-ops-followup` | `/career-ops followup` | Follow-up cadence tracker |
 
 **Note:** OpenCode commands invoke the same `.claude/skills/career-ops/SKILL.md` skill used by Claude Code. The `modes/*` files are shared between both platforms.
 
@@ -218,6 +221,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Processes pending URLs | `pipeline` |
 | Batch processes offers | `batch` |
 | Asks about rejection patterns or wants to improve targeting | `patterns` |
+| Asks about follow-ups or application cadence | `followup` |
 
 ### CV Source of Truth
 

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -17,6 +17,7 @@ These files contain your personal data, customizations, and work product. Update
 | `data/applications.md` | Your application tracker |
 | `data/pipeline.md` | Your URL inbox |
 | `data/scan-history.tsv` | Your scan history |
+| `data/follow-ups.md` | Your follow-up history |
 | `reports/*` | Your evaluation reports |
 | `output/*` | Your generated PDFs |
 | `jds/*` | Your saved job descriptions |
@@ -41,6 +42,8 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/project.md` | Project evaluation instructions |
 | `modes/tracker.md` | Tracker instructions |
 | `modes/training.md` | Training evaluation instructions |
+| `modes/patterns.md` | Pattern analysis instructions |
+| `modes/followup.md` | Follow-up cadence instructions |
 | `modes/de/*` | German language modes |
 | `CLAUDE.md` | Agent instructions |
 | `AGENTS.md` | Codex instructions |

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * followup-cadence.mjs — Follow-up Cadence Tracker for career-ops
+ *
+ * Parses applications.md + follow-ups.md, calculates follow-up cadence
+ * for active applications, extracts contacts, and flags overdue entries.
+ *
+ * Run: node followup-cadence.mjs             (JSON to stdout)
+ *      node followup-cadence.mjs --summary   (human-readable dashboard)
+ *      node followup-cadence.mjs --overdue-only
+ *      node followup-cadence.mjs --applied-days 10
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
+  ? join(CAREER_OPS, 'data/applications.md')
+  : join(CAREER_OPS, 'applications.md');
+const FOLLOWUPS_FILE = join(CAREER_OPS, 'data/follow-ups.md');
+
+
+// --- CLI args ---
+const args = process.argv.slice(2);
+const summaryMode = args.includes('--summary');
+const overdueOnly = args.includes('--overdue-only');
+const appliedDaysIdx = args.indexOf('--applied-days');
+const APPLIED_FIRST = appliedDaysIdx !== -1 ? parseInt(args[appliedDaysIdx + 1]) || 7 : 7;
+
+// --- Cadence config ---
+const CADENCE = {
+  applied_first: APPLIED_FIRST,
+  applied_subsequent: 7,
+  applied_max_followups: 2,
+  responded_initial: 1,
+  responded_subsequent: 3,
+  interview_thankyou: 1,
+};
+
+// --- Status normalization (mirrors verify-pipeline.mjs) ---
+const ALIASES = {
+  'evaluada': 'evaluated', 'condicional': 'evaluated', 'hold': 'evaluated',
+  'evaluar': 'evaluated', 'verificar': 'evaluated',
+  'aplicado': 'applied', 'enviada': 'applied', 'aplicada': 'applied',
+  'applied': 'applied', 'sent': 'applied',
+  'respondido': 'responded',
+  'entrevista': 'interview',
+  'oferta': 'offer',
+  'rechazado': 'rejected', 'rechazada': 'rejected',
+  'descartado': 'discarded', 'descartada': 'discarded',
+  'cerrada': 'discarded', 'cancelada': 'discarded',
+  'no aplicar': 'skip', 'no_aplicar': 'skip', 'monitor': 'skip', 'geo blocker': 'skip',
+};
+
+const ACTIONABLE_STATUSES = ['applied', 'responded', 'interview'];
+
+function normalizeStatus(raw) {
+  const clean = raw.replace(/\*\*/g, '').trim().toLowerCase()
+    .replace(/\s+\d{4}-\d{2}-\d{2}.*$/, '').trim();
+  return ALIASES[clean] || clean;
+}
+
+// --- Date helpers ---
+function today() {
+  return new Date(new Date().toISOString().split('T')[0]);
+}
+
+function parseDate(dateStr) {
+  if (!dateStr || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr.trim())) return null;
+  return new Date(dateStr.trim());
+}
+
+function daysBetween(d1, d2) {
+  return Math.floor((d2 - d1) / (1000 * 60 * 60 * 24));
+}
+
+function addDays(date, days) {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result.toISOString().split('T')[0];
+}
+
+// --- Parse applications.md ---
+function parseTracker() {
+  if (!existsSync(APPS_FILE)) return [];
+  const content = readFileSync(APPS_FILE, 'utf-8');
+  const entries = [];
+  for (const line of content.split('\n')) {
+    if (!line.startsWith('|')) continue;
+    const parts = line.split('|').map(s => s.trim());
+    if (parts.length < 9) continue;
+    const num = parseInt(parts[1]);
+    if (isNaN(num)) continue;
+    entries.push({
+      num, date: parts[2], company: parts[3], role: parts[4],
+      score: parts[5], status: parts[6], pdf: parts[7], report: parts[8],
+      notes: parts[9] || '',
+    });
+  }
+  return entries;
+}
+
+// --- Parse follow-ups.md ---
+function parseFollowups() {
+  if (!existsSync(FOLLOWUPS_FILE)) return [];
+  const content = readFileSync(FOLLOWUPS_FILE, 'utf-8');
+  const entries = [];
+  for (const line of content.split('\n')) {
+    if (!line.startsWith('|')) continue;
+    const parts = line.split('|').map(s => s.trim());
+    if (parts.length < 8) continue;
+    const num = parseInt(parts[1]);
+    if (isNaN(num)) continue;
+    entries.push({
+      num,
+      appNum: parseInt(parts[2]),
+      date: parts[3],
+      company: parts[4],
+      role: parts[5],
+      channel: parts[6],
+      contact: parts[7],
+      notes: parts[8] || '',
+    });
+  }
+  return entries;
+}
+
+// --- Extract contacts from notes ---
+function extractContacts(notes) {
+  if (!notes) return [];
+  const contacts = [];
+  const emailRegex = /[\w.-]+@[\w.-]+\.\w+/g;
+  const emails = notes.match(emailRegex) || [];
+  for (const email of emails) {
+    // Try to extract name before email: "Emailed Name at" or "contact: Name"
+    let name = null;
+    const beforeEmail = notes.substring(0, notes.indexOf(email));
+    const nameMatch = beforeEmail.match(/(?:Emailed|emailed|contact[:\s]+|to\s+)([A-Z][a-z]+ ?[A-Z]?[a-z]*)\s*(?:at|@|$)/i);
+    if (nameMatch) name = nameMatch[1].trim();
+    contacts.push({ email, name });
+  }
+  return contacts;
+}
+
+// --- Resolve report path ---
+function resolveReportPath(reportField) {
+  const match = reportField.match(/\]\(([^)]+)\)/);
+  if (!match) return null;
+  const fullPath = join(CAREER_OPS, match[1]);
+  return existsSync(fullPath) ? match[1] : null;
+}
+
+// --- Compute urgency ---
+function computeUrgency(status, daysSinceApp, daysSinceLastFollowup, followupCount) {
+  if (status === 'applied') {
+    if (followupCount >= CADENCE.applied_max_followups) return 'cold';
+    if (followupCount === 0 && daysSinceApp >= CADENCE.applied_first) return 'overdue';
+    if (followupCount > 0 && daysSinceLastFollowup !== null && daysSinceLastFollowup >= CADENCE.applied_subsequent) return 'overdue';
+    return 'waiting';
+  }
+  if (status === 'responded') {
+    if (daysSinceApp < CADENCE.responded_initial) return 'urgent';
+    if (daysSinceApp >= CADENCE.responded_subsequent) return 'overdue';
+    return 'waiting';
+  }
+  if (status === 'interview') {
+    if (daysSinceApp >= CADENCE.interview_thankyou) return 'overdue';
+    return 'waiting';
+  }
+  return 'waiting';
+}
+
+// --- Compute next follow-up date ---
+function computeNextFollowupDate(status, appDate, lastFollowupDate, followupCount) {
+  if (status === 'applied') {
+    if (followupCount >= CADENCE.applied_max_followups) return null; // cold
+    if (followupCount === 0) return addDays(parseDate(appDate), CADENCE.applied_first);
+    if (lastFollowupDate) return addDays(parseDate(lastFollowupDate), CADENCE.applied_subsequent);
+    return addDays(parseDate(appDate), CADENCE.applied_first);
+  }
+  if (status === 'responded') {
+    if (lastFollowupDate) return addDays(parseDate(lastFollowupDate), CADENCE.responded_subsequent);
+    return addDays(parseDate(appDate), CADENCE.responded_subsequent);
+  }
+  if (status === 'interview') {
+    return addDays(parseDate(appDate), CADENCE.interview_thankyou);
+  }
+  return null;
+}
+
+// --- Main analysis ---
+function analyze() {
+  const apps = parseTracker();
+  if (apps.length === 0) {
+    return { error: 'No applications found in tracker.' };
+  }
+
+  const followups = parseFollowups();
+
+  // Group follow-ups by app number
+  const followupsByApp = new Map();
+  for (const fu of followups) {
+    if (!followupsByApp.has(fu.appNum)) followupsByApp.set(fu.appNum, []);
+    followupsByApp.get(fu.appNum).push(fu);
+  }
+
+  const now = today();
+  const entries = [];
+
+  for (const app of apps) {
+    const normalized = normalizeStatus(app.status);
+    if (!ACTIONABLE_STATUSES.includes(normalized)) continue;
+
+    const appDate = parseDate(app.date);
+    if (!appDate) continue;
+
+    const daysSinceApp = daysBetween(appDate, now);
+    const appFollowups = followupsByApp.get(app.num) || [];
+    const followupCount = appFollowups.length;
+
+    // Find most recent follow-up
+    let lastFollowupDate = null;
+    let daysSinceLastFollowup = null;
+    if (appFollowups.length > 0) {
+      const sorted = appFollowups.sort((a, b) => (a.date > b.date ? -1 : 1));
+      lastFollowupDate = sorted[0].date;
+      const lastDate = parseDate(lastFollowupDate);
+      if (lastDate) daysSinceLastFollowup = daysBetween(lastDate, now);
+    }
+
+    const urgency = computeUrgency(normalized, daysSinceApp, daysSinceLastFollowup, followupCount);
+    const nextFollowupDate = computeNextFollowupDate(normalized, app.date, lastFollowupDate, followupCount);
+    const nextDate = nextFollowupDate ? parseDate(nextFollowupDate) : null;
+    const daysUntilNext = nextDate ? daysBetween(now, nextDate) : null;
+
+    const contacts = extractContacts(app.notes);
+    const reportPath = resolveReportPath(app.report);
+
+    entries.push({
+      num: app.num,
+      date: app.date,
+      company: app.company,
+      role: app.role,
+      status: normalized,
+      score: app.score,
+      notes: app.notes,
+      reportPath,
+      contacts,
+      daysSinceApplication: daysSinceApp,
+      daysSinceLastFollowup,
+      followupCount,
+      urgency,
+      nextFollowupDate,
+      daysUntilNext,
+    });
+  }
+
+  // Sort by urgency priority: urgent > overdue > waiting > cold
+  const urgencyOrder = { urgent: 0, overdue: 1, waiting: 2, cold: 3 };
+  entries.sort((a, b) => (urgencyOrder[a.urgency] ?? 9) - (urgencyOrder[b.urgency] ?? 9));
+
+  const filtered = overdueOnly
+    ? entries.filter(e => e.urgency === 'overdue' || e.urgency === 'urgent')
+    : entries;
+
+  return {
+    metadata: {
+      analysisDate: now.toISOString().split('T')[0],
+      totalTracked: apps.length,
+      actionable: entries.length,
+      overdue: entries.filter(e => e.urgency === 'overdue').length,
+      urgent: entries.filter(e => e.urgency === 'urgent').length,
+      cold: entries.filter(e => e.urgency === 'cold').length,
+      waiting: entries.filter(e => e.urgency === 'waiting').length,
+    },
+    entries: filtered,
+    cadenceConfig: CADENCE,
+  };
+}
+
+// --- Summary mode ---
+function printSummary(result) {
+  if (result.error) {
+    console.log(`\n${result.error}\n`);
+    return;
+  }
+
+  const { metadata, entries } = result;
+
+  console.log(`\n${'='.repeat(70)}`);
+  console.log(`  Follow-up Cadence Dashboard — ${metadata.analysisDate}`);
+  console.log(`  ${metadata.totalTracked} total applications, ${metadata.actionable} actionable`);
+  console.log(`${'='.repeat(70)}\n`);
+
+  if (entries.length === 0) {
+    console.log('  No active applications to track. Apply to some roles first.\n');
+    return;
+  }
+
+  // Status summary
+  const urgencyIcon = { urgent: 'URGENT', overdue: 'OVERDUE', waiting: 'waiting', cold: 'COLD' };
+  console.log(`  ${metadata.urgent} urgent | ${metadata.overdue} overdue | ${metadata.waiting} waiting | ${metadata.cold} cold\n`);
+
+  // Table header
+  console.log('  ' + '#'.padEnd(5) + 'Company'.padEnd(16) + 'Status'.padEnd(12) + 'Days'.padEnd(6) + 'F/U'.padEnd(5) + 'Next'.padEnd(13) + 'Urgency'.padEnd(10) + 'Contact');
+  console.log('  ' + '-'.repeat(80));
+
+  for (const e of entries) {
+    const urgLabel = urgencyIcon[e.urgency] || e.urgency;
+    const nextStr = e.nextFollowupDate || '-';
+    const contactStr = e.contacts.length > 0 ? e.contacts[0].email : '-';
+    console.log(
+      '  ' +
+      String(e.num).padEnd(5) +
+      e.company.substring(0, 15).padEnd(16) +
+      e.status.padEnd(12) +
+      String(e.daysSinceApplication).padEnd(6) +
+      String(e.followupCount).padEnd(5) +
+      nextStr.padEnd(13) +
+      urgLabel.padEnd(10) +
+      contactStr
+    );
+  }
+
+  console.log('');
+}
+
+// --- Run ---
+const result = analyze();
+
+if (summaryMode) {
+  printSummary(result);
+} else {
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (result.error) process.exit(1);

--- a/modes/followup.md
+++ b/modes/followup.md
@@ -1,0 +1,173 @@
+# Mode: followup -- Follow-up Cadence Tracker
+
+## Purpose
+
+Track follow-up cadence for active applications. Flag overdue follow-ups, extract contacts from notes, and generate tailored follow-up email/LinkedIn drafts using report context.
+
+## Inputs
+
+- `data/applications.md` — Application tracker
+- `data/follow-ups.md` — Follow-up history (created on first use)
+- `reports/` — Evaluation reports (for context in drafts)
+- `config/profile.yml` — User profile (name, identity)
+- `cv.md` — CV for proof points in drafts
+
+## Step 1 — Run Cadence Script
+
+Execute:
+
+```bash
+node followup-cadence.mjs
+```
+
+Parse the JSON output. It contains:
+
+| Key | Contents |
+|-----|----------|
+| `metadata` | Analysis date, total tracked, actionable count, overdue/urgent/cold/waiting counts |
+| `entries` | Per-application: company, role, status, days since application, follow-up count, urgency, next follow-up date, extracted contacts, report path |
+| `cadenceConfig` | Cadence rules (applied: 7 days, responded: 3 days, interview: 1 day) |
+
+If no actionable entries, tell the user:
+> "No active applications to follow up on. Apply to some roles first with `/career-ops` and come back when they're aging."
+
+## Step 2 — Display Dashboard
+
+Show a cadence dashboard sorted by urgency (urgent > overdue > waiting > cold):
+
+```
+Follow-up Cadence Dashboard — {date}
+{N} applications tracked, {N} actionable
+
+| # | Company | Role | Status | Days | Follow-ups | Next | Urgency | Contact |
+```
+
+Use visual indicators:
+- **URGENT** — respond within 24 hours (company replied)
+- **OVERDUE** — follow-up is past due
+- **waiting (X days)** — on track, follow-up scheduled
+- **COLD** — 2+ follow-ups sent, suggest closing
+
+## Step 3 — Generate Follow-up Drafts
+
+For each **overdue** or **urgent** entry only:
+
+1. Read the linked report (`reportPath` from JSON) for company context
+2. Read `cv.md` for proof points
+3. Read `config/profile.yml` for candidate name and identity
+
+### Email Follow-up Framework (first follow-up, followupCount == 0)
+
+Generate a 3-4 sentence email:
+
+1. **Sentence 1:** Reference the specific role + when you applied. Be specific — mention the company name and role title.
+2. **Sentence 2:** One concrete value-add from the report's Block B match or a proof point from cv.md. Quantify if possible.
+3. **Sentence 3:** Soft ask + availability. Offer a specific time window ("this week" or "next Tuesday").
+4. **Sentence 4 (optional):** Brief mention of a relevant recent project or achievement.
+
+**Rules:**
+- Professional but warm, NOT desperate
+- **NEVER** use "just checking in", "just following up", "touching base", or "circling back"
+- Lead with value, not with the ask
+- Reference something specific to THAT company (from report Block A)
+- Keep under 150 words
+- Include a subject line
+- Use the candidate's name from `config/profile.yml`
+
+**Example tone:**
+> Subject: Re: Senior PHP/Laravel Developer — IxDF
+>
+> Hi [contact name or "team"],
+>
+> I submitted my application for the Senior PHP/Laravel Developer role on April 7th. I wanted to share that my production Laravel app (Barbeiro.app — 120 models, 315 API endpoints, full test suite) closely mirrors the TDD-driven culture described in the posting.
+>
+> I'd love to discuss how my 15 years of PHP experience and hands-on AI tooling workflow could contribute to IxDF's platform. Would any time this week work for a brief conversation?
+>
+> Best,
+> [Name]
+
+### LinkedIn Follow-up (if no email contact found)
+
+Reuse the contacto framework: 3 sentences, 300 character max.
+- Hook specific to company → proof point → soft ask
+- Suggest the user run `/career-ops contacto {company}` to find the right person first
+
+### Second Follow-up (followupCount == 1)
+
+Shorter than first (2-3 sentences). Take a **new angle**:
+- Share a relevant insight, article, or project update
+- Don't repeat the first follow-up's content
+- Still reference the role specifically
+
+### Cold Application (followupCount >= 2)
+
+Do NOT generate another follow-up. Instead suggest:
+> "This application has had {N} follow-ups with no response. Consider:
+> - Updating status to `Discarded` if the role seems filled
+> - Trying a different contact via `/career-ops contacto`
+> - Keeping in `Applied` status but deprioritizing"
+
+## Step 4 — Present Drafts
+
+For each draft, show:
+
+```
+## Follow-up: {Company} — {Role} (#{num})
+
+**To:** {email or "No contact found — run `/career-ops contacto` first"}
+**Subject:** {subject line}
+**Days since application:** {N}
+**Follow-ups sent:** {N}
+**Channel:** Email / LinkedIn
+
+{draft text}
+```
+
+## Step 5 — Record Follow-ups
+
+After the user reviews and says they've sent a follow-up, record it:
+
+1. If `data/follow-ups.md` doesn't exist, create it:
+   ```markdown
+   # Follow-up History
+
+   | # | App# | Date | Company | Role | Channel | Contact | Notes |
+   |---|------|------|---------|------|---------|---------|-------|
+   ```
+
+2. Append a row with:
+   - `#` = next sequential number in the follow-ups table
+   - `App#` = application number from tracker
+   - `Date` = today's date
+   - `Company` = company name
+   - `Role` = role title
+   - `Channel` = Email / LinkedIn / Other
+   - `Contact` = who it was sent to
+   - `Notes` = brief note (e.g., "First follow-up, referenced Barbeiro.app")
+
+3. Optionally update the Notes column in `data/applications.md` with "Follow-up {N} sent {YYYY-MM-DD}"
+
+**IMPORTANT:** Only record follow-ups the user confirms they actually sent. Never record a draft as sent.
+
+## Step 6 — Summary
+
+After showing all drafts, summarize:
+
+> **Follow-up Dashboard** ({date})
+> - {N} applications being tracked
+> - {N} overdue — drafts generated above
+> - {N} urgent — respond today
+> - {N} waiting — next follow-up dates shown
+> - {N} cold — consider closing
+>
+> Review the drafts above and tell me which ones you've sent so I can record them.
+
+## Cadence Rules Reference
+
+| Status | First follow-up | Subsequent | Max attempts |
+|--------|----------------|------------|-------------|
+| Applied | 7 days after application | Every 7 days | 2 (then mark cold) |
+| Responded | 1 day (urgent reply) | Every 3 days | No limit |
+| Interview | 1 day after (thank-you) | Every 3 days | No limit |
+
+These defaults can be overridden via `node followup-cadence.mjs --applied-days N`.


### PR DESCRIPTION
## Summary

- Adds `/career-ops followup` mode that tracks follow-up cadence for active applications
- New `followup-cadence.mjs` script parses tracker + follow-up history, calculates days since application, extracts contacts from notes, determines urgency, outputs JSON
- Generates tailored follow-up email/LinkedIn drafts using report context
- Tracks follow-up history in `data/follow-ups.md` (created on first use)

## New files

- `followup-cadence.mjs` — Cadence calculator script (JSON output)
- `modes/followup.md` — Standalone mode instructions

## Modified files

- `SKILL.md` — Added `followup` routing, discovery menu entry, standalone mode
- `CLAUDE.md` — Added to skill modes, main files, OpenCode commands tables
- `DATA_CONTRACT.md` — Added `data/follow-ups.md` to user layer, `modes/followup.md` to system layer

## How it works

### Dashboard (`node followup-cadence.mjs --summary`)

```
======================================================================
  Follow-up Cadence Dashboard — 2026-05-20
  42 total applications, 8 actionable
======================================================================

  1 urgent | 3 overdue | 3 waiting | 1 cold

  #    Company         Status      Days  F/U  Next         Urgency   Contact
  --------------------------------------------------------------------------------
  31   Acme Corp       responded   0     0    2026-05-23   URGENT    recruiter@acme.com
  22   Globex Inc      applied     14    1    2026-05-20   OVERDUE   -
  18   Initech         applied     10    0    2026-05-17   OVERDUE   hr@initech.io
  25   Hooli           applied     9     0    2026-05-18   OVERDUE   -
  29   Pied Piper      applied     3     0    2026-05-26   waiting   richard@piedpiper.com
  30   Massive Dynamic applied     2     0    2026-05-27   waiting   -
  33   Stark Ind       interview   1     0    2026-05-21   waiting   pepper@stark.com
  15   Umbrella Corp   applied     21    2    -            COLD      -
```

### Cadence rules

| Status | First follow-up | Subsequent | Max |
|--------|----------------|------------|-----|
| Applied | 7 days | Every 7 days | 2 (then cold) |
| Responded | Reply within 24h | Every 3 days | No limit |
| Interview | 1 day (thank-you) | Every 3 days | No limit |

### Follow-up drafts

For overdue/urgent entries, the mode reads the evaluation report and CV to generate tailored drafts:

```
## Follow-up: Initech — Senior Backend Engineer (#18)

**To:** hr@initech.io
**Subject:** Re: Senior Backend Engineer — Initech
**Days since application:** 10
**Follow-ups sent:** 0

Hi team,

I applied for the Senior Backend Engineer role on May 10th and wanted to
share a quick update — I recently shipped a real-time notification system
handling 50K events/day on a stack very similar to yours (PHP 8.3, Laravel,
Redis). I'd welcome the chance to discuss how that experience maps to the
challenges your platform team is tackling. Would any time this week work
for a brief conversation?

Best,
Jane
```

### Contact extraction

Emails are auto-extracted from the tracker notes column:
- `"Applied via email to hr@initech.io"` → extracts `hr@initech.io`
- `"Emailed Richard at richard@piedpiper.com"` → extracts `richard@piedpiper.com` + name `Richard`
- No contact found → suggests running `/career-ops contacto` to find one

### Follow-up history tracking

After sending a follow-up, record it and the script tracks the cadence:

```markdown
# Follow-up History

| # | App# | Date | Company | Role | Channel | Contact | Notes |
|---|------|------|---------|------|---------|---------|-------|
| 1 | 18 | 2026-05-20 | Initech | Senior Backend Engineer | Email | hr@initech.io | First follow-up, referenced notification system |
| 2 | 22 | 2026-05-20 | Globex Inc | Staff Engineer | LinkedIn | CTO via LinkedIn | Second follow-up, shared article on distributed systems |
```

## Test plan

- [x] `node followup-cadence.mjs` outputs valid JSON with keys `metadata`, `entries`, `cadenceConfig`
- [x] `node followup-cadence.mjs --summary` prints readable dashboard
- [x] `node followup-cadence.mjs --overdue-only` filters to overdue/urgent only
- [x] `node followup-cadence.mjs --applied-days 1` overrides threshold, makes entries overdue
- [x] `node verify-pipeline.mjs` still passes (no regression)
- [x] Graceful handling when `data/follow-ups.md` doesn't exist
- [x] QA team (4 parallel agents) found 0 bugs, 5 non-blocking warnings
- [ ] `/career-ops followup` triggers mode and generates drafts
- [ ] `/career-ops` discovery menu shows new command