### PR TITLE
feat: add evidence graph contract

### DIFF
--- a/docs/evidence-graph.md
+++ b/docs/evidence-graph.md
@@ -7,7 +7,7 @@ The evidence graph connects user-owned proof points to generated CVs, cover lett
 ## Evidence Item
 
 ```yaml
-id: ev_...
+id: ev_a1b2c3d4e5f6
 source: article-digest.md
 source_anchor: "Project Alpha"
 claim_type: metric
@@ -31,15 +31,15 @@ urls:
 Generated artifacts may reference evidence internally:
 
 ```markdown
-<!-- evidence: ev_latency_40, ev_project_alpha -->
+<!-- evidence: ev_a1b2c3d4e5f6, ev_1234abcd5678 -->
 ```
 
 Reports may also include metadata:
 
 ```yaml
 evidence_ids:
-  - ev_latency_40
-  - ev_project_alpha
+  - ev_a1b2c3d4e5f6
+  - ev_1234abcd5678
 ```
 
 ## Unsupported Claim Rule
@@ -52,4 +52,3 @@ Before finalizing candidate-facing output, agents should flag claims that:
 - cite a URL that is not present in the user layer
 
 The graph remains local. Evidence IDs may appear in generated metadata, but private source content must not be shared without explicit privacy-mode consent.
-

--- a/docs/evidence-graph.md
+++ b/docs/evidence-graph.md
@@ -1,0 +1,55 @@
+# Evidence Graph Contract
+
+Issue: #1033
+
+The evidence graph connects user-owned proof points to generated CVs, cover letters, reports, and interview stories. It helps agents avoid unsupported claims before output is finalized.
+
+## Evidence Item
+
+```yaml
+id: ev_...
+source: article-digest.md
+source_anchor: "Project Alpha"
+claim_type: metric
+claim: "Reduced inference latency 40%"
+confidence: high
+urls:
+  - https://example.com/project-alpha
+```
+
+## Claim Types
+
+- `metric`: measurable impact, revenue, latency, adoption, scale, quality, or cost
+- `project`: project ownership or delivery claim
+- `skill`: technology, domain, language, or method evidence
+- `leadership`: mentoring, cross-functional work, hiring, stakeholder management
+- `story`: STAR/STAR+R interview narrative
+- `credential`: degree, certificate, publication, award, or talk
+
+## Reference Format
+
+Generated artifacts may reference evidence internally:
+
+```markdown
+<!-- evidence: ev_latency_40, ev_project_alpha -->
+```
+
+Reports may also include metadata:
+
+```yaml
+evidence_ids:
+  - ev_latency_40
+  - ev_project_alpha
+```
+
+## Unsupported Claim Rule
+
+Before finalizing candidate-facing output, agents should flag claims that:
+
+- contain a strong metric without an evidence ID
+- introduce a company, project, credential, or technology not present in user-layer evidence
+- strengthen a claim beyond the evidence confidence
+- cite a URL that is not present in the user layer
+
+The graph remains local. Evidence IDs may appear in generated metadata, but private source content must not be shared without explicit privacy-mode consent.
+

--- a/evidence-graph.mjs
+++ b/evidence-graph.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { createHash } from 'crypto';
+import { existsSync, readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+function evidenceId(source, claim) {
+  const digest = createHash('sha256').update(`${source}\n${claim}`).digest('hex').slice(0, 12);
+  return `ev_${digest}`;
+}
+
+export function extractEvidenceItems(markdown = '', source = 'unknown') {
+  const lines = markdown.split('\n');
+  const items = [];
+  for (const line of lines) {
+    const metric = line.match(/(\d+[%x]|\$[\d,.]+|[\d,.]+\s*(users|stars|ms|sec|seconds|minutes|hours|days))/i);
+    const bullet = line.match(/^\s*[-*]\s+(.+)/);
+    if (!bullet && !metric) continue;
+    const claim = (bullet?.[1] || line).trim();
+    if (!claim) continue;
+    items.push({
+      id: evidenceId(source, claim),
+      source,
+      claim_type: metric ? 'metric' : 'project',
+      claim,
+      confidence: 'medium',
+    });
+  }
+  return items;
+}
+
+export function findUnsupportedStrongClaims(output = '', evidenceIds = []) {
+  const known = new Set(evidenceIds);
+  const claimBlocks = output.split('\n').filter((line) => /\d+[%x]|\$[\d,.]+/.test(line));
+  return claimBlocks.filter((line) => {
+    const refs = Array.from(line.matchAll(/ev_[a-f0-9]{12}/g)).map((match) => match[0]);
+    return refs.length === 0 || refs.some((ref) => !known.has(ref));
+  });
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const files = process.argv.slice(2);
+  const evidence = files.flatMap((file) => existsSync(file) ? extractEvidenceItems(readFileSync(file, 'utf8'), file) : []);
+  console.log(JSON.stringify({ schema_version: 'career-ops.evidence-graph/v1', evidence }, null, 2));
+}

--- a/evidence-graph.mjs
+++ b/evidence-graph.mjs
@@ -2,25 +2,47 @@
 
 import { createHash } from 'crypto';
 import { existsSync, readFileSync } from 'fs';
+import { isAbsolute, relative, resolve, sep } from 'path';
 import { fileURLToPath } from 'url';
 
+const METRIC_PATTERN = /(\d+[%x]|\$[\d,.]+|[\d,.]+\s*(users|stars|ms|sec|seconds|minutes|hours|days))/i;
+const WORKSPACE_ROOT = process.cwd();
+
+function normalizeSource(source = 'unknown') {
+  if (source === 'unknown') return source;
+  return relative(WORKSPACE_ROOT, resolve(source)).replaceAll(sep, '/') || '.';
+}
+
+function safeWorkspacePath(file) {
+  if (isAbsolute(file) || file.split(/[\\/]/).includes('..')) {
+    throw new Error(`Evidence input must be a relative workspace path: ${file}`);
+  }
+  const resolved = resolve(WORKSPACE_ROOT, file);
+  const relativePath = relative(WORKSPACE_ROOT, resolved);
+  if (!relativePath || relativePath.startsWith('..') || relativePath.startsWith(sep)) {
+    throw new Error(`Evidence input must stay inside the workspace: ${file}`);
+  }
+  return resolved;
+}
+
 function evidenceId(source, claim) {
-  const digest = createHash('sha256').update(`${source}\n${claim}`).digest('hex').slice(0, 12);
+  const digest = createHash('sha256').update(`${normalizeSource(source)}\n${claim}`).digest('hex').slice(0, 12);
   return `ev_${digest}`;
 }
 
 export function extractEvidenceItems(markdown = '', source = 'unknown') {
+  const normalizedSource = normalizeSource(source);
   const lines = markdown.split('\n');
   const items = [];
   for (const line of lines) {
-    const metric = line.match(/(\d+[%x]|\$[\d,.]+|[\d,.]+\s*(users|stars|ms|sec|seconds|minutes|hours|days))/i);
+    const metric = line.match(METRIC_PATTERN);
     const bullet = line.match(/^\s*[-*]\s+(.+)/);
     if (!bullet && !metric) continue;
     const claim = (bullet?.[1] || line).trim();
     if (!claim) continue;
     items.push({
-      id: evidenceId(source, claim),
-      source,
+      id: evidenceId(normalizedSource, claim),
+      source: normalizedSource,
       claim_type: metric ? 'metric' : 'project',
       claim,
       confidence: 'medium',
@@ -31,7 +53,7 @@ export function extractEvidenceItems(markdown = '', source = 'unknown') {
 
 export function findUnsupportedStrongClaims(output = '', evidenceIds = []) {
   const known = new Set(evidenceIds);
-  const claimBlocks = output.split('\n').filter((line) => /\d+[%x]|\$[\d,.]+/.test(line));
+  const claimBlocks = output.split('\n').filter((line) => METRIC_PATTERN.test(line));
   return claimBlocks.filter((line) => {
     const refs = Array.from(line.matchAll(/ev_[a-f0-9]{12}/g)).map((match) => match[0]);
     return refs.length === 0 || refs.some((ref) => !known.has(ref));
@@ -39,7 +61,13 @@ export function findUnsupportedStrongClaims(output = '', evidenceIds = []) {
 }
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {
-  const files = process.argv.slice(2);
-  const evidence = files.flatMap((file) => existsSync(file) ? extractEvidenceItems(readFileSync(file, 'utf8'), file) : []);
+  let files;
+  try {
+    files = process.argv.slice(2).map((file) => ({ input: file, path: safeWorkspacePath(file) }));
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+  const evidence = files.flatMap(({ input, path }) => existsSync(path) ? extractEvidenceItems(readFileSync(path, 'utf8'), input) : []);
   console.log(JSON.stringify({ schema_version: 'career-ops.evidence-graph/v1', evidence }, null, 2));
 }


### PR DESCRIPTION
## Summary

Adds an evidence graph contract so strong CV, cover, report, and interview claims can trace back to user-owned proof points.

## Details

- documents evidence item schema, claim types, artifact references, and unsupported-claim rules
- adds `evidence-graph.mjs` to derive stable evidence IDs from markdown proof points
- includes a helper for flagging metric-heavy output that lacks known evidence references

Fixes #1033.

## Validation

- `node --check evidence-graph.mjs`
- `node evidence-graph.mjs examples/article-digest-example.md`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Evidence Graph documentation defining evidence item structure, supported claim types, reference formats, and validation rules for flagging unsupported claims.

* **New Features**
  * Added evidence extraction from markdown content supporting metrics and project claims.
  * Added validation to identify unsupported claims in output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->