### PR TITLE
fix(batch): remove bc from score math

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -388,8 +388,8 @@ process_offer() {
     fi
 
     # Check min-score gate
-    if [[ "$score" != "-" && -n "$score" ]] && awk "BEGIN{exit !($MIN_SCORE > 0)}"; then
-      if awk "BEGIN{exit !($score < $MIN_SCORE)}"; then
+    if [[ "$score" != "-" && -n "$score" ]] && awk -v min="$MIN_SCORE" 'BEGIN{exit !(min > 0)}'; then
+      if awk -v score="$score" -v min="$MIN_SCORE" 'BEGIN{exit !(score < min)}'; then
         update_state "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries"
         echo "    ⏭️  Skipped (score: $score < min-score: $MIN_SCORE)"
         return
@@ -449,7 +449,7 @@ print_summary() {
 
   if (( score_count > 0 )); then
     local avg
-    avg=$(awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{if (count <= 0) { print "N/A"; exit } raw=sprintf("%.12f", sum / count); split(raw, parts, "."); frac=substr(parts[2] "0", 1, 1); if (parts[1] == "0" && frac == "0") print "0"; else if (parts[1] == "0") printf ".%s", frac; else printf "%s.%s", parts[1], frac}')
+    avg=$(awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{printf "%.1f", sum / count}')
     echo "Average score: $avg/5 ($score_count scored)"
   fi
 }

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -388,11 +388,11 @@ process_offer() {
     fi
 
     # Check min-score gate
-    if [[ "$score" != "-" && -n "$score" ]] && (( $(echo "$MIN_SCORE > 0" | bc -l) )); then
-      if (( $(echo "$score < $MIN_SCORE" | bc -l) )); then
+    if [[ "$score" != "-" && -n "$score" ]] && awk "BEGIN{exit !($MIN_SCORE > 0)}"; then
+      if awk "BEGIN{exit !($score < $MIN_SCORE)}"; then
         update_state "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries"
         echo "    ⏭️  Skipped (score: $score < min-score: $MIN_SCORE)"
-        continue
+        return
       fi
     fi
 
@@ -436,7 +436,7 @@ print_summary() {
     case "$sstatus" in
       completed) completed=$((completed + 1))
         if [[ "$sscore" != "-" && -n "$sscore" ]]; then
-          score_sum=$(echo "$score_sum + $sscore" | bc 2>/dev/null || echo "$score_sum")
+          score_sum=$(awk -v sum="$score_sum" -v score="$sscore" 'BEGIN{print sum + score}')
           score_count=$((score_count + 1))
         fi
         ;;
@@ -449,7 +449,7 @@ print_summary() {
 
   if (( score_count > 0 )); then
     local avg
-    avg=$(echo "scale=1; $score_sum / $score_count" | bc 2>/dev/null || echo "N/A")
+    avg=$(awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{if (count <= 0) { print "N/A"; exit } raw=sprintf("%.12f", sum / count); split(raw, parts, "."); frac=substr(parts[2] "0", 1, 1); if (parts[1] == "0" && frac == "0") print "0"; else if (parts[1] == "0") printf ".%s", frac; else printf "%s.%s", parts[1], frac}')
     echo "Average score: $avg/5 ($score_count scored)"
   fi
 }

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -449,7 +449,22 @@ print_summary() {
 
   if (( score_count > 0 )); then
     local avg
-    avg=$(awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{printf "%.1f", sum / count}')
+    # Preserve bc scale=1 display semantics: truncate, and omit the leading zero for fractions.
+    avg=$(
+      awk -v sum="$score_sum" -v count="$score_count" '
+        BEGIN {
+          split(sprintf("%.12f", sum / count), parts, ".")
+          frac = substr(parts[2] "0", 1, 1)
+          if (parts[1] == "0" && frac == "0") {
+            print "0"
+          } else if (parts[1] == "0") {
+            printf ".%s", frac
+          } else {
+            printf "%s.%s", parts[1], frac
+          }
+        }
+      '
+    )
     echo "Average score: $avg/5 ($score_count scored)"
   fi
 }


### PR DESCRIPTION
## Summary
- replace bc-based min-score and summary arithmetic with awk
- pass score thresholds via awk -v instead of shell interpolation
- preserve bc scale=1 average display semantics without requiring bc

## Verification
- node update-system.mjs check
- bash -n batch/batch-runner.sh
- npm run verify
- ./batch/batch-runner.sh --dry-run
- awk parity probes for 0, 4.5, 4.0, .5, .1, and 2.4 average displays

Supersedes the closed temporary PRs #741 and #742 with the review feedback incorporated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected offer skipping logic in batch processing to ensure proper execution flow.

* **Refactor**
  * Improved performance of score calculations and numeric comparisons in batch operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->