### PR TITLE
feat: add {{PHONE}} placeholder to CV template

### DIFF
--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -70,6 +70,7 @@ Usar el template en `cv-template.html`. Reemplazar los placeholders `{{...}}` co
 | `{{LANG}}` | `en` o `es` |
 | `{{PAGE_WIDTH}}` | `8.5in` (letter) o `210mm` (A4) |
 | `{{NAME}}` | (from profile.yml) |
+| `{{PHONE}}` | (from profile.yml — include with its separator only when `profile.yml` has a non-empty `phone` value; omit both `<span>` and `<span class="separator">` otherwise) |
 | `{{EMAIL}}` | (from profile.yml) |
 | `{{LINKEDIN_URL}}` | [from profile.yml] |
 | `{{LINKEDIN_DISPLAY}}` | [from profile.yml] |

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -357,6 +357,8 @@
     <h1>{{NAME}}</h1>
     <div class="header-gradient"></div>
     <div class="contact-row">
+      <span>{{PHONE}}</span>
+      <span class="separator">|</span>
       <span>{{EMAIL}}</span>
       <span class="separator">|</span>
       <a href="{{LINKEDIN_URL}}">{{LINKEDIN_DISPLAY}}</a>


### PR DESCRIPTION
## Description

Résolution de l'issue #268 — ajout du placeholder `{{PHONE}}` dans le template CV afin de supporter le numéro de téléphone, champ standard attendu notamment pour les candidatures UK/Europe.

## Modifications

- **`templates/cv-template.html`** : ajout d'un `<span>{{PHONE}}</span>` et de son séparateur `|` avant `{{EMAIL}}` dans la ligne de contact du header
- **`modes/pdf.md`** : documentation du placeholder `{{PHONE}}` dans la table des placeholders, avec une note précisant que le span et son séparateur doivent être omis si la valeur `phone` est absente dans `profile.yml`

## Comportement

- Quand `profile.yml` contient une valeur `phone` → le numéro s'affiche en première position dans la ligne de contact, suivi du séparateur `|` puis de l'email
- Quand `phone` est absent ou vide → l'agent supprime le `<span>` et le `<span class="separator">` correspondants, conformément à la note dans `pdf.md`

## Remarques

- `config/profile.example.yml` disposait déjà du champ `phone: "+1-555-0123"` — aucune modification nécessaire
- Le pattern suivi est identique à celui de `{{EMAIL}}` et `{{NAME}}` (lecture depuis `profile.yml`)
- Aucune régression sur les autres placeholders

## Test plan

- [ ] Générer un CV avec un `profile.yml` contenant un `phone` → vérifier que le numéro apparaît avant l'email
- [ ] Générer un CV sans champ `phone` dans `profile.yml` → vérifier que ni le numéro ni le séparateur n'apparaissent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phone number display to CV contact information, appearing in the header when a phone number is provided in the profile.

* **Documentation**
  * Updated template documentation to document the new phone number placeholder and its conditional rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->