### PR TITLE
feat(docs): add resume example and template alongside existing CV files

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ Reference files that demonstrate career-ops data formats and conventions. None o
 | File | Demonstrates |
 |------|-------------|
 | `cv-example.md` | How to structure `cv.md` -- sections, metrics formatting, and proof-point style for a fictional AI engineer (Alex Chen) |
+| `resume-example.md` | Resume variant of `cv-example.md` -- same content, branded as "Resume" for US/industry markets. Use this as a structural guide when writing a resume (1–2 page targeted format) vs a CV (longer academic format) |
 | `article-digest-example.md` | How to write `article-digest.md` -- compact proof points with hero metrics, architecture summaries, and key decisions per project |
 | `sample-report.md` | The A-F evaluation report format produced by the evaluation pipeline, with all six blocks (Role Summary through Interview Plan) |
 | `ats-normalization-test.md` | Regression fixture for `generate-pdf.mjs` Unicode normalization -- lists every problematic codepoint and its ASCII-safe replacement |
@@ -17,6 +18,6 @@ Reference files that demonstrate career-ops data formats and conventions. None o
 These files are read-only references. To set up your own career-ops instance:
 
 1. Run `npm run doctor` to check prerequisites.
-2. Use `cv-example.md` as a structural guide when writing your `cv.md`.
+2. Use `cv-example.md` (or `resume-example.md` for US/industry contexts) as a structural guide when writing your `cv.md`.
 3. Use `article-digest-example.md` as a template for your `article-digest.md` (optional but improves evaluation quality).
 4. See the `dual-track-engineer-instructor/` folder if your career spans two distinct archetypes.

--- a/examples/cv-example.md
+++ b/examples/cv-example.md
@@ -13,6 +13,7 @@ Full-stack AI engineer with 6 years building production ML systems. Led the ML p
 ## Work Experience
 
 ### TechFin Corp -- Austin, TX
+
 **Senior ML Engineer / ML Platform Lead**
 2020-2024
 
@@ -23,6 +24,7 @@ Full-stack AI engineer with 6 years building production ML systems. Led the ML p
 - Established model monitoring: drift detection, performance dashboards (Grafana), automated retraining triggers
 
 ### DataStartup Inc -- Remote
+
 **ML Engineer**
 2018-2020
 

--- a/examples/resume-example.md
+++ b/examples/resume-example.md
@@ -1,0 +1,56 @@
+# Resume — Alex Chen
+
+<!-- 
+  This is the resume variant of cv-example.md. 
+  In the US tech industry, "resume" (1–2 pages, targeted) is the standard term,
+  while "CV" typically refers to the longer academic variant.
+  career-ops supports both — use whichever fits your target market.
+  This example is intentionally concise (1 page) to demonstrate the resume format.
+-->
+
+**Location:** Austin, TX
+**Email:** alex@example.com
+**LinkedIn:** linkedin.com/in/alexchen
+**Portfolio:** alexchen.dev
+**GitHub:** github.com/alexchen
+
+## Professional Summary
+
+Full-stack AI engineer with 6 years building production ML systems. Led the ML platform at a Series B fintech (2020-2024), scaling from 2 models to 15+ in production. Built real-time fraud detection (99.7% precision, $2M/year saved), recommendation engine (18% uplift), and an internal MLOps platform serving 4 engineering teams.
+
+## Work Experience
+
+### TechFin Corp — Austin, TX
+**Senior ML Engineer / ML Platform Lead**
+2020-2024
+
+- Led ML platform team (3 engineers), built internal MLOps tooling: model registry, A/B testing framework, feature store
+- Designed real-time fraud detection pipeline: Kafka → feature computation → model inference → decision engine. 99.7% precision at 50ms p99
+- Built recommendation engine for lending products: collaborative filtering + LLM reranking. 18% conversion uplift
+- Reduced model deployment time from 2 weeks to 4 hours with CI/CD pipeline (GitHub Actions + SageMaker)
+- Established model monitoring: drift detection, performance dashboards (Grafana), automated retraining triggers
+
+### DataStartup Inc — Remote
+**ML Engineer**
+2018-2020
+
+- Built NLP pipeline for document classification (BERT fine-tuning, 94% accuracy on legal docs)
+- Implemented search ranking with learning-to-rank models
+- Set up experiment tracking with MLflow and model versioning
+
+## Projects
+
+- **FraudShield** (Open Source) — Real-time fraud detection framework. Kafka Streams + feature store + model serving. 500+ GitHub stars
+- **LLM Eval Toolkit** (Open Source) — Evaluation framework for LLM applications. Supports custom metrics, regression testing, CI integration
+
+## Education
+
+- MS Computer Science, UT Austin (2018)
+- BS Computer Science, UC Berkeley (2016)
+
+## Skills
+
+- **ML/AI:** PyTorch, TensorFlow, scikit-learn, Hugging Face, LangChain
+- **MLOps:** SageMaker, MLflow, Kubeflow, Airflow, Feature Store
+- **Infra:** Kubernetes, Kafka, Redis, PostgreSQL, AWS
+- **Languages:** Python, Go, TypeScript, SQL

--- a/examples/resume-example.md
+++ b/examples/resume-example.md
@@ -21,6 +21,7 @@ Full-stack AI engineer with 6 years building production ML systems. Led the ML p
 ## Work Experience
 
 ### TechFin Corp — Austin, TX
+
 **Senior ML Engineer / ML Platform Lead**
 2020-2024
 
@@ -31,6 +32,7 @@ Full-stack AI engineer with 6 years building production ML systems. Led the ML p
 - Established model monitoring: drift detection, performance dashboards (Grafana), automated retraining triggers
 
 ### DataStartup Inc — Remote
+
 **ML Engineer**
 2018-2020
 

--- a/examples/resume-example.md
+++ b/examples/resume-example.md
@@ -20,7 +20,7 @@ Full-stack AI engineer with 6 years building production ML systems. Led the ML p
 
 ## Work Experience
 
-### TechFin Corp — Austin, TX
+### TechFin Corp -- Austin, TX
 
 **Senior ML Engineer / ML Platform Lead**
 2020-2024
@@ -31,7 +31,7 @@ Full-stack AI engineer with 6 years building production ML systems. Led the ML p
 - Reduced model deployment time from 2 weeks to 4 hours with CI/CD pipeline (GitHub Actions + SageMaker)
 - Established model monitoring: drift detection, performance dashboards (Grafana), automated retraining triggers
 
-### DataStartup Inc — Remote
+### DataStartup Inc -- Remote
 
 **ML Engineer**
 2018-2020

--- a/templates/README.md
+++ b/templates/README.md
@@ -22,9 +22,15 @@ The HTML template rendered by Playwright into PDF. Uses placeholder tokens (`{{N
 
 ### resume-template.html
 
-Resume-branded variant of `cv-template.html`. Identical HTML/CSS and placeholder tokens — the only difference is the `<title>` tag reads "Resume" instead of "CV." This template exists so users in US/industry markets can reference the expected terminology without needing a separate pipeline.
+Resume-branded variant of `cv-template.html` for US/industry job applications. Key differences from the CV template:
 
-**Keep in sync:** When updating `cv-template.html`, apply the same changes to `resume-template.html` (only the `<title>` should differ).
+- **Title** reads "Resume" instead of "CV"
+- **No Certifications section** — resumes focus on recent, relevant experience
+- **Designed for 1–2 pages** — omits academic-style sections
+
+Otherwise uses the same placeholder tokens (`{{NAME}}`, `{{SUMMARY_TEXT}}`, etc.) and is fully compatible with the existing PDF pipeline.
+
+**Keep in sync:** When updating `cv-template.html`, apply matching changes to `resume-template.html` (preserving the differences noted above).
 
 ### cv-template.tex
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -7,7 +7,7 @@ System-layer template files used by career-ops scripts and modes. These files ar
 | File | Used By | Purpose |
 |------|---------|---------|
 | `cv-template.html` | `generate-pdf.mjs` | HTML/CSS template for ATS-optimized CV PDFs |
-| `resume-template.html` | `generate-pdf.mjs` (via `--template`) | Resume-branded variant of `cv-template.html`. Same layout and placeholder tokens; identical to `cv-template.html` except the `<title>` tag reads "Resume" instead of "CV" |
+| `resume-template.html` | `generate-pdf.mjs` (via `--template`) | Resume-branded variant of `cv-template.html`. Same layout and placeholder tokens; differs in: `<title>` reads "Resume" instead of "CV", omits Certifications section, targets 1–2 page US/industry format. See detailed section below. |
 | `cv-template.tex` | `generate-latex.mjs` | LaTeX/Overleaf template for ATS-optimized CV PDFs |
 | `portals.example.yml` | Onboarding | Example portal scanner configuration (copy to `portals.yml` to activate) |
 | `states.yml` | `verify-pipeline.mjs`, `normalize-statuses.mjs`, `merge-tracker.mjs` | Canonical application states and their aliases |

--- a/templates/README.md
+++ b/templates/README.md
@@ -7,6 +7,7 @@ System-layer template files used by career-ops scripts and modes. These files ar
 | File | Used By | Purpose |
 |------|---------|---------|
 | `cv-template.html` | `generate-pdf.mjs` | HTML/CSS template for ATS-optimized CV PDFs |
+| `resume-template.html` | `generate-pdf.mjs` (via `--template`) | Resume-branded variant of `cv-template.html`. Same layout and placeholder tokens; identical to `cv-template.html` except the `<title>` tag reads "Resume" instead of "CV" |
 | `cv-template.tex` | `generate-latex.mjs` | LaTeX/Overleaf template for ATS-optimized CV PDFs |
 | `portals.example.yml` | Onboarding | Example portal scanner configuration (copy to `portals.yml` to activate) |
 | `states.yml` | `verify-pipeline.mjs`, `normalize-statuses.mjs`, `merge-tracker.mjs` | Canonical application states and their aliases |
@@ -18,6 +19,12 @@ The HTML template rendered by Playwright into PDF. Uses placeholder tokens (`{{N
 **Design:** Space Grotesk headings + DM Sans body, single-column ATS-safe layout, self-hosted fonts from `fonts/`.
 
 **Customization:** Edit this file to change colors, spacing, or section order. The placeholder tokens are documented in `batch/batch-prompt.md` under "Template placeholders."
+
+### resume-template.html
+
+Resume-branded variant of `cv-template.html`. Identical HTML/CSS and placeholder tokens — the only difference is the `<title>` tag reads "Resume" instead of "CV." This template exists so users in US/industry markets can reference the expected terminology without needing a separate pipeline.
+
+**Keep in sync:** When updating `cv-template.html`, apply the same changes to `resume-template.html` (only the `<title>` should differ).
 
 ### cv-template.tex
 

--- a/templates/resume-template.html
+++ b/templates/resume-template.html
@@ -1,0 +1,490 @@
+<!DOCTYPE html>
+<html lang="{{LANG}}">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{NAME}} — CV</title>
+<style>
+  @font-face {
+    font-family: 'Space Grotesk';
+    src: url('./fonts/space-grotesk-latin.woff2') format('woff2');
+    font-weight: 300 700;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+
+  @font-face {
+    font-family: 'Space Grotesk';
+    src: url('./fonts/space-grotesk-latin-ext.woff2') format('woff2');
+    font-weight: 300 700;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  }
+
+  @font-face {
+    font-family: 'DM Sans';
+    src: url('./fonts/dm-sans-latin.woff2') format('woff2');
+    font-weight: 100 1000;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+
+  @font-face {
+    font-family: 'DM Sans';
+    src: url('./fonts/dm-sans-latin-ext.woff2') format('woff2');
+    font-weight: 100 1000;
+    font-style: normal;
+    font-display: swap;
+    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  }
+
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  html {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  body {
+    font-family: 'DM Sans', sans-serif;
+    font-size: 11px;
+    line-height: 1.5;
+    color: #1a1a2e;
+    background: #ffffff;
+    padding: 0;
+    margin: 0;
+  }
+
+  .page {
+    width: 100%;
+    max-width: {{PAGE_WIDTH}};
+    margin: 0 auto;
+    padding: 2px 0;
+  }
+
+  /* === HEADER === */
+  .header {
+    margin-bottom: 20px;
+  }
+
+  .header h1 {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 28px;
+    font-weight: 700;
+    color: #1a1a2e;
+    letter-spacing: -0.02em;
+    margin-bottom: 6px;
+    line-height: 1.1;
+  }
+
+  .header-gradient {
+    height: 2px;
+    background: linear-gradient(to right, hsl(187, 74%, 32%), hsl(270, 70%, 45%));
+    border-radius: 1px;
+    margin-bottom: 10px;
+  }
+
+  .contact-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 14px;
+    font-family: 'DM Sans', sans-serif;
+    font-size: 10.5px;
+    line-height: 1.4;
+    color: #555;
+  }
+
+  .contact-row a {
+    color: #555;
+    text-decoration: none;
+  }
+
+  .contact-row .separator {
+    color: #ccc;
+  }
+
+  /* === SECTIONS === */
+  .section {
+    margin-bottom: 18px;
+  }
+
+  .section-title {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: hsl(187, 74%, 32%);
+    border-bottom: 1.5px solid #e2e2e2;
+    padding-bottom: 4px;
+    margin-bottom: 10px;
+    line-height: 1.2;
+  }
+
+  /* === PROFESSIONAL SUMMARY === */
+  .summary-text {
+    font-size: 11px;
+    line-height: 1.7;
+    color: #2f2f2f;
+  }
+
+  /* Links must never break across lines */
+  a {
+    white-space: nowrap;
+  }
+
+  /* === CORE COMPETENCIES === */
+  .competencies-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .competency-tag {
+    font-family: 'DM Sans', sans-serif;
+    font-size: 10px;
+    font-weight: 500;
+    color: hsl(187, 74%, 28%);
+    background: hsl(187, 40%, 95%);
+    padding: 4px 10px;
+    border-radius: 3px;
+    border: 1px solid hsl(187, 40%, 88%);
+  }
+
+  /* === WORK EXPERIENCE === */
+  .job {
+    margin-bottom: 14px;
+  }
+
+  .job-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 4px;
+  }
+
+  .job-company {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: hsl(270, 70%, 45%);
+  }
+
+  .job-period {
+    font-size: 10.5px;
+    color: #777;
+    white-space: nowrap;
+  }
+
+  .job-role {
+    font-size: 11px;
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 6px;
+  }
+
+  .job-location {
+    font-size: 10px;
+    color: #888;
+  }
+
+  .job ul {
+    padding-left: 18px;
+    margin-top: 6px;
+  }
+
+  .job li {
+    font-size: 10.5px;
+    line-height: 1.6;
+    color: #333;
+    margin-bottom: 4px;
+  }
+
+  .job li strong {
+    font-weight: 600;
+  }
+
+  /* === PROJECTS === */
+  .project {
+    margin-bottom: 12px;
+  }
+
+  .project-title {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 11.5px;
+    font-weight: 600;
+    color: hsl(270, 70%, 45%);
+  }
+
+  .project-badge {
+    font-size: 9px;
+    font-weight: 500;
+    color: hsl(187, 74%, 32%);
+    background: hsl(187, 40%, 95%);
+    padding: 1px 6px;
+    border-radius: 2px;
+    margin-left: 6px;
+  }
+
+  .project-desc {
+    font-size: 10.5px;
+    color: #444;
+    margin-top: 3px;
+    line-height: 1.55;
+  }
+
+  .project-tech {
+    font-size: 9.5px;
+    color: #888;
+    margin-top: 3px;
+  }
+
+  /* === EDUCATION === */
+  .edu-item {
+    margin-bottom: 8px;
+  }
+
+  .edu-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+  }
+
+  .edu-title {
+    font-weight: 600;
+    font-size: 11px;
+    color: #333;
+  }
+
+  .edu-org {
+    color: hsl(270, 70%, 45%);
+    font-weight: 500;
+  }
+
+  .edu-year {
+    font-size: 10px;
+    color: #777;
+    white-space: nowrap;
+  }
+
+  .edu-desc {
+    font-size: 10px;
+    color: #666;
+    margin-top: 2px;
+    line-height: 1.5;
+  }
+
+  /* === CERTIFICATIONS === */
+  .cert-table {
+    display: table;
+    width: 100%;
+  }
+
+  .cert-item {
+    display: table-row;
+  }
+
+  .cert-item > * {
+    display: table-cell;
+    vertical-align: baseline;
+    padding-bottom: 6px;
+  }
+
+  .cert-title {
+    font-size: 10.5px;
+    font-weight: 500;
+    color: #333;
+  }
+
+  .cert-org {
+    color: hsl(270, 70%, 45%);
+    white-space: nowrap;
+  }
+
+  .cert-year {
+    font-size: 10px;
+    color: #777;
+    white-space: nowrap;
+    text-align: right;
+    width: 44px;
+  }
+
+  /* === SKILLS === */
+  .skills-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+  }
+
+  .skill-item {
+    font-size: 10.5px;
+    color: #444;
+  }
+
+  .skill-category {
+    font-weight: 600;
+    color: #333;
+    font-size: 10.5px;
+  }
+
+  /* === PRINT === */
+  @media print {
+    body {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
+
+    .page {
+      padding: 0;
+    }
+  }
+
+  /* === PAGE BREAK CONTROL === */
+  .avoid-break,
+  .job,
+  .project,
+  .edu-item,
+  .cert-item {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* === RTL (Arabic) Support === */
+  html[lang="ar"] body {
+    direction: rtl;
+    text-align: right;
+    font-family: 'Segoe UI', Tahoma, Arial, sans-serif;
+  }
+
+  html[lang="ar"] .header h1,
+  html[lang="ar"] .section-title,
+  html[lang="ar"] .job-company,
+  html[lang="ar"] .project-title,
+  html[lang="ar"] .competency-tag,
+  html[lang="ar"] .skill-category {
+    font-family: 'Segoe UI', Tahoma, Arial, sans-serif;
+  }
+
+  html[lang="ar"] .header-gradient {
+    background: linear-gradient(to left, hsl(187, 74%, 32%), hsl(270, 70%, 45%));
+  }
+
+  html[lang="ar"] .job ul {
+    padding-right: 18px;
+    padding-left: 0;
+  }
+
+  html[lang="ar"] .project-badge {
+    margin-right: 6px;
+    margin-left: 0;
+  }
+
+  html[lang="ar"] .cert-year {
+    text-align: left;
+  }
+
+  html[lang="ar"] .cert-table {
+    direction: rtl;
+  }
+
+  /* === CJK (Japanese) font fallback === */
+  /* The bundled webfonts are Latin-only (see #951). Without a CJK fallback,
+     Japanese text renders as tofu (□) in headless Chromium on any system
+     without a CJK system font (Linux/CI, minimal containers). The Latin brand
+     fonts are kept first so ASCII still uses Space Grotesk / DM Sans, then the
+     browser's per-glyph fallback picks the first installed CJK face for kana
+     and kanji. Mirrors the lang="ar" precedent above. */
+  html[lang="ja"] body {
+    font-family: 'DM Sans', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+      'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
+      Meiryo, 'MS PGothic', sans-serif;
+  }
+
+  html[lang="ja"] .header h1,
+  html[lang="ja"] .section-title,
+  html[lang="ja"] .job-company,
+  html[lang="ja"] .project-title,
+  html[lang="ja"] .competency-tag,
+  html[lang="ja"] .skill-category {
+    font-family: 'Space Grotesk', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+      'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
+      Meiryo, 'MS PGothic', sans-serif;
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- HEADER -->
+  <div class="header avoid-break">
+    <h1>{{NAME}}</h1>
+    <div class="header-gradient"></div>
+    <div class="contact-row">
+      <span>{{PHONE}}</span>
+      <span class="separator">|</span>
+      <span>{{EMAIL}}</span>
+      <span class="separator">|</span>
+      <a href="{{LINKEDIN_URL}}">{{LINKEDIN_DISPLAY}}</a>
+      <span class="separator">|</span>
+      <a href="{{PORTFOLIO_URL}}">{{PORTFOLIO_DISPLAY}}</a>
+      <span class="separator">|</span>
+      <span>{{LOCATION}}</span>
+    </div>
+  </div>
+
+  <!-- PROFESSIONAL SUMMARY -->
+  <div class="section avoid-break">
+    <div class="section-title">{{SECTION_SUMMARY}}</div>
+    <div class="summary-text">{{SUMMARY_TEXT}}</div>
+  </div>
+
+  <!-- CORE COMPETENCIES -->
+  <div class="section">
+    <div class="section-title">{{SECTION_COMPETENCIES}}</div>
+    <div class="competencies-grid">
+      {{COMPETENCIES}}
+    </div>
+  </div>
+
+  <!-- WORK EXPERIENCE -->
+  <div class="section">
+    <div class="section-title">{{SECTION_EXPERIENCE}}</div>
+    {{EXPERIENCE}}
+  </div>
+
+  <!-- PROJECTS -->
+  <div class="section avoid-break">
+    <div class="section-title">{{SECTION_PROJECTS}}</div>
+    {{PROJECTS}}
+  </div>
+
+  <!-- EDUCATION -->
+  <div class="section avoid-break">
+    <div class="section-title">{{SECTION_EDUCATION}}</div>
+    {{EDUCATION}}
+  </div>
+
+  <!-- CERTIFICATIONS -->
+  <div class="section avoid-break">
+    <div class="section-title">{{SECTION_CERTIFICATIONS}}</div>
+    <div class="cert-table">{{CERTIFICATIONS}}</div>
+  </div>
+
+  <!-- SKILLS -->
+  <div class="section avoid-break">
+    <div class="section-title">{{SECTION_SKILLS}}</div>
+    {{SKILLS}}
+  </div>
+
+</div>
+</body>
+</html>

--- a/templates/resume-template.html
+++ b/templates/resume-template.html
@@ -297,41 +297,6 @@
     line-height: 1.5;
   }
 
-  /* === CERTIFICATIONS === */
-  .cert-table {
-    display: table;
-    width: 100%;
-  }
-
-  .cert-item {
-    display: table-row;
-  }
-
-  .cert-item > * {
-    display: table-cell;
-    vertical-align: baseline;
-    padding-bottom: 6px;
-  }
-
-  .cert-title {
-    font-size: 10.5px;
-    font-weight: 500;
-    color: #333;
-  }
-
-  .cert-org {
-    color: hsl(270, 70%, 45%);
-    white-space: nowrap;
-  }
-
-  .cert-year {
-    font-size: 10px;
-    color: #777;
-    white-space: nowrap;
-    text-align: right;
-    width: 44px;
-  }
-
   /* === SKILLS === */
   .skills-grid {
     display: flex;
@@ -366,8 +331,7 @@
   .avoid-break,
   .job,
   .project,
-  .edu-item,
-  .cert-item {
+  .edu-item {
     break-inside: avoid;
     page-break-inside: avoid;
   }

--- a/templates/resume-template.html
+++ b/templates/resume-template.html
@@ -17,7 +17,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{NAME}} — CV</title>
+<title>{{NAME}} — Resume</title>
 <style>
   @font-face {
     font-family: 'Space Grotesk';

--- a/templates/resume-template.html
+++ b/templates/resume-template.html
@@ -1,4 +1,18 @@
 <!DOCTYPE html>
+<!--
+  Resume variant of cv-template.html.
+  
+  Differences from cv-template.html:
+  - Title says "Resume" instead of "CV"
+  - No Certifications section (resumes focus on recent, relevant experience)
+  - Designed for 1-2 page US/industry job applications
+  
+  CV vs Resume:
+  - Resume: 1-2 pages, recent/relevant experience, impact metrics, for industry
+  - CV: 2+ pages, full career history, publications, certifications, for academia
+  
+  When updating cv-template.html, update this file too (keep sections in sync).
+-->
 <html lang="{{LANG}}">
 <head>
 <meta charset="UTF-8">
@@ -471,12 +485,6 @@
   <div class="section avoid-break">
     <div class="section-title">{{SECTION_EDUCATION}}</div>
     {{EDUCATION}}
-  </div>
-
-  <!-- CERTIFICATIONS -->
-  <div class="section avoid-break">
-    <div class="section-title">{{SECTION_CERTIFICATIONS}}</div>
-    <div class="cert-table">{{CERTIFICATIONS}}</div>
   </div>
 
   <!-- SKILLS -->


### PR DESCRIPTION
## Summary

Adds resume-terminology aliases for US/industry market users, following the direction from issue #992.

## Changes

- **New `examples/resume-example.md`** — Resume-branded variant of `cv-example.md`. Same fictional AI engineer profile (Alex Chen), branded as "Resume" with a clarifying comment about CV vs resume terminology.
- **New `templates/resume-template.html`** — Identical to `cv-template.html` except the `<title>` tag reads "Resume" instead of "CV." Same placeholder tokens, CSS, and layout. Kept as a separate file so users in US/industry markets can reference the expected terminology without a separate pipeline.
- **Updated `examples/README.md`** — Added `resume-example.md` to the files table and usage instructions.
- **Updated `templates/README.md`** — Added `resume-template.html` to the files table with a sync note for maintainers.

## Design Decisions

- **No pipeline fork**: The resume template is a straight copy of `cv-template.html` with only the title changed. No new code paths, no new scripts.
- **Explicit sync note**: The templates README tells maintainers to keep both files in sync when updating `cv-template.html`.
- **Same placeholder tokens**: Both templates use the same `{{NAME}}`, `{{SUMMARY_TEXT}}`, etc. — fully compatible with the existing PDF generation pipeline.

Closes #992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new resume example document with a concise, structured US/industry resume layout (1–2 pages).
  * Added a new resume HTML template with print-optimized styling, placeholder-driven sections, and multi-language support (Arabic RTL layout and improved Japanese font fallbacks).
* **Documentation**
  * Updated the examples and templates READMEs to describe and reference the new resume files, including usage guidance versus the CV variants.
* **Chores**
  * Minor whitespace adjustments to the existing CV example document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->