### PR TITLE
feat(ollama): Ollama batch backend — ollama-batch.mjs + batch-runner.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,20 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # Alternatives: gemini-1.5-flash, gemini-1.5-pro, gemini-2.5-flash-thinking-exp
 # GEMINI_MODEL=gemini-2.5-flash
 
+# ── Ollama Integration (local / free / private) ──────────────────────────────
+# Required for: node ollama-eval.mjs  and  batch-runner.sh --backend ollama
+# Install Ollama: https://ollama.com  |  Pull model: ollama pull llama3.3
+#
+# Recommended models (32K+ context window):
+#   llama3.3      — best balance of quality and speed (70B, needs ~40 GB RAM)
+#   qwen2.5:32b   — strong reasoning, lighter than llama3.3
+#   mistral-nemo  — fast 128K context, good for longer JDs
+#   gemma3:27b    — good quality, moderate resource use
+#
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=llama3.3
+# OLLAMA_TIMEOUT_MS=300000   # Per-offer timeout (default: 5 minutes)
+
 # ── Other integrations (add your own below) ──────────────────────────────────
 # ANTHROPIC_API_KEY=your_anthropic_key_here   # For Claude-based workflows
 # OPENAI_API_KEY=your_openai_key_here          # Future OpenAI integration

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# career-ops batch runner — standalone orchestrator for claude -p workers
-# Reads batch-input.tsv, delegates each offer to a claude -p worker,
+# career-ops batch runner — standalone orchestrator for LLM workers
+# Reads batch-input.tsv, delegates each offer to a worker (claude -p or Ollama),
 # tracks state in batch-state.tsv for resumability.
 #
-# NOTE: This script is Claude Code-specific. It uses claude -p with
-# --dangerously-skip-permissions and --append-system-prompt-file flags
-# that are not available in other CLIs. Multi-CLI support is out of scope
-# for now — contributions welcome.
+# Backends:
+#   claude  (default) — requires Claude Code CLI + Claude Max subscription
+#   ollama             — requires Ollama running locally (free, private)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -34,11 +33,11 @@ START_FROM=0
 MAX_RETRIES=2
 MIN_SCORE=0
 MODEL=""  # empty = let claude -p use the Claude Max default
+BACKEND="${CAREER_OPS_BACKEND:-claude}"
 
 usage() {
   cat <<'USAGE'
-career-ops batch runner — process job offers in batch via claude -p workers
-Uses your default Claude model (Claude Max subscription).
+career-ops batch runner — process job offers in batch via LLM workers
 
 Usage: batch-runner.sh [OPTIONS]
 
@@ -52,12 +51,23 @@ Options:
   --model NAME         Claude model passed to `claude -p --model` (default:
                        unset = Claude Max default). Use a cheaper model for
                        large batches, e.g. `--model claude-sonnet-4-6`.
+  --backend <name>     LLM backend: claude (default) or ollama
   -h, --help           Show this help
+
+Backends:
+  claude   Uses `claude -p` workers (requires Claude Code + Claude Max subscription)
+  ollama   Uses local Ollama (free, private — set OLLAMA_MODEL and OLLAMA_BASE_URL)
+
+Environment (Ollama backend):
+  OLLAMA_BASE_URL      Ollama server URL (default: http://localhost:11434)
+  OLLAMA_MODEL         Model name (default: llama3.3)
+  OLLAMA_TIMEOUT_MS    Per-offer timeout in ms (default: 300000)
+  CAREER_OPS_BACKEND   Set default backend without --backend flag
 
 Files:
   batch-input.tsv      Input offers (id, url, source, notes)
   batch-state.tsv      Processing state (auto-managed)
-  batch-prompt.md      Prompt template for workers
+  batch-prompt.md      Prompt template (claude backend only)
   logs/                Per-offer logs
   tracker-additions/   Tracker lines for post-batch merge
 
@@ -65,8 +75,14 @@ Examples:
   # Dry run to see pending offers
   ./batch-runner.sh --dry-run
 
-  # Process all pending
+  # Process all pending (Claude backend, default)
   ./batch-runner.sh
+
+  # Process with local Ollama
+  ./batch-runner.sh --backend ollama
+
+  # Ollama with a specific model, 2 workers
+  OLLAMA_MODEL=qwen2.5:72b ./batch-runner.sh --backend ollama --parallel 2
 
   # Retry only failed offers
   ./batch-runner.sh --retry-failed
@@ -86,6 +102,7 @@ while [[ $# -gt 0 ]]; do
     --max-retries) MAX_RETRIES="$2"; shift 2 ;;
     --min-score) MIN_SCORE="$2"; shift 2 ;;
     --model) MODEL="$2"; shift 2 ;;
+    --backend) BACKEND="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1"; usage; exit 1 ;;
   esac
@@ -124,15 +141,45 @@ check_prerequisites() {
     exit 1
   fi
 
-  if [[ ! -f "$PROMPT_FILE" ]]; then
-    echo "ERROR: $PROMPT_FILE not found."
-    exit 1
-  fi
-
-  if ! command -v claude &>/dev/null; then
-    echo "ERROR: 'claude' CLI not found in PATH."
-    exit 1
-  fi
+  case "$BACKEND" in
+    claude)
+      if [[ ! -f "$PROMPT_FILE" ]]; then
+        echo "ERROR: $PROMPT_FILE not found."
+        exit 1
+      fi
+      if ! command -v claude &>/dev/null; then
+        echo "ERROR: 'claude' CLI not found in PATH (required for claude backend)."
+        echo "       Install Claude Code: https://claude.ai/code"
+        exit 1
+      fi
+      ;;
+    ollama)
+      if ! command -v node &>/dev/null; then
+        echo "ERROR: 'node' not found in PATH (required for ollama backend)."
+        exit 1
+      fi
+      if [[ ! -f "$PROJECT_DIR/ollama-batch.mjs" ]]; then
+        echo "ERROR: ollama-batch.mjs not found in $PROJECT_DIR"
+        exit 1
+      fi
+      if ! command -v curl &>/dev/null; then
+        echo "ERROR: 'curl' not found in PATH (required to probe Ollama)."
+        exit 1
+      fi
+      local ollama_url="${OLLAMA_BASE_URL:-http://localhost:11434}"
+      if ! curl -sf --connect-timeout 5 --max-time 10 "${ollama_url}/api/tags" -o /dev/null 2>/dev/null; then
+        echo "ERROR: Ollama not reachable at ${ollama_url}"
+        echo "       Start Ollama with: ollama serve"
+        echo "       Install Ollama:    https://ollama.com"
+        exit 1
+      fi
+      echo "Backend: ollama (model: ${OLLAMA_MODEL:-llama3.3}, url: ${ollama_url})"
+      ;;
+    *)
+      echo "ERROR: Unknown backend '$BACKEND'. Use 'claude' or 'ollama'."
+      exit 1
+      ;;
+  esac
 
   mkdir -p "$LOGS_DIR" "$TRACKER_DIR" "$REPORTS_DIR"
 }
@@ -341,39 +388,45 @@ process_offer() {
 
   local log_file="$LOGS_DIR/${report_num}-${id}.log"
 
-  # Prepare system prompt with placeholders resolved
-  local resolved_prompt="$BATCH_DIR/.resolved-prompt-${id}.md"
-  # Escape sed delimiter characters in variables to prevent substitution breakage
-  local esc_url esc_jd_file esc_report_num esc_date esc_id
-  esc_url="${url//\\/\\\\}"
-  esc_url="${esc_url//|/\\|}"
-  esc_jd_file="${jd_file//\\/\\\\}"
-  esc_jd_file="${esc_jd_file//|/\\|}"
-  esc_report_num="${report_num//|/\\|}"
-  esc_date="${date//|/\\|}"
-  esc_id="${id//|/\\|}"
-  sed \
-    -e "s|{{URL}}|${esc_url}|g" \
-    -e "s|{{JD_FILE}}|${esc_jd_file}|g" \
-    -e "s|{{REPORT_NUM}}|${esc_report_num}|g" \
-    -e "s|{{DATE}}|${esc_date}|g" \
-    -e "s|{{ID}}|${esc_id}|g" \
-    "$PROMPT_FILE" > "$resolved_prompt"
-
-  # Launch claude -p worker.
-  # Model defaults to the Claude Max subscription default unless --model was
-  # passed. Building the command in an array keeps quoting safe regardless.
-  local -a claude_args=(-p --dangerously-skip-permissions)
-  if [[ -n "$MODEL" ]]; then
-    claude_args+=(--model "$MODEL")
-  fi
-  claude_args+=(--append-system-prompt-file "$resolved_prompt" "$prompt")
-
+  # Launch worker — backend-specific
   local exit_code=0
-  claude "${claude_args[@]}" > "$log_file" 2>&1 || exit_code=$?
+  if [[ "$BACKEND" == "ollama" ]]; then
+    node "$PROJECT_DIR/ollama-batch.mjs" \
+      --url        "$url" \
+      --jd-file    "$jd_file" \
+      --report-num "$report_num" \
+      --date       "$date" \
+      --batch-id   "$id" \
+      --min-score  "$MIN_SCORE" \
+      > "$log_file" 2>&1 || exit_code=$?
+  else
+    # claude backend: resolve placeholders into a temp system prompt file
+    local resolved_prompt="$BATCH_DIR/.resolved-prompt-${id}.md"
+    local esc_url esc_jd_file esc_report_num esc_date esc_id
+    esc_url="${url//\\/\\\\}";           esc_url="${esc_url//|/\\|}";           esc_url="${esc_url//&/\\&}"
+    esc_jd_file="${jd_file//\\/\\\\}";   esc_jd_file="${esc_jd_file//|/\\|}";   esc_jd_file="${esc_jd_file//&/\\&}"
+    esc_report_num="${report_num//|/\\|}"; esc_report_num="${esc_report_num//&/\\&}"
+    esc_date="${date//|/\\|}";           esc_date="${esc_date//&/\\&}"
+    esc_id="${id//|/\\|}";               esc_id="${esc_id//&/\\&}"
+    sed \
+      -e "s|{{URL}}|${esc_url}|g" \
+      -e "s|{{JD_FILE}}|${esc_jd_file}|g" \
+      -e "s|{{REPORT_NUM}}|${esc_report_num}|g" \
+      -e "s|{{DATE}}|${esc_date}|g" \
+      -e "s|{{ID}}|${esc_id}|g" \
+      "$PROMPT_FILE" > "$resolved_prompt"
 
-  # Cleanup resolved prompt
-  rm -f "$resolved_prompt"
+    # Build invocation array; --model is optional (defaults to Claude Max)
+    local -a claude_args=(-p --dangerously-skip-permissions)
+    if [[ -n "$MODEL" ]]; then
+      claude_args+=(--model "$MODEL")
+    fi
+    claude_args+=(--append-system-prompt-file "$resolved_prompt" "$prompt")
+
+    claude "${claude_args[@]}" > "$log_file" 2>&1 || exit_code=$?
+
+    rm -f "$resolved_prompt"
+  fi
 
   local completed_at
   completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -392,7 +445,7 @@ process_offer() {
       if (( $(echo "$score < $MIN_SCORE" | bc -l) )); then
         update_state "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries"
         echo "    ⏭️  Skipped (score: $score < min-score: $MIN_SCORE)"
-        continue
+        return 0
       fi
     fi
 

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -166,7 +166,24 @@ check_prerequisites() {
         echo "ERROR: 'curl' not found in PATH (required to probe Ollama)."
         exit 1
       fi
+      # Map --model to OLLAMA_MODEL when the Ollama backend is selected.
+      # --model is defined for the claude backend; for Ollama the canonical
+      # env var is OLLAMA_MODEL. Bridge them so `--backend ollama --model X`
+      # works as expected without silently falling back to llama3.3.
+      if [[ -n "$MODEL" && -z "${OLLAMA_MODEL:-}" ]]; then
+        OLLAMA_MODEL="$MODEL"
+      fi
       local ollama_url="${OLLAMA_BASE_URL:-http://localhost:11434}"
+      # Loopback guard: reject remote URLs early so we don't reserve report
+      # numbers before per-worker guards fire.
+      if [[ "${OLLAMA_ALLOW_REMOTE:-0}" != "1" ]]; then
+        if [[ ! "$ollama_url" =~ ^https?://(localhost|127\.0\.0\.1|\[::1\])(:[0-9]+)?(/.*)?$ ]]; then
+          echo "ERROR: OLLAMA_BASE_URL must point to localhost/127.0.0.1/::1"
+          echo "       Remote endpoint detected: ${ollama_url}"
+          echo "       Set OLLAMA_ALLOW_REMOTE=1 to use a remote endpoint intentionally."
+          exit 1
+        fi
+      fi
       if ! curl -sf --connect-timeout 5 --max-time 10 "${ollama_url}/api/tags" -o /dev/null 2>/dev/null; then
         echo "ERROR: Ollama not reachable at ${ollama_url}"
         echo "       Start Ollama with: ollama serve"
@@ -391,6 +408,9 @@ process_offer() {
   # Launch worker — backend-specific
   local exit_code=0
   if [[ "$BACKEND" == "ollama" ]]; then
+    # OLLAMA_MODEL may have been set from --model by check_prerequisites.
+    # Export it so the child process inherits the resolved value.
+    OLLAMA_MODEL="${OLLAMA_MODEL:-llama3.3}" \
     node "$PROJECT_DIR/ollama-batch.mjs" \
       --url        "$url" \
       --jd-file    "$jd_file" \

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -12,6 +12,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 BATCH_DIR="$SCRIPT_DIR"
+
+# Source .env from the project root so that OLLAMA_BASE_URL, OLLAMA_MODEL,
+# etc. are available to both the preflight checks here and the Node.js workers
+# without requiring users to export them from their shell.
+# set -a / set +a makes every sourced variable auto-exported to children.
+if [[ -f "$PROJECT_DIR/.env" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$PROJECT_DIR/.env"
+  set +a
+fi
 INPUT_FILE="$BATCH_DIR/batch-input.tsv"
 STATE_FILE="$BATCH_DIR/batch-state.tsv"
 PROMPT_FILE="$BATCH_DIR/batch-prompt.md"
@@ -408,9 +419,6 @@ process_offer() {
   # Launch worker — backend-specific
   local exit_code=0
   if [[ "$BACKEND" == "ollama" ]]; then
-    # OLLAMA_MODEL may have been set from --model by check_prerequisites.
-    # Export it so the child process inherits the resolved value.
-    OLLAMA_MODEL="${OLLAMA_MODEL:-llama3.3}" \
     node "$PROJECT_DIR/ollama-batch.mjs" \
       --url        "$url" \
       --jd-file    "$jd_file" \
@@ -586,8 +594,8 @@ main() {
         continue
       fi
     else
-      # Skip completed offers
-      if [[ "$status" == "completed" ]]; then
+      # Skip completed or previously skipped (low-score) offers
+      if [[ "$status" == "completed" || "$status" == "skipped" ]]; then
         continue
       fi
       # Skip failed offers that hit retry limit (unless --retry-failed)

--- a/ollama-batch.mjs
+++ b/ollama-batch.mjs
@@ -32,6 +32,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { promises as dns } from 'dns';
 
 try {
   const { config } = await import('dotenv');
@@ -200,18 +201,52 @@ if (!jdText && url) {
   if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
     fail(`JD URL must use http or https (got ${parsedUrl.protocol})`);
   }
+
+  /**
+   * Return true if an IP address string falls in a private/loopback/link-local range.
+   * Covers IPv4 (127.*, 10.*, 192.168.*, 172.16-31.*, 169.254.*) and
+   * IPv6 (::1, fe80::/10 link-local, fc00::/7 ULA).
+   * @param {string} ip
+   * @returns {boolean}
+   */
+  function isPrivateAddress(ip) {
+    if (/^127\./.test(ip))                           return true; // IPv4 loopback
+    if (/^10\./.test(ip))                            return true; // IPv4 private class A
+    if (/^192\.168\./.test(ip))                      return true; // IPv4 private class C
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(ip))      return true; // IPv4 private class B
+    if (/^169\.254\./.test(ip))                      return true; // IPv4 link-local
+    if (ip === '::1')                                return true; // IPv6 loopback
+    if (/^fe[89ab]/i.test(ip))                       return true; // IPv6 link-local fe80::/10
+    if (/^f[cd]/i.test(ip))                          return true; // IPv6 ULA fc00::/7
+    return false;
+  }
+
+  // Fast-fail on hostname literals before DNS resolution.
   const h = parsedUrl.hostname;
-  const isPrivate =
-    h === 'localhost' ||
-    /^127\./.test(h) ||
-    /^10\./.test(h) ||
-    /^192\.168\./.test(h) ||
-    /^172\.(1[6-9]|2\d|3[01])\./.test(h) ||
-    /^169\.254\./.test(h) ||
-    h === '::1' ||
-    h === '[::1]';
-  if (isPrivate) {
+  if (h === 'localhost' || h === '::1' || h === '[::1]' || isPrivateAddress(h)) {
     fail(`JD URL points to a private/loopback address — refusing to fetch: ${url}`);
+  }
+
+  // DNS resolution check — guards against DNS rebinding where a public
+  // hostname resolves to a private IP. Resolves both A and AAAA records.
+  try {
+    const [v4, v6] = await Promise.allSettled([
+      dns.resolve4(h),
+      dns.resolve6(h),
+    ]);
+    const allAddresses = [
+      ...(v4.status === 'fulfilled' ? v4.value : []),
+      ...(v6.status === 'fulfilled' ? v6.value : []),
+    ];
+    // If neither resolved, DNS lookup failed entirely — let fetch() surface the error.
+    for (const addr of allAddresses) {
+      if (isPrivateAddress(addr)) {
+        fail(`JD URL hostname "${h}" resolves to a private address (${addr}) — SSRF guard`);
+      }
+    }
+  } catch (dnsErr) {
+    // dns.resolve4/resolve6 throw on NXDOMAIN etc. — let fetch() produce the
+    // user-facing error; don't block on DNS errors alone.
   }
 
   try {

--- a/ollama-batch.mjs
+++ b/ollama-batch.mjs
@@ -111,7 +111,16 @@ for (let i = 0; i < args.length; i++) {
     case '--report-num': reportNum = args[++i]; break;
     case '--date':       date      = args[++i]; break;
     case '--batch-id':   batchId   = args[++i]; break;
-    case '--min-score':  minScore  = parseFloat(args[++i]) || 0; break;
+    case '--min-score': {
+      const raw = args[++i];
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed)) {
+        console.error(`ERROR: invalid --min-score "${raw}" (must be a number)`);
+        process.exit(1);
+      }
+      minScore = parsed;
+      break;
+    }
   }
 }
 
@@ -146,7 +155,15 @@ if (!/^\d{1,10}$/.test(batchId)) {
  */
 function readFile(path, label) {
   if (!existsSync(path)) return `[${label} not found — skipping]`;
-  return readFileSync(path, 'utf-8').trim();
+  try {
+    return readFileSync(path, 'utf-8').trim();
+  } catch (err) {
+    // Permission error, directory path, broken symlink, etc.
+    // Return a placeholder so the worker emits a structured JSON failure
+    // via fail() rather than crashing with a raw stack trace.
+    process.stderr.write(`WARN: could not read ${label} at ${path}: ${err.message}\n`);
+    return `[${label} unreadable — skipping]`;
+  }
 }
 
 /**
@@ -250,10 +267,58 @@ if (!jdText && url) {
   }
 
   try {
-    const res = await fetch(url, {
-      headers: { 'User-Agent': 'Mozilla/5.0 career-ops/1.0' },
-      signal: AbortSignal.timeout(30_000),
-    });
+    // Use redirect:'manual' so we can validate each redirect destination
+    // before following it — a public URL could redirect to a private IP
+    // and bypass the hostname check above.
+    let fetchUrl = url;
+    const MAX_REDIRECTS = 5;
+    let redirectsLeft = MAX_REDIRECTS;
+    let res;
+
+    while (redirectsLeft-- > 0) {
+      res = await fetch(fetchUrl, {
+        headers: { 'User-Agent': 'Mozilla/5.0 career-ops/1.0' },
+        redirect: 'manual',
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      if (res.status >= 300 && res.status < 400) {
+        const location = res.headers.get('location');
+        if (!location) fail(`Redirect with no Location header from ${fetchUrl}`);
+        let redirectUrl;
+        try { redirectUrl = new URL(location, fetchUrl); } catch {
+          fail(`Invalid redirect Location: "${location}"`);
+        }
+        if (redirectUrl.protocol !== 'http:' && redirectUrl.protocol !== 'https:') {
+          fail(`Redirect to non-http(s) URL blocked: ${redirectUrl.href}`);
+        }
+        const rh = redirectUrl.hostname;
+        if (rh === 'localhost' || rh === '::1' || rh === '[::1]' || isPrivateAddress(rh)) {
+          fail(`Redirect to private/loopback address blocked: ${redirectUrl.href}`);
+        }
+        // DNS-check the redirect destination too
+        try {
+          const [rv4, rv6] = await Promise.allSettled([
+            dns.resolve4(rh),
+            dns.resolve6(rh),
+          ]);
+          const rAddrs = [
+            ...(rv4.status === 'fulfilled' ? rv4.value : []),
+            ...(rv6.status === 'fulfilled' ? rv6.value : []),
+          ];
+          for (const addr of rAddrs) {
+            if (isPrivateAddress(addr)) {
+              fail(`Redirect hostname "${rh}" resolves to private address (${addr}) — SSRF guard`);
+            }
+          }
+        } catch { /* DNS errors fall through to the next fetch attempt */ }
+        fetchUrl = redirectUrl.href;
+        continue;
+      }
+
+      break; // non-redirect response
+    }
+
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const html = await res.text();
     jdText = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 50_000);
@@ -449,7 +514,12 @@ mkdirSync(PATHS.tracker, { recursive: true });
 //
 // Sanitize model-derived strings before writing to TSV: tab and newline
 // characters would corrupt the column structure and break merge-tracker.mjs.
-const sanitizeTsv = (v) => String(v ?? '').replace(/[\t\r\n]+/g, ' ').trim();
+const sanitizeTsv = (v) => {
+  const cleaned = String(v ?? '').replace(/[\t\r\n]+/g, ' ').trim();
+  // Prefix cells starting with formula-trigger characters so spreadsheet
+  // applications (Excel, Google Sheets) don't execute them as formulas.
+  return /^[=+\-@]/.test(cleaned) ? `'${cleaned}` : cleaned;
+};
 const scoreStr    = score !== null ? `${score}/5` : 'N/A';
 const reportLink  = `[${reportNum}](reports/${reportFile})`;
 const notesStr    = sanitizeTsv(`${archetype} — ${legitimacy}`);

--- a/ollama-batch.mjs
+++ b/ollama-batch.mjs
@@ -484,7 +484,11 @@ const reportPath  = join(PATHS.reports, reportFile);
 // ---------------------------------------------------------------------------
 // Write report .md
 // ---------------------------------------------------------------------------
-mkdirSync(PATHS.reports, { recursive: true });
+try {
+  mkdirSync(PATHS.reports, { recursive: true });
+} catch (err) {
+  fail(`Could not prepare reports directory "${PATHS.reports}": ${err.message}`);
+}
 
 const cleanEval = evalText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').trim();
 
@@ -505,12 +509,20 @@ const reportContent = `# Evaluación: ${company} — ${role}
 ${cleanEval}
 `;
 
-writeFileSync(reportPath, reportContent, 'utf-8');
+try {
+  writeFileSync(reportPath, reportContent, 'utf-8');
+} catch (err) {
+  fail(`Could not write report "${reportPath}": ${err.message}`);
+}
 
 // ---------------------------------------------------------------------------
 // Write tracker TSV
 // ---------------------------------------------------------------------------
-mkdirSync(PATHS.tracker, { recursive: true });
+try {
+  mkdirSync(PATHS.tracker, { recursive: true });
+} catch (err) {
+  fail(`Could not prepare tracker directory "${PATHS.tracker}": ${err.message}`);
+}
 
 // Row ID (column 1) is intentionally set to 0 — merge-tracker.mjs assigns
 // the real sequential number during merge. Computing it here would race
@@ -529,7 +541,11 @@ const reportLink  = `[${reportNum}](reports/${reportFile})`;
 const notesStr    = sanitizeTsv(`${archetype} — ${legitimacy}`);
 const tsvLine     = [0, date, sanitizeTsv(company), sanitizeTsv(role), 'Evaluada', scoreStr, '❌', reportLink, notesStr].join('\t');
 
-writeFileSync(join(PATHS.tracker, `${batchId}.tsv`), tsvLine + '\n', 'utf-8');
+try {
+  writeFileSync(join(PATHS.tracker, `${batchId}.tsv`), tsvLine + '\n', 'utf-8');
+} catch (err) {
+  fail(`Could not write tracker TSV for batch "${batchId}": ${err.message}`);
+}
 
 // ---------------------------------------------------------------------------
 // JSON summary to stdout (parsed by batch-runner.sh)

--- a/ollama-batch.mjs
+++ b/ollama-batch.mjs
@@ -191,7 +191,28 @@ if (jdFile && existsSync(jdFile)) {
 
 if (!jdText && url) {
   // Validate URL before fetching to catch malformed input early.
-  try { new URL(url); } catch { fail(`Invalid JD URL: "${url}"`); }
+  let parsedUrl;
+  try { parsedUrl = new URL(url); } catch { fail(`Invalid JD URL: "${url}"`); }
+
+  // SSRF guard: only allow http/https and reject private/loopback hosts.
+  // JD URLs must be public job postings — there is no valid reason to fetch
+  // from localhost or internal network ranges in batch mode.
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    fail(`JD URL must use http or https (got ${parsedUrl.protocol})`);
+  }
+  const h = parsedUrl.hostname;
+  const isPrivate =
+    h === 'localhost' ||
+    /^127\./.test(h) ||
+    /^10\./.test(h) ||
+    /^192\.168\./.test(h) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(h) ||
+    /^169\.254\./.test(h) ||
+    h === '::1' ||
+    h === '[::1]';
+  if (isPrivate) {
+    fail(`JD URL points to a private/loopback address — refusing to fetch: ${url}`);
+  }
 
   try {
     const res = await fetch(url, {
@@ -318,7 +339,8 @@ if (summaryMatch) {
   };
   company    = extract('COMPANY');
   role       = extract('ROLE');
-  score      = parseFloat(extract('SCORE')) || null;
+  const parsedScore = Number(extract('SCORE'));
+  score      = Number.isFinite(parsedScore) ? parsedScore : null;
   archetype  = extract('ARCHETYPE');
   legitimacy = extract('LEGITIMACY');
 } else {
@@ -389,10 +411,14 @@ mkdirSync(PATHS.tracker, { recursive: true });
 // Row ID (column 1) is intentionally set to 0 — merge-tracker.mjs assigns
 // the real sequential number during merge. Computing it here would race
 // with parallel workers all reading applications.md at the same time.
-const scoreStr   = score !== null ? `${score}/5` : 'N/A';
-const reportLink = `[${reportNum}](reports/${reportFile})`;
-const notesStr   = `${archetype} — ${legitimacy}`;
-const tsvLine    = [0, date, company, role, 'Evaluada', scoreStr, '❌', reportLink, notesStr].join('\t');
+//
+// Sanitize model-derived strings before writing to TSV: tab and newline
+// characters would corrupt the column structure and break merge-tracker.mjs.
+const sanitizeTsv = (v) => String(v ?? '').replace(/[\t\r\n]+/g, ' ').trim();
+const scoreStr    = score !== null ? `${score}/5` : 'N/A';
+const reportLink  = `[${reportNum}](reports/${reportFile})`;
+const notesStr    = sanitizeTsv(`${archetype} — ${legitimacy}`);
+const tsvLine     = [0, date, sanitizeTsv(company), sanitizeTsv(role), 'Evaluada', scoreStr, '❌', reportLink, notesStr].join('\t');
 
 writeFileSync(join(PATHS.tracker, `${batchId}.tsv`), tsvLine + '\n', 'utf-8');
 

--- a/ollama-batch.mjs
+++ b/ollama-batch.mjs
@@ -204,7 +204,11 @@ function fail(msg, extra = {}) {
 let jdText = '';
 
 if (jdFile && existsSync(jdFile)) {
-  jdText = readFileSync(jdFile, 'utf-8').trim();
+  try {
+    jdText = readFileSync(jdFile, 'utf-8').trim();
+  } catch (err) {
+    fail(`Could not read JD file "${jdFile}": ${err.message}`);
+  }
 }
 
 if (!jdText && url) {

--- a/ollama-batch.mjs
+++ b/ollama-batch.mjs
@@ -1,0 +1,415 @@
+#!/usr/bin/env node
+/**
+ * ollama-batch.mjs — Ollama batch worker for career-ops
+ *
+ * Drop-in replacement for `claude -p` workers in batch-runner.sh.
+ * Evaluates one job offer using a local Ollama model, writes the report .md
+ * and tracker TSV, then prints a JSON summary to stdout for the orchestrator.
+ *
+ * Usage (invoked by batch-runner.sh --backend ollama):
+ *   node ollama-batch.mjs \
+ *     --url <URL> \
+ *     --jd-file <PATH> \
+ *     --report-num <NUM> \
+ *     --date <YYYY-MM-DD> \
+ *     --batch-id <ID>
+ *
+ * Environment:
+ *   OLLAMA_BASE_URL     Ollama server base URL (default: http://localhost:11434)
+ *   OLLAMA_MODEL        Model name (default: llama3.3)
+ *   OLLAMA_TIMEOUT_MS   Request timeout in ms (default: 300000 = 5 min)
+ *
+ * Context window guidance:
+ *   The system prompt (cv.md + modes files + JD) is typically 10K-15K tokens.
+ *   Use a model with at least 32K context — llama3.3, mistral-nemo, qwen2.5.
+ *   Smaller models (llama3.2:3b, phi3) may truncate and produce poor results.
+ *
+ * PDF generation:
+ *   PDFs are not generated in Ollama batch mode (no tool-calling harness).
+ *   Generate manually: node generate-pdf.mjs <html-file> <output.pdf>
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+try {
+  const { config } = await import('dotenv');
+  config();
+} catch { /* dotenv optional */ }
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+const OLLAMA_BASE_URL = (process.env.OLLAMA_BASE_URL || 'http://localhost:11434').replace(/\/$/, '');
+const OLLAMA_MODEL    = process.env.OLLAMA_MODEL    || 'llama3.3';
+const TIMEOUT_MS      = parseInt(process.env.OLLAMA_TIMEOUT_MS || '300000', 10);
+
+// Loopback guard — batch workers send cv.md + full JD to this endpoint.
+// A remote URL silently exfiltrates private data.
+{
+  let hostname;
+  try { hostname = new URL(OLLAMA_BASE_URL).hostname; }
+  catch { console.error(`ERROR: invalid OLLAMA_BASE_URL: "${OLLAMA_BASE_URL}"`); process.exit(1); }
+  const isLoopback = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+  if (!isLoopback && process.env.OLLAMA_ALLOW_REMOTE !== '1') {
+    console.error(
+      `ERROR: remote OLLAMA_BASE_URL detected: ${OLLAMA_BASE_URL}\n` +
+      `       Batch mode sends cv.md and job descriptions to this endpoint.\n` +
+      `       Set OLLAMA_ALLOW_REMOTE=1 to use a remote endpoint intentionally.`
+    );
+    process.exit(1);
+  }
+}
+
+const PATHS = {
+  shared:  join(ROOT, 'modes', '_shared.md'),
+  oferta:  join(ROOT, 'modes', 'oferta.md'),
+  cv:      join(ROOT, 'cv.md'),
+  reports: join(ROOT, 'reports'),
+  tracker: join(ROOT, 'batch', 'tracker-additions'),
+};
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h') || args.length === 0) {
+  console.log(`
+Usage: node ollama-batch.mjs \\
+  --url <URL> \\
+  --jd-file <PATH> \\
+  --report-num <NUM> \\
+  --date <YYYY-MM-DD> \\
+  --batch-id <ID>
+
+Environment:
+  OLLAMA_BASE_URL   (default: http://localhost:11434)
+  OLLAMA_MODEL      (default: llama3.3)
+  OLLAMA_TIMEOUT_MS (default: 300000)
+
+Invoked automatically by batch-runner.sh --backend ollama.
+`);
+  process.exit(0);
+}
+
+let url       = '';
+let jdFile    = '';
+let reportNum = '';
+let date      = new Date().toISOString().split('T')[0];
+let batchId   = '';
+let minScore  = 0;
+
+for (let i = 0; i < args.length; i++) {
+  switch (args[i]) {
+    case '--url':        url       = args[++i]; break;
+    case '--jd-file':    jdFile    = args[++i]; break;
+    case '--report-num': reportNum = args[++i]; break;
+    case '--date':       date      = args[++i]; break;
+    case '--batch-id':   batchId   = args[++i]; break;
+    case '--min-score':  minScore  = parseFloat(args[++i]) || 0; break;
+  }
+}
+
+if (!reportNum || !batchId) {
+  console.error('ERROR: --report-num and --batch-id are required');
+  process.exit(1);
+}
+
+// Validate inputs used in file paths to prevent path traversal.
+if (!/^\d{1,6}$/.test(reportNum)) {
+  console.error(`ERROR: invalid --report-num "${reportNum}" (must be numeric)`);
+  process.exit(1);
+}
+if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+  console.error(`ERROR: invalid --date "${date}" (must be YYYY-MM-DD)`);
+  process.exit(1);
+}
+if (!/^\d{1,10}$/.test(batchId)) {
+  console.error(`ERROR: invalid --batch-id "${batchId}" (must be numeric)`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a file and return its trimmed contents, or a placeholder if missing.
+ * @param {string} path - Absolute path to the file.
+ * @param {string} label - Human-readable label used in the placeholder message.
+ * @returns {string} File contents or a "[label not found]" placeholder.
+ */
+function readFile(path, label) {
+  if (!existsSync(path)) return `[${label} not found — skipping]`;
+  return readFileSync(path, 'utf-8').trim();
+}
+
+/**
+ * Convert a string to a URL-safe slug (lowercase, hyphens, no leading/trailing hyphens).
+ * @param {string} str - Input string (e.g. company name).
+ * @returns {string} Slugified string, or "unknown" if the result would be empty.
+ */
+function slugify(str) {
+  return str.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'unknown';
+}
+
+/**
+ * Write a JSON failure summary to stdout and exit with code 1.
+ * Called on any unrecoverable error so batch-runner.sh can parse the result.
+ * @param {string} msg - Human-readable error description.
+ * @param {Object} [extra={}] - Optional fields to merge into the output object.
+ */
+function fail(msg, extra = {}) {
+  const out = {
+    status:     'failed',
+    id:         batchId,
+    report_num: reportNum,
+    company:    'unknown',
+    role:       'unknown',
+    score:      null,
+    pdf:        null,
+    report:     null,
+    error:      msg,
+    ...extra,
+  };
+  process.stdout.write(JSON.stringify(out) + '\n');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Get JD text — file first, URL fetch fallback
+// ---------------------------------------------------------------------------
+let jdText = '';
+
+if (jdFile && existsSync(jdFile)) {
+  jdText = readFileSync(jdFile, 'utf-8').trim();
+}
+
+if (!jdText && url) {
+  // Validate URL before fetching to catch malformed input early.
+  try { new URL(url); } catch { fail(`Invalid JD URL: "${url}"`); }
+
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': 'Mozilla/5.0 career-ops/1.0' },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const html = await res.text();
+    jdText = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 50_000);
+  } catch (err) {
+    fail(`Could not fetch JD: ${err.message}`);
+  }
+}
+
+if (!jdText) {
+  fail('No JD text — jd-file missing/empty and URL fetch failed');
+}
+
+// ---------------------------------------------------------------------------
+// Build prompt
+// ---------------------------------------------------------------------------
+const sharedCtx = readFile(PATHS.shared, 'modes/_shared.md');
+const ofertaCtx = readFile(PATHS.oferta, 'modes/oferta.md');
+const cvContent = readFile(PATHS.cv,     'cv.md');
+
+const systemPrompt = `You are career-ops, an AI-powered job search assistant.
+You evaluate job offers against the candidate's CV using a structured A-G scoring system.
+Follow the evaluation methodology below exactly.
+
+═══════════════════════════════════════════════════════
+SYSTEM CONTEXT (_shared.md)
+═══════════════════════════════════════════════════════
+${sharedCtx}
+
+═══════════════════════════════════════════════════════
+EVALUATION MODE (oferta.md)
+═══════════════════════════════════════════════════════
+${ofertaCtx}
+
+═══════════════════════════════════════════════════════
+CANDIDATE RESUME (cv.md)
+═══════════════════════════════════════════════════════
+${cvContent}
+
+═══════════════════════════════════════════════════════
+OPERATING RULES FOR THIS BATCH SESSION
+═══════════════════════════════════════════════════════
+1. You do NOT have access to WebSearch, Playwright, or file-writing tools.
+   - Block D (Comp research): use training-data salary estimates; note them as estimates.
+   - Block G (Legitimacy): analyze JD text only. Mark posting freshness as "unverified (batch mode)".
+   - File writing is handled by the script after you respond.
+2. Generate all Blocks A through G in full.
+3. At the very end output this exact machine-readable block (no extra whitespace):
+
+---SCORE_SUMMARY---
+COMPANY: <company name or "Unknown">
+ROLE: <role title>
+SCORE: <global score as decimal, e.g. 3.8>
+ARCHETYPE: <detected archetype>
+LEGITIMACY: <High Confidence | Proceed with Caution | Suspicious>
+---END_SUMMARY---
+`;
+
+const userMessage = `BATCH EVALUATION — Report #${reportNum} | Date: ${date} | Batch ID: ${batchId}
+URL: ${url || 'N/A'}
+
+JOB DESCRIPTION TO EVALUATE:
+
+${jdText}`;
+
+// ---------------------------------------------------------------------------
+// Call Ollama (OpenAI-compatible endpoint)
+// ---------------------------------------------------------------------------
+const endpoint = `${OLLAMA_BASE_URL}/v1/chat/completions`;
+
+let evalText;
+try {
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model:    OLLAMA_MODEL,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user',   content: userMessage  },
+      ],
+      stream:      false,
+      temperature: 0.4,
+      options: { num_ctx: 32768 },
+    }),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    fail(`Ollama API error: HTTP ${res.status} — ${body.slice(0, 300)}`);
+  }
+
+  const data = await res.json();
+  evalText = data.choices?.[0]?.message?.content?.trim();
+  if (!evalText) fail('Ollama returned an empty response');
+} catch (err) {
+  if (err.name === 'TimeoutError') {
+    fail(`Ollama request timed out after ${Math.round(TIMEOUT_MS / 1000)}s — try a smaller model or increase OLLAMA_TIMEOUT_MS`);
+  }
+  fail(`Ollama API call failed: ${err.message}`);
+}
+
+// ---------------------------------------------------------------------------
+// Parse SCORE_SUMMARY block
+// ---------------------------------------------------------------------------
+const summaryMatch = evalText.match(/---SCORE_SUMMARY---\s*([\s\S]*?)---END_SUMMARY---/);
+
+let company    = 'unknown';
+let role       = 'unknown';
+let score      = null;
+let archetype  = 'unknown';
+let legitimacy = 'Proceed with Caution';
+
+if (summaryMatch) {
+  const extract = (key) => {
+    const m = summaryMatch[1].match(new RegExp(`${key}:\\s*(.+)`));
+    return m ? m[1].trim() : 'unknown';
+  };
+  company    = extract('COMPANY');
+  role       = extract('ROLE');
+  score      = parseFloat(extract('SCORE')) || null;
+  archetype  = extract('ARCHETYPE');
+  legitimacy = extract('LEGITIMACY');
+} else {
+  // The model didn't produce the expected summary block. Evaluation text
+  // will still be saved so the user can read it, but scoring/gating is
+  // unavailable. Stderr is captured to the log file by batch-runner.sh.
+  process.stderr.write(
+    `WARN: SCORE_SUMMARY block missing from model response for batch-id ${batchId}.\n` +
+    `      Report will be saved with score=null. Check the log for the raw output.\n`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Min-score gate — checked BEFORE any file writes
+// ---------------------------------------------------------------------------
+if (minScore > 0 && score !== null && score < minScore) {
+  const skipped = {
+    status:     'skipped',
+    id:         batchId,
+    report_num: reportNum,
+    company,
+    role,
+    score,
+    legitimacy,
+    pdf:        null,
+    report:     null,
+    error:      `score ${score} below --min-score ${minScore}`,
+  };
+  process.stdout.write(JSON.stringify(skipped) + '\n');
+  process.exit(0);
+}
+
+const companySlug = slugify(company);
+const reportFile  = `${reportNum}-${companySlug}-${date}.md`;
+const reportPath  = join(PATHS.reports, reportFile);
+
+// ---------------------------------------------------------------------------
+// Write report .md
+// ---------------------------------------------------------------------------
+mkdirSync(PATHS.reports, { recursive: true });
+
+const cleanEval = evalText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').trim();
+
+const reportContent = `# Evaluación: ${company} — ${role}
+
+**Fecha:** ${date}
+**Arquetipo:** ${archetype}
+**Score:** ${score !== null ? score + '/5' : 'N/A'}
+**Legitimacy:** ${legitimacy}
+**URL:** ${url || 'N/A'}
+**PDF:** ❌ (generate manually: \`node generate-pdf.mjs\`)
+**Batch ID:** ${batchId}
+**Tool:** Ollama (${OLLAMA_MODEL})
+**Verification:** unverified (batch mode)
+
+---
+
+${cleanEval}
+`;
+
+writeFileSync(reportPath, reportContent, 'utf-8');
+
+// ---------------------------------------------------------------------------
+// Write tracker TSV
+// ---------------------------------------------------------------------------
+mkdirSync(PATHS.tracker, { recursive: true });
+
+// Row ID (column 1) is intentionally set to 0 — merge-tracker.mjs assigns
+// the real sequential number during merge. Computing it here would race
+// with parallel workers all reading applications.md at the same time.
+const scoreStr   = score !== null ? `${score}/5` : 'N/A';
+const reportLink = `[${reportNum}](reports/${reportFile})`;
+const notesStr   = `${archetype} — ${legitimacy}`;
+const tsvLine    = [0, date, company, role, 'Evaluada', scoreStr, '❌', reportLink, notesStr].join('\t');
+
+writeFileSync(join(PATHS.tracker, `${batchId}.tsv`), tsvLine + '\n', 'utf-8');
+
+// ---------------------------------------------------------------------------
+// JSON summary to stdout (parsed by batch-runner.sh)
+// ---------------------------------------------------------------------------
+const summary = {
+  status:     'completed',
+  id:         batchId,
+  report_num: reportNum,
+  company,
+  role,
+  score,
+  legitimacy,
+  pdf:        null,
+  report:     `reports/${reportFile}`,
+  error:      null,
+};
+
+process.stdout.write(JSON.stringify(summary) + '\n');

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
     "scan": "node scan.mjs",
-    "gemini:eval": "node gemini-eval.mjs"
+    "gemini:eval": "node gemini-eval.mjs",
+    "ollama:batch": "node ollama-batch.mjs"
   },
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary

- **`ollama-batch.mjs`** (new, ~415 lines) — drop-in worker replacing `claude -p` in batch mode. Evaluates one offer via Ollama's OpenAI-compatible API, writes `reports/<num>-<slug>-<date>.md` and `batch/tracker-additions/<id>.tsv`, emits a JSON summary to stdout for the orchestrator.
- **`batch/batch-runner.sh`** (modified) — adds `--backend [claude|ollama]` flag. Backend-aware `check_prerequisites` probes Ollama with `curl` before starting. `process_offer` dispatches to `node ollama-batch.mjs` or the existing `claude -p` array invocation depending on backend.
- **`.env.example`** — documents `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `OLLAMA_TIMEOUT_MS` and recommended models.
- **`package.json`** — adds `ollama:batch` npm script.

## Security

- Loopback guard: `OLLAMA_BASE_URL` must resolve to `localhost`/`127.0.0.1`/`::1`; opt-out via `OLLAMA_ALLOW_REMOTE=1` (strict equality).
- Path traversal prevention: `--report-num`, `--date`, `--batch-id` validated by regex before use in file paths.
- Min-score gate fires **before** any file writes so low-score offers don't pollute `reports/`.

## Usage

```bash
# Local Ollama, default model (llama3.3)
./batch/batch-runner.sh --backend ollama

# Specific model, 2 parallel workers
OLLAMA_MODEL=qwen2.5:32b ./batch/batch-runner.sh --backend ollama --parallel 2

# Or via npm
npm run ollama:batch
```

## Test plan

- [ ] `./batch/batch-runner.sh --backend ollama --dry-run` lists pending offers without errors
- [ ] Single offer processes end-to-end with Ollama running locally
- [ ] `OLLAMA_BASE_URL=http://remote:11434 node ollama-batch.mjs ...` exits with loopback error
- [ ] `--min-score 4.0` with a low-scoring offer exits cleanly without writing files
- [ ] `./batch/batch-runner.sh` (no `--backend`) still works as before (Claude backend)

## Companion PR

PR B adds `ollama-eval.mjs` (interactive single-offer evaluator, mirrors `gemini-eval.mjs`).
The Ollama env vars documented in `.env.example` here serve both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ollama as an alternative LLM backend with a selectable backend option, per-offer timeout support, and stricter low-score skipping that excludes skipped offers from later processing.
  * Added a standalone CLI worker to evaluate single offers and emit structured status outputs (completed/skipped/failed).

* **Security**
  * Added network, redirect and input safeguards for remote content fetching and Ollama endpoint usage.

* **Chores**
  * Added example environment variables and an npm script to run Ollama batches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->