### PR TITLE
feat(scan): add --rediscover-404 fallback for moved tracked-company roles

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -443,7 +443,10 @@ async function verifyOffers(offers, { headedFallback = false, throttleBaseMs = 0
           const newUrl = await searchForNewUrl(page, offer);
           if (newUrl) {
             const recheck = await checkUrlLiveness(page, newUrl);
-            if (recheck.result !== 'expired') {
+            // Require a *confirmed* live page before migrating. A transient
+            // 'uncertain' (timeout/DNS/5xx) must not commit an unverified URL —
+            // fall through to expired (the original 404/410 is a real closure).
+            if (recheck.result === 'active') {
               migrated.push({ ...offer, url: newUrl, previousUrl: offer.url });
               console.log(`  🔄 migrated  ${offer.company} | ${offer.title} → ${newUrl}`);
               continue;

--- a/scan.mjs
+++ b/scan.mjs
@@ -176,6 +176,92 @@ export function buildLocationFilter(locationFilter) {
   };
 }
 
+// ── URL rediscovery (--rediscover-404) ──────────────────────────────
+// When a tracked company's job URL returns 404/410, the role may have just
+// moved to a new URL (Workday/Greenhouse rotate URLs without closing roles).
+// These helpers back an opt-in search-and-reverify fallback before giving up.
+
+// extractCareersUrlDomain returns the hostname of a company's careers_url, or
+// null when it's missing/unparseable. The presence of a domain is what gates
+// the fallback — broad-discovery offers without a careers_url stay ineligible.
+export function extractCareersUrlDomain(careersUrl) {
+  if (!careersUrl) return null;
+  try {
+    return new URL(careersUrl).hostname;
+  } catch {
+    return null;
+  }
+}
+
+// resolveSearchHref unwraps a DuckDuckGo HTML redirect (`/l/?uddg=<encoded>`)
+// to its real destination, so domain matching sees the actual host instead of
+// duckduckgo.com. Non-redirect hrefs pass through unchanged.
+function resolveSearchHref(href) {
+  try {
+    const u = new URL(href, 'https://duckduckgo.com');
+    if (u.hostname.endsWith('duckduckgo.com') && u.pathname === '/l/') {
+      const target = u.searchParams.get('uddg');
+      if (target) return target;
+    }
+  } catch {
+    /* fall through to the raw href */
+  }
+  return href;
+}
+
+// pickRediscoveredUrl chooses the first result whose hostname *exactly* equals
+// the careers domain (no substring/look-alike matches), unwrapping search-engine
+// redirects first. Pure + exported so result-matching is unit-testable without
+// driving a real browser. Returns null when nothing matches.
+export function pickRediscoveredUrl(hrefs, domain) {
+  if (!domain || !Array.isArray(hrefs)) return null;
+  for (const raw of hrefs) {
+    const href = resolveSearchHref(raw);
+    let host;
+    try {
+      host = new URL(href).hostname;
+    } catch {
+      continue;
+    }
+    if (host === domain) return href;
+  }
+  return null;
+}
+
+// REDISCOVER_TIMEOUT_MS bounds the single fallback search so a slow or blocked
+// search engine can't stall the sequential verify loop.
+const REDISCOVER_TIMEOUT_MS = 10_000;
+
+// searchForNewUrl runs one site-scoped search for a moved tracked role and
+// returns a same-domain URL if found, else null. Every failure path returns
+// null — the fallback must never throw into the verify loop. Leaves the page on
+// a blank document so the next checkUrlLiveness call starts clean.
+async function searchForNewUrl(page, offer) {
+  const domain = offer.careersUrlDomain;
+  if (!domain) return null;
+  const query = `"${offer.title}" "${offer.company}" site:${domain}`;
+  try {
+    await page.goto(
+      `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`,
+      { waitUntil: 'domcontentloaded', timeout: REDISCOVER_TIMEOUT_MS },
+    );
+    const hrefs = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('a.result__a'))
+        .map((a) => a.getAttribute('href'))
+        .filter(Boolean),
+    );
+    return pickRediscoveredUrl(hrefs, domain);
+  } catch {
+    return null;
+  } finally {
+    try {
+      await page.goto('about:blank');
+    } catch {
+      /* ignore — best-effort cleanup */
+    }
+  }
+}
+
 // ── Dedup ───────────────────────────────────────────────────────────
 
 function loadSeenUrls() {
@@ -295,7 +381,7 @@ async function parallelFetch(tasks, limit) {
 
 // ── Main ────────────────────────────────────────────────────────────
 
-async function verifyOffers(offers, { headedFallback = false, throttleBaseMs = 0 } = {}) {
+async function verifyOffers(offers, { headedFallback = false, throttleBaseMs = 0, rediscover = false } = {}) {
   // Dynamic imports keep the default zero-token path free of Playwright startup
   let chromium;
   let checkUrlLiveness;
@@ -335,6 +421,7 @@ async function verifyOffers(offers, { headedFallback = false, throttleBaseMs = 0
   const expired = [];
   const dropped = [];
   const invalid = [];
+  const migrated = [];
 
   const headed = headedFallback ? createHeadedPageProvider(chromium) : null;
   const getHeadedPage = headed ? () => headed.get() : undefined;
@@ -348,6 +435,21 @@ async function verifyOffers(offers, { headedFallback = false, throttleBaseMs = 0
         ? await checkUrlLivenessWithFallback(page, offer.url, { getHeadedPage })
         : await checkUrlLiveness(page, offer.url);
       if (result === 'expired') {
+        // 404/410 on a tracked company may just be a moved role — run one
+        // search + re-verify before giving up (opt-in via --rediscover-404).
+        // Only http_gone (HTTP 404/410) qualifies; soft-expiry signals
+        // (redirect/body/listing) are real closures, not URL moves.
+        if (rediscover && code === 'http_gone' && offer.tracked && offer.careersUrlDomain) {
+          const newUrl = await searchForNewUrl(page, offer);
+          if (newUrl) {
+            const recheck = await checkUrlLiveness(page, newUrl);
+            if (recheck.result !== 'expired') {
+              migrated.push({ ...offer, url: newUrl, previousUrl: offer.url });
+              console.log(`  🔄 migrated  ${offer.company} | ${offer.title} → ${newUrl}`);
+              continue;
+            }
+          }
+        }
         expired.push({ ...offer, reason });
         console.log(`  ❌ expired   ${offer.company} | ${offer.title} (${reason})`);
       } else if (result === 'uncertain' && GUARD_CODES.has(code)) {
@@ -377,7 +479,7 @@ async function verifyOffers(offers, { headedFallback = false, throttleBaseMs = 0
     await browser.close();
   }
 
-  return { verified, expired, dropped, invalid };
+  return { verified, expired, dropped, invalid, migrated };
 }
 
 // Stable codes from liveness-browser's up-front URL guard. Routing dispatches
@@ -405,6 +507,9 @@ async function main() {
   // hits). Default base 5000ms. Off by default — most ATS feeds don't need it.
   const throttleArg = args.find((a) => a === '--throttle' || a.startsWith('--throttle='));
   const throttleBaseMs = throttleArg ? (Number(throttleArg.split('=')[1]) || 5000) : 0;
+  // --rediscover-404: when a tracked company's URL 404/410s, search for the
+  // moved role and re-verify before marking it expired. Opt-in; rides on --verify.
+  const rediscover = args.includes('--rediscover-404');
   const companyFlag = args.indexOf('--company');
   const filterCompany = companyFlag !== -1 ? args[companyFlag + 1]?.toLowerCase() : null;
 
@@ -518,7 +623,16 @@ async function main() {
         // Mark as seen to avoid intra-scan dupes
         seenUrls.add(job.url);
         seenCompanyRoles.add(key);
-        newOffers.push({ ...job, source: sourceName });
+        // Tag with the company's careers domain so verify can offer a 404/410
+        // rediscovery fallback. A null domain (no careers_url) marks the offer
+        // as broad-discovery — ineligible for the fallback, per the issue scope.
+        const careersUrlDomain = extractCareersUrlDomain(company.careers_url);
+        newOffers.push({
+          ...job,
+          source: sourceName,
+          tracked: Boolean(careersUrlDomain),
+          careersUrlDomain,
+        });
       }
     } catch (err) {
       errors.push({ company: company.name, error: err.message });
@@ -532,13 +646,19 @@ async function main() {
   let expiredOffers = [];
   let droppedOffers = [];
   let invalidOffers = [];
+  let migratedOffers = [];
   if (verify && newOffers.length > 0) {
     console.log(`\nVerifying liveness of ${newOffers.length} new offer(s) with Playwright (sequential)...`);
-    const result = await verifyOffers(newOffers, { headedFallback, throttleBaseMs });
+    const result = await verifyOffers(newOffers, { headedFallback, throttleBaseMs, rediscover });
     verifiedOffers = result.verified;
     expiredOffers = result.expired;
     droppedOffers = result.dropped;
     invalidOffers = result.invalid;
+    migratedOffers = result.migrated;
+    // Migrated offers re-enter the pipeline at their newly discovered URL.
+    if (migratedOffers.length > 0) {
+      verifiedOffers = [...verifiedOffers, ...migratedOffers];
+    }
   }
 
   // 6. Write results
@@ -546,8 +666,14 @@ async function main() {
     appendToPipeline(verifiedOffers);
     appendToScanHistory(verifiedOffers, date);
   }
-  if (!dryRun && expiredOffers.length > 0) {
-    appendToScanHistory(expiredOffers, date, 'skipped_expired');
+  // Expired postings — plus the old URLs of migrated offers — are recorded as
+  // skipped_expired so subsequent scans dedup-skip the dead URLs.
+  const expiredForHistory = [
+    ...expiredOffers,
+    ...migratedOffers.map(o => ({ ...o, url: o.previousUrl })),
+  ];
+  if (!dryRun && expiredForHistory.length > 0) {
+    appendToScanHistory(expiredForHistory, date, 'skipped_expired');
   }
   // Pages that loaded but had no Apply control: record so we don't re-verify
   // them next scan, but never let them reach pipeline.md.
@@ -581,6 +707,7 @@ async function main() {
   console.log(`Duplicates:            ${totalDupes} skipped`);
   if (verify) {
     console.log(`Expired (verified):    ${expiredOffers.length} dropped`);
+    console.log(`Rediscovered (moved):  ${migratedOffers.length} migrated`);
     console.log(`No apply control:      ${droppedOffers.length} dropped`);
     console.log(`Invalid (guarded):     ${invalidOffers.length} dropped`);
   }

--- a/scan.mjs
+++ b/scan.mjs
@@ -443,7 +443,12 @@ async function verifyOffers(offers, { headedFallback = false, throttleBaseMs = 0
         if (rediscover && code === 'http_gone' && offer.tracked && offer.careersUrlDomain) {
           const newUrl = await searchForNewUrl(page, offer);
           if (newUrl) {
-            const recheck = await checkUrlLiveness(page, newUrl);
+            // Mirror the primary check: without the headed fallback, a
+            // challenge-prone domain would flag the rediscovered URL as
+            // expired just because the recheck hit the same anti-bot wall.
+            const recheck = headed
+              ? await checkUrlLivenessWithFallback(page, newUrl, { getHeadedPage })
+              : await checkUrlLiveness(page, newUrl);
             // Require a *confirmed* live page before migrating. A transient
             // 'uncertain' (timeout/DNS/5xx) must not commit an unverified URL —
             // fall through to expired (the original 404/410 is a real closure).

--- a/scan.mjs
+++ b/scan.mjs
@@ -199,7 +199,8 @@ export function extractCareersUrlDomain(careersUrl) {
 function resolveSearchHref(href) {
   try {
     const u = new URL(href, 'https://duckduckgo.com');
-    if (u.hostname.endsWith('duckduckgo.com') && u.pathname === '/l/') {
+    const isDdgHost = u.hostname === 'duckduckgo.com' || u.hostname.endsWith('.duckduckgo.com');
+    if (isDdgHost && u.pathname === '/l/') {
       const target = u.searchParams.get('uddg');
       if (target) return target;
     }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1358,6 +1358,15 @@ try {
   } else {
     fail('pickRediscoveredUrl did not return null for empty input');
   }
+  // Redirect unwrapping is restricted to real DuckDuckGo hosts: a look-alike
+  // host must not get its uddg target unwrapped (and its own hostname does not
+  // match the careers domain, so the result is null).
+  const lookAlike = `https://evil-duckduckgo.com/l/?uddg=${encodeURIComponent('https://job-boards.greenhouse.io/acme/456')}`;
+  if (pickRediscoveredUrl([lookAlike], domain) === null) {
+    pass('pickRediscoveredUrl ignores uddg redirects from look-alike hosts');
+  } else {
+    fail('pickRediscoveredUrl unwrapped a redirect from a look-alike host');
+  }
   // DuckDuckGo HTML wraps each result in a /l/?uddg= redirect — must be
   // unwrapped, otherwise every hostname looks like duckduckgo.com and nothing
   // ever matches the careers domain (the fallback would silently never fire).

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1309,6 +1309,74 @@ try {
   fail(`Cold-start trigger test crashed: ${e.message}`);
 }
 
+// ── 15. URL REDISCOVERY FALLBACK (--rediscover-404) ─────────────
+
+console.log('\n15. URL rediscovery fallback');
+
+try {
+  const { extractCareersUrlDomain, pickRediscoveredUrl } = await import(
+    pathToFileURL(join(ROOT, 'scan.mjs')).href
+  );
+
+  // extractCareersUrlDomain — pure hostname extraction, null on missing/invalid
+  if (extractCareersUrlDomain('https://job-boards.greenhouse.io/anthropic') === 'job-boards.greenhouse.io') {
+    pass('extractCareersUrlDomain pulls hostname from a careers URL');
+  } else {
+    fail('extractCareersUrlDomain failed on a valid URL');
+  }
+  if (extractCareersUrlDomain(null) === null) {
+    pass('extractCareersUrlDomain returns null for missing careers_url');
+  } else {
+    fail('extractCareersUrlDomain did not return null for null input');
+  }
+  if (extractCareersUrlDomain('not-a-url') === null) {
+    pass('extractCareersUrlDomain returns null for an unparseable URL');
+  } else {
+    fail('extractCareersUrlDomain did not return null for a bad URL');
+  }
+
+  // pickRediscoveredUrl — first search hit whose hostname exactly matches domain
+  const domain = 'job-boards.greenhouse.io';
+  const hrefs = [
+    'https://duckduckgo.com/l/?uddg=ad',          // search-engine chrome / noise
+    'https://other-board.lever.co/acme/123',      // wrong domain
+    'https://job-boards.greenhouse.io/acme/456',  // first real match
+    'https://job-boards.greenhouse.io/acme/789',  // later match
+  ];
+  if (pickRediscoveredUrl(hrefs, domain) === 'https://job-boards.greenhouse.io/acme/456') {
+    pass('pickRediscoveredUrl returns the first same-domain result');
+  } else {
+    fail(`pickRediscoveredUrl picked the wrong URL: ${pickRediscoveredUrl(hrefs, domain)}`);
+  }
+  if (pickRediscoveredUrl(['https://elsewhere.com/x'], domain) === null) {
+    pass('pickRediscoveredUrl returns null when no result matches the domain');
+  } else {
+    fail('pickRediscoveredUrl did not return null for no domain match');
+  }
+  if (pickRediscoveredUrl([], domain) === null) {
+    pass('pickRediscoveredUrl returns null for an empty result set');
+  } else {
+    fail('pickRediscoveredUrl did not return null for empty input');
+  }
+  // DuckDuckGo HTML wraps each result in a /l/?uddg= redirect — must be
+  // unwrapped, otherwise every hostname looks like duckduckgo.com and nothing
+  // ever matches the careers domain (the fallback would silently never fire).
+  const ddg = ['//duckduckgo.com/l/?uddg=' + encodeURIComponent('https://job-boards.greenhouse.io/acme/999')];
+  if (pickRediscoveredUrl(ddg, domain) === 'https://job-boards.greenhouse.io/acme/999') {
+    pass('pickRediscoveredUrl unwraps DuckDuckGo redirect links');
+  } else {
+    fail(`pickRediscoveredUrl did not unwrap DDG redirect: ${pickRediscoveredUrl(ddg, domain)}`);
+  }
+  // A look-alike host that merely contains the domain as a substring must not match.
+  if (pickRediscoveredUrl(['https://job-boards.greenhouse.io.attacker.com/x'], domain) === null) {
+    pass('pickRediscoveredUrl rejects look-alike hostnames');
+  } else {
+    fail('pickRediscoveredUrl accepted a look-alike hostname');
+  }
+} catch (e) {
+  fail(`URL rediscovery tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `--rediscover-404` flag to `scan.mjs --verify`. When liveness verification gets a **404/410** (`classifyLiveness` → `code: 'http_gone'`) on a **tracked company's** job URL, the role may have just moved — Workday/Greenhouse rotate posting URLs without closing roles, producing false negatives. Before marking the offer `skipped_expired`, the flag:

1. Runs **one** site-scoped search: `"{title}" "{company}" site:{careers_url_domain}`
2. Picks the first result whose hostname **exactly** matches the careers domain
3. Re-verifies that URL with the existing `checkUrlLiveness`
4. If it's live → the offer re-enters the pipeline at the **new** URL, and the **old** URL is recorded as `skipped_expired` for dedup
5. If nothing is found / re-verify still expired → falls back to current behaviour

**Scope guard:** only offers carrying a `careers_url` (`tracked: true`) are eligible. Broad-discovery (Level 3) offers without a per-company `careers_url` are never rediscovered, exactly as the issue specifies. The flag rides on `--verify`; the default zero-token path is unchanged.

**Safety:** the search is fully wrapped — any navigation/parse error or timeout (10s) returns `null`, so the fallback can never crash the verify loop. Only `http_gone` qualifies; soft-expiry signals (redirect/body/listing) are treated as real closures, not moves.

### Implementation notes / deviation from the proposed plan

This implements the plan @nakul-chawla proposed in #266 — credit for the design is theirs. One deliberate deviation: result-URL matching is extracted into an **exported pure helper** `pickRediscoveredUrl(hrefs, domain)` (per the repo's "pure helpers exported for testability" convention) rather than an inline closure. It also **unwraps DuckDuckGo's `/l/?uddg=` redirect links** — without that the result hostnames all look like `duckduckgo.com` and the fallback would silently never fire — and rejects look-alike hostnames (`job-boards.greenhouse.io.attacker.com`).

## Related issue

Fixes #266

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My PR is linked to a related issue
- [x] My PR contains no personal data (uses fictional fixtures)
- [x] I ran `node test-all.mjs` locally
- [x] My changes respect the Data Contract (only `scan.mjs` + `test-all.mjs`, both System Layer)
- [x] My changes align with the project roadmap

## Testing

- 8 new unit tests (section 15, `test-all.mjs`) covering `extractCareersUrlDomain` and `pickRediscoveredUrl` (domain match, no-match, empty, DDG-redirect unwrap, look-alike rejection).
- `node test-all.mjs --quick` → **158 passed, 0 failed** (7 pre-existing warnings, unrelated).
- `node --check scan.mjs` / `node --check test-all.mjs` → clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in rediscovery (--rediscover-404) to locate replacement URLs for expired job listings; successful rediscoveries are recorded as migrated and re-verified as new results
  * Offer records now note whether a careers domain is tracked and include extracted career-domain info; migrated listings keep their previous URL in history and are skipped from redundant checks
  * Backend uses a bounded HTML search query to attempt rediscovery and unwraps common redirect links during matching

* **Tests**
  * Added tests for domain extraction, redirect unwrapping, and rediscovery selection behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->