### PR TITLE
feat: universal LaTeX CV parse, write, and compile pipeline

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -3,7 +3,7 @@ name: career-ops
 description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
 arguments: mode # Claude Code specific
 user-invocable: true
-argument-hint: "[scan | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
+argument-hint: "[scan | deep | pdf | latex-tex | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
 license: MIT
 ---
 
@@ -23,6 +23,7 @@ Determine the mode from `$mode`:
 | `deep` | `deep` |
 | `interview-prep` | `interview-prep` |
 | `pdf` | `pdf` |
+| `latex-tex` | `latex-tex` (tailor user's `resume.tex` / `cv.tex`) |
 | `training` | `training` |
 | `project` | `project` |
 | `tracker` | `tracker` |
@@ -77,7 +78,7 @@ After determining the mode, load the necessary files before executing:
 ### Modes that require `_shared.md` + their mode file:
 Read `modes/_shared.md` + `modes/{mode}.md`
 
-Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `latex-tex`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
 
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,11 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `templates/cv-template.html` | HTML template for CVs |
 | `templates/cv-template.tex` | LaTeX/Overleaf template for CVs |
 | `generate-pdf.mjs` | Playwright: HTML to PDF |
-| `generate-latex.mjs` | LaTeX CV validator + pdflatex compiler |
+| `generate-latex.mjs` | LaTeX CV validator + pdflatex compiler (career-ops template) |
+| `parse-latex.mjs` | Universal `.tex` → structured JSON + template metadata |
+| `write-latex.mjs` | Tailored JSON + original `.tex` → tailored `.tex` |
+| `compile-latex.mjs` | Generic `.tex` → PDF (any format) |
+| `latex-pipeline.mjs` | Orchestrates parse → write → compile |
 | `article-digest.md` | Compact proof points from portfolio (optional) |
 | `interview-prep/story-bank.md` | Accumulated STAR+R stories across evaluations |
 | `interview-prep/{company}-{role}.md` | Company-specific interview intel reports |
@@ -73,7 +77,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 
 **Before doing ANYTHING else, check if the system is set up.** Run these checks silently every time a session starts:
 
-1. Does `cv.md` exist?
+1. Does `cv.md` exist OR `resume.tex` / `cv.tex` exist?
 2. Does `config/profile.yml` exist (not just profile.example.yml)?
 3. Does `modes/_profile.md` exist (not just _profile.template.md)?
 4. Does `portals.yml` exist (not just templates/portals.example.yml)?
@@ -83,15 +87,16 @@ If `modes/_profile.md` is missing, copy from `modes/_profile.template.md` silent
 **If ANY of these is missing, enter onboarding mode.** Do NOT proceed with evaluations, scans, or any other mode until the basics are in place. Guide the user step by step:
 
 #### Step 1: CV (required)
-If `cv.md` is missing, ask:
+If `cv.md` and `resume.tex` / `cv.tex` are all missing, ask:
 > "I don't have your CV yet. You can either:
 > 1. Paste your CV here and I'll convert it to markdown
-> 2. Paste your LinkedIn URL and I'll extract the key info
-> 3. Tell me about your experience and I'll draft a CV for you
+> 2. Provide your LaTeX CV (`resume.tex` or `cv.tex`) for tailoring in your own format
+> 3. Paste your LinkedIn URL and I'll extract the key info
+> 4. Tell me about your experience and I'll draft a CV for you
 >
 > Which do you prefer?"
 
-Create `cv.md` from whatever they provide. Make it clean markdown with standard sections (Summary, Experience, Projects, Education, Skills).
+Create `cv.md` from markdown/LinkedIn/draft input. If the user provides LaTeX, save as `resume.tex` (or `cv.tex`) and use `modes/latex-tex.md` for PDF generation — no need to duplicate into `cv.md` unless they also want markdown workflows.
 
 #### Step 2: Profile (required)
 If `config/profile.yml` is missing, copy from `config/profile.example.yml` and then ask:
@@ -206,7 +211,8 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Wants LinkedIn outreach | `contacto` |
 | Asks for company research | `deep` |
 | Preps for interview at specific company | `interview-prep` |
-| Wants to generate CV/PDF | `pdf` |
+| Wants to generate CV/PDF | `pdf` (from `cv.md`) or `latex-tex` (from `resume.tex` / `cv.tex`) |
+| Has LaTeX CV + JD, wants tailored PDF in same format | `latex-tex` |
 | Evaluates a course/cert | `training` |
 | Evaluates portfolio project | `project` |
 | Asks about application status | `tracker` |
@@ -219,9 +225,24 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 
 ### CV Source of Truth
 
-- `cv.md` in project root is the canonical CV
+**Priority (highest first):**
+
+1. `resume.tex` or `cv.tex` in project root — LaTeX CV in the user's template (`modes/latex-tex.md`)
+2. `cv.md` in project root — canonical markdown CV (`modes/pdf.md`, `modes/latex.md`)
+
+If both LaTeX and markdown exist, use LaTeX for PDF/CV generation unless the user asks for markdown/HTML output.
+
 - `article-digest.md` has detailed proof points (optional)
 - **NEVER hardcode metrics** -- read them from these files at evaluation time
+
+**LaTeX pipeline commands:**
+
+```bash
+node parse-latex.mjs resume.tex output/
+node write-latex.mjs resume.tex output/cv-tailored-{company}-{date}.json output/cv-{company}-{date}.tex
+node compile-latex.mjs output/cv-{company}-{date}.tex output/cv-{company}-{date}.pdf
+# Or: node latex-pipeline.mjs resume.tex --json output/cv-tailored-....json --company acme
+```
 
 ---
 

--- a/compile-latex.mjs
+++ b/compile-latex.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+/**
+ * compile-latex.mjs — Compile any .tex CV to PDF (no career-ops template validation)
+ *
+ * Usage:
+ *   node compile-latex.mjs <input.tex> [output.pdf]
+ *
+ * Requires: tectonic (preferred) or pdflatex on PATH.
+ */
+
+import { readFile, writeFile, stat, copyFile, rm } from 'fs/promises';
+import { resolve, basename, dirname, join } from 'path';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync } from 'fs';
+
+function detectEngine() {
+  for (const candidate of ['tectonic', 'pdflatex']) {
+    try {
+      execFileSync(candidate, ['--version'], { stdio: 'pipe' });
+      return candidate;
+    } catch {
+      /* not installed */
+    }
+  }
+  return null;
+}
+
+export async function compileLatex(inputPath, outputPath = null) {
+  const absPath = resolve(inputPath);
+  let content;
+  try {
+    content = await readFile(absPath, 'utf-8');
+  } catch (err) {
+    console.error(`Error reading ${absPath}: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (!content.includes('\\begin{document}') || !content.includes('\\end{document}')) {
+    console.error('Invalid LaTeX: missing \\begin{document} or \\end{document}');
+    process.exit(1);
+  }
+
+  const texDir = dirname(absPath);
+  const texBase = basename(absPath, '.tex');
+  const defaultPdf = join(texDir, `${texBase}.pdf`);
+  const targetPdf = outputPath ? resolve(outputPath) : defaultPdf;
+  const targetDir = dirname(targetPdf);
+  if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
+
+  const engine = detectEngine();
+  const report = {
+    file: basename(absPath),
+    path: absPath,
+    valid: true,
+    issues: [],
+  };
+
+  if (!engine) {
+    report.compiled = false;
+    report.compileError =
+      'No LaTeX engine found. Install tectonic (brew install tectonic) or pdflatex.';
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(1);
+  }
+
+  report.engine = engine;
+
+  let compilePath = absPath;
+  if (engine === 'tectonic') {
+    const patched = content
+      .replace(/\\pdfgentounicode\s*=\s*\d+[^\n]*\n?/g, '')
+      .replace(/\\input\{glyphtounicode\}[^\n]*\n?/g, '');
+    compilePath = join(texDir, `${texBase}._tectonic.tex`);
+    await writeFile(compilePath, patched, 'utf-8');
+  }
+
+  try {
+    if (engine === 'tectonic') {
+      execFileSync('tectonic', ['--outdir', texDir, compilePath], {
+        cwd: texDir,
+        stdio: 'pipe',
+        timeout: 120_000,
+      });
+    } else {
+      const args = [
+        '-no-shell-escape',
+        '-interaction=nonstopmode',
+        '-halt-on-error',
+        `-output-directory=${texDir}`,
+        absPath,
+      ];
+      execFileSync('pdflatex', args, { cwd: texDir, stdio: 'pipe', timeout: 120_000 });
+      execFileSync('pdflatex', args, { cwd: texDir, stdio: 'pipe', timeout: 120_000 });
+    }
+    report.compiled = true;
+  } catch (err) {
+    const logPath = join(texDir, `${texBase}.log`);
+    let latexError = err.message;
+    try {
+      const log = await readFile(logPath, 'utf-8');
+      const errorLines = log.split('\n').filter((l) => l.startsWith('!'));
+      if (errorLines.length > 0) latexError = errorLines.join('\n');
+    } catch {
+      /* no log */
+    }
+    report.compiled = false;
+    report.compileError = latexError;
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(1);
+  }
+
+  const compileBase = basename(compilePath, '.tex');
+  const compiledPdf = join(texDir, `${compileBase}.pdf`);
+
+  try {
+    await copyFile(compiledPdf, targetPdf);
+    if (resolve(compiledPdf) !== resolve(targetPdf)) {
+      await rm(compiledPdf).catch(() => {});
+    }
+    const pdfStat = await stat(targetPdf);
+    report.pdf = {
+      path: targetPdf,
+      sizeKB: parseFloat((pdfStat.size / 1024).toFixed(1)),
+    };
+  } catch (err) {
+    report.compiled = false;
+    report.compileError = `Failed to finalize PDF: ${err.message}`;
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(1);
+  }
+
+  const auxExts = ['.aux', '.log', '.out', '.fls', '.fdb_latexmk', '.synctex.gz'];
+  for (const ext of auxExts) {
+    await rm(join(texDir, `${compileBase}${ext}`)).catch(() => {});
+  }
+  if (engine === 'tectonic' && compilePath !== absPath) {
+    await rm(compilePath).catch(() => {});
+  }
+
+  console.log(JSON.stringify(report, null, 2));
+  return report;
+}
+
+const inputPath = process.argv[2];
+const outputPath = process.argv[3];
+
+if (!inputPath) {
+  console.error('Usage: node compile-latex.mjs <input.tex> [output.pdf]');
+  process.exit(1);
+}
+
+compileLatex(inputPath, outputPath);

--- a/examples/resume-tabularx.example.tex
+++ b/examples/resume-tabularx.example.tex
@@ -1,0 +1,164 @@
+\documentclass[a4paper,10pt]{article}
+
+\usepackage[left=0.6in, right=0.6in, top=0.55in, bottom=0.55in]{geometry}
+\usepackage{enumitem}
+\usepackage{titlesec}
+\usepackage[hidelinks]{hyperref}
+\usepackage{xcolor}
+\usepackage{tabularx}
+\usepackage{array}
+\usepackage{fontenc}
+\usepackage{lmodern}
+
+\pagenumbering{gobble}
+
+% Color for section rules and accents
+\definecolor{darkblue}{RGB}{0, 51, 102}
+
+% Section formatting — small caps label, full-width rule
+\titleformat{\section}
+  {\large\bfseries\color{darkblue}}{}{0em}{}
+  [\color{darkblue}\titlerule]
+\titlespacing{\section}{0pt}{10pt}{5pt}
+
+% Compact list settings
+\setlist[itemize]{
+  noitemsep,
+  topsep=2pt,
+  partopsep=0pt,
+  parsep=0pt,
+  leftmargin=1.2em,
+  label=\textbullet
+}
+
+% Hyperlink style
+\hypersetup{
+  colorlinks=false,
+  urlbordercolor=darkblue
+}
+
+\begin{document}
+
+% ─────────────────────────── HEADER ───────────────────────────
+\begin{center}
+  {\LARGE \textbf{Alex Example}} \\[4pt]
+  {\small
+    Example City, State, Country \quad\textbar\quad
+    \href{mailto:alex@example.com}{alex@example.com} \quad\textbar\quad
+    +1-555-010-1234 \\[2pt]
+    \href{https://www.linkedin.com/in/alex-example}{linkedin.com/in/alex-example} \quad\textbar\quad
+    \href{https://github.com/alex-example}{github.com/alex-example}
+  }
+\end{center}
+
+
+
+
+% ─────────────────────────── EXPERIENCE ───────────────────────────
+\section*{Professional Experience}
+
+% --- Job 1 ---
+\noindent
+\begin{tabularx}{\textwidth}{@{}X r@{}}
+  \textbf{Senslyze} & \textit{Aug 2025 – Present}
+\end{tabularx}
+\textit{Software Development Engineer}
+
+\begin{itemize}
+  \item Designed and deployed production-grade WhatsApp-native AI systems with secure webhooks, encrypted Flow endpoints (RSA/AES), and scalable backend services.
+  \item Built end-to-end RAG pipelines (PDF → chunking → embeddings → Qdrant retrieval) enabling grounded, context-aware responses with optimized latency.
+  \item Engineered hybrid conversational systems combining deterministic state machines with LLM-based structured NLU.
+  \item Orchestrated multimodal AI workflows (STT → NLU → reasoning → TTS) enabling voice-first interactions.
+  \item Implemented vision-based validation using multimodal LLMs for strict JSON outputs (accept/reject + scoring).
+  \item Developed LLM routing pipelines using OpenAI-compatible APIs, OpenRouter, and Gemini fallback strategies.
+  \item Built a Flow Builder platform for visualizing and managing conversational workflows.
+  \item Applied schema validation (Zod) and structured prompting to improve reliability and reduce hallucination.
+\end{itemize}
+
+\vspace{4pt}
+
+% --- Job 2 ---
+\noindent
+\begin{tabularx}{\textwidth}{@{}X r@{}}
+  \textbf{Dinosys Infotech Pvt Ltd} & \textit{Jul 2024 – Mar 2025}
+\end{tabularx}
+\textit{Software Developer}
+
+\begin{itemize}
+  \item Developed OSINT automation tools for law enforcement using Python and Selenium.
+  \item Built backend pipelines for data extraction, normalization, and analysis.
+  \item Optimized scraping workflows using parallel execution to improve efficiency.
+\end{itemize}
+
+% ─────────────────────────── PROJECTS ───────────────────────────
+\section*{Projects}
+
+
+
+% --- Project 1 ---
+\noindent
+\begin{tabularx}{\textwidth}{@{}X r@{}}
+  \textbf{Refaktr AI} &
+\end{tabularx}
+\textit{VS Code Extension, TypeScript/Node.js, Express, ts-morph, Graph-based Analysis, LLM Planning}
+\begin{itemize}
+  \item Designed an AI-assisted refactoring system that converts codebases into dependency graphs and generates structured refactor plans from user intent.
+  \item Executed safe code transformations using AST-based edits, avoiding regex-based risks and ensuring maintainability.
+  \item Built step-wise execution pipeline with validation hooks (type-check, build, tests) to ensure reliable and reviewable refactors.
+\end{itemize}
+
+\vspace{4pt}
+
+% --- Project 2 ---
+\noindent
+\begin{tabularx}{\textwidth}{@{}X r@{}}
+  \textbf{AI Document Analyzer} &
+  \href{https://example.com/demo}{\small Live} \;|\;
+  \href{https://example.com/demo-video}{\small Demo} \;|\;
+  \href{https://github.com/alex-example/sample-project}{\small GitHub}
+\end{tabularx}
+\textit{React, TypeScript, FastAPI, Python, PostgreSQL, LangChain, Gemini, Docker}
+\begin{itemize}
+  \item Built an AI-powered platform for document analysis, summarization, and RAG-based Q\&A with a containerized stack.
+\end{itemize}
+
+\vspace{4pt}
+
+% --- Project 3 ---
+\noindent
+\begin{tabularx}{\textwidth}{@{}X r@{}}
+  \textbf{DevPilotAI} &
+  \href{https://github.com/alex-example/devpilot-ai}{\small GitHub}
+\end{tabularx}
+\textit{Next.js, TypeScript, Express, Gemini, LangChain, Qdrant}
+\begin{itemize}
+  \item Built an AI development assistant with RAG-based code querying, architecture generation, and real-time streaming outputs.
+\end{itemize}
+
+% ─────────────────────────── SKILLS ───────────────────────────
+\section*{Technical Skills}
+
+\newsavebox{\skillsbox}
+\begin{lrbox}{\skillsbox}
+\begin{tabularx}{\textwidth}{@{}>{\bfseries}p{2.8cm} X@{}}
+  AI / ML          & RAG, NLP, Prompt Engineering, Multimodal AI (Vision + Voice), Embeddings, Vector DB (Qdrant, FAISS) \\
+  LLM Systems      & OpenAI APIs, OpenRouter, Gemini, LangChain, LLM Routing, Tool Calling, AI Orchestration \\
+  Backend          & Node.js, Express, FastAPI, Flask, Bun, Hono, REST APIs, Webhooks \\
+  Frontend         & React.js, Next.js, TypeScript \\
+  Databases        & PostgreSQL, Prisma, SQLite \\
+  DevOps           & Docker, Git, Postman, Linux, AWS \\
+  Core CS          & DSA, OS, DBMS, CN, OOP \\
+\end{tabularx}
+\end{lrbox}
+\usebox{\skillsbox}
+
+% ─────────────────────────── EDUCATION ───────────────────────────
+\section*{Education}
+
+\noindent
+\begin{tabularx}{\textwidth}{@{}X r@{}}
+  \textbf{B.E. in Computer Science and Engineering} & \textbf{June 2025} \\
+  Government College of Engineering, Chandrapur & CGPA: \textbf{8.94 / 10.00}
+\end{tabularx}
+
+\end{document}

--- a/latex-pipeline.mjs
+++ b/latex-pipeline.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+/**
+ * latex-pipeline.mjs — Parse → write → compile (script steps; AI tailors JSON separately)
+ *
+ * Usage:
+ *   node latex-pipeline.mjs <source.tex> [options]
+ *
+ * Options:
+ *   --json <path>       Tailored content JSON (default: parse source, round-trip for testing)
+ *   --company <slug>    Output filename slug (default: "tailored")
+ *   --outdir <dir>      Output directory (default: ./output)
+ *   --skip-compile      Only produce .tex, skip PDF
+ *   --skip-parse        Require --json (do not parse source)
+ */
+
+import { mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { resolve, dirname, basename, join } from 'path';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+
+function parseArgs(argv) {
+  const opts = {
+    source: null,
+    json: null,
+    company: 'tailored',
+    outdir: 'output',
+    skipCompile: false,
+    skipParse: false,
+  };
+  const positional = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') opts.json = argv[++i];
+    else if (a === '--company') opts.company = argv[++i];
+    else if (a === '--outdir') opts.outdir = argv[++i];
+    else if (a === '--skip-compile') opts.skipCompile = true;
+    else if (a === '--skip-parse') opts.skipParse = true;
+    else if (!a.startsWith('--')) positional.push(a);
+  }
+  opts.source = positional[0];
+  return opts;
+}
+
+function runNode(script, args) {
+  const out = execFileSync('node', [join(ROOT, script), ...args], {
+    encoding: 'utf-8',
+    cwd: ROOT,
+  });
+  return JSON.parse(out.trim().split('\n').pop());
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (!opts.source) {
+    console.error(`Usage: node latex-pipeline.mjs <source.tex> [options]
+
+Options:
+  --json <path>       Tailored JSON (default: parse + round-trip)
+  --company <slug>    Output name slug
+  --outdir <dir>      Output directory
+  --skip-compile      Stop after .tex
+  --skip-parse        Require --json`);
+    process.exit(1);
+  }
+
+  const absSource = resolve(opts.source);
+  const outDir = resolve(opts.outdir);
+  if (!existsSync(outDir)) await mkdir(outDir, { recursive: true });
+
+  const date = new Date().toISOString().slice(0, 10);
+  let jsonPath = opts.json ? resolve(opts.json) : null;
+
+  if (!jsonPath) {
+    if (opts.skipParse) {
+      console.error('--skip-parse requires --json');
+      process.exit(1);
+    }
+    const parsed = runNode('parse-latex.mjs', [absSource, outDir]);
+    jsonPath = parsed.parse_file;
+  }
+
+  const outTex = join(outDir, `cv-${opts.company}-${date}.tex`);
+  const outPdf = join(outDir, `cv-${opts.company}-${date}.pdf`);
+
+  const written = runNode('write-latex.mjs', [absSource, jsonPath, outTex]);
+
+  const result = {
+    status: 'ok',
+    source_tex: basename(absSource),
+    json_file: jsonPath,
+    output_tex: written.output_tex,
+    company: opts.company,
+  };
+
+  if (!opts.skipCompile) {
+    try {
+      const compiled = runNode('compile-latex.mjs', [outTex, outPdf]);
+      result.output_pdf = compiled.pdf?.path || outPdf;
+      result.pdf_size_kb = compiled.pdf?.sizeKB;
+      result.engine = compiled.engine;
+    } catch (e) {
+      result.status = 'partial';
+      result.compile_error = e.message;
+      result.output_tex = outTex;
+      console.log(JSON.stringify(result, null, 2));
+      process.exit(1);
+    }
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main();

--- a/modes/latex-tex.md
+++ b/modes/latex-tex.md
@@ -1,0 +1,80 @@
+# Mode: latex-tex — Tailor an existing LaTeX CV (preserve your template)
+
+Use when the candidate has `cv.tex`, `resume.tex`, or another LaTeX CV in their own format — **not** the career-ops `templates/cv-template.tex` flow (`modes/latex.md` + `cv.md`).
+
+## CV source priority
+
+1. `resume.tex` or `cv.tex` in project root (if both exist, prefer `resume.tex`)
+2. `cv.md` (fallback — use `modes/pdf.md` or `modes/latex.md`)
+
+## Pipeline
+
+1. **Parse** — `node parse-latex.mjs <cv.tex> output/`
+   - Produces `cv-parse-{name}-{timestamp}.json` (content) and `cv-template-*.json` (metadata).
+2. **Tailor (AI)** — Same ethical rules as `modes/pdf.md`:
+   - Read JD → extract 15–20 keywords
+   - Reorder experience/project bullets by JD relevance
+   - Inject keywords into **existing** bullets only — **NEVER invent skills**
+   - Optionally reorder skill **values** within categories (do not add categories the candidate lacks)
+   - Write tailored JSON to `output/cv-tailored-{company}-{YYYY-MM-DD}.json`
+3. **Write** — `node write-latex.mjs <original.tex> output/cv-tailored-{company}-{date}.json output/cv-{company}-{date}.tex`
+   - Replaces bullet text and skill values only; preserves layout, colors, `tabularx`, `lrbox`, spacing.
+4. **Compile** — `node compile-latex.mjs output/cv-{company}-{date}.tex output/cv-{company}-{date}.pdf`
+5. **Report** — `.tex` path, `.pdf` path, sizes, keyword coverage %, sections touched.
+
+**One-shot (parse + write + compile, round-trip JSON for testing):**
+
+```bash
+node latex-pipeline.mjs resume.tex --company acme --json output/cv-tailored-acme-2026-05-21.json
+```
+
+Without `--json`, the pipeline parses the source and writes back the same content (smoke test).
+
+## Supported formats
+
+| Format | Detection | Write support |
+|--------|-----------|---------------|
+| tabularx + itemize | `tabularx` + `itemize` sections | ✅ |
+| resumeSubheading | `\resumeSubheading` / `\resumeItem` | ✅ |
+| section + itemize | generic | partial (itemize bullets) |
+
+## Tailoring JSON schema
+
+Use the structure from `parse-latex.mjs` output:
+
+```json
+{
+  "meta": { "format_detected": "tabularx-itemize" },
+  "contact": { "email": "", "phone": "", "linkedin": "", "github": "" },
+  "experience": [{ "company": "", "role": "", "start": "", "end": "", "bullets": ["..."] }],
+  "projects": [{ "name": "", "tech": "", "date": "", "bullets": ["..."] }],
+  "skills": { "Category Name": ["skill1", "skill2"] },
+  "education": [{ "degree": "", "institution": "", "date": "", "details": "" }]
+}
+```
+
+Only fields with bullets/skills you changed need updating; writer merges by section order and category keys.
+
+## LaTeX escaping
+
+Bullet strings in JSON should be plain text. `write-latex.mjs` escapes `&`, `%`, `_`, `#`, etc., and preserves existing escapes like `\&`.
+
+## Requires
+
+- `tectonic` (preferred: `brew install tectonic`) or `pdflatex` on PATH for PDF output.
+
+## vs `modes/latex.md`
+
+| | latex-tex | latex |
+|---|-----------|-------|
+| Input | User's `.tex` | `cv.md` |
+| Template | Original file | `templates/cv-template.tex` |
+| Output layout | Unchanged | career-ops resume class |
+
+## Auto-pipeline integration
+
+When JD is pasted and `resume.tex` / `cv.tex` exists:
+
+1. Run evaluation blocks (oferta) as usual
+2. For PDF step, use **this mode** instead of HTML `generate-pdf.mjs`
+3. Record PDF path in tracker TSV as for `pdf` mode

--- a/parse-latex.mjs
+++ b/parse-latex.mjs
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+
+/**
+ * parse-latex.mjs — Universal LaTeX CV Parser
+ *
+ * Parses any LaTeX CV file and extracts:
+ *   1. content JSON  — structured sections (experience, projects, skills, education)
+ *   2. template JSON — template metadata (packages, layout, colors, structure)
+ *
+ * Supports format families:
+ *   1. tabularx-itemize   (tabularx rows + itemize bullets — your format)
+ *   2. resumeSubheading  (career-ops template: \resumeSubheading commands)
+ *   3. section-itemize    (generic: \section{} + itemize bullets)
+ *
+ * Usage:
+ *   node parse-latex.mjs <path-to-resume.tex> [output-dir]
+ *
+ * Output (written to output-dir or ./output/):
+ *   cv-parse-{name}-{timestamp}.json
+ *   cv-template-{name}-{timestamp}.json
+ */
+
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { resolve, dirname, basename } from 'path';
+
+function detectFormat(content) {
+  if (/\\resumeSubheading/.test(content) || /\\resumeItem\b/.test(content)) return 'resumeSubheading';
+  if (/\\begin\{tabularx\}/.test(content) && /\\begin\{itemize\}/.test(content)) return 'tabularx-itemize';
+  if (/\\begin\{itemize\}/.test(content) && /\\section\{/.test(content)) return 'section-itemize';
+  return 'generic';
+}
+
+function extractName(headerText) {
+  const patterns = [
+    /\\Large\s+\*?\\textbf\{([^}]+)\}/,
+    /\\Huge\s+[\\]?scshape\s*\{([^}]+)\}/,
+    /\\name\{([^}]+)\}/,
+    /\\textbf\{\s*([A-Z][A-Za-z]+ [A-Z][A-Za-z]+)\s*\}/,
+  ];
+  for (const p of patterns) {
+    const m = headerText.match(p);
+    if (m) return m[1].trim();
+  }
+  return 'Unknown';
+}
+
+function extractContact(centerBlock) {
+  if (!centerBlock) return { email: '', phone: '', linkedin: '', github: '', location: '' };
+  const email = (centerBlock.match(/href\{mailto:([^}]+)\}/)?.[1]) ||
+                (centerBlock.match(/([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})/))?.[1] || '';
+  const phone = (centerBlock.match(/\+?[\d][\d\-\s().]{8,}/))?.[0]?.trim() || '';
+  const linkedin = (centerBlock.match(/linkedin\.com\/in\/([^\s\\}>&]+)/)?.[1]) ? `linkedin.com/in/${centerBlock.match(/linkedin\.com\/in\/([^\s\\}>&]+)/)[1]}` : '';
+  const github = (centerBlock.match(/github\.com\/([^\s\\}>&]+)/)?.[1]) ? `github.com/${centerBlock.match(/github\.com\/([^\s\\}>&]+)/)[1]}` : '';
+  return { email, phone, linkedin, github, location: '' };
+}
+
+function extractPackages(content) {
+  const pkgs = [];
+  const re = /\\usepackage(?:\[[^\]]*\])?\{([^}]+)\}/g;
+  let m;
+  while ((m = re.exec(content)) !== null) pkgs.push(m[1]);
+  return pkgs;
+}
+
+function extractDocumentClass(content) {
+  const m = content.match(/\\documentclass\[[^\]]*\]\{[^}]+\}/);
+  return m ? m[0] : '';
+}
+
+function extractColors(content) {
+  const colors = {};
+  const re = /\\definecolor\{(\w+)\}\{([^}]+)\}\{([^}]+)\}/g;
+  let m;
+  while ((m = re.exec(content)) !== null) colors[m[1]] = `${m[2]}{${m[3]}}`;
+  return colors;
+}
+
+function extractLayout(content) {
+  const margins = {};
+  const m = content.match(/\\usepackage\[([^\]]+)\]\{geometry\}/);
+  if (m) {
+    for (const p of m[1].split(',')) {
+      const [k, v] = p.trim().split('=').map(s => s.trim());
+      if (k && v) margins[k] = v;
+    }
+  }
+  return { margins, page: '' };
+}
+
+function detectSectionOrder(content) {
+  const order = [];
+  const patterns = [
+    { key: 'experience', regex: /\\section\*?\{(?:Professional\s+)?[Ee]xperience\}/ },
+    { key: 'projects', regex: /\\section\*?\{[Pp]rojects?\}/ },
+    { key: 'skills', regex: /\\section\*?\{(?:Technical\s+)?[Ss]kills?\}/ },
+    { key: 'education', regex: /\\section\*?\{[Ee]ducation\}/ },
+    { key: 'summary', regex: /\\section\*?\{(?:Professional\s+)?[Ss]ummary\}/ },
+    { key: 'certifications', regex: /\\section\*?\{[Cc]ertifications?\}/ },
+  ];
+  for (const { key, regex } of patterns) {
+    if (regex.test(content)) order.push(key);
+  }
+  return order;
+}
+
+function parseItemizeBullets(itemizeBlock) {
+  const bullets = [];
+  const lines = itemizeBlock.split('\n');
+  for (const line of lines) {
+    if (/\\item\b/.test(line)) {
+      let text = line
+        .replace(/\\item\b/, '')
+        .replace(/\[[^\]]*\]/, '')
+        .replace(/\\\n/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+      if (text) bullets.push(text);
+    }
+  }
+  return bullets;
+}
+
+function getSectionContent(content, sectionName) {
+  const re = new RegExp(`\\\\section\\*?\\{[^}]*${sectionName}[^}]*\\}[\\s\\S]*?(?=\\\\section\\*?\\{|\\\\end\\{document\\})`, 'i');
+  return content.match(re)?.[0] || '';
+}
+
+function parseExperienceTabularx(content) {
+  const items = [];
+  const expIdx = content.indexOf('Experience');
+  if (expIdx < 0) return items;
+
+  const afterSection = content.substring(expIdx);
+  const nextSection = afterSection.indexOf('\\section', 20);
+  const section = nextSection > 0 ? afterSection.substring(0, nextSection) : afterSection;
+
+  const tabularxBlocks = [...section.matchAll(/\\begin\{tabularx\}[\s\S]*?\\end\{tabularx\}/g)];
+  const itemizeBlocks = [...section.matchAll(/\\begin\{itemize\}[\s\S]*?\\end\{itemize\}/g)];
+
+  for (let i = 0; i < tabularxBlocks.length; i++) {
+    const txBlock = tabularxBlocks[i][0];
+    const lines = txBlock.split('\n');
+    let company = '';
+    let dateRange = '';
+    let role = '';
+
+    for (const line of lines) {
+      const bt = line.match(/\\textbf\{([^}]+)\}/);
+      if (bt && !company) company = bt[1];
+
+      const dates = [...line.matchAll(/\\textit\{([^}]+)\}/g)];
+      for (const d of dates) {
+        if (/[\d]{4}|Present/.test(d[1]) && !dateRange) dateRange = d[1];
+      }
+
+      const rm = line.match(/\\textit\{([^}]+(?:Developer|Engineer|Manager|Analyst|Scientist|Lead|Architect|Designer|Intern)[^}]*)\}/);
+      if (rm && !role) role = rm[1].trim();
+    }
+
+    const bullets = (itemizeBlocks[i]) ? parseItemizeBullets(itemizeBlocks[i][0]) : [];
+
+    if (company && bullets.length > 0) {
+      const parts = dateRange ? dateRange.split(/\s*[-–]\s*/) : ['', ''];
+      items.push({ company, role, start: parts[0] || '', end: parts[1] || '', bullets });
+    }
+  }
+
+  if (items.length === 0) {
+    for (const match of itemizeBlocks) {
+      const bullets = parseItemizeBullets(match[0]);
+      if (bullets.length > 0) items.push({ company: 'Experience', role: '', start: '', end: '', bullets });
+    }
+  }
+
+  return items;
+}
+
+function parseProjectsTabularx(content) {
+  const items = [];
+  const projIdx = content.indexOf('Projects');
+  if (projIdx < 0) return items;
+
+  const afterSection = content.substring(projIdx);
+  const nextSection = afterSection.indexOf('\\section', 20);
+  const section = nextSection > 0 ? afterSection.substring(0, nextSection) : afterSection;
+
+  const tabularxBlocks = [...section.matchAll(/\\begin\{tabularx\}[\s\S]*?\\end\{tabularx\}/g)];
+  const itemizeBlocks = [...section.matchAll(/\\begin\{itemize\}[\s\S]*?\\end\{itemize\}/g)];
+
+  for (let i = 0; i < tabularxBlocks.length; i++) {
+    const txBlock = tabularxBlocks[i][0];
+    const lines = txBlock.split('\n');
+    let name = '';
+    let tech = '';
+    let date = '';
+
+    for (const line of lines) {
+      const nm = line.match(/\\textbf\{([^}]+)\}/);
+      if (nm && !name) {
+        name = nm[1].replace(/\\emph\{[^}]*\|\s*/g, '').replace(/\|[^}]*\}/g, '').trim();
+      }
+
+      const ts = [...line.matchAll(/\\textit\{([^}]+)\}/g)];
+      for (const t of ts) {
+        if (!/[\d]{4}|Live|GitHub|Demo|Links/.test(t[1]) && !tech) tech = t[1];
+        if (/[\d]{4}/.test(t[1]) && !date) date = t[1];
+      }
+    }
+
+    const bullets = (itemizeBlocks[i]) ? parseItemizeBullets(itemizeBlocks[i][0]) : [];
+
+    if (name) items.push({ name, tech, date, bullets });
+  }
+
+  return items;
+}
+
+function splitSkillValues(vals) {
+  const result = [];
+  let cur = '';
+  let depth = 0;
+  for (const c of vals) {
+    if (c === '(') depth++;
+    else if (c === ')') depth = Math.max(0, depth - 1);
+    else if (c === ',' && depth === 0) {
+      const s = cur.trim();
+      if (s) result.push(s);
+      cur = '';
+      continue;
+    }
+    cur += c;
+  }
+  const s = cur.trim();
+  if (s) result.push(s);
+  return result;
+}
+
+function extractSkillsTabularx(section) {
+  const lrboxM = section.match(
+    /\\begin\{lrbox\}[\s\S]*?\\begin\{tabularx\}([\s\S]*?)\\end\{tabularx\}[\s\S]*?\\end\{lrbox\}/
+  );
+  if (lrboxM) return lrboxM[1];
+
+  const txM = section.match(/\\begin\{tabularx\}[\s\S]*?\\end\{tabularx\}/);
+  if (!txM) return '';
+  return txM[0]
+    .replace(/\\begin\{tabularx\}[^\n]*\n?/, '')
+    .replace(/\\end\{tabularx\}/, '');
+}
+
+function parseSkillCategory(cell) {
+  const lines = cell.split('\n').map(l => l.trim()).filter(Boolean);
+  const raw = lines.length > 1 ? lines[lines.length - 1] : cell;
+  return raw
+    .replace(/\\[a-zA-Z]+\*?(?:\[[^\]]*\])?\{[^}]*\}/g, '')
+    .replace(/[{}>@]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseSkills(content) {
+  const skills = {};
+
+  const sectionM = content.match(
+    /\\section\*?\{(?:Technical\s+)?[Ss]kills?\}([\s\S]*?)(?=\\section\*?\{|\\end\{document\})/i
+  );
+  if (!sectionM) return skills;
+
+  const section = sectionM[1];
+  const tabularBody = extractSkillsTabularx(section);
+  if (!tabularBody) return skills;
+
+  const rows = tabularBody.split('\\\\');
+  for (const row of rows) {
+    if (!row.includes('&')) continue;
+    const parts = row.split('&');
+    const cat = parseSkillCategory(parts[0]);
+    const vals = parts.slice(1).join('&').replace(/\\\n/g, ' ').replace(/\s+/g, ' ').trim();
+    if (cat && vals) skills[cat] = splitSkillValues(vals);
+  }
+
+  if (Object.keys(skills).length === 0) {
+    const itemizes = section.matchAll(/\\begin\{itemize\}[\s\S]*?\\end\{itemize\}/g);
+    for (const match of itemizes) {
+      const bullets = parseItemizeBullets(match[0]);
+      for (const b of bullets) {
+        const colon = b.indexOf(':');
+        if (colon > 0) {
+          const cat = b.substring(0, colon).trim();
+          const vals = b.substring(colon + 1).split(/,\s*/).map(s => s.trim()).filter(s => s);
+          if (cat && vals.length > 0) skills[cat] = vals;
+        }
+      }
+    }
+  }
+
+return skills;
+}
+
+function parseEducation(content) {
+  const items = [];
+
+  const idx = content.indexOf('Education');
+  if (idx < 0) return items;
+
+  const afterSection = content.substring(idx);
+  const nextSection = afterSection.indexOf('\\section', 20);
+  const section = nextSection > 0 ? afterSection.substring(0, nextSection) : afterSection;
+
+  const eduTxMatches = section.match(/\\begin\{tabularx\}[\s\S]*?\\end\{tabularx\}/g);
+  if (eduTxMatches) {
+    for (const eduBlock of eduTxMatches) {
+      const boldItems = [...eduBlock.matchAll(/\\textbf\{([^}]+)\}/g)];
+      const italicItems = [...eduBlock.matchAll(/\\textit\{([^}]+)\}/g)];
+
+      let degree = '';
+      let institution = '';
+      let date = '';
+
+      if (boldItems.length >= 1) degree = boldItems[0][1];
+      if (boldItems.length >= 2) {
+        institution = boldItems[1][1].replace(/^CGPA:\s*/i, '');
+      }
+
+      for (const im of italicItems) {
+        if (/[\d]{4}/.test(im[1])) date = im[1];
+      }
+
+      if (degree) items.push({ degree, institution, date, details: '' });
+    }
+  }
+
+  if (items.length === 0) {
+    const bullets = parseItemizeBullets(section);
+    for (const b of bullets) items.push({ degree: b, institution: '', date: '', details: '' });
+  }
+
+  return items;
+}
+
+function parseResumeSubheading(content) {
+  const items = { experience: [], projects: [], skills: {}, education: [] };
+
+  const expBlockM = content.match(/\\resumeSubHeadingListStart\s*\n([\s\S]*?)\\resumeSubHeadingListEnd/);
+  if (expBlockM) {
+    const subheadings = expBlockM[1].split(/(?=\n\s*\\resumeSubheading\s*\{)/);
+    for (const sub of subheadings) {
+      const params = sub.match(/\\resumeSubheading\{([^}]+)\}\{([^}]+)\}\{([^}]+)\}\{([^}]+)\}/);
+      if (params) {
+        const bullets = [...sub.matchAll(/\\resumeItem\{([^}]+)\}/g)].map(m => m[1]);
+        items.experience.push({ company: params[1], date: params[2], role: params[3], location: params[4], bullets });
+      }
+    }
+  }
+
+  const projMatches = content.matchAll(/\\resumeProjectHeading\{([^}]+)\}\{([^}]+)\}/g);
+  for (const pm of projMatches) {
+    const idx = content.indexOf(pm[0]);
+    const nextIdx = content.indexOf('\\resumeProjectHeading', idx + 1);
+    const projBlock = content.substring(idx, nextIdx > 0 ? nextIdx : content.length);
+    const bullets = [...projBlock.matchAll(/\\resumeItem\{([^}]+)\}/g)].map(m => m[1]);
+    items.projects.push({ name: pm[1], date: pm[2], bullets });
+  }
+
+  const skillMatches = content.matchAll(/\\textbf\{([^}]+)\}\{:\s*([^}]+)\}/g);
+  for (const sm of skillMatches) {
+    items.skills[sm[1]] = sm[2].split(/,\s*/).map(s => s.trim()).filter(s => s);
+  }
+
+  return items;
+}
+
+async function parseLatex(inputPath, outputDir = null) {
+  const absPath = resolve(inputPath);
+  let content;
+  try {
+    content = await readFile(absPath, 'utf-8');
+  } catch (err) {
+    console.error(`Error reading ${absPath}: ${err.message}`);
+    process.exit(1);
+  }
+
+  const outDir = outputDir ? resolve(outputDir) : resolve(dirname(absPath), 'output');
+  if (!existsSync(outDir)) await mkdir(outDir, { recursive: true });
+
+  const format = detectFormat(content);
+  const centerBlock = content.match(/\\begin\{center\}\s*([\s\S]*?)\\end\{center\}/)?.[1] || '';
+  const name = extractName(centerBlock);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const safeName = name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+
+  const result = {
+    meta: {
+      source_file: basename(absPath),
+      format_detected: format,
+      parsed_at: new Date().toISOString(),
+    },
+  };
+
+  if (format === 'resumeSubheading') {
+    result.contact = extractContact(centerBlock);
+    const parsed = parseResumeSubheading(content);
+    result.experience = parsed.experience;
+    result.projects = parsed.projects;
+    result.skills = parsed.skills;
+    result.education = parsed.education;
+  } else {
+    result.contact = extractContact(centerBlock);
+    result.experience = parseExperienceTabularx(content);
+    result.projects = parseProjectsTabularx(content);
+    result.skills = parseSkills(content);
+    result.education = parseEducation(content);
+  }
+
+  result.meta.sections_found = Object.keys(result).filter(k => !['meta'].includes(k));
+
+  const templateResult = {
+    source_file: basename(absPath),
+    format,
+    document_class: extractDocumentClass(content),
+    packages: extractPackages(content),
+    colors: extractColors(content),
+    section_order: detectSectionOrder(content),
+    layout: extractLayout(content),
+  };
+
+  const parseOut = `${outDir}/cv-parse-${safeName}-${timestamp}.json`;
+  const templateOut = `${outDir}/cv-template-${safeName}-${timestamp}.json`;
+
+  await writeFile(parseOut, JSON.stringify(result, null, 2), 'utf-8');
+  await writeFile(templateOut, JSON.stringify(templateResult, null, 2), 'utf-8');
+
+  console.log(JSON.stringify({
+    status: 'ok',
+    parse_file: parseOut,
+    template_file: templateOut,
+    format,
+    name,
+    sections: result.meta.sections_found,
+    experience_count: result.experience.length,
+    projects_count: result.projects.length,
+    skills_categories: Object.keys(result.skills).length,
+  }));
+  return result;
+}
+
+const inputPath = process.argv[2];
+if (!inputPath) {
+  console.error('Usage: node parse-latex.mjs <path-to-resume.tex> [output-dir]');
+  process.exit(1);
+}
+
+parseLatex(inputPath, process.argv[3]);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -299,9 +299,90 @@ for (const section of requiredSections) {
   }
 }
 
-// ── 10. VERSION FILE ─────────────────────────────────────────────
+// ── 10. PARSE-LATEX (optional fixture) ───────────────────────────
 
-console.log('\n10. Version file');
+console.log('\n10. parse-latex.mjs');
+
+if (fileExists('resume.tex') && fileExists('output')) {
+  const parseOut = run('node', ['parse-latex.mjs', 'resume.tex', 'output']);
+  if (parseOut) {
+    try {
+      const summary = JSON.parse(parseOut);
+      const parsed = JSON.parse(readFile(join('output', summary.parse_file.split('/').pop())));
+      const skillKeys = Object.keys(parsed.skills || {});
+      const hasMalformedKey = skillKeys.some(k => /tabularx|textwidth|\\\\/.test(k));
+      if (skillKeys.length >= 6 && !hasMalformedKey && parsed.skills['AI / ML']?.length >= 5) {
+        pass(`parse-latex skills: ${skillKeys.length} categories, AI / ML OK`);
+      } else {
+        fail(`parse-latex skills malformed: keys=${skillKeys.join(', ')}`);
+      }
+      if (parsed.experience?.length >= 2 && parsed.projects?.length >= 1) {
+        pass(`parse-latex sections: ${parsed.experience.length} jobs, ${parsed.projects.length} projects`);
+      } else {
+        fail('parse-latex missing experience/projects');
+      }
+    } catch (e) {
+      fail(`parse-latex output invalid: ${e.message}`);
+    }
+  } else {
+    fail('parse-latex.mjs crashed on resume.tex');
+  }
+} else {
+  warn('resume.tex or output/ not present — skipping parse-latex integration test');
+}
+
+// ── 11. LATEX PIPELINE (write + optional compile) ───────────────
+
+console.log('\n11. LaTeX pipeline (write-latex / compile-latex)');
+
+if (fileExists('resume.tex') && fileExists('output')) {
+  const parseOut = run('node', ['parse-latex.mjs', 'resume.tex', 'output']);
+  if (parseOut) {
+    try {
+      const summary = JSON.parse(parseOut);
+      const parseFile = join('output', summary.parse_file.split('/').pop());
+      const outTex = join('output', 'cv-test-roundtrip.tex');
+      const writeOut = run('node', ['write-latex.mjs', 'resume.tex', parseFile, outTex]);
+      if (writeOut) {
+        const written = JSON.parse(writeOut);
+        const texContent = readFile(outTex);
+        if (texContent.includes('\\item') && texContent.includes('\\section*{Professional Experience}')) {
+          pass('write-latex produces valid experience itemize');
+        } else {
+          fail('write-latex output missing expected structure');
+        }
+      } else {
+        fail('write-latex.mjs crashed');
+      }
+
+      const compileOut = run('node', ['compile-latex.mjs', outTex, join('output', 'cv-test-roundtrip.pdf')]);
+      if (compileOut) {
+        const compiled = JSON.parse(compileOut);
+        if (compiled.compiled && compiled.pdf?.path) {
+          pass(`compile-latex PDF OK (${compiled.engine}, ${compiled.pdf.sizeKB} KB)`);
+        } else {
+          warn(`compile-latex failed: ${compiled.compileError || 'unknown'}`);
+        }
+      } else {
+        warn('compile-latex skipped (no tectonic/pdflatex or compile error)');
+      }
+
+      if (fileExists('modes/latex-tex.md')) {
+        pass('modes/latex-tex.md exists');
+      } else {
+        fail('modes/latex-tex.md missing');
+      }
+    } catch (e) {
+      fail(`LaTeX pipeline test error: ${e.message}`);
+    }
+  }
+} else {
+  warn('resume.tex or output/ missing — skipping LaTeX pipeline tests');
+}
+
+// ── 12. VERSION FILE ─────────────────────────────────────────────
+
+console.log('\n12. Version file');
 
 if (fileExists('VERSION')) {
   const version = readFile('VERSION').trim();

--- a/write-latex.mjs
+++ b/write-latex.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+
+/**
+ * write-latex.mjs — Reconstruct tailored .tex from original template + JSON content
+ *
+ * Replaces ONLY bullet text and skill values — preserves layout, colors, tabularx, lrbox.
+ *
+ * Usage:
+ *   node write-latex.mjs <original.tex> <tailored.json> [output.tex]
+ */
+
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { resolve, dirname, basename } from 'path';
+
+function detectFormat(content) {
+  if (/\\resumeSubheading/.test(content) || /\\resumeItem\b/.test(content)) return 'resumeSubheading';
+  if (/\\begin\{tabularx\}/.test(content) && /\\begin\{itemize\}/.test(content)) return 'tabularx-itemize';
+  return 'generic';
+}
+
+/** Escape user text for LaTeX body; preserve existing backslash escapes (e.g. \\&). */
+export function escapeLatexText(text) {
+  if (!text) return '';
+  const map = {
+    '&': '\\&',
+    '%': '\\%',
+    '$': '\\$',
+    '#': '\\#',
+    '_': '\\_',
+    '{': '\\{',
+    '}': '\\}',
+    '~': '\\textasciitilde{}',
+    '^': '\\textasciicircum{}',
+  };
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '\\' && i + 1 < text.length) {
+      out += text[i] + text[i + 1];
+      i++;
+      continue;
+    }
+    out += map[text[i]] ?? text[i];
+  }
+  return out;
+}
+
+function replaceItemizeBullets(itemizeBlock, bullets) {
+  if (!bullets?.length) return itemizeBlock;
+  let i = 0;
+  return itemizeBlock.replace(/^(\s*\\item(?:\[[^\]]*\])?)\s*(.*)$/gm, (match, itemCmd) => {
+    if (i >= bullets.length) return match;
+    return `${itemCmd} ${escapeLatexText(bullets[i++])}`;
+  });
+}
+
+/** Match itemize blocks to JSON entries via \\textbf{Name} in the preceding tabularx row. */
+function replaceSectionEntriesByName(fullContent, sectionRe, entries, getKey) {
+  const m = fullContent.match(sectionRe);
+  if (!m || !entries?.length) return fullContent;
+
+  const header = m[0].match(/^\\section\*?\{[^}]+\}/)?.[0] || '';
+  const bodyStart = m.index + header.length;
+  const bodyEnd = m.index + m[0].length;
+  let body = fullContent.slice(bodyStart, bodyEnd);
+
+  const entryMap = new Map();
+  for (const e of entries) {
+    const k = getKey(e);
+    if (k) entryMap.set(k, e);
+  }
+
+  body = body.replace(
+    /\\begin\{tabularx\}[\s\S]*?\\end\{tabularx\}[\s\S]*?\\begin\{itemize\}[\s\S]*?\\end\{itemize\}/g,
+    (chunk) => {
+      const nameM = chunk.match(/\\textbf\{([^}]+)\}/);
+      if (!nameM) return chunk;
+      const entry = entryMap.get(nameM[1].trim());
+      if (!entry?.bullets?.length) return chunk;
+      return chunk.replace(/\\begin\{itemize\}[\s\S]*?\\end\{itemize\}/, (iz) =>
+        replaceItemizeBullets(iz, entry.bullets)
+      );
+    }
+  );
+
+  return fullContent.slice(0, bodyStart) + body + fullContent.slice(bodyEnd);
+}
+
+function parseSkillCategory(cell) {
+  const lines = cell.split('\n').map(l => l.trim()).filter(Boolean);
+  const raw = lines.length > 1 ? lines[lines.length - 1] : cell;
+  return raw
+    .replace(/\\[a-zA-Z]+\*?(?:\[[^\]]*\])?\{[^}]*\}/g, '')
+    .replace(/[{}>@]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function replaceSkillsTabularx(tex, skills) {
+  if (!skills || Object.keys(skills).length === 0) return tex;
+
+  const sectionRe =
+    /\\section\*?\{(?:Technical\s+)?[Ss]kills?\}[\s\S]*?(?=\\section\*?\{|\\end\{document\})/i;
+  const m = tex.match(sectionRe);
+  if (!m) return tex;
+
+  const section = m[0];
+  const newSection = section.replace(
+    /(\\begin\{tabularx\}[^\n]*\n)([\s\S]*?)(\n\\end\{tabularx\})/,
+    (_, begin, body, end) => {
+      const rows = body.split('\\\\');
+      const newRows = rows.map((row) => {
+        if (!row.includes('&')) return row;
+        const parts = row.split('&');
+        const cat = parseSkillCategory(parts[0]);
+        if (!cat || !skills[cat]) return row;
+        const vals = skills[cat].join(', ');
+        const pad = parts[0].match(/\n(\s*)/)?.[1] || '  ';
+        return `${parts[0].trimEnd()} & ${vals} `;
+      });
+      return begin + newRows.join(' \\\\\n') + end;
+    }
+  );
+
+  return tex.slice(0, m.index) + newSection + tex.slice(m.index + section.length);
+}
+
+function replaceResumeItemBlock(block, bullets) {
+  if (!bullets?.length) return block;
+  let i = 0;
+  return block.replace(/\\resumeItem\{([^}]*)\}/g, (match, old) => {
+    if (i >= bullets.length) return match;
+    return `\\resumeItem{${escapeLatexText(bullets[i++])}}`;
+  });
+}
+
+function writeResumeSubheading(tex, data) {
+  let result = tex;
+
+  if (data.experience?.length) {
+    const re =
+      /\\resumeSubheading\{([^}]+)\}\{([^}]+)\}\{([^}]+)\}\{([^}]+)\}([\s\S]*?)(?=\\resumeSubheading|\\resumeProjectHeading|\\resumeSubHeadingListEnd)/g;
+    let idx = 0;
+    result = result.replace(re, (full, _c, _d, _r, _l, tail) => {
+      const job = data.experience[idx++];
+      if (!job?.bullets?.length) return full;
+      const head = full.slice(0, full.length - tail.length);
+      return head + replaceResumeItemBlock(tail, job.bullets);
+    });
+  }
+
+  if (data.projects?.length) {
+    const re =
+      /\\resumeProjectHeading\{([^}]+)\}\{([^}]+)\}([\s\S]*?)(?=\\resumeProjectHeading|\\section|\\resumeSubHeadingListEnd)/g;
+    let idx = 0;
+    result = result.replace(re, (full, _n, _d, tail) => {
+      const proj = data.projects[idx++];
+      if (!proj?.bullets?.length) return full;
+      const head = full.slice(0, full.length - tail.length);
+      return head + replaceResumeItemBlock(tail, proj.bullets);
+    });
+  }
+
+  if (data.skills && Object.keys(data.skills).length > 0) {
+    const skillLines = Object.entries(data.skills)
+      .map(([cat, vals]) => `    \\textbf{${cat}}{: ${vals.join(', ')}} \\\\`)
+      .join('\n');
+    result = result.replace(
+      /\\section\{Technical Skills\}[\s\S]*?(?=\\section\{)/,
+      (block) => {
+        const header = block.match(/^\\section\{Technical Skills\}/)?.[0] || '\\section{Technical Skills}';
+        return `${header}\n\n${skillLines}\n\n`;
+      }
+    );
+  }
+
+  return result;
+}
+
+function writeTabularxItemize(tex, data) {
+  let result = tex;
+
+  result = replaceSectionEntriesByName(
+    result,
+    /\\section\*?\{(?:Professional\s+)?[Ee]xperience\}[\s\S]*?(?=\\section\*?\{)/i,
+    data.experience,
+    (e) => e.company
+  );
+
+  result = replaceSectionEntriesByName(
+    result,
+    /\\section\*?\{[Pp]rojects?\}[\s\S]*?(?=\\section\*?\{)/i,
+    data.projects,
+    (e) => e.name
+  );
+
+  result = replaceSkillsTabularx(result, data.skills);
+
+  return result;
+}
+
+export async function writeLatex(originalPath, jsonPath, outputPath = null) {
+  const absOrig = resolve(originalPath);
+  const absJson = resolve(jsonPath);
+
+  const [tex, jsonRaw] = await Promise.all([
+    readFile(absOrig, 'utf-8'),
+    readFile(absJson, 'utf-8'),
+  ]);
+
+  let data;
+  try {
+    data = JSON.parse(jsonRaw);
+  } catch (err) {
+    console.error(`Invalid JSON in ${absJson}: ${err.message}`);
+    process.exit(1);
+  }
+
+  const format = data.meta?.format_detected || detectFormat(tex);
+  let out =
+    format === 'resumeSubheading' ? writeResumeSubheading(tex, data) : writeTabularxItemize(tex, data);
+
+  const outDir = outputPath
+    ? resolve(dirname(outputPath))
+    : resolve(dirname(absOrig), 'output');
+  if (!existsSync(outDir)) await mkdir(outDir, { recursive: true });
+
+  const outFile = outputPath
+    ? resolve(outputPath)
+    : resolve(outDir, `cv-tailored-${basename(absOrig, '.tex')}.tex`);
+
+  await writeFile(outFile, out, 'utf-8');
+
+  const summary = {
+    status: 'ok',
+    source_tex: basename(absOrig),
+    json_file: basename(absJson),
+    output_tex: outFile,
+    format,
+    experience_jobs: data.experience?.length ?? 0,
+    projects: data.projects?.length ?? 0,
+    skills_categories: Object.keys(data.skills || {}).length,
+  };
+
+  console.log(JSON.stringify(summary));
+  return { outFile, data };
+}
+
+const originalPath = process.argv[2];
+const jsonPath = process.argv[3];
+const outputPath = process.argv[4];
+
+if (!originalPath || !jsonPath) {
+  console.error('Usage: node write-latex.mjs <original.tex> <tailored.json> [output.tex]');
+  process.exit(1);
+}
+
+writeLatex(originalPath, jsonPath, outputPath);


### PR DESCRIPTION
Lets users with existing `.tex` CVs tailor bullets while preserving their template. Adds `latex-tex` mode and `cv.tex` / `resume.tex` source priority over `cv.md`.

## What does this PR do?

Adds a universal LaTeX CV pipeline for candidates who already use their own LaTeX template (e.g. tabularx + itemize), separate from the existing `cv.md` → `templates/cv-template.tex` flow:

- **`parse-latex.mjs`** — Parses `.tex` into structured JSON (contact, experience, projects, skills, education) plus template metadata (packages, layout, section order). Supports tabularx-itemize and resumeSubheading formats.
- **`write-latex.mjs`** — Merges tailored JSON back into the **original** `.tex` (bullets and skill values only; layout/colors preserved). Matches experience/projects by company/name, not list index.
- **`compile-latex.mjs`** — Compiles any valid `.tex` to PDF via tectonic or pdflatex (no career-ops template validation).
- **`latex-pipeline.mjs`** — Orchestrates parse → write → compile for scripting/tests.
- **`modes/latex-tex.md`** — Agent mode: JD tailoring rules (same ethics as `pdf` — never invent skills).
- **`AGENTS.md` + skill router** — CV source priority: `resume.tex` / `cv.tex` > `cv.md`; documents pipeline commands.
- **`examples/resume-tabularx.example.tex`** — Fictional sample CV for integration tests (no real PII).
- **`test-all.mjs`** — Parse, write, and optional compile checks against the example file.

## Related issue

Fixes #695 


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Testing

```bash
node test-all.mjs --quick
node parse-latex.mjs examples/resume-tabularx.example.tex output/
node write-latex.mjs examples/resume-tabularx.example.tex output/cv-parse-*.json output/cv-test.tex
node compile-latex.mjs output/cv-test.tex output/cv-test.pdf   # requires tectonic or pdflatex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native LaTeX CV/resume support with automatic parsing, tailoring, and PDF compilation
  * New `latex-tex` workflow mode for LaTeX-based resume templates (prioritized when `.tex` files exist)
  * Automatic LaTeX engine detection for PDF generation

* **Documentation**
  * Updated career-ops workflow documentation to cover LaTeX CV processing and pipeline orchestration

* **Tests**
  * Added LaTeX parsing and pipeline integration test coverage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->