### PR TITLE
refactor(tracker): extract duplicated rebuildRow into shared tracker-utils.mjs

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -13,6 +13,7 @@ import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { roleFuzzyMatch } from './role-matcher.mjs';
+import { rebuildRow } from './tracker-utils.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md
@@ -229,27 +230,6 @@ function parseScore(s) {
  * @param {string} line - One line from applications.md.
  * @returns {object|null} Parsed tracker row, or null for non-application lines.
  */
-/**
- * Rebuild a markdown table row from the cells produced by `line.split('|')`.
- *
- * `split('|')` yields a leading empty element (before the opening `|`) and,
- * when the row ends with a trailing `|`, a trailing empty element too. The old
- * `slice(1, -1)` assumed that trailing empty always existed — but a row written
- * without a trailing pipe (`| 5 | … | note`, still a valid 9-cell row) has its
- * real last cell (the notes) at the end, so `slice(1, -1)` silently dropped it.
- * Here we drop the leading empty and only drop a trailing element when it is
- * actually empty, preserving every real cell regardless of trailing-pipe style
- * (and tolerating extra columns like a custom Location).
- *
- * @param {string[]} parts - Trimmed cells from `line.split('|').map(s => s.trim())`.
- * @returns {string} The rebuilt `| a | b | … |` row.
- */
-function rebuildRow(parts) {
-  const cells = parts.slice(1);
-  if (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
-  return '| ' + cells.join(' | ') + ' |';
-}
-
 function parseAppLine(line) {
   const parts = line.split('|').map(s => s.trim());
   if (parts.length < 9) return null;

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -14,6 +14,7 @@
 import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { rebuildRow } from './tracker-utils.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original)
@@ -84,23 +85,6 @@ function normalizeStatus(raw) {
 
   // Unknown — flag it
   return { status: null, unknown: true };
-}
-
-/**
- * Rebuild a markdown table row from `line.split('|')` cells without dropping the
- * last real cell. `split('|')` adds a leading empty element and, only when the
- * row ends with `|`, a trailing empty one. The old `slice(1, -1)` assumed that
- * trailing empty always existed, so a row written without a trailing pipe
- * (`| 5 | … | note`) lost its notes cell on rewrite. Drop the leading empty and
- * only drop a trailing element when it is genuinely empty.
- *
- * @param {string[]} parts - Trimmed cells from `line.split('|').map(s => s.trim())`.
- * @returns {string} The rebuilt `| a | b | … |` row.
- */
-function rebuildRow(parts) {
-  const cells = parts.slice(1);
-  if (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
-  return '| ' + cells.join(' | ') + ' |';
 }
 
 // Read applications.md

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2458,6 +2458,42 @@ try {
   fail(`dedup row-rebuild notes test crashed: ${e.message}`);
 }
 
+// rebuildRow() is now shared from tracker-utils.mjs (extracted from the two
+// copies introduced in #1004). Unit-test the helper contract directly.
+console.log('\n🧪 Testing shared tracker-utils rebuildRow()...');
+try {
+  const { rebuildRow } = await import(pathToFileURL(join(ROOT, 'tracker-utils.mjs')).href);
+  const cellsOf = (line) => line.split('|').map(s => s.trim());
+
+  // Trailing-pipe row → unchanged round-trip.
+  const withPipe = '| 5 | 2026-02-01 | Acme | Eng | 4.0/5 | Applied | ❌ | [5](r.md) | note |';
+  if (rebuildRow(cellsOf(withPipe)) === withPipe) {
+    pass('rebuildRow round-trips a row that already has a trailing pipe');
+  } else {
+    fail(`rebuildRow changed a trailing-pipe row: "${rebuildRow(cellsOf(withPipe))}"`);
+  }
+
+  // No-trailing-pipe row → last cell (notes) preserved, trailing pipe added.
+  const noPipe = '| 5 | 2026-02-01 | Acme | Eng | 4.0/5 | Applied | ❌ | [5](r.md) | keepme';
+  const rebuilt = rebuildRow(cellsOf(noPipe));
+  if (rebuilt.includes('keepme') && rebuilt.endsWith('|')) {
+    pass('rebuildRow preserves the notes cell on a row without a trailing pipe');
+  } else {
+    fail(`rebuildRow dropped notes on no-trailing-pipe row: "${rebuilt}"`);
+  }
+
+  // Extra column (e.g. a custom Location) → every cell preserved.
+  const extra = '| 5 | 2026-02-01 | Acme | Eng | Berlin | 4.0/5 | Applied | ❌ | [5](r.md) | note |';
+  const rebuiltExtra = rebuildRow(cellsOf(extra));
+  if (rebuiltExtra === extra && rebuiltExtra.includes('Berlin')) {
+    pass('rebuildRow preserves extra columns (custom Location)');
+  } else {
+    fail(`rebuildRow mangled an extra-column row: "${rebuiltExtra}"`);
+  }
+} catch (e) {
+  fail(`tracker-utils rebuildRow unit test crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER FUZZY DEDUP (#751 / #721 family) ──────────────
 // roleFuzzyMatch over-matched whenever the token overlap dominated the
 // SMALLER side: two distinct roles sharing a long prefix ("Full-Stack

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -1,0 +1,28 @@
+/**
+ * tracker-utils.mjs — shared helpers for rewriting `data/applications.md` rows.
+ *
+ * The tracker is a markdown table that several scripts mutate in place
+ * (`dedup-tracker.mjs`, `normalize-statuses.mjs`). Keeping the row-rewrite logic
+ * here means a fix lands once instead of drifting between copies.
+ */
+
+/**
+ * Rebuild a markdown table row from the cells produced by `line.split('|')`.
+ *
+ * `split('|')` yields a leading empty element (before the opening `|`) and,
+ * when the row ends with a trailing `|`, a trailing empty element too. A naive
+ * `slice(1, -1)` assumes that trailing empty always exists — but a row written
+ * without a trailing pipe (`| 5 | … | note`, still a valid row) keeps its real
+ * last cell (the notes) at the end, so `slice(1, -1)` silently drops it. Here we
+ * drop the leading empty and only drop a trailing element when it is genuinely
+ * empty, preserving every real cell regardless of trailing-pipe style (and
+ * tolerating extra columns like a custom Location).
+ *
+ * @param {string[]} parts - Trimmed cells from `line.split('|').map(s => s.trim())`.
+ * @returns {string} The rebuilt `| a | b | … |` row.
+ */
+export function rebuildRow(parts) {
+  const cells = parts.slice(1);
+  if (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
+  return '| ' + cells.join(' | ') + ' |';
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -81,6 +81,7 @@ const SYSTEM_PATHS = [
   'reconcile-pipeline.mjs',
   'dedup-tracker.mjs',
   'role-matcher.mjs',
+  'tracker-utils.mjs',
   'normalize-statuses.mjs',
   'cv-sync-check.mjs',
   'update-system.mjs',
@@ -567,7 +568,7 @@ async function apply() {
 
     // 3a. Keep bootstrap paths as a fallback for very old targets, but the
     // target updater's SYSTEM_PATHS is now the source of truth for new files.
-    const BOOTSTRAP_PATHS = ['.agents/', '.opencode/skills/', '.antigravitycli/skills/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'role-matcher.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs', 'tracker-columns-tests.mjs'];
+    const BOOTSTRAP_PATHS = ['.agents/', '.opencode/skills/', '.antigravitycli/skills/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'role-matcher.mjs', 'tracker-utils.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs', 'tracker-columns-tests.mjs'];
     const updatePaths = mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS);
 
     for (const path of updatePaths) {

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -81,6 +81,7 @@ const requiredBootstrapPaths = [
   'providers/',
   'liveness-browser.mjs',
   'role-matcher.mjs',
+  'tracker-utils.mjs',
   'updater-migration-tests.mjs',
   'tracker-columns-tests.mjs',
 ];


### PR DESCRIPTION
## Summary

Fixes #1103. #1004 fixed the notes-column data-loss bug by adding a `rebuildRow()` helper, but — to land the fix quickly and keep each script self-contained — it was **copied into both** `dedup-tracker.mjs` and `normalize-statuses.mjs`. CodeRabbit flagged the duplication on that PR.

Tracker-row rewriting is a cross-cutting concern (both scripts mutate `data/applications.md`), so this pulls the helper into a single `tracker-utils.mjs` that both scripts import. Duplicated, a future fix to one copy would silently leave the other wrong.

## Changes
- **New** `tracker-utils.mjs` — exports `rebuildRow(parts)` with its JSDoc.
- `dedup-tracker.mjs` — import the helper, drop the local copy (restores the `parseAppLine` JSDoc adjacency that #1004 had split).
- `normalize-statuses.mjs` — import the helper, drop the local copy.
- `test-all.mjs` — add a direct unit test for `rebuildRow()` (trailing-pipe round-trip, no-trailing-pipe notes preservation, extra-column / custom-Location preservation). The #1004 integration test is untouched and still green.

## Test plan
- [x] `node test-all.mjs --quick` → **387 passed, 0 failed**
- [x] `node --check` on all three scripts + the new module
- [x] Pure structural refactor — **no behavior change**; the #1004 regression test (dedup status-promotion preserving notes) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared markdown table row reconstruction into a dedicated utility module and reused it across the tracker and normalization workflows.
  * Updated system/bootstrap handling so the new shared utility is included during environment updates.
* **Tests**
  * Added unit tests for row reconstruction edge cases to ensure round-tripping and correct handling of missing/extra columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->