### PR TITLE
feat(scan): add Workday API support

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -40,6 +40,19 @@ function detectApi(company) {
     return { type: 'greenhouse', url: company.api };
   }
 
+  // Workday: explicit api field with /wday/cxs/{tenant}/{site}/jobs pattern
+  if (company.api) {
+    const wd = company.api.match(/^(https?:\/\/[^/]+)\/wday\/cxs\/[^/]+\/([^/]+)\/jobs/);
+    if (wd) {
+      return { type: 'workday', url: company.api, host: wd[1], site: wd[2] };
+    }
+  }
+
+  // Lever: explicit api field
+  if (company.api && company.api.includes('api.lever.co')) {
+    return { type: 'lever', url: company.api };
+  }
+
   const url = company.careers_url || '';
 
   // Ashby
@@ -104,20 +117,62 @@ function parseLever(json, companyName) {
   }));
 }
 
-const PARSERS = { greenhouse: parseGreenhouse, ashby: parseAshby, lever: parseLever };
+function parseWorkday(json, companyName) {
+  const postings = json.jobPostings || [];
+  const host = json._host || '';
+  const site = json._site || '';
+  return postings.map(j => ({
+    title: j.title || '',
+    url: `${host}/en-US/${site}${j.externalPath || ''}`,
+    company: companyName,
+    location: j.locationsText || '',
+  }));
+}
+
+const PARSERS = { greenhouse: parseGreenhouse, ashby: parseAshby, lever: parseLever, workday: parseWorkday };
 
 // ── Fetch with timeout ──────────────────────────────────────────────
 
-async function fetchJson(url) {
+async function fetchJson(url, options = {}) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
-    const res = await fetch(url, { signal: controller.signal });
+    const res = await fetch(url, { ...options, signal: controller.signal });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return await res.json();
   } finally {
     clearTimeout(timer);
   }
+}
+
+// Workday paginates at limit=20 (hard cap). POST with empty facets to get all jobs.
+async function fetchWorkdayAll(url, host, site) {
+  const limit = 20;
+  const maxPages = 250; // safety cap: 5000 jobs per company
+  const allPostings = [];
+  let lastPageSize = 0;
+  let pages = 0;
+
+  for (let page = 0; page < maxPages; page++) {
+    const json = await fetchJson(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ appliedFacets: {}, limit, offset: page * limit, searchText: '' }),
+    });
+    const postings = json.jobPostings || [];
+    pages = page + 1;
+    if (postings.length === 0) break;
+    allPostings.push(...postings);
+    lastPageSize = postings.length;
+    if (postings.length < limit) break;
+  }
+
+  // If we exited via the loop bound (not via empty/partial page), more jobs likely exist.
+  if (pages === maxPages && lastPageSize === limit) {
+    console.warn(`⚠️  Workday pagination cap (${maxPages} pages = ${maxPages * limit} jobs) reached for ${host}; additional jobs may exist`);
+  }
+
+  return { jobPostings: allPostings, _host: host, _site: site };
 }
 
 // ── Title filter ────────────────────────────────────────────────────
@@ -290,9 +345,11 @@ async function main() {
   const errors = [];
 
   const tasks = targets.map(company => async () => {
-    const { type, url } = company._api;
+    const { type, url, host, site } = company._api;
     try {
-      const json = await fetchJson(url);
+      const json = type === 'workday'
+        ? await fetchWorkdayAll(url, host, site)
+        : await fetchJson(url);
       const jobs = PARSERS[type](json, company.name);
       totalFound += jobs.length;
 


### PR DESCRIPTION
Detect /wday/cxs/{tenant}/{site}/jobs URLs as a Workday provider via the explicit api: field. fetchWorkdayAll paginates POST requests at limit=20 (Workday's hard cap on most public job APIs) up to a 5000-job safety bound. parseWorkday extracts title and locationsText, and builds the public job URL as host + /en-US/{site} + externalPath.

Unlocks federal contractors that run Workday boards (Leidos, GDIT, Booz Allen Hamilton, RTX, Amentum, Parsons, DXC, Accenture Federal) for zero-token scanning. Backwards compatible — fetchJson takes an optional options parameter (default {}) so the same helper handles both Workday's POST + body and the existing GET semantics for Greenhouse / Ashby / Lever.

Closes #533

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- REQUIRED: Link the issue this PR addresses. PRs without a related issue will be closed. -->
<!-- Format: Fixes #123 / Closes #123 -->
<!-- Bug fixes can skip this if the fix is obvious (e.g., typo, crash). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] I linked a related issue above (required for features and architecture changes)
- [ ] My PR does not include personal data (CV, email, real names)
- [ ] I ran `node test-all.mjs` and all tests pass
- [ ] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Workday detection and automatic ingestion of job postings with paginated fetching and a safety cap
  * Scan routing updated so Workday sources use the new paginated ingestion path

* **Enhancements**
  * Improved Lever detection via explicit API recognition
  * JSON fetching enhanced to accept optional request parameters
<!-- end of auto-generated comment: release notes by coderabbit.ai -->