### PR TITLE
fix(test-all): scan only tracked files via git grep

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -175,18 +175,35 @@ const leakPatterns = [
 ];
 
 const scanExtensions = ['md', 'yml', 'html', 'mjs', 'sh', 'go', 'json'];
-const excludeDirs = ['node_modules', '.git', 'dashboard/go.sum'];
-const allowedFiles = ['README.md', 'LICENSE', 'CITATION.cff', 'CONTRIBUTING.md',
-  'package.json', '.github/FUNDING.yml', 'CLAUDE.md', 'go.mod', 'test-all.mjs'];
+const allowedFiles = [
+  // English README + localized translations (all legitimately credit Santiago)
+  'README.md', 'README.es.md', 'README.ja.md', 'README.ko-KR.md',
+  'README.pt-BR.md', 'README.ru.md',
+  // Standard project files
+  'LICENSE', 'CITATION.cff', 'CONTRIBUTING.md',
+  'package.json', '.github/FUNDING.yml', 'CLAUDE.md', 'go.mod', 'test-all.mjs',
+  // Community / governance files (added in v1.3.0, all legitimately reference the maintainer)
+  'CODE_OF_CONDUCT.md', 'GOVERNANCE.md', 'SECURITY.md', 'SUPPORT.md',
+  '.github/SECURITY.md',
+  // Dashboard credit string
+  'dashboard/internal/ui/screens/pipeline.go',
+];
+
+// Build pathspec for git grep — only scan tracked files matching these
+// extensions. This is what `grep -rn` was trying to do, but git-aware:
+// untracked files (debate artifacts, AI tool scratch, local plans/) and
+// gitignored files can't trigger false positives because they were never
+// going to reach a commit anyway.
+const grepPathspec = scanExtensions.map(e => `'*.${e}'`).join(' ');
 
 let leakFound = false;
 for (const pattern of leakPatterns) {
   const result = run(
-    `grep -rn "${pattern}" --include="*.{${scanExtensions.join(',')}}" . 2>/dev/null | grep -v node_modules | grep -v ".git/" | grep -v go.sum`
+    `git grep -n "${pattern}" -- ${grepPathspec} 2>/dev/null`
   );
   if (result) {
     for (const line of result.split('\n')) {
-      const file = line.split(':')[0].replace('./', '');
+      const file = line.split(':')[0];
       if (allowedFiles.some(a => file.includes(a))) continue;
       if (file.includes('dashboard/go.mod')) continue;
       warn(`Possible personal data in ${file}: "${pattern}"`);
@@ -202,8 +219,10 @@ if (!leakFound) {
 
 console.log('\n7. Absolute path check');
 
+// Same git grep approach: only scans tracked files. Untracked AI tool
+// outputs, local debate artifacts, etc. can't false-positive here.
 const absPathResult = run(
-  `grep -rn "/Users/" --include="*.mjs" --include="*.sh" --include="*.md" --include="*.go" --include="*.yml" . 2>/dev/null | grep -v node_modules | grep -v ".git/" | grep -v README.md | grep -v LICENSE | grep -v go.sum | grep -v CLAUDE.md | grep -v test-all.mjs`
+  `git grep -n "/Users/" -- '*.mjs' '*.sh' '*.md' '*.go' '*.yml' 2>/dev/null | grep -v README.md | grep -v LICENSE | grep -v CLAUDE.md | grep -v test-all.mjs`
 );
 if (!absPathResult) {
   pass('No absolute paths in code files');


### PR DESCRIPTION
Closes #184.

## Summary

The personal-data-leak check and absolute-path check in \`test-all.mjs\` use bare \`grep -rn .\`, which walks the entire working directory and only excludes a few hardcoded paths. This causes two opposite-sign bugs documented in #184:

1. **False positives on untracked files** — local-only debate artifacts, plan drafts, AI scratch dirs, etc. fail the test even though they can never reach a commit.
2. **Silent misses on tracked files** — brace expansion in \`--include=\"*.{md,...}\"\` apparently fails to match i18n README files added in v1.3.0, so the leak check has been running green while 36+ matches in those files went unscanned.

## Approach

Replace \`grep -rn\` with \`git grep -n\` in both checks. \`git grep\` only sees files in the index, so:

- Untracked files can never false-positive
- \`.gitignore\` is honored automatically
- The manual \`| grep -v node_modules | grep -v .git/ | grep -v go.sum\` pipeline becomes dead code
- Native pathspec syntax replaces brace expansion that wasn't working
- The i18n READMEs (\`README.es.md\`, \`README.ja.md\`, \`README.ko-KR.md\`, \`README.pt-BR.md\`, \`README.ru.md\`) get scanned for the first time

## Side effect: 36+ previously-hidden matches surfaced

The more thorough scan picks up legitimate maintainer credits in v1.3.0 community files. Added them to \`allowedFiles\`:

- All 5 localized READMEs
- \`CODE_OF_CONDUCT.md\`, \`GOVERNANCE.md\`, \`SECURITY.md\`, \`SUPPORT.md\`, \`.github/SECURITY.md\`
- \`dashboard/internal/ui/screens/pipeline.go\` (credit string)

These are all legitimate references to Santiago / santifer.io as the maintainer, so they're correctly classified as allowed rather than suppressed.

## Verification

| Test | Before fix | After fix |
|------|-----------|-----------|
| \`node test-all.mjs --quick\` (clean tree) | 64 pass / 6 fail / 0 warn | 63 pass / **0 fail** / **0 warn** |
| Plant \`/Users/santifer/test\` in tracked \`doctor.mjs\` | Caught ✅ | Caught ✅ (no regression) |
| Plant \`/Users/foo\` in untracked \`debates/test/test.md\` | Failed ❌ (false positive) | Not flagged ✅ |
| Untracked file with \"Santiago\" | (would false-positive) | Not flagged ✅ |

Diff stats: \`+25 -6\` in a single file. No new dependencies.

## Test plan

- [x] \`node test-all.mjs --quick\` → all green on a clean working tree
- [x] Regression test: planted abs path in tracked file still fails
- [x] False-positive test: planted abs path in untracked file does not fail
- [x] Manual: confirmed git grep honors .gitignore
- [ ] (Reviewer) verify on a different OS / git version if concerned about portability

## Notes

- This is independent of #181 (filter-expired-results). They touch different parts of test-all.mjs and don't conflict.
- I would have had to bake the \`debates/\` exclusion into my other PR otherwise; this fix is the cleaner solution and benefits any future contributor running AI tools that drop artifacts in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)