### PR TITLE
Fix: optional Location column breaks dedup/normalize/analyze/followup (shared column-map)

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -16,6 +16,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { load as yamlLoad } from 'js-yaml';
+import { resolveColumns, parseTrackerRow } from './column-map.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -152,19 +153,12 @@ next_action: "Follow up on ticket #42 with tailored CV"
 // --- Parse applications.md ---
 function parseTracker() {
   if (!existsSync(APPS_FILE)) return [];
-  const content = readFileSync(APPS_FILE, 'utf-8');
+  const lines = readFileSync(APPS_FILE, 'utf-8').split('\n');
+  const colmap = resolveColumns(lines);
   const entries = [];
-  for (const line of content.split('\n')) {
-    if (!line.startsWith('|')) continue;
-    const parts = line.split('|').map(s => s.trim());
-    if (parts.length < 9) continue;
-    const num = parseInt(parts[1]);
-    if (isNaN(num)) continue;
-    entries.push({
-      num, date: parts[2], company: parts[3], role: parts[4],
-      score: parts[5], status: parts[6], pdf: parts[7], report: parts[8],
-      notes: parts[9] || '',
-    });
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (row) entries.push(row);
   }
   return entries;
 }

--- a/column-map.mjs
+++ b/column-map.mjs
@@ -1,0 +1,88 @@
+// @ts-check
+//
+// Shared applications.md column-map detection.
+//
+// The tracker table has an optional Location column (inserted after Role) and
+// localized headers (e.g. "Empresa"/"Puesto" in the Spanish modes), so column
+// positions are not fixed. Scripts must map columns by header NAME and fall
+// back to the legacy fixed 9-column layout when no header row is present.
+//
+// merge-tracker.mjs and verify-pipeline.mjs already did this; the logic lived
+// in two verbatim copies. The dedup-tracker / normalize-statuses /
+// analyze-patterns / followup-cadence scripts hardcoded `parts[5]`/`parts[6]`
+// instead, so they misread Score as Status (and could write a status back into
+// the Score cell) whenever the Location column was enabled. Centralizing the
+// detection here is the single source of truth for every tracker reader.
+
+/** @type {Record<string, number>} */
+export const LEGACY_COLMAP = { num: 1, date: 2, company: 3, role: 4, score: 5, status: 6, pdf: 7, report: 8, notes: 9 };
+
+/** @type {Record<string, string>} */
+export const HEADER_ALIASES = {
+  '#': 'num', 'num': 'num', 'date': 'date', 'company': 'company', 'empresa': 'company',
+  'role': 'role', 'puesto': 'role', 'location': 'location', 'score': 'score',
+  'status': 'status', 'pdf': 'pdf', 'report': 'report', 'notes': 'notes',
+};
+
+/**
+ * Detect tracker column indices from the markdown header row.
+ *
+ * Splits each table row on `|` (the leading `|` yields an empty cell at index
+ * 0, so a header's `#` lands at index 1 — matching LEGACY_COLMAP). Returns the
+ * first row that carries Company + Role and resolves the required columns.
+ *
+ * @param {string[]} lines - Lines of applications.md.
+ * @returns {Record<string, number>|null} Column→index map, or null when no
+ *   header row is found (caller should fall back to LEGACY_COLMAP).
+ */
+export function detectColumns(lines) {
+  for (const line of lines) {
+    if (!line.startsWith('|')) continue;
+    const cells = line.split('|').map(s => s.trim().toLowerCase());
+    if (!cells.includes('company') || !cells.includes('role')) continue;
+    const map = {};
+    cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
+    if (['num', 'company', 'role', 'score', 'status'].every(k => map[k] != null)) return map;
+  }
+  return null;
+}
+
+/**
+ * Resolve the column map for a tracker, falling back to the legacy layout.
+ * @param {string[]} lines - Lines of applications.md.
+ * @returns {Record<string, number>}
+ */
+export function resolveColumns(lines) {
+  return detectColumns(lines) || LEGACY_COLMAP;
+}
+
+/**
+ * Parse one applications.md table row into a normalized object using a column
+ * map. Returns null for header/separator/malformed rows (num not an integer or
+ * too few cells). The Location field is '' when the tracker has no Location
+ * column.
+ *
+ * @param {string} line - A single line from applications.md.
+ * @param {Record<string, number>} colmap - From resolveColumns().
+ * @returns {{num:number,date:string,company:string,role:string,location:string,score:string,status:string,pdf:string,report:string,notes:string}|null}
+ */
+export function parseTrackerRow(line, colmap) {
+  if (!line.startsWith('|')) return null;
+  const parts = line.split('|').map(s => s.trim());
+  const maxIdx = Math.max(...Object.values(colmap));
+  if (parts.length <= maxIdx) return null;
+  const num = parseInt(parts[colmap.num]);
+  if (isNaN(num)) return null;
+  return {
+    num,
+    date: parts[colmap.date],
+    company: parts[colmap.company],
+    role: parts[colmap.role],
+    location: colmap.location != null ? parts[colmap.location] : '',
+    score: parts[colmap.score],
+    status: parts[colmap.status],
+    pdf: parts[colmap.pdf],
+    report: parts[colmap.report],
+    notes: colmap.notes != null ? (parts[colmap.notes] || '') : '',
+  };
+}

--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -13,6 +13,7 @@ import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { roleFuzzyMatch } from './role-matcher.mjs';
+import { resolveColumns, parseTrackerRow } from './column-map.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md
@@ -251,22 +252,10 @@ function rebuildRow(parts) {
 }
 
 function parseAppLine(line) {
-  const parts = line.split('|').map(s => s.trim());
-  if (parts.length < 9) return null;
-  const num = parseInt(parts[1]);
-  if (isNaN(num)) return null;
-  return {
-    num,
-    date: parts[2],
-    company: parts[3],
-    role: parts[4],
-    score: parts[5],
-    status: parts[6],
-    pdf: parts[7],
-    report: parts[8],
-    notes: parts[9] || '',
-    raw: line,
-  };
+  // Column indices come from COLMAP (resolved by header) so Score/Status read
+  // correctly when an optional Location column shifts their positions.
+  const row = parseTrackerRow(line, COLMAP);
+  return row ? { ...row, raw: line } : null;
 }
 
 // Read
@@ -276,6 +265,10 @@ if (!existsSync(APPS_FILE)) {
 }
 const content = readFileSync(APPS_FILE, 'utf-8');
 const lines = content.split('\n');
+// Resolve columns by header (shared via column-map.mjs) so parseAppLine and the
+// status write-back below address Score/Status correctly even when an optional
+// Location column is present.
+const COLMAP = resolveColumns(lines);
 
 // Parse all entries
 const entries = [];
@@ -343,7 +336,7 @@ for (const [company, companyEntries] of groups) {
       const lineIdx = keeper.lineIdx;
       if (lineIdx !== undefined) {
         const parts = lines[lineIdx].split('|').map(s => s.trim());
-        parts[6] = bestStatus;
+        parts[COLMAP.status] = bestStatus;
         lines[lineIdx] = rebuildRow(parts);
         console.log(`  📝 #${keeper.num}: status promoted to "${bestStatus}" (from #${cluster.find(e => e.status === bestStatus)?.num})`);
       }

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -15,6 +15,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import yaml from 'js-yaml';
+import { resolveColumns, parseTrackerRow } from './column-map.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -138,19 +139,12 @@ export function addDays(date, days) {
 // --- Parse applications.md ---
 function parseTracker() {
   if (!existsSync(APPS_FILE)) return [];
-  const content = readFileSync(APPS_FILE, 'utf-8');
+  const lines = readFileSync(APPS_FILE, 'utf-8').split('\n');
+  const colmap = resolveColumns(lines);
   const entries = [];
-  for (const line of content.split('\n')) {
-    if (!line.startsWith('|')) continue;
-    const parts = line.split('|').map(s => s.trim());
-    if (parts.length < 9) continue;
-    const num = parseInt(parts[1]);
-    if (isNaN(num)) continue;
-    entries.push({
-      num, date: parts[2], company: parts[3], role: parts[4],
-      score: parts[5], status: parts[6], pdf: parts[7], report: parts[8],
-      notes: parts[9] || '',
-    });
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (row) entries.push(row);
   }
   return entries;
 }

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -18,6 +18,7 @@ import { readFileSync, writeFileSync, readdirSync, mkdirSync, renameSync, exists
 import { join, basename, dirname, resolve, relative, isAbsolute, sep } from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
+import { LEGACY_COLMAP, detectColumns } from './column-map.mjs';
 import { createHash, randomUUID } from 'crypto';
 import { tmpdir } from 'os';
 import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
@@ -427,31 +428,8 @@ function parseScore(s) {
 // position so both work — fixed-position indexing would otherwise read, say,
 // Location where it expects Score. Falls back to the legacy layout when no
 // recognizable header row is found.
-const LEGACY_COLMAP = { num: 1, date: 2, company: 3, role: 4, score: 5, status: 6, pdf: 7, report: 8, notes: 9 };
+// Column detection (LEGACY_COLMAP + detectColumns) is shared via column-map.mjs.
 let COLMAP = LEGACY_COLMAP;
-
-const HEADER_ALIASES = {
-  '#': 'num', 'num': 'num', 'date': 'date', 'company': 'company', 'empresa': 'company',
-  'role': 'role', 'puesto': 'role', 'location': 'location', 'score': 'score',
-  'status': 'status', 'pdf': 'pdf', 'report': 'report', 'notes': 'notes',
-};
-
-// Scan the table for a header row and build a header-name → column-index map.
-// Indexing matches `line.split('|')` (leading empty cell before the first pipe),
-// the same split parseAppLine uses. Returns null — caller keeps the legacy
-// layout — unless the essential columns are all present, so a stray pipe line
-// can't yield a bogus mapping.
-function detectColumns(lines) {
-  for (const line of lines) {
-    if (!line.startsWith('|')) continue;
-    const cells = line.split('|').map(s => s.trim().toLowerCase());
-    if (!cells.includes('company') || !cells.includes('role')) continue;
-    const map = {};
-    cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
-    if (['num', 'company', 'role', 'score', 'status'].every(k => map[k] != null)) return map;
-  }
-  return null;
-}
 
 // Build a tracker row string matching the detected layout (with or without the
 // optional Location column) so writes round-trip through the same schema.

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -14,6 +14,7 @@
 import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { resolveColumns } from './column-map.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original)
@@ -110,6 +111,9 @@ if (!existsSync(APPS_FILE)) {
 }
 const content = readFileSync(APPS_FILE, 'utf-8');
 const lines = content.split('\n');
+// Resolve columns by header so Score/Status read correctly when an optional
+// Location column shifts their positions (shared with column-map.mjs).
+const COLMAP = resolveColumns(lines);
 
 let changes = 0;
 let unknowns = [];
@@ -126,7 +130,7 @@ for (let i = 0; i < lines.length; i++) {
   const num = parseInt(parts[1]);
   if (isNaN(num)) continue;
 
-  const rawStatus = parts[6];
+  const rawStatus = parts[COLMAP.status];
   const result = normalizeStatus(rawStatus);
 
   if (result.unknown) {
@@ -138,21 +142,20 @@ for (let i = 0; i < lines.length; i++) {
 
   // Apply change
   const oldStatus = rawStatus;
-  parts[6] = result.status;
+  parts[COLMAP.status] = result.status;
 
   // Move DUPLICADO info to notes if needed
-  if (result.moveToNotes && parts[9]) {
-    const existing = parts[9] || '';
+  const notesIdx = COLMAP.notes;
+  if (result.moveToNotes && notesIdx != null) {
+    const existing = parts[notesIdx] || '';
     if (!existing.includes(result.moveToNotes)) {
-      parts[9] = result.moveToNotes + (existing ? '. ' + existing : '');
+      parts[notesIdx] = result.moveToNotes + (existing ? '. ' + existing : '');
     }
-  } else if (result.moveToNotes && !parts[9]) {
-    parts[9] = result.moveToNotes;
   }
 
   // Also strip bold from score field
-  if (parts[5]) {
-    parts[5] = parts[5].replace(/\*\*/g, '');
+  if (parts[COLMAP.score]) {
+    parts[COLMAP.score] = parts[COLMAP.score].replace(/\*\*/g, '');
   }
 
   // Reconstruct line

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2227,6 +2227,83 @@ try {
   fail(`shared role matcher / dedup safety tests crashed: ${e.message}`);
 }
 
+// ── SHARED COLUMN MAP + OPTIONAL LOCATION COLUMN ────────────────
+// column-map.mjs is the single source of truth for tracker column detection.
+// dedup-tracker / normalize-statuses / analyze-patterns / followup-cadence used
+// to hardcode parts[5]=score / parts[6]=status; with the optional Location
+// column (inserted after Role) those offsets shift, so they read Score as
+// Status and could write a status back into the Score cell. They now resolve
+// columns by header like merge-tracker.mjs and verify-pipeline.mjs.
+console.log('\n🧪 Testing shared column map + optional Location column...');
+try {
+  const { resolveColumns, parseTrackerRow } = await import(pathToFileURL(join(ROOT, 'column-map.mjs')).href);
+
+  const legacy = resolveColumns(['| # | Date | Company | Role | Score | Status | PDF | Report | Notes |']);
+  if (legacy.score === 5 && legacy.status === 6 && legacy.location == null) {
+    pass('resolveColumns maps the 9-column layout (Score=5, Status=6, no Location)');
+  } else {
+    fail(`resolveColumns 9-col wrong: ${JSON.stringify(legacy)}`);
+  }
+
+  const withLoc = resolveColumns(['| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |']);
+  if (withLoc.location === 5 && withLoc.score === 6 && withLoc.status === 7) {
+    pass('resolveColumns shifts Score/Status when a Location column is present');
+  } else {
+    fail(`resolveColumns Location layout wrong: ${JSON.stringify(withLoc)}`);
+  }
+
+  if (resolveColumns(['plain text, no table']).score === 5) {
+    pass('resolveColumns falls back to the legacy layout when no header row exists');
+  } else {
+    fail('resolveColumns should fall back to LEGACY_COLMAP without a header');
+  }
+
+  const row = parseTrackerRow('| 1 | 2026-01-01 | Acme | Backend Engineer | Remote | 4.2/5 | Applied | ❌ | [1](../reports/001.md) | n |', withLoc);
+  if (row && row.score === '4.2/5' && row.status === 'Applied' && row.location === 'Remote' && row.company === 'Acme') {
+    pass('parseTrackerRow reads Score/Status/Location correctly with a Location column');
+  } else {
+    fail(`parseTrackerRow Location row wrong: ${JSON.stringify(row)}`);
+  }
+  if (parseTrackerRow('| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |', withLoc) === null) {
+    pass('parseTrackerRow returns null for the header row');
+  } else {
+    fail('parseTrackerRow should return null for the header row');
+  }
+
+  // Integration: dedup-tracker on a Location-column tracker must dedup correctly
+  // (it read Score as Status before, so it missed the duplicate entirely).
+  const colTmp = mkdtempSync(join(tmpdir(), 'career-ops-colmap-'));
+  try {
+    mkdirSync(join(colTmp, 'data'));
+    const tracker = join(colTmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|----------|-------|--------|-----|--------|-------|\n' +
+      '| 1 | 2026-05-01 | Acme | Product Engineer, Growth | Remote | 3.0/5 | Evaluated | ❌ | [1](../reports/001-a.md) | lower-scored dup |\n' +
+      '| 2 | 2026-05-02 | Acme | Product Engineer, Growth | Remote | 4.5/5 | Evaluated | ❌ | [2](../reports/002-b.md) | higher-scored dup |\n');
+
+    const r = run(NODE, ['dedup-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
+    if (r === null) {
+      fail('dedup-tracker.mjs crashed on a Location-column tracker');
+    } else {
+      const dataRows = readFileSync(tracker, 'utf-8').split('\n').filter(l => /^\|\s*\d/.test(l));
+      // The fix lets dedup read Score from the Location-shifted column, so it
+      // keeps the genuinely higher-scored row (4.5). The old hardcoded offset
+      // read Location ("Remote") as the score → both scored 0 → wrong keeper.
+      if (dataRows.length === 1 && dataRows[0].includes('4.5/5') && dataRows[0].includes('Evaluated')) {
+        pass('dedup-tracker deduplicates a Location-column tracker, keeping the higher-scored row');
+      } else {
+        fail(`dedup-tracker Location dedup wrong: ${dataRows.length} rows -> ${JSON.stringify(dataRows)}`);
+      }
+    }
+  } finally {
+    rmSync(colTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`shared column map tests crashed: ${e.message}`);
+}
+
 // dedup-tracker / normalize-statuses rebuilt promoted rows with
 // `parts.slice(1, -1)`, which assumes the closing `|` produced a trailing empty
 // cell. A valid row written WITHOUT a trailing pipe keeps its real last cell

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -17,6 +17,7 @@
 import { readFileSync, readdirSync, existsSync, mkdirSync, unlinkSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { resolveColumns } from './column-map.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original).
@@ -73,24 +74,9 @@ const lines = content.split('\n');
 // Location column after Role). Fixed-position indexing would otherwise read
 // Location where Score is expected and flag false errors. Falls back to the
 // legacy fixed layout when no recognizable header row is found.
-const LEGACY_COLMAP = { num: 1, date: 2, company: 3, role: 4, score: 5, status: 6, pdf: 7, report: 8, notes: 9 };
-const HEADER_ALIASES = {
-  '#': 'num', 'num': 'num', 'date': 'date', 'company': 'company', 'empresa': 'company',
-  'role': 'role', 'puesto': 'role', 'location': 'location', 'score': 'score',
-  'status': 'status', 'pdf': 'pdf', 'report': 'report', 'notes': 'notes',
-};
-function detectColumns(allLines) {
-  for (const line of allLines) {
-    if (!line.startsWith('|')) continue;
-    const cells = line.split('|').map(s => s.trim().toLowerCase());
-    if (!cells.includes('company') || !cells.includes('role')) continue;
-    const map = {};
-    cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
-    if (['num', 'company', 'role', 'score', 'status'].every(k => map[k] != null)) return map;
-  }
-  return null;
-}
-const COLMAP = detectColumns(lines) || LEGACY_COLMAP;
+// Column detection is shared via column-map.mjs (resolveColumns falls back to
+// the legacy fixed layout when no recognizable header row is found).
+const COLMAP = resolveColumns(lines);
 const MAX_IDX = Math.max(...Object.values(COLMAP));
 
 const entries = [];


### PR DESCRIPTION
## Problem

The tracker table supports an **optional Location column** (inserted after Role) — `merge-tracker.mjs` and `verify-pipeline.mjs` already detect it by header name, and the most recent feature is literally "customizable columns". But four other scripts hardcoded `parts[5]=score` / `parts[6]=status`, so when the Location column is present every offset shifts and they read **Score as Status** (and can write a status back into the Score cell):

- `normalize-statuses.mjs` — flags every row as an unknown status (it reads the score, e.g. `"4.2/5"`, as the status). Reproduced:
  ```
  ⚠️  1 unknown statuses:
    #1 (line 5): "4.2/5"
  ```
- `dedup-tracker.mjs` — reads Location (`"Remote"`) as the score, so both duplicates score 0 and it keeps the **wrong** row; `parts[6] = bestStatus` on the promotion path writes a status into the **Score** cell.
- `analyze-patterns.mjs` — feeds inverted Score/Status into the analytics.
- `followup-cadence.mjs` — computes cadence from the wrong status.

## Fix

Introduce **`column-map.mjs`** as the single source of truth for tracker column detection (`LEGACY_COLMAP`, `detectColumns`, `resolveColumns`, `parseTrackerRow`). The two verbatim copies in `merge-tracker.mjs` and `verify-pipeline.mjs` now import it (no behavior change), and the four hardcoded scripts resolve columns by header instead of fixed offsets. Legacy 9-column trackers are unaffected (the detector falls back to the fixed layout when there's no recognizable header).

## Tests

New `shared column map + optional Location column` block in `test-all.mjs`:
- `resolveColumns` maps the 9-col layout, shifts Score/Status when Location is present, and falls back to legacy with no header.
- `parseTrackerRow` reads Score/Status/Location correctly and rejects the header row.
- Integration: `dedup-tracker` on a Location-column tracker deduplicates and keeps the genuinely higher-scored row (fails on the old hardcoded offset, which read Location as the score).

`node test-all.mjs --quick` → **383 passed, 0 failed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tracker tables now support optional columns (e.g., Location) with automatic layout detection.

* **Bug Fixes**
  * Fixed incorrect column parsing when table structure varies across tracker files.
  * Improved handling of alternative header names and formats.

* **Tests**
  * Added validation tests for flexible table column detection and row parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->