### PR TITLE
feat: optional editable .docx export via pandoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ claude   # or gemini / codex / qwen / opencode — open your AI CLI here
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
 npx playwright install chromium   # only needed for PDF generation
+brew install pandoc                # optional -- only needed for editable .docx export (generate-docx.mjs)
 claude   # open your AI CLI — it onboards you on first launch
 ```
 

--- a/generate-docx.mjs
+++ b/generate-docx.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * generate-docx.mjs — editable Word (.docx) export via pandoc.
+ *
+ * Companion to generate-pdf.mjs: the PDF is the submission/ATS artifact, the
+ * .docx is a hand-editable copy so you can tweak wording before sending.
+ * Converts a generated CV (HTML) or a cover letter (txt/md) into .docx.
+ *
+ * Requires: pandoc (https://pandoc.org)  ->  brew install pandoc  /  apt install pandoc
+ *
+ * Usage:
+ *   node generate-docx.mjs <input.html|.txt|.md> <output.docx> [--reference-doc=ref.docx]
+ */
+import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+import { extname } from "path";
+
+const PANDOC = ["pandoc", "/opt/homebrew/bin/pandoc", "/usr/local/bin/pandoc", "/usr/bin/pandoc"]
+  .find((p) => { try { execFileSync(p, ["--version"], { stdio: "ignore" }); return true; } catch { return false; } });
+if (!PANDOC) { console.error("pandoc not found. Install: brew install pandoc (macOS) / apt install pandoc (Linux)"); process.exit(1); }
+
+const argv = process.argv.slice(2);
+const positional = argv.filter((a) => !a.startsWith("--"));
+const [input, output] = positional;
+const refDoc = (argv.find((a) => a.startsWith("--reference-doc=")) || "").split("=")[1];
+if (!input || !output) { console.error("Usage: node generate-docx.mjs <input.html|.txt|.md> <output.docx> [--reference-doc=ref.docx]"); process.exit(1); }
+if (!existsSync(input)) { console.error("input not found: " + input); process.exit(1); }
+
+const ext = extname(input).toLowerCase();
+const from = ext === ".html" || ext === ".htm" ? "html" : "markdown";
+const pandocArgs = [input, "-f", from, "-t", "docx", "-o", output];
+if (refDoc && existsSync(refDoc)) pandocArgs.push("--reference-doc=" + refDoc);
+
+try {
+  execFileSync(PANDOC, pandocArgs, { stdio: ["ignore", "ignore", "inherit"] });
+  console.log("DOCX generated: " + output);
+} catch (e) { console.error("pandoc failed: " + (e.message || e)); process.exit(1); }

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -19,6 +19,7 @@
 13. Read `name` from `config/profile.yml` → normalize to kebab-case lowercase (e.g. "John Doe" → "john-doe") → `{candidate}`
 14. Write HTML to `/tmp/cv-{candidate}-{company}.html`
 15. Execute: `node generate-pdf.mjs /tmp/cv-{candidate}-{company}.html output/cv-{candidate}-{company}-{YYYY-MM-DD}.pdf --format={letter|a4}`
+15b. (Optional) Export an editable Word copy via pandoc: `node generate-docx.mjs /tmp/cv-{candidate}-{company}.html output/cv-{candidate}-{company}-{YYYY-MM-DD}.docx`. Requires pandoc; the script exits with a hint if pandoc is not installed, so this step is safe to skip when it is absent. The PDF stays the submission artifact; the .docx is for hand-editing.
 16. Report: PDF path, number of pages, keyword coverage %
 
 ## ATS Rules (clean parsing)


### PR DESCRIPTION
## What
Adds `generate-docx.mjs` — a small pandoc wrapper that exports a generated CV (HTML) or cover letter (txt/md) to an editable Word `.docx`, alongside the existing PDF.

## Why
The PDF is the submission/ATS artifact, but it's common to want to hand-tweak wording before sending. A `.docx` gives an editable copy without leaving the pipeline.

## How
- **`generate-docx.mjs`** (~30 LOC): `pandoc <input> -t docx -o <output>`. Auto-detects HTML vs markdown by extension; supports optional `--reference-doc` for styling.
- **`modes/pdf.md`**: one optional step (15b) after the PDF render.
- **`README.md`**: notes pandoc as an optional dependency (only needed for `.docx`).

## Notes
- **Optional + self-contained:** if pandoc isn't installed the script exits with a hint and the step is skipped — no impact on the existing PDF flow, no new npm deps.
- Follows the project's simple/minimal philosophy.
- Happy to open a tracking issue or adjust to fit conventions if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting CVs and cover letters to editable Word documents (.docx) format.

* **Documentation**
  * Documented optional pandoc installation for Word export functionality and included export instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->