### PR TITLE
feat: add A16Z job board provider and integrate with scan functionality

### DIFF
--- a/providers/job-board-a16z.mjs
+++ b/providers/job-board-a16z.mjs
@@ -1,0 +1,472 @@
+/**
+ * job-board-a16z.mjs — a16z public jobs API provider
+ *
+ * Exposes search + filter metadata + autocomplete helpers for the
+ * Andreessen Horowitz public jobs API.
+ */
+
+const A16Z_API_BASE_URL = 'https://jobs.a16z.com/api-boards';
+const A16Z_FETCH_TIMEOUT_MS = 10_000;
+
+export const A16Z_PROVIDER_ID = 'a16z';
+export const A16Z_DEFAULT_PAGE_SIZE = 15;
+export const A16Z_BOARD = Object.freeze({
+  id: 'andreessen-horowitz',
+  isParent: true,
+});
+
+const A16Z_FILTER_GROUPS = Object.freeze([
+  'jobTypes',
+  'jobSeniority',
+  'skills',
+  'locations',
+  'companies',
+  'stages',
+  'markets',
+  'departments',
+  'currencies',
+  'salaryPeriods',
+]);
+
+/**
+ * @typedef {{ label: string, value: string }} A16ZFacetOption
+ * @typedef {{
+ *   size?: number,
+ *   sequence?: string,
+ *   promoteFeatured?: boolean,
+ *   remoteOnly?: boolean,
+ *   internshipsOnly?: boolean,
+ *   query?: Record<string, unknown>,
+ *   jobTypes?: Array<string|A16ZFacetOption>,
+ *   jobSeniority?: Array<string|A16ZFacetOption>,
+ *   skills?: Array<string|A16ZFacetOption>,
+ *   locations?: Array<string|A16ZFacetOption>,
+ *   companies?: Array<string|A16ZFacetOption>,
+ *   stages?: Array<string|A16ZFacetOption>,
+ *   markets?: Array<string|A16ZFacetOption>,
+ *   departments?: Array<string|A16ZFacetOption>,
+ *   currencies?: Array<string|A16ZFacetOption>,
+ *   salaryPeriods?: Array<string|A16ZFacetOption>
+ * }} A16ZSearchFilters
+ */
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function safeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function safeBoolean(value, fallback = false) {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function safeNumber(value, fallback = 0) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function buildBoardConfig() {
+  return { ...A16Z_BOARD };
+}
+
+function normalizeSize(size) {
+  if (Number.isInteger(size) && size > 0) return size;
+  return A16Z_DEFAULT_PAGE_SIZE;
+}
+
+function normalizeFilterInput(value) {
+  if (typeof value === 'string') return value.trim();
+  if (!value || typeof value !== 'object') return '';
+  return safeString(value.value) || safeString(value.id) || safeString(value.label);
+}
+
+function pickFilterValues(values) {
+  return asArray(values)
+    .map((value) => normalizeFilterInput(value))
+    .filter(Boolean);
+}
+
+function normalizeFacetOption(option, fallbackValue = '') {
+  if (typeof option === 'string') {
+    const value = option.trim();
+    if (!value) return null;
+    return { label: value, value };
+  }
+
+  if (!option || typeof option !== 'object' || Array.isArray(option)) return null;
+
+  const label = safeString(option.label) || safeString(option.name) || safeString(option.value) || fallbackValue;
+  const value = safeString(option.value) || safeString(option.id) || fallbackValue || label;
+  if (!label && !value) return null;
+
+  return { label: label || value, value: value || label };
+}
+
+function normalizeFacetOptions(values) {
+  return asArray(values)
+    .map((value) => normalizeFacetOption(value))
+    .filter(Boolean);
+}
+
+function normalizeTextOptions(values) {
+  return asArray(values)
+    .map((value) => safeString(value))
+    .filter(Boolean);
+}
+
+function normalizeAutocompleteNode(node) {
+  if (!node || typeof node !== 'object') return null;
+
+  const self = normalizeFacetOption(node.self);
+  if (!self) return null;
+
+  return {
+    ...self,
+    bolding: safeString(node.self?.bolding),
+    count: safeNumber(node.self?.count),
+    score: safeNumber(node.self?.score ?? node.score),
+    children: asArray(node.children)
+      .map((child) => normalizeAutocompleteNode({ self: child.self ?? child, children: child.children }))
+      .filter(Boolean),
+  };
+}
+
+function normalizeAutocompleteResults(values) {
+  return asArray(values)
+    .map((value) => normalizeAutocompleteNode(value))
+    .filter(Boolean);
+}
+
+async function fetchAutocomplete(path, query) {
+  if (!safeString(query)) return [];
+
+  const response = await postJson(`autocomplete/${path}`, {
+    q: query.trim(),
+    board: buildBoardConfig(),
+    skipCompanyExcludes: false,
+  });
+
+  return normalizeAutocompleteResults(response.results);
+}
+
+function normalizeSalary(salary) {
+  if (!salary || typeof salary !== 'object' || Array.isArray(salary)) return null;
+
+  const min = Number.isFinite(salary.minValue) ? salary.minValue : null;
+  const max = Number.isFinite(salary.maxValue) ? salary.maxValue : null;
+  const currency = normalizeFacetOption(salary.currency);
+  const period = normalizeFacetOption(salary.period);
+
+  if (min === null && max === null && !currency && !period) return null;
+
+  return {
+    minValue: min,
+    maxValue: max,
+    currency,
+    period,
+    isOriginal: safeBoolean(salary.isOriginal),
+  };
+}
+
+function normalizeAvailableFilters(values) {
+  return asArray(values)
+    .map((value) => {
+      if (!value || typeof value !== 'object') return null;
+      return {
+        param: safeString(value.param),
+        value: safeString(value.value),
+        total: safeNumber(value.total),
+      };
+    })
+    .filter((value) => value && (value.param || value.value));
+}
+
+function normalizeMessages(values) {
+  return asArray(values).map((value) => safeString(value)).filter(Boolean);
+}
+
+async function postJson(path, body) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), A16Z_FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${A16Z_API_BASE_URL}/${path}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    const text = await response.text();
+    let json = {};
+
+    if (text.trim()) {
+      try {
+        json = JSON.parse(text);
+      } catch (error) {
+        throw new Error(`A16Z ${path} returned malformed JSON: ${error.message}`);
+      }
+    }
+
+    if (!response.ok) {
+      const errors = normalizeMessages(json.errors);
+      const detail = errors.length > 0 ? ` (${errors.join('; ')})` : '';
+      throw new Error(`A16Z ${path} failed with HTTP ${response.status}${detail}`);
+    }
+
+    if (!json || typeof json !== 'object' || Array.isArray(json)) {
+      return {};
+    }
+
+    return json;
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      throw new Error(`A16Z ${path} timed out after ${A16Z_FETCH_TIMEOUT_MS}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * @param {A16ZSearchFilters} filters
+ */
+export function buildA16zSearchPayload(filters = {}) {
+  const meta = {
+    size: normalizeSize(filters.size),
+  };
+
+  if (safeString(filters.sequence)) {
+    meta.sequence = filters.sequence.trim();
+  }
+
+  const query = {
+    promoteFeatured: filters.promoteFeatured !== false,
+  };
+
+  for (const group of A16Z_FILTER_GROUPS) {
+    const values = pickFilterValues(filters[group]);
+    if (values.length > 0) {
+      query[group] = values;
+    }
+  }
+
+  if (filters.remoteOnly === true) query.remoteOnly = true;
+  if (filters.internshipsOnly === true) query.internshipsOnly = true;
+
+  if (filters.query && typeof filters.query === 'object' && !Array.isArray(filters.query)) {
+    Object.assign(query, filters.query);
+  }
+
+  return {
+    meta,
+    board: buildBoardConfig(),
+    query,
+  };
+}
+
+async function resolveFilterValue(autocompletePath, input, cache) {
+  const normalized = normalizeFacetOption(input);
+  if (!normalized) return null;
+
+  const existingValue = safeString(normalized.value);
+  const lookup = safeString(normalized.label) || existingValue;
+  if (!lookup) return null;
+
+  const cacheKey = `${autocompletePath}:${lookup.toLowerCase()}`;
+  if (!cache.has(cacheKey)) {
+    cache.set(cacheKey, fetchAutocomplete(autocompletePath, lookup).catch(() => []));
+  }
+
+  const options = await cache.get(cacheKey);
+  const lowerLookup = lookup.toLowerCase();
+  const exact = options.find((option) =>
+    option.label.toLowerCase() === lowerLookup || option.value.toLowerCase() === lowerLookup
+  );
+  const match = exact || options[0] || null;
+
+  if (!match) {
+    return { label: normalized.label || lookup, value: existingValue || lookup };
+  }
+
+  return { label: match.label, value: match.value };
+}
+
+async function resolveSearchFilters(filters = {}) {
+  const resolved = { ...filters };
+  const skills = asArray(filters.skills);
+  const locations = asArray(filters.locations);
+  const markets = asArray(filters.markets);
+
+  if (skills.length === 0 && locations.length === 0 && markets.length === 0) {
+    return resolved;
+  }
+
+  const cache = new Map();
+
+  const [resolvedSkills, resolvedLocations, resolvedMarkets] = await Promise.all([
+    Promise.all(skills.map((s) => resolveFilterValue('skills', s, cache))),
+    Promise.all(locations.map((l) => resolveFilterValue('locations', l, cache))),
+    Promise.all(markets.map((m) => resolveFilterValue('markets', m, cache))),
+  ]);
+
+  if (skills.length > 0) resolved.skills = resolvedSkills.filter(Boolean);
+  if (locations.length > 0) resolved.locations = resolvedLocations.filter(Boolean);
+  if (markets.length > 0) resolved.markets = resolvedMarkets.filter(Boolean);
+
+  return resolved;
+}
+
+export function normalizeA16zJob(job) {
+  if (!job || typeof job !== 'object') return null;
+
+  const locations = normalizeTextOptions(job.locations);
+  const normalizedLocations = normalizeFacetOptions(job.normalizedLocations);
+  const jobTypes = normalizeFacetOptions(job.jobTypes);
+  const jobFunctions = normalizeFacetOptions(job.jobFunctions);
+  const jobSeniorities = normalizeFacetOptions(job.jobSeniorities);
+  const markets = normalizeFacetOptions(job.markets);
+  const stages = normalizeFacetOptions(job.stages);
+  const skills = normalizeFacetOptions(job.skills);
+  const requiredSkills = normalizeFacetOptions(job.requiredSkills);
+  const preferredSkills = normalizeFacetOptions(job.preferredSkills);
+
+  const url = safeString(job.url) || safeString(job.applyUrl);
+  const title = safeString(job.title);
+  const company = safeString(job.companyName);
+
+  if (!url || !title || !company) return null;
+
+  return {
+    id: safeString(job.jobId),
+    title,
+    url,
+    applyUrl: safeString(job.applyUrl) || url,
+    company,
+    companyId: safeString(job.companyId),
+    companySlug: safeString(job.companySlug),
+    companyDomain: safeString(job.companyDomain),
+    location: normalizedLocations[0]?.label || locations[0] || '',
+    locations,
+    normalizedLocations,
+    departments: normalizeTextOptions(job.departments),
+    jobTypes,
+    jobFunctions,
+    jobSeniorities,
+    jobSeniorityIds: normalizeTextOptions(job.jobSeniorityIds),
+    markets,
+    stages,
+    skills,
+    requiredSkills,
+    preferredSkills,
+    salary: normalizeSalary(job.salary),
+    remote: safeBoolean(job.remote),
+    hybrid: safeBoolean(job.hybrid),
+    featured: safeBoolean(job.isFeatured),
+    manager: safeBoolean(job.manager),
+    consultant: safeBoolean(job.consultant),
+    contractor: safeBoolean(job.contractor),
+    postedAt: safeString(job.timeStamp),
+    source: 'a16z-api',
+  };
+}
+
+export function mapA16zJobToScanOffer(job) {
+  const normalized = normalizeA16zJob(job);
+  if (!normalized) return null;
+
+  return {
+    title: normalized.title,
+    url: normalized.url,
+    company: normalized.company,
+    location: normalized.location,
+  };
+}
+
+export function normalizeA16zNameMapping(response = {}) {
+  const groups = {};
+
+  for (const group of A16Z_FILTER_GROUPS) {
+    const bucket = response[group];
+
+    if (Array.isArray(bucket)) {
+      groups[group] = normalizeFacetOptions(bucket);
+      continue;
+    }
+
+    if (!bucket || typeof bucket !== 'object') {
+      groups[group] = [];
+      continue;
+    }
+
+    groups[group] = Object.entries(bucket)
+      .map(([key, value]) => normalizeFacetOption(value, key))
+      .filter(Boolean);
+  }
+
+  return {
+    groups,
+    errors: normalizeMessages(response.errors),
+    debug: normalizeMessages(response.debug),
+    version: response.version && typeof response.version === 'object' ? response.version : null,
+  };
+}
+
+/**
+ * @param {A16ZSearchFilters} filters
+ */
+export async function searchJobs(filters = {}) {
+  const resolvedFilters = await resolveSearchFilters(filters);
+  const payload = buildA16zSearchPayload(resolvedFilters);
+  const response = await postJson('search-jobs', payload);
+  const jobs = asArray(response.jobs)
+    .map((job) => normalizeA16zJob(job))
+    .filter(Boolean);
+
+  return {
+    jobs,
+    total: safeNumber(response.total, jobs.length),
+    meta: response.meta && typeof response.meta === 'object'
+      ? { ...response.meta, size: normalizeSize(response.meta.size ?? payload.meta.size) }
+      : { ...payload.meta },
+    availableFilters: normalizeAvailableFilters(response.availableFilters),
+    errors: normalizeMessages(response.errors),
+    debug: normalizeMessages(response.debug),
+    version: response.version && typeof response.version === 'object' ? response.version : null,
+  };
+}
+
+export async function fetchNameMapping() {
+  const response = await postJson('name-mapping', {
+    board: buildBoardConfig(),
+  });
+
+  return normalizeA16zNameMapping(response);
+}
+
+export async function autocompleteLocations(query) {
+  return fetchAutocomplete('locations', query);
+}
+
+export async function autocompleteMarkets(query) {
+  return fetchAutocomplete('markets', query);
+}
+
+export async function autocompleteSkills(query) {
+  return fetchAutocomplete('skills', query);
+}
+
+export const a16zProvider = Object.freeze({
+  id: A16Z_PROVIDER_ID,
+  board: A16Z_BOARD,
+  searchJobs,
+  mapToScanOffer: mapA16zJobToScanOffer,
+  fetchNameMapping,
+  autocompleteLocations,
+  autocompleteMarkets,
+  autocompleteSkills,
+});

--- a/providers/job-board-providers.mjs
+++ b/providers/job-board-providers.mjs
@@ -1,0 +1,10 @@
+import { a16zProvider } from './job-board-a16z.mjs';
+
+export const JOB_BOARD_PROVIDERS = Object.freeze({
+  [a16zProvider.id]: a16zProvider,
+});
+
+export function getJobBoardProvider(providerId) {
+  if (typeof providerId !== 'string') return null;
+  return JOB_BOARD_PROVIDERS[providerId.trim()] || null;
+}

--- a/scan.mjs
+++ b/scan.mjs
@@ -3,7 +3,7 @@
 /**
  * scan.mjs — Zero-token portal scanner
  *
- * Fetches Greenhouse, Ashby, and Lever APIs directly, applies title
+ * Fetches Greenhouse, Ashby, Lever, and A16Z APIs directly, applies title
  * filters from portals.yml, deduplicates against existing history,
  * and appends new offers to pipeline.md + scan-history.tsv.
  *
@@ -17,6 +17,7 @@
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
 import yaml from 'js-yaml';
+import { getJobBoardProvider } from './providers/job-board-providers.mjs';
 const parseYaml = yaml.load;
 
 // ── Config ──────────────────────────────────────────────────────────
@@ -32,12 +33,21 @@ const FETCH_TIMEOUT_MS = 10_000;
 // ── API detection ───────────────────────────────────────────────────
 
 function detectApi(company) {
+  const providerId = typeof company.api_provider === 'string' ? company.api_provider.trim() : '';
+  if (providerId && getJobBoardProvider(providerId)) {
+    return { type: providerId, url: company.api || company.careers_url || '' };
+  }
+
   // Greenhouse: explicit api field
   if (company.api && company.api.includes('greenhouse')) {
     return { type: 'greenhouse', url: company.api };
   }
 
   const url = company.careers_url || '';
+
+  if (url.includes('jobs.a16z.com')) {
+    return { type: 'a16z', url };
+  }
 
   // Ashby
   const ashbyMatch = url.match(/jobs\.ashbyhq\.com\/([^/?#]+)/);
@@ -289,8 +299,30 @@ async function main() {
   const tasks = targets.map(company => async () => {
     const { type, url } = company._api;
     try {
-      const json = await fetchJson(url);
-      const jobs = PARSERS[type](json, company.name);
+      const provider = getJobBoardProvider(type);
+      let jobs;
+
+      if (provider) {
+        const apiFilters = company.api_filters && typeof company.api_filters === 'object' && !Array.isArray(company.api_filters)
+          ? company.api_filters
+          : {};
+        const result = await provider.searchJobs({
+          ...apiFilters,
+          size: company.api_size,
+        });
+
+        if (result.errors.length > 0 && result.jobs.length === 0) {
+          throw new Error(result.errors.join('; '));
+        }
+
+        jobs = result.jobs
+          .map(job => provider.mapToScanOffer(job))
+          .filter(Boolean);
+      } else {
+        const json = await fetchJson(url);
+        jobs = PARSERS[type](json, company.name);
+      }
+
       totalFound += jobs.length;
 
       for (const job of jobs) {

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -296,10 +296,45 @@ search_queries:
 # Companies whose career pages are checked directly.
 # scan_method: playwright (default), websearch, greenhouse_api
 # For Greenhouse companies, add api: field for faster structured JSON access.
+# For provider-backed boards, set api_provider: <id>. Currently supported: a16z.
+# Optional provider knobs:
+#   api_size: page size / result count
+#   api_filters: provider-native filters passed to the search payload, e.g.
+#     remoteOnly: true
+#     internshipsOnly: false
+#     promoteFeatured: true
+#     skills:       ["Python", "LLMs"]
+#     markets:      ["Fintech", "AI"]
+#     locations:    ["San Francisco", "Remote"]
+#     companies:    ["OpenAI", "Anthropic"]
+#     stages:       ["1000+ employees"]
+#     departments:  ["Engineering"]
+#     jobTypes:     ["Full-time"]
+#     jobSeniority: ["Senior", "Staff"]
+#     currencies:   ["USD"]
+#     salaryPeriods: ["year"]
+#   Notes:
+#     - skills, locations, and markets are resolved through the provider's
+#       autocomplete API before the search is sent — use human-readable labels
+#     - other facets (stages, departments, jobTypes, jobSeniority, etc.) should
+#       match values from the provider's name-mapping metadata exactly
 
 tracked_companies:
 
   # -- AI Labs & LLM providers --
+
+  - name: A16Z Portfolio Jobs
+    careers_url: https://jobs.a16z.com
+    api_provider: a16z
+    api_size: 15
+    api_filters:
+      markets:
+        - "Fintech"
+        - "Artificial Intelligence"
+      locations:
+        - "San Francisco"
+    notes: "Aggregate board across a16z portfolio companies. Tune markets/locations to your search before enabling."
+    enabled: true
 
   - name: Anthropic
     careers_url: https://job-boards.greenhouse.io/anthropic


### PR DESCRIPTION
## What does this PR do?

Adds a new custom job board provider (`job-board-a16z.mjs`) to enable automated scanning of the Andreessen Horowitz (a16z) portfolio jobs page for relevant open roles. It integrates the new provider into the core scanner pipeline (`scan.mjs`), registers it in the provider registry (`job-board-providers.mjs`), and includes an example configuration block inside `templates/portals.example.yml`. 

## Solution

This PR implements a dedicated provider (`job-board-a16z.mjs`) to fetch, parse, and normalize job listings directly from the a16z portfolio job board, integrating it seamlessly into the existing `career-ops` scanner pipeline. 

### How it works

1. The core logic for interacting with the a16z job board is encapsulated within `job-board-a16z.mjs`. It handles payload parsing and normalizing the results into the standard `career-ops` job format.
2. The new provider is registered in `job-board-providers.mjs` so the `scan.mjs` orchestrator can dynamically route scanning requests to it.
3. Users can configure a16z searches by defining the portal type in their local `portals.yml`. 

### Folder structure

- `providers/job-board-a16z.mjs`: Core logic and integration for the a16z portal.
- `providers/job-board-providers.mjs`: Registry update to export the new a16z provider.
- `scan.mjs`: Updated to handle the routing and execution for the new provider type.
- `templates/portals.example.yml`: Added an example configuration block so new users know how to set up the a16z scanner.

### Design choices worth noting

- **Modular Provider Pattern**: Rather than bloating `scan.mjs`, all a16z-specific scraping and data normalization is kept isolated in its own provider file, adhering to the project's existing architecture.
- **Data Contract Adherence**: Only `templates/portals.example.yml` was modified to document the feature. The user's local `portals.yml` is untouched, strictly respecting the system's Data Contract.

## Related issue

Closes: #230 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---