### PR TITLE
fix(scan): raise Ashby provider timeout + add backoff retry

### DIFF
--- a/providers/ashby.mjs
+++ b/providers/ashby.mjs
@@ -3,6 +3,16 @@
 
 // Ashby provider — hits the public posting-api endpoint.
 // Auto-detects from careers_url pattern `https://jobs.ashbyhq.com/<slug>`.
+//
+// Ashby's public posting-api carries a ~10s+ server-side latency floor
+// (response time is independent of board size) and rate-limits repeated
+// unauthenticated hits. The global default timeout (10s, providers/_http.mjs)
+// sits right on that floor, so requests race the timeout and abort. We give
+// Ashby a longer timeout plus a backoff+jitter retry (the backoff spaces
+// requests out to dodge rate-limiting).
+// See .planning/codebase/ashby-scan-abort-diagnosis.md.
+const ASHBY_TIMEOUT_MS = 30_000;
+const ASHBY_RETRIES = 2;
 
 function resolveApiUrl(entry) {
   const url = entry.careers_url || '';
@@ -10,6 +20,8 @@ function resolveApiUrl(entry) {
   if (!match) return null;
   return `https://api.ashbyhq.com/posting-api/job-board/${match[1]}?includeCompensation=true`;
 }
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /** @type {Provider} */
 export default {
@@ -23,13 +35,27 @@ export default {
   async fetch(entry, ctx) {
     const apiUrl = resolveApiUrl(entry);
     if (!apiUrl) throw new Error(`ashby: cannot derive API URL for ${entry.name}`);
-    const json = await ctx.fetchJson(apiUrl);
-    const jobs = Array.isArray(json?.jobs) ? json.jobs : [];
-    return jobs.map(j => ({
-      title: j.title || '',
-      url: j.jobUrl || '',
-      company: entry.name,
-      location: j.location || '',
-    }));
+
+    let lastErr;
+    for (let attempt = 0; attempt <= ASHBY_RETRIES; attempt++) {
+      if (attempt > 0) {
+        // exponential backoff + jitter — spaces out retries to dodge Ashby rate-limiting
+        const backoff = 1000 * 2 ** (attempt - 1) + Math.floor(Math.random() * 500);
+        await sleep(backoff);
+      }
+      try {
+        const json = await ctx.fetchJson(apiUrl, { timeoutMs: ASHBY_TIMEOUT_MS });
+        const jobs = Array.isArray(json?.jobs) ? json.jobs : [];
+        return jobs.map((j) => ({
+          title: j.title || '',
+          url: j.jobUrl || '',
+          company: entry.name,
+          location: j.location || '',
+        }));
+      } catch (e) {
+        lastErr = e;
+      }
+    }
+    throw lastErr;
   },
 };


### PR DESCRIPTION
## Problem

Running `node scan.mjs` reports ~40 errors, almost all `This operation was aborted`, and they are **consistently the Ashby-hosted companies** (Zapier, Supabase, n8n, Cohere, LangChain, Perplexity, Resend, Clerk, ElevenLabs, …). Greenhouse and Lever companies succeed. The aborted boards never reach `pipeline.md`, so a large slice of tracked companies is silently dropped from every scan.

## Root cause

Ashby's public posting-api (`https://api.ashbyhq.com/posting-api/job-board/<slug>`) carries a **~10s+ server-side latency floor**, and the response time is **independent of board size** — i.e. it's a server-side throttle, not payload weight:

| Board | Jobs returned | Solo response time |
|-------|---------------|--------------------|
| clerk | 0 | 10.32s |
| resend | 4 | 10.34s |
| vapi | 26 | 10.39s |
| legora | 170 | 10.33s |
| inngest | 3 | **25.3s** |
| _(Greenhouse control: anthropic)_ | ~400 | **0.38s** |

The shared HTTP transport default is `DEFAULT_TIMEOUT_MS = 10_000` (`providers/_http.mjs`). Because the client timeout (10s) sits **right on** Ashby's best-case latency, nearly every Ashby request races the `AbortController` and loses — while sub-second Greenhouse boards are unaffected. Repeated unauthenticated hits also get rate-limited, pushing some boards past 25s.

`providers/ashby.mjs` calls `ctx.fetchJson(apiUrl)` with no options, so it always uses the 10s default — even though `fetchWithTimeout` already accepts a per-request `timeoutMs`.

## Fix

Scoped to the Ashby provider (no change to global defaults, so other providers' failure detection stays fast):

- Pass `{ timeoutMs: 30_000 }` to `ctx.fetchJson` — clears the latency floor.
- Add an exponential-backoff + jitter retry (2 attempts). The backoff doubles as request spacing, which mitigates the rate-limiting.

## Verification

- A board that returns in ~18s (ElevenLabs/WorkOS class) **previously aborted at 10s, now succeeds**.
- `node test-all.mjs` → **89 passed, 0 failed**.

## Notes

- Hard rate-limited boards (>30s after many rapid requests from one IP) may still need request spacing across the whole scan; a follow-up could add per-provider concurrency. This PR fixes the dominant failure mode (the ~10–25s floor) with a minimal, contained change.
- One unrelated dead slug surfaced during diagnosis: `travelperk` returns HTTP 404 (wrong Ashby board slug in `portals.yml`) — left out of this PR to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of Ashby job provider with automatic retry logic, exponential backoff, and jitter for handling transient request failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->