### PR TITLE
fix(gemini): write tracker additions instead of manual rows

### DIFF
--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -31,6 +31,7 @@
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { execFileSync } from 'child_process';
 
 // ---------------------------------------------------------------------------
 // Bootstrap: load .env before anything else
@@ -160,6 +161,23 @@ function nextReportNumber() {
     .filter(n => !isNaN(n));
   if (files.length === 0) return '001';
   return String(Math.max(...files) + 1).padStart(3, '0');
+}
+
+function slugifyCompany(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '') || 'unknown';
+}
+
+function tsvSafe(value) {
+  return String(value ?? '').replace(/[\t\r\n]+/g, ' ').trim();
+}
+
+function normalizedTrackerScore(value) {
+  const clean = tsvSafe(value);
+  if (!clean || clean === '?') return 'N/A';
+  return /\/5$/i.test(clean) ? clean : `${clean}/5`;
 }
 
 // Lazy import — only used when saving
@@ -319,7 +337,7 @@ if (saveReport) {
 
     const num         = nextReportNumber();
     const today       = new Date().toISOString().split('T')[0];
-    const companySlug = company.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    const companySlug = slugifyCompany(company);
     const filename    = `${num}-${companySlug}-${today}.md`;
     const reportPath  = join(PATHS.reports, filename);
     const trackerPath = join(PATHS.trackerAdditions, `${num}-${companySlug}.tsv`);
@@ -340,16 +358,30 @@ ${evaluationText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').tri
 
     writeFileSync(reportPath, reportContent, 'utf-8');
     mkdirSync(PATHS.trackerAdditions, { recursive: true });
-    writeFileSync(
-      trackerPath,
-      `${parseInt(num, 10)}\t${today}\t${company}\t${role}\tEvaluated\t${score}/5\t❌\t[${num}](reports/${filename})\tGemini evaluation; run npm run merge\n`,
-      'utf-8',
-    );
+    const trackerFields = [
+      String(parseInt(num, 10)),
+      today,
+      tsvSafe(company),
+      tsvSafe(role),
+      'Evaluated',
+      normalizedTrackerScore(score),
+      '❌',
+      `[${num}](reports/${filename})`,
+      'Gemini evaluation',
+    ];
+    writeFileSync(trackerPath, `${trackerFields.join('\t')}\n`, 'utf-8');
     console.log(`\n✅  Report saved: reports/${filename}`);
     console.log(`📊  Tracker addition saved: batch/tracker-additions/${num}-${companySlug}.tsv`);
-    console.log('    Run `npm run merge` to update data/applications.md.');
+    const mergeOutput = execFileSync(process.execPath, [join(ROOT, 'merge-tracker.mjs')], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    if (mergeOutput.trim()) console.log(mergeOutput.trim());
+    console.log('📊  Tracker merged into data/applications.md.');
   } catch (err) {
     console.warn(`⚠️   Could not save report: ${err.message}`);
+    process.exitCode = 1;
   }
 }
 

--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -60,6 +60,7 @@ const PATHS = {
   profileYml:  join(ROOT, 'config', 'profile.yml'),
   reports:     join(ROOT, 'reports'),
   tracker:     join(ROOT, 'data', 'applications.md'),
+  trackerAdditions: join(ROOT, 'batch', 'tracker-additions'),
 };
 
 // ---------------------------------------------------------------------------
@@ -321,6 +322,7 @@ if (saveReport) {
     const companySlug = company.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
     const filename    = `${num}-${companySlug}-${today}.md`;
     const reportPath  = join(PATHS.reports, filename);
+    const trackerPath = join(PATHS.trackerAdditions, `${num}-${companySlug}.tsv`);
 
     const reportContent = `# Evaluation: ${company} — ${role}
 
@@ -337,11 +339,15 @@ ${evaluationText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').tri
 `;
 
     writeFileSync(reportPath, reportContent, 'utf-8');
+    mkdirSync(PATHS.trackerAdditions, { recursive: true });
+    writeFileSync(
+      trackerPath,
+      `${parseInt(num, 10)}\t${today}\t${company}\t${role}\tEvaluated\t${score}/5\t❌\t[${num}](reports/${filename})\tGemini evaluation; run npm run merge\n`,
+      'utf-8',
+    );
     console.log(`\n✅  Report saved: reports/${filename}`);
-
-    // Append tracker entry reminder
-    console.log(`\n📊  Tracker entry (add to data/applications.md):`);
-    console.log(`    | ${num} | ${today} | ${company} | ${role} | ${score} | Evaluada | ❌ | [${num}](reports/${filename}) |`);
+    console.log(`📊  Tracker addition saved: batch/tracker-additions/${num}-${companySlug}.tsv`);
+    console.log('    Run `npm run merge` to update data/applications.md.');
   } catch (err) {
     console.warn(`⚠️   Could not save report: ${err.message}`);
   }


### PR DESCRIPTION
## Summary

`gemini-eval.mjs` now follows the tracker data contract after saving a report:

- writes a TSV file to `batch/tracker-additions/`
- uses canonical `Evaluated` status
- keeps the report link root-relative for `merge-tracker.mjs` normalization
- stops telling users to manually edit `data/applications.md`

This keeps Gemini-generated evaluations on the same merge path as batch/agent evaluations.

## Validation

- `node --check gemini-eval.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tracker additions are now automatically written to designated files with evaluation status, score, and report link information.
  * Console output updated to confirm file locations instead of displaying manual entry reminders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->