### PR TITLE
fix(pdf): reject unsafe CV section ordering

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -139,7 +139,7 @@ function extractSourceSectionOrder(markdown) {
   const sections = [];
 
   for (const line of markdown.split(/\r?\n/)) {
-    const heading = line.match(/^\s{0,3}(#{2,6})\s+(.+?)\s*#*\s*$/);
+    const heading = line.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/);
     if (!heading) continue;
     const text = normalizeSectionTitle(heading[2]);
     if (!text) continue;
@@ -209,7 +209,12 @@ async function generatePDF() {
 
   // Read HTML to inject font paths as absolute file:// URLs
   let html = await readFile(inputPath, 'utf-8');
-  const cvMarkdown = await readFile(resolve(__dirname, 'cv.md'), 'utf-8').catch(() => '');
+  let cvMarkdown = '';
+  try {
+    cvMarkdown = await readFile(resolve(__dirname, 'cv.md'), 'utf-8');
+  } catch (err) {
+    if (err?.code !== 'ENOENT') throw err;
+  }
   validateCvSectionOrder(html, cvMarkdown);
 
   // Resolve font paths relative to career-ops/fonts/

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -88,42 +88,86 @@ function normalizeTextForATS(html) {
   }
 }
 
-function validateCvSectionOrder(html) {
-  const canonical = [
-    ['summary', 'professional summary'],
-    ['competencies', 'core competencies'],
-    ['experience', 'work experience', 'professional experience'],
-    ['projects', 'selected projects', 'personal projects'],
-    ['education', 'education & certifications'],
-    ['certifications'],
-    ['skills', 'technical skills'],
-  ];
+const SECTION_ALIASES = new Map([
+  ['summary', 'summary'],
+  ['professional summary', 'summary'],
+  ['competencies', 'competencies'],
+  ['core competencies', 'competencies'],
+  ['experience', 'experience'],
+  ['work experience', 'experience'],
+  ['professional experience', 'experience'],
+  ['projects', 'projects'],
+  ['selected projects', 'projects'],
+  ['personal projects', 'projects'],
+  ['education', 'education'],
+  ['education & certifications', 'education'],
+  ['certifications', 'certifications'],
+  ['skills', 'skills'],
+  ['technical skills', 'skills'],
+]);
+
+function normalizeSectionTitle(text) {
+  return text
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\{\{[^}]+\}\}/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/[*_`~]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function sectionKey(text) {
+  const normalized = normalizeSectionTitle(text);
+  return SECTION_ALIASES.get(normalized) ?? normalized;
+}
+
+function extractRenderedSectionOrder(html) {
   const titleMatches = [...html.matchAll(/class=["'][^"']*\bsection-title\b[^"']*["'][^>]*>([\s\S]*?)<\/[^>]+>/gi)];
-  const seen = [];
+  const sections = [];
 
   for (const match of titleMatches) {
-    const text = match[1]
-      .replace(/<[^>]+>/g, ' ')
-      .replace(/\{\{[^}]+\}\}/g, ' ')
-      .replace(/&amp;/g, '&')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .toLowerCase();
+    const text = normalizeSectionTitle(match[1]);
     if (!text) continue;
-
-    const index = canonical.findIndex(names => names.includes(text));
-    if (index !== -1) seen.push({ index, title: text });
+    sections.push({ key: sectionKey(text), title: text });
   }
 
-  // Only enforce when the generated HTML contains enough recognizable
-  // standard headers. This keeps localized or custom templates from failing
-  // solely because their section labels are different.
-  if (seen.length < 2) return;
+  return sections;
+}
 
-  for (let i = 1; i < seen.length; i++) {
-    if (seen[i].index < seen[i - 1].index) {
-      const order = seen.map(s => s.title).join(' -> ');
-      throw new Error(`CV section order is not ATS-safe: ${order}`);
+function extractSourceSectionOrder(markdown) {
+  const sections = [];
+
+  for (const line of markdown.split(/\r?\n/)) {
+    const heading = line.match(/^\s{0,3}(#{2,6})\s+(.+?)\s*#*\s*$/);
+    if (!heading) continue;
+    const text = normalizeSectionTitle(heading[2]);
+    if (!text) continue;
+    sections.push({ key: sectionKey(text), title: text });
+  }
+
+  return sections;
+}
+
+function validateCvSectionOrder(html, cvMarkdown) {
+  const rendered = extractRenderedSectionOrder(html);
+  const source = extractSourceSectionOrder(cvMarkdown);
+  if (rendered.length < 2 || source.length < 2) return;
+
+  const sourcePositions = new Map(source.map((section, index) => [section.key, index]));
+  const renderedComparable = rendered.filter(section => sourcePositions.has(section.key));
+  if (renderedComparable.length < 2) return;
+
+  for (let i = 1; i < renderedComparable.length; i++) {
+    const previous = renderedComparable[i - 1];
+    const current = renderedComparable[i];
+    if (sourcePositions.get(current.key) < sourcePositions.get(previous.key)) {
+      const renderedOrder = renderedComparable.map(section => section.title).join(' -> ');
+      const sourceOrder = source
+        .filter(section => renderedComparable.some(renderedSection => renderedSection.key === section.key))
+        .map(section => section.title)
+        .join(' -> ');
+      throw new Error(`CV section order diverges from cv.md: rendered ${renderedOrder}; cv.md ${sourceOrder}`);
     }
   }
 }
@@ -165,7 +209,8 @@ async function generatePDF() {
 
   // Read HTML to inject font paths as absolute file:// URLs
   let html = await readFile(inputPath, 'utf-8');
-  validateCvSectionOrder(html);
+  const cvMarkdown = await readFile(resolve(__dirname, 'cv.md'), 'utf-8').catch(() => '');
+  validateCvSectionOrder(html, cvMarkdown);
 
   // Resolve font paths relative to career-ops/fonts/
   const fontsDir = resolve(__dirname, 'fonts');

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -88,6 +88,46 @@ function normalizeTextForATS(html) {
   }
 }
 
+function validateCvSectionOrder(html) {
+  const canonical = [
+    ['summary', 'professional summary'],
+    ['competencies', 'core competencies'],
+    ['experience', 'work experience', 'professional experience'],
+    ['projects', 'selected projects', 'personal projects'],
+    ['education', 'education & certifications'],
+    ['certifications'],
+    ['skills', 'technical skills'],
+  ];
+  const titleMatches = [...html.matchAll(/class=["'][^"']*\bsection-title\b[^"']*["'][^>]*>([\s\S]*?)<\/[^>]+>/gi)];
+  const seen = [];
+
+  for (const match of titleMatches) {
+    const text = match[1]
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\{\{[^}]+\}\}/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toLowerCase();
+    if (!text) continue;
+
+    const index = canonical.findIndex(names => names.includes(text));
+    if (index !== -1) seen.push({ index, title: text });
+  }
+
+  // Only enforce when the generated HTML contains enough recognizable
+  // standard headers. This keeps localized or custom templates from failing
+  // solely because their section labels are different.
+  if (seen.length < 2) return;
+
+  for (let i = 1; i < seen.length; i++) {
+    if (seen[i].index < seen[i - 1].index) {
+      const order = seen.map(s => s.title).join(' -> ');
+      throw new Error(`CV section order is not ATS-safe: ${order}`);
+    }
+  }
+}
+
 async function generatePDF() {
   const args = process.argv.slice(2);
 
@@ -125,6 +165,7 @@ async function generatePDF() {
 
   // Read HTML to inject font paths as absolute file:// URLs
   let html = await readFile(inputPath, 'utf-8');
+  validateCvSectionOrder(html);
 
   // Resolve font paths relative to career-ops/fonts/
   const fontsDir = resolve(__dirname, 'fonts');


### PR DESCRIPTION
## Summary

Fixes #635.

Adds a pre-render guard in `generate-pdf.mjs` that detects standard CV section headers and rejects generated HTML when the recognizable sections are out of ATS-safe order. This prevents a tailored HTML CV from becoming a polished but structurally wrong PDF when an agent accidentally reorders sections.

The check only runs when at least two standard English section headers are recognizable, so localized/custom templates with different labels are not blocked simply for using different wording.

## Validation

- `node --check generate-pdf.mjs`
- bad-order fixture with `Skills` before `Work Experience` fails before PDF rendering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CV section order is now validated during PDF generation; out-of-order sections are detected and reported.
  * Validation runs immediately after the CV content is loaded to surface ordering issues sooner.
  * Missing or unreadable source CV is handled gracefully (treated as empty) during validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->