### PR TITLE
fix(update): create timestamped backup branches

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -156,7 +156,7 @@ Possible JSON responses:
 
 ## update
 
-Applies the upstream update. Creates a backup branch (`backup-pre-update-{version}`), fetches from the canonical repo, checks out only system-layer files, runs `npm install`, and commits. User-layer files (`cv.md`, `config/profile.yml`, `data/`, etc.) are never touched.
+Applies the upstream update. Creates a timestamped backup branch (`backup-pre-update-<version>-<YYYYMMDDTHHMMSSZ>`), fetches from the canonical repo, checks out only system-layer files, runs `npm install`, and commits. The timestamp is derived from UTC ISO time with separators and milliseconds removed (for example, `backup-pre-update-1.8.1-20260608T071302Z`). User-layer files (`cv.md`, `config/profile.yml`, `data/`, etc.) are never touched.
 
 ```bash
 npm run update
@@ -168,7 +168,7 @@ npm run update
 
 ## rollback
 
-Restores system-layer files from the most recent backup branch created during an update.
+Restores system-layer files from the most recent backup branch created during an update. Rollback prefers the newest timestamped branch matching `backup-pre-update-<version>-<YYYYMMDDTHHMMSSZ>` and still accepts legacy `backup-pre-update-{version}` branches for older installs.
 
 ```bash
 npm run rollback

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -168,7 +168,7 @@ npm run update
 
 ## rollback
 
-Restores system-layer files from the most recent backup branch created during an update. Rollback prefers the newest timestamped branch matching `backup-pre-update-<version>-<YYYYMMDDTHHMMSSZ>` and still accepts legacy `backup-pre-update-{version}` branches for older installs.
+Restores system-layer files from the most recent backup branch created during an update. Rollback prefers the newest timestamped branch matching `backup-pre-update-<version>-<YYYYMMDDTHHMMSSZ>` and still accepts legacy `backup-pre-update-<version>` branches for older installs.
 
 ```bash
 npm run rollback

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -128,6 +128,36 @@ function compareVersions(a, b) {
   return 0;
 }
 
+function updateBackupBranchName(version, date = new Date()) {
+  const stamp = date.toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}Z$/, 'Z');
+  return `backup-pre-update-${version}-${stamp}`;
+}
+
+function backupTimestamp(branchName) {
+  const match = branchName.match(/-(\d{8}T\d{6}Z)$/);
+  if (!match) return 0;
+  const [date, time] = match[1].split('T');
+  return Date.parse(
+    `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}T${time.slice(0, 2)}:${time.slice(2, 4)}:${time.slice(4, 6)}Z`,
+  ) || 0;
+}
+
+function newestBackupBranch(branches) {
+  const branchList = branches.split('\n').map(b => b.trim()).filter(Boolean);
+  if (branchList.length === 0) return null;
+
+  // Prefer timestamped backup branches created by current versions. Older
+  // backups are still accepted below for rollback compatibility.
+  const timestamped = branchList
+    .map(branch => ({ branch, timestamp: backupTimestamp(branch) }))
+    .filter(entry => entry.timestamp > 0)
+    .sort((a, b) => b.timestamp - a.timestamp);
+
+  return timestamped[0]?.branch || branchList[0];
+}
+
 function git(...args) {
   return execFileSync('git', args, { cwd: ROOT, encoding: 'utf-8', timeout: 30000 }).trim();
 }
@@ -264,13 +294,9 @@ async function apply() {
 
   try {
     // 1. Backup: create branch
-    const backupBranch = `backup-pre-update-${local}`;
-    try {
-      git('branch', backupBranch);
-      console.log(`Backup branch created: ${backupBranch}`);
-    } catch {
-      console.log(`Backup branch already exists (${backupBranch}), continuing...`);
-    }
+    const backupBranch = updateBackupBranchName(local);
+    git('branch', backupBranch);
+    console.log(`Backup branch created: ${backupBranch}`);
 
     // 2. Fetch from canonical repo
     console.log('Fetching latest from upstream...');
@@ -408,14 +434,13 @@ function rollback() {
   // Find most recent backup branch
   try {
     const branches = git('for-each-ref', '--sort=-committerdate', '--format=%(refname:short)', 'refs/heads/backup-pre-update-*');
-    const branchList = branches.split('\n').map(b => b.trim()).filter(Boolean);
+    const latest = newestBackupBranch(branches);
 
-    if (branchList.length === 0) {
+    if (!latest) {
       console.error('No backup branches found. Nothing to rollback.');
       process.exit(1);
     }
 
-    const latest = branchList[0];
     console.log(`Rolling back to: ${latest}`);
 
     // Checkout system files from backup branch.


### PR DESCRIPTION
## Summary

Fixes #733.

`update-system.mjs apply` now creates a unique `backup-pre-update-<version>-<timestamp>` branch for every update attempt instead of reusing `backup-pre-update-<version>`. Rollback prefers the newest timestamped backup branch while still accepting legacy backup branch names.

## Why

When a user updates more than once from the same local version, the previous branch name could already exist. The updater would continue with the stale branch, and `rollback` could restore an older pre-update state than intended.

## Validation

- `node --check update-system.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Backup branches for system updates now include timestamps, and backups are always created before applying updates to improve rollback reliability.
  * Rollback now restores from the newest matching backup branch, with fallback to legacy backups when needed.
* **Documentation**
  * Update instructions now describe the timestamped backup naming and the updated rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->