### PR TITLE
feat: add scanner benchmark suite

### DIFF
--- a/docs/scanner-benchmark.md
+++ b/docs/scanner-benchmark.md
@@ -1,0 +1,42 @@
+# Scanner Benchmark Suite
+
+Issue: #1034
+
+The scanner benchmark suite measures whether providers improve useful coverage or merely add stale/noisy postings. It starts with deterministic fixtures so CI does not depend on live job boards.
+
+## Fixture Format
+
+```json
+{
+  "schema_version": "career-ops.scanner-benchmark/v1",
+  "name": "core-ai-roles",
+  "expected": [
+    {
+      "id": "expected-1",
+      "company": "Example Inc",
+      "title": "Senior AI Engineer",
+      "location": "Berlin",
+      "fresh": true
+    }
+  ],
+  "actual": [
+    {
+      "provider": "greenhouse",
+      "company": "Example Inc",
+      "title": "Senior AI Engineer",
+      "location": "Berlin",
+      "fresh": true
+    }
+  ]
+}
+```
+
+## Metrics
+
+- `coverage`: expected postings matched by actual provider output
+- `freshness`: actual postings marked fresh
+- `noise`: actual postings that do not match any expected posting
+- `duplicate_rate`: duplicate normalized postings in actual output
+
+Live network benchmarks can be added later, but provider PRs should be able to include deterministic fixture evidence first.
+

--- a/docs/scanner-benchmark.md
+++ b/docs/scanner-benchmark.md
@@ -16,7 +16,8 @@ The scanner benchmark suite measures whether providers improve useful coverage o
       "company": "Example Inc",
       "title": "Senior AI Engineer",
       "location": "Berlin",
-      "fresh": true
+      "fresh": true,
+      "compensation_expected": true
     }
   ],
   "actual": [
@@ -25,8 +26,17 @@ The scanner benchmark suite measures whether providers improve useful coverage o
       "company": "Example Inc",
       "title": "Senior AI Engineer",
       "location": "Berlin",
-      "fresh": true
+      "fresh": true,
+      "compensation": {
+        "min": 120000,
+        "max": 160000,
+        "currency": "EUR"
+      }
     }
+  ],
+  "provider_results": [
+    { "provider": "greenhouse", "status": "ok" },
+    { "provider": "lever", "status": "timeout" }
   ]
 }
 ```
@@ -36,7 +46,10 @@ The scanner benchmark suite measures whether providers improve useful coverage o
 - `coverage`: expected postings matched by actual provider output
 - `freshness`: actual postings marked fresh
 - `noise`: actual postings that do not match any expected posting
+- `location_accuracy`: matched postings whose location matches the expected location
+- `compensation_extraction`: expected compensation-bearing postings where the provider returned compensation
 - `duplicate_rate`: duplicate normalized postings in actual output
+- `provider_failure_rate`: provider runs with a non-OK status
+- `timeout_rate`: provider runs that timed out
 
 Live network benchmarks can be added later, but provider PRs should be able to include deterministic fixture evidence first.
-

--- a/fixtures/scanner-benchmark/core-ai-roles.json
+++ b/fixtures/scanner-benchmark/core-ai-roles.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "career-ops.scanner-benchmark/v1",
+  "name": "core-ai-roles",
+  "expected": [
+    {
+      "id": "expected-1",
+      "company": "Example Inc",
+      "title": "Senior AI Engineer",
+      "location": "Berlin",
+      "fresh": true
+    },
+    {
+      "id": "expected-2",
+      "company": "Acme Labs",
+      "title": "Applied ML Engineer",
+      "location": "Remote",
+      "fresh": true
+    }
+  ],
+  "actual": [
+    {
+      "provider": "greenhouse",
+      "company": "Example Inc",
+      "title": "Senior AI Engineer",
+      "location": "Berlin",
+      "fresh": true
+    },
+    {
+      "provider": "lever",
+      "company": "Acme Labs",
+      "title": "Applied ML Engineer",
+      "location": "Remote",
+      "fresh": true
+    },
+    {
+      "provider": "workday",
+      "company": "Old Corp",
+      "title": "Frontend Intern",
+      "location": "Paris",
+      "fresh": false
+    }
+  ]
+}

--- a/fixtures/scanner-benchmark/core-ai-roles.json
+++ b/fixtures/scanner-benchmark/core-ai-roles.json
@@ -7,7 +7,8 @@
       "company": "Example Inc",
       "title": "Senior AI Engineer",
       "location": "Berlin",
-      "fresh": true
+      "fresh": true,
+      "compensation_expected": true
     },
     {
       "id": "expected-2",
@@ -23,7 +24,12 @@
       "company": "Example Inc",
       "title": "Senior AI Engineer",
       "location": "Berlin",
-      "fresh": true
+      "fresh": true,
+      "compensation": {
+        "min": 120000,
+        "max": 160000,
+        "currency": "EUR"
+      }
     },
     {
       "provider": "lever",
@@ -38,6 +44,20 @@
       "title": "Frontend Intern",
       "location": "Paris",
       "fresh": false
+    }
+  ],
+  "provider_results": [
+    {
+      "provider": "greenhouse",
+      "status": "ok"
+    },
+    {
+      "provider": "lever",
+      "status": "ok"
+    },
+    {
+      "provider": "workday",
+      "status": "timeout"
     }
   ]
 }

--- a/scanner-benchmark-tests.mjs
+++ b/scanner-benchmark-tests.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'fs';
+import { scoreScannerBenchmark } from './scanner-benchmark.mjs';
+
+let passed = 0;
+let failed = 0;
+
+function pass(message) {
+  console.log(`PASS ${message}`);
+  passed++;
+}
+
+function fail(message) {
+  console.error(`FAIL ${message}`);
+  failed++;
+}
+
+function assertEqual(actual, expected, message) {
+  if (Object.is(actual, expected)) pass(message);
+  else fail(`${message}: expected ${expected}, got ${actual}`);
+}
+
+const result = scoreScannerBenchmark({
+  name: 'metric-coverage',
+  expected: [
+    {
+      id: 'expected-1',
+      company: 'Example Inc',
+      title: 'Senior AI Engineer',
+      location: 'Berlin',
+      compensation_expected: true,
+    },
+    {
+      id: 'expected-2',
+      company: 'Acme Labs',
+      title: 'Applied ML Engineer',
+      location: 'Remote',
+      compensation_expected: false,
+    },
+  ],
+  actual: [
+    {
+      provider: 'greenhouse',
+      company: 'Example Inc',
+      title: 'Senior AI Engineer',
+      location: 'Berlin',
+      fresh: true,
+      compensation: { min: 120000, max: 160000, currency: 'EUR' },
+    },
+    {
+      provider: 'lever',
+      company: 'Acme Labs',
+      title: 'Applied ML Engineer',
+      location: 'Paris',
+      fresh: true,
+    },
+    {
+      provider: 'workday',
+      company: 'Old Corp',
+      title: 'Frontend Intern',
+      location: 'Paris',
+      fresh: false,
+    },
+    {
+      provider: 'greenhouse',
+      company: 'Example Inc',
+      title: 'Senior AI Engineer',
+      location: 'Berlin',
+      fresh: true,
+      compensation: { min: 120000, max: 160000, currency: 'EUR' },
+    },
+  ],
+  provider_results: [
+    { provider: 'greenhouse', status: 'ok' },
+    { provider: 'lever', status: 'timeout' },
+    { provider: 'workday', status: 'error' },
+  ],
+});
+
+assertEqual(result.coverage, 1, 'coverage matches expected postings by identity');
+assertEqual(result.freshness, 0.75, 'freshness counts non-stale actual postings');
+assertEqual(result.noise, 0.25, 'noise counts unmatched actual postings');
+assertEqual(result.duplicate_rate, 0.25, 'duplicate_rate counts repeated normalized postings');
+assertEqual(result.location_accuracy, 0.5, 'location_accuracy scores matched postings with correct locations');
+assertEqual(result.compensation_extraction, 1, 'compensation_extraction scores required compensation matches');
+assertEqual(result.provider_failure_rate, 2 / 3, 'provider_failure_rate scores failed provider runs');
+assertEqual(result.timeout_rate, 1 / 3, 'timeout_rate scores timeout provider runs');
+
+const docs = readFileSync('docs/scanner-benchmark.md', 'utf-8');
+for (const metric of ['location_accuracy', 'compensation_extraction', 'provider_failure_rate', 'timeout_rate']) {
+  if (docs.includes(metric)) pass(`docs mention ${metric}`);
+  else fail(`docs missing ${metric}`);
+}
+
+const updateSystem = readFileSync('update-system.mjs', 'utf-8');
+if (updateSystem.includes("'scanner-benchmark.mjs'")) pass('scanner-benchmark.mjs is registered in SYSTEM_PATHS');
+else fail('scanner-benchmark.mjs missing from SYSTEM_PATHS');
+if (updateSystem.includes("'scanner-benchmark-tests.mjs'")) pass('scanner-benchmark-tests.mjs is registered in SYSTEM_PATHS');
+else fail('scanner-benchmark-tests.mjs missing from SYSTEM_PATHS');
+
+if (failed > 0) {
+  console.error(`\n${passed} passed, ${failed} failed`);
+  process.exit(1);
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);

--- a/scanner-benchmark.mjs
+++ b/scanner-benchmark.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+function normalize(value) {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+function key(job) {
+  return [job.company, job.title, job.location].map(normalize).join('|');
+}
+
+export function scoreScannerBenchmark(fixture = {}) {
+  const expected = Array.isArray(fixture.expected) ? fixture.expected : [];
+  const actual = Array.isArray(fixture.actual) ? fixture.actual : [];
+  const expectedKeys = new Set(expected.map(key));
+  const actualKeys = actual.map(key);
+  const uniqueActualKeys = new Set(actualKeys);
+  const matched = new Set(actualKeys.filter((item) => expectedKeys.has(item)));
+  const noise = actualKeys.filter((item) => !expectedKeys.has(item)).length;
+  const fresh = actual.filter((item) => item.fresh !== false).length;
+  const duplicates = actual.length - uniqueActualKeys.size;
+
+  return {
+    schema_version: 'career-ops.scanner-benchmark-result/v1',
+    fixture: fixture.name || 'unnamed',
+    expected: expected.length,
+    actual: actual.length,
+    matched: matched.size,
+    coverage: expected.length ? matched.size / expected.length : 0,
+    freshness: actual.length ? fresh / actual.length : 0,
+    noise: actual.length ? noise / actual.length : 0,
+    duplicate_rate: actual.length ? duplicates / actual.length : 0,
+  };
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const file = process.argv[2] || 'fixtures/scanner-benchmark/core-ai-roles.json';
+  const fixture = JSON.parse(readFileSync(file, 'utf8'));
+  console.log(JSON.stringify(scoreScannerBenchmark(fixture), null, 2));
+}

--- a/scanner-benchmark.mjs
+++ b/scanner-benchmark.mjs
@@ -35,8 +35,22 @@ export function scoreScannerBenchmark(fixture = {}) {
   };
 }
 
+export function loadFixture(file) {
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'));
+  } catch (error) {
+    throw new Error(`Unable to load benchmark fixture "${file}": ${error.message}`);
+  }
+}
+
 if (fileURLToPath(import.meta.url) === process.argv[1]) {
   const file = process.argv[2] || 'fixtures/scanner-benchmark/core-ai-roles.json';
-  const fixture = JSON.parse(readFileSync(file, 'utf8'));
+  let fixture;
+  try {
+    fixture = loadFixture(file);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
   console.log(JSON.stringify(scoreScannerBenchmark(fixture), null, 2));
 }

--- a/scanner-benchmark.mjs
+++ b/scanner-benchmark.mjs
@@ -4,23 +4,61 @@ import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 
 function normalize(value) {
-  return String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+  return String(value ?? '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
 }
 
-function key(job) {
+function identityKey(job) {
+  return [job.company, job.title].map(normalize).join('|');
+}
+
+function postingKey(job) {
   return [job.company, job.title, job.location].map(normalize).join('|');
+}
+
+function hasCompensation(job) {
+  return Boolean(job?.compensation || job?.compensation_text || job?.salary || job?.salary_range);
+}
+
+function expectsCompensation(job) {
+  return job?.compensation_expected === true || hasCompensation(job);
+}
+
+function providerStatus(result) {
+  return normalize(result?.status || result?.result || result?.error || '');
 }
 
 export function scoreScannerBenchmark(fixture = {}) {
   const expected = Array.isArray(fixture.expected) ? fixture.expected : [];
   const actual = Array.isArray(fixture.actual) ? fixture.actual : [];
-  const expectedKeys = new Set(expected.map(key));
-  const actualKeys = actual.map(key);
-  const uniqueActualKeys = new Set(actualKeys);
-  const matched = new Set(actualKeys.filter((item) => expectedKeys.has(item)));
-  const noise = actualKeys.filter((item) => !expectedKeys.has(item)).length;
+  const providerResults = Array.isArray(fixture.provider_results)
+    ? fixture.provider_results
+    : (Array.isArray(fixture.providerResults) ? fixture.providerResults : []);
+
+  const expectedByIdentity = new Map(expected.map((item) => [identityKey(item), item]));
+  const expectedKeys = new Set(expectedByIdentity.keys());
+  const actualIdentityKeys = actual.map(identityKey);
+  const actualPostingKeys = actual.map(postingKey);
+  const uniqueActualPostingKeys = new Set(actualPostingKeys);
+  const matched = new Set(actualIdentityKeys.filter((item) => expectedKeys.has(item)));
+  const noise = actualIdentityKeys.filter((item) => !expectedKeys.has(item)).length;
   const fresh = actual.filter((item) => item.fresh !== false).length;
-  const duplicates = actual.length - uniqueActualKeys.size;
+  const duplicates = actual.length - uniqueActualPostingKeys.size;
+  const locationCorrect = Array.from(matched).filter((matchedKey) => {
+    const expectedItem = expectedByIdentity.get(matchedKey);
+    return actual.some((item) =>
+      identityKey(item) === matchedKey &&
+      normalize(item.location) === normalize(expectedItem.location)
+    );
+  }).length;
+  const compensationExpected = expected.filter(expectsCompensation);
+  const compensationFound = compensationExpected.filter((expectedItem) =>
+    actual.some((item) => identityKey(item) === identityKey(expectedItem) && hasCompensation(item))
+  ).length;
+  const failedProviders = providerResults.filter((item) => {
+    const status = providerStatus(item);
+    return status && !['ok', 'success', 'passed'].includes(status);
+  }).length;
+  const timedOutProviders = providerResults.filter((item) => providerStatus(item).includes('timeout')).length;
 
   return {
     schema_version: 'career-ops.scanner-benchmark-result/v1',
@@ -32,6 +70,10 @@ export function scoreScannerBenchmark(fixture = {}) {
     freshness: actual.length ? fresh / actual.length : 0,
     noise: actual.length ? noise / actual.length : 0,
     duplicate_rate: actual.length ? duplicates / actual.length : 0,
+    location_accuracy: matched.size ? locationCorrect / matched.size : 0,
+    compensation_extraction: compensationExpected.length ? compensationFound / compensationExpected.length : 0,
+    provider_failure_rate: providerResults.length ? failedProviders / providerResults.length : 0,
+    timeout_rate: providerResults.length ? timedOutProviders / providerResults.length : 0,
   };
 }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -156,6 +156,7 @@ const scripts = [
   { name: 'merge-tracker.mjs --dry-run', expectExit: 0 },
   { name: 'reconcile-pipeline.mjs --dry-run', expectExit: 0 },
   { name: 'analyze-patterns.mjs --self-test', expectExit: 0 },
+  { name: 'scanner-benchmark-tests.mjs', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
   { name: 'validate-portals.mjs --file templates/portals.example.yml', expectExit: 0 },

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -104,6 +104,8 @@ const SYSTEM_PATHS = [
   'liveness-browser.mjs',
   'liveness-api.mjs',
   'analyze-patterns.mjs',
+  'scanner-benchmark.mjs',
+  'scanner-benchmark-tests.mjs',
   'followup-cadence.mjs',
   'gemini-eval.mjs',
   'test-all.mjs',

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -63,6 +63,8 @@ const requiredSystemPaths = [
   '.antigravitycli/skills/',
   '.grok/skills/',
   'tracker-columns-tests.mjs',
+  'scanner-benchmark.mjs',
+  'scanner-benchmark-tests.mjs',
   'updater-migration-tests.mjs',
   'README.ar.md',
   'README.ja.md',


### PR DESCRIPTION
## Summary

Adds a deterministic scanner benchmark suite for provider coverage, freshness, noise, and duplicate-rate evidence.

## Details

- documents the scanner benchmark fixture format and metrics
- adds a representative fixture for core AI roles
- adds `scanner-benchmark.mjs` to score provider outputs without live network access

Fixes #1034.

## Validation

- `node --check scanner-benchmark.mjs`
- `node scanner-benchmark.mjs fixtures/scanner-benchmark/core-ai-roles.json`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added deterministic scanner benchmark docs, including fixture structure and metric definitions.
* **New Features**
  * Added a scanner benchmark runner that scores fixture outputs and returns structured evaluation metrics.
* **Tests**
  * Added benchmark fixture data and an automated benchmark validation script covering coverage, freshness, noise, duplicates, location accuracy, compensation extraction, and provider failure/timeout rates.
  * Extended the general test suite to run the new benchmark script.
* **Chores**
  * Updated the system update allowlist to include the new benchmark runner and test script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->