### PR TITLE
fix(merge-tracker): prevent false-positive duplicates from fuzzy match and num collisions

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -71,7 +71,49 @@ function normalizeCompany(name) {
   return name.toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
+// Seniority modifiers — if titles disagree on seniority, they are different roles
+// even when other words overlap (e.g. "Junior Electrical Engineer" ≠ "Electrical Engineer").
+const SENIORITY_MODIFIERS = ['junior', 'senior', 'lead', 'principal', 'staff', 'head', 'chief'];
+
+// Specialty modifiers — same logic for role specialty (QA / quality / test / safety / security).
+const SPECIALTY_MODIFIERS = ['qa', 'qc', 'quality', 'test', 'assurance', 'safety', 'security'];
+
+function findModifier(text, list) {
+  const low = text.toLowerCase();
+  return list.find(m => new RegExp(`\\b${m}\\b`).test(low));
+}
+
+// Extract reference / job IDs from role title or notes (e.g. "#148182", "job=148031",
+// "req. 58035", "ref 10001-1002450425-S"). Used to short-circuit dedup when both
+// entries carry distinct portal references.
+function extractRefIds(text) {
+  if (!text) return [];
+  const out = [];
+  const patterns = [
+    /#(\d{4,})/g,
+    /\bjob[=\s]*(\d{4,})/gi,
+    /\breq\.?\s*(\d{4,})/gi,
+    /\bref\.?\s+([\w][\w\-.]{5,})/gi,
+  ];
+  for (const re of patterns) {
+    let m;
+    while ((m = re.exec(text)) !== null) out.push(m[1].toLowerCase());
+  }
+  return out;
+}
+
 function roleFuzzyMatch(a, b) {
+  // Seniority mismatch → different role
+  const senA = findModifier(a, SENIORITY_MODIFIERS);
+  const senB = findModifier(b, SENIORITY_MODIFIERS);
+  if (senA !== senB) return false;
+
+  // Specialty mismatch (e.g. "QA" vs no QA) → different role
+  const specA = findModifier(a, SPECIALTY_MODIFIERS);
+  const specB = findModifier(b, SPECIALTY_MODIFIERS);
+  if (specA !== specB) return false;
+
+  // Word overlap: existing heuristic
   const wordsA = a.toLowerCase().split(/\s+/).filter(w => w.length > 3);
   const wordsB = b.toLowerCase().split(/\s+/).filter(w => w.length > 3);
   const overlap = wordsA.filter(w => wordsB.some(wb => wb.includes(w) || w.includes(wb)));
@@ -253,15 +295,32 @@ for (const file of tsvFiles) {
   }
 
   if (!duplicate) {
-    // Exact entry number match
-    duplicate = existingApps.find(app => app.num === addition.num);
+    // Exact entry number match — only treated as a duplicate if company+role
+    // also fuzzy-match. A bare num collision (e.g. two unrelated TSVs both
+    // numbered 076) is NOT a duplicate; the new entry should get the next
+    // available number instead. (Bug fix 2026-04-29: prior logic would
+    // silently drop valid entries when an unrelated entry already used the
+    // same num.)
+    duplicate = existingApps.find(app => {
+      if (app.num !== addition.num) return false;
+      if (normalizeCompany(app.company) !== normalizeCompany(addition.company)) return false;
+      return roleFuzzyMatch(addition.role, app.role);
+    });
   }
 
   if (!duplicate) {
-    // Company + role fuzzy match
+    // Company + role fuzzy match — with reference-ID short-circuit:
+    // if both entries carry distinct portal/job IDs, they are different roles
+    // regardless of title similarity.
     const normCompany = normalizeCompany(addition.company);
+    const newRefs = extractRefIds(`${addition.role} ${addition.notes || ''}`);
     duplicate = existingApps.find(app => {
       if (normalizeCompany(app.company) !== normCompany) return false;
+      const oldRefs = extractRefIds(`${app.role} ${app.notes || ''}`);
+      if (newRefs.length > 0 && oldRefs.length > 0) {
+        const shared = newRefs.some(r => oldRefs.includes(r));
+        if (!shared) return false;
+      }
       return roleFuzzyMatch(addition.role, app.role);
     });
   }


### PR DESCRIPTION
## Summary

Two related issues in `merge-tracker.mjs` that cause valid TSV additions to be silently dropped or to overwrite unrelated existing entries.

### Bug 1 — `roleFuzzyMatch` ignored seniority and specialty modifiers

`"Junior Electrical QA Engineer"` was treated as a duplicate of `"Electrical Engineer"` because they shared two long words (`electrical`, `engineer`). With score `N/A < existing score`, the new entry was silently skipped — so a real rejection (or any new entry on a sub-variant role at the same company) never made it into the tracker.

**Fix:** gate fuzzy match on seniority and specialty modifier agreement before checking word overlap. Also add a reference-ID short-circuit (`#148182`, `job=148031`, `req. 58035`, `ref ABC-123-S`) so entries with distinct portal IDs cannot be considered the same role regardless of title similarity.

### Bug 2 — exact-num match treated bare number collisions as duplicates

When a TSV's `num` happened to match an existing entry of a different company/role, the merge used that existing entry as a duplicate target. With higher existing score, the new TSV was dropped — silently rewriting the wrong row.

**Fix:** only treat exact-num match as duplicate when **company AND role** also fuzzy-match. Bare num collisions fall through to the "new entry" path, which auto-assigns the next available number via the existing logic.

## Why this matters

Both bugs failed silently: TSVs were marked as merged (moved to `merged/`), the script reported success, but the tracker either lost the row or had the wrong row updated. Recovery required manual editing of `applications.md` — which the data contract discourages.

## Test plan

- [x] `roleFuzzyMatch` unit tests (7/7 passed):
  - `Junior Electrical QA Engineer` ≠ `Electrical Engineer – Düsseldorf` (bug fix)
  - `Senior Electrical Engineer – Mons` = `Senior Electrical Engineer – Dublin` (legit dup)
  - `Electrical Engineer – Frankfurt (3)` = `Electrical Engineer – Frankfurt (4)` (legit numbered variants)
  - `Senior Electrical Engineer` ≠ `Electrical Engineer` (seniority mismatch)
  - `Lead Commissioning Engineer` ≠ `Commissioning Engineer` (seniority mismatch)
  - `Commissioning Manager` = `Commissioning Engineer` when no seniority modifier on either side (allowed)
  - `Electrical QA Engineer` ≠ `Electrical Engineer` (specialty mismatch)
- [x] Exact-num collision tests (3/3 passed):
  - Same num + different company → not duplicate (bug fix)
  - Same num + same company + different role → not duplicate (bug fix)
  - Same num + same company + matching role → still duplicate (legit re-eval)
- [x] `extractRefIds` recognises four ID patterns (#NNN, job=NNN, req. NNN, ref ABC-...).
- [x] End-to-end run on a real session with 14 new TSVs — no false-positive skips, no overwrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of duplicate role detection to prevent incorrectly merging unrelated entries.
  * Enhanced role comparison to better distinguish roles with different seniority levels and specialties (e.g., QA, security-related roles).
  * Added reference ID matching to ensure roles from different sources are treated as distinct entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->