### PR TITLE
fix(gemini-eval): include profile.yml and _profile.md in evaluation

### DIFF
--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -40,13 +40,15 @@ const ROOT = dirname(fileURLToPath(import.meta.url));
 
 const PATHS = {
   // Primary evaluation logic lives in these two mode files
-  shared:   join(ROOT, 'modes', '_shared.md'),
-  oferta:   join(ROOT, 'modes', 'oferta.md'),
+  shared:      join(ROOT, 'modes', '_shared.md'),
+  oferta:      join(ROOT, 'modes', 'oferta.md'),
   // Canonical skill path referenced in Issue #344
-  evaluate: join(ROOT, '.claude', 'skills', 'career-ops', 'SKILL.md'),
-  cv:       join(ROOT, 'cv.md'),
-  reports:  join(ROOT, 'reports'),
-  tracker:  join(ROOT, 'data', 'applications.md'),
+  evaluate:    join(ROOT, '.claude', 'skills', 'career-ops', 'SKILL.md'),
+  cv:          join(ROOT, 'cv.md'),
+  profile:     join(ROOT, 'modes', '_profile.md'),
+  profileYml:  join(ROOT, 'config', 'profile.yml'),
+  reports:     join(ROOT, 'reports'),
+  tracker:     join(ROOT, 'data', 'applications.md'),
 };
 
 // ---------------------------------------------------------------------------
@@ -163,9 +165,11 @@ if (!readdirSync) {
 // ---------------------------------------------------------------------------
 console.log('\n📂  Loading context files...');
 
-const sharedContext  = readFile(PATHS.shared,   'modes/_shared.md');
-const ofertaLogic    = readFile(PATHS.oferta,   'modes/oferta.md');
-const cvContent      = readFile(PATHS.cv,       'cv.md');
+const sharedContext  = readFile(PATHS.shared,      'modes/_shared.md');
+const ofertaLogic    = readFile(PATHS.oferta,      'modes/oferta.md');
+const cvContent      = readFile(PATHS.cv,          'cv.md');
+const profileContent = readFile(PATHS.profile,     'modes/_profile.md');
+const profileYml     = readFile(PATHS.profileYml,  'config/profile.yml');
 
 // ---------------------------------------------------------------------------
 // Build the system prompt (mirrors the Claude skill router logic)
@@ -189,6 +193,16 @@ ${ofertaLogic}
 CANDIDATE RESUME (cv.md)
 ═══════════════════════════════════════════════════════
 ${cvContent}
+
+═══════════════════════════════════════════════════════
+CANDIDATE PROFILE & TARGETS (config/profile.yml)
+═══════════════════════════════════════════════════════
+${profileYml}
+
+═══════════════════════════════════════════════════════
+USER ARCHETYPES & NARRATIVE (_profile.md)
+═══════════════════════════════════════════════════════
+${profileContent}
 
 ═══════════════════════════════════════════════════════
 IMPORTANT OPERATING RULES FOR THIS CLI SESSION


### PR DESCRIPTION
- Adds `profile` and `profileYml` entries to PATHS.
- Appends two new sections to the system prompt after CANDIDATE RESUME: CANDIDATE PROFILE & TARGETS (config/profile.yml) and USER ARCHETYPES & NARRATIVE (_profile.md). After this change, `node gemini-eval.mjs` produces evaluations from the same context surface as `/career-ops oferta` in Claude Code.

## Related issue

Resolves https://github.com/santifer/career-ops/issues/617

## Type of change

- [x] Bug fix



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluations now incorporate candidate profile information and user archetype definitions, delivering more contextually relevant and personalized assessments that better reflect organizational targets and constraints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/618)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->