### PR TITLE
fix(update-system): use releases API as source of truth for remote version

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -137,33 +137,35 @@ async function check() {
 
   const local = localVersion();
   let remote;
+  let changelog = '';
 
+  // Primary: GitHub releases API. The release tag is the source of truth —
+  // the VERSION file on main can lag behind a tag if release-please config
+  // doesn't list it under extra-files.
   try {
-    const res = await fetch(RAW_VERSION_URL);
+    const res = await fetch(RELEASES_API, {
+      headers: { 'Accept': 'application/vnd.github.v3+json' }
+    });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    remote = (await res.text()).trim();
+    const release = await res.json();
+    remote = (release.tag_name || '').replace(/^v/, '').trim();
+    changelog = release.body || '';
+    if (!remote) throw new Error('no tag_name in latest release');
   } catch {
-    console.log(JSON.stringify({ status: 'offline', local }));
-    return;
+    // Fallback: raw VERSION file (e.g., private fork without releases)
+    try {
+      const res = await fetch(RAW_VERSION_URL);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      remote = (await res.text()).trim();
+    } catch {
+      console.log(JSON.stringify({ status: 'offline', local }));
+      return;
+    }
   }
 
   if (compareVersions(local, remote) >= 0) {
     console.log(JSON.stringify({ status: 'up-to-date', local, remote }));
     return;
-  }
-
-  // Fetch changelog from GitHub releases
-  let changelog = '';
-  try {
-    const res = await fetch(RELEASES_API, {
-      headers: { 'Accept': 'application/vnd.github.v3+json' }
-    });
-    if (res.ok) {
-      const release = await res.json();
-      changelog = release.body || '';
-    }
-  } catch {
-    // No changelog available, that's OK
   }
 
   console.log(JSON.stringify({


### PR DESCRIPTION
## Summary

- `update-system.mjs check` currently pulls the remote version from `raw.githubusercontent.com/santifer/career-ops/main/VERSION` and treats that as authoritative. But release-please (with `release-type: simple` and the `.release-please-manifest.json` setup in `.github/workflows/release.yml`) doesn't touch the root `VERSION` file by default — so when a release tag ships, `VERSION` on `main` can stay behind.
- Observed today: releases `v1.4.0` (2026-04-13) and `v1.5.0` (2026-04-14) are tagged and published, but `VERSION` on `main` still reads `1.3.0`. Users on `1.3.0` run `check` and get `"status": "up-to-date"` — silently missing `--min-score`, the dashboard progress analytics, the `roleMatch` stopword fix, etc.
- Flip the lookup order: the GitHub releases API is now primary (tag_name is the authoritative published version, with `^v` stripped), and the raw `VERSION` file is the fallback for offline or private-fork scenarios. Also folds the changelog fetch into the same call — one HTTP request when an update is available instead of two.
- `apply` is unchanged: it already pulls via `git fetch … main`, which is always the right thing regardless of file-state drift.

Alternative fix would be to list `VERSION` under `extra-files` in `.github/release-please-config.json` so release-please keeps it in sync. That's a valid patch too, but it leaves the checker brittle to future config mistakes. Reading from the releases API is self-correcting.

## Test plan

- [x] `node update-system.mjs check` against current `main` now returns `{"status":"update-available","local":"1.3.0","remote":"1.5.0", ...}` — matches ground truth
- [x] Releases-API-down path still falls through to `VERSION` file (unchanged behavior)
- [x] Both paths still return `{"status":"offline", …}` when everything is unreachable
- [ ] (reviewer) run `check` from a private fork without published releases to confirm the fallback kicks in as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the update checking mechanism to more efficiently retrieve version information and release notes. Enhanced fallback handling ensures the system can access updates reliably even if primary sources are temporarily unavailable, with improved error management for offline scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->