### PR TITLE
feat: pluggable job discovery layer (scan-sources.mjs)

### DIFF
--- a/scan-sources.mjs
+++ b/scan-sources.mjs
@@ -63,12 +63,10 @@ export const SOURCES = [
     name: 'greenhouse',
     type: 'ats-api',
     detect(company) {
-      if (company.api?.includes('greenhouse')) return { url: company.api };
+      if (company.api?.includes('boards-api.greenhouse.io')) return { url: company.api };
       const m = (company.careers_url || '')
         .match(/job-boards(?:\.eu)?\.greenhouse\.io\/([^/?#]+)/);
-      if (m && !company.api) {
-        return { url: `https://boards-api.greenhouse.io/v1/boards/${m[1]}/jobs` };
-      }
+      if (m) return { url: `https://boards-api.greenhouse.io/v1/boards/${m[1]}/jobs` };
       return null;
     },
     fetch: fetchJson,
@@ -132,8 +130,8 @@ export const SOURCES = [
     fetch: fetchJson,
     parse(json, companyName) {
       return (json.content || []).map(j => ({
-        title:    j.name || '',
-        url:      j.ref  || '',
+        title:    j.name        || '',
+        url:      j.postingUrl  || j.ref || '',
         company:  companyName,
         location: [j.location?.city, j.location?.region].filter(Boolean).join(', '),
       }));

--- a/scan-sources.mjs
+++ b/scan-sources.mjs
@@ -1,0 +1,178 @@
+/**
+ * scan-sources.mjs — Job discovery source registry
+ *
+ * Defines the JobSource contract and all built-in ATS API sources.
+ * Imported by scan.mjs (runtime) and test-all.mjs (tests).
+ *
+ * Adding a new source
+ * ───────────────────
+ * Append one object to SOURCES that satisfies this interface:
+ *
+ *   name    string   Identifier written to scan-history.tsv
+ *   type    string   'ats-api' | 'search' | 'scrape' | 'static'
+ *
+ *   detect(company) → { url: string } | null
+ *     Inspect a portals.yml company entry and return the API endpoint
+ *     URL if this source handles it, or null if it doesn't.
+ *
+ *   fetch(url) → Promise<any>
+ *     Retrieve raw data from the resolved endpoint.
+ *
+ *   parse(data, companyName) → Array<Job>
+ *     Convert raw data into jobs. Missing fields are fine —
+ *     normalizeJob() will fill defaults after this call.
+ *
+ * That's it. Nothing else in scan.mjs needs to change.
+ */
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+// ── Shared fetch helper ──────────────────────────────────────────────
+
+export async function fetchJson(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Output contract ──────────────────────────────────────────────────
+//
+// Every source.parse() return value passes through normalizeJob().
+// This guarantees core logic always receives clean strings, regardless
+// of how consistent or inconsistent an individual parser is.
+
+export function normalizeJob(job) {
+  return {
+    title:    (job.title    || '').trim(),
+    url:      (job.url      || '').trim(),
+    company:  (job.company  || '').trim(),
+    location: (job.location || '').trim(),
+  };
+}
+
+// ── Source registry ──────────────────────────────────────────────────
+
+export const SOURCES = [
+  {
+    name: 'greenhouse',
+    type: 'ats-api',
+    detect(company) {
+      if (company.api?.includes('greenhouse')) return { url: company.api };
+      const m = (company.careers_url || '')
+        .match(/job-boards(?:\.eu)?\.greenhouse\.io\/([^/?#]+)/);
+      if (m && !company.api) {
+        return { url: `https://boards-api.greenhouse.io/v1/boards/${m[1]}/jobs` };
+      }
+      return null;
+    },
+    fetch: fetchJson,
+    parse(json, companyName) {
+      return (json.jobs || []).map(j => ({
+        title:    j.title || '',
+        url:      j.absolute_url || '',
+        company:  companyName,
+        location: j.location?.name || '',
+      }));
+    },
+  },
+
+  {
+    name: 'ashby',
+    type: 'ats-api',
+    detect(company) {
+      const m = (company.careers_url || '').match(/jobs\.ashbyhq\.com\/([^/?#]+)/);
+      if (!m) return null;
+      return { url: `https://api.ashbyhq.com/posting-api/job-board/${m[1]}?includeCompensation=true` };
+    },
+    fetch: fetchJson,
+    parse(json, companyName) {
+      return (json.jobs || []).map(j => ({
+        title:    j.title || '',
+        url:      j.jobUrl || '',
+        company:  companyName,
+        location: j.location || '',
+      }));
+    },
+  },
+
+  {
+    name: 'lever',
+    type: 'ats-api',
+    detect(company) {
+      const m = (company.careers_url || '').match(/jobs\.lever\.co\/([^/?#]+)/);
+      if (!m) return null;
+      return { url: `https://api.lever.co/v0/postings/${m[1]}` };
+    },
+    fetch: fetchJson,
+    parse(json, companyName) {
+      if (!Array.isArray(json)) return [];
+      return json.map(j => ({
+        title:    j.text || '',
+        url:      j.hostedUrl || '',
+        company:  companyName,
+        location: j.categories?.location || '',
+      }));
+    },
+  },
+
+  {
+    name: 'smartrecruiters',
+    type: 'ats-api',
+    detect(company) {
+      const m = (company.careers_url || '').match(/jobs\.smartrecruiters\.com\/([^/?#]+)/);
+      if (!m) return null;
+      return { url: `https://api.smartrecruiters.com/v1/companies/${m[1]}/postings?limit=100` };
+    },
+    fetch: fetchJson,
+    parse(json, companyName) {
+      return (json.content || []).map(j => ({
+        title:    j.name || '',
+        url:      j.ref  || '',
+        company:  companyName,
+        location: [j.location?.city, j.location?.region].filter(Boolean).join(', '),
+      }));
+    },
+  },
+
+  {
+    name: 'workable',
+    type: 'ats-api',
+    detect(company) {
+      const m = (company.careers_url || '').match(/apply\.workable\.com\/([^/?#]+)/);
+      if (!m) return null;
+      return { url: `https://apply.workable.com/api/v1/widget/jobs/${m[1]}` };
+    },
+    fetch: fetchJson,
+    parse(json, companyName) {
+      return (json.results || []).map(j => ({
+        title:    j.title || '',
+        url:      j.url   || '',
+        company:  companyName,
+        location: j.location?.city || '',
+      }));
+    },
+  },
+];
+
+// ── Source resolution ────────────────────────────────────────────────
+
+/**
+ * Find the first source that handles a given portals.yml company entry.
+ * @param {object} company - Entry from portals.yml tracked_companies
+ * @param {string[]} [types] - Optional type filter (e.g. ['ats-api'])
+ * @returns {{ source: object, url: string } | null}
+ */
+export function resolveSource(company, types) {
+  for (const source of SOURCES) {
+    if (types && !types.includes(source.type)) continue;
+    const result = source.detect(company);
+    if (result) return { source, url: result.url };
+  }
+  return null;
+}

--- a/scan-sources.mjs
+++ b/scan-sources.mjs
@@ -63,7 +63,13 @@ export const SOURCES = [
     name: 'greenhouse',
     type: 'ats-api',
     detect(company) {
-      if (company.api?.includes('boards-api.greenhouse.io')) return { url: company.api };
+      if (company.api) {
+        try {
+          if (new URL(company.api).hostname === 'boards-api.greenhouse.io') {
+            return { url: company.api };
+          }
+        } catch { /* invalid URL — fall through to careers_url inference */ }
+      }
       const m = (company.careers_url || '')
         .match(/job-boards(?:\.eu)?\.greenhouse\.io\/([^/?#]+)/);
       if (m) return { url: `https://boards-api.greenhouse.io/v1/boards/${m[1]}/jobs` };

--- a/scan-sources.mjs
+++ b/scan-sources.mjs
@@ -47,12 +47,13 @@ export async function fetchJson(url) {
 // This guarantees core logic always receives clean strings, regardless
 // of how consistent or inconsistent an individual parser is.
 
-export function normalizeJob(job) {
+export function normalizeJob(job = {}) {
+  const toText = (v) => (v == null ? '' : String(v)).trim();
   return {
-    title:    (job.title    || '').trim(),
-    url:      (job.url      || '').trim(),
-    company:  (job.company  || '').trim(),
-    location: (job.location || '').trim(),
+    title:    toText(job.title),
+    url:      toText(job.url),
+    company:  toText(job.company),
+    location: toText(job.location),
   };
 }
 
@@ -63,12 +64,13 @@ export const SOURCES = [
     name: 'greenhouse',
     type: 'ats-api',
     detect(company) {
-      if (company.api) {
+      if (typeof company.api === 'string') {
         try {
-          if (new URL(company.api).hostname === 'boards-api.greenhouse.io') {
-            return { url: company.api };
+          const apiUrl = new URL(company.api);
+          if (apiUrl.protocol === 'https:' && apiUrl.hostname === 'boards-api.greenhouse.io') {
+            return { url: apiUrl.toString() };
           }
-        } catch { /* invalid URL — fall through to careers_url inference */ }
+        } catch { /* fall through */ }
       }
       const m = (company.careers_url || '')
         .match(/job-boards(?:\.eu)?\.greenhouse\.io\/([^/?#]+)/);
@@ -77,7 +79,7 @@ export const SOURCES = [
     },
     fetch: fetchJson,
     parse(json, companyName) {
-      return (json.jobs || []).map(j => ({
+      return (Array.isArray(json?.jobs) ? json.jobs : []).map(j => ({
         title:    j.title || '',
         url:      j.absolute_url || '',
         company:  companyName,
@@ -96,7 +98,7 @@ export const SOURCES = [
     },
     fetch: fetchJson,
     parse(json, companyName) {
-      return (json.jobs || []).map(j => ({
+      return (Array.isArray(json?.jobs) ? json.jobs : []).map(j => ({
         title:    j.title || '',
         url:      j.jobUrl || '',
         company:  companyName,
@@ -115,8 +117,7 @@ export const SOURCES = [
     },
     fetch: fetchJson,
     parse(json, companyName) {
-      if (!Array.isArray(json)) return [];
-      return json.map(j => ({
+      return (Array.isArray(json) ? json : []).map(j => ({
         title:    j.text || '',
         url:      j.hostedUrl || '',
         company:  companyName,
@@ -135,7 +136,7 @@ export const SOURCES = [
     },
     fetch: fetchJson,
     parse(json, companyName) {
-      return (json.content || []).map(j => ({
+      return (Array.isArray(json?.content) ? json.content : []).map(j => ({
         title:    j.name        || '',
         url:      j.postingUrl  || j.ref || '',
         company:  companyName,
@@ -154,7 +155,7 @@ export const SOURCES = [
     },
     fetch: fetchJson,
     parse(json, companyName) {
-      return (json.results || []).map(j => ({
+      return (Array.isArray(json?.results) ? json.results : []).map(j => ({
         title:    j.title || '',
         url:      j.url   || '',
         company:  companyName,
@@ -173,9 +174,16 @@ export const SOURCES = [
  * @returns {{ source: object, url: string } | null}
  */
 export function resolveSource(company, types) {
+  if (!company || typeof company !== 'object') return null;
+  const allowedTypes = Array.isArray(types) ? types : null;
   for (const source of SOURCES) {
-    if (types && !types.includes(source.type)) continue;
-    const result = source.detect(company);
+    if (allowedTypes && !allowedTypes.includes(source.type)) continue;
+    let result = null;
+    try {
+      result = source.detect(company);
+    } catch {
+      continue;
+    }
     if (result) return { source, url: result.url };
   }
   return null;

--- a/scan.mjs
+++ b/scan.mjs
@@ -165,7 +165,15 @@ async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
   const companyFlag = args.indexOf('--company');
-  const filterCompany = companyFlag !== -1 ? args[companyFlag + 1]?.toLowerCase() : null;
+  let filterCompany = null;
+  if (companyFlag !== -1) {
+    const companyValue = args[companyFlag + 1];
+    if (!companyValue || companyValue.startsWith('-')) {
+      console.error('Error: --company requires a value (e.g. --company Acme)');
+      process.exit(1);
+    }
+    filterCompany = companyValue.toLowerCase();
+  }
   const typeFlag = args.indexOf('--type');
   const rawTypeValue = typeFlag !== -1 ? args[typeFlag + 1] : null;
   if (typeFlag !== -1 && (!rawTypeValue || rawTypeValue.startsWith('-') || !rawTypeValue.trim())) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -167,12 +167,12 @@ async function main() {
   const companyFlag = args.indexOf('--company');
   const filterCompany = companyFlag !== -1 ? args[companyFlag + 1]?.toLowerCase() : null;
   const typeFlag = args.indexOf('--type');
-  const typeValue = typeFlag !== -1 ? args[typeFlag + 1] : null;
-  if (typeFlag !== -1 && !typeValue) {
+  const rawTypeValue = typeFlag !== -1 ? args[typeFlag + 1] : null;
+  if (typeFlag !== -1 && (!rawTypeValue || rawTypeValue.startsWith('-') || !rawTypeValue.trim())) {
     console.error('Error: --type requires a value (e.g. --type ats-api)');
     process.exit(1);
   }
-  const filterTypes = typeValue ? [typeValue] : null;
+  const filterTypes = rawTypeValue ? [rawTypeValue.trim().toLowerCase()] : null;
 
   // 1. Read portals.yml
   if (!existsSync(PORTALS_PATH)) {
@@ -216,6 +216,7 @@ async function main() {
       totalFound += jobs.length;
 
       for (const job of jobs) {
+        if (!job.url || !job.title) continue;
         if (!titleFilter(job.title)) {
           totalFiltered++;
           continue;

--- a/scan.mjs
+++ b/scan.mjs
@@ -20,7 +20,7 @@
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
 import yaml from 'js-yaml';
-import { normalizeJob, resolveSource } from './scan-sources.mjs';
+import { SOURCES, normalizeJob, resolveSource } from './scan-sources.mjs';
 const parseYaml = yaml.load;
 
 // ── Config ──────────────────────────────────────────────────────────
@@ -180,7 +180,17 @@ async function main() {
     console.error('Error: --type requires a value (e.g. --type ats-api)');
     process.exit(1);
   }
-  const filterTypes = rawTypeValue ? [rawTypeValue.trim().toLowerCase()] : null;
+  const normalizedType = rawTypeValue ? rawTypeValue.trim().toLowerCase() : null;
+  if (normalizedType) {
+    const supportedTypes = new Set(SOURCES.map(s => s.type));
+    if (!supportedTypes.has(normalizedType)) {
+      console.error(
+        `Error: unsupported --type "${normalizedType}". Supported values: ${[...supportedTypes].join(', ')}`
+      );
+      process.exit(1);
+    }
+  }
+  const filterTypes = normalizedType ? [normalizedType] : null;
 
   // 1. Read portals.yml
   if (!existsSync(PORTALS_PATH)) {
@@ -220,11 +230,14 @@ async function main() {
     const { source, url } = company._resolved;
     try {
       const json = await source.fetch(url);
-      const jobs = source.parse(json, company.name).map(normalizeJob);
+      const jobs = source
+        .parse(json, company.name)
+        .map(normalizeJob)
+        .map(job => ({ ...job, company: job.company || company.name }));
       totalFound += jobs.length;
 
       for (const job of jobs) {
-        if (!job.url || !job.title) continue;
+        if (!job.url || !job.title || !job.company) continue;
         if (!titleFilter(job.title)) {
           totalFiltered++;
           continue;

--- a/scan.mjs
+++ b/scan.mjs
@@ -3,20 +3,24 @@
 /**
  * scan.mjs — Zero-token portal scanner
  *
- * Fetches Greenhouse, Ashby, and Lever APIs directly, applies title
- * filters from portals.yml, deduplicates against existing history,
- * and appends new offers to pipeline.md + scan-history.tsv.
+ * Fetches job listings from ATS APIs (Greenhouse, Ashby, Lever,
+ * SmartRecruiters, Workable), applies title filters from portals.yml,
+ * deduplicates against existing history, and appends new offers to
+ * pipeline.md + scan-history.tsv.
  *
  * Zero Claude API tokens — pure HTTP + JSON.
+ * Source definitions live in scan-sources.mjs.
  *
  * Usage:
- *   node scan.mjs                  # scan all enabled companies
- *   node scan.mjs --dry-run        # preview without writing files
- *   node scan.mjs --company Cohere # scan a single company
+ *   node scan.mjs                       # scan all enabled companies
+ *   node scan.mjs --dry-run             # preview without writing files
+ *   node scan.mjs --company Cohere      # scan a single company
+ *   node scan.mjs --type ats-api        # only sources of this type
  */
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'fs';
 import yaml from 'js-yaml';
+import { normalizeJob, resolveSource } from './scan-sources.mjs';
 const parseYaml = yaml.load;
 
 // ── Config ──────────────────────────────────────────────────────────
@@ -27,95 +31,6 @@ const PIPELINE_PATH = 'data/pipeline.md';
 const APPLICATIONS_PATH = 'data/applications.md';
 
 const CONCURRENCY = 10;
-const FETCH_TIMEOUT_MS = 10_000;
-
-// ── API detection ───────────────────────────────────────────────────
-
-function detectApi(company) {
-  // Greenhouse: explicit api field
-  if (company.api && company.api.includes('greenhouse')) {
-    return { type: 'greenhouse', url: company.api };
-  }
-
-  const url = company.careers_url || '';
-
-  // Ashby
-  const ashbyMatch = url.match(/jobs\.ashbyhq\.com\/([^/?#]+)/);
-  if (ashbyMatch) {
-    return {
-      type: 'ashby',
-      url: `https://api.ashbyhq.com/posting-api/job-board/${ashbyMatch[1]}?includeCompensation=true`,
-    };
-  }
-
-  // Lever
-  const leverMatch = url.match(/jobs\.lever\.co\/([^/?#]+)/);
-  if (leverMatch) {
-    return {
-      type: 'lever',
-      url: `https://api.lever.co/v0/postings/${leverMatch[1]}`,
-    };
-  }
-
-  // Greenhouse EU boards
-  const ghEuMatch = url.match(/job-boards(?:\.eu)?\.greenhouse\.io\/([^/?#]+)/);
-  if (ghEuMatch && !company.api) {
-    return {
-      type: 'greenhouse',
-      url: `https://boards-api.greenhouse.io/v1/boards/${ghEuMatch[1]}/jobs`,
-    };
-  }
-
-  return null;
-}
-
-// ── API parsers ─────────────────────────────────────────────────────
-
-function parseGreenhouse(json, companyName) {
-  const jobs = json.jobs || [];
-  return jobs.map(j => ({
-    title: j.title || '',
-    url: j.absolute_url || '',
-    company: companyName,
-    location: j.location?.name || '',
-  }));
-}
-
-function parseAshby(json, companyName) {
-  const jobs = json.jobs || [];
-  return jobs.map(j => ({
-    title: j.title || '',
-    url: j.jobUrl || '',
-    company: companyName,
-    location: j.location || '',
-  }));
-}
-
-function parseLever(json, companyName) {
-  if (!Array.isArray(json)) return [];
-  return json.map(j => ({
-    title: j.text || '',
-    url: j.hostedUrl || '',
-    company: companyName,
-    location: j.categories?.location || '',
-  }));
-}
-
-const PARSERS = { greenhouse: parseGreenhouse, ashby: parseAshby, lever: parseLever };
-
-// ── Fetch with timeout ──────────────────────────────────────────────
-
-async function fetchJson(url) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  try {
-    const res = await fetch(url, { signal: controller.signal });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return await res.json();
-  } finally {
-    clearTimeout(timer);
-  }
-}
 
 // ── Title filter ────────────────────────────────────────────────────
 
@@ -251,6 +166,8 @@ async function main() {
   const dryRun = args.includes('--dry-run');
   const companyFlag = args.indexOf('--company');
   const filterCompany = companyFlag !== -1 ? args[companyFlag + 1]?.toLowerCase() : null;
+  const typeFlag = args.indexOf('--type');
+  const filterTypes = typeFlag !== -1 ? [args[typeFlag + 1]] : null;
 
   // 1. Read portals.yml
   if (!existsSync(PORTALS_PATH)) {
@@ -266,8 +183,8 @@ async function main() {
   const targets = companies
     .filter(c => c.enabled !== false)
     .filter(c => !filterCompany || c.name.toLowerCase().includes(filterCompany))
-    .map(c => ({ ...c, _api: detectApi(c) }))
-    .filter(c => c._api !== null);
+    .map(c => ({ ...c, _resolved: resolveSource(c, filterTypes) }))
+    .filter(c => c._resolved !== null);
 
   const skippedCount = companies.filter(c => c.enabled !== false).length - targets.length;
 
@@ -287,10 +204,10 @@ async function main() {
   const errors = [];
 
   const tasks = targets.map(company => async () => {
-    const { type, url } = company._api;
+    const { source, url } = company._resolved;
     try {
-      const json = await fetchJson(url);
-      const jobs = PARSERS[type](json, company.name);
+      const json = await source.fetch(url);
+      const jobs = source.parse(json, company.name).map(normalizeJob);
       totalFound += jobs.length;
 
       for (const job of jobs) {
@@ -310,7 +227,7 @@ async function main() {
         // Mark as seen to avoid intra-scan dupes
         seenUrls.add(job.url);
         seenCompanyRoles.add(key);
-        newOffers.push({ ...job, source: `${type}-api` });
+        newOffers.push({ ...job, source: `${source.name}-api` });
       }
     } catch (err) {
       errors.push({ company: company.name, error: err.message });

--- a/scan.mjs
+++ b/scan.mjs
@@ -167,7 +167,12 @@ async function main() {
   const companyFlag = args.indexOf('--company');
   const filterCompany = companyFlag !== -1 ? args[companyFlag + 1]?.toLowerCase() : null;
   const typeFlag = args.indexOf('--type');
-  const filterTypes = typeFlag !== -1 ? [args[typeFlag + 1]] : null;
+  const typeValue = typeFlag !== -1 ? args[typeFlag + 1] : null;
+  if (typeFlag !== -1 && !typeValue) {
+    console.error('Error: --type requires a value (e.g. --type ats-api)');
+    process.exit(1);
+  }
+  const filterTypes = typeValue ? [typeValue] : null;
 
   // 1. Read portals.yml
   if (!existsSync(PORTALS_PATH)) {
@@ -227,7 +232,7 @@ async function main() {
         // Mark as seen to avoid intra-scan dupes
         seenUrls.add(job.url);
         seenCompanyRoles.add(key);
-        newOffers.push({ ...job, source: `${source.name}-api` });
+        newOffers.push({ ...job, source: source.name });
       }
     } catch (err) {
       errors.push({ company: company.name, error: err.message });

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -273,6 +273,82 @@ if (fileExists('VERSION')) {
   fail('VERSION file missing');
 }
 
+// ── 11. JOB SOURCE LAYER ─────────────────────────────────────────
+
+console.log('\n11. Job source layer (scan-sources.mjs)');
+
+try {
+  const { normalizeJob, SOURCES, resolveSource } = await import(
+    pathToFileURL(join(ROOT, 'scan-sources.mjs')).href
+  );
+
+  // normalizeJob: messy input → clean strings
+  const messy = normalizeJob({ title: '  AI Engineer  ', url: undefined, location: null });
+  if (messy.title === 'AI Engineer' && messy.url === '' && messy.location === '') {
+    pass('normalizeJob trims whitespace and fills missing fields with empty strings');
+  } else {
+    fail(`normalizeJob returned unexpected shape: ${JSON.stringify(messy)}`);
+  }
+
+  // normalizeJob: all fields present
+  const clean = normalizeJob({ title: 'ML Lead', url: 'https://example.com/job', company: 'Acme', location: 'Berlin' });
+  if (clean.title === 'ML Lead' && clean.company === 'Acme') {
+    pass('normalizeJob passes through valid fields unchanged');
+  } else {
+    fail(`normalizeJob mutated valid fields: ${JSON.stringify(clean)}`);
+  }
+
+  // All SOURCES have required fields
+  const requiredFields = ['name', 'type', 'detect', 'fetch', 'parse'];
+  let sourcesOk = true;
+  for (const source of SOURCES) {
+    for (const field of requiredFields) {
+      if (source[field] == null) {
+        fail(`Source "${source.name || '?'}" is missing required field: ${field}`);
+        sourcesOk = false;
+      }
+    }
+  }
+  if (sourcesOk) pass(`All ${SOURCES.length} sources have required fields (name, type, detect, fetch, parse)`);
+
+  // resolveSource: known URL patterns resolve to the correct source
+  const fixtures = [
+    { careers_url: 'https://job-boards.greenhouse.io/acme', expected: 'greenhouse' },
+    { careers_url: 'https://jobs.ashbyhq.com/acme', expected: 'ashby' },
+    { careers_url: 'https://jobs.lever.co/acme', expected: 'lever' },
+    { careers_url: 'https://jobs.smartrecruiters.com/Acme', expected: 'smartrecruiters' },
+    { careers_url: 'https://apply.workable.com/acme', expected: 'workable' },
+  ];
+  for (const { careers_url, expected } of fixtures) {
+    const result = resolveSource({ careers_url });
+    if (result?.source.name === expected) {
+      pass(`resolveSource detects "${expected}" from careers_url`);
+    } else {
+      fail(`resolveSource("${careers_url}") → expected "${expected}", got "${result?.source.name ?? 'null'}"`);
+    }
+  }
+
+  // resolveSource: unknown URL returns null (no false positives)
+  const unknown = resolveSource({ careers_url: 'https://careers.somecompany.com/jobs' });
+  if (unknown === null) {
+    pass('resolveSource returns null for unrecognised URL patterns');
+  } else {
+    fail(`resolveSource matched unknown URL to source "${unknown.source.name}"`);
+  }
+
+  // --type flag: resolveSource respects type filter
+  const atsResult = resolveSource({ careers_url: 'https://jobs.ashbyhq.com/acme' }, ['ats-api']);
+  const filteredOut = resolveSource({ careers_url: 'https://jobs.ashbyhq.com/acme' }, ['search']);
+  if (atsResult !== null && filteredOut === null) {
+    pass('resolveSource type filter includes matching types and excludes non-matching');
+  } else {
+    fail('resolveSource type filter behaved unexpectedly');
+  }
+
+} catch (e) {
+  fail(`Job source layer tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
Part of 🔗 Multi-CLI & AI-Agnostic Support #272
## Problem

`scan.mjs` had job discovery sources hardcoded as a `detectApi()` function,
separate `parseGreenhouse/parseAshby/parseLever` functions, and a `PARSERS`
map. Adding a new ATS meant touching core scan logic in multiple places with
no clear contract for what a "source" should look like.

## What this changes

**New file: `scan-sources.mjs`**

Extracted, testable source registry — same pattern as `liveness-core.mjs`.
Exports three things:

- `normalizeJob(job)` — enforces `{ title, url, company, location }` output
  contract so core logic never sees `undefined`, regardless of parser quality
- `SOURCES` — array of source objects, each with `{ name, type, detect, fetch, parse }`
- `resolveSource(company, types?)` — finds the matching source for a portals.yml entry,
  with optional type filter

**`scan.mjs`** — imports from `scan-sources.mjs`, ~100 lines shorter, adds `--type` flag:
```bash
node scan.mjs --type ats-api   # only ATS API sources
node scan.mjs --type search    # future: search-based sources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI filter to target scans by ATS provider via --type.
  * Centralized job-source registry to discover and parse provider APIs.

* **Improvements**
  * Normalized job fields (title, URL, company, location) for cleaner output.
  * Emitted job source now uses provider name for clearer attribution.
  * Network fetches apply a timeout and stricter HTTP error handling for more reliable scans.

* **Tests**
  * Added tests validating source registry, discovery, type filtering, and job normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->