### PR TITLE
feat(modes/es): Argentina-first Spanish localization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 - **German (DACH market):** `modes/de/` — native German translations with DACH-specific vocabulary (13. Monatsgehalt, Probezeit, Kündigungsfrist, AGG, Tarifvertrag, etc.). Includes `_shared.md`, `angebot.md` (evaluation), `bewerben.md` (apply), `pipeline.md`.
 - **French (Francophone market):** `modes/fr/` — native French translations with France/Belgium/Switzerland/Luxembourg-specific vocabulary (CDI/CDD, convention collective SYNTEC, RTT, mutuelle, prévoyance, 13e mois, intéressement/participation, titres-restaurant, CSE, portage salarial, etc.). Includes `_shared.md`, `offre.md` (evaluation), `postuler.md` (apply), `pipeline.md`.
 - **Japanese (Japan market):** `modes/ja/` — native Japanese translations with Japan-specific vocabulary (正社員, 業務委託, 賞与, 退職金, みなし残業, 年俸制, 36協定, 通勤手当, 住宅手当, etc.). Includes `_shared.md`, `kyujin.md` (evaluation), `oubo.md` (apply), `pipeline.md`.
+- **Spanish (Argentina market):** `modes/es/` — rioplatense Spanish translations with Argentina-specific vocabulary (relación de dependencia, monotributo, SAC/aguinaldo, ART, obra social, art. 245 LCT indemnización, período de prueba, preaviso, cláusula de ajuste IPC, etc.). Includes `_shared.md`, `oferta.md` (evaluation), `aplicar.md` (apply), `pipeline.md`.
 
 **When to use German modes:** If the user is targeting German-language job postings, lives in DACH, or asks for German output. Either:
 1. User says "use German modes" → read from `modes/de/` instead of `modes/`
@@ -236,7 +237,14 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 2. User sets `language.modes_dir: modes/ja` in `config/profile.yml` → always use Japanese modes
 3. You detect a Japanese JD → suggest switching to Japanese modes
 
-**When NOT to:** If the user applies to English-language roles, even at French, German, or Japanese companies, use the default English modes.
+**When to use Spanish (AR) modes:** If the user is targeting Argentine job postings, lives in Argentina, or asks for Spanish output. Either:
+1. User says "use Spanish modes" / "usá los modos en español" → read from `modes/es/` instead of `modes/`
+2. User sets `language.modes_dir: modes/es` in `config/profile.yml` → always use Spanish modes
+3. You detect a Spanish/rioplatense JD for an Argentine role → suggest switching to Spanish modes
+
+For Spanish-speaking users targeting other markets (MX/CL/CO/UY/PE), recommend forking `modes/es/` into a market-specific directory (`modes/es-mx/`, etc.) and replacing the "Mercado argentino" section.
+
+**When NOT to:** If the user applies to English-language roles, even at Argentine, French, German, or Japanese companies, use the default English modes.
 
 ### Skill Modes
 

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -16,6 +16,14 @@ candidate:
   # The ID starts with "D" and is 11 characters long.
   # canva_resume_design_id: "DAxxxxxxxxx"
 
+# Optional: localized modes.
+# When set, career-ops reads evaluation/apply/pipeline modes from this
+# directory instead of the default modes/. See CLAUDE.md § Language Modes.
+# Supported: modes/de, modes/es, modes/fr, modes/ja, modes/pt, modes/ru
+# Unset or omitted → uses modes/ (English / mixed).
+# language:
+#   modes_dir: modes/es   # example: Argentine Spanish
+
 target_roles:
   # Your North Star roles — what you're optimizing for
   primary:

--- a/docs/superpowers/plans/2026-04-20-modes-es-ar-implementation.md
+++ b/docs/superpowers/plans/2026-04-20-modes-es-ar-implementation.md
@@ -1,0 +1,964 @@
+# modes/es/ (Argentina-First Spanish) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `modes/es/` as a rioplatense + Argentina-first localization for career-ops, plus an `templates/portals.ar.example.yml` starter list and the integration glue, without modifying any `.mjs` script or existing English mode files.
+
+**Architecture:** Additive i18n following the `modes/fr/` precedent. Four mode files (`_shared.md`, `oferta.md`, `aplicar.md`, `pipeline.md`) plus `README.md` live in `modes/es/`. User-specific content (archetypes, narrative, scripts) is explicitly kept OUT of `modes/es/_shared.md` and referenced back to `modes/_profile.md`. A new parallel portals template captures AR-native, LATAM-regional, and global-with-AR-team companies. Activation happens via an existing agent-resolved convention (`language.modes_dir` in `config/profile.yml`); we only document it and extend the example file.
+
+**Tech Stack:** Markdown (modes), YAML (portals + profile config), Node.js (verification scripts: `test-all.mjs`, `verify-pipeline.mjs`). No new scripts, no dependencies.
+
+**Related docs:**
+- Spec: `docs/superpowers/specs/2026-04-20-modes-es-ar-design.md`
+- Precedent: `modes/fr/_shared.md`, `modes/fr/offre.md`, `modes/fr/postuler.md`, `modes/fr/pipeline.md`
+- Schema reference: `templates/portals.example.yml`
+- Integration: `CLAUDE.md` § "Language Modes", `config/profile.example.yml`
+
+**Verification baseline (run BEFORE starting):**
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+node test-all.mjs 2>&1 | tail -5
+node verify-pipeline.mjs 2>&1 | tail -5
+```
+Capture the output. The same commands must pass at the end with the same structural signal.
+
+---
+
+## File Structure
+
+Files created or modified by this plan:
+
+| File | Action | Purpose |
+|---|---|---|
+| `modes/es/README.md` | create | Scope, activation, forking guide |
+| `modes/es/_shared.md` | create | System context (Spanish) + "Mercado argentino" section |
+| `modes/es/oferta.md` | create | A-G evaluation with AR additions in blocks C, F |
+| `modes/es/aplicar.md` | create | Live-apply assistant with AR form hints |
+| `modes/es/pipeline.md` | create | URL queue processor (translation, no logic delta) |
+| `templates/portals.ar.example.yml` | create | 50-company starter for AR/LATAM/global-AR-remote |
+| `config/profile.example.yml` | modify | Add optional `language.modes_dir` key + docstring |
+| `CLAUDE.md` | modify | Extend "Language Modes" section with Spanish (AR) entry |
+
+Files explicitly NOT touched (out of scope, per spec):
+- Any `.mjs` script
+- Any mode file under `modes/` that is not in `modes/es/`
+- `templates/cv-template.{html,tex}`, `templates/states.yml`, `templates/portals.example.yml`
+- Dashboard, batch prompt (reviewer flagged `batch/batch-prompt.md` as advisory; handled only if Task 10 verification exposes a real break)
+
+---
+
+## Task 1: Scaffold `modes/es/` directory with placeholder files
+
+**Files:**
+- Create: `modes/es/README.md` (placeholder, final content in Task 6)
+- Create: `modes/es/_shared.md` (placeholder, final content in Task 2)
+- Create: `modes/es/oferta.md` (placeholder, final content in Task 3)
+- Create: `modes/es/aplicar.md` (placeholder, final content in Task 4)
+- Create: `modes/es/pipeline.md` (placeholder, final content in Task 5)
+
+**Rationale:** Establish the directory and commit placeholders so subsequent per-file tasks have a clean, isolated diff. Each placeholder has a frontmatter-like header so `test-all.mjs` does not fail on empty files (if it checks).
+
+- [ ] **Step 1: Verify we are on the feature branch**
+
+Run:
+```bash
+cd /Users/fernacri/Developer/git/career-ops && git branch --show-current
+```
+Expected output: `feature/Argentina-ES`
+
+If it says `main` or anything else, STOP and ask the user.
+
+- [ ] **Step 2: Run the baseline verification**
+
+Run:
+```bash
+cd /Users/fernacri/Developer/git/career-ops && node test-all.mjs 2>&1 | tail -10
+cd /Users/fernacri/Developer/git/career-ops && node verify-pipeline.mjs 2>&1 | tail -10
+```
+Record the exit status and the last 10 lines. This is your regression baseline for Task 10.
+
+- [ ] **Step 3: Create directory and placeholder files**
+
+Write each file with a short placeholder that names the file's role and a TODO marker. Example for `modes/es/_shared.md`:
+
+```markdown
+# Contexto compartido -- career-ops (Español, Argentina)
+
+<!-- TODO(Task 2): contenido completo pendiente. -->
+```
+
+Do the same for the other four files, adjusting the H1 title per file:
+- `modes/es/README.md` → `# career-ops -- Modos en español (Argentina)`
+- `modes/es/oferta.md` → `# Modo: oferta -- Evaluación Completa A-G (ES)`
+- `modes/es/aplicar.md` → `# Modo: aplicar -- Asistente de Postulación en Vivo (ES)`
+- `modes/es/pipeline.md` → `# Modo: pipeline -- Procesamiento de URLs Pendientes (ES)`
+
+- [ ] **Step 4: Verify the files exist and the directory listing matches the precedent**
+
+Run:
+```bash
+ls /Users/fernacri/Developer/git/career-ops/modes/es/
+```
+Expected: `README.md _shared.md aplicar.md oferta.md pipeline.md` (in alphabetical order)
+
+- [ ] **Step 5: Commit the scaffold**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+git add modes/es/
+git commit -m "$(cat <<'EOF'
+feat(modes/es): scaffold directory with placeholders
+
+Adds empty modes/es/{README,_shared,oferta,aplicar,pipeline}.md
+to track the new localized directory in git. Content populated in
+subsequent commits per the implementation plan.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Write `modes/es/_shared.md`
+
+**Files:**
+- Modify: `modes/es/_shared.md` (replace placeholder with full content, ~220 lines)
+
+**Reference source:** `modes/_shared.md` (161 lines, English) — structural skeleton and section order.
+**Reference precedent:** `modes/fr/_shared.md` (205 lines) — localization pattern, especially the market-specific section.
+
+**Sections to include (in this order):**
+1. Header + comentario explicativo (este archivo es auto-updatable, user data va en `_profile.md`)
+2. Fuentes de verdad (tabla)
+3. Sistema de scoring A-G (tabla + interpretación)
+4. Block G Posting Legitimacy (tiers + señales)
+5. Reglas globales -- NUNCA / SIEMPRE
+6. Herramientas (Playwright obligatorio, fallback WebFetch para batch mode)
+7. **Mercado argentino -- Especificidades** (sección nueva, detallada abajo)
+8. Referencia a `modes/_profile.md` para archetypes/narrativa/scripts de negociación
+
+**Content rules:**
+- Voseo consistente (vos, tenés, querés, sabés, podés). NO tuteo.
+- Spanish rioplatense: "acá", "laburo" OK en contexto informal pero NO en rules/technical sections.
+- Preserve English technical terms that are job-market conventions: "proof points", "hero metric", "seniority", "offer", "interview", "pipeline", "evals", "HITL". Translate when a Spanish term is already conventional: "ATS" stays, "currículum vitae" NO (use "CV").
+- NO user-specific archetypes inline. Section 8 just points to `modes/_profile.md`.
+
+**"Mercado argentino -- Especificidades" section must contain:**
+
+```markdown
+## Mercado argentino -- Especificidades (IMPORTANTE)
+
+### Modalidades de contratación típicas
+- **Relación de dependencia (RD):** empleo formal bajo LCT. SAC (aguinaldo), vacaciones, ART, obra social obligatoria, indemnización (art. 245), período de prueba 3 meses, preaviso.
+- **Monotributo facturando USD:** contratación como monotributista, factura mensual. Sin SAC/ART/indemnización. Riesgo: no hay amparo LCT si rescinden.
+- **Contractor / consultoría:** similar a monotributo pero a veces LLC/SA. Frecuente en roles remotos globales.
+- **Híbrido:** base RD en ARS + bonos/comisiones en USD.
+
+### Red flags de compensación
+Marcar en bloque C (rationale, no sumar dimensión nueva):
+- ARS fijo anual SIN cláusula de ajuste por inflación (IPC).
+- "Sueldo competitivo" / "a convenir" sin rango.
+- Pago solo en pesos sin hedge para roles globales (cuando mercado comparable paga USD).
+- Bonos "a discreción" sin criterio publicado.
+
+### Green flags de compensación
+- Pago en USD o equivalente (dólar MEP/CCL, cripto estable).
+- Ajustes trimestrales o semestrales por IPC con fórmula publicada.
+- USD-equivalent explícito aun cuando se liquide en ARS.
+- Rango publicado en el JD.
+
+### Vocabulario LCT a detectar o preguntar
+Si la JD NO especifica alguno de estos, flaggear como pregunta para el recruiter en bloque F:
+- Modalidad (RD vs monotributo vs contractor)
+- Moneda de pago y cláusula de ajuste
+- SAC (aguinaldo)
+- ART (riesgos del trabajo)
+- Obra social y prepaga
+- Vacaciones (mínimo LCT + días por antigüedad)
+- Período de prueba (default 3 meses)
+- Preaviso (default 1-2 meses según antigüedad)
+- Indemnización (art. 245, para RD)
+
+### Reglas de evaluación AR
+- NUNCA bajar el score global por modalidad no declarada. Convertirlo en pregunta para bloque F.
+- Si la JD declara explícitamente "USD" o "ajuste por IPC" → tratar como señal positiva en rationale de bloque C.
+- Si la JD dice solo "ARS fijo" y el rol es comparable a mercado global que paga USD → penalización explícita en bloque C (narrativa, no sub-dimensión nueva).
+- Este modo NO brinda asesoramiento legal. Es orientación orientativa para decidir dónde aplicar.
+```
+
+- [ ] **Step 1: Read the source files to anchor the translation**
+
+Run:
+```bash
+cat /Users/fernacri/Developer/git/career-ops/modes/_shared.md
+cat /Users/fernacri/Developer/git/career-ops/modes/fr/_shared.md
+```
+Hold both in context. The English file defines structure; the French file shows the market-section pattern.
+
+- [ ] **Step 2: Write `modes/es/_shared.md` in full**
+
+Replace the placeholder with the complete content following the section order above. Aim for ~200-230 lines.
+
+- [ ] **Step 3: Structural-parity check**
+
+Run:
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+echo "Spanish H2 count:" && grep -c "^## " modes/es/_shared.md
+echo "Spanish H3 count:" && grep -c "^### " modes/es/_shared.md
+echo "English H2 count:" && grep -c "^## " modes/_shared.md
+echo "English H3 count:" && grep -c "^### " modes/_shared.md
+```
+Expected: Spanish H2 count = English H2 count + 1 (new "Mercado argentino" section). Spanish H3 count ≥ English H3 count (new section has sub-headings).
+
+If the delta is unexpected, re-check the outline before moving on.
+
+- [ ] **Step 4: English-leakage check**
+
+Run:
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+grep -nE "\b(the|and|with|this|that|always|never|should|must|when|where|which)\b" modes/es/_shared.md | grep -v "^\s*<!--" | head -30
+```
+Expected: only matches inside code blocks, proper nouns, or intentional English technical terms (e.g., "proof points", "HITL"). Any prose line with raw English is a translation miss — fix and re-run.
+
+- [ ] **Step 5: Voseo consistency check**
+
+Run:
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+grep -nE "\b(tú|tu eres|tu tienes|tu debes|tus)\b" modes/es/_shared.md
+```
+Expected: no matches (we use voseo: vos, tenés, querés). False positives: "tu CV" (possessive, NOT the pronoun "tú"). Scan the results manually; fix any pronoun slips.
+
+- [ ] **Step 6: Verify references to `_profile.md` are intact**
+
+Run:
+```bash
+grep -n "_profile.md" /Users/fernacri/Developer/git/career-ops/modes/es/_shared.md
+```
+Expected: at least 2 matches (user-layer reference in sources-of-truth table + end-of-file pointer).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+git add modes/es/_shared.md
+git commit -m "$(cat <<'EOF'
+feat(modes/es): write _shared.md with AR market section
+
+Spanish (rioplatense) translation of modes/_shared.md structure plus a
+dedicated "Mercado argentino" section covering contratación modalities,
+comp red/green flags, and LCT vocabulary to detect or ask for in Block F.
+User-specific archetypes and narrative remain in modes/_profile.md per
+the system/user layer separation rule in CLAUDE.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Write `modes/es/oferta.md`
+
+**Files:**
+- Modify: `modes/es/oferta.md` (replace placeholder with full content, ~230 lines)
+
+**Reference source:** `modes/oferta.md` (216 lines, already Spanish-leaning) — structural skeleton.
+**Delta vs source:**
+1. Full voseo pass (the root `oferta.md` mixes tuteo and voseo inconsistently).
+2. Block C gets a new subsection "Chequeo de modalidad AR" (detect modality, flag if missing, note ARS-vs-USD signal).
+3. Block F gets a new subsection "Preguntas sobre contratación AR" (dynamic list populated from LCT items missing in JD).
+4. Post-evaluation footer unchanged (same report filename, same tracker TSV columns, same headers: `**Score:**`, `**URL:**`, `**Legitimacy:**`).
+
+**Contract to preserve (critical — breaking these breaks `merge-tracker.mjs`, `verify-pipeline.mjs`, etc.):**
+- Block letters A through G, in order.
+- Report filename format: `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+- Report header fields in this order: Company/Role, Fecha, Arquetipo, Score, URL, Legitimacy, PDF.
+- TSV output instructions must reference the 9 columns defined in CLAUDE.md ("TSV Format for Tracker Additions").
+- Canonical states from `templates/states.yml` stay in English identifiers (`Evaluated`, `Applied`, etc.). In Spanish narrative you can reference them as "estado `Evaluated`" but do NOT translate the identifier itself.
+
+- [ ] **Step 1: Read the source**
+
+```bash
+cat /Users/fernacri/Developer/git/career-ops/modes/oferta.md
+```
+
+- [ ] **Step 2: Write `modes/es/oferta.md`**
+
+Reproduce the A-G structure exactly. Translate to rioplatense with full voseo. Insert the two AR-specific subsections:
+
+**Inside Block C, append after the existing sub-items:**
+```markdown
+### Chequeo de modalidad AR
+
+1. **Modalidad declarada en la JD:** RD / monotributo / contractor / no declarada.
+2. **Moneda de pago:** ARS / USD / mixto / no declarada.
+3. **Cláusula de ajuste:** IPC / sin cláusula / no aplica (si es USD) / no declarada.
+4. Si alguno de los 3 quedó en "no declarada" → agregar a bloque F como pregunta obligatoria.
+5. Si la moneda es ARS y NO hay cláusula de ajuste → nota explícita en el rationale de comp: "penalización por ausencia de protección contra inflación".
+6. Si la moneda es USD o hay cláusula de ajuste clara → nota positiva en el rationale de comp: "comp protegida contra inflación".
+```
+
+**Inside Block F, append as a mandatory subsection (only populate items that were flagged missing in Block C):**
+```markdown
+### Preguntas sobre contratación AR
+
+Incluir SOLO las preguntas que corresponden a items NO declarados en la JD:
+- Si modalidad no declarada: "¿La contratación es en relación de dependencia, monotributo, o contractor?"
+- Si moneda no declarada: "¿En qué moneda se liquida el pago? ¿Hay cláusula de ajuste por inflación?"
+- Si SAC/ART/obra social no mencionados: "¿Se incluyen SAC (aguinaldo), ART y cobertura de obra social? ¿Hay prepaga cubierta por la empresa?"
+- Si vacaciones no mencionadas: "¿Cuántos días de vacaciones? ¿Incluye los días adicionales por antigüedad del art. 150 LCT?"
+- Si período de prueba no mencionado: "¿Cuál es el período de prueba? ¿Es el estándar de 3 meses?"
+- Si preaviso no mencionado: "¿Cuál es el preaviso estipulado para ambas partes?"
+
+Si TODAS las preguntas anteriores están cubiertas en la JD → omitir esta subsección del bloque F (no incluir un encabezado vacío).
+```
+
+- [ ] **Step 3: Structural-parity check (blocks A-G intact)**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+for block in "A" "B" "C" "D" "E" "F" "G"; do
+  count=$(grep -cE "^## Bloque ${block}" modes/es/oferta.md)
+  echo "Bloque ${block}: ${count}"
+done
+```
+Expected: each block appears exactly once (count = 1). Anything else is a regression.
+
+- [ ] **Step 4: Report-header contract check**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+grep -E "\*\*Score:\*\*|\*\*URL:\*\*|\*\*Legitimacy:\*\*|\*\*PDF:\*\*|\*\*Fecha:\*\*" modes/es/oferta.md
+```
+Expected: all five header fields present in the "Formato del report" example. These are the field names `verify-pipeline.mjs` greps for in generated reports.
+
+- [ ] **Step 5: Tracker-TSV contract check**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+echo "-- path reference --"
+grep -nE "tracker-additions|\.tsv" modes/es/oferta.md
+echo "-- 9-column enumeration (num, date, company, role, status, score, pdf, report, notes) --"
+grep -ciE "9.*(columna|column)" modes/es/oferta.md
+echo "-- canonical column order mention (status BEFORE score in TSV) --"
+grep -iE "status.*score|estado.*score|estado.*puntaje" modes/es/oferta.md | head -3
+echo "-- forbidden: direct edits to applications.md for NEW entries --"
+grep -iE "editar.*applications\.md.*(nuevo|nueva|agregar)|agregar.*applications\.md" modes/es/oferta.md
+```
+Expected:
+- Path reference: at least one match for `batch/tracker-additions/...tsv`.
+- 9-column enumeration: at least one match (e.g., "9 columnas tab-separadas" or equivalent).
+- TSV column-order mention: at least one match — the CLAUDE.md TSV rule says **status BEFORE score** in TSV, even though tracker shows **score BEFORE status**. This inversion must be called out.
+- Forbidden-edit check: zero matches for instructions to edit `applications.md` directly for NEW entries (the rule is TSV-only for adds; updates to existing entries are OK).
+
+If the 9-column enumeration or column-order mention is missing, the translation dropped critical contract detail from the root `modes/oferta.md` — go back and restore it before committing.
+
+- [ ] **Step 6: Canonical-state check**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+grep -nE "Evaluada|Aplicada|Respondida|Rechazada|Descartada" modes/es/oferta.md
+```
+Expected: **zero matches**. Canonical states stay in English (`Evaluated`, `Applied`, etc.). If any Spanish state name appears, replace with its English canonical form.
+
+- [ ] **Step 7: English-leakage and voseo checks**
+
+Same as Task 2, Steps 4 and 5, against `modes/es/oferta.md`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+git add modes/es/oferta.md
+git commit -m "$(cat <<'EOF'
+feat(modes/es): write oferta.md with AR additions to blocks C and F
+
+Rioplatense translation of the A-G evaluation flow. Block C adds an AR
+modality/currency/adjustment-clause check that feeds mandatory recruiter
+questions in Block F when any item is missing from the JD. Report
+headers, block letters, and tracker TSV contract preserved verbatim to
+keep verify-pipeline.mjs and merge-tracker.mjs compatible. Canonical
+states stay in English identifiers per templates/states.yml.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Write `modes/es/aplicar.md`
+
+**Files:**
+- Modify: `modes/es/aplicar.md` (replace placeholder with full content, ~130 lines)
+
+**Reference source:** `modes/apply.md` (107 lines, English).
+
+**Deltas vs source:**
+1. Translation to rioplatense.
+2. Add AR form-field guidance (CUIT/CUIL, localidad/provincia, disponibilidad de viajar).
+3. Add "Expected salary" branching by modality.
+4. Restate the ethical rule in Spanish: "NUNCA enviar sin revisión del candidato."
+
+- [ ] **Step 1: Read the source**
+
+```bash
+cat /Users/fernacri/Developer/git/career-ops/modes/apply.md
+```
+
+- [ ] **Step 2: Write `modes/es/aplicar.md`**
+
+Reproduce the section order, translated. Insert these two AR-specific blocks where appropriate:
+
+**"Expected salary" / "Pretensiones salariales" handling:**
+```markdown
+### Pretensiones salariales (AR)
+
+Ramificar según la modalidad detectada en la evaluación (bloque C):
+- **Relación de dependencia en ARS:** sugerir un rango en ARS con la nota "sujeto a cláusula de ajuste por IPC o equivalente".
+- **Monotributo en USD:** sugerir el número USD neto directo (el candidato factura el bruto).
+- **Contractor / LLC:** sugerir USD bruto y dejar que el candidato ajuste según costos.
+- **Modalidad no declarada:** NO dar número. Recomendar: "Antes de dar un número concreto, ¿podés confirmarme si la contratación es en relación de dependencia o monotributo, y en qué moneda se liquida?"
+
+En todos los casos, leer `config/profile.yml` y `modes/_profile.md` para el rango target del candidato. NUNCA inventar un número.
+```
+
+**Campos típicos en forms AR:**
+```markdown
+### Campos comunes en forms AR
+
+- **CUIT / CUIL:** leer de `config/profile.yml` si está. Si no está, preguntar al candidato y NO inventar.
+- **Localidad / Provincia:** dar la dirección canónica del candidato (no improvisar).
+- **Disponibilidad para viajar:** leer la preferencia declarada en `modes/_profile.md` o `config/profile.yml`. Si no está, preguntar antes de responder.
+- **Situación laboral actual:** manejar con cuidado ("activo y buscando cambio", "disponible para inicio en 30-60 días") -- nunca decir que el candidato está desempleado si no lo está.
+- **Referido por:** si el candidato tiene un contacto, incluir su nombre; si no, dejar vacío (NO inventar referencias).
+```
+
+**Ethical gate (in Spanish, reinforcing CLAUDE.md):**
+```markdown
+### Regla crítica -- NUNCA enviar sin revisión
+
+Antes de apretar Submit / Enviar / Apply:
+1. Mostrar al candidato el resumen completo de todos los campos.
+2. Esperar confirmación explícita ("sí, enviar" / "dale" / similar).
+3. Si hay duda o si el candidato no respondió, NO enviar.
+4. Guardar un borrador local del form completado antes de enviar, por si la página falla.
+
+Este punto NO es negociable. CLAUDE.md lo exige como principio ético del sistema.
+```
+
+- [ ] **Step 3: Structural-parity check**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+echo "ES H2:" && grep -c "^## " modes/es/aplicar.md
+echo "EN H2:" && grep -c "^## " modes/apply.md
+```
+Expected: Spanish ≥ English (Spanish adds the two AR sections and the ethical gate).
+
+- [ ] **Step 4: Ethical-rule presence check**
+
+```bash
+grep -nE "NUNCA.*(enviar|submit|apretar)" /Users/fernacri/Developer/git/career-ops/modes/es/aplicar.md
+```
+Expected: at least one match.
+
+- [ ] **Step 5: English-leakage and voseo checks**
+
+Same as Task 2, Steps 4 and 5, against `modes/es/aplicar.md`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+git add modes/es/aplicar.md
+git commit -m "$(cat <<'EOF'
+feat(modes/es): write aplicar.md with AR form guidance
+
+Rioplatense translation of modes/apply.md plus AR-specific sections:
+pretensiones salariales branched by modality, handling of common AR form
+fields (CUIT/CUIL, localidad/provincia, disponibilidad), and the
+ethical gate restated in Spanish. NUNCA enviar sin revisión.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Write `modes/es/pipeline.md`
+
+**Files:**
+- Modify: `modes/es/pipeline.md` (replace placeholder with full content, ~70 lines)
+
+**Reference source:** `modes/pipeline.md` (57 lines, English).
+
+**Delta vs source:** pure translation. The AR-specific logic already lives in `_shared.md` and `oferta.md`, and `pipeline.md` just orchestrates them. No AR additions here.
+
+- [ ] **Step 1: Read the source**
+
+```bash
+cat /Users/fernacri/Developer/git/career-ops/modes/pipeline.md
+```
+
+- [ ] **Step 2: Write `modes/es/pipeline.md`**
+
+Direct translation preserving section order and any referenced file paths verbatim (`data/pipeline.md`, `data/applications.md`, `reports/`, `batch/tracker-additions/`).
+
+- [ ] **Step 3: Structural-parity check**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+diff <(grep -c "^## " modes/pipeline.md) <(grep -c "^## " modes/es/pipeline.md)
+```
+Expected: no output (counts equal).
+
+- [ ] **Step 4: Referenced-path intactness**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+grep -E "data/pipeline\.md|data/applications\.md|batch/tracker-additions|reports/" modes/es/pipeline.md
+```
+Expected: all four paths present (same as English source).
+
+- [ ] **Step 5: English-leakage and voseo checks**
+
+Same as Task 2, Steps 4 and 5, against `modes/es/pipeline.md`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+git add modes/es/pipeline.md
+git commit -m "$(cat <<'EOF'
+feat(modes/es): write pipeline.md
+
+Rioplatense translation of modes/pipeline.md. Orchestration logic only;
+AR-specific evaluation rules live in _shared.md and oferta.md, which this
+mode invokes. File paths and tracker-additions contract unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Write `modes/es/README.md`
+
+**Files:**
+- Modify: `modes/es/README.md` (replace placeholder with full content, ~60 lines)
+
+**Reference precedent:** `modes/fr/README.md` (read first to match voice and sections).
+
+**Required sections:**
+1. Scope statement: rioplatense + Argentina-first. Explicit note that other Spanish-speaking markets should fork.
+2. How to activate: `language.modes_dir: modes/es` in `config/profile.yml`, OR ask the agent to use Spanish modes inline.
+3. What is localized: `_shared.md`, `oferta.md`, `aplicar.md`, `pipeline.md`.
+4. What is NOT localized (stays in English for now): `scan`, `patterns`, `followup`, `batch`, `pdf`, `latex`, `tracker`, `deep`, `contacto`, `interview-prep`, `training`, `project`, `auto-pipeline`, `ofertas`. Users can request specific modes in Spanish.
+5. Note about the mixed-state root `modes/oferta.md`: it is partly Spanish for historical reasons; `modes/es/oferta.md` is the proper, consistent version reached via `language.modes_dir`.
+6. Fork guide for other es-* markets: copy to `modes/es-mx/` (or similar), replace the "Mercado argentino" section, adjust voseo → tuteo if needed.
+7. Starter portals file: `templates/portals.ar.example.yml` (created in Task 7).
+
+- [ ] **Step 1: Read the precedent**
+
+```bash
+cat /Users/fernacri/Developer/git/career-ops/modes/fr/README.md
+```
+
+- [ ] **Step 2: Write `modes/es/README.md`**
+
+Match the French README's voice (direct, practical) but in rioplatense.
+
+- [ ] **Step 3: Reference integrity check**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+grep -E "modes/oferta\.md|modes/_profile\.md|language\.modes_dir|portals\.ar\.example\.yml" modes/es/README.md
+```
+Expected: all four strings present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+git add modes/es/README.md
+git commit -m "$(cat <<'EOF'
+docs(modes/es): write README with scope, activation and fork guide
+
+Documents rioplatense/AR-first scope, activation via language.modes_dir,
+the four localized files, the English-still modes, the mixed-state root
+modes/oferta.md caveat, and a fork guide for es-mx/es-cl/etc.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Create `templates/portals.ar.example.yml`
+
+**Files:**
+- Create: `templates/portals.ar.example.yml` (~450-500 lines expected)
+
+**Reference source:** `templates/portals.example.yml` (896 lines) — YAML schema that `scan.mjs` expects. DO NOT diverge from the schema.
+
+**Structure to reproduce (top-level keys in order):**
+1. Header comment block (adapted to AR scope: mention rioplatense, `modes/es/`, branded careers_url rule, copy-to-`portals.yml` workflow).
+2. `title_filter.positive` (Spanish + English keywords).
+3. `title_filter.negative` (AR-specific additions on top of the base negatives).
+4. `search_queries` (AR boards + LATAM-remote boards).
+5. `tracked_companies` (~50 entries, distribution below).
+
+**`title_filter.positive` — add these Spanish keywords** on top of the English base (reuse the English block from `portals.example.yml`):
+- "Ingeniero/a de IA", "Ingeniero/a de Machine Learning", "Desarrollador/a", "Analista", "Líder Técnico/a", "Arquitecto/a", "Consultor/a", "Especialista", "Product Manager de IA".
+
+**`title_filter.negative` — add:**
+- "Pasantía", "Practicante", "Becario/a" (if the user is senior).
+- "Reemplazo por maternidad" (non-ideal — temporary).
+- "Staffing", "Body shopping" without a disclosed client.
+
+**`search_queries` — include these AR-specific queries:**
+- `site:bumeran.com.ar "{role keyword}"`
+- `site:ar.computrabajo.com "{role keyword}"`
+- `site:getonbrd.com "{role keyword}" Argentina`
+- LinkedIn AR geo filter (documented query template, no hardcoded URL).
+- LATAM-remote: `site:lever.co OR site:greenhouse.io "remote" "Argentina"` (or variants).
+
+**`tracked_companies` — 50 entries, approximate distribution:**
+
+- **~30 AR-native:** Mercado Libre, Globant, Despegar, MODO, Ualá, Pomelo, OLX, Etermax, Digital House, TiendaNube (Nuvemshop), Mudafy, Satellogic, Ripio, Lemon Cash, Buenbit, Prisma Medios de Pago, Naranja X, Brubank, 10Pines, Jampp, Auth0 (AR heritage), Personal Pay / Movistar Money, Reba, Quilla, Bigbox/Bigbox, Wildlife Studios AR, Bitfarms, Rapid7 AR team, Tiendanube alternatives (avoid duplicates), etc.
+- **~10 LATAM regional with AR presence:** Belvo, Bitso, Kushki, NotCo, Fintual, Kavak, Rappi, dLocal, Betterfly, Nubank LATAM.
+- **~10 global with known AR-remote teams:** Stripe, Deel, Remote, GitLab, Canonical, DataDog, Turing, Toptal, Andela LATAM, Modak.
+
+**For each company:**
+- Verify the branded careers URL before committing. If no branded page exists, use the ATS URL and add a YAML comment: `# ATS fallback -- no branded careers page found on {date}`.
+- Set `enabled: true` for the ~15 most likely-high-fit. Set `enabled: false` for the rest (user can flip).
+- Follow the exact schema from `portals.example.yml` (fields: `name`, `careers_url`, `ats` if applicable, `enabled`, `notes`).
+
+- [ ] **Step 1: Read the schema**
+
+```bash
+cat /Users/fernacri/Developer/git/career-ops/templates/portals.example.yml | head -200
+cat /Users/fernacri/Developer/git/career-ops/templates/portals.example.yml | grep -A 5 "^tracked_companies:" | head -40
+```
+
+Identify the exact fields used per company entry. Copy that shape.
+
+- [ ] **Step 2: Draft the header, filters, and queries**
+
+Write the top of `templates/portals.ar.example.yml` (sections 1-4 above). Keep the schema identical to the English example. Deviate only in the values (keywords, queries).
+
+- [ ] **Step 3: Draft the 50-company list**
+
+For each of the 50 companies, verify the branded careers URL via `WebFetch` or a quick browse. DO NOT guess URLs. If uncertain, use the ATS URL and add the YAML comment.
+
+- [ ] **Step 4: YAML-parse sanity check**
+
+Run:
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+node -e "const yaml=require('js-yaml'); const fs=require('fs'); try { const data=yaml.load(fs.readFileSync('templates/portals.ar.example.yml','utf8')); console.log('OK companies:',data.tracked_companies.length); } catch(e){ console.error('YAML ERROR:', e.message); process.exit(1); }"
+```
+Expected: `OK companies: 50` (or ±1 if a last-minute add/drop). Any YAML parse error must be fixed before proceeding.
+
+If `js-yaml` is not installed locally, fall back to a Python one-liner:
+```bash
+python3 -c "import yaml,sys; d=yaml.safe_load(open('templates/portals.ar.example.yml')); print('OK companies:', len(d.get('tracked_companies', [])))"
+```
+
+- [ ] **Step 5: Schema-parity check**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+diff <(awk '/^[a-z_]+:/{print $1}' templates/portals.example.yml | sort -u) <(awk '/^[a-z_]+:/{print $1}' templates/portals.ar.example.yml | sort -u)
+```
+Expected: no output (top-level keys identical). If a key is added or removed, investigate before committing.
+
+- [ ] **Step 6: Branded-URL rule check**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+grep -cE "greenhouse\.io|lever\.co|workday|ashbyhq|myworkdayjobs" templates/portals.ar.example.yml
+```
+Expected: as low as possible. Every ATS URL should have a nearby `# ATS fallback` comment. Count should generally be ≤ 10 out of 50 companies.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+git add templates/portals.ar.example.yml
+git commit -m "$(cat <<'EOF'
+feat(templates): add portals.ar.example.yml starter for AR/LATAM
+
+50-company starter list (~30 AR-native, ~10 LATAM regional, ~10 global
+with AR-remote teams) plus AR-specific title_filter entries and search
+queries for Bumeran, Computrabajo AR, GetOnBoard, LinkedIn AR. Schema
+matches portals.example.yml verbatim; scan.mjs can consume either.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Extend `config/profile.example.yml` with `language.modes_dir`
+
+**Files:**
+- Modify: `config/profile.example.yml` (add new top-level `language:` block)
+
+**Insertion point:** After the `candidate:` block, before `target_roles:`. Keep the file well-organized.
+
+- [ ] **Step 1: Re-read the current file**
+
+```bash
+cat /Users/fernacri/Developer/git/career-ops/config/profile.example.yml
+```
+
+- [ ] **Step 2: Add the `language:` block**
+
+Insert after `candidate:` block (line ~18) and before `target_roles:`:
+
+```yaml
+# Optional: localized modes.
+# If set, career-ops reads evaluation/apply/pipeline modes from this
+# directory instead of the default modes/. See CLAUDE.md § Language Modes.
+# Supported: modes/de, modes/es, modes/fr, modes/ja, modes/pt, modes/ru
+# Unset or omitted → uses modes/ (English / mixed).
+# language:
+#   modes_dir: modes/es   # example: Argentine Spanish
+
+```
+
+The block stays commented out so the example file works for English users out of the box. The comment documents the options.
+
+- [ ] **Step 3: YAML-parse sanity check**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+node -e "const yaml=require('js-yaml'); const fs=require('fs'); try { const d=yaml.load(fs.readFileSync('config/profile.example.yml','utf8')); console.log('candidate:', d.candidate ? 'ok' : 'MISSING'); console.log('target_roles:', d.target_roles ? 'ok' : 'MISSING'); } catch(e){ console.error('YAML ERROR:', e.message); process.exit(1); }"
+```
+Expected: `candidate: ok` + `target_roles: ok`. YAML must still parse with the new block (commented) present.
+
+- [ ] **Step 4: Verify the insertion did not break existing users**
+
+Run:
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+node test-all.mjs 2>&1 | tail -5
+```
+Expected: same exit status and summary lines as the baseline recorded in Task 1, Step 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+git add config/profile.example.yml
+git commit -m "$(cat <<'EOF'
+feat(config): document language.modes_dir in profile.example.yml
+
+Adds commented-out language.modes_dir block with supported values
+(modes/{de,es,fr,ja,pt,ru}). Matches the convention already documented
+in CLAUDE.md § Language Modes and consumed by the agent at mode read
+time. No behavior change for users who do not set the key.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Update `CLAUDE.md` § Language Modes
+
+**Files:**
+- Modify: `CLAUDE.md` (extend "Language Modes" section around line 216-239)
+
+**Edits:**
+1. Add a fourth bullet to the "Additional language-specific modes available" list: Spanish (Argentina).
+2. Add a fourth "When to use..." block after the Japanese one.
+3. Update the Skill Modes / mode-files references if any call out specific English-only mode files (spot-check).
+
+- [ ] **Step 1: Read the target section**
+
+```bash
+sed -n '216,240p' /Users/fernacri/Developer/git/career-ops/CLAUDE.md
+```
+
+- [ ] **Step 2: Apply the edit**
+
+Insert a new bullet in the language list (after the Japanese bullet, before "**When to use German modes:**"):
+
+```markdown
+- **Spanish (Argentina market):** `modes/es/` — rioplatense Spanish translations with Argentina-specific vocabulary (relación de dependencia, monotributo, SAC/aguinaldo, ART, obra social, art. 245 LCT indemnización, período de prueba, preaviso, cláusula de ajuste IPC, etc.). Includes `_shared.md`, `oferta.md` (evaluation), `aplicar.md` (apply), `pipeline.md`.
+```
+
+Insert a new "When to use..." block after the Japanese one (before "**When NOT to:**"):
+
+```markdown
+**When to use Spanish (AR) modes:** If the user is targeting Argentine job postings, lives in Argentina, or asks for Spanish output. Either:
+1. User says "use Spanish modes" / "usa los modos en español" → read from `modes/es/` instead of `modes/`
+2. User sets `language.modes_dir: modes/es` in `config/profile.yml` → always use Spanish modes
+3. You detect a Spanish/rioplatense JD for an Argentine role → suggest switching to Spanish modes
+
+For Spanish-speaking users targeting other markets (MX/CL/CO/UY/PE), recommend forking `modes/es/` into a market-specific directory (`modes/es-mx/`, etc.) and replacing the "Mercado argentino" section.
+```
+
+Update the final "**When NOT to:**" line to list Spanish alongside the others:
+
+```markdown
+**When NOT to:** If the user applies to English-language roles, even at Argentine, French, German, or Japanese companies, use the default English modes.
+```
+
+- [ ] **Step 3: Verify the insertion**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+grep -nE "Spanish \(Argentina|Spanish \(AR|rioplatense" CLAUDE.md
+```
+Expected: at least three matches (bullet + when-to-use block + when-not-to line).
+
+- [ ] **Step 4: Whole-file sanity check**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+node test-all.mjs 2>&1 | tail -5
+```
+Expected: same pass/fail signal as baseline (test-all.mjs reads CLAUDE.md; must not break).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs(CLAUDE.md): document modes/es/ (Argentina) in Language Modes
+
+Adds Spanish (Argentina) entry to the language-specific modes list,
+explains when to use modes/es/ (user request, modes_dir config, JD
+detection), and updates the "When NOT to" line to include Argentine
+companies with English-language postings.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: End-to-end verification and smoke test
+
+**Files:** no file changes — verification and cleanup only.
+
+- [ ] **Step 1: Full static verification**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+node test-all.mjs 2>&1 | tail -15
+node verify-pipeline.mjs 2>&1 | tail -15
+```
+Expected: same pass/fail signal as the baseline captured in Task 1, Step 2. No new failures.
+
+If failures appear, diagnose which file change introduced them:
+```bash
+git log --oneline feature/Argentina-ES ^main
+git diff main...feature/Argentina-ES --stat
+```
+
+- [ ] **Step 2: Directory-parity sanity**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+for d in de fr ja pt ru es; do
+  echo "=== modes/${d}/ ==="
+  ls modes/${d}/ 2>/dev/null || echo "(missing)"
+done
+```
+Expected: `modes/es/` lists `README.md _shared.md aplicar.md oferta.md pipeline.md`. Other dirs unchanged.
+
+- [ ] **Step 3: Contract-string spot check across new files**
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+echo "-- Score header --"
+grep -c "\*\*Score:\*\*" modes/es/oferta.md modes/oferta.md
+echo "-- URL header --"
+grep -c "\*\*URL:\*\*" modes/es/oferta.md modes/oferta.md
+echo "-- Legitimacy header --"
+grep -c "\*\*Legitimacy:\*\*" modes/es/oferta.md modes/oferta.md
+echo "-- tracker-additions ref --"
+grep -c "tracker-additions" modes/es/oferta.md modes/oferta.md
+```
+Expected: each count ≥ 1 in `modes/es/oferta.md`. If any is zero, Task 3 is incomplete.
+
+- [ ] **Step 4: Functional smoke test (user-assisted)**
+
+This step requires the user because it needs a real URL and human judgment on prose quality. Announce:
+
+> "Task 10 step 4: smoke test. Please set `language.modes_dir: modes/es` in `config/profile.yml` (if you haven't already) and paste an Argentine job URL. I'll run the evaluation in Spanish and we'll verify the report is structurally valid and the AR additions fire correctly."
+
+Wait for the user. Then:
+1. Run the evaluation in Spanish mode (paste the URL, follow `oferta.md`).
+2. Verify the generated `reports/NNN-slug-YYYY-MM-DD.md` has all required headers: `**Score:**`, `**URL:**`, `**Legitimacy:**`, `**Fecha:**`, `**PDF:**`.
+3. Verify Block F includes the "Preguntas sobre contratación AR" subsection IF the JD was missing LCT items (not always — if the JD is complete, the subsection should be absent).
+4. Run `node merge-tracker.mjs` and confirm it ingests the new TSV without error.
+5. Run `node verify-pipeline.mjs` and confirm it still passes with the new report present.
+
+- [ ] **Step 5: Spot-check `batch/batch-prompt.md` for Spanish-mode awareness**
+
+The spec reviewer flagged this as advisory. Check now:
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+grep -nE "language\.modes_dir|modes/fr|modes/de|modes/ja" batch/batch-prompt.md 2>&1 || echo "(no existing language-mode references in batch-prompt.md)"
+```
+
+If the batch prompt has NO language-mode awareness, leave it alone — it is out of scope per the spec. If it references other localized dirs but not Spanish, open a follow-up task (do NOT modify in this plan).
+
+- [ ] **Step 6: Final commit (only if any doc fixes surfaced)**
+
+If steps 1-5 surfaced any real issue and you fixed it, commit here. Otherwise, skip.
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+git status
+# only if there are changes:
+git add -p
+git commit -m "..."
+```
+
+- [ ] **Step 7: Summarize for the user**
+
+Report:
+- All commits made on `feature/Argentina-ES`.
+- `test-all.mjs` and `verify-pipeline.mjs` status (pass/fail).
+- Any deferred follow-ups (e.g., batch-prompt update, `modes/es/` expansion to other mode files).
+- Next step for the user: review the branch, run their own smoke test, merge or request changes.
+
+---
+
+## Deferred / out-of-scope follow-ups (not part of this plan)
+
+- Spanish versions of the other 14 mode files (`scan.md`, `patterns.md`, etc.).
+- Mexican / Chilean / Colombian / Spanish (Spain) variants.
+- Updating `batch/batch-prompt.md` for Spanish mode awareness (only if verification surfaces a real break).
+- PR creation (user will decide merge target and timing).
+
+## Rollback plan (if needed)
+
+The entire implementation lives on `feature/Argentina-ES` and every task commits separately. To undo:
+
+```bash
+cd /Users/fernacri/Developer/git/career-ops
+git checkout main
+git branch -D feature/Argentina-ES   # only if you want to abandon entirely
+```
+
+If only some tasks need to be undone, use `git log --oneline feature/Argentina-ES ^main` to list commits and `git revert <sha>` for the ones to undo. Prefer revert over reset to preserve history.

--- a/docs/superpowers/specs/2026-04-20-modes-es-ar-design.md
+++ b/docs/superpowers/specs/2026-04-20-modes-es-ar-design.md
@@ -1,0 +1,226 @@
+# Design: Spanish (Argentina) Modes for career-ops
+
+**Date:** 2026-04-20
+**Branch:** `feature/Argentina-ES`
+**Status:** Approved, pending implementation plan
+
+## Problem
+
+career-ops ships with localized modes for DACH (`modes/de/`), Francophone (`modes/fr/`), Japan (`modes/ja/`), Brazil (`modes/pt/`), and Russia (`modes/ru/`). There is no Spanish variant. A user targeting the Argentine job market cannot activate a market-adapted evaluation flow without manually rewriting modes.
+
+The root `modes/` directory is in mixed state: file names are Spanish (`oferta.md`, `ofertas.md`, `contacto.md`) but `_shared.md` is in English and other content varies. Relying on that mixed state is not a substitute for a proper localized mode.
+
+## Goal
+
+Ship `modes/es/` as a rioplatense-Spanish, Argentina-first localized mode that:
+
+1. Covers the core evaluation path (`_shared.md`, `oferta.md`, `aplicar.md`, `pipeline.md`) — same scope as `modes/fr/` and `modes/de/`.
+2. Encodes Argentine labor-law and compensation realities into the evaluation without hardcoding salary ranges.
+3. Provides an Argentine job-board and company list as `templates/portals.ar.example.yml`, parallel to `portals.example.yml` rather than replacing it.
+4. Integrates with the existing `language.modes_dir` config mechanism so activation is one YAML line.
+5. Respects the system/user layer separation defined in `CLAUDE.md`: user-specific content stays in `modes/_profile.md` and `config/profile.yml`, never in `modes/es/_shared.md`.
+
+## Non-goals
+
+- Translating every mode file. Out of scope for this iteration: `scan.md`, `patterns.md`, `followup.md`, `batch.md`, `pdf.md`, `latex.md`, `tracker.md`, `deep.md`, `contacto.md`, `interview-prep.md`, `training.md`, `project.md`, `auto-pipeline.md`, `ofertas.md`. These remain in the root `modes/` directory and will work in English; users can request Spanish versions later.
+- Modifying any `.mjs` script. Scripts read YAML and Markdown by structure, not by natural language, so the localization does not require code changes.
+- Modifying `templates/cv-template.html`, `templates/cv-template.tex`, or `templates/states.yml`. The CV templates are language-agnostic (they adapt to the user's `cv.md`), and `states.yml` values are identifiers, not UI strings.
+- Translating the dashboard or any UI.
+- Building a separate `modes/es-ar/` directory plus a neutral `modes/es/`. We follow the pragmatic path: one `modes/es/` directory with a rioplatense + AR-first bias, same convention as `modes/de/` (DACH-heavy) and `modes/fr/` (France-heavy). Users in other Spanish-speaking markets can fork to `modes/es-mx/`, `modes/es-cl/`, etc.
+- Rewriting `modes/_shared.md` or any English mode file. This design is additive.
+- Covering every corner of Argentine labor law. The scope is "Medium" depth (see Scope Decisions below) — detect and ask, don't lawyer.
+
+## Scope Decisions (recorded from brainstorming)
+
+The following decisions were made during brainstorming on 2026-04-20 and underpin the design below:
+
+| Decision | Option chosen | Rejected alternatives |
+|---|---|---|
+| Market scope | Rioplatense + AR-first single directory (`modes/es/`) | Separate AR-only (`modes/es-ar/`); neutral LATAM with country overrides |
+| Comp calibration depth | Medium: AR comp section in `_shared.md` with modality detection and red/green flags, no hardcoded ranges | Minimal (text-only translation); Maximum (hardcoded ranges per seniority/archetype) |
+| Labor-law vocab depth | Medium: detect mentions of LCT concepts; ask in Block F for items the JD doesn't specify | Light (only flag what appears); Heavy (scoring penalties + compliance checks) |
+| Activation | Default: set `language.modes_dir: modes/es` in this user's `config/profile.yml` during onboarding | Opt-in only (user must edit config manually) |
+| Portals file | Separate `templates/portals.ar.example.yml`; user copies to `portals.yml` based on region | Merge into the existing `portals.example.yml`; extend existing with marked sections |
+| Initial company count | ~50 companies in `portals.ar.example.yml` | 25-30 starter set; full 127-entry port |
+| User-layer bleed into `_shared.md` | Keep `modes/es/_shared.md` clean of user data; archetypes and narrative stay in `modes/_profile.md` | Follow the fr/de/pt inline `[PERSONNALISER]` pattern (which we consider a codebase inconsistency, not a pattern to replicate) |
+
+## Architecture
+
+### Directory layout
+
+```
+modes/es/
+├── README.md           # scope, activation, forking guide for other es-* markets
+├── _shared.md          # system context (Spanish) + "Mercado argentino" section
+├── oferta.md           # A-G evaluation with AR adaptations in blocks C and F
+├── aplicar.md          # live application assistant with AR form hints
+└── pipeline.md         # orchestration (Spanish) — reads pending URLs, invokes oferta.md
+
+templates/
+└── portals.ar.example.yml   # ~50 companies: AR-native + LATAM regional + global w/ AR teams
+
+config/
+└── profile.example.yml      # add optional `language.modes_dir` key with docstring
+
+CLAUDE.md                    # extend "Language Modes" section with Spanish (AR) entry
+```
+
+### File responsibilities
+
+**`modes/es/README.md`** — scope statement (rioplatense, AR-first), activation instructions (`language.modes_dir: modes/es`), fork guide for other Spanish markets (`modes/es-mx/`, `modes/es-cl/`), list of modes not yet translated and how to request them.
+
+**`modes/es/_shared.md`** (~220 lines, similar to `modes/fr/_shared.md`) sections:
+
+1. Header + sources of truth (translation of `modes/_shared.md` header)
+2. Scoring system A-G (translation)
+3. Posting Legitimacy / Block G signals (translation)
+4. Global rules — NUNCA / SIEMPRE (translation)
+5. Tools section — Playwright, WebFetch, batch mode caveat (translation)
+6. **New section: "Mercado argentino — Especificidades"** with:
+   - Hiring modalities: relación de dependencia (RD), monotributo-USD, contractor/consultancy, hybrid
+   - Comp red flags: flat ARS with no IPC adjustment clause, "sueldo competitivo" with no range, pesos-only with no FX hedge
+   - Comp green flags: USD/crypto payment, quarterly IPC adjustments, USD-equivalent explicit
+   - LCT vocabulary to detect or ask for: SAC (aguinaldo), ART, obra social, vacaciones por antigüedad, período de prueba 3m, preaviso, art. 245 indemnización
+   - Instruction: if the JD does not specify modality, flag it in Block F as a recruiter question, do not penalize the overall score
+7. Reference to `modes/_profile.md` for archetypes, narrative, negotiation scripts, location policy (these stay user-layer)
+
+**`modes/es/oferta.md`** (~220 lines, parallel to `modes/oferta.md`):
+- Translation to rioplatense Spanish (voseo: vos, tenés, querés)
+- Block A-B-D-E-G: structural translation, no logic change
+- **Block C (Comp y Demanda) — AR additions:**
+  - Detect modality mentioned in the JD
+  - If modality unspecified → flag as "modalidad no declarada — preguntar"
+  - If ARS-only with no adjustment clause → explicit penalty note in comp sub-score rationale (not a new dimension)
+  - If USD/crypto/adjusted-ARS → treat as stability green flag in rationale
+- **Block F (Plan de Entrevistas) — AR additions:**
+  - Mandatory subsection "Preguntas para el recruiter sobre contratación AR", populated dynamically from the LCT items the JD did not specify:
+    - ¿Es relación de dependencia o monotributo?
+    - ¿En qué moneda se paga? ¿Hay cláusula de ajuste por inflación?
+    - ¿SAC, ART, obra social cubiertos?
+    - Período de prueba y preaviso
+  - Only include questions for items actually missing from the JD (no spam)
+- Post-evaluation flow (report save, tracker TSV, PDF trigger): unchanged; only surrounding text translated
+
+**`modes/es/aplicar.md`** (~150 lines, parallel to `modes/apply.md`):
+- Translation to rioplatense
+- **AR additions:**
+  - "Expected salary" fields: branch by modality (RD → ARS range with IPC-adjustment note; monotributo → USD neto; unknown → recommend asking before stating a number)
+  - Recognize and handle AR-specific form fields (CUIT/CUIL, localidad vs provincia, disponibilidad para viajar) when they appear
+- **Ethical rule reinforced in Spanish:** NUNCA submit without user review (already in `CLAUDE.md`; restated inline for Spanish-only readers)
+
+**`modes/es/pipeline.md`** (~80 lines, parallel to `modes/pipeline.md`):
+- Direct translation. No AR additions — it is orchestration logic (read URLs from `data/pipeline.md`, invoke `oferta.md`, save reports). All AR-specific logic already lives in `_shared.md` and `oferta.md`, which this mode calls.
+
+**`templates/portals.ar.example.yml`** (~400-500 lines):
+- Header and customization guide translated
+- `title_filter.positive`: Spanish keywords ("Ingeniero de IA", "Desarrollador", "Analista", "Líder Técnico", etc.) + reuse of English keywords from the root example (since many AR postings are in English)
+- `title_filter.negative`: AR-specific additions ("Pasantía" / "Practicante" for senior users; "Reemplazo por maternidad" as a non-ideal signal; staffing-agency signals without disclosed client)
+- `search_queries`: queries targeting AR boards — Bumeran (`site:bumeran.com.ar`), Computrabajo AR (`site:ar.computrabajo.com`), GetOnBoard (`site:getonbrd.com`), LinkedIn AR geo-filter, plus LATAM-remote boards
+- `tracked_companies`: ~50 entries split approximately:
+  - ~30 AR-native (Mercado Libre, Globant, Despegar, MODO, Ualá, Pomelo, OLX, Etermax, Digital House, TiendaNube, Mudafy, Satellogic, Ripio, Lemon Cash, Buenbit, Prisma, Naranja X, Brubank, 10Pines, etc.)
+  - ~10 LATAM regional with strong AR presence (Belvo, Bitso, Kushki, NotCo, Fintual, Kavak, Rappi AR, dLocal, Betterfly)
+  - ~10 global with known AR-remote teams (Stripe, Deel, Remote, GitLab, Canonical, DataDog, Turing, Toptal, Andela)
+- Each entry carries a verified **branded** `careers_url` — not the raw ATS URL. This matches the rule enforced in `modes/scan.md` and `templates/portals.example.yml` header. If a company has no branded careers page, the ATS URL is acceptable as documented fallback.
+- Closing note: "Esta lista es un punto de partida. Pedile al agente que agregue o saque empresas según tu búsqueda."
+
+### Integration points
+
+**`config/profile.example.yml`** — add:
+```yaml
+# Optional: localized modes. When set, career-ops reads modes from this directory.
+# Supported: modes/de, modes/es, modes/fr, modes/ja, modes/pt, modes/ru
+# Unset → uses modes/ (English/mixed).
+language:
+  modes_dir: modes/es   # example: Argentine Spanish
+```
+
+**`CLAUDE.md` — "Language Modes" section** — add paragraph after the existing ja/fr/de entries:
+> **When to use Spanish (AR) modes:** If the user is targeting Argentine job postings, lives in Argentina, or requests Spanish output. Either: (1) user says "usa los modos en español" → read from `modes/es/` instead of `modes/`, (2) user sets `language.modes_dir: modes/es` in `config/profile.yml` → always use Spanish modes, (3) you detect an AR Spanish JD → suggest switching to Spanish modes. For Spanish-speaking users in MX/CL/CO/etc., recommend forking `modes/es/` into a country-specific directory.
+
+And update the mode-files table if it references the default English files by name.
+
+**Onboarding flow (`CLAUDE.md` Step 2)** — during profile setup, if the user's location or email TLD is Argentine (or the user explicitly targets AR), propose setting `language.modes_dir: modes/es`. For this specific user (whose environment shows an Argentine email and Argentine location), set it by default during onboarding.
+
+### Data flow
+
+```
+User action                  File read                         File written
+─────────────                ─────────                         ─────────────
+/career-ops <URL>      →     modes/_profile.md                 reports/NNN-slug-date.md
+                             config/profile.yml                batch/tracker-additions/NNN-slug.tsv
+                             cv.md
+                             (language.modes_dir resolves →)
+                             modes/es/_shared.md
+                             modes/es/oferta.md
+```
+
+The resolution of `language.modes_dir` is handled by the agent (Claude) reading the config, not by a new script. The existing pattern is documented in `CLAUDE.md` ("When the user sets `language.modes_dir: modes/de` in `config/profile.yml` → always use German modes") and applies identically.
+
+### Error handling / edge cases
+
+- **User has `modes_dir: modes/es` set but asks to evaluate an English-language JD at a non-AR company.** The agent should evaluate in Spanish but note in the report that the role is not AR-based and the "Mercado argentino" section applies less. Do not force AR framing on unrelated roles.
+- **A JD is Spanish but not rioplatense (e.g., a Spain-based role).** The agent uses Spanish evaluation but flags in Block F that Spain-specific labor concepts (paga extra vs SAC, autónomo vs monotributo) may apply and recommends the user seek Spain-specific info. Do not hallucinate Spain labor law.
+- **Missing modality in JD.** Never penalize the global score. Always flag in Block F as a recruiter question.
+- **Scripts (`scan.mjs`, `merge-tracker.mjs`, etc.) running against Spanish-generated reports.** Contract: reports continue to use identical headers (`**Score:**`, `**URL:**`, `**Legitimacy:**`), identical block names (A-G), identical TSV schema. Translation affects body prose, not metadata. Verified by re-running `verify-pipeline.mjs` after first Spanish-generated report.
+- **Report filename convention.** Remains `reports/NNN-company-slug-YYYY-MM-DD.md` regardless of language. No localization in filenames.
+
+## Testing strategy
+
+Not a code change, so traditional TDD does not apply. Verification instead:
+
+1. **Structural checks:**
+   - `node verify-pipeline.mjs` passes after generating the first Spanish report
+   - `node merge-tracker.mjs` correctly ingests a TSV generated from `modes/es/oferta.md`
+   - `node test-all.mjs` continues to pass (63+ checks)
+
+2. **Linguistic consistency (manual review):**
+   - Every file in `modes/es/` uses voseo consistently
+   - No untranslated English strings in user-facing output except proper nouns and technical identifiers (state names, block letters, field labels in reports that scripts depend on)
+   - Proof-read by a native Spanish speaker — that's the user
+
+3. **Functional smoke test:**
+   - Create `config/profile.yml` with `language.modes_dir: modes/es`
+   - Paste a known AR job posting URL (Mercado Libre, Ualá, etc.)
+   - Verify: report is generated in Spanish, block F contains AR-specific recruiter questions for any missing LCT items, `applications.md` row appears with canonical state, URL is captured, legitimacy tier is set
+
+4. **Regression check:**
+   - Unset `language.modes_dir`, paste a non-AR English JD
+   - Verify: English flow still works as before, no leakage of Spanish or AR content
+
+5. **Portals YAML schema check:**
+   - `node scan.mjs` accepts `portals.ar.example.yml` when copied to `portals.yml` without schema errors
+   - At least one scan cycle completes against the AR portals file
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| AR company list rots fast (company renames, acquisitions, careers URL moves) | Keep the list modest (50, not 127); document that it's a starting point; `check-liveness.mjs` already flags dead URLs |
+| Other Spanish-speaking users (MX/CL/CO) adopt `modes/es/` and encounter rioplatense friction | `README.md` is explicit about scope and documents the fork path; we do not advertise `modes/es/` as "LATAM Spanish" |
+| Drift between `modes/_shared.md` (English) and `modes/es/_shared.md` when the former gets updated | Accept this risk — same problem applies to `fr/`, `de/`, `ja/`, `pt/`, `ru/`; out of scope to solve here; maintainer runs `test-all.mjs` to catch structural drift, relies on PR review for content |
+| `language.modes_dir` resolution is agent-driven and could be ignored in batch mode (`claude -p`) where system prompt may be shorter | `CLAUDE.md` update will be explicit about the rule; the batch worker prompt in `batch/batch-prompt.md` may need a note (checked during implementation — low cost to fix) |
+| Labor-law claims in `_shared.md` go stale (LCT article numbers, period lengths) | Only reference stable concepts (SAC, ART, period of probation of 3 months). Avoid article numbers except art. 245 indemnización, which is the canonical reference; add a disclaimer that the mode is not legal advice |
+| Rioplatense tone feels unprofessional in Spain-facing applications | Scope is AR; if the user applies to Spain, they switch off `modes_dir` or use the English flow. Document explicitly. |
+
+## Open questions (deferred to implementation)
+
+- **Exact company list (all 50 with verified branded careers_urls).** The design commits to the count and distribution (30 AR + 10 LATAM + 10 global). The specific URLs are verified during implementation. Companies with no verifiable branded careers page drop to ATS fallback, with a comment in YAML.
+- **Which existing modes (beyond the core 4) the user wants translated next.** Out of scope for this spec.
+- **Whether to add a `modes/es/` language mention to `README.md` of the repo root.** Minor — handle during implementation, inside the scope of "integration points".
+
+## Out of scope (explicit)
+
+- Spanish versions of `scan.md`, `patterns.md`, `followup.md`, `batch.md`, `pdf.md`, `latex.md`, `tracker.md`, `deep.md`, `contacto.md`, `interview-prep.md`, `training.md`, `project.md`, `auto-pipeline.md`, `ofertas.md`.
+- Mexican, Chilean, Colombian, Uruguayan, Peruvian, Spanish (Spain) variants.
+- Code changes to any `.mjs` script.
+- Dashboard localization.
+- Adding `es` to the `language.modes_dir` validation in any hypothetical config-validator.
+- Translating `templates/states.yml` (identifiers, not UI).
+
+## References
+
+- Pattern source: `modes/fr/_shared.md` (205 lines) and `modes/fr/offre.md` (166 lines) — closest precedent.
+- Existing AR-related infrastructure: Spanish-named mode files in root `modes/` (`oferta.md`, `ofertas.md`, `contacto.md`).
+- CLAUDE.md rules on system vs user layer separation.
+- `templates/portals.example.yml` as base schema (do not diverge).
+- `modes/scan.md` branded-careers_url rule.

--- a/modes/es/README.md
+++ b/modes/es/README.md
@@ -1,3 +1,143 @@
-# career-ops -- Modos en español (Argentina)
+# career-ops -- Modos en español (`modes/es/`)
 
-<!-- TODO: contenido completo pendiente. -->
+Este directorio contiene las traducciones al español (rioplatense, con perspectiva argentina) de los principales modos de career-ops para candidatos que cumplen objetivos en el mercado hispanohablante, **especialmente Argentina**.
+
+## ¿Cuándo usar estos modos?
+
+Usá `modes/es/` si al menos una de estas condiciones se cumple:
+
+- Postulás principalmente a **ofertas de empleo en español** (sitios de carrera de empresas argentinas, regionales o hispanohablantes, LinkedIn ES, Glassdoor LATAM, Bumerán, Computrabajo)
+- Tu **CV es en español** o alternás entre ES e EN según la ofre
+- Necesitás respuestas y cartas de presentación en **español tech natural**, no traducidas por máquina
+- Tenés que manejar **especificidades contractuales del mercado argentino**: relación de dependencia, descuento jubilatorio, aportes AFJP/SIPA, vacaciones, licencias, jornada laboral, convenio colectivo, modalidad de trabajo, indemnización por despido, SAC (Salario Anual Complementario)
+
+Si la mayoría de tus ofertas son en inglés, quedate con los modos estándar en `modes/`. Los modos en inglés funcionan para ofertas hispanohablantes, pero no conocen los detalles del mercado argentino.
+
+## ¿Cómo activar?
+
+### Opción 1 -- Por sesión
+
+Decile a Claude al principio de la sesión:
+
+> "Usá los modos en español bajo `modes/es/`."
+
+Claude va a leer los archivos de ese directorio en lugar de `modes/`.
+
+### Opción 2 -- Permanentemente
+
+Agregá en `config/profile.yml`:
+
+```yaml
+language:
+  primary: es
+  modes_dir: modes/es
+```
+
+Recordale a Claude en tu primera sesión ("Mirá en `profile.yml`, configuré `language.modes_dir`"). Claude va a usar automáticamente los modos en español.
+
+## ¿Qué modos están traducidos?
+
+Esta primera iteración cubre los cuatro modos con mayor impacto:
+
+| Archivo | Traducido desde | Función |
+|---------|-----------------|---------|
+| `_shared.md` | `modes/_shared.md` (EN) | Contexto compartido, arquetipos, reglas globales, especificidades del mercado argentino |
+| `oferta.md` | `modes/oferta.md` (ES original) | Evaluación completa de una oferta (Bloques A-G) |
+| `aplicar.md` | `modes/apply.md` (EN) | Asistente en vivo para rellenar formularios de candidatura |
+| `pipeline.md` | `modes/pipeline.md` (ES original) | Inbox de URLs / Segunda mente para ofertas recolectadas |
+
+Los otros modos (`scan`, `batch`, `pdf`, `tracker`, `auto-pipeline`, `deep`, `contacto`, `ofertas`, `project`, `training`, `patterns`, `followup`) siguen en EN/ES. Su contenido es principalmente tooling, rutas y comandos -- tiene que mantenerse independiente del idioma. Si necesitás alguno en español, pedíselo directamente al agente.
+
+## Caveat: `modes/oferta.md` en la raíz
+
+Por razones históricas, existe `modes/oferta.md` en la raíz del proyecto (fue el archivo original con sesgo al español). Ese archivo es **una versión anterior y parcial**. La versión completa y actualizada está en `modes/es/oferta.md`. 
+
+**Usá `modes/es/` configurando `language.modes_dir`** como se describe arriba. No mezcles los dos.
+
+## Portales argentinos
+
+Para escanear ofertas de empresas argentinas y regionales, hay un archivo de ejemplo con keywords optimizados para el mercado:
+
+```bash
+# En la raíz del proyecto:
+cp templates/portals.ar.example.yml portals.yml
+```
+
+Ese archivo ya tiene empresas, keywords y regiones para Argentina. Ajustalo según tus preferencias de roles y ciudades.
+
+## ¿Qué sigue siendo en inglés?
+
+Intencionalmente no traducido porque es vocabulario técnico estándar:
+
+- Nombres de herramientas (`Playwright`, `WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`)
+- Términos de estatus en el tracker (`Evaluated`, `Applied`, `Interview`, `Offer`, `Rejected`)
+- Fragmentos de código, rutas, comandos
+- Conceptos de scoring (`Score`, `Archetype`, `Proof Point`)
+
+Los modos usan español tech natural, como se habla en equipos de ingeniería en Buenos Aires, Córdoba o Rosario: texto corriente en español, términos técnicos en inglés donde es el uso. Sin traducciones forzadas de "Pipeline" a "Canalización" ni de "Deploy" a "Despliegue aplicativo".
+
+## Lexicografía de referencia
+
+Para mantener un tono coherente si modificás o extendés los modos:
+
+| Inglés | Español (en esta codebase) |
+|--------|---------------------------|
+| Job posting | Oferta / Aviso / Publicación |
+| Application | Candidatura / Postulación |
+| Cover letter | Carta de presentación / Presentación |
+| Resume / CV | CV |
+| Salary | Salario / Remuneración |
+| Compensation | Remuneración / Paquete |
+| Skills | Competencias / Habilidades |
+| Interview | Entrevista / Ronda |
+| Hiring manager | Hiring manager / Gerente de selección |
+| Recruiter | Recruiter / Reclutador |
+| AI | IA (Inteligencia Artificial) |
+| Requirements | Requisitos / Exigencias |
+| Career history | Trayectoria profesional |
+| Probation | Período de prueba / Contrato a prueba |
+| Vacation | Licencias / Vacaciones |
+| Salary component | Componente salarial |
+| Permanent employment | Relación de dependencia / Contrato indefinido |
+| Fixed-term contract | Contrato por tiempo determinado |
+| Freelance | Freelance / Independiente / Monotributo |
+| Collective agreement | Convenio colectivo |
+| Union | Sindicato |
+| Works council | Comisión interna / Delegado gremial |
+| Profit sharing | Participación de ganancias / Bonus |
+| Meal vouchers | Viáticos / Almuerzo |
+| Health insurance | Cobertura médica / Prepaga |
+| Severance pay | Indemnización por despido |
+| Annual bonus | SAC (Salario Anual Complementario) / 13º mes |
+| Notice period | Período de preaviso |
+| Retirement contributions | Aportes jubilatorios / AFJP / SIPA |
+| Remote work | Trabajo remoto / Modalidad híbrida |
+
+## Guía para otras regiones hispanohablantes
+
+Si tu mercado objetivo es México, Chile, Colombia, Uruguay o Perú: copiá `modes/es/` a `modes/es-mx/`, `modes/es-cl/`, etc., según corresponda. Luego:
+
+1. En `_shared.md`, reemplazá la sección "Mercado argentino" con especificidades locales:
+   - **México:** ISR, IMSS, INFONAVIT, prima de antigüedad, PTU (Participación de Trabajadores en las Ganancias), aguinaldo
+   - **Chile:** AFP, isapre, CTS (Cesantía), bono de desempeño, gratificación, descuento de salud
+   - **Colombia:** ARL, EPS, fondos de pensión, prima de servicios, prima de Navidad, auxilio de transporte
+   - **Uruguay:** BPS, fondo de desempleo, régimen de jornada laboral, comisión interna, afiliación sindical
+   - **Perú:** SPP, AFP, EPS, gratificación, CTS, prima de desempeño, bonificación extraordinaria
+
+2. Ajustá el léxico según el uso local (voseo/tuteo/ustedeo, regionalismos técnicos).
+
+3. Copiá `templates/portals.ar.example.yml` y adaptalo con empresas y keywords de tu región.
+
+4. Abrí una Issue en GitHub con la propuesta, y considerá contribuir el nuevo directorio regional a `main` (ver `CONTRIBUTING.md`).
+
+## Contribuir
+
+Para mejorar una traducción o agregar un modo:
+
+1. Abrí una Issue con tu propuesta (ver `CONTRIBUTING.md`)
+2. Respetá el léxico arriba para mantener tono coherente
+3. Traducí de manera idiomática -- sin traducciones palabra por palabra
+4. Conservá los elementos estructurales (Bloques A-G, tablas, bloques de código, instrucciones de herramientas) idénticos
+5. Testeá con una verdadera oferta hispanohablante (LinkedIn ES, Bumerán, sitio de carrera de empresa argentina) antes de enviar la PR
+
+Recordá: `config/profile.yml` y `modes/_profile.md` es donde va tu personalización. No edites `modes/es/_shared.md` para contenido específico del usuario -- eso asegura que las actualizaciones del sistema no sobrescriban tus customizaciones.

--- a/modes/es/README.md
+++ b/modes/es/README.md
@@ -1,0 +1,3 @@
+# career-ops -- Modos en español (Argentina)
+
+<!-- TODO: contenido completo pendiente. -->

--- a/modes/es/_shared.md
+++ b/modes/es/_shared.md
@@ -1,0 +1,3 @@
+# Contexto compartido -- career-ops (Español, Argentina)
+
+<!-- TODO: contenido completo pendiente. -->

--- a/modes/es/_shared.md
+++ b/modes/es/_shared.md
@@ -1,3 +1,210 @@
 # Contexto compartido -- career-ops (Español, Argentina)
 
-<!-- TODO: contenido completo pendiente. -->
+<!-- ============================================================
+     ESTE ARCHIVO ES AUTO-ACTUALIZABLE. No pongas datos personales aquí.
+
+     Tus personalizaciones van en modes/_profile.md (nunca se sobreescribe
+     con actualizaciones). Este archivo contiene las reglas del sistema,
+     la lógica de scoring y la configuración de herramientas que mejoran
+     con cada versión de career-ops.
+     ============================================================ -->
+
+## Fuentes de verdad (SIEMPRE leer antes de cada evaluación)
+
+| Archivo | Ruta | Cuándo |
+|---------|------|--------|
+| cv.md | `cv.md` (raíz del proyecto) | SIEMPRE |
+| article-digest.md | `article-digest.md` (si existe) | SIEMPRE (proof points detallados) |
+| profile.yml | `config/profile.yml` | SIEMPRE (identidad y roles objetivo) |
+| _profile.md | `modes/_profile.md` | SIEMPRE (arquetipos, narrativa y negociación del candidato) |
+
+**REGLA: NUNCA hardcodear métricas de proof points.** Leelas desde `cv.md` y `article-digest.md` al momento de evaluar.
+**REGLA: Para métricas de artículos/proyectos, `article-digest.md` tiene precedencia sobre `cv.md`** (`cv.md` puede tener números desactualizados).
+**REGLA: Leé `_profile.md` DESPUÉS de este archivo. Las personalizaciones del candidato en `_profile.md` sobreescriben los valores por defecto de acá.**
+
+---
+
+## Sistema de scoring
+
+La evaluación usa 6 bloques (A-F) con un score global de 1-5:
+
+| Dimensión | Qué mide |
+|-----------|----------|
+| Match con CV | Skills, experiencia, alineación de proof points |
+| Alineación North Star | Qué tan bien la oferta encaja con los arquetipos objetivo del candidato (desde `_profile.md`) |
+| Comp | Salario vs mercado (5=cuartil superior, 1=muy por debajo) |
+| Señales culturales | Cultura de empresa, crecimiento, estabilidad, política de trabajo remoto |
+| Red flags | Bloqueadores, advertencias (ajustes negativos) |
+| **Global** | Promedio ponderado de los anteriores |
+
+**Interpretación del score:**
+- 4.5+ → Match fuerte, recomendado aplicar de inmediato
+- 4.0-4.4 → Buen match, vale la pena aplicar
+- 3.5-3.9 → Aceptable pero no ideal, aplicar solo si hay un motivo específico
+- Por debajo de 3.5 → Recomendado no aplicar (ver Ethical Use en CLAUDE.md)
+
+## Legitimidad del posting (Bloque G)
+
+El Bloque G evalúa si el posting es probablemente una búsqueda real y activa. NO afecta el score global de 1-5 — es una evaluación cualitativa separada.
+
+**Tres niveles:**
+- **Alta confianza** — Búsqueda real y activa (la mayoría de las señales son positivas)
+- **Proceder con precaución** — Señales mixtas que vale la pena notar (hay algunas dudas)
+- **Sospechoso** — Múltiples indicadores de ghost posting, el candidato debería investigar primero
+
+**Señales clave (ponderadas por confiabilidad):**
+
+| Señal | Fuente | Confiabilidad | Notas |
+|-------|--------|---------------|-------|
+| Antigüedad del posting | Snapshot de la página | Alta | Menos de 30d=bueno, 30-60d=mixto, más de 60d=preocupante (ajustar según tipo de rol) |
+| Botón Apply activo | Snapshot de la página | Alta | Hecho directamente observable |
+| Especificidad técnica en el JD | Texto del JD | Media | Los JDs genéricos correlacionan con ghost postings, pero también con mala redacción |
+| Realismo de los requisitos | Texto del JD | Media | Las contradicciones son señal fuerte; la vaguedad es señal débil |
+| Noticias recientes de despidos | WebSearch | Media | Considerar departamento, timing y tamaño de la empresa |
+| Patrón de reposteo | scan-history.tsv | Media | El mismo rol reposteado 2+ veces en 90 días es preocupante |
+| Transparencia salarial | Texto del JD | Baja | Depende de la jurisdicción; hay muchas razones legítimas para omitirlo |
+| Fit rol-empresa | Cualitativo | Baja | Subjetivo, usar solo como señal de apoyo |
+
+**Encuadre ético (OBLIGATORIO):**
+- Esto ayuda al candidato a priorizar tiempo en oportunidades reales
+- NUNCA presentar los hallazgos como acusaciones de deshonestidad
+- Presentar las señales y dejar que el candidato decida
+- Siempre señalar explicaciones legítimas para las señales preocupantes
+
+## Detección de arquetipos
+
+Clasificar cada oferta en uno de estos tipos (o híbrido de 2). Los arquetipos del candidato y su framing específico viven en `modes/_profile.md`:
+
+| Arquetipo | Señales clave en el JD |
+|-----------|------------------------|
+| AI Platform / LLMOps | "observability", "evals", "pipelines", "monitoring", "reliability" |
+| Agentic / Automation | "agent", "HITL", "orchestration", "workflow", "multi-agent" |
+| Technical AI PM | "PRD", "roadmap", "discovery", "stakeholder", "product manager" |
+| AI Solutions Architect | "architecture", "enterprise", "integration", "design", "systems" |
+| AI Forward Deployed | "client-facing", "deploy", "prototype", "fast delivery", "field" |
+| AI Transformation | "change management", "adoption", "enablement", "transformation" |
+
+Después de detectar el arquetipo, leé `modes/_profile.md` para el framing y los proof points específicos del candidato para ese arquetipo.
+
+---
+
+## Reglas globales
+
+### NUNCA
+
+1. Inventar experiencia o métricas
+2. Modificar `cv.md` o archivos del portfolio
+3. Enviar candidaturas en nombre del candidato
+4. Compartir número de teléfono en mensajes generados
+5. Recomendar una compensación por debajo del mercado
+6. Generar un PDF sin haber leído el JD antes
+7. Usar jerga corporativa o frases vacías
+8. Ignorar el tracker (toda oferta evaluada se registra)
+
+### SIEMPRE
+
+0. **Carta de presentación:** Si el formulario lo permite, SIEMPRE incluir una. Mismo diseño visual que el CV. Citas del JD mapeadas a proof points. Máximo 1 página.
+1. Leer `cv.md`, `_profile.md` y `article-digest.md` (si existe) antes de evaluar
+1b. **Primera evaluación de cada sesión:** Ejecutar `node cv-sync-check.mjs` vía Bash. Si hay advertencias, notificarlo antes de continuar.
+2. Detectar el arquetipo del rol y adaptar el framing según `_profile.md`
+3. Citar líneas exactas del CV al hacer matching
+4. Usar WebSearch para datos de compensación y empresa
+5. Registrar en el tracker después de cada evaluación
+6. Generar el contenido en el idioma del JD (EN por defecto)
+7. Ser directo y accionable — sin relleno
+8. Inglés técnico nativo para textos generados. Frases cortas, verbos de acción, sin voz pasiva.
+8b. URLs de case studies en el PDF Professional Summary (el recruiter puede leer solo eso).
+9. **Entradas al tracker como TSV** — NUNCA editar `applications.md` directamente. Escribir TSV en `batch/tracker-additions/`.
+10. **Incluir `**URL:**` en todo header de reporte.**
+
+---
+
+### Herramientas
+
+| Herramienta | Uso |
+|-------------|-----|
+| WebSearch | Investigación de compensación, tendencias, cultura de empresa, contactos LinkedIn, fallback para JDs |
+| WebFetch | Fallback para extraer JDs desde páginas estáticas |
+| Playwright | Verificar ofertas activas (browser_navigate + browser_snapshot). **NUNCA 2+ agentes con Playwright en paralelo — comparten la misma instancia del navegador.** |
+| Read | cv.md, _profile.md, article-digest.md, cv-template.html |
+| Write | HTML temporal para PDF, applications.md, reports .md |
+| Edit | Actualizar el tracker |
+| Canva MCP | Generación visual de CV (opcional). Duplicar diseño base, editar texto, exportar PDF. Requiere `canva_resume_design_id` en profile.yml. |
+| Bash | `node generate-pdf.mjs` |
+
+**Verificación de ofertas — OBLIGATORIO:** Usar Playwright (`browser_navigate` + `browser_snapshot`) para verificar si una oferta está activa. Footer/navbar sin JD = cerrada. Título + descripción + Apply = activa.
+
+**Excepción batch:** En workers headless (`claude -p`), Playwright no está disponible. Usar WebFetch como fallback y marcar el header del reporte con `**Verification:** unconfirmed (batch mode)`.
+
+---
+
+## Mercado argentino — Especificidades (IMPORTANTE)
+
+### Modalidades de contratación típicas
+- **Relación de dependencia (RD):** empleo formal bajo LCT. SAC (aguinaldo), vacaciones, ART, obra social obligatoria, indemnización (art. 245), período de prueba 3 meses, preaviso.
+- **Monotributo facturando USD:** contratación como monotributista, factura mensual. Sin SAC/ART/indemnización. Riesgo: no hay amparo LCT si rescinden.
+- **Contractor / consultoría:** similar a monotributo pero a veces LLC/SA. Frecuente en roles remotos globales.
+- **Híbrido:** base RD en ARS + bonos/comisiones en USD.
+
+### Red flags de compensación
+Marcar en bloque C (rationale, no sumar dimensión nueva):
+- ARS fijo anual SIN cláusula de ajuste por inflación (IPC).
+- "Sueldo competitivo" / "a convenir" sin rango.
+- Pago solo en pesos sin hedge para roles globales (cuando mercado comparable paga USD).
+- Bonos "a discreción" sin criterio publicado.
+
+### Green flags de compensación
+- Pago en USD o equivalente (dólar MEP/CCL, cripto estable).
+- Ajustes trimestrales o semestrales por IPC con fórmula publicada.
+- USD-equivalent explícito aun cuando se liquide en ARS.
+- Rango publicado en el JD.
+
+### Vocabulario LCT a detectar o preguntar
+Si la JD NO especifica alguno de estos, flaggear como pregunta para el recruiter en bloque F:
+- Modalidad (RD vs monotributo vs contractor)
+- Moneda de pago y cláusula de ajuste
+- SAC (aguinaldo)
+- ART (riesgos del trabajo)
+- Obra social y prepaga
+- Vacaciones (mínimo LCT + días por antigüedad)
+- Período de prueba (default 3 meses)
+- Preaviso (default 1-2 meses según antigüedad)
+- Indemnización (art. 245, para RD)
+
+### Reglas de evaluación AR
+- NUNCA bajar el score global por modalidad no declarada. Convertirlo en pregunta para bloque F.
+- Si la JD declara explícitamente "USD" o "ajuste por IPC" → tratar como señal positiva en rationale de bloque C.
+- Si la JD dice solo "ARS fijo" y el rol es comparable a mercado global que paga USD → penalización explícita en bloque C (narrativa, no sub-dimensión nueva).
+- Este modo NO brinda asesoramiento legal. Es orientación orientativa para decidir dónde aplicar.
+
+---
+
+## Escritura profesional y compatibilidad ATS
+
+Estas reglas aplican a TODO el texto generado que va a documentos del candidato: summaries PDF, bullets, cartas de presentación, respuestas a formularios, mensajes de LinkedIn. NO aplican a reportes internos de evaluación.
+
+### Evitar frases cliché
+- "apasionado por" / "orientado a resultados" / "track record probado"
+- "leveragueé" (usar "usé" o nombrar la herramienta)
+- "lideré" cuando en realidad fue "participé" (ser exacto)
+- "facilité" (usar "organicé" o "puse en marcha")
+- "sinergias" / "robusto" / "seamless" / "cutting-edge" / "innovador"
+- "en el acelerado mundo actual"
+- "capacidad demostrada para" / "mejores prácticas" (nombrar la práctica)
+
+### Normalización Unicode para ATS
+`generate-pdf.mjs` normaliza automáticamente em-dashes, comillas tipográficas y caracteres de ancho cero a equivalentes ASCII. De todas formas, evitar generarlos desde el principio.
+
+### Variar la estructura de las oraciones
+- No empezar todos los bullets con el mismo verbo
+- Mezclar longitudes de oraciones (corta. Luego más larga con contexto. Corta de nuevo.)
+- No usar siempre "X, Y y Z" — a veces dos ítems, a veces cuatro
+
+### Preferir lo específico sobre lo abstracto
+- "Reduje la latencia p95 de 2.1s a 380ms" supera a "mejoré la performance"
+- "Postgres + pgvector para retrieval sobre 12k docs" supera a "diseñé arquitectura RAG escalable"
+- Nombrar herramientas, proyectos y clientes cuando sea posible
+
+---
+
+Los arquetipos, narrativa, scripts de negociación y política de ubicación del candidato viven en `modes/_profile.md` (nunca en este archivo).

--- a/modes/es/_shared.md
+++ b/modes/es/_shared.md
@@ -26,7 +26,7 @@
 
 ## Sistema de scoring
 
-La evaluación usa 6 bloques (A-F) con un score global de 1-5:
+La evaluación usa 7 bloques (A-G) con un score global de 1-5:
 
 | Dimensión | Qué mide |
 |-----------|----------|

--- a/modes/es/_shared.md
+++ b/modes/es/_shared.md
@@ -86,6 +86,8 @@ Clasificar cada oferta en uno de estos tipos (o híbrido de 2). Los arquetipos d
 
 Después de detectar el arquetipo, leé `modes/_profile.md` para el framing y los proof points específicos del candidato para ese arquetipo.
 
+Los arquetipos por defecto pueden reemplazarse en `modes/_profile.md` — si tus roles objetivo no encajan en esta tabla, editá ese archivo, no este.
+
 ---
 
 ## Reglas globales
@@ -112,7 +114,7 @@ Después de detectar el arquetipo, leé `modes/_profile.md` para el framing y lo
 5. Registrar en el tracker después de cada evaluación
 6. Generar el contenido en el idioma del JD (EN por defecto)
 7. Ser directo y accionable — sin relleno
-8. Inglés técnico nativo para textos generados. Frases cortas, verbos de acción, sin voz pasiva.
+8. Español rioplatense técnico para textos generados cuando el JD es en español. Si el JD está en inglés, generar en inglés nativo. Frases cortas, verbos de acción, sin voz pasiva.
 8b. URLs de case studies en el PDF Professional Summary (el recruiter puede leer solo eso).
 9. **Entradas al tracker como TSV** — NUNCA editar `applications.md` directamente. Escribir TSV en `batch/tracker-additions/`.
 10. **Incluir `**URL:**` en todo header de reporte.**
@@ -135,6 +137,11 @@ Después de detectar el arquetipo, leé `modes/_profile.md` para el framing y lo
 **Verificación de ofertas — OBLIGATORIO:** Usar Playwright (`browser_navigate` + `browser_snapshot`) para verificar si una oferta está activa. Footer/navbar sin JD = cerrada. Título + descripción + Apply = activa.
 
 **Excepción batch:** En workers headless (`claude -p`), Playwright no está disponible. Usar WebFetch como fallback y marcar el header del reporte con `**Verification:** unconfirmed (batch mode)`.
+
+### Prioridad de time-to-offer
+- Demo funcional con métricas > perfección
+- Aplicar antes > seguir investigando
+- Enfoque 80/20, todo tiene un timebox
 
 ---
 

--- a/modes/es/aplicar.md
+++ b/modes/es/aplicar.md
@@ -1,0 +1,3 @@
+# Modo: aplicar -- Asistente de Postulación en Vivo (ES)
+
+<!-- TODO: contenido completo pendiente. -->

--- a/modes/es/aplicar.md
+++ b/modes/es/aplicar.md
@@ -1,3 +1,143 @@
-# Modo: aplicar -- Asistente de Postulación en Vivo (ES)
+# Modo: aplicar — Asistente de Postulación en Vivo (AR)
 
-<!-- TODO: contenido completo pendiente. -->
+Modo interactivo para cuando el candidato está completando un formulario de postulación en Chrome. Lee lo que hay en pantalla, carga el contexto previo de la oferta, y genera respuestas personalizadas para cada pregunta del formulario.
+
+## Requisitos
+
+- **Mejor con Playwright visible**: En modo visible, el candidato ve el navegador y Claude puede interactuar con la página.
+- **Sin Playwright**: el candidato comparte un screenshot o pega las preguntas manualmente.
+
+## Workflow
+
+```
+1. DETECTAR    → Leer pestaña activa de Chrome (screenshot/URL/título)
+2. IDENTIFICAR → Extraer empresa + rol de la página
+3. BUSCAR      → Match contra reports existentes en reports/
+4. CARGAR      → Leer report completo + Bloque G (si existe)
+5. COMPARAR    → ¿El rol en pantalla coincide con el evaluado? Si cambió → avisar
+6. ANALIZAR    → Identificar TODAS las preguntas del formulario visibles
+7. GENERAR     → Para cada pregunta, generar respuesta personalizada
+8. PRESENTAR   → Mostrar respuestas formateadas para copy-paste
+```
+
+## Paso 1 — Detectar la oferta
+
+**Con Playwright:** Tomar snapshot de la página activa. Leer título, URL, y contenido visible.
+
+**Sin Playwright:** Pedirle al candidato que:
+- Comparta un screenshot del formulario (la herramienta Read lee imágenes)
+- O pegue las preguntas del formulario como texto
+- O diga empresa + rol para buscarlo
+
+## Paso 2 — Identificar y buscar contexto
+
+1. Extraer nombre de empresa y título del rol de la página
+2. Buscar en `reports/` por nombre de empresa (Grep sin distinción de mayúsculas)
+3. Si hay match → cargar el report completo
+4. Si hay Bloque G → cargar los draft answers previos como base
+5. Si NO hay match → avisar y ofrecer ejecutar el auto-pipeline rápido
+
+## Paso 3 — Detectar cambios en el rol
+
+Si el rol en pantalla difiere del evaluado:
+- **Avisar al candidato**: "El rol cambió de [X] a [Y]. ¿Querés que re-evalúe o adaptamos las respuestas al nuevo título?"
+- **Si adaptar**: Ajustar las respuestas al nuevo rol sin re-evaluar
+- **Si re-evaluar**: Ejecutar evaluación A-F completa, actualizar report, regenerar Bloque G
+- **Actualizar tracker**: Cambiar el título del rol en `applications.md` si corresponde
+
+## Paso 4 — Analizar preguntas del formulario
+
+Identificar TODAS las preguntas visibles:
+- Campos de texto libre (carta de presentación, por qué este rol, etc.)
+- Dropdowns (cómo te enteraste, autorización de trabajo, etc.)
+- Sí/No (reubicación, visa, disponibilidad para viajar, etc.)
+- Campos de salario / pretensiones salariales
+- Campos de carga de archivos (CV, carta de presentación en PDF)
+
+Clasificar cada pregunta:
+- **Ya respondida en Bloque G** → adaptar la respuesta existente
+- **Pregunta nueva** → generar respuesta desde el report + `cv.md`
+
+## Paso 5 — Generar respuestas
+
+Para cada pregunta, generar la respuesta siguiendo:
+
+1. **Contexto del report**: Usar proof points del bloque B, historias STAR del bloque F
+2. **Bloque G previo**: Si existe una respuesta draft, usarla como base y refinar
+3. **Tono "I'm choosing you"**: Mismo framework del auto-pipeline
+4. **Especificidad**: Referenciar algo concreto del JD visible en pantalla
+5. **Proof point de career-ops**: Incluir en "Información adicional" si hay campo disponible
+
+**Formato de output:**
+
+```
+## Respuestas para [Empresa] — [Rol]
+
+Basado en: Report #NNN | Score: X.X/5 | Arquetipo: [tipo]
+
+---
+
+### 1. [Pregunta exacta del formulario]
+> [Respuesta lista para copy-paste]
+
+### 2. [Siguiente pregunta]
+> [Respuesta]
+
+...
+
+---
+
+Notas:
+- [Cualquier observación sobre el rol, cambios, etc.]
+- [Sugerencias de personalización que el candidato debería revisar]
+```
+
+---
+
+### Pretensiones salariales (AR)
+
+Ramificar según la modalidad detectada en la evaluación (bloque C de `modes/es/oferta.md`):
+- **Relación de dependencia en ARS:** sugerir un rango en ARS con la nota "sujeto a cláusula de ajuste por IPC o equivalente".
+- **Monotributo en USD:** sugerir el número USD neto directo (el candidato factura el bruto).
+- **Contractor / LLC:** sugerir USD bruto y dejar que el candidato ajuste según costos.
+- **Modalidad no declarada:** NO dar número. Recomendar preguntar primero: "Antes de dar un número concreto, ¿podés confirmarme si la contratación es en relación de dependencia o monotributo, y en qué moneda se liquida?"
+
+En todos los casos, leer `config/profile.yml` y `modes/_profile.md` para el rango target del candidato. NUNCA inventar un número.
+
+---
+
+### Campos comunes en forms AR
+
+- **CUIT / CUIL:** leer de `config/profile.yml` si está disponible. Si no, preguntar al candidato y NO inventar.
+- **Localidad / Provincia:** usar la dirección canónica del candidato. No improvisar.
+- **Disponibilidad para viajar:** leer preferencia declarada en `modes/_profile.md` o `config/profile.yml`. Si no está, preguntar antes de responder.
+- **Situación laboral actual:** usar framing cuidadoso ("activo y buscando cambio", "disponible para inicio en 30-60 días"). NUNCA decir que el candidato está desempleado si no lo está.
+- **Referido por:** si el candidato tiene un contacto, incluir su nombre. Si no, dejar vacío. NO inventar referencias.
+
+---
+
+### Regla crítica — NUNCA enviar sin revisión
+
+Antes de hacer clic en Submit / Enviar / Apply:
+1. Mostrar al candidato el resumen completo de todos los campos completados.
+2. Esperar confirmación explícita ("sí, enviá" / "dale" / similar).
+3. Si hay duda o si el candidato no respondió, NO enviar.
+4. Guardar un borrador del form completado antes de enviar, por si la página falla.
+
+Este punto NO es negociable. CLAUDE.md lo exige como principio ético del sistema.
+
+---
+
+## Paso 6 — Post-apply (opcional)
+
+Si el candidato confirma que envió la postulación:
+1. Actualizar estado en `applications.md` de "Evaluada" a "Aplicado"
+2. Actualizar el Bloque G del report con las respuestas finales
+3. Sugerir siguiente paso: `/career-ops contacto` para LinkedIn outreach
+
+## Manejo del scroll
+
+Si el formulario tiene más preguntas que las visibles:
+- Pedirle al candidato que haga scroll y comparta otro screenshot
+- O que pegue las preguntas restantes
+- Procesar en iteraciones hasta cubrir todo el formulario

--- a/modes/es/oferta.md
+++ b/modes/es/oferta.md
@@ -52,6 +52,7 @@ Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
 4. Si alguno de los 3 quedó en "no declarada" → agregar a bloque F como pregunta obligatoria.
 5. Si la moneda es ARS y NO hay cláusula de ajuste → nota explícita en el rationale de comp: "penalización por ausencia de protección contra inflación".
 6. Si la moneda es USD o hay cláusula de ajuste clara → nota positiva en el rationale de comp: "comp protegida contra inflación".
+7. Verificar también en el JD: SAC/aguinaldo, ART, obra social/prepaga, vacaciones, período de prueba, preaviso. Los que no estén mencionados → agregarlos como preguntas en bloque F.
 
 ## Bloque D — Comp y Demanda
 
@@ -106,7 +107,7 @@ Incluir SOLO las preguntas que corresponden a ítems NO declarados en la JD (det
 
 Si TODAS las preguntas anteriores están cubiertas en la JD → omitir esta subsección del bloque F (no incluir un encabezado vacío).
 
-## Bloque G — Posting Legitimacy
+## Bloque G — Legitimidad del Posting
 
 Analizar el posting para detectar señales que indiquen si es una búsqueda real y activa. Esto ayuda al candidato a priorizar esfuerzo en las oportunidades con más chances de llevar a un proceso real.
 
@@ -142,9 +143,9 @@ Analizar el posting para detectar señales que indiquen si es una búsqueda real
 - ¿El rol tiene sentido para el negocio de esta empresa?
 - ¿El nivel de seniority es uno que legítimamente tarda más en cubrirse?
 
-### Formato de output:
+### Formato de salida:
 
-**Assessment:** Uno de tres niveles:
+**Evaluación:** Uno de tres niveles:
 - **High Confidence** — Múltiples señales sugieren una búsqueda real y activa
 - **Proceed with Caution** — Señales mixtas que vale la pena notar
 - **Suspicious** — Múltiples indicadores de ghost posting, investigar antes de invertir tiempo

--- a/modes/es/oferta.md
+++ b/modes/es/oferta.md
@@ -1,0 +1,3 @@
+# Modo: oferta -- Evaluación Completa A-G (ES)
+
+<!-- TODO: contenido completo pendiente. -->

--- a/modes/es/oferta.md
+++ b/modes/es/oferta.md
@@ -1,3 +1,258 @@
-# Modo: oferta -- Evaluación Completa A-G (ES)
+# Modo: oferta — Evaluación Completa A-G
 
-<!-- TODO: contenido completo pendiente. -->
+Cuando el candidato pega una oferta (texto o URL), entregar SIEMPRE los 7 bloques (A-F evaluación + G legitimidad):
+
+## Paso 0 — Detección de Arquetipo
+
+Clasificar la oferta en uno de los 6 arquetipos (ver `_shared.md`). Si es híbrido, indicar los 2 más cercanos. Esto determina:
+- Qué proof points priorizar en el bloque B
+- Cómo reescribir el summary en el bloque E
+- Qué historias STAR preparar en el bloque F
+
+## Bloque A — Resumen del Rol
+
+Tabla con:
+- Arquetipo detectado
+- Dominio (platform/agentic/LLMOps/ML/enterprise)
+- Función (build/consult/manage/deploy)
+- Seniority
+- Remoto (full/hybrid/onsite)
+- Tamaño de equipo (si se menciona)
+- TL;DR en 1 frase
+
+## Bloque B — Match con CV
+
+Leé `cv.md`. Creá una tabla con cada requisito del JD mapeado a líneas exactas del CV.
+
+**Adaptado al arquetipo:**
+- Si FDE → priorizar proof points de delivery rápida y client-facing
+- Si SA → priorizar diseño de sistemas e integrations
+- Si PM → priorizar product discovery y métricas
+- Si LLMOps → priorizar evals, observability, pipelines
+- Si Agentic → priorizar multi-agent, HITL, orchestration
+- Si Transformation → priorizar change management, adoption, scaling
+
+Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
+1. ¿Es un hard blocker o un nice-to-have?
+2. ¿Puede el candidato demostrar experiencia adyacente?
+3. ¿Hay un proyecto portfolio que cubra este gap?
+4. Plan de mitigación concreto (frase para cover letter, proyecto rápido, etc.)
+
+## Bloque C — Nivel y Estrategia
+
+1. **Nivel detectado** en el JD vs **nivel natural del candidato para ese arquetipo**
+2. **Plan "vender senior sin mentir"**: frases específicas adaptadas al arquetipo, logros concretos a destacar, cómo posicionar la experiencia de founder como ventaja
+3. **Plan "si me downlevelan"**: aceptar si la comp es justa, negociar review a 6 meses, criterios de promoción claros
+
+### Chequeo de modalidad AR
+
+1. **Modalidad declarada en la JD:** RD / monotributo / contractor / no declarada.
+2. **Moneda de pago:** ARS / USD / mixto / no declarada.
+3. **Cláusula de ajuste:** IPC / sin cláusula / no aplica (si es USD) / no declarada.
+4. Si alguno de los 3 quedó en "no declarada" → agregar a bloque F como pregunta obligatoria.
+5. Si la moneda es ARS y NO hay cláusula de ajuste → nota explícita en el rationale de comp: "penalización por ausencia de protección contra inflación".
+6. Si la moneda es USD o hay cláusula de ajuste clara → nota positiva en el rationale de comp: "comp protegida contra inflación".
+
+## Bloque D — Comp y Demanda
+
+Usar WebSearch para:
+- Salarios actuales del rol (Glassdoor, Levels.fyi, Blind, Talent.io, Glassdoor AR)
+- Reputación de compensación de la empresa
+- Tendencia de demanda del rol
+
+Tabla con datos y fuentes citadas. Si no hay datos, decirlo en vez de inventar.
+
+## Bloque E — Plan de Personalización
+
+| # | Sección | Estado actual | Cambio propuesto | Por qué |
+|---|---------|---------------|------------------|---------|
+| 1 | Summary | ... | ... | ... |
+| ... | ... | ... | ... | ... |
+
+Top 5 cambios al CV + Top 5 cambios a LinkedIn para maximizar el match.
+
+## Bloque F — Plan de Entrevistas
+
+6-10 historias STAR+R mapeadas a requisitos del JD (STAR + **Reflection**):
+
+| # | Requisito del JD | Historia STAR+R | S | T | A | R | Reflection |
+|---|-----------------|-----------------|---|---|---|---|------------|
+
+La columna **Reflection** captura qué se aprendió o qué se haría distinto. Señala seniority — los candidatos junior describen qué pasó, los senior extraen aprendizajes.
+
+**Story Bank:** Si `interview-prep/story-bank.md` existe, chequeá si alguna de estas historias ya está ahí. Si no, agregá las nuevas. Con el tiempo esto construye un banco reutilizable de 5-10 historias master que se pueden adaptar a cualquier pregunta de entrevista.
+
+**Seleccionadas y enmarcadas según el arquetipo:**
+- FDE → enfatizar velocidad de entrega y client-facing
+- SA → enfatizar decisiones de arquitectura
+- PM → enfatizar discovery y trade-offs
+- LLMOps → enfatizar métricas, evals, production hardening
+- Agentic → enfatizar orchestration, error handling, HITL
+- Transformation → enfatizar adopción, cambio organizacional
+
+Incluir también:
+- 1 case study recomendado (cuál de sus proyectos presentar y cómo)
+- Preguntas red-flag y cómo responderlas (ej: "¿por qué vendiste tu empresa?", "¿tenés equipo de reports?")
+
+### Preguntas sobre contratación AR
+
+Incluir SOLO las preguntas que corresponden a ítems NO declarados en la JD (detectados en el bloque C):
+- Si modalidad no declarada: "¿La contratación es en relación de dependencia, monotributo, o contractor?"
+- Si moneda no declarada: "¿En qué moneda se liquida el pago? ¿Hay cláusula de ajuste por inflación?"
+- Si SAC/ART/obra social no mencionados: "¿Se incluyen SAC (aguinaldo), ART y cobertura de obra social? ¿Hay prepaga cubierta por la empresa?"
+- Si vacaciones no mencionadas: "¿Cuántos días de vacaciones? ¿Incluye los días adicionales por antigüedad del art. 150 LCT?"
+- Si período de prueba no mencionado: "¿Cuál es el período de prueba? ¿Es el estándar de 3 meses?"
+- Si preaviso no mencionado: "¿Cuál es el preaviso estipulado para ambas partes?"
+
+Si TODAS las preguntas anteriores están cubiertas en la JD → omitir esta subsección del bloque F (no incluir un encabezado vacío).
+
+## Bloque G — Posting Legitimacy
+
+Analizar el posting para detectar señales que indiquen si es una búsqueda real y activa. Esto ayuda al candidato a priorizar esfuerzo en las oportunidades con más chances de llevar a un proceso real.
+
+**Encuadre ético:** Presentar observaciones, no acusaciones. Cada señal tiene explicaciones legítimas. El candidato decide cómo pesarlas.
+
+### Señales a analizar (en orden):
+
+**1. Frescura del posting** (desde el snapshot de Playwright, ya capturado en el Paso 0):
+- Fecha de publicación o "hace X días" — extraer de la página
+- Estado del botón Apply (activo / cerrado / ausente / redirige a página genérica)
+- Si la URL redirigió a una página genérica de careers, anotarlo
+
+**2. Calidad de la descripción** (desde el texto del JD):
+- ¿Nombra tecnologías, frameworks y herramientas específicas?
+- ¿Menciona tamaño del equipo, estructura de reporte o contexto organizacional?
+- ¿Son realistas los requisitos? (años de experiencia vs antigüedad de la tecnología)
+- ¿Hay un scope claro para los primeros 6-12 meses?
+- ¿Se menciona salario o compensación?
+- ¿Qué porcentaje del JD es específico del rol vs boilerplate genérico?
+- ¿Hay contradicciones internas? (título entry-level + requisitos de staff, etc.)
+
+**3. Señales de contratación de la empresa** (2-3 queries de WebSearch, combinar con la investigación del Bloque D):
+- Search: `"{empresa}" despidos {año}` — notar fecha, escala, departamentos
+- Search: `"{empresa}" hiring freeze {año}` — notar anuncios
+- Si hay despidos: ¿son del mismo departamento que este rol?
+
+**4. Detección de reposteos** (desde scan-history.tsv):
+- Chequear si empresa + título similar aparecieron antes con una URL distinta
+- Notar cuántas veces y en qué período
+
+**5. Contexto de mercado del rol** (cualitativo, sin queries adicionales):
+- ¿Es un rol común que típicamente se cubre en 4-6 semanas?
+- ¿El rol tiene sentido para el negocio de esta empresa?
+- ¿El nivel de seniority es uno que legítimamente tarda más en cubrirse?
+
+### Formato de output:
+
+**Assessment:** Uno de tres niveles:
+- **High Confidence** — Múltiples señales sugieren una búsqueda real y activa
+- **Proceed with Caution** — Señales mixtas que vale la pena notar
+- **Suspicious** — Múltiples indicadores de ghost posting, investigar antes de invertir tiempo
+
+**Tabla de señales:** Cada señal observada con su hallazgo y peso (Positivo / Neutral / Preocupante).
+
+**Notas de contexto:** Cualquier aclaración (rol de nicho, puesto estatal, posición evergreen, etc.) que explique señales potencialmente preocupantes.
+
+### Casos borde:
+- **Postings gubernamentales/académicos:** Los plazos más largos son normales. Ajustar umbrales (60-90 días es normal).
+- **Posiciones evergreen/contratación continua:** Si el JD dice explícitamente "ongoing" o "rolling", anotarlo como contexto — no es un ghost posting, es un pipeline role.
+- **Roles de nicho/ejecutivos:** Staff+, VP, Director o roles muy especializados pueden estar abiertos meses sin ser ghost jobs. Ajustar umbrales de antigüedad.
+- **Startup / pre-revenue:** Las empresas early-stage pueden tener JDs vagos porque el rol genuinamente no está definido. Ponderar menos la vaguedad de la descripción.
+- **Sin fecha disponible:** Si no se puede determinar la antigüedad del posting y no hay otras señales preocupantes, usar "Proceed with Caution" con nota de datos limitados. NUNCA usar "Suspicious" sin evidencia.
+- **Sourcing por recruiter (sin posting público):** Las señales de frescura no están disponibles. Notar que el contacto activo del recruiter es en sí mismo una señal positiva de legitimidad.
+
+---
+
+## Post-evaluación
+
+**SIEMPRE** después de generar los bloques A-G:
+
+### 1. Guardar report .md
+
+Guardar la evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+
+- `{###}` = siguiente número secuencial (3 dígitos, zero-padded)
+- `{company-slug}` = nombre de empresa en lowercase, sin espacios (usar guiones)
+- `{YYYY-MM-DD}` = fecha actual
+
+**Formato del report:**
+
+```markdown
+# Evaluación: {Empresa} — {Rol}
+
+**Fecha:** {YYYY-MM-DD}
+**Arquetipo:** {detectado}
+**Score:** {X/5}
+**URL:** {url}
+**Legitimacy:** {High Confidence | Proceed with Caution | Suspicious}
+**PDF:** {ruta o pendiente}
+
+---
+
+## A) Resumen del Rol
+(contenido completo del bloque A)
+
+## B) Match con CV
+(contenido completo del bloque B)
+
+## C) Nivel y Estrategia
+(contenido completo del bloque C)
+
+## D) Comp y Demanda
+(contenido completo del bloque D)
+
+## E) Plan de Personalización
+(contenido completo del bloque E)
+
+## F) Plan de Entrevistas
+(contenido completo del bloque F)
+
+## G) Posting Legitimacy
+(contenido completo del bloque G)
+
+## H) Borradores de respuestas para la candidatura
+(solo si score >= 4.5 — borradores de respuestas para el formulario de aplicación)
+
+---
+
+## Keywords extraídas
+(lista de 15-20 keywords del JD para optimización ATS)
+```
+
+### 2. Registrar en el tracker
+
+**NUNCA editar `applications.md` directamente para AGREGAR entradas nuevas. Escribir TSV en `batch/tracker-additions/` y ejecutar `merge-tracker.mjs`.**
+
+Crear un archivo TSV en `batch/tracker-additions/{num}-{company-slug}.tsv` con una sola línea y 9 columnas separadas por tabulaciones:
+
+```
+{num}\t{date}\t{company}\t{role}\t{status}\t{score}/5\t{pdf_emoji}\t[{num}](reports/{num}-{slug}-{date}.md)\t{note}
+```
+
+**Orden de columnas (IMPORTANTE — status ANTES que score en el TSV):**
+1. `num` — número secuencial (entero)
+2. `date` — YYYY-MM-DD
+3. `company` — nombre corto de la empresa
+4. `role` — título del puesto
+5. `status` — estado canónico (columna 5 = status)
+6. `score` — formato `X.X/5` (columna 6 = score/5)
+7. `pdf` — `✅` o `❌`
+8. `report` — link markdown `[num](reports/...)`
+9. `notes` — resumen en una línea
+
+**Nota:** En `applications.md` el score aparece ANTES que el status. `merge-tracker.mjs` maneja ese swap de columnas automáticamente.
+
+**Estado canónico: `Evaluated`** (identificador en inglés, requerido por `templates/states.yml`).
+
+**Estados canónicos disponibles** (siempre en inglés, según `templates/states.yml`):
+
+| Estado | Cuándo usarlo |
+|--------|---------------|
+| `Evaluated` | Reporte completado, decisión pendiente |
+| `Applied` | Candidatura enviada |
+| `Responded` | La empresa respondió |
+| `Interview` | En proceso de entrevistas |
+| `Offer` | Oferta recibida |
+| `Rejected` | Rechazado por la empresa |
+| `Discarded` | Descartado por el candidato o la oferta cerró |
+| `SKIP` | No encaja, no aplicar |

--- a/modes/es/pipeline.md
+++ b/modes/es/pipeline.md
@@ -1,0 +1,3 @@
+# Modo: pipeline -- Procesamiento de URLs Pendientes (ES)
+
+<!-- TODO: contenido completo pendiente. -->

--- a/modes/es/pipeline.md
+++ b/modes/es/pipeline.md
@@ -1,3 +1,57 @@
-# Modo: pipeline -- Procesamiento de URLs Pendientes (ES)
+# Modo: pipeline — Inbox de URLs (Second Brain)
 
-<!-- TODO: contenido completo pendiente. -->
+Procesa URLs de ofertas acumuladas en `data/pipeline.md`. Vos agregás URLs cuando quieras y luego ejecutás `/career-ops pipeline` para procesarlas todas.
+
+## Workflow
+
+1. **Leer** `data/pipeline.md` → buscar items `- [ ]` en la sección "Pendientes"
+2. **Para cada URL pendiente**:
+   a. Calcular siguiente `REPORT_NUM` secuencial (leer `reports/`, tomar el número más alto + 1)
+   b. **Extraer JD** usando Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
+   c. Si la URL no es accesible → marcar como `- [!]` con nota y continuar
+   d. **Ejecutar auto-pipeline completo**: Evaluación A-F → Report .md → PDF (si score >= 3.0) → Tracker
+   e. **Mover de "Pendientes" a "Procesadas"**: `- [x] #NNN | URL | Empresa | Rol | Score/5 | PDF ✅/❌`
+3. **Si hay 3+ URLs pendientes**, lanzar agentes en paralelo (Agent tool con `run_in_background`) para maximizar velocidad.
+4. **Al terminar**, mostrar tabla resumen:
+
+```
+| # | Empresa | Rol | Score | PDF | Acción recomendada |
+```
+
+## Formato de pipeline.md
+
+```markdown
+## Pendientes
+- [ ] https://jobs.example.com/posting/123
+- [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
+- [!] https://private.url/job — Error: login required
+
+## Procesadas
+- [x] #143 | https://jobs.example.com/posting/789 | Acme Corp | AI PM | 4.2/5 | PDF ✅
+- [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF ❌
+```
+
+## Detección inteligente de JD desde URL
+
+1. **Playwright (preferido):** `browser_navigate` + `browser_snapshot`. Funciona con todas las SPAs.
+2. **WebFetch (fallback):** Para páginas estáticas o cuando Playwright no está disponible.
+3. **WebSearch (último recurso):** Buscar en portales secundarios que indexan el JD.
+
+**Casos especiales:**
+- **LinkedIn**: Puede requerir login → marcar `[!]` y pedirle al usuario que pegue el texto
+- **PDF**: Si la URL apunta a un PDF, leerlo directamente con Read tool
+- **`local:` prefix**: Leer el archivo local. Ejemplo: `local:jds/linkedin-pm-ai.md` → leer `jds/linkedin-pm-ai.md`
+
+## Numeración automática
+
+1. Listar todos los archivos en `reports/`
+2. Extraer el número del prefijo (e.g., `142-medispend...` → 142)
+3. Nuevo número = máximo encontrado + 1
+
+## Sincronización de fuentes
+
+Antes de procesar cualquier URL, verificar sync:
+```bash
+node cv-sync-check.mjs
+```
+Si hay desincronización, advertirte antes de continuar.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
     "dotenv": "^16.4.5",
-    "js-yaml": "^4.1.1",
     "playwright": "^1.58.1"
+  },
+  "devDependencies": {
+    "js-yaml": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
     "dotenv": "^16.4.5",
+    "js-yaml": "^4.1.1",
     "playwright": "^1.58.1"
-  },
-  "devDependencies": {
-    "js-yaml": "^4.1.1"
   }
 }

--- a/templates/portals.ar.example.yml
+++ b/templates/portals.ar.example.yml
@@ -1,0 +1,586 @@
+# Portal Scanner Configuration — AR/LATAM Variant
+# Used by /career-ops scan to discover new offers automatically.
+# This file is tailored for candidates targeting the Argentine and
+# Latin American tech market (remote, hybrid, or on-site in AR/LATAM).
+#
+# Strategy (3 levels):
+#   1. Playwright → careers_url of each company (real-time, reliable)
+#   2. Greenhouse API → structured JSON (fast, Greenhouse-only)
+#   3. WebSearch with site: filters (broad discovery, may be stale)
+#
+# IMPORTANT: Each company in tracked_companies MUST have careers_url.
+#   Prefer the BRANDED company careers URL whenever available; use ATS-hosted URL only as fallback.
+#   ✅ https://careers.mercadolibre.com   ⚠️ https://job-boards.greenhouse.io/mercadolibre (fallback only)
+#   ✅ https://dlocal.com/careers/        ⚠️ https://job-boards.greenhouse.io/dlocal (fallback only)
+#   Exception: ATS-hosted careers_url is acceptable when no branded careers page exists.
+#   Using raw ATS URLs when a branded page exists can cause false 410 errors (job ID mismatch).
+#
+# HOW TO CUSTOMIZE:
+#   1. Copy this file to portals.yml in the project root
+#   2. Edit title_filter.positive with YOUR target role keywords
+#   3. Add/remove companies in tracked_companies
+#   4. Adjust search_queries for your preferred job boards
+#   5. Set enabled: false on companies you don't care about
+#
+# MARKET COVERAGE:
+#   ~30 AR-native companies (Buenos Aires tech ecosystem)
+#   ~10 LATAM regional companies (regional HQ or significant AR presence)
+#   ~10 global companies with active AR-remote hiring programs
+
+# -- Title filter --
+# The scanner uses these keywords to decide if a title is relevant.
+# At least 1 positive must match AND 0 negatives must match (case-insensitive).
+
+title_filter:
+  positive:
+    # [CUSTOMIZE] Add keywords matching YOUR target roles
+    # -- AI/ML roles (English) --
+    - "AI"
+    - "ML"
+    - "LLM"
+    - "Agent"
+    - "Agentic"
+    - "GenAI"
+    - "Generative AI"
+    - "NLP"
+    - "LLMOps"
+    - "MLOps"
+    - "Voice AI"
+    - "Conversational AI"
+    - "Speech"
+    # -- Engineering roles (English) --
+    - "Backend"
+    - "Full Stack"
+    - "Platform"
+    - "DevOps"
+    - "Data Engineer"
+    - "Data Scientist"
+    - "Solutions Architect"
+    - "Tech Lead"
+    - "Staff Engineer"
+    - "Principal Engineer"
+    # -- Product roles (English) --
+    - "Product Manager"
+    - "Technical PM"
+    # -- Automation roles (English) --
+    - "Automation"
+    - "Hyperautomation"
+    - "Low-Code"
+    - "No-Code"
+    # -- AR/LATAM Spanish equivalents --
+    - "Ingeniero de IA"
+    - "Ingeniero de Machine Learning"
+    - "Ingeniero de Datos"
+    - "Ingeniero de Software"
+    - "Desarrollador"
+    - "Desarrolladora"
+    - "Analista de Datos"
+    - "Científico de Datos"
+    - "Líder Técnico"
+    - "Arquitecto de Software"
+    - "Gerente de Producto"
+    - "Automatización"
+    - "Inteligencia Artificial"
+    - "Aprendizaje Automático"
+
+  negative:
+    # [CUSTOMIZE] Add keywords for roles you want to exclude
+    - "Junior"
+    - "Intern"
+    - ".NET"
+    - "Java "
+    - "iOS"
+    - "Android"
+    - "PHP"
+    - "Ruby"
+    - "Embedded"
+    - "Firmware"
+    - "FPGA"
+    - "ASIC"
+    - "Blockchain"
+    - "Web3"
+    - "Crypto"
+    - "Salesforce Admin"
+    - "SAP "
+    - "Oracle EBS"
+    - "Mainframe"
+    - "COBOL"
+    # -- AR-specific negatives (uncomment based on your seniority) --
+    # - "Pasantía"
+    # - "Practicante"
+    # - "Becario"
+    # - "Trainee"
+    - "Reemplazo por maternidad"
+    - "Reemplazo por licencia"
+
+  seniority_boost:
+    # These prefixes add relevance but are not required
+    - "Senior"
+    - "Semi Senior"
+    - "SSr"
+    - "Sr"
+    - "Staff"
+    - "Principal"
+    - "Lead"
+    - "Head"
+    - "Director"
+    - "Ssr."
+    - "Sr."
+
+# -- Search queries --
+# Each query triggers a WebSearch. Use site: to filter by portal.
+# The scanner extracts title, URL, and company from results.
+
+search_queries:
+  # -- AR job boards --
+  - name: Bumeran — Tech e IA
+    query: 'site:bumeran.com.ar "ingeniero" OR "developer" OR "AI" OR "datos" senior'
+    enabled: true
+
+  - name: Computrabajo AR — Tech senior
+    query: 'site:ar.computrabajo.com "tech" OR "tecnología" OR "software" OR "datos" senior'
+    enabled: true
+
+  - name: GetOnBoard — Argentina remote
+    query: 'site:getonbrd.com "Argentina" ("remote" OR "remoto") ("AI" OR "ML" OR "datos" OR "backend")'
+    enabled: true
+
+  - name: GetOnBoard — LATAM Tech
+    query: 'site:getonbrd.com "LATAM" OR "Latinoamérica" senior engineer OR developer OR data'
+    enabled: true
+
+  # -- LinkedIn AR targeting --
+  - name: LinkedIn — Argentina AI/ML remote
+    query: 'site:linkedin.com/jobs "Argentina" ("AI" OR "ML" OR "LLM" OR "datos") remote'
+    enabled: true
+
+  - name: LinkedIn — Argentina Tech Senior
+    query: 'site:linkedin.com/jobs "Argentina" ("ingeniero de software" OR "backend" OR "full stack") ("senior" OR "ssr")'
+    enabled: true
+
+  # -- Global ATS boards targeting AR/LATAM --
+  - name: Greenhouse — Argentina/LATAM remote
+    query: 'site:boards.greenhouse.io OR site:job-boards.greenhouse.io "remote" ("Argentina" OR "LATAM") engineer'
+    enabled: true
+
+  - name: Lever — LATAM remote
+    query: 'site:jobs.lever.co "remote" ("LATAM" OR "Argentina") ("engineer" OR "developer" OR "AI")'
+    enabled: true
+
+  - name: Ashby — LATAM remote
+    query: 'site:jobs.ashbyhq.com "remote" ("Argentina" OR "LATAM") ("engineer" OR "developer")'
+    enabled: true
+
+  # -- Remote-friendly boards (AR/LATAM candidates) --
+  - name: Remotive — AR-compatible remote
+    query: 'site:remotive.com ("Argentina" OR "LATAM" OR "Americas") ("AI Engineer" OR "Data Engineer" OR "Backend")'
+    enabled: true
+
+  - name: WeWorkRemotely — Tech/AI Americas
+    query: 'site:weworkremotely.com ("AI" OR "Data" OR "Backend" OR "Full Stack") ("Americas" OR "LATAM" OR "worldwide")'
+    enabled: true
+
+  - name: RemoteOK — AI/Data/Backend
+    query: 'site:remoteok.com ("AI Engineer" OR "Data Engineer" OR "Backend" OR "Full Stack") worldwide'
+    enabled: true
+
+  - name: Himalayas — Remote AI/Data Americas
+    query: 'site:himalayas.app ("AI Engineer" OR "Data Scientist" OR "Backend Engineer") ("Argentina" OR "LATAM" OR "Americas")'
+    enabled: true
+
+  # -- Specialized tech job boards --
+  - name: YC Jobs — AI/Founding/Remote
+    query: 'site:ycombinator.com/jobs OR site:workatastartup.com ("AI Engineer" OR "Data Engineer" OR "Backend") remote ("LATAM" OR "Americas" OR "worldwide")'
+    enabled: true
+
+  - name: HN Who is Hiring — Remote LATAM
+    query: 'site:news.ycombinator.com "who is hiring" ("Argentina" OR "LATAM" OR "Americas") remote engineer'
+    enabled: true
+
+# -- Tracked companies --
+# Companies whose career pages are checked directly.
+# scan_method: playwright (default), websearch, greenhouse_api
+# For Greenhouse companies, add api: field for faster structured JSON access.
+
+tracked_companies:
+
+  # =========================================================
+  # AR-NATIVE (~30) — Buenos Aires tech ecosystem
+  # =========================================================
+
+  # -- AR tech leaders --
+
+  - name: Mercado Libre
+    careers_url: https://careers.mercadolibre.com
+    scan_method: websearch
+    scan_query: 'site:careers.mercadolibre.com "engineer" OR "AI" OR "datos" OR "producto"'
+    notes: "AR tech giant, e-commerce + fintech + logistics. Large engineering and AI teams."
+    enabled: true
+
+  - name: Globant
+    careers_url: https://career.globant.com
+    scan_method: websearch
+    scan_query: 'site:career.globant.com "AI" OR "ML" OR "engineer" OR "architect" senior'
+    notes: "AR-founded IT/digital transformation consultancy. 30k+ employees in 35 countries."
+    enabled: true
+
+  - name: Despegar
+    careers_url: https://despegar.com/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"despegar" OR "despegar.com" careers "engineer" OR "data" OR "AI" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR travel unicorn. Strong data and engineering teams in Buenos Aires."
+    enabled: false
+
+  # -- AR fintech --
+
+  - name: Ualá
+    careers_url: https://www.uala.com.ar/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"uala" OR "ualá" careers "engineer" OR "data" OR "AI" site:linkedin.com/jobs OR site:getonbrd.com'
+    notes: "AR neobank unicorn. Engineering and data teams in BA."
+    enabled: true
+
+  - name: Naranja X
+    careers_url: https://naranjax.com/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"naranja x" careers "engineer" OR "developer" OR "data" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR fintech (Banco Naranja digital arm). Córdoba + remote."
+    enabled: false
+
+  - name: Brubank
+    careers_url: https://brubank.com/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"brubank" careers "engineer" OR "backend" OR "data" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR digital bank. Buenos Aires based."
+    enabled: false
+
+  - name: Pomelo
+    careers_url: https://pomelo.la/careers
+    scan_method: websearch
+    scan_query: '"pomelo" OR "pomelo.la" careers "engineer" OR "data" OR "backend" site:linkedin.com/jobs OR site:getonbrd.com'
+    notes: "AR fintech infrastructure (card issuing, BaaS). Series B."
+    enabled: true
+
+  - name: Ripio
+    careers_url: https://ripio.com/ar/careers/
+    scan_method: websearch
+    scan_query: '"ripio" careers "engineer" OR "developer" OR "blockchain" site:linkedin.com/jobs OR site:getonbrd.com'
+    notes: "AR crypto exchange and fintech. Buenos Aires."
+    enabled: false
+
+  - name: Lemon Cash
+    careers_url: https://lemon.me/careers
+    scan_method: websearch
+    scan_query: '"lemon cash" OR "lemon.me" careers "engineer" OR "developer" OR "backend" site:linkedin.com/jobs'
+    notes: "AR crypto neobank. Buenos Aires."
+    enabled: false
+
+  - name: Buenbit
+    careers_url: https://buenbit.com/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"buenbit" careers "engineer" OR "developer" OR "data" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR crypto exchange. Buenos Aires."
+    enabled: false
+
+  - name: Personal Pay
+    careers_url: https://personalpay.com.ar/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"personal pay" careers "engineer" OR "developer" OR "data" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR digital wallet by Telecom Argentina. Buenos Aires."
+    enabled: false
+
+  - name: MODO
+    careers_url: https://modo.com.ar/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"MODO" "pagos" OR "fintech" careers "engineer" OR "developer" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR interoperable digital wallet backed by major AR banks."
+    enabled: false
+
+  - name: Prisma Medios de Pago
+    careers_url: https://prisma.com.ar/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"prisma medios de pago" careers "engineer" OR "developer" OR "data" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR payments infrastructure (Visa acquiring, Todo1). Buenos Aires."
+    enabled: false
+
+  # -- AR e-commerce & retail tech --
+
+  - name: TiendaNube
+    careers_url: https://www.tiendanube.com/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"tiendanube" OR "nuvemshop" careers "engineer" OR "developer" OR "data" OR "product" site:linkedin.com/jobs OR site:getonbrd.com'
+    notes: "AR/BR e-commerce platform unicorn. Buenos Aires + São Paulo. Strong product & engineering."
+    enabled: true
+
+  - name: OLX LATAM
+    careers_url: https://olx.com.ar/jobs
+    scan_method: websearch
+    scan_query: '"OLX LATAM" OR "OLX Argentina" careers "engineer" OR "data" OR "product" site:linkedin.com/jobs'
+    notes: "AR classifieds marketplace. Data and product engineering teams in BA."
+    enabled: false
+
+  - name: InvertirOnline
+    careers_url: https://www.invertironline.com/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"invertironline" OR "iol" careers "developer" OR "engineer" OR "data" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR online brokerage (Grupo Supervielle). Buenos Aires."
+    enabled: false
+
+  # -- AR tech consultancies & dev shops --
+
+  - name: 10Pines
+    careers_url: https://www.10pines.com/jobs
+    scan_method: websearch
+    scan_query: '"10pines" careers "developer" OR "engineer" OR "agile" site:linkedin.com/jobs OR site:getonbrd.com'
+    notes: "AR software consultancy with XP/agile culture. Buenos Aires + remote."
+    enabled: false
+
+  - name: Wolox (Accenture AR)
+    careers_url: https://wolox.com.ar/careers
+    scan_method: websearch
+    scan_query: '"wolox" OR "wolox accenture" careers "engineer" OR "developer" OR "AI" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR tech studio acquired by Accenture. Buenos Aires. Still operates own brand."
+    enabled: false
+
+  # -- AR gaming & entertainment tech --
+
+  - name: Etermax
+    careers_url: https://etermax.com/careers/
+    scan_method: websearch
+    scan_query: '"etermax" careers "engineer" OR "developer" OR "data" OR "AI" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR mobile gaming company (Trivia Crack). Buenos Aires. Data & AI teams."
+    enabled: false
+
+  - name: Wildlife Studios AR
+    careers_url: https://wildlifestudios.com/careers
+    scan_method: websearch
+    scan_query: '"wildlife studios" careers "engineer" OR "developer" OR "data" site:linkedin.com/jobs'
+    notes: "BR mobile gaming studio with significant AR engineering presence."
+    enabled: false
+
+  # -- AR space tech & deep tech --
+
+  - name: Satellogic
+    careers_url: https://satellogic.com/careers/
+    scan_method: websearch
+    scan_query: 'site:satellogic.com/careers OR "satellogic" "engineer" OR "data" OR "ML" site:linkedin.com/jobs'
+    notes: "AR-founded satellite imagery company. Nanosatellite constellation. ML and data roles."
+    enabled: false
+
+  # -- AR proptech & marketplace --
+
+  - name: Mudafy
+    careers_url: https://mudafy.com/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"mudafy" careers "engineer" OR "developer" OR "product" site:linkedin.com/jobs OR site:getonbrd.com'
+    notes: "AR proptech (real estate marketplace). Buenos Aires."
+    enabled: false
+
+  - name: 123Seguro
+    careers_url: https://123seguro.com/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"123seguro" careers "engineer" OR "developer" OR "data" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR insurtech. Buenos Aires."
+    enabled: false
+
+  # -- AR adtech & martech --
+
+  - name: Jampp
+    careers_url: https://job-boards.greenhouse.io/jampp
+    api: https://boards-api.greenhouse.io/v1/boards/jampp/jobs
+    notes: "AR adtech (mobile app marketing). Buenos Aires. Has ML Engineer roles."
+    enabled: false
+
+  # -- AR digital education --
+
+  - name: Digital House
+    careers_url: https://digitalhouse.com/ar/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"digital house" careers "engineer" OR "developer" OR "data" OR "instructor" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR edtech (coding bootcamp + tech education). Buenos Aires."
+    enabled: false
+
+  - name: MercadoPago
+    careers_url: https://careers.mercadolibre.com/ml/jobs
+    scan_method: websearch
+    scan_query: '"mercado pago" careers "engineer" OR "data" OR "AI" OR "backend" site:linkedin.com/jobs'
+    notes: "Fintech arm of Mercado Libre. Massive engineering and data org in BA. Tracks under ML careers portal."
+    enabled: false
+
+  - name: Quipu
+    careers_url: https://quipu.com.ar/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"quipu" OR "quipu market" careers "engineer" OR "developer" OR "data" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR fintech (B2B payments and credit for SMEs). Buenos Aires."
+    enabled: false
+
+  - name: Reba
+    careers_url: https://reba.com.ar/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"reba" OR "reba fintech" careers "engineer" OR "developer" OR "data" site:linkedin.com/jobs OR site:bumeran.com.ar'
+    notes: "AR corporate expense management fintech. Buenos Aires."
+    enabled: false
+
+  # -- AR/LATAM heritage / now global --
+
+  - name: Auth0 (Okta)
+    careers_url: https://www.okta.com/company/careers/
+    scan_method: websearch
+    scan_query: 'site:okta.com/company/careers "engineer" OR "developer" OR "AI" remote ("LATAM" OR "Americas")'
+    notes: "AR-founded identity platform (Auth0), now Okta. Remote-first, AR-heritage. Strong engineering culture."
+    enabled: false
+
+  - name: dLocal
+    careers_url: https://dlocal.com/careers/
+    scan_method: websearch
+    scan_query: 'site:dlocal.com/careers "engineer" OR "developer" OR "data" OR "product" remote'
+    notes: "UY-founded payments platform with major AR presence. Remote-friendly. Processes payments across 40+ markets."
+    enabled: true
+
+  # =========================================================
+  # LATAM REGIONAL (~10) — Significant AR presence or LATAM HQ
+  # =========================================================
+
+  - name: Belvo
+    careers_url: https://belvo.com/careers/
+    scan_method: websearch
+    scan_query: 'site:belvo.com/careers "engineer" OR "developer" OR "data" OR "product"'
+    notes: "Open banking API for LATAM. Remote across LATAM. Strong eng and data teams."
+    enabled: true
+
+  - name: Bitso
+    careers_url: https://bitso.com/jobs
+    scan_method: websearch
+    scan_query: 'site:bitso.com/jobs "engineer" OR "developer" OR "data" OR "product"'
+    notes: "MX-founded crypto exchange, major LATAM presence incl AR. Remote-friendly."
+    enabled: true
+
+  - name: Kushki
+    careers_url: https://kushki.com/careers
+    scan_method: websearch
+    scan_query: '"kushki" careers "engineer" OR "developer" OR "data" site:linkedin.com/jobs OR site:getonbrd.com'
+    notes: "LATAM payments infrastructure (Ecuador HQ). Remote across LATAM."
+    enabled: false
+
+  - name: NotCo
+    careers_url: https://notco.com/us/careers/
+    scan_method: websearch
+    scan_query: '"notco" careers "engineer" OR "developer" OR "data" OR "AI" site:linkedin.com/jobs'
+    notes: "CL-founded food-tech AI company (NotMilk, NotBurger). AI-driven product development."
+    enabled: false
+
+  - name: Kavak
+    careers_url: https://kavak.com/ar/trabaja-con-nosotros
+    scan_method: websearch
+    scan_query: '"kavak" careers "engineer" OR "developer" OR "data" OR "product" site:linkedin.com/jobs'
+    notes: "MX-founded used car marketplace unicorn. Growing AR operations. Data and tech teams."
+    enabled: false
+
+  - name: Rappi
+    careers_url: https://about.rappi.com/careers
+    scan_method: websearch
+    scan_query: '"rappi" careers "engineer" OR "developer" OR "data" OR "AI" site:linkedin.com/jobs OR site:getonbrd.com'
+    notes: "CO-founded super-app unicorn. Large AR market. Engineering and data teams across LATAM."
+    enabled: false
+
+  - name: Betterfly
+    careers_url: https://betterfly.com/careers
+    scan_method: websearch
+    scan_query: '"betterfly" careers "engineer" OR "developer" OR "product" site:linkedin.com/jobs OR site:getonbrd.com'
+    notes: "CL-founded benefits platform unicorn. Remote across LATAM."
+    enabled: false
+
+  - name: Nubank
+    careers_url: https://international.nubank.com.br/careers/
+    scan_method: websearch
+    scan_query: 'site:international.nubank.com.br/careers "engineer" OR "developer" OR "AI" OR "ML" remote'
+    notes: "BR-founded neobank with AR hiring. 8k+ employees. ML and data teams."
+    enabled: true
+
+  - name: Fintual
+    careers_url: https://fintual.com/trabaja-en-fintual
+    scan_method: websearch
+    scan_query: '"fintual" careers "engineer" OR "developer" OR "data" site:linkedin.com/jobs OR site:getonbrd.com'
+    notes: "CL-founded robo-advisor. Strong engineering culture. Chile + Mexico + Colombia."
+    enabled: false
+
+  - name: Clip
+    careers_url: https://clip.mx/empleos
+    scan_method: websearch
+    scan_query: '"clip" OR "clip.mx" careers "engineer" OR "developer" OR "data" site:linkedin.com/jobs'
+    notes: "MX payment terminal fintech. Engineering and data teams."
+    enabled: false
+
+  # =========================================================
+  # GLOBAL WITH AR-REMOTE TEAMS (~10)
+  # =========================================================
+
+  - name: Stripe
+    careers_url: https://stripe.com/jobs
+    scan_method: websearch
+    scan_query: 'site:stripe.com/jobs "engineer" OR "developer" OR "data" remote ("LATAM" OR "Americas" OR "worldwide")'
+    notes: "Global payments infrastructure. Remote-first. Has hired AR engineers. High engineering bar."
+    enabled: true
+
+  - name: Deel
+    careers_url: https://www.deel.com/careers
+    scan_method: websearch
+    scan_query: 'site:deel.com/careers "engineer" OR "developer" OR "AI" OR "data" remote'
+    notes: "Global HR/payroll platform. Remote-first. 265+ open roles. Hires across LATAM."
+    enabled: true
+
+  - name: Remote
+    careers_url: https://remote.com/careers
+    scan_method: websearch
+    scan_query: 'site:remote.com/careers "engineer" OR "developer" OR "product" OR "AI"'
+    notes: "Global employment platform. Fully remote, worldwide hiring. Hires in AR."
+    enabled: true
+
+  - name: GitLab
+    careers_url: https://about.gitlab.com/jobs/
+    scan_method: websearch
+    scan_query: 'site:about.gitlab.com/jobs "engineer" OR "developer" OR "AI" OR "data" remote'
+    notes: "DevOps platform. Fully remote, worldwide. Has hired AR engineers historically."
+    enabled: true
+
+  - name: Canonical
+    careers_url: https://canonical.com/careers
+    scan_method: websearch
+    scan_query: 'site:canonical.com/careers "engineer" OR "developer" OR "AI" OR "data" remote'
+    notes: "Ubuntu/Linux company. Fully remote, 162+ engineering roles. Hires in AR."
+    enabled: true
+
+  - name: DataDog
+    careers_url: https://careers.datadoghq.com/
+    scan_method: websearch
+    scan_query: 'site:careers.datadoghq.com "engineer" OR "developer" OR "AI" OR "ML" remote ("Americas" OR "LATAM")'
+    notes: "Observability/monitoring platform. Remote-friendly. Has LATAM engineering roles."
+    enabled: true
+
+  - name: Toptal
+    careers_url: https://www.toptal.com/careers
+    scan_method: websearch
+    scan_query: '"toptal" site:toptal.com/careers "engineer" OR "developer" OR "product" remote'
+    notes: "Remote talent network. Fully distributed. Has internal roles for engineers and product managers."
+    enabled: false
+
+  - name: Turing
+    careers_url: https://careers.turing.com
+    scan_method: websearch
+    scan_query: 'site:careers.turing.com "engineer" OR "developer" OR "product" remote'
+    notes: "Remote tech talent platform. Internal roles for engineers and product managers worldwide."
+    enabled: false
+
+  - name: Andela
+    careers_url: https://jobs.ashbyhq.com/andela
+    scan_method: websearch
+    scan_query: 'site:jobs.ashbyhq.com/andela "engineer" OR "developer" OR "product" remote'
+    notes: "African-founded remote talent network expanding to LATAM. Internal roles globally."
+    enabled: false
+
+  - name: Modak
+    careers_url: https://modak.com/careers/
+    scan_method: websearch
+    scan_query: '"modak" site:modak.com/careers OR site:linkedin.com/jobs "engineer" OR "developer" OR "data" remote'
+    notes: "Data engineering consultancy with strong LATAM team. Remote-friendly."
+    enabled: false


### PR DESCRIPTION
## Summary

- Adds `modes/es/` — a complete rioplatense Spanish localization of career-ops for the Argentine job market
- Includes `_shared.md` with Argentine labor law vocabulary (LCT, SAC, ART, obra social, ajuste IPC) and compensation red/green flags
- `oferta.md` extends blocks C and F with AR-specific contract checks (modalidad, moneda, ajuste IPC, SAC/ART/obra social)
- `aplicar.md` handles Argentine salary negotiation branches (RD/ARS, monotributo/USD, contractor/USD) and common form fields (CUIT/CUIL)
- `pipeline.md` direct translation with all file paths verbatim
- `templates/portals.ar.example.yml` — 50-company starter (30 AR-native, 10 LATAM regional, 10 global-AR-remote)
- `CLAUDE.md` updated with Spanish (AR) trigger conditions and fork guide for other LATAM markets
- `config/profile.example.yml` updated with commented `language.modes_dir` example

## Design decisions

- All pipeline contract identifiers stay in English (`**Score:**`, `**Legitimacy:**`, canonical states like `Evaluated`) so `verify-pipeline.mjs` and `merge-tracker.mjs` work without changes
- User-layer separation maintained: `modes/es/_shared.md` is system-layer (auto-updatable); user data stays in `modes/_profile.md` and `config/profile.yml`
- JD in English → evaluation in English (rule 8); JD in Spanish → rioplatense Spanish output

## Test plan

- [x] `node verify-pipeline.mjs` — 0 errors, 0 warnings after smoke test evaluation
- [x] `node merge-tracker.mjs` — entry #1 added correctly from TSV
- [x] Smoke test: evaluated Globant VP of Technology listing via `modes/es/oferta.md` — all 7 blocks A-G generated, Block C AR checks fired, pipeline contract intact
- [ ] Run `node test-all.mjs` to confirm no regressions beyond pre-existing failures

## Scope

Implements the design in `docs/superpowers/specs/2026-04-20-modes-es-ar-design.md` and plan in `docs/superpowers/plans/2026-04-20-modes-es-ar-implementation.md`.

For other LATAM markets (MX, CL, CO): fork `modes/es/` into `modes/es-mx/` etc. and replace the "Mercado argentino" section — see `modes/es/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Spanish (Argentina) language modes for the career-ops evaluation system.

* **Documentation**
  * Introduced comprehensive Spanish (Argentina) documentation for job evaluation, application, and pipeline workflows.
  * Added Argentina-specific job portal scanner templates and configuration examples.
  * Updated core documentation with Spanish mode activation guidelines and usage conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->