### PR TITLE
fix(doctor): treat missing setup files as warnings, not failures

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -68,6 +68,7 @@ function checkCv() {
   }
   return {
     pass: false,
+    severity: 'setup',
     label: 'cv.md not found',
     fix: [
       'Create cv.md in the project root with your CV in markdown',
@@ -82,6 +83,7 @@ function checkProfile() {
   }
   return {
     pass: false,
+    severity: 'setup',
     label: 'config/profile.yml not found',
     fix: [
       'Run: cp config/profile.example.yml config/profile.yml',
@@ -96,6 +98,7 @@ function checkPortals() {
   }
   return {
     pass: false,
+    severity: 'setup',
     label: 'portals.yml not found',
     fix: [
       'Run: cp templates/portals.example.yml portals.yml',
@@ -167,10 +170,18 @@ async function main() {
   ];
 
   let failures = 0;
+  let setupWarnings = 0;
 
   for (const result of checks) {
     if (result.pass) {
       console.log(`${green('✓')} ${result.label}`);
+    } else if (result.severity === 'setup') {
+      setupWarnings++;
+      console.log(`! ${result.label}`);
+      const fixes = Array.isArray(result.fix) ? result.fix : [result.fix];
+      for (const hint of fixes) {
+        console.log(`  ${dim('→ ' + hint)}`);
+      }
     } else {
       failures++;
       console.log(`${red('✗')} ${result.label}`);
@@ -183,8 +194,11 @@ async function main() {
 
   console.log('');
   if (failures > 0) {
-    console.log(`Result: ${failures} issue${failures === 1 ? '' : 's'} found. Fix them and run \`npm run doctor\` again.`);
+    console.log(`Result: ${failures} prerequisite issue${failures === 1 ? '' : 's'} found. Fix them and run \`npm run doctor\` again.`);
     process.exit(1);
+  } else if (setupWarnings > 0) {
+    console.log(`Result: Required checks passed with ${setupWarnings} setup warning${setupWarnings === 1 ? '' : 's'}. Add your local profile/CV files before evaluating jobs.`);
+    process.exit(0);
   } else {
     console.log('Result: All checks passed. You\'re ready to go! Run `claude` to start.');
     console.log('');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12,7 +12,8 @@
  */
 
 import { execSync, execFileSync } from 'child_process';
-import { readFileSync, existsSync, readdirSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, mkdtempSync, copyFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -1013,6 +1014,46 @@ try {
 
 } catch (e) {
   fail(`recruitee provider tests crashed: ${e.message}`);
+}
+
+// ── 15. DOCTOR SETUP SEVERITY ───────────────────────────────────
+
+console.log('\n15. Doctor setup severity');
+
+try {
+  // Run doctor.mjs from an isolated temp dir. projectRoot is the script's own
+  // directory, so a standalone copy sees cv.md / config/profile.yml / portals.yml
+  // as absent — they must surface as setup *warnings* (!), not hard failures (✗).
+  const tmp = mkdtempSync(join(tmpdir(), 'careerops-doctor-'));
+  copyFileSync(join(ROOT, 'doctor.mjs'), join(tmp, 'doctor.mjs'));
+  let out = '';
+  try {
+    out = execFileSync('node', [join(tmp, 'doctor.mjs')], { encoding: 'utf-8', timeout: 30000 });
+  } catch (err) {
+    // Non-zero exit is expected here: the bare dir is missing real prerequisites
+    // (deps/playwright). We only assert the setup-file routing + wording.
+    out = `${err.stdout || ''}${err.stderr || ''}`;
+  }
+  rmSync(tmp, { recursive: true, force: true });
+
+  const setupLabels = [
+    'cv.md not found',
+    'config/profile.yml not found',
+    'portals.yml not found',
+  ];
+  for (const label of setupLabels) {
+    if (out.includes(`! ${label}`)) pass(`missing ${label} is a setup warning (!)`);
+    else fail(`missing ${label} should be a setup warning (!)`);
+    if (!out.includes(`✗ ${label}`)) pass(`missing ${label} is not counted as a hard failure (✗)`);
+    else fail(`missing ${label} should not be a hard failure (✗)`);
+  }
+  // Real prerequisites (deps/playwright) still count as failures with the new wording.
+  if (/✗ /.test(out)) pass('real prerequisites still reported as failures (✗)');
+  else fail('expected at least one real prerequisite failure in a bare dir');
+  if (out.includes('prerequisite issue')) pass('result distinguishes prerequisite issues from setup warnings');
+  else fail('result wording should mention "prerequisite issue"');
+} catch (e) {
+  fail(`doctor setup-severity test crashed: ${e.message}`);
 }
 
 // ── SUMMARY ─────────────────────────────────────────────────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1028,7 +1028,7 @@ try {
   copyFileSync(join(ROOT, 'doctor.mjs'), join(tmp, 'doctor.mjs'));
   let out = '';
   try {
-    out = execFileSync('node', [join(tmp, 'doctor.mjs')], { encoding: 'utf-8', timeout: 30000 });
+    out = execFileSync(NODE, [join(tmp, 'doctor.mjs')], { encoding: 'utf-8', timeout: 30000 });
   } catch (err) {
     // Non-zero exit is expected here: the bare dir is missing real prerequisites
     // (deps/playwright). We only assert the setup-file routing + wording.


### PR DESCRIPTION
Closes #772

Tags the first-run setup checks (`cv.md`, `config/profile.yml`, and `portals.yml`) with `severity: "setup"` and routes them to warning output with fix hints instead of counting them as hard failures.

Real prerequisites (Node, dependencies, Playwright, fonts) still fail hard, so genuine setup problems are not masked. When only setup files are missing, `doctor` now exits 0 with a setup-warning summary, and the failure line is reworded to "prerequisite issue(s)" to distinguish the two.

Adds a focused test in `test-all.mjs` that runs `doctor.mjs` in an isolated temp dir and asserts the three setup files surface as `!` warnings (not `✗` failures), real prerequisites still count as failures, and the new wording is present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The doctor tool now separates setup prerequisite warnings from hard failures: missing local config/content are shown as warnings and no longer cause a failing exit; exit codes and final messages reflect this.

* **Tests**
  * Added CLI tests to confirm setup issues are reported as warnings, hard failures still surface, and outputs show the prerequisite distinction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->