### PR TITLE
fix: surface latex mode in command menus

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -3,7 +3,7 @@ name: career-ops
 description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
 user_invocable: true
 user-invocable: true
-argument-hint: "[scan | deep | pdf | cover | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | interview | patterns | followup | update]"
+argument-hint: "[scan | deep | pdf | latex | cover | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | interview | patterns | followup | update]"
 license: MIT
 ---
 
@@ -24,6 +24,7 @@ Determine the mode from `$mode`:
 | `interview-prep` | `interview-prep` |
 | `interview` | `interview` |
 | `pdf` | `pdf` |
+| `latex` | `latex` |
 | `training` | `training` |
 | `project` | `project` |
 | `tracker` | `tracker` |
@@ -59,6 +60,7 @@ Available commands:
   /career-ops interview-prep → Generate company-specific interview prep doc
   /career-ops interview    → Interactive profile/CV onboarding interview
   /career-ops pdf       → PDF only, ATS-optimized CV
+  /career-ops latex     → Export CV as LaTeX/Overleaf .tex
   /career-ops cover     → Cover letter: standalone JD paste or /career-ops cover {slug}
   /career-ops training  → Evaluate course/cert against North Star
   /career-ops project   → Evaluate portfolio project idea
@@ -88,7 +90,7 @@ Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `p
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`
 
-Applies to: `tracker`, `deep`, `interview-prep`, `interview`, `training`, `project`, `patterns`, `followup`, `cover`
+Applies to: `tracker`, `deep`, `interview-prep`, `interview`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`
 
 ### Modes delegated to subagent:
 For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as Agent with the content of `_shared.md` + `modes/{mode}.md` injected into the subagent prompt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ When using the [Gemini CLI](https://github.com/google-gemini/gemini-cli), the fo
 | `/career-ops-contact` | `/career-ops contacto` | LinkedIn outreach (find contacts + draft) |
 | `/career-ops-deep` | `/career-ops deep` | Deep company research |
 | `/career-ops-pdf` | `/career-ops pdf` | Generate ATS-optimized CV |
+| `/career-ops-latex` | `/career-ops latex` | Export CV as LaTeX/Overleaf .tex |
 | `/career-ops-training` | `/career-ops training` | Evaluate course/cert against goals |
 | `/career-ops-project` | `/career-ops project` | Evaluate portfolio project idea |
 | `/career-ops-tracker` | `/career-ops tracker` | Application status overview |

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -480,7 +480,7 @@ const expectedModes = [
   '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'scan.md',
   'batch.md', 'apply.md', 'auto-pipeline.md', 'contacto.md', 'deep.md',
   'ofertas.md', 'pipeline.md', 'project.md', 'tracker.md', 'training.md',
-  'interview.md',
+  'interview.md', 'latex.md',
 ];
 
 for (const mode of expectedModes) {
@@ -497,6 +497,15 @@ if (shared.includes('_profile.md')) {
   pass('_shared.md references _profile.md');
 } else {
   fail('_shared.md does NOT reference _profile.md');
+}
+
+for (const skillPath of ['.claude/skills/career-ops/SKILL.md', '.agents/skills/career-ops/SKILL.md']) {
+  const skill = readFile(skillPath);
+  if (skill.includes('/career-ops latex')) {
+    pass(`${skillPath} exposes /career-ops latex in discovery menu`);
+  } else {
+    fail(`${skillPath} does not expose /career-ops latex in discovery menu`);
+  }
 }
 
 const applyMode = readFile('modes/apply.md');


### PR DESCRIPTION
## Summary
- expose  in the unified career-ops skill menu and routing metadata
- add the missing Gemini CLI command table row in CLAUDE.md
- cover latex mode discoverability in test-all.mjs

Fixes #563

## Validation
- node test-all.mjs --quick (233 passed, 0 failed; existing README personal-data warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Career Ops now supports exporting CVs in LaTeX/Overleaf format via the `/career-ops latex` command.

* **Documentation**
  * Updated command reference to include the new LaTeX export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->