### PR TITLE
fix batch-runner grep -P portability issue on macOS

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -365,7 +365,7 @@ process_offer() {
     # Try to extract score from worker output
     local score="-"
     local score_match
-    score_match=$(grep -oP '"score":\s*[\d.]+' "$log_file" 2>/dev/null | head -1 | grep -oP '[\d.]+' || true)
+   score_match=$(sed -nE 's/.*"score":[[:space:]]*([0-9.]+).*/\1/p' "$log_file" 2>/dev/null | head -1 || true)
     if [[ -n "$score_match" ]]; then
       score="$score_match"
     fi


### PR DESCRIPTION
## Summary

Fix `batch/batch-runner.sh` score extraction so it does not rely on `grep -P`, which breaks on macOS/BSD grep.

## Changes made

* replaced `grep -oP` score parsing with portable `sed -E` parsing
* kept the existing behavior of extracting the first score from the worker log

## Related issue

Closes #141
