### PR TITLE
fix(batch): append profile context to worker prompts

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -360,6 +360,21 @@ process_offer() {
     -e "s|{{ID}}|${esc_id}|g" \
     "$PROMPT_FILE" > "$resolved_prompt"
 
+  # Inject user-layer personalization into the temporary worker prompt.
+  # The resolved prompt is gitignored runtime state, so user profile data stays
+  # out of the system layer while batch scoring matches interactive scoring.
+  for context_file in "$PROJECT_DIR/modes/_profile.md" "$PROJECT_DIR/config/profile.yml"; do
+    if [[ -f "$context_file" ]]; then
+      {
+        printf '\n\n---\n\n'
+        printf '## Runtime personalization: %s\n\n' "${context_file#$PROJECT_DIR/}"
+        printf '```text\n'
+        sed 's/```/` ` `/g' "$context_file"
+        printf '\n```\n'
+      } >> "$resolved_prompt"
+    fi
+  done
+
   # Launch claude -p worker.
   # Model defaults to the Claude Max subscription default unless --model was
   # passed. Building the command in an array keeps quoting safe regardless.

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -368,9 +368,8 @@ process_offer() {
       {
         printf '\n\n---\n\n'
         printf '## Runtime personalization: %s\n\n' "${context_file#$PROJECT_DIR/}"
-        printf '```text\n'
-        sed 's/```/` ` `/g' "$context_file"
-        printf '\n```\n'
+        sed 's/^/    /' "$context_file"
+        printf '\n'
       } >> "$resolved_prompt"
     fi
   done


### PR DESCRIPTION
## Summary

Fixes #583.

`batch/batch-runner.sh` now appends runtime personalization from `modes/_profile.md` and `config/profile.yml` to each temporary resolved worker prompt when those files exist. This keeps user data out of committed system files while making batch workers see the same personalization layer that interactive modes rely on.

## Validation

- `bash -n batch/batch-runner.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch prompt processing now supports injection of user profile content from local configuration files, enabling customized prompt handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->