### PR TITLE
fix(gemini-eval): Gemini endpoint returning 429 errors when using default model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,13 +6,13 @@
 # ── Gemini Integration (Issue #344) ─────────────────────────────────────────
 # Required for: node gemini-eval.mjs "JD text here"
 # Free API key: https://aistudio.google.com/apikey
-# Free tier: 15 RPM / 1M tokens/day with gemini-2.0-flash (no billing needed)
+# Free tier: 15 RPM / 1M tokens/day with gemini-2.5-flash (no billing needed)
 GEMINI_API_KEY=your_gemini_api_key_here
 
 # ── Optional: Override default Gemini model ───────────────────────────────────
-# Default: gemini-2.0-flash (free-tier, fast)
-# Alternatives: gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash-thinking-exp
-# GEMINI_MODEL=gemini-2.0-flash
+# Default: gemini-2.5-flash (free-tier, fast)
+# Alternatives: gemini-1.5-flash, gemini-1.5-pro, gemini-2.5-flash-thinking-exp
+# GEMINI_MODEL=gemini-2.5-flash
 
 # ── Other integrations (add your own below) ──────────────────────────────────
 # ANTHROPIC_API_KEY=your_anthropic_key_here   # For Claude-based workflows

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ node gemini-eval.mjs --file ./jds/my-job.txt
 npm run gemini:eval -- "JD text here"
 ```
 
-> **Free tier:** Both options work without billing. Native CLI uses Google OAuth; the API script uses `gemini-2.0-flash` (15 RPM, 1M tokens/day free).
+> **Free tier:** Both options work without billing. Native CLI uses Google OAuth; the API script uses `gemini-2.5-flash` (15 RPM, 1M tokens/day free).
 
 ## Usage
 

--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -14,7 +14,18 @@
  * Requires:
  *   GEMINI_API_KEY in .env (or environment variable)
  *
- * Free-tier model: gemini-2.0-flash (generous quota, no billing required)
+ * Free-tier model: gemini-2.5-flash (generous quota, no billing required)
+ *
+ * Model deprecation reference (per Google AI for Developers, May 2026):
+ *   - gemini-2.0-flash       deprecated 2026-03-31  (do not use)
+ *   - gemini-2.0-flash-lite  deprecated 2026-03-31
+ *   - gemini-2.5-flash       deprecated 2026-06-17  (current default)
+ *   - gemini-2.5-flash-lite  deprecated 2026-07-22
+ * Stable Gemini models follow a 12-month lifecycle from their release date.
+ * Source: https://ai.google.dev/gemini-api/docs/models
+ *
+ * When the current default approaches its deprecation date, bump
+ * `modelName` below and the `--model` examples accordingly.
  */
 
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
@@ -65,11 +76,11 @@ if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
   USAGE
     node gemini-eval.mjs "<JD text>"
     node gemini-eval.mjs --file ./jds/my-job.txt
-    node gemini-eval.mjs --model gemini-2.0-flash "<JD text>"
+    node gemini-eval.mjs --model gemini-2.5-flash "<JD text>"
 
   OPTIONS
     --file <path>    Read JD from a file instead of inline text
-    --model <name>   Gemini model to use (default: gemini-2.0-flash)
+    --model <name>   Gemini model to use (default: gemini-2.5-flash)
     --no-save        Do not save report to reports/ directory
     --help           Show this help
 
@@ -87,7 +98,7 @@ if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
 
 // Parse flags
 let jdText = '';
-let modelName = process.env.GEMINI_MODEL || 'gemini-2.0-flash';
+let modelName = process.env.GEMINI_MODEL || 'gemini-2.5-flash';
 let saveReport = true;
 
 for (let i = 0; i < args.length; i++) {


### PR DESCRIPTION
## What does this PR do?

Bumps default Gemini model to `gemini-2.5-flash`. 
Includes model deprecation dates in documentation

## Related issue
Resolves https://github.com/santifer/career-ops/issues/614

## Type of change

- [x] Bug fix
- [x] Documentation / translation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Gemini model from 2.0-flash to 2.5-flash in configuration and documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/615)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->