### PR TITLE
feat(dashboard): add light theme for terminals with light backgrounds

### DIFF
--- a/dashboard/internal/theme/catppuccin.go
+++ b/dashboard/internal/theme/catppuccin.go
@@ -22,3 +22,24 @@ func newCatppuccinMocha() Theme {
 		Pink:   lipgloss.Color("#f5c2e7"),
 	}
 }
+
+func newCatppuccinLatte() Theme {
+	return Theme{
+		// Catppuccin Latte palette (light theme)
+		Base:    lipgloss.Color("#eff1f5"),
+		Surface: lipgloss.Color("#ccd0da"),
+		Overlay: lipgloss.Color("#bcc0cc"),
+		Text:    lipgloss.Color("#4c4f69"),
+		Subtext: lipgloss.Color("#6c6f85"),
+
+		// Accents
+		Blue:   lipgloss.Color("#1e66f5"),
+		Mauve:  lipgloss.Color("#8839ef"),
+		Green:  lipgloss.Color("#40a02b"),
+		Yellow: lipgloss.Color("#df8e1d"),
+		Sky:    lipgloss.Color("#04a5e5"),
+		Peach:  lipgloss.Color("#fe640b"),
+		Red:    lipgloss.Color("#d20f39"),
+		Pink:   lipgloss.Color("#ea76cb"),
+	}
+}

--- a/dashboard/internal/theme/theme.go
+++ b/dashboard/internal/theme/theme.go
@@ -28,7 +28,9 @@ type Theme struct {
 // NewTheme creates a theme by name. Currently only "catppuccin-mocha" is supported.
 func NewTheme(name string) Theme {
 	switch name {
-	case "catppuccin-mocha", "":
+	case "catppuccin-latte", "light":
+		return newCatppuccinLatte()
+	case "catppuccin-mocha", "dark", "":
 		return newCatppuccinMocha()
 	default:
 		return newCatppuccinMocha()


### PR DESCRIPTION
The dark Mocha palette was unreadable on light terminal backgrounds. Added a Catppuccin Latte light variant — use --theme=light or --theme=catppuccin-latte to switch.

Fixes #186