### PR TITLE
fix(flake): declare systems so the devShell resolves on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,17 @@
 
       inputs.nixpkgs = nixpkgs;
 
+      # flakelight only exposes its default Linux systems unless `systems` is
+      # set, so on macOS `nix develop` / direnv fail with a confusing
+      # "does not provide attribute 'devShells.aarch64-darwin.default'" error.
+      # List the common dev systems so the devShell resolves on macOS too.
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
       devShell.packages =
         pkgs: with pkgs; [
 


### PR DESCRIPTION
## What does this PR do?

`flake.nix` calls `flakelight ./.` without a `systems` attribute, so flakelight only exposes its default Linux systems. On macOS, `nix develop` / direnv then fail with a confusing `flake ... does not provide attribute 'devShells.aarch64-darwin.default'` error (reported in #334). This adds an explicit `systems` list so the devShell resolves on macOS as well as Linux.

The devShell packages (`nodejs`, `bun`, `coreutils`, `playwright-driver.browsers`) are all available on darwin — `playwright-driver` inherits nodejs's platforms, and the `PLAYWRIGHT_BROWSERS_PATH = "${playwright-driver.browsers}"` pattern used here is the documented macOS setup — so adding darwin resolves the missing-attribute error rather than trading it for an eval failure. This matches the fix the reporter confirmed works on their macOS machine.

## Related issue

Fixes #334

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass — 151 passed, 0 failed (8 pre-existing warnings unrelated to this change: a `cv-sync-check` "expected without user data" note and `README.ua.md` maintainer-domain hits)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files) — only `flake.nix` changed
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

**Note on Nix verification:** I don't have a Nix install on this machine, so I couldn't run `nix flake check` / `nix develop` directly. The change is the exact `systems` list the reporter validated on macOS in #334, and `node test-all.mjs` (the CI gate) is green on this branch. A quick `nix develop` on macOS from a maintainer/reporter would be the final confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to ensure development shells properly resolve on macOS platforms, with explicit support for both Apple Silicon and Intel-based architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->