### PR TITLE
feat: cover letter generation

### DIFF
--- a/.claude/skills/career-ops/SKILL.md
+++ b/.claude/skills/career-ops/SKILL.md
@@ -3,7 +3,7 @@ name: career-ops
 description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
 user_invocable: true
 args: mode
-argument-hint: "[scan | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
+argument-hint: "[scan | deep | pdf | cover-letter | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
 ---
 
 # career-ops -- Router
@@ -29,6 +29,7 @@ Determine the mode from `{{mode}}`:
 | `scan` | `scan` |
 | `batch` | `batch` |
 | `patterns` | `patterns` |
+| `cover-letter` / `cover` / `cl` | `cover-letter` |
 
 **Auto-pipeline detection:** If `{{mode}}` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
 
@@ -58,6 +59,7 @@ Available commands:
   /career-ops scan      → Scan portals and discover new offers
   /career-ops batch     → Batch processing with parallel workers
   /career-ops patterns  → Analyze rejection patterns and improve targeting
+  /career-ops cover-letter → Generate single-page cover letter PDF (matches CV design)
 
 Inbox: add URLs to data/pipeline.md → /career-ops pipeline
 Or paste a JD directly to run the full pipeline.
@@ -72,7 +74,7 @@ After determining the mode, load the necessary files before executing:
 ### Modes that require `_shared.md` + their mode file:
 Read `modes/_shared.md` + `modes/{mode}.md`
 
-Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `cover-letter`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
 
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ jds/*
 !jds/.gitkeep
 
 # User config and customization (never auto-updated)
+cv.md
+article-digest.md
 config/profile.yml
 portals.yml
 modes/_profile.md

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Built by someone who used it to evaluate 740+ job offers, generate 100+ tailored
 | **6-Block Evaluation** | Role summary, CV match, level strategy, comp research, personalization, interview prep (STAR+R) |
 | **Interview Story Bank** | Accumulates STAR+Reflection stories across evaluations -- 5-10 master stories that answer any behavioral question |
 | **Negotiation Scripts** | Salary negotiation frameworks, geographic discount pushback, competing offer leverage |
+| **Cover Letter PDF** | Single-page cover letter PDF that matches CV design, auto-generated for offers scoring ≥ 4.5 (or on-demand via `/career-ops cover-letter`) |
 | **ATS PDF Generation** | Keyword-injected CVs with Space Grotesk + DM Sans design |
 | **Portal Scanner** | 45+ companies pre-configured (Anthropic, OpenAI, ElevenLabs, Retool, n8n...) + custom queries across Ashby, Greenhouse, Lever, Wellfound |
 | **Batch Processing** | Parallel evaluation with `claude -p` workers |
@@ -116,6 +117,7 @@ Career-ops is a single slash command with multiple modes:
 /career-ops {paste a JD}   → Full auto-pipeline (evaluate + PDF + tracker)
 /career-ops scan           → Scan portals for new offers
 /career-ops pdf            → Generate ATS-optimized CV
+/career-ops cover-letter   → Generate single-page cover letter PDF
 /career-ops batch          → Batch evaluate multiple offers
 /career-ops tracker        → View application status
 /career-ops apply          → Fill application forms with AI

--- a/examples/sample-cover-letter.json
+++ b/examples/sample-cover-letter.json
@@ -1,0 +1,25 @@
+{
+  "lang": "en",
+  "page_width": "8.5in",
+  "format": "letter",
+  "candidate": {
+    "name": "Jane Doe",
+    "email": "jane@example.com",
+    "linkedin_url": "https://www.linkedin.com/in/jane-doe-12345",
+    "linkedin_display": "linkedin.com/in/jane-doe-12345",
+    "location": "San Francisco, CA"
+  },
+  "letter": {
+    "company": "Acme AI",
+    "role": "Full-Stack AI Engineer",
+    "date": "2026-04-09",
+    "salutation": "Dear Acme AI hiring team,",
+    "closing": "Best,",
+    "paragraphs": [
+      "I've spent the past year building production AI agent systems on a stack that looks a lot like yours — TypeScript, Postgres + pgvector, BullMQ, and Vercel AI SDK. Your role is where I want to apply that experience next.",
+      "Your job description mentions building reliable retrieval pipelines with hybrid dense and sparse search. That maps directly to RetrievalLab, the open-source retrieval platform I built: a configurable multi-stage RAG stack with Reciprocal Rank Fusion and metadata-aware filtering, sustaining sub-300ms retrieval latency over a 50k-document corpus. Code at github.com/jane-doe/retrieval-lab.",
+      "What makes me a fit beyond the stack match is the engineering judgment I bring around AI tool orchestration: I designed a broker-agnostic execution layer with a three-phase stage/commit/execute lifecycle backed by atomic Redis Lua transitions, exactly the kind of reliability work your platform team is hiring for.",
+      "I'm being intentional about where I apply. Acme AI is on the short list because of the public work your team has shipped on retrieval observability. Happy to walk through the RetrievalLab architecture in a call."
+    ]
+  }
+}

--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -21,7 +21,7 @@
  */
 
 import { readFile, writeFile } from 'fs/promises';
-import { resolve, dirname, basename } from 'path';
+import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
 
@@ -96,6 +96,32 @@ function selectJdQuotesAndProofs(jdText, proofPoints) {
 }
 
 /**
+ * Validate that a parsed content object has all required fields.
+ * Throws clear, specific errors instead of the cryptic TypeErrors that
+ * surface when an agent produces malformed JSON.
+ */
+function validateContent(content) {
+  if (!content.candidate) {
+    throw new Error('content.candidate is required (see examples/sample-cover-letter.json for the expected shape)');
+  }
+  if (!content.letter) {
+    throw new Error('content.letter is required (see examples/sample-cover-letter.json for the expected shape)');
+  }
+  const requiredCandidateFields = ['name', 'email', 'linkedin_url', 'linkedin_display', 'location'];
+  for (const k of requiredCandidateFields) {
+    if (!content.candidate[k]) {
+      throw new Error(`content.candidate.${k} is required`);
+    }
+  }
+  const requiredLetterFields = ['company', 'role', 'date', 'salutation', 'closing', 'paragraphs'];
+  for (const k of requiredLetterFields) {
+    if (content.letter[k] === undefined) {
+      throw new Error(`content.letter.${k} is required`);
+    }
+  }
+}
+
+/**
  * Substitute {{PLACEHOLDER}} tokens in the template with values from content.
  * Mirrors the convention in modes/pdf.md (placeholder table).
  */
@@ -105,7 +131,7 @@ function fillTemplate(template, content) {
 
   const replacements = {
     LANG: content.lang || 'en',
-    PAGE_WIDTH: content.page_width || '8.5in',
+    PAGE_WIDTH: content.page_width,
     NAME: escapeHtml(c.name),
     EMAIL: escapeHtml(c.email),
     LINKEDIN_URL: escapeHtml(c.linkedin_url),
@@ -135,7 +161,10 @@ function fillTemplate(template, content) {
 
 async function main() {
   const args = process.argv.slice(2);
-  let inputJson, outputPdf, format = 'letter';
+  let inputJson, outputPdf;
+  // Default to 'letter' (not 'a4' like generate-pdf.mjs) because US cover letters
+  // almost always target letter-size paper. Override with --format=a4 for EU/world.
+  let format = 'letter';
 
   for (const arg of args) {
     if (arg.startsWith('--format=')) {
@@ -161,6 +190,7 @@ async function main() {
 
   // Read content + template
   const content = JSON.parse(await readFile(inputJson, 'utf-8'));
+  validateContent(content);
   const templatePath = resolve(__dirname, 'templates/cover-letter-template.html');
   const template = await readFile(templatePath, 'utf-8');
 
@@ -183,6 +213,11 @@ async function main() {
   const result = spawnSync('node', [renderer, tmpHtml, outputPdf, `--format=${format}`], {
     stdio: 'inherit',
   });
+
+  if (result.error) {
+    console.error(`❌ Failed to spawn generate-pdf.mjs: ${result.error.message}`);
+    process.exit(1);
+  }
 
   if (result.status !== 0) {
     console.error(`❌ generate-pdf.mjs exited with status ${result.status}`);

--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+/**
+ * generate-cover-letter.mjs — Cover letter content JSON → HTML → PDF
+ *
+ * Thin composition layer over generate-pdf.mjs. Reads a JSON content file
+ * (produced by the agent following modes/cover-letter.md), substitutes it
+ * into templates/cover-letter-template.html, then shells out to the existing
+ * generate-pdf.mjs renderer for ATS normalization and Playwright PDF output.
+ *
+ * Usage:
+ *   node generate-cover-letter.mjs <content.json> <output.pdf> [--format=letter|a4]
+ *
+ * The JSON shape is documented in examples/sample-cover-letter.json.
+ *
+ * Why this script exists:
+ *   - The cover letter mode (modes/cover-letter.md) tells the agent WHAT to write.
+ *   - This script handles the deterministic plumbing (template fill + invoke renderer)
+ *     so the agent does not have to deal with file I/O or HTML escaping.
+ *   - generate-pdf.mjs is reused unchanged — open/closed principle.
+ */
+
+import { readFile, writeFile } from 'fs/promises';
+import { resolve, dirname, basename } from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * HTML-escape a string so it is safe to inject into the template body.
+ * We only escape the four characters that matter inside <p> elements;
+ * generate-pdf.mjs handles Unicode normalization separately.
+ */
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Render the 4 paragraphs as <p> elements.
+ * Each paragraph becomes one <p>...</p>; nothing else is wrapped.
+ */
+function paragraphsToHtml(paragraphs) {
+  if (!Array.isArray(paragraphs) || paragraphs.length === 0) {
+    throw new Error('content.letter.paragraphs must be a non-empty array');
+  }
+  if (paragraphs.length > 5) {
+    throw new Error(`Cover letter has ${paragraphs.length} paragraphs; max is 5 for single-page constraint`);
+  }
+  return paragraphs.map(p => `<p>${escapeHtml(p)}</p>`).join('\n    ');
+}
+
+/**
+ * ★ USER CONTRIBUTION POINT — Learning Mode TODO
+ *
+ * Select 1-3 quotes from the JD text and pair each with the strongest
+ * matching proof point from profile.yml. This function defines the
+ * "personality" of the cover letter — what the agent emphasizes.
+ *
+ * The function is OPTIONAL — the script works without it. The agent in
+ * modes/cover-letter.md does the actual prose generation. This function
+ * is here as a deterministic helper if you (the user) want to encode
+ * a specific selection strategy that overrides agent improvisation.
+ *
+ * Decisions you must make if you implement it:
+ *   1. Which JD sentences are worth quoting?
+ *      - longest responsibility bullet?
+ *      - sentences containing archetype keywords?
+ *      - sentences marked "required" or "must have"?
+ *   2. How to score proof point match?
+ *      - keyword overlap count?
+ *      - hardcoded preference order?
+ *      - delegated to LLM?
+ *   3. How many quotes is right?
+ *      - 1 strong vs 3 medium?
+ *      - adaptive based on JD length?
+ *
+ * @function selectJdQuotesAndProofs
+ * @param {string} jdText - Full job description text
+ * @param {Array<{name: string, url: string, hero_metric: string}>} proofPoints - From profile.yml
+ * @returns {Array<{quote: string, proof: object, why: string}>}
+ *
+ * Default implementation: returns empty array (script falls back to using
+ * paragraphs as-is from the JSON). The agent calling this script should
+ * have already incorporated quote selection during prose generation.
+ */
+// eslint-disable-next-line no-unused-vars
+function selectJdQuotesAndProofs(jdText, proofPoints) {
+  // TODO (user): implement your quote-selection strategy here.
+  // See JSDoc above for the design questions to answer.
+  return [];
+}
+
+/**
+ * Substitute {{PLACEHOLDER}} tokens in the template with values from content.
+ * Mirrors the convention in modes/pdf.md (placeholder table).
+ */
+function fillTemplate(template, content) {
+  const c = content.candidate;
+  const l = content.letter;
+
+  const replacements = {
+    LANG: content.lang || 'en',
+    PAGE_WIDTH: content.page_width || '8.5in',
+    NAME: escapeHtml(c.name),
+    EMAIL: escapeHtml(c.email),
+    LINKEDIN_URL: escapeHtml(c.linkedin_url),
+    LINKEDIN_DISPLAY: escapeHtml(c.linkedin_display),
+    LOCATION: escapeHtml(c.location),
+    COMPANY: escapeHtml(l.company),
+    ROLE: escapeHtml(l.role),
+    DATE: escapeHtml(l.date),
+    SALUTATION: escapeHtml(l.salutation),
+    CLOSING: escapeHtml(l.closing),
+    PARAGRAPHS_HTML: paragraphsToHtml(l.paragraphs),
+  };
+
+  let out = template;
+  for (const [key, value] of Object.entries(replacements)) {
+    out = out.split(`{{${key}}}`).join(value);
+  }
+
+  // Sanity check: any unreplaced placeholders are a bug
+  const leftover = out.match(/\{\{[A-Z_]+\}\}/g);
+  if (leftover) {
+    throw new Error(`Unreplaced placeholders in template: ${leftover.join(', ')}`);
+  }
+
+  return out;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let inputJson, outputPdf, format = 'letter';
+
+  for (const arg of args) {
+    if (arg.startsWith('--format=')) {
+      format = arg.split('=')[1].toLowerCase();
+    } else if (!inputJson) {
+      inputJson = arg;
+    } else if (!outputPdf) {
+      outputPdf = arg;
+    }
+  }
+
+  if (!inputJson || !outputPdf) {
+    console.error('Usage: node generate-cover-letter.mjs <content.json> <output.pdf> [--format=letter|a4]');
+    process.exit(1);
+  }
+
+  inputJson = resolve(inputJson);
+  outputPdf = resolve(outputPdf);
+
+  console.log(`📄 Content: ${inputJson}`);
+  console.log(`📁 Output:  ${outputPdf}`);
+  console.log(`📏 Format:  ${format.toUpperCase()}`);
+
+  // Read content + template
+  const content = JSON.parse(await readFile(inputJson, 'utf-8'));
+  const templatePath = resolve(__dirname, 'templates/cover-letter-template.html');
+  const template = await readFile(templatePath, 'utf-8');
+
+  // Override page_width based on format flag if not set in JSON
+  if (!content.page_width) {
+    content.page_width = format === 'a4' ? '210mm' : '8.5in';
+  }
+
+  // Fill template
+  const filled = fillTemplate(template, content);
+
+  // Write filled HTML to /tmp
+  const slug = (content.letter.company || 'unknown').toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  const tmpHtml = `/tmp/cover-letter-${slug}.html`;
+  await writeFile(tmpHtml, filled);
+  console.log(`📝 Filled HTML: ${tmpHtml}`);
+
+  // Shell out to generate-pdf.mjs (reuse, do not reinvent)
+  const renderer = resolve(__dirname, 'generate-pdf.mjs');
+  const result = spawnSync('node', [renderer, tmpHtml, outputPdf, `--format=${format}`], {
+    stdio: 'inherit',
+  });
+
+  if (result.status !== 0) {
+    console.error(`❌ generate-pdf.mjs exited with status ${result.status}`);
+    process.exit(result.status || 1);
+  }
+
+  console.log(`✅ Cover letter ready: ${outputPdf}`);
+}
+
+main().catch((err) => {
+  console.error('❌ Cover letter generation failed:', err.message);
+  process.exit(1);
+});

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -61,6 +61,21 @@ Si el score final es >= 4.5, generar borrador de respuestas para el formulario d
 
 **Idioma**: Siempre en el idioma del JD (EN default). Aplicar `/tech-translate`.
 
+## Paso 4b — Generate Cover Letter (solo si score >= 4.5)
+
+Si el score final es >= 4.5, generar también un cover letter PDF de 1 página.
+
+**Workflow:**
+1. Cargar `modes/cover-letter.md` (ya con `_shared.md` cargado)
+2. Seguir el workflow definido ahí (LOAD → DETECT → SELECT → MAP → COMPOSE → BUILD JSON → RUN SCRIPT → APPEND → VERIFY)
+3. Output: `output/cover-letter-{candidate-slug}-{company-slug}-{YYYY-MM-DD}.pdf`
+4. Append `## H) Cover Letter` section to the report .md (path + plain-text fallback + JD quotes used)
+5. Si la generación falla, continuar con Paso 5 y marcar `cover_letter: pending` en las notas del tracker
+
+**Cuándo NO generar (override del trigger ≥4.5):**
+- JD dice explícitamente "no cover letter accepted"
+- Score >= 4.5 pero el formulario no tiene campo de cover letter Y tampoco un campo de free-text donde pegarlo
+
 ## Paso 5 — Actualizar Tracker
 Registrar en `data/applications.md` con todas las columnas incluyendo Report y PDF en ✅.
 

--- a/modes/cover-letter.md
+++ b/modes/cover-letter.md
@@ -1,0 +1,124 @@
+# Modo: cover-letter — Single-Page Cover Letter PDF
+
+When the user runs `/career-ops cover-letter` (or auto-pipeline triggers
+this at score ≥ 4.5), produce a one-page cover letter PDF that mirrors
+the CV's visual identity and uses the "I'm choosing you" tone defined
+in `modes/auto-pipeline.md`.
+
+This mode REQUIRES `_shared.md` to be loaded first.
+
+## Inputs Required
+
+| Source | Used for |
+|--------|----------|
+| JD text or URL (from user or report) | Quote selection, archetype detection, tone calibration |
+| `cv.md` | Real proof points, real metrics, real project names |
+| `config/profile.yml` | Candidate name, email, LinkedIn, location, proof_points |
+| `modes/_profile.md` | Archetype-specific framing, exit narrative |
+| `article-digest.md` (if exists) | Detailed proof point metrics (overrides cv.md) |
+| Most recent matching report in `reports/` (if exists) | Section B match table, archetype already detected |
+
+## Tone Rules (from auto-pipeline.md lines 44-60)
+
+**Position: "I'm choosing you."** The candidate has options and is choosing this company for concrete reasons.
+
+- **Confident, not arrogant**
+- **Selective, not haughty**
+- **Specific and concrete** — always reference something REAL from JD AND something REAL from CV
+- **Direct, no fluff** — see `_shared.md` lines 113-121 for the cliché ban list (do NOT use those words)
+- **The hook is the proof, not the claim** — "I built X that does Y" beats "I'm great at X"
+
+## Structure (4 Paragraphs, ~250-350 words total, max 1 page)
+
+| # | Paragraph | What it does |
+|---|-----------|--------------|
+| 1 | **Hook + position** | One sentence on what you've been building (real, specific, recent), one sentence positioning this role as the next step. Reference the stack or domain of the JD. |
+| 2 | **JD quote → proof point** | Quote 1-2 sentences from the JD verbatim. Map each quote to a specific project/metric from `cv.md`. Include a project link (`github.com/...` or `proof_points[].url`). |
+| 3 | **Why this fit beyond stack match** | One paragraph on the engineering judgment / archetype-specific value the candidate brings. Use the archetype framing from `modes/_profile.md`. |
+| 4 | **Selective close + soft CTA** | Mention something concrete about the company (their public work, product, blog, GitHub). Soft call-to-action: "Happy to walk through X in a call." NO "I would love the opportunity to..." |
+
+**Word budget:** 60-90 words per paragraph. Total under 350. The template's `max-height: 9.5in` + `overflow: hidden` will silently truncate overflow — verify the rendered PDF reports `Pages: 1`.
+
+## Workflow
+
+```
+1. LOAD CONTEXT  → cv.md, profile.yml, _profile.md, JD, matching report (if any)
+2. DETECT        → archetype from JD (per _shared.md)
+3. SELECT        → quote 1-2 JD sentences worth referencing
+4. MAP           → pair each quote to a real proof point from cv.md/profile.yml
+5. COMPOSE       → 4 paragraphs following the structure table above
+6. BUILD JSON    → write content JSON to /tmp/cover-letter-{slug}.json
+7. RUN SCRIPT    → node generate-cover-letter.mjs {json} output/cover-letter-{slug}-{date}.pdf
+8. APPEND        → "## H) Cover Letter" section to the report .md
+9. VERIFY        → confirm PDF reports "Pages: 1" — if not, shorten paragraphs and re-run
+```
+
+## Content JSON Shape
+
+The agent must produce a JSON file matching `examples/sample-cover-letter.json`:
+
+```json
+{
+  "lang": "en",
+  "format": "letter",
+  "candidate": {
+    "name": "...from profile.yml",
+    "email": "...from profile.yml",
+    "linkedin_url": "https://linkedin.com/in/...",
+    "linkedin_display": "linkedin.com/in/...",
+    "location": "...from profile.yml"
+  },
+  "letter": {
+    "company": "Detected from JD",
+    "role": "Detected from JD",
+    "date": "YYYY-MM-DD (today)",
+    "salutation": "Dear {Company} hiring team,",
+    "closing": "Best,",
+    "paragraphs": [
+      "Paragraph 1 (hook + position)...",
+      "Paragraph 2 (JD quote → proof)...",
+      "Paragraph 3 (engineering judgment)...",
+      "Paragraph 4 (selective close + soft CTA)..."
+    ]
+  }
+}
+```
+
+**Format selection rule (same as `pdf.md`):**
+- US/Canada companies → `"format": "letter"`, `"page_width": "8.5in"`
+- Rest of world → `"format": "a4"`, `"page_width": "210mm"`
+
+**Language rule:** Same language as the JD (EN default). For German JDs, use `modes/de/` translations and salutation "Sehr geehrtes Team von {Company},".
+
+## Output Path
+
+Save the PDF to:
+```
+output/cover-letter-{candidate-slug}-{company-slug}-{YYYY-MM-DD}.pdf
+```
+
+Example: `output/cover-letter-jane-doe-acme-ai-2026-04-09.pdf`
+
+## Post-Generation
+
+1. **Append to report .md** — add a `## H) Cover Letter` section with:
+   - Path to the generated PDF
+   - Plain-text version of the 4 paragraphs (so the user can copy-paste into a textarea field if the form does not accept PDF upload)
+   - List of JD quotes used
+2. **Update tracker note** — add `cover_letter:✅` to the Notes column of the corresponding `applications.md` row (only if the row already exists; use Edit, not Write).
+3. **Report to user** — show: PDF path, page count, paragraph word counts, list of JD quotes used.
+
+## When NOT to Generate
+
+- Score < 4.5 in auto-pipeline → skip silently. Cover letters waste energy on weak fits.
+- JD has no clear company name → ask user before proceeding (the salutation depends on it).
+- Form explicitly says "no cover letter accepted" → skip and note in report.
+
+## Failure Modes
+
+| Symptom | Fix |
+|---------|-----|
+| `Pages: 2` reported | Paragraphs too long. Cut to 60-70 words each and re-run. |
+| `Unreplaced placeholders` error | JSON missing a required field. Check shape against `examples/sample-cover-letter.json`. |
+| `generate-pdf.mjs` not found | Run from project root, not from `modes/`. |
+| Cliché word warning | The user's `_shared.md` flagged a banned word. Rewrite. |

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "update:check": "node update-system.mjs check",
     "update": "node update-system.mjs apply",
     "rollback": "node update-system.mjs rollback",
-    "liveness": "node check-liveness.mjs"
+    "liveness": "node check-liveness.mjs",
+    "cover-letter": "node generate-cover-letter.mjs"
   },
   "keywords": ["ai", "job-search", "claude-code", "career", "automation"],
   "author": "Santiago Fernández de Valderrama <hi@santifer.io> (https://santifer.io)",

--- a/templates/cover-letter-template.html
+++ b/templates/cover-letter-template.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="{{LANG}}">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{NAME}} — Cover Letter — {{COMPANY}}</title>
+<style>
+  @font-face {
+    font-family: 'Space Grotesk';
+    src: url('./fonts/space-grotesk-latin.woff2') format('woff2');
+    font-weight: 300 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'DM Sans';
+    src: url('./fonts/dm-sans-latin.woff2') format('woff2');
+    font-weight: 100 1000;
+    font-style: normal;
+    font-display: swap;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  html {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  body {
+    font-family: 'DM Sans', sans-serif;
+    font-size: 11.5px;
+    line-height: 1.65;
+    color: #1a1a2e;
+    background: #ffffff;
+  }
+
+  .page {
+    width: 100%;
+    max-width: {{PAGE_WIDTH}};
+    max-height: 9.5in;
+    overflow: hidden;
+    margin: 0 auto;
+    padding: 2px 0;
+  }
+
+  /* === HEADER (matches CV visual identity) === */
+  .header { margin-bottom: 22px; }
+
+  .header h1 {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 26px;
+    font-weight: 700;
+    color: #1a1a2e;
+    letter-spacing: -0.02em;
+    margin-bottom: 6px;
+    line-height: 1.1;
+  }
+
+  .header-gradient {
+    height: 2px;
+    background: linear-gradient(to right, hsl(187, 74%, 32%), hsl(270, 70%, 45%));
+    border-radius: 1px;
+    margin-bottom: 10px;
+  }
+
+  .contact-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 14px;
+    font-size: 10.5px;
+    line-height: 1.4;
+    color: #555;
+  }
+
+  .contact-row a { color: #555; text-decoration: none; }
+  .contact-row .separator { color: #ccc; }
+
+  /* === LETTER META === */
+  .letter-meta {
+    margin-bottom: 18px;
+    font-size: 11px;
+    color: #555;
+  }
+
+  .letter-meta .recipient {
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 2px;
+  }
+
+  /* === SALUTATION === */
+  .salutation {
+    font-size: 11.5px;
+    margin-bottom: 14px;
+    color: #1a1a2e;
+  }
+
+  /* === BODY PARAGRAPHS === */
+  .letter-body p {
+    margin-bottom: 12px;
+    text-align: left;
+    color: #2f2f2f;
+  }
+
+  .letter-body p:last-child { margin-bottom: 16px; }
+
+  /* === SIGN-OFF === */
+  .sign-off {
+    margin-top: 14px;
+  }
+
+  .sign-off .closing {
+    margin-bottom: 18px;
+    color: #1a1a2e;
+  }
+
+  .sign-off .signature-name {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    color: hsl(270, 70%, 45%);
+  }
+
+  /* Links should not break across lines */
+  a { white-space: nowrap; }
+
+  @media print {
+    body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    .page { padding: 0; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- HEADER -->
+  <div class="header">
+    <h1>{{NAME}}</h1>
+    <div class="header-gradient"></div>
+    <div class="contact-row">
+      <span>{{EMAIL}}</span>
+      <span class="separator">|</span>
+      <a href="{{LINKEDIN_URL}}">{{LINKEDIN_DISPLAY}}</a>
+      <span class="separator">|</span>
+      <span>{{LOCATION}}</span>
+    </div>
+  </div>
+
+  <!-- LETTER META -->
+  <div class="letter-meta">
+    <div class="recipient">{{COMPANY}}</div>
+    <div>{{ROLE}}</div>
+    <div>{{DATE}}</div>
+  </div>
+
+  <!-- SALUTATION -->
+  <div class="salutation">{{SALUTATION}}</div>
+
+  <!-- BODY (4 paragraphs from JSON) -->
+  <div class="letter-body">
+    {{PARAGRAPHS_HTML}}
+  </div>
+
+  <!-- SIGN-OFF -->
+  <div class="sign-off">
+    <div class="closing">{{CLOSING}}</div>
+    <div class="signature-name">{{NAME}}</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/templates/cover-letter-template.html
+++ b/templates/cover-letter-template.html
@@ -11,13 +11,34 @@
     font-weight: 300 700;
     font-style: normal;
     font-display: swap;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
   }
+
+  @font-face {
+    font-family: 'Space Grotesk';
+    src: url('./fonts/space-grotesk-latin-ext.woff2') format('woff2');
+    font-weight: 300 700;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  }
+
   @font-face {
     font-family: 'DM Sans';
     src: url('./fonts/dm-sans-latin.woff2') format('woff2');
     font-weight: 100 1000;
     font-style: normal;
     font-display: swap;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+
+  @font-face {
+    font-family: 'DM Sans';
+    src: url('./fonts/dm-sans-latin-ext.woff2') format('woff2');
+    font-weight: 100 1000;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
   }
 
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -35,6 +56,12 @@
     background: #ffffff;
   }
 
+  /* === PAGE — single-page hard limit ===
+     The max-height + overflow:hidden combo SILENTLY TRUNCATES content
+     that doesn't fit on one page. This is intentional: a cover letter
+     must be one page. The agent generating content (modes/cover-letter.md)
+     is responsible for keeping paragraphs within ~250-350 words total.
+     Task 9 end-to-end verification visually checks that nothing was cut. */
   .page {
     width: 100%;
     max-width: {{PAGE_WIDTH}};


### PR DESCRIPTION
## Summary

Adds a first-class cover letter generation feature that fulfills the
"**Cover letter:** If the form allows it, ALWAYS include one. Same visual
design as CV. JD quotes mapped to proof points. 1 page max." rule in
`modes/_shared.md` line 75 — previously a standalone policy statement
without an implementation path.

The feature is triggered two ways:
- **Automatically** from `auto-pipeline` when an evaluation scores >= 4.5
  (same threshold as Section G draft answers)
- **Explicitly** via `/career-ops cover-letter` for on-demand generation

Output is a single-page PDF that visually matches `cv-template.html`
(same gradient header, Space Grotesk + DM Sans fonts, cyan/purple
accents). Generation reuses the existing `generate-pdf.mjs` renderer
unchanged — the new script is a thin composition layer, not a
reimplementation.

## Architecture

```
Agent (modes/cover-letter.md)
  │ reads cv.md + profile.yml + _profile.md + JD
  │ composes 4 paragraphs using auto-pipeline.md "I'm choosing you" tone
  │ writes JSON → /tmp/cover-letter-{slug}.json
  ▼
generate-cover-letter.mjs
  │ fills templates/cover-letter-template.html with JSON values
  │ writes /tmp/cover-letter-{slug}.html
  │ spawnSync → generate-pdf.mjs (unchanged)
  ▼
output/cover-letter-{candidate-slug}-{company-slug}-{YYYY-MM-DD}.pdf
```

**Open/closed principle:** `generate-pdf.mjs` is not modified. The new
script composes over it, keeping the renderer generic.

## Letter Structure (4 paragraphs, <= 350 words)

| # | Paragraph | Purpose |
|---|-----------|---------|
| 1 | Hook + position | What you've been building, why this role is next |
| 2 | JD quote -> proof point | Verbatim JD quote mapped to a `cv.md` project |
| 3 | Engineering judgment | Archetype-specific value beyond stack match |
| 4 | Selective close + soft CTA | Specific company reference + "happy to walk through X" |

Follows the `auto-pipeline.md` "I'm choosing you" tone framework already
established for form answers — no duplication, the mode file references
`_shared.md` lines 113-121 for the cliché ban list and
`auto-pipeline.md` lines 44-60 for tone rules.

## What's Included

| Change | Files |
|--------|-------|
| **HTML template** | `templates/cover-letter-template.html` (new, 200 lines). Mirrors `cv-template.html`'s 4 `@font-face` blocks with `unicode-range` for latin + latin-ext coverage. Includes `max-height: 9.5in` + `overflow: hidden` safety net with documented contract. |
| **Node script** | `generate-cover-letter.mjs` (new, 233 lines). Reads JSON, fills template via `split().join()` global replacement, validates all required fields with clear errors, `spawnSync`s `generate-pdf.mjs`. Contains `selectJdQuotesAndProofs()` as a `// TODO (user)` stub so users can encode their own quote-selection strategy without touching the core flow. |
| **Sample fixture** | `examples/sample-cover-letter.json`. Generic "Jane Doe" / "RetrievalLab" placeholder content used as smoke test input and shape-by-example documentation. |
| **Agent instructions** | `modes/cover-letter.md` (new). Workflow, structure table, JSON shape, output path, format-selection rules (US/Canada -> letter, else a4), language rule (same as JD), failure modes. |
| **Routing** | `.claude/skills/career-ops/SKILL.md`. Adds `cover-letter` / `cover` / `cl` aliases to the routing table, discovery menu, `argument-hint` frontmatter, and context-loading `_shared.md` group. |
| **Auto-pipeline integration** | `modes/auto-pipeline.md`. New "Paso 4b" between Paso 4 (Section G) and Paso 5 (tracker), triggering only at score >= 4.5. Failure is non-fatal (marks `cover_letter: pending` in tracker notes). |
| **npm script** | `package.json`. `"cover-letter": "node generate-cover-letter.mjs"` for `npm run cover-letter -- input.json output.pdf`. |
| **README** | `README.md`. New feature table row and usage command line. |
| **`.gitignore` safety fix** | `.gitignore`. Adds `cv.md` and `article-digest.md` — both are user-layer per `DATA_CONTRACT.md` but were not ignored, meaning a user's `git add .` could accidentally publish their private CV. Defensive fix; neither file is currently tracked upstream. |

## Not Included (Out of Scope)

- **No translations for `modes/de/`, `modes/fr/`, `modes/pt/`** — v1 English-only. The mode file notes the DE/FR convention (`Sehr geehrtes Team…`) so future translation PRs have a reference.
- **No quote-selection algorithm** — `selectJdQuotesAndProofs()` is left as a TODO stub with JSDoc design questions. The agent's prose composition handles quote selection inline; the stub exists for users who want to encode deterministic selection logic.
- **No Playwright auto-upload** — per CLAUDE.md's "never submit" rule, the user always reviews and submits the PDF manually.
- **No Canva variant** — the HTML/PDF flow is the canonical path; Canva can be added later following the existing `pdf.md` Canva workflow pattern.

## Testing

Smoke test via the existing `test-all.mjs` convention (no new test
framework introduced):

```bash
node generate-cover-letter.mjs examples/sample-cover-letter.json /tmp/test.pdf
# Expected: ✅ Cover letter ready, Pages: 1, Size: ~45 KB

node test-all.mjs --quick
# Expected: 59 passed, 0 failed (was 58 on upstream; this PR adds 1
#            more passing test because test-all.mjs auto-discovers
#            the new .mjs file via node --check)
```

Error-path testing (field validation):

```bash
echo '{}' | node generate-cover-letter.mjs /dev/stdin /tmp/x.pdf
# Expected: ❌ content.candidate is required
#           (NOT a cryptic TypeError)
```

## Visual Verification

The generated PDF has:
- Gradient header line matching `cv-template.html`
  (`linear-gradient(to right, hsl(187,74%,32%), hsl(270,70%,45%))`)
- Space Grotesk headline + DM Sans body
- 4 paragraphs, each 40-50 words in the fixture (175 total)
- Purple signature name in the sign-off

## Test plan

- [ ] `node generate-cover-letter.mjs examples/sample-cover-letter.json /tmp/test.pdf` produces a 1-page PDF
- [ ] `npm run cover-letter -- examples/sample-cover-letter.json /tmp/test.pdf` (alias) does the same
- [ ] `node test-all.mjs --quick` reports `failed: 0`
- [ ] Malformed JSON (missing `candidate` or `letter`) produces a clear error, not a TypeError
- [ ] Visual inspection of the generated PDF shows gradient header, 4 paragraphs, no placeholder leakage
- [ ] `/career-ops cover-letter` appears in the discovery menu
- [ ] `/career-ops` with a JD scoring >= 4.5 auto-triggers cover letter generation via Paso 4b

## Notes

- 11 commits, each one scoped to a single concern (template, fixture,
  script, mode, routing, auto-pipeline wiring, npm script, README,
  gitignore). Can be squash-merged or merged as-is.
- The `chore: gitignore cv.md` commit is independent of the cover letter
  feature and fixes a pre-existing data-contract safety gap. Happy to
  split it into a separate PR if preferred.