### PR TITLE
Add company API source pipeline for non-ATS ecosystems

### DIFF
--- a/build-company-review-queue.mjs
+++ b/build-company-review-queue.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import path from 'path';
+
+const SHORTLIST_DIR = path.resolve('output');
+
+function latestShortlistPath() {
+  const today = new Date().toISOString().slice(0, 10);
+  const candidate = path.join(SHORTLIST_DIR, `company-dump-shortlist-${today}.md`);
+  if (existsSync(candidate)) return candidate;
+  throw new Error('No shortlist file found for today');
+}
+
+function parseShortlist(markdown) {
+  const sections = markdown.split(/^## /m).slice(1);
+  return sections.map(section => {
+    const lines = section.trim().split('\n');
+    const name = lines[0].trim();
+    const obj = { name, relevance: '', matchingRoles: '', careersHint: '', location: '', summary: '' };
+    for (const line of lines.slice(1)) {
+      const cleaned = line.trim();
+      if (cleaned.startsWith('- Relevance:')) obj.relevance = cleaned.replace('- Relevance: ', '').replace(/`/g, '');
+      else if (cleaned.startsWith('- Matching roles:')) obj.matchingRoles = cleaned.replace('- Matching roles: ', '');
+      else if (cleaned.startsWith('- Careers hint:')) obj.careersHint = cleaned.replace('- Careers hint: ', '');
+      else if (cleaned.startsWith('- Location:')) obj.location = cleaned.replace('- Location: ', '');
+      else if (cleaned.startsWith('- Summary:')) obj.summary = cleaned.replace('- Summary: ', '');
+    }
+    return obj;
+  });
+}
+
+function buildQueue(items) {
+  const direct = items.filter(item => item.relevance === 'direct-role-match').slice(0, 10);
+  const manual = items.filter(item => item.relevance === 'check-manually').slice(0, 12);
+
+  const lines = [];
+  lines.push(`# Company Review Queue — ${new Date().toISOString().slice(0, 10)}`);
+  lines.push('');
+  lines.push('## First Pass');
+  lines.push('');
+  for (const item of direct) {
+    lines.push(`- [ ] ${item.name} | ${item.matchingRoles || 'direct role match'} | ${item.careersHint || 'no public hint'} | ${item.location}`);
+  }
+  lines.push('');
+  lines.push('## Second Pass');
+  lines.push('');
+  for (const item of manual) {
+    lines.push(`- [ ] ${item.name} | manual check | ${item.careersHint || 'no public hint'} | ${item.location}`);
+  }
+  lines.push('');
+  lines.push('## Notes');
+  lines.push('');
+  lines.push('- First Pass = highest-priority companies for live vacancy/contact verification');
+  lines.push('- Second Pass = promising companies with openings signal but no role match yet');
+  return lines.join('\n');
+}
+
+function main() {
+  const shortlistPath = latestShortlistPath();
+  const markdown = readFileSync(shortlistPath, 'utf-8');
+  const items = parseShortlist(markdown);
+  const out = buildQueue(items);
+  const outPath = path.join(SHORTLIST_DIR, `company-review-queue-${new Date().toISOString().slice(0, 10)}.md`);
+  writeFileSync(outPath, out, 'utf-8');
+  console.log(`Wrote ${outPath}`);
+}
+
+main();

--- a/build-tracker-candidate-queue.mjs
+++ b/build-tracker-candidate-queue.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+
+const OUTPUT_DIR = path.resolve('output');
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function enrichedPath() {
+  const file = path.join(OUTPUT_DIR, `company-review-enriched-${today()}.md`);
+  if (!existsSync(file)) throw new Error(`Enriched review file not found: ${file}`);
+  return file;
+}
+
+function parseEnriched(md) {
+  const chunks = md.split(/^## /m).slice(1);
+  return chunks.map(chunk => {
+    const lines = chunk.trim().split('\n');
+    const name = lines[0].trim();
+    const item = {
+      name,
+      queueSection: '',
+      roleHint: '',
+      location: '',
+      originalHint: '',
+      candidates: [],
+    };
+    for (const raw of lines.slice(1)) {
+      const line = raw.trim();
+      if (line.startsWith('- Queue section: ')) item.queueSection = line.replace('- Queue section: ', '');
+      else if (line.startsWith('- Role hint: ')) item.roleHint = line.replace('- Role hint: ', '');
+      else if (line.startsWith('- Location: ')) item.location = line.replace('- Location: ', '');
+      else if (line.startsWith('- Original hint: ')) item.originalHint = line.replace('- Original hint: ', '');
+      else if (line.startsWith('- Candidate: ')) {
+        const rest = line.replace('- Candidate: ', '');
+        const [urlPart, scorePart, verifyPart] = rest.split(' | ');
+        const candidate = {
+          url: urlPart || '',
+          score: Number((scorePart || '').replace('score: ', '')) || 0,
+          verifyStatus: '',
+          verifyNote: '',
+        };
+        if (verifyPart && verifyPart.startsWith('verify: ')) {
+          const text = verifyPart.replace('verify: ', '');
+          const m = text.match(/^([^(]+)\((.*)\)$/);
+          if (m) {
+            candidate.verifyStatus = m[1].trim();
+            candidate.verifyNote = m[2].trim();
+          } else {
+            candidate.verifyStatus = text.trim();
+          }
+        }
+        item.candidates.push(candidate);
+      }
+    }
+    return item;
+  });
+}
+
+function rankItem(item) {
+  let score = 0;
+  if (item.queueSection === 'first pass') score += 5;
+  if (/backend|data|integration|api|software engineer/i.test(item.roleHint)) score += 4;
+  if (/frontend/i.test(item.roleHint)) score -= 2;
+
+  const statuses = new Set(item.candidates.map(c => c.verifyStatus));
+  if (statuses.has('careers-page')) score += 5;
+  if (statuses.has('company-page')) score += 3;
+  if (statuses.has('linkedin-company')) score += 1;
+  if (statuses.has('search-results')) score -= 1;
+  if (statuses.has('dead')) score -= 2;
+
+  return score;
+}
+
+function nextAction(item) {
+  const statuses = new Set(item.candidates.map(c => c.verifyStatus));
+  if (statuses.has('careers-page')) return 'Open official careers page and check live roles first';
+  if (statuses.has('company-page')) return 'Open company page and look for careers/contact links';
+  if (statuses.has('linkedin-company')) return 'Use company LinkedIn as fallback and search for official site';
+  return 'Manual web check needed';
+}
+
+function render(items) {
+  const lines = [];
+  lines.push(`# Tracker Candidate Queue — ${today()}`);
+  lines.push('');
+  for (const item of items) {
+    lines.push(`## ${item.name}`);
+    lines.push('');
+    lines.push(`- Priority score: ${item.priority}`);
+    if (item.roleHint) lines.push(`- Role hint: ${item.roleHint}`);
+    if (item.location) lines.push(`- Location: ${item.location}`);
+    lines.push(`- Next action: ${item.action}`);
+    const best = item.candidates[0];
+    if (best) {
+      lines.push(`- Best link: ${best.url}`);
+      if (best.verifyStatus) lines.push(`- Best link status: ${best.verifyStatus}${best.verifyNote ? ` (${best.verifyNote})` : ''}`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function main() {
+  const items = parseEnriched(readFileSync(enrichedPath(), 'utf-8'))
+    .map(item => ({
+      ...item,
+      priority: rankItem(item),
+      action: nextAction(item),
+    }))
+    .sort((a, b) => b.priority - a.priority || a.name.localeCompare(b.name))
+    .slice(0, 20);
+
+  const outPath = path.join(OUTPUT_DIR, `tracker-candidate-queue-${today()}.md`);
+  writeFileSync(outPath, render(items), 'utf-8');
+  console.log(`Wrote ${outPath}`);
+}
+
+main();

--- a/docs/COMPANY_SOURCES.md
+++ b/docs/COMPANY_SOURCES.md
@@ -1,0 +1,54 @@
+# Company API Sources
+
+Career-Ops already supports classic ATS-style job boards such as Greenhouse, Ashby, and Lever.
+This feature adds a second discovery path for ecosystems where opportunities are not exposed
+through a standard ATS board, but where company data is available through a browser-backed JSON API.
+
+## What This Enables
+
+- fetch company datasets from ecosystem maps and startup directories
+- run existing title and location filters against those datasets
+- build a shortlist of promising companies
+- generate a review queue for live vacancy/contact verification
+- support browser-backed APIs that are not accessible through plain HTTP clients
+
+## Workflow
+
+```bash
+npm run source:refresh -- --source startup-map-berlin --offset 0 --pages 8
+```
+
+This command:
+
+1. fetches company batches into `data/company-dumps/`
+2. rebuilds the shortlist
+3. builds a review queue
+4. enriches the queue with candidate links
+5. produces a tracker-candidate queue for the next manual pass
+
+## Why This Is Separate From ATS Scanning
+
+ATS boards start from live job postings.
+
+Company API sources start from a company dataset and then narrow down to likely targets before
+manual or browser-based verification. This is useful for:
+
+- startup ecosystem maps
+- regional startup directories
+- hiring/discovery aggregators
+- browser-only JSON APIs protected by Cloudflare or similar edge checks
+
+## Source Profiles
+
+Sources live in `sources/company-api/` as YAML profiles.
+
+Each profile defines:
+
+- `boot_url` — the page to open before making the API request
+- `transport` — `browser` or `http`
+- `api` request metadata
+- headers
+- default filters such as region and sort
+- payload template
+
+The included `startup-map-berlin.yml` profile is the first example implementation.

--- a/enrich-company-review-queue.mjs
+++ b/enrich-company-review-queue.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+
+const OUTPUT_DIR = path.resolve('output');
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function latestQueuePath() {
+  const file = path.join(OUTPUT_DIR, `company-review-queue-${today()}.md`);
+  if (!existsSync(file)) throw new Error(`Queue not found: ${file}`);
+  return file;
+}
+
+function parseArgs(argv) {
+  const args = {
+    limit: 10,
+    verify: true,
+    section: 'first-pass',
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--limit') args.limit = Number(argv[++i] || 10);
+    else if (arg === '--no-verify') args.verify = false;
+    else if (arg === '--section') args.section = argv[++i] || 'first-pass';
+  }
+  return args;
+}
+
+function parseQueue(md) {
+  const lines = md.split('\n');
+  const items = [];
+  let section = '';
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      section = line.replace('## ', '').trim().toLowerCase();
+      continue;
+    }
+    if (!line.startsWith('- [ ] ')) continue;
+    const body = line.replace('- [ ] ', '');
+    const parts = body.split(' | ').map(x => x.trim());
+    items.push({
+      section,
+      name: parts[0] || '',
+      roleHint: parts[1] || '',
+      extraRoleHint: parts[2] || '',
+      hintUrl: parts[parts.length - 2] || '',
+      location: parts[parts.length - 1] || '',
+    });
+  }
+  return items;
+}
+
+function sectionMatches(item, sectionArg) {
+  if (sectionArg === 'all') return true;
+  if (sectionArg === 'first-pass') return item.section === 'first pass';
+  if (sectionArg === 'second-pass') return item.section === 'second pass';
+  return true;
+}
+
+function normalizeUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return parsed.href;
+  } catch {
+    return '';
+  }
+}
+
+function scoreCandidate(url, companyName) {
+  const lower = url.toLowerCase();
+  const slug = companyName.toLowerCase().replace(/[^a-z0-9]+/g, '');
+  let score = 0;
+  if (lower.includes('careers') || lower.includes('jobs') || lower.includes('join')) score += 5;
+  if (lower.includes(slug)) score += 3;
+  if (lower.includes('linkedin.com')) score -= 3;
+  if (lower.includes('join.com')) score -= 1;
+  if (lower.includes('greenhouse') || lower.includes('lever') || lower.includes('ashby')) score += 2;
+  return score;
+}
+
+function fallbackCandidates(item) {
+  const candidates = [];
+  if (item.hintUrl) {
+    candidates.push({ url: item.hintUrl, score: 0 });
+    if (item.hintUrl.includes('linkedin.com/company/')) {
+      const linkedInJobs = item.hintUrl.replace(/\/$/, '') + '/jobs/';
+      candidates.push({ url: linkedInJobs, score: 1 });
+    }
+  }
+  const searchUrl = `https://www.bing.com/search?q=${encodeURIComponent(`${item.name} careers jobs`)}`;
+  candidates.push({ url: searchUrl, score: -1 });
+  return candidates;
+}
+
+async function searchCompany(page, companyName) {
+  const query = encodeURIComponent(`${companyName} careers jobs company`);
+  const url = `https://www.bing.com/search?q=${query}`;
+  await page.goto(url, { waitUntil: 'load', timeout: 30000 });
+  await page.waitForTimeout(1200);
+  const rawLinks = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('li.b_algo h2 a[href]')).map(a => a.href)
+  );
+
+  const unique = [];
+  const seen = new Set();
+  for (const link of rawLinks.map(normalizeUrl)) {
+    const lower = link.toLowerCase();
+    if (!link) continue;
+    if (seen.has(link)) continue;
+    if (lower.includes('bing.com')) continue;
+    if (lower.includes('microsoft.com')) continue;
+    seen.add(link);
+    unique.push(link);
+  }
+
+  return unique
+    .map(link => ({ url: link, score: scoreCandidate(link, companyName) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+}
+
+async function verifyUrl(page, url) {
+  try {
+    const response = await page.goto(url, { waitUntil: 'load', timeout: 30000 });
+    await page.waitForTimeout(1200);
+    const bodyText = await page.evaluate(() => (document.body?.innerText || '').replace(/\s+/g, ' ').trim().slice(0, 3000));
+    const title = await page.title();
+    const lower = `${title} ${bodyText}`.toLowerCase();
+    const lowerUrl = url.toLowerCase();
+    if ((response && response.status() >= 400) || lower.includes('404') || lower.includes('not found')) {
+      return { status: 'dead', note: `HTTP ${response?.status?.() || 'n/a'}` };
+    }
+    if (lowerUrl.includes('bing.com/search')) {
+      return { status: 'search-results', note: title };
+    }
+    if (lowerUrl.includes('linkedin.com/company/') && !lowerUrl.includes('/jobs')) {
+      return { status: 'linkedin-company', note: title };
+    }
+    if (lowerUrl.includes('linkedin.com/company/') && lowerUrl.includes('/jobs')) {
+      return { status: 'linkedin-jobs', note: title };
+    }
+    if (/(career|careers|jobs|open roles|open positions|join us|work with us)/i.test(lower)) {
+      return { status: 'careers-page', note: title };
+    }
+    if (/(contact|about us|team|company)/i.test(lower)) {
+      return { status: 'company-page', note: title };
+    }
+    return { status: 'uncertain', note: title };
+  } catch (err) {
+    return { status: 'error', note: err.message };
+  }
+}
+
+function renderMarkdown(results) {
+  const lines = [];
+  lines.push(`# Company Review Enrichment — ${today()}`);
+  lines.push('');
+  for (const item of results) {
+    lines.push(`## ${item.name}`);
+    lines.push('');
+    lines.push(`- Queue section: ${item.section}`);
+    if (item.roleHint) lines.push(`- Role hint: ${item.roleHint}`);
+    if (item.location) lines.push(`- Location: ${item.location}`);
+    if (item.hintUrl) lines.push(`- Original hint: ${item.hintUrl}`);
+    for (const candidate of item.candidates) {
+      const verify = candidate.verify ? ` | verify: ${candidate.verify.status} (${candidate.verify.note})` : '';
+      lines.push(`- Candidate: ${candidate.url} | score: ${candidate.score}${verify}`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const queue = parseQueue(readFileSync(latestQueuePath(), 'utf-8'))
+    .filter(item => sectionMatches(item, args.section))
+    .slice(0, args.limit);
+
+  const browser = await (await import('playwright')).chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+
+  const results = [];
+  try {
+    for (const item of queue) {
+      let candidates = await searchCompany(page, item.name);
+      if (candidates.length === 0) {
+        candidates = fallbackCandidates(item);
+      }
+      for (const candidate of candidates) {
+        if (args.verify && page) {
+          candidate.verify = await verifyUrl(page, candidate.url);
+        }
+      }
+      results.push({ ...item, candidates });
+    }
+  } finally {
+    if (browser) await browser.close();
+  }
+
+  const outPath = path.join(OUTPUT_DIR, `company-review-enriched-${today()}.md`);
+  writeFileSync(outPath, renderMarkdown(results), 'utf-8');
+  console.log(`Wrote ${outPath}`);
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/fetch-company-source.mjs
+++ b/fetch-company-source.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const SOURCES_DIR = path.resolve('sources/company-api');
+const DEFAULT_OUT_DIR = path.resolve('data/company-dumps');
+
+function parseArgs(argv) {
+  const args = {
+    source: 'startup-map-berlin',
+    offset: 0,
+    limit: null,
+    pages: 1,
+    region: null,
+    sort: null,
+    outDir: DEFAULT_OUT_DIR,
+    prefix: null,
+    dryRun: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--source') args.source = argv[++i] || args.source;
+    else if (arg === '--offset') args.offset = Number(argv[++i] || 0);
+    else if (arg === '--limit') args.limit = Number(argv[++i] || 0);
+    else if (arg === '--pages') args.pages = Number(argv[++i] || 1);
+    else if (arg === '--region') args.region = argv[++i] || null;
+    else if (arg === '--sort') args.sort = argv[++i] || null;
+    else if (arg === '--out-dir') args.outDir = path.resolve(argv[++i] || DEFAULT_OUT_DIR);
+    else if (arg === '--prefix') args.prefix = argv[++i] || null;
+    else if (arg === '--dry-run') args.dryRun = true;
+    else if (arg === '--help' || arg === '-h') args.help = true;
+  }
+
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node fetch-company-source.mjs --source startup-map-berlin --offset 0 --pages 4
+  node fetch-company-source.mjs --source startup-map-berlin --offset 800 --pages 8 --limit 25
+`);
+}
+
+function loadSourceConfig(sourceId) {
+  const filePath = path.join(SOURCES_DIR, `${sourceId}.yml`);
+  if (!existsSync(filePath)) throw new Error(`Unknown source: ${sourceId}`);
+  return yaml.load(readFileSync(filePath, 'utf-8'));
+}
+
+function formatDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function outputPath(outDir, prefix, index, offset) {
+  const n = String(index).padStart(2, '0');
+  return path.join(outDir, `${formatDate()}-${prefix}-batch-${n}-offset-${offset}.json`);
+}
+
+function interpolate(value, vars) {
+  if (Array.isArray(value)) return value.map(item => interpolate(item, vars));
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, interpolate(v, vars)]));
+  }
+  if (typeof value !== 'string') return value;
+
+  if (/^\{[a-z_]+\}$/.test(value)) {
+    const key = value.slice(1, -1);
+    return vars[key];
+  }
+
+  return value.replace(/\{([a-z_]+)\}/g, (_, key) => String(vars[key] ?? ''));
+}
+
+async function fetchInBrowser(config, request) {
+  const { chromium } = await import('playwright');
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage({
+      viewport: { width: 1440, height: 900 },
+      userAgent: config.browser?.user_agent || 'Mozilla/5.0 (compatible; career-ops)',
+    });
+    await page.goto(config.boot_url, { waitUntil: 'load', timeout: 45000 });
+    await page.waitForTimeout(2500);
+    const result = await page.evaluate(async ({ url, method, headers, body }) => {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: JSON.stringify(body),
+      });
+      const text = await response.text();
+      return { ok: response.ok, status: response.status, text };
+    }, request);
+
+    if (!result.ok) throw new Error(`HTTP ${result.status}: ${result.text.slice(0, 400)}`);
+    return JSON.parse(result.text);
+  } finally {
+    await browser.close();
+  }
+}
+
+async function fetchInHttp(request) {
+  const response = await fetch(request.url, {
+    method: request.method,
+    headers: request.headers,
+    body: JSON.stringify(request.body),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`HTTP ${response.status}: ${text.slice(0, 400)}`);
+  }
+  return await response.json();
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const config = loadSourceConfig(args.source);
+  const limit = args.limit || Number(config.defaults?.limit || 25);
+  const region = args.region || config.defaults?.region || '';
+  const sort = args.sort || config.defaults?.sort || '';
+  const prefix = args.prefix || config.defaults?.prefix || config.id || args.source;
+  const fieldsCsv = Array.isArray(config.fields) ? config.fields.join(',') : '';
+
+  if (!args.dryRun) mkdirSync(args.outDir, { recursive: true });
+
+  for (let pageIndex = 0; pageIndex < args.pages; pageIndex++) {
+    const offset = args.offset + pageIndex * limit;
+    const vars = {
+      fields_csv: fieldsCsv,
+      limit_num: limit,
+      offset_num: offset,
+      region,
+      sort,
+    };
+    const request = {
+      url: config.api?.url,
+      method: config.api?.method || 'POST',
+      headers: interpolate(config.headers || {}, vars),
+      body: interpolate(config.payload || {}, vars),
+    };
+
+    const json = config.transport === 'http'
+      ? await fetchInHttp(request)
+      : await fetchInBrowser(config, request);
+
+    const items = Array.isArray(json?.items) ? json.items.length : 0;
+    const total = Number(json?.total || 0);
+    const filePath = outputPath(args.outDir, prefix, pageIndex + 1, offset);
+
+    console.log(`source=${args.source} offset=${offset} items=${items} total=${total}`);
+    if (!args.dryRun) {
+      writeFileSync(filePath, JSON.stringify(json, null, 2), 'utf-8');
+      console.log(`wrote ${filePath}`);
+    }
+  }
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
     "scan": "node scan.mjs",
+    "dump:scan": "node scan-company-dumps.mjs --write",
+    "review:queue": "node build-company-review-queue.mjs",
+    "review:enrich": "node enrich-company-review-queue.mjs",
+    "tracker:candidates": "node build-tracker-candidate-queue.mjs",
+    "source:fetch": "node fetch-company-source.mjs",
+    "source:refresh": "node source-refresh.mjs",
     "patterns": "node analyze-patterns.mjs",
     "gemini:eval": "node gemini-eval.mjs"
   },

--- a/scan-company-dumps.mjs
+++ b/scan-company-dumps.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const DUMPS_DIR = path.resolve('data/company-dumps');
+const PORTALS_PATH = path.resolve('portals.yml');
+const PORTALS_EXAMPLE_PATH = path.resolve('templates/portals.example.yml');
+const OUT_DIR = path.resolve('output');
+
+function normalizeKeywordList(value) {
+  if (value == null) return [];
+  const arr = Array.isArray(value) ? value : [value];
+  return arr
+    .filter(v => typeof v === 'string')
+    .map(v => v.toLowerCase().trim())
+    .filter(Boolean);
+}
+
+function buildTitleFilter(titleFilter) {
+  const positive = normalizeKeywordList(titleFilter?.positive);
+  const negative = normalizeKeywordList(titleFilter?.negative);
+
+  return (title) => {
+    const lower = String(title || '').toLowerCase();
+    if (!lower) return false;
+    const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
+    const hasNegative = negative.some(k => lower.includes(k));
+    return hasPositive && !hasNegative;
+  };
+}
+
+function buildLocationFilter(locationFilter) {
+  if (!locationFilter) return () => true;
+  const alwaysAllow = normalizeKeywordList(locationFilter.always_allow);
+  const allow = normalizeKeywordList(locationFilter.allow);
+  const block = normalizeKeywordList(locationFilter.block);
+
+  return (location) => {
+    if (typeof location !== 'string' || location.trim() === '') return true;
+    const lower = location.toLowerCase();
+    if (alwaysAllow.length > 0 && alwaysAllow.some(k => lower.includes(k))) return true;
+    if (block.length > 0 && block.some(k => lower.includes(k))) return false;
+    if (allow.length === 0) return true;
+    return allow.some(k => lower.includes(k));
+  };
+}
+
+function slugify(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+function loadConfig() {
+  if (existsSync(PORTALS_PATH)) {
+    return yaml.load(readFileSync(PORTALS_PATH, 'utf-8'));
+  }
+  if (existsSync(PORTALS_EXAMPLE_PATH)) {
+    return yaml.load(readFileSync(PORTALS_EXAMPLE_PATH, 'utf-8'));
+  }
+  throw new Error('Neither portals.yml nor templates/portals.example.yml was found');
+}
+
+function parseJsonFile(filePath) {
+  const raw = readFileSync(filePath, 'utf-8');
+  if (!raw.trim()) return [];
+  const parsed = JSON.parse(raw);
+  if (Array.isArray(parsed)) return parsed;
+  if (Array.isArray(parsed?.items)) return parsed.items;
+  return [];
+}
+
+function parseJsonlFile(filePath) {
+  const lines = readFileSync(filePath, 'utf-8')
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+  return lines.map(line => JSON.parse(line));
+}
+
+function loadDumpItems(filePath) {
+  if (filePath.endsWith('.jsonl')) return parseJsonlFile(filePath);
+  if (filePath.endsWith('.json')) return parseJsonFile(filePath);
+  return [];
+}
+
+function extractLocation(company) {
+  const hq = Array.isArray(company?.hq_locations) ? company.hq_locations : [];
+  const first = hq.find(loc => loc?.is_headquarters) || hq[0];
+  if (!first) return '';
+  const city = first?.city?.name || '';
+  const country = first?.country?.name || '';
+  return [city, country].filter(Boolean).join(', ');
+}
+
+function getCareersHint(company) {
+  const linkedin = company?.linkedin_url || '';
+  if (linkedin) return linkedin;
+  return '';
+}
+
+function getCompanySummary(company) {
+  const parts = [];
+  if (company?.tagline) parts.push(company.tagline);
+  const industries = Array.isArray(company?.industries) ? company.industries.map(x => x?.name).filter(Boolean) : [];
+  if (industries.length) parts.push(`industries: ${industries.slice(0, 4).join(', ')}`);
+  if (company?.employees) parts.push(`size: ${company.employees}`);
+  if (company?.growth_stage) parts.push(`stage: ${company.growth_stage}`);
+  return parts.join(' | ');
+}
+
+function evaluateCompany(company, titleFilter, locationFilter) {
+  const roles = Array.isArray(company?.job_roles) ? company.job_roles.filter(Boolean) : [];
+  const location = extractLocation(company);
+  const matchingRoles = roles.filter(role => titleFilter(role) && locationFilter(location));
+  const locationPass = locationFilter(location);
+
+  const totalJobs = Number(company?.total_jobs_available || 0);
+  const hasOpeningsSignal = totalJobs > 0 || roles.length > 0;
+  const relevance =
+    matchingRoles.length > 0 ? 'direct-role-match'
+    : hasOpeningsSignal && locationPass ? 'check-manually'
+    : 'low-priority';
+
+  return {
+    name: company?.name || 'Unknown',
+    slug: slugify(company?.name || company?.path || company?.uuid || 'company'),
+    location,
+    matchingRoles,
+    allRoles: roles,
+    totalJobs,
+    relevance,
+    summary: getCompanySummary(company),
+    linkedin: company?.linkedin_url || '',
+    careersHint: getCareersHint(company),
+    websitePath: company?.path || '',
+    employees: company?.employees || '',
+    sourceUuid: company?.uuid || '',
+  };
+}
+
+function buildMarkdown(results, meta) {
+  const lines = [];
+  lines.push(`# Company Dump Shortlist — ${meta.date}`);
+  lines.push('');
+  lines.push(`- Files scanned: ${meta.files}`);
+  lines.push(`- Companies scanned: ${meta.totalCompanies}`);
+  lines.push(`- Direct role matches: ${meta.directMatches}`);
+  lines.push(`- Manual-check companies: ${meta.manualChecks}`);
+  lines.push('');
+
+  if (results.length === 0) {
+    lines.push('No relevant companies found.');
+    return lines.join('\n');
+  }
+
+  for (const item of results) {
+    lines.push(`## ${item.name}`);
+    lines.push('');
+    lines.push(`- Relevance: \`${item.relevance}\``);
+    if (item.location) lines.push(`- Location: ${item.location}`);
+    if (item.employees) lines.push(`- Size: ${item.employees}`);
+    if (item.summary) lines.push(`- Summary: ${item.summary}`);
+    if (item.matchingRoles.length > 0) lines.push(`- Matching roles: ${item.matchingRoles.join(' | ')}`);
+    else if (item.totalJobs > 0 || item.allRoles.length > 0) lines.push(`- Openings signal: total_jobs_available=${item.totalJobs}, listed roles=${item.allRoles.length}`);
+    if (item.linkedin) lines.push(`- LinkedIn: ${item.linkedin}`);
+    if (item.careersHint) lines.push(`- Careers hint: ${item.careersHint}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const write = args.includes('--write');
+  const config = loadConfig();
+  const titleFilter = buildTitleFilter(config?.title_filter);
+  const locationFilter = buildLocationFilter(config?.location_filter);
+
+  if (!existsSync(DUMPS_DIR)) {
+    throw new Error(`Dump directory not found: ${DUMPS_DIR}`);
+  }
+
+  const files = readdirSync(DUMPS_DIR)
+    .filter(name => /\.(json|jsonl)$/i.test(name))
+    .sort();
+
+  if (files.length === 0) {
+    console.log('No dump files found in data/company-dumps/');
+    return;
+  }
+
+  const evaluated = [];
+  let totalCompanies = 0;
+  const skippedFiles = [];
+
+  for (const file of files) {
+    const filePath = path.join(DUMPS_DIR, file);
+    let items = [];
+    try {
+      items = loadDumpItems(filePath);
+    } catch (err) {
+      skippedFiles.push({ file, error: err.message });
+      continue;
+    }
+    totalCompanies += items.length;
+    for (const company of items) {
+      evaluated.push(evaluateCompany(company, titleFilter, locationFilter));
+    }
+  }
+
+  const seen = new Set();
+  const deduped = evaluated.filter(item => {
+    const key = item.slug || item.name.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  const results = deduped
+    .filter(item => item.relevance !== 'low-priority')
+    .sort((a, b) => {
+      const weight = { 'direct-role-match': 0, 'check-manually': 1 };
+      return (weight[a.relevance] ?? 9) - (weight[b.relevance] ?? 9) || b.matchingRoles.length - a.matchingRoles.length || a.name.localeCompare(b.name);
+    });
+
+  const date = new Date().toISOString().slice(0, 10);
+  const meta = {
+    date,
+    files: files.length,
+    totalCompanies,
+    directMatches: results.filter(x => x.relevance === 'direct-role-match').length,
+    manualChecks: results.filter(x => x.relevance === 'check-manually').length,
+  };
+
+  const markdown = buildMarkdown(results, meta);
+
+  if (skippedFiles.length > 0) {
+    console.error(`Skipped ${skippedFiles.length} invalid or empty file(s):`);
+    for (const item of skippedFiles) {
+      console.error(`- ${item.file}: ${item.error}`);
+    }
+  }
+
+  if (write) {
+    mkdirSync(OUT_DIR, { recursive: true });
+    const outPath = path.join(OUT_DIR, `company-dump-shortlist-${date}.md`);
+    writeFileSync(outPath, markdown, 'utf-8');
+    console.log(`Wrote ${outPath}`);
+  } else {
+    console.log(markdown);
+  }
+}
+
+main();

--- a/source-refresh.mjs
+++ b/source-refresh.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'child_process';
+
+function parseArgs(argv) {
+  const args = {
+    source: 'startup-map-berlin',
+    offset: 0,
+    limit: null,
+    pages: 4,
+    region: null,
+    dryRun: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--source') args.source = argv[++i] || args.source;
+    else if (arg === '--offset') args.offset = Number(argv[++i] || 0);
+    else if (arg === '--limit') args.limit = Number(argv[++i] || 0);
+    else if (arg === '--pages') args.pages = Number(argv[++i] || 4);
+    else if (arg === '--region') args.region = argv[++i] || null;
+    else if (arg === '--dry-run') args.dryRun = true;
+  }
+
+  return args;
+}
+
+function run(cmd, args) {
+  execFileSync(cmd, args, { stdio: 'inherit' });
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const fetchArgs = [
+    'fetch-company-source.mjs',
+    '--source', args.source,
+    '--offset', String(args.offset),
+    '--pages', String(args.pages),
+  ];
+  if (args.limit) fetchArgs.push('--limit', String(args.limit));
+  if (args.region) fetchArgs.push('--region', args.region);
+  if (args.dryRun) fetchArgs.push('--dry-run');
+
+  run('node', fetchArgs);
+  if (args.dryRun) return;
+  run('node', ['scan-company-dumps.mjs', '--write']);
+  run('node', ['build-company-review-queue.mjs']);
+  run('node', ['enrich-company-review-queue.mjs', '--limit', '8']);
+  run('node', ['build-tracker-candidate-queue.mjs']);
+}
+
+main();

--- a/sources/company-api/startup-map-berlin.yml
+++ b/sources/company-api/startup-map-berlin.yml
@@ -1,0 +1,134 @@
+id: startup-map-berlin
+label: Startup Map Berlin / Dealroom
+transport: browser
+boot_url: https://startup-map.berlin/companies.startups
+api:
+  url: https://api.dealroom.co/api/v2/companies
+  method: POST
+headers:
+  accept: application/json, text/plain, */*
+  content-type: application/json
+  x-dealroom-app-id: "110618058"
+  x-requested-with: XMLHttpRequest
+  x-unsafe-url-referrer: https://startup-map.berlin/companies.startups
+browser:
+  user_agent: Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Mobile Safari/537.36
+defaults:
+  limit: 25
+  region: Berlin/Brandenburg Metropolitan Region
+  sort: -employee_12_months_growth_relative
+  prefix: startup-map-berlin
+fields:
+  - job_roles
+  - create_date
+  - uuid
+  - appstore_app_id
+  - client_focus
+  - company_status
+  - employees_chart
+  - employees_latest
+  - employees
+  - entity_sub_types
+  - employee_12_months_growth_percentile
+  - employee_12_months_growth_unique
+  - similarweb_12_months_growth_percentile
+  - similarweb_12_months_growth_unique
+  - similarweb_12_months_growth_delta
+  - similarweb_12_months_growth_relative
+  - similarweb_3_months_growth_delta
+  - similarweb_3_months_growth_percentile
+  - similarweb_3_months_growth_relative
+  - similarweb_3_months_growth_unique
+  - similarweb_6_months_growth_delta
+  - similarweb_6_months_growth_percentile
+  - similarweb_6_months_growth_relative
+  - similarweb_6_months_growth_unique
+  - facebook_url
+  - founders
+  - growth_stage
+  - growth_stage_manual
+  - hq_locations
+  - income_streams
+  - industries
+  - innovations_count
+  - investments
+  - investors
+  - is_editorial
+  - kpi_summary
+  - latest_valuation_enhanced
+  - launch_month
+  - launch_year
+  - linkedin_url
+  - lists_ids
+  - lists
+  - name
+  - patents_count
+  - path
+  - playmarket_app_id
+  - revenues
+  - sdgs
+  - service_industries
+  - similarweb_chart
+  - sub_industries
+  - tags
+  - tagline
+  - technologies
+  - total_funding_enhanced
+  - type
+  - tech_stack
+  - twitter_url
+  - employee_12_months_growth_delta
+  - employee_12_months_growth_relative
+  - employee_3_months_growth_delta
+  - employee_3_months_growth_percentile
+  - employee_3_months_growth_relative
+  - employee_3_months_growth_unique
+  - employee_6_months_growth_delta
+  - employee_6_months_growth_percentile
+  - employee_6_months_growth_relative
+  - employee_6_months_growth_unique
+  - founders_score_cumulated
+  - founders_top_university
+  - founders_top_past_companies
+  - fundings
+  - has_strong_founder
+  - has_super_founder
+  - images
+  - innovations
+  - innovation_corporate_rank
+  - is_ai_data
+  - ipo_round
+  - latest_revenue_enhanced
+  - matching_score
+  - past_founders_raised_10m
+  - past_founders
+  - startup_ranking_rating
+  - total_jobs_available
+  - year_became_unicorn
+  - year_became_future_unicorn
+payload:
+  fields: "{fields_csv}"
+  limit: "{limit_num}"
+  offset: "{offset_num}"
+  form_data:
+    must:
+      filters:
+        all_regions:
+          execution: or
+          values:
+            - "{region}"
+      execution: and
+    should:
+      filters: {}
+    must_not:
+      growth_stages:
+        - mature
+      company_type:
+        - service provider
+        - government nonprofit
+      tags:
+        - outside tech
+      company_status:
+        - closed
+  multi_match: false
+  sort: "{sort}"


### PR DESCRIPTION
## Summary
Adds a second discovery mode for `career-ops`: company-dataset ingestion for non-ATS ecosystems.

Today `career-ops` works well when the entry point is a live job board such as Greenhouse, Ashby, or Lever.
This PR adds a path for cases where the entry point is instead a company dataset exposed through a browser-backed JSON API.

That makes it possible to start from:
- startup maps
- ecosystem directories
- hiring/discovery aggregators
- browser-only JSON APIs that sit behind Cloudflare or similar edge checks

## What is included
- generic browser-backed company API source fetcher
- YAML source profiles under `sources/company-api/`
- `startup-map-berlin.yml` as the first real example profile
- company-dump shortlist builder
- review queue, enrichment, and tracker-candidate queue scripts
- docs for the new source type in `docs/COMPANY_SOURCES.md`

## Why this is useful
This is not meant to replace ATS scanning.
It adds a second discovery path for markets where interesting companies show up in ecosystem datasets long before a clean ATS posting is easy to find.

The resulting workflow is:
1. fetch company batches from a configured source profile
2. run existing title/location logic against that dataset
3. build a shortlist of promising companies
4. generate a review queue for live vacancy/contact verification
5. hand off the survivors to the normal tracker/application flow

## Why browser-backed transport matters
A plain HTTP client is not always enough for these sources.
Some APIs are only usable from a browser context because of Cloudflare or similar edge checks.
This PR therefore introduces a browser-backed transport mode instead of assuming every source can be fetched through plain server-side HTTP.

## Positioning
The PR is intentionally framed as a generic company API source pipeline, not as a one-off integration for a single Berlin-specific site.
`startup-map-berlin.yml` is included only as the first working profile that proves the abstraction.

## Draft status / maintainer questions
Keeping this as draft because I would value feedback on the product shape before polishing further:
- Is `sources/company-api/` the right home for this source type?
- Should this stay as separate scripts first, or eventually fold into the main `scan` UX?
- Is the shortlist -> review-queue -> candidate-queue flow the right level of abstraction, or too much for core?

If the direction is interesting, I can happily follow up with cleanup, naming adjustments, and a second source profile to prove the model is reusable.
