### PR TITLE
fix(tracker): preserve notes column when rewriting rows without a trailing pipe

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -229,6 +229,27 @@ function parseScore(s) {
  * @param {string} line - One line from applications.md.
  * @returns {object|null} Parsed tracker row, or null for non-application lines.
  */
+/**
+ * Rebuild a markdown table row from the cells produced by `line.split('|')`.
+ *
+ * `split('|')` yields a leading empty element (before the opening `|`) and,
+ * when the row ends with a trailing `|`, a trailing empty element too. The old
+ * `slice(1, -1)` assumed that trailing empty always existed — but a row written
+ * without a trailing pipe (`| 5 | … | note`, still a valid 9-cell row) has its
+ * real last cell (the notes) at the end, so `slice(1, -1)` silently dropped it.
+ * Here we drop the leading empty and only drop a trailing element when it is
+ * actually empty, preserving every real cell regardless of trailing-pipe style
+ * (and tolerating extra columns like a custom Location).
+ *
+ * @param {string[]} parts - Trimmed cells from `line.split('|').map(s => s.trim())`.
+ * @returns {string} The rebuilt `| a | b | … |` row.
+ */
+function rebuildRow(parts) {
+  const cells = parts.slice(1);
+  if (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
+  return '| ' + cells.join(' | ') + ' |';
+}
+
 function parseAppLine(line) {
   const parts = line.split('|').map(s => s.trim());
   if (parts.length < 9) return null;
@@ -323,7 +344,7 @@ for (const [company, companyEntries] of groups) {
       if (lineIdx !== undefined) {
         const parts = lines[lineIdx].split('|').map(s => s.trim());
         parts[6] = bestStatus;
-        lines[lineIdx] = '| ' + parts.slice(1, -1).join(' | ') + ' |';
+        lines[lineIdx] = rebuildRow(parts);
         console.log(`  📝 #${keeper.num}: status promoted to "${bestStatus}" (from #${cluster.find(e => e.status === bestStatus)?.num})`);
       }
     }

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -86,6 +86,23 @@ function normalizeStatus(raw) {
   return { status: null, unknown: true };
 }
 
+/**
+ * Rebuild a markdown table row from `line.split('|')` cells without dropping the
+ * last real cell. `split('|')` adds a leading empty element and, only when the
+ * row ends with `|`, a trailing empty one. The old `slice(1, -1)` assumed that
+ * trailing empty always existed, so a row written without a trailing pipe
+ * (`| 5 | … | note`) lost its notes cell on rewrite. Drop the leading empty and
+ * only drop a trailing element when it is genuinely empty.
+ *
+ * @param {string[]} parts - Trimmed cells from `line.split('|').map(s => s.trim())`.
+ * @returns {string} The rebuilt `| a | b | … |` row.
+ */
+function rebuildRow(parts) {
+  const cells = parts.slice(1);
+  if (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
+  return '| ' + cells.join(' | ') + ' |';
+}
+
 // Read applications.md
 if (!existsSync(APPS_FILE)) {
   console.log('No applications.md found. Nothing to normalize.');
@@ -139,7 +156,7 @@ for (let i = 0; i < lines.length; i++) {
   }
 
   // Reconstruct line
-  const newLine = '| ' + parts.slice(1, -1).join(' | ') + ' |';
+  const newLine = rebuildRow(parts);
   lines[i] = newLine;
   changes++;
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1735,6 +1735,47 @@ try {
   fail(`shared role matcher / dedup safety tests crashed: ${e.message}`);
 }
 
+// dedup-tracker / normalize-statuses rebuilt promoted rows with
+// `parts.slice(1, -1)`, which assumes the closing `|` produced a trailing empty
+// cell. A valid row written WITHOUT a trailing pipe keeps its real last cell
+// (the notes) at the end, so the old reconstruction silently dropped the notes
+// when promoting a keeper's status during dedup. rebuildRow() now preserves it.
+console.log('\n🧪 Testing dedup row rebuild preserves notes on no-trailing-pipe rows...');
+try {
+  const rebuildTmp = mkdtempSync(join(tmpdir(), 'career-ops-rebuild-'));
+  try {
+    mkdirSync(join(rebuildTmp, 'data'));
+    const tracker = join(rebuildTmp, 'data', 'applications.md');
+    // Keeper row #50 has the higher score AND no trailing pipe; dup #51 carries a
+    // more-advanced status (both below Applied, so the advanced-status safety
+    // guard doesn't block the collapse), so dedup promotes #50's status and
+    // rewrites the row — exercising rebuildRow() on a no-trailing-pipe row.
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 50 | 2026-02-01 | Globex | Widget Engineer | 4.5/5 | Rejected | ❌ | [50](../reports/050-widget.md) | KEEPER_NOTE_SENTINEL\n' +
+      '| 51 | 2026-02-02 | Globex | Widget Engineer | 3.0/5 | Evaluated | ❌ | [51](../reports/051-widget.md) | dup row |\n');
+
+    const r = run(NODE, ['dedup-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
+    if (r === null) {
+      fail('dedup-tracker.mjs crashed during notes-preservation test');
+    } else {
+      const out = readFileSync(tracker, 'utf-8');
+      const keeperRow = out.split('\n').find(l => l.includes('| 50 |'));
+      if (keeperRow && keeperRow.includes('KEEPER_NOTE_SENTINEL') && keeperRow.includes('Evaluated')) {
+        pass('dedup row rebuild preserves the notes column on rows without a trailing pipe');
+      } else {
+        fail(`dedup row rebuild dropped notes / status on no-trailing-pipe row: "${keeperRow}"`);
+      }
+    }
+  } finally {
+    rmSync(rebuildTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`dedup row-rebuild notes test crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER FUZZY DEDUP (#751 / #721 family) ──────────────
 // roleFuzzyMatch over-matched whenever the token overlap dominated the
 // SMALLER side: two distinct roles sharing a long prefix ("Full-Stack


### PR DESCRIPTION
## Summary

`dedup-tracker.mjs` and `normalize-statuses.mjs` both rebuild a modified tracker row with:

```js
'| ' + parts.slice(1, -1).join(' | ') + ' |'
```

That `slice(1, -1)` assumes `line.split('|')` produced a **trailing empty element** from the closing `|`. But a row written **without** a trailing pipe — e.g. `| 5 | … | report | note` — is still valid markdown and parses fine (`parts.length >= 9`, all column indices resolve), yet its real last cell (the **notes**) now sits at the end of the array. The old reconstruction dropped it, **silently deleting the notes** on any row these scripts rewrite.

In `normalize-statuses.mjs` it's worse: the script can *write* to `parts[9]` (moving DUPLICADO info into notes) and then **drop that same cell** in the reconstruction pass.

Both the Go dashboard parser and `verify-pipeline.mjs` already tolerate rows without a trailing pipe, so such rows do exist in the wild (manual edits, external tooling) — they just got their notes quietly eaten on the next dedup/normalize.

## Fix

A shared `rebuildRow(parts)` helper in each script: drop the leading empty element, and drop a trailing element **only when it is genuinely empty**. Every real cell is preserved regardless of trailing-pipe style, and it tolerates extra columns (e.g. a custom Location column).

```js
function rebuildRow(parts) {
  const cells = parts.slice(1);
  if (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
  return '| ' + cells.join(' | ') + ' |';
}
```

## Test plan
- [x] New regression test: a dedup status-promotion on a **no-trailing-pipe keeper row** asserts the notes column survives the rewrite (`test-all.mjs`). It fails on the old `slice(1, -1)` and passes with `rebuildRow`.
- [x] `node test-all.mjs --quick` → **271 passed, 0 failed**
- [x] No behavior change for rows that already end with a trailing pipe (the common case).

## Notes
- Found via a codebase scout; **no existing issue or PR** covers this (verified against the open issue/PR list).
- Scoped to the two `.mjs` rewriters that used the brittle `slice(1, -1)` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed markdown table row handling to consistently preserve the notes column when normalizing and deduplicating table data, regardless of row format.

* **Tests**
  * Added regression test to verify notes column preservation in table rows without trailing pipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->