### PR TITLE
fix(contract): expand interview-prep/* coverage in DATA_CONTRACT and USER_PATHS (#962)

### DIFF
--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -13,6 +13,7 @@ These files contain your personal data, customizations, and work product. Update
 | `modes/_profile.md` | Your archetypes, narrative, negotiation scripts |
 | `article-digest.md` | Your proof points from portfolio |
 | `interview-prep/story-bank.md` | Your accumulated STAR+R stories |
+| `interview-prep/{company}-{role}.md` | Company-specific interview prep reports (written by `/career-ops interview-prep`) |
 | `portals.yml` | Your customized company list |
 | `data/applications.md` | Your application tracker (source of truth) |
 | `data/applications.db` | Derived query index over `applications.md` (SQLite, rebuilt by `node tracker.mjs sync` — safe to delete) |

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -170,7 +170,7 @@ const USER_PATHS = [
   'modes/_profile.md',
   'portals.yml',
   'article-digest.md',
-  'interview-prep/story-bank.md',
+  'interview-prep/',
   'data/',
   'reports/',
   'output/',


### PR DESCRIPTION
## Summary

- `DATA_CONTRACT.md` documented only `interview-prep/story-bank.md` in the User Layer, omitting the per-company prep reports that `/career-ops interview-prep` writes to `interview-prep/{company}-{role}.md`. Add the missing entry.
- `USER_PATHS` in `update-system.mjs` had the same narrow scope — only `interview-prep/story-bank.md` was protected. Change it to `interview-prep/` (directory prefix) so every file written there is guarded by the safety check. The `.gitignore` already covers `interview-prep/*` (added in a prior commit).

## Test plan

- [ ] `node --check update-system.mjs` passes
- [ ] `node updater-migration-tests.mjs` passes (no new required paths added)
- [ ] Confirm `interview-prep/` matches all per-company prep files in `USER_PATHS` safety check
- [ ] `DATA_CONTRACT.md` User Layer table now lists both `interview-prep/story-bank.md` and `interview-prep/{company}-{role}.md`

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protection for the `interview-prep/` directory to prevent automatic system updates from overwriting user-maintained interview preparation files.

* **Documentation**
  * Updated data contract to document the new interview preparation file structure for company and role-specific interview prep reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->