### PR TITLE
feat(cover): add optional salutation/greeting to cover letters

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -8,45 +8,15 @@
  *
  * Fills templates/cover-letter-template.html with the payload, then renders
  * it to PDF via the same Playwright pipeline used for CVs (generate-pdf.mjs).
+ *
+ * `buildHtml` is exported as a pure function so the template can be tested
+ * without loading Playwright (renderHtmlToPdf is imported lazily inside main).
  */
 
 import { readFileSync, existsSync, mkdirSync } from "fs";
 import { dirname, resolve, basename, join } from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { parseArgs } from "util";
-import { renderHtmlToPdf } from "./generate-pdf.mjs";
-
-const { values: args } = parseArgs({
-  options: {
-    payload: { type: "string" },
-    out:     { type: "string" },
-    help:    { type: "boolean", short: "h" },
-  },
-  strict: false,
-});
-
-if (args.help || !args.payload) {
-  console.log(`
-Usage:
-  node generate-cover-letter.mjs --payload payload.json [--out output/path.pdf]
-
-  --payload   Path to the JSON payload file (required)
-  --out       Override output path from payload (optional)
-`);
-  process.exit(args.help ? 0 : 1);
-}
-
-const payloadPath = resolve(args.payload);
-if (!existsSync(payloadPath)) {
-  console.error(`ERROR: payload file not found: ${payloadPath}`);
-  process.exit(1);
-}
-
-const payload = JSON.parse(readFileSync(payloadPath, "utf-8"));
-
-if (args.out) {
-  payload.output_path = args.out;
-}
 
 const OUTPUT_ROOT = resolve("output");
 
@@ -55,16 +25,6 @@ function safeOutputPath(raw) {
   const filename = basename(raw).replace(/[^a-zA-Z0-9._-]/g, "-").replace(/\.{2,}/g, "-");
   return join(OUTPUT_ROOT, filename);
 }
-
-if (!payload.output_path) {
-  const company = (payload.letter?.company || "company").toLowerCase().replace(/[^a-z0-9]+/g, "-");
-  const role    = (payload.letter?.role_title || "role").toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 30);
-  payload.output_path = join(OUTPUT_ROOT, `${company}-${role}-cover.pdf`);
-} else {
-  payload.output_path = safeOutputPath(payload.output_path);
-}
-
-if (!existsSync(OUTPUT_ROOT)) mkdirSync(OUTPUT_ROOT, { recursive: true });
 
 function _require(obj, keys, context) {
   for (const key of keys) {
@@ -143,7 +103,7 @@ function buildFootnotesBlock(footnotes) {
   return `<div class="footnotes">\n${lines}\n  </div>`;
 }
 
-function buildHtml(payload) {
+export function buildHtml(payload) {
   _require(payload, ["candidate", "letter"], "payload");
   const candidate = payload.candidate;
   const letter = payload.letter;
@@ -154,6 +114,9 @@ function buildHtml(payload) {
   const templatePath = resolve(scriptDir, "templates", "cover-letter-template.html");
   let html = readFileSync(templatePath, "utf-8");
 
+  // Optional salutation (e.g. "Dear Jane Smith,"). Omitted -> no salutation,
+  // preserving the original behavior for payloads that don't set it.
+  const greetingBlock = letter.greeting ? `<p class="greeting">${escapeHtml(letter.greeting)}</p>` : "";
   const closingBlock = letter.closing ? `<p>${escapeHtml(letter.closing)}</p>` : "";
   const languageClosingBlock = letter.language_closing
     ? `<p class="language-closing">${escapeHtml(letter.language_closing)}</p>`
@@ -166,6 +129,7 @@ function buildHtml(payload) {
     "{{CREDENTIALS_BLOCK}}": buildCredentialsBlock(candidate),
     "{{ROLE_TITLE}}": escapeHtml(letter.role_title),
     "{{DATELINE}}": buildDateline(letter),
+    "{{GREETING_BLOCK}}": greetingBlock,
     "{{OPENING}}": escapeHtml(letter.opening),
     "{{PROFILE_INTRO}}": escapeHtml(letter.profile_intro),
     "{{ACHIEVEMENTS_BLOCK}}": buildAchievementsBlock(letter.achievements),
@@ -182,13 +146,63 @@ function buildHtml(payload) {
   return html;
 }
 
-try {
-  const html = buildHtml(payload);
-  const outputPath = resolve(payload.output_path);
-  await renderHtmlToPdf(html, outputPath, { format: "a4" });
-  console.log(`\nCover letter PDF: ${payload.output_path}`);
-} catch (err) {
-  console.error("ERROR generating cover letter PDF:");
-  console.error(err.message);
-  process.exit(1);
+async function main() {
+  const { values: args } = parseArgs({
+    options: {
+      payload: { type: "string" },
+      out:     { type: "string" },
+      help:    { type: "boolean", short: "h" },
+    },
+    strict: false,
+  });
+
+  if (args.help || !args.payload) {
+    console.log(`
+Usage:
+  node generate-cover-letter.mjs --payload payload.json [--out output/path.pdf]
+
+  --payload   Path to the JSON payload file (required)
+  --out       Override output path from payload (optional)
+`);
+    process.exit(args.help ? 0 : 1);
+  }
+
+  const payloadPath = resolve(args.payload);
+  if (!existsSync(payloadPath)) {
+    console.error(`ERROR: payload file not found: ${payloadPath}`);
+    process.exit(1);
+  }
+
+  const payload = JSON.parse(readFileSync(payloadPath, "utf-8"));
+
+  if (args.out) {
+    payload.output_path = args.out;
+  }
+
+  if (!payload.output_path) {
+    const company = (payload.letter?.company || "company").toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    const role    = (payload.letter?.role_title || "role").toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 30);
+    payload.output_path = join(OUTPUT_ROOT, `${company}-${role}-cover.pdf`);
+  } else {
+    payload.output_path = safeOutputPath(payload.output_path);
+  }
+
+  if (!existsSync(OUTPUT_ROOT)) mkdirSync(OUTPUT_ROOT, { recursive: true });
+
+  // Imported lazily so buildHtml can be used (and tested) without Playwright.
+  const { renderHtmlToPdf } = await import("./generate-pdf.mjs");
+
+  try {
+    const html = buildHtml(payload);
+    const outputPath = resolve(payload.output_path);
+    await renderHtmlToPdf(html, outputPath, { format: "a4" });
+    console.log(`\nCover letter PDF: ${payload.output_path}`);
+  } catch (err) {
+    console.error("ERROR generating cover letter PDF:");
+    console.error(err.message);
+    process.exit(1);
+  }
 }
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) main();

--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -139,11 +139,12 @@ export function buildHtml(payload) {
     "{{FOOTNOTES_BLOCK}}": buildFootnotesBlock(letter.footnotes),
   };
 
-  for (const [token, value] of Object.entries(replacements)) {
-    html = html.split(token).join(value);
-  }
-
-  return html;
+  // Single-pass substitution: each {{TOKEN}} is replaced exactly once against
+  // the original template. A single regex pass (rather than iterative
+  // split/join) ensures a substituted value that itself contains a {{TOKEN}}
+  // sequence is left literal instead of being re-interpreted as a placeholder.
+  // Tokens with no entry in the map are left untouched.
+  return html.replace(/\{\{[A-Z_]+\}\}/g, (token) => replacements[token] ?? token);
 }
 
 async function main() {

--- a/modes/cover.md
+++ b/modes/cover.md
@@ -215,6 +215,9 @@ Cover Letter: [Role Title]
 
 ────────────────────────────────────────────────
 
+[Salutation — optional]
+Address the named hiring manager if known, e.g. "Dear Jane Smith,". Omit if no name.
+
 [Opening — 2 sentences]
 Why applying + functional summary. Derived from Angle A. Uses JD mirror vocabulary.
 
@@ -282,6 +285,7 @@ Assemble the JSON payload:
     "company": "{company name}",
     "city": "{JD city}",
     "date": "{YYYY-MM-DD}",
+    "greeting": "{optional salutation, e.g. 'Dear Jane Smith,'; omit the key to skip the salutation}",
     "opening": "{approved opening paragraph}",
     "profile_intro": "{approved profile intro}",
     "achievements": [

--- a/templates/cover-letter-template.html
+++ b/templates/cover-letter-template.html
@@ -60,6 +60,10 @@
     margin-bottom: 12pt;
   }
 
+  .greeting {
+    margin-bottom: 8pt;
+  }
+
   p {
     margin-bottom: 8pt;
   }
@@ -110,6 +114,7 @@
   <div class="role-title">Cover Letter: {{ROLE_TITLE}}</div>
   <div class="dateline">{{DATELINE}}</div>
 
+  {{GREETING_BLOCK}}
   <p>{{OPENING}}</p>
   <p>{{PROFILE_INTRO}}</p>
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2576,6 +2576,42 @@ try {
   fail(`Cover letter greeting test crashed: ${e.message}`);
 }
 
+// ── 18. COVER LETTER SINGLE-PASS SUBSTITUTION ───────────────────
+
+console.log('\n18. Cover letter single-pass substitution');
+
+try {
+  const { buildHtml } = await import(pathToFileURL(join(ROOT, 'generate-cover-letter.mjs')).href);
+
+  // A field value that itself contains literal {{TOKEN}} sequences must NOT be
+  // re-substituted. The old iterative split/join loop would have blanked these
+  // (no footnotes/closing in the payload → replaced with ""). Single-pass leaves
+  // them verbatim because replacement output is never re-scanned.
+  const injected = buildHtml({
+    candidate: { name: 'Jane Doe' },
+    letter: {
+      role_title: 'Engineer',
+      opening: 'See {{FOOTNOTES_BLOCK}} and {{CLOSING_BLOCK}} markers.',
+      profile_intro: 'Intro.',
+    },
+  });
+
+  if (injected.includes('See {{FOOTNOTES_BLOCK}} and {{CLOSING_BLOCK}} markers.')) {
+    pass('Field values containing {{TOKEN}} are left literal (single-pass, not re-substituted)');
+  } else {
+    fail('A field value containing {{TOKEN}} was re-substituted');
+  }
+
+  // Known template tokens still resolve, and no unreplaced tokens leak through.
+  if (injected.includes('Jane Doe') && !injected.includes('{{NAME}}') && !injected.includes('{{ROLE_TITLE}}')) {
+    pass('Known template tokens still substitute under single-pass');
+  } else {
+    fail('Single-pass substitution left a known token unreplaced');
+  }
+} catch (e) {
+  fail(`Cover letter single-pass substitution test crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2522,6 +2522,60 @@ try {
   fail(`update-system SEMVER_RE test crashed: ${e.message}`);
 }
 
+// ── 17. COVER LETTER GREETING BLOCK ─────────────────────────────
+
+console.log('\n17. Cover letter greeting block');
+
+try {
+  const { buildHtml } = await import(pathToFileURL(join(ROOT, 'generate-cover-letter.mjs')).href);
+
+  const basePayload = {
+    candidate: { name: 'Jane Doe' },
+    letter: {
+      role_title: 'Head of Applied AI',
+      opening: 'OPENING_MARKER sentence.',
+      profile_intro: 'Profile intro.',
+    },
+  };
+
+  // (a) greeting present → renders <p class="greeting"> above the opening
+  const withGreeting = buildHtml({
+    ...basePayload,
+    letter: { ...basePayload.letter, greeting: 'Dear Hiring Manager,' },
+  });
+  const greetingTag = '<p class="greeting">Dear Hiring Manager,</p>';
+  const greetingIdx = withGreeting.indexOf(greetingTag);
+  const openingIdx = withGreeting.indexOf('OPENING_MARKER');
+  if (greetingIdx !== -1 && openingIdx !== -1 && greetingIdx < openingIdx) {
+    pass('Greeting renders as <p class="greeting"> above the opening');
+  } else {
+    fail(`Greeting block missing or misordered (greeting=${greetingIdx}, opening=${openingIdx})`);
+  }
+
+  // greeting text is HTML-escaped
+  const escaped = buildHtml({
+    ...basePayload,
+    letter: { ...basePayload.letter, greeting: 'Dear <O\'Brien> & "Co",' },
+  });
+  if (escaped.includes('Dear &lt;O&#39;Brien&gt; &amp; &quot;Co&quot;,') && !escaped.includes('Dear <O\'Brien>')) {
+    pass('Greeting text is HTML-escaped');
+  } else {
+    fail('Greeting text was not HTML-escaped');
+  }
+
+  // (b) greeting omitted → no salutation, no leftover token (backward compatible)
+  const withoutGreeting = buildHtml(basePayload);
+  if (!withoutGreeting.includes('class="greeting"')
+      && !withoutGreeting.includes('{{GREETING_BLOCK}}')
+      && withoutGreeting.includes('OPENING_MARKER')) {
+    pass('Omitted greeting leaves no salutation and no leftover token (backward compatible)');
+  } else {
+    fail('Omitted greeting did not render cleanly (stray greeting markup or unreplaced token)');
+  }
+} catch (e) {
+  fail(`Cover letter greeting test crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What does this PR do?

Adds an optional `letter.greeting` salutation (e.g. "Dear Jane Smith,") to the cover-letter generator. When present it renders as a `<p class="greeting">` directly above the opening paragraph; when omitted, output is identical to today, so existing payloads are unaffected.

Also hardens `buildHtml`'s template substitution to a single regex pass (second commit), so a field value that contains a literal `{{TOKEN}}` is no longer re-interpreted as a placeholder.

## Related issue

Closes #1009

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## What changed

**`feat(cover): add optional salutation/greeting`**
- **`templates/cover-letter-template.html`** — `{{GREETING_BLOCK}}` placeholder between the dateline and the opening, plus a `.greeting` style (matches the template's per-block convention, e.g. `.language-closing`).
- **`generate-cover-letter.mjs`** — fills the placeholder from `letter.greeting` (HTML-escaped via the existing `escapeHtml`). To make the renderer testable without a browser, `buildHtml` is now exported and `renderHtmlToPdf` is imported lazily inside a `main()` guarded by `import.meta.url === pathToFileURL(process.argv[1]).href` (the documented, percent-encoding-correct form already used by 5 scripts in this repo).
- **`modes/cover.md`** — documents the optional salutation (Step 8) and the `greeting` payload field (Step 9).

**`refactor(cover): single-pass template substitution`**
- **`generate-cover-letter.mjs`** — the token loop previously used iterative `html.split(token).join(value)`, which re-scanned already-substituted output. A field value containing a literal `{{TOKEN}}` (e.g. an opening of `"see {{FOOTNOTES_BLOCK}}"`) was therefore re-interpreted and blanked. Replaced with one `html.replace(/\{\{[A-Z_]+\}\}/g, t => replacements[t] ?? t)` pass — replacement output is never re-scanned (the standard template-substitution design). Unknown tokens are left untouched; empty values still resolve (`??` keeps `""`).

## Testing

- `node test-all.mjs --quick` → **275 passed, 0 failed** (16 pre-existing warnings from data-dependent scripts).
- New section 17 (greeting present/escaped/omitted) and section 18 (single-pass: a `{{TOKEN}}` inside a field value stays literal; known tokens still resolve).
- Manually rendered PDFs with/without `greeting` and with a `{{TOKEN}}`-bearing field — all valid single-page output; omitting `greeting` reproduces current output.

## Notes

- `DATA_CONTRACT.md` reviewed and intentionally left unchanged: `greeting` is a payload field, not a file-ownership concern, and all touched files are system-layer.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cover letters now support an optional greeting/salutation field. When provided, it appears after the dateline and before the opening paragraph; omit it to remove the salutation.
* **Bug Fixes**
  * Greeting content is now correctly HTML-escaped and rendered via a dedicated block (no leftover placeholders).
  * Template token replacement now avoids unintended re-substitution and leaves unknown placeholders untouched.
  * PDF generation failures are handled with clearer error logging and a non-zero exit code.
* **Tests**
  * Added automated tests for greeting block placement/escaping and for single-pass template token substitution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->