### PR TITLE
fix(dashboard): resolve tracker-relative report links against the tracker directory

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -26,6 +26,25 @@ var (
 	reBatchID        = regexp.MustCompile(`(?m)^\*\*Batch ID:\*\*\s*(\d+)`)
 )
 
+// resolveReportPath converts a report link from the tracker into a path
+// relative to careerOpsPath. Links are normally relative to the tracker
+// file's own directory (see merge-tracker.mjs link normalization, #760);
+// legacy trackers may still carry root-relative links, so fall back to the
+// raw link when the tracker-relative resolution does not exist on disk.
+func resolveReportPath(careerOpsPath, trackerPath, link string) string {
+	resolved := filepath.Join(filepath.Dir(trackerPath), link)
+	if _, err := os.Stat(resolved); err != nil {
+		legacy := filepath.Join(careerOpsPath, link)
+		if _, err2 := os.Stat(legacy); err2 == nil {
+			resolved = legacy
+		}
+	}
+	if rel, err := filepath.Rel(careerOpsPath, resolved); err == nil {
+		return rel
+	}
+	return link
+}
+
 // ParseApplications reads applications.md and returns parsed applications.
 // It tries both {path}/applications.md and {path}/data/applications.md for compatibility.
 func ParseApplications(careerOpsPath string) []model.CareerApplication {
@@ -96,10 +115,15 @@ func ParseApplications(careerOpsPath string) []model.CareerApplication {
 			app.Score, _ = strconv.ParseFloat(sm[1], 64)
 		}
 
-		// Parse report link
+		// Parse report link. Tracker links are written relative to the
+		// tracker file itself (e.g. ../reports/... when the tracker lives in
+		// data/), so resolve against the tracker's directory and normalize
+		// back to a careerOpsPath-relative path, which is what every
+		// consumer joins against. Legacy root-relative links are kept as a
+		// fallback when the resolved file does not exist.
 		if rm := reReportLink.FindStringSubmatch(fields[7]); rm != nil {
 			app.ReportNumber = rm[1]
-			app.ReportPath = rm[2]
+			app.ReportPath = resolveReportPath(careerOpsPath, filePath, rm[2])
 		}
 
 		// Notes (field 8 if exists)

--- a/dashboard/internal/data/career_test.go
+++ b/dashboard/internal/data/career_test.go
@@ -41,3 +41,57 @@ func TestParseApplicationsUsesTrackerNumberColumn(t *testing.T) {
 		t.Fatalf("expected report numbers to stay aligned with tracker IDs, got %q and %q", apps[0].ReportNumber, apps[1].ReportNumber)
 	}
 }
+
+func TestParseApplicationsResolvesTrackerRelativeReportLinks(t *testing.T) {
+	tempDir := t.TempDir()
+	dataDir := filepath.Join(tempDir, "data")
+	reportsDir := filepath.Join(tempDir, "reports")
+	for _, dir := range []string{dataDir, reportsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("failed to create dir %s: %v", dir, err)
+		}
+	}
+
+	// Tracker links are written relative to the tracker file itself
+	// (merge-tracker.mjs normalization): ../reports/... when the tracker
+	// lives under data/. Legacy trackers may still carry root-relative
+	// links; both must resolve to the same on-disk report.
+	applications := `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-03 | Acme | Engineer | 4.0/5 | Evaluated | ✅ | [1](../reports/001-acme-2026-06-03.md) | Tracker-relative link |
+| 2 | 2026-06-03 | Legacy Co | Engineer | 3.0/5 | Evaluated | ❌ | [2](reports/002-legacy-2026-06-03.md) | Legacy root-relative link |
+`
+
+	if err := os.WriteFile(filepath.Join(dataDir, "applications.md"), []byte(applications), 0o644); err != nil {
+		t.Fatalf("failed to write applications tracker: %v", err)
+	}
+	for _, name := range []string{"001-acme-2026-06-03.md", "002-legacy-2026-06-03.md"} {
+		if err := os.WriteFile(filepath.Join(reportsDir, name), []byte("# Report\n"), 0o644); err != nil {
+			t.Fatalf("failed to write report %s: %v", name, err)
+		}
+	}
+
+	apps := ParseApplications(tempDir)
+	if len(apps) != 2 {
+		t.Fatalf("expected 2 parsed applications, got %d", len(apps))
+	}
+
+	wantFirst := filepath.Join("reports", "001-acme-2026-06-03.md")
+	if apps[0].ReportPath != wantFirst {
+		t.Fatalf("expected tracker-relative link to resolve to %q, got %q", wantFirst, apps[0].ReportPath)
+	}
+	wantSecond := filepath.Join("reports", "002-legacy-2026-06-03.md")
+	if apps[1].ReportPath != wantSecond {
+		t.Fatalf("expected legacy root-relative link to resolve to %q, got %q", wantSecond, apps[1].ReportPath)
+	}
+
+	// Every consumer joins ReportPath against careerOpsPath — both rows
+	// must point at files that exist.
+	for i, app := range apps {
+		if _, err := os.Stat(filepath.Join(tempDir, app.ReportPath)); err != nil {
+			t.Fatalf("row %d: resolved report path %q does not exist: %v", i, app.ReportPath, err)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #779

## Problem

Since #760, `merge-tracker.mjs` writes report links relative to the tracker file itself — `[004](../reports/004-faculty-2026-06-03.md)` when the tracker lives at `data/applications.md`. The dashboard joined those links against the repo root (`career.go`), so `filepath.Join(root, "../reports/...")` cleaned to a path one directory above the repo, and the report viewer failed:

```
Error reading file: open ../../reports/004-faculty-2026-06-03.md: no such file or directory
```

`LoadReportSummary` enrichment in `main.go` silently failed the same way.

## Fix

New `resolveReportPath()` in `ParseApplications`:
- resolves the link against the directory of the tracker file actually loaded (markdown link semantics — both supported layouts work: `{path}/applications.md` and `{path}/data/applications.md`)
- falls back to root-relative resolution when the tracker-relative path doesn't exist on disk (legacy trackers that predate #760 normalization)
- normalizes `ReportPath` back to careerOpsPath-relative, so every existing consumer (`Join(careerOpsPath, ReportPath)`) keeps working unchanged

## Testing

- New regression test `TestParseApplicationsResolvesTrackerRelativeReportLinks` covering both link styles (tracker-relative and legacy root-relative)
- `go build ./...` and `go test ./...` green
- Manually verified against a real tracker: viewer opens all reports; before the fix every `enter` errored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report link resolution to correctly handle multiple path formats with proper fallback behavior.
  * Enhanced link processing to normalize paths and verify filesystem existence.

* **Tests**
  * Added test coverage for report link resolution across different path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->