### PR TITLE
fix(tooling): declare Node.js 18+ built-in globals for ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "globals": {
+    "URLSearchParams": "readonly",
+    "fetch": "readonly",
+    "AbortController": "readonly"
+  },
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "rules": {}
+}


### PR DESCRIPTION
## What does this PR do?

Adds `.eslintrc.json` to declare Node.js 18+ built-in globals that ESLint doesn't know about without explicit configuration.

Node.js 18 ships `fetch`, `URLSearchParams`, and `AbortController` as native globals, but ESLint reports them as undefined unless they are declared. This causes false-positive lint errors on any code that uses them (such as the scanner's `fetchJson` and `fetchText` helpers).

**Changes:**
- Adds `.eslintrc.json` with `env: { node: true, es2022: true }` and explicit `globals` for `fetch`, `URLSearchParams`, `AbortController`
- Sets `parserOptions.ecmaVersion = 2022` and `sourceType = module` to match the project's `.mjs` ESM modules

This is a standalone, non-breaking change that only affects linting — no runtime behavior changed.

## Related issue

No related issue — tooling improvement.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project configuration to standardize code quality and consistency across the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->