### PR TITLE
fix(tests): run tracker-mutating scripts with --dry-run in smoke tests

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -67,9 +67,14 @@ console.log('\n2. Script execution (graceful on empty data)');
 const scripts = [
   { name: 'cv-sync-check.mjs', expectExit: 1, allowFail: true }, // fails without cv.md (normal in repo)
   { name: 'verify-pipeline.mjs', expectExit: 0 },
-  { name: 'normalize-statuses.mjs', expectExit: 0 },
-  { name: 'dedup-tracker.mjs', expectExit: 0 },
-  { name: 'merge-tracker.mjs', expectExit: 0 },
+  // --dry-run: these three scripts resolve ROOT from import.meta.url and write
+  // data/applications.md in place. On a provisioned working copy (real tracker
+  // present) running them without --dry-run mutates user data — the fuzzy dedup
+  // can merge distinct same-company roles and drop rows. Harmless in this repo
+  // (no tracker shipped), destructive for end users who run `node test-all.mjs`.
+  { name: 'normalize-statuses.mjs --dry-run', expectExit: 0 },
+  { name: 'dedup-tracker.mjs --dry-run', expectExit: 0 },
+  { name: 'merge-tracker.mjs --dry-run', expectExit: 0 },
   { name: 'analyze-patterns.mjs --self-test', expectExit: 0 },
   { name: 'update-system.mjs check', expectExit: 0 },
 ];


### PR DESCRIPTION
Fixes #924

## Problem

The script-execution smoke tests run `normalize-statuses.mjs`, `dedup-tracker.mjs`, and `merge-tracker.mjs` for real. All three resolve their root from `import.meta.url`, so they always operate on the actual repo — on an end user's provisioned working copy that means the live `data/applications.md`. The fuzzy dedup can merge distinct same-company roles and silently drop tracker rows every time the user runs `node test-all.mjs` (full repro + real-data impact in #924).

## Fix

Add `--dry-run` (already supported by all three scripts) to the smoke-test entries, with a comment explaining why it must stay. The scripts still parse and execute end-to-end, so the "graceful on empty data" coverage is unchanged.

## Testing

- `node test-all.mjs` on this branch: **212 passed, 0 failed** (8 pre-existing warnings)
- Verified on a provisioned working copy with a 53-row tracker: `data/applications.md` is byte-identical before/after the suite with this patch; without it, 8 rows are dropped and 2 statuses regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test harness safety by running data-altering scripts in dry-run mode during testing.
  * Added documentation explaining script behavior in live data environments to prevent accidental modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->