### PR TITLE
fix(pdf): avoid networkidle wait during render

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -261,7 +261,7 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
 
     // Set content with file base URL for any relative resources
     await page.setContent(html, {
-      waitUntil: 'networkidle',
+      waitUntil: 'load',
       baseURL: `file://${baseDir}/`,
     });
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -472,6 +472,22 @@ if (!absPathResult) {
   }
 }
 
+// ── 7b. PDF RENDER WAIT CONDITION ───────────────────────────────
+
+console.log('\n7b. PDF render wait condition');
+
+const generatePdfScript = readFile('generate-pdf.mjs');
+if (/waitUntil:\s*['"]load['"]/.test(generatePdfScript)) {
+  pass('generate-pdf waits for load before rendering');
+} else {
+  fail('generate-pdf does not wait for load before rendering');
+}
+if (!/waitUntil:\s*['"]networkidle['"]/.test(generatePdfScript)) {
+  pass('generate-pdf does not wait for networkidle');
+} else {
+  fail('generate-pdf still waits for networkidle');
+}
+
 // ── 8. MODE FILE INTEGRITY ──────────────────────────────────────
 
 console.log('\n8. Mode file integrity');


### PR DESCRIPTION
## Summary
- switch HTML-to-PDF rendering from networkidle to load so open background requests do not stall printing
- add a regression assertion in test-all.mjs for the PDF render wait condition

Fixes #863

## Validation
- node test-all.mjs --quick (232 passed, 0 failed; existing README personal-data warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF generation performance by optimizing the content initialization timing before rendering begins.

* **Tests**
  * Added test validation to ensure PDF rendering configuration is properly maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->