### PR TITLE
Refocus career ops for product management roles

### DIFF
--- a/article-digest.md
+++ b/article-digest.md
@@ -1,0 +1,88 @@
+# Mei Liu -- Product Proof Points
+
+## Trust, Safety, and Identity
+
+### Binance.US -- Lead Product Manager, Platform
+- Owned trust and safety platform scope across account security, fraud prevention, risk challenges, and internal tooling.
+- Expanded the risk rules engine to ingest real-time device identity, behavioral signals, RAT detection, and third-party data.
+- Reduced false positives and user friction by improving rule evaluation and signal weighting across the risk stack.
+- Led vendor evaluation and integration strategy for next-generation KYC/IDV capabilities including AI-generated video detection and biometric face mapping.
+- Defined the strategy for AI-driven abuse detection against agent-based and coordinated attacks.
+
+### Self-service account recovery
+- Built and launched a self-service account recovery flow using step-up IDV challenges.
+- Replaced manual CX workflows with automated identity verification and decisioning.
+- Reduced time to resolution from 15.5 hours to roughly 10 minutes, a ~99% improvement.
+- Lowered support burden while materially improving customer experience.
+
+### Coinbase -- Account compromise prevention and login
+- Wrote engineering-ready product requirements for a risk-based ATO challenge framework, bot protection, rate limiting, and stronger authentication.
+- Shaped the roadmap for passwordless flows, security keys, push auth, biometrics, and unified logins.
+- Improved Android weekly app rating from 3.5 to 4.2 stars in six weeks by shipping login usability improvements.
+- Designed Login 2.0 to improve login success by 20% while protecting compromise metrics for 35M users.
+
+## Internal Platforms and Operational Tooling
+
+### Binance.US -- Admin platform rebuild
+- Defined the product vision and system architecture for a next-generation admin platform used across Compliance, CX, Risk, and Finance.
+- Rebuilt core internal tooling as an integrated system with user management, unified chat, case management, rules engine controls, and change management.
+- Built a functional front-end prototype in four weeks without dedicated frontend engineering.
+- Used a live system to accelerate stakeholder alignment and remove requirement ambiguity.
+- Secured cross-functional sign-off to migrate off fragmented legacy tooling and establish a single operational control plane.
+
+### Coinbase -- Enterprise apps and support tooling
+- Led a one-year initiative to sunset, migrate, and upgrade five channels of customer help tooling across email, phone, forms, social, and help center.
+- Delivered other enterprise apps spanning localization vendor integration, AI/ML for support responses, sales pipeline tooling, and vendor selection.
+- Rebuilt legacy GDPR and CCPA privacy tooling in three weeks to avoid fines and resolve out-of-SLA requests.
+
+### Intentional Studio -- Operations stack transformation
+- Led a $2.5M program to revamp the operations stack for a $250M brand scaling toward a $1B target.
+- Orchestrated a team of 20 across executives, managers, US engineers, and offshore engineers.
+- Built custom integrations across ERP, WMS/3PL, eCommerce, CRM, subscription, invoicing, and fulfillment systems.
+- Increased sales by 20% via a Shopify-to-Salesforce integration and text-driven upsell workflow.
+- Reduced support cost by 5 headcount through a custom subscription portal and self-service flows.
+
+## Consumer, Growth, and New Business Lines
+
+### Stripe-relevant consumer wallet and identity themes
+- Experience spanning trust, identity, checkout, consumer UX, and financial products.
+- Shipped features where safety, convenience, and conversion had to improve together rather than trade off.
+- Comfortable working from ambiguous future-state product concepts into staged roadmaps and MVPs.
+
+### Fast -- Group Product Manager, Creators, Identity & Trust, Labs
+- Built a partnership platform connecting creators and merchants via in-content commerce experiences.
+- Led mission, vision, strategy, pricing, and GTM planning for the Fast Commerce Network.
+- Business line was forecasted to generate 50% of company revenue in a two-year timeline.
+- Recruited a founding team and launched MVP capabilities for product search, commissionable link generation, and insights reporting in three months.
+- Led sports QR commerce activations that drove 70K scans and 50K orders in six hours.
+
+### Coinbase -- Institutional onboarding and billing
+- Led a cross-functional team of 20 to deliver a dynamic, risk-adjusted onboarding flow for business customers.
+- Reduced onboarding time by 45 days, a 75% reduction.
+- Built an automated contracting and audit process for a custom billing product that unlocked 4x customer growth and supported SOC compliance.
+
+## AI Product and Automation
+
+### Spaulding Ridge -- Senior Director, Data Solutions
+- Led AI and custom application discovery and delivery motion across 35 enterprise customers.
+- Helped customers roadmap and build AI solutions for Sales, Support, Legal, and Finance teams using platform AI and custom apps.
+- Scaled the team from 20 to 100 people in 12 months.
+- Managed senior consultants and a 15-person organization.
+
+### Binance.US -- AI triage and debugging system
+- Architected a secure AI-powered triage and debugging system across 200+ repositories.
+- Solved for PII masking, ephemeral isolated VMs, and no persistent production access.
+- Built indexing and retrieval layers to surface relevant context across large codebases.
+- Evaluated off-the-shelf tools and chose custom architecture for security and scale requirements.
+
+### Notable side projects
+- GemCast Podcast Agents -- built in four hours at the Gemini Agent Hackathon.
+- Legion Health FAQ Chatbot -- built in two hours.
+- Image MCP -- AI image generation service aggregating 37 models for MCP clients, built with two YC founders.
+
+## Leadership and Credibility
+
+- First PM hired in four emerging product areas at Coinbase.
+- Managed PMs and designed an APM program at Fast.
+- Women in Product Conference speaker selected as one of 40 speakers from 600 applications.
+- Northwestern graduate, magna cum laude, and highest GPA among female student-athletes while competing in Division I golf.

--- a/cv.md
+++ b/cv.md
@@ -1,0 +1,110 @@
+# CV -- Mei Liu
+
+**Location:** San Francisco, CA
+**Email:** contact@meiliu.me
+**Phone:** (512) 767-0733
+**LinkedIn:** https://www.linkedin.com/in/mei-liu-512/
+
+## Professional Summary
+
+Product leader with 15 years building trust, identity, internal platforms, and customer-facing products across fintech, crypto, enterprise software, and AI. Led 0-to-1 and scaling initiatives spanning trust and safety, onboarding, internal tooling, consumer growth bets, and AI-enabled operations. Strong track record of turning ambiguous cross-functional problems into measurable outcomes, including a 99% faster account recovery flow, a 75% faster institutional onboarding journey, and multiple initiatives tied to major revenue growth.
+
+## Work Experience
+
+### Binance.US -- San Francisco, CA
+**Lead Product Manager, Platform**
+Jan 2026 - Present
+
+- Own product strategy for trust and safety systems spanning account security, fraud prevention, risk challenges, and internal tooling across a global crypto user base.
+- Expanded the risk rules engine to use real-time device identity, behavioral signals, RAT detection, and third-party data to improve fraud detection accuracy and decision speed.
+- Built and launched a self-service account recovery flow using step-up identity verification, reducing time to resolution from 15.5 hours to roughly 10 minutes while lowering support burden.
+- Defined the product vision for a next-generation admin platform across Compliance, CX, Risk, and Finance; shipped a functional prototype in four weeks and secured cross-functional sign-off to replace fragmented legacy tooling.
+- Lead a new revenue platform initiative expected to drive roughly 50% platform revenue growth through cross-functional coordination across legal, compliance, risk, data science, and engineering.
+
+### Spaulding Ridge -- Austin, TX / San Francisco, CA
+**Senior Director, Data Solutions -- Data, AI & Apps**
+Jul 2023 - Jan 2026
+
+- Led AI and custom application selling and delivery across 35 enterprise customers in high tech, retail, manufacturing, and financial services.
+- Ran discovery workshops and voice-of-customer work to define product and platform roadmaps for Sales, Support, Legal, and Finance teams.
+- Helped scale the organization from 20 to 100 people in 12 months.
+- Managed senior consultants and a 15-person organization while guiding strategic client programs.
+- Built credibility in AI product strategy through rapid prototyping and cross-functional solution design.
+
+### Genies -- New York, NY
+**Principal Product Manager**
+Jun 2022 - Nov 2022
+
+- Partnered with the founding team to convert a long-range avatar ecosystem vision into concrete multi-year product roadmaps.
+- Built a prototype culture with engineering, creative, and art teams to quickly test and iterate on MVP concepts.
+- Led strategy for Web3 interactions across key management, IP rights, NFT minting, remixing, and gated access.
+- Focused on supply-side marketplace growth by enabling creators to build avatars and digital spaces.
+
+### Intentional Studio -- Austin, TX
+**Founder**
+Dec 2022 - Jul 2023
+
+- Led a $2.5M engagement to redesign the operations stack for a $250M brand scaling toward a $1B target.
+- Drove product requirements and technical design across inventory, sales, subscriptions, fulfillment, and financial reporting systems.
+- Increased sales by 20% through a Shopify-to-Salesforce integration and custom text-driven upsell workflow.
+- Reduced support costs by 5 headcount by launching a custom subscription manager and self-service customer portal.
+- Orchestrated a three-week migration of 15M+ Salesforce records across 20 objects with a distributed eight-person team.
+
+### Fast -- New York, NY / Austin, TX
+**Group Product Manager -- Creators, Identity & Trust, Labs**
+Dec 2020 - Apr 2022
+
+- Built a partnership platform connecting creators and merchants through in-content commerce experiences.
+- Led mission, vision, strategy, pricing, and GTM planning for the Fast Commerce Network, a business line forecasted to generate 50% of company revenue within two years.
+- Recruited and onboarded a founding team of six engineers and one designer; launched MVP capabilities in three months.
+- Owned roadmap for platform features covering user data modeling and identity APIs used by internal teams and external customers.
+- Led high-visibility commerce activations, including sports QR campaigns that drove 70K scans and 50K orders in six hours.
+
+### Coinbase -- San Francisco, CA
+**Senior Product Manager / Product Manager -- Platform, Consumer, Institutional, Enterprise Apps**
+Jun 2018 - Dec 2020
+
+- First PM hired into four emerging product areas, setting mission, vision, metrics, and multi-year roadmaps across institutional onboarding, trust and safety, internal apps, and consumer foundations.
+- Led a cross-functional team of 20 to deliver a dynamic, risk-adjusted institutional onboarding flow, reducing onboarding time by 45 days, a 75% improvement.
+- Built an automated contracting and audit process for a custom billing product that unlocked 4x customer growth while supporting SOC compliance.
+- Shipped trust and safety product requirements for risk-based account takeover controls, bot protection, stronger authentication, and unified login experiences.
+- Improved Android weekly app rating from 3.5 to 4.2 stars in six weeks via login usability improvements and designed Login 2.0 for 35M users.
+- Rebuilt GDPR and CCPA privacy tooling in three weeks to avoid fines and resolve out-of-SLA regulatory requests.
+- Led a one-year migration and upgrade of five customer support tooling channels across email, phone, form, social, and help center systems.
+
+### Huron Consulting Group -- Chicago, IL
+**Manager, Customer Experience Products**
+Dec 2016 - Jun 2018
+
+- Worked with 3-5 startups at a time to roadmap and implement internal and customer-facing tooling across sales, marketing, support, finance, and data teams.
+- Participated in the scoping, design, or delivery of 55 product initiatives for 30 clients during consulting career.
+- Managed three consultants and won the 2017 "Impactful Coaching" award.
+
+**Intern / Analyst / Associate / Senior Associate, Data & Finance Engineering**
+May 2012 - Nov 2016
+
+- Implemented data warehousing and analytics solutions for enterprise customers after joining via Bluestone International's acquisition.
+
+## Selected Projects
+
+- **GemCast Podcast Agents** -- Built a podcast-agent product in four hours at the Gemini Agent Hackathon.
+- **Legion Health FAQ Chatbot** -- Built a working FAQ chatbot in two hours.
+- **Image MCP** -- Co-built an AI image generation service that aggregates 37 models into a single secure MCP-compatible server.
+
+## Education
+
+- **Northwestern University** -- BA Economics, Legal Studies, Business Institutions, 2013
+- Magna cum laude, GPA 3.9
+- Four-year Division I golfer; part of the 2013 Big Ten Championship team
+
+## Additional
+
+- 2021 Women in Product Conference speaker, selected as 1 of 40 speakers from 600 applicants
+- Remote Year participant; pitched and executed a full-time remote work model while managing $1M in revenue across 42 countries
+
+## Skills
+
+- **Product:** Product strategy, roadmap, prioritization, discovery, experimentation, GTM planning, cross-functional leadership
+- **Domains:** Trust & safety, identity, onboarding, consumer fintech, internal tooling, enterprise apps, AI products
+- **Technical:** SQL, data platforms, risk systems, KYC/AML workflows, API products, enterprise systems, AI-assisted prototyping
+- **Functions:** Customer research, vendor evaluation, workflow automation, operational tooling, compliance-heavy product delivery

--- a/modes/_profile.template.md
+++ b/modes/_profile.template.md
@@ -13,35 +13,35 @@
 ## Your Target Roles
 
 <!-- Replace these with YOUR target roles. Examples:
-     - Senior Backend Engineer / Staff Platform Engineer
+     - Senior Product Manager / Group Product Manager
+     - Growth PM / Monetization PM
+     - Platform PM / Developer Platform PM
      - AI Product Manager / Technical PM
-     - Data Engineer / ML Engineer
-     - DevOps / SRE / Platform
      Whatever you're optimizing for. -->
 
 | Archetype | Thematic axes | What they buy |
 |-----------|---------------|---------------|
-| **AI Platform / LLMOps Engineer** | Evaluation, observability, reliability, pipelines | Someone who puts AI in production with metrics |
-| **Agentic Workflows / Automation** | HITL, tooling, orchestration, multi-agent | Someone who builds reliable agent systems |
-| **Technical AI Product Manager** | GenAI/Agents, PRDs, discovery, delivery | Someone who translates business to AI product |
-| **AI Solutions Architect** | Hyperautomation, enterprise, integrations | Someone who designs end-to-end AI architectures |
-| **AI Forward Deployed Engineer** | Client-facing, fast delivery, prototyping | Someone who delivers AI solutions to clients fast |
-| **AI Transformation Lead** | Change management, adoption, org enablement | Someone who leads AI transformation in an org |
+| **Core Product Management** | Discovery, prioritization, roadmap, execution | Someone who turns ambiguous problems into shipped outcomes |
+| **Growth Product Management** | Activation, conversion, retention, experimentation | Someone who grows product metrics with disciplined tests |
+| **Platform Product Management** | APIs, internal platforms, DX, scale | Someone who improves leverage for internal or external builders |
+| **AI Product Management** | GenAI, workflow automation, evaluation, trust | Someone who translates AI capability into useful product bets |
+| **Enterprise / B2B Product** | Customer pain, GTM, integrations, implementation | Someone who balances user value with commercial reality |
+| **Product Strategy & Ops** | Portfolio planning, operating cadence, business cases | Someone who makes product organizations more focused and effective |
 
 ## Your Adaptive Framing
 
 <!-- Map YOUR projects to each archetype. Example:
-     | Platform / LLMOps | My monitoring dashboard project | article-digest.md |
-     | Agentic | My chatbot with HITL escalation | cv.md section 3 | -->
+     | Core PM | My onboarding revamp that improved activation | article-digest.md |
+     | Growth PM | My pricing experiment series | cv.md section 3 | -->
 
 | If the role is... | Emphasize about you... | Proof point sources |
 |-------------------|------------------------|---------------------|
-| Platform / LLMOps | Production systems builder, observability, evals | article-digest.md + cv.md |
-| Agentic / Automation | Multi-agent orchestration, HITL, reliability | article-digest.md + cv.md |
-| Technical AI PM | Product discovery, PRDs, metrics | cv.md + article-digest.md |
-| Solutions Architect | System design, integrations, enterprise-ready | article-digest.md + cv.md |
-| Forward Deployed Engineer | Fast delivery, client-facing, prototype to prod | cv.md + article-digest.md |
-| AI Transformation Lead | Change management, team enablement, adoption | cv.md + article-digest.md |
+| Core PM | Customer discovery, prioritization, roadmap judgment, delivery | cv.md + article-digest.md |
+| Growth PM | Funnel diagnosis, experimentation, retention and monetization | article-digest.md + cv.md |
+| Platform PM | Internal users, API/platform leverage, cross-team influence | cv.md + article-digest.md |
+| AI PM | New product bets, UX around AI, evaluation and trust | cv.md + article-digest.md |
+| Enterprise / B2B PM | Customer-facing discovery, GTM alignment, implementation trade-offs | article-digest.md + cv.md |
+| Product Strategy & Ops | Portfolio rigor, planning cadence, KPI systems, executive communication | cv.md + article-digest.md |
 
 ## Your Exit Narrative
 
@@ -56,16 +56,16 @@ Use the candidate's exit story from `config/profile.yml` to frame ALL content:
 
 <!-- What's your "signature move"? What do you do that others can't? -->
 
-Frame profile as **"Technical builder with real-world proof"** that adapts framing to the role.
+Frame profile as **"Product leader with operating rigor and real-world proof"** that adapts framing to the role.
 
 ## Your Portfolio / Demo
 
 <!-- If you have a live demo, dashboard, or public project:
      url: https://yoursite.dev/demo
      password: demo-2026
-     when_to_share: "LLMOps, AI Platform roles" -->
+     when_to_share: "Platform PM, AI PM, or product strategy roles" -->
 
-If you have a live demo/dashboard (check profile.yml), offer access in applications for relevant roles.
+If you have a portfolio, case study deck, PRD sample, product teardown, or live demo (check profile.yml), offer it in applications for relevant roles.
 
 ## Your Comp Targets
 

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -29,11 +29,12 @@ The evaluation uses 6 blocks (A-F) with a global score of 1-5:
 
 | Dimension | What it measures |
 |-----------|-----------------|
-| Match con CV | Skills, experience, proof points alignment |
-| North Star alignment | How well the role fits the user's target archetypes (from _profile.md) |
+| PM fit | Discovery, prioritization, execution, and outcomes alignment |
+| North Star alignment | How well the role fits the user's target PM archetypes (from _profile.md) |
+| Scope and level | Product area complexity, team scope, ownership breadth, and level match |
 | Comp | Salary vs market (5=top quartile, 1=well below) |
-| Cultural signals | Company culture, growth, stability, remote policy |
-| Red flags | Blockers, warnings (negative adjustments) |
+| Company context | Product maturity, org quality, growth, and decision velocity |
+| Red flags | Blockers, warnings, missing PM fundamentals, or unhealthy product culture |
 | **Global** | Weighted average of above |
 
 **Score interpretation:**
@@ -48,12 +49,12 @@ Classify every offer into one of these types (or hybrid of 2):
 
 | Archetype | Key signals in JD |
 |-----------|-------------------|
-| AI Platform / LLMOps | "observability", "evals", "pipelines", "monitoring", "reliability" |
-| Agentic / Automation | "agent", "HITL", "orchestration", "workflow", "multi-agent" |
-| Technical AI PM | "PRD", "roadmap", "discovery", "stakeholder", "product manager" |
-| AI Solutions Architect | "architecture", "enterprise", "integration", "design", "systems" |
-| AI Forward Deployed | "client-facing", "deploy", "prototype", "fast delivery", "field" |
-| AI Transformation | "change management", "adoption", "enablement", "transformation" |
+| Core Product Management | "roadmap", "prioritization", "stakeholders", "requirements", "execution" |
+| Growth Product Management | "activation", "conversion", "retention", "funnel", "experimentation", "A/B" |
+| Platform Product Management | "platform", "APIs", "developer experience", "internal tools", "scalability" |
+| AI Product Management | "AI", "ML", "LLM", "copilot", "evaluation", "automation", "workflow" |
+| Enterprise / B2B Product | "enterprise", "customers", "sales", "implementation", "integration", "GTM" |
+| Product Strategy & Ops | "portfolio", "operating cadence", "planning", "OKRs", "business case", "transformation" |
 
 After detecting archetype, read `modes/_profile.md` for the user's specific framing and proof points for that archetype.
 
@@ -69,6 +70,7 @@ After detecting archetype, read `modes/_profile.md` for the user's specific fram
 6. Generate a PDF without reading the JD first
 7. Use corporate-speak
 8. Ignore the tracker (every evaluated offer gets registered)
+9. Frame the candidate as an engineer if their actual value is PM leadership, strategy, or delivery
 
 ### ALWAYS
 
@@ -81,8 +83,8 @@ After detecting archetype, read `modes/_profile.md` for the user's specific fram
 5. Register in tracker after evaluating
 6. Generate content in the language of the JD (EN default)
 7. Be direct and actionable -- no fluff
-8. Native tech English for generated text. Short sentences, action verbs, no passive voice.
-8b. Case study URLs in PDF Professional Summary (recruiter may only read this).
+8. Native business English for generated text. Short sentences, action verbs, no passive voice.
+8b. Emphasize product impact, customer outcomes, metrics, and cross-functional leadership before tooling details.
 9. **Tracker additions as TSV** -- NEVER edit applications.md directly. Write TSV in `batch/tracker-additions/`.
 10. **Include `**URL:**` in every report header.**
 

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -46,17 +46,17 @@ Si el score final es >= 4.5, generar borrador de respuestas para el formulario d
 **Posición: "I'm choosing you."** el candidato tiene opciones y está eligiendo esta empresa por razones concretas.
 
 **Reglas de tono:**
-- **Confiado sin arrogancia**: "I've spent the past year building production AI agent systems — your role is where I want to apply that experience next"
+- **Confiado sin arrogancia**: "I've spent the last few years turning ambiguous product problems into measurable outcomes — your role is where that pattern fits next"
 - **Selectivo sin soberbia**: "I've been intentional about finding a team where I can contribute meaningfully from day one"
 - **Específico y concreto**: Siempre referenciar algo REAL del JD o de la empresa, y algo REAL de la experiencia del candidato
 - **Directo, sin fluff**: 2-4 frases por respuesta. Sin "I'm passionate about..." ni "I would love the opportunity to..."
-- **El hook es la prueba, no la afirmación**: En vez de "I'm great at X", decir "I built X that does Y"
+- **El hook es la prueba, no la afirmación**: En vez de "I'm great at X", decir "I led X and it changed Y"
 
 **Framework por pregunta:**
-- **Why this role?** → "Your [specific thing] maps directly to [specific thing I built]."
+- **Why this role?** → "Your [specific product challenge] maps directly to [specific problem/outcome I owned]."
 - **Why this company?** → Mencionar algo concreto sobre la empresa. "I've been using [product] for [time/purpose]."
-- **Relevant experience?** → Un proof point cuantificado. "Built [X] that [metric]. Sold the company in 2025."
-- **Good fit?** → "I sit at the intersection of [A] and [B], which is exactly where this role lives."
+- **Relevant experience?** → Un proof point cuantificado. "Led [initiative] that moved [metric] by [delta]."
+- **Good fit?** → "I sit at the intersection of customer insight, product judgment, and execution, which is exactly where this role lives."
 - **How did you hear?** → Honesto: "Found through [portal/scan], evaluated against my criteria, and it scored highest."
 
 **Idioma**: Siempre en el idioma del JD (EN default). Aplicar `/tech-translate`.

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -13,8 +13,8 @@ Clasificar la oferta en uno de los 6 arquetipos (ver `_shared.md`). Si es híbri
 
 Tabla con:
 - Arquetipo detectado
-- Domain (platform/agentic/LLMOps/ML/enterprise)
-- Function (build/consult/manage/deploy)
+- Product domain (consumer/B2B/platform/AI/growth/fintech/etc.)
+- Function (discovery/growth/platform/strategy/launch)
 - Seniority
 - Remote (full/hybrid/onsite)
 - Team size (si se menciona)
@@ -25,12 +25,12 @@ Tabla con:
 Lee `cv.md`. Crea tabla con cada requisito del JD mapeado a líneas exactas del CV.
 
 **Adaptado al arquetipo:**
-- Si FDE → priorizar proof points de delivery rápida y client-facing
-- Si SA → priorizar diseño de sistemas e integrations
-- Si PM → priorizar product discovery y métricas
-- Si LLMOps → priorizar evals, observability, pipelines
-- Si Agentic → priorizar multi-agent, HITL, orchestration
-- Si Transformation → priorizar change management, adoption, scaling
+- Si Core PM → priorizar discovery, roadmap trade-offs, y shipped outcomes
+- Si Growth PM → priorizar funnel metrics, experiments, retention, monetization
+- Si Platform PM → priorizar internal customers, APIs/platform leverage, cross-team influence
+- Si AI PM → priorizar user problem selection, trust/safety, evaluation loops, workflow design
+- Si Enterprise / B2B PM → priorizar customer discovery, GTM alignment, integrations, implementation realities
+- Si Product Strategy & Ops → priorizar planning systems, KPI governance, portfolio choices, executive alignment
 
 Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
 1. ¿Es un hard blocker o un nice-to-have?
@@ -41,8 +41,9 @@ Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
 ## Bloque C — Nivel y Estrategia
 
 1. **Nivel detectado** en el JD vs **nivel natural del candidato para ese arquetipo**
-2. **Plan "vender senior sin mentir"**: frases específicas adaptadas al arquetipo, logros concretos a destacar, cómo posicionar la experiencia de founder como ventaja
-3. **Plan "si me downlevelan"**: aceptar si comp es justa, negociar review a 6 meses, criterios de promoción claros
+2. **Scope check**: área de producto, usuarios, revenue/surface area, team topology, decision rights
+3. **Plan "vender senior sin mentir"**: frases específicas adaptadas al arquetipo, métricas a destacar, cómo posicionar ownership, influence, and decision quality
+4. **Plan "si me downlevelan"**: aceptar si comp es justa, negociar review a 6 meses, criterios de promoción claros
 
 ## Bloque D — Comp y Demanda
 
@@ -50,6 +51,7 @@ Usar WebSearch para:
 - Salarios actuales del rol (Glassdoor, Levels.fyi, Blind)
 - Reputación de compensación de la empresa
 - Tendencia de demanda del rol
+- Señales de salud de producto: crecimiento, layoffs, major product launches, PM org quality if visible
 
 Tabla con datos y fuentes citadas. Si no hay datos, decirlo en vez de inventar.
 
@@ -61,6 +63,12 @@ Tabla con datos y fuentes citadas. Si no hay datos, decirlo en vez de inventar.
 | ... | ... | ... | ... | ... |
 
 Top 5 cambios al CV + Top 5 cambios a LinkedIn para maximizar match.
+
+Los cambios deben privilegiar:
+- Outcome metrics over feature lists
+- Decision quality over task lists
+- Cross-functional leadership over individual contributor implementation detail
+- Customer insight, experimentation, launches, and business impact
 
 ## Bloque F — Plan de Entrevistas
 
@@ -74,16 +82,16 @@ The **Reflection** column captures what was learned or what would be done differ
 **Story Bank:** If `interview-prep/story-bank.md` exists, check if any of these stories are already there. If not, append new ones. Over time this builds a reusable bank of 5-10 master stories that can be adapted to any interview question.
 
 **Seleccionadas y enmarcadas según el arquetipo:**
-- FDE → enfatizar velocidad de entrega y client-facing
-- SA → enfatizar decisiones de arquitectura
-- PM → enfatizar discovery y trade-offs
-- LLMOps → enfatizar métricas, evals, production hardening
-- Agentic → enfatizar orchestration, error handling, HITL
-- Transformation → enfatizar adopción, cambio organizacional
+- Core PM → enfatizar problem framing, prioritization, and shipped outcomes
+- Growth PM → enfatizar experiments, funnel movement, and learning velocity
+- Platform PM → enfatizar stakeholder alignment, platform adoption, and leverage
+- AI PM → enfatizar product judgment around AI capability, trust, UX, and measurement
+- Enterprise / B2B PM → enfatizar customer conversations, GTM partnership, and delivery in constrained environments
+- Product Strategy & Ops → enfatizar planning discipline, decision cadence, and org leverage
 
 Incluir también:
-- 1 case study recomendado (cuál de sus proyectos presentar y cómo)
-- Preguntas red-flag y cómo responderlas (ej: "¿por qué vendiste tu empresa?", "¿tienes equipo de reports?")
+- 1 case study recomendado (cuál de sus launches/proyectos presentar y cómo)
+- Preguntas red-flag y cómo responderlas (ej: "how technical are you really?", "what metrics did you own directly?", "how do you work with engineering/design?", "why this product domain?")
 
 ---
 

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -10,8 +10,8 @@
    - US/Canada → `letter`
    - Resto del mundo → `a4`
 6. Detecta arquetipo del rol → adapta framing
-7. Reescribe Professional Summary inyectando keywords del JD + exit narrative bridge ("Built and sold a business. Now applying systems thinking to [domain del JD].")
-8. Selecciona top 3-4 proyectos más relevantes para la oferta
+7. Reescribe Professional Summary inyectando keywords del JD + PM positioning bridge ("Product manager who turns ambiguity into shipped outcomes and clear metrics in [domain del JD].")
+8. Selecciona top 3-4 launches, projects, or initiatives más relevantes para la oferta
 9. Reordena bullets de experiencia por relevancia al JD
 10. Construye competency grid desde requisitos del JD (6-8 keyword phrases)
 11. Inyecta keywords naturalmente en logros existentes (NUNCA inventa)
@@ -47,16 +47,17 @@
 2. Professional Summary (3-4 líneas, keyword-dense)
 3. Core Competencies (6-8 keyword phrases en flex-grid)
 4. Work Experience (cronológico inverso)
-5. Projects (top 3-4 más relevantes)
+5. Selected Launches / Projects (top 3-4 más relevantes)
 6. Education & Certifications
 7. Skills (idiomas + técnicos)
 
 ## Estrategia de keyword injection (ético, basado en verdad)
 
 Ejemplos de reformulación legítima:
-- JD dice "RAG pipelines" y CV dice "LLM workflows with retrieval" → cambiar a "RAG pipeline design and LLM orchestration workflows"
-- JD dice "MLOps" y CV dice "observability, evals, error handling" → cambiar a "MLOps and observability: evals, error handling, cost monitoring"
-- JD dice "stakeholder management" y CV dice "collaborated with team" → cambiar a "stakeholder management across engineering, operations, and business"
+- JD dice "roadmap prioritization" y CV dice "planned quarterly launches" → cambiar a "roadmap prioritization across quarterly launches and dependencies"
+- JD dice "experimentation" y CV dice "tested onboarding changes" → cambiar a "experimentation on onboarding flows to improve activation"
+- JD dice "stakeholder management" y CV dice "collaborated with team" → cambiar a "stakeholder management across engineering, design, operations, and business"
+- JD dice "product strategy" y CV dice "owned feature direction" → cambiar a "product strategy and feature direction informed by customer and business signals"
 
 **NUNCA añadir skills que el candidato no tiene. Solo reformular experiencia real con el vocabulario exacto del JD.**
 


### PR DESCRIPTION
## Summary
- refocus role archetypes and evaluation language from engineering/AI platform roles to product management paths
- update pipeline, offer analysis, and PDF guidance to emphasize PM outcomes, scope, and cross-functional leadership
- add candidate-specific `cv.md` and `article-digest.md` proof point source files for PM-tailored application generation

## Testing
- not run (content and workflow prompt changes only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive professional summary and CV documentation.
  * Updated role archetype guidance and evaluation frameworks.
  * Refined positioning templates and cross-functional leadership emphasis.
  * Improved PDF optimization and profile guidance with refined evaluation criteria and proof-point strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->