### PR TITLE
feat(followup): read cadence settings from profile.yml

### DIFF
--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -66,6 +66,16 @@ location:
   # For remote roles outside your country:
   # onsite_availability: "1 week/month in any city"
 
+# Optional follow-up cadence preferences for `node followup-cadence.mjs`.
+# CLI flags still win for one-off runs (for example `--applied-days 10`).
+# followup_cadence:
+#   applied_first_days: 7
+#   applied_subsequent_days: 7
+#   applied_max_followups: 2
+#   responded_initial_days: 1
+#   responded_subsequent_days: 3
+#   interview_thankyou_days: 1
+
 cv:
   output_format: "html" # "html" (default) or "latex"
   # (Optional) Canva resume design ID for visual CV generation via /career-ops pdf.

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -57,7 +57,12 @@ function positiveInteger(value) {
 
 export function loadProfileCadence(profilePath = PROFILE_FILE) {
   if (!profilePath || !existsSync(profilePath)) return {};
-  const raw = yaml.load(readFileSync(profilePath, 'utf-8')) || {};
+  let raw;
+  try {
+    raw = yaml.load(readFileSync(profilePath, 'utf-8')) || {};
+  } catch {
+    return {};
+  }
   const source = raw.followup_cadence || {};
   const cadence = {};
   for (const [profileKey, cadenceKey] of Object.entries(PROFILE_CADENCE_KEYS)) {

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -14,12 +14,14 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+import yaml from 'js-yaml';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
   ? join(CAREER_OPS, 'data/applications.md')
   : join(CAREER_OPS, 'applications.md');
 const FOLLOWUPS_FILE = join(CAREER_OPS, 'data/follow-ups.md');
+const PROFILE_FILE = process.env.CAREER_OPS_PROFILE || join(CAREER_OPS, 'config/profile.yml');
 
 
 // --- CLI args ---
@@ -27,17 +29,52 @@ const args = process.argv.slice(2);
 const summaryMode = args.includes('--summary');
 const overdueOnly = args.includes('--overdue-only');
 const appliedDaysIdx = args.indexOf('--applied-days');
-const APPLIED_FIRST = appliedDaysIdx !== -1 ? parseInt(args[appliedDaysIdx + 1]) || 7 : 7;
+const appliedDaysOverride = appliedDaysIdx !== -1 ? parseInt(args[appliedDaysIdx + 1], 10) : null;
 
 // --- Cadence config ---
-const CADENCE = {
-  applied_first: APPLIED_FIRST,
+export const DEFAULT_CADENCE = {
+  applied_first: 7,
   applied_subsequent: 7,
   applied_max_followups: 2,
   responded_initial: 1,
   responded_subsequent: 3,
   interview_thankyou: 1,
 };
+
+const PROFILE_CADENCE_KEYS = {
+  applied_first_days: 'applied_first',
+  applied_subsequent_days: 'applied_subsequent',
+  applied_max_followups: 'applied_max_followups',
+  responded_initial_days: 'responded_initial',
+  responded_subsequent_days: 'responded_subsequent',
+  interview_thankyou_days: 'interview_thankyou',
+};
+
+function positiveInteger(value) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+export function loadProfileCadence(profilePath = PROFILE_FILE) {
+  if (!profilePath || !existsSync(profilePath)) return {};
+  const raw = yaml.load(readFileSync(profilePath, 'utf-8')) || {};
+  const source = raw.followup_cadence || {};
+  const cadence = {};
+  for (const [profileKey, cadenceKey] of Object.entries(PROFILE_CADENCE_KEYS)) {
+    const parsed = positiveInteger(source[profileKey]);
+    if (parsed !== null) cadence[cadenceKey] = parsed;
+  }
+  return cadence;
+}
+
+export function resolveCadenceConfig({ profilePath = PROFILE_FILE, appliedDays = appliedDaysOverride } = {}) {
+  const cadence = { ...DEFAULT_CADENCE, ...loadProfileCadence(profilePath) };
+  const cliApplied = positiveInteger(appliedDays);
+  if (cliApplied !== null) cadence.applied_first = cliApplied;
+  return cadence;
+}
+
+const CADENCE = resolveCadenceConfig();
 
 // --- Status normalization (mirrors verify-pipeline.mjs) ---
 const ALIASES = {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -715,6 +715,15 @@ try {
     fail(`CLI cadence override failed: ${JSON.stringify(cliCadence)}`);
   }
 
+  const malformedProfile = join(cadenceTmp, 'malformed.yml');
+  writeFileSync(malformedProfile, 'followup_cadence: [');
+  const fallbackCadence = cadence.resolveCadenceConfig({ profilePath: malformedProfile });
+  if (fallbackCadence.applied_first === cadence.DEFAULT_CADENCE.applied_first) {
+    pass('follow-up cadence ignores malformed optional profile config');
+  } else {
+    fail(`malformed profile did not fall back to defaults: ${JSON.stringify(fallbackCadence)}`);
+  }
+
   rmSync(cadenceTmp, { recursive: true, force: true });
 
   // Urgency decision tree (CADENCE defaults: applied_first=7, max_followups=2, responded_initial=1, interview_thankyou=1)

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -682,6 +682,41 @@ try {
     fail(`normalizeStatus produced ${cadence.normalizeStatus('**Applied** 2026-05-01')}`);
   }
 
+  const cadenceTmp = mkdtempSync(join(tmpdir(), 'co-cadence-'));
+  const profilePath = join(cadenceTmp, 'profile.yml');
+  writeFileSync(profilePath, [
+    'followup_cadence:',
+    '  applied_first_days: 11',
+    '  applied_subsequent_days: 5',
+    '  applied_max_followups: 4',
+    '  responded_initial_days: 2',
+    '  responded_subsequent_days: 6',
+    '  interview_thankyou_days: 3',
+  ].join('\n'));
+
+  const profileCadence = cadence.resolveCadenceConfig({ profilePath });
+  if (
+    profileCadence.applied_first === 11 &&
+    profileCadence.applied_subsequent === 5 &&
+    profileCadence.applied_max_followups === 4 &&
+    profileCadence.responded_initial === 2 &&
+    profileCadence.responded_subsequent === 6 &&
+    profileCadence.interview_thankyou === 3
+  ) {
+    pass('follow-up cadence reads profile.yml overrides');
+  } else {
+    fail(`profile cadence override failed: ${JSON.stringify(profileCadence)}`);
+  }
+
+  const cliCadence = cadence.resolveCadenceConfig({ profilePath, appliedDays: 9 });
+  if (cliCadence.applied_first === 9 && cliCadence.applied_subsequent === 5) {
+    pass('follow-up cadence CLI override wins over profile applied_first');
+  } else {
+    fail(`CLI cadence override failed: ${JSON.stringify(cliCadence)}`);
+  }
+
+  rmSync(cadenceTmp, { recursive: true, force: true });
+
   // Urgency decision tree (CADENCE defaults: applied_first=7, max_followups=2, responded_initial=1, interview_thankyou=1)
   const urgencyCases = [
     [['applied', 7, null, 0], 'overdue', 'applied past applied_first → overdue'],


### PR DESCRIPTION
## Summary

- Read optional `followup_cadence` settings from `config/profile.yml` while preserving existing defaults.
- Keep CLI `--applied-days` as the highest-precedence one-off override.
- Document the profile keys in `config/profile.example.yml` and add precedence coverage in `test-all.mjs`.

Fixes #881

## Tests

- `node --check followup-cadence.mjs && node --check test-all.mjs`
- `node test-all.mjs --quick` — 167 passed, 0 failed, 7 existing README.ua personal-data warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable follow-up cadence to customize timing for first/subsequent applied follow-ups, response windows, and interview thank-you reminders.
  * Cadence can be set in profile configuration and overridden via CLI for one-off runs.

* **Documentation**
  * Included commented example profile entries showing optional follow-up cadence settings.

* **Tests**
  * Added tests covering profile-based cadence loading, CLI override precedence, and malformed-profile fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->