### PR TITLE
feat(scan): preserve locations in pipeline rows

### DIFF
--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -28,12 +28,17 @@ Process job URLs stored in `data/pipeline.md`. The user adds URLs at any time an
 ## Pending
 - [ ] https://jobs.example.com/posting/123
 - [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
+- [ ] https://jobs.example.com/posting/789 | Acme Corp | AI Engineer | Remote, EU
 - [!] https://private.url/job — Error: login required
 
 ## Processed
 - [x] #143 | https://jobs.example.com/posting/789 | Acme Corp | AI PM | 4.2/5 | PDF ✅
 - [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF ❌
 ```
+
+The pending metadata after the URL is optional. Legacy URL-only and
+`URL | Company | Role` rows remain valid; scanner-created rows include
+`URL | Company | Role | Location` when the provider returns location.
 
 ## Intelligent JD detection from URL
 

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -215,7 +215,7 @@ Levels are additive — they are executed in order, and results are merged and d
 7. **Deduplicate** against 3 sources:
    - `scan-history.tsv` → exact URL already seen
    - `applications.md` → normalized company + role already evaluated
-   - `pipeline.md` → exact URL already in pending or processed list
+   - `pipeline.md` → exact public `http(s)` URL already in pending or processed list
 
 7.5. **Verify Liveness of WebSearch Results (Level 3)** — BEFORE adding to pipeline:
 
@@ -237,7 +237,7 @@ Levels are additive — they are executed in order, and results are merged and d
 
 8. **For each new verified offer that passes filters**:
    a. Add to the `pipeline.md` pending section (`## Pendientes` in the stock file): `- [ ] {url} | {company} | {title} | {location}` when location is known. If location is missing, keep the legacy 3-column shape: `- [ ] {url} | {company} | {title}`.
-   b. Record in `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded\t{location}`
+   b. Record in `scan-history.tsv`: `{url}\t{date}\t{portal}\t{title}\t{company}\tadded\t{location}`
 
 9. **Offers filtered by title**: record in `scan-history.tsv` with status `skipped_title`.
 10. **Duplicate offers**: record with status `skipped_dup`.
@@ -259,6 +259,7 @@ Generic regex: `(.+?)(?:\s*[@|—–-]\s*|\s+at\s+)(.+?)$`
 If a non-publicly accessible URL is found:
 1. Save the JD in `jds/{company}-{role-slug}.md`.
 2. Add to `pipeline.md` as: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title} | {location}` when location is known.
+3. Keep the original source URL in `scan-history.tsv` when available; `pipeline.md` URL dedup only indexes public `http(s)` rows.
 
 ## Scan History
 
@@ -284,7 +285,7 @@ Duplicates: N (already evaluated or in pipeline)
 Expired discarded: N (dead links, Level 3)
 New added to pipeline.md: N
 
-  + {company} | {title} | {query_name}
+  + {company} | {title} | {portal}
   ...
 
 → Run /career-ops pipeline to evaluate the new offers.

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -236,8 +236,8 @@ Levels are additive — they are executed in order, and results are merged and d
    **Do not interrupt the entire scan if a single URL fails.** If `browser_navigate` errors (timeout, 403, etc.), mark as `skipped_expired` and continue with the next one.
 
 8. **For each new verified offer that passes filters**:
-   a. Add to the `pipeline.md` "Pending" section: `- [ ] {url} | {company} | {title}`
-   b. Record in `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
+   a. Add to the `pipeline.md` "Pending" section: `- [ ] {url} | {company} | {title} | {location}` when location is known. If location is missing, keep the legacy 3-column shape: `- [ ] {url} | {company} | {title}`.
+   b. Record in `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded\t{location}`
 
 9. **Offers filtered by title**: record in `scan-history.tsv` with status `skipped_title`.
 10. **Duplicate offers**: record with status `skipped_dup`.
@@ -258,15 +258,18 @@ Generic regex: `(.+?)(?:\s*[@|—–-]\s*|\s+at\s+)(.+?)$`
 
 If a non-publicly accessible URL is found:
 1. Save the JD in `jds/{company}-{role-slug}.md`.
-2. Add to `pipeline.md` as: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title}`
+2. Add to `pipeline.md` as: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title} | {location}` when location is known.
 
 ## Scan History
 
 `data/scan-history.tsv` tracks ALL seen URLs:
 
+The scanner writes `location` as a trailing column when known; legacy 6-column
+history rows remain valid.
+
 ```tsv
-url	first_seen	portal	title	company	status
-https://...	2026-02-10	Ashby — AI PM	PM AI	Acme	added
+url	first_seen	portal	title	company	status	location
+https://...	2026-02-10	Ashby — AI PM	PM AI	Acme	added	Remote, EU
 ```
 
 ## Output Summary

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -236,7 +236,7 @@ Levels are additive — they are executed in order, and results are merged and d
    **Do not interrupt the entire scan if a single URL fails.** If `browser_navigate` errors (timeout, 403, etc.), mark as `skipped_expired` and continue with the next one.
 
 8. **For each new verified offer that passes filters**:
-   a. Add to the `pipeline.md` "Pending" section: `- [ ] {url} | {company} | {title} | {location}` when location is known. If location is missing, keep the legacy 3-column shape: `- [ ] {url} | {company} | {title}`.
+   a. Add to the `pipeline.md` pending section (`## Pendientes` in the stock file): `- [ ] {url} | {company} | {title} | {location}` when location is known. If location is missing, keep the legacy 3-column shape: `- [ ] {url} | {company} | {title}`.
    b. Record in `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded\t{location}`
 
 9. **Offers filtered by title**: record in `scan-history.tsv` with status `skipped_title`.

--- a/scan.mjs
+++ b/scan.mjs
@@ -356,13 +356,16 @@ function scanHistoryPolicy(config = {}) {
   };
 }
 
-export function loadSeenUrls(policy = {}) {
+export function loadSeenUrls(policy = {}, paths = {}) {
+  const scanHistoryPath = paths.scanHistoryPath || SCAN_HISTORY_PATH;
+  const pipelinePath = paths.pipelinePath || PIPELINE_PATH;
+  const applicationsPath = paths.applicationsPath || APPLICATIONS_PATH;
   const seen = new Set();
   let recheckEligible = 0;
 
   // scan-history.tsv
-  if (existsSync(SCAN_HISTORY_PATH)) {
-    const lines = readFileSync(SCAN_HISTORY_PATH, 'utf-8').split('\n');
+  if (existsSync(scanHistoryPath)) {
+    const lines = readFileSync(scanHistoryPath, 'utf-8').split('\n');
     for (const line of lines.slice(1)) { // skip header
       const [url, firstSeen, , , , status = 'added'] = line.split('\t');
       if (!url) continue;
@@ -372,16 +375,16 @@ export function loadSeenUrls(policy = {}) {
   }
 
   // pipeline.md — extract URLs from checkbox lines
-  if (existsSync(PIPELINE_PATH)) {
-    const text = readFileSync(PIPELINE_PATH, 'utf-8');
+  if (existsSync(pipelinePath)) {
+    const text = readFileSync(pipelinePath, 'utf-8');
     for (const match of text.matchAll(/- \[[ x]\] (https?:\/\/\S+)/g)) {
       seen.add(match[1]);
     }
   }
 
   // applications.md — extract URLs from report links and any inline URLs
-  if (existsSync(APPLICATIONS_PATH)) {
-    const text = readFileSync(APPLICATIONS_PATH, 'utf-8');
+  if (existsSync(applicationsPath)) {
+    const text = readFileSync(applicationsPath, 'utf-8');
     for (const match of text.matchAll(/https?:\/\/[^\s|)]+/g)) {
       seen.add(match[0]);
     }
@@ -408,6 +411,13 @@ function loadSeenCompanyRoles() {
 
 // ── Pipeline writer ─────────────────────────────────────────────────
 
+/**
+ * Format a pending pipeline row while preserving the legacy 3-column shape.
+ *
+ * Providers may return location metadata, but existing pipeline readers accept
+ * URL-only or `URL | Company | Role` rows. Only write the fourth column when
+ * location is a non-blank string so older user-maintained rows stay valid.
+ */
 export function formatPipelineOffer(o) {
   const fields = [o.url, o.company, o.title];
   const location = typeof o.location === 'string' ? o.location.trim() : '';
@@ -415,10 +425,10 @@ export function formatPipelineOffer(o) {
   return `- [ ] ${fields.join(' | ')}`;
 }
 
-export function appendToPipeline(offers) {
+export function appendToPipeline(offers, pipelinePath = PIPELINE_PATH) {
   if (offers.length === 0) return;
 
-  let text = readFileSync(PIPELINE_PATH, 'utf-8');
+  let text = readFileSync(pipelinePath, 'utf-8');
 
   // Find "## Pendientes" section and append after it
   const marker = '## Pendientes';
@@ -443,7 +453,7 @@ export function appendToPipeline(offers) {
     text = text.slice(0, insertAt) + block + text.slice(insertAt);
   }
 
-  writeFileSync(PIPELINE_PATH, text, 'utf-8');
+  writeFileSync(pipelinePath, text, 'utf-8');
 }
 
 export function appendToScanHistory(offers, date, status = 'added') {

--- a/scan.mjs
+++ b/scan.mjs
@@ -430,7 +430,7 @@ export function appendToPipeline(offers, pipelinePath = PIPELINE_PATH) {
 
   mkdirSync(path.dirname(pipelinePath), { recursive: true });
   if (!existsSync(pipelinePath)) {
-    writeFileSync(pipelinePath, '', 'utf-8');
+    writeFileSync(pipelinePath, '# Pipeline\n\n## Pendientes\n', 'utf-8');
   }
 
   let text = readFileSync(pipelinePath, 'utf-8');

--- a/scan.mjs
+++ b/scan.mjs
@@ -408,6 +408,13 @@ function loadSeenCompanyRoles() {
 
 // ── Pipeline writer ─────────────────────────────────────────────────
 
+export function formatPipelineOffer(o) {
+  const fields = [o.url, o.company, o.title];
+  const location = typeof o.location === 'string' ? o.location.trim() : '';
+  if (location) fields.push(location);
+  return `- [ ] ${fields.join(' | ')}`;
+}
+
 export function appendToPipeline(offers) {
   if (offers.length === 0) return;
 
@@ -421,7 +428,7 @@ export function appendToPipeline(offers) {
     const procIdx = text.indexOf('## Procesadas');
     const insertAt = procIdx === -1 ? text.length : procIdx;
     const block = `\n${marker}\n\n` + offers.map(o =>
-      `- [ ] ${o.url} | ${o.company} | ${o.title}`
+      formatPipelineOffer(o)
     ).join('\n') + '\n\n';
     text = text.slice(0, insertAt) + block + text.slice(insertAt);
   } else {
@@ -431,7 +438,7 @@ export function appendToPipeline(offers) {
     const insertAt = nextSection === -1 ? text.length : nextSection;
 
     const block = '\n' + offers.map(o =>
-      `- [ ] ${o.url} | ${o.company} | ${o.title}`
+      formatPipelineOffer(o)
     ).join('\n') + '\n';
     text = text.slice(0, insertAt) + block + text.slice(insertAt);
   }

--- a/scan.mjs
+++ b/scan.mjs
@@ -428,6 +428,11 @@ export function formatPipelineOffer(o) {
 export function appendToPipeline(offers, pipelinePath = PIPELINE_PATH) {
   if (offers.length === 0) return;
 
+  mkdirSync(path.dirname(pipelinePath), { recursive: true });
+  if (!existsSync(pipelinePath)) {
+    writeFileSync(pipelinePath, '', 'utf-8');
+  }
+
   let text = readFileSync(pipelinePath, 'utf-8');
 
   // Find "## Pendientes" section and append after it

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1052,6 +1052,17 @@ try {
     } else {
       fail('formatPipelineOffer should not write blank location columns');
     }
+
+    const missingPipelinePath = join(pipelineTmp, 'missing', 'data', 'pipeline.md');
+    appendToPipeline([
+      { url: 'https://jobs.example.com/new-file', company: 'Gamma', title: 'ML Engineer', location: 'Paris' },
+    ], missingPipelinePath);
+    const missingPipelineText = readFileSync(missingPipelinePath, 'utf-8');
+    if (missingPipelineText.includes('## Pendientes') && missingPipelineText.includes('- [ ] https://jobs.example.com/new-file | Gamma | ML Engineer | Paris')) {
+      pass('scan pipeline writer creates missing pipeline files before appending');
+    } else {
+      fail('scan pipeline writer should create missing pipeline files before appending');
+    }
   } finally {
     rmSync(pipelineTmp, { recursive: true, force: true });
   }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1018,16 +1018,15 @@ try {
   }
 
   const pipelineTmp = mkdtempSync(join(tmpdir(), 'career-ops-pipeline-'));
-  const previousCwd = process.cwd();
   try {
     mkdirSync(join(pipelineTmp, 'data'), { recursive: true });
-    writeFileSync(join(pipelineTmp, 'data', 'pipeline.md'), '# Pipeline\n\n## Pendientes\n\n## Procesadas\n');
-    process.chdir(pipelineTmp);
+    const pipelinePath = join(pipelineTmp, 'data', 'pipeline.md');
+    writeFileSync(pipelinePath, '# Pipeline\n\n## Pendientes\n\n## Procesadas\n');
     appendToPipeline([
       { url: 'https://jobs.example.com/with-location', company: 'Acme', title: 'AI Engineer', location: 'Remote, EU' },
       { url: 'https://jobs.example.com/legacy-shape', company: 'Beta', title: 'Product Lead', location: '' },
-    ]);
-    const pipelineText = readFileSync(join(pipelineTmp, 'data', 'pipeline.md'), 'utf-8');
+    ], pipelinePath);
+    const pipelineText = readFileSync(pipelinePath, 'utf-8');
     if (pipelineText.includes('- [ ] https://jobs.example.com/with-location | Acme | AI Engineer | Remote, EU')) {
       pass('scan pipeline writer preserves location as optional fourth column');
     } else {
@@ -1038,7 +1037,11 @@ try {
     } else {
       fail('scan pipeline writer should omit empty location columns for backward compatibility');
     }
-    const { seen } = loadSeenUrls();
+    const { seen } = loadSeenUrls({}, {
+      applicationsPath: join(pipelineTmp, 'data', 'applications.md'),
+      pipelinePath,
+      scanHistoryPath: join(pipelineTmp, 'data', 'scan-history.tsv'),
+    });
     if (seen.has('https://jobs.example.com/with-location') && seen.has('https://jobs.example.com/legacy-shape')) {
       pass('pipeline URL dedup still reads location and legacy pipeline rows');
     } else {
@@ -1050,7 +1053,6 @@ try {
       fail('formatPipelineOffer should not write blank location columns');
     }
   } finally {
-    process.chdir(previousCwd);
     rmSync(pipelineTmp, { recursive: true, force: true });
   }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1058,7 +1058,10 @@ try {
       { url: 'https://jobs.example.com/new-file', company: 'Gamma', title: 'ML Engineer', location: 'Paris' },
     ], missingPipelinePath);
     const missingPipelineText = readFileSync(missingPipelinePath, 'utf-8');
-    if (missingPipelineText.includes('## Pendientes') && missingPipelineText.includes('- [ ] https://jobs.example.com/new-file | Gamma | ML Engineer | Paris')) {
+    if (
+      missingPipelineText.startsWith('# Pipeline\n\n## Pendientes\n') &&
+      missingPipelineText.includes('- [ ] https://jobs.example.com/new-file | Gamma | ML Engineer | Paris')
+    ) {
       pass('scan pipeline writer creates missing pipeline files before appending');
     } else {
       fail('scan pipeline writer should create missing pipeline files before appending');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -882,7 +882,7 @@ if (fileExists('VERSION')) {
 console.log('\n15. Location filter — always_allow tier');
 
 try {
-  const { buildLocationFilter, shouldDedupScanHistoryRow } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+  const { appendToPipeline, buildLocationFilter, formatPipelineOffer, loadSeenUrls, shouldDedupScanHistoryRow } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
 
   const filter = buildLocationFilter({
     always_allow: ['belgium', 'brussels'],
@@ -1015,6 +1015,43 @@ try {
     pass('scan-history TTL rechecks old added URLs while permanent statuses stay deduped');
   } else {
     fail('scan-history TTL policy did not match expected recheck/permanent behavior');
+  }
+
+  const pipelineTmp = mkdtempSync(join(tmpdir(), 'career-ops-pipeline-'));
+  const previousCwd = process.cwd();
+  try {
+    mkdirSync(join(pipelineTmp, 'data'), { recursive: true });
+    writeFileSync(join(pipelineTmp, 'data', 'pipeline.md'), '# Pipeline\n\n## Pendientes\n\n## Procesadas\n');
+    process.chdir(pipelineTmp);
+    appendToPipeline([
+      { url: 'https://jobs.example.com/with-location', company: 'Acme', title: 'AI Engineer', location: 'Remote, EU' },
+      { url: 'https://jobs.example.com/legacy-shape', company: 'Beta', title: 'Product Lead', location: '' },
+    ]);
+    const pipelineText = readFileSync(join(pipelineTmp, 'data', 'pipeline.md'), 'utf-8');
+    if (pipelineText.includes('- [ ] https://jobs.example.com/with-location | Acme | AI Engineer | Remote, EU')) {
+      pass('scan pipeline writer preserves location as optional fourth column');
+    } else {
+      fail('scan pipeline writer did not preserve location in pipeline.md');
+    }
+    if (pipelineText.includes('- [ ] https://jobs.example.com/legacy-shape | Beta | Product Lead')) {
+      pass('scan pipeline writer keeps legacy 3-column shape when location is missing');
+    } else {
+      fail('scan pipeline writer should omit empty location columns for backward compatibility');
+    }
+    const { seen } = loadSeenUrls();
+    if (seen.has('https://jobs.example.com/with-location') && seen.has('https://jobs.example.com/legacy-shape')) {
+      pass('pipeline URL dedup still reads location and legacy pipeline rows');
+    } else {
+      fail('pipeline URL dedup should read both location and legacy pipeline rows');
+    }
+    if (formatPipelineOffer({ url: 'u', company: 'c', title: 't', location: '  ' }) === '- [ ] u | c | t') {
+      pass('formatPipelineOffer trims blank locations instead of writing empty columns');
+    } else {
+      fail('formatPipelineOffer should not write blank location columns');
+    }
+  } finally {
+    process.chdir(previousCwd);
+    rmSync(pipelineTmp, { recursive: true, force: true });
   }
 
 } catch (e) {


### PR DESCRIPTION
Context
This implements the B1 item from #586 only. scan.mjs already receives provider locations, but pipeline rows dropped them before the evaluation step.

Changes
- Preserve location as an optional fourth pending pipeline column when known: URL | Company | Role | Location.
- Keep legacy URL-only and 3-column pipeline rows valid; blank locations are omitted.
- Update the central EN scan/pipeline docs and add behavioral coverage in test-all.mjs.

How to test
- npm install --no-package-lock
- node --check scan.mjs
- node --check test-all.mjs
- node test-all.mjs

Local note: on this Windows worktree, node test-all.mjs reaches 273 passed, 3 failed, 1 warning. The remaining failures are the pre-existing Windows symlink/skill integrity checks for .claude/.opencode; the new scan location tests pass. CI should provide the canonical Linux result.

Risks / rollback
Low risk: only scan-created pending rows gain optional metadata. Existing rows remain compatible. Rollback is reverting this commit.

Refs #586 (B1 only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipeline “Pending” entries can now show Location as an optional 4th column when known, while preserving legacy 3-column/URL-only formats.
  * Deduplication considers exact public `http(s)` URLs found in pipeline entries; private sources are handled separately.

* **Documentation**
  * Updated pipeline and scan mode docs to clarify optional Location metadata and backward compatibility with legacy row shapes.
  * Updated scan-history examples to reflect the optional Location column.

* **Tests**
  * Added regression coverage for conditional row formatting, whitespace-only Location trimming, cross-format deduplication, and appending to newly created pipeline paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->