### PR TITLE
feat: add mode parity checker for localized modes

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -8,6 +8,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 |---------|--------|---------|
 | `npm run doctor` | `doctor.mjs` | Validate setup prerequisites |
 | `npm run verify` | `verify-pipeline.mjs` | Check pipeline data integrity |
+| `npm run verify:modes` | `verify-mode-parity.mjs` | Check localized mode semantic anchors |
 | `npm run normalize` | `normalize-statuses.mjs` | Fix non-canonical statuses |
 | `npm run dedup` | `dedup-tracker.mjs` | Remove duplicate tracker entries |
 | `npm run merge` | `merge-tracker.mjs` | Merge batch TSVs into applications.md |
@@ -43,6 +44,29 @@ npm run verify
 ```
 
 **Exit codes:** `0` pipeline clean (zero errors), `1` errors found. Warnings (e.g. possible duplicates) do not cause a non-zero exit.
+
+---
+
+## verify:modes
+
+Checks localized mode files for semantic anchors that should stay aligned with canonical modes, without requiring literal translations.
+
+Examples of anchors:
+
+- `_shared.md` references user profile sources and the no-hardcoded-metrics rule
+- offer/evaluation modes mention posting legitimacy and the `**URL:**` report header
+- apply modes keep a human-review/submit safety anchor
+- pipeline modes retain PDF and tracker-output behavior
+
+By default, missing semantic anchors are warnings so existing translations can be audited without breaking every PR. Missing expected locale files are errors. Use `--strict` to fail on warnings as well.
+
+```bash
+npm run verify:modes
+npm run verify:modes -- --strict
+node verify-mode-parity.mjs --self-test
+```
+
+**Exit codes:** `0` no missing files and, unless `--strict`, warnings only; `1` missing files or strict-mode warnings.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "doctor": "node doctor.mjs",
     "verify": "node verify-pipeline.mjs",
+    "verify:modes": "node verify-mode-parity.mjs",
     "normalize": "node normalize-statuses.mjs",
     "dedup": "node dedup-tracker.mjs",
     "merge": "node merge-tracker.mjs",

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -71,6 +71,7 @@ const scripts = [
   { name: 'dedup-tracker.mjs', expectExit: 0 },
   { name: 'merge-tracker.mjs', expectExit: 0 },
   { name: 'analyze-patterns.mjs --self-test', expectExit: 0 },
+  { name: 'verify-mode-parity.mjs --self-test', expectExit: 0 },
   { name: 'update-system.mjs check', expectExit: 0 },
 ];
 

--- a/verify-mode-parity.mjs
+++ b/verify-mode-parity.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * verify-mode-parity.mjs — semantic-anchor checks for localized modes.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { basename, dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const MODES_DIR = process.env.CAREER_OPS_MODES || join(ROOT, 'modes');
+
+const LOCALE_FILE_MAP = {
+  de: { _shared: '_shared.md', oferta: 'angebot.md', apply: 'bewerben.md', pipeline: 'pipeline.md' },
+  fr: { _shared: '_shared.md', oferta: 'offre.md', apply: 'postuler.md', pipeline: 'pipeline.md' },
+  ja: { _shared: '_shared.md', oferta: 'kyujin.md', apply: 'oubo.md', pipeline: 'pipeline.md' },
+  tr: { _shared: '_shared.md', oferta: 'is-ilani.md', apply: 'basvuru.md', pipeline: 'pipeline.md' },
+  pt: { _shared: '_shared.md', oferta: 'oferta.md', apply: 'aplicar.md', pipeline: 'pipeline.md' },
+  ru: { _shared: '_shared.md', oferta: 'oferta.md', apply: 'apply.md', pipeline: 'pipeline.md' },
+  ua: { _shared: '_shared.md', oferta: 'oferta.md', apply: 'apply.md', pipeline: 'pipeline.md' },
+};
+
+const ANCHORS = {
+  _shared: [
+    { id: 'profile-source', pattern: /_profile\.md|profile\.yml/i },
+    { id: 'no-hardcoded-metrics', pattern: /hardcode|hart cod|codificat|ハードコード|sabit|жорстко|жестко|hardcoded/i },
+  ],
+  oferta: [
+    { id: 'posting-legitimacy', pattern: /legitimacy|legitimidad|legitimit|meşruiyet|正当性|легітим|легитим|legitimidade|glaubwürdig/i },
+    { id: 'url-header', pattern: /\*\*URL:\*\*/i },
+  ],
+  apply: [
+    { id: 'human-review-before-submit', pattern: /submit|send|apply|enviar|absenden|送信|başvur|відправ|отправ/i },
+  ],
+  pipeline: [
+    { id: 'pdf-gate', pattern: /PDF/i },
+    { id: 'tracker-output', pattern: /tracker|applications\.md|suivi|verfolg|追跡|izleyici|трекер/i },
+  ],
+};
+
+function localeDirs(root) {
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(join(root, entry.name, 'README.md')))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function checkFile({ locale, modeType, path }) {
+  if (!existsSync(path)) {
+    return [{
+      level: 'error',
+      locale,
+      mode: modeType,
+      file: path,
+      anchor: 'file-exists',
+      message: 'localized mode file is missing',
+    }];
+  }
+  const content = readFileSync(path, 'utf-8');
+  return (ANCHORS[modeType] || [])
+    .filter(({ pattern }) => !pattern.test(content))
+    .map(({ id }) => ({
+      level: 'warning',
+      locale,
+      mode: modeType,
+      file: path,
+      anchor: id,
+      message: `semantic anchor missing: ${id}`,
+    }));
+}
+
+export function verifyModeParity({ modesDir = MODES_DIR } = {}) {
+  const findings = [];
+  for (const locale of localeDirs(modesDir)) {
+    const fileMap = LOCALE_FILE_MAP[locale];
+    if (!fileMap) {
+      findings.push({
+        level: 'warning',
+        locale,
+        mode: '*',
+        file: join(modesDir, locale),
+        anchor: 'locale-map',
+        message: 'locale directory has no parity file map',
+      });
+      continue;
+    }
+    for (const [modeType, file] of Object.entries(fileMap)) {
+      findings.push(...checkFile({
+        locale,
+        modeType,
+        path: join(modesDir, locale, file),
+      }));
+    }
+  }
+  return findings.map((finding) => ({ ...finding, file: basename(finding.file) }));
+}
+
+function writeFixture(root, locale, files) {
+  const dir = join(root, locale);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'README.md'), '# locale\n');
+  for (const [file, content] of Object.entries(files)) {
+    writeFileSync(join(dir, file), content);
+  }
+}
+
+function runSelfTest() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-modes-'));
+  try {
+    writeFixture(dir, 'de', {
+      '_shared.md': '_profile.md hardcode',
+      'angebot.md': '**URL:**\nLegitimacy',
+      'bewerben.md': 'submit only after review',
+      'pipeline.md': 'PDF applications.md tracker',
+    });
+    writeFixture(dir, 'fr', {
+      '_shared.md': '_profile.md',
+      'offre.md': '**URL:**',
+      'postuler.md': 'formulaire',
+      'pipeline.md': 'PDF',
+    });
+    const findings = verifyModeParity({ modesDir: dir });
+    const deErrors = findings.filter((f) => f.locale === 'de' && f.level === 'error');
+    const frWarnings = findings.filter((f) => f.locale === 'fr' && f.level === 'warning');
+    if (deErrors.length !== 0 || frWarnings.length === 0) {
+      throw new Error(`unexpected self-test findings: ${JSON.stringify(findings)}`);
+    }
+    console.log('verify-mode-parity self-test passed');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) return runSelfTest();
+  const strict = process.argv.includes('--strict');
+  const findings = verifyModeParity();
+  const errors = findings.filter((finding) => finding.level === 'error').length;
+  const warnings = findings.filter((finding) => finding.level === 'warning').length;
+  console.log(JSON.stringify({ errors, warnings, findings }, null, 2));
+  if (errors > 0 || (strict && warnings > 0)) process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}

--- a/verify-mode-parity.mjs
+++ b/verify-mode-parity.mjs
@@ -5,7 +5,7 @@
 
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { basename, dirname, join } from 'path';
+import { dirname, join, relative } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
@@ -94,7 +94,7 @@ export function verifyModeParity({ modesDir = MODES_DIR } = {}) {
       }));
     }
   }
-  return findings.map((finding) => ({ ...finding, file: basename(finding.file) }));
+  return findings.map((finding) => ({ ...finding, file: relative(modesDir, finding.file) || finding.file }));
 }
 
 function writeFixture(root, locale, files) {


### PR DESCRIPTION
## Summary

- Add `verify-mode-parity.mjs` to scan localized modes for semantic anchors without requiring literal translations.
- Default to warning-only semantic drift reporting, with `--strict` available for maintainers.
- Wire `npm run verify:modes`, docs, and self-test coverage in `test-all.mjs`.

Fixes #880

## Tests

- `node --check verify-mode-parity.mjs && node verify-mode-parity.mjs --self-test && node verify-mode-parity.mjs` — current locales: 0 errors, 13 warnings
- `node test-all.mjs --quick` — 167 passed, 0 failed, 7 existing README.ua personal-data warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `npm run verify:modes` script to validate consistency of localized documentation anchors across supported languages.

* **Documentation**
  * Added comprehensive documentation for the new verification script, including usage examples and exit code reference.

* **Tests**
  * Integrated automated self-test for the new verification script into the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->