### PR TITLE
fix: ensure data/ and output/ dirs exist before writing in scripts

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -9,7 +9,7 @@
  * Run: node career-ops/dedup-tracker.mjs [--dry-run]
  */
 
-import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -19,6 +19,9 @@ const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
   ? join(CAREER_OPS, 'data/applications.md')
   : join(CAREER_OPS, 'applications.md');
 const DRY_RUN = process.argv.includes('--dry-run');
+
+// Ensure required directories exist (fresh setup)
+mkdirSync(join(CAREER_OPS, 'data'), { recursive: true });
 
 // Status advancement order (higher = more advanced in pipeline)
 // Aplicado > Rechazado because active application > terminal state

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -13,9 +13,13 @@
 import { chromium } from 'playwright';
 import { resolve, dirname } from 'path';
 import { readFile } from 'fs/promises';
+import { mkdirSync } from 'fs';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Ensure output directory exists (fresh setup)
+mkdirSync(resolve(__dirname, 'output'), { recursive: true });
 
 /**
  * Normalize text for ATS compatibility by converting problematic Unicode.

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -29,6 +29,10 @@ const MERGED_DIR = join(ADDITIONS_DIR, 'merged');
 const DRY_RUN = process.argv.includes('--dry-run');
 const VERIFY = process.argv.includes('--verify');
 
+// Ensure required directories exist (fresh setup)
+mkdirSync(join(CAREER_OPS, 'data'), { recursive: true });
+mkdirSync(ADDITIONS_DIR, { recursive: true });
+
 // Canonical states and aliases
 const CANONICAL_STATES = ['Evaluated', 'Applied', 'Responded', 'Interview', 'Offer', 'Rejected', 'Discarded', 'SKIP'];
 

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -11,7 +11,7 @@
  * Run: node career-ops/normalize-statuses.mjs [--dry-run]
  */
 
-import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -21,6 +21,9 @@ const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
   ? join(CAREER_OPS, 'data/applications.md')
   : join(CAREER_OPS, 'applications.md');
 const DRY_RUN = process.argv.includes('--dry-run');
+
+// Ensure required directories exist (fresh setup)
+mkdirSync(join(CAREER_OPS, 'data'), { recursive: true });
 
 // Canonical status mapping
 function normalizeStatus(raw) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -15,7 +15,7 @@
  *   node scan.mjs --company Cohere # scan a single company
  */
 
-import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
 import yaml from 'js-yaml';
 const parseYaml = yaml.load;
 
@@ -25,6 +25,9 @@ const PORTALS_PATH = 'portals.yml';
 const SCAN_HISTORY_PATH = 'data/scan-history.tsv';
 const PIPELINE_PATH = 'data/pipeline.md';
 const APPLICATIONS_PATH = 'data/applications.md';
+
+// Ensure required directories exist (fresh setup)
+mkdirSync('data', { recursive: true });
 
 const CONCURRENCY = 10;
 const FETCH_TIMEOUT_MS = 10_000;

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -14,7 +14,7 @@
  * Run: node career-ops/verify-pipeline.mjs
  */
 
-import { readFileSync, readdirSync, existsSync } from 'fs';
+import { readFileSync, readdirSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -28,6 +28,10 @@ const REPORTS_DIR = join(CAREER_OPS, 'reports');
 const STATES_FILE = existsSync(join(CAREER_OPS, 'templates/states.yml'))
   ? join(CAREER_OPS, 'templates/states.yml')
   : join(CAREER_OPS, 'states.yml');
+
+// Ensure required directories exist (fresh setup)
+mkdirSync(join(CAREER_OPS, 'data'), { recursive: true });
+mkdirSync(REPORTS_DIR, { recursive: true });
 
 const CANONICAL_STATUSES = [
   'evaluated', 'applied', 'responded', 'interview',


### PR DESCRIPTION
## Summary

Fixes #256

Scripts crashed with `ENOENT` on fresh setup because `data/`, `reports/`, `output/`, and `batch/tracker-additions/` directories don't exist. Now each script auto-creates its required directories before writing.

## Changes

Added `mkdirSync(..., { recursive: true })` at the top of each affected script, after path constants:

| Script | Directories ensured |
|--------|-------------------|
| `merge-tracker.mjs` | `data/`, `batch/tracker-additions/` |
| `verify-pipeline.mjs` | `data/`, `reports/` |
| `normalize-statuses.mjs` | `data/` |
| `dedup-tracker.mjs` | `data/` |
| `scan.mjs` | `data/` |
| `generate-pdf.mjs` | `output/` |

`{ recursive: true }` makes it idempotent — no-op when dirs already exist. No shared helper file, each script handles its own dirs inline.

## Test plan

- [ ] `node test-all.mjs` passes (62/0)
- [ ] Fresh clone without `data/` dir → `node merge-tracker.mjs` runs without ENOENT
- [ ] Fresh clone without `output/` dir → PDF generation doesn't crash
- [ ] Existing setup with dirs already present → no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)