### PR TITLE
  fix(updater): fix orphaned lock, incomplete revert, and fail-open safety check in apply()                                       

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -277,7 +277,7 @@ async function apply() {
     }
 
     // 4. Validate: check NO user files were touched
-    let userFileTouched = false;
+    const violatingUserPaths = [];
     try {
       for (const entry of gitStatusEntries()) {
         const file = entry.path;
@@ -285,18 +285,19 @@ async function apply() {
         for (const userPath of USER_PATHS) {
           if (file.startsWith(userPath)) {
             console.error(`SAFETY VIOLATION: User file was modified: ${file}`);
-            userFileTouched = true;
+            violatingUserPaths.push(file);
           }
         }
       }
-    } catch {
-      // git status failed, skip validation
+    } catch (err) {
+      // git status failed — fail closed, never proceed without a clean safety check
+      throw new Error(`Safety check failed (git status error): ${err.message}`);
     }
 
-    if (userFileTouched) {
+    if (violatingUserPaths.length > 0) {
       console.error('Aborting: user files were touched. Rolling back...');
-      revertPaths(updated);
-      process.exit(1);
+      revertPaths([...updated, ...violatingUserPaths]);
+      throw new Error('Safety violation: user files were modified during update');
     }
 
     // 5. Install any new dependencies


### PR DESCRIPTION


## What does this PR do?

  Fixes three bugs in `apply()` that could leave the repo in a broken state                                                                             
  after a safety violation: the lock file was orphaned (process.exit bypassed                                                                           
  finally), user-layer files that triggered the violation were not reverted,                                                                            
  and a git status failure silently allowed the update to proceed unchecked. 


## Related issue

 Closes #482  

## Type of change

- [. ] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced update validation to properly detect and report failures in the safety check process, preventing silent skips of critical validation steps.
  * Improved rollback mechanism to comprehensively revert all affected files when update violations are detected, ensuring system integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->