### PR TITLE
fix(ci): use pull_request_target for labeler on fork PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Label PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
## Summary

Fixes #259

The labeler workflow fails on every fork PR with `Error: Resource not accessible by integration` because `pull_request` trigger gives fork PRs a read-only `GITHUB_TOKEN`.

## Change

1 line changed in `.github/workflows/labeler.yml`:

```diff
-  pull_request:
+  pull_request_target:
```

## Why this is safe

`pull_request_target` runs in the context of the base repo (not the fork), so the token has write permissions. This is safe because:
- `actions/labeler@v5` only reads the PR diff to match file patterns against `.github/labeler.yml`
- No checkout of fork code occurs in this workflow
- This is the [recommended approach](https://github.com/actions/labeler#permissions) in the labeler docs

## Test plan

- [ ] `node test-all.mjs --quick` passes (61/0)
- [ ] After merge, fork PRs should get labels without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)