### PR TITLE
feat(scan): persist compensation to pipeline.md

### DIFF
--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -43,6 +43,7 @@ This complements — does not replace — the per-URL liveness gate in `auto-pip
 - [ ] https://jobs.example.com/posting/123
 - [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
 - [ ] https://jobs.ashbyhq.com/acme/789 | Acme Corp | Solutions Architect | Remote (US)
+- [ ] https://jobs.ashbyhq.com/acme/790 | Acme Corp | AI Engineer | Remote (US) | 180000-220000 USD
 - [!] https://private.url/job — Error: login required
 
 ## Processed
@@ -50,9 +51,16 @@ This complements — does not replace — the per-URL liveness gate in `auto-pip
 - [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF ❌
 ```
 
-Pending lines are `- [ ] {url} | {company} | {title} | {location}`. The scanner
-fills the trailing `| {location}` column when the ATS exposes it; older
-3-column lines (no location) remain valid and are read as an empty location.
+Pending lines are variable-width. The rawest form is a bare pasted URL,
+`- [ ] {url}` (1 column) — what you drop into the inbox by hand. Scanner-written
+entries add `| {company} | {title}` (3 columns) plus two optional trailing
+columns: `| {location}` (4th) and `| {compensation}` (5th). The scanner fills the
+trailing columns only when the ATS exposes them, so 1-, 3-, 4-, and 5-column rows
+are all valid — `{url} | {company} | {title} | {location} | {compensation}` is the
+maximum (canonical) shape, not the only one. The columns are positional, so a row
+carrying compensation always includes the location cell (empty if unknown); a row
+with only a location stays 4 columns. Existing shorter rows remain valid and are
+read as having empty values for the missing trailing columns.
 
 ## Intelligent JD detection from URL
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -494,16 +494,36 @@ export function sanitizeTsvField(value) {
   return /^[=+\-@]/.test(normalized) ? `'${normalized}` : normalized;
 }
 
+// Format an offer's parsed compensation (the annualized {min,max,currency} that
+// providers like Ashby attach as `offer.salary`) into a compact, sanitized cell
+// such as `120000-160000 USD`. Returns '' when there is no usable salary data.
+// Non-positive bounds are dropped (a 0 min/max is meaningless comp data, not "$0").
+export function formatCompensation(salary) {
+  if (!salary || typeof salary !== 'object') return '';
+  const num = (n) => (Number.isFinite(n) && n > 0 ? String(Math.round(n)) : null);
+  const lo = num(salary.min);
+  const hi = num(salary.max);
+  const range = lo && hi && lo !== hi ? `${lo}-${hi}` : (lo || hi || '');
+  if (!range) return '';
+  const currency = typeof salary.currency === 'string' ? salary.currency.trim() : '';
+  return sanitizeMarkdownField(currency ? `${range} ${currency}` : range);
+}
+
 export function formatPipelineOffer(offer) {
   const url = sanitizePipelineUrl(offer.url);
   const company = sanitizeMarkdownField(offer.company);
   const title = sanitizeMarkdownField(offer.title);
-  // Location is appended as an optional 4th pipe-delimited column when the ATS
-  // exposes it (sanitized like every other field). Offers without a location
-  // keep the original 3-column form, which downstream readers treat as empty;
+  // Optional trailing columns, each sanitized like every other field:
+  //   4th = location, 5th = compensation.
+  // Gate location on an actual string so malformed provider data (a number or
+  // object) degrades to the 3-column form instead of stringifying into a
+  // spurious column. The columns are positional, so a present compensation
+  // forces the (possibly empty) location cell to keep comp in column 5.
   // loadSeenUrls dedups on the URL and ignores trailing columns (backward-compatible).
-  const location = sanitizeMarkdownField(offer.location);
+  const location = typeof offer.location === 'string' ? sanitizeMarkdownField(offer.location) : '';
+  const compensation = formatCompensation(offer.salary);
   const base = `- [ ] ${url} | ${company} | ${title}`;
+  if (compensation) return `${base} | ${location} | ${compensation}`;
   return location ? `${base} | ${location}` : base;
 }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -770,18 +770,42 @@ if (fileExists('providers/local-parser.mjs')) {
 // 4th pipe-delimited column when present, and degrades to the original 3-column
 // form when the ATS exposes no location.
 try {
-  const { formatPipelineOffer } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+  const { formatPipelineOffer, formatCompensation } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
   const withLoc = formatPipelineOffer({ url: 'https://x/1', company: 'Acme', title: 'SA', location: 'Remote (US)' });
   const noLoc = formatPipelineOffer({ url: 'https://x/2', company: 'BigCo', title: 'PM' });
   const blankLoc = formatPipelineOffer({ url: 'https://x/3', company: 'Co', title: 'Eng', location: '   ' });
+  const nonStringLoc = formatPipelineOffer({ url: 'https://x/3b', company: 'Co', title: 'Eng', location: 42 });
   if (
     withLoc === '- [ ] https://x/1 | Acme | SA | Remote (US)' &&
     noLoc === '- [ ] https://x/2 | BigCo | PM' &&
-    blankLoc === '- [ ] https://x/3 | Co | Eng'
+    blankLoc === '- [ ] https://x/3 | Co | Eng' &&
+    nonStringLoc === '- [ ] https://x/3b | Co | Eng'
   ) {
-    pass('scan.mjs formatPipelineOffer appends location column (degrades to 3 cols when absent)');
+    pass('scan.mjs formatPipelineOffer appends location column (degrades to 3 cols when absent / non-string)');
   } else {
-    fail(`scan.mjs formatPipelineOffer location column wrong: "${withLoc}" / "${noLoc}" / "${blankLoc}"`);
+    fail(`scan.mjs formatPipelineOffer location column wrong: "${withLoc}" / "${noLoc}" / "${blankLoc}" / "${nonStringLoc}"`);
+  }
+
+  // pipeline.md compensation column (B3): formatCompensation renders the parsed
+  // {min,max,currency} salary; formatPipelineOffer appends it as the 5th column,
+  // forcing the (possibly empty) location cell so comp stays positionally 5th.
+  const compRange = formatCompensation({ min: 180000, max: 220000, currency: 'USD' });
+  const compSingle = formatCompensation({ min: 150000, max: 150000, currency: 'usd' });
+  const compNone = formatCompensation(null);
+  const compZeroMin = formatCompensation({ min: 0, max: 200000, currency: '' });
+  const withComp = formatPipelineOffer({ url: 'https://x/4', company: 'Acme', title: 'AI Eng', location: 'Remote', salary: { min: 180000, max: 220000, currency: 'USD' } });
+  const compNoLoc = formatPipelineOffer({ url: 'https://x/5', company: 'Acme', title: 'AI Eng', salary: { min: 180000, max: 220000, currency: 'USD' } });
+  if (
+    compRange === '180000-220000 USD' &&
+    compSingle === '150000 usd' &&
+    compNone === '' &&
+    compZeroMin === '200000' &&
+    withComp === '- [ ] https://x/4 | Acme | AI Eng | Remote | 180000-220000 USD' &&
+    compNoLoc === '- [ ] https://x/5 | Acme | AI Eng |  | 180000-220000 USD'
+  ) {
+    pass('scan.mjs formatPipelineOffer appends compensation column (forces empty location cell when needed)');
+  } else {
+    fail(`scan.mjs compensation column wrong: "${compRange}" / "${compSingle}" / "${compNone}" / "${compZeroMin}" / "${withComp}" / "${compNoLoc}"`);
   }
 } catch (err) {
   fail(`scan.mjs formatPipelineOffer import failed: ${err.message}`);


### PR DESCRIPTION
## What does this PR do?

Implements **B3** from #586. Providers like Ashby already parse compensation into an annualized `{min,max,currency}` on `offer.salary` (the salary filter consumes it), but it was never written out. This persists it to `data/pipeline.md` as a 5th pipe-delimited column:

```
- [ ] {url} | {company} | {title} | {location} | {compensation}
```

rendered as a sanitized range like `180000-220000 USD`. **Persistence only — no scoring logic** (as scoped in the issue).

Built on the current `formatPipelineOffer` sanitized path (post-#1098): compensation is escaped like every other field. Because the columns are positional, a present compensation forces the (possibly empty) location cell so comp always lands in column 5. Offers without comp keep the 1–4 column behavior. Non-positive bounds are dropped (a `0` min/max is meaningless comp data, not "$0").

Also gates the location column on an actual string, so malformed provider data (a number/object) degrades to the documented 3-column form instead of stringifying into a spurious column — this addresses CodeRabbit's location-gating note from #1015.

Note: the issue assumed the field was named `compensation`; it's actually already wired as `offer.salary` by the Ashby provider, so this reuses that.

Rebased onto `main` now that B1 (#1015) has merged — this is a single self-contained commit (no longer stacked). `node test-all.mjs` passes (526/0), including the existing pipeline injection/sanitization test.

## Related issue

Refs #586 (item B3)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipeline entries now support variable-width pipe-delimited rows, including optional location and optional compensation (range format) while staying compatible with older 3-column rows.
* **Bug Fixes**
  * Location is ignored when blank or non-text; compensation is only shown when valid salary bounds/currency are available (and location becomes an empty cell when compensation exists but location is missing).
* **Documentation**
  * Updated the pipeline “Pending”/“Processed” examples and clarified the positional column format (including optional location and compensation handling).
* **Tests**
  * Expanded coverage for compensation formatting and the expected 3/4/5-column output shapes across edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->