### PR TITLE
[codex] Use score as secondary dashboard sort

### DIFF
--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -444,24 +444,9 @@ func (m *PipelineModel) applyFilterAndSort() {
 	}
 
 	// Sort
-	switch m.sortMode {
-	case sortScore:
-		sort.SliceStable(filtered, func(i, j int) bool {
-			return filtered[i].Score > filtered[j].Score
-		})
-	case sortDate:
-		sort.SliceStable(filtered, func(i, j int) bool {
-			return filtered[i].Date > filtered[j].Date
-		})
-	case sortCompany:
-		sort.SliceStable(filtered, func(i, j int) bool {
-			return strings.ToLower(filtered[i].Company) < strings.ToLower(filtered[j].Company)
-		})
-	case sortStatus:
-		sort.SliceStable(filtered, func(i, j int) bool {
-			return data.StatusPriority(filtered[i].Status) < data.StatusPriority(filtered[j].Status)
-		})
-	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return m.lessBySortMode(filtered[i], filtered[j])
+	})
 
 	// In grouped mode, always sort by status priority first, then by selected sort within groups
 	if m.viewMode == "grouped" {
@@ -471,21 +456,66 @@ func (m *PipelineModel) applyFilterAndSort() {
 			if pi != pj {
 				return pi < pj
 			}
-			// Within same group, use selected sort
-			switch m.sortMode {
-			case sortScore:
-				return filtered[i].Score > filtered[j].Score
-			case sortDate:
-				return filtered[i].Date > filtered[j].Date
-			case sortCompany:
-				return strings.ToLower(filtered[i].Company) < strings.ToLower(filtered[j].Company)
-			default:
-				return filtered[i].Score > filtered[j].Score
-			}
+			return m.lessWithinStatusGroup(filtered[i], filtered[j])
 		})
 	}
 
 	m.filtered = filtered
+}
+
+// lessBySortMode keeps score as the secondary key for every non-score sort so
+// the highest-value jobs stay at the top when the primary field ties.
+func (m PipelineModel) lessBySortMode(left, right model.CareerApplication) bool {
+	switch m.sortMode {
+	case sortDate:
+		if left.Date != right.Date {
+			return left.Date > right.Date
+		}
+	case sortCompany:
+		leftCompany := strings.ToLower(left.Company)
+		rightCompany := strings.ToLower(right.Company)
+		if leftCompany != rightCompany {
+			return leftCompany < rightCompany
+		}
+	case sortStatus:
+		leftPriority := data.StatusPriority(left.Status)
+		rightPriority := data.StatusPriority(right.Status)
+		if leftPriority != rightPriority {
+			return leftPriority < rightPriority
+		}
+	case sortScore:
+		fallthrough
+	default:
+		return left.Score > right.Score
+	}
+
+	return left.Score > right.Score
+}
+
+// lessWithinStatusGroup applies the selected secondary sort inside one grouped
+// status bucket while still falling back to score when the chosen field ties.
+func (m PipelineModel) lessWithinStatusGroup(left, right model.CareerApplication) bool {
+	switch m.sortMode {
+	case sortDate:
+		if left.Date != right.Date {
+			return left.Date > right.Date
+		}
+	case sortCompany:
+		leftCompany := strings.ToLower(left.Company)
+		rightCompany := strings.ToLower(right.Company)
+		if leftCompany != rightCompany {
+			return leftCompany < rightCompany
+		}
+	case sortStatus:
+		// Status is already fixed by the group header, so score becomes the
+		// next meaningful ordering signal within that bucket.
+	case sortScore:
+		fallthrough
+	default:
+		return left.Score > right.Score
+	}
+
+	return left.Score > right.Score
 }
 
 // adjustScroll updates scrollOffset so the cursor stays visible.

--- a/dashboard/internal/ui/screens/pipeline_test.go
+++ b/dashboard/internal/ui/screens/pipeline_test.go
@@ -1,12 +1,30 @@
 package screens
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/santifer/career-ops/dashboard/internal/model"
 	"github.com/santifer/career-ops/dashboard/internal/theme"
 )
+
+func filteredNumbers(apps []model.CareerApplication) []int {
+	numbers := make([]int, 0, len(apps))
+	for _, app := range apps {
+		numbers = append(numbers, app.Number)
+	}
+	return numbers
+}
+
+func assertFilteredOrder(t *testing.T, apps []model.CareerApplication, want []int) {
+	t.Helper()
+
+	got := filteredNumbers(apps)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected filtered order %v, got %v", want, got)
+	}
+}
 
 func TestWithReloadedDataPreservesStateAndSelection(t *testing.T) {
 	initialApps := []model.CareerApplication{
@@ -93,4 +111,83 @@ func TestRenderAppLineIncludesDateColumn(t *testing.T) {
 	if !strings.Contains(line, "2026-04-13") {
 		t.Fatalf("expected rendered line to include date column, got %q", line)
 	}
+}
+
+func TestFlatNonScoreSortsUseScoreTieBreaker(t *testing.T) {
+	testCases := []struct {
+		name     string
+		sortMode string
+		apps     []model.CareerApplication
+		want     []int
+	}{
+		{
+			name:     "date",
+			sortMode: sortDate,
+			apps: []model.CareerApplication{
+				{Number: 101, Company: "Acme", Role: "Backend Engineer", Status: "Applied", Date: "2026-04-18", Score: 3.2},
+				{Number: 102, Company: "Zulu", Role: "AI Engineer", Status: "Applied", Date: "2026-04-18", Score: 4.8},
+				{Number: 103, Company: "Beta", Role: "Platform Engineer", Status: "Applied", Date: "2026-04-17", Score: 4.1},
+			},
+			want: []int{102, 101, 103},
+		},
+		{
+			name:     "company",
+			sortMode: sortCompany,
+			apps: []model.CareerApplication{
+				{Number: 201, Company: "Acme", Role: "Backend Engineer", Status: "Applied", Score: 3.1},
+				{Number: 202, Company: "Acme", Role: "AI Engineer", Status: "Applied", Score: 4.7},
+				{Number: 203, Company: "Beta", Role: "Platform Engineer", Status: "Applied", Score: 4.9},
+			},
+			want: []int{202, 201, 203},
+		},
+		{
+			name:     "status",
+			sortMode: sortStatus,
+			apps: []model.CareerApplication{
+				{Number: 301, Company: "Acme", Role: "Backend Engineer", Status: "Applied", Score: 3.1},
+				{Number: 302, Company: "Zulu", Role: "AI Engineer", Status: "Applied", Score: 4.7},
+				{Number: 303, Company: "Beta", Role: "Platform Engineer", Status: "Interview", Score: 2.0},
+			},
+			want: []int{303, 302, 301},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pm := NewPipelineModel(
+				theme.NewTheme("catppuccin-mocha"),
+				tc.apps,
+				model.PipelineMetrics{Total: len(tc.apps)},
+				"..",
+				120,
+				40,
+			)
+			pm.viewMode = "flat"
+			pm.sortMode = tc.sortMode
+			pm.applyFilterAndSort()
+
+			assertFilteredOrder(t, pm.filtered, tc.want)
+		})
+	}
+}
+
+func TestGroupedDateSortUsesScoreTieBreakerWithinStatusGroup(t *testing.T) {
+	apps := []model.CareerApplication{
+		{Number: 401, Company: "Acme", Role: "Backend Engineer", Status: "Applied", Date: "2026-04-18", Score: 3.2},
+		{Number: 402, Company: "Zulu", Role: "AI Engineer", Status: "Applied", Date: "2026-04-18", Score: 4.8},
+		{Number: 403, Company: "Beta", Role: "Platform Engineer", Status: "Interview", Date: "2026-04-18", Score: 2.1},
+	}
+
+	pm := NewPipelineModel(
+		theme.NewTheme("catppuccin-mocha"),
+		apps,
+		model.PipelineMetrics{Total: len(apps)},
+		"..",
+		120,
+		40,
+	)
+	pm.sortMode = sortDate
+	pm.applyFilterAndSort()
+
+	assertFilteredOrder(t, pm.filtered, []int{403, 402, 401})
 }


### PR DESCRIPTION
## Summary
- make score the secondary sort key whenever the pipeline primary sort is not score
- keep grouped status sections ordered by score when the selected sort field ties within a group
- add regression coverage for flat and grouped tie-break scenarios

## Testing
- `cd dashboard && go test ./...`
- `cd dashboard && go build ./...`

Bug-fix note: this is a focused dashboard sorting fix, so I did not open a separate issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved pipeline sorting architecture by consolidating sort logic into dedicated methods, ensuring consistent behavior across all sort modes and tie-breaking scenarios.

* **Tests**
  * Added comprehensive test coverage for pipeline sorting and filtering, including verification of tie-breaking and secondary sorting within grouped views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->