### PR TITLE
fix(dashboard): report last-contact in calendar days, not hours-since-midnight

### DIFF
--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -2,6 +2,7 @@ package screens
 
 import (
 	"fmt"
+	"math"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -1295,23 +1296,29 @@ func (m PipelineModel) countByNormStatus(status string) int {
 	return count
 }
 
-// formatTimeAgo renders an ISO date as a relative duration: hours while the
-// contact is less than a day old ("5h ago"), days otherwise ("3d ago").
-// Tracker dates are day-granular, so hours count from local midnight of that day.
+// formatTimeAgo renders an ISO date as a relative duration in calendar days:
+// "today", "yesterday", or "Nd ago". Tracker dates are day-granular (no
+// time-of-day), so we never report sub-day hours — doing so would fabricate
+// precision the data doesn't have (e.g. an entry dated today would otherwise
+// read "13h ago" simply because it's 1pm, not because contact was 13h back).
 func formatTimeAgo(dateStr string) string {
 	t, err := time.ParseInLocation("2006-01-02", dateStr, time.Local)
 	if err != nil {
 		return dateStr // not a date — show it untouched rather than lie
 	}
-	d := time.Since(t)
-	if d < 0 {
-		d = 0
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	contactDay := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.Local)
+	// Round to the nearest day so DST transitions don't skew the count.
+	days := int(math.Round(today.Sub(contactDay).Hours() / 24))
+	switch {
+	case days <= 0:
+		return "today"
+	case days == 1:
+		return "yesterday"
+	default:
+		return fmt.Sprintf("%dd ago", days)
 	}
-	hours := int(d.Hours())
-	if hours < 24 {
-		return fmt.Sprintf("%dh ago", hours)
-	}
-	return fmt.Sprintf("%dd ago", hours/24)
 }
 
 // truncateRunes truncates a string to at most maxRunes runes, appending "..." if truncated.

--- a/dashboard/internal/ui/screens/timeago_test.go
+++ b/dashboard/internal/ui/screens/timeago_test.go
@@ -1,28 +1,30 @@
 package screens
 
 import (
-	"strings"
 	"testing"
 	"time"
 )
 
 func TestFormatTimeAgo(t *testing.T) {
 	today := time.Now().Format("2006-01-02")
+	yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
 	threeDaysAgo := time.Now().AddDate(0, 0, -3).Format("2006-01-02")
 
-	if got := formatTimeAgo(today); !strings.HasSuffix(got, "h ago") {
-		t.Errorf("today should render in hours, got %q", got)
+	// Day-granular dates never fabricate sub-day hours: same day is "today".
+	if got := formatTimeAgo(today); got != "today" {
+		t.Errorf("today should render as \"today\", got %q", got)
 	}
-	got := formatTimeAgo(threeDaysAgo)
-	// Midnight-based day math: 3 calendar days back is 3d (or 2d right after midnight).
-	if got != "3d ago" && got != "2d ago" {
-		t.Errorf("three days ago should render in days, got %q", got)
+	if got := formatTimeAgo(yesterday); got != "yesterday" {
+		t.Errorf("one day ago should render as \"yesterday\", got %q", got)
+	}
+	if got := formatTimeAgo(threeDaysAgo); got != "3d ago" {
+		t.Errorf("three days ago should render as \"3d ago\", got %q", got)
 	}
 
-	// Future dates clamp to zero instead of going negative.
+	// Future dates clamp to "today" instead of going negative.
 	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
-	if got := formatTimeAgo(tomorrow); got != "0h ago" {
-		t.Errorf("future date should clamp to 0h ago, got %q", got)
+	if got := formatTimeAgo(tomorrow); got != "today" {
+		t.Errorf("future date should clamp to \"today\", got %q", got)
 	}
 
 	// Non-dates pass through untouched.


### PR DESCRIPTION
## Problem

The dashboard's last-contact column showed a misleading relative time. `formatTimeAgo` (`dashboard/internal/ui/screens/pipeline.go`) parsed the **day-granular** tracker date as **local midnight** and printed `time.Since(midnight)` in hours. So any application dated *today* rendered as e.g. **"13h ago"** at 1 PM — that's just *hours since midnight*, not hours since the contact actually happened. Tracker dates carry no time-of-day, so the hours figure was fabricated precision.

## Fix

Render in **calendar days** instead:
- same day → `today`
- previous day → `yesterday`
- older → `Nd ago`
- future dates clamp to `today`; non-date strings still pass through untouched

Day difference is computed midnight-to-midnight with `math.Round` so DST transitions don't skew the count.

## Tests

`timeago_test.go` updated — it previously asserted the buggy "render in hours" behavior. New cases cover `today` / `yesterday` / `Nd ago` / future-clamp / non-date passthrough. `go build ./...` and the screens test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated relative time display to use day-granular labels (today, yesterday, and Nd ago) instead of hour-based labels (xh ago) for more intuitive time references when viewing recent activities and events.
  * Enhanced date handling to accurately reflect calendar days, accounting for timezone considerations for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->