### PR TITLE
feat(modes): add Polish market modes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,6 +41,7 @@
           - modes/de/**
           - modes/fr/**
           - modes/ja/**
+          - modes/pl/**
           - modes/ru/**
 
 "📊 dashboard":

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 - **Arabic (Middle East / Arab market):** `modes/ar/` — native Arabic translations with Arab region-specific vocabulary (مكافأة نهاية الخدمة, التأمينات الاجتماعية, راتب إجمالي/صافي, فترة التجربة, فترة الإخطار, البدلات, etc.). Includes `_shared.md`, `fursah.md` (evaluation), `takdeem.md` (apply), `pipeline.md`.
 - **Japanese (Japan market):** `modes/ja/` — native Japanese translations with Japan-specific vocabulary (正社員, 業務委託, 賞与, 退職金, みなし残業, 年俸制, 36協定, 通勤手当, 住宅手当, etc.). Includes `_shared.md`, `kyujin.md` (evaluation), `oubo.md` (apply), `pipeline.md`.
 - **Turkish (Turkey market):** `modes/tr/` — native Turkish translations with Turkey-specific vocabulary (SGK, kıdem tazminatı, ihbar süresi, brüt/net maaş, AGİ, BES, yemek kartı, yol yardımı, TÜFE zammı, etc.). Includes `_shared.md`, `is-ilani.md` (evaluation), `basvuru.md` (apply), `pipeline.md`.
+- **Polish (Poland market):** `modes/pl/` — native Polish translations with Poland-specific vocabulary (UoP, B2B, netto/brutto, VAT, ZUS, PIT, okres wypowiedzenia, L4, Multisport, LuxMed, etc.). Includes `_shared.md`, `oferta.md` (evaluation), `aplikuj.md` (apply), `pipeline.md`.
 
 **When to use German modes:** If the user is targeting German-language job postings, lives in DACH, or asks for German output. Either:
 1. User says "use German modes" → read from `modes/de/` instead of `modes/`
@@ -200,7 +201,12 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 2. User sets `language.modes_dir: modes/tr` in `config/profile.yml` → always use Turkish modes
 3. You detect a Turkish JD → suggest switching to Turkish modes
 
-**When NOT to:** If the user applies to English-language roles, even at French, German, Arabic, Japanese, or Turkish companies, use the default English modes — *unless* the user has explicitly requested another mode in this conversation, or `language.modes_dir` is set in `config/profile.yml` (the explicit user preference always wins over JD-language detection).
+**When to use Polish modes:** If the user is targeting Polish-language job postings, lives in Poland, is comparing UoP/B2B offers, or asks for Polish output. Either:
+1. User says "use Polish modes" → read from `modes/pl/` instead of `modes/`
+2. User sets `language.modes_dir: modes/pl` in `config/profile.yml` → always use Polish modes
+3. You detect a Polish-market JD → suggest switching to Polish modes
+
+**When NOT to:** If the user applies to English-language roles, even at French, German, Arabic, Japanese, Turkish, or Polish companies, use the default English modes — *unless* the user has explicitly requested another mode in this conversation, or `language.modes_dir` is set in `config/profile.yml` (the explicit user preference always wins over JD-language detection).
 
 ### Skill Modes
 

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -51,6 +51,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/de/*` | German language modes |
 | `modes/fr/*` | French language modes |
 | `modes/ja/*` | Japanese language modes |
+| `modes/pl/*` | Polish language modes |
 | `modes/pt/*` | Portuguese language modes |
 | `modes/ru/*` | Russian language modes |
 | `CLAUDE.md` | Agent instructions (Claude Code) |

--- a/modes/pl/README.md
+++ b/modes/pl/README.md
@@ -1,0 +1,99 @@
+# career-ops -- Polskie tryby (`modes/pl/`)
+
+Ten folder zawiera polskie wersje najważniejszych trybów career-ops dla osób, które aplikują na polskie oferty IT albo chcą oceniać oferty przez pryzmat polskiego rynku pracy.
+
+## Kiedy używać?
+
+Użyj `modes/pl/`, jeśli przynajmniej jeden warunek jest prawdziwy:
+
+- aplikujesz na **polskie oferty pracy** lub role w firmach zatrudniających w Polsce,
+- chcesz, żeby raporty i odpowiedzi do formularzy były pisane naturalnym polskim językiem technicznym,
+- porównujesz **UoP, B2B, kontrakt, netto/brutto, VAT, ZUS, PIT, urlop i okres wypowiedzenia**,
+- chcesz dobrze oceniać pracę zdalną, hybrydową i oferty "Poland remote".
+
+Jeśli oferta jest po angielsku i dotyczy firmy międzynarodowej, nadal możesz użyć standardowych `modes/`. Jeśli jednak oferta dotyczy polskiego rynku, polskie tryby lepiej interpretują lokalne warunki.
+
+## Jak włączyć?
+
+### Opcja 1 -- na daną sesję
+
+Na początku sesji powiedz agentowi:
+
+> "Używaj polskich trybów z `modes/pl/`."
+
+albo:
+
+> "Oceniaj polskie oferty przez `modes/pl/_shared.md` i `modes/pl/oferta.md`."
+
+### Opcja 2 -- na stałe w profilu
+
+Dodaj do `config/profile.yml`:
+
+```yaml
+language:
+  primary: pl
+  modes_dir: modes/pl
+```
+
+To jest konwencja career-ops, nie twardy mechanizm w kodzie. Agent powinien najpierw przeczytać `config/profile.yml`, zobaczyć `language.modes_dir`, a potem dla polskich ofert czytać pliki z tego folderu. Brakujące tryby nadal korzystają z głównych plików w `modes/`.
+
+## Przetłumaczone tryby
+
+| Plik | Źródło | Cel |
+|------|--------|-----|
+| `_shared.md` | `modes/_shared.md` | Wspólny kontekst, punktacja, zasady, polski rynek pracy |
+| `oferta.md` | `modes/oferta.md` | Pełna ocena pojedynczej oferty, bloki A-G |
+| `aplikuj.md` | `modes/apply.md` | Asystent do wypełniania formularzy aplikacyjnych |
+| `pipeline.md` | `modes/pipeline.md` | Przetwarzanie URL-i z `data/pipeline.md` |
+
+Pozostałe tryby (`scan`, `batch`, `pdf`, `tracker`, `auto-pipeline`, `deep`, `contacto`, `ofertas`, `project`, `training`, `patterns`, `followup`, `update`) zostają w wersji bazowej. Zawierają głównie komendy, ścieżki, formaty danych i instrukcje narzędziowe, więc nie wymagają pełnej lokalizacji na start.
+
+## Co zostaje po angielsku?
+
+Celowo nie tłumaczymy:
+
+- nazw plikow i folderow: `cv.md`, `config/profile.yml`, `modes/_profile.md`, `reports/`, `output/`, `data/pipeline.md`,
+- nazw narzędzi: `Playwright`, `WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Shell`,
+- statusów w trackerze: `Evaluated`, `Applied`, `Responded`, `Interview`, `Offer`, `Rejected`, `Discarded`, `SKIP`,
+- standardowych terminów technicznych, kiedy polski odpowiednik brzmiałby sztucznie: `pipeline`, `tracker`, `report`, `score`, `archetype`, `proof point`, `deploy`, `backend`, `frontend`.
+
+Tryby używają polskiego technicznego stylu tak, jak mówi się w zespołach IT w Warszawie, Krakowie, Wrocławiu, Gdańsku czy zdalnych zespołach międzynarodowych: polski tekst, angielskie terminy tam, gdzie są standardem.
+
+## Słownik
+
+| English | Polski w tej codebase |
+|---------|-----------------------|
+| Job posting | Oferta pracy / ogłoszenie |
+| Application | Aplikacja / zgłoszenie / proces rekrutacyjny |
+| Cover letter | List motywacyjny |
+| Resume / CV | CV |
+| Salary | Wynagrodzenie |
+| Compensation | Pakiet / całkowite wynagrodzenie |
+| Salary range | Widełki wynagrodzenia |
+| Gross / net | Brutto / netto |
+| Employment contract | Umowa o pracę / UoP |
+| B2B contract | Kontrakt B2B |
+| Mandate contract | Umowa zlecenie |
+| Specific-task contract | Umowa o dzieło |
+| Notice period | Okres wypowiedzenia |
+| Probation | Okres próbny |
+| Annual leave | Urlop wypoczynkowy |
+| Sick leave | Zwolnienie chorobowe / L4 |
+| Social security | ZUS |
+| Income tax | PIT |
+| VAT invoice | Faktura VAT |
+| Remote / hybrid / onsite | Zdalnie / hybrydowo / stacjonarnie |
+| Private healthcare | Prywatna opieka medyczna |
+| Gym card | Karta sportowa / Multisport |
+| Holiday subsidy | Wczasy pod gruszą |
+| Training budget | Budżet szkoleniowy |
+| Recruiter | Rekruter / rekruterka |
+| Hiring manager | Hiring manager / manager rekrutujący |
+| Interview | Rozmowa rekrutacyjna |
+
+## Wskazówki dla rozbudowy
+
+1. Tłumacz sens, nie słowo w słowo.
+2. Zachowuj strukturę bloków A-G, tabele, formaty TSV i ścieżki plików.
+3. Nie dodawaj danych osobowych do `modes/pl/*`; personalizacja należy do `modes/_profile.md` i `config/profile.yml`.
+4. Testuj tryb na prawdziwych polskich ofertach przed PR-em.

--- a/modes/pl/_shared.md
+++ b/modes/pl/_shared.md
@@ -162,8 +162,8 @@ Zawsze korzystaj z `config/profile.yml` dla targetów kandydata. W polskich ofer
 1. Przeczytaj `cv.md`, `config/profile.yml` i `modes/_profile.md` przed oceną.
 2. Jeśli istnieje `article-digest.md`, przeczytaj je dla proof points.
 3. W pierwszej ocenie sesji uruchom `node cv-sync-check.mjs`; jeśli są ostrzeżenia, powiedz użytkownikowi.
-4. Zweryfikuj aktywność oferty Playwrightem, gdy to możliwe.
-5. Użyj WebSearch do danych o wynagrodzeniu, rynku i firmie.
+4. Zweryfikuj aktywność oferty Playwrightem, gdy jest dostępny; jeśli nie, użyj dostępnego fallbacku i oznacz poziom pewności.
+5. Użyj WebSearch do danych o wynagrodzeniu, rynku i firmie, gdy jest dostępny; jeśli nie, opisz braki i oznacz elementy jako `needs_check`.
 6. W raporcie dodaj `**URL:**` i `**Legitimacy:**`.
 7. Dla nowych wpisów trackera zapisz TSV i potem uruchom `node merge-tracker.mjs`.
 8. Pisz prosto, konkretnie i bez nadmuchanych deklaracji.

--- a/modes/pl/_shared.md
+++ b/modes/pl/_shared.md
@@ -1,0 +1,179 @@
+# Wspólny kontekst -- career-ops (Polska)
+
+<!-- ============================================================
+     TEN PLIK JEST SYSTEMOWY. Nie wpisuj tutaj danych osobowych.
+
+     Personalizacja kandydata należy do:
+     - config/profile.yml
+     - modes/_profile.md
+     - cv.md
+     - article-digest.md
+
+     Ten plik zawiera zasady, punktację i kontekst polskiego rynku.
+     ============================================================ -->
+
+## Źródła prawdy
+
+| Plik | Ścieżka | Kiedy czytać |
+|------|---------|--------------|
+| CV | `cv.md` | Zawsze przed oceną oferty albo generowaniem PDF |
+| Profil | `config/profile.yml` | Zawsze: tożsamość, target roles, lokalizacja, wynagrodzenie |
+| Personalizacja | `modes/_profile.md` | Zawsze po tym pliku: arketypy, narracja, proof points, negocjacje |
+| Proof points | `article-digest.md` | Jeśli istnieje: szczegółowe case studies i metryki |
+| Writing samples | `writing-samples/` | Tylko dla tekstów wysyłanych do firm, jeśli `_profile.md` nie ma sekcji `## Writing Style` |
+
+**Zasada:** nigdy nie wymyślaj doświadczenia, metryk ani linków. Czytaj je z `cv.md`, `article-digest.md`, `config/profile.yml` i `modes/_profile.md`.
+
+**Kolejność:** najpierw ten plik, potem `modes/_profile.md`. Personalizacja z `_profile.md` wygrywa z domyślnymi zasadami.
+
+---
+
+## System punktacji
+
+Ocena używa bloków A-F i globalnego wyniku 1-5. Blok G jest osobną oceną wiarygodności ogłoszenia i nie zmienia score.
+
+| Wymiar | Co mierzy |
+|--------|-----------|
+| Dopasowanie do CV | Umiejętności, doświadczenie, metryki, proof points |
+| Dopasowanie do North Star | Czy rola pasuje do arketypów z `modes/_profile.md` |
+| Wynagrodzenie | Pozycja oferty względem rynku i targetu kandydata |
+| Sygnały kultury i stabilności | Firma, zespół, remote policy, tempo rekrutacji, dojrzałość techniczna |
+| Red flags | Blokery, ryzyka, niespójności, słabe warunki |
+| **Global** | Ważona ocena decyzji: czy warto aplikować |
+
+**Interpretacja score:**
+- 4.5+ -> bardzo mocne dopasowanie, warto aplikować szybko
+- 4.0-4.4 -> dobre dopasowanie, warto aplikować
+- 3.5-3.9 -> umiarkowane dopasowanie, aplikuj tylko z konkretnym powodem
+- poniżej 3.5 -> rekomenduj nieaplikowanie, chyba że użytkownik świadomie nadpisuje decyzję
+
+## Wiarygodność ogłoszenia (Blok G)
+
+Blok G ocenia, czy oferta wygląda na realną i aktywną. To nie jest oskarżanie firmy o "ghost job"; pokazuj sygnały i pozwól użytkownikowi zdecydować.
+
+**Poziomy:**
+- **High Confidence** -- wiele sygnałów wskazuje na realną, aktywną rekrutację
+- **Proceed with Caution** -- mieszane sygnały, warto zachować ostrożność
+- **Suspicious** -- wiele sygnałów sugeruje, że przed inwestowaniem czasu trzeba sprawdzić ofertę
+
+**Sygnały:**
+
+| Sygnał | Źródło | Waga | Jak interpretować |
+|--------|--------|------|-------------------|
+| Wiek ogłoszenia | Snapshot strony / portal | Wysoka | <30 dni dobrze, 30-60 dni mieszane, 60+ dni ostrożnie; role senior/niszowe mogą wisieć dłużej |
+| Aktywny przycisk aplikacji | Playwright snapshot | Wysoka | Bezpośredni dowód, że formularz istnieje |
+| Konkret w opisie | JD | Średnia | Technologie, zakres, zespół, pierwsze 6-12 miesięcy |
+| Realistyczne wymagania | JD | Średnia | Szukaj sprzeczności: junior title + senior scope, zbyt dużo stacków naraz |
+| Widełki wynagrodzenia | JD / portal | Niska-średnia | W Polsce coraz częstsze na portalach IT, ale brak widełek nie oznacza automatycznie ghost job |
+| Reposty | `data/scan-history.tsv` | Średnia | Ta sama rola wraca wiele razy w 90 dni -> ostrożność |
+| Sygnały firmowe | WebSearch | Średnia | Zwolnienia, hiring freeze, finansowanie, zamknięcia biur |
+
+**Etyka:**
+- Nie zarzucaj firmie nieuczciwości.
+- Oddziel obserwacje od wniosków.
+- Podawaj możliwe neutralne wyjaśnienia: evergreen role, rola niszowa, długi proces, rekrutacja przez kilka lokalizacji.
+
+---
+
+## Arketypy
+
+Domyślne arketypy w tym pliku są ogólne i zgodne z głównym kierunkiem `career-ops`. Dla konkretnego użytkownika zawsze używaj `modes/_profile.md`.
+
+| Arketyp | Sygnały w ofercie |
+|---------|-------------------|
+| AI Platform / LLMOps Engineer | ewaluacje, observability, monitoring, reliability, pipeline'y, wdrożenia modeli |
+| Agentic Workflows / Automation | agent, HITL, orchestration, workflow automation, multi-agent, narzędzia wewnętrzne |
+| Technical AI Product Manager | PRD, roadmapa, discovery, stakeholderzy, product metrics, GenAI/agents |
+| AI Solutions Architect | architektura, enterprise, integracje, system design, rozwiązania end-to-end |
+| AI Forward Deployed Engineer | client-facing, szybkie prototypowanie, wdrożenia u klienta, field engineering |
+| AI Transformation Lead | change management, adoption, enablement, szkolenia zespołów, transformacja organizacji |
+
+Po wykryciu arketypu od razu przeczytaj `modes/_profile.md`, bo tam są docelowe role i mapping proof points użytkownika. Nie wpisuj konkretnych projektów, metryk ani preferencji kandydata w tym pliku.
+
+---
+
+## Polski rynek pracy IT -- rzeczy do sprawdzenia
+
+| Element | Co oznacza | Wpływ na decyzję |
+|---------|------------|------------------|
+| **UoP** | Umowa o pracę; Kodeks pracy, płatny urlop, L4, okres wypowiedzenia, ochrona pracownika | Porównuj brutto miesięczne z benefitami i stabilnością |
+| **B2B** | Kontrakt między firmami; kandydat zwykle prowadzi JDG i wystawia fakturę | Porównuj netto + VAT, podatki/ZUS, płatny urlop, okres wypowiedzenia, autonomię |
+| **Netto + VAT** | Typowy zapis stawek B2B w Polsce | Nie myl z UoP netto ani brutto |
+| **Brutto / netto** | UoP zwykle podawana brutto, B2B często netto + VAT | Zawsze normalizuj przed porównaniem |
+| **ZUS / PIT / VAT** | Obciążenia podatkowo-składkowe | Wpływają na realny take-home i ryzyko B2B |
+| **Ryczałt / liniowy** | Popularne formy opodatkowania JDG; IT często analizuje 12% ryczałt albo 19% liniowy | Nie doradzaj podatkowo; powiedz, że kandydat powinien potwierdzić z księgowością |
+| **Okres próbny** | UoP może mieć okres próbny do 3 miesięcy | Standard, nie red flag sam w sobie |
+| **Okres wypowiedzenia UoP** | Zwykle 2 tygodnie / 1 miesiąc / 3 miesiące zależnie od stażu | Ważne dla daty startu |
+| **Okres wypowiedzenia B2B** | Ustalany w umowie; często 1 miesiąc w IT | Sprawdź, czy jest symetryczny i czy nie ma jednostronnych zapisów |
+| **Urlop** | UoP 20 albo 26 dni; B2B tylko jeśli umowa przewiduje płatne przerwy | B2B bez płatnego urlopu wymaga wyższej stawki |
+| **Benefity** | LuxMed/Medicover, Multisport, wczasy pod gruszą, budżet szkoleniowy, sprzęt, remote stipend | Licz jako dodatek, nie zamiennik za słabe wynagrodzenie |
+| **Tryb pracy** | zdalnie, hybrydowo, stacjonarnie | Hybryda wymaga sprawdzenia liczby dni w biurze i lokalizacji |
+
+**Portale i źródła ofert w Polsce:**
+- Just Join IT
+- No Fluff Jobs
+- Bulldogjob
+- The Protocol
+- Pracuj.pl
+- LinkedIn PL
+- JobHunt.pl jako agregator
+- strony karier firm i ATS-y: Greenhouse, Ashby, Lever, Workable
+
+**Miasta i regiony często spotykane w ofertach:** Warszawa, Kraków, Wrocław, Gdańsk, Poznań, Katowice, Łódź, Polska zdalnie, EU remote, EMEA remote.
+
+---
+
+## Wynagrodzenie i negocjacje
+
+Zawsze korzystaj z `config/profile.yml` dla targetów kandydata. W polskich ofertach dopytuj:
+
+- UoP czy B2B?
+- Czy kwota jest brutto, netto, netto + VAT?
+- Czy B2B ma płatne dni wolne?
+- Jaki jest okres wypowiedzenia?
+- Czy jest budżet szkoleniowy, prywatna opieka medyczna, karta sportowa?
+- Czy praca zdalna jest faktyczna, czy "hybryda po okresie wdrożenia"?
+
+**Formułka do widełek:**
+> "Dla tej roli celuję w zakres z `config/profile.yml`. Jestem elastyczny co do formy współpracy, ale porównujmy cały pakiet: scope, tryb pracy, UoP/B2B, płatny czas wolny, benefity i odpowiedzialność techniczna."
+
+**B2B vs UoP:**
+> "Przy B2B patrzę na stawkę netto + VAT, płatne przerwy, okres wypowiedzenia i autonomię. Przy UoP porównuję brutto, urlop, stabilność, benefity i długoterminowy rozwój."
+
+**Zdalna praca i Polska:**
+> "Moja lokalizacja i strefa czasowa są opisane w `config/profile.yml`. Dla zespołów europejskich i zdalnych porównujmy wartość pracy, overlap czasowy i zakres odpowiedzialności, a nie sam kraj zamieszkania."
+
+---
+
+## Globalne zasady
+
+### Nigdy
+
+1. Nie wymyślaj doświadczenia, metryk, certyfikatów ani linków.
+2. Nie wysyłaj aplikacji za użytkownika.
+3. Nie klikaj `Submit`, `Send`, `Apply`, `Aplikuj` ani podobnych przycisków bez jasnej zgody.
+4. Nie rekomenduj aplikowania na niskie dopasowanie bez ostrzeżenia.
+5. Nie edytuj `applications.md`, żeby dodać nowy wpis; używaj TSV w `batch/tracker-additions/`.
+6. Nie generuj PDF bez przeczytania konkretnej oferty.
+7. Nie używaj pustych fraz typu "dynamiczny zespół", "pasjonat technologii", "ambitny i zmotywowany" w tekstach kandydata.
+
+### Zawsze
+
+1. Przeczytaj `cv.md`, `config/profile.yml` i `modes/_profile.md` przed oceną.
+2. Jeśli istnieje `article-digest.md`, przeczytaj je dla proof points.
+3. W pierwszej ocenie sesji uruchom `node cv-sync-check.mjs`; jeśli są ostrzeżenia, powiedz użytkownikowi.
+4. Zweryfikuj aktywność oferty Playwrightem, gdy to możliwe.
+5. Użyj WebSearch do danych o wynagrodzeniu, rynku i firmie.
+6. W raporcie dodaj `**URL:**` i `**Legitimacy:**`.
+7. Dla nowych wpisów trackera zapisz TSV i potem uruchom `node merge-tracker.mjs`.
+8. Pisz prosto, konkretnie i bez nadmuchanych deklaracji.
+
+## Styl tekstów kandydackich
+
+Dotyczy CV summary, listów motywacyjnych, odpowiedzi w formularzach i wiadomości LinkedIn. Nie dotyczy wewnętrznych raportów.
+
+- Pisz konkretnie: problem -> działanie -> metryka -> efekt biznesowy.
+- Używaj czasowników aktywnych.
+- Nie tłumacz na siłę terminów technicznych.
+- Nie podawaj telefonu w wygenerowanych wiadomościach, chyba że użytkownik wyraźnie poprosi.
+- Jeśli oferta jest po polsku, generuj tekst po polsku; jeśli po angielsku, generuj po angielsku, chyba że użytkownik chce inaczej.

--- a/modes/pl/aplikuj.md
+++ b/modes/pl/aplikuj.md
@@ -1,0 +1,144 @@
+# Tryb: aplikuj -- asystent aplikowania
+
+Tryb interaktywny do pomocy przy wypełnianiu formularzy aplikacyjnych. Czyta stronę lub pytania z formularza, znajduje wcześniejszy raport dla tej roli i generuje odpowiedzi gotowe do wklejenia.
+
+## Zasada krytyczna
+
+**Nigdy nie wysyłaj aplikacji za użytkownika.**
+
+Możesz wypełnić, przygotować, sprawdzić i zaproponować odpowiedzi. Kliknięcie `Submit`, `Send`, `Apply`, `Aplikuj`, `Wyślij aplikację` albo podobnego przycisku zawsze należy do użytkownika.
+
+## Wymagania
+
+- Najlepiej: Playwright / widoczna przeglądarka, żeby odczytać aktywną kartę.
+- Alternatywnie: użytkownik wkleja pytania z formularza albo udostępnia screenshot.
+
+## Workflow
+
+```text
+1. WYKRYJ       -> odczytaj aktywną stronę, screenshot, URL albo tekst formularza
+2. ROZPOZNAJ    -> wyciągnij firmę i rolę
+3. ZNAJDŹ       -> znajdź pasujący raport w reports/
+4. WCZYTAJ      -> przeczytaj raport, CV, profil i Blok G
+5. PORÓWNAJ     -> sprawdź, czy rola w formularzu zgadza się z raportem
+6. ANALIZUJ     -> wypisz wszystkie pytania i pola
+7. GENERUJ      -> przygotuj odpowiedzi
+8. POKAŻ        -> pokaż użytkownikowi do review/copy-paste
+```
+
+## Krok 1 -- Wykrycie roli
+
+**Z Playwrightem:**
+- zrób snapshot strony,
+- odczytaj tytuł, URL, firmę, rolę i widoczne pytania,
+- jeśli formularz jest wieloetapowy, pracuj etapami.
+
+**Bez Playwrighta:**
+Poproś użytkownika o jedno z:
+- screenshot formularza,
+- wklejone pytania,
+- nazwę firmy + rolę + link do oferty.
+
+## Krok 2 -- Znalezienie kontekstu
+
+1. Szukaj w `reports/` po nazwie firmy i roli.
+2. Jeśli znajdziesz raport, przeczytaj całość.
+3. Szczególnie wykorzystaj:
+   - Blok B: dopasowanie CV,
+   - Blok F: historie STAR+R,
+   - Blok G: wiarygodność ogłoszenia,
+   - `## Keywords extracted`, jeśli istnieje.
+4. Jeśli raportu nie ma, powiedz to i zaproponuj szybką ocenę oferty przed przygotowaniem odpowiedzi.
+
+## Krok 3 -- Zmiana roli lub niespójność
+
+Jeśli formularz dotyczy innej roli niż raport:
+
+> "Formularz wygląda na rolę [nowa rola], a raport dotyczy [stara rola]. Chcesz, żebym zrobił nową ocenę, czy tylko dostosował odpowiedzi do nowego tytułu?"
+
+Nie udawaj, że kontekst jest ten sam.
+
+## Krok 4 -- Analiza formularza
+
+Wypisz wszystkie pola:
+
+- dane osobowe,
+- CV / cover letter upload,
+- pytania tekstowe,
+- salary expectations,
+- work authorization,
+- dostępność / okres wypowiedzenia,
+- preferencja UoP/B2B,
+- praca zdalna / hybrydowa / stacjonarna,
+- portfolio/GitHub/LinkedIn,
+- zgody RODO,
+- pytania techniczne.
+
+## Krok 5 -- Generowanie odpowiedzi
+
+Każda odpowiedź ma być:
+
+- konkretna,
+- zgodna z `cv.md`,
+- dopasowana do oferty,
+- bez przesady i bez wymyślania,
+- w języku formularza, chyba że użytkownik chce inaczej.
+
+Używaj proof points z CV i `_profile.md`. Nie podawaj telefonu w odpowiedziach tekstowych, chyba że formularz ma osobne pole telefonu i użytkownik chce je wypełnić.
+
+## Polskie pola formularzy
+
+**Oczekiwania finansowe**
+- Jeśli pytają o B2B, podawaj zakres z `config/profile.yml` jako netto + VAT.
+- Jeśli pytają o UoP, podawaj zakres brutto.
+- Jeśli forma nie jest jasna, odpowiedz z rozróżnieniem: "dla B2B..." / "dla UoP...".
+
+**Forma współpracy**
+- UoP: stabilność, urlop, L4, benefity.
+- B2B: wyższa stawka, autonomia, okres wypowiedzenia, płatne przerwy, jeśli są.
+- Nie doradzaj podatkowo; jeśli temat dotyczy PIT/ZUS/VAT, sugeruj potwierdzenie z księgowością.
+
+**Dostępność**
+- Uwzględnij okres wypowiedzenia i realną datę startu.
+- Jeśli użytkownik nie podał daty, przygotuj neutralną odpowiedź: "do uzgodnienia, po potwierdzeniu okresu wypowiedzenia".
+
+**Praca zdalna/hybrydowa**
+- Użyj preferencji zapisanych w `config/profile.yml`, jeśli istnieją.
+- Jeśli profil nie określa preferencji, poproś użytkownika o potwierdzenie modelu pracy i lokalizacji.
+
+**RODO**
+- Jeśli formularz wymaga zgody RODO, nie twórz prawnych klauzul na siłę. Możesz przygotować neutralną odpowiedź, ale użytkownik powinien sprawdzić wymaganą treść formularza.
+
+## Format odpowiedzi
+
+```markdown
+## Odpowiedzi: {Firma} -- {Rola}
+
+Kontekst: raport #{NNN} | Score: {X.X}/5 | Arketyp: {arketype}
+
+---
+
+### 1. {dokładne pytanie z formularza}
+> {odpowiedź gotowa do wklejenia}
+
+### 2. {kolejne pytanie}
+> {odpowiedź}
+
+---
+
+## Uwagi do review
+
+- {co użytkownik powinien sprawdzić przed wysłaniem}
+- {ryzyka albo niespójności}
+- {czy warto dodać cover letter / portfolio / GitHub}
+```
+
+## Po aplikacji
+
+Jeśli użytkownik potwierdzi, że sam wysłał aplikację:
+
+1. Zmień status w `data/applications.md` z `Evaluated` na `Applied`.
+2. Dodaj notatkę z datą, jeśli repo tak prowadzi tracker.
+3. Zaproponuj follow-up albo kontakt na LinkedIn, jeśli score był wysoki.
+
+Nie aktualizuj statusu na `Applied`, dopóki użytkownik nie potwierdzi, że aplikacja faktycznie została wysłana.

--- a/modes/pl/aplikuj.md
+++ b/modes/pl/aplikuj.md
@@ -84,7 +84,7 @@ Każda odpowiedź ma być:
 - bez przesady i bez wymyślania,
 - w języku formularza, chyba że użytkownik chce inaczej.
 
-Używaj proof points z CV i `_profile.md`. Nie podawaj telefonu w odpowiedziach tekstowych, chyba że formularz ma osobne pole telefonu i użytkownik chce je wypełnić.
+Używaj proof points z CV i `modes/_profile.md`. Nie podawaj telefonu w odpowiedziach tekstowych, chyba że formularz ma osobne pole telefonu i użytkownik chce je wypełnić.
 
 ## Polskie pola formularzy
 
@@ -114,7 +114,7 @@ Używaj proof points z CV i `_profile.md`. Nie podawaj telefonu w odpowiedziach 
 ```markdown
 ## Odpowiedzi: {Firma} -- {Rola}
 
-Kontekst: raport #{NNN} | Score: {X.X}/5 | Arketyp: {arketype}
+Kontekst: raport #{NNN} | Score: {X.X}/5 | Arketyp: {arketyp}
 
 ---
 

--- a/modes/pl/oferta.md
+++ b/modes/pl/oferta.md
@@ -1,0 +1,271 @@
+# Tryb: oferta -- pełna ocena A-G
+
+Gdy użytkownik poda ofertę pracy jako URL albo tekst, zawsze przygotuj pełną ocenę: bloki A-F plus blok G dotyczący wiarygodności ogłoszenia.
+
+## Krok 0 -- Identyfikacja arketypu
+
+1. Przeczytaj `modes/pl/_shared.md`.
+2. Przeczytaj `modes/_profile.md`, bo personalizacja użytkownika nadpisuje domyślne arketypy.
+3. Sklasyfikuj ofertę jako jeden główny arketyp albo hybrydę dwóch najbliższych.
+
+Arketyp decyduje o tym:
+- jakie proof points pokazać w bloku B,
+- jak zaproponować zmiany w CV w bloku E,
+- jakie historie STAR+R przygotować w bloku F,
+- jak ocenić realne dopasowanie, nie tylko keyword match.
+
+## Blok A -- Podsumowanie roli
+
+Zrób zwięzłą tabelę:
+
+| Pole | Wartość |
+|------|---------|
+| Firma | ... |
+| Rola | ... |
+| Wykryty arketyp | ... |
+| Domeny | e-commerce / SaaS / agency / product / fintech / enterprise / AI / inne |
+| Funkcja | budowanie / utrzymanie / modernizacja / konsulting / leadership / delivery |
+| Seniority | junior / mid / senior / lead / staff |
+| Tryb pracy | zdalnie / hybrydowo / biuro / niejasne |
+| Lokalizacja | Polska / EU / EMEA / global / konkretne miasto |
+| Forma współpracy | UoP / B2B / kontrakt / niejasne |
+| Wynagrodzenie | widełki i waluta, jeśli podane |
+| Flagi decyzji | `project_based`, `fixed_term`, `temporary_relocation_candidate`, `needs_extension_check`, `needs_rate_premium` albo `brak` |
+| TL;DR | jedna konkretna sentencja |
+
+## Blok B -- Dopasowanie do CV
+
+Przeczytaj `cv.md`. Stwórz tabelę, która mapuje wymagania z oferty na konkretne dowody z CV.
+
+| Wymaganie z oferty | Dowód w CV | Siła dopasowania | Komentarz |
+|--------------------|------------|------------------|-----------|
+| ... | cytat / sekcja / metryka | Mocne / Średnie / Słabe | ... |
+
+Zasady:
+- Cytuj konkretne metryki tylko z `cv.md` albo `article-digest.md`.
+- Jeśli metryka w CV ma adnotację typu "REFERENCE METRIC -- VERIFY", oznacz ją jako do potwierdzenia przed publikacją.
+- Nie uznawaj samego podobieństwa technologii za pełne dopasowanie; oceń zakres odpowiedzialności.
+
+**Sekcja luk:**
+Dla każdej luki odpowiedz:
+1. Czy to blocker, czy nice-to-have?
+2. Czy kandydat ma doświadczenie pokrewne?
+3. Czy da się to pokryć portfolio, case study albo krótką odpowiedzią w liście?
+4. Jak to nazwać uczciwie w aplikacji?
+
+## Blok C -- Poziom i strategia
+
+Oceń:
+
+1. Poziom z oferty vs naturalny poziom kandydata dla tego arketypu.
+2. Jak sprzedać seniority bez przesady:
+   - jakie metryki pokazać,
+   - jaki zakres ownership podkreślić,
+   - jakie słowa z JD wykorzystać.
+3. Co zrobić, jeśli firma chce downlevel:
+   - czy scope nadal jest wart rozmowy,
+   - czy wynagrodzenie rekompensuje niższy tytuł,
+   - czy prosić o 6-miesięczny review i konkretne kryteria awansu.
+
+## Blok D -- Wynagrodzenie i popyt
+
+Użyj WebSearch. Dla polskich ofert sprawdzaj źródła typu:
+- No Fluff Jobs,
+- Just Join IT,
+- The Protocol,
+- Bulldogjob,
+- Pracuj.pl,
+- Glassdoor,
+- Levels.fyi, jeśli firma jest globalna,
+- raporty płacowe dla IT w Polsce, jeśli są aktualne.
+
+Tabela:
+
+| Źródło | Dane | Jak interpretować |
+|--------|------|-------------------|
+| ... | ... | ... |
+
+Uwzględnij:
+- UoP vs B2B,
+- brutto vs netto + VAT,
+- walutę,
+- płatny urlop przy B2B,
+- benefit package,
+- remote/hybrid policy,
+- czy stawka jest zgodna z targetem z `config/profile.yml`.
+
+Jeśli nie ma wiarygodnych danych, napisz to wprost. Nie wymyślaj widełek.
+
+## Blok E -- Plan personalizacji
+
+Zaproponuj zmiany pod tę konkretną ofertę.
+
+| # | Sekcja | Obecnie | Proponowana zmiana | Dlaczego |
+|---|--------|---------|--------------------|----------|
+| 1 | Summary | ... | ... | ... |
+
+Dodaj:
+- top 5 zmian w CV,
+- top 5 zmian w LinkedIn,
+- 5-10 słów kluczowych ATS z oferty,
+- czy warto robić osobny case study / portfolio note.
+
+Nie edytuj `cv.md` automatycznie bez prośby użytkownika.
+
+## Blok F -- Plan rozmowy rekrutacyjnej
+
+Przygotuj 6-10 historii STAR+R:
+
+| # | Wymaganie z oferty | Historia STAR+R | S | T | A | R | Refleksja |
+|---|--------------------|-----------------|---|---|---|---|-----------|
+
+Refleksja pokazuje seniority: czego kandydat się nauczył, co powtórzyłby inaczej, jakie trade-offy rozumie.
+
+Jeśli istnieje `interview-prep/story-bank.md`, sprawdź, czy historia już tam jest. Jeśli nie ma, dodaj nową historię po ocenie.
+
+Dodaj:
+- najważniejsze pytania, które kandydat powinien zadać firmie,
+- czerwone flagi i jak na nie odpowiedzieć,
+- który proof point z CV ma być "hero story" w rozmowie.
+
+Jeśli oferta ma flagi projektowe / fixed-term / relokacyjne, dodaj obowiązkowe pytania do rekrutera:
+- dokładna data końca projektu i oczekiwany wymiar godzin,
+- prawdopodobieństwo przedłużenia albo kolejnego projektu,
+- płatne przerwy/urlop, okres wypowiedzenia i przerwy między projektami,
+- kto jest klientem/projektem i jaki jest realny ownership,
+- jak często trzeba być onsite i czy tymczasowa relokacja ma sens,
+- czy stawka uwzględnia premium za ryzyko kontraktowe.
+
+## Blok G -- Wiarygodność ogłoszenia
+
+Oceń, czy oferta wygląda na realną i aktywną. To osobna ocena, nie część score 1-5.
+
+**Analizuj po kolei:**
+
+1. **Świeżość ogłoszenia**
+   - data publikacji albo "X dni temu",
+   - aktywny przycisk aplikacji,
+   - czy URL przekierowuje na ogólną stronę karier.
+
+2. **Jakość opisu**
+   - konkretne technologie,
+   - zakres pierwszych 6-12 miesięcy,
+   - zespół i raportowanie,
+   - realistyczne wymagania,
+   - stosunek konkretów do ogólnego boilerplate.
+
+3. **Sygnały firmy**
+   - WebSearch: `"{firma}" layoffs {rok}`,
+   - WebSearch: `"{firma}" hiring freeze {rok}`,
+   - dla polskich firm: `"{firma}" zwolnienia`, `"{firma}" opinie praca`, `"{firma}" rekrutacja`.
+
+4. **Reposty**
+   - sprawdź `data/scan-history.tsv`, jeśli istnieje,
+   - czy podobna rola wraca z nowym URL-em.
+
+5. **Kontekst rynku**
+   - czy rola jest typowa i szybko obsadzana,
+   - czy to senior/niszowa rola, która naturalnie trwa dłużej,
+   - czy evergreen hiring jest jawnie nazwany.
+
+**Wynik:**
+- **High Confidence**
+- **Proceed with Caution**
+- **Suspicious**
+
+Pokaż tabelę sygnałów:
+
+| Sygnał | Obserwacja | Waga | Wniosek |
+|--------|------------|------|---------|
+
+Nie przedstawiaj podejrzeń jako faktów.
+
+---
+
+## Wynik globalny
+
+Podaj score `X.X/5` i decyzje:
+
+- **Apply now** -- 4.5+
+- **Apply** -- 4.0-4.4
+- **Maybe, only with a reason** -- 3.5-3.9
+- **Skip** -- poniżej 3.5
+
+Jeśli score jest poniżej 4.0, wyraźnie odradź aplikowanie, chyba że użytkownik ma konkretny powód.
+
+Pokaż też krótką sekcję `Score Breakdown`, ale bez dodatkowych kar, soft ceilingów ani osobnej logiki. Ma to być tylko czytelne rozbicie tej samej oceny globalnej:
+
+Jeśli oferta jest projektowa, freelance, fixed-term albo wymaga potencjalnej tymczasowej relokacji, opisz to jako flagę decyzyjną. Nie odejmuj punktów tylko za sam fixed-term albo możliwość relokacji. Odejmuj punkty dopiero za konkretne problemy: słabą stawkę wobec ryzyka, niejasne przedłużenie, długoterminowy mandatory onsite, słaby fit techniczny albo nieprzejrzysty projekt/klienta.
+
+| Wymiar | Score | Uzasadnienie |
+|--------|-------|--------------|
+| Dopasowanie do CV | X/5 | ... |
+| Dopasowanie do North Star | X/5 | ... |
+| Wynagrodzenie | X/5 | ... |
+| Sygnały kultury i stabilności | X/5 | ... |
+| Red flags | -X | ... |
+| **Global** | **X.X/5** | Ta sama ocena co w nagłówku raportu |
+
+## Po ocenie
+
+### 1. Zapisz raport
+
+Zapisz raport jako:
+
+```text
+reports/{###}-{company-slug}-{YYYY-MM-DD}.md
+```
+
+Wymagany nagłówek:
+
+```markdown
+# Evaluation: {Company} -- {Role}
+
+**Date:** {YYYY-MM-DD}
+**URL:** {job URL}
+**Archetype:** {detected archetype}
+**Score:** {X.X/5}
+**Legitimacy:** {High Confidence | Proceed with Caution | Suspicious}
+**PDF:** {path or pending}
+```
+
+W raporcie zachowaj sekcje:
+- `## A) Role Summary`
+- `## B) Match with CV`
+- `## C) Level and Strategy`
+- `## D) Comp and Demand`
+- `## E) Customization Plan`
+- `## F) Interview Plan`
+- `## G) Posting Legitimacy`
+- `## Score Breakdown`
+- `## Machine Summary`
+
+`## Machine Summary` powinno być YAML-em, jeśli repo tego wymaga w aktualnych raportach. Jeśli dotyczy, dodaj:
+
+```yaml
+decision_flags:
+  - project_based
+project_terms:
+  end_date: unknown
+  extension_path: needs_check
+  onsite_or_relocation: needs_check
+  rate_premium: needs_check
+```
+
+### 2. Zapisz wpis do trackera
+
+Nie dodawaj nowych wpisów bezpośrednio do `data/applications.md`.
+
+Zapisz TSV:
+
+```tsv
+{num}\t{date}\t{company}\t{role}\tEvaluated\t{score}/5\t{pdf_emoji}\t[{num}](reports/{num}-{slug}-{date}.md)\t{note}
+```
+
+Potem uruchom:
+
+```bash
+node merge-tracker.mjs
+```
+
+Jeśli firma + rola już istnieje, zaktualizuj istniejący wpis zamiast tworzyć duplikat.

--- a/modes/pl/oferta.md
+++ b/modes/pl/oferta.md
@@ -213,8 +213,10 @@ Jeśli oferta jest projektowa, freelance, fixed-term albo wymaga potencjalnej ty
 Zapisz raport jako:
 
 ```text
-reports/{###}-{company-slug}-{YYYY-MM-DD}.md
+reports/{num}-{company-slug}-{date}.md
 ```
+
+`{num}` to trzycyfrowy numer raportu, a `{date}` to data w formacie `YYYY-MM-DD`.
 
 Wymagany nagłówek:
 
@@ -259,7 +261,7 @@ Nie dodawaj nowych wpisów bezpośrednio do `data/applications.md`.
 Zapisz TSV:
 
 ```tsv
-{num}\t{date}\t{company}\t{role}\tEvaluated\t{score}/5\t{pdf_emoji}\t[{num}](reports/{num}-{slug}-{date}.md)\t{note}
+{num}\t{date}\t{company}\t{role}\tEvaluated\t{score}/5\t{pdf_emoji}\t[{num}](reports/{num}-{company-slug}-{date}.md)\t{note}
 ```
 
 Potem uruchom:

--- a/modes/pl/pipeline.md
+++ b/modes/pl/pipeline.md
@@ -7,18 +7,22 @@ Przetwarza URL-e zapisane w `data/pipeline.md`. Użytkownik może zbierać linki
 1. **Przeczytaj** `data/pipeline.md` i znajdź pozycje `- [ ]` w sekcji "Pending" albo jej lokalnym odpowiedniku.
 2. **Dla każdego pending URL-a**:
    a. Zarezerwuj kolejny `REPORT_NUM` przez `node reserve-report-num.mjs` i zwolnij sentinel po zapisaniu raportu przez `node reserve-report-num.mjs --release <num>`.
-   b. Wyciągnij JD: Playwright (`browser_navigate` + `browser_snapshot`) → WebFetch → WebSearch.
+   b. Wyciągnij JD: Playwright (`browser_navigate` + `browser_snapshot`), jeśli jest dostępny → WebFetch → WebSearch.
    c. Jeśli URL jest niedostępny, oznacz go jako `- [!]` z krótką notatką i przejdź dalej.
-   d. Uruchom pełny auto-pipeline: ocena A-F → raport `.md` → PDF według progu `auto_pdf_score_threshold` → tracker.
+   d. Uruchom pełny auto-pipeline: ocena A-G z Block G / `Legitimacy` → raport `.md` → PDF według progu `auto_pdf_score_threshold` → tracker.
    e. Przenieś wpis z "Pending" do "Processed": `- [x] #NNN | URL | Company | Role | Score/5 | PDF ✅/❌`.
+
+Tylko aktywny proces pipeline albo koordynator może aktualizować `data/pipeline.md`. Workerzy równolegli nie mogą edytować `data/pipeline.md` ani `data/applications.md`; zapisują tylko raporty, TSV w `batch/tracker-additions/`, logi i wyniki per oferta.
+
+**Legitimacy / Block G:** każda ocena musi obliczyć tier `High Confidence`, `Proceed with Caution` albo `Suspicious` zgodnie z `modes/oferta.md`. Ten tier wpisz w nagłówku raportu jako `**Legitimacy:**`, w sekcji `## G) Posting Legitimacy` oraz w tabeli końcowej. Jeśli narzędzia weryfikacyjne są niedostępne, oznacz brakujące fakty jako `needs_check` zamiast zgadywać.
 
 **Próg PDF:** przeczytaj `config/profile.yml` → `auto_pdf_score_threshold`. Jeśli klucz nie istnieje, domyślnie użyj `3.0`. Jeśli score jest niższy niż próg, zapisz raport bez PDF, wpisz w nagłówku `**PDF:** not generated — run /career-ops pdf {company-slug} to create on demand` i oznacz PDF jako ❌ w trackerze. Jeśli score jest równy lub wyższy od progu, wygeneruj PDF normalnie.
 
-3. **Jeśli są 3+ pending URL-e**, uruchom agentów równolegle zgodnie z bazowym trybem pipeline.
+3. **Jeśli są 3+ pending URL-e**, użyj bazowego koordynatora pipeline dla równoległości, resume i retry. Zachowaj granicę: koordynator aktualizuje wspólne pliki, workerzy wykonują tylko pracę per oferta.
 4. **Na końcu** pokaż tabelę:
 
 ```markdown
-| # | Firma | Rola | Score | PDF | Rekomendowany następny krok |
+| # | Firma | Rola | Score | Legitimacy | PDF | Rekomendowany następny krok |
 ```
 
 ## Format `data/pipeline.md`

--- a/modes/pl/pipeline.md
+++ b/modes/pl/pipeline.md
@@ -1,0 +1,93 @@
+# Tryb: pipeline -- skrzynka URL-i z ofertami
+
+Przetwarza URL-e zapisane w `data/pipeline.md`. Użytkownik może zbierać linki do ofert przez kilka dni, a potem uruchomić `/career-ops pipeline`, żeby przetworzyć je zbiorczo.
+
+## Workflow
+
+1. **Przeczytaj** `data/pipeline.md` i znajdź pozycje `- [ ]` w sekcji "Pending" albo jej lokalnym odpowiedniku.
+2. **Dla każdego pending URL-a**:
+   a. Zarezerwuj kolejny `REPORT_NUM` przez `node reserve-report-num.mjs` i zwolnij sentinel po zapisaniu raportu przez `node reserve-report-num.mjs --release <num>`.
+   b. Wyciągnij JD: Playwright (`browser_navigate` + `browser_snapshot`) → WebFetch → WebSearch.
+   c. Jeśli URL jest niedostępny, oznacz go jako `- [!]` z krótką notatką i przejdź dalej.
+   d. Uruchom pełny auto-pipeline: ocena A-F → raport `.md` → PDF według progu `auto_pdf_score_threshold` → tracker.
+   e. Przenieś wpis z "Pending" do "Processed": `- [x] #NNN | URL | Company | Role | Score/5 | PDF ✅/❌`.
+
+**Próg PDF:** przeczytaj `config/profile.yml` → `auto_pdf_score_threshold`. Jeśli klucz nie istnieje, domyślnie użyj `3.0`. Jeśli score jest niższy niż próg, zapisz raport bez PDF, wpisz w nagłówku `**PDF:** not generated — run /career-ops pdf {company-slug} to create on demand` i oznacz PDF jako ❌ w trackerze. Jeśli score jest równy lub wyższy od progu, wygeneruj PDF normalnie.
+
+3. **Jeśli są 3+ pending URL-e**, uruchom agentów równolegle zgodnie z bazowym trybem pipeline.
+4. **Na końcu** pokaż tabelę:
+
+```markdown
+| # | Firma | Rola | Score | PDF | Rekomendowany następny krok |
+```
+
+## Format `data/pipeline.md`
+
+```markdown
+## Pending
+- [ ] https://jobs.example.com/posting/123
+- [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
+- [!] https://private.url/job -- Error: login required
+
+## Processed
+- [x] #143 | https://jobs.example.com/posting/789 | Acme Corp | AI PM | 4.2/5 | PDF ✅
+- [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF ❌
+```
+
+Polskie nagłówki też są akceptowalne, jeśli już istnieją w pliku:
+
+```markdown
+## Oczekujące
+- [ ] https://example.com/jobs/123
+
+## Przetworzone
+- [x] #001 | https://example.com/jobs/123 | Example | Senior Engineer | 4.2/5 | PDF ✅
+```
+
+Przy zapisie zachowaj styl nagłówków, który już istnieje w pliku.
+
+## Wykrywanie JD z URL-a
+
+1. **Playwright (preferowane):** `browser_navigate` + `browser_snapshot`. Działa z większością SPA.
+2. **WebFetch (fallback):** dla statycznych stron lub gdy Playwright jest niedostępny.
+3. **WebSearch (ostatnia opcja):** szukaj w portalach wtórnych, które indeksują JD.
+
+Przypadki specjalne:
+
+- **LinkedIn:** może wymagać logowania; oznacz `[!]` i poproś użytkownika o wklejenie treści.
+- **PDF:** jeśli URL prowadzi do PDF, odczytaj plik bezpośrednio.
+- **`local:` prefix:** czytaj lokalny plik, np. `local:jds/linkedin-pm-ai.md` → `jds/linkedin-pm-ai.md`.
+
+## Automatyczna numeracja
+
+1. Uruchom `node reserve-report-num.mjs`, żeby zarezerwować kolejny numer raportu.
+2. Zapisz raport z tym numerem.
+3. Po zapisaniu raportu uruchom `node reserve-report-num.mjs --release {###}`.
+
+## Synchronizacja źródeł
+
+Przed przetwarzaniem pierwszego URL-a uruchom:
+
+```bash
+node cv-sync-check.mjs
+```
+
+Jeśli są ostrzeżenia o niespójności CV/profilu, pokaż je użytkownikowi przed kontynuacją.
+
+## Polskie niuanse przy ocenie z pipeline
+
+- Rozróżniaj UoP, B2B, umowę zlecenie i kontrakt. Nie porównuj brutto UoP bezpośrednio z netto + VAT na B2B.
+- Jeśli widełki są podane jako netto + VAT, traktuj je jako B2B, chyba że JD mówi inaczej.
+- Jeśli oferta nie określa formy współpracy, oznacz to jako lukę do wyjaśnienia.
+- Zwracaj uwagę na okres wypowiedzenia, płatny urlop przy B2B, L4, benefity i realny model pracy.
+- Nie udzielaj porad podatkowych. Przy PIT/ZUS/VAT zasugeruj potwierdzenie z księgowością.
+
+## Podsumowanie końcowe
+
+Po zakończeniu pokaż:
+
+```markdown
+| # | Firma | Rola | Score | Legitimacy | PDF | Rekomendacja |
+```
+
+Dla ofert poniżej 4.0/5 jasno napisz, że aplikowanie nie jest rekomendowane, chyba że użytkownik ma strategiczny powód.

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -61,6 +61,7 @@ const SYSTEM_PATHS = [
   'modes/de/',
   'modes/fr/',
   'modes/ja/',
+  'modes/pl/',
   'modes/pt/',
   'modes/ru/',
   'modes/tr/',


### PR DESCRIPTION
## Summary

Adds Polish market modes for #993.

This is an alternative implementation to #1129. It keeps the existing locale-pack convention, but aligns the Polish files with the current `main` data contract and pipeline behavior rather than only mirroring older locale files.

## What differs from #1129

- adds updater/data-contract/i18n registration for `modes/pl/`
- preserves current tracker flow through TSV + `merge-tracker.mjs`
- keeps current Block G / posting-legitimacy expectations
- uses localized Polish mode filenames, including `aplikuj.md`
- keeps the scope limited to Polish modes and registration

## Scope

- `modes/pl/README.md`
- `modes/pl/_shared.md`
- `modes/pl/oferta.md`
- `modes/pl/aplikuj.md`
- `modes/pl/pipeline.md`
- minimal locale registration

## Tests

- `node --check update-system.mjs test-all.mjs`
- `node test-all.mjs --quick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Polish language modes for job-offer evaluation, application assistance, and pipeline processing, including end-to-end workflows and decision/routing outputs.
  * Included auto-pipeline support for fetching, scoring legitimacy confidence, PDF generation gating, and tracker/report generation behavior for Polish offers.

* **Documentation**
  * Added Polish mode documentation (including shared rules, usage guidance, and terminology/dictionary mappings).
  * Updated language-mode instructions to clarify when to use Polish modes and how to force Polish targeting.

* **Chores**
  * Updated system/labeling and data-contract rules to include Polish modes in safe auto-update scope and i18n labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->