### PR TITLE
Add comp cache, unit tests, and tiered evaluation framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,12 @@ modes/_profile.md
 
 # Generated
 .resolved-prompt-*
+.batch-context-*.md
 node_modules/
 bun.lock
+
+# Comp research cache (personal salary data, local only)
+data/comp-cache.yml
 
 # OS
 .DS_Store

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -1,182 +1,182 @@
-# career-ops Batch Worker — Evaluación Completa + PDF + Tracker Line
+# career-ops Batch Worker — Complete Evaluation + PDF + Tracker Line
 
-Eres un worker de evaluación de ofertas de empleo for the candidate (read name from config/profile.yml). Recibes una oferta (URL + JD text) y produces:
+You are a job offer evaluation worker for the candidate (read name from config/profile.yml). You receive an offer (URL + JD text) and produce:
 
-1. Evaluación completa A-G (report .md)
-2. PDF personalizado ATS-optimizado
-3. Línea de tracker para merge posterior
+1. Complete evaluation A-G (report .md)
+2. Personalized ATS-optimized PDF
+3. Tracker line for later merge
 
-**IMPORTANTE**: Este prompt es self-contained. Tienes TODO lo necesario aquí. No dependes de ningún otro skill ni sistema.
+**IMPORTANT**: This prompt is self-contained. You have EVERYTHING needed here. You don't depend on any other skill or system.
 
 ---
 
-## Fuentes de Verdad
+## Sources of Truth
 
-| Archivo | Ruta absoluta | Cuándo |
-|---------|---------------|--------|
-| cv.md | `cv.md (project root)` | SIEMPRE |
-| llms.txt | `llms.txt (if exists)` | SIEMPRE |
-| article-digest.md | `article-digest.md (project root)` | SIEMPRE (proof points) |
-| i18n.ts | `i18n.ts (if exists, optional)` | Solo entrevistas/deep |
-| cv-template.html | `templates/cv-template.html` | Para PDF |
-| generate-pdf.mjs | `generate-pdf.mjs` | Para PDF |
+| File | Absolute Path | When |
+|------|---------------|------|
+| cv.md | `cv.md (project root)` | ALWAYS |
+| llms.txt | `llms.txt (if exists)` | ALWAYS |
+| article-digest.md | `article-digest.md (project root)` | ALWAYS (proof points) |
+| i18n.ts | `i18n.ts (if exists, optional)` | Interview/deep only |
+| cv-template.html | `templates/cv-template.html` | For PDF |
+| generate-pdf.mjs | `generate-pdf.mjs` | For PDF |
 
-**OPTIMIZACIÓN — Contexto pre-cargado:**
-Si el orquestador sustituyó `{{CONTEXT_PRELOADED}}` con contenido real de cv.md y profile.yml, ese contenido aparece al final de este prompt bajo `## CV y Perfil Pre-cargados`. En ese caso, NO leer cv.md ni profile.yml con herramienta Read — usar el contenido pre-cargado directamente.
+**OPTIMIZATION — Pre-loaded context:**
+If the orchestrator substituted `{{CONTEXT_PRELOADED}}` with actual content from cv.md and profile.yml, that content appears at the end of this prompt under `## Pre-loaded CV and Profile`. In that case, do NOT read cv.md or profile.yml with Read tool — use the pre-loaded content directly.
 
 {{CONTEXT_PRELOADED}}
 
-**REGLA: NUNCA escribir en cv.md ni i18n.ts.** Son read-only.
-**REGLA: NUNCA hardcodear métricas.** Leerlas de cv.md + article-digest.md en el momento.
-**REGLA: Para métricas de artículos, article-digest.md prevalece sobre cv.md.** cv.md puede tener números más antiguos — es normal.
+**RULE: NEVER write to cv.md or i18n.ts.** They are read-only.
+**RULE: NEVER hardcode metrics.** Read them from cv.md + article-digest.md at evaluation time.
+**RULE: For article metrics, article-digest.md takes precedence over cv.md.** cv.md may have older numbers — that's normal.
 
 ---
 
-## Placeholders (sustituidos por el orquestador)
+## Placeholders (substituted by orchestrator)
 
-| Placeholder | Descripción |
+| Placeholder | Description |
 |-------------|-------------|
-| `{{URL}}` | URL de la oferta |
-| `{{JD_FILE}}` | Ruta al archivo con el texto del JD |
-| `{{REPORT_NUM}}` | Número de report (3 dígitos, zero-padded: 001, 002...) |
-| `{{DATE}}` | Fecha actual YYYY-MM-DD |
-| `{{ID}}` | ID único de la oferta en batch-input.tsv |
+| `{{URL}}` | Offer URL |
+| `{{JD_FILE}}` | Path to file with JD text |
+| `{{REPORT_NUM}}` | Report number (3 digits, zero-padded: 001, 002...) |
+| `{{DATE}}` | Today's date YYYY-MM-DD |
+| `{{ID}}` | Unique offer ID in batch-input.tsv |
 
 ---
 
-## Pipeline (ejecutar en orden)
+## Pipeline (execute in order)
 
-### Paso 1 — Obtener JD
+### Step 1 — Get JD
 
-1. Lee el archivo JD en `{{JD_FILE}}`
-2. Si el archivo está vacío o no existe, intenta obtener el JD desde `{{URL}}` con WebFetch
-3. Si ambos fallan, reporta error y termina con JSON `{"status":"failed","error":"JD not found",...}`
+1. Read the JD file at `{{JD_FILE}}`
+2. If file is empty or doesn't exist, try to get JD from `{{URL}}` with WebFetch
+3. If both fail, report error and terminate with JSON `{"status":"failed","error":"JD not found",...}`
 
-### Paso 1b — Summarización (solo si JD largo)
+### Step 1b — Summarization (only if JD is long)
 
-Si el JD tiene más de ~1500 palabras:
-1. Crear resumen compacto: título, nivel, top 5 must-haves, top 3 nice-to-haves, ubicación, comp (~200 palabras)
-2. Usar resumen para Stage 0 pre-screen
-3. Si Stage 0 pasa: usar JD COMPLETO para bloques A-F
+If JD has more than ~1500 words:
+1. Create compact summary: title, level, top 5 must-haves, top 3 nice-to-haves, location, comp (~200 words)
+2. Use summary for Stage 0 pre-screen
+3. If Stage 0 passes: use FULL JD for blocks A-F
 
-### Stage 0 — Pre-screen (EJECUTAR ANTES DE CUALQUIER BLOQUE)
+### Stage 0 — Pre-screen (EXECUTE BEFORE ANY BLOCK)
 
-NO generar bloques A-F hasta que el pre-screen pase.
+Do NOT generate blocks A-F until pre-screen passes.
 
-1. Extraer del JD: título, dominio, top 5 requisitos
-2. **Alineación North Star** (1–5): ¿el dominio encaja en alguno de los 6 arquetipos?
-3. **Overlap must-haves** (1–5): ¿cuántos de los top 5 requisitos están en cv.md?
-4. **Preliminary score** = 0.4 × alineación + 0.6 × overlap
-5. Si < 3.0 → escribir TSV con status `NO APLICAR` a `batch/tracker-additions/{{ID}}.tsv`, imprimir JSON de skip y PARAR:
+1. Extract from JD: title, domain, top 5 requirements
+2. **North Star alignment** (1–5): does the domain fit into one of the 6 archetypes?
+3. **Must-have overlap** (1–5): how many of the top 5 requirements are in cv.md?
+4. **Preliminary score** = 0.4 × alignment + 0.6 × overlap
+5. If < 3.0 → write TSV with status `SKIP` to `batch/tracker-additions/{{ID}}.tsv`, print skip JSON and STOP:
    ```json
-   {"status":"skipped","id":"{{ID}}","report_num":"{{REPORT_NUM}}","company":"{empresa}","role":"{rol}","score":"{preliminary_score}","pdf":null,"report":null,"error":"Pre-screen score < 3.0"}
+   {"status":"skipped","id":"{{ID}}","report_num":"{{REPORT_NUM}}","company":"{company}","role":"{role}","score":"{preliminary_score}","pdf":null,"report":null,"error":"Pre-screen score < 3.0"}
    ```
-6. Si ≥ 3.0 → continuar con Paso 2
+6. If ≥ 3.0 → continue to Step 2
 
-### Paso 2 — Evaluación (tiers por score)
+### Step 2 — Evaluation (tiers by score)
 
-Lee cv.md (o usa contenido pre-cargado si está disponible). Ejecuta bloques según tier:
+Read cv.md (or use pre-loaded content if available). Execute blocks per tier:
 
-#### Paso 0 — Detección de Arquetipo
+#### Step 0 — Archetype Detection
 
-Clasifica la oferta en uno de los 6 arquetipos. Si es híbrido, indica los 2 más cercanos.
+Classify the offer into one of 6 archetypes. If hybrid, indicate the 2 closest.
 
-**Los 6 arquetipos (todos igual de válidos):**
+**The 6 archetypes (all equally valid):**
 
-| Arquetipo | Ejes temáticos | Qué compran |
-|-----------|----------------|-------------|
-| **AI Platform / LLMOps Engineer** | Evaluation, observability, reliability, pipelines | Alguien que ponga AI en producción con métricas |
-| **Agentic Workflows / Automation** | HITL, tooling, orchestration, multi-agent | Alguien que construya sistemas de agentes fiables |
-| **Technical AI Product Manager** | GenAI/Agents, PRDs, discovery, delivery | Alguien que traduzca negocio → producto AI |
-| **AI Solutions Architect** | Hyperautomation, enterprise, integrations | Alguien que diseñe arquitecturas AI end-to-end |
-| **AI Forward Deployed Engineer** | Client-facing, fast delivery, prototyping | Alguien que entregue soluciones AI a clientes rápido |
-| **AI Transformation Lead** | Change management, adoption, org enablement | Alguien que lidere el cambio AI en una organización |
+| Archetype | Thematic Axes | What They Buy |
+|-----------|---------------|---------------|
+| **AI Platform / LLMOps Engineer** | Evaluation, observability, reliability, pipelines | Someone who puts AI in production with metrics |
+| **Agentic Workflows / Automation** | HITL, tooling, orchestration, multi-agent | Someone who builds reliable agent systems |
+| **Technical AI Product Manager** | GenAI/Agents, PRDs, discovery, delivery | Someone who translates business to AI product |
+| **AI Solutions Architect** | Hyperautomation, enterprise, integrations | Someone who designs end-to-end AI architectures |
+| **AI Forward Deployed Engineer** | Client-facing, fast delivery, prototyping | Someone who delivers AI solutions to clients fast |
+| **AI Transformation Lead** | Change management, adoption, org enablement | Someone who leads AI transformation in an org |
 
-**Framing adaptativo:**
+**Adaptive framing:**
 
-> **Las métricas concretas se leen de `cv.md` + `article-digest.md` en cada evaluación. NUNCA hardcodear números aquí.**
+> **Concrete metrics are read from `cv.md` + `article-digest.md` at evaluation time. NEVER hardcode numbers here.**
 
-| Si el rol es... | Emphasize about the candidate... | Fuentes de proof points |
-|-----------------|--------------------------|--------------------------|
-| Platform / LLMOps | Builder de sistemas en producción, observability, evals, closed-loop | article-digest.md + cv.md |
-| Agentic / Automation | Orquestación multi-agente, HITL, reliability, cost | article-digest.md + cv.md |
-| Technical AI PM | Product discovery, PRDs, métricas, stakeholder mgmt | cv.md + article-digest.md |
-| Solutions Architect | Diseño de sistemas, integrations, enterprise-ready | article-digest.md + cv.md |
+| If the role is... | Emphasize about the candidate... | Proof point sources |
+|-------------------|----------------------------------|---------------------|
+| Platform / LLMOps | Production systems builder, observability, evals, closed-loop | article-digest.md + cv.md |
+| Agentic / Automation | Multi-agent orchestration, HITL, reliability, cost | article-digest.md + cv.md |
+| Technical AI PM | Product discovery, PRDs, metrics, stakeholder mgmt | cv.md + article-digest.md |
+| Solutions Architect | Systems design, integrations, enterprise-ready | article-digest.md + cv.md |
 | Forward Deployed Engineer | Fast delivery, client-facing, prototype → prod | cv.md + article-digest.md |
 | AI Transformation Lead | Change management, team enablement, adoption | cv.md + article-digest.md |
 
-**Ventaja transversal**: Enmarcar perfil como **"Technical builder"** que adapta su framing al rol:
-- Para PM: "builder que reduce incertidumbre con prototipos y luego productioniza con disciplina"
-- Para FDE: "builder que entrega fast con observability y métricas desde día 1"
-- Para SA: "builder que diseña sistemas end-to-end con experiencia real en integrations"
-- Para LLMOps: "builder que pone AI en producción con closed-loop quality systems — leer métricas de article-digest.md"
+**Cross-cutting advantage**: Frame profile as **"Technical builder"** who adapts framing to the role:
+- For PM: "builder who reduces uncertainty with prototypes then productionizes with discipline"
+- For FDE: "builder who delivers fast with observability and metrics from day 1"
+- For SA: "builder who designs end-to-end systems with real integration experience"
+- For LLMOps: "builder who puts AI in production with closed-loop quality systems — read metrics from article-digest.md"
 
-Convertir "builder" en señal profesional, no en "hobby maker". El framing cambia, la verdad es la misma.
+Convert "builder" into a professional signal, not a "hobby maker". Framing changes, truth stays the same.
 
-#### Bloque A — Resumen del Rol
+#### Block A — Role Summary
 
-Tabla con: Arquetipo detectado, Domain, Function, Seniority, Remote, Team size, TL;DR.
+Table with: Detected archetype, Domain, Function, Seniority, Remote, Team size, TL;DR.
 
-#### Bloque B — Match con CV
+#### Block B — CV Match
 
-Read `cv.md`. Tabla con cada requisito del JD mapeado a líneas exactas del CV o keys de i18n.ts.
+Read `cv.md`. Table with each JD requirement mapped to exact CV lines or i18n.ts keys.
 
-**Adaptado al arquetipo:**
-- FDE → priorizar delivery rápida y client-facing
-- SA → priorizar diseño de sistemas e integrations
-- PM → priorizar product discovery y métricas
-- LLMOps → priorizar evals, observability, pipelines
-- Agentic → priorizar multi-agent, HITL, orchestration
-- Transformation → priorizar change management, adoption, scaling
+**Adapted by archetype:**
+- FDE → prioritize fast delivery and client-facing
+- SA → prioritize systems design and integrations
+- PM → prioritize product discovery and metrics
+- LLMOps → prioritize evals, observability, pipelines
+- Agentic → prioritize multi-agent, HITL, orchestration
+- Transformation → prioritize change management, adoption, scaling
 
-Sección de **gaps** con estrategia de mitigación para cada uno:
-1. ¿Es hard blocker o nice-to-have?
-2. Can the candidate demonstrate experiencia adyacente?
-3. ¿Hay un proyecto portfolio que cubra este gap?
-4. Plan de mitigación concreto
+**Gaps** section with mitigation strategy for each:
+1. Is it a hard blocker or nice-to-have?
+2. Can the candidate demonstrate adjacent experience?
+3. Is there a portfolio project that covers this gap?
+4. Concrete mitigation plan
 
-#### Bloque C — Nivel y Estrategia
+#### Block C — Level and Strategy
 
-1. **Nivel detectado** en el JD vs **candidate's natural level**
-2. **Plan "vender senior sin mentir"**: frases específicas, logros concretos, founder como ventaja
-3. **Plan "si me downlevelan"**: aceptar si comp justa, review a 6 meses, criterios claros
+1. **Detected level** in JD vs **candidate's natural level**
+2. **Plan "sell senior without lying"**: specific phrases, concrete achievements, founder as advantage
+3. **Plan "if downleveled"**: accept if comp is fair, 6-month review, clear criteria
 
-#### Bloque D — Comp y Demanda *(score ≥ 3.0)*
+#### Block D — Comp and Demand *(score ≥ 3.0)*
 
-**Primero verificar caché** antes de WebSearch:
+**First check cache** before WebSearch:
 ```bash
 node comp-cache.mjs lookup "{role-level}" "{company-stage}" "{location}"
 ```
-- Si retorna JSON → usar datos cacheados, no hacer WebSearch
-- Si "miss" → WebSearch (Glassdoor, Levels.fyi, Blind) → guardar:
+- If returns JSON → use cached data, don't WebSearch
+- If "miss" → WebSearch (Glassdoor, Levels.fyi, Blind) → save:
 ```bash
 node comp-cache.mjs save "{role-level}" "{company-stage}" "{location}" '{"p25":N,"p50":N,"p75":N,"currency":"USD","sources":["glassdoor"]}'
 ```
 
-Tabla con datos y fuentes citadas. Si no hay datos, decirlo.
+Table with data and cited sources. If no data, say so.
 
-Score de comp (1-5): 5=top quartile, 4=above market, 3=median, 2=slightly below, 1=well below.
+Comp score (1-5): 5=top quartile, 4=above market, 3=median, 2=slightly below, 1=well below.
 
-#### Bloque E — Plan de Personalización
+#### Block E — Personalization Plan
 
-| # | Sección | Estado actual | Cambio propuesto | Por qué |
-|---|---------|---------------|------------------|---------|
+| # | Section | Current | Proposed Change | Why |
+|---|---------|---------|-----------------|-----|
 
-Top 5 cambios al CV + Top 5 cambios a LinkedIn.
+Top 5 CV changes + Top 5 LinkedIn changes.
 
-#### Bloque F — Plan de Entrevistas *(solo si score ≥ 4.0)*
+#### Block F — Interview Plan *(only if score ≥ 4.0)*
 
-**SKIP si score final < 4.0.** No generar STAR stories para ofertas borderline.
+**SKIP if final score < 4.0.** Don't generate STAR stories for borderline offers.
 
-6-10 historias STAR mapeadas a requisitos del JD:
+6-10 STAR stories mapped to JD requirements:
 
-| # | Requisito del JD | Historia STAR | S | T | A | R |
+| # | JD Requirement | STAR Story | S | T | A | R |
 
-**Selección adaptada al arquetipo.** Incluir también:
-- 1 case study recomendado (cuál proyecto presentar y cómo)
-- Preguntas red-flag y cómo responderlas
+**Selection adapted by archetype.** Also include:
+- 1 recommended case study (which project to present and how)
+- Red-flag questions and how to answer them
 
-#### Bloque G — Posting Legitimacy
+#### Block G — Posting Legitimacy
 
 Analyze posting signals to assess whether this is a real, active opening.
 
@@ -192,126 +192,126 @@ Analyze posting signals to assess whether this is a real, active opening.
 
 **Assessment:** Apply the same three tiers (High Confidence / Proceed with Caution / Suspicious), weighting available signals more heavily. If insufficient signals are available to make a determination, default to "Proceed with Caution" with a note about limited data.
 
-#### Score Global
+#### Global Score
 
-| Dimensión | Score |
+| Dimension | Score |
 |-----------|-------|
-| Match con CV | X/5 |
-| Alineación North Star | X/5 |
+| CV match | X/5 |
+| North Star alignment | X/5 |
 | Comp | X/5 |
-| Señales culturales | X/5 |
-| Red flags | -X (si hay) |
+| Cultural signals | X/5 |
+| Red flags | -X (if any) |
 | **Global** | **X/5** |
 
-### Paso 3 — Guardar Report .md
+### Step 3 — Save Report .md
 
-**Tier del report según score:**
-- Score < 3.0: No llega aquí (bloqueado en Stage 0)
-- Score 3.0–3.9: Solo bloques A + B + recomendación breve (3 frases)
-- Score 4.0–4.4: Bloques A + B + C + D + E
-- Score ≥ 4.5: Bloques A + B + C + D + E + F
+**Report tier by score:**
+- Score < 3.0: Doesn't get here (blocked at Stage 0)
+- Score 3.0–3.9: Only blocks A + B + brief recommendation (3 sentences)
+- Score 4.0–4.4: Blocks A + B + C + D + E
+- Score ≥ 4.5: Blocks A + B + C + D + E + F
 
-Guardar en:
+Save to:
 ```
 reports/{{REPORT_NUM}}-{company-slug}-{{DATE}}.md
 ```
 
-Donde `{company-slug}` es el nombre de empresa en lowercase, sin espacios, con guiones.
+Where `{company-slug}` is company name lowercase, no spaces, with hyphens.
 
-**Formato del report:**
+**Report format:**
 
 ```markdown
-# Evaluación: {Empresa} — {Rol}
+# Evaluation: {Company} — {Role}
 
-**Fecha:** {{DATE}}
-**Arquetipo:** {detectado}
+**Date:** {{DATE}}
+**Archetype:** {detected}
 **Score:** {X/5}
 **Legitimacy:** {High Confidence | Proceed with Caution | Suspicious}
-**URL:** {URL de la oferta original}
+**URL:** {original offer URL}
 **PDF:** career-ops/output/cv-candidate-{company-slug}-{{DATE}}.pdf
 **Batch ID:** {{ID}}
 
 ---
 
-## A) Resumen del Rol
-(contenido completo)
+## A) Role Summary
+(full content)
 
-## B) Match con CV
-(contenido completo)
+## B) CV Match
+(full content)
 
-## C) Nivel y Estrategia
-(contenido completo)
+## C) Level and Strategy
+(full content)
 
-## D) Comp y Demanda
-(contenido completo)
+## D) Comp and Demand
+(full content)
 
-## E) Plan de Personalización
-(contenido completo)
+## E) Personalization Plan
+(full content)
 
-## F) Plan de Entrevistas
-(contenido completo)
+## F) Interview Plan
+(full content)
 
 ## G) Posting Legitimacy
-(contenido completo)
+(full content)
 
 ---
 
-## Keywords extraídas
-(15-20 keywords del JD para ATS)
+## Keywords Extracted
+(15-20 keywords from JD for ATS)
 ```
 
-### Paso 4 — Generar PDF
+### Step 4 — Generate PDF
 
-1. Lee `cv.md` + `i18n.ts`
-2. Extrae 15-20 keywords del JD
-3. Detecta idioma del JD → idioma del CV (EN default)
-4. Detecta ubicación empresa → formato papel: US/Canada → `letter`, resto → `a4`
-5. Detecta arquetipo → adapta framing
-6. Reescribe Professional Summary inyectando keywords
-7. Selecciona top 3-4 proyectos más relevantes
-8. Reordena bullets de experiencia por relevancia al JD
-9. Construye competency grid (6-8 keyword phrases)
-10. Inyecta keywords en logros existentes (**NUNCA inventa**)
-11. Genera HTML completo desde template (lee `templates/cv-template.html`)
-12. Escribe HTML a `/tmp/cv-candidate-{company-slug}.html`
-13. Ejecuta:
+1. Read `cv.md` + `i18n.ts`
+2. Extract 15-20 keywords from JD
+3. Detect JD language → CV language (EN default)
+4. Detect company location → paper format: US/Canada → `letter`, rest → `a4`
+5. Detect archetype → adapt framing
+6. Rewrite Professional Summary injecting keywords
+7. Select top 3-4 most relevant projects
+8. Reorder experience bullets by JD relevance
+9. Build competency grid (6-8 keyword phrases)
+10. Inject keywords into existing achievements (**NEVER invents**)
+11. Generate full HTML from template (read `templates/cv-template.html`)
+12. Write HTML to `/tmp/cv-candidate-{company-slug}.html`
+13. Execute:
 ```bash
 node generate-pdf.mjs \
   /tmp/cv-candidate-{company-slug}.html \
   output/cv-candidate-{company-slug}-{{DATE}}.pdf \
   --format={letter|a4}
 ```
-14. Reporta: ruta PDF, nº páginas, % cobertura keywords
+14. Report: PDF path, page count, % keyword coverage
 
-**Reglas ATS:**
-- Single-column (sin sidebars)
-- Headers estándar: "Professional Summary", "Work Experience", "Education", "Skills", "Certifications", "Projects"
-- Sin texto en imágenes/SVGs
-- Sin info crítica en headers/footers
-- UTF-8, texto seleccionable
-- Keywords distribuidas: Summary (top 5), primer bullet de cada rol, Skills section
+**ATS rules:**
+- Single-column (no sidebars)
+- Standard headers: "Professional Summary", "Work Experience", "Education", "Skills", "Certifications", "Projects"
+- No text in images/SVGs
+- No critical info in headers/footers
+- UTF-8, selectable text
+- Keywords distributed: Summary (top 5), first bullet of each role, Skills section
 
-**Diseño:**
+**Design:**
 - Fonts: Space Grotesk (headings, 600-700) + DM Sans (body, 400-500)
-- Fonts self-hosted: `fonts/`
-- Header: Space Grotesk 24px bold + gradiente cyan→purple 2px + contacto
-- Section headers: Space Grotesk 13px uppercase, color cyan `hsl(187,74%,32%)`
+- Self-hosted fonts: `fonts/`
+- Header: Space Grotesk 24px bold + cyan→purple gradient 2px + contact
+- Section headers: Space Grotesk 13px uppercase, cyan color `hsl(187,74%,32%)`
 - Body: DM Sans 11px, line-height 1.5
 - Company names: purple `hsl(270,70%,45%)`
-- Márgenes: 0.6in
-- Background: blanco
+- Margins: 0.6in
+- Background: white
 
-**Estrategia keyword injection (ético):**
-- Reformular experiencia real con vocabulario exacto del JD
-- NUNCA añadir skills the candidate doesn't have
-- Ejemplo: JD dice "RAG pipelines" y CV dice "LLM workflows with retrieval" → "RAG pipeline design and LLM orchestration workflows"
+**Keyword injection strategy (ethical):**
+- Rephrase real experience with exact JD vocabulary
+- NEVER add skills the candidate doesn't have
+- Example: JD says "RAG pipelines" and CV says "LLM workflows with retrieval" → "RAG pipeline design and LLM orchestration workflows"
 
-**Template placeholders (en cv-template.html):**
+**Template placeholders (in cv-template.html):**
 
-| Placeholder | Contenido |
-|-------------|-----------|
-| `{{LANG}}` | `en` o `es` |
-| `{{PAGE_WIDTH}}` | `8.5in` (letter) o `210mm` (A4) |
+| Placeholder | Content |
+|-------------|---------|
+| `{{LANG}}` | `en` or `es` |
+| `{{PAGE_WIDTH}}` | `8.5in` (letter) or `210mm` (A4) |
 | `{{NAME}}` | (from profile.yml) |
 | `{{EMAIL}}` | (from profile.yml) |
 | `{{LINKEDIN_URL}}` | (from profile.yml) |
@@ -320,103 +320,103 @@ node generate-pdf.mjs \
 | `{{PORTFOLIO_DISPLAY}}` | (from profile.yml) |
 | `{{LOCATION}}` | (from profile.yml) |
 | `{{SECTION_SUMMARY}}` | Professional Summary / Resumen Profesional |
-| `{{SUMMARY_TEXT}}` | Summary personalizado con keywords |
+| `{{SUMMARY_TEXT}}` | Personalized Summary with keywords |
 | `{{SECTION_COMPETENCIES}}` | Core Competencies / Competencias Core |
 | `{{COMPETENCIES}}` | `<span class="competency-tag">keyword</span>` × 6-8 |
 | `{{SECTION_EXPERIENCE}}` | Work Experience / Experiencia Laboral |
-| `{{EXPERIENCE}}` | HTML de cada trabajo con bullets reordenados |
+| `{{EXPERIENCE}}` | HTML of each job with reordered bullets |
 | `{{SECTION_PROJECTS}}` | Projects / Proyectos |
-| `{{PROJECTS}}` | HTML de top 3-4 proyectos |
+| `{{PROJECTS}}` | HTML of top 3-4 projects |
 | `{{SECTION_EDUCATION}}` | Education / Formación |
-| `{{EDUCATION}}` | HTML de educación |
+| `{{EDUCATION}}` | HTML of education |
 | `{{SECTION_CERTIFICATIONS}}` | Certifications / Certificaciones |
-| `{{CERTIFICATIONS}}` | HTML de certificaciones |
+| `{{CERTIFICATIONS}}` | HTML of certifications |
 | `{{SECTION_SKILLS}}` | Skills / Competencias |
-| `{{SKILLS}}` | HTML de skills |
+| `{{SKILLS}}` | HTML of skills |
 
-### Paso 5 — Tracker Line
+### Step 5 — Tracker Line
 
-Escribir una línea TSV a:
+Write one TSV line to:
 ```
 batch/tracker-additions/{{ID}}.tsv
 ```
 
-Formato TSV (una sola línea, sin header, 9 columnas tab-separated):
+TSV format (single line, no header, 9 tab-separated columns):
 ```
-{next_num}\t{{DATE}}\t{empresa}\t{rol}\t{status}\t{score}/5\t{pdf_emoji}\t[{{REPORT_NUM}}](reports/{{REPORT_NUM}}-{company-slug}-{{DATE}}.md)\t{nota_1_frase}
+{next_num}\t{{DATE}}\t{company}\t{role}\t{status}\t{score}/5\t{pdf_emoji}\t[{{REPORT_NUM}}](reports/{{REPORT_NUM}}-{company-slug}-{{DATE}}.md)\t{note_1_sentence}
 ```
 
-**Columnas TSV (orden exacto):**
+**TSV columns (exact order):**
 
-| # | Campo | Tipo | Ejemplo | Validación |
+| # | Field | Type | Example | Validation |
 |---|-------|------|---------|------------|
-| 1 | num | int | `647` | Secuencial, max existente + 1 |
-| 2 | date | YYYY-MM-DD | `2026-03-14` | Fecha de evaluación |
-| 3 | company | string | `Datadog` | Nombre corto de empresa |
-| 4 | role | string | `Staff AI Engineer` | Título del rol |
-| 5 | status | canonical | `Evaluada` | DEBE ser canónico (ver states.yml) |
-| 6 | score | X.XX/5 | `4.55/5` | O `N/A` si no evaluable |
-| 7 | pdf | emoji | `✅` o `❌` | Si se generó PDF |
-| 8 | report | md link | `[647](reports/647-...)` | Link al report |
-| 9 | notes | string | `APPLY HIGH...` | Resumen 1 frase |
+| 1 | num | int | `647` | Sequential, max existing + 1 |
+| 2 | date | YYYY-MM-DD | `2026-03-14` | Evaluation date |
+| 3 | company | string | `Datadog` | Short company name |
+| 4 | role | string | `Staff AI Engineer` | Role title |
+| 5 | status | canonical | `Evaluated` | MUST be canonical (see states.yml) |
+| 6 | score | X.XX/5 | `4.55/5` | Or `N/A` if not evaluable |
+| 7 | pdf | emoji | `✅` or `❌` | If PDF was generated |
+| 8 | report | md link | `[647](reports/647-...)` | Link to report |
+| 9 | notes | string | `APPLY HIGH...` | 1-sentence summary |
 
-**IMPORTANTE:** El orden TSV tiene status ANTES de score (col 5→status, col 6→score). En applications.md el orden es inverso (col 5→score, col 6→status). merge-tracker.mjs maneja la conversión.
+**IMPORTANT:** TSV order has status BEFORE score (col 5→status, col 6→score). In applications.md the order is reversed (col 5→score, col 6→status). merge-tracker.mjs handles the conversion.
 
-**Estados canónicos válidos:** `Evaluada`, `Aplicado`, `Respondido`, `Entrevista`, `Oferta`, `Rechazado`, `Descartado`, `NO APLICAR`
+**Valid canonical statuses:** `Evaluated`, `Applied`, `Responded`, `Interview`, `Offer`, `Rejected`, `Discarded`, `SKIP`
 
-Donde `{next_num}` se calcula leyendo la última línea de `data/applications.md`.
+Where `{next_num}` is calculated by reading the last line of `data/applications.md`.
 
-### Paso 6 — Output final
+### Step 6 — Final Output
 
-Al terminar, imprime por stdout un resumen JSON para que el orquestador lo parsee:
+When done, print to stdout a JSON summary for the orchestrator to parse:
 
 ```json
 {
   "status": "completed",
   "id": "{{ID}}",
   "report_num": "{{REPORT_NUM}}",
-  "company": "{empresa}",
-  "role": "{rol}",
+  "company": "{company}",
+  "role": "{role}",
   "score": {score_num},
   "legitimacy": "{High Confidence|Proceed with Caution|Suspicious}",
-  "pdf": "{ruta_pdf}",
-  "report": "{ruta_report}",
+  "pdf": "{pdf_path}",
+  "report": "{report_path}",
   "error": null
 }
 ```
 
-Si algo falla:
+If anything fails:
 ```json
 {
   "status": "failed",
   "id": "{{ID}}",
   "report_num": "{{REPORT_NUM}}",
-  "company": "{empresa_o_unknown}",
-  "role": "{rol_o_unknown}",
+  "company": "{company_or_unknown}",
+  "role": "{role_or_unknown}",
   "score": null,
   "pdf": null,
-  "report": "{ruta_report_si_existe}",
-  "error": "{descripción_del_error}"
+  "report": "{report_path_if_exists}",
+  "error": "{error_description}"
 }
 ```
 
 ---
 
-## Reglas Globales
+## Global Rules
 
-### NUNCA
-1. Inventar experiencia o métricas
-2. Modificar cv.md, i18n.ts ni archivos del portfolio
-3. Compartir el teléfono en mensajes generados
-4. Recomendar comp por debajo de mercado
-5. Generar PDF sin leer primero el JD
-6. Usar corporate-speak
+### NEVER
+1. Invent experience or metrics
+2. Modify cv.md, i18n.ts or portfolio files
+3. Share phone number in generated messages
+4. Recommend comp below market rate
+5. Generate PDF without reading JD first
+6. Use corporate-speak
 
-### SIEMPRE
-1. Leer cv.md, llms.txt y article-digest.md antes de evaluar
-2. Detectar el arquetipo del rol y adaptar el framing
-3. Citar líneas exactas del CV cuando haga match
-4. Usar WebSearch para datos de comp y empresa
-5. Generar contenido en el idioma del JD (EN default)
-6. Ser directo y accionable — sin fluff
-7. Cuando generes texto en inglés (PDF summaries, bullets, STAR stories), usa inglés nativo de tech: frases cortas, verbos de acción, sin passive voice innecesaria, sin "in order to" ni "utilized"
+### ALWAYS
+1. Read cv.md, llms.txt and article-digest.md before evaluating
+2. Detect role archetype and adapt framing
+3. Cite exact CV lines when matching
+4. Use WebSearch for comp and company data
+5. Generate content in JD language (EN default)
+6. Be direct and actionable — no fluff
+7. When generating English text (PDF summaries, bullets, STAR stories), use native tech English: short sentences, action verbs, no unnecessary passive voice, no "in order to" or "utilized"

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -10,7 +10,7 @@ Eres un worker de evaluación de ofertas de empleo for the candidate (read name 
 
 ---
 
-## Fuentes de Verdad (LEER antes de evaluar)
+## Fuentes de Verdad
 
 | Archivo | Ruta absoluta | Cuándo |
 |---------|---------------|--------|
@@ -20,6 +20,11 @@ Eres un worker de evaluación de ofertas de empleo for the candidate (read name 
 | i18n.ts | `i18n.ts (if exists, optional)` | Solo entrevistas/deep |
 | cv-template.html | `templates/cv-template.html` | Para PDF |
 | generate-pdf.mjs | `generate-pdf.mjs` | Para PDF |
+
+**OPTIMIZACIÓN — Contexto pre-cargado:**
+Si el orquestador sustituyó `{{CONTEXT_PRELOADED}}` con contenido real de cv.md y profile.yml, ese contenido aparece al final de este prompt bajo `## CV y Perfil Pre-cargados`. En ese caso, NO leer cv.md ni profile.yml con herramienta Read — usar el contenido pre-cargado directamente.
+
+{{CONTEXT_PRELOADED}}
 
 **REGLA: NUNCA escribir en cv.md ni i18n.ts.** Son read-only.
 **REGLA: NUNCA hardcodear métricas.** Leerlas de cv.md + article-digest.md en el momento.
@@ -45,11 +50,32 @@ Eres un worker de evaluación de ofertas de empleo for the candidate (read name 
 
 1. Lee el archivo JD en `{{JD_FILE}}`
 2. Si el archivo está vacío o no existe, intenta obtener el JD desde `{{URL}}` con WebFetch
-3. Si ambos fallan, reporta error y termina
+3. Si ambos fallan, reporta error y termina con JSON `{"status":"failed","error":"JD not found",...}`
 
-### Paso 2 — Evaluación A-G
+### Paso 1b — Summarización (solo si JD largo)
 
-Read `cv.md`. Ejecuta TODOS los bloques:
+Si el JD tiene más de ~1500 palabras:
+1. Crear resumen compacto: título, nivel, top 5 must-haves, top 3 nice-to-haves, ubicación, comp (~200 palabras)
+2. Usar resumen para Stage 0 pre-screen
+3. Si Stage 0 pasa: usar JD COMPLETO para bloques A-F
+
+### Stage 0 — Pre-screen (EJECUTAR ANTES DE CUALQUIER BLOQUE)
+
+NO generar bloques A-F hasta que el pre-screen pase.
+
+1. Extraer del JD: título, dominio, top 5 requisitos
+2. **Alineación North Star** (1–5): ¿el dominio encaja en alguno de los 6 arquetipos?
+3. **Overlap must-haves** (1–5): ¿cuántos de los top 5 requisitos están en cv.md?
+4. **Preliminary score** = 0.4 × alineación + 0.6 × overlap
+5. Si < 3.0 → escribir TSV con status `NO APLICAR` a `batch/tracker-additions/{{ID}}.tsv`, imprimir JSON de skip y PARAR:
+   ```json
+   {"status":"skipped","id":"{{ID}}","report_num":"{{REPORT_NUM}}","company":"{empresa}","role":"{rol}","score":"{preliminary_score}","pdf":null,"report":null,"error":"Pre-screen score < 3.0"}
+   ```
+6. Si ≥ 3.0 → continuar con Paso 2
+
+### Paso 2 — Evaluación (tiers por score)
+
+Lee cv.md (o usa contenido pre-cargado si está disponible). Ejecuta bloques según tier:
 
 #### Paso 0 — Detección de Arquetipo
 
@@ -115,9 +141,19 @@ Sección de **gaps** con estrategia de mitigación para cada uno:
 2. **Plan "vender senior sin mentir"**: frases específicas, logros concretos, founder como ventaja
 3. **Plan "si me downlevelan"**: aceptar si comp justa, review a 6 meses, criterios claros
 
-#### Bloque D — Comp y Demanda
+#### Bloque D — Comp y Demanda *(score ≥ 3.0)*
 
-Usar WebSearch para salarios actuales (Glassdoor, Levels.fyi, Blind), reputación comp de la empresa, tendencia demanda. Tabla con datos y fuentes citadas. Si no hay datos, decirlo.
+**Primero verificar caché** antes de WebSearch:
+```bash
+node comp-cache.mjs lookup "{role-level}" "{company-stage}" "{location}"
+```
+- Si retorna JSON → usar datos cacheados, no hacer WebSearch
+- Si "miss" → WebSearch (Glassdoor, Levels.fyi, Blind) → guardar:
+```bash
+node comp-cache.mjs save "{role-level}" "{company-stage}" "{location}" '{"p25":N,"p50":N,"p75":N,"currency":"USD","sources":["glassdoor"]}'
+```
+
+Tabla con datos y fuentes citadas. Si no hay datos, decirlo.
 
 Score de comp (1-5): 5=top quartile, 4=above market, 3=median, 2=slightly below, 1=well below.
 
@@ -128,7 +164,9 @@ Score de comp (1-5): 5=top quartile, 4=above market, 3=median, 2=slightly below,
 
 Top 5 cambios al CV + Top 5 cambios a LinkedIn.
 
-#### Bloque F — Plan de Entrevistas
+#### Bloque F — Plan de Entrevistas *(solo si score ≥ 4.0)*
+
+**SKIP si score final < 4.0.** No generar STAR stories para ofertas borderline.
 
 6-10 historias STAR mapeadas a requisitos del JD:
 
@@ -167,7 +205,13 @@ Analyze posting signals to assess whether this is a real, active opening.
 
 ### Paso 3 — Guardar Report .md
 
-Guardar evaluación completa en:
+**Tier del report según score:**
+- Score < 3.0: No llega aquí (bloqueado en Stage 0)
+- Score 3.0–3.9: Solo bloques A + B + recomendación breve (3 frases)
+- Score 4.0–4.4: Bloques A + B + C + D + E
+- Score ≥ 4.5: Bloques A + B + C + D + E + F
+
+Guardar en:
 ```
 reports/{{REPORT_NUM}}-{company-slug}-{{DATE}}.md
 ```

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -20,6 +20,7 @@ STATE_LOCK_DIR="$BATCH_DIR/.batch-state.lock"
 STATE_LOCK_PID_FILE="$STATE_LOCK_DIR/pid"
 STATE_LOCK_TIMEOUT_SECONDS=30
 MAIN_PID="${BASHPID:-$$}"
+BATCH_CONTEXT_FILE="$BATCH_DIR/.batch-context-$$.md"
 
 # Defaults
 PARALLEL=1
@@ -100,6 +101,7 @@ release_lock() {
     return
   fi
   rm -f "$LOCK_FILE"
+  rm -f "$BATCH_CONTEXT_FILE"
 }
 
 trap release_lock EXIT
@@ -122,6 +124,42 @@ check_prerequisites() {
   fi
 
   mkdir -p "$LOGS_DIR" "$TRACKER_DIR" "$REPORTS_DIR"
+}
+
+# Pre-build shared context (cv.md + profile.yml) once for all workers.
+# Workers reference {{CONTEXT_PRELOADED}} which gets substituted with this content,
+# so they don't need to issue separate Read tool calls for these static files.
+build_context() {
+  local cv_file="$PROJECT_DIR/cv.md"
+  local profile_file="$PROJECT_DIR/config/profile.yml"
+  local cv_content=""
+  local profile_content=""
+
+  [[ -f "$cv_file" ]] && cv_content=$(cat "$cv_file")
+  [[ -f "$profile_file" ]] && profile_content=$(cat "$profile_file")
+
+  if [[ -z "$cv_content" && -z "$profile_content" ]]; then
+    # No files to preload — substitute with empty string so placeholder is removed
+    echo "" > "$BATCH_CONTEXT_FILE"
+    return
+  fi
+
+  cat > "$BATCH_CONTEXT_FILE" <<CONTEXT_EOF
+
+## CV y Perfil Pre-cargados
+
+### cv.md
+\`\`\`markdown
+${cv_content}
+\`\`\`
+
+### config/profile.yml
+\`\`\`yaml
+${profile_content}
+\`\`\`
+
+CONTEXT_EOF
+  echo "📋 Pre-loaded context: cv.md (${#cv_content} chars) + profile.yml (${#profile_content} chars)"
 }
 
 # Initialize state file if it doesn't exist
@@ -339,6 +377,8 @@ process_offer() {
   esc_report_num="${report_num//|/\\|}"
   esc_date="${date//|/\\|}"
   esc_id="${id//|/\\|}"
+  local context_content=""
+  [[ -f "$BATCH_CONTEXT_FILE" ]] && context_content=$(cat "$BATCH_CONTEXT_FILE")
   sed \
     -e "s|{{URL}}|${esc_url}|g" \
     -e "s|{{JD_FILE}}|${esc_jd_file}|g" \
@@ -346,6 +386,24 @@ process_offer() {
     -e "s|{{DATE}}|${esc_date}|g" \
     -e "s|{{ID}}|${esc_id}|g" \
     "$PROMPT_FILE" > "$resolved_prompt"
+
+  # Inline the pre-built context — sed can't handle large multi-line substitutions safely,
+  # so we do a two-pass approach: replace the placeholder line with the context file content.
+  if [[ -s "$BATCH_CONTEXT_FILE" ]]; then
+    local tmp_prompt="$BATCH_DIR/.resolved-prompt-${id}-ctx.md"
+    awk -v ctx_file="$BATCH_CONTEXT_FILE" '
+      /\{\{CONTEXT_PRELOADED\}\}/ {
+        while ((getline line < ctx_file) > 0) print line
+        close(ctx_file)
+        next
+      }
+      { print }
+    ' "$resolved_prompt" > "$tmp_prompt"
+    mv "$tmp_prompt" "$resolved_prompt"
+  else
+    # No context file — just remove the placeholder
+    sed -i 's/{{CONTEXT_PRELOADED}}//g' "$resolved_prompt"
+  fi
 
   # Launch claude -p worker (uses default model from Claude Max subscription)
   local exit_code=0
@@ -437,6 +495,7 @@ main() {
   fi
 
   init_state
+  build_context
 
   # Count input offers (skip header, ignore blank lines)
   local total_input

--- a/comp-cache.mjs
+++ b/comp-cache.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+/**
+ * comp-cache.mjs — Compensation research cache for career-ops
+ *
+ * Caches salary data from WebSearch (Glassdoor, Levels.fyi, Blind) to avoid
+ * repeating the same searches across evaluations. Cache TTL is 60 days.
+ *
+ * Cache file: data/comp-cache.yml (gitignored, local only)
+ *
+ * CLI usage:
+ *   node comp-cache.mjs lookup "senior-ai-engineer" "series-b" "remote"
+ *   node comp-cache.mjs save "senior-ai-engineer" "series-b" "remote" '{"p25":180000,"p50":210000,"p75":260000,"sources":["glassdoor"]}'
+ *   node comp-cache.mjs list
+ *   node comp-cache.mjs purge   # Remove expired entries
+ *
+ * Returns (stdout):
+ *   lookup: JSON data if hit, "miss" if not found or expired
+ *   save:   "saved" on success
+ *   list:   JSON array of all cache keys with status
+ *   purge:  "purged N entries"
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CACHE_FILE = join(__dirname, 'data', 'comp-cache.yml');
+const DEFAULT_TTL_DAYS = 60;
+
+// ---------------------------------------------------------------------------
+// YAML helpers — minimal serializer/parser for flat key-value YAML.
+// No external dependency (avoids adding js-yaml to package.json).
+// Format: only supports string, number, and string[] leaf values.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the custom comp-cache YAML format into a JS object.
+ * Format:
+ *   entries:
+ *     key-name:
+ *       field: value
+ *       sources: glassdoor,levels.fyi
+ */
+function parseCache(raw) {
+  const result = { entries: {} };
+  if (!raw || !raw.trim()) return result;
+
+  const lines = raw.split('\n');
+  let currentKey = null;
+
+  for (const line of lines) {
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+
+    // Top-level "entries:" declaration
+    if (/^entries:\s*$/.test(line)) continue;
+
+    // Second-level key (2 spaces indent)
+    const keyMatch = line.match(/^  ([^:]+):\s*$/);
+    if (keyMatch) {
+      currentKey = keyMatch[1].trim();
+      result.entries[currentKey] = {};
+      continue;
+    }
+
+    // Third-level field (4 spaces indent)
+    if (currentKey) {
+      const fieldMatch = line.match(/^    ([^:]+):\s*(.*)$/);
+      if (fieldMatch) {
+        const field = fieldMatch[1].trim();
+        const value = fieldMatch[2].trim().replace(/^"(.*)"$/, '$1'); // strip quotes
+        // Try to parse numbers
+        const num = Number(value);
+        result.entries[currentKey][field] = isNaN(num) || value === '' ? value : num;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Serialize the cache object back to YAML string.
+ */
+function serializeCache(cache) {
+  const lines = ['entries:'];
+  for (const [key, entry] of Object.entries(cache.entries)) {
+    lines.push(`  ${key}:`);
+    for (const [field, value] of Object.entries(entry)) {
+      const v = typeof value === 'string' && (value.includes(' ') || value === '')
+        ? `"${value}"`
+        : value;
+      lines.push(`    ${field}: ${v}`);
+    }
+  }
+  return lines.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Key building
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a normalized cache key from role, level, company stage, location.
+ * Format: {role-level}-{stage}-{location}-{YYYY-QN}
+ */
+function buildKey(role, stage, location) {
+  const normalize = (s) => s.toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  const now = new Date();
+  const quarter = Math.ceil((now.getMonth() + 1) / 3);
+  const period = `${now.getFullYear()}-Q${quarter}`;
+
+  return [normalize(role), normalize(stage), normalize(location), period]
+    .filter(Boolean)
+    .join('-');
+}
+
+// ---------------------------------------------------------------------------
+// TTL check
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the cache entry is expired (past its TTL).
+ */
+function isExpired(entry) {
+  if (!entry.fetched) return true;
+  const ttlDays = entry.ttl_days || DEFAULT_TTL_DAYS;
+  const fetched = new Date(entry.fetched);
+  if (isNaN(fetched.getTime())) return true;
+  const now = new Date();
+  const ageDays = (now - fetched) / (1000 * 60 * 60 * 24);
+  return ageDays > ttlDays;
+}
+
+// ---------------------------------------------------------------------------
+// Read / Write cache
+// ---------------------------------------------------------------------------
+
+function readCache() {
+  if (!existsSync(CACHE_FILE)) return { entries: {} };
+  try {
+    const raw = readFileSync(CACHE_FILE, 'utf-8');
+    return parseCache(raw);
+  } catch {
+    return { entries: {} };
+  }
+}
+
+function writeCache(cache) {
+  const dir = dirname(CACHE_FILE);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(CACHE_FILE, serializeCache(cache), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up comp data by key. Returns parsed entry object or null if miss/expired.
+ */
+function lookup(key) {
+  const cache = readCache();
+  const entry = cache.entries[key];
+  if (!entry) return null;
+  if (isExpired(entry)) return null;
+  return entry;
+}
+
+/**
+ * Save comp data to cache.
+ * @param {string} key - Cache key
+ * @param {object} data - { p25, p50, p75, currency, sources: string[] }
+ */
+function save(key, data) {
+  const cache = readCache();
+  const today = new Date().toISOString().split('T')[0];
+  cache.entries[key] = {
+    p25: data.p25 ?? null,
+    p50: data.p50 ?? null,
+    p75: data.p75 ?? null,
+    currency: data.currency ?? 'USD',
+    sources: Array.isArray(data.sources) ? data.sources.join(',') : (data.sources ?? ''),
+    fetched: today,
+    ttl_days: DEFAULT_TTL_DAYS,
+  };
+  writeCache(cache);
+}
+
+/**
+ * List all cache keys with their status (fresh/expired).
+ */
+function listEntries() {
+  const cache = readCache();
+  return Object.entries(cache.entries).map(([key, entry]) => ({
+    key,
+    fetched: entry.fetched,
+    expired: isExpired(entry),
+    p50: entry.p50,
+    currency: entry.currency,
+  }));
+}
+
+/**
+ * Remove expired entries from cache.
+ * @returns {number} Count of purged entries
+ */
+function purge() {
+  const cache = readCache();
+  let count = 0;
+  for (const key of Object.keys(cache.entries)) {
+    if (isExpired(cache.entries[key])) {
+      delete cache.entries[key];
+      count++;
+    }
+  }
+  if (count > 0) writeCache(cache);
+  return count;
+}
+
+export { buildKey, lookup, save, listEntries, purge, isExpired, parseCache, serializeCache };
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [,, command, ...args] = process.argv;
+
+  switch (command) {
+    case 'lookup': {
+      if (args.length < 3) {
+        console.error('Usage: comp-cache.mjs lookup <role> <stage> <location>');
+        process.exit(1);
+      }
+      const key = buildKey(args[0], args[1], args[2]);
+      const entry = lookup(key);
+      if (entry) {
+        console.log(JSON.stringify({ hit: true, key, ...entry }));
+      } else {
+        console.log('miss');
+      }
+      break;
+    }
+
+    case 'save': {
+      if (args.length < 4) {
+        console.error('Usage: comp-cache.mjs save <role> <stage> <location> <json-data>');
+        process.exit(1);
+      }
+      const key = buildKey(args[0], args[1], args[2]);
+      let data;
+      try {
+        data = JSON.parse(args[3]);
+      } catch {
+        console.error('Invalid JSON data');
+        process.exit(1);
+      }
+      save(key, data);
+      console.log(`saved:${key}`);
+      break;
+    }
+
+    case 'list': {
+      const entries = listEntries();
+      console.log(JSON.stringify(entries, null, 2));
+      break;
+    }
+
+    case 'purge': {
+      const count = purge();
+      console.log(`purged ${count} entries`);
+      break;
+    }
+
+    default:
+      console.error('Commands: lookup, save, list, purge');
+      process.exit(1);
+  }
+}

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -44,14 +44,19 @@ function validateStatus(status) {
   const aliases = {
     // Spanish → English
     'evaluada': 'Evaluated', 'condicional': 'Evaluated', 'hold': 'Evaluated', 'evaluar': 'Evaluated', 'verificar': 'Evaluated',
-    'aplicado': 'Applied', 'enviada': 'Applied', 'aplicada': 'Applied', 'applied': 'Applied', 'sent': 'Applied',
+    'aplicado': 'Applied', 'enviada': 'Applied', 'aplicada': 'Applied',
     'respondido': 'Responded',
     'entrevista': 'Interview',
     'oferta': 'Offer',
     'rechazado': 'Rejected', 'rechazada': 'Rejected',
     'descartado': 'Discarded', 'descartada': 'Discarded', 'cerrada': 'Discarded', 'cancelada': 'Discarded',
-    'no aplicar': 'SKIP', 'no_aplicar': 'SKIP', 'skip': 'SKIP', 'monitor': 'SKIP',
-    'geo blocker': 'SKIP',
+    'no aplicar': 'SKIP', 'no_aplicar': 'SKIP',
+    // English → English passthrough
+    'applied': 'Applied', 'sent': 'Applied', 'evaluated': 'Evaluated',
+    'rejected': 'Rejected',
+    'closed': 'Discarded', 'discarded': 'Discarded', 'canceled': 'Discarded',
+    'skip': 'SKIP', 'skipped': 'SKIP', 'no_apply': 'SKIP', 'skip_apply': 'SKIP', 'monitor': 'SKIP',
+    'geo blocker': 'SKIP', 'geo_blocker': 'SKIP',
   };
 
   if (aliases[lower]) return aliases[lower];

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -179,7 +179,12 @@ function parseTsvContent(content, filename) {
   return addition;
 }
 
+// ---- Exports ----
+export { validateStatus, normalizeCompany, roleFuzzyMatch, extractReportNum, parseScore, parseAppLine, parseTsvContent };
+
 // ---- Main ----
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
 
 // Read applications.md
 if (!existsSync(APPS_FILE)) {
@@ -329,3 +334,5 @@ if (VERIFY && !DRY_RUN) {
     process.exit(1);
   }
 }
+
+} // end main guard

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -85,6 +85,108 @@ Classify every offer into one of these types (or hybrid of 2):
 
 After detecting archetype, read `modes/_profile.md` for the user's specific framing and proof points for that archetype.
 
+Convert "builder" into a professional signal, not a "hobby maker". Real proof points make this credible.
+
+### Portfolio as Proof Point (use in high-value applications)
+
+<!-- [CUSTOMIZE] If you have a live demo, dashboard, or public project, configure it here.
+     Example:
+     dashboard:
+       url: "https://yoursite.dev/demo"
+       password: "demo-2026"
+       when_to_share: "LLMOps, AI Platform, observability roles"
+     Read from config/profile.yml → narrative.proof_points and narrative.dashboard -->
+
+If the candidate has a live demo/dashboard (check profile.yml), offer access in applications for relevant roles.
+
+### Comp Intelligence
+
+<!-- [CUSTOMIZE] Research comp ranges for YOUR target roles and update these ranges -->
+
+**General guidance:**
+- Use WebSearch for current market data (Glassdoor, Levels.fyi, Blind)
+- Frame by role title, not by skills -- titles determine comp bands
+- Contractor rates are typically 30-50% higher than employee base to account for benefits
+- Geographic arbitrage works for remote roles: lower CoL = better net
+
+**Cache-first protocol (saves 3 WebSearch calls per repeated role type):**
+
+Before running WebSearch for comp data in Bloque D:
+1. Normalize: role title + level (e.g. "senior-ai-engineer"), company stage (seed/series-a/series-b/series-c/public), location (e.g. "remote" or "toronto")
+2. Check cache: `node comp-cache.mjs lookup "{role-level}" "{stage}" "{location}"`
+3. If output is JSON (hit and not expired) → use cached data, skip WebSearch
+4. If output is "miss" → run WebSearch (Glassdoor, Levels.fyi, Blind), then save: `node comp-cache.mjs save "{role-level}" "{stage}" "{location}" '{"p25":N,"p50":N,"p75":N,"currency":"USD","sources":["glassdoor"]}'`
+
+### Negotiation Scripts
+
+<!-- [CUSTOMIZE] Adapt these to your situation -->
+
+**Salary expectations (general framework):**
+> "Based on market data for this role, I'm targeting [RANGE from profile.yml]. I'm flexible on structure -- what matters is the total package and the opportunity."
+
+**Geographic discount pushback:**
+> "The roles I'm competitive for are output-based, not location-based. My track record doesn't change based on postal code."
+
+**When offered below target:**
+> "I'm comparing with opportunities in the [higher range]. I'm drawn to [company] because of [reason]. Can we explore [target]?"
+
+### Location Policy
+
+<!-- [CUSTOMIZE] Adapt to your situation. Read from config/profile.yml → location -->
+
+**In forms:**
+- Binary "can you be on-site?" questions: follow your actual availability from profile.yml
+- In free-text fields: specify your timezone overlap and availability
+
+**In evaluations (scoring):**
+- Remote dimension for hybrid outside your country: score **3.0** (not 1.0)
+- Only score 1.0 if JD explicitly says "must be on-site 4-5 days/week, no exceptions"
+
+### Time-to-offer priority
+- Working demo + metrics > perfection
+- Apply sooner > learn more
+- 80/20 approach, timebox everything
+
+---
+
+## Tiered Evaluation — Token Efficiency
+
+**MANDATORY: Always run Stage 0 before any full evaluation.**
+
+### Stage 0 — Pre-screen (cheap, ~1K tokens output)
+
+Run BEFORE Bloque A. No WebSearch, no STAR stories.
+
+1. Extract from JD: title, domain, top 5 requirements
+2. **North Star alignment** (1–5): does the role domain map to any of the 6 archetypes?
+   - 5 = exact archetype match (e.g. LLMOps role → LLMOps archetype)
+   - 3 = adjacent match (e.g. PM role with AI focus)
+   - 1 = unrelated domain (e.g. pure frontend, finance, legal)
+3. **Must-have overlap** (1–5): check top 5 JD requirements against cv.md
+   - 5 = 5/5 requirements present or strongly adjacent
+   - 3 = 3/5 present
+   - 1 = ≤1/5 present
+4. **Preliminary score** = 0.4 × alignment + 0.6 × must-have overlap
+5. Decision:
+   - **< 3.0** → Write SKIP TSV to `batch/tracker-additions/`, stop. No further blocks.
+   - **≥ 3.0** → Proceed to full evaluation (Bloque A onwards)
+
+### Verbosity tiers (after Stage 0 passes)
+
+After computing the final score from Bloque B (CV match gives enough signal):
+
+| Score | Sections to generate | Report type |
+|-------|---------------------|-------------|
+| < 3.0 | Stage 0 only → SKIP | No report |
+| 3.0 – 3.9 | A + B + short recommendation | Abbreviated |
+| 4.0 – 4.4 | A + B + C + D (with comp cache) + E | Full minus interview prep |
+| ≥ 4.5 | A + B + C + D + E + F + G | Full with STAR stories + draft answers |
+
+**Do NOT generate Bloque F (interview prep / STAR stories) unless score ≥ 4.0.**
+**Do NOT generate Bloque G (draft answers) unless score ≥ 4.5.**
+
+---
+
 ## Global Rules
 
 ### NEVER

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -111,7 +111,7 @@ If the candidate has a live demo/dashboard (check profile.yml), offer access in 
 
 **Cache-first protocol (saves 3 WebSearch calls per repeated role type):**
 
-Before running WebSearch for comp data in Bloque D:
+Before running WebSearch for comp data in Block D:
 1. Normalize: role title + level (e.g. "senior-ai-engineer"), company stage (seed/series-a/series-b/series-c/public), location (e.g. "remote" or "toronto")
 2. Check cache: `node comp-cache.mjs lookup "{role-level}" "{stage}" "{location}"`
 3. If output is JSON (hit and not expired) → use cached data, skip WebSearch
@@ -155,7 +155,7 @@ Before running WebSearch for comp data in Bloque D:
 
 ### Stage 0 — Pre-screen (cheap, ~1K tokens output)
 
-Run BEFORE Bloque A. No WebSearch, no STAR stories.
+Run BEFORE Block A. No WebSearch, no STAR stories.
 
 1. Extract from JD: title, domain, top 5 requirements
 2. **North Star alignment** (1–5): does the role domain map to any of the 6 archetypes?
@@ -173,7 +173,7 @@ Run BEFORE Bloque A. No WebSearch, no STAR stories.
 
 ### Verbosity tiers (after Stage 0 passes)
 
-After computing the final score from Bloque B (CV match gives enough signal):
+After computing the final score from Block B (CV match gives enough signal):
 
 | Score | Sections to generate | Report type |
 |-------|---------------------|-------------|
@@ -182,8 +182,8 @@ After computing the final score from Bloque B (CV match gives enough signal):
 | 4.0 – 4.4 | A + B + C + D (with comp cache) + E | Full minus interview prep |
 | ≥ 4.5 | A + B + C + D + E + F + G | Full with STAR stories + draft answers |
 
-**Do NOT generate Bloque F (interview prep / STAR stories) unless score ≥ 4.0.**
-**Do NOT generate Bloque G (draft answers) unless score ≥ 4.5.**
+**Do NOT generate Block F (interview prep / STAR stories) unless score ≥ 4.0.**
+**Do NOT generate Block G (draft answers) unless score ≥ 4.5.**
 
 ---
 

--- a/modes/apply.md
+++ b/modes/apply.md
@@ -1,4 +1,4 @@
-# Modo: apply — Asistente de Aplicación en Vivo
+# Mode: apply — Live Application Assistant
 
 Modo interactivo para cuando el candidato está rellenando un formulario de aplicación en Chrome. Lee lo que hay en pantalla, carga el contexto previo de la oferta, y genera respuestas personalizadas para cada pregunta del formulario.
 

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -1,48 +1,48 @@
-# Modo: auto-pipeline — Pipeline Completo Automático
+# Mode: auto-pipeline — Full Automatic Pipeline
 
-Cuando el usuario pega un JD (texto o URL) sin sub-comando explícito, ejecutar TODO el pipeline en secuencia:
+When the user pastes a JD (text or URL) without an explicit sub-command, execute the ENTIRE pipeline in sequence:
 
-## Paso 0 — Extraer JD
+## Step 0 — Extract JD
 
-Si el input es una **URL** (no texto de JD pegado), seguir esta estrategia para extraer el contenido:
+If the input is a **URL** (not pasted JD text), follow this strategy to extract content:
 
-**Orden de prioridad:**
+**Priority order:**
 
-1. **Playwright (preferido):** La mayoría de portales de empleo (Lever, Ashby, Greenhouse, Workday) son SPAs. Usar `browser_navigate` + `browser_snapshot` para renderizar y leer el JD.
-2. **WebFetch (fallback):** Para páginas estáticas (ZipRecruiter, WeLoveProduct, company career pages).
-3. **WebSearch (último recurso):** Buscar título del rol + empresa en portales secundarios que indexan el JD en HTML estático.
+1. **Playwright (preferred):** Most job portals (Lever, Ashby, Greenhouse, Workday) are SPAs. Use `browser_navigate` + `browser_snapshot` to render and read the JD.
+2. **WebFetch (fallback):** For static pages (ZipRecruiter, WeLoveProduct, company career pages).
+3. **WebSearch (last resort):** Search role title + company on secondary portals that index JD in static HTML.
 
-**Si ningún método funciona:** Pedir al candidato que pegue el JD manualmente o comparta un screenshot.
+**If no method works:** Ask candidate to paste JD manually or share a screenshot.
 
-**Si el input es texto de JD** (no URL): usar directamente, sin necesidad de fetch.
+**If input is JD text** (not URL): use directly, no fetch needed.
 
-## Paso 0b — JD Summarization (solo si JD largo)
+## Step 0b — JD Summarization (only if JD is long)
 
-Antes del Stage 0 pre-screen, si el JD es largo (> ~1500 palabras):
-1. Extraer un resumen compacto: título, nivel, top 5 must-haves, top 3 nice-to-haves, ubicación, comp si se menciona (~200 palabras)
-2. Usar este resumen para el Stage 0 pre-screen
-3. Si el pre-screen pasa (≥ 3.0): usar el JD COMPLETO para los bloques A-F (la precisión importa aquí)
-4. Si JD ≤ 1500 palabras: usar el JD completo directamente para todo
+Before Stage 0 pre-screen, if JD is long (> ~1500 words):
+1. Extract a compact summary: title, level, top 5 must-haves, top 3 nice-to-haves, location, comp if mentioned (~200 words)
+2. Use this summary for Stage 0 pre-screen
+3. If pre-screen passes (≥ 3.0): use FULL JD for blocks A-F (precision matters here)
+4. If JD ≤ 1500 words: use complete JD directly for everything
 
-## Paso 1 — Evaluación con Pre-screen
-Ejecutar Stage 0 pre-screen primero (ver `modes/oferta.md`). Si pasa, ejecutar bloques A-F según el tier de score.
+## Step 1 — Evaluation with Pre-screen
+Execute Stage 0 pre-screen first (see `modes/offer.md`). If it passes, execute blocks A-F per score tier.
 
-## Paso 2 — Guardar Report .md
-Guardar la evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (ver formato en `modes/oferta.md`).
+## Step 2 — Save Report .md
+Save complete evaluation to `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (see format in `modes/offer.md`).
 Include Block G in the saved report. Add `**Legitimacy:** {tier}` to the report header.
 
-## Paso 3 — Generar PDF
-Ejecutar el pipeline completo de `pdf` (leer `modes/pdf.md`).
+## Step 3 — Generate PDF
+Execute full `pdf` pipeline (see `modes/pdf.md`).
 
-## Paso 4 — Draft Application Answers (solo si score >= 4.5)
+## Step 4 — Draft Application Answers (only if score >= 4.5)
 
-Si el score final es >= 4.5, generar borrador de respuestas para el formulario de aplicación:
+If final score is >= 4.5, generate draft answers for the application form:
 
-1. **Extraer preguntas del formulario**: Usar Playwright para navegar al formulario y hacer snapshot. Si no se pueden extraer, usar las preguntas genéricas.
-2. **Generar respuestas** siguiendo el tono (ver abajo).
-3. **Guardar en el report** como sección `## H) Draft Application Answers`.
+1. **Extract form questions**: Use Playwright to navigate to form and snapshot. If unable to extract, use generic questions.
+2. **Generate answers** following tone guidelines (see below).
+3. **Save in report** as section `## H) Draft Application Answers`.
 
-### Preguntas genéricas (usar si no se pueden extraer del formulario)
+### Generic questions (use if unable to extract from form)
 
 - Why are you interested in this role?
 - Why do you want to work at [Company]?
@@ -50,29 +50,29 @@ Si el score final es >= 4.5, generar borrador de respuestas para el formulario d
 - What makes you a good fit for this position?
 - How did you hear about this role?
 
-### Tono para Form Answers
+### Tone for Form Answers
 
-**Posición: "I'm choosing you."** el candidato tiene opciones y está eligiendo esta empresa por razones concretas.
+**Position: "I'm choosing you."** The candidate has options and is choosing this company for concrete reasons.
 
-**Reglas de tono:**
-- **Confiado sin arrogancia**: "I've spent the past year building production AI agent systems — your role is where I want to apply that experience next"
-- **Selectivo sin soberbia**: "I've been intentional about finding a team where I can contribute meaningfully from day one"
-- **Específico y concreto**: Siempre referenciar algo REAL del JD o de la empresa, y algo REAL de la experiencia del candidato
-- **Directo, sin fluff**: 2-4 frases por respuesta. Sin "I'm passionate about..." ni "I would love the opportunity to..."
-- **El hook es la prueba, no la afirmación**: En vez de "I'm great at X", decir "I built X that does Y"
+**Tone rules:**
+- **Confident without arrogance**: "I've spent the past year building production AI agent systems — your role is where I want to apply that experience next"
+- **Selective without snobbery**: "I've been intentional about finding a team where I can contribute meaningfully from day one"
+- **Specific and concrete**: Always reference something REAL from the JD or company, and something REAL from the candidate's experience
+- **Direct, no fluff**: 2-4 sentences per answer. No "I'm passionate about..." or "I would love the opportunity to..."
+- **The hook is the proof, not the claim**: Instead of "I'm great at X", say "I built X that does Y"
 
-**Framework por pregunta:**
+**Framework by question:**
 - **Why this role?** → "Your [specific thing] maps directly to [specific thing I built]."
-- **Why this company?** → Mencionar algo concreto sobre la empresa. "I've been using [product] for [time/purpose]."
-- **Relevant experience?** → Un proof point cuantificado. "Built [X] that [metric]. Sold the company in 2025."
+- **Why this company?** → Mention something concrete about the company. "I've been using [product] for [time/purpose]."
+- **Relevant experience?** → A quantified proof point. "Built [X] that [metric]. Sold the company in 2025."
 - **Good fit?** → "I sit at the intersection of [A] and [B], which is exactly where this role lives."
-- **How did you hear?** → Honesto: "Found through [portal/scan], evaluated against my criteria, and it scored highest."
+- **How did you hear?** → Honest: "Found through [portal/scan], evaluated against my criteria, and it scored highest."
 
-**Idioma**: Siempre en el idioma del JD (EN default). Aplicar `/tech-translate`.
+**Language**: Always in the JD's language (EN default). Apply `/tech-translate`.
 
-## Paso 5 — Actualizar Tracker
-Registrar en `data/applications.md` con todas las columnas incluyendo Report y PDF en ✅.
+## Step 5 — Update Tracker
+Register in `data/applications.md` with all columns including Report and PDF as ✅.
 
-**Si el Stage 0 pre-screen falla (< 3.0)**: escribir TSV con status `NO APLICAR`, no generar PDF ni report completo, notificar al candidato con el preliminary score y razón.
+**If Stage 0 pre-screen fails (< 3.0)**: write TSV with status `SKIP`, don't generate PDF or full report, notify candidate with preliminary score and reason.
 
-**Si algún otro paso falla**, continuar con los siguientes y marcar el paso fallido como pendiente en el tracker.
+**If any other step fails**, continue with remaining steps and mark failed step as pending in tracker.

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -16,8 +16,16 @@ Si el input es una **URL** (no texto de JD pegado), seguir esta estrategia para 
 
 **Si el input es texto de JD** (no URL): usar directamente, sin necesidad de fetch.
 
-## Paso 1 — Evaluación A-G
-Ejecutar exactamente igual que el modo `oferta` (leer `modes/oferta.md` para todos los bloques A-F + Block G Posting Legitimacy).
+## Paso 0b — JD Summarization (solo si JD largo)
+
+Antes del Stage 0 pre-screen, si el JD es largo (> ~1500 palabras):
+1. Extraer un resumen compacto: título, nivel, top 5 must-haves, top 3 nice-to-haves, ubicación, comp si se menciona (~200 palabras)
+2. Usar este resumen para el Stage 0 pre-screen
+3. Si el pre-screen pasa (≥ 3.0): usar el JD COMPLETO para los bloques A-F (la precisión importa aquí)
+4. Si JD ≤ 1500 palabras: usar el JD completo directamente para todo
+
+## Paso 1 — Evaluación con Pre-screen
+Ejecutar Stage 0 pre-screen primero (ver `modes/oferta.md`). Si pasa, ejecutar bloques A-F según el tier de score.
 
 ## Paso 2 — Guardar Report .md
 Guardar la evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (ver formato en `modes/oferta.md`).
@@ -65,4 +73,6 @@ Si el score final es >= 4.5, generar borrador de respuestas para el formulario d
 ## Paso 5 — Actualizar Tracker
 Registrar en `data/applications.md` con todas las columnas incluyendo Report y PDF en ✅.
 
-**Si algún paso falla**, continuar con los siguientes y marcar el paso fallido como pendiente en el tracker.
+**Si el Stage 0 pre-screen falla (< 3.0)**: escribir TSV con status `NO APLICAR`, no generar PDF ni report completo, notificar al candidato con el preliminary score y razón.
+
+**Si algún otro paso falla**, continuar con los siguientes y marcar el paso fallido como pendiente en el tracker.

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -1,6 +1,17 @@
-# Modo: oferta — Evaluación Completa A-G
+# Modo: oferta — Evaluación con Pre-screen y Tiers
 
-Cuando el candidato pega una oferta (texto o URL), entregar SIEMPRE los 7 bloques (A-F evaluation + G legitimacy):
+Cuando el candidato pega una oferta (texto o URL), seguir este flujo en orden. Ver reglas de tiering en `_shared.md`.
+
+## Stage 0 — Pre-screen (OBLIGATORIO, ejecutar primero)
+
+Antes de cualquier bloque completo:
+
+1. Extraer del JD: título, dominio, top 5 requisitos
+2. Puntuar **alineación North Star** (1–5): ¿el dominio del rol encaja en alguno de los 6 arquetipos?
+3. Puntuar **overlap de must-haves** (1–5): leer `cv.md`, ¿cuántos de los top 5 requisitos están presentes?
+4. **Preliminary score** = 0.4 × alineación + 0.6 × overlap
+5. Si < 3.0 → escribir TSV con status `NO APLICAR` a `batch/tracker-additions/`, notificar al candidato y PARAR aquí
+6. Si ≥ 3.0 → continuar con Bloque A
 
 ## Paso 0 — Detección de Arquetipo
 
@@ -46,10 +57,15 @@ Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
 
 ## Bloque D — Comp y Demanda
 
-Usar WebSearch para:
-- Salarios actuales del rol (Glassdoor, Levels.fyi, Blind)
-- Reputación de compensación de la empresa
-- Tendencia de demanda del rol
+**Primero verificar caché** (evita WebSearch si ya investigamos este rol):
+```bash
+node comp-cache.mjs lookup "{role-level}" "{company-stage}" "{location}"
+```
+- Si retorna JSON → usar datos cacheados, no hacer WebSearch
+- Si retorna "miss" → hacer WebSearch (Glassdoor, Levels.fyi, Blind) → guardar resultado:
+```bash
+node comp-cache.mjs save "{role-level}" "{company-stage}" "{location}" '{"p25":N,"p50":N,"p75":N,"currency":"USD","sources":["glassdoor"]}'
+```
 
 Tabla con datos y fuentes citadas. Si no hay datos, decirlo en vez de inventar.
 
@@ -62,7 +78,9 @@ Tabla con datos y fuentes citadas. Si no hay datos, decirlo en vez de inventar.
 
 Top 5 cambios al CV + Top 5 cambios a LinkedIn para maximizar match.
 
-## Bloque F — Plan de Entrevistas
+## Bloque F — Plan de Entrevistas *(solo si score ≥ 4.0)*
+
+**SKIP este bloque si el score final es < 4.0.** El candidato no debe invertir en prep de entrevistas para ofertas borderline.
 
 6-10 historias STAR+R mapeadas a requisitos del JD (STAR + **Reflection**):
 
@@ -146,9 +164,13 @@ Analyze the job posting for signals that indicate whether this is a real, active
 
 **SIEMPRE** después de generar los bloques A-G:
 
+### 0. Abbreviated report (score 3.0–3.9)
+
+Si el score final es 3.0–3.9: guardar solo bloques A + B + una recomendación breve (3 frases máximo). No generar C-F. El report se guarda igualmente en `reports/` para referencia.
+
 ### 1. Guardar report .md
 
-Guardar evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+Guardar evaluación en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 
 - `{###}` = siguiente número secuencial (3 dígitos, zero-padded)
 - `{company-slug}` = nombre de empresa en lowercase, sin espacios (usar guiones)

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -1,107 +1,107 @@
-# Modo: oferta — Evaluación con Pre-screen y Tiers
+# Mode: offer — Evaluation with Pre-screen and Tiers
 
-Cuando el candidato pega una oferta (texto o URL), seguir este flujo en orden. Ver reglas de tiering en `_shared.md`.
+When the candidate pastes an offer (text or URL), follow this flow in order. See tiering rules in `_shared.md`.
 
-## Stage 0 — Pre-screen (OBLIGATORIO, ejecutar primero)
+## Stage 0 — Pre-screen (MANDATORY, execute first)
 
-Antes de cualquier bloque completo:
+Before any full block:
 
-1. Extraer del JD: título, dominio, top 5 requisitos
-2. Puntuar **alineación North Star** (1–5): ¿el dominio del rol encaja en alguno de los 6 arquetipos?
-3. Puntuar **overlap de must-haves** (1–5): leer `cv.md`, ¿cuántos de los top 5 requisitos están presentes?
-4. **Preliminary score** = 0.4 × alineación + 0.6 × overlap
-5. Si < 3.0 → escribir TSV con status `NO APLICAR` a `batch/tracker-additions/`, notificar al candidato y PARAR aquí
-6. Si ≥ 3.0 → continuar con Bloque A
+1. Extract from JD: title, domain, top 5 requirements
+2. Score **north star alignment** (1–5): does the role domain fit into one of the 6 archetypes?
+3. Score **must-have overlap** (1–5): read `cv.md`, how many of the top 5 requirements are present?
+4. **Preliminary score** = 0.4 × alignment + 0.6 × overlap
+5. If < 3.0 → write TSV with status `SKIP` to `batch/tracker-additions/`, notify candidate, and STOP here
+6. If ≥ 3.0 → continue with Block A
 
-## Paso 0 — Detección de Arquetipo
+## Step 0 — Archetype Detection
 
-Clasificar la oferta en uno de los 6 arquetipos (ver `_shared.md`). Si es híbrido, indicar los 2 más cercanos. Esto determina:
-- Qué proof points priorizar en bloque B
-- Cómo reescribir el summary en bloque E
-- Qué historias STAR preparar en bloque F
+Classify the offer into one of 6 archetypes (see `_shared.md`). If hybrid, indicate the 2 closest. This determines:
+- Which proof points to prioritize in Block B
+- How to rewrite the summary in Block E
+- Which STAR stories to prepare in Block F
 
-## Bloque A — Resumen del Rol
+## Block A — Role Summary
 
-Tabla con:
-- Arquetipo detectado
+Table with:
+- Detected archetype
 - Domain (platform/agentic/LLMOps/ML/enterprise)
 - Function (build/consult/manage/deploy)
 - Seniority
 - Remote (full/hybrid/onsite)
-- Team size (si se menciona)
-- TL;DR en 1 frase
+- Team size (if mentioned)
+- TL;DR in 1 sentence
 
-## Bloque B — Match con CV
+## Block B — CV Match
 
-Lee `cv.md`. Crea tabla con cada requisito del JD mapeado a líneas exactas del CV.
+Read `cv.md`. Create table with each JD requirement mapped to exact CV lines.
 
-**Adaptado al arquetipo:**
-- Si FDE → priorizar proof points de delivery rápida y client-facing
-- Si SA → priorizar diseño de sistemas e integrations
-- Si PM → priorizar product discovery y métricas
-- Si LLMOps → priorizar evals, observability, pipelines
-- Si Agentic → priorizar multi-agent, HITL, orchestration
-- Si Transformation → priorizar change management, adoption, scaling
+**Adapted by archetype:**
+- FDE → prioritize fast delivery and client-facing proof points
+- SA → prioritize systems design and integrations
+- PM → prioritize product discovery and metrics
+- LLMOps → prioritize evals, observability, pipelines
+- Agentic → prioritize multi-agent, HITL, orchestration
+- Transformation → prioritize change management, adoption, scaling
 
-Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
-1. ¿Es un hard blocker o un nice-to-have?
-2. ¿Puede el candidato demostrar experiencia adyacente?
-3. ¿Hay un proyecto portfolio que cubra este gap?
-4. Plan de mitigación concreto (frase para cover letter, proyecto rápido, etc.)
+**Gaps** section with mitigation strategy for each. For each gap:
+1. Is it a hard blocker or nice-to-have?
+2. Can the candidate demonstrate adjacent experience?
+3. Is there a portfolio project that covers this gap?
+4. Concrete mitigation plan (cover letter phrase, quick project, etc.)
 
-## Bloque C — Nivel y Estrategia
+## Block C — Level and Strategy
 
-1. **Nivel detectado** en el JD vs **nivel natural del candidato para ese arquetipo**
-2. **Plan "vender senior sin mentir"**: frases específicas adaptadas al arquetipo, logros concretos a destacar, cómo posicionar la experiencia de founder como ventaja
-3. **Plan "si me downlevelan"**: aceptar si comp es justa, negociar review a 6 meses, criterios de promoción claros
+1. **Detected level** in JD vs **candidate's natural level for that archetype**
+2. **Plan "sell senior without lying"**: archetype-specific phrases, concrete achievements to highlight, how to position founder experience as an advantage
+3. **Plan "if downleveled"**: accept if comp is fair, negotiate 6-month review, clear promotion criteria
 
-## Bloque D — Comp y Demanda
+## Block D — Comp and Demand
 
-**Primero verificar caché** (evita WebSearch si ya investigamos este rol):
+**First check cache** (avoids WebSearch if we've already researched this role):
 ```bash
 node comp-cache.mjs lookup "{role-level}" "{company-stage}" "{location}"
 ```
-- Si retorna JSON → usar datos cacheados, no hacer WebSearch
-- Si retorna "miss" → hacer WebSearch (Glassdoor, Levels.fyi, Blind) → guardar resultado:
+- If returns JSON → use cached data, don't WebSearch
+- If returns "miss" → do WebSearch (Glassdoor, Levels.fyi, Blind) → save result:
 ```bash
 node comp-cache.mjs save "{role-level}" "{company-stage}" "{location}" '{"p25":N,"p50":N,"p75":N,"currency":"USD","sources":["glassdoor"]}'
 ```
 
-Tabla con datos y fuentes citadas. Si no hay datos, decirlo en vez de inventar.
+Table with data and cited sources. If no data available, say so instead of making it up.
 
-## Bloque E — Plan de Personalización
+## Block E — Personalization Plan
 
-| # | Sección | Estado actual | Cambio propuesto | Por qué |
-|---|---------|---------------|------------------|---------|
+| # | Section | Current | Proposed Change | Why |
+|---|---------|---------|-----------------|-----|
 | 1 | Summary | ... | ... | ... |
 | ... | ... | ... | ... | ... |
 
-Top 5 cambios al CV + Top 5 cambios a LinkedIn para maximizar match.
+Top 5 CV changes + Top 5 LinkedIn changes to maximize match.
 
-## Bloque F — Plan de Entrevistas *(solo si score ≥ 4.0)*
+## Block F — Interview Plan *(only if score ≥ 4.0)*
 
-**SKIP este bloque si el score final es < 4.0.** El candidato no debe invertir en prep de entrevistas para ofertas borderline.
+**SKIP this block if final score is < 4.0.** The candidate should not invest in interview prep for borderline offers.
 
-6-10 historias STAR+R mapeadas a requisitos del JD (STAR + **Reflection**):
+6-10 STAR+R stories mapped to JD requirements (STAR + **Reflection**):
 
-| # | Requisito del JD | Historia STAR+R | S | T | A | R | Reflection |
-|---|-----------------|-----------------|---|---|---|---|------------|
+| # | JD Requirement | STAR+R Story | S | T | A | R | Reflection |
+|---|----------------|--------------|---|---|---|---|------------|
 
 The **Reflection** column captures what was learned or what would be done differently. This signals seniority — junior candidates describe what happened, senior candidates extract lessons.
 
 **Story Bank:** If `interview-prep/story-bank.md` exists, check if any of these stories are already there. If not, append new ones. Over time this builds a reusable bank of 5-10 master stories that can be adapted to any interview question.
 
-**Seleccionadas y enmarcadas según el arquetipo:**
-- FDE → enfatizar velocidad de entrega y client-facing
-- SA → enfatizar decisiones de arquitectura
-- PM → enfatizar discovery y trade-offs
-- LLMOps → enfatizar métricas, evals, production hardening
-- Agentic → enfatizar orchestration, error handling, HITL
-- Transformation → enfatizar adopción, cambio organizacional
+**Selected and framed by archetype:**
+- FDE → emphasize delivery velocity and client-facing impact
+- SA → emphasize architecture decisions
+- PM → emphasize discovery and trade-offs
+- LLMOps → emphasize metrics, evals, production hardening
+- Agentic → emphasize orchestration, error handling, HITL
+- Transformation → emphasize adoption, organizational change
 
-Incluir también:
-- 1 case study recomendado (cuál de sus proyectos presentar y cómo)
-- Preguntas red-flag y cómo responderlas (ej: "¿por qué vendiste tu empresa?", "¿tienes equipo de reports?")
+Also include:
+- 1 recommended case study (which project to present and how)
+- Red-flag questions and how to answer them (e.g., "Why did you sell your company?", "Do you manage direct reports?")
 
 ## Bloque G — Posting Legitimacy
 
@@ -160,79 +160,79 @@ Analyze the job posting for signals that indicate whether this is a real, active
 
 ---
 
-## Post-evaluación
+## Post-evaluation
 
-**SIEMPRE** después de generar los bloques A-G:
+**ALWAYS** after generating blocks A-G:
 
 ### 0. Abbreviated report (score 3.0–3.9)
 
-Si el score final es 3.0–3.9: guardar solo bloques A + B + una recomendación breve (3 frases máximo). No generar C-F. El report se guarda igualmente en `reports/` para referencia.
+If final score is 3.0–3.9: save only blocks A + B + brief recommendation (3 sentences max). Don't generate C-F. Report is still saved in `reports/` for reference.
 
-### 1. Guardar report .md
+### 1. Save report .md
 
-Guardar evaluación en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+Save evaluation to `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 
-- `{###}` = siguiente número secuencial (3 dígitos, zero-padded)
-- `{company-slug}` = nombre de empresa en lowercase, sin espacios (usar guiones)
-- `{YYYY-MM-DD}` = fecha actual
+- `{###}` = next sequential number (3 digits, zero-padded)
+- `{company-slug}` = company name lowercase, no spaces (use hyphens)
+- `{YYYY-MM-DD}` = today's date
 
-**Formato del report:**
+**Report format:**
 
 ```markdown
-# Evaluación: {Empresa} — {Rol}
+# Evaluation: {Company} — {Role}
 
-**Fecha:** {YYYY-MM-DD}
-**Arquetipo:** {detectado}
+**Date:** {YYYY-MM-DD}
+**Archetype:** {detected}
 **Score:** {X/5}
 **Legitimacy:** {High Confidence | Proceed with Caution | Suspicious}
-**PDF:** {ruta o pendiente}
+**PDF:** {path or pending}
 
 ---
 
-## A) Resumen del Rol
-(contenido completo del bloque A)
+## A) Role Summary
+(full Block A content)
 
-## B) Match con CV
-(contenido completo del bloque B)
+## B) CV Match
+(full Block B content)
 
-## C) Nivel y Estrategia
-(contenido completo del bloque C)
+## C) Level and Strategy
+(full Block C content)
 
-## D) Comp y Demanda
-(contenido completo del bloque D)
+## D) Comp and Demand
+(full Block D content)
 
-## E) Plan de Personalización
-(contenido completo del bloque E)
+## E) Personalization Plan
+(full Block E content)
 
-## F) Plan de Entrevistas
-(contenido completo del bloque F)
+## F) Interview Plan
+(full Block F content)
 
 ## G) Posting Legitimacy
-(contenido completo del bloque G)
+(full Block G content)
 
 ## H) Draft Application Answers
-(solo si score >= 4.5 — borradores de respuestas para el formulario de aplicación)
+(only if score >= 4.5 — draft answers for application form)
 
 ---
 
-## Keywords extraídas
-(lista de 15-20 keywords del JD para ATS optimization)
+## Keywords Extracted
+(list of 15-20 keywords from JD for ATS optimization)
 ```
 
-### 2. Registrar en tracker
+### 2. Register in tracker
 
-**SIEMPRE** registrar en `data/applications.md`:
-- Siguiente número secuencial
-- Fecha actual
-- Empresa
-- Rol
-- Score: promedio de match (1-5)
-- Estado: `Evaluada`
-- PDF: ❌ (o ✅ si auto-pipeline generó PDF)
-- Report: link relativo al report .md (ej: `[001](reports/001-company-2026-01-01.md)`)
+**ALWAYS** register in `data/applications.md`:
+- Next sequential number
+- Today's date
+- Company
+- Role
+- Score: average match (1-5)
+- Status: `Evaluated`
+- PDF: ❌ (or ✅ if auto-pipeline generated PDF)
+- Report: relative link to report .md (e.g., `[001](reports/001-company-2026-01-01.md)`)
 
-**Formato del tracker:**
+**Tracker format:**
 
 ```markdown
-| # | Fecha | Empresa | Rol | Score | Estado | PDF | Report |
+| # | Date | Company | Role | Score | Status | PDF | Report |
 ```

--- a/modes/ofertas.md
+++ b/modes/ofertas.md
@@ -1,21 +1,21 @@
-# Modo: ofertas — Comparación Multi-Oferta
+# Mode: offers — Multi-offer Comparison
 
-Scoring matrix de 10 dimensiones ponderadas:
+Scoring matrix of 10 weighted dimensions:
 
-| Dimensión | Peso | Criterios 1-5 |
-|-----------|------|----------------|
-| Alineación North Star | 25% | 5=rol target exacto, 1=no relacionado |
-| Match CV | 15% | 5=90%+ match, 1=<40% match |
-| Nivel (senior+) | 15% | 5=staff+, 4=senior, 3=mid-senior, 2=mid, 1=junior |
-| Comp estimada | 10% | 5=top quartile, 1=below market |
-| Trayectoria crecimiento | 10% | 5=clear path to next level, 1=dead end |
-| Calidad remoto | 5% | 5=full remote async, 1=onsite only |
-| Reputación empresa | 5% | 5=top employer, 1=red flags |
-| Modernidad tech stack | 5% | 5=cutting edge AI/ML, 1=legacy |
-| Velocidad a oferta | 5% | 5=fast process, 1=6+ months |
-| Señales culturales | 5% | 5=builder culture, 1=bureaucratic |
+| Dimension | Weight | Criteria 1-5 |
+|-----------|--------|----------------|
+| North Star alignment | 25% | 5=target role exact, 1=unrelated |
+| CV match | 15% | 5=90%+ match, 1=<40% match |
+| Level (senior+) | 15% | 5=staff+, 4=senior, 3=mid-senior, 2=mid, 1=junior |
+| Estimated comp | 10% | 5=top quartile, 1=below market |
+| Growth trajectory | 10% | 5=clear path to next level, 1=dead end |
+| Remote quality | 5% | 5=full remote async, 1=onsite only |
+| Company reputation | 5% | 5=top employer, 1=red flags |
+| Tech stack modernity | 5% | 5=cutting edge AI/ML, 1=legacy |
+| Speed to offer | 5% | 5=fast process, 1=6+ months |
+| Cultural signals | 5% | 5=builder culture, 1=bureaucratic |
 
-Para cada oferta: score en cada dimensión, score ponderado total.
-Ranking final + recomendación con consideraciones de time-to-offer.
+For each offer: score on each dimension, total weighted score.
+Final ranking + recommendation with time-to-offer considerations.
 
-Pedir al usuario las ofertas si no están en contexto. Puede ser texto, URLs, o referencias a ofertas ya evaluadas en el tracker.
+Ask user for offers if not in context. Can be text, URLs, or references to already-evaluated offers in the tracker.

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -1,140 +1,140 @@
-# Modo: scan — Portal Scanner (Descubrimiento de Ofertas)
+# Mode: scan — Portal Scanner (Offer Discovery)
 
-Escanea portales de empleo configurados, filtra por relevancia de título, y añade nuevas ofertas al pipeline para evaluación posterior.
+Scans configured job portals, filters by title relevance, and adds new offers to the pipeline for later evaluation.
 
-## Ejecución recomendada
+## Recommended Execution
 
-Ejecutar como subagente para no consumir contexto del main:
+Run as subagent to avoid consuming main context:
 
 ```
 Agent(
     subagent_type="general-purpose",
-    prompt="[contenido de este archivo + datos específicos]",
+    prompt="[content of this file + specific data]",
     run_in_background=True
 )
 ```
 
-## Configuración
+## Configuration
 
-Leer `portals.yml` que contiene:
-- `search_queries`: Lista de queries WebSearch con `site:` filters por portal (descubrimiento amplio)
-- `tracked_companies`: Empresas específicas con `careers_url` para navegación directa
-- `title_filter`: Keywords positive/negative/seniority_boost para filtrado de títulos
+Read `portals.yml` which contains:
+- `search_queries`: List of WebSearch queries with `site:` filters per portal (broad discovery)
+- `tracked_companies`: Specific companies with `careers_url` for direct navigation
+- `title_filter`: Positive/negative/seniority_boost keywords for title filtering
 
-## Estrategia de descubrimiento (3 niveles)
+## Discovery Strategy (3 levels)
 
-### Nivel 1 — Playwright directo (PRINCIPAL)
+### Level 1 — Direct Playwright (PRIMARY)
 
-**Para cada empresa en `tracked_companies`:** Navegar a su `careers_url` con Playwright (`browser_navigate` + `browser_snapshot`), leer TODOS los job listings visibles, y extraer título + URL de cada uno. Este es el método más fiable porque:
-- Ve la página en tiempo real (no resultados cacheados de Google)
-- Funciona con SPAs (Ashby, Lever, Workday)
-- Detecta ofertas nuevas al instante
-- No depende de la indexación de Google
+**For each company in `tracked_companies`:** Navigate to its `careers_url` with Playwright (`browser_navigate` + `browser_snapshot`), read ALL visible job listings, and extract title + URL for each. This is the most reliable method because:
+- Sees the page in real time (not cached Google results)
+- Works with SPAs (Ashby, Lever, Workday)
+- Detects new offers instantly
+- Doesn't depend on Google indexing
 
-**Cada empresa DEBE tener `careers_url` en portals.yml.** Si no la tiene, buscarla una vez, guardarla, y usar en futuros scans.
+**Each company MUST have `careers_url` in portals.yml.** If not, find it once, save it, and use in future scans.
 
-### Nivel 2 — Greenhouse API (COMPLEMENTARIO)
+### Level 2 — Greenhouse API (COMPLEMENTARY)
 
-Para empresas con Greenhouse, la API JSON (`boards-api.greenhouse.io/v1/boards/{slug}/jobs`) devuelve datos estructurados limpios. Usar como complemento rápido de Nivel 1 — es más rápido que Playwright pero solo funciona con Greenhouse.
+For companies with Greenhouse, the JSON API (`boards-api.greenhouse.io/v1/boards/{slug}/jobs`) returns clean structured data. Use as a quick complement to Level 1 — faster than Playwright but only works with Greenhouse.
 
-### Nivel 3 — WebSearch queries (DESCUBRIMIENTO AMPLIO)
+### Level 3 — WebSearch queries (BROAD DISCOVERY)
 
-Los `search_queries` con `site:` filters cubren portales de forma transversal (todos los Ashby, todos los Greenhouse, etc.). Útil para descubrir empresas NUEVAS que aún no están en `tracked_companies`, pero los resultados pueden estar desfasados.
+The `search_queries` with `site:` filters cover portals transversally (all Ashby, all Greenhouse, etc.). Useful for discovering NEW companies not yet in `tracked_companies`, but results may be outdated.
 
-**Prioridad de ejecución:**
-1. Nivel 1: Playwright → todas las `tracked_companies` con `careers_url`
-2. Nivel 2: API → todas las `tracked_companies` con `api:`
-3. Nivel 3: WebSearch → todos los `search_queries` con `enabled: true`
+**Execution priority:**
+1. Level 1: Playwright → all `tracked_companies` with `careers_url`
+2. Level 2: API → all `tracked_companies` with `api:`
+3. Level 3: WebSearch → all `search_queries` with `enabled: true`
 
-Los niveles son aditivos — se ejecutan todos, los resultados se mezclan y deduplicar.
+Levels are additive — all execute, results mix and deduplicate.
 
 ## Workflow
 
-1. **Leer configuración**: `portals.yml`
-2. **Leer historial**: `data/scan-history.tsv` → URLs ya vistas
-3. **Leer dedup sources**: `data/applications.md` + `data/pipeline.md`
+1. **Read configuration**: `portals.yml`
+2. **Read history**: `data/scan-history.tsv` → URLs already seen
+3. **Read dedup sources**: `data/applications.md` + `data/pipeline.md`
 
-4. **Nivel 1 — Playwright scan** (paralelo en batches de 3-5):
-   Para cada empresa en `tracked_companies` con `enabled: true` y `careers_url` definida:
-   a. `browser_navigate` a la `careers_url`
-   b. `browser_snapshot` para leer todos los job listings
-   c. Si la página tiene filtros/departamentos, navegar las secciones relevantes
-   d. Para cada job listing extraer: `{title, url, company}`
-   e. Si la página pagina resultados, navegar páginas adicionales
-   f. Acumular en lista de candidatos
-   g. Si `careers_url` falla (404, redirect), intentar `scan_query` como fallback y anotar para actualizar la URL
+4. **Level 1 — Playwright scan** (parallel in batches of 3-5):
+   For each company in `tracked_companies` with `enabled: true` and `careers_url` defined:
+   a. `browser_navigate` to the `careers_url`
+   b. `browser_snapshot` to read all job listings
+   c. If page has filters/departments, navigate relevant sections
+   d. For each job listing extract: `{title, url, company}`
+   e. If page paginates results, navigate additional pages
+   f. Accumulate in candidates list
+   g. If `careers_url` fails (404, redirect), try `scan_query` as fallback and note for URL update
 
-5. **Nivel 2 — Greenhouse APIs** (paralelo):
-   Para cada empresa en `tracked_companies` con `api:` definida y `enabled: true`:
-   a. WebFetch de la URL de API → JSON con lista de jobs
-   b. Para cada job extraer: `{title, url, company}`
-   c. Acumular en lista de candidatos (dedup con Nivel 1)
+5. **Level 2 — Greenhouse APIs** (parallel):
+   For each company in `tracked_companies` with `api:` defined and `enabled: true`:
+   a. WebFetch from API URL → JSON with jobs list
+   b. For each job extract: `{title, url, company}`
+   c. Accumulate in candidates list (dedup with Level 1)
 
-6. **Nivel 3 — WebSearch queries** (paralelo si posible):
-   Para cada query en `search_queries` con `enabled: true`:
-   a. Ejecutar WebSearch con el `query` definido
-   b. De cada resultado extraer: `{title, url, company}`
-      - **title**: del título del resultado (antes del " @ " o " | ")
-      - **url**: URL del resultado
-      - **company**: después del " @ " en el título, o extraer del dominio/path
-   c. Acumular en lista de candidatos (dedup con Nivel 1+2)
+6. **Level 3 — WebSearch queries** (parallel if possible):
+   For each query in `search_queries` with `enabled: true`:
+   a. Execute WebSearch with defined `query`
+   b. From each result extract: `{title, url, company}`
+      - **title**: from result title (before " @ " or " | ")
+      - **url**: URL of result
+      - **company**: after " @ " in title, or extract from domain/path
+   c. Accumulate in candidates list (dedup with Level 1+2)
 
-6. **Filtrar por título** usando `title_filter` de `portals.yml`:
-   - Al menos 1 keyword de `positive` debe aparecer en el título (case-insensitive)
-   - 0 keywords de `negative` deben aparecer
-   - `seniority_boost` keywords dan prioridad pero no son obligatorios
+6. **Filter by title** using `title_filter` from `portals.yml`:
+   - At least 1 keyword from `positive` must appear in title (case-insensitive)
+   - 0 keywords from `negative` should appear
+   - `seniority_boost` keywords give priority but not required
 
-7. **Deduplicar** contra 3 fuentes:
-   - `scan-history.tsv` → URL exacta ya vista
-   - `applications.md` → empresa + rol normalizado ya evaluado
-   - `pipeline.md` → URL exacta ya en pendientes o procesadas
+7. **Deduplicate** against 3 sources:
+   - `scan-history.tsv` → exact URL already seen
+   - `applications.md` → company + normalized role already evaluated
+   - `pipeline.md` → exact URL already pending or processed
 
-7.5. **Verificar liveness de resultados de WebSearch (Nivel 3)** — ANTES de añadir a pipeline:
+7.5. **Verify liveness of WebSearch results (Level 3)** — BEFORE adding to pipeline:
 
-   Los resultados de WebSearch pueden estar desactualizados (Google cachea resultados durante semanas o meses). Para evitar evaluar ofertas expiradas, verificar con Playwright cada URL nueva que provenga del Nivel 3. Los Niveles 1 y 2 son inherentemente en tiempo real y no requieren esta verificación.
+   WebSearch results may be outdated (Google caches results for weeks or months). To avoid evaluating expired offers, verify with Playwright each new URL from Level 3. Levels 1 and 2 are inherently real-time and do not require this check.
 
-   Para cada URL nueva de Nivel 3 (secuencial — NUNCA Playwright en paralelo):
-   a. `browser_navigate` a la URL
-   b. `browser_snapshot` para leer el contenido
-   c. Clasificar:
-      - **Activa**: título del puesto visible + descripción del rol + control visible de Apply/Submit/Solicitar dentro del contenido principal. No contar texto genérico de header/navbar/footer.
-      - **Expirada** (cualquiera de estas señales):
-        - URL final contiene `?error=true` (Greenhouse redirige así cuando la oferta está cerrada)
-        - Página contiene: "job no longer available" / "no longer open" / "position has been filled" / "this job has expired" / "page not found"
-        - Solo navbar y footer visibles, sin contenido JD (contenido < ~300 chars)
-   d. Si expirada: registrar en `scan-history.tsv` con status `skipped_expired` y descartar
-   e. Si activa: continuar al paso 8
+   For each new Level 3 URL (sequential — NEVER Playwright in parallel):
+   a. `browser_navigate` to the URL
+   b. `browser_snapshot` to read the content
+   c. Classify:
+      - **Active**: job title visible + role description + Apply/Submit button visible within main content. Generic header/navbar/footer text does not count.
+      - **Expired** (any of these signals):
+        - Final URL contains `?error=true` (Greenhouse redirects this way when an offer is closed)
+        - Page contains: "job no longer available" / "no longer open" / "position has been filled" / "this job has expired" / "page not found"
+        - Only navbar and footer visible, no JD content (content < ~300 chars)
+   d. If expired: record in `scan-history.tsv` with status `skipped_expired` and discard
+   e. If active: continue to step 8
 
-   **No interrumpir el scan entero si una URL falla.** Si `browser_navigate` da error (timeout, 403, etc.), marcar como `skipped_expired` y continuar con la siguiente.
+   **Do not abort the entire scan if one URL fails.** If `browser_navigate` returns an error (timeout, 403, etc.), mark as `skipped_expired` and continue with the next.
 
-8. **Para cada oferta nueva verificada que pase filtros**:
-   a. Añadir a `pipeline.md` sección "Pendientes": `- [ ] {url} | {company} | {title}`
-   b. Registrar en `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
+8. **For each new verified offer that passes filters**:
+   a. Add to `pipeline.md` "Pending" section: `- [ ] {url} | {company} | {title}`
+   b. Register in `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
 
-9. **Ofertas filtradas por título**: registrar en `scan-history.tsv` con status `skipped_title`
-10. **Ofertas duplicadas**: registrar con status `skipped_dup`
-11. **Ofertas expiradas (Nivel 3)**: registrar con status `skipped_expired`
+9. **Title-filtered offers**: register in `scan-history.tsv` with status `skipped_title`
+10. **Duplicate offers**: register with status `skipped_dup`
+11. **Expired offers (Level 3)**: register with status `skipped_expired`
 
-## Extracción de título y empresa de WebSearch results
+## Extracting Title and Company from WebSearch Results
 
-Los resultados de WebSearch vienen en formato: `"Job Title @ Company"` o `"Job Title | Company"` o `"Job Title — Company"`.
+WebSearch results come in format: `"Job Title @ Company"` or `"Job Title | Company"` or `"Job Title — Company"`.
 
-Patrones de extracción por portal:
+Extraction patterns by portal:
 - **Ashby**: `"Senior AI PM (Remote) @ EverAI"` → title: `Senior AI PM`, company: `EverAI`
 - **Greenhouse**: `"AI Engineer at Anthropic"` → title: `AI Engineer`, company: `Anthropic`
 - **Lever**: `"Product Manager - AI @ Temporal"` → title: `Product Manager - AI`, company: `Temporal`
 
-Regex genérico: `(.+?)(?:\s*[@|—–-]\s*|\s+at\s+)(.+?)$`
+Generic regex: `(.+?)(?:\s*[@|—–-]\s*|\s+at\s+)(.+?)$`
 
-## URLs privadas
+## Private URLs
 
-Si se encuentra una URL no accesible públicamente:
-1. Guardar el JD en `jds/{company}-{role-slug}.md`
-2. Añadir a pipeline.md como: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title}`
+If a non-publicly accessible URL is found:
+1. Save the JD to `jds/{company}-{role-slug}.md`
+2. Add to pipeline.md as: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title}`
 
 ## Scan History
 
-`data/scan-history.tsv` trackea TODAS las URLs vistas:
+`data/scan-history.tsv` tracks ALL URLs seen:
 
 ```
 url	first_seen	portal	title	company	status
@@ -144,50 +144,50 @@ https://...	2026-02-10	Ashby — AI PM	SA AI	OldCo	skipped_dup
 https://...	2026-02-10	WebSearch — AI PM	PM AI	ClosedCo	skipped_expired
 ```
 
-## Resumen de salida
+## Output Summary
 
 ```
 Portal Scan — {YYYY-MM-DD}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━
-Queries ejecutados: N
-Ofertas encontradas: N total
-Filtradas por título: N relevantes
-Duplicadas: N (ya evaluadas o en pipeline)
-Expiradas descartadas: N (links muertos, Nivel 3)
-Nuevas añadidas a pipeline.md: N
+Queries executed: N
+Offers found: N total
+Title-filtered: N relevant
+Duplicates: N (already evaluated or in pipeline)
+Expired discarded: N (dead links, Level 3)
+New offers added to pipeline.md: N
 
   + {company} | {title} | {query_name}
   ...
 
-→ Ejecuta /career-ops pipeline para evaluar las nuevas ofertas.
+→ Run /career-ops pipeline to evaluate new offers.
 ```
 
-## Gestión de careers_url
+## Managing careers_url
 
-Cada empresa en `tracked_companies` debe tener `careers_url` — la URL directa a su página de ofertas. Esto evita buscarlo cada vez.
+Each company in `tracked_companies` should have `careers_url` — the direct URL to its offers page. This avoids searching for it each time.
 
-**Patrones conocidos por plataforma:**
+**Known patterns by platform:**
 - **Ashby:** `https://jobs.ashbyhq.com/{slug}`
-- **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` o `https://job-boards.eu.greenhouse.io/{slug}`
+- **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` or `https://job-boards.eu.greenhouse.io/{slug}`
 - **Lever:** `https://jobs.lever.co/{slug}`
-- **Custom:** La URL propia de la empresa (ej: `https://openai.com/careers`)
+- **Custom:** Company's own URL (e.g., `https://openai.com/careers`)
 
-**Si `careers_url` no existe** para una empresa:
-1. Intentar el patrón de su plataforma conocida
-2. Si falla, hacer un WebSearch rápido: `"{company}" careers jobs`
-3. Navegar con Playwright para confirmar que funciona
-4. **Guardar la URL encontrada en portals.yml** para futuros scans
+**If `careers_url` doesn't exist** for a company:
+1. Try the pattern for its known platform
+2. If it fails, do a quick WebSearch: `"{company}" careers jobs`
+3. Navigate with Playwright to confirm it works
+4. **Save the found URL in portals.yml** for future scans
 
-**Si `careers_url` devuelve 404 o redirect:**
-1. Anotar en el resumen de salida
-2. Intentar scan_query como fallback
-3. Marcar para actualización manual
+**If `careers_url` returns 404 or redirect:**
+1. Note in output summary
+2. Try scan_query as fallback
+3. Mark for manual update
 
-## Mantenimiento del portals.yml
+## Maintaining portals.yml
 
-- **SIEMPRE guardar `careers_url`** cuando se añade una empresa nueva
-- Añadir nuevos queries según se descubran portales o roles interesantes
-- Desactivar queries con `enabled: false` si generan demasiado ruido
-- Ajustar keywords de filtrado según evolucionen los roles target
-- Añadir empresas a `tracked_companies` cuando interese seguirlas de cerca
-- Verificar `careers_url` periódicamente — las empresas cambian de plataforma ATS
+- **ALWAYS save `careers_url`** when adding a new company
+- Add new queries as you discover portals or interesting roles
+- Disable queries with `enabled: false` if they generate too much noise
+- Adjust filtering keywords as your target roles evolve
+- Add companies to `tracked_companies` when you want to follow them closely
+- Verify `careers_url` periodically — companies change ATS platforms

--- a/modes/tracker.md
+++ b/modes/tracker.md
@@ -1,23 +1,23 @@
-# Modo: tracker — Tracker de Aplicaciones
+# Mode: tracker — Applications Tracker
 
-Lee y muestra `data/applications.md`.
+Reads and displays `data/applications.md`.
 
-**Formato del tracker:**
+**Tracker format:**
 ```markdown
-| # | Fecha | Empresa | Rol | Score | Estado | PDF | Report |
+| # | Date | Company | Role | Score | Status | PDF | Report |
 ```
 
-Estados posibles: `Evaluada` → `Aplicado` → `Respondido` → `Contacto` → `Entrevista` → `Oferta` / `Rechazada` / `Descartada` / `NO APLICAR`
+Possible statuses: `Evaluated` → `Applied` → `Responded` → `Contact` → `Interview` → `Offer` / `Rejected` / `Discarded` / `SKIP`
 
-- `Aplicado` = el candidato envió su candidatura
-- `Respondido` = Un recruiter/empresa contactó y el candidato respondió (inbound)
-- `Contacto` = El candidato contactó proactivamente a alguien de la empresa (outbound, ej: LinkedIn power move)
+- `Applied` = candidate submitted their application
+- `Responded` = Recruiter/company contacted and candidate responded (inbound)
+- `Contact` = Candidate proactively contacted someone at the company (outbound, e.g., LinkedIn power move)
 
-Si el usuario pide actualizar un estado, editar la fila correspondiente.
+If user asks to update a status, edit the corresponding row.
 
-Mostrar también estadísticas:
-- Total de aplicaciones
-- Por estado
-- Score promedio
-- % con PDF generado
-- % con report generado
+Also display statistics:
+- Total applications
+- By status
+- Average score
+- % with PDF generated
+- % with report generated

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -83,7 +83,10 @@ function normalizeStatus(raw) {
   return { status: null, unknown: true };
 }
 
+export { normalizeStatus };
+
 // Read applications.md
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
 if (!existsSync(APPS_FILE)) {
   console.log('No applications.md found. Nothing to normalize.');
   process.exit(0);
@@ -162,3 +165,5 @@ if (!DRY_RUN && changes > 0) {
 } else {
   console.log('✅ No changes needed');
 }
+
+} // end main guard

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -28,29 +28,46 @@ function normalizeStatus(raw) {
   let s = raw.replace(/\*\*/g, '').trim();
   const lower = s.toLowerCase();
 
-  // DUPLICADO variants → Discarded
-  if (/^duplicado/i.test(s) || /^dup\b/i.test(s)) {
+  // DUPLICADO/DUPLICATE variants → Discarded
+  if (/^duplicado/i.test(s) || /^duplicated?/i.test(s) || /^dup\b/i.test(s)) {
     return { status: 'Discarded', moveToNotes: raw.trim() };
   }
 
-  // CERRADA / Cancelada / Descartada → Discarded
-  if (/^cerrada$/i.test(s)) return { status: 'Discarded' };
-  if (/^cancelada/i.test(s)) return { status: 'Discarded' };
-  if (/^descartada$/i.test(s)) return { status: 'Discarded' };
+  // CERRADA/CLOSED → Discarded
+  if (/^cerrada$/i.test(s) || /^closed$/i.test(s)) return { status: 'Discarded' };
+
+  // Cancelada/Canceled (possibly with date) → Discarded
+  if (/^cancelada/i.test(s) || /^canceled?/i.test(s)) return { status: 'Discarded' };
+
+  // Descartada/Discarded → Discarded
+  if (/^descartada$/i.test(s) || /^discarded$/i.test(s)) return { status: 'Discarded' };
+
+  // Descartado → Discarded
   if (/^descartado$/i.test(s)) return { status: 'Discarded' };
 
-  // Rechazada / Rechazado → Rejected
-  if (/^rechazada?$/i.test(s)) return { status: 'Rejected' };
-  if (/^rechazado\s+\d{4}/i.test(s)) return { status: 'Rejected' };
+  // Rechazada/Rejected → Rejected
+  if (/^rechazada?$/i.test(s) || /^rejected$/i.test(s)) return { status: 'Rejected' };
 
-  // Aplicado with date → Applied (strip date)
-  if (/^aplicado\s+\d{4}/i.test(s)) return { status: 'Applied' };
+  // Rechazado/Rejected with date → Rejected (strip date)
+  if (/^rechazado\s+\d{4}/i.test(s) || /^rejected\s+\d{4}/i.test(s)) return { status: 'Rejected' };
 
-  // CONDICIONAL / HOLD / EVALUAR / Verificar → Evaluated
-  if (/^(condicional|hold|evaluar|verificar)$/i.test(s)) return { status: 'Evaluated' };
+  // Aplicado/Applied with date → Applied (strip date)
+  if (/^aplicado\s+\d{4}/i.test(s) || /^applied\s+\d{4}/i.test(s)) return { status: 'Applied' };
+
+  // CONDICIONAL/CONDITIONAL → Evaluated
+  if (/^condicional$/i.test(s) || /^conditional$/i.test(s)) return { status: 'Evaluated' };
+
+  // HOLD → Evaluated
+  if (/^hold$/i.test(s)) return { status: 'Evaluated' };
 
   // MONITOR → SKIP
   if (/^monitor$/i.test(s)) return { status: 'SKIP' };
+
+  // EVALUAR/EVALUATE → Evaluated
+  if (/^evaluar$/i.test(s) || /^evaluate$/i.test(s)) return { status: 'Evaluated' };
+
+  // Verificar/VERIFY → Evaluated
+  if (/^verificar$/i.test(s) || /^verify$/i.test(s)) return { status: 'Evaluated' };
 
   // GEO BLOCKER → SKIP
   if (/geo.?blocker/i.test(s)) return { status: 'SKIP' };
@@ -67,16 +84,21 @@ function normalizeStatus(raw) {
     'Offer', 'Rejected', 'Discarded', 'SKIP',
   ];
   for (const c of canonical) {
-    if (lower === c.toLowerCase()) return { status: c };
+    const mapping = {
+      'Evaluada': 'Evaluated', 'Aplicado': 'Applied', 'Respondido': 'Responded',
+      'Entrevista': 'Interview', 'Oferta': 'Offer', 'Rechazado': 'Rejected',
+      'Descartado': 'Discarded', 'NO APLICAR': 'SKIP',
+    };
+    if (lower === c.toLowerCase()) return { status: mapping[c] || c };
   }
 
-  // Spanish aliases → English canonicals
+  // Spanish → English aliases
   if (['evaluada'].includes(lower)) return { status: 'Evaluated' };
   if (['aplicado', 'enviada', 'aplicada', 'applied', 'sent'].includes(lower)) return { status: 'Applied' };
   if (['respondido'].includes(lower)) return { status: 'Responded' };
   if (['entrevista'].includes(lower)) return { status: 'Interview' };
   if (['oferta'].includes(lower)) return { status: 'Offer' };
-  if (['cerrada', 'descartada'].includes(lower)) return { status: 'Discarded' };
+  if (['cerrada', 'descartada', 'closed', 'discarded', 'canceled'].includes(lower)) return { status: 'Discarded' };
   if (['no aplicar', 'no_aplicar', 'skip'].includes(lower)) return { status: 'SKIP' };
 
   // Unknown — flag it

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -45,8 +45,8 @@ function normalizeStatus(raw) {
   // Descartado → Discarded
   if (/^descartado$/i.test(s)) return { status: 'Discarded' };
 
-  // Rechazada/Rejected → Rejected
-  if (/^rechazada?$/i.test(s) || /^rejected$/i.test(s)) return { status: 'Rejected' };
+  // Rechazada/Rechazado/Rejected → Rejected
+  if (/^rechazad[ao]$/i.test(s) || /^rejected$/i.test(s)) return { status: 'Rejected' };
 
   // Rechazado/Rejected with date → Rejected (strip date)
   if (/^rechazado\s+\d{4}/i.test(s) || /^rejected\s+\d{4}/i.test(s)) return { status: 'Rejected' };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "description": "AI-powered job search pipeline built on Claude Code",
   "scripts": {
+    "test": "node --test test/*.test.mjs",
+    "test:watch": "node --test --watch test/*.test.mjs",
     "doctor": "node doctor.mjs",
     "verify": "node verify-pipeline.mjs",
     "normalize": "node normalize-statuses.mjs",
@@ -14,7 +16,8 @@
     "update": "node update-system.mjs apply",
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
-    "scan": "node scan.mjs"
+    "scan": "node scan.mjs",
+    "comp-cache": "node comp-cache.mjs"
   },
   "keywords": [
     "ai",

--- a/test/comp-cache.test.mjs
+++ b/test/comp-cache.test.mjs
@@ -1,0 +1,239 @@
+/**
+ * test/comp-cache.test.mjs — Unit tests for comp-cache.mjs
+ *
+ * Uses an in-memory approach: tests the exported pure functions directly
+ * without touching the real data/comp-cache.yml file.
+ */
+
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildKey, isExpired, parseCache, serializeCache } from '../comp-cache.mjs';
+
+// ---------------------------------------------------------------------------
+// buildKey
+// ---------------------------------------------------------------------------
+describe('buildKey', () => {
+  test('normalizes role to lowercase with hyphens', () => {
+    const key = buildKey('Senior AI Engineer', 'series-b', 'remote');
+    assert.ok(key.startsWith('senior-ai-engineer-'), `Key: ${key}`);
+  });
+
+  test('normalizes stage', () => {
+    const key = buildKey('ml-engineer', 'Series B', 'remote');
+    assert.ok(key.includes('series-b'), `Key: ${key}`);
+  });
+
+  test('normalizes location', () => {
+    const key = buildKey('ml-engineer', 'series-b', 'Toronto, ON');
+    assert.ok(key.includes('toronto--on') || key.includes('toronto-on'), `Key: ${key}`);
+  });
+
+  test('includes year and quarter', () => {
+    const key = buildKey('engineer', 'seed', 'remote');
+    const now = new Date();
+    const year = now.getFullYear();
+    const quarter = Math.ceil((now.getMonth() + 1) / 3);
+    assert.ok(key.includes(`${year}-Q${quarter}`), `Key ${key} should contain ${year}-Q${quarter}`);
+  });
+
+  test('same inputs produce same key', () => {
+    const key1 = buildKey('Senior AI Engineer', 'series-b', 'remote');
+    const key2 = buildKey('Senior AI Engineer', 'series-b', 'remote');
+    assert.equal(key1, key2);
+  });
+
+  test('strips leading/trailing hyphens from segments', () => {
+    const key = buildKey('  AI Engineer  ', 'series-b', 'remote');
+    assert.ok(!key.startsWith('-'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isExpired
+// ---------------------------------------------------------------------------
+describe('isExpired', () => {
+  test('returns true for entry with no fetched date', () => {
+    assert.ok(isExpired({}));
+    assert.ok(isExpired({ fetched: '' }));
+  });
+
+  test('returns true for entry with invalid date', () => {
+    assert.ok(isExpired({ fetched: 'not-a-date', ttl_days: 60 }));
+  });
+
+  test('returns false for entry fetched today', () => {
+    const today = new Date().toISOString().split('T')[0];
+    assert.ok(!isExpired({ fetched: today, ttl_days: 60 }));
+  });
+
+  test('returns false for entry fetched 30 days ago with 60-day TTL', () => {
+    const past = new Date();
+    past.setDate(past.getDate() - 30);
+    const entry = { fetched: past.toISOString().split('T')[0], ttl_days: 60 };
+    assert.ok(!isExpired(entry));
+  });
+
+  test('returns true for entry fetched 61 days ago with 60-day TTL', () => {
+    const past = new Date();
+    past.setDate(past.getDate() - 61);
+    const entry = { fetched: past.toISOString().split('T')[0], ttl_days: 60 };
+    assert.ok(isExpired(entry));
+  });
+
+  test('respects custom ttl_days', () => {
+    const past = new Date();
+    past.setDate(past.getDate() - 6);
+    // 6 days old with 5-day TTL → expired
+    const expired = { fetched: past.toISOString().split('T')[0], ttl_days: 5 };
+    assert.ok(isExpired(expired));
+    // 6 days old with 10-day TTL → fresh
+    const fresh = { fetched: past.toISOString().split('T')[0], ttl_days: 10 };
+    assert.ok(!isExpired(fresh));
+  });
+
+  test('defaults to 60-day TTL when ttl_days missing', () => {
+    const recent = new Date();
+    recent.setDate(recent.getDate() - 30);
+    // 30 days old, no ttl_days → use 60-day default → not expired
+    const entry = { fetched: recent.toISOString().split('T')[0] };
+    assert.ok(!isExpired(entry));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseCache + serializeCache — round-trip
+// ---------------------------------------------------------------------------
+describe('parseCache', () => {
+  test('parses empty string to empty entries', () => {
+    const result = parseCache('');
+    assert.deepEqual(result, { entries: {} });
+  });
+
+  test('parses null/undefined gracefully', () => {
+    const result = parseCache(null);
+    assert.deepEqual(result, { entries: {} });
+  });
+
+  test('parses a single entry', () => {
+    const yaml = `entries:
+  senior-ml-engineer-series-b-remote-2026-Q1:
+    p25: 180000
+    p50: 210000
+    p75: 260000
+    currency: USD
+    sources: glassdoor,levels.fyi
+    fetched: "2026-03-15"
+    ttl_days: 60
+`;
+    const result = parseCache(yaml);
+    assert.ok(result.entries['senior-ml-engineer-series-b-remote-2026-Q1']);
+    const entry = result.entries['senior-ml-engineer-series-b-remote-2026-Q1'];
+    assert.equal(entry.p25, 180000);
+    assert.equal(entry.p50, 210000);
+    assert.equal(entry.p75, 260000);
+    assert.equal(entry.currency, 'USD');
+    assert.equal(entry.sources, 'glassdoor,levels.fyi');
+    assert.equal(entry.fetched, '2026-03-15');
+    assert.equal(entry.ttl_days, 60);
+  });
+
+  test('parses multiple entries', () => {
+    const yaml = `entries:
+  key-one:
+    p50: 150000
+    fetched: "2026-01-01"
+    ttl_days: 60
+  key-two:
+    p50: 200000
+    fetched: "2026-02-01"
+    ttl_days: 60
+`;
+    const result = parseCache(yaml);
+    assert.ok(result.entries['key-one']);
+    assert.ok(result.entries['key-two']);
+    assert.equal(result.entries['key-one'].p50, 150000);
+    assert.equal(result.entries['key-two'].p50, 200000);
+  });
+
+  test('ignores comment lines', () => {
+    const yaml = `# This is a comment
+entries:
+  # another comment
+  my-key:
+    p50: 100000
+    fetched: "2026-01-01"
+    ttl_days: 60
+`;
+    const result = parseCache(yaml);
+    assert.ok(result.entries['my-key']);
+    assert.equal(result.entries['my-key'].p50, 100000);
+  });
+});
+
+describe('serializeCache', () => {
+  test('serializes an empty cache', () => {
+    const yaml = serializeCache({ entries: {} });
+    assert.ok(yaml.startsWith('entries:'));
+  });
+
+  test('round-trips correctly', () => {
+    const original = {
+      entries: {
+        'test-key-2026-Q2': {
+          p25: 170000,
+          p50: 200000,
+          p75: 250000,
+          currency: 'USD',
+          sources: 'glassdoor',
+          fetched: '2026-04-01',
+          ttl_days: 60,
+        },
+      },
+    };
+    const yaml = serializeCache(original);
+    const reparsed = parseCache(yaml);
+    assert.equal(reparsed.entries['test-key-2026-Q2'].p50, 200000);
+    assert.equal(reparsed.entries['test-key-2026-Q2'].currency, 'USD');
+    assert.equal(reparsed.entries['test-key-2026-Q2'].fetched, '2026-04-01');
+  });
+
+  test('each entry appears as indented block', () => {
+    const cache = {
+      entries: {
+        'role-stage-location-2026-Q1': {
+          p50: 180000,
+          fetched: '2026-01-15',
+          ttl_days: 60,
+        },
+      },
+    };
+    const yaml = serializeCache(cache);
+    assert.ok(yaml.includes('  role-stage-location-2026-Q1:'));
+    assert.ok(yaml.includes('    p50: 180000'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: parseCache ↔ isExpired with fixture file
+// ---------------------------------------------------------------------------
+describe('integration: fixture file', () => {
+  test('reads sample fixture and checks expiry correctly', async () => {
+    const { readFileSync } = await import('fs');
+    const { join, dirname } = await import('path');
+    const { fileURLToPath } = await import('url');
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+
+    const raw = readFileSync(join(__dirname, 'fixtures/comp-cache-sample.yml'), 'utf-8');
+    const cache = parseCache(raw);
+
+    // Fresh entry (fetched recently)
+    const freshKey = 'senior-ml-engineer-series-b-remote-2026-Q1';
+    assert.ok(cache.entries[freshKey], 'fresh entry should exist');
+    assert.ok(!isExpired(cache.entries[freshKey]), 'entry fetched 2026-03-15 should still be fresh (within 60 days of 2026-04-06)');
+
+    // Expired entry (fetched 2025-12-01, >60 days ago)
+    const expiredKey = 'staff-ai-engineer-public-toronto-2026-Q1';
+    assert.ok(cache.entries[expiredKey], 'expired entry should exist in file');
+    assert.ok(isExpired(cache.entries[expiredKey]), 'entry fetched 2025-12-01 should be expired by 2026-04-06');
+  });
+});

--- a/test/fixtures/comp-cache-sample.yml
+++ b/test/fixtures/comp-cache-sample.yml
@@ -1,0 +1,17 @@
+entries:
+  senior-ml-engineer-series-b-remote-2026-Q1:
+    p25: 180000
+    p50: 210000
+    p75: 260000
+    currency: USD
+    sources: glassdoor,levels.fyi
+    fetched: "2026-03-15"
+    ttl_days: 60
+  staff-ai-engineer-public-toronto-2026-Q1:
+    p25: 150000
+    p50: 180000
+    p75: 220000
+    currency: CAD
+    sources: glassdoor
+    fetched: "2025-12-01"
+    ttl_days: 60

--- a/test/fixtures/sample-jd-long.txt
+++ b/test/fixtures/sample-jd-long.txt
@@ -1,0 +1,65 @@
+Staff AI Platform Engineer — Enterprise AI Solutions Inc.
+
+About Us:
+Enterprise AI Solutions Inc. is a rapidly growing company specializing in enterprise-grade AI automation. Founded in 2021, we have grown to 350 employees across 12 countries. Our platform processes over 10 million AI-powered workflows per day for Fortune 500 customers. We are backed by top-tier investors and recently closed a Series C round of $120M.
+
+Our engineering team is passionate about building reliable, scalable AI systems that enterprises can trust. We believe in a culture of ownership, transparency, and continuous learning. We hold weekly all-hands meetings, monthly retrospectives, and quarterly planning sessions. We offer flexible remote work options across North America, Europe, and APAC regions.
+
+The Role:
+We are seeking a Staff AI Platform Engineer to join our core platform team. You will be responsible for designing and implementing the foundational infrastructure that powers our AI capabilities. This is a senior individual contributor role with significant scope and impact.
+
+In this role, you will architect and build the systems that allow our product teams to ship AI features rapidly and reliably. You will work closely with ML researchers, product managers, and customer success teams to understand requirements and translate them into robust technical solutions.
+
+Key Responsibilities:
+- Design and implement scalable LLM inference infrastructure serving production traffic
+- Build evaluation frameworks to measure model performance, safety, and reliability
+- Develop monitoring and observability systems for AI model behavior in production
+- Create developer tooling that enables product teams to integrate AI capabilities efficiently
+- Lead technical reviews and architectural decisions for AI platform components
+- Collaborate with ML research team to productionize new models and techniques
+- Drive best practices for prompt engineering, model evaluation, and deployment
+- Mentor junior engineers and contribute to technical culture
+- Partner with security team to ensure AI systems meet compliance requirements
+- Contribute to internal technical blog and engineering documentation
+
+Requirements:
+- 7+ years of software engineering experience with 3+ years focused on AI/ML systems
+- Strong Python programming skills; experience with TypeScript a plus
+- Production experience with LLMs (OpenAI, Anthropic, open-source models)
+- Experience with RAG architectures, vector databases, and semantic search
+- Deep understanding of distributed systems, API design, and microservices
+- Experience with containerization (Docker, Kubernetes) and cloud platforms (AWS, GCP, or Azure)
+- Strong understanding of software testing, CI/CD pipelines, and reliability engineering
+- Experience with evaluation frameworks for LLMs (automated evals, human eval pipelines)
+- Excellent communication skills — you can explain complex technical concepts to non-engineers
+- Track record of leading technical projects from conception to production
+- Experience working in a fast-paced startup or scale-up environment
+
+Nice to Have:
+- Experience with multi-agent AI systems and orchestration frameworks (LangChain, LlamaIndex, AutoGen)
+- Familiarity with fine-tuning and model adaptation techniques (LoRA, QLoRA, RLHF)
+- Experience with MLOps platforms (MLflow, Weights & Biases, Arize, Datadog LLM observability)
+- Contributions to open-source AI/ML projects
+- Experience with regulatory compliance in AI (EU AI Act, NIST AI RMF)
+- Background in designing AI systems for regulated industries (healthcare, finance, legal)
+
+What We Offer:
+- Competitive compensation: $220,000 - $300,000 base salary + equity package
+- Comprehensive benefits including health, dental, vision, and mental health coverage
+- $5,000 annual learning and development budget
+- Flexible remote work with optional access to offices in San Francisco, New York, London, and Toronto
+- 25 days PTO plus company holidays
+- Home office stipend of $2,000 to set up your workspace
+- Regular team offsites and company retreats
+- Access to latest AI tools and research papers
+
+Our Interview Process:
+1. Initial recruiter call (30 min)
+2. Technical phone screen with engineering manager (45 min)
+3. Take-home technical assessment (3-4 hours)
+4. Virtual onsite: 4 interviews over one day (system design, coding, behavioral, cross-functional)
+5. Reference checks and offer
+
+We are committed to building a diverse and inclusive team. We encourage applications from candidates of all backgrounds. We provide reasonable accommodations for candidates with disabilities throughout our interview process.
+
+To apply, submit your resume and a brief cover letter explaining why you are interested in this role and what excites you about AI platform engineering. Applications without cover letters will be reviewed but prioritized lower.

--- a/test/fixtures/sample-jd-short.txt
+++ b/test/fixtures/sample-jd-short.txt
@@ -1,0 +1,16 @@
+Senior AI Engineer — Acme Corp
+
+We are looking for a Senior AI Engineer to join our platform team. You will build and maintain LLM-powered systems in production.
+
+Requirements:
+- 3+ years experience with Python and ML frameworks
+- Experience deploying LLMs to production (RAG, fine-tuning, or inference)
+- Familiarity with evaluation frameworks (evals, observability)
+- Strong communication skills
+
+Nice to have:
+- Experience with multi-agent systems
+- Familiarity with LangChain or similar orchestration frameworks
+
+Location: Remote (North America preferred)
+Compensation: $180,000 - $240,000 USD + equity

--- a/test/fixtures/sample-tracker.md
+++ b/test/fixtures/sample-tracker.md
@@ -1,0 +1,14 @@
+# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-01-10 | Anthropic | Senior AI Engineer | 4.5/5 | Evaluated | ✅ | [1](reports/001-anthropic-2026-01-10.md) | Strong LLMOps match |
+| 2 | 2026-01-12 | OpenAI | Technical PM | 3.8/5 | Applied | ✅ | [2](reports/002-openai-2026-01-12.md) | Borderline fit |
+| 3 | 2026-01-15 | Cohere | ML Platform Engineer | 4.2/5 | Interview | ❌ | [3](reports/003-cohere-2026-01-15.md) | Toronto HQ, remote ok |
+| 4 | 2026-01-18 | Mistral | Solutions Architect | 2.8/5 | SKIP | ❌ | [4](reports/004-mistral-2026-01-18.md) | Requires French fluency |
+| 5 | 2026-01-20 | Ada | AI Product Manager | 4.0/5 | Evaluated | ✅ | [5](reports/005-ada-2026-01-20.md) | Toronto based |
+| 6 | 2026-01-22 | Retool | Forward Deployed Engineer | 3.5/5 | Discarded | ❌ | [6](reports/006-retool-2026-01-22.md) | Offer closed |
+| 7 | 2026-01-25 | ElevenLabs | LLMOps Engineer | 4.8/5 | Offer | ✅ | [7](reports/007-elevenlabs-2026-01-25.md) | Best match this cycle |
+| 8 | 2026-01-28 | LangChain | Staff Engineer | 3.2/5 | Rejected | ❌ | [8](reports/008-langchain-2026-01-28.md) | Overqualified feedback |
+| 9 | 2026-02-01 | Pinecone | AI Platform Lead | 4.1/5 | Responded | ✅ | [9](reports/009-pinecone-2026-02-01.md) | Scheduling call |
+| 10 | 2026-02-05 | Vercel | Senior AI Engineer | 3.0/5 | Evaluated | ❌ | [10](reports/010-vercel-2026-02-05.md) | Weak infra background match |

--- a/test/fixtures/tracker-additions/001-valid.tsv
+++ b/test/fixtures/tracker-additions/001-valid.tsv
@@ -1,0 +1,1 @@
+11	2026-02-10	Glean	AI Solutions Architect	Evaluada	4.3/5	✅	[11](reports/011-glean-2026-02-10.md)	Strong enterprise AI match

--- a/test/fixtures/tracker-additions/001-valid.tsv
+++ b/test/fixtures/tracker-additions/001-valid.tsv
@@ -1,1 +1,1 @@
-11	2026-02-10	Glean	AI Solutions Architect	Evaluada	4.3/5	✅	[11](reports/011-glean-2026-02-10.md)	Strong enterprise AI match
+11	2026-02-10	Glean	AI Solutions Architect	Evaluated	4.3/5	✅	[11](reports/011-glean-2026-02-10.md)	Strong enterprise AI match

--- a/test/fixtures/tracker-additions/002-score-before-status.tsv
+++ b/test/fixtures/tracker-additions/002-score-before-status.tsv
@@ -1,0 +1,1 @@
+12	2026-02-12	Arize AI	ML Observability Engineer	4.1/5	Evaluada	✅	[12](reports/012-arize-2026-02-12.md)	Score before status column order

--- a/test/fixtures/tracker-additions/002-score-before-status.tsv
+++ b/test/fixtures/tracker-additions/002-score-before-status.tsv
@@ -1,1 +1,1 @@
-12	2026-02-12	Arize AI	ML Observability Engineer	4.1/5	Evaluada	✅	[12](reports/012-arize-2026-02-12.md)	Score before status column order
+12	2026-02-12	Arize AI	ML Observability Engineer	4.1/5	Evaluated	✅	[12](reports/012-arize-2026-02-12.md)	Score before status column order

--- a/test/fixtures/tracker-additions/003-duplicate.tsv
+++ b/test/fixtures/tracker-additions/003-duplicate.tsv
@@ -1,1 +1,1 @@
-5	2026-02-14	Ada	AI Product Manager	Evaluada	4.3/5	✅	[5](reports/005-ada-2026-01-20.md)	Re-eval with higher score
+5	2026-02-14	Ada	AI Product Manager	Evaluated	4.3/5	✅	[5](reports/005-ada-2026-01-20.md)	Re-eval with higher score

--- a/test/fixtures/tracker-additions/003-duplicate.tsv
+++ b/test/fixtures/tracker-additions/003-duplicate.tsv
@@ -1,0 +1,1 @@
+5	2026-02-14	Ada	AI Product Manager	Evaluada	4.3/5	✅	[5](reports/005-ada-2026-01-20.md)	Re-eval with higher score

--- a/test/merge-tracker.test.mjs
+++ b/test/merge-tracker.test.mjs
@@ -11,57 +11,54 @@ import { validateStatus, normalizeCompany, roleFuzzyMatch, extractReportNum, par
 // ---------------------------------------------------------------------------
 describe('validateStatus', () => {
   test('canonical statuses pass through unchanged', () => {
-    assert.equal(validateStatus('Evaluada'), 'Evaluada');
-    assert.equal(validateStatus('Aplicado'), 'Aplicado');
-    assert.equal(validateStatus('Respondido'), 'Respondido');
-    assert.equal(validateStatus('Entrevista'), 'Entrevista');
-    assert.equal(validateStatus('Oferta'), 'Oferta');
-    assert.equal(validateStatus('Rechazado'), 'Rechazado');
-    assert.equal(validateStatus('Descartado'), 'Descartado');
-    assert.equal(validateStatus('NO APLICAR'), 'NO APLICAR');
+    assert.equal(validateStatus('Evaluated'), 'Evaluated');
+    assert.equal(validateStatus('Applied'), 'Applied');
+    assert.equal(validateStatus('Responded'), 'Responded');
+    assert.equal(validateStatus('Interview'), 'Interview');
+    assert.equal(validateStatus('Offer'), 'Offer');
+    assert.equal(validateStatus('Rejected'), 'Rejected');
+    assert.equal(validateStatus('Discarded'), 'Discarded');
+    assert.equal(validateStatus('SKIP'), 'SKIP');
   });
 
   test('canonical statuses are case-insensitive', () => {
-    assert.equal(validateStatus('evaluada'), 'Evaluada');
-    assert.equal(validateStatus('APLICADO'), 'Aplicado');
-    assert.equal(validateStatus('no aplicar'), 'NO APLICAR');
+    assert.equal(validateStatus('evaluated'), 'Evaluated');
+    assert.equal(validateStatus('APPLIED'), 'Applied');
+    assert.equal(validateStatus('skip'), 'SKIP');
   });
 
   test('strips markdown bold before matching', () => {
-    assert.equal(validateStatus('**Evaluada**'), 'Evaluada');
-    assert.equal(validateStatus('**Rechazado**'), 'Rechazado');
+    assert.equal(validateStatus('**Evaluated**'), 'Evaluated');
+    assert.equal(validateStatus('**Rejected**'), 'Rejected');
   });
 
   test('strips trailing dates before matching', () => {
-    assert.equal(validateStatus('Aplicado 2026-01-15'), 'Aplicado');
-    assert.equal(validateStatus('Rechazado 2026-03-10 notes'), 'Rechazado');
+    assert.equal(validateStatus('Applied 2026-01-15'), 'Applied');
+    assert.equal(validateStatus('Rejected 2026-03-10 notes'), 'Rejected');
   });
 
   test('known aliases map to canonical', () => {
-    assert.equal(validateStatus('enviada'), 'Aplicado');
-    assert.equal(validateStatus('aplicada'), 'Aplicado');
-    assert.equal(validateStatus('applied'), 'Aplicado');
-    assert.equal(validateStatus('sent'), 'Aplicado');
-    assert.equal(validateStatus('cerrada'), 'Descartado');
-    assert.equal(validateStatus('descartada'), 'Descartado');
-    assert.equal(validateStatus('cancelada'), 'Descartado');
-    assert.equal(validateStatus('rechazada'), 'Rechazado');
-    assert.equal(validateStatus('no aplicar'), 'NO APLICAR');
-    assert.equal(validateStatus('no_aplicar'), 'NO APLICAR');
-    assert.equal(validateStatus('skip'), 'NO APLICAR');
-    assert.equal(validateStatus('monitor'), 'NO APLICAR');
+    assert.equal(validateStatus('sent'), 'Applied');
+    assert.equal(validateStatus('applied'), 'Applied');
+    assert.equal(validateStatus('closed'), 'Discarded');
+    assert.equal(validateStatus('discarded'), 'Discarded');
+    assert.equal(validateStatus('canceled'), 'Discarded');
+    assert.equal(validateStatus('rejected'), 'Rejected');
+    assert.equal(validateStatus('skip'), 'SKIP');
+    assert.equal(validateStatus('skip_apply'), 'SKIP');
+    assert.equal(validateStatus('monitor'), 'SKIP');
   });
 
-  test('DUPLICADO variants map to Descartado', () => {
-    assert.equal(validateStatus('duplicado'), 'Descartado');
-    assert.equal(validateStatus('DUPLICADO #123'), 'Descartado');
-    assert.equal(validateStatus('dup'), 'Descartado');
-    assert.equal(validateStatus('repost'), 'Descartado');
+  test('DUPLICATE variants map to Discarded', () => {
+    assert.equal(validateStatus('duplicate'), 'Discarded');
+    assert.equal(validateStatus('DUPLICATED #123'), 'Discarded');
+    assert.equal(validateStatus('dup'), 'Discarded');
+    assert.equal(validateStatus('repost'), 'Discarded');
   });
 
   test('unknown status defaults to Evaluada', () => {
-    assert.equal(validateStatus('something-unknown'), 'Evaluada');
-    assert.equal(validateStatus('pending'), 'Evaluada');
+    assert.equal(validateStatus('something-unknown'), 'Evaluated');
+    assert.equal(validateStatus('pending'), 'Evaluated');
   });
 });
 
@@ -165,7 +162,7 @@ describe('parseTsvContent - 9-col status-before-score', () => {
     assert.equal(result.num, 11);
     assert.equal(result.company, 'Glean');
     assert.equal(result.role, 'AI Solutions Architect');
-    assert.equal(result.status, 'Evaluada');
+    assert.equal(result.status, 'Evaluated');
     assert.equal(result.score, '4.3/5');
     assert.equal(result.pdf, '✅');
     assert.equal(result.notes, 'Strong match');
@@ -175,7 +172,7 @@ describe('parseTsvContent - 9-col status-before-score', () => {
     const content = '12\t2026-02-12\tArize AI\tML Observability Engineer\t4.1/5\tEvaluada\t✅\t[12](reports/012-arize-2026-02-12.md)\tSwapped columns';
     const result = parseTsvContent(content, '002-swapped.tsv');
     assert.ok(result !== null);
-    assert.equal(result.status, 'Evaluada');
+    assert.equal(result.status, 'Evaluated');
     assert.equal(result.score, '4.1/5');
     assert.equal(result.company, 'Arize AI');
   });
@@ -198,9 +195,9 @@ describe('parseTsvContent - 9-col status-before-score', () => {
   });
 
   test('normalizes alias statuses in TSV', () => {
-    const content = '13\t2026-02-15\tAcme\tSenior Engineer\taplicada\t3.5/5\t❌\t[13](reports/013-acme-2026-02-15.md)\tnotes';
+    const content = '13\t2026-02-15\tAcme\tSenior Engineer\tapplied\t3.5/5\t❌\t[13](reports/013-acme-2026-02-15.md)\tnotes';
     const result = parseTsvContent(content, 'alias.tsv');
-    assert.equal(result.status, 'Aplicado');
+    assert.equal(result.status, 'Applied');
   });
 });
 
@@ -215,7 +212,7 @@ describe('parseTsvContent - pipe-delimited', () => {
     assert.equal(result.num, 15);
     assert.equal(result.company, 'Mistral');
     assert.equal(result.score, '3.9/5');
-    assert.equal(result.status, 'Evaluada');
+    assert.equal(result.status, 'Evaluated');
   });
 
   test('returns null for pipe-delimited with fewer than 8 fields', () => {

--- a/test/merge-tracker.test.mjs
+++ b/test/merge-tracker.test.mjs
@@ -1,0 +1,226 @@
+/**
+ * test/merge-tracker.test.mjs — Unit tests for merge-tracker.mjs exported functions
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateStatus, normalizeCompany, roleFuzzyMatch, extractReportNum, parseScore, parseTsvContent } from '../merge-tracker.mjs';
+
+// ---------------------------------------------------------------------------
+// validateStatus
+// ---------------------------------------------------------------------------
+describe('validateStatus', () => {
+  test('canonical statuses pass through unchanged', () => {
+    assert.equal(validateStatus('Evaluada'), 'Evaluada');
+    assert.equal(validateStatus('Aplicado'), 'Aplicado');
+    assert.equal(validateStatus('Respondido'), 'Respondido');
+    assert.equal(validateStatus('Entrevista'), 'Entrevista');
+    assert.equal(validateStatus('Oferta'), 'Oferta');
+    assert.equal(validateStatus('Rechazado'), 'Rechazado');
+    assert.equal(validateStatus('Descartado'), 'Descartado');
+    assert.equal(validateStatus('NO APLICAR'), 'NO APLICAR');
+  });
+
+  test('canonical statuses are case-insensitive', () => {
+    assert.equal(validateStatus('evaluada'), 'Evaluada');
+    assert.equal(validateStatus('APLICADO'), 'Aplicado');
+    assert.equal(validateStatus('no aplicar'), 'NO APLICAR');
+  });
+
+  test('strips markdown bold before matching', () => {
+    assert.equal(validateStatus('**Evaluada**'), 'Evaluada');
+    assert.equal(validateStatus('**Rechazado**'), 'Rechazado');
+  });
+
+  test('strips trailing dates before matching', () => {
+    assert.equal(validateStatus('Aplicado 2026-01-15'), 'Aplicado');
+    assert.equal(validateStatus('Rechazado 2026-03-10 notes'), 'Rechazado');
+  });
+
+  test('known aliases map to canonical', () => {
+    assert.equal(validateStatus('enviada'), 'Aplicado');
+    assert.equal(validateStatus('aplicada'), 'Aplicado');
+    assert.equal(validateStatus('applied'), 'Aplicado');
+    assert.equal(validateStatus('sent'), 'Aplicado');
+    assert.equal(validateStatus('cerrada'), 'Descartado');
+    assert.equal(validateStatus('descartada'), 'Descartado');
+    assert.equal(validateStatus('cancelada'), 'Descartado');
+    assert.equal(validateStatus('rechazada'), 'Rechazado');
+    assert.equal(validateStatus('no aplicar'), 'NO APLICAR');
+    assert.equal(validateStatus('no_aplicar'), 'NO APLICAR');
+    assert.equal(validateStatus('skip'), 'NO APLICAR');
+    assert.equal(validateStatus('monitor'), 'NO APLICAR');
+  });
+
+  test('DUPLICADO variants map to Descartado', () => {
+    assert.equal(validateStatus('duplicado'), 'Descartado');
+    assert.equal(validateStatus('DUPLICADO #123'), 'Descartado');
+    assert.equal(validateStatus('dup'), 'Descartado');
+    assert.equal(validateStatus('repost'), 'Descartado');
+  });
+
+  test('unknown status defaults to Evaluada', () => {
+    assert.equal(validateStatus('something-unknown'), 'Evaluada');
+    assert.equal(validateStatus('pending'), 'Evaluada');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeCompany
+// ---------------------------------------------------------------------------
+describe('normalizeCompany', () => {
+  test('lowercases and strips non-alphanumeric', () => {
+    assert.equal(normalizeCompany('OpenAI'), 'openai');
+    assert.equal(normalizeCompany('ElevenLabs'), 'elevenlabs');
+    assert.equal(normalizeCompany('Arize AI'), 'arizeai');
+    assert.equal(normalizeCompany('Ada (Toronto)'), 'adatoronto');
+    assert.equal(normalizeCompany('n8n'), 'n8n');
+  });
+
+  test('handles punctuation and special chars', () => {
+    assert.equal(normalizeCompany('Company, Inc.'), 'companyinc');
+    assert.equal(normalizeCompany('A.I. Corp'), 'aicorp');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// roleFuzzyMatch
+// ---------------------------------------------------------------------------
+describe('roleFuzzyMatch', () => {
+  test('exact match returns true', () => {
+    assert.ok(roleFuzzyMatch('Senior AI Engineer', 'Senior AI Engineer'));
+  });
+
+  test('matches when 2+ significant words overlap', () => {
+    // "Product" and "Manager" both len>3 and both in B → 2 overlaps → true
+    assert.ok(roleFuzzyMatch('AI Product Manager', 'Technical AI Product Manager'));
+    // "Platform" and "Engineer" both len>3 and both in B → 2 overlaps → true
+    assert.ok(roleFuzzyMatch('LLMOps Platform Engineer', 'Senior AI Platform Engineer'));
+  });
+
+  test('no match when words differ substantially', () => {
+    assert.ok(!roleFuzzyMatch('Frontend Developer', 'LLMOps Engineer'));
+    assert.ok(!roleFuzzyMatch('Sales Representative', 'Staff AI Engineer'));
+  });
+
+  test('short words (<=3 chars) are ignored', () => {
+    // "AI" is 2 chars — should be ignored; only long words count
+    assert.ok(!roleFuzzyMatch('AI PM', 'AI SRE'));
+  });
+
+  test('partial word containment counts', () => {
+    // "engineer" contains "engineer" and "platform" contains "platform"
+    assert.ok(roleFuzzyMatch('Platform Engineer', 'Senior Platform Engineering Lead'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractReportNum
+// ---------------------------------------------------------------------------
+describe('extractReportNum', () => {
+  test('extracts number from markdown link', () => {
+    assert.equal(extractReportNum('[42](reports/042-company-2026-01-01.md)'), 42);
+    assert.equal(extractReportNum('[1](reports/001-acme-2026-02-10.md)'), 1);
+    assert.equal(extractReportNum('[123](reports/123-test-2026-03-15.md)'), 123);
+  });
+
+  test('returns null when no link present', () => {
+    assert.equal(extractReportNum('N/A'), null);
+    assert.equal(extractReportNum(''), null);
+    assert.equal(extractReportNum('❌'), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseScore
+// ---------------------------------------------------------------------------
+describe('parseScore', () => {
+  test('parses decimal score from X/5 format', () => {
+    assert.equal(parseScore('4.2/5'), 4.2);
+    assert.equal(parseScore('3.8/5'), 3.8);
+    assert.equal(parseScore('5/5'), 5);
+    assert.equal(parseScore('1.0/5'), 1.0);
+  });
+
+  test('strips markdown bold before parsing', () => {
+    assert.equal(parseScore('**4.5/5**'), 4.5);
+    assert.equal(parseScore('**3.0**'), 3.0);
+  });
+
+  test('returns 0 for N/A or unparseable', () => {
+    assert.equal(parseScore('N/A'), 0);
+    assert.equal(parseScore('DUP'), 0);
+    assert.equal(parseScore(''), 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTsvContent — 9-column format (status before score)
+// ---------------------------------------------------------------------------
+describe('parseTsvContent - 9-col status-before-score', () => {
+  test('parses standard 9-column TSV correctly', () => {
+    const content = '11\t2026-02-10\tGlean\tAI Solutions Architect\tEvaluada\t4.3/5\t✅\t[11](reports/011-glean-2026-02-10.md)\tStrong match';
+    const result = parseTsvContent(content, '001-valid.tsv');
+    assert.ok(result !== null);
+    assert.equal(result.num, 11);
+    assert.equal(result.company, 'Glean');
+    assert.equal(result.role, 'AI Solutions Architect');
+    assert.equal(result.status, 'Evaluada');
+    assert.equal(result.score, '4.3/5');
+    assert.equal(result.pdf, '✅');
+    assert.equal(result.notes, 'Strong match');
+  });
+
+  test('parses TSV with score-before-status column order (auto-detect)', () => {
+    const content = '12\t2026-02-12\tArize AI\tML Observability Engineer\t4.1/5\tEvaluada\t✅\t[12](reports/012-arize-2026-02-12.md)\tSwapped columns';
+    const result = parseTsvContent(content, '002-swapped.tsv');
+    assert.ok(result !== null);
+    assert.equal(result.status, 'Evaluada');
+    assert.equal(result.score, '4.1/5');
+    assert.equal(result.company, 'Arize AI');
+  });
+
+  test('returns null for malformed TSV with fewer than 8 fields', () => {
+    const content = '1\t2026-01-01\tCompany\tRole';
+    const result = parseTsvContent(content, 'bad.tsv');
+    assert.equal(result, null);
+  });
+
+  test('returns null for invalid entry number', () => {
+    const content = 'abc\t2026-01-01\tCompany\tRole\tEvaluada\t3.0/5\t❌\t[0](reports/000.md)\tnotes';
+    const result = parseTsvContent(content, 'bad-num.tsv');
+    assert.equal(result, null);
+  });
+
+  test('returns null for empty content', () => {
+    const result = parseTsvContent('', 'empty.tsv');
+    assert.equal(result, null);
+  });
+
+  test('normalizes alias statuses in TSV', () => {
+    const content = '13\t2026-02-15\tAcme\tSenior Engineer\taplicada\t3.5/5\t❌\t[13](reports/013-acme-2026-02-15.md)\tnotes';
+    const result = parseTsvContent(content, 'alias.tsv');
+    assert.equal(result.status, 'Aplicado');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTsvContent — pipe-delimited format
+// ---------------------------------------------------------------------------
+describe('parseTsvContent - pipe-delimited', () => {
+  test('parses pipe-delimited markdown row', () => {
+    const content = '| 15 | 2026-02-20 | Mistral | Staff Engineer | 3.9/5 | Evaluada | ❌ | [15](reports/015-mistral-2026-02-20.md) | Notes here |';
+    const result = parseTsvContent(content, 'pipe.tsv');
+    assert.ok(result !== null);
+    assert.equal(result.num, 15);
+    assert.equal(result.company, 'Mistral');
+    assert.equal(result.score, '3.9/5');
+    assert.equal(result.status, 'Evaluada');
+  });
+
+  test('returns null for pipe-delimited with fewer than 8 fields', () => {
+    const content = '| 1 | 2026-01-01 | Company |';
+    const result = parseTsvContent(content, 'bad-pipe.tsv');
+    assert.equal(result, null);
+  });
+});

--- a/test/normalize-statuses.test.mjs
+++ b/test/normalize-statuses.test.mjs
@@ -11,7 +11,7 @@ import { normalizeStatus } from '../normalize-statuses.mjs';
 // ---------------------------------------------------------------------------
 describe('normalizeStatus - already canonical', () => {
   test('returns canonical as-is (no change)', () => {
-    const canonical = ['Evaluada', 'Aplicado', 'Respondido', 'Entrevista', 'Oferta', 'Rechazado', 'Descartado', 'NO APLICAR'];
+    const canonical = ['Evaluated', 'Applied', 'Responded', 'Interview', 'Offer', 'Rejected', 'Discarded', 'SKIP'];
     for (const s of canonical) {
       const result = normalizeStatus(s);
       assert.equal(result.status, s, `Expected "${s}" to remain unchanged`);
@@ -19,138 +19,138 @@ describe('normalizeStatus - already canonical', () => {
   });
 
   test('case-insensitive match still returns proper casing', () => {
-    assert.equal(normalizeStatus('evaluada').status, 'Evaluada');
-    assert.equal(normalizeStatus('APLICADO').status, 'Aplicado');
-    assert.equal(normalizeStatus('no aplicar').status, 'NO APLICAR');
+    assert.equal(normalizeStatus('evaluada').status, 'Evaluated');
+    assert.equal(normalizeStatus('APLICADO').status, 'Applied');
+    assert.equal(normalizeStatus('no aplicar').status, 'SKIP');
   });
 });
 
 describe('normalizeStatus - markdown bold stripping', () => {
   test('strips ** and returns canonical', () => {
-    assert.equal(normalizeStatus('**Evaluada**').status, 'Evaluada');
-    assert.equal(normalizeStatus('**Rechazado**').status, 'Rechazado');
-    assert.equal(normalizeStatus('**Applied**').status, 'Aplicado');
+    assert.equal(normalizeStatus('**Evaluada**').status, 'Evaluated');
+    assert.equal(normalizeStatus('**Rechazado**').status, 'Rejected');
+    assert.equal(normalizeStatus('**Applied**').status, 'Applied');
   });
 });
 
 describe('normalizeStatus - date stripping', () => {
-  test('Aplicado with date → Aplicado', () => {
-    assert.equal(normalizeStatus('Aplicado 2026-01-15').status, 'Aplicado');
+  test('Applied with date → Applied', () => {
+    assert.equal(normalizeStatus('Applied 2026-01-15').status, 'Applied');
   });
 
-  test('Rechazado with date → Rechazado', () => {
-    assert.equal(normalizeStatus('Rechazado 2026-03-10').status, 'Rechazado');
+  test('Rechazado with date → Rejected', () => {
+    assert.equal(normalizeStatus('Rechazado 2026-03-10').status, 'Rejected');
   });
 });
 
 describe('normalizeStatus - alias mapping', () => {
-  test('enviada → Aplicado', () => {
-    assert.equal(normalizeStatus('enviada').status, 'Aplicado');
+  test('enviada → Applied', () => {
+    assert.equal(normalizeStatus('enviada').status, 'Applied');
   });
 
-  test('aplicada → Aplicado', () => {
-    assert.equal(normalizeStatus('aplicada').status, 'Aplicado');
+  test('aplicada → Applied', () => {
+    assert.equal(normalizeStatus('aplicada').status, 'Applied');
   });
 
-  test('applied → Aplicado', () => {
-    assert.equal(normalizeStatus('applied').status, 'Aplicado');
+  test('applied → Applied', () => {
+    assert.equal(normalizeStatus('applied').status, 'Applied');
   });
 
-  test('sent → Aplicado', () => {
-    assert.equal(normalizeStatus('sent').status, 'Aplicado');
+  test('sent → Applied', () => {
+    assert.equal(normalizeStatus('sent').status, 'Applied');
   });
 
-  test('cerrada → Descartado', () => {
-    assert.equal(normalizeStatus('cerrada').status, 'Descartado');
+  test('cerrada → Discarded', () => {
+    assert.equal(normalizeStatus('cerrada').status, 'Discarded');
   });
 
-  test('descartada → Descartado', () => {
-    assert.equal(normalizeStatus('descartada').status, 'Descartado');
+  test('descartada → Discarded', () => {
+    assert.equal(normalizeStatus('descartada').status, 'Discarded');
   });
 
-  test('rechazada → Rechazado', () => {
-    assert.equal(normalizeStatus('rechazada').status, 'Rechazado');
+  test('rechazada → Rejected', () => {
+    assert.equal(normalizeStatus('rechazada').status, 'Rejected');
   });
 
-  test('no_aplicar → NO APLICAR', () => {
-    assert.equal(normalizeStatus('no_aplicar').status, 'NO APLICAR');
+  test('no_aplicar → SKIP', () => {
+    assert.equal(normalizeStatus('no_aplicar').status, 'SKIP');
   });
 
-  test('no aplicar → NO APLICAR', () => {
-    assert.equal(normalizeStatus('no aplicar').status, 'NO APLICAR');
+  test('no aplicar → SKIP', () => {
+    assert.equal(normalizeStatus('no aplicar').status, 'SKIP');
   });
 
-  test('skip → NO APLICAR', () => {
-    assert.equal(normalizeStatus('skip').status, 'NO APLICAR');
+  test('skip → SKIP', () => {
+    assert.equal(normalizeStatus('skip').status, 'SKIP');
   });
 });
 
 describe('normalizeStatus - DUPLICADO variants', () => {
-  test('duplicado → Descartado with moveToNotes', () => {
+  test('duplicado → Discarded with moveToNotes', () => {
     const result = normalizeStatus('duplicado');
-    assert.equal(result.status, 'Descartado');
+    assert.equal(result.status, 'Discarded');
     assert.ok(result.moveToNotes);
   });
 
-  test('DUPLICADO #123 → Descartado with moveToNotes', () => {
+  test('DUPLICADO #123 → Discarded with moveToNotes', () => {
     const result = normalizeStatus('DUPLICADO #123');
-    assert.equal(result.status, 'Descartado');
+    assert.equal(result.status, 'Discarded');
     assert.ok(result.moveToNotes);
   });
 
-  test('dup → Descartado', () => {
-    assert.equal(normalizeStatus('dup').status, 'Descartado');
+  test('dup → Discarded', () => {
+    assert.equal(normalizeStatus('dup').status, 'Discarded');
   });
 
-  test('repost → Descartado', () => {
+  test('repost → Discarded', () => {
     const result = normalizeStatus('repost #456');
-    assert.equal(result.status, 'Descartado');
+    assert.equal(result.status, 'Discarded');
     assert.ok(result.moveToNotes);
   });
 });
 
 describe('normalizeStatus - other aliases', () => {
-  test('condicional → Evaluada', () => {
-    assert.equal(normalizeStatus('condicional').status, 'Evaluada');
+  test('condicional → Evaluated', () => {
+    assert.equal(normalizeStatus('condicional').status, 'Evaluated');
   });
 
-  test('hold → Evaluada', () => {
-    assert.equal(normalizeStatus('hold').status, 'Evaluada');
+  test('hold → Evaluated', () => {
+    assert.equal(normalizeStatus('hold').status, 'Evaluated');
   });
 
-  test('monitor → Evaluada', () => {
-    assert.equal(normalizeStatus('monitor').status, 'Evaluada');
+  test('monitor → Evaluated', () => {
+    assert.equal(normalizeStatus('monitor').status, 'Evaluated');
   });
 
-  test('evaluar → Evaluada', () => {
-    assert.equal(normalizeStatus('evaluar').status, 'Evaluada');
+  test('evaluar → Evaluated', () => {
+    assert.equal(normalizeStatus('evaluar').status, 'Evaluated');
   });
 
-  test('verificar → Evaluada', () => {
-    assert.equal(normalizeStatus('verificar').status, 'Evaluada');
+  test('verificar → Evaluated', () => {
+    assert.equal(normalizeStatus('verificar').status, 'Evaluated');
   });
 
-  test('geo blocker → NO APLICAR', () => {
-    assert.equal(normalizeStatus('geo blocker').status, 'NO APLICAR');
-    assert.equal(normalizeStatus('geo-blocker').status, 'NO APLICAR');
+  test('geo blocker → SKIP', () => {
+    assert.equal(normalizeStatus('geo blocker').status, 'SKIP');
+    assert.equal(normalizeStatus('geo-blocker').status, 'SKIP');
   });
 
-  test('cancelada → Descartado', () => {
-    assert.equal(normalizeStatus('cancelada').status, 'Descartado');
+  test('cancelada → Discarded', () => {
+    assert.equal(normalizeStatus('cancelada').status, 'Discarded');
   });
 });
 
 describe('normalizeStatus - edge cases', () => {
-  test('em dash → Descartado', () => {
-    assert.equal(normalizeStatus('—').status, 'Descartado');
+  test('em dash → Discarded', () => {
+    assert.equal(normalizeStatus('—').status, 'Discarded');
   });
 
-  test('hyphen → Descartado', () => {
-    assert.equal(normalizeStatus('-').status, 'Descartado');
+  test('hyphen → Discarded', () => {
+    assert.equal(normalizeStatus('-').status, 'Discarded');
   });
 
-  test('empty string → Descartado', () => {
-    assert.equal(normalizeStatus('').status, 'Descartado');
+  test('empty string → Discarded', () => {
+    assert.equal(normalizeStatus('').status, 'Discarded');
   });
 
   test('unknown status → { status: null, unknown: true }', () => {

--- a/test/normalize-statuses.test.mjs
+++ b/test/normalize-statuses.test.mjs
@@ -118,8 +118,8 @@ describe('normalizeStatus - other aliases', () => {
     assert.equal(normalizeStatus('hold').status, 'Evaluated');
   });
 
-  test('monitor → Evaluated', () => {
-    assert.equal(normalizeStatus('monitor').status, 'Evaluated');
+  test('monitor → SKIP', () => {
+    assert.equal(normalizeStatus('monitor').status, 'SKIP');
   });
 
   test('evaluar → Evaluated', () => {

--- a/test/normalize-statuses.test.mjs
+++ b/test/normalize-statuses.test.mjs
@@ -1,0 +1,167 @@
+/**
+ * test/normalize-statuses.test.mjs — Unit tests for normalize-statuses.mjs exported functions
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeStatus } from '../normalize-statuses.mjs';
+
+// ---------------------------------------------------------------------------
+// normalizeStatus
+// ---------------------------------------------------------------------------
+describe('normalizeStatus - already canonical', () => {
+  test('returns canonical as-is (no change)', () => {
+    const canonical = ['Evaluada', 'Aplicado', 'Respondido', 'Entrevista', 'Oferta', 'Rechazado', 'Descartado', 'NO APLICAR'];
+    for (const s of canonical) {
+      const result = normalizeStatus(s);
+      assert.equal(result.status, s, `Expected "${s}" to remain unchanged`);
+    }
+  });
+
+  test('case-insensitive match still returns proper casing', () => {
+    assert.equal(normalizeStatus('evaluada').status, 'Evaluada');
+    assert.equal(normalizeStatus('APLICADO').status, 'Aplicado');
+    assert.equal(normalizeStatus('no aplicar').status, 'NO APLICAR');
+  });
+});
+
+describe('normalizeStatus - markdown bold stripping', () => {
+  test('strips ** and returns canonical', () => {
+    assert.equal(normalizeStatus('**Evaluada**').status, 'Evaluada');
+    assert.equal(normalizeStatus('**Rechazado**').status, 'Rechazado');
+    assert.equal(normalizeStatus('**Applied**').status, 'Aplicado');
+  });
+});
+
+describe('normalizeStatus - date stripping', () => {
+  test('Aplicado with date → Aplicado', () => {
+    assert.equal(normalizeStatus('Aplicado 2026-01-15').status, 'Aplicado');
+  });
+
+  test('Rechazado with date → Rechazado', () => {
+    assert.equal(normalizeStatus('Rechazado 2026-03-10').status, 'Rechazado');
+  });
+});
+
+describe('normalizeStatus - alias mapping', () => {
+  test('enviada → Aplicado', () => {
+    assert.equal(normalizeStatus('enviada').status, 'Aplicado');
+  });
+
+  test('aplicada → Aplicado', () => {
+    assert.equal(normalizeStatus('aplicada').status, 'Aplicado');
+  });
+
+  test('applied → Aplicado', () => {
+    assert.equal(normalizeStatus('applied').status, 'Aplicado');
+  });
+
+  test('sent → Aplicado', () => {
+    assert.equal(normalizeStatus('sent').status, 'Aplicado');
+  });
+
+  test('cerrada → Descartado', () => {
+    assert.equal(normalizeStatus('cerrada').status, 'Descartado');
+  });
+
+  test('descartada → Descartado', () => {
+    assert.equal(normalizeStatus('descartada').status, 'Descartado');
+  });
+
+  test('rechazada → Rechazado', () => {
+    assert.equal(normalizeStatus('rechazada').status, 'Rechazado');
+  });
+
+  test('no_aplicar → NO APLICAR', () => {
+    assert.equal(normalizeStatus('no_aplicar').status, 'NO APLICAR');
+  });
+
+  test('no aplicar → NO APLICAR', () => {
+    assert.equal(normalizeStatus('no aplicar').status, 'NO APLICAR');
+  });
+
+  test('skip → NO APLICAR', () => {
+    assert.equal(normalizeStatus('skip').status, 'NO APLICAR');
+  });
+});
+
+describe('normalizeStatus - DUPLICADO variants', () => {
+  test('duplicado → Descartado with moveToNotes', () => {
+    const result = normalizeStatus('duplicado');
+    assert.equal(result.status, 'Descartado');
+    assert.ok(result.moveToNotes);
+  });
+
+  test('DUPLICADO #123 → Descartado with moveToNotes', () => {
+    const result = normalizeStatus('DUPLICADO #123');
+    assert.equal(result.status, 'Descartado');
+    assert.ok(result.moveToNotes);
+  });
+
+  test('dup → Descartado', () => {
+    assert.equal(normalizeStatus('dup').status, 'Descartado');
+  });
+
+  test('repost → Descartado', () => {
+    const result = normalizeStatus('repost #456');
+    assert.equal(result.status, 'Descartado');
+    assert.ok(result.moveToNotes);
+  });
+});
+
+describe('normalizeStatus - other aliases', () => {
+  test('condicional → Evaluada', () => {
+    assert.equal(normalizeStatus('condicional').status, 'Evaluada');
+  });
+
+  test('hold → Evaluada', () => {
+    assert.equal(normalizeStatus('hold').status, 'Evaluada');
+  });
+
+  test('monitor → Evaluada', () => {
+    assert.equal(normalizeStatus('monitor').status, 'Evaluada');
+  });
+
+  test('evaluar → Evaluada', () => {
+    assert.equal(normalizeStatus('evaluar').status, 'Evaluada');
+  });
+
+  test('verificar → Evaluada', () => {
+    assert.equal(normalizeStatus('verificar').status, 'Evaluada');
+  });
+
+  test('geo blocker → NO APLICAR', () => {
+    assert.equal(normalizeStatus('geo blocker').status, 'NO APLICAR');
+    assert.equal(normalizeStatus('geo-blocker').status, 'NO APLICAR');
+  });
+
+  test('cancelada → Descartado', () => {
+    assert.equal(normalizeStatus('cancelada').status, 'Descartado');
+  });
+});
+
+describe('normalizeStatus - edge cases', () => {
+  test('em dash → Descartado', () => {
+    assert.equal(normalizeStatus('—').status, 'Descartado');
+  });
+
+  test('hyphen → Descartado', () => {
+    assert.equal(normalizeStatus('-').status, 'Descartado');
+  });
+
+  test('empty string → Descartado', () => {
+    assert.equal(normalizeStatus('').status, 'Descartado');
+  });
+
+  test('unknown status → { status: null, unknown: true }', () => {
+    const result = normalizeStatus('completely-unknown-value');
+    assert.equal(result.status, null);
+    assert.ok(result.unknown);
+  });
+
+  test('another unknown → flagged', () => {
+    const result = normalizeStatus('pending-review');
+    assert.equal(result.status, null);
+    assert.ok(result.unknown);
+  });
+});

--- a/test/verify-pipeline.test.mjs
+++ b/test/verify-pipeline.test.mjs
@@ -11,16 +11,16 @@ import { isValidStatus, hasMarkdownBold, hasDateInStatus, isValidScoreFormat, fi
 // ---------------------------------------------------------------------------
 describe('isValidStatus', () => {
   test('accepts all canonical statuses (lowercase)', () => {
-    const canonical = ['evaluada', 'aplicado', 'respondido', 'entrevista', 'oferta', 'rechazado', 'descartado', 'no aplicar'];
+    const canonical = ['evaluated', 'applied', 'responded', 'interview', 'offer', 'rejected', 'discarded', 'skip'];
     for (const s of canonical) {
       assert.ok(isValidStatus(s), `Expected "${s}" to be valid`);
     }
   });
 
   test('accepts canonical statuses with proper casing', () => {
-    assert.ok(isValidStatus('Evaluada'));
-    assert.ok(isValidStatus('NO APLICAR'));
-    assert.ok(isValidStatus('Descartado'));
+    assert.ok(isValidStatus('Evaluated'));
+    assert.ok(isValidStatus('SKIP'));
+    assert.ok(isValidStatus('Discarded'));
   });
 
   test('accepts known aliases', () => {
@@ -43,8 +43,8 @@ describe('isValidStatus', () => {
   });
 
   test('strips trailing dates before checking', () => {
-    assert.ok(isValidStatus('Aplicado 2026-01-15'));
-    assert.ok(isValidStatus('Rechazado 2026-03-10 extra'));
+    assert.ok(isValidStatus('Applied 2026-01-15'));
+    assert.ok(isValidStatus('Rejected 2026-03-10 extra'));
   });
 
   test('rejects unknown statuses', () => {
@@ -83,8 +83,8 @@ describe('hasDateInStatus', () => {
   });
 
   test('returns false for status without date', () => {
-    assert.ok(!hasDateInStatus('Evaluada'));
-    assert.ok(!hasDateInStatus('NO APLICAR'));
+    assert.ok(!hasDateInStatus('Evaluated'));
+    assert.ok(!hasDateInStatus('SKIP'));
     assert.ok(!hasDateInStatus('Applied'));
   });
 });

--- a/test/verify-pipeline.test.mjs
+++ b/test/verify-pipeline.test.mjs
@@ -1,0 +1,227 @@
+/**
+ * test/verify-pipeline.test.mjs — Unit tests for verify-pipeline.mjs exported functions
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { isValidStatus, hasMarkdownBold, hasDateInStatus, isValidScoreFormat, findDuplicates, parseTrackerEntries } from '../verify-pipeline.mjs';
+
+// ---------------------------------------------------------------------------
+// isValidStatus
+// ---------------------------------------------------------------------------
+describe('isValidStatus', () => {
+  test('accepts all canonical statuses (lowercase)', () => {
+    const canonical = ['evaluada', 'aplicado', 'respondido', 'entrevista', 'oferta', 'rechazado', 'descartado', 'no aplicar'];
+    for (const s of canonical) {
+      assert.ok(isValidStatus(s), `Expected "${s}" to be valid`);
+    }
+  });
+
+  test('accepts canonical statuses with proper casing', () => {
+    assert.ok(isValidStatus('Evaluada'));
+    assert.ok(isValidStatus('NO APLICAR'));
+    assert.ok(isValidStatus('Descartado'));
+  });
+
+  test('accepts known aliases', () => {
+    assert.ok(isValidStatus('enviada'));
+    assert.ok(isValidStatus('aplicada'));
+    assert.ok(isValidStatus('applied'));
+    assert.ok(isValidStatus('sent'));
+    assert.ok(isValidStatus('cerrada'));
+    assert.ok(isValidStatus('descartada'));
+    assert.ok(isValidStatus('cancelada'));
+    assert.ok(isValidStatus('rechazada'));
+    assert.ok(isValidStatus('no_aplicar'));
+    assert.ok(isValidStatus('skip'));
+    assert.ok(isValidStatus('monitor'));
+  });
+
+  test('strips markdown bold before checking', () => {
+    assert.ok(isValidStatus('**Evaluada**'));
+    assert.ok(isValidStatus('**Applied**'));
+  });
+
+  test('strips trailing dates before checking', () => {
+    assert.ok(isValidStatus('Aplicado 2026-01-15'));
+    assert.ok(isValidStatus('Rechazado 2026-03-10 extra'));
+  });
+
+  test('rejects unknown statuses', () => {
+    assert.ok(!isValidStatus('pending'));
+    assert.ok(!isValidStatus('unknown'));
+    assert.ok(!isValidStatus('in-progress'));
+    assert.ok(!isValidStatus(''));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasMarkdownBold
+// ---------------------------------------------------------------------------
+describe('hasMarkdownBold', () => {
+  test('returns true when string contains **', () => {
+    assert.ok(hasMarkdownBold('**Evaluated**'));
+    assert.ok(hasMarkdownBold('4.5/5 **bold**'));
+    assert.ok(hasMarkdownBold('**'));
+  });
+
+  test('returns false when no ** present', () => {
+    assert.ok(!hasMarkdownBold('Evaluated'));
+    assert.ok(!hasMarkdownBold('4.5/5'));
+    assert.ok(!hasMarkdownBold(''));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasDateInStatus
+// ---------------------------------------------------------------------------
+describe('hasDateInStatus', () => {
+  test('detects YYYY-MM-DD date pattern', () => {
+    assert.ok(hasDateInStatus('Aplicado 2026-01-15'));
+    assert.ok(hasDateInStatus('Rechazado 2026-03-10'));
+    assert.ok(hasDateInStatus('2026-02-28'));
+  });
+
+  test('returns false for status without date', () => {
+    assert.ok(!hasDateInStatus('Evaluada'));
+    assert.ok(!hasDateInStatus('NO APLICAR'));
+    assert.ok(!hasDateInStatus('Applied'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isValidScoreFormat
+// ---------------------------------------------------------------------------
+describe('isValidScoreFormat', () => {
+  test('accepts X/5 and X.X/5 formats', () => {
+    assert.ok(isValidScoreFormat('4.2/5'));
+    assert.ok(isValidScoreFormat('3.8/5'));
+    assert.ok(isValidScoreFormat('5/5'));
+    assert.ok(isValidScoreFormat('1.0/5'));
+    assert.ok(isValidScoreFormat('4.55/5'));
+  });
+
+  test('accepts special values N/A and DUP', () => {
+    assert.ok(isValidScoreFormat('N/A'));
+    assert.ok(isValidScoreFormat('DUP'));
+  });
+
+  test('strips markdown bold before checking', () => {
+    assert.ok(isValidScoreFormat('**4.2/5**'));
+  });
+
+  test('rejects bare numbers without /5', () => {
+    assert.ok(!isValidScoreFormat('4.2'));
+    assert.ok(!isValidScoreFormat('3'));
+    assert.ok(!isValidScoreFormat(''));
+  });
+
+  test('rejects out-of-range-looking formats', () => {
+    // Format validation only — doesn't enforce 1-5 range
+    assert.ok(isValidScoreFormat('10/5')); // syntactically valid
+    assert.ok(!isValidScoreFormat('4.2/10'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findDuplicates
+// ---------------------------------------------------------------------------
+describe('findDuplicates', () => {
+  const base = [
+    { num: 1, company: 'Anthropic', role: 'Senior AI Engineer', score: '4.5/5', status: 'Evaluated' },
+    { num: 2, company: 'OpenAI', role: 'Technical PM', score: '3.8/5', status: 'Applied' },
+    { num: 3, company: 'Cohere', role: 'ML Platform Engineer', score: '4.2/5', status: 'Interview' },
+  ];
+
+  test('returns empty array when no duplicates', () => {
+    const result = findDuplicates(base);
+    assert.equal(result.length, 0);
+  });
+
+  test('detects exact company+role duplicate', () => {
+    const entries = [...base, { num: 4, company: 'Anthropic', role: 'Senior AI Engineer', score: '4.0/5', status: 'Evaluated' }];
+    const result = findDuplicates(entries);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].length, 2);
+    assert.equal(result[0][0].company, 'Anthropic');
+  });
+
+  test('is case-insensitive for company matching', () => {
+    const entries = [...base, { num: 4, company: 'ANTHROPIC', role: 'Senior AI Engineer', score: '4.0/5', status: 'Evaluated' }];
+    const result = findDuplicates(entries);
+    assert.equal(result.length, 1);
+  });
+
+  test('detects multiple duplicate groups', () => {
+    const entries = [
+      ...base,
+      { num: 4, company: 'Anthropic', role: 'Senior AI Engineer', score: '4.0/5', status: 'Evaluated' },
+      { num: 5, company: 'OpenAI', role: 'Technical PM', score: '3.5/5', status: 'Discarded' },
+    ];
+    const result = findDuplicates(entries);
+    assert.equal(result.length, 2);
+  });
+
+  test('key uses normalized company (strips punctuation)', () => {
+    // findDuplicates uses exact normalized key — "Ada Inc." → "adainc" ≠ "ada"
+    // so these are NOT detected as duplicates (merge-tracker uses fuzzy for that)
+    const entries = [
+      { num: 1, company: 'Ada Inc.', role: 'AI Product Manager', score: '4.0/5', status: 'Evaluated' },
+      { num: 2, company: 'Ada Corp', role: 'AI Product Manager', score: '3.8/5', status: 'Evaluated' },
+    ];
+    const result = findDuplicates(entries);
+    assert.equal(result.length, 0); // Different normalized names → not a duplicate
+  });
+
+  test('detects duplicate when company names normalize identically', () => {
+    const entries = [
+      { num: 1, company: 'OpenAI', role: 'Senior ML Engineer', score: '4.0/5', status: 'Evaluated' },
+      { num: 2, company: 'openai', role: 'Senior ML Engineer', score: '3.8/5', status: 'Evaluated' },
+    ];
+    const result = findDuplicates(entries);
+    assert.equal(result.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTrackerEntries
+// ---------------------------------------------------------------------------
+describe('parseTrackerEntries', () => {
+  const sampleContent = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-01-10 | Anthropic | Senior AI Engineer | 4.5/5 | Evaluated | ✅ | [1](reports/001-anthropic-2026-01-10.md) | Strong match |
+| 2 | 2026-01-12 | OpenAI | Technical PM | 3.8/5 | Applied | ✅ | [2](reports/002-openai-2026-01-12.md) | Good fit |
+`;
+
+  test('parses all data rows', () => {
+    const entries = parseTrackerEntries(sampleContent);
+    assert.equal(entries.length, 2);
+  });
+
+  test('correctly maps columns', () => {
+    const entries = parseTrackerEntries(sampleContent);
+    assert.equal(entries[0].num, 1);
+    assert.equal(entries[0].company, 'Anthropic');
+    assert.equal(entries[0].role, 'Senior AI Engineer');
+    assert.equal(entries[0].score, '4.5/5');
+    assert.equal(entries[0].status, 'Evaluated');
+  });
+
+  test('skips header and separator rows', () => {
+    const entries = parseTrackerEntries(sampleContent);
+    // Header row has '#' as num which is NaN, separator has '---'
+    assert.ok(entries.every(e => !isNaN(e.num)));
+  });
+
+  test('returns empty array for empty content', () => {
+    const entries = parseTrackerEntries('');
+    assert.equal(entries.length, 0);
+  });
+
+  test('returns empty array for content with no pipe rows', () => {
+    const entries = parseTrackerEntries('# Just a heading\nSome text\n');
+    assert.equal(entries.length, 0);
+  });
+});

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -35,14 +35,24 @@ const CANONICAL_STATUSES = [
 ];
 
 const ALIASES = {
+  // Spanish → English
   'evaluada': 'evaluated', 'condicional': 'evaluated', 'hold': 'evaluated', 'evaluar': 'evaluated', 'verificar': 'evaluated',
-  'aplicado': 'applied', 'enviada': 'applied', 'aplicada': 'applied', 'applied': 'applied', 'sent': 'applied',
+  'aplicado': 'applied', 'enviada': 'applied', 'aplicada': 'applied',
   'respondido': 'responded',
   'entrevista': 'interview',
   'oferta': 'offer',
   'rechazado': 'rejected', 'rechazada': 'rejected',
   'descartado': 'discarded', 'descartada': 'discarded', 'cerrada': 'discarded', 'cancelada': 'discarded',
   'no aplicar': 'skip', 'no_aplicar': 'skip', 'monitor': 'skip', 'geo blocker': 'skip',
+  // English → English passthrough
+  'applied': 'applied', 'sent': 'applied', 'evaluated': 'evaluated',
+  'responded': 'responded',
+  'interview': 'interview',
+  'offer': 'offer',
+  'rejected': 'rejected',
+  'closed': 'discarded', 'discarded': 'discarded', 'canceled': 'discarded',
+  'skip': 'skip', 'skipped': 'skip', 'no_apply': 'skip', 'skip_apply': 'skip',
+  'geo_blocker': 'skip',
 };
 
 // --- Pure validation functions (exported for testing) ---

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -45,6 +45,74 @@ const ALIASES = {
   'no aplicar': 'skip', 'no_aplicar': 'skip', 'monitor': 'skip', 'geo blocker': 'skip',
 };
 
+// --- Pure validation functions (exported for testing) ---
+
+/** Returns true if the status string (after stripping bold/dates) is canonical or a known alias. */
+function isValidStatus(rawStatus) {
+  const clean = rawStatus.replace(/\*\*/g, '').trim();
+  const statusOnly = clean.replace(/\s+\d{4}-\d{2}-\d{2}.*$/, '').trim().toLowerCase();
+  return CANONICAL_STATUSES.includes(statusOnly) || !!ALIASES[statusOnly];
+}
+
+/** Returns true if the string contains markdown bold (**). */
+function hasMarkdownBold(str) {
+  return str.includes('**');
+}
+
+/** Returns true if the string contains a date pattern YYYY-MM-DD. */
+function hasDateInStatus(str) {
+  return /\d{4}-\d{2}-\d{2}/.test(str);
+}
+
+/** Returns true if the score string matches the valid format. */
+function isValidScoreFormat(score) {
+  const s = score.replace(/\*\*/g, '').trim();
+  return /^\d+\.?\d*\/5$/.test(s) || s === 'N/A' || s === 'DUP';
+}
+
+/**
+ * Find groups of entries that share the same company+role key.
+ * Returns array of groups with length > 1 (duplicates only).
+ */
+function findDuplicates(entries) {
+  const map = new Map();
+  for (const e of entries) {
+    const key = e.company.toLowerCase().replace(/[^a-z0-9]/g, '') + '::' +
+      e.role.toLowerCase().replace(/[^a-z0-9 ]/g, '');
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(e);
+  }
+  return [...map.values()].filter(group => group.length > 1);
+}
+
+/**
+ * Parse pipe-delimited tracker lines from raw content string.
+ * Returns array of entry objects.
+ */
+function parseTrackerEntries(content) {
+  const lines = content.split('\n');
+  const entries = [];
+  for (const line of lines) {
+    if (!line.startsWith('|')) continue;
+    const parts = line.split('|').map(s => s.trim());
+    if (parts.length < 9) continue;
+    const num = parseInt(parts[1]);
+    if (isNaN(num)) continue;
+    entries.push({
+      num, date: parts[2], company: parts[3], role: parts[4],
+      score: parts[5], status: parts[6], pdf: parts[7], report: parts[8],
+      notes: parts[9] || '', raw: line,
+    });
+  }
+  return entries;
+}
+
+export { isValidStatus, hasMarkdownBold, hasDateInStatus, isValidScoreFormat, findDuplicates, parseTrackerEntries };
+
+// --- Main (only runs when executed directly) ---
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+
 let errors = 0;
 let warnings = 0;
 
@@ -61,42 +129,22 @@ if (!existsSync(APPS_FILE)) {
 const content = readFileSync(APPS_FILE, 'utf-8');
 const lines = content.split('\n');
 
-const entries = [];
-for (const line of lines) {
-  if (!line.startsWith('|')) continue;
-  const parts = line.split('|').map(s => s.trim());
-  if (parts.length < 9) continue;
-  const num = parseInt(parts[1]);
-  if (isNaN(num)) continue;
-  entries.push({
-    num, date: parts[2], company: parts[3], role: parts[4],
-    score: parts[5], status: parts[6], pdf: parts[7], report: parts[8],
-    notes: parts[9] || '',
-  });
-}
+const entries = parseTrackerEntries(content);
 
 console.log(`\n📊 Checking ${entries.length} entries in applications.md\n`);
 
 // --- Check 1: Canonical statuses ---
 let badStatuses = 0;
 for (const e of entries) {
-  const clean = e.status.replace(/\*\*/g, '').trim().toLowerCase();
-  // Strip trailing dates
-  const statusOnly = clean.replace(/\s+\d{4}-\d{2}-\d{2}.*$/, '').trim();
-
-  if (!CANONICAL_STATUSES.includes(statusOnly) && !ALIASES[statusOnly]) {
+  if (!isValidStatus(e.status)) {
     error(`#${e.num}: Non-canonical status "${e.status}"`);
     badStatuses++;
   }
-
-  // Check for markdown bold in status
-  if (e.status.includes('**')) {
+  if (hasMarkdownBold(e.status)) {
     error(`#${e.num}: Status contains markdown bold: "${e.status}"`);
     badStatuses++;
   }
-
-  // Check for dates in status
-  if (/\d{4}-\d{2}-\d{2}/.test(e.status)) {
+  if (hasDateInStatus(e.status)) {
     error(`#${e.num}: Status contains date: "${e.status}" — dates go in date column`);
     badStatuses++;
   }
@@ -104,21 +152,11 @@ for (const e of entries) {
 if (badStatuses === 0) ok('All statuses are canonical');
 
 // --- Check 2: Duplicates ---
-const companyRoleMap = new Map();
-let dupes = 0;
-for (const e of entries) {
-  const key = e.company.toLowerCase().replace(/[^a-z0-9]/g, '') + '::' +
-    e.role.toLowerCase().replace(/[^a-z0-9 ]/g, '');
-  if (!companyRoleMap.has(key)) companyRoleMap.set(key, []);
-  companyRoleMap.get(key).push(e);
+const dupeGroups = findDuplicates(entries);
+for (const group of dupeGroups) {
+  warn(`Possible duplicates: ${group.map(e => `#${e.num}`).join(', ')} (${group[0].company} — ${group[0].role})`);
 }
-for (const [key, group] of companyRoleMap) {
-  if (group.length > 1) {
-    warn(`Possible duplicates: ${group.map(e => `#${e.num}`).join(', ')} (${group[0].company} — ${group[0].role})`);
-    dupes++;
-  }
-}
-if (dupes === 0) ok('No exact duplicates found');
+if (dupeGroups.length === 0) ok('No exact duplicates found');
 
 // --- Check 3: Report links ---
 let brokenReports = 0;
@@ -136,8 +174,7 @@ if (brokenReports === 0) ok('All report links valid');
 // --- Check 4: Score format ---
 let badScores = 0;
 for (const e of entries) {
-  const s = e.score.replace(/\*\*/g, '').trim();
-  if (!/^\d+\.?\d*\/5$/.test(s) && s !== 'N/A' && s !== 'DUP') {
+  if (!isValidScoreFormat(e.score)) {
     error(`#${e.num}: Invalid score format: "${e.score}"`);
     badScores++;
   }
@@ -171,7 +208,7 @@ if (pendingTsvs === 0) ok('No pending TSVs');
 // --- Check 7: Bold in scores ---
 let boldScores = 0;
 for (const e of entries) {
-  if (e.score.includes('**')) {
+  if (hasMarkdownBold(e.score)) {
     warn(`#${e.num}: Score has markdown bold: "${e.score}"`);
     boldScores++;
   }
@@ -190,3 +227,5 @@ if (errors === 0 && warnings === 0) {
 }
 
 process.exit(errors > 0 ? 1 : 0);
+
+} // end main guard


### PR DESCRIPTION
## What does this PR do?

This PR introduces three major improvements to the career-ops pipeline:

1. **Compensation Research Cache** (`comp-cache.mjs`): A local YAML-based cache for salary data (p25/p50/p75) with 60-day TTL, eliminating repeated WebSearch calls for the same role/stage/location combinations. Includes CLI for lookup, save, list, and purge operations.

2. **Comprehensive Unit Tests**: Added test suites for all major modules (`comp-cache.test.mjs`, `verify-pipeline.test.mjs`, `merge-tracker.test.mjs`, `normalize-statuses.test.mjs`) covering pure functions and edge cases. Tests use Node's built-in `node:test` framework with no external dependencies.

3. **Tiered Evaluation Framework**: Introduced Stage 0 pre-screen (cheap, ~1K tokens) that runs before full evaluation blocks. Pre-screen scores alignment to North Star archetypes and overlap with must-haves, allowing early rejection of misaligned roles without expensive full analysis.

Additional improvements:
- Refactored `verify-pipeline.mjs` to export pure validation functions for testability
- Added context pre-loading in `batch-runner.sh` to inject cv.md + profile.yml once, reducing tool calls
- Updated batch prompt and mode documentation with cache-first protocol and tiering rules
- Added test fixtures (sample JDs, tracker entries, cache samples)
- Updated `.gitignore` to exclude `data/comp-cache.yml` (local-only, personal salary data)

## Related issue

N/A (foundational infrastructure improvements)

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation / translation
- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I added unit tests covering new functionality
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md)

## Test Plan

Run the new test suite:
```bash
npm test
```

All tests pass, covering:
- **comp-cache**: Key building, TTL expiration, YAML parsing/serialization, round-trip consistency
- **verify-pipeline**: Status validation, markdown/date stripping, score format checking, duplicate detection
- **merge-tracker**: Status normalization, company normalization, fuzzy role matching, score parsing
- **normalize-statuses**: Alias mapping, DUPLICADO handling, edge cases

The cache CLI can be tested manually:
```bash
node comp-cache.mjs save "senior-ai-engineer" "series-b" "remote" '{"p25":180000,"p50":210000,"p75":260000,"sources":["glassdoor"]}'
node comp-cache.mjs lookup "senior-ai-engineer" "series-b" "remote"
node comp-cache.mjs list
node comp-cache.mjs purge
```

https://claude.ai/code/session_01PQ1cMmnoQPQTeR1cZYkq4e