### PR TITLE
fix(merge-tracker): stop collapsing different roles at the same company

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -70,6 +70,9 @@ const ROLE_STOPWORDS = new Set([
   'manager', 'director', 'associate', 'intern', 'contractor',
   'remote', 'hybrid', 'onsite',
   'engineer', 'engineering',
+  // role-type prefixes — keep in sync with merge-tracker.mjs
+  // so both pipelines agree on TPM-style cases.
+  'technical', 'program',
 ]);
 
 const LOCATION_STOPWORDS = new Set([
@@ -92,6 +95,12 @@ function roleMatch(a, b) {
   const smaller = Math.min(wordsA.length, wordsB.length);
   const ratio = overlap.length / smaller;
 
+  // Subset match (mirrors merge-tracker.mjs): re-evaluation of a
+  // single-discriminator role like "TPM, Compute" should match itself
+  // even when stopword filtering reduces it to one token. Require BOTH
+  // sides to reduce to the same set so "Engineering Manager" does not
+  // collapse into "Engineering Manager, Backend".
+  if (wordsA.length === wordsB.length && ratio === 1.0) return true;
   return overlap.length >= 2 && ratio >= 0.6;
 }
 

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -124,10 +124,11 @@ function roleFuzzyMatch(a, b) {
 
   // Subset match: when role-type prefixes (technical/program/manager) are
   // filtered out, single-discriminator roles like "TPM, Compute" reduce
-  // to one token. Allow a match when the shorter side is fully contained
-  // in the longer (ratio === 1.0). Otherwise require the original
-  // overlap >= 2 with substantial ratio.
-  return ratio === 1.0 || (overlap >= 2 && ratio >= 0.6);
+  // to one token. Allow a match only when BOTH sides reduce to the same
+  // token set (same length + ratio 1.0) so a bare "Engineering Manager"
+  // does not collapse into "Engineering Manager, Backend".
+  if (wordsA.length === wordsB.length && ratio === 1.0) return true;
+  return overlap >= 2 && ratio >= 0.6;
 }
 
 function extractReportNum(reportStr) {

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -82,6 +82,11 @@ const ROLE_STOPWORDS = new Set([
   'fulltime', 'parttime', 'permanent', 'temporary', 'intern', 'internship',
   // generic job words
   'role', 'position', 'opportunity', 'team', 'based',
+  // role-type prefixes — same scope as seniority. Without these,
+  // "Technical Program Manager, Infrastructure" and
+  // "Technical Program Manager, Compute" share 3 tokens and false-match.
+  // The discriminator is what comes after, not the role-type prefix.
+  'technical', 'program', 'manager',
   // very common locations (extend in portals.yml later if needed)
   'bangalore', 'bengaluru', 'mumbai', 'delhi', 'hyderabad', 'pune', 'chennai',
   'london', 'berlin', 'paris', 'madrid', 'barcelona', 'amsterdam', 'dublin',
@@ -117,7 +122,12 @@ function roleFuzzyMatch(a, b) {
   const minLen = Math.min(wordsA.length, wordsB.length);
   const ratio = overlap / minLen;
 
-  return overlap >= 2 && ratio >= 0.6;
+  // Subset match: when role-type prefixes (technical/program/manager) are
+  // filtered out, single-discriminator roles like "TPM, Compute" reduce
+  // to one token. Allow a match when the shorter side is fully contained
+  // in the longer (ratio === 1.0). Otherwise require the original
+  // overlap >= 2 with substantial ratio.
+  return ratio === 1.0 || (overlap >= 2 && ratio >= 0.6);
 }
 
 function extractReportNum(reportStr) {


### PR DESCRIPTION
Follow-up to #329 / #356.

#356 fixed the location-and-seniority over-match. This PR fixes a related but distinct case: role-type prefix tokens (`technical`, `program`, `manager`) on their own provided enough overlap to false-match different roles at the same company.

## Summary

The role fuzzy-matcher in `merge-tracker.mjs` was collapsing distinct roles whenever the shared role-type prefix (e.g. "Technical Program Manager") provided enough token overlap on its own.

## Concrete failure

Running a batch with three Anthropic TPM tracker additions produced **one** tracker entry instead of three:

```
TPM, Infrastructure        → ['technical','program','manager','infrastructure']
TPM, Compute               → ['technical','program','manager','compute']
TPM, Inference Performance → ['technical','program','manager','inference','performance']

overlap=3, minLen=4, ratio=0.75  →  matched (incorrectly)
```

The "Technical Program Manager" prefix is a role-type label — same low-signal class as "senior" or "remote" — and shouldn't drive a duplicate decision. The actual discriminator is what follows (Infrastructure / Compute / Inference Performance).

## Changes

1. **Add `technical`, `program`, `manager` to `ROLE_STOPWORDS`** so the tokenizer strips them like it already strips seniority levels.

2. **Allow tightened subset match in `roleFuzzyMatch`** (`wordsA.length === wordsB.length && ratio === 1.0`) so single-discriminator roles like "TPM, Compute" still match themselves on re-evaluation. Tightened from the initial `ratio === 1.0` per CodeRabbit review to avoid false-positives like "Engineering Manager" matching "Engineering Manager, Backend".

3. **Mirror the changes in `dedup-tracker.mjs`** (added `technical`/`program` stopwords + same subset rule). Both pipelines now agree on TPM-style cases.

## Test plan

End-to-end verification on a fresh tracker:

- [x] 3 distinct Anthropic TPM TSV additions → 3 separate rows added
- [x] Re-evaluation of "TPM, Compute" with a higher score → updates the existing row in-place (4.8 → 4.9), no duplicate created
- [x] "Engineering Manager" vs "Engineering Manager, Backend" — does NOT false-match (different lengths)
- [x] "Account Manager, EMEA" vs "Account Manager, Enterprise" — does NOT false-match
- [x] "Engineering Manager, Platform" vs "Engineering Manager, Backend" — does NOT false-match
- [x] "Senior Backend Engineer, Identity Platform" vs "Backend Engineer, Identity Platform" — still matches (subset, both length 3)

## Known follow-up (deferred)

When two different role *families* both reduce to the same single token after stopword filtering — e.g. `"Senior Compute Lead"` → `["compute"]` and `"TPM, Compute"` → `["compute"]` — they still match. Resolving requires preserving role-type tokens as a separate axis or falling back to exact-string match for single-token cases. Will file as a separate issue if desired.

## Out of scope

There's a separate, pre-existing edge case where "Software Engineer, Backend" and "Software Engineer, Frontend" match (overlap=2, ratio=0.67). That's untouched here — would require its own discussion about whether specialization tokens should outweigh the shared "software / engineer" pair.