### PR TITLE
feat: add optional location filter to portal scanner

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -134,6 +134,17 @@ function buildTitleFilter(titleFilter) {
   };
 }
 
+function buildLocationFilter(locationFilter) {
+  const positive = (locationFilter?.positive || []).map(k => k.toLowerCase());
+  if (positive.length === 0) return () => true;
+
+  return (location) => {
+    if (!location) return true;
+    const lower = location.toLowerCase();
+    return positive.some(k => lower.includes(k));
+  };
+}
+
 // ── Dedup ───────────────────────────────────────────────────────────
 
 function loadSeenUrls() {
@@ -264,6 +275,7 @@ async function main() {
   const config = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
   const companies = config.tracked_companies || [];
   const titleFilter = buildTitleFilter(config.title_filter);
+  const locationFilter = buildLocationFilter(config.location_filter);
 
   // 2. Filter to enabled companies with detectable APIs
   const targets = companies
@@ -285,6 +297,7 @@ async function main() {
   const date = new Date().toISOString().slice(0, 10);
   let totalFound = 0;
   let totalFiltered = 0;
+  let totalLocationFiltered = 0;
   let totalDupes = 0;
   const newOffers = [];
   const errors = [];
@@ -299,6 +312,10 @@ async function main() {
       for (const job of jobs) {
         if (!titleFilter(job.title)) {
           totalFiltered++;
+          continue;
+        }
+        if (!locationFilter(job.location)) {
+          totalLocationFiltered++;
           continue;
         }
         if (seenUrls.has(job.url)) {
@@ -335,6 +352,7 @@ async function main() {
   console.log(`Companies scanned:     ${targets.length}`);
   console.log(`Total jobs found:      ${totalFound}`);
   console.log(`Filtered by title:     ${totalFiltered} removed`);
+  console.log(`Filtered by location:  ${totalLocationFiltered} removed`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
   console.log(`New offers added:      ${newOffers.length}`);
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -136,11 +136,14 @@ function buildTitleFilter(titleFilter) {
 
 function buildLocationFilter(locationFilter) {
   const positive = (locationFilter?.positive || []).map(k => k.toLowerCase());
-  if (positive.length === 0) return () => true;
+  const negative = (locationFilter?.negative || []).map(k => k.toLowerCase());
+  if (positive.length === 0 && negative.length === 0) return () => true;
 
   return (location) => {
     if (!location) return true;
     const lower = location.toLowerCase();
+    if (negative.some(k => lower.includes(k))) return false;
+    if (positive.length === 0) return true;
     return positive.some(k => lower.includes(k));
   };
 }

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -100,6 +100,20 @@ title_filter:
     - "Head"
     - "Director"
 
+# -- Location filter --
+# Optional. Keep only offers whose location contains at least one positive keyword.
+# Jobs with empty/missing location pass through unfiltered (e.g. ATS-without-location data).
+# Comment out the whole section or remove `positive` to disable.
+#
+# location_filter:
+#   positive:
+#     - "San Francisco"
+#     - "Bay Area"
+#     - "New York"
+#     - "NYC"
+#     - "Remote"
+#     - "United States"
+
 # -- Search queries --
 # Each query triggers a WebSearch. Use site: to filter by portal.
 # The scanner extracts title, URL, and company from results.

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -103,7 +103,8 @@ title_filter:
 # -- Location filter --
 # Optional. Keep only offers whose location contains at least one positive keyword.
 # Jobs with empty/missing location pass through unfiltered (e.g. ATS-without-location data).
-# Comment out the whole section or remove `positive` to disable.
+# Negative keywords win over positive — drops "Remote (Singapore)" even when "Remote"
+# is in the positive list. Comment out the whole section to disable.
 #
 # location_filter:
 #   positive:
@@ -113,6 +114,11 @@ title_filter:
 #     - "NYC"
 #     - "Remote"
 #     - "United States"
+#   negative:
+#     - "Singapore"
+#     - "London"
+#     - "EMEA"
+#     - "APJ"
 
 # -- Search queries --
 # Each query triggers a WebSearch. Use site: to filter by portal.


### PR DESCRIPTION
Closes #302
Partially addresses #441 (location filtering portion only)

## Summary

Adds an optional `location_filter` config block to `portals.yml` that filters API scan results by location keyword. Useful for users targeting a specific geography who want to skip noise from other regions in their pipeline.

## Behavior

- When `location_filter.positive` is set, jobs whose `location` field doesn't contain any of the positive keywords are dropped before dedup.
- `location_filter.negative` (added in second commit) wins over `positive` to handle ATS quirks like `"Remote (Singapore)"` matching `"Remote"` as substring.
- When both lists are empty/unset, filter is a no-op — backwards compatible.
- Jobs with empty/missing location pass through unfiltered, so ATS responses without location data (some Lever boards, certain Workday tenants) aren't silently lost.

## Example

```yaml
location_filter:
  positive:
    - "San Francisco"
    - "Bay Area"
    - "New York"
    - "Remote"
    - "United States"
  negative:
    - "Singapore"
    - "London"
    - "EMEA"
    - "APJ"
```

After enabling on a TPM-targeted scan, the summary shows the new bucket:

```
Companies scanned:     38
Total jobs found:      2774
Filtered by title:     2345 removed
Filtered by location:  226 removed   ← new
Duplicates:            178 skipped
New offers added:      21
```

## Changes

- `scan.mjs`: new `buildLocationFilter()` mirrors `buildTitleFilter()`, integrated into the main loop and summary output.
- `templates/portals.example.yml`: documents the new config block (commented out by default — opt-in).

## Scope vs #441

#441 proposes three filtering layers (location toggles, salary, location keywords). This PR only delivers the keyword-based location filter, which matches the design described in #302. The salary filter and `remote_only`/`onsite_only` boolean toggles from #441 are left as separate work.

## Test plan

- [x] Default behavior unchanged when `location_filter` absent
- [x] Empty `positive: []` is a no-op
- [x] Jobs with empty `location` field still pass through
- [x] Real scan with 38 companies and SF/NYC filter correctly drops EU/APAC offers (226 dropped from 2,774)
- [x] Negative keywords correctly drop "Remote (Singapore)" while keeping "Remote" US roles
- [x] Summary line displays `Filtered by location: N removed`