### PR TITLE
fix: make career-ops skill discoverable in Claude Code

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: career-ops
 description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
-arguments: mode # Claude Code specific
-user-invocable: true
+user_invocable: true
 argument-hint: "[scan | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
-license: MIT
 ---
 
 # career-ops -- Router

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -174,6 +174,18 @@ for (const f of systemFiles) {
   }
 }
 
+const careerOpsSkill = readFile('.agents/skills/career-ops/SKILL.md');
+if (
+  careerOpsSkill.includes('user_invocable: true') &&
+  !careerOpsSkill.includes('user-invocable: true') &&
+  !careerOpsSkill.includes('arguments: mode') &&
+  !careerOpsSkill.includes('license: MIT')
+) {
+  pass('career-ops skill frontmatter matches Claude Code schema');
+} else {
+  fail('career-ops skill frontmatter still contains non-Claude keys');
+}
+
 // Check user files are NOT tracked (gitignored)
 const userFiles = [
   'config/profile.yml', 'modes/_profile.md', 'portals.yml',

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -174,16 +174,28 @@ for (const f of systemFiles) {
   }
 }
 
-const careerOpsSkill = readFile('.agents/skills/career-ops/SKILL.md');
-if (
-  careerOpsSkill.includes('user_invocable: true') &&
-  !careerOpsSkill.includes('user-invocable: true') &&
-  !careerOpsSkill.includes('arguments: mode') &&
-  !careerOpsSkill.includes('license: MIT')
-) {
-  pass('career-ops skill frontmatter matches Claude Code schema');
+const careerOpsSkillPath = '.agents/skills/career-ops/SKILL.md';
+if (!fileExists(careerOpsSkillPath)) {
+  fail(`Missing system file: ${careerOpsSkillPath}`);
 } else {
-  fail('career-ops skill frontmatter still contains non-Claude keys');
+  const careerOpsSkill = readFile(careerOpsSkillPath);
+  const frontmatterMatch = careerOpsSkill.match(/^---\n([\s\S]*?)\n---\n?/);
+
+  if (!frontmatterMatch) {
+    fail('career-ops skill is missing YAML frontmatter');
+  } else {
+    const frontmatter = frontmatterMatch[1];
+    if (
+      frontmatter.includes('user_invocable: true') &&
+      !frontmatter.includes('user-invocable: true') &&
+      !frontmatter.includes('arguments: mode') &&
+      !frontmatter.includes('license: MIT')
+    ) {
+      pass('career-ops skill frontmatter uses Claude-compatible keys');
+    } else {
+      fail('career-ops skill frontmatter still contains non-Claude keys');
+    }
+  }
 }
 
 // Check user files are NOT tracked (gitignored)


### PR DESCRIPTION
  ## What does this PR do?

  Fixes Claude Code slash-command discovery for `career-ops` by correcting the skill frontmatter schema in `.agents/skills/career-ops/SKILL.md`. It also adds a regression check in `test-all.mjs` so the same metadata drift is caught in future.

  ## Related issue

  Fixes #763

  ## Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Documentation / translation
  - [ ] Refactor (no behavior change)

  ## Checklist

  - [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
  - [x] I linked a related issue above (required for features and architecture changes)
  - [x] My PR does not include personal data (CV, email, real names)
  - [x] I ran `node test-all.mjs` and all tests pass
  - [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
  - [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

  ---
  Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized frontmatter metadata naming for skill files to improve consistency.
  * Removed legacy/unsupported metadata entries from skill frontmatter.
  * Added validation to enforce the new frontmatter schema and reject legacy or malformed entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->