### PR TITLE
fix: add data/ dir guard and pipeline.md init in scan.mjs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,15 @@
+# Contributors
+
+Thanks to everyone who has contributed to Career-Ops!
+
+## Creator
+
+- **Santiago Fernández de Valderrama** ([@santifer](https://github.com/santifer)) — original author and maintainer
+
+## Contributors
+
+- **Sai Dheeraj Gollu** ([@saidheerajgollu](https://github.com/saidheerajgollu)) — bug fixes: `scan.mjs` missing file existence guard and `data/` directory creation
+
+---
+
+Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/scan.mjs
+++ b/scan.mjs
@@ -15,7 +15,7 @@
  *   node scan.mjs --company Cohere # scan a single company
  */
 
-import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
 import yaml from 'js-yaml';
 const parseYaml = yaml.load;
 
@@ -185,6 +185,12 @@ function loadSeenCompanyRoles() {
 function appendToPipeline(offers) {
   if (offers.length === 0) return;
 
+  // Ensure data/ directory and pipeline.md exist before reading
+  mkdirSync('data', { recursive: true });
+  if (!existsSync(PIPELINE_PATH)) {
+    writeFileSync(PIPELINE_PATH, '# Pipeline\n\n## Pendientes\n\n## Procesadas\n', 'utf-8');
+  }
+
   let text = readFileSync(PIPELINE_PATH, 'utf-8');
 
   // Find "## Pendientes" section and append after it
@@ -214,7 +220,8 @@ function appendToPipeline(offers) {
 }
 
 function appendToScanHistory(offers, date) {
-  // Ensure file + header exist
+  // Ensure data/ directory and file + header exist
+  mkdirSync('data', { recursive: true });
   if (!existsSync(SCAN_HISTORY_PATH)) {
     writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\n', 'utf-8');
   }


### PR DESCRIPTION
## Summary

- `appendToPipeline()` called `readFileSync` on `data/pipeline.md` without checking if the file or directory existed, causing a crash on fresh installs
- `appendToScanHistory()` had the same missing directory guard
- Added `mkdirSync` with `recursive: true` before any file write in both functions
- Initializes `pipeline.md` with default section structure if missing
- Added `CONTRIBUTORS.md`

## Test plan

- [x] Run `node scan.mjs --dry-run` on a fresh clone with no `data/` directory — should not crash
- [x] Verify `data/pipeline.md` is created automatically on first real scan
- [x] Verify `data/scan-history.tsv` is created automatically on first real scan