### PR TITLE
fix(batch): isolate workers from inherited MCP to prevent deadlock

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -381,7 +381,11 @@ process_offer() {
   # Launch claude -p worker.
   # Model defaults to the Claude Max subscription default unless --model was
   # passed. Building the command in an array keeps quoting safe regardless.
-  local -a claude_args=(-p --dangerously-skip-permissions)
+  # --strict-mcp-config (with no --mcp-config) starts workers with no MCP
+  # servers: they only evaluate offers and need none. Without it each parallel
+  # worker inherits the parent session's MCP (e.g. Playwright) and they deadlock
+  # fighting over the single shared browser when --parallel > 1 (issue #506).
+  local -a claude_args=(-p --dangerously-skip-permissions --strict-mcp-config)
   if [[ -n "$MODEL" ]]; then
     claude_args+=(--model "$MODEL")
   fi

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1309,6 +1309,27 @@ try {
   fail(`Cold-start trigger test crashed: ${e.message}`);
 }
 
+// ── 15. BATCH RUNNER MCP ISOLATION (#506) ───────────────────────
+
+console.log('\n15. Batch runner MCP isolation');
+
+try {
+  const batchRunner = readFileSync(join(ROOT, 'batch', 'batch-runner.sh'), 'utf-8');
+  // Workers must be spawned with --strict-mcp-config so they don't inherit the
+  // parent session's MCP servers (e.g. Playwright) and deadlock fighting over a
+  // single browser when --parallel > 1 (issue #506).
+  const claudeArgsLine = batchRunner
+    .split('\n')
+    .find(l => l.includes('claude_args=('));
+  if (claudeArgsLine && claudeArgsLine.includes('--strict-mcp-config')) {
+    pass('batch workers spawn with --strict-mcp-config (no inherited MCP)');
+  } else {
+    fail('batch-runner.sh worker spawn missing --strict-mcp-config (issue #506 regression)');
+  }
+} catch (e) {
+  fail(`Batch runner MCP isolation test crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What does this PR do?

Fixes the batch runner hanging when Playwright MCP (or any MCP server) is enabled in the parent Claude session. `batch/batch-runner.sh` spawned each worker with `claude -p --dangerously-skip-permissions` but **no `--strict-mcp-config`**, so every parallel worker inherited the parent session's MCP servers — including Playwright — and they deadlocked fighting over the single shared browser as soon as `--parallel > 1` (exactly the reporter's "each parallel session tried fighting over playwright and got locked out").

Batch workers only evaluate offers from a resolved prompt; they need no MCP servers at all. Passing `--strict-mcp-config` (with no `--mcp-config`) starts them with a clean, empty MCP set, isolating them from whatever the parent session has loaded.

One-line change to the worker spawn array, plus a regression test asserting the flag is present.

## Related issue

Fixes #506

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My PR is linked to a related issue
- [x] My PR contains no personal data
- [x] I ran `node test-all.mjs` locally
- [x] My changes respect the Data Contract (only `batch/batch-runner.sh` + `test-all.mjs`, both System Layer)
- [x] My changes align with the project roadmap

## Testing

- `bash -n batch/batch-runner.sh` → clean.
- New regression test (section 15, `test-all.mjs`) asserting the worker spawn line carries `--strict-mcp-config`.
- `node test-all.mjs --quick` → **151 passed, 0 failed** (7 pre-existing warnings, unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of batch job processing by enforcing a stricter MCP isolation configuration to prevent potential deadlocks when running workers in parallel.

* **Tests**
  * Added an automated test that verifies the batch runner enforces the stricter isolation and reports clear pass/fail results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->