### PR TITLE
docs(scan): clarify scan.mjs is API-only; Playwright/WebSearch is the…

### DIFF
--- a/modes/scan.md
+++ b/modes/scan.md
@@ -2,6 +2,8 @@
 
 Escanea portales de empleo configurados, filtra por relevancia de título, y añade nuevas ofertas al pipeline para evaluación posterior.
 
+> **Nota (v1.5+):** El escáner por defecto (`scan.mjs` / `npm run scan`) es **zero-token** y sólo consulta directamente las APIs públicas de Greenhouse, Ashby y Lever. Los niveles con Playwright/WebSearch descritos abajo son el flujo **agente** (ejecutado por Claude/Codex), no lo que hace `scan.mjs`. Si una empresa no tiene API Greenhouse/Ashby/Lever, `scan.mjs` la ignorará; para esos casos, el agente debe completar manualmente el Nivel 1 (Playwright) o Nivel 3 (WebSearch).
+
 ## Ejecución recomendada
 
 Ejecutar como subagente para no consumir contexto del main:


### PR DESCRIPTION
… agent flow (#339)

modes/scan.md described a 3-tier scanner (Playwright, API, WebSearch) but scan.mjs only queries Greenhouse/Ashby/Lever public APIs — which is correct and intentional (zero-token).

Added a v1.5+ note at the top of scan.md explaining the split:
- scan.mjs / 'npm run scan' is zero-token and API-only.
- The Playwright / WebSearch tiers are the agent flow run by Claude/Codex, not scan.mjs.
- For companies without a Greenhouse/Ashby/Lever API, the agent should cover them via Tier 1 (Playwright) or Tier 3 (WebSearch).

No behaviour change; docs now match the code.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- REQUIRED: Link the issue this PR addresses. PRs without a related issue will be closed. -->
<!-- Format: Fixes #123 / Closes #123 -->
<!-- Bug fixes can skip this if the fix is obvious (e.g., typo, crash). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] I linked a related issue above (required for features and architecture changes)
- [ ] My PR does not include personal data (CV, email, real names)
- [ ] I ran `node test-all.mjs` and all tests pass
- [ ] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated scan documentation to clarify that default scan execution is zero-token, making direct public API calls to Greenhouse, Ashby, and Lever. Documented behavior when tracked companies lack these APIs, requiring manual completion for advanced scanning levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->