### PR TITLE
Add Nix flake devshell with Playwright support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+export DIRENV_WARN_TIMEOUT=2m
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
+fi
+dotenv
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ modes/_profile.md
 # Generated
 .resolved-prompt-*
 node_modules/
+bun.lock
 
 # OS
 .DS_Store

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,62 @@
+{
+  "nodes": {
+    "flakelight": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1775481670,
+        "narHash": "sha256-y/c2JCNmjeuxbSpfE4r2qN02dQX+tkfIZpwEfOlF64s=",
+        "owner": "nix-community",
+        "repo": "flakelight",
+        "rev": "0868c446b28e412ff2a685e93856658a43c30b1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flakelight",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flakelight": "flakelight",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "career-ops - AI job search pipeline";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flakelight.url = "github:nix-community/flakelight";
+  };
+
+  outputs =
+    { flakelight, nixpkgs, ... }:
+    flakelight ./. {
+
+      inputs.nixpkgs = nixpkgs;
+
+      devShell.packages =
+        pkgs: with pkgs; [
+
+          nodejs
+          bun
+
+          coreutils
+
+          playwright-driver.browsers
+
+        ];
+
+      devShell.env = pkgs: {
+        PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
+        PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
+      };
+
+    };
+
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,18 @@
       devShell.env = pkgs: {
         PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
         PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
       };
+
+      devShell.shellHook = pkgs: ''
+        # Pin npm playwright to match nixpkgs browser binaries
+        EXPECTED="${pkgs.playwright-driver.version}"
+        CURRENT=$(node -e "try{console.log(require('playwright-core/package.json').version)}catch{}" 2>/dev/null)
+        if [ "$CURRENT" != "$EXPECTED" ]; then
+          echo "Pinning playwright to $EXPECTED to match Nix-provided browsers..."
+          npm install --no-save "playwright@$EXPECTED" >/dev/null 2>&1
+        fi
+      '';
 
     };
 


### PR DESCRIPTION
## Summary
- Adds a Nix flake that provides a reproducible dev environment with `nodejs`, `bun`, `coreutils`, and `playwright-driver.browsers`
- Playwright browsers are provided via nixpkgs — no manual `npx playwright install` needed
- Includes `.envrc` for automatic environment activation via direnv
- Adds `bun.lock` to `.gitignore` (project uses npm)

## Details

The flake sets `PLAYWRIGHT_BROWSERS_PATH` and `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS` so Playwright works out of the box on NixOS and other Nix-managed systems where the standard browser download doesn't work.

## Test plan
- [ ] Run `nix develop` and verify `node`, `bun`, and `playwright` are available
- [ ] Run `node generate-pdf.mjs` to confirm Playwright can find its browsers
- [ ] Verify `direnv allow` activates the environment automatically