### PR TITLE
feat(batch): add --status and --watch progress monitoring to batch-runner.sh

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -38,6 +38,8 @@ MIN_SCORE=0
 MODEL=""  # empty = let claude -p use the Claude Max default
 RATE_LIMIT_SLEEP=300
 BATCH_PAUSED=false
+STATUS_ONLY=false
+WATCH_MODE=false
 
 usage() {
   cat <<'USAGE'
@@ -59,6 +61,8 @@ Options:
   --model NAME         Claude model passed to `claude -p --model` (default:
                        unset = Claude Max default). Use a cheaper model for
                        large batches, e.g. `--model claude-sonnet-4-6`.
+  --status             Show batch progress and a per-job table, then exit
+  --watch              Live-refresh progress until the run completes
   -h, --help           Show this help
 
 Files:
@@ -99,6 +103,8 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --model) MODEL="$2"; shift 2 ;;
+    --status) STATUS_ONLY=true; shift ;;
+    --watch) WATCH_MODE=true; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1"; usage; exit 1 ;;
   esac
@@ -547,9 +553,126 @@ print_summary() {
   fi
 }
 
+print_status_table() {
+  if [[ ! -f "$STATE_FILE" ]]; then
+    echo "No state file found at $STATE_FILE"
+    return
+  fi
+
+  local total=0 completed=0 processing=0 failed=0 pending=0 skipped=0 rate_limited=0 paused_rate_limit=0
+  local score_sum=0 score_count=0
+
+  # Read first line to skip header
+  local header=true
+  while IFS=$'\t' read -r sid surl sstatus sstarted scompleted sreport sscore serror sretries || [[ -n "$sid" ]]; do
+    if [[ "$header" == "true" ]]; then
+      header=false
+      continue
+    fi
+    [[ -z "$sid" ]] && continue
+    sstatus="${sstatus%$'\r'}"
+    sscore="${sscore%$'\r'}"
+    serror="${serror%$'\r'}"
+    sreport="${sreport%$'\r'}"
+    total=$((total + 1))
+    case "$sstatus" in
+      completed)
+        completed=$((completed + 1))
+        if [[ "$sscore" != "-" && -n "$sscore" ]]; then
+          score_sum=$(echo "$score_sum + $sscore" | bc 2>/dev/null || echo "$score_sum")
+          score_count=$((score_count + 1))
+        fi
+        ;;
+      processing) processing=$((processing + 1)) ;;
+      failed) failed=$((failed + 1)) ;;
+      skipped) skipped=$((skipped + 1)) ;;
+      rate_limited) rate_limited=$((rate_limited + 1)) ;;
+      paused_rate_limit) paused_rate_limit=$((paused_rate_limit + 1)) ;;
+      *) pending=$((pending + 1)) ;;
+    esac
+  done < "$STATE_FILE"
+
+  echo "=== Batch Progress ==="
+  echo "Total: $total | Completed: $completed | Processing: $processing | Failed: $failed | Pending: $pending | Skipped: $skipped | Rate Limited: $rate_limited | Paused: $paused_rate_limit"
+  if (( score_count > 0 )); then
+    local avg
+    avg=$(echo "scale=1; $score_sum / $score_count" | bc 2>/dev/null || echo "N/A")
+    echo "Average score: $avg/5 ($score_count scored)"
+  fi
+  echo ""
+
+  # Format the per-job table:
+  # Columns: ID, Status, Report, Score, Target (URL or Error Message)
+  printf "%-4s | %-17s | %-6s | %-5s | %-40s\n" "ID" "Status" "Report" "Score" "URL / Error"
+  printf "%-4s+%-19s+%-8s+%-7s+%-42s\n" "----" "-------------------" "--------" "-------" "------------------------------------------"
+
+  header=true
+  while IFS=$'\t' read -r sid surl sstatus sstarted scompleted sreport sscore serror sretries || [[ -n "$sid" ]]; do
+    if [[ "$header" == "true" ]]; then
+      header=false
+      continue
+    fi
+    [[ -z "$sid" ]] && continue
+    sstatus="${sstatus%$'\r'}"
+    sscore="${sscore%$'\r'}"
+    serror="${serror%$'\r'}"
+    sreport="${sreport%$'\r'}"
+    local target="$surl"
+    if [[ "$sstatus" == "failed" && -n "$serror" && "$serror" != "-" ]]; then
+      target="Error: $serror"
+    fi
+    # Trim target to fit nicely (e.g. 50 chars)
+    if (( ${#target} > 50 )); then
+      target="${target:0:47}..."
+    fi
+    printf "%-4s | %-17s | %-6s | %-5s | %-50s\n" "$sid" "$sstatus" "$sreport" "$sscore" "$target"
+  done < "$STATE_FILE"
+}
+
+watch_status() {
+  local active_pid=""
+  if [[ -f "$LOCK_FILE" ]]; then
+    active_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+  fi
+
+  if [[ -n "$active_pid" ]] && kill -0 "$active_pid" 2>/dev/null; then
+    echo "Watching batch-runner (PID $active_pid)... Press Ctrl+C to stop."
+    while kill -0 "$active_pid" 2>/dev/null; do
+      clear || printf "\033[c"
+      echo "=== Watching Batch Progress (PID $active_pid) ==="
+      print_status_table
+      sleep 2
+    done
+    echo ""
+    echo "=== Batch runner process (PID $active_pid) has finished ==="
+  else
+    echo "No active batch-runner detected."
+  fi
+
+  echo "Showing final status:"
+  print_status_table
+
+  # Chain verify-pipeline.mjs
+  if [[ -f "$PROJECT_DIR/verify-pipeline.mjs" ]]; then
+    echo ""
+    echo "=== Running pipeline verification ==="
+    node "$PROJECT_DIR/verify-pipeline.mjs" || echo "⚠️  Verification found issues"
+  fi
+}
+
 # Main
 main() {
   check_prerequisites
+
+  if [[ "$STATUS_ONLY" == "true" ]]; then
+    print_status_table
+    exit 0
+  fi
+
+  if [[ "$WATCH_MODE" == "true" ]]; then
+    watch_status
+    exit 0
+  fi
 
   if [[ "$DRY_RUN" == "false" ]]; then
     acquire_lock
@@ -725,6 +848,8 @@ main() {
 
   # Print summary
   print_summary
+
+  exit 0
 }
 
 main "$@"

--- a/modes/batch.md
+++ b/modes/batch.md
@@ -55,6 +55,14 @@ batch/
 5. **Pagination**: If no more jobs → click "Next" → repeat
 6. **End**: Merge `tracker-additions/` → `applications.md` + summary
 
+### What to watch during a run
+
+During a conductor run, the operator has two primary live interfaces to monitor:
+1. **The headed Chrome window:** Watch the browser navigate the portals, login to sessions, and interact with the job description pages in real time.
+2. **The agent CLI conversation:** Follow the agent's turn-by-turn narration in the shell.
+
+The individual worker tasks spawn headlessly in the background and write their stdout/stderr logs to `batch/logs/{report_num}-{id}.log`, which can be inspected on demand.
+
 ## Mode B: Standalone script
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

This PR adds live progress monitoring and observability to the standalone batch runner by:

- Adding `--status` flag to `batch/batch-runner.sh` that parses `batch-state.tsv` and prints a summary line (Total / Completed / Processing / Failed / Pending / Skipped / Rate Limited / Paused counts) plus a per-job ASCII table (ID | Status | Report | Score | URL or Error), then exits immediately — runs before the execution lock is acquired so it can be invoked safely from a second terminal while a batch is running.
- Adding `--watch` flag to `batch/batch-runner.sh` that detects the active runner PID via the lock file, loops every 2 seconds clearing the terminal and refreshing the status table until the process exits, then automatically runs `verify-pipeline.mjs` to validate the completed run.
- Updating `modes/batch.md` with a new "What to watch during a run" section documenting: (1) the headed Chrome Conductor window for real-time browser navigation, (2) the agent CLI conversation narration, and (3) the per-worker log files at `batch/logs/{report_num}-{id}.log`.

## Related issue

Fixes #922

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs --quick` and all tests pass (257 passed, 0 failed)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--status` flag to display batch progress summary and exit
  * Added `--watch` flag to continuously monitor batch progress until completion

* **Documentation**
  * Added guidance on monitoring batch operations with live interfaces and log file locations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->