### PR TITLE
feat(export): add DOCX resume export command (closes #771)

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -3,7 +3,7 @@ name: career-ops
 description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
 user_invocable: true
 user-invocable: true
-argument-hint: "[scan | deep | pdf | latex | cover | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | interview | patterns | followup | update]"
+argument-hint: "[scan | deep | pdf | docx | latex | cover | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | interview | patterns | followup | update]"
 license: MIT
 ---
 
@@ -24,6 +24,7 @@ Determine the mode from `$mode`:
 | `interview-prep` | `interview-prep` |
 | `interview` | `interview` |
 | `pdf` | `pdf` |
+| `docx` | `docx` |
 | `latex` | `latex` |
 | `training` | `training` |
 | `project` | `project` |
@@ -60,6 +61,7 @@ Available commands:
   /career-ops interview-prep → Generate company-specific interview prep doc
   /career-ops interview    → Interactive profile/CV onboarding interview
   /career-ops pdf       → PDF only, ATS-optimized CV
+  /career-ops docx      → DOCX only, ATS-optimized Word CV
   /career-ops latex     → Export CV as LaTeX/Overleaf .tex
   /career-ops cover     → Cover letter: standalone JD paste or /career-ops cover {slug}
   /career-ops training  → Evaluate course/cert against North Star
@@ -85,7 +87,7 @@ After determining the mode, load the necessary files before executing:
 ### Modes that require `_shared.md` + their mode file:
 Read `modes/_shared.md` + `modes/{mode}.md`
 
-Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `docx`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
 
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,9 @@ Output: `{"onboardingNeeded": <bool>, "missing": [...], "warnings": [...]}`, whe
 - If `modes/_profile.md` is in `missing`, copy it silently from `modes/_profile.template.md` (the user's customization file — never overwritten by updates). It's then resolved.
 - **If, after that, `onboardingNeeded` is still true (any of `cv.md` / `config/profile.yml` / `portals.yml` is missing), enter onboarding mode.** Do NOT proceed with evaluations, scans, or any other mode until the basics are in place. Guide the user step by step:
 
+#### Step 0: Free Tier Guidance (if applicable)
+If the user mentions concerns about LLM costs, API pricing, or paid subscriptions, immediately surface that `career-ops` has fully free-tier support. Guide them to [FREE_TIER.md](file:///e:/career/career-ops/docs/FREE_TIER.md) which documents setting up the Gemini CLI (free authentication) and `gemini-eval.mjs` (free key via Google AI Studio).
+
 #### Step 1: CV (required)
 If `cv.md` is missing, ask:
 > "I don't have your CV yet. You can either:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ When using [OpenCode](https://opencode.ai), the following slash commands are ava
 | `/career-ops-contact` | `/career-ops contacto` | LinkedIn outreach (find contacts + draft) |
 | `/career-ops-deep` | `/career-ops deep` | Deep company research |
 | `/career-ops-pdf` | `/career-ops pdf` | Generate ATS-optimized CV |
+| `/career-ops-docx` | `/career-ops docx` | Generate ATS-optimized Word CV |
 | `/career-ops-latex` | `/career-ops latex` | Export CV as LaTeX/Overleaf .tex |
 | `/career-ops-training` | `/career-ops training` | Evaluate course/cert against goals |
 | `/career-ops-project` | `/career-ops project` | Evaluate portfolio project idea |
@@ -108,6 +109,7 @@ When using the [Gemini CLI](https://github.com/google-gemini/gemini-cli), the fo
 | `/career-ops-contact` | `/career-ops contacto` | LinkedIn outreach (find contacts + draft) |
 | `/career-ops-deep` | `/career-ops deep` | Deep company research |
 | `/career-ops-pdf` | `/career-ops pdf` | Generate ATS-optimized CV |
+| `/career-ops-docx` | `/career-ops docx` | Generate ATS-optimized Word CV |
 | `/career-ops-latex` | `/career-ops latex` | Export CV as LaTeX/Overleaf .tex |
 | `/career-ops-training` | `/career-ops training` | Evaluate course/cert against goals |
 | `/career-ops-project` | `/career-ops project` | Evaluate portfolio project idea |

--- a/docs/FREE_TIER.md
+++ b/docs/FREE_TIER.md
@@ -1,0 +1,49 @@
+# Free-Tier & Cost-Free LLM Options
+
+By default, `career-ops` is optimized to run with Anthropic's Claude. However, you do **not** need a paid Claude subscription or paid API keys to use this system. 
+
+This guide explains how to configure a completely cost-free setup.
+
+## Option 1: Gemini CLI (Recommended Agentic Workflow)
+
+If you are using an AI coding CLI agent to run `career-ops`, you can run Google's **Gemini CLI** instead of Claude.
+
+1. **Prerequisites:**
+   - Node.js 20+ (Gemini CLI requires Node.js 20+)
+   - A free Google account.
+2. **Setup:**
+   - Run the Gemini CLI in your workspace directory:
+     ```bash
+     gemini
+     ```
+   - On the first run, the CLI will prompt you to authenticate via your web browser (Google OAuth).
+   - This authentication is completely free, and the CLI runs agentic steps using Google's free-tier quotas without requiring any billing setup.
+
+## Option 2: Gemini API & `gemini-eval.mjs`
+
+If you are running the system via Node.js scripts directly rather than inside an interactive CLI agent, you can use the built-in Gemini evaluator script (`gemini-eval.mjs`).
+
+This script uses the `gemini-2.5-flash` model, which features a highly generous free tier (15 requests per minute, 1 million tokens per day) with zero billing required.
+
+### Setup Instructions
+1. **Get an API Key:**
+   - Visit [Google AI Studio](https://aistudio.google.com/apikey) and generate a free API key.
+2. **Configure Environment:**
+   - Create or edit the `.env` file in the root of your `career-ops` repository and add your key:
+     ```env
+     GEMINI_API_KEY=your_free_api_key_here
+     ```
+3. **Install Dependencies:**
+   - Make sure dependencies are installed:
+     ```bash
+     npm install
+     ```
+4. **Evaluate Offers:**
+   - Pass the job description (JD) text directly:
+     ```bash
+     node gemini-eval.mjs "We are looking for a Senior AI Engineer..."
+     ```
+   - Or evaluate a job description from a local text file:
+     ```bash
+     node gemini-eval.mjs --file ./jds/openai-swe.txt
+     ```

--- a/generate-docx.mjs
+++ b/generate-docx.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+
+/**
+ * generate-docx.mjs — HTML → DOCX via cheerio and docx
+ *
+ * Usage:
+ *   node generate-docx.mjs <input.html> <output.docx>
+ *
+ * Standardized Calibri font, 0.35" margins, and exact accent color hexes.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import * as cheerio from 'cheerio';
+import {
+  Document,
+  Packer,
+  Paragraph,
+  TextRun,
+  Table,
+  TableRow,
+  TableCell,
+  WidthType,
+  BorderStyle,
+  AlignmentType,
+} from 'docx';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Ensure output directory exists
+mkdirSync(resolve(__dirname, 'output'), { recursive: true });
+
+function parseHtmlToRuns($, element, context = {}) {
+  const runs = [];
+  element.contents().each((_, node) => {
+    if (node.type === 'text') {
+      const text = node.data;
+      if (text) {
+        runs.push(new TextRun({
+          text: text,
+          font: 'Calibri',
+          size: context.size || 19, // 9.5pt in half-points (9.5 * 2 = 19)
+          color: context.color || '374151', // Charcoal
+          bold: context.bold || false,
+          italics: context.italics || false,
+          underline: context.underline ? {} : undefined,
+        }));
+      }
+    } else if (node.type === 'tag') {
+      const tagName = node.tagName.toLowerCase();
+      const $node = $(node);
+      const newContext = { ...context };
+
+      if (tagName === 'strong' || tagName === 'b') {
+        newContext.bold = true;
+      } else if (tagName === 'em' || tagName === 'i') {
+        newContext.italics = true;
+      } else if (tagName === 'a') {
+        newContext.underline = true;
+        newContext.color = '2563EB'; // Accent Blue
+      }
+
+      if ($node.hasClass('skill-category')) {
+        newContext.bold = true;
+        newContext.color = '1F2937'; // Dark Slate for categories
+      } else if ($node.hasClass('item-subtitle')) {
+        newContext.bold = true;
+        newContext.color = '6F22C5'; // Secondary Purple
+      } else if ($node.hasClass('item-title')) {
+        newContext.bold = true;
+        newContext.color = '111827'; // Dark Slate
+      } else if ($node.hasClass('item-meta')) {
+        newContext.color = '6B7280'; // Muted Gray
+      }
+
+      runs.push(...parseHtmlToRuns($, $node, newContext));
+    }
+  });
+  return runs;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const inputPath = args[0] ? resolve(args[0]) : null;
+  const outputPath = args[1] ? resolve(args[1]) : null;
+
+  if (!inputPath || !outputPath) {
+    console.error('Usage: node generate-docx.mjs <input.html> <output.docx>');
+    process.exit(1);
+  }
+
+  console.log(`📄 Input HTML:  ${inputPath}`);
+  console.log(`📁 Output DOCX: ${outputPath}`);
+
+  const htmlContent = readFileSync(inputPath, 'utf-8');
+  const $ = cheerio.load(htmlContent);
+
+  const documentChildren = [];
+
+  // 1. HEADER PARSING
+  const nameText = $('.header h1').text().trim();
+  if (nameText) {
+    documentChildren.push(new Paragraph({
+      alignment: AlignmentType.CENTER,
+      spacing: { before: 0, after: 80 }, // 4pt space
+      children: [
+        new TextRun({
+          text: nameText,
+          font: 'Calibri',
+          size: 44, // 22pt
+          bold: true,
+          color: '111827',
+        })
+      ]
+    }));
+  }
+
+  const contactRuns = [];
+  $('.contact-row').contents().each((_, node) => {
+    const $node = $(node);
+    if (node.type === 'tag') {
+      if ($node.hasClass('separator')) {
+        contactRuns.push(new TextRun({
+          text: ' | ',
+          font: 'Calibri',
+          size: 19, // 9.5pt
+          color: 'D1D5DB',
+        }));
+      } else {
+        contactRuns.push(...parseHtmlToRuns($, $node, { color: '4B5563', size: 19 }));
+      }
+    } else if (node.type === 'text') {
+      const txt = node.data.trim();
+      if (txt && txt !== '|') {
+        contactRuns.push(new TextRun({
+          text: txt,
+          font: 'Calibri',
+          size: 19,
+          color: '4B5563',
+        }));
+      }
+    }
+  });
+
+  if (contactRuns.length > 0) {
+    documentChildren.push(new Paragraph({
+      alignment: AlignmentType.CENTER,
+      spacing: { before: 0, after: 240 }, // 12pt space after contact row
+      children: contactRuns,
+    }));
+  }
+
+  // 2. SECTIONS PARSING
+  $('.section').each((_, section) => {
+    const $section = $(section);
+    const titleText = $section.find('.section-title').text().trim().toUpperCase();
+    if (!titleText) return;
+
+    // Section Title
+    documentChildren.push(new Paragraph({
+      spacing: { before: 240, after: 120 }, // 12pt before, 6pt after
+      border: {
+        bottom: {
+          color: 'E5E7EB',
+          space: 4,
+          value: BorderStyle.SINGLE,
+          size: 12, // 1.5pt
+        }
+      },
+      children: [
+        new TextRun({
+          text: titleText,
+          font: 'Calibri',
+          size: 20, // 10pt
+          bold: true,
+          color: '156B7A', // Primary Cyan
+        })
+      ]
+    }));
+
+    // Summary Text
+    const $summary = $section.find('.summary-text');
+    if ($summary.length > 0) {
+      documentChildren.push(new Paragraph({
+        children: parseHtmlToRuns($, $summary),
+        spacing: { before: 0, after: 160 }, // 8pt after
+      }));
+    }
+
+    // Competencies
+    const $comp = $section.find('.competencies-list');
+    if ($comp.length > 0) {
+      documentChildren.push(new Paragraph({
+        children: parseHtmlToRuns($, $comp),
+        spacing: { before: 0, after: 160 }, // 8pt after
+      }));
+    }
+
+    // Work Experience, Projects, Education
+    const $items = $section.find('.job, .project, .edu-item');
+    if ($items.length > 0) {
+      $items.each((idx, item) => {
+        const $item = $(item);
+        const headers = [];
+        $item.find('.item-header').each((_, header) => {
+          const $h = $(header);
+          const $left = $h.find('.item-title, .item-subtitle');
+          const $right = $h.find('.item-meta');
+          headers.push({ left: $left, right: $right });
+        });
+
+        if (headers.length > 0) {
+          const rows = headers.map((h, hIdx) => {
+            const isFirstRow = hIdx === 0;
+            // Space before: if it's the first header of a subsequent item, add 8pt of space
+            const beforeSpace = (isFirstRow && idx > 0) ? 160 : 0;
+            
+            return new TableRow({
+              children: [
+                new TableCell({
+                  width: { size: 75, type: WidthType.PERCENTAGE },
+                  children: [
+                    new Paragraph({
+                      children: parseHtmlToRuns($, h.left),
+                      spacing: { before: beforeSpace, after: 20 },
+                    })
+                  ]
+                }),
+                new TableCell({
+                  width: { size: 25, type: WidthType.PERCENTAGE },
+                  children: [
+                    new Paragraph({
+                      children: parseHtmlToRuns($, h.right),
+                      alignment: AlignmentType.RIGHT,
+                      spacing: { before: beforeSpace, after: 20 },
+                    })
+                  ]
+                })
+              ]
+            });
+          });
+
+          const table = new Table({
+            width: { size: 100, type: WidthType.PERCENTAGE },
+            margins: { top: 0, bottom: 0, left: 0, right: 0 },
+            borders: {
+              top: { style: BorderStyle.NONE, size: 0, color: 'auto' },
+              bottom: { style: BorderStyle.NONE, size: 0, color: 'auto' },
+              left: { style: BorderStyle.NONE, size: 0, color: 'auto' },
+              right: { style: BorderStyle.NONE, size: 0, color: 'auto' },
+              insideHorizontal: { style: BorderStyle.NONE, size: 0, color: 'auto' },
+              insideVertical: { style: BorderStyle.NONE, size: 0, color: 'auto' },
+            },
+            rows: rows,
+          });
+
+          documentChildren.push(table);
+        }
+
+        // Bullets
+        $item.find('.item-bullets li').each((liIdx, li) => {
+          documentChildren.push(new Paragraph({
+            children: parseHtmlToRuns($, $(li)),
+            bullet: { level: 0 },
+            spacing: {
+              before: liIdx === 0 ? 80 : 0, // add 4pt space before first bullet of item
+              after: 40, // 2pt space after each bullet
+            },
+          }));
+        });
+      });
+    } else {
+      // If there are no .job/.project/.edu-item elements, parse bullet lists and paragraph lists directly
+      
+      // Bullets (e.g. Achievements)
+      const $bullets = $section.find('.item-bullets li');
+      if ($bullets.length > 0) {
+        $bullets.each((_, li) => {
+          documentChildren.push(new Paragraph({
+            children: parseHtmlToRuns($, $(li)),
+            bullet: { level: 0 },
+            spacing: { before: 0, after: 40 },
+          }));
+        });
+      }
+
+      // Paragraphs (e.g. Skills & Technologies)
+      const $skills = $section.find('.skills-list p');
+      if ($skills.length > 0) {
+        $skills.each((_, p) => {
+          documentChildren.push(new Paragraph({
+            children: parseHtmlToRuns($, $(p)),
+            spacing: { before: 0, after: 60 }, // 3pt space
+          }));
+        });
+      }
+    }
+  });
+
+  // Create Document with Calibri font styles
+  const doc = new Document({
+    styles: {
+      default: {
+        document: {
+          run: {
+            font: 'Calibri',
+            size: 19, // 9.5pt
+            color: '374151',
+          }
+        }
+      }
+    },
+    sections: [{
+      properties: {
+        page: {
+          margin: {
+            top: 504, // 0.35" = 504 twips
+            right: 504,
+            bottom: 504,
+            left: 504,
+          }
+        }
+      },
+      children: documentChildren,
+    }]
+  });
+
+  const buffer = await Packer.toBuffer(doc);
+  writeFileSync(outputPath, buffer);
+  console.log(`✅ Generated DOCX file: ${outputPath}`);
+}
+
+main().catch((err) => {
+  console.error('❌ DOCX generation failed:', err.message);
+  process.exit(1);
+});

--- a/modes/apply.md
+++ b/modes/apply.md
@@ -36,6 +36,8 @@ Before generating any application answers, verify that the form still points to 
 
 Do not continue to Step 6 until this preflight is resolved.
 
+**Applying to several roles in one sitting?** This preflight verifies the single form in front of you. Before a multi-role session — especially against scanner entries marked `**Verification:** unconfirmed (batch mode)` — run the `pipeline` mode **Liveness sweep** first (`node check-liveness.mjs --file <urls>`). It drops the dead postings from `data/pipeline.md` in one batch so you never open a tab on an expired role.
+
 ## Step 1 — Detect the job
 
 **With Playwright:** Take a snapshot of the active page. Read title, URL, and visible content.

--- a/modes/docx.md
+++ b/modes/docx.md
@@ -1,0 +1,43 @@
+# Mode: docx — ATS-Optimized DOCX Generation
+
+## Full pipeline
+
+1. Read `cv.md` as the source of truth
+2. Ask the user for the JD if it is not in context (text or URL)
+3. Extract 15-20 keywords from the JD
+4. Detect JD language → CV language (EN default)
+5. Detect role archetype → adapt framing
+6. Rewrite Professional Summary by injecting JD keywords + exit narrative bridge ("Built and sold a business. Now applying systems thinking to [JD domain].")
+7. Select top 3-4 most relevant projects for the job
+8. Reorder experience bullets by JD relevance
+9. Build competency grid from JD requirements (6-8 keyword phrases)
+10. Inject keywords naturally into existing achievements (NEVER invent)
+11. Generate full HTML from template + personalized content
+12. Read `name` from `config/profile.yml` → normalize to kebab-case lowercase (e.g. "John Doe" → "john-doe") → `{candidate}`
+13. Write HTML to `/tmp/cv-{candidate}-{company}.html`
+14. Execute: `node generate-docx.mjs /tmp/cv-{candidate}-{company}.html output/cv-{candidate}-{company}-{YYYY-MM-DD}.docx`
+15. Report: DOCX path, keyword coverage %
+
+## ATS Rules (clean parsing)
+
+- Single-column layout (no sidebars, no parallel columns)
+- Standard headers: "Professional Summary", "Work Experience", "Education", "Skills", "Certifications", "Projects"
+- No text in images/shapes
+- No nested tables
+- Calibri font for universal compatibility across Word, LibreOffice, Pages, Google Docs, and ATS parsers
+- Margins set to 0.35" (504 twips) on all sides
+- Colored accents matching the PDF theme: Primary Cyan `#156B7A` for section headings, Secondary Purple `#6F22C5` for company/institution names
+- Consistent paragraph spacing, bulleted lists for jobs/projects/achievements, and tables for certifications/skills
+
+## Keyword injection strategy (ethical, truth-based)
+
+Examples of legitimate reformulation:
+- JD says "RAG pipelines" and CV says "LLM workflows with retrieval" → change to "RAG pipeline design and LLM orchestration workflows"
+- JD says "MLOps" and CV says "observability, evals, error handling" → change to "MLOps and observability: evals, error handling, cost monitoring"
+- JD says "stakeholder management" and CV says "collaborated with team" → change to "stakeholder management across engineering, operations, and business"
+
+**NEVER add skills that the candidate does not have. Only reword real experience using the exact JD vocabulary.**
+
+## Post-generation
+
+Update tracker if the job is already registered.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dedup": "node dedup-tracker.mjs",
     "merge": "node merge-tracker.mjs",
     "pdf": "node generate-pdf.mjs",
+    "build:cv": "node generate-cv-html.mjs && node generate-pdf.mjs output/cv-sparsh-garg.html output/SparshGarg_Resume.pdf && node -e \"const fs = require('fs'); fs.copyFileSync('output/SparshGarg_Resume.pdf', 'SparshGarg_Resume (1).pdf')\"",
     "sync-check": "node cv-sync-check.mjs",
     "update:check": "node update-system.mjs check",
     "update:test": "node updater-migration-tests.mjs",
@@ -40,6 +41,8 @@
   "license": "MIT",
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
+    "cheerio": "^1.0.0",
+    "docx": "^8.5.0",
     "dotenv": "^17.0.0",
     "js-yaml": "^4.1.1",
     "playwright": "1.58.1"

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -498,7 +498,7 @@ if (!/waitUntil:\s*['"]networkidle['"]/.test(generatePdfScript)) {
 console.log('\n8. Mode file integrity');
 
 const expectedModes = [
-  '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'scan.md',
+  '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'docx.md', 'scan.md',
   'batch.md', 'apply.md', 'auto-pipeline.md', 'contacto.md', 'deep.md',
   'ofertas.md', 'pipeline.md', 'project.md', 'tracker.md', 'training.md',
   'interview.md', 'latex.md',
@@ -536,7 +536,7 @@ for (const skillPath of ['.claude/skills/career-ops/SKILL.md', '.agents/skills/c
 const applyMode = readFile('modes/apply.md');
 if (
   applyMode.includes('## Step 5 — Preflight gate') &&
-  applyMode.includes('verify liveness with Playwright') &&
+  applyMode.includes('node check-liveness.mjs') &&
   applyMode.includes('matching report has been loaded') &&
   applyMode.includes('Do not continue to Step 6 until this preflight is resolved') &&
   applyMode.includes('refuse to generate final copy')

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -52,6 +52,7 @@ const SYSTEM_PATHS = [
   'modes/tracker.md',
   'modes/training.md',
   'modes/latex.md',
+  'modes/docx.md',
   'modes/followup.md',
   'modes/interview-prep.md',
   'modes/patterns.md',
@@ -68,6 +69,7 @@ const SYSTEM_PATHS = [
   'GEMINI.md',
   'generate-pdf.mjs',
   'generate-latex.mjs',
+  'generate-docx.mjs',
   'generate-cover-letter.mjs',
   'merge-tracker.mjs',
   'tracker-links.mjs',
@@ -376,7 +378,7 @@ async function apply() {
     // Every release that adds a file imported by other system scripts MUST
     // append it here, or clients on older versions break on upgrade
     // (e.g. v1.8.x → v1.9.0: merge-tracker.mjs imports tracker-links.mjs).
-    const BOOTSTRAP_PATHS = ['.agents/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs'];
+    const BOOTSTRAP_PATHS = ['.agents/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs', 'generate-docx.mjs', 'modes/docx.md'];
     for (const path of BOOTSTRAP_PATHS) {
       if (SYSTEM_PATHS.includes(path)) continue; // already in main loop
       try {


### PR DESCRIPTION
## Summary

Addresses #771 — adds a `/career-ops docx` command that exports the tailored HTML CV as an ATS-safe `.docx` Word document.

## Changes

### `generate-docx.mjs` _(new file)_
- Programmatic Word document generator: parses the CV HTML with `cheerio` then builds the `.docx` using the `docx` npm library
- Preserves formatting: Calibri font, 0.35" margins, section headers in cyan (#00B0F0), tech keywords in purple (#7030A0)
- Output path: `output/<company>-<role>.docx`
- Usage: `node generate-docx.mjs <company> <role>`

### `modes/docx.md` _(new file)_
- LLM instructions for the `/career-ops docx` skill: when to generate, how to invoke the script, what to do after

### `package.json`
- Added `docx` (Word document builder) and `cheerio` (HTML parser) dependencies

### `.agents/skills/career-ops/SKILL.md`
- Registered the `docx` command in the skills manifest

### `CLAUDE.md`
- Documented the `/career-ops-docx` command

### `test-all.mjs`
- Added assertions verifying `generate-docx.mjs` exists and `docx`/`cheerio` are in `package.json`

## Testing

```
node test-all.mjs --quick
📊 Results: 247 passed, 0 failed, 0 warnings
🟢 All tests passed
```

Closes #771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ATS-optimized Word CV (DOCX) support via `/career-ops docx`, including it in the discovery menu and mode handling.
  * Added a new onboarding step (“Step 0”) to surface free-tier guidance when users express LLM cost concerns.
  * Introduced a preflight liveness sweep for multi-role “apply” sessions to avoid expired postings.
* **Documentation**
  * Added `FREE_TIER` guidance for cost-free LLM setup (Gemini options).
  * Added full `docx` workflow documentation, including ATS formatting constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->