### PR TITLE
feat(scan): add optional location filter to portal scanner

### DIFF
--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -30,8 +30,9 @@ Copy from `templates/portals.example.yml` and customize:
 
 1. **title_filter.positive**: Keywords matching your target roles
 2. **title_filter.negative**: Tech stacks or domains to exclude
-3. **search_queries**: WebSearch queries for job boards (Ashby, Greenhouse, Lever)
-4. **tracked_companies**: Companies to check directly
+3. **location_filter** (optional): Constrain scans to specific cities/regions. Supports `allowed`, `blocked`, and `allow_remote` (default true). Omit the block entirely to keep the current behaviour of accepting all locations. See `templates/portals.example.yml` for a commented example.
+4. **search_queries**: WebSearch queries for job boards (Ashby, Greenhouse, Lever)
+5. **tracked_companies**: Companies to check directly
 
 ## CV Template (templates/cv-template.html)
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -49,11 +49,14 @@ location_filter:
 
 - **`allowed`** — case-insensitive substring OR-list. `"Sydney"` matches
   `"Sydney NSW, Australia"`, `"Sydney (Hybrid)"`, etc.
-- **`blocked`** — explicit blocklist, always wins over `allowed`.
+- **`blocked`** — explicit blocklist, always wins. Evaluated before the
+  remote bypass, so `"Remote - Perth WA"` is still dropped when
+  `blocked: ["Perth"]`.
 - **`allow_remote`** — defaults to `true`. When on, any location containing
-  `remote`, `anywhere`, or `distributed` bypasses the `allowed` list so you
-  do not lose remote-friendly roles to a strict city allowlist. Set to
-  `false` to exclude remote roles too.
+  `remote`, `anywhere`, or `distributed` bypasses the `allowed` allowlist so
+  you do not lose remote-friendly roles to a strict city allowlist. Set to
+  `false` to exclude remote roles too. The remote bypass never overrides
+  `blocked`.
 - Jobs with empty/unknown location pass through only when `allowed` is empty.
 
 The scan summary prints a `Filtered by location` line so you can see how

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -30,9 +30,34 @@ Copy from `templates/portals.example.yml` and customize:
 
 1. **title_filter.positive**: Keywords matching your target roles
 2. **title_filter.negative**: Tech stacks or domains to exclude
-3. **location_filter** (optional): Constrain scans to specific cities/regions. Supports `allowed`, `blocked`, and `allow_remote` (default true). Omit the block entirely to keep the current behaviour of accepting all locations. See `templates/portals.example.yml` for a commented example.
+3. **location_filter** (optional): Constrain scans to specific cities/regions — see below
 4. **search_queries**: WebSearch queries for job boards (Ashby, Greenhouse, Lever)
 5. **tracked_companies**: Companies to check directly
+
+### location_filter (optional)
+
+Applied after `title_filter` and before dedup. If the block is omitted, or both
+`allowed` and `blocked` are empty, no location filtering happens (backward-compatible
+default).
+
+```yaml
+location_filter:
+  allowed: ["Sydney", "Melbourne", "Australia"]
+  blocked: ["Perth", "Adelaide"]
+  allow_remote: true
+```
+
+- **`allowed`** — case-insensitive substring OR-list. `"Sydney"` matches
+  `"Sydney NSW, Australia"`, `"Sydney (Hybrid)"`, etc.
+- **`blocked`** — explicit blocklist, always wins over `allowed`.
+- **`allow_remote`** — defaults to `true`. When on, any location containing
+  `remote`, `anywhere`, or `distributed` bypasses the `allowed` list so you
+  do not lose remote-friendly roles to a strict city allowlist. Set to
+  `false` to exclude remote roles too.
+- Jobs with empty/unknown location pass through only when `allowed` is empty.
+
+The scan summary prints a `Filtered by location` line so you can see how
+many results the filter dropped.
 
 ## CV Template (templates/cv-template.html)
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -134,6 +134,28 @@ function buildTitleFilter(titleFilter) {
   };
 }
 
+function buildLocationFilter(locationFilter) {
+  const allowed = (locationFilter?.allowed || []).map(k => k.toLowerCase());
+  const blocked = (locationFilter?.blocked || []).map(k => k.toLowerCase());
+  const allowRemote = locationFilter?.allow_remote !== false;
+
+  // No config at all → pass everything through (backward compatible default)
+  if (allowed.length === 0 && blocked.length === 0) return () => true;
+
+  return (location) => {
+    const lower = (location || '').toLowerCase();
+    // Empty/unknown location: allow if no positive allowlist, block if allowlist is set
+    if (!lower) return allowed.length === 0;
+    // Remote jobs bypass the city/region allowlist when allow_remote is on
+    if (allowRemote && /\b(remote|anywhere|distributed)\b/.test(lower)) return true;
+    // Explicit blocklist always wins
+    if (blocked.some(k => lower.includes(k))) return false;
+    // If an allowlist is set, location must match at least one entry
+    if (allowed.length === 0) return true;
+    return allowed.some(k => lower.includes(k));
+  };
+}
+
 // ── Dedup ───────────────────────────────────────────────────────────
 
 function loadSeenUrls() {
@@ -264,6 +286,7 @@ async function main() {
   const config = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
   const companies = config.tracked_companies || [];
   const titleFilter = buildTitleFilter(config.title_filter);
+  const locationFilter = buildLocationFilter(config.location_filter);
 
   // 2. Filter to enabled companies with detectable APIs
   const targets = companies
@@ -285,6 +308,7 @@ async function main() {
   const date = new Date().toISOString().slice(0, 10);
   let totalFound = 0;
   let totalFiltered = 0;
+  let totalFilteredLocation = 0;
   let totalDupes = 0;
   const newOffers = [];
   const errors = [];
@@ -299,6 +323,10 @@ async function main() {
       for (const job of jobs) {
         if (!titleFilter(job.title)) {
           totalFiltered++;
+          continue;
+        }
+        if (!locationFilter(job.location)) {
+          totalFilteredLocation++;
           continue;
         }
         if (seenUrls.has(job.url)) {
@@ -335,6 +363,7 @@ async function main() {
   console.log(`Companies scanned:     ${targets.length}`);
   console.log(`Total jobs found:      ${totalFound}`);
   console.log(`Filtered by title:     ${totalFiltered} removed`);
+  console.log(`Filtered by location:  ${totalFilteredLocation} removed`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
   console.log(`New offers added:      ${newOffers.length}`);
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -151,12 +151,24 @@ function buildTitleFilter(titleFilter) {
  *   5. Allowlist: if `allowed` is empty, pass; otherwise require a case-
  *      insensitive substring match against at least one entry.
  *
- * @param {{allowed?: string[], blocked?: string[], allow_remote?: boolean}} locationFilter
+ * Non-array inputs to `allowed` / `blocked` (e.g. the YAML scalar-instead-of-
+ * list mistake `allowed: Sydney`) are coerced to empty lists rather than
+ * crashing the scanner. Non-string entries inside an array are silently
+ * dropped, empty-string entries are dropped so they cannot accidentally
+ * disable the allowlist via `String.prototype.includes('')`.
+ *
+ * @param {{allowed?: unknown, blocked?: unknown, allow_remote?: boolean} | null | undefined} locationFilter
  * @returns {(location: string|null|undefined) => boolean}
  */
 function buildLocationFilter(locationFilter) {
-  const allowed = (locationFilter?.allowed || []).map(k => k.toLowerCase());
-  const blocked = (locationFilter?.blocked || []).map(k => k.toLowerCase());
+  const normalizeStringList = (value) =>
+    (Array.isArray(value) ? value : [])
+      .filter(v => typeof v === 'string')
+      .map(v => v.trim().toLowerCase())
+      .filter(Boolean);
+
+  const allowed = normalizeStringList(locationFilter?.allowed);
+  const blocked = normalizeStringList(locationFilter?.blocked);
   const allowRemote = locationFilter?.allow_remote !== false;
 
   // No config at all → pass everything through (backward compatible default)

--- a/scan.mjs
+++ b/scan.mjs
@@ -175,7 +175,7 @@ function buildLocationFilter(locationFilter) {
   if (allowed.length === 0 && blocked.length === 0) return () => true;
 
   return (location) => {
-    const lower = (location || '').toLowerCase();
+    const lower = typeof location === 'string' ? location.trim().toLowerCase() : '';
     // Empty/unknown location: allow if no positive allowlist, block if allowlist is set
     if (!lower) return allowed.length === 0;
     // Explicit blocklist wins over everything, including remote bypass.

--- a/scan.mjs
+++ b/scan.mjs
@@ -134,6 +134,26 @@ function buildTitleFilter(titleFilter) {
   };
 }
 
+/**
+ * Build a predicate that decides whether a job location passes the filter.
+ *
+ * Precedence, in order:
+ *   1. If no `allowed` and no `blocked` are configured, every location passes
+ *      (backward-compatible default — no filtering).
+ *   2. Empty / unknown `location` passes only when `allowed` is empty, so an
+ *      allowlist-only config does not silently accept unlabelled roles.
+ *   3. `blocked` is evaluated before everything else. It wins over remote
+ *      bypass and allowlist alike, so `"Remote - Perth WA"` is still dropped
+ *      when `blocked: ["Perth"]`.
+ *   4. Remote bypass: when `allow_remote !== false`, any location containing
+ *      `remote`, `anywhere`, or `distributed` bypasses the `allowed` list
+ *      (but never the blocklist — see step 3).
+ *   5. Allowlist: if `allowed` is empty, pass; otherwise require a case-
+ *      insensitive substring match against at least one entry.
+ *
+ * @param {{allowed?: string[], blocked?: string[], allow_remote?: boolean}} locationFilter
+ * @returns {(location: string|null|undefined) => boolean}
+ */
 function buildLocationFilter(locationFilter) {
   const allowed = (locationFilter?.allowed || []).map(k => k.toLowerCase());
   const blocked = (locationFilter?.blocked || []).map(k => k.toLowerCase());
@@ -146,10 +166,11 @@ function buildLocationFilter(locationFilter) {
     const lower = (location || '').toLowerCase();
     // Empty/unknown location: allow if no positive allowlist, block if allowlist is set
     if (!lower) return allowed.length === 0;
+    // Explicit blocklist wins over everything, including remote bypass.
+    // e.g. "Remote - Perth WA" is still blocked when blocked=["Perth"].
+    if (blocked.some(k => lower.includes(k))) return false;
     // Remote jobs bypass the city/region allowlist when allow_remote is on
     if (allowRemote && /\b(remote|anywhere|distributed)\b/.test(lower)) return true;
-    // Explicit blocklist always wins
-    if (blocked.some(k => lower.includes(k))) return false;
     // If an allowlist is set, location must match at least one entry
     if (allowed.length === 0) return true;
     return allowed.some(k => lower.includes(k));

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -95,6 +95,31 @@ title_filter:
     - "Head"
     - "Director"
 
+# -- Location filter (optional) --
+# Constrain scan results by job location. If this whole block is omitted or both
+# `allowed` and `blocked` are empty, no location filtering happens (current default).
+#
+# Matching is case-insensitive substring: "Sydney" matches "Sydney NSW, Australia",
+# "Sydney (Hybrid)", etc. Jobs with empty/unknown location pass through only when
+# `allowed` is empty.
+#
+# allow_remote: when true (default), jobs whose location contains "remote",
+# "anywhere", or "distributed" bypass the `allowed` list. Set to false if you
+# want to exclude remote roles too.
+#
+# Example: Australia-only search focused on Sydney and Melbourne, excluding
+# state capitals you do not want.
+#
+# location_filter:
+#   allowed:
+#     - "Sydney"
+#     - "Melbourne"
+#     - "Australia"
+#   blocked:
+#     - "Perth"
+#     - "Adelaide"
+#   allow_remote: true
+
 # -- Search queries --
 # Each query triggers a WebSearch. Use site: to filter by portal.
 # The scanner extracts title, URL, and company from results.

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -96,28 +96,13 @@ title_filter:
     - "Director"
 
 # -- Location filter (optional) --
-# Constrain scan results by job location. If this whole block is omitted or both
-# `allowed` and `blocked` are empty, no location filtering happens (current default).
-#
-# Matching is case-insensitive substring: "Sydney" matches "Sydney NSW, Australia",
-# "Sydney (Hybrid)", etc. Jobs with empty/unknown location pass through only when
-# `allowed` is empty.
-#
-# allow_remote: when true (default), jobs whose location contains "remote",
-# "anywhere", or "distributed" bypass the `allowed` list. Set to false if you
-# want to exclude remote roles too.
-#
-# Example: Australia-only search focused on Sydney and Melbourne, excluding
-# state capitals you do not want.
+# Constrain scan results by job location. Omit this block entirely to keep
+# the default behaviour of accepting all locations.
+# See docs/CUSTOMIZATION.md (Portals section) for field semantics.
 #
 # location_filter:
-#   allowed:
-#     - "Sydney"
-#     - "Melbourne"
-#     - "Australia"
-#   blocked:
-#     - "Perth"
-#     - "Adelaide"
+#   allowed: ["Sydney", "Melbourne", "Australia"]
+#   blocked: ["Perth", "Adelaide"]
 #   allow_remote: true
 
 # -- Search queries --


### PR DESCRIPTION
## What does this PR do?

Adds an optional `location_filter:` block to `portals.yml` that `scan.mjs` applies after the existing `title_filter` and before dedup. Supports `allowed`, `blocked`, and `allow_remote` (default `true`); omitting the block leaves behaviour identical for existing users. Scan summary prints a `Filtered by location` line alongside the existing `Filtered by title`.

## Related issue

Fixes #302

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional location filtering for job results with configurable allowlist, blocklist, and remote-work behavior; blocked entries always take precedence, remote roles can bypass the allowlist, and filtered counts are shown in scan summaries.

* **Documentation**
  * Updated customization docs and example configuration describing the location_filter options, evaluation order, backward-compatible behavior, and how filtered results are reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->