### PR TITLE
docs: define market pack contract

### DIFF
--- a/docs/market-packs.md
+++ b/docs/market-packs.md
@@ -1,0 +1,69 @@
+# Market Pack Contract
+
+Issue: #1026
+
+Market packs are first-class bundles for country or regional job-search behavior. They are not just translated modes. A market pack may combine local boards, compensation vocabulary, CV conventions, location aliases, legitimacy signals, and recruiter etiquette while leaving candidate personalization in the user layer.
+
+## Directory Shape
+
+```text
+markets/<market-id>/
+  README.md
+  portals.example.yml
+  compensation.yml
+  location-aliases.yml
+  cv-conventions.md
+  legitimacy-signals.yml
+```
+
+`<market-id>` should use a stable BCP-47-style identifier such as `de-DE`, `fr-FR`, `pt-BR`, or `en-US`.
+
+## Selection Order
+
+Agents and future scripts should resolve market context in this order:
+
+1. `config/profile.yml` explicit setting:
+
+   ```yaml
+   language:
+     market_pack: de-DE
+   ```
+
+2. detected market from the JD, source domain, salary currency, location, or portal provider.
+3. fallback to the current `language.modes_dir` or default modes.
+
+The market pack controls market vocabulary and local conventions. It must not override user-specific goals, compensation floors, constraints, preferred tone, or personal evidence.
+
+## Separation From User Personalization
+
+Market packs may contain:
+
+- market-specific compensation terms and normalization hints
+- public portal/job-board defaults
+- location aliases and remote-work vocabulary
+- CV/resume conventions for the market
+- local legitimacy and scam signals
+- application and follow-up etiquette
+
+Market packs must not contain:
+
+- user CV facts
+- target companies
+- personal compensation minimums
+- immigration details
+- private application decisions
+- user narrative strategy
+
+Those remain in `config/profile.yml`, `modes/_profile.md`, `article-digest.md`, and other user-layer files.
+
+## Reference Mapping
+
+The existing `modes/de/` directory maps naturally to a DACH-style market pack:
+
+- `modes/de/angebot.md` -> localized evaluation mode
+- `modes/de/bewerben.md` -> localized apply mode
+- `modes/de/pipeline.md` -> localized pipeline mode
+- `modes/de/_shared.md` -> shared German-language market vocabulary
+
+`markets/de-DE/README.md` documents the first reference bundle without moving the existing modes.
+

--- a/docs/market-packs.md
+++ b/docs/market-packs.md
@@ -34,6 +34,58 @@ Agents and future scripts should resolve market context in this order:
 
 The market pack controls market vocabulary and local conventions. It must not override user-specific goals, compensation floors, constraints, preferred tone, or personal evidence.
 
+## File Schemas
+
+### `portals.example.yml`
+
+Purpose: market-specific public job-board and ATS defaults. Required top-level key: `portals`, an array of portal entries.
+
+Each portal entry should include:
+
+- `name` (string, required): display name.
+- `url` (string, required): base URL or search URL.
+- `type` (string, optional): `ats`, `job_board`, `company`, or `aggregator`.
+- `enabled` (boolean, optional): default inclusion flag.
+- `notes` (string, optional): market-specific caveats.
+
+### `compensation.yml`
+
+Purpose: salary vocabulary and normalization hints. Required top-level key: `terms`, an array.
+
+Each term should include:
+
+- `term` (string, required): local phrase.
+- `normalized` (string, required): canonical career-ops meaning.
+- `category` (string, optional): `base`, `bonus`, `equity`, `benefit`, `tax`, or `frequency`.
+- `notes` (string, optional): interpretation guidance.
+
+### `location-aliases.yml`
+
+Purpose: normalize cities, regions, remote-work phrases, and cross-border location terms. Required top-level key: `aliases`, an array.
+
+Each alias should include:
+
+- `alias` (string, required): observed phrase.
+- `canonical` (string, required): normalized location or work-mode bucket.
+- `country` (string, optional): ISO country code or region name.
+- `work_mode` (string, optional): `remote`, `hybrid`, `onsite`, or `unknown`.
+
+### `cv-conventions.md`
+
+Purpose: human-readable conventions for CV/resume expectations in the market.
+
+It should cover expected length, photo usage, reverse chronology norms, language expectations, credential formatting, and common ATS concerns.
+
+### `legitimacy-signals.yml`
+
+Purpose: market-specific public signals for credible or risky postings. Required top-level keys: `positive_signals` and `risk_signals`, both arrays of strings or objects.
+
+Object entries may include:
+
+- `signal` (string, required): observed public fact.
+- `severity` (string, optional): `low`, `medium`, or `high`.
+- `notes` (string, optional): evaluation guidance.
+
 ## Separation From User Personalization
 
 Market packs may contain:
@@ -66,4 +118,3 @@ The existing `modes/de/` directory maps naturally to a DACH-style market pack:
 - `modes/de/_shared.md` -> shared German-language market vocabulary
 
 `markets/de-DE/README.md` documents the first reference bundle without moving the existing modes.
-

--- a/markets/de-DE/README.md
+++ b/markets/de-DE/README.md
@@ -37,3 +37,9 @@ language:
 
 `market_pack` selects market conventions. `modes_dir` continues to select localized mode files until scripts grow first-class market-pack loading.
 
+During the migration period, the two fields compose:
+
+- `market_pack` is the authoritative market-convention selector when code or agents understand market packs.
+- `modes_dir` remains the authoritative mode-loading selector for current scripts that still load prompts from `modes/<lang>/`.
+- If only `market_pack` is set before scripts support it, current mode-loading behavior falls back to the default modes while agents can still read this pack for market guidance.
+- Once first-class loading exists, scripts should resolve `market_pack` first and treat `modes_dir` as a backward-compatible fallback. Deprecating `modes_dir` should happen only after all CLI entrypoints can load modes through market packs.

--- a/markets/de-DE/README.md
+++ b/markets/de-DE/README.md
@@ -1,0 +1,39 @@
+# Market Pack: de-DE
+
+Issue: #1026
+
+This reference pack maps the existing German modes into the market-pack contract without moving files.
+
+## Existing Mode Mapping
+
+| Market capability | Current source |
+|---|---|
+| localized evaluation mode | `modes/de/angebot.md` |
+| localized apply mode | `modes/de/bewerben.md` |
+| localized pipeline mode | `modes/de/pipeline.md` |
+| shared German vocabulary | `modes/de/_shared.md` |
+
+## Market Scope
+
+This pack represents Germany-first DACH conventions for:
+
+- salary language such as gross annual salary, 13th month pay, bonus, and tariff hints
+- contract language such as permanent employment, fixed-term contracts, notice periods, and probation
+- remote-work wording such as hybrid, on-site, remote within Germany, and EU-only remote
+- CV conventions around concise reverse chronology, impact bullets, and market-relevant certifications
+- legitimacy signals such as imprint/company identity, recruiter domain consistency, and realistic compensation ranges
+
+## User-Layer Boundary
+
+The pack does not store target salary, visa status, personal constraints, preferred sectors, or application history. Those remain in `config/profile.yml`, `modes/_profile.md`, tracker files, and reports.
+
+## Example Profile Selection
+
+```yaml
+language:
+  market_pack: de-DE
+  modes_dir: modes/de
+```
+
+`market_pack` selects market conventions. `modes_dir` continues to select localized mode files until scripts grow first-class market-pack loading.
+


### PR DESCRIPTION
## Summary

Defines market packs as first-class market bundles instead of treating localization as translated modes only.

## Details

- documents the market-pack directory contract and selection order
- keeps market conventions separate from user-layer personalization
- adds a `de-DE` reference mapping that points at the existing German modes without moving them

Fixes #1026.

## Validation

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Market Pack contract documentation for regional job-search behavior bundles, including market selection precedence and the expected market-pack file schemas.
  * Added a German (de-DE) reference market pack README documenting how existing German modes map into the new market-pack layout and how it interacts with profile configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->