### PR TITLE
fix(pdf): ATS-safe static fonts so CV text extracts cleanly (#1074)

### DIFF
--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -5,41 +5,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{NAME}} — CV</title>
 <style>
-  @font-face {
-    font-family: 'Space Grotesk';
-    src: url('./fonts/space-grotesk-latin.woff2') format('woff2');
-    font-weight: 300 700;
-    font-style: normal;
-    font-display: swap;
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-  }
-
-  @font-face {
-    font-family: 'Space Grotesk';
-    src: url('./fonts/space-grotesk-latin-ext.woff2') format('woff2');
-    font-weight: 300 700;
-    font-style: normal;
-    font-display: swap;
-    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
-  }
-
-  @font-face {
-    font-family: 'DM Sans';
-    src: url('./fonts/dm-sans-latin.woff2') format('woff2');
-    font-weight: 100 1000;
-    font-style: normal;
-    font-display: swap;
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-  }
-
-  @font-face {
-    font-family: 'DM Sans';
-    src: url('./fonts/dm-sans-latin-ext.woff2') format('woff2');
-    font-weight: 100 1000;
-    font-style: normal;
-    font-display: swap;
-    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
-  }
+  /* ATS-safe typography (#font-extraction fix):
+     The bundled variable woff2 fonts (Space Grotesk / DM Sans) render with
+     glyph advances that make PDF text extractors inject spurious spaces inside
+     words (e.g. "SUM M ARY", "Germ any") — which corrupts ATS keyword parsing.
+     This template's job is clean machine-readable parsing, so we use a standard
+     static system sans stack instead. Verified clean via pypdf text extraction.
+     Latin base stack is reused by the lang="ja"/lang="ar" rules below. */
 
   * {
     margin: 0;
@@ -53,7 +25,7 @@
   }
 
   body {
-    font-family: 'DM Sans', sans-serif;
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 11px;
     line-height: 1.5;
     color: #1a1a2e;
@@ -75,7 +47,7 @@
   }
 
   .header h1 {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 28px;
     font-weight: 700;
     color: #1a1a2e;
@@ -95,7 +67,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 8px 14px;
-    font-family: 'DM Sans', sans-serif;
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 10.5px;
     line-height: 1.4;
     color: #555;
@@ -116,7 +88,7 @@
   }
 
   .section-title {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 12px;
     font-weight: 700;
     text-transform: uppercase;
@@ -148,7 +120,7 @@
   }
 
   .competency-tag {
-    font-family: 'DM Sans', sans-serif;
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 10px;
     font-weight: 500;
     color: hsl(187, 74%, 28%);
@@ -172,7 +144,7 @@
   }
 
   .job-company {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 12.5px;
     font-weight: 600;
     color: hsl(270, 70%, 45%);
@@ -218,7 +190,7 @@
   }
 
   .project-title {
-    font-family: 'Space Grotesk', sans-serif;
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
     font-size: 11.5px;
     font-weight: 600;
     color: hsl(270, 70%, 45%);
@@ -404,7 +376,7 @@
      browser's per-glyph fallback picks the first installed CJK face for kana
      and kanji. Mirrors the lang="ar" precedent above. */
   html[lang="ja"] body {
-    font-family: 'DM Sans', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
       'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
       Meiryo, 'MS PGothic', sans-serif;
   }
@@ -415,7 +387,7 @@
   html[lang="ja"] .project-title,
   html[lang="ja"] .competency-tag,
   html[lang="ja"] .skill-category {
-    font-family: 'Space Grotesk', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
       'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
       Meiryo, 'MS PGothic', sans-serif;
   }

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -11,7 +11,8 @@
      words (e.g. "SUM M ARY", "Germ any") — which corrupts ATS keyword parsing.
      This template's job is clean machine-readable parsing, so we use a standard
      static system sans stack instead. Verified clean via pypdf text extraction.
-     Latin base stack is reused by the lang="ja"/lang="ar" rules below. */
+     The lang="ja" rules reuse this Latin base stack (with a CJK fallback added);
+     the lang="ar" rules below intentionally define their own Arabic stack. */
 
   * {
     margin: 0;


### PR DESCRIPTION
Fixes #1074.

`templates/cv-template.html` used variable woff2 web-fonts (Space Grotesk / DM Sans). Generated PDFs looked fine but their **text layer extracted with spurious intra-word spaces** (`PROFESSIONAL SUM M ARY`, `Germ any`), which corrupts ATS keyword/section parsing — defeating the template's "ATS-optimized" purpose.

**Change:** switch the default font-family to a static ATS-safe system stack (`'Liberation Sans','Helvetica Neue', Arial, 'DejaVu Sans', sans-serif`), preserving the existing `lang="ja"` CJK and `lang="ar"` RTL rules. Verified clean via pypdf text extraction after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the CV template typography to use an ATS-safe system sans font stack instead of bundled webfonts.
  * Applied the system font stack across body text, headers, section titles, contact info, competency tags, company names, and project titles.
  * For Japanese (`lang="ja"`), adjusted the font stack to include appropriate CJK fallbacks for consistent rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->