### PR TITLE
chore: add cv.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ jds/*
 config/profile.yml
 portals.yml
 modes/_profile.md
+cv.md
 .update-dismissed
 .update-lock
 


### PR DESCRIPTION
## Summary

`cv.md` is user personal data (CV content) but is not listed in `.gitignore`, while every other user-layer file is:

- `config/profile.yml` — ignored
- `modes/_profile.md` — ignored
- `portals.yml` — ignored
- `cv.md` — **not ignored** ← this PR

A careless `git add .` (or a contributor opening a PR from their own fork) would stage personal CV content and risk leaking it into git history.

`DATA_CONTRACT.md` and `CLAUDE.md` already classify `cv.md` as a user-layer file that should never be auto-updated, so ignoring it matches the documented contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to optimize file tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->