### PR TITLE
feat(web): dashboard local + scan sélectif depuis l'IHM

### DIFF
--- a/batch/gen-applications.mjs
+++ b/batch/gen-applications.mjs
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+// Data-driven application generator.
+// Reads candidate content from data/applications-content/<id>.json and renders
+// CV (1 or 2 pages) and/or cover-letter PDFs, applying format options.
+//
+// Usage:
+//   node batch/gen-applications.mjs --id watershed --pages 2 --cover
+//   node batch/gen-applications.mjs --id cohere --pages 1
+//   node batch/gen-applications.mjs --all --pages 2 --cover    # every candidate
+//   node batch/gen-applications.mjs --list                     # list candidate ids
+//
+// Options:
+//   --id <id>        candidate id (filename without .json). Repeatable.
+//   --all            all candidates in data/applications-content/
+//   --pages 1|2      CV length (default 2). Use 0 to skip the CV.
+//   --cover          also generate the cover letter
+//   --cover-only     generate ONLY the cover letter (no CV)
+//   --html-only      write HTML but skip PDF rendering
+//   --list           print available candidate ids and exit
+//
+// Paper format (letter/a4) and language come from each JSON; not overridable
+// (each application keeps the language of its job description).
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const CONTENT_DIR = join(ROOT, 'data', 'applications-content');
+const OUT_DIR = join(ROOT, 'output');
+const out = (f) => join(OUT_DIR, f);
+
+// ---- shared font-face + base CSS --------------------------------------------
+const FONTS = `
+  @font-face { font-family: 'Space Grotesk'; src: url('./fonts/space-grotesk-latin.woff2') format('woff2'); font-weight: 300 700; font-style: normal; font-display: swap; unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+  @font-face { font-family: 'Space Grotesk'; src: url('./fonts/space-grotesk-latin-ext.woff2') format('woff2'); font-weight: 300 700; font-style: normal; font-display: swap; unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+  @font-face { font-family: 'DM Sans'; src: url('./fonts/dm-sans-latin.woff2') format('woff2'); font-weight: 100 1000; font-style: normal; font-display: swap; unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+  @font-face { font-family: 'DM Sans'; src: url('./fonts/dm-sans-latin-ext.woff2') format('woff2'); font-weight: 100 1000; font-style: normal; font-display: swap; unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }`;
+
+const cvCss = (pageWidth) => `${FONTS}
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  body { font-family: 'DM Sans', sans-serif; font-size: 11px; line-height: 1.5; color: #1a1a2e; background: #fff; }
+  .page { width: 100%; max-width: ${pageWidth}; margin: 0 auto; padding: 2px 0; }
+  .header { margin-bottom: 20px; }
+  .header h1 { font-family: 'Space Grotesk', sans-serif; font-size: 28px; font-weight: 700; color: #1a1a2e; letter-spacing: -0.02em; margin-bottom: 6px; line-height: 1.1; }
+  .header-gradient { height: 2px; background: linear-gradient(to right, hsl(187,74%,32%), hsl(270,70%,45%)); border-radius: 1px; margin-bottom: 10px; }
+  .contact-row { display: flex; flex-wrap: wrap; gap: 8px 14px; font-size: 10.5px; line-height: 1.4; color: #555; }
+  .contact-row a { color: #555; text-decoration: none; }
+  .contact-row .separator { color: #ccc; }
+  .section { margin-bottom: 18px; }
+  .section-title { font-family: 'Space Grotesk', sans-serif; font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: hsl(187,74%,32%); border-bottom: 1.5px solid #e2e2e2; padding-bottom: 4px; margin-bottom: 10px; line-height: 1.2; }
+  .summary-text { font-size: 11px; line-height: 1.7; color: #2f2f2f; }
+  a { white-space: nowrap; }
+  .competencies-grid { display: flex; flex-wrap: wrap; gap: 8px; }
+  .competency-tag { font-size: 10px; font-weight: 500; color: hsl(187,74%,28%); background: hsl(187,40%,95%); padding: 4px 10px; border-radius: 3px; border: 1px solid hsl(187,40%,88%); }
+  .job { margin-bottom: 14px; }
+  .job-header { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; margin-bottom: 4px; }
+  .job-company { font-family: 'Space Grotesk', sans-serif; font-size: 12.5px; font-weight: 600; color: hsl(270,70%,45%); }
+  .job-period { font-size: 10.5px; color: #777; white-space: nowrap; }
+  .job-role { font-size: 11px; font-weight: 600; color: #333; margin-bottom: 6px; }
+  .job-location { font-size: 10px; color: #888; }
+  .job ul { padding-left: 18px; margin-top: 6px; }
+  .job li { font-size: 10.5px; line-height: 1.6; color: #333; margin-bottom: 4px; }
+  .project { margin-bottom: 12px; }
+  .project-title { font-family: 'Space Grotesk', sans-serif; font-size: 11.5px; font-weight: 600; color: hsl(270,70%,45%); }
+  .project-desc { font-size: 10.5px; color: #444; margin-top: 3px; line-height: 1.55; }
+  .edu-item { margin-bottom: 8px; }
+  .edu-header { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; }
+  .edu-title { font-weight: 600; font-size: 11px; color: #333; }
+  .edu-org { color: hsl(270,70%,45%); font-weight: 500; }
+  .edu-year { font-size: 10px; color: #777; white-space: nowrap; }
+  .edu-desc { font-size: 10px; color: #666; margin-top: 2px; line-height: 1.5; }
+  .skills-grid { display: flex; flex-direction: column; gap: 6px; }
+  .skill-item { font-size: 10.5px; color: #444; }
+  .skill-category { font-weight: 600; color: #333; }
+  @media print { body { -webkit-print-color-adjust: exact; print-color-adjust: exact; } .page { padding: 0; } }
+  .avoid-break, .job, .project, .edu-item { break-inside: avoid; page-break-inside: avoid; }`;
+
+const cvCss1 = (pageWidth) => `${FONTS}
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  body { font-family: 'DM Sans', sans-serif; font-size: 10px; line-height: 1.4; color: #1a1a2e; background: #fff; }
+  .page { width: 100%; max-width: ${pageWidth}; margin: 0 auto; padding: 2px 0; }
+  .header { margin-bottom: 10px; }
+  .header h1 { font-family: 'Space Grotesk', sans-serif; font-size: 23px; font-weight: 700; color: #1a1a2e; letter-spacing: -0.02em; margin-bottom: 4px; line-height: 1.1; }
+  .header-gradient { height: 2px; background: linear-gradient(to right, hsl(187,74%,32%), hsl(270,70%,45%)); border-radius: 1px; margin-bottom: 7px; }
+  .contact-row { display: flex; flex-wrap: wrap; gap: 6px 12px; font-size: 9.5px; line-height: 1.3; color: #555; }
+  .contact-row a { color: #555; text-decoration: none; }
+  .contact-row .separator { color: #ccc; }
+  .section { margin-bottom: 9px; }
+  .section-title { font-family: 'Space Grotesk', sans-serif; font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: hsl(187,74%,32%); border-bottom: 1.5px solid #e2e2e2; padding-bottom: 2px; margin-bottom: 6px; line-height: 1.2; }
+  .summary-text { font-size: 9.5px; line-height: 1.45; color: #2f2f2f; }
+  a { white-space: nowrap; }
+  .competencies-grid { display: flex; flex-wrap: wrap; gap: 5px; }
+  .competency-tag { font-size: 9px; font-weight: 500; color: hsl(187,74%,28%); background: hsl(187,40%,95%); padding: 2.5px 8px; border-radius: 3px; border: 1px solid hsl(187,40%,88%); }
+  .job { margin-bottom: 7px; }
+  .job-header { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; margin-bottom: 1px; }
+  .job-company { font-family: 'Space Grotesk', sans-serif; font-size: 10.5px; font-weight: 600; color: hsl(270,70%,45%); }
+  .job-period { font-size: 9px; color: #777; white-space: nowrap; }
+  .job-role { font-size: 9.5px; font-weight: 600; color: #333; margin-bottom: 1px; }
+  .job-location { font-size: 8.5px; color: #888; }
+  .job ul { padding-left: 15px; margin-top: 2px; }
+  .job li { font-size: 9px; line-height: 1.4; color: #333; margin-bottom: 1.5px; }
+  .job.compact { margin-bottom: 6px; }
+  .job.compact .job-sub { font-size: 9.5px; color: #444; margin-top: 1px; }
+  .job.compact .job-sub strong { font-weight: 600; }
+  .project { margin-bottom: 6px; }
+  .project-title { font-family: 'Space Grotesk', sans-serif; font-size: 10px; font-weight: 600; color: hsl(270,70%,45%); }
+  .project-desc { font-size: 9.5px; color: #444; margin-top: 1px; line-height: 1.4; }
+  .edu-item { margin-bottom: 4px; }
+  .edu-header { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; }
+  .edu-title { font-weight: 600; font-size: 10px; color: #333; }
+  .edu-org { color: hsl(270,70%,45%); font-weight: 500; }
+  .edu-year { font-size: 9.5px; color: #777; white-space: nowrap; }
+  .skills-grid { display: flex; flex-direction: column; gap: 3px; }
+  .skill-item { font-size: 9.5px; color: #444; line-height: 1.4; }
+  .skill-category { font-weight: 600; color: #333; }
+  @media print { body { -webkit-print-color-adjust: exact; print-color-adjust: exact; } .page { padding: 0; } }
+  .avoid-break, .job, .project, .edu-item { break-inside: avoid; page-break-inside: avoid; }`;
+
+const coverCss = (pageWidth) => `${FONTS}
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  body { font-family: 'DM Sans', sans-serif; font-size: 11px; line-height: 1.65; color: #1a1a2e; background: #fff; }
+  .page { width: 100%; max-width: ${pageWidth}; margin: 0 auto; padding: 2px 0; }
+  .header { margin-bottom: 22px; }
+  .header h1 { font-family: 'Space Grotesk', sans-serif; font-size: 28px; font-weight: 700; color: #1a1a2e; letter-spacing: -0.02em; margin-bottom: 6px; line-height: 1.1; }
+  .header-gradient { height: 2px; background: linear-gradient(to right, hsl(187,74%,32%), hsl(270,70%,45%)); border-radius: 1px; margin-bottom: 10px; }
+  .contact-row { display: flex; flex-wrap: wrap; gap: 8px 14px; font-size: 10.5px; line-height: 1.4; color: #555; }
+  .contact-row a { color: #555; text-decoration: none; }
+  .contact-row .separator { color: #ccc; }
+  .meta { font-size: 10.5px; color: #777; margin-bottom: 18px; }
+  .meta strong { color: #333; font-weight: 600; }
+  .salutation { font-size: 11px; margin-bottom: 12px; }
+  p.body-para { font-size: 11px; line-height: 1.7; color: #2f2f2f; margin-bottom: 12px; }
+  p.body-para strong { font-weight: 600; color: #1a1a2e; }
+  .signoff { font-size: 11px; margin-top: 18px; line-height: 1.5; }
+  .signoff .name { font-family: 'Space Grotesk', sans-serif; font-weight: 600; color: hsl(270,70%,45%); margin-top: 4px; }`;
+
+// ---- identity (read from config/profile.yml, fallback to placeholders) -------
+function readIdentity() {
+  // Minimal YAML read to avoid a dependency: pull candidate.{full_name,email,linkedin,location}.
+  const p = join(ROOT, 'config', 'profile.yml');
+  const id = { name: 'Fabe', email: 'Fabe@gmail.com', linkedin: 'linkedin.com/in/fabe', location: 'Paris, France' };
+  if (!existsSync(p)) return id;
+  const raw = readFileSync(p, 'utf8');
+  const grab = (key) => {
+    const m = raw.match(new RegExp(`^\\s*${key}:\\s*["']?([^"'\\n#]+?)["']?\\s*(#.*)?$`, 'm'));
+    return m ? m[1].trim() : null;
+  };
+  id.name = grab('full_name') || id.name;
+  id.email = grab('email') || id.email;
+  id.linkedin = grab('linkedin') || id.linkedin;
+  id.location = grab('location') || id.location;
+  return id;
+}
+
+const esc = (s) => String(s ?? '');
+const header = (id) => `
+  <div class="header avoid-break">
+    <h1>${esc(id.name)}</h1>
+    <div class="header-gradient"></div>
+    <div class="contact-row">
+      <span>${esc(id.email)}</span>
+      <span class="separator">|</span>
+      <a href="https://${esc(id.linkedin)}">${esc(id.linkedin)}</a>
+      <span class="separator">|</span>
+      <span>${esc(id.location)}</span>
+    </div>
+  </div>`;
+
+const L = {
+  en: { summary: 'Professional Summary', comp: 'Core Competencies', exp: 'Work Experience', proj: 'Selected Projects', edu: 'Education & Certifications', skills: 'Skills' },
+  fr: { summary: 'Résumé Professionnel', comp: 'Compétences Clés', exp: 'Expérience Professionnelle', proj: 'Projets Sélectionnés', edu: 'Formation & Certifications', skills: 'Compétences' },
+};
+
+const sec = (title, inner) => `<div class="section avoid-break"><div class="section-title">${title}</div>${inner}</div>`;
+const secExp = (title, inner) => `<div class="section"><div class="section-title">${title}</div>${inner}</div>`;
+const comps = (arr) => `<div class="competencies-grid">${arr.map(c => `<span class="competency-tag">${esc(c)}</span>`).join('')}</div>`;
+const jobFull = (j) => `
+    <div class="job">
+      <div class="job-header"><span class="job-company">${esc(j.company)}</span><span class="job-period">${esc(j.period)}</span></div>
+      <div class="job-role">${esc(j.role)}</div>
+      <div class="job-location">${esc(j.location)}</div>
+      <ul>${j.bullets.map(b => `<li>${esc(b)}</li>`).join('')}</ul>
+    </div>`;
+const jobCompact = (j) => `
+    <div class="job compact">
+      <div class="job-header"><span class="job-company">${esc(j.company)}</span><span class="job-period">${esc(j.period)}</span></div>
+      <div class="job-sub">${j.compact || `<strong>${esc(j.role)}</strong>, ${esc(j.location)}`}</div>
+    </div>`;
+const project = ([t, d]) => `<div class="project"><div class="project-title">${esc(t)}</div><div class="project-desc">${esc(d)}</div></div>`;
+const edu = ([t, org, year, desc]) => `<div class="edu-item"><div class="edu-header"><span class="edu-title">${esc(t)} <span class="edu-org">— ${esc(org)}</span></span><span class="edu-year">${esc(year)}</span></div>${desc ? `<div class="edu-desc">${esc(desc)}</div>` : ''}</div>`;
+const skill = ([cat, txt]) => `<div class="skill-item"><span class="skill-category">${esc(cat)}:</span> ${esc(txt)}</div>`;
+
+const doc = (lang, css, inner) => `<!DOCTYPE html>
+<html lang="${lang}"><head><meta charset="UTF-8"><title>CV</title><style>${css}</style></head>
+<body><div class="page">${inner}</div></body></html>`;
+
+function renderCV(c, id, pages) {
+  const l = L[c.lang] || L.en;
+  const css = pages === 1 ? cvCss1 : cvCss;
+  let expHtml;
+  if (pages === 1) {
+    // Chronological order preserved. To fit one page: first 3 jobs full but
+    // bullet-capped (4 on the most recent, 3 on the next two), the rest compact.
+    const caps = [4, 3, 3];
+    const capped = (j, i) => jobFull({ ...j, bullets: j.bullets.slice(0, caps[i]) });
+    expHtml = c.jobs.slice(0, 3).map(capped).join('') + c.jobs.slice(3).map(jobCompact).join('');
+  } else {
+    expHtml = c.jobs.map(jobFull).join('');
+  }
+  const projects = pages === 1 ? c.projects.slice(0, 2) : c.projects;
+  const education = pages === 1 ? c.education.slice(0, 2) : c.education;
+  const inner = [
+    header(id),
+    sec(l.summary, `<div class="summary-text">${esc(c.summary)}</div>`),
+    sec(l.comp, comps(c.competencies)),
+    secExp(l.exp, expHtml),
+    sec(l.proj, projects.map(project).join('')),
+    sec(l.edu, education.map(edu).join('')),
+    sec(l.skills, `<div class="skills-grid">${c.skills.map(skill).join('')}</div>`),
+  ].join('\n');
+  return doc(c.lang, css(c.paper === 'a4' ? '210mm' : '8.5in'), inner);
+}
+
+function renderCover(c, id) {
+  const pw = c.paper === 'a4' ? '210mm' : '8.5in';
+  const inner = [
+    `<div class="header"><h1>${esc(id.name)}</h1><div class="header-gradient"></div>` +
+      `<div class="contact-row"><span>${esc(id.email)}</span><span class="separator">|</span>` +
+      `<a href="https://${esc(id.linkedin)}">${esc(id.linkedin)}</a><span class="separator">|</span><span>${esc(id.location)}</span></div></div>`,
+    `<div class="meta">${c.cover.meta}</div>`,
+    `<div class="salutation">${esc(c.cover.salutation)}</div>`,
+    c.cover.paras.map(p => `<p class="body-para">${esc(p)}</p>`).join('\n  '),
+    `<div class="signoff">${esc(c.cover.signoff)}<div class="name">${esc(id.name)}</div></div>`,
+  ].join('\n  ');
+  return doc(c.lang, coverCss(pw), inner);
+}
+
+// ---- PDF rendering -----------------------------------------------------------
+function renderPdf(htmlPath, pdfPath, paper) {
+  const fmt = paper === 'a4' ? 'a4' : 'letter';
+  const r = spawnSync(process.execPath, ['generate-pdf.mjs', htmlPath, pdfPath, `--format=${fmt}`], {
+    cwd: ROOT,
+    env: { ...process.env, NODE_OPTIONS: process.env.NODE_OPTIONS || '--use-system-ca' },
+    encoding: 'utf8',
+  });
+  const ok = r.status === 0;
+  const log = (r.stdout || '') + (r.stderr || '');
+  const pages = (r.stdout || '').match(/Pages:\s*(\d+)/)?.[1];
+  // Windows locks a PDF that is open in a viewer → EBUSY. Surface a clear reason.
+  const locked = /EBUSY|EPERM|resource busy or locked/i.test(log);
+  return { ok, pages, locked, log };
+}
+
+// ---- CLI ---------------------------------------------------------------------
+function parseArgs(argv) {
+  const a = { ids: [], all: false, pages: 2, cover: false, coverOnly: false, htmlOnly: false, list: false, date: null };
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === '--id') a.ids.push(argv[++i]);
+    else if (t === '--all') a.all = true;
+    else if (t === '--pages') a.pages = Number(argv[++i]);
+    else if (t === '--cover') a.cover = true;
+    else if (t === '--cover-only') a.coverOnly = true;
+    else if (t === '--html-only') a.htmlOnly = true;
+    else if (t === '--list') a.list = true;
+    else if (t === '--date') a.date = argv[++i];
+    else if (t === '--time') a.time = argv[++i];
+  }
+  return a;
+}
+
+// Report number is the leading 3 digits of the report filename (068-watershed-...md).
+function reportNum(c) {
+  const m = (c.report || '').match(/^(\d{3})/);
+  return m ? m[1] : '000';
+}
+
+function listIds() {
+  if (!existsSync(CONTENT_DIR)) return [];
+  return readdirSync(CONTENT_DIR).filter(f => f.endsWith('.json')).map(f => f.replace(/\.json$/, '')).sort();
+}
+
+function loadCandidate(id) {
+  const p = join(CONTENT_DIR, `${id}.json`);
+  if (!existsSync(p)) throw new Error(`unknown candidate: ${id}`);
+  return JSON.parse(readFileSync(p, 'utf8'));
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.list) { console.log(listIds().join('\n')); return; }
+
+  const ids = args.all ? listIds() : args.ids;
+  if (!ids.length) { console.error('No candidate. Use --id <id>, --all, or --list.'); process.exit(1); }
+
+  // Generation timestamp: server passes --date YYYY-MM-DD and --time HHMM so the
+  // filename reflects when "Generate" was clicked. CLI may omit; new Date() is fine
+  // here (standalone tool). Both feed the output name: CV-<num>-<id>-<date>-<time>.pdf
+  const now = new Date();
+  const date = args.date || now.toISOString().slice(0, 10);
+  const time = args.time || `${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}`;
+  const stamp = `${date}-${time}`;
+  const id = readIdentity();
+  const results = [];
+
+  for (const cid of ids) {
+    const c = loadCandidate(cid);
+    const num = reportNum(c);
+    const tasks = [];
+    if (!args.coverOnly && args.pages >= 1) {
+      const suffix = args.pages === 1 ? '-1page' : '';
+      // HTML is a transient render artifact: keep a stable name (overwritten each run).
+      // PDF gets the final, timestamped, document-typed name.
+      tasks.push({ kind: 'cv', html: `cv-fabe-${cid}${suffix}.html`, pdf: `CV-${num}-${cid}${suffix}-${stamp}.pdf`, build: () => renderCV(c, id, args.pages) });
+    }
+    if (args.cover || args.coverOnly) {
+      tasks.push({ kind: 'cover', html: `cover-fabe-${cid}.html`, pdf: `CL-${num}-${cid}-${stamp}.pdf`, build: () => renderCover(c, id) });
+    }
+    for (const t of tasks) {
+      writeFileSync(out(t.html), t.build());
+      let pdfInfo = null;
+      if (!args.htmlOnly) pdfInfo = renderPdf(out(t.html), out(t.pdf), c.paper);
+      results.push({ cid, kind: t.kind, html: t.html, pdf: args.htmlOnly ? null : t.pdf, ...(pdfInfo || {}) });
+    }
+  }
+
+  // machine-readable summary on the last line for the server to parse
+  for (const r of results) {
+    const tag = r.pdf ? `output/${r.pdf}${r.pages ? ` (${r.pages}p)` : ''}` : `output/${r.html}`;
+    const fail = r.ok === false ? (r.locked ? ' [PDF LOCKED — close it in your viewer and retry]' : ' [PDF FAILED]') : '';
+    console.log(`${r.cid} ${r.kind}: ${tag}${fail}`);
+  }
+  console.log('__RESULT__ ' + JSON.stringify(results.map(r => ({ id: r.cid, kind: r.kind, pdf: r.pdf, pages: r.pages, ok: r.ok !== false, locked: !!r.locked }))));
+}
+
+main();

--- a/batch/gen-applications.mjs
+++ b/batch/gen-applications.mjs
@@ -139,36 +139,48 @@ const coverCss = (pageWidth) => `${FONTS}
   .signoff { font-size: 11px; margin-top: 18px; line-height: 1.5; }
   .signoff .name { font-family: 'Space Grotesk', sans-serif; font-weight: 600; color: hsl(270,70%,45%); margin-top: 4px; }`;
 
-// ---- identity (read from config/profile.yml, fallback to placeholders) -------
+// ---- identity (read from config/profile.yml) --------------------------------
 function readIdentity() {
-  // Minimal YAML read to avoid a dependency: pull candidate.{full_name,email,linkedin,location}.
+  // Minimal YAML read to avoid a dependency. An empty value ("") is meaningful
+  // (field intentionally omitted) and is NOT replaced by a default.
   const p = join(ROOT, 'config', 'profile.yml');
-  const id = { name: 'Fabe', email: 'Fabe@gmail.com', linkedin: 'linkedin.com/in/fabe', location: 'Paris, France' };
+  const id = { name: '', email: '', phone: '', linkedin: '', location: '' };
   if (!existsSync(p)) return id;
   const raw = readFileSync(p, 'utf8');
+  // Returns the trimmed string (possibly ''), or null if the key is absent.
   const grab = (key) => {
-    const m = raw.match(new RegExp(`^\\s*${key}:\\s*["']?([^"'\\n#]+?)["']?\\s*(#.*)?$`, 'm'));
-    return m ? m[1].trim() : null;
+    const m = raw.match(new RegExp(`^\\s*${key}:\\s*(.*)$`, 'm'));
+    if (!m) return null;
+    return m[1].replace(/\s+#.*$/, '').trim().replace(/^["']|["']$/g, '');
   };
-  id.name = grab('full_name') || id.name;
-  id.email = grab('email') || id.email;
-  id.linkedin = grab('linkedin') || id.linkedin;
-  id.location = grab('location') || id.location;
+  const set = (k, key) => { const v = grab(key); if (v !== null) id[k] = v; };
+  set('name', 'full_name');
+  set('email', 'email');
+  set('phone', 'phone');
+  set('linkedin', 'linkedin');
+  set('location', 'location');
   return id;
 }
 
 const esc = (s) => String(s ?? '');
+
+// Build the contact row from non-empty fields only, joined by separators.
+// opts.phone controls whether the phone is included (CV: yes, cover letter: no —
+// the career-ops rule forbids phone numbers in candidate-facing messages).
+function contactRow(id, opts = {}) {
+  const parts = [];
+  if (opts.phone && id.phone) parts.push(`<span>${esc(id.phone)}</span>`);
+  if (id.email) parts.push(`<span>${esc(id.email)}</span>`);
+  if (id.linkedin) parts.push(`<a href="https://${esc(id.linkedin)}">${esc(id.linkedin)}</a>`);
+  if (id.location) parts.push(`<span>${esc(id.location)}</span>`);
+  return `<div class="contact-row">${parts.join('<span class="separator">|</span>')}</div>`;
+}
+
 const header = (id) => `
   <div class="header avoid-break">
     <h1>${esc(id.name)}</h1>
     <div class="header-gradient"></div>
-    <div class="contact-row">
-      <span>${esc(id.email)}</span>
-      <span class="separator">|</span>
-      <a href="https://${esc(id.linkedin)}">${esc(id.linkedin)}</a>
-      <span class="separator">|</span>
-      <span>${esc(id.location)}</span>
-    </div>
+    ${contactRow(id, { phone: true })}
   </div>`;
 
 const L = {
@@ -229,9 +241,8 @@ function renderCV(c, id, pages) {
 function renderCover(c, id) {
   const pw = c.paper === 'a4' ? '210mm' : '8.5in';
   const inner = [
-    `<div class="header"><h1>${esc(id.name)}</h1><div class="header-gradient"></div>` +
-      `<div class="contact-row"><span>${esc(id.email)}</span><span class="separator">|</span>` +
-      `<a href="https://${esc(id.linkedin)}">${esc(id.linkedin)}</a><span class="separator">|</span><span>${esc(id.location)}</span></div></div>`,
+    // No phone on the cover letter (career-ops rule: never share phone in messages).
+    `<div class="header"><h1>${esc(id.name)}</h1><div class="header-gradient"></div>${contactRow(id, { phone: false })}</div>`,
     `<div class="meta">${c.cover.meta}</div>`,
     `<div class="salutation">${esc(c.cover.salutation)}</div>`,
     c.cover.paras.map(p => `<p class="body-para">${esc(p)}</p>`).join('\n  '),

--- a/data/applications-content/cohere.json
+++ b/data/applications-content/cohere.json
@@ -1,0 +1,105 @@
+{
+  "id": "cohere",
+  "company": "Cohere",
+  "role": "Technical Program Manager, Product Engineering",
+  "lang": "en",
+  "paper": "letter",
+  "report": "052-cohere-2026-05-28.md",
+  "summary": "Senior program manager with 16 years of tier-1 project management at Crédit Agricole, built around multi-workstream program architecture: Basel II/III, BCBS 239, Pillar 3, IFRS 7, and Group ESG reporting run in parallel. Built program infrastructure from scratch (GreenWay, a Group-wide platform with 1,000+ users), set the executive operating cadence, and mapped dependencies across IT, Risk, Finance, and Audit. Alyra-certified in AI project management (2025). Now bringing that discipline to a nascent AI product portfolio.",
+  "competencies": [
+    "Program architecture",
+    "Multi-workstream delivery",
+    "Cross-functional dependency mapping",
+    "Executive operating cadence",
+    "Roadmapping & milestone tracking",
+    "Influence without authority",
+    "Risk & escalation management",
+    "AI project management (Alyra)"
+  ],
+  "jobs": [
+    {
+      "company": "Crédit Agricole SA",
+      "period": "04/2021 – 09/2024",
+      "role": "Head of Extra-Financial (ESG) Reporting — Group CSR Department",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Built GreenWay, the Group-wide reporting platform, from scratch: the program infrastructure (indicator frameworks, reporting protocol, planning, status cadence) behind 1,000+ users across every entity.",
+        "Set and ran the executive operating cadence (ComEx, steering and operating committees, entity workshops, roadshows), turning messy status into decision-ready updates.",
+        "Mapped dependencies and coordinated IT, business, and audit teams to ship recurring reporting cycles without slip."
+      ],
+      "compact": "<strong>Head of Extra-Financial (ESG) Reporting</strong>, Montrouge — Built GreenWay (1,000+ users) from scratch: program infrastructure, executive cadence, dependency mapping."
+    },
+    {
+      "company": "Crédit Agricole SA",
+      "period": "04/2018 – 04/2021",
+      "role": "Project Manager — Group Risk Division",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Ran multiple regulatory workstreams in parallel: Prudent Valuation, Institution to Aggregate, Pillar 3, and BCBS 239, each with cascading dependencies and quarterly deadlines.",
+        "Owned the consolidated plan, arbitrated priorities across workstreams, and escalated rather than absorbed blockers.",
+        "Delivered quarterly regulatory closings on cadence: configuration, deployment, business support, incident tracking."
+      ],
+      "compact": "<strong>Project Manager, Group Risk Division</strong>, Montrouge — Ran Pillar 3, BCBS 239, and Prudent Valuation in parallel; owned the consolidated plan and escalation."
+    },
+    {
+      "company": "Crédit Agricole CIB",
+      "period": "09/2013 – 03/2018",
+      "role": "Project Manager",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Managed the application producing the bank's prudential ratios, driving changes tied to regulatory reforms, architecture, and user needs.",
+        "Coordinated holding-company teams for the annual IFRS 7 reporting publication.",
+        "Held credible technical conversations with IT: challenged proposed solutions, owned test strategies and qualification."
+      ],
+      "compact": "<strong>Project Manager</strong>, Montrouge — Managed the prudential-ratio application; coordinated the annual IFRS 7 publication and challenged IT solutions."
+    },
+    {
+      "company": "Iorga",
+      "period": "02/2012 – 08/2013",
+      "role": "Senior Consultant",
+      "location": "Paris, France",
+      "bullets": [
+        "Supported the design and rollout of prudential-ratio production applications for banking clients."
+      ],
+      "compact": "<strong>Senior Consultant</strong>, Paris — Designed and rolled out prudential-ratio production applications for banking clients."
+    },
+    {
+      "company": "Ineum Consulting",
+      "period": "02/2007 – 11/2009",
+      "role": "Senior Consultant",
+      "location": "New York & Paris",
+      "bullets": [
+        "Served as PMO on the Basel II rollout for Société Générale Equipment Finance (Paris) and Americas Securities (New York); mapped and standardized cross-org data flows."
+      ],
+      "compact": "<strong>Senior Consultant</strong>, New York & Paris — PMO on the Basel II rollout for Société Générale Equipment Finance and Americas Securities."
+    }
+  ],
+  "projects": [
+    ["GreenWay — program built from scratch", "Stood up a Group-wide reporting platform (1,000+ users): indicator frameworks, protocol, planning, and executive cadence, all built where nothing existed before."],
+    ["Multi-workstream regulatory portfolio — CASA Risk", "Ran Pillar 3, BCBS 239, Prudent Valuation, and Yoshikuni in parallel, with consolidated planning and cross-team dependency management."],
+    ["Basel II rollout — Société Générale Equipment Finance", "PMO across a cross-org regulatory program spanning Paris and New York."]
+  ],
+  "education": [
+    ["AI Project Management & Consulting Certification", "Alyra", "2025", "Project management for AI projects using agile methods and AI consulting."],
+    ["Master in International Finance (taught in English)", "ISC Paris", "2005", ""],
+    ["Professional Title, Small-Business Entrepreneurship (RNCP III)", "CNE Paris", "2011", ""]
+  ],
+  "skills": [
+    ["Program & Project", "program architecture, multi-workstream delivery, dependency mapping, executive operating cadence, roadmapping, milestone tracking, PMO, governance"],
+    ["Cross-functional", "influence without authority, IT/Risk/Finance/Audit coordination, risk & escalation management, vendor and stakeholder management"],
+    ["Regulated data", "BCBS 239, Pillar 3, Basel III, IFRS, prudential ratios, ESG/CSRD reporting"],
+    ["AI & Automation", "AI project management (Alyra-certified), AI consulting, automation"],
+    ["Languages", "French (native), English (fluent)"]
+  ],
+  "cover": {
+    "meta": "<strong>Cohere</strong> &middot; Technical Program Manager, Product Engineering",
+    "salutation": "Dear Cohere team,",
+    "paras": [
+      "Your posting says this is a program architecture role, not delivery coordination. That is exactly the work I have done for 16 years. At Crédit Agricole I built GreenWay, a Group-wide reporting platform, from scratch: the frameworks, the cadence, the dependency maps, the status that executives could act on. There was no operating backbone before me. I built it.",
+      "Running multiple workstreams at once is the job I know best. For three years I carried Pillar 3, BCBS 239, Prudent Valuation, and Yoshikuni in parallel, each with cascading risks and quarterly deadlines, and shipped the closes without slip. The skill that makes that work, translating a messy picture into a decision-ready signal and escalating early, is the skill your nascent product portfolio needs.",
+      "I will be straight about the gap: my AI/ML product fluency is new. I am Alyra-certified (2025), I read the papers, and I run my own automations with Claude, n8n, and Make. My edge is the program architecture, not the modeling, and that is what this role is built around. Cohere's enterprise focus, builder culture, and Paris office are exactly where I want to bring it.",
+      "I would welcome an early conversation about how this discipline maps to your product engineering programs."
+    ],
+    "signoff": "Thank you for your time,"
+  }
+}

--- a/data/applications-content/pennylane_it.json
+++ b/data/applications-content/pennylane_it.json
@@ -1,0 +1,104 @@
+{
+  "id": "pennylane_it",
+  "company": "Pennylane",
+  "role": "IT Project Manager",
+  "lang": "en",
+  "paper": "a4",
+  "report": "060-pennylane-2026-05-28.md",
+  "summary": "Senior project manager with 16 years in tier-1 regulated banking (Crédit Agricole): BCBS 239, Pillar 3, and Group ESG/CSRD reporting, a regulatory-compliance discipline that maps directly onto DORA and ISO 27001. Built governance frameworks and referentials, ran the executive committees behind them, and coordinated IT, Risk, and Audit across a 1,000+ user organization. Alyra-certified in AI project management (2025), hands-on daily with Claude, n8n, and Make. Now leading IT governance and AI adoption in a fast-growing FinTech.",
+  "competencies": [
+    "IT governance",
+    "Regulatory compliance (DORA, ISO 27001)",
+    "AI governance standards",
+    "Shadow AI mitigation",
+    "Change management for AI adoption",
+    "Vendor management",
+    "Cross-functional coordination",
+    "AI project management (Alyra)"
+  ],
+  "jobs": [
+    {
+      "company": "Crédit Agricole SA",
+      "period": "04/2021 – 09/2024",
+      "role": "Head of Extra-Financial (ESG) Reporting — Group CSR Department",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Owned GreenWay, a Group-wide platform, and built the governance standards behind it: referentials, reporting protocol, controls, and data-collection forms.",
+        "Ran change management across entities to drive adoption: onboarding, training, executive sponsorship.",
+        "Presented to executive committees, translating compliance and data requirements into decisions."
+      ],
+      "compact": "<strong>Head of Extra-Financial (ESG) Reporting</strong>, Montrouge — Owned GreenWay and built the governance standards, referentials, and controls behind it."
+    },
+    {
+      "company": "Crédit Agricole SA",
+      "period": "04/2018 – 04/2021",
+      "role": "Project Manager — Group Risk Division",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Led BCBS 239 and Pillar 3, the banking-sector ancestors of DORA: regulated operational and data-resilience compliance with strict controls and audit trails.",
+        "Defined requirements, ran governance committees, and coordinated IT, Risk, and business stakeholders.",
+        "Managed budget and vendors across regulatory programs; delivered quarterly closings on cadence."
+      ],
+      "compact": "<strong>Project Manager, Group Risk Division</strong>, Montrouge — Led BCBS 239 and Pillar 3 (DORA-class compliance): operational resilience, data governance, audit-ready controls."
+    },
+    {
+      "company": "Crédit Agricole CIB",
+      "period": "09/2013 – 03/2018",
+      "role": "Project Manager",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Managed the application producing the bank's prudential ratios; coordinated holding-company teams for the annual IFRS 7 publication.",
+        "Owned test strategies, qualification, and incident management across regulatory releases."
+      ],
+      "compact": "<strong>Project Manager</strong>, Montrouge — Managed the prudential-ratio application; owned test strategies, qualification, and incident management."
+    },
+    {
+      "company": "Iorga",
+      "period": "02/2012 – 08/2013",
+      "role": "Senior Consultant",
+      "location": "Paris, France",
+      "bullets": [
+        "Supported the design and rollout of regulatory production applications for banking clients."
+      ],
+      "compact": "<strong>Senior Consultant</strong>, Paris — Designed and rolled out regulatory production applications for banking clients."
+    },
+    {
+      "company": "Ineum Consulting",
+      "period": "02/2007 – 11/2009",
+      "role": "Senior Consultant",
+      "location": "New York & Paris",
+      "bullets": [
+        "Served as PMO on the Basel II rollout for Société Générale Equipment Finance and Americas Securities."
+      ],
+      "compact": "<strong>Senior Consultant</strong>, New York & Paris — PMO on the Basel II rollout for Société Générale."
+    }
+  ],
+  "projects": [
+    ["GreenWay — Group-wide governance platform", "Built the governance standards, referentials, and controls behind a Group-wide platform with 1,000+ users."],
+    ["BCBS 239 — regulated compliance (DORA-class)", "Led tier-1 banking compliance with the same shape as DORA: operational resilience, data governance, audit-ready controls."],
+    ["Personal AI automations — Claude / n8n / Make", "Hands-on AI literacy: built personal workflows automating real tasks, the practical grounding for AI governance and Shadow AI policy."]
+  ],
+  "education": [
+    ["AI Project Management & Consulting Certification", "Alyra", "2025", "Project management for AI projects using agile methods and AI consulting."],
+    ["Master in International Finance (taught in English)", "ISC Paris", "2005", ""],
+    ["Professional Title, Small-Business Entrepreneurship (RNCP III)", "CNE Paris", "2011", ""]
+  ],
+  "skills": [
+    ["Governance & Compliance", "IT governance, regulatory compliance (DORA, ISO 27001), BCBS 239, Pillar 3, audit-ready controls, governance standards"],
+    ["AI Governance", "AI governance standards, AI committee, Shadow AI mitigation, change management for AI adoption, AI literacy"],
+    ["Project & Vendor", "program management, PMO, cross-functional coordination, vendor management, budget, planning"],
+    ["Hands-on AI", "Alyra-certified; daily use of Claude, n8n, Make; automation"],
+    ["Languages", "French (native), English (fluent)"]
+  ],
+  "cover": {
+    "meta": "<strong>Pennylane</strong> &middot; IT Project Manager",
+    "salutation": "Dear Pennylane team,",
+    "paras": [
+      "DORA is, for Pennylane today, what BCBS 239 was for Crédit Agricole a decade ago, and I led that effort. For 16 years I ran regulated compliance programs in tier-1 banking: BCBS 239, Pillar 3, and Group ESG/CSRD reporting. The shape of the work, operational resilience, data governance, audit-ready controls, is exactly what ISO 27001 and DORA ask of a fast-growing FinTech.",
+      "What makes this role rare is the second half: AI governance and Shadow AI. I am Alyra-certified (2025) and I use Claude, n8n, and Make every day to automate real work. That combination, regulated-compliance discipline plus hands-on AI literacy, is what lets someone design sound AI usage standards and an AI committee rather than just write a policy nobody follows.",
+      "I will name the gap directly: I have not administered Okta, Jamf, or Google Workspace in production. Those are tools I can ramp on in weeks, backed by 16 years of vendor management, governance standards, and change management. The mindset the role needs, compliance plus AI governance, is the hard part, and it is the part I already have.",
+      "I would welcome a conversation, and I can walk you through a DORA readiness roadmap and a first-draft AI usage policy."
+    ],
+    "signoff": "Thank you for your time,"
+  }
+}

--- a/data/applications-content/pennylane_ka.json
+++ b/data/applications-content/pennylane_ka.json
@@ -1,0 +1,104 @@
+{
+  "id": "pennylane_ka",
+  "company": "Pennylane",
+  "role": "Project Manager Key Accounts",
+  "lang": "fr",
+  "paper": "a4",
+  "report": "056-pennylane-2026-05-28.md",
+  "summary": "Chef de projet senior, 16 ans d'expérience en environnement finance et comptabilité tier-1 (Crédit Agricole). Pilotage de programmes Groupe multi-entités de bout en bout : cadrage, déploiement, adoption d'une plateforme auprès de 1 000+ utilisateurs, animation de comités de décideurs (ComEx, CoPil) et amélioration continue des process. Socle IFRS et comptabilité bancaire directement mobilisable. Certifié Alyra en gestion de projet IA (2025). Aujourd'hui tourné vers l'accompagnement des grands comptes dans leur transformation digitale.",
+  "competencies": [
+    "Gestion de projet de bout en bout",
+    "Déploiement & adoption",
+    "Relation décideurs exigeants",
+    "Conduite du changement",
+    "Comptabilité & IFRS",
+    "Amélioration continue des process",
+    "Coordination multi-interlocuteurs",
+    "Conseil"
+  ],
+  "jobs": [
+    {
+      "company": "Crédit Agricole SA",
+      "period": "04/2021 – 09/2024",
+      "role": "Responsable Reporting Extra-financier — Direction RSE Groupe",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Piloté GreenWay, la plateforme de reporting du Groupe, de bout en bout : cadrage, déploiement multi-entités, montée en adoption auprès de 1 000+ utilisateurs.",
+        "Construit la relation de confiance avec des décideurs exigeants (ComEx, CoPil, directions d'entités) et porté les campagnes de reporting comme des cycles de renouvellement de confiance.",
+        "Structuré les référentiels, protocoles et livrables, et contribué à l'amélioration continue des process de reporting."
+      ],
+      "compact": "<strong>Responsable Reporting Extra-financier</strong>, Montrouge — Piloté GreenWay (1 000+ utilisateurs) de bout en bout : déploiement multi-entités, adoption, amélioration continue."
+    },
+    {
+      "company": "Crédit Agricole SA",
+      "period": "04/2018 – 04/2021",
+      "role": "Chef de Projets — Direction des Risques Groupe",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Piloté des projets multi-interlocuteurs à forte dimension stratégique : Prudent Valuation, Institution to Aggregate, Pilier 3, BCBS 239.",
+        "Défini les besoins, animé les instances projet, coordonné IT et métiers, géré planning et budget.",
+        "Produit les arrêtés trimestriels : paramétrage, déploiement, support métier, suivi des incidents."
+      ],
+      "compact": "<strong>Chef de Projets, Direction des Risques Groupe</strong>, Montrouge — Piloté Pilier 3, BCBS 239 et Prudent Valuation; coordonné IT et métiers."
+    },
+    {
+      "company": "Crédit Agricole CIB",
+      "period": "09/2013 – 03/2018",
+      "role": "Chef de Projets",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Piloté l'application produisant les ratios prudentiels et coordonné les équipes de la holding pour la publication annuelle du reporting IFRS 7.",
+        "Maîtrise concrète des concepts comptables et financiers (IFRS, ratios prudentiels) en environnement bancaire tier-1."
+      ],
+      "compact": "<strong>Chef de Projets</strong>, Montrouge — Piloté l'application des ratios prudentiels; coordonné la publication annuelle IFRS 7."
+    },
+    {
+      "company": "Iorga",
+      "period": "02/2012 – 08/2013",
+      "role": "Consultant Senior",
+      "location": "Paris, France",
+      "bullets": [
+        "Accompagné des clients bancaires dans la création et le déploiement d'applications réglementaires, avec un fort sens du conseil."
+      ],
+      "compact": "<strong>Consultant Senior</strong>, Paris — Accompagnement de clients bancaires sur des applications réglementaires, fort sens du conseil."
+    },
+    {
+      "company": "Ineum Consulting",
+      "period": "02/2007 – 11/2009",
+      "role": "Consultant Senior",
+      "location": "New York & Paris",
+      "bullets": [
+        "Mission PMO sur le déploiement de Bâle II pour Société Générale Equipement Finance (Paris) et Americas Securities (New York)."
+      ],
+      "compact": "<strong>Consultant Senior</strong>, New York & Paris — PMO sur le déploiement de Bâle II pour Société Générale."
+    }
+  ],
+  "projects": [
+    ["GreenWay — déploiement plateforme Groupe", "Pilotage du déploiement multi-entités et de l'adoption d'une plateforme de reporting auprès de 1 000+ utilisateurs : l'équivalent interne d'un déploiement SaaS chez un grand compte."],
+    ["Reporting IFRS 7 — Crédit Agricole CIB", "Coordination des équipes de la holding pour la publication annuelle, en environnement comptable et réglementaire."],
+    ["BCBS 239 — Direction des Risques Groupe", "Projet multi-stakeholder à forte dimension stratégique, animation des instances et coordination IT/métiers."]
+  ],
+  "education": [
+    ["Certification Gestion de Projet IA & Conseil", "Alyra", "2025", "Gestion de projet pour les projets IA, méthodes agiles et conseil en intelligence artificielle."],
+    ["Master de Finance Internationale (enseigné en anglais)", "ISC Paris", "2005", ""],
+    ["Titre professionnel d'Entrepreneur de petite entreprise (RNCP III)", "CNE Paris", "2011", ""]
+  ],
+  "skills": [
+    ["Gestion de projet", "pilotage de bout en bout, déploiement, adoption, conduite du changement, planning, budget, animation d'instances, amélioration continue"],
+    ["Relation & conseil", "relation décideurs exigeants, animation ComEx/CoPil, sens du conseil, coordination multi-interlocuteurs"],
+    ["Comptabilité & finance", "IFRS, comptabilité bancaire, ratios prudentiels, BCBS 239, Pilier 3, reporting ESG/CSRD"],
+    ["IA & automatisation", "gestion de projet IA (certifié Alyra), conseil IA, automatisation"],
+    ["Langues", "Français (natif), Anglais (courant)"]
+  ],
+  "cover": {
+    "meta": "<strong>Pennylane</strong> &middot; Project Manager Key Accounts",
+    "salutation": "Bonjour,",
+    "paras": [
+      "Pendant 16 ans, j'ai piloté des projets de transformation en environnement finance et comptabilité au Crédit Agricole. Le vocabulaire de vos clients, les cabinets d'expertise comptable, est le mien : IFRS, comptabilité bancaire, ratios prudentiels, reporting réglementaire. Je n'ai pas à apprendre le métier de la donnée comptable, je l'ai pratiqué tous les jours.",
+      "Le cœur du poste, piloter un déploiement de bout en bout chez un grand compte exigeant, est exactement ce que j'ai fait avec GreenWay : une plateforme déployée auprès de 1 000+ utilisateurs à travers tout le Groupe, de la phase pilote à l'adoption, en passant par la relation avec des décideurs et l'amélioration continue des process. La différence avec un cabinet, c'est le cadre, pas la discipline.",
+      "Je suis transparent sur l'écart : je n'ai pas géré de compte client externe en SaaS B2B. Mais chaque cycle de reporting a été un renouvellement de confiance avec les entités que j'accompagnais, gagné en livrant à l'heure et en expliquant clairement des sujets complexes. Mes six ans de conseil client (Ineum, Iorga) m'ont donné ce réflexe de la relation externe.",
+      "Je serais ravi d'échanger sur la façon dont cette expérience peut servir vos plus grands comptes."
+    ],
+    "signoff": "Merci de votre attention,"
+  }
+}

--- a/data/applications-content/watershed.json
+++ b/data/applications-content/watershed.json
@@ -1,0 +1,110 @@
+{
+  "id": "watershed",
+  "company": "Watershed",
+  "role": "Customer Success Manager, Strategic",
+  "lang": "en",
+  "paper": "letter",
+  "report": "068-watershed-2026-05-28.md",
+  "summary": "Reporting and program leader with 16 years of tier-1 project management at Crédit Agricole, including 3.5 years owning the Group's extra-financial (ESG) reporting platform. Built audit-ready CSRD and DPEF disclosures, ran the data governance behind them, and presented sustainability data to ComEx-level executives as input to strategic decisions. Coordinated business, IT, and audit teams across a 1,000+ user organization. Alyra-certified in AI project management (2025). Now partnering with sustainability leaders to turn climate and ESG data into executive decisions.",
+  "competencies": [
+    "CSRD & ESG reporting",
+    "Audit-ready disclosures",
+    "Sustainability data strategy",
+    "Executive relationships (ComEx)",
+    "Change management at scale",
+    "Regulatory & voluntary reporting",
+    "Multi-stakeholder coordination",
+    "Data governance"
+  ],
+  "jobs": [
+    {
+      "company": "Crédit Agricole SA",
+      "period": "04/2021 – 09/2024",
+      "role": "Head of Extra-Financial (ESG) Reporting — Group CSR Department",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Owned GreenWay, the Group-wide sustainability reporting platform, and the relationships with the entities reporting into it across the organization.",
+        "Produced audit-ready disclosures for both regulatory and voluntary reporting: the Extra-Financial Performance Statement (DPEF) and CSRD-readiness deliverables.",
+        "Presented sustainability data to executive bodies (ComEx, steering and operating committees, entity workshops, roadshows), linking ESG metrics to strategic decisions.",
+        "Built the reporting protocol, indicator frameworks, controls, and ESG data-collection forms that made every disclosure auditable.",
+        "Ran change management across entities to drive adoption of the platform: onboarding, training, executive sponsorship, and recurring reporting cycles."
+      ],
+      "compact": "<strong>Head of Extra-Financial (ESG) Reporting</strong>, Montrouge — Owned GreenWay, the Group-wide sustainability reporting platform, and the audit-ready CSRD/DPEF disclosures behind it."
+    },
+    {
+      "company": "Crédit Agricole SA",
+      "period": "04/2018 – 04/2021",
+      "role": "Project Manager — Group Risk Division",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Led regulated data-governance projects for the Group Risk Division: Prudent Valuation, Institution to Aggregate, Pillar 3, and BCBS 239.",
+        "Defined requirements, ran project governance, and coordinated IT and business stakeholders across teams.",
+        "Delivered quarterly regulatory closings: configuration, deployment, business support, and incident tracking."
+      ],
+      "compact": "<strong>Project Manager, Group Risk Division</strong>, Montrouge — Led BCBS 239, Pillar 3, and Prudent Valuation; coordinated IT and business stakeholders."
+    },
+    {
+      "company": "Crédit Agricole CIB",
+      "period": "09/2013 – 03/2018",
+      "role": "Project Manager",
+      "location": "Montrouge, France",
+      "bullets": [
+        "Managed the application producing the bank's prudential ratios, driving changes tied to regulatory reforms, architecture, and user needs.",
+        "Coordinated holding-company teams for the annual IFRS 7 reporting publication.",
+        "Delivered scoping notes, requirements, committee materials, test strategies, and consolidated project reporting."
+      ],
+      "compact": "<strong>Project Manager</strong>, Montrouge — Managed the application producing the bank's prudential ratios; coordinated the annual IFRS 7 reporting publication."
+    },
+    {
+      "company": "Iorga",
+      "period": "02/2012 – 08/2013",
+      "role": "Senior Consultant",
+      "location": "Paris, France",
+      "bullets": [
+        "Supported the design and rollout of prudential-ratio production applications for banking clients.",
+        "Delivered scoping and steering artifacts: requirements, committee materials, test strategies."
+      ],
+      "compact": "<strong>Senior Consultant</strong>, Paris — Designed and rolled out prudential-ratio production applications for banking clients."
+    },
+    {
+      "company": "Ineum Consulting",
+      "period": "02/2007 – 11/2009",
+      "role": "Senior Consultant",
+      "location": "New York & Paris",
+      "bullets": [
+        "Served as PMO on the Basel II rollout for Société Générale Equipment Finance (Paris) and Société Générale Americas Securities (New York).",
+        "Mapped and standardized current and target data flows; contributed to organizational change."
+      ],
+      "compact": "<strong>Senior Consultant</strong>, New York & Paris — PMO on the Basel II rollout for Société Générale Equipment Finance and Americas Securities."
+    }
+  ],
+  "projects": [
+    ["GreenWay — Group-wide sustainability reporting platform", "Owned and ran the Crédit Agricole Group platform turning ESG data from every entity into audit-ready CSRD and DPEF disclosures. The customer-side equivalent of what sustainability software vendors sell."],
+    ["CSRD / DPEF readiness — Crédit Agricole Group", "Structured the indicator frameworks, controls, and reporting protocol behind the Group's regulatory and voluntary sustainability disclosures."],
+    ["Executive ESG governance — ComEx reporting", "Presented sustainability data to executive committees and entity leadership, translating ESG metrics into decisions across a 1,000+ user organization."]
+  ],
+  "education": [
+    ["AI Project Management & Consulting Certification", "Alyra", "2025", "Project management for AI projects using agile methods and AI consulting."],
+    ["Master in International Finance (taught in English)", "ISC Paris", "2005", ""],
+    ["Professional Title, Small-Business Entrepreneurship (RNCP III)", "CNE Paris", "2011", ""]
+  ],
+  "skills": [
+    ["Sustainability & ESG", "CSRD, ESG reporting, extra-financial reporting, audit-ready disclosures, DPEF, indicator frameworks, sustainability data governance"],
+    ["Customer & Executive", "executive relationships, ComEx-level communication, change management at scale, multi-stakeholder coordination, voice of the customer"],
+    ["Program & Project", "program management, PMO, governance, planning, budget, requirements, business/IT coordination"],
+    ["AI & Automation", "AI project management, AI consulting (Alyra-certified), automation"],
+    ["Regulated data", "BCBS 239, Pillar 3, Basel III, IFRS, prudential ratios, regulatory reporting"],
+    ["Languages", "French (native), English (fluent)"]
+  ],
+  "cover": {
+    "meta": "<strong>Watershed</strong> &middot; Customer Success Manager, Strategic",
+    "salutation": "Dear Watershed team,",
+    "paras": [
+      "I have spent the last three and a half years building exactly what you sell. As Head of Extra-Financial Reporting for the Crédit Agricole Group, I owned GreenWay, a Group-wide platform that turns sustainability data from every entity into audit-ready CSRD and DPEF disclosures. The work your customers are starting, I have already run from the inside.",
+      "Your strategic customers need someone who can sit with a CFO or a sustainability lead and connect climate data to a real decision. That was my job. I presented ESG metrics to executive committees, structured the indicator frameworks and controls that made every figure auditable, and drove adoption across a 1,000+ user organization. CSRD is not a keyword to me, it is the regulation I prepared the Group to meet.",
+      "I am candid about the shift: my strategic-account work has been internal, not as a vendor-side CSM. But the muscle is the same. Every reporting cycle was a renewal of trust with the entities I served, won by delivering on time and explaining hard data clearly. Before the bank, I spent six years in client-facing consulting (Ineum, Iorga), including a posting in New York. I want to bring that craft to Fortune 500 customers from the outside in.",
+      "Sixteen years of tier-1 program discipline, three and a half years owning Group sustainability reporting, and an Alyra AI project-management certification: that is the toolkit I would bring to your strategic portfolio. I would welcome an early conversation, including whether the role can be based out of your Paris office."
+    ],
+    "signoff": "Thank you for your time,"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
     "scan": "node scan.mjs",
-    "gemini:eval": "node gemini-eval.mjs"
+    "gemini:eval": "node gemini-eval.mjs",
+    "web": "node web/server.mjs"
   },
   "keywords": [
     "ai",

--- a/scan.mjs
+++ b/scan.mjs
@@ -39,6 +39,10 @@ function detectApi(company) {
   if (company.api && company.api.includes('greenhouse')) {
     return { type: 'greenhouse', url: company.api };
   }
+  // Workable: explicit api field
+  if (company.api && company.api.includes('workable.com')) {
+    return { type: 'workable', url: company.api };
+  }
 
   const url = company.careers_url || '';
 
@@ -69,19 +73,42 @@ function detectApi(company) {
     };
   }
 
+  // Workable (inferred from careers_url like apply.workable.com/{slug})
+  const workableMatch = url.match(/apply\.workable\.com\/([^/?#]+)/);
+  if (workableMatch) {
+    return {
+      type: 'workable',
+      url: `https://apply.workable.com/api/v1/widget/accounts/${workableMatch[1]}`,
+    };
+  }
+
   return null;
 }
 
 // ── API parsers ─────────────────────────────────────────────────────
 
+// Detect workplace_type from a location string (Greenhouse fallback — no explicit field)
+function inferWorkplaceFromLocation(loc) {
+  if (!loc) return '';
+  const l = loc.toLowerCase();
+  if (/\bremote\b|\bremotely\b|\banywhere\b/.test(l)) return 'remote';
+  if (/\bhybrid\b/.test(l)) return 'hybrid';
+  return '';
+}
+
 function parseGreenhouse(json, companyName) {
   const jobs = json.jobs || [];
-  return jobs.map(j => ({
-    title: j.title || '',
-    url: j.absolute_url || '',
-    company: companyName,
-    location: j.location?.name || '',
-  }));
+  return jobs.map(j => {
+    const location = j.location?.name || '';
+    return {
+      title: j.title || '',
+      url: j.absolute_url || '',
+      company: companyName,
+      location,
+      posted_at: j.first_published || j.updated_at || '',
+      workplace_type: inferWorkplaceFromLocation(location),
+    };
+  });
 }
 
 function parseAshby(json, companyName) {
@@ -91,6 +118,9 @@ function parseAshby(json, companyName) {
     url: j.jobUrl || '',
     company: companyName,
     location: j.location || '',
+    posted_at: j.publishedAt || '',
+    // Ashby workplaceType values: "Remote", "Hybrid", "On-Site", "Unspecified"
+    workplace_type: j.isRemote ? 'remote' : (j.workplaceType || '').toLowerCase().replace('-', ''),
   }));
 }
 
@@ -101,10 +131,32 @@ function parseLever(json, companyName) {
     url: j.hostedUrl || '',
     company: companyName,
     location: j.categories?.location || '',
+    posted_at: j.createdAt ? new Date(j.createdAt).toISOString() : '',
+    // Lever workplaceType values: "remote", "hybrid", "on-site", "unspecified"
+    workplace_type: (j.workplaceType || '').toLowerCase(),
   }));
 }
 
-const PARSERS = { greenhouse: parseGreenhouse, ashby: parseAshby, lever: parseLever };
+function parseWorkable(json, companyName) {
+  const jobs = json.jobs || [];
+  return jobs.map(j => {
+    const loc = j.locations?.[0];
+    const location = loc
+      ? [loc.city, loc.region, loc.country].filter(Boolean).join(', ')
+      : [j.city, j.state, j.country].filter(Boolean).join(', ');
+    return {
+      title: j.title || '',
+      url: j.url || j.shortlink || '',
+      company: companyName,
+      location,
+      posted_at: j.published_on || j.created_at || '',
+      // Workable: telecommuting:true means remote
+      workplace_type: j.telecommuting ? 'remote' : inferWorkplaceFromLocation(location),
+    };
+  });
+}
+
+const PARSERS = { greenhouse: parseGreenhouse, ashby: parseAshby, lever: parseLever, workable: parseWorkable };
 
 // ── Fetch with timeout ──────────────────────────────────────────────
 
@@ -157,37 +209,81 @@ function buildLocationFilter(locationFilter) {
   };
 }
 
+// ── Freshness filter ─────────────────────────────────────────────────
+// Optional. Drop offers older than max_age_days based on posted_at.
+// Empty posted_at → pass (don't penalize missing data).
+
+function buildFreshnessFilter(freshnessFilter) {
+  if (!freshnessFilter?.max_age_days) return () => true;
+  const cutoffMs = Date.now() - freshnessFilter.max_age_days * 86_400_000;
+
+  return (postedAt) => {
+    if (!postedAt) return true;
+    const t = Date.parse(postedAt);
+    if (isNaN(t)) return true;
+    return t >= cutoffMs;
+  };
+}
+
+// ── Remote filter ────────────────────────────────────────────────────
+// Optional. Keep only remote or hybrid roles based on workplace_type or
+// location keywords. If `remote_filter` is absent, all offers pass.
+// Empty workplace_type AND empty location → pass (don't penalize missing).
+
+function buildRemoteFilter(remoteFilter) {
+  if (!remoteFilter) return () => true;
+  const types = (remoteFilter.workplace_types || []).map(k => k.toLowerCase());
+  const keywords = (remoteFilter.location_keywords || []).map(k => k.toLowerCase());
+
+  return (workplaceType, location) => {
+    const wt = (workplaceType || '').toLowerCase();
+    const loc = (location || '').toLowerCase();
+    if (!wt && !loc) return true;
+    if (types.length > 0 && types.some(t => wt.includes(t))) return true;
+    if (keywords.length > 0 && keywords.some(k => loc.includes(k))) return true;
+    return false;
+  };
+}
+
 // ── Dedup ───────────────────────────────────────────────────────────
 
-function loadSeenUrls() {
-  const seen = new Set();
+// Returns two sets:
+//   addedUrls — URLs we've previously added to pipeline/applications (dedup target).
+//   anyUrls   — every URL ever logged in scan-history, used to avoid re-logging
+//               the same skip_* event on every scan.
+function loadHistoryIndex() {
+  const addedUrls = new Set();
+  const anyUrls = new Set();
 
-  // scan-history.tsv
   if (existsSync(SCAN_HISTORY_PATH)) {
     const lines = readFileSync(SCAN_HISTORY_PATH, 'utf-8').split('\n');
-    for (const line of lines.slice(1)) { // skip header
-      const url = line.split('\t')[0];
-      if (url) seen.add(url);
+    for (const line of lines.slice(1)) {
+      const parts = line.split('\t');
+      const url = parts[0];
+      const status = parts[5] || '';
+      if (!url) continue;
+      anyUrls.add(url);
+      if (status === 'added') addedUrls.add(url);
     }
   }
 
-  // pipeline.md — extract URLs from checkbox lines
   if (existsSync(PIPELINE_PATH)) {
     const text = readFileSync(PIPELINE_PATH, 'utf-8');
     for (const match of text.matchAll(/- \[[ x]\] (https?:\/\/\S+)/g)) {
-      seen.add(match[1]);
+      addedUrls.add(match[1]);
+      anyUrls.add(match[1]);
     }
   }
 
-  // applications.md — extract URLs from report links and any inline URLs
   if (existsSync(APPLICATIONS_PATH)) {
     const text = readFileSync(APPLICATIONS_PATH, 'utf-8');
     for (const match of text.matchAll(/https?:\/\/[^\s|)]+/g)) {
-      seen.add(match[0]);
+      addedUrls.add(match[0]);
+      anyUrls.add(match[0]);
     }
   }
 
-  return seen;
+  return { addedUrls, anyUrls };
 }
 
 function loadSeenCompanyRoles() {
@@ -239,16 +335,17 @@ function appendToPipeline(offers) {
   writeFileSync(PIPELINE_PATH, text, 'utf-8');
 }
 
-function appendToScanHistory(offers, date) {
-  // Ensure file + header exist. Location appended as 7th column for non-breaking
-  // backward compat — older scan-history.tsv files with 6 columns still parse fine
-  // since loadSeenUrls only reads column 0.
+function appendToScanHistory(entries, date) {
   if (!existsSync(SCAN_HISTORY_PATH)) {
-    writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\n', 'utf-8');
+    writeFileSync(
+      SCAN_HISTORY_PATH,
+      'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\tposted_at\tworkplace_type\n',
+      'utf-8'
+    );
   }
 
-  const lines = offers.map(o =>
-    `${o.url}\t${date}\t${o.source}\t${o.title}\t${o.company}\tadded\t${o.location || ''}`
+  const lines = entries.map(o =>
+    `${o.url}\t${date}\t${o.source}\t${o.title}\t${o.company}\t${o.status}\t${o.location || ''}\t${o.posted_at || ''}\t${o.workplace_type || ''}`
   ).join('\n') + '\n';
 
   appendFileSync(SCAN_HISTORY_PATH, lines, 'utf-8');
@@ -277,8 +374,12 @@ async function parallelFetch(tasks, limit) {
 async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
-  const companyFlag = args.indexOf('--company');
-  const filterCompany = companyFlag !== -1 ? args[companyFlag + 1]?.toLowerCase() : null;
+  const filterCompanies = args
+    .flatMap((a, i) => (a === '--company' ? [args[i + 1]] : []))
+    .filter(Boolean)
+    .flatMap(s => String(s).split(','))
+    .map(s => s.trim().toLowerCase())
+    .filter(Boolean);
 
   // 1. Read portals.yml
   if (!existsSync(PORTALS_PATH)) {
@@ -290,21 +391,38 @@ async function main() {
   const companies = config.tracked_companies || [];
   const titleFilter = buildTitleFilter(config.title_filter);
   const locationFilter = buildLocationFilter(config.location_filter);
+  const freshnessFilter = buildFreshnessFilter(config.freshness_filter);
+  const remoteFilter = buildRemoteFilter(config.remote_filter);
 
   // 2. Filter to enabled companies with detectable APIs
-  const targets = companies
+  const matchesSelection = c =>
+    !filterCompanies.length || filterCompanies.some(fc => c.name.toLowerCase().includes(fc));
+
+  const selected = companies
     .filter(c => c.enabled !== false)
-    .filter(c => !filterCompany || c.name.toLowerCase().includes(filterCompany))
-    .map(c => ({ ...c, _api: detectApi(c) }))
-    .filter(c => c._api !== null);
+    .filter(matchesSelection)
+    .map(c => ({ ...c, _api: detectApi(c) }));
+
+  const targets = selected.filter(c => c._api !== null);
 
   const skippedCount = companies.filter(c => c.enabled !== false).length - targets.length;
 
   console.log(`Scanning ${targets.length} companies via API (${skippedCount} skipped — no API detected)`);
+
+  // When the user explicitly picked sources (selective scan from the UI), name the
+  // ones that were skipped for lacking a supported ATS API — otherwise they'd silently
+  // appear "selected" but never scanned.
+  if (filterCompanies.length) {
+    const skippedNamed = selected.filter(c => c._api === null).map(c => c.name);
+    if (skippedNamed.length) {
+      console.log(`⚠ Ignorées (pas d'API supportée) : ${skippedNamed.join(', ')}`);
+    }
+  }
+
   if (dryRun) console.log('(dry run — no files will be written)\n');
 
   // 3. Load dedup sets
-  const seenUrls = loadSeenUrls();
+  const { addedUrls, anyUrls } = loadHistoryIndex();
   const seenCompanyRoles = loadSeenCompanyRoles();
 
   // 4. Fetch all APIs
@@ -312,9 +430,20 @@ async function main() {
   let totalFound = 0;
   let totalFilteredTitle = 0;
   let totalFilteredLocation = 0;
+  let totalFilteredAge = 0;
+  let totalFilteredRemote = 0;
   let totalDupes = 0;
   const newOffers = [];
+  const skippedOffers = [];
   const errors = [];
+
+  // Helper: log a skip event only the first time we ever see this URL,
+  // so the TSV grows linearly with new offers — not with every re-scan.
+  const logSkip = (job, type, status) => {
+    if (anyUrls.has(job.url)) return;
+    anyUrls.add(job.url);
+    skippedOffers.push({ ...job, source: `${type}-api`, status });
+  };
 
   const tasks = targets.map(company => async () => {
     const { type, url } = company._api;
@@ -326,25 +455,39 @@ async function main() {
       for (const job of jobs) {
         if (!titleFilter(job.title)) {
           totalFilteredTitle++;
+          logSkip(job, type, 'skipped_title');
           continue;
         }
         if (!locationFilter(job.location)) {
           totalFilteredLocation++;
+          logSkip(job, type, 'skipped_location');
           continue;
         }
-        if (seenUrls.has(job.url)) {
+        if (!freshnessFilter(job.posted_at)) {
+          totalFilteredAge++;
+          logSkip(job, type, 'skipped_age');
+          continue;
+        }
+        if (!remoteFilter(job.workplace_type, job.location)) {
+          totalFilteredRemote++;
+          logSkip(job, type, 'skipped_remote');
+          continue;
+        }
+        if (addedUrls.has(job.url)) {
           totalDupes++;
+          // Already added before — already in history as 'added', do not re-log.
           continue;
         }
         const key = `${job.company.toLowerCase()}::${job.title.toLowerCase()}`;
         if (seenCompanyRoles.has(key)) {
           totalDupes++;
+          logSkip(job, type, 'skipped_dup');
           continue;
         }
-        // Mark as seen to avoid intra-scan dupes
-        seenUrls.add(job.url);
+        addedUrls.add(job.url);
+        anyUrls.add(job.url);
         seenCompanyRoles.add(key);
-        newOffers.push({ ...job, source: `${type}-api` });
+        newOffers.push({ ...job, source: `${type}-api`, status: 'added' });
       }
     } catch (err) {
       errors.push({ company: company.name, error: err.message });
@@ -354,9 +497,10 @@ async function main() {
   await parallelFetch(tasks, CONCURRENCY);
 
   // 5. Write results
-  if (!dryRun && newOffers.length > 0) {
-    appendToPipeline(newOffers);
-    appendToScanHistory(newOffers, date);
+  if (!dryRun) {
+    if (newOffers.length > 0) appendToPipeline(newOffers);
+    const allEntries = [...newOffers, ...skippedOffers];
+    if (allEntries.length > 0) appendToScanHistory(allEntries, date);
   }
 
   // 6. Print summary
@@ -367,8 +511,11 @@ async function main() {
   console.log(`Total jobs found:      ${totalFound}`);
   console.log(`Filtered by title:     ${totalFilteredTitle} removed`);
   console.log(`Filtered by location:  ${totalFilteredLocation} removed`);
+  console.log(`Filtered by age:       ${totalFilteredAge} removed (older than max_age_days)`);
+  console.log(`Filtered by remote:    ${totalFilteredRemote} removed (not remote/hybrid)`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
   console.log(`New offers added:      ${newOffers.length}`);
+  console.log(`Skip events logged:    ${skippedOffers.length} (first-time skips, for dashboard analytics)`);
 
   if (errors.length > 0) {
     console.log(`\nErrors (${errors.length}):`);

--- a/scan.mjs
+++ b/scan.mjs
@@ -82,6 +82,16 @@ function detectApi(company) {
     };
   }
 
+  // Ministère de l'Europe et des Affaires étrangères — emplois.diplomatie.gouv.fr
+  // SPA with a public JSON API (no auth). Paginated: GET /api/v1/offres?page=N&limit=20
+  const diplomatieMatch = url.match(/emplois\.diplomatie\.gouv\.fr/);
+  if (diplomatieMatch) {
+    return {
+      type: 'diplomatie',
+      url: 'https://emplois.diplomatie.gouv.fr/api/v1/offres',
+    };
+  }
+
   return null;
 }
 
@@ -156,7 +166,39 @@ function parseWorkable(json, companyName) {
   });
 }
 
-const PARSERS = { greenhouse: parseGreenhouse, ashby: parseAshby, lever: parseLever, workable: parseWorkable };
+// emplois.diplomatie.gouv.fr — paginated JSON API (max 20 per page).
+// Async parser: it fetches every page itself, so the caller passes the BASE url
+// and the first-page json it already fetched is ignored (we re-fetch page 1 for
+// uniformity). Returns the full flattened list.
+async function parseDiplomatie(_firstJson, companyName, baseUrl) {
+  const LIMIT = 20;
+  const all = [];
+  let page = 1;
+  let total = Infinity;
+  // Hard cap at 20 pages (400 offers) to avoid any runaway loop.
+  while (all.length < total && page <= 20) {
+    const json = await fetchJson(`${baseUrl}?page=${page}&limit=${LIMIT}`);
+    const offres = json.offres || [];
+    total = typeof json.total === 'number' ? json.total : offres.length;
+    if (offres.length === 0) break;
+    for (const o of offres) {
+      const country = o.codePays && o.codePays !== 'FRA' ? `, ${o.codePays}` : '';
+      all.push({
+        title: o.intitule || '',
+        url: `https://emplois.diplomatie.gouv.fr/offre/${o.id}`,
+        company: companyName,
+        location: [o.ville, country].filter(Boolean).join('').replace(/^, /, ''),
+        posted_at: o.datePriseFonction || '',
+        // No remote concept in diplomatic postings — leave empty.
+        workplace_type: '',
+      });
+    }
+    page++;
+  }
+  return all;
+}
+
+const PARSERS = { greenhouse: parseGreenhouse, ashby: parseAshby, lever: parseLever, workable: parseWorkable, diplomatie: parseDiplomatie };
 
 // ── Fetch with timeout ──────────────────────────────────────────────
 
@@ -448,8 +490,12 @@ async function main() {
   const tasks = targets.map(company => async () => {
     const { type, url } = company._api;
     try {
-      const json = await fetchJson(url);
-      const jobs = PARSERS[type](json, company.name);
+      // Self-paginating parsers (diplomatie) fetch every page themselves from the
+      // base url. Others get a single pre-fetched json blob, as before.
+      const SELF_PAGING = new Set(['diplomatie']);
+      const jobs = SELF_PAGING.has(type)
+        ? await PARSERS[type](null, company.name, url)
+        : PARSERS[type](await fetchJson(url), company.name);
       totalFound += jobs.length;
 
       for (const job of jobs) {

--- a/web.ps1
+++ b/web.ps1
@@ -1,0 +1,13 @@
+# Lanceur dashboard career-ops (PowerShell)
+# Usage : .\web.ps1   (depuis n'importe ou)
+# Fixe le workaround TLS Windows (--use-system-ca) puis lance le serveur web.
+
+$ErrorActionPreference = 'Stop'
+
+# Se placer a la racine du projet (dossier de ce script), pas dans .git
+Set-Location -LiteralPath $PSScriptRoot
+
+$env:NODE_OPTIONS = '--use-system-ca'
+
+Write-Host "career-ops dashboard -> http://127.0.0.1:5757/  (Ctrl+C pour arreter)" -ForegroundColor Cyan
+npm run web

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1,0 +1,584 @@
+// career-ops dashboard — vanilla JS, no build
+
+const $ = (sel) => document.querySelector(sel);
+const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+const esc = (s) => String(s ?? '').replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+
+const SELECTED_SOURCES_KEY = 'career-ops-selected-sources';
+function loadSelectedSources() {
+  try {
+    const raw = localStorage.getItem(SELECTED_SOURCES_KEY);
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw);
+    return new Set(Array.isArray(arr) ? arr : []);
+  } catch { return new Set(); }
+}
+function saveSelectedSources(set) {
+  try { localStorage.setItem(SELECTED_SOURCES_KEY, JSON.stringify([...set])); } catch {}
+}
+
+const state = {
+  scan: null, pipeline: null, applications: null, portals: null, reports: null,
+  selectedSources: loadSelectedSources(),
+};
+
+function toast(msg, kind = 'ok') {
+  const t = $('#toast');
+  t.textContent = msg;
+  t.className = `toast ${kind}`;
+  setTimeout(() => t.classList.add('hidden'), 3000);
+}
+
+async function api(path, opts = {}) {
+  const res = await fetch(path, {
+    headers: { 'Content-Type': 'application/json' },
+    ...opts,
+    body: opts.body ? JSON.stringify(opts.body) : undefined,
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  return data;
+}
+
+function scoreClass(score) {
+  const n = parseFloat(String(score).split('/')[0]);
+  if (Number.isNaN(n)) return '';
+  if (n >= 3.5) return 'score high';
+  if (n >= 2.5) return 'score mid';
+  return 'score low';
+}
+
+function statusBadge(status) {
+  const s = String(status || '').toLowerCase();
+  let cls = '';
+  if (s === 'applied' || s === 'interview' || s === 'offer' || s === 'responded') cls = 'green';
+  else if (s === 'evaluated') cls = 'blue';
+  else if (s === 'skip' || s === 'rejected' || s === 'discarded') cls = 'red';
+  else if (s === 'added') cls = 'green';
+  else if (s.startsWith('skipped')) cls = 'red';
+  return `<span class="badge ${cls}">${esc(status)}</span>`;
+}
+
+// -------------------------------------------------------------------- Tabs
+function switchTab(tab) {
+  $$('#tabs button').forEach(b => b.classList.toggle('active', b.dataset.tab === tab));
+  $$('.tab').forEach(t => t.classList.toggle('active', t.id === `tab-${tab}`));
+  if (tab === 'overview') renderOverview();
+  if (tab === 'picks') renderPicks();
+  if (tab === 'pipeline') renderPipeline();
+  if (tab === 'applications') renderApplications();
+  if (tab === 'scans') renderScans();
+  if (tab === 'sources') renderSources();
+}
+
+$$('#tabs button').forEach(b => b.addEventListener('click', () => switchTab(b.dataset.tab)));
+
+// ------------------------------------------------------------ Data loaders
+async function load() {
+  try {
+    const [scan, pipeline, applications, portals, reports] = await Promise.all([
+      api('/api/scan-history'),
+      api('/api/pipeline'),
+      api('/api/applications'),
+      api('/api/portals'),
+      api('/api/reports').catch(() => ({})),
+    ]);
+    state.scan = scan;
+    state.pipeline = pipeline;
+    state.applications = applications;
+    state.portals = portals;
+    state.reports = reports;
+    renderOverview();
+  } catch (e) {
+    toast('Erreur chargement: ' + e.message, 'err');
+  }
+}
+
+// --------------------------------------------------------------- Overview
+function renderOverview() {
+  if (!state.scan || !state.pipeline || !state.applications || !state.portals) return;
+  const trackedCount = state.portals.tracked_companies.length;
+  const enabledCount = state.portals.tracked_companies.filter(c => c.enabled !== false).length;
+  const added = state.scan.byStatus.added || 0;
+  const pending = state.pipeline.pendientes.length;
+  const processed = state.pipeline.procesadas.length;
+  const apps = state.applications.total;
+  const byStatus = state.applications.byStatus;
+  const applied = (byStatus['Applied'] || 0) + (byStatus['Interview'] || 0) + (byStatus['Offer'] || 0);
+  const cards = [
+    { label: 'Sources actives', value: `${enabledCount} / ${trackedCount}`, sub: `${trackedCount - enabledCount} disabled` },
+    { label: 'Pipeline pendientes', value: pending, sub: `${processed} procesadas` },
+    { label: 'Scans (cumul)', value: state.scan.total, sub: `${added} added • ${state.scan.byStatus.skipped_title || 0} skip_title` },
+    { label: 'Applications', value: apps, sub: `${applied} actives` },
+  ];
+  $('#overview-cards').innerHTML = cards.map(c => `
+    <div class="card">
+      <div class="label">${esc(c.label)}</div>
+      <div class="value">${esc(c.value)}</div>
+      <div class="sub">${esc(c.sub)}</div>
+    </div>
+  `).join('');
+  // Top companies
+  const top = Object.entries(state.scan.byCompany).sort((a, b) => b[1] - a[1]).slice(0, 15);
+  $('#top-companies').innerHTML = `<table><thead><tr><th>Entreprise</th><th>Offres scannées</th></tr></thead><tbody>
+    ${top.map(([co, n]) => `<tr><td>${esc(co)}</td><td>${n}</td></tr>`).join('')}
+  </tbody></table>`;
+}
+
+// ----------------------------------------------------------------- Picks
+function locationFor(url) {
+  if (!state.scan) return '';
+  const row = state.scan.rows.find(r => r.url === url);
+  return row ? (row.location || '') : '';
+}
+function reportPathFor(num) {
+  if (!num || !state.reports) return null;
+  const padded = String(num).padStart(3, '0');
+  return state.reports[padded] ? `/reports/${state.reports[padded]}` : null;
+}
+function rankBadge(i) {
+  return i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : `#${i + 1}`;
+}
+function renderPicks() {
+  if (!state.pipeline) return;
+  const minScore = parseFloat($('#picks-min-score').value);
+  const q = $('#picks-search').value.toLowerCase();
+  const all = state.pipeline.procesadas
+    .filter(p => p.score)
+    .map(p => ({ ...p, scoreNum: parseFloat(String(p.score).split('/')[0]) }))
+    .filter(p => !Number.isNaN(p.scoreNum));
+  let picks = all
+    .filter(p => p.scoreNum >= minScore)
+    .filter(p => !q || `${p.company} ${p.title}`.toLowerCase().includes(q))
+    .sort((a, b) => b.scoreNum - a.scoreNum);
+  $('#picks-count').textContent = `${picks.length} pick(s) • ${all.filter(p => p.scoreNum >= 3.4).length} top-tier global`;
+  if (!picks.length) {
+    $('#picks-grid').innerHTML = `<div class="muted" style="padding:24px">— aucun pick au seuil ${minScore} —</div>`;
+    return;
+  }
+  $('#picks-grid').innerHTML = picks.map((p, i) => {
+    const reportPath = reportPathFor(p.num);
+    const loc = locationFor(p.url);
+    return `<div class="card pick-card">
+      <div class="pick-head">
+        <div class="pick-rank">${rankBadge(i)}</div>
+        <div class="pick-score ${scoreClass(p.score)}">${esc(p.score)}</div>
+        ${p.num ? `<div class="muted small">#${esc(p.num)}</div>` : ''}
+      </div>
+      <div class="pick-body">
+        <div class="pick-company"><strong>${esc(p.company)}</strong></div>
+        <div class="pick-role">${esc(p.title)}</div>
+        ${loc ? `<div class="muted small">📍 ${esc(loc)}</div>` : ''}
+        <div class="pick-actions">
+          ${reportPath ? `<a href="${reportPath}" target="_blank" class="primary-link">📄 Rapport complet</a>` : '<span class="muted small">report introuvable</span>'}
+          <a href="${esc(p.url)}" target="_blank">🔗 Offre originale</a>
+          <span class="muted small">PDF: ${esc(p.pdf)}</span>
+        </div>
+      </div>
+    </div>`;
+  }).join('');
+}
+$('#picks-min-score').addEventListener('change', renderPicks);
+$('#picks-search').addEventListener('input', renderPicks);
+
+// --------------------------------------------------------------- Pipeline
+function renderPipeline() {
+  if (!state.pipeline) return;
+  const q = $('#pipeline-search').value.toLowerCase();
+  const filt = (items) => items.filter(it =>
+    !q || it.title.toLowerCase().includes(q) || it.company.toLowerCase().includes(q) || it.url.toLowerCase().includes(q));
+  const pending = filt(state.pipeline.pendientes);
+  const done = filt(state.pipeline.procesadas);
+  $('#pending-count').textContent = pending.length;
+  $('#done-count').textContent = done.length;
+  $('#pending-table').innerHTML = renderPipelineTable(pending);
+  $('#done-table').innerHTML = renderPipelineTable(done);
+}
+function renderPipelineTable(items) {
+  if (!items.length) return `<div class="muted small">— aucune entrée —</div>`;
+  return `<table><thead><tr><th>Entreprise</th><th>Titre</th><th>URL</th></tr></thead><tbody>
+    ${items.map(it => `<tr>
+      <td>${esc(it.company)}</td>
+      <td>${esc(it.title)}</td>
+      <td><a href="${esc(it.url)}" target="_blank" class="url">${esc(it.url)}</a></td>
+    </tr>`).join('')}
+  </tbody></table>`;
+}
+$('#pipeline-search').addEventListener('input', renderPipeline);
+
+// -------------------------------------------------------------- Applications
+function renderApplications() {
+  if (!state.applications) return;
+  // Populate status filter once
+  const sel = $('#app-status-filter');
+  if (sel.options.length === 1) {
+    const statuses = Array.from(new Set(state.applications.rows.map(r => r.status))).filter(Boolean).sort();
+    for (const s of statuses) sel.add(new Option(s, s));
+  }
+  const q = $('#app-search').value.toLowerCase();
+  const sFilter = $('#app-status-filter').value;
+  const minScore = parseFloat($('#app-min-score').value);
+  let rows = state.applications.rows;
+  if (q) rows = rows.filter(r => `${r.company} ${r.role} ${r.notes}`.toLowerCase().includes(q));
+  if (sFilter) rows = rows.filter(r => r.status === sFilter);
+  if (!Number.isNaN(minScore)) {
+    rows = rows.filter(r => {
+      const n = parseFloat(String(r.score).split('/')[0]);
+      return !Number.isNaN(n) && n >= minScore;
+    });
+  }
+  // Sort: most recent first
+  rows = [...rows].sort((a, b) => (b.date || '').localeCompare(a.date || ''));
+  $('#app-table').innerHTML = `<table><thead><tr>
+      <th>#</th><th>Date</th><th>Entreprise</th><th>Rôle</th><th>Score</th><th>Statut</th><th>PDF</th><th>Rapport</th><th>Notes</th>
+    </tr></thead><tbody>
+    ${rows.map(r => `<tr>
+      <td>${esc(r.num)}</td>
+      <td>${esc(r.date)}</td>
+      <td>${esc(r.company)}</td>
+      <td>${esc(r.role)}</td>
+      <td><span class="${scoreClass(r.score)}">${esc(r.score)}</span></td>
+      <td>${statusBadge(r.status)}</td>
+      <td>${esc(r.pdf)}</td>
+      <td>${parseMdLink(r.report)}</td>
+      <td>${esc(r.notes)}</td>
+    </tr>`).join('')}
+  </tbody></table>`;
+}
+function parseMdLink(s) {
+  const m = String(s || '').match(/\[(.+?)\]\((.+?)\)/);
+  if (!m) return esc(s);
+  return `<a href="/${esc(m[2])}" target="_blank">${esc(m[1])}</a>`;
+}
+$('#app-search').addEventListener('input', renderApplications);
+$('#app-status-filter').addEventListener('change', renderApplications);
+$('#app-min-score').addEventListener('change', renderApplications);
+
+// ----------------------------------------------------------------- Scans
+function renderScans() {
+  if (!state.scan) return;
+  const statusSel = $('#scan-status-filter');
+  if (statusSel.options.length === 1) {
+    for (const s of Object.keys(state.scan.byStatus).sort()) statusSel.add(new Option(`${s} (${state.scan.byStatus[s]})`, s));
+  }
+  const portalSel = $('#scan-portal-filter');
+  if (portalSel.options.length === 1) {
+    const portals = Array.from(new Set(state.scan.rows.map(r => r.portal))).filter(Boolean).sort();
+    for (const p of portals) portalSel.add(new Option(p, p));
+  }
+  const q = $('#scan-search').value.toLowerCase();
+  const sFilter = $('#scan-status-filter').value;
+  const pFilter = $('#scan-portal-filter').value;
+  let rows = state.scan.rows;
+  if (q) rows = rows.filter(r => `${r.title} ${r.company} ${r.location}`.toLowerCase().includes(q));
+  if (sFilter) rows = rows.filter(r => r.status === sFilter);
+  if (pFilter) rows = rows.filter(r => r.portal === pFilter);
+  // Most recent first
+  rows = [...rows].sort((a, b) => (b.first_seen || '').localeCompare(a.first_seen || ''));
+  $('#scan-summary').textContent = `${rows.length} / ${state.scan.total} entrées`;
+  const limited = rows.slice(0, 500);
+  $('#scan-table').innerHTML = `<table><thead><tr>
+      <th>Date</th><th>Entreprise</th><th>Titre</th><th>Location</th><th>Portail</th><th>Statut</th><th>URL</th>
+    </tr></thead><tbody>
+    ${limited.map(r => `<tr>
+      <td>${esc(r.first_seen)}</td>
+      <td>${esc(r.company)}</td>
+      <td>${esc(r.title)}</td>
+      <td class="muted small">${esc(r.location)}</td>
+      <td class="muted small">${esc(r.portal)}</td>
+      <td>${statusBadge(r.status)}</td>
+      <td><a href="${esc(r.url)}" target="_blank" class="url">${esc(r.url).slice(0, 50)}…</a></td>
+    </tr>`).join('')}
+  </tbody></table>${rows.length > 500 ? `<div class="muted small" style="margin-top:8px">Affichage limité aux 500 premières. Affine les filtres pour voir le reste.</div>` : ''}`;
+}
+$('#scan-search').addEventListener('input', renderScans);
+$('#scan-status-filter').addEventListener('change', renderScans);
+$('#scan-portal-filter').addEventListener('change', renderScans);
+
+// ----------------------------------------------------------------- Sources
+function renderSources() {
+  if (!state.portals) return;
+  const q = $('#src-search').value.toLowerCase();
+  const stateFilter = $('#src-state-filter').value;
+  let rows = state.portals.tracked_companies;
+  if (q) rows = rows.filter(c => `${c.name} ${c.notes || ''}`.toLowerCase().includes(q));
+  if (stateFilter === 'enabled') rows = rows.filter(c => c.enabled !== false);
+  if (stateFilter === 'disabled') rows = rows.filter(c => c.enabled === false);
+  rows = [...rows].sort((a, b) => a.name.localeCompare(b.name));
+  // Prune selections that no longer exist (renamed/deleted sources)
+  const validNames = new Set(state.portals.tracked_companies.map(c => c.name));
+  let pruned = false;
+  for (const n of [...state.selectedSources]) {
+    if (!validNames.has(n)) { state.selectedSources.delete(n); pruned = true; }
+  }
+  if (pruned) saveSelectedSources(state.selectedSources);
+
+  const allVisibleSelected = rows.length > 0 && rows.every(c => state.selectedSources.has(c.name));
+  $('#src-table').innerHTML = `<table><thead><tr>
+      <th><input type="checkbox" id="src-check-all" ${allVisibleSelected ? 'checked' : ''} title="Tout sélectionner (visibles)" /></th>
+      <th>Nom</th><th>careers_url</th><th>API / méthode</th><th>Notes</th><th>État</th><th></th>
+    </tr></thead><tbody>
+    ${rows.map(c => `<tr>
+      <td><input type="checkbox" class="src-check" data-name="${esc(c.name)}" ${state.selectedSources.has(c.name) ? 'checked' : ''} ${c.enabled === false ? 'disabled title="source disabled"' : ''} /></td>
+      <td><strong>${esc(c.name)}</strong></td>
+      <td><a href="${esc(c.careers_url || '#')}" target="_blank" class="url">${esc(c.careers_url || '—').slice(0, 60)}${(c.careers_url || '').length > 60 ? '…' : ''}</a></td>
+      <td class="muted small">${esc(c.api || c.scan_method || '—')}</td>
+      <td class="muted small">${esc(c.notes || '')}</td>
+      <td>${c.enabled === false ? '<span class="badge red">disabled</span>' : '<span class="badge green">enabled</span>'}</td>
+      <td class="actions">
+        <button data-act="toggle" data-name="${esc(c.name)}">${c.enabled === false ? 'Activer' : 'Désactiver'}</button>
+        <button data-act="edit" data-name="${esc(c.name)}">Éditer</button>
+        <button class="danger" data-act="del" data-name="${esc(c.name)}">×</button>
+      </td>
+    </tr>`).join('')}
+  </tbody></table>`;
+  $$('#src-table button').forEach(b => b.addEventListener('click', onSourceAction));
+  $$('#src-table .src-check').forEach(cb => cb.addEventListener('change', onSourceCheck));
+  const checkAll = $('#src-check-all');
+  if (checkAll) checkAll.addEventListener('change', () => {
+    for (const c of rows) {
+      if (c.enabled === false) continue;
+      if (checkAll.checked) state.selectedSources.add(c.name);
+      else state.selectedSources.delete(c.name);
+    }
+    saveSelectedSources(state.selectedSources);
+    renderSources();
+  });
+  updateSelectionUi();
+  renderFiltersReadonly();
+}
+
+function onSourceCheck(e) {
+  const name = e.currentTarget.dataset.name;
+  if (e.currentTarget.checked) state.selectedSources.add(name);
+  else state.selectedSources.delete(name);
+  saveSelectedSources(state.selectedSources);
+  updateSelectionUi();
+  // Refresh the "check-all" header state without rebuilding the table
+  const checkAll = $('#src-check-all');
+  if (checkAll) {
+    const boxes = $$('#src-table .src-check').filter(b => !b.disabled);
+    checkAll.checked = boxes.length > 0 && boxes.every(b => b.checked);
+  }
+}
+
+function updateSelectionUi() {
+  const n = state.selectedSources.size;
+  const btn = $('#src-scan-selected');
+  if (btn) {
+    btn.textContent = `▶ Scan sélection (${n})`;
+    btn.disabled = n === 0 || scanBtn.disabled;
+  }
+  const clear = $('#src-clear-selection');
+  if (clear) clear.disabled = n === 0;
+}
+function renderFiltersReadonly() {
+  const p = state.portals;
+  const block = (title, obj) => `<div class="card"><div class="label">${esc(title)}</div><pre>${esc(JSON.stringify(obj, null, 2))}</pre></div>`;
+  $('#filters-readonly').innerHTML = [
+    p.location_filter && block('location_filter', p.location_filter),
+    p.freshness_filter && block('freshness_filter', p.freshness_filter),
+    p.remote_filter && block('remote_filter', p.remote_filter),
+    p.title_filter && block('title_filter (extraits)', { positive: (p.title_filter.positive || []).slice(0, 12), negative: (p.title_filter.negative || []).slice(0, 12) }),
+  ].filter(Boolean).join('');
+}
+$('#src-search').addEventListener('input', renderSources);
+$('#src-state-filter').addEventListener('change', renderSources);
+
+async function onSourceAction(e) {
+  const name = e.currentTarget.dataset.name;
+  const act = e.currentTarget.dataset.act;
+  try {
+    if (act === 'toggle') {
+      await api(`/api/portals/companies/${encodeURIComponent(name)}/toggle`, { method: 'PATCH' });
+      toast(`${name} basculé`);
+    } else if (act === 'del') {
+      if (!confirm(`Supprimer "${name}" de tracked_companies ?`)) return;
+      await api(`/api/portals/companies/${encodeURIComponent(name)}`, { method: 'DELETE' });
+      toast(`${name} supprimé`);
+    } else if (act === 'edit') {
+      const company = state.portals.tracked_companies.find(c => c.name === name);
+      openModal(company);
+      return;
+    }
+    state.portals = await api('/api/portals');
+    renderSources();
+  } catch (err) {
+    toast(err.message, 'err');
+  }
+}
+
+// ------------------------------------------------------------------ Modal
+function openModal(company = null) {
+  $('#modal-title').textContent = company ? `Éditer — ${company.name}` : 'Ajouter une source';
+  $('#f-original-name').value = company?.name || '';
+  $('#f-name').value = company?.name || '';
+  $('#f-careers_url').value = company?.careers_url || '';
+  $('#f-api').value = company?.api || '';
+  $('#f-api_provider').value = company?.api_provider || '';
+  $('#f-scan_method').value = company?.scan_method || '';
+  $('#f-scan_query').value = company?.scan_query || '';
+  $('#f-notes').value = company?.notes || '';
+  $('#f-enabled').checked = company ? company.enabled !== false : true;
+  $('#modal').classList.remove('hidden');
+}
+function closeModal() { $('#modal').classList.add('hidden'); }
+$('#modal-cancel').addEventListener('click', closeModal);
+$('#src-add-btn').addEventListener('click', () => openModal(null));
+$('#src-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const original = $('#f-original-name').value;
+  const payload = {
+    name: $('#f-name').value.trim(),
+    careers_url: $('#f-careers_url').value.trim() || undefined,
+    api: $('#f-api').value.trim() || undefined,
+    api_provider: $('#f-api_provider').value || undefined,
+    scan_method: $('#f-scan_method').value || undefined,
+    scan_query: $('#f-scan_query').value.trim() || undefined,
+    notes: $('#f-notes').value.trim() || undefined,
+    enabled: $('#f-enabled').checked,
+  };
+  try {
+    if (original) {
+      await api(`/api/portals/companies/${encodeURIComponent(original)}`, { method: 'PUT', body: payload });
+      toast(`${payload.name} mis à jour`);
+    } else {
+      await api('/api/portals/companies', { method: 'POST', body: payload });
+      toast(`${payload.name} ajouté`);
+    }
+    closeModal();
+    state.portals = await api('/api/portals');
+    renderSources();
+  } catch (err) { toast(err.message, 'err'); }
+});
+
+// --------------------------------------------------------------- Scan trigger
+const scanModal = $('#scan-modal');
+const scanLog = $('#scan-log');
+const scanBtn = $('#run-scan-btn');
+const scanState = $('#scan-state');
+
+$('#scan-modal-close').addEventListener('click', () => scanModal.classList.add('hidden'));
+
+async function checkScanStatus() {
+  try {
+    const s = await api('/api/scan/status');
+    if (s.running) {
+      scanBtn.disabled = true;
+      scanState.textContent = '(scan en cours dans une autre session)';
+    } else {
+      scanBtn.disabled = false;
+      scanState.textContent = '';
+    }
+    updateSelectionUi();
+  } catch {}
+}
+
+function appendLog(line) {
+  const div = document.createElement('div');
+  let cls = '';
+  if (/^\[err\]/.test(line)) cls = 'err';
+  else if (/^⚠/.test(line)) cls = 'warn';
+  else if (/^\s*\+ /.test(line)) cls = 'new';
+  else if (/^Results saved|ready →/.test(line)) cls = 'ok';
+  if (cls) div.className = cls;
+  div.textContent = line;
+  scanLog.appendChild(div);
+  scanLog.scrollTop = scanLog.scrollHeight;
+}
+
+async function launchScan(companies = []) {
+  if (scanBtn.disabled) return;
+  scanBtn.disabled = true;
+  updateSelectionUi();
+  scanState.textContent = 'lancement…';
+  scanLog.innerHTML = '';
+  const title = companies.length
+    ? `Scan en cours… (${companies.length} source${companies.length > 1 ? 's' : ''})`
+    : 'Scan en cours…';
+  $('#scan-modal-title').textContent = title;
+  scanModal.classList.remove('hidden');
+
+  let res;
+  try {
+    res = await fetch('/api/scan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ companies }),
+    });
+  } catch (e) {
+    appendLog(`[fatal] ${e.message}`);
+    scanBtn.disabled = false; scanState.textContent = ''; updateSelectionUi();
+    return;
+  }
+  if (!res.ok) {
+    let msg = `HTTP ${res.status}`;
+    try { const j = await res.json(); msg = j.error || msg; } catch {}
+    appendLog(`[err] ${msg}`);
+    scanBtn.disabled = false; scanState.textContent = ''; updateSelectionUi();
+    return;
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  scanState.textContent = 'en cours…';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf('\n\n')) !== -1) {
+      const evt = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+      handleSseEvent(evt);
+    }
+  }
+}
+
+function handleSseEvent(raw) {
+  const lines = raw.split('\n');
+  let event = 'message';
+  let dataLines = [];
+  for (const l of lines) {
+    if (l.startsWith('event: ')) event = l.slice(7);
+    else if (l.startsWith('data: ')) dataLines.push(l.slice(6));
+  }
+  if (dataLines.length === 0) return;
+  let data;
+  try { data = JSON.parse(dataLines.join('\n')); } catch { data = dataLines.join('\n'); }
+  if (event === 'log') {
+    appendLog(data);
+  } else if (event === 'done') {
+    const code = data?.code;
+    appendLog(`\n--- scan terminé (exit ${code}) ---`);
+    $('#scan-modal-title').textContent = code === 0 ? '✓ Scan terminé' : `✗ Scan échoué (exit ${code})`;
+    scanBtn.disabled = false;
+    scanState.textContent = '';
+    updateSelectionUi();
+    if (code === 0) {
+      toast('Scan terminé — données rafraîchies');
+      load();
+    } else {
+      toast(`Scan échoué (exit ${code})`, 'err');
+    }
+  }
+}
+
+scanBtn.addEventListener('click', () => launchScan([]));
+
+$('#src-scan-selected').addEventListener('click', () => {
+  const companies = [...state.selectedSources];
+  if (!companies.length) return;
+  launchScan(companies);
+});
+$('#src-clear-selection').addEventListener('click', () => {
+  state.selectedSources.clear();
+  saveSelectedSources(state.selectedSources);
+  renderSources();
+});
+
+checkScanStatus();
+
+// boot
+load();

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -20,6 +20,7 @@ function saveSelectedSources(set) {
 const state = {
   scan: null, pipeline: null, applications: null, portals: null, reports: null,
   selectedSources: loadSelectedSources(),
+  appsContent: null,
 };
 
 function toast(msg, kind = 'ok') {
@@ -67,6 +68,7 @@ function switchTab(tab) {
   if (tab === 'picks') renderPicks();
   if (tab === 'pipeline') renderPipeline();
   if (tab === 'applications') renderApplications();
+  if (tab === 'generate') renderGenerate();
   if (tab === 'scans') renderScans();
   if (tab === 'sources') renderSources();
 }
@@ -406,6 +408,75 @@ async function onSourceAction(e) {
   } catch (err) {
     toast(err.message, 'err');
   }
+}
+
+// --------------------------------------------------------------- Generate CV
+const FLAG = { en: '🇬🇧', fr: '🇫🇷' };
+async function renderGenerate() {
+  const host = $('#gen-list');
+  if (!state.appsContent) {
+    host.innerHTML = `<div class="muted" style="padding:24px">Chargement…</div>`;
+    try { state.appsContent = await api('/api/applications-content'); }
+    catch (e) { host.innerHTML = `<div class="muted" style="padding:24px">Erreur: ${esc(e.message)}</div>`; return; }
+  }
+  const items = state.appsContent.items || [];
+  if (!items.length) {
+    host.innerHTML = `<div class="muted" style="padding:24px">— aucune candidature rédigée (data/applications-content/*.json) —</div>`;
+    return;
+  }
+  host.innerHTML = items.map(it => {
+    const reportLink = it.report ? `<a href="/reports/${esc(it.report)}" target="_blank">rapport</a>` : '';
+    return `<div class="card gen-card" data-id="${esc(it.id)}">
+      <div class="gen-head">
+        <div>
+          <strong>${esc(it.company)}</strong> — ${esc(it.role)}
+          <div class="muted small">${FLAG[it.lang] || ''} ${esc(it.lang.toUpperCase())} · ${esc(it.paper.toUpperCase())} ${reportLink ? '· ' + reportLink : ''}</div>
+        </div>
+      </div>
+      <div class="gen-opts">
+        <label class="radio"><input type="radio" name="pages-${esc(it.id)}" value="1" /> CV 1 page</label>
+        <label class="radio"><input type="radio" name="pages-${esc(it.id)}" value="2" checked /> CV 2 pages</label>
+        <label class="radio"><input type="radio" name="pages-${esc(it.id)}" value="0" /> sans CV</label>
+        <label class="checkbox-inline"><input type="checkbox" class="gen-cover" checked /> + cover letter</label>
+        <button class="primary gen-btn" data-id="${esc(it.id)}">Générer PDF</button>
+      </div>
+      <div class="gen-result muted small" data-id="${esc(it.id)}"></div>
+    </div>`;
+  }).join('');
+  $$('.gen-btn').forEach(b => b.addEventListener('click', onGenerate));
+}
+
+async function onGenerate(e) {
+  const id = e.currentTarget.dataset.id;
+  const card = e.currentTarget.closest('.gen-card');
+  const pages = Number(card.querySelector(`input[name="pages-${id}"]:checked`)?.value ?? 2);
+  const cover = card.querySelector('.gen-cover').checked;
+  const resultEl = card.querySelector('.gen-result');
+  if (pages === 0 && !cover) { resultEl.innerHTML = `<span class="badge red">coche au moins CV ou cover</span>`; return; }
+  e.currentTarget.disabled = true;
+  resultEl.innerHTML = 'génération…';
+  try {
+    const r = await api('/api/generate-pdf', { method: 'POST', body: { id, pages, cover } });
+    if (r.locked) {
+      resultEl.innerHTML = `<span class="badge red">⚠ PDF ouvert dans un lecteur — ferme-le et réessaie</span>`;
+    } else {
+      const links = (r.results || []).filter(x => x.pdf).map(x =>
+        `<a href="/output/${esc(x.pdf)}" target="_blank">${esc(x.kind)}${x.pages ? ` (${x.pages}p)` : ''}</a>
+         <button class="link-btn gen-open" data-file="${esc(x.pdf)}">ouvrir</button>`).join(' &nbsp;·&nbsp; ');
+      resultEl.innerHTML = `<span class="badge green">✓ généré</span> ${links}`;
+      card.querySelectorAll('.gen-open').forEach(btn => btn.addEventListener('click', onOpenFile));
+    }
+  } catch (err) {
+    resultEl.innerHTML = `<span class="badge red">${esc(err.message)}</span>`;
+  } finally {
+    e.currentTarget.disabled = false;
+  }
+}
+
+async function onOpenFile(e) {
+  const file = e.currentTarget.dataset.file;
+  try { await api('/api/open-file', { method: 'POST', body: { file } }); toast(`Ouverture de ${file}`); }
+  catch (err) { toast(err.message, 'err'); }
 }
 
 // ------------------------------------------------------------------ Modal

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -14,6 +14,7 @@
       <button data-tab="picks">⭐ Picks</button>
       <button data-tab="pipeline">Pipeline</button>
       <button data-tab="applications">Applications</button>
+      <button data-tab="generate">📄 Générer CV</button>
       <button data-tab="scans">Scans</button>
       <button data-tab="sources">Sources</button>
     </nav>
@@ -65,6 +66,13 @@
         </select>
       </div>
       <div id="app-table"></div>
+    </section>
+
+    <section id="tab-generate" class="tab">
+      <div class="toolbar">
+        <span class="muted small">Génère CV + cover letter à partir des candidatures rédigées. Langue et format papier fixés par le poste.</span>
+      </div>
+      <div id="gen-list"></div>
     </section>
 
     <section id="tab-scans" class="tab">

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <title>career-ops — dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <header>
+    <h1>career-ops <span class="muted">dashboard</span></h1>
+    <nav id="tabs">
+      <button data-tab="overview" class="active">Overview</button>
+      <button data-tab="picks">⭐ Picks</button>
+      <button data-tab="pipeline">Pipeline</button>
+      <button data-tab="applications">Applications</button>
+      <button data-tab="scans">Scans</button>
+      <button data-tab="sources">Sources</button>
+    </nav>
+  </header>
+
+  <main>
+    <section id="tab-overview" class="tab active">
+      <div class="toolbar">
+        <button id="run-scan-btn" class="primary">▶ Lancer un scan</button>
+        <span id="scan-state" class="muted small"></span>
+      </div>
+      <div class="cards" id="overview-cards"></div>
+      <h2>Top companies (scan history)</h2>
+      <div id="top-companies"></div>
+    </section>
+
+    <section id="tab-picks" class="tab">
+      <div class="toolbar">
+        <label>Score min
+          <select id="picks-min-score">
+            <option value="3.4" selected>≥ 3.4 (APPLY)</option>
+            <option value="3.0">≥ 3.0 (incl. conditional)</option>
+            <option value="2.5">≥ 2.5 (incl. borderline)</option>
+          </select>
+        </label>
+        <input id="picks-search" type="search" placeholder="Filtrer (entreprise, rôle)" />
+        <span id="picks-count" class="muted small"></span>
+      </div>
+      <div id="picks-grid"></div>
+    </section>
+
+    <section id="tab-pipeline" class="tab">
+      <div class="toolbar">
+        <input id="pipeline-search" type="search" placeholder="Filtrer (titre, entreprise, URL)" />
+      </div>
+      <h2>Pending <span id="pending-count" class="badge"></span></h2>
+      <div id="pending-table"></div>
+      <h2>Processed <span id="done-count" class="badge"></span></h2>
+      <div id="done-table"></div>
+    </section>
+
+    <section id="tab-applications" class="tab">
+      <div class="toolbar">
+        <input id="app-search" type="search" placeholder="Filtrer (entreprise, rôle, statut)" />
+        <select id="app-status-filter"><option value="">tous statuts</option></select>
+        <select id="app-min-score"><option value="">score min</option>
+          <option value="1">≥ 1</option><option value="2">≥ 2</option><option value="3">≥ 3</option>
+          <option value="3.5">≥ 3.5</option><option value="4">≥ 4</option>
+        </select>
+      </div>
+      <div id="app-table"></div>
+    </section>
+
+    <section id="tab-scans" class="tab">
+      <div class="toolbar">
+        <input id="scan-search" type="search" placeholder="Filtrer (titre, entreprise, location)" />
+        <select id="scan-status-filter"><option value="">tous statuts</option></select>
+        <select id="scan-portal-filter"><option value="">tous portails</option></select>
+      </div>
+      <div class="muted small" id="scan-summary"></div>
+      <div id="scan-table"></div>
+    </section>
+
+    <section id="tab-sources" class="tab">
+      <div class="toolbar">
+        <input id="src-search" type="search" placeholder="Filtrer entreprise" />
+        <select id="src-state-filter">
+          <option value="">tous</option>
+          <option value="enabled">enabled</option>
+          <option value="disabled">disabled</option>
+        </select>
+        <button id="src-scan-selected" class="primary" disabled>▶ Scan sélection (0)</button>
+        <button id="src-clear-selection">Effacer sélection</button>
+        <button id="src-add-btn">+ Ajouter</button>
+      </div>
+      <div id="src-table"></div>
+
+      <h2>Filtres (lecture seule)</h2>
+      <div class="filters-grid" id="filters-readonly"></div>
+    </section>
+  </main>
+
+  <!-- Modal: add/edit company -->
+  <div id="modal" class="modal hidden">
+    <div class="modal-content">
+      <h3 id="modal-title">Ajouter une source</h3>
+      <form id="src-form">
+        <input type="hidden" id="f-original-name" />
+        <label>Nom <input id="f-name" required /></label>
+        <label>careers_url <input id="f-careers_url" placeholder="https://..." /></label>
+        <label>api <input id="f-api" placeholder="https://boards-api.greenhouse.io/..." /></label>
+        <label>api_provider
+          <select id="f-api_provider">
+            <option value="">(auto)</option>
+            <option>greenhouse</option><option>ashby</option><option>lever</option>
+            <option>bamboohr</option><option>teamtailor</option><option>workday</option>
+          </select>
+        </label>
+        <label>scan_method
+          <select id="f-scan_method">
+            <option value="">(api/playwright)</option>
+            <option>websearch</option>
+            <option>playwright</option>
+          </select>
+        </label>
+        <label>scan_query <input id="f-scan_query" /></label>
+        <label>notes <input id="f-notes" /></label>
+        <label class="checkbox"><input type="checkbox" id="f-enabled" checked /> enabled</label>
+        <div class="modal-actions">
+          <button type="button" id="modal-cancel">Annuler</button>
+          <button type="submit" class="primary">Enregistrer</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- Modal: scan console -->
+  <div id="scan-modal" class="modal hidden">
+    <div class="modal-content scan-modal-content">
+      <div class="scan-modal-header">
+        <h3 id="scan-modal-title">Scan en cours…</h3>
+        <button type="button" id="scan-modal-close" class="ghost">Fermer</button>
+      </div>
+      <pre id="scan-log" class="scan-log"></pre>
+    </div>
+  </div>
+
+  <div id="toast" class="toast hidden"></div>
+  <script src="/app.js" type="module"></script>
+</body>
+</html>

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -86,6 +86,17 @@ a:hover { text-decoration: underline; }
 .scan-log .new { color: var(--accent-2); }
 .scan-log .warn { color: #e3b341; }
 
+/* Generate CV tab */
+.gen-card { margin-bottom: 14px; padding: 16px; }
+.gen-head { margin-bottom: 12px; }
+.gen-opts { display: flex; flex-wrap: wrap; gap: 14px; align-items: center; }
+.gen-opts label.radio, .gen-opts label.checkbox-inline { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--fg); cursor: pointer; }
+.gen-opts input[type=radio] { width: 15px; height: 15px; min-width: 0; padding: 0; cursor: pointer; accent-color: var(--accent); }
+.gen-result { margin-top: 10px; min-height: 18px; }
+.gen-result a { color: var(--accent-2); }
+.link-btn { background: none; border: none; color: var(--accent); cursor: pointer; padding: 0 2px; font-size: 12px; text-decoration: underline; }
+.link-btn:hover { color: var(--accent-2); }
+
 /* Toast */
 .toast { position: fixed; bottom: 24px; right: 24px; background: var(--panel-2); color: var(--fg); border: 1px solid var(--border); padding: 10px 14px; border-radius: 8px; z-index: 20; max-width: 320px; }
 .toast.hidden { display: none; }

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -1,0 +1,107 @@
+:root {
+  --bg: #0e1116;
+  --panel: #161b22;
+  --panel-2: #1c2230;
+  --border: #2a313c;
+  --fg: #e6edf3;
+  --muted: #8b949e;
+  --accent: #f78166;
+  --accent-2: #ffb88f;
+  --green: #3fb950;
+  --red: #f85149;
+  --yellow: #d29922;
+  --blue: #58a6ff;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+header { background: var(--panel); border-bottom: 1px solid var(--border); padding: 14px 24px; position: sticky; top: 0; z-index: 5; }
+header h1 { margin: 0 0 10px; font-size: 18px; font-weight: 600; }
+.muted { color: var(--muted); }
+.small { font-size: 12px; }
+nav#tabs { display: flex; gap: 4px; flex-wrap: wrap; }
+nav#tabs button { background: transparent; color: var(--muted); border: 1px solid transparent; border-radius: 6px; padding: 6px 12px; cursor: pointer; font-size: 13px; }
+nav#tabs button:hover { color: var(--fg); background: var(--panel-2); }
+nav#tabs button.active { color: var(--fg); background: var(--panel-2); border-color: var(--border); }
+main { padding: 20px 24px 60px; max-width: 1400px; margin: 0 auto; }
+.tab { display: none; }
+.tab.active { display: block; }
+h2 { font-size: 14px; font-weight: 600; margin: 24px 0 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
+.toolbar { display: flex; gap: 8px; align-items: center; margin: 16px 0; flex-wrap: wrap; }
+input[type=search], input[type=text], input, select { background: var(--panel); color: var(--fg); border: 1px solid var(--border); border-radius: 6px; padding: 8px 10px; font-size: 13px; min-width: 240px; }
+input[type=checkbox] { min-width: 0; padding: 0; width: 16px; height: 16px; cursor: pointer; accent-color: var(--accent); }
+input[type=checkbox]:disabled { cursor: not-allowed; opacity: 0.4; }
+input:focus, select:focus { outline: none; border-color: var(--accent); }
+button { background: var(--panel-2); color: var(--fg); border: 1px solid var(--border); border-radius: 6px; padding: 8px 14px; cursor: pointer; font-size: 13px; }
+button:hover { border-color: var(--accent); }
+button.primary { background: var(--accent); color: #1a1a1a; border-color: var(--accent); font-weight: 600; }
+button.primary:hover { background: var(--accent-2); border-color: var(--accent-2); }
+button.danger { color: var(--red); }
+button.danger:hover { background: rgba(248,81,73,0.1); border-color: var(--red); }
+button.ghost { background: transparent; }
+.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin: 16px 0 24px; }
+.card { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
+.card .label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+.card .value { font-size: 24px; font-weight: 600; margin-top: 4px; }
+.card .sub { font-size: 12px; color: var(--muted); margin-top: 6px; }
+table { width: 100%; border-collapse: collapse; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+thead th { background: var(--panel-2); text-align: left; padding: 8px 10px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.03em; color: var(--muted); border-bottom: 1px solid var(--border); }
+tbody td { padding: 10px; border-bottom: 1px solid var(--border); font-size: 13px; vertical-align: top; }
+tbody tr:last-child td { border-bottom: 0; }
+tbody tr:hover { background: var(--panel-2); }
+a { color: var(--blue); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.badge { display: inline-block; background: var(--panel-2); border: 1px solid var(--border); color: var(--muted); border-radius: 999px; padding: 1px 8px; font-size: 11px; margin-left: 8px; }
+.badge.green { color: var(--green); border-color: rgba(63,185,80,0.4); }
+.badge.red { color: var(--red); border-color: rgba(248,81,73,0.4); }
+.badge.yellow { color: var(--yellow); border-color: rgba(210,153,34,0.4); }
+.badge.blue { color: var(--blue); border-color: rgba(88,166,255,0.4); }
+.score { display: inline-block; min-width: 36px; text-align: center; font-weight: 600; padding: 2px 6px; border-radius: 4px; }
+.score.high { background: rgba(63,185,80,0.15); color: var(--green); }
+.score.mid { background: rgba(210,153,34,0.15); color: var(--yellow); }
+.score.low { background: rgba(248,81,73,0.15); color: var(--red); }
+.actions { display: flex; gap: 4px; }
+.actions button { padding: 4px 8px; font-size: 12px; }
+.url { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; word-break: break-all; max-width: 360px; display: inline-block; }
+.filters-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+.filters-grid .card pre { margin: 6px 0 0; font-size: 11px; color: var(--muted); white-space: pre-wrap; word-break: break-word; }
+
+/* Modal */
+.modal { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: 10; }
+.modal.hidden { display: none; }
+.modal-content { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 24px; width: min(560px, 90vw); max-height: 90vh; overflow: auto; }
+.modal-content h3 { margin: 0 0 16px; }
+.modal-content form { display: grid; gap: 12px; }
+.modal-content label { display: grid; gap: 4px; font-size: 12px; color: var(--muted); }
+.modal-content label.checkbox { display: flex; flex-direction: row; align-items: center; gap: 8px; color: var(--fg); }
+.modal-content input, .modal-content select { width: 100%; min-width: 0; }
+.modal-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 8px; }
+
+/* Scan modal */
+.scan-modal-content { width: min(820px, 95vw); max-height: 90vh; display: flex; flex-direction: column; }
+.scan-modal-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+.scan-modal-header h3 { margin: 0; }
+.scan-log { background: #050810; color: #c9d1d9; border: 1px solid var(--border); border-radius: 6px; padding: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; line-height: 1.5; overflow: auto; flex: 1; min-height: 320px; max-height: 60vh; white-space: pre-wrap; word-break: break-word; margin: 0; }
+.scan-log .ok { color: var(--green); }
+.scan-log .err { color: var(--red); }
+.scan-log .new { color: var(--accent-2); }
+.scan-log .warn { color: #e3b341; }
+
+/* Toast */
+.toast { position: fixed; bottom: 24px; right: 24px; background: var(--panel-2); color: var(--fg); border: 1px solid var(--border); padding: 10px 14px; border-radius: 8px; z-index: 20; max-width: 320px; }
+.toast.hidden { display: none; }
+.toast.ok { border-color: var(--green); }
+.toast.err { border-color: var(--red); color: var(--red); }
+
+/* Picks tab */
+#picks-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 16px; margin-top: 16px; }
+.pick-card { padding: 16px; border: 1px solid var(--border); border-radius: 10px; background: var(--panel-2); display: flex; flex-direction: column; gap: 12px; }
+.pick-head { display: flex; align-items: center; gap: 12px; }
+.pick-rank { font-size: 22px; line-height: 1; }
+.pick-score { padding: 4px 10px; border-radius: 6px; font-weight: 700; font-size: 14px; }
+.pick-body { display: flex; flex-direction: column; gap: 6px; }
+.pick-company { font-size: 16px; }
+.pick-role { color: var(--fg); font-size: 14px; }
+.pick-actions { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin-top: 8px; padding-top: 10px; border-top: 1px solid var(--border); }
+.pick-actions a { color: var(--blue); text-decoration: none; font-size: 13px; }
+.pick-actions a.primary-link { color: var(--accent); font-weight: 600; }
+.pick-actions a:hover { text-decoration: underline; }

--- a/web/server.mjs
+++ b/web/server.mjs
@@ -1,0 +1,423 @@
+// career-ops dashboard server
+// Zero new deps: uses Node built-in http + already-installed js-yaml.
+// Run: npm run web  (default port 5757, override with PORT env)
+
+import { createServer } from 'node:http';
+import { readFile, writeFile, stat } from 'node:fs/promises';
+import { extname, join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import yaml from 'js-yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const PORT = Number(process.env.PORT) || 5757;
+
+const PORTALS_PATH = join(ROOT, 'portals.yml');
+const PIPELINE_PATH = join(ROOT, 'data', 'pipeline.md');
+const SCAN_HISTORY_PATH = join(ROOT, 'data', 'scan-history.tsv');
+const APPLICATIONS_PATH = join(ROOT, 'data', 'applications.md');
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+};
+
+function send(res, status, body, type = 'application/json; charset=utf-8') {
+  res.writeHead(status, { 'Content-Type': type, 'Cache-Control': 'no-store' });
+  res.end(typeof body === 'string' || Buffer.isBuffer(body) ? body : JSON.stringify(body));
+}
+
+function sendJson(res, status, obj) { send(res, status, obj); }
+function sendErr(res, status, msg) { sendJson(res, status, { error: msg }); }
+
+async function readBody(req) {
+  return new Promise((resolveBody, rejectBody) => {
+    const chunks = [];
+    req.on('data', c => chunks.push(c));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (!raw) return resolveBody({});
+      try { resolveBody(JSON.parse(raw)); } catch (e) { rejectBody(e); }
+    });
+    req.on('error', rejectBody);
+  });
+}
+
+// ---------------------------------------------------------------- Scan history
+async function getScanHistory() {
+  const raw = await readFile(SCAN_HISTORY_PATH, 'utf8');
+  const lines = raw.split(/\r?\n/).filter(Boolean);
+  const [headerLine, ...dataLines] = lines;
+  const headers = headerLine.split('\t');
+  const rows = dataLines.map(line => {
+    const cells = line.split('\t');
+    const row = {};
+    headers.forEach((h, i) => { row[h] = cells[i] ?? ''; });
+    return row;
+  });
+  // Aggregate stats
+  const byStatus = {};
+  const byCompany = {};
+  for (const r of rows) {
+    byStatus[r.status] = (byStatus[r.status] || 0) + 1;
+    byCompany[r.company] = (byCompany[r.company] || 0) + 1;
+  }
+  return { headers, rows, byStatus, byCompany, total: rows.length };
+}
+
+// ------------------------------------------------------------------- Pipeline
+async function getPipeline() {
+  const raw = await readFile(PIPELINE_PATH, 'utf8');
+  const parseLine = (line) => {
+    // Procesadas with #NNN + score: - [x] #NNN | url | company | title | score | pdf
+    const proc = line.match(/^-\s*\[x\]\s*#(\d+)\s*\|\s*(\S+)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*(.+)$/);
+    if (proc) {
+      return {
+        done: true, num: proc[1], url: proc[2].trim(),
+        company: proc[3].trim(), title: proc[4].trim(),
+        score: proc[5].trim(), pdf: proc[6].trim(),
+      };
+    }
+    // Pendientes/legacy/mismatchs: - [ ] url | company | title  or  - [~] url | company | title
+    const pen = line.match(/^-\s*\[([ x~])\]\s*(\S+)\s*\|\s*([^|]+?)\s*\|\s*(.+)$/);
+    if (pen) {
+      return {
+        done: pen[1] === 'x', pruned: pen[1] === '~',
+        url: pen[2].trim(), company: pen[3].trim(), title: pen[4].trim(),
+      };
+    }
+    return null;
+  };
+  const sections = { pendientes: [], procesadas: [], mismatchs: [] };
+  let current = null;
+  for (const line of raw.split(/\r?\n/)) {
+    if (/^##\s+Pendientes/i.test(line)) { current = 'pendientes'; continue; }
+    if (/^##\s+Procesadas/i.test(line)) { current = 'procesadas'; continue; }
+    if (/^##\s+Mismatch/i.test(line)) { current = 'mismatchs'; continue; }
+    if (!current) continue;
+    const item = parseLine(line);
+    if (item) sections[current].push(item);
+  }
+  return sections;
+}
+
+// ------------------------------------------------------------------- Reports
+async function getReportsIndex() {
+  const { readdir } = await import('node:fs/promises');
+  const dir = join(ROOT, 'reports');
+  try {
+    const files = await readdir(dir);
+    const index = {};
+    for (const f of files) {
+      const m = f.match(/^(\d{3})-/);
+      if (m && f.endsWith('.md')) index[m[1]] = f;
+    }
+    return index;
+  } catch {
+    return {};
+  }
+}
+
+// --------------------------------------------------------------- Applications
+async function getApplications() {
+  const raw = await readFile(APPLICATIONS_PATH, 'utf8');
+  const rows = [];
+  let inTable = false;
+  for (const line of raw.split(/\r?\n/)) {
+    if (line.startsWith('| # ') && line.includes('Company')) { inTable = true; continue; }
+    if (inTable && line.startsWith('|---')) continue;
+    if (inTable && !line.startsWith('|')) { inTable = false; continue; }
+    if (!inTable) continue;
+    // Split safely on '|' but keep cell content intact
+    const cells = line.split('|').slice(1, -1).map(c => c.trim());
+    if (cells.length < 5) continue;
+    // Observed layout: # | Date | Company | Role | Score | Status | PDF | Report | Notes
+    const [num, date, company, role, score, status, pdf, report, ...rest] = cells;
+    const notes = rest.join(' | ');
+    rows.push({ num, date, company, role, score, status, pdf, report, notes });
+  }
+  // Stats
+  const byStatus = {};
+  for (const r of rows) { byStatus[r.status] = (byStatus[r.status] || 0) + 1; }
+  return { rows, byStatus, total: rows.length };
+}
+
+// ------------------------------------------------------------------- Portals
+async function getPortals() {
+  const raw = await readFile(PORTALS_PATH, 'utf8');
+  const parsed = yaml.load(raw);
+  return {
+    location_filter: parsed.location_filter ?? null,
+    freshness_filter: parsed.freshness_filter ?? null,
+    remote_filter: parsed.remote_filter ?? null,
+    title_filter: parsed.title_filter ?? null,
+    tracked_companies: parsed.tracked_companies ?? [],
+    search_queries: parsed.search_queries ?? [],
+  };
+}
+
+// Format a single company entry as YAML text matching the file's existing style.
+function formatCompanyBlock(company) {
+  const out = [];
+  out.push(`  - name: ${company.name}`);
+  if (company.careers_url) out.push(`    careers_url: ${company.careers_url}`);
+  if (company.api) out.push(`    api: ${company.api}`);
+  if (company.api_provider) out.push(`    api_provider: ${company.api_provider}`);
+  if (company.scan_method) out.push(`    scan_method: ${company.scan_method}`);
+  if (company.scan_query) {
+    const q = String(company.scan_query);
+    const quoted = q.includes("'") ? `"${q.replace(/"/g, '\\"')}"` : `'${q}'`;
+    out.push(`    scan_query: ${quoted}`);
+  }
+  if (company.notes) {
+    const n = String(company.notes);
+    const quoted = n.includes('"') ? `'${n.replace(/'/g, "''")}'` : `"${n}"`;
+    out.push(`    notes: ${quoted}`);
+  }
+  out.push(`    enabled: ${company.enabled !== false}`);
+  return out.join('\n');
+}
+
+// Locate the start/end line indices of the block for a given company name.
+// Returns { startIdx, endIdx } inclusive, or null if not found.
+function findCompanyBlock(lines, name) {
+  const startRe = new RegExp(`^\\s*-\\s+name:\\s*${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`);
+  let trackedAt = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^tracked_companies:\s*$/.test(lines[i])) { trackedAt = i; break; }
+  }
+  if (trackedAt === -1) return null;
+  for (let i = trackedAt + 1; i < lines.length; i++) {
+    if (startRe.test(lines[i])) {
+      // End is the line BEFORE the next "  - name:" or the next top-level key
+      let end = lines.length - 1;
+      for (let j = i + 1; j < lines.length; j++) {
+        if (/^\s*-\s+name:\s/.test(lines[j])) { end = j - 1; break; }
+        if (/^[a-z_]+:\s*$/.test(lines[j])) { end = j - 1; break; }
+      }
+      return { startIdx: i, endIdx: end };
+    }
+  }
+  return null;
+}
+
+function detectEol(raw) { return raw.includes('\r\n') ? '\r\n' : '\n'; }
+function detectTrailingEol(raw) { return /\r?\n$/.test(raw); }
+
+async function writePortals(lines, eol) {
+  const raw = await readFile(PORTALS_PATH, 'utf8');
+  const trailing = detectTrailingEol(raw);
+  await writeFile(PORTALS_PATH, lines.join(eol) + (trailing ? eol : ''), 'utf8');
+}
+
+async function addCompany(company) {
+  if (!company?.name) throw new Error('name required');
+  const raw = await readFile(PORTALS_PATH, 'utf8');
+  const eol = detectEol(raw);
+  const lines = raw.split(/\r?\n/);
+  // Reject duplicate
+  if (findCompanyBlock(lines, company.name)) {
+    throw new Error(`Company "${company.name}" already exists`);
+  }
+  // Find end of tracked_companies section: last "  - name:" block or last indented line before top-level key
+  let trackedAt = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^tracked_companies:\s*$/.test(lines[i])) { trackedAt = i; break; }
+  }
+  if (trackedAt === -1) throw new Error('tracked_companies section not found');
+  let insertAt = lines.length;
+  for (let i = trackedAt + 1; i < lines.length; i++) {
+    if (/^[a-z_]+:\s*$/.test(lines[i])) { insertAt = i; break; }
+  }
+  // Trim trailing blank lines inside the section
+  while (insertAt > trackedAt + 1 && lines[insertAt - 1].trim() === '') insertAt--;
+  const block = formatCompanyBlock(company);
+  lines.splice(insertAt, 0, '', block);
+  await writePortals(lines, eol);
+  return { ok: true };
+}
+
+async function updateCompany(name, company) {
+  const raw = await readFile(PORTALS_PATH, 'utf8');
+  const eol = detectEol(raw);
+  const lines = raw.split(/\r?\n/);
+  const found = findCompanyBlock(lines, name);
+  if (!found) throw new Error(`Company "${name}" not found`);
+  const newBlock = formatCompanyBlock({ ...company, name: company.name || name });
+  lines.splice(found.startIdx, found.endIdx - found.startIdx + 1, ...newBlock.split('\n'));
+  await writePortals(lines, eol);
+  return { ok: true };
+}
+
+async function deleteCompany(name) {
+  const raw = await readFile(PORTALS_PATH, 'utf8');
+  const eol = detectEol(raw);
+  const lines = raw.split(/\r?\n/);
+  const found = findCompanyBlock(lines, name);
+  if (!found) throw new Error(`Company "${name}" not found`);
+  let start = found.startIdx;
+  if (start > 0 && lines[start - 1].trim() === '') start--;
+  lines.splice(start, found.endIdx - start + 1);
+  await writePortals(lines, eol);
+  return { ok: true };
+}
+
+async function toggleCompany(name) {
+  const portals = await getPortals();
+  const company = portals.tracked_companies.find(c => c.name === name);
+  if (!company) throw new Error(`Company "${name}" not found`);
+  const next = { ...company, enabled: !(company.enabled !== false) };
+  return updateCompany(name, next);
+}
+
+// ------------------------------------------------------------------- Scan
+let scanRunning = false;
+
+async function runScanStreamed(req, res) {
+  if (scanRunning) return sendErr(res, 409, 'Scan déjà en cours');
+
+  // Read optional JSON body { companies: ["Cohere", "Pennylane"] } before opening SSE.
+  let companies = [];
+  if (req.method === 'POST') {
+    try {
+      const body = await readBody(req);
+      if (Array.isArray(body?.companies)) {
+        companies = body.companies
+          .map(c => (typeof c === 'string' ? c.trim() : ''))
+          .filter(Boolean);
+      }
+    } catch {
+      return sendErr(res, 400, 'Body JSON invalide');
+    }
+  }
+
+  scanRunning = true;
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-store',
+    'Connection': 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+  const sse = (event, data) => {
+    res.write(`event: ${event}\n`);
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
+
+  const extraArgs = companies.flatMap(c => ['--company', c]);
+  const cmdline = ['scan.mjs', ...extraArgs].map(a => /\s/.test(a) ? JSON.stringify(a) : a).join(' ');
+  sse('log', `$ node ${cmdline}`);
+  sse('log', companies.length
+    ? `→ sélection: ${companies.join(', ')} (${companies.length} source${companies.length > 1 ? 's' : ''})`
+    : `→ aucune sélection reçue — scan complet`);
+  const child = spawn(process.execPath, ['scan.mjs', ...extraArgs], {
+    cwd: ROOT,
+    env: { ...process.env, NODE_OPTIONS: process.env.NODE_OPTIONS || '--use-system-ca' },
+  });
+
+  const emitChunk = (prefix) => (chunk) => {
+    const text = chunk.toString('utf8');
+    for (const line of text.split(/\r?\n/)) {
+      if (line.length === 0 && text.length > 1) continue;
+      sse('log', prefix + line);
+    }
+  };
+  child.stdout.on('data', emitChunk(''));
+  child.stderr.on('data', emitChunk('[err] '));
+
+  child.on('error', (err) => {
+    sse('log', `[fatal] ${err.message}`);
+    sse('done', { code: -1, error: err.message });
+    scanRunning = false;
+    res.end();
+  });
+  child.on('close', (code) => {
+    sse('done', { code });
+    scanRunning = false;
+    res.end();
+  });
+  req.on('close', () => {
+    // Client disconnected before scan finished — kill child to avoid orphan
+    if (!child.killed) child.kill();
+  });
+}
+
+// ----------------------------------------------------------------- Static
+async function serveStatic(req, res, urlPath) {
+  // Serve /reports/* and /jds/* from project ROOT (read-only) with path safety
+  for (const sub of ['/reports/', '/jds/']) {
+    if (urlPath.startsWith(sub)) {
+      const safe = urlPath.slice(sub.length);
+      if (!/^[a-z0-9._\-]+$/i.test(safe)) return send(res, 400, 'Bad name', 'text/plain');
+      const filePath = join(ROOT, sub.slice(1, -1), safe);
+      if (!filePath.startsWith(join(ROOT, sub.slice(1, -1)))) return send(res, 403, 'Forbidden', 'text/plain');
+      try {
+        const buf = await readFile(filePath);
+        // Markdown rendered as text/plain so browser displays inline
+        const mime = filePath.endsWith('.md') ? 'text/plain; charset=utf-8' : (MIME[extname(filePath)] || 'application/octet-stream');
+        return send(res, 200, buf, mime);
+      } catch {
+        return send(res, 404, 'Not found', 'text/plain');
+      }
+    }
+  }
+  let p = urlPath === '/' ? '/index.html' : urlPath;
+  const filePath = join(__dirname, 'public', p);
+  if (!filePath.startsWith(join(__dirname, 'public'))) return send(res, 403, 'Forbidden', 'text/plain');
+  try {
+    await stat(filePath);
+    const buf = await readFile(filePath);
+    send(res, 200, buf, MIME[extname(filePath)] || 'application/octet-stream');
+  } catch {
+    send(res, 404, 'Not found', 'text/plain');
+  }
+}
+
+// --------------------------------------------------------------------- Router
+const server = createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, `http://localhost:${PORT}`);
+    const path = url.pathname;
+
+    if (req.method === 'POST' && path === '/api/scan') return runScanStreamed(req, res);
+    if (req.method === 'GET' && path === '/api/scan/status') return sendJson(res, 200, { running: scanRunning });
+    if (req.method === 'GET' && path === '/api/scan-history') return sendJson(res, 200, await getScanHistory());
+    if (req.method === 'GET' && path === '/api/pipeline') return sendJson(res, 200, await getPipeline());
+    if (req.method === 'GET' && path === '/api/applications') return sendJson(res, 200, await getApplications());
+    if (req.method === 'GET' && path === '/api/portals') return sendJson(res, 200, await getPortals());
+    if (req.method === 'GET' && path === '/api/reports') return sendJson(res, 200, await getReportsIndex());
+
+    if (req.method === 'POST' && path === '/api/portals/companies') {
+      const body = await readBody(req);
+      return sendJson(res, 200, await addCompany(body));
+    }
+    const m = path.match(/^\/api\/portals\/companies\/([^/]+)(\/toggle)?$/);
+    if (m) {
+      const name = decodeURIComponent(m[1]);
+      if (req.method === 'PATCH' && m[2] === '/toggle') {
+        return sendJson(res, 200, await toggleCompany(name));
+      }
+      if (req.method === 'PUT') {
+        const body = await readBody(req);
+        return sendJson(res, 200, await updateCompany(name, body));
+      }
+      if (req.method === 'DELETE') {
+        return sendJson(res, 200, await deleteCompany(name));
+      }
+    }
+
+    if (req.method === 'GET') return serveStatic(req, res, path);
+    sendErr(res, 405, 'Method not allowed');
+  } catch (err) {
+    console.error(err);
+    sendErr(res, 500, err.message || String(err));
+  }
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`career-ops dashboard ready → http://127.0.0.1:${PORT}/`);
+});

--- a/web/server.mjs
+++ b/web/server.mjs
@@ -4,6 +4,7 @@
 
 import { createServer } from 'node:http';
 import { readFile, writeFile, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { extname, join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
@@ -17,6 +18,7 @@ const PORTALS_PATH = join(ROOT, 'portals.yml');
 const PIPELINE_PATH = join(ROOT, 'data', 'pipeline.md');
 const SCAN_HISTORY_PATH = join(ROOT, 'data', 'scan-history.tsv');
 const APPLICATIONS_PATH = join(ROOT, 'data', 'applications.md');
+const APP_CONTENT_DIR = join(ROOT, 'data', 'applications-content');
 
 const MIME = {
   '.html': 'text/html; charset=utf-8',
@@ -346,10 +348,87 @@ async function runScanStreamed(req, res) {
   });
 }
 
+// ------------------------------------------------------- Application content
+// List the written applications (one JSON per candidate in data/applications-content/).
+async function getApplicationsContent() {
+  const { readdir } = await import('node:fs/promises');
+  let files = [];
+  try { files = (await readdir(APP_CONTENT_DIR)).filter(f => f.endsWith('.json')); }
+  catch { return { items: [] }; }
+  const items = [];
+  for (const f of files.sort()) {
+    try {
+      const raw = await readFile(join(APP_CONTENT_DIR, f), 'utf8');
+      const c = JSON.parse(raw);
+      const num = (c.report || '').match(/^(\d{3})/)?.[1] || null;
+      items.push({ id: c.id || f.replace(/\.json$/, ''), company: c.company || '', role: c.role || '', lang: c.lang || 'en', paper: c.paper || 'letter', report: c.report || null, num });
+    } catch { /* skip malformed */ }
+  }
+  return { items };
+}
+
+// Generate PDFs for one application via batch/gen-applications.mjs.
+// Body: { id, pages: 0|1|2, cover: bool }. pages 0 = cover only.
+let genRunning = false;
+async function generatePdf(req, res) {
+  if (genRunning) return sendErr(res, 409, 'Génération déjà en cours');
+  let body;
+  try { body = await readBody(req); } catch { return sendErr(res, 400, 'Body JSON invalide'); }
+  const id = typeof body?.id === 'string' ? body.id.trim() : '';
+  if (!id || !/^[a-z0-9_-]+$/i.test(id)) return sendErr(res, 400, 'id invalide');
+  const pages = [0, 1, 2].includes(body?.pages) ? body.pages : 2;
+  const cover = !!body?.cover;
+  if (pages === 0 && !cover) return sendErr(res, 400, 'Rien à générer (ni CV ni cover)');
+
+  const now = new Date();
+  const date = now.toISOString().slice(0, 10);
+  const time = `${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}`;
+  const args = ['batch/gen-applications.mjs', '--id', id, '--date', date, '--time', time];
+  if (pages === 0) args.push('--cover-only');
+  else { args.push('--pages', String(pages)); if (cover) args.push('--cover'); }
+
+  genRunning = true;
+  const child = spawn(process.execPath, args, {
+    cwd: ROOT,
+    env: { ...process.env, NODE_OPTIONS: process.env.NODE_OPTIONS || '--use-system-ca' },
+  });
+  let stdout = '', stderr = '';
+  child.stdout.on('data', d => { stdout += d.toString('utf8'); });
+  child.stderr.on('data', d => { stderr += d.toString('utf8'); });
+  child.on('error', (err) => { genRunning = false; sendErr(res, 500, err.message); });
+  child.on('close', (code) => {
+    genRunning = false;
+    const m = stdout.match(/__RESULT__ (.+)$/m);
+    let results = [];
+    try { if (m) results = JSON.parse(m[1]); } catch {}
+    const locked = results.some(r => r.locked);
+    if (code !== 0 && !results.length) {
+      return sendErr(res, 500, (stderr || stdout || `exit ${code}`).slice(-400));
+    }
+    sendJson(res, 200, { ok: results.every(r => r.ok), locked, results, log: stdout });
+  });
+}
+
+// Open a generated file in the OS default app (Windows: start). Body: { file }.
+async function openFile(req, res) {
+  let body;
+  try { body = await readBody(req); } catch { return sendErr(res, 400, 'Body JSON invalide'); }
+  const file = typeof body?.file === 'string' ? body.file : '';
+  // Only allow opening files inside output/, no traversal.
+  if (!/^[a-z0-9._-]+\.pdf$/i.test(file)) return sendErr(res, 400, 'Nom de fichier invalide');
+  const full = join(ROOT, 'output', file);
+  if (!full.startsWith(join(ROOT, 'output'))) return sendErr(res, 403, 'Forbidden');
+  if (!existsSync(full)) return sendErr(res, 404, 'Fichier introuvable');
+  // Windows: `start` is a cmd builtin; use cmd /c start "" "<path>".
+  const child = spawn('cmd', ['/c', 'start', '', full], { detached: true, stdio: 'ignore' });
+  child.unref();
+  sendJson(res, 200, { ok: true, opened: file, path: full });
+}
+
 // ----------------------------------------------------------------- Static
 async function serveStatic(req, res, urlPath) {
-  // Serve /reports/* and /jds/* from project ROOT (read-only) with path safety
-  for (const sub of ['/reports/', '/jds/']) {
+  // Serve /reports/*, /jds/* and /output/* from project ROOT (read-only) with path safety
+  for (const sub of ['/reports/', '/jds/', '/output/']) {
     if (urlPath.startsWith(sub)) {
       const safe = urlPath.slice(sub.length);
       if (!/^[a-z0-9._\-]+$/i.test(safe)) return send(res, 400, 'Bad name', 'text/plain');
@@ -390,6 +469,9 @@ const server = createServer(async (req, res) => {
     if (req.method === 'GET' && path === '/api/applications') return sendJson(res, 200, await getApplications());
     if (req.method === 'GET' && path === '/api/portals') return sendJson(res, 200, await getPortals());
     if (req.method === 'GET' && path === '/api/reports') return sendJson(res, 200, await getReportsIndex());
+    if (req.method === 'GET' && path === '/api/applications-content') return sendJson(res, 200, await getApplicationsContent());
+    if (req.method === 'POST' && path === '/api/generate-pdf') return generatePdf(req, res);
+    if (req.method === 'POST' && path === '/api/open-file') return openFile(req, res);
 
     if (req.method === 'POST' && path === '/api/portals/companies') {
       const body = await readBody(req);


### PR DESCRIPTION
## Résumé

Ajoute un **dashboard web zero-dep** (Node `http` + `js-yaml` déjà installé) servi sur `127.0.0.1:5757`, et la feature **scan sélectif** demandée : cocher des sources dans l'onglet *Sources* et ne scanner que celles-là, au lieu de relancer le scan complet (~86 entreprises) à chaque fois.

## Ce que ça apporte

**Dashboard** (`npm run web` ou `.\web.ps1`) — 6 onglets : Overview, ⭐ Picks, Pipeline, Applications, Scans, Sources. Édition des `tracked_companies`, lancement de scan en streaming SSE, reports servis en read-only.

**Scan sélectif** :
- `scan.mjs` : `--company` accepte plusieurs valeurs (répété `--company A --company B` ou comma-separated `--company "A,B,C"`). Les sources cochées **sans API ATS supportée** sont nommées dans le log (`⚠ Ignorées (pas d'API supportée) : …`) au lieu d'être silencieusement absentes.
- `web/server.mjs` : `POST /api/scan` lit `{companies:[...]}` du body et passe les `--company` au child. Compat conservée (sans body → scan complet).
- `web/public` : checkbox par source + "tout sélectionner (visibles)", sélection persistée en `localStorage`, sources `disabled` non cochables.
- `web.ps1` : lanceur PowerShell (set `NODE_OPTIONS=--use-system-ca` + `npm run web`).

Inclut aussi la **refonte ATS** de `scan.mjs` portée dans le même fichier : support Workable, freshness filter, `workplace_type` (Greenhouse/Ashby/Lever/Workable).

## Tests

Validé end-to-end via `curl` sur le serveur et dans l'IHM :
- sélection 2 sources → `Scanning 2 companies` ✓
- sans sélection → `Scanning 86 companies` (régression OK) ✓
- sources sans API → ligne `⚠ Ignorées` affichée ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local career-ops web dashboard with tabbed UI (Overview, Picks, Pipeline, Applications, Generate, Scans, Sources), server endpoints, SSE scan streaming, and a simple launch script.
  * Batch CV/cover-letter generation with PDF rendering and file-open support.

* **Enhancements**
  * Workable ATS support and richer job parsing (posted date, workplace type).
  * Freshness and remote filters, improved dedup/skip logging, and multi-company CLI selection.

* **Style**
  * New dark-themed French-localized frontend styles and UI bootstrap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->