### PR TITLE
fix: make tracker report links relative to the tracker file (#760)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,10 +303,12 @@ Write one TSV file per evaluation to `batch/tracker-additions/{num}-{company-slu
 5. `status` -- canonical status (e.g., `Evaluated`)
 6. `score` -- format `X.X/5` (e.g., `4.2/5`)
 7. `pdf` -- `✅` or `❌`
-8. `report` -- markdown link `[num](reports/...)`
+8. `report` -- markdown link, always written **root-relative**: `[num](reports/...)`
 9. `notes` -- one-line summary
 
 **Note:** In applications.md, score comes BEFORE status. The merge script handles this column swap automatically.
+
+**Report link normalization:** The TSV always carries a **root-relative** `[num](reports/...)` link. `merge-tracker.mjs` rewrites it so the link is relative to the tracker file's own directory before writing it into the tracker — `../reports/...` when the tracker is at `data/applications.md`, or `reports/...` at the root layout. This keeps links clickable from the tracker (markdown links resolve relative to the file that contains them). Normalization is idempotent. To fix links in an existing tracker, run `node merge-tracker.mjs --migrate` (see #760).
 
 ### Pipeline Integrity
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,10 +332,12 @@ Write one TSV file per evaluation to `batch/tracker-additions/{num}-{company-slu
 5. `status` -- canonical status (e.g., `Evaluated`)
 6. `score` -- format `X.X/5` (e.g., `4.2/5`)
 7. `pdf` -- `✅` or `❌`
-8. `report` -- markdown link `[num](reports/...)`
+8. `report` -- markdown link, always written **root-relative**: `[num](reports/...)`
 9. `notes` -- one-line summary
 
 **Note:** In applications.md, score comes BEFORE status. The merge script handles this column swap automatically.
+
+**Report link normalization:** The TSV always carries a **root-relative** `[num](reports/...)` link. `merge-tracker.mjs` rewrites it so the link is relative to the tracker file's own directory before writing it into the tracker — `../reports/...` when the tracker is at `data/applications.md`, or `reports/...` at the root layout. This keeps links clickable from the tracker (markdown links resolve relative to the file that contains them). Normalization is idempotent. To fix links in an existing tracker, run `node merge-tracker.mjs --migrate` (see #760).
 
 ### Pipeline Integrity
 

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -377,7 +377,7 @@ Formato TSV (una sola línea, sin header, 9 columnas tab-separated):
 | 5 | status | canonical | `Evaluada` | DEBE ser canónico (ver states.yml) |
 | 6 | score | X.XX/5 | `4.55/5` | O `N/A` si no evaluable |
 | 7 | pdf | emoji | `✅` o `❌` | Si se generó PDF |
-| 8 | report | md link | `[647](reports/647-...)` | Link al report |
+| 8 | report | md link | `[647](reports/647-...)` | Link root-relative; merge-tracker.mjs lo normaliza relativo al tracker (ej. `../reports/...`, #760) |
 | 9 | notes | string | `APPLY HIGH...` | Resumen 1 frase |
 
 **IMPORTANTE:** El orden TSV tiene status ANTES de score (col 5→status, col 6→score). En applications.md el orden es inverso (col 5→score, col 6→status). merge-tracker.mjs maneja la conversión.

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -18,16 +18,29 @@ import { readFileSync, writeFileSync, readdirSync, mkdirSync, renameSync, exists
 import { join, basename, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
+import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
-// Support both layouts: data/applications.md (boilerplate) and applications.md (original)
-const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
-  ? join(CAREER_OPS, 'data/applications.md')
-  : join(CAREER_OPS, 'applications.md');
+// Support both layouts: data/applications.md (boilerplate) and applications.md (original).
+// CAREER_OPS_TRACKER overrides the path (used by tests and non-standard layouts).
+const APPS_FILE = process.env.CAREER_OPS_TRACKER
+  ? process.env.CAREER_OPS_TRACKER
+  : existsSync(join(CAREER_OPS, 'data/applications.md'))
+    ? join(CAREER_OPS, 'data/applications.md')
+    : join(CAREER_OPS, 'applications.md');
+const TRACKER_DIR = dirname(APPS_FILE);
 const ADDITIONS_DIR = join(CAREER_OPS, 'batch/tracker-additions');
 const MERGED_DIR = join(ADDITIONS_DIR, 'merged');
 const DRY_RUN = process.argv.includes('--dry-run');
 const VERIFY = process.argv.includes('--verify');
+const MIGRATE = process.argv.includes('--migrate');
+
+// The reports/ dir sits at the repo root, which is the tracker's parent in the
+// data/ layout (data/applications.md) and the tracker's own dir at root layout.
+const REPORTS_ROOT = basename(TRACKER_DIR) === 'data' ? dirname(TRACKER_DIR) : TRACKER_DIR;
+
+// Normalize a report link relative to the tracker file's own directory (#760).
+const normalizeReportLink = (reportField) => normalizeLink(reportField, TRACKER_DIR, REPORTS_ROOT);
 
 // Ensure required directories exist (fresh setup)
 mkdirSync(join(CAREER_OPS, 'data'), { recursive: true });
@@ -263,6 +276,25 @@ if (!existsSync(APPS_FILE)) {
   process.exit(0);
 }
 const appContent = readFileSync(APPS_FILE, 'utf-8');
+
+// One-time migration: rewrite existing report links so they resolve relative
+// to the tracker file's directory (see #760). Run with: node merge-tracker.mjs --migrate
+if (MIGRATE) {
+  const migrated = appContent
+    .split('\n')
+    .map(line => (line.startsWith('|') ? normalizeReportLink(line) : line));
+  const before = appContent.split('\n');
+  const changed = migrated.filter((l, i) => l !== before[i]).length;
+
+  if (DRY_RUN) {
+    console.log(`🔎 Migration (dry-run): ${changed} row(s) would be rewritten in ${basename(APPS_FILE)}`);
+  } else {
+    writeFileSync(APPS_FILE, migrated.join('\n'));
+    console.log(`✅ Migration: rewrote ${changed} report link(s) in ${basename(APPS_FILE)} relative to ${TRACKER_DIR === CAREER_OPS ? 'repo root' : 'data/'}`);
+  }
+  process.exit(0);
+}
+
 const appLines = appContent.split('\n');
 const existingApps = [];
 let maxNum = 0;
@@ -309,6 +341,11 @@ for (const file of tsvFiles) {
   const content = readFileSync(join(ADDITIONS_DIR, file), 'utf-8').trim();
   const addition = parseTsvContent(content, file);
   if (!addition) { skipped++; continue; }
+
+  // Normalize the report link to be relative to the tracker file's directory.
+  // The TSV convention carries a root-relative `reports/...` link; rewrite it
+  // so it resolves correctly when clicked from applications.md (see #760).
+  addition.report = normalizeReportLink(addition.report);
 
   // Check for duplicate by:
   // 1. Exact report number match

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -208,7 +208,7 @@ Save full evaluation in `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 - Score: match average (1-5)
 - Status: `Evaluated`
 - PDF: ❌ (or ✅ if auto-pipeline generated PDF)
-- Report: link relative to the report .md (e.g., `[001](reports/001-company-2026-01-01.md)`)
+- Report: root-relative link `[001](reports/001-company-2026-01-01.md)` (when merged via `merge-tracker.mjs` it is normalized to be relative to the tracker's own dir, e.g. `../reports/...`; see #760)
 
 **Tracker format:**
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -541,10 +541,11 @@ try {
     fail(`root layout normalization wrong: ${atRoot}`);
   }
 
-  // Non-report links are left untouched
-  const other = normalizeReportLink('[site](https://example.com)', dataDir, repo);
-  if (other === '[site](https://example.com)') {
-    pass('non-report links are left untouched');
+  // Non-report links are left untouched — including external URLs that happen
+  // to contain an embedded "/reports/" segment (must not be rewritten).
+  const other = normalizeReportLink('[site](https://example.com/reports/foo.md)', dataDir, repo);
+  if (other === '[site](https://example.com/reports/foo.md)') {
+    pass('non-report links (incl. URLs with embedded /reports/) are left untouched');
   } else {
     fail(`non-report link altered: ${other}`);
   }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12,8 +12,9 @@
  */
 
 import { execSync, execFileSync } from 'child_process';
-import { readFileSync, existsSync, readdirSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
+import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -505,6 +506,75 @@ try {
 
 } catch (e) {
   fail(`always_allow tests crashed: ${e.message}`);
+}
+
+// ── 12. TRACKER REPORT LINK NORMALIZATION (#760) ────────────────
+
+console.log('\n12. Tracker report-link normalization');
+
+try {
+  const { normalizeReportLink } = await import(pathToFileURL(join(ROOT, 'tracker-links.mjs')).href);
+  const repo = '/repo';
+  const dataDir = join(repo, 'data');
+
+  // data/ layout: root-relative TSV link → ../reports/...
+  const fromTsv = normalizeReportLink('[12](reports/012-acme-2026-01-04.md)', dataDir, repo);
+  if (fromTsv === '[12](../reports/012-acme-2026-01-04.md)') {
+    pass('data/ layout: root-relative link rewritten to ../reports/...');
+  } else {
+    fail(`data/ layout normalization wrong: ${fromTsv}`);
+  }
+
+  // Idempotent: re-running on an already-normalized link must not double-prefix
+  const twice = normalizeReportLink(fromTsv, dataDir, repo);
+  if (twice === fromTsv) {
+    pass('normalization is idempotent (no double-prefix on re-run)');
+  } else {
+    fail(`normalization not idempotent: ${twice}`);
+  }
+
+  // Root layout: tracker at repo root → link stays reports/...
+  const atRoot = normalizeReportLink('[12](reports/012-acme-2026-01-04.md)', repo, repo);
+  if (atRoot === '[12](reports/012-acme-2026-01-04.md)') {
+    pass('root layout: link stays root-relative reports/...');
+  } else {
+    fail(`root layout normalization wrong: ${atRoot}`);
+  }
+
+  // Non-report links are left untouched
+  const other = normalizeReportLink('[site](https://example.com)', dataDir, repo);
+  if (other === '[site](https://example.com)') {
+    pass('non-report links are left untouched');
+  } else {
+    fail(`non-report link altered: ${other}`);
+  }
+
+  // End-to-end migration against a fictional fixture tracker (no personal data)
+  const tmpDir = mkdtempSync(join(tmpdir(), 'career-ops-migrate-'));
+  try {
+    mkdirSync(join(tmpDir, 'data'));
+    mkdirSync(join(tmpDir, 'reports'));
+    writeFileSync(join(tmpDir, 'reports', '012-acme-2026-01-04.md'), '# fixture\n');
+    const tracker = join(tmpDir, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 12 | 2026-01-04 | Acme | Engineer | 4.2/5 | Evaluated | ✅ | [12](reports/012-acme-2026-01-04.md) | ok |\n');
+
+    // Migrate by pointing the script at the fixture tracker via env override.
+    run(NODE, ['merge-tracker.mjs', '--migrate'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
+    const after = readFileSync(tracker, 'utf-8');
+    if (after.includes('[12](../reports/012-acme-2026-01-04.md)')) {
+      pass('migration rewrites fixture tracker links to ../reports/...');
+    } else {
+      fail('migration did not rewrite fixture tracker link');
+    }
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`tracker-link normalization tests crashed: ${e.message}`);
 }
 
 // ── SUMMARY ─────────────────────────────────────────────────────

--- a/tracker-links.mjs
+++ b/tracker-links.mjs
@@ -25,7 +25,7 @@ import { join, relative, sep } from 'path';
  */
 export function normalizeReportLink(reportField, trackerDir, repoRoot) {
   return reportField.replace(/\]\(([^)]+)\)/g, (whole, linkPath) => {
-    const m = linkPath.match(/(?:^|\/)(reports\/.+)$/);
+    const m = linkPath.match(/^(?:\.\.\/)*(reports\/.+)$/);
     if (!m) return whole; // not a report path — leave untouched
     const reportAbs = join(repoRoot, m[1]);
     const rel = relative(trackerDir, reportAbs).split(sep).join('/');

--- a/tracker-links.mjs
+++ b/tracker-links.mjs
@@ -1,0 +1,34 @@
+/**
+ * tracker-links.mjs — Shared report-link normalization for the tracker.
+ *
+ * Markdown links resolve relative to the file that contains them, so a report
+ * link in applications.md must be relative to wherever that tracker file lives:
+ * `../reports/...` when the tracker is at `data/applications.md`, or
+ * `reports/...` when it sits at the repo root.
+ *
+ * Report files canonically live in `<repoRoot>/reports/`, so we resolve the
+ * incoming link to that absolute location regardless of how it was written
+ * (root-relative `reports/...` per the TSV convention, or an already-normalized
+ * `../reports/...`) and recompute the path with path.relative. Idempotent:
+ * re-running never double-prefixes a link. See issue #760.
+ */
+
+import { join, relative, sep } from 'path';
+
+/**
+ * Rewrite every report link in a string so its path is relative to trackerDir.
+ *
+ * @param {string} reportField  Text containing one or more `[label](path)` links.
+ * @param {string} trackerDir   Absolute dir of the tracker file (dirname of applications.md).
+ * @param {string} repoRoot     Absolute repo root where `reports/` lives.
+ * @returns {string} The same text with report links normalized.
+ */
+export function normalizeReportLink(reportField, trackerDir, repoRoot) {
+  return reportField.replace(/\]\(([^)]+)\)/g, (whole, linkPath) => {
+    const m = linkPath.match(/(?:^|\/)(reports\/.+)$/);
+    if (!m) return whole; // not a report path — leave untouched
+    const reportAbs = join(repoRoot, m[1]);
+    const rel = relative(trackerDir, reportAbs).split(sep).join('/');
+    return `](${rel})`;
+  });
+}

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -19,10 +19,13 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
-// Support both layouts: data/applications.md (boilerplate) and applications.md (original)
-const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
-  ? join(CAREER_OPS, 'data/applications.md')
-  : join(CAREER_OPS, 'applications.md');
+// Support both layouts: data/applications.md (boilerplate) and applications.md (original).
+// CAREER_OPS_TRACKER overrides the path (used by tests and non-standard layouts).
+const APPS_FILE = process.env.CAREER_OPS_TRACKER
+  ? process.env.CAREER_OPS_TRACKER
+  : existsSync(join(CAREER_OPS, 'data/applications.md'))
+    ? join(CAREER_OPS, 'data/applications.md')
+    : join(CAREER_OPS, 'applications.md');
 const ADDITIONS_DIR = join(CAREER_OPS, 'batch/tracker-additions');
 const REPORTS_DIR = join(CAREER_OPS, 'reports');
 const STATES_FILE = existsSync(join(CAREER_OPS, 'templates/states.yml'))
@@ -125,13 +128,18 @@ for (const [key, group] of companyRoleMap) {
 if (dupes === 0) ok('No exact duplicates found');
 
 // --- Check 3: Report links ---
+// Markdown links resolve relative to the file that contains them, so report
+// links must resolve against the tracker's own directory (see #760). For the
+// transition we also accept legacy root-relative links: try the tracker dir
+// first, then fall back to the repo root before flagging a link broken.
+const TRACKER_DIR = dirname(APPS_FILE);
 let brokenReports = 0;
 for (const e of entries) {
   const match = e.report.match(/\]\(([^)]+)\)/);
   if (!match) continue;
-  const reportPath = join(CAREER_OPS, match[1]);
-  if (!existsSync(reportPath)) {
-    error(`#${e.num}: Report not found: ${match[1]}`);
+  const link = match[1];
+  if (!existsSync(join(TRACKER_DIR, link)) && !existsSync(join(CAREER_OPS, link))) {
+    error(`#${e.num}: Report not found: ${link}`);
     brokenReports++;
   }
 }


### PR DESCRIPTION
Fixes #760.

## The bug
The tracker (`data/applications.md`) indexes each evaluation with a link to its report, e.g. `[12](reports/012-acme-2026-01-04.md)`. That path is **root-relative**, but Markdown links resolve relative to the file that contains them. Since the tracker lives in `data/`, clicking the link targets the non-existent `data/reports/012-...` — every report link in the tracker is broken for humans.

It stayed hidden because `verify-pipeline.mjs` (Check 3) resolved links against the **repo root** (`join(CAREER_OPS, link)`), so broken-for-humans links still passed validation.

Confirmed in a fresh clone: tracker resolves to `data/applications.md`, reports live at repo-root `reports/`, there is no `data/reports/`, and the TSV convention in AGENTS.md hardcodes `[{num}](reports/...)` which `merge-tracker.mjs` copied verbatim.

## The fix (two-sided + migration)
1. **Write side — `merge-tracker.mjs`:** normalize every report link relative to the tracker file's own directory using `path.relative`, not string-prefixing — `../reports/...` for the `data/` layout, `reports/...` for the root layout. Idempotent: re-runs never double-prefix. The logic lives in a new shared, unit-testable `tracker-links.mjs` (same pattern as `liveness-core.mjs`).
2. **Validate side — `verify-pipeline.mjs`:** resolve links against the tracker's directory first, then **fall back to the repo root** so legacy root-relative links still validate during the transition.
3. **Migration:** `node merge-tracker.mjs --migrate` rewrites existing `](reports/...)` links in place (supports `--dry-run`). Users run it locally. No `data/applications.md` or `reports/` is committed — the migration is exercised against **fictional fixture data only** in `test-all.mjs`.
4. **Docs:** AGENTS.md / CLAUDE.md TSV convention, `modes/oferta.md`, and `batch/batch-prompt.md` now state explicitly that the TSV carries a root-relative `[num](reports/...)` link that `merge-tracker.mjs` then normalizes.

## Compatibility
- Both layouts handled: `data/applications.md` → `../reports/...`, root `applications.md` → `reports/...`.
- Validation stays tolerant of old and new link forms during transition.
- No new external/API dependencies.

## Testing
- `node test-all.mjs` → 93 passed, 0 failed (added 5 checks covering normalization, idempotency, both layouts, non-report links, and end-to-end migration on a fixture tracker).
- `node verify-pipeline.mjs` → passes.
- `npm run doctor` → only flags missing user data (`cv.md`, `config/profile.yml`, `portals.yml`), expected in a fresh clone; unrelated to this change.

The diff contains **no personal data**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a one-time migrate mode (with dry-run) to rewrite and normalize report links in trackers so they resolve consistently relative to each tracker.

* **Documentation**
  * Clarified that report links should use root-relative Markdown and documented how links are normalized and migrated.

* **Tests**
  * Added tests covering link normalization, idempotency, and end-to-end migration behavior.

* **Other**
  * Validation updated to resolve links relative to tracker location with a repo-root fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/santifer/career-ops/pull/761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->