### PR TITLE
Fix concurrent tracker merge overwrites

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -14,10 +14,12 @@
  * Run: node career-ops/merge-tracker.mjs [--dry-run] [--verify]
  */
 
-import { readFileSync, writeFileSync, readdirSync, mkdirSync, renameSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, readdirSync, mkdirSync, renameSync, existsSync, rmSync, statSync } from 'fs';
 import { join, basename, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
+import { createHash, randomUUID } from 'crypto';
+import { tmpdir } from 'os';
 import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
@@ -37,6 +39,11 @@ const MERGED_DIR = join(ADDITIONS_DIR, 'merged');
 const DRY_RUN = process.argv.includes('--dry-run');
 const VERIFY = process.argv.includes('--verify');
 const MIGRATE = process.argv.includes('--migrate');
+const MERGE_HOLD_MS = Number(process.env.CAREER_OPS_MERGE_HOLD_MS) || 0;
+
+const trackerLockKey = createHash('sha256').update(APPS_FILE).digest('hex').slice(0, 16);
+const TRACKER_LOCK_DIR = process.env.CAREER_OPS_TRACKER_LOCK
+  || join(tmpdir(), `career-ops-merge-tracker-${trackerLockKey}.lock`);
 
 // The reports/ dir sits at the repo root, which is the tracker's parent in the
 // data/ layout (data/applications.md) and the tracker's own dir at root layout.
@@ -48,6 +55,114 @@ const normalizeReportLink = (reportField) => normalizeLink(reportField, TRACKER_
 // Ensure required directories exist (fresh setup)
 mkdirSync(join(CAREER_OPS, 'data'), { recursive: true });
 mkdirSync(ADDITIONS_DIR, { recursive: true });
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === 'EPERM';
+  }
+}
+
+function readLockOwner(lockDir) {
+  try {
+    return JSON.parse(readFileSync(join(lockDir, 'owner.json'), 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function lockCanRecover(lockDir, staleMs) {
+  const owner = readLockOwner(lockDir);
+  if (owner?.pid) return !processIsAlive(owner.pid);
+
+  try {
+    return Date.now() - statSync(lockDir).mtimeMs > staleMs;
+  } catch {
+    return true;
+  }
+}
+
+async function acquireTrackerLock(lockDir, options = {}) {
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const retryMs = options.retryMs ?? 75;
+  const staleMs = options.staleMs ?? 10 * 60_000;
+  const token = randomUUID();
+  const startedAt = Date.now();
+  let attempts = 0;
+  let staleRecovered = false;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    attempts++;
+    try {
+      mkdirSync(lockDir);
+      writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
+        pid: process.pid,
+        token,
+        started_at: new Date().toISOString(),
+        tracker: APPS_FILE,
+      }, null, 2));
+
+      let released = false;
+      return {
+        attempts,
+        waitMs: Date.now() - startedAt,
+        staleRecovered,
+        release() {
+          if (released) return;
+          released = true;
+          const owner = readLockOwner(lockDir);
+          if (owner?.token === token) {
+            rmSync(lockDir, { recursive: true, force: true });
+          }
+        },
+      };
+    } catch (err) {
+      if (err?.code !== 'EEXIST') throw err;
+      if (lockCanRecover(lockDir, staleMs)) {
+        rmSync(lockDir, { recursive: true, force: true });
+        staleRecovered = true;
+        continue;
+      }
+      await sleep(retryMs);
+    }
+  }
+
+  throw new Error(`Timed out waiting for tracker merge lock at ${lockDir}`);
+}
+
+function writeFileAtomic(path, content) {
+  const tmpPath = join(dirname(path), `.${basename(path)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`);
+  try {
+    writeFileSync(tmpPath, content);
+    renameSync(tmpPath, path);
+  } catch (err) {
+    rmSync(tmpPath, { force: true });
+    throw err;
+  }
+}
+
+let trackerLock;
+try {
+  trackerLock = await acquireTrackerLock(TRACKER_LOCK_DIR, {
+    timeoutMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_TIMEOUT_MS) || 60_000,
+    retryMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_RETRY_MS) || 75,
+    staleMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_STALE_MS) || 10 * 60_000,
+  });
+  process.once('exit', () => trackerLock?.release());
+  if (trackerLock.waitMs > 0 || trackerLock.staleRecovered) {
+    console.log(`🔒 Tracker merge lock acquired (wait_ms=${trackerLock.waitMs} | attempts=${trackerLock.attempts} | stale_recovered=${trackerLock.staleRecovered})`);
+  }
+} catch (err) {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+}
 
 // Canonical states and aliases
 const CANONICAL_STATES = ['Evaluated', 'Applied', 'Responded', 'Interview', 'Offer', 'Rejected', 'Discarded', 'SKIP'];
@@ -282,6 +397,9 @@ if (!existsSync(APPS_FILE)) {
   process.exit(0);
 }
 const appContent = readFileSync(APPS_FILE, 'utf-8');
+if (MERGE_HOLD_MS > 0) {
+  await sleep(MERGE_HOLD_MS);
+}
 
 // One-time migration: rewrite existing report links so they resolve relative
 // to the tracker file's directory (see #760). Run with: node merge-tracker.mjs --migrate
@@ -295,7 +413,7 @@ if (MIGRATE) {
   if (DRY_RUN) {
     console.log(`🔎 Migration (dry-run): ${changed} row(s) would be rewritten in ${basename(APPS_FILE)}`);
   } else {
-    writeFileSync(APPS_FILE, migrated.join('\n'));
+    writeFileAtomic(APPS_FILE, migrated.join('\n'));
     console.log(`✅ Migration: rewrote ${changed} report link(s) in ${basename(APPS_FILE)} relative to ${TRACKER_DIR === CAREER_OPS ? 'repo root' : 'data/'}`);
   }
   process.exit(0);
@@ -434,7 +552,7 @@ if (newLines.length > 0) {
 
 // Write back
 if (!DRY_RUN) {
-  writeFileSync(APPS_FILE, appLines.join('\n'));
+  writeFileAtomic(APPS_FILE, appLines.join('\n'));
 
   // Move processed files to merged/
   if (!existsSync(MERGED_DIR)) mkdirSync(MERGED_DIR, { recursive: true });
@@ -446,6 +564,7 @@ if (!DRY_RUN) {
 
 console.log(`\n📊 Summary: +${added} added, 🔄${updated} updated, ⏭️${skipped} skipped`);
 if (DRY_RUN) console.log('(dry-run — no changes written)');
+trackerLock.release();
 
 // Optional verify
 if (VERIFY && !DRY_RUN) {

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -41,6 +41,7 @@ const DRY_RUN = process.argv.includes('--dry-run');
 const VERIFY = process.argv.includes('--verify');
 const MIGRATE = process.argv.includes('--migrate');
 const MERGE_HOLD_MS = Number(process.env.CAREER_OPS_MERGE_HOLD_MS) || 0;
+const MERGE_READY_IPC = process.env.CAREER_OPS_MERGE_READY_IPC === '1';
 
 const trackerLockKey = createHash('sha256').update(APPS_FILE).digest('hex').slice(0, 16);
 const TRACKER_LOCK_DIR = resolveTrackerLockDir(process.env.CAREER_OPS_TRACKER_LOCK, trackerLockKey);
@@ -552,6 +553,12 @@ if (!existsSync(APPS_FILE)) {
   process.exit(0);
 }
 const appContent = readFileSync(APPS_FILE, 'utf-8');
+// Test-only synchronization hook: the concurrent merge test waits for the
+// first worker to read the tracker while still holding the lock, then starts a
+// second worker to prove the lock prevents the old lost-update race.
+if (MERGE_READY_IPC && typeof process.send === 'function') {
+  process.send({ type: 'merge-tracker-ready' });
+}
 if (MERGE_HOLD_MS > 0) {
   await sleep(MERGE_HOLD_MS);
 }

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -14,8 +14,8 @@
  * Run: node career-ops/merge-tracker.mjs [--dry-run] [--verify]
  */
 
-import { readFileSync, writeFileSync, readdirSync, mkdirSync, renameSync, existsSync, rmSync, statSync } from 'fs';
-import { join, basename, dirname } from 'path';
+import { readFileSync, writeFileSync, readdirSync, mkdirSync, renameSync, existsSync, rmSync, statSync, realpathSync } from 'fs';
+import { join, basename, dirname, resolve, relative, isAbsolute, sep } from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
 import { createHash, randomUUID } from 'crypto';
@@ -25,11 +25,12 @@ import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original).
 // CAREER_OPS_TRACKER overrides the path (used by tests and non-standard layouts).
-const APPS_FILE = process.env.CAREER_OPS_TRACKER
+const APPS_FILE_RAW = process.env.CAREER_OPS_TRACKER
   ? process.env.CAREER_OPS_TRACKER
   : existsSync(join(CAREER_OPS, 'data/applications.md'))
     ? join(CAREER_OPS, 'data/applications.md')
     : join(CAREER_OPS, 'applications.md');
+const APPS_FILE = canonicalizeTrackerPath(APPS_FILE_RAW);
 const TRACKER_DIR = dirname(APPS_FILE);
 // CAREER_OPS_ADDITIONS overrides the additions dir (used by tests, mirrors CAREER_OPS_TRACKER).
 const ADDITIONS_DIR = process.env.CAREER_OPS_ADDITIONS
@@ -42,8 +43,7 @@ const MIGRATE = process.argv.includes('--migrate');
 const MERGE_HOLD_MS = Number(process.env.CAREER_OPS_MERGE_HOLD_MS) || 0;
 
 const trackerLockKey = createHash('sha256').update(APPS_FILE).digest('hex').slice(0, 16);
-const TRACKER_LOCK_DIR = process.env.CAREER_OPS_TRACKER_LOCK
-  || join(tmpdir(), `career-ops-merge-tracker-${trackerLockKey}.lock`);
+const TRACKER_LOCK_DIR = resolveTrackerLockDir(process.env.CAREER_OPS_TRACKER_LOCK, trackerLockKey);
 
 // The reports/ dir sits at the repo root, which is the tracker's parent in the
 // data/ layout (data/applications.md) and the tracker's own dir at root layout.
@@ -55,6 +55,67 @@ const normalizeReportLink = (reportField) => normalizeLink(reportField, TRACKER_
 // Ensure required directories exist (fresh setup)
 mkdirSync(join(CAREER_OPS, 'data'), { recursive: true });
 mkdirSync(ADDITIONS_DIR, { recursive: true });
+
+/**
+ * Convert the tracker path into one stable absolute spelling before hashing it.
+ *
+ * Equivalent tracker paths can be written in multiple ways, such as a relative
+ * path from the current shell, an absolute path, or a path that travels through
+ * a symlink. The lock key must be based on one canonical spelling so all merge
+ * processes that target the same tracker also target the same lock directory.
+ *
+ * @param {string} path - Raw tracker path from config, env, or the default.
+ * @returns {string} Absolute canonical path when the file exists, else resolved path.
+ */
+function canonicalizeTrackerPath(path) {
+  const absolutePath = resolve(path);
+  try {
+    return realpathSync(absolutePath);
+  } catch {
+    return absolutePath;
+  }
+}
+
+/**
+ * Check whether one absolute path stays inside another directory.
+ *
+ * This protects recursive lock cleanup from accepting paths that escape the
+ * system temp directory through `..` segments or unrelated absolute roots.
+ *
+ * @param {string} childPath - Candidate path to validate.
+ * @param {string} parentDir - Required parent directory boundary.
+ * @returns {boolean} True when childPath is inside parentDir or equal to it.
+ */
+function pathIsInside(childPath, parentDir) {
+  const relativePath = relative(parentDir, childPath);
+  return relativePath === '' || (relativePath !== '..' && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath));
+}
+
+/**
+ * Validate and resolve the tracker lock directory.
+ *
+ * `CAREER_OPS_TRACKER_LOCK` exists for tests and unusual local layouts, but the
+ * merge script later removes the lock directory recursively. To keep that safe,
+ * env-provided lock paths must be absolute, live under the OS temp directory,
+ * and use the career-ops lock-name prefix. Invalid values are ignored and the
+ * deterministic temp-dir default is used instead.
+ *
+ * @param {string|undefined} envValue - Optional lock path override.
+ * @param {string} lockKey - Stable tracker hash suffix.
+ * @returns {string} Safe lock directory path.
+ */
+function resolveTrackerLockDir(envValue, lockKey) {
+  const tmpRoot = realpathSync(tmpdir());
+  const fallback = join(tmpRoot, `career-ops-merge-tracker-${lockKey}.lock`);
+  if (!envValue || !isAbsolute(envValue)) return fallback;
+
+  const candidate = resolve(envValue);
+  const parentDir = dirname(candidate);
+  const canonicalParent = existsSync(parentDir) ? realpathSync(parentDir) : resolve(parentDir);
+  if (!pathIsInside(canonicalParent, tmpRoot)) return fallback;
+  if (!basename(candidate).startsWith('career-ops-merge-tracker-')) return fallback;
+  return candidate;
+}
 
 /**
  * Pause the async merge flow for a fixed number of milliseconds.
@@ -158,6 +219,7 @@ async function acquireTrackerLock(lockDir, options = {}) {
   const timeoutMs = options.timeoutMs ?? 60_000;
   const retryMs = options.retryMs ?? 75;
   const staleMs = options.staleMs ?? 10 * 60_000;
+  const recoverGuardDir = `${lockDir}.recover`;
   const token = randomUUID();
   const startedAt = Date.now();
   let attempts = 0;
@@ -190,11 +252,27 @@ async function acquireTrackerLock(lockDir, options = {}) {
       };
     } catch (err) {
       if (err?.code !== 'EEXIST') throw err;
-      if (lockCanRecover(lockDir, staleMs)) {
-        rmSync(lockDir, { recursive: true, force: true });
-        staleRecovered = true;
-        continue;
+
+      let hasRecoverGuard = false;
+      try {
+        mkdirSync(recoverGuardDir);
+        hasRecoverGuard = true;
+      } catch (guardErr) {
+        if (guardErr?.code !== 'EEXIST') throw guardErr;
       }
+
+      if (hasRecoverGuard) {
+        try {
+          if (lockCanRecover(lockDir, staleMs)) {
+            rmSync(lockDir, { recursive: true, force: true });
+            staleRecovered = true;
+            continue;
+          }
+        } finally {
+          rmSync(recoverGuardDir, { recursive: true, force: true });
+        }
+      }
+
       await sleep(retryMs);
     }
   }

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -56,10 +56,34 @@ const normalizeReportLink = (reportField) => normalizeLink(reportField, TRACKER_
 mkdirSync(join(CAREER_OPS, 'data'), { recursive: true });
 mkdirSync(ADDITIONS_DIR, { recursive: true });
 
+/**
+ * Pause the async merge flow for a fixed number of milliseconds.
+ *
+ * This is used in two places:
+ * - the lock retry loop, where waiting briefly avoids a tight CPU spin while
+ *   another `merge-tracker.mjs` process owns the tracker lock;
+ * - the regression test hook (`CAREER_OPS_MERGE_HOLD_MS`), which deliberately
+ *   holds the first merge after it reads `applications.md` so a second merge can
+ *   try to enter the same critical section.
+ *
+ * @param {number} ms - Milliseconds to wait before resolving.
+ * @returns {Promise<void>} Resolves after the requested delay.
+ */
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * Determine whether a process id still belongs to a live process.
+ *
+ * The tracker lock stores the owner PID in `owner.json`. When another process
+ * finds an existing lock, this check lets it distinguish a valid live owner from
+ * a crashed process that left a stale lock directory behind. `EPERM` counts as
+ * alive because the process exists even if the current user cannot signal it.
+ *
+ * @param {number} pid - Process id recorded by the lock owner.
+ * @returns {boolean} True when the process appears to still exist.
+ */
 function processIsAlive(pid) {
   if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
@@ -70,6 +94,16 @@ function processIsAlive(pid) {
   }
 }
 
+/**
+ * Read lock ownership metadata from a tracker lock directory.
+ *
+ * The metadata contains the owner PID, a unique release token, the acquisition
+ * timestamp, and the tracker path. Invalid or missing metadata is treated as
+ * unreadable so the stale-lock recovery path can fall back to directory age.
+ *
+ * @param {string} lockDir - Directory that represents the active lock.
+ * @returns {object|null} Parsed owner metadata, or null when unavailable.
+ */
 function readLockOwner(lockDir) {
   try {
     return JSON.parse(readFileSync(join(lockDir, 'owner.json'), 'utf-8'));
@@ -78,6 +112,19 @@ function readLockOwner(lockDir) {
   }
 }
 
+/**
+ * Decide whether an existing lock can be safely recovered.
+ *
+ * Recovery is conservative: if the lock has an owner PID and that process is
+ * still alive, the lock is never considered stale merely because it is old. If
+ * the owner process is gone, or if the metadata cannot be read and the lock
+ * directory itself is older than the stale threshold, the waiting process may
+ * remove the lock and retry acquisition.
+ *
+ * @param {string} lockDir - Directory that represents the active lock.
+ * @param {number} staleMs - Age threshold for metadata-free lock recovery.
+ * @returns {boolean} True when the caller may remove and recreate the lock.
+ */
 function lockCanRecover(lockDir, staleMs) {
   const owner = readLockOwner(lockDir);
   if (owner?.pid) return !processIsAlive(owner.pid);
@@ -89,6 +136,24 @@ function lockCanRecover(lockDir, staleMs) {
   }
 }
 
+/**
+ * Acquire an exclusive filesystem lock for one tracker merge.
+ *
+ * The critical section must cover the full read/modify/write/move sequence, not
+ * just the final write. Otherwise two processes can read the same old tracker
+ * snapshot, compute independent updates, and let the later writer erase rows
+ * written by the earlier one. The lock is implemented with atomic directory
+ * creation, owner metadata, retry/backoff, stale-owner recovery, and a release
+ * token so one process cannot delete another process's newer lock.
+ *
+ * @param {string} lockDir - Directory path used as the lock sentinel.
+ * @param {object} [options] - Lock timing options.
+ * @param {number} [options.timeoutMs=60000] - Maximum time to wait for the lock.
+ * @param {number} [options.retryMs=75] - Delay between acquisition attempts.
+ * @param {number} [options.staleMs=600000] - Metadata-free stale-lock threshold.
+ * @returns {Promise<{attempts:number,waitMs:number,staleRecovered:boolean,release:Function}>}
+ * Lock handle with metadata and an idempotent release method.
+ */
 async function acquireTrackerLock(lockDir, options = {}) {
   const timeoutMs = options.timeoutMs ?? 60_000;
   const retryMs = options.retryMs ?? 75;
@@ -137,6 +202,18 @@ async function acquireTrackerLock(lockDir, options = {}) {
   throw new Error(`Timed out waiting for tracker merge lock at ${lockDir}`);
 }
 
+/**
+ * Replace a tracker file atomically using a same-directory temporary file.
+ *
+ * Writing into the same directory keeps the final `renameSync` atomic on normal
+ * filesystems and avoids exposing a partially written `applications.md` to other
+ * readers. If the write or rename fails, the temporary file is cleaned up before
+ * the original error is rethrown.
+ *
+ * @param {string} path - Final file path to replace.
+ * @param {string} content - Complete file content to write.
+ * @returns {void}
+ */
 function writeFileAtomic(path, content) {
   const tmpPath = join(dirname(path), `.${basename(path)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`);
   try {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1546,7 +1546,9 @@ try {
    * @param {number} ms - Milliseconds to wait.
    * @returns {Promise<void>} Resolves after the delay.
    */
-  const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+  function wait(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
   /**
    * Spawn one isolated `merge-tracker.mjs` process against the temporary fixture.
    *
@@ -1561,25 +1563,27 @@ try {
    * @returns {Promise<{code:number|null,stdout:string,stderr:string}>}
    * Process result after `merge-tracker.mjs` exits.
    */
-  const runMergeAsync = (additionsDir, holdMs = 0) => new Promise(resolve => {
-    const child = spawn(NODE, ['merge-tracker.mjs'], {
-      cwd: ROOT,
-      env: {
-        ...process.env,
-        CAREER_OPS_TRACKER: join(mergeTmp, 'data', 'applications.md'),
-        CAREER_OPS_ADDITIONS: additionsDir,
-        CAREER_OPS_TRACKER_LOCK: join(mergeTmp, 'tracker-merge.lock'),
-        CAREER_OPS_MERGE_HOLD_MS: String(holdMs),
-      },
-      stdio: ['ignore', 'pipe', 'pipe'],
+  function runMergeAsync(additionsDir, holdMs = 0) {
+    return new Promise(resolve => {
+      const child = spawn(NODE, ['merge-tracker.mjs'], {
+        cwd: ROOT,
+        env: {
+          ...process.env,
+          CAREER_OPS_TRACKER: join(mergeTmp, 'data', 'applications.md'),
+          CAREER_OPS_ADDITIONS: additionsDir,
+          CAREER_OPS_TRACKER_LOCK: join(mergeTmp, 'tracker-merge.lock'),
+          CAREER_OPS_MERGE_HOLD_MS: String(holdMs),
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', chunk => { stdout += chunk; });
+      child.stderr.on('data', chunk => { stderr += chunk; });
+      child.on('error', err => resolve({ code: -1, stdout, stderr: String(err) }));
+      child.on('close', code => resolve({ code, stdout, stderr }));
     });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', chunk => { stdout += chunk; });
-    child.stderr.on('data', chunk => { stderr += chunk; });
-    child.on('error', err => resolve({ code: -1, stdout, stderr: String(err) }));
-    child.on('close', code => resolve({ code, stdout, stderr }));
-  });
+  }
 
   try {
     mkdirSync(join(mergeTmp, 'data'));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1571,7 +1571,7 @@ try {
           ...process.env,
           CAREER_OPS_TRACKER: join(mergeTmp, 'data', 'applications.md'),
           CAREER_OPS_ADDITIONS: additionsDir,
-          CAREER_OPS_TRACKER_LOCK: join(mergeTmp, 'tracker-merge.lock'),
+          CAREER_OPS_TRACKER_LOCK: join(mergeTmp, 'career-ops-merge-tracker-fixture.lock'),
           CAREER_OPS_MERGE_HOLD_MS: String(holdMs),
         },
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -516,6 +516,10 @@ if (shared.includes('_profile.md')) {
 }
 
 for (const skillPath of ['.claude/skills/career-ops/SKILL.md', '.agents/skills/career-ops/SKILL.md']) {
+  if (!fileExists(skillPath)) {
+    fail(`${skillPath} is missing`);
+    continue;
+  }
   const skill = readFile(skillPath);
   if (skill.includes('/career-ops latex')) {
     pass(`${skillPath} exposes /career-ops latex in discovery menu`);
@@ -1561,35 +1565,25 @@ console.log('\n🧪 Testing merge-tracker concurrent writes...');
 try {
   const mergeTmp = mkdtempSync(join(tmpdir(), 'career-ops-merge-lock-'));
   /**
-   * Wait briefly between starting concurrent merge processes.
-   *
-   * The first process is started with `CAREER_OPS_MERGE_HOLD_MS`, then this
-   * helper gives it time to acquire the tracker lock before the second process
-   * starts. That makes the test exercise lock waiting instead of relying on
-   * scheduler luck.
-   *
-   * @param {number} ms - Milliseconds to wait.
-   * @returns {Promise<void>} Resolves after the delay.
-   */
-  function wait(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
-  /**
    * Spawn one isolated `merge-tracker.mjs` process against the temporary fixture.
    *
    * Each spawned process receives the same tracker path and lock path but a
    * different additions directory. Without serialization, both processes can
    * read the same old tracker and the later write can lose the other row. The
-   * returned result captures stdout/stderr so failures explain which worker
-   * failed and why.
+   * first worker also sends an IPC readiness message after reading the tracker
+   * and before its test hold, which lets the test launch the second worker at
+   * the exact old race point instead of relying on scheduler timing.
    *
    * @param {string} additionsDir - Directory containing this process's TSV row.
    * @param {number} [holdMs=0] - Optional post-read delay injected into the merge.
-   * @returns {Promise<{code:number|null,stdout:string,stderr:string}>}
-   * Process result after `merge-tracker.mjs` exits.
+   * @returns {{ready: Promise<void>, result: Promise<{code:number|null,stdout:string,stderr:string}>}}
+   * Worker readiness and final process result promises.
    */
-  function runMergeAsync(additionsDir, holdMs = 0) {
-    return new Promise(resolve => {
+  function spawnMerge(additionsDir, holdMs = 0) {
+    let markReady;
+    let readyMarked = false;
+    const ready = new Promise(resolve => { markReady = resolve; });
+    const result = new Promise(resolve => {
       const child = spawn(NODE, ['merge-tracker.mjs'], {
         cwd: ROOT,
         env: {
@@ -1598,16 +1592,50 @@ try {
           CAREER_OPS_ADDITIONS: additionsDir,
           CAREER_OPS_TRACKER_LOCK: join(mergeTmp, 'career-ops-merge-tracker-fixture.lock'),
           CAREER_OPS_MERGE_HOLD_MS: String(holdMs),
+          CAREER_OPS_MERGE_READY_IPC: '1',
         },
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
       });
       let stdout = '';
       let stderr = '';
+      const resolveReady = () => {
+        if (readyMarked) return;
+        readyMarked = true;
+        markReady();
+      };
       child.stdout.on('data', chunk => { stdout += chunk; });
       child.stderr.on('data', chunk => { stderr += chunk; });
-      child.on('error', err => resolve({ code: -1, stdout, stderr: String(err) }));
-      child.on('close', code => resolve({ code, stdout, stderr }));
+      child.on('message', msg => {
+        if (msg?.type === 'merge-tracker-ready') resolveReady();
+      });
+      child.on('error', err => {
+        resolveReady();
+        resolve({ code: -1, stdout, stderr: String(err) });
+      });
+      child.on('close', code => {
+        resolveReady();
+        resolve({ code, stdout, stderr });
+      });
     });
+    return { ready, result };
+  }
+
+  /**
+   * Fail fast when a worker never reaches the deterministic race checkpoint.
+   *
+   * A missing readiness signal would otherwise hang the test suite. Timing out
+   * turns that broken test contract into a normal assertion failure with a clear
+   * message.
+   *
+   * @param {Promise<void>} ready - Worker readiness promise.
+   * @param {number} timeoutMs - Maximum milliseconds to wait.
+   * @returns {Promise<void>} Resolves when ready arrives before the timeout.
+   */
+  function waitForReady(ready, timeoutMs) {
+    return Promise.race([
+      ready,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('merge worker did not signal readiness')), timeoutMs)),
+    ]);
   }
 
   try {
@@ -1629,10 +1657,10 @@ try {
     writeFileSync(join(additionsB, '011-beta.tsv'),
       '11\t2026-01-07\tBeta\tData Engineer\tEvaluated\t4.2/5\t❌\t[11](reports/011-beta-2026-01-07.md)\tsecond concurrent merge\n');
 
-    const first = runMergeAsync(additionsA, 350);
-    await wait(75);
-    const second = runMergeAsync(additionsB, 0);
-    const [firstResult, secondResult] = await Promise.all([first, second]);
+    const first = spawnMerge(additionsA, 350);
+    await waitForReady(first.ready, 2_000);
+    const second = spawnMerge(additionsB, 0);
+    const [firstResult, secondResult] = await Promise.all([first.result, second.result]);
 
     if (firstResult.code === 0 && secondResult.code === 0) {
       pass('concurrent merge processes both exited successfully');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -11,7 +11,7 @@
  *   node test-all.mjs --quick   # Skip dashboard build (faster)
  */
 
-import { execSync, execFileSync } from 'child_process';
+import { execSync, execFileSync, spawn } from 'child_process';
 import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
@@ -1523,6 +1523,80 @@ try {
   }
 } catch (e) {
   fail(`merge-tracker fuzzy dedup tests crashed: ${e.message}`);
+}
+
+// ── MERGE-TRACKER CONCURRENT WRITES (#781 follow-up) ─────────────────────
+// Report-number reservation is atomic now (#803), but tracker merges are a
+// separate read/modify/write step. If two merge-tracker processes read the same
+// old applications.md snapshot and then write back independently, one process
+// can erase the row added by the other. This fixture gives each process a
+// different additions dir and pauses the first process after it has read the
+// tracker, making the old race deterministic.
+console.log('\n🧪 Testing merge-tracker concurrent writes...');
+try {
+  const mergeTmp = mkdtempSync(join(tmpdir(), 'career-ops-merge-lock-'));
+  const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+  const runMergeAsync = (additionsDir, holdMs = 0) => new Promise(resolve => {
+    const child = spawn(NODE, ['merge-tracker.mjs'], {
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        CAREER_OPS_TRACKER: join(mergeTmp, 'data', 'applications.md'),
+        CAREER_OPS_ADDITIONS: additionsDir,
+        CAREER_OPS_TRACKER_LOCK: join(mergeTmp, 'tracker-merge.lock'),
+        CAREER_OPS_MERGE_HOLD_MS: String(holdMs),
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', chunk => { stdout += chunk; });
+    child.stderr.on('data', chunk => { stderr += chunk; });
+    child.on('error', err => resolve({ code: -1, stdout, stderr: String(err) }));
+    child.on('close', code => resolve({ code, stdout, stderr }));
+  });
+
+  try {
+    mkdirSync(join(mergeTmp, 'data'));
+    mkdirSync(join(mergeTmp, 'reports'));
+    const additionsA = join(mergeTmp, 'additions-a');
+    const additionsB = join(mergeTmp, 'additions-b');
+    mkdirSync(additionsA);
+    mkdirSync(additionsB);
+
+    writeFileSync(join(mergeTmp, 'data', 'applications.md'),
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n');
+    writeFileSync(join(mergeTmp, 'reports', '010-alpha-2026-01-07.md'), '# fixture\n');
+    writeFileSync(join(mergeTmp, 'reports', '011-beta-2026-01-07.md'), '# fixture\n');
+    writeFileSync(join(additionsA, '010-alpha.tsv'),
+      '10\t2026-01-07\tAlpha\tPlatform Engineer\tEvaluated\t4.1/5\t❌\t[10](reports/010-alpha-2026-01-07.md)\tfirst concurrent merge\n');
+    writeFileSync(join(additionsB, '011-beta.tsv'),
+      '11\t2026-01-07\tBeta\tData Engineer\tEvaluated\t4.2/5\t❌\t[11](reports/011-beta-2026-01-07.md)\tsecond concurrent merge\n');
+
+    const first = runMergeAsync(additionsA, 350);
+    await wait(75);
+    const second = runMergeAsync(additionsB, 0);
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    if (firstResult.code === 0 && secondResult.code === 0) {
+      pass('concurrent merge processes both exited successfully');
+    } else {
+      fail(`concurrent merge process failed: first=${firstResult.code} second=${secondResult.code} stderr=${firstResult.stderr || secondResult.stderr}`);
+    }
+
+    const merged = readFileSync(join(mergeTmp, 'data', 'applications.md'), 'utf-8');
+    if (merged.includes('Alpha') && merged.includes('Beta')) {
+      pass('concurrent tracker merges preserve rows from both processes');
+    } else {
+      fail(`concurrent tracker merge lost a row: ${merged}`);
+    }
+  } finally {
+    rmSync(mergeTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`merge-tracker concurrent write test crashed: ${e.message}`);
 }
 
 // ── 12. COLD-START TRIGGER ──────────────────────────────────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1535,7 +1535,32 @@ try {
 console.log('\n🧪 Testing merge-tracker concurrent writes...');
 try {
   const mergeTmp = mkdtempSync(join(tmpdir(), 'career-ops-merge-lock-'));
+  /**
+   * Wait briefly between starting concurrent merge processes.
+   *
+   * The first process is started with `CAREER_OPS_MERGE_HOLD_MS`, then this
+   * helper gives it time to acquire the tracker lock before the second process
+   * starts. That makes the test exercise lock waiting instead of relying on
+   * scheduler luck.
+   *
+   * @param {number} ms - Milliseconds to wait.
+   * @returns {Promise<void>} Resolves after the delay.
+   */
   const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+  /**
+   * Spawn one isolated `merge-tracker.mjs` process against the temporary fixture.
+   *
+   * Each spawned process receives the same tracker path and lock path but a
+   * different additions directory. Without serialization, both processes can
+   * read the same old tracker and the later write can lose the other row. The
+   * returned result captures stdout/stderr so failures explain which worker
+   * failed and why.
+   *
+   * @param {string} additionsDir - Directory containing this process's TSV row.
+   * @param {number} [holdMs=0] - Optional post-read delay injected into the merge.
+   * @returns {Promise<{code:number|null,stdout:string,stderr:string}>}
+   * Process result after `merge-tracker.mjs` exits.
+   */
   const runMergeAsync = (additionsDir, holdMs = 0) => new Promise(resolve => {
     const child = spawn(NODE, ['merge-tracker.mjs'], {
       cwd: ROOT,


### PR DESCRIPTION
## Summary
- add a local filesystem lock around the full `merge-tracker.mjs` read/modify/write/move sequence
- write `applications.md` via a same-directory temp file and atomic rename
- add a deterministic regression test that runs two tracker merges concurrently and confirms both rows survive

## Why
#803 fixed atomic report-number reservation, but tracker merging still had a separate race. Two `merge-tracker.mjs` processes could read the same old `applications.md` snapshot and the later writer could drop rows written by the earlier process.

Closes #940.

## Validation
- `node --check merge-tracker.mjs`
- `node --check test-all.mjs`
- `git diff --check`
- `node test-all.mjs --quick` → 231 passed, 0 failed, 16 warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent-write clobbers by adding a filesystem lock with retry/timeout, stale-lock recovery, and idempotent release (including guaranteed release on exit).
  * Switched critical writes to atomic file replacement to ensure safe updates and added an optional configurable merge delay to control interleaving.

* **Tests**
  * Added deterministic concurrency tests that spawn parallel processes to verify merged results remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->