### PR TITLE
feat: adopt doctor --json as onboarding source of truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 node doctor.mjs --json
 ```
 
-Output: `{"onboardingNeeded": <bool>, "missing": [...]}`, where `missing` lists whichever of `cv.md`, `config/profile.yml`, `modes/_profile.md`, `portals.yml` are absent.
+Output: `{"onboardingNeeded": <bool>, "missing": [...], "warnings": [...]}`, where `missing` lists whichever of `cv.md`, `config/profile.yml`, `modes/_profile.md`, `portals.yml` are absent. `warnings` is reserved for non-blocking setup signals.
 
 - If `modes/_profile.md` is in `missing`, copy it silently from `modes/_profile.template.md` (the user's customization file — never overwritten by updates). It's then resolved.
 - **If, after that, `onboardingNeeded` is still true (any of `cv.md` / `config/profile.yml` / `portals.yml` is missing), enter onboarding mode.** Do NOT proceed with evaluations, scans, or any other mode until the basics are in place. Guide the user step by step:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,16 +120,17 @@ When using the [Gemini CLI](https://github.com/google-gemini/gemini-cli), the fo
 
 ### First Run — Onboarding (IMPORTANT)
 
-**Before doing ANYTHING else, check if the system is set up.** Run these checks silently every time a session starts:
+**Before doing ANYTHING else, check if the system is set up.** On the first message of each session, run the cold-start check — one deterministic source of truth (this doc and `doctor.mjs` share the same prerequisite list, so they can never drift):
 
-1. Does `cv.md` exist?
-2. Does `config/profile.yml` exist (not just profile.example.yml)?
-3. Does `modes/_profile.md` exist (not just _profile.template.md)?
-4. Does `portals.yml` exist (not just templates/portals.example.yml)?
+```bash
+node doctor.mjs --json
+```
+
+Output: `{"onboardingNeeded": <bool>, "missing": [...], "warnings": [...]}`, where `missing` lists whichever of `cv.md`, `config/profile.yml`, `modes/_profile.md`, `portals.yml` are absent. `warnings` is reserved for non-blocking setup signals.
 
 If `modes/_profile.md` is missing, copy from `modes/_profile.template.md` silently. This is the user's customization file — it will never be overwritten by updates.
 
-**If ANY of these is missing, enter onboarding mode.** Do NOT proceed with evaluations, scans, or any other mode until the basics are in place. Guide the user step by step:
+**If, after that, `onboardingNeeded` is still true (any of `cv.md` / `config/profile.yml` / `portals.yml` is missing), enter onboarding mode.** Do NOT proceed with evaluations, scans, or any other mode until the basics are in place. Guide the user step by step:
 
 #### Step 1: CV (required)
 If `cv.md` is missing, ask:

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -207,7 +207,7 @@ function onboardingState(root) {
   const missing = USER_LAYER_PREREQS
     .filter(({ path }) => !prereqPresent(root, path))
     .map(({ path }) => path);
-  return { onboardingNeeded: missing.length > 0, missing };
+  return { onboardingNeeded: missing.length > 0, missing, warnings: [] };
 }
 
 if (JSON_OUT) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1313,9 +1313,9 @@ try {
 
   const claudeDoc = readFile('CLAUDE.md');
   if (
-    claudeDoc.includes('node doctor.mjs --json') &&
-    claudeDoc.includes('"warnings": [...]') &&
-    !claudeDoc.includes('Does `cv.md` exist?')
+    /node\s+doctor\.mjs\s+--json/.test(claudeDoc) &&
+    /"warnings"\s*:\s*\[\.\.\.\]/.test(claudeDoc) &&
+    !/Does\s+`cv\.md`\s+exist\?/i.test(claudeDoc)
   ) {
     pass('CLAUDE.md delegates onboarding state to doctor --json');
   } else {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1284,7 +1284,12 @@ try {
   // Virgin env: none of the 4 user-layer prerequisites present → must onboard.
   const virgin = mkdtempSync(join(tmpdir(), 'co-cold-'));
   const v = JSON.parse(run(NODE, ['doctor.mjs', '--json', '--target', virgin]) || '{}');
-  if (v.onboardingNeeded === true && Array.isArray(v.missing) && v.missing.length === 4) {
+  if (
+    v.onboardingNeeded === true &&
+    Array.isArray(v.missing) &&
+    v.missing.length === 4 &&
+    Array.isArray(v.warnings)
+  ) {
     pass('Virgin env → onboarding triggered (4 prerequisites missing)');
   } else {
     fail(`Virgin env not flagged for onboarding: ${JSON.stringify(v)}`);
@@ -1299,12 +1304,23 @@ try {
     writeFileSync(join(ready, f), 'x');
   }
   const r = JSON.parse(run(NODE, ['doctor.mjs', '--json', '--target', ready]) || '{}');
-  if (r.onboardingNeeded === false) {
+  if (r.onboardingNeeded === false && Array.isArray(r.warnings)) {
     pass('Provisioned env → no onboarding');
   } else {
     fail(`Provisioned env falsely flagged for onboarding: ${JSON.stringify(r)}`);
   }
   rmSync(ready, { recursive: true, force: true });
+
+  const claudeDoc = readFile('CLAUDE.md');
+  if (
+    claudeDoc.includes('node doctor.mjs --json') &&
+    claudeDoc.includes('"warnings": [...]') &&
+    !claudeDoc.includes('Does `cv.md` exist?')
+  ) {
+    pass('CLAUDE.md delegates onboarding state to doctor --json');
+  } else {
+    fail('CLAUDE.md still duplicates onboarding prerequisite checks');
+  }
 } catch (e) {
   fail(`Cold-start trigger test crashed: ${e.message}`);
 }


### PR DESCRIPTION
## Summary

- Stabilize `doctor.mjs --json` with a machine-readable `warnings` array alongside `onboardingNeeded` and `missing`.
- Update `CLAUDE.md` to delegate onboarding state to `node doctor.mjs --json` instead of duplicating file-existence checks.
- Update `AGENTS.md` JSON contract docs and test the stable JSON/documentation contract.

Fixes #884

## Tests

- `node --check doctor.mjs && node --check test-all.mjs`
- `node doctor.mjs --json`
- `node test-all.mjs --quick` — 166 passed, 0 failed, 7 existing README.ua personal-data warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced setup detection system with deterministic prerequisite validation for reliable cold-start behavior
  * Improved automatic handling of missing prerequisite files during initial configuration
  * Optimized onboarding state detection for a smoother first-time experience

* **Documentation**
  * Updated documentation for setup and onboarding workflows
  * Clarified prerequisite validation procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->