### PR TITLE
fix(release): keep VERSION in release-please updates

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "simple",
@@ -10,6 +11,10 @@
           "type": "json",
           "path": "package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "generic",
+          "path": "VERSION"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Fixes #588.

Updates `release-please-config.json` so release-please keeps the root `VERSION` file in sync with `package.json`, and sets `include-component-in-tag: false` for the simple single-component release flow.

## Validation

- parsed `release-please-config.json` with Node JSON parser


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release configuration to refine version tagging and management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->