### PR TITLE
chore: close GoVerify — go build clean on go1.26.4

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,0 +1,133 @@
+# BUGS.md — Career-Ops Bug & Tech-Debt Tracker
+
+Single source of truth for open defects and tech debt in the career-ops + AutoSubmit stack.
+The 8am report's 🔧 section reads from CLAUDE.md's Tech Debt Log for resolved items;
+this file tracks **open** work.
+
+**Severity:** P1 = data-loss / silent failure | P2 = blocks automation | P3 = degrades quality | P4 = hygiene
+**Status:** New | In-progress | Blocked | Closed
+
+---
+
+## Open
+
+| ID | Sev | Status | Opened | Title |
+|----|-----|--------|--------|-------|
+| r7 | P1 | In-progress | 2026-06-04 | OneDrive file-corruption (trailing null bytes / mid-token truncation) silently breaks .mjs files |
+| B4 | P3 | New | 2026-06-04 | `data/last-refresh.json` `ran_at` timezone is local system time; cross-timezone Cowork runs produce ambiguous timestamps |
+| r8 | P2 | In-progress | 2026-06-04 | State model triplication: `states.yml`, `normalize-statuses.mjs`, `dashboard/internal/data/career.go` diverge — codegen scaffold live, migration pending |
+| B2 | P3 | New | 2026-06-04 | `scan-linkedin.mjs` HTTP-999 / authwall rate-limit not adaptive — no backoff, always skips entire query on first 999 |
+| B6 | P2 | In-progress | 2026-06-05 | Pulse Engine MVP runs in browser; MCPs only callable from Claude sessions — ingestion must happen scheduled-task-side and write to a fetchable store |
+| B7 | P2 | New | 2026-06-05 | AutoSubmit launches browser on expired/redirect listings — `no-submit-button`×469 + `dead-listing-redirect`×57 dominate blocks; needs submit-time ATS liveness re-check |
+| B3 | P3 | New | 2026-06-04 | `dedup-tracker.mjs` role-match overlap floor (`Math.min(2, smaller)`) still misses single-word roles with different suffixes (e.g. "Engineer" vs "Engineering") |
+| r10 | P4 | New | 2026-06-04 | `batch/tracker-additions/*.tsv` files accumulate without cleanup — no archival or max-age policy |
+
+---
+
+## Closed
+
+| ID | Sev | Closed | Title | Resolution |
+|----|-----|--------|-------|------------|
+| B0 | P2 | 2026-06-05 | `check-syntax.mjs` critical-file list not exhaustive | Rewritten to glob 39 root `.mjs` + validate 7 critical JSON + NUL scan; caught live `last-refresh.json` corruption |
+| GoVerify | P2 | 2026-06-08 | `career.go` state list hand-coded, no compile-time check vs `states.yml` | `go build ./...` verified clean on Rahil's Windows host (go1.26.4). `gen/states.go` committed. Dashboard builds. |
+| B1 | P2 | 2026-06-08 | exit-code contract not enforced at call-site | Ingestion pipeline (Phase 1+2) supersedes the single-script exit-code contract. Bat-level handling tracked separately. |
+| B5 | P1 | 2026-06-02 | Pre-auth Workday sessions not persisted — every run hits auth wall | `workday-login.mjs` implemented; cookie/localStorage saved per tenant |
+| r9 | P3 | 2026-06-04 | Uncommitted work on local main, no branch/PR | Closed by `chore/safe-edit-kit` PR |
+
+---
+
+## Detail
+
+### B0 — check-syntax.mjs critical-file list not exhaustive
+**Repro:** Add a new .mjs file (e.g. `process-autosubmit-queue.mjs`). It is NOT in the 11-file list in `check-syntax.mjs`. A truncation on this file goes undetected by TD-35 gate.
+**Next action:** Rewrite `check-syntax.mjs` to glob `*.mjs` at root instead of using a hardcoded list.
+**Owner:** Rahil
+
+---
+
+### r7 — OneDrive file-corruption pattern
+**Repro:** Files saved via OneDrive sync on Windows can receive trailing `\0` bytes or be truncated mid-token, particularly during concurrent writes. Root cause is OneDrive cloud-sync racing with write completion. The safe-edit kit (this PR) adds the guardrail; moving the repo off OneDrive is the permanent fix.
+**Status:** Guardrails live (`scripts/safe-edit.mjs`, `scripts/pre-commit.sh`). Repo already on `C:\Users\rahil\career-ops` (NOT OneDrive — good). Monitor for recurrence.
+**Next action:** Verify repo path is not under any OneDrive-managed folder tree. If so, move it.
+**Owner:** Rahil
+
+---
+
+### B1 — exit-code contract not enforced
+**Repro:** `run-autosubmit.bat` calls `auto-submit.mjs` and checks `%ERRORLEVEL%` but treats 1, 2, and 3 identically as "failed". Exit code 2 = SuS-blocked (new company), 3 = form-blocked — these are qualitatively different and should route to different columns.
+**Next action:** Add exit-code enum to `docs/autosubmit-exit-codes.md`; update bat to handle each code distinctly.
+**Owner:** Rahil
+
+---
+
+### B4 — last-refresh.json timezone ambiguity
+**Repro:** `ran_at` is written with `new Date().toISOString()` which uses UTC. But display in 8am report converts to local time via system locale. If the Cowork VM is in a different timezone than the Windows bat, `ran_at` comparisons are off by several hours.
+**Next action:** Standardize `ran_at` to always UTC; document in schema comment.
+**Owner:** Rahil
+
+---
+
+### r8 — state model triplication
+**Repro:** Add a new state. Must update `templates/states.yml` AND `normalize-statuses.mjs` AND `dashboard/internal/data/career.go`. Any one being missed causes silent state-mismatch bugs.
+**Status:** `scripts/codegen-states.mjs` generates `gen/states.json|.js|.go`. Full migration (replacing hand-coded lists in normalize-statuses.mjs and career.go) is pending.
+**Next action:** Wire `gen/states.js` into `normalize-statuses.mjs`; wire `gen/states.go` into dashboard package.
+**Owner:** Rahil
+
+---
+
+### B2 — LinkedIn 999 no backoff
+**Repro:** Run `scan-linkedin.mjs` during peak hours. LinkedIn returns HTTP 999 on first request; the script logs "authwall — skipping" and moves to the next query with no delay. Entire session may 999 on all queries.
+**Next action:** Add exponential backoff (1s, 2s, 4s cap 30s) on 999; retry up to 3 times per query before skipping.
+**Owner:** Rahil
+
+---
+
+### GoVerify — dashboard state list out of sync
+**CLOSED 2026-06-08** — Rahil ran `cd dashboard && go build ./...` on Windows host (go1.26.4). Zero errors. All dashboard packages built clean with the `career.go` edits and `gen/states.go` committed by `chore/safe-edit-kit`. The earlier `Blocked` status was a sandbox PATH issue (winget MSI updated system PATH but the shell predated it) — not an actual code defect.
+**Remaining work (tracked as r8):** Full migration of `career.go`'s hand-coded state switch to import from `gen/states.go` is still pending — but the build is proven safe for now.
+
+---
+
+### B3 — dedup role-match misses suffix variants
+**Repro:** `dedup-tracker.mjs` will not deduplicate "Software Engineer" vs "Software Engineering" because after stop-word removal both reduce to the same token but overlap check requires `Math.min(2, smaller)` words to match, and single-word match is blocked by the floor.
+**Next action:** Lower floor to 1 for exact single-token matches after normalization.
+**Owner:** Rahil
+
+---
+
+### r10 — tracker-additions TSV accumulation
+**Repro:** `batch/tracker-additions/` grows unbounded; after `merge-tracker.mjs` runs, the TSV files are no longer needed but remain in the directory. On a large batch this is hundreds of files.
+**Next action:** Add archive step to `merge-tracker.mjs` — move processed TSVs to `batch/tracker-additions/archive/YYYY-MM/`.
+**Owner:** Rahil
+
+---
+
+### B6 — MCP calls only callable from Claude sessions, not browser
+**Repro:** The Pulse Engine MVP (`dashboard/job-pulse-kanban.html`) runs in a browser. The Indeed MCP and Dice MCP are only callable from within a Claude/AI session. The `fetchIndeedRSS()` UI button in the Kanban is a stub — it cannot call the MCP directly from a browser context.
+**Impact:** Secondary MCP ingestion MUST happen on the scheduled-task side (inside the 1am Claude session), write to `data/jobs-incoming-{date}.json`, and the SKILL then reads that file to inject cards into the Kanban. The browser UI cannot drive ingestion.
+**Status:** Ingestion scaffolding built (`adapter-indeed.mjs`, `adapter-dice.mjs`, `ingest-runner.mjs`). 1am SKILL Step 1.5 (MCP call instructions) added. Pending: live test on tomorrow's 6am run.
+**Next action:** Validate read path — confirm 1am SKILL can write `data/jobs-incoming-{date}.json` and the resulting Kanban injection works end-to-end.
+**Owner:** Rahil
+
+---
+
+### B7 — AutoSubmit launches browser on expired/redirect listings
+**Repro:** `auto-submit.mjs` blocks on `no-submit-button` (×469) and `dead-listing-redirect` (×57) — job pages that have expired and redirect to a marketing page or careers home. The submit-time ATS API verification gate fires at Kanban injection time, but pages can expire AFTER being injected. AutoSubmit wastes a full Playwright launch per dead URL.
+**Next action:** Add a lightweight submit-time liveness check in `auto-submit.mjs` before launching Playwright: re-verify Greenhouse/Lever via their APIs (`boards-api.greenhouse.io` / `api.lever.co`). If 404 → exit 3 with `dead-listing` flag, skip browser launch entirely.
+**Owner:** Rahil
+
+---
+
+## Kaizens
+
+### K-2026-06-05-1 — Always grep available MCPs before building new integrations
+**What happened:** The session considered building an Indeed Publisher API integration while Indeed MCP was already installed and idle in the same session.
+**Rule:** Before implementing any new data-source integration, call `ToolSearch` or list available MCPs and verify none of them already cover the source. Two minutes of inspection saved hours of implementation.
+**Applies to:** Any new external data source (LinkedIn, Glassdoor, ZipRecruiter, etc.).
+
+---
+
+### K-2026-06-05-2 — Use CLI OAuth flows over web signups when possible
+**What happened:** Cloudflare Worker deployment was blocked on a dashboard signup step. `wrangler login` OAuth (via PowerShell background task) bypassed this entirely — same model that worked for `gh auth login`. Cloudflare auto-created a free account on first OAuth.
+**Rule:** When a service offers a CLI OAuth flow, use it before reaching for the web dashboard. Free-tier accounts are auto-created on first OAuth for most major platforms (Cloudflare, Vercel, Fly, Render, Netlify, Supabase). Where OAuth requires localhost redirect (wrangler, gcloud, etc.), use an API token if the sandbox can't reach localhost.
+**Note:** Company source lists for Greenhouse/Lever are currently hardcoded in `SKILL_UPDATE_PHASE1.md`. They should migrate to `config/sources.yml` so they're version-controlled and code-reviewable.


### PR DESCRIPTION
## Summary

Closes GoVerify following Rahil's manual verification on his Windows host:

```
PS C:\Users\rahil\career-ops\dashboard> go build ./...
[downloads 21 deps — zero errors]
```

`career.go` edits + `gen/states.go` committed in `chore/safe-edit-kit` are compatible. Dashboard builds clean on go1.26.4.

## BUGS.md changes

- **GoVerify → Closed** (verified 2026-06-08, go1.26.4 Windows host)
- **B0 → Closed** (already resolved 2026-06-05: `check-syntax.mjs` rewritten to glob all `.mjs` + validate JSON + NUL scan)
- **B1** removed from Open table (already in Closed since Phase 1 PR)
- **B7 → added** (P2, New): AutoSubmit wastes Playwright launch on expired/redirect listings — `no-submit-button`×469 + `dead-listing-redirect`×57; needs submit-time ATS liveness re-check before browser launch

## Still open (accurate as of 2026-06-08)

| ID | Notes |
|----|-------|
| r7 | OneDrive corruption guardrails live; monitoring |
| B4 | `ran_at` UTC/local ambiguity — low urgency |
| r8 | `career.go` migration to `gen/states.go` still pending (build proven safe) |
| B2 | LinkedIn 999 no-backoff — known, low urgency |
| B6 | MCP ingestion pipeline live test pending |
| B7 | **New this PR** — submit-time liveness check |
| B3 | Dedup role-match floor — low urgency |
| r10 | TSV accumulation — P4 hygiene |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Added repository documentation for tracking and managing open defects and technical debt, including severity classifications, status conventions, detailed issue descriptions with reproduction steps, ownership assignments, and closure notes for improved project organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->