### PR TITLE
fix(batch): stop after min-score skip

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -437,7 +437,7 @@ process_offer() {
       if (( $(echo "$score < $MIN_SCORE" | bc -l) )); then
         update_state "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries"
         echo "    ⏭️  Skipped (score: $score < min-score: $MIN_SCORE)"
-        continue
+        return 0
       fi
     fi
 

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -474,7 +474,7 @@ print_summary() {
     return
   fi
 
-  local total=0 completed=0 failed=0 pending=0
+  local total=0 completed=0 skipped=0 failed=0 pending=0
   local score_sum=0 score_count=0
 
   while IFS=$'\t' read -r sid _ sstatus _ _ _ sscore _ _; do
@@ -487,12 +487,13 @@ print_summary() {
           score_count=$((score_count + 1))
         fi
         ;;
+      skipped) skipped=$((skipped + 1)) ;;
       failed) failed=$((failed + 1)) ;;
       *) pending=$((pending + 1)) ;;
     esac
   done < "$STATE_FILE"
 
-  echo "Total: $total | Completed: $completed | Failed: $failed | Pending: $pending"
+  echo "Total: $total | Completed: $completed | Skipped: $skipped | Failed: $failed | Pending: $pending"
 
   if (( score_count > 0 )); then
     local avg
@@ -560,8 +561,8 @@ main() {
         continue
       fi
     else
-      # Skip completed offers
-      if [[ "$status" == "completed" ]]; then
+      # Skip terminal offers
+      if [[ "$status" == "completed" || "$status" == "skipped" ]]; then
         continue
       fi
       # Skip failed offers that hit retry limit (unless --retry-failed)

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -313,7 +313,16 @@ for (const f of userFiles) {
 }
 
 const batchRunnerSource = readFile('batch/batch-runner.sh');
-if (/below-min-score" "\$retries"[\s\S]{0,220}return 0/.test(batchRunnerSource)) {
+const minScoreSkipIndex = batchRunnerSource.indexOf('update_state "$id" "$url" "skipped"');
+const minScoreReturnIndex = batchRunnerSource.indexOf('return 0', minScoreSkipIndex);
+const completedStateIndex = batchRunnerSource.indexOf('update_state "$id" "$url" "completed"', minScoreSkipIndex);
+if (
+  minScoreSkipIndex !== -1 &&
+  minScoreReturnIndex !== -1 &&
+  completedStateIndex !== -1 &&
+  minScoreSkipIndex < minScoreReturnIndex &&
+  minScoreReturnIndex < completedStateIndex
+) {
   pass('Batch min-score gate returns before completed state update');
 } else {
   fail('Batch min-score gate can fall through to completed state update');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -328,6 +328,20 @@ if (
   fail('Batch min-score gate can fall through to completed state update');
 }
 
+if (/if \[\[ "\$status" == "completed" \|\| "\$status" == "skipped" \]\]/.test(batchRunnerSource)) {
+  pass('Batch resume treats min-score skipped offers as terminal');
+} else {
+  fail('Batch resume can reprocess min-score skipped offers');
+}
+
+if (/local total=0 completed=0 skipped=0 failed=0 pending=0/.test(batchRunnerSource) &&
+    /skipped\) skipped=\$\(\(skipped \+ 1\)\)/.test(batchRunnerSource) &&
+    /Completed: \$completed \| Skipped: \$skipped \| Failed: \$failed \| Pending: \$pending/.test(batchRunnerSource)) {
+  pass('Batch summary reports skipped offers separately from pending');
+} else {
+  fail('Batch summary can misreport skipped offers as pending');
+}
+
 // ── 6. PERSONAL DATA LEAK CHECK ─────────────────────────────────
 
 console.log('\n6. Personal data leak check');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -312,6 +312,13 @@ for (const f of userFiles) {
   }
 }
 
+const batchRunnerSource = readFile('batch/batch-runner.sh');
+if (/below-min-score" "\$retries"[\s\S]{0,220}return 0/.test(batchRunnerSource)) {
+  pass('Batch min-score gate returns before completed state update');
+} else {
+  fail('Batch min-score gate can fall through to completed state update');
+}
+
 // ── 6. PERSONAL DATA LEAK CHECK ─────────────────────────────────
 
 console.log('\n6. Personal data leak check');


### PR DESCRIPTION
## Context

Santiago called out in #834 that the min-score fallthrough is a real standalone bug fix. This PR splits that fix out so it can be reviewed independently from the multi-agent batch work.

## Changes

- Return from `process_offer` after marking an offer as `skipped` for `below-min-score`.
- Add a regression check in `test-all.mjs` so the skipped path cannot fall through to the completed-state update.

## How to test

```bash
npm install --ignore-scripts --no-package-lock
bash -n batch/batch-runner.sh
node test-all.mjs
cd dashboard && go test ./...
```

Verified locally on Windows using Git Bash for the shell syntax check. `test-all.mjs` reports the existing expected warning from `cv-sync-check.mjs` when no local user CV data is present.

## Risks / rollback

Low risk: the change only affects the already-skipped min-score path. Rollback is a straight revert of this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Low-scoring offers are now marked as skipped and exit processing immediately, preventing them from being reprocessed or treated as completed.

* **Tests**
  * Added verification to ensure low-scoring offers terminate early, are treated as terminal/skipped during resume, and are counted separately in batch summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->