### PR TITLE
docs: sync CLAUDE.md language modes with AGENTS.md (Arabic + Turkish)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,8 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 - **German (DACH market):** `modes/de/` — native German translations with DACH-specific vocabulary (13. Monatsgehalt, Probezeit, Kündigungsfrist, AGG, Tarifvertrag, etc.). Includes `_shared.md`, `angebot.md` (evaluation), `bewerben.md` (apply), `pipeline.md`.
 - **French (Francophone market):** `modes/fr/` — native French translations with France/Belgium/Switzerland/Luxembourg-specific vocabulary (CDI/CDD, convention collective SYNTEC, RTT, mutuelle, prévoyance, 13e mois, intéressement/participation, titres-restaurant, CSE, portage salarial, etc.). Includes `_shared.md`, `offre.md` (evaluation), `postuler.md` (apply), `pipeline.md`.
 - **Japanese (Japan market):** `modes/ja/` — native Japanese translations with Japan-specific vocabulary (正社員, 業務委託, 賞与, 退職金, みなし残業, 年俸制, 36協定, 通勤手当, 住宅手当, etc.). Includes `_shared.md`, `kyujin.md` (evaluation), `oubo.md` (apply), `pipeline.md`.
+- **Arabic (Middle East / Arab market):** `modes/ar/` — native Arabic translations with Arab region-specific vocabulary (مكافأة نهاية الخدمة, التأمينات الاجتماعية, راتب إجمالي/صافي, فترة التجربة, فترة الإخطار, البدلات, etc.). Includes `_shared.md`, `fursah.md` (evaluation), `takdeem.md` (apply), `pipeline.md`.
+- **Turkish (Turkey market):** `modes/tr/` — native Turkish translations with Turkey-specific vocabulary (SGK, kıdem tazminatı, ihbar süresi, brüt/net maaş, AGİ, BES, yemek kartı, yol yardımı, TÜFE zammı, etc.). Includes `_shared.md`, `is-ilani.md` (evaluation), `basvuru.md` (apply), `pipeline.md`.
 
 **When to use German modes:** If the user is targeting German-language job postings, lives in DACH, or asks for German output. Either:
 1. User says "use German modes" → read from `modes/de/` instead of `modes/`
@@ -241,7 +243,17 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 2. User sets `language.modes_dir: modes/ja` in `config/profile.yml` → always use Japanese modes
 3. You detect a Japanese JD → suggest switching to Japanese modes
 
-**When NOT to:** If the user applies to English-language roles, even at French, German, or Japanese companies, use the default English modes.
+**When to use Arabic modes:** If the user is targeting Arabic-language job postings, lives in the Middle East / Arab region, or asks for Arabic output. Either:
+1. User says "use Arabic modes" → read from `modes/ar/` instead of `modes/`
+2. User sets `language.modes_dir: modes/ar` in `config/profile.yml` → always use Arabic modes
+3. You detect an Arabic JD → suggest switching to Arabic modes
+
+**When to use Turkish modes:** If the user is targeting Turkish-language job postings, lives in Turkey, or asks for Turkish output. Either:
+1. User says "use Turkish modes" → read from `modes/tr/` instead of `modes/`
+2. User sets `language.modes_dir: modes/tr` in `config/profile.yml` → always use Turkish modes
+3. You detect a Turkish JD → suggest switching to Turkish modes
+
+**When NOT to:** If the user applies to English-language roles, even at French, German, Arabic, Japanese, or Turkish companies, use the default English modes — *unless* the user has explicitly requested another mode in this conversation, or `language.modes_dir` is set in `config/profile.yml` (the explicit user preference always wins over JD-language detection).
 
 ### Skill Modes
 


### PR DESCRIPTION
## Summary

`AGENTS.md` documents Arabic (`modes/ar/`) and Turkish (`modes/tr/`) language modes, but `CLAUDE.md` was missing both entries. This PR syncs the two files so Claude Code users see the same language options as users of other supported CLIs.

**Changes to `CLAUDE.md`:**
- Added Arabic and Turkish to the language modes list (with vocabulary examples and file references)
- Added `**When to use Arabic modes**` and `**When to use Turkish modes**` guidance sections
- Updated `**When NOT to**` paragraph to mention Arabic and Turkish alongside the existing languages, and aligned the wording with `AGENTS.md`

No logic or script changes — documentation only.

## Test plan

- [ ] Verify `CLAUDE.md` language modes list matches `AGENTS.md` (German, French, Japanese, Arabic, Turkish)
- [ ] Confirm `modes/ar/` and `modes/tr/` directories exist in the repo

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Extended language mode documentation to include Arabic and Turkish support with explicit guidance on when to use these modes based on user request, system configuration, or language detection.
* Updated rules clarifying when English-language roles at various markets should maintain default modes versus using alternative language modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->