### PR TITLE
Fix PDF rendering hangs and restore scanner/template compatibility

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -150,10 +150,13 @@ async function generatePDF() {
   const browser = await chromium.launch({ headless: true });
   try {
     const page = await browser.newPage();
+    page.setDefaultTimeout(15_000);
 
-    // Set content with file base URL for any relative resources
+    // Use "load" instead of "networkidle": self-contained CV HTML can keep
+    // background requests or font bookkeeping alive longer than necessary,
+    // which makes PDF generation look hung even though the document is ready.
     await page.setContent(html, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
       baseURL: `file://${dirname(inputPath)}/`,
     });
 

--- a/modes/latex.md
+++ b/modes/latex.md
@@ -89,7 +89,7 @@ Each project becomes:
 ### Skills
 
 ```latex
-    \textbf{Languages}{: C, C++, Java, ...} \\
+    \textbf{Languages}{: Python, TypeScript, SQL, C, C++, ...} \\
     \textbf{Frameworks \& ML}{: PyTorch, LangChain, ...} \\
     \textbf{Tools \& Cloud}{: Docker, Kubernetes, ...}
 ```

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -10,7 +10,7 @@
    - US/Canada → `letter`
    - Rest of the world → `a4`
 6. Detect role archetype → adapt framing
-7. Rewrite Professional Summary by injecting JD keywords + exit narrative bridge ("Built and sold a business. Now applying systems thinking to [JD domain].")
+7. Rewrite Professional Summary by injecting JD keywords + the candidate's actual exit narrative from profile/context
 8. Select top 3-4 most relevant projects for the job
 9. Reorder experience bullets by JD relevance
 10. Build competency grid from JD requirements (6-8 keyword phrases)

--- a/scan.mjs
+++ b/scan.mjs
@@ -141,6 +141,11 @@ function buildTitleFilter(titleFilter) {
 //   - `block` matches → reject
 //   - `allow` empty → pass (already cleared block)
 //   - `allow` non-empty → must match at least one keyword
+//
+// Backward compatibility:
+//   - Older configs used `positive:` instead of `allow:`
+//   - Older configs could set `accept_empty: false` to reject postings whose
+//     provider returned a blank location string
 
 // Normalize a keyword list from portals.yml: tolerates a bare string
 // (wrapped to a 1-item array), null/undefined (→ []), and non-string
@@ -160,11 +165,14 @@ function normalizeKeywordList(value) {
 export function buildLocationFilter(locationFilter) {
   if (!locationFilter) return () => true;
   const alwaysAllow = normalizeKeywordList(locationFilter.always_allow);
-  const allow = normalizeKeywordList(locationFilter.allow);
+  const allow = normalizeKeywordList(
+    locationFilter.allow ?? locationFilter.positive
+  );
   const block = normalizeKeywordList(locationFilter.block);
+  const acceptEmpty = locationFilter.accept_empty !== false;
 
   return (location) => {
-    if (typeof location !== 'string' || location.trim() === '') return true;
+    if (typeof location !== 'string' || location.trim() === '') return acceptEmpty;
     const lower = location.toLowerCase();
     if (alwaysAllow.length > 0 && alwaysAllow.some(k => lower.includes(k))) return true;
     if (block.length > 0 && block.some(k => lower.includes(k))) return false;

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -214,7 +214,15 @@
 
   /* === PROJECTS === */
   .project {
-    margin-bottom: 12px;
+    margin-bottom: 18px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #f0f0f0;
+  }
+
+  .project:last-child {
+    margin-bottom: 0;
+    padding-bottom: 0;
+    border-bottom: none;
   }
 
   .project-title {
@@ -222,6 +230,7 @@
     font-size: 11.5px;
     font-weight: 600;
     color: hsl(270, 70%, 45%);
+    line-height: 1.35;
   }
 
   .project-badge {
@@ -237,14 +246,16 @@
   .project-desc {
     font-size: 10.5px;
     color: #444;
-    margin-top: 3px;
+    margin-top: 5px;
     line-height: 1.55;
   }
 
   .project-tech {
     font-size: 9.5px;
     color: #888;
-    margin-top: 3px;
+    margin-top: 5px;
+    line-height: 1.45;
+    display: block;
   }
 
   /* === EDUCATION === */

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -506,6 +506,22 @@ try {
   if (filter(42) === true) pass('non-string locations are passed through to downstream evaluation, not silently dropped');
   else fail('non-string locations should pass through');
 
+  // Case 16: legacy `positive` key aliases the current `allow` key
+  const legacyPositiveFilter = buildLocationFilter({ positive: ['berlin', 'germany'] });
+  if (legacyPositiveFilter('Berlin, Germany') === true && legacyPositiveFilter('Paris, France') === false) {
+    pass('legacy location_filter.positive aliases allow');
+  } else {
+    fail('legacy location_filter.positive should behave like allow');
+  }
+
+  // Case 17: legacy accept_empty=false rejects missing provider locations
+  const rejectEmptyFilter = buildLocationFilter({ allow: ['germany'], accept_empty: false });
+  if (rejectEmptyFilter('') === false && rejectEmptyFilter('   ') === false && rejectEmptyFilter(null) === false) {
+    pass('legacy accept_empty=false rejects missing locations');
+  } else {
+    fail('legacy accept_empty=false should reject blank and non-string locations');
+  }
+
 } catch (e) {
   fail(`always_allow tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
## Summary

Fixes #863.

This PR fixes a small set of system-layer compatibility and PDF-generation issues:

- PDF generation could appear to hang during HTML → PDF rendering
- older `location_filter` configs using `positive:` or `accept_empty: false` were no longer respected
- project entries in the HTML CV template were dense enough to risk ATS text-extraction collisions
- PDF/LaTeX mode examples contained overly specific or outdated sample wording

## Changes

### PDF generation
- set a default page timeout
- switched `page.setContent(... waitUntil)` from `networkidle` to `load`

### Scanner compatibility
- restored `positive:` as a backward-compatible alias for `allow:`
- restored `accept_empty: false` behavior
- added regression tests for both legacy options

### CV template / prompt cleanup
- improved spacing and separation between project blocks
- replaced candidate-specific/outdated prompt examples with neutral wording

## Validation

- `npm run doctor` — passed in a clean worktree with fictional setup files
- `node verify-pipeline.mjs` — passed
- `node cv-sync-check.mjs` — passed with expected fictional-data warnings
- PDF smoke test using `generate-pdf.mjs` — passed; valid one-page PDF generated
- `node test-all.mjs` — 153 passed; the only local failure was dashboard build because `go` is not installed in the local environment
- `git diff --check` — passed

## Notes

- no user-layer or candidate-specific data is included
- changes are limited to six system-layer files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PDF generation hangs caused by background/font requests in HTML content.
  * Improved location filtering to better handle missing or malformed data with backward compatibility support.

* **Documentation**
  * Updated programming languages list in LaTeX CV mode.
  * Reorganized documentation steps in PDF mode.

* **Style**
  * Enhanced Projects section styling in CV template with improved spacing and visual formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->