### PR TITLE
feat(mock-interview): voice-based mock interview mode

### DIFF
--- a/.claude/skills/career-ops/SKILL.md
+++ b/.claude/skills/career-ops/SKILL.md
@@ -3,7 +3,7 @@ name: career-ops
 description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
 user_invocable: true
 args: mode
-argument-hint: "[scan | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
+argument-hint: "[scan | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | mock | update]"
 ---
 
 # career-ops -- Router
@@ -30,6 +30,8 @@ Determine the mode from `{{mode}}`:
 | `batch` | `batch` |
 | `patterns` | `patterns` |
 | `followup` | `followup` |
+| `mock`     | `mock-interview` |
+| `mock-interview` | `mock-interview` |
 
 **Auto-pipeline detection:** If `{{mode}}` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
 
@@ -60,6 +62,7 @@ Available commands:
   /career-ops batch     → Batch processing with parallel workers
   /career-ops patterns  → Analyze rejection patterns and improve targeting
   /career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
+  /career-ops mock      → Voice mock interview (browser app, ElevenLabs voice)
 
 Inbox: add URLs to data/pipeline.md → /career-ops pipeline
 Or paste a JD directly to run the full pipeline.
@@ -79,7 +82,7 @@ Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `p
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`
 
-Applies to: `tracker`, `deep`, `training`, `project`, `patterns`, `followup`
+Applies to: `tracker`, `deep`, `training`, `project`, `patterns`, `followup`, `mock-interview`
 
 ### Modes delegated to subagent:
 For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as Agent with the content of `_shared.md` + `modes/{mode}.md` injected into the subagent prompt.

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,17 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # Alternatives: gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash-thinking-exp
 # GEMINI_MODEL=gemini-2.0-flash
 
+# ── Mock Interview (modes/mock-interview.md) ─────────────────────────────────
+# Required for: node mock-interview.mjs
+# ANTHROPIC_API_KEY drives the interviewer (Claude). Get one at:
+#   https://console.anthropic.com/
+# ELEVENLABS_API_KEY drives the voice synthesis. Get one at:
+#   https://elevenlabs.io/app/settings/api-keys
+# ANTHROPIC_API_KEY=sk-ant-...
+# ELEVENLABS_API_KEY=...
+# Optional overrides:
+# ANTHROPIC_MODEL=claude-sonnet-4-5
+# ELEVENLABS_MODEL=eleven_turbo_v2_5
+
 # ── Other integrations (add your own below) ──────────────────────────────────
-# ANTHROPIC_API_KEY=your_anthropic_key_here   # For Claude-based workflows
 # OPENAI_API_KEY=your_openai_key_here          # Future OpenAI integration

--- a/.gemini/commands/career-ops-mock.toml
+++ b/.gemini/commands/career-ops-mock.toml
@@ -1,0 +1,24 @@
+description = "Launch the voice mock interview server. Opens a local browser app that practices interviews using your CV, profile, story bank, and (optionally) a specific evaluation report from reports/."
+
+prompt = """
+You are career-ops in mock-interview mode.
+
+Load the mock-interview context:
+- Read file: modes/mock-interview.md
+
+Then execute the mock-interview mode as defined in modes/mock-interview.md. The mode launches a local web server via:
+
+```
+node mock-interview.mjs
+```
+
+The server boots at http://127.0.0.1:3737/mock-interview/ and opens the browser. The user picks a target (a row from data/applications.md or a file from reports/, or a generic role+industry), an interviewer persona (tough/friendly/technical/executive/custom), an interview type, a feedback mode, an ElevenLabs voice, and a duration. Speech-to-text runs in the browser; the server proxies Anthropic for the interviewer's brain and ElevenLabs for voice synthesis. After hangup, a coach report is saved to interview-prep/sessions/{date}-{slug}.md.
+
+Required env (.env):
+- ANTHROPIC_API_KEY
+- ELEVENLABS_API_KEY
+
+If those aren't set, the UI surfaces clear warnings before any call starts.
+
+Additional arguments (if any): $ARGUMENTS
+"""

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ batch/tracker-additions/**/*.tsv
 !batch/tracker-additions/.gitkeep
 jds/*
 !jds/.gitkeep
+interview-prep/sessions/*
+!interview-prep/sessions/.gitkeep
 
 # User config and customization (never auto-updated)
 config/profile.yml
@@ -41,3 +43,4 @@ bun.lock
 .claude/memory/
 career-dashboard
 package-lock.json
+.claude/worktrees/

--- a/.opencode/commands/career-ops-mock.md
+++ b/.opencode/commands/career-ops-mock.md
@@ -1,0 +1,10 @@
+---
+description: Voice mock interview (browser app, ElevenLabs voice)
+---
+
+Launch the voice-based mock interview using career-ops mock-interview mode.
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,6 @@ Parse the JSON output:
 - `{"status": "up-to-date"}` → say nothing
 - `{"status": "dismissed"}` → say nothing
 - `{"status": "offline"}` → say nothing
-- `{"status": "no-remote-version"}` → say nothing (checker reached GitHub but neither VERSION nor the latest release tag parsed as semver — treat as a silent non-failure, same as offline)
 
 The user can also say "check for updates" or "update career-ops" at any time to force a check.
 To rollback: `node update-system.mjs rollback`
@@ -61,6 +60,9 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `article-digest.md` | Compact proof points from portfolio (optional) |
 | `interview-prep/story-bank.md` | Accumulated STAR+R stories across evaluations |
 | `interview-prep/{company}-{role}.md` | Company-specific interview intel reports |
+| `mock-interview.mjs` | Voice mock-interview server (Anthropic + ElevenLabs) |
+| `web/mock-interview/` | Browser UI for the mock interview (single-page) |
+| `interview-prep/sessions/` | Mock interview transcripts + coach reports (gitignored) |
 | `analyze-patterns.mjs` | Pattern analysis script (JSON output) |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `data/follow-ups.md` | Follow-up history tracker |
@@ -91,6 +93,7 @@ When using [OpenCode](https://opencode.ai), the following slash commands are ava
 | `/career-ops-batch` | `/career-ops batch` | Batch processing with parallel workers |
 | `/career-ops-patterns` | `/career-ops patterns` | Analyze rejection patterns and improve targeting |
 | `/career-ops-followup` | `/career-ops followup` | Follow-up cadence tracker |
+| `/career-ops-mock` | `/career-ops mock` | Voice mock interview (browser app) |
 
 **Note:** OpenCode commands invoke the same `.claude/skills/career-ops/SKILL.md` skill used by Claude Code. The `modes/*` files are shared between both platforms.
 
@@ -115,6 +118,7 @@ When using the [Gemini CLI](https://github.com/google-gemini/gemini-cli), the fo
 | `/career-ops-batch` | `/career-ops batch` | Batch processing with parallel workers |
 | `/career-ops-patterns` | `/career-ops patterns` | Analyze rejection patterns and improve targeting |
 | `/career-ops-followup` | `/career-ops followup` | Follow-up cadence tracker |
+| `/career-ops-mock` | `/career-ops mock` | Voice mock interview (browser app) |
 
 **Note:** Gemini CLI commands are defined in `.gemini/commands/*.toml`. The project context is auto-loaded from `GEMINI.md`. All `modes/*` files are shared across Claude Code, OpenCode, and Gemini CLI.
 
@@ -259,6 +263,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Batch processes offers | `batch` |
 | Asks about rejection patterns or wants to improve targeting | `patterns` |
 | Asks about follow-ups or application cadence | `followup` |
+| Wants to practice a phone-style interview with voice | `mock-interview` |
 
 ### CV Source of Truth
 

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -13,6 +13,7 @@ These files contain your personal data, customizations, and work product. Update
 | `modes/_profile.md` | Your archetypes, narrative, negotiation scripts |
 | `article-digest.md` | Your proof points from portfolio |
 | `interview-prep/story-bank.md` | Your accumulated STAR+R stories |
+| `interview-prep/sessions/*` | Your mock interview transcripts and coach reports (gitignored) |
 | `portals.yml` | Your customized company list |
 | `data/applications.md` | Your application tracker |
 | `data/pipeline.md` | Your URL inbox |
@@ -44,11 +45,9 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/training.md` | Training evaluation instructions |
 | `modes/patterns.md` | Pattern analysis instructions |
 | `modes/followup.md` | Follow-up cadence instructions |
+| `modes/mock-interview.md` | Mock interview mode (voice-based) |
+| `web/mock-interview/*` | Browser UI for the mock interview |
 | `modes/de/*` | German language modes |
-| `modes/fr/*` | French language modes |
-| `modes/ja/*` | Japanese language modes |
-| `modes/pt/*` | Portuguese language modes |
-| `modes/ru/*` | Russian language modes |
 | `CLAUDE.md` | Agent instructions |
 | `AGENTS.md` | Codex instructions |
 | `*.mjs` | Utility scripts |

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -11,6 +11,10 @@ candidate:
   portfolio_url: "https://janesmith.dev"
   github: "github.com/janesmith"
   twitter: "https://x.com/janesmith"
+  # (Optional) Canva resume design ID for visual CV generation via /career-ops pdf.
+  # Find it in your Canva design URL: https://www.canva.com/design/DAxxxxxxx/...
+  # The ID starts with "D" and is 11 characters long.
+  # canva_resume_design_id: "DAxxxxxxxxx"
 
 target_roles:
   # Your North Star roles — what you're optimizing for
@@ -66,9 +70,15 @@ location:
   # For remote roles outside your country:
   # onsite_availability: "1 week/month in any city"
 
-cv:
-  output_format: "html" # "html" (default) or "latex"
-  # (Optional) Canva resume design ID for visual CV generation via /career-ops pdf.
-  # Find it in your Canva design URL: https://www.canva.com/design/DAxxxxxxx/...
-  # The ID starts with "D" and is 11 characters long.
-  # canva_resume_design_id: "DAxxxxxxxxx"
+mock_interview:
+  # Voice pipeline. "diy" = browser STT + Anthropic + ElevenLabs TTS (best realism, needs both keys).
+  # "system_tts" = browser STT + Anthropic + your OS's built-in voices (free, no
+  # ElevenLabs key needed; lower realism). "elevenlabs_cai" = full ElevenLabs
+  # Conversational AI (lowest latency, scaffolded only in v1).
+  voice_track: diy            # diy | system_tts | elevenlabs_cai
+  default_persona: tough           # tough | friendly | technical | executive | custom
+  default_feedback_mode: in_character  # in_character | coach_mode | break_character
+  default_voice_id: ""             # ElevenLabs voice_id; empty = first available
+  default_duration_minutes: 25
+  port: 3737
+  # elevenlabs_cai_agent_id: ""    # only used when voice_track: elevenlabs_cai

--- a/mock-interview.mjs
+++ b/mock-interview.mjs
@@ -1,0 +1,692 @@
+#!/usr/bin/env node
+/**
+ * mock-interview.mjs — Voice-based mock interview server
+ *
+ * Boots a local HTTP server on 127.0.0.1:{port} and opens the browser to the
+ * mock-interview web app. The browser handles mic capture (Web Speech API) and
+ * audio playback. This server proxies the Anthropic API (interviewer brain)
+ * and ElevenLabs (voice synthesis), and keeps API keys off the client.
+ *
+ * Reads:
+ *   cv.md, config/profile.yml, modes/_profile.md, article-digest.md,
+ *   interview-prep/story-bank.md, reports/*.md, interview-prep/{slug}.md
+ *
+ * Writes:
+ *   interview-prep/sessions/{date}-{slug}.md   (transcripts + coach reports)
+ *   interview-prep/story-bank.md               (when user promotes a story)
+ *
+ * Usage:
+ *   node mock-interview.mjs            # boot and open browser
+ *   node mock-interview.mjs --check    # boot, hit /api/config, exit (smoke test)
+ *   node mock-interview.mjs --no-open  # boot but don't open browser
+ *
+ * Env (.env):
+ *   ANTHROPIC_API_KEY=sk-ant-...
+ *   ELEVENLABS_API_KEY=...
+ *
+ * See modes/mock-interview.md for the behavioral spec.
+ */
+
+import http from 'node:http';
+import { readFile, writeFile, readdir, mkdir, appendFile, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { exec } from 'node:child_process';
+import dotenv from 'dotenv';
+import yaml from 'js-yaml';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.dirname(__filename);
+const WEB_ROOT = path.join(ROOT, 'web', 'mock-interview');
+const SESSIONS_DIR = path.join(ROOT, 'interview-prep', 'sessions');
+
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || '';
+const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY || '';
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-5';
+const ELEVENLABS_MODEL = process.env.ELEVENLABS_MODEL || 'eleven_turbo_v2_5';
+
+// In-memory session store. Resets when the process restarts.
+const sessions = new Map();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Profile + context loading
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function readIfExists(p) {
+  try { return await readFile(p, 'utf8'); } catch { return null; }
+}
+
+async function loadProfile() {
+  const raw = await readIfExists(path.join(ROOT, 'config', 'profile.yml'));
+  if (!raw) return {};
+  try { return yaml.load(raw) || {}; } catch (e) {
+    console.warn('[mock] profile.yml parse error:', e.message);
+    return {};
+  }
+}
+
+function defaults(profile) {
+  const m = profile?.mock_interview || {};
+  return {
+    voice_track: m.voice_track || 'diy',
+    default_persona: m.default_persona || 'tough',
+    default_feedback_mode: m.default_feedback_mode || 'in_character',
+    default_voice_id: m.default_voice_id || '',
+    default_duration_minutes: m.default_duration_minutes || 25,
+    port: m.port || 3737,
+    language: profile?.language?.modes_dir
+      ? profile.language.modes_dir.replace(/^modes\//, '') || 'en'
+      : 'en',
+  };
+}
+
+async function loadCandidateContext() {
+  const cv = await readIfExists(path.join(ROOT, 'cv.md'));
+  const profileRaw = await readIfExists(path.join(ROOT, 'config', 'profile.yml'));
+  const profileMd = await readIfExists(path.join(ROOT, 'modes', '_profile.md'));
+  const articleDigest = await readIfExists(path.join(ROOT, 'article-digest.md'));
+  const storyBank = await readIfExists(path.join(ROOT, 'interview-prep', 'story-bank.md'));
+  return { cv, profileRaw, profileMd, articleDigest, storyBank };
+}
+
+async function listTargets() {
+  const reportsDir = path.join(ROOT, 'reports');
+  const out = [];
+  try {
+    const files = await readdir(reportsDir);
+    for (const f of files.sort()) {
+      if (!f.endsWith('.md') || f.startsWith('.')) continue;
+      // Filename: NNN-{slug}-{YYYY-MM-DD}.md
+      const m = f.match(/^(\d{3})-(.+)-(\d{4}-\d{2}-\d{2})\.md$/);
+      if (!m) continue;
+      const [, num, slug, date] = m;
+      const fp = path.join(reportsDir, f);
+      const content = await readIfExists(fp);
+      let company = slug, role = '', score = '';
+      if (content) {
+        const titleMatch = content.match(/^#\s+(.+)$/m);
+        if (titleMatch) {
+          // Strip common evaluation-prefix labels in EN/ES/FR/DE/JA before splitting.
+          const cleaned = titleMatch[1]
+            .replace(/^\s*(Evaluation|Evaluación|Évaluation|Evaluierung|評価)\s*:\s*/i, '')
+            .trim();
+          // Try "Company — Role" pattern
+          const parts = cleaned.split(/[—-]/).map(s => s.trim()).filter(Boolean);
+          if (parts.length >= 2) { company = parts[0]; role = parts.slice(1).join(' — '); }
+          else company = cleaned;
+        }
+        const scoreMatch = content.match(/\*\*Score:\*\*\s*([\d.]+)/i);
+        if (scoreMatch) score = scoreMatch[1];
+      }
+      out.push({ id: f.replace(/\.md$/, ''), num, slug, date, company, role, score, file: fp });
+    }
+  } catch { /* no reports/ dir */ }
+  return out;
+}
+
+async function loadTargetContext(targetId) {
+  if (!targetId) return null;
+  const fp = path.join(ROOT, 'reports', `${targetId}.md`);
+  const report = await readIfExists(fp);
+  if (!report) return null;
+  // Extract Block A (Role Summary) and Block F (Interview Plan)
+  const blockA = extractBlock(report, /##\s+Block A[^\n]*/i, /\n##\s+Block [BCDEFG]/i);
+  const blockF = extractBlock(report, /##\s+Block F[^\n]*/i, /\n##\s+Block [G-Z]/i);
+  // Try to find a matching company-specific intel file
+  const m = targetId.match(/^\d{3}-(.+)-\d{4}-\d{2}-\d{2}$/);
+  const slug = m ? m[1] : targetId;
+  const intelFp = await findIntelFile(slug);
+  const intel = intelFp ? await readIfExists(intelFp) : null;
+  return { reportPath: fp, report, blockA, blockF, intel, intelPath: intelFp };
+}
+
+async function findIntelFile(slug) {
+  const dir = path.join(ROOT, 'interview-prep');
+  try {
+    const files = await readdir(dir);
+    // slug looks like "company-role"; intel files look like "company-role.md"
+    // Match by leading company token.
+    const company = slug.split('-')[0];
+    const candidate = files.find(f =>
+      f.endsWith('.md') &&
+      f !== 'story-bank.md' &&
+      (f.replace(/\.md$/, '') === slug || f.startsWith(company + '-'))
+    );
+    return candidate ? path.join(dir, candidate) : null;
+  } catch { return null; }
+}
+
+function extractBlock(text, startRe, endRe) {
+  const start = text.search(startRe);
+  if (start < 0) return null;
+  const after = text.slice(start);
+  const endIdx = after.slice(1).search(endRe);
+  return endIdx < 0 ? after.trim() : after.slice(0, endIdx + 1).trim();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Persona + feedback + system prompt
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PERSONAS = {
+  tough: 'A skeptical senior. You probe weaknesses. You ask "and then what?" until the candidate hits the actual root cause. You do not flatter. You give the candidate space to recover but you do not rescue them.',
+  friendly: 'A warm screener. You make small talk briefly, you keep the conversation flowing, you find positives in answers and use them as bridges to the next topic. You are not a pushover; you still ask the hard questions, but with a smile.',
+  technical: 'A senior IC. You drill into code, system design, and tradeoffs. You ask "why did you pick X over Y?" and "what would break first under load?". You are comfortable with silence while the candidate thinks.',
+  executive: 'A strategic hiring manager. You optimize for judgment and impact. You ask about ambiguity, prioritization, and what the candidate would do in their first 90 days. You are time-conscious; you steer firmly when answers wander.',
+};
+
+const FEEDBACK_BLOCKS = {
+  in_character: 'Stay fully in character through wrap-up. Do not give feedback inside the interview itself. The post-call analysis happens after the call ends.',
+  coach_mode: 'Stay in character verbally. After each candidate answer, in addition to your spoken response, append a single coaching note as a JSON line on a new line at the very end of your response, prefixed with `<<COACH>>`. Example: `<<COACH>> {"strength":"Strong STAR Action","weakness":"Result was vague","tip":"State a metric"}`. The note must be 30 words or less. The frontend will strip this line from the spoken audio and show it as a sidebar pop-up.',
+  break_character: 'When the candidate gives a notably weak or strong answer, briefly step out of character and say so before resuming. Use the literal opener "Quick coaching note:" at the start of the break, and "Back to the interview." when you resume. Use sparingly — at most once per 3-4 answers.',
+};
+
+const LANGUAGE_NAMES = {
+  en: 'English', de: 'German', fr: 'French', ja: 'Japanese', es: 'Spanish',
+  pt: 'Portuguese', ru: 'Russian', zh: 'Chinese', ko: 'Korean',
+};
+
+function buildSystemPrompt({
+  cfg, candidate, target, role, company, industry, persona, customPersona,
+  interviewType, feedbackMode, durationMinutes, language,
+}) {
+  const personaText = persona === 'custom'
+    ? (customPersona || 'A balanced interviewer.')
+    : (PERSONAS[persona] || PERSONAS.tough);
+  const feedbackText = FEEDBACK_BLOCKS[feedbackMode] || FEEDBACK_BLOCKS.in_character;
+  const languageName = LANGUAGE_NAMES[language] || 'English';
+
+  const parts = [];
+  parts.push(`You are conducting a ${interviewType.replace(/-/g, ' ')} interview for the role of ${role || 'the role'} at ${company || 'the company'}${industry ? ` (${industry} industry)` : ''}.`);
+  parts.push(`Your persona is: ${personaText}`);
+  parts.push(`The interview should last roughly ${durationMinutes} minutes.`);
+  parts.push(`Conduct the interview in ${languageName}.`);
+  parts.push('');
+  parts.push('You have full context on the candidate:');
+  if (candidate.cv) parts.push(`<candidate_cv>\n${candidate.cv}\n</candidate_cv>`);
+  if (candidate.profileRaw) parts.push(`<candidate_profile>\n${candidate.profileRaw}\n</candidate_profile>`);
+  if (candidate.profileMd) parts.push(`<candidate_profile_narrative>\n${candidate.profileMd}\n</candidate_profile_narrative>`);
+  if (candidate.articleDigest) parts.push(`<candidate_proof_points>\n${candidate.articleDigest}\n</candidate_proof_points>`);
+  if (candidate.storyBank) parts.push(`<candidate_story_bank>\n${candidate.storyBank}\n</candidate_story_bank>`);
+  if (target?.intel) parts.push(`<company_intel>\n${target.intel}\n</company_intel>`);
+  if (target?.blockA) parts.push(`<role_summary>\n${target.blockA}\n</role_summary>`);
+  if (target?.blockF) parts.push(`<interview_plan>\n${target.blockF}\n</interview_plan>`);
+  parts.push('');
+  parts.push('== HOW TO CONDUCT THIS INTERVIEW ==');
+  parts.push('1. Greet the candidate by name (from profile). Briefly state your name (invent a consistent one), your fictional role at the company, and the planned format.');
+  parts.push('2. Open with a warm-up question appropriate to the interview type.');
+  parts.push('3. Probe specifics. The candidate has detailed proof points and stories — surface them. If they make a claim, ask "what was the metric?" or "what would you do differently?" or "who pushed back?".');
+  parts.push('4. Stay in character. Do not break the fourth wall, do not narrate that you are an AI.');
+  parts.push('5. Keep turns short. One question at a time. Let silence work.');
+  parts.push('6. Allow the candidate to ask questions of you near the end.');
+  parts.push('7. When the duration target is reached, wrap professionally: thank them, explain the (fictional) next steps, close.');
+  parts.push('');
+  parts.push(`== FEEDBACK MODE: ${feedbackMode} ==`);
+  parts.push(feedbackText);
+  parts.push('');
+  parts.push('== OUTPUT FORMAT ==');
+  parts.push('Respond with plain spoken text only. No markdown, no stage directions in asterisks, no bullet points, no headings. Speak the way a human interviewer speaks on a phone call. Keep each turn to 1-3 sentences unless the candidate asks you to elaborate. The current turn begins now: greet the candidate and ask your first question.');
+  return parts.join('\n');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Anthropic
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function callAnthropic({ system, messages, maxTokens = 600 }) {
+  if (!ANTHROPIC_API_KEY) throw new Error('ANTHROPIC_API_KEY not set in .env');
+  const r = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'x-api-key': ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: maxTokens,
+      system,
+      messages,
+    }),
+  });
+  if (!r.ok) {
+    const err = await r.text();
+    throw new Error(`Anthropic ${r.status}: ${err}`);
+  }
+  const data = await r.json();
+  const text = (data.content || []).map(b => b.text || '').join('').trim();
+  return text;
+}
+
+function splitCoachNote(text) {
+  // Look for `<<COACH>> {...}` on its own line at the end.
+  const m = text.match(/\n*<<COACH>>\s*(\{[\s\S]*?\})\s*$/);
+  if (!m) return { speech: text, coach: null };
+  const speech = text.slice(0, m.index).trim();
+  let coach = null;
+  try { coach = JSON.parse(m[1]); } catch { coach = { raw: m[1] }; }
+  return { speech, coach };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ElevenLabs
+// ─────────────────────────────────────────────────────────────────────────────
+
+let voicesCache = null;
+async function listVoices() {
+  if (voicesCache) return voicesCache;
+  if (!ELEVENLABS_API_KEY) return [];
+  const r = await fetch('https://api.elevenlabs.io/v1/voices', {
+    headers: { 'xi-api-key': ELEVENLABS_API_KEY },
+  });
+  if (!r.ok) return [];
+  const data = await r.json();
+  voicesCache = (data.voices || []).map(v => ({
+    voice_id: v.voice_id,
+    name: v.name,
+    labels: v.labels || {},
+    preview_url: v.preview_url || null,
+  }));
+  return voicesCache;
+}
+
+async function synthesizeSpeech({ text, voiceId }) {
+  if (!ELEVENLABS_API_KEY) throw new Error('ELEVENLABS_API_KEY not set in .env');
+  if (!voiceId) throw new Error('voiceId required');
+  const r = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`, {
+    method: 'POST',
+    headers: {
+      'xi-api-key': ELEVENLABS_API_KEY,
+      'content-type': 'application/json',
+      'accept': 'audio/mpeg',
+    },
+    body: JSON.stringify({
+      text,
+      model_id: ELEVENLABS_MODEL,
+      voice_settings: { stability: 0.5, similarity_boost: 0.75, style: 0.0, use_speaker_boost: true },
+    }),
+  });
+  if (!r.ok) {
+    const err = await r.text();
+    throw new Error(`ElevenLabs ${r.status}: ${err}`);
+  }
+  return Buffer.from(await r.arrayBuffer());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Session lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function startSession(opts) {
+  const profile = await loadProfile();
+  const cfg = defaults(profile);
+  const candidate = await loadCandidateContext();
+  const target = opts.targetId ? await loadTargetContext(opts.targetId) : null;
+  const sysPrompt = buildSystemPrompt({
+    cfg, candidate, target,
+    role: opts.role || (target?.blockA ? extractRoleFromBlockA(target.blockA) : ''),
+    company: opts.company || (opts.targetId ? slugToCompany(opts.targetId) : ''),
+    industry: opts.industry || '',
+    persona: opts.persona || cfg.default_persona,
+    customPersona: opts.customPersona || '',
+    interviewType: opts.interviewType || 'phone-screen',
+    feedbackMode: opts.feedbackMode || cfg.default_feedback_mode,
+    durationMinutes: opts.durationMinutes || cfg.default_duration_minutes,
+    language: opts.language || cfg.language || 'en',
+  });
+
+  const sessionId = randomUUID();
+  const session = {
+    id: sessionId,
+    createdAt: new Date().toISOString(),
+    opts: { ...opts, voiceTrack: opts.voiceTrack || cfg.voice_track },
+    systemPrompt: sysPrompt,
+    history: [],   // Anthropic-format messages
+    transcript: [], // [{role: 'interviewer'|'candidate', text, ts}]
+    target,
+    candidateName: extractCandidateName(candidate.profileRaw) || 'Candidate',
+  };
+  sessions.set(sessionId, session);
+
+  // Generate the opener immediately
+  const opener = await callAnthropic({
+    system: sysPrompt,
+    messages: [{ role: 'user', content: '[The candidate has just picked up the phone.]' }],
+    maxTokens: 250,
+  });
+  const { speech, coach } = splitCoachNote(opener);
+  session.history.push({ role: 'user', content: '[The candidate has just picked up the phone.]' });
+  session.history.push({ role: 'assistant', content: opener });
+  session.transcript.push({ role: 'interviewer', text: speech, ts: new Date().toISOString() });
+
+  return { sessionId, openingTurn: { speech, coach } };
+}
+
+function extractCandidateName(profileYaml) {
+  if (!profileYaml) return null;
+  const m = profileYaml.match(/full_name:\s*"?([^"\n]+)"?/);
+  return m ? m[1].trim() : null;
+}
+
+function extractRoleFromBlockA(blockA) {
+  // Block A is a free-form table; just look for "Seniority" or fall back.
+  const m = blockA.match(/role|position|title/i);
+  return m ? '' : '';
+}
+
+function slugToCompany(targetId) {
+  // "042-acme-staff-eng-2026-04-26" → "Acme"
+  const m = targetId.match(/^\d{3}-([^-]+)/);
+  if (!m) return '';
+  return m[1].charAt(0).toUpperCase() + m[1].slice(1);
+}
+
+async function takeTurn(sessionId, candidateText) {
+  const s = sessions.get(sessionId);
+  if (!s) throw new Error('session not found');
+  s.history.push({ role: 'user', content: candidateText });
+  s.transcript.push({ role: 'candidate', text: candidateText, ts: new Date().toISOString() });
+  const reply = await callAnthropic({ system: s.systemPrompt, messages: s.history, maxTokens: 500 });
+  s.history.push({ role: 'assistant', content: reply });
+  const { speech, coach } = splitCoachNote(reply);
+  s.transcript.push({ role: 'interviewer', text: speech, ts: new Date().toISOString() });
+  return { speech, coach };
+}
+
+async function endSession(sessionId, actualMinutes) {
+  const s = sessions.get(sessionId);
+  if (!s) throw new Error('session not found');
+
+  const transcriptText = s.transcript
+    .map(t => `${t.role === 'interviewer' ? 'INTERVIEWER' : 'CANDIDATE'}: ${t.text}`)
+    .join('\n\n');
+
+  const rubricSystem = `You are an interview coach. Score this candidate's mock interview against the rubric below. Be direct and specific. Cite exact lines from the transcript when noting a strength or a weakness.
+
+Rubric (1-5 each):
+- Communication clarity
+- STAR+R structure (concrete Situation/Task/Action/Result + Reflection)
+- Specificity (real metrics, named systems, named stakeholders vs. vague language)
+- Role/archetype fit (signal of seniority and archetype-relevant experience)
+- Cultural signals (curiosity, ownership, humility, collaboration)
+- Self-awareness (acknowledges tradeoffs and what they'd do differently)
+
+Output structure (markdown):
+1. Overall score (X.X/5)
+2. Per-dimension scores in a table
+3. Top 3 strengths (each with a quoted line from the transcript)
+4. Top 3 weaknesses (each with a quoted line and a concrete fix)
+5. ## New Stories Pending — for each strong story the candidate told that is NOT already in the candidate's story bank, draft a STAR+R entry ready to append. Use this exact format for each story:
+
+\`\`\`
+### [Theme] Story Title
+**Source:** Mock Interview {DATE} — {COMPANY} — {ROLE}
+**S (Situation):** ...
+**T (Task):** ...
+**A (Action):** ...
+**R (Result):** ...
+**Reflection:** ...
+**Best for questions about:** ...
+\`\`\`
+
+6. ## Stories to Develop — for each likely-question topic the candidate stumbled on, suggest the experience from their CV they should turn into a story
+7. ## Recommended Next Prep — 3 bullets max, concrete actions
+`;
+
+  const candidate = await loadCandidateContext();
+  const userMsg = `<candidate_cv>\n${candidate.cv || ''}\n</candidate_cv>\n\n<existing_story_bank>\n${candidate.storyBank || '(empty)'}\n</existing_story_bank>\n\n<transcript>\n${transcriptText}\n</transcript>`;
+
+  const report = await callAnthropic({
+    system: rubricSystem,
+    messages: [{ role: 'user', content: userMsg }],
+    maxTokens: 3000,
+  });
+
+  // Parse "New Stories Pending" blocks for the promote-story endpoint
+  const newStories = parseNewStories(report);
+  s.coachReport = report;
+  s.newStories = newStories;
+  s.actualMinutes = actualMinutes;
+
+  // Write session file
+  const meta = s.opts;
+  const date = s.createdAt.slice(0, 10);
+  const company = (meta.company || (s.target ? slugToCompany(meta.targetId) : 'Generic')).replace(/[^a-z0-9]/gi, '').toLowerCase() || 'generic';
+  const role = (meta.role || 'role').replace(/[^a-z0-9]/gi, '-').toLowerCase().replace(/-+/g, '-').replace(/^-|-$/g, '');
+  const fname = `${date}-${company}-${role}.md`;
+  const fp = path.join(SESSIONS_DIR, fname);
+  await mkdir(SESSIONS_DIR, { recursive: true });
+
+  const scoreMatch = report.match(/(\d\.\d)\s*\/\s*5/);
+  const score = scoreMatch ? scoreMatch[1] : '?';
+
+  const fileBody = `# Mock Interview — ${meta.company || 'Generic'} — ${meta.role || ''}
+
+**Date:** ${date}
+**Persona:** ${meta.persona || 'tough'}
+**Interview type:** ${meta.interviewType || 'phone-screen'}
+**Feedback mode:** ${meta.feedbackMode || 'in_character'}
+**Voice track:** ${meta.voiceTrack || meta.voice_track || 'diy'}
+**Voice ID:** ${meta.voiceId || meta.osVoiceName || '(default)'}
+**Duration:** ${actualMinutes || '?'} min
+**Score:** ${score}/5
+**Source target:** ${meta.targetId ? `reports/${meta.targetId}.md` : 'Generic'}
+
+## Transcript
+
+${s.transcript.map(t => `**${t.role === 'interviewer' ? 'Interviewer' : 'Candidate'} (${t.ts.slice(11, 16)}):** ${t.text}`).join('\n\n')}
+
+## Coach Report
+
+${report}
+`;
+  await writeFile(fp, fileBody, 'utf8');
+
+  return { reportMarkdown: report, newStories, sessionFile: fp, score };
+}
+
+function parseNewStories(report) {
+  // Extract STAR+R blocks under "New Stories Pending" section
+  const sectionMatch = report.match(/##\s+New Stories Pending([\s\S]*?)(?=\n##\s|$)/);
+  if (!sectionMatch) return [];
+  const section = sectionMatch[1];
+  const blocks = [...section.matchAll(/```[\s\S]*?###\s+([^\n]+)\n([\s\S]*?)```/g)];
+  return blocks.map((m, i) => ({
+    index: i,
+    title: m[1].trim(),
+    body: m[0].replace(/^```[a-z]*\n?|```$/g, '').trim(),
+  }));
+}
+
+async function promoteStory(sessionId, storyIndex) {
+  const s = sessions.get(sessionId);
+  if (!s) throw new Error('session not found');
+  const story = s.newStories?.[storyIndex];
+  if (!story) throw new Error('story not found');
+  const bankFp = path.join(ROOT, 'interview-prep', 'story-bank.md');
+  const existing = (await readIfExists(bankFp)) || '';
+  const sep = existing.endsWith('\n\n') ? '' : (existing.endsWith('\n') ? '\n' : '\n\n');
+  await writeFile(bankFp, existing + sep + story.body + '\n', 'utf8');
+  return { ok: true, file: bankFp };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HTTP plumbing
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg':  'image/svg+xml',
+  '.ico':  'image/x-icon',
+};
+
+function send(res, status, body, headers = {}) {
+  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8', ...headers });
+  res.end(typeof body === 'string' ? body : JSON.stringify(body));
+}
+
+async function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', c => chunks.push(c));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      try { resolve(raw ? JSON.parse(raw) : {}); }
+      catch (e) { reject(new Error('Invalid JSON body: ' + e.message)); }
+    });
+    req.on('error', reject);
+  });
+}
+
+async function serveStatic(res, urlPath) {
+  // Map "/mock-interview/foo" → web/mock-interview/foo
+  const sub = urlPath.replace(/^\/mock-interview\/?/, '') || 'index.html';
+  const safe = sub.replace(/\.\.+/g, '').replace(/^\/+/, '');
+  const fp = path.join(WEB_ROOT, safe);
+  try {
+    const data = await readFile(fp);
+    const ext = path.extname(fp);
+    res.writeHead(200, { 'content-type': MIME[ext] || 'application/octet-stream' });
+    res.end(data);
+  } catch {
+    res.writeHead(404, { 'content-type': 'text/plain' });
+    res.end('Not found: ' + urlPath);
+  }
+}
+
+async function handle(req, res) {
+  const u = new URL(req.url, 'http://localhost');
+  const p = u.pathname;
+  try {
+    // ─── static ──────────────────────────────────────────────────────────
+    if (p === '/' || p === '/mock-interview' || p.startsWith('/mock-interview/')) {
+      return serveStatic(res, p === '/' ? '/mock-interview/' : p);
+    }
+
+    // ─── API ─────────────────────────────────────────────────────────────
+    if (p === '/api/config' && req.method === 'GET') {
+      const profile = await loadProfile();
+      const cfg = defaults(profile);
+      return send(res, 200, {
+        defaults: cfg,
+        candidate_name: profile?.candidate?.full_name || 'Candidate',
+        has_anthropic_key: !!ANTHROPIC_API_KEY,
+        has_elevenlabs_key: !!ELEVENLABS_API_KEY,
+      });
+    }
+
+    if (p === '/api/voices' && req.method === 'GET') {
+      const voices = await listVoices();
+      return send(res, 200, { voices });
+    }
+
+    if (p === '/api/targets' && req.method === 'GET') {
+      const targets = await listTargets();
+      return send(res, 200, { targets });
+    }
+
+    if (p === '/api/voice-preview' && req.method === 'POST') {
+      const body = await readBody(req);
+      const text = body.text || 'Hi, this is your mock interviewer. Let\u2019s get started in a moment.';
+      try {
+        const audio = await synthesizeSpeech({ text, voiceId: body.voiceId });
+        res.writeHead(200, { 'content-type': 'audio/mpeg' });
+        return res.end(audio);
+      } catch (e) {
+        return send(res, 500, { error: e.message });
+      }
+    }
+
+    if (p === '/api/session/start' && req.method === 'POST') {
+      const body = await readBody(req);
+      const out = await startSession(body);
+      return send(res, 200, out);
+    }
+
+    let m;
+    if ((m = p.match(/^\/api\/session\/([^/]+)\/turn$/)) && req.method === 'POST') {
+      const body = await readBody(req);
+      const out = await takeTurn(m[1], body.userTranscript || '');
+      return send(res, 200, out);
+    }
+
+    if ((m = p.match(/^\/api\/session\/([^/]+)\/tts$/)) && req.method === 'POST') {
+      const body = await readBody(req);
+      try {
+        const audio = await synthesizeSpeech({ text: body.text || '', voiceId: body.voiceId });
+        res.writeHead(200, { 'content-type': 'audio/mpeg' });
+        return res.end(audio);
+      } catch (e) {
+        return send(res, 500, { error: e.message });
+      }
+    }
+
+    if ((m = p.match(/^\/api\/session\/([^/]+)\/end$/)) && req.method === 'POST') {
+      const body = await readBody(req);
+      const out = await endSession(m[1], body.actualMinutes || 0);
+      return send(res, 200, out);
+    }
+
+    if ((m = p.match(/^\/api\/session\/([^/]+)\/promote-story$/)) && req.method === 'POST') {
+      const body = await readBody(req);
+      const out = await promoteStory(m[1], body.storyIndex);
+      return send(res, 200, out);
+    }
+
+    return send(res, 404, { error: 'Unknown route: ' + p });
+  } catch (e) {
+    console.error('[mock] handler error:', e);
+    return send(res, 500, { error: e.message || String(e) });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Boot
+// ─────────────────────────────────────────────────────────────────────────────
+
+function openBrowser(url) {
+  const cmd = process.platform === 'darwin' ? `open "${url}"`
+    : process.platform === 'win32'           ? `start "" "${url}"`
+    :                                          `xdg-open "${url}"`;
+  exec(cmd, () => {});
+}
+
+async function main() {
+  const profile = await loadProfile();
+  const cfg = defaults(profile);
+  const args = process.argv.slice(2);
+  const noOpen = args.includes('--no-open');
+  const checkOnly = args.includes('--check');
+
+  // Pre-flight warnings
+  if (!ANTHROPIC_API_KEY) console.warn('[mock] WARNING: ANTHROPIC_API_KEY is not set. Interviewer turns will fail. Add it to .env.');
+  if (!ELEVENLABS_API_KEY) console.warn('[mock] WARNING: ELEVENLABS_API_KEY is not set. TTS will fail. Add it to .env.');
+
+  const server = http.createServer(handle);
+  server.listen(cfg.port, '127.0.0.1', () => {
+    const url = `http://127.0.0.1:${cfg.port}/mock-interview/`;
+    console.log(`[mock] mock-interview server listening at ${url}`);
+    console.log(`[mock] voice track: ${cfg.voice_track}    persona default: ${cfg.default_persona}    feedback default: ${cfg.default_feedback_mode}`);
+    if (cfg.voice_track === 'elevenlabs_cai') {
+      console.log('[mock] note: elevenlabs_cai track is scaffolded but not wired in v1; falling back to diy in the UI.');
+    }
+    if (checkOnly) {
+      // Hit /api/config and exit
+      fetch(`http://127.0.0.1:${cfg.port}/api/config`)
+        .then(r => r.json())
+        .then(j => { console.log('[mock] /api/config OK:', JSON.stringify(j)); server.close(() => process.exit(0)); })
+        .catch(e => { console.error('[mock] /api/config FAILED:', e); server.close(() => process.exit(1)); });
+      return;
+    }
+    if (!noOpen) openBrowser(url);
+  });
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/modes/mock-interview.md
+++ b/modes/mock-interview.md
@@ -1,0 +1,238 @@
+# Mode: mock-interview — Voice-Based Mock Interview Simulator
+
+When the user asks to run a mock interview with voice (typing patterns: "mock interview", "practice interview", "simulate phone screen", "let me practice for {company}"), launch the local mock-interview web app:
+
+```
+node mock-interview.mjs
+```
+
+The script boots a local server at http://127.0.0.1:3737 and opens the browser. The user picks a target, persona, voice, and feedback mode in the UI, then runs the call. The server uses the Anthropic API for the interviewer's brain and the ElevenLabs API for voice synthesis. Speech-to-text is handled in the browser (Web Speech API).
+
+---
+
+## Inputs
+
+The web app prompts the user for:
+
+1. **Target** — one of:
+   - **Targeted**: a row from `data/applications.md` or a file from `reports/`. The interviewer is hydrated with that report's Block F (Interview Plan), the matching `interview-prep/{company}-{role}.md` intel file (if present), and the company name + role + JD context.
+   - **Generic**: role title + industry + seniority. The interviewer still has `cv.md`, `config/profile.yml`, `article-digest.md`, and `interview-prep/story-bank.md`, but no company specifics.
+2. **Persona** (`tough` | `friendly` | `technical` | `executive` | `custom`).
+3. **Interview type** (`phone-screen` | `behavioral` | `technical-deep-dive` | `hiring-manager` | `executive`).
+4. **Feedback mode** (`in_character` | `coach_mode` | `break_character`).
+5. **Voice** (ElevenLabs `voice_id`; the UI fetches the user's available voices and offers a preview button).
+6. **Duration** (target wall-clock minutes; the interviewer paces and wraps).
+7. **Language** (defaults to `config/profile.yml` → `language.modes_dir` if set, otherwise English. Honor `de`, `fr`, `ja`, etc. by instructing the interviewer to conduct the interview in that language.)
+
+---
+
+## Pre-Call Hydration
+
+Before the first turn, the server builds the system prompt by reading:
+
+| File | Required | Used for |
+|------|----------|----------|
+| `cv.md` | yes | Candidate background; lets the interviewer probe real claims |
+| `config/profile.yml` | yes | Identity, target roles, narrative, comp range |
+| `modes/_profile.md` | optional | Archetypes, negotiation, custom framing |
+| `article-digest.md` | optional | Detailed proof points (preferred over CV metrics) |
+| `interview-prep/story-bank.md` | optional | The candidate's own STAR+R stories — interviewer can probe for these |
+| `reports/{NNN}-{slug}-{date}.md` | targeted only | Block F Interview Plan + Block A Role Summary |
+| `interview-prep/{company-slug}-{role-slug}.md` | targeted only | Researched intel: process, real questions, values |
+
+**RULE:** Never hardcode candidate metrics. The interviewer must read them at hydration time so it stays in sync with edits.
+
+---
+
+## System Prompt Skeleton
+
+The server hydrates this template for each session:
+
+```
+You are conducting a {interview_type} interview for the role of {role} at {company}.
+Your persona is: {persona_block}.
+The interview should last roughly {duration} minutes.
+Conduct the interview in {language}.
+
+You have full context on the candidate:
+<candidate_cv>
+{cv.md}
+</candidate_cv>
+<candidate_profile>
+{config/profile.yml + modes/_profile.md}
+</candidate_profile>
+<candidate_proof_points>
+{article-digest.md}
+</candidate_proof_points>
+<candidate_story_bank>
+{interview-prep/story-bank.md}
+</candidate_story_bank>
+
+[If targeted:]
+<company_intel>
+{interview-prep/{company}-{role}.md}
+</company_intel>
+<interview_plan>
+{Block F from reports/{NNN}-...md}
+</interview_plan>
+<role_summary>
+{Block A from reports/{NNN}-...md}
+</role_summary>
+
+== HOW TO CONDUCT THIS INTERVIEW ==
+
+1. Greet the candidate by name (from profile.yml). Briefly state your name (invent one consistent with the persona), your fictional role at the company, and the planned format.
+2. Open with a warm-up question appropriate to the interview type.
+3. Probe specifics. The candidate has detailed proof points and stories — surface them. If they make a claim, ask "what was the metric?" or "what would you do differently?" or "who pushed back, and how did you handle it?".
+4. Stay in character. Do not break the fourth wall, do not narrate that you are an AI, do not provide tips inside the dialogue.
+5. Keep turns short. Real interviewers ask one question at a time and let silence work.
+6. Allow the candidate to ask questions of you near the end.
+7. When the duration target is reached, wrap professionally: thank them, explain the (fictional) next steps, and close.
+
+== FEEDBACK MODE: {feedback_mode} ==
+
+{feedback_block}
+
+== OUTPUT FORMAT ==
+
+Respond with plain spoken text only. No markdown, no stage directions in asterisks, no bullet points. Speak the way a human interviewer speaks on a phone call. Keep each turn to 1-3 sentences unless the candidate asks you to elaborate.
+```
+
+### Persona blocks
+
+- **tough** — A skeptical senior. You probe weaknesses. You ask "and then what?" until the candidate hits the actual root cause. You do not flatter. You give the candidate space to recover but you do not rescue them.
+- **friendly** — A warm screener. You make small talk briefly, you keep the conversation flowing, you find positives in answers and use them as bridges to the next topic. You are not a pushover; you still ask the hard questions, but with a smile.
+- **technical** — A senior IC. You drill into code, system design, and tradeoffs. You ask "why did you pick X over Y?" and "what would break first under load?". You are comfortable with silence while the candidate thinks.
+- **executive** — A strategic hiring manager. You optimize for judgment and impact. You ask about ambiguity, prioritization, and what the candidate would do in their first 90 days. You are time-conscious; you steer firmly when answers wander.
+- **custom** — Use the verbatim text the user provided in the UI's "Custom persona" textarea.
+
+### Feedback blocks
+
+- **in_character** — Do not give feedback inside the interview. Stay fully in character through wrap-up. The post-call report (see below) is where the analysis lives.
+- **coach_mode** — Stay in character verbally. After every candidate answer, also emit a single short coaching note as a JSON line on a new line at the very end of your spoken response, prefixed with `<<COACH>>`. Example: `<<COACH>> {"strength":"Strong STAR Action","weakness":"Result was vague","tip":"State a metric"}`. The frontend strips the `<<COACH>>` line from speech and shows it as a sidebar pop-up. The note must be 30 words or less.
+- **break_character** — When the candidate gives a notably weak or strong answer, briefly step out of character and say so before resuming. Use the literal opener "Quick coaching note:" at the start of the break, and "Back to the interview." when you resume. Use sparingly — once per 3-4 answers maximum.
+
+---
+
+## Post-Call Feedback Report
+
+When the call ends (user clicks End, or the duration is reached and the interviewer wraps), the server makes a separate Anthropic call with the full transcript and this rubric prompt:
+
+```
+You are an interview coach. Score this candidate's mock interview against the rubric below. Be direct and specific. Cite exact lines from the transcript when noting a strength or a weakness.
+
+Rubric (1-5 each):
+- Communication clarity
+- STAR+R structure (concrete Situation/Task/Action/Result + Reflection)
+- Specificity (real metrics, named systems, named stakeholders vs. vague language)
+- Role/archetype fit (signal of seniority and archetype-relevant experience)
+- Cultural signals (curiosity, ownership, humility, collaboration)
+- Self-awareness (acknowledges tradeoffs and what they'd do differently)
+
+Output structure:
+1. Overall score (X.X/5)
+2. Top 3 strengths (each with a quoted line from the transcript)
+3. Top 3 weaknesses (each with a quoted line and a concrete fix)
+4. Stories to add to the story bank — for each strong story the candidate told that is NOT already in story-bank.md, draft a STAR+R entry ready to append
+5. Stories to develop — for each likely-question topic the candidate stumbled on, suggest the experience from cv.md they should turn into a story
+6. Recommended next prep — 3 bullets max, concrete actions
+```
+
+The full report is saved to:
+
+```
+interview-prep/sessions/{YYYY-MM-DD}-{company-slug}-{role-slug}.md
+```
+
+With this header:
+
+```markdown
+# Mock Interview — {Company} — {Role}
+
+**Date:** {YYYY-MM-DD}
+**Persona:** {persona}
+**Interview type:** {interview_type}
+**Feedback mode:** {feedback_mode}
+**Voice:** {elevenlabs_voice_name}
+**Duration:** {actual_minutes} min
+**Score:** {X.X}/5
+**Source target:** {report path or "Generic"}
+
+## Transcript
+
+[full transcript with timestamps]
+
+## Coach Report
+
+[the rubric output]
+
+## New Stories Pending
+
+[STAR+R drafts the user can promote into story-bank.md with one click in the UI]
+```
+
+The `interview-prep/sessions/` folder is **gitignored by default** (transcripts can contain sensitive employer or candidate detail). Users who want to track sessions in git can remove the gitignore line.
+
+---
+
+## Story Promotion
+
+In the debrief view, each "New Story Pending" has a "Promote to story-bank" button. When clicked, the server appends the STAR+R block to `interview-prep/story-bank.md` using the same format the `oferta` mode uses, with:
+
+```
+**Source:** Mock Interview {YYYY-MM-DD} — {Company} — {Role}
+```
+
+---
+
+## Tracker Touch
+
+If the session was targeted (linked to a row in `data/applications.md`), append a one-line note to the existing entry's notes column:
+
+```
+Mock interview {YYYY-MM-DD}: {score}/5
+```
+
+**RULE:** Never create a new tracker row from a mock interview. Only update an existing one. (Same rule as the rest of career-ops: TSV tracker additions only come from `oferta`/`auto-pipeline`.)
+
+---
+
+## Voice Track Configuration
+
+Three pipelines, controlled by `config/profile.yml` → `mock_interview.voice_track` (and overridable per-session in the UI):
+
+- **`diy`** (default if ElevenLabs key is set) — Browser Web Speech API for STT (the candidate's voice), Anthropic for the interviewer's turn, ElevenLabs TTS for the interviewer's voice. Best realism. Requires `ANTHROPIC_API_KEY` and `ELEVENLABS_API_KEY`.
+- **`system_tts`** (no-key fallback) — Browser Web Speech API for STT, Anthropic for the interviewer's turn, browser's built-in `speechSynthesis` for playback (OS voices: Apple "Samantha", Windows "David", etc.). Free, works offline for the TTS half. Voice quality varies by OS; persona variation is limited because every persona uses the same voice pool. Requires only `ANTHROPIC_API_KEY`. The setup screen auto-selects this track when `ELEVENLABS_API_KEY` is missing.
+- **`elevenlabs_cai`** — ElevenLabs Conversational AI agent with a "Custom LLM" webhook pointing at this server's `/api/cai-llm` endpoint, which forwards to Anthropic. Lower latency, supports interruption. Costs ElevenLabs minutes. Requires the user to create an agent in ElevenLabs and paste its `agent_id` into the profile. **Scaffolded only in v1** — the UI falls back to `diy`.
+
+The frontend reads the default track from `/api/config` and the user can override it in the setup screen each session.
+
+---
+
+## Configuration Surface
+
+In `config/profile.yml`:
+
+```yaml
+mock_interview:
+  voice_track: diy            # diy | system_tts | elevenlabs_cai
+  default_persona: tough
+  default_feedback_mode: in_character
+  default_voice_id: ""        # ElevenLabs voice_id; empty = first available
+  default_duration_minutes: 25
+  port: 3737
+  # elevenlabs_cai_agent_id: ""  # only used when voice_track: elevenlabs_cai
+```
+
+The user can change defaults per-session in the UI; profile values just seed the form.
+
+---
+
+## Rules
+
+- **NEVER submit, post, or share the transcript anywhere outside this machine.** The server is bound to `127.0.0.1` only.
+- **NEVER auto-create new tracker rows.** Only update existing rows when the session is targeted.
+- **NEVER write personal data into the system layer.** Persona/voice/feedback defaults live in `config/profile.yml`; archetypes and narrative live in `modes/_profile.md`.
+- **The interviewer must stay in character** unless `feedback_mode: break_character` is active.
+- **Cite when claiming.** Post-call rubric strengths/weaknesses must quote the transcript verbatim.
+- **Honor language modes.** If the user's profile says `language.modes_dir: modes/de`, conduct the interview in German. Same for `fr`, `ja`. The persona blocks above translate naturally; just instruct the model to speak the target language.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
     "scan": "node scan.mjs",
-    "gemini:eval": "node gemini-eval.mjs"
+    "gemini:eval": "node gemini-eval.mjs",
+    "mock": "node mock-interview.mjs",
+    "mock:check": "node mock-interview.mjs --check"
   },
   "keywords": [
     "ai",
@@ -32,7 +34,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@google/generative-ai": "^0.24.1",
+    "@google/generative-ai": "^0.21.0",
     "dotenv": "^16.4.5",
     "js-yaml": "^4.1.1",
     "playwright": "^1.58.1"

--- a/web/mock-interview/app.js
+++ b/web/mock-interview/app.js
@@ -1,0 +1,560 @@
+// app.js — mock interview frontend
+//
+// Three views:
+//   #setup-view   — pick target, persona, voice, etc.
+//   #call-view    — phone-style UI: push-to-talk, transcript, coach pane
+//   #debrief-view — coach report and story-promote buttons
+//
+// Browser STT: Web Speech API (Chrome/Edge). Audio playback: <audio>.
+// Server contract: see mock-interview.mjs.
+
+const $ = (sel) => document.querySelector(sel);
+const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+
+const state = {
+  config: null,
+  voices: [],
+  targets: [],
+  sessionId: null,
+  startTimeMs: 0,
+  timerInterval: null,
+  voiceTrack: 'diy',     // 'diy' | 'system_tts'
+  voiceId: '',           // ElevenLabs voice_id when voiceTrack === 'diy'
+  osVoiceName: '',       // SpeechSynthesisVoice.name when voiceTrack === 'system_tts'
+  feedbackMode: 'in_character',
+  recognition: null,
+  recognizing: false,
+  pendingTranscript: '',
+  callContext: '',
+  newStories: [],
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Setup view
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function loadSetup() {
+  const cfgRes = await fetch('/api/config');
+  state.config = await cfgRes.json();
+
+  // Key warnings
+  const warn = $('#key-warnings');
+  warn.innerHTML = '';
+  if (!state.config.has_anthropic_key) {
+    warn.insertAdjacentHTML('beforeend', `<div class="errbox">ANTHROPIC_API_KEY is missing from <code>.env</code>. The interviewer can't think without it.</div>`);
+  }
+  if (!state.config.has_elevenlabs_key) {
+    warn.insertAdjacentHTML('beforeend', `<div class="infobox">No <code>ELEVENLABS_API_KEY</code> in <code>.env</code>. Defaulting to System voice (free, uses your OS voices).</div>`);
+  }
+  if (state.config.defaults?.voice_track === 'elevenlabs_cai') {
+    warn.insertAdjacentHTML('beforeend', `<div class="infobox">Voice track is set to <code>elevenlabs_cai</code>, but the v1 server falls back to the DIY pipeline for now.</div>`);
+  }
+
+  // Defaults
+  const d = state.config.defaults || {};
+  $('#persona').value = d.default_persona || 'tough';
+  $('#feedback-mode').value = d.default_feedback_mode || 'in_character';
+  $('#duration').value = d.default_duration_minutes || 25;
+
+  // Targets
+  const tRes = await fetch('/api/targets');
+  const t = await tRes.json();
+  state.targets = t.targets || [];
+  const sel = $('#target-id');
+  sel.innerHTML = '';
+  if (state.targets.length === 0) {
+    sel.innerHTML = `<option value="">(no reports/ files yet — switch to Generic)</option>`;
+  } else {
+    for (const tg of state.targets) {
+      const score = tg.score ? ` · ${tg.score}/5` : '';
+      sel.insertAdjacentHTML('beforeend',
+        `<option value="${tg.id}" data-company="${esc(tg.company)}" data-role="${esc(tg.role)}">#${tg.num} · ${esc(tg.company)} — ${esc(tg.role)}${score}</option>`);
+    }
+  }
+  updateTargetNote();
+
+  // ElevenLabs voices
+  const vRes = await fetch('/api/voices');
+  const v = await vRes.json();
+  state.voices = v.voices || [];
+  const vSel = $('#voice-id');
+  vSel.innerHTML = '';
+  if (state.voices.length === 0) {
+    vSel.innerHTML = `<option value="">(no voices — check ElevenLabs key)</option>`;
+  } else {
+    for (const vc of state.voices) {
+      const tags = Object.entries(vc.labels || {}).map(([k, v]) => `${k}:${v}`).join(', ');
+      vSel.insertAdjacentHTML('beforeend',
+        `<option value="${vc.voice_id}">${esc(vc.name)}${tags ? ` — ${esc(tags)}` : ''}</option>`);
+    }
+    if (d.default_voice_id && state.voices.find(v => v.voice_id === d.default_voice_id)) {
+      vSel.value = d.default_voice_id;
+    }
+  }
+
+  // OS voices (system_tts track)
+  populateSystemVoices();
+  if (typeof window.speechSynthesis !== 'undefined') {
+    window.speechSynthesis.addEventListener?.('voiceschanged', populateSystemVoices);
+  }
+
+  // Voice-track selector — pick a sensible default
+  const trackSel = $('#voice-track');
+  const profileTrack = d.voice_track || 'diy';
+  // Auto-fallback to system_tts when ElevenLabs key is missing or no voices loaded
+  const initialTrack = (!state.config.has_elevenlabs_key || state.voices.length === 0)
+    ? 'system_tts'
+    : (profileTrack === 'elevenlabs_cai' ? 'diy' : profileTrack);
+  trackSel.value = initialTrack;
+  applyVoiceTrack(initialTrack);
+  trackSel.addEventListener('change', () => applyVoiceTrack(trackSel.value));
+
+  // Wire events
+  $('#target-mode').addEventListener('change', onTargetModeChange);
+  $('#target-id').addEventListener('change', updateTargetNote);
+  $('#persona').addEventListener('change', () => {
+    $('#custom-persona-field').classList.toggle('hidden', $('#persona').value !== 'custom');
+  });
+  $('#preview-voice-btn').addEventListener('click', previewVoice);
+  $('#preview-sys-voice-btn').addEventListener('click', previewSystemVoice);
+  $('#start-btn').addEventListener('click', startInterview);
+
+  // Enable start
+  $('#start-btn').disabled = false;
+  $('#start-hint').textContent = 'Ready when you are.';
+}
+
+function onTargetModeChange() {
+  const mode = $('#target-mode').value;
+  $('#targeted-fields').classList.toggle('hidden', mode !== 'targeted');
+  $('#generic-fields').classList.toggle('hidden', mode !== 'generic');
+}
+
+function updateTargetNote() {
+  const sel = $('#target-id');
+  const opt = sel.options[sel.selectedIndex];
+  const note = $('#target-note');
+  if (!opt || !opt.value) { note.textContent = ''; return; }
+  const company = opt.dataset.company || '';
+  const role = opt.dataset.role || '';
+  note.textContent = `Will hydrate the interviewer with Block A + Block F from this report${company ? ` (${company}${role ? ' — ' + role : ''})` : ''}.`;
+}
+
+function applyVoiceTrack(track) {
+  $('#el-voice-block').classList.toggle('hidden', track !== 'diy');
+  $('#sys-voice-block').classList.toggle('hidden', track !== 'system_tts');
+  const note = $('#voice-track-note');
+  if (track === 'system_tts') {
+    note.textContent = 'No API key needed. The interviewer will speak using your operating system\u2019s built-in voices. Quality varies by OS; persona variation will be limited.';
+  } else {
+    note.textContent = 'Uses ElevenLabs for natural human-sounding voices. Different voices per persona.';
+  }
+}
+
+function populateSystemVoices() {
+  const sel = $('#sys-voice-id');
+  if (!sel) return;
+  const synth = window.speechSynthesis;
+  if (!synth) {
+    sel.innerHTML = `<option value="">(this browser doesn't support speechSynthesis)</option>`;
+    return;
+  }
+  const voices = synth.getVoices() || [];
+  if (voices.length === 0) {
+    sel.innerHTML = `<option value="">(loading OS voices… click again in a moment)</option>`;
+    return;
+  }
+  // Prefer English-locale voices first, but show all so the user can pick another language.
+  voices.sort((a, b) => {
+    const ae = a.lang?.startsWith('en') ? 0 : 1;
+    const be = b.lang?.startsWith('en') ? 0 : 1;
+    return ae - be || a.name.localeCompare(b.name);
+  });
+  const prev = sel.value;
+  sel.innerHTML = '';
+  for (const v of voices) {
+    sel.insertAdjacentHTML('beforeend',
+      `<option value="${esc(v.name)}">${esc(v.name)}${v.lang ? ` — ${esc(v.lang)}` : ''}${v.default ? ' (default)' : ''}</option>`);
+  }
+  if (prev && voices.some(v => v.name === prev)) sel.value = prev;
+}
+
+async function previewVoice() {
+  const voiceId = $('#voice-id').value;
+  if (!voiceId) return alert('Pick a voice first.');
+  const btn = $('#preview-voice-btn');
+  btn.disabled = true; btn.textContent = 'Loading…';
+  try {
+    const r = await fetch('/api/voice-preview', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ voiceId, text: 'Hi, this is your mock interviewer. Let\u2019s get started in a moment.' }),
+    });
+    if (!r.ok) throw new Error(await r.text());
+    const blob = await r.blob();
+    const audio = $('#preview-audio');
+    audio.src = URL.createObjectURL(blob);
+    await audio.play();
+  } catch (e) {
+    alert('Preview failed: ' + e.message);
+  } finally {
+    btn.disabled = false; btn.textContent = 'Preview voice';
+  }
+}
+
+async function previewSystemVoice() {
+  const name = $('#sys-voice-id').value;
+  const synth = window.speechSynthesis;
+  if (!synth) return alert('speechSynthesis not supported here. Try Chrome, Edge, or Safari.');
+  synth.cancel();
+  const u = new SpeechSynthesisUtterance('Hi, this is your mock interviewer. Let\u2019s get started in a moment.');
+  if (name) {
+    const v = (synth.getVoices() || []).find(x => x.name === name);
+    if (v) u.voice = v;
+  }
+  u.rate = 1.0;
+  u.pitch = 1.0;
+  synth.speak(u);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Start interview
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function startInterview() {
+  const mode = $('#target-mode').value;
+  const persona = $('#persona').value;
+  const feedbackMode = $('#feedback-mode').value;
+  const interviewType = $('#interview-type').value;
+  const voiceTrack = $('#voice-track').value;
+  const voiceId = $('#voice-id').value;
+  const osVoiceName = $('#sys-voice-id').value;
+  const durationMinutes = parseInt($('#duration').value, 10) || 25;
+  const customPersona = $('#custom-persona').value;
+
+  if (voiceTrack === 'system_tts' && !window.speechSynthesis) {
+    alert('Your browser doesn\u2019t support speechSynthesis. Try Chrome, Edge, or Safari, or switch to ElevenLabs.');
+    return;
+  }
+  if (voiceTrack === 'diy' && !voiceId) {
+    alert('Pick an ElevenLabs voice, or switch the voice track to System voice.');
+    return;
+  }
+
+  let body = { persona, feedbackMode, interviewType, voiceId, durationMinutes, customPersona, voiceTrack };
+  if (mode === 'targeted') {
+    const sel = $('#target-id');
+    const opt = sel.options[sel.selectedIndex];
+    if (!opt || !opt.value) { alert('Pick a report or switch to Generic.'); return; }
+    body.targetId = opt.value;
+    body.company = opt.dataset.company || '';
+    body.role = opt.dataset.role || '';
+  } else {
+    body.role = $('#generic-role').value.trim();
+    body.company = $('#generic-company').value.trim();
+    body.industry = $('#generic-industry').value.trim();
+    if (!body.role) { alert('Enter a role.'); return; }
+  }
+
+  state.voiceTrack = voiceTrack;
+  state.voiceId = voiceId;
+  state.osVoiceName = osVoiceName;
+  state.feedbackMode = feedbackMode;
+  state.callContext = body.targetId
+    ? `${body.company}${body.role ? ' — ' + body.role : ''} · ${persona}`
+    : `${body.role}${body.company ? ' @ ' + body.company : ''} · ${persona}`;
+
+  $('#start-btn').disabled = true;
+  $('#start-hint').textContent = 'Hydrating interviewer…';
+
+  let resp;
+  try {
+    const r = await fetch('/api/session/start', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    resp = await r.json();
+    if (!r.ok) throw new Error(resp.error || 'Server error');
+  } catch (e) {
+    alert('Could not start session: ' + e.message);
+    $('#start-btn').disabled = false;
+    $('#start-hint').textContent = 'Ready when you are.';
+    return;
+  }
+
+  state.sessionId = resp.sessionId;
+  state.startTimeMs = Date.now();
+  $('#setup-view').classList.add('hidden');
+  $('#call-view').classList.remove('hidden');
+  $('#call-context').textContent = state.callContext;
+  $('#avatar').textContent = avatarFor(persona);
+
+  startTimer();
+  setupRecognition();
+  $('#hangup-btn').addEventListener('click', endCall);
+
+  // Play the opener
+  await speak(resp.openingTurn.speech, 'interviewer');
+  if (resp.openingTurn.coach) showCoachNote(resp.openingTurn.coach);
+}
+
+function avatarFor(persona) {
+  return ({ tough: 'TS', friendly: 'FR', technical: 'TC', executive: 'EX', custom: 'IV' })[persona] || 'IV';
+}
+
+function startTimer() {
+  state.timerInterval = setInterval(() => {
+    const sec = Math.floor((Date.now() - state.startTimeMs) / 1000);
+    const m = String(Math.floor(sec / 60)).padStart(2, '0');
+    const s = String(sec % 60).padStart(2, '0');
+    $('#timer').textContent = `${m}:${s}`;
+  }, 500);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Speech recognition (Web Speech API)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function setupRecognition() {
+  const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+  if (!SR) {
+    setStatus('This browser doesn\u2019t support Web Speech API. Try Chrome or Edge.', 'bad');
+    return;
+  }
+  const rec = new SR();
+  rec.continuous = true;
+  rec.interimResults = true;
+  rec.lang = 'en-US';
+  rec.onresult = (e) => {
+    let interim = '', finalT = '';
+    for (let i = e.resultIndex; i < e.results.length; i++) {
+      const r = e.results[i];
+      if (r.isFinal) finalT += r[0].transcript;
+      else interim += r[0].transcript;
+    }
+    if (finalT) state.pendingTranscript += finalT + ' ';
+    setStatus(`Listening… ${state.pendingTranscript}${interim}`, 'listening');
+  };
+  rec.onend = () => { state.recognizing = false; };
+  rec.onerror = (e) => { console.warn('STT error:', e); };
+  state.recognition = rec;
+
+  const ptt = $('#ptt-btn');
+  ptt.disabled = false;
+  const startTalk = (e) => { e.preventDefault(); beginTalk(); };
+  const endTalk   = (e) => { e.preventDefault(); finishTalk(); };
+  ptt.addEventListener('mousedown', startTalk);
+  ptt.addEventListener('mouseup', endTalk);
+  ptt.addEventListener('mouseleave', (e) => { if (state.recognizing) endTalk(e); });
+  ptt.addEventListener('touchstart', startTalk, { passive: false });
+  ptt.addEventListener('touchend', endTalk);
+
+  document.addEventListener('keydown', (e) => {
+    if (e.code === 'Space' && !e.repeat && document.activeElement.tagName !== 'TEXTAREA' && document.activeElement.tagName !== 'INPUT') {
+      e.preventDefault(); beginTalk();
+    }
+  });
+  document.addEventListener('keyup', (e) => {
+    if (e.code === 'Space') { e.preventDefault(); finishTalk(); }
+  });
+}
+
+function beginTalk() {
+  if (state.recognizing || !state.recognition) return;
+  state.pendingTranscript = '';
+  try { state.recognition.start(); state.recognizing = true; } catch {}
+  $('#ptt-btn').classList.add('active');
+  $('#ptt-btn').innerHTML = 'RELEASE<br/>TO SEND';
+  setStatus('Listening…', 'listening');
+}
+
+async function finishTalk() {
+  if (!state.recognizing) return;
+  state.recognizing = false;
+  try { state.recognition.stop(); } catch {}
+  $('#ptt-btn').classList.remove('active');
+  $('#ptt-btn').innerHTML = 'HOLD<br/>TO TALK';
+  // Wait briefly for trailing final result
+  await new Promise(r => setTimeout(r, 400));
+  const text = state.pendingTranscript.trim();
+  state.pendingTranscript = '';
+  if (!text) { setStatus('Didn\u2019t catch that. Try again.', 'warn'); return; }
+  await sendTurn(text);
+}
+
+async function sendTurn(candidateText) {
+  appendTurn('candidate', candidateText);
+  setStatus('Interviewer thinking…', 'speaking');
+  $('#ptt-btn').disabled = true;
+  try {
+    const r = await fetch(`/api/session/${state.sessionId}/turn`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ userTranscript: candidateText }),
+    });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.error || 'turn failed');
+    if (j.coach) showCoachNote(j.coach);
+    await speak(j.speech, 'interviewer');
+  } catch (e) {
+    setStatus('Error: ' + e.message, 'bad');
+  } finally {
+    $('#ptt-btn').disabled = false;
+  }
+}
+
+async function speak(text, who) {
+  appendTurn(who, text);
+  if (!text) return;
+  setStatus('Interviewer speaking…', 'speaking');
+  try {
+    if (state.voiceTrack === 'system_tts') {
+      await speakWithSystemTTS(text, state.osVoiceName);
+    } else {
+      const r = await fetch(`/api/session/${state.sessionId}/tts`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ text, voiceId: state.voiceId }),
+      });
+      if (!r.ok) throw new Error(await r.text());
+      const blob = await r.blob();
+      const audio = $('#reply-audio');
+      audio.src = URL.createObjectURL(blob);
+      await audio.play();
+      await new Promise(res => { audio.onended = res; });
+    }
+  } catch (e) {
+    setStatus('TTS error: ' + e.message, 'bad');
+  } finally {
+    setStatus('Hold the button to reply.', '');
+  }
+}
+
+function speakWithSystemTTS(text, voiceName) {
+  return new Promise((resolve) => {
+    const synth = window.speechSynthesis;
+    if (!synth) return resolve();
+    synth.cancel();
+    const u = new SpeechSynthesisUtterance(text);
+    if (voiceName) {
+      const v = (synth.getVoices() || []).find(x => x.name === voiceName);
+      if (v) u.voice = v;
+    }
+    u.rate = 1.0;
+    u.pitch = 1.0;
+    u.onend = () => resolve();
+    u.onerror = () => resolve();
+    synth.speak(u);
+  });
+}
+
+function appendTurn(role, text) {
+  const t = $('#transcript');
+  const div = document.createElement('div');
+  div.className = `turn ${role}`;
+  div.innerHTML = `<div class="who">${role === 'interviewer' ? 'Interviewer' : 'You'}</div><div>${esc(text)}</div>`;
+  t.appendChild(div);
+  t.scrollTop = t.scrollHeight;
+}
+
+function showCoachNote(coach) {
+  $('#coach-empty')?.classList.add('hidden');
+  const card = document.createElement('div');
+  card.className = 'coach-note';
+  const parts = [];
+  if (coach.strength) parts.push(`<span class="label">+ Strength</span>${esc(coach.strength)}`);
+  if (coach.weakness) parts.push(`<span class="label">! Weakness</span>${esc(coach.weakness)}`);
+  if (coach.tip)      parts.push(`<span class="label">→ Tip</span>${esc(coach.tip)}`);
+  if (coach.raw)      parts.push(esc(coach.raw));
+  card.innerHTML = parts.join('<br/>');
+  $('#coach-notes').prepend(card);
+}
+
+function setStatus(text, cls) {
+  const el = $('#status-line');
+  el.textContent = text;
+  el.className = 'status-line ' + (cls || '');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// End call → debrief
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function endCall() {
+  if (state.recognition && state.recognizing) try { state.recognition.stop(); } catch {}
+  clearInterval(state.timerInterval);
+  setStatus('Generating coach report…', 'speaking');
+  $('#hangup-btn').disabled = true;
+  $('#ptt-btn').disabled = true;
+  const minutes = Math.max(1, Math.round((Date.now() - state.startTimeMs) / 60000));
+  try {
+    const r = await fetch(`/api/session/${state.sessionId}/end`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ actualMinutes: minutes }),
+    });
+    const j = await r.json();
+    if (!r.ok) throw new Error(j.error || 'end failed');
+    state.newStories = j.newStories || [];
+    showDebrief(j);
+  } catch (e) {
+    alert('Could not generate debrief: ' + e.message);
+  }
+}
+
+function showDebrief(j) {
+  $('#call-view').classList.add('hidden');
+  $('#debrief-view').classList.remove('hidden');
+  $('#session-file').textContent = j.sessionFile || '(saved)';
+  $('#report').textContent = j.reportMarkdown || '(empty)';
+  const list = $('#stories-list');
+  list.innerHTML = '';
+  if (!state.newStories.length) {
+    list.innerHTML = `<p class="subtle">No new stories drafted from this session.</p>`;
+  } else {
+    state.newStories.forEach((s, i) => {
+      const card = document.createElement('div');
+      card.className = 'story-card';
+      card.innerHTML = `
+        <div class="title">${esc(s.title)}</div>
+        <div class="body">${esc(s.body)}</div>
+        <button data-idx="${i}" class="primary">Promote to story-bank</button>
+        <span class="subtle promote-status"></span>`;
+      list.appendChild(card);
+    });
+    list.addEventListener('click', async (e) => {
+      const btn = e.target.closest('button[data-idx]');
+      if (!btn) return;
+      const idx = parseInt(btn.dataset.idx, 10);
+      btn.disabled = true; btn.textContent = 'Adding…';
+      try {
+        const r = await fetch(`/api/session/${state.sessionId}/promote-story`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ storyIndex: idx }),
+        });
+        const j2 = await r.json();
+        if (!r.ok) throw new Error(j2.error || 'promote failed');
+        btn.textContent = 'Added ✓';
+        btn.parentElement.querySelector('.promote-status').textContent = ' appended to ' + j2.file.replace(/^.*\//, '');
+      } catch (e) {
+        btn.disabled = false; btn.textContent = 'Promote to story-bank';
+        alert('Failed: ' + e.message);
+      }
+    });
+  }
+  $('#another-btn').addEventListener('click', () => location.reload());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// utilities
+// ─────────────────────────────────────────────────────────────────────────────
+
+function esc(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c => ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[c]));
+}
+
+loadSetup().catch(e => {
+  document.body.innerHTML = `<div class="container"><div class="errbox">Could not load setup: ${esc(e.message)}</div></div>`;
+});

--- a/web/mock-interview/index.html
+++ b/web/mock-interview/index.html
@@ -1,0 +1,283 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>career-ops · mock interview</title>
+<style>
+  :root {
+    --bg: #0c0d10;
+    --panel: #14161b;
+    --panel-2: #1a1d24;
+    --border: #232732;
+    --text: #e8eaf0;
+    --text-dim: #8b93a7;
+    --accent: #5b9cff;
+    --good: #4ade80;
+    --warn: #fbbf24;
+    --bad: #f87171;
+    --radius: 10px;
+    --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --sans: -apple-system, system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; padding: 0; min-height: 100vh;
+    background: var(--bg); color: var(--text);
+    font: 14px/1.5 var(--sans);
+  }
+  a { color: var(--accent); }
+  button {
+    font: inherit; color: inherit; background: var(--panel-2); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 9px 14px; cursor: pointer;
+  }
+  button:hover { background: #20242e; }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+  button.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+  button.primary:hover { background: #4a8cf0; }
+  button.danger { background: #c0392b; color: #fff; border-color: #c0392b; }
+  input, select, textarea {
+    width: 100%; font: inherit; color: inherit;
+    background: var(--panel-2); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 9px 10px;
+  }
+  textarea { resize: vertical; font-family: var(--sans); }
+  label { display: block; margin: 0 0 4px 0; color: var(--text-dim); font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; }
+  .field { margin-bottom: 14px; }
+  .row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  .row3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+  .panel {
+    background: var(--panel); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 18px;
+  }
+  .container { max-width: 880px; margin: 40px auto; padding: 0 20px; }
+  h1 { font-size: 22px; margin: 0 0 4px 0; }
+  h2 { font-size: 16px; margin: 24px 0 10px 0; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
+  .subtle { color: var(--text-dim); font-size: 13px; }
+  .hidden { display: none !important; }
+  .badge { display: inline-block; padding: 2px 8px; font-size: 11px; border-radius: 999px; background: var(--panel-2); border: 1px solid var(--border); color: var(--text-dim); }
+  .badge.good { color: var(--good); border-color: rgba(74,222,128,0.3); }
+  .badge.warn { color: var(--warn); border-color: rgba(251,191,36,0.3); }
+  .badge.bad  { color: var(--bad);  border-color: rgba(248,113,113,0.3); }
+
+  /* Call view */
+  .call-shell { display: grid; grid-template-columns: 1fr 280px; gap: 18px; min-height: 60vh; }
+  .call-main { display: flex; flex-direction: column; }
+  .call-header { display: flex; align-items: center; justify-content: space-between; padding: 14px 18px; border-bottom: 1px solid var(--border); }
+  .call-header .who { display: flex; align-items: center; gap: 12px; }
+  .avatar { width: 44px; height: 44px; border-radius: 50%; background: linear-gradient(135deg, #5b9cff, #b864ff); display: grid; place-items: center; font-weight: 600; }
+  .timer { font-family: var(--mono); color: var(--text-dim); }
+  .transcript { flex: 1; overflow-y: auto; padding: 18px; max-height: 60vh; }
+  .turn { margin: 0 0 12px 0; padding: 10px 12px; border-radius: 10px; max-width: 90%; }
+  .turn.interviewer { background: var(--panel-2); }
+  .turn.candidate { background: rgba(91, 156, 255, 0.12); border: 1px solid rgba(91, 156, 255, 0.25); margin-left: auto; }
+  .turn .who { font-size: 11px; color: var(--text-dim); text-transform: uppercase; margin-bottom: 4px; }
+  .controls {
+    display: flex; align-items: center; justify-content: center; gap: 14px;
+    padding: 18px; border-top: 1px solid var(--border);
+  }
+  .ptt {
+    width: 96px; height: 96px; border-radius: 50%; border: none;
+    background: linear-gradient(135deg, #5b9cff, #4a8cf0); color: #fff;
+    font-size: 13px; font-weight: 600; letter-spacing: 0.05em; cursor: pointer;
+    box-shadow: 0 6px 20px rgba(91, 156, 255, 0.4);
+    transition: transform 80ms;
+  }
+  .ptt.active { background: linear-gradient(135deg, #ef4444, #dc2626); transform: scale(0.95); box-shadow: 0 6px 20px rgba(239, 68, 68, 0.45); }
+  .ptt:disabled { opacity: 0.5; cursor: wait; }
+  .hangup { width: 56px; height: 56px; border-radius: 50%; background: #c0392b; border: none; color: #fff; font-size: 18px; cursor: pointer; }
+  .coach-pane { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 16px; overflow-y: auto; }
+  .coach-pane h3 { margin: 0 0 8px 0; font-size: 12px; color: var(--text-dim); text-transform: uppercase; }
+  .coach-note { background: rgba(251, 191, 36, 0.08); border: 1px solid rgba(251, 191, 36, 0.25); padding: 10px; border-radius: 8px; margin-bottom: 10px; font-size: 13px; }
+  .coach-note .label { font-size: 10px; text-transform: uppercase; color: var(--warn); margin-right: 6px; letter-spacing: 0.05em; }
+  .status-line { padding: 8px 18px; font-size: 12px; color: var(--text-dim); border-top: 1px solid var(--border); }
+  .listening { color: var(--good); }
+  .speaking { color: var(--accent); }
+
+  /* Debrief view */
+  .debrief { padding: 18px; }
+  .report { background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--radius); padding: 18px; white-space: pre-wrap; font-size: 13px; line-height: 1.6; max-height: 50vh; overflow-y: auto; }
+  .story-card { background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px; margin-bottom: 12px; }
+  .story-card .title { font-weight: 600; margin-bottom: 6px; }
+  .story-card .body { white-space: pre-wrap; font-size: 13px; color: var(--text-dim); margin-bottom: 10px; }
+
+  .errbox { background: rgba(248, 113, 113, 0.1); border: 1px solid rgba(248, 113, 113, 0.3); color: #fca5a5; padding: 10px 14px; border-radius: var(--radius); margin-bottom: 12px; font-size: 13px; }
+  .infobox { background: rgba(91, 156, 255, 0.1); border: 1px solid rgba(91, 156, 255, 0.3); color: #cfe0ff; padding: 10px 14px; border-radius: var(--radius); margin-bottom: 12px; font-size: 13px; }
+</style>
+</head>
+<body>
+
+<div id="setup-view" class="container">
+  <div class="panel">
+    <h1>Mock Interview</h1>
+    <p class="subtle">Voice-based practice run powered by your career-ops profile, story bank, and (optionally) a specific evaluation report.</p>
+    <div id="key-warnings"></div>
+
+    <h2>Target</h2>
+    <div class="field">
+      <label>What are you preparing for?</label>
+      <select id="target-mode">
+        <option value="targeted">Targeted — link to one of my evaluation reports</option>
+        <option value="generic">Generic — by role + industry, no specific company</option>
+      </select>
+    </div>
+
+    <div id="targeted-fields">
+      <div class="field">
+        <label>Pick a report</label>
+        <select id="target-id">
+          <option value="">Loading…</option>
+        </select>
+        <p class="subtle" id="target-note"></p>
+      </div>
+    </div>
+
+    <div id="generic-fields" class="hidden">
+      <div class="row">
+        <div class="field">
+          <label>Role</label>
+          <input id="generic-role" placeholder="Senior Backend Engineer" />
+        </div>
+        <div class="field">
+          <label>Company (optional)</label>
+          <input id="generic-company" placeholder="Acme" />
+        </div>
+      </div>
+      <div class="field">
+        <label>Industry</label>
+        <input id="generic-industry" placeholder="fintech, healthtech, consumer SaaS, …" />
+      </div>
+    </div>
+
+    <h2>Interviewer</h2>
+    <div class="row">
+      <div class="field">
+        <label>Persona</label>
+        <select id="persona">
+          <option value="tough">Tough — skeptical senior, probes weaknesses</option>
+          <option value="friendly">Friendly — warm screener, keeps it flowing</option>
+          <option value="technical">Technical — drills code, system design, tradeoffs</option>
+          <option value="executive">Executive — strategic hiring manager, time-conscious</option>
+          <option value="custom">Custom — write your own</option>
+        </select>
+      </div>
+      <div class="field">
+        <label>Interview type</label>
+        <select id="interview-type">
+          <option value="phone-screen">Phone screen</option>
+          <option value="behavioral">Behavioral</option>
+          <option value="technical-deep-dive">Technical deep-dive</option>
+          <option value="hiring-manager">Hiring manager</option>
+          <option value="executive">Executive round</option>
+        </select>
+      </div>
+    </div>
+    <div class="field hidden" id="custom-persona-field">
+      <label>Custom persona</label>
+      <textarea id="custom-persona" rows="3" placeholder="Describe the interviewer's style, background, and what they probe for."></textarea>
+    </div>
+
+    <div class="row">
+      <div class="field">
+        <label>Feedback mode</label>
+        <select id="feedback-mode">
+          <option value="in_character">In-character — feedback only after the call</option>
+          <option value="coach_mode">Coach mode — sidebar coach notes after each answer</option>
+          <option value="break_character">Break character — interviewer pauses to coach occasionally</option>
+        </select>
+      </div>
+      <div class="field">
+        <label>Duration target (minutes)</label>
+        <input id="duration" type="number" min="5" max="90" value="25" />
+      </div>
+    </div>
+
+    <h2>Voice</h2>
+    <div class="field">
+      <label>Voice track</label>
+      <select id="voice-track">
+        <option value="diy">ElevenLabs — natural human voices (requires API key)</option>
+        <option value="system_tts">System voice — free, uses your OS voices, lower realism</option>
+      </select>
+      <p class="subtle" id="voice-track-note"></p>
+    </div>
+    <div id="el-voice-block">
+      <div class="row">
+        <div class="field">
+          <label>ElevenLabs voice</label>
+          <select id="voice-id"><option value="">Loading…</option></select>
+        </div>
+        <div class="field" style="display: flex; align-items: end;">
+          <button id="preview-voice-btn" type="button">Preview voice</button>
+        </div>
+      </div>
+    </div>
+    <div id="sys-voice-block" class="hidden">
+      <div class="row">
+        <div class="field">
+          <label>System voice</label>
+          <select id="sys-voice-id"><option value="">Loading…</option></select>
+        </div>
+        <div class="field" style="display: flex; align-items: end;">
+          <button id="preview-sys-voice-btn" type="button">Preview voice</button>
+        </div>
+      </div>
+    </div>
+    <audio id="preview-audio" preload="none"></audio>
+
+    <div style="margin-top: 24px; display: flex; gap: 12px; align-items: center;">
+      <button id="start-btn" class="primary" disabled>Start interview →</button>
+      <span class="subtle" id="start-hint">Loading…</span>
+    </div>
+  </div>
+</div>
+
+<div id="call-view" class="container hidden">
+  <div class="panel" style="padding: 0;">
+    <div class="call-header">
+      <div class="who">
+        <div class="avatar" id="avatar">IV</div>
+        <div>
+          <div id="interviewer-label" style="font-weight: 600;">Interviewer</div>
+          <div class="subtle" id="call-context">—</div>
+        </div>
+      </div>
+      <div class="timer" id="timer">00:00</div>
+    </div>
+    <div class="call-shell">
+      <div class="call-main">
+        <div class="transcript" id="transcript"></div>
+        <div class="status-line" id="status-line">Tap and hold the big button to speak. Release to send.</div>
+        <div class="controls">
+          <button class="hangup" id="hangup-btn" title="End interview">✕</button>
+          <button class="ptt" id="ptt-btn" disabled>HOLD<br/>TO TALK</button>
+        </div>
+      </div>
+      <div class="coach-pane" id="coach-pane">
+        <h3>Coach pane</h3>
+        <div id="coach-notes"></div>
+        <p class="subtle" id="coach-empty">Notes appear here in coach mode after each answer.</p>
+      </div>
+    </div>
+  </div>
+  <audio id="reply-audio" preload="none"></audio>
+</div>
+
+<div id="debrief-view" class="container hidden">
+  <div class="panel">
+    <h1>Debrief</h1>
+    <p class="subtle">Saved to <code id="session-file">interview-prep/sessions/…</code></p>
+    <h2>Coach report</h2>
+    <div class="report" id="report"></div>
+    <h2>New stories pending</h2>
+    <p class="subtle">These STAR+R stories were drafted from your transcript. Promote any you want to keep.</p>
+    <div id="stories-list"></div>
+    <div style="margin-top: 24px;">
+      <button id="another-btn" class="primary">Run another mock interview</button>
+    </div>
+  </div>
+</div>
+
+<script src="/mock-interview/app.js" type="module"></script>
+</body>
+</html>


### PR DESCRIPTION
## What does this PR do?

Adds a new `/career-ops mock` command that launches a local web app for practicing phone-style interviews. The browser handles speech-to-text via the Web Speech API; the server proxies Anthropic for the interviewer's responses and ElevenLabs for voice synthesis (with a no-key fallback to the browser's built-in `speechSynthesis`). Hydrates the interviewer with the user's existing career-ops files (`cv.md`, profile, story bank, and optionally a specific evaluation report's Block F) so practice sessions are personalized to who you are and the role you're prepping for.

## Related issue

Closes #509

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Details

**New command:** `/career-ops mock` (also `/career-ops-mock` for OpenCode and Gemini CLI).

**External API dependencies** (declared per `CONTRIBUTING.md`):

- `ANTHROPIC_API_KEY` — required.
- `ELEVENLABS_API_KEY` — optional (only used by the `diy` and `elevenlabs_cai` voice tracks; `system_tts` works without it).

**Voice tracks** — selectable per session in the UI, default seeded from `config/profile.yml`:

- `diy` (default when both keys are set): browser STT + Anthropic + ElevenLabs TTS. Best realism, distinct voice per persona.
- `system_tts` (no-key fallback): browser STT + Anthropic + browser `speechSynthesis` (OS voices). Free, lower realism. The setup screen auto-selects this when `ELEVENLABS_API_KEY` is missing.
- `elevenlabs_cai`: scaffolded only — the v1 UI falls back to `diy` and shows an info banner.

**Customization** — interviewer persona (`tough` / `friendly` / `technical` / `executive` / `custom`), interview type (`phone-screen` / `behavioral` / `technical-deep-dive` / `hiring-manager` / `executive`), feedback mode (`in_character` / `coach_mode` / `break_character`), voice, and duration target. All overridable per session.

**Output** — full transcript and coach report saved to `interview-prep/sessions/{date}-{company}-{role}.md` (gitignored). STAR+R stories the candidate told that aren't already in `story-bank.md` come back as drafts the user can promote to the bank with one click.

**Out of scope / explicitly not changed**

- No existing scoring, evaluation, scan, batch, PDF, or apply logic touched.
- No platform scraping; the mode only reads files that already exist locally.
- No auto-submit anywhere — purely a practice tool.

## How to try it

```sh
cp .env.example .env   # add ANTHROPIC_API_KEY (required) and ELEVENLABS_API_KEY (optional)
npm run mock           # boots the server and opens the browser
npm run mock:check     # boots, hits /api/config, exits — useful for CI
```

The setup screen automatically lists targets from `reports/` and falls back to `system_tts` voices when no ElevenLabs key is set. Recommended browsers: Chrome or Edge (Web Speech API).

## Files added / changed

**New:**
- `mock-interview.mjs` — launcher and HTTP server (Node built-ins only, no Express)
- `modes/mock-interview.md` — mode behavioral spec
- `web/mock-interview/index.html`, `web/mock-interview/app.js` — single-page UI
- `interview-prep/sessions/.gitkeep`
- `.opencode/commands/career-ops-mock.md`
- `.gemini/commands/career-ops-mock.toml`

**Modified:**
- `.env.example` — documents `ANTHROPIC_API_KEY` and `ELEVENLABS_API_KEY`
- `.gitignore` — ignores `interview-prep/sessions/*` (keeps `.gitkeep`)
- `package.json` — adds `mock` and `mock:check` scripts
- `CLAUDE.md` — skill modes table, main files table, OpenCode and Gemini command tables
- `DATA_CONTRACT.md` — adds `interview-prep/sessions/*` to user layer and `modes/mock-interview.md`, `web/mock-interview/*` to system layer
- `.claude/skills/career-ops/SKILL.md` — adds `mock` / `mock-interview` to routing
- `config/profile.example.yml` — new `mock_interview:` block

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [ ] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice-based mock interview with configurable persona and feedback modes.
  * Web interface supporting speech-to-text and text-to-speech for realistic practice sessions.
  * Coach report generation and story promotion for capturing interview insights.

* **Documentation**
  * Added mock interview mode documentation and setup guides.

* **Chores**
  * Updated environment and configuration templates for mock interview settings.
  * Added npm scripts for running mock interview operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->