### PR TITLE
[codex] Show application dates in pipeline list

### DIFF
--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -724,11 +724,12 @@ func (m PipelineModel) renderAppLine(app model.CareerApplication, selected bool)
 
 	// Column widths
 	scoreW := 5 // "4.5  "
-	companyW := 20
+	dateW := 10
+	companyW := 16
 	statusW := 12
 	compW := 14
 	// Role gets remaining space
-	roleW := m.width - scoreW - companyW - statusW - compW - 10
+	roleW := m.width - scoreW - dateW - companyW - statusW - compW - 12
 	if roleW < 15 {
 		roleW = 15
 	}
@@ -740,6 +741,13 @@ func (m PipelineModel) renderAppLine(app model.CareerApplication, selected bool)
 	// Company (truncate)
 	company := truncateRunes(app.Company, companyW)
 	companyStyle := lipgloss.NewStyle().Foreground(m.theme.Text).Width(companyW)
+
+	// Date (fixed width)
+	dateText := app.Date
+	if dateText == "" {
+		dateText = "—"
+	}
+	dateStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext).Width(dateW)
 
 	// Role (truncate)
 	role := truncateRunes(app.Role, roleW)
@@ -759,8 +767,9 @@ func (m PipelineModel) renderAppLine(app model.CareerApplication, selected bool)
 		compText = compStyle.Render(comp)
 	}
 
-	line := fmt.Sprintf(" %s %s %s %s %s",
+	line := fmt.Sprintf(" %s %s %s %s %s %s",
 		score,
+		dateStyle.Render(truncateRunes(dateText, dateW)),
 		companyStyle.Render(company),
 		roleStyle.Render(role),
 		statusText,

--- a/dashboard/internal/ui/screens/pipeline_test.go
+++ b/dashboard/internal/ui/screens/pipeline_test.go
@@ -1,6 +1,7 @@
 package screens
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/santifer/career-ops/dashboard/internal/model"
@@ -68,5 +69,28 @@ func TestWithReloadedDataPreservesStateAndSelection(t *testing.T) {
 	}
 	if reloaded.reportCache["reports/002-beta.md"].tldr != "cached" {
 		t.Fatal("expected cached report summaries to survive refresh")
+	}
+}
+
+func TestRenderAppLineIncludesDateColumn(t *testing.T) {
+	pm := NewPipelineModel(
+		theme.NewTheme("catppuccin-mocha"),
+		nil,
+		model.PipelineMetrics{},
+		"..",
+		120,
+		40,
+	)
+
+	line := pm.renderAppLine(model.CareerApplication{
+		Date:    "2026-04-13",
+		Company: "Anthropic",
+		Role:    "Forward Deployed Engineer",
+		Status:  "Applied",
+		Score:   4.5,
+	}, false)
+
+	if !strings.Contains(line, "2026-04-13") {
+		t.Fatalf("expected rendered line to include date column, got %q", line)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Shows each application's tracker date directly in the dashboard pipeline list so the `date` sort mode is visible in the UI instead of being a hidden ordering key.

## Why does this change matter?

The pipeline already lets users press `s` to sort by date, but the list did not render a date column. That made the sort harder to understand at a glance because users could not see the value the dashboard was ordering by.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Validation

- `cd dashboard && go test ./...`
- `cd dashboard && go build ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Date column to the application pipeline dashboard, displaying submission dates for each career application. Missing dates are indicated with a dash (—).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->