### PR TITLE
docs: mention Block G posting-legitimacy check in README features

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Built by someone who used it to evaluate 740+ job offers, generate 100+ tailored
 | Feature                  | Description                                                                                                                              |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | **Auto-Pipeline**        | Paste a URL, get a full evaluation + PDF + tracker entry                                                                                 |
-| **6-Block Evaluation**   | Role summary, CV match, level strategy, comp research, personalization, interview prep (STAR+R)                                          |
+| **6-Block Evaluation**   | Role summary, CV match, level strategy, comp research, personalization, interview prep (STAR+R) -- plus a Block G posting-legitimacy check that flags scams and ghost jobs |
 | **Interview Story Bank** | Accumulates STAR+Reflection stories across evaluations -- 5-10 master stories that answer any behavioral question                        |
 | **Negotiation Scripts**  | Salary negotiation frameworks, geographic discount pushback, competing offer leverage                                                    |
 | **ATS PDF Generation**   | Keyword-injected CVs with Space Grotesk + DM Sans design                                                                                 |


### PR DESCRIPTION
The Features table listed the 6 scoring blocks (A-F) but omitted **Block G** — the posting-legitimacy check that flags scams and ghost jobs (a separate qualitative assessment, per `modes/_shared.md`). Adds it so the table reflects the full evaluation report.

Verified: `node test-all.mjs` → 151 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature documentation for Auto-Pipeline / 6-Block Evaluation to include Block G, a new posting-legitimacy check that flags scams and ghost jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->