### PR TITLE
fix(modes): make /career-ops deep respect user language, not JD language

### DIFF
--- a/modes/deep.md
+++ b/modes/deep.md
@@ -1,5 +1,24 @@
 # Modo: deep — Deep Research Prompt
 
+## Language
+
+This mode is **user-facing**: the output is a research/interview-prep doc the
+user reads, not application content sent to the company. Override the shared
+"language of the JD (EN default)" rule for this mode and resolve the output
+language in this order:
+
+1. **User prompt language** — if the user wrote `/career-ops deep` (or its
+   surrounding chat) in Spanish, French, German, Japanese, etc., emit the
+   doc in that language.
+2. **`config/profile.yml`** — if `language.modes_dir` is set
+   (`modes/de`, `modes/fr`, `modes/ja`), prefer that locale.
+3. **JD language** — only as a last resort, when the user prompt has no
+   language signal (e.g., a bare URL with no surrounding chat).
+
+The template below is written in Spanish as a scaffold. **Translate it to the
+resolved output language** before presenting; do not pass the Spanish through
+when the user is writing in another language.
+
 Genera un prompt estructurado para Perplexity/Claude/ChatGPT con 6 ejes:
 
 ```
@@ -44,4 +63,5 @@ Dado mi perfil (read from cv.md and profile.yml for specific experience):
 - ¿Qué historia debería contar en la entrevista?
 ```
 
-Personalizar cada sección con el contexto específico de la oferta evaluada.
+Personalizar cada sección con el contexto específico de la oferta evaluada,
+en el idioma resuelto en la sección **Language** de arriba (NO siempre español).


### PR DESCRIPTION
## Summary

Fixes #567. `/career-ops deep` produces a research/interview-prep doc the **user** reads (not application content sent to the company), but its output language was driven by the JD language. A Spanish-speaking user pasting an English JD got an English doc, even when their prompt was in Spanish.

## Root cause

- `modes/_shared.md:111` says *"Generate content in the language of the JD (EN default)"*.
- That rule is correct for `pdf` / `latex` (CV → company → JD language is right).
- But `deep`'s output is for the user, and `modes/deep.md` had no override → it inherited the wrong default.
- Sister modes `modes/pdf.md:8` and `modes/latex.md:11` already have explicit "Detecta idioma del JD" steps; `deep` had nothing.

## Fix

Adds an explicit **Language** section at the top of `modes/deep.md` with this resolution order:

1. User prompt language (highest priority — it's a doc *for* them)
2. `config/profile.yml`'s `language.modes_dir` (`modes/de` → German, etc.)
3. JD language (last resort, only when the prompt is e.g. a bare URL with no language signal)

Also clarifies the closing instruction so the LLM translates the in-mode Spanish scaffold to the resolved output language instead of passing Spanish through verbatim.

## Why scoped to `deep` only

Other user-facing modes (`tracker`, `patterns`, `interview-prep`, follow-up *drafts that go to the user* not the recruiter) likely have the same gap, but each has different nuances (e.g., follow-up message bodies sent to recruiters do match JD language). I'm scoping this PR to the surface the user reported. Happy to follow up on the other modes in separate PRs once this lands.

## Out of scope

- #190 / #363 are about the `modes/*.md` source files themselves being in Spanish (codebase-readability concern). This PR doesn't translate the template — it just makes the runtime output respect the user's language. Translating the template can ride alongside #363.

## Test plan

- [ ] `node test-all.mjs --quick` passes (64 passed locally)
- [ ] Manual: write `/career-ops deep` prompt in Spanish with an English JD in context → expect Spanish output
- [ ] Manual: write the same prompt in English with the same JD → expect English output
- [ ] Manual: with `language.modes_dir: modes/de` in profile.yml → expect German output regardless of prompt
- [ ] No regressions in `pdf` / `latex` (those still match JD language as before — the shared rule is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Clarified language resolution precedence rules and updated guidance to ensure all content is properly translated and personalized based on the determined output language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->