### PR TITLE
feat(dashboard): `d` key discards highlighted application

### DIFF
--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -359,6 +359,17 @@ func (m PipelineModel) handleKey(msg tea.KeyMsg) (PipelineModel, tea.Cmd) {
 			m.statusCursor = 0
 		}
 
+	case "d":
+		if app, ok := m.CurrentApp(); ok {
+			return m, func() tea.Msg {
+				return PipelineUpdateStatusMsg{
+					CareerOpsPath: m.careerOpsPath,
+					App:           app,
+					NewStatus:     "Discarded",
+				}
+			}
+		}
+
 	case "g":
 		if len(m.filtered) > 0 {
 			m.cursor = 0
@@ -1034,6 +1045,7 @@ func (m PipelineModel) renderHelp() string {
 		keyStyle.Render("Enter") + descStyle.Render(" report  ") +
 		keyStyle.Render("o") + descStyle.Render(" open URL  ") +
 		keyStyle.Render("c") + descStyle.Render(" change  ") +
+		keyStyle.Render("d") + descStyle.Render(" 🗑 discard  ") +
 		keyStyle.Render("v") + descStyle.Render(" view  ") +
 		keyStyle.Render("p") + descStyle.Render(" progress  ") +
 		keyStyle.Render("q") + descStyle.Render(" quit")

--- a/dashboard/internal/ui/screens/pipeline_test.go
+++ b/dashboard/internal/ui/screens/pipeline_test.go
@@ -426,3 +426,50 @@ func TestSearchTypingDoesNotLoadReports(t *testing.T) {
 		}
 	}
 }
+
+// `d` discards the highlighted row by emitting a PipelineUpdateStatusMsg with
+// "Discarded", reusing the same path as the status picker so persistence and
+// reload behavior stay in one place.
+func TestDiscardKeyEmitsUpdateStatusMsg(t *testing.T) {
+	apps := []model.CareerApplication{
+		{Company: "Stripe", Role: "Backend Engineer", Status: "Evaluated", Score: 4.6, ReportNumber: "001"},
+		{Company: "Anthropic", Role: "AI Engineer", Status: "Evaluated", Score: 4.8, ReportNumber: "002"},
+	}
+
+	pm := NewPipelineModel(theme.NewTheme("catppuccin-mocha"), apps, model.PipelineMetrics{Total: len(apps)}, "/tmp/career-ops", 120, 40)
+
+	_, cmd := pm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if cmd == nil {
+		t.Fatal("expected `d` to return a command, got nil")
+	}
+	msg := cmd()
+	upd, ok := msg.(PipelineUpdateStatusMsg)
+	if !ok {
+		t.Fatalf("expected PipelineUpdateStatusMsg, got %T", msg)
+	}
+	if upd.NewStatus != "Discarded" {
+		t.Fatalf("expected NewStatus=Discarded, got %q", upd.NewStatus)
+	}
+	if upd.CareerOpsPath != "/tmp/career-ops" {
+		t.Fatalf("expected CareerOpsPath to flow through, got %q", upd.CareerOpsPath)
+	}
+	// Default sort is by score, so the higher-scored Anthropic row is on top.
+	if upd.App.ReportNumber != "002" {
+		t.Fatalf("expected discard to target highlighted app (002), got %q", upd.App.ReportNumber)
+	}
+}
+
+// With no rows in the filtered list, `d` must be a no-op — otherwise it would
+// dispatch an update for a zero-value app and corrupt applications.md.
+func TestDiscardKeyIsNoOpWhenNoRows(t *testing.T) {
+	pm := NewPipelineModel(theme.NewTheme("catppuccin-mocha"), nil, model.PipelineMetrics{}, "/tmp/career-ops", 120, 40)
+
+	_, cmd := pm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			if _, ok := msg.(PipelineUpdateStatusMsg); ok {
+				t.Fatal("expected `d` to be a no-op with no rows, got PipelineUpdateStatusMsg")
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a single-keystroke `d` action on the pipeline screen that marks the highlighted application as `Discarded`, reusing the existing `PipelineUpdateStatusMsg` flow so persistence + reload semantics stay in one place.
- Surfaces a 🗑 hint in the footer next to the existing `c change` entry.

Today the only way to move an Evaluated row off the queue is the status picker (`c` → navigate → enter), which is slow when triaging a backlog of low-fit evals. Discarded items remain recoverable via the DISCARDED tab and `c`.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./...` — added `TestDiscardKeyEmitsUpdateStatusMsg` (asserts the highlighted row, `Discarded` status, and `CareerOpsPath` flow through) and `TestDiscardKeyIsNoOpWhenNoRows` (guards against firing an update for a zero-value app when the filtered list is empty)
- [ ] Manual: run the dashboard, sit on the EVALUATED tab, press `d` on a row → row moves to DISCARDED, applications.md persists, footer shows the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "d" keyboard shortcut in the pipeline screen to mark the selected application as "Discarded"
  * Help bar now displays the new discard command

* **Tests**
  * Added validation tests for the new discard keyboard shortcut

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->