### PR TITLE
fix(update-system): include .agents/ in SYSTEM_PATHS

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -74,6 +74,7 @@ const SYSTEM_PATHS = [
   'dashboard/',
   'templates/',
   'fonts/',
+  '.agents/',
   '.claude/skills/',
   '.gemini/commands/',
   'docs/',


### PR DESCRIPTION
## What does this PR do?

Adds `.agents/` to `SYSTEM_PATHS` in `update-system.mjs` so the auto-updater syncs the canonical skill location alongside the `.claude/skills/` symlinks that point to it.

## Related issue

Fixes #596

## Root cause

PR #572 introduced the open-agent-skill layout: the real skill lives at `.agents/skills/career-ops/SKILL.md` and `.claude/skills/career-ops/SKILL.md` is a symlink (`../../../.agents/skills/career-ops/SKILL.md`) so every CLI scanning `.claude/skills/` resolves to the same file.

`update-system.mjs` listed `.claude/skills/` and `.gemini/commands/` in `SYSTEM_PATHS` but not `.agents/`. When existing users ran `node update-system.mjs apply` to move to v1.7.0, the symlink was synced but its target was never copied — the symlink dangled and `/career-ops` stopped loading as a slash command.

Fresh clones are unaffected because the whole tree (including `.agents/`) lands at clone time. The bug is specific to the auto-updater path, which is why `npm run doctor` and CI both pass.

Two users have confirmed the bug across macOS and Linux in #596.

## Fix

One line — add `.agents/` to `SYSTEM_PATHS`:

```diff
   'fonts/',
+  '.agents/',
   '.claude/skills/',
   '.gemini/commands/',
```

After this lands, users still on the broken state can run `node update-system.mjs apply` again to pull the missing `.agents/` tree, and the symlink will resolve.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass (66 passed, 0 failed; warnings are pre-existing and unrelated)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Follow-ups (out of scope here)

The reporter of #596 also suggested `doctor.mjs` flag dangling symlinks under `.claude/skills/` so this failure mode isn't silent. Happy to send that as a separate small PR if helpful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System update and rollback operations now correctly include additional system-level files in their scope when applying updates and restoring from backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->