### PR TITLE
dashboard: add sortable Location, Pay, and Last-contact columns to pipeline view

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -107,6 +107,9 @@ func ParseApplications(careerOpsPath string) []model.CareerApplication {
 			app.Notes = fields[8]
 		}
 
+		// Lift location / work mode / pay / last-contact out of the notes free-text
+		deriveNoteFields(&app)
+
 		apps = append(apps, app)
 	}
 

--- a/dashboard/internal/data/derive.go
+++ b/dashboard/internal/data/derive.go
@@ -1,0 +1,104 @@
+package data
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/santifer/career-ops/dashboard/internal/model"
+)
+
+// The tracker's Notes column is free-text, but evaluations write it with stable
+// conventions: work mode ("Remote US", "Charlotte NC (Hybrid)"), a pay range
+// ("$140-210K (POSTED)" / "~$150-220K (est)") and event dates ("Rejected
+// 2026-06-04"). These regexes lift that structure back out so the dashboard can
+// show Location / Pay / Last-contact columns without a tracker schema change.
+var (
+	// $-amounts, optionally a range: "$140-210K", "$174,986-209,983", "~$124.2-198.7K"
+	reMoneySpan = regexp.MustCompile(`~?\$\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*\$?\d[\d,]*(?:\.\d+)?[KkMm]?)?`)
+	// ISO dates embedded in notes ("Rejected 2026-06-04", "viewed 2026-06-04")
+	reISODate = regexp.MustCompile(`\b20\d{2}-\d{2}-\d{2}\b`)
+	// "City ST" / "City, ST" with a strict two-letter US state code so prose like
+	// "Sams AI" or "Kerin Colby DONE" can't false-positive.
+	reCityState = regexp.MustCompile(`\b([A-Z][A-Za-z.'-]+(?: [A-Z][A-Za-z.'-]+){0,2}),? (A[KLRZ]|C[AOT]|D[CE]|FL|GA|HI|I[ADLN]|K[SY]|LA|M[ADEINOST]|N[CDEHJMVY]|O[HKR]|PA|RI|S[CD]|T[NX]|UT|V[AT]|W[AIVY])\b`)
+	// Individual amounts inside an already-matched span: "140", "210K", "209,983"
+	reMoneyPart = regexp.MustCompile(`(\d[\d,]*(?:\.\d+)?)\s*([KkMm]?)`)
+)
+
+// payCeiling converts a matched pay span to its top dollar amount for sorting:
+// "$140-210K" → 210000, "$174,986-209,983" → 209983, "$170K" → 170000.
+func payCeiling(span string) float64 {
+	top := 0.0
+	for _, p := range reMoneyPart.FindAllStringSubmatch(span, -1) {
+		v, err := strconv.ParseFloat(strings.ReplaceAll(p[1], ",", ""), 64)
+		if err != nil {
+			continue
+		}
+		switch strings.ToLower(p[2]) {
+		case "k":
+			v *= 1_000
+		case "m":
+			v *= 1_000_000
+		}
+		if v > top {
+			top = v
+		}
+	}
+	return top
+}
+
+// deriveNoteFields populates Location, WorkMode, PayRange, PaySource and
+// LastContact from the application's Notes (plus Role for work-mode keywords).
+func deriveNoteFields(app *model.CareerApplication) {
+	lower := strings.ToLower(app.Role + " " + app.Notes)
+
+	// Location: first "City, ST" in the notes.
+	if m := reCityState.FindStringSubmatch(app.Notes); m != nil {
+		app.Location = m[1] + ", " + m[2]
+	}
+
+	// Work mode: hybrid beats remote ("Remote/hybrid" means office days exist);
+	// a bare city+state with no keyword implies fully on-site.
+	switch {
+	case strings.Contains(lower, "hybrid"):
+		app.WorkMode = "Hybrid"
+	case strings.Contains(lower, "remote"):
+		app.WorkMode = "Remote"
+	case strings.Contains(lower, "onsite") || strings.Contains(lower, "on-site") || strings.Contains(lower, "in-office"):
+		app.WorkMode = "Full"
+	case app.Location != "":
+		app.WorkMode = "Full"
+	}
+
+	// Pay: prefer the first $-range; fall back to the first lone $-amount
+	// (e.g. "$170K min floor") only when no range exists.
+	matches := reMoneySpan.FindAllString(app.Notes, -1)
+	for _, mm := range matches {
+		if strings.ContainsAny(mm, "-–") {
+			app.PayRange = mm
+			break
+		}
+	}
+	if app.PayRange == "" && len(matches) > 0 {
+		app.PayRange = matches[0]
+	}
+	app.PayMax = payCeiling(app.PayRange)
+	if app.PayRange != "" {
+		switch {
+		case strings.Contains(lower, "(posted"):
+			app.PaySource = "POSTED"
+		case strings.Contains(lower, "(est") || strings.Contains(lower, "est)") || strings.Contains(lower, "market"):
+			app.PaySource = "est"
+		}
+	}
+
+	// Last contact: the most recent ISO date mentioned anywhere in the notes
+	// (rejections, recruiter views, phone screens), else the applied date.
+	last := app.Date
+	for _, d := range reISODate.FindAllString(app.Notes, -1) {
+		if d > last {
+			last = d
+		}
+	}
+	app.LastContact = last
+}

--- a/dashboard/internal/data/derive.go
+++ b/dashboard/internal/data/derive.go
@@ -23,6 +23,9 @@ var (
 	reCityState = regexp.MustCompile(`\b([A-Z][A-Za-z.'-]+(?: [A-Z][A-Za-z.'-]+){0,2}),? (A[KLRZ]|C[AOT]|D[CE]|FL|GA|HI|I[ADLN]|K[SY]|LA|M[ADEINOST]|N[CDEHJMVY]|O[HKR]|PA|RI|S[CD]|T[NX]|UT|V[AT]|W[AIVY])\b`)
 	// Individual amounts inside an already-matched span: "140", "210K", "209,983"
 	reMoneyPart = regexp.MustCompile(`(\d[\d,]*(?:\.\d+)?)\s*([KkMm]?)`)
+	// Estimate markers: "(est)", "(est;", "market est)" or "market" as its own
+	// word — but not "(EST/CST" timezones, "interest)" or "marketing".
+	reEstHint = regexp.MustCompile(`\(est[),;. ]|\best\)|\bmarket\b`)
 )
 
 // payCeiling converts a matched pay span to its top dollar amount for sorting:
@@ -52,8 +55,11 @@ func payCeiling(span string) float64 {
 func deriveNoteFields(app *model.CareerApplication) {
 	lower := strings.ToLower(app.Role + " " + app.Notes)
 
-	// Location: first "City, ST" in the notes.
+	// Location: first "City, ST" in the notes, falling back to the role title
+	// (some tracker rows carry the city there, e.g. "... — Charlotte, NC").
 	if m := reCityState.FindStringSubmatch(app.Notes); m != nil {
+		app.Location = m[1] + ", " + m[2]
+	} else if m := reCityState.FindStringSubmatch(app.Role); m != nil {
 		app.Location = m[1] + ", " + m[2]
 	}
 
@@ -87,7 +93,7 @@ func deriveNoteFields(app *model.CareerApplication) {
 		switch {
 		case strings.Contains(lower, "(posted"):
 			app.PaySource = "POSTED"
-		case strings.Contains(lower, "(est") || strings.Contains(lower, "est)") || strings.Contains(lower, "market"):
+		case reEstHint.MatchString(lower):
 			app.PaySource = "est"
 		}
 	}

--- a/dashboard/internal/data/derive_test.go
+++ b/dashboard/internal/data/derive_test.go
@@ -1,0 +1,124 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/santifer/career-ops/dashboard/internal/model"
+)
+
+func TestDeriveNoteFields(t *testing.T) {
+	cases := []struct {
+		name     string
+		app      model.CareerApplication
+		location string
+		workMode string
+		payRange string
+		paySrc   string
+		last     string
+	}{
+		{
+			name: "remote with posted comma range and rejection date",
+			app: model.CareerApplication{
+				Date:  "2026-06-04",
+				Notes: "Remote US (EST/CST). Base $174,986-209,983 + RSUs (POSTED). Rejected 2026-06-05 (not moving forward). Via Greenhouse",
+			},
+			workMode: "Remote",
+			payRange: "$174,986-209,983",
+			paySrc:   "POSTED",
+			last:     "2026-06-05",
+		},
+		{
+			name: "hybrid city state with estimate",
+			app: model.CareerApplication{
+				Date:  "2026-06-03",
+				Notes: "Charlotte NC (Hybrid), via LinkedIn. Comp ~$130-170K (est). Application VIEWED by recruiter 2026-06-04",
+			},
+			location: "Charlotte, NC",
+			workMode: "Hybrid",
+			payRange: "~$130-170K",
+			paySrc:   "est",
+			last:     "2026-06-04",
+		},
+		{
+			name: "bare location implies full onsite, decimal K range",
+			app: model.CareerApplication{
+				Date:  "2026-06-01",
+				Notes: "Austin TX (location mismatch). Salary $124.2-198.7K (POSTED)",
+			},
+			location: "Austin, TX",
+			workMode: "Full",
+			payRange: "$124.2-198.7K",
+			paySrc:   "POSTED",
+			last:     "2026-06-01",
+		},
+		{
+			name: "lone amount fallback when no range, date falls back to applied",
+			app: model.CareerApplication{
+				Date:  "2026-06-02",
+				Notes: "Via LinkedIn (recruiting agency). Sam stated $170K min floor",
+			},
+			workMode: "",
+			payRange: "$170K",
+			last:     "2026-06-02",
+		},
+		{
+			name: "range preferred over earlier lone amount",
+			app: model.CareerApplication{
+				Date:  "2026-05-31",
+				Notes: "Comp $100-175K base + 10% bonus + $300 health credit (recruiter-confirmed). Phone screen DONE 2026-06-03",
+			},
+			payRange: "$100-175K",
+			last:     "2026-06-03",
+		},
+		{
+			name: "no false-positive city from prose",
+			app: model.CareerApplication{
+				Date:  "2026-06-01",
+				Notes: "Strong fit for Sams AI-augmented edge. Rejected by recruiter Nadia Kong",
+			},
+			location: "",
+			workMode: "",
+			last:     "2026-06-01",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deriveNoteFields(&tc.app)
+			if want := payCeiling(tc.payRange); tc.app.PayMax != want {
+				t.Errorf("PayMax = %v, want %v", tc.app.PayMax, want)
+			}
+			if tc.app.Location != tc.location {
+				t.Errorf("Location = %q, want %q", tc.app.Location, tc.location)
+			}
+			if tc.app.WorkMode != tc.workMode {
+				t.Errorf("WorkMode = %q, want %q", tc.app.WorkMode, tc.workMode)
+			}
+			if tc.app.PayRange != tc.payRange {
+				t.Errorf("PayRange = %q, want %q", tc.app.PayRange, tc.payRange)
+			}
+			if tc.app.PaySource != tc.paySrc {
+				t.Errorf("PaySource = %q, want %q", tc.app.PaySource, tc.paySrc)
+			}
+			if tc.app.LastContact != tc.last {
+				t.Errorf("LastContact = %q, want %q", tc.app.LastContact, tc.last)
+			}
+		})
+	}
+}
+
+func TestPayCeiling(t *testing.T) {
+	cases := map[string]float64{
+		"$140-210K":        210_000,
+		"$174,986-209,983": 209_983,
+		"~$124.2-198.7K":   198_700,
+		"$170K":            170_000,
+		"$95-159K":         159_000,
+		"":                 0,
+	}
+	for span, want := range cases {
+		if got := payCeiling(span); got != want {
+			t.Errorf("payCeiling(%q) = %v, want %v", span, got, want)
+		}
+	}
+}

--- a/dashboard/internal/data/derive_test.go
+++ b/dashboard/internal/data/derive_test.go
@@ -71,6 +71,30 @@ func TestDeriveNoteFields(t *testing.T) {
 			last:     "2026-06-03",
 		},
 		{
+			name: "city falls back to role title, timezone parens are not an estimate",
+			app: model.CareerApplication{
+				Date:  "2026-05-31",
+				Role:  "Sr Software Engineer, Enterprise Systems — Charlotte, NC",
+				Notes: "Referral via friend. Remote US (EST/CST). Comp $100-175K base (recruiter-confirmed)",
+			},
+			location: "Charlotte, NC",
+			workMode: "Remote",
+			payRange: "$100-175K",
+			paySrc:   "",
+			last:     "2026-05-31",
+		},
+		{
+			name: "marketing role and interest prose are not estimate markers",
+			app: model.CareerApplication{
+				Date:  "2026-06-01",
+				Role:  "Product Marketing Manager",
+				Notes: "Strong fit (AI-augmented interest). Salary $140-180K. Via Lever",
+			},
+			payRange: "$140-180K",
+			paySrc:   "",
+			last:     "2026-06-01",
+		},
+		{
 			name: "no false-positive city from prose",
 			app: model.CareerApplication{
 				Date:  "2026-06-01",

--- a/dashboard/internal/model/career.go
+++ b/dashboard/internal/model/career.go
@@ -14,6 +14,13 @@ type CareerApplication struct {
 	ReportNumber string
 	Notes        string
 	JobURL       string // URL of the original job posting
+	// Derived from Notes free-text (see data.deriveNoteFields)
+	Location    string  // "City, ST" when a US city+state appears in the notes
+	WorkMode    string  // "Remote" | "Hybrid" | "Full" (onsite), "" when unknown
+	PayRange    string  // first $-range found in the notes, e.g. "$140-210K"
+	PayMax      float64 // top of PayRange in dollars (sort key), 0 when unknown
+	PaySource   string  // "POSTED" when the JD listed it, "est" for estimates, "" unknown
+	LastContact string  // max YYYY-MM-DD found in notes (falls back to applied date)
 	// Enrichment (lazy loaded from report)
 	Archetype    string
 	TlDr         string
@@ -48,10 +55,10 @@ type ProgressMetrics struct {
 	OfferRate     float64 // Offer / Applied
 
 	// Averages
-	AvgScore     float64
-	TopScore     float64
-	TotalOffers  int
-	ActiveApps int // not skip/rejected/discarded
+	AvgScore    float64
+	TopScore    float64
+	TotalOffers int
+	ActiveApps  int // not skip/rejected/discarded
 }
 
 // FunnelStage represents one stage of the application funnel.

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -57,10 +58,13 @@ type reportSummary struct {
 
 // Sort modes
 const (
-	sortScore   = "score"
-	sortDate    = "date"
-	sortCompany = "company"
-	sortStatus  = "status"
+	sortScore    = "score"
+	sortDate     = "date"
+	sortCompany  = "company"
+	sortStatus   = "status"
+	sortLocation = "location"
+	sortPay      = "pay"
+	sortLast     = "last"
 )
 
 // Filter modes
@@ -91,7 +95,7 @@ var pipelineTabs = []pipelineTab{
 	{filterDiscarded, "DISCARDED"},
 }
 
-var sortCycle = []string{sortScore, sortDate, sortCompany, sortStatus}
+var sortCycle = []string{sortScore, sortDate, sortCompany, sortStatus, sortLocation, sortPay, sortLast}
 
 var statusOptions = []string{"Evaluated", "Applied", "Responded", "Interview", "Offer", "Rejected", "Discarded", "SKIP"}
 
@@ -555,24 +559,10 @@ func (m *PipelineModel) applyFilterAndSort() {
 	}
 
 	// Sort
-	switch m.sortMode {
-	case sortScore:
-		sort.SliceStable(filtered, func(i, j int) bool {
-			return filtered[i].Score > filtered[j].Score
-		})
-	case sortDate:
-		sort.SliceStable(filtered, func(i, j int) bool {
-			return filtered[i].Date > filtered[j].Date
-		})
-	case sortCompany:
-		sort.SliceStable(filtered, func(i, j int) bool {
-			return strings.ToLower(filtered[i].Company) < strings.ToLower(filtered[j].Company)
-		})
-	case sortStatus:
-		sort.SliceStable(filtered, func(i, j int) bool {
-			return data.StatusPriority(filtered[i].Status) < data.StatusPriority(filtered[j].Status)
-		})
-	}
+	less := m.sortLess()
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return less(filtered[i], filtered[j])
+	})
 
 	// In grouped mode, always sort by status priority first, then by selected sort within groups
 	if m.viewMode == "grouped" {
@@ -583,27 +573,66 @@ func (m *PipelineModel) applyFilterAndSort() {
 				return pi < pj
 			}
 			// Within same group, use selected sort
-			switch m.sortMode {
-			case sortScore:
-				return filtered[i].Score > filtered[j].Score
-			case sortDate:
-				return filtered[i].Date > filtered[j].Date
-			case sortCompany:
-				return strings.ToLower(filtered[i].Company) < strings.ToLower(filtered[j].Company)
-			default:
-				return filtered[i].Score > filtered[j].Score
-			}
+			return less(filtered[i], filtered[j])
 		})
 	}
 
 	m.filtered = filtered
 }
 
+// sortLess returns the comparator for the active sort mode. Shared by the flat
+// sort and the within-group tiebreaker in grouped view.
+func (m PipelineModel) sortLess() func(a, b model.CareerApplication) bool {
+	switch m.sortMode {
+	case sortDate:
+		return func(a, b model.CareerApplication) bool { return a.Date > b.Date }
+	case sortCompany:
+		return func(a, b model.CareerApplication) bool {
+			return strings.ToLower(a.Company) < strings.ToLower(b.Company)
+		}
+	case sortStatus:
+		return func(a, b model.CareerApplication) bool {
+			return data.StatusPriority(a.Status) < data.StatusPriority(b.Status)
+		}
+	case sortLocation:
+		// Remote-first, then hybrid, then onsite; alphabetical city as tiebreaker.
+		return func(a, b model.CareerApplication) bool {
+			ra, rb := workModeRank(a.WorkMode), workModeRank(b.WorkMode)
+			if ra != rb {
+				return ra < rb
+			}
+			return a.Location < b.Location
+		}
+	case sortPay:
+		// Highest band ceiling first; unknown pay (0) sinks to the bottom.
+		return func(a, b model.CareerApplication) bool { return a.PayMax > b.PayMax }
+	case sortLast:
+		// Most recent contact first; empty dates sink to the bottom.
+		return func(a, b model.CareerApplication) bool { return a.LastContact > b.LastContact }
+	default: // sortScore
+		return func(a, b model.CareerApplication) bool { return a.Score > b.Score }
+	}
+}
+
+// workModeRank orders work modes remote-first for the location sort.
+func workModeRank(mode string) int {
+	switch mode {
+	case "Remote":
+		return 0
+	case "Hybrid":
+		return 1
+	case "Full":
+		return 2
+	default:
+		return 3
+	}
+}
+
 // chromeRowsFixed returns the number of fixed chrome rows above/below the body
-// (header + tabs(2) + metrics + sortbar + help + 1 search bar when active).
-// Shared by View() and adjustScroll() so the search-row addition stays in sync.
+// (header + tabs(2) + metrics + sortbar + column header + help + 1 search bar
+// when active). Shared by View() and adjustScroll() so additions stay in sync.
 func (m PipelineModel) chromeRowsFixed() int {
-	rows := 7 // header + tabs(2) + metrics + sortbar + help + preview baseline
+	rows := 8 // header + tabs(2) + metrics + sortbar + column header + help + preview baseline
 	if m.searchInput || m.searchQuery != "" {
 		rows++
 	}
@@ -613,7 +642,7 @@ func (m PipelineModel) chromeRowsFixed() int {
 // previewBudgetApprox is the approximate row count reserved for the preview block
 // when computing scroll positioning. View() measures the actual rendered preview
 // height; adjustScroll uses this constant to avoid re-rendering on every keystroke.
-const previewBudgetApprox = 5
+const previewBudgetApprox = 6
 
 // adjustScroll updates scrollOffset so the cursor stays visible.
 func (m *PipelineModel) adjustScroll() {
@@ -695,7 +724,7 @@ func (m PipelineModel) View() string {
 	if searchBar != "" {
 		sections = append(sections, searchBar)
 	}
-	sections = append(sections, body, preview, help)
+	sections = append(sections, m.renderColumnHeader(), body, preview, help)
 	return lipgloss.JoinVertical(lipgloss.Left, sections...)
 }
 
@@ -879,71 +908,166 @@ func (m PipelineModel) renderBody() string {
 	return strings.Join(lines, "\n")
 }
 
+// colWidths holds per-column rune budgets for the table. The location and
+// last-contact columns are adaptive: they appear only when the terminal is wide
+// enough, so narrow windows keep the original compact layout.
+type colWidths struct {
+	num, score, date, company, status, loc, pay, last, role int
+}
+
+func (m PipelineModel) columnWidths() colWidths {
+	c := colWidths{num: 5, score: 5, date: 10, company: 16, status: 12, pay: 16}
+	if m.width >= 110 {
+		c.loc = 20
+	}
+	if m.width >= 132 {
+		c.last = 10
+	}
+	fixed := c.num + c.score + c.date + c.company + c.status + c.pay + c.loc + c.last
+	c.role = m.width - fixed - 14 // separators + outer padding
+	if c.role < 15 {
+		c.role = 15
+	}
+	return c
+}
+
+// renderLocCell renders the work-mode + city column, e.g. "Remote",
+// "Hybrid · Charlotte, NC", "Full · Austin, TX".
+func (m PipelineModel) renderLocCell(app model.CareerApplication, width int) string {
+	color := m.theme.Subtext
+	switch app.WorkMode {
+	case "Remote":
+		color = m.theme.Green
+	case "Hybrid":
+		color = m.theme.Yellow
+	case "Full":
+		color = m.theme.Red
+	}
+	text := app.WorkMode
+	if app.Location != "" {
+		if text != "" {
+			text += " · " + app.Location
+		} else {
+			text = app.Location
+		}
+	}
+	if text == "" {
+		text = "—"
+	}
+	return lipgloss.NewStyle().Foreground(color).Width(width).Render(truncateRunes(text, width))
+}
+
+// renderPayCell prefers the pay range parsed from notes and falls back to the
+// report-cache comp estimate (the pre-column behavior). POSTED bands render
+// green; estimates stay yellow.
+func (m PipelineModel) renderPayCell(app model.CareerApplication, width int) string {
+	text := app.PayRange
+	color := m.theme.Yellow
+	if app.PaySource == "POSTED" {
+		color = m.theme.Green
+	}
+	if text == "" {
+		if summary, ok := m.reportCache[app.ReportPath]; ok && summary.comp != "" {
+			text = summary.comp
+		}
+	}
+	if text == "" {
+		return lipgloss.NewStyle().Width(width).Render("")
+	}
+	return lipgloss.NewStyle().Foreground(color).Width(width).Render(truncateRunes(text, width-1))
+}
+
+// renderColumnHeader labels the table columns; widths mirror renderAppLine.
+func (m PipelineModel) renderColumnHeader() string {
+	cw := m.columnWidths()
+	h := lipgloss.NewStyle().Foreground(m.theme.Subtext).Bold(true)
+	cell := func(label string, width int) string {
+		return h.Width(width).Render(truncateRunes(label, width))
+	}
+
+	segments := []string{
+		cell("#", cw.num),
+		h.Render("FIT"), // score cell is unpadded, always 3 runes wide
+		cell("APPLIED", cw.date),
+		cell("COMPANY", cw.company),
+		cell("ROLE", cw.role),
+		cell("STATUS", cw.status),
+	}
+	if cw.loc > 0 {
+		segments = append(segments, cell("LOCATION", cw.loc))
+	}
+	segments = append(segments, cell("PAY", cw.pay))
+	if cw.last > 0 {
+		segments = append(segments, cell("LAST", cw.last))
+	}
+
+	padStyle := lipgloss.NewStyle().Padding(0, 2)
+	return padStyle.Render(" " + strings.Join(segments, " "))
+}
+
 func (m PipelineModel) renderAppLine(app model.CareerApplication, selected bool) string {
 	padStyle := lipgloss.NewStyle().Padding(0, 2)
-
-	// Column widths
-	numW := 5   // "#123 "
-	scoreW := 5 // "4.5  "
-	dateW := 10
-	companyW := 16
-	statusW := 12
-	compW := 14
-	// Role gets remaining space
-	roleW := m.width - numW - scoreW - dateW - companyW - statusW - compW - 13
-	if roleW < 15 {
-		roleW = 15
-	}
+	cw := m.columnWidths()
 
 	// Tracker number (fixed width)
 	numText := "#—"
 	if app.Number > 0 {
 		numText = fmt.Sprintf("#%d", app.Number)
 	}
-	numStyle := lipgloss.NewStyle().Foreground(m.theme.Blue).Bold(true).Width(numW)
+	numStyle := lipgloss.NewStyle().Foreground(m.theme.Blue).Bold(true).Width(cw.num)
 
 	// Score with color
 	scoreStyle := m.scoreStyle(app.Score)
 	score := scoreStyle.Render(fmt.Sprintf("%.1f", app.Score))
 
 	// Company (truncate)
-	company := truncateRunes(app.Company, companyW)
-	companyStyle := lipgloss.NewStyle().Foreground(m.theme.Text).Width(companyW)
+	company := truncateRunes(app.Company, cw.company)
+	companyStyle := lipgloss.NewStyle().Foreground(m.theme.Text).Width(cw.company)
 
 	// Date (fixed width)
 	dateText := app.Date
 	if dateText == "" {
 		dateText = "—"
 	}
-	dateStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext).Width(dateW)
+	dateStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext).Width(cw.date)
 
 	// Role (truncate)
-	role := truncateRunes(app.Role, roleW)
-	roleStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext).Width(roleW)
+	role := truncateRunes(app.Role, cw.role)
+	roleStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext).Width(cw.role)
 
 	// Status with color -- fixed column
 	norm := data.NormalizeStatus(app.Status)
 	statusColor := m.statusColorMap()[norm]
-	statusStyle := lipgloss.NewStyle().Foreground(statusColor).Width(statusW)
+	statusStyle := lipgloss.NewStyle().Foreground(statusColor).Width(cw.status)
 	statusText := statusStyle.Render(statusLabel(norm))
 
-	// Comp from report cache -- fixed column
-	compText := ""
-	if summary, ok := m.reportCache[app.ReportPath]; ok && summary.comp != "" {
-		comp := truncateRunes(summary.comp, compW-1)
-		compStyle := lipgloss.NewStyle().Foreground(m.theme.Yellow)
-		compText = compStyle.Render(comp)
-	}
-
-	line := fmt.Sprintf(" %s %s %s %s %s %s %s",
-		numStyle.Render(truncateRunes(numText, numW)),
+	segments := []string{
+		numStyle.Render(truncateRunes(numText, cw.num)),
 		score,
-		dateStyle.Render(truncateRunes(dateText, dateW)),
+		dateStyle.Render(truncateRunes(dateText, cw.date)),
 		companyStyle.Render(company),
 		roleStyle.Render(role),
 		statusText,
-		compText,
-	)
+	}
+
+	if cw.loc > 0 {
+		segments = append(segments, m.renderLocCell(app, cw.loc))
+	}
+	segments = append(segments, m.renderPayCell(app, cw.pay))
+	if cw.last > 0 {
+		lastText := "—"
+		if app.LastContact != "" {
+			lastText = formatTimeAgo(app.LastContact)
+		}
+		lastStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext).Width(cw.last)
+		if app.LastContact != "" && app.LastContact != app.Date {
+			// Activity after applying (rejection, recruiter view, screen) — surface it.
+			lastStyle = lastStyle.Foreground(m.theme.Text)
+		}
+		segments = append(segments, lastStyle.Render(truncateRunes(lastText, cw.last)))
+	}
+
+	line := " " + strings.Join(segments, " ")
 
 	if selected {
 		selStyle := lipgloss.NewStyle().
@@ -969,6 +1093,35 @@ func (m PipelineModel) renderPreview() string {
 	labelStyle := lipgloss.NewStyle().Foreground(m.theme.Sky).Bold(true)
 	valueStyle := lipgloss.NewStyle().Foreground(m.theme.Text)
 	dimStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+
+	// Quick facts derived from notes — available even when there is no report,
+	// and the only place narrow terminals see location/pay/last-contact.
+	var facts []string
+	if app.WorkMode != "" || app.Location != "" {
+		loc := app.WorkMode
+		if app.Location != "" {
+			if loc != "" {
+				loc += " · " + app.Location
+			} else {
+				loc = app.Location
+			}
+		}
+		facts = append(facts, labelStyle.Render("Loc: ")+valueStyle.Render(loc))
+	}
+	if app.PayRange != "" {
+		pay := app.PayRange
+		if app.PaySource != "" {
+			pay += " (" + app.PaySource + ")"
+		}
+		facts = append(facts, labelStyle.Render("Pay: ")+valueStyle.Render(pay))
+	}
+	if app.LastContact != "" {
+		facts = append(facts, labelStyle.Render("Last contact: ")+
+			valueStyle.Render(fmt.Sprintf("%s (%s)", app.LastContact, formatTimeAgo(app.LastContact))))
+	}
+	if len(facts) > 0 {
+		lines = append(lines, padStyle.Render(strings.Join(facts, "   ")))
+	}
 
 	// Check report cache
 	if summary, ok := m.reportCache[app.ReportPath]; ok {
@@ -1112,6 +1265,25 @@ func (m PipelineModel) countByNormStatus(status string) int {
 		}
 	}
 	return count
+}
+
+// formatTimeAgo renders an ISO date as a relative duration: hours while the
+// contact is less than a day old ("5h ago"), days otherwise ("3d ago").
+// Tracker dates are day-granular, so hours count from local midnight of that day.
+func formatTimeAgo(dateStr string) string {
+	t, err := time.ParseInLocation("2006-01-02", dateStr, time.Local)
+	if err != nil {
+		return dateStr // not a date — show it untouched rather than lie
+	}
+	d := time.Since(t)
+	if d < 0 {
+		d = 0
+	}
+	hours := int(d.Hours())
+	if hours < 24 {
+		return fmt.Sprintf("%dh ago", hours)
+	}
+	return fmt.Sprintf("%dd ago", hours/24)
 }
 
 // truncateRunes truncates a string to at most maxRunes runes, appending "..." if truncated.

--- a/dashboard/internal/ui/screens/sort_test.go
+++ b/dashboard/internal/ui/screens/sort_test.go
@@ -1,0 +1,58 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/santifer/career-ops/dashboard/internal/model"
+	"github.com/santifer/career-ops/dashboard/internal/theme"
+)
+
+func TestSortCycleIncludesNewColumns(t *testing.T) {
+	want := map[string]bool{sortLocation: false, sortPay: false, sortLast: false}
+	for _, s := range sortCycle {
+		if _, ok := want[s]; ok {
+			want[s] = true
+		}
+	}
+	for mode, found := range want {
+		if !found {
+			t.Errorf("sort cycle is missing %q", mode)
+		}
+	}
+}
+
+func TestSortByPayLocationAndLastContact(t *testing.T) {
+	apps := []model.CareerApplication{
+		{Company: "LowPay", Status: "Applied", PayMax: 150_000, WorkMode: "Full", Location: "Austin, TX", LastContact: "2026-06-01"},
+		{Company: "NoPay", Status: "Applied", PayMax: 0, WorkMode: "", LastContact: ""},
+		{Company: "HighPay", Status: "Applied", PayMax: 250_000, WorkMode: "Hybrid", Location: "Charlotte, NC", LastContact: "2026-06-05"},
+		{Company: "MidPay", Status: "Applied", PayMax: 200_000, WorkMode: "Remote", LastContact: "2026-06-03"},
+	}
+
+	pm := NewPipelineModel(theme.NewTheme("catppuccin-mocha"), apps, model.PipelineMetrics{Total: len(apps)}, "..", 120, 40)
+	pm.viewMode = "flat"
+
+	pm.sortMode = sortPay
+	pm.applyFilterAndSort()
+	if pm.filtered[0].Company != "HighPay" || pm.filtered[len(pm.filtered)-1].Company != "NoPay" {
+		t.Fatalf("pay sort: expected HighPay first and NoPay last, got %s..%s",
+			pm.filtered[0].Company, pm.filtered[len(pm.filtered)-1].Company)
+	}
+
+	pm.sortMode = sortLocation
+	pm.applyFilterAndSort()
+	// Remote-first ordering: Remote, Hybrid, Full, unknown.
+	wantOrder := []string{"MidPay", "HighPay", "LowPay", "NoPay"}
+	for i, w := range wantOrder {
+		if pm.filtered[i].Company != w {
+			t.Fatalf("location sort: position %d = %s, want %s", i, pm.filtered[i].Company, w)
+		}
+	}
+
+	pm.sortMode = sortLast
+	pm.applyFilterAndSort()
+	if pm.filtered[0].Company != "HighPay" || pm.filtered[len(pm.filtered)-1].Company != "NoPay" {
+		t.Fatalf("last-contact sort: expected HighPay first and NoPay last, got %s..%s",
+			pm.filtered[0].Company, pm.filtered[len(pm.filtered)-1].Company)
+	}
+}

--- a/dashboard/internal/ui/screens/timeago_test.go
+++ b/dashboard/internal/ui/screens/timeago_test.go
@@ -1,0 +1,32 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatTimeAgo(t *testing.T) {
+	today := time.Now().Format("2006-01-02")
+	threeDaysAgo := time.Now().AddDate(0, 0, -3).Format("2006-01-02")
+
+	if got := formatTimeAgo(today); !strings.HasSuffix(got, "h ago") {
+		t.Errorf("today should render in hours, got %q", got)
+	}
+	got := formatTimeAgo(threeDaysAgo)
+	// Midnight-based day math: 3 calendar days back is 3d (or 2d right after midnight).
+	if got != "3d ago" && got != "2d ago" {
+		t.Errorf("three days ago should render in days, got %q", got)
+	}
+
+	// Future dates clamp to zero instead of going negative.
+	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	if got := formatTimeAgo(tomorrow); got != "0h ago" {
+		t.Errorf("future date should clamp to 0h ago, got %q", got)
+	}
+
+	// Non-dates pass through untouched.
+	if got := formatTimeAgo("—"); got != "—" {
+		t.Errorf("non-date should pass through, got %q", got)
+	}
+}


### PR DESCRIPTION
## Why

When triaging a 50+ row tracker, the three questions that decide "what do I act on next?" are not answerable from the current pipeline columns:

1. **Can I actually work there?** Remote vs hybrid vs onsite (and which city) is the first hard filter on any role. Today it hides inside the notes free-text or the report file.
2. **Does it pay enough?** Comp only renders for rows that have a full report; most catchup/backfilled rows have the band sitting unread in the notes ("$140-210K (POSTED)").
3. **Is it going stale?** Knowing a company last signaled "3d ago" vs "12d ago" is what tells you which Applied rows need a follow-up nudge and which Interview threads are hot. That date currently lives buried in note suffixes like "Rejected 2026-06-04" or "viewed by recruiter 2026-06-04".

Answering any of these meant opening rows one by one. With these columns plus sort modes, the at-a-glance workflows become one keystroke each:

- sort by **pay** -> highest bands first, unknown comp sinks to the bottom (where it can't bias a decision)
- sort by **location** -> remote-first, hybrid next, onsite last, alphabetical city within each
- sort by **last** -> most recent company activity first; a quick reverse scan shows what's gone quiet
- posted bands render green vs yellow estimates, so you can tell verified comp from guesses without reading a report

The evaluations already write the notes with stable conventions, so all of this is derivable - no tracker schema change, no migration, fully backward compatible with existing `applications.md` files.

## What

- **`data/derive.go` (new)** - regex layer lifting structure out of the Notes free-text:
  - `Location` ("City, ST", with a strict two-letter state code so prose can't false-positive; falls back to the role title)
  - `WorkMode` (Remote / Hybrid / Full; hybrid beats remote, bare city implies onsite)
  - `PayRange` + `PaySource` (POSTED vs est, word-boundary markers so "(EST/CST" timezones and "interest)" don't mislabel) + `PayMax` (numeric ceiling as the sort key: "$95-159K" -> 159000, "$174,986-209,983" -> 209983)
  - `LastContact` (max ISO date in the notes, falls back to the applied date)
- **`screens/pipeline.go`**
  - LOCATION / PAY / LAST columns with a header row; LAST renders relative ("5h ago" under a day, "3d ago" otherwise)
  - adaptive widths: LOCATION appears at >=110 cols, LAST at >=132, so narrow terminals keep the original compact layout; the preview pane always shows the derived facts
  - `s` sort cycle extended: `score -> date -> company -> status -> location -> pay -> last`, via a shared `sortLess()` comparator used by both the flat sort and the grouped-view tiebreaker (removes the previously duplicated comparator logic)
- **Tests** - derivation table tests using real tracker note patterns, pay-ceiling parsing, relative-time formatting, sort ordering. Validated against a live 67-row tracker: 45/67 pay parses with zero false positives, 67/67 last-contact, zero city false-positives.

## Screenshots / verification

- `go test ./...`, `go vet ./...`, `gofmt -l` clean (module: `dashboard/`)
- Exercised against a real `applications.md` with 67 rows across all statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added sorting by location, pay range, and last-contact date in the pipeline view.
* Pipeline table now displays location, pay range, and last-contact columns with adaptive layout based on terminal width.
* Application preview panel shows extracted details—location, pay, and last-contact date—upfront before full notes.
* Last-contact dates displayed as relative time format (e.g., "3 days ago").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->