### PR TITLE
[codex] update career-ops scanner wording and filters

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -59,7 +59,7 @@ Available commands:
   /career-ops project   → Evaluate portfolio project idea
   /career-ops tracker   → Application status overview
   /career-ops apply     → Live application assistant (reads form + generates answers)
-  /career-ops scan      → Scan portals and discover new offers
+  /career-ops scan      → Scan portals and discover new job postings
   /career-ops batch     → Batch processing with parallel workers
   /career-ops patterns  → Analyze rejection patterns and improve targeting
   /career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 # Personal data (user fills these)
 cv.md
+article-digest.md
 data/applications.md
 data/pipeline.md
 data/scan-history.tsv
+data/follow-ups.md
 reports/*.md
 !reports/.gitkeep
 output/*

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -50,16 +50,22 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/ja/*` | Japanese language modes |
 | `modes/pt/*` | Portuguese language modes |
 | `modes/ru/*` | Russian language modes |
+| `modes/tr/*` | Turkish language modes |
 | `CLAUDE.md` | Agent instructions |
 | `AGENTS.md` | Codex instructions |
 | `*.mjs` | Utility scripts |
+| `providers/*` | Scanner provider modules |
 | `batch/batch-prompt.md` | Batch worker prompt |
 | `batch/batch-runner.sh` | Batch orchestrator |
 | `dashboard/*` | Go TUI dashboard |
 | `templates/*` | Base templates |
 | `fonts/*` | Self-hosted fonts |
+| `.agents/skills/*` | Agent skill definitions |
 | `.claude/skills/*` | Skill definitions |
+| `.qwen/skills/*` | Qwen skill definitions |
+| `.claude-plugin/*` | Claude plugin metadata |
 | `docs/*` | Documentation |
+| `.env.example` | Environment variable template |
 | `VERSION` | Current version number |
 | `DATA_CONTRACT.md` | This file |
 | `writing-samples/README.md` | System-owned onboarding documentation for the writing-samples directory |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See [docs/SETUP.md](docs/SETUP.md) for the full setup guide.
 
 ## Gemini CLI Integration
 
-Career-ops supports [Gemini CLI](https://github.com/google-gemini/gemini-cli) natively — the same way it supports Claude Code and OpenCode. All 15 slash commands are available, using the same `modes/*.md` evaluation logic.
+Career-ops supports [Gemini CLI](https://github.com/google-gemini/gemini-cli) through `GEMINI.md`, which points Gemini at the same agent instructions used by Claude Code and Codex. The repo also includes a standalone Gemini API evaluator for users who do not want to install the CLI.
 
 ### Option A — Native Gemini CLI (Recommended)
 
@@ -131,15 +131,13 @@ gemini auth
 cd career-ops
 gemini
 
-# 4. Use slash commands just like Claude Code
-/career-ops "Senior AI Engineer at Anthropic..."
-/career-ops-evaluate --file ./jds/openai.txt
-/career-ops-scan
-/career-ops-pdf
-/career-ops-tracker
+# 4. Ask Gemini to use career-ops
+Evaluate this JD with career-ops and save the report.
+Scan my configured portals with career-ops.
+Generate a tailored PDF for this role with career-ops.
 ```
 
-The `GEMINI.md` file is auto-loaded as context. All 15 commands are defined in `.gemini/commands/*.toml`.
+The `GEMINI.md` file is auto-loaded as context. This release does not ship `.gemini/commands/*.toml` slash-command files; use natural-language prompts in Gemini CLI, or use the standalone script below for API-based evaluations.
 
 ### Option B — Standalone API Script (No CLI install needed)
 
@@ -248,7 +246,7 @@ career-ops/
 ├── config/
 │   └── profile.example.yml      # Template for your profile
 ├── modes/                       # 14 skill modes
-│   ├── _shared.md               # Shared context (customize this)
+│   ├── _shared.md               # Shared system context (do not personalize)
 │   ├── oferta.md                # Single evaluation
 │   ├── pdf.md                   # PDF generation
 │   ├── scan.md                  # Portal scanner

--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -28,7 +28,7 @@
  * `modelName` below and the `--model` examples accordingly.
  */
 
-import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -37,7 +37,7 @@ import { fileURLToPath } from 'url';
 // ---------------------------------------------------------------------------
 try {
   const { config } = await import('dotenv');
-  config();
+  config({ quiet: true });
 } catch {
   // dotenv is optional — fall back to process.env if not installed
 }
@@ -60,6 +60,7 @@ const PATHS = {
   profileYml:  join(ROOT, 'config', 'profile.yml'),
   reports:     join(ROOT, 'reports'),
   tracker:     join(ROOT, 'data', 'applications.md'),
+  trackerAdditions: join(ROOT, 'batch', 'tracker-additions'),
 };
 
 // ---------------------------------------------------------------------------
@@ -82,6 +83,7 @@ if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
 
   OPTIONS
     --file <path>    Read JD from a file instead of inline text
+    --url <url>      Source job posting URL for the saved report header
     --model <name>   Gemini model to use (default: gemini-2.5-flash)
     --no-save        Do not save report to reports/ directory
     --help           Show this help
@@ -102,6 +104,7 @@ if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
 let jdText = '';
 let modelName = process.env.GEMINI_MODEL || 'gemini-2.5-flash';
 let saveReport = true;
+let sourceUrl = 'N/A';
 
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--file' && args[i + 1]) {
@@ -111,6 +114,9 @@ for (let i = 0; i < args.length; i++) {
       process.exit(1);
     }
     jdText = readFileSync(filePath, 'utf-8').trim();
+    if (sourceUrl === 'N/A') sourceUrl = `local:${filePath}`;
+  } else if (args[i] === '--url' && args[i + 1]) {
+    sourceUrl = args[++i];
   } else if (args[i] === '--model' && args[i + 1]) {
     modelName = args[++i];
   } else if (args[i] === '--no-save') {
@@ -161,14 +167,28 @@ function nextReportNumber() {
   return String(Math.max(...files) + 1).padStart(3, '0');
 }
 
-// Lazy import — only used when saving
-let readdirSync;
-try {
-  ({ readdirSync } = await import('fs'));
-} catch { /* already imported above via named exports */ }
-// Use named import fallback
-if (!readdirSync) {
-  readdirSync = (await import('fs')).readdirSync;
+function slugify(value, fallback = 'unknown') {
+  const slug = String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || fallback;
+}
+
+function normalizeScore(rawScore) {
+  const match = String(rawScore || '').match(/(\d+(?:\.\d+)?)/);
+  if (!match) return 'N/A';
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value)) return 'N/A';
+  return `${value.toFixed(1)}/5`;
+}
+
+function cleanTsvField(value) {
+  return String(value ?? '')
+    .replace(/\r?\n/g, ' ')
+    .replace(/\t/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 // ---------------------------------------------------------------------------
@@ -318,15 +338,17 @@ if (saveReport) {
 
     const num         = nextReportNumber();
     const today       = new Date().toISOString().split('T')[0];
-    const companySlug = company.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    const companySlug = slugify(company);
     const filename    = `${num}-${companySlug}-${today}.md`;
     const reportPath  = join(PATHS.reports, filename);
+    const scoreDisplay = normalizeScore(score);
 
     const reportContent = `# Evaluation: ${company} — ${role}
 
 **Date:** ${today}
 **Archetype:** ${archetype}
-**Score:** ${score}/5
+**Score:** ${scoreDisplay}
+**URL:** ${sourceUrl}
 **Legitimacy:** ${legitimacy}
 **PDF:** pending
 **Tool:** Gemini (${modelName})
@@ -339,14 +361,29 @@ ${evaluationText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').tri
     writeFileSync(reportPath, reportContent, 'utf-8');
     console.log(`\n✅  Report saved: reports/${filename}`);
 
-    // Append tracker entry reminder
-    console.log(`\n📊  Tracker entry (add to data/applications.md):`);
-    console.log(`    | ${num} | ${today} | ${company} | ${role} | ${score} | Evaluada | ❌ | [${num}](reports/${filename}) |`);
+    mkdirSync(PATHS.trackerAdditions, { recursive: true });
+    const tsvPath = join(PATHS.trackerAdditions, `${num}-${companySlug}.tsv`);
+    const note = `Gemini eval. Legitimacy: ${legitimacy}`;
+    const tsvLine = [
+      num,
+      today,
+      company,
+      role,
+      'Evaluated',
+      scoreDisplay,
+      '❌',
+      `[${num}](reports/${filename})`,
+      note,
+    ].map(cleanTsvField).join('\t') + '\n';
+
+    writeFileSync(tsvPath, tsvLine, 'utf-8');
+    console.log(`📊  Tracker TSV saved: batch/tracker-additions/${num}-${companySlug}.tsv`);
+    console.log('    Run `node merge-tracker.mjs` to merge it into data/applications.md.');
   } catch (err) {
     console.warn(`⚠️   Could not save report: ${err.message}`);
   }
 }
 
 console.log('\n' + '─'.repeat(66));
-console.log(`  Score: ${score}/5  |  Archetype: ${archetype}  |  Legitimacy: ${legitimacy}`);
+console.log(`  Score: ${normalizeScore(score)}  |  Archetype: ${archetype}  |  Legitimacy: ${legitimacy}`);
 console.log('─'.repeat(66) + '\n');

--- a/liveness-browser.mjs
+++ b/liveness-browser.mjs
@@ -20,16 +20,24 @@ const PRIVATE_HOST_PATTERNS = [
   /^192\.168\./,
   /^172\.(1[6-9]|2\d|3[01])\./,
   /^169\.254\./,
+  /^::$/,
   /^::1$/,
-  /^fc[0-9a-f]{2}:/i,
-  /^fe80:/i,
+  /^::ffff:/i,
+  /^f[cd][0-9a-f]{2}:/i,
+  /^fe[89ab][0-9a-f]:/i,
 ];
+
+function normalizeHostnameForGuard(hostname) {
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1');
+  const ipv4Mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  return ipv4Mapped ? ipv4Mapped[1] : normalized;
+}
 
 // Returns null when the URL is safe to fetch, otherwise a structured guard
 // result with a stable `code` (used for routing in scan.mjs) plus a human
 // `reason`. Stable codes — not regex on reason strings — drive downstream
 // dispatch so the wording can change freely without breaking callers.
-function rejectPrivateOrInvalid(url) {
+export function rejectPrivateOrInvalid(url) {
   let parsed;
   try {
     parsed = new URL(url);
@@ -39,7 +47,8 @@ function rejectPrivateOrInvalid(url) {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     return { code: 'unsupported_protocol', reason: `unsupported protocol ${parsed.protocol}` };
   }
-  if (PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(parsed.hostname))) {
+  const hostname = normalizeHostnameForGuard(parsed.hostname);
+  if (PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(hostname))) {
     return { code: 'blocked_host', reason: `blocked host ${parsed.hostname}` };
   }
   return null;

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -123,7 +123,7 @@ After detecting archetype, read `modes/_profile.md` for the user's specific fram
 | WebFetch | Fallback for extracting JDs from static pages |
 | Playwright | Verify offers (browser_navigate + browser_snapshot). **NEVER 2+ agents with Playwright in parallel.** |
 | Read | cv.md, _profile.md, article-digest.md, cv-template.html |
-| Write | Temporary HTML for PDF, applications.md, reports .md |
+| Write | Temporary HTML for PDF, tracker TSV additions, reports .md |
 | Edit | Update tracker |
 | Canva MCP | Optional visual CV generation. Duplicate base design, edit text, export PDF. Requires `cv.canva_resume_design_id` in profile.yml. |
 | Bash | `node generate-pdf.mjs` |

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -70,6 +70,14 @@ If the final score is >= 4.5, generate a draft of responses for the application 
 
 ## Step 5 — Update Tracker
 
-Record it in `data/applications.md` with all columns including Report and PDF as ✅.
+Write one TSV tracker addition to `batch/tracker-additions/{###}-{company-slug}.tsv`, then run `node merge-tracker.mjs` to merge it into `data/applications.md`.
+
+Use the canonical TSV order:
+
+```tsv
+{num}	{date}	{company}	{role}	Evaluated	{score}/5	✅	[{num}](reports/{num}-{company-slug}-{YYYY-MM-DD}.md)	{one-line note}
+```
+
+Do not add a new tracker row by editing `data/applications.md` directly. Direct edits are only allowed for status or notes updates on existing rows.
 
 **If any step fails**, continue with the next ones and mark the failed step as pending in the tracker.

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -200,7 +200,7 @@ Save full evaluation in `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 
 ### 2. Record in tracker
 
-**ALWAYS** record in `data/applications.md`:
+**ALWAYS** record the evaluation through the TSV merge flow:
 - Next sequential number
 - Current date
 - Company
@@ -209,9 +209,14 @@ Save full evaluation in `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 - Status: `Evaluated`
 - PDF: ❌ (or ✅ if auto-pipeline generated PDF)
 - Report: link relative to the report .md (e.g., `[001](reports/001-company-2026-01-01.md)`)
+- One-line note
 
-**Tracker format:**
+Write one TSV file to `batch/tracker-additions/{###}-{company-slug}.tsv`:
 
-```markdown
-| # | Date | Company | Role | Score | Status | PDF | Report |
+```tsv
+{num}	{date}	{company}	{role}	Evaluated	{score}/5	{pdf_emoji}	[{num}](reports/{num}-{company-slug}-{YYYY-MM-DD}.md)	{one-line note}
 ```
+
+Then run `node merge-tracker.mjs` to merge the addition into `data/applications.md`.
+
+Do not add a new tracker row by editing `data/applications.md` directly. Direct edits are only allowed for status or notes updates on existing rows.

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -44,6 +44,7 @@ Para empresas con API pública o feed estructurado, usar la respuesta JSON/XML c
 - **Ashby**: `https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobBoardWithTeams`
 - **BambooHR**: lista `https://{company}.bamboohr.com/careers/list`; detalle de una oferta `https://{company}.bamboohr.com/careers/{id}/detail`
 - **Lever**: `https://api.lever.co/v0/postings/{company}?mode=json`
+- **USAJOBS**: `https://data.usajobs.gov/api/search`
 - **Teamtailor**: `https://{company}.teamtailor.com/jobs.rss`
 - **Workday**: `https://{company}.{shard}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs`
 
@@ -52,6 +53,7 @@ Para empresas con API pública o feed estructurado, usar la respuesta JSON/XML c
 - `ashby`: GraphQL `ApiJobBoardWithTeams` con `organizationHostedJobsPageName={company}` → `jobBoard.jobPostings[]` (`title`, `id`; construir URL pública si no viene en payload)
 - `bamboohr`: lista `result[]` → `jobOpeningName`, `id`; construir URL de detalle `https://{company}.bamboohr.com/careers/{id}/detail`; para leer el JD completo, hacer GET del detalle y usar `result.jobOpening` (`jobOpeningName`, `description`, `datePosted`, `minimumExperience`, `compensation`, `jobOpeningShareUrl`)
 - `lever`: array raíz `[]` → `text`, `hostedUrl` (fallback: `applyUrl`)
+- `usajobs`: `SearchResult.SearchResultItems[]` → `PositionTitle`, `PositionID`, `OrganizationName`, `PositionLocation`; requires `usajobs_keywords` and may require `usajobs_api_key`
 - `teamtailor`: RSS items → `title`, `link`
 - `workday`: `jobPostings[]`/`jobPostings` (según tenant) → `title`, `externalPath` o URL construida desde el host
 

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -1,6 +1,6 @@
-# Modo: scan — Portal Scanner (Descubrimiento de Ofertas)
+# Modo: scan — Portal Scanner (Descubrimiento de Puestos)
 
-Escanea portales de empleo configurados, filtra por relevancia de título, y añade nuevas ofertas al pipeline para evaluación posterior.
+Escanea portales de empleo configurados, filtra por relevancia de título, y añade nuevos puestos al pipeline para evaluación posterior.
 
 > **Nota (v1.5+):** El escáner por defecto (`scan.mjs` / `npm run scan`) es **zero-token** y sólo consulta directamente las APIs públicas de Greenhouse, Ashby y Lever. Los niveles con Playwright/WebSearch descritos abajo son el flujo **agente** (ejecutado por Claude/Codex), no lo que hace `scan.mjs`. Si una empresa no tiene API Greenhouse/Ashby/Lever, `scan.mjs` la ignorará; para esos casos, el agente debe completar manualmente el Nivel 1 (Playwright) o Nivel 3 (WebSearch).
 
@@ -21,7 +21,7 @@ Agent(
 Leer `portals.yml` que contiene:
 - `search_queries`: Lista de queries WebSearch con `site:` filters por portal (descubrimiento amplio)
 - `tracked_companies`: Empresas específicas con `careers_url` para navegación directa
-- `title_filter`: Keywords positive/negative/seniority_boost para filtrado de títulos
+- `title_filter`: Keywords positive/negative, `negative_regex`, y seniority_boost para filtrado de títulos
 
 ## Estrategia de descubrimiento (3 niveles)
 
@@ -109,6 +109,7 @@ Los niveles son aditivos — se ejecutan todos, los resultados se mezclan y dedu
 6. **Filtrar por título** usando `title_filter` de `portals.yml`:
    - Al menos 1 keyword de `positive` debe aparecer en el título (case-insensitive)
    - 0 keywords de `negative` deben aparecer
+   - 0 patrones de `negative_regex` deben coincidir
    - `seniority_boost` keywords dan prioridad pero no son obligatorios
 
 6b. **Filtrar por ubicación (opcional)** usando `location_filter` de `portals.yml`:
@@ -143,13 +144,13 @@ Los niveles son aditivos — se ejecutan todos, los resultados se mezclan y dedu
 
    **No interrumpir el scan entero si una URL falla.** Si `browser_navigate` da error (timeout, 403, etc.), marcar como `skipped_expired` y continuar con la siguiente.
 
-8. **Para cada oferta nueva verificada que pase filtros**:
+8. **Para cada puesto nuevo verificado que pase filtros**:
    a. Añadir a `pipeline.md` sección "Pendientes": `- [ ] {url} | {company} | {title}`
    b. Registrar en `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
 
-9. **Ofertas filtradas por título**: registrar en `scan-history.tsv` con status `skipped_title`
-10. **Ofertas duplicadas**: registrar con status `skipped_dup`
-11. **Ofertas expiradas (Nivel 3)**: registrar con status `skipped_expired`
+9. **Puestos filtrados por título**: registrar en `scan-history.tsv` con status `skipped_title`
+10. **Puestos duplicados**: registrar con status `skipped_dup`
+11. **Puestos expirados (Nivel 3)**: registrar con status `skipped_expired`
 
 ## Extracción de título y empresa de WebSearch results
 

--- a/modes/tr/_shared.md
+++ b/modes/tr/_shared.md
@@ -2,7 +2,7 @@
 
 <!-- ============================================================
      BU DOSYA OTOMATİK GÜNCELLENEBİLİR. Buraya kişisel veri ekleme.
-     
+
      Özelleştirmeler modes/_profile.md dosyasına gider (hiçbir zaman
      otomatik güncellenmez). Bu dosya sistem kurallarını, puanlama
      mantığını ve her sürümde gelişen araç yapılandırmasını içerir.

--- a/providers/usajobs.mjs
+++ b/providers/usajobs.mjs
@@ -1,0 +1,131 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// USAJOBS provider — hits the official Search API.
+// Docs: https://developer.usajobs.gov/APIs/Search
+//
+// Supported portals.yml fields:
+//   api_type: usajobs
+//   usajobs_keywords: string[]
+//   usajobs_remote_only: boolean
+//   usajobs_public_only: boolean
+//   usajobs_contact_email: string
+//   usajobs_api_key: string
+
+function detectUsajobs(entry) {
+  const url = entry.careers_url || '';
+  if (entry.provider === 'usajobs') return true;
+  if (entry.api_type === 'usajobs') return true;
+  return url.includes('usajobs.gov');
+}
+
+function buildSearchUrl(entry) {
+  const keywords = Array.isArray(entry.usajobs_keywords)
+    ? entry.usajobs_keywords.filter(Boolean).join(' OR ')
+    : '';
+
+  if (!keywords) {
+    throw new Error('usajobs: missing usajobs_keywords');
+  }
+
+  const params = new URLSearchParams({
+    Keyword: keywords,
+    ResultsPerPage: '50',
+    PositionStatus: 'active',
+  });
+
+  if (entry.usajobs_public_only !== false) {
+    params.set('WhoMayApply', 'public');
+  }
+
+  if (entry.usajobs_remote_only) {
+    params.set('RemoteIndicator', 'True');
+  }
+
+  return `https://data.usajobs.gov/api/search?${params}`;
+}
+
+function buildHeaders(entry) {
+  const headers = {
+    'user-agent': entry.usajobs_contact_email || 'career-ops-scanner',
+  };
+
+  if (entry.usajobs_api_key) {
+    headers['authorization-key'] = entry.usajobs_api_key;
+  }
+
+  return headers;
+}
+
+function isPublicPosting(details) {
+  const whoMayApply = details?.WhoMayApply?.Name || '';
+  const lower = whoMayApply.toLowerCase();
+  return (
+    !whoMayApply ||
+    lower.includes('public') ||
+    lower.includes('all u.s. citizens')
+  );
+}
+
+/** @type {Provider} */
+export default {
+  id: 'usajobs',
+
+  detect(entry) {
+    return detectUsajobs(entry) ? { url: 'https://data.usajobs.gov/api/search' } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const apiUrl = buildSearchUrl(entry);
+
+    let json;
+    try {
+      json = await ctx.fetchJson(apiUrl, { headers: buildHeaders(entry) });
+    } catch (err) {
+      if (err?.status === 401) {
+        throw new Error(
+          'usajobs: API key required or invalid. Register at https://developer.usajobs.gov/APIRequest/Index, then add usajobs_api_key to this portals.yml entry.',
+        );
+      }
+      throw err;
+    }
+
+    if (json?.status === 401) {
+      throw new Error(
+        'usajobs: API key required or invalid. Register at https://developer.usajobs.gov/APIRequest/Index, then add usajobs_api_key to this portals.yml entry.',
+      );
+    }
+
+    const items = Array.isArray(json?.SearchResult?.SearchResultItems)
+      ? json.SearchResult.SearchResultItems
+      : [];
+
+    const jobs = [];
+    for (const item of items) {
+      const descriptor = item?.MatchedObjectDescriptor;
+      if (!descriptor) continue;
+
+      const details = descriptor.UserArea?.Details || {};
+      if (entry.usajobs_public_only !== false && !isPublicPosting(details)) continue;
+
+      const title = descriptor.PositionTitle || '';
+      const positionId = descriptor.PositionID;
+      if (!title || !positionId) continue;
+
+      const agency = descriptor.OrganizationName || descriptor.DepartmentName || entry.name || 'Federal';
+      const remote = details.RemoteIndicator === true;
+      const location = remote
+        ? 'Remote'
+        : descriptor.PositionLocation?.[0]?.LocationName || details.Telework || '';
+
+      jobs.push({
+        title,
+        url: `https://www.usajobs.gov/job/${positionId}`,
+        company: agency,
+        location,
+      });
+    }
+
+    return jobs;
+  },
+};

--- a/scan.mjs
+++ b/scan.mjs
@@ -107,12 +107,20 @@ function resolveProvider(entry, providers) {
 function buildTitleFilter(titleFilter) {
   const positive = (titleFilter?.positive || []).map(k => k.toLowerCase());
   const negative = (titleFilter?.negative || []).map(k => k.toLowerCase());
+  const negativeRegex = (titleFilter?.negative_regex || []).map(pattern => {
+    try {
+      return new RegExp(pattern, 'i');
+    } catch (err) {
+      throw new Error(`Invalid title_filter.negative_regex pattern "${pattern}": ${err.message}`);
+    }
+  });
 
   return (title) => {
     const lower = title.toLowerCase();
     const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
     const hasNegative = negative.some(k => lower.includes(k));
-    return hasPositive && !hasNegative;
+    const hasNegativeRegex = negativeRegex.some(re => re.test(title));
+    return hasPositive && !hasNegative && !hasNegativeRegex;
   };
 }
 
@@ -195,14 +203,17 @@ function appendToPipeline(offers) {
 
   let text = readFileSync(PIPELINE_PATH, 'utf-8');
 
-  // Find "## Pendientes" section and append after it
-  const marker = '## Pendientes';
+  // Prefer the English "Pending" section. Older local files may still have
+  // "Pendientes", so keep it as a compatibility fallback.
+  const marker = text.includes('## Pending') ? '## Pending' : '## Pendientes';
   const idx = text.indexOf(marker);
   if (idx === -1) {
-    // No Pendientes section — append at end before Procesadas
-    const procIdx = text.indexOf('## Procesadas');
+    // No pending section — append before a processed section if present.
+    const processedMarkers = ['## Processed', '## Procesadas'];
+    const procIdxs = processedMarkers.map(m => text.indexOf(m)).filter(i => i !== -1);
+    const procIdx = procIdxs.length > 0 ? Math.min(...procIdxs) : -1;
     const insertAt = procIdx === -1 ? text.length : procIdx;
-    const block = `\n${marker}\n\n` + offers.map(o =>
+    const block = `\n## Pending\n\n` + offers.map(o =>
       `- [ ] ${o.url} | ${o.company} | ${o.title}`
     ).join('\n') + '\n\n';
     text = text.slice(0, insertAt) + block + text.slice(insertAt);
@@ -446,7 +457,7 @@ async function main() {
   let droppedOffers = [];
   let invalidOffers = [];
   if (verify && newOffers.length > 0) {
-    console.log(`\nVerifying liveness of ${newOffers.length} new offer(s) with Playwright (sequential)...`);
+    console.log(`\nVerifying liveness of ${newOffers.length} new job posting(s) with Playwright (sequential)...`);
     const result = await verifyOffers(newOffers);
     verifiedOffers = result.verified;
     expiredOffers = result.expired;
@@ -497,7 +508,7 @@ async function main() {
     console.log(`No apply control:      ${droppedOffers.length} dropped`);
     console.log(`Invalid (guarded):     ${invalidOffers.length} dropped`);
   }
-  console.log(`New offers added:      ${verifiedOffers.length}`);
+  console.log(`New job postings:      ${verifiedOffers.length}`);
 
   if (errors.length > 0) {
     console.log(`\nErrors (${errors.length}):`);
@@ -507,7 +518,7 @@ async function main() {
   }
 
   if (verifiedOffers.length > 0) {
-    console.log('\nNew offers:');
+    console.log('\nNew job postings:');
     for (const o of verifiedOffers) {
       console.log(`  + ${o.company} | ${o.title} | ${o.location || 'N/A'}`);
     }
@@ -518,7 +529,7 @@ async function main() {
     }
   }
 
-  console.log(`\n→ Run /career-ops pipeline to evaluate new offers.`);
+  console.log(`\n→ Run /career-ops pipeline to evaluate new job postings.`);
   console.log('→ Share results and get help: https://discord.gg/8pRpHETxa4');
 }
 

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -346,7 +346,7 @@ search_queries:
 #
 # Provider routing (scan.mjs):
 #   By default each entry is auto-detected from `careers_url` against the
-#   loaded providers in providers/*.mjs (ashby, greenhouse, lever — the
+#   loaded providers in providers/*.mjs (ashby, greenhouse, lever, usajobs — the
 #   first one whose detect() matches wins, alphabetical order).
 #
 #   Optional fields on a tracked_companies entry:

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -88,6 +88,7 @@ console.log('\n3. Liveness classification');
 
 try {
   const { classifyLiveness } = await import(pathToFileURL(join(ROOT, 'liveness-core.mjs')).href);
+  const { rejectPrivateOrInvalid } = await import(pathToFileURL(join(ROOT, 'liveness-browser.mjs')).href);
 
   const expiredChromeApply = classifyLiveness({
     finalUrl: 'https://example.com/jobs/closed-role',
@@ -132,6 +133,20 @@ try {
     pass('Closed postings with "Applications have closed" banner are detected');
   } else {
     fail(`Closed mycareersfuture posting misclassified as ${closedMycareersfuture.result}`);
+  }
+
+  const privateHosts = [
+    'http://[::1]/',
+    'http://[fc00::1]/',
+    'http://[fd00::1]/',
+    'http://[fe80::1]/',
+    'http://[::ffff:127.0.0.1]/',
+  ];
+  const unblockedPrivateHost = privateHosts.find(url => rejectPrivateOrInvalid(url)?.code !== 'blocked_host');
+  if (!unblockedPrivateHost) {
+    pass('Private IPv6 and IPv4-mapped hosts are blocked before Playwright navigation');
+  } else {
+    fail(`Private host was not blocked: ${unblockedPrivateHost}`);
   }
 } catch (e) {
   fail(`Liveness classification tests crashed: ${e.message}`);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -39,8 +39,11 @@ const SYSTEM_PATHS = [
   'modes/auto-pipeline.md',
   'modes/contacto.md',
   'modes/deep.md',
+  'modes/interview-prep.md',
   'modes/ofertas.md',
   'modes/pipeline.md',
+  'modes/patterns.md',
+  'modes/followup.md',
   'modes/project.md',
   'modes/tracker.md',
   'modes/training.md',
@@ -50,6 +53,7 @@ const SYSTEM_PATHS = [
   'modes/ja/',
   'modes/pt/',
   'modes/ru/',
+  'modes/tr/',
   'CLAUDE.md',
   'AGENTS.md',
   'GEMINI.md',
@@ -77,17 +81,46 @@ const SYSTEM_PATHS = [
   'fonts/',
   '.agents/',
   '.claude/skills/',
+  '.qwen/',
+  '.claude-plugin/',
   '.gemini/commands/',
   'docs/',
   'writing-samples/README.md',
   'VERSION',
   'DATA_CONTRACT.md',
   'CONTRIBUTING.md',
+  'CONTRIBUTORS.md',
+  'CHANGELOG.md',
+  'CODE_OF_CONDUCT.md',
+  'GOVERNANCE.md',
+  'LEGAL_DISCLAIMER.md',
+  'SECURITY.md',
+  'SUPPORT.md',
+  'TRADEMARK.md',
   'README.md',
+  'README.cn.md',
+  'README.es.md',
+  'README.ja.md',
+  'README.ko-KR.md',
+  'README.pt-BR.md',
+  'README.ru.md',
+  'README.zh-TW.md',
   'LICENSE',
   'CITATION.cff',
   '.github/',
+  '.env.example',
+  '.release-please-manifest.json',
+  'release-please-config.json',
+  'renovate.json',
+  'flake.nix',
+  'flake.lock',
   'package.json',
+];
+
+// System paths intentionally removed from current releases. These are deleted
+// only when absent from FETCH_HEAD, so a future upstream reintroduction wins.
+const REMOVED_SYSTEM_PATHS = [
+  '.opencode/commands/',
 ];
 
 // User layer paths — NEVER touch these (safety check)
@@ -150,6 +183,23 @@ function revertPaths(paths) {
 function addPaths(paths) {
   if (paths.length === 0) return;
   git('add', '--', ...paths);
+}
+
+function treeHasPath(ref, path) {
+  const pathspec = path.endsWith('/') ? path.slice(0, -1) : path;
+  try {
+    git('cat-file', '-e', `${ref}:${pathspec}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function removeSystemPath(path) {
+  const pathspec = path.endsWith('/') ? path.slice(0, -1) : path;
+  git('rm', '-r', '-f', '--ignore-unmatch', '--', pathspec);
+  rmSync(join(ROOT, pathspec), { recursive: true, force: true });
+  return pathspec;
 }
 
 // ── CHECK ───────────────────────────────────────────────────────
@@ -305,6 +355,13 @@ async function apply() {
       }
     }
 
+    // 3b. Remove system-owned paths that the target release deleted.
+    const removed = [];
+    for (const path of REMOVED_SYSTEM_PATHS) {
+      if (treeHasPath('FETCH_HEAD', path)) continue;
+      removed.push(removeSystemPath(path));
+    }
+
     // 4. Validate: check NO user files were touched.
     //
     // Track which user paths the update unexpectedly touched so we
@@ -391,7 +448,7 @@ async function apply() {
     }
 
     console.log(`\nUpdate complete: v${local} → v${remote}`);
-    console.log(`Updated ${updated.length} system paths.`);
+    console.log(`Updated ${updated.length} system paths; removed ${removed.length} stale system path(s).`);
     console.log(`Rollback available: node update-system.mjs rollback`);
 
   } finally {
@@ -433,18 +490,14 @@ function rollback() {
     // that but is a larger change; tracked separately if it ever bites.
     const restored = [];
     const removed = [];
-    for (const path of SYSTEM_PATHS) {
+    const rollbackPaths = [...SYSTEM_PATHS, ...REMOVED_SYSTEM_PATHS];
+    for (const path of rollbackPaths) {
       try {
         git('checkout', latest, '--', path);
         restored.push(path);
       } catch (err) {
         const pathspec = path.endsWith('/') ? path.slice(0, -1) : path;
-        let existedInBackup = true;
-        try {
-          git('cat-file', '-e', `${latest}:${pathspec}`);
-        } catch {
-          existedInBackup = false;
-        }
+        const existedInBackup = treeHasPath(latest, path);
         if (existedInBackup) {
           throw err;
         }
@@ -453,12 +506,7 @@ function rollback() {
         // for tracked files; `rmSync` cleans up the untracked-but-
         // on-disk case (e.g. an apply() that crashed between checkout
         // and commit, leaving the path untracked locally).
-        git('rm', '-r', '-f', '--ignore-unmatch', '--', pathspec);
-        try {
-          rmSync(join(ROOT, pathspec), { recursive: true, force: true });
-        } catch {
-          // Already gone, or not present on disk — fine.
-        }
+        removeSystemPath(pathspec);
         removed.push(pathspec);
       }
     }


### PR DESCRIPTION
## Summary

- Rebase the worktree branch onto current `origin/main` and retain the existing hardening commit.
- Add scanner support for `title_filter.negative_regex` so user configs can block senior/manager variants without losing senior recruiting IC matches.
- Update scan-facing language from “offers” to “job postings” and prefer the English `## Pending` pipeline section with compatibility for older `## Pendientes` files.

## Validation

- `node --check scan.mjs`
- `npm run doctor`
- `npm run verify`
- `npm run sync-check`
- `npm run scan -- --dry-run`
- `node test-all.mjs --quick` passed with existing personal-data metadata warnings only

## Notes

Local user config updates in `portals.yml`, `config/profile.yml`, `modes/_profile.md`, and `data/pipeline.md` remain gitignored per the Career-Ops data contract and are not included in this PR.