### PR TITLE
Fix CV certification alignment

### DIFF
--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -285,8 +285,8 @@
 
   /* === CERTIFICATIONS === */
   .cert-item {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(90px, max-content) 44px;
     align-items: baseline;
     gap: 12px;
     margin-bottom: 6px;
@@ -296,16 +296,19 @@
     font-size: 10.5px;
     font-weight: 500;
     color: #333;
+    min-width: 0;
   }
 
   .cert-org {
     color: hsl(270, 70%, 45%);
+    white-space: nowrap;
   }
 
   .cert-year {
     font-size: 10px;
     color: #777;
     white-space: nowrap;
+    text-align: right;
   }
 
   /* === SKILLS === */


### PR DESCRIPTION
## Summary
- Change certification rows from `space-between` flex layout to a stable three-column grid.
- Keep long certification titles constrained while issuer names and years stay aligned.
- Prevent issuer/year wrapping and right-align the year column.

## Why
Long certification names could push issuer names to different x-positions in generated CV PDFs, making the certifications section look misaligned.

## Test plan
- `node - <<'NODE' ... NODE` certification CSS regression checks
- `node --check test-all.mjs && node --check generate-pdf.mjs`
- `node test-all.mjs --quick` — 64 passed, 0 failed, 24 warnings; `cv-sync-check` warning is expected in an isolated worktree without user data, and personal-data warnings are pre-existing upstream references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Certifications section layout with better organization of certificate details (content, organization, and year).
  * Enhanced text display handling to prevent unwanted text wrapping and ensure proper alignment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/638)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->