### PR TITLE
fix: use candidate name in generated resume filename

### DIFF
--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -16,8 +16,9 @@
 10. Construye competency grid desde requisitos del JD (6-8 keyword phrases)
 11. Inyecta keywords naturalmente en logros existentes (NUNCA inventa)
 12. Genera HTML completo desde template + contenido personalizado
-13. Escribe HTML a `/tmp/cv-candidate-{company}.html`
-14. Ejecuta: `node generate-pdf.mjs /tmp/cv-candidate-{company}.html output/cv-candidate-{company}-{YYYY-MM-DD}.pdf --format={letter|a4}`
+13. Lee `name` de `config/profile.yml` → normaliza a kebab-case lowercase (e.g. "John Doe" → "john-doe") → `{candidate}`
+14. Escribe HTML a `/tmp/cv-{candidate}-{company}.html`
+15. Ejecuta: `node generate-pdf.mjs /tmp/cv-{candidate}-{company}.html output/cv-{candidate}-{company}-{YYYY-MM-DD}.pdf --format={letter|a4}`
 15. Reporta: ruta del PDF, nº páginas, % cobertura de keywords
 
 ## Reglas ATS (parseo limpio)


### PR DESCRIPTION
## Summary

- Reads `name` from `config/profile.yml` and normalizes it to kebab-case (e.g. `"John Doe"` → `"john-doe"`)
- Uses `{candidate}` in both the intermediate HTML file and final PDF output filename
- Replaces the generic `cv-candidate-{company}` pattern with `cv-{candidate}-{company}`

This makes it easier to identify resumes when multiple candidates or profiles are in use, and is consistent with how the Canva workflow already names its output files.

## Test plan

- [ ] Generate a PDF for a job offer
- [ ] Verify the output file is named `output/cv-{your-name}-{company}-{date}.pdf` instead of `output/cv-candidate-{company}-{date}.pdf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)