### PR TITLE
fix(generate-pdf): inline local fonts as data: URLs so they actually embed

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -14,7 +14,7 @@ import { chromium } from 'playwright';
 import { resolve, dirname } from 'path';
 import { readFile } from 'fs/promises';
 import { mkdirSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -221,7 +221,7 @@ async function generatePDF() {
   const fontsDir = resolve(__dirname, 'fonts');
   html = html.replace(
     /url\(['"]?\.\/fonts\//g,
-    `url('file://${fontsDir}/`
+    `url('${pathToFileURL(fontsDir).href}/`
   );
   // Close any unclosed quotes from the replacement (handles all font formats)
   html = html.replace(
@@ -262,7 +262,7 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
     // Set content with file base URL for any relative resources
     await page.setContent(html, {
       waitUntil: 'load',
-      baseURL: `file://${baseDir}/`,
+      baseURL: `${pathToFileURL(baseDir).href}/`,
     });
 
     // Wait for fonts to load
@@ -299,7 +299,7 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
   }
 }
 
-const isMain = process.argv[1] && import.meta.url === `file://${resolve(process.argv[1])}`;
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
 if (isMain) {
   generatePDF().catch((err) => {
     console.error('❌ PDF generation failed:', err.message);

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -11,7 +11,7 @@
  */
 
 import { chromium } from 'playwright';
-import { resolve, dirname } from 'path';
+import { resolve, dirname, relative, isAbsolute } from 'path';
 import { readFile } from 'fs/promises';
 import { mkdirSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -244,12 +244,20 @@ async function generatePDF() {
 export async function inlineLocalFonts(html) {
   const FONT_REF = /url\(\s*(['"]?)\.\/fonts\/([^'")\s]+)\1\s*\)/g;
   const MIME = { woff2: 'font/woff2', woff: 'font/woff', otf: 'font/otf', ttf: 'font/ttf' };
+  const fontsDir = resolve(__dirname, 'fonts');
   const names = [...new Set([...html.matchAll(FONT_REF)].map((m) => m[2]))];
   const dataUrls = new Map();
   for (const name of names) {
-    if (name.includes('..')) continue;
+    // Containment check: ".." segments and absolute names (./fonts//etc/passwd)
+    // would otherwise resolve outside fonts/.
+    const fontPath = resolve(fontsDir, name);
+    const rel = relative(fontsDir, fontPath);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      console.warn(`⚠️  Font reference escapes fonts/, keeping original reference: ${name}`);
+      continue;
+    }
     try {
-      const buf = await readFile(resolve(__dirname, 'fonts', name));
+      const buf = await readFile(fontPath);
       const ext = name.slice(name.lastIndexOf('.') + 1).toLowerCase();
       dataUrls.set(name, `url('data:${MIME[ext] || 'application/octet-stream'};base64,${buf.toString('base64')}')`);
     } catch (err) {

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -207,7 +207,6 @@ async function generatePDF() {
   console.log(`📁 Output: ${outputPath}`);
   console.log(`📏 Format: ${format.toUpperCase()}`);
 
-  // Read HTML to inject font paths as absolute file:// URLs
   let html = await readFile(inputPath, 'utf-8');
   let cvMarkdown = '';
   try {
@@ -216,18 +215,6 @@ async function generatePDF() {
     if (err?.code !== 'ENOENT') throw err;
   }
   validateCvSectionOrder(html, cvMarkdown);
-
-  // Resolve font paths relative to career-ops/fonts/
-  const fontsDir = resolve(__dirname, 'fonts');
-  html = html.replace(
-    /url\(['"]?\.\/fonts\//g,
-    `url('${pathToFileURL(fontsDir).href}/`
-  );
-  // Close any unclosed quotes from the replacement (handles all font formats)
-  html = html.replace(
-    /file:\/\/([^'")]+)\.(woff2?|ttf|otf)['"]?\)/g,
-    `file://$1.$2')`
-  );
 
   // Normalize text for ATS compatibility (issue #1)
   const normalized = normalizeTextForATS(html);
@@ -242,7 +229,42 @@ async function generatePDF() {
 }
 
 /**
+ * Inline url('./fonts/...') references as base64 data: URLs.
+ *
+ * Chromium refuses to load file:// subresources from a setContent() page
+ * (the document stays at about:blank), so fonts referenced by path are
+ * silently dropped and PDFs fall back to system fonts. data: URLs carry
+ * no origin restriction, so they load from any page. See #951.
+ *
+ * Missing font files keep their original reference and log a warning.
+ *
+ * @param {string} html - HTML that may reference url('./fonts/<file>').
+ * @returns {Promise<string>} HTML with local font references inlined.
+ */
+export async function inlineLocalFonts(html) {
+  const FONT_REF = /url\(\s*(['"]?)\.\/fonts\/([^'")\s]+)\1\s*\)/g;
+  const MIME = { woff2: 'font/woff2', woff: 'font/woff', otf: 'font/otf', ttf: 'font/ttf' };
+  const names = [...new Set([...html.matchAll(FONT_REF)].map((m) => m[2]))];
+  const dataUrls = new Map();
+  for (const name of names) {
+    if (name.includes('..')) continue;
+    try {
+      const buf = await readFile(resolve(__dirname, 'fonts', name));
+      const ext = name.slice(name.lastIndexOf('.') + 1).toLowerCase();
+      dataUrls.set(name, `url('data:${MIME[ext] || 'application/octet-stream'};base64,${buf.toString('base64')}')`);
+    } catch (err) {
+      if (err?.code !== 'ENOENT') throw err;
+      console.warn(`⚠️  Font file not found, keeping original reference: fonts/${name}`);
+    }
+  }
+  return html.replace(FONT_REF, (match, _quote, name) => dataUrls.get(name) || match);
+}
+
+/**
  * Render an HTML string to a PDF file via headless Chromium.
+ *
+ * Local url('./fonts/...') references are inlined as data: URLs first so
+ * fonts render regardless of page origin (see inlineLocalFonts).
  *
  * @param {string} html - Full HTML document to render.
  * @param {string} outputPath - Absolute path to write the PDF to.
@@ -254,6 +276,8 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
   const baseDir = opts.baseDir || process.cwd();
 
   mkdirSync(dirname(outputPath), { recursive: true });
+
+  html = await inlineLocalFonts(html);
 
   const browser = await chromium.launch({ headless: true });
   try {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2200,6 +2200,46 @@ try {
   fail(`update-system SEMVER_RE test crashed: ${e.message}`);
 }
 
+// ── 17. FONT INLINING (#951) ────────────────────────────────────
+
+console.log('\n17. Font inlining (data: URLs, #951)');
+
+try {
+  // Importing must not trigger the CLI (the import.meta.url guard); it
+  // exposes inlineLocalFonts, which renderHtmlToPdf runs before setContent.
+  const { inlineLocalFonts } = await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
+
+  // Chromium blocks file:// subresources from setContent() pages (the page
+  // stays at about:blank), so ./fonts refs must become data: URLs (#951).
+  const fontFile = readdirSync(join(ROOT, 'fonts')).find(f => f.endsWith('.woff2'));
+  const inlined = await inlineLocalFonts(
+    `<style>@font-face { src: url('./fonts/${fontFile}') format('woff2'); }</style>`
+  );
+  if (inlined.includes('data:font/woff2;base64,') && !inlined.includes('./fonts/')) {
+    pass('local ./fonts references are inlined as data: URLs');
+  } else {
+    fail('./fonts reference was not inlined as a data: URL — fonts will silently fall back (#951)');
+  }
+
+  // A missing font file must not corrupt the HTML or throw.
+  const missing = await inlineLocalFonts(`<style>src: url('./fonts/does-not-exist.woff2');</style>`);
+  if (missing.includes(`url('./fonts/does-not-exist.woff2')`)) {
+    pass('missing font files keep their original reference');
+  } else {
+    fail('missing font file mangled the url() reference');
+  }
+
+  // Traversal outside fonts/ must never be inlined.
+  const traversal = await inlineLocalFonts(`<style>src: url('./fonts/../cv.md');</style>`);
+  if (traversal.includes(`url('./fonts/../cv.md')`)) {
+    pass('path traversal outside fonts/ is not inlined');
+  } else {
+    fail('path traversal escaped the fonts/ directory');
+  }
+} catch (e) {
+  fail(`font inlining test crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2229,12 +2229,19 @@ try {
     fail('missing font file mangled the url() reference');
   }
 
-  // Traversal outside fonts/ must never be inlined.
+  // Traversal outside fonts/ must never be inlined — neither via ".."
+  // segments nor via absolute names (resolve() returns those verbatim).
   const traversal = await inlineLocalFonts(`<style>src: url('./fonts/../cv.md');</style>`);
   if (traversal.includes(`url('./fonts/../cv.md')`)) {
     pass('path traversal outside fonts/ is not inlined');
   } else {
     fail('path traversal escaped the fonts/ directory');
+  }
+  const absolute = await inlineLocalFonts(`<style>src: url('./fonts//etc/passwd');</style>`);
+  if (absolute.includes(`url('./fonts//etc/passwd')`)) {
+    pass('absolute-path escape (./fonts//etc/passwd) is not inlined');
+  } else {
+    fail('absolute-path reference escaped the fonts/ directory');
   }
 } catch (e) {
   fail(`font inlining test crashed: ${e.message}`);


### PR DESCRIPTION
Fixes #951

> **Stacked on #949** — this branch includes that PR's commit (`14e65cc`) because both touch the font-injection lines. Once #949 merges, this PR reduces to the single font-inlining commit (`32fe58b`). Happy to rebase either way.

## What

Custom fonts have never been embedded in generated PDFs (issue #951): `renderHtmlToPdf()` uses `page.setContent()`, which leaves the page at `about:blank`, and Chromium blocks `file://` subresource loads from non-file pages — so the `file://` font URLs injected by `generatePDF()` were always silently dropped and every PDF fell back to system fonts, on all platforms.

This PR takes option 1 from the issue:

- **`inlineLocalFonts(html)`** (new, exported): replaces `url('./fonts/<file>')` references with base64 `data:` URLs read from the repo's `fonts/` directory. `data:` URLs carry no origin restriction, so they load from any page — no change to how the document is loaded. Missing files keep their original reference (with a warning); `..` traversal outside `fonts/` is refused.
- Called from **`renderHtmlToPdf()`**, not `generatePDF()`, so `generate-cover-letter.mjs` — which calls `renderHtmlToPdf()` directly and previously had **no** font handling at all — is covered too.
- The old two-step `file://` regex injection in `generatePDF()` (prefix replace + quote-fixup) is removed; it was both the broken mechanism and dead weight once inlining happens in the renderer.
- 3 new checks in `test-all.mjs` (section 17): inlining produces `data:font/woff2` URLs, missing fonts keep their reference, traversal is refused.

## Verification (Windows 11, Node v24.14.0, Playwright 1.58.1)

Embedded fonts in a PDF rendered from `templates/cv-template.html`, extracted from the PDF's font descriptors:

| | `/FontName` entries |
|---|---|
| before (main and #949) | `AAAAAA+Arial-BoldMT`, `BAAAAA+ArialMT` — system fallback |
| **after** | `AAAAAA+Space-Grotesk-Light-Light`, `BAAAAA+DM-Sans-9pt-14pt-Thin`, `CAAAAA+Space-Grotesk-Light-Light`, `DAAAAA+DM-Sans-9pt-14pt-Thin` |

Chromium emits the variable woff2 fonts as Type3 glyph programs with `/ToUnicode` maps (4 present). **ATS parseability is unchanged**: text extracted with pdf.js from the before/after PDFs is byte-identical (386 chars, same content).

`node test-all.mjs`: 248 passed (245 + the 3 new checks) — remaining failures on this machine are the same pre-existing Windows-environment issues as on unmodified `main` (Go toolchain, SKILL.md symlink checkout, `chmod`); Linux CI should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF generation now inlines locally stored font files into documents as base64 data URLs, replacing external file references while leaving missing fonts unchanged and preventing directory-escape inlining.

* **Tests**
  * Added tests validating font inlining, correct data URL embedding, preservation of missing references, and enforcement of path-based access restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->