### PR TITLE
Fix 10 bugs: resource leaks, command injection, Unicode corruption, and more

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -25,7 +25,9 @@ const REPORTS_DIR = join(CAREER_OPS, 'reports');
 const args = process.argv.slice(2);
 const summaryMode = args.includes('--summary');
 const minThresholdIdx = args.indexOf('--min-threshold');
-const MIN_THRESHOLD = minThresholdIdx !== -1 ? parseInt(args[minThresholdIdx + 1]) || 5 : 5;
+const MIN_THRESHOLD = minThresholdIdx !== -1 && args[minThresholdIdx + 1] !== undefined
+  ? (Number.isNaN(parseInt(args[minThresholdIdx + 1])) ? 5 : parseInt(args[minThresholdIdx + 1]))
+  : 5;
 
 // --- Status normalization (mirrors verify-pipeline.mjs) ---
 const ALIASES = {

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -330,12 +330,21 @@ process_offer() {
 
   # Prepare system prompt with placeholders resolved
   local resolved_prompt="$BATCH_DIR/.resolved-prompt-${id}.md"
+  # Escape sed delimiter characters in variables to prevent substitution breakage
+  local esc_url esc_jd_file esc_report_num esc_date esc_id
+  esc_url="${url//\\/\\\\}"
+  esc_url="${esc_url//|/\\|}"
+  esc_jd_file="${jd_file//\\/\\\\}"
+  esc_jd_file="${esc_jd_file//|/\\|}"
+  esc_report_num="${report_num//|/\\|}"
+  esc_date="${date//|/\\|}"
+  esc_id="${id//|/\\|}"
   sed \
-    -e "s|{{URL}}|${url}|g" \
-    -e "s|{{JD_FILE}}|${jd_file}|g" \
-    -e "s|{{REPORT_NUM}}|${report_num}|g" \
-    -e "s|{{DATE}}|${date}|g" \
-    -e "s|{{ID}}|${id}|g" \
+    -e "s|{{URL}}|${esc_url}|g" \
+    -e "s|{{JD_FILE}}|${esc_jd_file}|g" \
+    -e "s|{{REPORT_NUM}}|${esc_report_num}|g" \
+    -e "s|{{DATE}}|${esc_date}|g" \
+    -e "s|{{ID}}|${esc_id}|g" \
     "$PROMPT_FILE" > "$resolved_prompt"
 
   # Launch claude -p worker (uses default model from Claude Max subscription)
@@ -453,6 +462,9 @@ main() {
   while IFS=$'\t' read -r id url source notes; do
     [[ "$id" == "id" ]] && continue  # skip header
     [[ -z "$id" || -z "$url" ]] && continue
+
+    # Guard against non-numeric id values
+    [[ "$id" =~ ^[0-9]+$ ]] || continue
 
     # Skip if before start-from
     if (( id < START_FROM )); then

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -269,15 +269,32 @@ func (m PipelineModel) handleKey(msg tea.KeyMsg) (PipelineModel, tea.Cmd) {
 		}
 
 	case "pgdown", "ctrl+d":
-		m.scrollOffset += m.height / 2
-		return m, nil
+		if len(m.filtered) > 0 {
+			halfPage := m.height / 2
+			if halfPage < 1 {
+				halfPage = 1
+			}
+			m.cursor += halfPage
+			if m.cursor >= len(m.filtered) {
+				m.cursor = len(m.filtered) - 1
+			}
+			m.adjustScroll()
+			return m, m.loadCurrentReport()
+		}
 
 	case "pgup", "ctrl+u":
-		m.scrollOffset -= m.height / 2
-		if m.scrollOffset < 0 {
-			m.scrollOffset = 0
+		if len(m.filtered) > 0 {
+			halfPage := m.height / 2
+			if halfPage < 1 {
+				halfPage = 1
+			}
+			m.cursor -= halfPage
+			if m.cursor < 0 {
+				m.cursor = 0
+			}
+			m.adjustScroll()
+			return m, m.loadCurrentReport()
 		}
-		return m, nil
 	}
 
 	return m, nil
@@ -648,17 +665,11 @@ func (m PipelineModel) renderAppLine(app model.CareerApplication, selected bool)
 	score := scoreStyle.Render(fmt.Sprintf("%.1f", app.Score))
 
 	// Company (truncate)
-	company := app.Company
-	if len(company) > companyW {
-		company = company[:companyW-3] + "..."
-	}
+	company := truncateRunes(app.Company, companyW)
 	companyStyle := lipgloss.NewStyle().Foreground(m.theme.Text).Width(companyW)
 
 	// Role (truncate)
-	role := app.Role
-	if len(role) > roleW {
-		role = role[:roleW-3] + "..."
-	}
+	role := truncateRunes(app.Role, roleW)
 	roleStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext).Width(roleW)
 
 	// Status with color -- fixed column
@@ -670,10 +681,7 @@ func (m PipelineModel) renderAppLine(app model.CareerApplication, selected bool)
 	// Comp from report cache -- fixed column
 	compText := ""
 	if summary, ok := m.reportCache[app.ReportPath]; ok && summary.comp != "" {
-		comp := summary.comp
-		if len(comp) > compW-1 {
-			comp = comp[:compW-4] + "..."
-		}
+		comp := truncateRunes(summary.comp, compW-1)
 		compStyle := lipgloss.NewStyle().Foreground(m.theme.Yellow)
 		compText = compStyle.Render(comp)
 	}
@@ -731,10 +739,7 @@ func (m PipelineModel) renderPreview() string {
 		}
 	} else if app.Notes != "" {
 		// Fallback: show notes
-		notes := app.Notes
-		if len(notes) > m.width-10 {
-			notes = notes[:m.width-13] + "..."
-		}
+		notes := truncateRunes(app.Notes, m.width-10)
 		lines = append(lines, padStyle.Render(dimStyle.Render(notes)))
 	} else {
 		lines = append(lines, padStyle.Render(dimStyle.Render("Loading preview...")))
@@ -845,6 +850,18 @@ func (m PipelineModel) countByNormStatus(status string) int {
 		}
 	}
 	return count
+}
+
+// truncateRunes truncates a string to at most maxRunes runes, appending "..." if truncated.
+func truncateRunes(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	if maxRunes <= 3 {
+		return string(runes[:maxRunes])
+	}
+	return string(runes[:maxRunes-3]) + "..."
 }
 
 func statusLabel(norm string) string {

--- a/dashboard/main.go
+++ b/dashboard/main.go
@@ -54,7 +54,8 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case screens.PipelineUpdateStatusMsg:
 		err := data.UpdateApplicationStatus(msg.CareerOpsPath, msg.App, msg.NewStatus)
 		if err != nil {
-			return m, nil
+			// Log the error but still reload data to keep UI consistent
+			fmt.Fprintf(os.Stderr, "WARN: status update failed: %v\n", err)
 		}
 		apps := data.ParseApplications(m.careerOpsPath)
 		metrics := data.ComputeMetrics(apps)
@@ -94,7 +95,7 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			default:
 				cmd = exec.Command("xdg-open", url)
 			}
-			_ = cmd.Start()
+			_ = cmd.Run()
 			return nil
 		}
 

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -114,10 +114,10 @@ async function generatePDF() {
     /url\(['"]?\.\/fonts\//g,
     `url('file://${fontsDir}/`
   );
-  // Close any unclosed quotes from the replacement
+  // Close any unclosed quotes from the replacement (handles all font formats)
   html = html.replace(
-    /file:\/\/([^'")]+)\.woff2['"]\)/g,
-    `file://$1.woff2')`
+    /file:\/\/([^'")]+)\.(woff2?|ttf|otf)['"]?\)/g,
+    `file://$1.$2')`
   );
 
   // Normalize text for ATS compatibility (issue #1)
@@ -130,45 +130,47 @@ async function generatePDF() {
   }
 
   const browser = await chromium.launch({ headless: true });
-  const page = await browser.newPage();
+  try {
+    const page = await browser.newPage();
 
-  // Set content with file base URL for any relative resources
-  await page.setContent(html, {
-    waitUntil: 'networkidle',
-    baseURL: `file://${dirname(inputPath)}/`,
-  });
+    // Set content with file base URL for any relative resources
+    await page.setContent(html, {
+      waitUntil: 'networkidle',
+      baseURL: `file://${dirname(inputPath)}/`,
+    });
 
-  // Wait for fonts to load
-  await page.evaluate(() => document.fonts.ready);
+    // Wait for fonts to load
+    await page.evaluate(() => document.fonts.ready);
 
-  // Generate PDF
-  const pdfBuffer = await page.pdf({
-    format: format,
-    printBackground: true,
-    margin: {
-      top: '0.6in',
-      right: '0.6in',
-      bottom: '0.6in',
-      left: '0.6in',
-    },
-    preferCSSPageSize: false,
-  });
+    // Generate PDF
+    const pdfBuffer = await page.pdf({
+      format: format,
+      printBackground: true,
+      margin: {
+        top: '0.6in',
+        right: '0.6in',
+        bottom: '0.6in',
+        left: '0.6in',
+      },
+      preferCSSPageSize: false,
+    });
 
-  // Write PDF
-  const { writeFile } = await import('fs/promises');
-  await writeFile(outputPath, pdfBuffer);
+    // Write PDF
+    const { writeFile } = await import('fs/promises');
+    await writeFile(outputPath, pdfBuffer);
 
-  // Count pages (approximate from PDF structure)
-  const pdfString = pdfBuffer.toString('latin1');
-  const pageCount = (pdfString.match(/\/Type\s*\/Page[^s]/g) || []).length;
+    // Count pages (approximate from PDF structure)
+    const pdfString = pdfBuffer.toString('latin1');
+    const pageCount = (pdfString.match(/\/Type\s*\/Page[^s]/g) || []).length;
 
-  await browser.close();
+    console.log(`✅ PDF generated: ${outputPath}`);
+    console.log(`📊 Pages: ${pageCount}`);
+    console.log(`📦 Size: ${(pdfBuffer.length / 1024).toFixed(1)} KB`);
 
-  console.log(`✅ PDF generated: ${outputPath}`);
-  console.log(`📊 Pages: ${pageCount}`);
-  console.log(`📦 Size: ${(pdfBuffer.length / 1024).toFixed(1)} KB`);
-
-  return { outputPath, pageCount, size: pdfBuffer.length };
+    return { outputPath, pageCount, size: pdfBuffer.length };
+  } finally {
+    await browser.close();
+  }
 }
 
 generatePDF().catch((err) => {

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -17,6 +17,7 @@
 import { readFileSync, writeFileSync, readdirSync, mkdirSync, renameSync, existsSync } from 'fs';
 import { join, basename, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { execFileSync } from 'child_process';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original)
@@ -322,9 +323,8 @@ if (DRY_RUN) console.log('(dry-run — no changes written)');
 // Optional verify
 if (VERIFY && !DRY_RUN) {
   console.log('\n--- Running verification ---');
-  const { execSync } = await import('child_process');
   try {
-    execSync(`node ${join(CAREER_OPS, 'verify-pipeline.mjs')}`, { stdio: 'inherit' });
+    execFileSync('node', [join(CAREER_OPS, 'verify-pipeline.mjs')], { stdio: 'inherit' });
   } catch (e) {
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

Found and fixed 10 bugs across the JavaScript, Go, and Bash components during a thorough code review:

### High Severity
- **generate-pdf.mjs**: Browser process leaked when `writeFile` throws — wrapped in `try/finally` to ensure `browser.close()` always runs
- **generate-pdf.mjs**: Font URL regex only handled `.woff2`, breaking `.woff`/`.ttf`/`.otf` fonts in PDFs
- **merge-tracker.mjs**: Command injection via `execSync` with string-interpolated path — switched to `execFileSync` with array args
- **dashboard/main.go**: Zombie process leak — `cmd.Start()` without `Wait()` spawned unreaped child processes on every URL open

### Medium Severity
- **dashboard/pipeline.go**: `pgdown`/`pgup` only moved scroll offset without updating cursor, creating a desynchronized UI state
- **dashboard/pipeline.go**: Company/role/notes truncation used `len()` (byte count), corrupting Unicode characters like accented letters common in Spanish company names
- **dashboard/main.go**: Status update failures were silently discarded — now logs a warning and still reloads data
- **batch-runner.sh**: `sed` substitution broke on URLs containing `|` (common in query parameters)

### Low Severity
- **analyze-patterns.mjs**: `--min-threshold 0` evaluated to `5` because `0 || 5` is falsy — now uses proper NaN check
- **batch-runner.sh**: Non-numeric `id` values in TSV caused arithmetic crash under `set -e` — added numeric guard

## Test plan
- [ ] `node generate-pdf.mjs` still generates valid PDFs with all font formats
- [ ] `node merge-tracker.mjs --verify` runs without shell injection issues
- [ ] `node analyze-patterns.mjs --min-threshold 0` correctly uses threshold of 0
- [ ] Dashboard TUI: pgdown/pgup moves cursor and scroll together
- [ ] Dashboard TUI: company names with accented chars (e.g., "Société Générale") display without corruption
- [ ] Dashboard: opening a URL no longer leaves zombie `open`/`xdg-open` processes
- [ ] Dashboard: failed status update shows warning in stderr
- [ ] `batch-runner.sh` handles URLs with `|` characters in query params
- [ ] `batch-runner.sh` gracefully skips rows with non-numeric IDs in TSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)