### PR TITLE
feat(tracker): SQLite storage layer phase 2 — opt-in DB source of truth

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -22,6 +22,7 @@ import { createHash, randomUUID } from 'crypto';
 import { tmpdir } from 'os';
 import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
+import { loadSqlite, openDb, isDbSource, checkDivergence, rowToMarkdown, HEADER, SEPARATOR, DB_PATH, updateHeaderLayout } from './tracker.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original).
@@ -589,58 +590,100 @@ function parseTsvContent(content, filename) {
 
 // ---- Main ----
 
-// Read applications.md
-if (!existsSync(APPS_FILE)) {
-  console.log('No applications.md found. Nothing to merge into.');
-  process.exit(0);
-}
-const appContent = readFileSync(APPS_FILE, 'utf-8');
-// Test-only synchronization hook: the concurrent merge test waits for the
-// first worker to read the tracker while still holding the lock, then starts a
-// second worker to prove the lock prevents the old lost-update race.
-if (MERGE_READY_IPC && typeof process.send === 'function') {
-  process.send({ type: 'merge-tracker-ready' });
-}
-if (MERGE_HOLD_MS > 0) {
-  await sleep(MERGE_HOLD_MS);
+let dbIsSource = false;
+let db = null;
+try {
+  const DatabaseSync = await loadSqlite();
+  db = openDb(DatabaseSync);
+  dbIsSource = isDbSource(db);
+} catch (e) {
+  dbIsSource = false;
 }
 
-// One-time migration: rewrite existing report links so they resolve relative
-// to the tracker file's directory (see #760). Run with: node merge-tracker.mjs --migrate
+if (dbIsSource) {
+  const force = process.argv.includes('--force');
+  checkDivergence(db, force);
+}
+
 if (MIGRATE) {
-  const migrated = appContent
-    .split('\n')
-    .map(line => (line.startsWith('|') ? normalizeReportLink(line) : line));
-  const before = appContent.split('\n');
-  const changed = migrated.filter((l, i) => l !== before[i]).length;
-
-  if (DRY_RUN) {
-    console.log(`🔎 Migration (dry-run): ${changed} row(s) would be rewritten in ${basename(APPS_FILE)}`);
-  } else {
-    writeFileAtomic(APPS_FILE, migrated.join('\n'));
-    console.log(`✅ Migration: rewrote ${changed} report link(s) in ${basename(APPS_FILE)} relative to ${TRACKER_DIR === CAREER_OPS ? 'repo root' : 'data/'}`);
+  if (dbIsSource) {
+    console.error('Error: link migration (--migrate) is not supported when the database is the source of truth.');
+    process.exit(1);
   }
-  process.exit(0);
 }
 
-const appLines = appContent.split('\n');
-// Detect the tracker's column layout via header names so parsing and writing
-// both work whether the table uses the original 9-column layout or a customized
-// one (e.g. with a Location column after Role). Falls back to the legacy layout.
-COLMAP = detectColumns(appLines) || LEGACY_COLMAP;
-if (COLMAP.location != null) console.log('🧭 Detected Location column.');
+
 const existingApps = [];
 let maxNum = 0;
+let appLines = [];
 
-for (const line of appLines) {
-  if (line.startsWith('|') && !line.includes('---') && !line.includes('Empresa')) {
-    const app = parseAppLine(line);
-    if (app) {
-      existingApps.push(app);
-      if (app.num > maxNum) maxNum = app.num;
+if (dbIsSource) {
+  const rows = db.prepare('SELECT * FROM applications ORDER BY pos').all();
+  for (const r of rows) {
+    existingApps.push({
+      num: r.id,
+      date: r.date,
+      company: r.company,
+      role: r.role,
+      score: r.score,
+      status: r.status,
+      pdf: r.pdf,
+      report: r.report,
+      notes: r.notes
+    });
+    if (r.id > maxNum) maxNum = r.id;
+  }
+} else {
+  // Read applications.md
+  if (!existsSync(APPS_FILE)) {
+    console.log('No applications.md found. Nothing to merge into.');
+    process.exit(0);
+  }
+  const appContent = readFileSync(APPS_FILE, 'utf-8');
+  // Test-only synchronization hook: the concurrent merge test waits for the
+  // first worker to read the tracker while still holding the lock, then starts a
+  // second worker to prove the lock prevents the old lost-update race.
+  if (MERGE_READY_IPC && typeof process.send === 'function') {
+    process.send({ type: 'merge-tracker-ready' });
+  }
+  if (MERGE_HOLD_MS > 0) {
+    await sleep(MERGE_HOLD_MS);
+  }
+
+  // One-time migration: rewrite existing report links so they resolve relative
+  // to the tracker file's directory (see #760). Run with: node merge-tracker.mjs --migrate
+  if (MIGRATE) {
+    const migrated = appContent
+      .split('\n')
+      .map(line => (line.startsWith('|') ? normalizeReportLink(line) : line));
+    const before = appContent.split('\n');
+    const changed = migrated.filter((l, i) => l !== before[i]).length;
+
+    if (DRY_RUN) {
+      console.log(`🔎 Migration (dry-run): ${changed} row(s) would be rewritten in ${basename(APPS_FILE)}`);
+    } else {
+      writeFileAtomic(APPS_FILE, migrated.join('\n'));
+      console.log(`✅ Migration: rewrote ${changed} report link(s) in ${basename(APPS_FILE)} relative to ${TRACKER_DIR === CAREER_OPS ? 'repo root' : 'data/'}`);
+    }
+    process.exit(0);
+  }
+
+  appLines = appContent.split('\n');
+  COLMAP = detectColumns(appLines) || LEGACY_COLMAP;
+  if (COLMAP.location != null) console.log('🧭 Detected Location column.');
+  for (const line of appLines) {
+    if (line.startsWith('|') && !line.includes('---') && !line.includes('Empresa')) {
+      const app = parseAppLine(line);
+      if (app) {
+        existingApps.push(app);
+        if (app.num > maxNum) maxNum = app.num;
+      }
     }
   }
 }
+
+const dbUpdates = [];
+const dbInserts = [];
 
 console.log(`📊 Existing: ${existingApps.length} entries, max #${maxNum}`);
 
@@ -727,18 +770,30 @@ for (const file of tsvFiles) {
 
     if (newScore > oldScore) {
       console.log(`🔄 Update: #${duplicate.num} ${addition.company} — ${addition.role} (${oldScore}→${newScore})`);
-      const lineIdx = appLines.indexOf(duplicate.raw);
-      if (lineIdx >= 0) {
-        const updatedLine = buildRow({
-          num: duplicate.num, date: addition.date, company: addition.company, role: addition.role,
-          location: addition.location || duplicate.location || '—',
-          score: addition.score, status: duplicate.status, pdf: duplicate.pdf,
+      if (dbIsSource) {
+        dbUpdates.push({
+          id: duplicate.num,
+          date: addition.date,
+          company: addition.company,
+          role: addition.role,
+          score: addition.score,
           report: addition.report,
-          notes: `Re-eval ${addition.date} (${oldScore}→${newScore}). ${addition.notes}`,
+          notes: `Re-eval ${addition.date} (${oldScore}→${newScore}). ${addition.notes}`
         });
-        appLines[lineIdx] = updatedLine;
-        updated++;
+      } else {
+        const lineIdx = appLines.indexOf(duplicate.raw);
+        if (lineIdx >= 0) {
+          const updatedLine = buildRow({
+            num: duplicate.num, date: addition.date, company: addition.company, role: addition.role,
+            location: addition.location || duplicate.location || '—',
+            score: addition.score, status: duplicate.status, pdf: duplicate.pdf,
+            report: addition.report,
+            notes: `Re-eval ${addition.date} (${oldScore}→${newScore}). ${addition.notes}`,
+          });
+          appLines[lineIdx] = updatedLine;
+        }
       }
+      updated++;
     } else {
       console.log(`⏭️  Skip: ${addition.company} — ${addition.role} (existing #${duplicate.num} ${oldScore} >= new ${newScore})`);
       skipped++;
@@ -748,13 +803,28 @@ for (const file of tsvFiles) {
     const entryNum = addition.num > maxNum ? addition.num : ++maxNum;
     if (addition.num > maxNum) maxNum = addition.num;
 
-    const newLine = buildRow({
-      num: entryNum, date: addition.date, company: addition.company, role: addition.role,
-      location: addition.location || '—',
-      score: addition.score, status: addition.status, pdf: addition.pdf,
-      report: addition.report, notes: addition.notes,
-    });
-    newLines.push(newLine);
+    if (dbIsSource) {
+      dbInserts.push({
+        id: entryNum,
+        pos: existingApps.length + dbInserts.length,
+        date: addition.date,
+        company: addition.company,
+        role: addition.role,
+        score: addition.score,
+        status: addition.status,
+        pdf: addition.pdf,
+        report: addition.report,
+        notes: addition.notes
+      });
+    } else {
+      const newLine = buildRow({
+        num: entryNum, date: addition.date, company: addition.company, role: addition.role,
+        location: addition.location || '—',
+        score: addition.score, status: addition.status, pdf: addition.pdf,
+        report: addition.report, notes: addition.notes,
+      });
+      newLines.push(newLine);
+    }
     added++;
     console.log(`➕ Add #${entryNum}: ${addition.company} — ${addition.role} (${addition.score})`);
   }
@@ -775,9 +845,44 @@ if (newLines.length > 0) {
   }
 }
 
+
 // Write back
 if (!DRY_RUN) {
-  writeFileAtomic(APPS_FILE, appLines.join('\n'));
+  if (dbIsSource) {
+    db.exec('BEGIN');
+    try {
+      const updateStmt = db.prepare('UPDATE applications SET date = ?, company = ?, role = ?, score = ?, report = ?, notes = ? WHERE id = ?');
+      for (const u of dbUpdates) {
+        updateStmt.run(u.date, u.company, u.role, u.score, u.report, u.notes, u.id);
+      }
+      const insertStmt = db.prepare('INSERT INTO applications (id, pos, date, company, role, score, status, pdf, report, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+      const insertEvent = db.prepare('INSERT INTO status_events (app_id, status, date) VALUES (?, ?, ?)');
+      for (const i of dbInserts) {
+        insertStmt.run(i.id, i.pos, i.date, i.company, i.role, i.score, i.status, i.pdf, i.report, i.notes);
+        insertEvent.run(i.id, i.status, i.date);
+      }
+      db.exec('COMMIT');
+    } catch (err) {
+      db.exec('ROLLBACK');
+      throw err;
+    }
+
+    const rows = db.prepare('SELECT * FROM applications ORDER BY pos').all();
+    const out = [
+      '# Applications Tracker',
+      '',
+      HEADER,
+      SEPARATOR,
+      ...rows.map(rowToMarkdown),
+      '',
+    ].join('\n');
+    writeFileAtomic(APPS_FILE, out);
+
+    const mdHash = createHash('sha256').update(out).digest('hex');
+    db.prepare("INSERT INTO meta (key, value) VALUES ('md_sha256', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value").run(mdHash);
+  } else {
+    writeFileAtomic(APPS_FILE, appLines.join('\n'));
+  }
 
   // Move processed files to merged/
   if (!existsSync(MERGED_DIR)) mkdirSync(MERGED_DIR, { recursive: true });

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3071,6 +3071,147 @@ if (!sqliteAvailable) {
   }
 }
 
+// ── 15b. TRACKER DB SOURCE OF TRUTH (#918 phase 2) ──────────────────
+// opt-in DB source-of-truth mode. migrate command imports markdown, activates
+// DB-first mode, and renders applications.md. merge-tracker writes to the DB
+// and re-renders applications.md. rollback-migration reverts back.
+// Any manual edit to applications.md in DB-first mode must be detected as a
+// divergence, blocking further writes unless --force is passed.
+
+console.log('\n15b. Tracker DB source of truth (migrate, rollback, merge write-through, divergence guard)');
+
+if (!sqliteAvailable) {
+  warn('node:sqlite unavailable (Node < 22.5) — tracker Phase 2 tests skipped');
+} else {
+  try {
+    const sqlite = await import('node:sqlite');
+    const idxTmp2 = mkdtempSync(join(tmpdir(), 'career-ops-db-first-'));
+    try {
+      const md = join(idxTmp2, 'applications.md');
+      const env = { ...process.env, CAREER_OPS_TRACKER: md };
+      const trackerRun = (args) => run(NODE, ['tracker.mjs', ...args], { env, stdio: ['pipe', 'pipe', 'pipe'] });
+
+      const clean =
+        '# Applications Tracker\n\n' +
+        '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+        '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+        '| 2 | 2026-01-05 | Beta | Designer | 4.0/5 | Applied | ✅ | [2](../reports/002-beta-2026-01-05.md) | second |\n' +
+        '| 1 | 2026-01-04 | Acme | Engineer | 4.2/5 | Evaluated | ❌ | [1](../reports/001-acme-2026-01-04.md) | first |\n';
+      writeFileSync(md, clean);
+
+      // Initialize derived index
+      trackerRun(['sync']);
+
+      // 1. Migrate to DB source of truth
+      if (trackerRun(['migrate']) === null) {
+        fail('tracker migrate command crashed');
+      } else {
+        pass('tracker migrate command succeeds');
+      }
+
+      const dbFile = md.replace('.md', '.db');
+      const testDb = new sqlite.DatabaseSync(dbFile);
+      const sot = testDb.prepare("SELECT value FROM meta WHERE key = 'source_of_truth'").get();
+      if (sot && sot.value === 'db') {
+        pass('migration correctly sets source_of_truth to db');
+      } else {
+        fail('migration did not set source_of_truth to db');
+      }
+      testDb.close();
+
+      // 2. Verify merge-tracker writes to DB in source-of-truth mode
+      const additionsDir = join(idxTmp2, 'batch', 'tracker-additions');
+      mkdirSync(additionsDir, { recursive: true });
+      writeFileSync(join(additionsDir, '004-gamma.tsv'),
+        '4\t2026-01-08\tGamma\tQA\tEvaluated\t4.4/5\t❌\t[4](../reports/004-gamma-2026-01-08.md)\tnew row\n'
+      );
+
+      const mergeResult = run(NODE, ['merge-tracker.mjs'], {
+        env: {
+          ...env,
+          CAREER_OPS_ADDITIONS: additionsDir
+        }
+      });
+      if (mergeResult === null) {
+        fail('merge-tracker crashed in db-first mode');
+      } else {
+        pass('merge-tracker runs successfully in db-first mode');
+      }
+
+      const testDb2 = new sqlite.DatabaseSync(dbFile);
+      const row = testDb2.prepare("SELECT * FROM applications WHERE id = 4").get();
+      if (row && row.company === 'Gamma' && row.role === 'QA' && row.score === '4.4/5') {
+        pass('merge-tracker writes through to DB in source-of-truth mode');
+      } else {
+        fail('merge-tracker did not write through to DB in source-of-truth mode');
+      }
+      testDb2.close();
+
+      // Verify applications.md was updated (rendered view)
+      let mdContent = readFileSync(md, 'utf-8');
+      if (mdContent.includes('Gamma') && mdContent.includes('QA') && mdContent.includes('4.4/5')) {
+        pass('merge-tracker updates applications.md rendered view in source-of-truth mode');
+      } else {
+        fail('merge-tracker did not update applications.md rendered view');
+      }
+
+      // 3. Divergence Guard test (silent data loss prevention)
+      // Manually edit applications.md to cause a hash mismatch
+      writeFileSync(md, mdContent + '| 5 | 2026-01-09 | Manual | Edit | 1.0/5 | Evaluated | ❌ | — | hand edited |\n');
+
+      // Attempt to run merge-tracker again without --force (should fail/abort)
+      const additionsDir2 = join(idxTmp2, 'batch', 'tracker-additions-2');
+      mkdirSync(additionsDir2, { recursive: true });
+      writeFileSync(join(additionsDir2, '006-invalid.tsv'),
+        '6\t2026-01-10\tInvalid\tRole\tEvaluated\t3.0/5\t❌\t—\tshould fail\n'
+      );
+      const mergeDiverged = run(NODE, ['merge-tracker.mjs'], {
+        env: {
+          ...env,
+          CAREER_OPS_ADDITIONS: additionsDir2
+        },
+        stdio: ['pipe', 'pipe', 'pipe']
+      });
+      if (mergeDiverged === null) {
+        pass('merge-tracker aborts when markdown has diverged (prevents data loss)');
+      } else {
+        fail('merge-tracker did not abort on diverged markdown');
+      }
+
+      // Attempt to run rollback-migration without --force (should fail/abort)
+      const rollbackDiverged = run(NODE, ['tracker.mjs', 'rollback-migration'], { env, stdio: ['pipe', 'pipe', 'pipe'] });
+      if (rollbackDiverged === null) {
+        pass('rollback-migration aborts when markdown has diverged (prevents data loss)');
+      } else {
+        fail('rollback-migration did not abort on diverged markdown');
+      }
+
+      // Run rollback-migration WITH --force (should succeed)
+      const rollbackForced = run(NODE, ['tracker.mjs', 'rollback-migration', '--force'], { env, stdio: ['pipe', 'pipe', 'pipe'] });
+      if (rollbackForced !== null) {
+        pass('rollback-migration with --force bypasses divergence check and succeeds');
+      } else {
+        fail('rollback-migration with --force failed to execute');
+      }
+
+      // Verify source_of_truth key is removed after successful rollback
+      const testDb3 = new sqlite.DatabaseSync(dbFile);
+      const sotRollback = testDb3.prepare("SELECT value FROM meta WHERE key = 'source_of_truth'").get();
+      if (!sotRollback) {
+        pass('rollback correctly removes source_of_truth key');
+      } else {
+        fail('rollback did not remove source_of_truth key');
+      }
+      testDb3.close();
+
+    } finally {
+      rmSync(idxTmp2, { recursive: true, force: true });
+    }
+  } catch (e) {
+    fail(`tracker Phase 2 tests crashed: ${e.message}`);
+  }
+}
+
 // ── 12b. PLAYWRIGHT MCP DETECTION WARNING (#522) ────────────────
 
 console.log('\n12d. Playwright MCP detection warning');

--- a/tracker.mjs
+++ b/tracker.mjs
@@ -41,7 +41,7 @@ import { pathToFileURL } from 'url';
 import yaml from 'js-yaml';
 
 const MD_PATH = process.env.CAREER_OPS_TRACKER || 'data/applications.md';
-const DB_PATH = process.env.CAREER_OPS_TRACKER_DB
+export const DB_PATH = process.env.CAREER_OPS_TRACKER_DB
   || (MD_PATH.endsWith('.md') ? MD_PATH.slice(0, -3) + '.db' : MD_PATH + '.db');
 
 // SQLite must never open the source of truth itself (an explicit
@@ -51,12 +51,51 @@ if (resolve(MD_PATH) === resolve(DB_PATH)) {
   process.exit(1);
 }
 const STATES_PATH = 'templates/states.yml';
-const HEADER = '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |';
-const SEPARATOR = '|---|------|---------|------|-------|--------|-----|--------|-------|';
+
+export const LEGACY_COLMAP = { num: 1, date: 2, company: 3, role: 4, score: 5, status: 6, pdf: 7, report: 8, notes: 9 };
+export const HEADER_ALIASES = {
+  '#': 'num', 'num': 'num', 'date': 'date', 'company': 'company', 'empresa': 'company',
+  'role': 'role', 'puesto': 'role', 'location': 'location', 'score': 'score',
+  'status': 'status', 'pdf': 'pdf', 'report': 'report', 'notes': 'notes',
+};
+
+/**
+ * Detects the column mapping from markdown lines by looking for a header row.
+ * @param {string[]} lines - Markdown file lines.
+ * @returns {object|null} A map of header name to column index, or null if invalid.
+ */
+export function detectColumns(lines) {
+  for (const line of lines) {
+    if (!line.startsWith('|')) continue;
+    const cells = line.split('|').map(s => s.trim().toLowerCase());
+    if (!cells.includes('company') || !cells.includes('role')) continue;
+    const map = {};
+    cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
+    if (['num', 'company', 'role', 'score', 'status'].every(k => map[k] != null)) return map;
+  }
+  return null;
+}
+
+/**
+ * Updates the global HEADER and SEPARATOR layout based on the column map.
+ * @param {object} colmap - The column map.
+ */
+export function updateHeaderLayout(colmap) {
+  if (colmap.location != null) {
+    HEADER = '| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |';
+    SEPARATOR = '|---|------|---------|------|----------|-------|--------|-----|--------|-------|';
+  } else {
+    HEADER = '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |';
+    SEPARATOR = '|---|------|---------|------|-------|--------|-----|--------|-------|';
+  }
+}
+
+export let HEADER = '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |';
+export let SEPARATOR = '|---|------|---------|------|-------|--------|-----|--------|-------|';
 
 // ── node:sqlite loading ─────────────────────────────────────────────
 
-async function loadSqlite() {
+export async function loadSqlite() {
   // node:sqlite is stable in behavior but still flagged experimental in some
   // Node lines — silence only that one warning, leave everything else alone.
   const origEmit = process.emitWarning;
@@ -77,7 +116,7 @@ async function loadSqlite() {
   }
 }
 
-function openDb(DatabaseSync) {
+export function openDb(DatabaseSync) {
   mkdirSync(dirname(DB_PATH) || '.', { recursive: true });
   const db = new DatabaseSync(DB_PATH);
   db.exec('PRAGMA foreign_keys = ON'); // SQLite ignores REFERENCES without this
@@ -113,7 +152,7 @@ function openDb(DatabaseSync) {
 
 // ── Canonical states (templates/states.yml is the source of truth) ──
 
-function loadStates() {
+export function loadStates() {
   if (!existsSync(STATES_PATH)) {
     console.error(`Error: ${STATES_PATH} not found — cannot validate statuses. Run from the career-ops root.`);
     process.exit(1);
@@ -133,7 +172,7 @@ function loadStates() {
 
 // Strip markdown bold, trailing dates, and surrounding noise, then resolve
 // against canonical labels/aliases. Returns the canonical label or null.
-function normalizeStatus(raw, states) {
+export function normalizeStatus(raw, states) {
   if (!raw) return null;
   const cleaned = String(raw)
     .replace(/\*\*/g, '')
@@ -310,12 +349,21 @@ function syncIndex(db, states) {
   return { apps, diag };
 }
 
-async function sync(args) {
+export async function sync(args) {
   if (!existsSync(MD_PATH)) {
     console.error(`Error: ${MD_PATH} not found — nothing to index.`);
     process.exit(1);
   }
   const states = loadStates();
+
+  const DatabaseSync = await loadSqlite();
+  const db = openDb(DatabaseSync);
+
+  if (isDbSource(db) && !args.includes('--force') && !args.includes('--check')) {
+    console.error('Error: Database is currently the source of truth. Running sync could overwrite newer database data with markdown.');
+    console.error('If you really want to sync from markdown to DB, run with `node tracker.mjs sync --force`.');
+    process.exit(1);
+  }
 
   if (args.includes('--check')) {
     const { apps, diag } = parseTracker(states);
@@ -325,8 +373,6 @@ async function sync(args) {
     process.exit(issues > 0 ? 1 : 0);
   }
 
-  const DatabaseSync = await loadSqlite();
-  const db = openDb(DatabaseSync);
   const { apps, diag } = syncIndex(db, states);
   console.error(`Indexed ${apps.length} applications from ${MD_PATH} into ${DB_PATH}`);
   reportDiagnostics(diag);
@@ -334,7 +380,8 @@ async function sync(args) {
 
 // query/history must never serve stale reads: if the markdown changed since
 // the last sync (or was never synced), rebuild the index first.
-function ensureFresh(db, states) {
+export function ensureFresh(db, states) {
+  if (isDbSource(db)) return; // DB is source of truth, no resync from markdown!
   if (!existsSync(MD_PATH)) {
     console.error(`Error: ${MD_PATH} not found — the index has no source of truth to read from.`);
     process.exit(1);
@@ -354,7 +401,7 @@ function flagValue(args, flag) {
   return kv ? kv.split('=').slice(1).join('=') : null;
 }
 
-function rowToMarkdown(r) {
+export function rowToMarkdown(r) {
   const clean = (v) => String(v ?? '').replace(/\|/g, '│').replace(/\r?\n/g, ' ');
   return `| ${r.id} | ${clean(r.date)} | ${clean(r.company)} | ${clean(r.role)} | ${clean(r.score)} | ${clean(r.status)} | ${clean(r.pdf)} | ${clean(r.report)} | ${clean(r.notes)} |`;
 }
@@ -421,7 +468,7 @@ async function history(args) {
 // a repaired copy the user can review and adopt by hand. It never touches
 // applications.md unless explicitly asked to via --out.
 
-async function exportMd(args) {
+export async function exportMd(args) {
   const DatabaseSync = await loadSqlite();
   const db = openDb(DatabaseSync);
   ensureFresh(db, loadStates());
@@ -452,6 +499,105 @@ async function exportMd(args) {
   }
   writeFileSync(outPath, out, 'utf-8');
   console.error(`Exported ${rows.length} applications to ${outPath}`);
+}
+
+
+/**
+ * Checks if the SQLite database is currently the source of truth.
+ * @param {any} db - SQLite database instance.
+ * @returns {boolean} True if the DB is the source of truth, false otherwise.
+ */
+export function isDbSource(db) {
+  try {
+    const row = db.prepare("SELECT value FROM meta WHERE key = 'source_of_truth'").get();
+    return row?.value === 'db';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks for divergence between markdown file and database, aborting if found.
+ * @param {any} db - SQLite database instance.
+ * @param {boolean} [force=false] - If true, bypasses the check.
+ */
+export function checkDivergence(db, force = false) {
+  if (!isDbSource(db)) return;
+  if (force) return;
+  const synced = db.prepare("SELECT value FROM meta WHERE key = 'md_sha256'").get();
+  const currentHash = existsSync(MD_PATH) ? mdHash() : null;
+  if (currentHash !== null && (!synced || !synced.value || synced.value !== currentHash)) {
+    console.error('Error: applications.md has been modified directly on disk and has diverged from the SQLite database.');
+    console.error('To resolve this:');
+    console.error('  1. If you want to overwrite your manual markdown edits with the database state, run the command again with --force.');
+    console.error('  2. If you want to import your manual markdown edits into the database, run `node tracker.mjs sync --force`.');
+    process.exit(1);
+  }
+}
+
+/**
+ * Command: Migrates the tracker from markdown-first to DB-first mode.
+ * @param {string[]} args - CLI arguments.
+ * @returns {Promise<void>}
+ */
+export async function migrate(args) {
+  const DatabaseSync = await loadSqlite();
+  const db = openDb(DatabaseSync);
+  const states = loadStates();
+
+  if (isDbSource(db)) {
+    console.error('Error: Database is already the source of truth.');
+    process.exit(1);
+  }
+
+  console.error('Migrating: syncing database from applications.md first...');
+  // Force a sync to make sure the DB has all latest data
+  syncIndex(db, states);
+
+  // Set source of truth to 'db'
+  db.prepare("INSERT INTO meta (key, value) VALUES ('source_of_truth', 'db') ON CONFLICT(key) DO UPDATE SET value = excluded.value").run();
+
+  // Export back to applications.md so it is canonical/rendered
+  console.error(`Rewriting ${MD_PATH} to be the rendered view of the database...`);
+  await exportMd(['--out', MD_PATH]);
+
+  // Update md_sha256 meta key to match the new markdown file hash
+  db.prepare("INSERT INTO meta (key, value) VALUES ('md_sha256', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+    .run(mdHash());
+
+  console.log('Migration successful. The SQLite database at ' + DB_PATH + ' is now the source of truth.');
+  console.log(MD_PATH + ' has been updated and is now a rendered view.');
+  console.log('Deleting the database file will revert the source of truth back to ' + MD_PATH + '.');
+}
+
+/**
+ * Command: Rolls back from DB-first mode to markdown-first mode.
+ * @param {string[]} args - CLI arguments.
+ * @returns {Promise<void>}
+ */
+export async function rollbackMigration(args) {
+  const DatabaseSync = await loadSqlite();
+  const db = openDb(DatabaseSync);
+
+  if (!isDbSource(db)) {
+    console.error('Error: Database is not currently the source of truth.');
+    process.exit(1);
+  }
+
+  checkDivergence(db, args.includes('--force'));
+
+  console.error('Rolling back: exporting database to applications.md to ensure it is fresh...');
+  await exportMd(['--out', MD_PATH, ...(args.includes('--force') ? ['--force'] : [])]);
+
+  // Remove source of truth key
+  db.prepare("DELETE FROM meta WHERE key = 'source_of_truth'").run();
+
+  // Update md_sha256 key
+  db.prepare("INSERT INTO meta (key, value) VALUES ('md_sha256', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+    .run(mdHash());
+
+  console.log('Rollback successful. ' + MD_PATH + ' is now the source of truth again.');
+  console.log('The database at ' + DB_PATH + ' is now a derived index.');
 }
 
 // ── Main ────────────────────────────────────────────────────────────
@@ -510,13 +656,24 @@ async function deleteApp(args) {
   if (report) console.error(`Note: report file may now be orphaned — ${report}`);
 }
 
-const COMMANDS = { sync, query, history, export: exportMd, delete: deleteApp };
+const COMMANDS = {
+  sync,
+  query,
+  history,
+  export: exportMd,
+  migrate,
+  'rollback-migration': rollbackMigration,
+  delete: deleteApp
+};
 
 async function main() {
-  const [command, ...args] = process.argv.slice(2);
+  let [command, ...args] = process.argv.slice(2);
+  if (command === 'migrate' && args.includes('--rollback')) {
+    command = 'rollback-migration';
+  }
   const fn = COMMANDS[command];
   if (!fn) {
-    console.log('Usage: node tracker.mjs <sync|query|history|export|delete> [flags]');
+    console.log('Usage: node tracker.mjs <sync|query|history|export|migrate|rollback-migration|delete> [flags]');
     console.log('See the header comment of this file for examples, or docs/SCRIPTS.md.');
     process.exit(command ? 1 : 0);
   }


### PR DESCRIPTION
## What does this PR do?

This PR implements Phase 2 of the SQLite storage layer, making the database an opt-in source of truth (with `applications.md` as the rendered view), by:

- Adding `node tracker.mjs migrate` command to `tracker.mjs` that syncs the current `applications.md` into SQLite, sets `source_of_truth = 'db'` in the `meta` table, re-renders `applications.md` from the database as a canonical view, and updates the stored `md_sha256` hash.
- Adding `node tracker.mjs rollback-migration` command (also aliased as `node tracker.mjs migrate --rollback`) that exports the latest DB state back to `applications.md`, removes the `source_of_truth` meta key, and updates the hash — reverting back to markdown-first mode.
- Guarding `sync` in `tracker.mjs` to refuse overwriting a DB-source-of-truth setup unless `--force` is explicitly passed.
- Short-circuiting `ensureFresh` in `tracker.mjs` to skip markdown hash checks when the DB is the source of truth (reads come from the DB, not the file).
- Exporting helpers (`openDb`, `loadSqlite`, `loadStates`, `normalizeStatus`, `rowToMarkdown`, `exportMd`, `isDbSource`) from `tracker.mjs` so downstream scripts can share them without re-implementing.
- Updating `merge-tracker.mjs` to detect DB source-of-truth mode via `isDbSource()`, perform dedup checks and inserts/updates directly on the SQLite database, and atomically re-render `applications.md` from the DB after every merge.
- Updating `test-all.mjs` with new test cases covering: `migrate` command success, `source_of_truth` meta key verification, `merge-tracker` DB write-through, `applications.md` rendered-view update, and `rollback-migration` round-trip — plus Windows compatibility fixes for `chmod`, CRLF line endings in WSL `bash`, and PATH separator handling.

## Related issue

Part of #918

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs --quick` and all tests pass (257 passed, 0 failed)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in SQLite-first workflow with `migrate` and `rollback-migration`, including DB-backed merges and rendered `applications.md` view behavior.
* **Bug Fixes**
  * Improved divergence protection for canonical `applications.md` exports and safer DB write behavior (transactional updates/inserts).
  * Enhanced Windows path handling for file resolution and symlink integrity checks.
* **Tests**
  * Added end-to-end coverage for DB source-of-truth, merge write-through, divergence/rollback behavior, and Windows portability.
* **Documentation**
  * Updated `tracker` script docs to reflect Phase 2 `migrate`/`rollback-migration` support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->