### PR TITLE
fix(pdf): use fileURLToPath for isMain check — fixes silent no-op on Windows

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -299,7 +299,7 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
   }
 }
 
-const isMain = process.argv[1] && import.meta.url === `file://${resolve(process.argv[1])}`;
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
 if (isMain) {
   generatePDF().catch((err) => {
     console.error('❌ PDF generation failed:', err.message);


### PR DESCRIPTION
## Summary

- generate-pdf.mjs was a silent no-op on Windows since #807: the isMain guard compared import.meta.url (e.g. ile:///C:/path/... with forward slashes) against ` ile://\ ` (e.g. ile://C:\path\... with backslashes) — they never matched, so generatePDF() was never called. The script exited 0 with no output and no PDF written.
- Fix: replace the broken string comparison with ileURLToPath(import.meta.url) === resolve(process.argv[1]), using the ileURLToPath already imported at the top of the file. This is the idiomatic Node.js way to compare a ile:// URL against a filesystem path across platforms.
- Root cause introduced in #807 (feat/cover), which added the isMain guard to allow 
enderHtmlToPdf to be imported without triggering the CLI entrypoint.

## Test plan

- [ ] `node generate-pdf.mjs output/<any>.html output/test.pdf --format=letter` completes with output on Windows (previously exited silently)
- [ ] Same command on macOS/Linux still works (no regression)
- [ ] generate-cover-letter.mjs can still import 
enderHtmlToPdf from generate-pdf.mjs without triggering the CLI (isMain correctly false when imported)

Fixes #948.
Introduced by #807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
