### PR TITLE
fix(scanner): word-boundary filter + location gate + dashboard scan button

### DIFF
--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -48,6 +48,20 @@ type PipelineRefreshMsg struct{}
 // PipelineOpenProgressMsg is emitted when the progress screen should open.
 type PipelineOpenProgressMsg struct{}
 
+// PipelineScanMsg asks the app to kick off `node scan.mjs` in the background.
+type PipelineScanMsg struct{}
+
+// PipelineScanDoneMsg reports a finished scan so the UI can refresh and
+// display a summary. NewCount is parsed from scan.mjs stdout; Err holds any
+// fatal error (e.g. node not installed, portals.yml missing).
+type PipelineScanDoneMsg struct {
+	NewCount int
+	Err      error
+}
+
+// PipelineScanFlashClearMsg clears the post-scan flash message after a delay.
+type PipelineScanFlashClearMsg struct{}
+
 type reportSummary struct {
 	archetype string
 	tldr      string
@@ -111,6 +125,29 @@ type PipelineModel struct {
 	// Status picker sub-state
 	statusPicker bool
 	statusCursor int
+	// Scan button state
+	scanning  bool
+	scanFlash string // transient message shown after a scan completes
+}
+
+// SetScanning toggles the scanning state (called from app-level when scan starts/ends).
+func (m *PipelineModel) SetScanning(v bool) { m.scanning = v }
+
+// SetScanFlash sets a transient post-scan message (e.g., "✓ Found 3 new jobs").
+func (m *PipelineModel) SetScanFlash(msg string) { m.scanFlash = msg }
+
+// scanButtonLabel returns the current button label; bounds can be derived
+// from its rendered width. View and Update must use this same helper so
+// click detection matches what the user sees.
+func (m PipelineModel) scanButtonLabel() string {
+	switch {
+	case m.scanning:
+		return " ⠋ Scanning… "
+	case m.scanFlash != "":
+		return " " + m.scanFlash + " "
+	default:
+		return " 🔎 Scan Jobs (n) "
+	}
 }
 
 // NewPipelineModel creates a new pipeline screen.
@@ -228,6 +265,17 @@ func (m PipelineModel) Update(msg tea.Msg) (PipelineModel, tea.Cmd) {
 			return m.handleStatusPicker(msg)
 		}
 		return m.handleKey(msg)
+	case tea.MouseMsg:
+		if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft {
+			// Button sits on the last visible row at columns [1, 1+width).
+			btnWidth := lipgloss.Width(m.scanButtonLabel())
+			btnRow := m.height - 1
+			if msg.Y == btnRow && msg.X >= 1 && msg.X < 1+btnWidth {
+				if !m.scanning {
+					return m, func() tea.Msg { return PipelineScanMsg{} }
+				}
+			}
+		}
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -320,6 +368,11 @@ func (m PipelineModel) handleKey(msg tea.KeyMsg) (PipelineModel, tea.Cmd) {
 
 	case "r":
 		return m, func() tea.Msg { return PipelineRefreshMsg{} }
+
+	case "n":
+		if !m.scanning {
+			return m, func() tea.Msg { return PipelineScanMsg{} }
+		}
 
 	case "c":
 		if len(m.filtered) > 0 {
@@ -830,6 +883,8 @@ func (m PipelineModel) renderPreview() string {
 	return strings.Join(lines, "\n")
 }
 
+// renderHelp renders the footer including a clickable Scan Jobs button.
+// Button bounds are recomputed on demand from scanButtonLabel() in Update.
 func (m PipelineModel) renderHelp() string {
 	style := lipgloss.NewStyle().
 		Foreground(m.theme.Subtext).
@@ -849,6 +904,19 @@ func (m PipelineModel) renderHelp() string {
 
 	brand := lipgloss.NewStyle().Foreground(m.theme.Overlay).Render("career-ops by santifer.io")
 
+	// Scan Jobs button — always visible, swaps label during scan / flash.
+	btnLabel := m.scanButtonLabel()
+	var btnStyle lipgloss.Style
+	switch {
+	case m.scanning:
+		btnStyle = lipgloss.NewStyle().Foreground(m.theme.Base).Background(m.theme.Yellow).Bold(true)
+	case m.scanFlash != "":
+		btnStyle = lipgloss.NewStyle().Foreground(m.theme.Base).Background(m.theme.Green).Bold(true)
+	default:
+		btnStyle = lipgloss.NewStyle().Foreground(m.theme.Base).Background(m.theme.Blue).Bold(true)
+	}
+	button := btnStyle.Render(btnLabel)
+
 	keys := keyStyle.Render("↑↓/jk") + descStyle.Render(" nav  ") +
 		keyStyle.Render("←→/hl") + descStyle.Render(" tabs  ") +
 		keyStyle.Render("s") + descStyle.Render(" sort  ") +
@@ -860,12 +928,14 @@ func (m PipelineModel) renderHelp() string {
 		keyStyle.Render("p") + descStyle.Render(" progress  ") +
 		keyStyle.Render("Esc") + descStyle.Render(" quit")
 
-	gap := m.width - lipgloss.Width(keys) - lipgloss.Width(brand) - 2
-	if gap < 1 {
-		gap = 1
+	// Layout: [button] [gap] keys [gap] brand
+	btnWidth := lipgloss.Width(button)
+	gap := m.width - btnWidth - lipgloss.Width(keys) - lipgloss.Width(brand) - 4
+	if gap < 2 {
+		gap = 2
 	}
 
-	return style.Render(keys + strings.Repeat(" ", gap) + brand)
+	return style.Render(button + "  " + keys + strings.Repeat(" ", gap) + brand)
 }
 
 func (m PipelineModel) overlayStatusPicker(body string) string {

--- a/dashboard/main.go
+++ b/dashboard/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
+	"strconv"
+	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -14,6 +19,8 @@ import (
 	"github.com/santifer/career-ops/dashboard/internal/theme"
 	"github.com/santifer/career-ops/dashboard/internal/ui/screens"
 )
+
+var scanNewCountRe = regexp.MustCompile(`New offers added:\s+(\d+)`)
 
 type viewState int
 
@@ -123,6 +130,51 @@ func (m appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return nil
 		}
 
+	case screens.PipelineScanMsg:
+		(&m.pipeline).SetScanning(true)
+		(&m.pipeline).SetScanFlash("")
+		path := m.careerOpsPath
+		return m, func() tea.Msg {
+			cmd := exec.Command("node", "scan.mjs")
+			cmd.Dir = path
+			var out strings.Builder
+			cmd.Stdout = &out
+			cmd.Stderr = &out
+			err := cmd.Run()
+			count := 0
+			if match := scanNewCountRe.FindStringSubmatch(out.String()); len(match) == 2 {
+				count, _ = strconv.Atoi(match[1])
+			} else if err == nil {
+				// Fallback: scan stdout line-by-line (defensive — regex above should hit).
+				scanner := bufio.NewScanner(strings.NewReader(out.String()))
+				for scanner.Scan() {
+					if m := scanNewCountRe.FindStringSubmatch(scanner.Text()); len(m) == 2 {
+						count, _ = strconv.Atoi(m[1])
+						break
+					}
+				}
+			}
+			return screens.PipelineScanDoneMsg{NewCount: count, Err: err}
+		}
+
+	case screens.PipelineScanDoneMsg:
+		(&m.pipeline).SetScanning(false)
+		var flash string
+		if msg.Err != nil {
+			flash = "✗ Scan failed"
+		} else {
+			flash = fmt.Sprintf("✓ Found %d new", msg.NewCount)
+		}
+		(&m.pipeline).SetScanFlash(flash)
+		m.reloadPipelineData()
+		return m, tea.Tick(3*time.Second, func(time.Time) tea.Msg {
+			return screens.PipelineScanFlashClearMsg{}
+		})
+
+	case screens.PipelineScanFlashClearMsg:
+		(&m.pipeline).SetScanFlash("")
+		return m, nil
+
 	default:
 		if m.state == viewReport {
 			vm, cmd := m.viewer.Update(msg)
@@ -189,7 +241,7 @@ func main() {
 		progressMetrics: progressMetrics,
 	}
 
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/scan.mjs
+++ b/scan.mjs
@@ -123,14 +123,44 @@ async function fetchJson(url) {
 // ── Title filter ────────────────────────────────────────────────────
 
 function buildTitleFilter(titleFilter) {
-  const positive = (titleFilter?.positive || []).map(k => k.toLowerCase());
+  // Positive / positive_role keywords match on word boundaries so "intern"
+  // does not collide with "International", and "PM" does not collide with
+  // "CPM". Both gates must pass (AND) when both are non-empty.
+  // Negatives keep substring semantics so entries with punctuation
+  // ("APM,", "Engineer,") still behave like the original filter.
+  const compile = (list) => (list || []).map(k => {
+    const escaped = k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`\\b${escaped}\\b`, 'i');
+  });
+  const positivePatterns = compile(titleFilter?.positive);
+  const rolePatterns = compile(titleFilter?.positive_role);
   const negative = (titleFilter?.negative || []).map(k => k.toLowerCase());
 
   return (title) => {
     const lower = title.toLowerCase();
-    const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
+    const hasPositive = positivePatterns.length === 0 || positivePatterns.some(re => re.test(title));
+    const hasRole = rolePatterns.length === 0 || rolePatterns.some(re => re.test(title));
     const hasNegative = negative.some(k => lower.includes(k));
-    return hasPositive && !hasNegative;
+    return hasPositive && hasRole && !hasNegative;
+  };
+}
+
+// ── Location filter ─────────────────────────────────────────────────
+
+function buildLocationFilter(locationFilter) {
+  const allowed = (locationFilter?.allowed || []).map(k => k.toLowerCase());
+  if (allowed.length === 0) return () => true;
+  // Generic labels lack country info — pass through for manual review rather
+  // than silently drop. Real geo-mismatches still get filtered.
+  const GENERIC = new Set([
+    '', 'in-office', 'in office', 'remote', 'hybrid', 'on-site', 'onsite',
+    'anywhere', 'multiple locations', 'various', 'global', 'worldwide',
+  ]);
+  return (location) => {
+    if (!location) return true;
+    const lower = location.toLowerCase().trim();
+    if (GENERIC.has(lower)) return true;
+    return allowed.some(k => lower.includes(k));
   };
 }
 
@@ -264,6 +294,7 @@ async function main() {
   const config = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
   const companies = config.tracked_companies || [];
   const titleFilter = buildTitleFilter(config.title_filter);
+  const locationFilter = buildLocationFilter(config.location_filter);
 
   // 2. Filter to enabled companies with detectable APIs
   const targets = companies
@@ -285,6 +316,7 @@ async function main() {
   const date = new Date().toISOString().slice(0, 10);
   let totalFound = 0;
   let totalFiltered = 0;
+  let totalLocFiltered = 0;
   let totalDupes = 0;
   const newOffers = [];
   const errors = [];
@@ -299,6 +331,10 @@ async function main() {
       for (const job of jobs) {
         if (!titleFilter(job.title)) {
           totalFiltered++;
+          continue;
+        }
+        if (!locationFilter(job.location)) {
+          totalLocFiltered++;
           continue;
         }
         if (seenUrls.has(job.url)) {
@@ -335,6 +371,7 @@ async function main() {
   console.log(`Companies scanned:     ${targets.length}`);
   console.log(`Total jobs found:      ${totalFound}`);
   console.log(`Filtered by title:     ${totalFiltered} removed`);
+  console.log(`Filtered by location:  ${totalLocFiltered} removed`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
   console.log(`New offers added:      ${newOffers.length}`);
 


### PR DESCRIPTION
## Summary

**Scanner bug fix (P0):** `scan.mjs` title filter rejected 100% of jobs (4347/4347) due to phrase-level positive matching and a substring trap where `"Manager I"` negative killed `"Manager Intern"`.

- **Word-boundary regex** for positive keywords — `"intern"` no longer collides with `"International"`/`"Internal"`
- **`positive_role` gate** — title must also match a PM-role keyword (Product Manager, PM, APM, etc.), preventing BDR/HR/Security interns from flooding in
- **`location_filter.allowed` wired in** — was configured in `portals.yml` but never read by `scan.mjs`. Generic labels like `"In-Office"`/`"Remote"` pass through for manual review
- **Removed `"Manager I"`/`"Manager II"` negatives** — they substring-matched `"Manager Intern"`, silently hiding all PM intern roles
- **22 new tracked companies** added to `portals.yml` (user config, gitignored): Cloudflare, Rubrik, Databricks, OpenAI, Figma, Notion, GitLab, Roblox, etc.

**Dashboard scan button (feature):** Visible `🔎 Scan Jobs (n)` button in TUI footer.
- Click or press `n` to trigger `node scan.mjs` asynchronously
- Yellow `⠋ Scanning…` indicator during scan, green `✓ Found N new` flash on completion
- Auto-reloads pipeline data after scan
- Mouse support enabled via `tea.WithMouseCellMotion()`

**Result:** 0 → 1 genuine PM Intern offer (Cloudflare Summer 2026). April is genuinely thin for intern recruiting — the scanner now correctly surfaces what exists.

## Test plan
- [x] `node scan.mjs --dry-run` returns 1 new offer (was 0)
- [x] `go build ./...` compiles clean
- [x] `go vet ./...` passes
- [ ] Manual: launch dashboard, verify scan button visible, press `n`, confirm scan runs and refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Scan Jobs" button in the pipeline view, accessible via mouse click or 'n' key, with real-time status feedback
  * Enhanced job title filtering with improved pattern matching and keyword combination logic
  * Introduced location-based filtering for job opportunities to refine search results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->