### PR TITLE
Add unit tests, syntax lint, and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Lint & test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Syntax lint (.mjs)
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test

--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -11,6 +11,14 @@
 
 import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import {
+  STATUS_RANK,
+  normalizeCompany,
+  normalizeRole,
+  roleMatch,
+  parseScore,
+  parseAppLine,
+} from './lib/tracker-core.mjs';
 
 const CAREER_OPS = new URL('.', import.meta.url).pathname;
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original)
@@ -18,66 +26,6 @@ const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
   ? join(CAREER_OPS, 'data/applications.md')
   : join(CAREER_OPS, 'applications.md');
 const DRY_RUN = process.argv.includes('--dry-run');
-
-// Status advancement order (higher = more advanced in pipeline)
-// Aplicado > Rechazado because active application > terminal state
-const STATUS_RANK = {
-  'no aplicar': 0,
-  'descartado': 0,
-  'rechazado': 1,  // Terminal — below active states
-  'evaluada': 2,
-  'aplicado': 3,
-  'respondido': 4,
-  'entrevista': 5,
-  'oferta': 6,
-};
-
-function normalizeCompany(name) {
-  return name.toLowerCase()
-    .replace(/[()]/g, '')
-    .replace(/\s+/g, ' ')
-    .replace(/[^a-z0-9 ]/g, '')
-    .trim();
-}
-
-function normalizeRole(role) {
-  return role.toLowerCase()
-    .replace(/[()]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .replace(/[^a-z0-9 /]/g, '')
-    .trim();
-}
-
-function roleMatch(a, b) {
-  const wordsA = normalizeRole(a).split(/\s+/).filter(w => w.length > 3);
-  const wordsB = normalizeRole(b).split(/\s+/).filter(w => w.length > 3);
-  const overlap = wordsA.filter(w => wordsB.some(wb => wb.includes(w) || w.includes(wb)));
-  return overlap.length >= 2;
-}
-
-function parseScore(s) {
-  const m = s.replace(/\*\*/g, '').match(/([\d.]+)/);
-  return m ? parseFloat(m[1]) : 0;
-}
-
-function parseAppLine(line) {
-  const parts = line.split('|').map(s => s.trim());
-  if (parts.length < 9) return null;
-  const num = parseInt(parts[1]);
-  if (isNaN(num)) return null;
-  return {
-    num,
-    date: parts[2],
-    company: parts[3],
-    role: parts[4],
-    score: parts[5],
-    status: parts[6],
-    pdf: parts[7],
-    report: parts[8],
-    notes: parts[9] || '',
-    raw: line,
-  };
-}
 
 // Read
 if (!existsSync(APPS_FILE)) {

--- a/lib/tracker-core.mjs
+++ b/lib/tracker-core.mjs
@@ -1,0 +1,172 @@
+/**
+ * tracker-core.mjs — Pure, side-effect-free helpers shared by the tracker scripts.
+ *
+ * These functions contain the core parsing/normalization logic used by
+ * normalize-statuses.mjs, dedup-tracker.mjs, merge-tracker.mjs and
+ * verify-pipeline.mjs. They are extracted here so they can be imported by
+ * those scripts AND unit-tested in isolation (see test/tracker-core.test.mjs).
+ *
+ * Nothing in this module touches the filesystem, the network, or process state.
+ */
+
+// Canonical pipeline states (per templates/states.yml).
+export const CANONICAL_STATUSES = [
+  'Evaluada', 'Aplicado', 'Respondido', 'Entrevista',
+  'Oferta', 'Rechazado', 'Descartado', 'NO APLICAR',
+];
+
+// Status advancement order (higher = more advanced in pipeline).
+// Aplicado > Rechazado because an active application beats a terminal state.
+export const STATUS_RANK = {
+  'no aplicar': 0,
+  'descartado': 0,
+  'rechazado': 1, // Terminal — below active states
+  'evaluada': 2,
+  'aplicado': 3,
+  'respondido': 4,
+  'entrevista': 5,
+  'oferta': 6,
+};
+
+/**
+ * Rank for a status string (case-insensitive). Unknown → -1.
+ */
+export function statusRank(status) {
+  if (status == null) return -1;
+  const r = STATUS_RANK[String(status).trim().toLowerCase()];
+  return r === undefined ? -1 : r;
+}
+
+/**
+ * Map any non-canonical status to a canonical one.
+ * Returns { status, moveToNotes?, unknown? }.
+ * status === null with unknown === true means it could not be mapped.
+ */
+export function normalizeStatus(raw) {
+  // Strip markdown bold
+  let s = raw.replace(/\*\*/g, '').trim();
+  const lower = s.toLowerCase();
+
+  // DUPLICADO variants → Descartado
+  if (/^duplicado/i.test(s) || /^dup\b/i.test(s)) {
+    return { status: 'Descartado', moveToNotes: raw.trim() };
+  }
+
+  // CERRADA → Descartado
+  if (/^cerrada$/i.test(s)) return { status: 'Descartado' };
+
+  // Cancelada (possibly with date) → Descartado
+  if (/^cancelada/i.test(s)) return { status: 'Descartado' };
+
+  // Descartada → Descartado
+  if (/^descartada$/i.test(s)) return { status: 'Descartado' };
+
+  // Rechazada → Rechazado
+  if (/^rechazada$/i.test(s)) return { status: 'Rechazado' };
+
+  // Rechazado with date → Rechazado (strip date)
+  if (/^rechazado\s+\d{4}/i.test(s)) return { status: 'Rechazado' };
+
+  // Aplicado with date → Aplicado (strip date)
+  if (/^aplicado\s+\d{4}/i.test(s)) return { status: 'Aplicado' };
+
+  // CONDICIONAL → Evaluada
+  if (/^condicional$/i.test(s)) return { status: 'Evaluada' };
+
+  // HOLD → Evaluada
+  if (/^hold$/i.test(s)) return { status: 'Evaluada' };
+
+  // MONITOR → Evaluada
+  if (/^monitor$/i.test(s)) return { status: 'Evaluada' };
+
+  // EVALUAR → Evaluada
+  if (/^evaluar$/i.test(s)) return { status: 'Evaluada' };
+
+  // Verificar → Evaluada
+  if (/^verificar$/i.test(s)) return { status: 'Evaluada' };
+
+  // GEO BLOCKER → NO APLICAR
+  if (/geo.?blocker/i.test(s)) return { status: 'NO APLICAR' };
+
+  // Repost #NNN → Descartado
+  if (/^repost/i.test(s)) return { status: 'Descartado', moveToNotes: raw.trim() };
+
+  // "—" (em dash, no status) → Descartado
+  if (s === '—' || s === '-' || s === '') return { status: 'Descartado' };
+
+  // Already canonical — just fix casing/bold
+  for (const c of CANONICAL_STATUSES) {
+    if (lower === c.toLowerCase()) return { status: c };
+  }
+
+  // Aliases from states.yml
+  if (['enviada', 'aplicada', 'applied', 'sent'].includes(lower)) return { status: 'Aplicado' };
+  if (['cerrada', 'descartada'].includes(lower)) return { status: 'Descartado' };
+  if (['no aplicar', 'no_aplicar', 'skip'].includes(lower)) return { status: 'NO APLICAR' };
+
+  // Unknown — flag it
+  return { status: null, unknown: true };
+}
+
+/**
+ * Normalize a company name for grouping/dedup (lowercase, strip punctuation).
+ */
+export function normalizeCompany(name) {
+  return name.toLowerCase()
+    .replace(/[()]/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/[^a-z0-9 ]/g, '')
+    .trim();
+}
+
+/**
+ * Normalize a role title for fuzzy matching (keeps "/" for things like "Frontend/Backend").
+ */
+export function normalizeRole(role) {
+  return role.toLowerCase()
+    .replace(/[()]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/[^a-z0-9 /]/g, '')
+    .trim();
+}
+
+/**
+ * Fuzzy role match: true when two roles share >= 2 significant (len>3) words.
+ */
+export function roleMatch(a, b) {
+  const wordsA = normalizeRole(a).split(/\s+/).filter(w => w.length > 3);
+  const wordsB = normalizeRole(b).split(/\s+/).filter(w => w.length > 3);
+  const overlap = wordsA.filter(w => wordsB.some(wb => wb.includes(w) || w.includes(wb)));
+  return overlap.length >= 2;
+}
+
+/**
+ * Parse a score cell ("4.25/5", "**3.8**", "N/A") to a number. Non-numeric → 0.
+ */
+export function parseScore(s) {
+  const m = s.replace(/\*\*/g, '').match(/([\d.]+)/);
+  return m ? parseFloat(m[1]) : 0;
+}
+
+/**
+ * Parse a pipe-delimited applications.md row into a structured object.
+ * Returns null for separators, headers, or malformed rows.
+ */
+export function parseAppLine(line) {
+  const parts = line.split('|').map(s => s.trim());
+  if (parts.length < 9) return null;
+  const num = parseInt(parts[1]);
+  if (isNaN(num)) return null;
+  return {
+    num,
+    date: parts[2],
+    company: parts[3],
+    role: parts[4],
+    score: parts[5],
+    status: parts[6],
+    pdf: parts[7],
+    report: parts[8],
+    notes: parts[9] || '',
+    raw: line,
+  };
+}

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -13,6 +13,7 @@
 
 import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import { normalizeStatus } from './lib/tracker-core.mjs';
 
 const CAREER_OPS = new URL('.', import.meta.url).pathname;
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original)
@@ -20,77 +21,6 @@ const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
   ? join(CAREER_OPS, 'data/applications.md')
   : join(CAREER_OPS, 'applications.md');
 const DRY_RUN = process.argv.includes('--dry-run');
-
-// Canonical status mapping
-function normalizeStatus(raw) {
-  // Strip markdown bold
-  let s = raw.replace(/\*\*/g, '').trim();
-  const lower = s.toLowerCase();
-
-  // DUPLICADO variants → Descartado
-  if (/^duplicado/i.test(s) || /^dup\b/i.test(s)) {
-    return { status: 'Descartado', moveToNotes: raw.trim() };
-  }
-
-  // CERRADA → Descartado
-  if (/^cerrada$/i.test(s)) return { status: 'Descartado' };
-
-  // Cancelada (possibly with date) → Descartado
-  if (/^cancelada/i.test(s)) return { status: 'Descartado' };
-
-  // Descartada → Descartado
-  if (/^descartada$/i.test(s)) return { status: 'Descartado' };
-
-  // Rechazada → Rechazado
-  if (/^rechazada$/i.test(s)) return { status: 'Rechazado' };
-
-  // Rechazado with date → Rechazado (strip date)
-  if (/^rechazado\s+\d{4}/i.test(s)) return { status: 'Rechazado' };
-
-  // Aplicado with date → Aplicado (strip date)
-  if (/^aplicado\s+\d{4}/i.test(s)) return { status: 'Aplicado' };
-
-  // CONDICIONAL → Evaluada
-  if (/^condicional$/i.test(s)) return { status: 'Evaluada' };
-
-  // HOLD → Evaluada
-  if (/^hold$/i.test(s)) return { status: 'Evaluada' };
-
-  // MONITOR → Evaluada
-  if (/^monitor$/i.test(s)) return { status: 'Evaluada' };
-
-  // EVALUAR → Evaluada
-  if (/^evaluar$/i.test(s)) return { status: 'Evaluada' };
-
-  // Verificar → Evaluada
-  if (/^verificar$/i.test(s)) return { status: 'Evaluada' };
-
-  // GEO BLOCKER → NO APLICAR
-  if (/geo.?blocker/i.test(s)) return { status: 'NO APLICAR' };
-
-  // Repost #NNN → Descartado
-  if (/^repost/i.test(s)) return { status: 'Descartado', moveToNotes: raw.trim() };
-
-  // "—" (em dash, no status) → Descartado
-  if (s === '—' || s === '-' || s === '') return { status: 'Descartado' };
-
-  // Already canonical — just fix casing/bold
-  const canonical = [
-    'Evaluada', 'Aplicado', 'Respondido', 'Entrevista',
-    'Oferta', 'Rechazado', 'Descartado', 'NO APLICAR',
-  ];
-  for (const c of canonical) {
-    if (lower === c.toLowerCase()) return { status: c };
-  }
-
-  // Aliases from states.yml
-  if (['enviada', 'aplicada', 'applied', 'sent'].includes(lower)) return { status: 'Aplicado' };
-  if (['cerrada', 'descartada'].includes(lower)) return { status: 'Descartado' };
-  if (['no aplicar', 'no_aplicar', 'skip'].includes(lower)) return { status: 'NO APLICAR' };
-
-  // Unknown — flag it
-  return { status: null, unknown: true };
-}
 
 // Read applications.md
 if (!existsSync(APPS_FILE)) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "description": "AI-powered job search pipeline built on Claude Code",
   "scripts": {
+    "test": "node --test",
+    "lint": "node scripts/check-syntax.mjs",
     "verify": "node verify-pipeline.mjs",
     "normalize": "node normalize-statuses.mjs",
     "dedup": "node dedup-tracker.mjs",

--- a/scripts/check-syntax.mjs
+++ b/scripts/check-syntax.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * check-syntax.mjs — Zero-dependency syntax linter.
+ *
+ * Runs `node --check` on every tracked .mjs file so a typo can't land on main.
+ * Used by `npm run lint` and the CI workflow. Exits non-zero on the first error.
+ */
+
+import { readdirSync, statSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execFileSync } from 'child_process';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SKIP_DIRS = new Set(['node_modules', '.git', 'output', 'data']);
+
+function collect(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    if (SKIP_DIRS.has(name)) continue;
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...collect(full));
+    else if (name.endsWith('.mjs')) out.push(full);
+  }
+  return out;
+}
+
+const files = collect(root);
+let failed = 0;
+
+for (const file of files) {
+  try {
+    execFileSync(process.execPath, ['--check', file], { stdio: 'pipe' });
+  } catch (err) {
+    failed++;
+    console.error(`✗ ${file.replace(root, '.')}`);
+    console.error(String(err.stderr || err.message).trim());
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} file(s) failed syntax check.`);
+  process.exit(1);
+}
+console.log(`✓ ${files.length} .mjs files passed syntax check.`);

--- a/test/tracker-core.test.mjs
+++ b/test/tracker-core.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for lib/tracker-core.mjs — the pure logic shared by the tracker scripts.
+ * Run with: npm test   (uses Node's built-in test runner, no dependencies)
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CANONICAL_STATUSES,
+  STATUS_RANK,
+  statusRank,
+  normalizeStatus,
+  normalizeCompany,
+  normalizeRole,
+  roleMatch,
+  parseScore,
+  parseAppLine,
+} from '../lib/tracker-core.mjs';
+
+test('normalizeStatus: canonical statuses pass through unchanged', () => {
+  for (const c of CANONICAL_STATUSES) {
+    assert.deepEqual(normalizeStatus(c), { status: c });
+  }
+});
+
+test('normalizeStatus: strips markdown bold and fixes casing', () => {
+  assert.deepEqual(normalizeStatus('**aplicado**'), { status: 'Aplicado' });
+  assert.deepEqual(normalizeStatus('OFERTA'), { status: 'Oferta' });
+});
+
+test('normalizeStatus: DUPLICADO/repost moves original to notes', () => {
+  const dup = normalizeStatus('DUPLICADO de #12');
+  assert.equal(dup.status, 'Descartado');
+  assert.equal(dup.moveToNotes, 'DUPLICADO de #12');
+
+  const rep = normalizeStatus('Repost #45');
+  assert.equal(rep.status, 'Descartado');
+  assert.equal(rep.moveToNotes, 'Repost #45');
+});
+
+test('normalizeStatus: strips trailing dates', () => {
+  assert.deepEqual(normalizeStatus('Rechazado 2025-03-01'), { status: 'Rechazado' });
+  assert.deepEqual(normalizeStatus('Aplicado 2024'), { status: 'Aplicado' });
+});
+
+test('normalizeStatus: feminine and alias variants map to canonical', () => {
+  assert.deepEqual(normalizeStatus('Rechazada'), { status: 'Rechazado' });
+  assert.deepEqual(normalizeStatus('Descartada'), { status: 'Descartado' });
+  assert.deepEqual(normalizeStatus('Cancelada 2025'), { status: 'Descartado' });
+  assert.deepEqual(normalizeStatus('enviada'), { status: 'Aplicado' });
+  assert.deepEqual(normalizeStatus('applied'), { status: 'Aplicado' });
+  assert.deepEqual(normalizeStatus('skip'), { status: 'NO APLICAR' });
+});
+
+test('normalizeStatus: holding states collapse to Evaluada', () => {
+  for (const s of ['CONDICIONAL', 'HOLD', 'MONITOR', 'EVALUAR', 'Verificar']) {
+    assert.deepEqual(normalizeStatus(s), { status: 'Evaluada' });
+  }
+});
+
+test('normalizeStatus: geo blocker maps to NO APLICAR', () => {
+  assert.deepEqual(normalizeStatus('GEO BLOCKER'), { status: 'NO APLICAR' });
+  assert.deepEqual(normalizeStatus('geo-blocker'), { status: 'NO APLICAR' });
+});
+
+test('normalizeStatus: empty / dash means Descartado', () => {
+  assert.deepEqual(normalizeStatus('—'), { status: 'Descartado' });
+  assert.deepEqual(normalizeStatus('-'), { status: 'Descartado' });
+  assert.deepEqual(normalizeStatus(''), { status: 'Descartado' });
+});
+
+test('normalizeStatus: unrecognized status is flagged unknown', () => {
+  assert.deepEqual(normalizeStatus('Banana'), { status: null, unknown: true });
+});
+
+test('statusRank: known ranks and ordering', () => {
+  assert.equal(statusRank('Oferta'), 6);
+  assert.equal(statusRank('aplicado'), 3);
+  // Active application outranks terminal rejection.
+  assert.ok(statusRank('Aplicado') > statusRank('Rechazado'));
+  // Case-insensitive.
+  assert.equal(statusRank('ENTREVISTA'), STATUS_RANK['entrevista']);
+});
+
+test('statusRank: unknown and nullish return -1', () => {
+  assert.equal(statusRank('Banana'), -1);
+  assert.equal(statusRank(null), -1);
+  assert.equal(statusRank(undefined), -1);
+});
+
+test('normalizeCompany: lowercases and strips punctuation', () => {
+  assert.equal(normalizeCompany('Acme, Inc. (Remote)'), 'acme inc remote');
+  assert.equal(normalizeCompany('  Foo   Bar  '), 'foo bar');
+});
+
+test('normalizeRole: keeps slashes, drops other punctuation', () => {
+  assert.equal(normalizeRole('Senior Frontend/Backend Engineer!'), 'senior frontend/backend engineer');
+});
+
+test('roleMatch: matches on >= 2 significant shared words', () => {
+  assert.equal(roleMatch('Senior Software Engineer', 'Software Engineer II'), true);
+  assert.equal(roleMatch('Backend Engineer', 'Frontend Engineer'), false);
+  assert.equal(roleMatch('Product Manager', 'Engineering Manager'), false);
+});
+
+test('parseScore: extracts numeric value, handles bold and N/A', () => {
+  assert.equal(parseScore('4.25/5'), 4.25);
+  assert.equal(parseScore('**3.8**'), 3.8);
+  assert.equal(parseScore('N/A'), 0);
+  assert.equal(parseScore('DUP'), 0);
+});
+
+test('parseAppLine: parses a valid pipe-delimited row', () => {
+  const row = '| 7 | 2025-01-02 | Acme | Senior Engineer | 4.25/5 | Aplicado | cv.pdf | report-7.md | great |';
+  const app = parseAppLine(row);
+  assert.equal(app.num, 7);
+  assert.equal(app.company, 'Acme');
+  assert.equal(app.role, 'Senior Engineer');
+  assert.equal(app.status, 'Aplicado');
+  assert.equal(app.notes, 'great');
+});
+
+test('parseAppLine: rejects header, separator, and short rows', () => {
+  assert.equal(parseAppLine('| # | fecha | empresa | rol | score | status | pdf | report | notas |'), null);
+  assert.equal(parseAppLine('| --- | --- | --- |'), null);
+  assert.equal(parseAppLine('not a table row'), null);
+});
+
+test('parseAppLine: missing notes column defaults to empty string', () => {
+  const row = '| 3 | 2025-01-01 | Foo | Dev | 3/5 | Evaluada | x.pdf | r.md |';
+  const app = parseAppLine(row);
+  assert.equal(app.num, 3);
+  assert.equal(app.notes, '');
+});


### PR DESCRIPTION
- Extract pure tracker logic into lib/tracker-core.mjs (status normalization, company/role matching, score + row parsing)
- Refactor normalize-statuses.mjs and dedup-tracker.mjs to import it (behavior-preserving — no logic changes)
- Add test/tracker-core.test.mjs: 18 cases via node:test (zero deps)
- Add scripts/check-syntax.mjs: node --check over all .mjs
- Add npm scripts: "test" and "lint"
- Add .github/workflows/ci.yml: lint + test on Node 20/22 for PRs

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- REQUIRED: Link the issue this PR addresses. PRs without a related issue will be closed. -->
<!-- Format: Fixes #123 / Closes #123 -->
<!-- Bug fixes can skip this if the fix is obvious (e.g., typo, crash). -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] I linked a related issue above (required for features and architecture changes)
- [ ] My PR does not include personal data (CV, email, real names)
- [ ] I ran `node test-all.mjs` and all tests pass
- [ ] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test suite for core tracking functionality.

* **Chores**
  * Enabled automated CI/CD pipeline to run tests and linting on every push and pull request.
  * Added syntax checking and testing as standard development commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->