### PR TITLE
Add Codex Skills to match Claude Code

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: career-ops
+description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
+---
+
+# career-ops -- Router
+
+## Mode Routing
+
+Determine the mode from the user's request text after invoking `$career-ops`, or from the full request if the skill is invoked implicitly:
+
+| Input | Mode |
+|-------|------|
+| (empty / no args) | `discovery` -- Show command menu |
+| JD text or URL (no sub-command) | **`auto-pipeline`** |
+| `oferta` | `oferta` |
+| `ofertas` | `ofertas` |
+| `contacto` | `contacto` |
+| `deep` | `deep` |
+| `pdf` | `pdf` |
+| `training` | `training` |
+| `project` | `project` |
+| `tracker` | `tracker` |
+| `pipeline` | `pipeline` |
+| `apply` | `apply` |
+| `scan` | `scan` |
+| `batch` | `batch` |
+| `patterns` | `patterns` |
+| `followup` | `followup` |
+
+**Auto-pipeline detection:** If the request text is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
+
+If the request text is not a sub-command AND doesn't look like a JD, show discovery.
+
+---
+
+## Discovery Mode (no arguments)
+
+Show this menu:
+
+```
+career-ops -- Command Center
+
+Available commands:
+  $career-ops {JD}      → AUTO-PIPELINE: evaluate + report + PDF + tracker (paste text or URL)
+  $career-ops pipeline  → Process pending URLs from inbox (data/pipeline.md)
+  $career-ops oferta    → Evaluation only A-F (no auto PDF)
+  $career-ops ofertas   → Compare and rank multiple offers
+  $career-ops contacto  → LinkedIn power move: find contacts + draft message
+  $career-ops deep      → Deep research prompt about company
+  $career-ops pdf       → PDF only, ATS-optimized CV
+  $career-ops training  → Evaluate course/cert against North Star
+  $career-ops project   → Evaluate portfolio project idea
+  $career-ops tracker   → Application status overview
+  $career-ops apply     → Live application assistant (reads form + generates answers)
+  $career-ops scan      → Scan portals and discover new offers
+  $career-ops batch     → Batch processing with parallel workers
+  $career-ops patterns  → Analyze rejection patterns and improve targeting
+  $career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
+
+Inbox: add URLs to data/pipeline.md → $career-ops pipeline
+Or paste a JD directly to run the full pipeline.
+```
+
+---
+
+## Context Loading by Mode
+
+After determining the mode, load the necessary files before executing:
+
+### Modes that require `_shared.md` + their mode file:
+Read `modes/_shared.md` + `modes/{mode}.md`
+
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+
+### Standalone modes (only their mode file):
+Read `modes/{mode}.md`
+
+Applies to: `tracker`, `deep`, `training`, `project`, `patterns`, `followup`
+
+### Modes delegated to subagent:
+For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as Agent with the content of `_shared.md` + `modes/{mode}.md` injected into the subagent prompt.
+
+```
+Agent(
+  subagent_type="general-purpose",
+  prompt="[content of modes/_shared.md]\n\n[content of modes/{mode}.md]\n\n[invocation-specific data]",
+  description="career-ops {mode}"
+)
+```
+
+Execute the instructions from the loaded mode file.

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -7,6 +7,10 @@ is enough for routing and behavior. Codex should reuse the same checked-in
 mode files, templates, tracker flow, and scripts that already power the
 Claude workflow.
 
+For repo-scoped Codex usage, this repo exposes Career-Ops as a repo skill:
+
+- Skill path: `.agents/skills/career-ops/SKILL.md`
+
 ## Prerequisites
 
 - A Codex client that can work with project `AGENTS.md`
@@ -46,6 +50,24 @@ npx playwright install chromium
 The key point: Codex support is additive. It should route into the existing
 Career-Ops modes and scripts rather than introducing a parallel automation
 layer.
+
+## Skill Discovery
+
+Codex's official docs recommend direct skill folders for local authoring and
+repo-scoped workflows. In this repo, that means launching Codex from the repo
+so it can see `.agents/skills/career-ops/SKILL.md`.
+
+Use Career-Ops through the skill system:
+
+- `$career-ops https://company.example/job-posting`
+- `$career-ops tracker`
+- `$career-ops pdf`
+- `Evaluate this job URL with Career-Ops and run the full pipeline.`
+
+Codex docs also describe explicit skill invocation via `/skills` or `$`, and
+say enabled skills can appear in the `/` menu. The exact UI surface still
+depends on the client build, so if `career-ops` does not appear in the `/`
+menu, invoke it directly with `$career-ops` or ask in plain language.
 
 ## Behavioral Rules
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

Adds Codex Skills functionality so that you can run `$career-ops ...` the same way you run `/career-ops ...` in claude code

## Related issue

<!-- Link the issue this PR addresses: Fixes #123 / Closes #123 -->

## Type of change

- [X] New feature
- [X] Documentation

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I opened an issue first (required for features and architecture changes) -> https://github.com/santifer/career-ops/issues/165
- [X] My PR does not include personal data (CV, email, real names)
- [X] I ran `node test-all.mjs` and all tests pass
- [X] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.
