### PR TITLE
fix: add .playwright-mcp/ to .gitignore (closes #799)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ bun.lock
 .claude/memory/
 career-dashboard
 package-lock.json
+
+# Playwright MCP server run artifacts (ephemeral, machine-local — never commit)
+.playwright-mcp/


### PR DESCRIPTION
Fixes #799

## What does this PR do?

Adds `.playwright-mcp/` to `.gitignore` so the ephemeral run artifacts
written by the Playwright MCP server (snapshots, screenshots, traces)
are not tracked by git.

## Why?

When any mode that uses the Playwright MCP for browser automation runs
(e.g. offer verification via `browser_navigate` + `browser_snapshot`),
the server writes session artifacts to a local `.playwright-mcp/`
directory. These files are ephemeral and machine-local — they carry no
project state and should never be committed, just like `output/` and
`batch/` artifacts already excluded in the same file.

Without this entry the directory shows up as untracked noise in
`git status` and can be committed accidentally.

## Changes

- `.gitignore` — added `.playwright-mcp/` under the *Claude Code local*
  section (same grouping as `.claude/settings.local.json` and
  `.claude/memory/`, which are conceptually the same kind of tool-local
  state).

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass (`.gitignore` change only — no logic affected)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude additional development tool artifacts from the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->