### PR TITLE
feat: Modular Auth Portal Scan Support + LinkedIn Scan Support

### DIFF
--- a/.claude/skills/career-ops/SKILL.md
+++ b/.claude/skills/career-ops/SKILL.md
@@ -3,7 +3,7 @@ name: career-ops
 description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
 user_invocable: true
 args: mode
-argument-hint: "[scan | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
+argument-hint: "[scan | scan-auth | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
 ---
 
 # career-ops -- Router
@@ -27,9 +27,12 @@ Determine the mode from `{{mode}}`:
 | `pipeline` | `pipeline` |
 | `apply` | `apply` |
 | `scan` | `scan` |
+| `scan-auth`, `scan-auth <portal>` | `scan-auth` |
 | `batch` | `batch` |
 | `patterns` | `patterns` |
 | `followup` | `followup` |
+
+**scan-auth mode:** Runs `node scan-auth.mjs <portal>` (e.g. `node scan-auth.mjs linkedin`). Uses Playwright with a persistent browser profile for authenticated portal scanning. Supports `--login`, `--search`, `--dry-run`, `--max` flags. Portal-specific logic lives in `scan-auth/<portal>.mjs`.
 
 **Auto-pipeline detection:** If `{{mode}}` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
 
@@ -57,6 +60,7 @@ Available commands:
   /career-ops tracker   → Application status overview
   /career-ops apply     → Live application assistant (reads form + generates answers)
   /career-ops scan      → Scan portals and discover new offers
+  /career-ops scan-auth → Authenticated portal scan (LinkedIn etc.)
   /career-ops batch     → Batch processing with parallel workers
   /career-ops patterns  → Analyze rejection patterns and improve targeting
   /career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
@@ -74,7 +78,7 @@ After determining the mode, load the necessary files before executing:
 ### Modes that require `_shared.md` + their mode file:
 Read `modes/_shared.md` + `modes/{mode}.md`
 
-Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `scan-auth`, `batch`
 
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`
@@ -82,7 +86,7 @@ Read `modes/{mode}.md`
 Applies to: `tracker`, `deep`, `training`, `project`, `patterns`, `followup`
 
 ### Modes delegated to subagent:
-For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as Agent with the content of `_shared.md` + `modes/{mode}.md` injected into the subagent prompt.
+For `scan`, `scan-auth`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as Agent with the content of `_shared.md` + `modes/{mode}.md` injected into the subagent prompt.
 
 ```
 Agent(

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `data/follow-ups.md` | Follow-up history tracker |
 | `scan.mjs` | Zero-token portal scanner — hits Greenhouse/Ashby/Lever APIs directly, zero LLM cost |
+| `scan-auth.mjs` | Authenticated portal scanner — Playwright with persistent browser profiles. Portal classes in `scan-auth/` |
 | `check-liveness.mjs` | Job posting liveness checker |
 | `liveness-core.mjs` | Shared liveness logic (expired signals win over generic Apply text) |
 | `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`). Blocks A-F + G (Posting Legitimacy). Header includes `**Legitimacy:** {tier}`. |

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -21,6 +21,7 @@ These files contain your personal data, customizations, and work product. Update
 | `reports/*` | Your evaluation reports |
 | `output/*` | Your generated PDFs |
 | `jds/*` | Your saved job descriptions |
+| `~/.scan-auth/<portal>/profile/` | Your browser profile for authenticated scanning |
 
 ## System Layer (safe to auto-update)
 
@@ -32,6 +33,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/oferta.md` | Evaluation mode instructions |
 | `modes/pdf.md` | PDF generation instructions |
 | `modes/scan.md` | Portal scanner instructions |
+| `modes/scan-auth.md` | Authenticated portal scanner instructions |
 | `modes/batch.md` | Batch processing instructions |
 | `modes/apply.md` | Application assistant instructions |
 | `modes/auto-pipeline.md` | Auto-pipeline instructions |
@@ -48,6 +50,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `CLAUDE.md` | Agent instructions |
 | `AGENTS.md` | Codex instructions |
 | `*.mjs` | Utility scripts |
+| `scan-auth/*.mjs` | Portal scanner classes |
 | `batch/batch-prompt.md` | Batch worker prompt |
 | `batch/batch-runner.sh` | Batch orchestrator |
 | `dashboard/*` | Go TUI dashboard |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Built by someone who used it to evaluate 740+ job offers, generate 100+ tailored
 | **Negotiation Scripts** | Salary negotiation frameworks, geographic discount pushback, competing offer leverage |
 | **ATS PDF Generation** | Keyword-injected CVs with Space Grotesk + DM Sans design |
 | **Portal Scanner** | 45+ companies pre-configured (Anthropic, OpenAI, ElevenLabs, Retool, n8n...) + custom queries across Ashby, Greenhouse, Lever, Wellfound |
+| **Authenticated Scanner** | Playwright-based scanner with persistent browser profiles for portals requiring login (LinkedIn). Extensible per-portal scanner classes (`scan-auth/<portal>.mjs`) |
 | **Batch Processing** | Parallel evaluation with `claude -p` workers |
 | **Dashboard TUI** | Terminal UI to browse, filter, and sort your pipeline |
 | **Human-in-the-Loop** | AI evaluates and recommends, you decide and act. The system never submits an application -- you always have the final call |
@@ -118,6 +119,7 @@ Career-ops is a single slash command with multiple modes:
 /career-ops                → Show all available commands
 /career-ops {paste a JD}   → Full auto-pipeline (evaluate + PDF + tracker)
 /career-ops scan           → Scan portals for new offers
+/career-ops scan-auth      → Authenticated portal scan (LinkedIn etc.)
 /career-ops pdf            → Generate ATS-optimized CV
 /career-ops batch          → Batch evaluate multiple offers
 /career-ops tracker        → View application status
@@ -200,6 +202,8 @@ career-ops/
 │   ├── cv-template.html         # ATS-optimized CV template
 │   ├── portals.example.yml      # Scanner config template
 │   └── states.yml               # Canonical statuses
+├── scan-auth/
+│   └── linkedin.mjs             # LinkedIn scanner class
 ├── batch/
 │   ├── batch-prompt.md          # Self-contained worker prompt
 │   └── batch-runner.sh          # Orchestrator script
@@ -222,7 +226,7 @@ career-ops/
 
 - **Agent**: Claude Code with custom skills and modes
 - **PDF**: Playwright/Puppeteer + HTML template
-- **Scanner**: Playwright + Greenhouse API + WebSearch
+- **Scanner**: Playwright + Greenhouse API + WebSearch (public); Playwright + persistent browser profiles (authenticated portals)
 - **Dashboard**: Go + Bubble Tea + Lipgloss (Catppuccin Mocha theme)
 - **Data**: Markdown tables + YAML config + TSV batch files
 

--- a/modes/scan-auth.md
+++ b/modes/scan-auth.md
@@ -1,0 +1,75 @@
+# Mode: scan-auth — Authenticated portal scanner
+
+Runs the authenticated portal scanner (Playwright with persistent browser profiles), then processes results into the pipeline.
+
+Supported portals: `linkedin` (more coming soon).
+
+## Prerequisites
+
+The user must have logged in at least once for the target portal:
+```bash
+node scan-auth.mjs --login <portal>
+```
+If the scanner reports "Not logged in", tell the user to run the above command first.
+
+## Workflow
+
+### 1. Run the scanner
+
+```bash
+node scan-auth.mjs <portal>
+```
+
+Optional flags:
+- `--search "keyword"` — scan a single keyword only
+- `--max N` — cap results per search keyword
+- `--dry-run` — extract but don't write files
+
+The scanner:
+- Reads `portals.yml` for keywords, experience level, date filter, and employer blocklist
+- Launches Chromium with a persistent profile (`~/.scan-auth/<portal>/profile`)
+- Searches the portal for each keyword, extracts job details
+- Applies title filter and employer blocklist
+- Dedupes against `data/scan-history.tsv`
+- Saves accepted listings to `jds/{company}-{role-slug}.md` with frontmatter
+- Writes results to `data/<portal>-scan-results.json`
+
+Note: The scanner itself handles scan history dedup, employer blocklist, and title filtering internally. The orchestrator (`scan-auth.mjs`) only writes JD files and results output.
+
+### 2. Process results
+
+Read `data/<portal>-scan-results.json`. For each listing:
+
+a. **Dedupe** against `data/pipeline.md` and `data/applications.md` (by company + role title, normalized)
+b. **Skip** if already present
+
+c. **Append to `data/pipeline.md`** under Pending:
+   - If `application_url` exists (external apply link): `- [ ] {application_url} | {company} | {title}`
+   - Otherwise use local JD: `- [ ] local:{jd_file} | {company} | {title}`
+
+d. **Log to `data/scan-history.tsv`**:
+   `{source_url}\t{date}\t{portal}\t{title}\t{company}\tadded`
+
+e. Duplicates: log with status `skipped_dup`
+
+### 3. Print summary
+
+```
+{Portal} Scan — {YYYY-MM-DD}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Scanner found: N listings
+New to pipeline: N
+Duplicates skipped: N
+Errors: N
+
+  + {company} | {title}
+  ...
+
+→ Run /career-ops pipeline to evaluate new listings.
+```
+
+## Error handling
+
+- If the scanner exits with an error, show the error message to the user
+- If `<portal>-scan-results.json` has entries in `errors`, report them
+- If scanner reports CAPTCHA or login issues, tell the user to run `node scan-auth.mjs --login <portal>` and browse the portal manually to warm the session

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "update": "node update-system.mjs apply",
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
-    "scan": "node scan.mjs"
+    "scan": "node scan.mjs",
+    "scan:auth": "node scan-auth.mjs",
+    "scan:login": "node scan-auth.mjs --login"
   },
   "keywords": [
     "ai",

--- a/scan-auth.mjs
+++ b/scan-auth.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+/**
+ * Job Portal Scanner
+ *
+ * Orchestrates authenticated job portal scanning. Each portal has its own
+ * scanner class (in scan-auth/) that handles page interaction, extraction,
+ * filtering, dedup, and employer blocklist. This file handles CLI, browser
+ * setup, login, JD file writing, and results output.
+ * 
+ * DISCLAIMER: Portal scanning uses your own browser session. Respect each portal's terms of service.
+ *
+ * Usage:
+ *   node scan-auth.mjs linkedin              # Normal scan
+ *   node scan-auth.mjs --login linkedin       # Open browser to log in, then exit
+ *   node scan-auth.mjs --search "AI Engineer" linkedin
+ *   node scan-auth.mjs --dry-run linkedin     # Extract but don't write files
+ */
+
+import { chromium } from 'playwright';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createInterface } from 'readline';
+
+import LinkedInScanner from './scan-auth/linkedin.mjs';
+
+// ---------------------------------------------------------------------------
+// Scanner registry — add new portal scanners here
+// ---------------------------------------------------------------------------
+
+const SCANNERS = {
+  linkedin: new LinkedInScanner(),
+};
+
+// ---------------------------------------------------------------------------
+// Constants & paths
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORTALS_PATH = join(__dirname, 'portals.yml');
+const SCAN_HISTORY_PATH = join(__dirname, 'data', 'scan-history.tsv');
+const JDS_DIR = join(__dirname, 'jds');
+
+function getProfileDir(portal) {
+  return join(process.env.HOME, '.scan-auth', portal, 'profile');
+}
+
+function getResultsPath(portal) {
+  return join(__dirname, 'data', `${portal}-scan-results.json`);
+}
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const supportedNames = Object.keys(SCANNERS);
+
+const FLAG_WITH_VALUE = new Set(['--search', '--max']);
+const FLAGS = new Set(['--login', '--dry-run', ...FLAG_WITH_VALUE]);
+const portalId = (() => {
+  for (let i = 0; i < args.length; i++) {
+    if (FLAGS.has(args[i])) { if (FLAG_WITH_VALUE.has(args[i])) i++; continue; }
+    return args[i];
+  }
+  return null;
+})();
+
+if (!portalId) {
+  console.error(`Usage: node scan-auth.mjs [options] <portal>\n\nSupported portals: ${supportedNames.join(', ')}`);
+  process.exit(1);
+}
+if (!SCANNERS[portalId]) {
+  console.error(`Unknown portal: "${portalId}"\nSupported portals: ${supportedNames.join(', ')}`);
+  process.exit(1);
+}
+
+const scanner = SCANNERS[portalId];
+
+const FLAG = {
+  login: args.includes('--login'),
+  dryRun: args.includes('--dry-run'),
+  search: (() => {
+    const idx = args.indexOf('--search');
+    return idx !== -1 ? args[idx + 1] : null;
+  })(),
+  maxResults: (() => {
+    const idx = args.indexOf('--max');
+    return idx !== -1 ? parseInt(args[idx + 1], 10) : null;
+  })(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function log(msg) { console.log(`[scan-auth] ${msg}`); }
+function warn(msg) { console.warn(`[scan-auth] ⚠ ${msg}`); }
+function error(msg) { console.error(`[scan-auth] ✗ ${msg}`); }
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+function prompt(question) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => {
+    rl.question(question, answer => { rl.close(); resolve(answer); });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Scan history (dedup)
+// ---------------------------------------------------------------------------
+
+function loadScanHistory() {
+  const urls = new Set();
+  if (!existsSync(SCAN_HISTORY_PATH)) return urls;
+  const lines = readFileSync(SCAN_HISTORY_PATH, 'utf-8').split('\n');
+  for (let i = 1; i < lines.length; i++) {
+    const url = lines[i].split('\t')[0];
+    if (url) urls.add(url);
+  }
+  return urls;
+}
+
+// ---------------------------------------------------------------------------
+// Browser session
+// ---------------------------------------------------------------------------
+
+async function launchBrowser(profileDir) {
+  mkdirSync(profileDir, { recursive: true });
+
+  log(`Launching browser (profile: ${profileDir})`);
+  const context = await chromium.launchPersistentContext(profileDir, {
+    headless: false,
+    viewport: { width: 1280, height: 900 },
+    args: [
+      '--disable-blink-features=AutomationControlled',
+      '--no-first-run',
+      '--no-default-browser-check',
+    ],
+  });
+
+  await context.addInitScript(() => {
+    Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+  });
+
+  return context;
+}
+
+async function waitForLogin(page) {
+  console.log('\n╔══════════════════════════════════════════════════╗');
+  console.log(`║  Please log in to ${scanner.name.padEnd(10)} in the browser window ║`);
+  console.log('║  Press ENTER here once you\'re logged in...       ║');
+  console.log('╚══════════════════════════════════════════════════╝\n');
+
+  await prompt('');
+
+  const ok = await scanner.checkSession(page);
+  if (!ok) {
+    warn('Still not logged in. Try again or Ctrl+C to exit.');
+    return waitForLogin(page);
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// JD saving
+// ---------------------------------------------------------------------------
+
+function saveJd(detail) {
+  mkdirSync(JDS_DIR, { recursive: true });
+  const slug = slugify(`${detail.company}-${detail.title}`);
+  const filename = `${slug}.md`;
+  const filepath = join(JDS_DIR, filename);
+
+  const content = `---
+title: "${detail.title}"
+company: "${detail.company}"
+url: "${detail.url}"
+application_url: "${detail.applicationUrl || ''}"
+scraped: "${new Date().toISOString().split('T')[0]}"
+source: ${portalId}
+---
+
+# ${detail.title} — ${detail.company}
+
+${detail.jdText}
+`;
+
+  writeFileSync(filepath, content, 'utf-8');
+  return `jds/${filename}`;
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+function writeResults(results, resultsPath) {
+  mkdirSync(dirname(resultsPath), { recursive: true });
+  writeFileSync(resultsPath, JSON.stringify(results, null, 2), 'utf-8');
+  log(`Results written to ${resultsPath}`);
+}
+
+function printSummary(results) {
+  const s = results.stats;
+  const label = `${scanner.name} Scan Summary`;
+  const pad = Math.max(0, 48 - label.length);
+  const left = Math.floor(pad / 2);
+  const right = pad - left;
+  console.log('\n╔══════════════════════════════════════════════════╗');
+  console.log(`║${' '.repeat(left + 1)}${label}${' '.repeat(right + 1)}║`);
+  console.log('╠══════════════════════════════════════════════════╣');
+  console.log(`║  Searches run:      ${String(s.searched).padStart(4)}                        ║`);
+  console.log(`║  Listings found:    ${String(s.found).padStart(4)}                        ║`);
+  console.log(`║  Extracted:         ${String(s.extracted).padStart(4)}                        ║`);
+  console.log(`║  Filtered out:      ${String(s.skipped_filter).padStart(4)}                        ║`);
+  console.log(`║  Already seen:      ${String(s.skipped_dedup).padStart(4)}                        ║`);
+  console.log(`║  JDs saved:         ${String(s.saved).padStart(4)}                        ║`);
+  console.log(`║  Errors:            ${String(s.errors).padStart(4)}                        ║`);
+  console.log('╚══════════════════════════════════════════════════╝');
+
+  if (results.listings.length > 0) {
+    console.log('\nNew listings:');
+    for (const l of results.listings) {
+      console.log(`  • ${l.title} — ${l.company}`);
+    }
+    console.log(`\nNext step: run /career-ops ${portalId} to process these into your pipeline.`);
+  } else {
+    console.log('\nNo new listings found this run.');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function main() {
+  log(`Starting ${scanner.name} scanner...`);
+
+  const config = scanner.parseConfig(readFileSync(PORTALS_PATH, 'utf-8'));
+
+  const profileDir = getProfileDir(portalId);
+  const context = await launchBrowser(profileDir);
+
+  try {
+    const page = await context.newPage();
+
+    log('Checking session...');
+    const loggedIn = await scanner.checkSession(page);
+    if (loggedIn) {
+      log('Session active — logged in');
+    } else {
+      warn('Not logged in — login required');
+    }
+
+    if (!loggedIn) {
+      if (FLAG.login) {
+        log(`Login mode — opening ${scanner.name} login page`);
+        await page.goto(scanner.loginUrl, { waitUntil: 'domcontentloaded' });
+      }
+      await waitForLogin(page);
+    }
+
+    await page.close();
+
+    if (FLAG.login) {
+      log(`Login successful — ${scanner.name} session saved. Run again without --login to scan.`);
+      return;
+    }
+
+    // Scanner handles extraction, filtering, dedup — returns accepted listings
+    const scanResult = await scanner.scan(context, config, {
+      maxResults: FLAG.maxResults,
+      searchFilter: FLAG.search,
+      scanHistory: loadScanHistory(),
+    });
+
+    if (!scanResult) return;
+
+    // Write JD files for each accepted listing
+    const savedListings = [];
+    for (const detail of scanResult.listings) {
+      let jdFile = null;
+      if (!FLAG.dryRun) {
+        jdFile = saveJd(detail);
+      }
+      savedListings.push({
+        title: detail.title,
+        company: detail.company,
+        source_url: detail.url,
+        application_url: detail.applicationUrl || '',
+        jd_file: jdFile || `jds/${slugify(`${detail.company}-${detail.title}`)}.md`,
+      });
+    }
+
+    const results = {
+      scan_date: new Date().toISOString().split('T')[0],
+      source: portalId,
+      listings: savedListings,
+      errors: scanResult.errors,
+      stats: { ...scanResult.stats, saved: savedListings.length },
+    };
+
+    if (!FLAG.dryRun) {
+      writeResults(results, getResultsPath(portalId));
+    } else {
+      log('Dry run — no files written');
+      console.log(JSON.stringify(results, null, 2));
+    }
+    printSummary(results);
+  } finally {
+    await context.close();
+  }
+}
+
+main().catch(e => {
+  error(e.message);
+  process.exit(1);
+});

--- a/scan-auth/linkedin.mjs
+++ b/scan-auth/linkedin.mjs
@@ -1,0 +1,478 @@
+/**
+ * LinkedIn Scanner
+ *
+ * All LinkedIn-specific logic: selectors, config parsing, session checks,
+ * pagination, card extraction, search URL construction, and the scan loop.
+ *
+ * scan() handles the full extraction pipeline including filtering, dedup,
+ * and employer blocklist. Returns only accepted listings ready to be saved.
+ */
+
+
+// ---------------------------------------------------------------------------
+// Selectors — grouped for easy maintenance when LinkedIn changes DOM
+// ---------------------------------------------------------------------------
+
+const SELECTORS = {
+  xpathListingCard: "//button[starts-with(@aria-label, 'Dismiss') and contains(@aria-label, 'job')]/ancestor::div[@role='button']",
+  xpathApplyUrl: "//a[@aria-label='Apply on company website']",
+  xpathTitle: "//div[@data-display-contents='true']//a[contains(@href,'trackingId')]",
+  xpathCompany: "//a[contains(@href,'/company/')]",
+  xpathMoreButton: "//span[normalize-space(text())='more']",
+  jdContent: 'span[data-testid="expandable-text-box"]',
+  loggedIn: 'a[aria-label*="My Network"]',
+  xpathCurrentPage: "//button[@aria-current='true'][starts-with(@aria-label, 'Page')]",
+  xpathPageButton: "//button[starts-with(@aria-label, 'Page')]",
+};
+
+const NOISE_LABELS = new Set([
+  'more', 'show more', 'see more',
+  'less', 'show less', 'see less',
+  'retry premium',
+]);
+const MIN_POSITION_LENGTH = 4;
+
+function randomDelay(range) {
+  const [min, max] = range;
+  return Math.floor(Math.random() * (max - min) + min);
+}
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+function log(msg) { console.log(`[linkedin] ${msg}`); }
+function warn(msg) { console.warn(`[linkedin] ⚠ ${msg}`); }
+
+export default class LinkedInScanner {
+  name = 'LinkedIn';
+  portalId = 'linkedin';
+  loginUrl = 'https://www.linkedin.com/login';
+  feedUrl = 'https://www.linkedin.com/feed/';
+
+  // -------------------------------------------------------------------------
+  // Config parsing — extracts linkedin_searches section from portals.yml
+  // -------------------------------------------------------------------------
+
+  parseConfig(raw) {
+    const lines = raw.split('\n');
+    const config = {
+      title_filter: { positive: [], negative: [] },
+      keywords: [],
+      employer_blocklist: [],
+    };
+
+    let section = null;
+    let subsection = null;
+
+    for (const line of lines) {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith('#') || trimmed === '') continue;
+
+      const indent = line.length - line.trimStart().length;
+
+      if (indent === 0) {
+        if (trimmed.startsWith('title_filter:')) { section = 'title_filter'; subsection = null; continue; }
+        if (trimmed.startsWith('linkedin_searches:')) { section = 'linkedin_searches'; subsection = null; continue; }
+        if (trimmed.match(/^\w/)) { section = null; subsection = null; continue; }
+      }
+
+      if (section === 'title_filter') {
+        if (trimmed.startsWith('positive:')) { subsection = 'positive'; continue; }
+        if (trimmed.startsWith('negative:')) { subsection = 'negative'; continue; }
+        if (trimmed.startsWith('seniority_boost:')) { subsection = 'seniority_boost'; continue; }
+        if (subsection && trimmed.startsWith('- ')) {
+          const val = trimmed.slice(2).replace(/^["']|["']$/g, '');
+          if (subsection === 'positive' || subsection === 'negative') {
+            config.title_filter[subsection].push(val);
+          }
+        }
+      }
+
+      if (section === 'linkedin_searches') {
+        if (indent === 2 && trimmed.match(/^\w+:\s*$/)) {
+          if (trimmed.startsWith('keywords:')) subsection = 'keywords';
+          else if (trimmed.startsWith('employer_blocklist:')) subsection = 'employer_blocklist';
+          continue;
+        }
+        if (indent === 2 && !trimmed.startsWith('-')) {
+          const m = trimmed.match(/^([\w_]+):\s*(.+)/);
+          if (m) {
+            let val = m[2].replace(/^["']|["']$/g, '');
+            if (m[1] === 'date_posted') config.date_posted = val;
+            if (m[1] === 'max_results_per_search') config.max_results = parseInt(val, 10);
+            if (m[1] === 'delay_between_pages_ms') {
+              config.delay_pages = val.replace(/[\[\]]/g, '').split(',').map(s => parseInt(s.trim(), 10));
+            }
+            if (m[1] === 'delay_between_searches_ms') {
+              config.delay_searches = val.replace(/[\[\]]/g, '').split(',').map(s => parseInt(s.trim(), 10));
+            }
+            if (m[1] === 'experience_level') {
+              config.experience_level = val.startsWith('[')
+                ? val.replace(/[\[\]]/g, '').split(',').map(s => s.trim()).filter(Boolean)
+                : [val.trim()];
+            }
+            if (m[1] === 'employer_blocklist' && val.startsWith('[')) {
+              config.employer_blocklist = val.replace(/[\[\]]/g, '').split(',').map(s => s.trim()).filter(Boolean);
+            }
+            if (m[1] === 'keywords' && val.startsWith('[')) {
+              config.keywords = val.replace(/[\[\]]/g, '').split(',').map(s => s.trim()).filter(Boolean);
+            }
+          }
+          subsection = null;
+          continue;
+        }
+        if (indent >= 4 && trimmed.startsWith('- ')) {
+          const val = trimmed.slice(2).replace(/^["']|["']$/g, '');
+          if (!val) continue;
+          if (subsection === 'keywords') config.keywords.push(val);
+          if (subsection === 'employer_blocklist') config.employer_blocklist.push(val);
+        }
+      }
+    }
+
+    return config;
+  }
+
+  // -------------------------------------------------------------------------
+  // Session management
+  // -------------------------------------------------------------------------
+
+  async isLoggedIn(page) {
+    const url = page.url();
+    if (url.includes('/login') || url.includes('/uas/') || url.includes('/checkpoint/')) {
+      return false;
+    }
+    if (await page.$(SELECTORS.loggedIn)) return true;
+    return false;
+  }
+
+  async checkSession(page) {
+    await page.goto(this.feedUrl, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await sleep(3000);
+    return this.isLoggedIn(page);
+  }
+
+  // -------------------------------------------------------------------------
+  // Scan — the main extraction loop
+  //
+  // Handles extraction, filtering, dedup, and employer blocklist.
+  // Returns only accepted listings ready to be saved.
+  //
+  // Options: { maxResults, searchFilter, scanHistory }
+  // -------------------------------------------------------------------------
+
+  async scan(context, config, options = {}) {
+    const page = await context.newPage();
+    const maxPerSearch = options.maxResults || config.max_results || 25;
+    const delayPages = config.delay_pages || [3000, 8000];
+    const delaySearches = config.delay_searches || [5000, 15000];
+    const titleFilter = config.title_filter;
+    const employerBlocklist = config.employer_blocklist || [];
+    const scanHistory = options.scanHistory || new Set();
+
+    const keywords = config.keywords || [];
+    if (keywords.length === 0) {
+      log('No keywords found in portals.yml');
+      await page.close();
+      return null;
+    }
+
+    const searches = this.#buildSearches(config);
+
+    const toRun = options.searchFilter
+      ? searches.filter(s => s.name === options.searchFilter)
+      : searches;
+
+    if (toRun.length === 0) {
+      log(`No keyword matching "${options.searchFilter}"`);
+      log(`Available: ${searches.map(s => s.name).join(', ')}`);
+      await page.close();
+      return null;
+    }
+
+    const listings = [];
+    const errors = [];
+    const stats = {
+      searched: 0, found: 0, extracted: 0,
+      skipped_filter: 0, skipped_dedup: 0, errors: 0,
+    };
+
+    for (const search of toRun) {
+      log(`\n── Search: ${search.name} ──`);
+      stats.searched++;
+
+      try {
+        await page.goto(search.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+        await sleep(randomDelay(delayPages));
+        await this.#scrollToLoadResults(page);
+
+        let accepted = 0;
+        let hasNextPage = true;
+
+        while (hasNextPage && accepted < maxPerSearch) {
+          const currentPage = await this.#getCurrentPage(page);
+          log(`Page ${currentPage || 1}`);
+
+          await this.#scrollToLoadResults(page);
+
+          const cardCount = await this.#getCardCount(page);
+          log(`Found ${cardCount} job cards`);
+          stats.found += cardCount;
+
+          for (let i = 0; i < cardCount; i++) {
+            if (accepted >= maxPerSearch) {
+              log(`Reached max results (${maxPerSearch}) for this search`);
+              break;
+            }
+
+            const clicked = await this.#clickCard(page, i);
+            if (!clicked) {
+              warn(`  ✗ Could not click card ${i}`);
+              continue;
+            }
+            await sleep(randomDelay(delayPages));
+
+            const detail = await this.#extractDetailFromPanel(page);
+            if (!detail.title) {
+              warn(`  ✗ No title extracted from card ${i}`);
+              stats.errors++;
+              continue;
+            }
+
+            detail.applicationUrl = this.#unwrapRedirect(detail.applicationUrl);
+            stats.extracted++;
+
+            // Dedup
+            if (scanHistory.has(detail.url)) {
+              log(`  ✗ Already seen: ${detail.title} (${detail.company})`);
+              stats.skipped_dedup++;
+              continue;
+            }
+
+            // Employer blocklist
+            if (employerBlocklist.length && detail.company) {
+              const companyLower = detail.company.toLowerCase();
+              if (employerBlocklist.some(b => companyLower.includes(b.toLowerCase()))) {
+                log(`  ✗ Blocked employer: ${detail.company}`);
+                stats.skipped_filter++;
+                continue;
+              }
+            }
+
+            // Title / keyword filter
+            if (!this.#matchesFilter(detail.title, detail.jdText, titleFilter)) {
+              log(`  ✗ Filtered: ${detail.title} (${detail.company})`);
+              stats.skipped_filter++;
+              continue;
+            }
+
+            // No JD content
+            if (!detail.jdText) {
+              warn(`  ✗ No JD content: ${detail.title}`);
+              stats.errors++;
+              continue;
+            }
+
+            listings.push(detail);
+            accepted++;
+            log(`  ✓ Accepted: ${detail.title} at ${detail.company}`);
+          }
+
+          if (accepted < maxPerSearch) {
+            hasNextPage = await this.#goToNextPage(page);
+            if (hasNextPage) {
+              log(`Navigating to next page...`);
+              await sleep(randomDelay(delayPages));
+            }
+          } else {
+            hasNextPage = false;
+          }
+        }
+      } catch (e) {
+        log(`Search "${search.name}" failed: ${e.message}`);
+        errors.push({ search: search.name, error: e.message });
+        stats.errors++;
+      }
+
+      if (toRun.indexOf(search) < toRun.length - 1) {
+        const d = randomDelay(delaySearches);
+        log(`Waiting ${(d / 1000).toFixed(1)}s before next search...`);
+        await sleep(d);
+      }
+    }
+
+    await page.close();
+    return { listings, errors, stats };
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — scan history & filtering
+  // -------------------------------------------------------------------------
+
+  #matchesFilter(title, jdText, filter) {
+    if (!filter) return true;
+    const combined = `${title} ${jdText}`.toLowerCase();
+    const titleLower = title.toLowerCase();
+    const hasPositive = !filter.positive?.length ||
+      filter.positive.some(kw => combined.includes(kw.toLowerCase()));
+    const hasNegative = filter.negative?.length &&
+      filter.negative.some(kw => titleLower.includes(kw.toLowerCase()));
+    return hasPositive && !hasNegative;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — search URL construction
+  // -------------------------------------------------------------------------
+
+  #buildSearches(config) {
+    const datePostedMap = { '24': 'past 24 hours', 'Week': 'past week', 'Month': 'past month' };
+    const dateSuffix = datePostedMap[config.date_posted] || '';
+    const levels = config.experience_level || [];
+    const levelPrefix = levels.length ? levels.join(' or ') : '';
+
+    return config.keywords.map(kw => {
+      let query = levelPrefix ? `${levelPrefix} ${kw}` : kw;
+      if (dateSuffix) query += ` posted in the ${dateSuffix}`;
+      const params = new URLSearchParams({ keywords: query });
+      return { name: kw, url: `https://www.linkedin.com/jobs/search-results/?${params}` };
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — URL helpers
+  // -------------------------------------------------------------------------
+
+  #unwrapRedirect(href) {
+    const trimmed = (href || '').trim();
+    if (!trimmed) return '';
+    try {
+      const u = new URL(trimmed);
+      if (!u.hostname.includes('linkedin.com')) return trimmed;
+      if (!u.pathname.includes('/safety/go')) return trimmed;
+      const nested = u.searchParams.get('url');
+      if (!nested) return trimmed;
+      const decoded = decodeURIComponent(nested);
+      new URL(decoded);
+      return decoded;
+    } catch {
+      return trimmed;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — pagination
+  // -------------------------------------------------------------------------
+
+  async #getCurrentPage(page) {
+    return page.evaluate(({ xpath }) => {
+      const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+      const btn = result.singleNodeValue;
+      if (!btn) return 0;
+      const label = btn.getAttribute('aria-label') || '';
+      const match = label.match(/Page (\d+)/);
+      return match ? parseInt(match[1], 10) : 0;
+    }, { xpath: SELECTORS.xpathCurrentPage });
+  }
+
+  async #goToNextPage(page) {
+    return page.evaluate(({ xpathCurrent, xpathAll }) => {
+      const curResult = document.evaluate(xpathCurrent, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+      const curBtn = curResult.singleNodeValue;
+      if (!curBtn) return false;
+      const curLabel = curBtn.getAttribute('aria-label') || '';
+      const curMatch = curLabel.match(/Page (\d+)/);
+      if (!curMatch) return false;
+      const currentNum = parseInt(curMatch[1], 10);
+
+      const allResult = document.evaluate(xpathAll, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+      for (let i = 0; i < allResult.snapshotLength; i++) {
+        const btn = allResult.snapshotItem(i);
+        const label = btn.getAttribute('aria-label') || '';
+        const match = label.match(/Page (\d+)/);
+        if (match && parseInt(match[1], 10) === currentNum + 1) {
+          btn.click();
+          return true;
+        }
+      }
+      return false;
+    }, { xpathCurrent: SELECTORS.xpathCurrentPage, xpathAll: SELECTORS.xpathPageButton });
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — extraction helpers
+  // -------------------------------------------------------------------------
+
+  async #scrollToLoadResults(page) {
+    for (let i = 0; i < 5; i++) {
+      await page.mouse.wheel(0, randomDelay([300, 600]));
+      await sleep(randomDelay([500, 1200]));
+    }
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await sleep(1000);
+  }
+
+  async #getCardCount(page) {
+    return page.evaluate((xpath) => {
+      const result = document.evaluate(xpath, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+      return result.snapshotLength;
+    }, SELECTORS.xpathListingCard);
+  }
+
+  async #clickCard(page, index) {
+    return page.evaluate(({ xpath, idx }) => {
+      const result = document.evaluate(xpath, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+      const card = result.snapshotItem(idx);
+      if (card) { card.click(); return true; }
+      return false;
+    }, { xpath: SELECTORS.xpathListingCard, idx: index });
+  }
+
+  async #extractDetailFromPanel(page) {
+    const hasMore = await page.evaluate(({ xpath }) => {
+      const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+      const moreSpan = result.singleNodeValue;
+      if (moreSpan) { moreSpan.click(); return true; }
+      return false;
+    }, { xpath: SELECTORS.xpathMoreButton });
+
+    if (!hasMore) return { title: '', company: '', applicationUrl: '', jdText: '', url: '' };
+
+    await sleep(500);
+
+    return page.evaluate(({ sel, noiseLabels, minLen }) => {
+      function xpathAll(expression) {
+        const result = document.evaluate(
+          expression, document, null,
+          XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null
+        );
+        const items = [];
+        for (let i = 0; i < result.snapshotLength; i++) {
+          const item = result.snapshotItem(i);
+          if (item) items.push(item);
+        }
+        return items;
+      }
+
+      const applyEl = xpathAll(sel.xpathApplyUrl)[0];
+      const applicationUrl = applyEl?.href?.trim() ?? '';
+
+      const titleAnchors = xpathAll(sel.xpathTitle);
+      let title = '';
+      for (const a of titleAnchors) {
+        const text = a.textContent?.trim() ?? '';
+        if (text.length >= minLen && !noiseLabels.includes(text.toLowerCase())) {
+          title = text;
+          break;
+        }
+      }
+
+      const companyAnchors = xpathAll(sel.xpathCompany);
+      const company = companyAnchors[1]?.textContent?.trim() ?? '';
+
+      const jdEl = document.querySelector(sel.jdContent);
+      const jdText = jdEl?.innerText?.trim() ?? '';
+
+      const url = window.location.href;
+
+      return { title, company, applicationUrl, jdText, url };
+    }, { sel: SELECTORS, noiseLabels: [...NOISE_LABELS], minLen: MIN_POSITION_LENGTH });
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Career-ops now supports authenticated job portal scanning through a pluggable scanner architecture. A CLI argument selects the portal (e.g. `node scan-auth.mjs linkedin`), and each portal is implemented as its own scanner class that handles extraction, filtering, dedup, and pagination while the orchestrator handles browser setup, login, file writing, and output. Adding a new portal requires only a new class in `scan-auth/` and one line in the scanner registry.

**note**: `scan-auth.md` mode may need to be translated to Spanish before merge

## Related issue

Main issue: https://github.com/santifer/career-ops/issues/238
Umbrella issue: https://github.com/santifer/career-ops/issues/238

## Type of change

- [ ] Bug fix
- [X] New feature
- [X] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [X] I linked a related issue above (required for features and architecture changes)
- [X] My PR does not include personal data (CV, email, real names)
- [X] I ran `node test-all.mjs` and all tests pass
- [X] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
**note**: browser-profiles are saved to ~/scan-auth/<portal>/profile/.
- [X] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated portal scanner for login-requiring job sites (e.g., LinkedIn) with persistent browser profiles
  * New `/career-ops scan-auth` command with optional flags: `--login`, `--search`, `--dry-run`, `--max`
  * New npm scripts: `scan:auth` and `scan:login`

* **Documentation**
  * Added authenticated scanner mode guide with workflow, configuration, and deduplication instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->