### PR TITLE
fix(apply): preserve form field contracts

### DIFF
--- a/modes/apply.md
+++ b/modes/apply.md
@@ -87,19 +87,9 @@ Based on: Report #NNN | Score: X.X/5 | Archetype: [type]
 ---
 
 ### 1. [Exact form question]
-Field: [field_type] | Required: [yes/no/unknown] | Limit: [limit/unknown]
-Options: [for select/radio/checkbox; otherwise N/A]
-Needs candidate confirmation: [yes/no]
-
-Recommended answer:
-> [Response ready for copy-paste, or "Ask candidate: ..."]
-
-Why this answer:
-[1-2 sentences grounded in the report/CV/JD, or explain why confirmation is required]
+> [Response ready for copy-paste, or "Ask candidate: ..." if the field needs confirmation]
 
 ### 2. [Next question]
-Field: ...
-Recommended answer:
 > [Response]
 
 ...

--- a/modes/apply.md
+++ b/modes/apply.md
@@ -65,7 +65,7 @@ For each field, preserve the application form contract:
 - `options`: visible options for select/radio/checkbox fields
 - `needs_candidate_confirmation`: `yes` for legal, demographic, work authorization, visa, relocation, salary, disability, veteran, sponsorship, background-check, or self-identification questions unless the answer is explicitly present in `config/profile.yml`
 
-Never invent answers for legal/work-authorization/self-identification fields. If the answer is not present in `config/profile.yml` or visible context, mark it as needing candidate confirmation and provide the safest question to ask the candidate.
+Never invent answers for legal, demographic, work-authorization, visa/sponsorship, salary, disability, veteran, background-check, relocation, or self-identification fields. If the answer is not present in `config/profile.yml` or visible context, mark it as needing candidate confirmation and provide the safest question to ask the candidate.
 
 ## Step 5 — Generate responses
 

--- a/modes/apply.md
+++ b/modes/apply.md
@@ -58,6 +58,15 @@ Classify each question:
 - **Already answered in Section G** → adapt the existing response
 - **New question** → generate response from the report + cv.md
 
+For each field, preserve the application form contract:
+- `field_type`: `text`, `textarea`, `select`, `radio`, `checkbox`, `number`, `file`, or `unknown`
+- `required`: `yes`, `no`, or `unknown`
+- `limit`: exact character/word limit if visible; otherwise `unknown`
+- `options`: visible options for select/radio/checkbox fields
+- `needs_candidate_confirmation`: `yes` for legal, demographic, work authorization, visa, relocation, salary, disability, veteran, sponsorship, background-check, or self-identification questions unless the answer is explicitly present in `config/profile.yml`
+
+Never invent answers for legal/work-authorization/self-identification fields. If the answer is not present in `config/profile.yml` or visible context, mark it as needing candidate confirmation and provide the safest question to ask the candidate.
+
 ## Step 5 — Generate responses
 
 For each question, generate the response following:
@@ -78,9 +87,19 @@ Based on: Report #NNN | Score: X.X/5 | Archetype: [type]
 ---
 
 ### 1. [Exact form question]
-> [Response ready for copy-paste]
+Field: [field_type] | Required: [yes/no/unknown] | Limit: [limit/unknown]
+Options: [for select/radio/checkbox; otherwise N/A]
+Needs candidate confirmation: [yes/no]
+
+Recommended answer:
+> [Response ready for copy-paste, or "Ask candidate: ..."]
+
+Why this answer:
+[1-2 sentences grounded in the report/CV/JD, or explain why confirmation is required]
 
 ### 2. [Next question]
+Field: ...
+Recommended answer:
 > [Response]
 
 ...


### PR DESCRIPTION
## Summary

Fixes #699.

Tightens apply mode so generated answers align with the actual application form fields instead of treating every question as free text. The mode now requires field type, required/optional state, visible limits, options, and a candidate-confirmation flag for sensitive/legal fields.

It also explicitly forbids inventing answers for work authorization, sponsorship, demographic, salary, and self-identification questions unless the answer is present in profile/config or visible context.

## Validation

- reviewed `modes/apply.md` diff for mode-only behavior change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified per-form field contracts: field type, required, limits, options, and a new needs_candidate_confirmation flag.
  * Strengthened safeguards to avoid inventing answers for sensitive questions (legal, demographic, work-authorization/visa/sponsorship, salary, disability, veteran, background-check, relocation, self-identification) unless present in profile or visible context.
  * Updated response templates to support direct copy-paste answers or explicit "Ask candidate: …" prompts when confirmation is needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->