### PR TITLE
fix(followup): resolve report path relative to tracker dir (closes #1070)

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -190,7 +190,11 @@ function extractContacts(notes) {
 function resolveReportPath(reportField) {
   const match = reportField.match(/\]\(([^)]+)\)/);
   if (!match) return null;
-  const fullPath = join(CAREER_OPS, match[1]);
+  // Report links in the tracker are normalized relative to the tracker file's
+  // own directory (see PR #760 — `merge-tracker.mjs --migrate`). Resolve against
+  // dirname(APPS_FILE), not the project root, otherwise relative paths like
+  // `../reports/...` (the data/applications.md layout) escape above the project.
+  const fullPath = join(dirname(APPS_FILE), match[1]);
   return existsSync(fullPath) ? match[1] : null;
 }
 


### PR DESCRIPTION
## Summary

- Fixes `followup-cadence.mjs:resolveReportPath` returning `null` for every entry under the `data/applications.md` tracker layout.
- Joins relative report links against `dirname(APPS_FILE)` (the tracker file's own directory) instead of the project root.
- Restores the report-context personalization step in `/career-ops followup`'s draft generation, which has been silently degraded since the tracker layout migrated to `data/` (PR #760).

Fixes #1070.

## Prior art

Same anti-pattern, same fix shape, already validated by **PR #780** (merged) which fixed the dashboard report-viewer for the identical reason. This change applies the pattern to the remaining caller — `followup-cadence.mjs:resolveReportPath`.

## Root cause

`resolveReportPath` joined relative report links against `CAREER_OPS` (project root). After PR #760, tracker report links are normalized relative to the tracker file's directory — so for the `data/applications.md` layout, the link is `[007](../reports/007-...)`. Joining `../reports/...` from the project root resolved *above* the project, `existsSync` returned false, and the helper returned null even though the report existed on disk.

Worked for the legacy root-level `applications.md` layout (link was `[007](reports/007-...)`) but broke silently after the migration.

## Change

```diff
 function resolveReportPath(reportField) {
   const match = reportField.match(/\]\(([^)]+)\)/);
   if (!match) return null;
-  const fullPath = join(CAREER_OPS, match[1]);
+  // Report links in the tracker are normalized relative to the tracker file's
+  // own directory (see PR #760 — `merge-tracker.mjs --migrate`). Resolve against
+  // dirname(APPS_FILE), not the project root, otherwise relative paths like
+  // `../reports/...` (the data/applications.md layout) escape above the project.
+  const fullPath = join(dirname(APPS_FILE), match[1]);
   return existsSync(fullPath) ? match[1] : null;
 }
```

Handles both layouts:

| Layout | Tracker location | Link in tracker | Resolved to | Result |
|---|---|---|---|---|
| New | `data/applications.md` | `../reports/001-...` | `<repo>/reports/001-...` | ✓ |
| Legacy | `applications.md` (root) | `reports/001-...` | `<repo>/reports/001-...` | ✓ |

## Test plan

- [x] Reproduce on a real tracker: `node followup-cadence.mjs` previously returned `"reportPath": null` for every entry whose report exists at `<repo>/reports/{NNN}-{slug}-{YYYY-MM-DD}.md`. After the fix it returns the correct relative-path string.
- [x] Verified both layouts mentally (table above). The `dirname(APPS_FILE)` resolution handles both because `APPS_FILE` is already resolved per the existsSync check at lines 20-22.
- [x] No change to function signature, return type, or behavior for already-working inputs (legacy layout) — purely additive correctness.
- [ ] Adding a unit test alongside the existing `cadence.resolveCadenceConfig` test in `test-all.mjs` is a sensible follow-up; happy to include in this PR if preferred. Skipped here to keep the PR minimal and focused per the prior art (PR #780 also shipped without an inline test, with broader coverage added separately).

## Duplicate-check trail

- All open and merged PRs touching `followup-cadence.mjs` reviewed: #142, #768, #889 — none touch `resolveReportPath`.
- No open PRs currently modify `followup-cadence.mjs`.
- Issues searched: `reportPath`, `report null`, `resolveReportPath`, `tracker relative path`, `followup-cadence`. Closest matches are #779 / #780 (prior-art dashboard fix, already merged) — referenced above.
- Most recent commits to `followup-cadence.mjs`: 2026-06-11 (#889), 2026-06-02 (#768). Neither touched the report-path resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path resolution for report links to ensure correct file references during report migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->