### PR TITLE
fix(update-system): allow writing-samples/README.md as system-owned file

### DIFF
--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -18,7 +18,7 @@ These files contain your personal data, customizations, and work product. Update
 | `data/pipeline.md` | Your URL inbox |
 | `data/scan-history.tsv` | Your scan history |
 | `data/follow-ups.md` | Your follow-up history |
-| `writing-samples/*` | Your personal writing samples for style calibration |
+| `writing-samples/*` | Your personal writing samples for style calibration (except `writing-samples/README.md`, which is system-owned documentation delivered by updates) |
 | `reports/*` | Your evaluation reports |
 | `output/*` | Your generated PDFs |
 | `jds/*` | Your saved job descriptions |

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -62,6 +62,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `docs/*` | Documentation |
 | `VERSION` | Current version number |
 | `DATA_CONTRACT.md` | This file |
+| `writing-samples/README.md` | System-owned onboarding documentation for the writing-samples directory |
 
 ## The Rule
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -77,6 +77,7 @@ const SYSTEM_PATHS = [
   '.claude/skills/',
   '.gemini/commands/',
   'docs/',
+  'writing-samples/README.md',
   'VERSION',
   'DATA_CONTRACT.md',
   'CONTRIBUTING.md',
@@ -283,6 +284,9 @@ async function apply() {
       for (const entry of gitStatusEntries()) {
         const file = entry.path;
         if (initialStatusPaths.has(file)) continue;
+        // Explicit SYSTEM_PATHS entries override USER_PATHS prefix matches.
+        // (e.g. writing-samples/README.md is system-owned doc inside a user dir.)
+        if (SYSTEM_PATHS.includes(file)) continue;
         for (const userPath of USER_PATHS) {
           if (file.startsWith(userPath)) {
             console.error(`SAFETY VIOLATION: User file was modified: ${file}`);


### PR DESCRIPTION
## What does this PR do?

Adds `writing-samples/README.md` to `SYSTEM_PATHS` and short-circuits the apply-time safety check when a file appears verbatim in the `SYSTEM_PATHS` allowlist, so the explicit allowlist takes precedence over `USER_PATHS` prefix matches. `DATA_CONTRACT.md` is updated with a one-line note documenting the exception.

## Related issue

Closes #549

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass (65 passed, 0 failed, 15 pre-existing warnings)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Notes

- `SYSTEM_PATHS` lookup uses exact-string `Array.includes()`, so only the explicitly-listed `writing-samples/README.md` is exempted — other files under `writing-samples/` remain protected by the existing `USER_PATHS` prefix check.
- New guard runs before the `USER_PATHS` loop, ensuring the explicit allowlist always wins over prefix matches without changing behavior for any other path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the auto-updater to recognize a specific onboarding document inside the writing-samples area as system-owned so it can be updated automatically, and to skip that document during user-path violation checks—protecting other user-created content in the same directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->