### PR TITLE
feat: Add advanced location and salary filtering to scanner

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -81,6 +81,7 @@ function parseGreenhouse(json, companyName) {
     url: j.absolute_url || '',
     company: companyName,
     location: j.location?.name || '',
+    salary: null
   }));
 }
 
@@ -175,7 +176,7 @@ function buildSalaryFilter(config) {
 
   return (salary) => {
     if (min === 0 && max === 0) return true; // Filter disabled
-    if (!salary) return false; // Salary expected but missing
+    if (!salary) return true; // Keep the job if salary data is missing (e.g. Greenhouse/Lever)
 
     // Currency check (if both have currency, they must match)
     if (currency && salary.currency && currency !== salary.currency) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -53,6 +53,10 @@ const INTERVAL_MULTIPLIERS = {
   '1 YEAR': 1
 };
 
+function normalize(str) {
+  return (str || "").toLowerCase().trim();
+}
+
 // ── API detection ───────────────────────────────────────────────────
 
 function detectApi(company) {
@@ -176,23 +180,41 @@ function buildTitleFilter(titleFilter) {
 function buildLocationFilter(config) {
   const remoteOnly = config?.remote_only === true;
   const onsiteOnly = config?.onsite_only === true;
-  const positive = (config?.positive || []).map(k => k.toLowerCase());
-  const negative = (config?.negative || []).map(k => k.toLowerCase());
+
+  const positive = (config?.positive || []).map(normalize).filter(Boolean);
+  const negative = (config?.negative || []).map(normalize).filter(Boolean);
 
   return (location) => {
-    const lower = (location || "").toLowerCase();
+    const lower = normalize(location);
+
+    // Empty location handling
+    if (!lower) {
+      // If strict filtering requested, reject
+      if (remoteOnly || onsiteOnly || positive.length > 0) return false;
+      return true;
+    }
+
     const isRemote = REMOTE_SYNONYMS.some(s => lower.includes(s));
 
+    // ── Step 1: Remote/Onsite constraints ──
     if (remoteOnly && !isRemote) return false;
     if (onsiteOnly && isRemote) return false;
 
-    // Short-circuit: if it's remote and user wants remote, keep it regardless of city keywords
+    // ── Step 2: Negative filter (ALWAYS applied) ──
+    if (negative.length > 0 && negative.some(k => lower.includes(k))) {
+      return false;
+    }
+
+    // Short-circuit: if it's remote and user wants remote, keep it
     if (remoteOnly && isRemote) return true;
 
-    const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
-    const hasNegative = negative.some(k => lower.includes(k));
+    // ── Step 3: Positive filter ──
+    if (positive.length > 0) {
+      return positive.some(k => lower.includes(k));
+    }
 
-    return hasPositive && !hasNegative;
+    // ── Step 4: Default accept ──
+    return true;
   };
 }
 
@@ -204,7 +226,7 @@ function buildSalaryFilter(config) {
   const currency = config?.currency || "";
 
   return (salary) => {
-    if (min === 0 && max === 0) return true; // Filter disabled
+    if (min === 0 && max === 0) return true; 
     if (!salary) return true; // Keep the job if salary data is missing (e.g. Greenhouse/Lever)
 
     // Currency check (if both have currency, they must match)

--- a/scan.mjs
+++ b/scan.mjs
@@ -94,7 +94,11 @@ function parseAshby(json, companyName) {
       url: j.jobUrl || '',
       company: companyName,
       location: j.location || '',
-      salary: comp ? { value: comp.minValue || comp.maxValue, currency: comp.currencyCode } : null
+      salary: comp ? { 
+        min: comp.minValue, 
+        max: comp.maxValue, 
+        currency: comp.currencyCode 
+      } : null
     };
   });
 }
@@ -167,14 +171,26 @@ function buildLocationFilter(config) {
 function buildSalaryFilter(config) {
   const min = Number(config?.min) || 0;
   const max = Number(config?.max) || 0;
+  const currency = config?.currency || "";
 
   return (salary) => {
     if (min === 0 && max === 0) return true; // Filter disabled
     if (!salary) return false; // Salary expected but missing
 
-    const val = Number(salary.value) || 0;
-    if (min > 0 && val < min) return false;
-    if (max > 0 && val > max) return false;
+    // Currency check (if both have currency, they must match)
+    if (currency && salary.currency && currency !== salary.currency) {
+      return true; // Don't filter if currencies don't match (conservative)
+    }
+
+    const jobMin = salary.min || 0;
+    const jobMax = salary.max || 0;
+
+    // Range-aware logic (CodeRabbit suggestion):
+    // If the job's TOP salary is below our MIN, discard.
+    if (min > 0 && jobMax > 0 && jobMax < min) return false;
+    
+    // If the job's BOTTOM salary is above our MAX, discard.
+    if (max > 0 && jobMin > 0 && jobMin > max) return false;
 
     return true;
   };

--- a/scan.mjs
+++ b/scan.mjs
@@ -30,7 +30,7 @@ const APPLICATIONS_PATH = 'data/applications.md';
 mkdirSync('data', { recursive: true });
 
 const CONCURRENCY = 10;
-const FETCH_TIMEOUT_MS = 10_000;
+const FETCH_TIMEOUT_MS = 15_000;
 
 // ── API detection ───────────────────────────────────────────────────
 
@@ -86,12 +86,17 @@ function parseGreenhouse(json, companyName) {
 
 function parseAshby(json, companyName) {
   const jobs = json.jobs || [];
-  return jobs.map(j => ({
-    title: j.title || '',
-    url: j.jobUrl || '',
-    company: companyName,
-    location: j.location || '',
-  }));
+  return jobs.map(j => {
+    const compensation = Array.isArray(j.compensation) ? j.compensation : [];
+    const comp = compensation.find(c => c.compensationType === 'Salary' && c.interval === '1 YEAR');
+    return {
+      title: j.title || '',
+      url: j.jobUrl || '',
+      company: companyName,
+      location: j.location || '',
+      salary: comp ? { value: comp.minValue || comp.maxValue, currency: comp.currencyCode } : null
+    };
+  });
 }
 
 function parseLever(json, companyName) {
@@ -101,6 +106,7 @@ function parseLever(json, companyName) {
     url: j.hostedUrl || '',
     company: companyName,
     location: j.categories?.location || '',
+    salary: null
   }));
 }
 
@@ -131,6 +137,46 @@ function buildTitleFilter(titleFilter) {
     const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
     const hasNegative = negative.some(k => lower.includes(k));
     return hasPositive && !hasNegative;
+  };
+}
+
+// ── Location filter ─────────────────────────────────────────────────
+
+function buildLocationFilter(config) {
+  const remoteOnly = config?.remote_only === true;
+  const onsiteOnly = config?.onsite_only === true;
+  const positive = (config?.positive || []).map(k => k.toLowerCase());
+  const negative = (config?.negative || []).map(k => k.toLowerCase());
+
+  return (location) => {
+    const lower = (location || "").toLowerCase();
+    const isRemote = lower.includes("remote") || lower.includes("distributed");
+
+    if (remoteOnly && !isRemote) return false;
+    if (onsiteOnly && isRemote) return false;
+
+    const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
+    const hasNegative = negative.some(k => lower.includes(k));
+
+    return hasPositive && !hasNegative;
+  };
+}
+
+// ── Salary filter ───────────────────────────────────────────────────
+
+function buildSalaryFilter(config) {
+  const min = Number(config?.min) || 0;
+  const max = Number(config?.max) || 0;
+
+  return (salary) => {
+    if (min === 0 && max === 0) return true; // Filter disabled
+    if (!salary) return false; // Salary expected but missing
+
+    const val = Number(salary.value) || 0;
+    if (min > 0 && val < min) return false;
+    if (max > 0 && val > max) return false;
+
+    return true;
   };
 }
 
@@ -263,7 +309,11 @@ async function main() {
 
   const config = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
   const companies = config.tracked_companies || [];
+  
+  // Build Filters
   const titleFilter = buildTitleFilter(config.title_filter);
+  const locationFilter = buildLocationFilter(config.location_filter);
+  const salaryFilter = buildSalaryFilter(config.salary_filter);
 
   // 2. Filter to enabled companies with detectable APIs
   const targets = companies
@@ -277,30 +327,41 @@ async function main() {
   console.log(`Scanning ${targets.length} companies via API (${skippedCount} skipped — no API detected)`);
   if (dryRun) console.log('(dry run — no files will be written)\n');
 
-  // 3. Load dedup sets
+  // 3. Scan loop
+  const date = new Date().toISOString().slice(0, 10);
+  let totalFound = 0, totalFiltered = 0, totalLocationFiltered = 0, totalSalaryFiltered = 0, totalDupes = 0;
+  const newOffers = [];
+  const errors = [];
   const seenUrls = loadSeenUrls();
   const seenCompanyRoles = loadSeenCompanyRoles();
 
-  // 4. Fetch all APIs
-  const date = new Date().toISOString().slice(0, 10);
-  let totalFound = 0;
-  let totalFiltered = 0;
-  let totalDupes = 0;
-  const newOffers = [];
-  const errors = [];
-
   const tasks = targets.map(company => async () => {
-    const { type, url } = company._api;
     try {
+      const { type, url } = company._api;
       const json = await fetchJson(url);
       const jobs = PARSERS[type](json, company.name);
+
       totalFound += jobs.length;
 
       for (const job of jobs) {
+        // Filter 1: Title
         if (!titleFilter(job.title)) {
           totalFiltered++;
           continue;
         }
+
+        // Filter 2: Location
+        if (!locationFilter(job.location)) {
+          totalLocationFiltered++;
+          continue;
+        }
+
+        // Filter 3: Salary
+        if (!salaryFilter(job.salary)) {
+          totalSalaryFiltered++;
+          continue;
+        }
+
         if (seenUrls.has(job.url)) {
           totalDupes++;
           continue;
@@ -335,6 +396,8 @@ async function main() {
   console.log(`Companies scanned:     ${targets.length}`);
   console.log(`Total jobs found:      ${totalFound}`);
   console.log(`Filtered by title:     ${totalFiltered} removed`);
+  console.log(`Filtered by location:  ${totalLocationFiltered} removed`);
+  console.log(`Filtered by salary:    ${totalSalaryFiltered} removed`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
   console.log(`New offers added:      ${newOffers.length}`);
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -219,6 +219,8 @@ function buildLocationFilter(config) {
 }
 
 // ── Salary filter ───────────────────────────────────────────────────
+// Filters jobs based on user-defined salary range and currency.
+// Uses range-overlap logic and conservative defaults for missing data.
 
 function buildSalaryFilter(config) {
   const min = Number(config?.min) || 0;
@@ -226,24 +228,41 @@ function buildSalaryFilter(config) {
   const currency = config?.currency || "";
 
   return (salary) => {
-    if (min === 0 && max === 0) return true; 
-    if (!salary) return true; // Keep the job if salary data is missing (e.g. Greenhouse/Lever)
+    // If no salary constraints are configured, allow all jobs
+    if (min === 0 && max === 0) return true;
 
-    // Currency check (if both have currency, they must match)
+    // If salary data is missing, keep the job (conservative approach)
+    // Many job boards do not provide structured compensation data
+    if (!salary) return true;
+
+    // Enforce currency match when both user preference and job currency are present
+    // Reject mismatched currencies to avoid incorrect comparisons
     if (currency && salary.currency && currency !== salary.currency) {
-      return true; // Don't filter if currencies don't match (conservative)
+      return false;
     }
 
-    const jobMin = salary.min || salary.max || 0;
-    const jobMax = salary.max || salary.min || 0;
+    // Preserve full salary range (do not collapse to a single value)
+    // Fallback ensures we still handle cases where only one bound is provided
+    const jobMin = salary.min ?? salary.max ?? null;
+    const jobMax = salary.max ?? salary.min ?? null;
 
-    // Range-aware logic (CodeRabbit suggestion):
-    // If the job's TOP salary is below our MIN, discard.
-    if (min > 0 && jobMax > 0 && jobMax < min) return false;
-    
-    // If the job's BOTTOM salary is above our MAX, discard.
-    if (max > 0 && jobMin > 0 && jobMin > max) return false;
+    // If both bounds are missing, keep the job (cannot evaluate reliably)
+    if (jobMin == null && jobMax == null) return true;
 
+    // ── Range overlap logic ──
+    // Reject only if the job's range is completely outside the user-defined range
+
+    // Case 1: Job's maximum is below user's minimum → no overlap
+    if (min > 0 && jobMax != null && jobMax < min) {
+      return false;
+    }
+
+    // Case 2: Job's minimum is above user's maximum → no overlap
+    if (max > 0 && jobMin != null && jobMin > max) {
+      return false;
+    }
+
+    // Otherwise, ranges overlap → accept job
     return true;
   };
 }

--- a/scan.mjs
+++ b/scan.mjs
@@ -32,6 +32,27 @@ mkdirSync('data', { recursive: true });
 const CONCURRENCY = 10;
 const FETCH_TIMEOUT_MS = 15_000;
 
+// ── Constants ───────────────────────────────────────────────────────
+
+const REMOTE_SYNONYMS = [
+  "remote", "distributed", "anywhere", "worldwide", "wfh", "work from home",
+  "wfa", "work from anywhere", "virtual", "telecommute", "location independent",
+  "flexible location"
+];
+
+const INTERVAL_MULTIPLIERS = {
+  '1 HOUR': 2080,
+  '1 DAY': 260,
+  '1 WEEK': 52,
+  '2 WEEK': 26,
+  '0.5 MONTH': 24,
+  '1 MONTH': 12,
+  '2 MONTH': 6,
+  '3 MONTH': 4,
+  '6 MONTH': 2,
+  '1 YEAR': 1
+};
+
 // ── API detection ───────────────────────────────────────────────────
 
 function detectApi(company) {
@@ -87,17 +108,9 @@ function parseGreenhouse(json, companyName) {
 
 function parseAshby(json, companyName) {
   const jobs = json.jobs || [];
-  const INTERVAL_MULTIPLIERS = {
-    '1 HOUR': 2080,
-    '1 DAY': 260,
-    '1 WEEK': 52,
-    '1 MONTH': 12,
-    '1 YEAR': 1
-  };
 
   return jobs.map(j => {
     const compensation = Array.isArray(j.compensation) ? j.compensation : [];
-    // Find any salary compensation we can normalize
     const comp = compensation.find(c => c.compensationType === 'Salary' && INTERVAL_MULTIPLIERS[c.interval]);
     
     if (!comp) return { title: j.title || '', url: j.jobUrl || '', company: companyName, location: j.location || '', salary: null };
@@ -109,9 +122,9 @@ function parseAshby(json, companyName) {
       company: companyName,
       location: j.location || '',
       salary: { 
-        min: comp.minValue ? comp.minValue * mult : null, 
-        max: comp.maxValue ? comp.maxValue * mult : null, 
-        currency: comp.currencyCode 
+        min: comp.minValue != null ? comp.minValue * mult : null, 
+        max: comp.maxValue != null ? comp.maxValue * mult : null, 
+        currency: comp.currencyCode ?? null
       }
     };
   });
@@ -168,12 +181,7 @@ function buildLocationFilter(config) {
 
   return (location) => {
     const lower = (location || "").toLowerCase();
-    const remoteSynonyms = [
-      "remote", "distributed", "anywhere", "worldwide", "wfh", "work from home",
-      "wfa", "work from anywhere", "virtual", "telecommute", "location independent",
-      "flexible location"
-    ];
-    const isRemote = remoteSynonyms.some(s => lower.includes(s));
+    const isRemote = REMOTE_SYNONYMS.some(s => lower.includes(s));
 
     if (remoteOnly && !isRemote) return false;
     if (onsiteOnly && isRemote) return false;

--- a/scan.mjs
+++ b/scan.mjs
@@ -155,7 +155,12 @@ function buildLocationFilter(config) {
 
   return (location) => {
     const lower = (location || "").toLowerCase();
-    const isRemote = lower.includes("remote") || lower.includes("distributed");
+    const remoteSynonyms = [
+      "remote", "distributed", "anywhere", "worldwide", "wfh", "work from home",
+      "wfa", "work from anywhere", "virtual", "telecommute", "location independent",
+      "flexible location"
+    ];
+    const isRemote = remoteSynonyms.some(s => lower.includes(s));
 
     if (remoteOnly && !isRemote) return false;
     if (onsiteOnly && isRemote) return false;

--- a/scan.mjs
+++ b/scan.mjs
@@ -87,19 +87,32 @@ function parseGreenhouse(json, companyName) {
 
 function parseAshby(json, companyName) {
   const jobs = json.jobs || [];
+  const INTERVAL_MULTIPLIERS = {
+    '1 HOUR': 2080,
+    '1 DAY': 260,
+    '1 WEEK': 52,
+    '1 MONTH': 12,
+    '1 YEAR': 1
+  };
+
   return jobs.map(j => {
     const compensation = Array.isArray(j.compensation) ? j.compensation : [];
-    const comp = compensation.find(c => c.compensationType === 'Salary' && c.interval === '1 YEAR');
+    // Find any salary compensation we can normalize
+    const comp = compensation.find(c => c.compensationType === 'Salary' && INTERVAL_MULTIPLIERS[c.interval]);
+    
+    if (!comp) return { title: j.title || '', url: j.jobUrl || '', company: companyName, location: j.location || '', salary: null };
+
+    const mult = INTERVAL_MULTIPLIERS[comp.interval];
     return {
       title: j.title || '',
       url: j.jobUrl || '',
       company: companyName,
       location: j.location || '',
-      salary: comp ? { 
-        min: comp.minValue, 
-        max: comp.maxValue, 
+      salary: { 
+        min: comp.minValue ? comp.minValue * mult : null, 
+        max: comp.maxValue ? comp.maxValue * mult : null, 
         currency: comp.currencyCode 
-      } : null
+      }
     };
   });
 }
@@ -165,6 +178,9 @@ function buildLocationFilter(config) {
     if (remoteOnly && !isRemote) return false;
     if (onsiteOnly && isRemote) return false;
 
+    // Short-circuit: if it's remote and user wants remote, keep it regardless of city keywords
+    if (remoteOnly && isRemote) return true;
+
     const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
     const hasNegative = negative.some(k => lower.includes(k));
 
@@ -188,8 +204,8 @@ function buildSalaryFilter(config) {
       return true; // Don't filter if currencies don't match (conservative)
     }
 
-    const jobMin = salary.min || 0;
-    const jobMax = salary.max || 0;
+    const jobMin = salary.min || salary.max || 0;
+    const jobMax = salary.max || salary.min || 0;
 
     // Range-aware logic (CodeRabbit suggestion):
     // If the job's TOP salary is below our MIN, discard.

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -95,6 +95,33 @@ title_filter:
     - "Head"
     - "Director"
 
+# -- Location filter --
+# Filters jobs based on remote/on-site status and specific regions.
+# Note: location data is extracted from career portal APIs.
+location_filter:
+  remote_only: false        # [CUSTOMIZE] Set to true to find ONLY remote roles
+  onsite_only: false        # [CUSTOMIZE] Set to true to find ONLY on-site roles
+  positive:
+    # [CUSTOMIZE] Cities, regions or countries you are interested in
+    - "Remote"
+    - "India"
+    - "Pune"
+    - "Bangalore"
+    - "Europe"
+    - "EMEA"
+  negative:
+    # [CUSTOMIZE] Locations you want to exclude
+    - "USA"
+    - "China"
+
+# -- Salary filter --
+# Discards jobs with compensation below your floor or outside your range.
+# Currently supported for: Ashby boards.
+salary_filter:
+  min: 0                    # [CUSTOMIZE] Yearly minimum (number only, e.g. 100000)
+  max: 0                    # [CUSTOMIZE] Yearly maximum (0 = no limit)
+  currency: "USD"           # [CUSTOMIZE] Preferred currency for matching
+
 # -- Search queries --
 # Each query triggers a WebSearch. Use site: to filter by portal.
 # The scanner extracts title, URL, and company from results.


### PR DESCRIPTION
### Summary
This PR enhances the `scan.mjs` portal scanner by adding two new filtering layers: **Location** (Remote/On-site/Region) and **Salary Range**. 

Currently, the scanner only filters by title keywords, which can lead to high noise for users with strict location or compensation requirements. This change allows for much more precise automated job discovery.

### Changes
- **Configuration Schema**: Added `location_filter` and `salary_filter` blocks to `portals.example.yml`.
- **Location Filtering**: 
  - Added `remote_only` and `onsite_only` logic.
  - Implemented positive/negative keyword matching for locations (cities, regions, countries).
- **Salary Filtering**: 
  - Updated `parseAshby` to extract structured compensation data.
  - Implemented numerical range filtering (`min`/`max`).
- **User Interface**: Updated the terminal summary to report the number of jobs removed by each specific filter.

### Testing Performed
- Ran `node scan.mjs --dry-run` against the full company list.
- Verified that `remote_only: true` correctly filtered out on-site roles (approx. 900 jobs removed in a sample scan).
- Verified that location keyword matching (e.g., "India", "Europe") works as expected.
- Verified that the scanner remains backwards-compatible if new filters are not defined in `portals.yml`.

**Fixes #441**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added location-based filtering with remote/on-site preferences and positive/negative matching
  * Added salary filtering with configurable min/max thresholds and optional currency handling; conservatively skips or rejects jobs based on availability and currency
  * Improved salary extraction for supported boards; unavailable salaries reported as null
  * Enhanced scan summaries with separate counts for location- and salary-based rejections

* **Improvements**
  * Increased HTTP fetch timeout to 15 seconds for more reliable job fetching
<!-- end of auto-generated comment: release notes by coderabbit.ai -->