### PR TITLE
fix(merge-tracker): don't match on worker-assigned entry num (paralle…

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -29,7 +29,11 @@ const APPS_FILE = process.env.CAREER_OPS_TRACKER
     ? join(CAREER_OPS, 'data/applications.md')
     : join(CAREER_OPS, 'applications.md');
 const TRACKER_DIR = dirname(APPS_FILE);
-const ADDITIONS_DIR = join(CAREER_OPS, 'batch/tracker-additions');
+// CAREER_OPS_ADDITIONS_DIR overrides the additions dir (used by tests for
+// isolated end-to-end runs against a fixture tracker).
+const ADDITIONS_DIR = process.env.CAREER_OPS_ADDITIONS_DIR
+  ? process.env.CAREER_OPS_ADDITIONS_DIR
+  : join(CAREER_OPS, 'batch/tracker-additions');
 const MERGED_DIR = join(ADDITIONS_DIR, 'merged');
 const DRY_RUN = process.argv.includes('--dry-run');
 const VERIFY = process.argv.includes('--verify');
@@ -361,10 +365,12 @@ for (const file of tsvFiles) {
     });
   }
 
-  if (!duplicate) {
-    // Exact entry number match
-    duplicate = existingApps.find(app => app.num === addition.num);
-  }
+  // NOTE: we deliberately do NOT match on the TSV's entry `num`. Parallel batch
+  // workers self-assign that number by reading applications.md concurrently, so
+  // two unrelated offers can carry the same num. Matching on it caused an
+  // unrelated row to be silently overwritten. Identity is established only by
+  // report number (above) and company+role (below) — both unique. The num is
+  // used solely to seed sequential numbering for genuinely new entries.
 
   if (!duplicate) {
     // Company + role fuzzy match

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1086,6 +1086,56 @@ try {
   fail(`tracker-link normalization tests crashed: ${e.message}`);
 }
 
+console.log('\n13. merge-tracker: parallel num-collision must not overwrite (regression)');
+
+try {
+  // Reproduces the bug where parallel batch workers self-assign the same
+  // tracker `num`, and merge-tracker matched on that num — overwriting an
+  // unrelated existing row. A colliding num for a DIFFERENT company/role/report
+  // must be added as a NEW entry, never an update of the existing row.
+  const tmpDir = mkdtempSync(join(tmpdir(), 'career-ops-merge-'));
+  try {
+    mkdirSync(join(tmpDir, 'data'));
+    mkdirSync(join(tmpDir, 'reports'));
+    const additionsDir = join(tmpDir, 'additions');
+    mkdirSync(additionsDir);
+    writeFileSync(join(tmpDir, 'reports', '010-langchain-2026-06-07.md'), '# fixture\n');
+    writeFileSync(join(tmpDir, 'reports', '014-elevenlabs-2026-06-07.md'), '# fixture\n');
+
+    const tracker = join(tmpDir, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 10 | 2026-06-07 | LangChain | Solutions Architect (APAC) | 3.4/5 | Evaluated | ✅ | [010](../reports/010-langchain-2026-06-07.md) | keep me |\n');
+
+    // Incoming TSV: DIFFERENT company/role/report but COLLIDING num=10.
+    writeFileSync(join(additionsDir, '5.tsv'),
+      ['10', '2026-06-07', 'ElevenLabs', 'Forward Deployed Engineer', 'Evaluated', '3.9/5', '✅',
+       '[014](reports/014-elevenlabs-2026-06-07.md)', 'new role'].join('\t') + '\n');
+
+    run(NODE, ['merge-tracker.mjs'], {
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS_DIR: additionsDir },
+    });
+    const after = readFileSync(tracker, 'utf-8');
+
+    const langchainKept = after.includes('LangChain') && after.includes('[010](../reports/010-langchain-2026-06-07.md)');
+    const elevenAdded = after.includes('ElevenLabs') && after.includes('[014](../reports/014-elevenlabs-2026-06-07.md)');
+
+    if (langchainKept && elevenAdded) {
+      pass('colliding num adds a new entry without overwriting the existing row');
+    } else if (!langchainKept) {
+      fail('colliding num OVERWROTE the existing LangChain row (the bug)');
+    } else {
+      fail('colliding num did not add the new ElevenLabs entry');
+    }
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`merge-tracker num-collision test crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
…l-batch data loss)

Parallel batch workers (`batch-runner.sh --parallel N`) each self-assign a tracker entry `num` by reading the last line of applications.md concurrently, so two unrelated offers can carry the same num. merge-tracker's duplicate detection matched on that num, so a colliding addition was merged as an *update* to an existing row — silently overwriting an unrelated evaluation.

Identity is now established only by report number and company+role (both unique). The TSV `num` is used solely to seed sequential numbering for new entries. Adds regression test #13 reproducing the collision.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- REQUIRED: Link the issue this PR addresses. PRs without a related issue will be closed. -->
<!-- Format: Fixes #123 / Closes #123 -->
<!-- Bug fixes can skip this if the fix is obvious (e.g., typo, crash). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] I linked a related issue above (required for features and architecture changes)
- [ ] My PR does not include personal data (CV, email, real names)
- [ ] I ran `node test-all.mjs` and all tests pass
- [ ] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable directory location for additions via environment variable.

* **Bug Fixes**
  * Fixed duplicate detection logic to prevent parallel workers from accidentally overwriting existing entries.
  * Improved identity matching to prioritize report-number and company+role fuzzy matching.

* **Tests**
  * Added regression test to prevent data corruption from parallel worker scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->