### PR TITLE
feat: add Indonesia job portal providers (Jobstreet + Glints) (#1085)

### DIFF
--- a/providers/glints.mjs
+++ b/providers/glints.mjs
@@ -1,0 +1,256 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Glints provider — hits the undocumented public GraphQL endpoint.
+//
+// Glints (glints.com) covers Singapore, Indonesia, Malaysia, and Vietnam.
+// Their internal API is a no-auth GraphQL endpoint at /api/graphql that
+// powers the job search page. The schema is not officially documented, so
+// the GraphQL query is configurable via the portal entry.
+//
+// This provider is designed for explicit `provider: glints` in portals.yml.
+// Auto-detection is not supported — Glints is a job board aggregator, not
+// a company ATS.
+//
+// Portal entry fields (all optional except `provider`):
+//   api             — GraphQL endpoint URL (default: https://glints.com/api/graphql)
+//   searchKeywords  — Search keywords string (default: '')
+//   countryCode     — Two-letter country code (default: "ID" for Indonesia)
+//   pageSize        — Results per page (default: 30)
+//   maxPages        — Maximum pages via offset-based pagination (default: 3)
+//   graphqlQuery    — Custom GraphQL query string. If not provided, the
+//                     built-in default query is used. The query MUST accept
+//                     $keywords (String!), $country (String!), $limit (Int!),
+//                     $offset (Int!) as variables and return results that
+//                     the parser can map.
+
+const DEFAULT_API = 'https://glints.com/api/graphql';
+const DEFAULT_COUNTRY = 'ID';
+const DEFAULT_PAGE_SIZE = 30;
+const DEFAULT_MAX_PAGES = 3;
+
+const ALLOWED_GLINTS_HOSTS = new Set([
+  'glints.com',
+  'www.glints.com',
+  'glints.id',
+]);
+
+// Default GraphQL query — based on reverse-engineered schema.
+// Field names are best-guess; adjust via `graphqlQuery` in your portal entry
+// if the schema changes or differs by region.
+const DEFAULT_GRAPHQL_QUERY = `
+query SearchJobs($keywords: String!, $country: String!, $limit: Int!, $offset: Int!) {
+  opportunities(
+    filters: { keywords: $keywords, countryCode: $country }
+    first: $limit
+    offset: $offset
+  ) {
+    data {
+      id
+      title
+      company {
+        name
+      }
+      location
+      salary {
+        min
+        max
+        currency
+      }
+      postedAt
+      url
+    }
+    totalCount
+  }
+}`;
+
+/** @param {string} url */
+function assertGlintsUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`glints: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`glints: URL must use HTTPS: ${url}`);
+  if (!ALLOWED_GLINTS_HOSTS.has(parsed.hostname))
+    throw new Error(`glints: untrusted hostname "${parsed.hostname}" — must be one of: ${[...ALLOWED_GLINTS_HOSTS].join(', ')}`);
+  return url;
+}
+
+// NaN-safe Date.parse
+function toEpochMs(value) {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Derive the job detail base URL from the API hostname.
+ * @param {string} apiUrl
+ * @returns {string}
+ */
+function deriveBaseUrl(apiUrl) {
+  try {
+    const parsed = new URL(apiUrl);
+    return `${parsed.protocol}//${parsed.hostname}`;
+  } catch {
+    return 'https://glints.com';
+  }
+}
+
+/**
+ * Parse a single Glints opportunity into the canonical Job shape.
+ *
+ * This parser is exported as a named export for unit tests.
+ *
+ * @param {any} item — raw GraphQL result item
+ * @param {string} baseUrl — scheme + hostname for resolving relative URLs
+ * @param {string} fallbackCompany — company name fallback from portal entry
+ * @returns {{title: string, url: string, company: string, location: string, postedAt: number|undefined}|null}
+ */
+export function parseGlintsItem(item, baseUrl, fallbackCompany) {
+  if (!item || typeof item !== 'object') return null;
+
+  const title = (item.title || '').trim();
+  if (!title) return null;
+
+  // Resolve job URL
+  let url = (item.url || '').trim();
+  if (url) {
+    try {
+      // Try absolute URL first
+      const parsed = new URL(url);
+      url = parsed.href;
+    } catch {
+      // Relative URL — prepend base
+      if (url.startsWith('/')) {
+        url = `${baseUrl}${url}`;
+      }
+    }
+  }
+  if (!url) return null;
+
+  // Validate URL hostname — allow glints.com, its subdomains, and glints.id
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname;
+    const allowed = ALLOWED_GLINTS_HOSTS.has(hostname) || hostname.endsWith('.glints.com');
+    if (!allowed) return null;
+    url = parsed.href;
+  } catch {
+    return null;
+  }
+
+  const company = (item.company?.name || fallbackCompany || '').trim();
+  const location = (item.location || '').trim();
+  const postedAt = toEpochMs(item.postedAt);
+
+  return { title, url, company, location, ...(postedAt != null ? { postedAt } : {}) };
+}
+
+/**
+ * Execute a single GraphQL query page.
+ * @param {string} apiUrl
+ * @param {string} query
+ * @param {object} variables
+ * @param {import('./_types.js').Context} ctx
+ * @returns {Promise<any>}
+ */
+async function graphqlPage(apiUrl, query, variables, ctx) {
+  const body = JSON.stringify({ query, variables });
+  // _http.mjs's fetchWithTimeout passes method, headers, and body through
+  // to the underlying fetch() call, so POST + JSON body works transparently.
+  try {
+    const res = await ctx.fetchJson(apiUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      redirect: 'error',
+    });
+    return res;
+  } catch (err) {
+    // On POST, some servers return non-JSON errors; attempt text fallback
+    if (err.status && err.body) {
+      let detail = '';
+      try {
+        const parsed = JSON.parse(err.body);
+        detail = parsed.errors?.[0]?.message || err.body.slice(0, 200);
+      } catch {
+        detail = err.body.slice(0, 200);
+      }
+      throw new Error(`glints: HTTP ${err.status} — ${detail}`);
+    }
+    throw err;
+  }
+}
+
+/** @type {Provider} */
+export default {
+  id: 'glints',
+
+  detect(_entry) {
+    // Glints is a job board aggregator, not a company ATS.
+    // Auto-detection is intentionally not supported —
+    // use `provider: glints` explicitly in portals.yml.
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const apiUrl = entry.api || DEFAULT_API;
+    assertGlintsUrl(apiUrl);
+    const baseUrl = deriveBaseUrl(apiUrl);
+
+    const query = entry.graphqlQuery || DEFAULT_GRAPHQL_QUERY;
+    const keywords = entry.searchKeywords || '';
+    const country = entry.countryCode || DEFAULT_COUNTRY;
+    const pageSize = Number(entry.pageSize) || DEFAULT_PAGE_SIZE;
+    const maxPages = Number(entry.maxPages) || DEFAULT_MAX_PAGES;
+    const fallbackCompany = entry.name || '';
+
+    const allJobs = [];
+    let totalCount = null; // API may tell us when to stop
+
+    for (let page = 0; page < maxPages; page++) {
+      const offset = page * pageSize;
+      const variables = { keywords, country, limit: pageSize, offset };
+
+      let json;
+      try {
+        json = /** @type {any} */ (await graphqlPage(apiUrl, query, variables, ctx));
+      } catch (err) {
+        if (page === 0) throw err;
+        console.error(`glints: page ${page} fetch failed — ${err.message}`);
+        break;
+      }
+
+      // Handle both GraphQL response shapes:
+      //   { data: { opportunities: { data: [...], totalCount: N } } }
+      //   { data: { opportunities: [...] }
+      const opportunities = json?.data?.opportunities;
+      if (!opportunities) {
+        if (page === 0) throw new Error(`glints: unexpected API response — ${JSON.stringify(json).slice(0, 200)}`);
+        break;
+      }
+
+      const data = Array.isArray(opportunities) ? opportunities : (Array.isArray(opportunities.data) ? opportunities.data : []);
+      if (typeof opportunities.totalCount === 'number') totalCount = opportunities.totalCount;
+
+      if (data.length === 0) break;
+
+      for (const item of data) {
+        const job = parseGlintsItem(item, baseUrl, fallbackCompany);
+        if (job) allJobs.push(job);
+      }
+
+      // Stop conditions
+      if (totalCount != null && allJobs.length >= totalCount) break;
+      if (data.length < pageSize) break;
+
+      // Rate-limit courtesy delay
+      await new Promise(resolve => setTimeout(resolve, 300));
+    }
+
+    return allJobs;
+  },
+};

--- a/providers/jobstreet.mjs
+++ b/providers/jobstreet.mjs
@@ -1,0 +1,222 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Jobstreet / SEEK provider — hits the public chalice-search JSON API.
+// Jobstreet (jobstreet.com, jobstreet.co.id, etc.) and SEEK (seek.com.au,
+// seek.co.nz) share the same SEEK infrastructure and expose a public,
+// no-auth JSON search endpoint at /api/chalice-search/v4/search.
+//
+// This provider is designed for explicit `provider: jobstreet` in
+// portals.yml. Auto-detection from careers_url is not supported because
+// Jobstreet is a job board aggregator, not a company ATS — setting
+// `provider: jobstreet` on a tracked_companies entry is the intended usage.
+//
+// Portal entry fields (all optional except `provider`):
+//   api             — Base search URL (default: https://id.jobstreet.com/api/chalice-search/v4/search)
+//   siteKey         — SEEK site key (default: "ID-Main" for Indonesia)
+//   searchKeywords  — Search keywords, space-separated (default: reads from title_filter via keywords parameter)
+//   searchLocation  — Location filter string (default: none)
+//   pageSize        — Results per page (default: 30, max observed: 100)
+//   maxPages        — Maximum pages to fetch (default: 3, set to 1 for speed)
+//   countryCode     — Two-letter country code for building job detail URLs (default: "id")
+
+const DEFAULT_API = 'https://id.jobstreet.com/api/chalice-search/v4/search';
+const DEFAULT_SITE_KEY = 'ID-Main';
+const DEFAULT_PAGE_SIZE = 30;
+const DEFAULT_MAX_PAGES = 3;
+
+const ALLOWED_JOBSTREET_HOSTS = new Set([
+  'id.jobstreet.com',
+  'www.jobstreet.com',
+  'www.jobstreet.co.id',
+  'jobstreet.com',
+  'jobstreet.co.id',
+  'sg.jobstreet.com',
+  'my.jobstreet.com',
+  'www.seek.com.au',
+  'www.seek.co.nz',
+]);
+
+/** @param {string} url */
+function assertJobstreetUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`jobstreet: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`jobstreet: URL must use HTTPS: ${url}`);
+  if (!ALLOWED_JOBSTREET_HOSTS.has(parsed.hostname))
+    throw new Error(`jobstreet: untrusted hostname "${parsed.hostname}" — must be one of: ${[...ALLOWED_JOBSTREET_HOSTS].join(', ')}`);
+  return url;
+}
+
+/**
+ * Derive the job detail base URL from the API hostname.
+ * e.g. id.jobstreet.com → https://id.jobstreet.com
+ * @param {string} apiUrl
+ * @returns {string}
+ */
+function deriveBaseUrl(apiUrl) {
+  try {
+    const parsed = new URL(apiUrl);
+    return `${parsed.protocol}//${parsed.hostname}`;
+  } catch {
+    return 'https://id.jobstreet.com';
+  }
+}
+
+// NaN-safe Date.parse
+function toEpochMs(value) {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Parse a single Jobstreet/SEEK API result into the canonical Job shape.
+ * The SEEK chalice-search API returns objects like:
+ *   {
+ *     id: 123456,
+ *     title: "Senior Data Scientist",
+ *     teaser: "...",
+ *     bulletText: [...],
+ *     branding: { companyName: "Tech Corp" },
+ *     location: "Jakarta Selatan",
+ *     listingDate: "2026-06-15T00:00:00Z",
+ *     salary: "Rp 15.000.000 - 25.000.000 per month",
+ *     jobUrl: "/id/job/123456",
+ *     ...
+ *   }
+ *
+ * This parser is exported as a named export for unit tests.
+ *
+ * @param {any} item — raw API result item
+ * @param {string} baseUrl — scheme + hostname for resolving relative job URLs
+ * @param {string} fallbackCompany — company name fallback from the portal entry
+ * @returns {{title: string, url: string, company: string, location: string, postedAt: number|undefined}|null}
+ */
+export function parseJobstreetItem(item, baseUrl, fallbackCompany) {
+  if (!item || typeof item !== 'object') return null;
+
+  const title = (item.title || '').trim();
+  if (!title) return null;
+
+  // Resolve job URL — can be relative (/id/job/123) or absolute
+  let url = '';
+  const rawUrl = item.jobUrl || '';
+  if (rawUrl) {
+    try {
+      // Try absolute first
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+        url = parsed.href;
+      }
+    } catch {
+      // Relative URL — prepend base
+      if (rawUrl.startsWith('/')) {
+        url = `${baseUrl}${rawUrl}`;
+      }
+    }
+  }
+  if (!url) return null;
+
+  // Validate URL hostname belongs to allowed set
+  try {
+    const parsed = new URL(url);
+    if (!ALLOWED_JOBSTREET_HOSTS.has(parsed.hostname)) return null;
+    url = parsed.href;
+  } catch {
+    return null;
+  }
+
+  const company = (item.branding?.companyName || item.companyName || item.advertiser?.description || fallbackCompany || '').trim();
+  const location = (item.location || '').trim();
+  const postedAt = toEpochMs(item.listingDate);
+
+  return { title, url, company, location, ...(postedAt != null ? { postedAt } : {}) };
+}
+
+/**
+ * Build the search URL with query parameters.
+ * @param {string} apiUrl
+ * @param {object} params
+ * @returns {string}
+ */
+function buildSearchUrl(apiUrl, params) {
+  const url = new URL(apiUrl);
+  const { siteKey, keywords, location, pageSize, page } = params;
+  if (siteKey) url.searchParams.set('siteKey', siteKey);
+  if (keywords) url.searchParams.set('keywords', keywords);
+  if (location) url.searchParams.set('where', location);
+  url.searchParams.set('pageSize', String(pageSize || DEFAULT_PAGE_SIZE));
+  url.searchParams.set('page', String(page || 1));
+  // Request Solr fields relevant for job listings — narrower than the default
+  // response which includes full ad body. Keeps payloads small.
+  url.searchParams.set('solrFields', 'id,title,location,listingDate,jobUrl,companyName,branding.companyName,advertiser.description,salary');
+  return url.href;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'jobstreet',
+
+  detect(_entry) {
+    // Jobstreet is a job board aggregator, not a company ATS.
+    // Auto-detection from careers_url is intentionally not supported —
+    // use `provider: jobstreet` explicitly in portals.yml.
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const apiUrl = entry.api || DEFAULT_API;
+    assertJobstreetUrl(apiUrl);
+    const baseUrl = deriveBaseUrl(apiUrl);
+
+    const siteKey = entry.siteKey || DEFAULT_SITE_KEY;
+    const keywords = entry.searchKeywords || '';
+    const searchLocation = entry.searchLocation || '';
+    const pageSize = Number(entry.pageSize) || DEFAULT_PAGE_SIZE;
+    const maxPages = Number(entry.maxPages) || DEFAULT_MAX_PAGES;
+    const fallbackCompany = entry.name || '';
+
+    const allJobs = [];
+
+    for (let page = 1; page <= maxPages; page++) {
+      const searchUrl = buildSearchUrl(apiUrl, {
+        siteKey,
+        keywords,
+        location: searchLocation,
+        pageSize,
+        page,
+      });
+
+      let json;
+      try {
+        json = /** @type {any} */ (await ctx.fetchJson(searchUrl, { redirect: 'error' }));
+      } catch (err) {
+        // If page 1 fails, surface the error. Later pages failing is non-fatal
+        // — we return whatever we've collected so far.
+        if (page === 1) throw err;
+        console.error(`jobstreet: page ${page} fetch failed — ${err.message}`);
+        break;
+      }
+
+      const data = Array.isArray(json?.data) ? json.data : [];
+      if (data.length === 0) break;
+
+      for (const item of data) {
+        const job = parseJobstreetItem(item, baseUrl, fallbackCompany);
+        if (job) allJobs.push(job);
+      }
+
+      // Stop if we got fewer results than pageSize (last page)
+      if (data.length < pageSize) break;
+
+      // Respect rate limits — small delay between pages
+      await new Promise(resolve => setTimeout(resolve, 200));
+    }
+
+    return allJobs;
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -1284,3 +1284,26 @@ job_boards:
     provider: solidjobs
     enabled: false
     notes: "Polish job board — Other specialists division"
+
+  # -- Indonesia job boards (provider: jobstreet / glints) --
+
+  - name: Jobstreet Indonesia
+    provider: jobstreet
+    api: https://id.jobstreet.com/api/chalice-search/v4/search
+    siteKey: ID-Main
+    searchKeywords: "data scientist"
+    searchLocation: "Jakarta"
+    pageSize: 30
+    maxPages: 3
+    enabled: false
+    notes: "Indonesia's largest job board (SEEK group). Public JSON search API — zero tokens."
+
+  - name: Glints Indonesia
+    provider: glints
+    api: https://glints.com/api/graphql
+    searchKeywords: "data scientist"
+    countryCode: ID
+    pageSize: 30
+    maxPages: 3
+    enabled: false
+    notes: "SEA job platform covering ID/SG/MY/VN. Undocumented public GraphQL API — adjust graphqlQuery if schema changes."

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2820,6 +2820,350 @@ try {
   fail(`CJK rendering test crashed: ${e.message}`);
 }
 
+// ── 22. PROVIDERS — Jobstreet ──────────────────────────────────────
+
+console.log('\n22. Provider — jobstreet');
+
+try {
+  const jobstreet = (await import(pathToFileURL(join(ROOT, 'providers/jobstreet.mjs')).href)).default;
+  const { parseJobstreetItem } = await import(pathToFileURL(join(ROOT, 'providers/jobstreet.mjs')).href);
+
+  // id check
+  if (jobstreet.id === 'jobstreet') pass('jobstreet.id is "jobstreet"');
+  else fail(`jobstreet.id is ${JSON.stringify(jobstreet.id)}`);
+
+  // detect() always returns null (job board, not ATS)
+  if (jobstreet.detect({ name: 'X', careers_url: 'https://id.jobstreet.com/jobs' }) === null) {
+    pass('jobstreet.detect() returns null — explicit provider only, no URL auto-detection');
+  } else {
+    fail('jobstreet.detect() should return null for any URL');
+  }
+
+  // parseJobstreetItem — valid item
+  const sampleItem = {
+    id: 123456,
+    title: 'Senior Data Scientist',
+    branding: { companyName: 'TechCorp Indonesia' },
+    location: 'Jakarta Selatan',
+    listingDate: '2026-06-15T00:00:00Z',
+    jobUrl: '/id/job/123456',
+  };
+  const parsed = parseJobstreetItem(sampleItem, 'https://id.jobstreet.com', 'FallbackCo');
+  if (parsed && parsed.title === 'Senior Data Scientist'
+      && parsed.url === 'https://id.jobstreet.com/id/job/123456'
+      && parsed.company === 'TechCorp Indonesia'
+      && parsed.location === 'Jakarta Selatan'
+      && parsed.postedAt != null) {
+    pass('parseJobstreetItem extracts title, url, company, location, postedAt correctly');
+  } else {
+    fail(`parseJobstreetItem returned ${JSON.stringify(parsed)}`);
+  }
+
+  // parseJobstreetItem — resolves absolute URL without modification
+  const absItem = { id: 1, title: 'Role', jobUrl: 'https://id.jobstreet.com/id/job/999' };
+  const absParsed = parseJobstreetItem(absItem, 'https://id.jobstreet.com', 'Co');
+  if (absParsed && absParsed.url === 'https://id.jobstreet.com/id/job/999') {
+    pass('parseJobstreetItem preserves absolute URLs');
+  } else {
+    fail(`parseJobstreetItem absolute URL: ${JSON.stringify(absParsed)}`);
+  }
+
+  // parseJobstreetItem — rejects items without title
+  if (parseJobstreetItem({ jobUrl: '/id/job/1' }, 'https://id.jobstreet.com', 'Co') === null) {
+    pass('parseJobstreetItem returns null for items without title');
+  } else {
+    fail('parseJobstreetItem should return null for title-less items');
+  }
+
+  // parseJobstreetItem — rejects items without url
+  if (parseJobstreetItem({ title: 'Role' }, 'https://id.jobstreet.com', 'Co') === null) {
+    pass('parseJobstreetItem returns null for items without jobUrl');
+  } else {
+    fail('parseJobstreetItem should return null for URL-less items');
+  }
+
+  // parseJobstreetItem — rejects off-domain URLs
+  const offDomain = parseJobstreetItem(
+    { title: 'Role', jobUrl: 'https://evil.example.com/jobs/1' },
+    'https://id.jobstreet.com', 'Co'
+  );
+  if (offDomain === null) pass('parseJobstreetItem rejects off-domain job URLs');
+  else fail(`parseJobstreetItem should reject off-domain URLs, got ${JSON.stringify(offDomain)}`);
+
+  // parseJobstreetItem — handles null/malformed input safely
+  if (parseJobstreetItem(null, 'https://id.jobstreet.com', 'Co') === null) pass('parseJobstreetItem(null) → null');
+  else fail('parseJobstreetItem(null) should return null');
+  if (parseJobstreetItem(7, 'https://id.jobstreet.com', 'Co') === null) pass('parseJobstreetItem(7) → null');
+  else fail('parseJobstreetItem(number) should return null');
+
+  // parseJobstreetItem — fallback company when branding is missing
+  const noBrand = parseJobstreetItem(
+    { id: 1, title: 'Engineer', jobUrl: '/id/job/42' },
+    'https://id.jobstreet.com', 'PortalFallback'
+  );
+  if (noBrand && noBrand.company === 'PortalFallback') {
+    pass('parseJobstreetItem uses fallback company when branding is absent');
+  } else {
+    fail(`parseJobstreetItem fallback company: ${JSON.stringify(noBrand)}`);
+  }
+
+  // fetch() — happy path with mock context
+  const mockCtx = {
+    transport: 'http',
+    fetchJson: async (url) => {
+      if (!url.startsWith('https://id.jobstreet.com/')) throw new Error('Unexpected URL');
+      return {
+        data: [
+          { id: 1, title: 'AI Engineer', branding: { companyName: 'TestCo' }, location: 'Remote', listingDate: '2026-01-01T00:00:00Z', jobUrl: '/id/job/1' },
+        ],
+      };
+    },
+    fetchText: async () => { throw new Error('should not be called'); },
+  };
+  const jobs = await jobstreet.fetch(
+    { name: 'Jobstreet ID', provider: 'jobstreet', searchKeywords: 'AI' },
+    mockCtx,
+  );
+  if (jobs.length === 1 && jobs[0].title === 'AI Engineer') pass('jobstreet.fetch() returns parsed jobs');
+  else fail(`jobstreet.fetch() returned ${JSON.stringify(jobs)}`);
+
+  // fetch() — handles empty results
+  const emptyCtx = {
+    transport: 'http',
+    fetchJson: async () => ({ data: [] }),
+    fetchText: async () => { throw new Error('should not be called'); },
+  };
+  const emptyJobs = await jobstreet.fetch(
+    { name: 'Jobstreet ID', provider: 'jobstreet', searchKeywords: 'nonexistent' },
+    emptyCtx,
+  );
+  if (emptyJobs.length === 0) pass('jobstreet.fetch() handles empty results');
+  else fail(`jobstreet.fetch() should return empty array for no results, got ${emptyJobs.length}`);
+
+  // fetch() — rejects invalid hostname
+  let hostRejected = false;
+  try {
+    await jobstreet.fetch(
+      { name: 'Bad', provider: 'jobstreet', api: 'https://evil.example.com/api/search' },
+      { transport: 'http', fetchJson: async () => ({}), fetchText: async () => '' },
+    );
+  } catch (e) {
+    if (e.message.includes('untrusted hostname')) hostRejected = true;
+    else fail(`jobstreet.fetch() host rejection wrong error: ${e.message}`);
+  }
+  if (hostRejected) pass('jobstreet.fetch() rejects untrusted hostnames');
+  else fail('jobstreet.fetch() should reject non-jobstreet hostnames');
+
+  // fetch() — handles non-array data field
+  const badDataCtx = {
+    transport: 'http',
+    fetchJson: async () => ({ data: null }),
+    fetchText: async () => { throw new Error('should not be called'); },
+  };
+  const badDataJobs = await jobstreet.fetch(
+    { name: 'Jobstreet ID', provider: 'jobstreet', searchKeywords: 'test' },
+    badDataCtx,
+  );
+  if (badDataJobs.length === 0) pass('jobstreet.fetch() handles null data field');
+  else fail(`jobstreet.fetch() should return empty for null data`);
+
+} catch (e) {
+  fail(`jobstreet provider tests crashed: ${e.message}`);
+}
+
+// ── 23. PROVIDERS — Glints ─────────────────────────────────────────
+
+console.log('\n23. Provider — glints');
+
+try {
+  const glints = (await import(pathToFileURL(join(ROOT, 'providers/glints.mjs')).href)).default;
+  const { parseGlintsItem } = await import(pathToFileURL(join(ROOT, 'providers/glints.mjs')).href);
+
+  // id check
+  if (glints.id === 'glints') pass('glints.id is "glints"');
+  else fail(`glints.id is ${JSON.stringify(glints.id)}`);
+
+  // detect() always returns null (job board, not ATS)
+  if (glints.detect({ name: 'X', careers_url: 'https://glints.com/id/jobs' }) === null) {
+    pass('glints.detect() returns null — explicit provider only, no URL auto-detection');
+  } else {
+    fail('glints.detect() should return null for any URL');
+  }
+
+  // parseGlintsItem — valid item
+  const sampleItem = {
+    id: 'abc123',
+    title: 'Backend Engineer',
+    company: { name: 'StartupCorp' },
+    location: 'Jakarta, Indonesia',
+    postedAt: '2026-06-10T00:00:00Z',
+    url: 'https://glints.com/id/jobs/backend-engineer/abc123',
+  };
+  const parsed = parseGlintsItem(sampleItem, 'https://glints.com', 'FallbackCo');
+  if (parsed && parsed.title === 'Backend Engineer'
+      && parsed.url === 'https://glints.com/id/jobs/backend-engineer/abc123'
+      && parsed.company === 'StartupCorp'
+      && parsed.location === 'Jakarta, Indonesia'
+      && parsed.postedAt != null) {
+    pass('parseGlintsItem extracts title, url, company, location, postedAt correctly');
+  } else {
+    fail(`parseGlintsItem returned ${JSON.stringify(parsed)}`);
+  }
+
+  // parseGlintsItem — resolves relative URL
+  const relItem = { id: 'x', title: 'Dev', url: '/id/jobs/dev/x' };
+  const relParsed = parseGlintsItem(relItem, 'https://glints.com', 'Co');
+  if (relParsed && relParsed.url === 'https://glints.com/id/jobs/dev/x') {
+    pass('parseGlintsItem resolves relative URLs');
+  } else {
+    fail(`parseGlintsItem relative URL: ${JSON.stringify(relParsed)}`);
+  }
+
+  // parseGlintsItem — rejects items without title
+  if (parseGlintsItem({ url: 'https://glints.com/job/1' }, 'https://glints.com', 'Co') === null) {
+    pass('parseGlintsItem returns null for title-less items');
+  } else {
+    fail('parseGlintsItem should return null for items without title');
+  }
+
+  // parseGlintsItem — rejects items without url
+  if (parseGlintsItem({ title: 'Role' }, 'https://glints.com', 'Co') === null) {
+    pass('parseGlintsItem returns null for URL-less items');
+  } else {
+    fail('parseGlintsItem should return null for items without URL');
+  }
+
+  // parseGlintsItem — rejects off-domain URLs
+  const offDomain = parseGlintsItem(
+    { title: 'Role', url: 'https://evil.example.com/jobs/1' },
+    'https://glints.com', 'Co'
+  );
+  if (offDomain === null) pass('parseGlintsItem rejects off-domain URLs');
+  else fail(`parseGlintsItem should reject off-domain URLs, got ${JSON.stringify(offDomain)}`);
+
+  // parseGlintsItem — allows subdomains of glints.com
+  const subdomainItem = parseGlintsItem(
+    { title: 'Role', url: 'https://www.glints.com/id/jobs/role/1' },
+    'https://glints.com', 'Co'
+  );
+  if (subdomainItem && subdomainItem.url === 'https://www.glints.com/id/jobs/role/1') {
+    pass('parseGlintsItem accepts www.glints.com subdomain URLs');
+  } else {
+    fail(`parseGlintsItem subdomain URL rejected: ${JSON.stringify(subdomainItem)}`);
+  }
+
+  // parseGlintsItem — handles null/malformed input
+  if (parseGlintsItem(null, 'https://glints.com', 'Co') === null) pass('parseGlintsItem(null) → null');
+  else fail('parseGlintsItem(null) should return null');
+  if (parseGlintsItem(42, 'https://glints.com', 'Co') === null) pass('parseGlintsItem(number) → null');
+  else fail('parseGlintsItem(number) should return null');
+
+  // parseGlintsItem — fallback company when company.name is missing
+  const noCompany = parseGlintsItem(
+    { title: 'Engineer', url: 'https://glints.com/id/jobs/eng/1' },
+    'https://glints.com', 'PortalName'
+  );
+  if (noCompany && noCompany.company === 'PortalName') {
+    pass('parseGlintsItem uses fallback company when company.name is absent');
+  } else {
+    fail(`parseGlintsItem fallback company: ${JSON.stringify(noCompany)}`);
+  }
+
+  // fetch() — happy path with mock context
+  const mockCtx = {
+    transport: 'http',
+    fetchJson: async (url, opts) => {
+      if (opts?.method !== 'POST') throw new Error('Expected POST');
+      const body = JSON.parse(opts.body || '{}');
+      if (!body.query) throw new Error('Expected GraphQL query');
+      return {
+        data: {
+          opportunities: {
+            data: [
+              { title: 'AI PM', company: { name: 'TechCo' }, location: 'Remote', postedAt: '2026-01-01T00:00:00Z', url: 'https://glints.com/id/jobs/ai-pm/1' },
+            ],
+            totalCount: 1,
+          },
+        },
+      };
+    },
+    fetchText: async () => { throw new Error('should not be called'); },
+  };
+  const jobs = await glints.fetch(
+    { name: 'Glints ID', provider: 'glints', searchKeywords: 'AI' },
+    mockCtx,
+  );
+  if (jobs.length === 1 && jobs[0].title === 'AI PM') pass('glints.fetch() returns parsed jobs via GraphQL');
+  else fail(`glints.fetch() returned ${JSON.stringify(jobs)}`);
+
+  // fetch() — handles empty results
+  const emptyCtx = {
+    transport: 'http',
+    fetchJson: async () => ({ data: { opportunities: { data: [], totalCount: 0 } } }),
+    fetchText: async () => { throw new Error('should not be called'); },
+  };
+  const emptyJobs = await glints.fetch(
+    { name: 'Glints ID', provider: 'glints', searchKeywords: 'nonexistent' },
+    emptyCtx,
+  );
+  if (emptyJobs.length === 0) pass('glints.fetch() handles empty results');
+  else fail(`glints.fetch() should return empty array for no results, got ${emptyJobs.length}`);
+
+  // fetch() — handles flat opportunities array (alternative response shape)
+  const flatCtx = {
+    transport: 'http',
+    fetchJson: async () => ({
+      data: {
+        opportunities: [
+          { title: 'Dev', company: { name: 'Co' }, location: 'Remote', url: 'https://glints.com/id/jobs/dev/1' },
+        ],
+      },
+    }),
+    fetchText: async () => { throw new Error('should not be called'); },
+  };
+  const flatJobs = await glints.fetch(
+    { name: 'Glints ID', provider: 'glints', searchKeywords: 'dev' },
+    flatCtx,
+  );
+  if (flatJobs.length === 1) pass('glints.fetch() handles flat opportunities array response');
+  else fail(`glints.fetch() flat array: ${JSON.stringify(flatJobs)}`);
+
+  // fetch() — rejects invalid hostname
+  let hostRejected = false;
+  try {
+    await glints.fetch(
+      { name: 'Bad', provider: 'glints', api: 'https://evil.example.com/graphql' },
+      { transport: 'http', fetchJson: async () => ({}), fetchText: async () => '' },
+    );
+  } catch (e) {
+    if (e.message.includes('untrusted hostname')) hostRejected = true;
+    else fail(`glints.fetch() host rejection wrong error: ${e.message}`);
+  }
+  if (hostRejected) pass('glints.fetch() rejects untrusted hostnames');
+  else fail('glints.fetch() should reject non-glints hostnames');
+
+  // fetch() — throws on missing opportunities in response
+  let missingThrew = false;
+  try {
+    await glints.fetch(
+      { name: 'Glints ID', provider: 'glints', searchKeywords: 'test' },
+      {
+        transport: 'http',
+        fetchJson: async () => ({ data: { somethingElse: [] } }),
+        fetchText: async () => { throw new Error('should not be called'); },
+      },
+    );
+  } catch (e) {
+    if (e.message.includes('unexpected API response')) missingThrew = true;
+    else fail(`glints.fetch() missing opportunities wrong error: ${e.message}`);
+  }
+  if (missingThrew) pass('glints.fetch() throws on unexpected API response shape');
+  else fail('glints.fetch() should throw when opportunities is missing');
+
+} catch (e) {
+  fail(`glints provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
Closes #1085

## Summary

Adds two new zero-token providers for the Indonesian job market, following the existing provider plugin pattern.

### New providers

| Provider | API Type | Endpoint |
|----------|----------|----------|
| **Jobstreet** | REST (GET) | `id.jobstreet.com/api/chalice-search/v4/search` |
| **Glints** | GraphQL (POST) | `glints.com/api/graphql` |

Both are public, no-auth APIs — matching career-ops' zero-token scanner philosophy (same pattern as Greenhouse/Ashby/Lever).

### Files changed

| File | Change |
|------|--------|
| `providers/jobstreet.mjs` | **New** — SEEK/Jobstreet REST provider with pagination, URL validation, exported `parseJobstreetItem()` |
| `providers/glints.mjs` | **New** — Glints GraphQL provider with configurable query, tolerance for nested+flat response shapes, exported `parseGlintsItem()` |
| `test-all.mjs` | +344 lines — Sections 22 (jobstreet, 14 tests) + 23 (glints, 15 tests) |
| `templates/portals.example.yml` | +25 lines — Example entries for both portals (disabled by default) |

### Design decisions

- Explicit `provider:` only (no URL auto-detection) — these are job board aggregators, not company ATSes
- Glints uses configurable `graphqlQuery` field since the schema is undocumented
- HTTPS + hostname allowlists for SSRF protection (following existing provider patterns)
- Pagination with courtesy delays between pages

### Portals excluded

| Portal | Reason |
|--------|--------|
| Kalibrr | Undocumented internal API, needs mobile app traffic proxy |
| KitaLulus | Locked down, would require Playwright scraping |
| Indeed Indonesia | Requires OAuth partner access |

### Verified

- ✅ All 29 new tests pass
- ✅ No existing tests broken
- ✅ Syntax check clean on both provider files