### PR TITLE
fix(pipeline): batch liveness sweep for unconfirmed entries before apply

### DIFF
--- a/modes/apply.md
+++ b/modes/apply.md
@@ -36,6 +36,8 @@ Before generating any application answers, verify that the form still points to 
 
 Do not continue to Step 6 until this preflight is resolved.
 
+**Applying to several roles in one sitting?** This preflight verifies the single form in front of you. Before a multi-role session — especially against scanner entries marked `**Verification:** unconfirmed (batch mode)` — run the `pipeline` mode **Liveness sweep** first (`node check-liveness.mjs --file <urls>`). It drops the dead postings from `data/pipeline.md` in one batch so you never open a tab on an expired role.
+
 ## Step 1 — Detect the job
 
 **With Playwright:** Take a snapshot of the active page. Read title, URL, and visible content.

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -2,10 +2,24 @@
 
 Process job URLs stored in `data/pipeline.md`. The user adds URLs at any time and then executes `/career-ops pipeline` to process them all.
 
+## Liveness sweep
+
+**Run this before processing any URLs.** Entries added by the scanner in headless/batch mode carry `**Verification:** unconfirmed (batch mode)` because Playwright was unavailable at scan time — they were never checked for liveness. Without a sweep, dead postings reach evaluation one tab at a time, burning time and tokens on phantom roles (a single inbox of 8 stale URLs produces 8 wasted evaluations).
+
+Sweep all pending URLs in one batch with the zero-token liveness checker before the per-URL loop:
+
+1. Collect every `- [ ]` URL from the "Pending" section into a temp file (one URL per line).
+2. Run `node check-liveness.mjs --file <tmpfile>` (add `--throttle` for large batches to stay under WAF rate limits; it's pure Playwright, zero Claude tokens). The checker prints a per-URL verdict and exits non-zero if any are expired/uncertain.
+3. For every URL the checker reports as **expired/closed**, resolve the pipeline entry instead of processing it: move it to "Processed" as `- [x] ~~URL | Company | Role~~ — posting expired (liveness sweep)` and, if it already has a tracker row, mark it `Discarded`. **Do not** extract the JD, evaluate, or generate a report/PDF for it.
+4. Leave `uncertain` results in place to be confirmed during normal per-URL extraction (a transient timeout shouldn't drop a possibly-live posting).
+5. Only the surviving live URLs continue to the per-URL processing loop below.
+
+This complements — does not replace — the per-URL liveness gate in `auto-pipeline` (Step 0.5) and the `apply` preflight: the sweep drops the dead postings up front, in bulk, so the user never opens a tab or spends a token on them.
+
 ## Workflow
 
-1. **Read** `data/pipeline.md` → search for `- [ ]` items in the "Pending" section
-2. **For each pending URL**:
+1. **Read** `data/pipeline.md` → search for `- [ ]` items in the "Pending" section. Run the **Liveness sweep** (above) first and drop any expired entries before continuing.
+2. **For each surviving pending URL**:
    a. Claim the next sequential `REPORT_NUM` atomically by running `node reserve-report-num.mjs` (and release the sentinel using `node reserve-report-num.mjs --release <num>` after the report is written)
    b. **Extract JD** using Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
    c. If the URL is not accessible → mark as `- [!]` with a note and continue

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -634,6 +634,19 @@ if (
   fail('eval modes missing liveness gate before evaluation');
 }
 
+const pipelineMode = readFile('modes/pipeline.md');
+if (
+  pipelineMode.includes('## Liveness sweep') &&
+  pipelineMode.includes('check-liveness.mjs') &&
+  pipelineMode.includes('unconfirmed') &&
+  pipelineMode.includes('Do not') &&
+  pipelineMode.includes('liveness sweep')
+) {
+  pass('pipeline mode sweeps unconfirmed entries for liveness before processing');
+} else {
+  fail('pipeline mode missing batch liveness sweep for unconfirmed entries');
+}
+
 // ── 9. LOCAL PARSER CONTRACT ────────────────────────────────────
 
 console.log('\n9. Local parser contract');


### PR DESCRIPTION
## Summary

Fixes #750. Closes the remaining half of the liveness-gate class (the eval-side half landed in #937).

Batch scan adds roles to `data/pipeline.md` marked `**Verification:** unconfirmed (batch mode)` because Playwright is unavailable in headless mode — they're never liveness-checked. The reporter then applied to 8 roles, all already closed/filled, wasting time generating materials for dead postings.

## Why the existing gates don't cover this

- `modes/apply.md` Step 5 preflight verifies the **single** form currently open in Chrome.
- `modes/auto-pipeline.md` Step 0.5 (from #937) gates **per-URL** during evaluation.

Neither sweeps the inbox up front, so the user still opens every dead tab one at a time before discovering it's closed.

## Fix

Adds a **"Liveness sweep"** step to `modes/pipeline.md` that runs the existing zero-token `check-liveness.mjs` over all pending URLs in one batch *before* the per-URL loop:
- Expired/closed entries are resolved to "Processed" (and `Discarded` in the tracker) without being evaluated.
- `uncertain` results are left for normal per-URL confirmation (a transient timeout shouldn't drop a possibly-live posting).
- `apply.md` gets a short cross-reference pointing multi-role sessions at the sweep.

Complements — does not replace — the per-URL gates. No new scripts; `check-liveness.mjs` already exists.

## Test plan
- [x] `node test-all.mjs --quick` → 243 passed, 0 failed
- [x] New test asserts the pipeline sweep step markers exist (mirrors the #937 eval-gate test)
- [x] Pure mode-contract + test change — no script behavior altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-processing "Liveness sweep" that batch-detects expired/closed URLs, moves them to Processed with expiration notes, and prevents further processing of expired entries.

* **Documentation**
  * Added a preflight instruction to run the liveness sweep before per-URL processing in multi-role sessions.

* **Tests**
  * Added a mode integrity check that ensures liveness-sweep guidance is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->