### PR TITLE
docs: lead install with npx @santifer/career-ops + onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@
 
 <p align="center"><strong>740+ job listings evaluated · 100+ personalized CVs · 1 dream role landed</strong></p>
 
-<p align="center"><a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/Join_the_community-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a></p>
+<p align="center">
+  <a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/Join_the_community-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  &nbsp;
+  <a href="https://www.npmjs.com/package/@santifer/career-ops"><img src="https://img.shields.io/npm/dt/@santifer/career-ops?style=for-the-badge&logo=npm&color=CB3837&label=npx%20installs" alt="npm installs"></a>
+</p>
 
 <p align="center">
   <sub>Built with</sub><br>
@@ -88,34 +92,36 @@ Built by someone who used it to evaluate 740+ job offers, generate 100+ tailored
 
 ## Quick Start
 
+**Fastest way — one command:**
+
 ```bash
-# 1. Clone and install
+npx @santifer/career-ops init
+```
+
+> 💡 `npx` ships with [Node.js](https://nodejs.org) — it runs the installer once,
+> without installing anything globally. No Node yet? Install it first.
+> (Already using a Claude Code / Gemini / Codex CLI? Then you already have it.)
+
+This clones the latest release into `./career-ops` and installs dependencies. Then:
+
+```bash
+cd career-ops
+claude   # or gemini / codex / qwen / opencode — open your AI CLI here
+```
+
+**On first launch, career-ops walks you through setup — your CV, profile and target roles — just by chatting. Nothing to edit by hand.**
+
+<details>
+<summary><b>Prefer to set it up manually? (git clone)</b></summary>
+
+```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
-npx playwright install chromium   # Required for PDF generation
-
-# 2. Check setup
-npm run doctor                     # Validates all prerequisites
-
-# 3. Configure
-cp config/profile.example.yml config/profile.yml  # Edit with your details
-cp templates/portals.example.yml portals.yml       # Customize companies
-
-# 4. Add your CV
-# Create cv.md in the project root with your CV in markdown
-
-# 5. Personalize with Claude
-claude   # Open Claude Code in this directory
-
-# Then ask Claude to adapt the system to you:
-# "Change the archetypes to backend engineering roles"
-# "Translate the modes to English"
-# "Add these 5 companies to portals.yml"
-# "Update my profile with this CV I'm pasting"
-
-# 6. Start using
-# Paste a job URL or run /career-ops
+npx playwright install chromium   # only needed for PDF generation
+claude   # open your AI CLI — it onboards you on first launch
 ```
+
+</details>
 
 > **The system is designed to be customized by Claude itself.** Modes, archetypes, scoring weights, negotiation scripts -- just ask Claude to change them. It reads the same files it uses, so it knows exactly what to edit.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -2,55 +2,49 @@
 
 ## Prerequisites
 
-- [Claude Code](https://claude.ai/code) installed and configured
-- Node.js 18+ (for PDF generation and utility scripts)
+- An AI coding CLI — [Claude Code](https://claude.ai/code), Gemini CLI, Codex, Qwen Code, OpenCode or GitHub Copilot CLI
+- [Node.js](https://nodejs.org) 18+ and `git` (`npx` ships with Node — the installer refuses to run without them)
 - (Optional) Go 1.21+ (for the dashboard TUI)
 
-## Quick Start (5 steps)
+## Quick Start
 
-### 1. Clone and install
+### Recommended — one command
+
+```bash
+npx @santifer/career-ops init
+```
+
+`npx` ships with Node.js — it runs the installer once without installing anything globally. This clones the latest release into `./career-ops` and installs dependencies. Then move into the workspace and open your AI CLI:
+
+```bash
+cd career-ops
+claude   # or gemini / codex / qwen / opencode
+```
+
+**On first launch, career-ops walks you through setup by chatting** — it asks for your CV, your details (name, target roles, salary), and sets up the job scanner with pre-configured companies. Nothing to edit by hand: just answer its questions. Then paste a job offer URL or description and it evaluates it, writes a report, generates a tailored PDF, and tracks it.
+
+### Advanced — clone manually
+
+<details>
+<summary>Prefer to clone the repo yourself?</summary>
 
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops
 npm install
-npx playwright install chromium   # Required for PDF generation
 ```
 
-### 2. Configure your profile
+Then open your AI CLI in the folder — the same first-run onboarding applies. Use this path if you want to track a specific branch, contribute, or audit the code before installing dependencies.
+
+</details>
+
+### PDF rendering (one-time)
+
+PDFs are rendered with a headless Chromium. Install it once per machine:
 
 ```bash
-cp config/profile.example.yml config/profile.yml
+npx playwright install chromium
 ```
-
-Edit `config/profile.yml` with your personal details: name, email, target roles, narrative, proof points.
-
-### 3. Add your CV
-
-Create `cv.md` in the project root with your full CV in markdown format. This is the source of truth for all evaluations and PDFs.
-
-(Optional) Create `article-digest.md` with proof points from your portfolio projects/articles.
-
-### 4. Configure portals
-
-```bash
-cp templates/portals.example.yml portals.yml
-```
-
-Edit `portals.yml`:
-- Update `title_filter.positive` with keywords matching your target roles
-- Add companies you want to track in `tracked_companies`
-- Customize `search_queries` for your preferred job boards
-
-### 5. Start using
-
-Open Claude Code in this directory:
-
-```bash
-claude
-```
-
-Then paste a job offer URL or description. Career-ops will automatically evaluate it, generate a report, create a tailored PDF, and track it.
 
 ## Available Commands
 


### PR DESCRIPTION
Aligns the repo core with the website (career-ops.org, already live) on the new install story.

## Changes
- **README.md** `## Quick Start`: `npx @santifer/career-ops init` is now the primary path (with a one-line note explaining what `npx` is + a link to Node.js). `git clone` moved to an `<details>` **Advanced** block. Both make clear the agent **onboards you conversationally on first launch** (CV, profile, target roles) — no manual config editing.
- **README.md hero**: npm-installs badge next to the Discord badge → public download metric.
- **docs/SETUP.md**: same Recommended / Advanced / PDF-one-time structure; prerequisites updated to be CLI-agnostic (Node 18+ / git).

## Why the onboarding emphasis
The scaffolder (1.8.2) deliberately does **not** pre-create `cv.md`/`profile.yml`/`portals.yml` — their absence triggers the agent's "First Run — Onboarding" (`AGENTS.md`). The docs now reflect that: install in one command, then the agent sets you up by chatting.

## Not in this PR
The 8 localized READMEs keep their current Quick Start; they'll get the npx-first + badge treatment in a follow-up i18n pass (coordinated with the docs site) to avoid rushed translations.

Verified: `node test-all.mjs` → 151 passed, 0 failed. Refs #855.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Streamlined Quick Start section featuring a simplified one-command installation flow with optional advanced manual steps available
* Reorganized setup instructions with clearer "Recommended" and "Advanced" installation and configuration guidance paths
* Added community engagement badges showcasing Discord community members and npm package download statistics
* Improved onboarding guidance to assist with initial setup, CV data collection, and job configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->