### PR TITLE
[codex] Add manual refresh shortcut to dashboard

### DIFF
--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -42,6 +42,9 @@ type PipelineUpdateStatusMsg struct {
 	NewStatus     string
 }
 
+// PipelineRefreshMsg requests a full tracker reload from disk.
+type PipelineRefreshMsg struct{}
+
 // PipelineOpenProgressMsg is emitted when the progress screen should open.
 type PipelineOpenProgressMsg struct{}
 
@@ -162,6 +165,53 @@ func (m *PipelineModel) EnrichReport(reportPath, archetype, tldr, remote, comp s
 	}
 }
 
+// WithReloadedData rebuilds the pipeline with fresh tracker data while preserving
+// the current UI state so manual refresh feels seamless.
+func (m PipelineModel) WithReloadedData(apps []model.CareerApplication, metrics model.PipelineMetrics) PipelineModel {
+	selectedReportPath := ""
+	selectedCompany := ""
+	selectedRole := ""
+	if app, ok := m.CurrentApp(); ok {
+		selectedReportPath = app.ReportPath
+		selectedCompany = app.Company
+		selectedRole = app.Role
+	}
+
+	reloaded := NewPipelineModel(m.theme, apps, metrics, m.careerOpsPath, m.width, m.height)
+	reloaded.sortMode = m.sortMode
+	reloaded.activeTab = m.activeTab
+	reloaded.viewMode = m.viewMode
+	reloaded.applyFilterAndSort()
+	reloaded.CopyReportCache(&m)
+
+	for i, app := range reloaded.filtered {
+		if selectedReportPath != "" && app.ReportPath == selectedReportPath {
+			reloaded.cursor = i
+			reloaded.adjustScroll()
+			return reloaded
+		}
+		if selectedReportPath == "" && app.Company == selectedCompany && app.Role == selectedRole {
+			reloaded.cursor = i
+			reloaded.adjustScroll()
+			return reloaded
+		}
+	}
+
+	if len(reloaded.filtered) == 0 {
+		reloaded.cursor = 0
+		reloaded.scrollOffset = 0
+		return reloaded
+	}
+
+	if m.cursor >= len(reloaded.filtered) {
+		reloaded.cursor = len(reloaded.filtered) - 1
+	} else if m.cursor > 0 {
+		reloaded.cursor = m.cursor
+	}
+	reloaded.adjustScroll()
+	return reloaded
+}
+
 // CurrentApp returns the currently selected application, if any.
 func (m PipelineModel) CurrentApp() (model.CareerApplication, bool) {
 	if m.cursor < 0 || m.cursor >= len(m.filtered) {
@@ -267,6 +317,9 @@ func (m PipelineModel) handleKey(msg tea.KeyMsg) (PipelineModel, tea.Cmd) {
 
 	case "p":
 		return m, func() tea.Msg { return PipelineOpenProgressMsg{} }
+
+	case "r":
+		return m, func() tea.Msg { return PipelineRefreshMsg{} }
 
 	case "c":
 		if len(m.filtered) > 0 {
@@ -656,7 +709,7 @@ func (m PipelineModel) renderAppLine(app model.CareerApplication, selected bool)
 	padStyle := lipgloss.NewStyle().Padding(0, 2)
 
 	// Column widths
-	scoreW := 5   // "4.5  "
+	scoreW := 5 // "4.5  "
 	companyW := 20
 	statusW := 12
 	compW := 14
@@ -776,6 +829,7 @@ func (m PipelineModel) renderHelp() string {
 	keys := keyStyle.Render("↑↓") + descStyle.Render(" nav  ") +
 		keyStyle.Render("←→") + descStyle.Render(" tabs  ") +
 		keyStyle.Render("s") + descStyle.Render(" sort  ") +
+		keyStyle.Render("r") + descStyle.Render(" refresh  ") +
 		keyStyle.Render("Enter") + descStyle.Render(" report  ") +
 		keyStyle.Render("o") + descStyle.Render(" open URL  ") +
 		keyStyle.Render("c") + descStyle.Render(" change  ") +

--- a/dashboard/internal/ui/screens/pipeline_test.go
+++ b/dashboard/internal/ui/screens/pipeline_test.go
@@ -1,0 +1,72 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/santifer/career-ops/dashboard/internal/model"
+	"github.com/santifer/career-ops/dashboard/internal/theme"
+)
+
+func TestWithReloadedDataPreservesStateAndSelection(t *testing.T) {
+	initialApps := []model.CareerApplication{
+		{
+			Company:    "Acme",
+			Role:       "Backend Engineer",
+			Status:     "Evaluated",
+			Score:      4.2,
+			ReportPath: "reports/001-acme.md",
+		},
+		{
+			Company:    "Beta",
+			Role:       "Platform Engineer",
+			Status:     "Applied",
+			Score:      4.6,
+			ReportPath: "reports/002-beta.md",
+		},
+	}
+
+	pm := NewPipelineModel(
+		theme.NewTheme("catppuccin-mocha"),
+		initialApps,
+		model.PipelineMetrics{Total: len(initialApps)},
+		"..",
+		120,
+		40,
+	)
+	pm.sortMode = sortCompany
+	pm.activeTab = 0
+	pm.viewMode = "flat"
+	pm.applyFilterAndSort()
+	pm.cursor = 1
+	pm.reportCache["reports/002-beta.md"] = reportSummary{tldr: "cached"}
+
+	refreshedApps := []model.CareerApplication{
+		initialApps[0],
+		initialApps[1],
+		{
+			Company:    "Gamma",
+			Role:       "AI Engineer",
+			Status:     "Interview",
+			Score:      4.8,
+			ReportPath: "reports/003-gamma.md",
+		},
+	}
+
+	reloaded := pm.WithReloadedData(refreshedApps, model.PipelineMetrics{Total: len(refreshedApps)})
+
+	if reloaded.sortMode != sortCompany {
+		t.Fatalf("expected sort mode %q, got %q", sortCompany, reloaded.sortMode)
+	}
+	if reloaded.viewMode != "flat" {
+		t.Fatalf("expected view mode to stay flat, got %q", reloaded.viewMode)
+	}
+	if got := len(reloaded.filtered); got != 3 {
+		t.Fatalf("expected 3 filtered apps after refresh, got %d", got)
+	}
+	if app, ok := reloaded.CurrentApp(); !ok || app.ReportPath != "reports/002-beta.md" {
+		t.Fatalf("expected selection to stay on beta app, got %+v (ok=%v)", app, ok)
+	}
+	if reloaded.reportCache["reports/002-beta.md"].tldr != "cached" {
+		t.Fatal("expected cached report summaries to survive refresh")
+	}
+}

--- a/dashboard/main.go
+++ b/dashboard/main.go
@@ -33,6 +33,13 @@ type appModel struct {
 	progressMetrics model.ProgressMetrics
 }
 
+func (m *appModel) reloadPipelineData() {
+	apps := data.ParseApplications(m.careerOpsPath)
+	metrics := data.ComputeMetrics(apps)
+	m.progressMetrics = data.ComputeProgressMetrics(apps)
+	m.pipeline = m.pipeline.WithReloadedData(apps, metrics)
+}
+
 func (m appModel) Init() tea.Cmd {
 	return nil
 }
@@ -65,16 +72,11 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Log the error but still reload data to keep UI consistent
 			fmt.Fprintf(os.Stderr, "WARN: status update failed: %v\n", err)
 		}
-		apps := data.ParseApplications(m.careerOpsPath)
-		metrics := data.ComputeMetrics(apps)
-		m.progressMetrics = data.ComputeProgressMetrics(apps)
-		old := m.pipeline
-		m.pipeline = screens.NewPipelineModel(
-			m.theme,
-			apps, metrics, m.careerOpsPath,
-			old.Width(), old.Height(),
-		)
-		m.pipeline.CopyReportCache(&old)
+		m.reloadPipelineData()
+		return m, nil
+
+	case screens.PipelineRefreshMsg:
+		m.reloadPipelineData()
 		return m, nil
 
 	case screens.PipelineOpenReportMsg:


### PR DESCRIPTION
## What does this PR do?

Adds a manual `r` refresh shortcut to the dashboard pipeline screen so users can reload tracker data from disk without quitting and reopening the TUI. The refresh preserves the current tab, sort mode, view mode, selection, and cached report previews when possible.

## Related issue

Closes #247

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` (passed with warnings noted below)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Validation

- `cd dashboard && go test ./...`
- `cd dashboard && go build ./...`
- `node test-all.mjs` (completed with 62 passed, 0 failed, 2 warnings)

## Notes

The full suite completed with 0 failures and 2 warnings:
- `cv-sync-check.mjs` warns without user data in a clean contribution clone
- the personal-data leak check flagged `"santifer.io"` in `dashboard/internal/ui/screens/progress.go`
