### PR TITLE
feat(scan): filter jobs by content (description)

### DIFF
--- a/providers/_types.js
+++ b/providers/_types.js
@@ -18,6 +18,7 @@
  * @property {string} company  May be empty when the source can't expose it
  *                             at the list-page level; populated downstream.
  * @property {string} location May be empty.
+ * @property {string} [description] Optional, full text of the job description or body.
  */
 
 /**

--- a/providers/ashby.mjs
+++ b/providers/ashby.mjs
@@ -51,6 +51,7 @@ export default {
           url: j.jobUrl || '',
           company: entry.name,
           location: j.location || '',
+          description: j.description || j.content || '',
         }));
       } catch (e) {
         lastErr = e;

--- a/providers/lever.mjs
+++ b/providers/lever.mjs
@@ -30,6 +30,7 @@ export default {
       url: j.hostedUrl || '',
       company: entry.name,
       location: j.categories?.location || '',
+      description: j.description || j.descriptionPlain || '',
     }));
   },
 };

--- a/providers/local-parser.mjs
+++ b/providers/local-parser.mjs
@@ -70,6 +70,7 @@ function normalizeParserJob(job, entry) {
     url,
     company: String(job.company || entry.name || '').trim(),
     location: normalizeLocation(job.location || job.locations),
+    description: job.description || job.content || '',
   };
 }
 

--- a/providers/recruitee.mjs
+++ b/providers/recruitee.mjs
@@ -99,6 +99,7 @@ export function parseRecruiteeResponse(json, companyName) {
       url,
       location,
       company: companyName,
+      description: j.description || j.requirements || '',
     };
   });
 }

--- a/providers/smartrecruiters.mjs
+++ b/providers/smartrecruiters.mjs
@@ -120,6 +120,12 @@ export function parseSmartRecruitersResponse(json, companyName) {
         url = `https://jobs.smartrecruiters.com/${companySlug}/${j.id}-${slugified}`;
       }
     }
-    return { title: j.name || '', url, location, company: companyName };
+    return {
+      title: j.name || '',
+      url,
+      location,
+      company: companyName,
+      description: j.description || j.content || '',
+    };
   });
 }

--- a/scan.mjs
+++ b/scan.mjs
@@ -176,6 +176,17 @@ export function buildLocationFilter(locationFilter) {
   };
 }
 
+export function buildContentFilter(contentFilter) {
+  if (!contentFilter) return () => true;
+  const negative = normalizeKeywordList(contentFilter.negative);
+
+  return (text) => {
+    if (typeof text !== 'string' || text.trim() === '') return true;
+    const lower = text.toLowerCase();
+    return !negative.some(k => lower.includes(k));
+  };
+}
+
 // ── Dedup ───────────────────────────────────────────────────────────
 
 function loadSeenUrls() {
@@ -425,6 +436,7 @@ async function main() {
   const companies = config.tracked_companies || [];
   const titleFilter = buildTitleFilter(config.title_filter);
   const locationFilter = buildLocationFilter(config.location_filter);
+  const contentFilter = buildContentFilter(config.content_filter);
 
   // 3. Resolve a provider for each enabled company
   const targets = [];
@@ -468,6 +480,7 @@ async function main() {
   let totalFound = 0;
   let totalFilteredTitle = 0;
   let totalFilteredLocation = 0;
+  let totalFilteredContent = 0;
   let totalDupes = 0;
   const newOffers = [];
   const errors = [...resolveErrors];
@@ -504,6 +517,10 @@ async function main() {
         }
         if (!locationFilter(job.location)) {
           totalFilteredLocation++;
+          continue;
+        }
+        if (!contentFilter(job.description || job.content || '')) {
+          totalFilteredContent++;
           continue;
         }
         if (seenUrls.has(job.url)) {
@@ -578,6 +595,7 @@ async function main() {
   console.log(`Total jobs found:      ${totalFound}`);
   console.log(`Filtered by title:     ${totalFilteredTitle} removed`);
   console.log(`Filtered by location:  ${totalFilteredLocation} removed`);
+  console.log(`Filtered by content:   ${totalFilteredContent} removed`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
   if (verify) {
     console.log(`Expired (verified):    ${expiredOffers.length} dropped`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -633,6 +633,71 @@ try {
 } catch (e) {
   fail(`always_allow tests crashed: ${e.message}`);
 }
+
+// ── 11.5. CONTENT FILTER ──────────────────────────────────────────
+
+console.log('\n11.5. Content filter');
+
+try {
+  const { buildContentFilter } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+
+  const filter = buildContentFilter({
+    negative: ['junior', 'intern', 'java developer'],
+  });
+
+  // Case 1: normal matching of negative keywords
+  if (filter('Looking for a Senior Software Engineer') === true) pass('matching senior description passes');
+  else fail('matching senior description should pass');
+
+  if (filter('Looking for a Junior Software Engineer') === false) pass('matching junior description is rejected');
+  else fail('matching junior description should be rejected');
+
+  // Case 2: case-insensitivity
+  if (filter('Looking for a JUNIOR Developer') === false) pass('case-insensitive match is rejected');
+  else fail('case-insensitive match should be rejected');
+
+  // Case 3: null/missing contentFilter → pass-all filter
+  const nullFilter = buildContentFilter(null);
+  if (nullFilter('Any description') === true) {
+    pass('null contentFilter returns a pass-all filter');
+  } else {
+    fail('null contentFilter should return a pass-all filter');
+  }
+
+  // Case 4: non-string description passes
+  if (filter(42) === true && filter(null) === true) {
+    pass('non-string description values pass without throwing');
+  } else {
+    fail('non-string description values should pass');
+  }
+
+  // Case 5: bare string instead of array for negative is wrapped and works
+  const stringFilter = buildContentFilter({ negative: 'junior' });
+  if (stringFilter('Looking for a junior developer') === false && stringFilter('Senior developer') === true) {
+    pass('negative as a bare string works');
+  } else {
+    fail('negative as a bare string failed');
+  }
+
+  // Case 6: empty/whitespace keywords are dropped
+  const whitespaceFilter = buildContentFilter({ negative: ['', '  ', 'junior'] });
+  if (whitespaceFilter('Some role') === true && whitespaceFilter('junior role') === false) {
+    pass('empty/whitespace negative entries are dropped without blocking everything');
+  } else {
+    fail('empty negative entries should be dropped');
+  }
+
+  // Case 7: surrounding whitespace is trimmed
+  const trimFilter = buildContentFilter({ negative: ['  junior  '] });
+  if (trimFilter('Looking for junior developer') === false) {
+    pass('whitespace-padded negative keywords still match after trim');
+  } else {
+    fail('whitespace-padded negative keywords failed to match after trim');
+  }
+} catch (e) {
+  fail(`content filter tests crashed: ${e.message}`);
+}
+
 // ── 12. FOLLOW-UP CADENCE LOGIC ─────────────────────────────────
 
 console.log('\n12. Follow-up cadence logic');


### PR DESCRIPTION
## What does this PR do?

This PR implements job description filtering in the zero-token portal scanner by:
- Introducing the `buildContentFilter` function in `scan.mjs` and configuring a `content_filter` block list.
- Updating Ashby, Lever, Recruitee, SmartRecruiters, and local-parser provider modules to extract and map job descriptions to the `Job` object.
- Adding unit tests in `test-all.mjs` to cover negative matching, case-insensitivity, trim, bare string, and empty keyword behaviors.

## Related issue

Fixes #734

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs --quick` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job description support across multiple job board integrations with intelligent fallback logic
  * Introduced content filtering capability to exclude job listings based on negative keywords (case-insensitive matching)

* **Documentation**
  * Updated job type schema to include optional description field

* **Tests**
  * Added comprehensive test suite for content filter functionality, including keyword matching, case sensitivity, and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->