### PR TITLE
fix(merge-tracker): preserve short specialty acronyms + require non-baseline overlap

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -94,12 +94,37 @@ const ROLE_STOPWORDS = new Set([
   'with', 'from', 'into', 'over', 'this', 'that',
 ]);
 
+// Short specialty acronyms that ARE discriminating despite their length.
+// Without this allowlist, `length > 3` strips them out, leaving only the
+// generic "Software Engineer" baseline (see Issue #633).
+//
+// Deliberately narrow: includes tokens like 'api' / 'sre' / 'sdk' that name
+// a specific team or technology, and excludes broad ones like 'ai' / 'ml' /
+// 'llm' that appear across many roles (AI Engineer, ML Manager, etc.).
+// Adding the broad ones would regress #329's AI Success/Deployment case.
+const SHORT_SPECIALTY = new Set([
+  'api', 'sre', 'sdk', 'cli', 'gpu', 'cpu',
+  'ios', 'qa', 'ux', 'ui', 'ar', 'vr',
+  'ocr', 'crm', 'erp',
+]);
+
+// Generic role-level descriptors. Two roles whose ONLY overlap is in this
+// set (e.g. [software, engineer]) are NOT the same role — they're just
+// labelled at the same altitude. See Issue #633: "Staff SWE, API" vs
+// "Staff SWE, Kubernetes Platform" share [software, engineer] only.
+const BASELINE_TOKENS = new Set([
+  'software', 'engineer', 'developer', 'manager', 'architect',
+  'analyst', 'designer', 'consultant', 'specialist',
+  'platform', 'systems', 'services',
+  'backend', 'frontend', 'fullstack',
+]);
+
 function roleTokens(s) {
   return s
     .toLowerCase()
     .replace(/[^a-z0-9\s]/g, ' ')
     .split(/\s+/)
-    .filter(w => w.length > 3 && !ROLE_STOPWORDS.has(w));
+    .filter(w => (w.length > 3 || SHORT_SPECIALTY.has(w)) && !ROLE_STOPWORDS.has(w));
 }
 
 function roleFuzzyMatch(a, b) {
@@ -108,16 +133,21 @@ function roleFuzzyMatch(a, b) {
   if (wordsA.length === 0 || wordsB.length === 0) return false;
 
   const setB = new Set(wordsB);
-  const overlap = wordsA.filter(w => setB.has(w)).length;
-  if (overlap === 0) return false;
+  const overlap = wordsA.filter(w => setB.has(w));
+  if (overlap.length < 2) return false;
+
+  // Require at least one non-baseline token in the overlap. Roles that
+  // share only generic descriptors like [software, engineer] are NOT the
+  // same role (see Issue #633).
+  const discriminating = overlap.filter(w => !BASELINE_TOKENS.has(w));
+  if (discriminating.length === 0) return false;
 
   // Jaccard-style ratio on content tokens. Two roles are "the same" only
   // when the overlap dominates the smaller side — not when they just share
   // a location + "engineer".
   const minLen = Math.min(wordsA.length, wordsB.length);
-  const ratio = overlap / minLen;
-
-  return overlap >= 2 && ratio >= 0.6;
+  const ratio = overlap.length / minLen;
+  return ratio >= 0.6;
 }
 
 function extractReportNum(reportStr) {


### PR DESCRIPTION
## Summary

Closes #633 (follow-on to #329).

`roleFuzzyMatch()` still over-matched when a role's specialty token got filtered out by `length > 3`, leaving only the generic `[software, engineer]` baseline. Two changes, layered:

1. **`SHORT_SPECIALTY` allowlist** preserves discriminating short acronyms (`api`, `sre`, `sdk`, `gpu`, `ios`, `qa`, `ux`, `ui`, `ocr`, `crm`, `erp`). Deliberately narrow — `ai` / `ml` / `llm` were excluded because they appear across many distinct roles (AI Engineer, ML Manager, etc.) and adding them would regress #329's AI Success/Deployment case.

2. **`BASELINE_TOKENS` gate** — refuse to match when the overlap is ENTIRELY generic role-level descriptors (`software`, `engineer`, `manager`, `architect`, `platform`, `backend`, etc.). Two roles sharing only `[software, engineer]` are not the same role — they're labelled at the same altitude.

## Reproduction (from issue #633)

Real batch on 2026-05-12:

```
Existing: #5  "Senior Staff Software Engineer, API"            (4.5/5)
New TSV:  #30 "Staff Software Engineer, Kubernetes Platform"   (2.4/5)
```

Both reduced to `[software, engineer]` after the stopword + length filters (`api` is length 3, dropped). Overlap=2, ratio=1.0 → false match → new entry silently skipped because its score was lower. Report `029-anthropic-2026-05-12.md` existed on disk with no tracker row.

## Test results

Verified against 14 cases — #633 reproduction + #633 ML/AI Platform variant + all 10 of #329's regression cases + 2 same-role-different-seniority sanity checks. **14/14 passing.**

| A | B | Expected | Result |
|---|---|----------|--------|
| Senior Staff SWE, API | Staff SWE, Kubernetes Platform | no match | ✅ |
| Staff SWE, ML Platform | Staff SWE, AI Platform | no match | ✅ |
| AI Success Engineer - Tokyo | AI Deployment Engineer - Tokyo | no match | ✅ |
| AI Success Engineer - Tokyo | AI Support Engineer - Tokyo | no match | ✅ |
| AI Success Engineer - Tokyo | Senior Support Engineer - Tokyo | no match | ✅ |
| AI Success Engineer - Tokyo | AI Deployment Engineer, Codex - Tokyo | no match | ✅ |
| Partner Director - Tokyo | Partner Director | match | ✅ |
| Strategic Partnerships Lead, Japan | Strategic Partnerships Lead - Japan | match | ✅ |
| Forward Deployed Engineer - Tokyo | Forward Deployed Software Engineer - Tokyo | match | ✅ |
| Revenue Strategy & Operations Lead, Japan | Revenue Strategy & Operations Lead | match | ✅ |
| Solutions Engineer - Tokyo | Solutions Architect - Tokyo | no match | ✅ |
| Head of Finance | Head of Social | no match | ✅ |
| Staff SWE, API | Senior Staff SWE, API | match | ✅ |
| Staff SWE, SRE | Staff SWE, SRE Platform | match | ✅ |

## Test plan

- [x] `node test-all.mjs` — 66 passed, 0 failed
- [x] `node merge-tracker.mjs` — runs clean against a populated `tracker-additions/` and `applications.md`
- [x] Inline 14-case verification script (see commit message for details)
- [ ] Reviewer can sanity-check the SHORT_SPECIALTY and BASELINE_TOKENS sets — these are judgment calls and may want trimming/expanding based on the maintainer's view

## Notes for reviewer

- Refined from the issue's proposal: the issue suggested Option A (short specialty allowlist) + Option C (min-3-tokens guard). The min-3-tokens guard was too aggressive — it killed legitimate matches like `Strategic Partnerships Lead - Japan` ↔ `Strategic Partnerships Lead, Japan` (2 tokens each after stopwords). The `BASELINE_TOKENS` gate is a finer-grained version that handles the original case without breaking those.
- Broad acronyms (`ai`, `ml`, `cv`, `llm`, `nlp`) deliberately excluded from `SHORT_SPECIALTY` — including them re-introduces #329's failure mode.
- No new exports, no test-file addition — kept the PR minimal. Happy to add proper unit tests in a follow-up if the maintainers want them; would require wrapping the top-level procedural code in a `main()` guard first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection accuracy for similar job titles by implementing stricter matching criteria that reduce false positives while better distinguishing between comparable roles.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/634)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->