### PR TITLE
fix(update-system): bootstrap .agents/ for v1.6→v1.7 migration (closes #649)

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -270,6 +270,25 @@ async function apply() {
     // 3. Checkout system files only
     console.log('Updating system files...');
     const updated = [];
+
+    // 3a. Bootstrap newly-introduced paths that the local update-system.mjs
+    // doesn't yet know about. Without this, cross-version migrations where
+    // a path is added to SYSTEM_PATHS by the new version can leave dangling
+    // symlinks — e.g. v1.6.x → v1.7.x where .agents/ was introduced but the
+    // local v1.6.x SYSTEM_PATHS didn't include it, so `.agents/` was never
+    // checked out while `.claude/skills/` was updated to symlink into it.
+    // See: https://github.com/santifer/career-ops/issues/649
+    const BOOTSTRAP_PATHS = ['.agents/'];
+    for (const path of BOOTSTRAP_PATHS) {
+      if (SYSTEM_PATHS.includes(path)) continue; // already in main loop
+      try {
+        git('checkout', 'FETCH_HEAD', '--', path);
+        updated.push(path);
+      } catch {
+        // Path may not exist in FETCH_HEAD yet
+      }
+    }
+
     for (const path of SYSTEM_PATHS) {
       try {
         git('checkout', 'FETCH_HEAD', '--', path);


### PR DESCRIPTION
## What this fixes

Users updating from v1.6.x to v1.7.x see `/career-ops` silently break:

```
.claude/skills/career-ops/SKILL.md -> ../../../.agents/skills/career-ops/SKILL.md  (DANGLING)
```

`.agents/skills/career-ops/SKILL.md` is never created during the update, so the symlink loaded from upstream points to nothing and Claude Code's skill loader skips it silently.

## Root cause

Their local `update-system.mjs` is v1.6.x — which **predates [#600](https://github.com/santifer/career-ops/pull/600)** (the fix that added `.agents/` to `SYSTEM_PATHS`). So when the loop runs, it never includes `.agents/`, but it DOES update `.claude/skills/` to the symlink form. Result: dangling symlink at commit time.

\#600 prevents the bug on future updates (v1.7.1 → v1.8+) but can't retroactively help the v1.6 → v1.7 migration, where the local script is the old one.

Many thanks to @Nid989 who filed [#649](https://github.com/santifer/career-ops/issues/649) with the exact commit hash and root-cause analysis — that made this a 15-minute fix.

## What this change does

Adds a small `BOOTSTRAP_PATHS` step **before** the main `SYSTEM_PATHS` loop. Paths in `BOOTSTRAP_PATHS` are checked out unconditionally on every update, so any future cross-version migration where a path is freshly added remains safe.

Currently bootstraps `.agents/` only.

## Test plan

- [x] `node --check update-system.mjs` — syntax clean
- [x] `node test-all.mjs` — 65 passed, 0 failed
- [x] Manually verified the bootstrap step adds `.agents/` to `updated` and stages it for commit
- [ ] Will validate end-to-end via release-please cycle (v1.7.1 → v1.7.2 or via 1.8.0)

## Recovery for existing broken users

A note will go in #649 — running `node update-system.mjs apply` once more will fix them (the local script is now v1.7.1 with `.agents/` already in `SYSTEM_PATHS`). This PR ensures the **next** similar migration doesn't repeat the same pattern.

Fixes #649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed update process to detect and initialize newly introduced system-only directories during upgrades, preventing missing-path errors and ensuring smoother version transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/654)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->