### PR TITLE
feat: add Codex support via .agents/ skill files and runner

### DIFF
--- a/.agents/career-ops-apply.md
+++ b/.agents/career-ops-apply.md
@@ -1,0 +1,9 @@
+---
+description: Live application assistant
+---
+
+Application assistant using career-ops apply mode.
+
+Read `modes/_shared.md` then `modes/apply.md` and follow the instructions.
+
+Form data or context: $ARGUMENTS

--- a/.agents/career-ops-batch.md
+++ b/.agents/career-ops-batch.md
@@ -1,0 +1,9 @@
+---
+description: Batch processing with parallel workers
+---
+
+Batch processing using career-ops batch mode.
+
+Read `modes/_shared.md` then `modes/batch.md` and follow the instructions.
+
+$ARGUMENTS

--- a/.agents/career-ops-compare.md
+++ b/.agents/career-ops-compare.md
@@ -1,0 +1,9 @@
+---
+description: Compare and rank multiple job offers
+---
+
+Compare the following job offers using career-ops ofertas mode.
+
+Read `modes/_shared.md` then `modes/ofertas.md` and follow the instructions.
+
+Offers to compare: $ARGUMENTS

--- a/.agents/career-ops-contact.md
+++ b/.agents/career-ops-contact.md
@@ -1,0 +1,9 @@
+---
+description: LinkedIn power move - find contacts and draft message
+---
+
+LinkedIn outreach for company/role using career-ops contacto mode.
+
+Read `modes/_shared.md` then `modes/contacto.md` and follow the instructions.
+
+Company or role context: $ARGUMENTS

--- a/.agents/career-ops-deep.md
+++ b/.agents/career-ops-deep.md
@@ -1,0 +1,9 @@
+---
+description: Deep research about a company
+---
+
+Deep research about company using career-ops deep mode.
+
+Read `modes/deep.md` and follow the instructions.
+
+Company or context: $ARGUMENTS

--- a/.agents/career-ops-evaluate.md
+++ b/.agents/career-ops-evaluate.md
@@ -1,0 +1,9 @@
+---
+description: Evaluate job offer (A-F scoring, no auto PDF)
+---
+
+Evaluate the following job description using career-ops oferta mode.
+
+Read `modes/_shared.md` then `modes/oferta.md` and follow the instructions.
+
+Job description or URL: $ARGUMENTS

--- a/.agents/career-ops-followup.md
+++ b/.agents/career-ops-followup.md
@@ -1,0 +1,7 @@
+---
+description: Follow-up cadence tracker - flag overdue, generate drafts
+---
+
+Follow-up cadence tracking using career-ops followup mode.
+
+Read `modes/followup.md` and follow the instructions.

--- a/.agents/career-ops-patterns.md
+++ b/.agents/career-ops-patterns.md
@@ -1,0 +1,7 @@
+---
+description: Analyze rejection patterns and improve targeting
+---
+
+Analyze rejection patterns and improve targeting using career-ops patterns mode.
+
+Read `modes/patterns.md` and follow the instructions.

--- a/.agents/career-ops-pdf.md
+++ b/.agents/career-ops-pdf.md
@@ -1,0 +1,7 @@
+---
+description: Generate ATS-optimized CV PDF
+---
+
+Generate ATS-optimized CV using career-ops pdf mode.
+
+Read `modes/_shared.md` then `modes/pdf.md` and follow the instructions.

--- a/.agents/career-ops-pipeline.md
+++ b/.agents/career-ops-pipeline.md
@@ -1,0 +1,7 @@
+---
+description: Process pending URLs from pipeline inbox
+---
+
+Process pending job URLs from `data/pipeline.md` using career-ops pipeline mode.
+
+Read `modes/_shared.md` then `modes/pipeline.md` and follow the instructions.

--- a/.agents/career-ops-project.md
+++ b/.agents/career-ops-project.md
@@ -1,0 +1,9 @@
+---
+description: Evaluate portfolio project idea
+---
+
+Evaluate the following portfolio project using career-ops project mode.
+
+Read `modes/project.md` and follow the instructions.
+
+Project idea or context: $ARGUMENTS

--- a/.agents/career-ops-scan.md
+++ b/.agents/career-ops-scan.md
@@ -1,0 +1,7 @@
+---
+description: Scan job portals and discover new offers
+---
+
+Scan job portals for new offers using career-ops scan mode.
+
+Read `modes/_shared.md` then `modes/scan.md` and follow the instructions.

--- a/.agents/career-ops-tracker.md
+++ b/.agents/career-ops-tracker.md
@@ -1,0 +1,7 @@
+---
+description: Application status overview
+---
+
+Show application tracker status using career-ops tracker mode.
+
+Read `modes/tracker.md` and follow the instructions.

--- a/.agents/career-ops-training.md
+++ b/.agents/career-ops-training.md
@@ -1,0 +1,9 @@
+---
+description: Evaluate course/cert against North Star goals
+---
+
+Evaluate the following training or course using career-ops training mode.
+
+Read `modes/training.md` and follow the instructions.
+
+Course or certification: $ARGUMENTS

--- a/.agents/career-ops.md
+++ b/.agents/career-ops.md
@@ -1,0 +1,78 @@
+---
+description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
+---
+
+# career-ops -- Router
+
+Career-ops router. Arguments provided: "$ARGUMENTS"
+
+## Mode Detection
+
+Determine the mode from the arguments:
+
+| Input | Mode |
+|-------|------|
+| (empty / no args) | `discovery` -- Show command menu |
+| JD text or URL (no sub-command) | `auto-pipeline` |
+| `oferta` | `oferta` |
+| `ofertas` | `ofertas` |
+| `contacto` | `contacto` |
+| `deep` | `deep` |
+| `pdf` | `pdf` |
+| `training` | `training` |
+| `project` | `project` |
+| `tracker` | `tracker` |
+| `pipeline` | `pipeline` |
+| `apply` | `apply` |
+| `scan` | `scan` |
+| `batch` | `batch` |
+| `patterns` | `patterns` |
+| `followup` | `followup` |
+
+**Auto-pipeline detection:** If the argument is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for") or a URL, execute `auto-pipeline`.
+
+If the argument is not a sub-command AND doesn't look like a JD, show discovery.
+
+## Discovery Mode (no arguments)
+
+Show this menu:
+
+```
+career-ops -- Command Center
+
+Available commands:
+  career-ops {JD}      → AUTO-PIPELINE: evaluate + report + PDF + tracker (paste text or URL)
+  career-ops pipeline  → Process pending URLs from inbox (data/pipeline.md)
+  career-ops oferta    → Evaluation only A-F (no auto PDF)
+  career-ops ofertas   → Compare and rank multiple offers
+  career-ops contacto  → LinkedIn power move: find contacts + draft message
+  career-ops deep      → Deep research prompt about company
+  career-ops pdf       → PDF only, ATS-optimized CV
+  career-ops training  → Evaluate course/cert against North Star
+  career-ops project   → Evaluate portfolio project idea
+  career-ops tracker   → Application status overview
+  career-ops apply     → Live application assistant (reads form + generates answers)
+  career-ops scan      → Scan portals and discover new offers
+  career-ops batch     → Batch processing with parallel workers
+  career-ops patterns  → Analyze rejection patterns and improve targeting
+  career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
+
+Inbox: add URLs to data/pipeline.md → career-ops pipeline
+Or paste a JD directly to run the full pipeline.
+```
+
+## Context Loading by Mode
+
+After determining the mode, read the necessary files before executing:
+
+### Modes that require `_shared.md` + their mode file:
+Read `modes/_shared.md` then `modes/{mode}.md`
+
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+
+### Standalone modes (only their mode file):
+Read `modes/{mode}.md`
+
+Applies to: `tracker`, `deep`, `training`, `project`, `patterns`, `followup`
+
+Execute the instructions from the loaded mode file.

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ modes/_profile.md
 
 # Generated
 .resolved-prompt-*
+.agents/cache/
+runs/codex-runs.jsonl
 node_modules/
 bun.lock
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,25 @@ Key points:
 - Never submit an application on the user's behalf.
 
 For Codex-specific setup, see `docs/CODEX.md`.
+
+## Codex Commands
+
+Individual command agents are available under `.agents/`:
+
+| File | Equivalent | Description |
+|------|------------|-------------|
+| `.agents/career-ops.md` | main router | Show menu or auto-pipeline a JD/URL |
+| `.agents/career-ops-evaluate.md` | `oferta` | Evaluate job offer (A-F scoring) |
+| `.agents/career-ops-compare.md` | `ofertas` | Compare and rank multiple offers |
+| `.agents/career-ops-scan.md` | `scan` | Scan portals for new offers |
+| `.agents/career-ops-pdf.md` | `pdf` | Generate ATS-optimized CV PDF |
+| `.agents/career-ops-pipeline.md` | `pipeline` | Process pending URLs from inbox |
+| `.agents/career-ops-apply.md` | `apply` | Live application assistant |
+| `.agents/career-ops-tracker.md` | `tracker` | Application status overview |
+| `.agents/career-ops-contact.md` | `contacto` | LinkedIn outreach |
+| `.agents/career-ops-deep.md` | `deep` | Deep company research |
+| `.agents/career-ops-batch.md` | `batch` | Batch processing with parallel workers |
+| `.agents/career-ops-training.md` | `training` | Evaluate course/cert |
+| `.agents/career-ops-project.md` | `project` | Evaluate portfolio project idea |
+| `.agents/career-ops-patterns.md` | `patterns` | Analyze rejection patterns |
+| `.agents/career-ops-followup.md` | `followup` | Follow-up cadence tracker |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,30 @@ When using [OpenCode](https://opencode.ai), the following slash commands are ava
 
 **Note:** OpenCode commands invoke the same `.claude/skills/career-ops/SKILL.md` skill used by Claude Code. The `modes/*` files are shared between both platforms.
 
+### Codex Commands
+
+When using [OpenAI Codex](https://openai.com/codex), the following agent files are available (defined in `.agents/`):
+
+| Agent file | Claude Code Equivalent | Description |
+|------------|------------------------|-------------|
+| `.agents/career-ops.md` | `/career-ops` | Show menu or evaluate JD with args |
+| `.agents/career-ops-pipeline.md` | `/career-ops pipeline` | Process pending URLs from inbox |
+| `.agents/career-ops-evaluate.md` | `/career-ops oferta` | Evaluate job offer (A-F scoring) |
+| `.agents/career-ops-compare.md` | `/career-ops ofertas` | Compare and rank multiple offers |
+| `.agents/career-ops-contact.md` | `/career-ops contacto` | LinkedIn outreach (find contacts + draft) |
+| `.agents/career-ops-deep.md` | `/career-ops deep` | Deep company research |
+| `.agents/career-ops-pdf.md` | `/career-ops pdf` | Generate ATS-optimized CV |
+| `.agents/career-ops-training.md` | `/career-ops training` | Evaluate course/cert against goals |
+| `.agents/career-ops-project.md` | `/career-ops project` | Evaluate portfolio project idea |
+| `.agents/career-ops-tracker.md` | `/career-ops tracker` | Application status overview |
+| `.agents/career-ops-apply.md` | `/career-ops apply` | Live application assistant |
+| `.agents/career-ops-scan.md` | `/career-ops scan` | Scan portals for new offers |
+| `.agents/career-ops-batch.md` | `/career-ops batch` | Batch processing with parallel workers |
+| `.agents/career-ops-patterns.md` | `/career-ops patterns` | Analyze rejection patterns and improve targeting |
+| `.agents/career-ops-followup.md` | `/career-ops followup` | Follow-up cadence tracker |
+
+**Note:** Codex agent files load the same `modes/*` files used by Claude Code and OpenCode. No parallel logic — the same evaluation, scoring, and tracker flow applies.
+
 ### First Run — Onboarding (IMPORTANT)
 
 **Before doing ANYTHING else, check if the system is set up.** Run these checks silently every time a session starts:

--- a/codex-runner.mjs
+++ b/codex-runner.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * codex-runner.mjs
+ *
+ * Bridge between career-ops .agents/ prompt files and the Codex CLI.
+ * Reads the matching .agents/career-ops-{command}.md file, substitutes
+ * any arguments, then invokes `codex` with the assembled prompt.
+ *
+ * On fallback (Codex CLI not installed):
+ *   - Caches the constructed prompt to .agents/cache/ for later use
+ *   - Tells the user exactly which file to open and what to paste
+ *
+ * Each run is appended to runs/codex-runs.jsonl for audit and resume.
+ *
+ * TODO: Add auto-routing and batch execution when Codex supports skill loading.
+ *
+ * Usage:
+ *   node codex-runner.mjs                           # show menu
+ *   node codex-runner.mjs scan
+ *   node codex-runner.mjs evaluate "URL or JD text"
+ *   node codex-runner.mjs pdf
+ *
+ * npm shortcuts:
+ *   npm run codex:scan
+ *   npm run codex:evaluate -- "https://example.com/job/123"
+ *
+ * Requires the Codex CLI: https://github.com/openai/codex
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, appendFileSync } from "fs";
+import { spawnSync } from "child_process";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+
+const MODES = [
+  "evaluate",
+  "compare",
+  "scan",
+  "pdf",
+  "pipeline",
+  "apply",
+  "tracker",
+  "contact",
+  "deep",
+  "batch",
+  "training",
+  "project",
+  "patterns",
+  "followup",
+];
+
+// Commands that take no user arguments — warn if args are passed.
+const NO_ARGS_MODES = new Set(["scan", "pdf", "pipeline", "tracker", "patterns", "followup"]);
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function printUsage() {
+  console.log(`career-ops Codex runner
+
+Usage:
+  node codex-runner.mjs [command] [args]
+
+Commands:
+  (no args)    Show command menu
+  evaluate     Evaluate job offer (A-F scoring, no auto PDF)
+  compare      Compare and rank multiple offers
+  scan         Scan portals for new offers
+  pdf          Generate ATS-optimized CV PDF
+  pipeline     Process pending URLs from data/pipeline.md
+  apply        Live application assistant
+  tracker      Application status overview
+  contact      LinkedIn outreach: find contacts + draft message
+  deep         Deep company research
+  batch        Batch processing with parallel workers
+  training     Evaluate course/cert against goals
+  project      Evaluate portfolio project idea
+  patterns     Analyze rejection patterns and improve targeting
+  followup     Follow-up cadence tracker
+
+Examples:
+  node codex-runner.mjs
+  node codex-runner.mjs scan
+  node codex-runner.mjs evaluate "https://example.com/job/123"
+  node codex-runner.mjs evaluate "$(cat jds/my-role.md)"
+
+Requires the Codex CLI: https://github.com/openai/codex
+`);
+}
+
+/**
+ * Append a run record to runs/codex-runs.jsonl.
+ * Creates the file and directory on first use.
+ */
+function logRun(entry) {
+  const runsDir = join(__dir, "runs");
+  if (!existsSync(runsDir)) mkdirSync(runsDir, { recursive: true });
+  appendFileSync(
+    join(runsDir, "codex-runs.jsonl"),
+    JSON.stringify({ ...entry, ts: new Date().toISOString() }) + "\n",
+    "utf-8",
+  );
+}
+
+/**
+ * Cache a constructed prompt to .agents/cache/{command}-{ts}.md.
+ * Returns the path so it can be shown to the user.
+ */
+function cachePrompt(command, prompt) {
+  const cacheDir = join(__dir, ".agents", "cache");
+  if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const cachePath = join(cacheDir, `${command}-${ts}.md`);
+  writeFileSync(cachePath, prompt, "utf-8");
+  return cachePath;
+}
+
+/**
+ * Read and prepare a prompt from an agent file.
+ * Strips YAML frontmatter, substitutes $ARGUMENTS safely.
+ */
+function buildPrompt(agentFile, rawArgs) {
+  const raw = readFileSync(agentFile, "utf-8").replace(/^---[\s\S]*?---\n?/, "").trim();
+
+  if (!rawArgs) {
+    // Remove $ARGUMENTS and any trailing whitespace left behind
+    return raw.replace(/\$ARGUMENTS/g, "").replace(/[ \t]+\n/g, "\n").trim();
+  }
+
+  // Validate: warn if the substituted value looks like it might break the prompt.
+  // We don't block — just surface it so users know what happened.
+  if (rawArgs.includes("`") || rawArgs.includes("---")) {
+    process.stderr.write(
+      `Warning: argument contains characters that may affect prompt formatting.\n`,
+    );
+  }
+
+  return raw.replace(/\$ARGUMENTS/g, rawArgs);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────
+
+const [, , mode, ...rest] = process.argv;
+// Join with a space but preserve multi-word quoted args passed by the shell
+const extraArgs = rest.join(" ").trim();
+
+if (mode === "--help" || mode === "-h") {
+  printUsage();
+  process.exit(0);
+}
+
+// Warn if args are passed to a no-argument command
+if (mode && NO_ARGS_MODES.has(mode) && extraArgs) {
+  process.stderr.write(
+    `Warning: "${mode}" takes no arguments — ignoring "${extraArgs}"\n`,
+  );
+}
+
+// No command → show the interactive career-ops menu via the main router agent
+if (!mode) {
+  const routerFile = join(__dir, ".agents", "career-ops.md");
+  const routerPrompt = buildPrompt(routerFile, "");
+
+  console.log("career-ops -- Command Center\n");
+
+  const result = spawnSync("codex", [routerPrompt], { stdio: "inherit", encoding: "utf-8" });
+  logRun({ command: "(menu)", args: "", status: result.error ? "fallback" : "launched" });
+
+  if (result.error?.code === "ENOENT") {
+    console.log(`Available commands:
+  node codex-runner.mjs scan
+  node codex-runner.mjs evaluate "URL or JD text"
+  node codex-runner.mjs pdf
+  node codex-runner.mjs pipeline
+  node codex-runner.mjs tracker
+  node codex-runner.mjs patterns
+  node codex-runner.mjs followup
+  node codex-runner.mjs --help   (full list)
+
+Install the Codex CLI to run these automatically: https://github.com/openai/codex`);
+  }
+  process.exit(result.status ?? 0);
+}
+
+// Resolve the agent file: known mode → specific file, else main router
+const agentFile = MODES.includes(mode)
+  ? join(__dir, ".agents", `career-ops-${mode}.md`)
+  : join(__dir, ".agents", "career-ops.md");
+
+if (!existsSync(agentFile)) {
+  console.error(`Error: agent file not found — ${agentFile}`);
+  console.error(`Run "node codex-runner.mjs --help" to see available commands.`);
+  logRun({ command: mode, args: extraArgs, status: "error", reason: "agent file not found" });
+  process.exit(1);
+}
+
+const prompt = buildPrompt(agentFile, NO_ARGS_MODES.has(mode) ? "" : extraArgs);
+
+// Attempt to invoke the Codex CLI
+const result = spawnSync("codex", [prompt], {
+  stdio: "inherit",
+  encoding: "utf-8",
+});
+
+if (result.error?.code === "ENOENT") {
+  // Codex CLI not found — cache the prompt and tell the user exactly where it is
+  const cachePath = cachePrompt(mode, prompt);
+  const relCache = cachePath.replace(__dir + "/", "");
+
+  logRun({ command: mode, args: extraArgs, status: "fallback", cache: relCache });
+
+  console.error("Codex CLI not found in PATH.\n");
+  console.log(`Prompt cached to: ${relCache}\n`);
+  console.log("Open that file and paste its contents into your Codex session, or:\n");
+  console.log("─".repeat(72));
+  console.log(prompt);
+  console.log("─".repeat(72));
+  console.log("\nInstall the Codex CLI: https://github.com/openai/codex");
+  process.exit(0);
+}
+
+logRun({ command: mode, args: extraArgs, status: result.status === 0 ? "ok" : "error", exitCode: result.status });
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -21,6 +21,107 @@ npm install
 npx playwright install chromium
 ```
 
+## Usage
+
+Career-Ops ships a runner script that bridges `.agents/` prompt files to the
+Codex CLI. It reads the matching agent file, substitutes any arguments, and
+invokes `codex` with the assembled prompt. If the Codex CLI is not installed,
+it prints the prompt so you can paste it manually.
+
+```bash
+# show the command menu
+node codex-runner.mjs
+
+# scan portals for new offers
+node codex-runner.mjs scan
+
+# evaluate a job URL (full auto-pipeline)
+node codex-runner.mjs evaluate "https://example.com/job/123"
+
+# evaluate a local JD file
+node codex-runner.mjs evaluate "$(cat jds/my-role.md)"
+
+# generate ATS-optimized PDF
+node codex-runner.mjs pdf
+
+# check application tracker status
+node codex-runner.mjs tracker
+```
+
+**npm shortcuts** (most common commands):
+
+```bash
+npm run codex              # show menu
+npm run codex:scan
+npm run codex:evaluate -- "https://example.com/job/123"
+npm run codex:pdf
+npm run codex:tracker
+npm run codex:pipeline
+npm run codex:patterns
+npm run codex:followup
+```
+
+## Codex Commands
+
+Individual agent files are available under `.agents/` and map 1-to-1 with
+Claude Code commands:
+
+| Agent file | Claude Code equivalent | Description |
+|------------|------------------------|-------------|
+| `.agents/career-ops.md` | `/career-ops` | Main router: show menu or auto-pipeline a JD/URL |
+| `.agents/career-ops-evaluate.md` | `/career-ops oferta` | Evaluate job offer (A-F scoring, no auto PDF) |
+| `.agents/career-ops-compare.md` | `/career-ops ofertas` | Compare and rank multiple offers |
+| `.agents/career-ops-scan.md` | `/career-ops scan` | Scan job portals for new offers |
+| `.agents/career-ops-pdf.md` | `/career-ops pdf` | Generate ATS-optimized CV PDF |
+| `.agents/career-ops-pipeline.md` | `/career-ops pipeline` | Process pending URLs from `data/pipeline.md` |
+| `.agents/career-ops-apply.md` | `/career-ops apply` | Live application assistant |
+| `.agents/career-ops-tracker.md` | `/career-ops tracker` | Application status overview |
+| `.agents/career-ops-contact.md` | `/career-ops contacto` | LinkedIn outreach: find contacts + draft message |
+| `.agents/career-ops-deep.md` | `/career-ops deep` | Deep company research |
+| `.agents/career-ops-batch.md` | `/career-ops batch` | Batch processing with parallel workers |
+| `.agents/career-ops-training.md` | `/career-ops training` | Evaluate course/cert against goals |
+| `.agents/career-ops-project.md` | `/career-ops project` | Evaluate portfolio project idea |
+| `.agents/career-ops-patterns.md` | `/career-ops patterns` | Analyze rejection patterns and improve targeting |
+| `.agents/career-ops-followup.md` | `/career-ops followup` | Follow-up cadence tracker: flag overdue, generate drafts |
+
+## Limitations
+
+Codex does not have a native skill-loading mechanism equivalent to Claude
+Code's `/career-ops` slash commands. The `.agents/` files are prompt
+templates — `codex-runner.mjs` is the glue layer that makes them callable
+from the terminal.
+
+Current known gaps vs. the Claude Code experience:
+
+- **No auto-routing on file open.** Claude Code detects a pasted JD
+  automatically; with Codex you need to run
+  `node codex-runner.mjs evaluate "URL"` explicitly.
+- **Playwright dependency.** PDF generation and live offer verification
+  require `npx playwright install chromium`. These work the same as in
+  Claude Code once installed.
+- **Batch mode.** The `batch` command spawns parallel workers via
+  `claude -p`. This is Claude-specific and will not work in a Codex
+  session — use single evaluations instead.
+
+## Example Session
+
+```bash
+$ npm run codex:scan
+
+> career-ops@1.3.0 codex:scan
+> node codex-runner.mjs scan
+
+Scanning portals defined in portals.yml...
+Checking 12 companies × 3 search queries...
+Found 4 new offers not in scan-history.tsv:
+  → Acme Corp — Staff AI Engineer
+  → Beta Labs — Head of Applied AI
+  → Gamma Inc — ML Platform Lead
+  → Delta Co — AI Product Manager
+Writing 4 entries to data/pipeline.md
+Done. Run "node codex-runner.mjs pipeline" to evaluate them.
+```
+
 ## Recommended Starting Prompts
 
 - `Evaluate this job URL with Career-Ops and run the full pipeline.`

--- a/package.json
+++ b/package.json
@@ -14,7 +14,16 @@
     "update": "node update-system.mjs apply",
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
-    "scan": "node scan.mjs"
+    "scan": "node scan.mjs",
+    "codex": "node codex-runner.mjs",
+    "codex:scan": "node codex-runner.mjs scan",
+    "codex:evaluate": "node codex-runner.mjs evaluate",
+    "codex:pdf": "node codex-runner.mjs pdf",
+    "codex:pipeline": "node codex-runner.mjs pipeline",
+    "codex:tracker": "node codex-runner.mjs tracker",
+    "codex:patterns": "node codex-runner.mjs patterns",
+    "codex:followup": "node codex-runner.mjs followup",
+    "codex:validate": "node validate-agents.mjs"
   },
   "keywords": [
     "ai",

--- a/validate-agents.mjs
+++ b/validate-agents.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * validate-agents.mjs
+ *
+ * Verifies that .agents/ prompt files are in sync with modes/.
+ * Catches silent divergence when modes/ is updated but .agents/ is not —
+ * or vice versa.
+ *
+ * Checks:
+ *   1. Every expected agent file exists in .agents/
+ *   2. Every mode file referenced by an agent file exists in modes/
+ *   3. No unregistered agent files are present
+ *   4. Commands that accept $ARGUMENTS declare it; commands that don't, don't
+ *
+ * Usage:
+ *   node validate-agents.mjs
+ *   npm run codex:validate
+ *
+ * Exits 0 on success, 1 on any error.
+ */
+
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+
+// Maps each agent file to the mode files it must reference.
+// Update this map whenever a new mode or agent is added.
+const AGENT_MODE_MAP = {
+  "career-ops.md":          ["modes/_shared.md"],
+  "career-ops-evaluate.md": ["modes/_shared.md", "modes/oferta.md"],
+  "career-ops-compare.md":  ["modes/_shared.md", "modes/ofertas.md"],
+  "career-ops-scan.md":     ["modes/_shared.md", "modes/scan.md"],
+  "career-ops-pdf.md":      ["modes/_shared.md", "modes/pdf.md"],
+  "career-ops-pipeline.md": ["modes/_shared.md", "modes/pipeline.md"],
+  "career-ops-apply.md":    ["modes/_shared.md", "modes/apply.md"],
+  "career-ops-batch.md":    ["modes/_shared.md", "modes/batch.md"],
+  "career-ops-tracker.md":  ["modes/tracker.md"],
+  "career-ops-contact.md":  ["modes/_shared.md", "modes/contacto.md"],
+  "career-ops-deep.md":     ["modes/deep.md"],
+  "career-ops-training.md": ["modes/training.md"],
+  "career-ops-project.md":  ["modes/project.md"],
+  "career-ops-patterns.md": ["modes/patterns.md"],
+  "career-ops-followup.md": ["modes/followup.md"],
+};
+
+// Commands that must NOT contain $ARGUMENTS (they take no user input).
+const NO_ARGS_AGENTS = new Set([
+  "career-ops-scan.md",
+  "career-ops-pdf.md",
+  "career-ops-pipeline.md",
+  "career-ops-tracker.md",
+  "career-ops-patterns.md",
+  "career-ops-followup.md",
+]);
+
+let errors = 0;
+let warnings = 0;
+
+function err(msg)  { console.error(`  ✗ ${msg}`); errors++; }
+function warn(msg) { console.warn(`  ⚠ ${msg}`);  warnings++; }
+function ok(msg)   { console.log(`  ✓ ${msg}`); }
+
+// ── 1. Every expected agent file must exist ────────────────────────────────
+console.log("\nChecking agent files exist…");
+for (const agentFile of Object.keys(AGENT_MODE_MAP)) {
+  const p = join(__dir, ".agents", agentFile);
+  if (existsSync(p)) {
+    ok(`.agents/${agentFile}`);
+  } else {
+    err(`Missing agent file: .agents/${agentFile}`);
+  }
+}
+
+// ── 2. Every referenced mode file must exist ──────────────────────────────
+console.log("\nChecking referenced mode files exist…");
+for (const [agentFile, modeFiles] of Object.entries(AGENT_MODE_MAP)) {
+  for (const modeFile of modeFiles) {
+    const p = join(__dir, modeFile);
+    if (existsSync(p)) {
+      ok(`${modeFile}  (referenced by .agents/${agentFile})`);
+    } else {
+      err(`${modeFile} not found — referenced by .agents/${agentFile}`);
+    }
+  }
+}
+
+// ── 3. No unregistered agent files ────────────────────────────────────────
+console.log("\nChecking for unregistered agent files…");
+const agentsDir = join(__dir, ".agents");
+const actualFiles = readdirSync(agentsDir).filter((f) => f.endsWith(".md"));
+for (const f of actualFiles) {
+  if (AGENT_MODE_MAP[f]) {
+    ok(`.agents/${f} is registered`);
+  } else {
+    warn(`Unregistered agent file: .agents/${f} — add it to AGENT_MODE_MAP in validate-agents.mjs`);
+  }
+}
+
+// ── 4. $ARGUMENTS consistency ─────────────────────────────────────────────
+console.log("\nChecking $ARGUMENTS consistency…");
+for (const agentFile of Object.keys(AGENT_MODE_MAP)) {
+  const p = join(__dir, ".agents", agentFile);
+  if (!existsSync(p)) continue;
+
+  const content = readFileSync(p, "utf-8");
+  const hasArgs = content.includes("$ARGUMENTS");
+
+  if (NO_ARGS_AGENTS.has(agentFile) && hasArgs) {
+    warn(`.agents/${agentFile} contains $ARGUMENTS but this command takes no user input`);
+  } else if (!NO_ARGS_AGENTS.has(agentFile) && !hasArgs && agentFile !== "career-ops.md") {
+    warn(`.agents/${agentFile} takes user input but $ARGUMENTS is not present`);
+  } else {
+    ok(`.agents/${agentFile} — $ARGUMENTS usage correct`);
+  }
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────
+console.log("\n" + "─".repeat(60));
+if (errors === 0 && warnings === 0) {
+  console.log("✅  All checks passed — .agents/ is in sync with modes/");
+  process.exit(0);
+}
+if (errors > 0) console.error(`\n✗  ${errors} error(s) — fix before committing`);
+if (warnings > 0) console.warn(`⚠  ${warnings} warning(s)`);
+process.exit(errors > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #<165>

## What this adds

Codex doesn't have a native skill-loading mechanism like Claude Code's
/career-ops commands. This PR adds a complete execution layer:

- `.agents/` — 15 prompt files (one per command) that instruct Codex to
  load the correct `modes/` files, matching the Claude Code skill 1-to-1
- `codex-runner.mjs` — CLI bridge that reads an agent file, substitutes
  arguments safely, and invokes the Codex CLI. Falls back gracefully:
  caches the prompt to `.agents/cache/` and logs the run to
  `runs/codex-runs.jsonl`
- `validate-agents.mjs` — sync checker: errors if `.agents/` references
  a `modes/` file that doesn't exist, catches silent divergence
- `npm run codex:*` shortcuts for the most common commands
- Updated `AGENTS.md`, `CLAUDE.md`, `docs/CODEX.md` with usage examples,
  command table, and an honest Limitations section

## Testing

node codex-runner.mjs --help   # usage
node codex-runner.mjs scan     # fallback path (caches prompt, logs run)
node validate-agents.mjs       # all checks pass
npm run codex:validate
