### PR TITLE
feat(dashboard): customizable columns with column picker overlay

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -16,12 +16,13 @@ import (
 var (
 	reReportLink     = regexp.MustCompile(`\[(\d+)\]\(([^)]+)\)`)
 	reScoreValue     = regexp.MustCompile(`(\d+\.?\d*)/5`)
-	reArchetype      = regexp.MustCompile(`(?i)\*\*Arquetipo(?:\s+detectado)?\*\*\s*\|\s*(.+)`)
+	reArchetype      = regexp.MustCompile(`(?i)\*\*(?:Arquetipo|Archetype)(?:\s+(?:detectado|detected))?\*\*\s*\|\s*(.+)`)
 	reTlDr           = regexp.MustCompile(`(?i)\*\*TL;DR\*\*\s*\|\s*(.+)`)
 	reTlDrColon      = regexp.MustCompile(`(?i)\*\*TL;DR:\*\*\s*(.+)`)
 	reRemote         = regexp.MustCompile(`(?i)\*\*Remote\*\*\s*\|\s*(.+)`)
 	reComp           = regexp.MustCompile(`(?i)\*\*Comp\*\*\s*\|\s*(.+)`)
-	reArchetypeColon = regexp.MustCompile(`(?i)\*\*Arquetipo:\*\*\s*(.+)`)
+	reArchetypeColon = regexp.MustCompile(`(?i)\*\*(?:Arquetipo|Archetype):\*\*\s*(.+)`)
+	reArchetypeYAML  = regexp.MustCompile(`(?m)^archetype:\s*"?([^"\n]+)"?\s*$`)
 	reReportURL      = regexp.MustCompile(`(?m)^\*\*URL:\*\*\s*(https?://\S+)`)
 	reBatchID        = regexp.MustCompile(`(?m)^\*\*Batch ID:\*\*\s*(\d+)`)
 )
@@ -543,6 +544,8 @@ func LoadReportSummary(careerOpsPath, reportPath string) (archetype, tldr, remot
 		archetype = cleanTableCell(m[1])
 	} else if m := reArchetypeColon.FindStringSubmatch(text); m != nil {
 		archetype = cleanTableCell(m[1])
+	} else if m := reArchetypeYAML.FindStringSubmatch(text); m != nil {
+		archetype = strings.TrimSpace(m[1])
 	}
 
 	// Try table-format TL;DR first (most reports), then colon format

--- a/dashboard/internal/data/derive.go
+++ b/dashboard/internal/data/derive.go
@@ -64,10 +64,16 @@ func deriveNoteFields(app *model.CareerApplication) {
 	}
 
 	// Work mode: hybrid beats remote ("Remote/hybrid" means office days exist);
+	// "remote-first" / "remote + flex" is softer than fully remote;
 	// a bare city+state with no keyword implies fully on-site.
 	switch {
 	case strings.Contains(lower, "hybrid"):
 		app.WorkMode = "Hybrid"
+	case strings.Contains(lower, "remote") &&
+		(strings.Contains(lower, "flex") ||
+			strings.Contains(lower, "remote-first") ||
+			strings.Contains(lower, "remote first")):
+		app.WorkMode = "RemoteFlex"
 	case strings.Contains(lower, "remote"):
 		app.WorkMode = "Remote"
 	case strings.Contains(lower, "onsite") || strings.Contains(lower, "on-site") || strings.Contains(lower, "in-office"):

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -105,9 +105,8 @@ const (
 	ColDate        ColumnID = iota // APPLIED date
 	ColLocation                    // LOCATION city+state
 	ColPay                         // PAY range
-	ColWorkMode                    // MODE: RMT/HYB/RFLX/SITE
-	ColHasPDF                      // PDF: ✓/—
 	ColHasReport                   // RPT: ✓/—
+	ColHasPDF                      // PDF: ✓/—
 	ColLastContact                 // LAST contact date
 )
 
@@ -124,9 +123,8 @@ var optionalCols = []colDef{
 	{ColDate, "APPLIED", "", 10, true},
 	{ColLocation, "LOCATION", "", 20, true},
 	{ColPay, "PAY", "", 16, true},
-	{ColWorkMode, "MODE", "RMT/HYB/RFLX/SITE", 5, false},
-	{ColHasPDF, "PDF", "✓/—", 4, false},
 	{ColHasReport, "RPT", "✓/—", 4, false},
+	{ColHasPDF, "PDF", "✓/—", 4, false},
 	{ColLastContact, "LAST", "", 10, false},
 }
 
@@ -283,7 +281,6 @@ func (m PipelineModel) CurrentApp() (model.CareerApplication, bool) {
 func (m PipelineModel) Update(msg tea.Msg) (PipelineModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		m.flash = ""
 		if m.colPicker {
 			return m.handleColPicker(msg)
 		}
@@ -576,42 +573,6 @@ func (m PipelineModel) handleColPicker(msg tea.KeyMsg) (PipelineModel, tea.Cmd) 
 		m.visibleCols[col.id] = !m.visibleCols[col.id]
 	}
 	return m, nil
-}
-
-// handlePDFPicker consumes keys while the PDF picker overlay is open.
-func (m PipelineModel) handlePDFPicker(msg tea.KeyMsg) (PipelineModel, tea.Cmd) {
-	switch msg.String() {
-	case "esc", "q":
-		m.pdfPicker = false
-		return m, nil
-
-	case "down", "j":
-		m.pdfCursor++
-		if m.pdfCursor >= len(m.pdfChoices) {
-			m.pdfCursor = len(m.pdfChoices) - 1
-		}
-
-	case "up", "k":
-		m.pdfCursor--
-		if m.pdfCursor < 0 {
-			m.pdfCursor = 0
-		}
-
-	case "enter", "d":
-		m.pdfPicker = false
-		if m.pdfCursor >= 0 && m.pdfCursor < len(m.pdfChoices) {
-			return m, m.openPDFCmd(m.pdfChoices[m.pdfCursor])
-		}
-	}
-	return m, nil
-}
-
-// openPDFCmd emits a PipelineOpenPDFMsg for a root-relative PDF path.
-func (m PipelineModel) openPDFCmd(relPath string) tea.Cmd {
-	fullPath := filepath.Join(m.careerOpsPath, filepath.FromSlash(relPath))
-	return func() tea.Msg {
-		return PipelineOpenPDFMsg{Path: fullPath}
-	}
 }
 
 func (m PipelineModel) loadCurrentReport() tea.Cmd {
@@ -1034,7 +995,7 @@ func (m PipelineModel) renderBody() string {
 type colWidths struct {
 	num, score, company, status, role int
 	// optional columns — 0 means the column is hidden
-	date, loc, pay, mode, pdf, rpt, last int
+	date, loc, pay, rpt, pdf, last int
 }
 
 func (m PipelineModel) colVisible(id ColumnID) bool {
@@ -1061,19 +1022,16 @@ func (m PipelineModel) columnWidths() colWidths {
 	if m.colVisible(ColPay) {
 		c.pay = 16
 	}
-	if m.colVisible(ColWorkMode) {
-		c.mode = 5
+	if m.colVisible(ColHasReport) {
+		c.rpt = 4
 	}
 	if m.colVisible(ColHasPDF) {
 		c.pdf = 4
 	}
-	if m.colVisible(ColHasReport) {
-		c.rpt = 4
-	}
 	if m.colVisible(ColLastContact) {
 		c.last = 10
 	}
-	fixed := c.num + c.score + c.date + c.company + c.status + c.loc + c.pay + c.mode + c.pdf + c.rpt + c.last
+	fixed := c.num + c.score + c.date + c.company + c.status + c.loc + c.pay + c.rpt + c.pdf + c.last
 	c.role = m.width - fixed - 14 // separators + outer padding
 	if c.role < 15 {
 		c.role = 15
@@ -1109,27 +1067,6 @@ func (m PipelineModel) renderLocCell(app model.CareerApplication, width int) str
 		text = "—"
 	}
 	return lipgloss.NewStyle().Foreground(m.workModeColor(app.WorkMode)).Width(width).Render(truncateRunes(text, width))
-}
-
-// workModeAbbr returns a short abbreviation for the MODE column.
-func workModeAbbr(mode string) string {
-	switch mode {
-	case "Remote":
-		return "RMT"
-	case "RemoteFlex":
-		return "RFLX"
-	case "Hybrid":
-		return "HYB"
-	case "Full":
-		return "SITE"
-	default:
-		return "—"
-	}
-}
-
-func (m PipelineModel) renderModeCell(app model.CareerApplication, width int) string {
-	text := workModeAbbr(app.WorkMode)
-	return lipgloss.NewStyle().Foreground(m.workModeColor(app.WorkMode)).Width(width).Render(text)
 }
 
 func (m PipelineModel) renderCheckCell(yes bool, width int) string {
@@ -1186,14 +1123,11 @@ func (m PipelineModel) renderColumnHeader() string {
 	if cw.pay > 0 {
 		segments = append(segments, cell("PAY", cw.pay))
 	}
-	if cw.mode > 0 {
-		segments = append(segments, cell("MODE", cw.mode))
+	if cw.rpt > 0 {
+		segments = append(segments, cell("RPT", cw.rpt))
 	}
 	if cw.pdf > 0 {
 		segments = append(segments, cell("PDF", cw.pdf))
-	}
-	if cw.rpt > 0 {
-		segments = append(segments, cell("RPT", cw.rpt))
 	}
 	if cw.last > 0 {
 		segments = append(segments, cell("LAST", cw.last))
@@ -1256,14 +1190,11 @@ func (m PipelineModel) renderAppLine(app model.CareerApplication, selected bool)
 	if cw.pay > 0 {
 		segments = append(segments, m.renderPayCell(app, cw.pay))
 	}
-	if cw.mode > 0 {
-		segments = append(segments, m.renderModeCell(app, cw.mode))
+	if cw.rpt > 0 {
+		segments = append(segments, m.renderCheckCell(app.ReportPath != "", cw.rpt))
 	}
 	if cw.pdf > 0 {
 		segments = append(segments, m.renderCheckCell(app.HasPDF, cw.pdf))
-	}
-	if cw.rpt > 0 {
-		segments = append(segments, m.renderCheckCell(app.ReportPath != "", cw.rpt))
 	}
 	if cw.last > 0 {
 		lastText := "—"
@@ -1400,15 +1331,6 @@ func (m PipelineModel) renderHelp() string {
 	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Text)
 	descStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
 
-	if m.flash != "" {
-		flashStyle := lipgloss.NewStyle().
-			Foreground(m.theme.Yellow).
-			Background(m.theme.Surface).
-			Width(m.width).
-			Padding(0, 1)
-		return flashStyle.Render(m.flash)
-	}
-
 	if m.colPicker {
 		return style.Render(
 			keyStyle.Render("↑↓/jk") + descStyle.Render(" navigate  ") +
@@ -1416,7 +1338,7 @@ func (m PipelineModel) renderHelp() string {
 				keyStyle.Render("Esc/C") + descStyle.Render(" close"))
 	}
 
-	if m.statusPicker || m.pdfPicker {
+	if m.statusPicker {
 		return style.Render(
 			keyStyle.Render("↑↓/jk") + descStyle.Render(" navigate  ") +
 				keyStyle.Render("Enter") + descStyle.Render(" confirm  ") +
@@ -1515,41 +1437,6 @@ func (m PipelineModel) overlayColPicker(body string) string {
 		}
 		row := checkStr + " " + label
 		picker = append(picker, padStyle.Render(style.Render(row)))
-	}
-
-	bodyLines = append(bodyLines, picker...)
-	return strings.Join(bodyLines, "\n")
-}
-
-// overlayPDFPicker renders the PDF chooser inline at the bottom of the body,
-// mirroring overlayStatusPicker. Choices show the PDF filename only — the
-// directory is always output/ and the role variant lives in the name.
-func (m PipelineModel) overlayPDFPicker(body string) string {
-	bodyLines := strings.Split(body, "\n")
-
-	pickerWidth := m.width - 8
-	if pickerWidth < 30 {
-		pickerWidth = 30
-	}
-	padStyle := lipgloss.NewStyle().Padding(0, 2)
-	borderStyle := lipgloss.NewStyle().
-		Foreground(m.theme.Blue).
-		Bold(true)
-
-	var picker []string
-	picker = append(picker, padStyle.Render(borderStyle.Render("Open CV PDF:")))
-
-	for i, choice := range m.pdfChoices {
-		style := lipgloss.NewStyle().Foreground(m.theme.Text).Width(pickerWidth)
-		if i == m.pdfCursor {
-			style = style.Background(m.theme.Overlay).Bold(true)
-		}
-		prefix := "  "
-		if i == m.pdfCursor {
-			prefix = "> "
-		}
-		name := truncateRunes(filepath.Base(filepath.FromSlash(choice)), pickerWidth-2)
-		picker = append(picker, padStyle.Render(style.Render(prefix+name)))
 	}
 
 	bodyLines = append(bodyLines, picker...)

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -97,6 +97,39 @@ var pipelineTabs = []pipelineTab{
 
 var sortCycle = []string{sortScore, sortDate, sortCompany, sortStatus, sortLocation, sortPay, sortLast}
 
+// ColumnID identifies an optional table column in the pipeline view.
+type ColumnID int
+
+const (
+	// Optional columns — user-toggleable via the column picker (C key).
+	ColDate        ColumnID = iota // APPLIED date
+	ColLocation                    // LOCATION city+state
+	ColPay                         // PAY range
+	ColWorkMode                    // MODE: RMT/HYB/RFLX/SITE
+	ColHasPDF                      // PDF: ✓/—
+	ColHasReport                   // RPT: ✓/—
+	ColLastContact                 // LAST contact date
+)
+
+// colDef describes one optional column for the picker UI.
+type colDef struct {
+	id     ColumnID
+	header string
+	hint   string
+	width  int
+	onByDefault bool
+}
+
+var optionalCols = []colDef{
+	{ColDate, "APPLIED", "", 10, true},
+	{ColLocation, "LOCATION", "", 20, true},
+	{ColPay, "PAY", "", 16, true},
+	{ColWorkMode, "MODE", "RMT/HYB/RFLX/SITE", 5, false},
+	{ColHasPDF, "PDF", "✓/—", 4, false},
+	{ColHasReport, "RPT", "✓/—", 4, false},
+	{ColLastContact, "LAST", "", 10, false},
+}
+
 var statusOptions = []string{"Evaluated", "Applied", "Responded", "Interview", "Offer", "Rejected", "Discarded", "SKIP"}
 
 // statusGroupOrder defines display order for grouped view.
@@ -122,10 +155,18 @@ type PipelineModel struct {
 	// Search sub-state — narrows the active tab by substring on company/role/notes.
 	searchInput bool   // true while the user is typing the query
 	searchQuery string // committed (or in-progress) lowercased query
+	// Column picker sub-state — opened with C, closed with esc.
+	colPicker    bool
+	colPickerIdx int
+	visibleCols  map[ColumnID]bool
 }
 
 // NewPipelineModel creates a new pipeline screen.
 func NewPipelineModel(t theme.Theme, apps []model.CareerApplication, metrics model.PipelineMetrics, careerOpsPath string, width, height int) PipelineModel {
+	visible := make(map[ColumnID]bool)
+	for _, col := range optionalCols {
+		visible[col.id] = col.onByDefault
+	}
 	m := PipelineModel{
 		apps:          apps,
 		metrics:       metrics,
@@ -137,6 +178,7 @@ func NewPipelineModel(t theme.Theme, apps []model.CareerApplication, metrics mod
 		theme:         t,
 		careerOpsPath: careerOpsPath,
 		reportCache:   make(map[string]reportSummary),
+		visibleCols:   visible,
 	}
 	m.applyFilterAndSort()
 	return m
@@ -196,6 +238,8 @@ func (m PipelineModel) WithReloadedData(apps []model.CareerApplication, metrics 
 	// committed query and the user loses their place mid-investigation.
 	reloaded.searchQuery = m.searchQuery
 	reloaded.searchInput = m.searchInput
+	// Preserve user's column visibility choices across refresh.
+	reloaded.visibleCols = m.visibleCols
 	reloaded.applyFilterAndSort()
 	reloaded.CopyReportCache(&m)
 
@@ -239,6 +283,10 @@ func (m PipelineModel) CurrentApp() (model.CareerApplication, bool) {
 func (m PipelineModel) Update(msg tea.Msg) (PipelineModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		m.flash = ""
+		if m.colPicker {
+			return m.handleColPicker(msg)
+		}
 		if m.statusPicker {
 			return m.handleStatusPicker(msg)
 		}
@@ -356,6 +404,11 @@ func (m PipelineModel) handleKey(msg tea.KeyMsg) (PipelineModel, tea.Cmd) {
 
 	case "r":
 		return m, func() tea.Msg { return PipelineRefreshMsg{} }
+
+	case "C":
+		m.colPicker = true
+		m.colPickerIdx = 0
+		return m, nil
 
 	case "c":
 		if len(m.filtered) > 0 {
@@ -499,6 +552,68 @@ func (m PipelineModel) handleStatusPicker(msg tea.KeyMsg) (PipelineModel, tea.Cm
 	return m, nil
 }
 
+// handleColPicker consumes keys while the column picker overlay is open.
+func (m PipelineModel) handleColPicker(msg tea.KeyMsg) (PipelineModel, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q", "C":
+		m.colPicker = false
+		return m, nil
+
+	case "down", "j":
+		m.colPickerIdx++
+		if m.colPickerIdx >= len(optionalCols) {
+			m.colPickerIdx = len(optionalCols) - 1
+		}
+
+	case "up", "k":
+		m.colPickerIdx--
+		if m.colPickerIdx < 0 {
+			m.colPickerIdx = 0
+		}
+
+	case " ":
+		col := optionalCols[m.colPickerIdx]
+		m.visibleCols[col.id] = !m.visibleCols[col.id]
+	}
+	return m, nil
+}
+
+// handlePDFPicker consumes keys while the PDF picker overlay is open.
+func (m PipelineModel) handlePDFPicker(msg tea.KeyMsg) (PipelineModel, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q":
+		m.pdfPicker = false
+		return m, nil
+
+	case "down", "j":
+		m.pdfCursor++
+		if m.pdfCursor >= len(m.pdfChoices) {
+			m.pdfCursor = len(m.pdfChoices) - 1
+		}
+
+	case "up", "k":
+		m.pdfCursor--
+		if m.pdfCursor < 0 {
+			m.pdfCursor = 0
+		}
+
+	case "enter", "d":
+		m.pdfPicker = false
+		if m.pdfCursor >= 0 && m.pdfCursor < len(m.pdfChoices) {
+			return m, m.openPDFCmd(m.pdfChoices[m.pdfCursor])
+		}
+	}
+	return m, nil
+}
+
+// openPDFCmd emits a PipelineOpenPDFMsg for a root-relative PDF path.
+func (m PipelineModel) openPDFCmd(relPath string) tea.Cmd {
+	fullPath := filepath.Join(m.careerOpsPath, filepath.FromSlash(relPath))
+	return func() tea.Msg {
+		return PipelineOpenPDFMsg{Path: fullPath}
+	}
+}
+
 func (m PipelineModel) loadCurrentReport() tea.Cmd {
 	app, ok := m.CurrentApp()
 	if !ok || app.ReportPath == "" {
@@ -619,12 +734,14 @@ func workModeRank(mode string) int {
 	switch mode {
 	case "Remote":
 		return 0
-	case "Hybrid":
+	case "RemoteFlex":
 		return 1
-	case "Full":
+	case "Hybrid":
 		return 2
-	default:
+	case "Full":
 		return 3
+	default:
+		return 4
 	}
 }
 
@@ -714,6 +831,11 @@ func (m PipelineModel) View() string {
 		bodyLines = bodyLines[:availHeight]
 	}
 	body = strings.Join(bodyLines, "\n")
+
+	// Column picker overlay
+	if m.colPicker {
+		body = m.overlayColPicker(body)
+	}
 
 	// Status picker overlay
 	if m.statusPicker {
@@ -908,22 +1030,50 @@ func (m PipelineModel) renderBody() string {
 	return strings.Join(lines, "\n")
 }
 
-// colWidths holds per-column rune budgets for the table. The location and
-// last-contact columns are adaptive: they appear only when the terminal is wide
-// enough, so narrow windows keep the original compact layout.
+// colWidths holds per-column rune budgets for the table.
 type colWidths struct {
-	num, score, date, company, status, loc, pay, last, role int
+	num, score, company, status, role int
+	// optional columns — 0 means the column is hidden
+	date, loc, pay, mode, pdf, rpt, last int
+}
+
+func (m PipelineModel) colVisible(id ColumnID) bool {
+	if m.visibleCols == nil {
+		// Fall back to default for callers before init (tests, etc.)
+		for _, col := range optionalCols {
+			if col.id == id {
+				return col.onByDefault
+			}
+		}
+		return false
+	}
+	return m.visibleCols[id]
 }
 
 func (m PipelineModel) columnWidths() colWidths {
-	c := colWidths{num: 5, score: 5, date: 10, company: 16, status: 12, pay: 16}
-	if m.width >= 110 {
+	c := colWidths{num: 5, score: 5, company: 16, status: 12}
+	if m.colVisible(ColDate) {
+		c.date = 10
+	}
+	if m.colVisible(ColLocation) {
 		c.loc = 20
 	}
-	if m.width >= 132 {
+	if m.colVisible(ColPay) {
+		c.pay = 16
+	}
+	if m.colVisible(ColWorkMode) {
+		c.mode = 5
+	}
+	if m.colVisible(ColHasPDF) {
+		c.pdf = 4
+	}
+	if m.colVisible(ColHasReport) {
+		c.rpt = 4
+	}
+	if m.colVisible(ColLastContact) {
 		c.last = 10
 	}
-	fixed := c.num + c.score + c.date + c.company + c.status + c.pay + c.loc + c.last
+	fixed := c.num + c.score + c.date + c.company + c.status + c.loc + c.pay + c.mode + c.pdf + c.rpt + c.last
 	c.role = m.width - fixed - 14 // separators + outer padding
 	if c.role < 15 {
 		c.role = 15
@@ -931,18 +1081,22 @@ func (m PipelineModel) columnWidths() colWidths {
 	return c
 }
 
-// renderLocCell renders the work-mode + city column, e.g. "Remote",
-// "Hybrid · Charlotte, NC", "Full · Austin, TX".
-func (m PipelineModel) renderLocCell(app model.CareerApplication, width int) string {
-	color := m.theme.Subtext
-	switch app.WorkMode {
+func (m PipelineModel) workModeColor(mode string) lipgloss.Color {
+	switch mode {
 	case "Remote":
-		color = m.theme.Green
+		return m.theme.Green
+	case "RemoteFlex":
+		return m.theme.Sky
 	case "Hybrid":
-		color = m.theme.Yellow
+		return m.theme.Yellow
 	case "Full":
-		color = m.theme.Red
+		return m.theme.Red
+	default:
+		return m.theme.Subtext
 	}
+}
+
+func (m PipelineModel) renderLocCell(app model.CareerApplication, width int) string {
 	text := app.WorkMode
 	if app.Location != "" {
 		if text != "" {
@@ -954,7 +1108,38 @@ func (m PipelineModel) renderLocCell(app model.CareerApplication, width int) str
 	if text == "" {
 		text = "—"
 	}
-	return lipgloss.NewStyle().Foreground(color).Width(width).Render(truncateRunes(text, width))
+	return lipgloss.NewStyle().Foreground(m.workModeColor(app.WorkMode)).Width(width).Render(truncateRunes(text, width))
+}
+
+// workModeAbbr returns a short abbreviation for the MODE column.
+func workModeAbbr(mode string) string {
+	switch mode {
+	case "Remote":
+		return "RMT"
+	case "RemoteFlex":
+		return "RFLX"
+	case "Hybrid":
+		return "HYB"
+	case "Full":
+		return "SITE"
+	default:
+		return "—"
+	}
+}
+
+func (m PipelineModel) renderModeCell(app model.CareerApplication, width int) string {
+	text := workModeAbbr(app.WorkMode)
+	return lipgloss.NewStyle().Foreground(m.workModeColor(app.WorkMode)).Width(width).Render(text)
+}
+
+func (m PipelineModel) renderCheckCell(yes bool, width int) string {
+	text := "—"
+	color := m.theme.Subtext
+	if yes {
+		text = "✓"
+		color = m.theme.Green
+	}
+	return lipgloss.NewStyle().Foreground(color).Width(width).Render(text)
 }
 
 // renderPayCell prefers the pay range parsed from notes and falls back to the
@@ -988,15 +1173,28 @@ func (m PipelineModel) renderColumnHeader() string {
 	segments := []string{
 		cell("#", cw.num),
 		h.Render("FIT"), // score cell is unpadded, always 3 runes wide
-		cell("APPLIED", cw.date),
-		cell("COMPANY", cw.company),
-		cell("ROLE", cw.role),
-		cell("STATUS", cw.status),
 	}
+	if cw.date > 0 {
+		segments = append(segments, cell("APPLIED", cw.date))
+	}
+	segments = append(segments, cell("COMPANY", cw.company))
+	segments = append(segments, cell("ROLE", cw.role))
+	segments = append(segments, cell("STATUS", cw.status))
 	if cw.loc > 0 {
 		segments = append(segments, cell("LOCATION", cw.loc))
 	}
-	segments = append(segments, cell("PAY", cw.pay))
+	if cw.pay > 0 {
+		segments = append(segments, cell("PAY", cw.pay))
+	}
+	if cw.mode > 0 {
+		segments = append(segments, cell("MODE", cw.mode))
+	}
+	if cw.pdf > 0 {
+		segments = append(segments, cell("PDF", cw.pdf))
+	}
+	if cw.rpt > 0 {
+		segments = append(segments, cell("RPT", cw.rpt))
+	}
 	if cw.last > 0 {
 		segments = append(segments, cell("LAST", cw.last))
 	}
@@ -1044,16 +1242,29 @@ func (m PipelineModel) renderAppLine(app model.CareerApplication, selected bool)
 	segments := []string{
 		numStyle.Render(truncateRunes(numText, cw.num)),
 		score,
-		dateStyle.Render(truncateRunes(dateText, cw.date)),
-		companyStyle.Render(company),
-		roleStyle.Render(role),
-		statusText,
 	}
+	if cw.date > 0 {
+		segments = append(segments, dateStyle.Render(truncateRunes(dateText, cw.date)))
+	}
+	segments = append(segments, companyStyle.Render(company))
+	segments = append(segments, roleStyle.Render(role))
+	segments = append(segments, statusText)
 
 	if cw.loc > 0 {
 		segments = append(segments, m.renderLocCell(app, cw.loc))
 	}
-	segments = append(segments, m.renderPayCell(app, cw.pay))
+	if cw.pay > 0 {
+		segments = append(segments, m.renderPayCell(app, cw.pay))
+	}
+	if cw.mode > 0 {
+		segments = append(segments, m.renderModeCell(app, cw.mode))
+	}
+	if cw.pdf > 0 {
+		segments = append(segments, m.renderCheckCell(app.HasPDF, cw.pdf))
+	}
+	if cw.rpt > 0 {
+		segments = append(segments, m.renderCheckCell(app.ReportPath != "", cw.rpt))
+	}
 	if cw.last > 0 {
 		lastText := "—"
 		if app.LastContact != "" {
@@ -1061,7 +1272,6 @@ func (m PipelineModel) renderAppLine(app model.CareerApplication, selected bool)
 		}
 		lastStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext).Width(cw.last)
 		if app.LastContact != "" && app.LastContact != app.Date {
-			// Activity after applying (rejection, recruiter view, screen) — surface it.
 			lastStyle = lastStyle.Foreground(m.theme.Text)
 		}
 		segments = append(segments, lastStyle.Render(truncateRunes(lastText, cw.last)))
@@ -1190,7 +1400,23 @@ func (m PipelineModel) renderHelp() string {
 	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(m.theme.Text)
 	descStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
 
-	if m.statusPicker {
+	if m.flash != "" {
+		flashStyle := lipgloss.NewStyle().
+			Foreground(m.theme.Yellow).
+			Background(m.theme.Surface).
+			Width(m.width).
+			Padding(0, 1)
+		return flashStyle.Render(m.flash)
+	}
+
+	if m.colPicker {
+		return style.Render(
+			keyStyle.Render("↑↓/jk") + descStyle.Render(" navigate  ") +
+				keyStyle.Render("SPACE") + descStyle.Render(" toggle  ") +
+				keyStyle.Render("Esc/C") + descStyle.Render(" close"))
+	}
+
+	if m.statusPicker || m.pdfPicker {
 		return style.Render(
 			keyStyle.Render("↑↓/jk") + descStyle.Render(" navigate  ") +
 				keyStyle.Render("Enter") + descStyle.Render(" confirm  ") +
@@ -1215,6 +1441,7 @@ func (m PipelineModel) renderHelp() string {
 		keyStyle.Render("Enter") + descStyle.Render(" report  ") +
 		keyStyle.Render("o") + descStyle.Render(" open URL  ") +
 		keyStyle.Render("c") + descStyle.Render(" change  ") +
+		keyStyle.Render("C") + descStyle.Render(" columns  ") +
 		keyStyle.Render("v") + descStyle.Render(" view  ") +
 		keyStyle.Render("p") + descStyle.Render(" progress  ") +
 		keyStyle.Render("q") + descStyle.Render(" quit")
@@ -1253,6 +1480,78 @@ func (m PipelineModel) overlayStatusPicker(body string) string {
 	}
 
 	// Append picker to body
+	bodyLines = append(bodyLines, picker...)
+	return strings.Join(bodyLines, "\n")
+}
+
+// overlayColPicker renders the column visibility picker inline at the bottom
+// of the body. SPACE toggles the focused column; ESC or C closes.
+func (m PipelineModel) overlayColPicker(body string) string {
+	bodyLines := strings.Split(body, "\n")
+	pickerWidth := 36
+	padStyle := lipgloss.NewStyle().Padding(0, 2)
+	borderStyle := lipgloss.NewStyle().Foreground(m.theme.Blue).Bold(true)
+	dimStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+
+	var picker []string
+	picker = append(picker, padStyle.Render(borderStyle.Render("─── Columns (SPACE toggle · ESC close) ───")))
+
+	for i, col := range optionalCols {
+		on := m.visibleCols[col.id]
+		check := "[ ]"
+		checkColor := m.theme.Subtext
+		if on {
+			check = "[✓]"
+			checkColor = m.theme.Green
+		}
+		style := lipgloss.NewStyle().Foreground(m.theme.Text).Width(pickerWidth)
+		if i == m.colPickerIdx {
+			style = style.Background(m.theme.Overlay).Bold(true)
+		}
+		checkStr := lipgloss.NewStyle().Foreground(checkColor).Render(check)
+		label := col.header
+		if col.hint != "" {
+			label += "  " + dimStyle.Render(col.hint)
+		}
+		row := checkStr + " " + label
+		picker = append(picker, padStyle.Render(style.Render(row)))
+	}
+
+	bodyLines = append(bodyLines, picker...)
+	return strings.Join(bodyLines, "\n")
+}
+
+// overlayPDFPicker renders the PDF chooser inline at the bottom of the body,
+// mirroring overlayStatusPicker. Choices show the PDF filename only — the
+// directory is always output/ and the role variant lives in the name.
+func (m PipelineModel) overlayPDFPicker(body string) string {
+	bodyLines := strings.Split(body, "\n")
+
+	pickerWidth := m.width - 8
+	if pickerWidth < 30 {
+		pickerWidth = 30
+	}
+	padStyle := lipgloss.NewStyle().Padding(0, 2)
+	borderStyle := lipgloss.NewStyle().
+		Foreground(m.theme.Blue).
+		Bold(true)
+
+	var picker []string
+	picker = append(picker, padStyle.Render(borderStyle.Render("Open CV PDF:")))
+
+	for i, choice := range m.pdfChoices {
+		style := lipgloss.NewStyle().Foreground(m.theme.Text).Width(pickerWidth)
+		if i == m.pdfCursor {
+			style = style.Background(m.theme.Overlay).Bold(true)
+		}
+		prefix := "  "
+		if i == m.pdfCursor {
+			prefix = "> "
+		}
+		name := truncateRunes(filepath.Base(filepath.FromSlash(choice)), pickerWidth-2)
+		picker = append(picker, padStyle.Render(style.Render(prefix+name)))
+	}
+
 	bodyLines = append(bodyLines, picker...)
 	return strings.Join(bodyLines, "\n")
 }

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -1129,7 +1129,7 @@ func (m PipelineModel) renderPreview() string {
 	if summary, ok := m.reportCache[app.ReportPath]; ok {
 		if summary.archetype != "" {
 			lines = append(lines, padStyle.Render(
-				labelStyle.Render("Arquetipo: ")+valueStyle.Render(summary.archetype)))
+				labelStyle.Render("Archetype: ")+valueStyle.Render(summary.archetype)))
 		}
 		if summary.tldr != "" {
 			lines = append(lines, padStyle.Render(


### PR DESCRIPTION
﻿## Summary

- Add opt-in column picker overlay (press `c`) for the pipeline table: APPLIED, LOCATION, PAY on by default; RPT and PDF off by default
- Columns toggle with SPACE, navigate with up/down/jk, close with Esc/C
- LOCATION column colored by work mode (Remote=green, Hybrid=yellow, On-site=red, RemoteFlex=sky)
- Remove MODE column - it duplicated info already shown via LOCATION column color
- Swap column order: RPT now appears before PDF (report exists before the PDF is generated)
- Add RemoteFlex detection to `derive.go` for "remote + flex" / "remote-first" patterns

## Test plan

- [ ] Run dashboard, press `c` to open column picker
- [ ] Toggle RPT and PDF on -- verify columns appear and ROLE column shrinks to compensate
- [ ] Toggle back off -- table returns to previous layout
- [ ] Verify LOCATION column shows work mode color (green for Remote, yellow for Hybrid)
- [ ] Verify MODE column is gone from the picker list
- [ ] Verify RPT appears before PDF when both enabled
- [ ] `go test ./dashboard/...` passes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive column picker to pipeline view (press `C` to toggle optional columns including applied date, location, pay, report/PDF status, and last-contact time).
  * Enhanced work mode detection to recognize "remote flex" arrangements.
  * Improved metadata parsing with expanded language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->