### PR TITLE
[draft] proposal: structural SYSTEM_PATHS/USER_PATHS coverage check

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -94,6 +94,7 @@ const SYSTEM_PATHS = [
   'test-salary-filter.mjs',
   'validate-portals.mjs',
   'updater-migration-tests.mjs',
+  'validate-system-paths-coverage.mjs',
   'batch/batch-prompt.md',
   'batch/batch-runner.sh',
   'batch/README.md',

--- a/validate-system-paths-coverage.mjs
+++ b/validate-system-paths-coverage.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * validate-system-paths-coverage.mjs — structural coverage check for the
+ * auto-updater layer split.
+ *
+ * Every tracked file in the repo must be covered by either SYSTEM_PATHS
+ * (system layer, fetched on `update-system.mjs apply`) or USER_PATHS
+ * (user-owned, never touched). Anything else is a coverage gap: it
+ * lives in the repo but the auto-updater won't propagate it to
+ * clients on `apply`. That breaks them on the next test run.
+ *
+ * Complements updater-migration-tests.mjs which checks a HARDCODED
+ * list of required paths — that catches drift in known paths, this
+ * catches the "we forgot to add the new file" class entirely.
+ *
+ * Run: node validate-system-paths-coverage.mjs
+ * Exit 0 = clean. Exit 1 = orphan files listed.
+ */
+
+import { execFileSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
+
+function extractArray(name) {
+  const match = source.match(new RegExp(`const\\s+${name}\\s*=\\s*\\[([\\s\\S]*?)\\];`));
+  if (!match) {
+    console.error(`FAIL ${name} array not found in update-system.mjs`);
+    process.exit(1);
+  }
+  return Array.from(match[1].matchAll(/'([^']+)'/g), (m) => m[1]);
+}
+
+const SYSTEM_PATHS = extractArray('SYSTEM_PATHS');
+const USER_PATHS = extractArray('USER_PATHS');
+const ALL_PATHS = [...SYSTEM_PATHS, ...USER_PATHS];
+
+function covered(file) {
+  return ALL_PATHS.some((path) =>
+    path.endsWith('/') ? file.startsWith(path) : file === path,
+  );
+}
+
+const tracked = execFileSync('git', ['ls-files'], {
+  cwd: ROOT,
+  encoding: 'utf-8',
+})
+  .trim()
+  .split('\n')
+  .filter(Boolean);
+
+const orphans = tracked.filter((f) => !covered(f));
+
+if (orphans.length > 0) {
+  console.error('Coverage gap — tracked files not in SYSTEM_PATHS or USER_PATHS:');
+  for (const orphan of orphans) console.error(`  ${orphan}`);
+  console.error('');
+  console.error('Add each path to update-system.mjs SYSTEM_PATHS (if system layer)');
+  console.error('or USER_PATHS (if user-owned), then re-run this check.');
+  process.exit(1);
+}
+
+console.log(`OK ${tracked.length} tracked files covered by SYSTEM_PATHS or USER_PATHS`);


### PR DESCRIPTION
**Draft — opened in case it helps, not requesting review.** See #1005 for the proposal and design questions; merge only if you decide to take that direction.

## What this is

A small script (`validate-system-paths-coverage.mjs`, ~35 lines) that asserts every tracked file in the repo is covered by either `SYSTEM_PATHS` or `USER_PATHS` in `update-system.mjs` (exact match for files, prefix match for directory entries). Catches the class of bug behind #1002 structurally — no hardcoded list of "required paths" to drift out of sync.

## Output on current main

Running it against `main` right now flags 19 orphans, including:

```
modes/interview.md           ← the #1002 case
tracker-columns-tests.mjs    ← the #1002 case
modes/ar/ (whole tree)       ← Arabic language pack
README.ar.md
.coderabbit.yaml / .envrc / .gitignore / renovate.json / flake.lock / ...
batch/logs/.gitkeep / batch/tracker-additions/.gitkeep / interview-prep/.gitkeep
```

The Arabic mode pack alone is a real find — anyone setting `language.modes_dir: modes/ar` in `config/profile.yml` is missing the whole language on every fresh apply.

## What this PR does

1. Adds `validate-system-paths-coverage.mjs` (the script).
2. Adds it to `SYSTEM_PATHS` in `update-system.mjs` so it propagates to clients on `apply`.

## What this PR deliberately does NOT do

1. **Does not wire into `test-all.mjs`.** That would break CI immediately on the orphans listed above — the right move is to resolve / explicitly exclude those first, then wire it as a hard gate in a follow-up.
2. **Does not add an EXCLUDES mechanism.** Some of the orphans (e.g. `.coderabbit.yaml`, `renovate.json`, `flake.lock`) are likely maintainer-only and should be excluded from coverage rather than added to either list. The exclusion design is in #1005 for your call.
3. **Does not change `updater-migration-tests.mjs`.** The hardcoded-list approach there is still useful as an extra anchor — this script is meant to complement it, not replace it.

## If you want this landed

Happy to take it the rest of the way:

- Decide on exclusion mechanism (likely a small `EXCLUDES` array).
- Triage current orphans: add legitimate ones to `SYSTEM_PATHS`/`USER_PATHS`, exclude maintainer-only ones.
- Wire into `test-all.mjs`.
- Backfill any missing paths discovered in the triage (the Arabic pack at minimum).

## If you'd rather not

Close it — no work lost on your side, and the structural idea is documented in #1005 if you want to revisit it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)