### PR TITLE
feat: create-a-role "gambit" mode + Speculative pipeline state

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -4,7 +4,7 @@ description: AI job search command center -- evaluate offers, tailor CVs, scan p
 arguments: mode
 user_invocable: true
 user-invocable: true
-argument-hint: "[scan | deep | pdf | latex | latex-tex | cover | email | add | expand | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | interview-redflag | patterns | offer-prep | titles | upskill | followup | reply-watch | update]"
+argument-hint: "[scan | deep | pdf | latex | latex-tex | cover | email | add | expand | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | gambit | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | interview-redflag | patterns | offer-prep | titles | upskill | followup | reply-watch | update]"
 license: MIT
 ---
 
@@ -40,6 +40,7 @@ Determine the mode from `$mode`:
 | `oferta` | `oferta` |
 | `ofertas` | `ofertas` |
 | `contacto` | `contacto` |
+| `gambit` | `gambit` |
 | `deep` | `deep` |
 | `interview-prep` | `interview-prep` |
 | `interview` | `interview` |
@@ -119,6 +120,7 @@ Available commands:
   /career-ops oferta    → Evaluation only A-F (no auto PDF)
   /career-ops ofertas   → Compare and rank multiple offers
   /career-ops contacto  → LinkedIn power move: find contacts + draft message
+  /career-ops gambit {company} → CREATE-A-ROLE: research + role thesis + CV + cover letter + pitch package
   /career-ops deep      → Deep research prompt about company
   /career-ops interview-prep → Generate company-specific interview prep doc
   /career-ops interview    → Interactive profile/CV onboarding interview
@@ -163,7 +165,7 @@ If `modes/_custom.md` exists, read it after `modes/_profile.md` and before the s
 
 Read `modes/_shared.md` + `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
 
-Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `gambit`, `apply`, `pipeline`, `scan`, `batch`
 
 ### Standalone modes with profile and custom context
 
@@ -173,7 +175,7 @@ Applies to: `tracker`, `agent-inbox`, `deep`, `interview-prep`, `interview`, `re
 
 ### Modes delegated to subagent
 
-For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `_profile.md` (if exists) + `_custom.md` (if exists) + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:
+For `scan`, `apply` (with Playwright), `gambit` (research-heavy: WebSearch + Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `_profile.md` (if exists) + `_custom.md` (if exists) + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:
 
 ```python
 Agent(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,7 @@ Two separate axes:
 | Asks to compare offers | `ofertas` |
 | Wants LinkedIn outreach | `contacto` — identifies hiring manager, recruiter, or team peers via web search; drafts a ≤300-char message tailored to the contact type (recruiter / hiring manager / peer / interviewer) |
 | Wants a formal application email | `email` — draft-only subject, body, attachment checklist, and contact block from a report or JD; never sends, submits, or clicks anything |
+| Wants to create/pitch a role that doesn't exist yet at a target company | `gambit` — researches an evidenced unmet need, builds a role thesis, and drafts the pitch package; records the pursuit as `Speculative` and holds a stricter conviction bar than a normal application |
 | Asks for company research | `deep` — structured 6-axis research prompt (AI strategy, recent moves, engineering culture, likely challenges, competitors, candidate's angle) |
 | Preps for interview at specific company | `interview-prep` |
 | Wants a time-blocked prep plan for an upcoming interview | `interview/plan` |
@@ -382,6 +383,7 @@ One TSV file per evaluation at `batch/tracker-additions/{num}-{company-slug}.tsv
 | State | When to use |
 |-------|-------------|
 | `Evaluated` | Report completed, pending decision |
+| `Speculative` | Create-a-role gambit pitch in flight (no posting yet) |
 | `Applied` | Application sent |
 | `Responded` | Company responded |
 | `Interview` | In interview process |

--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -882,6 +882,7 @@ func StatusPriority(status string) int {
 		return 3
 	case "evaluated":
 		return 4
+	// tie with "evaluated": speculative rows sort in the same band
 	case "speculative":
 		return 4
 	case "skip":

--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -522,6 +522,8 @@ func NormalizeStatus(raw string) string {
 	case strings.Contains(s, "discarded") || strings.Contains(s, "descartado") || s == "descartada" || s == "cerrada" || s == "cancelada" ||
 		strings.HasPrefix(s, "duplicado") || strings.HasPrefix(s, "dup") || strings.Contains(s, "iptal edildi") || strings.Contains(s, "iptal_edildi") || strings.Contains(s, "ıptal edildi") || strings.Contains(s, "ıptal_edildi"):
 		return "discarded"
+	case strings.Contains(s, "speculative") || s == "spec" || s == "gambit":
+		return "speculative"
 	case strings.Contains(s, "evaluated") || strings.Contains(s, "evaluada") || s == "condicional" || s == "hold" || s == "monitor" || s == "evaluar" || s == "verificar" || strings.Contains(s, "değerlendirildi") || strings.Contains(s, "degerlendirildi"):
 		return "evaluated"
 	default:
@@ -879,6 +881,8 @@ func StatusPriority(status string) int {
 	case "applied":
 		return 3
 	case "evaluated":
+		return 4
+	case "speculative":
 		return 4
 	case "skip":
 		return 5

--- a/dashboard/internal/data/career_test.go
+++ b/dashboard/internal/data/career_test.go
@@ -240,6 +240,20 @@ func TestParseApplicationsResolvesTrackerRelativeReportLinks(t *testing.T) {
 	}
 }
 
+func TestNormalizeStatusSpeculative(t *testing.T) {
+	cases := map[string]string{
+		"Speculative": "speculative",
+		"speculative": "speculative",
+		"gambit":      "speculative",
+		"spec":        "speculative",
+	}
+	for in, want := range cases {
+		if got := NormalizeStatus(in); got != want {
+			t.Fatalf("NormalizeStatus(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 // writeTracker writes applications.md under data/ and returns the temp root and
 // the tracker path.
 func writeTracker(t *testing.T, body string) (string, string) {
@@ -445,5 +459,11 @@ func TestNormalizeStatus(t *testing.T) {
 				t.Errorf("NormalizeStatus(%q) = %q; want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestStatusPrioritySpeculativeBeatsTerminal(t *testing.T) {
+	if StatusPriority("Speculative") >= StatusPriority("skip") {
+		t.Fatalf("Speculative should sort ahead of skip/rejected/discarded")
 	}
 }

--- a/dashboard/internal/i18n/catalog.go
+++ b/dashboard/internal/i18n/catalog.go
@@ -17,14 +17,15 @@ type Catalog struct {
 	LoadingPreview string
 
 	// Tabs & filters
-	TabAll       string
-	TabEvaluated string
-	TabApplied   string
-	TabInterview string
-	TabTop       string
-	TabSkip      string
-	TabRejected  string
-	TabDiscarded string
+	TabAll         string
+	TabEvaluated   string
+	TabSpeculative string
+	TabApplied     string
+	TabInterview   string
+	TabTop         string
+	TabSkip        string
+	TabRejected    string
+	TabDiscarded   string
 
 	// Table column headers
 	ColFit      string
@@ -64,15 +65,16 @@ type Catalog struct {
 	TimeDaysAgo   string
 
 	// Status display names
-	StatusEvaluated string
-	StatusApplied   string
-	StatusResponded string
-	StatusInterview string
-	StatusOffer     string
-	StatusRejected  string
-	StatusDiscarded string
-	StatusSkip      string
-	StatusHired     string
+	StatusEvaluated   string
+	StatusSpeculative string
+	StatusApplied     string
+	StatusResponded   string
+	StatusInterview   string
+	StatusOffer       string
+	StatusRejected    string
+	StatusDiscarded   string
+	StatusSkip        string
+	StatusHired       string
 
 	// Additional UI strings
 	NoData        string
@@ -183,6 +185,8 @@ func (c *Catalog) StatusLabel(norm string) string {
 		return c.StatusApplied
 	case "evaluated":
 		return c.StatusEvaluated
+	case "speculative":
+		return c.StatusSpeculative
 	case "skip":
 		return c.StatusSkip
 	case "rejected":
@@ -227,14 +231,15 @@ var En = Catalog{
 	LoadingPreview: "Loading preview...",
 
 	// Tabs & filters
-	TabAll:       "ALL",
-	TabEvaluated: "EVALUATED",
-	TabApplied:   "APPLIED",
-	TabInterview: "INTERVIEW",
-	TabTop:       "TOP ≥4",
-	TabSkip:      "SKIP",
-	TabRejected:  "REJECTED",
-	TabDiscarded: "DISCARDED",
+	TabAll:         "ALL",
+	TabEvaluated:   "EVALUATED",
+	TabSpeculative: "SPEC",
+	TabApplied:     "APPLIED",
+	TabInterview:   "INTERVIEW",
+	TabTop:         "TOP ≥4",
+	TabSkip:        "SKIP",
+	TabRejected:    "REJECTED",
+	TabDiscarded:   "DISCARDED",
 
 	// Table column headers
 	ColFit:      "FIT",
@@ -274,15 +279,16 @@ var En = Catalog{
 	TimeDaysAgo:   "%dd ago",
 
 	// Status display names
-	StatusEvaluated: "Evaluated",
-	StatusApplied:   "Applied",
-	StatusResponded: "Responded",
-	StatusInterview: "Interview",
-	StatusOffer:     "Offer",
-	StatusRejected:  "Rejected",
-	StatusDiscarded: "Discarded",
-	StatusSkip:      "SKIP",
-	StatusHired:     "Hired",
+	StatusEvaluated:   "Evaluated",
+	StatusSpeculative: "Speculative",
+	StatusApplied:     "Applied",
+	StatusResponded:   "Responded",
+	StatusInterview:   "Interview",
+	StatusOffer:       "Offer",
+	StatusRejected:    "Rejected",
+	StatusDiscarded:   "Discarded",
+	StatusSkip:        "SKIP",
+	StatusHired:       "Hired",
 
 	// Additional UI strings
 	NoData:        "No data",
@@ -354,14 +360,15 @@ var Tr = Catalog{
 	LoadingPreview: "Önizleme yükleniyor...",
 
 	// Tabs & filters
-	TabAll:       "TÜMÜ",
-	TabEvaluated: "DEĞERLENDİRİLDİ",
-	TabApplied:   "BAŞVURULDU",
-	TabInterview: "MÜLAKAT",
-	TabTop:       "EN İYİ ≥4",
-	TabSkip:      "UYGUN DEĞİL",
-	TabRejected:  "REDDEDİLDİ",
-	TabDiscarded: "İPTAL",
+	TabAll:         "TÜMÜ",
+	TabEvaluated:   "DEĞERLENDİRİLDİ",
+	TabSpeculative: "SPEKÜLATİF",
+	TabApplied:     "BAŞVURULDU",
+	TabInterview:   "MÜLAKAT",
+	TabTop:         "EN İYİ ≥4",
+	TabSkip:        "UYGUN DEĞİL",
+	TabRejected:    "REDDEDİLDİ",
+	TabDiscarded:   "İPTAL",
 
 	// Table column headers
 	ColFit:      "UYUM",
@@ -401,15 +408,16 @@ var Tr = Catalog{
 	TimeDaysAgo:   "%d gün önce",
 
 	// Status display names
-	StatusEvaluated: "Değerlendirildi",
-	StatusApplied:   "Başvuruldu",
-	StatusResponded: "Yanıt Verildi",
-	StatusInterview: "Mülakat",
-	StatusOffer:     "Teklif",
-	StatusRejected:  "Reddedildi",
-	StatusDiscarded: "İptal Edildi",
-	StatusSkip:      "Uygun Değil",
-	StatusHired:     "İşe Alındı",
+	StatusEvaluated:   "Değerlendirildi",
+	StatusSpeculative: "Spekülatif",
+	StatusApplied:     "Başvuruldu",
+	StatusResponded:   "Yanıt Verildi",
+	StatusInterview:   "Mülakat",
+	StatusOffer:       "Teklif",
+	StatusRejected:    "Reddedildi",
+	StatusDiscarded:   "İptal Edildi",
+	StatusSkip:        "Uygun Değil",
+	StatusHired:       "İşe Alındı",
 
 	// Additional UI strings
 	NoData:        "Veri yok",
@@ -481,14 +489,15 @@ var Es = Catalog{
 	LoadingPreview: "Cargando vista previa...",
 
 	// Tabs & filters
-	TabAll:       "TODAS",
-	TabEvaluated: "EVALUADAS",
-	TabApplied:   "APLICADAS",
-	TabInterview: "ENTREVISTA",
-	TabTop:       "TOP ≥4",
-	TabSkip:      "OMITIR",
-	TabRejected:  "RECHAZADAS",
-	TabDiscarded: "DESCARTADAS",
+	TabAll:         "TODAS",
+	TabEvaluated:   "EVALUADAS",
+	TabSpeculative: "ESPECULATIVAS",
+	TabApplied:     "APLICADAS",
+	TabInterview:   "ENTREVISTA",
+	TabTop:         "TOP ≥4",
+	TabSkip:        "OMITIR",
+	TabRejected:    "RECHAZADAS",
+	TabDiscarded:   "DESCARTADAS",
 
 	// Table column headers
 	ColFit:      "AJUSTE",
@@ -528,15 +537,16 @@ var Es = Catalog{
 	TimeDaysAgo:   "hace %dd",
 
 	// Status display names
-	StatusEvaluated: "Evaluada",
-	StatusApplied:   "Aplicada",
-	StatusResponded: "Respondida",
-	StatusInterview: "Entrevista",
-	StatusOffer:     "Oferta",
-	StatusRejected:  "Rechazada",
-	StatusDiscarded: "Descartada",
-	StatusSkip:      "OMITIR",
-	StatusHired:     "Contratada",
+	StatusEvaluated:   "Evaluada",
+	StatusSpeculative: "Especulativa",
+	StatusApplied:     "Aplicada",
+	StatusResponded:   "Respondida",
+	StatusInterview:   "Entrevista",
+	StatusOffer:       "Oferta",
+	StatusRejected:    "Rechazada",
+	StatusDiscarded:   "Descartada",
+	StatusSkip:        "OMITIR",
+	StatusHired:       "Contratada",
 
 	// Additional UI strings
 	NoData:        "Sin datos",

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -124,14 +124,15 @@ const (
 
 // Filter modes
 const (
-	filterAll       = "all"
-	filterEvaluated = "evaluated"
-	filterApplied   = "applied"
-	filterInterview = "interview"
-	filterSkip      = "skip"
-	filterRejected  = "rejected"
-	filterDiscarded = "discarded"
-	filterTop       = "top"
+	filterAll         = "all"
+	filterEvaluated   = "evaluated"
+	filterSpeculative = "speculative"
+	filterApplied     = "applied"
+	filterInterview   = "interview"
+	filterSkip        = "skip"
+	filterRejected    = "rejected"
+	filterDiscarded   = "discarded"
+	filterTop         = "top"
 )
 
 type pipelineTab struct {
@@ -143,6 +144,7 @@ func getPipelineTabs() []pipelineTab {
 	return []pipelineTab{
 		{filterAll, i18n.Current.TabAll},
 		{filterEvaluated, i18n.Current.TabEvaluated},
+		{filterSpeculative, i18n.Current.TabSpeculative},
 		{filterApplied, i18n.Current.TabApplied},
 		{filterInterview, i18n.Current.TabInterview},
 		{filterTop, i18n.Current.TabTop},
@@ -195,6 +197,7 @@ type StatusPair struct {
 func getStatusPairs() []StatusPair {
 	return []StatusPair{
 		{i18n.Current.StatusEvaluated, "Evaluated"},
+		{i18n.Current.StatusSpeculative, "Speculative"},
 		{i18n.Current.StatusApplied, "Applied"},
 		{i18n.Current.StatusResponded, "Responded"},
 		{i18n.Current.StatusInterview, "Interview"},
@@ -207,7 +210,10 @@ func getStatusPairs() []StatusPair {
 }
 
 // statusGroupOrder defines display order for grouped view.
-var statusGroupOrder = []string{"hired", "interview", "offer", "responded", "applied", "evaluated", "skip", "rejected", "discarded"}
+// speculative sits just after evaluated: a gambit pitch is pre-application, so
+// it outranks nothing that has actually been sent, but it is live work and
+// belongs above skip/rejected/discarded.
+var statusGroupOrder = []string{"hired", "interview", "offer", "responded", "applied", "evaluated", "speculative", "skip", "rejected", "discarded"}
 
 // PipelineModel implements the career pipeline dashboard screen.
 type PipelineModel struct {
@@ -2035,14 +2041,15 @@ func (m PipelineModel) scoreStyle(score float64) lipgloss.Style {
 
 func (m PipelineModel) statusColorMap() map[string]lipgloss.Color {
 	return map[string]lipgloss.Color{
-		"interview": m.theme.Green,
-		"offer":     m.theme.Green,
-		"applied":   m.theme.Sky,
-		"responded": m.theme.Blue,
-		"evaluated": m.theme.Text,
-		"skip":      m.theme.Red,
-		"rejected":  m.theme.Subtext,
-		"discarded": m.theme.Subtext,
+		"interview":   m.theme.Green,
+		"offer":       m.theme.Green,
+		"applied":     m.theme.Sky,
+		"responded":   m.theme.Blue,
+		"evaluated":   m.theme.Text,
+		"speculative": m.theme.Mauve,
+		"skip":        m.theme.Red,
+		"rejected":    m.theme.Subtext,
+		"discarded":   m.theme.Subtext,
 	}
 }
 

--- a/dashboard/internal/ui/screens/pipeline_test.go
+++ b/dashboard/internal/ui/screens/pipeline_test.go
@@ -580,3 +580,21 @@ func TestWithReloadedDataPreservesCursorWhenAppRemoved(t *testing.T) {
 		t.Fatalf("expected cursor to be within [0, %d], got %d", len(reloaded.filtered)-1, reloaded.cursor)
 	}
 }
+
+func TestPipelineTabsIncludeSpeculative(t *testing.T) {
+	found := false
+	for _, tab := range getPipelineTabs() {
+		if tab.filter == filterSpeculative {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected pipeline tabs to include the speculative filter")
+	}
+}
+
+func TestStatusLabelSpeculative(t *testing.T) {
+	if got := statusLabel("speculative"); got != "Speculative" {
+		t.Fatalf("statusLabel(speculative) = %q, want Speculative", got)
+	}
+}

--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -36,6 +36,7 @@ const STATUS_RANK = {
   'discarded': 0,
   'rejected': 1,
   'evaluated': 2,
+  'speculative': 2,
   'applied': 3,
   'responded': 4,
   'interview': 5,

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -98,7 +98,7 @@ try {
 }
 
 // Canonical states and aliases
-const CANONICAL_STATES = ['Evaluated', 'Applied', 'Responded', 'Interview', 'Offer', 'Hired', 'Rejected', 'Discarded', 'SKIP'];
+const CANONICAL_STATES = ['Evaluated', 'Speculative', 'Applied', 'Responded', 'Interview', 'Offer', 'Hired', 'Rejected', 'Discarded', 'SKIP'];
 
 /**
  * Convert raw addition status text into one canonical tracker state.
@@ -121,6 +121,8 @@ function validateStatus(status) {
 
   // Aliases
   const aliases = {
+    // Speculative / gambit
+    'speculative': 'Speculative', 'spec': 'Speculative', 'gambit': 'Speculative',
     // Spanish → English
     'evaluada': 'Evaluated', 'condicional': 'Evaluated', 'hold': 'Evaluated', 'evaluar': 'Evaluated', 'verificar': 'Evaluated',
     'aplicado': 'Applied', 'enviada': 'Applied', 'aplicada': 'Applied', 'applied': 'Applied', 'sent': 'Applied',

--- a/modes/_profile.template.md
+++ b/modes/_profile.template.md
@@ -43,6 +43,24 @@
 | Forward Deployed Engineer | Fast delivery, client-facing, prototype to prod | cv.md + article-digest.md |
 | AI Transformation Lead | Change management, team enablement, adoption | cv.md + article-digest.md |
 
+## Your Natural Level & Company-Stage Calibration
+
+<!-- Read by the `gambit` (create-a-role) mode and useful for evaluations.
+     The same title means different things at a 20-person seed startup vs a
+     5,000-person public company. Fill in YOUR natural level per stage so the
+     system pitches you at the right altitude. Replace the example rows. -->
+
+| Company stage | Title that fits you | Why (your evidence) |
+|---------------|---------------------|---------------------|
+| Seed / Series A | [e.g. Founding <Function> / Head of X] | Small team -- you'd stand up the function 0->1 |
+| Series B-C | [e.g. Director / Senior Staff] | Function exists -- you'd scale and systematize it |
+| Series D+ / public | [e.g. Senior / Staff IC or Sr. Manager] | Established org -- calibrate to their leveling |
+
+**Rule of thumb:** the earlier the stage, the more "build it from nothing" your
+pitch should be; the later the stage, the more it should map to their existing
+ladder. When unsure, pitch one level *below* your ceiling -- easier to negotiate
+up than to recover from an over-reach.
+
 ## Your Exit Narrative
 
 <!-- Replace with YOUR story. This frames everything. -->
@@ -100,3 +118,29 @@ If you have a live demo/dashboard (check profile.yml), offer access in applicati
 **In evaluations (scoring):**
 - Remote dimension for hybrid outside your country: score **3.0** (not 1.0)
 - Only score 1.0 if JD says "must be on-site 4-5 days/week, no exceptions"
+
+## Gambit Playbook
+
+<!-- Read by the `gambit` (create-a-role) mode: pitching a role that doesn't
+     exist yet at a company that needs it. This is how YOU run that play.
+     Replace every [placeholder] with your own specifics. -->
+
+**Your gambit superpower:** [What can you credibly claim to have *built* -- not
+just done? The gambit pitch is *"I'll build the function you don't have yet,"*
+which only lands if you've stood up that function before. State yours, e.g.
+"two-time 0->1 <function> builder with an exit."]
+
+**Strongest gambit archetypes** (highest hit-rate for create-a-role):
+- **[Archetype 1]** -- [the kind of company gap it targets]. Proof: [your evidence].
+- **[Archetype 2]** -- [company gap]. Proof: [your evidence].
+- **[Archetype 3]** -- [company gap]. Proof: [your evidence].
+
+**Gambit conviction bar (stricter than a normal application):** only recommend
+SEND when the unmet need is *evidenced* (cited, not invented), the fit is strong
+(>=4.0), AND a specific exec who could create the role is reachable. A speculative
+cold pitch is the highest-annoyance-risk move in the system -- hold it to the
+highest bar.
+
+**Who you pitch:** the founder/CEO at seed-Series A; the owning exec (VP / C-level
+of the relevant function) at Series B+. Never a recruiter -- recruiters fill
+posted reqs, they do not invent them.

--- a/modes/gambit.md
+++ b/modes/gambit.md
@@ -24,6 +24,26 @@ candidate, not the company. Same rule as "never invent metrics."
 - `cv.md` (source of truth) + `article-digest.md` (proof points, if present) +
   `config/profile.yml`.
 
+## Step 0.5 — Disambiguate the company (if the name isn't unique)
+
+Before any research, make sure you are aimed at the right entity. Company names
+collide — a recipe app, a blockchain firm, and an HR-tech startup can all be
+"Crouton."
+
+- If the user gave a **URL or otherwise unambiguous identifier**, use it directly
+  and skip to Step 1.
+- If the user gave only a **name**, run ONE quick WebSearch to check whether it
+  maps to more than one company.
+  - **Unique** → proceed to Step 1.
+  - **Ambiguous** → STOP. Present the 2–4 candidate companies, each with a
+    one-line fit read against the candidate's archetypes (`_profile.md`), and ask
+    which one. Do NOT research or generate anything until the user confirms the
+    entity.
+
+A gambit's most expensive wrong turn is researching the wrong company under a
+shared name — resolve the entity before spending the research/generation budget.
+(This is the CHECKPOINT instinct applied one level earlier than the role thesis.)
+
 ## Step 1 — Research the company
 
 Use WebSearch + Playwright (single Playwright agent only — see `_shared.md`):

--- a/modes/gambit.md
+++ b/modes/gambit.md
@@ -1,0 +1,199 @@
+# Mode: gambit — Create-a-Role Power Move
+
+You are running **the gambit**: there is NO job posting. Given a target company
+and the candidate's background, you (1) diagnose the role the company sorely
+needs but has not posted, then (2) make the case for it — a tailored CV, a cover
+letter, and a pitch package aimed at the person who can *create* the role.
+
+This mode INVERTS the normal reactive flow. The keystone is a **synthetic JD**:
+once you write the invented role as the posting the company *should* publish, the
+rest of the pipeline (CV tailoring, cover letter, A–F report blocks) reuses the
+standard machinery.
+
+**Honesty is non-negotiable.** NEVER fabricate a company problem to flatter the
+pitch. Every claim in the Company-Need Thesis must cite evidence (news, funding,
+product, org signals). The synthetic JD must ALWAYS be labeled as authored by the
+candidate, not the company. Same rule as "never invent metrics."
+
+## Step 0 — Load context
+
+`_shared.md` is already injected. Also read:
+- `modes/_profile.md` — especially `## Your Target Roles`, `## Your Adaptive
+  Framing`, `## Your Natural Level & Company-Stage Calibration`, and
+  `## Gambit Playbook`.
+- `cv.md` (source of truth) + `article-digest.md` (proof points, if present) +
+  `config/profile.yml`.
+
+## Step 1 — Research the company
+
+Use WebSearch + Playwright (single Playwright agent only — see `_shared.md`):
+- WebSearch: funding stage + total raised, headcount, recent news (last 6–12
+  months), product direction, leadership team + recent exec hires/departures,
+  stated priorities, strategic inflection points.
+- Playwright: navigate the careers page; snapshot the open roles.
+- **Negative-space analysis:** what they ARE hiring reveals priorities and org
+  shape. The gap is what is conspicuously MISSING given their trajectory. (E.g.,
+  heavy enterprise-sales hiring + a developer-facing product + zero DevRel
+  headcount = a developer-relations gap.)
+- Detect **company stage** (per the `_profile.md` calibration) — it determines
+  the level you can credibly pitch.
+
+## Step 2 — Diagnose 2–3 candidate role theses
+
+Produce a ranked table:
+
+| # | Invented title | Evidenced company gap (cite source) | Archetype leveraged (`_profile.md`) | Stage-calibrated level | Conviction |
+|---|---|---|---|---|---|
+
+- **Invented title** — what you would call the role.
+- **Evidenced gap** — the specific unmet need with a cited signal. No fabrication.
+- **Archetype** — which of the candidate's archetypes makes them the credible
+  person to fill it.
+- **Level** — apply the `_profile.md` company-stage × title calibration.
+- **Conviction** — High / Medium / Low: strength of (need-evidence × fit ×
+  decision-maker reachability).
+
+Recommend one.
+
+## Step 3 — CHECKPOINT (mandatory)
+
+Present the 2–3 theses to the candidate. STOP and ask which to pursue (or to
+refine one). Do NOT generate any documents until they choose. Heavy generation
+happens only after the bet is chosen.
+
+## Step 4 — Write the synthetic JD
+
+For the chosen role, write the posting the company *should* publish:
+- Title + one-line mission
+- "Why now" (the company-need thesis in 2–3 cited sentences)
+- 12-month mandate / what success looks like
+- Responsibilities (5–8)
+- Requirements (mapped to what the candidate actually has)
+
+**Header it clearly:**
+`> Synthetic role — drafted by {candidate} as a proposal. {Company} has not posted this role.`
+
+## Step 5 — Generate the CV + cover letter (reuse the engine)
+
+Treat the synthetic JD as the JD and run the standard `modes/pdf.md` flow:
+- Extract 15–20 keywords from the synthetic JD.
+- Tailor the Professional Summary, competencies, and experience ordering.
+  NEVER invent — only reword real experience using the synthetic JD's vocabulary.
+- Generate the PDF via `node generate-pdf.mjs`.
+- Generate a one-page cover letter (same visual design as the CV, per the
+  `_shared.md` ALWAYS rule) that maps the synthetic JD's needs to real proof
+  points and opens the create-a-role frame.
+
+## Step 6 — Contact discovery (Founder/Exec — create-a-role)
+
+Find the person who could *create* this role (NOT a recruiter — recruiters fill
+posted reqs, they do not invent them):
+- The exec who owns the function the role would sit in (founder/CEO at seed–A;
+  the relevant VP / C-level at Series B+).
+- 1–2 alternates.
+Use WebSearch (LinkedIn, company about page, news).
+
+**Founder/Exec (create-a-role) contact type** — the outreach is longer than a
+`contacto` LinkedIn request (this is email/DM, not a 300-char connection note):
+- **Hook (their reality):** the specific, cited gap you see — framed as
+  opportunity, not criticism.
+- **Bridge (you):** the one proof point that shows you have built exactly this
+  before.
+- **Ask (low-friction):** a 20-minute conversation about the gap — NOT "give me a
+  job." You are offering a perspective, not asking for a req.
+
+## Step 7 — Pitch package
+
+Produce three artifacts:
+1. **Cold email** — ~150–200 words. Subject line + body. Hook → bridge → ask.
+   Attach CV + memo.
+2. **LinkedIn DM variant** — shorter, same arc, no attachment (link the
+   portfolio instead).
+3. **One-page forwardable memo** — "The {role}: why now, and why me." Spine =
+   synthetic JD + the cited thesis + top 3 proof points + a 90-day plan sketch.
+   Written to be forwarded internally by the exec.
+
+## Step 8 — Conviction & Go/No-Go gate (MANDATORY)
+
+Before presenting, evaluate the three legs:
+- **(a) Evidenced need** — is the gap real and cited, or invented to flatter?
+- **(b) Strong fit** — is the match ≥ ~4.0?
+- **(c) Reachable decision-maker** — did you find a specific exec who could
+  create the role?
+
+**Recommendation:**
+- All three strong → **SEND**: present the package and suggest the best channel.
+- Any leg weak → **HOLD / DON'T SEND**: say so plainly and name which leg failed.
+  Still hand over the drafts (the candidate decides), but lead with the honest
+  recommendation. A weak gambit wastes an exec's attention and burns a warm
+  company — the "quality over quantity, respect their time" ethos applies
+  *harder* here.
+
+## Step 9 — Save report + tracker
+
+### Report
+
+Save to `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (sequential number =
+max existing + 1). Use this gambit-variant structure.
+
+**Header fields** (one per line, in this order):
+- `# Gambit: {Company} — {Proposed Role}`
+- `**Date:** {YYYY-MM-DD}`
+- `**Mode:** gambit (speculative / create-a-role)`
+- `**Role (proposed):** {invented title}`
+- `**Archetype:** {selected}`
+- `**Conviction:** {X}/5`
+- `**URL:** {company / careers URL used for research}`
+- `**Legitimacy:** N/A (speculative — no posting to verify)`
+- `**PDF:** {path or pending}`
+
+**Body sections** (in this order):
+- `## G0) Company-Need Thesis` — the evidenced diagnosis. Gaps ranked. Every
+  claim cited.
+- `## G1) The Synthetic Role` — open with the synthetic-role disclaimer line
+  (`> Synthetic role — drafted by {candidate} as a proposal. {Company} has not
+  posted this role.`), then the synthetic JD.
+- `## A) Role Summary` — of the synthetic role: archetype, domain, function,
+  seniority, stage.
+- `## B) Match with CV` — synthetic-JD requirements → exact `cv.md` lines.
+- `## C) Level & Strategy` — apply the `_profile.md` company-stage × title
+  calibration. Sell senior without lying.
+- `## D) Comp & Demand` — market comp for the invented role; note speculative
+  comp is especially negotiable.
+- `## E) Conviction & Go/No-Go` — the Step 8 gate: the three legs + the send /
+  hold recommendation.
+- `## F) Interview Plan` — STAR+R stories for the conversation the pitch opens.
+- `## Documents` — CV path, cover-letter path, and the pitch (email + DM + memo,
+  inline or linked).
+
+**Then a `## Machine Summary` section containing exactly this YAML fenced block**
+(keep all keys — `legitimacy` carries a sentinel so downstream parsers stay
+happy; `mode` and `decision_maker` are additive):
+
+```yaml
+num: {NNN}
+company: {Company}
+role: "{invented title} (gambit)"
+score: {conviction X.X}
+archetype: {selected}
+legitimacy: "N/A (speculative)"
+recommend: {send | hold | skip}
+stage: {detected stage}
+comp_estimate: "{range}"
+top_gap: "{the company need being filled}"
+mode: gambit
+decision_maker: "{name, title}"
+```
+
+### Tracker
+
+Write a TSV to `batch/tracker-additions/{num}-{company-slug}.tsv` — one line, 9
+tab-separated columns (per `_shared.md` / AGENTS.md TSV Format). Column order is
+`num`, `date`, `company`, `role`, `status`, `score`, `pdf`, `report`, `notes`:
+
+```
+{num}	{date}	{company}	{invented title} (gambit)	Speculative	{conviction}/5	{✅ or ❌}	[{num}](reports/{num}-{slug}-{date}.md)	{one-line: gap + decision-maker}
+```
+
+Then run `node merge-tracker.mjs`. NEVER edit `applications.md` directly to add a
+row.

--- a/modes/gambit.md
+++ b/modes/gambit.md
@@ -42,7 +42,7 @@ Use WebSearch + Playwright (single Playwright agent only — see `_shared.md`):
 
 Produce a ranked table:
 
-| # | Invented title | Evidenced company gap (cite source) | Archetype leveraged (`_profile.md`) | Stage-calibrated level | Conviction |
+| # | Invented title | Evidenced company gap (cite source) | Archetype leveraged (`_profile.md`) | Stage-calibrated level | Conviction (1–5) |
 |---|---|---|---|---|---|
 
 - **Invented title** — what you would call the role.
@@ -50,8 +50,11 @@ Produce a ranked table:
 - **Archetype** — which of the candidate's archetypes makes them the credible
   person to fill it.
 - **Level** — apply the `_profile.md` company-stage × title calibration.
-- **Conviction** — High / Medium / Low: strength of (need-evidence × fit ×
-  decision-maker reachability).
+- **Conviction (1–5)** — a single numeric score (one decimal allowed) for the
+  strength of the bet = evidenced need × CV-to-role fit × decision-maker
+  reachability. This is the score that flows to the report header, the Machine
+  Summary `score`, and the tracker. (5 = slam-dunk; below ~4.0 → likely HOLD,
+  see Step 8.)
 
 Recommend one.
 
@@ -117,7 +120,9 @@ Produce three artifacts:
 
 Before presenting, evaluate the three legs:
 - **(a) Evidenced need** — is the gap real and cited, or invented to flatter?
-- **(b) Strong fit** — is the match ≥ ~4.0?
+- **(b) Strong fit** — is the CV-to-role match (Block B) strong (≥ ~4.0/5)?
+  This is the CV-match component specifically, distinct from the composite
+  Conviction score.
 - **(c) Reachable decision-maker** — did you find a specific exec who could
   create the role?
 
@@ -163,8 +168,11 @@ max existing + 1). Use this gambit-variant structure.
 - `## E) Conviction & Go/No-Go` — the Step 8 gate: the three legs + the send /
   hold recommendation.
 - `## F) Interview Plan` — STAR+R stories for the conversation the pitch opens.
-- `## Documents` — CV path, cover-letter path, and the pitch (email + DM + memo,
-  inline or linked).
+- `## Documents` — links to the saved CV (in `output/`), the cover letter, and
+  the pitch artifacts. Save the cold email, the LinkedIn DM, and the memo to
+  `output/` and link them here; inline them only if short.
+- `## Keywords extracted` — the 15–20 ATS keywords pulled from the synthetic JD
+  in Step 5 (mirrors the standard report format for ATS optimization).
 
 **Then a `## Machine Summary` section containing exactly this YAML fenced block**
 (keep all keys — `legitimacy` carries a sentinel so downstream parsers stay
@@ -174,7 +182,7 @@ happy; `mode` and `decision_maker` are additive):
 num: {NNN}
 company: {Company}
 role: "{invented title} (gambit)"
-score: {conviction X.X}
+score: {X.X}
 archetype: {selected}
 legitimacy: "N/A (speculative)"
 recommend: {send | hold | skip}
@@ -192,8 +200,15 @@ tab-separated columns (per `_shared.md` / AGENTS.md TSV Format). Column order is
 `num`, `date`, `company`, `role`, `status`, `score`, `pdf`, `report`, `notes`:
 
 ```
-{num}	{date}	{company}	{invented title} (gambit)	Speculative	{conviction}/5	{✅ or ❌}	[{num}](reports/{num}-{slug}-{date}.md)	{one-line: gap + decision-maker}
+{num}	{date}	{company}	{invented title} (gambit)	Speculative	{X.X}/5	{✅ or ❌}	[{num}](reports/{num}-{slug}-{date}.md)	{one-line: gap + decision-maker}
 ```
+
+The `score` column is the numeric Conviction value (`{X.X}/5`, e.g. `4.3/5`) —
+never write `High/5` or a word.
+
+`Speculative` is a canonical status (defined in `templates/states.yml`, aliases
+`spec` / `gambit`). Use it as-is — do NOT substitute `Evaluated` even though the
+shorter states tables in `CLAUDE.md` / `AGENTS.md` may not list it.
 
 Then run `node merge-tracker.mjs`. NEVER edit `applications.md` directly to add a
 row.

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -66,7 +66,7 @@ function normalizeStatus(raw) {
 
   // Already canonical (English, per states.yml) — just fix casing/bold
   const canonical = [
-    'Evaluated', 'Applied', 'Responded', 'Interview',
+    'Evaluated', 'Speculative', 'Applied', 'Responded', 'Interview',
     'Offer', 'Hired', 'Rejected', 'Discarded', 'SKIP',
   ];
   for (const c of canonical) {
@@ -82,6 +82,7 @@ function normalizeStatus(raw) {
   if (['contratado', 'contratada', 'hired', 'accepted', 'accept'].includes(lower)) return { status: 'Hired' };
   if (['cerrada', 'descartada'].includes(lower)) return { status: 'Discarded' };
   if (['no aplicar', 'no_aplicar', 'skip'].includes(lower)) return { status: 'SKIP' };
+  if (['speculative', 'spec', 'gambit'].includes(lower)) return { status: 'Speculative' };
 
   // Unknown — flag it
   return { status: null, unknown: true };

--- a/templates/states.yml
+++ b/templates/states.yml
@@ -13,6 +13,12 @@ states:
     description: Offer evaluated with report, pending decision
     dashboard_group: evaluated
 
+  - id: speculative
+    label: Speculative
+    aliases: [spec, gambit]
+    description: Create-a-role pitch in flight (no posting); pre-response
+    dashboard_group: speculative
+
   - id: applied
     label: Applied
     aliases: [aplicado, enviada, aplicada, sent]

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4699,7 +4699,6 @@ if (mergeSpec.includes("'Speculative'")) {
   fail('merge-tracker.mjs CANONICAL_STATES missing Speculative');
 }
 
-<<<<<<< HEAD
 // ── RESERVE-REPORT-NUM RANGE RESERVATION (#1426) ────────────────
 // Manual multi-agent fan-outs need N report numbers up front. --count N
 // reserves a contiguous range (per-slot atomic sentinels); tests run against

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4660,6 +4660,38 @@ try {
   fail(`tracker-link normalization tests crashed: ${e.message}`);
 }
 
+// ── 63. SPECULATIVE STATE (gambit) ──────────────────────────────
+
+console.log('\n63. Speculative state (gambit)');
+
+const statesSpec = readFile('templates/states.yml');
+if (statesSpec.includes('label: Speculative')) {
+  pass('states.yml defines the Speculative state');
+} else {
+  fail('states.yml is missing the Speculative state');
+}
+
+const verifySpec = readFile('verify-pipeline.mjs');
+if (verifySpec.includes("'speculative'")) {
+  pass('verify-pipeline.mjs accepts speculative as canonical');
+} else {
+  fail('verify-pipeline.mjs CANONICAL_STATUSES missing speculative');
+}
+
+const normSpec = readFile('normalize-statuses.mjs');
+if (/canonical\s*=\s*\[[^\]]*'Speculative'/s.test(normSpec)) {
+  pass('normalize-statuses.mjs treats Speculative as canonical');
+} else {
+  fail('normalize-statuses.mjs canonical array missing Speculative');
+}
+
+const dedupSpec = readFile('dedup-tracker.mjs');
+if (dedupSpec.includes("'speculative'")) {
+  pass('dedup-tracker.mjs ranks speculative');
+} else {
+  fail('dedup-tracker.mjs STATUS_RANK missing speculative');
+}
+
 // ── RESERVE-REPORT-NUM RANGE RESERVATION (#1426) ────────────────
 // Manual multi-agent fan-outs need N report numbers up front. --count N
 // reserves a contiguous range (per-slot atomic sentinels); tests run against

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1353,7 +1353,7 @@ const expectedModes = [
   'batch.md', 'apply.md', 'auto-pipeline.md', 'contacto.md', 'deep.md',
   'ofertas.md', 'pipeline.md', 'project.md', 'tracker.md', 'training.md',
   'interview.md', 'latex.md', 'latex-tex.md', 'email.md', 'add.md', 'titles.md',
-  'expand.md',
+  'expand.md', 'gambit.md',
   'regional/eu-swe.md',
 ];
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4692,6 +4692,14 @@ if (dedupSpec.includes("'speculative'")) {
   fail('dedup-tracker.mjs STATUS_RANK missing speculative');
 }
 
+const mergeSpec = readFile('merge-tracker.mjs');
+if (mergeSpec.includes("'Speculative'")) {
+  pass('merge-tracker.mjs accepts Speculative as canonical');
+} else {
+  fail('merge-tracker.mjs CANONICAL_STATES missing Speculative');
+}
+
+<<<<<<< HEAD
 // ── RESERVE-REPORT-NUM RANGE RESERVATION (#1426) ────────────────
 // Manual multi-agent fan-outs need N report numbers up front. --count N
 // reserves a contiguous range (per-slot atomic sentinels); tests run against

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -74,6 +74,7 @@ const SYSTEM_PATHS = [
   'modes/auto-pipeline.md',
   'modes/contacto.md',
   'modes/deep.md',
+  'modes/gambit.md',
   'modes/ofertas.md',
   'modes/pipeline.md',
   'modes/project.md',

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -44,12 +44,13 @@ mkdirSync(join(CAREER_OPS, 'data'), { recursive: true });
 mkdirSync(REPORTS_DIR, { recursive: true });
 
 const CANONICAL_STATUSES = [
-  'evaluated', 'applied', 'responded', 'interview',
+  'evaluated', 'speculative', 'applied', 'responded', 'interview',
   'offer', 'rejected', 'discarded', 'skip', 'hired',
 ];
 
 const ALIASES = {
   'evaluada': 'evaluated', 'condicional': 'evaluated', 'hold': 'evaluated', 'evaluar': 'evaluated', 'verificar': 'evaluated',
+  'speculative': 'speculative', 'spec': 'speculative', 'gambit': 'speculative',
   'aplicado': 'applied', 'enviada': 'applied', 'aplicada': 'applied', 'applied': 'applied', 'sent': 'applied',
   'respondido': 'responded',
   'entrevista': 'interview',


### PR DESCRIPTION
## What

Adds a new **`gambit`** mode — the "create-a-role" play — plus a new **`Speculative`** canonical pipeline state to track those pitches end-to-end (JS pipeline scripts **and** the Go dashboard).

A gambit is the move career-ops didn't have a home for: instead of applying *into* a posted req, you research a company, find the function it's conspicuously **missing** given its trajectory, and pitch a role that doesn't exist yet to the person who could create it.

```
/career-ops gambit {company}
  → research → negative-space gap analysis → ranked role theses
  → tailored CV + cover letter + pitch package
```

## Why

The existing modes (`oferta`, `apply`, `scan`, `pipeline`) all assume a **posted** role. But some of the highest-leverage opportunities are unposted: a developer-facing product with zero DevRel headcount, an API nobody has productized, an AI capability with no one shipping it. Pursuing those well is a distinct workflow with distinct risks, and it deserves first-class, **ethically-bounded** support rather than ad-hoc prompting.

The design leans hard into the repo's existing "respect the recruiter's time" ethos, turned up a notch — a speculative cold pitch is the highest-annoyance-risk action in the whole system, so the mode holds itself to the **strictest** bar:

- **Evidenced, not invented.** Every claimed company gap must cite a real signal (a careers page, a funding note, an exec hire). No fabricated needs — the same rule as "never invent metrics."
- **High conviction only.** Recommend SEND only when the unmet need is evidenced, fit is strong (≥4.0), **and** a specific decision-maker who could create the role is reachable.
- **The right human.** Pitch the founder/CEO at seed–Series A, the owning exec at Series B+ — **never a recruiter**, because recruiters fill posted reqs, they don't invent them.
- **Human-in-the-loop.** The mode produces the drafts; it always leads with an honest recommendation and the user decides. Nothing is sent automatically.

## How

**The mode — `modes/gambit.md`**
- **Step 0.5 — entity disambiguation.** Company names collide (a recipe app, a blockchain firm, and an HR-tech startup can all be "Crouton"). Before spending any research budget, one quick check resolves the entity; if ambiguous, it STOPs and asks. *(This step was added after the first real run surfaced exactly this failure mode.)*
- **Negative-space analysis.** What a company *is* hiring reveals its priorities and org shape; the gap is what's conspicuously absent given that trajectory.
- **Ranked role theses** with a single numeric **Conviction (1–5)** score = evidenced need × CV-to-role fit × decision-maker reachability. That one number flows to the report header and the machine summary, consistent with how `oferta` scores.
- Reads the candidate's archetypes, stage calibration, and gambit edge from `_profile.md` (user layer) — exactly as `oferta` reads `_profile.md` for framing.

**The `Speculative` state**
`templates/states.yml` is the named source of truth, but several consumers hardcode the state list, so a new state has real blast radius. This PR propagates it to **every** consumer so nothing silently downgrades a `Speculative` row to `Evaluated`:

| Layer | File(s) |
|---|---|
| Source of truth | `templates/states.yml` |
| JS pipeline | `normalize-statuses.mjs`, `verify-pipeline.mjs`, `dedup-tracker.mjs`, `merge-tracker.mjs` |
| Go dashboard | `dashboard/internal/data/career.go`, `dashboard/internal/ui/screens/pipeline.go` (render, sort, group, color) |

**Lifecycle:** `Speculative` → `Responded` / `Interview` / `Offer` (if the pitch lands) or `Discarded` (if it doesn't). It marks a pursuit that has no posting behind it yet.

**Wiring + docs**
- Skill routing in `.agents/skills/career-ops/SKILL.md` (added to the mode table, the help text, the `_shared.md` group, and the research-heavy subagent-delegation list).
- Documented in `AGENTS.md` and `CLAUDE.md`, and CI-enforced via `test-all.mjs`.
- `modes/_profile.template.md` gains two **bio-free, fill-in-yourself** scaffolds — `## Your Natural Level & Company-Stage Calibration` and `## Gambit Playbook` — so the two sections `gambit.md` reads actually exist on a fresh install instead of resolving to nothing.

## Testing

- `node test-all.mjs` → **157 passed, 0 failed** (5 new assertions covering the `Speculative` state across states.yml, verify-pipeline, normalize-statuses, dedup-tracker, and merge-tracker).
- `cd dashboard && go test ./...` → **pass** (`internal/data`, `internal/ui/screens`, including Speculative render/sort coverage).

## Notes for the maintainer

- **CLI skill parity (intentional scope choice):** routing was added to `.agents/skills/career-ops/SKILL.md` only. The `.claude/` and `.qwen/` variants are structurally different, so I left mirroring them to your conventions rather than guessing. Happy to extend if you'd prefer it in one PR.
- No user/personal data is included — only system-layer files. The personalization hook lives entirely in the `_profile.template.md` placeholders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Create-a-Role” workflow for proposing evidence-backed roles that do not yet have job postings.
  - Added the **Speculative** application status, including aliases such as “spec” and “gambit.”
  - Added Speculative filtering, sorting, display labels, colors, and localized support in the career pipeline.

- **Bug Fixes**
  - Improved status normalization, validation, duplicate handling, and pipeline verification for speculative applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->