### PR TITLE
fix: add stopword filtering and overlap ratio to roleMatch

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -62,11 +62,34 @@ function normalizeRole(role) {
     .trim();
 }
 
+const ROLE_STOPWORDS = new Set([
+  'senior', 'junior', 'lead', 'staff', 'principal', 'head', 'chief',
+  'manager', 'director', 'associate', 'intern', 'contractor',
+  'remote', 'hybrid', 'onsite',
+  'engineer', 'engineering',
+]);
+
+const LOCATION_STOPWORDS = new Set([
+  'tokyo', 'japan', 'london', 'berlin', 'paris', 'singapore',
+  'york', 'francisco', 'angeles', 'seattle', 'austin', 'boston',
+  'chicago', 'denver', 'toronto', 'amsterdam', 'dublin', 'sydney',
+  'remote', 'global', 'emea', 'apac', 'latam',
+]);
+
 function roleMatch(a, b) {
-  const wordsA = normalizeRole(a).split(/\s+/).filter(w => w.length > 3);
-  const wordsB = normalizeRole(b).split(/\s+/).filter(w => w.length > 3);
-  const overlap = wordsA.filter(w => wordsB.some(wb => wb.includes(w) || w.includes(wb)));
-  return overlap.length >= 2;
+  const filterStopwords = (words) =>
+    words.filter(w => !ROLE_STOPWORDS.has(w) && !LOCATION_STOPWORDS.has(w));
+
+  const wordsA = filterStopwords(normalizeRole(a).split(/\s+/).filter(w => w.length > 2));
+  const wordsB = filterStopwords(normalizeRole(b).split(/\s+/).filter(w => w.length > 2));
+
+  if (wordsA.length === 0 || wordsB.length === 0) return false;
+
+  const overlap = wordsA.filter(w => wordsB.some(wb => wb === w));
+  const smaller = Math.min(wordsA.length, wordsB.length);
+  const ratio = overlap.length / smaller;
+
+  return overlap.length >= 2 && ratio >= 0.6;
 }
 
 function parseScore(s) {


### PR DESCRIPTION
The dedup logic was treating any 2 shared words (with substring matching) as a duplicate. Roles sharing location names like 'Tokyo' or generic level words like 'Manager' got collapsed even when they were completely different positions.

Three changes to the matching:
- Filter out common role-level words (Senior, Lead, Manager, Director, etc.) and location fragments before comparing
- Use exact word matching instead of substring (no more 'data' matching 'database')
- Require both 2+ overlapping meaningful words AND 60% overlap ratio

Single file change.

Fixes #157