### PR TITLE
feat(scan): add job board scrapers, HN Who is Hiring, and --source flag

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -180,10 +180,32 @@ Each URL gets a verdict: `active`, `expired`, or `uncertain` with a reason.
 
 ## scan
 
-Zero-token portal scanner. Hits ATS APIs (Greenhouse, Ashby, Lever) and career pages directly — no LLM tokens consumed. Reads `portals.yml` for target companies and search queries, outputs matching listings to stdout and optionally appends to `data/pipeline.md`.
+Zero-token portal scanner running in three phases — no LLM tokens consumed. Reads `portals.yml` for configuration and appends new listings to `data/pipeline.md` + `data/scan-history.tsv`.
+
+**Phase A — Tracked companies:** Hits ATS APIs directly (Greenhouse, Ashby, Lever, BambooHR, Teamtailor, Workable, SmartRecruiters, Recruitee). Auto-detects provider from `careers_url` or explicit `api_provider` field in `portals.yml`.
+
+**Phase B — Job boards:** Scrapes global boards configured under `job_boards:` in `portals.yml`. Supported board types:
+
+| Type | Source |
+|------|--------|
+| `remoteok` | remoteok.com/api |
+| `remotive` | remotive.com/api/remote-jobs |
+| `himalayas` | himalayas.app/jobs/api (paginated) |
+| `arbeitnow` | arbeitnow.com/api/job-board-api (paginated) |
+| `themuse` | themuse.com/api/public/jobs (paginated) |
+| `weworkremotely` | RSS feeds per category |
+| `findwork` | findwork.dev/api (requires free API key) |
+| `indeed` | indeed.com/rss (multi-query) |
+
+**Phase C — HN Who is Hiring:** Fetches the most recent monthly thread via Algolia + Firebase APIs. Enable with `hn_hiring: enabled: true` in `portals.yml`.
 
 ```bash
-npm run scan
+npm run scan                     # all three phases
+npm run scan -- --dry-run        # preview without saving
+npm run scan -- --company Cohere # single company only
+npm run scan -- --source boards  # job boards only (skip companies + HN)
+npm run scan -- --source companies # tracked companies only
+npm run scan -- --source hn      # HN Who is Hiring only
 ```
 
 **Exit codes:** `0` scan completed, `1` configuration error or no portals.yml found.

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -2,7 +2,14 @@
 
 Escanea portales de empleo configurados, filtra por relevancia de título, y añade nuevas ofertas al pipeline para evaluación posterior.
 
-> **Nota (v1.5+):** El escáner por defecto (`scan.mjs` / `npm run scan`) es **zero-token** y sólo consulta directamente las APIs públicas de Greenhouse, Ashby y Lever. Los niveles con Playwright/WebSearch descritos abajo son el flujo **agente** (ejecutado por Claude/Codex), no lo que hace `scan.mjs`. Si una empresa no tiene API Greenhouse/Ashby/Lever, `scan.mjs` la ignorará; para esos casos, el agente debe completar manualmente el Nivel 1 (Playwright) o Nivel 3 (WebSearch).
+> **Nota (v1.5+):** El escáner por defecto (`scan.mjs` / `npm run scan`) es **zero-token** y consulta directamente las APIs públicas de los proveedores ATS soportados (Greenhouse, Ashby, Lever, BambooHR, Teamtailor, Workable, SmartRecruiters, Recruitee), además de **boards globales** (RemoteOK, Remotive, Himalayas, Arbeitnow, The Muse, WeWorkRemotely, Findwork, Indeed RSS) y **HN Who is Hiring**. Los niveles con Playwright/WebSearch descritos abajo son el flujo **agente** (ejecutado por Claude/Codex), no lo que hace `scan.mjs`. Si una empresa no tiene API soportada, `scan.mjs` la ignorará; para esos casos, el agente debe completar manualmente el Nivel 1 (Playwright) o Nivel 3 (WebSearch).
+
+**Flags disponibles para `scan.mjs`:**
+- `--dry-run` — vista previa sin escribir archivos
+- `--company Cohere` — escanear solo esa empresa
+- `--source boards` — solo job boards globales (skip tracked_companies y HN)
+- `--source companies` — solo tracked_companies (skip boards y HN)
+- `--source hn` — solo HN Who is Hiring
 
 ## Ejecución recomendada
 
@@ -45,7 +52,27 @@ Para empresas con API pública o feed estructurado, usar la respuesta JSON/XML c
 - **BambooHR**: lista `https://{company}.bamboohr.com/careers/list`; detalle de una oferta `https://{company}.bamboohr.com/careers/{id}/detail`
 - **Lever**: `https://api.lever.co/v0/postings/{company}?mode=json`
 - **Teamtailor**: `https://{company}.teamtailor.com/jobs.rss`
+- **Workable**: `https://apply.workable.com/api/v3/accounts/{slug}/jobs`
+- **SmartRecruiters**: `https://api.smartrecruiters.com/v1/companies/{id}/postings?status=PUBLIC`
+- **Recruitee**: `https://careers.{slug}.com/o/api/jobs`
 - **Workday**: `https://{company}.{shard}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs`
+
+### Nivel 2b — Job boards globales (AUTOMÁTICO via scan.mjs)
+
+`scan.mjs` lee la sección `job_boards:` de `portals.yml` y consulta directamente cada board:
+
+| Board | Endpoint | Parámetros clave |
+|-------|----------|-----------------|
+| **RemoteOK** | `https://remoteok.com/api?tags=...` | `tags[]` comma-separated |
+| **Remotive** | `https://remotive.com/api/remote-jobs` | `category`, `search` |
+| **Himalayas** | `https://himalayas.app/jobs/api` | `search`, `seniority`, `max_pages` |
+| **Arbeitnow** | `https://www.arbeitnow.com/api/job-board-api` | `tag`, `remote`, `max_pages` |
+| **The Muse** | `https://www.themuse.com/api/public/jobs` | `category`, `level`, `max_pages` |
+| **WeWorkRemotely** | RSS feed URLs | `feeds[]` list |
+| **Findwork** | `https://findwork.dev/api/jobs/` | `search`, `remote`, `api_key` |
+| **Indeed** | `https://www.indeed.com/rss?q=...` | `queries[]` con `q` y `l`, `results_per_query` |
+
+HN Who is Hiring se activa con `hn_hiring: enabled: true` en `portals.yml` y consulta el hilo mensual más reciente via Algolia + Firebase APIs.
 
 **Convención de parsing por provider:**
 - `greenhouse`: `jobs[]` → `title`, `absolute_url`

--- a/scan.mjs
+++ b/scan.mjs
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
+/* eslint-env node */
+/* global process, console, fetch, AbortController, setTimeout, clearTimeout */
 
 /**
  * scan.mjs — Zero-token portal scanner
  *
- * Fetches Greenhouse, Ashby, and Lever APIs directly, applies title
- * filters from portals.yml, deduplicates against existing history,
- * and appends new offers to pipeline.md + scan-history.tsv.
+ * Fetches Greenhouse, Ashby, Lever, BambooHR, Teamtailor, Workable,
+ * SmartRecruiters, and Recruitee APIs directly, applies title filters
+ * from portals.yml, deduplicates against existing history, and appends
+ * new offers to pipeline.md + scan-history.tsv.
  *
- * Zero Claude API tokens — pure HTTP + JSON.
+ * Zero Claude API tokens — pure HTTP + JSON/RSS.
  *
  * Usage:
  *   node scan.mjs                  # scan all enabled companies
@@ -69,6 +72,76 @@ function detectApi(company) {
     };
   }
 
+  // BambooHR: explicit api_provider or {slug}.bamboohr.com
+  if (company.api_provider === 'bamboohr' && company.bamboohr_slug) {
+    return {
+      type: 'bamboohr',
+      url: `https://${company.bamboohr_slug}.bamboohr.com/careers/list`,
+      meta: { slug: company.bamboohr_slug },
+    };
+  }
+  const bambooMatch = url.match(/([^/]+)\.bamboohr\.com/);
+  if (bambooMatch) {
+    return {
+      type: 'bamboohr',
+      url: `https://${bambooMatch[1]}.bamboohr.com/careers/list`,
+      meta: { slug: bambooMatch[1] },
+    };
+  }
+
+  // Teamtailor: {slug}.teamtailor.com — returns RSS feed
+  if (company.api_provider === 'teamtailor' && company.teamtailor_slug) {
+    return {
+      type: 'teamtailor',
+      url: `https://${company.teamtailor_slug}.teamtailor.com/jobs.rss`,
+    };
+  }
+  const ttMatch = url.match(/([^/]+)\.teamtailor\.com/);
+  if (ttMatch) {
+    return {
+      type: 'teamtailor',
+      url: `https://${ttMatch[1]}.teamtailor.com/jobs.rss`,
+    };
+  }
+
+  // Workable: apply.workable.com/{slug}
+  if (company.api_provider === 'workable' && company.workable_slug) {
+    return {
+      type: 'workable',
+      url: `https://apply.workable.com/api/v3/accounts/${company.workable_slug}/jobs`,
+    };
+  }
+  const workableMatch = url.match(/apply\.workable\.com\/([^/?#]+)/);
+  if (workableMatch) {
+    return {
+      type: 'workable',
+      url: `https://apply.workable.com/api/v3/accounts/${workableMatch[1]}/jobs`,
+    };
+  }
+
+  // SmartRecruiters: careers.smartrecruiters.com/{id}
+  if (company.api_provider === 'smartrecruiters' && company.smartrecruiters_id) {
+    return {
+      type: 'smartrecruiters',
+      url: `https://api.smartrecruiters.com/v1/companies/${company.smartrecruiters_id}/postings?status=PUBLIC`,
+    };
+  }
+  const srMatch = url.match(/careers\.smartrecruiters\.com\/([^/?#]+)/);
+  if (srMatch) {
+    return {
+      type: 'smartrecruiters',
+      url: `https://api.smartrecruiters.com/v1/companies/${srMatch[1]}/postings?status=PUBLIC`,
+    };
+  }
+
+  // Recruitee: careers.{slug}.com/o/api/jobs
+  if (company.api_provider === 'recruitee' && company.recruitee_slug) {
+    return {
+      type: 'recruitee',
+      url: `https://careers.${company.recruitee_slug}.com/o/api/jobs`,
+    };
+  }
+
   return null;
 }
 
@@ -104,7 +177,82 @@ function parseLever(json, companyName) {
   }));
 }
 
-const PARSERS = { greenhouse: parseGreenhouse, ashby: parseAshby, lever: parseLever };
+// ── BambooHR / Teamtailor / Workable / SmartRecruiters / Recruitee parsers ─────
+
+function parseBambooHR(json, companyName, _url, meta) {
+  const jobs = json.result || [];
+  const slug = meta?.slug || '';
+  return jobs.map(j => ({
+    title: j.jobOpeningName || '',
+    url: j.jobOpeningShareUrl || `https://${slug}.bamboohr.com/careers/${j.id}/detail`,
+    company: companyName,
+    location: j.location?.city || j.location?.country || '',
+  }));
+}
+
+function parseTeamtailor(xmlText, companyName) {
+  // Teamtailor publishes an RSS feed — parse items with regex
+  const items = [];
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
+  let m;
+  while ((m = itemRegex.exec(xmlText)) !== null) {
+    const block = m[1];
+    const titleM = block.match(/<title><!\[CDATA\[(.*?)\]\]><\/title>|<title>(.*?)<\/title>/);
+    const linkM = block.match(/<link>(.*?)<\/link>|<guid[^>]*>(.*?)<\/guid>/);
+    const locationM = block.match(/<location>(.*?)<\/location>/);
+    if (titleM && linkM) {
+      items.push({
+        title: (titleM[1] || titleM[2] || '').trim(),
+        url: (linkM[1] || linkM[2] || '').trim(),
+        company: companyName,
+        location: locationM ? (locationM[1] || '').trim() : '',
+      });
+    }
+  }
+  return items;
+}
+
+function parseWorkable(json, companyName) {
+  const jobs = json.results || [];
+  return jobs.map(j => ({
+    title: j.title || '',
+    url: j.url || j.shortlink || '',
+    company: companyName,
+    location: j.location?.telecommuting ? 'Remote'
+      : j.location?.city || j.location?.country || '',
+  }));
+}
+
+function parseSmartRecruiters(json, companyName) {
+  const jobs = json.content || [];
+  return jobs.map(j => ({
+    title: j.name || '',
+    url: `https://jobs.smartrecruiters.com/${j.company?.identifier || ''}/${j.id}`,
+    company: companyName,
+    location: j.location?.city || j.location?.country || '',
+  }));
+}
+
+function parseRecruitee(json, companyName) {
+  const jobs = json.offers || [];
+  return jobs.map(j => ({
+    title: j.title || '',
+    url: j.careers_url || '',
+    company: companyName,
+    location: j.city || j.country || '',
+  }));
+}
+
+const ALL_PARSERS = {
+  greenhouse: parseGreenhouse,
+  ashby: parseAshby,
+  lever: parseLever,
+  bamboohr: parseBambooHR,
+  teamtailor: parseTeamtailor,
+  workable: parseWorkable,
+  smartrecruiters: parseSmartRecruiters,
+  recruitee: parseRecruitee,
+};
 
 // ── Fetch with timeout ──────────────────────────────────────────────
 
@@ -115,6 +263,18 @@ async function fetchJson(url) {
     const res = await fetch(url, { signal: controller.signal });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchText(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.text();
   } finally {
     clearTimeout(timer);
   }
@@ -290,10 +450,19 @@ async function main() {
   const errors = [];
 
   const tasks = targets.map(company => async () => {
-    const { type, url } = company._api;
+    const { type, url, meta } = company._api;
     try {
-      const json = await fetchJson(url);
-      const jobs = PARSERS[type](json, company.name);
+      let jobs;
+      if (type === 'teamtailor') {
+        // Teamtailor returns RSS/XML — fetch as text
+        const xml = await fetchText(url);
+        jobs = parseTeamtailor(xml, company.name);
+      } else {
+        const json = await fetchJson(url);
+        const parser = ALL_PARSERS[type];
+        if (!parser) throw new Error(`No parser for type: ${type}`);
+        jobs = parser(json, company.name, url, meta);
+      }
       totalFound += jobs.length;
 
       for (const job of jobs) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -6,16 +6,22 @@
  * scan.mjs — Zero-token portal scanner
  *
  * Fetches Greenhouse, Ashby, Lever, BambooHR, Teamtailor, Workable,
- * SmartRecruiters, and Recruitee APIs directly, applies title filters
- * from portals.yml, deduplicates against existing history, and appends
- * new offers to pipeline.md + scan-history.tsv.
+ * SmartRecruiters, and Recruitee APIs directly, plus global job boards
+ * (RemoteOK, Remotive, Himalayas, Arbeitnow, The Muse, WeWorkRemotely,
+ * Findwork, Indeed) and Hacker News "Who is Hiring" monthly thread.
+ *
+ * Applies title filters from portals.yml, deduplicates against existing
+ * history, and appends new offers to pipeline.md + scan-history.tsv.
  *
  * Zero Claude API tokens — pure HTTP + JSON/RSS.
  *
  * Usage:
- *   node scan.mjs                  # scan all enabled companies
- *   node scan.mjs --dry-run        # preview without writing files
- *   node scan.mjs --company Cohere # scan a single company
+ *   node scan.mjs                        # scan all enabled companies + all enabled boards
+ *   node scan.mjs --dry-run              # preview without writing files
+ *   node scan.mjs --company Cohere       # scan a single company
+ *   node scan.mjs --source boards        # scan job boards only
+ *   node scan.mjs --source companies     # scan tracked_companies only
+ *   node scan.mjs --source hn            # scan HN Who is Hiring only
  */
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
@@ -280,6 +286,381 @@ async function fetchText(url) {
   }
 }
 
+// ── Generic RSS parser (used by WeWorkRemotely, Indeed, and others) ─
+
+function parseRSSItems(xmlText, sourceLabel) {
+  const items = [];
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
+  let m;
+  while ((m = itemRegex.exec(xmlText)) !== null) {
+    const block = m[1];
+    const titleM = block.match(
+      /<title><!\[CDATA\[(.*?)\]\]><\/title>|<title>(.*?)<\/title>/,
+    );
+    const linkM =
+      block.match(/<link>(.*?)<\/link>/) ||
+      block.match(/<guid[^>]*isPermaLink="true"[^>]*>(.*?)<\/guid>/);
+    const companyM = block.match(
+      /<company>(.*?)<\/company>|<companyName>(.*?)<\/companyName>/,
+    );
+    const locationM = block.match(
+      /<location>(.*?)<\/location>|<region>(.*?)<\/region>/,
+    );
+    if (titleM && linkM) {
+      items.push({
+        title: (titleM[1] || titleM[2] || '')
+          .replace(/<!\[CDATA\[|\]\]>/g, '')
+          .trim(),
+        url: (linkM[1] || '').trim(),
+        company: (companyM ? companyM[1] || companyM[2] || '' : '')
+          .replace(/<!\[CDATA\[|\]\]>/g, '')
+          .trim(),
+        location: (locationM ? locationM[1] || locationM[2] || '' : '')
+          .replace(/<!\[CDATA\[|\]\]>/g, '')
+          .trim(),
+        source: sourceLabel,
+      });
+    }
+  }
+  return items;
+}
+
+// ── Global job board fetchers ────────────────────────────────────────
+
+/**
+ * RemoteOK — remoteok.com/api
+ * JSON array. First element is a notice object (skip it).
+ * Filter by ?tags=react,typescript (comma-separated).
+ */
+async function fetchRemoteOK(boardConfig) {
+  const tags = (boardConfig.tags || []).join(',');
+  const url = tags
+    ? `https://remoteok.com/api?tags=${encodeURIComponent(tags)}`
+    : 'https://remoteok.com/api';
+  const json = await fetchJson(url);
+  const jobs = Array.isArray(json) ? json.slice(1) : []; // skip first notice element
+  return jobs
+    .filter(j => j.position)
+    .map(j => ({
+      title: j.position || '',
+      url: j.url || j.apply_url || `https://remoteok.com/remote-jobs/${j.slug}`,
+      company: j.company || '',
+      location: j.location || 'Remote',
+      source: 'remoteok',
+    }));
+}
+
+/**
+ * Remotive — remotive.com/api/remote-jobs
+ * Free public API. ?category=software-dev&search=react
+ */
+async function fetchRemotive(boardConfig) {
+  const params = new URLSearchParams();
+  if (boardConfig.category) params.set('category', boardConfig.category);
+  if (boardConfig.search) params.set('search', boardConfig.search);
+  const url = `https://remotive.com/api/remote-jobs${params.toString() ? '?' + params : ''}`;
+  const json = await fetchJson(url);
+  const jobs = json.jobs || [];
+  return jobs.map(j => ({
+    title: j.title || '',
+    url: j.url || '',
+    company: j.company_name || '',
+    location: j.candidate_required_location || 'Remote',
+    source: 'remotive',
+  }));
+}
+
+/**
+ * Himalayas — himalayas.app/jobs/api
+ * Free JSON API. Paginated with ?page=N&limit=100
+ */
+async function fetchHimalayas(boardConfig) {
+  const allJobs = [];
+  const limit = boardConfig.limit || 100;
+  const maxPages = boardConfig.max_pages || 5;
+  const params = new URLSearchParams();
+  params.set('limit', String(limit));
+  if (boardConfig.skills) params.set('skills', boardConfig.skills);
+  if (boardConfig.seniority) params.set('seniority', boardConfig.seniority);
+  if (boardConfig.search) params.set('search', boardConfig.search);
+
+  for (let page = 1; page <= maxPages; page++) {
+    params.set('page', String(page));
+    let json;
+    try {
+      json = await fetchJson(`https://himalayas.app/jobs/api?${params}`);
+    } catch {
+      break;
+    }
+    const jobs = json.jobs || [];
+    if (jobs.length === 0) break;
+    for (const j of jobs) {
+      allJobs.push({
+        title: j.title || '',
+        url: j.applicationLink || j.jobUrl || `https://himalayas.app/jobs/${j.slug}`,
+        company: j.company?.name || j.companyName || '',
+        location: j.location || 'Remote',
+        source: 'himalayas',
+      });
+    }
+    if (!json.pagination?.hasNextPage) break;
+  }
+  return allJobs;
+}
+
+/**
+ * Arbeitnow — arbeitnow.com/api/job-board-api
+ * Free JSON API, paginated, EU-focused. ?tag=React&remote=true
+ */
+async function fetchArbeitnow(boardConfig) {
+  const allJobs = [];
+  const maxPages = boardConfig.max_pages || 3;
+  const params = new URLSearchParams();
+  if (boardConfig.tag) params.set('tag', boardConfig.tag);
+  if (boardConfig.remote) params.set('remote', 'true');
+
+  for (let page = 1; page <= maxPages; page++) {
+    params.set('page', String(page));
+    let json;
+    try {
+      json = await fetchJson(`https://www.arbeitnow.com/api/job-board-api?${params}`);
+    } catch {
+      break;
+    }
+    const jobs = json.data || [];
+    if (jobs.length === 0) break;
+    for (const j of jobs) {
+      allJobs.push({
+        title: j.title || '',
+        url: j.url || '',
+        company: j.company_name || '',
+        location: j.location || '',
+        source: 'arbeitnow',
+      });
+    }
+    if (!json.links?.next) break;
+  }
+  return allJobs;
+}
+
+/**
+ * The Muse — themuse.com/api/public/jobs
+ * Free JSON API. ?category=Engineering&page=N (0-indexed)
+ */
+async function fetchTheMuse(boardConfig) {
+  const allJobs = [];
+  const maxPages = boardConfig.max_pages || 5;
+  const params = new URLSearchParams();
+  if (boardConfig.category) params.set('category', boardConfig.category);
+  if (boardConfig.level) params.set('level', boardConfig.level);
+  params.set('per_page', '100');
+
+  for (let page = 0; page < maxPages; page++) {
+    params.set('page', String(page));
+    let json;
+    try {
+      json = await fetchJson(`https://www.themuse.com/api/public/jobs?${params}`);
+    } catch {
+      break;
+    }
+    const jobs = json.results || [];
+    if (jobs.length === 0) break;
+    for (const j of jobs) {
+      allJobs.push({
+        title: j.name || '',
+        url: j.refs?.landing_page || '',
+        company: j.company?.name || '',
+        location: (j.locations || []).map(l => l.name).join(', ') || '',
+        source: 'themuse',
+      });
+    }
+    const pageCount = json.page_count || 1;
+    if (page + 1 >= pageCount) break;
+  }
+  return allJobs;
+}
+
+/**
+ * WeWorkRemotely — weworkremotely.com RSS feeds
+ * Title format: "Company: Job Title" — extract company from title.
+ */
+async function fetchWeWorkRemotely(boardConfig) {
+  const feeds = boardConfig.feeds || [
+    'https://weworkremotely.com/categories/remote-programming-jobs.rss',
+  ];
+  const allJobs = [];
+  for (const feedUrl of feeds) {
+    let xml;
+    try {
+      xml = await fetchText(feedUrl);
+    } catch {
+      continue;
+    }
+    const items = parseRSSItems(xml, 'weworkremotely');
+    for (const item of items) {
+      // WWR title format: "Company: Job Title" — parse company from title prefix
+      if (!item.company && item.title.includes(':')) {
+        const colonIdx = item.title.indexOf(':');
+        item.company = item.title.slice(0, colonIdx).trim();
+        item.title = item.title.slice(colonIdx + 1).trim();
+      }
+      allJobs.push(item);
+    }
+  }
+  return allJobs;
+}
+
+/**
+ * Findwork — findwork.dev/api/jobs
+ * Requires free API key. ?search=react&remote=true
+ */
+async function fetchFindwork(boardConfig) {
+  if (!boardConfig.api_key) return []; // skip if no key configured
+  const params = new URLSearchParams();
+  if (boardConfig.search) params.set('search', boardConfig.search);
+  if (boardConfig.remote) params.set('remote', 'true');
+  const url = `https://findwork.dev/api/jobs/?${params}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  let json;
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { Authorization: `Token ${boardConfig.api_key}` },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    json = await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+  const jobs = json.results || [];
+  return jobs.map(j => ({
+    title: j.role || '',
+    url: j.url || '',
+    company: j.company_name || '',
+    location: j.location || 'Remote',
+    source: 'findwork',
+  }));
+}
+
+/**
+ * Indeed RSS — indeed.com/rss public feed
+ * Supports multiple search queries per board entry.
+ * Company extracted from <source> element (Indeed-specific tag).
+ */
+async function fetchIndeed(boardConfig) {
+  const queries = boardConfig.queries || [
+    { q: boardConfig.search || 'software engineer', l: boardConfig.location || 'remote' },
+  ];
+  const allJobs = [];
+  for (const query of queries) {
+    const params = new URLSearchParams({
+      q: query.q || '',
+      l: query.l || 'remote',
+      sort: 'date',
+      limit: String(boardConfig.results_per_query || 50),
+    });
+    const url = `https://www.indeed.com/rss?${params}`;
+    let xml;
+    try {
+      xml = await fetchText(url);
+    } catch {
+      continue;
+    }
+    const items = parseRSSItems(xml, 'indeed');
+    // Indeed uses <source url="...">Company Name</source> — not standard <company> tag
+    const srcRegex = /<source[^>]*>([^<]+)<\/source>/g;
+    const sources = [];
+    let sm;
+    while ((sm = srcRegex.exec(xml)) !== null) {
+      sources.push(sm[1].trim());
+    }
+    items.forEach((item, i) => {
+      if (!item.company && sources[i]) item.company = sources[i];
+    });
+    allJobs.push(...items);
+  }
+  return allJobs;
+}
+
+// ── HN Who is Hiring fetcher ────────────────────────────────────────
+
+/**
+ * Fetch the most recent "Ask HN: Who is Hiring?" thread via Algolia HN API.
+ * Searches by date (not relevance) to get the latest thread.
+ * Parses top-level comments and extracts job entries.
+ */
+async function fetchHNWhoIsHiring(titleFilter) {
+  // Step 1: Find the most recent monthly thread (sorted by date)
+  const searchUrl =
+    'https://hn.algolia.com/api/v1/search_by_date?query=Ask+HN+Who+is+hiring&tags=story,author_whoishiring&hitsPerPage=1';
+  const searchJson = await fetchJson(searchUrl);
+  const hits = searchJson.hits || [];
+  if (hits.length === 0) throw new Error('HN: no hiring thread found');
+
+  const threadId = hits[0].objectID;
+  const threadTitle = hits[0].title || 'Ask HN: Who is Hiring?';
+  console.log(`  HN thread: ${threadTitle} (${threadId})`);
+
+  // Step 2: Fetch top-level comments (kids)
+  const story = await fetchJson(`https://hacker-news.firebaseio.com/v0/item/${threadId}.json`);
+  const kids = (story.kids || []).slice(0, 500); // limit to 500 comments
+
+  // Step 3: Fetch comments in parallel batches
+  const jobs = [];
+  const BATCH = 20;
+  for (let i = 0; i < kids.length; i += BATCH) {
+    const batch = kids.slice(i, i + BATCH);
+    const fetched = await Promise.allSettled(
+      batch.map(id => fetchJson(`https://hacker-news.firebaseio.com/v0/item/${id}.json`)),
+    );
+    for (const result of fetched) {
+      if (result.status !== 'fulfilled') continue;
+      const comment = result.value;
+      if (!comment || comment.dead || comment.deleted) continue;
+      const text = comment.text || '';
+      // HN hiring comments typically start with "Company | Role | ..."
+      const firstLine = text
+        .replace(/<[^>]+>/g, ' ')
+        .split('\n')[0]
+        .trim();
+      if (!firstLine || firstLine.length < 10) continue;
+
+      const parts = firstLine.split('|').map(p => p.trim());
+      const company = parts[0] || '';
+      const title = parts[1] || firstLine.slice(0, 100);
+      const location =
+        parts.slice(2).find(p => /remote|hybrid|onsite|on.site/i.test(p)) ||
+        parts[2] ||
+        '';
+
+      if (!titleFilter(title)) continue;
+
+      jobs.push({
+        title: title.slice(0, 200),
+        url: `https://news.ycombinator.com/item?id=${comment.id}`,
+        company: company.slice(0, 100),
+        location: location.slice(0, 100),
+        source: 'hn-hiring',
+      });
+    }
+  }
+  return jobs;
+}
+
+// ── Board dispatcher ────────────────────────────────────────────────
+
+const BOARD_FETCHERS = {
+  remoteok: fetchRemoteOK,
+  remotive: fetchRemotive,
+  himalayas: fetchHimalayas,
+  arbeitnow: fetchArbeitnow,
+  themuse: fetchTheMuse,
+  weworkremotely: fetchWeWorkRemotely,
+  findwork: cfg => fetchFindwork(cfg).catch(() => []),
+  indeed: fetchIndeed,
+};
+
 // ── Title filter ────────────────────────────────────────────────────
 
 function buildTitleFilter(titleFilter) {
@@ -414,6 +795,8 @@ async function main() {
   const dryRun = args.includes('--dry-run');
   const companyFlag = args.indexOf('--company');
   const filterCompany = companyFlag !== -1 ? args[companyFlag + 1]?.toLowerCase() : null;
+  const sourceIdx = args.indexOf('--source');
+  const sourceFlag = sourceIdx !== -1 ? args[sourceIdx + 1] : null; // 'boards' | 'companies' | 'hn' | null
 
   // 1. Read portals.yml
   if (!existsSync(PORTALS_PATH)) {
@@ -425,23 +808,12 @@ async function main() {
   const companies = config.tracked_companies || [];
   const titleFilter = buildTitleFilter(config.title_filter);
 
-  // 2. Filter to enabled companies with detectable APIs
-  const targets = companies
-    .filter(c => c.enabled !== false)
-    .filter(c => !filterCompany || c.name.toLowerCase().includes(filterCompany))
-    .map(c => ({ ...c, _api: detectApi(c) }))
-    .filter(c => c._api !== null);
-
-  const skippedCount = companies.filter(c => c.enabled !== false).length - targets.length;
-
-  console.log(`Scanning ${targets.length} companies via API (${skippedCount} skipped — no API detected)`);
   if (dryRun) console.log('(dry run — no files will be written)\n');
 
-  // 3. Load dedup sets
+  // 2. Load dedup sets
   const seenUrls = loadSeenUrls();
   const seenCompanyRoles = loadSeenCompanyRoles();
 
-  // 4. Fetch all APIs
   const date = new Date().toISOString().slice(0, 10);
   let totalFound = 0;
   let totalFiltered = 0;
@@ -449,59 +821,121 @@ async function main() {
   const newOffers = [];
   const errors = [];
 
-  const tasks = targets.map(company => async () => {
-    const { type, url, meta } = company._api;
-    try {
-      let jobs;
-      if (type === 'teamtailor') {
-        // Teamtailor returns RSS/XML — fetch as text
-        const xml = await fetchText(url);
-        jobs = parseTeamtailor(xml, company.name);
-      } else {
-        const json = await fetchJson(url);
-        const parser = ALL_PARSERS[type];
-        if (!parser) throw new Error(`No parser for type: ${type}`);
-        jobs = parser(json, company.name, url, meta);
-      }
-      totalFound += jobs.length;
+  // Helper: apply title filter + dedup, push to newOffers if OK
+  function processJob(job, sourceLabel) {
+    totalFound++;
+    if (!titleFilter(job.title)) { totalFiltered++; return; }
+    if (seenUrls.has(job.url)) { totalDupes++; return; }
+    const key = `${(job.company || '').toLowerCase()}::${job.title.toLowerCase()}`;
+    if (seenCompanyRoles.has(key)) { totalDupes++; return; }
+    seenUrls.add(job.url);
+    seenCompanyRoles.add(key);
+    newOffers.push({ ...job, source: sourceLabel });
+  }
 
-      for (const job of jobs) {
-        if (!titleFilter(job.title)) {
-          totalFiltered++;
-          continue;
+  // ── Phase A: Tracked companies (Greenhouse, Ashby, Lever, BambooHR, etc.) ──
+
+  const runCompanies = sourceFlag == null || sourceFlag === 'companies';
+  if (runCompanies) {
+    const targets = companies
+      .filter(c => c.enabled !== false)
+      .filter(c => !filterCompany || c.name.toLowerCase().includes(filterCompany))
+      .map(c => ({ ...c, _api: detectApi(c) }))
+      .filter(c => c._api !== null);
+
+    const skippedCount = companies.filter(c => c.enabled !== false).length - targets.length;
+    console.log(`Scanning ${targets.length} companies via API (${skippedCount} skipped — no API detected)`);
+
+    const tasks = targets.map(company => async () => {
+      const { type, url, meta } = company._api;
+      try {
+        let jobs;
+        if (type === 'teamtailor') {
+          const xml = await fetchText(url);
+          jobs = parseTeamtailor(xml, company.name);
+        } else {
+          const json = await fetchJson(url);
+          const parser = ALL_PARSERS[type];
+          if (!parser) throw new Error(`No parser for type: ${type}`);
+          jobs = parser(json, company.name, url, meta);
         }
-        if (seenUrls.has(job.url)) {
-          totalDupes++;
-          continue;
-        }
-        const key = `${job.company.toLowerCase()}::${job.title.toLowerCase()}`;
-        if (seenCompanyRoles.has(key)) {
-          totalDupes++;
-          continue;
-        }
-        // Mark as seen to avoid intra-scan dupes
-        seenUrls.add(job.url);
-        seenCompanyRoles.add(key);
-        newOffers.push({ ...job, source: `${type}-api` });
+        for (const job of jobs) processJob(job, `${type}-api`);
+      } catch (err) {
+        errors.push({ company: company.name, error: err.message });
       }
-    } catch (err) {
-      errors.push({ company: company.name, error: err.message });
+    });
+
+    await parallelFetch(tasks, CONCURRENCY);
+  }
+
+  // ── Phase B: Global job boards ────────────────────────────────────────────
+
+  const runBoards = sourceFlag == null || sourceFlag === 'boards';
+  if (runBoards) {
+    const boards = (config.job_boards || []).filter(b => b.enabled !== false);
+    if (boards.length > 0) {
+      console.log(`\nScanning ${boards.length} job boards...`);
+      for (const board of boards) {
+        const fetcher = BOARD_FETCHERS[board.type];
+        if (!fetcher) {
+          errors.push({ company: `board:${board.name}`, error: `Unknown board type: ${board.type}` });
+          continue;
+        }
+        process.stdout.write(`  → ${board.name} ... `);
+        try {
+          const jobs = await fetcher(board);
+          for (const job of jobs) processJob(job, board.type);
+          console.log(`${jobs.length} found`);
+        } catch (err) {
+          console.log('error');
+          errors.push({ company: `board:${board.name}`, error: err.message });
+        }
+      }
     }
-  });
+  }
 
-  await parallelFetch(tasks, CONCURRENCY);
+  // ── Phase C: HN Who is Hiring ─────────────────────────────────────────────
 
-  // 5. Write results
+  const runHN = sourceFlag == null || sourceFlag === 'hn';
+  if (runHN && config.hn_hiring?.enabled !== false && config.hn_hiring) {
+    console.log('\nFetching HN Who is Hiring...');
+    try {
+      const hnJobs = await fetchHNWhoIsHiring(titleFilter);
+      for (const job of hnJobs) {
+        // HN jobs already passed titleFilter inside fetchHNWhoIsHiring
+        if (seenUrls.has(job.url)) { totalDupes++; continue; }
+        seenUrls.add(job.url);
+        newOffers.push(job);
+      }
+      console.log(`  ${hnJobs.length} matching HN comments found`);
+    } catch (err) {
+      errors.push({ company: 'HN Who is Hiring', error: err.message });
+    }
+  }
+
+  // ── Write results ─────────────────────────────────────────────────────────
+
   if (!dryRun && newOffers.length > 0) {
     appendToPipeline(newOffers);
     appendToScanHistory(newOffers, date);
   }
 
-  // 6. Print summary
+  // Print summary
   console.log(`\n${'━'.repeat(45)}`);
   console.log(`Portal Scan — ${date}`);
   console.log(`${'━'.repeat(45)}`);
-  console.log(`Companies scanned:     ${targets.length}`);
+  if (runCompanies) {
+    const targets = companies
+      .filter(c => c.enabled !== false)
+      .filter(c => !filterCompany || c.name.toLowerCase().includes(filterCompany))
+      .map(c => ({ ...c, _api: detectApi(c) }))
+      .filter(c => c._api !== null);
+    console.log(`Companies scanned:     ${targets.length}`);
+  }
+  if (runBoards) {
+    const boards = (config.job_boards || []).filter(b => b.enabled !== false);
+    if (boards.length) console.log(`Job boards scanned:    ${boards.length}`);
+  }
   console.log(`Total jobs found:      ${totalFound}`);
   console.log(`Filtered by title:     ${totalFiltered} removed`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
@@ -517,7 +951,7 @@ async function main() {
   if (newOffers.length > 0) {
     console.log('\nNew offers:');
     for (const o of newOffers) {
-      console.log(`  + ${o.company} | ${o.title} | ${o.location || 'N/A'}`);
+      console.log(`  + ${o.company || '?'} | ${o.title} | ${o.location || 'N/A'}`);
     }
     if (dryRun) {
       console.log('\n(dry run — run without --dry-run to save results)');

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -942,3 +942,50 @@ tracked_companies:
     scan_query: '"Maxim AI" OR "getmaxim" careers "engineer" OR "product"'
     notes: "AI evaluation and observability platform. Bangalore-based, mostly on-site."
     enabled: true
+
+  # ── BambooHR examples ────────────────────────────────────────────────────────
+  # Auto-detected from {slug}.bamboohr.com/careers URLs.
+  # Or set api_provider: bamboohr + bamboohr_slug explicitly.
+
+  - name: Basecamp
+    careers_url: https://basecamp.bamboohr.com/careers
+    notes: "Fully remote. Project management. Engineering & product."
+    enabled: false
+
+  - name: Doist
+    careers_url: https://doist.bamboohr.com/careers
+    notes: "Async-remote. Todoist & Twist. Engineering, design, and marketing."
+    enabled: false
+
+  - name: Buffer
+    bamboohr_slug: buffer
+    api_provider: bamboohr
+    notes: "Fully remote social media tooling. Engineering & growth roles."
+    enabled: false
+
+  # ── Teamtailor examples ──────────────────────────────────────────────────────
+  # Auto-detected from {slug}.teamtailor.com URLs.
+  # Teamtailor publishes RSS at {slug}.teamtailor.com/jobs.rss — no auth needed.
+
+  - name: Factorial HR
+    careers_url: https://factorialhr.teamtailor.com/jobs
+    notes: "Barcelona HR-tech scale-up. Engineering, Product, Sales."
+    enabled: false
+
+  # ── SmartRecruiters examples ─────────────────────────────────────────────────
+  # Auto-detected from careers.smartrecruiters.com/{id} URLs.
+
+  - name: Bolt
+    careers_url: https://careers.smartrecruiters.com/Bolt
+    notes: "European mobility platform. Engineering, Product, Data."
+    enabled: false
+
+  # ── Recruitee examples ───────────────────────────────────────────────────────
+  # Recruitee boards use careers.{slug}.com/o/api/jobs.
+  # Set api_provider: recruitee + recruitee_slug explicitly.
+
+  # - name: YourCompany
+  #   recruitee_slug: yourcompany
+  #   api_provider: recruitee
+  #   notes: "Example Recruitee company."
+  #   enabled: false

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -989,3 +989,75 @@ tracked_companies:
   #   api_provider: recruitee
   #   notes: "Example Recruitee company."
   #   enabled: false
+
+# ────────────────────────────────────────────────────────────────────────────────
+# JOB BOARDS
+# Zero-token scrapers for global boards. Each entry has a 'type' field that maps
+# to a built-in fetcher. Configure filters (tags, category, search) per board.
+# ────────────────────────────────────────────────────────────────────────────────
+
+job_boards:
+
+  - name: RemoteOK
+    type: remoteok
+    tags: [react, typescript, python]  # comma-separated tags (see remoteok.com/api)
+    enabled: true
+
+  - name: Remotive
+    type: remotive
+    category: software-dev             # see remotive.com/api/remote-jobs/categories
+    search: AI engineer
+    enabled: true
+
+  - name: Himalayas
+    type: himalayas
+    search: machine learning
+    seniority: Senior                  # Senior | Mid | Junior
+    max_pages: 3
+    enabled: true
+
+  - name: Arbeitnow (EU)
+    type: arbeitnow
+    tag: Python
+    remote: true
+    enabled: true
+
+  - name: The Muse
+    type: themuse
+    category: Software Engineer        # see themuse.com/api/public/jobs
+    level: Senior Level
+    max_pages: 3
+    enabled: true
+
+  - name: WeWorkRemotely
+    type: weworkremotely
+    feeds:
+      - https://weworkremotely.com/categories/remote-programming-jobs.rss
+      - https://weworkremotely.com/categories/remote-devops-sysadmin-jobs.rss
+    enabled: true
+
+  - name: Findwork (requires API key)
+    type: findwork
+    search: machine learning
+    remote: true
+    api_key: YOUR_FINDWORK_API_KEY     # free at findwork.dev/register
+    enabled: false                     # disabled until api_key is set
+
+  - name: Indeed
+    type: indeed
+    queries:
+      - q: "AI engineer"
+        l: "Remote"
+      - q: "machine learning engineer"
+        l: "Remote"
+    results_per_query: 50
+    enabled: true
+
+# ────────────────────────────────────────────────────────────────────────────────
+# HN WHO IS HIRING
+# Scrapes the monthly "Ask HN: Who is Hiring?" thread via Algolia API.
+# Applies your title_filter to match relevant job comments.
+# ────────────────────────────────────────────────────────────────────────────────
+
+hn_hiring:
+  enabled: true


### PR DESCRIPTION
## What does this PR do?

> **Depends on #478** — This PR is stacked on top of feat/scan-new-ats-providers. The diff shown here includes changes from both PRs. Please merge #478 first, or review this diff knowing that ATS provider changes (from #478) are included.

Adds three additional scan phases to `scan.mjs` beyond tracked companies:

**Phase B — Job board scrapers (8 sources, zero-token):**

| Board | Endpoint | Config keys |
|-------|----------|-------------|
| RemoteOK | remoteok.com/api | `tags[]` |
| Remotive | remotive.com/api/remote-jobs | `category`, `search` |
| Himalayas | himalayas.app/jobs/api | `search`, `seniority`, `max_pages` |
| Arbeitnow | arbeitnow.com/api (EU-focused) | `tag`, `remote`, `max_pages` |
| The Muse | themuse.com/api/public/jobs | `category`, `level`, `max_pages` |
| WeWorkRemotely | RSS feeds per category | `feeds[]` |
| Findwork | findwork.dev/api | `search`, `remote`, `api_key` |
| Indeed | indeed.com/rss | `queries[]`, `results_per_query` |

**Phase C — HN Who is Hiring:**
- Fetches the most recent monthly "Ask HN: Who is Hiring?" thread via Algolia + Firebase APIs
- Parses top-level comments for `Company | Role | Location` patterns
- Applies `title_filter` before adding to pipeline

**New `--source` flag:**
```bash
node scan.mjs --source boards      # job boards only
node scan.mjs --source companies   # tracked companies only
node scan.mjs --source hn          # HN thread only
# (default: all three phases)
```

**Other changes:**
- Adds `parseRSSItems()` generic RSS helper used by WeWorkRemotely, Indeed, and others
- Adds `BOARD_FETCHERS` dispatcher registry for clean extension
- `processJob()` helper inside `main()` for shared dedup logic
- `templates/portals.example.yml`: adds `job_boards:` and `hn_hiring:` config examples
- `modes/scan.md`: documents all board types and `--source` flag
- `docs/SCRIPTS.md`: documents 3-phase scan and all board types

## Related issue

No related issue — new feature contribution.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded job scanning to include global job boards and "Ask HN: Who is Hiring?" thread
  * Added support for additional ATS providers (BambooHR, Teamtailor, Workable, SmartRecruiters, Recruitee)
  * New command-line filtering options (--dry-run, --company, --source)
  * Results now logged to scan-history.tsv alongside pipeline.md

* **Documentation**
  * Updated scan process documentation with multi-phase job acquisition flow and new CLI patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->