### PR TITLE
Tracker pipeline: i18n + optional Location column + integrity checks

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -16,6 +16,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { load as yamlLoad } from 'js-yaml';
+import { resolveColumns, parseTrackerRow } from './column-map.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -152,19 +153,12 @@ next_action: "Follow up on ticket #42 with tailored CV"
 // --- Parse applications.md ---
 function parseTracker() {
   if (!existsSync(APPS_FILE)) return [];
-  const content = readFileSync(APPS_FILE, 'utf-8');
+  const lines = readFileSync(APPS_FILE, 'utf-8').split('\n');
+  const colmap = resolveColumns(lines);
   const entries = [];
-  for (const line of content.split('\n')) {
-    if (!line.startsWith('|')) continue;
-    const parts = line.split('|').map(s => s.trim());
-    if (parts.length < 9) continue;
-    const num = parseInt(parts[1]);
-    if (isNaN(num)) continue;
-    entries.push({
-      num, date: parts[2], company: parts[3], role: parts[4],
-      score: parts[5], status: parts[6], pdf: parts[7], report: parts[8],
-      notes: parts[9] || '',
-    });
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (row) entries.push(row);
   }
   return entries;
 }

--- a/column-map.mjs
+++ b/column-map.mjs
@@ -1,0 +1,88 @@
+// @ts-check
+//
+// Shared applications.md column-map detection.
+//
+// The tracker table has an optional Location column (inserted after Role) and
+// localized headers (e.g. "Empresa"/"Puesto" in the Spanish modes), so column
+// positions are not fixed. Scripts must map columns by header NAME and fall
+// back to the legacy fixed 9-column layout when no header row is present.
+//
+// merge-tracker.mjs and verify-pipeline.mjs already did this; the logic lived
+// in two verbatim copies. The dedup-tracker / normalize-statuses /
+// analyze-patterns / followup-cadence scripts hardcoded `parts[5]`/`parts[6]`
+// instead, so they misread Score as Status (and could write a status back into
+// the Score cell) whenever the Location column was enabled. Centralizing the
+// detection here is the single source of truth for every tracker reader.
+
+/** @type {Record<string, number>} */
+export const LEGACY_COLMAP = { num: 1, date: 2, company: 3, role: 4, score: 5, status: 6, pdf: 7, report: 8, notes: 9 };
+
+/** @type {Record<string, string>} */
+export const HEADER_ALIASES = {
+  '#': 'num', 'num': 'num', 'date': 'date', 'company': 'company', 'empresa': 'company',
+  'role': 'role', 'puesto': 'role', 'location': 'location', 'score': 'score',
+  'status': 'status', 'pdf': 'pdf', 'report': 'report', 'notes': 'notes',
+};
+
+/**
+ * Detect tracker column indices from the markdown header row.
+ *
+ * Splits each table row on `|` (the leading `|` yields an empty cell at index
+ * 0, so a header's `#` lands at index 1 — matching LEGACY_COLMAP). Returns the
+ * first row that carries Company + Role and resolves the required columns.
+ *
+ * @param {string[]} lines - Lines of applications.md.
+ * @returns {Record<string, number>|null} Column→index map, or null when no
+ *   header row is found (caller should fall back to LEGACY_COLMAP).
+ */
+export function detectColumns(lines) {
+  for (const line of lines) {
+    if (!line.startsWith('|')) continue;
+    const cells = line.split('|').map(s => s.trim().toLowerCase());
+    if (!cells.includes('company') || !cells.includes('role')) continue;
+    const map = {};
+    cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
+    if (['num', 'company', 'role', 'score', 'status'].every(k => map[k] != null)) return map;
+  }
+  return null;
+}
+
+/**
+ * Resolve the column map for a tracker, falling back to the legacy layout.
+ * @param {string[]} lines - Lines of applications.md.
+ * @returns {Record<string, number>}
+ */
+export function resolveColumns(lines) {
+  return detectColumns(lines) || LEGACY_COLMAP;
+}
+
+/**
+ * Parse one applications.md table row into a normalized object using a column
+ * map. Returns null for header/separator/malformed rows (num not an integer or
+ * too few cells). The Location field is '' when the tracker has no Location
+ * column.
+ *
+ * @param {string} line - A single line from applications.md.
+ * @param {Record<string, number>} colmap - From resolveColumns().
+ * @returns {{num:number,date:string,company:string,role:string,location:string,score:string,status:string,pdf:string,report:string,notes:string}|null}
+ */
+export function parseTrackerRow(line, colmap) {
+  if (!line.startsWith('|')) return null;
+  const parts = line.split('|').map(s => s.trim());
+  const maxIdx = Math.max(...Object.values(colmap));
+  if (parts.length <= maxIdx) return null;
+  const num = parseInt(parts[colmap.num]);
+  if (isNaN(num)) return null;
+  return {
+    num,
+    date: parts[colmap.date],
+    company: parts[colmap.company],
+    role: parts[colmap.role],
+    location: colmap.location != null ? parts[colmap.location] : '',
+    score: parts[colmap.score],
+    status: parts[colmap.status],
+    pdf: parts[colmap.pdf],
+    report: parts[colmap.report],
+    notes: colmap.notes != null ? (parts[colmap.notes] || '') : '',
+  };
+}

--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -67,11 +67,23 @@ const STATUS_RANK = {
  * @returns {string} Lowercase company key used for same-company grouping.
  */
 function normalizeCompany(name) {
-  return name.toLowerCase()
+  // Use Unicode letter/number classes (\p{L}\p{N}), not [a-z0-9]: Cyrillic, CJK,
+  // Arabic and other non-Latin company names must keep their letters. Stripping
+  // them collapsed every non-Latin company into the same empty key, which let the
+  // fuzzy role matcher merge unrelated rows — silent data loss for non-English
+  // markets (the localized de/fr/ja/ar/tr modes target exactly these users).
+  // NFC-normalize first so NFC/NFD variants of the same accented name (e.g.
+  // "Société" pasted as decomposed e + ´) don't strip the combining mark and
+  // produce a different key for the same company.
+  const key = name.normalize('NFC').toLowerCase()
     .replace(/[()]/g, '')
     .replace(/\s+/g, ' ')
-    .replace(/[^a-z0-9 ]/g, '')
+    .replace(/[^\p{L}\p{N} ]/gu, '')
     .trim();
+  // Never group under an empty key. A name that is all punctuation/emoji would
+  // normalize to '' and cluster with every other such name; fall back to the
+  // trimmed lowercase original so those rows stay distinct.
+  return key || name.normalize('NFC').toLowerCase().trim();
 }
 
 /**

--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -13,6 +13,7 @@ import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { roleFuzzyMatch } from './role-matcher.mjs';
+import { resolveColumns, parseTrackerRow } from './column-map.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md
@@ -251,22 +252,10 @@ function rebuildRow(parts) {
 }
 
 function parseAppLine(line) {
-  const parts = line.split('|').map(s => s.trim());
-  if (parts.length < 9) return null;
-  const num = parseInt(parts[1]);
-  if (isNaN(num)) return null;
-  return {
-    num,
-    date: parts[2],
-    company: parts[3],
-    role: parts[4],
-    score: parts[5],
-    status: parts[6],
-    pdf: parts[7],
-    report: parts[8],
-    notes: parts[9] || '',
-    raw: line,
-  };
+  // Column indices come from COLMAP (resolved by header) so Score/Status read
+  // correctly when an optional Location column shifts their positions.
+  const row = parseTrackerRow(line, COLMAP);
+  return row ? { ...row, raw: line } : null;
 }
 
 // Read
@@ -276,6 +265,10 @@ if (!existsSync(APPS_FILE)) {
 }
 const content = readFileSync(APPS_FILE, 'utf-8');
 const lines = content.split('\n');
+// Resolve columns by header (shared via column-map.mjs) so parseAppLine and the
+// status write-back below address Score/Status correctly even when an optional
+// Location column is present.
+const COLMAP = resolveColumns(lines);
 
 // Parse all entries
 const entries = [];
@@ -343,7 +336,7 @@ for (const [company, companyEntries] of groups) {
       const lineIdx = keeper.lineIdx;
       if (lineIdx !== undefined) {
         const parts = lines[lineIdx].split('|').map(s => s.trim());
-        parts[6] = bestStatus;
+        parts[COLMAP.status] = bestStatus;
         lines[lineIdx] = rebuildRow(parts);
         console.log(`  📝 #${keeper.num}: status promoted to "${bestStatus}" (from #${cluster.find(e => e.status === bestStatus)?.num})`);
       }

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -15,6 +15,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import yaml from 'js-yaml';
+import { resolveColumns, parseTrackerRow } from './column-map.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -138,19 +139,12 @@ export function addDays(date, days) {
 // --- Parse applications.md ---
 function parseTracker() {
   if (!existsSync(APPS_FILE)) return [];
-  const content = readFileSync(APPS_FILE, 'utf-8');
+  const lines = readFileSync(APPS_FILE, 'utf-8').split('\n');
+  const colmap = resolveColumns(lines);
   const entries = [];
-  for (const line of content.split('\n')) {
-    if (!line.startsWith('|')) continue;
-    const parts = line.split('|').map(s => s.trim());
-    if (parts.length < 9) continue;
-    const num = parseInt(parts[1]);
-    if (isNaN(num)) continue;
-    entries.push({
-      num, date: parts[2], company: parts[3], role: parts[4],
-      score: parts[5], status: parts[6], pdf: parts[7], report: parts[8],
-      notes: parts[9] || '',
-    });
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (row) entries.push(row);
   }
   return entries;
 }

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -18,6 +18,7 @@ import { readFileSync, writeFileSync, readdirSync, mkdirSync, renameSync, exists
 import { join, basename, dirname, resolve, relative, isAbsolute, sep } from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
+import { LEGACY_COLMAP, detectColumns } from './column-map.mjs';
 import { createHash, randomUUID } from 'crypto';
 import { tmpdir } from 'os';
 import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
@@ -427,31 +428,8 @@ function parseScore(s) {
 // position so both work — fixed-position indexing would otherwise read, say,
 // Location where it expects Score. Falls back to the legacy layout when no
 // recognizable header row is found.
-const LEGACY_COLMAP = { num: 1, date: 2, company: 3, role: 4, score: 5, status: 6, pdf: 7, report: 8, notes: 9 };
+// Column detection (LEGACY_COLMAP + detectColumns) is shared via column-map.mjs.
 let COLMAP = LEGACY_COLMAP;
-
-const HEADER_ALIASES = {
-  '#': 'num', 'num': 'num', 'date': 'date', 'company': 'company', 'empresa': 'company',
-  'role': 'role', 'puesto': 'role', 'location': 'location', 'score': 'score',
-  'status': 'status', 'pdf': 'pdf', 'report': 'report', 'notes': 'notes',
-};
-
-// Scan the table for a header row and build a header-name → column-index map.
-// Indexing matches `line.split('|')` (leading empty cell before the first pipe),
-// the same split parseAppLine uses. Returns null — caller keeps the legacy
-// layout — unless the essential columns are all present, so a stray pipe line
-// can't yield a bogus mapping.
-function detectColumns(lines) {
-  for (const line of lines) {
-    if (!line.startsWith('|')) continue;
-    const cells = line.split('|').map(s => s.trim().toLowerCase());
-    if (!cells.includes('company') || !cells.includes('role')) continue;
-    const map = {};
-    cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
-    if (['num', 'company', 'role', 'score', 'status'].every(k => map[k] != null)) return map;
-  }
-  return null;
-}
 
 // Build a tracker row string matching the detected layout (with or without the
 // optional Location column) so writes round-trip through the same schema.

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -389,7 +389,13 @@ function validateStatus(status) {
  * @returns {string} Lowercase alphanumeric company key.
  */
 function normalizeCompany(name) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, '');
+  // Mirror of dedup-tracker.mjs's normalizeCompany. Use Unicode letter/number
+  // classes (\p{L}\p{N}), not [a-z0-9]: stripping non-Latin characters collapsed
+  // every Cyrillic/CJK/Arabic company to the same empty key, so a TSV addition
+  // for one non-Latin company would merge into an unrelated one. NFC-normalize
+  // first so NFC/NFD variants of the same accented name (e.g. "Société") agree.
+  const key = name.normalize('NFC').toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
+  return key || name.normalize('NFC').toLowerCase().trim();
 }
 
 /**

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -14,6 +14,7 @@
 import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { resolveColumns } from './column-map.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original)
@@ -110,6 +111,9 @@ if (!existsSync(APPS_FILE)) {
 }
 const content = readFileSync(APPS_FILE, 'utf-8');
 const lines = content.split('\n');
+// Resolve columns by header so Score/Status read correctly when an optional
+// Location column shifts their positions (shared with column-map.mjs).
+const COLMAP = resolveColumns(lines);
 
 let changes = 0;
 let unknowns = [];
@@ -126,7 +130,7 @@ for (let i = 0; i < lines.length; i++) {
   const num = parseInt(parts[1]);
   if (isNaN(num)) continue;
 
-  const rawStatus = parts[6];
+  const rawStatus = parts[COLMAP.status];
   const result = normalizeStatus(rawStatus);
 
   if (result.unknown) {
@@ -138,21 +142,20 @@ for (let i = 0; i < lines.length; i++) {
 
   // Apply change
   const oldStatus = rawStatus;
-  parts[6] = result.status;
+  parts[COLMAP.status] = result.status;
 
   // Move DUPLICADO info to notes if needed
-  if (result.moveToNotes && parts[9]) {
-    const existing = parts[9] || '';
+  const notesIdx = COLMAP.notes;
+  if (result.moveToNotes && notesIdx != null) {
+    const existing = parts[notesIdx] || '';
     if (!existing.includes(result.moveToNotes)) {
-      parts[9] = result.moveToNotes + (existing ? '. ' + existing : '');
+      parts[notesIdx] = result.moveToNotes + (existing ? '. ' + existing : '');
     }
-  } else if (result.moveToNotes && !parts[9]) {
-    parts[9] = result.moveToNotes;
   }
 
   // Also strip bold from score field
-  if (parts[5]) {
-    parts[5] = parts[5].replace(/\*\*/g, '');
+  if (parts[COLMAP.score]) {
+    parts[COLMAP.score] = parts[COLMAP.score].replace(/\*\*/g, '');
   }
 
   // Reconstruct line

--- a/role-matcher.mjs
+++ b/role-matcher.mjs
@@ -63,8 +63,13 @@ export const BASELINE_TOKENS = new Set([
 export function roleTokens(role) {
   const text = typeof role === 'string' ? role : String(role ?? '');
   return text
+    .normalize('NFC')
+    // Keep Unicode letters/digits (\p{L}\p{N}), not just [a-z0-9]: a [^a-z0-9\s]
+    // class erased every Cyrillic/CJK/Arabic character, so non-Latin role titles
+    // tokenized to [] and roleFuzzyMatch() bailed out — duplicate non-Latin-role
+    // rows never deduplicated even once the company key was correct.
     .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
     .split(/\s+/)
     .filter(w => (w.length > 3 || SHORT_SPECIALTY.has(w)) && !ROLE_STOPWORDS.has(w));
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2304,6 +2304,82 @@ try {
   fail(`shared column map tests crashed: ${e.message}`);
 }
 
+// ── NON-LATIN COMPANY + ROLE DEDUP (i18n) ───────────────────────
+// normalizeCompany() (in BOTH dedup-tracker.mjs and merge-tracker.mjs) and the
+// shared roleTokens() stripped every non-[a-z0-9] character. All Cyrillic / CJK
+// / Arabic company names collapsed to the same empty key, and non-Latin role
+// titles tokenized to [] so roleFuzzyMatch() bailed out. Net effect: unrelated
+// non-Latin employers were merged, while genuine duplicates at the same
+// non-Latin company never deduplicated. Both now keep Unicode letters/digits
+// (\p{L}\p{N}) and NFC-normalize first.
+console.log('\n🧪 Testing non-Latin company + role dedup (i18n)...');
+try {
+  const { roleFuzzyMatch } = await import(pathToFileURL(join(ROOT, 'role-matcher.mjs')).href);
+
+  if (roleFuzzyMatch('Бэкенд разработчик', 'Бэкенд разработчик')) {
+    pass('roleFuzzyMatch matches identical Cyrillic role titles');
+  } else {
+    fail('roleFuzzyMatch fails on identical Cyrillic roles (non-Latin tokens stripped)');
+  }
+  if (!roleFuzzyMatch('Бэкенд разработчик', 'Фронтенд дизайнер')) {
+    pass('roleFuzzyMatch keeps distinct Cyrillic roles separate');
+  } else {
+    fail('roleFuzzyMatch merged two distinct Cyrillic roles');
+  }
+
+  const nlTmp = mkdtempSync(join(tmpdir(), 'career-ops-nonlatin-'));
+  try {
+    mkdirSync(join(nlTmp, 'data'));
+    const tracker = join(nlTmp, 'data', 'applications.md');
+    const nfc = 'Société Générale'.normalize('NFC');
+    const nfd = 'Société Générale'.normalize('NFD');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      // same Cyrillic company + role → must dedup to the higher-scored row
+      '| 60 | 2026-03-01 | Яндекс | Бэкенд-разработчик | 4.0/5 | Evaluated | ❌ | [60](../reports/060-ya-a.md) | cyrillic dup low |\n' +
+      '| 61 | 2026-03-01 | Яндекс | Бэкенд-разработчик | 4.3/5 | Evaluated | ❌ | [61](../reports/061-ya-b.md) | cyrillic dup high |\n' +
+      // distinct Cyrillic company, same role → must survive
+      '| 62 | 2026-03-01 | Сбербанк | Бэкенд-разработчик | 4.1/5 | Evaluated | ❌ | [62](../reports/062-sber.md) | distinct cyrillic |\n' +
+      // CJK + Arabic companies → must NOT collapse into each other
+      '| 63 | 2026-03-01 | 百度 | Frontend Developer | 3.0/5 | Evaluated | ❌ | [63](../reports/063-cjk.md) | cjk company |\n' +
+      '| 64 | 2026-03-01 | أمازون | DevOps Engineer | 3.5/5 | Evaluated | ❌ | [64](../reports/064-ar.md) | arabic company |\n' +
+      // NFC vs NFD of the SAME accented company + same role → must dedup to 1
+      `| 65 | 2026-03-01 | ${nfc} | Risk Engineer | 3.8/5 | Evaluated | ❌ | [65](../reports/065-sg-nfc.md) | nfc |\n` +
+      `| 66 | 2026-03-01 | ${nfd} | Risk Engineer | 4.2/5 | Evaluated | ❌ | [66](../reports/066-sg-nfd.md) | nfd |\n`);
+
+    const r = run(NODE, ['dedup-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
+    if (r === null) {
+      fail('dedup-tracker.mjs crashed during non-Latin dedup test');
+    } else {
+      const out = readFileSync(tracker, 'utf-8');
+      const lines = out.split('\n');
+      const yandexRows = lines.filter(l => l.includes('Яндекс'));
+      if (yandexRows.length === 1 && yandexRows[0].includes('4.3/5')) {
+        pass('dedup-tracker deduplicates same Cyrillic company+role, keeping the higher score');
+      } else {
+        fail(`dedup-tracker Cyrillic dedup wrong: ${yandexRows.length} Яндекс rows`);
+      }
+      if (out.includes('Сбербанк') && out.includes('百度') && out.includes('أمازون')) {
+        pass('dedup-tracker keeps distinct Cyrillic / CJK / Arabic companies separate (no empty-key collision)');
+      } else {
+        fail('dedup-tracker merged or dropped a distinct non-Latin company');
+      }
+      const riskRows = lines.filter(l => l.includes('Risk Engineer'));
+      if (riskRows.length === 1 && riskRows[0].includes('4.2/5')) {
+        pass('dedup-tracker deduplicates NFC/NFD variants of the same accented company');
+      } else {
+        fail(`dedup-tracker NFC/NFD dedup wrong: ${riskRows.length} "Risk Engineer" rows`);
+      }
+    }
+  } finally {
+    rmSync(nlTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`non-Latin dedup test crashed: ${e.message}`);
+}
+
 // dedup-tracker / normalize-statuses rebuilt promoted rows with
 // `parts.slice(1, -1)`, which assumes the closing `|` produced a trailing empty
 // cell. A valid row written WITHOUT a trailing pipe keeps its real last cell

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2227,6 +2227,83 @@ try {
   fail(`shared role matcher / dedup safety tests crashed: ${e.message}`);
 }
 
+// ── SHARED COLUMN MAP + OPTIONAL LOCATION COLUMN ────────────────
+// column-map.mjs is the single source of truth for tracker column detection.
+// dedup-tracker / normalize-statuses / analyze-patterns / followup-cadence used
+// to hardcode parts[5]=score / parts[6]=status; with the optional Location
+// column (inserted after Role) those offsets shift, so they read Score as
+// Status and could write a status back into the Score cell. They now resolve
+// columns by header like merge-tracker.mjs and verify-pipeline.mjs.
+console.log('\n🧪 Testing shared column map + optional Location column...');
+try {
+  const { resolveColumns, parseTrackerRow } = await import(pathToFileURL(join(ROOT, 'column-map.mjs')).href);
+
+  const legacy = resolveColumns(['| # | Date | Company | Role | Score | Status | PDF | Report | Notes |']);
+  if (legacy.score === 5 && legacy.status === 6 && legacy.location == null) {
+    pass('resolveColumns maps the 9-column layout (Score=5, Status=6, no Location)');
+  } else {
+    fail(`resolveColumns 9-col wrong: ${JSON.stringify(legacy)}`);
+  }
+
+  const withLoc = resolveColumns(['| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |']);
+  if (withLoc.location === 5 && withLoc.score === 6 && withLoc.status === 7) {
+    pass('resolveColumns shifts Score/Status when a Location column is present');
+  } else {
+    fail(`resolveColumns Location layout wrong: ${JSON.stringify(withLoc)}`);
+  }
+
+  if (resolveColumns(['plain text, no table']).score === 5) {
+    pass('resolveColumns falls back to the legacy layout when no header row exists');
+  } else {
+    fail('resolveColumns should fall back to LEGACY_COLMAP without a header');
+  }
+
+  const row = parseTrackerRow('| 1 | 2026-01-01 | Acme | Backend Engineer | Remote | 4.2/5 | Applied | ❌ | [1](../reports/001.md) | n |', withLoc);
+  if (row && row.score === '4.2/5' && row.status === 'Applied' && row.location === 'Remote' && row.company === 'Acme') {
+    pass('parseTrackerRow reads Score/Status/Location correctly with a Location column');
+  } else {
+    fail(`parseTrackerRow Location row wrong: ${JSON.stringify(row)}`);
+  }
+  if (parseTrackerRow('| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |', withLoc) === null) {
+    pass('parseTrackerRow returns null for the header row');
+  } else {
+    fail('parseTrackerRow should return null for the header row');
+  }
+
+  // Integration: dedup-tracker on a Location-column tracker must dedup correctly
+  // (it read Score as Status before, so it missed the duplicate entirely).
+  const colTmp = mkdtempSync(join(tmpdir(), 'career-ops-colmap-'));
+  try {
+    mkdirSync(join(colTmp, 'data'));
+    const tracker = join(colTmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|----------|-------|--------|-----|--------|-------|\n' +
+      '| 1 | 2026-05-01 | Acme | Product Engineer, Growth | Remote | 3.0/5 | Evaluated | ❌ | [1](../reports/001-a.md) | lower-scored dup |\n' +
+      '| 2 | 2026-05-02 | Acme | Product Engineer, Growth | Remote | 4.5/5 | Evaluated | ❌ | [2](../reports/002-b.md) | higher-scored dup |\n');
+
+    const r = run(NODE, ['dedup-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
+    if (r === null) {
+      fail('dedup-tracker.mjs crashed on a Location-column tracker');
+    } else {
+      const dataRows = readFileSync(tracker, 'utf-8').split('\n').filter(l => /^\|\s*\d/.test(l));
+      // The fix lets dedup read Score from the Location-shifted column, so it
+      // keeps the genuinely higher-scored row (4.5). The old hardcoded offset
+      // read Location ("Remote") as the score → both scored 0 → wrong keeper.
+      if (dataRows.length === 1 && dataRows[0].includes('4.5/5') && dataRows[0].includes('Evaluated')) {
+        pass('dedup-tracker deduplicates a Location-column tracker, keeping the higher-scored row');
+      } else {
+        fail(`dedup-tracker Location dedup wrong: ${dataRows.length} rows -> ${JSON.stringify(dataRows)}`);
+      }
+    }
+  } finally {
+    rmSync(colTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`shared column map tests crashed: ${e.message}`);
+}
+
 // dedup-tracker / normalize-statuses rebuilt promoted rows with
 // `parts.slice(1, -1)`, which assumes the closing `|` produced a trailing empty
 // cell. A valid row written WITHOUT a trailing pipe keeps its real last cell

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2421,6 +2421,63 @@ try {
   fail(`dedup row-rebuild notes test crashed: ${e.message}`);
 }
 
+// ── VERIFY-PIPELINE INTEGRITY CHECKS (dup report #, machine summary) ──
+// verify-pipeline.mjs gained two warning-only checks: duplicate report file
+// numbers (orphan twins invisible to number-indexed scripts) and a missing
+// `## Machine Summary` block on actionable rows (which analyze-patterns.mjs
+// needs to read a report's metadata). Both must warn without failing the run.
+console.log('\n🧪 Testing verify-pipeline integrity checks...');
+try {
+  const vpTmp = mkdtempSync(join(tmpdir(), 'career-ops-verify-'));
+  try {
+    mkdirSync(join(vpTmp, 'data'));
+    mkdirSync(join(vpTmp, 'reports'));
+    const tracker = join(vpTmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 70 | 2026-04-01 | Acme | Backend Engineer | 4.0/5 | Applied | ❌ | [70](../reports/070-acme.md) | heading, no fence |\n' +
+      '| 71 | 2026-04-01 | Globex | Backend Engineer | 4.1/5 | Applied | ❌ | [71](../reports/071-globex.md) | compliant report |\n');
+    // Applied report #70 has the heading but NO fenced YAML — analyze-patterns
+    // returns null for this, so the check must still warn (old heading-only
+    // regex would have passed it).
+    writeFileSync(join(vpTmp, 'reports', '070-acme.md'), '# Evaluation: Acme\n\n## Machine Summary\n\nstatus: applied (no fenced block)\n');
+    // A second file colliding on report number 070.
+    writeFileSync(join(vpTmp, 'reports', '070-acme-orphan.md'), '# duplicate-numbered orphan\n');
+    // Applied report #71 has a proper fenced Machine Summary — must NOT warn.
+    writeFileSync(join(vpTmp, 'reports', '071-globex.md'),
+      '# Evaluation: Globex\n\n## Machine Summary\n\n```yaml\ncompany: Globex\nscore: 4.1\n```\n');
+
+    const out = run(NODE, ['verify-pipeline.mjs'], {
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_REPORTS_DIR: join(vpTmp, 'reports') },
+    });
+    if (out === null) {
+      fail('verify-pipeline.mjs exited non-zero on warning-only input (warnings must not fail the run)');
+    } else {
+      if (/Duplicate report number 070/.test(out)) {
+        pass('verify-pipeline flags duplicate report file numbers');
+      } else {
+        fail('verify-pipeline did not flag a duplicate report number');
+      }
+      if (/#70 .*missing a parseable "## Machine Summary"/.test(out)) {
+        pass('verify-pipeline flags a heading-only report (no fenced YAML) as unparseable');
+      } else {
+        fail('verify-pipeline did not flag the heading-only (no-fence) Machine Summary report');
+      }
+      if (!/#71 /.test(out)) {
+        pass('verify-pipeline does not warn on a compliant fenced Machine Summary (no false positive)');
+      } else {
+        fail('verify-pipeline warned on a report that has a valid fenced Machine Summary');
+      }
+    }
+  } finally {
+    rmSync(vpTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`verify-pipeline integrity-check tests crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER FUZZY DEDUP (#751 / #721 family) ──────────────
 // roleFuzzyMatch over-matched whenever the token overlap dominated the
 // SMALLER side: two distinct roles sharing a long prefix ("Full-Stack

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -28,7 +28,8 @@ const APPS_FILE = process.env.CAREER_OPS_TRACKER
     ? join(CAREER_OPS, 'data/applications.md')
     : join(CAREER_OPS, 'applications.md');
 const ADDITIONS_DIR = join(CAREER_OPS, 'batch/tracker-additions');
-const REPORTS_DIR = join(CAREER_OPS, 'reports');
+// CAREER_OPS_REPORTS_DIR overrides the reports directory (used by tests).
+const REPORTS_DIR = process.env.CAREER_OPS_REPORTS_DIR || join(CAREER_OPS, 'reports');
 const STATES_FILE = existsSync(join(CAREER_OPS, 'templates/states.yml'))
   ? join(CAREER_OPS, 'templates/states.yml')
   : join(CAREER_OPS, 'states.yml');
@@ -233,6 +234,56 @@ if (existsSync(REPORTS_DIR)) {
   }
 }
 if (staleSentinels === 0) ok('No stale reservation sentinels');
+
+// --- Check 9: Duplicate report file numbers ---
+// reserve-report-num.mjs and batch runs can collide on a number and write two
+// files sharing the same NNN- prefix. Earlier checks only catch duplicate
+// tracker rows, so the orphaned twin stays invisible to any script that
+// iterates reports by number.
+let dupReportNums = 0;
+if (existsSync(REPORTS_DIR)) {
+  const numMap = new Map();
+  for (const name of readdirSync(REPORTS_DIR)) {
+    if (!name.endsWith('.md') || name.endsWith('-RESERVED.md')) continue;
+    const m = name.match(/^(\d+)-/);
+    if (!m) continue;
+    if (!numMap.has(m[1])) numMap.set(m[1], []);
+    numMap.get(m[1]).push(name);
+  }
+  for (const [n, files] of numMap) {
+    if (files.length > 1) {
+      warn(`Duplicate report number ${n}: ${files.join(', ')} — renumber the orphan to a free slot`);
+      dupReportNums++;
+    }
+  }
+}
+if (dupReportNums === 0) ok('No duplicate report numbers');
+
+// --- Check 10: Machine Summary present on actionable reports ---
+// analyze-patterns.mjs reads a report's metadata from its `## Machine Summary`
+// fenced block. Applied/Responded/Interview/Offer rows are the actionable ones
+// whose metadata feeds pattern analysis — warn when their report lacks it.
+const ACTIONABLE_STATUSES = new Set(['applied', 'responded', 'interview', 'offer']);
+let missingMachineSummary = 0;
+for (const e of entries) {
+  const st = e.status.replace(/\*\*/g, '').trim().toLowerCase().replace(/\s+\d{4}-\d{2}-\d{2}.*$/, '').trim();
+  const canon = CANONICAL_STATUSES.includes(st) ? st : (ALIASES[st] || st);
+  if (!ACTIONABLE_STATUSES.has(canon)) continue;
+  const match = e.report.match(/\]\(([^)]+)\)/);
+  if (!match) continue;
+  const link = match[1];
+  const path = existsSync(join(TRACKER_DIR, link)) ? join(TRACKER_DIR, link)
+    : existsSync(join(CAREER_OPS, link)) ? join(CAREER_OPS, link) : null;
+  if (!path) continue; // broken link already flagged by the report-links check
+  // Mirror analyze-patterns.mjs's parseMachineSummary regex: a bare heading with
+  // no fenced YAML block still yields null there, so require the fence too.
+  const MACHINE_SUMMARY_RE = /##\s*Machine Summary\s*\n+```(?:yaml|yml|json)?\s*\n[\s\S]*?\n```/i;
+  if (!MACHINE_SUMMARY_RE.test(readFileSync(path, 'utf-8'))) {
+    warn(`#${e.num} (${canon}): report missing a parseable "## Machine Summary" block — analyze-patterns can't read its metadata`);
+    missingMachineSummary++;
+  }
+}
+if (missingMachineSummary === 0) ok('All actionable reports have a Machine Summary');
 
 // --- Summary ---
 console.log('\n' + '='.repeat(50));

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -17,6 +17,7 @@
 import { readFileSync, readdirSync, existsSync, mkdirSync, unlinkSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { resolveColumns } from './column-map.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original).
@@ -73,24 +74,9 @@ const lines = content.split('\n');
 // Location column after Role). Fixed-position indexing would otherwise read
 // Location where Score is expected and flag false errors. Falls back to the
 // legacy fixed layout when no recognizable header row is found.
-const LEGACY_COLMAP = { num: 1, date: 2, company: 3, role: 4, score: 5, status: 6, pdf: 7, report: 8, notes: 9 };
-const HEADER_ALIASES = {
-  '#': 'num', 'num': 'num', 'date': 'date', 'company': 'company', 'empresa': 'company',
-  'role': 'role', 'puesto': 'role', 'location': 'location', 'score': 'score',
-  'status': 'status', 'pdf': 'pdf', 'report': 'report', 'notes': 'notes',
-};
-function detectColumns(allLines) {
-  for (const line of allLines) {
-    if (!line.startsWith('|')) continue;
-    const cells = line.split('|').map(s => s.trim().toLowerCase());
-    if (!cells.includes('company') || !cells.includes('role')) continue;
-    const map = {};
-    cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
-    if (['num', 'company', 'role', 'score', 'status'].every(k => map[k] != null)) return map;
-  }
-  return null;
-}
-const COLMAP = detectColumns(lines) || LEGACY_COLMAP;
+// Column detection is shared via column-map.mjs (resolveColumns falls back to
+// the legacy fixed layout when no recognizable header row is found).
+const COLMAP = resolveColumns(lines);
 const MAX_IDX = Math.max(...Object.values(COLMAP));
 
 const entries = [];


### PR DESCRIPTION
Consolidates three related `applications.md` tracker-pipeline fixes into one PR. They touch the same parsing core (`dedup-tracker` / `merge-tracker` / `verify-pipeline` + `test-all.mjs`) and would otherwise conflict, so they're cleaner as one reviewable unit — each is a separate, self-contained commit.

## 1. Non-Latin company/role names break dedup + merge (i18n)

`normalizeCompany` (in **both** `dedup-tracker.mjs` and `merge-tracker.mjs`) and the shared `roleTokens` stripped every non-`[a-z0-9]` character, so Cyrillic / CJK / Arabic company names collapsed to one empty key (dedup merged unrelated employers) and non-Latin role titles tokenized to `[]` (so `roleFuzzyMatch` bailed and real duplicates never merged). Now uses `\p{L}\p{N}` + NFC normalization; Latin behavior is unchanged. Helps the users the localized `de/fr/ja/ar/tr` modes target.

## 2. Optional Location column corrupts dedup / normalize / analyze / followup

`dedup-tracker`, `normalize-statuses`, `analyze-patterns`, and `followup-cadence` hardcoded `parts[5]=score` / `parts[6]=status`. `merge-tracker` and `verify-pipeline` already detect columns by header, so with the optional Location column enabled the four scripts read **Score as Status** (and could write a status back into the Score cell). Introduces **`column-map.mjs`** as the single source of truth (`merge-tracker` + `verify-pipeline` now import it — they previously had two verbatim copies), and the four scripts resolve columns by header. Legacy 9-column trackers are unaffected.

## 3. verify-pipeline integrity checks

Two warning-only checks (exit code unchanged): duplicate report **file numbers**, and an unparseable `## Machine Summary` block on Applied/Responded/Interview/Offer rows (the regex mirrors `analyze-patterns.parseMachineSummary`). Adds a `CAREER_OPS_REPORTS_DIR` env override for testability.

---

Each fix has a regression test in `test-all.mjs`. `node test-all.mjs --quick` → **391 passed, 0 failed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Application tracker now supports flexible column layouts, including optional Location column.
  * Added validation checks for duplicate report files and Machine Summary content verification.

* **Bug Fixes**
  * Improved internationalization: Unicode-aware company and role name processing for better deduplication and matching across non-Latin characters.

* **Tests**
  * Extended test coverage for tracker column parsing, multi-language deduplication, and pipeline integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->