### PR TITLE
fix(merge-tracker): stop distinct "Product Manager, X" roles deduping

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -389,18 +389,24 @@ const ROLE_STOPWORDS = new Set([
 // a specific team or technology, and excludes broad ones like 'ai' / 'ml' /
 // 'llm' that appear across many roles (AI Engineer, ML Manager, etc.).
 // Adding the broad ones would regress #329's AI Success/Deployment case.
+// 'gtm' (go-to-market) names a specific commercial function, like 'crm'/'erp';
+// without it, "Product Manager, GTM Experiences" loses its discriminating
+// token and collapses into other "Product Manager, X" roles.
 const SHORT_SPECIALTY = new Set([
   'api', 'sre', 'sdk', 'cli', 'gpu', 'cpu',
   'ios', 'qa', 'ux', 'ui', 'ar', 'vr',
-  'ocr', 'crm', 'erp',
+  'ocr', 'crm', 'erp', 'gtm',
 ]);
 
 // Generic role-level descriptors. Two roles whose ONLY overlap is in this
 // set (e.g. [software, engineer]) are NOT the same role — they're just
 // labelled at the same altitude. See Issue #633: "Staff SWE, API" vs
 // "Staff SWE, Kubernetes Platform" share [software, engineer] only.
+// 'product' is the same kind of altitude word as 'manager'/'engineer':
+// "Product Manager, GTM Experiences" vs "Product Manager, Enterprise" share
+// only [product, manager] and are different roles, not duplicates.
 const BASELINE_TOKENS = new Set([
-  'software', 'engineer', 'developer', 'manager', 'architect',
+  'software', 'engineer', 'developer', 'manager', 'product', 'architect',
   'analyst', 'designer', 'consultant', 'specialist',
   'platform', 'systems', 'services',
   'backend', 'frontend', 'fullstack',

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1574,6 +1574,64 @@ try {
   fail(`merge-tracker fuzzy dedup tests crashed: ${e.message}`);
 }
 
+// ── MERGE-TRACKER FUZZY DEDUP: ROLE-ALTITUDE FALSE POSITIVE ─────
+// #751's union ratio fixed long titles ("Product Manager, GTM Experiences"
+// scores 2/4 = 0.5) but not the root cause: two "Product Manager, X" roles
+// share [product, manager], and because 'product' was not a BASELINE token it
+// counted as discriminating overlap. When the distinguishing token is a short
+// acronym that the length filter strips ('gtm'), the overlap is [product,
+// manager] over a 3-token union = 0.667 >= 0.6 — a false dup that SKIPS the
+// new role (silent data loss). 'product' is now a role-altitude baseline word
+// and 'gtm' a kept specialty acronym, so the roles stay distinct.
+console.log('\n🧪 Testing merge-tracker fuzzy dedup (role-altitude: PM GTM vs PM Enterprise)...');
+try {
+  const gtmTmp = mkdtempSync(join(tmpdir(), 'career-ops-merge-gtm-'));
+  try {
+    mkdirSync(join(gtmTmp, 'data'));
+    mkdirSync(join(gtmTmp, 'reports'));
+    const additionsDir = join(gtmTmp, 'additions');
+    mkdirSync(additionsDir);
+    const tracker = join(gtmTmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 1 | 2026-01-04 | Anthropic | Product Manager, Enterprise | 4.5/5 | Evaluated | ❌ | [1](../reports/001-anthropic-2026-01-04.md) | existing |\n');
+    for (const n of ['001-anthropic-2026-01-04', '002-anthropic-gtm-2026-01-05', '003-anthropic-2026-01-06']) {
+      writeFileSync(join(gtmTmp, 'reports', `${n}.md`), '# fixture\n');
+    }
+    // Distinct role at the same company sharing only [product, manager], with a
+    // LOWER score than the existing row: a false-positive dup would SKIP it.
+    writeFileSync(join(additionsDir, '002-anthropic-gtm.tsv'),
+      '2\t2026-01-05\tAnthropic\tProduct Manager, GTM\tEvaluated\t3.8/5\t❌\t[2](reports/002-anthropic-gtm-2026-01-05.md)\tdistinct GTM role\n');
+    // True repost of the existing role (higher score) must still UPDATE in place.
+    writeFileSync(join(additionsDir, '003-anthropic-enterprise.tsv'),
+      '3\t2026-01-06\tAnthropic\tProduct Manager, Enterprise\tEvaluated\t4.7/5\t❌\t[3](reports/003-anthropic-2026-01-06.md)\trepost\n');
+
+    run(NODE, ['merge-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: additionsDir } });
+    const merged = readFileSync(tracker, 'utf-8');
+
+    // The distinct role must be ADDED, not folded into the Enterprise row.
+    if (merged.includes('Product Manager, GTM') && merged.includes('Product Manager, Enterprise')) {
+      pass('role-altitude roles kept separate (PM GTM vs PM Enterprise)');
+    } else {
+      fail('"Product Manager, GTM" was skipped as a false-positive duplicate of "Product Manager, Enterprise"');
+    }
+
+    // Same-role dedup must still work: the repost updates the one existing row in place.
+    const enterpriseRows = merged.split('\n').filter(l => l.includes('Product Manager, Enterprise'));
+    if (enterpriseRows.length === 1 && enterpriseRows[0].includes('4.7/5')) {
+      pass('true repost still updates the existing row in place (4.5 → 4.7, no duplicate)');
+    } else {
+      fail(`repost handling broken: ${enterpriseRows.length} 'Enterprise' rows, expected 1 updated to 4.7/5`);
+    }
+  } finally {
+    rmSync(gtmTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`merge-tracker GTM dedup test crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER CONCURRENT WRITES (#781 follow-up) ─────────────────────
 // Report-number reservation is atomic now (#803), but tracker merges are a
 // separate read/modify/write step. If two merge-tracker processes read the same


### PR DESCRIPTION
## Problem

`roleFuzzyMatch()` in `merge-tracker.mjs` can collapse two genuinely different roles at the same company onto one tracker row, silently dropping the second evaluation.

Concrete case — with `Product Manager, Enterprise` already on the tracker, merging a distinct `Product Manager, GTM` at the same company is treated as a duplicate and skipped:

```
⏭️  Skip: Anthropic — Product Manager, GTM (existing #N 4.5 >= new 3.8)
```

## Root cause

Both titles tokenize to share only `[product, manager]`:

- `product` was **not** in `BASELINE_TOKENS`, so it counted as *discriminating* overlap (the `discriminating.length === 0` gate passed).
- `gtm` is a 3-char token, so the `length > 3` filter in `roleTokens()` strips it (it isn't in `SHORT_SPECIALTY`).

That leaves `[product, manager]` over a 3-token union → `2/3 = 0.667 >= 0.6` → reported as a duplicate.

`#751` switched the ratio from `overlap/minLen` to `overlap/union`, which incidentally fixed *long* titles — `Product Manager, GTM Experiences` scores `2/4 = 0.5` and is correctly kept. But it didn't address the root cause: whenever the distinguishing token is short enough to be stripped, the `[product, manager]` overlap still dominates the union.

Verified against current `main` (existing row: `Product Manager, Enterprise` @ 4.5/5):

| New role being merged | `main` | this PR |
|---|---|---|
| `Product Manager, GTM Experiences` | ✅ Add | ✅ Add |
| `Product Manager, GTM` | ❌ **Skip (dropped)** | ✅ Add |
| `Product Manager, Sales` | ✅ Add | ✅ Add |

## Fix

- Add `product` to `BASELINE_TOKENS` — a role-altitude word exactly like `manager`/`engineer`. `[product, manager]` is now non-discriminating, so the pair is rejected at the discriminating gate *before* the ratio is computed — independent of how the ratio is defined.
- Add `gtm` to `SHORT_SPECIALTY` — go-to-market names a specific commercial function (like `crm`/`erp`); keeping the token also lets it distinguish on the ratio.

Both are consistent with the existing design intent of `#633` (roles sharing only baseline altitude words are not the same role).

## Tests

Adds a regression test to the existing merge-tracker fuzzy-dedup suite in `test-all.mjs`:

- `Product Manager, GTM` vs `Product Manager, Enterprise` → kept as separate rows (**fails on `main`**, passes here).
- A genuine `Product Manager, Enterprise` repost (higher score) still updates the existing row in place — confirms same-role dedup isn't over-corrected.

`node test-all.mjs --quick` → **244 passed, 0 failed**.

## Notes

Happy to open a tracking issue first if that's preferred — I went straight to a focused PR with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved role matching logic to correctly distinguish between product manager roles with different specializations (e.g., GTM vs Enterprise), reducing false positives in role deduplication and ensuring distinct roles are not incorrectly merged together as duplicates.

* **Tests**
  * Added regression test to verify that distinct roles sharing only generic baseline descriptors are properly differentiated and not treated as duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->