### PR TITLE
feat(scan): add Amazon Jobs scanner with US-only default

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -66,6 +66,27 @@ function detectApi(company) {
     };
   }
 
+  // Amazon Jobs — public search.json endpoint. Defaults to US-only to
+  // avoid flooding the pipeline with Bengaluru / Dublin / Shanghai roles
+  // from global keyword searches. To scan globally, pass `country: ALL`
+  // in the portal config, or include your own `&country[]=XX` in
+  // careers_url.
+  const amazonMatch = url.match(/amazon\.jobs\/en\/search/);
+  if (amazonMatch) {
+    const target = new URL(url);
+    const hasCountry = [...target.searchParams.keys()].some(k => k.startsWith('country'));
+    const searchParams = new URLSearchParams(target.searchParams);
+    if (!hasCountry && company.country !== 'ALL') {
+      searchParams.append('country[]', 'USA');
+      searchParams.append('country[]', 'US');
+    }
+    searchParams.set('result_limit', '100');
+    return {
+      type: 'amazon',
+      url: `https://www.amazon.jobs/en/search.json?${searchParams.toString()}`,
+    };
+  }
+
   return null;
 }
 
@@ -101,15 +122,34 @@ function parseLever(json, companyName) {
   }));
 }
 
-const PARSERS = { greenhouse: parseGreenhouse, ashby: parseAshby, lever: parseLever };
+function parseAmazon(json, companyName) {
+  const jobs = json?.jobs || [];
+  return jobs.map(j => ({
+    title: j.title || '',
+    url: j.job_path ? `https://www.amazon.jobs${j.job_path}` : '',
+    company: companyName,
+    location: j.normalized_location || '',
+  })).filter(o => o.url);
+}
+
+const PARSERS = {
+  greenhouse: parseGreenhouse,
+  ashby: parseAshby,
+  lever: parseLever,
+  amazon: parseAmazon,
+};
 
 // ── Fetch with timeout ──────────────────────────────────────────────
 
 async function fetchJson(url) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  // amazon.jobs rejects requests without a browser-like User-Agent.
+  const headers = url.includes('amazon.jobs')
+    ? { 'User-Agent': 'Mozilla/5.0' }
+    : undefined;
   try {
-    const res = await fetch(url, { signal: controller.signal });
+    const res = await fetch(url, { signal: controller.signal, headers });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return await res.json();
   } finally {


### PR DESCRIPTION
## Summary

Adds `amazon` as a fourth ATS type alongside greenhouse/ashby/lever in `scan.mjs`. Driven by Amazon's public `search.json` endpoint. Defaults to US-only postings because Amazon's global keyword searches readily return Bengaluru / Dublin / Shanghai roles that most users don't want cluttering their pipeline.

## Motivation

Amazon is one of the largest employers in AI/ML and GTM roles, but currently has no scanner support. A naive keyword search like `base_query=AI+product+manager` returns 500+ results across every region Amazon operates in. Without country filtering, the pipeline fills with roles the user can't apply to.

## What changed

`scan.mjs` — **2 additions, 0 modifications to existing flow:**

1. **`detectApi()`** — new case matching `amazon.jobs/en/search` URLs. Rewrites to `search.json` with:
   - `&country[]=USA&country[]=US` appended by default
   - Preserves any pre-existing `country[*]` filter in `careers_url` (so users can scan a specific region without fighting the defaults)
   - `result_limit=100`
2. **`parseAmazon()`** — new parser: `json.jobs` → `{title, url, company, location}` with `normalized_location` for display.
3. **`fetchJson()`** — adds `User-Agent: Mozilla/5.0` when the URL is an Amazon search endpoint. Amazon's edge returns 400/403 without a browser UA.

## Usage

Add an entry to `portals.yml`:

```yaml
  - name: Amazon
    careers_url: https://www.amazon.jobs/en/search?base_query=AI+product+manager
    enabled: true
```

To scan globally (override US-only default):

```yaml
    country: ALL
```

Or target specific countries:

```yaml
    careers_url: https://www.amazon.jobs/en/search?base_query=AI+product+manager&country[]=UK
```

## Opt-out path

Users who don't want Amazon in their pipeline just leave it out of `portals.yml` — the scanner only processes entries the user adds. No default portal change.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor

## Checklist

- [x] Read CONTRIBUTING.md
- [x] No personal data
- [x] Respects Data Contract — system-layer only (`scan.mjs`), no user files touched
- [x] Syntax-checked with `node --check scan.mjs`
- [x] Follows existing parser + detector pattern; no new deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)