### PR TITLE
fix: scope npm package as @santifer/career-ops

### DIFF
--- a/scaffolder/README.md
+++ b/scaffolder/README.md
@@ -3,7 +3,7 @@
 One-command installer for [**career-ops**](https://github.com/santifer/career-ops) — the AI-powered job search pipeline built on Claude Code.
 
 ```bash
-npx career-ops init
+npx @santifer/career-ops init
 ```
 
 This scaffolds a ready-to-use workspace:
@@ -17,7 +17,7 @@ Then open your AI coding tool in the folder and paste a job offer. career-ops is
 ## Usage
 
 ```bash
-npx career-ops init [folder]   # default folder: ./career-ops
+npx @santifer/career-ops init [folder]   # default folder: ./career-ops
 ```
 
 Prefer the manual route? `git clone` still works exactly as before — see the [setup guide](https://github.com/santifer/career-ops/blob/main/docs/SETUP.md).

--- a/scaffolder/package.json
+++ b/scaffolder/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "career-ops",
+  "name": "@santifer/career-ops",
   "version": "1.8.1",
   "description": "One-command installer for career-ops — the AI-powered job search pipeline built on Claude Code.",
   "bin": {


### PR DESCRIPTION
npm rejects the unscoped name `career-ops` as too similar to an existing package (`careerops`). Publishing under the author scope instead — install is now `npx @santifer/career-ops init`.

- `scaffolder/package.json`: name → `@santifer/career-ops`
- `scaffolder/README.md`: updated install commands

No behavior change; `git clone` path untouched. Follow-up to #856. Refs #855.

`@santifer/career-ops@1.8.1` is already published to npm; this syncs the repo so the release workflow publishes the correct name going forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated scaffolder installation and usage instructions to reference the scoped package name when running the initialization command and specifying optional target folders.

* **Chores**
  * Updated package configuration to reflect the scoped package naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->