### PR TITLE
fix: auto-create data/pipeline.md and fix Playwright doctor check (#1055 #1056)

### DIFF
--- a/.opencode/commands/career-ops-interview-intel.md
+++ b/.opencode/commands/career-ops-interview-intel.md
@@ -1,0 +1,15 @@
+---
+description: Load static interview guide for a specific company
+---
+
+# Load Interview Intelligence Guide
+
+Show the interview intelligence guide for the following company:
+
+$ARGUMENTS
+
+Load the career-ops skill:
+
+```javascript
+skill({ name: "career-ops" })
+```

--- a/.opencode/commands/career-ops-interview-prep.md
+++ b/.opencode/commands/career-ops-interview-prep.md
@@ -1,0 +1,15 @@
+---
+description: Full interview prep package for a specific company and role
+---
+
+# Run Full Interview Prep
+
+Run full interview prep for the following company and role:
+
+$ARGUMENTS
+
+Load the career-ops skill:
+
+```javascript
+skill({ name: "career-ops" })
+```

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -5,7 +5,7 @@
  * Checks all prerequisites and prints a pass/fail checklist.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -47,23 +47,33 @@ function checkDependencies() {
 }
 
 async function checkPlaywright() {
+  let chromium;
   try {
-    const { chromium } = await import('playwright');
-    const execPath = chromium.executablePath();
-    if (existsSync(execPath)) {
-      return { pass: true, label: 'Playwright chromium installed' };
-    }
-    return {
-      pass: false,
-      label: 'Playwright chromium not installed',
-      fix: 'Run: npx playwright install chromium',
-    };
+    ({ chromium } = await import('playwright'));
   } catch {
     return {
       pass: false,
       label: 'Playwright chromium not installed',
       fix: 'Run: npx playwright install chromium',
     };
+  }
+  // Validate by launching — chromium.executablePath() points at Chrome for Testing
+  // (full binary) but chromium.launch() may use the headless-shell binary, which
+  // lives at a different path and requires a separate install. Launching directly
+  // tests the exact binary the runtime uses and catches stub-installs (directory
+  // present but no binary — just ABOUT + LICENSE files).
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+    return { pass: true, label: 'Playwright chromium installed' };
+  } catch {
+    return {
+      pass: false,
+      label: 'Playwright chromium not installed',
+      fix: 'Run: npx playwright install chromium',
+    };
+  } finally {
+    try { await browser?.close(); } catch { /* ignore */ }
   }
 }
 
@@ -199,6 +209,33 @@ function checkAutoDir(name) {
   }
 }
 
+const PIPELINE_SKELETON = `# Pipeline — Pending URLs
+
+Paste job URLs below as \`- [ ] {url}\` then run \`/career-ops pipeline\`.
+
+## Pending
+
+## Processed
+`;
+
+function checkPipelineFile() {
+  const filePath = join(projectRoot, 'data', 'pipeline.md');
+  if (existsSync(filePath)) {
+    return { pass: true, label: 'data/pipeline.md ready' };
+  }
+  try {
+    mkdirSync(join(projectRoot, 'data'), { recursive: true });
+    writeFileSync(filePath, PIPELINE_SKELETON, 'utf-8');
+    return { pass: true, label: 'data/pipeline.md ready (auto-created)' };
+  } catch {
+    return {
+      pass: false,
+      label: 'data/pipeline.md could not be created',
+      fix: 'Run: mkdir -p data && touch data/pipeline.md',
+    };
+  }
+}
+
 async function main() {
   console.log('\ncareer-ops doctor');
   console.log('================\n');
@@ -211,6 +248,7 @@ async function main() {
     ...USER_LAYER_PREREQS.map(checkPrereq),
     checkFonts(),
     checkAutoDir('data'),
+    checkPipelineFile(),
     checkAutoDir('output'),
     checkAutoDir('reports'),
   ];

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * doctor.mjs — Setup validation for career-ops
+ * doctor.mjs â€” Setup validation for career-ops
  * Checks all prerequisites and prints a pass/fail checklist.
  */
 
@@ -57,11 +57,11 @@ async function checkPlaywright() {
       fix: 'Run: npx playwright install chromium',
     };
   }
-  // Validate by launching — chromium.executablePath() points at Chrome for Testing
+  // Validate by launching â€” chromium.executablePath() points at Chrome for Testing
   // (full binary) but chromium.launch() may use the headless-shell binary, which
   // lives at a different path and requires a separate install. Launching directly
   // tests the exact binary the runtime uses and catches stub-installs (directory
-  // present but no binary — just ABOUT + LICENSE files).
+  // present but no binary â€” just ABOUT + LICENSE files).
   let browser;
   try {
     browser = await chromium.launch({ headless: true });
@@ -80,7 +80,7 @@ async function checkPlaywright() {
 // The browser tools (`browser_navigate` / `browser_snapshot`) that scan / pipeline /
 // apply rely on are provided by the Playwright MCP server, registered through a
 // project-level Claude Code config (`.mcp.json` or `.claude/settings.json`). When it
-// is absent, SPA job boards silently return empty or stale content (#522) — so doctor
+// is absent, SPA job boards silently return empty or stale content (#522) â€” so doctor
 // surfaces it as a non-fatal warning rather than letting it fail invisibly.
 const PLAYWRIGHT_MCP_WARNING = 'Playwright MCP tools not detected';
 
@@ -97,7 +97,7 @@ function playwrightMcpConfigured(root) {
         }
       }
     } catch {
-      // Malformed config — keep scanning the other locations; never crash doctor on it.
+      // Malformed config â€” keep scanning the other locations; never crash doctor on it.
     }
   }
   return false;
@@ -112,7 +112,7 @@ function checkPlaywrightMcp(root) {
     label: PLAYWRIGHT_MCP_WARNING,
     fix: [
       'Browser-driven JD fetching and liveness checks (scan / pipeline / apply) need the',
-      'Playwright MCP server, which this project does not configure yet — SPA job boards',
+      'Playwright MCP server, which this project does not configure yet â€” SPA job boards',
       'may return empty or stale content. Tracking: https://github.com/santifer/career-ops/issues/506',
     ],
   };
@@ -209,7 +209,7 @@ function checkAutoDir(name) {
   }
 }
 
-const PIPELINE_SKELETON = `# Pipeline — Pending URLs
+const PIPELINE_SKELETON = `# Pipeline â€” Pending URLs
 
 Paste job URLs below as \`- [ ] {url}\` then run \`/career-ops pipeline\`.
 
@@ -224,7 +224,6 @@ function checkPipelineFile() {
     return { pass: true, label: 'data/pipeline.md ready' };
   }
   try {
-    mkdirSync(join(projectRoot, 'data'), { recursive: true });
     writeFileSync(filePath, PIPELINE_SKELETON, 'utf-8');
     return { pass: true, label: 'data/pipeline.md ready (auto-created)' };
   } catch {
@@ -260,17 +259,17 @@ async function main() {
     const fixes = Array.isArray(result.fix) ? result.fix : result.fix ? [result.fix] : [];
     if (result.warn) {
       warnings++;
-      console.log(`${yellow('⚠')} ${result.label}`);
+      console.log(`${yellow('âš ')} ${result.label}`);
       for (const hint of fixes) {
-        console.log(`  ${dim('→ ' + hint)}`);
+        console.log(`  ${dim('â†’ ' + hint)}`);
       }
     } else if (result.pass) {
-      console.log(`${green('✓')} ${result.label}`);
+      console.log(`${green('âœ“')} ${result.label}`);
     } else {
       failures++;
-      console.log(`${red('✗')} ${result.label}`);
+      console.log(`${red('âœ—')} ${result.label}`);
       for (const hint of fixes) {
-        console.log(`  ${dim('→ ' + hint)}`);
+        console.log(`  ${dim('â†’ ' + hint)}`);
       }
     }
   }
@@ -280,7 +279,7 @@ async function main() {
     console.log(`Result: ${failures} issue${failures === 1 ? '' : 's'} found. Fix them and run \`npm run doctor\` again.`);
     process.exit(1);
   } else {
-    const warnNote = warnings > 0 ? ` (${warnings} warning${warnings === 1 ? '' : 's'} — see above)` : '';
+    const warnNote = warnings > 0 ? ` (${warnings} warning${warnings === 1 ? '' : 's'} â€” see above)` : '';
     console.log(`Result: All checks passed${warnNote}. You're ready to go! Run \`claude\` (or \`opencode\`) to start.`);
     console.log('');
     console.log('Join the community: https://discord.gg/8pRpHETxa4');

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * doctor.mjs Ã¢â¬â Setup validation for career-ops
+ * doctor.mjs — Setup validation for career-ops
  * Checks all prerequisites and prints a pass/fail checklist.
  */
 
@@ -57,11 +57,11 @@ async function checkPlaywright() {
       fix: 'Run: npx playwright install chromium',
     };
   }
-  // Validate by launching Ã¢â¬â chromium.executablePath() points at Chrome for Testing
+  // Validate by launching — chromium.executablePath() points at Chrome for Testing
   // (full binary) but chromium.launch() may use the headless-shell binary, which
   // lives at a different path and requires a separate install. Launching directly
   // tests the exact binary the runtime uses and catches stub-installs (directory
-  // present but no binary Ã¢â¬â just ABOUT + LICENSE files).
+  // present but no binary — just ABOUT + LICENSE files).
   let browser;
   try {
     browser = await chromium.launch({ headless: true });
@@ -80,7 +80,7 @@ async function checkPlaywright() {
 // The browser tools (`browser_navigate` / `browser_snapshot`) that scan / pipeline /
 // apply rely on are provided by the Playwright MCP server, registered through a
 // project-level Claude Code config (`.mcp.json` or `.claude/settings.json`). When it
-// is absent, SPA job boards silently return empty or stale content (#522) Ã¢â¬â so doctor
+// is absent, SPA job boards silently return empty or stale content (#522) — so doctor
 // surfaces it as a non-fatal warning rather than letting it fail invisibly.
 const PLAYWRIGHT_MCP_WARNING = 'Playwright MCP tools not detected';
 
@@ -97,7 +97,7 @@ function playwrightMcpConfigured(root) {
         }
       }
     } catch {
-      // Malformed config Ã¢â¬â keep scanning the other locations; never crash doctor on it.
+      // Malformed config — keep scanning the other locations; never crash doctor on it.
     }
   }
   return false;
@@ -112,7 +112,7 @@ function checkPlaywrightMcp(root) {
     label: PLAYWRIGHT_MCP_WARNING,
     fix: [
       'Browser-driven JD fetching and liveness checks (scan / pipeline / apply) need the',
-      'Playwright MCP server, which this project does not configure yet Ã¢â¬â SPA job boards',
+      'Playwright MCP server, which this project does not configure yet — SPA job boards',
       'may return empty or stale content. Tracking: https://github.com/santifer/career-ops/issues/506',
     ],
   };
@@ -209,7 +209,7 @@ function checkAutoDir(name) {
   }
 }
 
-const PIPELINE_SKELETON = `# Pipeline Ã¢â¬â Pending URLs
+const PIPELINE_SKELETON = `# Pipeline — Pending URLs
 
 Paste job URLs below as \`- [ ] {url}\` then run \`/career-ops pipeline\`.
 
@@ -259,17 +259,17 @@ async function main() {
     const fixes = Array.isArray(result.fix) ? result.fix : result.fix ? [result.fix] : [];
     if (result.warn) {
       warnings++;
-      console.log(`${yellow('Ã¢Å¡Â ')} ${result.label}`);
+      console.log(`${yellow('⚠')} ${result.label}`);
       for (const hint of fixes) {
-        console.log(`  ${dim('Ã¢â â ' + hint)}`);
+        console.log(`  ${dim('→ ' + hint)}`);
       }
     } else if (result.pass) {
-      console.log(`${green('Ã¢Åâ')} ${result.label}`);
+      console.log(`${green('✓')} ${result.label}`);
     } else {
       failures++;
-      console.log(`${red('Ã¢Å—')} ${result.label}`);
+      console.log(`${red('✗')} ${result.label}`);
       for (const hint of fixes) {
-        console.log(`  ${dim('Ã¢â â ' + hint)}`);
+        console.log(`  ${dim('→ ' + hint)}`);
       }
     }
   }
@@ -279,7 +279,7 @@ async function main() {
     console.log(`Result: ${failures} issue${failures === 1 ? '' : 's'} found. Fix them and run \`npm run doctor\` again.`);
     process.exit(1);
   } else {
-    const warnNote = warnings > 0 ? ` (${warnings} warning${warnings === 1 ? '' : 's'} Ã¢â¬â see above)` : '';
+    const warnNote = warnings > 0 ? ` (${warnings} warning${warnings === 1 ? '' : 's'} — see above)` : '';
     console.log(`Result: All checks passed${warnNote}. You're ready to go! Run \`claude\` (or \`opencode\`) to start.`);
     console.log('');
     console.log('Join the community: https://discord.gg/8pRpHETxa4');

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * doctor.mjs â€” Setup validation for career-ops
+ * doctor.mjs Ã¢â¬â Setup validation for career-ops
  * Checks all prerequisites and prints a pass/fail checklist.
  */
 
@@ -57,11 +57,11 @@ async function checkPlaywright() {
       fix: 'Run: npx playwright install chromium',
     };
   }
-  // Validate by launching â€” chromium.executablePath() points at Chrome for Testing
+  // Validate by launching Ã¢â¬â chromium.executablePath() points at Chrome for Testing
   // (full binary) but chromium.launch() may use the headless-shell binary, which
   // lives at a different path and requires a separate install. Launching directly
   // tests the exact binary the runtime uses and catches stub-installs (directory
-  // present but no binary â€” just ABOUT + LICENSE files).
+  // present but no binary Ã¢â¬â just ABOUT + LICENSE files).
   let browser;
   try {
     browser = await chromium.launch({ headless: true });
@@ -80,7 +80,7 @@ async function checkPlaywright() {
 // The browser tools (`browser_navigate` / `browser_snapshot`) that scan / pipeline /
 // apply rely on are provided by the Playwright MCP server, registered through a
 // project-level Claude Code config (`.mcp.json` or `.claude/settings.json`). When it
-// is absent, SPA job boards silently return empty or stale content (#522) â€” so doctor
+// is absent, SPA job boards silently return empty or stale content (#522) Ã¢â¬â so doctor
 // surfaces it as a non-fatal warning rather than letting it fail invisibly.
 const PLAYWRIGHT_MCP_WARNING = 'Playwright MCP tools not detected';
 
@@ -97,7 +97,7 @@ function playwrightMcpConfigured(root) {
         }
       }
     } catch {
-      // Malformed config â€” keep scanning the other locations; never crash doctor on it.
+      // Malformed config Ã¢â¬â keep scanning the other locations; never crash doctor on it.
     }
   }
   return false;
@@ -112,7 +112,7 @@ function checkPlaywrightMcp(root) {
     label: PLAYWRIGHT_MCP_WARNING,
     fix: [
       'Browser-driven JD fetching and liveness checks (scan / pipeline / apply) need the',
-      'Playwright MCP server, which this project does not configure yet â€” SPA job boards',
+      'Playwright MCP server, which this project does not configure yet Ã¢â¬â SPA job boards',
       'may return empty or stale content. Tracking: https://github.com/santifer/career-ops/issues/506',
     ],
   };
@@ -209,7 +209,7 @@ function checkAutoDir(name) {
   }
 }
 
-const PIPELINE_SKELETON = `# Pipeline â€” Pending URLs
+const PIPELINE_SKELETON = `# Pipeline Ã¢â¬â Pending URLs
 
 Paste job URLs below as \`- [ ] {url}\` then run \`/career-ops pipeline\`.
 
@@ -259,17 +259,17 @@ async function main() {
     const fixes = Array.isArray(result.fix) ? result.fix : result.fix ? [result.fix] : [];
     if (result.warn) {
       warnings++;
-      console.log(`${yellow('âš ')} ${result.label}`);
+      console.log(`${yellow('Ã¢Å¡Â ')} ${result.label}`);
       for (const hint of fixes) {
-        console.log(`  ${dim('â†’ ' + hint)}`);
+        console.log(`  ${dim('Ã¢â â ' + hint)}`);
       }
     } else if (result.pass) {
-      console.log(`${green('âœ“')} ${result.label}`);
+      console.log(`${green('Ã¢Åâ')} ${result.label}`);
     } else {
       failures++;
-      console.log(`${red('âœ—')} ${result.label}`);
+      console.log(`${red('Ã¢Å—')} ${result.label}`);
       for (const hint of fixes) {
-        console.log(`  ${dim('â†’ ' + hint)}`);
+        console.log(`  ${dim('Ã¢â â ' + hint)}`);
       }
     }
   }
@@ -279,7 +279,7 @@ async function main() {
     console.log(`Result: ${failures} issue${failures === 1 ? '' : 's'} found. Fix them and run \`npm run doctor\` again.`);
     process.exit(1);
   } else {
-    const warnNote = warnings > 0 ? ` (${warnings} warning${warnings === 1 ? '' : 's'} â€” see above)` : '';
+    const warnNote = warnings > 0 ? ` (${warnings} warning${warnings === 1 ? '' : 's'} Ã¢â¬â see above)` : '';
     console.log(`Result: All checks passed${warnNote}. You're ready to go! Run \`claude\` (or \`opencode\`) to start.`);
     console.log('');
     console.log('Join the community: https://discord.gg/8pRpHETxa4');

--- a/scan.mjs
+++ b/scan.mjs
@@ -492,22 +492,46 @@ export function formatScanHistoryRow(offer, date, status = 'added') {
   ].map(sanitizeTsvField).join('\t');
 }
 
+// Standard skeleton created on fresh install — matches the format documented
+// in modes/pipeline.md and expected by /career-ops pipeline.
+const PIPELINE_SKELETON = `# Pipeline — Pending URLs
+
+Paste job URLs below as \`- [ ] {url}\` then run \`/career-ops pipeline\`.
+
+## Pending
+
+## Processed
+`;
+
+// Current section names (English). Legacy Spanish names are checked as fallback
+// so existing pipeline.md files created before this change keep working.
+const PENDING_MARKERS = ['## Pending', '## Pendientes'];
+const PROCESSED_MARKERS = ['## Processed', '## Procesadas'];
+
 export function appendToPipeline(offers) {
   if (offers.length === 0) return;
 
+  // Auto-create with standard skeleton if missing (fresh-install guard).
+  if (!existsSync(PIPELINE_PATH)) {
+    writeFileSync(PIPELINE_PATH, PIPELINE_SKELETON, 'utf-8');
+  }
+
   let text = readFileSync(PIPELINE_PATH, 'utf-8');
 
-  // Find "## Pendientes" section and append after it
-  const marker = '## Pendientes';
-  const idx = text.indexOf(marker);
+  const marker = PENDING_MARKERS.find(m => text.includes(m)) ?? null;
+  const idx = marker !== null ? text.indexOf(marker) : -1;
+
   if (idx === -1) {
-    // No Pendientes section — append at end before Procesadas
-    const procIdx = text.indexOf('## Procesadas');
+    // No Pending section found — insert one before Processed (or at end)
+    const procIdx = PROCESSED_MARKERS.reduce((found, m) => {
+      const i = text.indexOf(m);
+      return (found === -1 || (i !== -1 && i < found)) ? i : found;
+    }, -1);
     const insertAt = procIdx === -1 ? text.length : procIdx;
-    const block = `\n${marker}\n\n` + offers.map(formatPipelineOffer).join('\n') + '\n\n';
+    const block = `\n## Pending\n\n` + offers.map(formatPipelineOffer).join('\n') + '\n\n';
     text = text.slice(0, insertAt) + block + text.slice(insertAt);
   } else {
-    // Find the end of existing Pendientes content (next ## or end)
+    // Find the end of existing Pending content (next ## or end)
     const afterMarker = idx + marker.length;
     const nextSection = text.indexOf('\n## ', afterMarker);
     const insertAt = nextSection === -1 ? text.length : nextSection;


### PR DESCRIPTION
## Summary

Fixes two p1 bugs reported together in #1055 and #1056.

### scan.mjs — crash on first run (fixes #1056)

`appendToPipeline` called `readFileSync(PIPELINE_PATH)` unconditionally, causing a hard `ENOENT` crash when `data/pipeline.md` didn't exist yet (fresh clone before any `/career-ops pipeline` run).

- Guard: if file is absent, write the standard skeleton (`# Pipeline — Pending URLs` + `## Pending` + `## Processed`) before reading.
- Also updated section-name lookups to prefer the English names documented in `modes/pipeline.md` (`## Pending` / `## Processed`) and fall back to the legacy Spanish names (`## Pendientes` / `## Procesadas`) so existing files keep working without migration.

### doctor.mjs — wrong Playwright binary + missing pipeline.md check (fixes #1055)

**Gap A — false-negative Playwright check:**

`checkPlaywright` checked `chromium.executablePath()`, which returns the path to Chrome for Testing (full binary). But `chromium.launch({ headless: true })` — what `generate-pdf.mjs` and `scan --verify` actually invoke — may use the headless-shell binary at a different path. This caused two failure modes:

1. User installs full chromium → doctor says ✗ even though PDF generation works.
2. User installs headless-shell only → doctor says ✗ even though PDF generation works.

Fix: replace `existsSync(executablePath())` with an actual `chromium.launch()` probe. This tests the exact binary path the runtime uses and also catches stub-installs (directory present but contains only `ABOUT`/`LICENSE` files, no binary).

**Gap B — `data/pipeline.md` not in prerequisites:**

`npm run doctor` reported all green yet `node scan.mjs` immediately crashed because `data/pipeline.md` was absent. Added `checkPipelineFile()` — idempotent auto-create (same pattern as `checkAutoDir`) — so a green doctor output now implies scan can run.

## Test plan

- [ ] Fresh clone with no `data/pipeline.md` → `node scan.mjs --dry-run` should not crash (file auto-created)
- [ ] `npm run doctor` on fresh clone → `data/pipeline.md ready (auto-created)` line appears
- [ ] Existing `pipeline.md` with `## Pendientes` → `node scan.mjs --dry-run` still appends to the legacy Spanish section
- [ ] Playwright not installed → doctor correctly reports ✗ with the install hint
- [ ] Playwright headless-shell installed → doctor correctly reports ✓
- [ ] `node --check scan.mjs && node --check doctor.mjs` → both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added company-specific “Interview Intelligence” guides, including an index and interview prep/intel command documentation.
* **Improvements**
  * Strengthened Playwright Chromium validation by verifying a real headless launch and reporting pass/fail reliably.
  * Auto-creates `data/pipeline.md` from a standard skeleton when missing.
  * Improves pipeline updates for fresh installs and supports bilingual (English/legacy Spanish) section headers.
  * Refreshed doctor output glyphs for warnings and hints.
* **Documentation**
  * Expanded interview-intel coverage across multiple companies and added Copilot conventions guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->