### PR TITLE
fix: disable 403-blocking boards in search_queries (Lever, Wellfound, RemoteFront)

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -131,18 +131,20 @@ search_queries:
     enabled: true
 
   # -- Lever --
+  # Disabled: jobs.lever.co returns 403 on liveness verification, making discovered URLs unverifiable (see issue #285)
   - name: Lever — AI PM
     query: 'site:jobs.lever.co "AI Product Manager" OR "Solutions Architect" AI remote'
-    enabled: true
+    enabled: false
 
   - name: Lever — AI Roles
     query: 'site:jobs.lever.co "AI Engineer" OR "Agentic" OR "LLMOps" OR "Automation" remote'
-    enabled: true
+    enabled: false
 
   # -- Wellfound (startups) --
+  # Disabled: wellfound.com returns 403 on liveness verification, making discovered URLs unverifiable (see issue #285)
   - name: Wellfound — AI PM
     query: 'site:wellfound.com "AI Product Manager" OR "AI Solutions" remote'
-    enabled: true
+    enabled: false
 
   # -- Workable --
   - name: Workable — AI Roles
@@ -182,9 +184,10 @@ search_queries:
     enabled: true
 
   # -- RemoteFront (aggregator) --
+  # Disabled: remotefront.com returns 403 on liveness verification, making discovered URLs unverifiable (see issue #285)
   - name: RemoteFront — AI & Automation
     query: 'site:remotefront.com "AI Engineer" OR "Solutions Engineer" OR "Automation" OR "LLM" OR "Agent" remote'
-    enabled: true
+    enabled: false
 
   # -- Remote-friendly Europe boards --
 


### PR DESCRIPTION
## Description

Résolution de l'issue #285 — plusieurs entrées dans `search_queries` de `templates/portals.example.yml` pointaient vers des agrégateurs qui bloquent l'accès automatisé et retournent des erreurs **403** lors de la vérification de liveness. Les URLs découvertes via WebSearch devenaient ainsi invérifiables et inutilisables.

## Boards concernés

| Board | Domaine | Problème |
|---|---|---|
| Lever | `jobs.lever.co` | Bloque la vérification automatisée → 403 |
| Wellfound | `wellfound.com` | Bloque la vérification automatisée → 403 |
| RemoteFront | `remotefront.com` | Bloque la vérification automatisée → 403 |

## Modifications

- **`templates/portals.example.yml`** : passage de `enabled: true` à `enabled: false` pour les 4 entrées concernées (2 Lever, 1 Wellfound, 1 RemoteFront)
- Ajout d'un commentaire explicatif au-dessus de chaque bloc désactivé avec référence à l'issue #285, pour que les utilisateurs comprennent pourquoi ces entrées sont désactivées

## Choix d'implémentation

Les entrées ont été **désactivées** plutôt que supprimées afin de conserver la documentation des boards existants. Un utilisateur qui souhaiterait les réactiver manuellement (ex. si le comportement change) peut le faire en repassant `enabled: true`.

## Test plan

- [ ] Vérifier que `/career-ops scan` ne tente plus de requêtes WebSearch sur `jobs.lever.co`, `wellfound.com`, `remotefront.com`
- [ ] Vérifier que les autres entrées `search_queries` (`boards.greenhouse.io`, `jobs.ashbyhq.com`, etc.) restent fonctionnelles
- [ ] Vérifier qu'un `portals.yml` copié depuis ce fichier n'inclut plus ces boards dans les scans actifs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled web search queries for Lever (AI PM and Roles), Wellfound (AI PM), and RemoteFront (AI & Automation). These portal domains are returning verification errors that prevent proper validation of discovered job listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->