### PR TITLE
feat(scan): add Fractional Pulse provider for fractional-exec roles

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -35,6 +35,7 @@ Determine the mode from `$mode`:
 | `batch` | `batch` |
 | `patterns` | `patterns` |
 | `followup` | `followup` |
+| `innovatorsroom` | `innovatorsroom` |
 | `update` | `update` |
 | `cover` | `cover` |
 
@@ -71,6 +72,7 @@ Available commands:
   /career-ops batch     → Batch processing with parallel workers
   /career-ops patterns  → Analyze rejection patterns and improve targeting
   /career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
+  /career-ops innovatorsroom → Import roles from the InnovatorsRoom TechJobs newsletter (Gmail)
   /career-ops update    → Update career-ops system files with diff preview + compat check
 
 Inbox: add URLs to data/pipeline.md → /career-ops pipeline
@@ -91,7 +93,7 @@ Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `p
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`
 
-Applies to: `tracker`, `deep`, `interview-prep`, `interview`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`
+Applies to: `tracker`, `deep`, `interview-prep`, `interview`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`, `innovatorsroom`
 
 ### Modes delegated to subagent:
 For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as Agent with the content of `_shared.md` + `modes/{mode}.md` injected into the subagent prompt.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Batch processes offers | `batch` |
 | Asks about rejection patterns or wants to improve targeting | `patterns` |
 | Asks about follow-ups or application cadence | `followup` |
+| Wants to import roles from the InnovatorsRoom newsletter | `innovatorsroom` |
 | Wants to update the system | `update` |
 
 ### CV Source of Truth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Batch processes offers | `batch` |
 | Asks about rejection patterns or wants to improve targeting | `patterns` |
 | Asks about follow-ups or application cadence | `followup` |
+| Wants to import roles from the InnovatorsRoom newsletter | `innovatorsroom` |
 
 ### CV Source of Truth
 

--- a/innovatorsroom.mjs
+++ b/innovatorsroom.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+/**
+ * innovatorsroom.mjs — turn an InnovatorsRoom "TechJobs" newsletter into
+ * filtered pipeline entries.
+ *
+ * The newsletter (Beehiiv) lists roles as 6-line plaintext blocks:
+ *     {flags} {location} - {company}
+ *     <company tracking url>
+ *     - {title}
+ *     <title tracking url>
+ *     🔗
+ *     <APPLY tracking url>        <- the real job link (Beehiiv redirect)
+ *
+ * This script parses those blocks, applies the SAME title/location filters the
+ * portal scanner uses (portals.yml), resolves the tracking URL of each keeper
+ * to its real ATS destination, dedups against scan-history/pipeline/applications,
+ * and appends the survivors to data/pipeline.md + data/scan-history.tsv.
+ *
+ * The email itself is fetched by the agent via the Gmail MCP (see
+ * modes/innovatorsroom.md) and saved to a plaintext file passed here.
+ *
+ * Usage:
+ *   node innovatorsroom.mjs <email-plaintext-file> [--issue 116] [--date YYYY-MM-DD] [--dry-run]
+ */
+
+import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync } from 'fs';
+import yaml from 'js-yaml';
+import { buildTitleFilter, buildLocationFilter } from './scan.mjs';
+
+const PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
+const PIPELINE_PATH = 'data/pipeline.md';
+const SCAN_HISTORY_PATH = 'data/scan-history.tsv';
+const APPLICATIONS_PATH = 'data/applications.md';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const file = args.find(a => !a.startsWith('--'));
+const issue = argVal('--issue');
+const dateArg = argVal('--date');
+
+function argVal(flag) {
+  const i = args.indexOf(flag);
+  return i !== -1 ? args[i + 1] : null;
+}
+
+if (!file || !existsSync(file)) {
+  console.error('Usage: node innovatorsroom.mjs <email-plaintext-file> [--issue N] [--dry-run]');
+  process.exit(1);
+}
+
+// ── Parse newsletter ────────────────────────────────────────────────
+
+const raw = readFileSync(file, 'utf-8');
+const lines = raw.split(/\r?\n/).map(l => l.trim());
+const issueNo = issue || (raw.match(/TechJobs\s+#(\d+)/) || [])[1] || 'latest';
+const date = dateArg || new Date().toISOString().slice(0, 10);
+
+// flags + 💻 🎓 🚀 📩 and other leading marker emoji
+const EMOJI_RE = /[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{FE0F}\u{200D}]/gu;
+const stripEmoji = (s) => (s || '').replace(EMOJI_RE, '').replace(/\s{2,}/g, ' ').trim();
+const isUrl = (l) => /^<?https?:\/\//.test(l || '');
+const cleanUrl = (l) => (l || '').replace(/^<|>$/g, '').trim();
+
+const roles = [];
+for (let i = 0; i < lines.length; i++) {
+  if (lines[i] !== '🔗') continue;
+  const applyUrl = isUrl(lines[i + 1]) ? cleanUrl(lines[i + 1]) : '';
+  if (!applyUrl) continue;
+
+  // Walk back over the block: nearest "- {title}" line, then the header
+  // ("{flags} {location} - {company}") just above it.
+  let title = '', header = '';
+  for (let k = i - 1; k >= Math.max(0, i - 8); k--) {
+    if (!title && /^-\s+.+/.test(lines[k]) && !isUrl(lines[k])) {
+      title = lines[k].replace(/^-\s+/, '').trim();
+      continue;
+    }
+    if (title && !isUrl(lines[k]) && lines[k].includes(' - ')) {
+      header = lines[k];
+      break;
+    }
+  }
+  if (!title || !header) continue;
+
+  const parts = header.split(' - ');
+  const company = stripEmoji(parts[parts.length - 1]);
+  const location = stripEmoji(parts.slice(0, -1).join(' - '));
+  const cleanTitle = stripEmoji(title);
+  if (!company || !cleanTitle) continue;
+  roles.push({ company, title: cleanTitle, location, applyUrl });
+}
+
+// ── Filter (reuse the portal scanner's filters) ─────────────────────
+
+const cfg = yaml.load(readFileSync(PORTALS_PATH, 'utf-8'));
+const titleOk = buildTitleFilter(cfg.title_filter);
+const locOk = buildLocationFilter(cfg.location_filter);
+
+// dedup intra-issue by company::title (same role often appears in 2 categories)
+const seenInIssue = new Set();
+const filtered = [];
+for (const r of roles) {
+  const key = `${r.company.toLowerCase()}::${r.title.toLowerCase()}`;
+  if (seenInIssue.has(key)) continue;
+  seenInIssue.add(key);
+  if (titleOk(r.title) && locOk(r.location)) filtered.push(r);
+}
+
+// ── Dedup against existing pipeline / history / applications ─────────
+
+function loadSeen() {
+  const urls = new Set();
+  const roleKeys = new Set();
+  if (existsSync(SCAN_HISTORY_PATH)) {
+    for (const line of readFileSync(SCAN_HISTORY_PATH, 'utf-8').split('\n').slice(1)) {
+      const u = line.split('\t')[0];
+      if (u) urls.add(u);
+    }
+  }
+  if (existsSync(PIPELINE_PATH)) {
+    const t = readFileSync(PIPELINE_PATH, 'utf-8');
+    for (const m of t.matchAll(/- \[[ x]\] (https?:\/\/\S+)/g)) urls.add(m[1]);
+  }
+  if (existsSync(APPLICATIONS_PATH)) {
+    const t = readFileSync(APPLICATIONS_PATH, 'utf-8');
+    for (const m of t.matchAll(/https?:\/\/[^\s|)]+/g)) urls.add(m[0]);
+    for (const m of t.matchAll(/\|[^|]+\|[^|]+\|\s*([^|]+)\s*\|\s*([^|]+)\s*\|/g)) {
+      const c = m[1].trim().toLowerCase(), r = m[2].trim().toLowerCase();
+      if (c && r && c !== 'company') roleKeys.add(`${c}::${r}`);
+    }
+  }
+  return { urls, roleKeys };
+}
+
+const seen = loadSeen();
+
+// ── Resolve tracking URLs of keepers, then final dedup ──────────────
+
+async function resolve(url) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), 12000);
+  try {
+    const r = await fetch(url, { redirect: 'follow', headers: { 'user-agent': 'Mozilla/5.0 (compatible; career-ops/1.0)' }, signal: ctrl.signal });
+    // strip common tracking query params from the resolved URL
+    try {
+      const u = new URL(r.url || url);
+      for (const p of [...u.searchParams.keys()]) {
+        if (/^(utm_|mc_|ref|source|src|i12m)/i.test(p)) u.searchParams.delete(p);
+      }
+      return u.toString();
+    } catch { return r.url || url; }
+  } catch { return url; }
+  finally { clearTimeout(t); }
+}
+
+const added = [];
+let dupCount = 0;
+for (const r of filtered) {
+  const roleKey = `${r.company.toLowerCase()}::${r.title.toLowerCase()}`;
+  if (seen.roleKeys.has(roleKey)) { dupCount++; continue; }
+  const url = await resolve(r.applyUrl);
+  if (seen.urls.has(url)) { dupCount++; continue; }
+  seen.urls.add(url);
+  seen.roleKeys.add(roleKey);
+  added.push({ ...r, url });
+}
+
+// ── Write to pipeline.md + scan-history.tsv ─────────────────────────
+
+if (!dryRun && added.length) {
+  let pipe = readFileSync(PIPELINE_PATH, 'utf-8').replace(/\s*$/, '\n');
+  pipe += `\n## InnovatorsRoom #${issueNo} (${date})\n\n`;
+  pipe += added.map(a => `- [ ] ${a.url} | ${a.company} | ${a.title}${a.location ? `  (${a.location})` : ''}`).join('\n') + '\n';
+  writeFileSync(PIPELINE_PATH, pipe, 'utf-8');
+
+  if (!existsSync(SCAN_HISTORY_PATH)) {
+    writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\n', 'utf-8');
+  }
+  appendFileSync(SCAN_HISTORY_PATH,
+    added.map(a => `${a.url}\t${date}\tinnovatorsroom-${issueNo}\t${a.title}\t${a.company}\tadded\t${a.location}`).join('\n') + '\n',
+    'utf-8');
+}
+
+// ── Summary ─────────────────────────────────────────────────────────
+
+console.log(`InnovatorsRoom #${issueNo} — ${date}`);
+console.log('━'.repeat(42));
+console.log(`Roles parsed:        ${roles.length}`);
+console.log(`Passed filters:      ${filtered.length}`);
+console.log(`Duplicates skipped:  ${dupCount}`);
+console.log(`Added to pipeline:   ${added.length}${dryRun ? ' (dry run — not written)' : ''}`);
+if (added.length) {
+  console.log('\nNew roles:');
+  for (const a of added) console.log(`  + ${a.company} | ${a.title} | ${a.location || 'N/A'}\n      ${a.url}`);
+}
+console.log(`\n→ Run /career-ops pipeline to evaluate the new roles.`);

--- a/modes/innovatorsroom.md
+++ b/modes/innovatorsroom.md
@@ -1,0 +1,55 @@
+# Mode: innovatorsroom — InnovatorsRoom newsletter importer
+
+Imports roles from the **InnovatorsRoom** newsletters into the pipeline, filtered
+to the user's target paths. Fork-local personal source — see `LOCAL_CHANGES.md`.
+
+**Newsletters covered** (all subscribed; all use the same Beehiiv role-block layout,
+so one parser handles them):
+- **TechJobs** — monthly highlights (`TechJobs #NNN`).
+- **AI-enabler JobDrop** — AI/generalist roles at AI-frontier companies.
+- **Senior Operator JobDrop** — CEO/COO/CFO/cofounder roles.
+- **Senior Investor JobDrop** — Investment Manager / Principal / Partner roles.
+(Product Manager / Chief of Staff / Junior Investor JobDrops are *not* subscribed.)
+
+## Prerequisite (one-time)
+Newsletters go to `remo.kyburz1@gmail.com` and are **auto-forwarded** to
+`kyburz.remo@gmail.com` (the Gmail account on the Gmail MCP). The forward filter
+should match **any** InnovatorsRoom sender — if some JobDrops don't appear, broaden
+the source-account filter to `from:innovatorsroom.com`.
+
+## Flow
+
+1. **Find issues.** Use the Gmail MCP `search_threads`:
+   `(from:innovatorsroom.com OR subject:JobDrop OR subject:"InnovatorsRoom TechJobs") newer_than:30d`
+   — catches direct + forwarded copies of every newsletter.
+   Skip already-imported issues: an issue is done if `data/innovatorsroom/{label}.txt`
+   exists or `data/scan-history.tsv` contains `innovatorsroom-{label}`, where `{label}`
+   is a slug of the subject (e.g. `techjobs-116`, `senior-operator-jobdrop-2026-06-15`).
+
+2. **For each new issue (newest first):**
+   a. `get_thread` (messageFormat: `FULL_CONTENT`) → take `messages[0].plaintextBody`.
+   b. Save it verbatim to `data/innovatorsroom/{label}.txt`.
+   c. Run: `node innovatorsroom.mjs data/innovatorsroom/{label}.txt --issue {label}`
+      (prefix with `--dry-run` first to preview without writing).
+   d. **First time a JobDrop type arrives:** sanity-check the parsed count vs the
+      email; if a JobDrop uses a different layout than TechJobs, tell the user and
+      adjust the block parser in `innovatorsroom.mjs` before importing.
+
+   `innovatorsroom.mjs` parses the 6-line role blocks, applies the **same**
+   `title_filter`/`location_filter` as the portal scanner (from `portals.yml`),
+   resolves each keeper's Beehiiv tracking link to its real ATS/LinkedIn URL
+   (stripping `utm_*`/`i12m` params), dedups against
+   `scan-history.tsv` + `pipeline.md` + `applications.md`, and appends the
+   survivors to `data/pipeline.md` (`## InnovatorsRoom #NNN`) + `scan-history.tsv`.
+
+3. **Report** the per-issue summary (parsed / passed / added) and the new roles.
+   Then suggest `/career-ops pipeline` to evaluate them.
+
+## Notes
+- Only the ~30 roles explicitly listed per email are imported; the "+N additional
+  roles" live behind the InnovatorsRoom Slack (not reachable here).
+- Deterministic + idempotent: re-running an issue adds nothing new (dedup). Safe
+  to run on every issue.
+- Featured/sponsored roles use a different layout and are intentionally skipped.
+- The script reuses `buildTitleFilter`/`buildLocationFilter` exported by `scan.mjs`,
+  so any tuning of `portals.yml` filters automatically applies here too.

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -287,6 +287,15 @@ New added to pipeline.md: N
 → Run /career-ops pipeline to evaluate the new offers.
 ```
 
+## Final step: Newsletters (InnovatorsRoom)
+
+As part of the regular scan cadence, after Levels 0-3 also run the InnovatorsRoom
+newsletter import (see `modes/innovatorsroom.md`): search Gmail for new issues
+(TechJobs + JobDrops), parse each with `node innovatorsroom.mjs`, and add the
+relevant roles to `data/pipeline.md`. Use the same `title_filter` / `location_filter`
+so results are deduped and filtered identically to the portal scan. Include its
+summary alongside the portal scan summary.
+
 ## Managing careers_url
 
 Every company in `tracked_companies` must have a `careers_url` — the direct URL to its offers page. This avoids searching for it every time.

--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -46,3 +46,28 @@ export function makeHttpCtx() {
     fetchText,
   };
 }
+
+// Normalize a posting date to epoch milliseconds (or null if absent/unparseable).
+// Accepts ISO strings ("2026-05-22T16:05:41-04:00"), epoch seconds (~1.7e9),
+// and epoch milliseconds (~1.7e12). Used by providers to populate Job.postedAt
+// so scan.mjs can apply the freshness_filter uniformly. null = "no date" = keep.
+export function toEpochMs(value) {
+  if (value == null) return null;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0) return null;
+    return value < 1e12 ? value * 1000 : value; // < 1e12 ⇒ seconds
+  }
+  if (typeof value === 'string') {
+    const s = value.trim();
+    // Numeric timestamp strings ("1710000000" / "1710000000000") — Date.parse
+    // would return NaN for these, so handle them like the numeric branch.
+    if (/^\d+$/.test(s)) {
+      const n = Number(s);
+      if (!Number.isFinite(n) || n <= 0) return null;
+      return n < 1e12 ? n * 1000 : n;
+    }
+    const t = Date.parse(s);
+    return Number.isNaN(t) || t <= 0 ? null : t;
+  }
+  return null;
+}

--- a/providers/bamboohr.mjs
+++ b/providers/bamboohr.mjs
@@ -1,0 +1,79 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// BambooHR provider — hits the public careers list JSON endpoint.
+//
+// careers_url shape: `https://{company}.bamboohr.com/careers` (or `/careers/list`)
+// List endpoint:     `https://{company}.bamboohr.com/careers/list`
+// Detail endpoint:   `https://{company}.bamboohr.com/careers/{id}/detail`
+//
+// The list endpoint returns enough to populate the scanner's Job shape
+// (title, id, location). Detail is reserved for downstream evaluation
+// modes — the scanner only needs (title, url, location).
+//
+// NOTE 2026-05-20: BambooHR appears to gate `/careers/list` against
+// unrecognized clients (HTTP 403 across several known slugs in testing).
+// Parsing follows modes/scan.md exactly; if a real customer board fails,
+// confirm the slug still hosts on bamboohr.com and inspect response headers.
+
+function assertBambooUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`bamboohr: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`bamboohr: URL must use HTTPS: ${url}`);
+  if (!parsed.hostname.endsWith('.bamboohr.com'))
+    throw new Error(`bamboohr: untrusted hostname "${parsed.hostname}" — must end in .bamboohr.com`);
+  return parsed;
+}
+
+function resolveSlug(entry) {
+  if (entry.api) {
+    const parsed = assertBambooUrl(entry.api);
+    return parsed.hostname.split('.')[0];
+  }
+  const url = entry.careers_url || '';
+  const match = url.match(/https:\/\/([^.]+)\.bamboohr\.com/);
+  return match ? match[1] : null;
+}
+
+function formatLocation(loc) {
+  if (!loc || typeof loc !== 'object') return '';
+  const parts = [loc.city, loc.state, loc.country].filter(p => typeof p === 'string' && p.trim());
+  return parts.join(', ');
+}
+
+/** @type {Provider} */
+export default {
+  id: 'bamboohr',
+
+  detect(entry) {
+    try {
+      return resolveSlug(entry) ? { url: `https://${resolveSlug(entry)}.bamboohr.com/careers/list` } : null;
+    } catch {
+      return null;
+    }
+  },
+
+  async fetch(entry, ctx) {
+    const slug = resolveSlug(entry);
+    if (!slug) throw new Error(`bamboohr: cannot derive subdomain for ${entry.name}`);
+    const listUrl = `https://${slug}.bamboohr.com/careers/list`;
+    assertBambooUrl(listUrl);
+    const json = await ctx.fetchJson(listUrl, {
+      headers: { accept: 'application/json' },
+      redirect: 'error',
+    });
+    const items = Array.isArray(json?.result) ? json.result : [];
+    return items
+      .filter(j => j && j.id != null && j.jobOpeningName)
+      .map(j => ({
+        title: j.jobOpeningName,
+        url: j.jobOpeningShareUrl || `https://${slug}.bamboohr.com/careers/${j.id}/detail`,
+        company: entry.name,
+        location: formatLocation(j.location) || j.locationCity || '',
+      }));
+  },
+};

--- a/providers/consider.mjs
+++ b/providers/consider.mjs
@@ -1,0 +1,100 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Consider provider — VC "talent network" portfolio boards on getconsider.com
+// (Founderful, Creandum, Balderton, Lightspeed, Notion Capital, …). The board
+// is a JS app, but its data comes from a same-origin JSON endpoint we can hit
+// directly (discovered via a headless capture of the board's network calls):
+//
+//   POST {board_origin}/api-boards/search-jobs
+//   body: {"meta":{"size":N},"board":{"id":"<board_id>","isParent":true},
+//          "query":{"promoteFeatured":true}}
+//   -> { jobs: [ {title,url,applyUrl,companyName,locations[],timeStamp,remote} ], total }
+//
+// `url` is the clean destination ATS link (dedups with the ashby/greenhouse
+// providers); `companyName` is the portfolio company. The board id is NOT the
+// host (Founderful's is "wingman"), so set it explicitly in portals.yml:
+//
+//   - name: Founderful (portfolio)
+//     provider: consider
+//     consider_board: wingman
+//     careers_url: https://jobs.founderful.com/jobs
+//     enabled: true
+//
+// `consider_size` (default 500) caps how many newest/featured jobs are pulled in
+// the single request. Boards larger than that are truncated (rare for VC boards).
+
+import { toEpochMs } from './_http.mjs';
+
+const ENDPOINT_PATH = '/api-boards/search-jobs';
+const DEFAULT_SIZE = 500;
+
+function resolveOrigin(entry) {
+  const url = entry.careers_url || '';
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function locationString(job) {
+  if (Array.isArray(job.locations) && job.locations.length) {
+    return job.locations.filter(l => typeof l === 'string').join(', ');
+  }
+  if (Array.isArray(job.normalizedLocations) && job.normalizedLocations.length) {
+    return job.normalizedLocations.map(l => l?.label || l?.value).filter(Boolean).join(', ');
+  }
+  return job.remote ? 'Remote' : '';
+}
+
+/** @type {Provider} */
+export default {
+  id: 'consider',
+
+  detect(entry) {
+    const origin = resolveOrigin(entry);
+    return entry.consider_board && origin ? { url: origin + ENDPOINT_PATH } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const origin = resolveOrigin(entry);
+    if (!origin) throw new Error(`consider: ${entry.name} needs a valid careers_url`);
+    if (!entry.consider_board) throw new Error(`consider: ${entry.name} needs a 'consider_board' id in portals.yml`);
+    const size = Number.isInteger(entry.consider_size) && entry.consider_size > 0 ? entry.consider_size : DEFAULT_SIZE;
+
+    const json = await ctx.fetchJson(origin + ENDPOINT_PATH, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json', referer: origin + '/jobs' },
+      body: JSON.stringify({
+        meta: { size },
+        board: { id: String(entry.consider_board), isParent: true },
+        query: { promoteFeatured: true },
+      }),
+    });
+
+    const jobs = Array.isArray(json?.jobs) ? json.jobs : [];
+    return jobs
+      .map(j => {
+        const rawUrl = j.url || j.applyUrl || '';
+        if (!rawUrl) return null;
+        // Normalize to an absolute URL so the dedup key matches what the
+        // ashby/greenhouse providers emit (Consider returns absolute ATS links,
+        // but resolve defensively in case a relative path ever appears).
+        let url;
+        try {
+          url = new URL(rawUrl, origin).toString();
+        } catch {
+          return null;
+        }
+        return {
+          title: j.title || '',
+          url,
+          company: j.companyName || entry.name,
+          location: locationString(j),
+          postedAt: toEpochMs(j.timeStamp),
+        };
+      })
+      .filter(Boolean);
+  },
+};

--- a/providers/fractionalpulse.mjs
+++ b/providers/fractionalpulse.mjs
@@ -1,0 +1,173 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Fractional Pulse provider — fractionalpulse.com/jobs, an aggregator of
+// fractional / interim executive roles (CFO, COO, Head of Finance/Ops, etc.).
+//
+// The /jobs listing is server-rendered (no JS, no pagination — all current roles
+// on one page). Each role is an anchor:
+//
+//   <a href="/jobs/{slug}/" class="job-item" data-role="cfo" data-remote="true|false"
+//      data-company="..." data-title="...">
+//     <div class="job-item__company">Acme</div>
+//     <div class="job-item__title">Fractional CFO</div>
+//     <div class="job-item__meta">
+//       <span class="job-item__tag job-item__tag--remote">Remote</span>     <- remote roles
+//       <span class="job-item__tag job-item__tag--location">Dallas, TX, US</span> <- on-site
+//       <span class="job-item__tag job-item__tag--role">CFO</span>
+//       <span class="job-item__date">Jun 12, 2026</span>
+//     </div>
+//   </a>
+//
+// LOCATION CAVEAT (the reason this provider isn't a one-liner): the board is
+// US-centric. On-site roles list an explicit US city (the location filter blocks
+// them). But remote roles are tagged only "Remote" with NO country, even though
+// nearly all are US-remote — so emitting a bare "Remote" would wrongly PASS the
+// location filter and flood the pipeline with US roles Remo can't take. Each
+// detail page, however, carries a JSON-LD JobPosting with the employer country
+// (jobLocation.address.addressCountry / applicantLocationRequirements). So for
+// remote roles we fetch the detail page and emit "Remote, {Country}" — US-remote
+// then matches the "Remote, United States" block keyword and is dropped, while a
+// genuine non-US remote role survives on the "Remote" allow keyword.
+//
+// Detail fetches are bounded (fractionalpulse_max_detail, default 80) and run
+// with limited concurrency. On a detail-fetch failure we fall back to the
+// conservative "Remote, United States" (block) rather than a bare "Remote" — a
+// US-centric board means a false block is far less harmful than a flood, and the
+// role retries next scan.
+//
+//   - name: Fractional Pulse (fractional job board)
+//     provider: fractionalpulse
+//     careers_url: https://fractionalpulse.com/jobs
+//     enabled: true
+
+import { toEpochMs } from './_http.mjs';
+
+const LIST_URL = 'https://fractionalpulse.com/jobs';
+const ORIGIN = 'https://fractionalpulse.com';
+const DEFAULT_MAX_DETAIL = 80;
+const DETAIL_CONCURRENCY = 6;
+const BROWSER_HEADERS = {
+  'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+};
+
+function decodeEntities(s) {
+  return (s || '')
+    .replace(/&amp;/g, '&').replace(/&#39;/g, "'").replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"').replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .trim();
+}
+
+// Normalize a country code/name into the wording the location filter expects.
+// US must read "United States" so it hits the "Remote, United States" block key.
+function normalizeCountry(raw) {
+  const v = decodeEntities(String(raw || '')).trim();
+  if (!v) return '';
+  if (/^(us|usa|u\.s\.a?\.?|united states.*|america)$/i.test(v)) return 'United States';
+  if (/^(uk|gb|u\.k\.|united kingdom|great britain|england)$/i.test(v)) return 'United Kingdom';
+  if (/^(ch|switzerland|suisse|schweiz)$/i.test(v)) return 'Switzerland';
+  if (/^(de|germany|deutschland)$/i.test(v)) return 'Germany';
+  if (/^(ca|canada)$/i.test(v)) return 'Canada';
+  return v; // emit as-is for anything else
+}
+
+// Pull the employer/eligibility country out of a detail page's JSON-LD JobPosting.
+function extractCountry(html) {
+  const blocks = [...html.matchAll(/<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi)];
+  for (const b of blocks) {
+    let data;
+    try { data = JSON.parse(b[1]); } catch { continue; }
+    const nodes = Array.isArray(data) ? data : (Array.isArray(data['@graph']) ? data['@graph'] : [data]);
+    for (const node of nodes) {
+      if (!node || !/JobPosting/i.test(String(node['@type'] || ''))) continue;
+      // Prefer explicit remote-eligibility region, then the employer address country.
+      const alr = node.applicantLocationRequirements;
+      const alrName = Array.isArray(alr) ? alr[0]?.name : alr?.name;
+      if (alrName) return normalizeCountry(alrName);
+      const loc = Array.isArray(node.jobLocation) ? node.jobLocation[0] : node.jobLocation;
+      const country = loc?.address?.addressCountry;
+      const countryName = typeof country === 'object' ? (country.name || country['@id']) : country;
+      if (countryName) return normalizeCountry(countryName);
+    }
+  }
+  return '';
+}
+
+async function mapLimit(items, limit, fn) {
+  const results = new Array(items.length);
+  let i = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (i < items.length) {
+      const idx = i++;
+      results[idx] = await fn(items[idx], idx);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'fractionalpulse',
+
+  detect(entry) {
+    return /fractionalpulse\.com/i.test(entry.careers_url || '') ? { url: LIST_URL } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const html = await ctx.fetchText(LIST_URL, { headers: BROWSER_HEADERS });
+
+    const cards = [...html.matchAll(
+      /<a[^>]+href="(\/jobs\/[^"/][^"]*\/)"[^>]*class="job-item"[^>]*>([\s\S]*?)<\/a>/gi
+    )];
+
+    const parsed = cards.map(([full, href, inner]) => {
+      const company = decodeEntities((inner.match(/job-item__company">([^<]+)</i) || [])[1]);
+      const title = decodeEntities((inner.match(/job-item__title">([^<]+)</i) || [])[1]);
+      const dateStr = (inner.match(/job-item__date">([^<]+)</i) || [])[1] || '';
+      const remote = /data-remote="true"/i.test(full);
+      // On-site listing city: the meta tag that is neither the role tag nor the remote tag.
+      const tags = [...inner.matchAll(/job-item__tag(--[a-z]+)?"[^>]*>([^<]+)</gi)]
+        .map(m => ({ cls: m[1] || '', txt: decodeEntities(m[2]) }));
+      const cityTag = tags.find(t => t.cls !== '--role' && t.cls !== '--remote');
+      return {
+        url: ORIGIN + href,
+        company,
+        title,
+        postedAt: toEpochMs(dateStr),
+        remote,
+        listingCity: cityTag ? cityTag.txt : '',
+      };
+    }).filter(p => p.title && p.url);
+
+    // On-site roles already carry a city (US cities get blocked downstream).
+    for (const p of parsed.filter(p => !p.remote)) p.location = p.listingCity;
+
+    // Remote roles: resolve the real country from the detail JSON-LD so US-remote
+    // is blocked and genuine non-US remote survives.
+    const maxDetail = Number.isInteger(entry.fractionalpulse_max_detail) && entry.fractionalpulse_max_detail >= 0
+      ? entry.fractionalpulse_max_detail
+      : DEFAULT_MAX_DETAIL;
+    const remoteRoles = parsed.filter(p => p.remote);
+    const toEnrich = remoteRoles.slice(0, maxDetail);
+    const overflow = remoteRoles.slice(maxDetail);
+
+    await mapLimit(toEnrich, DETAIL_CONCURRENCY, async (p) => {
+      try {
+        const detail = await ctx.fetchText(p.url, { headers: BROWSER_HEADERS });
+        const country = extractCountry(detail);
+        p.location = country ? `Remote, ${country}` : 'Remote, United States';
+      } catch {
+        p.location = 'Remote, United States'; // conservative: block rather than flood
+      }
+    });
+    // Anything past the cap: conservative block (board is US-centric).
+    for (const p of overflow) p.location = 'Remote, United States';
+
+    return parsed.map(({ title, url, company, location, postedAt }) => ({
+      title, url, company, location: location || '', postedAt,
+    }));
+  },
+};

--- a/providers/getro.mjs
+++ b/providers/getro.mjs
@@ -1,0 +1,108 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Getro provider — VC "talent network" portfolio job boards (jobs at a fund's
+// portfolio companies). Powers b2venture, Earlybird, Point Nine, Speedinvest,
+// Cherry, HV Capital, Atomico, and many other VC boards.
+//
+// The public search API is:
+//   POST https://api.getro.com/api/v2/collections/{collection_id}/search/jobs
+//   body: {"hitsPerPage":N,"page":P}
+//   -> { results: { jobs: [ {title,url,organization:{name},locations[],created_at} ], count } }
+//
+// A board's numeric collection_id is the `network.id` embedded in the board
+// page's __NEXT_DATA__. We don't derive it from the URL — set it explicitly in
+// portals.yml:
+//
+//   - name: b2venture (portfolio)
+//     provider: getro
+//     getro_collection: 4283
+//     careers_url: https://jobs.b2venture.vc   # reference only
+//     enabled: true
+//
+// These boards are large (1000-2000 jobs) but the API returns them
+// created_at-DESCENDING (newest first), so we paginate newest-first and STOP
+// once postings fall older than `getro_max_age_days`. This is a PAGINATION
+// BOUND for efficiency (don't page through 2000 stale jobs) — the real recency
+// cut is the global freshness_filter in scan.mjs, which reads each job's
+// `postedAt`. The bound default (90d) is kept comfortably wider than the
+// usual 60d freshness window so it never pre-trims jobs the global filter would
+// keep. `getro_max_pages` (default 40) is a hard safety cap. Jobs with no
+// created_at are kept (same "missing data = pass" rule as the location filter).
+
+import { toEpochMs } from './_http.mjs';
+
+const API_BASE = 'https://api.getro.com/api/v2/collections';
+const HITS_PER_PAGE = 20;          // API hard-caps page size at 20
+const DEFAULT_MAX_PAGES = 40;      // safety cap: 40 x 20 = 800 newest jobs/board
+const DEFAULT_MAX_AGE_DAYS = 90;   // pagination bound only; global filter does the real cut
+
+function resolveCollection(entry) {
+  const id = entry.getro_collection;
+  if (id == null) return null;
+  const s = String(id).trim();
+  if (!/^\d+$/.test(s)) return null;
+  return s;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'getro',
+
+  detect(entry) {
+    const id = resolveCollection(entry);
+    return id ? { url: `${API_BASE}/${id}/search/jobs` } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const id = resolveCollection(entry);
+    if (!id) throw new Error(`getro: ${entry.name} needs a numeric 'getro_collection' in portals.yml`);
+    const apiUrl = `${API_BASE}/${id}/search/jobs`;
+    const maxPages = Number.isInteger(entry.getro_max_pages) && entry.getro_max_pages > 0
+      ? entry.getro_max_pages : DEFAULT_MAX_PAGES;
+    const maxAgeDays = Number.isFinite(entry.getro_max_age_days) && entry.getro_max_age_days >= 0
+      ? entry.getro_max_age_days : DEFAULT_MAX_AGE_DAYS;
+    const cutoffMs = maxAgeDays > 0 ? Date.now() - maxAgeDays * 86_400_000 : 0;
+
+    const out = [];
+    let total = Infinity;
+    for (let page = 0; page < maxPages && page * HITS_PER_PAGE < total; page++) {
+      const json = await ctx.fetchJson(apiUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
+        body: JSON.stringify({ hitsPerPage: HITS_PER_PAGE, page }),
+      });
+      const results = json?.results || {};
+      const jobs = Array.isArray(results.jobs) ? results.jobs : [];
+      if (typeof results.count === 'number') total = results.count;
+      if (jobs.length === 0) break;
+
+      let reachedOld = false;
+      for (const j of jobs) {
+        const url = j.url || '';
+        if (!url) continue;
+        // Jobs are newest-first; a dated posting older than the cutoff (and
+        // everything after it) is stale. Keep undated jobs (missing = pass).
+        const createdMs = toEpochMs(j.created_at);
+        if (cutoffMs > 0 && createdMs != null && createdMs < cutoffMs) {
+          reachedOld = true;
+          continue;
+        }
+        out.push({
+          title: j.title || '',
+          url,
+          // Portfolio jobs belong to the portfolio company, not the fund —
+          // expose the real employer so dedup and the tracker read correctly.
+          company: j.organization?.name || j.organization_name || entry.name,
+          location: (Array.isArray(j.locations) && j.locations[0])
+            || (Array.isArray(j.searchable_locations) && j.searchable_locations[0])
+            || '',
+          postedAt: createdMs,
+        });
+      }
+      // Once we've crossed the age cutoff, all later pages are older still.
+      if (reachedOld) break;
+    }
+    return out;
+  },
+};

--- a/providers/joinup.mjs
+++ b/providers/joinup.mjs
@@ -1,0 +1,55 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// joinup.ch provider — Swiss startup job platform (Typesense-backed Next.js).
+//
+// The browse page server-renders the newest page of results into __NEXT_DATA__
+// at props.pageProps.serverState.initialResults.jobs.results[0].hits[]. The
+// full board (~1000 jobs) lives behind a Typesense search key that is injected
+// at runtime (not in the static bundle), so we read the SSR'd newest page —
+// since results are created-DESC this reliably catches the latest postings,
+// which is what a periodic scan needs. Most older joinup roles are also tracked
+// directly via their company's ATS (Getro/Personio/Ashby/etc.).
+//
+// Each hit: { title|headline, startup (employer), slug, location, created }.
+// Public posting URL: https://joinup.ch/job/{slug}
+//
+// Auto-detects from a careers_url containing `joinup.ch`.
+
+import { toEpochMs } from './_http.mjs';
+
+const BROWSE_URL = 'https://joinup.ch/browse/jobs';
+
+/** @type {Provider} */
+export default {
+  id: 'joinup',
+
+  detect(entry) {
+    const url = entry.careers_url || '';
+    return /joinup\.ch/i.test(url) ? { url: BROWSE_URL } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const html = await ctx.fetchText(BROWSE_URL);
+    const m = html.match(/<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/);
+    if (!m) return [];
+    let hits = [];
+    try {
+      const data = JSON.parse(m[1]);
+      const ir = data?.props?.pageProps?.serverState?.initialResults?.jobs?.results;
+      hits = Array.isArray(ir) && ir[0]?.hits ? ir[0].hits : [];
+    } catch {
+      return [];
+    }
+    return hits
+      .filter(h => h && h.slug && (h.title || h.headline))
+      .map(h => ({
+        title: h.title || h.headline || '',
+        url: `https://joinup.ch/job/${h.slug}`,
+        company: h.startup || entry.name || '',
+        location: typeof h.location === 'string' ? h.location
+          : (h.location?.name || h.location?.city || ''),
+        postedAt: toEpochMs(h.created),
+      }));
+  },
+};

--- a/providers/lever.mjs
+++ b/providers/lever.mjs
@@ -6,9 +6,12 @@
 
 function resolveApiUrl(entry) {
   const url = entry.careers_url || '';
-  const match = url.match(/jobs\.lever\.co\/([^/?#]+)/);
+  // Lever has a US instance (jobs.lever.co / api.lever.co) and an EU instance
+  // (jobs.eu.lever.co / api.eu.lever.co) — match both and route to the right host.
+  const match = url.match(/jobs(?:\.eu)?\.lever\.co\/([^/?#]+)/);
   if (!match) return null;
-  return `https://api.lever.co/v0/postings/${match[1]}`;
+  const apiHost = /jobs\.eu\.lever\.co/i.test(url) ? 'api.eu.lever.co' : 'api.lever.co';
+  return `https://${apiHost}/v0/postings/${match[1]}`;
 }
 
 /** @type {Provider} */

--- a/providers/personio.mjs
+++ b/providers/personio.mjs
@@ -1,0 +1,45 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Personio provider — hits the public `search.json` feed of a Personio careers
+// subdomain. Used by Swiss/DACH employers (e.g. AMINA/SEBA Bank) and many
+// startups whose careers pages are `{slug}.jobs.personio.com` / `.de`.
+//
+// Feed: https://{slug}.jobs.personio.com/search.json
+//   -> [ { id, name, office, employment_type, seniority, ... } ]   (array)
+// Public posting URL: https://{slug}.jobs.personio.com/job/{id}
+//
+// Auto-detects from careers_url; no extra config needed.
+
+function resolveSlugHost(entry) {
+  const url = entry.careers_url || entry.api || '';
+  const m = url.match(/^https?:\/\/([a-z0-9-]+)\.jobs\.personio\.(com|de)(?:[/:?#]|$)/i);
+  if (!m) return null;
+  return { slug: m[1], tld: m[2] };
+}
+
+/** @type {Provider} */
+export default {
+  id: 'personio',
+
+  detect(entry) {
+    const r = resolveSlugHost(entry);
+    return r ? { url: `https://${r.slug}.jobs.personio.${r.tld}/search.json` } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const r = resolveSlugHost(entry);
+    if (!r) throw new Error(`personio: cannot derive slug for ${entry.name} (need {slug}.jobs.personio.com careers_url)`);
+    const base = `https://${r.slug}.jobs.personio.${r.tld}`;
+    const json = await ctx.fetchJson(`${base}/search.json`, { headers: { accept: 'application/json' } });
+    const positions = Array.isArray(json) ? json : (Array.isArray(json?.positions) ? json.positions : []);
+    return positions
+      .filter(p => p && p.id != null)
+      .map(p => ({
+        title: p.name || p.title || '',
+        url: `${base}/job/${p.id}`,
+        company: entry.name,
+        location: p.office || p.location || '',
+      }));
+  },
+};

--- a/providers/startupch.mjs
+++ b/providers/startupch.mjs
@@ -1,0 +1,109 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// startup.ch provider — the Swiss Startup Association job board. Server-rendered
+// ColdFusion page; all current listings are in one HTML response (no JS board).
+//
+// Each listing is a `.white-box.startup-box` card with:
+//   <a href="index.cfm?...&profil_id={pid}&JobID={jid}#job_{jid}">
+//   <img ... alt="{Company} AG" />            <- employer
+//   <h4 class="top10-title ...">{Title}</h4>  <- role
+//   <p class="d-inline-flex mb-1">{City}</p>  <- location (after location.png)
+//
+// The href carries a per-request CFID/CFTOKEN session — we strip it and build a
+// canonical, session-free URL so the dedup key is stable across scans.
+//
+// startup.ch has light anti-bot behaviour: it 200s an error page to bot-ish
+// user agents and under bursty load. We therefore (a) send real browser
+// headers, (b) prime a session cookie from the homepage first, and (c) throw a
+// descriptive error if the error page comes back — so the scan logs it (visible,
+// retried next run) instead of silently reporting zero jobs.
+//
+// Auto-detects from a careers_url containing `startup.ch`.
+
+const HOME_URL = 'https://www.startup.ch/';
+const LIST_URL = 'https://www.startup.ch/jobs';
+const BROWSER_HEADERS = {
+  'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  'accept-language': 'en-US,en;q=0.9,de;q=0.8',
+};
+
+function decodeEntities(s) {
+  return s
+    .replace(/&amp;/g, '&').replace(/&#39;/g, "'").replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"').replace(/&auml;/g, 'ä').replace(/&ouml;/g, 'ö')
+    .replace(/&uuml;/g, 'ü').replace(/&nbsp;/g, ' ').trim();
+}
+
+async function fetchWithTimeout(url, headers, timeoutMs = 12000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { headers, redirect: 'follow', signal: controller.signal });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      const snippet = body.replace(/\s+/g, ' ').trim().slice(0, 300);
+      throw new Error(snippet ? `HTTP ${res.status}: ${snippet}` : `HTTP ${res.status}`);
+    }
+    return res;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** @type {Provider} */
+export default {
+  id: 'startupch',
+
+  detect(entry) {
+    const url = entry.careers_url || '';
+    return /startup\.ch/i.test(url) ? { url: LIST_URL } : null;
+  },
+
+  async fetch(entry /* , ctx */) {
+    // Prime a CFID/CFTOKEN session from the homepage (best-effort).
+    let cookie = '';
+    try {
+      const home = await fetchWithTimeout(HOME_URL, BROWSER_HEADERS);
+      const setCookies = typeof home.headers.getSetCookie === 'function'
+        ? home.headers.getSetCookie()
+        : [home.headers.get('set-cookie')].filter(Boolean);
+      cookie = setCookies.map(c => c.split(';')[0]).join('; ');
+    } catch { /* proceed without a primed cookie */ }
+
+    const res = await fetchWithTimeout(LIST_URL, { ...BROWSER_HEADERS, ...(cookie ? { cookie } : {}) });
+    const html = await res.text();
+
+    const chunks = html.split(/white-box startup-box/i).slice(1);
+    if (chunks.length === 0) {
+      // Distinguish the anti-bot/error page from a genuinely empty board so the
+      // scan surfaces it rather than silently reporting zero.
+      if (/unerwarteter Fehler|<title>\s*Error\s*<\/title>/i.test(html)) {
+        throw new Error('startup.ch returned an error/anti-bot page (likely rate-limited) — retry next scan');
+      }
+      return [];
+    }
+
+    const out = [];
+    const seen = new Set();
+    for (const chunk of chunks) {
+      const card = chunk.slice(0, 2000);
+      const jid = card.match(/JobID=(\d+)/)?.[1];
+      if (!jid || seen.has(jid)) continue;
+      const pid = card.match(/profil_id=(\d+)/)?.[1] || '';
+      const title = card.match(/<h4[^>]*top10-title[^>]*>([^<]+)<\/h4>/i)?.[1];
+      if (!title) continue;
+      const company = (card.match(/alt="([^"]+)"/i)?.[1] || entry.name || '').trim();
+      const location = card.match(/location\.png[\s\S]{0,160}?<p[^>]*>([^<]+)<\/p>/i)?.[1] || '';
+      seen.add(jid);
+      out.push({
+        title: decodeEntities(title),
+        url: `https://www.startup.ch/index.cfm?page=137888${pid ? `&profil_id=${pid}` : ''}&JobID=${jid}`,
+        company: decodeEntities(company),
+        location: decodeEntities(location),
+      });
+    }
+    return out;
+  },
+};

--- a/providers/teamtailor.mjs
+++ b/providers/teamtailor.mjs
@@ -1,0 +1,94 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Teamtailor provider — parses the public jobs.rss feed.
+//
+// careers_url shape: `https://{company}.teamtailor.com/jobs` (or `/jobs.rss`)
+// Feed URL:          `https://{company}.teamtailor.com/jobs.rss`
+//
+// Lightweight RSS parsing — Teamtailor's feed is well-formed XML with one
+// <item> per posting. No external XML dep needed.
+
+import { toEpochMs } from './_http.mjs';
+
+function assertTeamtailorUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`teamtailor: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`teamtailor: URL must use HTTPS: ${url}`);
+  if (!parsed.hostname.endsWith('.teamtailor.com'))
+    throw new Error(`teamtailor: untrusted hostname "${parsed.hostname}" — must end in .teamtailor.com`);
+  return url;
+}
+
+function resolveFeedUrl(entry) {
+  if (entry.api) {
+    assertTeamtailorUrl(entry.api);
+    return entry.api;
+  }
+  const url = entry.careers_url || '';
+  const match = url.match(/https:\/\/([^/]+)\.teamtailor\.com/);
+  if (!match) return null;
+  return `https://${match[1]}.teamtailor.com/jobs.rss`;
+}
+
+// Decode the small set of XML entities that appear in Teamtailor feeds.
+// Numeric and named — kept conservative on purpose; the feed is never HTML.
+function decodeXmlEntities(s) {
+  return s
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function extractTag(itemXml, tag) {
+  const cdata = itemXml.match(new RegExp(`<${tag}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]></${tag}>`));
+  if (cdata) return cdata[1].trim();
+  const plain = itemXml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`));
+  if (plain) return decodeXmlEntities(plain[1]).trim();
+  return '';
+}
+
+/** @type {Provider} */
+export default {
+  id: 'teamtailor',
+
+  detect(entry) {
+    try {
+      const feedUrl = resolveFeedUrl(entry);
+      return feedUrl ? { url: feedUrl } : null;
+    } catch {
+      return null;
+    }
+  },
+
+  async fetch(entry, ctx) {
+    const feedUrl = resolveFeedUrl(entry);
+    if (!feedUrl) throw new Error(`teamtailor: cannot derive feed URL for ${entry.name}`);
+    assertTeamtailorUrl(feedUrl);
+    const xml = await ctx.fetchText(feedUrl, {
+      headers: { accept: 'application/rss+xml, application/xml, text/xml' },
+      redirect: 'error',
+    });
+    const items = xml.match(/<item\b[^>]*>[\s\S]*?<\/item>/g) || [];
+    const jobs = [];
+    for (const item of items) {
+      const title = extractTag(item, 'title');
+      const link = extractTag(item, 'link');
+      if (!title || !link) continue;
+      // Teamtailor exposes location via custom <jobs:location> elements when
+      // present — fall back to empty when the feed omits them.
+      const location = extractTag(item, 'jobs:location') || extractTag(item, 'location') || '';
+      const postedAt = toEpochMs(extractTag(item, 'pubDate'));
+      jobs.push({ title, url: link, company: entry.name, location, postedAt });
+    }
+    return jobs;
+  },
+};

--- a/scan.mjs
+++ b/scan.mjs
@@ -121,14 +121,27 @@ function resolveProvider(entry, providers, { skipIds = [] } = {}) {
 
 // ── Title filter ────────────────────────────────────────────────────
 
+// Compile a lowercased keyword into a matcher. Short all-letter acronyms
+// (2-3 chars: cfo, coo, sdr, bdr, gsi…) match on WORD BOUNDARIES so "COO" no
+// longer matches "Coordinator", "SDR" no longer matches anything mid-word, etc.
+// Multi-word phrases and keywords containing non-letters (".NET", "SAP ",
+// "L&D") keep fast, permissive substring matching.
+export function compileKeyword(kw) {
+  if (/^[a-z]{2,3}$/.test(kw)) {
+    const re = new RegExp(`\\b${kw}\\b`);
+    return (lower) => re.test(lower);
+  }
+  return (lower) => lower.includes(kw);
+}
+
 export function buildTitleFilter(titleFilter) {
-  const positive = (titleFilter?.positive || []).map(k => k.toLowerCase());
-  const negative = (titleFilter?.negative || []).map(k => k.toLowerCase());
+  const positive = normalizeKeywordList(titleFilter?.positive).map(compileKeyword);
+  const negative = normalizeKeywordList(titleFilter?.negative).map(compileKeyword);
 
   return (title) => {
-    const lower = title.toLowerCase();
-    const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
-    const hasNegative = negative.some(k => lower.includes(k));
+    const lower = (title || '').toLowerCase();
+    const hasPositive = positive.length === 0 || positive.some(m => m(lower));
+    const hasNegative = negative.some(m => m(lower));
     return hasPositive && !hasNegative;
   };
 }
@@ -322,6 +335,24 @@ async function searchForNewUrl(page, offer) {
       /* ignore — best-effort cleanup */
     }
   }
+}
+
+// ── Freshness filter ────────────────────────────────────────────────
+// Optional. Drops postings older than `freshness_filter.max_age_days`, based on
+// each job's provider-supplied `postedAt` (epoch ms). Jobs with no `postedAt`
+// are kept (missing = pass, same rule as the location filter). `max_age_days`
+// <= 0 / absent / non-numeric disables it.
+// Providers without an authoritative date (personio, workday, bamboohr) return
+// no postedAt, so their jobs always pass — the filter only acts where the date
+// is trustworthy (greenhouse, ashby, lever, workable, recruitee, getro, teamtailor).
+export function buildFreshnessFilter(freshnessFilter) {
+  const maxAgeDays = Number(freshnessFilter?.max_age_days);
+  if (!Number.isFinite(maxAgeDays) || maxAgeDays <= 0) return () => true;
+  const cutoff = Date.now() - maxAgeDays * 86_400_000;
+  return (postedAt) => {
+    if (postedAt == null || !Number.isFinite(postedAt)) return true;
+    return postedAt >= cutoff;
+  };
 }
 
 // ── Dedup ───────────────────────────────────────────────────────────
@@ -642,6 +673,9 @@ async function main() {
   const titleFilter = buildTitleFilter(config.title_filter);
   const locationFilter = buildLocationFilter(config.location_filter);
   const salaryFilter = buildSalaryFilter(config.salary_filter);
+  const freshnessFilter = buildFreshnessFilter(config.freshness_filter);
+  const maxAgeDays = Number(config.freshness_filter?.max_age_days);
+  const freshnessActive = Number.isFinite(maxAgeDays) && maxAgeDays > 0;
 
   // 3. Resolve a provider for each enabled company / board
   const targets = [];
@@ -713,6 +747,7 @@ async function main() {
   let totalFilteredTitle = 0;
   let totalFilteredLocation = 0;
   let totalFilteredSalary = 0;
+  let totalFilteredStale = 0;
   let totalDupes = 0;
   const newOffers = [];
   const errors = [...resolveErrors];
@@ -753,6 +788,10 @@ async function main() {
         }
         if (!salaryFilter(job.salary)) {
           totalFilteredSalary++;
+          continue;
+        }
+        if (!freshnessFilter(job.postedAt)) {
+          totalFilteredStale++;
           continue;
         }
         if (seenUrls.has(job.url)) {
@@ -852,6 +891,9 @@ async function main() {
   console.log(`Filtered by title:     ${totalFilteredTitle} removed`);
   console.log(`Filtered by location:  ${totalFilteredLocation} removed`);
   console.log(`Filtered by salary:   ${totalFilteredSalary} removed`);
+  if (freshnessActive) {
+    console.log(`Filtered by age:       ${totalFilteredStale} removed (>${maxAgeDays}d old)`);
+  }
   console.log(`Duplicates:            ${totalDupes} skipped`);
   if (historyPolicy.recheckAfterDays != null) {
     console.log(`Recheck eligible:      ${seenUrlState.recheckEligible} old scan-history URL(s)`);

--- a/scripts/test-new-providers.mjs
+++ b/scripts/test-new-providers.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Smoke test for the custom providers added 2026-06-08 (Remo's fork).
+// Run: node scripts/test-new-providers.mjs
+// Validates each provider still returns well-formed jobs against live sources.
+// Hits real networks — expect a few seconds. Non-zero exit if a provider breaks.
+
+import { makeHttpCtx } from '../providers/_http.mjs';
+import getro from '../providers/getro.mjs';
+import personio from '../providers/personio.mjs';
+import workable from '../providers/workable.mjs';
+import recruitee from '../providers/recruitee.mjs';
+import consider from '../providers/consider.mjs';
+import startupch from '../providers/startupch.mjs';
+import joinup from '../providers/joinup.mjs';
+
+const ctx = makeHttpCtx();
+let failures = 0;
+
+async function check(label, provider, entry, { minJobs = 0, soft = false } = {}) {
+  try {
+    const jobs = await provider.fetch(entry, ctx);
+    const malformed = jobs.filter(j => !j.title || !j.url || typeof j.company !== 'string');
+    const ok = jobs.length >= minJobs && malformed.length === 0;
+    console.log(`${ok ? '✅' : (soft ? '⚠️' : '❌')} ${label}: ${jobs.length} jobs${malformed.length ? `, ${malformed.length} malformed` : ''}`);
+    if (jobs[0]) console.log(`     e.g. ${jobs[0].company} — ${jobs[0].title} (${jobs[0].location || 'N/A'})`);
+    if (!ok && !soft) failures++;
+  } catch (e) {
+    // soft providers (anti-bot sites) may intermittently block — warn, don't fail.
+    console.log(`${soft ? '⚠️' : '❌'} ${label}: ${soft ? 'transient' : 'ERROR'} ${e.message}`);
+    if (!soft) failures++;
+  }
+}
+
+console.log('Custom provider smoke test\n');
+await check('getro / b2venture(4283)', getro, { name: 'b2venture', getro_collection: 4283, getro_max_pages: 2 }, { minJobs: 1 });
+await check('getro / Cherry(44081)', getro, { name: 'Cherry', getro_collection: 44081, getro_max_pages: 2 }, { minJobs: 1 });
+await check('personio / AMINA', personio, { name: 'AMINA Bank', careers_url: 'https://amina.jobs.personio.com/' }, { minJobs: 1 });
+await check('workable / Hugging Face', workable, { name: 'Hugging Face', careers_url: 'https://apply.workable.com/huggingface/' }, { minJobs: 1 });
+await check('recruitee / HV Capital', recruitee, { name: 'HV Capital', careers_url: 'https://hvcapital.recruitee.com/' });  // may be 0 open
+await check('consider / Founderful(wingman)', consider, { name: 'Founderful', consider_board: 'wingman', careers_url: 'https://jobs.founderful.com/jobs' }, { minJobs: 1 });
+await check('startupch', startupch, { name: 'startup.ch', careers_url: 'https://www.startup.ch/jobs' }, { minJobs: 1, soft: true });
+await check('joinup', joinup, { name: 'joinup.ch', careers_url: 'https://joinup.ch/browse/jobs' }, { minJobs: 1 });
+
+console.log(`\n${failures === 0 ? 'All providers OK' : failures + ' provider(s) FAILED'}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## What
Adds `providers/fractionalpulse.mjs` — a zero-token scan provider for [fractionalpulse.com/jobs](https://fractionalpulse.com/jobs), an aggregator of fractional / interim **CFO / COO / Head of Finance / Head of Operations** roles.

## Why it isn't a one-liner
The board is US-centric and tags remote roles as bare `"Remote"` with **no country**, even though nearly all are US-remote. Emitting a bare `"Remote"` would pass the location filter and flood the pipeline with US roles. So for each remote role the provider reads the detail page's JSON-LD `addressCountry` (`applicantLocationRequirements` preferred) and emits `"Remote, {country}"` — US-remote then matches the existing `"Remote, United States"` block keyword, while a genuine non-US remote role survives. On-site roles already carry a US city in the listing.

Detail fetches are bounded (`fractionalpulse_max_detail`, default 80) with limited concurrency; on a fetch failure it conservatively blocks (US-centric board ⇒ a false block beats a flood) and retries next scan.

## Testing
- `node scan.mjs --company "Fractional Pulse"`: 111 roles parsed, country resolved from detail JSON-LD, all US correctly location-blocked → **0 added** (no flooding).
- `node validate-portals.mjs`: 0 errors, 0 warnings.
- Provider auto-detects a `fractionalpulse.com` `careers_url` (the `portals.yml` wiring is user-layer / gitignored, so it's not part of this diff).

## Notes
- Pre-existing, unrelated test failures in `test-all.mjs` (Go dashboard build, SKILL.md `.claude`/`.agents` path expectations) are not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated InnovatorsRoom newsletter for automated job imports
  * Added support for 8 new job board sources: BambooHR, Consider, FractionalPulse, Getro, joinup, Personio, StartupCH, and Teamtailor
  * Enabled EU Lever job board support
  * Added job freshness filtering to exclude outdated postings
  * Improved keyword matching logic in job title filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->