### PR TITLE
fix(update-system): bootstrap liveness-browser.mjs for v1.7→v1.8 upgrades

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -66,6 +66,7 @@ const SYSTEM_PATHS = [
   'doctor.mjs',
   'check-liveness.mjs',
   'liveness-core.mjs',
+  'liveness-browser.mjs',
   'analyze-patterns.mjs',
   'followup-cadence.mjs',
   'gemini-eval.mjs',
@@ -285,7 +286,7 @@ async function apply() {
     // local v1.6.x SYSTEM_PATHS didn't include it, so `.agents/` was never
     // checked out while `.claude/skills/` was updated to symlink into it.
     // See: https://github.com/santifer/career-ops/issues/649
-    const BOOTSTRAP_PATHS = ['.agents/', 'providers/'];
+    const BOOTSTRAP_PATHS = ['.agents/', 'providers/', 'liveness-browser.mjs'];
     for (const path of BOOTSTRAP_PATHS) {
       if (SYSTEM_PATHS.includes(path)) continue; // already in main loop
       try {


### PR DESCRIPTION
## Summary

Third regression in the v1.8.0 SYSTEM_PATHS coverage gap (after #654 / #696):

- #487 added `liveness-browser.mjs` as a shared Playwright probe used by both `check-liveness.mjs` and `scan.mjs --verify`
- Neither SYSTEM_PATHS nor BOOTSTRAP_PATHS were updated to track it
- Result: v1.7.x → v1.8.0 upgrades report success (\`Updated 55 system paths\`) but then crash on the first invocation of `check-liveness.mjs` or `scan.mjs --verify` with \`ERR_MODULE_NOT_FOUND\`

Adds `'liveness-browser.mjs'` to both lists. Same pattern as #696 for `providers/`.

## Closes

- Closes #704 (precise reproduction by @PHcz)

## Test plan

- [x] `node test-all.mjs` — 66 passed, 0 failed
- [x] `node --check update-system.mjs`
- [ ] `node update-system.mjs apply` on a v1.7.x checkout → `liveness-browser.mjs` materializes
- [ ] `node check-liveness.mjs <any-url>` runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system update handling to ensure all system components are properly updated during system-only updates and version transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->