### PR TITLE
Fix: non-Latin company/role names break tracker dedup + merge (i18n)

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -71,7 +71,10 @@ function normalizeCompany(name) {
   // them collapsed every non-Latin company into the same empty key, which let the
   // fuzzy role matcher merge unrelated rows — silent data loss for non-English
   // markets (the localized de/fr/ja/ar/tr modes target exactly these users).
-  const key = name.toLowerCase()
+  // NFC-normalize first so NFC/NFD variants of the same accented name (e.g.
+  // "Société" pasted as decomposed e + ´) don't strip the combining mark and
+  // produce a different key for the same company.
+  const key = name.normalize('NFC').toLowerCase()
     .replace(/[()]/g, '')
     .replace(/\s+/g, ' ')
     .replace(/[^\p{L}\p{N} ]/gu, '')
@@ -79,7 +82,7 @@ function normalizeCompany(name) {
   // Never group under an empty key. A name that is all punctuation/emoji would
   // normalize to '' and cluster with every other such name; fall back to the
   // trimmed lowercase original so those rows stay distinct.
-  return key || name.toLowerCase().trim();
+  return key || name.normalize('NFC').toLowerCase().trim();
 }
 
 /**

--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -66,11 +66,20 @@ const STATUS_RANK = {
  * @returns {string} Lowercase company key used for same-company grouping.
  */
 function normalizeCompany(name) {
-  return name.toLowerCase()
+  // Use Unicode letter/number classes (\p{L}\p{N}), not [a-z0-9]: Cyrillic, CJK,
+  // Arabic and other non-Latin company names must keep their letters. Stripping
+  // them collapsed every non-Latin company into the same empty key, which let the
+  // fuzzy role matcher merge unrelated rows — silent data loss for non-English
+  // markets (the localized de/fr/ja/ar/tr modes target exactly these users).
+  const key = name.toLowerCase()
     .replace(/[()]/g, '')
     .replace(/\s+/g, ' ')
-    .replace(/[^a-z0-9 ]/g, '')
+    .replace(/[^\p{L}\p{N} ]/gu, '')
     .trim();
+  // Never group under an empty key. A name that is all punctuation/emoji would
+  // normalize to '' and cluster with every other such name; fall back to the
+  // trimmed lowercase original so those rows stay distinct.
+  return key || name.toLowerCase().trim();
 }
 
 /**

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -388,7 +388,13 @@ function validateStatus(status) {
  * @returns {string} Lowercase alphanumeric company key.
  */
 function normalizeCompany(name) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, '');
+  // Mirror of dedup-tracker.mjs's normalizeCompany. Use Unicode letter/number
+  // classes (\p{L}\p{N}), not [a-z0-9]: stripping non-Latin characters collapsed
+  // every Cyrillic/CJK/Arabic company to the same empty key, so a TSV addition
+  // for one non-Latin company would merge into an unrelated one. NFC-normalize
+  // first so NFC/NFD variants of the same accented name (e.g. "Société") agree.
+  const key = name.normalize('NFC').toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
+  return key || name.normalize('NFC').toLowerCase().trim();
 }
 
 /**

--- a/role-matcher.mjs
+++ b/role-matcher.mjs
@@ -63,8 +63,13 @@ export const BASELINE_TOKENS = new Set([
 export function roleTokens(role) {
   const text = typeof role === 'string' ? role : String(role ?? '');
   return text
+    .normalize('NFC')
+    // Keep Unicode letters/digits (\p{L}\p{N}), not just [a-z0-9]: a [^a-z0-9\s]
+    // class erased every Cyrillic/CJK/Arabic character, so non-Latin role titles
+    // tokenized to [] and roleFuzzyMatch() bailed out — duplicate non-Latin-role
+    // rows never deduplicated even once the company key was correct.
     .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
     .split(/\s+/)
     .filter(w => (w.length > 3 || SHORT_SPECIALTY.has(w)) && !ROLE_STOPWORDS.has(w));
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2227,44 +2227,80 @@ try {
   fail(`shared role matcher / dedup safety tests crashed: ${e.message}`);
 }
 
-// ── NON-LATIN COMPANY DEDUP (i18n) ──────────────────────────────
-// normalizeCompany() stripped every non-[a-z0-9] character, so Cyrillic / CJK /
-// Arabic company names all collapsed to the same empty key. Two unrelated
-// non-Latin employers sharing one generic role were then grouped and a row was
-// deleted as a "duplicate" — silent data loss for the localized de/fr/ja/ar/tr
-// markets. normalizeCompany now keeps Unicode letters/digits (\p{L}\p{N}).
-console.log('\n🧪 Testing dedup-tracker keeps distinct non-Latin companies...');
+// ── NON-LATIN COMPANY + ROLE DEDUP (i18n) ───────────────────────
+// normalizeCompany() (in BOTH dedup-tracker.mjs and merge-tracker.mjs) and the
+// shared roleTokens() stripped every non-[a-z0-9] character. All Cyrillic / CJK
+// / Arabic company names collapsed to the same empty key, and non-Latin role
+// titles tokenized to [] so roleFuzzyMatch() bailed out. Net effect: unrelated
+// non-Latin employers were merged, while genuine duplicates at the same
+// non-Latin company never deduplicated. Both now keep Unicode letters/digits
+// (\p{L}\p{N}) and NFC-normalize first.
+console.log('\n🧪 Testing non-Latin company + role dedup (i18n)...');
 try {
+  const { roleFuzzyMatch } = await import(pathToFileURL(join(ROOT, 'role-matcher.mjs')).href);
+
+  if (roleFuzzyMatch('Бэкенд разработчик', 'Бэкенд разработчик')) {
+    pass('roleFuzzyMatch matches identical Cyrillic role titles');
+  } else {
+    fail('roleFuzzyMatch fails on identical Cyrillic roles (non-Latin tokens stripped)');
+  }
+  if (!roleFuzzyMatch('Бэкенд разработчик', 'Фронтенд дизайнер')) {
+    pass('roleFuzzyMatch keeps distinct Cyrillic roles separate');
+  } else {
+    fail('roleFuzzyMatch merged two distinct Cyrillic roles');
+  }
+
   const nlTmp = mkdtempSync(join(tmpdir(), 'career-ops-nonlatin-'));
   try {
     mkdirSync(join(nlTmp, 'data'));
     const tracker = join(nlTmp, 'data', 'applications.md');
-    // Two DIFFERENT companies (Яндекс vs Сбербанк) with the SAME role. Under the
-    // old all-ASCII normalization both companies keyed to '' and the identical
-    // role made them look like duplicates, so one row would be deleted.
+    const nfc = 'Société Générale'.normalize('NFC');
+    const nfd = 'Société Générale'.normalize('NFD');
     writeFileSync(tracker,
       '# Applications Tracker\n\n' +
       '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
       '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
-      '| 60 | 2026-03-01 | Яндекс | Бэкенд-разработчик | 4.0/5 | Evaluated | ❌ | [60](../reports/060-ya.md) | distinct employer A |\n' +
-      '| 61 | 2026-03-01 | Сбербанк | Бэкенд-разработчик | 4.1/5 | Evaluated | ❌ | [61](../reports/061-sber.md) | distinct employer B |\n');
+      // same Cyrillic company + role → must dedup to the higher-scored row
+      '| 60 | 2026-03-01 | Яндекс | Бэкенд-разработчик | 4.0/5 | Evaluated | ❌ | [60](../reports/060-ya-a.md) | cyrillic dup low |\n' +
+      '| 61 | 2026-03-01 | Яндекс | Бэкенд-разработчик | 4.3/5 | Evaluated | ❌ | [61](../reports/061-ya-b.md) | cyrillic dup high |\n' +
+      // distinct Cyrillic company, same role → must survive
+      '| 62 | 2026-03-01 | Сбербанк | Бэкенд-разработчик | 4.1/5 | Evaluated | ❌ | [62](../reports/062-sber.md) | distinct cyrillic |\n' +
+      // CJK + Arabic companies → must NOT collapse into each other
+      '| 63 | 2026-03-01 | 百度 | Frontend Developer | 3.0/5 | Evaluated | ❌ | [63](../reports/063-cjk.md) | cjk company |\n' +
+      '| 64 | 2026-03-01 | أمازون | DevOps Engineer | 3.5/5 | Evaluated | ❌ | [64](../reports/064-ar.md) | arabic company |\n' +
+      // NFC vs NFD of the SAME accented company + same role → must dedup to 1
+      `| 65 | 2026-03-01 | ${nfc} | Risk Engineer | 3.8/5 | Evaluated | ❌ | [65](../reports/065-sg-nfc.md) | nfc |\n` +
+      `| 66 | 2026-03-01 | ${nfd} | Risk Engineer | 4.2/5 | Evaluated | ❌ | [66](../reports/066-sg-nfd.md) | nfd |\n`);
 
     const r = run(NODE, ['dedup-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
     if (r === null) {
-      fail('dedup-tracker.mjs crashed during non-Latin company test');
+      fail('dedup-tracker.mjs crashed during non-Latin dedup test');
     } else {
       const out = readFileSync(tracker, 'utf-8');
-      if (out.includes('Яндекс') && out.includes('Сбербанк')) {
-        pass('dedup-tracker keeps distinct non-Latin companies (no empty-key collision)');
+      const lines = out.split('\n');
+      const yandexRows = lines.filter(l => l.includes('Яндекс'));
+      if (yandexRows.length === 1 && yandexRows[0].includes('4.3/5')) {
+        pass('dedup-tracker deduplicates same Cyrillic company+role, keeping the higher score');
       } else {
-        fail('dedup-tracker merged two distinct non-Latin companies into one');
+        fail(`dedup-tracker Cyrillic dedup wrong: ${yandexRows.length} Яндекс rows`);
+      }
+      if (out.includes('Сбербанк') && out.includes('百度') && out.includes('أمازون')) {
+        pass('dedup-tracker keeps distinct Cyrillic / CJK / Arabic companies separate (no empty-key collision)');
+      } else {
+        fail('dedup-tracker merged or dropped a distinct non-Latin company');
+      }
+      const riskRows = lines.filter(l => l.includes('Risk Engineer'));
+      if (riskRows.length === 1 && riskRows[0].includes('4.2/5')) {
+        pass('dedup-tracker deduplicates NFC/NFD variants of the same accented company');
+      } else {
+        fail(`dedup-tracker NFC/NFD dedup wrong: ${riskRows.length} "Risk Engineer" rows`);
       }
     }
   } finally {
     rmSync(nlTmp, { recursive: true, force: true });
   }
 } catch (e) {
-  fail(`non-Latin company dedup test crashed: ${e.message}`);
+  fail(`non-Latin dedup test crashed: ${e.message}`);
 }
 
 // dedup-tracker / normalize-statuses rebuilt promoted rows with

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2227,6 +2227,46 @@ try {
   fail(`shared role matcher / dedup safety tests crashed: ${e.message}`);
 }
 
+// ── NON-LATIN COMPANY DEDUP (i18n) ──────────────────────────────
+// normalizeCompany() stripped every non-[a-z0-9] character, so Cyrillic / CJK /
+// Arabic company names all collapsed to the same empty key. Two unrelated
+// non-Latin employers sharing one generic role were then grouped and a row was
+// deleted as a "duplicate" — silent data loss for the localized de/fr/ja/ar/tr
+// markets. normalizeCompany now keeps Unicode letters/digits (\p{L}\p{N}).
+console.log('\n🧪 Testing dedup-tracker keeps distinct non-Latin companies...');
+try {
+  const nlTmp = mkdtempSync(join(tmpdir(), 'career-ops-nonlatin-'));
+  try {
+    mkdirSync(join(nlTmp, 'data'));
+    const tracker = join(nlTmp, 'data', 'applications.md');
+    // Two DIFFERENT companies (Яндекс vs Сбербанк) with the SAME role. Under the
+    // old all-ASCII normalization both companies keyed to '' and the identical
+    // role made them look like duplicates, so one row would be deleted.
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 60 | 2026-03-01 | Яндекс | Бэкенд-разработчик | 4.0/5 | Evaluated | ❌ | [60](../reports/060-ya.md) | distinct employer A |\n' +
+      '| 61 | 2026-03-01 | Сбербанк | Бэкенд-разработчик | 4.1/5 | Evaluated | ❌ | [61](../reports/061-sber.md) | distinct employer B |\n');
+
+    const r = run(NODE, ['dedup-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
+    if (r === null) {
+      fail('dedup-tracker.mjs crashed during non-Latin company test');
+    } else {
+      const out = readFileSync(tracker, 'utf-8');
+      if (out.includes('Яндекс') && out.includes('Сбербанк')) {
+        pass('dedup-tracker keeps distinct non-Latin companies (no empty-key collision)');
+      } else {
+        fail('dedup-tracker merged two distinct non-Latin companies into one');
+      }
+    }
+  } finally {
+    rmSync(nlTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`non-Latin company dedup test crashed: ${e.message}`);
+}
+
 // dedup-tracker / normalize-statuses rebuilt promoted rows with
 // `parts.slice(1, -1)`, which assumes the closing `|` produced a trailing empty
 // cell. A valid row written WITHOUT a trailing pipe keeps its real last cell


### PR DESCRIPTION
## Problem

The tracker dedup/merge pipeline assumed ASCII. Three functions stripped every non-Latin character, which silently corrupted data for Cyrillic / CJK / Arabic markets (the ones the localized `modes/de|fr|ja|ar|tr` target):

1. `dedup-tracker.mjs` `normalizeCompany` — `.replace(/[^a-z0-9 ]/g, '')` → every non-Latin company collapsed to the **same empty key**, so the fuzzy role matcher merged unrelated employers and deleted rows.
2. `merge-tracker.mjs` `normalizeCompany` — an identical second copy with the same bug; it runs after every batch, so a TSV addition for one non-Latin company merges into an unrelated one.
3. `role-matcher.mjs` `roleTokens` — `.replace(/[^a-z0-9\s]/g, ' ')` erased non-Latin role titles to `[]`, so `roleFuzzyMatch` bailed out and genuine duplicates at the **same** non-Latin company never deduplicated.

Plus an NFC/NFD bug: `'Société'` in NFC vs NFD produced different keys (`société` vs `societe`), so the same accented company never deduplicated across rows written on different OSes.

| Company | old key | new key |
|---|---|---|
| `Яндекс` | `""` | `яндекс` |
| `百度` | `""` | `百度` |
| `أمازون` | `""` | `أمازون` |
| `Société` (NFD) | `societe` | `société` (= NFC) |
| `Acme Inc.` | `acme inc` | `acme inc` |

## Fix

All three functions now use Unicode letter/number classes (`\p{L}\p{N}` with the `u` flag) instead of `[a-z0-9]`, NFC-normalize first, and fall back to the trimmed lowercase original when normalization yields an empty string. Latin behavior is unchanged (`\p{L}\p{N}` is a superset of `a-z0-9`).

## Tests

Extended the dedup safety section of `test-all.mjs`:
- `roleFuzzyMatch` matches identical Cyrillic roles and keeps distinct ones separate.
- A same-company Cyrillic pair deduplicates to the higher-scored row.
- Distinct Cyrillic / CJK / Arabic companies stay separate (no empty-key collision).
- NFC and NFD variants of the same accented company deduplicate.

`node test-all.mjs --quick` → **381 passed, 0 failed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved deduplication and merge behavior for international company names by using Unicode-aware normalization to avoid incorrect clustering.
  * Enhanced role matching for non-ASCII role titles so fuzzy matching behaves consistently across languages and accent variants.

* **Tests**
  * Added new coverage for non-Latin company + role deduplication, including Cyrillic matching rules, CJK/Arabic cases, and NFC vs. NFD normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->