### PR TITLE
fix(update): match Release Please component-prefixed tags in releases-API fallback

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1792,6 +1792,41 @@ try {
   fail(`Batch runner MCP isolation test crashed: ${e.message}`);
 }
 
+// ── 16. UPDATE-SYSTEM SEMVER PARSING (#923) ─────────────────────
+
+console.log('\n16. update-system SEMVER_RE');
+
+try {
+  // Importing must not trigger the CLI (the import.meta.url guard); it
+  // exposes SEMVER_RE, which the releases-API fallback uses on release.tag_name.
+  const { SEMVER_RE } = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+  const parse = (tag) => String(tag).trim().match(SEMVER_RE)?.[1] ?? null;
+
+  // Release Please tags carry the component prefix (career-ops-v1.9.0); the
+  // prefix must be stripped or the releases-API fallback is dead code (#923).
+  if (parse('career-ops-v1.9.0') === '1.9.0') {
+    pass('SEMVER_RE parses Release Please component-prefixed tag (career-ops-v1.9.0 → 1.9.0)');
+  } else {
+    fail(`SEMVER_RE failed on career-ops-v1.9.0 (got ${parse('career-ops-v1.9.0')}) — releases-API fallback is dead code (#923)`);
+  }
+
+  // No regression on plain tags.
+  if (parse('v1.9.0') === '1.9.0' && parse('1.9.0') === '1.9.0') {
+    pass('SEMVER_RE still parses plain v-prefixed and bare semver tags');
+  } else {
+    fail(`SEMVER_RE regressed on plain tags (v1.9.0 → ${parse('v1.9.0')}, 1.9.0 → ${parse('1.9.0')})`);
+  }
+
+  // Non-semver input must not match.
+  if (parse('career-ops') === null && parse('v1.9') === null) {
+    pass('SEMVER_RE rejects non-semver input');
+  } else {
+    fail(`SEMVER_RE matched non-semver input (career-ops → ${parse('career-ops')}, v1.9 → ${parse('v1.9')})`);
+  }
+} catch (e) {
+  fail(`update-system SEMVER_RE test crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -18,7 +18,7 @@
 import { execFile, execFileSync, execSync } from 'child_process';
 import { readFileSync, writeFileSync, existsSync, unlinkSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = __dirname;
@@ -26,6 +26,12 @@ const ROOT = __dirname;
 const CANONICAL_REPO = 'https://github.com/santifer/career-ops.git';
 const RAW_VERSION_URL = 'https://raw.githubusercontent.com/santifer/career-ops/main/VERSION';
 const RELEASES_API = 'https://api.github.com/repos/santifer/career-ops/releases/latest';
+
+// Matches a semver, with or without a leading `v` and an optional
+// Release Please component prefix (e.g. `career-ops-v1.9.0` → `1.9.0`).
+// Anchoring on `(?:^|-)` lets the releases-API fallback parse our tags,
+// which Release Please always prefixes with the component name.
+export const SEMVER_RE = /(?:^|-)v?(\d+\.\d+\.\d+)$/i;
 
 // System layer paths — ONLY these files get updated
 const SYSTEM_PATHS = [
@@ -265,8 +271,6 @@ async function check() {
   // Use curl instead of fetch() so the check works inside the Claude Code
   // sandbox (see curlGet() above for rationale).  Two sources are tried;
   // both failing is the only true-offline signal.
-  const SEMVER_RE = /^v?(\d+\.\d+\.\d+)$/i;
-
   const [rawVersion, releaseRaw] = await Promise.all([
     curlGet(RAW_VERSION_URL),
     curlGet(RELEASES_API, [
@@ -577,22 +581,27 @@ function dismiss() {
 
 // ── MAIN ────────────────────────────────────────────────────────
 
-const cmd = process.argv[2] || 'check';
+// Only run the CLI when executed directly, so importing this module
+// (e.g. from test-all.mjs to exercise SEMVER_RE) does not trigger a
+// live update check.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const cmd = process.argv[2] || 'check';
 
-try {
-  switch (cmd) {
-    case 'check': await check(); break;
-    case 'apply': await apply(); break;
-    case 'rollback': rollback(); break;
-    case 'dismiss': dismiss(); break;
-    default:
-      console.log('Usage: node update-system.mjs [check|apply|rollback|dismiss]');
-      process.exit(1);
+  try {
+    switch (cmd) {
+      case 'check': await check(); break;
+      case 'apply': await apply(); break;
+      case 'rollback': rollback(); break;
+      case 'dismiss': dismiss(); break;
+      default:
+        console.log('Usage: node update-system.mjs [check|apply|rollback|dismiss]');
+        process.exit(1);
+    }
+  } catch (err) {
+    // Subcommands now `throw` on aborts so their outer `finally` blocks
+    // run (e.g. apply() must release `.update-lock`). Print a clean
+    // message here instead of letting Node spit out a stack trace.
+    console.error(err.message || err);
+    process.exit(1);
   }
-} catch (err) {
-  // Subcommands now `throw` on aborts so their outer `finally` blocks
-  // run (e.g. apply() must release `.update-lock`). Print a clean
-  // message here instead of letting Node spit out a stack trace.
-  console.error(err.message || err);
-  process.exit(1);
 }


### PR DESCRIPTION
## What does this PR do?

`update-system.mjs check()` has two version sources: the raw `VERSION` file URL and the GitHub releases API as fallback. The fallback parsed `release.tag_name` with `/^v?(\d+\.\d+\.\d+)$/`, but Release Please tags this repo's releases with the component prefix — `career-ops-v1.9.0` — which never matches the `^v?` anchor.

So when the raw `VERSION` host is unreachable but `api.github.com` is, `check()` reported `no-remote-version` instead of falling back: the releases-API version path was effectively **dead code** (changelog extraction from `release.body` already worked — only the version-from-tag path was dead).

**Fix:** relax the anchor to `(?:^|-)v?` so the component prefix is stripped (`career-ops-v1.9.0` → `1.9.0`), while plain `v1.9.0` / `1.9.0` tags keep working and non-semver input is still rejected.

To cover this in `test-all.mjs`, `SEMVER_RE` is hoisted to module scope and exported, and an `import.meta.url` guard now wraps `MAIN` (mirroring `followup-cadence.mjs`) so importing the module for assertions doesn't trigger a live update check. No module currently imports `update-system.mjs`, and the existing CLI smoke test (`update-system.mjs check`, section 1) still passes.

## Related issue

Fixes #923

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My PR is linked to a related issue
- [x] No personal data (real CV/email/phone/name) is included
- [x] I ran `node test-all.mjs` locally (219 passed, 0 failed)
- [x] My changes respect the Data Contract (only System Layer files: `update-system.mjs`, `test-all.mjs`)
- [x] Changes align with the project roadmap/philosophy (minimal, surgical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced version parsing to support GitHub Release-Please tags with optional component prefixes (e.g., `career-ops-v1.9.0`), while maintaining backward compatibility with standard semver formats like `v1.9.0`.

* **Tests**
  * Introduced validation tests for semver regex parsing, covering component-prefixed release tags, standard version formats, and rejection of non-semver inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->