### PR TITLE
fix(ci): gracefully handle missing dependency graph in dependency-review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Dependency Review
+        continue-on-error: true
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Dependency Review
+        # TODO: remove continue-on-error once the Dependency graph is enabled in
+        # Settings > Security & Analysis (see #343). Until then, this is a temporary
+        # workaround to unblock PRs — note that fail-on-severity: high is still
+        # configured but will not block merges while continue-on-error is true.
         continue-on-error: true
         uses: actions/dependency-review-action@v4
         with:


### PR DESCRIPTION
## Problem

The `dependency-review` workflow fails with a hard error on every PR because the GitHub Dependency graph feature is not enabled on this repository:

```
Error: Dependency review is not supported on this repository.
Please ensure that Dependency graph is enabled.
```

This blocks all contributor PRs from passing CI, even when the actual code changes are perfectly valid.

## Solution

Add `continue-on-error: true` to the Dependency Review step. This makes the check non-blocking while the repository owner enables the Dependency graph in Settings → Security & Analysis. Once enabled, the step will work correctly and any high-severity dependency issues will still be reported as a warning in the PR summary.

## Changes

- `.github/workflows/dependency-review.yml` — added `continue-on-error: true` to the Dependency Review step

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked the related issue above (Closes #343)
- [x] My PR does not include personal data (CV, email, real names)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

Closes #343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated so dependency review failures no longer block the pipeline; review still flags high-severity issues.
  * Improves reliability of automated checks without changing application behavior.

---

Note: No user-facing changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->