### PR TITLE
docs(commands): surface /career-ops latex in menus and OpenCode/Gemini files

### DIFF
--- a/.claude/skills/career-ops/SKILL.md
+++ b/.claude/skills/career-ops/SKILL.md
@@ -3,7 +3,7 @@ name: career-ops
 description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
 user_invocable: true
 args: mode
-argument-hint: "[scan | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
+argument-hint: "[scan | deep | pdf | latex | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
 ---
 
 # career-ops -- Router

--- a/.claude/skills/career-ops/SKILL.md
+++ b/.claude/skills/career-ops/SKILL.md
@@ -52,6 +52,7 @@ Available commands:
   /career-ops contacto  → LinkedIn power move: find contacts + draft message
   /career-ops deep      → Deep research prompt about company
   /career-ops pdf       → PDF only, ATS-optimized CV
+  /career-ops latex     → Export CV as LaTeX/Overleaf .tex
   /career-ops training  → Evaluate course/cert against North Star
   /career-ops project   → Evaluate portfolio project idea
   /career-ops tracker   → Application status overview

--- a/.gemini/commands/career-ops-latex.toml
+++ b/.gemini/commands/career-ops-latex.toml
@@ -1,0 +1,19 @@
+description = "Export a tailored, ATS-optimized CV as a LaTeX/Overleaf .tex file (and compile to PDF)."
+
+prompt = """
+You are career-ops in latex (LaTeX/Overleaf CV export) mode.
+
+Job description or context:
+$ARGUMENTS
+
+Load the LaTeX export context:
+- Read file: modes/_shared.md
+- Read file: modes/latex.md
+- Read file: cv.md
+- Read file (if exists): modes/_profile.md
+- Read file (if exists): article-digest.md
+- Read file: templates/cv-template.tex
+
+Then execute the LaTeX export mode as defined in modes/latex.md.
+Generate a tailored .tex file and run: node generate-latex.mjs <output.tex> <output.pdf>
+"""

--- a/.gemini/commands/career-ops.toml
+++ b/.gemini/commands/career-ops.toml
@@ -22,6 +22,7 @@ Available commands:
   /career-ops-contact      → LinkedIn outreach: find contacts + draft message
   /career-ops-deep         → Deep research about a company
   /career-ops-pdf          → Generate ATS-optimized CV PDF
+  /career-ops-latex        → Export CV as LaTeX/Overleaf .tex
   /career-ops-training     → Evaluate course/cert against North Star
   /career-ops-project      → Evaluate a portfolio project idea
   /career-ops-tracker      → Application status overview

--- a/.opencode/commands/career-ops-latex.md
+++ b/.opencode/commands/career-ops-latex.md
@@ -1,0 +1,10 @@
+---
+description: Export CV as LaTeX/Overleaf .tex
+---
+
+Export a tailored, ATS-optimized CV as a LaTeX `.tex` file (and optionally compile to PDF) using career-ops latex mode.
+
+Load the career-ops skill:
+```
+skill({ name: "career-ops" })
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ When using the [Gemini CLI](https://github.com/google-gemini/gemini-cli), the fo
 | `/career-ops-contact` | `/career-ops contacto` | LinkedIn outreach (find contacts + draft) |
 | `/career-ops-deep` | `/career-ops deep` | Deep company research |
 | `/career-ops-pdf` | `/career-ops pdf` | Generate ATS-optimized CV |
+| `/career-ops-latex` | `/career-ops latex` | Export CV as LaTeX/Overleaf .tex |
 | `/career-ops-training` | `/career-ops training` | Evaluate course/cert against goals |
 | `/career-ops-project` | `/career-ops project` | Evaluate portfolio project idea |
 | `/career-ops-tracker` | `/career-ops tracker` | Application status overview |


### PR DESCRIPTION
## Summary

Fixes #563. The `latex` mode is built and committed (`modes/latex.md`, `generate-latex.mjs`, `templates/cv-template.tex`) but never advertised. Users who type `/career-ops` to see the menu won't find it, and OpenCode/Gemini CLI users have no slash-command file at all.

This PR mirrors the existing `pdf` wiring for `latex` in five places:

| File | Change |
|------|--------|
| `.claude/skills/career-ops/SKILL.md` | Add `latex` line in the discovery menu (between `pdf` and `training`) |
| `.gemini/commands/career-ops.toml` | Add `latex` line in the prompt-template menu |
| `.opencode/commands/career-ops-latex.md` | **New file**, modeled on `career-ops-pdf.md` |
| `.gemini/commands/career-ops-latex.toml` | **New file**, modeled on `career-ops-pdf.toml` |
| `CLAUDE.md` Gemini table | Add `latex` row (the OpenCode table above it already has it) |

## Why

Pure discoverability gap — every other mode appears in all four hint surfaces. Users today have to read the source to know `latex` exists.

## Test plan

- [ ] `/career-ops` (no args) in Claude Code shows `latex` between `pdf` and `training`
- [ ] `/career-ops` (no args) in Gemini CLI shows `/career-ops-latex` in the menu
- [ ] `/career-ops-latex` is discoverable in OpenCode's slash-command picker
- [ ] `/career-ops-latex` is discoverable in Gemini CLI's slash-command picker
- [ ] `node test-all.mjs --quick` passes (64 passed locally)
- [ ] No mode behavior changes — pure docs/wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CV export option that generates Overleaf-compatible LaTeX (.tex) exports and can optionally compile to PDF via a single command; a new command entry exposes this export mode in the discovery menu.

* **Documentation**
  * Added user-facing command docs and updated CLI reference to describe the new LaTeX export workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->