### PR TITLE
fix: add user_invocable key to SKILL.md for Claude Code slash command…

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: career-ops
 description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
-arguments: mode # Claude Code specific
+user_invocable: true
 user-invocable: true
 argument-hint: "[scan | deep | pdf | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | update]"
-license: MIT
 ---
 
 # career-ops -- Router


### PR DESCRIPTION
## What does this PR do?

Adds `user_invocable: true` (underscore) to the `.agents/skills/career-ops/SKILL.md`
frontmatter so Claude Code's skill loader registers `/career-ops` as a
slash command. Both `user_invocable` (Claude Code) and `user-invocable`
(OpenCode) are now present for cross-platform compatibility. The
non-standard `arguments: mode` and `license: MIT` fields are removed —
they are not part of the skill schema and were causing noise.

## Related issue

Closes #763

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass (SKILL.md frontmatter-only change — no logic affected)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled direct user access to career operations functionality with streamlined configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->