### PR TITLE
fix(merge-tracker): tighten fuzzy-match dedup to avoid false positives

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -111,13 +111,20 @@ function roleFuzzyMatch(a, b) {
   const overlap = wordsA.filter(w => setB.has(w)).length;
   if (overlap === 0) return false;
 
-  // Jaccard-style ratio on content tokens. Two roles are "the same" only
-  // when the overlap dominates the smaller side — not when they just share
-  // a location + "engineer".
+  // Coverage on the smaller side (ratio) AND Jaccard on the union — both must
+  // clear the bar. Without the Jaccard guard, two distinct roles that merely
+  // share generic tokens like "product"/"manager" get falsely merged when the
+  // rest of the role (vertical, level, geography) differs.
   const minLen = Math.min(wordsA.length, wordsB.length);
   const ratio = overlap / minLen;
+  const union = new Set([...wordsA, ...wordsB]);
+  const jaccard = overlap / union.size;
 
-  return overlap >= 2 && ratio >= 0.6;
+  // Strict: require either substantial multi-token agreement, or a near-
+  // complete overlap on the smaller role.
+  if (overlap >= 3 && jaccard >= 0.6) return true;
+  if (overlap >= 2 && ratio >= 0.85 && jaccard >= 0.6) return true;
+  return false;
 }
 
 function extractReportNum(reportStr) {
@@ -299,8 +306,16 @@ for (const file of tsvFiles) {
     duplicate = existingApps.find(app => app.num === addition.num);
   }
 
-  if (!duplicate) {
-    // Company + role fuzzy match
+  // Company + role fuzzy match — ONLY when the new addition lacks a valid
+  // report number. When a report number is present and didn't match any
+  // existing record above, the new TSV is by construction a NEW entry (the
+  // pipeline assigns sequential, unique report numbers). Running fuzzy match
+  // here historically caused false positives across same-company-different-
+  // role pairs (e.g. "Stripe Data Analyst (Canada)" was merged with
+  // "Stripe Data Analyst (Dublin)" because both reduced to ["data","analyst"]
+  // after stopword filtering, even though they're distinct postings). Reserve
+  // fuzzy for legacy/manual TSVs where the report column is missing.
+  if (!duplicate && !reportNum) {
     const normCompany = normalizeCompany(addition.company);
     duplicate = existingApps.find(app => {
       if (normalizeCompany(app.company) !== normCompany) return false;


### PR DESCRIPTION
## Summary

`merge-tracker.mjs`'s fuzzy-match dedup heuristic was overly permissive, causing data loss when multiple distinct postings from the same company arrived in the same merge run. Two related fixes tighten the dedup so that:

1. Distinct same-company postings whose titles only share a few generic tokens (e.g. `"product"`, `"manager"`, `"data"`, `"analyst"`) are no longer merged.
2. The fuzzy fallback only runs when the new addition lacks a valid report number — sequential `reportNum`s are by construction unique, so fuzzy matching at that point can only produce false positives.

## Bug repro

Setup `data/applications.md` with:

```
| 25 | 2026-04-29 | Stripe | Data Analyst (Dublin) | 1.2/5 | SKIP | ❌ | [025](reports/025-stripe-dublin-2026-04-29.md) | ... |
```

Drop a new TSV `batch/tracker-additions/035-stripe-canada.tsv`:

```
35	2026-05-01	Stripe	Data Analyst (Canada)	SKIP	1.2/5	❌	[035](reports/035-stripe-canada-2026-05-01.md)	Geo blocker — Canada-only.
```

Run `node merge-tracker.mjs`. **Before this fix:** the new addition is silently skipped because its `roleFuzzyMatch` against `#25` returns `true` (both `["data", "analyst"]` after stopword filtering — `Dublin` and `Canada` are in `ROLE_STOPWORDS`). Worse, when a *higher*-scoring new addition matches via the same false positive, the existing row is destructively overwritten — the original company/role/date/notes are replaced with the new addition's data, only the entry number is preserved. Multiple users have hit this in production runs.

**After this fix:** the new addition has `reportNum = 35` which doesn't match any existing report number, so the fuzzy fallback is skipped entirely — the entry is correctly added as new.

## Changes

### 1. `roleFuzzyMatch` — Jaccard guard + tighter thresholds

```js
const minLen = Math.min(wordsA.length, wordsB.length);
const ratio = overlap / minLen;
const union = new Set([...wordsA, ...wordsB]);
const jaccard = overlap / union.size;

if (overlap >= 3 && jaccard >= 0.6) return true;
if (overlap >= 2 && ratio >= 0.85 && jaccard >= 0.6) return true;
return false;
```

Both ratio and Jaccard must clear the bar. Genuine near-duplicates (`"Product Analyst"` vs `"Product Analyst (Updated)"`) still match; weak overlap on shared generic tokens no longer does.

### 2. Fuzzy fallback gated on `!reportNum`

```js
if (!duplicate && !reportNum) {
  const normCompany = normalizeCompany(addition.company);
  duplicate = existingApps.find(app => { ... });
}
```

When a sequential `reportNum` is present and didn't match any existing report-number-or-entry-number record, the new TSV is by construction a new entry. Reserve fuzzy for legacy/manual TSVs where the report column is missing.

## Test plan

- [x] Run `node merge-tracker.mjs --dry-run` against an existing tracker — no errors, correct count.
- [x] Reproduce the Stripe Dublin/Canada false-positive scenario — new fix correctly adds Canada as a new entry.
- [x] Reproduce a legitimate same-role re-evaluation (same `reportNum`) — still correctly updates in place.
- [x] Reproduce a same-company-different-role scenario (Paytm Travel PA vs Paytm Lending APM) — no false-positive merge.

## Backward compatibility

- All existing call sites of `merge-tracker.mjs` continue to work without changes.
- Legacy TSVs without a valid `reportNum` still benefit from fuzzy matching (the heuristic itself is stricter but functional).
- No changes to the file-on-disk format, the directory layout, or the CLI flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of role deduplication and matching with stricter validation criteria.
  * Enhanced handling of data entries during the merge process based on report number availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->