### PR TITLE
feat(cv): add opt-in profile photo for DACH/European CVs

### DIFF
--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -11,6 +11,12 @@ candidate:
   portfolio_url: "https://janesmith.dev"
   github: "github.com/janesmith"
   twitter: "https://x.com/janesmith"
+  # Optional profile photo for the PDF CV (opt-in, #264). Leave empty to omit it
+  # entirely: US/UK and many-market ATS penalize photos, so the photoless layout
+  # is the default. Set it only for DACH/European markets (Germany, Austria,
+  # Switzerland) where a professional photo is expected. Use a local file path or
+  # a data: URL — the PDF renderer inlines local images.
+  photo: ""
 
 target_roles:
   # Your North Star roles — what you're optimizing for

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -79,6 +79,7 @@ Use the template in `cv-template.html`. Replace the `{{...}}` placeholders with 
 |-------------|-----------|
 | `{{LANG}}` | CV language code (e.g. `en`, `es`, `ja`, `ar`). Drives language-specific CSS in the template: `ja` enables a CJK font fallback so Japanese renders instead of tofu (□); `ar` enables RTL + Arabic fonts. Use the BCP-47/ISO-639 code that matches the CV language. |
 | `{{PAGE_WIDTH}}` | `8.5in` (letter) or `210mm` (A4) |
+| `{{PHOTO}}` | Opt-in profile photo (#264). When `profile.yml` has a non-empty `candidate.photo`, replace with `<img class="cv-photo" src="<path-or-data-URL>" alt="{{NAME}}">`; otherwise **remove the whole `{{PHOTO}}` line** so no markup (and no `<img>`) is emitted. Opt-in for DACH/European markets — an absent photo renders identically (pixel-for-pixel) to the photoless layout (US/UK and many-market ATS penalize photos). |
 | `{{NAME}}` | (from profile.yml) |
 | `{{PHONE}}` | (from profile.yml — include with its separator only when `profile.yml` has a non-empty `phone` value; omit both the `<a href="tel:…">` element and the following `<span class="separator">` otherwise) |
 | `{{EMAIL}}` | (from profile.yml) |
@@ -101,6 +102,15 @@ Use the template in `cv-template.html`. Replace the `{{...}}` placeholders with 
 | `{{CERTIFICATIONS}}` | Certifications HTML |
 | `{{SECTION_SKILLS}}` | Skills |
 | `{{SKILLS}}` | Skills HTML |
+
+### Profile photo (opt-in, market-specific)
+
+The `{{PHOTO}}` slot is **off by default** and intentionally market-specific:
+
+- **DACH / much of continental Europe** (Germany, Austria, Switzerland): a professional photo is standard and often expected. Opt in by setting `candidate.photo` in `config/profile.yml` (a local file path or a `data:` URL).
+- **US / UK / Canada / Australia and many ATS-first markets**: photos are discouraged and can trip bias-avoidance filters. Leave `candidate.photo` empty — the `{{PHOTO}}` line is dropped entirely, no `<img>` is emitted, and the CV renders **pixel-for-pixel identical** to today's photoless layout.
+
+When set, the photo floats into the top corner (mirrored for RTL/Arabic) and the header/summary text wraps beside it; `.cv-photo` in `cv-template.html` controls its size and framing.
 
 ## Canva CV Generation (optional)
 

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -95,6 +95,22 @@
     color: #ccc;
   }
 
+  /* === OPTIONAL PROFILE PHOTO (opt-in, DACH/European markets — #264) ===
+     Off by default: with no candidate.photo the {{PHOTO}} slot is empty, no
+     <img> is emitted, and the layout is byte-identical to a photoless CV.
+     When opted in (candidate.photo in config/profile.yml) the photo floats into
+     the top corner and the header/summary text wraps beside it. Photos are
+     penalized by US/UK/many-market ATS, so this is never on by default. */
+  .cv-photo {
+    float: right;
+    width: 80px;
+    height: 100px;
+    object-fit: cover;
+    margin: 0 0 8px 14px;
+    border-radius: 3px;
+    border: 1px solid #e2e2e2;
+  }
+
   /* === SECTIONS === */
   .section {
     margin-bottom: 18px;
@@ -394,6 +410,11 @@
     direction: rtl;
   }
 
+  html[lang="ar"] .cv-photo {
+    float: left;
+    margin: 0 14px 8px 0;
+  }
+
   /* === CJK (Japanese) font fallback === */
   /* The bundled webfonts are Latin-only (see #951). Without a CJK fallback,
      Japanese text renders as tofu (□) in headless Chromium on any system
@@ -422,6 +443,7 @@
 <body>
 <div class="page">
 
+  {{PHOTO}}
   <!-- HEADER -->
   <div class="header">
     <h1>{{NAME}}</h1>

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4528,6 +4528,71 @@ try {
   fail(`breezy provider tests crashed: ${e.message}`);
 }
 
+// ── 28. OPTIONAL PROFILE PHOTO (opt-in, DACH/European — #264) ────
+
+console.log('\n28. Optional profile photo (opt-in, DACH/European, #264)');
+
+try {
+  const cvTemplate = readFileSync(join(ROOT, 'templates', 'cv-template.html'), 'utf-8');
+
+  // The opt-in photo must exist as a .cv-photo CSS rule.
+  if (/\.cv-photo\s*\{/.test(cvTemplate)) {
+    pass('cv-template.html defines a .cv-photo rule');
+  } else {
+    fail('cv-template.html is missing a .cv-photo rule — #264 opt-in photo not wired');
+  }
+
+  // It MUST be floated (taken out of normal flow) so a present photo is wrapped
+  // by the text beside it (the classic DACH top-corner photo) and an absent one
+  // leaves the layout unchanged. Anchor the check to the .cv-photo rule block so
+  // it can't accidentally read another rule (e.g. the lang="ar" float:left
+  // mirror) via offset slicing.
+  const photoRule = cvTemplate.match(/\.cv-photo\s*\{[^}]*\}/);
+  if (photoRule && /float:\s*right/.test(photoRule[0])) {
+    pass('.cv-photo floats right (text wraps when present; absent ⇒ unchanged layout)');
+  } else {
+    fail('.cv-photo must float so a present photo sits beside the text and an absent one does not shift the layout (#264)');
+  }
+
+  // The photo is an opt-in {{PHOTO}} slot, empty by default. The agent fills it
+  // only when config/profile.yml sets candidate.photo; otherwise it stays empty.
+  if (cvTemplate.includes('{{PHOTO}}')) {
+    pass('cv-template.html exposes a {{PHOTO}} opt-in slot (empty by default)');
+  } else {
+    fail('cv-template.html is missing the {{PHOTO}} opt-in slot (#264)');
+  }
+
+  // The slot MUST sit before the header (outside .header): the float anchors at
+  // the top of the page, and removing the line when absent cannot then perturb
+  // the header's own structure. Guards against a regression that moves the slot
+  // inside .header (which would shift the photoless layout).
+  const photoIdx = cvTemplate.indexOf('{{PHOTO}}');
+  const headerIdx = cvTemplate.indexOf('<!-- HEADER -->');
+  if (photoIdx !== -1 && headerIdx !== -1 && photoIdx < headerIdx) {
+    pass('{{PHOTO}} slot precedes the header (outside .header — keeps the photoless layout intact)');
+  } else {
+    fail('{{PHOTO}} slot must sit before <!-- HEADER --> so an absent photo leaves the header unchanged (#264)');
+  }
+
+  // The shipped template must NOT carry an active <img>: photos are opt-in,
+  // never the default (recruiters in the US/UK/many markets penalize photos).
+  if (!/<img[^>]*class="cv-photo"/.test(cvTemplate)) {
+    pass('default template has no active <img class="cv-photo"> (opt-in, not default)');
+  } else {
+    fail('cv-template.html ships an active photo <img> — photos must be opt-in, never default (#264)');
+  }
+
+  // RTL (Arabic) must mirror the photo to the opposite corner, like the other
+  // lang="ar" rules in this template.
+  if (/html\[lang="ar"\]\s+\.cv-photo/.test(cvTemplate)) {
+    pass('lang="ar" mirrors .cv-photo to the opposite corner');
+  } else {
+    fail('cv-template.html is missing an RTL mirror for .cv-photo (#264)');
+  }
+} catch (e) {
+  fail(`profile photo test crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What does this PR do?

Adds an **opt-in profile photo** to the PDF CV template for the DACH / European job market (#264), where a professional photo on a CV is standard and often expected.

**Opt-in and market-safe** — the hard constraints from the issue discussion:

- With no `candidate.photo` set, the agent drops the `{{PHOTO}}` line entirely, **no `<img>` is emitted, and the CV renders pixel-for-pixel identical to today's photoless layout**. Verified by rendering the modified template (photo absent) and the original `main` template with identical sample data through the project's Playwright/Chromium pipeline — the two screenshots are **pixel-identical (49,188 bytes each)**. US/UK and many ATS-first markets, where photos are penalized, are completely unaffected.
- When `candidate.photo` is set, the photo floats into the top corner (mirrored to the opposite corner for RTL/Arabic) and the header text wraps beside it.
- Documented as market-specific in the PDF docs (`modes/pdf.md`).

### Changes (all System-layer — Data Contract respected)

| File | Change |
|---|---|
| `templates/cv-template.html` | `.cv-photo` float rule + `lang="ar"` RTL mirror + opt-in `{{PHOTO}}` slot (before the header, so an absent photo can't perturb it) |
| `config/profile.example.yml` | document the opt-in `candidate.photo` key (empty by default) |
| `modes/pdf.md` | `{{PHOTO}}` substitution rule (drop the line when empty) + "market-specific" guidance section |
| `test-all.mjs` | assert the opt-in slot, its placement before the header, the float, the RTL mirror, and no default `<img>` |

### Screenshots (sample data, fictional)

_Photoless (default) is pixel-identical to current `main`; with `candidate.photo` set, the photo floats top-right and the header text wraps beside it (RTL mirrors to the left)._

<img width="816" height="1056" alt="264-A-mine-absent" src="https://github.com/user-attachments/assets/1a508c6c-2260-48bb-875b-0747cfe90054" />

<img width="816" height="1056" alt="264-C-mine-present" src="https://github.com/user-attachments/assets/9ba8a692-cc6b-4a65-988a-ae3563747842" />

## Related issue

Fixes #264

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My PR is linked to a related issue
- [x] My changes contain no personal data (sample CV data is fictional)
- [x] I ran `node test-all.mjs` locally — **389 passed, 0 failed**
- [x] My changes respect the Data Contract (no user-layer files modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in profile photo support to CV templates, including PDF rendering behavior that omits photo markup unless explicitly provided.
  * Implemented photo styling for consistent placement and automatic RTL layout adjustments.

* **Documentation**
  * Updated profile example configuration and PDF template instructions with market-specific guidance on when to include photos (e.g., DACH/Europe vs ATS-first markets).

* **Tests**
  * Added coverage to verify template photo wiring, CSS rules, placement relative to the header, and RTL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->