### PR TITLE
feat: add candidate feedback learning queue

### DIFF
--- a/data/profile-feedback.example.md
+++ b/data/profile-feedback.example.md
@@ -1,0 +1,22 @@
+# Profile Feedback Queue
+
+This example shows the structured learning records described in `docs/candidate-learning-loop.md`.
+
+## 2026-06-15 - example-company-senior-ai-engineer
+
+- type: scoring_correction
+- status: pending
+- source: reports/123-example-company-2026-06-15.md
+- feedback: "The score is too high because the role is mostly frontend platform work."
+- proposed_update: config/profile.yml
+- note: "Lower weight for frontend-heavy platform roles unless there is applied AI ownership."
+
+## 2026-06-15 - example-startup-ml-engineer
+
+- type: hard_constraint
+- status: proposed
+- source: reports/124-example-startup-2026-06-15.md
+- feedback: "I do not want companies under 20 people."
+- proposed_update: config/profile.yml
+- note: "Add company-size minimum to target filters after user approval."
+

--- a/docs/candidate-learning-loop.md
+++ b/docs/candidate-learning-loop.md
@@ -1,0 +1,60 @@
+# Candidate Learning Loop
+
+Issue: #1027
+
+The learning loop turns explicit user feedback about evaluations into auditable user-layer records. It does not silently mutate the profile.
+
+## Feedback Record
+
+Feedback records live in `data/profile-feedback.md` and use a small Markdown block format:
+
+```markdown
+## 2026-06-15 - company-role-slug
+
+- type: preference
+- status: pending
+- source: reports/123-example-2026-06-15.md
+- feedback: "This score is too high; I would never apply here."
+- proposed_update: config/profile.yml
+- note: "Consider adding an exclusion for companies under 20 people."
+```
+
+## Types
+
+Use one of these values:
+
+- `preference`: taste, energy, role shape, company size, work style, or domain preference
+- `hard_constraint`: non-negotiable location, compensation, visa, schedule, or company constraint
+- `missing_evidence`: candidate has evidence the evaluation failed to use
+- `scoring_correction`: score, weight, or fit assessment was too high or too low
+- `narrative_correction`: positioning, cover letter angle, CV emphasis, or interview story should change
+
+## Statuses
+
+- `pending`: captured but not yet reviewed
+- `proposed`: a concrete patch has been suggested
+- `accepted`: user accepted the profile/story/tracker update
+- `rejected`: user rejected the learning
+- `archived`: retained for history but not active
+
+## Allowed Update Targets
+
+Proposed updates may target user-layer files only:
+
+- `config/profile.yml`
+- `modes/_profile.md`
+- `article-digest.md`
+- `interview-prep/story-bank.md`
+- `data/applications.md`
+- `data/follow-ups.md`
+
+System-layer prompts and scripts must not be edited to encode a single user's preferences.
+
+## Agent Flow
+
+1. Capture the user's feedback as a structured record.
+2. Classify it by type.
+3. Leave it `pending` unless the user approves a patch.
+4. Before future evaluations, summarize unresolved `pending` and `proposed` records.
+5. Apply accepted updates only to user-layer files.
+

--- a/learning-feedback.mjs
+++ b/learning-feedback.mjs
@@ -1,10 +1,26 @@
 #!/usr/bin/env node
 
 import { existsSync, readFileSync } from 'fs';
+import { relative, resolve, sep } from 'path';
 import { fileURLToPath } from 'url';
 
 const DEFAULT_FILE = 'data/profile-feedback.md';
+const SAFE_DATA_DIR = resolve('data');
 const ACTIVE_STATUSES = new Set(['pending', 'proposed']);
+const REQUIRED_FIELDS = ['type', 'status', 'feedback'];
+
+function isInsideSafeDataDir(file) {
+  const relativePath = relative(SAFE_DATA_DIR, file);
+  return relativePath && !relativePath.startsWith('..') && !relativePath.startsWith(sep);
+}
+
+export function safeFeedbackPath(file = DEFAULT_FILE) {
+  const resolvedFile = resolve(file);
+  if (!isInsideSafeDataDir(resolvedFile)) {
+    throw new Error('Feedback files must live under the data/ directory.');
+  }
+  return resolvedFile;
+}
 
 export function parseFeedbackRecords(markdown = '') {
   const sections = markdown.split(/^##\s+/m).slice(1);
@@ -17,7 +33,10 @@ export function parseFeedbackRecords(markdown = '') {
       record[match[1]] = match[2].replace(/^"|"$/g, '').trim();
     }
     return record;
-  }).filter((record) => record.title);
+  }).filter((record) => (
+    record.title
+    && REQUIRED_FIELDS.every((field) => record[field])
+  ));
 }
 
 export function summarizeOpenFeedback(records = []) {
@@ -28,7 +47,13 @@ export function summarizeOpenFeedback(records = []) {
 }
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {
-  const file = process.argv[2] || DEFAULT_FILE;
+  let file;
+  try {
+    file = safeFeedbackPath(process.argv[2] || DEFAULT_FILE);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
   if (!existsSync(file)) {
     console.log('No profile feedback queue found.');
     process.exit(0);

--- a/learning-feedback.mjs
+++ b/learning-feedback.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const DEFAULT_FILE = 'data/profile-feedback.md';
+const ACTIVE_STATUSES = new Set(['pending', 'proposed']);
+
+export function parseFeedbackRecords(markdown = '') {
+  const sections = markdown.split(/^##\s+/m).slice(1);
+  return sections.map((section) => {
+    const [titleLine = '', ...lines] = section.trim().split('\n');
+    const record = { title: titleLine.trim() };
+    for (const line of lines) {
+      const match = line.match(/^-\s*([a-z_]+):\s*(.*)$/i);
+      if (!match) continue;
+      record[match[1]] = match[2].replace(/^"|"$/g, '').trim();
+    }
+    return record;
+  }).filter((record) => record.title);
+}
+
+export function summarizeOpenFeedback(records = []) {
+  return records
+    .filter((record) => ACTIVE_STATUSES.has(record.status))
+    .map((record) => `- [${record.status}] ${record.type}: ${record.feedback} (${record.proposed_update || 'no target yet'})`)
+    .join('\n');
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const file = process.argv[2] || DEFAULT_FILE;
+  if (!existsSync(file)) {
+    console.log('No profile feedback queue found.');
+    process.exit(0);
+  }
+  const records = parseFeedbackRecords(readFileSync(file, 'utf8'));
+  const summary = summarizeOpenFeedback(records);
+  console.log(summary || 'No unresolved profile feedback.');
+}


### PR DESCRIPTION
## Summary

Adds the first explicit candidate learning loop so user feedback on evaluations can become auditable learning records instead of ad hoc prompt edits.

## Details

- documents the feedback record format, allowed types, statuses, and user-layer update targets
- adds an example `data/profile-feedback.example.md` queue
- adds `learning-feedback.mjs` to summarize unresolved pending/proposed feedback before future evaluations

Fixes #1027.

## Validation

- `node --check learning-feedback.mjs`
- `node learning-feedback.mjs data/profile-feedback.example.md`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation explaining how user feedback is captured, classified, and applied to user-layer resources during evaluations
  * Added example profile feedback records demonstrating various feedback workflows and status states

* **New Features**
  * Added new utility to parse and summarize all pending or proposed feedback items for review

<!-- end of auto-generated comment: release notes by coderabbit.ai -->