### PR TITLE
feat: add commit message convention and validation hook

### DIFF
--- a/.github/commit-convention.md
+++ b/.github/commit-convention.md
@@ -1,0 +1,62 @@
+# Commit Message Convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) to keep the git history readable and to enable automated tooling (changelogs, version bumps).
+
+## Format
+
+```
+type(scope): description
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type       | When to use                                      |
+|------------|--------------------------------------------------|
+| `feat`     | A new feature or capability                      |
+| `fix`      | A bug fix                                        |
+| `docs`     | Documentation-only changes                       |
+| `style`    | Formatting, missing semicolons — no logic change |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test`     | Adding or updating tests                         |
+| `chore`    | Maintenance tasks (deps, config, tooling)        |
+| `ci`       | CI/CD pipeline changes                           |
+| `perf`     | Performance improvements                         |
+| `build`    | Build system or external dependency changes      |
+| `release`  | Version release commits                          |
+
+### Scope (optional)
+
+A short noun describing the area of the codebase:
+
+- `dashboard` — Go TUI dashboard
+- `modes` — skill mode files
+- `scripts` — `.mjs` utilities
+- `batch` — batch processing
+- `templates` — CV templates, portals, states
+- `docs` — documentation files
+
+### Examples
+
+```
+feat(modes): add German language support
+fix(scripts): filter expired links before pipeline
+chore: remove package-lock.json and add to gitignore
+docs(readme): update bilingual split layout
+release: v1.2.0
+```
+
+### Breaking Changes
+
+Append `!` after the type/scope to signal a breaking change:
+
+```
+feat(modes)!: restructure shared archetype format
+```
+
+## Validation
+
+Run `npm run setup-hooks` to install a local commit-msg hook that validates your messages before they are committed.

--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Validates commit messages against Conventional Commits format.
+# Install: npm run setup-hooks
+
+commit_msg=$(head -1 "$1")
+
+if [[ "$commit_msg" =~ ^Merge ]]; then
+  exit 0
+fi
+
+if [[ "$commit_msg" =~ ^Revert ]]; then
+  exit 0
+fi
+
+# type(scope)!: description
+# - scope is optional, must not contain closing paren
+# - ! for breaking change is optional
+# - description must have at least one non-space char after ": "
+pattern='^(fix|feat|chore|docs|refactor|test|ci|release|style|perf|build)(\([^)]+\))?!?:[[:space:]]+[^[:space:]]'
+
+if [[ "$commit_msg" =~ $pattern ]]; then
+  exit 0
+fi
+
+echo ""
+echo "ERROR: Commit message does not follow Conventional Commits format."
+echo ""
+echo "  Expected: type(scope): description"
+echo "  Got:      $commit_msg"
+echo ""
+echo "  Valid types: fix | feat | chore | docs | refactor | test | ci | release | style | perf | build"
+echo "  Scope is optional: feat(dashboard): add chart view"
+echo ""
+echo "  See .github/commit-convention.md for details."
+echo ""
+exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 ## Stack and Conventions
 
 - Node.js (mjs modules), Playwright (PDF + scraping), YAML (config), HTML/CSS (template), Markdown (data), Canva MCP (optional visual CV)
+- **Commit messages** must use Conventional Commits format: `type(scope): description` (see `.github/commit-convention.md`)
 - Scripts in `.mjs`, configuration in YAML
 - Output in `output/` (gitignored), Reports in `reports/`
 - JDs in `jds/` (referenced as `local:jds/{file}` in pipeline.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,15 +14,28 @@ PRs without a corresponding issue may be closed if they don't align with the pro
 - Includes a clear description of what changed and why
 - Follows the existing code style and project philosophy (simple, minimal, quality over quantity)
 
+## Commit Messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). Every commit message must follow:
+
+```
+type(scope): description
+```
+
+Valid types: `fix`, `feat`, `chore`, `docs`, `refactor`, `test`, `ci`, `release`, `style`, `perf`, `build`. Scope is optional.
+
+Run `npm run setup-hooks` to install a local git hook that validates your messages before commit. See [.github/commit-convention.md](.github/commit-convention.md) for full details and examples.
+
 ## Quick Start
 
 1. Open an issue to discuss your idea
 2. Fork the repo
 3. Create a branch (`git checkout -b feature/my-feature`)
-4. Make your changes
-5. Test with a fresh clone (see [docs/SETUP.md](docs/SETUP.md))
-6. Commit and push
-7. Open a Pull Request referencing the issue
+4. Run `npm run setup-hooks` to enable commit message validation
+5. Make your changes
+6. Test with a fresh clone (see [docs/SETUP.md](docs/SETUP.md))
+7. Commit and push
+8. Open a Pull Request referencing the issue
 
 ## What to Contribute
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "update:check": "node update-system.mjs check",
     "update": "node update-system.mjs apply",
     "rollback": "node update-system.mjs rollback",
-    "liveness": "node check-liveness.mjs"
+    "liveness": "node check-liveness.mjs",
+    "setup-hooks": "ln -sf ../../.github/hooks/commit-msg .git/hooks/commit-msg && echo 'commit-msg hook installed'"
   },
   "keywords": ["ai", "job-search", "claude-code", "career", "automation"],
   "author": "Santiago Fernández de Valderrama <hi@santifer.io> (https://santifer.io)",


### PR DESCRIPTION
## Summary
- Add `.github/commit-convention.md` documenting Conventional Commits standard with types, scopes, and examples
- Add `.github/hooks/commit-msg` shell script that validates messages against the pattern — rejects empty descriptions, empty scopes, invalid types, and non-conforming formats
- Add `setup-hooks` npm script for opt-in local hook installation via `npm run setup-hooks`
- Update `CONTRIBUTING.md` with commit message section and updated Quick Start steps
- Update `CLAUDE.md` Stack and Conventions with commit format rule

## Test plan
- [x] Hook accepts valid messages: `feat: x`, `fix(dashboard): y`, `feat(modes)!: z`, `release: v1.2.0`, `Merge ...`, `Revert ...`
- [x] Hook rejects invalid messages: imperative (`Add X`), empty description (`fix: `), empty scope (`feat(): x`), bad type (`invalid: x`), branch-style (`Feat/interview`), empty string
- [ ] Run `npm run setup-hooks` on fresh clone to verify symlink


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: claude
score: 1.0
cost-tier: Low (10-50k)
iterations: 2
duration: 14m53s
run-started: 2026-04-12T02:00:01+05:30
nightshift:metadata -->
