### PR TITLE
fix(update): block dirty user-layer updates

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -228,6 +228,26 @@ function gitStatusEntries() {
     }));
 }
 
+function pathMatches(path, candidate) {
+  if (candidate.endsWith('/')) return path.startsWith(candidate);
+  return path === candidate;
+}
+
+function isSystemLayerPath(path) {
+  return SYSTEM_PATHS.some(systemPath => pathMatches(path, systemPath));
+}
+
+function isUserLayerPath(path) {
+  if (isSystemLayerPath(path)) return false;
+  return USER_PATHS.some(userPath => pathMatches(path, userPath));
+}
+
+function dirtyUserLayerPaths() {
+  return gitStatusEntries()
+    .filter(entry => isUserLayerPath(entry.path))
+    .map(entry => entry.path);
+}
+
 function revertPaths(paths) {
   if (paths.length === 0) return;
   git('checkout', '--', ...paths);
@@ -371,6 +391,16 @@ async function check() {
 async function apply() {
   const local = localVersion();
   const initialStatusPaths = new Set(gitStatusEntries().map(entry => entry.path));
+  const dirtyUserPaths = dirtyUserLayerPaths();
+
+  if (dirtyUserPaths.length > 0) {
+    console.error('Update aborted: user-layer files have uncommitted changes.');
+    console.error('Commit, stash, or back up these files before running update-system.mjs apply:');
+    for (const path of dirtyUserPaths) {
+      console.error(`- ${path}`);
+    }
+    process.exit(1);
+  }
 
   // Check for lock
   const lockFile = join(ROOT, '.update-lock');
@@ -439,12 +469,10 @@ async function apply() {
         if (initialStatusPaths.has(file)) continue;
         // Explicit SYSTEM_PATHS entries override USER_PATHS prefix matches.
         // (e.g. writing-samples/README.md is system-owned doc inside a user dir.)
-        if (SYSTEM_PATHS.includes(file)) continue;
-        for (const userPath of USER_PATHS) {
-          if (file.startsWith(userPath)) {
-            console.error(`SAFETY VIOLATION: User file was modified: ${file}`);
-            violatedUserPaths.add(file);
-          }
+        if (isSystemLayerPath(file)) continue;
+        if (isUserLayerPath(file)) {
+          console.error(`SAFETY VIOLATION: User file was modified: ${file}`);
+          violatedUserPaths.add(file);
         }
       }
     } catch (err) {

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -91,6 +91,12 @@ for (const userPath of ['cv.md', 'config/profile.yml', 'modes/_profile.md', 'por
   else fail(`USER_PATHS missing ${userPath}`);
 }
 
+if (source.includes('function dirtyUserLayerPaths()') && source.includes('Update aborted: user-layer files have uncommitted changes.')) {
+  pass('apply() refuses to run with dirty user-layer paths');
+} else {
+  fail('apply() must refuse to run with dirty user-layer paths before checkout');
+}
+
 const allowedSystemUserOverlap = new Set(['writing-samples/README.md']);
 let hasSystemUserCollision = false;
 for (const systemPath of systemPaths) {


### PR DESCRIPTION
## Summary
- add a preflight guard that aborts `update-system.mjs apply` when Git sees dirty user-layer paths
- reuse shared system/user path matching for the apply safety check
- add source-level coverage so updater migrations keep the guard in place

Closes #995.

## Validation
- `node updater-migration-tests.mjs` -> 37 passed, 0 failed
- forced a tracked dirty `interview-prep/story-bank.md`; `node update-system.mjs apply` aborted before checkout and listed the file
- `node test-all.mjs` -> 270 passed, 1 failed, 16 warnings; only failure here is dashboard build because this machine does not have `go` installed (`go: command not found`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safety checks that prevent system updates when you have uncommitted user-layer changes, displaying a clear list of affected files to help you resolve conflicts before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->