### PR TITLE
fix(security): harden local-parser argv and reverse-scan SSRF

### DIFF
--- a/providers/local-parser.mjs
+++ b/providers/local-parser.mjs
@@ -2,7 +2,9 @@
 /** @typedef {import('./_types.js').Provider} Provider */
 
 import { execFile } from 'child_process';
-import { existsSync } from 'fs';
+import { realpathSync } from 'fs';
+import { resolve, sep } from 'path';
+import { fileURLToPath } from 'url';
 import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
@@ -10,10 +12,47 @@ const execFileAsync = promisify(execFile);
 const LOCAL_PARSER_TIMEOUT_MS = 20_000;
 const LOCAL_PARSER_MAX_BUFFER_BYTES = 2_000_000;
 
+// `parser.command` / `parser.script` come from portals.yml, which on a shared or
+// template config is not fully trusted. The command must be a known interpreter
+// or a file inside this project — never an arbitrary binary like `rm` or `curl`.
+const PROJECT_ROOT = realpathSync(resolve(fileURLToPath(new URL('..', import.meta.url))));
+const ALLOWED_INTERPRETERS = new Set(['python3', 'python', 'node', 'deno', 'bun', 'sh', 'bash']);
+
+// `{careers_url}` and `{company}` are interpolated into the parser's argv. Validate
+// them so an interpolated value can never be read as a CLI flag (argument injection).
+function safeCareersUrl(value) {
+  if (!value) return '';
+  let url;
+  try {
+    url = new URL(String(value));
+  } catch {
+    throw new Error(`local-parser: careers_url is not a valid URL: ${value}`);
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`local-parser: careers_url must be http(s): ${value}`);
+  }
+  return url.href;
+}
+
+function safeCompany(value) {
+  if (!value) return '';
+  const name = String(value).trim();
+  // execFile passes args verbatim (no shell), so the only injection risk is a
+  // value that begins like a CLI flag.
+  if (name.startsWith('-')) {
+    throw new Error(`local-parser: company name cannot start with '-': ${value}`);
+  }
+  return name;
+}
+
+// Only validate a placeholder's value when the arg actually uses it — a fixed
+// `parser.script` must not be rejected because some unrelated `{company}` value
+// has punctuation it never sees.
 function expandParserArg(value, entry) {
-  return String(value)
-    .replaceAll('{careers_url}', entry.careers_url || '')
-    .replaceAll('{company}', entry.name || '');
+  let out = String(value);
+  if (out.includes('{careers_url}')) out = out.replaceAll('{careers_url}', safeCareersUrl(entry.careers_url));
+  if (out.includes('{company}')) out = out.replaceAll('{company}', safeCompany(entry.name));
+  return out;
 }
 
 function getParserScriptPath(entry) {
@@ -37,6 +76,49 @@ function buildParserArgs(entry) {
   if (Array.isArray(parser.args)) args.push(...parser.args);
 
   return args.map(arg => expandParserArg(arg, entry));
+}
+
+// Resolve a configured path and confirm it stays inside the project tree.
+function resolveInsideRoot(rawPath) {
+  const resolved = realpathSync(resolve(PROJECT_ROOT, String(rawPath)));
+  if (resolved !== PROJECT_ROOT && !resolved.startsWith(PROJECT_ROOT + sep)) {
+    throw new Error(`local-parser: path escapes the project root: ${rawPath}`);
+  }
+  return resolved;
+}
+
+// The command is either a whitelisted interpreter (resolved via PATH) or a script
+// that lives inside the repo. Anything else is rejected.
+function resolveCommand(command) {
+  const value = String(command || '');
+  if (!value) throw new Error('local-parser: parser.command is required');
+  if (!value.includes('/') && ALLOWED_INTERPRETERS.has(value)) return value;
+  return resolveInsideRoot(value);
+}
+
+// Validate the whole invocation and return what to spawn. Throws on anything unsafe.
+function resolveInvocation(entry) {
+  const rawCommand = String(entry.parser?.command || '');
+  const command = resolveCommand(rawCommand);
+  const args = buildParserArgs(entry);
+  const scriptPath = getParserScriptPath(entry);
+
+  const usesInterpreter = !rawCommand.includes('/') && ALLOWED_INTERPRETERS.has(rawCommand);
+  if (usesInterpreter) {
+    // A whitelisted interpreter must run an in-repo script as its FIRST argument.
+    // Anything before the script is an interpreter option (node --eval / --require,
+    // python -c, …) that could execute arbitrary code, so require the script to lead.
+    if (!scriptPath) throw new Error('local-parser: interpreter command requires an in-repo parser script');
+    resolveInsideRoot(scriptPath);
+    if (args[0] !== scriptPath) {
+      throw new Error('local-parser: the parser script must be the interpreter\'s first argument');
+    }
+  } else if (scriptPath) {
+    // command is an in-repo file; keep any detected script path inside the repo too.
+    resolveInsideRoot(scriptPath);
+  }
+
+  return { command, args };
 }
 
 function normalizeJobUrl(rawUrl, baseUrl) {
@@ -75,11 +157,14 @@ function normalizeParserJob(job, entry) {
 
 async function runLocalParser(entry) {
   const parser = entry.parser || {};
-  const args = buildParserArgs(entry);
+  const { command, args } = resolveInvocation(entry);
   const timeout = Number(parser.timeout_ms || LOCAL_PARSER_TIMEOUT_MS);
   const maxBuffer = Number(parser.max_buffer_bytes || LOCAL_PARSER_MAX_BUFFER_BYTES);
 
-  const { stdout } = await execFileAsync(parser.command, args, {
+  // cwd is pinned to the project root so a relative script arg resolves to the
+  // same file resolveInvocation() validated, regardless of the caller's cwd.
+  const { stdout } = await execFileAsync(command, args, {
+    cwd: PROJECT_ROOT,
     timeout,
     maxBuffer,
     windowsHide: true,
@@ -109,8 +194,13 @@ export default {
   detect(entry) {
     if (!entry.parser?.command) return null;
 
-    const scriptPath = getParserScriptPath(entry);
-    if (scriptPath && !existsSync(scriptPath)) return null;
+    // An invocation we can't safely resolve (unknown command, out-of-repo or
+    // missing script, inline-code flags) is not runnable — skip it.
+    try {
+      resolveInvocation(entry);
+    } catch {
+      return null;
+    }
 
     return { url: entry.careers_url || 'local-parser' };
   },

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -46,16 +46,30 @@ const PIPELINE_PATH = 'data/pipeline.md';
 const CACHE_DIR = 'data/cache/ats-companies';
 const CACHE_TTL_HOURS = 24;
 // Tracks `main` deliberately: the dataset's value is freshness (new boards
-// appear weekly), so pinning a commit would defeat the purpose. The integrity
-// boundary is SLUG_RE below — every entry is validated against a safe charset
-// before it is interpolated into a provider URL, so a tampered dataset can at
-// worst name boards that don't exist.
+// appear weekly), so pinning a commit would defeat the purpose. Integrity rests
+// on two layers instead: SLUG_RE validates every entry against a safe charset
+// before interpolation, and entryOnHost (below) re-parses each finished
+// careers_url and drops anything that doesn't resolve to the ATS's own host —
+// so a tampered dataset can at worst name boards that don't exist.
 const DATASET_BASE = 'https://raw.githubusercontent.com/Feashliaa/job-board-aggregator/main/data';
 const CONCURRENCY = 20;
 
 // Dataset entries are external input destined for URL interpolation — reject
 // anything outside a conservative slug charset.
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+
+// SSRF guard / defense in depth: confirm a constructed careers_url actually
+// resolves to the expected ATS host before it reaches provider.fetch. Returns
+// the synthetic entry, or null if the URL won't parse or the host isn't canonical.
+export function entryOnHost(name, careersUrl, isCanonicalHost) {
+  let hostname;
+  try {
+    ({ hostname } = new URL(careersUrl));
+  } catch {
+    return null;
+  }
+  return isCanonicalHost(hostname) ? { name, careers_url: careersUrl } : null;
+}
 
 // Each source: the provider module that does the fetching, plus how to turn a
 // dataset entry into a synthetic PortalEntry the provider can detect/fetch.
@@ -64,19 +78,22 @@ const SOURCES = {
     provider: greenhouse,
     dataset: `${DATASET_BASE}/greenhouse_companies.json`,
     toEntry: (slug) => SLUG_RE.test(String(slug))
-      ? { name: String(slug), careers_url: `https://job-boards.greenhouse.io/${slug}` } : null,
+      ? entryOnHost(String(slug), `https://job-boards.greenhouse.io/${slug}`, h => h === 'job-boards.greenhouse.io')
+      : null,
   },
   lever: {
     provider: lever,
     dataset: `${DATASET_BASE}/lever_companies.json`,
     toEntry: (slug) => SLUG_RE.test(String(slug))
-      ? { name: String(slug), careers_url: `https://jobs.lever.co/${slug}` } : null,
+      ? entryOnHost(String(slug), `https://jobs.lever.co/${slug}`, h => h === 'jobs.lever.co')
+      : null,
   },
   ashby: {
     provider: ashby,
     dataset: `${DATASET_BASE}/ashby_companies.json`,
     toEntry: (slug) => SLUG_RE.test(String(slug))
-      ? { name: String(slug), careers_url: `https://jobs.ashbyhq.com/${slug}` } : null,
+      ? entryOnHost(String(slug), `https://jobs.ashbyhq.com/${slug}`, h => h === 'jobs.ashbyhq.com')
+      : null,
   },
   workday: {
     provider: workday,
@@ -85,7 +102,11 @@ const SOURCES = {
     toEntry: (line) => {
       const [tenant, instance, site] = String(line).split('|');
       if (![tenant, instance, site].every(p => p && SLUG_RE.test(p))) return null;
-      return { name: tenant, careers_url: `https://${tenant}.${instance}.myworkdayjobs.com/${site}` };
+      return entryOnHost(
+        tenant,
+        `https://${tenant}.${instance}.myworkdayjobs.com/${site}`,
+        h => h === `${tenant}.${instance}.myworkdayjobs.com` && h.endsWith('.myworkdayjobs.com'),
+      );
     },
   },
 };

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -694,6 +694,82 @@ if (
   fail('portals example still points at a bundled Cohere parser');
 }
 
+// Security hardening: command allowlist, in-repo script containment, careers_url/company validation.
+try {
+  const localParser = (await import(pathToFileURL(join(ROOT, 'providers/local-parser.mjs')).href)).default;
+
+  if (localParser.detect({ name: 'X', careers_url: 'https://x.co', parser: { command: 'rm' } }) === null) {
+    pass('local-parser rejects a non-interpreter command (e.g. rm)');
+  } else {
+    fail('local-parser should reject a command that is not a whitelisted interpreter or in-repo script');
+  }
+
+  if (localParser.detect({ name: 'X', careers_url: 'https://x.co', parser: { command: 'python3', script: '/etc/passwd' } }) === null) {
+    pass('local-parser rejects a script outside the project root');
+  } else {
+    fail('local-parser should reject a script path that escapes the project root');
+  }
+
+  const okEntry = localParser.detect({
+    name: 'X', careers_url: 'https://x.co',
+    parser: { command: 'node', script: 'scan.mjs' },
+  });
+  if (okEntry && okEntry.url) pass('local-parser accepts a whitelisted interpreter + an in-repo script');
+  else fail('local-parser should accept a whitelisted interpreter with an in-repo script');
+
+  let rejectedUrl = false;
+  try {
+    await localParser.fetch({ name: 'X', careers_url: '--oops', parser: { command: 'python3', args: ['--url', '{careers_url}'] } });
+  } catch (e) {
+    rejectedUrl = /careers_url/.test(e.message);
+  }
+  if (rejectedUrl) pass('local-parser rejects a non-URL careers_url before spawning (argument injection guard)');
+  else fail('local-parser should reject a careers_url that is not http(s)');
+
+  let rejectedCompany = false;
+  try {
+    await localParser.fetch({ name: '--rf', careers_url: 'https://x.co', parser: { command: 'python3', args: ['--company', '{company}'] } });
+  } catch (e) {
+    rejectedCompany = /company/.test(e.message);
+  }
+  if (rejectedCompany) pass('local-parser rejects a company name that could be read as a flag');
+  else fail('local-parser should reject an unsafe company name');
+
+  if (localParser.detect({ name: 'X', careers_url: 'https://x.co', parser: { command: 'node', args: ['-e', 'process.exit(0)'] } }) === null) {
+    pass('local-parser rejects inline interpreter code (node -e ...)');
+  } else {
+    fail('local-parser should reject inline-code flags (-e/-c/--eval)');
+  }
+
+  if (localParser.detect({ name: 'X', careers_url: 'https://x.co', parser: { command: 'node', args: ['--eval=globalThis.x=1', 'scan.mjs'] } }) === null) {
+    pass('local-parser rejects interpreter options before the script (node --eval=… script)');
+  } else {
+    fail('local-parser should reject interpreter options preceding the parser script');
+  }
+
+  if (localParser.detect({ name: 'Yahoo!', careers_url: 'https://x.co', parser: { command: 'node', script: 'scan.mjs' } })?.url) {
+    pass('local-parser accepts a company name with punctuation when {company} is unused');
+  } else {
+    fail('local-parser should not reject a fixed-script entry over an unused company placeholder');
+  }
+} catch (e) {
+  fail(`local-parser hardening tests crashed: ${e.message}`);
+}
+
+// Reverse-scan SSRF guard: a constructed careers_url must resolve to the ATS's own host.
+try {
+  const { entryOnHost } = await import(pathToFileURL(join(ROOT, 'scan-ats-full.mjs')).href);
+  const canonical = entryOnHost('acme', 'https://jobs.lever.co/acme', (h) => h === 'jobs.lever.co');
+  const offHost = entryOnHost('acme', 'https://evil.example.com/acme', (h) => h === 'jobs.lever.co');
+  if (canonical && canonical.careers_url === 'https://jobs.lever.co/acme' && offHost === null) {
+    pass('scan-ats-full entryOnHost keeps canonical ATS hosts and drops others (SSRF guard)');
+  } else {
+    fail('scan-ats-full entryOnHost should keep canonical hosts and drop non-canonical ones');
+  }
+} catch (e) {
+  fail(`scan-ats-full host-guard test crashed: ${e.message}`);
+}
+
 // ── 10. PORTALS CONFIG VALIDATOR ────────────────────────────────
 
 console.log('\n10. Portals config validator');


### PR DESCRIPTION
## What

Two security fixes in the zero-token scanner, both with tests.

### `providers/local-parser.mjs` — command / argument injection
The local-parser provider spawns a configured `parser.command` with `parser.args`, into which `{careers_url}` and `{company}` (from `portals.yml`) are interpolated. On a shared or community `portals.yml`, those are not fully trusted. Hardening:
- `parser.command` must be a known interpreter (`python3`, `node`, …) **or** a script inside the project root — never an arbitrary binary (`rm`, `curl`).
- a whitelisted interpreter must run an **in-repo script**, and inline-code flags (`node -e`, `python -c`, `bash -c`, …) are rejected — so config can't smuggle code through an otherwise-allowed interpreter.
- `parser.script` / a detected script arg must `realpath` inside the project root, and the process is spawned with `cwd` pinned there, so the file that runs is the one that was validated (no cwd-relative swap).
- `{careers_url}` (must be `http(s)`) and `{company}` (cannot start with `-`) are validated **only when the arg uses the placeholder**, so an interpolated value can never be read as a CLI flag (argument injection) without false-rejecting valid fixed-script entries like `Yahoo!`.

Spawning already used `execFile` (no shell); this closes the remaining argv vector. `detect()` fails closed.

### `scan-ats-full.mjs` — SSRF defense-in-depth
The reverse scanner builds ATS URLs from an external dataset. `SLUG_RE` already gates the charset; this adds `entryOnHost()`, which re-parses every finished `careers_url` and drops anything whose hostname isn't the ATS's canonical host (exact for Greenhouse/Lever/Ashby, `*.myworkdayjobs.com` for Workday) **before** it reaches `provider.fetch`. Keeps the deliberate `main`-tracking (freshness) while making the host invariant explicit and robust to future template/regex changes.

## Tests
8 behavioral tests added to the **Local Parser Contract** section of `test-all.mjs`. `node test-all.mjs --quick`: **288 passed, 0 failed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened ATS provider URL handling to only accept canonical host matches, rejecting off-host or mismatched careers links.
  * Strengthened local parser execution by constraining commands/arguments, enforcing project-root boundaries, blocking unsafe inline interpreter flags, and preventing argument injection.
* **Tests**
  * Added comprehensive security-hardening coverage for ATS host gating and local parser validation (allowlisted interpreters, path-escape prevention, and URL/company safety checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->