### PR TITLE
feat(scan): add --verify flag to drop expired postings before pipeline append

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ The scanner comes with **45+ companies** ready to scan and **19 search queries**
 
 **Job boards searched:** Ashby, Greenhouse, Lever, Wellfound, Workable, RemoteFront
 
+By default `node scan.mjs` (a.k.a. `npm run scan`) trusts what each ATS feed returns. Some companies leave stale postings in their public API even after the role is closed, so those expired entries can leak into `pipeline.md`. Pass `--verify` to launch Playwright after the API pass and drop expired postings before they hit the pipeline:
+
+```bash
+node scan.mjs --verify          # zero-token discovery + Playwright liveness check
+```
+
+The verification is sequential and only runs against new offers (after dedup), so the cost stays bounded.
+
 ## Dashboard TUI
 
 The built-in terminal dashboard lets you browse your pipeline visually:

--- a/README.md
+++ b/README.md
@@ -217,6 +217,14 @@ The scanner comes with **45+ companies** ready to scan and **19 search queries**
 
 **Job boards searched:** Ashby, Greenhouse, Lever, Wellfound, Workable, RemoteFront
 
+By default `node scan.mjs` (a.k.a. `npm run scan`) trusts what each ATS feed returns. Some companies leave stale postings in their public API even after the role is closed, so those expired entries can leak into `pipeline.md`. Pass `--verify` to launch Playwright after the API pass and drop expired postings before they hit the pipeline:
+
+```bash
+node scan.mjs --verify          # zero-token discovery + Playwright liveness check
+```
+
+The verification is sequential and only runs against new offers (after dedup), so the cost stays bounded.
+
 ## Dashboard TUI
 
 The built-in terminal dashboard lets you browse your pipeline visually:

--- a/check-liveness.mjs
+++ b/check-liveness.mjs
@@ -16,58 +16,7 @@
 
 import { chromium } from 'playwright';
 import { readFile } from 'fs/promises';
-import { classifyLiveness } from './liveness-core.mjs';
-
-async function checkUrl(page, url) {
-  try {
-    const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
-
-    const status = response?.status() ?? 0;
-
-    // Give SPAs (Ashby, Lever, Workday) time to hydrate
-    await page.waitForTimeout(2000);
-
-    const finalUrl = page.url();
-    const bodyText = await page.evaluate(() => document.body?.innerText ?? '');
-    const applyControls = await page.evaluate(() => {
-      const candidates = Array.from(
-        document.querySelectorAll('a, button, input[type="submit"], input[type="button"], [role="button"]')
-      );
-
-      return candidates
-        .filter((element) => {
-          if (element.closest('nav, header, footer')) return false;
-          if (element.closest('[aria-hidden="true"]')) return false;
-
-          const style = window.getComputedStyle(element);
-          if (style.display === 'none' || style.visibility === 'hidden') return false;
-          if (!element.getClientRects().length) return false;
-
-          return Array.from(element.getClientRects()).some((rect) => rect.width > 0 && rect.height > 0);
-        })
-        .map((element) => {
-          const label = [
-            element.innerText,
-            element.value,
-            element.getAttribute('aria-label'),
-            element.getAttribute('title'),
-          ]
-            .filter(Boolean)
-            .join(' ')
-            .replace(/\s+/g, ' ')
-            .trim();
-
-          return label;
-        })
-        .filter(Boolean);
-    });
-
-    return classifyLiveness({ status, finalUrl, bodyText, applyControls });
-
-  } catch (err) {
-    return { result: 'expired', reason: `navigation error: ${err.message.split('\n')[0]}` };
-  }
-}
+import { checkUrlLiveness } from './liveness-browser.mjs';
 
 async function main() {
   const args = process.argv.slice(2);
@@ -95,7 +44,7 @@ async function main() {
 
   // Sequential — project rule: never Playwright in parallel
   for (const url of urls) {
-    const { result, reason } = await checkUrl(page, url);
+    const { result, reason } = await checkUrlLiveness(page, url);
     const icon = { active: '✅', expired: '❌', uncertain: '⚠️' }[result];
     console.log(`${icon} ${result.padEnd(10)} ${url}`);
     if (result !== 'active') console.log(`           ${reason}`);

--- a/liveness-browser.mjs
+++ b/liveness-browser.mjs
@@ -1,0 +1,60 @@
+/**
+ * liveness-browser.mjs — Playwright-driven liveness check for a single URL.
+ *
+ * Shared by check-liveness.mjs (CLI tool) and scan.mjs (--verify flag).
+ * Returns the same shape as classifyLiveness: { result, reason }.
+ */
+
+import { classifyLiveness } from './liveness-core.mjs';
+
+const NAVIGATE_TIMEOUT_MS = 15_000;
+const HYDRATION_WAIT_MS = 2_000;
+
+export async function checkUrlLiveness(page, url) {
+  try {
+    const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: NAVIGATE_TIMEOUT_MS });
+    const status = response?.status() ?? 0;
+
+    // Give SPAs (Ashby, Lever, Workday) time to hydrate
+    await page.waitForTimeout(HYDRATION_WAIT_MS);
+
+    const finalUrl = page.url();
+    const bodyText = await page.evaluate(() => document.body?.innerText ?? '');
+    const applyControls = await page.evaluate(() => {
+      const candidates = Array.from(
+        document.querySelectorAll('a, button, input[type="submit"], input[type="button"], [role="button"]')
+      );
+
+      return candidates
+        .filter((element) => {
+          if (element.closest('nav, header, footer')) return false;
+          if (element.closest('[aria-hidden="true"]')) return false;
+
+          const style = window.getComputedStyle(element);
+          if (style.display === 'none' || style.visibility === 'hidden') return false;
+          if (!element.getClientRects().length) return false;
+
+          return Array.from(element.getClientRects()).some((rect) => rect.width > 0 && rect.height > 0);
+        })
+        .map((element) => {
+          const label = [
+            element.innerText,
+            element.value,
+            element.getAttribute('aria-label'),
+            element.getAttribute('title'),
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+
+          return label;
+        })
+        .filter(Boolean);
+    });
+
+    return classifyLiveness({ status, finalUrl, bodyText, applyControls });
+  } catch (err) {
+    return { result: 'expired', reason: `navigation error: ${err.message.split('\n')[0]}` };
+  }
+}

--- a/liveness-browser.mjs
+++ b/liveness-browser.mjs
@@ -25,18 +25,22 @@ const PRIVATE_HOST_PATTERNS = [
   /^fe80:/i,
 ];
 
+// Returns null when the URL is safe to fetch, otherwise a structured guard
+// result with a stable `code` (used for routing in scan.mjs) plus a human
+// `reason`. Stable codes — not regex on reason strings — drive downstream
+// dispatch so the wording can change freely without breaking callers.
 function rejectPrivateOrInvalid(url) {
   let parsed;
   try {
     parsed = new URL(url);
   } catch {
-    return 'invalid URL';
+    return { code: 'invalid_url', reason: 'invalid URL' };
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    return `unsupported protocol ${parsed.protocol}`;
+    return { code: 'unsupported_protocol', reason: `unsupported protocol ${parsed.protocol}` };
   }
   if (PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(parsed.hostname))) {
-    return `blocked host ${parsed.hostname}`;
+    return { code: 'blocked_host', reason: `blocked host ${parsed.hostname}` };
   }
   return null;
 }
@@ -44,7 +48,7 @@ function rejectPrivateOrInvalid(url) {
 export async function checkUrlLiveness(page, url) {
   const guardError = rejectPrivateOrInvalid(url);
   if (guardError) {
-    return { result: 'uncertain', reason: guardError };
+    return { result: 'uncertain', code: guardError.code, reason: guardError.reason };
   }
   try {
     const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: NAVIGATE_TIMEOUT_MS });
@@ -93,6 +97,10 @@ export async function checkUrlLiveness(page, url) {
     // Transient failures (timeout, DNS, TLS, 5xx) shouldn't be treated as expired —
     // doing so would cause scan --verify to drop the URL and write it to scan-history,
     // permanently filtering it out on subsequent scans.
-    return { result: 'uncertain', reason: `navigation error: ${err.message.split('\n')[0]}` };
+    return {
+      result: 'uncertain',
+      code: 'navigation_error',
+      reason: `navigation error: ${err.message.split('\n')[0]}`,
+    };
   }
 }

--- a/liveness-browser.mjs
+++ b/liveness-browser.mjs
@@ -55,6 +55,9 @@ export async function checkUrlLiveness(page, url) {
 
     return classifyLiveness({ status, finalUrl, bodyText, applyControls });
   } catch (err) {
-    return { result: 'expired', reason: `navigation error: ${err.message.split('\n')[0]}` };
+    // Transient failures (timeout, DNS, TLS, 5xx) shouldn't be treated as expired —
+    // doing so would cause scan --verify to drop the URL and write it to scan-history,
+    // permanently filtering it out on subsequent scans.
+    return { result: 'uncertain', reason: `navigation error: ${err.message.split('\n')[0]}` };
   }
 }

--- a/liveness-browser.mjs
+++ b/liveness-browser.mjs
@@ -10,7 +10,42 @@ import { classifyLiveness } from './liveness-core.mjs';
 const NAVIGATE_TIMEOUT_MS = 15_000;
 const HYDRATION_WAIT_MS = 2_000;
 
+// Defensive guards: URLs come from ATS feeds (mostly trusted) but a misconfigured
+// portals.yml entry or a hijacked feed shouldn't be able to point Playwright at
+// internal infrastructure. Only allow http(s) and reject loopback/private/link-local.
+const PRIVATE_HOST_PATTERNS = [
+  /^localhost$/i,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^169\.254\./,
+  /^::1$/,
+  /^fc[0-9a-f]{2}:/i,
+  /^fe80:/i,
+];
+
+function rejectPrivateOrInvalid(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return 'invalid URL';
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return `unsupported protocol ${parsed.protocol}`;
+  }
+  if (PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(parsed.hostname))) {
+    return `blocked host ${parsed.hostname}`;
+  }
+  return null;
+}
+
 export async function checkUrlLiveness(page, url) {
+  const guardError = rejectPrivateOrInvalid(url);
+  if (guardError) {
+    return { result: 'uncertain', reason: guardError };
+  }
   try {
     const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: NAVIGATE_TIMEOUT_MS });
     const status = response?.status() ?? 0;

--- a/liveness-core.mjs
+++ b/liveness-core.mjs
@@ -48,31 +48,31 @@ function hasApplyControl(controls = []) {
 
 export function classifyLiveness({ status = 0, finalUrl = '', bodyText = '', applyControls = [] } = {}) {
   if (status === 404 || status === 410) {
-    return { result: 'expired', reason: `HTTP ${status}` };
+    return { result: 'expired', code: 'http_gone', reason: `HTTP ${status}` };
   }
 
   const expiredUrl = firstMatch(EXPIRED_URL_PATTERNS, finalUrl);
   if (expiredUrl) {
-    return { result: 'expired', reason: `redirect to ${finalUrl}` };
+    return { result: 'expired', code: 'expired_url', reason: `redirect to ${finalUrl}` };
   }
 
   const expiredBody = firstMatch(HARD_EXPIRED_PATTERNS, bodyText);
   if (expiredBody) {
-    return { result: 'expired', reason: `pattern matched: ${expiredBody.source}` };
+    return { result: 'expired', code: 'expired_body', reason: `pattern matched: ${expiredBody.source}` };
   }
 
   if (hasApplyControl(applyControls)) {
-    return { result: 'active', reason: 'visible apply control detected' };
+    return { result: 'active', code: 'apply_control_visible', reason: 'visible apply control detected' };
   }
 
   const listingPage = firstMatch(LISTING_PAGE_PATTERNS, bodyText);
   if (listingPage) {
-    return { result: 'expired', reason: `pattern matched: ${listingPage.source}` };
+    return { result: 'expired', code: 'listing_page', reason: `pattern matched: ${listingPage.source}` };
   }
 
   if (bodyText.trim().length < MIN_CONTENT_CHARS) {
-    return { result: 'expired', reason: 'insufficient content — likely nav/footer only' };
+    return { result: 'expired', code: 'insufficient_content', reason: 'insufficient content — likely nav/footer only' };
   }
 
-  return { result: 'uncertain', reason: 'content present but no visible apply control found' };
+  return { result: 'uncertain', code: 'no_apply_control', reason: 'content present but no visible apply control found' };
 }

--- a/scan.mjs
+++ b/scan.mjs
@@ -13,6 +13,7 @@
  *   node scan.mjs                  # scan all enabled companies
  *   node scan.mjs --dry-run        # preview without writing files
  *   node scan.mjs --company Cohere # scan a single company
+ *   node scan.mjs --verify         # Playwright-check each new URL; drop expired postings
  */
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
@@ -249,9 +250,40 @@ async function parallelFetch(tasks, limit) {
 
 // ── Main ────────────────────────────────────────────────────────────
 
+async function verifyOffers(offers) {
+  // Dynamic imports keep the default zero-token path free of Playwright startup
+  const { chromium } = await import('playwright');
+  const { checkUrlLiveness } = await import('./liveness-browser.mjs');
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  const verified = [];
+  const expired = [];
+  try {
+    // Sequential — project rule: never Playwright in parallel
+    for (const offer of offers) {
+      const { result, reason } = await checkUrlLiveness(page, offer.url);
+      if (result === 'expired') {
+        expired.push({ ...offer, reason });
+        console.log(`  ❌ expired   ${offer.company} | ${offer.title} (${reason})`);
+      } else {
+        verified.push(offer);
+        const icon = result === 'active' ? '✅' : '⚠️';
+        console.log(`  ${icon} ${result.padEnd(9)} ${offer.company} | ${offer.title}`);
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  return { verified, expired };
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
+  const verify = args.includes('--verify');
   const companyFlag = args.indexOf('--company');
   const filterCompany = companyFlag !== -1 ? args[companyFlag + 1]?.toLowerCase() : null;
 
@@ -322,10 +354,26 @@ async function main() {
 
   await parallelFetch(tasks, CONCURRENCY);
 
+  // 4.5. Optional liveness verification — drop expired postings before persisting
+  let verifiedOffers = newOffers;
+  let expiredOffers = [];
+  if (verify && newOffers.length > 0) {
+    console.log(`\nVerifying liveness of ${newOffers.length} new offer(s) with Playwright (sequential)...`);
+    const result = await verifyOffers(newOffers);
+    verifiedOffers = result.verified;
+    expiredOffers = result.expired;
+  }
+
   // 5. Write results
-  if (!dryRun && newOffers.length > 0) {
-    appendToPipeline(newOffers);
-    appendToScanHistory(newOffers, date);
+  if (!dryRun && verifiedOffers.length > 0) {
+    appendToPipeline(verifiedOffers);
+    appendToScanHistory(verifiedOffers, date);
+  }
+  if (!dryRun && expiredOffers.length > 0) {
+    appendToScanHistory(
+      expiredOffers.map(o => ({ ...o, source: `${o.source} (expired)` })),
+      date,
+    );
   }
 
   // 6. Print summary
@@ -336,7 +384,10 @@ async function main() {
   console.log(`Total jobs found:      ${totalFound}`);
   console.log(`Filtered by title:     ${totalFiltered} removed`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
-  console.log(`New offers added:      ${newOffers.length}`);
+  if (verify) {
+    console.log(`Expired (verified):    ${expiredOffers.length} dropped`);
+  }
+  console.log(`New offers added:      ${verifiedOffers.length}`);
 
   if (errors.length > 0) {
     console.log(`\nErrors (${errors.length}):`);
@@ -345,9 +396,9 @@ async function main() {
     }
   }
 
-  if (newOffers.length > 0) {
+  if (verifiedOffers.length > 0) {
     console.log('\nNew offers:');
-    for (const o of newOffers) {
+    for (const o of verifiedOffers) {
       console.log(`  + ${o.company} | ${o.title} | ${o.location || 'N/A'}`);
     }
     if (dryRun) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -276,6 +276,7 @@ async function verifyOffers(offers) {
 
   const verified = [];
   const expired = [];
+  const invalid = []; // guard failures (invalid URL / unsupported protocol / blocked host)
   try {
     const page = await browser.newPage();
     // Sequential — project rule: never Playwright in parallel
@@ -284,6 +285,12 @@ async function verifyOffers(offers) {
       if (result === 'expired') {
         expired.push({ ...offer, reason });
         console.log(`  ❌ expired   ${offer.company} | ${offer.title} (${reason})`);
+      } else if (result === 'uncertain' && isGuardReason(reason)) {
+        // Guard failures are permanent (not transient like a timeout) — record them
+        // separately so they don't end up in pipeline.md but DO appear in scan-history
+        // with a precise status, dedup-blocking them on subsequent scans.
+        invalid.push({ ...offer, reason });
+        console.log(`  ⛔ invalid   ${offer.company} | ${offer.title} (${reason})`);
       } else {
         verified.push(offer);
         const icon = result === 'active' ? '✅' : '⚠️';
@@ -294,7 +301,27 @@ async function verifyOffers(offers) {
     await browser.close();
   }
 
-  return { verified, expired };
+  return { verified, expired, invalid };
+}
+
+// isGuardReason returns true when a liveness 'uncertain' result was caused by an
+// up-front URL guard rather than a transient navigation failure. Guard failures
+// stay constant across scans (a malformed URL doesn't heal itself), so we treat
+// them differently from timeouts/DNS blips that may resolve next time.
+function isGuardReason(reason = '') {
+  return (
+    reason === 'invalid URL' ||
+    reason.startsWith('unsupported protocol') ||
+    reason.startsWith('blocked host')
+  );
+}
+
+// guardStatusFor maps a guard reason to the canonical scan-history status string.
+function guardStatusFor(reason = '') {
+  if (reason === 'invalid URL') return 'skipped_invalid_url';
+  if (reason.startsWith('unsupported protocol')) return 'skipped_invalid_url';
+  if (reason.startsWith('blocked host')) return 'skipped_blocked_host';
+  return 'skipped_invalid_url';
 }
 
 async function main() {
@@ -371,14 +398,16 @@ async function main() {
 
   await parallelFetch(tasks, CONCURRENCY);
 
-  // 4.5. Optional liveness verification — drop expired postings before persisting
+  // 4.5. Optional liveness verification — drop expired and guard-rejected postings
   let verifiedOffers = newOffers;
   let expiredOffers = [];
+  let invalidOffers = [];
   if (verify && newOffers.length > 0) {
     console.log(`\nVerifying liveness of ${newOffers.length} new offer(s) with Playwright (sequential)...`);
     const result = await verifyOffers(newOffers);
     verifiedOffers = result.verified;
     expiredOffers = result.expired;
+    invalidOffers = result.invalid;
   }
 
   // 5. Write results
@@ -388,6 +417,21 @@ async function main() {
   }
   if (!dryRun && expiredOffers.length > 0) {
     appendToScanHistory(expiredOffers, date, 'skipped_expired');
+  }
+  // Guard-rejected URLs (invalid / unsupported protocol / blocked host) are
+  // recorded with a precise status so subsequent scans dedup-skip them via
+  // loadSeenUrls, but they never reach pipeline.md.
+  if (!dryRun && invalidOffers.length > 0) {
+    // Group by status so the TSV reflects the actual reason category.
+    const byStatus = new Map();
+    for (const o of invalidOffers) {
+      const status = guardStatusFor(o.reason);
+      if (!byStatus.has(status)) byStatus.set(status, []);
+      byStatus.get(status).push(o);
+    }
+    for (const [status, group] of byStatus) {
+      appendToScanHistory(group, date, status);
+    }
   }
 
   // 6. Print summary
@@ -400,6 +444,7 @@ async function main() {
   console.log(`Duplicates:            ${totalDupes} skipped`);
   if (verify) {
     console.log(`Expired (verified):    ${expiredOffers.length} dropped`);
+    console.log(`Invalid (guarded):     ${invalidOffers.length} dropped`);
   }
   console.log(`New offers added:      ${verifiedOffers.length}`);
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -274,24 +274,40 @@ async function verifyOffers(offers) {
     );
   }
 
+  // Three permanent buckets + one transient passthrough:
+  //   verified  → active pages and transient nav errors (retry next scan)
+  //   expired   → classifier-confirmed dead postings (HTTP 4xx, redirect markers,
+  //               body patterns, listing pages, insufficient content)
+  //   dropped   → page loaded but classifier saw no Apply control. --verify is an
+  //               opt-in stricter filter; keeping these defeats the purpose.
+  //   invalid   → up-front URL guard rejections (malformed / non-http / private)
   const verified = [];
   const expired = [];
-  const invalid = []; // guard failures (invalid URL / unsupported protocol / blocked host)
+  const dropped = [];
+  const invalid = [];
+
   try {
     const page = await browser.newPage();
     // Sequential — project rule: never Playwright in parallel
     for (const offer of offers) {
-      const { result, reason } = await checkUrlLiveness(page, offer.url);
+      const { result, code, reason } = await checkUrlLiveness(page, offer.url);
       if (result === 'expired') {
         expired.push({ ...offer, reason });
         console.log(`  ❌ expired   ${offer.company} | ${offer.title} (${reason})`);
-      } else if (result === 'uncertain' && isGuardReason(reason)) {
+      } else if (result === 'uncertain' && GUARD_CODES.has(code)) {
         // Guard failures are permanent (not transient like a timeout) — record them
         // separately so they don't end up in pipeline.md but DO appear in scan-history
         // with a precise status, dedup-blocking them on subsequent scans.
-        invalid.push({ ...offer, reason });
+        invalid.push({ ...offer, code, reason });
         console.log(`  ⛔ invalid   ${offer.company} | ${offer.title} (${reason})`);
+      } else if (result === 'uncertain' && code === 'no_apply_control') {
+        // Page loaded but classifier could not find an Apply control. Treat like
+        // expired for routing — drop from pipeline AND record in scan-history so
+        // we don't burn a verify cycle on the same URL next scan.
+        dropped.push({ ...offer, reason });
+        console.log(`  ⚠️ no-apply  ${offer.company} | ${offer.title} (${reason})`);
       } else {
+        // 'active' or 'uncertain' due to navigation_error (transient — retry next scan)
         verified.push(offer);
         const icon = result === 'active' ? '✅' : '⚠️';
         console.log(`  ${icon} ${result.padEnd(9)} ${offer.company} | ${offer.title}`);
@@ -301,26 +317,18 @@ async function verifyOffers(offers) {
     await browser.close();
   }
 
-  return { verified, expired, invalid };
+  return { verified, expired, dropped, invalid };
 }
 
-// isGuardReason returns true when a liveness 'uncertain' result was caused by an
-// up-front URL guard rather than a transient navigation failure. Guard failures
-// stay constant across scans (a malformed URL doesn't heal itself), so we treat
-// them differently from timeouts/DNS blips that may resolve next time.
-function isGuardReason(reason = '') {
-  return (
-    reason === 'invalid URL' ||
-    reason.startsWith('unsupported protocol') ||
-    reason.startsWith('blocked host')
-  );
-}
+// Stable codes from liveness-browser's up-front URL guard. Routing dispatches
+// on these codes (not on regex over reason strings) so wording can change
+// without breaking the pipeline.
+const GUARD_CODES = new Set(['invalid_url', 'unsupported_protocol', 'blocked_host']);
 
-// guardStatusFor maps a guard reason to the canonical scan-history status string.
-function guardStatusFor(reason = '') {
-  if (reason === 'invalid URL') return 'skipped_invalid_url';
-  if (reason.startsWith('unsupported protocol')) return 'skipped_invalid_url';
-  if (reason.startsWith('blocked host')) return 'skipped_blocked_host';
+// guardStatusFor maps a guard code to the canonical scan-history status string.
+function guardStatusFor(code) {
+  if (code === 'blocked_host') return 'skipped_blocked_host';
+  // invalid_url and unsupported_protocol both surface as malformed input
   return 'skipped_invalid_url';
 }
 
@@ -401,12 +409,14 @@ async function main() {
   // 4.5. Optional liveness verification — drop expired and guard-rejected postings
   let verifiedOffers = newOffers;
   let expiredOffers = [];
+  let droppedOffers = [];
   let invalidOffers = [];
   if (verify && newOffers.length > 0) {
     console.log(`\nVerifying liveness of ${newOffers.length} new offer(s) with Playwright (sequential)...`);
     const result = await verifyOffers(newOffers);
     verifiedOffers = result.verified;
     expiredOffers = result.expired;
+    droppedOffers = result.dropped;
     invalidOffers = result.invalid;
   }
 
@@ -418,14 +428,19 @@ async function main() {
   if (!dryRun && expiredOffers.length > 0) {
     appendToScanHistory(expiredOffers, date, 'skipped_expired');
   }
+  // Pages that loaded but had no Apply control: record so we don't re-verify
+  // them next scan, but never let them reach pipeline.md.
+  if (!dryRun && droppedOffers.length > 0) {
+    appendToScanHistory(droppedOffers, date, 'skipped_no_apply_control');
+  }
   // Guard-rejected URLs (invalid / unsupported protocol / blocked host) are
   // recorded with a precise status so subsequent scans dedup-skip them via
   // loadSeenUrls, but they never reach pipeline.md.
   if (!dryRun && invalidOffers.length > 0) {
-    // Group by status so the TSV reflects the actual reason category.
+    // Group by code so the TSV reflects the actual reason category.
     const byStatus = new Map();
     for (const o of invalidOffers) {
-      const status = guardStatusFor(o.reason);
+      const status = guardStatusFor(o.code);
       if (!byStatus.has(status)) byStatus.set(status, []);
       byStatus.get(status).push(o);
     }
@@ -444,6 +459,7 @@ async function main() {
   console.log(`Duplicates:            ${totalDupes} skipped`);
   if (verify) {
     console.log(`Expired (verified):    ${expiredOffers.length} dropped`);
+    console.log(`No apply control:      ${droppedOffers.length} dropped`);
     console.log(`Invalid (guarded):     ${invalidOffers.length} dropped`);
   }
   console.log(`New offers added:      ${verifiedOffers.length}`);

--- a/scan.mjs
+++ b/scan.mjs
@@ -217,14 +217,14 @@ function appendToPipeline(offers) {
   writeFileSync(PIPELINE_PATH, text, 'utf-8');
 }
 
-function appendToScanHistory(offers, date) {
+function appendToScanHistory(offers, date, status = 'added') {
   // Ensure file + header exist
   if (!existsSync(SCAN_HISTORY_PATH)) {
     writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\n', 'utf-8');
   }
 
   const lines = offers.map(o =>
-    `${o.url}\t${date}\t${o.source}\t${o.title}\t${o.company}\tadded`
+    `${o.url}\t${date}\t${o.source}\t${o.title}\t${o.company}\t${status}`
   ).join('\n') + '\n';
 
   appendFileSync(SCAN_HISTORY_PATH, lines, 'utf-8');
@@ -256,11 +256,10 @@ async function verifyOffers(offers) {
   const { checkUrlLiveness } = await import('./liveness-browser.mjs');
 
   const browser = await chromium.launch({ headless: true });
-  const page = await browser.newPage();
-
   const verified = [];
   const expired = [];
   try {
+    const page = await browser.newPage();
     // Sequential — project rule: never Playwright in parallel
     for (const offer of offers) {
       const { result, reason } = await checkUrlLiveness(page, offer.url);
@@ -370,10 +369,7 @@ async function main() {
     appendToScanHistory(verifiedOffers, date);
   }
   if (!dryRun && expiredOffers.length > 0) {
-    appendToScanHistory(
-      expiredOffers.map(o => ({ ...o, source: `${o.source} (expired)` })),
-      date,
-    );
+    appendToScanHistory(expiredOffers, date, 'skipped_expired');
   }
 
   // 6. Print summary

--- a/scan.mjs
+++ b/scan.mjs
@@ -252,10 +252,28 @@ async function parallelFetch(tasks, limit) {
 
 async function verifyOffers(offers) {
   // Dynamic imports keep the default zero-token path free of Playwright startup
-  const { chromium } = await import('playwright');
-  const { checkUrlLiveness } = await import('./liveness-browser.mjs');
+  let chromium;
+  let checkUrlLiveness;
+  try {
+    ({ chromium } = await import('playwright'));
+    ({ checkUrlLiveness } = await import('./liveness-browser.mjs'));
+  } catch (err) {
+    throw new Error(
+      `--verify requires Playwright with Chromium (run "npx playwright install chromium"): ${err.message}`,
+      { cause: err },
+    );
+  }
 
-  const browser = await chromium.launch({ headless: true });
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+  } catch (err) {
+    throw new Error(
+      `--verify could not launch Chromium (run "npx playwright install chromium" or re-run without --verify): ${err.message}`,
+      { cause: err },
+    );
+  }
+
   const verified = [];
   const expired = [];
   try {

--- a/scan.mjs
+++ b/scan.mjs
@@ -284,6 +284,7 @@ async function verifyOffers(offers) {
 
   const verified = [];
   const expired = [];
+  const invalid = []; // guard failures (invalid URL / unsupported protocol / blocked host)
   try {
     const page = await browser.newPage();
     // Sequential — project rule: never Playwright in parallel
@@ -292,6 +293,12 @@ async function verifyOffers(offers) {
       if (result === 'expired') {
         expired.push({ ...offer, reason });
         console.log(`  ❌ expired   ${offer.company} | ${offer.title} (${reason})`);
+      } else if (result === 'uncertain' && isGuardReason(reason)) {
+        // Guard failures are permanent (not transient like a timeout) — record them
+        // separately so they don't end up in pipeline.md but DO appear in scan-history
+        // with a precise status, dedup-blocking them on subsequent scans.
+        invalid.push({ ...offer, reason });
+        console.log(`  ⛔ invalid   ${offer.company} | ${offer.title} (${reason})`);
       } else {
         verified.push(offer);
         const icon = result === 'active' ? '✅' : '⚠️';
@@ -302,7 +309,27 @@ async function verifyOffers(offers) {
     await browser.close();
   }
 
-  return { verified, expired };
+  return { verified, expired, invalid };
+}
+
+// isGuardReason returns true when a liveness 'uncertain' result was caused by an
+// up-front URL guard rather than a transient navigation failure. Guard failures
+// stay constant across scans (a malformed URL doesn't heal itself), so we treat
+// them differently from timeouts/DNS blips that may resolve next time.
+function isGuardReason(reason = '') {
+  return (
+    reason === 'invalid URL' ||
+    reason.startsWith('unsupported protocol') ||
+    reason.startsWith('blocked host')
+  );
+}
+
+// guardStatusFor maps a guard reason to the canonical scan-history status string.
+function guardStatusFor(reason = '') {
+  if (reason === 'invalid URL') return 'skipped_invalid_url';
+  if (reason.startsWith('unsupported protocol')) return 'skipped_invalid_url';
+  if (reason.startsWith('blocked host')) return 'skipped_blocked_host';
+  return 'skipped_invalid_url';
 }
 
 async function main() {
@@ -405,14 +432,16 @@ async function main() {
 
   await parallelFetch(tasks, CONCURRENCY);
 
-  // 5.5. Optional liveness verification — drop expired postings before persisting
+  // 5.5. Optional liveness verification — drop expired and guard-rejected postings
   let verifiedOffers = newOffers;
   let expiredOffers = [];
+  let invalidOffers = [];
   if (verify && newOffers.length > 0) {
     console.log(`\nVerifying liveness of ${newOffers.length} new offer(s) with Playwright (sequential)...`);
     const result = await verifyOffers(newOffers);
     verifiedOffers = result.verified;
     expiredOffers = result.expired;
+    invalidOffers = result.invalid;
   }
 
   // 6. Write results
@@ -422,6 +451,21 @@ async function main() {
   }
   if (!dryRun && expiredOffers.length > 0) {
     appendToScanHistory(expiredOffers, date, 'skipped_expired');
+  }
+  // Guard-rejected URLs (invalid / unsupported protocol / blocked host) are
+  // recorded with a precise status so subsequent scans dedup-skip them via
+  // loadSeenUrls, but they never reach pipeline.md.
+  if (!dryRun && invalidOffers.length > 0) {
+    // Group by status so the TSV reflects the actual reason category.
+    const byStatus = new Map();
+    for (const o of invalidOffers) {
+      const status = guardStatusFor(o.reason);
+      if (!byStatus.has(status)) byStatus.set(status, []);
+      byStatus.get(status).push(o);
+    }
+    for (const [status, group] of byStatus) {
+      appendToScanHistory(group, date, status);
+    }
   }
 
   // 7. Print summary
@@ -435,6 +479,7 @@ async function main() {
   console.log(`Duplicates:            ${totalDupes} skipped`);
   if (verify) {
     console.log(`Expired (verified):    ${expiredOffers.length} dropped`);
+    console.log(`Invalid (guarded):     ${invalidOffers.length} dropped`);
   }
   console.log(`New offers added:      ${verifiedOffers.length}`);
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -23,6 +23,7 @@
  *   node scan.mjs                  # scan all enabled companies
  *   node scan.mjs --dry-run        # preview without writing files
  *   node scan.mjs --company Cohere # scan a single company
+ *   node scan.mjs --verify         # Playwright-check each new URL; drop expired postings
  */
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, readdirSync } from 'fs';
@@ -255,9 +256,40 @@ async function parallelFetch(tasks, limit) {
 
 // ── Main ────────────────────────────────────────────────────────────
 
+async function verifyOffers(offers) {
+  // Dynamic imports keep the default zero-token path free of Playwright startup
+  const { chromium } = await import('playwright');
+  const { checkUrlLiveness } = await import('./liveness-browser.mjs');
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  const verified = [];
+  const expired = [];
+  try {
+    // Sequential — project rule: never Playwright in parallel
+    for (const offer of offers) {
+      const { result, reason } = await checkUrlLiveness(page, offer.url);
+      if (result === 'expired') {
+        expired.push({ ...offer, reason });
+        console.log(`  ❌ expired   ${offer.company} | ${offer.title} (${reason})`);
+      } else {
+        verified.push(offer);
+        const icon = result === 'active' ? '✅' : '⚠️';
+        console.log(`  ${icon} ${result.padEnd(9)} ${offer.company} | ${offer.title}`);
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  return { verified, expired };
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
+  const verify = args.includes('--verify');
   const companyFlag = args.indexOf('--company');
   const filterCompany = companyFlag !== -1 ? args[companyFlag + 1]?.toLowerCase() : null;
 
@@ -354,10 +386,26 @@ async function main() {
 
   await parallelFetch(tasks, CONCURRENCY);
 
+  // 5.5. Optional liveness verification — drop expired postings before persisting
+  let verifiedOffers = newOffers;
+  let expiredOffers = [];
+  if (verify && newOffers.length > 0) {
+    console.log(`\nVerifying liveness of ${newOffers.length} new offer(s) with Playwright (sequential)...`);
+    const result = await verifyOffers(newOffers);
+    verifiedOffers = result.verified;
+    expiredOffers = result.expired;
+  }
+
   // 6. Write results
-  if (!dryRun && newOffers.length > 0) {
-    appendToPipeline(newOffers);
-    appendToScanHistory(newOffers, date);
+  if (!dryRun && verifiedOffers.length > 0) {
+    appendToPipeline(verifiedOffers);
+    appendToScanHistory(verifiedOffers, date);
+  }
+  if (!dryRun && expiredOffers.length > 0) {
+    appendToScanHistory(
+      expiredOffers.map(o => ({ ...o, source: `${o.source} (expired)` })),
+      date,
+    );
   }
 
   // 7. Print summary
@@ -369,7 +417,10 @@ async function main() {
   console.log(`Filtered by title:     ${totalFilteredTitle} removed`);
   console.log(`Filtered by location:  ${totalFilteredLocation} removed`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
-  console.log(`New offers added:      ${newOffers.length}`);
+  if (verify) {
+    console.log(`Expired (verified):    ${expiredOffers.length} dropped`);
+  }
+  console.log(`New offers added:      ${verifiedOffers.length}`);
 
   if (errors.length > 0) {
     console.log(`\nErrors (${errors.length}):`);
@@ -378,9 +429,9 @@ async function main() {
     }
   }
 
-  if (newOffers.length > 0) {
+  if (verifiedOffers.length > 0) {
     console.log('\nNew offers:');
-    for (const o of newOffers) {
+    for (const o of verifiedOffers) {
       console.log(`  + ${o.company} | ${o.title} | ${o.location || 'N/A'}`);
     }
     if (dryRun) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -221,16 +221,18 @@ function appendToPipeline(offers) {
   writeFileSync(PIPELINE_PATH, text, 'utf-8');
 }
 
-function appendToScanHistory(offers, date) {
+function appendToScanHistory(offers, date, status = 'added') {
   // Ensure file + header exist. Location appended as 7th column for non-breaking
   // backward compat — older scan-history.tsv files with 6 columns still parse fine
-  // since loadSeenUrls only reads column 0.
+  // since loadSeenUrls only reads column 0. `status` is parameterized so callers
+  // can record verify outcomes (`skipped_expired`, etc.) without the legacy
+  // `(expired)` suffix in `source`.
   if (!existsSync(SCAN_HISTORY_PATH)) {
     writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\n', 'utf-8');
   }
 
   const lines = offers.map(o =>
-    `${o.url}\t${date}\t${o.source}\t${o.title}\t${o.company}\tadded\t${o.location || ''}`
+    `${o.url}\t${date}\t${o.source}\t${o.title}\t${o.company}\t${status}\t${o.location || ''}`
   ).join('\n') + '\n';
 
   appendFileSync(SCAN_HISTORY_PATH, lines, 'utf-8');
@@ -262,11 +264,10 @@ async function verifyOffers(offers) {
   const { checkUrlLiveness } = await import('./liveness-browser.mjs');
 
   const browser = await chromium.launch({ headless: true });
-  const page = await browser.newPage();
-
   const verified = [];
   const expired = [];
   try {
+    const page = await browser.newPage();
     // Sequential — project rule: never Playwright in parallel
     for (const offer of offers) {
       const { result, reason } = await checkUrlLiveness(page, offer.url);
@@ -402,10 +403,7 @@ async function main() {
     appendToScanHistory(verifiedOffers, date);
   }
   if (!dryRun && expiredOffers.length > 0) {
-    appendToScanHistory(
-      expiredOffers.map(o => ({ ...o, source: `${o.source} (expired)` })),
-      date,
-    );
+    appendToScanHistory(expiredOffers, date, 'skipped_expired');
   }
 
   // 7. Print summary

--- a/scan.mjs
+++ b/scan.mjs
@@ -260,10 +260,28 @@ async function parallelFetch(tasks, limit) {
 
 async function verifyOffers(offers) {
   // Dynamic imports keep the default zero-token path free of Playwright startup
-  const { chromium } = await import('playwright');
-  const { checkUrlLiveness } = await import('./liveness-browser.mjs');
+  let chromium;
+  let checkUrlLiveness;
+  try {
+    ({ chromium } = await import('playwright'));
+    ({ checkUrlLiveness } = await import('./liveness-browser.mjs'));
+  } catch (err) {
+    throw new Error(
+      `--verify requires Playwright with Chromium (run "npx playwright install chromium"): ${err.message}`,
+      { cause: err },
+    );
+  }
 
-  const browser = await chromium.launch({ headless: true });
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+  } catch (err) {
+    throw new Error(
+      `--verify could not launch Chromium (run "npx playwright install chromium" or re-run without --verify): ${err.message}`,
+      { cause: err },
+    );
+  }
+
   const verified = [];
   const expired = [];
   try {

--- a/scan.mjs
+++ b/scan.mjs
@@ -282,24 +282,40 @@ async function verifyOffers(offers) {
     );
   }
 
+  // Three permanent buckets + one transient passthrough:
+  //   verified  → active pages and transient nav errors (retry next scan)
+  //   expired   → classifier-confirmed dead postings (HTTP 4xx, redirect markers,
+  //               body patterns, listing pages, insufficient content)
+  //   dropped   → page loaded but classifier saw no Apply control. --verify is an
+  //               opt-in stricter filter; keeping these defeats the purpose.
+  //   invalid   → up-front URL guard rejections (malformed / non-http / private)
   const verified = [];
   const expired = [];
-  const invalid = []; // guard failures (invalid URL / unsupported protocol / blocked host)
+  const dropped = [];
+  const invalid = [];
+
   try {
     const page = await browser.newPage();
     // Sequential — project rule: never Playwright in parallel
     for (const offer of offers) {
-      const { result, reason } = await checkUrlLiveness(page, offer.url);
+      const { result, code, reason } = await checkUrlLiveness(page, offer.url);
       if (result === 'expired') {
         expired.push({ ...offer, reason });
         console.log(`  ❌ expired   ${offer.company} | ${offer.title} (${reason})`);
-      } else if (result === 'uncertain' && isGuardReason(reason)) {
+      } else if (result === 'uncertain' && GUARD_CODES.has(code)) {
         // Guard failures are permanent (not transient like a timeout) — record them
         // separately so they don't end up in pipeline.md but DO appear in scan-history
         // with a precise status, dedup-blocking them on subsequent scans.
-        invalid.push({ ...offer, reason });
+        invalid.push({ ...offer, code, reason });
         console.log(`  ⛔ invalid   ${offer.company} | ${offer.title} (${reason})`);
+      } else if (result === 'uncertain' && code === 'no_apply_control') {
+        // Page loaded but classifier could not find an Apply control. Treat like
+        // expired for routing — drop from pipeline AND record in scan-history so
+        // we don't burn a verify cycle on the same URL next scan.
+        dropped.push({ ...offer, reason });
+        console.log(`  ⚠️ no-apply  ${offer.company} | ${offer.title} (${reason})`);
       } else {
+        // 'active' or 'uncertain' due to navigation_error (transient — retry next scan)
         verified.push(offer);
         const icon = result === 'active' ? '✅' : '⚠️';
         console.log(`  ${icon} ${result.padEnd(9)} ${offer.company} | ${offer.title}`);
@@ -309,26 +325,18 @@ async function verifyOffers(offers) {
     await browser.close();
   }
 
-  return { verified, expired, invalid };
+  return { verified, expired, dropped, invalid };
 }
 
-// isGuardReason returns true when a liveness 'uncertain' result was caused by an
-// up-front URL guard rather than a transient navigation failure. Guard failures
-// stay constant across scans (a malformed URL doesn't heal itself), so we treat
-// them differently from timeouts/DNS blips that may resolve next time.
-function isGuardReason(reason = '') {
-  return (
-    reason === 'invalid URL' ||
-    reason.startsWith('unsupported protocol') ||
-    reason.startsWith('blocked host')
-  );
-}
+// Stable codes from liveness-browser's up-front URL guard. Routing dispatches
+// on these codes (not on regex over reason strings) so wording can change
+// without breaking the pipeline.
+const GUARD_CODES = new Set(['invalid_url', 'unsupported_protocol', 'blocked_host']);
 
-// guardStatusFor maps a guard reason to the canonical scan-history status string.
-function guardStatusFor(reason = '') {
-  if (reason === 'invalid URL') return 'skipped_invalid_url';
-  if (reason.startsWith('unsupported protocol')) return 'skipped_invalid_url';
-  if (reason.startsWith('blocked host')) return 'skipped_blocked_host';
+// guardStatusFor maps a guard code to the canonical scan-history status string.
+function guardStatusFor(code) {
+  if (code === 'blocked_host') return 'skipped_blocked_host';
+  // invalid_url and unsupported_protocol both surface as malformed input
   return 'skipped_invalid_url';
 }
 
@@ -435,12 +443,14 @@ async function main() {
   // 5.5. Optional liveness verification — drop expired and guard-rejected postings
   let verifiedOffers = newOffers;
   let expiredOffers = [];
+  let droppedOffers = [];
   let invalidOffers = [];
   if (verify && newOffers.length > 0) {
     console.log(`\nVerifying liveness of ${newOffers.length} new offer(s) with Playwright (sequential)...`);
     const result = await verifyOffers(newOffers);
     verifiedOffers = result.verified;
     expiredOffers = result.expired;
+    droppedOffers = result.dropped;
     invalidOffers = result.invalid;
   }
 
@@ -452,14 +462,19 @@ async function main() {
   if (!dryRun && expiredOffers.length > 0) {
     appendToScanHistory(expiredOffers, date, 'skipped_expired');
   }
+  // Pages that loaded but had no Apply control: record so we don't re-verify
+  // them next scan, but never let them reach pipeline.md.
+  if (!dryRun && droppedOffers.length > 0) {
+    appendToScanHistory(droppedOffers, date, 'skipped_no_apply_control');
+  }
   // Guard-rejected URLs (invalid / unsupported protocol / blocked host) are
   // recorded with a precise status so subsequent scans dedup-skip them via
   // loadSeenUrls, but they never reach pipeline.md.
   if (!dryRun && invalidOffers.length > 0) {
-    // Group by status so the TSV reflects the actual reason category.
+    // Group by code so the TSV reflects the actual reason category.
     const byStatus = new Map();
     for (const o of invalidOffers) {
-      const status = guardStatusFor(o.reason);
+      const status = guardStatusFor(o.code);
       if (!byStatus.has(status)) byStatus.set(status, []);
       byStatus.get(status).push(o);
     }
@@ -479,6 +494,7 @@ async function main() {
   console.log(`Duplicates:            ${totalDupes} skipped`);
   if (verify) {
     console.log(`Expired (verified):    ${expiredOffers.length} dropped`);
+    console.log(`No apply control:      ${droppedOffers.length} dropped`);
     console.log(`Invalid (guarded):     ${invalidOffers.length} dropped`);
   }
   console.log(`New offers added:      ${verifiedOffers.length}`);


### PR DESCRIPTION
## Summary

- Adds opt-in `--verify` flag to `scan.mjs` that Playwright-checks each new offer (after dedup) and drops expired postings before they reach `pipeline.md`.
- Extracts the per-URL Playwright probe into `liveness-browser.mjs` so `scan.mjs` and `check-liveness.mjs` share one implementation of the heuristic (no behavioral change for `check-liveness`).
- Documents the flag in `README.md` next to the scanner section.

Fixes #373.

## Why

`scan.mjs` performs zero liveness checks — it's API fetch → title-filter → dedup → append. When an ATS feed (Greenhouse / Ashby / Lever) leaves a stale posting in its public response (companies forget to archive, feeds cache), it lands straight in `pipeline.md`. The user spends evaluation tokens on a job that closed months ago. `modes/scan.md` step 7.5 already specifies the heuristic for the Level-3 (WebSearch) flow, but the zero-token script never runs it.

## Design notes

- Default path stays exactly as before — same flow, same output, no Playwright startup cost. `--verify` is opt-in.
- Verification is **sequential** (project rule: never Playwright in parallel) and only runs against the post-dedup new offers, so the cost stays bounded by what the scan was going to evaluate anyway.
- `expired` offers get written to `scan-history.tsv` (with the source tagged `(expired)`) so the next scan won't re-fetch them.
- `uncertain` results are kept in the pipeline rather than dropped — better to surface a likely-live offer than silently lose one.
- Playwright is already a top-level dep (`generate-pdf.mjs`, `check-liveness.mjs`); the dynamic import keeps it out of the default startup path.

## Test plan

- [x] `node test-all.mjs` — 66 passed, 0 failed (15 pre-existing warnings unchanged)
- [x] `node --check` on all three modified `.mjs` files
- [ ] Manual smoke: `node scan.mjs --verify` against a real `portals.yml` containing at least one company with known stale postings (recommend running on a small `--company` slice first to validate)
- [ ] Confirm `check-liveness.mjs` still works after refactor (same heuristic, just imported from the new module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional --verify mode that performs live URL checks, persists only verified offers, and reports verified/dropped counts. Verification runs sequentially and only on new deduped offers.

* **Improvements**
  * Liveness checks now return explicit classification codes and clearer uncertain/navigation outcomes; expired, invalid, and “no apply control” results are recorded with distinct statuses.

* **Documentation**
  * README updated to explain default scan behavior and the optional verification workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->