### PR TITLE
feat(scan): add BambooHR, Teamtailor, Workable, SmartRecruiters, Recruitee ATS providers

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
+/* eslint-env node */
+/* global process, console, fetch, AbortController, setTimeout, clearTimeout */
 
 /**
  * scan.mjs — Zero-token portal scanner
  *
- * Fetches Greenhouse, Ashby, and Lever APIs directly, applies title
- * filters from portals.yml, deduplicates against existing history,
- * and appends new offers to pipeline.md + scan-history.tsv.
+ * Fetches Greenhouse, Ashby, Lever, BambooHR, Teamtailor, Workable,
+ * SmartRecruiters, and Recruitee APIs directly, applies title filters
+ * from portals.yml, deduplicates against existing history, and appends
+ * new offers to pipeline.md + scan-history.tsv.
  *
- * Zero Claude API tokens — pure HTTP + JSON.
+ * Zero Claude API tokens — pure HTTP + JSON/RSS.
  *
  * Usage:
  *   node scan.mjs                  # scan all enabled companies
@@ -69,6 +72,76 @@ function detectApi(company) {
     };
   }
 
+  // BambooHR: explicit api_provider or {slug}.bamboohr.com
+  if (company.api_provider === 'bamboohr' && company.bamboohr_slug) {
+    return {
+      type: 'bamboohr',
+      url: `https://${company.bamboohr_slug}.bamboohr.com/careers/list`,
+      meta: { slug: company.bamboohr_slug },
+    };
+  }
+  const bambooMatch = url.match(/([^/]+)\.bamboohr\.com/);
+  if (bambooMatch) {
+    return {
+      type: 'bamboohr',
+      url: `https://${bambooMatch[1]}.bamboohr.com/careers/list`,
+      meta: { slug: bambooMatch[1] },
+    };
+  }
+
+  // Teamtailor: {slug}.teamtailor.com — returns RSS feed
+  if (company.api_provider === 'teamtailor' && company.teamtailor_slug) {
+    return {
+      type: 'teamtailor',
+      url: `https://${company.teamtailor_slug}.teamtailor.com/jobs.rss`,
+    };
+  }
+  const ttMatch = url.match(/([^/]+)\.teamtailor\.com/);
+  if (ttMatch) {
+    return {
+      type: 'teamtailor',
+      url: `https://${ttMatch[1]}.teamtailor.com/jobs.rss`,
+    };
+  }
+
+  // Workable: apply.workable.com/{slug}
+  if (company.api_provider === 'workable' && company.workable_slug) {
+    return {
+      type: 'workable',
+      url: `https://apply.workable.com/api/v3/accounts/${company.workable_slug}/jobs`,
+    };
+  }
+  const workableMatch = url.match(/apply\.workable\.com\/([^/?#]+)/);
+  if (workableMatch) {
+    return {
+      type: 'workable',
+      url: `https://apply.workable.com/api/v3/accounts/${workableMatch[1]}/jobs`,
+    };
+  }
+
+  // SmartRecruiters: careers.smartrecruiters.com/{id}
+  if (company.api_provider === 'smartrecruiters' && company.smartrecruiters_id) {
+    return {
+      type: 'smartrecruiters',
+      url: `https://api.smartrecruiters.com/v1/companies/${company.smartrecruiters_id}/postings?status=PUBLIC`,
+    };
+  }
+  const srMatch = url.match(/careers\.smartrecruiters\.com\/([^/?#]+)/);
+  if (srMatch) {
+    return {
+      type: 'smartrecruiters',
+      url: `https://api.smartrecruiters.com/v1/companies/${srMatch[1]}/postings?status=PUBLIC`,
+    };
+  }
+
+  // Recruitee: careers.{slug}.com/o/api/jobs
+  if (company.api_provider === 'recruitee' && company.recruitee_slug) {
+    return {
+      type: 'recruitee',
+      url: `https://careers.${company.recruitee_slug}.com/o/api/jobs`,
+    };
+  }
+
   return null;
 }
 
@@ -104,7 +177,82 @@ function parseLever(json, companyName) {
   }));
 }
 
-const PARSERS = { greenhouse: parseGreenhouse, ashby: parseAshby, lever: parseLever };
+// ── BambooHR / Teamtailor / Workable / SmartRecruiters / Recruitee parsers ─────
+
+function parseBambooHR(json, companyName, _url, meta) {
+  const jobs = json.result || [];
+  const slug = meta?.slug || '';
+  return jobs.map(j => ({
+    title: j.jobOpeningName || '',
+    url: j.jobOpeningShareUrl || `https://${slug}.bamboohr.com/careers/${j.id}/detail`,
+    company: companyName,
+    location: j.location?.city || j.location?.country || '',
+  }));
+}
+
+function parseTeamtailor(xmlText, companyName) {
+  // Teamtailor publishes an RSS feed — parse items with regex
+  const items = [];
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
+  let m;
+  while ((m = itemRegex.exec(xmlText)) !== null) {
+    const block = m[1];
+    const titleM = block.match(/<title><!\[CDATA\[(.*?)\]\]><\/title>|<title>(.*?)<\/title>/);
+    const linkM = block.match(/<link>(.*?)<\/link>|<guid[^>]*>(.*?)<\/guid>/);
+    const locationM = block.match(/<location>(.*?)<\/location>/);
+    if (titleM && linkM) {
+      items.push({
+        title: (titleM[1] || titleM[2] || '').trim(),
+        url: (linkM[1] || linkM[2] || '').trim(),
+        company: companyName,
+        location: locationM ? (locationM[1] || '').trim() : '',
+      });
+    }
+  }
+  return items;
+}
+
+function parseWorkable(json, companyName) {
+  const jobs = json.results || [];
+  return jobs.map(j => ({
+    title: j.title || '',
+    url: j.url || j.shortlink || '',
+    company: companyName,
+    location: j.location?.telecommuting ? 'Remote'
+      : j.location?.city || j.location?.country || '',
+  }));
+}
+
+function parseSmartRecruiters(json, companyName) {
+  const jobs = json.content || [];
+  return jobs.map(j => ({
+    title: j.name || '',
+    url: `https://jobs.smartrecruiters.com/${j.company?.identifier || ''}/${j.id}`,
+    company: companyName,
+    location: j.location?.city || j.location?.country || '',
+  }));
+}
+
+function parseRecruitee(json, companyName) {
+  const jobs = json.offers || [];
+  return jobs.map(j => ({
+    title: j.title || '',
+    url: j.careers_url || '',
+    company: companyName,
+    location: j.city || j.country || '',
+  }));
+}
+
+const ALL_PARSERS = {
+  greenhouse: parseGreenhouse,
+  ashby: parseAshby,
+  lever: parseLever,
+  bamboohr: parseBambooHR,
+  teamtailor: parseTeamtailor,
+  workable: parseWorkable,
+  smartrecruiters: parseSmartRecruiters,
+  recruitee: parseRecruitee,
+};
 
 // ── Fetch with timeout ──────────────────────────────────────────────
 
@@ -115,6 +263,18 @@ async function fetchJson(url) {
     const res = await fetch(url, { signal: controller.signal });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchText(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.text();
   } finally {
     clearTimeout(timer);
   }
@@ -290,10 +450,19 @@ async function main() {
   const errors = [];
 
   const tasks = targets.map(company => async () => {
-    const { type, url } = company._api;
+    const { type, url, meta } = company._api;
     try {
-      const json = await fetchJson(url);
-      const jobs = PARSERS[type](json, company.name);
+      let jobs;
+      if (type === 'teamtailor') {
+        // Teamtailor returns RSS/XML — fetch as text
+        const xml = await fetchText(url);
+        jobs = parseTeamtailor(xml, company.name);
+      } else {
+        const json = await fetchJson(url);
+        const parser = ALL_PARSERS[type];
+        if (!parser) throw new Error(`No parser for type: ${type}`);
+        jobs = parser(json, company.name, url, meta);
+      }
       totalFound += jobs.length;
 
       for (const job of jobs) {

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -942,3 +942,50 @@ tracked_companies:
     scan_query: '"Maxim AI" OR "getmaxim" careers "engineer" OR "product"'
     notes: "AI evaluation and observability platform. Bangalore-based, mostly on-site."
     enabled: true
+
+  # ── BambooHR examples ────────────────────────────────────────────────────────
+  # Auto-detected from {slug}.bamboohr.com/careers URLs.
+  # Or set api_provider: bamboohr + bamboohr_slug explicitly.
+
+  - name: Basecamp
+    careers_url: https://basecamp.bamboohr.com/careers
+    notes: "Fully remote. Project management. Engineering & product."
+    enabled: false
+
+  - name: Doist
+    careers_url: https://doist.bamboohr.com/careers
+    notes: "Async-remote. Todoist & Twist. Engineering, design, and marketing."
+    enabled: false
+
+  - name: Buffer
+    bamboohr_slug: buffer
+    api_provider: bamboohr
+    notes: "Fully remote social media tooling. Engineering & growth roles."
+    enabled: false
+
+  # ── Teamtailor examples ──────────────────────────────────────────────────────
+  # Auto-detected from {slug}.teamtailor.com URLs.
+  # Teamtailor publishes RSS at {slug}.teamtailor.com/jobs.rss — no auth needed.
+
+  - name: Factorial HR
+    careers_url: https://factorialhr.teamtailor.com/jobs
+    notes: "Barcelona HR-tech scale-up. Engineering, Product, Sales."
+    enabled: false
+
+  # ── SmartRecruiters examples ─────────────────────────────────────────────────
+  # Auto-detected from careers.smartrecruiters.com/{id} URLs.
+
+  - name: Bolt
+    careers_url: https://careers.smartrecruiters.com/Bolt
+    notes: "European mobility platform. Engineering, Product, Data."
+    enabled: false
+
+  # ── Recruitee examples ───────────────────────────────────────────────────────
+  # Recruitee boards use careers.{slug}.com/o/api/jobs.
+  # Set api_provider: recruitee + recruitee_slug explicitly.
+
+  # - name: YourCompany
+  #   recruitee_slug: yourcompany
+  #   api_provider: recruitee
+  #   notes: "Example Recruitee company."
+  #   enabled: false


### PR DESCRIPTION
## What does this PR do?

Extends the zero-token scanner (`scan.mjs`) with five additional ATS providers beyond the existing Greenhouse/Ashby/Lever support. The scanner now auto-detects the provider from `careers_url` patterns or explicit `api_provider` / slug fields in `portals.yml`.

**New ATS providers:**

| Provider | Detection | Notes |
|----------|-----------|-------|
| **BambooHR** | `*.bamboohr.com/careers` in URL or `api_provider: bamboohr` + `bamboohr_slug` | Lists via `/careers/list`, constructs public URLs |
| **Teamtailor** | `*.teamtailor.com` in URL or `api_provider: teamtailor` + `teamtailor_slug` | RSS/XML feed — uses new `fetchText()` helper |
| **Workable** | `apply.workable.com` in URL or `api_provider: workable` + `workable_slug` | JSON API via `apply.workable.com/api/v3/accounts` |
| **SmartRecruiters** | `jobs.smartrecruiters.com` in URL or `api_provider: smartrecruiters` + `smartrecruiters_id` | Public postings API |
| **Recruitee** | `careers.*.com` (recruitee) or `api_provider: recruitee` + `recruitee_slug` | JSON jobs API |

**Changes:**
- `scan.mjs`: adds `detectApi()` support for 5 new providers, 5 new parser functions, `fetchText()` helper, renames `PARSERS` → `ALL_PARSERS`
- `templates/portals.example.yml`: adds example entries for BambooHR (Basecamp, Doist, Buffer), Teamtailor (Factorial HR), SmartRecruiters (Bolt), Recruitee placeholder

## Related issue

No related issue — new feature contribution.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added support for tracking job postings from five new providers: BambooHR, Teamtailor, SmartRecruiters, Recruitee, and Workable
- Extended configuration templates with detailed examples for setting up new ATS and job portal integrations
- Introduced RSS and XML feed parsing to expand provider compatibility and enhance job tracking coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->