### PR TITLE
feat(patterns): transcript-driven targeting correction (Step 1b) — closes #960

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ jds/*
 
 # Interview prep (accumulated STAR+R stories — user data)
 interview-prep/*
+!interview-prep/
 !interview-prep/.gitkeep
 # Session transcripts hold real interviewer names/companies — ignore content,
 # ship only the system-owned scaffold (README + .gitkeep). #1242

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Searches for new offers | `scan` |
 | Processes pending URLs | `pipeline` |
 | Batch processes offers | `batch` |
-| Asks about rejection patterns or wants to improve targeting | `patterns` |
+| Asks about rejection patterns, wants to improve targeting, or wants to match interview answers to best-fit roles | `patterns` |
 | Asks about follow-ups or application cadence | `followup` |
 | Wants to update the system | `update` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,7 @@ Default modes are in `modes/` (English). Language-specific modes live in `modes/
 | Searches for new offers | `scan` |
 | Processes pending URLs | `pipeline` |
 | Batch processes offers | `batch` |
-| Asks about rejection patterns or wants to improve targeting | `patterns` |
+| Asks about rejection patterns, wants to improve targeting, or wants to match interview answers to best-fit roles | `patterns` |
 | Asks about follow-ups or application cadence | `followup` |
 
 ### CV Source of Truth

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -16,6 +16,7 @@ These files contain your personal data, customizations, and work product. Update
 | `article-digest.md` | Your proof points from portfolio |
 | `interview-prep/story-bank.md` | Your accumulated STAR+R stories |
 | `interview-prep/{company}-{role}.md` | Company-specific interview prep reports (written by `/career-ops interview-prep`) |
+| `interview-prep/sessions/*.md` | Interview sessions — real transcripts + mock sessions (sensitive: real names/companies; gitignored except scaffold). Drives `patterns` Step 1b targeting signal and `interview-redflag` analysis. Scaffold files (`README.md`, `.gitkeep`) are system-owned. |
 | `portals.yml` | Your customized company list |
 | `config/plugins.yml` | Your plugin activation toggles (opt-in; seeded from `config/plugins.example.yml`) |
 | `plugins.local/` | Your own / private plugins (never auto-updated) |

--- a/modes/patterns.md
+++ b/modes/patterns.md
@@ -4,6 +4,8 @@
 
 Analyze all tracked applications to find patterns in outcomes and surface actionable insights. Identifies what's working (archetypes, remote policies, score ranges) and what's wasting time (geo-restricted roles, stack mismatches, low-score applications).
 
+When interview sessions are available, it also reads *what the candidate actually says in the room* — a higher-resolution, lower-noise signal of role-fit than win/loss — to detect role **misfit**: when the candidate's strongest, most fluent answers point at a different role-type than the one they keep applying to (Step 1b).
+
 ## Inputs
 
 - `data/applications.md` — Application tracker
@@ -11,6 +13,7 @@ Analyze all tracked applications to find patterns in outcomes and surface action
 - `config/profile.yml` — User profile (for recommendation context)
 - `modes/_profile.md` — User archetypes and framing
 - `portals.yml` — Portal config (for filter update recommendations)
+- `interview-prep/sessions/*.md` — Interview sessions (optional; drives Step 1b). Drop real-interview transcripts and mock-session files here.
 
 ## Minimum Threshold
 
@@ -72,6 +75,29 @@ When you narrate this to the user:
 - The `recommendations` array already contains the `high`-impact channel action
   when one qualifies — surface it verbatim rather than inventing a stronger claim.
 
+## Step 1b — Session-Content Targeting Signal (optional)
+
+Outcome data (Step 1) tells you *whether* you're winning. Interview sessions tell you *what role you're actually selling* in the room — a higher-resolution, lower-noise signal of role-fit than win/loss, which is confounded by comp, timing, headcount, and a dozen reasons unrelated to fit.
+
+**Run this step only if session data exists.** Check: `interview-prep/sessions/*.md` (excluding `README.md` and `.gitkeep`).
+
+If no sessions are present, **skip this step silently** and proceed with outcome-only analysis. This step is purely additive — the mode works fully without it, and gains resolution once sessions accumulate.
+
+If sessions exist, for each one:
+1. Separate the candidate's answers from the interviewer's questions. If speaker labels are missing, infer them (turns tagged `**Interviewer:**` / `**Candidate:**` per the session format).
+2. Determine the competency / role-signal each substantive answer demonstrates (e.g. *instructional-design*, *systems-architecture*, *data-analysis*, *stakeholder-management*, *people-leadership*). **Tags first, inference as fallback:** if the answer already carries an explicit competency tag — `<!-- competency: ... -->` per the convention in `interview-prep/sessions/README.md`, whether written by hand or emitted by a debrief tool (e.g. `interview/debrief`) — use it directly. Only infer the competency yourself when no tag is present.
+3. Mark whether the answer is **fluent and specific** (concrete metrics, named tools, real decisions) or **flat and generic** (hedged, vague, textbook).
+
+Then aggregate across all sessions:
+- **Where do the fluent/specific answers cluster?** That competency cluster is the role-type the candidate is *actually* strongest at — regardless of the title on their résumé.
+- Compare that cluster against (a) the archetypes in `modes/_profile.md` and (b) the distribution of roles actually applied to in `data/applications.md`.
+- **Surface the misfit:** if the strongest cluster (X) is under-represented in the roles applied to (Y), that is a targeting-correction signal:
+  > "Your answers consistently light up around **X**, but you're mostly applying to **Y**. Consider adding archetype X and reweighting `portals.yml` `title_filter.positive` toward it."
+
+This is the difference between *"you're losing"* (Step 1, outcomes) and *"you're aiming at the wrong target"* (Step 1b, content). Feed the result into the Step 2 report and Step 4 recommendations.
+
+**Privacy:** sessions contain real interviewer names and companies. Read them locally only; **never quote a real name or company into a committed report.** Summarize the signal (competency clusters), never the content.
+
 ## Step 2 — Generate Report
 
 Write the report to `reports/pattern-analysis-{YYYY-MM-DD}.md`.
@@ -128,6 +154,13 @@ List of most common missing skills in negative/self-filtered outcomes with frequ
 
 State the data-driven minimum score and reasoning.
 
+## Targeting Signal (interview sessions)
+
+*Include this section only if Step 1b ran.* Summarize, in competency terms only (no real names/companies):
+- Which competency cluster the candidate's answers are strongest at (X)
+- Which role-types they're actually applying to (Y)
+- The misfit gap and the suggested realignment (add archetype X / reweight `portals.yml`)
+
 ## Recommendations
 
 Number the top recommendations (from the script output). For each:
@@ -160,6 +193,7 @@ Ask the user if they want to act on any recommendations:
 > - Update `portals.yml` to filter out geo-restricted roles
 > - Set a score threshold in `_profile.md` for PDF generation
 > - Adjust archetype targeting based on what's converting
+> - Realign targeting from the session signal — add the under-targeted archetype X to `modes/_profile.md` and reweight `portals.yml` `title_filter.positive` (if Step 1b ran)
 >
 > Just say which ones, or 'all' to apply everything."
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9741,6 +9741,57 @@ try {
   fail(`prepare-application contract check crashed: ${e.message}`);
 }
 
+// ── PATTERNS STEP 1b — SESSION-PATH CONTRACT ────────────────────
+
+console.log('\n🧪 patterns mode: session-path contract');
+try {
+  const patternsMode = readFile('modes/patterns.md');
+  const gitignoreTxt = readFile('.gitignore');
+
+  if (patternsMode.includes('interview-prep/sessions/')) {
+    pass('patterns mode references interview-prep/sessions/');
+  } else {
+    fail('patterns mode does not reference interview-prep/sessions/ — path contract broken');
+  }
+
+  if (!patternsMode.includes('interview-prep/transcripts')) {
+    pass('patterns mode does not reference deprecated interview-prep/transcripts/');
+  } else {
+    fail('patterns mode still references interview-prep/transcripts/ — should use sessions/ only');
+  }
+
+  if (patternsMode.includes('skip this step silently')) {
+    pass('patterns mode Step 1b has graceful skip when no sessions present');
+  } else {
+    fail('patterns mode missing "skip this step silently" guard for Step 1b');
+  }
+
+  if (fileExists('interview-prep/sessions/README.md') && fileExists('interview-prep/sessions/.gitkeep')) {
+    pass('interview-prep/sessions/ scaffold (README.md + .gitkeep) present');
+  } else {
+    fail('interview-prep/sessions/ scaffold missing — README.md or .gitkeep absent');
+  }
+
+  if (
+    gitignoreTxt.includes('interview-prep/sessions/*') &&
+    gitignoreTxt.includes('!interview-prep/sessions/.gitkeep') &&
+    gitignoreTxt.includes('!interview-prep/sessions/') &&
+    gitignoreTxt.includes('!interview-prep/sessions/README.md')
+  ) {
+    pass('.gitignore protects sessions content but tracks scaffold files');
+  } else {
+    fail('.gitignore sessions scaffold rules incomplete — check re-include entries');
+  }
+
+  if (!gitignoreTxt.includes('interview-prep/transcripts')) {
+    pass('.gitignore does not contain deprecated transcripts/ rules');
+  } else {
+    fail('.gitignore still has deprecated interview-prep/transcripts/ rules');
+  }
+} catch (e) {
+  fail(`patterns session-path contract check crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9766,10 +9766,11 @@ try {
     fail('patterns mode missing "skip this step silently" guard for Step 1b');
   }
 
-  if (fileExists('interview-prep/sessions/README.md') && fileExists('interview-prep/sessions/.gitkeep')) {
-    pass('interview-prep/sessions/ scaffold (README.md + .gitkeep) present');
+  const dataContractTxt = readFile('DATA_CONTRACT.md');
+  if (dataContractTxt.includes('interview-prep/sessions/')) {
+    pass('DATA_CONTRACT.md registers interview-prep/sessions/ as User Layer');
   } else {
-    fail('interview-prep/sessions/ scaffold missing — README.md or .gitkeep absent');
+    fail('DATA_CONTRACT.md missing interview-prep/sessions/ registration');
   }
 
   if (


### PR DESCRIPTION
Closes #960.

## What

Extends the existing `patterns` mode with an optional **Step 1b — Transcript-Content Targeting Signal**: when interview sessions are present, it clusters the candidate's *fluent and specific* answers into competency signals, compares that cluster against the roles actually applied to (`data/applications.md`) and the archetypes in `modes/_profile.md`, and surfaces role **misfit**:

> "Your answers consistently light up around **X**, but you're mostly applying to **Y**. Consider adding archetype X and reweighting `portals.yml` `title_filter.positive`."

## Why

`patterns` today corrects targeting from **tracker outcomes** — but win/loss is a noisy signal (confounded by comp, timing, headcount). The highest-resolution signal of role-fit is *what the candidate actually says in the room*, and right now that content is discarded after the interview. This closes the gap between *"you're losing"* (outcomes) and *"you're aiming at the wrong target"* (content).

## Design — independent, degrades gracefully

- **No hard dependency on unmerged work.** This is the downstream consumer of `interview/debrief` (#956) and mock sessions, but it does **not** require them: it reads `interview-prep/sessions/*.md` and **skips silently** when no sessions exist. It merges and works today; it gains resolution once #956 lands and populates sessions.
- **Zero new dependencies, prompt-level only.** No new `.mjs`, no deps — same shape as the rest of `patterns`.
- **Recommendation only.** Never auto-edits `portals.yml` or `modes/_profile.md`; surfaces the suggestion, user decides (consistent with the review-before-action rule).
- **Privacy.** Sessions contain real interviewer names and companies. `interview-prep/sessions/` is gitignored (scaffold tracked by #956); the mode summarizes the *signal* (competency clusters) only and never quotes a real name/company into a committed report.

## Changes

| File | Change |
|------|--------|
| `modes/patterns.md` | Step 1b + report "Targeting Signal" section + Step 4 realign option + Inputs/Purpose |
| `.gitignore` | defensive gitignore for `interview-prep/sessions/*` (real content never committed) |
| `DATA_CONTRACT.md` | `interview-prep/sessions/*.md` registered as User Layer |
| `AGENTS.md` / `CLAUDE.md` | route "which roles do my answers fit best" → `patterns` |
| `test-all.mjs` | 7 assertions (Step 1b documented · sessions path contract · gitignore protects) |

## Tests

`node test-all.mjs` — all assertions pass. No new `.mjs` or deps introduced; behavior is additive and gated on session presence.

## Directory ownership — `sessions/`

`interview-prep/sessions/` is **owned by #956** (@skalrn), which ships the scaffold (`README.md` + `.gitkeep`) and the producer logic (debrief/practice emit one transcript per round in the canonical format). This PR is a **pure consumer** — it reads `sessions/*.md` without shipping the scaffold.

The scaffold files (`README.md`, `.gitkeep`) were removed from this PR in a follow-up commit after #956 added the producer side on Jun 28. When #956 merges, the sessions/ directory will exist and Step 1b will have data to read.

> **Note on DATA_CONTRACT:** This PR registers `interview-prep/sessions/*.md` as User Layer. #956's PR description deferred this to #963 — coordinate with @skalrn to avoid double-registration when #963 opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)