### PR TITLE
feat(providers): add RemoteOK, Remotive, Working Nomads, IBM board providers (#1075)

### DIFF
--- a/providers/ibm.mjs
+++ b/providers/ibm.mjs
@@ -28,10 +28,16 @@ const MAX_RECORDS = 600; // safety cap on pagination
  */
 function buildPostFilter(cfg) {
   const must = [];
-  if (Array.isArray(cfg.categories) && cfg.categories.length) {
-    must.push({ bool: { should: cfg.categories.map(c => ({ term: { field_keyword_08: c } })) } });
+  // Sanitize operator config: keep only non-empty trimmed strings so a stray/
+  // mistyped entry can't inject empty or non-string filter terms.
+  const categories = Array.isArray(cfg.categories)
+    ? cfg.categories.filter(c => typeof c === 'string' && c.trim()).map(c => c.trim())
+    : [];
+  if (categories.length) {
+    must.push({ bool: { should: categories.map(c => ({ term: { field_keyword_08: c } })) } });
   }
-  if (cfg.country) must.push({ term: { field_keyword_05: cfg.country } });
+  const country = typeof cfg.country === 'string' ? cfg.country.trim() : '';
+  if (country) must.push({ term: { field_keyword_05: country } });
   return { bool: { must } };
 }
 
@@ -82,12 +88,13 @@ export default {
 
       for (const h of hits) {
         const s = (h && h._source) || {};
-        if (typeof s.title !== 'string' || typeof s.url !== 'string' || !s.url.trim()) continue;
-        const loc = typeof s.field_keyword_19 === 'string' ? s.field_keyword_19 : '';
-        const mode = typeof s.field_keyword_17 === 'string' ? s.field_keyword_17 : '';
+        if (typeof s.title !== 'string' || s.title.trim() === '') continue;
+        if (typeof s.url !== 'string' || !/^https?:\/\//i.test(s.url.trim())) continue;
+        const loc = typeof s.field_keyword_19 === 'string' ? s.field_keyword_19.trim() : '';
+        const mode = typeof s.field_keyword_17 === 'string' ? s.field_keyword_17.trim() : '';
         out.push({
-          title: s.title,
-          url: s.url,
+          title: s.title.trim(),
+          url: s.url.trim(),
           company: 'IBM',
           location: [loc, mode].filter(Boolean).join(' · '),
         });

--- a/providers/ibm.mjs
+++ b/providers/ibm.mjs
@@ -1,0 +1,104 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// IBM careers provider — POSTs to IBM's careers search API (Elasticsearch-style;
+// the same endpoint the ibm.com/careers/search UI calls). One endpoint serves
+// every locale, so results are language-agnostic (lang: "zz").
+//
+// Configure via a `job_boards` (or `tracked_companies`) entry with `provider: ibm`
+// and an optional `ibm:` block of facet filters:
+//
+//   - name: IBM Germany — SWE & Data
+//     provider: ibm
+//     ibm:
+//       country: Germany                                   # field_keyword_05
+//       categories: ["Software Engineering", "Data & Analytics"]  # field_keyword_08
+//     enabled: true
+//
+// Omit `country` / `categories` to widen the search. Paginates via `from` until
+// the result set is exhausted or MAX_RECORDS is reached.
+
+const API_URL = 'https://www-api.ibm.com/search/api/v2';
+const PAGE_SIZE = 30;
+const MAX_RECORDS = 600; // safety cap on pagination
+
+/**
+ * Builds the Elasticsearch post_filter from the entry's `ibm:` config.
+ * @param {{ country?: string, categories?: string[] }} cfg
+ */
+function buildPostFilter(cfg) {
+  const must = [];
+  if (Array.isArray(cfg.categories) && cfg.categories.length) {
+    must.push({ bool: { should: cfg.categories.map(c => ({ term: { field_keyword_08: c } })) } });
+  }
+  if (cfg.country) must.push({ term: { field_keyword_05: cfg.country } });
+  return { bool: { must } };
+}
+
+/** @type {Provider} */
+export default {
+  id: 'ibm',
+
+  /**
+   * Fetches and normalizes postings from IBM's careers search API.
+   * @param {{ name?: string, ibm?: { country?: string, categories?: string[] } }} entry
+   * @param {{ fetchJson: (url: string, opts?: object) => Promise<any> }} ctx
+   * @returns {Promise<Array<{title: string, url: string, company: string, location: string}>>}
+   */
+  async fetch(entry, ctx) {
+    const postFilter = buildPostFilter(entry.ibm || {});
+    /** @type {Array<{title: string, url: string, company: string, location: string}>} */
+    const out = [];
+
+    for (let from = 0; from < MAX_RECORDS; from += PAGE_SIZE) {
+      const body = {
+        appId: 'careers',
+        scopes: ['careers2'],
+        query: { bool: { must: [] } },
+        post_filter: postFilter,
+        size: PAGE_SIZE,
+        from,
+        sort: [{ _score: 'desc' }, { pageviews: 'desc' }],
+        lang: 'zz',
+        localeSelector: {},
+        sm: { query: '', lang: 'zz' },
+        _source: ['_id', 'title', 'url', 'description', 'language',
+          'field_keyword_05', 'field_keyword_08', 'field_keyword_17',
+          'field_keyword_18', 'field_keyword_19'],
+      };
+
+      // redirect:'error' prevents SSRF via server-side redirects
+      const json = await ctx.fetchJson(API_URL, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
+        body: JSON.stringify(body),
+        redirect: 'error',
+      });
+
+      const hits = json && json.hits && Array.isArray(json.hits.hits) ? json.hits.hits : null;
+      if (!hits) {
+        throw new Error(`ibm: unexpected API response — expected hits.hits[], got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`);
+      }
+
+      for (const h of hits) {
+        const s = (h && h._source) || {};
+        if (typeof s.title !== 'string' || typeof s.url !== 'string' || !s.url.trim()) continue;
+        const loc = typeof s.field_keyword_19 === 'string' ? s.field_keyword_19 : '';
+        const mode = typeof s.field_keyword_17 === 'string' ? s.field_keyword_17 : '';
+        out.push({
+          title: s.title,
+          url: s.url,
+          company: 'IBM',
+          location: [loc, mode].filter(Boolean).join(' · '),
+        });
+      }
+
+      // Stop on the first short page. IBM's `total` is unreliable (often
+      // capped at the page size), so don't trust it for the loop bound —
+      // MAX_RECORDS is the hard ceiling.
+      if (hits.length < PAGE_SIZE) break;
+    }
+
+    return out;
+  },
+};

--- a/providers/remoteok.mjs
+++ b/providers/remoteok.mjs
@@ -30,12 +30,14 @@ export default {
     }
 
     return data
-      .filter(j => j && typeof j === 'object' && typeof j.position === 'string' && typeof j.url === 'string' && j.url.trim() !== '')
+      .filter(j => j && typeof j === 'object'
+        && typeof j.position === 'string' && j.position.trim() !== ''
+        && typeof j.url === 'string' && /^https?:\/\//i.test(j.url.trim()))
       .map(j => ({
-        title: j.position,
-        url: j.url,
-        company: typeof j.company === 'string' && j.company.trim() ? j.company : (entry.name || 'RemoteOK'),
-        location: typeof j.location === 'string' ? j.location : '',
+        title: j.position.trim(),
+        url: j.url.trim(),
+        company: typeof j.company === 'string' && j.company.trim() ? j.company.trim() : (entry.name || 'RemoteOK'),
+        location: typeof j.location === 'string' ? j.location.trim() : '',
       }));
   },
 };

--- a/providers/remoteok.mjs
+++ b/providers/remoteok.mjs
@@ -1,0 +1,41 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// RemoteOK provider — board-wide aggregator feed (https://remoteok.com/api).
+// Returns the latest ~100 remote postings as a JSON array; index 0 is a
+// {last_updated, legal} metadata object and is skipped. scan.mjs applies the
+// configured title_filter / location_filter to the returned rows.
+//
+// Wire in via a `job_boards:` entry with `provider: remoteok`.
+// RemoteOK API ToS asks for a follow link-back when republishing — N/A for
+// private scanning, but don't redistribute this feed publicly without it.
+
+const FEED_URL = 'https://remoteok.com/api';
+
+/** @type {Provider} */
+export default {
+  id: 'remoteok',
+
+  /**
+   * Fetches and normalizes postings from the RemoteOK public feed.
+   * @param {{ name?: string }} entry - The job_boards entry being processed.
+   * @param {{ fetchJson: (url: string, opts?: { redirect?: 'error'|'follow'|'manual' }) => Promise<any> }} ctx - HTTP context.
+   * @returns {Promise<Array<{title: string, url: string, company: string, location: string}>>}
+   */
+  async fetch(entry, ctx) {
+    // redirect:'error' prevents SSRF via server-side redirects
+    const data = await ctx.fetchJson(FEED_URL, { redirect: 'error' });
+    if (!Array.isArray(data)) {
+      throw new Error(`remoteok: unexpected API response — expected a JSON array, got ${data === null ? 'null' : typeof data}`);
+    }
+
+    return data
+      .filter(j => j && typeof j === 'object' && typeof j.position === 'string' && typeof j.url === 'string' && j.url.trim() !== '')
+      .map(j => ({
+        title: j.position,
+        url: j.url,
+        company: typeof j.company === 'string' && j.company.trim() ? j.company : (entry.name || 'RemoteOK'),
+        location: typeof j.location === 'string' ? j.location : '',
+      }));
+  },
+};

--- a/providers/remotive.mjs
+++ b/providers/remotive.mjs
@@ -1,0 +1,40 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Remotive provider — board-wide aggregator feed
+// (https://remotive.com/api/remote-jobs). Returns { jobs: [...] }. The full
+// feed (no ?search=) is fetched so scan.mjs's title_filter can gate on the
+// configured AI/ML titles; the feed's own ?search= is too narrow (a substring
+// match that misses e.g. "ML Engineer").
+//
+// Wire in via a `job_boards:` entry with `provider: remotive`.
+
+const FEED_URL = 'https://remotive.com/api/remote-jobs';
+
+/** @type {Provider} */
+export default {
+  id: 'remotive',
+
+  /**
+   * Fetches and normalizes postings from the Remotive public feed.
+   * @param {{ name?: string }} entry - The job_boards entry being processed.
+   * @param {{ fetchJson: (url: string, opts?: { redirect?: 'error'|'follow'|'manual' }) => Promise<any> }} ctx - HTTP context.
+   * @returns {Promise<Array<{title: string, url: string, company: string, location: string}>>}
+   */
+  async fetch(entry, ctx) {
+    // redirect:'error' prevents SSRF via server-side redirects
+    const json = await ctx.fetchJson(FEED_URL, { redirect: 'error' });
+    if (!json || !Array.isArray(json.jobs)) {
+      throw new Error(`remotive: unexpected API response — expected { jobs: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`);
+    }
+
+    return json.jobs
+      .filter(j => j && typeof j === 'object' && typeof j.title === 'string' && typeof j.url === 'string' && j.url.trim() !== '')
+      .map(j => ({
+        title: j.title,
+        url: j.url,
+        company: typeof j.company_name === 'string' && j.company_name.trim() ? j.company_name : (entry.name || 'Remotive'),
+        location: typeof j.candidate_required_location === 'string' ? j.candidate_required_location : '',
+      }));
+  },
+};

--- a/providers/remotive.mjs
+++ b/providers/remotive.mjs
@@ -29,12 +29,14 @@ export default {
     }
 
     return json.jobs
-      .filter(j => j && typeof j === 'object' && typeof j.title === 'string' && typeof j.url === 'string' && j.url.trim() !== '')
+      .filter(j => j && typeof j === 'object'
+        && typeof j.title === 'string' && j.title.trim() !== ''
+        && typeof j.url === 'string' && /^https?:\/\//i.test(j.url.trim()))
       .map(j => ({
-        title: j.title,
-        url: j.url,
-        company: typeof j.company_name === 'string' && j.company_name.trim() ? j.company_name : (entry.name || 'Remotive'),
-        location: typeof j.candidate_required_location === 'string' ? j.candidate_required_location : '',
+        title: j.title.trim(),
+        url: j.url.trim(),
+        company: typeof j.company_name === 'string' && j.company_name.trim() ? j.company_name.trim() : (entry.name || 'Remotive'),
+        location: typeof j.candidate_required_location === 'string' ? j.candidate_required_location.trim() : '',
       }));
   },
 };

--- a/providers/workingnomads.mjs
+++ b/providers/workingnomads.mjs
@@ -1,0 +1,38 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Working Nomads provider — board-wide aggregator feed
+// (https://www.workingnomads.com/api/exposed_jobs/). Returns a JSON array of
+// postings; scan.mjs applies the configured title_filter / location_filter.
+//
+// Wire in via a `job_boards:` entry with `provider: workingnomads`.
+
+const FEED_URL = 'https://www.workingnomads.com/api/exposed_jobs/';
+
+/** @type {Provider} */
+export default {
+  id: 'workingnomads',
+
+  /**
+   * Fetches and normalizes postings from the Working Nomads public feed.
+   * @param {{ name?: string }} entry - The job_boards entry being processed.
+   * @param {{ fetchJson: (url: string, opts?: { redirect?: 'error'|'follow'|'manual' }) => Promise<any> }} ctx - HTTP context.
+   * @returns {Promise<Array<{title: string, url: string, company: string, location: string}>>}
+   */
+  async fetch(entry, ctx) {
+    // redirect:'error' prevents SSRF via server-side redirects
+    const data = await ctx.fetchJson(FEED_URL, { redirect: 'error' });
+    if (!Array.isArray(data)) {
+      throw new Error(`workingnomads: unexpected API response — expected a JSON array, got ${data === null ? 'null' : typeof data}`);
+    }
+
+    return data
+      .filter(j => j && typeof j === 'object' && typeof j.title === 'string' && typeof j.url === 'string' && j.url.trim() !== '')
+      .map(j => ({
+        title: j.title,
+        url: j.url,
+        company: typeof j.company_name === 'string' && j.company_name.trim() ? j.company_name : (entry.name || 'Working Nomads'),
+        location: typeof j.location === 'string' ? j.location : '',
+      }));
+  },
+};

--- a/providers/workingnomads.mjs
+++ b/providers/workingnomads.mjs
@@ -27,12 +27,14 @@ export default {
     }
 
     return data
-      .filter(j => j && typeof j === 'object' && typeof j.title === 'string' && typeof j.url === 'string' && j.url.trim() !== '')
+      .filter(j => j && typeof j === 'object'
+        && typeof j.title === 'string' && j.title.trim() !== ''
+        && typeof j.url === 'string' && /^https?:\/\//i.test(j.url.trim()))
       .map(j => ({
-        title: j.title,
-        url: j.url,
-        company: typeof j.company_name === 'string' && j.company_name.trim() ? j.company_name : (entry.name || 'Working Nomads'),
-        location: typeof j.location === 'string' ? j.location : '',
+        title: j.title.trim(),
+        url: j.url.trim(),
+        company: typeof j.company_name === 'string' && j.company_name.trim() ? j.company_name.trim() : (entry.name || 'Working Nomads'),
+        location: typeof j.location === 'string' ? j.location.trim() : '',
       }));
   },
 };


### PR DESCRIPTION
Refs #1075 (proposal — opening for review alongside the discussion).

Adds four zero-token, in-process board providers that hit **public JSON APIs** via the existing `{id, fetch}` provider contract (same shape as greenhouse/ashby/lever):

- `providers/remoteok.mjs` — `https://remoteok.com/api`
- `providers/remotive.mjs` — `https://remotive.com/api/remote-jobs`
- `providers/workingnomads.mjs` — `https://www.workingnomads.com/api/exposed_jobs/`
- `providers/ibm.mjs` — `POST https://www-api.ibm.com/search/api/v2` (IBM careers-search endpoint)

Each returns `{title, url, company, location}` and is gated by the existing `title_filter`/`location_filter`. Intended to be wired via a `job_boards:` entry (or `tracked_companies` with `provider:`) — see #1075 for the config-shape question. No external npm deps (uses `ctx.fetchJson`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IBM careers as a job postings provider with search-based fetching and output normalization.
  * Added RemoteOK as a job postings provider with redirect-safe feed retrieval and cleaned fields.
  * Added Remotive as a job postings provider with validation and normalized job outputs.
  * Added Working Nomads as a job postings provider with redirect-safe feed retrieval and normalized job outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->