### PR TITLE
fix(update): materialize skill entrypoints without symlinks

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -936,6 +936,37 @@ console.log('\n12a. Skill entrypoint materialization');
   }
 }
 
+{
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-skills-entry-dir-'));
+  try {
+    const canonicalDir = join(fixtureRoot, '.agents', 'skills', 'career-ops');
+    const claudeDir = join(fixtureRoot, '.claude', 'skills', 'career-ops');
+    const opencodeDir = join(fixtureRoot, '.opencode', 'skills', 'career-ops');
+    mkdirSync(canonicalDir, { recursive: true });
+    mkdirSync(claudeDir, { recursive: true });
+    mkdirSync(opencodeDir, { recursive: true });
+
+    const fixtureSkill = '---\nname: career-ops\n---\n\n# canonical skill\n';
+    const pointer = '../../../.agents/skills/career-ops/SKILL.md';
+    writeFileSync(join(canonicalDir, 'SKILL.md'), fixtureSkill);
+    mkdirSync(join(claudeDir, 'SKILL.md'));
+    writeFileSync(join(opencodeDir, 'SKILL.md'), pointer);
+
+    const updater = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+    const materialized = updater.materializeSkillEntrypoints(fixtureRoot);
+    const opencodeSkill = readFileSync(join(opencodeDir, 'SKILL.md'), 'utf-8');
+    if (JSON.stringify(materialized) === JSON.stringify(['.opencode/skills/career-ops/SKILL.md']) && opencodeSkill === fixtureSkill) {
+      pass('update-system skips non-file skill entrypoints while materializing valid pointers');
+    } else {
+      fail(`non-file skill entrypoint handling was unexpected: ${JSON.stringify(materialized)}`);
+    }
+  } catch (e) {
+    fail(`non-file skill entrypoint test crashed: ${e.message}`);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
 console.log('\n12b. Materialized skill index mode');
 
 {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -909,6 +909,33 @@ console.log('\n12a. Skill entrypoint materialization');
   }
 }
 
+{
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-skills-unreadable-'));
+  try {
+    const canonicalDir = join(fixtureRoot, '.agents', 'skills', 'career-ops');
+    const claudeDir = join(fixtureRoot, '.claude', 'skills', 'career-ops');
+    mkdirSync(canonicalDir, { recursive: true });
+    mkdirSync(claudeDir, { recursive: true });
+
+    const pointer = '../../../.agents/skills/career-ops/SKILL.md';
+    mkdirSync(join(canonicalDir, 'SKILL.md'));
+    writeFileSync(join(claudeDir, 'SKILL.md'), pointer);
+
+    const updater = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+    const materialized = updater.materializeSkillEntrypoints(fixtureRoot);
+    const claudeSkill = readFileSync(join(claudeDir, 'SKILL.md'), 'utf-8');
+    if (materialized.length === 0 && claudeSkill === pointer) {
+      pass('update-system skips skill materialization when canonical entrypoint is unreadable');
+    } else {
+      fail(`unreadable canonical skill unexpectedly materialized: ${JSON.stringify(materialized)}`);
+    }
+  } catch (e) {
+    fail(`unreadable canonical skill test crashed: ${e.message}`);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
 console.log('\n12b. Materialized skill index mode');
 
 {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -829,8 +829,10 @@ const symlinks = [
 ];
 
 let canonicalReal = null;
+let canonicalContent = null;
 try {
   canonicalReal = realpathSync(join(ROOT, canonicalSkill));
+  canonicalContent = readFile(canonicalSkill);
   pass(`Canonical skill resolves: ${canonicalSkill}`);
 } catch {
   fail(`Canonical skill not found: ${canonicalSkill}`);
@@ -855,8 +857,123 @@ for (const link of symlinks) {
   }
   if (resolved === canonicalReal) {
     pass(`${link} → canonical skill`);
+  } else if (canonicalContent !== null && readFile(link) === canonicalContent) {
+    pass(`${link} is a materialized copy of canonical skill`);
   } else {
-    fail(`${link} resolves to ${resolved}, expected ${canonicalReal}`);
+    fail(`${link} resolves to ${resolved}, expected ${canonicalReal} or byte-identical canonical skill copy`);
+  }
+}
+
+console.log('\n12a. Skill entrypoint materialization');
+
+{
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-skills-'));
+  try {
+    const canonicalDir = join(fixtureRoot, '.agents', 'skills', 'career-ops');
+    const claudeDir = join(fixtureRoot, '.claude', 'skills', 'career-ops');
+    const opencodeDir = join(fixtureRoot, '.opencode', 'skills', 'career-ops');
+    mkdirSync(canonicalDir, { recursive: true });
+    mkdirSync(claudeDir, { recursive: true });
+    mkdirSync(opencodeDir, { recursive: true });
+
+    const fixtureSkill = '---\nname: career-ops\n---\n\n# canonical skill\n';
+    const pointer = '../../../.agents/skills/career-ops/SKILL.md';
+    writeFileSync(join(canonicalDir, 'SKILL.md'), fixtureSkill);
+    writeFileSync(join(claudeDir, 'SKILL.md'), pointer);
+    writeFileSync(join(opencodeDir, 'SKILL.md'), pointer);
+
+    const updater = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+    const materialized = updater.materializeSkillEntrypoints(fixtureRoot).sort();
+    const expected = [
+      '.claude/skills/career-ops/SKILL.md',
+      '.opencode/skills/career-ops/SKILL.md',
+    ];
+
+    if (JSON.stringify(materialized) === JSON.stringify(expected)) {
+      pass('update-system materializes pointer skill entrypoints');
+    } else {
+      fail(`unexpected materialized skill entrypoints: ${JSON.stringify(materialized)}`);
+    }
+
+    const claudeSkill = readFileSync(join(claudeDir, 'SKILL.md'), 'utf-8');
+    const opencodeSkill = readFileSync(join(opencodeDir, 'SKILL.md'), 'utf-8');
+    if (claudeSkill === fixtureSkill && opencodeSkill === fixtureSkill) {
+      pass('materialized skill entrypoints match canonical content');
+    } else {
+      fail('materialized skill entrypoints do not match canonical content');
+    }
+  } catch (e) {
+    fail(`skill entrypoint materialization test crashed: ${e.message}`);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+console.log('\n12b. Materialized skill index mode');
+
+{
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-skill-git-'));
+  const gitRun = (args, opts = {}) => execFileSync('git', args, {
+    cwd: fixtureRoot,
+    encoding: 'utf-8',
+    timeout: 30000,
+    ...opts,
+  }).trim();
+  const gitRaw = (args) => execFileSync('git', args, {
+    cwd: fixtureRoot,
+    encoding: 'utf-8',
+    timeout: 30000,
+  });
+
+  try {
+    const canonicalDir = join(fixtureRoot, '.agents', 'skills', 'career-ops');
+    const claudeDir = join(fixtureRoot, '.claude', 'skills', 'career-ops');
+    const opencodeDir = join(fixtureRoot, '.opencode', 'skills', 'career-ops');
+    mkdirSync(canonicalDir, { recursive: true });
+    mkdirSync(claudeDir, { recursive: true });
+    mkdirSync(opencodeDir, { recursive: true });
+
+    const fixtureSkill = '---\nname: career-ops\n---\n\n# canonical skill\n';
+    const pointer = '../../../.agents/skills/career-ops/SKILL.md';
+
+    gitRun(['init']);
+    gitRun(['config', 'core.symlinks', 'false']);
+    gitRun(['config', 'user.email', 'test@example.com']);
+    gitRun(['config', 'user.name', 'Test User']);
+
+    writeFileSync(join(canonicalDir, 'SKILL.md'), fixtureSkill);
+    writeFileSync(join(claudeDir, 'SKILL.md'), pointer);
+    writeFileSync(join(opencodeDir, 'SKILL.md'), pointer);
+    gitRun(['add', '--', '.agents/skills/career-ops/SKILL.md']);
+
+    const pointerBlob = gitRun(['hash-object', '-w', '--stdin'], { input: pointer });
+    gitRun(['update-index', '--add', '--cacheinfo', `120000,${pointerBlob},.claude/skills/career-ops/SKILL.md`]);
+    gitRun(['update-index', '--add', '--cacheinfo', `120000,${pointerBlob},.opencode/skills/career-ops/SKILL.md`]);
+
+    const updater = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+    const materialized = updater.materializeSkillEntrypoints(fixtureRoot);
+    updater.prepareMaterializedSkillEntrypointsForStage(materialized, fixtureRoot);
+    gitRun(['add', '--', '.claude/skills/', '.opencode/skills/']);
+
+    const claudeIndex = gitRun(['ls-files', '-s', '--', '.claude/skills/career-ops/SKILL.md']);
+    const opencodeIndex = gitRun(['ls-files', '-s', '--', '.opencode/skills/career-ops/SKILL.md']);
+    if (claudeIndex.startsWith('100644 ') && opencodeIndex.startsWith('100644 ')) {
+      pass('materialized skill entrypoints stage as regular files, not symlink blobs');
+    } else {
+      fail(`materialized skill entrypoints staged with wrong modes: ${JSON.stringify([claudeIndex, opencodeIndex])}`);
+    }
+
+    const claudeBlob = gitRaw(['show', ':.claude/skills/career-ops/SKILL.md']);
+    const opencodeBlob = gitRaw(['show', ':.opencode/skills/career-ops/SKILL.md']);
+    if (claudeBlob === fixtureSkill && opencodeBlob === fixtureSkill) {
+      pass('materialized skill blobs contain canonical skill content');
+    } else {
+      fail('materialized skill blobs do not contain canonical skill content');
+    }
+  } catch (e) {
+    fail(`skill entrypoint index-mode test crashed: ${e.message}`);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
   }
 }
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -293,6 +293,7 @@ export function materializeSkillEntrypoints(root = ROOT) {
       continue;
     }
     if (stat.isSymbolicLink()) continue;
+    if (!stat.isFile()) continue;
 
     try {
       const content = readFileSync(entryPath, 'utf-8').trim();

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -16,7 +16,7 @@
  */
 
 import { execFile, execFileSync, execSync } from 'child_process';
-import { readFileSync, writeFileSync, existsSync, unlinkSync, rmSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, unlinkSync, rmSync, lstatSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -149,6 +149,18 @@ const SYSTEM_PATHS = [
   'DOCKER.md',
 ];
 
+const CANONICAL_SKILL_PATH = '.agents/skills/career-ops/SKILL.md';
+const SKILL_ENTRYPOINTS = [
+  {
+    path: '.claude/skills/career-ops/SKILL.md',
+    pointer: '../../../.agents/skills/career-ops/SKILL.md',
+  },
+  {
+    path: '.opencode/skills/career-ops/SKILL.md',
+    pointer: '../../../.agents/skills/career-ops/SKILL.md',
+  },
+];
+
 // User layer paths — NEVER touch these (safety check)
 const USER_PATHS = [
   'cv.md',
@@ -215,8 +227,12 @@ function newestBackupBranch(branches) {
   return timestamped[0]?.branch || branchList[0];
 }
 
+function gitIn(root, ...args) {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf-8', timeout: 30000 }).trim();
+}
+
 function git(...args) {
-  return execFileSync('git', args, { cwd: ROOT, encoding: 'utf-8', timeout: 30000 }).trim();
+  return gitIn(ROOT, ...args);
 }
 
 function gitStatusEntries() {
@@ -248,6 +264,54 @@ function mergePathLists(...lists) {
     }
   }
   return merged;
+}
+
+function repoPath(root, path) {
+  return join(root, ...path.split('/'));
+}
+
+export function materializeSkillEntrypoints(root = ROOT) {
+  const canonicalPath = repoPath(root, CANONICAL_SKILL_PATH);
+  if (!existsSync(canonicalPath)) return [];
+
+  const canonicalContent = readFileSync(canonicalPath, 'utf-8');
+  const materialized = [];
+
+  for (const entry of SKILL_ENTRYPOINTS) {
+    const entryPath = repoPath(root, entry.path);
+    if (!existsSync(entryPath)) continue;
+
+    let stat = null;
+    try {
+      stat = lstatSync(entryPath);
+    } catch {
+      continue;
+    }
+    if (stat.isSymbolicLink()) continue;
+
+    const content = readFileSync(entryPath, 'utf-8').trim();
+    if (content !== entry.pointer) continue;
+
+    writeFileSync(entryPath, canonicalContent);
+    materialized.push(entry.path);
+  }
+
+  return materialized;
+}
+
+export function prepareMaterializedSkillEntrypointsForStage(paths, root = ROOT) {
+  const prepared = [];
+  for (const path of paths) {
+    const entry = gitIn(root, 'ls-files', '-s', '--', path);
+    if (!entry) continue;
+
+    const mode = entry.split(/\s+/, 1)[0];
+    if (mode === '120000') {
+      gitIn(root, 'rm', '--cached', '-f', '--', path);
+    }
+    prepared.push(path);
+  }
+  return prepared;
 }
 
 function revertPaths(paths) {
@@ -465,6 +529,14 @@ async function apply() {
       }
     }
 
+    const materializedSkillEntrypoints = materializeSkillEntrypoints();
+    if (materializedSkillEntrypoints.length > 0) {
+      for (const path of materializedSkillEntrypoints) {
+        if (!updated.includes(path)) updated.push(path);
+      }
+      console.log(`Materialized ${materializedSkillEntrypoints.length} skill entrypoint(s) for filesystems without symlink support`);
+    }
+
     // 4. Validate: check NO user files were touched.
     //
     // Track which user paths the update unexpectedly touched so we
@@ -547,6 +619,7 @@ async function apply() {
         unlinkSync(dismissFile);
         pathsToStage.push('.update-dismissed');
       }
+      prepareMaterializedSkillEntrypointsForStage(materializedSkillEntrypoints);
       addPaths(pathsToStage);
       git('commit', '-m', `chore: auto-update system files to v${remote}`);
     } catch {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -274,7 +274,12 @@ export function materializeSkillEntrypoints(root = ROOT) {
   const canonicalPath = repoPath(root, CANONICAL_SKILL_PATH);
   if (!existsSync(canonicalPath)) return [];
 
-  const canonicalContent = readFileSync(canonicalPath, 'utf-8');
+  let canonicalContent = '';
+  try {
+    canonicalContent = readFileSync(canonicalPath, 'utf-8');
+  } catch {
+    return [];
+  }
   const materialized = [];
 
   for (const entry of SKILL_ENTRYPOINTS) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -289,10 +289,13 @@ export function materializeSkillEntrypoints(root = ROOT) {
     }
     if (stat.isSymbolicLink()) continue;
 
-    const content = readFileSync(entryPath, 'utf-8').trim();
-    if (content !== entry.pointer) continue;
-
-    writeFileSync(entryPath, canonicalContent);
+    try {
+      const content = readFileSync(entryPath, 'utf-8').trim();
+      if (content !== entry.pointer) continue;
+      writeFileSync(entryPath, canonicalContent);
+    } catch {
+      continue;
+    }
     materialized.push(entry.path);
   }
 


### PR DESCRIPTION
## Context

Fixes #1051.

On Windows checkouts without symlink support, the tracked `.claude` / `.opencode` skill entrypoints can land as regular pointer text files instead of usable `SKILL.md` routers. That breaks multi-CLI discovery even though `.agents/skills/career-ops/SKILL.md` remains the canonical skill.

## Changes

- Keep `.agents/skills/career-ops/SKILL.md` as the canonical source.
- Add an update-time fallback that materializes known pointer files into byte-identical skill copies when the filesystem did not create real symlinks.
- Keep existing symlinks untouched on filesystems that support them.
- Before staging materialized files, remove any `120000` symlink index entry so Git records a real `100644` file instead of corrupting the symlink blob.
- Update the integrity check to accept either a symlink to the canonical skill or a byte-identical materialized copy.
- Add temp-fixture regressions for pointer-file materialization and the `core.symlinks=false` Git index-mode case.

## How to test

- `node --check update-system.mjs`
- `node --check test-all.mjs`
- Windows PowerShell: `node test-all.mjs --quick` reached `287 passed`; the only local failure was the pre-existing Windows `spawnSync chmod ENOENT` in the batch rate-limit pause test. The new skill materialization and index-mode checks passed.

## Risks / rollback

Low risk: this only rewrites exact known pointer-file contents, skips real symlinks, and does not touch user-layer paths. Rollback is the normal updater rollback path or reverting this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic materialization of canonical skill entrypoint content into existing real filesystem entrypoints when they contain the expected pointer text, keeping `.claude`/`.opencode` skills in sync and skipping missing, symlink, or non-matching targets.
  * Ensures materialized skill files are staged as regular files when the repository index previously tracked them in symlink mode.
* **Tests**
  * Strengthened skill symlink integrity to accept either matching resolved targets or byte-identical canonical content, with clearer failure messaging.
  * Added end-to-end coverage for materialization (including skip cases) and git-index staging/index-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->