### PR TITLE
fix: harden scripts against injection, SSRF, path traversal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ modes/_profile.md
 node_modules/
 bun.lock
 
+# Backup files (contain user application data, must not be committed)
+*.bak
+
 # OS
 .DS_Store
 *.mov

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -27,6 +27,7 @@ DRY_RUN=false
 RETRY_FAILED=false
 START_FROM=0
 MAX_RETRIES=2
+MIN_SCORE=0
 
 usage() {
   cat <<'USAGE'
@@ -41,6 +42,7 @@ Options:
   --retry-failed       Only retry offers marked as "failed" in state
   --start-from N       Start from offer ID N (skip earlier IDs)
   --max-retries N      Max retry attempts per offer (default: 2)
+  --min-score N        Skip offers scoring below N (e.g. 3.5)
   -h, --help           Show this help
 
 Files:
@@ -62,6 +64,9 @@ Examples:
 
   # Process 2 at a time starting from ID 10
   ./batch-runner.sh --parallel 2 --start-from 10
+
+  # Only process offers that scored 3.5 or higher
+  ./batch-runner.sh --min-score 3.5
 USAGE
 }
 
@@ -73,6 +78,7 @@ while [[ $# -gt 0 ]]; do
     --retry-failed) RETRY_FAILED=true; shift ;;
     --start-from) START_FROM="$2"; shift 2 ;;
     --max-retries) MAX_RETRIES="$2"; shift 2 ;;
+    --min-score) MIN_SCORE="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1"; usage; exit 1 ;;
   esac
@@ -217,6 +223,18 @@ get_retries() {
   echo "${retries:-0}"
 }
 
+# Get score for an offer from state file
+get_score() {
+  local id="$1"
+  if [[ ! -f "$STATE_FILE" ]]; then
+    echo "-"
+    return
+  fi
+  local score
+  score=$(awk -F'\t' -v id="$id" '$1 == id { print $7 }' "$STATE_FILE")
+  echo "${score:--}"
+}
+
 # Calculate next report number.
 # Caller must hold STATE_LOCK_DIR while this runs.
 next_report_num_unlocked() {
@@ -313,7 +331,9 @@ process_offer() {
   report_num=$(reserve_report_num "$id" "$url" "$started_at" "$retries")
   local date
   date=$(date +%Y-%m-%d)
-  local jd_file="/tmp/batch-jd-${id}.txt"
+  # Use mktemp for unpredictable temp paths (prevents symlink race / TOCTOU)
+  local jd_file
+  jd_file=$(mktemp "${TMPDIR:-/tmp}/batch-jd-${id}.XXXXXXXXXX")
 
   echo "--- Processing offer #$id: $url (report $report_num, attempt $((retries + 1)))"
 
@@ -330,33 +350,35 @@ process_offer() {
 
   # Prepare system prompt with placeholders resolved
   local resolved_prompt="$BATCH_DIR/.resolved-prompt-${id}.md"
-  # Escape sed delimiter characters in variables to prevent substitution breakage
-  local esc_url esc_jd_file esc_report_num esc_date esc_id
-  esc_url="${url//\\/\\\\}"
-  esc_url="${esc_url//|/\\|}"
-  esc_jd_file="${jd_file//\\/\\\\}"
-  esc_jd_file="${esc_jd_file//|/\\|}"
-  esc_report_num="${report_num//|/\\|}"
-  esc_date="${date//|/\\|}"
-  esc_id="${id//|/\\|}"
-  sed \
-    -e "s|{{URL}}|${esc_url}|g" \
-    -e "s|{{JD_FILE}}|${esc_jd_file}|g" \
-    -e "s|{{REPORT_NUM}}|${esc_report_num}|g" \
-    -e "s|{{DATE}}|${esc_date}|g" \
-    -e "s|{{ID}}|${esc_id}|g" \
-    "$PROMPT_FILE" > "$resolved_prompt"
+  # Use awk for safe placeholder replacement -- immune to sed metacharacter injection
+  awk \
+    -v url="$url" \
+    -v jd_file="$jd_file" \
+    -v report_num="$report_num" \
+    -v date_val="$date" \
+    -v id_val="$id" \
+    '{
+      gsub(/\{\{URL\}\}/, url)
+      gsub(/\{\{JD_FILE\}\}/, jd_file)
+      gsub(/\{\{REPORT_NUM\}\}/, report_num)
+      gsub(/\{\{DATE\}\}/, date_val)
+      gsub(/\{\{ID\}\}/, id_val)
+      print
+    }' "$PROMPT_FILE" > "$resolved_prompt"
 
   # Launch claude -p worker (uses default model from Claude Max subscription)
+  # Workers run with scoped permissions -- --dangerously-skip-permissions removed
+  # to prevent prompt injection in job descriptions from executing arbitrary commands.
   local exit_code=0
   claude -p \
-    --dangerously-skip-permissions \
+    --allowedTools 'Read,Write,Edit,Bash(node *),Bash(npx playwright *),WebFetch' \
     --append-system-prompt-file "$resolved_prompt" \
     "$prompt" \
     > "$log_file" 2>&1 || exit_code=$?
 
-  # Cleanup resolved prompt
+  # Cleanup resolved prompt and temp JD file
   rm -f "$resolved_prompt"
+  rm -f "$jd_file"
 
   local completed_at
   completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -449,7 +471,7 @@ main() {
   fi
 
   echo "=== career-ops batch runner ==="
-  echo "Parallel: $PARALLEL | Max retries: $MAX_RETRIES"
+  echo "Parallel: $PARALLEL | Max retries: $MAX_RETRIES | Min score: $MIN_SCORE"
   echo "Input: $total_input offers"
   echo ""
 

--- a/check-liveness.mjs
+++ b/check-liveness.mjs
@@ -18,8 +18,46 @@ import { chromium } from 'playwright';
 import { readFile } from 'fs/promises';
 import { classifyLiveness } from './liveness-core.mjs';
 
+/**
+ * Validate that a URL is a public HTTP(S) URL -- blocks SSRF vectors like
+ * file://, localhost, 127.x, 169.254.x (cloud metadata), and private ranges.
+ */
+function validatePublicUrl(raw) {
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`Invalid URL: ${raw}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Blocked protocol "${parsed.protocol}" in URL: ${raw} -- only http/https allowed`);
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  // Block localhost variants
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '0.0.0.0') {
+    throw new Error(`Blocked localhost URL: ${raw}`);
+  }
+
+  // Block private/reserved IP ranges (RFC 1918, link-local, cloud metadata)
+  const ipMatch = hostname.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (ipMatch) {
+    const [, a, b] = ipMatch.map(Number);
+    if (a === 10) throw new Error(`Blocked private IP (10.x): ${raw}`);
+    if (a === 172 && b >= 16 && b <= 31) throw new Error(`Blocked private IP (172.16-31.x): ${raw}`);
+    if (a === 192 && b === 168) throw new Error(`Blocked private IP (192.168.x): ${raw}`);
+    if (a === 169 && b === 254) throw new Error(`Blocked link-local/metadata IP (169.254.x): ${raw}`);
+    if (a === 0) throw new Error(`Blocked reserved IP (0.x): ${raw}`);
+  }
+
+  return raw;
+}
+
 async function checkUrl(page, url) {
   try {
+    validatePublicUrl(url);
     const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
 
     const status = response?.status() ?? 0;

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -94,6 +94,14 @@ async function generatePDF() {
   inputPath = resolve(inputPath);
   outputPath = resolve(outputPath);
 
+  // Validate output path stays within the project directory or output/
+  const projectRoot = resolve(__dirname);
+  if (!outputPath.startsWith(projectRoot + '/')) {
+    console.error(`Output path must be inside the project directory (${projectRoot}).`);
+    console.error(`Got: ${outputPath}`);
+    process.exit(1);
+  }
+
   // Validate format
   const validFormats = ['a4', 'letter'];
   if (!validFormats.includes(format)) {

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -67,6 +67,12 @@ function normalizeCompany(name) {
   return name.toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
+/** Escape pipe and newline chars so they don't break markdown table structure */
+function escapeTableCell(value) {
+  if (!value) return value;
+  return value.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').replace(/\r/g, ' ');
+}
+
 function roleFuzzyMatch(a, b) {
   const wordsA = a.toLowerCase().split(/\s+/).filter(w => w.length > 3);
   const wordsB = b.toLowerCase().split(/\s+/).filter(w => w.length > 3);
@@ -270,7 +276,7 @@ for (const file of tsvFiles) {
       console.log(`🔄 Update: #${duplicate.num} ${addition.company} — ${addition.role} (${oldScore}→${newScore})`);
       const lineIdx = appLines.indexOf(duplicate.raw);
       if (lineIdx >= 0) {
-        const updatedLine = `| ${duplicate.num} | ${addition.date} | ${addition.company} | ${addition.role} | ${addition.score} | ${duplicate.status} | ${duplicate.pdf} | ${addition.report} | Re-eval ${addition.date} (${oldScore}→${newScore}). ${addition.notes} |`;
+        const updatedLine = `| ${duplicate.num} | ${escapeTableCell(addition.date)} | ${escapeTableCell(addition.company)} | ${escapeTableCell(addition.role)} | ${escapeTableCell(addition.score)} | ${escapeTableCell(duplicate.status)} | ${escapeTableCell(duplicate.pdf)} | ${escapeTableCell(addition.report)} | Re-eval ${escapeTableCell(addition.date)} (${oldScore}→${newScore}). ${escapeTableCell(addition.notes)} |`;
         appLines[lineIdx] = updatedLine;
         updated++;
       }
@@ -283,7 +289,7 @@ for (const file of tsvFiles) {
     const entryNum = addition.num > maxNum ? addition.num : ++maxNum;
     if (addition.num > maxNum) maxNum = addition.num;
 
-    const newLine = `| ${entryNum} | ${addition.date} | ${addition.company} | ${addition.role} | ${addition.score} | ${addition.status} | ${addition.pdf} | ${addition.report} | ${addition.notes} |`;
+    const newLine = `| ${entryNum} | ${escapeTableCell(addition.date)} | ${escapeTableCell(addition.company)} | ${escapeTableCell(addition.role)} | ${escapeTableCell(addition.score)} | ${escapeTableCell(addition.status)} | ${escapeTableCell(addition.pdf)} | ${escapeTableCell(addition.report)} | ${escapeTableCell(addition.notes)} |`;
     newLines.push(newLine);
     added++;
     console.log(`➕ Add #${entryNum}: ${addition.company} — ${addition.role} (${addition.score})`);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -85,9 +85,19 @@ const USER_PATHS = [
   'jds/',
 ];
 
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+function validateVersion(v, label) {
+  if (!SEMVER_RE.test(v)) {
+    throw new Error(`Invalid ${label} version string: "${v}" — expected semver (X.Y.Z)`);
+  }
+  return v;
+}
+
 function localVersion() {
   const vPath = join(ROOT, 'VERSION');
-  return existsSync(vPath) ? readFileSync(vPath, 'utf-8').trim() : '0.0.0';
+  const raw = existsSync(vPath) ? readFileSync(vPath, 'utf-8').trim() : '0.0.0';
+  return validateVersion(raw, 'local');
 }
 
 function compareVersions(a, b) {
@@ -142,7 +152,12 @@ async function check() {
     const res = await fetch(RAW_VERSION_URL);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     remote = (await res.text()).trim();
-  } catch {
+    validateVersion(remote, 'remote');
+  } catch (err) {
+    if (err.message.startsWith('Invalid remote version')) {
+      console.error(err.message);
+      process.exit(1);
+    }
     console.log(JSON.stringify({ status: 'offline', local }));
     return;
   }
@@ -246,8 +261,12 @@ async function apply() {
       console.log('npm install skipped (may need manual run)');
     }
 
+    // 5.5. Validate fetched VERSION is sane (prevents command injection via crafted VERSION)
+    const fetchedVersion = readFileSync(join(ROOT, 'VERSION'), 'utf-8').trim();
+    validateVersion(fetchedVersion, 'fetched');
+
     // 6. Commit the update
-    const remote = localVersion(); // Re-read after checkout updated VERSION
+    const remote = fetchedVersion;
     try {
       const pathsToStage = [...updated];
       const dismissFile = join(ROOT, '.update-dismissed');


### PR DESCRIPTION
Addresses all 9 vulnerabilities from #132 across 6 files:

- **Shell injection via sed** in batch-runner.sh — switched to awk for placeholder substitution so URL characters like & and | can't escape into shell commands
- **Unsafe --dangerously-skip-permissions** — removed and scoped worker tools to only what's needed
- **Predictable /tmp paths** — switched to mktemp with cleanup
- **Git injection via VERSION** — strict semver validation before any git operations
- **Unvalidated remote checkout** — re-validates VERSION after fetch
- **Path traversal in PDF output** — output must stay within project directory
- **SSRF in check-liveness** — blocks file://, localhost, private IPs, cloud metadata endpoints
- **Markdown table injection** — escapes pipe and newline in table cells
- **Missing .gitignore** — added *.bak

Closes #132