### PR TITLE
contacto: adapt message framework by contact type

### DIFF
--- a/modes/contacto.md
+++ b/modes/contacto.md
@@ -1,26 +1,53 @@
-# Modo: contacto — LinkedIn Power Move
+# Modo: contacto -- LinkedIn Power Move
 
 1. **Identificar targets** via WebSearch:
    - Hiring manager del equipo
    - Recruiter asignado
    - 2-3 peers del equipo (gente con rol similar)
+   - Interviewer (si el candidato ya tiene entrevista programada)
 
-2. **Seleccionar target primario**: la persona que más se beneficiaría de que el candidato estuviera allí
+2. **Clasificar tipo de contacto** -- preguntar al candidato o inferir del contexto:
+   - **Recruiter** -- persona cuyo rol es talent acquisition, sourcing, o recruiting
+   - **Hiring Manager** -- la persona que lidera el equipo que contrata
+   - **Peer** -- alguien con un rol similar en el equipo (referral indirecto)
+   - **Interviewer** -- alguien que va a entrevistar al candidato (fecha conocida)
 
-3. **Generar mensaje** con framework de 3 frases:
-   - **Frase 1 (Gancho)**: Algo específico sobre su empresa o reto actual con IA (NO genérico)
-   - **Frase 2 (Prueba)**: Mayor logro cuantificable del candidato relevante para ESE rol (ej: "I built an AI agent handling 90% of customer service at my company before selling it")
-   - **Frase 3 (Propuesta)**: Charla rápida, sin presión ("Would love to chat about [tema específico] for 15 min")
+3. **Seleccionar target primario**: la persona que mas se beneficiaria de que el candidato estuviera alli
 
-4. **Versiones**:
+4. **Generar mensaje** con framework de 3 frases adaptado al tipo de contacto:
+
+   ### Recruiter
+   - **Frase 1 (Fit)**: Criterios de match directo -- rol, experiencia relevante, disponibilidad o ubicacion
+   - **Frase 2 (Prueba)**: Dato que responda sus preguntas de screening antes de que las hagan (ej: "5 years building ML pipelines, currently in Berlin, available immediately")
+   - **Frase 3 (CTA)**: "Happy to share my CV if this aligns with what you're looking for"
+
+   ### Hiring Manager
+   - **Frase 1 (Gancho)**: Reto especifico que enfrenta su equipo (extraido del JD, company blog, o noticias)
+   - **Frase 2 (Prueba)**: Mayor logro cuantificable del candidato que demuestre que ha resuelto problemas similares
+   - **Frase 3 (CTA)**: "Would love to hear how your team is approaching [reto especifico]"
+
+   ### Peer (referral)
+   - **Frase 1 (Interes)**: Referencia genuina a su trabajo -- blog post, charla, proyecto open source, o publicacion
+   - **Frase 2 (Conexion)**: Algo que el candidato esta haciendo en el mismo espacio (NO un pitch de empleo)
+   - **Frase 3 (CTA)**: "I've been working on similar problems at [empresa], would love to hear your take on [tema]"
+   - **Nota**: NO pedir empleo. La referral ocurre naturalmente si la conversacion fluye.
+
+   ### Interviewer (pre-entrevista)
+   - **Frase 1 (Research)**: Referencia a algo especifico de su trabajo o trayectoria
+   - **Frase 2 (Contexto)**: Conexion ligera con la experiencia del candidato en ese tema
+   - **Frase 3 (CTA)**: "Looking forward to our conversation on [fecha]"
+   - **Nota**: Tono ligero, no desesperado. El objetivo es que sepan que te preparaste.
+
+5. **Versiones**:
    - EN (default)
-   - ES (si empresa española)
+   - ES (si empresa espanola)
 
-5. **Targets alternativos** con justificación de por qué son buenos second choices
+6. **Targets alternativos** con justificacion de por que son buenos second choices
 
 **Reglas del mensaje:**
-- Máximo 300 caracteres (LinkedIn connection request limit)
+- Maximo 300 caracteres (LinkedIn connection request limit)
 - NO corporate-speak
 - NO "I'm passionate about..."
 - Algo que haga que quieran responder
-- NUNCA compartir teléfono
+- NUNCA compartir telefono
+- El tipo de contacto cambia el ENFASIS, no la estructura


### PR DESCRIPTION
## Summary

Closes #158

Adapts the contacto mode's 3-sentence message framework based on who the message is for. The mode already identifies recruiter, hiring manager, and peers in step 1 — this change follows through on that classification in the message generation step.

## Changes

**1 file modified: `modes/contacto.md`** (38 insertions, 11 deletions)

| What | Before | After |
|------|--------|-------|
| Message framework | Single generic framework for all contacts | 4 role-specific frameworks |
| Contact classification | Implicit (identified but ignored) | Explicit step 2 |
| Steps | 5 | 6 (new classification step inserted) |
| 300-char limit | Yes | Yes (unchanged) |
| 3-sentence structure | Yes | Yes (unchanged) |
| Cross-mode reads | None | None (stays standalone) |

### Role-specific frameworks

- **Recruiter**: Lead with fit criteria, answer screening questions, CTA offers CV
- **Hiring Manager**: Lead with team challenge, show similar wins, CTA asks about their approach
- **Peer**: Genuine interest in their work, no job pitch, CTA asks for perspective
- **Interviewer**: Research-driven prep signal, light tone

All four frameworks validated under 300 characters with realistic examples.

## What this does NOT do

- Does NOT add new files or modes
- Does NOT read from reports, evaluations, or other modes
- Does NOT change the 300-char limit or 3-sentence structure
- Does NOT integrate contacto with any other part of the system

## Test plan

- [ ] `node test-all.mjs` passes (59/0)
- [ ] Only `modes/contacto.md` in the diff
- [ ] No references to `_shared.md`, `oferta.md`, or reports in the file
- [ ] The word "passionate" does not appear in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)