### PR TITLE
fix(liveness): stop false-expiring anti-bot-walled postings (pracuj.pl)

### DIFF
--- a/check-liveness.mjs
+++ b/check-liveness.mjs
@@ -16,43 +16,71 @@
 
 import { chromium } from 'playwright';
 import { readFile } from 'fs/promises';
-import { checkUrlLiveness } from './liveness-browser.mjs';
+import {
+  checkUrlLivenessWithFallback,
+  createHeadedPageProvider,
+  newLivenessPage,
+  jitteredDelayMs,
+  sleep,
+} from './liveness-browser.mjs';
 
 async function main() {
   const args = process.argv.slice(2);
 
-  if (args.length === 0) {
-    console.error('Usage: node check-liveness.mjs <url1> [url2] ...');
-    console.error('       node check-liveness.mjs --file urls.txt');
+  // Portals like pracuj.pl serve a Cloudflare anti-bot wall to headless Chromium.
+  // On a challenge we retry once in a headed browser (which clears it); pass
+  // --no-fallback to stay fully headless (e.g. on a machine with no display).
+  const noFallback = args.includes('--no-fallback');
+  // --throttle or --throttle=<ms>: wait base..2*base ms (jittered) between checks
+  // to stay under rate-based WAF limits. pracuj.pl's Cloudflare flags the session
+  // after ~2 rapid hits, so a bulk run needs spacing. Default base 5000ms.
+  const throttleArg = args.find((a) => a === '--throttle' || a.startsWith('--throttle='));
+  const throttleBaseMs = throttleArg ? (Number(throttleArg.split('=')[1]) || 5000) : 0;
+  const positional = args.filter((a) => a !== '--no-fallback' && a !== throttleArg);
+
+  if (positional.length === 0) {
+    console.error('Usage: node check-liveness.mjs [--no-fallback] [--throttle[=ms]] <url1> [url2] ...');
+    console.error('       node check-liveness.mjs [--no-fallback] [--throttle[=ms]] --file urls.txt');
     process.exit(1);
   }
 
   let urls;
-  if (args[0] === '--file') {
-    const text = await readFile(args[1], 'utf-8');
+  if (positional[0] === '--file') {
+    const text = await readFile(positional[1], 'utf-8');
     urls = text.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
   } else {
-    urls = args;
+    urls = positional;
   }
 
-  console.log(`Checking ${urls.length} URL(s)...\n`);
+  const notes = [
+    noFallback ? null : 'headed fallback on challenge',
+    throttleBaseMs ? `throttle ~${throttleBaseMs / 1000}-${(throttleBaseMs * 2) / 1000}s` : null,
+  ].filter(Boolean);
+  console.log(`Checking ${urls.length} URL(s)...${notes.length ? ` (${notes.join(', ')})` : ''}\n`);
 
   const browser = await chromium.launch({ headless: true });
-  const page = await browser.newPage();
+  const page = await newLivenessPage(browser);
+  const headed = noFallback ? null : createHeadedPageProvider(chromium);
+  const getHeadedPage = headed ? () => headed.get() : undefined;
 
   let active = 0, expired = 0, uncertain = 0;
 
   // Sequential — project rule: never Playwright in parallel
-  for (const url of urls) {
-    const { result, reason } = await checkUrlLiveness(page, url);
+  for (let i = 0; i < urls.length; i++) {
+    const url = urls[i];
+    const { result, reason } = await checkUrlLivenessWithFallback(page, url, { getHeadedPage });
     const icon = { active: '✅', expired: '❌', uncertain: '⚠️' }[result];
     console.log(`${icon} ${result.padEnd(10)} ${url}`);
     if (result !== 'active') console.log(`           ${reason}`);
     if (result === 'active') active++;
     else if (result === 'expired') expired++;
     else uncertain++;
+
+    const wait = i < urls.length - 1 ? jitteredDelayMs(throttleBaseMs) : 0;
+    if (wait) await sleep(wait);
   }
 
+  if (headed) await headed.close();
   await browser.close();
 
   console.log(`\nResults: ${active} active  ${expired} expired  ${uncertain} uncertain`);

--- a/liveness-browser.mjs
+++ b/liveness-browser.mjs
@@ -10,6 +10,36 @@ import { classifyLiveness } from './liveness-core.mjs';
 const NAVIGATE_TIMEOUT_MS = 15_000;
 const HYDRATION_WAIT_MS = 2_000;
 
+// The default Playwright headless UA contains "HeadlessChrome", which Cloudflare
+// and similar WAFs flag — portals like pracuj.pl then serve a 403 challenge page
+// instead of the posting. Presenting a normal desktop Chrome UA clears the wall
+// headlessly (the scan parser scripts/parsers/pracuj-jobs.mjs relies on the same
+// trick), so the common case never needs the slower headed-browser fallback.
+export const LIVENESS_CONTEXT_OPTIONS = {
+  userAgent:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+  locale: 'en-US',
+};
+
+// Open a page in a context that already presents a realistic UA. Both callers use
+// this instead of browser.newPage() so headless checks aren't instantly bot-walled.
+export async function newLivenessPage(browser) {
+  const context = await browser.newContext(LIVENESS_CONTEXT_OPTIONS);
+  return context.newPage();
+}
+
+export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Throttle delay with jitter: a value in [baseMs, 2*baseMs). Spacing requests out
+// (and randomizing the gap) keeps a bulk run under rate-based WAF thresholds —
+// pracuj.pl's Cloudflare flags the session after ~2 rapid hits, after which even
+// headed retries are blocked. A randomized gap also avoids a fixed-cadence
+// fingerprint. Returns 0 for a non-positive base (throttling disabled).
+export function jitteredDelayMs(baseMs) {
+  if (!baseMs || baseMs <= 0) return 0;
+  return baseMs + Math.floor(Math.random() * baseMs);
+}
+
 // Defensive guards: URLs come from ATS feeds (mostly trusted) but a misconfigured
 // portals.yml entry or a hijacked feed shouldn't be able to point Playwright at
 // internal infrastructure. Only allow http(s) and reject loopback/private/link-local.
@@ -45,7 +75,7 @@ function rejectPrivateOrInvalid(url) {
   return null;
 }
 
-export async function checkUrlLiveness(page, url) {
+export async function checkUrlLiveness(page, url, { extraSettleMs = 0 } = {}) {
   const guardError = rejectPrivateOrInvalid(url);
   if (guardError) {
     return { result: 'uncertain', code: guardError.code, reason: guardError.reason };
@@ -54,8 +84,9 @@ export async function checkUrlLiveness(page, url) {
     const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: NAVIGATE_TIMEOUT_MS });
     const status = response?.status() ?? 0;
 
-    // Give SPAs (Ashby, Lever, Workday) time to hydrate
-    await page.waitForTimeout(HYDRATION_WAIT_MS);
+    // Give SPAs (Ashby, Lever, Workday) time to hydrate. extraSettleMs adds slack
+    // for the headed retry, where a JS anti-bot interstitial needs a moment to clear.
+    await page.waitForTimeout(HYDRATION_WAIT_MS + extraSettleMs);
 
     const finalUrl = page.url();
     const bodyText = await page.evaluate(() => document.body?.innerText ?? '');
@@ -103,4 +134,70 @@ export async function checkUrlLiveness(page, url) {
       reason: `navigation error: ${err.message.split('\n')[0]}`,
     };
   }
+}
+
+// Anti-bot results that a headed browser may be able to get past. A real (headed)
+// Chromium clears the JS/Cloudflare challenge that headless trips on (e.g. pracuj.pl).
+const CHALLENGE_CODES = new Set(['bot_challenge', 'access_blocked']);
+
+export function isChallengeResult(result) {
+  return result?.result === 'uncertain' && CHALLENGE_CODES.has(result.code);
+}
+
+// Lazily owns a single headed browser/page, created only on first use and reused
+// across URLs. Headed Chromium needs a display, so launch can fail in headless/CI
+// environments — in that case get() returns null and callers degrade to the
+// headless result (challenge stays uncertain, never falsely expired).
+export function createHeadedPageProvider(chromium) {
+  let browser = null;
+  let page = null;
+  let launchFailed = false;
+  return {
+    async get() {
+      if (page) return page;
+      if (launchFailed) return null;
+      try {
+        browser = await chromium.launch({ headless: false });
+        const context = await browser.newContext(LIVENESS_CONTEXT_OPTIONS);
+        page = await context.newPage();
+        return page;
+      } catch {
+        launchFailed = true;
+        browser = null;
+        page = null;
+        return null;
+      }
+    },
+    async close() {
+      if (browser) {
+        try {
+          await browser.close();
+        } catch {
+          // best-effort teardown
+        }
+      }
+      browser = null;
+      page = null;
+    },
+  };
+}
+
+// Runs the headless check, then retries once in a headed browser if the page was
+// blocked by an anti-bot wall. The headed result wins when it actually sees the
+// page; if the retry is still blocked (or no headed page is available) the
+// original uncertain result is kept — we never upgrade a block to expired.
+export async function checkUrlLivenessWithFallback(page, url, { getHeadedPage } = {}) {
+  const first = await checkUrlLiveness(page, url);
+  if (!getHeadedPage || !isChallengeResult(first)) {
+    return first;
+  }
+  const headedPage = await getHeadedPage();
+  if (!headedPage) {
+    return first;
+  }
+  const second = await checkUrlLiveness(headedPage, url, { extraSettleMs: 3_000 });
+  if (isChallengeResult(second)) {
+    return { ...second, reason: `${second.reason} (headed retry also blocked)` };
+  }
+  return second;
 }

--- a/liveness-core.mjs
+++ b/liveness-core.mjs
@@ -21,6 +21,24 @@ const LISTING_PAGE_PATTERNS = [
   /search for jobs page is loaded/i,
 ];
 
+// Anti-bot interstitials (Cloudflare "Just a moment...", hCaptcha walls, etc.)
+// render a tiny challenge page instead of the posting. Headless Playwright trips
+// these on portals like pracuj.pl. They must NOT be read as expired: the body is
+// short and lacks an apply control, so without this guard they fall through to
+// `insufficient_content` → expired, and scan --verify would write live jobs to
+// scan-history and permanently filter them out. Treat as uncertain instead.
+const BOT_CHALLENGE_PATTERNS = [
+  /just a moment/i,
+  /performing security verification/i,
+  /checking your browser before/i,
+  /verify you are (a |not a )?human/i,
+  /enable javascript and cookies to continue/i,
+  /attention required.*cloudflare/i,
+  /\bray id\b/i,
+  /\bcf-ray\b/i,
+  /please complete the security check/i,
+];
+
 const EXPIRED_URL_PATTERNS = [
   /[?&]error=true/i,
 ];
@@ -34,6 +52,12 @@ const APPLY_PATTERNS = [
   /easy apply/i,
   /start application/i,
   /ich bewerbe mich/i,
+  // Polish (pracuj.pl, justjoin.it, bulldogjob.pl): "Aplikuj" / "Aplikuj teraz" /
+  // "Wyślij CV" / "Przejdź do panelu aplikowania". Without these, a fully-loaded
+  // Polish posting has no recognized apply control and falls to no_apply_control.
+  /\baplikuj\b/i,
+  /panelu aplikowania/i,
+  /wyślij (cv|aplikacj)/i,
 ];
 
 const MIN_CONTENT_CHARS = 300;
@@ -49,6 +73,18 @@ function hasApplyControl(controls = []) {
 export function classifyLiveness({ status = 0, finalUrl = '', bodyText = '', applyControls = [] } = {}) {
   if (status === 404 || status === 410) {
     return { result: 'expired', code: 'http_gone', reason: `HTTP ${status}` };
+  }
+
+  // Bot/anti-scraping walls — never expired. Check before the content-length and
+  // listing-page heuristics, which would otherwise misread the short challenge
+  // body as a dead posting. 403/503 are access-blocked signals, not "gone"
+  // (a genuinely removed posting returns 404/410 or a hard-expired banner).
+  const botChallenge = firstMatch(BOT_CHALLENGE_PATTERNS, bodyText);
+  if (botChallenge) {
+    return { result: 'uncertain', code: 'bot_challenge', reason: `anti-bot challenge: ${botChallenge.source}` };
+  }
+  if (status === 403 || status === 503) {
+    return { result: 'uncertain', code: 'access_blocked', reason: `HTTP ${status} (access blocked, likely anti-bot)` };
   }
 
   const expiredUrl = firstMatch(EXPIRED_URL_PATTERNS, finalUrl);

--- a/scan.mjs
+++ b/scan.mjs
@@ -25,6 +25,9 @@
  *   node scan.mjs --dry-run        # preview without writing files
  *   node scan.mjs --company Cohere # scan a single company
  *   node scan.mjs --verify         # Playwright-check each new URL; drop expired postings
+ *   node scan.mjs --verify --headed-fallback  # retry anti-bot-blocked URLs in a headed browser (needs a display)
+ *   node scan.mjs --verify --throttle          # jittered ~5-10s gap between checks (stay under rate limits)
+ *   node scan.mjs --verify --throttle=8000     # custom base gap in ms (waits base..2*base)
  */
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, readdirSync } from 'fs';
@@ -292,13 +295,18 @@ async function parallelFetch(tasks, limit) {
 
 // ── Main ────────────────────────────────────────────────────────────
 
-async function verifyOffers(offers) {
+async function verifyOffers(offers, { headedFallback = false, throttleBaseMs = 0 } = {}) {
   // Dynamic imports keep the default zero-token path free of Playwright startup
   let chromium;
   let checkUrlLiveness;
+  let checkUrlLivenessWithFallback;
+  let createHeadedPageProvider;
+  let newLivenessPage;
+  let jitteredDelayMs;
+  let sleep;
   try {
     ({ chromium } = await import('playwright'));
-    ({ checkUrlLiveness } = await import('./liveness-browser.mjs'));
+    ({ checkUrlLiveness, checkUrlLivenessWithFallback, createHeadedPageProvider, newLivenessPage, jitteredDelayMs, sleep } = await import('./liveness-browser.mjs'));
   } catch (err) {
     throw new Error(
       `--verify requires Playwright with Chromium (run "npx playwright install chromium"): ${err.message}`,
@@ -328,11 +336,17 @@ async function verifyOffers(offers) {
   const dropped = [];
   const invalid = [];
 
+  const headed = headedFallback ? createHeadedPageProvider(chromium) : null;
+  const getHeadedPage = headed ? () => headed.get() : undefined;
+
   try {
-    const page = await browser.newPage();
+    const page = await newLivenessPage(browser);
     // Sequential — project rule: never Playwright in parallel
-    for (const offer of offers) {
-      const { result, code, reason } = await checkUrlLiveness(page, offer.url);
+    for (let i = 0; i < offers.length; i++) {
+      const offer = offers[i];
+      const { result, code, reason } = headed
+        ? await checkUrlLivenessWithFallback(page, offer.url, { getHeadedPage })
+        : await checkUrlLiveness(page, offer.url);
       if (result === 'expired') {
         expired.push({ ...offer, reason });
         console.log(`  ❌ expired   ${offer.company} | ${offer.title} (${reason})`);
@@ -354,8 +368,12 @@ async function verifyOffers(offers) {
         const icon = result === 'active' ? '✅' : '⚠️';
         console.log(`  ${icon} ${result.padEnd(9)} ${offer.company} | ${offer.title}`);
       }
+
+      const wait = i < offers.length - 1 ? jitteredDelayMs(throttleBaseMs) : 0;
+      if (wait) await sleep(wait);
     }
   } finally {
+    if (headed) await headed.close();
     await browser.close();
   }
 
@@ -378,6 +396,15 @@ async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
   const verify = args.includes('--verify');
+  // Opt-in: on an anti-bot challenge (e.g. pracuj.pl Cloudflare wall), retry the
+  // URL in a headed browser. Off by default — headed Chromium needs a display, so
+  // scheduled/unattended scans should not rely on it.
+  const headedFallback = args.includes('--headed-fallback');
+  // --throttle or --throttle=<ms>: jittered gap between --verify checks to stay
+  // under rate-based WAF limits (pracuj.pl flags the session after a few rapid
+  // hits). Default base 5000ms. Off by default — most ATS feeds don't need it.
+  const throttleArg = args.find((a) => a === '--throttle' || a.startsWith('--throttle='));
+  const throttleBaseMs = throttleArg ? (Number(throttleArg.split('=')[1]) || 5000) : 0;
   const companyFlag = args.indexOf('--company');
   const filterCompany = companyFlag !== -1 ? args[companyFlag + 1]?.toLowerCase() : null;
 
@@ -496,7 +523,7 @@ async function main() {
   let invalidOffers = [];
   if (verify && newOffers.length > 0) {
     console.log(`\nVerifying liveness of ${newOffers.length} new offer(s) with Playwright (sequential)...`);
-    const result = await verifyOffers(newOffers);
+    const result = await verifyOffers(newOffers, { headedFallback, throttleBaseMs });
     verifiedOffers = result.verified;
     expiredOffers = result.expired;
     droppedOffers = result.dropped;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -136,6 +136,128 @@ try {
   } else {
     fail(`Closed mycareersfuture posting misclassified as ${closedMycareersfuture.result}`);
   }
+
+  const cloudflareChallenge = classifyLiveness({
+    status: 403,
+    finalUrl: 'https://www.pracuj.pl/praca/sap-consultant,oferta,1004870954',
+    bodyText: 'www.pracuj.pl\nJust a moment...\nPerforming security verification\nThis website uses a security service to protect against malicious bots.\nRay ID: a06489bab8bc4cd7\nPerformance and Security by Cloudflare',
+    applyControls: [],
+  });
+  if (cloudflareChallenge.result === 'uncertain' && cloudflareChallenge.code === 'bot_challenge') {
+    pass('Cloudflare anti-bot challenge pages are uncertain, not expired');
+  } else {
+    fail(`Cloudflare challenge misclassified as ${cloudflareChallenge.result} (${cloudflareChallenge.code})`);
+  }
+
+  const blocked403 = classifyLiveness({
+    status: 403,
+    finalUrl: 'https://www.pracuj.pl/praca/sap-consultant,oferta,1004870954',
+    bodyText: 'Access denied',
+    applyControls: [],
+  });
+  if (blocked403.result === 'uncertain' && blocked403.code === 'access_blocked') {
+    pass('HTTP 403 is treated as access-blocked (uncertain), not expired');
+  } else {
+    fail(`HTTP 403 misclassified as ${blocked403.result} (${blocked403.code})`);
+  }
+
+  const activePolishPosting = classifyLiveness({
+    status: 200,
+    finalUrl: 'https://www.pracuj.pl/praca/administrator-sap-utilities-warszawa,oferta,1004870954',
+    bodyText: 'Administrator SAP Utilities. Connectis_. Siedziba firmy: Chmielna 71, Warszawa. '.repeat(6),
+    applyControls: ['Aplikuj Aplikuj na ogłoszenie'],
+  });
+  if (activePolishPosting.result === 'active') {
+    pass('Polish "Aplikuj" apply control marks a loaded posting active');
+  } else {
+    fail(`Polish apply control not recognized: ${activePolishPosting.result} (${activePolishPosting.code})`);
+  }
+
+  // Headed-fallback-on-challenge path (liveness-browser.mjs). Fake Playwright
+  // pages script the goto/evaluate calls so we can exercise the wrapper without
+  // launching a browser. checkUrlLiveness reads body text first, apply controls
+  // second — the fake returns them in that order.
+  const { checkUrlLivenessWithFallback, isChallengeResult, jitteredDelayMs } =
+    await import(pathToFileURL(join(ROOT, 'liveness-browser.mjs')).href);
+
+  const disabled = jitteredDelayMs(0) === 0 && jitteredDelayMs(-1) === 0;
+  let inRange = true;
+  for (let i = 0; i < 200; i += 1) {
+    const d = jitteredDelayMs(5000);
+    if (d < 5000 || d >= 10000) { inRange = false; break; }
+  }
+  if (disabled && inRange) {
+    pass('jitteredDelayMs returns 0 when disabled and stays in [base, 2*base)');
+  } else {
+    fail(`jitteredDelayMs out of spec (disabled=${disabled}, inRange=${inRange})`);
+  }
+
+  const fakePage = ({ status, finalUrl, bodyText, applyControls }) => {
+    let evalCall = 0;
+    return {
+      async goto() { return { status: () => status }; },
+      async waitForTimeout() {},
+      url() { return finalUrl; },
+      async evaluate() { evalCall += 1; return evalCall === 1 ? bodyText : applyControls; },
+    };
+  };
+  const URL = 'https://www.pracuj.pl/praca/sap-consultant,oferta,1004870954';
+  const challengePage = () => fakePage({
+    status: 403,
+    finalUrl: URL,
+    bodyText: 'Just a moment... Performing security verification. Ray ID: abc123. Cloudflare.',
+    applyControls: [],
+  });
+  const livePage = () => fakePage({
+    status: 200,
+    finalUrl: URL,
+    bodyText: 'Administrator SAP Utilities. '.repeat(20),
+    applyControls: ['Apply for this job'],
+  });
+
+  if (isChallengeResult({ result: 'uncertain', code: 'bot_challenge' }) &&
+      isChallengeResult({ result: 'uncertain', code: 'access_blocked' }) &&
+      !isChallengeResult({ result: 'expired', code: 'http_gone' }) &&
+      !isChallengeResult({ result: 'active', code: 'apply_control_visible' })) {
+    pass('isChallengeResult flags only bot_challenge/access_blocked uncertains');
+  } else {
+    fail('isChallengeResult misclassified a result');
+  }
+
+  const fellBackToActive = await checkUrlLivenessWithFallback(challengePage(), URL, {
+    getHeadedPage: async () => livePage(),
+  });
+  if (fellBackToActive.result === 'active') {
+    pass('Headed fallback recovers a challenge-blocked page as active');
+  } else {
+    fail(`Headed fallback did not recover page: ${fellBackToActive.result} (${fellBackToActive.code})`);
+  }
+
+  const noProvider = await checkUrlLivenessWithFallback(challengePage(), URL, {});
+  if (noProvider.result === 'uncertain' && noProvider.code === 'bot_challenge') {
+    pass('No fallback provider keeps the original challenge result');
+  } else {
+    fail(`Missing provider changed result to ${noProvider.result} (${noProvider.code})`);
+  }
+
+  const stillBlocked = await checkUrlLivenessWithFallback(challengePage(), URL, {
+    getHeadedPage: async () => challengePage(),
+  });
+  if (stillBlocked.result === 'uncertain' && stillBlocked.code === 'bot_challenge'
+      && /headed retry also blocked/.test(stillBlocked.reason)) {
+    pass('Persistent challenge stays uncertain after headed retry (never upgraded to expired)');
+  } else {
+    fail(`Persistent challenge mishandled: ${stillBlocked.result} (${stillBlocked.code})`);
+  }
+
+  const noHeadedAvailable = await checkUrlLivenessWithFallback(challengePage(), URL, {
+    getHeadedPage: async () => null, // headed launch failed (no display)
+  });
+  if (noHeadedAvailable.result === 'uncertain' && noHeadedAvailable.code === 'bot_challenge') {
+    pass('Headless-only environment degrades to original challenge result');
+  } else {
+    fail(`No-display degrade path wrong: ${noHeadedAvailable.result} (${noHeadedAvailable.code})`);
+  }
 } catch (e) {
   fail(`Liveness classification tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
## Problem

Headless Playwright trips Cloudflare's "Just a moment..." challenge on portals like **pracuj.pl**: the offer URL returns **HTTP 403** with a ~260-char challenge body. `classifyLiveness` read that short body as `insufficient_content` → **`expired`**.

Because `scan --verify` writes `expired` URLs to `scan-history.tsv` (permanently dedup-filtering them on later scans), a *transient* bot wall silently and **irreversibly drops live jobs** from the pipeline. A full 114-URL liveness pass mass-flagged **110 live pracuj.pl postings as expired**.

## Fix (layered, cheapest-first)

- **`classifyLiveness`** — detect anti-bot challenge bodies and `403`/`503` as `uncertain` (`bot_challenge` / `access_blocked`), **never `expired`**. Genuinely removed postings still return `404`/`410` or a hard-expired banner (unchanged). Ambiguity must stay `uncertain` so the URL is preserved and retried.
- **`newLivenessPage`** — open the headless context with a realistic Chrome UA. Playwright's default UA contains `HeadlessChrome`, which Cloudflare flags; a normal UA clears the wall for the common case (same trick `scripts/parsers/pracuj-jobs.mjs` already relies on).
- **`checkUrlLivenessWithFallback` + `createHeadedPageProvider`** — on a *persistent* challenge, retry once in a lazily-launched headed browser; degrades gracefully to the headless result when no display is available (never to `expired`).
- **`APPLY_PATTERNS`** — add Polish (`aplikuj` / `panelu aplikowania` / `wyślij CV`) so a loaded pracuj.pl page resolves to `active`, not `no_apply_control`.
- **`--throttle[=ms]`** (jittered) on `check-liveness` and `scan --verify`, for rate-limited portals. Off by default.

**Wiring:** `check-liveness` uses the headed fallback by default (`--no-fallback` to disable); `scan --verify` keeps it opt-in via `--headed-fallback` (needs a display, so unattended scans shouldn't depend on it).

## Tests

9 new liveness cases in `test-all.mjs` (challenge detection, 403 handling, Polish apply, the fallback wrapper's recover/no-provider/persistent/no-display paths, and the throttle helper). Suite: **159 passed** (was 150), with the one pre-existing `Dashboard build` failure unaffected.

## Known limitation

pracuj.pl's challenge is **per-session** — a fresh context gets ~2 free loads, then is challenged — so bulk per-URL verification still can't clear it at scale (confirmed empirically; request throttling does not help because the block isn't rate-based). Those URLs now stay `uncertain` (preserved, retried) instead of being dropped. Verify at apply-time per `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--throttle` flag to insert customizable delays between liveness checks
  * Added `--headed-fallback` and `--no-fallback` options for enhanced verification flexibility
  * Implemented anti-bot challenge detection with automatic retry capability
  * Added Polish language support for recognizing application controls

* **Tests**
  * Expanded test coverage for challenge detection and fallback mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->