### PR TITLE
Add verify-pipeline checks: duplicate report numbers + missing Machine Summary

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2268,6 +2268,52 @@ try {
   fail(`dedup row-rebuild notes test crashed: ${e.message}`);
 }
 
+// ── VERIFY-PIPELINE INTEGRITY CHECKS (dup report #, machine summary) ──
+// verify-pipeline.mjs gained two warning-only checks: duplicate report file
+// numbers (orphan twins invisible to number-indexed scripts) and a missing
+// `## Machine Summary` block on actionable rows (which analyze-patterns.mjs
+// needs to read a report's metadata). Both must warn without failing the run.
+console.log('\n🧪 Testing verify-pipeline integrity checks...');
+try {
+  const vpTmp = mkdtempSync(join(tmpdir(), 'career-ops-verify-'));
+  try {
+    mkdirSync(join(vpTmp, 'data'));
+    mkdirSync(join(vpTmp, 'reports'));
+    const tracker = join(vpTmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 70 | 2026-04-01 | Acme | Backend Engineer | 4.0/5 | Applied | ❌ | [70](../reports/070-acme.md) | applied row |\n');
+    // Applied report WITHOUT a Machine Summary block.
+    writeFileSync(join(vpTmp, 'reports', '070-acme.md'), '# Evaluation: Acme\n\nProse only, no machine summary.\n');
+    // A second file colliding on report number 070.
+    writeFileSync(join(vpTmp, 'reports', '070-acme-orphan.md'), '# duplicate-numbered orphan\n');
+
+    const out = run(NODE, ['verify-pipeline.mjs'], {
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_REPORTS_DIR: join(vpTmp, 'reports') },
+    });
+    if (out === null) {
+      fail('verify-pipeline.mjs exited non-zero on warning-only input (warnings must not fail the run)');
+    } else {
+      if (/Duplicate report number 070/.test(out)) {
+        pass('verify-pipeline flags duplicate report file numbers');
+      } else {
+        fail('verify-pipeline did not flag a duplicate report number');
+      }
+      if (/missing "## Machine Summary"/.test(out)) {
+        pass('verify-pipeline flags actionable reports missing a Machine Summary');
+      } else {
+        fail('verify-pipeline did not flag a missing Machine Summary on an Applied report');
+      }
+    }
+  } finally {
+    rmSync(vpTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`verify-pipeline integrity-check tests crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER FUZZY DEDUP (#751 / #721 family) ──────────────
 // roleFuzzyMatch over-matched whenever the token overlap dominated the
 // SMALLER side: two distinct roles sharing a long prefix ("Full-Stack

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2284,11 +2284,17 @@ try {
       '# Applications Tracker\n\n' +
       '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
       '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
-      '| 70 | 2026-04-01 | Acme | Backend Engineer | 4.0/5 | Applied | ❌ | [70](../reports/070-acme.md) | applied row |\n');
-    // Applied report WITHOUT a Machine Summary block.
-    writeFileSync(join(vpTmp, 'reports', '070-acme.md'), '# Evaluation: Acme\n\nProse only, no machine summary.\n');
+      '| 70 | 2026-04-01 | Acme | Backend Engineer | 4.0/5 | Applied | ❌ | [70](../reports/070-acme.md) | heading, no fence |\n' +
+      '| 71 | 2026-04-01 | Globex | Backend Engineer | 4.1/5 | Applied | ❌ | [71](../reports/071-globex.md) | compliant report |\n');
+    // Applied report #70 has the heading but NO fenced YAML — analyze-patterns
+    // returns null for this, so the check must still warn (old heading-only
+    // regex would have passed it).
+    writeFileSync(join(vpTmp, 'reports', '070-acme.md'), '# Evaluation: Acme\n\n## Machine Summary\n\nstatus: applied (no fenced block)\n');
     // A second file colliding on report number 070.
     writeFileSync(join(vpTmp, 'reports', '070-acme-orphan.md'), '# duplicate-numbered orphan\n');
+    // Applied report #71 has a proper fenced Machine Summary — must NOT warn.
+    writeFileSync(join(vpTmp, 'reports', '071-globex.md'),
+      '# Evaluation: Globex\n\n## Machine Summary\n\n```yaml\ncompany: Globex\nscore: 4.1\n```\n');
 
     const out = run(NODE, ['verify-pipeline.mjs'], {
       env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_REPORTS_DIR: join(vpTmp, 'reports') },
@@ -2301,10 +2307,15 @@ try {
       } else {
         fail('verify-pipeline did not flag a duplicate report number');
       }
-      if (/missing "## Machine Summary"/.test(out)) {
-        pass('verify-pipeline flags actionable reports missing a Machine Summary');
+      if (/#70 .*missing a parseable "## Machine Summary"/.test(out)) {
+        pass('verify-pipeline flags a heading-only report (no fenced YAML) as unparseable');
       } else {
-        fail('verify-pipeline did not flag a missing Machine Summary on an Applied report');
+        fail('verify-pipeline did not flag the heading-only (no-fence) Machine Summary report');
+      }
+      if (!/#71 /.test(out)) {
+        pass('verify-pipeline does not warn on a compliant fenced Machine Summary (no false positive)');
+      } else {
+        fail('verify-pipeline warned on a report that has a valid fenced Machine Summary');
       }
     }
   } finally {

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -259,7 +259,7 @@ if (existsSync(REPORTS_DIR)) {
   const numMap = new Map();
   for (const name of readdirSync(REPORTS_DIR)) {
     if (!name.endsWith('.md') || name.endsWith('-RESERVED.md')) continue;
-    const m = name.match(/^(\d{3})-/);
+    const m = name.match(/^(\d+)-/);
     if (!m) continue;
     if (!numMap.has(m[1])) numMap.set(m[1], []);
     numMap.get(m[1]).push(name);
@@ -289,8 +289,11 @@ for (const e of entries) {
   const path = existsSync(join(TRACKER_DIR, link)) ? join(TRACKER_DIR, link)
     : existsSync(join(CAREER_OPS, link)) ? join(CAREER_OPS, link) : null;
   if (!path) continue; // broken link already flagged by the report-links check
-  if (!/##\s*Machine Summary/i.test(readFileSync(path, 'utf-8'))) {
-    warn(`#${e.num} (${canon}): report missing "## Machine Summary" — analyze-patterns can't read its metadata`);
+  // Mirror analyze-patterns.mjs's parseMachineSummary regex: a bare heading with
+  // no fenced YAML block still yields null there, so require the fence too.
+  const MACHINE_SUMMARY_RE = /##\s*Machine Summary\s*\n+```(?:yaml|yml|json)?\s*\n[\s\S]*?\n```/i;
+  if (!MACHINE_SUMMARY_RE.test(readFileSync(path, 'utf-8'))) {
+    warn(`#${e.num} (${canon}): report missing a parseable "## Machine Summary" block — analyze-patterns can't read its metadata`);
     missingMachineSummary++;
   }
 }

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -27,7 +27,8 @@ const APPS_FILE = process.env.CAREER_OPS_TRACKER
     ? join(CAREER_OPS, 'data/applications.md')
     : join(CAREER_OPS, 'applications.md');
 const ADDITIONS_DIR = join(CAREER_OPS, 'batch/tracker-additions');
-const REPORTS_DIR = join(CAREER_OPS, 'reports');
+// CAREER_OPS_REPORTS_DIR overrides the reports directory (used by tests).
+const REPORTS_DIR = process.env.CAREER_OPS_REPORTS_DIR || join(CAREER_OPS, 'reports');
 const STATES_FILE = existsSync(join(CAREER_OPS, 'templates/states.yml'))
   ? join(CAREER_OPS, 'templates/states.yml')
   : join(CAREER_OPS, 'states.yml');
@@ -247,6 +248,53 @@ if (existsSync(REPORTS_DIR)) {
   }
 }
 if (staleSentinels === 0) ok('No stale reservation sentinels');
+
+// --- Check 9: Duplicate report file numbers ---
+// reserve-report-num.mjs and batch runs can collide on a number and write two
+// files sharing the same NNN- prefix. Earlier checks only catch duplicate
+// tracker rows, so the orphaned twin stays invisible to any script that
+// iterates reports by number.
+let dupReportNums = 0;
+if (existsSync(REPORTS_DIR)) {
+  const numMap = new Map();
+  for (const name of readdirSync(REPORTS_DIR)) {
+    if (!name.endsWith('.md') || name.endsWith('-RESERVED.md')) continue;
+    const m = name.match(/^(\d{3})-/);
+    if (!m) continue;
+    if (!numMap.has(m[1])) numMap.set(m[1], []);
+    numMap.get(m[1]).push(name);
+  }
+  for (const [n, files] of numMap) {
+    if (files.length > 1) {
+      warn(`Duplicate report number ${n}: ${files.join(', ')} — renumber the orphan to a free slot`);
+      dupReportNums++;
+    }
+  }
+}
+if (dupReportNums === 0) ok('No duplicate report numbers');
+
+// --- Check 10: Machine Summary present on actionable reports ---
+// analyze-patterns.mjs reads a report's metadata from its `## Machine Summary`
+// fenced block. Applied/Responded/Interview/Offer rows are the actionable ones
+// whose metadata feeds pattern analysis — warn when their report lacks it.
+const ACTIONABLE_STATUSES = new Set(['applied', 'responded', 'interview', 'offer']);
+let missingMachineSummary = 0;
+for (const e of entries) {
+  const st = e.status.replace(/\*\*/g, '').trim().toLowerCase().replace(/\s+\d{4}-\d{2}-\d{2}.*$/, '').trim();
+  const canon = CANONICAL_STATUSES.includes(st) ? st : (ALIASES[st] || st);
+  if (!ACTIONABLE_STATUSES.has(canon)) continue;
+  const match = e.report.match(/\]\(([^)]+)\)/);
+  if (!match) continue;
+  const link = match[1];
+  const path = existsSync(join(TRACKER_DIR, link)) ? join(TRACKER_DIR, link)
+    : existsSync(join(CAREER_OPS, link)) ? join(CAREER_OPS, link) : null;
+  if (!path) continue; // broken link already flagged by the report-links check
+  if (!/##\s*Machine Summary/i.test(readFileSync(path, 'utf-8'))) {
+    warn(`#${e.num} (${canon}): report missing "## Machine Summary" — analyze-patterns can't read its metadata`);
+    missingMachineSummary++;
+  }
+}
+if (missingMachineSummary === 0) ok('All actionable reports have a Machine Summary');
 
 // --- Summary ---
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What

Two warning-only health checks in `verify-pipeline.mjs`, in the same style as the existing eight (both warnings, not errors — the exit code is unchanged, so CI / `expectExit: 0` is unaffected):

- **Check 9 — duplicate report file numbers.** `reserve-report-num.mjs` and batch runs can collide on a number and write two files sharing the same prefix. The existing checks only catch duplicate tracker *rows*, so the orphaned twin stays invisible to scripts that iterate reports by number. The number match is `^(\d+)-` so it keeps working past 999 reports (when the slot width grows).
- **Check 10 — unparseable `## Machine Summary` on actionable rows.** For Applied / Responded / Interview / Offer rows, this warns when the linked report has no `## Machine Summary` block that `analyze-patterns.mjs` can actually parse. The regex mirrors `analyze-patterns.parseMachineSummary` exactly (`/##\s*Machine Summary\s*\n+```...\n```/i`) — a bare heading with no fenced YAML returns `null` there, so it must warn here too.

## Testability

Added a `CAREER_OPS_REPORTS_DIR` env override for the reports directory, mirroring the existing `CAREER_OPS_TRACKER` pattern.

## Test

New block in `test-all.mjs` over a tmp fixture: two report files colliding on number `070` (→ dup warning), an Applied report with a heading but **no fenced YAML** (→ unparseable warning), and a second Applied report with a **valid fenced** Machine Summary (→ asserts no false positive). Asserts the run still exits 0.

`node test-all.mjs --quick` → **379 passed, 0 failed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added coverage for pipeline integrity verification, including duplicate report-number detection and missing/invalid documentation sections.

* **New Features**
  * Reports directory can now be customized via environment variable configuration.

* **Bug Fixes**
  * Pipeline now detects and warns about duplicate report file numbers.
  * Pipeline validates that actionable records include a parseable `## Machine Summary` fenced block in the linked report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->