### PR TITLE
feat: add application learning queue

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -19,6 +19,28 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run rollback` | `update-system.mjs rollback` | Rollback last update |
 | `npm run liveness` | `check-liveness.mjs` | Test if job URLs are still active |
 | `npm run scan` | `scan.mjs` | Zero-token portal scanner |
+| `npm run learning` | `learning-queue.mjs` | Manage pending profile-learning items |
+
+---
+
+## learning
+
+Records proposed personalization changes from evaluation feedback in `data/learning-queue.md` before editing User Layer files.
+
+```bash
+npm run learning -- add \
+  --source "evaluation #42 feedback" \
+  --target modes/_profile.md \
+  --feedback "score too high for Java-only roles" \
+  --proposal "Lower Java-only backend fit unless AI automation is present."
+
+npm run learning -- list --status pending
+npm run learning -- set-status --id LQ-20260610-001 --status applied
+```
+
+Allowed targets are `modes/_profile.md`, `config/profile.yml`, and `article-digest.md`. Statuses are `pending`, `applied`, and `rejected`.
+
+**Exit codes:** `0` command succeeded, `1` invalid target/status, missing arguments, or missing entry.
 
 ---
 

--- a/learning-queue.mjs
+++ b/learning-queue.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * learning-queue.mjs — reviewable user-feedback learning queue.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_QUEUE = join(ROOT, 'data/learning-queue.md');
+const QUEUE_PATH = process.env.CAREER_OPS_LEARNING_QUEUE || DEFAULT_QUEUE;
+const VALID_STATUSES = new Set(['pending', 'applied', 'rejected']);
+const VALID_TARGETS = new Set(['modes/_profile.md', 'config/profile.yml', 'article-digest.md']);
+
+function today() {
+  return new Date().toISOString().split('T')[0];
+}
+
+function argValue(args, name) {
+  const idx = args.indexOf(name);
+  return idx !== -1 ? args[idx + 1] : null;
+}
+
+function queueHeader() {
+  return [
+    '# Learning Queue',
+    '',
+    'Reviewable profile-learning items proposed from evaluation feedback.',
+    '',
+    'Statuses: pending, applied, rejected.',
+    '',
+  ].join('\n');
+}
+
+function ensureQueue(path = QUEUE_PATH) {
+  if (!existsSync(path)) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, queueHeader());
+  }
+}
+
+function nextId(entries, date = today()) {
+  const prefix = `LQ-${date.replaceAll('-', '')}-`;
+  const max = entries
+    .map((entry) => entry.id)
+    .filter((id) => id.startsWith(prefix))
+    .map((id) => Number.parseInt(id.slice(prefix.length), 10))
+    .filter(Number.isFinite)
+    .reduce((acc, n) => Math.max(acc, n), 0);
+  return `${prefix}${String(max + 1).padStart(3, '0')}`;
+}
+
+export function parseQueue(markdown) {
+  const entries = [];
+  const blocks = markdown.split(/\n(?=## LQ-\d{8}-\d{3}\b)/);
+  for (const block of blocks) {
+    const id = block.match(/^## (LQ-\d{8}-\d{3})/m)?.[1];
+    if (!id) continue;
+    const field = (name) => block.match(new RegExp(`^- \\*\\*${name}:\\*\\*\\s*(.*)$`, 'm'))?.[1]?.trim() || '';
+    const proposal = block.match(/### Proposed change\n\n```text\n([\s\S]*?)\n```/)?.[1] || '';
+    entries.push({
+      id,
+      date: field('Date'),
+      source: field('Source'),
+      target: field('Target'),
+      status: field('Status'),
+      feedback: field('Feedback'),
+      proposal,
+    });
+  }
+  return entries;
+}
+
+function renderEntry(entry) {
+  return [
+    `## ${entry.id}`,
+    '',
+    `- **Date:** ${entry.date}`,
+    `- **Source:** ${entry.source}`,
+    `- **Target:** ${entry.target}`,
+    `- **Status:** ${entry.status}`,
+    `- **Feedback:** ${entry.feedback}`,
+    '',
+    '### Proposed change',
+    '',
+    '```text',
+    entry.proposal,
+    '```',
+    '',
+  ].join('\n');
+}
+
+export function addEntry({ source, target, feedback, proposal, queuePath = QUEUE_PATH, date = today() }) {
+  if (!source || !target || !feedback || !proposal) {
+    throw new Error('add requires --source, --target, --feedback, and --proposal');
+  }
+  if (!VALID_TARGETS.has(target)) {
+    throw new Error(`target must be one of: ${Array.from(VALID_TARGETS).join(', ')}`);
+  }
+  ensureQueue(queuePath);
+  const content = readFileSync(queuePath, 'utf-8');
+  const entry = {
+    id: nextId(parseQueue(content), date),
+    date,
+    source,
+    target,
+    status: 'pending',
+    feedback,
+    proposal,
+  };
+  writeFileSync(queuePath, `${content.trimEnd()}\n\n${renderEntry(entry)}`);
+  return entry;
+}
+
+export function setStatus({ id, status, queuePath = QUEUE_PATH }) {
+  if (!id || !VALID_STATUSES.has(status)) {
+    throw new Error('set-status requires --id and --status pending|applied|rejected');
+  }
+  const content = readFileSync(queuePath, 'utf-8');
+  const next = content.replace(
+    new RegExp(`(## ${id}[\\s\\S]*?- \\*\\*Status:\\*\\* )(${Array.from(VALID_STATUSES).join('|')})`),
+    `$1${status}`,
+  );
+  if (next === content) throw new Error(`entry not found: ${id}`);
+  writeFileSync(queuePath, next);
+}
+
+function listEntries({ status, queuePath = QUEUE_PATH } = {}) {
+  if (!existsSync(queuePath)) return [];
+  const entries = parseQueue(readFileSync(queuePath, 'utf-8'));
+  return status ? entries.filter((entry) => entry.status === status) : entries;
+}
+
+function selfTest() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-learning-'));
+  try {
+    const path = join(dir, 'queue.md');
+    const entry = addEntry({
+      source: 'self-test',
+      target: 'modes/_profile.md',
+      feedback: 'score too high for Java-only roles',
+      proposal: 'Lower Java-only backend fit unless AI automation is present.',
+      queuePath: path,
+      date: '2026-06-10',
+    });
+    setStatus({ id: entry.id, status: 'applied', queuePath: path });
+    const parsed = listEntries({ queuePath: path });
+    if (parsed.length !== 1 || parsed[0].status !== 'applied' || parsed[0].id !== entry.id) {
+      throw new Error('self-test failed');
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  console.log('learning-queue self-test passed');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const command = args[0] || 'list';
+
+  if (command === '--self-test') return selfTest();
+  if (command === 'add') {
+    const entry = addEntry({
+      source: argValue(args, '--source'),
+      target: argValue(args, '--target'),
+      feedback: argValue(args, '--feedback'),
+      proposal: argValue(args, '--proposal'),
+    });
+    console.log(JSON.stringify(entry, null, 2));
+    return;
+  }
+  if (command === 'set-status') {
+    setStatus({ id: argValue(args, '--id'), status: argValue(args, '--status') });
+    console.log(JSON.stringify({ ok: true }, null, 2));
+    return;
+  }
+  if (command === 'list') {
+    const entries = listEntries({ status: argValue(args, '--status') });
+    console.log(JSON.stringify({ entries }, null, 2));
+    return;
+  }
+  throw new Error(`unknown command: ${command}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}

--- a/learning-queue.mjs
+++ b/learning-queue.mjs
@@ -13,6 +13,7 @@ const DEFAULT_QUEUE = join(ROOT, 'data/learning-queue.md');
 const QUEUE_PATH = process.env.CAREER_OPS_LEARNING_QUEUE || DEFAULT_QUEUE;
 const VALID_STATUSES = new Set(['pending', 'applied', 'rejected']);
 const VALID_TARGETS = new Set(['modes/_profile.md', 'config/profile.yml', 'article-digest.md']);
+const ENTRY_ID_PATTERN = /^LQ-\d{8}-\d{3}$/;
 
 function today() {
   return new Date().toISOString().split('T')[0];
@@ -21,6 +22,10 @@ function today() {
 function argValue(args, name) {
   const idx = args.indexOf(name);
   return idx !== -1 ? args[idx + 1] : null;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function queueHeader() {
@@ -118,9 +123,12 @@ export function setStatus({ id, status, queuePath = QUEUE_PATH }) {
   if (!id || !VALID_STATUSES.has(status)) {
     throw new Error('set-status requires --id and --status pending|applied|rejected');
   }
+  if (!ENTRY_ID_PATTERN.test(id)) {
+    throw new Error('id must match LQ-YYYYMMDD-NNN');
+  }
   const content = readFileSync(queuePath, 'utf-8');
   const next = content.replace(
-    new RegExp(`(## ${id}[\\s\\S]*?- \\*\\*Status:\\*\\* )(${Array.from(VALID_STATUSES).join('|')})`),
+    new RegExp(`(## ${escapeRegExp(id)}[\\s\\S]*?- \\*\\*Status:\\*\\* )(${Array.from(VALID_STATUSES).join('|')})`),
     `$1${status}`,
   );
   if (next === content) throw new Error(`entry not found: ${id}`);

--- a/learning-queue.mjs
+++ b/learning-queue.mjs
@@ -28,6 +28,14 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function assertSingleLine(value, flag) {
+  if (/[\r\n]/.test(value)) throw new Error(`${flag} must be a single line`);
+}
+
+function assertProposalSafe(value) {
+  if (value.includes('```')) throw new Error('--proposal cannot contain markdown fence markers');
+}
+
 function queueHeader() {
   return [
     '# Learning Queue',
@@ -101,6 +109,9 @@ export function addEntry({ source, target, feedback, proposal, queuePath = QUEUE
   if (!source || !target || !feedback || !proposal) {
     throw new Error('add requires --source, --target, --feedback, and --proposal');
   }
+  assertSingleLine(source, '--source');
+  assertSingleLine(feedback, '--feedback');
+  assertProposalSafe(proposal);
   if (!VALID_TARGETS.has(target)) {
     throw new Error(`target must be one of: ${Array.from(VALID_TARGETS).join(', ')}`);
   }
@@ -125,6 +136,9 @@ export function setStatus({ id, status, queuePath = QUEUE_PATH }) {
   }
   if (!ENTRY_ID_PATTERN.test(id)) {
     throw new Error('id must match LQ-YYYYMMDD-NNN');
+  }
+  if (!existsSync(queuePath)) {
+    throw new Error(`learning queue not found: ${queuePath}`);
   }
   const content = readFileSync(queuePath, 'utf-8');
   const next = content.replace(
@@ -157,6 +171,36 @@ function selfTest() {
     const parsed = listEntries({ queuePath: path });
     if (parsed.length !== 1 || parsed[0].status !== 'applied' || parsed[0].id !== entry.id) {
       throw new Error('self-test failed');
+    }
+    try {
+      addEntry({
+        source: 'bad\nsource',
+        target: 'modes/_profile.md',
+        feedback: 'feedback',
+        proposal: 'proposal',
+        queuePath: path,
+      });
+      throw new Error('newline source accepted');
+    } catch (err) {
+      if (!err.message.includes('single line')) throw err;
+    }
+    try {
+      addEntry({
+        source: 'source',
+        target: 'modes/_profile.md',
+        feedback: 'feedback',
+        proposal: '```',
+        queuePath: path,
+      });
+      throw new Error('fence proposal accepted');
+    } catch (err) {
+      if (!err.message.includes('fence')) throw err;
+    }
+    try {
+      setStatus({ id: 'LQ-20260610-999', status: 'applied', queuePath: join(dir, 'missing.md') });
+      throw new Error('missing queue accepted');
+    } catch (err) {
+      if (!err.message.includes('learning queue not found')) throw err;
     }
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -21,6 +21,20 @@
 **RULE: NEVER hardcode metrics from proof points.** Read them from cv.md + article-digest.md at evaluation time.
 **RULE: For article/project metrics, article-digest.md takes precedence over cv.md.**
 **RULE: Read _profile.md AFTER this file. User customizations in _profile.md override defaults here.**
+**RULE: When evaluation feedback implies a lasting profile change, record a pending item with `node learning-queue.mjs add` before editing `modes/_profile.md`, `config/profile.yml`, or `article-digest.md`, unless the user explicitly asks for the edit immediately.**
+
+---
+
+## Learning From Feedback
+
+If the user says an evaluation score was too high/low, a blocker was missed, or a proof point/targeting preference should affect future evaluations:
+
+1. Summarize the feedback as a proposed learning item.
+2. Add it to `data/learning-queue.md` with `node learning-queue.mjs add`.
+3. Ask the user to confirm before applying the change to the target User Layer file.
+4. After applying or rejecting it, update the queue item status with `node learning-queue.mjs set-status`.
+
+This preserves an audit trail and prevents accidental personalization drift.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
     "scan": "node scan.mjs",
+    "learning": "node learning-queue.mjs",
     "patterns": "node analyze-patterns.mjs",
     "gemini:eval": "node gemini-eval.mjs"
   },

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -71,6 +71,7 @@ const scripts = [
   { name: 'dedup-tracker.mjs', expectExit: 0 },
   { name: 'merge-tracker.mjs', expectExit: 0 },
   { name: 'analyze-patterns.mjs --self-test', expectExit: 0 },
+  { name: 'learning-queue.mjs --self-test', expectExit: 0 },
   { name: 'update-system.mjs check', expectExit: 0 },
 ];
 


### PR DESCRIPTION
## Summary

- Add `learning-queue.mjs` to record, list, and update pending profile-learning items in `data/learning-queue.md`.
- Add `npm run learning`, script docs, and shared mode guidance so feedback is queued before User Layer edits unless the user explicitly requests an immediate change.
- Add self-test coverage in `test-all.mjs`.

Fixes #882

## Tests

- `node --check learning-queue.mjs && node learning-queue.mjs --self-test`
- manual `add` + `list --status pending` with `CAREER_OPS_LEARNING_QUEUE` temporary file
- `node test-all.mjs --quick` — 167 passed, 0 failed, 7 existing README.ua personal-data warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a learning-queue CLI to record and manage personalization suggestions with add, list, and status-update operations (exposed via the new npm script).

* **Documentation**
  * Updated script reference with usage examples and a guidance section describing when items should be recorded.

* **Tests**
  * Added an automated self-test to validate the learning-queue workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->