### PR TITLE
feat(batch): cut tokens via provider-API JD pre-fetch + two-stage report gate

### DIFF
--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -209,6 +209,15 @@ Rules:
 - `final_decision` must reflect the full evaluation, not only the CV match.
 - Do not invent missing data. If confidence is limited, set `confidence: "Low"` and explain the limitation in the human-readable sections.
 
+### Paso 2.5 — Gate de dos etapas (ahorro de tokens)
+
+Lee `auto_pdf_score_threshold` de `config/profile.yml` (default `3.5` si falta). Es el umbral de aplicación del candidato. El razonamiento A-G completo SIEMPRE se hace para calcular el score; lo que cambia es cuánta PROSA se escribe:
+
+- **Global score < umbral (la mayoría de ofertas):** escribe un report **ABREVIADO** — solo el header + el bloque `## Machine Summary` + una sección `## Veredicto` de 2-3 líneas (score, archetype, el/los hard-stop(s), y por qué cae bajo el umbral). **NO** escribas los bloques A-G en prosa. **NO** generes PDF; marca PDF ❌. (El report largo no se usaría: la oferta no se va a aplicar.)
+- **Global score ≥ umbral:** escribe el report **COMPLETO** (todos los bloques A-G abajo) y aplica el gate de PDF (mismo umbral).
+
+El tracker line, el Machine Summary y el header se escriben en AMBOS casos, así que merge-tracker y verify-pipeline siguen funcionando igual.
+
 ### Paso 3 — Guardar Report .md
 
 Guardar evaluación completa en:

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -211,7 +211,7 @@ Rules:
 
 ### Paso 2.5 — Gate de dos etapas (ahorro de tokens)
 
-Lee `auto_pdf_score_threshold` de `config/profile.yml` (default `3.5` si falta). Es el umbral de aplicación del candidato. El razonamiento A-G completo SIEMPRE se hace para calcular el score; lo que cambia es cuánta PROSA se escribe:
+Lee `auto_pdf_score_threshold` de `config/profile.yml` (default `3.0` si falta — mismo umbral y mismo default que el gate de PDF en Paso 4). Es el umbral de aplicación del candidato. El razonamiento A-G completo SIEMPRE se hace para calcular el score; lo que cambia es cuánta PROSA se escribe:
 
 - **Global score < umbral (la mayoría de ofertas):** escribe un report **ABREVIADO** — solo el header + el bloque `## Machine Summary` + una sección `## Veredicto` de 2-3 líneas (score, archetype, el/los hard-stop(s), y por qué cae bajo el umbral). **NO** escribas los bloques A-G en prosa. **NO** generes PDF; marca PDF ❌. (El report largo no se usaría: la oferta no se va a aplicar.)
 - **Global score ≥ umbral:** escribe el report **COMPLETO** (todos los bloques A-G abajo) y aplica el gate de PDF (mismo umbral).

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -308,6 +308,7 @@ next_report_num_unlocked() {
       local basename
       basename=$(basename "$f")
       local num="${basename%%-*}"
+      [[ "$num" =~ ^[0-9]+$ ]] || continue
       num=$((10#$num)) # Remove leading zeros for arithmetic
       if (( num > max_num )); then
         max_num=$num
@@ -318,6 +319,7 @@ next_report_num_unlocked() {
   if [[ -f "$STATE_FILE" ]]; then
     while IFS=$'\t' read -r _ _ _ _ _ rnum _ _ _; do
       [[ "$rnum" == "report_num" || "$rnum" == "-" || -z "$rnum" ]] && continue
+      [[ "$rnum" =~ ^[0-9]+$ ]] || continue
       local n=$((10#$rnum))
       if (( n > max_num )); then
         max_num=$n
@@ -422,6 +424,19 @@ process_offer() {
   jd_file="$(mktemp "${TMPDIR:-/tmp}/batch-jd-${id}.XXXXXX")"
 
   echo "--- Processing offer #$id: $url (report $report_num, attempt $((retries + 1)))"
+
+  # Pre-fetch the JD via the provider API (zero LLM tokens — a shell-level node
+  # call). The worker then reads clean JD text from jd_file instead of
+  # WebFetching the full HTML page (~80-90% fewer worker tokens, and avoids the
+  # SPA mis-fetches that produce wrong-company evaluations). On a miss or unknown
+  # provider, remove jd_file so the worker falls back to its own WebFetch path
+  # (see batch-prompt.md "if file empty, WebFetch {{URL}}").
+  if node "$PROJECT_DIR/fetch-jd.mjs" "$url" > "$jd_file" 2>/dev/null && [ -s "$jd_file" ]; then
+    echo "    JD pre-fetched via provider API ($(wc -c < "$jd_file") bytes)"
+  else
+    rm -f "$jd_file"
+    echo "    JD pre-fetch missed — worker will WebFetch"
+  fi
 
   # Build the prompt with placeholders replaced
   local prompt

--- a/fetch-jd.mjs
+++ b/fetch-jd.mjs
@@ -55,9 +55,12 @@ const FETCH_TIMEOUT_MS = 12000; // bound each request so a hung ATS endpoint can
 async function getJson(url, opts = {}) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  // Forward a caller-supplied signal so the timeout is always enforced (using
+  // controller.signal) without ignoring an external abort.
+  if (opts.signal) opts.signal.addEventListener('abort', () => controller.abort(), { once: true });
   const headers = { 'user-agent': UA, accept: 'application/json', ...(opts.headers || {}) };
   try {
-    const res = await fetch(url, { ...opts, headers, signal: opts.signal ?? controller.signal });
+    const res = await fetch(url, { ...opts, headers, signal: controller.signal });
     if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
     return res.json();
   } finally {

--- a/fetch-jd.mjs
+++ b/fetch-jd.mjs
@@ -18,6 +18,8 @@
  * back. Mirrors the API conventions in providers/ and modes/scan.md.
  */
 
+import { fileURLToPath } from 'node:url';
+
 const UA = 'career-ops-fetch-jd/1.0';
 const MIN_USEFUL = 200; // chars; below this we treat as a miss and fall back
 
@@ -27,14 +29,14 @@ const ENTITIES = {
   '&rsquo;': "'", '&lsquo;': "'", '&ldquo;': '"', '&rdquo;': '"', '&hellip;': '...',
 };
 
-function decodeEntities(s) {
+export function decodeEntities(s) {
   return s
     .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
     .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
     .replace(/&[a-z]+;|&#x?\d*;/gi, m => ENTITIES[m.toLowerCase()] ?? m);
 }
 
-function htmlToText(html) {
+export function htmlToText(html) {
   if (!html) return '';
   // Decode entities FIRST (Greenhouse `content` is entity-encoded HTML, e.g.
   // &lt;div&gt;), THEN strip tags — otherwise encoded tags survive as text.
@@ -133,6 +135,18 @@ async function workday(url) {
 
 const PROVIDERS = [greenhouse, ashby, lever, workday];
 
+// Classify a job URL by ATS provider without fetching (host-based). Returns the
+// provider id, or null when no provider handles the host (caller falls back to
+// WebFetch). Exported for tests.
+export function detectProvider(url) {
+  const u = String(url || '');
+  if (/greenhouse\.io\//.test(u)) return 'greenhouse';
+  if (/jobs\.ashbyhq\.com\//.test(u)) return 'ashby';
+  if (/lever\.co\//.test(u)) return 'lever';
+  if (/\.myworkdayjobs\.com\//.test(u)) return 'workday';
+  return null;
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const json = args.includes('--json');
@@ -157,4 +171,7 @@ async function main() {
   }
 }
 
-main().catch(err => { process.stderr.write(`fetch-jd error: ${err.message}\n`); process.exit(1); });
+// Only run the CLI when invoked directly, so the module can be imported by tests.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch(err => { process.stderr.write(`fetch-jd error: ${err.message}\n`); process.exit(1); });
+}

--- a/fetch-jd.mjs
+++ b/fetch-jd.mjs
@@ -50,10 +50,19 @@ function htmlToText(html) {
     .trim();
 }
 
+const FETCH_TIMEOUT_MS = 12000; // bound each request so a hung ATS endpoint can't stall a worker
+
 async function getJson(url, opts = {}) {
-  const res = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' }, ...opts });
-  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
-  return res.json();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  const headers = { 'user-agent': UA, accept: 'application/json', ...(opts.headers || {}) };
+  try {
+    const res = await fetch(url, { ...opts, headers, signal: opts.signal ?? controller.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+    return res.json();
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 // ── Provider detectors + single-job fetchers ─────────────────────────

--- a/fetch-jd.mjs
+++ b/fetch-jd.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/*
+ * fetch-jd.mjs — Fetch a single job's description as clean text via the ATS
+ * provider's per-job API (NOT a full HTML page).
+ *
+ * Usage:
+ *   node fetch-jd.mjs "<job-url>"            # prints clean JD text to stdout
+ *   node fetch-jd.mjs "<job-url>" --json     # prints {title, company, location, text}
+ *
+ * Exit 0 + non-empty stdout on success. Exit 1 (empty/short output) when the
+ * provider is unknown or the API misses, so callers (batch-runner.sh) can fall
+ * back to the worker's WebFetch path.
+ *
+ * Why: batch/in-session workers otherwise WebFetch the full HTML page (10-30k
+ * tokens of nav/markup, and mis-fetches on SPAs). The provider APIs return just
+ * the JD body — ~80-90% fewer tokens and far more reliable. Providers covered:
+ * Greenhouse, Ashby, Lever (solid); Workday (best-effort). Anything else falls
+ * back. Mirrors the API conventions in providers/ and modes/scan.md.
+ */
+
+const UA = 'career-ops-fetch-jd/1.0';
+const MIN_USEFUL = 200; // chars; below this we treat as a miss and fall back
+
+const ENTITIES = {
+  '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#39;': "'",
+  '&#x27;': "'", '&apos;': "'", '&nbsp;': ' ', '&mdash;': '-', '&ndash;': '-',
+  '&rsquo;': "'", '&lsquo;': "'", '&ldquo;': '"', '&rdquo;': '"', '&hellip;': '...',
+};
+
+function decodeEntities(s) {
+  return s
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&[a-z]+;|&#x?\d*;/gi, m => ENTITIES[m.toLowerCase()] ?? m);
+}
+
+function htmlToText(html) {
+  if (!html) return '';
+  // Decode entities FIRST (Greenhouse `content` is entity-encoded HTML, e.g.
+  // &lt;div&gt;), THEN strip tags — otherwise encoded tags survive as text.
+  return decodeEntities(String(html))
+    .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<\/(p|div|li|h[1-6]|tr|br)\s*>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '\n- ')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
+async function getJson(url, opts = {}) {
+  const res = await fetch(url, { headers: { 'user-agent': UA, accept: 'application/json' }, ...opts });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return res.json();
+}
+
+// ── Provider detectors + single-job fetchers ─────────────────────────
+
+async function greenhouse(url) {
+  // job-boards.greenhouse.io/{board}/jobs/{id} or boards.greenhouse.io/{board}/jobs/{id}
+  const m = url.match(/greenhouse\.io\/(?:embed\/job_app\?for=)?([^/?#]+)\/jobs\/(\d+)/)
+        || url.match(/greenhouse\.io\/([^/?#]+).*[?&]gh_jid=(\d+)/);
+  if (!m) return null;
+  const [, board, id] = m;
+  const j = await getJson(`https://boards-api.greenhouse.io/v1/boards/${board}/jobs/${id}?questions=false`);
+  return { title: j.title || '', company: board, location: j.location?.name || '', text: htmlToText(j.content) };
+}
+
+async function ashby(url) {
+  // jobs.ashbyhq.com/{org}/{postingId}
+  const m = url.match(/jobs\.ashbyhq\.com\/([^/?#]+)\/([^/?#]+)/i);
+  if (!m) return null;
+  const [, org, postingId] = m;
+  const j = await getJson(`https://api.ashbyhq.com/posting-api/job-board/${org}?includeCompensation=true`);
+  const jobs = Array.isArray(j?.jobs) ? j.jobs : [];
+  const post = jobs.find(p => p.id === postingId || p.jobId === postingId) || jobs.find(p => (p.jobUrl || '').includes(postingId));
+  if (!post) return null;
+  const text = post.descriptionPlain || htmlToText(post.descriptionHtml) || '';
+  return { title: post.title || '', company: org, location: post.location || post.locationName || '', text };
+}
+
+async function lever(url) {
+  // jobs.lever.co/{co}/{id} (also api.eu.lever.co)
+  const m = url.match(/lever\.co\/([^/?#]+)\/([0-9a-f-]{8,})/i);
+  if (!m) return null;
+  const [, co, id] = m;
+  const eu = /jobs\.eu\.lever\.co/.test(url);
+  const host = eu ? 'api.eu.lever.co' : 'api.lever.co';
+  const j = await getJson(`https://${host}/v0/postings/${co}/${id}`);
+  const parts = [j.descriptionPlain || htmlToText(j.description)];
+  for (const l of (j.lists || [])) parts.push(`\n${l.text}\n${htmlToText(l.content)}`);
+  if (j.additionalPlain || j.additional) parts.push(j.additionalPlain || htmlToText(j.additional));
+  return { title: j.text || '', company: co, location: j.categories?.location || '', text: parts.filter(Boolean).join('\n').trim() };
+}
+
+async function workday(url) {
+  // {tenant}.{dc}.myworkdayjobs.com[/{locale}]/{site}/job/{path}_{reqid}
+  const m = url.match(/^https:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([^/?#]+)\/job\/(.+?)(?:\?.*)?$/);
+  if (!m) return null;
+  const [, tenant, dc, site, jobPath] = m;
+  const host = `${tenant}.${dc}.myworkdayjobs.com`;
+  // CXS job-detail endpoint mirrors the careers path after /job/
+  const j = await getJson(`https://${host}/wday/cxs/${tenant}/${site}/job/${jobPath}`, {
+    headers: { 'user-agent': UA, accept: 'application/json' },
+  });
+  const info = j?.jobPostingInfo || {};
+  const text = info.jobDescription ? htmlToText(info.jobDescription) : '';
+  return { title: info.title || '', company: tenant, location: info.location || '', text };
+}
+
+const PROVIDERS = [greenhouse, ashby, lever, workday];
+
+async function main() {
+  const args = process.argv.slice(2);
+  const json = args.includes('--json');
+  const url = args.find(a => /^https?:\/\//.test(a));
+  if (!url) { process.stderr.write('usage: node fetch-jd.mjs <url> [--json]\n'); process.exit(2); }
+
+  let result = null;
+  for (const p of PROVIDERS) {
+    try {
+      const r = await p(url);
+      if (r && (r.text || '').length >= MIN_USEFUL) { result = r; break; }
+    } catch { /* try next / fall back */ }
+  }
+
+  if (!result) process.exit(1); // signal caller to fall back to WebFetch
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result));
+  } else {
+    const head = [result.title && `# ${result.title}`, result.company && `Company: ${result.company}`, result.location && `Location: ${result.location}`].filter(Boolean).join('\n');
+    process.stdout.write(`${head}\n\n${result.text}\n`);
+  }
+}
+
+main().catch(err => { process.stderr.write(`fetch-jd error: ${err.message}\n`); process.exit(1); });

--- a/fetch-jd.mjs
+++ b/fetch-jd.mjs
@@ -56,14 +56,23 @@ async function getJson(url, opts = {}) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   // Forward a caller-supplied signal so the timeout is always enforced (using
-  // controller.signal) without ignoring an external abort.
-  if (opts.signal) opts.signal.addEventListener('abort', () => controller.abort(), { once: true });
+  // controller.signal) without ignoring an external abort — including one that
+  // is already aborted before we attach the listener (the 'abort' event does not
+  // fire retroactively).
+  let forwardAbort;
+  if (opts.signal?.aborted) {
+    controller.abort(opts.signal.reason);
+  } else if (opts.signal) {
+    forwardAbort = () => controller.abort(opts.signal.reason);
+    opts.signal.addEventListener('abort', forwardAbort, { once: true });
+  }
   const headers = { 'user-agent': UA, accept: 'application/json', ...(opts.headers || {}) };
   try {
     const res = await fetch(url, { ...opts, headers, signal: controller.signal });
     if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
     return res.json();
   } finally {
+    if (forwardAbort) opts.signal.removeEventListener('abort', forwardAbort);
     clearTimeout(timer);
   }
 }

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -21,7 +21,11 @@ This complements — does not replace — the per-URL liveness gate in `auto-pip
 1. **Read** `data/pipeline.md` → search for `- [ ]` items in the "Pending" section. Run the **Liveness sweep** (above) first and drop any expired entries before continuing.
 2. **For each surviving pending URL**:
    a. Claim the next sequential `REPORT_NUM` atomically by running `node reserve-report-num.mjs` (and release the sentinel using `node reserve-report-num.mjs --release <num>` after the report is written)
-   b. **Extract JD** using Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
+   b. **Extract JD (token-efficient order):**
+      1. **Provider API first (cheapest):** `node fetch-jd.mjs "{url}"` — clean JD text via the ATS API (Greenhouse/Ashby/Lever/Workday), ~80-90% fewer tokens than a page scrape and no SPA mis-fetch. Use its stdout as the JD.
+      2. **Playwright on API miss / for liveness:** if `fetch-jd.mjs` exits non-zero, `browser_navigate` then `browser_snapshot` **with `filename:` to save the snapshot to a file** — then read/grep the file for the JD + liveness signals. Do NOT return the full a11y tree into context.
+      3. **WebFetch / WebSearch:** last-resort fallbacks for static pages.
+      For high-value roles, still run a quick Playwright liveness check (navigate + saved snapshot, grep for expired signals) even when the API returned the JD.
    c. If the URL is not accessible → mark as `- [!]` with a note and continue
    d. **Execute full auto-pipeline**: Evaluation A-F → Report .md → PDF (if score >= `auto_pdf_score_threshold`) → Tracker
    e. **Move from "Pending" to "Processed"**: `- [x] #NNN | URL | Company | Role | Score/5 | PDF ✅/❌`
@@ -64,9 +68,10 @@ read as having empty values for the missing trailing columns.
 
 ## Intelligent JD detection from URL
 
-1. **Playwright (preferred):** `browser_navigate` + `browser_snapshot`. Works with all SPAs.
-2. **WebFetch (fallback):** For static pages or when Playwright is unavailable.
-3. **WebSearch (last resort):** Search in secondary portals that index the JD.
+1. **Provider API (preferred — cheapest):** `node fetch-jd.mjs "{url}"` returns clean JD text via the ATS API (Greenhouse/Ashby/Lever/Workday). ~80-90% fewer tokens than scraping a page, and no SPA mis-fetch. Exits non-zero on unknown provider / API miss → fall through.
+2. **Playwright (liveness + API-miss fallback):** `browser_navigate` + `browser_snapshot` **saved to a file via `filename:`**, then grep the file — never dump the full a11y tree into context. Use for real-time liveness verification and when the API misses.
+3. **WebFetch (fallback):** For static pages or when the above are unavailable.
+4. **WebSearch (last resort):** Search secondary portals that index the JD.
 
 **Special cases:**
 - **LinkedIn**: May require login → mark `[!]` and ask the user to paste the text

--- a/reserve-report-num.mjs
+++ b/reserve-report-num.mjs
@@ -124,8 +124,8 @@ function gc() {
 const [,, cmd, arg] = process.argv;
 
 if (cmd === '--release') {
-  if (!arg || !/^\d{1,3}$/.test(arg)) {
-    process.stderr.write('Usage: node reserve-report-num.mjs --release <NNN>\n');
+  if (!arg || !/^\d+$/.test(arg)) {
+    process.stderr.write('Usage: node reserve-report-num.mjs --release <NUM>\n');
     process.exit(1);
   }
   releaseSlot(parseInt(arg, 10));

--- a/reserve-report-num.mjs
+++ b/reserve-report-num.mjs
@@ -63,7 +63,7 @@ function maxSlot() {
   const entries = readdirSync(REPORTS_DIR);
   let max = 0;
   for (const name of entries) {
-    const m = name.match(/^(\d{3})-/);
+    const m = name.match(/^(\d+)-/);
     if (m) max = Math.max(max, parseInt(m[1], 10));
   }
   return max;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8208,6 +8208,43 @@ try {
   if (__pluginTmp) { try { rmSync(__pluginTmp, { recursive: true, force: true }); } catch {} }
 }
 
+// ── 50. fetch-jd.mjs (JD provider pre-fetch) + two-stage report gate ──
+console.log('\n50. fetch-jd.mjs (JD provider pre-fetch) + two-stage report gate');
+
+try {
+  const { htmlToText, detectProvider } = await import(pathToFileURL(join(ROOT, 'fetch-jd.mjs')).href);
+  const { readFileSync } = await import('node:fs');
+
+  // htmlToText: entity-decode THEN strip tags (Greenhouse content is entity-encoded)
+  const t = htmlToText('&lt;p&gt;Senior &amp; Staff&lt;/p&gt;<script>x</script><b>Eng</b>');
+  if (!t.includes('<') && t.includes('Senior & Staff') && t.includes('Eng')) {
+    pass('fetch-jd htmlToText decodes entities and strips tags');
+  } else {
+    fail(`fetch-jd htmlToText unexpected output: ${JSON.stringify(t)}`);
+  }
+
+  // detectProvider: host-based ATS classification + null fallback
+  if (detectProvider('https://job-boards.greenhouse.io/x/jobs/1') === 'greenhouse'
+      && detectProvider('https://jobs.ashbyhq.com/x/uuid') === 'ashby'
+      && detectProvider('https://jobs.lever.co/x/id') === 'lever'
+      && detectProvider('https://x.wd5.myworkdayjobs.com/Y/job/Z') === 'workday'
+      && detectProvider('https://example.com/job') === null) {
+    pass('fetch-jd detectProvider classifies all ATS providers + null fallback');
+  } else {
+    fail('fetch-jd detectProvider misclassified a provider URL');
+  }
+
+  // two-stage gate present in the batch worker prompt
+  const bp = readFileSync(join(ROOT, 'batch/batch-prompt.md'), 'utf-8');
+  if (/Paso 2\.5/.test(bp) && /auto_pdf_score_threshold/.test(bp)) {
+    pass('batch-prompt two-stage gate (Paso 2.5) reads auto_pdf_score_threshold');
+  } else {
+    fail('batch-prompt two-stage gate missing or not referencing auto_pdf_score_threshold');
+  }
+} catch (e) {
+  fail(`fetch-jd / two-stage gate tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -105,6 +105,7 @@ const SYSTEM_PATHS = [
   'scan.mjs',
   'scan-ats-full.mjs',
   'match-star.mjs',
+  'fetch-jd.mjs',
   'providers/',
   'doctor.mjs',
   'check-liveness.mjs',


### PR DESCRIPTION
## Problem

Batch and pipeline workers fetch each offer's JD by WebFetching the **full HTML page** (`batch-prompt.md`: "if file empty, WebFetch `{{URL}}`"). For modern ATS pages this is both expensive (10–30k tokens of nav/markup per worker) and unreliable — JS-heavy boards (Ashby, Workday, Greenhouse) frequently mis-fetch and produce wrong-company evaluations.

## Change

Pre-fetch the JD from the provider's **per-job API** (clean text), and only write full reports/PDFs for offers worth applying to.

- **`fetch-jd.mjs` (new):** given a job URL, returns the JD body as clean text via the ATS provider's per-job endpoint — Greenhouse (`/v1/boards/{b}/jobs/{id}`), Ashby (posting-api), Lever (`/v0/postings/{co}/{id}`); Workday best-effort. Decodes HTML entities then strips tags. Exits non-zero on an unknown provider / API miss so callers can fall back. No new dependencies (global `fetch`).
- **`batch/batch-runner.sh`:** pre-fetch the JD into `jd_file` via a zero-LLM shell call before spawning each worker; on a miss, remove `jd_file` so the worker falls back to its existing WebFetch path. Also hardens `next_report_num_unlocked` against non-numeric report-file prefixes.
- **`batch/batch-prompt.md`:** two-stage gate. The full A–G reasoning still runs to compute the score, but offers scoring **below `auto_pdf_score_threshold`** get an abbreviated report (header + `## Machine Summary` + a short verdict) and skip PDF generation. The header, Machine Summary, and tracker line are written in **both** branches, so `merge-tracker.mjs` and `verify-pipeline.mjs` are unaffected.
- **`modes/pipeline.md`:** for in-session runs, prefer `fetch-jd.mjs` for JD extraction; use Playwright only for liveness / API-miss, with `browser_snapshot` saved to a file via `filename:` instead of dumping the full accessibility tree into context.
- **`reserve-report-num.mjs`:** fix `maxSlot()` regex `/^(\d{3})-/` → `/^(\d+)-/`. The 3-digit-only match ignored every report numbered ≥ 1000, so once a board crossed 999 reports the reserver handed out stale low numbers that collided with existing reports.

## Impact

- ~80–90% fewer worker input tokens on offers whose provider has an API.
- Sub-threshold offers no longer pay for a full report + PDF that won't be used.
- The API fetch fixes the SPA wrong-company mis-fetch.
- Fully backward compatible: any unknown provider / API miss falls back to the existing WebFetch path.

## Testing

- `node test-all.mjs` → **289 passed, 0 failed** on top of `main`.
- `fetch-jd.mjs` verified live against real Greenhouse, Ashby, Lever, and Workday job URLs (clean JD text, correct titles, graceful exit-1 on unknown hosts).
- End-to-end batch run confirmed: API pre-fetch where available, WebFetch fallback otherwise, abbreviated reports + skipped PDFs for sub-threshold scores, clean tracker merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a two-stage evaluation gate controlled by `auto_pdf_score_threshold` (default `3.0`), enabling an **ABREVIADO** report and skipping PDF generation for low global scores.
  * Introduced provider API–based job description fetching for faster, more reliable JD extraction, with fallback behavior for when provider extraction is unavailable.

* **Bug Fixes & Improvements**
  * Improved report numbering by ignoring non-numeric report identifiers; relaxed release-number validation to support larger numeric ranges.
  * Hardened per-offer JD pre-fetch behavior by using a clean local JD when available, otherwise reverting to the existing fallback path.
  * Added provider-aware JD normalization (clean text output) to improve downstream report content consistency.

* **Documentation**
  * Updated pipeline workflow and URL-based JD detection guidance to reflect the new extraction order and snapshot-based Playwright fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->