### PR TITLE
fix(batch): include modes/_profile.md in worker sources of truth

### DIFF
--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -15,12 +15,14 @@ Eres un worker de evaluación de ofertas de empleo for the candidate (read name 
 | Archivo | Ruta absoluta | Cuándo |
 |---------|---------------|--------|
 | cv.md | `cv.md (project root)` | SIEMPRE |
+| _profile.md | `modes/_profile.md` | SIEMPRE (user overrides — archetypes, framing, factual constraints, custom rules) |
 | llms.txt | `llms.txt (if exists)` | SIEMPRE |
 | article-digest.md | `article-digest.md (project root)` | SIEMPRE (proof points) |
 | i18n.ts | `i18n.ts (if exists, optional)` | Solo entrevistas/deep |
 | cv-template.html | `templates/cv-template.html` | Para PDF |
 | generate-pdf.mjs | `generate-pdf.mjs` | Para PDF |
 
+**REGLA: `_profile.md` tiene prioridad sobre este prompt.** Cuando algo en `_profile.md` contradiga las reglas siguientes (archetype list, framing por rol, constraints, etc.), prevalece `_profile.md`. Consistente con `modes/_shared.md` línea 23: *"Read _profile.md AFTER this file. User customizations in _profile.md override defaults here."*
 **REGLA: NUNCA escribir en cv.md ni i18n.ts.** Son read-only.
 **REGLA: NUNCA hardcodear métricas.** Leerlas de cv.md + article-digest.md en el momento.
 **REGLA: Para métricas de artículos, article-digest.md prevalece sobre cv.md.** cv.md puede tener números más antiguos — es normal.


### PR DESCRIPTION
Closes #583.

## Summary
- Makes batch workers honor `modes/_profile.md` the same way interactive modes do.
- Two-line addition to `batch/batch-prompt.md`: one source row + one precedence rule.

## Why
Parallel `claude -p` batch workers spawned by `/career-ops batch` don't inherit the orchestrator's context. `modes/_shared.md` line 23 routes interactive modes through `_profile.md` ("Read _profile.md AFTER this file. User customizations in _profile.md override defaults here."), but `batch/batch-prompt.md`'s "Fuentes de Verdad" table omits it. Batch evaluations therefore use the upstream defaults baked into `batch-prompt.md` instead of the user's customizations (archetypes, adaptive framing, factual constraints).

See #583 for the detailed problem write-up.

## Diff
```diff
 | cv.md | `cv.md (project root)` | SIEMPRE |
+| _profile.md | `modes/_profile.md` | SIEMPRE (user overrides — archetypes, framing, factual constraints, custom rules) |
 | llms.txt | `llms.txt (if exists)` | SIEMPRE |
 ...
+**REGLA: `_profile.md` tiene prioridad sobre este prompt.** Cuando algo en `_profile.md` contradiga las reglas siguientes (archetype list, framing por rol, constraints, etc.), prevalece `_profile.md`. Consistente con `modes/_shared.md` línea 23: *"Read _profile.md AFTER this file. User customizations in _profile.md override defaults here."*
 **REGLA: NUNCA escribir en cv.md ni i18n.ts.** Son read-only.
```

## Test plan
- [ ] Add a custom rule to `modes/_profile.md` (e.g., a factual constraint about how a specific role should be framed, or a new entry in "Your Adaptive Framing").
- [ ] Run `/career-ops batch` against an offer that would trigger the customization.
- [ ] Confirm the worker's report reflects the `_profile.md` rule (without this PR, it would not).
- [ ] Run `/career-ops oferta` against the same offer and compare — output should be consistent across both modes.

## Compatibility
No behavior change for users without `_profile.md` customizations (the default `_profile.template.md` ships with archetype/framing slots that *match* `batch-prompt.md`'s defaults, so worker output is identical). Users with customizations: batch and interactive modes converge on the customized output, matching `_shared.md`'s documented intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system configuration to establish priority rules for data sources and enforce stricter validation constraints on editable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->