### PR TITLE
feat(scan): optional location_filter in portals.yml + persist location to scan-history

### DIFF
--- a/modes/scan.md
+++ b/modes/scan.md
@@ -109,6 +109,15 @@ Los niveles son aditivos — se ejecutan todos, los resultados se mezclan y dedu
    - 0 keywords de `negative` deben aparecer
    - `seniority_boost` keywords dan prioridad pero no son obligatorios
 
+6b. **Filtrar por ubicación (opcional)** usando `location_filter` de `portals.yml`:
+   - Si el bloque `location_filter` está ausente, todas las ubicaciones pasan (comportamiento por defecto)
+   - Ubicación vacía en una oferta → pasa (no penalizar datos faltantes)
+   - Cualquier keyword de `block` presente → rechazar (precedencia sobre allow)
+   - `allow` vacío → pasa (ya superó block)
+   - `allow` no vacío → debe coincidir al menos una keyword
+   - Todas las coincidencias son case-insensitive substring
+   - La ubicación se persiste como 7ª columna en `scan-history.tsv` para auditoría posterior
+
 7. **Deduplicar** contra 3 fuentes:
    - `scan-history.tsv` → URL exacta ya vista
    - `applications.md` → empresa + rol normalizado ya evaluado

--- a/scan.mjs
+++ b/scan.mjs
@@ -134,6 +134,29 @@ function buildTitleFilter(titleFilter) {
   };
 }
 
+// ── Location filter ─────────────────────────────────────────────────
+// Optional. If `location_filter` is absent from portals.yml, all locations pass.
+// Semantics:
+//   - Empty location string → pass (don't penalize missing data)
+//   - `block` matches → reject (takes precedence over allow)
+//   - `allow` empty → pass (already cleared block)
+//   - `allow` non-empty → must match at least one keyword
+// All matches are case-insensitive substring.
+
+function buildLocationFilter(locationFilter) {
+  if (!locationFilter) return () => true;
+  const allow = (locationFilter.allow || []).map(k => k.toLowerCase());
+  const block = (locationFilter.block || []).map(k => k.toLowerCase());
+
+  return (location) => {
+    if (!location) return true;
+    const lower = location.toLowerCase();
+    if (block.length > 0 && block.some(k => lower.includes(k))) return false;
+    if (allow.length === 0) return true;
+    return allow.some(k => lower.includes(k));
+  };
+}
+
 // ── Dedup ───────────────────────────────────────────────────────────
 
 function loadSeenUrls() {
@@ -217,13 +240,15 @@ function appendToPipeline(offers) {
 }
 
 function appendToScanHistory(offers, date) {
-  // Ensure file + header exist
+  // Ensure file + header exist. Location appended as 7th column for non-breaking
+  // backward compat — older scan-history.tsv files with 6 columns still parse fine
+  // since loadSeenUrls only reads column 0.
   if (!existsSync(SCAN_HISTORY_PATH)) {
-    writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\n', 'utf-8');
+    writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\n', 'utf-8');
   }
 
   const lines = offers.map(o =>
-    `${o.url}\t${date}\t${o.source}\t${o.title}\t${o.company}\tadded`
+    `${o.url}\t${date}\t${o.source}\t${o.title}\t${o.company}\tadded\t${o.location || ''}`
   ).join('\n') + '\n';
 
   appendFileSync(SCAN_HISTORY_PATH, lines, 'utf-8');
@@ -264,6 +289,7 @@ async function main() {
   const config = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
   const companies = config.tracked_companies || [];
   const titleFilter = buildTitleFilter(config.title_filter);
+  const locationFilter = buildLocationFilter(config.location_filter);
 
   // 2. Filter to enabled companies with detectable APIs
   const targets = companies
@@ -284,7 +310,8 @@ async function main() {
   // 4. Fetch all APIs
   const date = new Date().toISOString().slice(0, 10);
   let totalFound = 0;
-  let totalFiltered = 0;
+  let totalFilteredTitle = 0;
+  let totalFilteredLocation = 0;
   let totalDupes = 0;
   const newOffers = [];
   const errors = [];
@@ -298,7 +325,11 @@ async function main() {
 
       for (const job of jobs) {
         if (!titleFilter(job.title)) {
-          totalFiltered++;
+          totalFilteredTitle++;
+          continue;
+        }
+        if (!locationFilter(job.location)) {
+          totalFilteredLocation++;
           continue;
         }
         if (seenUrls.has(job.url)) {
@@ -334,7 +365,8 @@ async function main() {
   console.log(`${'━'.repeat(45)}`);
   console.log(`Companies scanned:     ${targets.length}`);
   console.log(`Total jobs found:      ${totalFound}`);
-  console.log(`Filtered by title:     ${totalFiltered} removed`);
+  console.log(`Filtered by title:     ${totalFilteredTitle} removed`);
+  console.log(`Filtered by location:  ${totalFilteredLocation} removed`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
   console.log(`New offers added:      ${newOffers.length}`);
 

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -20,6 +20,39 @@
 #   4. Adjust search_queries for your preferred job boards
 #   5. Set enabled: false on companies you don't care about
 
+# -- Location filter (optional) --
+# Filter scanned jobs by location. Applied AFTER title filter, BEFORE dedup.
+# If this entire block is absent, all locations pass (current default behavior).
+#
+# Semantics:
+#   - Empty location string on a job → pass (don't penalize missing data)
+#   - Any `block` keyword present → reject (takes precedence over allow)
+#   - `allow` empty → pass (already cleared block)
+#   - `allow` non-empty → must match at least one keyword
+# All matches are case-insensitive substring.
+#
+# Example below targets US-based remote + a couple of US metros, blocking
+# common foreign hubs. Customize to your geography.
+
+# location_filter:
+#   allow:
+#     - "Remote"
+#     - "United States"
+#     - "USA"
+#     - "Atlanta"
+#     - "New York"
+#   block:
+#     - "India"
+#     - "Bengaluru"
+#     - "United Kingdom"
+#     - "London"
+#     - "Germany"
+#     - "France"
+#     - "Singapore"
+#     - "Japan"
+#     - "Brazil"
+#     - "Australia"
+
 # -- Title filter --
 # The scanner uses these keywords to decide if a title is relevant.
 # At least 1 positive must match AND 0 negatives must match (case-insensitive).


### PR DESCRIPTION
Closes #569.

## Summary

Adds opt-in location filtering to `scan.mjs`. Backwards compatible — if the new `location_filter` block is absent from `portals.yml`, behavior is identical to before.

## Changes

- **`scan.mjs`** (~25 lines net):
  - New `buildLocationFilter()` helper alongside `buildTitleFilter()`
  - Applied in the filter chain after title, before dedup
  - New `Filtered by location` counter in the summary output
  - Location persisted as 7th column in `scan-history.tsv` (appended — existing 6-column files still parse fine since `loadSeenUrls` only reads column 0)
- **`templates/portals.example.yml`**: documented commented-out example block above `title_filter`
- **`modes/scan.md`**: brief addition to the filter section (step 6b)

## Filter semantics

- Empty job location string → pass (don't penalize missing data)
- Any `block` keyword present → reject (precedence over allow)
- `allow` empty → pass once block is cleared
- `allow` non-empty → must match at least one
- All matches case-insensitive substring

## Verification

Local re-scan against 13 enabled companies on a real `portals.yml` with the new filter configured for US-only + ATL/NYC metros:

| Metric | Before | After |
|--------|--------|-------|
| Total jobs found | 3,144 | 3,144 |
| Filtered by title | 2,730 | 2,730 |
| Filtered by location | — | 308 |
| New offers added | 273 | 99 |

`npm run doctor` passes. Manually verified `scan-history.tsv` rows now include location column for audit.

## Test plan

- [x] `npm run doctor` passes
- [x] Real scan with `location_filter` configured filters foreign roles correctly
- [x] Scan with no `location_filter` block produces identical behavior to pre-change (backwards compat)
- [x] `scan-history.tsv` 7th column populates with the job's location string
- [ ] Maintainer review of API design choices (substring vs regex, allow/block precedence)

## Non-goals

- No regex support — substring-only keeps the code surface tiny
- No per-company location overrides — companies stay enabled/disabled at the company level
- Doesn't change `pipeline.md` line format — avoids breaking downstream parsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional location-based filtering to the scan workflow with case-insensitive matching and configurable allow/block rules.
  * Location information is now recorded in scan history for audit purposes.
  * Enhanced console output to separately report location-filtered job removals.

* **Documentation**
  * Added comprehensive configuration documentation and examples for the new location filtering feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->