### PR TITLE
fix(scan): sanitize external metadata before writes

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -446,8 +446,15 @@ function normalizeScanScalar(value) {
     .trim();
 }
 
+const MARKDOWN_ESCAPE_CHARS = {
+  '\\': '\\\\',
+  '[': '\\[',
+  ']': '\\]',
+  '|': '\\|',
+};
+
 export function sanitizeMarkdownField(value) {
-  return normalizeScanScalar(value).replace(/[|[\]]/g, '\\$&');
+  return normalizeScanScalar(value).replace(/[\\[\]|]/g, char => MARKDOWN_ESCAPE_CHARS[char]);
 }
 
 export function sanitizeTsvField(value) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -450,19 +450,27 @@ const MARKDOWN_ESCAPE_CHARS = {
   '\\': '\\\\',
   '[': '\\[',
   ']': '\\]',
-  '|': '\\|',
 };
 
 export function sanitizeMarkdownField(value) {
-  return normalizeScanScalar(value).replace(/[\\[\]|]/g, char => MARKDOWN_ESCAPE_CHARS[char]);
+  return normalizeScanScalar(value)
+    .replace(/[\\[\]]/g, char => MARKDOWN_ESCAPE_CHARS[char])
+    .replace(/\|/g, '/');
+}
+
+function sanitizePipelineUrl(value) {
+  return normalizeScanScalar(value)
+    .replace(/[\\[\]]/g, char => MARKDOWN_ESCAPE_CHARS[char])
+    .replace(/\|/g, '%7C');
 }
 
 export function sanitizeTsvField(value) {
-  return normalizeScanScalar(value);
+  const normalized = normalizeScanScalar(value);
+  return /^[=+\-@]/.test(normalized) ? `'${normalized}` : normalized;
 }
 
 export function formatPipelineOffer(offer) {
-  const url = normalizeScanScalar(offer.url);
+  const url = sanitizePipelineUrl(offer.url);
   const company = sanitizeMarkdownField(offer.company);
   const title = sanitizeMarkdownField(offer.title);
   return `- [ ] ${url} | ${company} | ${title}`;

--- a/scan.mjs
+++ b/scan.mjs
@@ -446,6 +446,10 @@ function normalizeScanScalar(value) {
     .trim();
 }
 
+function normalizeScanUrl(value) {
+  return String(value ?? '').trim().split(/\s+/)[0] || '';
+}
+
 const MARKDOWN_ESCAPE_CHARS = {
   '\\': '\\\\',
   '[': '\\[',
@@ -459,7 +463,7 @@ export function sanitizeMarkdownField(value) {
 }
 
 function sanitizePipelineUrl(value) {
-  return normalizeScanScalar(value)
+  return normalizeScanUrl(value)
     .replace(/[\\[\]]/g, char => MARKDOWN_ESCAPE_CHARS[char])
     .replace(/\|/g, '%7C');
 }
@@ -478,7 +482,7 @@ export function formatPipelineOffer(offer) {
 
 export function formatScanHistoryRow(offer, date, status = 'added') {
   return [
-    offer.url,
+    normalizeScanUrl(offer.url),
     date,
     offer.source,
     offer.title,

--- a/scan.mjs
+++ b/scan.mjs
@@ -439,6 +439,40 @@ function loadSeenCompanyRoles() {
 
 // ── Pipeline writer ─────────────────────────────────────────────────
 
+function normalizeScanScalar(value) {
+  return String(value ?? '')
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/ {2,}/g, ' ')
+    .trim();
+}
+
+export function sanitizeMarkdownField(value) {
+  return normalizeScanScalar(value).replace(/[|[\]]/g, '\\$&');
+}
+
+export function sanitizeTsvField(value) {
+  return normalizeScanScalar(value);
+}
+
+export function formatPipelineOffer(offer) {
+  const url = normalizeScanScalar(offer.url);
+  const company = sanitizeMarkdownField(offer.company);
+  const title = sanitizeMarkdownField(offer.title);
+  return `- [ ] ${url} | ${company} | ${title}`;
+}
+
+export function formatScanHistoryRow(offer, date, status = 'added') {
+  return [
+    offer.url,
+    date,
+    offer.source,
+    offer.title,
+    offer.company,
+    status,
+    offer.location || '',
+  ].map(sanitizeTsvField).join('\t');
+}
+
 export function appendToPipeline(offers) {
   if (offers.length === 0) return;
 
@@ -451,9 +485,7 @@ export function appendToPipeline(offers) {
     // No Pendientes section — append at end before Procesadas
     const procIdx = text.indexOf('## Procesadas');
     const insertAt = procIdx === -1 ? text.length : procIdx;
-    const block = `\n${marker}\n\n` + offers.map(o =>
-      `- [ ] ${o.url} | ${o.company} | ${o.title}`
-    ).join('\n') + '\n\n';
+    const block = `\n${marker}\n\n` + offers.map(formatPipelineOffer).join('\n') + '\n\n';
     text = text.slice(0, insertAt) + block + text.slice(insertAt);
   } else {
     // Find the end of existing Pendientes content (next ## or end)
@@ -461,9 +493,7 @@ export function appendToPipeline(offers) {
     const nextSection = text.indexOf('\n## ', afterMarker);
     const insertAt = nextSection === -1 ? text.length : nextSection;
 
-    const block = '\n' + offers.map(o =>
-      `- [ ] ${o.url} | ${o.company} | ${o.title}`
-    ).join('\n') + '\n';
+    const block = '\n' + offers.map(formatPipelineOffer).join('\n') + '\n';
     text = text.slice(0, insertAt) + block + text.slice(insertAt);
   }
 
@@ -480,9 +510,7 @@ export function appendToScanHistory(offers, date, status = 'added') {
     writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\n', 'utf-8');
   }
 
-  const lines = offers.map(o =>
-    `${o.url}\t${date}\t${o.source}\t${o.title}\t${o.company}\t${status}\t${o.location || ''}`
-  ).join('\n') + '\n';
+  const lines = offers.map(o => formatScanHistoryRow(o, date, status)).join('\n') + '\n';
 
   appendFileSync(SCAN_HISTORY_PATH, lines, 'utf-8');
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1163,7 +1163,7 @@ try {
     url: 'https://jobs.example.com/123',
     source: 'local-parser',
     title: 'Senior Engineer | Growth\n- [ ] https://evil.example/job | EvilCorp | Injected',
-    company: 'ACME\tCorp | R&D',
+    company: 'ACME\\Corp\t| R&D',
     location: 'Remote\nEU',
   };
   const pipelineRow = formatPipelineOffer(hostileOffer);
@@ -1172,7 +1172,7 @@ try {
     pendingLines.length === 1 &&
     !pipelineRow.includes('\n') &&
     !pipelineRow.includes('\t') &&
-    pipelineRow.includes('ACME Corp \\| R&D') &&
+    pipelineRow.includes('ACME\\\\Corp \\| R&D') &&
     pipelineRow.includes('- \\[ \\] https://evil.example/job')
   ) {
     pass('scan pipeline writer sanitizes external metadata without creating injected checkboxes');
@@ -1186,7 +1186,7 @@ try {
     historyColumns.length === 7 &&
     !historyColumns.some(col => /[\r\n\t]/.test(col)) &&
     historyColumns[3].includes('- [ ] https://evil.example/job') &&
-    historyColumns[4] === 'ACME Corp | R&D' &&
+    historyColumns[4] === 'ACME\\Corp | R&D' &&
     historyColumns[6] === 'Remote EU'
   ) {
     pass('scan-history writer preserves row shape when metadata contains TSV control chars');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1160,22 +1160,25 @@ try {
   }
 
   const hostileOffer = {
-    url: 'https://jobs.example.com/123',
+    url: 'https://jobs.example.com/123|evil',
     source: 'local-parser',
     title: 'Senior Engineer | Growth\n- [ ] https://evil.example/job | EvilCorp | Injected',
-    company: 'ACME\\Corp\t| R&D',
-    location: 'Remote\nEU',
+    company: '=ACME\\Corp\t| R&D',
+    location: '@Remote\nEU',
   };
   const pipelineRow = formatPipelineOffer(hostileOffer);
   const pendingLines = pipelineRow.split('\n').filter(line => /^\s*- \[ \] https?:\/\//.test(line));
   if (
     pendingLines.length === 1 &&
+    pipelineRow.split('|').length === 3 &&
     !pipelineRow.includes('\n') &&
     !pipelineRow.includes('\t') &&
-    pipelineRow.includes('ACME\\\\Corp \\| R&D') &&
-    pipelineRow.includes('- \\[ \\] https://evil.example/job')
+    !pipelineRow.includes('\\|') &&
+    pipelineRow.includes('https://jobs.example.com/123%7Cevil') &&
+    pipelineRow.includes('=ACME\\\\Corp / R&D') &&
+    pipelineRow.includes('- \\[ \\] https://evil.example/job / EvilCorp / Injected')
   ) {
-    pass('scan pipeline writer sanitizes external metadata without creating injected checkboxes');
+    pass('scan pipeline writer preserves row shape without injected checkboxes or extra pipes');
   } else {
     fail(`scan pipeline metadata sanitizer produced unsafe row: ${pipelineRow}`);
   }
@@ -1186,10 +1189,10 @@ try {
     historyColumns.length === 7 &&
     !historyColumns.some(col => /[\r\n\t]/.test(col)) &&
     historyColumns[3].includes('- [ ] https://evil.example/job') &&
-    historyColumns[4] === 'ACME\\Corp | R&D' &&
-    historyColumns[6] === 'Remote EU'
+    historyColumns[4] === "'=ACME\\Corp | R&D" &&
+    historyColumns[6] === "'@Remote EU"
   ) {
-    pass('scan-history writer preserves row shape when metadata contains TSV control chars');
+    pass('scan-history writer preserves row shape and neutralizes spreadsheet formulas');
   } else {
     fail(`scan-history metadata sanitizer produced unsafe TSV row: ${JSON.stringify(historyColumns)}`);
   }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1018,7 +1018,13 @@ if (fileExists('VERSION')) {
 console.log('\n15. Location filter — always_allow tier');
 
 try {
-  const { buildLocationFilter, buildContentFilter, shouldDedupScanHistoryRow } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+  const {
+    buildLocationFilter,
+    buildContentFilter,
+    shouldDedupScanHistoryRow,
+    formatPipelineOffer,
+    formatScanHistoryRow,
+  } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
 
   const filter = buildLocationFilter({
     always_allow: ['belgium', 'brussels'],
@@ -1151,6 +1157,41 @@ try {
     pass('scan-history TTL rechecks old added URLs while permanent statuses stay deduped');
   } else {
     fail('scan-history TTL policy did not match expected recheck/permanent behavior');
+  }
+
+  const hostileOffer = {
+    url: 'https://jobs.example.com/123',
+    source: 'local-parser',
+    title: 'Senior Engineer | Growth\n- [ ] https://evil.example/job | EvilCorp | Injected',
+    company: 'ACME\tCorp | R&D',
+    location: 'Remote\nEU',
+  };
+  const pipelineRow = formatPipelineOffer(hostileOffer);
+  const pendingLines = pipelineRow.split('\n').filter(line => /^\s*- \[ \] https?:\/\//.test(line));
+  if (
+    pendingLines.length === 1 &&
+    !pipelineRow.includes('\n') &&
+    !pipelineRow.includes('\t') &&
+    pipelineRow.includes('ACME Corp \\| R&D') &&
+    pipelineRow.includes('- \\[ \\] https://evil.example/job')
+  ) {
+    pass('scan pipeline writer sanitizes external metadata without creating injected checkboxes');
+  } else {
+    fail(`scan pipeline metadata sanitizer produced unsafe row: ${pipelineRow}`);
+  }
+
+  const historyRow = formatScanHistoryRow(hostileOffer, '2026-06-18');
+  const historyColumns = historyRow.split('\t');
+  if (
+    historyColumns.length === 7 &&
+    !historyColumns.some(col => /[\r\n\t]/.test(col)) &&
+    historyColumns[3].includes('- [ ] https://evil.example/job') &&
+    historyColumns[4] === 'ACME Corp | R&D' &&
+    historyColumns[6] === 'Remote EU'
+  ) {
+    pass('scan-history writer preserves row shape when metadata contains TSV control chars');
+  } else {
+    fail(`scan-history metadata sanitizer produced unsafe TSV row: ${JSON.stringify(historyColumns)}`);
   }
 
   // ── content_filter (#734) ──

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1160,7 +1160,7 @@ try {
   }
 
   const hostileOffer = {
-    url: 'https://jobs.example.com/123|evil',
+    url: 'https://jobs.example.com/123|evil\nhttps://evil.example/later',
     source: 'local-parser',
     title: 'Senior Engineer | Growth\n- [ ] https://evil.example/job | EvilCorp | Injected',
     company: '=ACME\\Corp\t| R&D',
@@ -1175,6 +1175,7 @@ try {
     !pipelineRow.includes('\t') &&
     !pipelineRow.includes('\\|') &&
     pipelineRow.includes('https://jobs.example.com/123%7Cevil') &&
+    !pipelineRow.includes('https://evil.example/later') &&
     pipelineRow.includes('=ACME\\\\Corp / R&D') &&
     pipelineRow.includes('- \\[ \\] https://evil.example/job / EvilCorp / Injected')
   ) {
@@ -1188,6 +1189,7 @@ try {
   if (
     historyColumns.length === 7 &&
     !historyColumns.some(col => /[\r\n\t]/.test(col)) &&
+    historyColumns[0] === 'https://jobs.example.com/123|evil' &&
     historyColumns[3].includes('- [ ] https://evil.example/job') &&
     historyColumns[4] === "'=ACME\\Corp | R&D" &&
     historyColumns[6] === "'@Remote EU"

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1168,14 +1168,14 @@ try {
   };
   const pipelineRow = formatPipelineOffer(hostileOffer);
   const pendingLines = pipelineRow.split('\n').filter(line => /^\s*- \[ \] https?:\/\//.test(line));
+  const pipelineFields = pipelineRow.split('|').map(part => part.trim());
   if (
     pendingLines.length === 1 &&
-    pipelineRow.split('|').length === 3 &&
+    pipelineFields.length === 3 &&
+    pipelineFields[0] === '- [ ] https://jobs.example.com/123%7Cevil' &&
     !pipelineRow.includes('\n') &&
     !pipelineRow.includes('\t') &&
     !pipelineRow.includes('\\|') &&
-    pipelineRow.includes('https://jobs.example.com/123%7Cevil') &&
-    !pipelineRow.includes('https://evil.example/later') &&
     pipelineRow.includes('=ACME\\\\Corp / R&D') &&
     pipelineRow.includes('- \\[ \\] https://evil.example/job / EvilCorp / Injected')
   ) {


### PR DESCRIPTION
## Context

Closes #1068.

External provider/local-parser metadata is written into `data/pipeline.md` and `data/scan-history.tsv`. A title/company/location containing record separators or Markdown table/list controls can split one scanner result into multiple pending rows or corrupt the TSV history.

## Changes

- Add small formatter helpers for scanner writes:
  - Markdown-facing fields collapse `\r`/`\n`/`\t` and escape `|`, `[` and `]`.
  - TSV fields collapse `\r`/`\n`/`\t` so each offer remains one physical row with 7 columns.
- Route both `appendToPipeline()` and `appendToScanHistory()` through those helpers.
- Add regression coverage using the #1068 fixture shape (`\n- [ ] https://...`, tabs, and pipes).

## How to test

- `node --check scan.mjs`
- `node --check test-all.mjs`
- Focused #1068 formatter repro via `node -` against `formatPipelineOffer()` / `formatScanHistoryRow()`
- `node test-all.mjs --quick` on Windows: new scan sanitizer checks pass; run ends with the existing unrelated batch fixture failure `Batch rate-limit pause test crashed: ENOENT ... batch-state.tsv`.

## Risk / rollback

Low risk: normal scanner output keeps the same row shape. Only external text metadata is normalized/escaped at the write boundary. Revert this commit to restore previous raw interpolation behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened sanitization and formatting for pipeline and scan-history outputs, preventing malformed rows and injection vectors.
  * Improved handling of whitespace normalization, Markdown escaping, pipe/table-like field behavior, URL sanitization, and TSV-safe quoting (including formula-like values).
  * Kept existing pipeline insertion behavior and preserved scan-history column order.

* **Tests**
  * Added security-focused tests with hostile input to verify outputs remain single-row, correctly escaped, and TSV/Markdown safe (including formula, newline, and pipe payloads).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->