### PR TITLE
feat: add apply quality gate contract

### DIFF
--- a/apply-quality-gate.mjs
+++ b/apply-quality-gate.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from 'url';
+
+export const DEFAULT_APPLY_QUALITY_THRESHOLD = 4.0;
+
+export function evaluateApplyQualityGate({ score, threshold = DEFAULT_APPLY_QUALITY_THRESHOLD, overrideReason = '' } = {}) {
+  const numericScore = Number(score);
+  const numericThreshold = Number(threshold || DEFAULT_APPLY_QUALITY_THRESHOLD);
+  if (!Number.isFinite(numericScore)) {
+    return { allowed: false, status: 'missing_score', threshold: numericThreshold };
+  }
+  if (numericScore >= numericThreshold) {
+    return { allowed: true, status: 'meets_threshold', score: numericScore, threshold: numericThreshold };
+  }
+  const reason = String(overrideReason || '').trim();
+  if (reason.length > 0) {
+    return { allowed: true, status: 'override', score: numericScore, threshold: numericThreshold, overrideReason: reason };
+  }
+  return { allowed: false, status: 'requires_override', score: numericScore, threshold: numericThreshold };
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const score = process.argv[2];
+  const threshold = process.argv[3] || DEFAULT_APPLY_QUALITY_THRESHOLD;
+  const overrideReason = process.argv.slice(4).join(' ');
+  const result = evaluateApplyQualityGate({ score, threshold, overrideReason });
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.allowed ? 0 : 1);
+}

--- a/apply-quality-gate.mjs
+++ b/apply-quality-gate.mjs
@@ -6,7 +6,7 @@ export const DEFAULT_APPLY_QUALITY_THRESHOLD = 4.0;
 
 export function evaluateApplyQualityGate({ score, threshold = DEFAULT_APPLY_QUALITY_THRESHOLD, overrideReason = '' } = {}) {
   const numericScore = Number(score);
-  const numericThreshold = Number(threshold || DEFAULT_APPLY_QUALITY_THRESHOLD);
+  const numericThreshold = Number(threshold ?? DEFAULT_APPLY_QUALITY_THRESHOLD);
   if (!Number.isFinite(numericScore)) {
     return { allowed: false, status: 'missing_score', threshold: numericThreshold };
   }

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -132,3 +132,14 @@ cover_letter:
 # half-point scores like 3.5/5 occur in evaluations). Set it to 0 to
 # generate a PDF for every offer.
 # auto_pdf_score_threshold: 4.0
+
+# ── Apply quality gate ──────────────────────────────────────────────────────
+#
+# Candidate-facing apply packages should normally be generated only for roles
+# that meet the project's quality bar. Low-score roles can still be applied to,
+# but the user should provide a short override reason so the exception is
+# auditable in user-layer notes.
+#
+# Default (key absent OR commented out): 4.0.
+# apply_quality:
+#   threshold: 4.0

--- a/docs/apply-quality-gate.md
+++ b/docs/apply-quality-gate.md
@@ -1,0 +1,48 @@
+# Apply Quality Gate
+
+Issue: #1028
+
+career-ops should not behave like a spray-and-pray application tool. Evaluation and reporting may run for any role, but candidate-facing apply packages should require an explicit override when the score is below the configured quality threshold.
+
+## Default Policy
+
+The default threshold is `4.0`.
+
+```yaml
+apply_quality:
+  threshold: 4.0
+```
+
+If `apply_quality.threshold` is absent, scripts and agents should use `4.0`.
+
+## Gate Behavior
+
+- Scores below the threshold default to `do_not_apply`.
+- Evaluation, reporting, scanner output, and tracker review are not blocked.
+- Apply/PDF/cover/form-answer flows must ask for an override reason before generating candidate-facing materials.
+- Override reasons are user-layer data and should be recorded in tracker/report notes or `data/apply-overrides.md`.
+
+## Override Record
+
+```markdown
+## 2026-06-15 - company-role-slug
+
+- score: 3.4
+- threshold: 4.0
+- reason: "Strategic relationship with the hiring manager despite weak role fit."
+- target: reports/123-company-2026-06-15.md
+```
+
+## Non-Blocking Scope
+
+The gate must not prevent:
+
+- scanning
+- liveness checks
+- evaluation reports
+- salary research
+- tracker entries
+- user review of a weak-fit opportunity
+
+It only gates the action of producing application materials.
+


### PR DESCRIPTION
## Summary

Adds a configurable apply-quality gate so low-fit roles require an explicit override reason before application materials are generated.

## Details

- documents the threshold policy and non-blocking scope for evaluation/reporting
- adds `apply_quality.threshold` guidance to `config/profile.example.yml`
- adds `apply-quality-gate.mjs` to evaluate pass/block/override states and preserve override reasons in user-layer notes

Fixes #1028.

## Validation

- `node --check apply-quality-gate.mjs`
- `node apply-quality-gate.mjs 4.2 4.0`
- `node apply-quality-gate.mjs 3.2 4.0`
- `node apply-quality-gate.mjs 3.2 4.0 'strategic exception'`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a quality gate mechanism with configurable score thresholds (default 4.0) for candidate-facing materials.
  * Added support for override reasons to bypass score requirements when needed.

* **Documentation**
  * Added configuration example documenting the new quality gate setting.
  * Added detailed guide explaining the quality gate policy and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->