### PR TITLE
feat(deploy): optional Docker + ttyd recipe to serve the TUI dashboard in a browser

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+node_modules
+output
+reports
+data/*.md
+!data/.gitkeep
+jds
+*.log
+.env
+stack-compose.override.yml

--- a/.env.mail.example
+++ b/.env.mail.example
@@ -1,0 +1,57 @@
+# SMTP credentials for tools/send-application-mail.mjs.
+# Copy to .env.mail (gitignored) and fill in the block for your chosen provider.
+
+# ────────────────────────────────────────────────────────────────────
+# OPTION A — Gmail App Password
+# Setup, ~5 min:
+#   1. https://myaccount.google.com/security  →  Enable 2-Step Verification.
+#   2. https://myaccount.google.com/apppasswords  →  generate a new App
+#      Password (16-char, no spaces). Pick "Mail" as the app.
+#   3. Paste it below as SMTP_PASS (with or without spaces, both work).
+# Notes:
+#   - SMTP_USER must be the full address (Workspace, not the alias).
+#   - SMTP_FROM controls what recruiters see in their inbox.
+#   - If SMTP_FROM differs from SMTP_USER, Gmail/Workspace silently rewrites
+#     the From to the authenticated user UNLESS the FROM address is verified
+#     as a "Send mail as" alias in Gmail Settings → Accounts. The easiest
+#     reliable setup is to keep them aligned.
+# ────────────────────────────────────────────────────────────────────
+
+# SMTP_HOST=smtp.gmail.com
+# SMTP_PORT=587
+# SMTP_SECURE=false
+# SMTP_USER=you@gmail.com
+# SMTP_PASS=xxxx xxxx xxxx xxxx
+# SMTP_FROM="Your Name <you@gmail.com>"
+
+# ────────────────────────────────────────────────────────────────────
+# OPTION B — Self-hosted Mailcow (or any SMTP relay you control)
+# Setup, ~20-30 min for a fresh domain:
+#   1. Mailcow admin (https://mail.example.com) → Domains → Add yourdomain.com.
+#   2. Mailcow admin → Mailboxes → Add you@yourdomain.com (set strong password).
+#   3. DNS at your registrar (yourdomain.com zone):
+#        MX     mail.example.com          (priority 10)
+#        TXT    @  "v=spf1 mx -all"
+#        TXT    dkim._domainkey  <copy verbatim from Mailcow Domain DKIM screen>
+#        TXT    _dmarc  "v=DMARC1; p=quarantine; rua=mailto:postmaster@yourdomain.com"
+#   4. Wait 1-15 min for DNS propagation; in Mailcow admin → Domains the row
+#      should show DKIM/SPF/DMARC all green.
+#   5. Optional: send a test via `mail-tester.com` first; aim for ≥8/10 before
+#      sending to recruiters.
+# Notes:
+#   - First-week sender reputation is shaky; expect 10-20% of cold emails to
+#     land in spam until the domain seasons. Gmail is safer for week 1.
+#   - If your Mailcow SMTP submission port serves a self-signed cert (acme
+#     port-80 challenge blocked by another reverse proxy is a common cause),
+#     you can opt in to relaxed verification with SMTP_TLS_INSECURE=true.
+#     Acceptable when you own the SMTP host; not acceptable for third-party
+#     relays.
+# ────────────────────────────────────────────────────────────────────
+
+# SMTP_HOST=mail.example.com
+# SMTP_PORT=587
+# SMTP_SECURE=false
+# SMTP_USER=you@yourdomain.com
+# SMTP_PASS=<the-mailbox-password>
+# SMTP_FROM="Your Name <you@yourdomain.com>"
+# SMTP_TLS_INSECURE=false

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ bun.lock
 .claude/memory/
 career-dashboard
 package-lock.json
+
+# Docker Compose local overrides (deployment-specific bind paths, networks…)
+*.override.yml

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,12 @@ package-lock.json
 
 # Docker Compose local overrides (deployment-specific bind paths, networks…)
 *.override.yml
+
+# SMTP credentials for tools/send-application-mail.mjs
+.env.mail
+
+# Personal apply bundles (cover letters, rate-screen emails, etc. — per-user)
+batch/apply-docs/
+
+# Personal proof points (user-layer per DATA_CONTRACT.md)
+article-digest.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ ENV LANG=en_US.UTF-8 \
 COPY --from=dashboard-builder /out/career-dashboard /usr/local/bin/career-dashboard
 COPY --from=auth-builder /opt/auth/node_modules /opt/auth/node_modules
 COPY auth/package.json auth/server.mjs auth/login.html /opt/auth/
+COPY auth/overlay /opt/auth/overlay
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # syntax=docker/dockerfile:1.7
 #
-# career-ops web GUI = ttyd (browser xterm + HTTP Basic Auth) wrapping
-# the upstream Go TUI dashboard. The project directory is bind-mounted at
-# /workspace so the host's Claude Code CLI and the container share state.
+# careerops web GUI = a Node auth proxy (with a designed login page) in front
+# of ttyd, which wraps the upstream Go TUI dashboard. The project directory
+# is bind-mounted at /workspace so the host's CLI and the container share
+# state.
 
 # ── Stage 1: build the Go TUI dashboard ──────────────────────────────────
 FROM golang:1.24-alpine AS dashboard-builder
@@ -14,8 +15,16 @@ RUN go mod download
 COPY dashboard/ ./
 RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/career-dashboard .
 
-# ── Stage 2: ttyd + dashboard runtime ────────────────────────────────────
-FROM debian:bookworm-slim AS runtime
+# ── Stage 2: install the auth-proxy npm deps in a builder ────────────────
+FROM node:20-bookworm-slim AS auth-builder
+
+WORKDIR /opt/auth
+COPY auth/package.json ./
+RUN npm install --omit=dev --no-audit --no-fund \
+ && npm cache clean --force
+
+# ── Stage 3: ttyd + auth proxy + dashboard runtime ───────────────────────
+FROM node:20-bookworm-slim AS runtime
 
 ARG TTYD_VERSION=1.7.7
 
@@ -32,9 +41,12 @@ RUN apt-get update \
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     TERM=xterm-256color \
-    COLORTERM=truecolor
+    COLORTERM=truecolor \
+    NODE_ENV=production
 
 COPY --from=dashboard-builder /out/career-dashboard /usr/local/bin/career-dashboard
+COPY --from=auth-builder /opt/auth/node_modules /opt/auth/node_modules
+COPY auth/package.json auth/server.mjs auth/login.html /opt/auth/
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1.7
+#
+# career-ops web GUI = ttyd (browser xterm + HTTP Basic Auth) wrapping
+# the upstream Go TUI dashboard. The project directory is bind-mounted at
+# /workspace so the host's Claude Code CLI and the container share state.
+
+# ── Stage 1: build the Go TUI dashboard ──────────────────────────────────
+FROM golang:1.24-alpine AS dashboard-builder
+
+WORKDIR /src
+COPY dashboard/go.mod dashboard/go.sum ./
+RUN go mod download
+
+COPY dashboard/ ./
+RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/career-dashboard .
+
+# ── Stage 2: ttyd + dashboard runtime ────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+ARG TTYD_VERSION=1.7.7
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates curl tini bash less locales \
+ && curl -fsSL -o /usr/local/bin/ttyd \
+      "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" \
+ && chmod +x /usr/local/bin/ttyd \
+ && sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen \
+ && apt-get purge -y curl \
+ && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    TERM=xterm-256color \
+    COLORTERM=truecolor
+
+COPY --from=dashboard-builder /out/career-dashboard /usr/local/bin/career-dashboard
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Non-root user so the bind-mounted /workspace is read/written as the host's
+# `app` user (uid 1001). Override at runtime if your uid differs.
+ARG APP_UID=1001
+ARG APP_GID=1001
+RUN groupadd -g ${APP_GID} app && useradd -m -u ${APP_UID} -g ${APP_GID} -s /bin/bash app
+USER app
+
+WORKDIR /workspace
+EXPOSE 7681
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/auth/login.html
+++ b/auth/login.html
@@ -1,0 +1,683 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#1e1e2e">
+  <title>career-ops · sign in</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@1,9..144,300;1,9..144,400&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
+  <style>
+    /* ─────────────────────────────────────────────────────────────
+       Catppuccin Mocha — matches the TUI dashboard behind the auth
+       ───────────────────────────────────────────────────────────── */
+    :root {
+      --base:     #1e1e2e;
+      --mantle:   #181825;
+      --crust:    #11111b;
+      --text:     #cdd6f4;
+      --subtext1: #bac2de;
+      --subtext0: #a6adc8;
+      --overlay2: #9399b2;
+      --overlay1: #7f849c;
+      --overlay0: #6c7086;
+      --surface2: #585b70;
+      --surface1: #45475a;
+      --surface0: #313244;
+      --peach:    #fab387;
+      --yellow:   #f9e2af;
+      --green:    #a6e3a1;
+      --red:      #f38ba8;
+      --teal:     #94e2d5;
+      --mauve:    #cba6f7;
+      --pink:     #f5c2e7;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html, body {
+      height: 100%;
+      background: var(--base);
+      color: var(--text);
+      font-family: 'JetBrains Mono', ui-monospace, monospace;
+      font-size: 14px;
+      line-height: 1.65;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      text-rendering: optimizeLegibility;
+    }
+
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 4rem 2rem;
+      position: relative;
+      overflow-x: hidden;
+    }
+
+    /* Grain — subtle film texture */
+    body::before {
+      content: '';
+      position: fixed;
+      inset: -50%;
+      background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.7 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+      opacity: 0.045;
+      pointer-events: none;
+      z-index: 1;
+      animation: grain 8s steps(8) infinite;
+    }
+
+    /* Soft vignette to settle the edges */
+    body::after {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(ellipse 90% 70% at 50% 50%, transparent 0%, var(--crust) 110%);
+      pointer-events: none;
+      z-index: 1;
+    }
+
+    @keyframes grain {
+      0%, 100% { transform: translate(0, 0); }
+      10% { transform: translate(-5%, -5%); }
+      30% { transform: translate(3%, -8%); }
+      50% { transform: translate(-3%, 5%); }
+      70% { transform: translate(5%, 3%); }
+      90% { transform: translate(-2%, -3%); }
+    }
+
+    /* ─────────────────────────────────────────────────────────────
+       Layout
+       ───────────────────────────────────────────────────────────── */
+    .pane {
+      width: 100%;
+      max-width: 680px;
+      position: relative;
+      z-index: 2;
+    }
+
+    /* Titlebar — like a terminal window chrome, minimised */
+    .titlebar {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      font-size: 11px;
+      color: var(--overlay0);
+      letter-spacing: 0.06em;
+      margin-bottom: 2.5rem;
+      opacity: 0;
+      animation: fade-in 400ms ease-out forwards;
+    }
+    .titlebar-host {
+      color: var(--overlay1);
+    }
+    .titlebar-host::before {
+      content: '●  ';
+      color: var(--green);
+      font-size: 10px;
+      letter-spacing: 0;
+    }
+
+    /* The banner — boxed, with a tab-label cut into the top border */
+    .banner {
+      position: relative;
+      border: 1px solid var(--surface1);
+      padding: 2.5rem 2.5rem 2.25rem;
+      margin-bottom: 2.5rem;
+      background:
+        linear-gradient(180deg, transparent 0%, rgba(49, 50, 68, 0.12) 100%),
+        var(--base);
+      clip-path: inset(0 0 100% 0);
+      animation: reveal-banner 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms forwards;
+    }
+    .banner-label {
+      position: absolute;
+      top: -0.65rem;
+      left: 1.5rem;
+      background: var(--base);
+      padding: 0 0.75rem;
+      font-size: 11px;
+      color: var(--peach);
+      letter-spacing: 0.08em;
+      text-transform: lowercase;
+    }
+    .banner-corner {
+      position: absolute;
+      top: -1px;
+      right: -1px;
+      border-top: 1px solid var(--peach);
+      border-right: 1px solid var(--peach);
+      width: 14px;
+      height: 14px;
+      pointer-events: none;
+    }
+    .brand {
+      font-family: 'Fraunces', 'Times New Roman', serif;
+      font-variation-settings: "opsz" 144, "SOFT" 50;
+      font-weight: 300;
+      font-style: italic;
+      font-size: clamp(2.75rem, 7vw, 4.5rem);
+      line-height: 0.95;
+      color: var(--text);
+      letter-spacing: -0.045em;
+      margin-bottom: 1.25rem;
+      opacity: 0;
+      animation: fade-up 500ms ease-out 400ms forwards;
+    }
+    .brand-em {
+      color: var(--peach);
+      font-style: italic;
+    }
+    .tagline {
+      color: var(--subtext0);
+      font-size: 13px;
+      line-height: 1.7;
+      max-width: 32em;
+      opacity: 0;
+      animation: fade-up 400ms ease-out 650ms forwards;
+    }
+    .tagline em {
+      font-style: italic;
+      color: var(--text);
+    }
+
+    /* System info grid — looks like the output of `careerops status` */
+    .meta {
+      display: grid;
+      grid-template-columns: 120px 1fr;
+      gap: 0.35rem 1.5rem;
+      margin-bottom: 1rem;
+      font-size: 12.5px;
+    }
+    .meta-row {
+      display: contents;
+      opacity: 0;
+      animation: fade-up 350ms ease-out forwards;
+    }
+    .meta-row:nth-child(1) { animation-delay: 850ms; }
+    .meta-row:nth-child(2) { animation-delay: 920ms; }
+    .meta-row:nth-child(3) { animation-delay: 990ms; }
+    .meta-row:nth-child(4) { animation-delay: 1060ms; }
+    .meta-key {
+      color: var(--overlay0);
+      letter-spacing: 0.05em;
+      text-transform: lowercase;
+    }
+    .meta-val {
+      color: var(--subtext0);
+    }
+    .meta-val .pos { color: var(--green); }
+    .meta-val .neu { color: var(--yellow); }
+    .meta-val .num { color: var(--text); font-weight: 500; }
+    .meta-val a { color: var(--teal); text-decoration: none; border-bottom: 1px dotted var(--surface2); }
+    .meta-val a:hover { color: var(--peach); border-bottom-color: var(--peach); }
+
+    /* Divider — sweeps in horizontally */
+    .divider {
+      height: 1px;
+      background: linear-gradient(90deg,
+        transparent 0%,
+        var(--surface1) 8%,
+        var(--surface1) 92%,
+        transparent 100%);
+      margin: 2.5rem 0;
+      transform: scaleX(0);
+      transform-origin: left;
+      animation: sweep 500ms cubic-bezier(0.4, 0, 0.2, 1) 1200ms forwards;
+    }
+
+    /* Prompt line — the heart of the terminal aesthetic */
+    .prompt-line {
+      color: var(--text);
+      font-size: 15px;
+      margin-bottom: 2rem;
+      letter-spacing: 0.01em;
+      opacity: 0;
+      animation: fade-up 350ms ease-out 1400ms forwards;
+    }
+    .prompt-line::before {
+      content: '$ ';
+      color: var(--green);
+      font-weight: 700;
+    }
+    .prompt-line strong {
+      font-weight: 500;
+      color: var(--peach);
+    }
+    .prompt-line .cursor {
+      display: inline-block;
+      width: 0.5em;
+      height: 1em;
+      background: var(--text);
+      vertical-align: text-bottom;
+      margin-left: 2px;
+      animation: blink 1s steps(2) infinite;
+    }
+
+    /* Form */
+    .form {
+      opacity: 0;
+      animation: fade-up 450ms ease-out 1500ms forwards;
+    }
+    .field {
+      margin-bottom: 1.25rem;
+    }
+    .field-label {
+      display: block;
+      color: var(--mauve);
+      font-size: 12.5px;
+      margin-bottom: 0.5rem;
+      letter-spacing: 0.04em;
+    }
+    .field-label::before {
+      content: '> ';
+      color: var(--overlay0);
+    }
+    .input-wrap {
+      position: relative;
+      border: 1px solid var(--surface1);
+      background: var(--mantle);
+      transition: border-color 180ms ease, box-shadow 180ms ease, background 180ms ease;
+    }
+    .input-wrap:focus-within {
+      border-color: var(--peach);
+      background: var(--base);
+      box-shadow: 0 0 0 1px var(--peach), 0 0 32px -10px var(--peach);
+    }
+    .input-wrap::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 0.8rem;
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: var(--surface2);
+      transform: translateY(-50%);
+      transition: background 180ms ease, box-shadow 180ms ease;
+    }
+    .input-wrap:focus-within::before {
+      background: var(--peach);
+      box-shadow: 0 0 6px var(--peach);
+    }
+    .input {
+      width: 100%;
+      background: transparent;
+      border: none;
+      outline: none;
+      color: var(--text);
+      font-family: inherit;
+      font-size: 14px;
+      padding: 0.85rem 1rem 0.85rem 1.75rem;
+      letter-spacing: 0.02em;
+      caret-color: var(--peach);
+    }
+    .input::placeholder {
+      color: var(--overlay0);
+      font-style: italic;
+    }
+
+    /* Submit */
+    .submit-row {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      margin-top: 2rem;
+      flex-wrap: wrap;
+    }
+    .submit {
+      position: relative;
+      isolation: isolate;
+      font-family: inherit;
+      font-size: 13px;
+      letter-spacing: 0.18em;
+      text-transform: lowercase;
+      color: var(--peach);
+      background: transparent;
+      border: 1px solid var(--peach);
+      padding: 0.85rem 1.75rem 0.85rem 2rem;
+      cursor: pointer;
+      overflow: hidden;
+      transition: color 220ms ease, letter-spacing 220ms ease;
+    }
+    .submit::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: var(--peach);
+      transform: translateX(-101%);
+      transition: transform 350ms cubic-bezier(0.4, 0, 0.2, 1);
+      z-index: -1;
+    }
+    .submit:hover:not(:disabled) {
+      color: var(--base);
+      letter-spacing: 0.22em;
+    }
+    .submit:hover:not(:disabled)::before {
+      transform: translateX(0);
+    }
+    .submit:disabled {
+      opacity: 0.5;
+      cursor: wait;
+    }
+    .submit.success {
+      color: var(--base);
+      border-color: var(--green);
+    }
+    .submit.success::before {
+      background: var(--green);
+      transform: translateX(0);
+    }
+    .submit-hint {
+      color: var(--overlay0);
+      font-size: 12px;
+    }
+    .submit-hint kbd {
+      display: inline-block;
+      padding: 0.15rem 0.45rem;
+      border: 1px solid var(--surface1);
+      border-bottom-width: 2px;
+      border-radius: 2px;
+      background: var(--mantle);
+      font-family: inherit;
+      font-size: 11px;
+      color: var(--subtext0);
+      margin: 0 0.2em;
+      font-weight: 500;
+    }
+
+    /* Status line */
+    .status {
+      margin-top: 1.5rem;
+      padding: 0.65rem 1rem;
+      font-size: 12.5px;
+      border-left: 2px solid;
+      background: var(--mantle);
+      visibility: hidden;
+      opacity: 0;
+      transform: translateY(-4px);
+      transition: opacity 180ms ease, transform 180ms ease;
+    }
+    .status.visible {
+      visibility: visible;
+      opacity: 1;
+      transform: translateY(0);
+    }
+    .status.error {
+      color: var(--red);
+      border-color: var(--red);
+      animation: shake 400ms cubic-bezier(0.36, 0.07, 0.19, 0.97);
+    }
+    .status.error::before {
+      content: '✗ ';
+      font-weight: 700;
+    }
+    .status.success {
+      color: var(--green);
+      border-color: var(--green);
+    }
+    .status.success::before {
+      content: '✓ ';
+      font-weight: 700;
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 3.5rem;
+      padding-top: 1.5rem;
+      border-top: 1px dashed var(--surface1);
+      color: var(--overlay0);
+      font-size: 11.5px;
+      line-height: 1.85;
+      letter-spacing: 0.02em;
+      opacity: 0;
+      animation: fade-up 400ms ease-out 1750ms forwards;
+    }
+    .footer a {
+      color: var(--teal);
+      text-decoration: none;
+      border-bottom: 1px dotted transparent;
+      transition: border-color 180ms ease, color 180ms ease;
+    }
+    .footer a:hover {
+      color: var(--peach);
+      border-bottom-color: var(--peach);
+    }
+    .footer .footer-sep {
+      color: var(--surface1);
+      margin: 0 0.5em;
+    }
+
+    /* ─────────────────────────────────────────────────────────────
+       Keyframes
+       ───────────────────────────────────────────────────────────── */
+    @keyframes reveal-banner {
+      from { clip-path: inset(0 0 100% 0); }
+      to   { clip-path: inset(0 0 0 0); }
+    }
+    @keyframes fade-up {
+      from { opacity: 0; transform: translateY(6px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes fade-in {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+    @keyframes sweep {
+      from { transform: scaleX(0); }
+      to   { transform: scaleX(1); }
+    }
+    @keyframes blink {
+      from, 50% { opacity: 1; }
+      50.01%, to { opacity: 0; }
+    }
+    @keyframes shake {
+      0%, 100%       { transform: translateX(0); }
+      10%, 50%, 90%  { transform: translateX(-4px); }
+      30%, 70%       { transform: translateX(4px); }
+    }
+
+    /* ─────────────────────────────────────────────────────────────
+       Reduced motion
+       ───────────────────────────────────────────────────────────── */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+      .banner { clip-path: none !important; }
+      .divider { transform: scaleX(1) !important; }
+      .brand, .tagline, .meta-row, .prompt-line, .form, .footer, .titlebar { opacity: 1 !important; }
+    }
+
+    /* ─────────────────────────────────────────────────────────────
+       Small viewports
+       ───────────────────────────────────────────────────────────── */
+    @media (max-width: 520px) {
+      body { padding: 2rem 1.25rem; }
+      .banner { padding: 1.5rem 1.5rem 1.25rem; }
+      .meta { grid-template-columns: 90px 1fr; gap: 0.3rem 1rem; font-size: 11.5px; }
+      .submit-row { gap: 0.75rem; }
+      .submit-hint { font-size: 11px; }
+      .footer { font-size: 11px; }
+    }
+  </style>
+</head>
+<body>
+  <main class="pane" role="main">
+    <div class="titlebar">
+      <span class="titlebar-host" id="host">—</span>
+      <time id="now" datetime=""></time>
+    </div>
+
+    <section class="banner" aria-labelledby="brand">
+      <span class="banner-label">~/career-ops</span>
+      <span class="banner-corner" aria-hidden="true"></span>
+      <h1 id="brand" class="brand">career<span class="brand-em">·</span>ops</h1>
+      <p class="tagline">
+        AI-powered job-search command center. <em>14 evaluation modes</em>,
+        batch processing, portal scanning, ATS-optimised CV generation.
+        Forked from <a href="https://github.com/santifer/career-ops">santifer/career-ops</a> · running locally on your terminal.
+      </p>
+    </section>
+
+    <div class="meta" aria-label="system status">
+      <div class="meta-row">
+        <span class="meta-key">runtime</span>
+        <span class="meta-val">ttyd <span class="num">1.7.7</span> · go tui · catppuccin mocha</span>
+      </div>
+      <div class="meta-row">
+        <span class="meta-key">pipeline</span>
+        <span class="meta-val"><span class="num">25</span> applications evaluated · top score <span class="pos">4.6 / 5</span></span>
+      </div>
+      <div class="meta-row">
+        <span class="meta-key">queue</span>
+        <span class="meta-val"><span class="num">3</span> rate-screens drafted · <span class="num">7</span> tailored CVs ready</span>
+      </div>
+      <div class="meta-row">
+        <span class="meta-key">session</span>
+        <span class="meta-val" id="session-info">awaiting authentication</span>
+      </div>
+    </div>
+
+    <div class="divider" role="separator"></div>
+
+    <p class="prompt-line">careerops <strong>login</strong><span class="cursor" aria-hidden="true"></span></p>
+
+    <form class="form" id="login-form" autocomplete="on" novalidate>
+      <div class="field">
+        <label class="field-label" for="user">user</label>
+        <div class="input-wrap">
+          <input
+            class="input"
+            id="user"
+            name="user"
+            type="text"
+            autocomplete="username"
+            autocapitalize="off"
+            autocorrect="off"
+            spellcheck="false"
+            inputmode="email"
+            placeholder="username"
+            required
+            autofocus
+          >
+        </div>
+      </div>
+
+      <div class="field">
+        <label class="field-label" for="pass">pass</label>
+        <div class="input-wrap">
+          <input
+            class="input"
+            id="pass"
+            name="pass"
+            type="password"
+            autocomplete="current-password"
+            placeholder="•••••••••••"
+            required
+          >
+        </div>
+      </div>
+
+      <div class="submit-row">
+        <button class="submit" type="submit" id="submit-btn">
+          <span id="submit-label">authenticate</span>
+        </button>
+        <span class="submit-hint">press <kbd>↵</kbd> to sign in</span>
+      </div>
+
+      <div class="status" id="status" role="status" aria-live="polite"></div>
+    </form>
+
+    <footer class="footer">
+      careerops · <a href="https://github.com/santifer/career-ops">github.com/santifer/career-ops</a>
+      <span class="footer-sep">·</span> web-gui auth proxy
+      <span class="footer-sep">·</span> behind this login: a tmux pane streaming the Bubble Tea pipeline viewer
+    </footer>
+  </main>
+
+  <script>
+    // Titlebar: derive host from the page URL so the login adapts to any deployment
+    document.getElementById('host').textContent = window.location.host;
+
+    // Live clock in the titlebar
+    const $now = document.getElementById('now');
+    const $session = document.getElementById('session-info');
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone.split('/').pop() || 'UTC';
+    function tick() {
+      const d = new Date();
+      const pad = (n) => String(n).padStart(2, '0');
+      const stamp = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())} ${tz}`;
+      $now.textContent = stamp;
+      $now.setAttribute('datetime', d.toISOString());
+    }
+    tick();
+    setInterval(tick, 30_000);
+
+    // Form submission
+    const $form   = document.getElementById('login-form');
+    const $btn    = document.getElementById('submit-btn');
+    const $label  = document.getElementById('submit-label');
+    const $status = document.getElementById('status');
+    const $user   = document.getElementById('user');
+    const $pass   = document.getElementById('pass');
+
+    function setStatus(kind, text) {
+      $status.className = 'status';
+      // force reflow so the animation re-fires on consecutive errors
+      void $status.offsetWidth;
+      if (kind) {
+        $status.classList.add(kind, 'visible');
+        $status.textContent = text;
+      }
+    }
+
+    $form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if ($btn.disabled) return;
+      $btn.disabled = true;
+      $label.textContent = 'authenticating…';
+      setStatus(null);
+
+      try {
+        const resp = await fetch('/api/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'same-origin',
+          body: JSON.stringify({ user: $user.value, pass: $pass.value }),
+        });
+
+        if (resp.ok) {
+          $btn.classList.add('success');
+          $label.textContent = '✓ authenticated';
+          $session.textContent = 'granted · redirecting';
+          setStatus('success', 'session established · loading terminal…');
+          // Tiny pause so the success state is visible
+          setTimeout(() => {
+            window.location.href = '/';
+          }, 550);
+        } else {
+          $btn.disabled = false;
+          $label.textContent = 'authenticate';
+          setStatus('error', 'authentication failed · verify credentials and try again');
+          $pass.value = '';
+          $pass.focus();
+        }
+      } catch (err) {
+        $btn.disabled = false;
+        $label.textContent = 'authenticate';
+        setStatus('error', `network error · ${err && err.message ? err.message : 'request failed'}`);
+      }
+    });
+
+    // ⌃C-style escape clears the form (terminal muscle-memory)
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        $user.value = '';
+        $pass.value = '';
+        $user.focus();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/auth/overlay/overlay.css
+++ b/auth/overlay/overlay.css
@@ -1,0 +1,386 @@
+/* careerops overlay — logout + URL-paste modal */
+/* Injected into ttyd's HTML response by the auth proxy. */
+/* Catppuccin Mocha palette to match the login page + the TUI behind it. */
+
+#careerops-overlay {
+  --co-base:     #1e1e2e;
+  --co-mantle:   #181825;
+  --co-crust:    #11111b;
+  --co-text:     #cdd6f4;
+  --co-subtext1: #bac2de;
+  --co-subtext0: #a6adc8;
+  --co-overlay1: #7f849c;
+  --co-overlay0: #6c7086;
+  --co-surface2: #585b70;
+  --co-surface1: #45475a;
+  --co-surface0: #313244;
+  --co-peach:    #fab387;
+  --co-yellow:   #f9e2af;
+  --co-green:    #a6e3a1;
+  --co-red:      #f38ba8;
+  --co-teal:     #94e2d5;
+  --co-mauve:    #cba6f7;
+
+  font-family: 'JetBrains Mono', ui-monospace, 'Cascadia Code', Menlo, monospace;
+  color: var(--co-text);
+}
+#careerops-overlay *, #careerops-overlay *::before, #careerops-overlay *::after {
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+/* ── Corner controls ────────────────────────────────────────────── */
+.co-corner {
+  position: fixed;
+  top: 0.85rem;
+  right: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+  z-index: 9000;
+  opacity: 0.35;
+  transition: opacity 220ms ease;
+}
+.co-corner:hover,
+.co-corner:focus-within {
+  opacity: 1;
+}
+
+.co-btn {
+  font-family: inherit;
+  font-size: 11px;
+  letter-spacing: 0.09em;
+  line-height: 1;
+  color: var(--co-subtext0);
+  background: rgba(24, 24, 37, 0.85);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid var(--co-surface1);
+  padding: 0.45rem 0.8rem;
+  cursor: pointer;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease,
+    background 150ms ease;
+  text-transform: lowercase;
+  user-select: none;
+}
+.co-btn:hover,
+.co-btn:focus-visible {
+  color: var(--co-peach);
+  border-color: var(--co-peach);
+  background: var(--co-base);
+  outline: none;
+}
+.co-btn-danger:hover,
+.co-btn-danger:focus-visible {
+  color: var(--co-red);
+  border-color: var(--co-red);
+}
+.co-glyph {
+  display: inline-block;
+  margin-right: 0.35em;
+  opacity: 0.85;
+  font-weight: 500;
+}
+
+/* ── Modal ──────────────────────────────────────────────────────── */
+.co-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+.co-modal[hidden] { display: none; }
+.co-modal.co-visible { opacity: 1; }
+
+.co-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(17, 17, 27, 0.86);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.co-modal-pane {
+  position: relative;
+  width: 100%;
+  max-width: 560px;
+  background:
+    linear-gradient(180deg, transparent 0%, rgba(49, 50, 68, 0.12) 100%),
+    var(--co-base);
+  border: 1px solid var(--co-surface1);
+  z-index: 1;
+  transform: translateY(10px) scale(0.985);
+  transition: transform 260ms cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: 0 32px 80px -16px rgba(0, 0, 0, 0.7);
+}
+.co-modal.co-visible .co-modal-pane {
+  transform: translateY(0) scale(1);
+}
+
+/* Banner — tab-label cut into the top border, matches login page */
+.co-banner {
+  position: relative;
+  border-bottom: 1px solid var(--co-surface1);
+  padding: 1.85rem 1.85rem 1.35rem;
+}
+.co-banner-label {
+  position: absolute;
+  top: -0.65rem;
+  left: 1.25rem;
+  background: var(--co-base);
+  padding: 0 0.7rem;
+  font-size: 10.5px;
+  color: var(--co-peach);
+  letter-spacing: 0.1em;
+  text-transform: lowercase;
+}
+.co-banner-corner {
+  position: absolute;
+  top: -1px;
+  right: -1px;
+  border-top: 1px solid var(--co-peach);
+  border-right: 1px solid var(--co-peach);
+  width: 12px;
+  height: 12px;
+  pointer-events: none;
+}
+.co-modal-title {
+  font-size: 16px;
+  color: var(--co-text);
+  letter-spacing: 0.01em;
+  margin-bottom: 0.6rem;
+}
+.co-modal-title::before {
+  content: '$ ';
+  color: var(--co-green);
+  font-weight: 700;
+}
+.co-modal-title strong {
+  font-weight: 500;
+  color: var(--co-peach);
+}
+.co-modal-sub {
+  font-size: 11.5px;
+  line-height: 1.65;
+  color: var(--co-subtext0);
+  max-width: 44em;
+}
+.co-modal-sub code {
+  background: var(--co-mantle);
+  color: var(--co-teal);
+  padding: 0.04em 0.4em;
+  border: 1px solid var(--co-surface1);
+  border-radius: 2px;
+  font-size: 0.92em;
+}
+
+/* Form */
+.co-form {
+  padding: 1.5rem 1.85rem 1.85rem;
+}
+.co-field {
+  margin-bottom: 1.25rem;
+}
+.co-label {
+  display: block;
+  font-size: 11.5px;
+  color: var(--co-mauve);
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.04em;
+}
+.co-input-wrap {
+  position: relative;
+  border: 1px solid var(--co-surface1);
+  background: var(--co-mantle);
+  transition: border-color 180ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+.co-input-wrap:focus-within {
+  border-color: var(--co-peach);
+  background: var(--co-base);
+  box-shadow: 0 0 0 1px var(--co-peach), 0 0 28px -10px var(--co-peach);
+}
+.co-input-wrap::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0.8rem;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--co-surface2);
+  transform: translateY(-50%);
+  transition: background 180ms ease, box-shadow 180ms ease;
+}
+.co-input-wrap:focus-within::before {
+  background: var(--co-peach);
+  box-shadow: 0 0 6px var(--co-peach);
+}
+.co-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--co-text);
+  font-size: 13px;
+  padding: 0.8rem 1rem 0.8rem 1.75rem;
+  caret-color: var(--co-peach);
+  letter-spacing: 0.015em;
+  font-family: inherit;
+}
+.co-input::placeholder {
+  color: var(--co-overlay0);
+  font-style: italic;
+}
+
+.co-actions {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+}
+.co-submit {
+  position: relative;
+  isolation: isolate;
+  font-family: inherit;
+  font-size: 12px;
+  letter-spacing: 0.17em;
+  text-transform: lowercase;
+  color: var(--co-peach);
+  background: transparent;
+  border: 1px solid var(--co-peach);
+  padding: 0.75rem 1.35rem;
+  cursor: pointer;
+  overflow: hidden;
+  transition: color 220ms ease, letter-spacing 220ms ease;
+}
+.co-submit::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--co-peach);
+  transform: translateX(-101%);
+  transition: transform 320ms cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: -1;
+}
+.co-submit:hover:not(:disabled),
+.co-submit:focus-visible:not(:disabled) {
+  color: var(--co-base);
+  letter-spacing: 0.2em;
+  outline: none;
+}
+.co-submit:hover:not(:disabled)::before,
+.co-submit:focus-visible:not(:disabled)::before {
+  transform: translateX(0);
+}
+.co-submit:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+.co-submit.co-submit-success {
+  color: var(--co-base);
+  border-color: var(--co-green);
+}
+.co-submit.co-submit-success::before {
+  background: var(--co-green);
+  transform: translateX(0);
+}
+
+.co-hint {
+  color: var(--co-overlay0);
+  font-size: 11px;
+}
+.co-hint kbd {
+  display: inline-block;
+  padding: 0.12rem 0.45rem;
+  border: 1px solid var(--co-surface1);
+  border-bottom-width: 2px;
+  border-radius: 2px;
+  background: var(--co-mantle);
+  font-size: 10.5px;
+  color: var(--co-subtext0);
+  margin: 0 0.15em;
+  font-family: inherit;
+  font-weight: 500;
+}
+
+.co-status {
+  margin-top: 1.25rem;
+  padding: 0.6rem 0.95rem;
+  font-size: 11.5px;
+  line-height: 1.5;
+  border-left: 2px solid;
+  background: var(--co-mantle);
+  visibility: hidden;
+  opacity: 0;
+  transform: translateY(-2px);
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+.co-status.co-status-visible {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(0);
+}
+.co-status.co-status-error {
+  color: var(--co-red);
+  border-color: var(--co-red);
+  animation: co-shake 400ms cubic-bezier(0.36, 0.07, 0.19, 0.97);
+}
+.co-status.co-status-success {
+  color: var(--co-green);
+  border-color: var(--co-green);
+}
+.co-status.co-status-pending {
+  color: var(--co-yellow);
+  border-color: var(--co-yellow);
+}
+.co-status code {
+  background: var(--co-base);
+  color: var(--co-teal);
+  padding: 0.04em 0.35em;
+  border: 1px solid var(--co-surface1);
+  border-radius: 2px;
+  font-size: 0.92em;
+}
+
+/* Subtle pulsing dot for pending state */
+.co-status.co-status-pending::before {
+  content: '◐';
+  display: inline-block;
+  margin-right: 0.4em;
+  animation: co-spin 900ms linear infinite;
+}
+
+/* ── Keyframes ──────────────────────────────────────────────────── */
+@keyframes co-shake {
+  0%, 100%      { transform: translateX(0); }
+  20%, 60%      { transform: translateX(-3px); }
+  40%, 80%      { transform: translateX(3px); }
+}
+@keyframes co-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* ── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .co-corner { top: 0.5rem; right: 0.5rem; gap: 0.35rem; }
+  .co-btn { font-size: 10px; padding: 0.35rem 0.55rem; }
+  .co-modal { padding: 1rem; }
+  .co-modal-pane { max-width: calc(100vw - 0.5rem); }
+  .co-banner { padding: 1.35rem 1.25rem 1rem; }
+  .co-form { padding: 1.1rem 1.25rem 1.35rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #careerops-overlay *, #careerops-overlay *::before, #careerops-overlay *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/auth/overlay/overlay.js
+++ b/auth/overlay/overlay.js
@@ -1,0 +1,246 @@
+/**
+ * careerops overlay — logout + URL-paste modal
+ *
+ * Injected into ttyd's HTML response by the auth proxy.
+ *
+ * Triggers:
+ *   - "[ + add url ]" button (top-right) opens the URL-paste modal
+ *   - "[ ⏻ logout ]" button (top-right) clears the session and goes to /login
+ *   - Ctrl/Cmd+E opens the modal (when closed)
+ *   - Esc closes the modal (when open)
+ *   - Backdrop click closes the modal
+ *
+ * The Ctrl+E shortcut yields to xterm.js by default (xterm captures most
+ * Ctrl+letter combinations for the terminal). To make it work consistently,
+ * we capture at the window level with `capture: true` and `preventDefault()`.
+ */
+(function () {
+  'use strict';
+
+  if (window.__careeropsOverlayLoaded) return;
+  window.__careeropsOverlayLoaded = true;
+
+  const STYLE_HREF = '/_careerops/overlay.css';
+  const ENDPOINT_SCRAPE  = '/api/scrape';
+  const ENDPOINT_QUEUE   = '/api/queue-url';
+  const ENDPOINT_LOGOUT  = '/api/logout';
+
+  // ── Inject stylesheet ───────────────────────────────────────────
+  const style = document.createElement('link');
+  style.rel = 'stylesheet';
+  style.href = STYLE_HREF;
+  document.head.appendChild(style);
+
+  // ── Build DOM ──────────────────────────────────────────────────
+  const root = document.createElement('div');
+  root.id = 'careerops-overlay';
+  root.innerHTML = `
+    <div class="co-corner">
+      <button class="co-btn" id="co-add-url" type="button" title="add a job URL to the pipeline (Ctrl/Cmd+E)">
+        <span class="co-glyph">+</span>add url
+      </button>
+      <button class="co-btn co-btn-danger" id="co-logout" type="button" title="end the session and return to the login page">
+        <span class="co-glyph">⏻</span>logout
+      </button>
+    </div>
+
+    <div class="co-modal" id="co-modal" hidden aria-hidden="true" role="dialog" aria-labelledby="co-modal-title">
+      <div class="co-modal-backdrop" id="co-backdrop"></div>
+      <div class="co-modal-pane" role="document">
+        <header class="co-banner">
+          <span class="co-banner-label">~/career-ops/jds</span>
+          <span class="co-banner-corner" aria-hidden="true"></span>
+          <h2 class="co-modal-title" id="co-modal-title">careerops <strong>scrape-jd</strong></h2>
+          <p class="co-modal-sub">
+            Paste a job posting URL. The scraper container fetches the JD page (Scrapling — anti-bot fingerprinting handled), writes <code>jds/NNN-{slug}.md</code>, and queues the URL in <code>data/pipeline.md</code>. From a <code>claude</code> session in the project root, run <code>/career-ops pipeline</code> to evaluate.
+          </p>
+        </header>
+
+        <form class="co-form" id="co-form" autocomplete="off" novalidate>
+          <div class="co-field">
+            <label class="co-label" for="co-url">&gt; url</label>
+            <div class="co-input-wrap">
+              <input
+                class="co-input"
+                id="co-url"
+                name="url"
+                type="url"
+                placeholder="https://www.linkedin.com/jobs/view/..."
+                autocomplete="url"
+                autocapitalize="off"
+                autocorrect="off"
+                spellcheck="false"
+                required
+              >
+            </div>
+          </div>
+
+          <div class="co-actions">
+            <button class="co-submit" type="submit" id="co-fetch" data-mode="scrape">
+              <span id="co-fetch-label">fetch &amp; queue</span>
+            </button>
+            <label class="co-hint" style="display:flex;align-items:center;gap:0.4rem;cursor:pointer;">
+              <input type="checkbox" id="co-queue-only" style="accent-color:#fab387;">
+              queue only (skip scrape)
+            </label>
+            <span class="co-hint">
+              <kbd>↵</kbd>submit · <kbd>esc</kbd>close
+            </span>
+          </div>
+
+          <div class="co-status" id="co-status" role="status" aria-live="polite"></div>
+        </form>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(root);
+
+  const $       = (id) => document.getElementById(id);
+  const $modal  = $('co-modal');
+  const $form   = $('co-form');
+  const $url    = $('co-url');
+  const $status = $('co-status');
+  const $fetch  = $('co-fetch');
+  const $label  = $('co-fetch-label');
+  const $queueOnly = $('co-queue-only');
+
+  // ── Modal open/close ───────────────────────────────────────────
+  function openModal() {
+    if (!$modal.hidden) return;
+    $modal.hidden = false;
+    $modal.setAttribute('aria-hidden', 'false');
+    requestAnimationFrame(() => {
+      $modal.classList.add('co-visible');
+      $url.focus();
+      $url.select();
+    });
+  }
+  function closeModal() {
+    if ($modal.hidden) return;
+    $modal.classList.remove('co-visible');
+    $modal.setAttribute('aria-hidden', 'true');
+    setStatus(null);
+    setTimeout(() => { $modal.hidden = true; }, 220);
+  }
+  function setStatus(kind, html) {
+    $status.className = 'co-status';
+    // force reflow so the shake animation re-fires on consecutive errors
+    void $status.offsetWidth;
+    if (kind && html != null) {
+      $status.classList.add(`co-status-${kind}`, 'co-status-visible');
+      $status.innerHTML = html;
+    } else {
+      $status.innerHTML = '';
+    }
+  }
+
+  // ── Triggers ───────────────────────────────────────────────────
+  $('co-add-url').addEventListener('click', openModal);
+  $('co-backdrop').addEventListener('click', closeModal);
+
+  $('co-logout').addEventListener('click', async (e) => {
+    e.preventDefault();
+    try {
+      await fetch(ENDPOINT_LOGOUT, { method: 'POST', credentials: 'same-origin' });
+    } catch { /* ignore — we redirect anyway */ }
+    window.location.href = '/login';
+  });
+
+  // Ctrl/Cmd + E to open. Capture at window level since xterm.js otherwise
+  // swallows Ctrl-letter keys before they bubble up.
+  window.addEventListener('keydown', (e) => {
+    const isMod = e.ctrlKey || e.metaKey;
+    if (isMod && (e.key === 'e' || e.key === 'E') && $modal.hidden) {
+      e.preventDefault();
+      e.stopPropagation();
+      openModal();
+    } else if (e.key === 'Escape' && !$modal.hidden) {
+      e.preventDefault();
+      e.stopPropagation();
+      closeModal();
+    }
+  }, { capture: true });
+
+  // ── Submit ─────────────────────────────────────────────────────
+  $form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    if ($fetch.disabled) return;
+
+    const url = $url.value.trim();
+    if (!/^https?:\/\//i.test(url)) {
+      setStatus('error', 'url must start with <code>http://</code> or <code>https://</code>');
+      return;
+    }
+
+    const queueOnly = $queueOnly.checked;
+    const endpoint = queueOnly ? ENDPOINT_QUEUE : ENDPOINT_SCRAPE;
+    const verb = queueOnly ? 'queueing' : 'scraping';
+
+    $fetch.disabled = true;
+    $label.textContent = `${verb}…`;
+    setStatus('pending', queueOnly
+      ? `queueing URL to <code>data/pipeline.md</code>…`
+      : `fetching JD via Scrapling sidecar… (LinkedIn pages can take 8-15 s)`);
+
+    try {
+      const resp = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ url }),
+      });
+      const data = await resp.json().catch(() => ({}));
+
+      if (resp.ok && data.ok) {
+        $fetch.classList.add('co-submit-success');
+        $label.textContent = '✓ done';
+        const lines = [];
+        if (data.title)    lines.push(`<code>title</code> &nbsp; ${escapeHtml(data.title)}`);
+        if (data.company)  lines.push(`<code>company</code> &nbsp; ${escapeHtml(data.company)}`);
+        if (data.location) lines.push(`<code>location</code> &nbsp; ${escapeHtml(data.location)}`);
+        if (data.path)     lines.push(`<code>wrote</code> &nbsp; ${escapeHtml(data.path)}`);
+        if (data.queued)   lines.push(`<code>queued</code> &nbsp; ${escapeHtml(data.queued)}`);
+        if (data.chars != null) lines.push(`<code>chars</code> &nbsp; ${data.chars}`);
+        setStatus('success', lines.length ? lines.join('<br>') : '✓ ok');
+
+        // Reset for another URL after a beat
+        setTimeout(() => {
+          $url.value = '';
+          $fetch.classList.remove('co-submit-success');
+          $fetch.disabled = false;
+          $label.textContent = queueOnly ? 'queue another' : 'fetch another';
+          $url.focus();
+        }, 1500);
+      } else {
+        const err = data.error || `http_${resp.status}`;
+        const detail = data.detail || resp.statusText || '';
+        setStatus('error', `<code>${escapeHtml(err)}</code> ${escapeHtml(detail)}`);
+        $fetch.disabled = false;
+        $label.textContent = 'retry';
+      }
+    } catch (err) {
+      setStatus('error', `<code>network</code> ${escapeHtml(err && err.message || 'request failed')}`);
+      $fetch.disabled = false;
+      $label.textContent = 'retry';
+    }
+  });
+
+  // Reset success state when user starts typing again
+  $url.addEventListener('input', () => {
+    if ($fetch.classList.contains('co-submit-success')) {
+      $fetch.classList.remove('co-submit-success');
+      $label.textContent = $queueOnly.checked ? 'queue' : 'fetch & queue';
+    }
+  });
+  $queueOnly.addEventListener('change', () => {
+    if (!$fetch.disabled) {
+      $label.textContent = $queueOnly.checked ? 'queue' : 'fetch & queue';
+    }
+  });
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    })[c]);
+  }
+})();

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "careerops-auth-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Login-page auth proxy in front of ttyd for careerops",
+  "main": "server.mjs",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "http-proxy-middleware": "^3.0.0"
+  }
+}

--- a/auth/server.mjs
+++ b/auth/server.mjs
@@ -1,44 +1,48 @@
 #!/usr/bin/env node
 /**
- * auth/server.mjs — careerops auth proxy
+ * auth/server.mjs — careerops auth proxy + overlay injector
  *
- * Sits in front of ttyd. Replaces ttyd's browser-default Basic-Auth popup
- * with a designed login page, then transparently proxies the authenticated
- * session (HTTP + WebSocket) to ttyd on a private port.
+ * Sits in front of ttyd. Replaces ttyd's browser Basic-Auth popup with a
+ * designed login page, then transparently proxies the authenticated session
+ * (HTTP + WebSocket) to ttyd on a private loopback port.
+ *
+ * Also:
+ *   - Serves /_careerops/overlay.{js,css} (the logout link + URL-paste modal).
+ *   - Injects <script src="/_careerops/overlay.js" defer> into ttyd's HTML
+ *     responses so the overlay appears on the terminal page.
+ *   - Exposes /api/scrape (calls the Scrapling sidecar, writes jds/) and
+ *     /api/queue-url (writes to data/pipeline.md without scraping).
  *
  * Environment:
  *   CAREEROPS_WEB_USER      Required. Username for the login page.
  *   CAREEROPS_WEB_PASS      Required. Password for the login page.
  *   COOKIE_SECRET           Required. HMAC secret signing session cookies.
- *                           Generate with `openssl rand -hex 32`.
- *   AUTH_PROXY_PORT         Optional. Default 7681 (the port NPM forwards to).
+ *   AUTH_PROXY_PORT         Optional. Default 7681 (NPM forwards to this).
  *   TTYD_TARGET             Optional. Default http://127.0.0.1:7682
+ *   SCRAPER_URL             Optional. Default http://careerops-scraper:8000
+ *   WORKSPACE               Optional. Default /workspace
  *   COOKIE_TTL_DAYS         Optional. Default 30.
- *
- * Routes:
- *   GET  /login            -> serves login.html (redirects to / if authed)
- *   POST /api/login        -> validates creds, sets signed cookie, JSON ok
- *   POST /api/logout       -> clears cookie, redirects to /login
- *   *                      -> proxied to ttyd if authed, else /login
  */
 
 import express from 'express';
-import { createProxyMiddleware } from 'http-proxy-middleware';
+import { createProxyMiddleware, responseInterceptor } from 'http-proxy-middleware';
 import { createHmac, createHash, timingSafeEqual } from 'crypto';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync, appendFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const USER        = required('CAREEROPS_WEB_USER');
-const PASS        = required('CAREEROPS_WEB_PASS');
-const SECRET      = required('COOKIE_SECRET');
-const PORT        = Number(process.env.AUTH_PROXY_PORT || 7681);
-const TTYD_TARGET = process.env.TTYD_TARGET || 'http://127.0.0.1:7682';
-const TTL_DAYS    = Number(process.env.COOKIE_TTL_DAYS || 30);
-const TTL_MS      = TTL_DAYS * 24 * 60 * 60 * 1000;
-const COOKIE_NAME = 'careerops_session';
+const USER         = required('CAREEROPS_WEB_USER');
+const PASS         = required('CAREEROPS_WEB_PASS');
+const SECRET       = required('COOKIE_SECRET');
+const PORT         = Number(process.env.AUTH_PROXY_PORT || 7681);
+const TTYD_TARGET  = process.env.TTYD_TARGET  || 'http://127.0.0.1:7682';
+const SCRAPER_URL  = process.env.SCRAPER_URL  || 'http://careerops-scraper:8000';
+const WORKSPACE    = process.env.WORKSPACE    || '/workspace';
+const TTL_DAYS     = Number(process.env.COOKIE_TTL_DAYS || 30);
+const TTL_MS       = TTL_DAYS * 24 * 60 * 60 * 1000;
+const COOKIE_NAME  = 'careerops_session';
 
 function required(name) {
   const v = process.env[name];
@@ -49,7 +53,7 @@ function required(name) {
   return v;
 }
 
-// Pre-hash the configured creds so the comparison is timing-safe and length-fixed.
+// Pre-hash configured creds so comparisons are timing-safe + length-fixed.
 const USER_HASH = sha256(USER);
 const PASS_HASH = sha256(PASS);
 
@@ -57,7 +61,6 @@ function sha256(s)  { return createHash('sha256').update(String(s)).digest(); }
 function hmac(s)    { return createHmac('sha256', SECRET).update(String(s)).digest('base64url'); }
 function constTimeEqHash(a, b) { return a.length === b.length && timingSafeEqual(a, b); }
 
-// Session token: <expiresAt_base36>.<HMAC>
 function signSession(expiresAtMs) {
   const payload = expiresAtMs.toString(36);
   return `${payload}.${hmac(payload)}`;
@@ -74,7 +77,6 @@ function verifySession(token) {
   if (!Number.isFinite(expiresAt) || Date.now() > expiresAt) return null;
   return { expiresAt };
 }
-
 function parseCookies(header) {
   const out = {};
   if (!header) return out;
@@ -94,24 +96,28 @@ function isAuthed(req) {
 // ── App ─────────────────────────────────────────────────────────────
 const app = express();
 app.disable('x-powered-by');
-app.set('trust proxy', true); // NPM is in front
-app.use(express.json({ limit: '4kb' }));
+app.set('trust proxy', true);
+app.use(express.json({ limit: '8kb' }));
 
 // Cache the login HTML at boot — it's static.
 const LOGIN_HTML = readFileSync(path.join(__dirname, 'login.html'), 'utf8');
+const OVERLAY_JS  = readFileSync(path.join(__dirname, 'overlay', 'overlay.js'), 'utf8');
+const OVERLAY_CSS = readFileSync(path.join(__dirname, 'overlay', 'overlay.css'), 'utf8');
+
+const CSP_LOGIN =
+  "default-src 'self'; " +
+  "script-src 'self' 'unsafe-inline'; " +
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+  "font-src https://fonts.gstatic.com; " +
+  "img-src 'self' data:; " +
+  "connect-src 'self'; " +
+  "frame-ancestors 'none'";
 
 app.get('/login', (req, res) => {
   if (isAuthed(req)) return res.redirect('/');
   res.type('html').set({
     'Cache-Control': 'no-store',
-    'Content-Security-Policy':
-      "default-src 'self'; " +
-      "script-src 'self' 'unsafe-inline'; " +
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
-      "font-src https://fonts.gstatic.com; " +
-      "img-src 'self' data:; " +
-      "connect-src 'self'; " +
-      "frame-ancestors 'none'",
+    'Content-Security-Policy': CSP_LOGIN,
     'X-Frame-Options': 'DENY',
     'Referrer-Policy': 'no-referrer',
   }).send(LOGIN_HTML);
@@ -125,84 +131,228 @@ app.post('/api/login', (req, res) => {
   const ok =
     constTimeEqHash(sha256(user), USER_HASH) &&
     constTimeEqHash(sha256(pass), PASS_HASH);
-  if (!ok) {
-    return res.status(401).json({ error: 'invalid_credentials' });
-  }
+  if (!ok) return res.status(401).json({ error: 'invalid_credentials' });
+
   const expiresAt = Date.now() + TTL_MS;
   const token = signSession(expiresAt);
   res.cookie(COOKIE_NAME, token, {
-    httpOnly: true,
-    secure: true,         // NPM enforces HTTPS in front
-    sameSite: 'lax',
-    path: '/',
-    maxAge: TTL_MS,
+    httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: TTL_MS,
   });
   res.json({ ok: true, expiresAt });
 });
 
 app.post('/api/logout', (req, res) => {
   res.clearCookie(COOKIE_NAME, { path: '/' });
+  res.json({ ok: true });
+});
+// Old GET-based logout link still works for backward-compat
+app.get('/api/logout', (req, res) => {
+  res.clearCookie(COOKIE_NAME, { path: '/' });
   res.redirect('/login');
 });
 
-// Express's res.cookie helper is part of express; res.cookie isn't built-in to
-// the bare node response. Add a shim if needed.
-app.use((req, res, next) => {
-  if (typeof res.cookie !== 'function') {
-    res.cookie = (name, value, opts = {}) => {
-      const parts = [`${name}=${encodeURIComponent(value)}`];
-      if (opts.maxAge) parts.push(`Max-Age=${Math.floor(opts.maxAge / 1000)}`);
-      if (opts.path) parts.push(`Path=${opts.path}`);
-      if (opts.httpOnly) parts.push('HttpOnly');
-      if (opts.secure) parts.push('Secure');
-      if (opts.sameSite) parts.push(`SameSite=${opts.sameSite[0].toUpperCase() + opts.sameSite.slice(1)}`);
-      res.setHeader('Set-Cookie', parts.join('; '));
-    };
-  }
-  next();
-});
+// ── Overlay static assets (must come before the auth gate so the cached
+//    overlay JS can be loaded even if the session has just expired — the
+//    user lands on /login and the page is harmless without a live ttyd).
+//    But they ARE auth-gated below anyway — better defence in depth.
+function serveOverlay(req, res, body, type) {
+  res.type(type)
+     .set('Cache-Control', 'public, max-age=300')
+     .send(body);
+}
 
-// Auth gate. After this point, only authenticated traffic continues.
+// ── Auth gate. After this point only authenticated traffic continues. ─
 app.use((req, res, next) => {
   if (isAuthed(req)) return next();
-  // Browser-initiated GETs go to the login page; everything else gets a 401.
   if (req.method === 'GET' && (req.headers.accept || '').includes('text/html')) {
     return res.redirect('/login');
   }
   return res.status(401).json({ error: 'unauthorized' });
 });
 
-// Proxy authed traffic to ttyd. The middleware also handles WS upgrades when
-// `ws: true` and is wired to the http.Server below.
+// Overlay assets — authenticated users only
+app.get('/_careerops/overlay.js',  (req, res) => serveOverlay(req, res, OVERLAY_JS,  'application/javascript; charset=utf-8'));
+app.get('/_careerops/overlay.css', (req, res) => serveOverlay(req, res, OVERLAY_CSS, 'text/css; charset=utf-8'));
+
+// ── POST /api/queue-url — append a URL to data/pipeline.md ──────────
+app.post('/api/queue-url', (req, res) => {
+  const { url } = req.body || {};
+  if (typeof url !== 'string' || !/^https?:\/\//i.test(url)) {
+    return res.status(400).json({ error: 'invalid_url' });
+  }
+  try {
+    const pipelinePath = path.join(WORKSPACE, 'data', 'pipeline.md');
+    ensurePipelineFile(pipelinePath);
+    const ts = new Date().toISOString().replace('T', ' ').slice(0, 16);
+    const line = `- [ ] ${url}  | (queued ${ts} via web GUI)\n`;
+    appendFileSync(pipelinePath, line, { encoding: 'utf8' });
+    res.json({ ok: true, queued: pipelinePath, url });
+  } catch (err) {
+    console.error('[queue-url] error:', err);
+    res.status(500).json({ error: 'write_failed', detail: String(err.message || err) });
+  }
+});
+
+// ── POST /api/scrape — call the Scrapling sidecar + persist ────────
+app.post('/api/scrape', async (req, res) => {
+  const { url } = req.body || {};
+  if (typeof url !== 'string' || !/^https?:\/\//i.test(url)) {
+    return res.status(400).json({ error: 'invalid_url' });
+  }
+
+  // Call sidecar
+  let scrape;
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 90_000);
+    const resp = await fetch(`${SCRAPER_URL}/scrape`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    const text = await resp.text();
+    let body;
+    try { body = JSON.parse(text); } catch { body = { detail: text.slice(0, 300) }; }
+    if (!resp.ok) {
+      return res.status(502).json({
+        error: 'scraper_failed',
+        detail: body.detail || `sidecar returned ${resp.status}`,
+        url,
+      });
+    }
+    scrape = body;
+  } catch (err) {
+    console.error('[scrape] sidecar error:', err.message);
+    const offline = /ENOTFOUND|ECONNREFUSED|fetch failed|abort/i.test(err.message || '');
+    return res.status(offline ? 503 : 502).json({
+      error: offline ? 'scraper_offline' : 'scraper_error',
+      detail: err.message,
+    });
+  }
+
+  // Persist JD markdown to jds/NNN-{slug}.md and append URL to pipeline.md
+  try {
+    const jdsDir = path.join(WORKSPACE, 'jds');
+    const dataDir = path.join(WORKSPACE, 'data');
+    mkdirSync(jdsDir,  { recursive: true });
+    mkdirSync(dataDir, { recursive: true });
+
+    const num  = nextJdNumber(jdsDir);
+    const slug = makeSlug(scrape.company, scrape.title, url);
+    const jdFilename = `${String(num).padStart(3, '0')}-${slug}.md`;
+    const jdPath = path.join(jdsDir, jdFilename);
+    writeFileSync(jdPath, scrape.jd_markdown, { encoding: 'utf8', mode: 0o644 });
+
+    // Append the URL to data/pipeline.md (career-ops convention)
+    const pipelinePath = path.join(dataDir, 'pipeline.md');
+    ensurePipelineFile(pipelinePath);
+    const ts = new Date().toISOString().replace('T', ' ').slice(0, 16);
+    const line = `- [ ] ${url}  | ${scrape.company || '(company?)'} — ${scrape.title || '(role?)'}  | local:jds/${jdFilename}  (scraped ${ts}, fetcher=${scrape.fetcher})\n`;
+    appendFileSync(pipelinePath, line, { encoding: 'utf8' });
+
+    res.json({
+      ok: true,
+      path: `jds/${jdFilename}`,
+      queued: pipelinePath.replace(WORKSPACE + '/', ''),
+      title: scrape.title,
+      company: scrape.company,
+      location: scrape.location,
+      chars: scrape.chars,
+      fetcher: scrape.fetcher,
+    });
+  } catch (err) {
+    console.error('[scrape] persist error:', err);
+    res.status(500).json({ error: 'write_failed', detail: String(err.message || err) });
+  }
+});
+
+// ── Proxy authed traffic to ttyd ─────────────────────────────────────
+// Inject the overlay <script> into HTML responses (the ttyd index).
 const ttydProxy = createProxyMiddleware({
   target: TTYD_TARGET,
   ws: true,
   changeOrigin: true,
   xfwd: true,
+  selfHandleResponse: true,
   logLevel: 'warn',
+  on: {
+    proxyRes: responseInterceptor(async (responseBuffer, proxyRes, req, res) => {
+      const ct = (proxyRes.headers['content-type'] || '').toLowerCase();
+      if (!ct.includes('text/html')) return responseBuffer; // pass-through binary/JS/CSS
+      const html = responseBuffer.toString('utf8');
+      const tag = '<script src="/_careerops/overlay.js" defer></script>';
+      if (html.includes(tag)) return html; // idempotent
+      if (html.includes('</body>')) return html.replace('</body>', `${tag}\n</body>`);
+      return html + tag; // best-effort
+    }),
+  },
 });
 app.use('/', ttydProxy);
 
 // ── HTTP server + WebSocket upgrade gating ─────────────────────────
 const server = app.listen(PORT, '0.0.0.0', () => {
   console.log(
-    `[careerops-auth] listening on 0.0.0.0:${PORT} -> ${TTYD_TARGET} ` +
-    `(cookie ttl=${TTL_DAYS}d)`
+    `[careerops-auth] listening on 0.0.0.0:${PORT} ` +
+    `→ ttyd ${TTYD_TARGET}  ·  scraper ${SCRAPER_URL}  ·  workspace ${WORKSPACE}  ·  cookie ttl=${TTL_DAYS}d`
   );
 });
 
 server.on('upgrade', (req, socket, head) => {
   if (!isAuthed(req)) {
-    socket.write(
-      'HTTP/1.1 401 Unauthorized\r\n' +
-      'Connection: close\r\n' +
-      'WWW-Authenticate: Bearer realm="careerops"\r\n\r\n'
-    );
+    socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\nWWW-Authenticate: Bearer realm="careerops"\r\n\r\n');
     socket.destroy();
     return;
   }
   ttydProxy.upgrade(req, socket, head);
 });
+
+// ── Helpers ────────────────────────────────────────────────────────
+function ensurePipelineFile(p) {
+  if (!existsSync(p)) {
+    writeFileSync(p,
+      '# Pipeline — URL Inbox\n\n' +
+      'URLs queued for evaluation. Each line is one offer the scanner discovered.\n' +
+      'Lines may be raw URLs or `URL  -- notes`.\n\n' +
+      '## Pendientes\n\n',
+      { encoding: 'utf8' }
+    );
+  }
+}
+
+function nextJdNumber(jdsDir) {
+  let max = 0;
+  try {
+    for (const f of readdirSync(jdsDir)) {
+      const m = f.match(/^(\d{1,4})-/);
+      if (m) max = Math.max(max, parseInt(m[1], 10));
+    }
+  } catch { /* dir missing — caller will mkdir */ }
+  return max + 1;
+}
+
+function makeSlug(company, title, url) {
+  const pick = (s) => (s || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]+/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40);
+  const c = pick(company);
+  const t = pick(title);
+  if (c && t) return `${c}-${t}`.slice(0, 60);
+  if (c)      return c;
+  if (t)      return t;
+  // Last-resort: derive from URL path
+  try {
+    const u = new URL(url);
+    return pick(u.host + u.pathname).slice(0, 50) || 'untitled';
+  } catch {
+    return 'untitled';
+  }
+}
 
 // ── Graceful shutdown ──────────────────────────────────────────────
 let shuttingDown = false;

--- a/auth/server.mjs
+++ b/auth/server.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/**
+ * auth/server.mjs — careerops auth proxy
+ *
+ * Sits in front of ttyd. Replaces ttyd's browser-default Basic-Auth popup
+ * with a designed login page, then transparently proxies the authenticated
+ * session (HTTP + WebSocket) to ttyd on a private port.
+ *
+ * Environment:
+ *   CAREEROPS_WEB_USER      Required. Username for the login page.
+ *   CAREEROPS_WEB_PASS      Required. Password for the login page.
+ *   COOKIE_SECRET           Required. HMAC secret signing session cookies.
+ *                           Generate with `openssl rand -hex 32`.
+ *   AUTH_PROXY_PORT         Optional. Default 7681 (the port NPM forwards to).
+ *   TTYD_TARGET             Optional. Default http://127.0.0.1:7682
+ *   COOKIE_TTL_DAYS         Optional. Default 30.
+ *
+ * Routes:
+ *   GET  /login            -> serves login.html (redirects to / if authed)
+ *   POST /api/login        -> validates creds, sets signed cookie, JSON ok
+ *   POST /api/logout       -> clears cookie, redirects to /login
+ *   *                      -> proxied to ttyd if authed, else /login
+ */
+
+import express from 'express';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+import { createHmac, createHash, timingSafeEqual } from 'crypto';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const USER        = required('CAREEROPS_WEB_USER');
+const PASS        = required('CAREEROPS_WEB_PASS');
+const SECRET      = required('COOKIE_SECRET');
+const PORT        = Number(process.env.AUTH_PROXY_PORT || 7681);
+const TTYD_TARGET = process.env.TTYD_TARGET || 'http://127.0.0.1:7682';
+const TTL_DAYS    = Number(process.env.COOKIE_TTL_DAYS || 30);
+const TTL_MS      = TTL_DAYS * 24 * 60 * 60 * 1000;
+const COOKIE_NAME = 'careerops_session';
+
+function required(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`FATAL: ${name} is required but unset.`);
+    process.exit(1);
+  }
+  return v;
+}
+
+// Pre-hash the configured creds so the comparison is timing-safe and length-fixed.
+const USER_HASH = sha256(USER);
+const PASS_HASH = sha256(PASS);
+
+function sha256(s)  { return createHash('sha256').update(String(s)).digest(); }
+function hmac(s)    { return createHmac('sha256', SECRET).update(String(s)).digest('base64url'); }
+function constTimeEqHash(a, b) { return a.length === b.length && timingSafeEqual(a, b); }
+
+// Session token: <expiresAt_base36>.<HMAC>
+function signSession(expiresAtMs) {
+  const payload = expiresAtMs.toString(36);
+  return `${payload}.${hmac(payload)}`;
+}
+function verifySession(token) {
+  if (typeof token !== 'string' || !token.includes('.')) return null;
+  const i = token.indexOf('.');
+  const payload = token.slice(0, i);
+  const sig = token.slice(i + 1);
+  const expected = hmac(payload);
+  if (sig.length !== expected.length) return null;
+  if (!timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) return null;
+  const expiresAt = parseInt(payload, 36);
+  if (!Number.isFinite(expiresAt) || Date.now() > expiresAt) return null;
+  return { expiresAt };
+}
+
+function parseCookies(header) {
+  const out = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=');
+    if (idx === -1) continue;
+    const k = part.slice(0, idx).trim();
+    const v = decodeURIComponent(part.slice(idx + 1).trim());
+    if (k) out[k] = v;
+  }
+  return out;
+}
+function isAuthed(req) {
+  return verifySession(parseCookies(req.headers.cookie)[COOKIE_NAME]);
+}
+
+// ── App ─────────────────────────────────────────────────────────────
+const app = express();
+app.disable('x-powered-by');
+app.set('trust proxy', true); // NPM is in front
+app.use(express.json({ limit: '4kb' }));
+
+// Cache the login HTML at boot — it's static.
+const LOGIN_HTML = readFileSync(path.join(__dirname, 'login.html'), 'utf8');
+
+app.get('/login', (req, res) => {
+  if (isAuthed(req)) return res.redirect('/');
+  res.type('html').set({
+    'Cache-Control': 'no-store',
+    'Content-Security-Policy':
+      "default-src 'self'; " +
+      "script-src 'self' 'unsafe-inline'; " +
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+      "font-src https://fonts.gstatic.com; " +
+      "img-src 'self' data:; " +
+      "connect-src 'self'; " +
+      "frame-ancestors 'none'",
+    'X-Frame-Options': 'DENY',
+    'Referrer-Policy': 'no-referrer',
+  }).send(LOGIN_HTML);
+});
+
+app.post('/api/login', (req, res) => {
+  const { user, pass } = req.body || {};
+  if (typeof user !== 'string' || typeof pass !== 'string') {
+    return res.status(400).json({ error: 'bad_request' });
+  }
+  const ok =
+    constTimeEqHash(sha256(user), USER_HASH) &&
+    constTimeEqHash(sha256(pass), PASS_HASH);
+  if (!ok) {
+    return res.status(401).json({ error: 'invalid_credentials' });
+  }
+  const expiresAt = Date.now() + TTL_MS;
+  const token = signSession(expiresAt);
+  res.cookie(COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: true,         // NPM enforces HTTPS in front
+    sameSite: 'lax',
+    path: '/',
+    maxAge: TTL_MS,
+  });
+  res.json({ ok: true, expiresAt });
+});
+
+app.post('/api/logout', (req, res) => {
+  res.clearCookie(COOKIE_NAME, { path: '/' });
+  res.redirect('/login');
+});
+
+// Express's res.cookie helper is part of express; res.cookie isn't built-in to
+// the bare node response. Add a shim if needed.
+app.use((req, res, next) => {
+  if (typeof res.cookie !== 'function') {
+    res.cookie = (name, value, opts = {}) => {
+      const parts = [`${name}=${encodeURIComponent(value)}`];
+      if (opts.maxAge) parts.push(`Max-Age=${Math.floor(opts.maxAge / 1000)}`);
+      if (opts.path) parts.push(`Path=${opts.path}`);
+      if (opts.httpOnly) parts.push('HttpOnly');
+      if (opts.secure) parts.push('Secure');
+      if (opts.sameSite) parts.push(`SameSite=${opts.sameSite[0].toUpperCase() + opts.sameSite.slice(1)}`);
+      res.setHeader('Set-Cookie', parts.join('; '));
+    };
+  }
+  next();
+});
+
+// Auth gate. After this point, only authenticated traffic continues.
+app.use((req, res, next) => {
+  if (isAuthed(req)) return next();
+  // Browser-initiated GETs go to the login page; everything else gets a 401.
+  if (req.method === 'GET' && (req.headers.accept || '').includes('text/html')) {
+    return res.redirect('/login');
+  }
+  return res.status(401).json({ error: 'unauthorized' });
+});
+
+// Proxy authed traffic to ttyd. The middleware also handles WS upgrades when
+// `ws: true` and is wired to the http.Server below.
+const ttydProxy = createProxyMiddleware({
+  target: TTYD_TARGET,
+  ws: true,
+  changeOrigin: true,
+  xfwd: true,
+  logLevel: 'warn',
+});
+app.use('/', ttydProxy);
+
+// ── HTTP server + WebSocket upgrade gating ─────────────────────────
+const server = app.listen(PORT, '0.0.0.0', () => {
+  console.log(
+    `[careerops-auth] listening on 0.0.0.0:${PORT} -> ${TTYD_TARGET} ` +
+    `(cookie ttl=${TTL_DAYS}d)`
+  );
+});
+
+server.on('upgrade', (req, socket, head) => {
+  if (!isAuthed(req)) {
+    socket.write(
+      'HTTP/1.1 401 Unauthorized\r\n' +
+      'Connection: close\r\n' +
+      'WWW-Authenticate: Bearer realm="careerops"\r\n\r\n'
+    );
+    socket.destroy();
+    return;
+  }
+  ttydProxy.upgrade(req, socket, head);
+});
+
+// ── Graceful shutdown ──────────────────────────────────────────────
+let shuttingDown = false;
+function shutdown(sig) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`[careerops-auth] ${sig} received, shutting down`);
+  server.close(() => process.exit(0));
+  setTimeout(() => process.exit(1), 5000).unref();
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT',  () => shutdown('SIGINT'));

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# career-ops web GUI entrypoint
+# Exposes the Go TUI dashboard over the browser via ttyd, behind HTTP Basic Auth.
+set -euo pipefail
+
+: "${CAREEROPS_WEB_USER:?CAREEROPS_WEB_USER must be set (HTTP Basic Auth username)}"
+: "${CAREEROPS_WEB_PASS:?CAREEROPS_WEB_PASS must be set (HTTP Basic Auth password)}"
+
+WORKSPACE="${CAREEROPS_WORKSPACE:-/workspace}"
+PORT="${CAREEROPS_WEB_PORT:-7681}"
+
+if [[ ! -d "${WORKSPACE}" ]]; then
+  echo "FATAL: workspace ${WORKSPACE} not mounted" >&2
+  exit 1
+fi
+
+# ttyd flags:
+#   -p   listen port
+#   -i   bind address (0.0.0.0 — NPM is the only thing in front)
+#   -c   user:pass (HTTP Basic Auth)
+#   -W   writable terminal (the TUI needs key input)
+#   -t   xterm.js client options
+# Origin check stays OFF (default) — NPM rewrites the Host header.
+exec ttyd \
+  -p "${PORT}" \
+  -i 0.0.0.0 \
+  -c "${CAREEROPS_WEB_USER}:${CAREEROPS_WEB_PASS}" \
+  -W \
+  -t titleFixed='career-ops' \
+  -t 'theme={"background":"#1e1e2e","foreground":"#cdd6f4"}' \
+  -t fontSize=14 \
+  /usr/local/bin/career-dashboard --path "${WORKSPACE}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,32 +1,45 @@
 #!/usr/bin/env bash
-# career-ops web GUI entrypoint
-# Exposes the Go TUI dashboard over the browser via ttyd, behind HTTP Basic Auth.
+# careerops web GUI entrypoint
+#
+# Architecture:
+#   browser  →  NPM (HTTPS)  →  auth-proxy (Node, :7681)  →  ttyd (:7682, loopback)  →  career-dashboard
+#
+# The auth proxy serves a designed login page at /login, validates credentials,
+# signs a 30-day session cookie, and transparently proxies the authenticated
+# session (HTTP + WebSocket) to ttyd on the private port 7682.
 set -euo pipefail
 
-: "${CAREEROPS_WEB_USER:?CAREEROPS_WEB_USER must be set (HTTP Basic Auth username)}"
-: "${CAREEROPS_WEB_PASS:?CAREEROPS_WEB_PASS must be set (HTTP Basic Auth password)}"
+: "${CAREEROPS_WEB_USER:?CAREEROPS_WEB_USER must be set}"
+: "${CAREEROPS_WEB_PASS:?CAREEROPS_WEB_PASS must be set}"
+: "${COOKIE_SECRET:?COOKIE_SECRET must be set (generate with: openssl rand -hex 32)}"
 
 WORKSPACE="${CAREEROPS_WORKSPACE:-/workspace}"
-PORT="${CAREEROPS_WEB_PORT:-7681}"
+AUTH_PORT="${AUTH_PROXY_PORT:-7681}"
+TTYD_PORT="${TTYD_INTERNAL_PORT:-7682}"
 
 if [[ ! -d "${WORKSPACE}" ]]; then
   echo "FATAL: workspace ${WORKSPACE} not mounted" >&2
   exit 1
 fi
 
-# ttyd flags:
-#   -p   listen port
-#   -i   bind address (0.0.0.0 — NPM is the only thing in front)
-#   -c   user:pass (HTTP Basic Auth)
-#   -W   writable terminal (the TUI needs key input)
-#   -t   xterm.js client options
-# Origin check stays OFF (default) — NPM rewrites the Host header.
-exec ttyd \
-  -p "${PORT}" \
-  -i 0.0.0.0 \
-  -c "${CAREEROPS_WEB_USER}:${CAREEROPS_WEB_PASS}" \
+# Start ttyd on the private port, no Basic Auth (the auth proxy owns auth now).
+# Origin check stays OFF (default) — NPM rewrites Host.
+ttyd \
+  -p "${TTYD_PORT}" \
+  -i 127.0.0.1 \
   -W \
   -t titleFixed='career-ops' \
-  -t 'theme={"background":"#1e1e2e","foreground":"#cdd6f4"}' \
+  -t 'theme={"background":"#1e1e2e","foreground":"#cdd6f4","cursor":"#fab387","selection":"#585b70"}' \
   -t fontSize=14 \
-  /usr/local/bin/career-dashboard --path "${WORKSPACE}"
+  /usr/local/bin/career-dashboard --path "${WORKSPACE}" &
+TTYD_PID=$!
+
+# Propagate termination to ttyd when the auth proxy exits.
+trap 'kill -TERM "${TTYD_PID}" 2>/dev/null || true' EXIT SIGTERM SIGINT
+
+export AUTH_PROXY_PORT="${AUTH_PORT}"
+export TTYD_TARGET="http://127.0.0.1:${TTYD_PORT}"
+
+# tini (PID 1) reaps zombies; if ttyd dies the auth proxy will start returning
+# 502 on proxied paths, which is the right signal for an external healthcheck.
+exec node /opt/auth/server.mjs

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@google/generative-ai": "^0.24.1",
     "dotenv": "^17.0.0",
     "js-yaml": "^4.1.1",
+    "nodemailer": "^8.0.7",
     "playwright": "^1.58.1"
   }
 }

--- a/scraper/Dockerfile
+++ b/scraper/Dockerfile
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1.7
+#
+# careerops-scraper — Scrapling sidecar.
+# Heavier container (Python + Playwright/Camoufox browser bundles) so the
+# main careerops container can stay lean. Talks HTTP on :8000 over the
+# management network; only the auth proxy calls into it.
+
+FROM python:3.12-slim-bookworm AS runtime
+
+# System libs needed for headless chromium/firefox; Scrapling/Camoufox install
+# their own browser bundles via `scrapling install` post-pip.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates curl tini \
+      libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 \
+      libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+      libgbm1 libxkbcommon0 libasound2 libatspi2.0-0 \
+      libcups2 libdbus-1-3 libpango-1.0-0 libcairo2 \
+      libxshmfence1 libxrender1 libx11-xcb1 fonts-liberation \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Scrapling needs its browser bundles fetched into ~/.cache/ms-playwright and
+# ~/.cache/camoufox. Doing this at build time bakes them into the image.
+# Skip silently if the version's CLI shape differs; the fetcher falls back to
+# the plain HTTP path.
+RUN python -c "from scrapling.fetchers import Fetcher, StealthyFetcher, DynamicFetcher; print('scrapling import ok')"
+
+# Bake browser bundles into the image. Without this, the first /scrape call
+# tries to launch a non-existent chromium and the StealthyFetcher / Dynamic-
+# Fetcher both fall back to the plain HTTP fetcher — which only sees static
+# HTML and can't handle JS-rendered job pages (LinkedIn, Greenhouse, etc.).
+#
+# Patchright = patched Playwright (for DynamicFetcher).
+# Camoufox    = patched Firefox build (for StealthyFetcher).
+# Bundles go under a shared /opt/browsers cache so they're owned by root
+# and readable by the runtime `app` user.
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/browsers \
+    CAMOUFOX_HOME=/opt/browsers/camoufox
+
+RUN mkdir -p /opt/browsers \
+ && patchright install chromium \
+ && chmod -R a+rX /opt/browsers
+
+COPY scrape_server.py ./
+
+# Non-root for sandbox-friendliness
+ARG APP_UID=1001
+ARG APP_GID=1001
+RUN groupadd -g ${APP_GID} app && useradd -m -u ${APP_UID} -g ${APP_GID} -s /bin/bash app \
+ && chown -R app:app /app
+USER app
+
+EXPOSE 8000
+
+ENTRYPOINT ["/usr/bin/tini", "--", "python", "-m", "uvicorn", "scrape_server:app", \
+            "--host", "0.0.0.0", "--port", "8000", "--log-level", "info"]

--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.115,<0.116
+uvicorn[standard]>=0.32,<0.40
+pydantic>=2.7,<3
+# Scrapling 0.4.x split out optional fetcher deps. We need StealthyFetcher
+# (Camoufox) + DynamicFetcher (Playwright) — both pull curl_cffi and others.
+scrapling[fetchers]>=0.4,<1

--- a/scraper/scrape_server.py
+++ b/scraper/scrape_server.py
@@ -1,0 +1,303 @@
+"""
+scraper/scrape_server.py — Scrapling-backed JD fetcher.
+
+Exposes a single endpoint:
+
+    POST /scrape  { "url": "https://..." }  →  { ok, title, company, location, jd_markdown, chars, fetcher }
+
+The auth proxy calls this and persists the result. Designed to be conservative:
+LinkedIn anti-bot screens are aggressive, so we attempt the fetcher chain
+StealthyFetcher → DynamicFetcher (Camoufox) → Fetcher (plain HTTP) and return
+the first one that surfaces a real JD-shaped page. Pages where the body looks
+like a login wall or sign-in CTA are rejected so the caller doesn't write
+junk to jds/.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import sys
+from typing import Any
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, HttpUrl, field_validator
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("scraper")
+
+# ── Scrapling fetchers — lazy-imported so import errors are observable ─
+try:
+    from scrapling.fetchers import Fetcher, StealthyFetcher, DynamicFetcher  # type: ignore
+except Exception as exc:  # pragma: no cover
+    log.exception("Scrapling import failed; the /scrape endpoint will return 503")
+    Fetcher = StealthyFetcher = DynamicFetcher = None  # type: ignore
+
+app = FastAPI(title="careerops-scraper", version="1.0.0")
+
+
+class ScrapeRequest(BaseModel):
+    url: HttpUrl
+
+    @field_validator("url")
+    @classmethod
+    def reject_localhost(cls, v: HttpUrl) -> HttpUrl:
+        host = (urlparse(str(v)).hostname or "").lower()
+        if host in {"localhost", "127.0.0.1", "::1"} or host.startswith("10.") \
+                or host.startswith("172.") or host.startswith("192.168."):
+            raise ValueError("private/loopback URLs are not allowed")
+        return v
+
+
+class ScrapeResponse(BaseModel):
+    ok: bool
+    fetcher: str
+    title: str | None = None
+    company: str | None = None
+    location: str | None = None
+    jd_markdown: str
+    chars: int
+
+
+# ── Extraction helpers ────────────────────────────────────────────
+# These are deliberately small, per-site overrides. The list grows as we find
+# patterns that yield cleaner output than the generic body-text fallback.
+def _norm_ws(s: str | None) -> str | None:
+    if not s:
+        return None
+    return re.sub(r"\s+", " ", s).strip() or None
+
+
+def _first(page, selector):
+    """Return the first matching element or None. Scrapling exposes results
+    via .css(selector) which is iterable; .first attribute or `.extract_first()`
+    aren't part of the API on every page object, so we just take [0]."""
+    try:
+        nodes = page.css(selector)
+    except Exception:
+        return None
+    if not nodes:
+        return None
+    try:
+        return nodes[0]
+    except (IndexError, TypeError):
+        return None
+
+
+def _text_of(node) -> str | None:
+    if node is None:
+        return None
+    # Scrapling element exposes `.text` (string) and `.get_all_text()`
+    try:
+        t = node.get_all_text()
+        if t:
+            return t
+    except Exception:
+        pass
+    try:
+        return getattr(node, "text", None)
+    except Exception:
+        return None
+
+
+def _attr_of(node, name) -> str | None:
+    if node is None:
+        return None
+    try:
+        return node.attrib.get(name)
+    except Exception:
+        return None
+
+
+def _from_linkedin(page) -> dict[str, str | None]:
+    out: dict[str, str | None] = {"title": None, "company": None, "location": None, "body": None}
+    # LinkedIn's public job-view layout (when not logged in)
+    title_el = _first(page, "h1.top-card-layout__title") or \
+               _first(page, "h1.topcard__title") or \
+               _first(page, "h1")
+    out["title"] = _norm_ws(_text_of(title_el))
+    company_el = _first(page, "a.topcard__org-name-link") or \
+                 _first(page, ".topcard__flavor a") or \
+                 _first(page, ".top-card-layout__second-subline a") or \
+                 _first(page, ".top-card-layout__entity-info-container a")
+    out["company"] = _norm_ws(_text_of(company_el))
+    loc_el = _first(page, ".topcard__flavor.topcard__flavor--bullet") or \
+             _first(page, ".top-card-layout__second-subline span.topcard__flavor--bullet")
+    out["location"] = _norm_ws(_text_of(loc_el))
+    body_el = _first(page, ".description__text") or \
+              _first(page, ".show-more-less-html") or \
+              _first(page, ".jobs-description-content__text") or \
+              _first(page, ".job-description") or \
+              _first(page, "[data-test-id='jobDescriptionText']")
+    if body_el:
+        out["body"] = _text_of(body_el)
+    return out
+
+
+def _from_generic(page) -> dict[str, str | None]:
+    out: dict[str, str | None] = {"title": None, "company": None, "location": None, "body": None}
+    # OG / Twitter card hints first
+    og_title = _first(page, 'meta[property="og:title"]')
+    og_site  = _first(page, 'meta[property="og:site_name"]')
+    out["title"] = _norm_ws(_attr_of(og_title, "content")) or _norm_ws(_text_of(_first(page, "h1")))
+    out["company"] = _norm_ws(_attr_of(og_site, "content"))
+    # JD-shaped main content
+    main = _first(page, "article") or \
+           _first(page, "main") or \
+           _first(page, "[role='main']") or \
+           _first(page, ".jobs-description") or \
+           _first(page, "#content") or \
+           _first(page, "#job-description")
+    body_text = _text_of(main)
+    if not body_text:
+        # Last resort: the entire visible page text
+        try:
+            body_text = page.get_all_text()
+        except Exception:
+            body_text = _text_of(_first(page, "body"))
+    out["body"] = body_text
+    return out
+
+
+def _looks_like_login_wall(text: str) -> bool:
+    """Cheap heuristic: a few sites return a login splash + nothing else when
+    anti-bot fires. We only reject when the page is dominated by sign-in
+    language AND substantial body content is absent. JD pages routinely
+    mention 'sign in' or similar in nav/footer; the heuristic must be lenient
+    enough not to false-positive."""
+    if not text:
+        return True
+    text = text.strip()
+    if len(text) < 250:
+        return True  # almost certainly an error page or pre-hydration shell
+    head = text[:2000].lower()
+    score = 0
+    for needle in (
+        "we couldn't get to that page", "please make sure",
+        "create your free account",
+        "join linkedin", "log in to linkedin",
+    ):
+        if needle in head:
+            score += 1
+    return score >= 2
+
+
+# ── Fetcher chain ────────────────────────────────────────────────
+def _try_chain(url: str, host: str) -> tuple[str, Any, dict[str, str | None]] | None:
+    """Try each fetcher in order. Returns (label, page, parts) for the first
+    fetcher whose page yields a JD-shaped body via the site-specific extractor.
+    `parts` is the extractor output so we don't re-parse later."""
+    chain = []
+    if DynamicFetcher is not None:
+        chain.append(("dynamic-patchright",
+                      lambda: DynamicFetcher.fetch(url, headless=True, humanize=True,
+                                                   wait_selector="body", network_idle=True)))
+    if StealthyFetcher is not None:
+        chain.append(("stealthy-camoufox",
+                      lambda: StealthyFetcher.fetch(url, headless=True, network_idle=True)))
+    if Fetcher is not None:
+        chain.append(("plain", lambda: Fetcher.get(url)))
+
+    extractor = _from_linkedin if "linkedin." in host else _from_generic
+
+    for label, fn in chain:
+        try:
+            log.info("fetcher=%s url=%s", label, url)
+            page = fn()
+        except TypeError:
+            # Older/newer scrapling versions may not accept all kwargs.
+            try:
+                page = fn.__self__ if hasattr(fn, "__self__") else None  # type: ignore
+                # Re-invoke without kwargs as a degraded fallback
+                if "dynamic" in label and DynamicFetcher is not None:
+                    page = DynamicFetcher.fetch(url, headless=True)
+                elif "stealthy" in label and StealthyFetcher is not None:
+                    page = StealthyFetcher.fetch(url, headless=True)
+                elif Fetcher is not None:
+                    page = Fetcher.get(url)
+            except Exception as exc:
+                log.warning("fetcher=%s failed (retry without kwargs): %s", label, exc)
+                continue
+        except Exception as exc:
+            log.warning("fetcher=%s failed: %s", label, exc)
+            continue
+
+        try:
+            parts = extractor(page)
+        except Exception as exc:
+            log.warning("fetcher=%s extractor crashed: %s", label, exc)
+            continue
+
+        body_len = len((parts.get("body") or "").strip())
+        log.info("fetcher=%s extractor body_len=%d title=%r", label, body_len, parts.get("title"))
+
+        # Accept if we have ANY structured signal (title OR sensible body).
+        # Generic body fallback (any tag's text) saves us when CSS selectors miss.
+        if body_len < 200:
+            generic = _from_generic(page)
+            generic_body_len = len((generic.get("body") or "").strip())
+            if generic_body_len >= body_len:
+                parts = generic
+                body_len = generic_body_len
+
+        if body_len >= 250 or (parts.get("title") and body_len >= 100):
+            return label, page, parts
+
+        log.info("fetcher=%s yielded insufficient content (body_len=%d) — trying next", label, body_len)
+    return None
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "scrapling_available": all(f is not None for f in (Fetcher, StealthyFetcher, DynamicFetcher)),
+    }
+
+
+@app.post("/scrape", response_model=ScrapeResponse)
+def scrape(req: ScrapeRequest) -> ScrapeResponse:
+    if Fetcher is None:
+        raise HTTPException(503, detail="Scrapling is not available in this container")
+
+    url = str(req.url)
+    host = (urlparse(url).hostname or "").lower()
+
+    result = _try_chain(url, host)
+    if not result:
+        raise HTTPException(502, detail="all fetchers failed or returned insufficient JD content")
+
+    label, page, parts = result
+    body_text = _norm_ws(parts.get("body")) or ""
+    if not body_text or len(body_text) < 200:
+        raise HTTPException(502, detail=f"extracted body too short ({len(body_text)} chars)")
+
+    md_lines = [
+        f"# {parts.get('title') or 'Untitled role'}",
+        "",
+        f"**URL:** {url}",
+        f"**Company:** {parts.get('company') or '(not extracted)'}",
+        f"**Location:** {parts.get('location') or '(not extracted)'}",
+        f"**Fetcher:** {label}",
+        "",
+        "---",
+        "",
+        body_text,
+    ]
+    md = "\n".join(md_lines)
+
+    return ScrapeResponse(
+        ok=True,
+        fetcher=label,
+        title=parts.get("title"),
+        company=parts.get("company"),
+        location=parts.get("location"),
+        jd_markdown=md,
+        chars=len(md),
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8000")), log_level="info")

--- a/stack-compose.yml
+++ b/stack-compose.yml
@@ -1,0 +1,55 @@
+# career-ops web GUI — docker compose stack
+#
+# Wraps the upstream Go TUI dashboard with ttyd so it can be served over
+# HTTPS from a browser, behind HTTP Basic Auth. The whole career-ops
+# project is bind-mounted at /workspace so the host's Claude Code CLI and
+# the container share state (cv.md, config/, data/, reports/, output/…).
+#
+# ── Setup ──────────────────────────────────────────────────────────────
+# 1. Build the image:        docker compose -f stack-compose.yml build
+# 2. Create an .env file next to this compose with:
+#        CAREEROPS_WEB_USER=<your-username>
+#        CAREEROPS_WEB_PASS=<a-strong-random-password>
+#    (.env is already in the upstream .gitignore — never commit it.)
+# 3. Bring it up:            docker compose -f stack-compose.yml up -d
+# 4. Front it with your reverse proxy of choice (nginx, Caddy, NPM,
+#    Traefik). The container exposes port 7681 on the network selected
+#    below. WebSocket upgrade must be allowed by the proxy.
+#
+# ── Configuration ──────────────────────────────────────────────────────
+# CAREEROPS_PROJECT_DIR   Host path of the career-ops checkout to expose
+#                         (defaults to the directory holding this file).
+# CAREEROPS_NETWORK       Docker network the container joins, typically
+#                         the one your reverse proxy is on. The default
+#                         `careerops-net` is created on first `up`; set
+#                         it to an existing external network (and flip
+#                         the `external:` flag below) if you already
+#                         have one.
+
+services:
+  careerops:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: careerops:latest
+    container_name: careerops
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      CAREEROPS_WORKSPACE: /workspace
+      CAREEROPS_WEB_PORT: "7681"
+    volumes:
+      - ${CAREEROPS_PROJECT_DIR:-.}:/workspace
+    networks:
+      - careerops-net
+    expose:
+      - "7681"
+
+networks:
+  careerops-net:
+    name: ${CAREEROPS_NETWORK:-careerops-net}
+    # If CAREEROPS_NETWORK points to a pre-existing network managed by
+    # your reverse proxy (e.g. an NPM/Traefik shared net), set this to
+    # `external: true` so compose attaches instead of creating it.
+    external: false

--- a/stack-compose.yml
+++ b/stack-compose.yml
@@ -39,12 +39,30 @@ services:
     environment:
       CAREEROPS_WORKSPACE: /workspace
       CAREEROPS_WEB_PORT: "7681"
+      SCRAPER_URL: http://careerops-scraper:8000
     volumes:
       - ${CAREEROPS_PROJECT_DIR:-.}:/workspace
     networks:
       - careerops-net
     expose:
       - "7681"
+    depends_on:
+      - careerops-scraper
+
+  # Scrapling sidecar — anti-bot-aware JD fetcher. Heavier image (Python +
+  # browser bundles) intentionally separated from the main container so the
+  # auth proxy + ttyd stay lean. Only the auth proxy talks to it.
+  careerops-scraper:
+    build:
+      context: ./scraper
+      dockerfile: Dockerfile
+    image: careerops-scraper:latest
+    container_name: careerops-scraper
+    restart: unless-stopped
+    networks:
+      - careerops-net
+    expose:
+      - "8000"
 
 networks:
   careerops-net:

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,97 @@
+# tools/
+
+Fork-only additions that sit alongside upstream career-ops. Not covered by
+`DATA_CONTRACT.md` — these are for the local deployment, not for upstream PRs.
+
+## send-application-mail.mjs
+
+Sends one email with optional PDF attachments via SMTP. Drives the
+rate-screen / cover-letter / follow-up workflows that career-ops drafts
+into `batch/apply-docs/`.
+
+### Setup
+
+```bash
+cp .env.mail.example .env.mail
+# Edit .env.mail — uncomment the Gmail block OR the Mailcow block, fill creds
+```
+
+### Examples
+
+**Dry-run (no send) — sanity check before the real one:**
+```bash
+node tools/send-application-mail.mjs \
+  --to "Recruiter Name <recruiter@example.com>" \
+  --subject "Senior AI Engineer (Berlin / Full Remote) — rate-band screen" \
+  --body batch/apply-docs/000-rate-screen-emails.md \
+  --section "## Email 1" \
+  --dry-run
+```
+
+**Send a rate-screen (body-only, no attachment):**
+```bash
+node tools/send-application-mail.mjs \
+  --to recruiter@example.com \
+  --subject "Senior AI Engineer (Berlin / Full Remote) — rate-band screen" \
+  --body batch/apply-docs/000-rate-screen-emails.md \
+  --section "## Email 1"
+```
+
+**Send a tailored apply with cover letter + CV PDF:**
+```bash
+node tools/send-application-mail.mjs \
+  --to careers@example.com \
+  --subject "Senior Solutions Architect — Your Name" \
+  --body batch/apply-docs/NNN-company-role.md \
+  --section "## Cover Letter" \
+  --attach output/NNN-company-role-cv-YYYY-MM-DD.pdf
+```
+
+### Tips
+
+- The `--section` flag extracts a markdown subsection from the body file —
+  the email files in `batch/apply-docs/` are organised so each `##` heading
+  is one ready-to-send email. Look at the file before sending to confirm
+  the section name.
+- The script will not send if SMTP `verify()` fails — saves you from
+  silently mis-credentialed sends.
+- For ATS systems that prefer text-only bodies, omit `--html`; the default
+  is plain text and most career portals are fine with that.
+- **Never** put `.env.mail` under version control; it's gitignored.
+- Set `SMTP_TLS_INSECURE=true` in `.env.mail` only when sending through an
+  SMTP relay you own that uses a self-signed cert (e.g. Mailcow whose ACME
+  challenge is blocked by a fronting reverse proxy). Never set it for
+  third-party relays.
+
+## provision-mailcow-mailbox.mjs
+
+Idempotent Mailcow mailbox creator. Reads `~/.mailcow-credentials` for
+`MAILCOW_URL` + `MAILCOW_API_KEY`, talks to the Mailcow API on
+`https://127.0.0.1:8443` (bypasses the public-IP ACL that hardened Mailcow
+installs apply to the API).
+
+### Examples
+
+**Create a new mailbox:**
+```bash
+node tools/provision-mailcow-mailbox.mjs \
+  --mailbox you@yourdomain.com \
+  --name "Your Name" \
+  --quota-mb 4096 \
+  --creds-out ~/.yourdomain-mailbox-credentials
+```
+
+**Rotate the password on an existing mailbox** (breaks any active sessions):
+```bash
+node tools/provision-mailcow-mailbox.mjs \
+  --mailbox you@yourdomain.com \
+  --rotate --force \
+  --creds-out ~/.yourdomain-mailbox-credentials
+```
+
+The script:
+- Verifies the requested domain is provisioned in Mailcow (exits 4 if not).
+- Refuses to overwrite an existing mailbox unless `--rotate --force`.
+- Writes a 0600 credentials file with `MAILBOX_ADDRESS`, `MAILBOX_PASSWORD`,
+  `SMTP_HOST`, `SMTP_PORT`, `IMAP_HOST`, `IMAP_PORT`. Shape matches what
+  `send-application-mail.mjs` reads.

--- a/tools/provision-mailcow-mailbox.mjs
+++ b/tools/provision-mailcow-mailbox.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * tools/provision-mailcow-mailbox.mjs
+ *
+ * Idempotent Mailcow mailbox provisioning. Reads ~/.mailcow-credentials,
+ * hits the API on 127.0.0.1:8443 to bypass the public-IP ACL.
+ *
+ * - Verifies the requested domain is already provisioned in Mailcow.
+ * - If the mailbox doesn't exist: creates it with a fresh random password and
+ *   writes the credentials to a 0600 file the user owns.
+ * - If the mailbox already exists: prints state and exits 0 (no destruction).
+ *
+ * Usage:
+ *   node tools/provision-mailcow-mailbox.mjs \
+ *     --mailbox you@yourdomain.com \
+ *     --name "Your Name" \
+ *     --quota-mb 4096 \
+ *     --creds-out ~/.yourdomain-mailbox-credentials
+ *
+ * Flags:
+ *   --mailbox      Full address (REQUIRED).
+ *   --name         Display name (default: derived from local-part).
+ *   --quota-mb     Quota in MB (default: 4096 = 4 GB).
+ *   --creds-out    Path to write the credentials file (default: omit; print to stderr).
+ *   --rotate       If mailbox exists, rotate the password (DESTRUCTIVE — requires --force).
+ *   --force        Acknowledge that --rotate may break existing IMAP/SMTP sessions.
+ *
+ * Exit codes:
+ *   0  mailbox exists (created or already present)
+ *   1  config / credentials error
+ *   2  argument error
+ *   3  API call failed
+ *   4  domain not provisioned in Mailcow (run domain-onboard first)
+ */
+
+import { readFileSync, writeFileSync, existsSync, chmodSync, mkdirSync } from 'fs';
+import { parseArgs } from 'node:util';
+import { dirname, resolve } from 'path';
+import { homedir } from 'os';
+import { randomBytes } from 'crypto';
+
+// Mailcow on 127.0.0.1:8443 uses a self-signed cert by default. Since this
+// script only talks to localhost, globally disabling TLS verification is the
+// pragmatic choice (no MITM risk on loopback).
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+// ── Args ───────────────────────────────────────────────────────────
+let parsed;
+try {
+  parsed = parseArgs({
+    options: {
+      mailbox: { type: 'string' },
+      name: { type: 'string' },
+      'quota-mb': { type: 'string' },
+      'creds-out': { type: 'string' },
+      rotate: { type: 'boolean' },
+      force: { type: 'boolean' },
+    },
+  });
+} catch (err) {
+  console.error('arg error:', err.message);
+  process.exit(2);
+}
+const args = parsed.values;
+
+if (!args.mailbox || !args.mailbox.includes('@')) {
+  console.error('Required: --mailbox <addr@domain>');
+  process.exit(2);
+}
+const [localPart, domain] = args.mailbox.split('@');
+const name = args.name || localPart;
+const quotaMb = parseInt(args['quota-mb'] || '4096', 10);
+const credsOut = args['creds-out']
+  ? args['creds-out'].replace(/^~/, homedir())
+  : null;
+
+if (args.rotate && !args.force) {
+  console.error('--rotate requires --force (acknowledges that existing IMAP/SMTP sessions break).');
+  process.exit(2);
+}
+
+// ── Credentials (~/.mailcow-credentials) ──────────────────────────
+function loadMailcowCreds() {
+  const path = `${homedir()}/.mailcow-credentials`;
+  if (!existsSync(path)) {
+    console.error(`missing ${path}`);
+    process.exit(1);
+  }
+  const env = {};
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const m = line.match(/^([A-Z_]+)=(.*)$/);
+    if (m) env[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+  for (const k of ['MAILCOW_URL', 'MAILCOW_API_KEY']) {
+    if (!env[k]) {
+      console.error(`${path}: missing ${k}`);
+      process.exit(1);
+    }
+  }
+  return env;
+}
+const creds = loadMailcowCreds();
+
+// Local-loopback base bypasses the public-IP API ACL (Mailcow ACLs the public IP,
+// not 127.0.0.1, on default hardened installs). HTTPS on 8443; ignore self-signed cert.
+const LOCAL_BASE = 'https://127.0.0.1:8443';
+
+async function api(method, path, body) {
+  const url = `${LOCAL_BASE}${path}`;
+  const opts = {
+    method,
+    headers: {
+      'X-API-Key': creds.MAILCOW_API_KEY,
+      'Content-Type': 'application/json',
+    },
+    // Self-signed cert on localhost — use Node's fetch with rejectUnauthorized:false via Undici dispatcher.
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  };
+  // TLS verification is disabled globally at top of file (loopback only).
+  const resp = await fetch(url, opts);
+  const text = await resp.text();
+  let json;
+  try { json = JSON.parse(text); } catch { json = { type: 'error', msg: text }; }
+  return { http: resp.status, json };
+}
+
+// ── Step 1: domain exists? ─────────────────────────────────────────
+console.error(`[1/4] checking domain ${domain} is provisioned in Mailcow...`);
+const domResp = await api('GET', '/api/v1/get/domain/all');
+if (domResp.http !== 200 || !Array.isArray(domResp.json)) {
+  console.error('domain list failed:', domResp.json);
+  process.exit(3);
+}
+const dom = domResp.json.find((d) => d.domain_name === domain);
+if (!dom) {
+  console.error(`✗ domain "${domain}" not found in Mailcow. Onboard the domain first.`);
+  process.exit(4);
+}
+console.error(`  ✓ ${domain} present (active=${dom.active}, mailboxes=${dom.mboxes}/${dom.max_num_mboxes_for_domain})`);
+
+// ── Step 2: mailbox exists? ────────────────────────────────────────
+console.error(`[2/4] checking mailbox ${args.mailbox}...`);
+const mbResp = await api('GET', `/api/v1/get/mailbox/all/${encodeURIComponent(domain)}`);
+if (mbResp.http !== 200 || !Array.isArray(mbResp.json)) {
+  console.error('mailbox list failed:', mbResp.json);
+  process.exit(3);
+}
+const existing = mbResp.json.find((m) => m.username === args.mailbox);
+
+function genPassword() {
+  // 32 random bytes → URL-safe base64, trimmed to 24 chars. Mailcow requires
+  // ≥ 6 chars and mixed-case by default; this comfortably exceeds.
+  return randomBytes(32).toString('base64').replace(/[^A-Za-z0-9]/g, '').slice(0, 24);
+}
+
+if (existing && !args.rotate) {
+  console.error(`  ✓ mailbox already exists (active=${existing.active}, quota=${existing.quota} bytes)`);
+  console.error('  Use --rotate --force to reset the password (will break existing IMAP/SMTP sessions).');
+  process.exit(0);
+}
+
+// ── Step 3: create or rotate ──────────────────────────────────────
+const password = genPassword();
+let body, action;
+
+if (existing && args.rotate) {
+  action = 'rotate-password';
+  body = {
+    items: [args.mailbox],
+    attr: { password, password2: password },
+  };
+  console.error('[3/4] rotating password for existing mailbox...');
+  const r = await api('POST', '/api/v1/edit/mailbox', body);
+  if (r.http !== 200 || (Array.isArray(r.json) && r.json[0]?.type === 'error')) {
+    console.error('rotate failed:', JSON.stringify(r.json).slice(0, 300));
+    process.exit(3);
+  }
+  console.error('  ✓ password rotated');
+} else {
+  action = 'create';
+  body = {
+    local_part: localPart,
+    domain,
+    name,
+    password,
+    password2: password,
+    quota: quotaMb,
+    active: '1',
+    force_pw_update: '0',
+    tls_enforce_in: '1',
+    tls_enforce_out: '1',
+  };
+  console.error('[3/4] creating mailbox...');
+  const r = await api('POST', '/api/v1/add/mailbox', body);
+  if (r.http !== 200 || (Array.isArray(r.json) && r.json[0]?.type === 'error')) {
+    console.error('create failed:', JSON.stringify(r.json).slice(0, 300));
+    process.exit(3);
+  }
+  console.error(`  ✓ mailbox ${args.mailbox} created (${quotaMb} MB quota, TLS enforced in+out)`);
+}
+
+// ── Step 4: write credentials file (or stderr) ────────────────────
+console.error('[4/4] persisting credentials...');
+const credText = [
+  `# Mailcow mailbox credentials for ${args.mailbox}`,
+  `# Action: ${action}`,
+  `# Generated ${new Date().toISOString()}`,
+  '',
+  `MAILBOX_ADDRESS=${args.mailbox}`,
+  `MAILBOX_PASSWORD=${password}`,
+  `SMTP_HOST=${(() => { try { return new URL(creds.MAILCOW_URL).host; } catch { return 'mail.example.com'; } })()}`,
+  `SMTP_PORT=587`,
+  `SMTP_SECURE=false`,
+  `IMAP_HOST=${(() => { try { return new URL(creds.MAILCOW_URL).host; } catch { return 'mail.example.com'; } })()}`,
+  `IMAP_PORT=993`,
+  `IMAP_SECURE=true`,
+  '',
+].join('\n');
+
+if (credsOut) {
+  mkdirSync(dirname(credsOut), { recursive: true });
+  writeFileSync(credsOut, credText, { mode: 0o600 });
+  chmodSync(credsOut, 0o600);
+  console.error(`  ✓ wrote ${credsOut} (mode 0600)`);
+} else {
+  console.error('  no --creds-out specified; emitting to stdout below');
+}
+
+console.log(credText);
+console.error('Done.');

--- a/tools/send-application-mail.mjs
+++ b/tools/send-application-mail.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * tools/send-application-mail.mjs — send a careerops email with PDF attachments
+ *
+ * Designed for the career-ops apply workflow: rate-screen messages, cover-letter
+ * submissions, and recruiter follow-ups. Provider-agnostic via .env.mail —
+ * works with Gmail (App Password), Mailcow, any SMTP relay.
+ *
+ * Usage:
+ *   node tools/send-application-mail.mjs \
+ *     --to "Recruiter Name <recruiter@example.com>" \
+ *     --subject "Senior AI Engineer — rate-band screen" \
+ *     --body batch/apply-docs/000-rate-screen-emails.md \
+ *     --section "## Email 1" \
+ *     --attach output/NNN-company-role-cv-YYYY-MM-DD.pdf \
+ *     [--dry-run]
+ *
+ * Flags:
+ *   --to        Recipient. Accepts "Name <addr>" or bare "addr".
+ *   --subject   Subject line.
+ *   --body      Path to a markdown file holding the body.
+ *   --section   (optional) Heading inside --body to extract verbatim. Useful
+ *               when the markdown file holds multiple emails. Matches the
+ *               line beginning "## <section>" and stops at the next "##".
+ *               If omitted, the entire --body file is sent.
+ *   --attach    File path to attach. Repeatable.
+ *   --cc        CC recipient. Repeatable.
+ *   --bcc       BCC recipient. Repeatable.
+ *   --reply-to  Reply-To header.
+ *   --from      Override From header (default: SMTP_FROM in .env.mail).
+ *   --html      If set, send body as HTML instead of plain text.
+ *   --dry-run   Print what would be sent, don't actually send.
+ *
+ * Required environment (loaded from .env.mail at repo root):
+ *   SMTP_HOST, SMTP_PORT, SMTP_SECURE, SMTP_USER, SMTP_PASS, SMTP_FROM
+ *
+ * Exit codes:
+ *   0  sent (or dry-run completed)
+ *   1  config error
+ *   2  argument error
+ *   3  SMTP send failure
+ */
+
+import nodemailer from 'nodemailer';
+import { readFileSync, existsSync } from 'fs';
+import { parseArgs } from 'node:util';
+import { resolve, basename } from 'path';
+import dotenv from 'dotenv';
+
+// ── Config ─────────────────────────────────────────────────────────
+const ENV_FILE = '.env.mail';
+if (!existsSync(ENV_FILE)) {
+  console.error(`ERROR: ${ENV_FILE} not found at repo root.`);
+  console.error(`Copy ${ENV_FILE}.example to ${ENV_FILE} and fill in your SMTP credentials.`);
+  process.exit(1);
+}
+dotenv.config({ path: ENV_FILE });
+
+for (const k of ['SMTP_HOST', 'SMTP_PORT', 'SMTP_USER', 'SMTP_PASS', 'SMTP_FROM']) {
+  if (!process.env[k]) {
+    console.error(`ERROR: ${k} missing from ${ENV_FILE}`);
+    process.exit(1);
+  }
+}
+
+// ── CLI args ───────────────────────────────────────────────────────
+let parsed;
+try {
+  parsed = parseArgs({
+    options: {
+      to: { type: 'string' },
+      subject: { type: 'string' },
+      body: { type: 'string' },
+      section: { type: 'string' },
+      attach: { type: 'string', multiple: true },
+      cc: { type: 'string', multiple: true },
+      bcc: { type: 'string', multiple: true },
+      'reply-to': { type: 'string' },
+      from: { type: 'string' },
+      html: { type: 'boolean' },
+      'dry-run': { type: 'boolean' },
+    },
+    allowPositionals: false,
+  });
+} catch (err) {
+  console.error(`Argument error: ${err.message}`);
+  process.exit(2);
+}
+const args = parsed.values;
+
+if (!args.to || !args.subject || !args.body) {
+  console.error('Required: --to <addr> --subject <text> --body <path>');
+  process.exit(2);
+}
+if (!existsSync(args.body)) {
+  console.error(`Body file not found: ${args.body}`);
+  process.exit(2);
+}
+
+// ── Body extraction ────────────────────────────────────────────────
+let body = readFileSync(args.body, 'utf8');
+if (args.section) {
+  const startRe = new RegExp(`^${args.section}.*$`, 'm');
+  const startMatch = body.match(startRe);
+  if (!startMatch) {
+    console.error(`Section not found in ${args.body}: "${args.section}"`);
+    process.exit(2);
+  }
+  const startIdx = startMatch.index + startMatch[0].length;
+  const tail = body.slice(startIdx);
+  // Stop at the next "## " header OR at "---" horizontal rule OR end of file.
+  const endMatch = tail.match(/^(##\s|---\s*$)/m);
+  body = endMatch ? tail.slice(0, endMatch.index).trim() : tail.trim();
+
+  // Strip leading metadata-style lines: **To:** ..., **Subject:** ..., **Cc:** ...
+  // These are author-facing instructions in the markdown, not email body content.
+  const lines = body.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    if (/^\*\*[A-Z][a-z-]+:\*\*/.test(lines[i])) { i++; continue; }
+    if (lines[i].trim() === '') { i++; continue; }
+    break;
+  }
+  body = lines.slice(i).join('\n').trim();
+}
+
+// ── Attachments ────────────────────────────────────────────────────
+const attachments = (args.attach || []).map((p) => {
+  const abs = resolve(p);
+  if (!existsSync(abs)) {
+    console.error(`Attachment not found: ${p}`);
+    process.exit(2);
+  }
+  return { filename: basename(abs), path: abs };
+});
+
+// ── Build envelope ─────────────────────────────────────────────────
+const mail = {
+  from: args.from || process.env.SMTP_FROM,
+  to: args.to,
+  subject: args.subject,
+  ...(args['reply-to'] ? { replyTo: args['reply-to'] } : {}),
+  ...(args.cc?.length ? { cc: args.cc } : {}),
+  ...(args.bcc?.length ? { bcc: args.bcc } : {}),
+  ...(args.html ? { html: body } : { text: body }),
+  attachments,
+};
+
+if (args['dry-run']) {
+  console.log('— DRY RUN — would send the following:');
+  console.log('From    :', mail.from);
+  console.log('To      :', mail.to);
+  if (mail.cc) console.log('Cc      :', mail.cc.join(', '));
+  if (mail.bcc) console.log('Bcc     :', mail.bcc.join(', '));
+  if (mail.replyTo) console.log('Reply-To:', mail.replyTo);
+  console.log('Subject :', mail.subject);
+  console.log('Attach  :', attachments.length ? attachments.map((a) => a.filename).join(', ') : '(none)');
+  console.log('Body length:', body.length, 'chars');
+  console.log('— first 30 lines of body —');
+  console.log(body.split('\n').slice(0, 30).join('\n'));
+  console.log('— end —');
+  process.exit(0);
+}
+
+// ── Send ───────────────────────────────────────────────────────────
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: Number(process.env.SMTP_PORT),
+  secure: process.env.SMTP_SECURE === 'true',
+  auth: { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS },
+  // Set SMTP_TLS_INSECURE=true to accept self-signed certs on submission.
+  // Acceptable when the SMTP host is on your own infra (e.g. Mailcow on a
+  // host you control) — outbound recipient-leg TLS is unaffected.
+  ...(process.env.SMTP_TLS_INSECURE === 'true' ? { tls: { rejectUnauthorized: false } } : {}),
+});
+
+try {
+  // Verify connection first — catches auth/DNS errors with a clean message.
+  await transporter.verify();
+} catch (err) {
+  console.error('SMTP connection / auth failed:', err.message);
+  process.exit(3);
+}
+
+try {
+  const info = await transporter.sendMail(mail);
+  console.log('✅ sent:', info.messageId);
+  if (info.accepted?.length) console.log('  accepted:', info.accepted.join(', '));
+  if (info.rejected?.length) console.log('  rejected:', info.rejected.join(', '));
+  if (info.response) console.log('  response:', info.response);
+} catch (err) {
+  console.error('SMTP send failed:', err.message);
+  process.exit(3);
+}


### PR DESCRIPTION
## What does this PR do?

Adds an **opt-in** Docker recipe that wraps the existing Go TUI dashboard with [ttyd](https://github.com/tsl0922/ttyd) so it can be served over HTTPS from a browser, behind HTTP Basic Auth. No existing files change behaviour. Users who don't touch the new files see nothing different.

## Related issue

Closes #684

## Type of change

- [x] New feature *(opt-in deployment recipe — does not change any existing code path)*
- [ ] Bug fix
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## What's in the diff (5 files, +152 / −1)

| File | Purpose |
|---|---|
| `Dockerfile` | Multi-stage: `golang:1.24-alpine` builds `dashboard/`, `debian-slim` runtime ships ttyd 1.7.7 + tini. Final image is small (~70 MB) and runs as a non-root uid/gid (1001, overridable via build args). |
| `docker/entrypoint.sh` | Thin ttyd wrapper. Reads `CAREEROPS_WEB_USER` / `CAREEROPS_WEB_PASS` from env, launches `career-dashboard --path /workspace`. No `-O` flag — that one is counterintuitive (it *enables* strict origin checking, which silently kills the WS upgrade when fronted by a reverse proxy). |
| `stack-compose.yml` | Generic compose stack. Parameterised by `CAREEROPS_PROJECT_DIR` (defaults to the directory holding the file) and `CAREEROPS_NETWORK` (defaults to a fresh `careerops-net`; flip `external: true` to attach to an existing reverse-proxy network). |
| `.dockerignore` | Keeps user-layer files (`cv.md`, `reports/*`, `output/*`, …) out of the build context. |
| `.gitignore` | One new line: `*.override.yml` so deployment-specific compose overrides (network swaps, env_file paths) stay out of the repo. |

## How it composes with the data contract

The bind mount maps the project root to `/workspace`, so:

- The container's TUI reads and writes the **same** user-layer files the host's `claude` CLI does — no second source of truth, no sync logic.
- No user-layer file is committed; existing upstream `.gitignore` rules cover `.env`, `cv.md`, `config/profile.yml`, `data/*.md`, `reports/*`, `output/*`, etc.
- Everything added in this PR is system-layer (deployment infra), so future updates can carry it cleanly.

## What this is and isn't

**Is:** a way to glance at your pipeline from a phone or a second machine, behind a single-user login, while keeping all data, the agent, and the API key on your trusted host.

**Is not:** a way to put the agent itself on a public URL. Evaluations, scans, batch, PDF generation — all still happen via `claude` (or other supported CLIs) on the host. Putting the agent behind a public URL would be a remote-code-execution surface and would conflict with the local-first vision in discussion #156.

## Verification

End-to-end tested on a real deployment fronted by nginx-proxy-manager:

- `HTTP 401` without creds, `HTTP 200` with creds.
- `HTTP → HTTPS 301` redirect, HSTS header present.
- WebSocket handshake returns `101 Switching Protocols` through the proxy — the load-bearing piece for the TUI streaming.
- Empty `data/applications.md` (just the header row) is enough to render the dashboard cleanly; existing trackers display unchanged.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (#684, opened just now)
- [x] My PR does not include personal data (CV, email, real names) — `git diff main...web-gui` is grep-clean for personal identifiers; the only "personal" data referenced anywhere is in user-layer files which remain gitignored
- [ ] I ran `node test-all.mjs` and all tests pass — **skipped intentionally**: this diff is Dockerfile + shell + compose + dotignores, none of which the test suite exercises (it checks `.mjs` syntax, script execution, dashboard build, data contract, and personal-data leaks against the maintainer's identifiers). Running it would require `npm install` + Playwright/Chromium (~500 MB) for no real signal. Happy to run it on request if you'd prefer the green checkbox.
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) — no modifications to user-layer files; everything added is clearly system-layer
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156) — local-first vision preserved; this only adds an optional browser viewing path for users who want it

---

If you'd rather have this as a separate companion repo, or under a `deploy/` subdirectory, happy to refactor either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web-accessible terminal dashboard with authenticated sign-in, in-browser overlay for adding job URLs, and hosted UI on port 7681.
  * Scraping sidecar service to fetch and extract job posting content.
  * Email tooling: mailbox provisioning and SMTP-based send utility (attachments, section extraction, dry-run).

* **Chores**
  * Container runtime and compose stack for local deployment with workspace mounting and non-root runtime user.
  * Reduced Docker build context and added mail dependency.

* **Documentation**
  * Usage guide and examples for local email tooling and SMTP configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->