### PR TITLE
fix: rebuild dashboard after updater changes

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -493,6 +493,23 @@ if (!/waitUntil:\s*['"]networkidle['"]/.test(generatePdfScript)) {
   fail('generate-pdf still waits for networkidle');
 }
 
+// ── 7c. UPDATER DASHBOARD REBUILD ─────────────────────────────────
+
+console.log('\n7c. Updater dashboard rebuild');
+
+const updateSystemScript = readFile('update-system.mjs');
+if (
+  /git\('diff',\s*'--name-only',\s*'HEAD',\s*'--',\s*'dashboard'\)/.test(updateSystemScript) &&
+  /path\.startsWith\(['"]dashboard\/['"]\)\s*&&\s*path\.endsWith\(['"]\.go['"]\)/.test(updateSystemScript) &&
+  /go build -o career-dashboard \./.test(updateSystemScript) &&
+  /cwd:\s*join\(ROOT,\s*['"]dashboard['"]\)/.test(updateSystemScript) &&
+  /dashboard binary rebuild skipped/.test(updateSystemScript)
+) {
+  pass('update-system rebuilds dashboard binary when dashboard Go sources change');
+} else {
+  fail('update-system does not rebuild dashboard binary after dashboard Go source updates');
+}
+
 // ── 8. MODE FILE INTEGRITY ──────────────────────────────────────
 
 console.log('\n8. Mode file integrity');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -234,6 +234,32 @@ function addPaths(paths) {
   git('add', '--', ...paths);
 }
 
+function dashboardGoSourcesChanged() {
+  try {
+    const changed = git('diff', '--name-only', 'HEAD', '--', 'dashboard');
+    return changed
+      .split('\n')
+      .some(path => path.startsWith('dashboard/') && path.endsWith('.go'));
+  } catch {
+    return false;
+  }
+}
+
+function rebuildDashboardBinaryIfNeeded() {
+  if (!dashboardGoSourcesChanged()) return;
+
+  try {
+    execFileSync('go', ['build', '-o', 'career-dashboard', '.'], {
+      cwd: join(ROOT, 'dashboard'),
+      timeout: 60000,
+      stdio: 'pipe',
+    });
+    console.log('dashboard binary rebuilt');
+  } catch {
+    console.log('dashboard binary rebuild skipped -- run: cd dashboard && go build -o career-dashboard . manually');
+  }
+}
+
 // ── CHECK ───────────────────────────────────────────────────────
 
 // curl helper used by check() — curl works inside the Claude Code sandbox
@@ -466,7 +492,10 @@ async function apply() {
       console.log('npm install skipped (may need manual run)');
     }
 
-    // 6. Commit the update
+    // 6. Rebuild compiled dashboard if Go sources changed
+    rebuildDashboardBinaryIfNeeded();
+
+    // 7. Commit the update
     const remote = localVersion(); // Re-read after checkout updated VERSION
     try {
       const pathsToStage = [...updated];


### PR DESCRIPTION
## Summary

Fixes #943. `update-system.mjs apply` now detects when dashboard Go source files changed during a system update and attempts to rebuild the ignored `dashboard/career-dashboard` binary before committing the update. If Go is unavailable or the build fails, the update remains non-blocking and prints the manual rebuild command.

The change uses `git diff --name-only HEAD -- dashboard` after checkout so it rebuilds only when actual dashboard `.go` files changed, rather than every time the updater checks out the `dashboard/` system path.

## Tests

- `node test-all.mjs --quick`
- `node --check update-system.mjs && node --check test-all.mjs`
- `node test-all.mjs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The update system now includes automated detection of dashboard source file changes and conditional rebuilding of the dashboard binary to keep compiled versions synchronized with source modifications.

* **Tests**
  * Added test validation to ensure the dashboard rebuild detection logic correctly identifies source file changes and triggers proper compilation during system updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->