### PR TITLE
fix(generate-pdf): silent no-op on Windows - build file:// URLs with pathToFileURL

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -14,7 +14,7 @@ import { chromium } from 'playwright';
 import { resolve, dirname } from 'path';
 import { readFile } from 'fs/promises';
 import { mkdirSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -221,7 +221,7 @@ async function generatePDF() {
   const fontsDir = resolve(__dirname, 'fonts');
   html = html.replace(
     /url\(['"]?\.\/fonts\//g,
-    `url('file://${fontsDir}/`
+    `url('${pathToFileURL(fontsDir).href}/`
   );
   // Close any unclosed quotes from the replacement (handles all font formats)
   html = html.replace(
@@ -262,7 +262,7 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
     // Set content with file base URL for any relative resources
     await page.setContent(html, {
       waitUntil: 'load',
-      baseURL: `file://${baseDir}/`,
+      baseURL: `${pathToFileURL(baseDir).href}/`,
     });
 
     // Wait for fonts to load
@@ -299,7 +299,7 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
   }
 }
 
-const isMain = process.argv[1] && import.meta.url === `file://${resolve(process.argv[1])}`;
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
 if (isMain) {
   generatePDF().catch((err) => {
     console.error('❌ PDF generation failed:', err.message);


### PR DESCRIPTION
Fixes #948

## What

On Windows, `node generate-pdf.mjs <input.html> <output.pdf>` was a **silent no-op**: no output, no PDF, exit code 0. The main-module guard hand-built the comparison URL:

```js
const isMain = process.argv[1] && import.meta.url === `file://${resolve(process.argv[1])}`;
```

On Windows `resolve()` returns backslash paths (`C:\...`, or `\\wsl.localhost\...` UNC when the repo lives in WSL), so the string never equals `import.meta.url` (`file:///C:/...` forward-slash form). `isMain` stayed `false`, the CLI entry never ran, and the script exited 0 after merely being imported.

This PR replaces the hand-built string with `pathToFileURL()` — the same pattern the repo already uses in `scan.mjs`, `scan-ats-full.mjs`, `update-system.mjs`, and `followup-cadence.mjs`. `generate-pdf.mjs` was the last script with the hand-built guard.

Per the issue, I grepped for all remaining `` `file://${...}` `` interpolations and fixed the other two in the same file, which produced invalid backslash URLs on Windows:

- the fonts injection (`url('file://${fontsDir}/`) → broken font loading, wrong typography in the PDF
- the Playwright `baseURL` (`file://${baseDir}/`) → broken relative resources

4 lines changed (3 sites + the `pathToFileURL` import). No behavior change on Linux/macOS: for POSIX absolute paths `pathToFileURL().href` produces the same `file:///...` string the template literal did (and additionally percent-encodes special characters correctly).

## Verification (Windows 11, Node v24.14.0)

**Before** (clean clone of `main` @ 0d57994):

```text
> node generate-pdf.mjs batch\does-not-exist.html out.pdf
> echo $LASTEXITCODE
0          # no output at all, no PDF
```

**After:**

```text
> node generate-pdf.mjs batch\does-not-exist.html out.pdf
📄 Input:  ...\batch\does-not-exist.html
📁 Output: ...\out.pdf
📏 Format: A4
❌ PDF generation failed: ENOENT: no such file or directory, open '...'
> echo $LASTEXITCODE
1
```

**End-to-end render** on Windows with `templates/cv-template.html` (exercises the fonts rewrite + baseURL):

```text
✅ PDF generated: ...\output\test-windows.pdf
📊 Pages: 1
📦 Size: 33.3 KB
```

**Test suite** (`node test-all.mjs`): 240 passed, 3 failed — and the *identical* 3 failures occur on unmodified `main` on this machine, all Windows-environment issues unrelated to this change (Go toolchain missing for the dashboard build, `.claude/.../SKILL.md` symlink checked out as a plain file, `spawnSync chmod ENOENT`). Linux CI should be fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF generation reliability and cross-platform compatibility through enhanced file URL handling for fonts and resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->