### PR TITLE
feat: add provenance metadata for pipeline entries

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -198,6 +198,8 @@ Each URL gets a verdict: `active`, `expired`, or `uncertain` with a reason.
 
 Zero-token portal scanner. Runs configured local parsers for SSR/static career pages and hits ATS APIs (Greenhouse, Ashby, Lever) directly — no LLM tokens consumed. Reads `portals.yml` for target companies, outputs matching listings to stdout, and optionally appends to `data/pipeline.md`.
 
+New pipeline rows include provenance metadata, for example `source=scan-api | provider=greenhouse | verified_at=2026-06-10`. Runs without `--verify` use `verified_at=unverified`.
+
 For custom SSR pages, configure a tracked company with `scan_method: local_parser` and a `parser` block. The parser can be written in JavaScript, Python, or any language available as a local executable. Company-specific parsers usually already know their source URL and only need to print JSON jobs to stdout:
 
 ```yaml

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -28,12 +28,15 @@ Process job URLs stored in `data/pipeline.md`. The user adds URLs at any time an
 ## Pending
 - [ ] https://jobs.example.com/posting/123
 - [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
+- [ ] https://jobs.example.com/posting/789 | Acme Corp | AI PM | source=scan-api | provider=greenhouse | verified_at=2026-06-10
 - [!] https://private.url/job — Error: login required
 
 ## Processed
 - [x] #143 | https://jobs.example.com/posting/789 | Acme Corp | AI PM | 4.2/5 | PDF ✅
 - [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF ❌
 ```
+
+Trailing metadata such as `source=...`, `provider=...`, and `verified_at=...` is optional and backward-compatible. Existing readers should use the leading URL and ignore unknown trailing fields.
 
 ## Intelligent JD detection from URL
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -227,7 +227,20 @@ function loadSeenCompanyRoles() {
 
 // ── Pipeline writer ─────────────────────────────────────────────────
 
-function appendToPipeline(offers) {
+export function pipelineSourceFor(source) {
+  if (source === 'local-parser') return 'local';
+  if (source === 'websearch' || source === 'agent-websearch') return 'websearch';
+  if (source) return 'scan-api';
+  return 'unknown';
+}
+
+export function formatPipelineEntry(offer, { verifiedAt = 'unverified' } = {}) {
+  const source = pipelineSourceFor(offer.source);
+  const verified = verifiedAt || 'unverified';
+  return `- [ ] ${offer.url} | ${offer.company} | ${offer.title} | source=${source} | provider=${offer.source || 'unknown'} | verified_at=${verified}`;
+}
+
+function appendToPipeline(offers, options = {}) {
   if (offers.length === 0) return;
 
   let text = readFileSync(PIPELINE_PATH, 'utf-8');
@@ -239,9 +252,7 @@ function appendToPipeline(offers) {
     // No Pendientes section — append at end before Procesadas
     const procIdx = text.indexOf('## Procesadas');
     const insertAt = procIdx === -1 ? text.length : procIdx;
-    const block = `\n${marker}\n\n` + offers.map(o =>
-      `- [ ] ${o.url} | ${o.company} | ${o.title}`
-    ).join('\n') + '\n\n';
+    const block = `\n${marker}\n\n` + offers.map(o => formatPipelineEntry(o, options)).join('\n') + '\n\n';
     text = text.slice(0, insertAt) + block + text.slice(insertAt);
   } else {
     // Find the end of existing Pendientes content (next ## or end)
@@ -249,9 +260,7 @@ function appendToPipeline(offers) {
     const nextSection = text.indexOf('\n## ', afterMarker);
     const insertAt = nextSection === -1 ? text.length : nextSection;
 
-    const block = '\n' + offers.map(o =>
-      `- [ ] ${o.url} | ${o.company} | ${o.title}`
-    ).join('\n') + '\n';
+    const block = '\n' + offers.map(o => formatPipelineEntry(o, options)).join('\n') + '\n';
     text = text.slice(0, insertAt) + block + text.slice(insertAt);
   }
 
@@ -543,7 +552,7 @@ async function main() {
 
   // 6. Write results
   if (!dryRun && verifiedOffers.length > 0) {
-    appendToPipeline(verifiedOffers);
+    appendToPipeline(verifiedOffers, { verifiedAt: verify ? date : 'unverified' });
     appendToScanHistory(verifiedOffers, date);
   }
   if (!dryRun && expiredOffers.length > 0) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -236,8 +236,7 @@ export function pipelineSourceFor(source) {
 
 export function formatPipelineEntry(offer, { verifiedAt = 'unverified' } = {}) {
   const source = pipelineSourceFor(offer.source);
-  const verified = verifiedAt || 'unverified';
-  return `- [ ] ${offer.url} | ${offer.company} | ${offer.title} | source=${source} | provider=${offer.source || 'unknown'} | verified_at=${verified}`;
+  return `- [ ] ${offer.url} | ${offer.company} | ${offer.title} | source=${source} | provider=${offer.source || 'unknown'} | verified_at=${verifiedAt}`;
 }
 
 function appendToPipeline(offers, options = {}) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -422,6 +422,28 @@ if (
   fail('scan.mjs does not guard company names before filtering');
 }
 
+try {
+  const { formatPipelineEntry } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+  const entry = formatPipelineEntry({
+    url: 'https://boards.greenhouse.io/acme/jobs/123',
+    company: 'Acme',
+    title: 'AI Engineer',
+    source: 'greenhouse',
+  }, { verifiedAt: '2026-06-10' });
+  if (
+    entry.includes('source=scan-api') &&
+    entry.includes('provider=greenhouse') &&
+    entry.includes('verified_at=2026-06-10') &&
+    /- \[[ x]\] (https?:\/\/\S+)/.test(entry)
+  ) {
+    pass('scan.mjs writes backward-compatible pipeline provenance metadata');
+  } else {
+    fail(`pipeline provenance entry malformed: ${entry}`);
+  }
+} catch (e) {
+  fail(`pipeline provenance metadata test crashed: ${e.message}`);
+}
+
 if (
   scanScript.includes("skipIds: ['local-parser']") &&
   scanScript.includes('local parser failed, used API fallback') &&


### PR DESCRIPTION
## Summary

- Add backward-compatible provenance metadata to new scan-written pipeline rows.
- Include `source`, `provider`, and `verified_at`, using `verified_at=unverified` when scans run without `--verify`.
- Document the metadata format and add a regression test proving the leading URL remains parseable by existing readers.

Fixes #878

## Tests

- `node --check scan.mjs && node --check test-all.mjs`
- `node test-all.mjs --quick` — 166 passed, 0 failed, 7 existing README.ua personal-data warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated scan script and pipeline documentation with new metadata field specifications.

* **New Features**
  * Pipeline entries now include provenance metadata (source, provider) and verification timestamps.
  * Runs without verification flag record `verified_at=unverified` for transparency.
  * Trailing metadata is backward-compatible; existing systems safely ignore unknown fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->