### PR TITLE
feat(batch): add skip-pdf and remove bc math

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -400,7 +400,7 @@ process_offer() {
       if awk "BEGIN{exit !($score < $MIN_SCORE)}"; then
         update_state "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries"
         echo "    ⏭️  Skipped (score: $score < min-score: $MIN_SCORE)"
-        continue
+        return
       fi
     fi
 

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -457,7 +457,7 @@ print_summary() {
 
   if (( score_count > 0 )); then
     local avg
-    avg=$(awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{if (count <= 0) { print "N/A"; exit } raw=sprintf("%.12f", sum / count); split(raw, parts, "."); printf "%s.%s", parts[1], substr(parts[2] "0", 1, 1)}')
+    avg=$(awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{printf "%.1f", sum / count}')
     echo "Average score: $avg/5 ($score_count scored)"
   fi
 }

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -33,6 +33,7 @@ RETRY_FAILED=false
 START_FROM=0
 MAX_RETRIES=2
 MIN_SCORE=0
+SKIP_PDF=false
 MODEL=""  # empty = let claude -p use the Claude Max default
 
 usage() {
@@ -49,6 +50,7 @@ Options:
   --start-from N       Start from offer ID N (skip earlier IDs)
   --max-retries N      Max retry attempts per offer (default: 2)
   --min-score N        Skip PDF/tracker for offers scoring below N (default: 0 = off)
+  --skip-pdf           Workers skip PDF generation (report + tracker only); generate PDFs later with /career-ops pdf
   --model NAME         Claude model passed to `claude -p --model` (default:
                        unset = Claude Max default). Use a cheaper model for
                        large batches, e.g. `--model claude-sonnet-4-6`.
@@ -85,6 +87,7 @@ while [[ $# -gt 0 ]]; do
     --start-from) START_FROM="$2"; shift 2 ;;
     --max-retries) MAX_RETRIES="$2"; shift 2 ;;
     --min-score) MIN_SCORE="$2"; shift 2 ;;
+    --skip-pdf) SKIP_PDF=true; shift ;;
     --model) MODEL="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1"; usage; exit 1 ;;
@@ -360,6 +363,11 @@ process_offer() {
     -e "s|{{ID}}|${esc_id}|g" \
     "$PROMPT_FILE" > "$resolved_prompt"
 
+  # Inject skip-pdf override if flag is set
+  if [[ "$SKIP_PDF" == "true" ]]; then
+    printf '\n\n**OVERRIDE: Skip Step 4 (PDF generation). Do NOT generate a PDF or read cv-template.html. Use `❌` for the PDF column in the tracker line.**\n' >> "$resolved_prompt"
+  fi
+
   # Launch claude -p worker.
   # Model defaults to the Claude Max subscription default unless --model was
   # passed. Building the command in an array keeps quoting safe regardless.
@@ -388,8 +396,8 @@ process_offer() {
     fi
 
     # Check min-score gate
-    if [[ "$score" != "-" && -n "$score" ]] && (( $(echo "$MIN_SCORE > 0" | bc -l) )); then
-      if (( $(echo "$score < $MIN_SCORE" | bc -l) )); then
+    if [[ "$score" != "-" && -n "$score" ]] && awk "BEGIN{exit !($MIN_SCORE > 0)}"; then
+      if awk "BEGIN{exit !($score < $MIN_SCORE)}"; then
         update_state "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries"
         echo "    ⏭️  Skipped (score: $score < min-score: $MIN_SCORE)"
         continue
@@ -513,8 +521,8 @@ main() {
         continue
       fi
     else
-      # Skip completed offers
-      if [[ "$status" == "completed" ]]; then
+      # Skip completed or explicitly skipped offers
+      if [[ "$status" == "completed" || "$status" == "skipped" ]]; then
         continue
       fi
       # Skip failed offers that hit retry limit (unless --retry-failed)

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -444,7 +444,7 @@ print_summary() {
     case "$sstatus" in
       completed) completed=$((completed + 1))
         if [[ "$sscore" != "-" && -n "$sscore" ]]; then
-          score_sum=$(echo "$score_sum + $sscore" | bc 2>/dev/null || echo "$score_sum")
+          score_sum=$(awk -v sum="$score_sum" -v score="$sscore" 'BEGIN{print sum + score}')
           score_count=$((score_count + 1))
         fi
         ;;
@@ -457,7 +457,7 @@ print_summary() {
 
   if (( score_count > 0 )); then
     local avg
-    avg=$(echo "scale=1; $score_sum / $score_count" | bc 2>/dev/null || echo "N/A")
+    avg=$(awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{if (count <= 0) { print "N/A"; exit } raw=sprintf("%.12f", sum / count); split(raw, parts, "."); printf "%s.%s", parts[1], substr(parts[2] "0", 1, 1)}')
     echo "Average score: $avg/5 ($score_count scored)"
   fi
 }


### PR DESCRIPTION
Continuation of #735 / #736 with the CodeRabbit follow-up applied.

Context:
- #735 could not be updated directly from this account: pushing to FrameAutomata/career-ops returned 403 even though the PR reports maintainerCanModify=true.
- This branch preserves the original #735 commit stack and adds the final CodeRabbit-requested fix for remaining bc usage in summary score math.
- The branch is published from wyl2607/career-ops so maintainers have a reachable patch path without rewriting the contributor fork.

Changes:
- Adds --skip-pdf support to batch/batch-runner.sh.
- Replaces min-score bc comparisons with awk.
- Replaces invalid continue inside process_offer with return.
- Replaces remaining summary score bc arithmetic with awk.

Validation:
- bash -n batch/batch-runner.sh
- git diff --check 1a6686da0e0bc6a86405499d0d9bd6c1b1ba48b3..bfb27190167bb0051ffdab627c08df6a1de45605
- node test-all.mjs --quick -> 87 passed, 0 failed, 33 existing personal-data warnings

Draft note: this overlaps #735. Maintainers should merge either the original contributor PR after it is updated, or this continuation branch, not both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--skip-pdf` flag to skip PDF generation in batch runs and mark PDFs with ❌ in tracker output.

* **Changes**
  * Offers below minimum score are consistently marked as skipped; score gating and aggregation are more reliable.
  * Batch summaries show a fixed one-decimal average score.
  * Normal runs treat skipped offers like completed ones when deciding skips; retry behavior for failed offers is unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->