### PR TITLE
fix: keep updater system paths in sync

### DIFF
--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -42,6 +42,8 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/project.md` | Project evaluation instructions |
 | `modes/tracker.md` | Tracker instructions |
 | `modes/training.md` | Training evaluation instructions |
+| `modes/interview-prep.md` | Interview preparation instructions |
+| `modes/latex.md` | LaTeX CV generation instructions |
 | `modes/patterns.md` | Pattern analysis instructions |
 | `modes/followup.md` | Follow-up cadence instructions |
 | `modes/de/*` | German language modes |

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -45,8 +45,13 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/patterns.md` | Pattern analysis instructions |
 | `modes/followup.md` | Follow-up cadence instructions |
 | `modes/de/*` | German language modes |
+| `modes/fr/*` | French language modes |
+| `modes/ja/*` | Japanese language modes |
+| `modes/pt/*` | Portuguese language modes |
+| `modes/ru/*` | Russian language modes |
 | `CLAUDE.md` | Agent instructions |
 | `AGENTS.md` | Codex instructions |
+| `GEMINI.md` | Gemini CLI instructions |
 | `*.mjs` | Utility scripts |
 | `batch/batch-prompt.md` | Batch worker prompt |
 | `batch/batch-runner.sh` | Batch orchestrator |

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -44,16 +44,20 @@ function readFile(path) { return readFileSync(join(ROOT, path), 'utf-8'); }
 function reportSetDifference(actual, expected, missingMsg, extraMsg) {
   const actualSet = new Set(actual);
   const expectedSet = new Set(expected);
+  let equal = true;
   for (const item of expected) {
-    if (!actualSet.has(item)) fail(missingMsg(item));
+    if (!actualSet.has(item)) {
+      fail(missingMsg(item));
+      equal = false;
+    }
   }
   for (const item of actual) {
-    if (!expectedSet.has(item)) fail(extraMsg(item));
+    if (!expectedSet.has(item)) {
+      fail(extraMsg(item));
+      equal = false;
+    }
   }
-  if (expected.every(item => actualSet.has(item)) && actual.every(item => expectedSet.has(item))) {
-    return true;
-  }
-  return false;
+  return equal;
 }
 
 console.log('\n🧪 career-ops test suite\n');
@@ -169,33 +173,38 @@ for (const f of systemFiles) {
 }
 
 const { SYSTEM_PATHS } = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
-const trackedFiles = (run('git', ['ls-files']) || '').split('\n').filter(Boolean);
-const rootScripts = trackedFiles
-  .filter(f => f.endsWith('.mjs') && !f.includes('/'))
-  .sort();
-const updaterRootScripts = SYSTEM_PATHS
-  .filter(f => f.endsWith('.mjs') && !f.includes('/'))
-  .sort();
-if (reportSetDifference(
-  updaterRootScripts,
-  rootScripts,
-  scriptName => `Updater missing script: ${scriptName}`,
-  scriptName => `Updater has untracked script: ${scriptName}`,
-)) pass('Updater root scripts match tracked scripts');
+const gitLsOutput = run('git', ['ls-files']);
+if (gitLsOutput === null || gitLsOutput === '') {
+  fail('Could not run `git ls-files` to validate updater paths');
+} else {
+  const trackedFiles = gitLsOutput.split('\n').filter(Boolean);
+  const rootScripts = trackedFiles
+    .filter(f => f.endsWith('.mjs') && !f.includes('/'))
+    .sort();
+  const updaterRootScripts = SYSTEM_PATHS
+    .filter(f => f.endsWith('.mjs') && !f.includes('/'))
+    .sort();
+  if (reportSetDifference(
+    updaterRootScripts,
+    rootScripts,
+    scriptName => `Updater missing script: ${scriptName}`,
+    scriptName => `Updater has untracked script: ${scriptName}`,
+  )) pass('Updater root scripts match tracked scripts');
 
-const localizedModeDirs = [...new Set(trackedFiles
-  .filter(f => f.startsWith('modes/') && f.split('/').length > 2)
-  .map(f => `${f.split('/').slice(0, 2).join('/')}/`))]
-  .sort();
-const updaterLocalizedModeDirs = SYSTEM_PATHS
-  .filter(f => /^modes\/[^/]+\/$/.test(f))
-  .sort();
-if (reportSetDifference(
-  updaterLocalizedModeDirs,
-  localizedModeDirs,
-  modeDir => `Updater missing localized modes: ${modeDir}`,
-  modeDir => `Updater has untracked localized modes: ${modeDir}`,
-)) pass('Updater localized mode directories match tracked directories');
+  const localizedModeDirs = [...new Set(trackedFiles
+    .filter(f => f.startsWith('modes/') && f.split('/').length > 2)
+    .map(f => `${f.split('/').slice(0, 2).join('/')}/`))]
+    .sort();
+  const updaterLocalizedModeDirs = SYSTEM_PATHS
+    .filter(f => /^modes\/[^/]+\/$/.test(f))
+    .sort();
+  if (reportSetDifference(
+    updaterLocalizedModeDirs,
+    localizedModeDirs,
+    modeDir => `Updater missing localized modes: ${modeDir}`,
+    modeDir => `Updater has untracked localized modes: ${modeDir}`,
+  )) pass('Updater localized mode directories match tracked directories');
+}
 
 // Check user files are NOT tracked (gitignored)
 const userFiles = [

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -173,8 +173,10 @@ for (const f of systemFiles) {
 }
 
 const gitLsOutput = run('git', ['ls-files']);
-if (gitLsOutput === null || gitLsOutput === '') {
+if (gitLsOutput === null) {
   fail('Could not run `git ls-files` to validate updater paths');
+} else if (gitLsOutput === '') {
+  fail('Repository has no tracked files; cannot validate updater paths');
 } else {
   const trackedFiles = gitLsOutput.split('\n').filter(Boolean);
   const rootScripts = trackedFiles
@@ -291,14 +293,11 @@ if (!absPathResult) {
 
 console.log('\n8. Mode file integrity');
 
-const expectedModes = CORE_MODE_FILES
-  .map(modePath => modePath.replace(/^modes\//, ''));
-
-for (const mode of expectedModes) {
-  if (fileExists(`modes/${mode}`)) {
-    pass(`Mode exists: ${mode}`);
+for (const modePath of CORE_MODE_FILES) {
+  if (fileExists(modePath)) {
+    pass(`Mode exists: ${modePath}`);
   } else {
-    fail(`Missing mode: ${mode}`);
+    fail(`Missing mode: ${modePath}`);
   }
 }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -155,7 +155,10 @@ for (const f of systemFiles) {
 }
 
 const updaterSource = readFile('update-system.mjs');
-const rootScripts = readdirSync(ROOT).filter(f => f.endsWith('.mjs')).sort();
+const trackedFiles = (run('git', ['ls-files']) || '').split('\n').filter(Boolean);
+const rootScripts = trackedFiles
+  .filter(f => f.endsWith('.mjs') && !f.includes('/'))
+  .sort();
 for (const scriptName of rootScripts) {
   if (updaterSource.includes(`'${scriptName}'`)) {
     pass(`Updater includes script: ${scriptName}`);
@@ -164,9 +167,9 @@ for (const scriptName of rootScripts) {
   }
 }
 
-const localizedModeDirs = readdirSync(join(ROOT, 'modes'), { withFileTypes: true })
-  .filter(entry => entry.isDirectory())
-  .map(entry => `modes/${entry.name}/`)
+const localizedModeDirs = [...new Set(trackedFiles
+  .filter(f => f.startsWith('modes/') && f.split('/').length > 2)
+  .map(f => `${f.split('/').slice(0, 2).join('/')}/`))]
   .sort();
 for (const modeDir of localizedModeDirs) {
   if (updaterSource.includes(`'${modeDir}'`)) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -41,6 +41,20 @@ function run(cmd, args = [], opts = {}) {
 
 function fileExists(path) { return existsSync(join(ROOT, path)); }
 function readFile(path) { return readFileSync(join(ROOT, path), 'utf-8'); }
+function reportSetDifference(actual, expected, missingMsg, extraMsg) {
+  const actualSet = new Set(actual);
+  const expectedSet = new Set(expected);
+  for (const item of expected) {
+    if (!actualSet.has(item)) fail(missingMsg(item));
+  }
+  for (const item of actual) {
+    if (!expectedSet.has(item)) fail(extraMsg(item));
+  }
+  if (expected.every(item => actualSet.has(item)) && actual.every(item => expectedSet.has(item))) {
+    return true;
+  }
+  return false;
+}
 
 console.log('\n🧪 career-ops test suite\n');
 
@@ -154,30 +168,34 @@ for (const f of systemFiles) {
   }
 }
 
-const updaterSource = readFile('update-system.mjs');
+const { SYSTEM_PATHS } = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
 const trackedFiles = (run('git', ['ls-files']) || '').split('\n').filter(Boolean);
 const rootScripts = trackedFiles
   .filter(f => f.endsWith('.mjs') && !f.includes('/'))
   .sort();
-for (const scriptName of rootScripts) {
-  if (updaterSource.includes(`'${scriptName}'`)) {
-    pass(`Updater includes script: ${scriptName}`);
-  } else {
-    fail(`Updater missing script: ${scriptName}`);
-  }
-}
+const updaterRootScripts = SYSTEM_PATHS
+  .filter(f => f.endsWith('.mjs') && !f.includes('/'))
+  .sort();
+if (reportSetDifference(
+  updaterRootScripts,
+  rootScripts,
+  scriptName => `Updater missing script: ${scriptName}`,
+  scriptName => `Updater has untracked script: ${scriptName}`,
+)) pass('Updater root scripts match tracked scripts');
 
 const localizedModeDirs = [...new Set(trackedFiles
   .filter(f => f.startsWith('modes/') && f.split('/').length > 2)
   .map(f => `${f.split('/').slice(0, 2).join('/')}/`))]
   .sort();
-for (const modeDir of localizedModeDirs) {
-  if (updaterSource.includes(`'${modeDir}'`)) {
-    pass(`Updater includes localized modes: ${modeDir}`);
-  } else {
-    fail(`Updater missing localized modes: ${modeDir}`);
-  }
-}
+const updaterLocalizedModeDirs = SYSTEM_PATHS
+  .filter(f => /^modes\/[^/]+\/$/.test(f))
+  .sort();
+if (reportSetDifference(
+  updaterLocalizedModeDirs,
+  localizedModeDirs,
+  modeDir => `Updater missing localized modes: ${modeDir}`,
+  modeDir => `Updater has untracked localized modes: ${modeDir}`,
+)) pass('Updater localized mode directories match tracked directories');
 
 // Check user files are NOT tracked (gitignored)
 const userFiles = [

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -155,11 +155,11 @@ if (!QUICK) {
 console.log('\n5. Data contract validation');
 
 // Check system files exist
+const { SYSTEM_PATHS, CORE_MODE_FILES } = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+
 const systemFiles = [
   'CLAUDE.md', 'VERSION', 'DATA_CONTRACT.md',
-  'modes/_shared.md', 'modes/_profile.template.md',
-  'modes/oferta.md', 'modes/pdf.md', 'modes/scan.md',
-  'modes/followup.md', 'modes/interview-prep.md', 'modes/latex.md', 'modes/patterns.md',
+  ...CORE_MODE_FILES,
   'templates/states.yml', 'templates/cv-template.html',
   '.claude/skills/career-ops/SKILL.md',
 ];
@@ -172,7 +172,6 @@ for (const f of systemFiles) {
   }
 }
 
-const { SYSTEM_PATHS } = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
 const gitLsOutput = run('git', ['ls-files']);
 if (gitLsOutput === null || gitLsOutput === '') {
   fail('Could not run `git ls-files` to validate updater paths');
@@ -292,12 +291,8 @@ if (!absPathResult) {
 
 console.log('\n8. Mode file integrity');
 
-const expectedModes = [
-  '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'scan.md',
-  'batch.md', 'apply.md', 'auto-pipeline.md', 'contacto.md', 'deep.md',
-  'followup.md', 'interview-prep.md', 'latex.md', 'ofertas.md', 'patterns.md',
-  'pipeline.md', 'project.md', 'tracker.md', 'training.md',
-];
+const expectedModes = CORE_MODE_FILES
+  .map(modePath => modePath.replace(/^modes\//, ''));
 
 for (const mode of expectedModes) {
   if (fileExists(`modes/${mode}`)) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -141,6 +141,7 @@ const systemFiles = [
   'CLAUDE.md', 'VERSION', 'DATA_CONTRACT.md',
   'modes/_shared.md', 'modes/_profile.template.md',
   'modes/oferta.md', 'modes/pdf.md', 'modes/scan.md',
+  'modes/followup.md', 'modes/interview-prep.md', 'modes/latex.md', 'modes/patterns.md',
   'templates/states.yml', 'templates/cv-template.html',
   '.claude/skills/career-ops/SKILL.md',
 ];
@@ -150,6 +151,28 @@ for (const f of systemFiles) {
     pass(`System file exists: ${f}`);
   } else {
     fail(`Missing system file: ${f}`);
+  }
+}
+
+const updaterSource = readFile('update-system.mjs');
+const rootScripts = readdirSync(ROOT).filter(f => f.endsWith('.mjs')).sort();
+for (const scriptName of rootScripts) {
+  if (updaterSource.includes(`'${scriptName}'`)) {
+    pass(`Updater includes script: ${scriptName}`);
+  } else {
+    fail(`Updater missing script: ${scriptName}`);
+  }
+}
+
+const localizedModeDirs = readdirSync(join(ROOT, 'modes'), { withFileTypes: true })
+  .filter(entry => entry.isDirectory())
+  .map(entry => `modes/${entry.name}/`)
+  .sort();
+for (const modeDir of localizedModeDirs) {
+  if (updaterSource.includes(`'${modeDir}'`)) {
+    pass(`Updater includes localized modes: ${modeDir}`);
+  } else {
+    fail(`Updater missing localized modes: ${modeDir}`);
   }
 }
 
@@ -242,7 +265,8 @@ console.log('\n8. Mode file integrity');
 const expectedModes = [
   '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'scan.md',
   'batch.md', 'apply.md', 'auto-pipeline.md', 'contacto.md', 'deep.md',
-  'ofertas.md', 'pipeline.md', 'project.md', 'tracker.md', 'training.md',
+  'followup.md', 'interview-prep.md', 'latex.md', 'ofertas.md', 'patterns.md',
+  'pipeline.md', 'project.md', 'tracker.md', 'training.md',
 ];
 
 for (const mode of expectedModes) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -17,7 +17,7 @@
 
 import { execFileSync, execSync } from 'child_process';
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -29,7 +29,7 @@ const RELEASES_API = 'https://api.github.com/repos/santifer/career-ops/releases/
 
 // System layer paths — ONLY these files get updated.
 // Keep these grouped so the updater mirrors DATA_CONTRACT.md and stays easy to audit.
-const CORE_MODE_FILES = [
+export const CORE_MODE_FILES = [
   'modes/_shared.md',
   'modes/_profile.template.md',
   'modes/apply.md',
@@ -51,7 +51,7 @@ const CORE_MODE_FILES = [
   'modes/training.md',
 ];
 
-const LOCALIZED_MODE_DIRECTORIES = [
+export const LOCALIZED_MODE_DIRECTORIES = [
   'modes/de/',
   'modes/fr/',
   'modes/ja/',
@@ -59,7 +59,7 @@ const LOCALIZED_MODE_DIRECTORIES = [
   'modes/ru/',
 ];
 
-const ROOT_SCRIPT_FILES = [
+export const ROOT_SCRIPT_FILES = [
   'analyze-patterns.mjs',
   'check-liveness.mjs',
   'cv-sync-check.mjs',
@@ -78,13 +78,13 @@ const ROOT_SCRIPT_FILES = [
   'verify-pipeline.mjs',
 ];
 
-const PROJECT_INSTRUCTION_FILES = [
+export const PROJECT_INSTRUCTION_FILES = [
   'CLAUDE.md',
   'AGENTS.md',
   'GEMINI.md',
 ];
 
-const SYSTEM_PATHS = [
+export const SYSTEM_PATHS = [
   ...CORE_MODE_FILES,
   ...LOCALIZED_MODE_DIRECTORIES,
   ...ROOT_SCRIPT_FILES,
@@ -351,14 +351,16 @@ function dismiss() {
 
 // ── MAIN ────────────────────────────────────────────────────────
 
-const cmd = process.argv[2] || 'check';
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const cmd = process.argv[2] || 'check';
 
-switch (cmd) {
-  case 'check': await check(); break;
-  case 'apply': await apply(); break;
-  case 'rollback': rollback(); break;
-  case 'dismiss': dismiss(); break;
-  default:
-    console.log('Usage: node update-system.mjs [check|apply|rollback|dismiss]');
-    process.exit(1);
+  switch (cmd) {
+    case 'check': await check(); break;
+    case 'apply': await apply(); break;
+    case 'rollback': rollback(); break;
+    case 'dismiss': dismiss(); break;
+    default:
+      console.log('Usage: node update-system.mjs [check|apply|rollback|dismiss]');
+      process.exit(1);
+  }
 }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -40,8 +40,8 @@ export const CORE_MODE_FILES = [
   'modes/followup.md',
   'modes/interview-prep.md',
   'modes/latex.md',
-  'modes/ofertas.md',
   'modes/oferta.md',
+  'modes/ofertas.md',
   'modes/patterns.md',
   'modes/pdf.md',
   'modes/pipeline.md',
@@ -351,7 +351,9 @@ function dismiss() {
 
 // ── MAIN ────────────────────────────────────────────────────────
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+const isMainModule = import.meta.main ?? (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url));
+
+if (isMainModule) {
   const cmd = process.argv[2] || 'check';
 
   switch (cmd) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -27,33 +27,68 @@ const CANONICAL_REPO = 'https://github.com/santifer/career-ops.git';
 const RAW_VERSION_URL = 'https://raw.githubusercontent.com/santifer/career-ops/main/VERSION';
 const RELEASES_API = 'https://api.github.com/repos/santifer/career-ops/releases/latest';
 
-// System layer paths — ONLY these files get updated
-const SYSTEM_PATHS = [
+// System layer paths — ONLY these files get updated.
+// Keep these grouped so the updater mirrors DATA_CONTRACT.md and stays easy to audit.
+const CORE_MODE_FILES = [
   'modes/_shared.md',
   'modes/_profile.template.md',
-  'modes/oferta.md',
-  'modes/pdf.md',
-  'modes/scan.md',
-  'modes/batch.md',
   'modes/apply.md',
   'modes/auto-pipeline.md',
+  'modes/batch.md',
   'modes/contacto.md',
   'modes/deep.md',
+  'modes/followup.md',
+  'modes/interview-prep.md',
+  'modes/latex.md',
   'modes/ofertas.md',
+  'modes/oferta.md',
+  'modes/patterns.md',
+  'modes/pdf.md',
   'modes/pipeline.md',
   'modes/project.md',
+  'modes/scan.md',
   'modes/tracker.md',
   'modes/training.md',
+];
+
+const LOCALIZED_MODE_DIRECTORIES = [
   'modes/de/',
+  'modes/fr/',
+  'modes/ja/',
+  'modes/pt/',
+  'modes/ru/',
+];
+
+const ROOT_SCRIPT_FILES = [
+  'analyze-patterns.mjs',
+  'check-liveness.mjs',
+  'cv-sync-check.mjs',
+  'dedup-tracker.mjs',
+  'doctor.mjs',
+  'followup-cadence.mjs',
+  'gemini-eval.mjs',
+  'generate-latex.mjs',
+  'generate-pdf.mjs',
+  'liveness-core.mjs',
+  'merge-tracker.mjs',
+  'normalize-statuses.mjs',
+  'scan.mjs',
+  'test-all.mjs',
+  'update-system.mjs',
+  'verify-pipeline.mjs',
+];
+
+const PROJECT_INSTRUCTION_FILES = [
   'CLAUDE.md',
   'AGENTS.md',
-  'generate-pdf.mjs',
-  'merge-tracker.mjs',
-  'verify-pipeline.mjs',
-  'dedup-tracker.mjs',
-  'normalize-statuses.mjs',
-  'cv-sync-check.mjs',
-  'update-system.mjs',
+  'GEMINI.md',
+];
+
+const SYSTEM_PATHS = [
+  ...CORE_MODE_FILES,
+  ...LOCALIZED_MODE_DIRECTORIES,
+  ...ROOT_SCRIPT_FILES,
+  ...PROJECT_INSTRUCTION_FILES,
   'batch/batch-prompt.md',
   'batch/batch-runner.sh',
   'dashboard/',


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- REQUIRED: Link the issue this PR addresses. PRs without a related issue will be closed. -->
<!-- Format: Fixes #123 / Closes #123 -->
<!-- Bug fixes can skip this if the fix is obvious (e.g., typo, crash). -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] I linked a related issue above (required for features and architecture changes)
- [ ] My PR does not include personal data (CV, email, real names)
- [ ] I ran `node test-all.mjs` and all tests pass
- [ ] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for French, Japanese, Portuguese, and Russian language modes plus new mode documents (interview‑prep and LaTeX).

* **Documentation**
  * Data contract updated to mark additional mode directories and the GEMINI system instructions file as safe for automated updates.

* **Tests**
  * Validation strengthened to require and verify presence and git-tracking of declared mode directories and system files.

* **Chores**
  * Reorganized updater configuration into clearer grouped categories and added an entry-module guard for CLI dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->