### PR TITLE
feat(scan): add fix-ats mode for automated ATS board URL repair

### DIFF
--- a/.claude/skills/career-ops/SKILL.md
+++ b/.claude/skills/career-ops/SKILL.md
@@ -1,1 +1,102 @@
-../../../.agents/skills/career-ops/SKILL.md
+---
+name: career-ops
+description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
+arguments: mode # Claude Code specific
+user-invocable: true
+argument-hint: "[scan | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update | fix-ats]"
+license: MIT
+---
+
+# career-ops -- Router
+
+## Mode Routing
+
+Determine the mode from `$mode`:
+
+| Input | Mode |
+|-------|------|
+| (empty / no args) | `discovery` -- Show command menu |
+| JD text or URL (no sub-command) | **`auto-pipeline`** |
+| `oferta` | `oferta` |
+| `ofertas` | `ofertas` |
+| `contacto` | `contacto` |
+| `deep` | `deep` |
+| `interview-prep` | `interview-prep` |
+| `pdf` | `pdf` |
+| `training` | `training` |
+| `project` | `project` |
+| `tracker` | `tracker` |
+| `pipeline` | `pipeline` |
+| `apply` | `apply` |
+| `scan` | `scan` |
+| `batch` | `batch` |
+| `patterns` | `patterns` |
+| `followup` | `followup` |
+| `update` | `update` |
+| `fix-ats` | `fix-ats` |
+
+**Auto-pipeline detection:** If `$mode` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
+
+If `$mode` is not a sub-command AND doesn't look like a JD, show discovery.
+
+---
+
+## Discovery Mode (no arguments)
+
+Show this menu:
+
+```
+career-ops -- Command Center
+
+Available commands:
+  /career-ops {JD}      → AUTO-PIPELINE: evaluate + report + PDF + tracker (paste text or URL)
+  /career-ops pipeline  → Process pending URLs from inbox (data/pipeline.md)
+  /career-ops oferta    → Evaluation only A-F (no auto PDF)
+  /career-ops ofertas   → Compare and rank multiple offers
+  /career-ops contacto  → LinkedIn power move: find contacts + draft message
+  /career-ops deep      → Deep research prompt about company
+  /career-ops interview-prep → Generate company-specific interview prep doc
+  /career-ops pdf       → PDF only, ATS-optimized CV
+  /career-ops training  → Evaluate course/cert against North Star
+  /career-ops project   → Evaluate portfolio project idea
+  /career-ops tracker   → Application status overview
+  /career-ops apply     → Live application assistant (reads form + generates answers)
+  /career-ops scan      → Scan portals and discover new offers
+  /career-ops batch     → Batch processing with parallel workers
+  /career-ops patterns  → Analyze rejection patterns and improve targeting
+  /career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
+  /career-ops update    → Update career-ops system files with diff preview + compat check
+  /career-ops fix-ats   → Find and fix broken ATS board URLs in portals.yml
+
+Inbox: add URLs to data/pipeline.md → /career-ops pipeline
+Or paste a JD directly to run the full pipeline.
+```
+
+---
+
+## Context Loading by Mode
+
+After determining the mode, load the necessary files before executing:
+
+### Modes that require `_shared.md` + their mode file:
+Read `modes/_shared.md` + `modes/{mode}.md`
+
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+
+### Standalone modes (only their mode file):
+Read `modes/{mode}.md`
+
+Applies to: `tracker`, `deep`, `interview-prep`, `training`, `project`, `patterns`, `followup`, `fix-ats`
+
+### Modes delegated to subagent:
+For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as Agent with the content of `_shared.md` + `modes/{mode}.md` injected into the subagent prompt.
+
+```
+Agent(
+  subagent_type="general-purpose",
+  prompt="[content of modes/_shared.md]\n\n[content of modes/{mode}.md]\n\n[invocation-specific data]",
+  description="career-ops {mode}"
+)
+```
+
+Execute the instructions from the loaded mode file.

--- a/modes/fix-ats.md
+++ b/modes/fix-ats.md
@@ -1,0 +1,132 @@
+# Mode: fix-ats — ATS Board URL Repair
+
+Finds correct ATS board URLs for companies in `portals.yml` whose current `careers_url` or `api:` returns 404, then updates the file.
+
+## When to use
+
+Run after a scan reports 404 errors, or any time you suspect `portals.yml` has stale ATS slugs.
+
+## Inputs
+
+- `portals.yml` — source of truth for company ATS config
+- Optional: a user-supplied list of specific companies to fix (e.g. "fix Rippling, Notion, Canva")
+
+## Step 1 — Build the work list
+
+If the user supplied company names, use those. Otherwise, run the scanner to collect errors:
+
+```bash
+node scan.mjs 2>&1
+```
+
+Parse stdout for lines matching `✗ {Company}: HTTP 404`. Extract the company names. These are the candidates.
+
+## Step 2 — For each broken company
+
+Work through the list sequentially. For each company:
+
+### 2a — Identify current ATS platform
+
+Look at the existing `careers_url` and `api:` in `portals.yml`:
+
+| URL pattern | Platform |
+|-------------|----------|
+| `job-boards.greenhouse.io/{slug}` or `boards-api.greenhouse.io/v1/boards/{slug}` | Greenhouse |
+| `jobs.ashbyhq.com/{slug}` | Ashby |
+| `jobs.lever.co/{slug}` or `api.lever.co/v0/postings/{slug}` | Lever |
+| `*.bamboohr.com/careers` | BambooHR |
+| `*.myworkdayjobs.com` | Workday |
+
+### 2b — Try known slug variants first (zero-cost)
+
+Before searching, try common slug patterns for the same platform:
+
+**Greenhouse slug variants** (try in order):
+1. `{slug}` (current)
+2. `{company-name-lowercase-hyphenated}` — e.g. `hinge-health`
+3. `{companyname}` — no hyphens, e.g. `hingehealth`
+4. `{company}inc`, `{company}hq`, `{company}jobs`
+
+Use WebFetch on `https://boards-api.greenhouse.io/v1/boards/{variant}/jobs` — if it returns JSON with a `jobs` array (even empty), the slug is valid.
+
+**Ashby slug variants** (try in order):
+Use the Ashby GraphQL endpoint:
+```
+POST https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobBoardWithTeams
+Body: {"operationName":"ApiJobBoardWithTeams","variables":{"organizationHostedJobsPageName":"{slug}"},"query":"{ jobBoard { jobPostings { id title } } }"}
+```
+Try: current slug → lowercase → hyphenated → no hyphens.
+
+**Lever slug variants** (try in order):
+`https://api.lever.co/v0/postings/{variant}?mode=json` — 200 + JSON array = valid.
+
+### 2c — Search if variants fail
+
+If all slug variants 404, use WebSearch to find the current careers page:
+
+```
+"{company name}" careers jobs site:job-boards.greenhouse.io OR site:jobs.ashbyhq.com OR site:jobs.lever.co OR site:jobs.lever.co OR site:apply.workable.com OR site:boards.eu.greenhouse.io
+```
+
+Also try: `"{company name}" site:linkedin.com/company careers` to spot an "ATS" link, or `"{company name}" careers jobs` to find the branded careers page.
+
+### 2d — Detect new platform
+
+If the company moved ATS, identify the new one from search results. Extract the new slug from the URL pattern.
+
+Verify by fetching the API endpoint directly:
+- Greenhouse: `https://boards-api.greenhouse.io/v1/boards/{new-slug}/jobs` → must return JSON
+- Ashby: GraphQL POST as above → must return `jobBoard`
+- Lever: `https://api.lever.co/v0/postings/{new-slug}?mode=json` → must return array
+
+### 2e — Check if company still exists
+
+If search returns no careers page at all:
+- Search `"{company name}" acquired OR shutdown OR closed 2024 OR 2025 OR 2026`
+- If acquired: note the acquirer and check if roles moved to parent company's board
+- If shutdown: mark for removal
+
+## Step 3 — Classify each company
+
+| Result | Action |
+|--------|--------|
+| Found new slug (same platform) | Update slug in `portals.yml` |
+| Found new platform | Update `careers_url`, `api:`, `scan_method` in `portals.yml` |
+| No open jobs but board exists | Update URL, add note `"No open roles as of {date}"` |
+| Company acquired | Update entry to point to acquirer's board, update `notes:` |
+| Company shut down | Set `enabled: false`, update `notes:` with shutdown context |
+| Cannot determine | Leave unchanged, note as `# TODO: manual verification needed` |
+
+## Step 4 — Update portals.yml
+
+For each fix, edit the relevant entry in `portals.yml`. Rules:
+
+- **Only change `careers_url`, `api:`, `scan_method`, `notes:`, `enabled:`** — never touch `title_filter`, `location_filter`, or `search_queries` unless explicitly asked
+- Preserve all other fields on the entry
+- When updating `careers_url` to a branded page, also update `api:` if the new ATS supports it
+- Add a comment `# Updated {YYYY-MM-DD}: {reason}` on the line above the entry when the change is non-trivial
+
+## Step 5 — Report
+
+Print a summary table:
+
+```
+ATS Board Repair — {YYYY-MM-DD}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Companies checked: N
+Fixed (new URL found): N
+  ✓ {Company} → {new slug/platform}
+  ...
+No open roles (board exists): N
+  ○ {Company} — board valid, 0 jobs
+  ...
+Disabled (shutdown/acquired): N
+  ✗ {Company} — {reason}
+  ...
+Could not resolve: N
+  ? {Company} — manual check needed
+  ...
+```
+
+End with:
+> "`portals.yml` updated. Run `/career-ops scan` to verify the fixed boards return results."


### PR DESCRIPTION
## Summary

- Adds  — a new standalone mode that finds broken ATS board URLs in , tries known slug variants across Greenhouse/Ashby/Lever, searches for platform migrations, and patches the file in place
- Wires  into the SKILL.md router (routing table, discovery menu, standalone modes list, argument-hint)

## What it does

1. Runs Scanning 145 companies via providers (0 local parser; 27 skipped — no provider matched)

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Portal Scan — 2026-05-31
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Companies scanned:     145
Total jobs found:      10887
Filtered by title:     9726 removed
Filtered by location:  802 removed
Duplicates:            359 skipped
New offers added:      0

Errors (3):
  ✗ Metadata: HTTP 404: {"status":404,"error":"Job not found"}
  ✗ Tofu: HTTP 404: Not Found
  ✗ Paper: HTTP 404: Not Found

→ Run /career-ops pipeline to evaluate new offers.
→ Share results and get help: https://discord.gg/8pRpHETxa4 to collect all HTTP 404 errors
2. For each broken company, tries common slug variants before falling back to search
3. Detects platform migrations (e.g. Greenhouse to Ashby), updates careers_url + api: accordingly
4. Falls back to websearch for companies that left standard ATS platforms entirely
5. Prints a summary table of fixed / unresolved entries

## Tested on

40 broken companies from a live scan run (2026-05-31). Resolved 37/40 — errors dropped from 40 to 3.

## Test plan

- [ ] Run /career-ops fix-ats after a scan that reports 404 errors and verify entries are updated
- [ ] Run /career-ops scan after fix-ats to confirm error count drops

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new career operations skill with intelligent request routing that auto-detects job descriptions and URLs while supporting multiple operational modes.
  * Added an automated repair procedure for detecting and fixing broken ATS board URLs, including platform identification, validation, and outcome classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->