### PR TITLE
feat: Add SolidJobs provider and job_boards support in scanner  

### DIFF
--- a/providers/_types.js
+++ b/providers/_types.js
@@ -52,6 +52,7 @@
  * @property {Object<string,string>} [headers]
  * @property {string}                [method]
  * @property {(string|null)}         [body]
+ * @property {('error'|'follow'|'manual')} [redirect]
  */
 
 /**

--- a/providers/solidjobs.mjs
+++ b/providers/solidjobs.mjs
@@ -1,0 +1,53 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// SolidJobs provider — hits the public offers API.
+// Auto-detects from careers_url pattern `https://solid.jobs/public-api/offers/<division>`.
+//
+// Available divisions: it, engineering, marketing, sales, hr, logistics, finances, other
+// API docs: https://solid.jobs/public-api/offers/{division}?campaign={campaign}
+
+const ALLOWED_HOSTS = new Set(['solid.jobs']);
+
+function assertUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`solidjobs: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`solidjobs: URL must use HTTPS: ${url}`);
+  if (!ALLOWED_HOSTS.has(parsed.hostname))
+    throw new Error(`solidjobs: untrusted hostname "${parsed.hostname}" — must be solid.jobs`);
+  return url;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'solidjobs',
+
+  detect(entry) {
+    const url = entry.careers_url || '';
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname === 'solid.jobs' && parsed.pathname.startsWith('/public-api/offers/'))
+        return { url };
+    } catch {}
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const url = entry.careers_url;
+    if (!url) throw new Error('solidjobs: careers_url required');
+    assertUrl(url);
+    // redirect:'error' prevents SSRF via server-side redirects
+    const json = await ctx.fetchJson(url, { redirect: 'error' });
+    const jobs = Array.isArray(json?.jobs) ? json.jobs : [];
+    return jobs.map(j => ({
+      title: j.title || '',
+      url: j.url || '',
+      company: j.company || entry.name,
+      location: Array.isArray(j.locations) ? j.locations.join(', ') : '',
+    }));
+  },
+};

--- a/providers/solidjobs.mjs
+++ b/providers/solidjobs.mjs
@@ -9,6 +9,14 @@
 
 const ALLOWED_HOSTS = new Set(['solid.jobs']);
 
+/**
+ * Validates that the provided URL is a trusted SolidJobs API endpoint.
+ * Enforces HTTPS protocol, strict hostname matching, and required path prefix.
+ * 
+ * @param {string} url - The URL string to validate.
+ * @returns {string} The validated URL string.
+ * @throws {Error} If the URL is malformed, uses non-HTTPS, has an untrusted host, or wrong path.
+ */
 function assertUrl(url) {
   let parsed;
   try {
@@ -28,6 +36,11 @@ function assertUrl(url) {
 export default {
   id: 'solidjobs',
 
+  /**
+   * Attempts to detect if the provider can handle the given entry by checking the careers_url.
+   * * @param {{ careers_url?: string, name?: string }} entry - The configuration entry.
+   * @returns {{url: string} | null} An object with the matched URL, or null if not matched.
+   */
   detect(entry) {
     const url = entry.careers_url || '';
     try {
@@ -37,7 +50,13 @@ export default {
     } catch {}
     return null;
   },
-
+  
+  /**
+   * Fetches and normalizes job offers from the SolidJobs public API.
+   * * @param {{ careers_url?: string, name: string }} entry - The configuration entry being processed.
+   * @param {{ fetchJson: (url: string, opts?: { redirect?: 'error'|'follow'|'manual' }) => Promise<any> }} ctx - HTTP context.
+   * @returns {Promise<Array<{title: string, url: string, company: string, location: string}>>} Array of parsed job offers.
+   */
   async fetch(entry, ctx) {
     const url = entry.careers_url;
     if (!url) throw new Error('solidjobs: careers_url required');
@@ -47,11 +66,15 @@ export default {
     if (!json || !Array.isArray(json.jobs)) {
       throw new Error(`solidjobs: unexpected API response — expected { jobs: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`);
     }
-    return json.jobs
+
+    /** @type {Array<{ title?: string, url?: string, company?: string, locations?: string | string[] }>} */
+    const jobs = json.jobs;
+
+    return jobs
       .filter(j => j && typeof j === 'object' && typeof j.url === 'string' && j.url.trim() !== '')
       .map(j => ({
         title: j.title || '',
-        url: j.url,
+        url: /** @type {string} */ j.url || '',
         company: j.company || entry.name,
         location: Array.isArray(j.locations) ? j.locations.join(', ') : (typeof j.locations === 'string' ? j.locations : ''),
       }));

--- a/providers/solidjobs.mjs
+++ b/providers/solidjobs.mjs
@@ -42,12 +42,16 @@ export default {
     assertUrl(url);
     // redirect:'error' prevents SSRF via server-side redirects
     const json = await ctx.fetchJson(url, { redirect: 'error' });
-    const jobs = Array.isArray(json?.jobs) ? json.jobs : [];
-    return jobs.map(j => ({
-      title: j.title || '',
-      url: j.url || '',
-      company: j.company || entry.name,
-      location: Array.isArray(j.locations) ? j.locations.join(', ') : '',
-    }));
+    if (!json || !Array.isArray(json.jobs)) {
+      throw new Error(`solidjobs: unexpected API response — expected { jobs: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`);
+    }
+    return json.jobs
+      .filter(j => j.url)
+      .map(j => ({
+        title: j.title || '',
+        url: j.url,
+        company: j.company || entry.name,
+        location: Array.isArray(j.locations) ? j.locations.join(', ') : (typeof j.locations === 'string' ? j.locations : ''),
+      }));
   },
 };

--- a/providers/solidjobs.mjs
+++ b/providers/solidjobs.mjs
@@ -19,6 +19,8 @@ function assertUrl(url) {
   if (parsed.protocol !== 'https:') throw new Error(`solidjobs: URL must use HTTPS: ${url}`);
   if (!ALLOWED_HOSTS.has(parsed.hostname))
     throw new Error(`solidjobs: untrusted hostname "${parsed.hostname}" — must be solid.jobs`);
+  if (!parsed.pathname.startsWith('/public-api/offers/'))
+    throw new Error(`solidjobs: URL path must start with /public-api/offers/: ${url}`);
   return url;
 }
 
@@ -46,7 +48,7 @@ export default {
       throw new Error(`solidjobs: unexpected API response — expected { jobs: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`);
     }
     return json.jobs
-      .filter(j => j.url)
+      .filter(j => j && typeof j === 'object' && typeof j.url === 'string' && j.url.trim() !== '')
       .map(j => ({
         title: j.title || '',
         url: j.url,

--- a/scan.mjs
+++ b/scan.mjs
@@ -421,9 +421,10 @@ async function main() {
     process.exit(1);
   }
 
-  const config = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
-  const companies = Array.isArray(config?.tracked_companies) ? config.tracked_companies : [];
-  const boards = Array.isArray(config?.job_boards) ? config.job_boards : [];
+  const rawConfig = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
+  const config = rawConfig && typeof rawConfig === 'object' ? rawConfig : {};
+  const companies = Array.isArray(config.tracked_companies) ? config.tracked_companies : [];
+  const boards = Array.isArray(config.job_boards) ? config.job_boards : [];
   const titleFilter = buildTitleFilter(config.title_filter);
   const locationFilter = buildLocationFilter(config.location_filter);
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -460,7 +460,6 @@ async function main() {
       const resolved = resolveProvider(entry, providers);
       if (!resolved) {
         skippedCount++;
-        // Logika z brancha main przeniesiona tutaj
         if (entry.scan_method === 'websearch') {
           agentHandoff.push({
             company: entry.name,

--- a/scan.mjs
+++ b/scan.mjs
@@ -422,8 +422,8 @@ async function main() {
   }
 
   const config = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
-  const companies = config.tracked_companies || [];
-  const boards = config.job_boards || [];
+  const companies = Array.isArray(config?.tracked_companies) ? config.tracked_companies : [];
+  const boards = Array.isArray(config?.job_boards) ? config.job_boards : [];
   const titleFilter = buildTitleFilter(config.title_filter);
   const locationFilter = buildLocationFilter(config.location_filter);
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -421,7 +421,13 @@ async function main() {
     process.exit(1);
   }
 
-  const rawConfig = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
+  let rawConfig;
+  try {
+    rawConfig = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
+  } catch (err) {
+    console.error(`Error: failed to parse ${PORTALS_PATH}: ${err.message}`);
+    process.exit(1);
+  }
   const config = rawConfig && typeof rawConfig === 'object' ? rawConfig : {};
   const companies = Array.isArray(config.tracked_companies) ? config.tracked_companies : [];
   const boards = Array.isArray(config.job_boards) ? config.job_boards : [];

--- a/scan.mjs
+++ b/scan.mjs
@@ -423,40 +423,67 @@ async function main() {
 
   const config = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
   const companies = config.tracked_companies || [];
+  const boards = config.job_boards || [];
   const titleFilter = buildTitleFilter(config.title_filter);
   const locationFilter = buildLocationFilter(config.location_filter);
 
-  // 3. Resolve a provider for each enabled company
+  // 3. Resolve a provider for each enabled company / board
   const targets = [];
   let skippedCount = 0;
+  let boardCount = 0;
   const resolveErrors = [];
   const agentHandoff = [];
-  for (const company of companies) {
-    if (!company || typeof company !== 'object') continue;
-    if (company.enabled === false) continue;
-    if (typeof company.name !== 'string' || !company.name.trim()) {
-      console.error(`⚠️  Skipping entry — missing or non-string 'name' field: ${JSON.stringify(company)}`);
-      continue;
-    }
-    if (filterCompany && !company.name.toLowerCase().includes(filterCompany)) continue;
-    const resolved = resolveProvider(company, providers);
-    if (!resolved) {
-      skippedCount++;
-      if (company.scan_method === 'websearch') {
-        agentHandoff.push({
-          company: company.name,
-          method: 'websearch',
-          query: company.scan_query || company.search_query || company.careers_url || '',
-        });
+
+  /**
+   * Processes a list of configuration entries, resolves their appropriate data providers,
+   * and appends valid entries to the global scanning targets list.
+   * @param {Array<{ name?: string, enabled?: boolean, [key: string]: unknown }>} entries - List of entries.
+   * @param {{ isBoard?: boolean }} [options={}] - Configuration options.
+   */
+  function resolveEntries(entries, { isBoard = false } = {}) {
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (entry.enabled === false) continue;
+      if (typeof entry.name !== 'string' || !entry.name.trim()) {
+        console.error(`⚠️  Skipping entry — missing or non-string 'name' field: ${JSON.stringify(entry)}`);
+        continue;
       }
-      continue;
+      if (filterCompany && !entry.name.toLowerCase().includes(filterCompany)) continue;
+      
+      const resolved = resolveProvider(entry, providers);
+      if (!resolved) {
+        skippedCount++;
+        // Logika z brancha main przeniesiona tutaj
+        if (entry.scan_method === 'websearch') {
+          agentHandoff.push({
+            company: entry.name,
+            method: 'websearch',
+            query: entry.scan_query || entry.search_query || entry.careers_url || '',
+          });
+        }
+        continue;
+      }
+      
+      if (resolved.error) { 
+        resolveErrors.push({ company: entry.name, error: resolved.error }); 
+        continue; 
+      }
+      
+      targets.push({ ...entry, _provider: resolved.provider, _isBoard: isBoard });
+      if (isBoard) boardCount++;
     }
-    if (resolved.error) { resolveErrors.push({ company: company.name, error: resolved.error }); continue; }
-    targets.push({ ...company, _provider: resolved.provider });
   }
 
+  resolveEntries(companies);
+  resolveEntries(boards, { isBoard: true });
+
   const localParserCount = targets.filter(t => t._provider.id === 'local-parser').length;
-  console.log(`Scanning ${targets.length} companies via providers (${localParserCount} local parser; ${skippedCount} skipped — no provider matched)`);
+  const companyCount = targets.length - boardCount;
+  const parts = [`${companyCount} companies`];
+  if (boardCount > 0) parts.push(`${boardCount} job boards`);
+  parts.push(`${localParserCount} local parser`);
+  parts.push(`${skippedCount} skipped — no provider matched`);
+  console.log(`Scanning ${parts.join('; ')} via providers`);
   if (dryRun) console.log('(dry run — no files will be written)\n');
 
   // 4. Load dedup sets
@@ -574,7 +601,10 @@ async function main() {
   console.log(`\n${'━'.repeat(45)}`);
   console.log(`Portal Scan — ${date}`);
   console.log(`${'━'.repeat(45)}`);
-  console.log(`Companies scanned:     ${targets.length}`);
+  const summaryCompanies = targets.filter(t => !t._isBoard).length;
+  const summaryBoards = targets.filter(t => t._isBoard).length;
+  console.log(`Companies scanned:     ${summaryCompanies}`);
+  if (summaryBoards > 0) console.log(`Job boards scanned:    ${summaryBoards}`);
   console.log(`Total jobs found:      ${totalFound}`);
   console.log(`Filtered by title:     ${totalFilteredTitle} removed`);
   console.log(`Filtered by location:  ${totalFilteredLocation} removed`);

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -1256,4 +1256,3 @@ job_boards:
     provider: solidjobs
     enabled: false
     notes: "Polish job board — Other specialists division"
-

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -1197,3 +1197,63 @@ tracked_companies:
     scan_query: '"n11" careers "Software Engineer" OR "Backend" OR "Frontend" OR "Yazılım"'
     notes: "Istanbul. E-commerce marketplace (Doğuş Group)."
     enabled: false
+
+# ── Job Boards ────────────────────────────────────────────────────────
+# Multi-employer aggregators. Unlike tracked_companies (one entry = one employer),
+# job boards return offers from many companies in a single API call.
+# Same title/location filtering and dedup apply.
+
+job_boards:
+
+  # ── SolidJobs (Polish market) ──────────────────────────────────────
+  # Public API — no auth needed. Division in URL path, campaign=career-ops for tracking.
+  # Available divisions: it, engineering, marketing, sales, hr, logistics, finances, other
+
+  - name: SolidJobs IT
+    careers_url: https://solid.jobs/public-api/offers/it?campaign=career-ops
+    provider: solidjobs
+    enabled: true
+    notes: "Polish IT job board — IT division"
+
+  - name: SolidJobs Engineering
+    careers_url: https://solid.jobs/public-api/offers/engineering?campaign=career-ops
+    provider: solidjobs
+    enabled: false
+    notes: "Polish job board — Engineering & Production division"
+
+  - name: SolidJobs Marketing
+    careers_url: https://solid.jobs/public-api/offers/marketing?campaign=career-ops
+    provider: solidjobs
+    enabled: false
+    notes: "Polish job board — Marketing division"
+
+  - name: SolidJobs Sales
+    careers_url: https://solid.jobs/public-api/offers/sales?campaign=career-ops
+    provider: solidjobs
+    enabled: false
+    notes: "Polish job board — Sales division"
+
+  - name: SolidJobs HR
+    careers_url: https://solid.jobs/public-api/offers/hr?campaign=career-ops
+    provider: solidjobs
+    enabled: false
+    notes: "Polish job board — HR division"
+
+  - name: SolidJobs Logistics
+    careers_url: https://solid.jobs/public-api/offers/logistics?campaign=career-ops
+    provider: solidjobs
+    enabled: false
+    notes: "Polish job board — Logistics division"
+
+  - name: SolidJobs Finances
+    careers_url: https://solid.jobs/public-api/offers/finances?campaign=career-ops
+    provider: solidjobs
+    enabled: false
+    notes: "Polish job board — Finances division"
+
+  - name: SolidJobs Other
+    careers_url: https://solid.jobs/public-api/offers/other?campaign=career-ops
+    provider: solidjobs
+    enabled: false
+    notes: "Polish job board — Other specialists division"
+

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1508,6 +1508,17 @@ try {
   if (capturedOpts && capturedOpts.redirect === 'error') pass('solidjobs.fetch() passes redirect:"error" to fetchJson');
   else fail(`solidjobs.fetch() should pass redirect:"error", got: ${JSON.stringify(capturedOpts)}`);
 
+  // fetch() tolerates malformed array members without crashing
+  const malformedMembers = { jobs: [null, 7, { title: 'OK', url: 'https://solid.jobs/o/3/career-ops', company: 'Z' }] };
+  const safeParsed = await sj.fetch(
+    { name: 'SolidJobs IT', careers_url: 'https://solid.jobs/public-api/offers/it?campaign=career-ops' },
+    { transport: 'http', fetchJson: async () => malformedMembers, fetchText: async () => '' },
+  );
+  if (safeParsed.length === 1 && safeParsed[0].url === 'https://solid.jobs/o/3/career-ops') {
+    pass('solidjobs.fetch() skips malformed jobs members without crashing');
+  } else {
+    fail(`solidjobs.fetch() malformed members handling failed: ${JSON.stringify(safeParsed)}`);
+  }
 } catch (e) {
   fail(`solidjobs provider tests crashed: ${e.message}`);
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1417,6 +1417,97 @@ try {
   if (missingUrl) pass('solidjobs.fetch() throws on missing careers_url');
   else fail('solidjobs.fetch() should throw when careers_url is missing');
 
+  // fetch() rejects HTTP (non-HTTPS) URL
+  let httpRejected = false;
+  try {
+    await sj.fetch(
+      { name: 'HTTP', careers_url: 'http://solid.jobs/public-api/offers/it' },
+      { transport: 'http', fetchJson: async () => { throw new Error('should not reach here'); }, fetchText: async () => '' },
+    );
+  } catch (e) {
+    if (e.message.includes('HTTPS')) httpRejected = true;
+    else fail(`solidjobs.fetch() HTTP rejection wrong error: ${e.message}`);
+  }
+  if (httpRejected) pass('solidjobs.fetch() rejects HTTP URLs (HTTPS enforcement)');
+  else fail('solidjobs.fetch() should reject non-HTTPS URLs');
+
+  // fetch() rejects malformed/unparseable URL
+  let malformedRejected = false;
+  try {
+    await sj.fetch(
+      { name: 'Bad', careers_url: 'not-a-url' },
+      { transport: 'http', fetchJson: async () => { throw new Error('should not reach here'); }, fetchText: async () => '' },
+    );
+  } catch (e) {
+    if (e.message.includes('invalid URL')) malformedRejected = true;
+    else fail(`solidjobs.fetch() malformed URL wrong error: ${e.message}`);
+  }
+  if (malformedRejected) pass('solidjobs.fetch() rejects malformed URLs');
+  else fail('solidjobs.fetch() should reject unparseable URLs');
+
+  // fetch() throws on unexpected API response (no jobs array)
+  const badResponses = [
+    [{}, 'empty object'],
+    [{ jobs: null }, 'jobs: null'],
+    [{ jobs: 'not-array' }, 'jobs: string'],
+    [{ offers: [] }, 'wrong key name'],
+    [null, 'null response'],
+  ];
+  for (const [resp, label] of badResponses) {
+    let threw = false;
+    try {
+      await sj.fetch(
+        { name: 'SolidJobs IT', careers_url: 'https://solid.jobs/public-api/offers/it?campaign=career-ops' },
+        { transport: 'http', fetchJson: async () => resp, fetchText: async () => '' },
+      );
+    } catch (e) {
+      if (e.message.includes('unexpected API response')) threw = true;
+      else fail(`solidjobs.fetch() bad response (${label}) wrong error: ${e.message}`);
+    }
+    if (threw) pass(`solidjobs.fetch() throws on bad API response (${label})`);
+    else fail(`solidjobs.fetch() should throw on bad API response (${label})`);
+  }
+
+  // fetch() filters out jobs with empty/missing url
+  const mixedJobs = {
+    jobs: [
+      { title: 'Has URL', url: 'https://solid.jobs/o/1/career-ops', company: 'A', locations: [] },
+      { title: 'No URL', url: '', company: 'B', locations: [] },
+      { title: 'Missing URL', company: 'C', locations: [] },
+    ],
+  };
+  const filtered = await sj.fetch(
+    { name: 'SolidJobs IT', careers_url: 'https://solid.jobs/public-api/offers/it?campaign=career-ops' },
+    { transport: 'http', fetchJson: async () => mixedJobs, fetchText: async () => '' },
+  );
+  if (filtered.length === 1 && filtered[0].title === 'Has URL') pass('solidjobs.fetch() filters out jobs with empty/missing url');
+  else fail(`solidjobs.fetch() should filter empty URLs, got ${filtered.length} jobs: ${JSON.stringify(filtered)}`);
+
+  // fetch() handles string locations (non-array)
+  const stringLocJobs = { jobs: [{ title: 'Dev', url: 'https://solid.jobs/o/2/career-ops', company: 'X', locations: 'Warsaw' }] };
+  const strLoc = await sj.fetch(
+    { name: 'SolidJobs IT', careers_url: 'https://solid.jobs/public-api/offers/it?campaign=career-ops' },
+    { transport: 'http', fetchJson: async () => stringLocJobs, fetchText: async () => '' },
+  );
+  if (strLoc[0].location === 'Warsaw') pass('solidjobs.fetch() handles string locations');
+  else fail(`solidjobs.fetch() string location is ${JSON.stringify(strLoc[0].location)}, expected "Warsaw"`);
+
+  // detect() returns null for valid hostname but wrong path
+  if (sj.detect({ name: 'X', careers_url: 'https://solid.jobs/careers' }) === null) {
+    pass('solidjobs.detect() rejects solid.jobs URL with wrong path');
+  } else {
+    fail('solidjobs.detect() should reject solid.jobs URLs not under /public-api/offers/');
+  }
+
+  // fetch() passes redirect:'error' to fetchJson
+  let capturedOpts = null;
+  await sj.fetch(
+    { name: 'SolidJobs IT', careers_url: 'https://solid.jobs/public-api/offers/it?campaign=career-ops' },
+    { transport: 'http', fetchJson: async (_url, opts) => { capturedOpts = opts; return { jobs: [] }; }, fetchText: async () => '' },
+  );
+  if (capturedOpts && capturedOpts.redirect === 'error') pass('solidjobs.fetch() passes redirect:"error" to fetchJson');
+  else fail(`solidjobs.fetch() should pass redirect:"error", got: ${JSON.stringify(capturedOpts)}`);
+
 } catch (e) {
   fail(`solidjobs provider tests crashed: ${e.message}`);
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1307,6 +1307,118 @@ try {
   rmSync(ready, { recursive: true, force: true });
 } catch (e) {
   fail(`Cold-start trigger test crashed: ${e.message}`);
+// ── 15. PROVIDERS — SolidJobs ─────────────────────────────────────
+
+console.log('\n15. Provider — solidjobs');
+
+try {
+  const sj = (await import(pathToFileURL(join(ROOT, 'providers/solidjobs.mjs')).href)).default;
+
+  if (sj.id === 'solidjobs') pass('solidjobs.id is "solidjobs"');
+  else fail(`solidjobs.id is ${JSON.stringify(sj.id)}`);
+
+  // detect() matches valid SolidJobs API URL
+  const hit = sj.detect({ name: 'SJ', careers_url: 'https://solid.jobs/public-api/offers/it?campaign=career-ops' });
+  if (hit && hit.url) pass('solidjobs.detect() matches valid API URL');
+  else fail('solidjobs.detect() should match solid.jobs public-api URL');
+
+  // detect() rejects non-SolidJobs URL
+  if (sj.detect({ name: 'X', careers_url: 'https://example.com/jobs' }) === null) {
+    pass('solidjobs.detect() rejects non-SolidJobs URL');
+  } else {
+    fail('solidjobs.detect() must reject non-SolidJobs URLs');
+  }
+
+  // detect() rejects path-spoofed URL (solid.jobs in path, not hostname)
+  if (sj.detect({ name: 'X', careers_url: 'https://evil.example/solid.jobs/public-api/offers/it' }) === null) {
+    pass('solidjobs.detect() rejects path-spoofed URLs');
+  } else {
+    fail('solidjobs.detect() must NOT misdetect URLs with solid.jobs in the path');
+  }
+
+  // detect() returns null for non-string careers_url
+  if (sj.detect({ name: 'X', careers_url: 42 }) === null) {
+    pass('solidjobs.detect() returns null for non-string careers_url (42)');
+  } else {
+    fail('solidjobs.detect() should treat non-string careers_url as missing');
+  }
+
+  // detect() returns null for missing careers_url
+  if (sj.detect({ name: 'X' }) === null) {
+    pass('solidjobs.detect() returns null for missing careers_url');
+  } else {
+    fail('solidjobs.detect() should return null when careers_url is missing');
+  }
+
+  // fetch() parses { jobs: [...] } response with company from API
+  const fakeJobs = {
+    jobs: [
+      { title: 'Senior Dev', url: 'https://solid.jobs/o/abc123/career-ops', company: 'Acme Corp', locations: ['Warszawa', 'Remote'] },
+      { title: 'Junior Dev', url: 'https://solid.jobs/o/def456/career-ops', company: 'Beta Inc', locations: ['Kraków'] },
+    ],
+  };
+  const parsed = await sj.fetch(
+    { name: 'SolidJobs IT', careers_url: 'https://solid.jobs/public-api/offers/it?campaign=career-ops' },
+    { transport: 'http', fetchJson: async () => fakeJobs, fetchText: async () => '' },
+  );
+  if (parsed.length === 2) pass('solidjobs.fetch() returns 2 jobs from mock response');
+  else fail(`solidjobs.fetch() returned ${parsed.length} jobs, expected 2`);
+
+  if (parsed[0].company === 'Acme Corp') pass('solidjobs.fetch() uses j.company from API response');
+  else fail(`solidjobs.fetch() company is ${JSON.stringify(parsed[0].company)}, expected "Acme Corp"`);
+
+  if (parsed[0].location === 'Warszawa, Remote') pass('solidjobs.fetch() joins locations array');
+  else fail(`solidjobs.fetch() location is ${JSON.stringify(parsed[0].location)}, expected "Warszawa, Remote"`);
+
+  if (parsed[0].title === 'Senior Dev' && parsed[0].url === 'https://solid.jobs/o/abc123/career-ops') {
+    pass('solidjobs.fetch() maps title and url correctly');
+  } else {
+    fail(`solidjobs.fetch() title/url wrong: ${JSON.stringify(parsed[0])}`);
+  }
+
+  // fetch() falls back to entry.name when j.company is missing
+  const noCompanyJobs = { jobs: [{ title: 'Tester', url: 'https://solid.jobs/o/xyz/career-ops', locations: [] }] };
+  const fallback = await sj.fetch(
+    { name: 'SolidJobs IT', careers_url: 'https://solid.jobs/public-api/offers/it?campaign=career-ops' },
+    { transport: 'http', fetchJson: async () => noCompanyJobs, fetchText: async () => '' },
+  );
+  if (fallback[0].company === 'SolidJobs IT') pass('solidjobs.fetch() falls back to entry.name when j.company missing');
+  else fail(`solidjobs.fetch() fallback company is ${JSON.stringify(fallback[0].company)}`);
+
+  // fetch() handles empty locations array
+  if (fallback[0].location === '') pass('solidjobs.fetch() returns empty string for empty locations array');
+  else fail(`solidjobs.fetch() location for empty array is ${JSON.stringify(fallback[0].location)}`);
+
+  // fetch() rejects non-SolidJobs hostname (SSRF)
+  let ssrfRejected = false;
+  try {
+    await sj.fetch(
+      { name: 'Evil', careers_url: 'https://evil.com/public-api/offers/it' },
+      { transport: 'http', fetchJson: async () => { throw new Error('SSRF! should not reach here'); }, fetchText: async () => '' },
+    );
+  } catch (e) {
+    if (e.message.includes('untrusted hostname')) ssrfRejected = true;
+    else fail(`solidjobs.fetch() rejected with wrong error: ${e.message}`);
+  }
+  if (ssrfRejected) pass('solidjobs.fetch() rejects untrusted hostname (SSRF protection)');
+  else fail('solidjobs.fetch() should reject non-solid.jobs hostnames');
+
+  // fetch() throws on missing careers_url
+  let missingUrl = false;
+  try {
+    await sj.fetch(
+      { name: 'No URL' },
+      { transport: 'http', fetchJson: async () => ({}), fetchText: async () => '' },
+    );
+  } catch (e) {
+    if (e.message.includes('careers_url required')) missingUrl = true;
+    else fail(`solidjobs.fetch() missing URL error: ${e.message}`);
+  }
+  if (missingUrl) pass('solidjobs.fetch() throws on missing careers_url');
+  else fail('solidjobs.fetch() should throw when careers_url is missing');
+
+} catch (e) {
+  fail(`solidjobs provider tests crashed: ${e.message}`);
 }
 
 // ── SUMMARY ─────────────────────────────────────────────────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -413,9 +413,9 @@ console.log('\n9. Local parser contract');
 
 const scanScript = readFile('scan.mjs');
 if (
-  scanScript.includes('typeof company.name !== \'string\'') &&
-  scanScript.includes('company.name.trim()') &&
-  scanScript.includes('company.name.toLowerCase()')
+  scanScript.includes('typeof entry.name !== \'string\'') &&
+  scanScript.includes('entry.name.trim()') &&
+  scanScript.includes('entry.name.toLowerCase()')
 ) {
   pass('scan.mjs guards company names before filtering');
 } else {
@@ -1307,6 +1307,7 @@ try {
   rmSync(ready, { recursive: true, force: true });
 } catch (e) {
   fail(`Cold-start trigger test crashed: ${e.message}`);
+}
 // ── 15. PROVIDERS — SolidJobs ─────────────────────────────────────
 
 console.log('\n15. Provider — solidjobs');


### PR DESCRIPTION
## What does this PR do?

This PR introduces support for SolidJobs as a new job board provider and refactors the scanner architecture to distinguish between single-company career pages and multi-employer aggregators. It adds a new job_boards configuration section in portals.yml and implements a dedicated provider (solidjobs.mjs) with robust security measures, including SSRF protection and strict API input validation.

## Related issue

Fixes #852

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SolidJobs multi-employer job board provider and support for scanning job boards alongside tracked companies; run summaries now report companies and job boards separately.

* **Documentation**
  * Added example configuration with multiple SolidJobs divisions.
  * JSDoc/docs updated to document an optional fetch redirect setting.

* **Bug Fixes / Reliability**
  * Strengthened input validation and SSRF protections for job-board URLs.

* **Tests**
  * Added comprehensive tests covering SolidJobs provider behavior and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->