### PR TITLE
fix(patterns): parse header-style and "Detected archetype" archetypes

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -225,14 +225,18 @@ function parseReport(reportPath) {
   const plain = content.replace(/\*\*/g, '');
 
   // Extract Block A table (Role Summary) — works with both EN and ES headers
-  const blockARegex = /\|\s*(?:Archetype|Arquetipo)\s*\|\s*(.*?)\s*\|/i;
+  // Archetype cell may be labeled "Archetype", "Arquetipo", or "Detected archetype" (drift from EN translation).
+  const blockARegex = /\|\s*(?:Detected\s+)?(?:Archetype|Arquetipo)\s*\|\s*(.*?)\s*\|/i;
   const seniorityRegex = /\|\s*(?:Seniority|Nivel|Level)\s*\|\s*(.*?)\s*\|/i;
   const remoteRegex = /\|\s*(?:Remote|Remoto|Location)\s*\|\s*(.*?)\s*\|/i;
   const teamRegex = /\|\s*(?:Team|Team size|Equipo)\s*\|\s*(.*?)\s*\|/i;
   const compRegex = /\|\s*(?:Comp|Salary|Salario|Listed salary)\s*\|\s*(.*?)\s*\|/i;
   const domainRegex = /\|\s*(?:Domain|Dominio|Industry)\s*\|\s*(.*?)\s*\|/i;
 
-  const archMatch = plain.match(blockARegex);
+  // Fallback: report header field `Archetype: ...` or `Arquetipo: ...` (newer reports use this).
+  const headerArchRegex = /^(?:Archetype|Arquetipo):\s*(.+?)$/im;
+
+  const archMatch = plain.match(blockARegex) || plain.match(headerArchRegex);
   if (archMatch && !report.archetype) report.archetype = archMatch[1].trim();
 
   const senMatch = plain.match(seniorityRegex);


### PR DESCRIPTION
## Problem

`analyze-patterns.mjs` extracts the report archetype only from the Block A table cell `| Archetype |`. Two real-world report shapes go unmatched:

1. **Header-field form** — the large majority of generated reports place the archetype in a header field (`Archetype: ...`) rather than the Block A table.
2. **`| Detected archetype |`** — EN-translation drift produces this table label instead of `| Archetype |`.

In both cases `report.archetype` stays `null`, so the archetype breakdown in the patterns analysis collapses every report into `"Unknown"` and the "best archetype" recommendation is unusable.

## Fix

- Widen `blockARegex` to accept an optional `Detected ` prefix.
- Add a `headerArchRegex` fallback (`^Archetype: ...` / `^Arquetipo: ...`, case-insensitive, multiline) used when the table match misses.
- Table match still takes precedence over the header fallback.

No behavior change for reports already using `| Archetype |`.

## Testing

- `node -c analyze-patterns.mjs` — syntax OK.
- Verified against a local report corpus: header-style reports that previously yielded `Unknown` now resolve to their actual archetype; existing table-format reports are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archetype detection in reports to tolerate optional prefixes (e.g., "Detected") and variations across English/Spanish formats.
  * Added a fallback that extracts archetype information from header lines when table-based parsing fails.
  * Ensures the report's archetype field is populated when a valid match is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->