### PR TITLE
fix(update): distribute missing runtime paths

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -51,11 +51,13 @@ const SYSTEM_PATHS = [
   'modes/project.md',
   'modes/tracker.md',
   'modes/training.md',
+  'modes/interview.md',
   'modes/latex.md',
   'modes/followup.md',
   'modes/interview-prep.md',
   'modes/patterns.md',
   'modes/update.md',
+  'modes/ar/',
   'modes/de/',
   'modes/fr/',
   'modes/ja/',
@@ -92,6 +94,7 @@ const SYSTEM_PATHS = [
   'gemini-eval.mjs',
   'test-all.mjs',
   'test-salary-filter.mjs',
+  'tracker-columns-tests.mjs',
   'validate-portals.mjs',
   'updater-migration-tests.mjs',
   'batch/batch-prompt.md',
@@ -115,6 +118,7 @@ const SYSTEM_PATHS = [
   'DATA_CONTRACT.md',
   'CONTRIBUTING.md',
   'README.md',
+  'README.ar.md',
   'README.cn.md',
   'README.es.md',
   'README.fr.md',
@@ -406,7 +410,7 @@ async function apply() {
     // Every release that adds a file imported by other system scripts MUST
     // append it here, or clients on older versions break on upgrade
     // (e.g. v1.8.x → v1.9.0: merge-tracker.mjs imports tracker-links.mjs).
-    const BOOTSTRAP_PATHS = ['.agents/', '.opencode/skills/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'role-matcher.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs'];
+    const BOOTSTRAP_PATHS = ['.agents/', '.opencode/skills/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'role-matcher.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs', 'tracker-columns-tests.mjs'];
     for (const path of BOOTSTRAP_PATHS) {
       if (SYSTEM_PATHS.includes(path)) continue; // already in main loop
       try {

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -47,9 +47,11 @@ const bootstrapPaths = extractArray('BOOTSTRAP_PATHS');
 
 const requiredSystemPaths = [
   'modes/followup.md',
+  'modes/interview.md',
   'modes/interview-prep.md',
   'modes/patterns.md',
   'modes/update.md',
+  'modes/ar/',
   'modes/tr/',
   'modes/ua/',
   'batch/README.md',
@@ -58,7 +60,9 @@ const requiredSystemPaths = [
   '.env.example',
   '.claude-plugin/',
   '.qwen/',
+  'tracker-columns-tests.mjs',
   'updater-migration-tests.mjs',
+  'README.ar.md',
   'README.ja.md',
   'README.ua.md',
   'CHANGELOG.md',
@@ -74,6 +78,7 @@ const requiredBootstrapPaths = [
   'providers/',
   'liveness-browser.mjs',
   'updater-migration-tests.mjs',
+  'tracker-columns-tests.mjs',
 ];
 
 for (const path of requiredSystemPaths) {


### PR DESCRIPTION
﻿## Context

Closes #990.

`update-system.mjs` was missing several tracked system/runtime paths, so installs updated through `node update-system.mjs apply` could miss files that are already referenced by docs or tests.

## Changes

- Add missing distributed paths to `SYSTEM_PATHS`:
  - `modes/interview.md`
  - `modes/ar/`
  - `README.ar.md`
  - `tracker-columns-tests.mjs`
- Add `tracker-columns-tests.mjs` to `BOOTSTRAP_PATHS` because new `test-all.mjs` invokes it directly.
- Extend `updater-migration-tests.mjs` coverage for the new paths and bootstrap requirement.

## How to test

- `npm install --no-package-lock`
- `node --check update-system.mjs`
- `node --check updater-migration-tests.mjs`
- `npm run update:test`
- `node tracker-columns-tests.mjs`
- `git diff --check`

Also ran `node test-all.mjs` through Git Bash on Windows: 269 passed, 3 failed, 1 warning. The remaining failures are the existing local Windows non-symlink checkout failures for `.claude/skills/career-ops/SKILL.md` and `.opencode/skills/career-ops/SKILL.md`; no failures are from this updater change.

## Risk / rollback

Low risk: this only expands the updater manifest to ship already-tracked system files and adds regression coverage. Rollback is reverting this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Arabic language support and localization documentation.

* **Chores**
  * Updated the system-file allowlist and bootstrap fallback list to improve cross-version update compatibility.

* **Tests**
  * Enhanced updater migration tests to verify required system/bootstrap entries are present for additional modes and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->