### PR TITLE
fix(pt): restore diacritical marks in PT-BR modes

### DIFF
--- a/modes/pt/README.md
+++ b/modes/pt/README.md
@@ -1,37 +1,37 @@
-# career-ops -- Modos em Portugues BR (`modes/pt/`)
+# career-ops -- Modos em Português BR (`modes/pt/`)
 
-Esta pasta contem as traducoes em portugues brasileiro dos principais modos do career-ops para candidatos que buscam vagas no mercado brasileiro ou em empresas que operam em portugues.
+Esta pasta contém as traduções em português brasileiro dos principais modos do career-ops para candidatos que buscam vagas no mercado brasileiro ou em empresas que operam em português.
 
 ## Quando usar estes modos?
 
-Use `modes/pt/` se pelo menos uma das condicoes abaixo for verdadeira:
+Use `modes/pt/` se pelo menos uma das condições abaixo for verdadeira:
 
-- Voce se candidata principalmente a **vagas em portugues** (Gupy, Greenhouse BR, LinkedIn BR, Vagas.com.br, Catho, InfoJobs)
-- Sua **lingua do curriculo** e portugues ou voce alterna entre PT-BR e EN conforme a vaga
-- Voce precisa de respostas e cartas de apresentacao em **portugues tech natural**, nao traduzido por maquina
-- Voce precisa lidar com **especificidades do mercado brasileiro**: CLT vs PJ, 13o salario, FGTS, PLR, vale-refeicao, plano de saude, aviso previo, periodo de experiencia
+- Você se candidata principalmente a **vagas em português** (Gupy, Greenhouse BR, LinkedIn BR, Vagas.com.br, Catho, InfoJobs)
+- Sua **língua do currículo** é português ou você alterna entre PT-BR e EN conforme a vaga
+- Você precisa de respostas e cartas de apresentação em **português tech natural**, não traduzido por máquina
+- Você precisa lidar com **especificidades do mercado brasileiro**: CLT vs PJ, 13º salário, FGTS, PLR, vale-refeição, plano de saúde, aviso prévio, período de experiência
 
-Se a maioria das suas vagas e em ingles, fique com os modos padrao em `modes/`. Os modos em ingles funcionam automaticamente quando Claude detecta uma vaga em portugues — mas nao conhecem as particularidades do mercado brasileiro no mesmo nivel de detalhe.
+Se a maioria das suas vagas é em inglês, fique com os modos padrão em `modes/`. Os modos em inglês funcionam automaticamente quando Claude detecta uma vaga em português — mas não conhecem as particularidades do mercado brasileiro no mesmo nível de detalhe.
 
 ## Como ativar?
 
-O career-ops nao tem um "switch de idioma" como flag de codigo. Em vez disso, existem dois caminhos:
+O career-ops não tem um "switch de idioma" como flag de código. Em vez disso, existem dois caminhos:
 
-### Caminho 1 -- Por sessao, via comando
+### Caminho 1 -- Por sessão, via comando
 
-Diga ao Claude no inicio da sessao:
+Diga ao Claude no início da sessão:
 
-> "Use os modos em portugues de `modes/pt/`."
+> "Use os modos em português de `modes/pt/`."
 
 ou
 
-> "Avaliar e candidaturas em portugues -- use `modes/pt/_shared.md` e `modes/pt/oferta.md`."
+> "Avaliar e candidaturas em português -- use `modes/pt/_shared.md` e `modes/pt/oferta.md`."
 
 Claude vai ler os arquivos desta pasta em vez de `modes/`.
 
 ### Caminho 2 -- Permanente, via perfil
 
-Adicione em `config/profile.yml` uma preferencia de idioma:
+Adicione em `config/profile.yml` uma preferência de idioma:
 
 ```yaml
 language:
@@ -39,73 +39,73 @@ language:
   modes_dir: modes/pt
 ```
 
-Lembre o Claude na primeira sessao de respeitar esse campo ("Olha no `profile.yml`, eu configurei `language.modes_dir`"). A partir dai, Claude usa automaticamente os modos em portugues.
+Lembre o Claude na primeira sessão de respeitar esse campo ("Olha no `profile.yml`, eu configurei `language.modes_dir`"). A partir daí, Claude usa automaticamente os modos em português.
 
-> Nota: O campo `language.modes_dir` e uma convencao, nao um schema rigido. Se os mantenedores quiserem estruturar diferente, o campo pode ser renomeado a qualquer momento.
+> Nota: O campo `language.modes_dir` é uma convenção, não um schema rígido. Se os mantenedores quiserem estruturar diferente, o campo pode ser renomeado a qualquer momento.
 
 ## O que foi traduzido?
 
-Esta primeira iteracao cobre os quatro modos com maior impacto:
+Esta primeira iteração cobre os quatro modos com maior impacto:
 
 | Arquivo | Traduzido de | Finalidade |
 |---------|-------------|------------|
-| `_shared.md` | `modes/_shared.md` (EN) | Contexto compartilhado, arquetipos, regras globais, especificidades do mercado BR |
-| `oferta.md` | `modes/oferta.md` (ES) | Avaliacao completa de uma vaga (Blocos A-F) |
-| `aplicar.md` | `modes/apply.md` (EN) | Assistente ao vivo para formularios de candidatura |
+| `_shared.md` | `modes/_shared.md` (EN) | Contexto compartilhado, arquétipos, regras globais, especificidades do mercado BR |
+| `oferta.md` | `modes/oferta.md` (ES) | Avaliação completa de uma vaga (Blocos A-F) |
+| `aplicar.md` | `modes/apply.md` (EN) | Assistente ao vivo para formulários de candidatura |
 | `pipeline.md` | `modes/pipeline.md` (ES) | Inbox de URLs / Second Brain para vagas acumuladas |
 
-Os demais modos (`scan`, `batch`, `pdf`, `tracker`, `auto-pipeline`, `deep`, `contacto`, `ofertas`, `project`, `training`) nao estao neste PR de proposito. Eles continuam funcionando via os originais em EN/ES, pois seu conteudo e majoritariamente tooling, caminhos e comandos de configuracao — que devem ser independentes de idioma.
+Os demais modos (`scan`, `batch`, `pdf`, `tracker`, `auto-pipeline`, `deep`, `contacto`, `ofertas`, `project`, `training`) não estão neste PR de propósito. Eles continuam funcionando via os originais em EN/ES, pois seu conteúdo é majoritariamente tooling, caminhos e comandos de configuração — que devem ser independentes de idioma.
 
-Se a comunidade adotar os modos em portugues, mais modos serao traduzidos em PRs futuros.
+Se a comunidade adotar os modos em português, mais modos serão traduzidos em PRs futuros.
 
-## O que continua em ingles?
+## O que continua em inglês?
 
-Propositalmente nao traduzido, porque e vocabulario padrao de tech:
+Propositalmente não traduzido, porque é vocabulário padrão de tech:
 
 - `cv.md`, `pipeline`, `tracker`, `report`, `score`, `archetype`, `proof point`
 - Nomes de tools (`Playwright`, `WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`)
 - Valores de status no tracker (`Evaluated`, `Applied`, `Interview`, `Offer`, `Rejected`)
 - Code snippets, caminhos de arquivo, comandos
 
-Os modos usam portugues tech brasileiro, como se fala em times de engenharia reais em Sao Paulo, Florianopolis ou Belo Horizonte: texto corrido em portugues, termos tecnicos em ingles onde sao de uso comum. Nada de traduzir "pipeline" para "tubulacao" ou "cv.md" para "curriculo.md".
+Os modos usam português tech brasileiro, como se fala em times de engenharia reais em São Paulo, Florianópolis ou Belo Horizonte: texto corrido em português, termos técnicos em inglês onde são de uso comum. Nada de traduzir "pipeline" para "tubulação" ou "cv.md" para "curriculo.md".
 
-## Vocabulario de Referencia
+## Vocabulário de Referência
 
-Se voce for adaptar ou expandir os modos, siga este vocabulario para manter a consistencia de tom:
+Se você for adaptar ou expandir os modos, siga este vocabulário para manter a consistência de tom:
 
-| Ingles | Portugues BR (nesta codebase) |
+| Inglês | Português BR (nesta codebase) |
 |--------|-------------------------------|
-| Job posting | Vaga / Descricao da vaga |
+| Job posting | Vaga / Descrição da vaga |
 | Application | Candidatura |
-| Cover letter | Carta de apresentacao |
-| Resume / CV | Curriculo |
-| Salary | Salario / Remuneracao |
-| Compensation | Remuneracao |
-| Skills | Habilidades / Competencias |
+| Cover letter | Carta de apresentação |
+| Resume / CV | Currículo |
+| Salary | Salário / Remuneração |
+| Compensation | Remuneração |
+| Skills | Habilidades / Competências |
 | Interview | Entrevista |
 | Hiring manager | Gestor da vaga / Hiring manager |
 | Recruiter | Recrutador(a) |
-| AI | IA (Inteligencia Artificial) |
+| AI | IA (Inteligência Artificial) |
 | Requirements | Requisitos |
-| Career history | Trajetoria profissional / Experiencia |
-| Notice period | Aviso previo |
-| Probation | Periodo de experiencia |
-| Vacation | Ferias |
-| 13th month salary | 13o salario |
+| Career history | Trajetória profissional / Experiência |
+| Notice period | Aviso prévio |
+| Probation | Período de experiência |
+| Vacation | Férias |
+| 13th month salary | 13º salário |
 | Formal employment (CLT) | CLT / Carteira assinada |
-| Contractor (PJ) | PJ (Pessoa Juridica) |
-| Profit sharing | PLR (Participacao nos Lucros e Resultados) |
-| Health insurance | Plano de saude |
-| Meal voucher | Vale-refeicao / Vale-alimentacao |
+| Contractor (PJ) | PJ (Pessoa Jurídica) |
+| Profit sharing | PLR (Participação nos Lucros e Resultados) |
+| Health insurance | Plano de saúde |
+| Meal voucher | Vale-refeição / Vale-alimentação |
 | Severance fund | FGTS (Fundo de Garantia) |
-| Stock options | Stock options (termo ja usado em PT-BR) |
+| Stock options | Stock options (termo já usado em PT-BR) |
 
 ## Contribuir
 
-Se quiser melhorar uma traducao ou traduzir um modo adicional:
+Se quiser melhorar uma tradução ou traduzir um modo adicional:
 
 1. Abra uma issue com a proposta (conforme `CONTRIBUTING.md`)
-2. Siga o vocabulario acima para manter o tom consistente
-3. Traduza de forma natural e idiomatica — nada de traducao literal palavra por palavra
-4. Mantenha os elementos estruturais (Bloco A-F, tabelas, blocos de codigo, instrucoes de tools) exatamente iguais
+2. Siga o vocabulário acima para manter o tom consistente
+3. Traduza de forma natural e idiomática — nada de tradução literal palavra por palavra
+4. Mantenha os elementos estruturais (Bloco A-F, tabelas, blocos de código, instruções de tools) exatamente iguais
 5. Teste com uma vaga real brasileira (ex: do Gupy ou LinkedIn BR) antes de abrir o PR

--- a/modes/pt/_shared.md
+++ b/modes/pt/_shared.md
@@ -1,4 +1,4 @@
-# Contexto Compartilhado -- career-ops (Portugues BR)
+# Contexto Compartilhado -- career-ops (Português BR)
 
 <!-- ============================================================
      THIS FILE IS AUTO-UPDATABLE. Don't put personal data here.
@@ -8,102 +8,102 @@
      that improve with each career-ops release.
      ============================================================ -->
 
-## Fontes da Verdade (SEMPRE ler antes de cada avaliacao)
+## Fontes da Verdade (SEMPRE ler antes de cada avaliação)
 
 | Arquivo | Caminho | Quando |
 |---------|---------|--------|
 | cv.md | `cv.md` (raiz do projeto) | SEMPRE |
 | article-digest.md | `article-digest.md` (se existir) | SEMPRE (proof points detalhados) |
 | profile.yml | `config/profile.yml` | SEMPRE (identidade e vagas-alvo) |
-| _profile.md | `modes/_profile.md` | SEMPRE (arquetipos, narrativa, negociacao do usuario) |
+| _profile.md | `modes/_profile.md` | SEMPRE (arquétipos, narrativa, negociação do usuário) |
 
-**REGRA: NUNCA fazer hardcode de metricas de proof points.** Leia-as de `cv.md` e `article-digest.md` no momento da avaliacao.
-**REGRA: Para metricas de artigos/projetos, `article-digest.md` tem prioridade sobre `cv.md`** (`cv.md` pode conter numeros desatualizados).
-**REGRA: Leia `_profile.md` DEPOIS deste arquivo. As personalizacoes do usuario em `_profile.md` sobrescrevem os valores padrao aqui.**
+**REGRA: NUNCA fazer hardcode de métricas de proof points.** Leia-as de `cv.md` e `article-digest.md` no momento da avaliação.
+**REGRA: Para métricas de artigos/projetos, `article-digest.md` tem prioridade sobre `cv.md`** (`cv.md` pode conter números desatualizados).
+**REGRA: Leia `_profile.md` DEPOIS deste arquivo. As personalizações do usuário em `_profile.md` sobrescrevem os valores padrão aqui.**
 
 ---
 
-## Sistema de Pontuacao
+## Sistema de Pontuação
 
-A avaliacao usa 6 blocos (A-F) com uma nota global de 1-5:
+A avaliação usa 6 blocos (A-F) com uma nota global de 1-5:
 
-| Dimensao | O que mede |
+| Dimensão | O que mede |
 |----------|------------|
-| Match com CV | Habilidades, experiencia, alinhamento de proof points |
-| Alinhamento North Star | Quao bem a vaga encaixa nos arquetipos-alvo do usuario (de `_profile.md`) |
-| Remuneracao | Salario vs mercado (5=quartil superior, 1=bem abaixo) |
-| Sinais culturais | Cultura da empresa, crescimento, estabilidade, politica de trabalho remoto |
+| Match com CV | Habilidades, experiência, alinhamento de proof points |
+| Alinhamento North Star | Quão bem a vaga encaixa nos arquétipos-alvo do usuário (de `_profile.md`) |
+| Remuneração | Salário vs mercado (5=quartil superior, 1=bem abaixo) |
+| Sinais culturais | Cultura da empresa, crescimento, estabilidade, política de trabalho remoto |
 | Red flags | Bloqueadores, alertas (ajustes negativos) |
-| **Global** | Media ponderada dos itens acima |
+| **Global** | Média ponderada dos itens acima |
 
-**Interpretacao da nota:**
+**Interpretação da nota:**
 - 4.5+ → Match forte, recomendado aplicar imediatamente
 - 4.0-4.4 → Bom match, vale a pena aplicar
-- 3.5-3.9 → Razoavel mas nao ideal, aplicar apenas se houver motivo especifico
-- Abaixo de 3.5 → Recomendado nao aplicar (veja Ethical Use no CLAUDE.md)
+- 3.5-3.9 → Razoável mas não ideal, aplicar apenas se houver motivo específico
+- Abaixo de 3.5 → Recomendado não aplicar (veja Ethical Use no CLAUDE.md)
 
 ## North Star -- Vagas-Alvo
 
-O skill trata TODAS as vagas-alvo com o mesmo cuidado. Nenhuma e primaria ou secundaria — qualquer uma e uma vitoria, desde que a remuneracao e a perspectiva de crescimento estejam adequadas:
+O skill trata TODAS as vagas-alvo com o mesmo cuidado. Nenhuma é primária ou secundária — qualquer uma é uma vitória, desde que a remuneração e a perspectiva de crescimento estejam adequadas:
 
-| Arquetipo | Eixos tematicos | O que estao comprando |
+| Arquétipo | Eixos temáticos | O que estão comprando |
 |-----------|-----------------|----------------------|
-| **AI Platform / LLMOps Engineer** | Avaliacao, Observability, Confiabilidade, Pipelines | Alguem que coloca IA em producao com metricas |
-| **Agentic Workflows / Automation** | HITL, Tooling, Orquestracao, Multi-Agent | Alguem que constroi sistemas de agentes confiaveis |
-| **Technical AI Product Manager** | GenAI/Agents, PRDs, Discovery, Delivery | Alguem que traduz negocios em produtos de IA |
-| **AI Solutions Architect** | Hiperautomacao, Enterprise, Integracoes | Alguem que projeta arquiteturas de IA de ponta a ponta |
-| **AI Forward Deployed Engineer** | Cliente-proximo, entrega rapida, Prototipagem | Alguem que implanta solucoes de IA rapidamente no cliente |
-| **AI Transformation Lead** | Gestao de mudanca, Adocao, Enablement organizacional | Alguem que lidera transformacao de IA em organizacoes |
+| **AI Platform / LLMOps Engineer** | Avaliação, Observability, Confiabilidade, Pipelines | Alguém que coloca IA em produção com métricas |
+| **Agentic Workflows / Automation** | HITL, Tooling, Orquestração, Multi-Agent | Alguém que constrói sistemas de agentes confiáveis |
+| **Technical AI Product Manager** | GenAI/Agents, PRDs, Discovery, Delivery | Alguém que traduz negócios em produtos de IA |
+| **AI Solutions Architect** | Hiperautomação, Enterprise, Integrações | Alguém que projeta arquiteturas de IA de ponta a ponta |
+| **AI Forward Deployed Engineer** | Cliente-próximo, entrega rápida, Prototipagem | Alguém que implanta soluções de IA rapidamente no cliente |
+| **AI Transformation Lead** | Gestão de mudança, Adoção, Enablement organizacional | Alguém que lidera transformação de IA em organizações |
 
-<!-- [PERSONALIZAR] Adapte os arquetipos acima para suas vagas-alvo.
+<!-- [PERSONALIZAR] Adapte os arquétipos acima para suas vagas-alvo.
      Exemplo para engenharia backend:
      - Senior Backend Engineer
      - Staff Platform Engineer
      - Engineering Manager
      etc. -->
 
-### Framing Adaptativo por Arquetipo
+### Framing Adaptativo por Arquétipo
 
-> **Metricas concretas: ler de `cv.md` e `article-digest.md` no momento da avaliacao. NUNCA fazer hardcode aqui.**
+> **Métricas concretas: ler de `cv.md` e `article-digest.md` no momento da avaliação. NUNCA fazer hardcode aqui.**
 
-| Se a vaga e... | Enfatizar no candidato... | Fontes de Proof Points |
+| Se a vaga é... | Enfatizar no candidato... | Fontes de Proof Points |
 |----------------|--------------------------|------------------------|
-| Platform / LLMOps | Experiencia em producao, Observability, Evals, Closed-Loop | article-digest.md + cv.md |
-| Agentic / Automation | Orquestracao multi-agent, HITL, Confiabilidade, Custos | article-digest.md + cv.md |
-| Technical AI PM | Product Discovery, PRDs, Metricas, Gestao de stakeholders | cv.md + article-digest.md |
-| Solutions Architect | Design de sistemas, Integracoes, Enterprise-ready | article-digest.md + cv.md |
-| Forward Deployed Engineer | Entrega rapida, proximo do cliente, Prototipo a producao | cv.md + article-digest.md |
-| AI Transformation Lead | Gestao de mudanca, Enablement de equipe, Adocao | cv.md + article-digest.md |
+| Platform / LLMOps | Experiência em produção, Observability, Evals, Closed-Loop | article-digest.md + cv.md |
+| Agentic / Automation | Orquestração multi-agent, HITL, Confiabilidade, Custos | article-digest.md + cv.md |
+| Technical AI PM | Product Discovery, PRDs, Métricas, Gestão de stakeholders | cv.md + article-digest.md |
+| Solutions Architect | Design de sistemas, Integrações, Enterprise-ready | article-digest.md + cv.md |
+| Forward Deployed Engineer | Entrega rápida, próximo do cliente, Protótipo a produção | cv.md + article-digest.md |
+| AI Transformation Lead | Gestão de mudança, Enablement de equipe, Adoção | cv.md + article-digest.md |
 
-<!-- [PERSONALIZAR] Mapeie seus projetos/artigos concretos para os arquetipos acima -->
+<!-- [PERSONALIZAR] Mapeie seus projetos/artigos concretos para os arquétipos acima -->
 
-### Narrativa de Transicao (usar em TODOS os framings)
+### Narrativa de Transição (usar em TODOS os framings)
 
-<!-- [PERSONALIZAR] Substitua pela sua propria narrativa. Exemplos:
-     - "Construi e vendi minha propria SaaS em 5 anos. Agora foco total em IA aplicada no Enterprise."
-     - "Lead de engenharia em uma Series-B durante crescimento 10x. Buscando o proximo desafio."
-     - "Transicao de consultoria para produto. Buscando vagas com alta responsabilidade."
+<!-- [PERSONALIZAR] Substitua pela sua própria narrativa. Exemplos:
+     - "Construí e vendi minha própria SaaS em 5 anos. Agora foco total em IA aplicada no Enterprise."
+     - "Lead de engenharia em uma Series-B durante crescimento 10x. Buscando o próximo desafio."
+     - "Transição de consultoria para produto. Buscando vagas com alta responsabilidade."
      Lido de config/profile.yml -> narrative.exit_story -->
 
-Use a narrativa de transicao de `config/profile.yml` para enquadrar TODO o conteudo:
-- **Em PDF Summaries:** Construir a ponte do passado para o futuro — "Aplico as mesmas [habilidades] agora em [dominio do JD]."
-- **Em historias STAR:** Referenciar proof points de `article-digest.md`.
-- **Em respostas rascunho (Bloco G):** A narrativa de transicao vai na primeira resposta.
-- **Quando a vaga menciona "empreendedor", "ownership", "builder", "end-to-end":** Esse e o diferencial numero 1. Aumentar peso de match.
+Use a narrativa de transição de `config/profile.yml` para enquadrar TODO o conteúdo:
+- **Em PDF Summaries:** Construir a ponte do passado para o futuro — "Aplico as mesmas [habilidades] agora em [domínio do JD]."
+- **Em histórias STAR:** Referenciar proof points de `article-digest.md`.
+- **Em respostas rascunho (Bloco G):** A narrativa de transição vai na primeira resposta.
+- **Quando a vaga menciona "empreendedor", "ownership", "builder", "end-to-end":** Esse é o diferencial número 1. Aumentar peso de match.
 
 ### Vantagem Transversal
 
-Enquadrar o perfil como **"Builder tecnico com pratica comprovada"**, adaptando o framing a vaga:
-- Para PM: "Builder que reduz incerteza com prototipos e depois leva a producao com disciplina"
-- Para FDE: "Builder que entrega desde o dia 1 com observability e metricas"
-- Para SA: "Builder que projeta sistemas end-to-end com experiencia real de integracao"
-- Para LLMOps: "Builder que coloca IA em producao com sistemas de qualidade closed-loop"
+Enquadrar o perfil como **"Builder técnico com prática comprovada"**, adaptando o framing à vaga:
+- Para PM: "Builder que reduz incerteza com protótipos e depois leva à produção com disciplina"
+- Para FDE: "Builder que entrega desde o dia 1 com observability e métricas"
+- Para SA: "Builder que projeta sistemas end-to-end com experiência real de integração"
+- Para LLMOps: "Builder que coloca IA em produção com sistemas de qualidade closed-loop"
 
-Posicionar "Builder" como sinal profissional — nao como "hobbyista". Proof points reais tornam isso credivel.
+Posicionar "Builder" como sinal profissional — não como "hobbyista". Proof points reais tornam isso crível.
 
 ### Portfolio como Proof Point (usar em candidaturas de alto valor)
 
-<!-- [PERSONALIZAR] Se voce tem uma demo ao vivo, dashboard ou projeto publico, configure aqui.
+<!-- [PERSONALIZAR] Se você tem uma demo ao vivo, dashboard ou projeto público, configure aqui.
      Exemplo:
      dashboard:
        url: "https://seudominio.dev/demo"
@@ -113,65 +113,65 @@ Posicionar "Builder" como sinal profissional — nao como "hobbyista". Proof poi
 
 Quando o candidato tem uma demo ao vivo / dashboard (verificar `profile.yml`), oferecer acesso em candidaturas relevantes.
 
-### Inteligencia de Remuneracao (Comp Intelligence)
+### Inteligência de Remuneração (Comp Intelligence)
 
 <!-- [PERSONALIZAR] Pesquise faixas salariais para suas vagas-alvo e ajuste os valores -->
 
-**Orientacoes gerais:**
+**Orientações gerais:**
 - WebSearch para dados atuais de mercado (Glassdoor, Levels.fyi, Blind)
-- Enquadrar por titulo da vaga, nao por skills — titulos definem as faixas salariais
-- Taxas de freelance geralmente ficam 30-60% acima da hora bruta de CLT (encargos, ferias, FGTS, INSS, contador)
-- Geo-arbitragem funciona em vagas remotas: custo de vida menor = melhor liquido
+- Enquadrar por título da vaga, não por skills — títulos definem as faixas salariais
+- Taxas de freelance geralmente ficam 30-60% acima da hora bruta de CLT (encargos, férias, FGTS, INSS, contador)
+- Geo-arbitragem funciona em vagas remotas: custo de vida menor = melhor líquido
 
 ### Mercado Brasileiro -- Especificidades (IMPORTANTE)
 
-Em vagas e negociacoes brasileiras, existem termos e praticas que nao aparecem nos mercados EN/ES/DE. Eles DEVEM ser avaliados corretamente:
+Em vagas e negociações brasileiras, existem termos e práticas que não aparecem nos mercados EN/ES/DE. Eles DEVEM ser avaliados corretamente:
 
-| Termo | Significado | Impacto na Avaliacao |
+| Termo | Significado | Impacto na Avaliação |
 |-------|-------------|----------------------|
-| **CLT** (Consolidacao das Leis do Trabalho) | Contrato formal com carteira assinada | Inclui FGTS, INSS, ferias, 13o, aviso previo. Na comparacao, considerar o custo total empregador |
-| **PJ** (Pessoa Juridica) | Contratacao como prestador de servicos (nota fiscal) | Valor mensal mais alto, mas sem beneficios CLT. Calcular equivalente CLT para comparacao justa |
-| **13o Salario** | Pagamento extra obrigatorio para CLT | Comp CLT = salario x 13 (ou 13,33 com 1/3 de ferias). NUNCA esquecer na comparacao |
-| **FGTS** (Fundo de Garantia) | 8% do salario depositado pelo empregador | Beneficio CLT, nao aparece no contra-cheque mas e remuneracao real |
-| **Vale-Refeicao / Vale-Alimentacao** | Beneficio alimentacao (iFood, Sodexo, Alelo) | Comum em vagas CLT, pode chegar a R$ 1.500+/mes. Incluir na comp total |
-| **PLR** (Participacao nos Lucros e Resultados) | Bonus atrelado a resultados da empresa | Pode ser 1-3 salarios extras/ano. Variavel — ponderar com cautela |
+| **CLT** (Consolidação das Leis do Trabalho) | Contrato formal com carteira assinada | Inclui FGTS, INSS, férias, 13º, aviso prévio. Na comparação, considerar o custo total empregador |
+| **PJ** (Pessoa Jurídica) | Contratação como prestador de serviços (nota fiscal) | Valor mensal mais alto, mas sem benefícios CLT. Calcular equivalente CLT para comparação justa |
+| **13º Salário** | Pagamento extra obrigatório para CLT | Comp CLT = salário x 13 (ou 13,33 com 1/3 de férias). NUNCA esquecer na comparação |
+| **FGTS** (Fundo de Garantia) | 8% do salário depositado pelo empregador | Benefício CLT, não aparece no contra-cheque mas é remuneração real |
+| **Vale-Refeição / Vale-Alimentação** | Benefício alimentação (iFood, Sodexo, Alelo) | Comum em vagas CLT, pode chegar a R$ 1.500+/mês. Incluir na comp total |
+| **PLR** (Participação nos Lucros e Resultados) | Bônus atrelado a resultados da empresa | Pode ser 1-3 salários extras/ano. Variável — ponderar com cautela |
 | **Stock Options / VSOP** | Equity em startups | Comum em startups brasileiras. Avaliar vesting, cliff e liquidez |
-| **Periodo de Experiencia** | 45+45 dias (CLT) ou conforme contrato (PJ) | Padrao de mercado, nao e red flag |
-| **Aviso Previo** | 30 dias (CLT) + 3 dias por ano trabalhado | Planejar data de inicio conforme vinculo atual |
-| **Plano de Saude** | Beneficio medico (Amil, SulAmerica, Bradesco Saude) | Muito valorizado no Brasil. Sem plano = red flag em vagas CLT |
-| **Cooperativa / MEI** | Formas alternativas de contratacao | Avaliar com cautela — pode indicar precarizacao trabalhista |
+| **Período de Experiência** | 45+45 dias (CLT) ou conforme contrato (PJ) | Padrão de mercado, não é red flag |
+| **Aviso Prévio** | 30 dias (CLT) + 3 dias por ano trabalhado | Planejar data de início conforme vínculo atual |
+| **Plano de Saúde** | Benefício médico (Amil, SulAmérica, Bradesco Saúde) | Muito valorizado no Brasil. Sem plano = red flag em vagas CLT |
+| **Cooperativa / MEI** | Formas alternativas de contratação | Avaliar com cautela — pode indicar precarização trabalhista |
 
-### Scripts de Negociacao
+### Scripts de Negociação
 
-<!-- [PERSONALIZAR] Adapte para sua situacao -->
+<!-- [PERSONALIZAR] Adapte para sua situação -->
 
-**Pretensao salarial (framework geral):**
-> "Com base em dados atuais de mercado para essa vaga, minha expectativa esta na faixa de [FAIXA do profile.yml]. Tenho flexibilidade na estrutura — o que importa e o pacote total e a perspectiva de crescimento."
+**Pretensão salarial (framework geral):**
+> "Com base em dados atuais de mercado para essa vaga, minha expectativa está na faixa de [FAIXA do profile.yml]. Tenho flexibilidade na estrutura — o que importa é o pacote total e a perspectiva de crescimento."
 
-**Pushback contra desconto geografico:**
-> "As vagas em que estou concorrendo sao orientadas a resultados, nao a localizacao. Meu track record nao muda com o CEP."
+**Pushback contra desconto geográfico:**
+> "As vagas em que estou concorrendo são orientadas a resultados, não a localização. Meu track record não muda com o CEP."
 
-**Quando a oferta esta abaixo do alvo:**
-> "Estou comparando com ofertas na faixa de [faixa mais alta]. [Empresa] me atrai por [motivo]. E possivel chegarmos em [valor-alvo] juntos?"
+**Quando a oferta está abaixo do alvo:**
+> "Estou comparando com ofertas na faixa de [faixa mais alta]. [Empresa] me atrai por [motivo]. É possível chegarmos em [valor-alvo] juntos?"
 
 **CLT vs PJ:**
-> "Para comparar de forma justa, preciso entender a composicao completa: salario-base, 13o, ferias, FGTS, vale-refeicao, plano de saude e PLR. Se for PJ, qual o valor mensal equivalente considerando esses itens?"
+> "Para comparar de forma justa, preciso entender a composição completa: salário-base, 13º, férias, FGTS, vale-refeição, plano de saúde e PLR. Se for PJ, qual o valor mensal equivalente considerando esses itens?"
 
-### Politica de Localizacao (Location Policy)
+### Política de Localização (Location Policy)
 
-<!-- [PERSONALIZAR] Adapte para sua situacao. Lido de config/profile.yml -> location -->
+<!-- [PERSONALIZAR] Adapte para sua situação. Lido de config/profile.yml -> location -->
 
-**Em formularios:**
-- Perguntas binarias "Voce pode trabalhar presencialmente?": responder conforme disponibilidade real de `profile.yml`
-- Em campos de texto livre: informar fuso horario e disponibilidade explicitamente
+**Em formulários:**
+- Perguntas binárias "Você pode trabalhar presencialmente?": responder conforme disponibilidade real de `profile.yml`
+- Em campos de texto livre: informar fuso horário e disponibilidade explicitamente
 
-**Em avaliacoes (Scoring):**
-- Dimensao remoto em hibrido fora do seu estado/pais: Score **3.0** (nao 1.0)
-- Score 1.0 apenas se a vaga diz explicitamente "deve estar presencial 4-5 dias/semana, sem excecoes"
+**Em avaliações (Scoring):**
+- Dimensão remoto em híbrido fora do seu estado/país: Score **3.0** (não 1.0)
+- Score 1.0 apenas se a vaga diz explicitamente "deve estar presencial 4-5 dias/semana, sem exceções"
 
 ### Prioridade Time-to-Offer
-- Demo funcional + metricas > perfeicao
-- Aplicar mais rapido > aprender mais
+- Demo funcional + métricas > perfeição
+- Aplicar mais rápido > aprender mais
 - Abordagem 80/20, tudo com prazo definido
 
 ---
@@ -180,28 +180,28 @@ Em vagas e negociacoes brasileiras, existem termos e praticas que nao aparecem n
 
 ### NUNCA
 
-1. Inventar experiencia ou metricas
+1. Inventar experiência ou métricas
 2. Modificar `cv.md` ou arquivos do portfolio
 3. Enviar candidaturas em nome do candidato
-4. Compartilhar numero de telefone em mensagens geradas
-5. Recomendar remuneracao abaixo do mercado
-6. Gerar PDF sem ter lido a descricao da vaga antes
-7. Usar jargao corporativo ou "corporates"
-8. Ignorar o tracker (toda vaga avaliada e registrada)
+4. Compartilhar número de telefone em mensagens geradas
+5. Recomendar remuneração abaixo do mercado
+6. Gerar PDF sem ter lido a descrição da vaga antes
+7. Usar jargão corporativo ou "corporates"
+8. Ignorar o tracker (toda vaga avaliada é registrada)
 
 ### SEMPRE
 
-0. **Carta de apresentacao:** Se o formulario permite anexar ou escrever uma carta, SEMPRE inclua uma. PDF no mesmo design visual do curriculo. Conteudo: citacoes da descricao da vaga mapeadas para proof points, links para case studies relevantes. Maximo 1 pagina.
+0. **Carta de apresentação:** Se o formulário permite anexar ou escrever uma carta, SEMPRE inclua uma. PDF no mesmo design visual do currículo. Conteúdo: citações da descrição da vaga mapeadas para proof points, links para case studies relevantes. Máximo 1 página.
 1. Ler `cv.md`, `_profile.md` e `article-digest.md` (se existir) antes de avaliar qualquer vaga
-1b. **Na primeira avaliacao de cada sessao:** Executar `node cv-sync-check.mjs` via Bash. Se houver avisos, informar o candidato antes de continuar
-2. Detectar o arquetipo da vaga e adaptar o framing conforme `_profile.md`
-3. Ao fazer matching, citar linhas exatas do curriculo
-4. Usar WebSearch para dados de remuneracao e empresa
-5. Registrar no tracker apos cada avaliacao
-6. Gerar conteudo na lingua da descricao da vaga (PT-BR padrao)
-7. Ser direto e pratico — sem enrolacao
-8. Ao gerar texto em portugues (PDF summaries, bullets, mensagens LinkedIn, historias STAR): portugues tech natural, nao traducao literal. Frases curtas, verbos de acao, evitar voz passiva. Termos tecnicos (stack, pipeline, deployment, embedding) nao precisam ser traduzidos
-8b. **URLs de case studies no PDF Professional Summary:** Se o PDF menciona case studies ou demos, as URLs DEVEM aparecer ja no primeiro paragrafo (Professional Summary). Recrutadores frequentemente so leem o resumo. Todos os URLs no HTML com `white-space: nowrap`
+1b. **Na primeira avaliação de cada sessão:** Executar `node cv-sync-check.mjs` via Bash. Se houver avisos, informar o candidato antes de continuar
+2. Detectar o arquétipo da vaga e adaptar o framing conforme `_profile.md`
+3. Ao fazer matching, citar linhas exatas do currículo
+4. Usar WebSearch para dados de remuneração e empresa
+5. Registrar no tracker após cada avaliação
+6. Gerar conteúdo na língua da descrição da vaga (PT-BR padrão)
+7. Ser direto e prático — sem enrolação
+8. Ao gerar texto em português (PDF summaries, bullets, mensagens LinkedIn, histórias STAR): português tech natural, não tradução literal. Frases curtas, verbos de ação, evitar voz passiva. Termos técnicos (stack, pipeline, deployment, embedding) não precisam ser traduzidos
+8b. **URLs de case studies no PDF Professional Summary:** Se o PDF menciona case studies ou demos, as URLs DEVEM aparecer já no primeiro parágrafo (Professional Summary). Recrutadores frequentemente só leem o resumo. Todos os URLs no HTML com `white-space: nowrap`
 9. **Entradas no tracker como TSV** — NUNCA editar `applications.md` diretamente para novos registros. Escrever TSV em `batch/tracker-additions/`, `merge-tracker.mjs` cuida do merge
 10. **Incluir `**URL:**` em todo header de report** — entre Score e PDF
 
@@ -209,10 +209,10 @@ Em vagas e negociacoes brasileiras, existem termos e praticas que nao aparecem n
 
 | Tool | Uso |
 |------|-----|
-| WebSearch | Pesquisa de remuneracao, tendencias, cultura da empresa, contatos LinkedIn, fallback para descricoes de vagas |
-| WebFetch | Fallback para extrair descricoes de vagas de paginas estaticas |
-| Playwright | Verificar se vagas ainda estao ativas (browser_navigate + browser_snapshot), extrair descricoes de SPAs. **CRITICO: NUNCA iniciar 2+ agentes com Playwright em paralelo — eles compartilham a mesma instancia do navegador** |
+| WebSearch | Pesquisa de remuneração, tendências, cultura da empresa, contatos LinkedIn, fallback para descrições de vagas |
+| WebFetch | Fallback para extrair descrições de vagas de páginas estáticas |
+| Playwright | Verificar se vagas ainda estão ativas (browser_navigate + browser_snapshot), extrair descrições de SPAs. **CRÍTICO: NUNCA iniciar 2+ agentes com Playwright em paralelo — eles compartilham a mesma instância do navegador** |
 | Read | cv.md, _profile.md, article-digest.md, cv-template.html |
-| Write | HTML temporario para PDF, applications.md, reports .md |
+| Write | HTML temporário para PDF, applications.md, reports .md |
 | Edit | Atualizar tracker |
 | Bash | `node generate-pdf.mjs` |

--- a/modes/pt/_shared.md
+++ b/modes/pt/_shared.md
@@ -213,6 +213,6 @@ Em vagas e negociações brasileiras, existem termos e práticas que não aparec
 | WebFetch | Fallback para extrair descrições de vagas de páginas estáticas |
 | Playwright | Verificar se vagas ainda estão ativas (browser_navigate + browser_snapshot), extrair descrições de SPAs. **CRÍTICO: NUNCA iniciar 2+ agentes com Playwright em paralelo — eles compartilham a mesma instância do navegador** |
 | Read | cv.md, _profile.md, article-digest.md, cv-template.html |
-| Write | HTML temporário para PDF, applications.md, reports .md |
-| Edit | Atualizar tracker |
-| Bash | `node generate-pdf.mjs` |
+| Write | HTML temporário para PDF, reports .md, TSV em `batch/tracker-additions/` |
+| Edit | Ajustes de conteúdo (não usar para criar novos registros no tracker) |
+| Bash | `node generate-pdf.mjs`, `node merge-tracker.mjs` |

--- a/modes/pt/aplicar.md
+++ b/modes/pt/aplicar.md
@@ -1,93 +1,93 @@
 # Modo: aplicar -- Assistente de Candidatura ao Vivo
 
-Modo interativo para quando o candidato esta preenchendo um formulario de candidatura no Chrome. Le o que esta na tela, carrega o contexto da avaliacao previa da vaga e gera respostas personalizadas para cada pergunta do formulario.
+Modo interativo para quando o candidato está preenchendo um formulário de candidatura no Chrome. Lê o que está na tela, carrega o contexto da avaliação prévia da vaga e gera respostas personalizadas para cada pergunta do formulário.
 
 ## Requisitos
 
-- **Melhor com Playwright visivel**: No modo visivel, o candidato ve o navegador e Claude pode interagir com a pagina.
+- **Melhor com Playwright visível**: No modo visível, o candidato vê o navegador e Claude pode interagir com a página.
 - **Sem Playwright**: o candidato compartilha um screenshot ou cola as perguntas manualmente.
 
 ## Workflow
 
 ```
-1. DETECTAR    → Ler aba ativa do Chrome (screenshot/URL/titulo)
-2. IDENTIFICAR → Extrair empresa + vaga da pagina
+1. DETECTAR    → Ler aba ativa do Chrome (screenshot/URL/título)
+2. IDENTIFICAR → Extrair empresa + vaga da página
 3. BUSCAR      → Match contra reports existentes em reports/
 4. CARREGAR    → Ler report completo + Bloco G (se existir)
 5. COMPARAR    → A vaga na tela coincide com a avaliada? Se mudou → avisar
-6. ANALISAR    → Identificar TODAS as perguntas visiveis do formulario
+6. ANALISAR    → Identificar TODAS as perguntas visíveis do formulário
 7. GERAR       → Para cada pergunta, gerar resposta personalizada
 8. APRESENTAR  → Mostrar respostas formatadas para copy-paste
 ```
 
 ## Passo 1 -- Detectar a vaga
 
-**Com Playwright:** Tirar snapshot da pagina ativa. Ler titulo, URL e conteudo visivel.
+**Com Playwright:** Tirar snapshot da página ativa. Ler título, URL e conteúdo visível.
 
 **Sem Playwright:** Pedir ao candidato que:
-- Compartilhe um screenshot do formulario (o Read tool le imagens)
-- Ou cole as perguntas do formulario como texto
+- Compartilhe um screenshot do formulário (o Read tool lê imagens)
+- Ou cole as perguntas do formulário como texto
 - Ou diga empresa + vaga para buscarmos o contexto
 
 ## Passo 2 -- Identificar e buscar contexto
 
-1. Extrair nome da empresa e titulo da vaga da pagina
+1. Extrair nome da empresa e título da vaga da página
 2. Buscar em `reports/` pelo nome da empresa (Grep case-insensitive)
 3. Se houver match → carregar o report completo
 4. Se houver Bloco G → carregar os rascunhos de respostas anteriores como base
-5. Se NAO houver match → avisar e oferecer executar auto-pipeline rapida
+5. Se NÃO houver match → avisar e oferecer executar auto-pipeline rápida
 
-## Passo 3 -- Detectar mudancas na vaga
+## Passo 3 -- Detectar mudanças na vaga
 
 Se a vaga na tela difere da avaliada:
-- **Avisar o candidato**: "A vaga mudou de [X] para [Y]. Quer que eu reavalie ou adapto as respostas ao novo titulo?"
-- **Se adaptar**: Ajustar as respostas ao novo titulo sem reavaliar
-- **Se reavaliar**: Executar avaliacao completa A-F, atualizar report, regenerar Bloco G
-- **Atualizar tracker**: Alterar titulo da vaga em `applications.md` se necessario
+- **Avisar o candidato**: "A vaga mudou de [X] para [Y]. Quer que eu reavalie ou adapto as respostas ao novo título?"
+- **Se adaptar**: Ajustar as respostas ao novo título sem reavaliar
+- **Se reavaliar**: Executar avaliação completa A-F, atualizar report, regenerar Bloco G
+- **Atualizar tracker**: Alterar título da vaga em `applications.md` se necessário
 
-## Passo 4 -- Analisar perguntas do formulario
+## Passo 4 -- Analisar perguntas do formulário
 
-Identificar TODAS as perguntas visiveis:
-- Campos de texto livre (carta de apresentacao, por que essa vaga, motivacao, etc.)
-- Dropdowns (como ficou sabendo da vaga, autorizacao de trabalho, etc.)
-- Sim/Nao (mudanca de cidade, visto, disponibilidade, etc.)
-- Campos de salario (faixa, pretensao salarial)
-- Campos de upload (curriculo, carta de apresentacao em PDF)
+Identificar TODAS as perguntas visíveis:
+- Campos de texto livre (carta de apresentação, por que essa vaga, motivação, etc.)
+- Dropdowns (como ficou sabendo da vaga, autorização de trabalho, etc.)
+- Sim/Não (mudança de cidade, visto, disponibilidade, etc.)
+- Campos de salário (faixa, pretensão salarial)
+- Campos de upload (currículo, carta de apresentação em PDF)
 
 Classificar cada pergunta:
-- **Ja respondida no Bloco G** → adaptar a resposta existente
+- **Já respondida no Bloco G** → adaptar a resposta existente
 - **Pergunta nova** → gerar resposta a partir do report + `cv.md`
 
 ## Passo 5 -- Gerar respostas
 
 Para cada pergunta, gerar a resposta seguindo:
 
-1. **Contexto do report**: Usar proof points do Bloco B, historias STAR do Bloco F
+1. **Contexto do report**: Usar proof points do Bloco B, histórias STAR do Bloco F
 2. **Bloco G anterior**: Se existe um rascunho, usar como base e refinar
-3. **Tom "Estou escolhendo voces"**: Mesmo framework da auto-pipeline — confiante, nao suplicante
-4. **Especificidade**: Referenciar algo concreto do JD visivel na tela
-5. **career-ops proof point**: Incluir em "Informacoes adicionais" se houver campo para isso
+3. **Tom "Estou escolhendo vocês"**: Mesmo framework da auto-pipeline — confiante, não suplicante
+4. **Especificidade**: Referenciar algo concreto do JD visível na tela
+5. **career-ops proof point**: Incluir em "Informações adicionais" se houver campo para isso
 
-**Campos especificos do mercado brasileiro que aparecem com frequencia:**
-- **Pretensao salarial (bruto, mensal ou anual)** → Faixa de `profile.yml`, em BRL, com nota "negociavel conforme pacote total"
-- **Regime de contratacao preferido (CLT/PJ)** → Responder conforme `profile.yml`, ou "aberto a ambos" se aplicavel
-- **Disponibilidade / prazo para inicio** → Data realista considerando aviso previo atual (CLT: 30 dias + 3 dias/ano)
-- **Autorizacao de trabalho** → Responder com clareza; se brasileiro: "Cidadao brasileiro, nao necessita autorizacao"
-- **Idiomas** → Informar nivel por idioma (nativo, fluente, intermediario, basico)
+**Campos específicos do mercado brasileiro que aparecem com frequência:**
+- **Pretensão salarial (bruto, mensal ou anual)** → Faixa de `profile.yml`, em BRL, com nota "negociável conforme pacote total"
+- **Regime de contratação preferido (CLT/PJ)** → Responder conforme `profile.yml`, ou "aberto a ambos" se aplicável
+- **Disponibilidade / prazo para início** → Data realista considerando aviso prévio atual (CLT: 30 dias + 3 dias/ano)
+- **Autorização de trabalho** → Responder com clareza; se brasileiro: "Cidadão brasileiro, não necessita autorização"
+- **Idiomas** → Informar nível por idioma (nativo, fluente, intermediário, básico)
 
 **Formato de output:**
 
 ```
 ## Respostas para [Empresa] -- [Vaga]
 
-Base: Report #NNN | Score: X.X/5 | Arquetipo: [tipo]
+Base: Report #NNN | Score: X.X/5 | Arquétipo: [tipo]
 
 ---
 
-### 1. [Pergunta exata do formulario]
+### 1. [Pergunta exata do formulário]
 > [Resposta pronta para copy-paste]
 
-### 2. [Proxima pergunta]
+### 2. [Próxima pergunta]
 > [Resposta]
 
 ...
@@ -95,20 +95,20 @@ Base: Report #NNN | Score: X.X/5 | Arquetipo: [tipo]
 ---
 
 Notas:
-- [Qualquer observacao sobre a vaga, mudancas, etc.]
-- [Sugestoes de personalizacao que o candidato deveria revisar]
+- [Qualquer observação sobre a vaga, mudanças, etc.]
+- [Sugestões de personalização que o candidato deveria revisar]
 ```
 
-## Passo 6 -- Pos-candidatura (opcional)
+## Passo 6 -- Pós-candidatura (opcional)
 
 Se o candidato confirmar que enviou a candidatura:
 1. Atualizar status em `applications.md` de "Evaluated" para "Applied"
 2. Atualizar Bloco G do report com as respostas finais
-3. Sugerir proximo passo: `/career-ops contacto` para LinkedIn outreach
+3. Sugerir próximo passo: `/career-ops contacto` para LinkedIn outreach
 
 ## Scroll handling
 
-Se o formulario tem mais perguntas do que as visiveis:
+Se o formulário tem mais perguntas do que as visíveis:
 - Pedir ao candidato para dar scroll e compartilhar outro screenshot
 - Ou colar as perguntas restantes
-- Processar em iteracoes ate cobrir todo o formulario
+- Processar em iterações até cobrir todo o formulário

--- a/modes/pt/oferta.md
+++ b/modes/pt/oferta.md
@@ -1,119 +1,119 @@
-# Modo: oferta -- Avaliacao Completa A-F
+# Modo: oferta -- Avaliação Completa A-F
 
 Quando o candidato cola uma vaga (texto ou URL), entregar SEMPRE os 6 blocos:
 
-## Passo 0 -- Deteccao de Arquetipo
+## Passo 0 -- Detecção de Arquétipo
 
-Classificar a vaga em um dos 6 arquetipos (ver `_shared.md`). Se for hibrido, indicar os 2 mais proximos. Isso determina:
+Classificar a vaga em um dos 6 arquétipos (ver `_shared.md`). Se for híbrido, indicar os 2 mais próximos. Isso determina:
 - Quais proof points priorizar no bloco B
 - Como reescrever o summary no bloco E
-- Quais historias STAR preparar no bloco F
+- Quais histórias STAR preparar no bloco F
 
 ## Bloco A -- Resumo da Vaga
 
 Tabela com:
-- Arquetipo detectado
+- Arquétipo detectado
 - Domain (platform/agentic/LLMOps/ML/enterprise)
-- Funcao (build/consult/manage/deploy)
+- Função (build/consult/manage/deploy)
 - Senioridade
-- Remoto (full/hibrido/presencial)
+- Remoto (full/híbrido/presencial)
 - Tamanho do time (se mencionado)
 - TL;DR em 1 frase
 
-## Bloco B -- Match com o Curriculo
+## Bloco B -- Match com o Currículo
 
-Ler `cv.md`. Criar tabela com cada requisito do JD mapeado para linhas exatas do curriculo.
+Ler `cv.md`. Criar tabela com cada requisito do JD mapeado para linhas exatas do currículo.
 
-**Adaptado ao arquetipo:**
-- Se FDE → priorizar proof points de entrega rapida e proximidade com cliente
-- Se SA → priorizar design de sistemas e integracoes
-- Se PM → priorizar product discovery e metricas
+**Adaptado ao arquétipo:**
+- Se FDE → priorizar proof points de entrega rápida e proximidade com cliente
+- Se SA → priorizar design de sistemas e integrações
+- Se PM → priorizar product discovery e métricas
 - Se LLMOps → priorizar evals, observability, pipelines
-- Se Agentic → priorizar multi-agent, HITL, orquestracao
-- Se Transformation → priorizar gestao de mudanca, adocao, escalabilidade
+- Se Agentic → priorizar multi-agent, HITL, orquestração
+- Se Transformation → priorizar gestão de mudança, adoção, escalabilidade
 
-Secao de **gaps** com estrategia de mitigacao para cada um. Para cada gap:
-1. E um hard blocker ou um nice-to-have?
-2. O candidato consegue demonstrar experiencia adjacente?
+Seção de **gaps** com estratégia de mitigação para cada um. Para cada gap:
+1. É um hard blocker ou um nice-to-have?
+2. O candidato consegue demonstrar experiência adjacente?
 3. Existe um projeto do portfolio que cubra esse gap?
-4. Plano de mitigacao concreto (frase para carta de apresentacao, projeto rapido, etc.)
+4. Plano de mitigação concreto (frase para carta de apresentação, projeto rápido, etc.)
 
-## Bloco C -- Nivel e Estrategia
+## Bloco C -- Nível e Estratégia
 
-1. **Nivel detectado** no JD vs **nivel natural do candidato para esse arquetipo**
-2. **Plano "vender senior sem mentir"**: frases especificas adaptadas ao arquetipo, conquistas concretas a destacar, como posicionar experiencia de founder como vantagem
-3. **Plano "se me downlevelearem"**: aceitar se a remuneracao for justa, negociar revisao em 6 meses, criterios claros de promocao
+1. **Nível detectado** no JD vs **nível natural do candidato para esse arquétipo**
+2. **Plano "vender senior sem mentir"**: frases específicas adaptadas ao arquétipo, conquistas concretas a destacar, como posicionar experiência de founder como vantagem
+3. **Plano "se me downlevelearem"**: aceitar se a remuneração for justa, negociar revisão em 6 meses, critérios claros de promoção
 
-## Bloco D -- Remuneracao e Demanda
+## Bloco D -- Remuneração e Demanda
 
 Usar WebSearch para:
-- Salarios atuais da vaga (Glassdoor, Levels.fyi, Blind, Glassdoor BR)
-- Reputacao de remuneracao da empresa
-- Tendencia de demanda da vaga
+- Salários atuais da vaga (Glassdoor, Levels.fyi, Blind, Glassdoor BR)
+- Reputação de remuneração da empresa
+- Tendência de demanda da vaga
 
-Tabela com dados e fontes citadas. Se nao houver dados, dizer isso em vez de inventar.
+Tabela com dados e fontes citadas. Se não houver dados, dizer isso em vez de inventar.
 
-**Mercado Brasileiro -- Checks obrigatorios:**
-- CLT ou PJ? Se CLT: considerar 13o, ferias, FGTS, plano de saude, VR/VA na comparacao.
+**Mercado Brasileiro -- Checks obrigatórios:**
+- CLT ou PJ? Se CLT: considerar 13º, férias, FGTS, plano de saúde, VR/VA na comparação.
 - Se PJ: qual o valor mensal? Calcular equivalente CLT.
-- PLR mencionado? Quantos salarios extras?
+- PLR mencionado? Quantos salários extras?
 - Stock options / VSOP? Avaliar vesting, cliff e liquidez.
-- Vale-refeicao / vale-alimentacao? Valor mensal?
-- Plano de saude? Coparticipacao ou integral?
+- Vale-refeição / vale-alimentação? Valor mensal?
+- Plano de saúde? Coparticipação ou integral?
 
-## Bloco E -- Plano de Personalizacao
+## Bloco E -- Plano de Personalização
 
-| # | Secao | Estado atual | Mudanca proposta | Por que |
+| # | Seção | Estado atual | Mudança proposta | Por que |
 |---|-------|-------------|------------------|---------|
 | 1 | Summary | ... | ... | ... |
 | ... | ... | ... | ... | ... |
 
-Top 5 mudancas no curriculo + Top 5 mudancas no LinkedIn para maximizar o match.
+Top 5 mudanças no currículo + Top 5 mudanças no LinkedIn para maximizar o match.
 
 ## Bloco F -- Plano de Entrevistas
 
-6-10 historias STAR+R mapeadas para requisitos do JD (STAR + **Reflection**):
+6-10 histórias STAR+R mapeadas para requisitos do JD (STAR + **Reflection**):
 
-| # | Requisito do JD | Historia STAR+R | S | T | A | R | Reflection |
+| # | Requisito do JD | História STAR+R | S | T | A | R | Reflection |
 |---|----------------|-----------------|---|---|---|---|------------|
 
-A coluna **Reflection** captura o que foi aprendido ou o que seria feito diferente. Isso sinaliza senioridade — candidatos juniores descrevem o que aconteceu, candidatos seniores extraem licoes.
+A coluna **Reflection** captura o que foi aprendido ou o que seria feito diferente. Isso sinaliza senioridade — candidatos juniores descrevem o que aconteceu, candidatos seniores extraem lições.
 
-**Story Bank:** Se `interview-prep/story-bank.md` existir, verificar se alguma dessas historias ja esta la. Se nao, adicionar as novas. Com o tempo, isso constroi um banco reutilizavel de 5-10 historias-mestre que podem ser adaptadas para qualquer pergunta de entrevista.
+**Story Bank:** Se `interview-prep/story-bank.md` existir, verificar se alguma dessas histórias já está lá. Se não, adicionar as novas. Com o tempo, isso constrói um banco reutilizável de 5-10 histórias-mestre que podem ser adaptadas para qualquer pergunta de entrevista.
 
-**Selecionadas e enquadradas conforme o arquetipo:**
+**Selecionadas e enquadradas conforme o arquétipo:**
 - FDE → enfatizar velocidade de entrega e proximidade com cliente
-- SA → enfatizar decisoes de arquitetura
+- SA → enfatizar decisões de arquitetura
 - PM → enfatizar discovery e trade-offs
-- LLMOps → enfatizar metricas, evals, production hardening
-- Agentic → enfatizar orquestracao, tratamento de erros, HITL
-- Transformation → enfatizar adocao e mudanca organizacional
+- LLMOps → enfatizar métricas, evals, production hardening
+- Agentic → enfatizar orquestração, tratamento de erros, HITL
+- Transformation → enfatizar adoção e mudança organizacional
 
-Incluir tambem:
+Incluir também:
 - 1 case study recomendado (qual projeto apresentar e como)
-- Perguntas red-flag e como responde-las (ex: "Por que voce vendeu sua empresa?", "Voce tinha reports diretos?")
+- Perguntas red-flag e como respondê-las (ex: "Por que você vendeu sua empresa?", "Você tinha reports diretos?")
 
 ---
 
-## Pos-avaliacao
+## Pós-avaliação
 
-**SEMPRE** apos gerar os blocos A-F:
+**SEMPRE** após gerar os blocos A-F:
 
 ### 1. Salvar report .md
 
-Salvar avaliacao completa em `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+Salvar avaliação completa em `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 
-- `{###}` = proximo numero sequencial (3 digitos, zero-padded)
-- `{company-slug}` = nome da empresa em lowercase, sem espacos (usar hifens)
+- `{###}` = próximo número sequencial (3 dígitos, zero-padded)
+- `{company-slug}` = nome da empresa em lowercase, sem espaços (usar hifens)
 - `{YYYY-MM-DD}` = data atual
 
 **Formato do report:**
 
 ```markdown
-# Avaliacao: {Empresa} -- {Vaga}
+# Avaliação: {Empresa} -- {Vaga}
 
 **Data:** {YYYY-MM-DD}
-**Arquetipo:** {detectado}
+**Arquétipo:** {detectado}
 **Score:** {X/5}
 **URL:** {URL da vaga}
 **PDF:** {caminho ou pendente}
@@ -121,40 +121,40 @@ Salvar avaliacao completa em `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 ---
 
 ## A) Resumo da Vaga
-(conteudo completo do bloco A)
+(conteúdo completo do bloco A)
 
-## B) Match com o Curriculo
-(conteudo completo do bloco B)
+## B) Match com o Currículo
+(conteúdo completo do bloco B)
 
-## C) Nivel e Estrategia
-(conteudo completo do bloco C)
+## C) Nível e Estratégia
+(conteúdo completo do bloco C)
 
-## D) Remuneracao e Demanda
-(conteudo completo do bloco D)
+## D) Remuneração e Demanda
+(conteúdo completo do bloco D)
 
-## E) Plano de Personalizacao
-(conteudo completo do bloco E)
+## E) Plano de Personalização
+(conteúdo completo do bloco E)
 
 ## F) Plano de Entrevistas
-(conteudo completo do bloco F)
+(conteúdo completo do bloco F)
 
 ## G) Rascunhos de Respostas para Candidatura
-(apenas se score >= 4.5 -- rascunhos de respostas para o formulario de candidatura)
+(apenas se score >= 4.5 -- rascunhos de respostas para o formulário de candidatura)
 
 ---
 
-## Keywords extraidas
-(lista de 15-20 keywords do JD para otimizacao ATS)
+## Keywords extraídas
+(lista de 15-20 keywords do JD para otimização ATS)
 ```
 
 ### 2. Registrar no tracker
 
 **SEMPRE** registrar em `data/applications.md`:
-- Proximo numero sequencial
+- Próximo número sequencial
 - Data atual
 - Empresa
 - Vaga
-- Score: media do match (1-5)
+- Score: média do match (1-5)
 - Status: `Evaluated`
 - PDF: ❌ (ou ✅ se a auto-pipeline gerou PDF)
 - Report: link relativo ao report .md (ex: `[001](reports/001-company-2026-01-01.md)`)

--- a/modes/pt/pipeline.md
+++ b/modes/pt/pipeline.md
@@ -4,18 +4,18 @@ Processa URLs de vagas acumuladas em `data/pipeline.md`. O candidato adiciona UR
 
 ## Workflow
 
-1. **Ler** `data/pipeline.md` → buscar itens `- [ ]` na secao "Pendentes"
+1. **Ler** `data/pipeline.md` → buscar itens `- [ ]` na seção "Pendentes"
 2. **Para cada URL pendente**:
-   a. Calcular proximo `REPORT_NUM` sequencial (ler `reports/`, pegar o numero mais alto + 1)
+   a. Calcular próximo `REPORT_NUM` sequencial (ler `reports/`, pegar o número mais alto + 1)
    b. **Extrair JD** usando Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
-   c. Se a URL nao for acessivel → marcar como `- [!]` com nota e continuar
-   d. **Executar auto-pipeline completa**: Avaliacao A-F → Report .md → PDF (se score >= 3.0) → Tracker
+   c. Se a URL não for acessível → marcar como `- [!]` com nota e continuar
+   d. **Executar auto-pipeline completa**: Avaliação A-F → Report .md → PDF (se score >= 3.0) → Tracker
    e. **Mover de "Pendentes" para "Processadas"**: `- [x] #NNN | URL | Empresa | Vaga | Score/5 | PDF ✅/❌`
-3. **Se houver 3+ URLs pendentes**, lancar agentes em paralelo (Agent tool com `run_in_background`) para maximizar velocidade.
+3. **Se houver 3+ URLs pendentes**, lançar agentes em paralelo (Agent tool com `run_in_background`) para maximizar velocidade.
 4. **Ao terminar**, mostrar tabela resumo:
 
 ```
-| # | Empresa | Vaga | Score | PDF | Acao recomendada |
+| # | Empresa | Vaga | Score | PDF | Ação recomendada |
 ```
 
 ## Formato de pipeline.md
@@ -24,41 +24,41 @@ Processa URLs de vagas acumuladas em `data/pipeline.md`. O candidato adiciona UR
 ## Pendentes
 - [ ] https://jobs.example.com/posting/123
 - [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
-- [!] https://private.url/job — Erro: login necessario
+- [!] https://private.url/job — Erro: login necessário
 
 ## Processadas
 - [x] #143 | https://jobs.example.com/posting/789 | Acme Corp | AI PM | 4.2/5 | PDF ✅
 - [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF ❌
 ```
 
-> Nota: Os titulos das secoes podem estar em EN ("Pending"/"Processed"), ES ("Pendientes"/"Procesadas"), DE ("Offen"/"Verarbeitet") ou PT-BR ("Pendentes"/"Processadas"). Ao ler, ser flexivel; ao escrever, manter o estilo da arquivo existente.
+> Nota: Os títulos das seções podem estar em EN ("Pending"/"Processed"), ES ("Pendientes"/"Procesadas"), DE ("Offen"/"Verarbeitet") ou PT-BR ("Pendentes"/"Processadas"). Ao ler, ser flexível; ao escrever, manter o estilo do arquivo existente.
 
-## Deteccao inteligente de JD a partir da URL
+## Detecção inteligente de JD a partir da URL
 
 1. **Playwright (preferido):** `browser_navigate` + `browser_snapshot`. Funciona com todas as SPAs.
-2. **WebFetch (fallback):** Para paginas estaticas ou quando Playwright nao esta disponivel.
-3. **WebSearch (ultimo recurso):** Buscar em portais secundarios que indexam o JD.
+2. **WebFetch (fallback):** Para páginas estáticas ou quando Playwright não está disponível.
+3. **WebSearch (último recurso):** Buscar em portais secundários que indexam o JD.
 
 **Casos especiais:**
 - **LinkedIn**: Pode exigir login → marcar com `[!]` e pedir ao candidato para colar o texto
 - **PDF**: Se a URL aponta para um PDF, ler diretamente com o Read tool
 - **`local:` prefix**: Ler arquivo local. Exemplo: `local:jds/linkedin-pm-ai.md` → ler `jds/linkedin-pm-ai.md`
 - **Gupy / Greenhouse / Lever**: Plataformas comuns no Brasil. Playwright funciona bem com todas
-- **Vagas.com.br / InfoJobs / Catho**: Portais brasileiros, geralmente acessiveis via WebFetch
-- **LinkedIn BR**: Mesmas restricoes do LinkedIn global — pode exigir login
+- **Vagas.com.br / InfoJobs / Catho**: Portais brasileiros, geralmente acessíveis via WebFetch
+- **LinkedIn BR**: Mesmas restrições do LinkedIn global — pode exigir login
 
-## Numeracao automatica
+## Numeração automática
 
 1. Listar todos os arquivos em `reports/`
-2. Extrair o numero do prefixo (ex: `142-medispend...` → 142)
-3. Novo numero = maximo encontrado + 1
+2. Extrair o número do prefixo (ex: `142-medispend...` → 142)
+3. Novo número = máximo encontrado + 1
 
-## Sincronizacao de fontes
+## Sincronização de fontes
 
-Antes de processar qualquer URL, verificar sincronizacao:
+Antes de processar qualquer URL, verificar sincronização:
 
 ```bash
 node cv-sync-check.mjs
 ```
 
-Se houver dessincronizacao, avisar o candidato antes de continuar.
+Se houver dessincronização, avisar o candidato antes de continuar.

--- a/modes/pt/pipeline.md
+++ b/modes/pt/pipeline.md
@@ -11,7 +11,8 @@ Processa URLs de vagas acumuladas em `data/pipeline.md`. O candidato adiciona UR
    c. Se a URL não for acessível → marcar como `- [!]` com nota e continuar
    d. **Executar auto-pipeline completa**: Avaliação A-F → Report .md → PDF (se score >= 3.0) → Tracker
    e. **Mover de "Pendentes" para "Processadas"**: `- [x] #NNN | URL | Empresa | Vaga | Score/5 | PDF ✅/❌`
-3. **Se houver 3+ URLs pendentes**, lançar agentes em paralelo (Agent tool com `run_in_background`) para maximizar velocidade.
+3. **Se houver 3+ URLs pendentes**, lançar agentes em paralelo apenas para etapas sem Playwright (ex.: organização, WebSearch/WebFetch).
+   Se a extração exigir Playwright, processar serialmente (1 vaga por vez) para evitar conflito de sessão.
 4. **Ao terminar**, mostrar tabela resumo:
 
 ```


### PR DESCRIPTION
## What does this PR do?

Restores all missing Portuguese diacritical marks (ã, ç, é, ê, ó, ú, ão, ção) across the PT-BR modes directory. 

All 5 files in modes/pt/ had systematic stripping of accented characters — every word with ã, ç, é, ê, ó, ú was rendered without its diacritic. This affected verbatim template labels that appear in generated reports (e.g., ## B) Match com o Currículo, **Arquétipo:**, negociação, remuneração) and negotiation scripts used in candidate-facing output. 

## Related issue

 Fixes #358

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Portuguese documentation across multiple guides with corrected spelling, diacritics, punctuation, and standardized terminology for clearer, more consistent reading.
* **Chores**
  * Clarified pipeline behavior: parallel agents now run only for steps that don’t require Playwright; Playwright-dependent extraction is processed serially.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->