### PR TITLE
docs: enforce branded careers_url rule in scan.md and portals.example.yml

### DIFF
--- a/modes/scan.md
+++ b/modes/scan.md
@@ -189,17 +189,17 @@ Nuevas añadidas a pipeline.md: N
 
 Cada empresa en `tracked_companies` debe tener `careers_url` — la URL directa a su página de ofertas. Esto evita buscarlo cada vez.
 
-**RULE: Always use the branded company URL — never the raw ATS endpoint.**
+**REGLA: Usa siempre la URL corporativa de la empresa; recurre al endpoint ATS solo si no existe página corporativa propia.**
 
-The `careers_url` must point to the company's own careers page, not the underlying ATS platform URL. Many companies use Workday, Greenhouse, or Lever under the hood but expose job IDs only through their branded domain. Using the raw ATS URL causes false 410 errors on active roles because the job IDs don't match.
+El `careers_url` debe apuntar a la página de empleo propia de la empresa siempre que esté disponible. Muchas empresas usan Workday, Greenhouse o Lever por debajo, pero exponen los IDs de las vacantes solo a través de su dominio corporativo. Usar la URL ATS directa cuando existe una página corporativa puede causar falsos errores 410 porque los IDs de los puestos no coinciden.
 
-| ✅ Correct (branded) | ❌ Wrong (raw ATS) |
+| ✅ Correcto (corporativa) | ❌ Incorrecto como primera opción (ATS directo) |
 |---|---|
-| `careers.mastercard.com` | `mastercard.wd1.myworkdayjobs.com` |
-| `openai.com/careers` | `boards.greenhouse.io/openai` |
-| `stripe.com/jobs` | `stripe.lever.co` |
+| `https://careers.mastercard.com` | `https://mastercard.wd1.myworkdayjobs.com` |
+| `https://openai.com/careers` | `https://job-boards.greenhouse.io/openai` |
+| `https://stripe.com/jobs` | `https://jobs.lever.co/stripe` |
 
-If you only have the raw ATS URL, navigate to the company website first and find the branded careers link. Only fall back to the raw ATS URL if the company has no branded page.
+Fallback: si solo tienes la URL ATS directa, navega primero al sitio web de la empresa y localiza su página corporativa de empleo. Usa la URL ATS directa únicamente si la empresa no tiene página corporativa propia.
 
 **Patrones conocidos por plataforma:**
 - **Ashby:** `https://jobs.ashbyhq.com/{slug}`

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -189,6 +189,18 @@ Nuevas añadidas a pipeline.md: N
 
 Cada empresa en `tracked_companies` debe tener `careers_url` — la URL directa a su página de ofertas. Esto evita buscarlo cada vez.
 
+**RULE: Always use the branded company URL — never the raw ATS endpoint.**
+
+The `careers_url` must point to the company's own careers page, not the underlying ATS platform URL. Many companies use Workday, Greenhouse, or Lever under the hood but expose job IDs only through their branded domain. Using the raw ATS URL causes false 410 errors on active roles because the job IDs don't match.
+
+| ✅ Correct (branded) | ❌ Wrong (raw ATS) |
+|---|---|
+| `careers.mastercard.com` | `mastercard.wd1.myworkdayjobs.com` |
+| `openai.com/careers` | `boards.greenhouse.io/openai` |
+| `stripe.com/jobs` | `stripe.lever.co` |
+
+If you only have the raw ATS URL, navigate to the company website first and find the branded careers link. Only fall back to the raw ATS URL if the company has no branded page.
+
 **Patrones conocidos por plataforma:**
 - **Ashby:** `https://jobs.ashbyhq.com/{slug}`
 - **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` o `https://job-boards.eu.greenhouse.io/{slug}`

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -7,6 +7,10 @@
 #   3. WebSearch with site: filters (broad discovery, may be stale)
 #
 # IMPORTANT: Each company in tracked_companies MUST have careers_url.
+#   careers_url must be the BRANDED company URL, never the raw ATS endpoint.
+#   ✅ careers.mastercard.com   ❌ mastercard.wd1.myworkdayjobs.com
+#   ✅ openai.com/careers        ❌ boards.greenhouse.io/openai
+#   Using raw ATS URLs causes false 410 errors — job IDs differ between branded and raw URLs.
 #
 # HOW TO CUSTOMIZE:
 #   1. Copy this file to portals.yml in the project root

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -7,10 +7,11 @@
 #   3. WebSearch with site: filters (broad discovery, may be stale)
 #
 # IMPORTANT: Each company in tracked_companies MUST have careers_url.
-#   careers_url must be the BRANDED company URL, never the raw ATS endpoint.
-#   ✅ careers.mastercard.com   ❌ mastercard.wd1.myworkdayjobs.com
-#   ✅ openai.com/careers        ❌ boards.greenhouse.io/openai
-#   Using raw ATS URLs causes false 410 errors — job IDs differ between branded and raw URLs.
+#   Prefer the BRANDED company careers URL whenever available; use ATS-hosted URL only as fallback.
+#   ✅ https://careers.mastercard.com   ⚠️ https://mastercard.wd1.myworkdayjobs.com (fallback only)
+#   ✅ https://openai.com/careers       ⚠️ https://job-boards.greenhouse.io/openai (fallback only)
+#   Exception: ATS-hosted careers_url is acceptable when no branded careers page exists.
+#   Using raw ATS URLs when a branded page exists can cause false 410 errors (job ID mismatch).
 #
 # HOW TO CUSTOMIZE:
 #   1. Copy this file to portals.yml in the project root


### PR DESCRIPTION
## Description

Résolution de l'issue #267 — clarification de la règle `careers_url` pour prévenir les faux 410 causés par l'utilisation d'URLs ATS brutes au lieu des URLs de carrières brandées.

## Problème

Beaucoup d'entreprises utilisent Workday, Greenhouse ou Lever en arrière-plan, mais exposent leurs offres via leur propre domaine brandé (ex: `careers.mastercard.com`). Les IDs de postes entre le domaine brandé et l'URL ATS brute sont différents. Résultat : Playwright retourne de faux 410 sur des offres encore actives.

## Modifications

- **`modes/scan.md`** : ajout d'un bloc **RULE** dans la section "Gestión de careers_url" avec :
  - Explication du problème (faux 410 causés par les raw ATS URLs)
  - Tableau comparatif branded ✅ vs raw ATS ❌ avec exemples concrets (Mastercard, OpenAI, Stripe)
  - Instruction de fallback : n'utiliser le raw ATS URL que si l'entreprise n'a pas de page brandée

- **`templates/portals.example.yml`** : ajout d'un commentaire inline sous la note `IMPORTANT: careers_url` avec des exemples ✅/❌ visibles dès l'ouverture du fichier

## Test plan

- [ ] Vérifier que la règle est visible dans `scan.md` section "Gestión de careers_url"
- [ ] Vérifier que le commentaire apparaît en tête de `portals.example.yml` près de la note `IMPORTANT`
- [ ] S'assurer qu'aucune `careers_url` existante dans `portals.example.yml` ne viole la règle (toutes sont déjà brandées ou sur ATS direct sans branded alternative)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Prefer branded corporate careers pages for tracked careers URLs; use ATS/board-hosted URLs only as a fallback when no corporate page exists.
  * Added concrete examples comparing branded vs direct ATS URLs (e.g., Mastercard, OpenAI, Stripe) and step-by-step guidance for locating corporate career pages.
  * Clarified fallback behavior: navigate to the company site first and use an ATS direct URL only as a last resort.
  * Warned that using raw ATS URLs when a branded page exists may produce false 410 errors due to job ID mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->