### PR TITLE
fix(followup): use the real application date from notes, not the eval date

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -114,6 +114,17 @@ export function parseDate(dateStr) {
   return new Date(dateStr.trim());
 }
 
+// The tracker `date` column is often the evaluation date, while the real
+// submission date is recorded in the notes as "Applied YYYY-MM-DD" (or
+// "APPLIED ..."). Prefer that so cadence reflects when the application actually
+// went out, not when the role was evaluated. Returns the first such date, or
+// null when the notes don't carry one (caller falls back to the date column).
+export function parseAppliedDate(notes) {
+  if (!notes) return null;
+  const m = String(notes).match(/\bapplied\s+(\d{4}-\d{2}-\d{2})/i);
+  return m ? m[1] : null;
+}
+
 export function daysBetween(d1, d2) {
   return Math.floor((d2 - d1) / (1000 * 60 * 60 * 24));
 }
@@ -259,7 +270,9 @@ function analyze() {
     const normalized = normalizeStatus(app.status);
     if (!ACTIONABLE_STATUSES.includes(normalized)) continue;
 
-    const appDate = parseDate(app.date);
+    // Prefer the "Applied YYYY-MM-DD" date from notes; fall back to the column.
+    const appliedDate = parseAppliedDate(app.notes) || app.date;
+    const appDate = parseDate(appliedDate);
     if (!appDate) continue;
 
     const daysSinceApp = daysBetween(appDate, now);
@@ -277,7 +290,7 @@ function analyze() {
     }
 
     const urgency = computeUrgency(normalized, daysSinceApp, daysSinceLastFollowup, followupCount);
-    const nextFollowupDate = computeNextFollowupDate(normalized, app.date, lastFollowupDate, followupCount);
+    const nextFollowupDate = computeNextFollowupDate(normalized, appliedDate, lastFollowupDate, followupCount);
     const nextDate = nextFollowupDate ? parseDate(nextFollowupDate) : null;
     const daysUntilNext = nextDate ? daysBetween(now, nextDate) : null;
 
@@ -287,6 +300,7 @@ function analyze() {
     entries.push({
       num: app.num,
       date: app.date,
+      appliedDate,
       company: app.company,
       role: app.role,
       status: normalized,

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1165,6 +1165,36 @@ try {
     fail('parseDate validation wrong');
   }
 
+  // parseAppliedDate — extracts the real submission date from notes (the
+  // tracker `date` column is the evaluation date), case-insensitive.
+  if (cadence.parseAppliedDate('Applied 2026-06-09 via Personio; raised part-time') === '2026-06-09') {
+    pass('parseAppliedDate extracts "Applied YYYY-MM-DD" from notes');
+  } else {
+    fail(`parseAppliedDate got ${JSON.stringify(cadence.parseAppliedDate('Applied 2026-06-09 via Personio; raised part-time'))}`);
+  }
+  if (cadence.parseAppliedDate('APPLIED 2026-06-17 (German CV; jobId=104170)') === '2026-06-17') {
+    pass('parseAppliedDate is case-insensitive (APPLIED)');
+  } else {
+    fail('parseAppliedDate should match uppercase APPLIED');
+  }
+  // First "Applied" date wins even when a later status date follows.
+  if (cadence.parseAppliedDate('Applied 2026-06-09. No response; discarded 2026-06-18.') === '2026-06-09') {
+    pass('parseAppliedDate takes the first applied date, not a later status date');
+  } else {
+    fail('parseAppliedDate should take the first applied date');
+  }
+  if (cadence.parseAppliedDate('On-archetype fit; no submission yet') === null && cadence.parseAppliedDate('') === null) {
+    pass('parseAppliedDate returns null when notes carry no applied date');
+  } else {
+    fail('parseAppliedDate should return null without an applied date');
+  }
+  // "reapplied" must not be mistaken for an applied date (word boundary).
+  if (cadence.parseAppliedDate('reapplied 2026-06-09 after rejection') === null) {
+    pass('parseAppliedDate does not match inside "reapplied"');
+  } else {
+    fail('parseAppliedDate should not match the date inside "reapplied"');
+  }
+
   // Status normalization (strips bold + trailing date, lowercases, maps aliases)
   if (cadence.normalizeStatus('**Applied** 2026-05-01') === 'applied') {
     pass('normalizeStatus strips bold + trailing date and lowercases');


### PR DESCRIPTION
Closes #1096.

## Problem

`followup-cadence.mjs` keys `daysSinceApplication` and `nextFollowupDate` off the tracker's `date` column, which in practice is often the **evaluation date**. The real submission date is recorded in the notes as `Applied YYYY-MM-DD`, so applications get flagged **overdue** days/weeks early. Real example: an OVGU role evaluated 2026-06-01 but applied 2026-06-14 reported as "17d overdue" when it was 4d old and not yet due.

## Fix

- New exported `parseAppliedDate(notes)` — first case-insensitive `\bapplied YYYY-MM-DD` match (word boundary so "reapplied" doesn't match), else `null`.
- `analyze()` resolves the application date as `parseAppliedDate(notes) || dateColumn`, uses it for the cadence math, and adds an `appliedDate` field to each entry. The `date` column value is left untouched for transparency.
- **Backward-compatible:** entries whose notes carry no applied date behave exactly as before.

## Testing

`node test-all.mjs` — extends the existing followup-cadence block with 5 `parseAppliedDate` assertions (extraction, case-insensitivity, first-date-wins, null fallback, "reapplied" word-boundary), all green. Verified on a real tracker: the OVGU entry now reports 4d/waiting instead of 17d/overdue, and the actionable count drops accordingly. The pre-existing `Dashboard build failed` check fails identically on a clean tree — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application dates are now extracted from notes text (case-insensitive format) to enhance follow-up cadence calculations and scheduling accuracy.
  * Follow-up output now includes the extracted application date for improved tracking and reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->