### PR TITLE
feat(providers): add Teamtailor RSS provider (#1119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ career-ops/
 - **Agent**: AI coding CLI with shared skills and modes (`AGENTS.md` + CLI wrapper)
 - **PDF**: Playwright/Puppeteer + HTML template
 - **Cover letters**: HTML template + Playwright (A4 PDF, same pipeline as CVs)
-- **Scanner**: Playwright + Greenhouse / Ashby / Lever / Teamtailor APIs & feeds + WebSearch
+- **Scanner**: Playwright + Greenhouse / Ashby / Lever / Teamtailor / Workday / SmartRecruiters / Workable and more APIs & feeds + WebSearch
 - **Dashboard**: Go + Bubble Tea + Lipgloss (Catppuccin Mocha theme)
 - **Data**: Markdown tables + YAML config + TSV batch files
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Career-Ops ([career-ops.org](https://career-ops.org), also known as **careerops*
 
 - **Evaluates offers** with a structured A-F scoring system (10 weighted dimensions)
 - **Generates tailored PDFs** -- ATS-optimized CVs customized per job description
-- **Scans portals** automatically (Greenhouse, Ashby, Lever, company pages)
+- **Scans portals** automatically (Greenhouse, Ashby, Lever, Teamtailor, company pages)
 - **Processes in batch** -- evaluate 10+ offers in parallel with sub-agents
 - **Tracks everything** in a single source of truth with integrity checks
 
@@ -104,7 +104,7 @@ Built by someone who used it to evaluate 740+ job offers, generate 100+ tailored
 | **Negotiation Scripts**  | Salary negotiation frameworks, geographic discount pushback, competing offer leverage                                                    |
 | **ATS PDF Generation**   | Keyword-injected CVs with Space Grotesk + DM Sans design                                                                                 |
 | **Cover Letter Generator** | Research-backed cover letters with keyword mirroring, four interactive angle prompts (why/problems/approach/tone), draft-in-chat approval gate, and A4 PDF via the same HTML + Playwright pipeline as CVs. Auto-drafts on every evaluation; complete and generate on demand via `/career-ops cover` |
-| **Portal Scanner**       | 45+ companies pre-configured (Anthropic, OpenAI, ElevenLabs, Retool, n8n...) + custom queries across Ashby, Greenhouse, Lever, Wellfound |
+| **Portal Scanner**       | 45+ companies pre-configured (Anthropic, OpenAI, ElevenLabs, Retool, n8n...) + custom queries across Ashby, Greenhouse, Lever, Teamtailor, Wellfound |
 | **Batch Processing**     | Parallel evaluation with headless CLI workers (`claude -p` / `opencode run`)                                                             |
 | **Dashboard TUI**        | Terminal UI to browse, filter, and sort your pipeline                                                                                    |
 | **Human-in-the-Loop**    | AI evaluates and recommends, you decide and act. The system never submits an application -- you always have the final call               |
@@ -395,7 +395,7 @@ career-ops/
 - **Agent**: AI coding CLI with shared skills and modes (`AGENTS.md` + CLI wrapper)
 - **PDF**: Playwright/Puppeteer + HTML template
 - **Cover letters**: HTML template + Playwright (A4 PDF, same pipeline as CVs)
-- **Scanner**: Playwright + Greenhouse API + WebSearch
+- **Scanner**: Playwright + Greenhouse / Ashby / Lever / Teamtailor APIs & feeds + WebSearch
 - **Dashboard**: Go + Bubble Tea + Lipgloss (Catppuccin Mocha theme)
 - **Data**: Markdown tables + YAML config + TSV batch files
 

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ career-ops/
 - **Agent**: AI coding CLI with shared skills and modes (`AGENTS.md` + CLI wrapper)
 - **PDF**: Playwright/Puppeteer + HTML template
 - **Cover letters**: HTML template + Playwright (A4 PDF, same pipeline as CVs)
-- **Scanner**: Playwright + Greenhouse / Ashby / Lever / Teamtailor / Workday / SmartRecruiters / Workable and more APIs & feeds + WebSearch
+- **Scanner**: Playwright + Greenhouse / Ashby / Lever / Teamtailor / BambooHR / Workday / SmartRecruiters / Workable and more APIs & feeds + WebSearch
 - **Dashboard**: Go + Bubble Tea + Lipgloss (Catppuccin Mocha theme)
 - **Data**: Markdown tables + YAML config + TSV batch files
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -31,7 +31,7 @@ Copy from `templates/portals.example.yml` and customize:
 1. **title_filter.positive**: Keywords matching your target roles
 2. **title_filter.negative**: Tech stacks or domains to exclude
 3. **search_queries**: WebSearch queries for job boards (Ashby, Greenhouse, Lever)
-4. **tracked_companies**: Companies to check directly
+4. **tracked_companies**: Companies to check directly (Greenhouse, Ashby, Lever, Teamtailor auto-detected from URL; set `provider: teamtailor` for custom domains)
 
 ## CV Template (templates/cv-template.html)
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -229,7 +229,7 @@ Each URL gets a verdict: `active`, `expired`, or `uncertain` with a reason.
 
 ## scan
 
-Zero-token portal scanner. Runs configured local parsers for SSR/static career pages and hits ATS APIs (Greenhouse, Ashby, Lever) directly — no LLM tokens consumed. Reads `portals.yml` for target companies, outputs matching listings to stdout, and optionally appends to `data/pipeline.md`.
+Zero-token portal scanner. Runs configured local parsers for SSR/static career pages and hits ATS APIs (Greenhouse, Ashby, Lever) and RSS feeds (Teamtailor) directly — no LLM tokens consumed. Reads `portals.yml` for target companies, outputs matching listings to stdout, and optionally appends to `data/pipeline.md`.
 
 `scan_history.recheck_after_days` in `portals.yml` lets old `added` URLs become eligible for recheck after the configured number of days. If absent, scan-history dedup keeps the historical behavior and dedups forever. Permanent invalid statuses such as blocked host and malformed URL remain permanent.
 

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -128,7 +128,7 @@ For companies with a public API or structured feed **that are not in `local_pars
 - **Ashby**: `https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobBoardWithTeams`
 - **BambooHR**: list `https://{company}.bamboohr.com/careers/list`; job details `https://{company}.bamboohr.com/careers/{id}/detail`
 - **Lever**: `https://api.lever.co/v0/postings/{company}?mode=json`
-- **Teamtailor**: `https://{company}.teamtailor.com/jobs.rss`
+- **Teamtailor**: RSS feed at `{careers_url}/jobs.rss` — `careers_url` must be the base URL (no `/jobs` suffix). Auto-detected for `*.teamtailor.com` hosts; for custom domains (e.g. `https://careers.bookingkit.com`) set `provider: teamtailor`.
 - **Workday**: `https://{company}.{shard}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs`
 - **Breezy**: `https://{company}.breezy.hr/json`
 
@@ -137,7 +137,7 @@ For companies with a public API or structured feed **that are not in `local_pars
 - `ashby`: GraphQL `ApiJobBoardWithTeams` with `organizationHostedJobsPageName={company}` → `jobBoard.jobPostings[]` (`title`, `id`; build public URL if not present in payload)
 - `bamboohr`: list `result[]` → `jobOpeningName`, `id`; build detail URL `https://{company}.bamboohr.com/careers/{id}/detail`; to read full JD, make a GET request to the detail URL and use `result.jobOpening` (`jobOpeningName`, `description`, `datePosted`, `minimumExperience`, `compensation`, `jobOpeningShareUrl`)
 - `lever`: root array `[]` → `text`, `hostedUrl` (fallback: `applyUrl`)
-- `teamtailor`: RSS items → `title`, `link`
+- `teamtailor`: RSS `<item>` → `title` (HTML entities decoded), `link` → url; location from `tt:city` + `tt:country` + `remoteStatus` (`fully` → "Remote (city, country)"); `pubDate` → `postedAt` (epoch ms, omitted when absent)
 - `workday`: `jobPostings[]`/`jobPostings` (based on tenant) → `title`, `externalPath` or URL built from the host
 - `breezy`: top-level array `[]` → `name`, `url` (absolute), `location.name` (or city/state/country + `is_remote`), `published_date`
 
@@ -182,7 +182,7 @@ Levels are additive — they are executed in order, and results are merged and d
    g. If `careers_url` fails (404, redirect), attempt `scan_query` as a fallback and note it to update the URL later.
 
 5. **Level 2 — ATS APIs / Feeds** (parallel):
-   For each company in `tracked_companies` with a defined `api:`, `enabled: true`, and a **name not listed in `local_parser_ok`**:
+   For each company in `tracked_companies` with a defined `api:` (or a Teamtailor-detected `careers_url`), `enabled: true`, and a **name not listed in `local_parser_ok`**:
    a. WebFetch the API/feed URL.
    b. If `api_provider` is defined, use its parser; if undefined, infer by domain (`boards-api.greenhouse.io`, `jobs.ashbyhq.com`, `api.lever.co`, `*.bamboohr.com`, `*.teamtailor.com`, `*.myworkdayjobs.com`, `*.breezy.hr`).
    c. For **Ashby**, send a POST request with:
@@ -191,8 +191,9 @@ Levels are additive — they are executed in order, and results are merged and d
       - GraphQL query of `jobBoardWithTeams` + `jobPostings { id title locationName employmentType compensationTierSummary }`
    d. For **BambooHR**, the list only returns basic metadata. For each relevant item, retrieve the `id`, make a GET request to `https://{company}.bamboohr.com/careers/{id}/detail`, and extract the full JD from `result.jobOpening`. Use `jobOpeningShareUrl` as the public URL if present; otherwise, use the detail URL.
    e. For **Workday**, send a JSON POST request with at least `{"appliedFacets":{},"limit":20,"offset":0,"searchText":""}` and paginate by `offset` until results are exhausted.
-   f. For each job, extract and normalize: `{title, url, company}`.
-   g. Accumulate in the candidates list (deduplicated against Level 1).
+   f. For **Teamtailor**, derive the feed URL as `{careers_url}/jobs.rss` (strip trailing slash; do not use the `/jobs` page URL as `careers_url`). Parse RSS `<item>` elements: `title` (HTML entities decoded), `link` → url, `tt:city` + `tt:country` + `remoteStatus` → location.
+   g. For each job, extract and normalize: `{title, url, company}`.
+   h. Accumulate in the candidates list (deduplicated against Level 1).
 
 6. **Level 3 — WebSearch Queries** (parallel if possible):
    For each query in `search_queries` with `enabled: true` (general queries by portal/role — not dedicated queries for a company with an active local parser):
@@ -314,7 +315,7 @@ Fallback: if you only have the direct ATS URL, navigate first to the company's w
 - **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` or `https://job-boards.eu.greenhouse.io/{slug}`
 - **Lever:** `https://jobs.lever.co/{slug}`
 - **BambooHR:** list `https://{company}.bamboohr.com/careers/list`; detail `https://{company}.bamboohr.com/careers/{id}/detail`
-- **Teamtailor:** `https://{company}.teamtailor.com/jobs`
+- **Teamtailor:** `https://{slug}.teamtailor.com` (base URL, not `.../jobs`) — e.g. `https://viragames.teamtailor.com`; for custom domains (e.g. `https://careers.bookingkit.com`) set `provider: teamtailor`
 - **Workday:** `https://{company}.{shard}.myworkdayjobs.com/{site}`
 - **Custom:** The company's own URL (e.g. `https://openai.com/careers`)
 
@@ -322,7 +323,7 @@ Fallback: if you only have the direct ATS URL, navigate first to the company's w
 - **Ashby API:** `https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobBoardWithTeams`
 - **BambooHR API:** list `https://{company}.bamboohr.com/careers/list`; detail `https://{company}.bamboohr.com/careers/{id}/detail` (`result.jobOpening`)
 - **Lever API:** `https://api.lever.co/v0/postings/{company}?mode=json`
-- **Teamtailor RSS:** `https://{company}.teamtailor.com/jobs.rss`
+- **Teamtailor RSS:** `{careers_url}/jobs.rss` — derived from `careers_url` (works for `*.teamtailor.com` subdomains and custom domains with `provider: teamtailor`)
 - **Workday API:** `https://{company}.{shard}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs`
 
 **If `careers_url` does not exist** for a company:

--- a/providers/_url-guard.mjs
+++ b/providers/_url-guard.mjs
@@ -1,0 +1,30 @@
+// @ts-check
+
+/**
+ * Returns true only for public http/https URLs — blocks loopback, private
+ * ranges, and link/unique-local IPv6 to prevent SSRF from user-supplied URLs.
+ *
+ * @param {string} rawUrl
+ * @returns {boolean}
+ */
+export function isSafeUrl(rawUrl) {
+  let parsed;
+  try { parsed = new URL(rawUrl); } catch { return false; }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+  const h = parsed.hostname.replace(/^\[|\]$/g, ''); // strip IPv6 brackets
+  if (h === 'localhost') return false;
+  if (/^(127|10)\.|^192\.168\.|^172\.(1[6-9]|2\d|3[01])\.|^169\.254\.|^0\./.test(h)) return false;
+  // IPv6: loopback, unspecified, link-local (fe80::/10), unique-local (fc00::/7)
+  if (h === '::1' || h === '::') return false;
+  if (/^fe[89ab]/i.test(h) || /^f[cd]/i.test(h)) return false;
+  // IPv4-mapped IPv6 — Node.js URL hex-encodes octets: ::ffff:7f00:1 = 127.0.0.1
+  const m = h.match(/^::ffff:([0-9a-f]+):([0-9a-f]+)$/i);
+  if (m) {
+    const a = parseInt(m[1], 16);
+    const [o1, o2] = [(a >> 8) & 0xff, a & 0xff];
+    if (o1 === 127 || o1 === 10 || o1 === 0) return false;
+    if ((o1 === 192 && o2 === 168) || (o1 === 172 && o2 >= 16 && o2 <= 31)) return false;
+    if (o1 === 169 && o2 === 254) return false;
+  }
+  return true;
+}

--- a/providers/teamtailor.mjs
+++ b/providers/teamtailor.mjs
@@ -5,9 +5,20 @@
 // Auto-detects from careers_url matching *.teamtailor.com.
 // For companies with a custom domain, set `provider: teamtailor` in portals.yml.
 
+function isSafeUrl(rawUrl) {
+  let parsed;
+  try { parsed = new URL(rawUrl); } catch { return false; }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+  const h = parsed.hostname;
+  if (h === 'localhost' || h === '::1') return false;
+  if (/^127\./.test(h) || /^10\./.test(h) || /^192\.168\./.test(h)) return false;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h) || /^169\.254\./.test(h) || /^0\./.test(h)) return false;
+  return true;
+}
+
 function resolveRssUrl(entry) {
   const url = (entry.careers_url || '').replace(/\/$/, '');
-  if (!url) return null;
+  if (!url || !isSafeUrl(url)) return null;
   // Auto-detect: slug.teamtailor.com
   if (/\.teamtailor\.com$/i.test(new URL(url).hostname)) return `${url}/jobs.rss`;
   // Explicit provider: custom domain — append /jobs.rss to the base

--- a/providers/teamtailor.mjs
+++ b/providers/teamtailor.mjs
@@ -5,16 +5,7 @@
 // Auto-detects from careers_url matching *.teamtailor.com.
 // For companies with a custom domain, set `provider: teamtailor` in portals.yml.
 
-function isSafeUrl(rawUrl) {
-  let parsed;
-  try { parsed = new URL(rawUrl); } catch { return false; }
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
-  const h = parsed.hostname;
-  if (h === 'localhost' || h === '::1') return false;
-  if (/^127\./.test(h) || /^10\./.test(h) || /^192\.168\./.test(h)) return false;
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h) || /^169\.254\./.test(h) || /^0\./.test(h)) return false;
-  return true;
-}
+import { isSafeUrl } from './_url-guard.mjs';
 
 function resolveRssUrl(entry) {
   const url = (entry.careers_url || '').replace(/\/$/, '');

--- a/providers/teamtailor.mjs
+++ b/providers/teamtailor.mjs
@@ -1,0 +1,75 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Teamtailor provider — reads jobs from the public /jobs.rss feed.
+// Auto-detects from careers_url matching *.teamtailor.com.
+// For companies with a custom domain, set `provider: teamtailor` in portals.yml.
+
+function resolveRssUrl(entry) {
+  const url = (entry.careers_url || '').replace(/\/$/, '');
+  if (!url) return null;
+  // Auto-detect: slug.teamtailor.com
+  if (/\.teamtailor\.com$/i.test(new URL(url).hostname)) return `${url}/jobs.rss`;
+  // Explicit provider: custom domain — append /jobs.rss to the base
+  if (entry.provider === 'teamtailor') return `${url}/jobs.rss`;
+  return null;
+}
+
+function decodeHtmlEntities(str) {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
+function parseRss(xml, companyName) {
+  const items = [];
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
+  let match;
+  while ((match = itemRegex.exec(xml)) !== null) {
+    const block = match[1];
+    const title = decodeHtmlEntities(
+      (/<title>(.*?)<\/title>/.exec(block) || [])[1] || ''
+    ).trim();
+    const url = ((/<link>(.*?)<\/link>/.exec(block) || [])[1] || '').trim();
+    const city = ((/<tt:city>(.*?)<\/tt:city>/.exec(block) || [])[1] || '').trim();
+    const country = ((/<tt:country>(.*?)<\/tt:country>/.exec(block) || [])[1] || '').trim();
+    const remote = ((/<remoteStatus>(.*?)<\/remoteStatus>/.exec(block) || [])[1] || '').trim();
+    const pubDate = ((/<pubDate>(.*?)<\/pubDate>/.exec(block) || [])[1] || '').trim();
+
+    if (!title || !url) continue;
+
+    const locationParts = [city, country].filter(Boolean);
+    const location = remote === 'fully'
+      ? locationParts.length ? `Remote (${locationParts.join(', ')})` : 'Remote'
+      : locationParts.join(', ');
+
+    const postedAt = pubDate ? Date.parse(pubDate) : undefined;
+    items.push({ title, url, company: companyName, location, ...(postedAt && !isNaN(postedAt) ? { postedAt } : {}) });
+  }
+  return items;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'teamtailor',
+
+  detect(entry) {
+    try {
+      const rssUrl = resolveRssUrl(entry);
+      return rssUrl ? { url: rssUrl } : null;
+    } catch {
+      return null;
+    }
+  },
+
+  async fetch(entry, ctx) {
+    const rssUrl = resolveRssUrl(entry);
+    if (!rssUrl) throw new Error('teamtailor: cannot derive RSS URL from careers_url');
+    const xml = await ctx.fetchText(rssUrl, { redirect: 'error' });
+    return parseRss(xml, entry.name);
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -491,10 +491,12 @@ search_queries:
 #   personio        <slug>.jobs.personio.(de|com)
 #   pinpoint        <slug>.pinpointhq.com
 #   rippling        ats.rippling.com/<slug>/jobs
+#   teamtailor      <slug>.teamtailor.com  (RSS feed at careers_url/jobs.rss)
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
-# bypass detect(). The `provider:` field wins over auto-detection.
+# bypass detect(). For Teamtailor custom domains set `provider: teamtailor`
+# instead. The `provider:` field wins over auto-detection.
 #
 # Some providers are job boards / aggregators with no per-company careers
 # URL to detect, so they must be selected with an explicit `provider:`
@@ -630,6 +632,25 @@ search_queries:
 #     enabled: true
 
 tracked_companies:
+
+  # ── Teamtailor provider examples ──────────────────────────────────────
+  # These entries are NOT curated companies — they demonstrate the two
+  # Teamtailor URL patterns. Replace or remove them as you see fit.
+  #
+  # Pattern 1 — auto-detect: any *.teamtailor.com careers_url is picked up
+  # automatically; the scanner fetches careers_url/jobs.rss.
+  - name: Vira Games
+    careers_url: https://viragames.teamtailor.com
+    notes: "Kyiv UA / Stockholm SE. Mobile gaming studio."
+    enabled: false
+
+  # Pattern 2 — custom domain: set `provider: teamtailor` so the scanner
+  # knows to fetch careers_url/jobs.rss instead of treating it as a generic page.
+  - name: Bookingkit
+    careers_url: https://careers.bookingkit.com
+    provider: teamtailor
+    notes: "Berlin DE. Online booking SaaS."
+    enabled: false
 
   # -- AI Labs & LLM providers --
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1151,6 +1151,46 @@ try {
     fail('verify-portals parseAtsSlug misclassified an ATS or branded URL');
   }
 
+  // Teamtailor: parseAtsSlug extracts subdomain from *.teamtailor.com
+  const ttSlug = parseAtsSlug('https://viragames.teamtailor.com');
+  if (ttSlug?.ats === 'teamtailor' && ttSlug?.slug === 'viragames') {
+    pass('verify-portals parseAtsSlug extracts teamtailor subdomain slug');
+  } else {
+    fail(`verify-portals parseAtsSlug teamtailor: ${JSON.stringify(ttSlug)}`);
+  }
+
+  // Custom domain (provider: teamtailor) is not recognized by parseAtsSlug
+  if (parseAtsSlug('https://careers.bookingkit.com') === null) {
+    pass('verify-portals parseAtsSlug returns null for teamtailor custom domain (handled separately)');
+  } else {
+    fail('verify-portals parseAtsSlug should return null for custom domains');
+  }
+
+  // Mock fetchText for RSS probing
+  const mockRss = (items) => `<?xml version="1.0"?><rss><channel>${'<item></item>'.repeat(items)}</channel></rss>`;
+  const mockFetchText = async (url) => {
+    if (url === 'https://viragames.teamtailor.com/jobs.rss') return mockRss(4);
+    if (url === 'https://empty.teamtailor.com/jobs.rss') return mockRss(0);
+    if (url === 'https://careers.bookingkit.com/jobs.rss') return mockRss(5);
+    const err = new Error('HTTP 404'); err.status = 404; throw err;
+  };
+
+  // probeSlug for teamtailor (RSS path)
+  const { probeSlug } = await import(pathToFileURL(join(ROOT, 'verify-portals.mjs')).href);
+  const ttLive = await probeSlug('teamtailor', 'viragames', { fetchText: mockFetchText });
+  if (ttLive.status === 'live' && ttLive.jobCount === 4 && ttLive.url === 'https://viragames.teamtailor.com/jobs.rss') {
+    pass('verify-portals probeSlug(teamtailor) reports live with item count');
+  } else {
+    fail(`verify-portals probeSlug(teamtailor) live: ${JSON.stringify(ttLive)}`);
+  }
+
+  const ttEmpty = await probeSlug('teamtailor', 'empty', { fetchText: mockFetchText });
+  if (ttEmpty.status === 'empty' && ttEmpty.jobCount === 0) {
+    pass('verify-portals probeSlug(teamtailor) reports empty board');
+  } else {
+    fail(`verify-portals probeSlug(teamtailor) empty: ${JSON.stringify(ttEmpty)}`);
+  }
+
   // Mock fetchJson: 200+jobs → live, 200+empty → empty, otherwise 404 → missing.
   const mockFetch = async (url) => {
     if (url.includes('/boards/live/')) return { jobs: [{}, {}] };
@@ -1163,14 +1203,17 @@ try {
     { name: 'Typo', careers_url: 'https://job-boards.greenhouse.io/nope' },
     { name: 'Branded', careers_url: 'https://acme.com/careers' },
     { name: 'Off', enabled: false, careers_url: 'https://job-boards.greenhouse.io/live' },
-  ], { fetchJson: mockFetch });
+    { name: 'TT Auto', careers_url: 'https://viragames.teamtailor.com' },
+    { name: 'TT Custom', careers_url: 'https://careers.bookingkit.com', provider: 'teamtailor' },
+  ], { fetchJson: mockFetch, fetchText: mockFetchText });
   const byName = Object.fromEntries(results.map((r) => [r.name, r.status]));
   if (
-    results.length === 4 &&
+    results.length === 6 &&
     byName.Live === 'live' && byName.Empty === 'empty' &&
-    byName.Typo === 'missing' && byName.Branded === 'skipped'
+    byName.Typo === 'missing' && byName.Branded === 'skipped' &&
+    byName['TT Auto'] === 'live' && byName['TT Custom'] === 'live'
   ) {
-    pass('verify-portals classifies live / empty / unresolved / non-ATS (disabled excluded)');
+    pass('verify-portals classifies live/empty/unresolved/non-ATS + Teamtailor auto + custom domain');
   } else {
     fail(`verify-portals classification wrong: ${JSON.stringify(byName)} (${results.length} rows)`);
   }
@@ -8206,6 +8249,138 @@ try {
 } finally {
   console.warn = __origWarn;
   if (__pluginTmp) { try { rmSync(__pluginTmp, { recursive: true, force: true }); } catch {} }
+}
+
+// ── 50. PROVIDERS — Teamtailor ──────────────────────────────────────────
+console.log('\n50. Provider — teamtailor');
+
+try {
+  const teamtailor = (await import(pathToFileURL(join(ROOT, 'providers/teamtailor.mjs')).href)).default;
+
+  if (teamtailor.id === 'teamtailor') pass('teamtailor.id is "teamtailor"');
+  else fail(`teamtailor.id is ${JSON.stringify(teamtailor.id)}`);
+
+  // detect() — auto-detects *.teamtailor.com URLs
+  const hit = teamtailor.detect({ name: 'TestCo', careers_url: 'https://acme.teamtailor.com' });
+  if (hit?.url === 'https://acme.teamtailor.com/jobs.rss') {
+    pass('teamtailor.detect() resolves *.teamtailor.com → /jobs.rss');
+  } else {
+    fail(`teamtailor.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  // detect() — custom domain with explicit provider: teamtailor
+  const customHit = teamtailor.detect({ name: 'TestCo', careers_url: 'https://careers.example.com', provider: 'teamtailor' });
+  if (customHit?.url === 'https://careers.example.com/jobs.rss') {
+    pass('teamtailor.detect() handles custom domain with explicit provider: teamtailor');
+  } else {
+    fail(`teamtailor.detect() custom domain returned ${JSON.stringify(customHit)}`);
+  }
+
+  // detect() — returns null for non-teamtailor URLs
+  const miss = teamtailor.detect({ name: 'TestCo', careers_url: 'https://jobs.lever.co/acme' });
+  if (miss === null || miss === undefined) pass('teamtailor.detect() returns null for non-teamtailor URLs');
+  else fail(`teamtailor.detect() should return null, got ${JSON.stringify(miss)}`);
+
+  // detect() — trailing slash is stripped
+  const trailingSlash = teamtailor.detect({ name: 'TestCo', careers_url: 'https://acme.teamtailor.com/' });
+  if (trailingSlash?.url === 'https://acme.teamtailor.com/jobs.rss') {
+    pass('teamtailor.detect() strips trailing slash before appending /jobs.rss');
+  } else {
+    fail(`teamtailor.detect() trailing slash returned ${JSON.stringify(trailingSlash)}`);
+  }
+
+  const sampleRss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:tt="https://teamtailor.com/locations">
+  <channel>
+    <title>Acme Corp</title>
+    <item>
+      <title>Senior AI Engineer (m/f/d)</title>
+      <link>https://careers.acme.com/jobs/123-senior-ai-engineer</link>
+      <tt:city>Berlin</tt:city>
+      <tt:country>Germany</tt:country>
+      <remoteStatus>fully</remoteStatus>
+      <pubDate>Mon, 16 Jun 2025 08:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>Product Manager &amp; Lead</title>
+      <link>https://careers.acme.com/jobs/456-product-manager</link>
+      <tt:city>Munich</tt:city>
+      <tt:country>Germany</tt:country>
+      <remoteStatus>none</remoteStatus>
+    </item>
+    <item>
+      <title></title>
+      <link>https://careers.acme.com/jobs/789-no-title</link>
+    </item>
+  </channel>
+</rss>`;
+
+  const jobs = await teamtailor.fetch(
+    { name: 'AcmeCorp', careers_url: 'https://acme.teamtailor.com', provider: 'teamtailor' },
+    {
+      fetchText: async (url) => {
+        if (url === 'https://acme.teamtailor.com/jobs.rss') return sampleRss;
+        throw new Error(`Unexpected URL: ${url}`);
+      },
+      fetchJson: async () => { throw new Error('fetchJson should not be called'); },
+    },
+  );
+
+  if (jobs.length === 2) pass('teamtailor.fetch() skips items with empty title');
+  else fail(`teamtailor.fetch() returned ${jobs.length} jobs, expected 2`);
+
+  if (jobs[0]?.title === 'Senior AI Engineer (m/f/d)' && jobs[0]?.company === 'AcmeCorp') {
+    pass('teamtailor.fetch() extracts title and company correctly');
+  } else {
+    fail(`teamtailor.fetch() job[0] = ${JSON.stringify(jobs[0])}`);
+  }
+
+  if (jobs[0]?.location === 'Remote (Berlin, Germany)') {
+    pass('teamtailor.fetch() builds "Remote (city, country)" for fully-remote jobs');
+  } else {
+    fail(`teamtailor.fetch() remote location = ${JSON.stringify(jobs[0]?.location)}`);
+  }
+
+  if (jobs[1]?.location === 'Munich, Germany') {
+    pass('teamtailor.fetch() builds "city, country" for non-remote jobs');
+  } else {
+    fail(`teamtailor.fetch() onsite location = ${JSON.stringify(jobs[1]?.location)}`);
+  }
+
+  if (jobs[1]?.title === 'Product Manager & Lead') {
+    pass('teamtailor.fetch() decodes &amp; HTML entity in title');
+  } else {
+    fail(`teamtailor.fetch() HTML entity decode: ${JSON.stringify(jobs[1]?.title)}`);
+  }
+
+  const expectedPostedAt = Date.parse('Mon, 16 Jun 2025 08:00:00 +0000');
+  if (jobs[0]?.postedAt === expectedPostedAt) {
+    pass('teamtailor.fetch() parses pubDate into postedAt (epoch ms)');
+  } else {
+    fail(`teamtailor.fetch() postedAt: expected ${expectedPostedAt}, got ${JSON.stringify(jobs[0]?.postedAt)}`);
+  }
+
+  if (jobs[1]?.postedAt === undefined) {
+    pass('teamtailor.fetch() omits postedAt when pubDate is absent');
+  } else {
+    fail(`teamtailor.fetch() postedAt should be absent when no pubDate, got ${JSON.stringify(jobs[1]?.postedAt)}`);
+  }
+
+  // fetch() — throws when RSS URL cannot be resolved
+  let threw = false;
+  try {
+    await teamtailor.fetch(
+      { name: 'Bad', careers_url: 'https://evil.com/not-teamtailor' },
+      { fetchText: async () => { throw new Error('SSRF! should not reach here'); } },
+    );
+  } catch (e) {
+    if (e.message.includes('RSS URL')) threw = true;
+  }
+  if (threw) pass('teamtailor.fetch() throws when RSS URL cannot be resolved');
+  else fail('teamtailor.fetch() should throw for non-teamtailor careers_url without explicit provider');
+
+} catch (e) {
+  fail(`teamtailor provider tests crashed: ${e.message}\n${e.stack}`);
 }
 
 // ── SUMMARY ─────────────────────────────────────────────────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1152,15 +1152,15 @@ try {
   }
 
   // Teamtailor: parseAtsSlug extracts subdomain from *.teamtailor.com
-  const ttSlug = parseAtsSlug('https://viragames.teamtailor.com');
-  if (ttSlug?.ats === 'teamtailor' && ttSlug?.slug === 'viragames') {
+  const ttSlug = parseAtsSlug('https://acme-corp.teamtailor.com');
+  if (ttSlug?.ats === 'teamtailor' && ttSlug?.slug === 'acme-corp') {
     pass('verify-portals parseAtsSlug extracts teamtailor subdomain slug');
   } else {
     fail(`verify-portals parseAtsSlug teamtailor: ${JSON.stringify(ttSlug)}`);
   }
 
   // Custom domain (provider: teamtailor) is not recognized by parseAtsSlug
-  if (parseAtsSlug('https://careers.bookingkit.com') === null) {
+  if (parseAtsSlug('https://careers.example-company.com') === null) {
     pass('verify-portals parseAtsSlug returns null for teamtailor custom domain (handled separately)');
   } else {
     fail('verify-portals parseAtsSlug should return null for custom domains');
@@ -1169,16 +1169,16 @@ try {
   // Mock fetchText for RSS probing
   const mockRss = (items) => `<?xml version="1.0"?><rss><channel>${'<item></item>'.repeat(items)}</channel></rss>`;
   const mockFetchText = async (url) => {
-    if (url === 'https://viragames.teamtailor.com/jobs.rss') return mockRss(4);
+    if (url === 'https://acme-corp.teamtailor.com/jobs.rss') return mockRss(4);
     if (url === 'https://empty.teamtailor.com/jobs.rss') return mockRss(0);
-    if (url === 'https://careers.bookingkit.com/jobs.rss') return mockRss(5);
+    if (url === 'https://careers.example-company.com/jobs.rss') return mockRss(5);
     const err = new Error('HTTP 404'); err.status = 404; throw err;
   };
 
   // probeSlug for teamtailor (RSS path)
   const { probeSlug } = await import(pathToFileURL(join(ROOT, 'verify-portals.mjs')).href);
-  const ttLive = await probeSlug('teamtailor', 'viragames', { fetchText: mockFetchText });
-  if (ttLive.status === 'live' && ttLive.jobCount === 4 && ttLive.url === 'https://viragames.teamtailor.com/jobs.rss') {
+  const ttLive = await probeSlug('teamtailor', 'acme-corp', { fetchText: mockFetchText });
+  if (ttLive.status === 'live' && ttLive.jobCount === 4 && ttLive.url === 'https://acme-corp.teamtailor.com/jobs.rss') {
     pass('verify-portals probeSlug(teamtailor) reports live with item count');
   } else {
     fail(`verify-portals probeSlug(teamtailor) live: ${JSON.stringify(ttLive)}`);
@@ -1203,8 +1203,8 @@ try {
     { name: 'Typo', careers_url: 'https://job-boards.greenhouse.io/nope' },
     { name: 'Branded', careers_url: 'https://acme.com/careers' },
     { name: 'Off', enabled: false, careers_url: 'https://job-boards.greenhouse.io/live' },
-    { name: 'TT Auto', careers_url: 'https://viragames.teamtailor.com' },
-    { name: 'TT Custom', careers_url: 'https://careers.bookingkit.com', provider: 'teamtailor' },
+    { name: 'TT Auto', careers_url: 'https://acme-corp.teamtailor.com' },
+    { name: 'TT Custom', careers_url: 'https://careers.example-company.com', provider: 'teamtailor' },
   ], { fetchJson: mockFetch, fetchText: mockFetchText });
   const byName = Object.fromEntries(results.map((r) => [r.name, r.status]));
   if (

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -30,13 +30,15 @@ import { resolve } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import yaml from 'js-yaml';
 
-import { fetchJson as defaultFetchJson } from './providers/_http.mjs';
+import { fetchJson as defaultFetchJson, fetchText as defaultFetchText } from './providers/_http.mjs';
 
 const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
 
 // How to turn a slug into a probe URL, and where the job list lives in the
 // response, for each supported ATS. Greenhouse/Ashby wrap jobs in `{ jobs }`;
 // Lever returns a bare array. `includeCompensation` mirrors the ashby provider.
+// Teamtailor is RSS-based: use `itemCount` (receives raw XML text) instead of
+// `jobCount` (receives parsed JSON). `probeSlug` dispatches on which is present.
 export const ATS = {
   greenhouse: {
     probeUrl: (slug) => `https://boards-api.greenhouse.io/v1/boards/${slug}/jobs`,
@@ -49,6 +51,10 @@ export const ATS = {
   lever: {
     probeUrl: (slug) => `https://api.lever.co/v0/postings/${slug}`,
     jobCount: (json) => (Array.isArray(json) ? json.length : null),
+  },
+  teamtailor: {
+    probeUrl: (slug) => `https://${slug}.teamtailor.com/jobs.rss`,
+    itemCount: (text) => (text.match(/<item>/g) || []).length,
   },
 };
 
@@ -63,6 +69,10 @@ const ATS_URL_PATTERNS = [
   { ats: 'ashby', re: /jobs\.ashbyhq\.com\/([^/?#]+)/ },
   { ats: 'lever', re: /api\.lever\.co\/v0\/postings\/([^/?#]+)/ },
   { ats: 'lever', re: /jobs\.lever\.co\/([^/?#]+)/ },
+  // Teamtailor: extract subdomain slug from *.teamtailor.com URLs.
+  // Custom domains (e.g. careers.bookingkit.com with provider: teamtailor) are
+  // handled separately in verifyCompanies — no slug to extract from the URL.
+  { ats: 'teamtailor', re: /^https?:\/\/([^.]+)\.teamtailor\.com/ },
 ];
 
 /**
@@ -109,18 +119,26 @@ export function deriveSlugCandidates(name) {
 /**
  * Probe one ATS for one slug and classify the result.
  *
- * @param {string} ats - Key into ATS (greenhouse | ashby | lever).
- * @param {string} slug - Candidate slug to probe.
- * @param {{fetchJson?: Function}} [deps] - Injectable HTTP for testability.
+ * JSON-based ATS (greenhouse/ashby/lever): fetches JSON, calls `spec.jobCount`.
+ * RSS-based ATS (teamtailor): fetches raw text, calls `spec.itemCount`.
+ *
+ * @param {string} ats - Key into ATS.
+ * @param {string} slug - Candidate slug to probe (or full RSS URL for Teamtailor custom domains).
+ * @param {{fetchJson?: Function, fetchText?: Function}} [deps] - Injectable HTTP for testability.
  * @returns {Promise<{ats,slug,url,status,jobCount?,httpStatus?,reason?}>}
  *   status is 'live' (jobs > 0), 'empty' (200, no jobs), or 'missing'
  *   (404/error/unexpected shape).
  */
-export async function probeSlug(ats, slug, { fetchJson = defaultFetchJson } = {}) {
+export async function probeSlug(ats, slug, { fetchJson = defaultFetchJson, fetchText = defaultFetchText } = {}) {
   const spec = ATS[ats];
   if (!spec) return { ats, slug, url: '', status: 'missing', reason: `unknown ATS: ${ats}` };
   const url = spec.probeUrl(slug);
   try {
+    if (spec.itemCount) {
+      const text = await fetchText(url);
+      const count = spec.itemCount(text);
+      return { ats, slug, url, status: count > 0 ? 'live' : 'empty', jobCount: count };
+    }
     const json = await fetchJson(url);
     const count = spec.jobCount(json);
     if (count == null) return { ats, slug, url, status: 'missing', reason: 'unexpected response shape' };
@@ -142,19 +160,35 @@ export async function probeSlug(ats, slug, { fetchJson = defaultFetchJson } = {}
  * @param {{fetchJson?: Function}} [deps]
  * @returns {Promise<Array<object>>} One result row per company.
  */
-export async function verifyCompanies(companies, { fetchJson = defaultFetchJson } = {}) {
+export async function verifyCompanies(companies, { fetchJson = defaultFetchJson, fetchText = defaultFetchText } = {}) {
   const list = Array.isArray(companies) ? companies : [];
   const results = [];
   for (const company of list) {
     if (!company || typeof company !== 'object') continue;
     if (company.enabled === false) continue;
     const name = typeof company.name === 'string' ? company.name : '(unnamed)';
-    const match = parseAtsSlug(company.api) || parseAtsSlug(company.careers_url);
-    if (!match) {
-      results.push({ name, status: 'skipped', reason: 'no Greenhouse/Ashby/Lever slug in careers_url or api' });
+
+    // Teamtailor custom domain: careers_url is not a *.teamtailor.com subdomain,
+    // so parseAtsSlug won't recognize it. Probe the RSS URL directly using the
+    // full careers_url as the "slug" — probeUrl is the identity in this case.
+    if (company.provider === 'teamtailor' && company.careers_url && !parseAtsSlug(company.careers_url)) {
+      const rssUrl = company.careers_url.replace(/\/$/, '') + '/jobs.rss';
+      try {
+        const text = await fetchText(rssUrl);
+        const count = (text.match(/<item>/g) || []).length;
+        results.push({ name, ats: 'teamtailor', slug: company.careers_url, url: rssUrl, status: count > 0 ? 'live' : 'empty', jobCount: count });
+      } catch (err) {
+        results.push({ name, ats: 'teamtailor', slug: company.careers_url, url: rssUrl, status: 'missing', httpStatus: err?.status, reason: err?.message || String(err) });
+      }
       continue;
     }
-    const probe = await probeSlug(match.ats, match.slug, { fetchJson });
+
+    const match = parseAtsSlug(company.api) || parseAtsSlug(company.careers_url);
+    if (!match) {
+      results.push({ name, status: 'skipped', reason: 'no Greenhouse/Ashby/Lever/Teamtailor slug in careers_url or api' });
+      continue;
+    }
+    const probe = await probeSlug(match.ats, match.slug, { fetchJson, fetchText });
     results.push({ name, ...probe });
   }
   return results;
@@ -164,15 +198,15 @@ export async function verifyCompanies(companies, { fetchJson = defaultFetchJson 
  * Read a portals file and verify its tracked companies' slugs.
  *
  * @param {string} filePath - Path to a portals.yml.
- * @param {{fetchJson?: Function}} [deps]
+ * @param {{fetchJson?: Function, fetchText?: Function}} [deps]
  * @returns {Promise<{found: boolean, results: Array<object>}>} found=false when
  *   the file is absent (a graceful no-op for fresh setups / CI).
  */
-export async function verifyPortalsFile(filePath, { fetchJson = defaultFetchJson } = {}) {
+export async function verifyPortalsFile(filePath, { fetchJson = defaultFetchJson, fetchText = defaultFetchText } = {}) {
   if (!existsSync(filePath)) return { found: false, results: [] };
   const config = yaml.load(readFileSync(filePath, 'utf-8'));
   const companies = Array.isArray(config?.tracked_companies) ? config.tracked_companies : [];
-  const results = await verifyCompanies(companies, { fetchJson });
+  const results = await verifyCompanies(companies, { fetchJson, fetchText });
   return { found: true, results };
 }
 
@@ -190,17 +224,17 @@ function printResults(results) {
   }
 }
 
-async function runAdd(name, { fetchJson }) {
+async function runAdd(name, { fetchJson, fetchText }) {
   const candidates = deriveSlugCandidates(name);
   if (candidates.length === 0) {
     console.error('verify-portals: --add needs a company name');
     process.exit(1);
   }
-  console.log(`Probing ${candidates.length} slug candidate(s) for "${name}" across Greenhouse/Ashby/Lever...\n`);
+  console.log(`Probing ${candidates.length} slug candidate(s) for "${name}" across Greenhouse/Ashby/Lever/Teamtailor...\n`);
   const hits = [];
   for (const slug of candidates) {
     for (const ats of Object.keys(ATS)) {
-      const r = await probeSlug(ats, slug, { fetchJson });
+      const r = await probeSlug(ats, slug, { fetchJson, fetchText });
       if (r.status !== 'missing') {
         hits.push(r);
         console.log(`  ${ICON[r.status]} ${ats}: ${slug}` + (r.status === 'empty' ? ' (live but empty)' : ` (${r.jobCount} jobs)`));
@@ -219,10 +253,11 @@ async function main() {
   const args = process.argv.slice(2);
   const strict = args.includes('--strict');
   const fetchJson = defaultFetchJson;
+  const fetchText = defaultFetchText;
 
   const addFlag = args.indexOf('--add');
   if (addFlag !== -1) {
-    await runAdd(args[addFlag + 1] || '', { fetchJson });
+    await runAdd(args[addFlag + 1] || '', { fetchJson, fetchText });
     return;
   }
 

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -34,6 +34,17 @@ import { fetchJson as defaultFetchJson, fetchText as defaultFetchText } from './
 
 const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
 
+function isSafeUrl(rawUrl) {
+  let parsed;
+  try { parsed = new URL(rawUrl); } catch { return false; }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+  const h = parsed.hostname;
+  if (h === 'localhost' || h === '::1') return false;
+  if (/^127\./.test(h) || /^10\./.test(h) || /^192\.168\./.test(h)) return false;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h) || /^169\.254\./.test(h) || /^0\./.test(h)) return false;
+  return true;
+}
+
 // How to turn a slug into a probe URL, and where the job list lives in the
 // response, for each supported ATS. Greenhouse/Ashby wrap jobs in `{ jobs }`;
 // Lever returns a bare array. `includeCompensation` mirrors the ashby provider.
@@ -172,6 +183,10 @@ export async function verifyCompanies(companies, { fetchJson = defaultFetchJson,
     // so parseAtsSlug won't recognize it. Probe the RSS URL directly using the
     // full careers_url as the "slug" — probeUrl is the identity in this case.
     if (company.provider === 'teamtailor' && company.careers_url && !parseAtsSlug(company.careers_url)) {
+      if (!isSafeUrl(company.careers_url)) {
+        results.push({ name, ats: 'teamtailor', slug: company.careers_url, status: 'missing', reason: 'SSRF: non-public host rejected' });
+        continue;
+      }
       const rssUrl = company.careers_url.replace(/\/$/, '') + '/jobs.rss';
       try {
         const text = await fetchText(rssUrl);

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -71,7 +71,7 @@ const ATS_URL_PATTERNS = [
   { ats: 'lever', re: /api\.lever\.co\/v0\/postings\/([^/?#]+)/ },
   { ats: 'lever', re: /jobs\.lever\.co\/([^/?#]+)/ },
   // Teamtailor: extract subdomain slug from *.teamtailor.com URLs.
-  // Custom domains (e.g. careers.bookingkit.com with provider: teamtailor) are
+  // Custom domains (e.g. careers.example-company.com with provider: teamtailor) are
   // handled separately in verifyCompanies — no slug to extract from the URL.
   { ats: 'teamtailor', re: /^https?:\/\/([^.]+)\.teamtailor\.com/ },
 ];

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -31,19 +31,9 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import yaml from 'js-yaml';
 
 import { fetchJson as defaultFetchJson, fetchText as defaultFetchText } from './providers/_http.mjs';
+import { isSafeUrl } from './providers/_url-guard.mjs';
 
 const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
-
-function isSafeUrl(rawUrl) {
-  let parsed;
-  try { parsed = new URL(rawUrl); } catch { return false; }
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
-  const h = parsed.hostname;
-  if (h === 'localhost' || h === '::1') return false;
-  if (/^127\./.test(h) || /^10\./.test(h) || /^192\.168\./.test(h)) return false;
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h) || /^169\.254\./.test(h) || /^0\./.test(h)) return false;
-  return true;
-}
 
 // How to turn a slug into a probe URL, and where the job list lives in the
 // response, for each supported ATS. Greenhouse/Ashby wrap jobs in `{ jobs }`;


### PR DESCRIPTION
## What does this PR do?

Adds a zero-token Teamtailor provider that reads the public `/jobs.rss` feed.
Auto-detects `*.teamtailor.com` URLs; custom domains supported via `provider: teamtailor` in `portals.yml`.
Also extends `verify-portals.mjs` to probe Teamtailor feeds alongside Greenhouse/Ashby/Lever.

## Related issue

Closes #1119

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Changes

- `providers/teamtailor.mjs`: reads `/jobs.rss` feed; auto-detects `*.teamtailor.com` URLs, custom domains via `provider: teamtailor`; parses title (HTML entities decoded), url, location (`tt:city` + `tt:country` + `remoteStatus`) and `pubDate` → `postedAt` (epoch ms)
- `verify-portals.mjs`: extend ATS map and `probeSlug` for RSS-based probing; handle Teamtailor custom domains in `verifyCompanies`
- `test-all.mjs`: 18 new tests covering provider and verify-portals
- `modes/scan.md`, `docs/SCRIPTS.md`, `docs/CUSTOMIZATION.md`, `README.md`: document Teamtailor alongside Greenhouse/Ashby/Lever
- `templates/portals.example.yml`: add auto-detection comment and two example entries (`*.teamtailor.com` and custom domain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Teamtailor job listings, enabling integration of job postings from Teamtailor-powered career portals

* **Security**
  * Enhanced URL validation for safer external resource access

* **Documentation**
  * Updated career operations skill documentation with comprehensive routing specifications and mode definitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->