### PR TITLE
fix(scan): bootstrap providers/ on update + harden greenhouse detect()

### DIFF
--- a/providers/greenhouse.mjs
+++ b/providers/greenhouse.mjs
@@ -40,8 +40,12 @@ export default {
   id: 'greenhouse',
 
   detect(entry) {
-    const apiUrl = resolveApiUrl(entry);
-    return apiUrl ? { url: apiUrl } : null;
+    try {
+      const apiUrl = resolveApiUrl(entry);
+      return apiUrl ? { url: apiUrl } : null;
+    } catch {
+      return null;
+    }
   },
 
   async fetch(entry, ctx) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -62,6 +62,7 @@ const SYSTEM_PATHS = [
   'cv-sync-check.mjs',
   'update-system.mjs',
   'scan.mjs',
+  'providers/',
   'doctor.mjs',
   'check-liveness.mjs',
   'liveness-core.mjs',
@@ -284,7 +285,7 @@ async function apply() {
     // local v1.6.x SYSTEM_PATHS didn't include it, so `.agents/` was never
     // checked out while `.claude/skills/` was updated to symlink into it.
     // See: https://github.com/santifer/career-ops/issues/649
-    const BOOTSTRAP_PATHS = ['.agents/'];
+    const BOOTSTRAP_PATHS = ['.agents/', 'providers/'];
     for (const path of BOOTSTRAP_PATHS) {
       if (SYSTEM_PATHS.includes(path)) continue; // already in main loop
       try {


### PR DESCRIPTION
## Summary

Two regressions surfaced in v1.8.0 after the plugin-arch refactor (#573):

1. **`providers/` not in `SYSTEM_PATHS`** — fresh `update-system.mjs apply` runs and v1.7.x → v1.8.0 upgrades land with `scan.mjs` immediately throwing `ERR_MODULE_NOT_FOUND` on `providers/_http.mjs` etc. Adds `'providers/'` to `SYSTEM_PATHS` plus `BOOTSTRAP_PATHS` so existing v1.8.0 installs catch up on their next `apply` (same pattern as #654 / #649 for `.agents/`).
2. **`greenhouse.detect()` threw on non-Greenhouse `api:` URLs** — violated the Provider contract in `providers/_types.js` (`detect` must return `null`, not throw). Silently disabled ArbeitNow on every fresh install. Wraps the lookup in `try/catch` so `detect()` returns `null` when the URL isn't Greenhouse-shaped; `fetch()` keeps the strict `assertGreenhouseUrl` as defense-in-depth.

## Closes

- Closes #658 (root cause analysis by @dnorth123 — proposed diff matched almost verbatim)
- Closes #656 (same upgrade-path bug, separate report)
- Closes #657 (greenhouse `detect()` throw on ArbeitNow)

## Test plan

- [x] `node test-all.mjs` — 65 passed, 0 failed
- [x] `node --check providers/greenhouse.mjs` + `node --check update-system.mjs`
- [ ] `node update-system.mjs apply` on a v1.7.1 checkout → `providers/` materializes
- [ ] `node scan.mjs` with ArbeitNow entry in portals.yml → no greenhouse warning, entry routed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the Greenhouse provider integration to gracefully handle API resolution failures without disrupting the detection process.

* **Chores**
  * Enhanced the system update mechanism to properly track provider files as system-owned content, ensuring consistent state during version upgrades and preventing missing references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->