### PR TITLE
feat: add evaluation report contract verifier

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -59,10 +59,10 @@ Checks:
 - `**URL:**` header is present
 - `**Legitimacy:**` is present and uses an accepted tier (`high`, `medium`, `low`, `uncertain`, `unverified`)
 - `**Score:**` is parseable as `X.X/5`, `N/A`, `SKIP`, or `DUP`
-- `**PDF:**` status is present
-- `## Machine Summary` parses as YAML/JSON when present
+- `**PDF:**` status is present for reports marked as `pipeline` / `auto-pipeline`; missing PDF status on other legacy reports is warning-only
+- `## Machine Summary` parses as YAML/JSON when present and includes analyzer-aligned core fields (`company`, `role`, `score`, `final_decision`)
 
-Missing `## Machine Summary` is warning-only for legacy reports. Header contract failures are errors.
+Missing `## Machine Summary` is warning-only for legacy reports. Malformed Machine Summary YAML/JSON and header contract failures are errors.
 
 ```bash
 npm run verify:reports

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -8,6 +8,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 |---------|--------|---------|
 | `npm run doctor` | `doctor.mjs` | Validate setup prerequisites |
 | `npm run verify` | `verify-pipeline.mjs` | Check pipeline data integrity |
+| `npm run verify:reports` | `verify-reports.mjs` | Validate evaluation report contracts |
 | `npm run normalize` | `normalize-statuses.mjs` | Fix non-canonical statuses |
 | `npm run dedup` | `dedup-tracker.mjs` | Remove duplicate tracker entries |
 | `npm run merge` | `merge-tracker.mjs` | Merge batch TSVs into applications.md |
@@ -46,6 +47,29 @@ npm run verify
 ```
 
 **Exit codes:** `0` pipeline clean (zero errors), `1` errors found. Warnings (e.g. possible duplicates) do not cause a non-zero exit.
+
+---
+
+## verify:reports
+
+Validates evaluation report markdown files in `reports/` before downstream tooling consumes them.
+
+Checks:
+
+- `**URL:**` header is present
+- `**Legitimacy:**` is present and uses an accepted tier (`high`, `medium`, `low`, `uncertain`, `unverified`)
+- `**Score:**` is parseable as `X.X/5`, `N/A`, `SKIP`, or `DUP`
+- `**PDF:**` status is present
+- `## Machine Summary` parses as YAML/JSON when present
+
+Missing `## Machine Summary` is warning-only for legacy reports. Header contract failures are errors.
+
+```bash
+npm run verify:reports
+node verify-reports.mjs --self-test
+```
+
+**Exit codes:** `0` no report contract errors, `1` one or more report contract errors.
 
 ---
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -58,7 +58,7 @@ Checks:
 
 - `**URL:**` header is present
 - `**Legitimacy:**` is present and uses an accepted tier (`high`, `medium`, `low`, `uncertain`, `unverified`)
-- `**Score:**` is parseable as `X.X/5`, `N/A`, `SKIP`, or `DUP`
+- `**Score:**` is parseable as `X/5`, `X.X/5`, `N/A`, `SKIP`, or `DUP`
 - `**PDF:**` status is present for reports marked as `pipeline` / `auto-pipeline`; missing PDF status on other legacy reports is warning-only
 - `## Machine Summary` parses as YAML/JSON when present and includes analyzer-aligned core fields (`company`, `role`, `score`, `final_decision`)
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -57,7 +57,7 @@ Validates evaluation report markdown files in `reports/` before downstream tooli
 Checks:
 
 - `**URL:**` header is present
-- `**Legitimacy:**` is present and uses an accepted tier (`high`, `medium`, `low`, `uncertain`, `unverified`)
+- `**Legitimacy:**` is present and uses an accepted tier (`High Confidence`, `Proceed with Caution`, `Suspicious`, or the machine-friendly `high`, `medium`, `low`, `uncertain`, `unverified`)
 - `**Score:**` is parseable as `X/5`, `X.X/5`, `N/A`, `SKIP`, or `DUP`
 - `**PDF:**` status is present for reports marked as `pipeline` / `auto-pipeline`; missing PDF status on other legacy reports is warning-only
 - `## Machine Summary` parses as YAML/JSON when present and includes analyzer-aligned core fields (`company`, `role`, `score`, `final_decision`)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "doctor": "node doctor.mjs",
     "verify": "node verify-pipeline.mjs",
+    "verify:reports": "node verify-reports.mjs",
     "normalize": "node normalize-statuses.mjs",
     "dedup": "node dedup-tracker.mjs",
     "merge": "node merge-tracker.mjs",

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -73,6 +73,7 @@ const scripts = [
   { name: 'analyze-patterns.mjs --self-test', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'validate-portals.mjs --file templates/portals.example.yml', expectExit: 0 },
+  { name: 'verify-reports.mjs --self-test', expectExit: 0 },
   { name: 'update-system.mjs check', expectExit: 0 },
 ];
 

--- a/verify-reports.mjs
+++ b/verify-reports.mjs
@@ -28,7 +28,8 @@ function parseMachineSummary(content) {
 }
 
 function requiresPdfStatus(content) {
-  return /(?:\*\*Source:\*\*|source_path:|source:)\s*(auto-pipeline|pipeline)/i.test(content);
+  const sourceLines = content.match(/^(?:\*\*Source:\*\*|source_path:|source:).*$/gim) ?? [];
+  return sourceLines.some((line) => /\b(?:auto-pipeline|pipeline)\b/i.test(line));
 }
 
 export function validateReport(content) {
@@ -54,14 +55,16 @@ export function validateReport(content) {
   }
 
   let machineSummary;
+  let machineSummaryParseFailed = false;
   try {
     machineSummary = parseMachineSummary(content);
   } catch (err) {
     errors.push(`Machine Summary failed to parse: ${err.message}`);
+    machineSummaryParseFailed = true;
     machineSummary = null;
   }
   if (!machineSummary) {
-    warnings.push('missing ## Machine Summary');
+    if (!machineSummaryParseFailed) warnings.push('missing ## Machine Summary');
   } else if (typeof machineSummary !== 'object' || Array.isArray(machineSummary)) {
     errors.push('Machine Summary must parse to an object');
   } else {
@@ -110,7 +113,7 @@ function selfTest() {
       '',
       '**Score:** banana',
       '**PDF:** maybe',
-      '**Source:** pipeline',
+      'source_path: batch/auto-pipeline/acme.md',
       '',
     ].join('\n'));
     writeFileSync(join(dir, '003-bad-summary-2026-06-10.md'), [
@@ -131,7 +134,13 @@ function selfTest() {
     const valid = results.find((result) => result.file.startsWith('001-'));
     const invalid = results.find((result) => result.file.startsWith('002-'));
     const badSummary = results.find((result) => result.file.startsWith('003-'));
-    if (valid?.status !== 'ok' || invalid?.status !== 'error' || invalid.errors.length < 3 || badSummary?.status !== 'error') {
+    if (
+      valid?.status !== 'ok' ||
+      invalid?.status !== 'error' ||
+      invalid.errors.length < 3 ||
+      badSummary?.status !== 'error' ||
+      badSummary.warnings.includes('missing ## Machine Summary')
+    ) {
       throw new Error(`unexpected self-test result: ${JSON.stringify(results)}`);
     }
     console.log('verify-reports self-test passed');

--- a/verify-reports.mjs
+++ b/verify-reports.mjs
@@ -11,7 +11,16 @@ import yaml from 'js-yaml';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const REPORTS_DIR = process.env.CAREER_OPS_REPORTS || join(ROOT, 'reports');
-const VALID_LEGITIMACY = new Set(['high', 'medium', 'low', 'uncertain', 'unverified']);
+const VALID_LEGITIMACY = new Set([
+  'high',
+  'medium',
+  'low',
+  'uncertain',
+  'unverified',
+  'high confidence',
+  'proceed with caution',
+  'suspicious',
+]);
 const MACHINE_SUMMARY_FIELDS = ['company', 'role', 'score', 'final_decision'];
 
 function reportFiles(dir) {
@@ -37,7 +46,7 @@ export function validateReport(content) {
   const warnings = [];
 
   if (!/\*\*URL:\*\*\s*\S+/i.test(content)) errors.push('missing **URL:** header');
-  const legitimacy = content.match(/\*\*Legitimacy:\*\*\s*([A-Za-z_-]+)/i)?.[1]?.toLowerCase();
+  const legitimacy = content.match(/\*\*Legitimacy:\*\*\s*([A-Za-z][A-Za-z _-]*)/i)?.[1]?.trim().toLowerCase();
   if (!legitimacy) {
     errors.push('missing **Legitimacy:** header');
   } else if (!VALID_LEGITIMACY.has(legitimacy)) {
@@ -97,7 +106,7 @@ function selfTest() {
       '**Score:** 4.2/5',
       '**URL:** https://jobs.example/acme',
       '**PDF:** ✅',
-      '**Legitimacy:** high',
+      '**Legitimacy:** High Confidence',
       '',
       '## Machine Summary',
       '```yaml',

--- a/verify-reports.mjs
+++ b/verify-reports.mjs
@@ -12,7 +12,7 @@ import yaml from 'js-yaml';
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const REPORTS_DIR = process.env.CAREER_OPS_REPORTS || join(ROOT, 'reports');
 const VALID_LEGITIMACY = new Set(['high', 'medium', 'low', 'uncertain', 'unverified']);
-const MACHINE_SUMMARY_FIELDS = ['company', 'role', 'score', 'recommendation'];
+const MACHINE_SUMMARY_FIELDS = ['company', 'role', 'score', 'final_decision'];
 
 function reportFiles(dir) {
   if (!existsSync(dir)) return [];
@@ -25,6 +25,10 @@ function parseMachineSummary(content) {
   const match = content.match(/##\s*Machine Summary\s*\n+```(?:yaml|yml|json)?\s*\n([\s\S]*?)\n```/i);
   if (!match) return null;
   return yaml.load(match[1]);
+}
+
+function requiresPdfStatus(content) {
+  return /(?:\*\*Source:\*\*|source_path:|source:)\s*(auto-pipeline|pipeline)/i.test(content);
 }
 
 export function validateReport(content) {
@@ -42,11 +46,20 @@ export function validateReport(content) {
   const score = content.match(/\*\*Score:\*\*\s*(\d(?:\.\d)?\/5|N\/A|SKIP|DUP)/i)?.[1];
   if (!score) errors.push('missing or invalid **Score:** header');
 
-  if (!/\*\*PDF:\*\*\s*(✅|❌|not generated|pending|N\/A)/i.test(content)) {
+  const hasPdfStatus = /\*\*PDF:\*\*\s*(✅|❌|not generated|pending|N\/A)/i.test(content);
+  if (requiresPdfStatus(content) && !hasPdfStatus) {
     errors.push('missing **PDF:** status header');
+  } else if (!hasPdfStatus) {
+    warnings.push('missing **PDF:** status header');
   }
 
-  const machineSummary = parseMachineSummary(content);
+  let machineSummary;
+  try {
+    machineSummary = parseMachineSummary(content);
+  } catch (err) {
+    errors.push(`Machine Summary failed to parse: ${err.message}`);
+    machineSummary = null;
+  }
   if (!machineSummary) {
     warnings.push('missing ## Machine Summary');
   } else if (typeof machineSummary !== 'object' || Array.isArray(machineSummary)) {
@@ -88,7 +101,7 @@ function selfTest() {
       'company: Acme',
       'role: AI Engineer',
       'score: 4.2',
-      'recommendation: apply',
+      'final_decision: apply',
       '```',
       '',
     ].join('\n'));
@@ -97,13 +110,28 @@ function selfTest() {
       '',
       '**Score:** banana',
       '**PDF:** maybe',
+      '**Source:** pipeline',
+      '',
+    ].join('\n'));
+    writeFileSync(join(dir, '003-bad-summary-2026-06-10.md'), [
+      '# Bad Summary',
+      '',
+      '**Score:** 4.1/5',
+      '**URL:** https://jobs.example/bad',
+      '**Legitimacy:** medium',
+      '',
+      '## Machine Summary',
+      '```yaml',
+      'company: [',
+      '```',
       '',
     ].join('\n'));
 
     const results = verifyReports({ reportsDir: dir });
     const valid = results.find((result) => result.file.startsWith('001-'));
     const invalid = results.find((result) => result.file.startsWith('002-'));
-    if (valid?.status !== 'ok' || invalid?.status !== 'error' || invalid.errors.length < 3) {
+    const badSummary = results.find((result) => result.file.startsWith('003-'));
+    if (valid?.status !== 'ok' || invalid?.status !== 'error' || invalid.errors.length < 3 || badSummary?.status !== 'error') {
       throw new Error(`unexpected self-test result: ${JSON.stringify(results)}`);
     }
     console.log('verify-reports self-test passed');

--- a/verify-reports.mjs
+++ b/verify-reports.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * verify-reports.mjs — validate evaluation report contract fields.
+ */
+
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import yaml from 'js-yaml';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const REPORTS_DIR = process.env.CAREER_OPS_REPORTS || join(ROOT, 'reports');
+const VALID_LEGITIMACY = new Set(['high', 'medium', 'low', 'uncertain', 'unverified']);
+const MACHINE_SUMMARY_FIELDS = ['company', 'role', 'score', 'recommendation'];
+
+function reportFiles(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((file) => /^\d{3}-.+\.md$/.test(file))
+    .map((file) => join(dir, file));
+}
+
+function parseMachineSummary(content) {
+  const match = content.match(/##\s*Machine Summary\s*\n+```(?:yaml|yml|json)?\s*\n([\s\S]*?)\n```/i);
+  if (!match) return null;
+  return yaml.load(match[1]);
+}
+
+export function validateReport(content) {
+  const errors = [];
+  const warnings = [];
+
+  if (!/\*\*URL:\*\*\s*\S+/i.test(content)) errors.push('missing **URL:** header');
+  const legitimacy = content.match(/\*\*Legitimacy:\*\*\s*([A-Za-z_-]+)/i)?.[1]?.toLowerCase();
+  if (!legitimacy) {
+    errors.push('missing **Legitimacy:** header');
+  } else if (!VALID_LEGITIMACY.has(legitimacy)) {
+    errors.push(`invalid legitimacy tier: ${legitimacy}`);
+  }
+
+  const score = content.match(/\*\*Score:\*\*\s*(\d(?:\.\d)?\/5|N\/A|SKIP|DUP)/i)?.[1];
+  if (!score) errors.push('missing or invalid **Score:** header');
+
+  if (!/\*\*PDF:\*\*\s*(✅|❌|not generated|pending|N\/A)/i.test(content)) {
+    errors.push('missing **PDF:** status header');
+  }
+
+  const machineSummary = parseMachineSummary(content);
+  if (!machineSummary) {
+    warnings.push('missing ## Machine Summary');
+  } else if (typeof machineSummary !== 'object' || Array.isArray(machineSummary)) {
+    errors.push('Machine Summary must parse to an object');
+  } else {
+    for (const field of MACHINE_SUMMARY_FIELDS) {
+      if (!(field in machineSummary)) warnings.push(`Machine Summary missing ${field}`);
+    }
+  }
+
+  return { errors, warnings };
+}
+
+export function verifyReports({ reportsDir = REPORTS_DIR } = {}) {
+  return reportFiles(reportsDir).map((path) => {
+    const { errors, warnings } = validateReport(readFileSync(path, 'utf-8'));
+    return {
+      file: path.replace(`${reportsDir}/`, ''),
+      status: errors.length ? 'error' : warnings.length ? 'warning' : 'ok',
+      errors,
+      warnings,
+    };
+  });
+}
+
+function selfTest() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-reports-'));
+  try {
+    writeFileSync(join(dir, '001-valid-2026-06-10.md'), [
+      '# Acme — AI Engineer',
+      '',
+      '**Score:** 4.2/5',
+      '**URL:** https://jobs.example/acme',
+      '**PDF:** ✅',
+      '**Legitimacy:** high',
+      '',
+      '## Machine Summary',
+      '```yaml',
+      'company: Acme',
+      'role: AI Engineer',
+      'score: 4.2',
+      'recommendation: apply',
+      '```',
+      '',
+    ].join('\n'));
+    writeFileSync(join(dir, '002-invalid-2026-06-10.md'), [
+      '# Broken',
+      '',
+      '**Score:** banana',
+      '**PDF:** maybe',
+      '',
+    ].join('\n'));
+
+    const results = verifyReports({ reportsDir: dir });
+    const valid = results.find((result) => result.file.startsWith('001-'));
+    const invalid = results.find((result) => result.file.startsWith('002-'));
+    if (valid?.status !== 'ok' || invalid?.status !== 'error' || invalid.errors.length < 3) {
+      throw new Error(`unexpected self-test result: ${JSON.stringify(results)}`);
+    }
+    console.log('verify-reports self-test passed');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) return selfTest();
+  const results = verifyReports();
+  const errors = results.reduce((sum, result) => sum + result.errors.length, 0);
+  const warnings = results.reduce((sum, result) => sum + result.warnings.length, 0);
+  console.log(JSON.stringify({ errors, warnings, results }, null, 2));
+  if (errors > 0) process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add verify-reports.mjs to validate evaluation report headers and Machine Summary blocks
- expose npm run verify:reports and include the self-test in test-all.mjs
- document accepted report contract fields in docs/SCRIPTS.md

## Validation
- node verify-reports.mjs --self-test
- npm run verify:reports
- node test-all.mjs --quick (232 passed, 0 failed; existing README personal-data warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `verify:reports` command to validate evaluation report markdown files, checking for required headers, accepted legitimacy tier values, proper score formats, PDF status, and Machine Summary sections.

* **Documentation**
  * Added comprehensive documentation for the report verification script with usage examples and exit code reference.

* **Tests**
  * Integrated automated report verification into the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->