### PR TITLE
feat(dashboard): keep the discard reason visible in the pipeline preview

### DIFF
--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -1123,6 +1123,8 @@ func (m PipelineModel) renderPreview() string {
 		lines = append(lines, padStyle.Render(strings.Join(facts, "   ")))
 	}
 
+	outcome := previewOutcome(app)
+
 	// Check report cache
 	if summary, ok := m.reportCache[app.ReportPath]; ok {
 		if summary.archetype != "" {
@@ -1141,15 +1143,41 @@ func (m PipelineModel) renderPreview() string {
 			lines = append(lines, padStyle.Render(
 				labelStyle.Render("Remote: ")+valueStyle.Render(summary.remote)))
 		}
-	} else if app.Notes != "" {
-		// Fallback: show notes
+	} else if app.Notes != "" && outcome == "" {
+		// Fallback: show notes (the outcome line below already carries them)
 		notes := truncateRunes(app.Notes, m.width-10)
 		lines = append(lines, padStyle.Render(dimStyle.Render(notes)))
-	} else {
+	} else if outcome == "" {
 		lines = append(lines, padStyle.Render(dimStyle.Render("Loading preview...")))
 	}
 
+	// Closed-out postings: surface what happened as the last preview line.
+	// The notes-only fallback above disappears once a report summary is
+	// cached, which is exactly when the discard reason got lost (#787).
+	if outcome != "" {
+		// Width budget: 4 cols padding + 9 for the "Outcome: " label + slack,
+		// mirroring the m.width-10 budget of the notes fallback above.
+		lines = append(lines, padStyle.Render(
+			labelStyle.Render("Outcome: ")+valueStyle.Render(truncateRunes(outcome, m.width-14))))
+	}
+
 	return strings.Join(lines, "\n")
+}
+
+// previewOutcome returns "what happened" to a closed-out application — the raw
+// status (which often carries the decision date, e.g. "descartado 2026-03-12")
+// plus the tracker notes holding the reason. Returns "" for apps still in play.
+func previewOutcome(app model.CareerApplication) string {
+	switch data.NormalizeStatus(app.Status) {
+	case "discarded", "skip", "rejected":
+	default:
+		return ""
+	}
+	outcome := strings.TrimSpace(strings.ReplaceAll(app.Status, "**", ""))
+	if app.Notes != "" {
+		outcome += " — " + app.Notes
+	}
+	return outcome
 }
 
 func (m PipelineModel) renderHelp() string {

--- a/dashboard/internal/ui/screens/pipeline_test.go
+++ b/dashboard/internal/ui/screens/pipeline_test.go
@@ -426,3 +426,98 @@ func TestSearchTypingDoesNotLoadReports(t *testing.T) {
 		}
 	}
 }
+
+func previewModelWith(t *testing.T, app model.CareerApplication) PipelineModel {
+	t.Helper()
+
+	pm := NewPipelineModel(
+		theme.NewTheme("catppuccin-mocha"),
+		[]model.CareerApplication{app},
+		model.PipelineMetrics{Total: 1},
+		"..",
+		120,
+		40,
+	)
+	pm.applyFilterAndSort()
+	pm.cursor = 0
+	return pm
+}
+
+func TestPreviewKeepsDiscardReasonWhenTlDrIsCached(t *testing.T) {
+	app := model.CareerApplication{
+		Company:    "Acme",
+		Role:       "Backend Engineer",
+		Status:     "Descartado 2026-03-12",
+		Notes:      "took too long to respond",
+		ReportPath: "reports/001-acme.md",
+	}
+	pm := previewModelWith(t, app)
+	pm.reportCache[app.ReportPath] = reportSummary{tldr: "great team, fast pace"}
+
+	preview := pm.renderPreview()
+
+	if !strings.Contains(preview, "great team, fast pace") {
+		t.Fatalf("expected preview to keep the cached TL;DR, got %q", preview)
+	}
+	// Regression for #787: before the Outcome line, a cached TL;DR replaced the
+	// notes entirely and the discard reason disappeared from the preview.
+	if !strings.Contains(preview, "took too long to respond") {
+		t.Fatalf("expected preview to keep the discard reason alongside the TL;DR, got %q", preview)
+	}
+	if !strings.Contains(preview, "Descartado 2026-03-12") {
+		t.Fatalf("expected preview to show the closing status, got %q", preview)
+	}
+}
+
+func TestPreviewOutcomeShownWithoutReportSummary(t *testing.T) {
+	pm := previewModelWith(t, model.CareerApplication{
+		Company: "Beta",
+		Role:    "Platform Engineer",
+		Status:  "SKIP",
+		Notes:   "geo blocker",
+	})
+
+	preview := pm.renderPreview()
+
+	if !strings.Contains(preview, "Outcome:") || !strings.Contains(preview, "geo blocker") {
+		t.Fatalf("expected outcome line with notes for skipped app, got %q", preview)
+	}
+	if strings.Count(preview, "geo blocker") != 1 {
+		t.Fatalf("expected notes to appear exactly once, got %q", preview)
+	}
+}
+
+func TestPreviewOutcomeOmittedForActiveApps(t *testing.T) {
+	app := model.CareerApplication{
+		Company:    "Gamma",
+		Role:       "AI Engineer",
+		Status:     "Applied 2026-04-01",
+		Notes:      "warm intro via referral",
+		ReportPath: "reports/003-gamma.md",
+	}
+	pm := previewModelWith(t, app)
+	pm.reportCache[app.ReportPath] = reportSummary{tldr: "strong fit"}
+
+	preview := pm.renderPreview()
+
+	if strings.Contains(preview, "Outcome:") {
+		t.Fatalf("expected no outcome line for an active app, got %q", preview)
+	}
+}
+
+func TestPreviewOutcomeForStatusWithoutNotes(t *testing.T) {
+	pm := previewModelWith(t, model.CareerApplication{
+		Company: "Delta",
+		Role:    "SRE",
+		Status:  "**Rejected** 2026-05-02",
+	})
+
+	preview := pm.renderPreview()
+
+	if !strings.Contains(preview, "Rejected 2026-05-02") {
+		t.Fatalf("expected outcome to show the bare closing status, got %q", preview)
+	}
+	if strings.Contains(preview, "Loading preview...") {
+		t.Fatalf("expected outcome line to replace the loading placeholder, got %q", preview)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds an **Outcome** line at the end of the pipeline preview for closed-out postings (discarded / skip / rejected), showing the raw closing status (which usually carries the decision date, e.g. `descartado 2026-03-12`) plus the tracker notes that hold the reason.

Root cause of the clobbering described in the issue: `renderPreview()` only rendered the tracker **Notes** as a *fallback* when no report summary was cached — once the report's Arquetipo/TL;DR loaded, the Notes line was replaced entirely, so the discard reason disappeared exactly for the postings that have a report. The Outcome line renders regardless of report-cache state; the old notes fallback is skipped when the Outcome line already carries them, so the reason appears exactly once.

Active postings (evaluated / applied / responded / interview / offer) are unchanged — no Outcome line.

## Related issue

Fixes #787

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass (165 passed, 0 failed; warnings are pre-existing env warnings)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Tests

4 new unit tests in `pipeline_test.go` (Go suite now 38 passed across 5 packages; `gofmt`/`go vet` clean):
- cached TL;DR + discarded → preview keeps **both** the TL;DR and the discard reason (red/green regression for the reported clobbering)
- skipped app without report summary → Outcome line carries the notes, and the notes appear exactly once (no duplication with the old fallback)
- active app with cached TL;DR → no Outcome line
- rejected app, no notes → Outcome shows the bare closing status (markdown bold stripped) and replaces the `Loading preview...` placeholder

## Example

```
──────────────────────────────────────────────────
Loc: Remote · Austin, TX   Pay: $140-210K (POSTED)   Last contact: 2026-03-12 (3mo ago)
Arquetipo: Scale-up backend
TL;DR: great team, fast pace, strong infra culture
Outcome: descartado 2026-03-12 — took too long to respond
```

## Scope

The Outcome line is intentionally limited to closed-out postings (**discarded / skip / rejected**). For active postings (applied / responded / interview / offer) the status column in the list already answers "what happened", and they have no closing reason to surface — adding the line there would just repeat the row. If you would rather have it on every posting, happy to drop the filter; it is a 3-line change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Application preview now displays an "Outcome:" line for closed-out applications, combining final status and notes in a single summary

* **Improvements**
  * Enhanced preview rendering logic to better handle rejected, discarded, and skipped applications
  * Improved loading state display when preview data is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->