### PR TITLE
feat(pdf): render Japanese CVs with a lang="ja" CJK font fallback

### DIFF
--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -67,7 +67,7 @@ Use the template in `cv-template.html`. Replace the `{{...}}` placeholders with 
 
 | Placeholder | Content |
 |-------------|-----------|
-| `{{LANG}}` | `en` or `es` |
+| `{{LANG}}` | CV language code (e.g. `en`, `es`, `ja`, `ar`). Drives language-specific CSS in the template: `ja` enables a CJK font fallback so Japanese renders instead of tofu (□); `ar` enables RTL + Arabic fonts. Use the BCP-47/ISO-639 code that matches the CV language. |
 | `{{PAGE_WIDTH}}` | `8.5in` (letter) or `210mm` (A4) |
 | `{{NAME}}` | (from profile.yml) |
 | `{{PHONE}}` | (from profile.yml — include with its separator only when `profile.yml` has a non-empty `phone` value; omit both `<span>` and `<span class="separator">` otherwise) |

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -395,6 +395,30 @@
   html[lang="ar"] .cert-table {
     direction: rtl;
   }
+
+  /* === CJK (Japanese) font fallback === */
+  /* The bundled webfonts are Latin-only (see #951). Without a CJK fallback,
+     Japanese text renders as tofu (□) in headless Chromium on any system
+     without a CJK system font (Linux/CI, minimal containers). The Latin brand
+     fonts are kept first so ASCII still uses Space Grotesk / DM Sans, then the
+     browser's per-glyph fallback picks the first installed CJK face for kana
+     and kanji. Mirrors the lang="ar" precedent above. */
+  html[lang="ja"] body {
+    font-family: 'DM Sans', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+      'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
+      Meiryo, 'MS PGothic', sans-serif;
+  }
+
+  html[lang="ja"] .header h1,
+  html[lang="ja"] .section-title,
+  html[lang="ja"] .job-company,
+  html[lang="ja"] .project-title,
+  html[lang="ja"] .competency-tag,
+  html[lang="ja"] .skill-category {
+    font-family: 'Space Grotesk', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+      'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
+      Meiryo, 'MS PGothic', sans-serif;
+  }
 </style>
 </head>
 <body>

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2659,6 +2659,35 @@ try {
   fail(`font inlining test crashed: ${e.message}`);
 }
 
+// ── 20. CJK CV RENDERING (lang="ja" font fallback) ──────────────
+
+console.log('\n20. CJK CV rendering (lang="ja" font fallback)');
+
+try {
+  // The bundled webfonts are Latin-only, so a Japanese CV (html lang="ja")
+  // needs a CJK system-font fallback or it renders as tofu (□) in headless
+  // Chromium. This mirrors the existing lang="ar" handling.
+  const template = readFileSync(join(ROOT, 'templates', 'cv-template.html'), 'utf-8');
+
+  if (/html\[lang="ja"\]\s+body/.test(template)) {
+    pass('cv-template.html has a lang="ja" body rule for CJK text');
+  } else {
+    fail('cv-template.html is missing a lang="ja" font fallback — Japanese CVs render as tofu (□)');
+  }
+
+  // The fallback must name a real CJK font family, not just rely on sans-serif
+  // (the generic sans-serif has no CJK glyphs on minimal/CI environments).
+  const cjkFonts = ['Hiragino Sans', 'Yu Gothic', 'Noto Sans CJK JP', 'Noto Sans JP', 'Meiryo', 'MS PGothic'];
+  const jaBlock = template.slice(template.indexOf('html[lang="ja"]'));
+  if (cjkFonts.some((f) => jaBlock.includes(f))) {
+    pass('lang="ja" rules name a concrete CJK font family');
+  } else {
+    fail('lang="ja" rules do not name any CJK font family — CJK fallback will not work');
+  }
+} catch (e) {
+  fail(`CJK rendering test crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What does this PR do?

The default HTML→PDF path renders Japanese CVs as tofu (□). The bundled webfonts are Latin-only (#951) and the template only special-cases Arabic (`html[lang="ar"]`), so Japanese text falls back to the generic `sans-serif` — which has no CJK glyphs in headless Chromium on systems without a CJK system font (Linux/CI, minimal containers). This adds a `html[lang="ja"]` font fallback mirroring the existing Arabic precedent.

## Related issue

N/A — obvious rendering defect. The project already ships Japanese support (`modes/ja/`), but the CV PDF could not render Japanese text. Happy to file an issue first if you'd prefer.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [ ] My changes align with the project roadmap

### Details

- `templates/cv-template.html`: add `html[lang="ja"]` body + heading font stacks. Latin brand fonts stay first (ASCII keeps Space Grotesk / DM Sans), then common CJK system faces (Hiragino, Yu Gothic, Noto Sans CJK JP, Meiryo, MS PGothic) so per-glyph fallback resolves a CJK face.
- `modes/pdf.md`: document that `{{LANG}}` drives language-specific CSS (`ja` → CJK fallback, `ar` → RTL).
- `test-all.mjs`: guard that the `lang="ja"` rule exists and names a real CJK family.

**Verified:** with `lang="ja"`, the computed body `font-family` resolves to the CJK stack and a concrete CJK face (Yu Gothic / Meiryo) is matched in Chromium.

> Note: my local `node test-all.mjs` showed 3 failures, all from `.claude`/`.opencode` → `.agents` symlinks materializing as plain files on Windows — identical on `main`, unrelated to this change. They should pass on the Linux CI runner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Japanese language support for CV rendering with proper character display for CJK fonts

* **Documentation**
  * Updated language code specification to clarify support for Japanese and Arabic with corresponding font and directional styling

* **Tests**
  * Added test coverage for Japanese language rendering validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->