### PR TITLE
docs: backfill SCRIPTS.md and subdirectory READMEs

### DIFF
--- a/batch/README.md
+++ b/batch/README.md
@@ -1,0 +1,80 @@
+# Batch Processing
+
+Process multiple job offers in parallel via `claude -p` workers. Each worker runs the full evaluation pipeline (A-F report + PDF + tracker line) autonomously.
+
+## Quick Start
+
+1. **Add offers** to `batch-input.tsv` (tab-separated: `id`, `url`, `source`, `notes`):
+
+   ```tsv
+   id	url	source	notes
+   1	https://jobs.example.com/role-a	LinkedIn	
+   2	https://greenhouse.io/company/role-b	Greenhouse	priority
+   ```
+
+2. **Dry run** to preview what will be processed:
+
+   ```bash
+   ./batch/batch-runner.sh --dry-run
+   ```
+
+3. **Run the batch**:
+
+   ```bash
+   ./batch/batch-runner.sh
+   ```
+
+4. **Results** are automatically merged into `data/applications.md` and verified with `verify-pipeline.mjs` at the end of the run.
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--parallel N` | `1` | Number of concurrent `claude -p` workers |
+| `--dry-run` | off | Preview pending offers without processing |
+| `--retry-failed` | off | Only retry offers marked as `failed` in state |
+| `--start-from N` | `0` | Skip offers with ID below N |
+| `--max-retries N` | `2` | Max retry attempts per offer before giving up |
+
+## Directory Layout
+
+```
+batch/
+  batch-runner.sh          # Orchestrator script
+  batch-prompt.md          # Prompt template sent to each worker
+  batch-input.tsv          # Input offers (you create this)
+  batch-state.tsv          # Processing state (auto-managed, resumable)
+  logs/                    # Per-offer worker logs ({report_num}-{id}.log)
+  tracker-additions/       # TSV lines produced by workers
+    merged/                # TSVs already merged into applications.md
+```
+
+## How It Works
+
+1. **batch-runner.sh** reads `batch-input.tsv` and `batch-state.tsv` to determine which offers need processing.
+2. For each pending offer, it assigns a report number and launches a `claude -p` worker with `batch-prompt.md` as the system prompt (placeholders like `{{URL}}`, `{{REPORT_NUM}}` are resolved).
+3. Each worker evaluates the offer, writes a report to `reports/`, generates a PDF to `output/`, and writes a tracker TSV to `tracker-additions/`.
+4. After all workers finish, batch-runner calls `merge-tracker.mjs` to merge TSVs into `data/applications.md` and runs `verify-pipeline.mjs` to check integrity.
+
+## Tracker Merge
+
+Workers write one TSV per offer to `batch/tracker-additions/`. The merge script (`npm run merge`) handles:
+
+- Deduplication by company + role fuzzy match and report number
+- Column order conversion (TSV has status before score; applications.md has score before status)
+- In-place updates when a re-evaluation scores higher than the existing entry
+- Moving processed TSVs to `tracker-additions/merged/`
+
+Run `npm run merge` manually if you need to merge outside of a batch run.
+
+## Resumability
+
+`batch-state.tsv` tracks the status of every offer (`pending`, `processing`, `completed`, `failed`). If the batch is interrupted, re-running `batch-runner.sh` picks up where it left off -- completed offers are skipped automatically.
+
+A PID-based lock file (`batch-runner.pid`) prevents concurrent batch runs. If a previous run crashed, the stale lock is detected and removed automatically.
+
+## Prerequisites
+
+- `claude` CLI in PATH (Claude Max subscription for default model)
+- Node.js >= 18, Playwright chromium installed (`npm run doctor` to verify)
+- `batch-input.tsv` with at least one offer

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -1,0 +1,176 @@
+# Scripts Reference
+
+All scripts live in the project root as `.mjs` modules and are exposed via `npm run <name>`.
+
+## Quick Reference
+
+| Command | Script | Purpose |
+|---------|--------|---------|
+| `npm run doctor` | `doctor.mjs` | Validate setup prerequisites |
+| `npm run verify` | `verify-pipeline.mjs` | Check pipeline data integrity |
+| `npm run normalize` | `normalize-statuses.mjs` | Fix non-canonical statuses |
+| `npm run dedup` | `dedup-tracker.mjs` | Remove duplicate tracker entries |
+| `npm run merge` | `merge-tracker.mjs` | Merge batch TSVs into applications.md |
+| `npm run pdf` | `generate-pdf.mjs` | Convert HTML to ATS-optimized PDF |
+| `npm run sync-check` | `cv-sync-check.mjs` | Validate CV/profile consistency |
+| `npm run update:check` | `update-system.mjs check` | Check for upstream updates |
+| `npm run update` | `update-system.mjs apply` | Apply upstream update |
+| `npm run rollback` | `update-system.mjs rollback` | Rollback last update |
+| `npm run liveness` | `check-liveness.mjs` | Test if job URLs are still active |
+
+---
+
+## doctor
+
+Validates that all prerequisites are in place: Node.js >= 18, dependencies installed, Playwright chromium, required files (`cv.md`, `config/profile.yml`, `portals.yml`), fonts directory, and auto-creates `data/`, `output/`, `reports/` if missing.
+
+```bash
+npm run doctor
+```
+
+**Exit codes:** `0` all checks passed, `1` one or more checks failed (fix messages printed).
+
+---
+
+## verify
+
+Health check for pipeline data integrity. Validates `data/applications.md` against seven rules: canonical statuses (per `templates/states.yml`), no duplicate company+role pairs, all report links point to existing files, scores match `X.XX/5` / `N/A` / `DUP`, rows have proper pipe-delimited format, no pending TSVs in `batch/tracker-additions/`, and no markdown bold in scores.
+
+```bash
+npm run verify
+```
+
+**Exit codes:** `0` pipeline clean (zero errors), `1` errors found. Warnings (e.g. possible duplicates) do not cause a non-zero exit.
+
+---
+
+## normalize
+
+Maps non-canonical statuses to their canonical equivalents and strips markdown bold and dates from the status column. Aliases like `Enviada` become `Aplicado`, `CERRADA` becomes `Descartado`, etc. DUPLICADO info is moved to the notes column.
+
+```bash
+npm run normalize             # apply changes
+npm run normalize -- --dry-run  # preview without writing
+```
+
+Creates a `.bak` backup of `applications.md` before writing.
+
+**Exit codes:** `0` always (changes or no changes).
+
+---
+
+## dedup
+
+Removes duplicate entries from `applications.md` by grouping on normalized company name + fuzzy role match. Keeps the entry with the highest score. If a removed entry had a more advanced pipeline status, that status is promoted to the keeper.
+
+```bash
+npm run dedup             # apply changes
+npm run dedup -- --dry-run  # preview without writing
+```
+
+Creates a `.bak` backup before writing.
+
+**Exit codes:** `0` always.
+
+---
+
+## merge
+
+Merges batch tracker additions (`batch/tracker-additions/*.tsv`) into `applications.md`. Handles 9-column TSV, 8-column TSV, and pipe-delimited markdown formats. Detects duplicates by report number, entry number, and company+role fuzzy match. Higher-scored re-evaluations update existing entries in place.
+
+```bash
+npm run merge                 # apply merge
+npm run merge -- --dry-run    # preview without writing
+npm run merge -- --verify     # merge then run verify-pipeline
+```
+
+Processed TSVs are moved to `batch/tracker-additions/merged/`.
+
+**Exit codes:** `0` success, `1` verification errors (with `--verify`).
+
+---
+
+## pdf
+
+Renders an HTML file to a print-quality, ATS-parseable PDF via headless Chromium. Resolves font paths from `fonts/`, normalizes Unicode for ATS compatibility (em-dashes, smart quotes, zero-width characters), and reports page count and file size.
+
+```bash
+npm run pdf -- input.html output.pdf
+npm run pdf -- input.html output.pdf --format=letter   # US letter
+npm run pdf -- input.html output.pdf --format=a4        # A4 (default)
+```
+
+**Exit codes:** `0` PDF generated, `1` missing arguments or generation failure.
+
+---
+
+## sync-check
+
+Validates that the career-ops setup is internally consistent: `cv.md` exists and is not too short, `config/profile.yml` exists with required fields, no hardcoded metrics in `modes/_shared.md` or `batch/batch-prompt.md`, and `article-digest.md` freshness (warns if older than 30 days).
+
+```bash
+npm run sync-check
+```
+
+**Exit codes:** `0` no errors (warnings allowed), `1` errors found.
+
+---
+
+## update:check
+
+Checks whether a newer version of career-ops is available upstream. Outputs JSON to stdout:
+
+```bash
+npm run update:check
+```
+
+Possible JSON responses:
+
+| `status` | Meaning |
+|----------|---------|
+| `up-to-date` | Local version matches remote |
+| `update-available` | Newer version exists (includes `local`, `remote`, `changelog`) |
+| `dismissed` | User dismissed the update prompt |
+| `offline` | Could not reach GitHub |
+
+**Exit codes:** `0` always.
+
+---
+
+## update
+
+Applies the upstream update. Creates a backup branch (`backup-pre-update-{version}`), fetches from the canonical repo, checks out only system-layer files, runs `npm install`, and commits. User-layer files (`cv.md`, `config/profile.yml`, `data/`, etc.) are never touched.
+
+```bash
+npm run update
+```
+
+**Exit codes:** `0` success, `1` lock conflict or safety violation.
+
+---
+
+## rollback
+
+Restores system-layer files from the most recent backup branch created during an update.
+
+```bash
+npm run rollback
+```
+
+**Exit codes:** `0` success, `1` no backup branch found or git error.
+
+---
+
+## liveness
+
+Tests whether job posting URLs are still live using headless Chromium. Detects expired patterns (e.g. "job no longer available"), HTTP 404/410, ATS redirect patterns, and apply-button presence. Supports multi-language expired patterns (English, German, French).
+
+```bash
+npm run liveness -- https://example.com/job/123
+npm run liveness -- https://a.com/job/1 https://b.com/job/2
+npm run liveness -- --file urls.txt
+```
+
+Each URL gets a verdict: `active`, `expired`, or `uncertain` with a reason.
+
+**Exit codes:** `0` all URLs active, `1` any expired or uncertain.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,22 @@
+# Examples
+
+Reference files that demonstrate career-ops data formats and conventions. None of these are used at runtime -- they exist so you can see the expected structure before creating your own files.
+
+## Files
+
+| File | Demonstrates |
+|------|-------------|
+| `cv-example.md` | How to structure `cv.md` -- sections, metrics formatting, and proof-point style for a fictional AI engineer (Alex Chen) |
+| `article-digest-example.md` | How to write `article-digest.md` -- compact proof points with hero metrics, architecture summaries, and key decisions per project |
+| `sample-report.md` | The A-F evaluation report format produced by the evaluation pipeline, with all six blocks (Role Summary through Interview Plan) |
+| `ats-normalization-test.md` | Regression fixture for `generate-pdf.mjs` Unicode normalization -- lists every problematic codepoint and its ASCII-safe replacement |
+| `dual-track-engineer-instructor/` | Complete profile config for a candidate with two primary archetypes (engineer + instructor), including `cv.md`, `profile.yml`, and a README explaining when and how to use the dual-track pattern |
+
+## Usage
+
+These files are read-only references. To set up your own career-ops instance:
+
+1. Run `npm run doctor` to check prerequisites.
+2. Use `cv-example.md` as a structural guide when writing your `cv.md`.
+3. Use `article-digest-example.md` as a template for your `article-digest.md` (optional but improves evaluation quality).
+4. See the `dual-track-engineer-instructor/` folder if your career spans two distinct archetypes.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,31 @@
+# Templates
+
+System-layer template files used by career-ops scripts and modes. These files are auto-updated when you run `npm run update` -- put user customizations in the user-layer files instead (see DATA_CONTRACT.md).
+
+## Files
+
+| File | Used By | Purpose |
+|------|---------|---------|
+| `cv-template.html` | `generate-pdf.mjs` | HTML/CSS template for ATS-optimized CV PDFs |
+| `portals.example.yml` | Onboarding | Example portal scanner configuration (copy to `portals.yml` to activate) |
+| `states.yml` | `verify-pipeline.mjs`, `normalize-statuses.mjs`, `merge-tracker.mjs` | Canonical application states and their aliases |
+
+### cv-template.html
+
+The HTML template rendered by Playwright into PDF. Uses placeholder tokens (`{{NAME}}`, `{{SUMMARY_TEXT}}`, `{{EXPERIENCE}}`, etc.) that the PDF pipeline fills at generation time.
+
+**Design:** Space Grotesk headings + DM Sans body, single-column ATS-safe layout, self-hosted fonts from `fonts/`.
+
+**Customization:** Edit this file to change colors, spacing, or section order. The placeholder tokens are documented in `batch/batch-prompt.md` under "Template placeholders."
+
+### portals.example.yml
+
+Pre-configured portal scanner with 45+ tracked companies and search queries. Contains title filters, company career page URLs, Greenhouse API endpoints, and WebSearch queries.
+
+**To activate:** Copy to project root as `portals.yml` and customize `title_filter.positive` keywords for your target roles. Add or remove companies as needed.
+
+### states.yml
+
+Defines the 8 canonical application states (`Evaluated`, `Applied`, `Responded`, `Interview`, `Offer`, `Rejected`, `Discarded`, `SKIP`) with aliases for common variants. All pipeline scripts validate statuses against this file.
+
+**Do not rename states** -- the dashboard and all scripts depend on these exact IDs. You can add aliases if you encounter new variants that should map to an existing state.


### PR DESCRIPTION
## Summary
- Add `docs/SCRIPTS.md` — central reference for all 11 `npm run` commands with synopsis, usage examples, arguments, and exit codes
- Add `batch/README.md` — quick-start guide for batch processing: workflow, options, directory layout, resumability, and tracker merge
- Add `templates/README.md` — index of template files with purpose and customization notes
- Add `examples/README.md` — index of example files explaining what each demonstrates

No source code changes. All existing tests pass (`test-all.mjs --quick`: 57/57).

## Test plan
- [x] `node verify-pipeline.mjs` exits 0
- [x] `node test-all.mjs --quick` — 57 passed, 0 failed
- [ ] Verify docs render correctly on GitHub


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/
task-type: docs-backfill
task-title: Documentation Backfiller
provider: claude
score: 0.9
cost-tier: Low (10-50k)
iterations: 1
duration: 10m2s
run-started: 2026-04-13T02:00:06+05:30
nightshift:metadata -->
