### PR TITLE
feat(modes): add Polish (pl) locale modes

### DIFF
--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -51,6 +51,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/de/*` | German language modes |
 | `modes/fr/*` | French language modes |
 | `modes/ja/*` | Japanese language modes |
+| `modes/pl/*` | Polish language modes |
 | `modes/pt/*` | Portuguese language modes |
 | `modes/ru/*` | Russian language modes |
 | `CLAUDE.md` | Agent instructions (Claude Code) |

--- a/modes/pl/README.md
+++ b/modes/pl/README.md
@@ -1,0 +1,106 @@
+# career-ops -- Tryby polskie (`modes/pl/`)
+
+Ten folder zawiera polskie tłumaczenia głównych trybów career-ops dla kandydatów celujących w polski rynek pracy (Polska oraz polskojęzyczne zespoły).
+
+## Kiedy używać tych trybów?
+
+Użyj `modes/pl/`, jeśli spełniony jest co najmniej jeden z poniższych warunków:
+
+- Aplikujesz głównie na **ogłoszenia o pracę po polsku** (Pracuj.pl, No Fluff Jobs, Just Join IT, LinkedIn PL, Bulldogjob, strony karierowe firm)
+- Twoje **CV jest po polsku** albo przełączasz się między PL i EN w zależności od ogłoszenia
+- Potrzebujesz odpowiedzi i listów motywacyjnych w **naturalnym, technicznym języku polskim**, a nie tłumaczonym maszynowo
+- Musisz ogarnąć **specyfikę umów na polskim rynku**: umowa o pracę (UoP), B2B, umowa zlecenie, okres próbny, okres wypowiedzenia, prywatna opieka medyczna, karta sportowa, premia, ZUS, PPK
+
+Jeśli większość Twoich ogłoszeń jest po angielsku, zostań przy standardowych trybach w `modes/`. Tryby angielskie działają dla ogłoszeń polskojęzycznych, ale nie znają specyfiki polskiego rynku w szczegółach.
+
+## Jak aktywować?
+
+### Opcja 1 -- Na sesję
+
+Powiedz Claude'owi na początku sesji:
+
+> "Używaj polskich trybów z `modes/pl/`."
+
+Claude będzie wtedy czytał pliki z tego folderu zamiast z `modes/`.
+
+### Opcja 2 -- Na stałe
+
+Dodaj w `config/profile.yml`:
+
+```yaml
+language:
+  primary: pl
+  modes_dir: modes/pl
+```
+
+Przypomnij o tym Claude'owi podczas pierwszej sesji ("Zajrzyj do `profile.yml`, ustawiłem `language.modes_dir`"). Claude automatycznie użyje polskich trybów.
+
+## Które tryby są przetłumaczone?
+
+Ta pierwsza iteracja obejmuje cztery tryby o najwyższym wpływie:
+
+| Plik | Przetłumaczony z | Rola |
+|---------|----------------|------|
+| `_shared.md` | `modes/_shared.md` (EN) | Wspólny kontekst, archetypy, reguły globalne, specyfika polskiego rynku |
+| `oferta.md` | `modes/oferta.md` (ES) | Pełna ocena oferty (Bloki A-F) |
+| `aplikuj.md` | `modes/apply.md` (EN) | Asystent na żywo do wypełniania formularzy aplikacyjnych |
+| `pipeline.md` | `modes/pipeline.md` (ES) | Inbox URL-i / Second Brain dla zebranych ofert |
+
+Pozostałe tryby (`scan`, `batch`, `pdf`, `tracker`, `auto-pipeline`, `deep`, `contacto`, `ofertas`, `project`, `training`) zostają w EN/ES. Ich treść to głównie tooling, ścieżki i komendy -- musi pozostać niezależna od języka.
+
+## Co zostaje po angielsku
+
+Świadomie nieprzetłumaczone, bo to standardowe słownictwo techniczne:
+
+- `cv.md`, `pipeline`, `tracker`, `report`, `score`, `archetype`, `proof point`
+- Nazwy narzędzi (`Playwright`, `WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`)
+- Wartości statusu w trackerze (`Evaluated`, `Applied`, `Interview`, `Offer`, `Rejected`)
+- Fragmenty kodu, ścieżki, komendy
+
+Tryby używają naturalnego, technicznego języka polskiego, takiego, jakim mówi się w zespołach engineeringowych w Warszawie, Krakowie czy Wrocławiu: tekst po polsku, terminy techniczne po angielsku tam, gdzie tak się ich używa. Bez wymuszonego tłumaczenia "Pipeline" na "Potok" ani "Deploy" na "Wdrożenie aplikacyjne".
+
+## Słownik referencyjny
+
+Aby zachować spójny ton, jeśli modyfikujesz lub rozszerzasz tryby:
+
+| Angielski | Polski (w tej codebase) |
+|---------|-------------------------------|
+| Job posting | Oferta pracy / Ogłoszenie |
+| Application | Aplikacja / Kandydatura |
+| Cover letter | List motywacyjny |
+| Resume / CV | CV |
+| Salary | Wynagrodzenie / Pensja |
+| Compensation | Wynagrodzenie / Pakiet |
+| Skills | Umiejętności / Kompetencje |
+| Interview | Rozmowa kwalifikacyjna |
+| Hiring manager | Manager rekrutujący / Hiring manager |
+| Recruiter | Rekruter (lub Recruiter) |
+| AI | AI / SI (Sztuczna Inteligencja) |
+| Requirements | Wymagania |
+| Career history | Doświadczenie zawodowe / Przebieg kariery |
+| Notice period | Okres wypowiedzenia |
+| Probation | Okres próbny |
+| Vacation | Urlop wypoczynkowy |
+| 13th month salary | 13. pensja / Trzynastka |
+| Permanent employment | Umowa o pracę na czas nieokreślony (UoP) |
+| Fixed-term contract | Umowa o pracę na czas określony |
+| Freelance | Freelance / B2B / Samozatrudnienie |
+| Mandate contract | Umowa zlecenie |
+| Specific-task contract | Umowa o dzieło |
+| Profit sharing | Udział w zyskach / Premia |
+| Health insurance | Prywatna opieka medyczna |
+| Sports card | Karta sportowa (Multisport / Medicover Sport) |
+| Social security | ZUS (Zakład Ubezpieczeń Społecznych) |
+| Employee pension scheme | PPK (Pracownicze Plany Kapitałowe) |
+| Net / Gross | Netto / Brutto |
+| Day rate (B2B) | Stawka dzienna |
+
+## Wkład (Contribute)
+
+Aby ulepszyć tłumaczenie lub dodać tryb:
+
+1. Otwórz Issue z propozycją (zobacz `CONTRIBUTING.md`)
+2. Trzymaj się powyższego słownika, aby zachować spójny ton
+3. Tłumacz idiomatycznie -- bez tłumaczenia słowo w słowo
+4. Zachowaj elementy strukturalne (Bloki A-F, tabele, bloki kodu, instrukcje narzędzi) identycznie
+5. Przetestuj na prawdziwej polskiej ofercie (Pracuj.pl, No Fluff Jobs, Just Join IT) przed wysłaniem PR-a

--- a/modes/pl/_shared.md
+++ b/modes/pl/_shared.md
@@ -1,0 +1,204 @@
+# Wspólny kontekst -- career-ops (Polski)
+
+<!-- ============================================================
+     PERSONALIZACJA TEGO PLIKU
+     ============================================================
+     Ten plik zawiera wspólny kontekst dla wszystkich trybów
+     career-ops w wersji polskiej. Zanim użyjesz career-ops, MUSISZ:
+     1. Wypełnić config/profile.yml swoimi danymi osobowymi
+     2. Utworzyć cv.md w katalogu głównym projektu (CV w Markdown)
+     3. (Opcjonalnie) Utworzyć article-digest.md ze swoimi proof points
+     4. Dostosować sekcje oznaczone [PERSONALIZUJ] poniżej
+     ============================================================ -->
+
+## Źródła prawdy (ZAWSZE czytaj przed każdą oceną)
+
+| Plik | Ścieżka | Kiedy |
+|---------|--------|-------|
+| cv.md | `cv.md` (katalog główny projektu) | ZAWSZE |
+| article-digest.md | `article-digest.md` (jeśli istnieje) | ZAWSZE (szczegółowe proof points) |
+| profile.yml | `config/profile.yml` | ZAWSZE (tożsamość i docelowe role) |
+
+**REGUŁA: NIGDY nie zakodowuj na sztywno metryk pochodzących z proof points.** Czytaj je z `cv.md` i `article-digest.md` w momencie oceny.
+**REGUŁA: Dla metryk z artykułów/projektów `article-digest.md` ma priorytet nad `cv.md`** (`cv.md` może zawierać starsze liczby).
+
+---
+
+## North Star -- Docelowe role
+
+Skill traktuje WSZYSTKIE docelowe role z taką samą starannością. Żadna nie jest podstawowa ani drugorzędna -- każda jest sukcesem, jeśli wynagrodzenie i perspektywy rozwoju są na właściwym poziomie:
+
+| Archetyp | Osie tematyczne | Co kupuje firma |
+|-----------|------------------|----------------------------|
+| **AI Platform / LLMOps Engineer** | Evaluation, Observability, Niezawodność, Pipelines | Kogoś, kto wdraża AI na produkcję z metrykami |
+| **Agentic Workflows / Automation** | HITL, Tooling, Orkiestracja, Multi-Agent | Kogoś, kto buduje niezawodne systemy agentowe |
+| **Technical AI Product Manager** | GenAI/Agents, PRD-y, Discovery, Delivery | Kogoś, kto przekłada biznes na produkty AI |
+| **AI Solutions Architect** | Hyperautomation, Enterprise, Integracje | Kogoś, kto projektuje architektury AI end-to-end |
+| **AI Forward Deployed Engineer** | Client-facing, szybkie dostarczanie, Prototypowanie | Kogoś, kto szybko wdraża rozwiązania AI u klienta |
+| **AI Transformation Lead** | Zarządzanie zmianą, Adopcja, Enablement | Kogoś, kto prowadzi transformację AI w organizacjach |
+
+<!-- [PERSONALIZUJ] Dostosuj powyższe archetypy do swoich docelowych ról.
+     Przykład dla backend engineering:
+     - Senior Backend Engineer
+     - Staff Platform Engineer
+     - Engineering Manager
+     itd. -->
+
+### Adaptacyjne framing według archetypu
+
+> **Konkretne metryki: czytaj je z `cv.md` i `article-digest.md` w momencie oceny. NIGDY nie zakodowuj ich na sztywno tutaj.**
+
+| Jeśli rola to... | Podkreśl u kandydata... | Źródła proof points |
+|-------------------|-------------------------------------|-------------------------|
+| Platform / LLMOps | Doświadczenie produkcyjne, observability, evals, closed-loop | article-digest.md + cv.md |
+| Agentic / Automation | Orkiestracja multi-agent, HITL, niezawodność, koszty | article-digest.md + cv.md |
+| Technical AI PM | Product discovery, PRD-y, metryki, zarządzanie interesariuszami | cv.md + article-digest.md |
+| Solutions Architect | Projektowanie systemów, integracje, gotowość enterprise | article-digest.md + cv.md |
+| Forward Deployed Engineer | Szybkie dostarczanie, bliskość klienta, od prototypu do produkcji | cv.md + article-digest.md |
+| AI Transformation Lead | Zarządzanie zmianą, enablement zespołu, adopcja | cv.md + article-digest.md |
+
+<!-- [PERSONALIZUJ] Powiąż swoje konkretne projekty/artykuły z powyższymi archetypami -->
+
+### Narracja przejścia (do użycia we WSZYSTKICH framingach)
+
+<!-- [PERSONALIZUJ] Zastąp własną narracją. Przykłady:
+     - "SaaS zbudowany i sprzedany po 5 latach. Teraz 100% fokus na stosowanej AI w enterprise."
+     - "Engineering lead w spółce Series-B podczas wzrostu x10. W poszukiwaniu kolejnego wyzwania."
+     - "Przejście z konsultingu do produktu. Szukam ról z dużą odpowiedzialnością."
+     Czytane z config/profile.yml -> narrative.exit_story -->
+
+Używaj narracji przejścia z `config/profile.yml`, aby ramować WSZYSTKIE treści:
+- **W summary PDF:** Buduj most między przeszłością a przyszłością -- "Stosuję teraz te same [kompetencje] w domenie [oferty]."
+- **W historiach STAR:** Odwołuj się do proof points z `article-digest.md`.
+- **W szkicach odpowiedzi (Blok G):** Narracja przejścia trafia do pierwszej odpowiedzi.
+- **Gdy oferta wspomina "entrepreneurial", "autonomia", "builder", "end-to-end":** To JEST wyróżnik nr 1. Zwiększ wagę dopasowania.
+
+### Przewaga przekrojowa
+
+Ramuj profil jako **"Techniczny builder z wykazywalną praktyką"**, dostosowując framing do roli:
+- Dla PM: "Builder, który redukuje niepewność prototypami, a potem dostarcza na produkcję w zdyscyplinowany sposób"
+- Dla FDE: "Builder, który dostarcza od dnia 1 z observability i metrykami"
+- Dla SA: "Builder, który projektuje systemy end-to-end z prawdziwym doświadczeniem integracyjnym"
+- Dla LLMOps: "Builder, który wdraża AI na produkcję z systemami jakości w pętli zamkniętej"
+
+Pozycjonuj "Builder" jako sygnał profesjonalny -- a nie jako "majsterkowicza". Prawdziwe proof points czynią to wiarygodnym.
+
+### Portfolio jako proof point (używaj w aplikacjach o wysokiej stawce)
+
+<!-- [PERSONALIZUJ] Jeśli masz demo na żywo, dashboard lub publiczny projekt, skonfiguruj go tutaj.
+     Przykład:
+     dashboard:
+       url: "https://twojadomena.dev/demo"
+       password: "demo-2026"
+       when_to_share: "Role LLMOps, AI Platform, Observability"
+     Czytane z config/profile.yml -> narrative.proof_points i narrative.dashboard -->
+
+Jeśli kandydat ma demo na żywo / dashboard (sprawdź `profile.yml`), zaproponuj dostęp w odpowiednich aplikacjach.
+
+### Wywiad wynagrodzeniowy (Comp Intelligence)
+
+<!-- [PERSONALIZUJ] Zbadaj widełki wynagrodzeń dla swoich docelowych ról i dostosuj wartości -->
+
+**Ogólne wskazówki:**
+- WebSearch dla aktualnych danych rynkowych (Glassdoor, Levels.fyi, No Fluff Jobs, Just Join IT, Raport Płacowy Pracuj.pl, justjoin.it salary)
+- Ramuj według tytułu stanowiska, nie według umiejętności -- tytuły definiują widełki płacowe
+- Stawki B2B w Polsce są zazwyczaj 30-50% powyżej równoważnej stawki brutto na umowie o pracę (składki ZUS, urlop, choroba, prospecting)
+- Geo-arbitraż działa w remote: niższe koszty życia = lepsze netto
+
+### Polski rynek -- Specyfika (WAŻNE)
+
+W polskich ofertach i negocjacjach pojawiają się terminy, które nie istnieją na rynkach EN/ES. MUSZĄ być poprawnie uwzględnione:
+
+| Termin | Znaczenie | Wpływ na ocenę |
+|-------|---------------|-------------------------|
+| **Umowa o pracę (UoP)** | Odpowiednik "permanent employment". Standard z pełną ochroną Kodeksu pracy | Standard oczekiwany. Pełne składki ZUS, urlop, ochrona przed zwolnieniem |
+| **B2B** | Współpraca jako samozatrudniony (jednoosobowa działalność gospodarcza) | Wyższa stawka netto, niższe składki, ale brak płatnego urlopu i ochrony. Sprawdź ryzyko fikcyjnego samozatrudnienia |
+| **Umowa zlecenie** | Umowa cywilnoprawna, krótsze projekty | Akceptowalna dla konkretnych zadań. Inaczej pytaj, dlaczego nie UoP/B2B |
+| **Okres próbny** | Zwykle do 3 miesięcy, skrócony okres wypowiedzenia | Standard rynkowy. Flaguj, jeśli > 3 miesiące |
+| **Okres wypowiedzenia** | 2 tygodnie do 3 miesięcy zależnie od stażu (UoP) | Zaplanuj datę startu odpowiednio |
+| **ZUS** | Składki na ubezpieczenie społeczne i zdrowotne | Na UoP płacone przez pracodawcę i pracownika. Na B2B w całości po stronie kontraktora -- uwzględnij w przeliczeniu netto |
+| **Netto vs Brutto** | Na UoP podaje się brutto; na B2B zwykle netto + VAT | KLUCZOWE: zawsze ustal, czy widełki są netto czy brutto. Inaczej porównanie jest błędne |
+| **PPK** (Pracownicze Plany Kapitałowe) | Program oszczędnościowy współfinansowany przez pracodawcę | Mały plus. Dopłata pracodawcy ~1,5% wynagrodzenia |
+| **Trzynastka / 13. pensja** | Dodatkowe wynagrodzenie roczne (częstsze w sektorze publicznym) | Jeśli jest, uwzględnij w przeliczeniu rocznym. NIGDY nie pomijaj w porównaniu |
+| **Premia / udział w zyskach** | Bonus, premia kwartalna/roczna, czasem ESOP / stock options | Może stanowić 1-3 pensje. Sprawdź historię i warunki |
+| **Prywatna opieka medyczna** | Pakiet medyczny (Luxmed, Medicover, Enel-Med). Częsty benefit | Standard w IT. Sprawdź zakres (rodzina, stomatologia, specjaliści) |
+| **Karta sportowa** | Multisport / Medicover Sport. Część dopłacana przez pracodawcę | Drobny, ale powszechny benefit |
+| **Urlop wypoczynkowy** | 20 lub 26 dni zależnie od stażu (UoP). B2B zwykle bez płatnego urlopu | < 20 dni na UoP = niezgodne z Kodeksem pracy. 26 dni = standard. B2B: wlicz brak urlopu w stawkę |
+| **Praca zdalna / hybrydowa** | Coraz częstszy standard w polskim IT | Sprawdź liczbę dni w biurze i czy "remote-first" |
+| **VAT (na B2B)** | Kontraktor zwykle wystawia fakturę + 23% VAT | Sprawdź, czy stawka jest "netto + VAT", czy "brutto" -- różnica jest istotna |
+
+### Skrypty negocjacyjne
+
+<!-- [PERSONALIZUJ] Dostosuj do swojej sytuacji -->
+
+**Oczekiwania płacowe (ogólny framework):**
+> "Na podstawie aktualnych danych rynkowych dla tego typu stanowiska celuję w widełki [WIDEŁKI z profile.yml]. Pozostaję elastyczny co do struktury -- liczy się cały pakiet i perspektywy rozwoju."
+
+**Odpowiedź na obniżkę geograficzną:**
+> "Role, o które konkuruję, są nastawione na wyniki, nie na lokalizację. Mój track record nie zmienia się wraz z kodem pocztowym."
+
+**Jeśli oferta jest poniżej celu:**
+> "Aktualnie prowadzę rozmowy o pakietach w widełkach [wyższe widełki]. [Firma] przyciąga mnie [powodem]. Czy da się osiągnąć [cel]?"
+
+**Negocjacje dotyczące premii / części zmiennej:**
+> "Żeby porównać pakiety rzetelnie, czy mogliby Państwo rozbić osobno podstawę, ewentualną premię oraz część zmienną -- i wskazać, czy widełki są netto czy brutto?"
+
+### Polityka lokalizacji (Location Policy)
+
+<!-- [PERSONALIZUJ] Dostosuj do swojej sytuacji. Czytane z config/profile.yml -> location -->
+
+**W formularzach:**
+- Pytania binarne "Czy może Pan/Pani być na miejscu?": odpowiadaj zgodnie z rzeczywistą dostępnością w `profile.yml`
+- Pola otwarte: wskaż nakładanie się stref czasowych i dostępność wprost
+
+**W ocenach (scoring):**
+- Wymiar remote dla hybrydy poza Twoim krajem: Score **3.0** (nie 1.0)
+- Score 1.0 tylko, jeśli oferta wprost mówi "obecność obowiązkowa 4-5 dni/tydzień, bez wyjątków"
+
+### Priorytet time-to-offer
+- Działające demo + metryki > perfekcja
+- Aplikować szybko > uczyć się więcej
+- Podejście 80/20, wszystko w timeboxie
+
+---
+
+## Reguły globalne
+
+### NIGDY
+
+1. Nie wymyślaj doświadczenia ani metryk
+2. Nie modyfikuj `cv.md` ani plików portfolio
+3. Nie wysyłaj aplikacji w imieniu kandydata
+4. Nie udostępniaj numeru telefonu w generowanych wiadomościach
+5. Nie rekomenduj wynagrodzenia poniżej rynku
+6. Nie generuj PDF bez wcześniejszego przeczytania oferty
+7. Nie używaj korporacyjnego żargonu ani pustych formułek
+8. Nie ignoruj trackera (każda oceniona oferta jest zapisywana)
+
+### ZAWSZE
+
+0. **List motywacyjny:** Jeśli formularz na to pozwala, ZAWSZE dołącz jeden. PDF w tym samym projekcie wizualnym co CV. Cytaty z oferty zmapowane na proof points. Maks. 1 strona.
+1. Czytaj `cv.md` i `article-digest.md` (jeśli istnieje) przed oceną oferty
+1b. **Pierwsza ocena każdej sesji:** Uruchom `node cv-sync-check.mjs` przez Bash. W razie ostrzeżeń poinformuj kandydata
+2. Wykryj archetyp roli i dostosuj framing
+3. Cytuj dokładne wiersze z CV podczas matchingu
+4. Używaj WebSearch do danych o wynagrodzeniach i firmie
+5. Zapisuj w trackerze po każdej ocenie
+6. Generuj treść w języku oferty (polski, jeśli oferta jest po polsku; angielski w przeciwnym razie)
+7. Bądź bezpośredni i konkretny -- bez gadania
+8. Naturalny, techniczny język polski dla generowanych tekstów. Krótkie zdania, czasowniki czynności, unikaj strony biernej. Nie tłumacz na siłę terminów technicznych (stack, pipeline, deployment, embedding)
+8b. **URL-e case studies w Professional Summary PDF-a:** Jeśli PDF wspomina case studies lub dema, URL-e MUSZĄ pojawić się w pierwszym akapicie (Professional Summary). Rekruterzy często czytają tylko summary. Wszystkie URL-e w HTML z `white-space: nowrap`
+9. **Wpisy do trackera w TSV** -- NIGDY nie edytuj applications.md bezpośrednio dla nowych dodań. Zapisz TSV do `batch/tracker-additions/`, `merge-tracker.mjs` zarządza scalaniem
+10. **`**URL:**` w każdym nagłówku reportu** -- między Score a PDF
+
+### Narzędzia
+
+| Narzędzie | Użycie |
+|-------|---------|
+| WebSearch | Wyszukiwanie wynagrodzeń, trendów, kultury firmy, kontaktów LinkedIn, fallback dla ofert |
+| WebFetch | Fallback do ekstrakcji ofert ze stron statycznych |
+| Playwright | Sprawdzenie, czy oferty są aktywne (browser_navigate + browser_snapshot), ekstrakcja ofert ze SPA. **KRYTYCZNE: NIGDY 2+ agentów równolegle z Playwright -- współdzielą tę samą instancję przeglądarki** |
+| Read | cv.md, article-digest.md, cv-template.html |
+| Write | Tymczasowy HTML dla PDF, applications.md, reporty .md |
+| Edit | Aktualizacja trackera |
+| Bash | `node generate-pdf.mjs` |

--- a/modes/pl/aplikuj.md
+++ b/modes/pl/aplikuj.md
@@ -1,0 +1,114 @@
+# Tryb: aplikuj -- Asystent na żywo do formularzy aplikacyjnych
+
+Tryb interaktywny na moment, gdy kandydat wypełnia formularz aplikacyjny w Chrome. Czyta to, co jest na ekranie, ładuje kontekst poprzedniej oceny oferty i generuje spersonalizowane odpowiedzi na każde pytanie formularza.
+
+## Wymagania wstępne
+
+- **Idealnie z widocznym Playwright**: W trybie widocznym kandydat widzi przeglądarkę, a Claude może wchodzić w interakcję ze stroną.
+- **Bez Playwright**: kandydat udostępnia zrzut ekranu lub wkleja pytania ręcznie.
+
+## Workflow
+
+```
+1. WYKRYJ       -> Przeczytaj aktywną kartę Chrome (zrzut/URL/tytuł)
+2. ZIDENTYFIKUJ -> Wyciągnij firmę + rolę ze strony
+3. WYSZUKAJ     -> Dopasuj do istniejących reportów w reports/
+4. ZAŁADUJ      -> Przeczytaj pełny report + Blok G (jeśli istnieje)
+5. PORÓWNAJ     -> Czy rola na ekranie odpowiada ocenionej? Jeśli zmiana -> ostrzeż
+6. PRZEANALIZUJ -> Zidentyfikuj WSZYSTKIE widoczne pytania formularza
+7. WYGENERUJ    -> Dla każdego pytania wygeneruj spersonalizowaną odpowiedź
+8. ZAPREZENTUJ  -> Wyświetl odpowiedzi sformatowane do skopiowania
+```
+
+## Krok 1 -- Wykryj ofertę
+
+**Z Playwright:** Snapshot aktywnej strony. Przeczytaj tytuł, URL i widoczną treść.
+
+**Bez Playwright:** Poproś kandydata, aby:
+- Udostępnił zrzut ekranu formularza (narzędzie Read czyta obrazy)
+- Lub wkleił pytania formularza jako tekst
+- Lub podał firmę + rolę, abyśmy mogli wyszukać kontekst
+
+## Krok 2 -- Zidentyfikuj i załaduj kontekst
+
+1. Wyciągnij nazwę firmy i tytuł stanowiska ze strony
+2. Wyszukaj w `reports/` po nazwie firmy (Grep case-insensitive)
+3. Jeśli dopasowanie -> załaduj pełny report
+4. Jeśli Blok G obecny -> załaduj poprzednie szkice odpowiedzi jako bazę
+5. Jeśli BRAK dopasowania -> ostrzeż kandydata i zaproponuj szybki auto-pipeline
+
+## Krok 3 -- Wykryj zmiany roli
+
+Jeśli rola na ekranie różni się od ocenionej:
+- **Ostrzeż kandydata**: "Rola zmieniła się z [X] na [Y]. Czy chcesz, żebym ocenił ją ponownie, czy dostosował odpowiedzi do nowego tytułu?"
+- **Jeśli dostosować**: Dostosuj odpowiedzi do nowej roli bez ponownej oceny
+- **Jeśli ocenić ponownie**: Uruchom pełną ocenę A-F, zaktualizuj report, wygeneruj ponownie Blok G
+- **Zaktualizuj tracker**: Zmień tytuł roli w applications.md, jeśli to konieczne
+
+## Krok 4 -- Przeanalizuj pytania formularza
+
+Zidentyfikuj WSZYSTKIE widoczne pytania:
+- Pola tekstu otwartego (list motywacyjny, "dlaczego to stanowisko", motywacja itp.)
+- Listy rozwijane (skąd dowiedziałeś się o firmie, pozwolenie na pracę itp.)
+- Tak/Nie (mobilność, wiza, dostępność itp.)
+- Pola wynagrodzenia (widełki, oczekiwania płacowe -- ustal, czy netto czy brutto)
+- Pola upload (CV, list motywacyjny PDF, referencje)
+
+Sklasyfikuj każde pytanie:
+- **Już odpowiedziane w Bloku G** -> wykorzystaj istniejącą odpowiedź
+- **Nowe pytanie** -> wygeneruj odpowiedź z reportu + `cv.md`
+
+## Krok 5 -- Wygeneruj odpowiedzi
+
+Dla każdego pytania zbuduj odpowiedź według tego schematu:
+
+1. **Kontekst z reportu**: Użyj proof points z bloku B, historii STAR z bloku F
+2. **Poprzedni Blok G**: Jeśli szkic istnieje, weź go jako bazę i dopracuj
+3. **Ton "To ja wybieram Was"**: ten sam framework co w auto-pipeline -- pewny siebie, nie błagalny
+4. **Konkretność**: zacytuj coś konkretnego z oferty widocznej na ekranie
+5. **career-ops proof point**: dołącz w "Informacje dodatkowe", jeśli takie pole istnieje
+
+**Pola specyficzne dla typowych polskich formularzy:**
+- **Oczekiwania płacowe** -> Widełki z `profile.yml`, w PLN, z zaznaczeniem, czy netto czy brutto (oraz UoP/B2B) i dopiskiem "do negocjacji w zależności od całego pakietu"
+- **Data dostępności** -> Realistyczna data uwzględniająca okres wypowiedzenia (często 2 tygodnie do 3 miesięcy)
+- **Pozwolenie na pracę / Obywatelstwo** -> Uczciwie i zwięźle; dla obywateli UE: "Brak wymogu zezwolenia na pracę (obywatel UE)"
+- **Języki** -> Poziomy według ESOKJ/CEFR (A1-C2)
+- **Mobilność** -> Sprecyzuj akceptowalny obszar geograficzny i częstotliwość wyjazdów
+
+**Format wyjścia:**
+
+```
+## Odpowiedzi dla [Firma] -- [Rola]
+
+Baza: Report #NNN | Score: X.X/5 | Archetyp: [typ]
+
+---
+
+### 1. [Dokładne pytanie z formularza]
+> [Odpowiedź gotowa do skopiowania]
+
+### 2. [Następne pytanie]
+> [Odpowiedź]
+
+...
+
+---
+
+Notatki:
+- [Obserwacje dotyczące roli, zmiany itp.]
+- [Sugestie personalizacji, które kandydat powinien zweryfikować]
+```
+
+## Krok 6 -- Po aplikacji (opcjonalnie)
+
+Jeśli kandydat potwierdzi, że aplikacja została wysłana:
+1. Zaktualizuj status w `applications.md` z "Evaluated" na "Applied"
+2. Zaktualizuj Blok G reportu finalnymi odpowiedziami
+3. Zasugeruj następny krok: `/career-ops contacto` dla LinkedIn outreach do hiring managera
+
+## Obsługa przewijania
+
+Jeśli formularz ma więcej pytań niż widać:
+- Poproś kandydata, aby przewinął i udostępnił kolejny zrzut ekranu
+- Lub wkleił pozostałe pytania
+- Przetwarzaj iteracyjnie, aż pokryjesz cały formularz

--- a/modes/pl/oferta.md
+++ b/modes/pl/oferta.md
@@ -1,0 +1,166 @@
+# Tryb: oferta -- Pełna ocena A-F
+
+Gdy kandydat wkleja ofertę (tekst lub URL), ZAWSZE dostarcz wszystkie 6 bloków.
+
+## Krok 0 -- Wykrycie archetypu
+
+Sklasyfikuj ofertę do jednego z 6 archetypów (zobacz `_shared.md`). Jeśli hybrydowa, wskaż 2 najbliższe. To determinuje:
+- Które proof points priorytetyzować w bloku B
+- Jak przepisać summary w bloku E
+- Które historie STAR przygotować w bloku F
+
+## Blok A -- Podsumowanie roli
+
+Tabela z:
+- Wykrytym archetypem
+- Domeną (Platform / Agentic / LLMOps / ML / Enterprise)
+- Funkcją (Build / Doradztwo / Zarządzanie / Deploy)
+- Poziomem seniority
+- Remote (Full remote / Hybryda / Na miejscu)
+- Wielkością zespołu (jeśli podana)
+- TL;DR w 1 zdaniu
+
+## Blok B -- Dopasowanie do CV
+
+Przeczytaj `cv.md`. Stwórz tabelę, w której każde wymaganie z oferty jest zmapowane na dokładne wiersze z CV.
+
+**Dostosowane do archetypu:**
+- FDE -> priorytetyzuj proof points szybkiego dostarczania i bliskości klienta
+- SA -> priorytetyzuj projektowanie systemów i integracje
+- PM -> priorytetyzuj product discovery i metryki
+- LLMOps -> priorytetyzuj evals, observability, pipelines
+- Agentic -> priorytetyzuj multi-agent, HITL, orkiestrację
+- Transformation -> priorytetyzuj zarządzanie zmianą, adopcję, skalowanie
+
+Sekcja **Luki (Gaps)** ze strategią mitygacji dla każdej. Dla każdej luki:
+1. Czy to twardy bloker czy nice-to-have?
+2. Czy kandydat może wykazać sąsiednie doświadczenie?
+3. Czy istnieje projekt portfolio, który pokrywa tę lukę?
+4. Konkretny plan mitygacji (zdanie do listu motywacyjnego, szybki mini-projekt itp.)
+
+## Blok C -- Poziom i strategia
+
+1. **Wykryty poziom** w ofercie vs **naturalny poziom kandydata dla tego archetypu**
+2. **Plan "sprzedać senior bez kłamstwa"**: konkretne sformułowania dostosowane do archetypu, konkretne osiągnięcia do podkreślenia, jak pozycjonować doświadczenie założycielskie jako atut
+3. **Plan "jeśli dostanę downlevel"**: zaakceptować, jeśli wynagrodzenie jest sprawiedliwe, wynegocjować przegląd po 6 miesiącach, jasne kryteria awansu
+
+## Blok D -- Wynagrodzenie i popyt
+
+Użyj WebSearch dla:
+- Aktualnych wynagrodzeń dla roli (Glassdoor, Levels.fyi, No Fluff Jobs, Just Join IT, Raport Płacowy Pracuj.pl)
+- Reputacji wynagrodzeniowej firmy (Glassdoor, GoWork)
+- Trendu popytu na rolę na polskim rynku
+
+Tabela z danymi i cytowanymi źródłami. Jeśli brak danych, powiedz to jasno -- nic nie wymyślaj.
+
+**Polski rynek -- Obowiązkowe weryfikacje:**
+- Czy widełki są netto czy brutto? Ustal to zawsze -- to fundament porównania.
+- Umowa o pracę (UoP) czy B2B? Jeśli B2B: stawka dzienna/miesięczna, ryzyko fikcyjnego samozatrudnienia, kwestia VAT.
+- Część zmienna (premia, prowizja, ESOP / stock options)?
+- Trzynastka / premia roczna wspomniana? Uwzględnij w przeliczeniu rocznym.
+- ZUS i PPK -- po czyjej stronie składki (zwłaszcza przy B2B)?
+- Benefity (prywatna opieka medyczna, karta sportowa) wspomniane? Wlicz w wartość pakietu.
+
+## Blok E -- Plan personalizacji
+
+| # | Sekcja | Stan obecny | Proponowana zmiana | Uzasadnienie |
+|---|---------|-------------|--------------------|----- ---------|
+| 1 | Summary | ... | ... | ... |
+| ... | ... | ... | ... | ... |
+
+Top 5 zmian w CV + Top 5 zmian na LinkedIn, aby zmaksymalizować dopasowanie.
+
+## Blok F -- Plan rozmów kwalifikacyjnych
+
+6-10 historii STAR+R zmapowanych na wymagania oferty (STAR + **Reflection**):
+
+| # | Wymaganie z oferty | Historia STAR+R | S | T | A | R | Reflection |
+|---|---------------------|--------------|---|---|---|---|------------|
+
+Kolumna **Reflection** ujmuje, czego się nauczono lub co zrobiono by inaczej. To sygnalizuje seniority -- juniorzy opisują, co się wydarzyło, seniorzy wyciągają z tego wnioski.
+
+**Story Bank:** Jeśli `interview-prep/story-bank.md` istnieje, sprawdź, czy te historie już tam są. Jeśli nie, dodaj nowe. Z czasem buduje to wielokrotnego użytku bank 5-10 historii master, które można dopasować do każdego pytania na rozmowie.
+
+**Wyselekcjonowane i sformowane według archetypu:**
+- FDE -> podkreśl szybkość dostarczania i bliskość klienta
+- SA -> podkreśl decyzje architektoniczne
+- PM -> podkreśl discovery i kompromisy
+- LLMOps -> podkreśl metryki, evals, hardening na produkcji
+- Agentic -> podkreśl orkiestrację, obsługę błędów, HITL
+- Transformation -> podkreśl adopcję i zmianę organizacyjną
+
+Dołącz także:
+- 1 rekomendowane case study (który projekt zaprezentować i jak)
+- Pytania red-flag i jak na nie odpowiadać (np. "Dlaczego sprzedał Pan swoją firmę?", "Czy miał Pan zespół pod sobą?", "Dlaczego zmiana po tak krótkim czasie?")
+
+---
+
+## Po ocenie
+
+**ZAWSZE** wykonaj po blokach A-F:
+
+### 1. Zapisz report .md
+
+Zapisz pełną ocenę w `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+
+- `{###}` = następny kolejny numer (3 cyfry, dopełnione zerami). Aby przydzielić go atomowo i uniknąć race conditions, musisz uruchomić `node reserve-report-num.mjs`, by zarezerwować numer (stdout zwraca `{###}`), zapisać report, a następnie uruchomić `node reserve-report-num.mjs --release {###}`, by zwolnić sentinel.
+- `{company-slug}` = nazwa firmy małymi literami, bez spacji (użyj myślników)
+- `{YYYY-MM-DD}` = dzisiejsza data
+
+**Format reportu:**
+
+```markdown
+# Ocena: {Firma} -- {Rola}
+
+**Data:** {YYYY-MM-DD}
+**Archetyp:** {wykryty}
+**Score:** {X/5}
+**URL:** {URL oferty}
+**PDF:** {ścieżka lub w toku}
+
+---
+
+## A) Podsumowanie roli
+(pełna zawartość bloku A)
+
+## B) Dopasowanie do CV
+(pełna zawartość bloku B)
+
+## C) Poziom i strategia
+(pełna zawartość bloku C)
+
+## D) Wynagrodzenie i popyt
+(pełna zawartość bloku D)
+
+## E) Plan personalizacji
+(pełna zawartość bloku E)
+
+## F) Plan rozmów kwalifikacyjnych
+(pełna zawartość bloku F)
+
+## G) Szkice odpowiedzi do aplikacji
+(tylko jeśli score >= 4.5 -- szkice odpowiedzi do formularza aplikacyjnego)
+
+---
+
+## Wyekstrahowane słowa kluczowe
+(lista 15-20 słów kluczowych z oferty do optymalizacji ATS)
+```
+
+### 2. Zapisz w trackerze
+
+**ZAWSZE** zapisz w `data/applications.md`:
+- Następny kolejny numer
+- Dzisiejsza data
+- Firma
+- Rola
+- Score: średnia dopasowania (1-5)
+- Status: `Evaluated`
+- PDF: nie (lub tak, jeśli auto-pipeline wygenerował PDF)
+- Report: względny link do pliku reportu (np. `[001](reports/001-company-2026-01-01.md)`)
+
+**Format trackera:**
+
+```markdown
+| # | Data | Firma | Rola | Score | Status | PDF | Report |
+```

--- a/modes/pl/pipeline.md
+++ b/modes/pl/pipeline.md
@@ -1,0 +1,63 @@
+# Tryb: pipeline -- Inbox URL-i (Second Brain)
+
+Przetwarza URL-e ofert nagromadzone w `data/pipeline.md`. Kandydat dodaje URL-e, kiedy chce, a potem uruchamia `/career-ops pipeline`, by przetworzyć je wszystkie naraz.
+
+## Workflow
+
+1. **Przeczytaj** `data/pipeline.md` -> znajdź itemy `- [ ]` w sekcji "Oczekujące" / "Pending" / "Pendientes"
+2. **Dla każdego oczekującego URL-a**:
+   a. Zarezerwuj następny kolejny `REPORT_NUM` atomowo, uruchamiając `node reserve-report-num.mjs` (i zwolnij sentinel, uruchamiając `node reserve-report-num.mjs --release <num>`, gdy report zostanie zapisany)
+   b. **Wyciągnij ofertę** za pomocą Playwright (`browser_navigate` + `browser_snapshot`) -> WebFetch -> WebSearch
+   c. Jeśli URL jest niedostępny -> oznacz jako `- [!]` z notatką i kontynuuj
+   d. **Wykonaj pełny auto-pipeline**: Ocena A-F -> Report .md -> PDF (jeśli score >= 3.0) -> Tracker
+   e. **Przenieś z "Oczekujące" do "Przetworzone"**: `- [x] #NNN | URL | Firma | Rola | Score/5 | PDF tak/nie`
+3. **Jeśli 3+ oczekujących URL-i**, uruchom agentów równolegle (Agent tool z `run_in_background`), aby zmaksymalizować szybkość.
+4. **Na końcu** wyświetl tabelę podsumowującą:
+
+```
+| # | Firma | Rola | Score | PDF | Rekomendowana akcja |
+```
+
+## Format pipeline.md
+
+```markdown
+## Oczekujące
+- [ ] https://jobs.example.com/posting/123
+- [ ] https://boards.greenhouse.io/company/jobs/456 | Company Sp. z o.o. | Senior PM
+- [!] https://private.url/job -- Błąd: wymagane logowanie
+
+## Przetworzone
+- [x] #143 | https://jobs.example.com/posting/789 | Acme Sp. z o.o. | AI PM | 4.2/5 | PDF tak
+- [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF nie
+```
+
+> Uwaga: Nagłówki sekcji mogą być w EN ("Pending"/"Processed"), ES ("Pendientes"/"Procesadas"), DE ("Offen"/"Verarbeitet") lub PL ("Oczekujące"/"Przetworzone"). Bądź elastyczny przy czytaniu, wierny istniejącemu stylowi przy pisaniu.
+
+## Inteligentne wykrywanie oferty z URL-a
+
+1. **Playwright (preferowane):** `browser_navigate` + `browser_snapshot`. Działa ze wszystkimi SPA.
+2. **WebFetch (fallback):** Dla stron statycznych lub gdy Playwright jest niedostępny.
+3. **WebSearch (ostateczność):** Szukaj na portalach drugorzędnych, które indeksują ofertę.
+
+**Przypadki szczególne:**
+- **LinkedIn**: Może wymagać logowania -> oznacz `[!]` i poproś kandydata o wklejenie tekstu
+- **PDF**: Jeśli URL wskazuje na PDF, przeczytaj go bezpośrednio narzędziem Read
+- **Prefiks `local:`**: Przeczytaj plik lokalny. Przykład: `local:jds/linkedin-pm-ai.md` -> przeczytaj `jds/linkedin-pm-ai.md`
+- **Pracuj.pl / No Fluff Jobs / Just Join IT**: Popularne polskie portale. Playwright dobrze radzi sobie z bannerami cookie
+- **Bulldogjob / LinkedIn PL**: Oferty ustrukturyzowane, dobrze czytelne maszynowo. WebFetch zwykle wystarcza
+
+## Automatyczna numeracja
+
+1. Uruchom `node reserve-report-num.mjs`, aby zarezerwować następny kolejny numer atomowo (stdout zwraca `{###}`).
+2. Zapisz report z tym numerem.
+3. Zwolnij sentinel, uruchamiając `node reserve-report-num.mjs --release {###}`, gdy report zostanie zapisany.
+
+## Synchronizacja źródeł
+
+Przed przetworzeniem URL-a sprawdź synchronizację:
+
+```bash
+node cv-sync-check.mjs
+```
+
+W razie desynchronizacji ostrzeż kandydata przed kontynuowaniem.

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -61,6 +61,7 @@ const SYSTEM_PATHS = [
   'modes/de/',
   'modes/fr/',
   'modes/ja/',
+  'modes/pl/',
   'modes/pt/',
   'modes/ru/',
   'modes/tr/',


### PR DESCRIPTION
## Summary

Adds the Polish (`pl`) locale modes under `modes/pl/`, mirroring `modes/fr/` with faithful Polish translations and the scoring blocks kept intact — per @santifer's guidance on #993. The Polish README landed earlier in #837; this is the `modes/` side.

Fixes #993

## What's included

Five files mirroring `modes/fr/`:
- `modes/pl/README.md`, `modes/pl/_shared.md`, `modes/pl/pipeline.md`
- `modes/pl/oferta.md` (offer ← `offre.md`)
- `modes/pl/aplikuj.md` (apply ← `postuler.md`)

File names follow the per-locale convention (de = `angebot`/`bewerben`, pt = `oferta`/`aplicar`) → Polish `oferta`/`aplikuj`.

## Localization approach

- **Scoring blocks unchanged** — every threshold/weight (`Score 3.0`/`1.0`, `score >= 4.5`, `{X/5}`, `80/20`, …) is preserved verbatim; only the labels are translated.
- **Market terms localized to PL**, the same way the de/pt locales adapt theirs: FR contract concepts (CDI/CDD/SYNTEC/RTT/CSE/Portage/13e mois) → Polish equivalents (UoP/B2B/umowa zlecenie/umowa o dzieło/ZUS/PPK/Netto-Brutto/VAT/fikcyjne samozatrudnienie); statutory values adjusted to Polish reality (e.g. urlop 20/26 dni, okres próbny 3 miesiące).
- Technical terms (pipeline, observability, evals, HITL) kept in English per the README's own rule.

## Validation

- `node test-all.mjs --quick` — 383 passed, 0 failed; these files add no new warnings.
- Structure mirrors `modes/fr/` exactly (heading counts 9 / 16 / 8 / 20 / 13).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Polish language support with a dedicated usage guide for career management workflows.
  * Introduced shared Polish workflow guidance, including terminology, narrative rules, and tool usage policies.
  * Added a complete Polish “Apply” workflow for filling job application forms in Chrome.
  * Added a Polish “Offer evaluation” workflow using an A–F framework with structured report outputs.
  * Added a Polish batch pipeline to process offer URLs, generate reports/PDFs when applicable, and track results.
  * Updated the system-owned data contract mapping to include Polish modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->