### PR TITLE
feat(scan): add scan-history TTL and recheck policy

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -198,6 +198,8 @@ Each URL gets a verdict: `active`, `expired`, or `uncertain` with a reason.
 
 Zero-token portal scanner. Runs configured local parsers for SSR/static career pages and hits ATS APIs (Greenhouse, Ashby, Lever) directly — no LLM tokens consumed. Reads `portals.yml` for target companies, outputs matching listings to stdout, and optionally appends to `data/pipeline.md`.
 
+`scan_history.recheck_after_days` in `portals.yml` lets old `added` URLs become eligible for recheck after the configured number of days. If absent, scan-history dedup keeps the historical behavior and dedups forever. Permanent invalid statuses such as blocked host and malformed URL remain permanent.
+
 For custom SSR pages, configure a tracked company with `scan_method: local_parser` and a `parser` block. The parser can be written in JavaScript, Python, or any language available as a local executable. Company-specific parsers usually already know their source URL and only need to print JSON jobs to stdout:
 
 ```yaml

--- a/scan.mjs
+++ b/scan.mjs
@@ -185,7 +185,10 @@ const PERMANENT_SCAN_HISTORY_STATUSES = new Set([
 
 function daysBetweenIsoDates(start, end) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(start) || !/^\d{4}-\d{2}-\d{2}$/.test(end)) return null;
-  return Math.floor((new Date(`${end}T00:00:00Z`) - new Date(`${start}T00:00:00Z`)) / (1000 * 60 * 60 * 24));
+  const startDate = new Date(`${start}T00:00:00Z`);
+  const endDate = new Date(`${end}T00:00:00Z`);
+  if (startDate.toISOString().slice(0, 10) !== start || endDate.toISOString().slice(0, 10) !== end) return null;
+  return Math.floor((endDate - startDate) / (1000 * 60 * 60 * 24));
 }
 
 export function shouldDedupScanHistoryRow({ firstSeen, status = 'added' }, { recheckAfterDays = null, today = new Date().toISOString().slice(0, 10) } = {}) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -178,15 +178,45 @@ export function buildLocationFilter(locationFilter) {
 
 // ── Dedup ───────────────────────────────────────────────────────────
 
-function loadSeenUrls() {
+const PERMANENT_SCAN_HISTORY_STATUSES = new Set([
+  'skipped_invalid_url',
+  'skipped_blocked_host',
+]);
+
+function daysBetweenIsoDates(start, end) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(start) || !/^\d{4}-\d{2}-\d{2}$/.test(end)) return null;
+  return Math.floor((new Date(`${end}T00:00:00Z`) - new Date(`${start}T00:00:00Z`)) / (1000 * 60 * 60 * 24));
+}
+
+export function shouldDedupScanHistoryRow({ firstSeen, status = 'added' }, { recheckAfterDays = null, today = new Date().toISOString().slice(0, 10) } = {}) {
+  if (PERMANENT_SCAN_HISTORY_STATUSES.has(status)) return true;
+  if (status !== 'added') return true;
+  if (recheckAfterDays == null) return true;
+  const ageDays = daysBetweenIsoDates(firstSeen, today);
+  if (ageDays == null) return true;
+  return ageDays < recheckAfterDays;
+}
+
+function scanHistoryPolicy(config = {}) {
+  const raw = config.scan_history?.recheck_after_days;
+  const parsed = Number.parseInt(raw, 10);
+  return {
+    recheckAfterDays: Number.isFinite(parsed) && parsed >= 0 ? parsed : null,
+  };
+}
+
+function loadSeenUrls(policy = {}) {
   const seen = new Set();
+  let recheckEligible = 0;
 
   // scan-history.tsv
   if (existsSync(SCAN_HISTORY_PATH)) {
     const lines = readFileSync(SCAN_HISTORY_PATH, 'utf-8').split('\n');
     for (const line of lines.slice(1)) { // skip header
-      const url = line.split('\t')[0];
-      if (url) seen.add(url);
+      const [url, firstSeen, , , , status = 'added'] = line.split('\t');
+      if (!url) continue;
+      if (shouldDedupScanHistoryRow({ firstSeen, status }, policy)) seen.add(url);
+      else recheckEligible++;
     }
   }
 
@@ -206,7 +236,7 @@ function loadSeenUrls() {
     }
   }
 
-  return seen;
+  return { seen, recheckEligible };
 }
 
 function loadSeenCompanyRoles() {
@@ -460,7 +490,9 @@ async function main() {
   if (dryRun) console.log('(dry run — no files will be written)\n');
 
   // 4. Load dedup sets
-  const seenUrls = loadSeenUrls();
+  const historyPolicy = scanHistoryPolicy(config);
+  const seenUrlState = loadSeenUrls(historyPolicy);
+  const seenUrls = seenUrlState.seen;
   const seenCompanyRoles = loadSeenCompanyRoles();
 
   // 5. Fetch from each target
@@ -579,6 +611,9 @@ async function main() {
   console.log(`Filtered by title:     ${totalFilteredTitle} removed`);
   console.log(`Filtered by location:  ${totalFilteredLocation} removed`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
+  if (historyPolicy.recheckAfterDays != null) {
+    console.log(`Recheck eligible:      ${seenUrlState.recheckEligible} old scan-history URL(s)`);
+  }
   if (verify) {
     console.log(`Expired (verified):    ${expiredOffers.length} dropped`);
     console.log(`No apply control:      ${droppedOffers.length} dropped`);

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -21,6 +21,16 @@
 #   4. Adjust search_queries for your preferred job boards
 #   5. Set enabled: false on companies you don't care about
 
+# -- Scan history recheck policy (optional) --
+# By default, URLs recorded in data/scan-history.tsv are deduped forever.
+# Set recheck_after_days to let previously added URLs become eligible again
+# after N days, useful for roles that reopen or are republished at the same URL.
+# Permanent invalid statuses such as blocked host or malformed URL still remain
+# deduped forever.
+#
+# scan_history:
+#   recheck_after_days: 30
+
 # -- Location filter (optional) --
 # Filter scanned jobs by location. Applied AFTER title filter, BEFORE dedup.
 # If this entire block is absent, all locations pass (current default behavior).

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -633,6 +633,7 @@ try {
   if (
     shouldDedupScanHistoryRow({ firstSeen: '2026-06-01', status: 'added' }, { recheckAfterDays: 30, today: '2026-06-10' }) === true &&
     shouldDedupScanHistoryRow({ firstSeen: '2026-05-01', status: 'added' }, { recheckAfterDays: 30, today: '2026-06-10' }) === false &&
+    shouldDedupScanHistoryRow({ firstSeen: '2026-02-31', status: 'added' }, { recheckAfterDays: 30, today: '2026-06-10' }) === true &&
     shouldDedupScanHistoryRow({ firstSeen: '2026-05-01', status: 'skipped_blocked_host' }, { recheckAfterDays: 30, today: '2026-06-10' }) === true &&
     shouldDedupScanHistoryRow({ firstSeen: '2026-05-01', status: 'added' }, { today: '2026-06-10' }) === true &&
     scanScript.includes('Recheck eligible:')

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -508,7 +508,7 @@ if (fileExists('VERSION')) {
 console.log('\n11. Location filter — always_allow tier');
 
 try {
-  const { buildLocationFilter } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+  const { buildLocationFilter, shouldDedupScanHistoryRow } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
 
   const filter = buildLocationFilter({
     always_allow: ['belgium', 'brussels'],
@@ -629,6 +629,18 @@ try {
   // step rather than being silently dropped here.
   if (filter(42) === true) pass('non-string locations are passed through to downstream evaluation, not silently dropped');
   else fail('non-string locations should pass through');
+
+  if (
+    shouldDedupScanHistoryRow({ firstSeen: '2026-06-01', status: 'added' }, { recheckAfterDays: 30, today: '2026-06-10' }) === true &&
+    shouldDedupScanHistoryRow({ firstSeen: '2026-05-01', status: 'added' }, { recheckAfterDays: 30, today: '2026-06-10' }) === false &&
+    shouldDedupScanHistoryRow({ firstSeen: '2026-05-01', status: 'skipped_blocked_host' }, { recheckAfterDays: 30, today: '2026-06-10' }) === true &&
+    shouldDedupScanHistoryRow({ firstSeen: '2026-05-01', status: 'added' }, { today: '2026-06-10' }) === true &&
+    scanScript.includes('Recheck eligible:')
+  ) {
+    pass('scan-history TTL rechecks old added URLs while permanent statuses stay deduped');
+  } else {
+    fail('scan-history TTL policy did not match expected recheck/permanent behavior');
+  }
 
 } catch (e) {
   fail(`always_allow tests crashed: ${e.message}`);


### PR DESCRIPTION
## Summary

- Add optional `scan_history.recheck_after_days` policy for `data/scan-history.tsv` dedup.
- Keep default behavior unchanged: without the key, `added` URLs dedup forever.
- Let old `added` URLs become recheck-eligible after TTL, while permanent invalid statuses remain deduped.
- Surface recheck-eligible counts in scan summaries and document the policy in the portals template/scripts docs.

Fixes #879

## Tests

- `node --check scan.mjs && node --check test-all.mjs`
- `node test-all.mjs --quick` — 166 passed, 0 failed, 7 existing README.ua personal-data warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable URL rechecking for scan history: previously scanned URLs can now be re-evaluated after a specified number of days via the `recheck_after_days` setting in configuration. Permanently invalid statuses remain permanently excluded.

* **Documentation**
  * Updated documentation to explain the new scan-history rechecking behavior and available configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->