### PR TITLE
feat(compass): career discovery mode for users who don't know their target roles

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -3,7 +3,7 @@ name: career-ops
 description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
 arguments: mode # Claude Code specific
 user-invocable: true
-argument-hint: "[scan | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
+argument-hint: "[compass | scan | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
 license: MIT
 ---
 
@@ -17,6 +17,7 @@ Determine the mode from `$mode`:
 |-------|------|
 | (empty / no args) | `discovery` -- Show command menu |
 | JD text or URL (no sub-command) | **`auto-pipeline`** |
+| `compass` | `compass` |
 | `oferta` | `oferta` |
 | `ofertas` | `ofertas` |
 | `contacto` | `contacto` |
@@ -48,6 +49,7 @@ career-ops -- Command Center
 
 Available commands:
   /career-ops {JD}      → AUTO-PIPELINE: evaluate + report + PDF + tracker (paste text or URL)
+  /career-ops compass   → Career discovery: figure out what you want + set up your profile
   /career-ops pipeline  → Process pending URLs from inbox (data/pipeline.md)
   /career-ops oferta    → Evaluation only A-F (no auto PDF)
   /career-ops ofertas   → Compare and rank multiple offers
@@ -77,7 +79,7 @@ After determining the mode, load the necessary files before executing:
 ### Modes that require `_shared.md` + their mode file:
 Read `modes/_shared.md` + `modes/{mode}.md`
 
-Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`, `compass`
 
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,11 @@ If `config/profile.yml` is missing, copy from `config/profile.example.yml` and t
 
 Fill in `config/profile.yml` with their answers. For archetypes and targeting narrative, store the user-specific mapping in `modes/_profile.md` or `config/profile.yml` rather than editing `modes/_shared.md`.
 
+**If the user is uncertain about target roles** (signals: "I don't know", "not sure", "still figuring it out", "exploring", "at a crossroads", or no clear answer to what roles they're targeting) → respond:
+> "No problem — run `/career-ops compass` and I'll help you figure it out. It takes about 5–10 minutes and ends with your profile fully set up."
+
+Do not attempt to run compass inline during onboarding. Route to it as a standalone follow-up.
+
 #### Step 3: Portals (recommended)
 If `portals.yml` is missing:
 > "I'll set up the job scanner with 45+ pre-configured companies. Want me to customize the search keywords for your target roles?"
@@ -194,6 +199,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 
 | If the user... | Mode |
 |----------------|------|
+| Doesn't know target roles or wants career direction help | `compass` |
 | Pastes JD or URL | auto-pipeline (evaluate + report + PDF + tracker) |
 | Asks to evaluate offer | `oferta` |
 | Asks to compare offers | `ofertas` |

--- a/docs/superpowers/specs/2026-05-13-compass-mode-design.md
+++ b/docs/superpowers/specs/2026-05-13-compass-mode-design.md
@@ -1,0 +1,204 @@
+# Design Spec: `/career-ops compass` — Career Discovery Mode
+
+**Date:** 2026-05-13  
+**Status:** Approved  
+**PR scope:** `modes/compass.md` (new) + `AGENTS.md` (modified) + `.claude/skills/career-ops/career-ops.md` (modified)  
+**Follow-on PR:** `/career-ops polish` — CV enhancement for target archetypes (out of scope here)
+
+---
+
+## Problem
+
+The current onboarding flow (AGENTS.md Step 2) assumes the user already knows their target roles and archetypes. Users who don't know what they want — or who are at a career crossroads — have no guided path. They land in a system built for clarity before they have it.
+
+---
+
+## Goal
+
+Give users who don't know their direction a structured, conversational path to figure it out — and end up with a working `profile.yml` and `_profile.md` without having to fill in blanks themselves.
+
+---
+
+## Design
+
+### Overview
+
+A single new mode, `compass`, that combines:
+1. Silent CV analysis (what your background implies)
+2. Adaptive discovery questions (what you actually want)
+3. An ikigai-style reveal comparing the two
+4. Interactive profile file drafting with section-by-section approval
+
+The mode is standalone (`/career-ops compass`) and reachable from onboarding when the user is unclear on target roles.
+
+---
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `modes/compass.md` | New mode file — all discovery logic |
+| `AGENTS.md` | Step 2 onboarding: add offramp for users who don't know their target roles |
+| `.claude/skills/career-ops/career-ops.md` | Add `compass` to routing table and discovery menu |
+
+---
+
+### Compass Flow
+
+#### Phase 0 — Profile Check
+
+Read `config/profile.yml` and `modes/_profile.md`.
+
+- If both are missing or contain only example/placeholder data → proceed to Phase 1 directly
+- If real data exists → ask: *"I see you already have a profile set up. Do you want to revisit your direction, or start fresh?"*
+  - "Revisit" → run full compass, frame questions around what's changed
+  - "Start fresh" → run full compass as if no profile exists
+  - Either path ends at Phase 4 with a new draft
+
+**Placeholder detection:** profile is considered a placeholder if `candidate.full_name` is `"Jane Smith"` or `candidate.email` contains `"example.com"`.
+
+---
+
+#### Phase 1 — Silent CV Analysis
+
+Read `cv.md`. Do not show output to the user. Internally derive:
+
+- **Domains** — what fields/industries the candidate has worked in
+- **Functions** — what they've actually done (build, consult, manage, train, sell, deploy, support)
+- **Seniority signals** — years of experience, titles held, scope of responsibility
+- **Candidate archetypes** — 2–3 best-fit archetypes from `_shared.md` with internal rationale notes
+
+Store all of this. It will surface only in Phase 3.
+
+---
+
+#### Phase 2 — Adaptive Discovery Questions
+
+Ask questions conversationally, one at a time. Never present a form or numbered list.
+
+**Core questions (always asked, in this order):**
+
+1. *"What kind of work energizes you most — building things, helping people solve problems, leading strategy, something else?"*
+2. *"What would you want more of in your next role that you don't have enough of now?"*
+3. *"What would be a hard no — work that would drain you, or conditions you'd walk away from?"*
+
+**Adaptive follow-ups** — ask when signals warrant it:
+
+| Signal | Follow-up |
+|--------|-----------|
+| Vague or "I don't know" answer | *"Tell me about a time at work when you felt most in your element. What were you doing?"* |
+| Mentions a crossroads or transition | *"What's changed for you recently that's making you rethink your direction?"* |
+| Clear direction but two competing options | *"If you had to pick one to optimize for in the next 2 years, which would it be — [A] or [B]?"* |
+| No mention of environment preferences | *"What kind of company environment fits you best — early-stage startup, growth-stage, enterprise, or something else?"* |
+| No signal on IC vs leadership | *"Do you want to go deeper as an individual contributor, or are you drawn to building and leading a team?"* |
+| Ambiguous on remote/location | *"Any constraints on location or travel?"* |
+
+**Stopping rule:** stop asking when archetypes have converged and deal-breakers are clear. Minimum 3 questions, maximum 10. If the user is consistently uncertain after 7 questions, surface a "here's what I'm hearing" summary and ask them to react rather than asking more questions.
+
+---
+
+#### Phase 3 — Ikigai Reveal
+
+This is the moment where the two threads come together.
+
+Present in three parts:
+
+**Part 1 — What your background says:**
+> *"Based on your CV alone, before you told me anything, here's where I would have pointed you..."*
+
+Show the 2–3 CV-derived archetype candidates with a one-sentence rationale for each (e.g., "9 years of client-facing technical work at enterprise software companies is a strong signal for Solutions Architect or Forward Deployed Engineer").
+
+**Part 2 — What you told me:**
+> *"Here's what I heard from your answers..."*
+
+A brief synthesis of the discovery questions: what energizes them, what they want more of, their deal-breakers, and any strong directional signals.
+
+**Part 3 — Where they overlap (and where they don't):**
+> *"Here's where your background and your answers point to the same place — that's your strongest signal..."*
+
+Highlight archetype(s) that appear in both the CV analysis and the discovery answers. If there's a gap — e.g., CV points to Solutions Architect but the user said they want to stop being client-facing — name it explicitly and let them react.
+
+End with:
+- **Primary archetype(s):** strongest fit, both from background and stated preferences
+- **Secondary archetype(s):** good fit, one dimension may be a stretch
+- **Notable gap (if any):** where background and preferences diverge, with a note on what bridging it would take
+
+Ask: *"Does this feel right, or does something land wrong?"* Adjust before moving to Phase 4.
+
+---
+
+#### Phase 4 — Profile Draft & Approval
+
+Draft both files. Present section by section. Write only after the user approves.
+
+**`config/profile.yml` sections (presented in order):**
+
+1. `candidate` block — populate from CV (name, email, phone, location, LinkedIn, GitHub)
+2. `target_roles` block — populate from Phase 3 archetype recommendations
+3. `narrative` block — headline, superpowers, and proof points derived from CV + discovery
+4. `compensation` block — ask directly if not surfaced in discovery: *"What's your target comp range and your walk-away number?"*
+5. `location` block — populate from CV + any constraints surfaced in discovery
+
+For each section: show the draft, ask *"Does this look right?"*, accept edits or approval, move on.
+
+**`modes/_profile.md` sections (presented after profile.yml is approved):**
+
+1. Target roles table — archetypes from Phase 3 with fit levels
+2. Adaptive framing table — how to position CV for each archetype
+3. Exit narrative — drafted from the discovery answers and CV summary
+4. Comp targets and negotiation scripts — populated from profile.yml comp block
+5. Location policy — populated from profile.yml location block
+
+Same section-by-section approval flow.
+
+**Write gate:** only write files after the user has approved all sections. Write both files atomically. Confirm with: *"Profile saved. You're ready to start evaluating roles — paste a job description or URL to run the full pipeline."*
+
+---
+
+### Onboarding Integration (AGENTS.md)
+
+In Step 2 (Profile setup), after asking for target roles, add:
+
+> If the user says "I don't know", "not sure", "exploring", or otherwise signals uncertainty about target roles → respond:
+> *"No problem — run `/career-ops compass` and I'll help you figure it out. It takes about 5–10 minutes and ends with your profile fully set up."*
+
+Do not attempt to run compass inline during onboarding. Route to it as a standalone follow-up.
+
+---
+
+### Router Changes (`.claude/skills/career-ops/career-ops.md`)
+
+Add to routing table:
+```
+| `compass` | `compass` |
+```
+
+Add to discovery menu:
+```
+/career-ops compass  → Career discovery: figure out what you want + set up your profile
+```
+
+Position it near the top of the menu, before `scan` — it's the first thing a new user without a clear direction needs.
+
+---
+
+## Success Criteria
+
+- A user with no `profile.yml` and no idea what they want can run `/career-ops compass` and end up with a complete, personalized `profile.yml` and `_profile.md` that they feel good about
+- A user who already has a profile can re-run compass when their direction changes, and update their profile without losing data they want to keep
+- The ikigai reveal moment surfaces at least one insight the user hadn't considered — either an archetype they didn't know existed, or a gap between what their background says and what they actually want
+- The adaptive question count stays between 3–10; no user should feel interrogated or bored
+
+---
+
+## Out of Scope
+
+- CV rewriting or enhancement (→ `/career-ops polish`, future PR)
+- Comp market research during compass (Block D in `oferta.md` covers this per-job; compass uses user-provided comp targets only)
+- Multi-language compass modes (DE/FR/JA) — can follow once English version is stable
+
+---
+
+## Follow-on PR
+
+**`/career-ops polish`** — given a finalized profile with target archetypes, analyze `cv.md` and produce a prioritized list of improvements to strengthen the CV for those archetypes. Operates on the baseline CV, not a job-specific tailoring (that's already handled by `modes/pdf.md`).

--- a/docs/superpowers/specs/2026-05-13-compass-mode-design.md
+++ b/docs/superpowers/specs/2026-05-13-compass-mode-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-13  
 **Status:** Approved  
-**PR scope:** `modes/compass.md` (new) + `AGENTS.md` (modified) + `.claude/skills/career-ops/career-ops.md` (modified)  
+**PR scope:** `modes/compass.md` (new) + `AGENTS.md` (modified) + `.agents/skills/career-ops/SKILL.md` (modified, symlinked from `.claude/`)  
 **Follow-on PR:** `/career-ops polish` — CV enhancement for target archetypes (out of scope here)
 
 ---
@@ -39,7 +39,7 @@ The mode is standalone (`/career-ops compass`) and reachable from onboarding whe
 |------|--------|
 | `modes/compass.md` | New mode file — all discovery logic |
 | `AGENTS.md` | Step 2 onboarding: add offramp for users who don't know their target roles |
-| `.claude/skills/career-ops/career-ops.md` | Add `compass` to routing table and discovery menu |
+| `.agents/skills/career-ops/SKILL.md` | Add `compass` to routing table and discovery menu (symlinked from `.claude/`) |
 
 ---
 
@@ -61,7 +61,9 @@ Read `config/profile.yml` and `modes/_profile.md`.
 
 #### Phase 1 — Silent CV Analysis
 
-Read `cv.md`. Do not show output to the user. Internally derive:
+Read `cv.md` if it exists. Do not show output to the user. Internally derive:
+
+If `cv.md` is absent, skip the analysis and proceed to Phase 2. Archetype detection becomes discovery-only; the Phase 3 reveal will omit the CV-derived baseline and present discovery findings directly.
 
 - **Domains** — what fields/industries the candidate has worked in
 - **Functions** — what they've actually done (build, consult, manage, train, sell, deploy, support)
@@ -166,15 +168,17 @@ Do not attempt to run compass inline during onboarding. Route to it as a standal
 
 ---
 
-### Router Changes (`.claude/skills/career-ops/career-ops.md`)
+### Router Changes (`.agents/skills/career-ops/SKILL.md`)
 
 Add to routing table:
-```
+
+```md
 | `compass` | `compass` |
 ```
 
 Add to discovery menu:
-```
+
+```md
 /career-ops compass  → Career discovery: figure out what you want + set up your profile
 ```
 

--- a/modes/compass.md
+++ b/modes/compass.md
@@ -1,0 +1,217 @@
+# Mode: compass — Career Discovery
+
+Help users who don't know their target roles figure out what they want.
+Combines silent CV analysis, adaptive discovery questions, an ikigai-style
+reveal, and interactive profile drafting.
+
+This mode is standalone (`/career-ops compass`) and reachable from onboarding
+when the user signals uncertainty about target roles.
+
+---
+
+## Phase 0 — Profile Check
+
+Read `config/profile.yml` and `modes/_profile.md`.
+
+**Placeholder detection:** a profile is considered unconfigured if
+`candidate.full_name` is `"Jane Smith"` OR `candidate.email` contains
+`"example.com"` OR either file does not exist.
+
+- If unconfigured → proceed to Phase 1 directly, no prompt needed.
+- If real data exists → ask:
+  > "I see you already have a profile set up. Do you want to revisit your
+  > direction, or start fresh?"
+  - "Revisit" → run full compass, frame questions around what has changed
+  - "Start fresh" → run full compass as if no profile exists
+  - Either path ends at Phase 4 with a new draft
+
+---
+
+## Phase 1 — Silent CV Analysis
+
+Read `cv.md`. **Do not show this analysis to the user yet.**
+
+Internally derive and store:
+
+- **Domains** — what fields/industries the candidate has worked in
+- **Functions** — what they have actually done: build, consult, manage,
+  train, sell, deploy, support (can be multiple)
+- **Seniority signals** — years of experience, titles held, scope of
+  responsibility described in role bullets
+- **Candidate archetypes** — 2–3 best-fit archetypes from the table in
+  `modes/_shared.md`, each with a one-sentence rationale note
+
+Store all of this. It surfaces only in Phase 3.
+
+---
+
+## Phase 2 — Adaptive Discovery Questions
+
+Ask questions one at a time, conversationally. Never present a numbered
+list or a form. Maintain the tone of a thoughtful career coach, not a
+survey.
+
+### Core questions (always asked, in this order)
+
+1. *"What kind of work energizes you most — building things, helping people
+   solve problems, leading strategy, something else entirely?"*
+
+2. *"What would you want more of in your next role that you don't have
+   enough of now?"*
+
+3. *"What would be a hard no — work that would drain you, or conditions
+   you'd walk away from?"*
+
+### Adaptive follow-ups
+
+After each answer, assess whether more depth is needed. Use this table:
+
+| Signal in the answer | Follow-up to ask |
+|----------------------|-----------------|
+| Vague, "I don't know", or very short | *"Tell me about a time at work when you felt most in your element. What were you doing?"* |
+| Mentions a transition, crossroads, or feeling stuck | *"What's changed recently that's making you rethink your direction?"* |
+| Two competing directions mentioned | *"If you had to pick one to optimize for over the next two years — [A] or [B] — which would it be?"* |
+| No mention of environment or company type | *"What kind of company fits you best — early-stage startup, growth-stage, enterprise, or something else?"* |
+| No signal on IC vs. leadership | *"Do you want to go deeper as an individual contributor, or are you drawn to building and leading a team?"* |
+| No signal on remote/location | *"Any constraints on location or travel?"* |
+
+### Stopping rule
+
+- **Minimum:** 3 questions (the core set)
+- **Maximum:** 10 questions total
+- **Stop early** when archetypes have converged and deal-breakers are clear
+- **If still uncertain after 7 questions:** surface a summary instead of
+  asking more:
+  > *"Here's what I'm hearing so far: [2–3 sentence synthesis]. Does that
+  > resonate, or does something feel off?"*
+  Use their reaction to finalize the picture.
+
+---
+
+## Phase 3 — Ikigai Reveal
+
+Present the three-part reveal. This is the moment where the two threads
+— what the CV shows and what the user said — come together.
+
+### Part 1: What your background says
+
+> *"Before you told me anything, here's where your CV alone would have
+> pointed me..."*
+
+List the 2–3 CV-derived archetype candidates from Phase 1. For each,
+give the one-sentence rationale stored in Phase 1.
+
+Example:
+> *"9 years of client-facing pre-sales work at enterprise software
+> companies is a strong signal for Solutions Architect or Forward
+> Deployed Engineer."*
+
+### Part 2: What you told me
+
+> *"Here's what I heard from your answers..."*
+
+Write a 3–5 sentence synthesis: what energizes them, what they want
+more of, their deal-breakers, and any strong directional signals.
+
+### Part 3: Where they overlap — and where they don't
+
+> *"Here's where your background and your answers point to the same
+> place. That's your strongest signal."*
+
+- **Overlap** — archetype(s) that appear in both the CV analysis and
+  the discovery answers: lead with these as primary recommendations
+- **Gap (if any)** — where background and stated preferences diverge:
+  name it explicitly and invite a reaction before moving on
+  > *"Your CV points strongly toward [X], but you said [Y]. That's
+  > worth pausing on — is [X] something you'd want to lean into, or
+  > are you actively moving away from it?"*
+
+End with clear recommendations:
+
+| Fit | Archetype(s) | Why |
+|-----|-------------|-----|
+| Primary | ... | Both CV and stated preference point here |
+| Secondary | ... | Strong from one signal, partial from the other |
+
+Ask: *"Does this feel right, or does something land wrong?"*
+
+Adjust based on the response before proceeding to Phase 4. Do not
+move forward until the user confirms the recommendations feel accurate.
+
+---
+
+## Phase 4 — Profile Draft & Approval
+
+Draft both `config/profile.yml` and `modes/_profile.md`. Present each
+section, get approval, then move to the next. Write files only after
+all sections are approved.
+
+### profile.yml — section by section
+
+Present each block as a formatted preview. Ask *"Does this look right?"*
+after each one. Accept edits inline before moving on.
+
+**Block 1: candidate**
+Populate from `cv.md` (name, email, phone, location, LinkedIn, GitHub).
+Show as a YAML preview.
+
+**Block 2: target_roles**
+Populate from Phase 3 archetype recommendations.
+- `primary`: archetype names with fit = primary
+- `archetypes`: full list with fit levels from Phase 3 table
+
+**Block 3: narrative**
+- `headline`: one-line professional identity, drafted from CV summary
+  and Phase 2 discovery
+- `superpowers`: 3–5 bullets derived from the functions identified in
+  Phase 1 and the "energizes you" answers from Phase 2
+- `proof_points`: notable projects or achievements from `cv.md`, each
+  with a `hero_metric` if one can be derived
+
+**Block 4: compensation**
+If a comp range surfaced during Phase 2 discovery, use it.
+If not, ask directly:
+> *"What's your target comp range and your walk-away number?"*
+
+**Block 5: location**
+Populate from `cv.md` location and any constraints surfaced in Phase 2.
+
+### _profile.md — section by section
+
+Present each section after `profile.yml` is fully approved.
+
+**Section 1: Target roles table**
+Archetypes from Phase 3, same fit levels. Follow the table format from
+`modes/_profile.template.md`.
+
+**Section 2: Adaptive framing table**
+For each archetype, a brief note on which parts of the candidate's
+background to emphasize. Derived from Phase 1 functions and Phase 2
+answers.
+
+**Section 3: Exit narrative**
+A 2–3 sentence professional narrative bridging past experience to
+target direction. Draws from CV summary + Phase 2 discovery.
+
+**Section 4: Comp targets and negotiation scripts**
+Populated from the compensation block approved in profile.yml.
+Use the script templates from `_profile.template.md` filled with
+real numbers.
+
+**Section 5: Location policy**
+Populated from profile.yml location block and any remote/travel
+preferences from Phase 2.
+
+### Write gate
+
+Only write files after the user has approved all sections of both files.
+
+Write both files in sequence: `config/profile.yml` first, then
+`modes/_profile.md`.
+
+Confirm:
+> *"Profile saved. You're ready to start evaluating roles — paste a
+> job description or URL to run the full pipeline."*
+
+If the user skips a section, write the file with that section left as
+the template placeholder so they can fill it in later.

--- a/modes/compass.md
+++ b/modes/compass.md
@@ -22,14 +22,20 @@ Read `config/profile.yml` and `modes/_profile.md`.
   > "I see you already have a profile set up. Do you want to revisit your
   > direction, or start fresh?"
   - "Revisit" → run full compass, frame questions around what has changed
-  - "Start fresh" → run full compass as if no profile exists
+  - "Start fresh" → discard the existing profile data from your working
+    context and run full compass as if no profile exists; do not surface
+    existing profile content during Phase 2 or Phase 3
   - Either path ends at Phase 4 with a new draft
 
 ---
 
 ## Phase 1 — Silent CV Analysis
 
-Read `cv.md`. **Do not show this analysis to the user yet.**
+Read `cv.md` if it exists. **Do not show this analysis to the user yet.**
+
+If `cv.md` does not exist, skip the analysis and proceed to Phase 2.
+Archetype detection will be discovery-only; the ikigai reveal in Phase 3
+will present discovery findings only, without a CV-derived baseline.
 
 Internally derive and store:
 
@@ -149,7 +155,8 @@ all sections are approved.
 ### profile.yml — section by section
 
 Present each block as a formatted preview. Ask *"Does this look right?"*
-after each one. Accept edits inline before moving on.
+after each one. If the user requests edits, apply them and re-present
+the updated block for confirmation before moving on.
 
 **Block 1: candidate**
 Populate from `cv.md` (name, email, phone, location, LinkedIn, GitHub).
@@ -195,8 +202,9 @@ target direction. Draws from CV summary + Phase 2 discovery.
 
 **Section 4: Comp targets and negotiation scripts**
 Populated from the compensation block approved in profile.yml.
-Use the script templates from `_profile.template.md` filled with
-real numbers.
+Use the "Your Negotiation Scripts" section of `modes/_profile.template.md`
+as the script structure, replacing bracketed placeholders with real numbers
+from the approved compensation block.
 
 **Section 5: Location policy**
 Populated from profile.yml location block and any remote/travel

--- a/modes/compass.md
+++ b/modes/compass.md
@@ -101,6 +101,8 @@ Present the three-part reveal. This is the moment where the two threads
 
 ### Part 1: What your background says
 
+If `cv.md` was present in Phase 1:
+
 > *"Before you told me anything, here's where your CV alone would have
 > pointed me..."*
 
@@ -112,6 +114,9 @@ Example:
 > companies is a strong signal for Solutions Architect or Forward
 > Deployed Engineer."*
 
+If `cv.md` was absent in Phase 1, skip Part 1 entirely and proceed
+directly to Part 2. The reveal will present discovery findings only.
+
 ### Part 2: What you told me
 
 > *"Here's what I heard from your answers..."*
@@ -120,6 +125,8 @@ Write a 3–5 sentence synthesis: what energizes them, what they want
 more of, their deal-breakers, and any strong directional signals.
 
 ### Part 3: Where they overlap — and where they don't
+
+If `cv.md` was present in Phase 1:
 
 > *"Here's where your background and your answers point to the same
 > place. That's your strongest signal."*
@@ -132,7 +139,13 @@ more of, their deal-breakers, and any strong directional signals.
   > worth pausing on — is [X] something you'd want to lean into, or
   > are you actively moving away from it?"*
 
-End with clear recommendations:
+If `cv.md` was absent in Phase 1, skip the overlap/gap framing and
+present discovery-derived archetype(s) directly:
+
+> *"Based on what you've told me, here are the directions that fit
+> you best..."*
+
+End with clear recommendations in either case:
 
 | Fit | Archetype(s) | Why |
 |-----|-------------|-----|
@@ -159,7 +172,18 @@ after each one. If the user requests edits, apply them and re-present
 the updated block for confirmation before moving on.
 
 **Block 1: candidate**
-Populate from `cv.md` (name, email, phone, location, LinkedIn, GitHub).
+If `cv.md` exists, populate from it (name, email, phone, location, LinkedIn, GitHub).
+If `cv.md` is absent, show the block with empty string placeholders and ask
+the user to fill in any blank fields before approving:
+```yaml
+candidate:
+  full_name: ""
+  email: ""
+  phone: ""
+  location: ""
+  linkedin: ""
+  github: ""
+```
 Show as a YAML preview.
 
 **Block 2: target_roles**
@@ -212,7 +236,11 @@ preferences from Phase 2.
 
 ### Write gate
 
-Only write files after the user has approved all sections of both files.
+Write files only after the user has either approved or explicitly skipped
+each section of both files. Approval and skip are distinct:
+- **Approved** — user confirmed the drafted content is correct
+- **Skipped** — user said to leave it blank or move on; the corresponding
+  section in the written file will remain as the template placeholder
 
 Write both files in sequence: `config/profile.yml` first, then
 `modes/_profile.md`.
@@ -220,6 +248,3 @@ Write both files in sequence: `config/profile.yml` first, then
 Confirm:
 > *"Profile saved. You're ready to start evaluating roles — paste a
 > job description or URL to run the full pipeline."*
-
-If the user skips a section, write the file with that section left as
-the template placeholder so they can fill it in later.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -260,7 +260,7 @@ console.log('\n8. Mode file integrity');
 
 const expectedModes = [
   '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'scan.md',
-  'batch.md', 'apply.md', 'auto-pipeline.md', 'contacto.md', 'deep.md',
+  'batch.md', 'apply.md', 'auto-pipeline.md', 'compass.md', 'contacto.md', 'deep.md',
   'ofertas.md', 'pipeline.md', 'project.md', 'tracker.md', 'training.md',
 ];
 


### PR DESCRIPTION
## What this adds

A new `/career-ops compass` mode that helps users who don't know what roles to target figure out their direction — and ends with a fully drafted `profile.yml` + `_profile.md` ready for their approval.

The current onboarding flow (AGENTS.md Step 2) assumes users already know their target roles. Users who don't have no guided path. Compass fills that gap.

## How it works

**Phase 0 — Profile check**
Detects whether a real profile exists. If so, asks "revisit your direction or start fresh?" before proceeding.

**Phase 1 — Silent CV analysis**
Reads `cv.md` internally and derives domains, functions, seniority signals, and 2–3 candidate archetypes. Nothing is shown to the user yet.

**Phase 2 — Adaptive discovery questions**
Asks 3 core questions (what energizes you, what you want more of, what's a hard no). Follows up adaptively based on signals of uncertainty — 3 questions minimum, 10 maximum. Stops early when the picture is clear.

**Phase 3 — Ikigai-style reveal**
This is the heart of the mode. Shows the CV-derived archetype suggestions ("here's what I would have pointed you toward before you told me anything"), then the discovery synthesis, then where they overlap and diverge. Surfaces insights the user may not have considered. Confirms before moving on.

**Phase 4 — Interactive profile drafting**
Presents draft `profile.yml` and `_profile.md` section by section. User approves, edits, or skips each block. Files are written only after full approval.

## Changes

- `modes/compass.md` — new mode (225 lines)
- `AGENTS.md` — Step 2 onboarding offramp + Skill Modes table entry
- `.agents/skills/career-ops/SKILL.md` — routing table, argument-hint, discovery menu, context loading
- `test-all.mjs` — compass added to expected modes list

## Test plan

- [ ] `node test-all.mjs` passes (66 passed, 0 failed)
- [ ] Run `/career-ops compass` with no profile set up — should proceed directly to CV analysis + questions
- [ ] Run `/career-ops compass` with existing profile — should ask "revisit or start fresh?"
- [ ] Run `/career-ops` with no args — compass should appear first in the discovery menu
- [ ] During onboarding Step 2, say "I don't know" to target roles — should route to compass

## Follow-on

`/career-ops polish` — CV enhancement for target archetypes — is the natural next PR once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /career-ops compass — a standalone career discovery mode to explore roles, surface strengths, and build a profile via guided questions and an ikigai-style reveal.

* **Documentation**
  * Added comprehensive design and workflow docs for compass, including phased discovery, silent CV analysis, drafting/approval flow, and onboarding routing to the standalone command.

* **Tests**
  * Updated tests to include and validate the new compass mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/643)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->