### PR TITLE
fix(eval): gate dead links before evaluation in oferta/auto-pipeline

### DIFF
--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -16,6 +16,18 @@ If the input is a **URL** (not pasted JD text), follow this strategy to extract 
 
 **If the input is JD text** (not a URL): use directly, without needing to fetch.
 
+## Step 0.5 — Liveness gate
+
+Before running any evaluation, confirm the posting is still live. The Step 0 Playwright snapshot already holds the evidence — judge it now, before spending tokens on the A-G evaluation, the report, or a PDF. A 404/expired page silently served as a static fallback ("position filled", empty shell) otherwise scores a full evaluation against phantom content.
+
+1. From the Step 0 snapshot/fetched content, classify the posting:
+   - **active posting evidence:** title/role + a real job description or an application/apply path
+   - **closed posting evidence:** expired/closed/"no longer accepting applications", missing JD with only nav/footer, hard redirect to a generic careers/search page, or 404/410
+2. If the posting appears closed or the page is a dead/fallback shell, **stop here**: do not run Step 1–Step 4. Tell the candidate the link is dead, and if the entry came from `data/pipeline.md`, mark it `- [x] ~~Company | Role~~ — oferta nieaktywna`.
+3. If only JD text was pasted (no URL), there is no link to verify — skip the gate and proceed.
+
+Do not continue to Step 1 until this gate is resolved.
+
 ## Step 1 — A-G Evaluation
 
 Execute the same as the `oferta` mode (read `modes/oferta.md` for all A-F blocks + Block G Posting Legitimacy).

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -2,6 +2,19 @@
 
 When the candidate pastes a job (text or URL), ALWAYS deliver the 7 blocks (A-F evaluation + G legitimacy):
 
+## Liveness gate (URL inputs)
+
+When the candidate pastes a **URL** (not JD text), confirm the posting is still live before doing any evaluation. A dead link must never reach Block A — a 404/expired page wastes a full A-G evaluation, report, and PDF on phantom content.
+
+1. Get the page content: if you arrived here from `auto-pipeline` (its Step 0.5 already navigated and cleared the link), reuse that snapshot — do not navigate again. On a direct URL entry, navigate with Playwright (`browser_navigate` + `browser_snapshot`) and read the title, URL, and visible content.
+2. Classify the posting:
+   - **active posting evidence:** title/role + a real job description or an application/apply path
+   - **closed posting evidence:** expired/closed/"no longer accepting applications", missing JD with only nav/footer, hard redirect to a generic careers/search page, or 404/410
+3. If the posting appears closed, **stop before Block A**: tell the candidate the link is dead, and if the entry came from `data/pipeline.md`, mark it `- [x] ~~Company | Role~~ — oferta nieaktywna`. Do not generate an evaluation, report, or CV.
+4. If the candidate pasted JD text (no URL), liveness cannot be verified — note that and proceed; there is no link to check.
+
+Do not continue to Block A until this gate is resolved. The snapshot captured here is reused by Block G's freshness signals.
+
 ## Step 0 — Archetype Detection
 
 Classify the job into one of the 6 archetypes (see `_shared.md`). If it is a hybrid, indicate the 2 closest ones. This determines:
@@ -93,7 +106,7 @@ Analyze the job posting for signals that indicate whether this is a real, active
 
 ### Signals to analyze (in order):
 
-**1. Posting Freshness** (from Playwright snapshot, already captured in Step 0):
+**1. Posting Freshness** (from the Playwright snapshot captured during the liveness gate, or in `auto-pipeline` Step 0; unavailable if only JD text was pasted):
 - Date posted or "X days ago" -- extract from page
 - Apply button state (active / closed / missing / redirects to generic page)
 - If URL redirected to generic careers page, note it

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -512,6 +512,21 @@ if (
   fail('apply mode missing liveness/role-match preflight gate');
 }
 
+const ofertaMode = readFile('modes/oferta.md');
+const autoPipelineMode = readFile('modes/auto-pipeline.md');
+if (
+  ofertaMode.includes('## Liveness gate (URL inputs)') &&
+  ofertaMode.includes('closed posting evidence') &&
+  ofertaMode.includes('Do not continue to Block A until this gate is resolved') &&
+  autoPipelineMode.includes('## Step 0.5 — Liveness gate') &&
+  autoPipelineMode.includes('closed posting evidence') &&
+  autoPipelineMode.includes('Do not continue to Step 1 until this gate is resolved')
+) {
+  pass('eval modes (oferta/auto-pipeline) gate dead links before evaluation');
+} else {
+  fail('eval modes missing liveness gate before evaluation');
+}
+
 // ── 9. LOCAL PARSER CONTRACT ────────────────────────────────────
 
 console.log('\n9. Local parser contract');


### PR DESCRIPTION
## What does this PR do?

Adds a **liveness gate at the evaluation entry points** so a dead/expired job link can no longer trigger a full A–G evaluation, a written report, and a tailored PDF on phantom content.

- **`modes/auto-pipeline.md`** — new **Step 0.5 — Liveness gate** between Step 0 (Extract JD) and Step 1 (A–G eval). The Step 0 Playwright snapshot is already in hand, so the gate judges it inline; a closed/dead/redirected/404 page **stops before Step 1** and marks the `data/pipeline.md` entry dead.
- **`modes/oferta.md`** — new **Liveness gate (URL inputs)** before Block A (covers direct-URL entry, e.g. running `oferta` on a pending pipeline link). When `auto-pipeline` already cleared the link in its Step 0.5, oferta **reuses that snapshot** instead of re-navigating. JD-text input (no URL) skips the gate.
- **`test-all.mjs`** — +1 regression assertion that both eval modes carry the gate (mirrors the apply-mode gate test).

## Related issue

Fixes #835

## Notes / design choices

- **Mirrors the apply-mode preflight gate (#887)** rather than calling `check-liveness.mjs`. `auto-pipeline` Step 0 already captures a Playwright snapshot, so judging liveness inline avoids a second navigation and keeps the convention consistent with `modes/apply.md`. (Thanks @PaulaBarszcz for the forensic 17/25-dead-links writeup and for surfacing `check-liveness.mjs` — the gate uses the same active/closed signal classes.)
- **`pdf` mode is intentionally not gated.** A standalone `pdf` run renders an already-written report; the dead link must be caught upstream at the eval, which is exactly where these gates sit. Gating `pdf` would be the wrong layer.
- Per @santifer's note grouping this with #750 (apply-side, fixed in #887), this closes the **eval-side** half of the same class.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My PR is linked to a related issue (`Fixes #835`)
- [x] No personal data (real CV / email / phone / name) is included
- [x] I ran `node test-all.mjs` locally — **231 passed, 0 failed** (16 pre-existing warnings: cv-sync without user data + README translation false-positives, unrelated)
- [x] My changes respect the Data Contract (System Layer only: `modes/*.md`, `test-all.mjs`)
- [x] Changes align with the project roadmap / philosophy (simple, minimal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added liveness verification that checks if job postings are active before evaluation begins
  * Supports both direct URL inputs and pasted job descriptions
  * Automatically stops processing when a posting is detected as closed or inactive

* **Tests**
  * Added validation to ensure liveness detection functionality is properly implemented

<!-- end of auto-generated comment: release notes by coderabbit.ai -->