### PR TITLE
Harden lever/ashby/workday against SSRF via redirect

### DIFF
--- a/providers/ashby.mjs
+++ b/providers/ashby.mjs
@@ -138,7 +138,7 @@ export default {
         await sleep(backoff);
       }
       try {
-        const json = /** @type {any} */ (await ctx.fetchJson(apiUrl, { timeoutMs: ASHBY_TIMEOUT_MS }));
+        const json = /** @type {any} */ (await ctx.fetchJson(apiUrl, { timeoutMs: ASHBY_TIMEOUT_MS, redirect: 'error' }));
         const jobs = Array.isArray(json?.jobs) ? json.jobs : [];
         return jobs.map(/** @param {any} j */ (j) => ({
           title: j.title || '',

--- a/providers/lever.mjs
+++ b/providers/lever.mjs
@@ -23,7 +23,7 @@ export default {
   async fetch(entry, ctx) {
     const apiUrl = resolveApiUrl(entry);
     if (!apiUrl) throw new Error(`lever: cannot derive API URL for ${entry.name}`);
-    const json = await ctx.fetchJson(apiUrl);
+    const json = await ctx.fetchJson(apiUrl, { redirect: 'error' });
     if (!Array.isArray(json)) return [];
     return json.map(j => ({
       title: j.text || '',

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -60,6 +60,7 @@ export default {
       });
       const json = await ctx.fetchJson(ep.api, {
         method: 'POST',
+        redirect: 'error',
         body,
         headers: { 'content-type': 'application/json', accept: 'application/json' },
       });

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2917,6 +2917,45 @@ try {
   fail(`solidjobs provider tests crashed: ${e.message}`);
 }
 
+// ── 16. SSRF redirect hardening (lever / ashby / workday) ───────
+// _http.mjs defaults to redirect:'follow', so a server-side redirect from any
+// of these ATS APIs to an internal address is an SSRF vector. Every other GET
+// provider passes redirect:'error'; these three were missing it.
+
+console.log('\n16. Provider — SSRF redirect hardening (lever / ashby / workday)');
+
+try {
+  const lever = (await import(pathToFileURL(join(ROOT, 'providers/lever.mjs')).href)).default;
+  const ashby = (await import(pathToFileURL(join(ROOT, 'providers/ashby.mjs')).href)).default;
+  const workday = (await import(pathToFileURL(join(ROOT, 'providers/workday.mjs')).href)).default;
+
+  let leverOpts = null;
+  await lever.fetch(
+    { name: 'L', careers_url: 'https://jobs.lever.co/example' },
+    { transport: 'http', fetchJson: async (_u, opts) => { leverOpts = opts; return []; }, fetchText: async () => '' },
+  );
+  if (leverOpts && leverOpts.redirect === 'error') pass('lever.fetch() passes redirect:"error"');
+  else fail(`lever.fetch() should pass redirect:"error", got ${JSON.stringify(leverOpts)}`);
+
+  let ashbyOpts = null;
+  await ashby.fetch(
+    { name: 'A', careers_url: 'https://jobs.ashbyhq.com/example' },
+    { transport: 'http', fetchJson: async (_u, opts) => { ashbyOpts = opts; return { jobs: [] }; }, fetchText: async () => '' },
+  );
+  if (ashbyOpts && ashbyOpts.redirect === 'error') pass('ashby.fetch() passes redirect:"error"');
+  else fail(`ashby.fetch() should pass redirect:"error", got ${JSON.stringify(ashbyOpts)}`);
+
+  let workdayOpts = null;
+  await workday.fetch(
+    { name: 'W', careers_url: 'https://example.wd5.myworkdayjobs.com/careers' },
+    { transport: 'http', fetchJson: async (_u, opts) => { workdayOpts = opts; return { jobPostings: [] }; }, fetchText: async () => '' },
+  );
+  if (workdayOpts && workdayOpts.redirect === 'error') pass('workday.fetch() passes redirect:"error"');
+  else fail(`workday.fetch() should pass redirect:"error", got ${JSON.stringify(workdayOpts)}`);
+} catch (e) {
+  fail(`SSRF redirect hardening tests crashed: ${e.message}`);
+}
+
 // ── 15. URL REDISCOVERY FALLBACK (--rediscover-404) ─────────────
 
 console.log('\n15. URL rediscovery fallback');


### PR DESCRIPTION
## Problem

`providers/_http.mjs` defaults to `redirect: 'follow'`. A server-side redirect from one of these ATS APIs to an internal/metadata address (e.g. `169.254.169.254`) would be followed — an SSRF vector. Every other GET provider (`remoteok`, `remotive`, `workingnomads`, `solidjobs`, …) already passes `redirect: 'error'`; three were missing it:

- `lever.mjs:26` — `ctx.fetchJson(apiUrl)` (Lever is one of the highest-volume ATS providers)
- `ashby.mjs:141` — `ctx.fetchJson(apiUrl, { timeoutMs })` (Ashby is the other)
- `workday.mjs:61` — the POST options object (Workday covers hundreds of enterprise tenants)

## Fix

One option added per provider: `redirect: 'error'`. No behavior change on the happy path (these APIs don't redirect); a redirect now throws instead of being followed, and the provider's existing try/catch returns `[]`.

## Test

New `Provider — SSRF redirect hardening` block in `test-all.mjs`: drives each provider's `fetch()` with a capturing `fetchJson` mock and asserts `redirect === 'error'` is passed (the `solidjobs` test is the pattern).

`node test-all.mjs --quick` → **379 passed, 0 failed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP redirect handling for Ashby, Lever, and Workday job posting providers.

* **Tests**
  * Added tests to verify redirect behavior is properly configured for Ashby, Lever, and Workday providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->