### PR TITLE
fix(update): rollback restores from HEAD; explicit-pathspec commits; backup snapshots working tree

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1309,6 +1309,60 @@ try {
   fail(`Cold-start trigger test crashed: ${e.message}`);
 }
 
+// ── update-system.mjs revert + commit safety (regression: aborted-update data loss) ──
+console.log('\nupdate-system.mjs revert + commit safety');
+try {
+  const src = readFile('update-system.mjs');
+
+  // (a) rollback must restore from HEAD — `git checkout -- <paths>` restores from
+  //     the index (no-op on staged files), leaving an aborted update half-applied.
+  if (/git\('checkout',\s*'HEAD',\s*'--'/.test(src)) {
+    pass('revertPaths restores from HEAD (git checkout HEAD --), not the index');
+  } else {
+    fail("revertPaths uses 'git checkout -- <paths>' — a no-op on staged files");
+  }
+
+  // (b) commits must use explicit pathspecs so a pre-staged unrelated file is not
+  //     swept into the update/rollback commit.
+  if (/'--',\s*\.\.\.pathsToStage/.test(src) && /\.\.\.rbPaths|'--',\s*\.\.\.restored/.test(src)) {
+    pass('apply()/rollback() commit with explicit pathspecs (no index sweep)');
+  } else {
+    fail('a bare git commit remains — would sweep pre-staged files into the commit');
+  }
+
+  // (c) backup must snapshot the working tree, not just branch from HEAD.
+  if (/stash',\s*'create'/.test(src)) {
+    pass('pre-update backup snapshots the working tree (git stash create)');
+  } else {
+    fail('backup does not capture uncommitted work (no git stash create)');
+  }
+
+  // (d) behavioral: the git primitives the fix relies on actually behave as claimed.
+  const t = mkdtempSync(join(tmpdir(), 'co-revert-'));
+  const gx = (...a) => execFileSync('git', a, { cwd: t, encoding: 'utf-8' });  // no shell
+  gx('init', '-q'); gx('config', 'user.email', 't@t'); gx('config', 'user.name', 't');
+  writeFileSync(join(t, 'f.txt'), 'v1\n'); gx('add', 'f.txt'); gx('commit', '-qm', 'init');
+  writeFileSync(join(t, 'f.txt'), 'v2\n'); gx('add', 'f.txt');           // stage a change
+  gx('checkout', 'HEAD', '--', 'f.txt');                                 // the fix
+  if (readFileSync(join(t, 'f.txt'), 'utf-8') === 'v1\n') {
+    pass('git checkout HEAD -- reverts a staged change (rollback actually works)');
+  } else {
+    fail('git checkout HEAD -- did not revert the staged change');
+  }
+  writeFileSync(join(t, 'sys.txt'), 's\n'); writeFileSync(join(t, 'user.txt'), 'u\n');
+  gx('add', 'sys.txt', 'user.txt');
+  gx('commit', '-qm', 'sys only', '--', 'sys.txt');                      // explicit pathspec
+  const leftStaged = gx('diff', '--cached', '--name-only').trim();
+  if (leftStaged === 'user.txt') {
+    pass('explicit-pathspec commit does not sweep an unrelated staged file');
+  } else {
+    fail(`pathspec commit swept extra files (still staged: '${leftStaged}')`);
+  }
+  rmSync(t, { recursive: true, force: true });
+} catch (e) {
+  fail(`update-system revert/commit safety test crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -205,7 +205,12 @@ function gitStatusEntries() {
 
 function revertPaths(paths) {
   if (paths.length === 0) return;
-  git('checkout', '--', ...paths);
+  // Restore from HEAD, not the index. `git checkout -- <paths>` restores the
+  // working tree from the INDEX, which is a no-op after a staged checkout (the
+  // index already holds the new content), so an aborted update left system files
+  // staged at the new version instead of reverting them. `git checkout HEAD --`
+  // resets both index and working tree to the committed state.
+  git('checkout', 'HEAD', '--', ...paths);
 }
 
 function addPaths(paths) {
@@ -326,10 +331,22 @@ async function apply() {
   writeFileSync(lockFile, new Date().toISOString());
 
   try {
-    // 1. Backup: create branch
+    // 1. Backup: branch from HEAD AND snapshot the working tree. The branch only
+    // captures committed state; uncommitted user work would be lost if the update
+    // or its rollback discarded it. `git stash create` records the dirty tree as a
+    // commit object WITHOUT touching the working tree, saved to a recoverable ref.
     const backupBranch = updateBackupBranchName(local);
     git('branch', backupBranch);
     console.log(`Backup branch created: ${backupBranch}`);
+    try {
+      const wipSha = git('stash', 'create');
+      if (wipSha) {
+        git('update-ref', `refs/backup-pre-update-wip/${local}`, wipSha);
+        console.log(`Working-tree snapshot: refs/backup-pre-update-wip/${local} (${wipSha.slice(0, 12)})`);
+      }
+    } catch {
+      // No dirty tree, or stash unavailable — the branch backup still applies.
+    }
 
     // 2. Fetch from canonical repo
     console.log('Fetching latest from upstream...');
@@ -446,7 +463,10 @@ async function apply() {
         pathsToStage.push('.update-dismissed');
       }
       addPaths(pathsToStage);
-      git('commit', '-m', `chore: auto-update system files to v${remote}`);
+      // Commit ONLY the update's own paths. A bare `git commit` commits the whole
+      // index, sweeping any unrelated file a concurrent process pre-staged into the
+      // update commit. Explicit pathspecs scope the commit to exactly what we staged.
+      git('commit', '-m', `chore: auto-update system files to v${remote}`, '--', ...pathsToStage);
     } catch {
       // Nothing to commit (already up to date)
     }
@@ -525,7 +545,11 @@ function rollback() {
 
     if (restored.length > 0) addPaths(restored);
     try {
-      git('commit', '-m', `chore: rollback system files from ${latest}`);
+      // Explicit pathspecs: scope the rollback commit to the paths we touched
+      // (restored + removed) so an unrelated pre-staged file isn't swept in.
+      const rbPaths = [...restored, ...removed];
+      git('commit', '-m', `chore: rollback system files from ${latest}`,
+          ...(rbPaths.length > 0 ? ['--', ...rbPaths] : []));
     } catch {
       // Tolerate any commit failure here — the common case is the
       // "nothing to commit" no-op when the working tree already


### PR DESCRIPTION
Fixes #915.

Three git-handling fixes in `update-system.mjs` so an aborted update can't lose uncommitted work or leave the repo half-applied:

1. **Rollback restores from HEAD.** `revertPaths()` used `git checkout -- <paths>`, which restores the working tree from the *index* — a no-op after the staged `git checkout FETCH_HEAD -- <paths>`, so an aborted update left system files staged at the new version. Now `git checkout HEAD -- <paths>` resets index and worktree to the committed state.

2. **Commits use explicit pathspecs.** `apply()` and `rollback()` committed with a bare `git commit -m`, committing the whole index — sweeping any unrelated pre-staged file into the update/rollback commit. Now scoped to exactly what the updater staged/restored.

3. **Backup snapshots the working tree.** The pre-update backup only branched from HEAD. Added `git stash create` → `refs/backup-pre-update-wip/<version>` (non-destructive; recoverable via `git stash apply <ref>`), so uncommitted work survives an aborted update.

### Tests

`test-all.mjs` gains an "update-system.mjs revert + commit safety" section:
- source assertions for all three fixes (so they can't silently regress), and
- a behavioral check of the underlying git primitives in a temp repo — `git checkout HEAD -- <file>` reverts a staged change, and an explicit-pathspec commit does not sweep an unrelated staged file.

All new assertions pass locally. (Two unrelated failures appear only in a bare checkout without `npm install`/fixtures — `js-yaml` not installed and the analyze-patterns self-test data absent; both are environmental and pre-date this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests validating update and rollback behavior in isolated scenarios.

* **Bug Fixes**
  * Improved safety when reverting system changes during aborted updates.
  * Enhanced commit scoping for updates and rollbacks to include only intended file modifications, preventing unrelated staged changes from being included in commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->