### PR TITLE
feat: add launch.json with dev server configurations

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,34 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Dashboard (TUI)",
+      "runtimeExecutable": "go",
+      "runtimeArgs": ["run", "."],
+      "cwd": "dashboard",
+      "port": null,
+      "note": "Terminal UI built with Bubbletea — runs in the terminal, no web port"
+    },
+    {
+      "name": "Portal Scanner",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["scan.mjs"],
+      "port": null,
+      "note": "Scans job portals for new offers — runs and exits"
+    },
+    {
+      "name": "Pipeline Health Check",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["verify-pipeline.mjs"],
+      "port": null,
+      "note": "Verifies pipeline integrity — runs and exits"
+    },
+    {
+      "name": "Doctor",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["doctor.mjs"],
+      "port": null,
+      "note": "System health diagnostics — runs and exits"
+    }
+  ]
+}


### PR DESCRIPTION
Documents all runnable processes (TUI dashboard, scanner, health checks) for the career-ops CLI toolchain.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- Link the issue this PR addresses: Fixes #123 / Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] I opened an issue first (required for features and architecture changes)
- [ ] My PR does not include personal data (CV, email, real names)
- [ ] I ran `node test-all.mjs` and all tests pass
- [ ] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.
