### PR TITLE
feat(oferta,auto-pipeline): gate evaluation on a step-0 liveness check

### DIFF
--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -6,6 +6,8 @@ When the user pastes a JD (text or URL) without an explicit sub-command, execute
 
 If the input is a **URL** (not pasted JD text), follow this strategy to extract the content:
 
+**Liveness gate (first):** Confirm the URL is live before any evaluation (#835). While navigating to read the JD, check for dead-posting evidence — 404/410, "position closed / filled / no longer accepting applications", a hard redirect to a generic careers or search page, or a page with no JD. If the posting is dead, **stop here**: do not run Step 1 evaluation, write a report, or generate a PDF. Mark the entry in `data/pipeline.md` as `- [x] ~~Company | Role~~ — posting expired` and tell the user the link is dead. The headless `check-liveness.mjs <url>` script is the fallback when Playwright MCP is unavailable.
+
 **Priority order:**
 
 1. **Playwright (preferred):** Most job portals (Lever, Ashby, Greenhouse, Workday) are SPAs. Use `browser_navigate` + `browser_snapshot` to render and read the JD.

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -2,7 +2,21 @@
 
 When the candidate pastes a job (text or URL), ALWAYS deliver the 7 blocks (A-F evaluation + G legitimacy):
 
-## Step 0 — Archetype Detection
+## Step 0 — Liveness gate
+
+When the candidate provides a **URL** (not pasted JD text), confirm the posting is still live before spending any evaluation tokens. Dead links must be caught here — not after a full A-G report and a tailored CV have already been generated for a 404 (#835).
+
+1. `browser_navigate` to the URL and take a `browser_snapshot` (this snapshot is reused by Block G — Posting Freshness).
+2. Read the URL, page title, JD body, and any closed/expired signals:
+   - **active evidence:** role title + a real job description + an apply/submit path
+   - **dead evidence:** 404/410, "position closed / filled / no longer accepting applications", a hard redirect to a generic careers or search page, or a page with only nav/footer and no JD
+3. If the posting is dead, **stop before Block A** — do not evaluate, write a report, or generate a CV. Mark the entry in `data/pipeline.md` as `- [x] ~~Company | Role~~ — posting expired` and tell the candidate the link is dead.
+4. If liveness cannot be verified (no Playwright, or navigation blocked by a challenge/403), say so and ask the candidate to confirm the posting is active before continuing. The headless `check-liveness.mjs <url>` script is the fallback when Playwright MCP is unavailable.
+5. If the input is pasted JD text (no URL), skip this gate.
+
+Do not continue to Step 1 until liveness is resolved.
+
+## Step 1 — Archetype Detection
 
 Classify the job into one of the 6 archetypes (see `_shared.md`). If it is a hybrid, indicate the 2 closest ones. This determines:
 - Which proof points to prioritize in block B

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -512,6 +512,29 @@ if (
   fail('apply mode missing liveness/role-match preflight gate');
 }
 
+// #835 — the eval side (oferta / auto-pipeline) must gate on URL liveness as
+// step 0, so a dead link is caught before a full A-G report + tailored CV.
+const ofertaMode = readFile('modes/oferta.md');
+if (
+  ofertaMode.includes('## Step 0 — Liveness gate') &&
+  ofertaMode.includes('stop before Block A') &&
+  ofertaMode.includes('Do not continue to Step 1 until liveness is resolved')
+) {
+  pass('oferta mode gates evaluation on a step-0 liveness check');
+} else {
+  fail('oferta mode missing the step-0 liveness gate');
+}
+
+const autoPipelineMode = readFile('modes/auto-pipeline.md');
+if (
+  autoPipelineMode.includes('Liveness gate (first)') &&
+  autoPipelineMode.includes('do not run Step 1 evaluation')
+) {
+  pass('auto-pipeline mode gates evaluation on URL liveness');
+} else {
+  fail('auto-pipeline mode missing the liveness gate before evaluation');
+}
+
 // ── 9. LOCAL PARSER CONTRACT ────────────────────────────────────
 
 console.log('\n9. Local parser contract');


### PR DESCRIPTION
## What does this PR do?

Adds a **step-0 URL liveness gate** to `oferta` and `auto-pipeline`, so a dead posting is caught before the full A-G evaluation, the report, and the tailored CV are generated — closing the eval-side half of the liveness-gate class.

## Related issue

Closes #835

## Why

The Level 3 (WebSearch) scan appends hits to `pipeline.md` as pending entries, and the eval side never re-verifies. `oferta` / `auto-pipeline` run all of blocks A-G, write a report, and generate a tailored PDF CV before anyone discovers the URL 404s. The reporter burned a session on **17/25 dead links**, including the session's top-scored offer (4.3/5) whose company had rebranded months earlier — full evaluation + PDF generated on phantom data.

`scan` already gates Level 3 results (step 7.5, `scan --verify`) and `apply` gates at its preflight (#887). This was the remaining gap: the eval side had no step-0 check, exactly as the maintainer noted in the issue thread.

## What users will see

- Pasting a **URL** into `oferta` or triggering `auto-pipeline` now verifies the posting is live first. On dead-posting evidence (404/410, "position closed / filled / no longer accepting applications", a hard redirect to a generic careers page, or a page with no JD), it **stops before any A-G work** — no report, no CV — marks the entry `- [x] ~~Company | Role~~ — posting expired` in `pipeline.md`, and tells the user the link is dead.
- Pasted JD text (no URL) is unaffected.
- `check-liveness.mjs <url>` is the documented headless fallback when Playwright MCP isn't available.

## Surface area

Two mode files (`modes/oferta.md`, `modes/auto-pipeline.md`) + integrity tests in `test-all.mjs`. System Layer only; no user-layer files. In `oferta.md`, the new gate takes Step 0 and `Archetype Detection` moves to Step 1 — Block G's "snapshot already captured in Step 0" now correctly points at the gate (which is where the `browser_snapshot` is taken).

## Screenshots

N/A — mode-instruction (prompt) change.

## Bug fix verification

`test-all.mjs` gains two integrity assertions (mirroring the existing apply-preflight check) so the gate can't silently disappear: `oferta` must carry `## Step 0 — Liveness gate` + `stop before Block A` + `Do not continue to Step 1 until liveness is resolved`; `auto-pipeline` must carry `Liveness gate (first)` + `do not run Step 1 evaluation`. Both go red without the mode-file changes and green with them.

## Validation

`node test-all.mjs --quick` → **231 passed, 0 failed** (the 16 warnings are pre-existing `santifer.io` personal-data false-positives in README.pl/ar/ua + the cv-sync no-user-data check — unrelated).

## Note on scope (translations)

Scoped to the two English modes named in the issue. The Arabic `modes/ar/fursah.md` has the same `Step 0` and would benefit from the same gate — happy to extend it here or leave it for a follow-up i18n PR, your call.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I linked a related issue above
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran the test suite (`node test-all.mjs --quick`) and all tests pass (0 failed)
- [x] My changes respect the Data Contract (no user-layer files)
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a liveness verification check that validates job postings are active before processing. If a posting is expired or dead, the pipeline stops immediately and informs the user.

* **Tests**
  * Added test coverage to verify liveness gate functionality is properly implemented and prevents workflow execution for inactive postings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->