### PR TITLE
[codex] Add regression coverage for update-system user-file safety

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -115,10 +115,49 @@ try {
   fail(`Liveness classification tests crashed: ${e.message}`);
 }
 
-// ── 4. DASHBOARD BUILD ──────────────────────────────────────────
+// ── 4. UPDATE SAFETY REGRESSION ─────────────────────────────────
+
+console.log('\n4. Update safety regression');
+
+try {
+  const {
+    parseGitStatusEntries,
+    collectUnexpectedUserTouches,
+  } = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+
+  const initialUntrackedCv = new Set(
+    parseGitStatusEntries('?? cv.md').map(entry => entry.path)
+  );
+  const currentWithUntrackedCv = parseGitStatusEntries(' M README.md\n?? cv.md');
+  const ignoredTouches = collectUnexpectedUserTouches({
+    initialStatusPaths: initialUntrackedCv,
+    currentEntries: currentWithUntrackedCv,
+  });
+
+  if (ignoredTouches.length === 0) {
+    pass('Updater ignores pre-existing untracked cv.md during safety checks');
+  } else {
+    fail(`Updater falsely flagged existing user files: ${ignoredTouches.join(', ')}`);
+  }
+
+  const freshUserTouch = collectUnexpectedUserTouches({
+    initialStatusPaths: new Set(),
+    currentEntries: parseGitStatusEntries('?? cv.md'),
+  });
+
+  if (freshUserTouch.includes('cv.md')) {
+    pass('Updater still blocks newly introduced user-file touches');
+  } else {
+    fail('Updater no longer detects newly touched user files');
+  }
+} catch (e) {
+  fail(`Update safety regression tests crashed: ${e.message}`);
+}
+
+// ── 5. DASHBOARD BUILD ──────────────────────────────────────────
 
 if (!QUICK) {
-  console.log('\n4. Dashboard build');
+  console.log('\n5. Dashboard build');
   const goBuild = run('cd dashboard && go build -o /tmp/career-dashboard-test . 2>&1');
   if (goBuild !== null) {
     pass('Dashboard compiles');
@@ -126,12 +165,12 @@ if (!QUICK) {
     fail('Dashboard build failed');
   }
 } else {
-  console.log('\n4. Dashboard build (skipped --quick)');
+  console.log('\n5. Dashboard build (skipped --quick)');
 }
 
-// ── 5. DATA CONTRACT ────────────────────────────────────────────
+// ── 6. DATA CONTRACT ────────────────────────────────────────────
 
-console.log('\n5. Data contract validation');
+console.log('\n6. Data contract validation');
 
 // Check system files exist
 const systemFiles = [
@@ -165,9 +204,9 @@ for (const f of userFiles) {
   }
 }
 
-// ── 6. PERSONAL DATA LEAK CHECK ─────────────────────────────────
+// ── 7. PERSONAL DATA LEAK CHECK ─────────────────────────────────
 
-console.log('\n6. Personal data leak check');
+console.log('\n7. Personal data leak check');
 
 const leakPatterns = [
   'Santiago', 'santifer.io', 'Santifer iRepair', 'Zinkee', 'ALMAS',
@@ -215,9 +254,9 @@ if (!leakFound) {
   pass('No personal data leaks outside allowed files');
 }
 
-// ── 7. ABSOLUTE PATH CHECK ──────────────────────────────────────
+// ── 8. ABSOLUTE PATH CHECK ──────────────────────────────────────
 
-console.log('\n7. Absolute path check');
+console.log('\n8. Absolute path check');
 
 // Same git grep approach: only scans tracked files. Untracked AI tool
 // outputs, local debate artifacts, etc. can't false-positive here.
@@ -232,9 +271,9 @@ if (!absPathResult) {
   }
 }
 
-// ── 8. MODE FILE INTEGRITY ──────────────────────────────────────
+// ── 9. MODE FILE INTEGRITY ──────────────────────────────────────
 
-console.log('\n8. Mode file integrity');
+console.log('\n9. Mode file integrity');
 
 const expectedModes = [
   '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'scan.md',
@@ -258,9 +297,9 @@ if (shared.includes('_profile.md')) {
   fail('_shared.md does NOT reference _profile.md');
 }
 
-// ── 9. CLAUDE.md INTEGRITY ──────────────────────────────────────
+// ── 10. CLAUDE.md INTEGRITY ─────────────────────────────────────
 
-console.log('\n9. CLAUDE.md integrity');
+console.log('\n10. CLAUDE.md integrity');
 
 const claude = readFile('CLAUDE.md');
 const requiredSections = [
@@ -277,9 +316,9 @@ for (const section of requiredSections) {
   }
 }
 
-// ── 10. VERSION FILE ─────────────────────────────────────────────
+// ── 11. VERSION FILE ────────────────────────────────────────────
 
-console.log('\n10. Version file');
+console.log('\n11. Version file');
 
 if (fileExists('VERSION')) {
   const version = readFile('VERSION').trim();

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -104,8 +104,7 @@ function git(...args) {
   return execFileSync('git', args, { cwd: ROOT, encoding: 'utf-8', timeout: 30000 }).trim();
 }
 
-function gitStatusEntries() {
-  const status = git('status', '--porcelain');
+export function parseGitStatusEntries(status) {
   if (!status) return [];
 
   return status.split('\n')
@@ -114,6 +113,31 @@ function gitStatusEntries() {
       code: line.slice(0, 2),
       path: line.slice(3),
     }));
+}
+
+function gitStatusEntries() {
+  return parseGitStatusEntries(git('status', '--porcelain'));
+}
+
+export function collectUnexpectedUserTouches({
+  initialStatusPaths,
+  currentEntries,
+  userPaths = USER_PATHS,
+}) {
+  const touched = [];
+
+  for (const entry of currentEntries) {
+    const file = entry.path;
+    if (initialStatusPaths.has(file)) continue;
+    for (const userPath of userPaths) {
+      if (file.startsWith(userPath)) {
+        touched.push(file);
+        break;
+      }
+    }
+  }
+
+  return touched;
 }
 
 function revertPaths(paths) {
@@ -219,15 +243,13 @@ async function apply() {
     // 4. Validate: check NO user files were touched
     let userFileTouched = false;
     try {
-      for (const entry of gitStatusEntries()) {
-        const file = entry.path;
-        if (initialStatusPaths.has(file)) continue;
-        for (const userPath of USER_PATHS) {
-          if (file.startsWith(userPath)) {
-            console.error(`SAFETY VIOLATION: User file was modified: ${file}`);
-            userFileTouched = true;
-          }
-        }
+      const unexpectedUserTouches = collectUnexpectedUserTouches({
+        initialStatusPaths,
+        currentEntries: gitStatusEntries(),
+      });
+      for (const file of unexpectedUserTouches) {
+        console.error(`SAFETY VIOLATION: User file was modified: ${file}`);
+        userFileTouched = true;
       }
     } catch {
       // git status failed, skip validation
@@ -316,14 +338,16 @@ function dismiss() {
 
 // ── MAIN ────────────────────────────────────────────────────────
 
-const cmd = process.argv[2] || 'check';
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const cmd = process.argv[2] || 'check';
 
-switch (cmd) {
-  case 'check': await check(); break;
-  case 'apply': await apply(); break;
-  case 'rollback': rollback(); break;
-  case 'dismiss': dismiss(); break;
-  default:
-    console.log('Usage: node update-system.mjs [check|apply|rollback|dismiss]');
-    process.exit(1);
+  switch (cmd) {
+    case 'check': await check(); break;
+    case 'apply': await apply(); break;
+    case 'rollback': rollback(); break;
+    case 'dismiss': dismiss(); break;
+    default:
+      console.log('Usage: node update-system.mjs [check|apply|rollback|dismiss]');
+      process.exit(1);
+  }
 }


### PR DESCRIPTION
## Summary
- factor the update-system safety check into small pure helpers so the user-file guard can be exercised directly
- add regression coverage to `test-all.mjs` for the `cv.md` false positive reported in #169
- keep the existing safety behavior for genuinely new user-file touches

## Why
Refs #169.

The updater logic on `main` already avoids the original false positive in practice, but that behavior was not covered by the repo's test suite. This makes the `cv.md` case explicit so a future refactor does not reintroduce the rollback path for pre-existing untracked user files.

## Impact
Contributors and maintainers get a cheap regression signal around one of the trickier safety paths in `update-system.mjs`, while preserving the guard that blocks real user-data touches.

## Validation
- `node --check update-system.mjs`
- `node update-system.mjs check`
- `node test-all.mjs --quick`