### PR TITLE
feat(dashboard): add Catppuccin Latte light theme with auto-detection

### DIFF
--- a/dashboard/go.mod
+++ b/dashboard/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/muesli/termenv v0.16.0
 )
 
 require (
@@ -23,7 +24,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/dashboard/go.sum
+++ b/dashboard/go.sum
@@ -1,5 +1,7 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
+github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco3ej+ngLk1kk=
@@ -10,6 +12,8 @@ github.com/charmbracelet/x/ansi v0.11.5 h1:NBWeBpj/lJPE3Q5l+Lusa4+mH6v7487OP8K0r
 github.com/charmbracelet/x/ansi v0.11.5/go.mod h1:2JNYLgQUsyqaiLovhU2Rv/pb8r6ydXKS3NIttu3VGZQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a h1:G99klV19u0QnhiizODirwVksQB91TJKV/UaTnACcG30=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/clipperhouse/displaywidth v0.9.0 h1:Qb4KOhYwRiN3viMv1v/3cTBlz3AcAZX3+y9OLhMtAtA=

--- a/dashboard/internal/theme/catppuccin_latte.go
+++ b/dashboard/internal/theme/catppuccin_latte.go
@@ -1,0 +1,24 @@
+package theme
+
+import "github.com/charmbracelet/lipgloss"
+
+func newCatppuccinLatte() Theme {
+	return Theme{
+		// Catppuccin Latte palette
+		Base:    lipgloss.Color("#eff1f5"),
+		Surface: lipgloss.Color("#dce0e8"),
+		Overlay: lipgloss.Color("#9ca0b0"),
+		Text:    lipgloss.Color("#4c4f69"),
+		Subtext: lipgloss.Color("#5c5f77"),
+
+		// Accents
+		Blue:   lipgloss.Color("#1e66f5"),
+		Mauve:  lipgloss.Color("#8839ef"),
+		Green:  lipgloss.Color("#40a02b"),
+		Yellow: lipgloss.Color("#df8e1d"),
+		Sky:    lipgloss.Color("#04a5e5"),
+		Peach:  lipgloss.Color("#fe640b"),
+		Red:    lipgloss.Color("#d20f39"),
+		Pink:   lipgloss.Color("#ea76cb"),
+	}
+}

--- a/dashboard/internal/theme/theme.go
+++ b/dashboard/internal/theme/theme.go
@@ -3,6 +3,7 @@ package theme
 
 import (
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 // Theme holds all color definitions for the pipeline dashboard.
@@ -25,11 +26,18 @@ type Theme struct {
 	Pink   lipgloss.Color
 }
 
-// NewTheme creates a theme by name. Currently only "catppuccin-mocha" is supported.
+// NewTheme creates a theme by name. Use "auto" or "" to detect from terminal background.
 func NewTheme(name string) Theme {
 	switch name {
-	case "catppuccin-mocha", "":
+	case "catppuccin-mocha":
 		return newCatppuccinMocha()
+	case "catppuccin-latte":
+		return newCatppuccinLatte()
+	case "auto", "":
+		if termenv.HasDarkBackground() {
+			return newCatppuccinMocha()
+		}
+		return newCatppuccinLatte()
 	default:
 		return newCatppuccinMocha()
 	}

--- a/dashboard/main.go
+++ b/dashboard/main.go
@@ -26,6 +26,7 @@ type appModel struct {
 	viewer        screens.ViewerModel
 	state         viewState
 	careerOpsPath string
+	theme         theme.Theme
 }
 
 func (m appModel) Init() tea.Cmd {
@@ -61,7 +62,7 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		metrics := data.ComputeMetrics(apps)
 		old := m.pipeline
 		m.pipeline = screens.NewPipelineModel(
-			theme.NewTheme("catppuccin-mocha"),
+			m.theme,
 			apps, metrics, m.careerOpsPath,
 			old.Width(), old.Height(),
 		)
@@ -70,7 +71,7 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case screens.PipelineOpenReportMsg:
 		m.viewer = screens.NewViewerModel(
-			theme.NewTheme("catppuccin-mocha"),
+			m.theme,
 			msg.Path, msg.Title,
 			m.pipeline.Width(), m.pipeline.Height(),
 		)
@@ -135,7 +136,7 @@ func main() {
 	metrics := data.ComputeMetrics(apps)
 
 	// Batch-load all report summaries
-	t := theme.NewTheme("catppuccin-mocha")
+	t := theme.NewTheme("auto")
 	pm := screens.NewPipelineModel(t, apps, metrics, careerOpsPath, 120, 40)
 
 	for _, app := range apps {
@@ -151,6 +152,7 @@ func main() {
 	m := appModel{
 		pipeline:      pm,
 		careerOpsPath: careerOpsPath,
+		theme:         t,
 	}
 
 	p := tea.NewProgram(m, tea.WithAltScreen())


### PR DESCRIPTION
Closes #186.

## Summary

Adds a Catppuccin Latte palette to the dashboard and auto-detects the terminal background at startup so light-theme users get a readable TUI.

- New `newCatppuccinLatte()` palette (Catppuccin Latte colors).
- `theme.NewTheme` now accepts `catppuccin-latte`, `catppuccin-mocha`, and `auto` (default). `auto` uses `termenv.HasDarkBackground()`.
- Detection happens **once** in `main()` before entering the alt-screen (termenv returns wrong results inside the alt-screen) and is stored on `appModel`, so subsequent screen constructions reuse the same `Theme` instead of re-detecting.
- `github.com/muesli/termenv` promoted from indirect to direct in `go.mod`.

## Test plan

- [x] `go build ./...` in `dashboard/`
- [x] Launch on Ghostty with `catppuccin-latte` theme → dashboard renders in Latte palette (header/footer/body readable)
- [x] Launch on a dark terminal → dashboard renders in Mocha palette (unchanged from current behavior)
- [ ] `NewTheme("catppuccin-mocha")` / `NewTheme("catppuccin-latte")` still work as explicit overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)