### PR TITLE
fix(batch): wait and retry on rate limits

### DIFF
--- a/batch/README.md
+++ b/batch/README.md
@@ -35,6 +35,7 @@ Process multiple job offers in parallel via headless workers. Each worker runs t
 | `--retry-failed` | off | Only retry offers marked as `failed` in state |
 | `--start-from N` | `0` | Skip offers with ID below N |
 | `--max-retries N` | `2` | Max retry attempts per offer before giving up |
+| `--rate-limit-sleep N` | `300` | Seconds to wait before retrying a rate-limited worker; use `0` to fail immediately |
 
 ## Directory Layout
 
@@ -69,7 +70,7 @@ Run `npm run merge` manually if you need to merge outside of a batch run.
 
 ## Resumability
 
-`batch-state.tsv` tracks the status of every offer (`pending`, `processing`, `completed`, `failed`). If the batch is interrupted, re-running `batch-runner.sh` picks up where it left off -- completed offers are skipped automatically.
+`batch-state.tsv` tracks the status of every offer (`pending`, `processing`, `completed`, `failed`, `skipped`, `rate_limited`). If the batch is interrupted, re-running `batch-runner.sh` picks up where it left off -- completed offers are skipped automatically. `rate_limited` is a non-completed state used while the runner waits before retrying, so interrupted rate-limited jobs are eligible on the next normal run.
 
 A PID-based lock file (`batch-runner.pid`) prevents concurrent batch runs. If a previous run crashed, the stale lock is detected and removed automatically.
 

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -88,12 +88,21 @@ while [[ $# -gt 0 ]]; do
     --start-from) START_FROM="$2"; shift 2 ;;
     --max-retries) MAX_RETRIES="$2"; shift 2 ;;
     --min-score) MIN_SCORE="$2"; shift 2 ;;
-    --rate-limit-sleep) RATE_LIMIT_SLEEP="$2"; shift 2 ;;
+    --rate-limit-sleep)
+      [[ $# -ge 2 ]] || { echo "ERROR: --rate-limit-sleep requires an argument"; exit 1; }
+      RATE_LIMIT_SLEEP="$2"
+      shift 2
+      ;;
     --model) MODEL="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1"; usage; exit 1 ;;
   esac
 done
+
+if ! [[ "$RATE_LIMIT_SLEEP" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: --rate-limit-sleep must be a non-negative integer (seconds)."
+  exit 1
+fi
 
 # Lock file to prevent double execution
 acquire_lock() {
@@ -379,6 +388,7 @@ process_offer() {
   claude_args+=(--append-system-prompt-file "$resolved_prompt" "$prompt")
 
   local exit_code=0
+  local terminal_failure_recorded=false
   while true; do
     exit_code=0
     claude "${claude_args[@]}" > "$log_file" 2>&1 || exit_code=$?
@@ -388,6 +398,12 @@ process_offer() {
     fi
 
     if is_rate_limit_log "$log_file" && (( retries < MAX_RETRIES )); then
+      if (( RATE_LIMIT_SLEEP <= 0 )); then
+        update_state "$id" "$url" "failed" "$started_at" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$report_num" "-" "rate-limit; no wait configured" "$retries"
+        echo "    ❌ Rate limited and --rate-limit-sleep is 0; not retrying."
+        terminal_failure_recorded=true
+        break
+      fi
       retries=$((retries + 1))
       local retry_completed_at
       retry_completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -426,7 +442,7 @@ process_offer() {
 
     update_state "$id" "$url" "completed" "$started_at" "$completed_at" "$report_num" "$score" "-" "$retries"
     echo "    ✅ Completed (score: $score, report: $report_num)"
-  else
+  elif [[ "$terminal_failure_recorded" == "false" ]]; then
     if (( retries < MAX_RETRIES )); then
       retries=$((retries + 1))
     fi

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -399,6 +399,7 @@ process_offer() {
 
     if is_rate_limit_log "$log_file" && (( retries < MAX_RETRIES )); then
       if (( RATE_LIMIT_SLEEP <= 0 )); then
+        retries=$((retries + 1))
         update_state "$id" "$url" "failed" "$started_at" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$report_num" "-" "rate-limit; no wait configured" "$retries"
         echo "    ❌ Rate limited and --rate-limit-sleep is 0; not retrying."
         terminal_failure_recorded=true

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -34,6 +34,7 @@ START_FROM=0
 MAX_RETRIES=2
 MIN_SCORE=0
 MODEL=""  # empty = let claude -p use the Claude Max default
+RATE_LIMIT_SLEEP=300
 
 usage() {
   cat <<'USAGE'
@@ -49,6 +50,8 @@ Options:
   --start-from N       Start from offer ID N (skip earlier IDs)
   --max-retries N      Max retry attempts per offer (default: 2)
   --min-score N        Skip PDF/tracker for offers scoring below N (default: 0 = off)
+  --rate-limit-sleep N Seconds to wait before retrying a rate-limited worker
+                       (default: 300)
   --model NAME         Claude model passed to `claude -p --model` (default:
                        unset = Claude Max default). Use a cheaper model for
                        large batches, e.g. `--model claude-sonnet-4-6`.
@@ -85,6 +88,7 @@ while [[ $# -gt 0 ]]; do
     --start-from) START_FROM="$2"; shift 2 ;;
     --max-retries) MAX_RETRIES="$2"; shift 2 ;;
     --min-score) MIN_SCORE="$2"; shift 2 ;;
+    --rate-limit-sleep) RATE_LIMIT_SLEEP="$2"; shift 2 ;;
     --model) MODEL="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1"; usage; exit 1 ;;
@@ -299,6 +303,11 @@ update_state() {
   run_with_state_lock update_state_unlocked "$@"
 }
 
+is_rate_limit_log() {
+  local log_file="$1"
+  grep -Eiq '(rate limit|rate_limit|too many requests|429|quota exceeded|try again later|temporarily unavailable)' "$log_file"
+}
+
 reserve_report_num_unlocked() {
   local id="$1" url="$2" started="$3" retries="$4"
 
@@ -370,7 +379,26 @@ process_offer() {
   claude_args+=(--append-system-prompt-file "$resolved_prompt" "$prompt")
 
   local exit_code=0
-  claude "${claude_args[@]}" > "$log_file" 2>&1 || exit_code=$?
+  while true; do
+    exit_code=0
+    claude "${claude_args[@]}" > "$log_file" 2>&1 || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+      break
+    fi
+
+    if is_rate_limit_log "$log_file" && (( retries < MAX_RETRIES )); then
+      retries=$((retries + 1))
+      local retry_completed_at
+      retry_completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      update_state "$id" "$url" "rate_limited" "$started_at" "$retry_completed_at" "$report_num" "-" "rate-limit; retrying after ${RATE_LIMIT_SLEEP}s" "$retries"
+      echo "    ⏳ Rate limited (attempt $retries/$MAX_RETRIES). Waiting ${RATE_LIMIT_SLEEP}s before retry..."
+      sleep "$RATE_LIMIT_SLEEP"
+      continue
+    fi
+
+    break
+  done
 
   # Cleanup resolved prompt
   rm -f "$resolved_prompt"
@@ -399,7 +427,9 @@ process_offer() {
     update_state "$id" "$url" "completed" "$started_at" "$completed_at" "$report_num" "$score" "-" "$retries"
     echo "    ✅ Completed (score: $score, report: $report_num)"
   else
-    retries=$((retries + 1))
+    if (( retries < MAX_RETRIES )); then
+      retries=$((retries + 1))
+    fi
     local error_msg
     error_msg=$(tail -5 "$log_file" 2>/dev/null | tr '\n' ' ' | cut -c1-200 || echo "Unknown error (exit code $exit_code)")
     update_state "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries"

--- a/modes/batch.md
+++ b/modes/batch.md
@@ -67,6 +67,7 @@ Options:
 - `--start-from N` — start from ID N
 - `--parallel N` — N workers in parallel
 - `--max-retries N` — attempts per job (default: 2)
+- `--rate-limit-sleep N` — seconds to wait before retrying a rate-limited worker (default: 300; use 0 to fail immediately)
 
 ## batch-state.tsv Format
 
@@ -75,7 +76,10 @@ id	url	status	started_at	completed_at	report_num	score	error	retries
 1	https://...	completed	2026-...	2026-...	002	4.2	-	0
 2	https://...	failed	2026-...	2026-...	-	-	Error msg	1
 3	https://...	pending	-	-	-	-	-	0
+4	https://...	rate_limited	2026-...	2026-...	004	-	rate-limit; retrying after 300s	1
 ```
+
+Valid statuses include `pending`, `processing`, `completed`, `failed`, `skipped`, and `rate_limited`. `rate_limited` is an intermediate non-completed state emitted while the runner waits before retrying; if the run is interrupted there, a later non-`--retry-failed` run treats it as pending work.
 
 ## Resumability
 


### PR DESCRIPTION
## Summary

Fixes #505.

Adds rate-limit handling to `batch/batch-runner.sh`:

- detects common rate-limit signals in worker logs (`429`, `rate limit`, `quota exceeded`, etc.)
- records the state as `rate_limited` while waiting
- waits before retrying the same job/report number
- adds `--rate-limit-sleep N` for tuning the wait period
- keeps retry counts bounded by `--max-retries`

## Validation

- `bash -n batch/batch-runner.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable rate-limit retry behavior with adjustable wait time and an option to treat zero wait as immediate terminal failure.
  * Automatic detection of rate-limit conditions and controlled per-item retry/resume logic, including a new intermediate "rate_limited" state.

* **Documentation**
  * CLI option documented with examples and behavior explained.
  * Batch state format and resume/retry semantics updated to include new statuses and interruption handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->