### PR TITLE
test(followup-cadence): cover cadence helpers without running CLI on import

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -13,7 +13,7 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -56,7 +56,7 @@ const ALIASES = {
 
 const ACTIONABLE_STATUSES = ['applied', 'responded', 'interview'];
 
-function normalizeStatus(raw) {
+export function normalizeStatus(raw) {
   const clean = raw.replace(/\*\*/g, '').trim().toLowerCase()
     .replace(/\s+\d{4}-\d{2}-\d{2}.*$/, '').trim();
   return ALIASES[clean] || clean;
@@ -67,16 +67,16 @@ function today() {
   return new Date(new Date().toISOString().split('T')[0]);
 }
 
-function parseDate(dateStr) {
+export function parseDate(dateStr) {
   if (!dateStr || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr.trim())) return null;
   return new Date(dateStr.trim());
 }
 
-function daysBetween(d1, d2) {
+export function daysBetween(d1, d2) {
   return Math.floor((d2 - d1) / (1000 * 60 * 60 * 24));
 }
 
-function addDays(date, days) {
+export function addDays(date, days) {
   const result = new Date(date);
   result.setUTCDate(result.getUTCDate() + days);
   return result.toISOString().split('T')[0];
@@ -153,7 +153,7 @@ function resolveReportPath(reportField) {
 }
 
 // --- Compute urgency ---
-function computeUrgency(status, daysSinceApp, daysSinceLastFollowup, followupCount) {
+export function computeUrgency(status, daysSinceApp, daysSinceLastFollowup, followupCount) {
   if (status === 'applied') {
     if (followupCount >= CADENCE.applied_max_followups) return 'cold';
     if (followupCount === 0 && daysSinceApp >= CADENCE.applied_first) return 'overdue';
@@ -173,7 +173,7 @@ function computeUrgency(status, daysSinceApp, daysSinceLastFollowup, followupCou
 }
 
 // --- Compute next follow-up date ---
-function computeNextFollowupDate(status, appDate, lastFollowupDate, followupCount) {
+export function computeNextFollowupDate(status, appDate, lastFollowupDate, followupCount) {
   if (status === 'applied') {
     if (followupCount >= CADENCE.applied_max_followups) return null; // cold
     if (followupCount === 0) return addDays(parseDate(appDate), CADENCE.applied_first);
@@ -327,13 +327,15 @@ function printSummary(result) {
   console.log('');
 }
 
-// --- Run ---
-const result = analyze();
+// --- Run (CLI only; guarded so the module is safely importable for tests) ---
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = analyze();
 
-if (summaryMode) {
-  printSummary(result);
-} else {
-  console.log(JSON.stringify(result, null, 2));
+  if (summaryMode) {
+    printSummary(result);
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+
+  if (result.error) process.exit(1);
 }
-
-if (result.error) process.exit(1);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -513,6 +513,24 @@ console.log('\n12. Follow-up cadence logic');
 try {
   const cadence = await import(pathToFileURL(join(ROOT, 'followup-cadence.mjs')).href);
 
+  // CLI regression: the import.meta.url guard must still let the module run as a CLI.
+  // Data-independent — default mode emits the result as JSON: a `metadata` object when
+  // the tracker has applications, or an `{error}` object (exit 1) when it is empty.
+  // Empty output would mean the guard wrongly suppressed main().
+  let cliOut = '';
+  try {
+    cliOut = execFileSync(NODE, [join(ROOT, 'followup-cadence.mjs')], { cwd: ROOT, encoding: 'utf-8', timeout: 30000 });
+  } catch (cliErr) {
+    cliOut = `${cliErr.stdout || ''}`; // exit 1 on an empty tracker is expected; keep stdout
+  }
+  let cliJson = null;
+  try { cliJson = JSON.parse(cliOut.trim()); } catch { /* leave null → fail below */ }
+  if (cliJson && typeof cliJson === 'object' && ('metadata' in cliJson || 'error' in cliJson)) {
+    pass('CLI still executes under the import.meta.url guard (emits result JSON)');
+  } else {
+    fail('CLI produced no structured JSON when run directly — import.meta.url guard may be broken');
+  }
+
   // Date helpers
   if (cadence.addDays(cadence.parseDate('2026-05-01'), 7) === '2026-05-08') {
     pass('addDays advances a parsed date by N days (UTC)');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -506,6 +506,65 @@ try {
 } catch (e) {
   fail(`always_allow tests crashed: ${e.message}`);
 }
+// ── 12. FOLLOW-UP CADENCE LOGIC ─────────────────────────────────
+
+console.log('\n12. Follow-up cadence logic');
+
+try {
+  const cadence = await import(pathToFileURL(join(ROOT, 'followup-cadence.mjs')).href);
+
+  // Date helpers
+  if (cadence.addDays(cadence.parseDate('2026-05-01'), 7) === '2026-05-08') {
+    pass('addDays advances a parsed date by N days (UTC)');
+  } else {
+    fail(`addDays produced ${cadence.addDays(cadence.parseDate('2026-05-01'), 7)}`);
+  }
+  if (cadence.daysBetween(cadence.parseDate('2026-05-01'), cadence.parseDate('2026-05-08')) === 7) {
+    pass('daysBetween counts whole days between two dates');
+  } else {
+    fail('daysBetween miscounted');
+  }
+  if (cadence.parseDate('not-a-date') === null && cadence.parseDate('2026-05-01') instanceof Date) {
+    pass('parseDate rejects malformed input and accepts ISO dates');
+  } else {
+    fail('parseDate validation wrong');
+  }
+
+  // Status normalization (strips bold + trailing date, lowercases, maps aliases)
+  if (cadence.normalizeStatus('**Applied** 2026-05-01') === 'applied') {
+    pass('normalizeStatus strips bold + trailing date and lowercases');
+  } else {
+    fail(`normalizeStatus produced ${cadence.normalizeStatus('**Applied** 2026-05-01')}`);
+  }
+
+  // Urgency decision tree (CADENCE defaults: applied_first=7, max_followups=2, responded_initial=1, interview_thankyou=1)
+  const urgencyCases = [
+    [['applied', 7, null, 0], 'overdue', 'applied past applied_first → overdue'],
+    [['applied', 3, null, 0], 'waiting', 'applied within window → waiting'],
+    [['applied', 30, null, 2], 'cold', 'applied at max follow-ups → cold'],
+    [['responded', 0, null, 0], 'urgent', 'responded before responded_initial → urgent'],
+    [['interview', 1, null, 0], 'overdue', 'interview past thank-you window → overdue'],
+  ];
+  for (const [args, expected, label] of urgencyCases) {
+    const got = cadence.computeUrgency(...args);
+    if (got === expected) pass(`computeUrgency: ${label}`);
+    else fail(`computeUrgency ${label}: expected ${expected}, got ${got}`);
+  }
+
+  // Next follow-up date scheduling
+  const nextCases = [
+    [['applied', '2026-05-01', null, 0], '2026-05-08', 'first applied follow-up = appDate + applied_first'],
+    [['applied', '2026-05-01', null, 2], null, 'cold (max follow-ups) → null'],
+    [['interview', '2026-05-01', null, 0], '2026-05-02', 'interview = appDate + interview_thankyou'],
+  ];
+  for (const [args, expected, label] of nextCases) {
+    const got = cadence.computeNextFollowupDate(...args);
+    if (got === expected) pass(`computeNextFollowupDate: ${label}`);
+    else fail(`computeNextFollowupDate ${label}: expected ${expected}, got ${got}`);
+  }
+} catch (e) {
+  fail(`follow-up cadence module crashed: ${e.message}`);
+}
 
 // ── SUMMARY ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #767

Exports the pure cadence helpers (`normalizeStatus`, `parseDate`, `daysBetween`, `addDays`, `computeUrgency`, `computeNextFollowupDate`) and guards the CLI entrypoint with an `import.meta.url` check so the module can be imported by tests without executing the report.

Adds 12 unit tests in `test-all.mjs` covering date math, status normalization, the urgency decision tree, and next-follow-up scheduling.

No runtime/CLI behavior change — `node followup-cadence.mjs` output is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made follow-up cadence logic more modular and safely runnable as both a CLI and an importable module, improving reuse and testability.

* **Tests**
  * Added comprehensive tests covering date calculations, status normalization, urgency scoring, and follow-up scheduling across first-contact, cold-prospect, and interview scenarios, including CLI execution validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->