### PR TITLE
feat: add listing fingerprint contract

### DIFF
--- a/docs/listing-fingerprint.md
+++ b/docs/listing-fingerprint.md
@@ -25,6 +25,26 @@ The listing fingerprint identifies a public job posting without including candid
 }
 ```
 
+## Canonical v1 Input Set
+
+The v1 digest is computed from this ordered public input set:
+
+1. `schema_version`
+2. `ats_provider`
+3. `board_slug`
+4. `posting_id`
+5. `company`
+6. `title`
+7. `location`
+8. `work_mode`
+9. `canonical_host`
+10. `canonical_path`
+11. `content_hash`
+
+Implementations may accept camelCase aliases for developer ergonomics, but the
+documented contract is snake_case. Do not include candidate data in the v1 input
+set.
+
 ## Share-Safe Inputs
 
 Allowed inputs are public posting facts:
@@ -54,9 +74,13 @@ Branded pages and ATS-hosted pages can point to the same role. Implementations s
 - company casing and punctuation
 - title whitespace and punctuation
 
-When both a branded page and an ATS page are available, prefer the ATS provider, board slug, and posting id as the strongest identity fields.
+ATS identity wins over URL aliases. When `ats_provider`, `board_slug`, and
+`posting_id` are all present, v1 omits `canonical_host` and `canonical_path`
+from the digest so a branded careers page and the ATS-hosted page collapse to
+the same fingerprint. When that stable ATS identity is missing, v1 falls back to
+the normalized `canonical_host` and `canonical_path` so different public URLs do
+not collapse accidentally.
 
 ## Versioning
 
 The version prefix `fp_v1_` is part of the fingerprint. If normalization changes in a backward-incompatible way, create a new version such as `fp_v2_` rather than rewriting old fingerprints.
-

--- a/docs/listing-fingerprint.md
+++ b/docs/listing-fingerprint.md
@@ -1,0 +1,62 @@
+# Listing Fingerprint Schema
+
+Issue: #1030
+
+The listing fingerprint identifies a public job posting without including candidate data. It supports local dedupe, reusable job-facts caches, and future anonymous market intelligence.
+
+## Schema
+
+```json
+{
+  "schema_version": "listing-fingerprint/v1",
+  "fingerprint": "fp_v1_...",
+  "public_inputs": {
+    "company": "Example Inc",
+    "title": "Senior AI Engineer",
+    "location": "Berlin, Germany",
+    "work_mode": "hybrid",
+    "ats_provider": "greenhouse",
+    "board_slug": "example",
+    "posting_id": "12345",
+    "canonical_host": "boards.greenhouse.io",
+    "canonical_path": "/example/jobs/12345",
+    "content_hash": "sha256:..."
+  }
+}
+```
+
+## Share-Safe Inputs
+
+Allowed inputs are public posting facts:
+
+- normalized company name
+- normalized role title
+- public location or work-mode bucket
+- ATS provider and board slug
+- public posting id
+- canonical URL host and stable path
+- selected public JD content hash
+
+Forbidden inputs:
+
+- candidate identity, CV, fit score, compensation floor, application decision, notes, or follow-up history
+- private tracker status
+- recruiter conversations
+- interview outcomes
+
+## Alias Handling
+
+Branded pages and ATS-hosted pages can point to the same role. Implementations should normalize:
+
+- tracking parameters and fragments out of URLs
+- known ATS host aliases
+- trailing slashes
+- company casing and punctuation
+- title whitespace and punctuation
+
+When both a branded page and an ATS page are available, prefer the ATS provider, board slug, and posting id as the strongest identity fields.
+
+## Versioning
+
+The version prefix `fp_v1_` is part of the fingerprint. If normalization changes in a backward-incompatible way, create a new version such as `fp_v2_` rather than rewriting old fingerprints.
+

--- a/listing-fingerprint-tests.mjs
+++ b/listing-fingerprint-tests.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'fs';
+import { computeListingFingerprint } from './listing-fingerprint.mjs';
+
+let passed = 0;
+let failed = 0;
+
+function pass(message) {
+  console.log(`PASS ${message}`);
+  passed++;
+}
+
+function fail(message) {
+  console.error(`FAIL ${message}`);
+  failed++;
+}
+
+function assert(condition, message) {
+  if (condition) pass(message);
+  else fail(message);
+}
+
+const snakeCase = computeListingFingerprint({
+  ats_provider: 'greenhouse',
+  board_slug: 'example',
+  posting_id: 0,
+  company: 'Example Inc',
+  title: 'Senior AI Engineer',
+  location: 'Remote',
+  work_mode: false,
+  canonical_url: 'https://boards.greenhouse.io/example/jobs/0',
+  content_hash: 'sha256:abc',
+});
+
+const camelCase = computeListingFingerprint({
+  atsProvider: 'greenhouse',
+  boardSlug: 'example',
+  postingId: 0,
+  company: 'Example Inc',
+  title: 'Senior AI Engineer',
+  location: 'Remote',
+  workMode: false,
+  canonicalUrl: 'https://boards.greenhouse.io/example/jobs/0',
+  contentHash: 'sha256:abc',
+});
+
+assert(snakeCase === camelCase, 'snake_case and camelCase inputs produce the same fingerprint');
+
+const blankPosting = computeListingFingerprint({
+  ats_provider: 'greenhouse',
+  board_slug: 'example',
+  posting_id: '',
+  company: 'Example Inc',
+  title: 'Senior AI Engineer',
+  location: 'Remote',
+  work_mode: false,
+  canonical_url: 'https://boards.greenhouse.io/example/jobs/0',
+  content_hash: 'sha256:abc',
+});
+assert(snakeCase !== blankPosting, 'posting_id 0 is preserved instead of collapsing to blank');
+
+const slashPath = computeListingFingerprint({
+  company: 'Example Inc',
+  title: 'Senior AI Engineer',
+  canonical_host: 'jobs.example.com',
+  canonical_path: '/roles/123/',
+});
+const noSlashPath = computeListingFingerprint({
+  company: 'Example Inc',
+  title: 'Senior AI Engineer',
+  source_url: 'https://jobs.example.com/roles/123',
+});
+assert(slashPath === noSlashPath, 'direct canonical_path and parsed URL path normalize trailing slashes consistently');
+
+const brandedUrl = computeListingFingerprint({
+  ats_provider: 'greenhouse',
+  board_slug: 'example',
+  posting_id: '12345',
+  company: 'Example Inc',
+  title: 'Senior AI Engineer',
+  source_url: 'https://example.com/careers/senior-ai-engineer',
+});
+const atsUrl = computeListingFingerprint({
+  ats_provider: 'greenhouse',
+  board_slug: 'example',
+  posting_id: '12345',
+  company: 'Example Inc',
+  title: 'Senior AI Engineer',
+  canonical_url: 'https://boards.greenhouse.io/example/jobs/12345',
+});
+assert(brandedUrl === atsUrl, 'ATS provider + board_slug + posting_id collapse branded and ATS URL aliases');
+
+const brandedOnly = computeListingFingerprint({
+  company: 'Example Inc',
+  title: 'Senior AI Engineer',
+  source_url: 'https://example.com/careers/senior-ai-engineer',
+});
+const atsOnly = computeListingFingerprint({
+  company: 'Example Inc',
+  title: 'Senior AI Engineer',
+  source_url: 'https://boards.greenhouse.io/example/jobs/12345',
+});
+assert(brandedOnly !== atsOnly, 'URL host/path still distinguish listings without a stable ATS identity');
+
+const docs = readFileSync('docs/listing-fingerprint.md', 'utf-8');
+for (const text of [
+  'Canonical v1 Input Set',
+  'ATS identity wins over URL aliases',
+  'Do not include candidate data',
+]) {
+  assert(docs.includes(text), `docs include ${text}`);
+}
+
+const updateSystem = readFileSync('update-system.mjs', 'utf-8');
+assert(updateSystem.includes("'listing-fingerprint.mjs'"), 'listing-fingerprint.mjs is registered in SYSTEM_PATHS');
+assert(updateSystem.includes("'listing-fingerprint-tests.mjs'"), 'listing-fingerprint-tests.mjs is registered in SYSTEM_PATHS');
+
+if (failed > 0) {
+  console.error(`\n${passed} passed, ${failed} failed`);
+  process.exit(1);
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);

--- a/listing-fingerprint.mjs
+++ b/listing-fingerprint.mjs
@@ -6,12 +6,21 @@ import { fileURLToPath } from 'url';
 export const LISTING_FINGERPRINT_SCHEMA_VERSION = 'listing-fingerprint/v1';
 
 function normalize(value) {
-  return String(value || '')
+  return String(value ?? '')
     .toLowerCase()
     .normalize('NFKD')
     .replace(/[^\p{Letter}\p{Number}:/.-]+/gu, ' ')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+function pick(input, camelCase, snakeCase) {
+  return input[camelCase] ?? input[snakeCase];
+}
+
+function normalizePath(path) {
+  if (!path) return '';
+  return String(path).replace(/\/+$/, '') || '/';
 }
 
 export function normalizeUrlParts(url) {
@@ -21,7 +30,7 @@ export function normalizeUrlParts(url) {
     parsed.search = '';
     return {
       canonicalHost: parsed.hostname.toLowerCase(),
-      canonicalPath: parsed.pathname.replace(/\/+$/, '') || '/',
+      canonicalPath: normalizePath(parsed.pathname),
     };
   } catch {
     return { canonicalHost: '', canonicalPath: '' };
@@ -29,25 +38,34 @@ export function normalizeUrlParts(url) {
 }
 
 export function computeListingFingerprint(input = {}) {
-  const urlParts = normalizeUrlParts(input.canonicalUrl || input.sourceUrl || '');
+  const canonicalUrl = pick(input, 'canonicalUrl', 'canonical_url');
+  const sourceUrl = pick(input, 'sourceUrl', 'source_url');
+  const urlParts = normalizeUrlParts(canonicalUrl || sourceUrl || '');
+  const canonicalPath = pick(input, 'canonicalPath', 'canonical_path');
   const fields = [
     LISTING_FINGERPRINT_SCHEMA_VERSION,
-    input.atsProvider,
-    input.boardSlug,
-    input.postingId,
+    pick(input, 'atsProvider', 'ats_provider'),
+    pick(input, 'boardSlug', 'board_slug'),
+    pick(input, 'postingId', 'posting_id'),
     input.company,
     input.title,
     input.location,
-    input.workMode,
-    input.canonicalHost || urlParts.canonicalHost,
-    input.canonicalPath || urlParts.canonicalPath,
-    input.contentHash,
+    pick(input, 'workMode', 'work_mode'),
+    pick(input, 'canonicalHost', 'canonical_host') || urlParts.canonicalHost,
+    normalizePath(canonicalPath) || urlParts.canonicalPath,
+    pick(input, 'contentHash', 'content_hash'),
   ].map(normalize);
   const digest = createHash('sha256').update(fields.join('\n')).digest('hex').slice(0, 32);
   return `fp_v1_${digest}`;
 }
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {
-  const input = JSON.parse(process.argv[2] || '{}');
+  let input;
+  try {
+    input = JSON.parse(process.argv[2] || '{}');
+  } catch {
+    console.error('Input must be valid JSON.');
+    process.exit(1);
+  }
   console.log(computeListingFingerprint(input));
 }

--- a/listing-fingerprint.mjs
+++ b/listing-fingerprint.mjs
@@ -23,6 +23,10 @@ function normalizePath(path) {
   return String(path).replace(/\/+$/, '') || '/';
 }
 
+function hasValue(value) {
+  return normalize(value) !== '';
+}
+
 export function normalizeUrlParts(url) {
   try {
     const parsed = new URL(url);
@@ -42,17 +46,21 @@ export function computeListingFingerprint(input = {}) {
   const sourceUrl = pick(input, 'sourceUrl', 'source_url');
   const urlParts = normalizeUrlParts(canonicalUrl || sourceUrl || '');
   const canonicalPath = pick(input, 'canonicalPath', 'canonical_path');
+  const atsProvider = pick(input, 'atsProvider', 'ats_provider');
+  const boardSlug = pick(input, 'boardSlug', 'board_slug');
+  const postingId = pick(input, 'postingId', 'posting_id');
+  const hasStableAtsIdentity = hasValue(atsProvider) && hasValue(boardSlug) && hasValue(postingId);
   const fields = [
     LISTING_FINGERPRINT_SCHEMA_VERSION,
-    pick(input, 'atsProvider', 'ats_provider'),
-    pick(input, 'boardSlug', 'board_slug'),
-    pick(input, 'postingId', 'posting_id'),
+    atsProvider,
+    boardSlug,
+    postingId,
     input.company,
     input.title,
     input.location,
     pick(input, 'workMode', 'work_mode'),
-    pick(input, 'canonicalHost', 'canonical_host') || urlParts.canonicalHost,
-    normalizePath(canonicalPath) || urlParts.canonicalPath,
+    hasStableAtsIdentity ? '' : (pick(input, 'canonicalHost', 'canonical_host') || urlParts.canonicalHost),
+    hasStableAtsIdentity ? '' : (normalizePath(canonicalPath) || urlParts.canonicalPath),
     pick(input, 'contentHash', 'content_hash'),
   ].map(normalize);
   const digest = createHash('sha256').update(fields.join('\n')).digest('hex').slice(0, 32);

--- a/listing-fingerprint.mjs
+++ b/listing-fingerprint.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { createHash } from 'crypto';
+import { fileURLToPath } from 'url';
+
+export const LISTING_FINGERPRINT_SCHEMA_VERSION = 'listing-fingerprint/v1';
+
+function normalize(value) {
+  return String(value || '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^\p{Letter}\p{Number}:/.-]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function normalizeUrlParts(url) {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = '';
+    parsed.search = '';
+    return {
+      canonicalHost: parsed.hostname.toLowerCase(),
+      canonicalPath: parsed.pathname.replace(/\/+$/, '') || '/',
+    };
+  } catch {
+    return { canonicalHost: '', canonicalPath: '' };
+  }
+}
+
+export function computeListingFingerprint(input = {}) {
+  const urlParts = normalizeUrlParts(input.canonicalUrl || input.sourceUrl || '');
+  const fields = [
+    LISTING_FINGERPRINT_SCHEMA_VERSION,
+    input.atsProvider,
+    input.boardSlug,
+    input.postingId,
+    input.company,
+    input.title,
+    input.location,
+    input.workMode,
+    input.canonicalHost || urlParts.canonicalHost,
+    input.canonicalPath || urlParts.canonicalPath,
+    input.contentHash,
+  ].map(normalize);
+  const digest = createHash('sha256').update(fields.join('\n')).digest('hex').slice(0, 32);
+  return `fp_v1_${digest}`;
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const input = JSON.parse(process.argv[2] || '{}');
+  console.log(computeListingFingerprint(input));
+}

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -156,6 +156,7 @@ const scripts = [
   { name: 'merge-tracker.mjs --dry-run', expectExit: 0 },
   { name: 'reconcile-pipeline.mjs --dry-run', expectExit: 0 },
   { name: 'analyze-patterns.mjs --self-test', expectExit: 0 },
+  { name: 'listing-fingerprint-tests.mjs', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
   { name: 'validate-portals.mjs --file templates/portals.example.yml', expectExit: 0 },

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -93,6 +93,8 @@ const SYSTEM_PATHS = [
   'tracker-utils.mjs',
   'normalize-statuses.mjs',
   'cv-sync-check.mjs',
+  'listing-fingerprint.mjs',
+  'listing-fingerprint-tests.mjs',
   'update-system.mjs',
   'reserve-report-num.mjs',
   'scan.mjs',

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -63,6 +63,8 @@ const requiredSystemPaths = [
   '.antigravitycli/skills/',
   '.grok/skills/',
   'tracker-columns-tests.mjs',
+  'listing-fingerprint.mjs',
+  'listing-fingerprint-tests.mjs',
   'updater-migration-tests.mjs',
   'README.ar.md',
   'README.ja.md',


### PR DESCRIPTION
## Summary

Adds a deterministic listing fingerprint schema for local dedupe, reusable job-facts caches, and future anonymous market intelligence.

## Details

- documents share-safe public inputs and forbidden candidate-specific inputs
- specifies alias handling for branded pages versus ATS-hosted pages
- adds `listing-fingerprint.mjs` to compute a versioned local fingerprint from public posting fields

Fixes #1030.

## Validation

- `node --check listing-fingerprint.mjs`
- `node listing-fingerprint.mjs '{"company":"Example Inc","title":"Senior AI Engineer","sourceUrl":"https://boards.greenhouse.io/example/jobs/12345?gh_src=x#app"}'`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic “listing fingerprint” generation for public job postings to support consistent identification and deduplication across platforms.
* **Documentation**
  * Added a new documentation page defining the listing fingerprint JSON schema (including versioning guidance) and the normalization/precedence rules used for fingerprint computation.
* **Tests**
  * Added automated tests covering normalization equivalences, inequality cases, CLI behavior, and registration in the system path manifest.
* **Chores**
  * Updated system-path handling so the new generator and tests can be managed by the auto-update/rollback workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->