### PR TITLE
docs(cover): load modes/_profile.md in Step 1 so personalization governs the letter

### DIFF
--- a/modes/cover.md
+++ b/modes/cover.md
@@ -36,6 +36,8 @@ Read `cv.md` for:
 
 Read `article-digest.md` if it exists — supplementary proof points and metrics take precedence over cv.md where they overlap.
 
+Read `modes/_profile.md` if it exists — the candidate's personalization file. It captures their target roles, adaptive framing and archetypes, exit narrative, cross-cutting advantage, proof points, comp targets, negotiation scripts, location policy, and any voice or writing-style rules they have added. Its rules **govern the letter's voice and structure and override the generic defaults in this mode**, so the candidate's personalization is never lost.
+
 ---
 
 ## Step 2 — Parse the JD


### PR DESCRIPTION
## What does this PR do?

Adds one instruction to Step 1 of the cover-letter mode telling the agent to read `modes/_profile.md` (if it exists) and treat it as governing — its voice and structure rules override the mode's generic defaults.

## Related issue

Closes #1011

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Why

`modes/cover.md` Step 1 loaded `config/profile.yml`, `cv.md`, and `article-digest.md` but never `modes/_profile.md` — the documented home for the user's voice/writing-style rules, opener/close formulas, archetypes, location policy, and proof points. So a letter only sounded like the user when `_profile.md` already happened to be in the agent's context; in a fresh or headless run the personalization was silently dropped and the mode's generic defaults took over.

## What changed

- **`modes/cover.md`** — one added line in Step 1: read `modes/_profile.md` if it exists and treat its rules as governing/overriding the generic defaults. Placed alongside the existing `cv.md` / `article-digest.md` load instructions.

This is generic: it only points at `_profile.md`. The actual voice rules stay in `_profile.md` (a user-layer file, never auto-updated), so no personal data is in this change.

## Testing

- `node test-all.mjs --quick` → **270 passed, 0 failed** (16 pre-existing warnings from data-dependent scripts). Doc-only change; no behavior in code paths.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I linked a related issue above
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files — only the system-layer `modes/cover.md` pointer; the voice rules live in user-layer `modes/_profile.md`)
- [x] My changes align with the project roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cover letter generator now optionally loads a candidate profile file to apply personalization rules (voice/structure, opener/close formulas, word preferences, level archetypes, exit narrative, cross-cutting advantages, proof points, comp targets, negotiation scripts, and location policy). When available, these settings take precedence over the mode defaults for a more tailored letter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->