### PR TITLE
Dashboard viewer: aligned tables and markdown syntax rendering

### DIFF
--- a/dashboard/internal/ui/screens/viewer.go
+++ b/dashboard/internal/ui/screens/viewer.go
@@ -2,6 +2,7 @@ package screens
 
 import (
 	"os"
+	"regexp"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -206,10 +207,35 @@ func (m ViewerModel) renderBody() string {
 	}
 	visible := m.lines[m.scrollOffset:end]
 
-	// Style markdown elements
+	// Render with table block detection
 	var styled []string
-	for _, line := range visible {
-		styled = append(styled, m.styleLine(line))
+	i := 0
+	for i < len(visible) {
+		if isTableLine(visible[i]) {
+			// Collect consecutive table lines
+			tableStart := i
+			for i < len(visible) && isTableLine(visible[i]) {
+				i++
+			}
+			tableLines := visible[tableStart:i]
+
+			// Also look ahead in full document for remaining table rows
+			// that may be just beyond the visible window, to get correct column widths
+			fullTableStart := m.scrollOffset + tableStart
+			fullTableEnd := fullTableStart
+			for fullTableEnd < len(m.lines) && isTableLine(m.lines[fullTableEnd]) {
+				fullTableEnd++
+			}
+			fullTable := m.lines[fullTableStart:fullTableEnd]
+
+			// Compute column widths from the full table, render only visible rows
+			colWidths := computeColumnWidths(fullTable, m.width-6)
+			rendered := m.renderTableBlock(tableLines, colWidths, fullTableStart)
+			styled = append(styled, rendered...)
+		} else {
+			styled = append(styled, m.styleLine(visible[i]))
+			i++
+		}
 	}
 
 	// Pad to fill height
@@ -220,29 +246,234 @@ func (m ViewerModel) renderBody() string {
 	return padStyle.Render(strings.Join(styled, "\n"))
 }
 
+// isTableLine checks if a line is part of a markdown table.
+func isTableLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return len(trimmed) > 1 && trimmed[0] == '|'
+}
+
+// isTableSeparator checks if a line is a table separator (|---|---|).
+func isTableSeparator(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "|") {
+		return false
+	}
+	cleaned := strings.NewReplacer("|", "", "-", "", ":", "", " ", "").Replace(trimmed)
+	return cleaned == ""
+}
+
+// parseTableCells splits a table line into trimmed cells.
+func parseTableCells(line string) []string {
+	trimmed := strings.TrimSpace(line)
+	// Remove leading and trailing pipes
+	if len(trimmed) > 0 && trimmed[0] == '|' {
+		trimmed = trimmed[1:]
+	}
+	if len(trimmed) > 0 && trimmed[len(trimmed)-1] == '|' {
+		trimmed = trimmed[:len(trimmed)-1]
+	}
+	parts := strings.Split(trimmed, "|")
+	cells := make([]string, len(parts))
+	for i, p := range parts {
+		cells[i] = strings.TrimSpace(p)
+	}
+	return cells
+}
+
+// computeColumnWidths calculates max width per column across all table rows.
+func computeColumnWidths(lines []string, maxTotal int) []int {
+	maxCols := 0
+	for _, line := range lines {
+		if isTableSeparator(line) {
+			continue
+		}
+		cells := parseTableCells(line)
+		if len(cells) > maxCols {
+			maxCols = len(cells)
+		}
+	}
+	if maxCols == 0 {
+		return nil
+	}
+
+	widths := make([]int, maxCols)
+	for _, line := range lines {
+		if isTableSeparator(line) {
+			continue
+		}
+		cells := parseTableCells(line)
+		for i, cell := range cells {
+			if i < maxCols {
+				w := lipgloss.Width(cell)
+				if w > widths[i] {
+					widths[i] = w
+				}
+			}
+		}
+	}
+
+	// Cap individual columns based on column count
+	maxColW := 45
+	if maxCols > 5 {
+		maxColW = 30
+	}
+	if maxCols > 7 {
+		maxColW = 22
+	}
+	for i := range widths {
+		if widths[i] > maxColW {
+			widths[i] = maxColW
+		}
+		if widths[i] < 3 {
+			widths[i] = 3
+		}
+	}
+
+	// Shrink to fit available width
+	for {
+		total := 1 // trailing border
+		for _, w := range widths {
+			total += w + 3 // cell padding + border
+		}
+		if total <= maxTotal {
+			break
+		}
+		// Find the widest column and shrink it by 1
+		widestIdx := 0
+		widestVal := 0
+		for i, w := range widths {
+			if w > widestVal {
+				widestVal = w
+				widestIdx = i
+			}
+		}
+		if widths[widestIdx] <= 3 {
+			break // can't shrink further
+		}
+		widths[widestIdx]--
+	}
+
+	return widths
+}
+
+// renderTableBlock renders table lines with aligned columns and box-drawing borders.
+func (m ViewerModel) renderTableBlock(lines []string, colWidths []int, firstLineIdx int) []string {
+	if len(lines) == 0 || len(colWidths) == 0 {
+		// Fallback: render as plain text
+		var result []string
+		for _, line := range lines {
+			result = append(result, m.styleLine(line))
+		}
+		return result
+	}
+
+	maxCols := len(colWidths)
+	borderStyle := lipgloss.NewStyle().Foreground(m.theme.Overlay)
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Sky)
+	dataStyle := lipgloss.NewStyle().Foreground(m.theme.Text)
+
+	// Build top border
+	var result []string
+	var topParts []string
+	for _, w := range colWidths {
+		topParts = append(topParts, strings.Repeat("─", w+2))
+	}
+	result = append(result, borderStyle.Render("┌"+strings.Join(topParts, "┬")+"┐"))
+
+	isFirstDataRow := true
+	for _, line := range lines {
+		if isTableSeparator(line) {
+			// Render middle separator
+			var sepParts []string
+			for _, w := range colWidths {
+				sepParts = append(sepParts, strings.Repeat("─", w+2))
+			}
+			result = append(result, borderStyle.Render("├"+strings.Join(sepParts, "┼")+"┤"))
+			continue
+		}
+
+		cells := parseTableCells(line)
+		var paddedCells []string
+		for i := 0; i < maxCols; i++ {
+			cell := ""
+			if i < len(cells) {
+				cell = cells[i]
+			}
+			cellWidth := lipgloss.Width(cell)
+			colW := colWidths[i]
+
+			if cellWidth > colW {
+				// Truncate — need to handle multi-byte/emoji carefully
+				runes := []rune(cell)
+				truncated := string(runes)
+				for lipgloss.Width(truncated) > colW-3 && len(runes) > 0 {
+					runes = runes[:len(runes)-1]
+					truncated = string(runes)
+				}
+				cell = truncated + "..."
+				cellWidth = lipgloss.Width(cell)
+			}
+
+			padding := colW - cellWidth
+			if padding < 0 {
+				padding = 0
+			}
+			paddedCells = append(paddedCells, " "+cell+strings.Repeat(" ", padding)+" ")
+		}
+
+		// Build row with borders
+		border := borderStyle.Render("│")
+		var rowParts []string
+		for _, cell := range paddedCells {
+			if isFirstDataRow {
+				rowParts = append(rowParts, headerStyle.Render(cell))
+			} else {
+				rowParts = append(rowParts, dataStyle.Render(cell))
+			}
+		}
+		row := border + strings.Join(rowParts, border) + border
+		result = append(result, row)
+		isFirstDataRow = false
+	}
+
+	// Bottom border
+	var bottomParts []string
+	for _, w := range colWidths {
+		bottomParts = append(bottomParts, strings.Repeat("─", w+2))
+	}
+	result = append(result, borderStyle.Render("└"+strings.Join(bottomParts, "┴")+"┘"))
+
+	return result
+}
+
+var reBold = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+
 func (m ViewerModel) styleLine(line string) string {
 	trimmed := strings.TrimSpace(line)
 
-	// H1
-	if strings.HasPrefix(trimmed, "# ") {
+	// H1 — render without the "# " prefix
+	if strings.HasPrefix(trimmed, "# ") && !strings.HasPrefix(trimmed, "## ") {
+		content := strings.TrimPrefix(trimmed, "# ")
 		return lipgloss.NewStyle().
 			Bold(true).
 			Foreground(m.theme.Blue).
-			Render(line)
+			Render("  " + content)
 	}
-	// H2
-	if strings.HasPrefix(trimmed, "## ") {
+	// H2 — render without the "## " prefix
+	if strings.HasPrefix(trimmed, "## ") && !strings.HasPrefix(trimmed, "### ") {
+		content := strings.TrimPrefix(trimmed, "## ")
 		return lipgloss.NewStyle().
 			Bold(true).
 			Foreground(m.theme.Mauve).
-			Render(line)
+			Render("  " + content)
 	}
-	// H3
+	// H3 — render without the "### " prefix
 	if strings.HasPrefix(trimmed, "### ") {
+		content := strings.TrimPrefix(trimmed, "### ")
 		return lipgloss.NewStyle().
 			Bold(true).
 			Foreground(m.theme.Sky).
-			Render(line)
+			Render("  " + content)
 	}
 	// Horizontal rule
 	if trimmed == "---" || trimmed == "***" {
@@ -250,35 +481,63 @@ func (m ViewerModel) styleLine(line string) string {
 			Foreground(m.theme.Overlay).
 			Render(strings.Repeat("─", m.width-4))
 	}
-	// Bold fields like **Score:** 4.0/5
+	// Blockquote
+	if strings.HasPrefix(trimmed, "> ") {
+		content := strings.TrimPrefix(trimmed, "> ")
+		border := lipgloss.NewStyle().Foreground(m.theme.Overlay).Render("▎ ")
+		text := lipgloss.NewStyle().Foreground(m.theme.Subtext).Italic(true).Render(content)
+		return border + text
+	}
+	// Bold fields like **Score:** 4.0/5 — render with bold label, strip asterisks
 	if strings.HasPrefix(trimmed, "**") && strings.Contains(trimmed, ":**") {
-		return lipgloss.NewStyle().
-			Foreground(m.theme.Yellow).
-			Render(line)
+		return m.renderInlineBold(line, m.theme.Yellow)
 	}
-	// Table headers/separators
-	if strings.HasPrefix(trimmed, "|") && strings.Contains(trimmed, "---") {
-		return lipgloss.NewStyle().
-			Foreground(m.theme.Overlay).
-			Render(line)
-	}
-	// Table rows
-	if strings.HasPrefix(trimmed, "|") {
-		return lipgloss.NewStyle().
-			Foreground(m.theme.Text).
-			Render(line)
-	}
-	// Bullet points
+	// Bullet points and numbered lists
 	if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
-		return lipgloss.NewStyle().
-			Foreground(m.theme.Text).
-			Render(line)
+		return m.renderInlineBold(line, m.theme.Text)
+	}
+	if len(trimmed) > 2 && trimmed[0] >= '0' && trimmed[0] <= '9' && strings.Contains(trimmed[:3], ".") {
+		return m.renderInlineBold(line, m.theme.Text)
 	}
 
-	// Default
+	// Default — still check for inline bold
+	if strings.Contains(trimmed, "**") {
+		return m.renderInlineBold(line, m.theme.Subtext)
+	}
+
 	return lipgloss.NewStyle().
 		Foreground(m.theme.Subtext).
 		Render(line)
+}
+
+// renderInlineBold renders a line with **bold** segments highlighted.
+func (m ViewerModel) renderInlineBold(line string, baseColor lipgloss.Color) string {
+	baseStyle := lipgloss.NewStyle().Foreground(baseColor)
+	boldStyle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Yellow)
+
+	matches := reBold.FindAllStringIndex(line, -1)
+	if len(matches) == 0 {
+		return baseStyle.Render(line)
+	}
+
+	var result strings.Builder
+	last := 0
+	for _, loc := range matches {
+		// Render text before the bold
+		if loc[0] > last {
+			result.WriteString(baseStyle.Render(line[last:loc[0]]))
+		}
+		// Extract bold content (without **)
+		boldText := line[loc[0]+2 : loc[1]-2]
+		result.WriteString(boldStyle.Render(boldText))
+		last = loc[1]
+	}
+	// Render remaining text
+	if last < len(line) {
+		result.WriteString(baseStyle.Render(line[last:]))
+	}
+
+	return result.String()
 }
 
 func (m ViewerModel) renderFooter() string {


### PR DESCRIPTION
## Summary

Closes #166

Improves the dashboard report viewer's markdown rendering. Tables now render with aligned columns and box-drawing borders. Markdown syntax (`#`, `**`, `>`) is rendered visually instead of shown as raw text.

## Before / After

**Before** — raw pipes, visible markdown syntax:

<img width="1348" height="878" alt="Captura de pantalla 2026-04-10 a la(s) 2 49 50 p m" src="https://github.com/user-attachments/assets/dcf1eb2d-b8ad-4700-b445-1fab79df4295" />

**After** — aligned tables, clean rendering:

<img width="1348" height="878" alt="image" src="https://github.com/user-attachments/assets/ed9b2d9a-a2c2-425b-9a10-5a2282c8bb7e" />


## Changes

**1 file modified: `dashboard/internal/ui/screens/viewer.go`** (290 insertions, 31 deletions)

### Table rendering
- Detect consecutive `|` lines and render as aligned block
- Box-drawing borders: `┌─┬─┐`, `│`, `├─┼─┤`, `└─┴─┘`
- Header row: bold + Sky color. Data rows: Text color
- Smart column fitting: iteratively shrink widest column to fit terminal
- Emoji-safe width via `lipgloss.Width()` (handles ✅ ❌ ⚠️)

### Markdown cleanup
- `# H1` / `## H2` / `### H3` → render without prefix, styled by level
- `**Key:** value` → bold label without asterisks
- `**bold**` inline → bold rendering without asterisks
- `> quote` → left border + italic
- `1.` numbered lists → styled like bullets

### What this does NOT change
- No changes to data parsing, pipeline screen, or any other file
- No new dependencies
- Uses existing Catppuccin theme colors only

## Test plan

- [ ] `cd dashboard && go build ./...` passes
- [ ] `node test-all.mjs` passes (63/0)
- [ ] Tables with emoji (✅ ❌ ⚠️) render with correct alignment
- [ ] Wide tables (8+ columns like STAR+R) fit terminal without overflow
- [ ] Existing heading/bullet/bold-field colors match original behavior
- [ ] Empty reports render without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)