### PR TITLE
feat: support local PII token substitution

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_message: |
             Welcome to career-ops, @${{ github.actor }}! Thanks for your first PR.
 
             A few things to know:
@@ -25,7 +25,7 @@ jobs:
             - Read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md) if you haven't
 
             We'll review your PR soon. Join our [Discord](https://discord.gg/8pRpHETxa4) if you have questions.
-          issue-message: |
+          issue_message: |
             Thanks for opening your first issue, @${{ github.actor }}! We'll take a look soon.
 
             In the meantime:

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ jds/*
 
 # User config and customization (never auto-updated)
 config/profile.yml
+config/pii.local.json
 portals.yml
 modes/_profile.md
 .update-dismissed

--- a/config/pii.example.json
+++ b/config/pii.example.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Copy this file to config/pii.local.json and fill in your real values. pii.local.json is gitignored AND never read by Claude — only local scripts (generate-pdf.mjs, generate-latex.mjs) read it to substitute tokens at compile time. Every key here matches a {{TOKEN}} used in the HTML/TeX CV templates. Keys you don't set are left as tokens; the generator will fail with a clear error so you know what's missing.",
+  "_latex_raw_tokens": ["CONTACT_LINE", "EMAIL_URL", "LINKEDIN_URL", "PORTFOLIO_URL", "GITHUB_URL"],
 
   "NAME": "Jane Smith",
   "EMAIL": "jane@example.com",

--- a/config/pii.example.json
+++ b/config/pii.example.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Copy this file to config/pii.local.json and fill in your real values. pii.local.json is gitignored AND never read by Claude — only local scripts (generate-pdf.mjs, generate-latex.mjs) read it to substitute tokens at compile time. Every key here matches a {{TOKEN}} used in the HTML/TeX CV templates. Keys you don't set are left as tokens; the generator will fail with a clear error so you know what's missing.",
+
+  "NAME": "Jane Smith",
+  "EMAIL": "jane@example.com",
+  "PHONE": "+1-555-0123",
+  "LOCATION": "San Francisco, CA",
+
+  "LINKEDIN_URL": "https://www.linkedin.com/in/janesmith",
+  "LINKEDIN_DISPLAY": "linkedin.com/in/janesmith",
+
+  "PORTFOLIO_URL": "https://janesmith.dev",
+  "PORTFOLIO_DISPLAY": "janesmith.dev",
+
+  "GITHUB_URL": "https://github.com/janesmith",
+  "GITHUB_DISPLAY": "github.com/janesmith",
+
+  "EMAIL_URL": "mailto:jane@example.com",
+  "EMAIL_DISPLAY": "jane@example.com",
+
+  "CONTACT_LINE": "+1-555-0123 $\\cdot$ jane@example.com $\\cdot$ \\href{https://www.linkedin.com/in/janesmith}{linkedin.com/in/janesmith}"
+}

--- a/generate-latex.mjs
+++ b/generate-latex.mjs
@@ -13,10 +13,32 @@
  * Requires: pdflatex (MiKTeX or TeX Live) on PATH.
  */
 
-import { readFile, stat, copyFile, rm } from 'fs/promises';
+import { readFile, writeFile, stat, copyFile, rm } from 'fs/promises';
 import { resolve, basename, dirname, join } from 'path';
 import { execFileSync } from 'child_process';
-import { existsSync, mkdirSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const __scriptDir = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * PII substitution — replaces {{TOKEN}} placeholders with values from
+ * config/pii.local.json. This file is gitignored and never read by Claude;
+ * it exists only on the local filesystem. Keeps PII out of model context.
+ * Any unsubstituted token is caught by the existing placeholder check below.
+ */
+function substitutePII(content) {
+  const piiPath = resolve(__scriptDir, 'config/pii.local.json');
+  if (!existsSync(piiPath)) return { content, substituted: 0 };
+  const pii = JSON.parse(readFileSync(piiPath, 'utf-8'));
+  let substituted = 0;
+  for (const [key, value] of Object.entries(pii)) {
+    if (key.startsWith('_') || typeof value !== 'string' || value === '') continue;
+    const pattern = new RegExp(`\\{\\{${key}\\}\\}`, 'g');
+    content = content.replace(pattern, () => { substituted++; return value; });
+  }
+  return { content, substituted };
+}
 
 const REQUIRED_SECTIONS = [
   '\\\\section{Education}',
@@ -46,6 +68,14 @@ async function main() {
   } catch (err) {
     console.error(`Error reading ${absPath}: ${err.message}`);
     process.exit(1);
+  }
+
+  // Substitute PII tokens from config/pii.local.json (kept out of model context).
+  // Write the substituted content back to disk so pdflatex compiles the real values.
+  const piiResult = substitutePII(content);
+  if (piiResult.substituted > 0) {
+    content = piiResult.content;
+    await writeFile(absPath, content, 'utf-8');
   }
 
   const issues = [];

--- a/generate-latex.mjs
+++ b/generate-latex.mjs
@@ -16,29 +16,11 @@
 import { readFile, writeFile, stat, copyFile, rm } from 'fs/promises';
 import { resolve, basename, dirname, join } from 'path';
 import { execFileSync } from 'child_process';
-import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import { fileURLToPath } from 'url';
+import { substitutePII } from './lib/pii.mjs';
 
 const __scriptDir = dirname(fileURLToPath(import.meta.url));
-
-/**
- * PII substitution — replaces {{TOKEN}} placeholders with values from
- * config/pii.local.json. This file is gitignored and never read by Claude;
- * it exists only on the local filesystem. Keeps PII out of model context.
- * Any unsubstituted token is caught by the existing placeholder check below.
- */
-function substitutePII(content) {
-  const piiPath = resolve(__scriptDir, 'config/pii.local.json');
-  if (!existsSync(piiPath)) return { content, substituted: 0 };
-  const pii = JSON.parse(readFileSync(piiPath, 'utf-8'));
-  let substituted = 0;
-  for (const [key, value] of Object.entries(pii)) {
-    if (key.startsWith('_') || typeof value !== 'string' || value === '') continue;
-    const pattern = new RegExp(`\\{\\{${key}\\}\\}`, 'g');
-    content = content.replace(pattern, () => { substituted++; return value; });
-  }
-  return { content, substituted };
-}
 
 const REQUIRED_SECTIONS = [
   '\\\\section{Education}',
@@ -70,13 +52,9 @@ async function main() {
     process.exit(1);
   }
 
-  // Substitute PII tokens from config/pii.local.json (kept out of model context).
-  // Write the substituted content back to disk so pdflatex compiles the real values.
-  const piiResult = substitutePII(content);
-  if (piiResult.substituted > 0) {
-    content = piiResult.content;
-    await writeFile(absPath, content, 'utf-8');
-  }
+  // Substitute PII tokens from config/pii.local.json without mutating the source .tex.
+  const piiResult = substitutePII(content, { projectRoot: __scriptDir, target: 'latex' });
+  content = piiResult.content;
 
   const issues = [];
 
@@ -151,6 +129,9 @@ async function main() {
   // --- Compile .tex → .pdf via pdflatex ---
   const texDir = dirname(absPath);
   const texBase = basename(absPath, '.tex');
+  const compilePath = piiResult.substituted > 0 ? join(texDir, `${texBase}.resolved.tex`) : absPath;
+  const compileBase = basename(compilePath, '.tex');
+  const compiledPdf = join(texDir, `${compileBase}.pdf`);
   const defaultPdf = join(texDir, `${texBase}.pdf`);
   const targetPdf = outputPath ? resolve(outputPath) : defaultPdf;
 
@@ -161,13 +142,17 @@ async function main() {
   }
 
   try {
+    if (compilePath !== absPath) {
+      await writeFile(compilePath, content, 'utf-8');
+    }
+
     // Run pdflatex twice for cross-references (standard practice)
     const pdflatexArgs = [
       '-no-shell-escape',
       '-interaction=nonstopmode',
       '-halt-on-error',
       `-output-directory=${texDir}`,
-      absPath,
+      compilePath,
     ];
 
     // First pass
@@ -187,7 +172,7 @@ async function main() {
     report.compiled = true;
   } catch (err) {
     // Try to extract useful error from pdflatex log
-    const logPath = join(texDir, `${texBase}.log`);
+    const logPath = join(texDir, `${compileBase}.log`);
     let latexError = err.message;
     try {
       const log = await readFile(logPath, 'utf-8');
@@ -205,9 +190,9 @@ async function main() {
   if (report.compiled) {
     try {
       // Move PDF to target location if different
-      if (resolve(defaultPdf) !== resolve(targetPdf)) {
-        await copyFile(defaultPdf, targetPdf);
-        await rm(defaultPdf).catch(() => {});
+      if (resolve(compiledPdf) !== resolve(targetPdf)) {
+        await copyFile(compiledPdf, targetPdf);
+        await rm(compiledPdf).catch(() => {});
       }
 
       const pdfStat = await stat(targetPdf);
@@ -222,8 +207,12 @@ async function main() {
     // Clean up auxiliary files (best-effort)
     const auxExts = ['.aux', '.log', '.out', '.fls', '.fdb_latexmk', '.synctex.gz'];
     for (const ext of auxExts) {
-      await rm(join(texDir, `${texBase}${ext}`)).catch(() => {});
+      await rm(join(texDir, `${compileBase}${ext}`)).catch(() => {});
     }
+  }
+
+  if (compilePath !== absPath) {
+    await rm(compilePath).catch(() => {});
   }
 
   console.log(JSON.stringify(report, null, 2));

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -13,13 +13,33 @@
 import { chromium } from 'playwright';
 import { resolve, dirname } from 'path';
 import { readFile } from 'fs/promises';
-import { mkdirSync } from 'fs';
+import { mkdirSync, existsSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Ensure output directory exists (fresh setup)
 mkdirSync(resolve(__dirname, 'output'), { recursive: true });
+
+/**
+ * PII substitution — replaces {{TOKEN}} placeholders with values from
+ * config/pii.local.json. This file is gitignored and never read by Claude;
+ * it exists only on the local filesystem. Keeps PII out of model context.
+ */
+function substitutePII(content) {
+  const piiPath = resolve(__dirname, 'config/pii.local.json');
+  if (!existsSync(piiPath)) return { content, substituted: 0, missing: [] };
+  const pii = JSON.parse(readFileSync(piiPath, 'utf-8'));
+  let substituted = 0;
+  for (const [key, value] of Object.entries(pii)) {
+    if (key.startsWith('_') || typeof value !== 'string' || value === '') continue;
+    const pattern = new RegExp(`\\{\\{${key}\\}\\}`, 'g');
+    content = content.replace(pattern, () => { substituted++; return value; });
+  }
+  const missing = [...new Set((content.match(/\{\{[A-Z_]+\}\}/g) || []))]
+    .filter(tok => ['NAME','EMAIL','PHONE','LOCATION','LINKEDIN_URL','LINKEDIN_DISPLAY','PORTFOLIO_URL','PORTFOLIO_DISPLAY','GITHUB_URL','GITHUB_DISPLAY','EMAIL_URL','EMAIL_DISPLAY','CONTACT_LINE'].includes(tok.slice(2,-2)));
+  return { content, substituted, missing };
+}
 
 /**
  * Normalize text for ATS compatibility by converting problematic Unicode.
@@ -111,6 +131,18 @@ async function generatePDF() {
 
   // Read HTML to inject font paths as absolute file:// URLs
   let html = await readFile(inputPath, 'utf-8');
+
+  // Substitute PII tokens from config/pii.local.json (kept out of model context)
+  const piiResult = substitutePII(html);
+  html = piiResult.content;
+  if (piiResult.substituted > 0) {
+    console.log(`🔒 PII substitution: ${piiResult.substituted} token replacements from config/pii.local.json`);
+  }
+  if (piiResult.missing.length > 0) {
+    console.error(`❌ Unresolved PII tokens: ${piiResult.missing.join(', ')}`);
+    console.error(`   Fill these in config/pii.local.json and retry.`);
+    process.exit(1);
+  }
 
   // Resolve font paths relative to career-ops/fonts/
   const fontsDir = resolve(__dirname, 'fonts');

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -13,33 +13,14 @@
 import { chromium } from 'playwright';
 import { resolve, dirname } from 'path';
 import { readFile } from 'fs/promises';
-import { mkdirSync, existsSync, readFileSync } from 'fs';
+import { mkdirSync } from 'fs';
 import { fileURLToPath } from 'url';
+import { substitutePII } from './lib/pii.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Ensure output directory exists (fresh setup)
 mkdirSync(resolve(__dirname, 'output'), { recursive: true });
-
-/**
- * PII substitution — replaces {{TOKEN}} placeholders with values from
- * config/pii.local.json. This file is gitignored and never read by Claude;
- * it exists only on the local filesystem. Keeps PII out of model context.
- */
-function substitutePII(content) {
-  const piiPath = resolve(__dirname, 'config/pii.local.json');
-  if (!existsSync(piiPath)) return { content, substituted: 0, missing: [] };
-  const pii = JSON.parse(readFileSync(piiPath, 'utf-8'));
-  let substituted = 0;
-  for (const [key, value] of Object.entries(pii)) {
-    if (key.startsWith('_') || typeof value !== 'string' || value === '') continue;
-    const pattern = new RegExp(`\\{\\{${key}\\}\\}`, 'g');
-    content = content.replace(pattern, () => { substituted++; return value; });
-  }
-  const missing = [...new Set((content.match(/\{\{[A-Z_]+\}\}/g) || []))]
-    .filter(tok => ['NAME','EMAIL','PHONE','LOCATION','LINKEDIN_URL','LINKEDIN_DISPLAY','PORTFOLIO_URL','PORTFOLIO_DISPLAY','GITHUB_URL','GITHUB_DISPLAY','EMAIL_URL','EMAIL_DISPLAY','CONTACT_LINE'].includes(tok.slice(2,-2)));
-  return { content, substituted, missing };
-}
 
 /**
  * Normalize text for ATS compatibility by converting problematic Unicode.
@@ -133,7 +114,7 @@ async function generatePDF() {
   let html = await readFile(inputPath, 'utf-8');
 
   // Substitute PII tokens from config/pii.local.json (kept out of model context)
-  const piiResult = substitutePII(html);
+  const piiResult = substitutePII(html, { projectRoot: __dirname, target: 'html' });
   html = piiResult.content;
   if (piiResult.substituted > 0) {
     console.log(`🔒 PII substitution: ${piiResult.substituted} token replacements from config/pii.local.json`);

--- a/lib/pii.mjs
+++ b/lib/pii.mjs
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const DEFAULT_LATEX_RAW_TOKENS = [
+  'CONTACT_LINE',
+  'EMAIL_URL',
+  'LINKEDIN_URL',
+  'PORTFOLIO_URL',
+  'GITHUB_URL',
+];
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch (err) {
+    throw new Error(`Unable to read ${label} at ${path}: ${err.message}`);
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeLatex(value) {
+  return value
+    .replace(/\\/g, '\\textbackslash{}')
+    .replace(/&/g, '\\&')
+    .replace(/%/g, '\\%')
+    .replace(/\$/g, '\\$')
+    .replace(/#/g, '\\#')
+    .replace(/_/g, '\\_')
+    .replace(/{/g, '\\{')
+    .replace(/}/g, '\\}')
+    .replace(/\^/g, '\\textasciicircum{}')
+    .replace(/~/g, '\\textasciitilde{}');
+}
+
+function escapePIIValue(key, value, target, latexRawTokens) {
+  if (target === 'html') return escapeHtml(value);
+  if (target === 'latex' && !latexRawTokens.has(key)) return escapeLatex(value);
+  return value;
+}
+
+export function substitutePII(content, { projectRoot, target }) {
+  const examplePath = resolve(projectRoot, 'config/pii.example.json');
+  const example = readJson(examplePath, 'config/pii.example.json');
+  const allowed = new Set(Object.keys(example).filter(key => !key.startsWith('_')));
+  const latexRawTokens = new Set(
+    Array.isArray(example._latex_raw_tokens)
+      ? example._latex_raw_tokens
+      : DEFAULT_LATEX_RAW_TOKENS
+  );
+
+  const piiPath = resolve(projectRoot, 'config/pii.local.json');
+  const pii = existsSync(piiPath) ? readJson(piiPath, 'config/pii.local.json') : {};
+
+  let substituted = 0;
+  for (const [key, value] of Object.entries(pii)) {
+    if (!allowed.has(key) || typeof value !== 'string' || value === '') continue;
+
+    const pattern = new RegExp(`\\{\\{${escapeRegExp(key)}\\}\\}`, 'g');
+    const escaped = escapePIIValue(key, value, target, latexRawTokens);
+    content = content.replace(pattern, () => {
+      substituted++;
+      return escaped;
+    });
+  }
+
+  const missing = [...new Set(content.match(/\{\{[A-Z_]+\}\}/g) || [])]
+    .filter(token => allowed.has(token.slice(2, -2)));
+
+  return { content, substituted, missing };
+}


### PR DESCRIPTION
## Summary
- Add `config/pii.example.json` as a template for local contact-detail placeholders.
- Keep `config/pii.local.json` gitignored while allowing PDF and LaTeX generation to substitute `{{TOKEN}}` values at compile time.
- Fail PDF generation clearly when expected PII placeholders remain unresolved.

## Test plan
- `node --check generate-pdf.mjs`
- `node --check generate-latex.mjs`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personalization: local personal-info configuration is applied during document generation to populate names, contacts and links.
  * Added an example configuration documenting available personalization fields and raw-LaTeX tokens.

* **Bug Fixes**
  * Generation now fails early if recognized placeholders remain unresolved, preventing incomplete outputs.

* **Chores**
  * CI workflow input keys renamed for consistency; local PII config excluded from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->