### PR TITLE
feat: add evaluation job facts cache contract

### DIFF
--- a/docs/evaluation-cache.md
+++ b/docs/evaluation-cache.md
@@ -1,0 +1,60 @@
+# Evaluation Cache Contract
+
+Issue: #1025
+
+career-ops evaluations contain two different layers:
+
+- **Job facts**: public facts derived from the posting, company pages, scanner output, and other public sources.
+- **Candidate fit**: private scoring and advice derived from the user's CV, profile, preferences, compensation floor, constraints, and strategy.
+
+Only the job-facts layer may be cached or shared. Candidate fit is always recomputed locally.
+
+## Cache Key
+
+A job-facts payload is keyed by a deterministic posting identity:
+
+```yaml
+schema_version: evaluation-job-facts/v1
+listing_fingerprint: fp_v1_...
+source_url: https://jobs.example.com/role/123
+canonical_url: https://jobs.example.com/role/123
+retrieved_at: 2026-06-15T00:00:00Z
+content_hash: sha256:...
+```
+
+`listing_fingerprint` should come from the listing fingerprint contract when available. Until then, implementations may derive it from normalized company, role title, location, ATS provider, posting id, canonical URL, and selected public JD text.
+
+## Share-Safe Job Facts
+
+The job-facts payload may contain:
+
+- company name, domain, public profile, size band, funding stage, and legitimacy signals
+- normalized role title, level, team, function, seniority, employment type, and work mode
+- public location, remote policy, relocation signal, travel signal, and visa signal
+- salary or compensation signals copied from the posting or public sources
+- posting freshness, liveness result, first seen, last seen, and expiry hints
+- public requirements, responsibilities, tech stack, nice-to-haves, and interview hints
+- public source URLs, retrieval timestamps, and confidence notes
+
+## Forbidden Candidate Fields
+
+The job-facts layer must not contain:
+
+- CV text, resume bullets, portfolio claims, story-bank entries, or writing samples
+- candidate name, email, phone, location, immigration status, or demographic data
+- compensation floor, current salary, target salary, personal constraints, or family constraints
+- fit score, gaps, mitigation strategy, apply/no-apply decision, override reason, or narrative advice
+- tracker status, application outcome, recruiter notes, interview notes, or follow-up history
+
+These fields belong to the candidate-fit layer and are recomputed per user.
+
+## Evaluation Flow
+
+1. Compute or receive a listing fingerprint.
+2. Look for a local job-facts payload matching the fingerprint and schema version.
+3. If present and fresh enough, reuse the public job facts.
+4. Recompute candidate fit from user-layer files every time.
+5. Save private evaluation output under `reports/`, `output/`, and tracker artifacts only.
+
+The first implementation is local-only. A future shared layer can reuse the same schema after adding consent, redaction preview, audit logs, and privacy-mode enforcement.
+

--- a/evaluation-cache-tests.mjs
+++ b/evaluation-cache-tests.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  buildJobFactsPayload,
+  readJobFactsCache,
+  writeJobFactsCache,
+} from './evaluation-cache.mjs';
+
+let passed = 0;
+let failed = 0;
+
+function pass(message) {
+  console.log(`PASS ${message}`);
+  passed++;
+}
+
+function fail(message) {
+  console.error(`FAIL ${message}`);
+  failed++;
+}
+
+function assert(condition, message) {
+  if (condition) pass(message);
+  else fail(message);
+}
+
+const cacheDir = mkdtempSync(join(tmpdir(), 'career-ops-jobfacts-'));
+
+try {
+  const input = {
+    postingId: '0',
+    atsProvider: 'greenhouse',
+    company: 'Example Inc',
+    title: 'Senior AI Engineer',
+    location: 'Remote',
+    workMode: false,
+    canonicalUrl: 'https://boards.greenhouse.io/example/jobs/0',
+    contentHash: 'sha256:abc',
+  };
+
+  const payload = buildJobFactsPayload(input, {
+    facts: { company: 'Example Inc', title: 'Senior AI Engineer' },
+    retrievedAt: '2026-06-20T00:00:00.000Z',
+  });
+
+  writeJobFactsCache(payload, { cacheDir });
+
+  const hit = readJobFactsCache(payload.cache_key, {
+    cacheDir,
+    now: new Date('2026-06-25T00:00:00.000Z'),
+    maxAgeDays: 7,
+  });
+  assert(hit.status === 'hit', 'fresh cache entry is returned as a hit');
+  assert(hit.payload.cache_key === payload.cache_key, 'cache hit returns the stored payload');
+
+  const miss = readJobFactsCache('jobfacts_missing', {
+    cacheDir,
+    now: new Date('2026-06-25T00:00:00.000Z'),
+    maxAgeDays: 7,
+  });
+  assert(miss.status === 'miss', 'missing cache key returns miss');
+
+  const stale = readJobFactsCache(payload.cache_key, {
+    cacheDir,
+    now: new Date('2026-07-10T00:00:00.000Z'),
+    maxAgeDays: 7,
+  });
+  assert(stale.status === 'stale', 'old cache entry returns stale');
+
+  const invalid = buildJobFactsPayload(input, {
+    facts: { candidate_email: 'person@example.com' },
+    retrievedAt: '2026-06-20T00:00:00.000Z',
+  });
+  const invalidWrite = writeJobFactsCache(invalid, { cacheDir });
+  assert(invalidWrite.status === 'rejected', 'candidate-bearing payload is rejected before writing');
+
+  const updateSystem = readFileSync('update-system.mjs', 'utf-8');
+  assert(updateSystem.includes("'evaluation-cache.mjs'"), 'evaluation-cache.mjs is registered in SYSTEM_PATHS');
+  assert(updateSystem.includes("'evaluation-cache-tests.mjs'"), 'evaluation-cache-tests.mjs is registered in SYSTEM_PATHS');
+
+  const geminiEval = readFileSync('gemini-eval.mjs', 'utf-8');
+  assert(geminiEval.includes('readJobFactsCache'), 'gemini-eval checks the job-facts cache before evaluation');
+  assert(geminiEval.includes('writeJobFactsCache'), 'gemini-eval writes reusable job facts after evaluation');
+} finally {
+  rmSync(cacheDir, { recursive: true, force: true });
+}
+
+if (failed > 0) {
+  console.error(`\n${passed} passed, ${failed} failed`);
+  process.exit(1);
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);

--- a/evaluation-cache.mjs
+++ b/evaluation-cache.mjs
@@ -27,11 +27,17 @@ export const FORBIDDEN_CANDIDATE_FIELDS = [
 ];
 
 function normalizePart(value) {
-  return String(value || '')
+  return String(value ?? '')
     .trim()
     .toLowerCase()
     .replace(/\s+/g, ' ');
 }
+
+function normalizeFieldName(value) {
+  return String(value ?? '').replace(/[_\-\s]+/g, '').toLowerCase();
+}
+
+const FORBIDDEN_FIELD_NAMES = new Set(FORBIDDEN_CANDIDATE_FIELDS.map(normalizeFieldName));
 
 export function computeJobFactsKey(input = {}) {
   const parts = [
@@ -43,6 +49,7 @@ export function computeJobFactsKey(input = {}) {
     input.location,
     input.workMode,
     input.canonicalUrl || input.sourceUrl,
+    input.retrieved_at || input.retrievedAt,
     input.contentHash,
   ].map(normalizePart);
   return `jobfacts_${createHash('sha256').update(parts.join('\n')).digest('hex').slice(0, 24)}`;
@@ -54,7 +61,7 @@ export function containsForbiddenCandidateField(payload = {}) {
     const current = stack.pop();
     if (!current || typeof current !== 'object') continue;
     for (const [key, value] of Object.entries(current)) {
-      if (FORBIDDEN_CANDIDATE_FIELDS.includes(key)) return true;
+      if (FORBIDDEN_FIELD_NAMES.has(normalizeFieldName(key))) return true;
       if (value && typeof value === 'object') stack.push(value);
     }
   }
@@ -73,7 +80,13 @@ if (fileURLToPath(import.meta.url) === process.argv[1]) {
     console.error('Usage: node evaluation-cache.mjs <job-facts.json>');
     process.exit(2);
   }
-  const payload = JSON.parse(readFileSync(file, 'utf8'));
+  let payload;
+  try {
+    payload = JSON.parse(readFileSync(file, 'utf8'));
+  } catch (error) {
+    console.error(`Could not read or parse job facts payload: ${error.message}`);
+    process.exit(1);
+  }
   if (!hasReusableJobFacts(payload)) {
     console.error('Job facts payload is not reusable.');
     process.exit(1);

--- a/evaluation-cache.mjs
+++ b/evaluation-cache.mjs
@@ -1,15 +1,21 @@
 #!/usr/bin/env node
 
 import { createHash } from 'crypto';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
 import { fileURLToPath } from 'url';
 
 export const JOB_FACTS_SCHEMA_VERSION = 'evaluation-job-facts/v1';
+export const DEFAULT_JOB_FACTS_MAX_AGE_DAYS = 14;
 
 export const FORBIDDEN_CANDIDATE_FIELDS = [
   'candidate',
   'candidateName',
+  'candidateEmail',
+  'candidatePhone',
   'cv',
+  'email',
+  'phone',
   'resume',
   'profile',
   'fitScore',
@@ -39,6 +45,10 @@ function normalizeFieldName(value) {
 
 const FORBIDDEN_FIELD_NAMES = new Set(FORBIDDEN_CANDIDATE_FIELDS.map(normalizeFieldName));
 
+export function contentHash(value) {
+  return `sha256:${createHash('sha256').update(String(value ?? '')).digest('hex')}`;
+}
+
 export function computeJobFactsKey(input = {}) {
   const parts = [
     JOB_FACTS_SCHEMA_VERSION,
@@ -53,6 +63,24 @@ export function computeJobFactsKey(input = {}) {
     input.contentHash,
   ].map(normalizePart);
   return `jobfacts_${createHash('sha256').update(parts.join('\n')).digest('hex').slice(0, 24)}`;
+}
+
+export function buildJobFactsPayload(input = {}, options = {}) {
+  const retrievedAt = options.retrievedAt || new Date().toISOString();
+  const cacheKeyInput = { ...input, retrieved_at: undefined, retrievedAt: undefined };
+  const cacheKey = input.cache_key || input.cacheKey || computeJobFactsKey(cacheKeyInput);
+  const facts = options.facts && typeof options.facts === 'object' ? options.facts : {};
+
+  return {
+    schema_version: JOB_FACTS_SCHEMA_VERSION,
+    cache_key: cacheKey,
+    listing_fingerprint: input.listing_fingerprint || input.listingFingerprint || '',
+    source_url: input.source_url || input.sourceUrl || '',
+    canonical_url: input.canonical_url || input.canonicalUrl || '',
+    retrieved_at: retrievedAt,
+    content_hash: input.content_hash || input.contentHash || '',
+    facts,
+  };
 }
 
 export function containsForbiddenCandidateField(payload = {}) {
@@ -72,6 +100,56 @@ export function hasReusableJobFacts(payload = {}) {
   return payload.schema_version === JOB_FACTS_SCHEMA_VERSION &&
     Boolean(payload.listing_fingerprint || payload.cache_key) &&
     !containsForbiddenCandidateField(payload);
+}
+
+export function jobFactsCachePath(cacheDir, cacheKey) {
+  if (!/^jobfacts_[a-f0-9]{24}$/i.test(String(cacheKey || ''))) return null;
+  return join(cacheDir, `${cacheKey}.json`);
+}
+
+function ageDays(payload, now) {
+  const retrievedAt = Date.parse(payload.retrieved_at || payload.retrievedAt || '');
+  if (!Number.isFinite(retrievedAt)) return Infinity;
+  return Math.max(0, (now.getTime() - retrievedAt) / 86_400_000);
+}
+
+export function readJobFactsCache(cacheKey, options = {}) {
+  const cacheDir = options.cacheDir || join('data', 'cache', 'job-facts');
+  const maxAgeDays = options.maxAgeDays ?? DEFAULT_JOB_FACTS_MAX_AGE_DAYS;
+  const now = options.now instanceof Date ? options.now : new Date(options.now || Date.now());
+  const path = jobFactsCachePath(cacheDir, cacheKey);
+  if (!path) return { status: 'miss', reason: 'invalid_key' };
+  if (!existsSync(path)) return { status: 'miss', reason: 'not_found' };
+
+  let payload;
+  try {
+    payload = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    return { status: 'miss', reason: 'unreadable', error: error.message };
+  }
+
+  if (!hasReusableJobFacts(payload)) {
+    return { status: 'miss', reason: 'not_reusable', payload };
+  }
+
+  const currentAgeDays = ageDays(payload, now);
+  if (Number.isFinite(maxAgeDays) && currentAgeDays > maxAgeDays) {
+    return { status: 'stale', reason: 'expired', ageDays: currentAgeDays, payload };
+  }
+
+  return { status: 'hit', ageDays: currentAgeDays, payload };
+}
+
+export function writeJobFactsCache(payload, options = {}) {
+  if (!hasReusableJobFacts(payload)) {
+    return { status: 'rejected', reason: 'not_reusable' };
+  }
+  const cacheDir = options.cacheDir || join('data', 'cache', 'job-facts');
+  const path = jobFactsCachePath(cacheDir, payload.cache_key);
+  if (!path) return { status: 'rejected', reason: 'invalid_key' };
+  mkdirSync(cacheDir, { recursive: true });
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return { status: 'written', path };
 }
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {

--- a/evaluation-cache.mjs
+++ b/evaluation-cache.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import { createHash } from 'crypto';
+import { existsSync, readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+export const JOB_FACTS_SCHEMA_VERSION = 'evaluation-job-facts/v1';
+
+export const FORBIDDEN_CANDIDATE_FIELDS = [
+  'candidate',
+  'candidateName',
+  'cv',
+  'resume',
+  'profile',
+  'fitScore',
+  'score',
+  'gaps',
+  'mitigation',
+  'applyDecision',
+  'overrideReason',
+  'compensationFloor',
+  'currentSalary',
+  'targetSalary',
+  'trackerStatus',
+  'interviewNotes',
+  'followUpHistory',
+];
+
+function normalizePart(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+}
+
+export function computeJobFactsKey(input = {}) {
+  const parts = [
+    JOB_FACTS_SCHEMA_VERSION,
+    input.postingId,
+    input.atsProvider,
+    input.company,
+    input.title,
+    input.location,
+    input.workMode,
+    input.canonicalUrl || input.sourceUrl,
+    input.contentHash,
+  ].map(normalizePart);
+  return `jobfacts_${createHash('sha256').update(parts.join('\n')).digest('hex').slice(0, 24)}`;
+}
+
+export function containsForbiddenCandidateField(payload = {}) {
+  const stack = [payload];
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current || typeof current !== 'object') continue;
+    for (const [key, value] of Object.entries(current)) {
+      if (FORBIDDEN_CANDIDATE_FIELDS.includes(key)) return true;
+      if (value && typeof value === 'object') stack.push(value);
+    }
+  }
+  return false;
+}
+
+export function hasReusableJobFacts(payload = {}) {
+  return payload.schema_version === JOB_FACTS_SCHEMA_VERSION &&
+    Boolean(payload.listing_fingerprint || payload.cache_key) &&
+    !containsForbiddenCandidateField(payload);
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const file = process.argv[2];
+  if (!file || !existsSync(file)) {
+    console.error('Usage: node evaluation-cache.mjs <job-facts.json>');
+    process.exit(2);
+  }
+  const payload = JSON.parse(readFileSync(file, 'utf8'));
+  if (!hasReusableJobFacts(payload)) {
+    console.error('Job facts payload is not reusable.');
+    process.exit(1);
+  }
+  console.log(payload.cache_key || computeJobFactsKey(payload));
+}

--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -32,6 +32,12 @@ import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
+import {
+  buildJobFactsPayload,
+  contentHash,
+  readJobFactsCache,
+  writeJobFactsCache,
+} from './evaluation-cache.mjs';
 
 // ---------------------------------------------------------------------------
 // Bootstrap: load .env before anything else
@@ -62,6 +68,7 @@ const PATHS = {
   reports:     join(ROOT, 'reports'),
   tracker:     join(ROOT, 'data', 'applications.md'),
   trackerAdditions: join(ROOT, 'batch', 'tracker-additions'),
+  jobFactsCache: join(ROOT, 'data', 'cache', 'job-facts'),
 };
 
 // ---------------------------------------------------------------------------
@@ -242,6 +249,26 @@ const cvContent      = readFile(PATHS.cv,          'cv.md');
 const profileContent = readFile(PATHS.profile,     'modes/_profile.md');
 const profileYml     = readFile(PATHS.profileYml,  'config/profile.yml');
 
+const jdContentHash = contentHash(jdText);
+const sourceUrlMatch = jdText.match(/https?:\/\/\S+/);
+const jobFactsSeed = buildJobFactsPayload({
+  sourceUrl: sourceUrlMatch ? sourceUrlMatch[0] : '',
+  contentHash: jdContentHash,
+});
+const jobFactsCache = readJobFactsCache(jobFactsSeed.cache_key, {
+  cacheDir: PATHS.jobFactsCache,
+});
+
+let reusableJobFactsContext = 'No reusable public job facts cache hit.';
+if (jobFactsCache.status === 'hit') {
+  reusableJobFactsContext = JSON.stringify(jobFactsCache.payload.facts || {}, null, 2);
+  console.log(`📦  Job facts cache hit: ${jobFactsSeed.cache_key}`);
+} else if (jobFactsCache.status === 'stale') {
+  console.log(`📦  Job facts cache stale: ${jobFactsSeed.cache_key}`);
+} else {
+  console.log(`📦  Job facts cache miss: ${jobFactsSeed.cache_key}`);
+}
+
 // ---------------------------------------------------------------------------
 // Build the system prompt (mirrors the Claude skill router logic)
 // ---------------------------------------------------------------------------
@@ -274,6 +301,11 @@ ${profileYml}
 USER ARCHETYPES & NARRATIVE (_profile.md)
 ═══════════════════════════════════════════════════════
 ${profileContent}
+
+═══════════════════════════════════════════════════════
+REUSABLE PUBLIC JOB FACTS CACHE
+═══════════════════════════════════════════════════════
+${reusableJobFactsContext}
 
 ═══════════════════════════════════════════════════════
 IMPORTANT OPERATING RULES FOR THIS CLI SESSION
@@ -373,6 +405,27 @@ if (summaryMatch) {
   score      = extract('SCORE');
   archetype  = extract('ARCHETYPE');
   legitimacy = extract('LEGITIMACY');
+}
+
+if (saveReport) {
+  const cachePayload = buildJobFactsPayload({
+    ...jobFactsSeed,
+    cache_key: jobFactsSeed.cache_key,
+    contentHash: jdContentHash,
+  }, {
+    facts: {
+      company,
+      role,
+      legitimacy,
+      source_text_hash: jdContentHash,
+    },
+  });
+  const cacheWrite = writeJobFactsCache(cachePayload, { cacheDir: PATHS.jobFactsCache });
+  if (cacheWrite.status === 'written') {
+    console.log(`📦  Job facts cache saved: ${jobFactsSeed.cache_key}`);
+  } else {
+    console.warn(`⚠️   Job facts cache not saved: ${cacheWrite.reason}`);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -156,6 +156,7 @@ const scripts = [
   { name: 'merge-tracker.mjs --dry-run', expectExit: 0 },
   { name: 'reconcile-pipeline.mjs --dry-run', expectExit: 0 },
   { name: 'analyze-patterns.mjs --self-test', expectExit: 0 },
+  { name: 'evaluation-cache-tests.mjs', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
   { name: 'validate-portals.mjs --file templates/portals.example.yml', expectExit: 0 },

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -93,6 +93,8 @@ const SYSTEM_PATHS = [
   'tracker-utils.mjs',
   'normalize-statuses.mjs',
   'cv-sync-check.mjs',
+  'evaluation-cache.mjs',
+  'evaluation-cache-tests.mjs',
   'update-system.mjs',
   'reserve-report-num.mjs',
   'scan.mjs',

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -63,6 +63,8 @@ const requiredSystemPaths = [
   '.antigravitycli/skills/',
   '.grok/skills/',
   'tracker-columns-tests.mjs',
+  'evaluation-cache.mjs',
+  'evaluation-cache-tests.mjs',
   'updater-migration-tests.mjs',
   'README.ar.md',
   'README.ja.md',


### PR DESCRIPTION
## Summary

Adds the first local evaluation cache contract so career-ops can separate reusable public job facts from private candidate-fit reasoning.

## Details

- documents the job-facts payload boundary, cache key inputs, share-safe fields, and forbidden candidate fields
- adds a small `evaluation-cache.mjs` helper that computes deterministic local cache keys and rejects payloads that contain candidate-specific fields
- keeps the first implementation local-only while preserving a future path for an optional shared layer

Fixes #1025.

## Validation

- `node --check evaluation-cache.mjs`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the evaluation cache contract, including cache key schema, job-facts data segregation rules, and permitted vs. forbidden fields.

* **New Features**
  * Introduced an end-to-end job-facts cache mechanism with deterministic cache keying, safe reuse validation (fresh vs. stale), and conditional cache writes.
  * Integrated reusable cached job facts into the Gemini evaluation prompt to improve efficiency.

* **Tests**
  * Added cache behavior tests and expanded the test runner to execute them.

* **Chores**
  * Updated updater system allowlists and migration checks to include the new cache artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->