### PR TITLE
feat(scan): VC portfolio-board + ATS providers, global freshness filter, title-filter acronym fix

### DIFF
--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -46,3 +46,28 @@ export function makeHttpCtx() {
     fetchText,
   };
 }
+
+// Normalize a posting date to epoch milliseconds (or null if absent/unparseable).
+// Accepts ISO strings ("2026-05-22T16:05:41-04:00"), epoch seconds (~1.7e9),
+// and epoch milliseconds (~1.7e12). Used by providers to populate Job.posted_at
+// so scan.mjs can apply the freshness_filter uniformly. null = "no date" = keep.
+export function toEpochMs(value) {
+  if (value == null) return null;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0) return null;
+    return value < 1e12 ? value * 1000 : value; // < 1e12 ⇒ seconds
+  }
+  if (typeof value === 'string') {
+    const s = value.trim();
+    // Numeric timestamp strings ("1710000000" / "1710000000000") — Date.parse
+    // would return NaN for these, so handle them like the numeric branch.
+    if (/^\d+$/.test(s)) {
+      const n = Number(s);
+      if (!Number.isFinite(n) || n <= 0) return null;
+      return n < 1e12 ? n * 1000 : n;
+    }
+    const t = Date.parse(s);
+    return Number.isNaN(t) ? null : t;
+  }
+  return null;
+}

--- a/providers/ashby.mjs
+++ b/providers/ashby.mjs
@@ -14,6 +14,8 @@
 const ASHBY_TIMEOUT_MS = 30_000;
 const ASHBY_RETRIES = 2;
 
+import { toEpochMs } from './_http.mjs';
+
 function resolveApiUrl(entry) {
   const url = entry.careers_url || '';
   const match = url.match(/jobs\.ashbyhq\.com\/([^/?#]+)/);
@@ -51,6 +53,7 @@ export default {
           url: j.jobUrl || '',
           company: entry.name,
           location: j.location || '',
+          posted_at: toEpochMs(j.publishedAt || j.updatedAt),
         }));
       } catch (e) {
         lastErr = e;

--- a/providers/consider.mjs
+++ b/providers/consider.mjs
@@ -1,0 +1,100 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Consider provider — VC "talent network" portfolio boards on getconsider.com
+// (Founderful, Creandum, Balderton, Lightspeed, Notion Capital, …). The board
+// is a JS app, but its data comes from a same-origin JSON endpoint we can hit
+// directly (discovered via a headless capture of the board's network calls):
+//
+//   POST {board_origin}/api-boards/search-jobs
+//   body: {"meta":{"size":N},"board":{"id":"<board_id>","isParent":true},
+//          "query":{"promoteFeatured":true}}
+//   -> { jobs: [ {title,url,applyUrl,companyName,locations[],timeStamp,remote} ], total }
+//
+// `url` is the clean destination ATS link (dedups with the ashby/greenhouse
+// providers); `companyName` is the portfolio company. The board id is NOT the
+// host (Founderful's is "wingman"), so set it explicitly in portals.yml:
+//
+//   - name: Founderful (portfolio)
+//     provider: consider
+//     consider_board: wingman
+//     careers_url: https://jobs.founderful.com/jobs
+//     enabled: true
+//
+// `consider_size` (default 500) caps how many newest/featured jobs are pulled in
+// the single request. Boards larger than that are truncated (rare for VC boards).
+
+import { toEpochMs } from './_http.mjs';
+
+const ENDPOINT_PATH = '/api-boards/search-jobs';
+const DEFAULT_SIZE = 500;
+
+function resolveOrigin(entry) {
+  const url = entry.careers_url || '';
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function locationString(job) {
+  if (Array.isArray(job.locations) && job.locations.length) {
+    return job.locations.filter(l => typeof l === 'string').join(', ');
+  }
+  if (Array.isArray(job.normalizedLocations) && job.normalizedLocations.length) {
+    return job.normalizedLocations.map(l => l?.label || l?.value).filter(Boolean).join(', ');
+  }
+  return job.remote ? 'Remote' : '';
+}
+
+/** @type {Provider} */
+export default {
+  id: 'consider',
+
+  detect(entry) {
+    const origin = resolveOrigin(entry);
+    return entry.consider_board && origin ? { url: origin + ENDPOINT_PATH } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const origin = resolveOrigin(entry);
+    if (!origin) throw new Error(`consider: ${entry.name} needs a valid careers_url`);
+    if (!entry.consider_board) throw new Error(`consider: ${entry.name} needs a 'consider_board' id in portals.yml`);
+    const size = Number.isInteger(entry.consider_size) && entry.consider_size > 0 ? entry.consider_size : DEFAULT_SIZE;
+
+    const json = await ctx.fetchJson(origin + ENDPOINT_PATH, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json', referer: origin + '/jobs' },
+      body: JSON.stringify({
+        meta: { size },
+        board: { id: String(entry.consider_board), isParent: true },
+        query: { promoteFeatured: true },
+      }),
+    });
+
+    const jobs = Array.isArray(json?.jobs) ? json.jobs : [];
+    return jobs
+      .map(j => {
+        const rawUrl = j.url || j.applyUrl || '';
+        if (!rawUrl) return null;
+        // Normalize to an absolute URL so the dedup key matches what the
+        // ashby/greenhouse providers emit (Consider returns absolute ATS links,
+        // but resolve defensively in case a relative path ever appears).
+        let url;
+        try {
+          url = new URL(rawUrl, origin).toString();
+        } catch {
+          return null;
+        }
+        return {
+          title: j.title || '',
+          url,
+          company: j.companyName || entry.name,
+          location: locationString(j),
+          posted_at: toEpochMs(j.timeStamp),
+        };
+      })
+      .filter(Boolean);
+  },
+};

--- a/providers/getro.mjs
+++ b/providers/getro.mjs
@@ -1,0 +1,106 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Getro provider — VC "talent network" portfolio job boards (jobs at a fund's
+// portfolio companies). Powers b2venture, Earlybird, Point Nine, Speedinvest,
+// Cherry, HV Capital, Atomico, and many other VC boards.
+//
+// The public search API is:
+//   POST https://api.getro.com/api/v2/collections/{collection_id}/search/jobs
+//   body: {"hitsPerPage":N,"page":P}
+//   -> { results: { jobs: [ {title,url,organization:{name},locations[],created_at} ], count } }
+//
+// A board's numeric collection_id is the `network.id` embedded in the board
+// page's __NEXT_DATA__. We don't derive it from the URL — set it explicitly in
+// portals.yml:
+//
+//   - name: b2venture (portfolio)
+//     provider: getro
+//     getro_collection: 4283
+//     careers_url: https://jobs.b2venture.vc   # reference only
+//     enabled: true
+//
+// These boards are large (1000-2000 jobs) but the API returns them
+// created_at-DESCENDING (newest first), so we paginate newest-first and STOP
+// once postings fall older than `getro_max_age_days`. This is a PAGINATION
+// BOUND for efficiency (don't page through 2000 stale jobs) — the real recency
+// cut is the global freshness_filter in scan.mjs, which reads each job's
+// `posted_at`. The bound default (90d) is kept comfortably wider than the
+// usual 60d freshness window so it never pre-trims jobs the global filter would
+// keep. `getro_max_pages` (default 40) is a hard safety cap. Jobs with no
+// created_at are kept (same "missing data = pass" rule as the location filter).
+
+const API_BASE = 'https://api.getro.com/api/v2/collections';
+const HITS_PER_PAGE = 20;          // API hard-caps page size at 20
+const DEFAULT_MAX_PAGES = 40;      // safety cap: 40 x 20 = 800 newest jobs/board
+const DEFAULT_MAX_AGE_DAYS = 90;   // pagination bound only; global filter does the real cut
+
+function resolveCollection(entry) {
+  const id = entry.getro_collection;
+  if (id == null) return null;
+  const s = String(id).trim();
+  if (!/^\d+$/.test(s)) return null;
+  return s;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'getro',
+
+  detect(entry) {
+    const id = resolveCollection(entry);
+    return id ? { url: `${API_BASE}/${id}/search/jobs` } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const id = resolveCollection(entry);
+    if (!id) throw new Error(`getro: ${entry.name} needs a numeric 'getro_collection' in portals.yml`);
+    const apiUrl = `${API_BASE}/${id}/search/jobs`;
+    const maxPages = Number.isInteger(entry.getro_max_pages) && entry.getro_max_pages > 0
+      ? entry.getro_max_pages : DEFAULT_MAX_PAGES;
+    const maxAgeDays = Number.isFinite(entry.getro_max_age_days) && entry.getro_max_age_days >= 0
+      ? entry.getro_max_age_days : DEFAULT_MAX_AGE_DAYS;
+    const cutoff = maxAgeDays > 0 ? Math.floor(Date.now() / 1000) - maxAgeDays * 86400 : 0;
+
+    const out = [];
+    let total = Infinity;
+    for (let page = 0; page < maxPages && page * HITS_PER_PAGE < total; page++) {
+      const json = await ctx.fetchJson(apiUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
+        body: JSON.stringify({ hitsPerPage: HITS_PER_PAGE, page }),
+      });
+      const results = json?.results || {};
+      const jobs = Array.isArray(results.jobs) ? results.jobs : [];
+      if (typeof results.count === 'number') total = results.count;
+      if (jobs.length === 0) break;
+
+      let reachedOld = false;
+      for (const j of jobs) {
+        const url = j.url || '';
+        if (!url) continue;
+        // Jobs are newest-first; a dated posting older than the cutoff (and
+        // everything after it) is stale. Keep undated jobs (missing = pass).
+        const created = Number(j.created_at);
+        if (cutoff > 0 && Number.isFinite(created) && created > 0 && created < cutoff) {
+          reachedOld = true;
+          continue;
+        }
+        out.push({
+          title: j.title || '',
+          url,
+          // Portfolio jobs belong to the portfolio company, not the fund —
+          // expose the real employer so dedup and the tracker read correctly.
+          company: j.organization?.name || j.organization_name || entry.name,
+          location: (Array.isArray(j.locations) && j.locations[0])
+            || (Array.isArray(j.searchable_locations) && j.searchable_locations[0])
+            || '',
+          posted_at: Number.isFinite(created) && created > 0 ? created * 1000 : null,
+        });
+      }
+      // Once we've crossed the age cutoff, all later pages are older still.
+      if (reachedOld) break;
+    }
+    return out;
+  },
+};

--- a/providers/greenhouse.mjs
+++ b/providers/greenhouse.mjs
@@ -4,6 +4,8 @@
 // Greenhouse provider — hits the public boards-api JSON endpoint.
 // Handles both explicit `api:` URLs and auto-detection from `careers_url`.
 
+import { toEpochMs } from './_http.mjs';
+
 const ALLOWED_GREENHOUSE_HOSTS = new Set([
   'boards-api.greenhouse.io',
   'boards.greenhouse.io',
@@ -30,7 +32,8 @@ function resolveApiUrl(entry) {
     return entry.api;
   }
   const url = entry.careers_url || '';
-  const match = url.match(/job-boards(?:\.eu)?\.greenhouse\.io\/([^/?#]+)/);
+  // Accept both job-boards[.eu].greenhouse.io/<slug> and boards.greenhouse.io/<slug>.
+  const match = url.match(/(?:job-boards(?:\.eu)?|boards)\.greenhouse\.io\/([^/?#]+)/);
   if (match) return `https://boards-api.greenhouse.io/v1/boards/${match[1]}/jobs`;
   return null;
 }
@@ -61,6 +64,7 @@ export default {
       url: j.absolute_url,
       company: entry.name,
       location: j.location?.name || '',
+      posted_at: toEpochMs(j.updated_at || j.first_published),
     }));
   },
 };

--- a/providers/joinup.mjs
+++ b/providers/joinup.mjs
@@ -1,0 +1,52 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// joinup.ch provider — Swiss startup job platform (Typesense-backed Next.js).
+//
+// The browse page server-renders the newest page of results into __NEXT_DATA__
+// at props.pageProps.serverState.initialResults.jobs.results[0].hits[]. The
+// full board (~1000 jobs) lives behind a Typesense search key that is injected
+// at runtime (not in the static bundle), so we read the SSR'd newest page —
+// since results are created-DESC this reliably catches the latest postings,
+// which is what a periodic scan needs. Most older joinup roles are also tracked
+// directly via their company's ATS (Getro/Personio/Ashby/etc.).
+//
+// Each hit: { title|headline, startup (employer), slug, location, created }.
+// Public posting URL: https://joinup.ch/job/{slug}
+//
+// Auto-detects from a careers_url containing `joinup.ch`.
+
+const BROWSE_URL = 'https://joinup.ch/browse/jobs';
+
+/** @type {Provider} */
+export default {
+  id: 'joinup',
+
+  detect(entry) {
+    const url = entry.careers_url || '';
+    return /joinup\.ch/i.test(url) ? { url: BROWSE_URL } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const html = await ctx.fetchText(BROWSE_URL);
+    const m = html.match(/<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/);
+    if (!m) return [];
+    let hits = [];
+    try {
+      const data = JSON.parse(m[1]);
+      const ir = data?.props?.pageProps?.serverState?.initialResults?.jobs?.results;
+      hits = Array.isArray(ir) && ir[0]?.hits ? ir[0].hits : [];
+    } catch {
+      return [];
+    }
+    return hits
+      .filter(h => h && h.slug && (h.title || h.headline))
+      .map(h => ({
+        title: h.title || h.headline || '',
+        url: `https://joinup.ch/job/${h.slug}`,
+        company: h.startup || entry.name || '',
+        location: typeof h.location === 'string' ? h.location
+          : (h.location?.name || h.location?.city || ''),
+      }));
+  },
+};

--- a/providers/lever.mjs
+++ b/providers/lever.mjs
@@ -4,6 +4,8 @@
 // Lever provider — hits the public postings endpoint.
 // Auto-detects from careers_url pattern `https://jobs.lever.co/<slug>`.
 
+import { toEpochMs } from './_http.mjs';
+
 function resolveApiUrl(entry) {
   const url = entry.careers_url || '';
   const match = url.match(/jobs\.lever\.co\/([^/?#]+)/);
@@ -30,6 +32,7 @@ export default {
       url: j.hostedUrl || '',
       company: entry.name,
       location: j.categories?.location || '',
+      posted_at: toEpochMs(j.createdAt),
     }));
   },
 };

--- a/providers/personio.mjs
+++ b/providers/personio.mjs
@@ -1,0 +1,45 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Personio provider — hits the public `search.json` feed of a Personio careers
+// subdomain. Used by Swiss/DACH employers (e.g. AMINA/SEBA Bank) and many
+// startups whose careers pages are `{slug}.jobs.personio.com` / `.de`.
+//
+// Feed: https://{slug}.jobs.personio.com/search.json
+//   -> [ { id, name, office, employment_type, seniority, ... } ]   (array)
+// Public posting URL: https://{slug}.jobs.personio.com/job/{id}
+//
+// Auto-detects from careers_url; no extra config needed.
+
+function resolveSlugHost(entry) {
+  const url = entry.careers_url || entry.api || '';
+  const m = url.match(/https?:\/\/([a-z0-9-]+)\.jobs\.personio\.(com|de)/i);
+  if (!m) return null;
+  return { slug: m[1], tld: m[2] };
+}
+
+/** @type {Provider} */
+export default {
+  id: 'personio',
+
+  detect(entry) {
+    const r = resolveSlugHost(entry);
+    return r ? { url: `https://${r.slug}.jobs.personio.${r.tld}/search.json` } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const r = resolveSlugHost(entry);
+    if (!r) throw new Error(`personio: cannot derive slug for ${entry.name} (need {slug}.jobs.personio.com careers_url)`);
+    const base = `https://${r.slug}.jobs.personio.${r.tld}`;
+    const json = await ctx.fetchJson(`${base}/search.json`, { headers: { accept: 'application/json' } });
+    const positions = Array.isArray(json) ? json : (Array.isArray(json?.positions) ? json.positions : []);
+    return positions
+      .filter(p => p && p.id != null)
+      .map(p => ({
+        title: p.name || p.title || '',
+        url: `${base}/job/${p.id}`,
+        company: entry.name,
+        location: p.office || p.location || '',
+      }));
+  },
+};

--- a/providers/startupch.mjs
+++ b/providers/startupch.mjs
@@ -1,0 +1,103 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// startup.ch provider — the Swiss Startup Association job board. Server-rendered
+// ColdFusion page; all current listings are in one HTML response (no JS board).
+//
+// Each listing is a `.white-box.startup-box` card with:
+//   <a href="index.cfm?...&profil_id={pid}&JobID={jid}#job_{jid}">
+//   <img ... alt="{Company} AG" />            <- employer
+//   <h4 class="top10-title ...">{Title}</h4>  <- role
+//   <p class="d-inline-flex mb-1">{City}</p>  <- location (after location.png)
+//
+// The href carries a per-request CFID/CFTOKEN session — we strip it and build a
+// canonical, session-free URL so the dedup key is stable across scans.
+//
+// startup.ch has light anti-bot behaviour: it 200s an error page to bot-ish
+// user agents and under bursty load. We therefore (a) send real browser
+// headers, (b) prime a session cookie from the homepage first, and (c) throw a
+// descriptive error if the error page comes back — so the scan logs it (visible,
+// retried next run) instead of silently reporting zero jobs.
+//
+// Auto-detects from a careers_url containing `startup.ch`.
+
+const HOME_URL = 'https://www.startup.ch/';
+const LIST_URL = 'https://www.startup.ch/jobs';
+const BROWSER_HEADERS = {
+  'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  'accept-language': 'en-US,en;q=0.9,de;q=0.8',
+};
+
+function decodeEntities(s) {
+  return s
+    .replace(/&amp;/g, '&').replace(/&#39;/g, "'").replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"').replace(/&auml;/g, 'ä').replace(/&ouml;/g, 'ö')
+    .replace(/&uuml;/g, 'ü').replace(/&nbsp;/g, ' ').trim();
+}
+
+async function fetchWithTimeout(url, headers, timeoutMs = 12000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { headers, redirect: 'follow', signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** @type {Provider} */
+export default {
+  id: 'startupch',
+
+  detect(entry) {
+    const url = entry.careers_url || '';
+    return /startup\.ch/i.test(url) ? { url: LIST_URL } : null;
+  },
+
+  async fetch(entry /* , ctx */) {
+    // Prime a CFID/CFTOKEN session from the homepage (best-effort).
+    let cookie = '';
+    try {
+      const home = await fetchWithTimeout(HOME_URL, BROWSER_HEADERS);
+      const setCookies = typeof home.headers.getSetCookie === 'function'
+        ? home.headers.getSetCookie()
+        : [home.headers.get('set-cookie')].filter(Boolean);
+      cookie = setCookies.map(c => c.split(';')[0]).join('; ');
+    } catch { /* proceed without a primed cookie */ }
+
+    const res = await fetchWithTimeout(LIST_URL, { ...BROWSER_HEADERS, ...(cookie ? { cookie } : {}) });
+    const html = await res.text();
+
+    const chunks = html.split(/white-box startup-box/i).slice(1);
+    if (chunks.length === 0) {
+      // Distinguish the anti-bot/error page from a genuinely empty board so the
+      // scan surfaces it rather than silently reporting zero.
+      if (/unerwarteter Fehler|<title>\s*Error\s*<\/title>/i.test(html)) {
+        throw new Error('startup.ch returned an error/anti-bot page (likely rate-limited) — retry next scan');
+      }
+      return [];
+    }
+
+    const out = [];
+    const seen = new Set();
+    for (const chunk of chunks) {
+      const card = chunk.slice(0, 2000);
+      const jid = card.match(/JobID=(\d+)/)?.[1];
+      if (!jid || seen.has(jid)) continue;
+      const pid = card.match(/profil_id=(\d+)/)?.[1] || '';
+      const title = card.match(/<h4[^>]*top10-title[^>]*>([^<]+)<\/h4>/i)?.[1];
+      if (!title) continue;
+      const company = (card.match(/alt="([^"]+)"/i)?.[1] || entry.name || '').trim();
+      const location = card.match(/location\.png[\s\S]{0,160}?<p[^>]*>([^<]+)<\/p>/i)?.[1] || '';
+      seen.add(jid);
+      out.push({
+        title: decodeEntities(title),
+        url: `https://www.startup.ch/index.cfm?page=137888${pid ? `&profil_id=${pid}` : ''}&JobID=${jid}`,
+        company: decodeEntities(company),
+        location: decodeEntities(location),
+      });
+    }
+    return out;
+  },
+};

--- a/scan.mjs
+++ b/scan.mjs
@@ -118,14 +118,27 @@ function resolveProvider(entry, providers, { skipIds = [] } = {}) {
 
 // ── Title filter ────────────────────────────────────────────────────
 
-function buildTitleFilter(titleFilter) {
-  const positive = (titleFilter?.positive || []).map(k => k.toLowerCase());
-  const negative = (titleFilter?.negative || []).map(k => k.toLowerCase());
+// Compile a lowercased keyword into a matcher. Short all-letter acronyms
+// (2-3 chars: cfo, coo, sdr, bdr, gsi…) match on WORD BOUNDARIES so "COO" no
+// longer matches "Coordinator", "SDR" no longer matches anything mid-word, etc.
+// Multi-word phrases and keywords containing non-letters (".NET", "SAP ",
+// "L&D") keep fast, permissive substring matching.
+export function compileKeyword(kw) {
+  if (/^[a-z]{2,3}$/.test(kw)) {
+    const re = new RegExp(`\\b${kw}\\b`);
+    return (lower) => re.test(lower);
+  }
+  return (lower) => lower.includes(kw);
+}
+
+export function buildTitleFilter(titleFilter) {
+  const positive = (titleFilter?.positive || []).map(k => k.toLowerCase()).map(compileKeyword);
+  const negative = (titleFilter?.negative || []).map(k => k.toLowerCase()).map(compileKeyword);
 
   return (title) => {
-    const lower = title.toLowerCase();
-    const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
-    const hasNegative = negative.some(k => lower.includes(k));
+    const lower = (title || '').toLowerCase();
+    const hasPositive = positive.length === 0 || positive.some(m => m(lower));
+    const hasNegative = negative.some(m => m(lower));
     return hasPositive && !hasNegative;
   };
 }
@@ -170,6 +183,24 @@ export function buildLocationFilter(locationFilter) {
     if (block.length > 0 && block.some(k => lower.includes(k))) return false;
     if (allow.length === 0) return true;
     return allow.some(k => lower.includes(k));
+  };
+}
+
+// ── Freshness filter ────────────────────────────────────────────────
+// Optional. Drops postings older than `freshness_filter.max_age_days`, based on
+// each job's provider-supplied `posted_at` (epoch ms via providers/_http.mjs
+// toEpochMs). Jobs with no `posted_at` are kept (missing = pass, same rule as
+// the location filter). `max_age_days` <= 0 / absent / non-numeric disables it.
+// Providers without an authoritative date (personio, workday, bamboohr) return
+// no posted_at, so their jobs always pass — the filter only acts where the date
+// is trustworthy (greenhouse, ashby, lever, workable, recruitee, getro, teamtailor).
+export function buildFreshnessFilter(freshnessFilter) {
+  const maxAgeDays = Number(freshnessFilter?.max_age_days);
+  if (!Number.isFinite(maxAgeDays) || maxAgeDays <= 0) return () => true;
+  const cutoff = Date.now() - maxAgeDays * 86_400_000;
+  return (postedAt) => {
+    if (postedAt == null || !Number.isFinite(postedAt)) return true;
+    return postedAt >= cutoff;
   };
 }
 
@@ -398,6 +429,9 @@ async function main() {
   const companies = config.tracked_companies || [];
   const titleFilter = buildTitleFilter(config.title_filter);
   const locationFilter = buildLocationFilter(config.location_filter);
+  const freshnessFilter = buildFreshnessFilter(config.freshness_filter);
+  const maxAgeDays = Number(config.freshness_filter?.max_age_days);
+  const freshnessActive = Number.isFinite(maxAgeDays) && maxAgeDays > 0;
 
   // 3. Resolve a provider for each enabled company
   const targets = [];
@@ -430,6 +464,7 @@ async function main() {
   let totalFound = 0;
   let totalFilteredTitle = 0;
   let totalFilteredLocation = 0;
+  let totalFilteredStale = 0;
   let totalDupes = 0;
   const newOffers = [];
   const errors = [...resolveErrors];
@@ -466,6 +501,10 @@ async function main() {
         }
         if (!locationFilter(job.location)) {
           totalFilteredLocation++;
+          continue;
+        }
+        if (!freshnessFilter(job.posted_at)) {
+          totalFilteredStale++;
           continue;
         }
         if (seenUrls.has(job.url)) {
@@ -540,6 +579,9 @@ async function main() {
   console.log(`Total jobs found:      ${totalFound}`);
   console.log(`Filtered by title:     ${totalFilteredTitle} removed`);
   console.log(`Filtered by location:  ${totalFilteredLocation} removed`);
+  if (freshnessActive) {
+    console.log(`Filtered by age:       ${totalFilteredStale} removed (>${maxAgeDays}d old)`);
+  }
   console.log(`Duplicates:            ${totalDupes} skipped`);
   if (verify) {
     console.log(`Expired (verified):    ${expiredOffers.length} dropped`);

--- a/scripts/test-new-providers.mjs
+++ b/scripts/test-new-providers.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Smoke test for the custom providers added 2026-06-08 (Remo's fork).
+// Run: node scripts/test-new-providers.mjs
+// Validates each provider still returns well-formed jobs against live sources.
+// Hits real networks — expect a few seconds. Non-zero exit if a provider breaks.
+
+import { makeHttpCtx } from '../providers/_http.mjs';
+import getro from '../providers/getro.mjs';
+import personio from '../providers/personio.mjs';
+import workable from '../providers/workable.mjs';
+import recruitee from '../providers/recruitee.mjs';
+import consider from '../providers/consider.mjs';
+import startupch from '../providers/startupch.mjs';
+import joinup from '../providers/joinup.mjs';
+
+const ctx = makeHttpCtx();
+let failures = 0;
+
+async function check(label, provider, entry, { minJobs = 0, soft = false } = {}) {
+  try {
+    const jobs = await provider.fetch(entry, ctx);
+    const malformed = jobs.filter(j => !j.title || !j.url || typeof j.company !== 'string');
+    const ok = jobs.length >= minJobs && malformed.length === 0;
+    console.log(`${ok ? '✅' : (soft ? '⚠️' : '❌')} ${label}: ${jobs.length} jobs${malformed.length ? `, ${malformed.length} malformed` : ''}`);
+    if (jobs[0]) console.log(`     e.g. ${jobs[0].company} — ${jobs[0].title} (${jobs[0].location || 'N/A'})`);
+    if (!ok && !soft) failures++;
+  } catch (e) {
+    // soft providers (anti-bot sites) may intermittently block — warn, don't fail.
+    console.log(`${soft ? '⚠️' : '❌'} ${label}: ${soft ? 'transient' : 'ERROR'} ${e.message}`);
+    if (!soft) failures++;
+  }
+}
+
+console.log('Custom provider smoke test\n');
+await check('getro / b2venture(4283)', getro, { name: 'b2venture', getro_collection: 4283, getro_max_pages: 2 }, { minJobs: 1 });
+await check('getro / Cherry(44081)', getro, { name: 'Cherry', getro_collection: 44081, getro_max_pages: 2 }, { minJobs: 1 });
+await check('personio / AMINA', personio, { name: 'AMINA Bank', careers_url: 'https://amina.jobs.personio.com/' }, { minJobs: 1 });
+await check('workable / Hugging Face', workable, { name: 'Hugging Face', careers_url: 'https://apply.workable.com/huggingface/' }, { minJobs: 1 });
+await check('recruitee / HV Capital', recruitee, { name: 'HV Capital', careers_url: 'https://hvcapital.recruitee.com/' });  // may be 0 open
+await check('consider / Founderful(wingman)', consider, { name: 'Founderful', consider_board: 'wingman', careers_url: 'https://jobs.founderful.com/jobs' }, { minJobs: 1 });
+await check('startupch', startupch, { name: 'startup.ch', careers_url: 'https://www.startup.ch/jobs' }, { minJobs: 1, soft: true });
+await check('joinup', joinup, { name: 'joinup.ch', careers_url: 'https://joinup.ch/browse/jobs' }, { minJobs: 1 });
+
+console.log(`\n${failures === 0 ? 'All providers OK' : failures + ' provider(s) FAILED'}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Adds seven zero-token provider plugins and re-applies the `freshness_filter` that
regressed when scanning moved to the `providers/` plugin architecture in v1.8.

Hi @santifer 👋 — first off, thank you for open-sourcing this. I've been using it
for my own search (Swiss operator / AI-builder / VC roles) and the biggest gap was
**VC portfolio job boards** and a few ATS platforms the plugin layer didn't cover
yet. This PR closes that, all still pure HTTP/JSON (no LLM tokens).

### New providers (`providers/*.mjs`)
| id | source | endpoint |
|----|--------|----------|
| `getro` | VC "talent network" portfolio boards (Getro) | `POST api.getro.com/api/v2/collections/{id}/search/jobs` |
| `consider` | VC portfolio boards on Consider/getconsider.com | `POST {board}/api-boards/search-jobs` |
| `personio` | `{slug}.jobs.personio.com` | `GET /search.json` |
| `workable` | `apply.workable.com/{slug}` | `POST /api/v3/accounts/{slug}/jobs` |
| `recruitee` | `{slug}.recruitee.com` | `GET /api/offers/` |
| `startupch` | startup.ch (Swiss Startup Association) | HTML parse + browser headers + session prime |
| `joinup` | joinup.ch (Swiss startup platform) | newest SSR page from `__NEXT_DATA__` |

`personio`/`recruitee`/`workable` auto-detect from `careers_url`, so existing
tracked companies on those ATSes upgrade to zero-token with no config change.
`getro`/`consider` need an explicit board id (`getro_collection` / `consider_board`)
since it isn't derivable from the URL — documented at the top of each file.

### What this fixes
1. **`freshness_filter` was a no-op after v1.8.** The provider refactor dropped the
   age filter — `scan.mjs` no longer read `portals.yml > freshness_filter`, so
   stale postings flowed straight through. Re-applied generically:
   - new `toEpochMs()` in `providers/_http.mjs` (ISO / epoch-s / epoch-ms → ms)
   - `greenhouse, ashby, lever, workable, recruitee, getro, teamtailor` now emit
     `posted_at`; providers without an authoritative date emit none (missing = pass,
     same rule as the location filter)
   - new exported `buildFreshnessFilter()` applied after the location filter, with a
     `Filtered by age: N removed (>Xd old)` summary line
2. **Title-filter substring bug.** Short all-letter acronym keywords (`CFO`, `COO`, …)
   matched substrings — `COO` matched "**Coo**rdinator", surfacing dozens of false
   positives once portfolio boards multiplied the volume. `compileKeyword()` now
   compiles 2–3-letter acronyms to word-boundary matchers; multi-word/symbol
   keywords keep fast substring matching. Both helpers are exported for tests.

### Testing
- `node scripts/test-new-providers.mjs` — live smoke test for all 7 providers.
- `node scan.mjs --dry-run` — 67 companies, ~12.9k jobs, freshness line present.
- `node test-all.mjs` — existing suite still green for everything I touched (the two
  reds in my checkout are the Go dashboard build and a missing `local-parser.mjs`
  vendor file, both unrelated to this PR).

### Notes
- Backward compatible: no changes to the provider contract or existing provider
  outputs beyond the additive `posted_at` field.
- I kept my personal `portals.yml` and fork change-log out of this PR. Happy to add
  a `freshness_filter` example to `templates/portals.example.yml` or split this into
  smaller PRs (providers / freshness / title-fix) if you'd prefer to review separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for 6 new job board sources: Consider, Getro, Joinup, Lever, Personio, and StartupCH
  * Enhanced job posting date handling across all providers
  * Improved title and location filtering with better matching accuracy
  * Added freshness filtering to exclude older job postings
  * Expanded Greenhouse board URL compatibility
  * Enhanced verification system with detailed result tracking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->