### PR TITLE
feat: add npx career-ops scaffolder for one-command install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,31 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Publish the npm scaffolder only when a release was just created.
+      # Runs in the same job because a release created via GITHUB_TOKEN does
+      # not trigger separate `on: release` workflows.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: actions/setup-node@v4
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+      - name: Publish scaffolder to npm
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm publish --provenance --access public
+        working-directory: scaffolder
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "career-ops",
   "version": "1.8.1",
   "description": "AI-powered job search pipeline built on Claude Code",
+  "private": true,
   "scripts": {
     "doctor": "node doctor.mjs",
     "verify": "node verify-pipeline.mjs",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,11 @@
           "type": "json",
           "path": "package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "scaffolder/package.json",
+          "jsonpath": "$.version"
         }
       ]
     }

--- a/scaffolder/README.md
+++ b/scaffolder/README.md
@@ -1,0 +1,32 @@
+# career-ops
+
+One-command installer for [**career-ops**](https://github.com/santifer/career-ops) — the AI-powered job search pipeline built on Claude Code.
+
+```bash
+npx career-ops init
+```
+
+This scaffolds a ready-to-use workspace:
+
+1. Clones career-ops at the latest stable release
+2. Installs dependencies
+3. Creates your config files (`config/profile.yml`, `portals.yml`, `cv.md`) — **without overwriting anything you've already set up**
+
+Then open Claude Code in the folder and paste a job offer.
+
+## Usage
+
+```bash
+npx career-ops init [folder]   # default folder: ./career-ops
+```
+
+Prefer the manual route? `git clone` still works exactly as before — see the [setup guide](https://github.com/santifer/career-ops/blob/main/docs/SETUP.md).
+
+## Requirements
+
+- Node.js 18+
+- git
+
+## License
+
+MIT © [Santiago Fernández de Valderrama](https://santifer.io)

--- a/scaffolder/README.md
+++ b/scaffolder/README.md
@@ -12,7 +12,7 @@ This scaffolds a ready-to-use workspace:
 2. Installs dependencies
 3. Creates your config files (`config/profile.yml`, `portals.yml`, `cv.md`) — **without overwriting anything you've already set up**
 
-Then open Claude Code in the folder and paste a job offer.
+Then open your AI coding tool in the folder and paste a job offer. career-ops is AI-agnostic — Claude Code, Gemini, Codex, Qwen, OpenCode and GitHub Copilot CLI all work.
 
 ## Usage
 

--- a/scaffolder/bin/cli.mjs
+++ b/scaffolder/bin/cli.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// career-ops scaffolder — one-command install.
+// Clones the repo at the latest release tag, installs deps, and scaffolds
+// user config without ever touching files that already exist.
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, copyFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO = "https://github.com/santifer/career-ops.git";
+const LATEST_RELEASE = "https://api.github.com/repos/santifer/career-ops/releases/latest";
+const NPM = process.platform === "win32" ? "npm.cmd" : "npm";
+
+const USAGE = `career-ops — set up an AI job search workspace.
+
+Usage:
+  npx career-ops init [folder]    Create a new workspace (default: ./career-ops)
+
+After setup, open Claude Code inside the folder and paste a job offer.
+Docs: https://github.com/santifer/career-ops`;
+
+function die(msg) {
+  console.error(`\n✗ ${msg}\n`);
+  process.exit(1);
+}
+
+function has(cmd, arg = "--version") {
+  try {
+    execFileSync(cmd, [arg], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function latestTag() {
+  try {
+    const res = await fetch(LATEST_RELEASE, {
+      headers: { "User-Agent": "career-ops-cli", Accept: "application/vnd.github+json" },
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.tag_name || null;
+  } catch {
+    return null;
+  }
+}
+
+// Copy `from` -> `to` only if `to` doesn't already exist. Returns true if created.
+function copyIfMissing(dir, from, to) {
+  const dest = join(dir, to);
+  const src = join(dir, from);
+  if (existsSync(dest) || !existsSync(src)) return false;
+  copyFileSync(src, dest);
+  return true;
+}
+
+async function main() {
+  const [cmd, dirArg] = process.argv.slice(2);
+
+  if (!cmd || cmd === "-h" || cmd === "--help") {
+    console.log(USAGE);
+    process.exit(cmd ? 0 : 1);
+  }
+  if (cmd !== "init") die(`Unknown command "${cmd}".\n${USAGE}`);
+
+  const target = dirArg || "career-ops";
+  if (existsSync(target) && readdirSync(target).length > 0) {
+    die(`Target folder "${target}" already exists and is not empty. Pick another name.`);
+  }
+  if (!has("git")) die("git is required but was not found on PATH. Install git and try again.");
+
+  // Pretty path for messages: "./career-ops" for relative, as-is for absolute.
+  const isAbsolute = target.startsWith("/") || /^[A-Za-z]:/.test(target);
+  const display = isAbsolute ? target : `./${target}`;
+
+  // 1. Clone at the latest stable release (fall back to the default branch).
+  const tag = await latestTag();
+  console.log(`\n→ Cloning career-ops${tag ? ` @ ${tag}` : ""} into ${display} ...`);
+  const cloneArgs = ["clone", "--depth=1"];
+  if (tag) cloneArgs.push("--branch", tag);
+  cloneArgs.push(REPO, target);
+  try {
+    execFileSync("git", cloneArgs, { stdio: "inherit" });
+  } catch {
+    die("git clone failed. Check your network connection and try again.");
+  }
+
+  // 2. Install dependencies.
+  console.log("\n→ Installing dependencies (npm install) ...");
+  try {
+    execFileSync(NPM, ["install"], { cwd: target, stdio: "inherit" });
+  } catch {
+    console.warn('\n! npm install failed — you can re-run it manually later with "npm install".');
+  }
+
+  // 3. Scaffold user config — idempotent, never overwrites the user layer.
+  if (!existsSync(join(target, "config"))) mkdirSync(join(target, "config"), { recursive: true });
+  const created = [];
+  if (copyIfMissing(target, "config/profile.example.yml", "config/profile.yml")) created.push("config/profile.yml");
+  if (copyIfMissing(target, "templates/portals.example.yml", "portals.yml")) created.push("portals.yml");
+  const cv = join(target, "cv.md");
+  if (!existsSync(cv)) {
+    writeFileSync(
+      cv,
+      "# Your Name\n\n> Replace this file with your full CV in markdown.\n> It's the source of truth for all evaluations and generated PDFs.\n> See docs/SETUP.md for details.\n"
+    );
+    created.push("cv.md");
+  }
+
+  // 4. Next steps.
+  console.log(`\n✓ career-ops is ready in ${display}\n`);
+  if (created.length) console.log(`  Created: ${created.join(", ")}\n`);
+  console.log("Next steps:");
+  console.log(`  1. cd ${target}`);
+  console.log("  2. Edit config/profile.yml (your details) and cv.md (your CV)");
+  console.log("  3. Edit portals.yml with your target roles and companies");
+  console.log("  4. Open Claude Code here:  claude");
+  console.log("\nOptional (for PDF generation):");
+  console.log("  npx playwright install chromium\n");
+}
+
+main().catch((err) => die(err?.message || String(err)));

--- a/scaffolder/bin/cli.mjs
+++ b/scaffolder/bin/cli.mjs
@@ -4,18 +4,30 @@
 // user config without ever touching files that already exist.
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, copyFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, delimiter } from "node:path";
 
 const REPO = "https://github.com/santifer/career-ops.git";
 const LATEST_RELEASE = "https://api.github.com/repos/santifer/career-ops/releases/latest";
 const NPM = process.platform === "win32" ? "npm.cmd" : "npm";
+
+// career-ops is AI-agnostic: every one of these CLIs reads AGENTS.md and works
+// out of the box. We only detect them to tailor the final message — we never
+// install, configure, or remove anything per-CLI.
+const SUPPORTED_CLIS = [
+  { name: "Claude Code", cmd: "claude" },
+  { name: "Gemini CLI", cmd: "gemini" },
+  { name: "Codex", cmd: "codex" },
+  { name: "Qwen Code", cmd: "qwen" },
+  { name: "OpenCode", cmd: "opencode" },
+  { name: "GitHub Copilot CLI", cmd: "copilot" },
+];
 
 const USAGE = `career-ops — set up an AI job search workspace.
 
 Usage:
   npx career-ops init [folder]    Create a new workspace (default: ./career-ops)
 
-After setup, open Claude Code inside the folder and paste a job offer.
+After setup, open your AI coding tool inside the folder and paste a job offer.
 Docs: https://github.com/santifer/career-ops`;
 
 function die(msg) {
@@ -30,6 +42,25 @@ function has(cmd, arg = "--version") {
   } catch {
     return false;
   }
+}
+
+// Is `cmd` resolvable on PATH? Manual lookup so it works cross-platform
+// without spawning which/where (and without any dependency).
+function onPath(cmd) {
+  const exts = process.platform === "win32" ? (process.env.PATHEXT || ".EXE;.CMD;.BAT").split(";") : [""];
+  for (const dir of (process.env.PATH || "").split(delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      try {
+        if (existsSync(join(dir, cmd + ext))) return true;
+      } catch {}
+    }
+  }
+  return false;
+}
+
+function detectClis() {
+  return SUPPORTED_CLIS.filter((c) => onPath(c.cmd));
 }
 
 async function latestTag() {
@@ -114,7 +145,19 @@ async function main() {
   console.log(`  1. cd ${target}`);
   console.log("  2. Edit config/profile.yml (your details) and cv.md (your CV)");
   console.log("  3. Edit portals.yml with your target roles and companies");
-  console.log("  4. Open Claude Code here:  claude");
+
+  // 5. Tailor the "open your AI tool" line to whatever CLI is installed.
+  // career-ops works with all of them; this is guidance only.
+  const detected = detectClis();
+  if (detected.length === 1) {
+    console.log(`  4. Open your workspace:  ${detected[0].cmd}   (${detected[0].name} detected)`);
+  } else if (detected.length > 1) {
+    console.log(`  4. Open your workspace with any of:  ${detected.map((c) => c.cmd).join(", ")}   (detected)`);
+  } else {
+    console.log(`  4. Open your AI coding tool here, e.g.:  ${SUPPORTED_CLIS.map((c) => c.cmd).join(", ")}`);
+  }
+
+  console.log("\ncareer-ops is AI-agnostic — Claude Code, Gemini, Codex, Qwen, OpenCode and Copilot all work.");
   console.log("\nOptional (for PDF generation):");
   console.log("  npx playwright install chromium\n");
 }

--- a/scaffolder/package.json
+++ b/scaffolder/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "career-ops",
+  "version": "1.8.1",
+  "description": "One-command installer for career-ops — the AI-powered job search pipeline built on Claude Code.",
+  "bin": {
+    "career-ops": "bin/cli.mjs"
+  },
+  "type": "module",
+  "files": [
+    "bin/cli.mjs",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "career-ops",
+    "claude-code",
+    "job-search",
+    "scaffold",
+    "create",
+    "cli"
+  ],
+  "author": "Santiago Fernández de Valderrama <hi@santifer.io> (https://santifer.io)",
+  "homepage": "https://github.com/santifer/career-ops#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/santifer/career-ops.git",
+    "directory": "scaffolder"
+  },
+  "bugs": {
+    "url": "https://github.com/santifer/career-ops/issues"
+  },
+  "license": "MIT",
+  "dependencies": {}
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -90,6 +90,7 @@ const SYSTEM_PATHS = [
   'CITATION.cff',
   '.github/',
   'package.json',
+  'scaffolder/',
 ];
 
 // User layer paths — NEVER touch these (safety check)


### PR DESCRIPTION
Code phase for #855.

## What this adds

One-command install: `npx career-ops init [folder]` clones the repo at the latest release, runs `npm install`, and scaffolds starter config — **never overwriting existing user files**.

- `scaffolder/` — zero-dependency CLI (node builtins only), published to npm as `career-ops`. Kept as a separate package so `npx` stays tiny and instant; the heavy deps (Playwright) are installed by the cloned workspace, not at npx time.
- Root `package.json` → `private: true` so the workspace itself can't be published by accident.
- `release-please-config.json` → keeps `scaffolder/package.json` version in sync on every release.
- `release.yml` → publishes the scaffolder to npm when a release is created (same job as release-please, since a release created via `GITHUB_TOKEN` doesn't trigger `on: release` workflows).
- The final setup message **detects which supported CLI is installed** (Claude Code, Gemini, Codex, Qwen, OpenCode, Copilot) and tailors the "open your workspace" line accordingly. This is a read-only PATH lookup — nothing is installed, configured, or removed per CLI, so the workspace stays fully AI-agnostic.

## What this does NOT change

- `git clone` works exactly as before (power users / contributors).
- The Claude Code plugin install path is untouched.
- Fully additive; respects `DATA_CONTRACT.md` — the scaffolder never touches the user layer.

## Verification

- `node test-all.mjs` → **151 passed, 0 failed** (8 pre-existing warnings, none from `scaffolder/`).
- E2E run clones the latest release tag, installs deps, and creates `config/profile.yml` + `portals.yml` + `cv.md`. Re-running into a non-empty folder is refused; existing config is never overwritten.

## Before this can ship (maintainer)

1. Add an `NPM_TOKEN` repo secret (npm automation token).
2. First publish is manual, to reserve the name and start the counter: `cd scaffolder && npm publish --access public`. CI handles every release after that.
3. Follow-up PR adds the `npx` quick-start to SETUP.md / README + an npm downloads badge — intentionally **not** in this PR, so we never ship a command or badge before the package is live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-command workspace initialization via `npx career-ops init [folder]` that clones the latest release, installs dependencies, and creates default configuration files without overwriting existing setups.

* **Documentation**
  * Added documentation for the scaffolder CLI tool, including usage syntax, prerequisites (Node.js 18+), and next-step instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->