### PR TITLE
feat(doctor): warn when Playwright MCP tools are not configured

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -5,7 +5,7 @@
  * Checks all prerequisites and prints a pass/fail checklist.
  */
 
-import { existsSync, mkdirSync, readdirSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -20,6 +20,7 @@ const JSON_OUT = argv.includes('--json');
 const isTTY = process.stdout.isTTY;
 const green = (s) => isTTY ? `\x1b[32m${s}\x1b[0m` : s;
 const red = (s) => isTTY ? `\x1b[31m${s}\x1b[0m` : s;
+const yellow = (s) => isTTY ? `\x1b[33m${s}\x1b[0m` : s;
 const dim = (s) => isTTY ? `\x1b[2m${s}\x1b[0m` : s;
 
 function checkNodeVersion() {
@@ -64,6 +65,47 @@ async function checkPlaywright() {
       fix: 'Run: npx playwright install chromium',
     };
   }
+}
+
+// The browser tools (`browser_navigate` / `browser_snapshot`) that scan / pipeline /
+// apply rely on are provided by the Playwright MCP server, registered through a
+// project-level Claude Code config (`.mcp.json` or `.claude/settings.json`). When it
+// is absent, SPA job boards silently return empty or stale content (#522) — so doctor
+// surfaces it as a non-fatal warning rather than letting it fail invisibly.
+const PLAYWRIGHT_MCP_WARNING = 'Playwright MCP tools not detected';
+
+function playwrightMcpConfigured(root) {
+  const configFiles = ['.mcp.json', '.claude/settings.json', '.claude/settings.local.json'];
+  for (const rel of configFiles) {
+    const file = join(root, ...rel.split('/'));
+    if (!existsSync(file)) continue;
+    try {
+      const servers = JSON.parse(readFileSync(file, 'utf8'))?.mcpServers;
+      if (servers && typeof servers === 'object') {
+        for (const server of Object.values(servers)) {
+          if (JSON.stringify(server ?? '').toLowerCase().includes('playwright')) return true;
+        }
+      }
+    } catch {
+      // Malformed config — keep scanning the other locations; never crash doctor on it.
+    }
+  }
+  return false;
+}
+
+function checkPlaywrightMcp(root) {
+  if (playwrightMcpConfigured(root)) {
+    return { pass: true, label: 'Playwright MCP server configured' };
+  }
+  return {
+    warn: true,
+    label: PLAYWRIGHT_MCP_WARNING,
+    fix: [
+      'Browser-driven JD fetching and liveness checks (scan / pipeline / apply) need the',
+      'Playwright MCP server, which this project does not configure yet — SPA job boards',
+      'may return empty or stale content. Tracking: https://github.com/santifer/career-ops/issues/506',
+    ],
+  };
 }
 
 // Single source of truth for the four user-layer prerequisites (the list
@@ -165,6 +207,7 @@ async function main() {
     checkNodeVersion(),
     checkDependencies(),
     await checkPlaywright(),
+    checkPlaywrightMcp(projectRoot),
     ...USER_LAYER_PREREQS.map(checkPrereq),
     checkFonts(),
     checkAutoDir('data'),
@@ -173,14 +216,21 @@ async function main() {
   ];
 
   let failures = 0;
+  let warnings = 0;
 
   for (const result of checks) {
-    if (result.pass) {
+    const fixes = Array.isArray(result.fix) ? result.fix : result.fix ? [result.fix] : [];
+    if (result.warn) {
+      warnings++;
+      console.log(`${yellow('⚠')} ${result.label}`);
+      for (const hint of fixes) {
+        console.log(`  ${dim('→ ' + hint)}`);
+      }
+    } else if (result.pass) {
       console.log(`${green('✓')} ${result.label}`);
     } else {
       failures++;
       console.log(`${red('✗')} ${result.label}`);
-      const fixes = Array.isArray(result.fix) ? result.fix : [result.fix];
       for (const hint of fixes) {
         console.log(`  ${dim('→ ' + hint)}`);
       }
@@ -192,7 +242,8 @@ async function main() {
     console.log(`Result: ${failures} issue${failures === 1 ? '' : 's'} found. Fix them and run \`npm run doctor\` again.`);
     process.exit(1);
   } else {
-    console.log('Result: All checks passed. You\'re ready to go! Run `claude` to start.');
+    const warnNote = warnings > 0 ? ` (${warnings} warning${warnings === 1 ? '' : 's'} — see above)` : '';
+    console.log(`Result: All checks passed${warnNote}. You're ready to go! Run \`claude\` to start.`);
     console.log('');
     console.log('Join the community: https://discord.gg/8pRpHETxa4');
     process.exit(0);
@@ -207,7 +258,8 @@ function onboardingState(root) {
   const missing = USER_LAYER_PREREQS
     .filter(({ path }) => !prereqPresent(root, path))
     .map(({ path }) => path);
-  return { onboardingNeeded: missing.length > 0, missing, warnings: [] };
+  const warnings = playwrightMcpConfigured(root) ? [] : [PLAYWRIGHT_MCP_WARNING];
+  return { onboardingNeeded: missing.length > 0, missing, warnings };
 }
 
 if (JSON_OUT) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1573,6 +1573,41 @@ try {
 } catch (e) {
   fail(`Cold-start trigger test crashed: ${e.message}`);
 }
+
+// ── 12b. PLAYWRIGHT MCP DETECTION WARNING (#522) ────────────────
+
+console.log('\n12b. Playwright MCP detection warning');
+
+try {
+  // No project MCP config → doctor surfaces a (non-fatal) warning instead of
+  // letting SPA job boards fail silently.
+  const noMcp = mkdtempSync(join(tmpdir(), 'co-nomcp-'));
+  const a = JSON.parse(run(NODE, ['doctor.mjs', '--json', '--target', noMcp]) || '{}');
+  if (Array.isArray(a.warnings) && a.warnings.some((w) => /playwright mcp/i.test(w))) {
+    pass('No Playwright MCP config → warning surfaced');
+  } else {
+    fail(`Expected a Playwright MCP warning, got: ${JSON.stringify(a.warnings)}`);
+  }
+  rmSync(noMcp, { recursive: true, force: true });
+
+  // A project that registers a Playwright MCP server → no warning.
+  const withMcp = mkdtempSync(join(tmpdir(), 'co-mcp-'));
+  mkdirSync(join(withMcp, '.claude'), { recursive: true });
+  writeFileSync(
+    join(withMcp, '.claude', 'settings.json'),
+    JSON.stringify({ mcpServers: { playwright: { command: 'npx', args: ['@playwright/mcp', '--headless'] } } }),
+  );
+  const b = JSON.parse(run(NODE, ['doctor.mjs', '--json', '--target', withMcp]) || '{}');
+  if (Array.isArray(b.warnings) && !b.warnings.some((w) => /playwright mcp/i.test(w))) {
+    pass('Playwright MCP configured → no warning');
+  } else {
+    fail(`Did not expect a Playwright MCP warning, got: ${JSON.stringify(b.warnings)}`);
+  }
+  rmSync(withMcp, { recursive: true, force: true });
+} catch (e) {
+  fail(`Playwright MCP detection test crashed: ${e.message}`);
+}
+
 // ── 15. PROVIDERS — SolidJobs ─────────────────────────────────────
 
 console.log('\n15. Provider — solidjobs');


### PR DESCRIPTION
## What does this PR do?

Adds a `doctor` check that surfaces a **non-fatal warning** when the Playwright MCP server isn't configured for the project — turning a silent failure (SPA job boards returning empty/stale content the agent misreads as "position filled") into a visible one.

## Related issue

Part of #522 — the **doctor-check piece** you carved out as independently-landable ("Your doctor-check idea could land independently though — want to take that piece?").

This intentionally does **not** close #522: it surfaces the gap, it doesn't fix it. The actual MCP config (`.claude/settings.json` + `@playwright/mcp`) is coupled with the batch-hang in #506 and is left untouched here.

## Why

`scan` / `pipeline` / `auto-pipeline` / `apply` modes call `browser_navigate` / `browser_snapshot`, which come from the Playwright MCP server. The repo registers no MCP config, so those tools are silently unavailable — SPA portals (Workday, Ashby, …) return static fallback pages scored as empty/closed, with nothing surfaced to the user. `npm run doctor` currently reports "All checks passed" while the browser tools are missing.

## What users will see

- `npm run doctor` prints a non-fatal `⚠ Playwright MCP tools not detected` line (with a one-line impact note + the #506 tracking link) when no project-level Claude Code config (`.mcp.json` / `.claude/settings.json` / `.claude/settings.local.json`) registers a Playwright MCP server. Doctor still exits 0.
- `doctor --json` now reports the same signal in its existing `warnings[]` slot.
- Once the tracking config (#506) ships a Playwright MCP server, the check passes silently — no warning.

## Surface area

`doctor.mjs` + a regression test in `test-all.mjs`. System Layer only. **No** `package.json` dependency added, **no** `.claude/settings.json` created (that's the #506-coupled change). No user-layer files.

## Screenshots

N/A — CLI text output (shown above).

## Bug fix verification

`test-all.mjs` section **12b** added: a target dir with no MCP config → `doctor --json` `warnings[]` contains the Playwright-MCP warning; a target dir whose `.claude/settings.json` registers a `playwright` MCP server → no warning. Both go red without the `doctor.mjs` change and green with it.

## Validation

`node test-all.mjs --quick` → **231 passed, 0 failed** (16 warnings are pre-existing `santifer.io` personal-data false-positives in README.pl/ar/ua + the cv-sync no-user-data check — unrelated to this change). The existing cold-start section (12) still passes unchanged (it only asserts `Array.isArray(warnings)`, which still holds).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I linked a related issue above
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran the test suite (`node test-all.mjs --quick`) and all tests pass (0 failed)
- [x] My changes respect the Data Contract (no user-layer files)
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playwright MCP configuration detection now treats missing configuration as a non-fatal warning instead of a failure; warnings display in yellow and are separately reported in diagnostic output.

* **Tests**
  * Added test coverage for Playwright MCP detection across different project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->