### PR TITLE
Pause batch runner on Claude session limits

### DIFF
--- a/batch/README.md
+++ b/batch/README.md
@@ -33,9 +33,10 @@ Process multiple job offers in parallel via headless workers. Each worker runs t
 | `--parallel N` | `1` | Number of concurrent headless workers |
 | `--dry-run` | off | Preview pending offers without processing |
 | `--retry-failed` | off | Only retry offers marked as `failed` in state |
+| `--resume-paused` | off | Resume offers paused after a Claude session/rate limit |
 | `--start-from N` | `0` | Skip offers with ID below N |
 | `--max-retries N` | `2` | Max retry attempts per offer before giving up |
-| `--rate-limit-sleep N` | `300` | Seconds to wait before retrying a rate-limited worker; use `0` to fail immediately |
+| `--rate-limit-sleep N` | `300` | Seconds to wait before retrying a transient rate-limited worker; use `0` to pause the batch immediately |
 
 ## Directory Layout
 
@@ -70,7 +71,13 @@ Run `npm run merge` manually if you need to merge outside of a batch run.
 
 ## Resumability
 
-`batch-state.tsv` tracks the status of every offer (`pending`, `processing`, `completed`, `failed`, `skipped`, `rate_limited`). If the batch is interrupted, re-running `batch-runner.sh` picks up where it left off -- completed offers are skipped automatically. `rate_limited` is a non-completed state used while the runner waits before retrying, so interrupted rate-limited jobs are eligible on the next normal run.
+`batch-state.tsv` tracks the status of every offer (`pending`, `processing`, `completed`, `failed`, `skipped`, `rate_limited`, `paused_rate_limit`). If the batch is interrupted, re-running `batch-runner.sh` picks up where it left off -- completed offers are skipped automatically. `rate_limited` is a non-completed state used while the runner waits before retrying, so interrupted rate-limited jobs are eligible on the next normal run.
+
+`paused_rate_limit` is different: it means a worker hit a Claude session/usage limit, so the runner stopped scheduling new offers and preserved the retry count. Resume those rows explicitly after the limit resets:
+
+```bash
+./batch/batch-runner.sh --resume-paused
+```
 
 A PID-based lock file (`batch-runner.pid`) prevents concurrent batch runs. If a previous run crashed, the stale lock is detected and removed automatically.
 

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -21,6 +21,7 @@ TRACKER_DIR="$BATCH_DIR/tracker-additions"
 REPORTS_DIR="$PROJECT_DIR/reports"
 APPLICATIONS_FILE="$PROJECT_DIR/data/applications.md"
 LOCK_FILE="$BATCH_DIR/batch-runner.pid"
+PAUSE_FILE="$BATCH_DIR/batch-runner.paused"
 STATE_LOCK_DIR="$BATCH_DIR/.batch-state.lock"
 STATE_LOCK_PID_FILE="$STATE_LOCK_DIR/pid"
 STATE_LOCK_TIMEOUT_SECONDS=30
@@ -30,11 +31,13 @@ MAIN_PID="${BASHPID:-$$}"
 PARALLEL=1
 DRY_RUN=false
 RETRY_FAILED=false
+RESUME_PAUSED=false
 START_FROM=0
 MAX_RETRIES=2
 MIN_SCORE=0
 MODEL=""  # empty = let claude -p use the Claude Max default
 RATE_LIMIT_SLEEP=300
+BATCH_PAUSED=false
 
 usage() {
   cat <<'USAGE'
@@ -47,6 +50,7 @@ Options:
   --parallel N         Number of parallel workers (default: 1)
   --dry-run            Show what would be processed, don't execute
   --retry-failed       Only retry offers marked as "failed" in state
+  --resume-paused      Resume offers paused by a Claude session/rate limit
   --start-from N       Start from offer ID N (skip earlier IDs)
   --max-retries N      Max retry attempts per offer (default: 2)
   --min-score N        Skip PDF/tracker for offers scoring below N (default: 0 = off)
@@ -85,6 +89,7 @@ while [[ $# -gt 0 ]]; do
     --parallel) PARALLEL="$2"; shift 2 ;;
     --dry-run) DRY_RUN=true; shift ;;
     --retry-failed) RETRY_FAILED=true; shift ;;
+    --resume-paused) RESUME_PAUSED=true; shift ;;
     --start-from) START_FROM="$2"; shift 2 ;;
     --max-retries) MAX_RETRIES="$2"; shift 2 ;;
     --min-score) MIN_SCORE="$2"; shift 2 ;;
@@ -317,6 +322,22 @@ is_rate_limit_log() {
   grep -Eiq '(rate limit|rate_limit|too many requests|429|quota exceeded|try again later|temporarily unavailable)' "$log_file"
 }
 
+is_session_limit_log() {
+  local log_file="$1"
+  grep -Eiq '(session limit|resets [0-9:]+[ap]m|usage limit|limit[[:space:]]+reached)' "$log_file"
+}
+
+mark_paused_rate_limit() {
+  local id="$1" url="$2" started_at="$3" report_num="$4" retries="$5" log_file="$6"
+  local completed_at
+  completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local error_msg
+  error_msg=$(tail -5 "$log_file" 2>/dev/null | tr '\n' ' ' | cut -c1-200 || echo "session/rate limit reached")
+  update_state "$id" "$url" "paused_rate_limit" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries"
+  printf '%s\t%s\t%s\n' "$id" "$report_num" "$error_msg" > "$PAUSE_FILE"
+  BATCH_PAUSED=true
+}
+
 reserve_report_num_unlocked() {
   local id="$1" url="$2" started="$3" retries="$4"
 
@@ -397,11 +418,17 @@ process_offer() {
       break
     fi
 
+    if is_session_limit_log "$log_file"; then
+      mark_paused_rate_limit "$id" "$url" "$started_at" "$report_num" "$retries" "$log_file"
+      echo "    ⏸️  Session/rate limit reached; pausing batch without consuming retry budget."
+      terminal_failure_recorded=true
+      break
+    fi
+
     if is_rate_limit_log "$log_file" && (( retries < MAX_RETRIES )); then
       if (( RATE_LIMIT_SLEEP <= 0 )); then
-        retries=$((retries + 1))
-        update_state "$id" "$url" "failed" "$started_at" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$report_num" "-" "rate-limit; no wait configured" "$retries"
-        echo "    ❌ Rate limited and --rate-limit-sleep is 0; not retrying."
+        mark_paused_rate_limit "$id" "$url" "$started_at" "$report_num" "$retries" "$log_file"
+        echo "    ⏸️  Rate limited and --rate-limit-sleep is 0; pausing batch without consuming retry budget."
         terminal_failure_recorded=true
         break
       fi
@@ -507,6 +534,7 @@ main() {
 
   if [[ "$DRY_RUN" == "false" ]]; then
     acquire_lock
+    rm -f "$PAUSE_FILE"
   fi
 
   init_state
@@ -547,7 +575,11 @@ main() {
     local status
     status=$(get_status "$id")
 
-    if [[ "$RETRY_FAILED" == "true" ]]; then
+    if [[ "$RESUME_PAUSED" == "true" ]]; then
+      if [[ "$status" != "paused_rate_limit" ]]; then
+        continue
+      fi
+    elif [[ "$RETRY_FAILED" == "true" ]]; then
       # Only process failed offers
       if [[ "$status" != "failed" ]]; then
         continue
@@ -562,6 +594,10 @@ main() {
     else
       # Skip completed offers
       if [[ "$status" == "completed" ]]; then
+        continue
+      fi
+      # Paused rate-limit offers resume explicitly with --resume-paused.
+      if [[ "$status" == "paused_rate_limit" ]]; then
         continue
       fi
       # Skip failed offers that hit retry limit (unless --retry-failed)
@@ -610,6 +646,10 @@ main() {
     # Sequential processing
     for i in "${!pending_ids[@]}"; do
       process_offer "${pending_ids[$i]}" "${pending_urls[$i]}" "${pending_sources[$i]}" "${pending_notes[$i]}"
+      if [[ "$BATCH_PAUSED" == "true" || -f "$PAUSE_FILE" ]]; then
+        echo "=== Batch paused: session/rate limit reached. Resume later with --resume-paused. ==="
+        break
+      fi
     done
   else
     # Parallel processing with job control
@@ -618,6 +658,11 @@ main() {
     local -a pid_ids=()
 
     for i in "${!pending_ids[@]}"; do
+      if [[ "$BATCH_PAUSED" == "true" || -f "$PAUSE_FILE" ]]; then
+        echo "=== Batch paused: session/rate limit reached. Waiting for running workers, not scheduling new offers. ==="
+        break
+      fi
+
       # Wait if we're at parallel limit
       while (( running >= PARALLEL )); do
         # Wait for any child to finish
@@ -632,8 +677,16 @@ main() {
         # Compact arrays
         pids=("${pids[@]}")
         pid_ids=("${pid_ids[@]}")
+        if [[ "$BATCH_PAUSED" == "true" || -f "$PAUSE_FILE" ]]; then
+          echo "=== Batch paused: session/rate limit reached. Waiting for running workers, not scheduling new offers. ==="
+          break
+        fi
         sleep 1
       done
+
+      if [[ "$BATCH_PAUSED" == "true" || -f "$PAUSE_FILE" ]]; then
+        break
+      fi
 
       # Launch worker in background
       process_offer "${pending_ids[$i]}" "${pending_urls[$i]}" "${pending_sources[$i]}" "${pending_notes[$i]}" &

--- a/modes/batch.md
+++ b/modes/batch.md
@@ -64,10 +64,11 @@ batch/batch-runner.sh [OPTIONS]
 Options:
 - `--dry-run` — list pending jobs without executing
 - `--retry-failed` — retry only failed jobs
+- `--resume-paused` — resume jobs paused after a Claude session/rate limit
 - `--start-from N` — start from ID N
 - `--parallel N` — N workers in parallel
 - `--max-retries N` — attempts per job (default: 2)
-- `--rate-limit-sleep N` — seconds to wait before retrying a rate-limited worker (default: 300; use 0 to fail immediately)
+- `--rate-limit-sleep N` — seconds to wait before retrying a transient rate-limited worker (default: 300; use 0 to pause the batch immediately)
 
 ## batch-state.tsv Format
 
@@ -77,9 +78,12 @@ id	url	status	started_at	completed_at	report_num	score	error	retries
 2	https://...	failed	2026-...	2026-...	-	-	Error msg	1
 3	https://...	pending	-	-	-	-	-	0
 4	https://...	rate_limited	2026-...	2026-...	004	-	rate-limit; retrying after 300s	1
+5	https://...	paused_rate_limit	2026-...	2026-...	005	-	session limit; paused	1
 ```
 
-Valid statuses include `pending`, `processing`, `completed`, `failed`, `skipped`, and `rate_limited`. `rate_limited` is an intermediate non-completed state emitted while the runner waits before retrying; if the run is interrupted there, a later non-`--retry-failed` run treats it as pending work.
+Valid statuses include `pending`, `processing`, `completed`, `failed`, `skipped`, `rate_limited`, and `paused_rate_limit`. `rate_limited` is an intermediate non-completed state emitted while the runner waits before retrying; if the run is interrupted there, a later non-`--retry-failed` run treats it as pending work.
+
+`paused_rate_limit` means a worker hit a Claude session/usage limit. The runner stops scheduling new offers, preserves the retry count, and resumes only when explicitly called with `--resume-paused`.
 
 ## Resumability
 
@@ -105,5 +109,6 @@ The worker produces:
 | JD behind login | Conductor attempts to read DOM. If it fails → `failed` |
 | Portal changes layout | Conductor reasons about HTML, adapts |
 | Worker crashes | Conductor marks `failed`, continues. Retry with `--retry-failed` |
+| Claude session/usage limit | Runner marks the current offer `paused_rate_limit`, stops scheduling new offers, preserves retries. Resume with `--resume-paused` after reset. |
 | Conductor crashes | Re-run → reads state → skip completed jobs |
 | PDF fails | .md report is saved. PDF remains pending |

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1309,6 +1309,73 @@ try {
   fail(`Cold-start trigger test crashed: ${e.message}`);
 }
 
+// ── 13. BATCH RATE-LIMIT PAUSE ──────────────────────────────────
+
+console.log('\n13. Batch rate-limit pause');
+
+try {
+  const tmp = mkdtempSync(join(tmpdir(), 'co-batch-rate-'));
+  const batchDir = join(tmp, 'batch');
+  const fakeBin = join(tmp, 'bin');
+  mkdirSync(batchDir, { recursive: true });
+  mkdirSync(join(tmp, 'reports'), { recursive: true });
+  mkdirSync(join(tmp, 'data'), { recursive: true });
+  mkdirSync(fakeBin, { recursive: true });
+
+  writeFileSync(join(batchDir, 'batch-runner.sh'), readFileSync(join(ROOT, 'batch/batch-runner.sh'), 'utf-8'));
+  execFileSync('chmod', ['+x', join(batchDir, 'batch-runner.sh')]);
+  writeFileSync(join(tmp, 'merge-tracker.mjs'), 'console.log("merge fixture");\n');
+  writeFileSync(join(tmp, 'verify-pipeline.mjs'), 'console.log("verify fixture");\n');
+  writeFileSync(join(batchDir, 'batch-prompt.md'), 'URL={{URL}}\nJD={{JD_FILE}}\nREPORT={{REPORT_NUM}}\n');
+  writeFileSync(join(batchDir, 'batch-input.tsv'), [
+    'id\turl\tsource\tnotes',
+    '1\thttps://example.com/one\tfixture\t-',
+    '2\thttps://example.com/two\tfixture\t-',
+    '3\thttps://example.com/three\tfixture\t-',
+  ].join('\n') + '\n');
+  writeFileSync(join(fakeBin, 'claude'), [
+    '#!/usr/bin/env bash',
+    'echo "You\\x27ve hit your session limit · resets 12:30pm (Asia/Taipei)"',
+    'exit 1',
+  ].join('\n') + '\n');
+  execFileSync('chmod', ['+x', join(fakeBin, 'claude')]);
+
+  const env = { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` };
+  const out = run('bash', [join(batchDir, 'batch-runner.sh'), '--parallel', '1', '--max-retries', '3', '--rate-limit-sleep', '0'], {
+    cwd: tmp,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) || '';
+  const state = readFileSync(join(batchDir, 'batch-state.tsv'), 'utf-8').trim().split('\n');
+  const first = state[1]?.split('\t') || [];
+
+  if (state.length === 2 && first[0] === '1' && first[2] === 'paused_rate_limit' && first[8] === '0' && out.includes('pausing batch')) {
+    pass('session-limit pauses batch without consuming retry budget or scheduling more jobs');
+  } else {
+    fail(`session-limit pause wrong: lines=${state.length}, first=${JSON.stringify(first)}, out=${JSON.stringify(out.slice(-240))}`);
+  }
+
+  writeFileSync(join(batchDir, 'batch-state.tsv'), [
+    'id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries',
+    '1\thttps://example.com/one\tpaused_rate_limit\t2026-01-01T00:00:00Z\t2026-01-01T00:00:01Z\t001\t-\tsession-limit; paused\t0',
+    '2\thttps://example.com/two\tfailed\t2026-01-01T00:00:00Z\t2026-01-01T00:00:01Z\t002\t-\tworker-crash\t1',
+  ].join('\n') + '\n');
+  const dry = run('bash', [join(batchDir, 'batch-runner.sh'), '--resume-paused', '--dry-run'], {
+    cwd: tmp,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) || '';
+  if (dry.includes('#1: https://example.com/one') && !dry.includes('#2: https://example.com/two')) {
+    pass('--resume-paused dry-run selects paused jobs only');
+  } else {
+    fail(`--resume-paused selection wrong: ${dry}`);
+  }
+
+  rmSync(tmp, { recursive: true, force: true });
+} catch (e) {
+  fail(`Batch rate-limit pause test crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
Fixes #875

## Summary

Adds a real pause state for Claude session/usage limits in the batch runner.

When a worker log indicates a Claude session/usage limit, the runner now:

- marks the current offer as `paused_rate_limit`
- preserves the retry count instead of consuming another retry
- writes a `batch-runner.paused` marker
- stops scheduling new offers in sequential and parallel runs
- resumes paused rows explicitly with `--resume-paused`

This keeps session-limit exhaustion separate from real worker failures and avoids burning an entire batch into `failed` rows after the first limit response.

## Notes

- Keeps the runner Claude-only.
- Does not change evaluation prompts, scoring, report generation, or tracker merge behavior.
- Existing transient `rate_limited` sleep/retry behavior remains for non-session rate-limit cases.

## Tests

```bash
bash -n batch/batch-runner.sh
node test-all.mjs --quick
```

Result: `166 passed, 0 failed, 8 warnings`.
