### PR TITLE
fix(updater): git-safety on abort + preserve user files on safety-violation rollback (#915)

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -327,7 +327,27 @@ export function prepareMaterializedSkillEntrypointsForStage(paths, root = ROOT) 
 
 function revertPaths(paths) {
   if (paths.length === 0) return;
-  git('checkout', '--', ...paths);
+  // Must restore from HEAD, not from the index (#915 bug 1). After
+  // `git checkout FETCH_HEAD -- <path>` the index already holds the new
+  // content, so `git checkout -- <path>` (index→worktree) is a no-op.
+  // `git checkout HEAD -- <path>` resets both the index and the worktree
+  // to the pre-update commit, which is the correct rollback target.
+  for (const p of paths) {
+    try {
+      git('checkout', 'HEAD', '--', p);
+    } catch (err) {
+      const pathspec = p.endsWith('/') ? p.slice(0, -1) : p;
+      // Only remove if the path genuinely doesn't exist in HEAD.
+      // Other errors (permissions, corrupt refs) should re-throw.
+      let existsInHead = true;
+      try { git('cat-file', '-e', `HEAD:${pathspec}`); } catch { existsInHead = false; }
+      if (existsInHead) throw err;
+      // Path was newly introduced by the update — remove it so the
+      // working tree is consistent with HEAD.
+      try { git('rm', '-r', '-f', '--ignore-unmatch', '--', pathspec); } catch { /* ignore */ }
+      try { rmSync(join(ROOT, pathspec), { recursive: true, force: true }); } catch { /* already gone */ }
+    }
+  }
 }
 
 function addPaths(paths) {
@@ -483,9 +503,22 @@ async function apply() {
   }
 
   try {
-    // 1. Backup: create branch
+    // 1. Backup: create branch + stash uncommitted work (#915 bug 3).
+    // The branch only captures committed state; any uncommitted edits are
+    // invisible to `git branch` and can be lost if the update aborts.
+    // `git stash create` builds a stash object without touching the stash
+    // stack, giving a recoverable ref for WIP even if the update fails.
     const backupBranch = process.env.CAREER_OPS_UPDATE_BACKUP_BRANCH || updateBackupBranchName(local);
     if (!isReexec) {
+      try {
+        const wip = git('stash', 'create');
+        if (wip) {
+          git('update-ref', `refs/backup-pre-update-wip/${local}`, wip);
+          console.log(`WIP stash ref saved: refs/backup-pre-update-wip/${local} (recover with: git stash apply refs/backup-pre-update-wip/${local})`);
+        }
+      } catch {
+        // Non-fatal: stash creation can fail in bare repos or empty trees.
+      }
       git('branch', backupBranch);
       console.log(`Backup branch created: ${backupBranch}`);
     }
@@ -639,7 +672,11 @@ async function apply() {
       }
       prepareMaterializedSkillEntrypointsForStage(materializedSkillEntrypoints);
       addPaths(pathsToStage);
-      git('commit', '-m', `chore: auto-update system files to v${remote}`);
+      // Scope the commit to only the staged update paths (#915 bug 2).
+      // A bare `git commit` would sweep any unrelated pre-staged files into
+      // the update commit. Passing the explicit pathspec list constrains the
+      // commit to exactly the files this update touched.
+      git('commit', '-m', `chore: auto-update system files to v${remote}`, '--', ...pathsToStage);
     } catch {
       // Nothing to commit (already up to date)
     }
@@ -717,8 +754,13 @@ function rollback() {
     }
 
     if (restored.length > 0) addPaths(restored);
+    const rollbackPaths = [...restored, ...removed];
     try {
-      git('commit', '-m', `chore: rollback system files from ${latest}`);
+      // Scope the commit to the rollback paths (#915 bug 2). A bare
+      // `git commit` would sweep unrelated staged files into the rollback.
+      if (rollbackPaths.length > 0) {
+        git('commit', '-m', `chore: rollback system files from ${latest}`, '--', ...rollbackPaths);
+      }
     } catch {
       // Tolerate any commit failure here — the common case is the
       // "nothing to commit" no-op when the working tree already

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -584,9 +584,7 @@ async function apply() {
     // 4. Validate: check NO user files were touched.
     //
     // Track which user paths the update unexpectedly touched so we
-    // can revert them too — reverting only `updated` would leave the
-    // repo in a half-applied state with the user-layer changes still
-    // staged.
+    // can exclude them from the revert and log what was preserved.
     const violatedUserPaths = new Set();
     try {
       for (const entry of gitStatusEntries()) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -622,13 +622,17 @@ async function apply() {
     }
 
     if (violatedUserPaths.size > 0) {
-      console.error('Aborting: user files were touched. Rolling back...');
-      // Revert BOTH the system-layer updates and the user-layer paths
-      // the update unexpectedly modified — otherwise the repo is left
-      // in a half-applied state.
+      console.error('Aborting: user files were touched. Rolling back system files...');
+      // Revert ONLY the system-layer updates — never `git checkout` the
+      // violated user paths back to HEAD. Doing so would overwrite the
+      // user's working-tree content (accumulated STAR+R stories, local
+      // edits) with whatever is committed upstream, causing data loss.
+      // The user files were flagged as touched by the update, not by the
+      // user; leaving them as-is is the safe choice — the user decides
+      // what to do with them.
       const violation = new Error('Update aborted: user files were touched.');
       try {
-        revertPaths([...updated, ...violatedUserPaths]);
+        revertPaths([...updated]);
       } catch (revertErr) {
         // If the revert itself fails, don't lose the safety-violation
         // diagnostic — chain it via `cause` so the user sees both.
@@ -637,6 +641,8 @@ async function apply() {
           { cause: violation },
         );
       }
+      console.error(`User file(s) left as-is (your content was NOT overwritten):`);
+      for (const f of violatedUserPaths) console.error(`  ${f}`);
       // `throw` (not `process.exit`) so the outer `finally` runs and
       // .update-lock is removed. Exiting here would leak the lock and
       // permanently block subsequent updates until the user deletes

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -128,6 +128,22 @@ const twoPassManifestChecks = [
     name: 'apply checks out the merged manifest instead of only the local manifest',
     pattern: /for\s*\(const path of updatePaths\)/,
   },
+  {
+    name: 'revertPaths uses git checkout HEAD (not just --) to reset index+worktree (#915)',
+    pattern: /git\('checkout',\s*'HEAD',\s*'--'/,
+  },
+  {
+    name: 'apply commit is scoped to update paths, not bare commit (#915)',
+    pattern: /git\('commit',\s*'-m',[^)]+'--',\s*\.\.\.pathsToStage\)/,
+  },
+  {
+    name: 'rollback commit is scoped to rollback paths, not bare commit (#915)',
+    pattern: /git\('commit',\s*'-m',[^)]+'--',\s*\.\.\.rollbackPaths\)/,
+  },
+  {
+    name: 'apply captures uncommitted work via git stash create before branching (#915)',
+    pattern: /git\('stash',\s*'create'\)/,
+  },
 ];
 
 for (const check of twoPassManifestChecks) {


### PR DESCRIPTION
Salvages the two updater-safety fixes from @lavkeshdwivedi's #1061 and #1066 onto a clean `main`, extracted from a swarm branch that was stacked on an unrelated large feature. **Commit authorship is preserved to @lavkeshdwivedi** (cherry-picked, not rewritten).

**From #1066 — three git-safety bugs in `update-system.mjs` (closes #915):**
1. `revertPaths()` ran `git checkout -- <path>`, a no-op after `apply()` already staged new content via `git checkout FETCH_HEAD -- <path>` → on abort, system files stayed staged at the new version. Now `git checkout HEAD -- <path>` (resets index+worktree to the pre-update commit), with a `cat-file -e` existence probe + `git rm` fallback for paths absent from HEAD (re-throws non-existence errors instead of blind-deleting).
2. `apply()` and `rollback()` ran bare `git commit -m` (no pathspec), sweeping unrelated pre-staged files into the update/rollback commit → now scoped to `-- <pathsToStage>` / `-- <rollbackPaths>`.
3. Backup branch only captured committed HEAD → added a `git stash create` WIP snapshot under `refs/backup-pre-update-wip/<version>` with a recovery hint (non-fatal).

**From #1061 — preserve user files on safety-violation rollback (refs #995, partial):**
- The safety-violation rollback path called `revertPaths([...updated, ...violatedUserPaths])`, and `revertPaths` does `git checkout -- <paths>` → it overwrote the user's *uncommitted* working-tree content (e.g. `interview-prep/story-bank.md`) with the upstream stub. Now reverts only system-layer `updated` and leaves user files untouched, printing a "your content was NOT overwritten" diagnostic for each.
- Note: #995 lists 3 distinct bugs; this fixes the rollback-overwrite one only, so #995 stays open for the remaining two.

Verified: `updater-migration-tests.mjs` 57/0, `test-all.mjs` 379/0, `update-system.mjs` syntax OK.

Credit: @lavkeshdwivedi (original authorship on both commits). Extracted maintainer-side because these touch the hot updater path and the originals were buried under ~2,000 lines of unrelated feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened rollback capabilities for more reliable recovery from update failures
  * Enhanced safety validation to protect user files from being overwritten during updates
  * Fixed issue where unrelated staged changes could be committed during system updates

* **Tests**
  * Expanded test coverage for update safety and rollback workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->