### PR TITLE
feat: add Claude Code plugin manifests (path-stable)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "career-ops",
+  "metadata": {
+    "description": "AI job search command center — evaluate offers, generate CVs, scan portals, track applications"
+  },
+  "owner": {
+    "name": "santifer",
+    "url": "https://santifer.io"
+  },
+  "plugins": [
+    {
+      "name": "career-ops",
+      "source": "./",
+      "description": "AI job search pipeline — evaluate offers, generate CVs, scan portals, track applications",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "career-ops",
+  "version": "1.6.0",
+  "description": "AI job search command center — evaluate offers, generate CVs, scan portals, track applications",
+  "author": {
+    "name": "santifer",
+    "url": "https://santifer.io"
+  },
+  "skills": [".claude/skills/"],
+  "permissions": {
+    "allow": [
+      "Bash(node:*)",
+      "WebFetch(domain:boards-api.greenhouse.io)",
+      "WebFetch(domain:jobs.ashbyhq.com)",
+      "WebSearch"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` so career-ops can be installed via:

```
claude plugin marketplace add ./
claude plugin install career-ops
```

Pointed at the existing `.claude/skills/` path — **no skill migration in this PR**. Zero breaking change for the ~39K existing classic clones.

## Context

This is **PR-A** of Option C agreed in [#275](https://github.com/santifer/career-ops/pull/275) (split):

- **PR-A (this PR)**: plugin manifests targeting current paths, zero migration risk
- **PR-B (deferred to RFC)**: skill path migration `.claude/skills/` → `skills/`, profile location migration `modes/_profile.md` → `config/_profile.md`, dynamic path resolution in SKILL.md, README Option A docs. Author @vl4duu invited to lead via RFC in [Discussion #284](https://github.com/santifer/career-ops/discussions/284).

## Why split?

Path migration affects:
- `update-system.mjs` SYSTEM_PATHS (just expanded in #366 to include `.claude/skills/`)
- `AGENTS.md`, `GEMINI.md`, `.gemini/commands/` references
- career-ops.org docs site
- External ecosystem readers (e.g. @ltrem's React dashboard reading the schema)
- Tutorials, Discord muscle memory

Each is solvable but coordinating them takes an RFC. Plugin install demand from the community (@mehtab_riaz, @vsy2876, others) doesn't have to wait for that coordination.

## Test plan

- [ ] `claude plugin validate ./` passes
- [ ] `claude plugin marketplace add ./` registers the marketplace
- [ ] `claude plugin install career-ops` installs and `/career-ops` is reachable
- [ ] Classic clone setup unchanged

## Backward compatibility

100%. Adds two new files. No existing path or behavior modified. Closes nothing in `.gitignore`.

## Related

- Closes part of #272 (Multi-CLI & AI-Agnostic umbrella)
- Splits #275 — Option C path
- Resolves community blocker on #412 (.skill no longer working) once docs reference plugin install path

## Credit

Original design (manifests structure, plugin name, permissions allowlist) from @vl4duu in #275. Co-author credited in commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Career-ops plugin is now registered and available in the marketplace for productivity enhancements.

* **Chores**
  * Added plugin configuration manifests defining version 1.6.0, metadata, author information, skills integration, and scoped runtime permissions enabling secure execution with specialized capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->