### PR TITLE
docs: note Gemini CLI needs Node.js 20+ and fix the bogus `gemini auth` step

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -132,18 +132,15 @@ career-ops 原生支持 [Gemini CLI](https://github.com/google-gemini/gemini-cli
 ### 选项 A —— 原生 Gemini CLI（推荐）
 
 ```bash
-# 1. 安装 Gemini CLI
+# 1. 安装 Gemini CLI（需要 Node.js 20+）
 npm install -g @google/gemini-cli
 # 或: npx @google/gemini-cli --version
 
-# 2. 认证（免费 —— 使用你的 Google 账号）
-gemini auth
-
-# 3. 在 career-ops 目录中运行
+# 2. 在 career-ops 目录中运行 —— 首次启动时使用你的 Google 账号登录（免费）完成认证
 cd career-ops
 gemini
 
-# 4. 像 Claude Code 一样使用斜杠命令
+# 3. 像 Claude Code 一样使用斜杠命令
 /career-ops "Anthropic 的资深 AI 工程师..."
 /career-ops-evaluate --file ./jds/openai.txt
 /career-ops-scan

--- a/README.md
+++ b/README.md
@@ -148,18 +148,16 @@ Career-ops supports [Gemini CLI](https://github.com/google-gemini/gemini-cli) na
 ### Option A: Native Gemini CLI (Recommended)
 
 ```bash
-# 1. Install Gemini CLI
+# 1. Install Gemini CLI (requires Node.js 20+)
 npm install -g @google/gemini-cli
 # or: npx @google/gemini-cli --version
 
-# 2. Authenticate (free, uses your Google account)
-gemini auth
-
-# 3. Run in the career-ops directory
+# 2. Run in the career-ops directory — on first launch, sign in with your
+#    Google account (free) to authenticate
 cd career-ops
 gemini
 
-# 4. Use slash commands just like Claude Code
+# 3. Use slash commands just like Claude Code
 /career-ops "Senior AI Engineer at Anthropic..."
 /career-ops-evaluate --file ./jds/openai.txt
 /career-ops-scan

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - An AI coding CLI — [Claude Code](https://claude.ai/code), Gemini CLI, Codex, Qwen Code, OpenCode or GitHub Copilot CLI
-- [Node.js](https://nodejs.org) 18+ and `git` (`npx` ships with Node — the installer refuses to run without them)
+- [Node.js](https://nodejs.org) 18+ and `git` (`npx` ships with Node — the installer refuses to run without them) — note: the Gemini CLI integration requires Node.js 20+
 - (Optional) Go 1.21+ (for the dashboard TUI)
 
 ## Quick Start


### PR DESCRIPTION
## What does this PR do?

Documentation fix for the Gemini CLI setup flow (#619): adds an explicit **Node.js 20+** requirement for the Gemini CLI integration, and replaces the non-existent `gemini auth` command with the real first-launch sign-in flow.

## Related issue

Closes #619

## Why

Two doc bugs the reporter hit (and the maintainer confirmed in-thread):

1. **Node version.** `docs/SETUP.md` advertises Node.js 18+, but the Gemini CLI integration crashes on Node 18 — `ink`'s `string-width` uses the regex `v` flag, which only parses on Node 20+ ([gemini-cli#13427](https://github.com/google-gemini/gemini-cli/issues/13427)). So `npm run doctor` reports "All checks passed" while `gemini` immediately throws `SyntaxError: Invalid regular expression flags`. The project itself still supports 18+, so this is a Gemini-path-specific callout, not a project-wide bump.
2. **Bogus command.** The READMEs document `gemini auth` as the authentication step, but that subcommand doesn't exist (`gemini: command not found` / no such subcommand). Authentication happens on the **first `gemini` launch** via the "Sign in with Google" browser flow. The auth step is folded into the launch step so the documented sequence actually works.

## What users will see

- `docs/SETUP.md` prerequisites now note that the Gemini CLI integration needs Node.js 20+.
- The README "Native Gemini CLI" quick-start (EN + 简体中文) installs with a Node 20+ note and authenticates by launching `gemini` (first-run Google sign-in) instead of the invalid `gemini auth`.

## Surface area

Docs only — `README.md`, `README.cn.md`, `docs/SETUP.md`. No code, no behavior change, no user-layer files.

## Screenshots

N/A — documentation-only change.

## Bug fix verification

Verified against the reporter's repro: on Node 18, `gemini` crashes with the `ink`/`string-width` `v`-flag `SyntaxError` (fixed by Node 20+); `gemini auth` returns `command not found` whereas `gemini` launches and triggers the Google sign-in flow. The doc now matches the working sequence.

## Validation

`node test-all.mjs --quick` → **229 passed, 0 failed** (the 16 warnings are pre-existing `santifer.io` personal-data false-positives in README.pl/ar/ua and the cv-sync no-user-data check — none in the files this PR touches).

## Note on scope (translations)

You named `README.md`, `README.cn.md`, `docs/SETUP.md`, which is exactly what this PR changes. Heads-up: the **same bogus `gemini auth` step also lives in `README.fr.md` and `README.ar.md`** (and they'd benefit from the Node 20+ note too). I kept this PR to the three files you scoped — happy to extend it to fr/ar here, or leave them for a follow-up i18n PR, whichever you prefer.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I linked a related issue above
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran the test suite (`node test-all.mjs --quick`) and all tests pass (0 failed)
- [x] My changes respect the Data Contract (docs only, no user-layer files)
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Gemini CLI integration instructions to require Node.js 20+
  * Simplified authentication workflow—login now occurs during initial setup instead of as a separate step
  * Clarified Node.js version requirements in setup prerequisites across English and Chinese documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->