### PR TITLE
test(providers): add IBM board provider test coverage

### DIFF
--- a/providers/ibm.mjs
+++ b/providers/ibm.mjs
@@ -26,7 +26,7 @@ const MAX_RECORDS = 600; // safety cap on pagination
  * Builds the Elasticsearch post_filter from the entry's `ibm:` config.
  * @param {{ country?: string, categories?: string[] }} cfg
  */
-function buildPostFilter(cfg) {
+export function buildPostFilter(cfg) {
   const must = [];
   // Sanitize operator config: keep only non-empty trimmed strings so a stray/
   // mistyped entry can't inject empty or non-string filter terms.
@@ -39,6 +39,36 @@ function buildPostFilter(cfg) {
   const country = typeof cfg.country === 'string' ? cfg.country.trim() : '';
   if (country) must.push({ term: { field_keyword_05: country } });
   return { bool: { must } };
+}
+
+/**
+ * Normalizes one page of the IBM careers API response into job entries.
+ * Throws if the response doesn't carry the expected `hits.hits[]` shape, so a
+ * silent endpoint change surfaces as a hard error instead of empty results.
+ * @param {any} json - A single API response page.
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parseIbmResponse(json) {
+  const hits = json && json.hits && Array.isArray(json.hits.hits) ? json.hits.hits : null;
+  if (!hits) {
+    throw new Error(`ibm: unexpected API response — expected hits.hits[], got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`);
+  }
+
+  const out = [];
+  for (const h of hits) {
+    const s = (h && h._source) || {};
+    if (typeof s.title !== 'string' || s.title.trim() === '') continue;
+    if (typeof s.url !== 'string' || !/^https?:\/\//i.test(s.url.trim())) continue;
+    const loc = typeof s.field_keyword_19 === 'string' ? s.field_keyword_19.trim() : '';
+    const mode = typeof s.field_keyword_17 === 'string' ? s.field_keyword_17.trim() : '';
+    out.push({
+      title: s.title.trim(),
+      url: s.url.trim(),
+      company: 'IBM',
+      location: [loc, mode].filter(Boolean).join(' · '),
+    });
+  }
+  return out;
 }
 
 /** @type {Provider} */
@@ -81,29 +111,12 @@ export default {
         redirect: 'error',
       });
 
-      const hits = json && json.hits && Array.isArray(json.hits.hits) ? json.hits.hits : null;
-      if (!hits) {
-        throw new Error(`ibm: unexpected API response — expected hits.hits[], got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`);
-      }
-
-      for (const h of hits) {
-        const s = (h && h._source) || {};
-        if (typeof s.title !== 'string' || s.title.trim() === '') continue;
-        if (typeof s.url !== 'string' || !/^https?:\/\//i.test(s.url.trim())) continue;
-        const loc = typeof s.field_keyword_19 === 'string' ? s.field_keyword_19.trim() : '';
-        const mode = typeof s.field_keyword_17 === 'string' ? s.field_keyword_17.trim() : '';
-        out.push({
-          title: s.title.trim(),
-          url: s.url.trim(),
-          company: 'IBM',
-          location: [loc, mode].filter(Boolean).join(' · '),
-        });
-      }
+      out.push(...parseIbmResponse(json));
 
       // Stop on the first short page. IBM's `total` is unreliable (often
       // capped at the page size), so don't trust it for the loop bound —
       // MAX_RECORDS is the hard ceiling.
-      if (hits.length < PAGE_SIZE) break;
+      if (json.hits.hits.length < PAGE_SIZE) break;
     }
 
     return out;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3275,6 +3275,100 @@ try {
   fail(`glints provider tests crashed: ${e.message}`);
 }
 
+console.log('\n24. Provider — ibm');
+
+try {
+  const ibm = (await import(pathToFileURL(join(ROOT, 'providers/ibm.mjs')).href)).default;
+  const { parseIbmResponse, buildPostFilter } = await import(pathToFileURL(join(ROOT, 'providers/ibm.mjs')).href);
+
+  if (ibm.id === 'ibm') pass('ibm.id is "ibm"');
+  else fail(`ibm.id is ${JSON.stringify(ibm.id)}`);
+
+  // buildPostFilter — empty config yields no filter terms
+  if (buildPostFilter({}).bool.must.length === 0) pass('buildPostFilter({}) → no must terms');
+  else fail(`buildPostFilter({}) = ${JSON.stringify(buildPostFilter({}))}`);
+
+  // buildPostFilter — country + categories produce the expected facet terms
+  const pf = buildPostFilter({ country: 'Germany', categories: ['Software Engineering', 'Data & Analytics'] });
+  const countryTerm = pf.bool.must.find(m => m.term && m.term.field_keyword_05);
+  const catTerm = pf.bool.must.find(m => m.bool && m.bool.should);
+  if (countryTerm?.term.field_keyword_05 === 'Germany' && catTerm?.bool.should.length === 2) {
+    pass('buildPostFilter maps country → field_keyword_05 and categories → field_keyword_08 should[]');
+  } else {
+    fail(`buildPostFilter facets = ${JSON.stringify(pf)}`);
+  }
+
+  // buildPostFilter — sanitizes empty/non-string category entries
+  const sanitized = buildPostFilter({ categories: ['Valid', '', '   ', 42, null] });
+  const sanitizedShould = sanitized.bool.must.find(m => m.bool && m.bool.should)?.bool.should;
+  if (sanitizedShould?.length === 1 && sanitizedShould[0].term.field_keyword_08 === 'Valid') {
+    pass('buildPostFilter drops empty/non-string category entries');
+  } else {
+    fail(`buildPostFilter sanitization = ${JSON.stringify(sanitizedShould)}`);
+  }
+
+  // parseIbmResponse — happy path, location assembled from keyword_19 · keyword_17
+  const sample = {
+    hits: {
+      hits: [
+        { _source: { title: 'ML Engineer', url: 'https://ibm.com/careers/1', field_keyword_19: 'Berlin, Germany', field_keyword_17: 'Hybrid' } },
+        { _source: { title: 'Data Scientist', url: 'https://ibm.com/careers/2', field_keyword_19: 'Remote' } },
+      ],
+    },
+  };
+  const jobs = parseIbmResponse(sample);
+  if (jobs.length === 2 && jobs[0].company === 'IBM') pass('parseIbmResponse extracts 2 jobs with company "IBM"');
+  else fail(`parseIbmResponse returned ${JSON.stringify(jobs)}`);
+
+  if (jobs[0].location === 'Berlin, Germany · Hybrid') pass('parseIbmResponse joins location · work mode');
+  else fail(`row 0 location = ${JSON.stringify(jobs[0]?.location)}`);
+
+  if (jobs[1].location === 'Remote') pass('parseIbmResponse omits the separator when work mode is absent');
+  else fail(`row 1 location = ${JSON.stringify(jobs[1]?.location)}`);
+
+  // parseIbmResponse — drops title-less, url-less, and non-http(s) entries
+  const dirty = parseIbmResponse({
+    hits: {
+      hits: [
+        { _source: { title: '', url: 'https://ibm.com/careers/3' } },
+        { _source: { title: 'No URL' } },
+        { _source: { title: 'Bad scheme', url: 'ftp://ibm.com/careers/4' } },
+        { _source: { title: 'Good', url: 'https://ibm.com/careers/5' } },
+      ],
+    },
+  });
+  if (dirty.length === 1 && dirty[0].title === 'Good') pass('parseIbmResponse drops title-less, url-less, and non-http(s) entries');
+  else fail(`parseIbmResponse dirty = ${JSON.stringify(dirty)}`);
+
+  // parseIbmResponse — throws on unexpected shape (endpoint drift surfaces loudly)
+  let drifted = false;
+  try { parseIbmResponse({ results: [] }); } catch { drifted = true; }
+  if (drifted) pass('parseIbmResponse throws when hits.hits[] is missing');
+  else fail('parseIbmResponse should throw on unexpected API response shape');
+
+  // fetch() — paginates until a short page, via mock ctx
+  let calls = 0;
+  const mockCtx = {
+    fetchJson: async (url, opts) => {
+      calls++;
+      if (url !== 'https://www-api.ibm.com/search/api/v2') throw new Error(`unexpected url ${url}`);
+      if (opts?.method !== 'POST') throw new Error('Expected POST');
+      // Page 1: a full page (30 hits) → keep paging; page 2: short page → stop.
+      const n = calls === 1 ? 30 : 2;
+      const hits = Array.from({ length: n }, (_, i) => ({
+        _source: { title: `Role ${calls}-${i}`, url: `https://ibm.com/careers/${calls}-${i}` },
+      }));
+      return { hits: { hits } };
+    },
+  };
+  const fetched = await ibm.fetch({ name: 'IBM', ibm: { country: 'Germany' } }, mockCtx);
+  if (calls === 2 && fetched.length === 32) pass('ibm.fetch() paginates and stops on the first short page');
+  else fail(`ibm.fetch() made ${calls} calls, returned ${fetched.length} jobs`);
+
+} catch (e) {
+  fail(`ibm provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
Closes #1093. Follow-up to the #1080 review request.

## What

Gives `providers/ibm.mjs` a test block, matching the convention used by the other logic-bearing providers (workable / recruitee / jobstreet / glints).

- Extracted response parsing into an exported `parseIbmResponse(json)` that **throws** on an unexpected shape, so a silent endpoint change fails loudly instead of returning empty results.
- Exported `buildPostFilter(cfg)` so facet building + category sanitization is testable.
- Added a `Provider — ibm` block (10 assertions) in `test-all.mjs`: facet building, category sanitization, location assembly (`loc · mode`), dropping title-less/url-less/non-http(s) entries, the throw-on-drift guard, and a mock-`ctx` `fetch()` exercising pagination + the short-page stop.

## No behavior change

`fetch()` now calls `parseIbmResponse` per page; the parsing and pagination logic is identical to before — pure refactor for testability.

## Testing

`node test-all.mjs` — all 10 new IBM assertions pass. (The pre-existing `Dashboard build failed` check fails identically on a clean tree, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)