### PR TITLE
docs: remove outdated .gemini/commands reference and adopt unified agentskills router

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,57 +69,37 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `liveness-core.mjs` | Shared liveness logic (expired signals win over generic Apply text) |
 | `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`). Blocks A-F + G (Posting Legitimacy), plus `## Machine Summary` YAML for downstream scripts. Header includes `**Legitimacy:** {tier}`. |
 
-### OpenCode Commands
+### OpenCode & Gemini CLI Commands
 
-When using [OpenCode](https://opencode.ai), the following slash commands are available (defined in `.opencode/commands/`):
+Both [OpenCode](https://opencode.ai) and [Gemini CLI](https://github.com/google-gemini/gemini-cli) natively support the open agent skill standard (`agentskills.io`). 
 
-| Command | Claude Code Equivalent | Description |
-|---------|------------------------|-------------|
-| `/career-ops` | `/career-ops` | Show menu or evaluate JD with args |
-| `/career-ops-pipeline` | `/career-ops pipeline` | Process pending URLs from inbox |
-| `/career-ops-evaluate` | `/career-ops oferta` | Evaluate job offer (A-F scoring) |
-| `/career-ops-compare` | `/career-ops ofertas` | Compare and rank multiple offers |
-| `/career-ops-contact` | `/career-ops contacto` | LinkedIn outreach (find contacts + draft) |
-| `/career-ops-deep` | `/career-ops deep` | Deep company research |
-| `/career-ops-pdf` | `/career-ops pdf` | Generate ATS-optimized CV |
-| `/career-ops-latex` | `/career-ops latex` | Export CV as LaTeX/Overleaf .tex |
-| `/career-ops-training` | `/career-ops training` | Evaluate course/cert against goals |
-| `/career-ops-project` | `/career-ops project` | Evaluate portfolio project idea |
-| `/career-ops-tracker` | `/career-ops tracker` | Application status overview |
-| `/career-ops-apply` | `/career-ops apply` | Live application assistant |
-| `/career-ops interview` | `/career-ops interview` | Interactive profile/CV onboarding interview |
-| `/career-ops-scan` | `/career-ops scan` | Scan portals for new offers |
-| `/career-ops-batch` | `/career-ops batch` | Batch processing with parallel workers |
-| `/career-ops-patterns` | `/career-ops patterns` | Analyze rejection patterns and improve targeting |
-| `/career-ops-followup` | `/career-ops followup` | Follow-up cadence tracker |
+Instead of registering individual `.toml` files for every slash command, all subcommands are routed through the single unified skill defined in `.agents/skills/career-ops/SKILL.md`.
 
-**Note:** OpenCode commands invoke the same `.claude/skills/career-ops/SKILL.md` skill used by Claude Code. The `modes/*` files are shared between both platforms.
+You can invoke the command center or any of its modes directly within your CLI:
 
-### Gemini CLI Commands
+* `/career-ops` (Shows the Command Center menu)
+* `/career-ops {JD text or URL}` (Runs the auto-evaluation pipeline)
+* `/career-ops [subcommand]` (Runs a specific subcommand)
 
-When using the [Gemini CLI](https://github.com/google-gemini/gemini-cli), the following slash commands are available (defined in `.gemini/commands/`):
+#### Subcommands:
+* `pipeline` — Process pending URLs from inbox
+* `scan` — Scan job portals for new offers
+* `tracker` — Show application status overview
+* `pdf` — Generate ATS-optimized CV PDF
+* `latex` — Export CV as LaTeX/Overleaf .tex
+* `cover` — Generate cover letter
+* `interview-prep` — Generate interview preparation guide
+* `interview` — Onboarding/on-demand interview
+* `contacto` — Generate LinkedIn outreach message
+* `deep` — Execute deep company research
+* `training` — Evaluate course/cert against North Star
+* `project` — Evaluate portfolio project idea
+* `batch` — Run parallel batch evaluations
+* `patterns` — Analyze rejection patterns
+* `followup` — Update and calculate follow-ups
+* `update` — Update system files
 
-| Command | Claude Code Equivalent | Description |
-|---------|------------------------|-------------|
-| `/career-ops` | `/career-ops` | Show menu or evaluate JD with args |
-| `/career-ops-pipeline` | `/career-ops pipeline` | Process pending URLs from inbox |
-| `/career-ops-evaluate` | `/career-ops oferta` | Evaluate job offer (A-G scoring) |
-| `/career-ops-compare` | `/career-ops ofertas` | Compare and rank multiple offers |
-| `/career-ops-contact` | `/career-ops contacto` | LinkedIn outreach (find contacts + draft) |
-| `/career-ops-deep` | `/career-ops deep` | Deep company research |
-| `/career-ops-pdf` | `/career-ops pdf` | Generate ATS-optimized CV |
-| `/career-ops-latex` | `/career-ops latex` | Export CV as LaTeX/Overleaf .tex |
-| `/career-ops-training` | `/career-ops training` | Evaluate course/cert against goals |
-| `/career-ops-project` | `/career-ops project` | Evaluate portfolio project idea |
-| `/career-ops-tracker` | `/career-ops tracker` | Application status overview |
-| `/career-ops-apply` | `/career-ops apply` | Live application assistant |
-| `/career-ops interview` | `/career-ops interview` | Interactive profile/CV onboarding interview |
-| `/career-ops-scan` | `/career-ops scan` | Scan portals for new offers |
-| `/career-ops-batch` | `/career-ops batch` | Batch processing with parallel workers |
-| `/career-ops-patterns` | `/career-ops patterns` | Analyze rejection patterns and improve targeting |
-| `/career-ops-followup` | `/career-ops followup` | Follow-up cadence tracker |
-
-**Note:** Gemini CLI commands are defined in `.gemini/commands/*.toml`. The project context is auto-loaded from `GEMINI.md`. All `modes/*` files are shared across Claude Code, OpenCode, and Gemini CLI.
+All `modes/*` files and prompt contexts (e.g., `GEMINI.md`) are shared across Claude Code, OpenCode, and Gemini CLI.
 
 ### First Run — Onboarding (IMPORTANT)
 

--- a/README.cn.md
+++ b/README.cn.md
@@ -140,15 +140,15 @@ npm install -g @google/gemini-cli
 cd career-ops
 gemini
 
-# 3. 像 Claude Code 一样使用斜杠命令
+# 3. 使用统一的 /career-ops 命令及其子命令：
 /career-ops "Anthropic 的资深 AI 工程师..."
-/career-ops-evaluate --file ./jds/openai.txt
-/career-ops-scan
-/career-ops-pdf
-/career-ops-tracker
+/career-ops pipeline
+/career-ops scan
+/career-ops pdf
+/career-ops tracker
 ```
 
-`GEMINI.md` 文件会自动作为上下文加载。所有 15 个命令都定义在 `.gemini/commands/*.toml` 中。
+`GEMINI.md` 文件会自动作为上下文加载。所有子命令都通过统一的 `.agents/skills/career-ops/SKILL.md` 定义进行路由。
 
 ### 选项 B —— 独立 API 脚本（无需安装 CLI）
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -147,15 +147,15 @@ gemini auth
 cd career-ops
 gemini
 
-# 4. Utilisez les commandes slash comme avec Claude Code
+# 4. Utilisez la commande unifiée /career-ops avec ses sous-commandes :
 /career-ops "Senior AI Engineer at Anthropic..."
-/career-ops-evaluate --file ./jds/openai.txt
-/career-ops-scan
-/career-ops-pdf
-/career-ops-tracker
+/career-ops pipeline
+/career-ops scan
+/career-ops pdf
+/career-ops tracker
 ```
 
-Le fichier `GEMINI.md` is chargé automatiquement comme contexte. Les 15 commandes sont définies dans `.gemini/commands/*.toml`.
+Le fichier `GEMINI.md` est chargé automatiquement comme contexte. Toutes les sous-commandes sont routées via la définition unifiée `.agents/skills/career-ops/SKILL.md`.
 
 ### Option B : Script d'API autonome (Aucune installation de CLI requise)
 

--- a/README.md
+++ b/README.md
@@ -203,15 +203,15 @@ npm install -g @google/gemini-cli
 cd career-ops
 gemini
 
-# 3. Use slash commands just like Claude Code
+# 3. Use the unified /career-ops command with subcommands:
 /career-ops "Senior AI Engineer at Anthropic..."
-/career-ops-evaluate --file ./jds/openai.txt
-/career-ops-scan
-/career-ops-pdf
-/career-ops-tracker
+/career-ops pipeline
+/career-ops scan
+/career-ops pdf
+/career-ops tracker
 ```
 
-The `GEMINI.md` file is auto-loaded as context. All 15 commands are defined in `.gemini/commands/*.toml`.
+The `GEMINI.md` file is auto-loaded as context. All subcommands are routed via the unified `.agents/skills/career-ops/SKILL.md` definition.
 
 ### Option B: Standalone API Script (No CLI install needed)
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -107,7 +107,6 @@ const SYSTEM_PATHS = [
   '.claude/skills/',
   '.opencode/skills/',
   '.claude-plugin/',
-  '.gemini/commands/',
   '.qwen/',
   'docs/',
   'writing-samples/README.md',


### PR DESCRIPTION
Following the recent refactor that deprecated CLI-specific commands in favor of the unified `.agents/skills/career-ops/SKILL.md` router standard, this PR:

1. Removes `.gemini/commands/` from the `SYSTEM_PATHS` array in `update-system.mjs`.
2. Updates `CLAUDE.md`, `README.md`, `README.cn.md`, and `README.fr.md` to replace legacy CLI commands with the unified `/career-ops [subcommand]` syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command documentation across English, Chinese, and French language guides.
  * Consolidated CLI integration instructions with unified command structure and subcommand routing.
  * Simplified reference documentation for command invocation and context loading.

* **Chores**
  * Removed legacy command configuration path from system update allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->