### PR TITLE
docs: define privacy modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ There are two layers. Read `DATA_CONTRACT.md` for the full list.
 
 **THE RULE: When the user asks to customize anything (archetypes, narrative, negotiation scripts, proof points, location policy, comp targets), ALWAYS write to `modes/_profile.md` or `config/profile.yml`. NEVER edit `modes/_shared.md` for user-specific content.** This ensures system updates don't overwrite their customizations.
 
+**Privacy mode rule:** Before any feature shares, syncs, uploads, or contributes data outside the local repo, read `config/profile.yml` `privacy.mode` and follow `docs/privacy-modes.md`. The default is `local_only`; do not share anything unless the user has explicitly opted into a mode that allows it and has seen an auditable preview.
+
 ## Update Check
 
 On the first message of each session, run the update checker silently:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ There are two layers. Read `DATA_CONTRACT.md` for the full list.
 
 **THE RULE: When the user asks to customize anything (archetypes, narrative, negotiation scripts, proof points, location policy, comp targets), ALWAYS write to `modes/_profile.md` or `config/profile.yml`. NEVER edit `modes/_shared.md` for user-specific content.** This ensures system updates don't overwrite their customizations.
 
+**Privacy mode rule:** Before any feature shares, syncs, uploads, or contributes data outside the local repo, read `config/profile.yml` `privacy.mode` and follow `docs/privacy-modes.md`. The default is `local_only`; do not share anything unless the user has explicitly opted into a mode that allows it and has seen an auditable preview.
+
 ## Update Check
 
 On the first message of each session, run the update checker silently:

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -58,6 +58,11 @@ compensation:
   minimum: "$120K"               # Walk-away number
   location_flexibility: "Remote preferred, 1 week/month on-site possible"
 
+privacy:
+  # Default privacy mode. Keep local_only unless you explicitly opt in to a
+  # future sharing or sync feature.
+  mode: "local_only"
+
 location:
   country: "United States"
   city: "San Francisco"

--- a/docs/privacy-modes.md
+++ b/docs/privacy-modes.md
@@ -56,5 +56,6 @@ Any non-local mode must show an auditable preview containing:
 - redaction summary
 - payload hash
 
-Agents must treat missing `privacy.mode` as `local_only`.
+If the user does not explicitly confirm the preview, the contribution or sync operation is blocked and no payload may be sent.
 
+Agents must treat missing `privacy.mode` as `local_only`.

--- a/docs/privacy-modes.md
+++ b/docs/privacy-modes.md
@@ -1,0 +1,60 @@
+# Privacy Modes
+
+Issue: #1031
+
+career-ops is local-first. Future shared intelligence or account sync features must be governed by explicit privacy modes instead of implicit agent behavior.
+
+## Modes
+
+### `local_only`
+
+Default mode.
+
+- Allowed: local file reads/writes, user-directed browsing, user-directed API calls, local reports, local tracker updates.
+- Prohibited: background sharing, anonymous contribution, account sync, hosted storage, telemetry, or uploading user-layer artifacts.
+- Consent: no sharing prompt should appear because sharing is disabled.
+- Audit: local operations may be logged in user-layer artifacts only.
+
+### `anonymous_contribution`
+
+Optional future mode for contributing public job-market signals after redaction and consent.
+
+- Allowed: share-safe public listing fingerprints, public job facts, provider quality metrics, liveness/freshness outcomes, and aggregate scanner signals.
+- Prohibited: CV, profile, compensation floor, candidate fit score, application decision, tracker status, recruiter conversations, interview notes, and personal constraints.
+- Consent: every contribution path must show a preview of the exact payload before sending.
+- Audit: write the timestamp, destination, schema version, and payload hash to a user-layer audit log.
+
+### `account_sync`
+
+Optional future mode for users who explicitly want cross-device or hosted features.
+
+- Allowed: only the data classes named in the sync consent screen.
+- Prohibited: silent sync of user-layer files, reports, CVs, or tracker data.
+- Consent: initial opt-in plus per-data-class confirmation.
+- Audit: local sync log with operation, destination, schema version, and changed artifact list.
+
+## Data-Class Matrix
+
+| Data class | local_only | anonymous_contribution | account_sync |
+|---|---:|---:|---:|
+| public listing fingerprint | local | allowed with preview | allowed if selected |
+| public job facts | local | allowed with preview | allowed if selected |
+| provider benchmark metrics | local | allowed with preview | allowed if selected |
+| CV/profile/story bank | local only | prohibited | opt-in only |
+| candidate fit score | local only | prohibited | opt-in only |
+| application decision/status | local only | prohibited | opt-in only |
+| recruiter/interview notes | local only | prohibited | opt-in only |
+
+## Preview Requirement
+
+Any non-local mode must show an auditable preview containing:
+
+- privacy mode
+- destination
+- schema version
+- payload JSON
+- redaction summary
+- payload hash
+
+Agents must treat missing `privacy.mode` as `local_only`.
+


### PR DESCRIPTION
## Summary

Defines first-class privacy modes for local-only use, anonymous contribution, and future account sync.

## Details

- documents the privacy mode contract and data-class matrix
- sets `privacy.mode: local_only` in the example profile
- updates agent instructions to check privacy mode before any sharing, sync, upload, or contribution path

Fixes #1031.

## Validation

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added privacy compliance rules for feature data handling
  * Added comprehensive privacy modes documentation defining three modes with data classification matrix and mandatory audit preview requirements

* **Configuration**
  * Added privacy configuration block with local-only default mode setting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->