### PR TITLE
fix(update): bootstrap tracker-links.mjs and scaffolder/ for v1.8.x → v1.9.0 upgrades

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -346,7 +346,10 @@ async function apply() {
     // local v1.6.x SYSTEM_PATHS didn't include it, so `.agents/` was never
     // checked out while `.claude/skills/` was updated to symlink into it.
     // See: https://github.com/santifer/career-ops/issues/649
-    const BOOTSTRAP_PATHS = ['.agents/', 'providers/', 'liveness-browser.mjs'];
+    // Every release that adds a file imported by other system scripts MUST
+    // append it here, or clients on older versions break on upgrade
+    // (e.g. v1.8.x → v1.9.0: merge-tracker.mjs imports tracker-links.mjs).
+    const BOOTSTRAP_PATHS = ['.agents/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'scaffolder/'];
     for (const path of BOOTSTRAP_PATHS) {
       if (SYSTEM_PATHS.includes(path)) continue; // already in main loop
       try {


### PR DESCRIPTION
Closes #920

## Problem

Updating from v1.8.1 via `node update-system.mjs apply` runs the **old** updater's `SYSTEM_PATHS` loop, which predates `tracker-links.mjs` and `scaffolder/`. The rest of the v1.9.0 tree lands (including the new `merge-tracker.mjs` and `test-all.mjs`, which import `tracker-links.mjs`), so the install is left broken: `node merge-tracker.mjs` crashes with `ERR_MODULE_NOT_FOUND` and `test-all.mjs` reports 6 failures.

Same cross-version migration gap as #649 / #704 / #718, fixed the same way those were (#654, #725, #696): append the newly-introduced paths to `BOOTSTRAP_PATHS`.

## Change

- Add `'tracker-links.mjs'` and `'scaffolder/'` to `BOOTSTRAP_PATHS` in `update-system.mjs`.
- Extend the comment above it so the next release that adds a cross-imported system file updates the list too (longer-term, #833's migration test coverage would catch this in CI).

One file, +4/−1. `node --check` passes.

## Verification

Reproduced on a real v1.8.1 install: first `apply` left `merge-tracker.mjs` crashing; checking out the two missing paths from `FETCH_HEAD` restored a green `test-all.mjs` (165 passed; the only failure is the optional Go dashboard build on a machine without a Go toolchain, which fails identically on v1.8.1).

Note: this fix helps clients whose local updater includes it (i.e. upgrades *from* any version released after this lands). Users already on ≤1.8.1 hitting the 1.9.0 gap can self-heal by running `apply` a second time, since the first apply self-updates `update-system.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the system installation process to manage additional required system files during upgrades. This ensures all necessary system components are properly checked out and made available when upgrading to new versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->