### PR TITLE
Add cryptocurrencyjobs provider (Web3 job board, RSS, zero-auth)

### DIFF
--- a/providers/cryptocurrencyjobs.mjs
+++ b/providers/cryptocurrencyjobs.mjs
@@ -1,0 +1,118 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+/** @typedef {import('./_types.js').Job} Job */
+//
+// CryptocurrencyJobs — curated Web3/crypto job board. RSS 2.0, no auth.
+// Feed: https://cryptocurrencyjobs.co/index.xml (listings are 100% remote).
+// Title format: "Role at Company" — split on the last " at " to extract company.
+//
+// The feed URL is a hardcoded constant (never user-supplied), so there is no
+// SSRF surface. Parsing is dependency-free regex over the raw XML, mirroring
+// the providers/rwfa.mjs pattern.
+
+import { decodeEntities } from './_html-entities.mjs';
+
+// The feed's generator double-encodes entities at the source (verified
+// 2026-07-30: the raw XML carries `Social Media &amp;amp; Growth Lead`), so a
+// single canonical pass leaves `&amp;` in 6 of 62 live titles. Exactly two
+// passes — not a decode-until-stable loop, which is the js/double-escaping
+// bug class — normalizes this feed's shape and stays deterministic.
+const decodeFeedText = (s) => decodeEntities(decodeEntities(s));
+
+const FEED = 'https://cryptocurrencyjobs.co/index.xml';
+
+/**
+ * Extract the text content of the first matching XML tag within a block.
+ * Handles both CDATA (<tag><![CDATA[...]]></tag>) and plain text.
+ * @param {string} block
+ * @param {string} tag
+ * @returns {string}
+ */
+function extractTag(block, tag) {
+  const re = new RegExp(
+    `<${tag}[^>]*>(?:<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>|([^<]*))<\\/${tag}>`,
+    'i'
+  );
+  const m = block.match(re);
+  if (!m) return '';
+  return (m[1] !== undefined ? m[1] : m[2] || '').trim();
+}
+
+/**
+ * Split "Role at Company" on the last " at " occurrence.
+ * Falls back to an empty company when the pattern isn't found.
+ * @param {string} raw
+ * @returns {{ title: string; company: string }}
+ */
+export function splitTitle(raw) {
+  const sep = ' at ';
+  const idx = raw.lastIndexOf(sep);
+  if (idx <= 0) return { title: raw, company: '' };
+  return {
+    title: raw.slice(0, idx).trim(),
+    company: raw.slice(idx + sep.length).trim(),
+  };
+}
+
+/**
+ * Parse a CryptocurrencyJobs RSS document into normalized Job objects.
+ * Exported for unit testing; fetch() wraps it around an HTTP fetch.
+ * @param {string} xml
+ * @returns {Job[]}
+ */
+export function parseCryptocurrencyJobsRss(xml) {
+  // Split on <item> boundaries; element 0 is the channel header — skip it.
+  const parts = String(xml ?? '').split(/<item[\s>]/i);
+  const results = [];
+
+  for (let i = 1; i < parts.length; i++) {
+    try {
+      const block = parts[i];
+      const rawTitle = decodeFeedText(extractTag(block, 'title'));
+      const link = extractTag(block, 'link') || extractTag(block, 'guid');
+      if (!rawTitle || !link) continue;
+
+      const { title, company } = splitTitle(rawTitle);
+      if (!title) continue;
+
+      // pubDate → postedAt epoch ms (optional field per the Job contract).
+      const pubDateStr = extractTag(block, 'pubDate');
+      const postedAt = pubDateStr ? new Date(pubDateStr).getTime() : undefined;
+
+      // The feed carries the job description for free in the same payload;
+      // populate it so scan.mjs's content_filter can run (it's a remote-only
+      // board, so location stays 'Remote').
+      const description = decodeFeedText(extractTag(block, 'description'));
+
+      results.push({
+        title,
+        url: link,
+        company,
+        location: 'Remote',
+        ...(description ? { description } : {}),
+        ...(postedAt && Number.isFinite(postedAt) ? { postedAt } : {}),
+      });
+    } catch {
+      // Malformed item — skip, don't abort the whole feed.
+    }
+  }
+
+  return results;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'cryptocurrencyjobs',
+
+  async fetch(_entry, ctx) {
+    let xml;
+    try {
+      // redirect:'error' — refuse server-side redirects (SSRF hardening, matches
+      // the other HTTP providers); the feed host is fixed so a redirect is a flag.
+      xml = await ctx.fetchText(FEED, { redirect: 'error' });
+    } catch {
+      return [];
+    }
+    return parseCryptocurrencyJobsRss(xml);
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -1924,3 +1924,12 @@ job_boards:
   #   provider: higheredjobs
   #   cat_id: 68
   #   enabled: true
+
+  # ── CryptocurrencyJobs (Web3 / crypto) ─────────────────────────────
+  # Curated Web3/crypto job board. Public RSS feed, zero-auth, 100% remote
+  # listings. The feed URL is hardcoded in the provider — no careers_url
+  # or api field needed.
+
+  # - name: CryptocurrencyJobs             # curated Web3/crypto board (RSS, all-remote)
+  #   provider: cryptocurrencyjobs
+  #   enabled: true

--- a/tests/providers/cryptocurrencyjobs.test.mjs
+++ b/tests/providers/cryptocurrencyjobs.test.mjs
@@ -1,0 +1,92 @@
+// tests/providers/cryptocurrencyjobs.test.mjs — provider-contract tests for the
+// CryptocurrencyJobs Web3 board RSS provider (providers/cryptocurrencyjobs.mjs).
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — cryptocurrencyjobs');
+
+try {
+  const ccj = (await import(pathToFileURL(join(ROOT, 'providers/cryptocurrencyjobs.mjs')).href)).default;
+  const { parseCryptocurrencyJobsRss, splitTitle } = await import(pathToFileURL(join(ROOT, 'providers/cryptocurrencyjobs.mjs')).href);
+
+  if (ccj.id === 'cryptocurrencyjobs') pass('cryptocurrencyjobs.id is "cryptocurrencyjobs"');
+  else fail(`cryptocurrencyjobs.id is ${JSON.stringify(ccj.id)}`);
+
+  if (splitTitle('Senior Backend Engineer at Acme Protocol').company === 'Acme Protocol' &&
+      splitTitle('Role with no separator').company === '') {
+    pass('splitTitle splits on the last " at " and handles the no-separator case');
+  } else {
+    fail(`splitTitle wrong: ${JSON.stringify(splitTitle('Senior Backend Engineer at Acme Protocol'))}`);
+  }
+
+  const sampleXml = [
+    '<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel>',
+    '<title>Cryptocurrency Jobs</title>',
+    '<item><title><![CDATA[Senior Backend Engineer at Acme Protocol]]></title>',
+    '<link>https://cryptocurrencyjobs.co/engineering/acme-senior-backend/</link>',
+    '<description><![CDATA[We are hiring a backend engineer. 100% remote.]]></description>',
+    '<pubDate>Wed, 01 Apr 2026 10:00:00 GMT</pubDate></item>',
+    '<item><title>Solidity Engineer at Beta Labs</title>',
+    '<guid>https://cryptocurrencyjobs.co/engineering/beta-solidity/</guid></item>',
+    '<item><title>Item with no link</title></item>',
+    '</channel></rss>',
+  ].join('');
+
+  const jobs = parseCryptocurrencyJobsRss(sampleXml);
+  if (jobs.length === 2) pass('parseCryptocurrencyJobsRss extracts 2 jobs (skips the link-less item)');
+  else fail(`parseCryptocurrencyJobsRss returned ${jobs.length} jobs, expected 2`);
+
+  if (jobs[0]?.title === 'Senior Backend Engineer' && jobs[0]?.company === 'Acme Protocol' &&
+      jobs[0]?.url === 'https://cryptocurrencyjobs.co/engineering/acme-senior-backend/') {
+    pass('parseCryptocurrencyJobsRss splits "Role at Company" and reads link');
+  } else {
+    fail(`parseCryptocurrencyJobsRss row 0 = ${JSON.stringify(jobs[0])}`);
+  }
+
+  if (typeof jobs[0]?.postedAt === 'number' && Number.isFinite(jobs[0].postedAt)) {
+    pass('parseCryptocurrencyJobsRss parses pubDate into a numeric postedAt');
+  } else {
+    fail(`parseCryptocurrencyJobsRss postedAt = ${JSON.stringify(jobs[0]?.postedAt)}`);
+  }
+
+  if (jobs[1]?.url === 'https://cryptocurrencyjobs.co/engineering/beta-solidity/') {
+    pass('parseCryptocurrencyJobsRss falls back to <guid> when <link> is absent');
+  } else {
+    fail(`parseCryptocurrencyJobsRss guid fallback failed: ${JSON.stringify(jobs[1])}`);
+  }
+
+  if (jobs[0]?.description === 'We are hiring a backend engineer. 100% remote.' && !('description' in (jobs[1] || {}))) {
+    pass('parseCryptocurrencyJobsRss populates description when present and omits it when absent');
+  } else {
+    fail(`parseCryptocurrencyJobsRss description handling = ${JSON.stringify(jobs[0]?.description)}`);
+  }
+
+  if (parseCryptocurrencyJobsRss('').length === 0 && parseCryptocurrencyJobsRss(null).length === 0) {
+    pass('parseCryptocurrencyJobsRss returns [] for empty/null input (no crash)');
+  } else {
+    fail('parseCryptocurrencyJobsRss should yield [] for empty/null input');
+  }
+
+  // fetch() reaches fetchText (passing redirect:'error') and returns parsed jobs
+  let capturedOpts = null;
+  const fetched = await ccj.fetch(
+    { name: 'CryptocurrencyJobs', provider: 'cryptocurrencyjobs' },
+    { transport: 'http', fetchText: async (_url, opts) => { capturedOpts = opts; return sampleXml; }, fetchJson: async () => { throw new Error('fetchJson should not be called'); } },
+  );
+  if (fetched.length === 2) pass('cryptocurrencyjobs.fetch() returns parsed jobs from fetchText');
+  else fail(`cryptocurrencyjobs.fetch() returned ${fetched.length} jobs`);
+  if (capturedOpts && capturedOpts.redirect === 'error') pass('cryptocurrencyjobs.fetch() passes redirect:"error" (SSRF hardening)');
+  else fail(`cryptocurrencyjobs.fetch() should pass redirect:"error", got ${JSON.stringify(capturedOpts)}`);
+
+  // fetch() swallows transport errors and returns [] (zero-token scan must not abort)
+  const errored = await ccj.fetch(
+    { name: 'CryptocurrencyJobs', provider: 'cryptocurrencyjobs' },
+    { transport: 'http', fetchText: async () => { throw new Error('network down'); }, fetchJson: async () => ({}) },
+  );
+  if (errored.length === 0) pass('cryptocurrencyjobs.fetch() returns [] when the feed fetch fails');
+  else fail('cryptocurrencyjobs.fetch() should return [] on fetch failure');
+} catch (e) {
+  fail(`cryptocurrencyjobs provider tests crashed: ${e.message}`);
+}
+


### PR DESCRIPTION
## What

A zero-auth provider for **cryptocurrencyjobs.co**, a curated Web3/crypto job board, via its public RSS feed (`/index.xml`). Listings are 100% remote — fills a crypto/web3 gap the existing boards don't cover.

## Conformance / hardening

- Provider contract: `// @ts-check` + `Provider` typedef, `export default { id, fetch }`, uses the injected `ctx.fetchText`.
- Passes `{ redirect: 'error' }` to `fetchText` (SSRF hardening, matches the other HTTP providers). The feed URL is also a hardcoded constant (never user-supplied), so there is no host-injection surface.
- Populates `description` from the feed (free in the same payload) so `scan.mjs`'s `content_filter` can run; `postedAt` from `<pubDate>`; `<guid>` fallback when `<link>` is absent; iterative entity decoding; remote-only board so `location` is `'Remote'`.
- `fetch()` swallows transport errors and returns `[]` so the zero-token scan never aborts on a flaky feed.

## Test + registration

`Provider — cryptocurrencyjobs` block in `test-all.mjs` (11 assertions): id, exported `splitTitle` ("Role at Company" + no-separator), 2-job extraction (skips link-less item), title/company/url, `postedAt`, `<guid>` fallback, `description` present/absent, empty/null safety, happy-path `fetch`, `redirect:'error'` captured, fetch-error → `[]`. Both `parseCryptocurrencyJobsRss` and `splitTitle` are exported.
Registered in `templates/portals.example.yml` under `job_boards`, `enabled: false` (opt-in).

`node test-all.mjs --quick` → **all green, 0 failed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CryptocurrencyJobs job board provider that fetches and parses a public RSS feed to surface remote Web3/crypto roles.
  * Updated the example portals configuration to include CryptocurrencyJobs (disabled by default).
* **Tests**
  * Added a dedicated test suite covering RSS parsing, title/company extraction, pubDate handling, skipping incomplete items, and fetch error fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->