### PR TITLE
feat: add Indeed Ireland scanner (scan-indeed.py)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `data/follow-ups.md` | Follow-up history tracker |
 | `scan.mjs` | Zero-token portal scanner — hits Greenhouse/Ashby/Lever APIs directly, zero LLM cost |
+| `scan-indeed.py` | Indeed Ireland scanner — uses Scrapling to bypass Cloudflare, applies title_filter from portals.yml |
 | `check-liveness.mjs` | Job posting liveness checker |
 | `liveness-core.mjs` | Shared liveness logic (expired signals win over generic Apply text) |
 | `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`). Blocks A-F + G (Posting Legitimacy). Header includes `**Legitimacy:** {tier}`. |

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -18,6 +18,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run rollback` | `update-system.mjs rollback` | Rollback last update |
 | `npm run liveness` | `check-liveness.mjs` | Test if job URLs are still active |
 | `npm run scan` | `scan.mjs` | Zero-token portal scanner |
+| `python3 scan-indeed.py` | `scan-indeed.py` | Indeed Ireland scanner (Scrapling) |
 
 ---
 
@@ -187,3 +188,21 @@ npm run scan
 ```
 
 **Exit codes:** `0` scan completed, `1` configuration error or no portals.yml found.
+
+---
+
+## scan-indeed
+
+Indeed Ireland scanner using Scrapling to bypass Cloudflare bot protection. Searches Indeed for configured queries, applies `title_filter` from `portals.yml`, deduplicates against existing history, and appends new offers to `data/pipeline.md` + `data/scan-history.tsv`.
+
+```bash
+python3 scan-indeed.py              # scan all queries, 2 pages each
+python3 scan-indeed.py --dry-run    # preview without writing files
+python3 scan-indeed.py --pages 3    # scan up to 3 pages per query
+```
+
+**Query source:** Reads `indeed_queries` from `portals.yml`. If absent, auto-generates queries from `title_filter.positive` keywords.
+
+**Dependencies:** `scrapling`, `pyyaml` (Python).
+
+**Exit codes:** `0` scan completed, `1` no queries configured.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -4,6 +4,7 @@
 
 - [Claude Code](https://claude.ai/code) installed and configured
 - Node.js 18+ (for PDF generation and utility scripts)
+- (Optional) Python 3.10+ with `scrapling` and `pyyaml` (for Indeed Ireland scanner)
 - (Optional) Go 1.21+ (for the dashboard TUI)
 
 ## Quick Start (5 steps)

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -122,11 +122,28 @@ After detecting archetype, read `modes/_profile.md` for the user's specific fram
 | WebSearch | Comp research, trends, company culture, LinkedIn contacts, fallback for JDs |
 | WebFetch | Fallback for extracting JDs from static pages |
 | Playwright | Verify offers (browser_navigate + browser_snapshot). **NEVER 2+ agents with Playwright in parallel.** |
+| Scrapling Fetcher | Bypass Cloudflare/bot protection for Indeed and protected career pages. Python: `from scrapling import Fetcher` |
+| Scrapling StealthyFetcher | Full real-browser rendering for heavy bot detection. Python: `from scrapling import StealthyFetcher` |
+| Jina Reader | Clean markdown extraction from public pages: `https://r.jina.ai/{url}`. Free tier. Blocked by Cloudflare sites. |
+| Agent Reach | Social aggregation: GitHub, YouTube, RSS, X/Twitter, Bilibili. Python: `from agent_reach import AgentReach` |
 | Read | cv.md, _profile.md, article-digest.md, cv-template.html |
 | Write | Temporary HTML for PDF, applications.md, reports .md |
 | Edit | Update tracker |
 | Canva MCP | Optional visual CV generation. Duplicate base design, edit text, export PDF. Requires `cv.canva_resume_design_id` in profile.yml. |
 | Bash | `node generate-pdf.mjs` |
+
+#### Web Scraping Escalation Ladder
+
+Use the minimal viable tool for each target:
+
+| Level | Tool | When to use |
+|-------|------|-------------|
+| 1 | `web_fetch` | Static/public pages, API endpoints, no bot protection |
+| 2 | Jina Reader (`r.jina.ai`) | Clean reader extraction from public pages. Blocked by Cloudflare-protected sites |
+| 3 | Scrapling `Fetcher` | JS-rendered pages, medium bot protection (Indeed, most career sites) |
+| 4 | Scrapling `StealthyFetcher` | Heavy bot detection, Cloudflare challenges, real browser needed |
+| 5 | CloakBrowser (`from cloakbrowser import launch`) | Nuclear option: 58 C++ source-level patches, passes Cloudflare Turnstile + reCAPTCHA 0.9, `humanize=True` for behavioral detection. Drop-in Playwright replacement (`pip install cloakbrowser`) |
+| 6 | Agent Reach | Social platforms (YouTube, GitHub, X, Reddit, RSS) |
 
 ### Time-to-offer priority
 - Working demo + metrics > perfection

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
     "scan": "node scan.mjs",
+    "scan:indeed": "python3 scan-indeed.py",
     "gemini:eval": "node gemini-eval.mjs"
   },
   "keywords": [

--- a/scan-indeed.py
+++ b/scan-indeed.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+scan-indeed.py — Indeed Ireland job scanner using Scrapling.
+
+Searches ie.indeed.com (Ireland) for configured queries, applies title
+filters from portals.yml, deduplicates against scan-history.tsv +
+pipeline.md + applications.md, and appends new offers to pipeline.md +
+scan-history.tsv.
+
+Uses Scrapling Fetcher to bypass Cloudflare bot protection.
+Fallback: swap to StealthyFetcher or CloakBrowser if Indeed upgrades
+detection (see modes/_shared.md escalation ladder).
+
+Usage:
+    python3 scan-indeed.py                # scan all queries
+    python3 scan-indeed.py --dry-run      # preview without writing
+    python3 scan-indeed.py --pages 3      # scan up to 3 pages per query
+
+Dependencies:
+    pip install scrapling pyyaml
+"""
+
+import argparse
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+import yaml
+from scrapling import Fetcher
+
+# ── Config ───────────────────────────────────────────────────────────
+
+ROOT = Path(__file__).parent
+PORTALS_PATH = ROOT / "portals.yml"
+SCAN_HISTORY_PATH = ROOT / "data" / "scan-history.tsv"
+PIPELINE_PATH = ROOT / "data" / "pipeline.md"
+APPLICATIONS_PATH = ROOT / "data" / "applications.md"
+BASE_URL = "https://ie.indeed.com"
+
+
+def load_portals():
+    with open(PORTALS_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def load_seen_urls():
+    """Load all URLs already in scan-history, pipeline, and applications."""
+    seen = set()
+    if SCAN_HISTORY_PATH.exists():
+        for line in SCAN_HISTORY_PATH.read_text().splitlines()[1:]:
+            parts = line.split("\t")
+            if parts:
+                seen.add(parts[0])
+    if PIPELINE_PATH.exists():
+        for line in PIPELINE_PATH.read_text().splitlines():
+            m = re.search(r"https?://\S+", line)
+            if m:
+                seen.add(m.group(0).rstrip("|").strip())
+    if APPLICATIONS_PATH.exists():
+        for line in APPLICATIONS_PATH.read_text().splitlines():
+            m = re.search(r"https?://\S+", line)
+            if m:
+                seen.add(m.group(0).rstrip("|").strip())
+    return seen
+
+
+def build_title_filter(portals):
+    """Build filter function from portals.yml title_filter."""
+    tf = portals.get("title_filter", {})
+    positive = [k.lower() for k in tf.get("positive", [])]
+    negative = [k.lower() for k in tf.get("negative", [])]
+
+    def matches(title):
+        lower = title.lower()
+        has_pos = not positive or any(k in lower for k in positive)
+        has_neg = any(k in lower for k in negative)
+        return has_pos and not has_neg
+
+    return matches
+
+
+def get_indeed_queries(portals):
+    """Extract Indeed-specific search queries from portals.yml."""
+    queries = portals.get("indeed_queries", [])
+    if not queries:
+        # Fallback: build from title_filter positive keywords
+        tf = portals.get("title_filter", {})
+        keywords = tf.get("positive", [])
+        # Pick the most specific ones for Indeed search
+        priority = [
+            "Technical Account Manager",
+            "Customer Success Engineer",
+            "Solutions Architect",
+            "AI Engineer",
+            "Customer Engineer",
+            "Support Engineer",
+        ]
+        queries = []
+        for kw in priority:
+            if any(kw.lower() in p.lower() for p in keywords):
+                queries.append({"query": kw, "location": "Dublin", "enabled": True})
+        if not queries and keywords:
+            queries = [{"query": keywords[0], "location": "Dublin", "enabled": True}]
+    return [q for q in queries if q.get("enabled", True)]
+
+
+def _first(selector_list):
+    """Return first element from a css selector result or None."""
+    return selector_list[0] if selector_list else None
+
+
+def scrape_indeed_page(fetcher, query, location, page=0):
+    """Scrape a single Indeed search results page. Returns list of jobs."""
+    start = page * 10
+    url = f"{BASE_URL}/jobs?q={query.replace(' ', '+')}&l={location.replace(' ', '+')}&start={start}"
+    try:
+        resp = fetcher.get(url)
+    except Exception as e:
+        print(f"  ⚠️  Failed to fetch: {e}", file=sys.stderr)
+        return []
+
+    if resp.status != 200:
+        print(f"  ⚠️  HTTP {resp.status} for {url}", file=sys.stderr)
+        return []
+
+    jobs = []
+    cards = resp.css("div.job_seen_beacon") or resp.css("div.jobsearch-ResultsList > div")
+
+    for card in cards:
+        # Extract title
+        title_el = _first(card.css("h2.jobTitle a span")) or _first(card.css("h2 a span"))
+        if not title_el:
+            continue
+        title = title_el.text.strip()
+
+        # Extract link
+        link_el = _first(card.css("h2.jobTitle a")) or _first(card.css("h2 a"))
+        if not link_el:
+            continue
+        href = link_el.attrib.get("href", "")
+        if href.startswith("/"):
+            jk_match = re.search(r"jk=([a-f0-9]+)", href)
+            if jk_match:
+                job_url = f"{BASE_URL}/viewjob?jk={jk_match.group(1)}"
+            else:
+                job_url = f"{BASE_URL}{href}"
+        elif href.startswith("http"):
+            job_url = href
+        else:
+            continue
+
+        # Extract company
+        company_el = _first(card.css("span[data-testid='company-name']")) or _first(card.css("span.companyName"))
+        company = company_el.text.strip() if company_el else "Unknown"
+
+        # Extract location
+        loc_el = _first(card.css("div[data-testid='text-location']")) or _first(card.css("div.companyLocation"))
+        loc = loc_el.text.strip() if loc_el else ""
+
+        jobs.append({
+            "title": title,
+            "url": job_url,
+            "company": company,
+            "location": loc,
+        })
+
+    return jobs
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scan Indeed Ireland for jobs")
+    parser.add_argument("--dry-run", action="store_true", help="Preview without writing")
+    parser.add_argument("--pages", type=int, default=2, help="Pages per query (default: 2)")
+    args = parser.parse_args()
+
+    # Ensure data dir exists
+    (ROOT / "data").mkdir(exist_ok=True)
+
+    portals = load_portals()
+    seen_urls = load_seen_urls()
+    title_filter = build_title_filter(portals)
+    queries = get_indeed_queries(portals)
+
+    if not queries:
+        print("❌ No Indeed queries configured. Add indeed_queries to portals.yml.")
+        sys.exit(1)
+
+    fetcher = Fetcher(auto_match=False)
+    today = date.today().isoformat()
+
+    all_found = []
+    new_jobs = []
+    skipped_title = 0
+    skipped_dup = 0
+
+    print(f"🔍 Indeed Ireland Scanner — {today}")
+    print(f"   Queries: {len(queries)} | Pages/query: {args.pages}")
+    print("━" * 50)
+
+    for q in queries:
+        query_text = q["query"]
+        location = q.get("location", "Dublin")
+        print(f"\n📋 \"{query_text}\" in {location}")
+
+        for page in range(args.pages):
+            jobs = scrape_indeed_page(fetcher, query_text, location, page)
+            if not jobs:
+                break
+            all_found.extend(jobs)
+            print(f"   Page {page + 1}: {len(jobs)} results")
+
+    # Deduplicate within results
+    seen_in_run = set()
+    unique_jobs = []
+    for job in all_found:
+        if job["url"] not in seen_in_run:
+            seen_in_run.add(job["url"])
+            unique_jobs.append(job)
+
+    # Apply filters
+    for job in unique_jobs:
+        if job["url"] in seen_urls:
+            skipped_dup += 1
+            continue
+        if not title_filter(job["title"]):
+            skipped_title += 1
+            # Record in history as skipped
+            if not args.dry_run:
+                if not SCAN_HISTORY_PATH.exists():
+                    SCAN_HISTORY_PATH.write_text("url\tfirst_seen\tportal\ttitle\tcompany\tstatus\n")
+                with open(SCAN_HISTORY_PATH, "a") as f:
+                    f.write(f"{job['url']}\t{today}\tindeed-ie\t{job['title']}\t{job['company']}\tskipped_title\n")
+            continue
+        new_jobs.append(job)
+
+    # Summary
+    print(f"\n{'━' * 50}")
+    print("📊 Results:")
+    print(f"   Found: {len(unique_jobs)} unique")
+    print(f"   Filtered by title: {skipped_title}")
+    print(f"   Already seen: {skipped_dup}")
+    print(f"   New to pipeline: {len(new_jobs)}")
+
+    if new_jobs:
+        print(f"\n✅ New offers:")
+        for job in new_jobs:
+            print(f"   + {job['company']} | {job['title']}")
+
+    if args.dry_run:
+        print("\n⚠️  Dry run — no files written.")
+        return
+
+    # Write to pipeline.md
+    if new_jobs:
+        # Ensure pipeline.md exists
+        if not PIPELINE_PATH.exists():
+            PIPELINE_PATH.write_text("# Pipeline - Pending URLs\n\n\n## Pendientes\n\n")
+
+        with open(PIPELINE_PATH, "a") as f:
+            for job in new_jobs:
+                f.write(f"- [ ] {job['url']} | {job['company']} | {job['title']}\n")
+
+        # Write to scan-history.tsv
+        # Ensure header exists
+        if not SCAN_HISTORY_PATH.exists():
+            SCAN_HISTORY_PATH.write_text("url\tfirst_seen\tportal\ttitle\tcompany\tstatus\n")
+
+        with open(SCAN_HISTORY_PATH, "a") as f:
+            for job in new_jobs:
+                f.write(f"{job['url']}\t{today}\tindeed-ie\t{job['title']}\t{job['company']}\tadded\n")
+
+    print(f"\n→ Run /career-ops pipeline to evaluate new offers.")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -133,6 +133,25 @@ title_filter:
     - "Head"
     - "Director"
 
+# -- Indeed Ireland queries (optional) --
+# Used by scan-indeed.py (Python, requires: pip install scrapling pyyaml).
+# Searches ie.indeed.com with Scrapling to bypass Cloudflare.
+# If this section is absent, scan-indeed.py auto-generates queries from title_filter.positive.
+
+indeed_queries:
+  - query: "Technical Account Manager"
+    location: "Dublin"
+    enabled: true
+  - query: "Customer Success Engineer"
+    location: "Dublin"
+    enabled: true
+  - query: "Solutions Architect"
+    location: "Dublin"
+    enabled: true
+  - query: "AI Engineer"
+    location: "Ireland"
+    enabled: true
+
 # -- Search queries --
 # Each query triggers a WebSearch. Use site: to filter by portal.
 # The scanner extracts title, URL, and company from results.


### PR DESCRIPTION
Closes #720

## What

Adds a Python-based scanner for ie.indeed.com (Ireland) using Scrapling to bypass Cloudflare bot protection. Searches Indeed Ireland for configured queries, applies title_filter from portals.yml, deduplicates against existing history, and appends new offers to pipeline.md + scan-history.tsv.

## Why

The existing `scan.mjs` covers Greenhouse/Ashby/Lever APIs but misses [Indeed Ireland](https://ie.indeed.com) — Ireland's largest job search website and a primary source for local roles. Indeed uses Cloudflare bot protection that blocks standard HTTP clients, so Scrapling is needed.

## Changes

- **New:** `scan-indeed.py` — the scanner script (Python)
- **New:** `npm run scan:indeed` script in package.json
- **New:** `indeed_queries` section in `templates/portals.example.yml`
- **Updated:** `AGENTS.md` — main files table
- **Updated:** `modes/_shared.md` — tools + web scraping escalation ladder
- **Updated:** `docs/SCRIPTS.md` — script reference
- **Updated:** `docs/SETUP.md` — optional Python dependency

## Indeed Bot Protection — Tested Approaches

| Tool | Indeed Result | Notes |
|------|-------------|-------|
| `web_fetch` | ✅ Works | Surprisingly passes for search results |
| Jina Reader | ❌ Blocked | Cloudflare 403 |
| Scrapling `Fetcher` | ✅ Works | **Used in this PR** — fast, lightweight, bypasses Cloudflare |
| Scrapling `StealthyFetcher` | ✅ Works | Fallback if Fetcher stops working (real browser) |
| [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) | ✅ Works | Nuclear fallback — 58 C++ source-level Chromium patches, `humanize=True` |

## Dependencies

- `scrapling` (Python, pip)
- `pyyaml` (Python, pip)

## Usage

```bash
python3 scan-indeed.py              # scan all queries, 2 pages each
python3 scan-indeed.py --dry-run    # preview without writing files
python3 scan-indeed.py --pages 3    # scan up to 3 pages per query
npm run scan:indeed                 # same via npm
```

## Tested

- Verified against live ie.indeed.com (38 results, 18 passed filters)
- Dedup against existing scan-history/pipeline/applications works
- `--dry-run` mode works without writing files

## Security

Scanned with [ASH v3.2.5](https://github.com/awslabs/automated-security-helper) (Bandit + Semgrep + detect-secrets): 0 findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Indeed Ireland job scanner that fetches and filters job listings, dedupes against scan history, and appends new matches to the pipeline.
  * CLI support for dry-run and pagination; script exposed via a package script.

* **Documentation**
  * Updated setup prerequisites for optional Python tooling.
  * Added scanner usage docs, query configuration guidance, and a web-scraping escalation guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->