### PR TITLE
feat(modes): add Danish (da) locale, README.da.md, and Denmark portals block

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -1,6 +1,6 @@
 # Career-Ops | نظام إدارة وتخطيط البحث عن وظائف باستخدام الذكاء الاصطناعي (وكيل مأتمت)
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="right" dir="rtl">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops — نظام البحث عن وظائف القائم على عدة وكلاء ذكاء اصطناعي" width="800"></a>

--- a/README.cn.md
+++ b/README.cn.md
@@ -1,6 +1,6 @@
 # Career-Ops
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="center">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops 多代理求职系统" width="800"></a>

--- a/README.da.md
+++ b/README.da.md
@@ -1,0 +1,301 @@
+# Career-Ops
+
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
+
+<p align="center">
+  <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops — Multi-agent jobsøgningssystem" width="800"></a>
+</p>
+
+<p align="center">
+  <em>I månedsvis søgte jeg job på den gammeldags måde. Så byggede jeg det system, jeg ønskede, jeg havde haft fra start.</em><br>
+  Virksomheder bruger AI til at filtrere kandidater. <strong>Jeg gav kandidaterne AI, så de kan <em>vælge</em> virksomhederne.</strong><br>
+  <em>Nu er det open source.</em>
+</p>
+
+<p align="center">
+  <a href="https://trendshift.io/repositories/25195" target="_blank"><img src="https://trendshift.io/api/badge/repositories/25195" alt="santifer%2Fcareer-ops | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
+
+<p align="center"><sub>OMTALT I MEDIERNE</sub></p>
+
+<p align="center">
+  <a href="https://wired.com.gr/article/to-ai-ergaleio-pou-fernei-epanastasi-ston-tropo-pou-psachnoume-douleia/" rel="noopener noreferrer nofollow"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/press/wired-dark.svg"><img src="docs/press/wired.svg" alt="WIRED" height="32"></picture></a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://www.businessinsider.com/how-i-built-tool-filter-job-listings-landed-head-ai-2026-4" rel="noopener noreferrer nofollow"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/press/business-insider-dark.svg"><img src="docs/press/business-insider.svg" alt="Business Insider" height="32"></picture></a>
+</p>
+
+---
+
+<p align="center">
+  <img src="docs/demo.gif" alt="Career-Ops Demo" width="800">
+</p>
+
+<p align="center"><strong>740+ vurderede stillinger · 100+ skræddersyede CV'er · 1 drømmerolle landet</strong></p>
+
+<p align="center"><a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/Bliv_en_del_af_fællesskabet-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a></p>
+
+<p align="center">
+  <a href="https://claude.com/claude-code"><img src="https://img.shields.io/badge/Built_with-Claude_Code-000?style=for-the-badge&logo=anthropic&logoColor=white" alt="Built with Claude Code"></a>
+</p>
+
+<p align="center">
+  <sub>Virker også på ethvert CLI, der følger agent-skill-standarden</sub><br>
+  <img src="https://img.shields.io/badge/Claude_Code-000?style=flat&logo=anthropic&logoColor=white" alt="Claude Code">
+  <img src="https://img.shields.io/badge/OpenCode-111827?style=flat&logo=terminal&logoColor=white" alt="OpenCode">
+  <img src="https://img.shields.io/badge/Gemini_CLI-4285F4?style=flat&logo=google&logoColor=white" alt="Gemini CLI">
+  <img src="https://img.shields.io/badge/Codex-412991?style=flat&logo=openai&logoColor=white" alt="Codex">
+  <img src="https://img.shields.io/badge/Qwen-615CED?style=flat" alt="Qwen">
+  <img src="https://img.shields.io/badge/GitHub_Copilot-000?style=flat&logo=githubcopilot&logoColor=white" alt="GitHub Copilot">
+  <br>
+  <img src="https://img.shields.io/badge/Node.js-339933?style=flat&logo=node.js&logoColor=white" alt="Node.js">
+  <img src="https://img.shields.io/badge/Go-00ADD8?style=flat&logo=go&logoColor=white" alt="Go">
+  <img src="https://img.shields.io/badge/Playwright-2EAD33?style=flat&logo=playwright&logoColor=white" alt="Playwright">
+  <img src="https://img.shields.io/badge/Bubble_Tea-FF75B5?style=flat&logo=go&logoColor=white" alt="Bubble Tea">
+  <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT">
+  <a href="TRADEMARK.md"><img src="https://img.shields.io/badge/Trademark-Policy-blue.svg" alt="Trademark Policy"></a>
+</p>
+
+## Hvad er det
+
+Career-Ops ([career-ops.org](https://career-ops.org), også kendt som **careerops**) forvandler et hvilket som helst AI-CLI til en komplet kommandocentral for jobsøgning. I stedet for manuelt at spore ansøgninger i et regneark får du en AI-drevet pipeline, der:
+
+- **Vurderer stillinger** med et struktureret A–F-system (10 vægtede dimensioner)
+- **Genererer skræddersyede PDF'er** — ATS-optimerede CV'er tilpasset hver stilling
+- **Skanner portaler** automatisk (Greenhouse, Ashby, Lever, virksomheders karrieresider)
+- **Batch-behandler** — vurderer 10+ stillinger parallelt via sub-agenter
+- **Sporer alt** i én kilde til sandhed med datakonsistenstjek
+
+> **Vigtigt: dette er IKKE et værktøj til masseudsendelse af ansøgninger.** Career-ops er et filter — det hjælper dig med at finde de få stillinger blandt hundredvis, der er din tid værd. Systemet fraråder kraftigt at ansøge stillinger med en vurdering under 4,0/5. Din tid er værdifuld, og det samme er rekrutterens. Tjek altid efter, før du sender.
+
+Career-ops arbejder agentisk: Claude Code navigerer karrieresider med Playwright, vurderer match ved at ræsonnere over dit CV kontra stillingsopslaget (ikke via søgeordsmatchning) og tilpasser CV'et til hvert opslag.
+
+> **Bemærk: de første vurderinger bliver ikke perfekte.** Systemet kender dig endnu ikke. Giv det kontekst — dit CV, din karrierehistorik, eksempler på resultater, præferencer, styrker, hvad du vil undgå. Jo mere du giver det, jo bedre virker det. Betragt det som onboarding af en ny rekrutter: i den første uge skal den lære, hvem du er — derefter bliver den uvurderlig.
+
+Bygget af en, der brugte det til at vurdere 740+ stillinger, generere 100+ skræddersyede CV'er og lande en rolle som Head of Applied AI. [Læs hele case-studiet](https://santifer.io/career-ops-system).
+
+## Funktioner
+
+| Funktion                       | Beskrivelse                                                                                                                                     |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Auto-Pipeline**              | Indsæt URL → fuld vurdering + PDF + tracker-post                                                                                                |
+| **6-bloks vurdering**          | Rolleresumé, CV-match, niveaustrategi, lønundersøgelse, personalisering, interviewforberedelse (STAR+R)                                          |
+| **Interviewhistoriebank**      | Samler STAR+Reflection-historier — 5–10 mesterhistorier, der besvarer ethvert adfærdsspørgsmål                                                  |
+| **Forhandlingsscripts**        | Frameworks til lønforhandling, imødegåelse af geografisk rabat, udnyttelse af konkurrerende tilbud                                              |
+| **ATS-optimeret PDF**          | CV med søgeordsindsprøjtning, Space Grotesk + DM Sans-design                                                                                    |
+| **Portalskanner**              | 45+ virksomheder konfigureret (Anthropic, OpenAI, ElevenLabs, Retool, n8n…) + forespørgsler via Ashby, Greenhouse, Lever, Wellfound            |
+| **Batch-behandling**           | Parallel vurdering via `claude -p`-workers                                                                                                      |
+| **TUI-dashboard**              | Terminal-UI til at gennemse, filtrere og sortere pipelinen                                                                                       |
+| **Human-in-the-Loop**          | AI vurderer og anbefaler, du beslutter og handler. Systemet sender aldrig ansøgninger — det sidste ord er altid dit                            |
+| **Pipeline-integritet**        | Automatisk merge, deduplikering, statusnormalisering, datakvalitetstjek                                                                          |
+
+## Hurtig start
+
+**Hurtigste måde — én kommando:**
+
+```bash
+npx @santifer/career-ops init
+```
+
+> 💡 `npx` følger med [Node.js](https://nodejs.org) — det kører installationsprogrammet én gang uden at installere noget globalt. Har du ikke Node.js endnu? Installer det først.
+> (Bruger du allerede Claude Code / Gemini / Codex CLI? Så har du det allerede.)
+
+Dette kloner den nyeste version til `./career-ops` og installerer afhængighederne. Derefter:
+
+```bash
+cd career-ops
+claude   # eller gemini / codex / qwen / opencode — åbn dit AI-CLI her
+```
+
+**Ved første kørsel guider career-ops dig gennem opsætningen — CV, profil og målstillinger — udelukkende via samtale. Intet skal redigeres manuelt.**
+
+<details>
+<summary><b>Foretrækker du manuel opsætning? (git clone)</b></summary>
+
+```bash
+git clone https://github.com/santifer/career-ops.git
+cd career-ops && npm install
+npx playwright install chromium   # kun nødvendigt til PDF-generering
+claude   # åbn dit AI-CLI — første kørsel guider dig gennem onboarding
+```
+
+</details>
+
+> **Systemet er designet til, at Claude tilpasser det.** Tilstande, arketyper, vurderingsvægte, forhandlingsscripts — bed blot Claude om ændringer. Den læser de samme filer, den bruger, så den ved præcis, hvad der skal redigeres.
+
+Fuld opsætningsguide: [docs/SETUP.md](docs/SETUP.md).
+
+## Brug
+
+Career-ops er én slash-kommando med flere tilstande:
+
+```text
+/career-ops                    → Vis alle tilgængelige kommandoer
+/career-ops {indsæt stilling}  → Fuld auto-pipeline (vurdering + PDF + tracker)
+/career-ops scan               → Skan portaler for nye stillinger
+/career-ops pdf                → Generér ATS-optimeret CV
+/career-ops batch              → Batch-vurdering af flere stillinger
+/career-ops tracker            → Se status på ansøgninger
+/career-ops apply              → AI-assisteret udfyldning af ansøgningsformularer
+/career-ops pipeline           → Behandl kø af URL'er
+/career-ops contacto           → LinkedIn-besked
+/career-ops deep               → Dybdegående virksomhedsundersøgelse
+/career-ops training           → Vurdering af kursus/certificering
+/career-ops project            → Vurdering af porteføljeprojekt
+```
+
+Du kan også blot indsætte en stillings-URL eller dens tekst — career-ops registrerer det automatisk og kører hele pipelinen.
+
+## Sådan virker det
+
+```diagram
+Du indsætter en stillings-URL eller -beskrivelse
+        │
+        ▼
+┌──────────────────┐
+│  Arketype-       │  Klassificering: Frontend / Backend / DevOps / PM / SA / ML
+│  registrering    │
+└────────┬─────────┘
+         │
+┌────────▼─────────┐
+│  A–F-vurdering   │  Match, mangler, lønundersøgelse, STAR-historier
+│  (læser cv.md)   │
+└────────┬─────────┘
+         │
+    ┌────┼────┐
+    ▼    ▼    ▼
+ Rapport PDF Tracker
+  .md   .pdf  .tsv
+```
+
+## Forudkonfigurerede portaler
+
+Skanneren leveres med **45+ virksomheder** klar til skanning og **19 forespørgsler** via de største jobportaler. Kopiér `templates/portals.example.yml` til `portals.yml`, og tilføj dine egne:
+
+**AI Labs:** Anthropic, OpenAI, Mistral, Cohere, LangChain, Pinecone
+**Voice AI:** ElevenLabs, PolyAI, Parloa, Hume AI, Deepgram, Vapi, Bland AI
+**AI Platforms:** Retool, Airtable, Vercel, Temporal, Glean, Arize AI
+**Contact Center:** Ada, LivePerson, Sierra, Decagon, Talkdesk, Genesys
+**Enterprise:** Salesforce, Twilio, Gong, Dialpad
+**LLMOps:** Langfuse, Weights & Biases, Lindy, Cognigy, Speechmatics
+**Automation:** n8n, Zapier, Make.com
+**European:** Factorial, Attio, Tinybird, Clarity AI, Travelperk
+
+**Gennemsøgte portaler:** Ashby, Greenhouse, Lever, Wellfound, Workable, RemoteFront
+
+Som standard stoler `node scan.mjs` (`npm run scan`) på det, hvert ATS-feed returnerer. Nogle virksomheder lader forældede opslag blive stående, selv efter rekrutteringen er lukket. Brug `--verify` for at køre Playwright efter API-fasen og frasortere udløbne stillinger, før de tilføjes pipelinen:
+
+```bash
+node scan.mjs --verify          # token-fri søgning + liveness-verifikation via Playwright
+```
+
+Verifikationen er sekventiel og gælder kun nye stillinger (efter deduplikering), så omkostningen er begrænset.
+
+## Dashboard TUI
+
+Indbygget terminal-dashboard til visuel gennemgang af pipelinen:
+
+```bash
+cd dashboard
+go build -o career-dashboard .
+./career-dashboard --path ..
+```
+
+Funktioner: 6 filterfaner, 4 sorteringstilstande, grupperet/flad visning, doven indlæsning af forhåndsvisninger, statusændring inline.
+
+## Projektstruktur
+
+```text
+career-ops/
+├── AGENTS.md                    # Kanoniske instruktioner til agenten (alle CLI'er)
+├── CLAUDE.md                    # Claude Code-wrapper (importerer AGENTS.md)
+├── cv.md                        # Dit CV (opret denne fil)
+├── article-digest.md            # Dine resultatbeviser (valgfrit)
+├── config/
+│   └── profile.example.yml      # Profilskabelon
+├── modes/                       # 14 skill-tilstande
+│   ├── _shared.md               # Fælles kontekst (tilpas denne fil)
+│   ├── oferta.md                # Vurdering af én stilling
+│   ├── pdf.md                   # PDF-generering
+│   ├── scan.md                  # Portalskanner
+│   ├── batch.md                 # Batch-behandling
+│   └── ...
+├── templates/
+│   ├── cv-template.html         # ATS-optimeret CV-skabelon
+│   ├── portals.example.yml      # Konfigurationsskabelon til skanneren
+│   └── states.yml               # Kanoniske statusser
+├── batch/
+│   ├── batch-prompt.md          # Selvstændig worker-prompt
+│   └── batch-runner.sh          # Orkestratorscript
+├── dashboard/                   # Go TUI-viewer til pipelinen
+├── data/                        # Dine sporingsdata (gitignored)
+├── reports/                     # Vurderingsrapporter (gitignored)
+├── output/                      # Genererede PDF'er (gitignored)
+├── fonts/                       # Space Grotesk + DM Sans
+├── docs/                        # Dokumentation: opsætning, tilpasning, arkitektur
+└── examples/                    # Eksempel-CV, -rapport, -resultatbeviser
+```
+
+## Teknologistak
+
+![Claude Code](https://img.shields.io/badge/Claude_Code-000?style=flat&logo=anthropic&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-339933?style=flat&logo=node.js&logoColor=white)
+![Playwright](https://img.shields.io/badge/Playwright-2EAD33?style=flat&logo=playwright&logoColor=white)
+![Go](https://img.shields.io/badge/Go-00ADD8?style=flat&logo=go&logoColor=white)
+![Bubble Tea](https://img.shields.io/badge/Bubble_Tea-FF75B5?style=flat&logo=go&logoColor=white)
+
+- **Agent**: Claude Code med brugerdefinerede skills og tilstande
+- **PDF**: Playwright/Puppeteer + HTML-skabelon
+- **Skanner**: Playwright + Greenhouse API + WebSearch
+- **Dashboard**: Go + Bubble Tea + Lipgloss (Catppuccin Mocha-tema)
+- **Data**: Markdown-tabeller + YAML-konfiguration + TSV-filer til batches
+
+## Også open source
+
+- **[cv-santiago](https://github.com/santifer/cv-santiago)** — Porteføljeside (santifer.io) med AI-chatbot, LLMOps-dashboard og case-studier. Har du brug for en portefølje til din jobsøgning, så fork den og tilpas den til dig selv.
+
+## Om forfatteren
+
+Jeg hedder Santiago — Head of Applied AI, tidligere founder (jeg byggede og solgte en virksomhed, der stadig kører med mit navn). Jeg byggede career-ops til at styre min egen jobsøgning. Det virkede: jeg brugte det til at lande min nuværende rolle.
+
+Min portefølje og andre open source-projekter → [santifer.io](https://santifer.io)
+
+## Stjernehistorik
+
+<a href="https://www.star-history.com/?repos=santifer%2Fcareer-ops&type=timeline&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=santifer/career-ops&type=timeline&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=santifer/career-ops&type=timeline&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=santifer/career-ops&type=timeline&legend=top-left" />
+ </picture>
+</a>
+
+## Juridisk ansvarsfraskrivelse
+
+**career-ops er et lokalt open source-værktøj, IKKE en hostingtjeneste.** Ved at bruge denne software anerkender du:
+
+1. **Du kontrollerer dine data.** Dit CV, dine kontaktoplysninger og personlige data forbliver på din computer og sendes direkte til den AI-udbyder, du vælger (Anthropic, OpenAI osv.). Vi indsamler, opbevarer eller har ikke adgang til dine data.
+2. **Du kontrollerer AI'en.** Standardprompterne instruerer AI'en i ikke at sende ansøgninger automatisk, men AI-modeller kan opføre sig uforudsigeligt. Du ændrer prompter på eget ansvar. **Tjek altid AI-genereret indhold, før du sender.**
+3. **Du overholder tredjeparters vilkår.** Brug værktøjet i overensstemmelse med servicevilkårene for de tjenester, du interagerer med (Greenhouse, Lever, jobindex.dk, LinkedIn osv.). Brug det ikke til at spamme arbejdsgivere.
+4. **Ingen garanti.** Vurderinger er anbefalinger, ikke sandheder. AI-modeller kan hallucinere. Forfatterne er ikke ansvarlige for rekrutteringsresultater, afviste ansøgninger, kontobegrænsninger eller andre konsekvenser.
+
+Detaljer: [LEGAL_DISCLAIMER.md](LEGAL_DISCLAIMER.md). Softwaren leveres under [MIT-licensen](LICENSE) "som den er", uden nogen form for garanti.
+
+## Bidragydere
+
+<a href="https://github.com/santifer/career-ops/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=santifer/career-ops" alt="Bidragydere" />
+</a>
+
+Fandt du job med career-ops? [Del din historie!](https://github.com/santifer/career-ops/issues/new?template=i-got-hired.yml)
+
+## Licens og varemærke
+
+Koden er licenseret under [MIT](LICENSE). Navnet og brandet "career-ops" er reguleret af [Varemærkepolitikken](TRADEMARK.md) — tilladt til fællesskabsbrug, forbeholdt kommerciel produktnavngivning og endorsement.
+
+## Lad os forbinde
+
+[![Website](https://img.shields.io/badge/santifer.io-000?style=for-the-badge&logo=safari&logoColor=white)](https://santifer.io)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://linkedin.com/in/santifer)
+[![X](https://img.shields.io/badge/X-000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/santifer)
+[![Discord](https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/8pRpHETxa4)
+[![Email](https://img.shields.io/badge/Email-EA4335?style=for-the-badge&logo=gmail&logoColor=white)](mailto:hi@santifer.io)

--- a/README.es.md
+++ b/README.es.md
@@ -1,6 +1,6 @@
 # Career-Ops
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="center">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops Sistema Multi-Agente de Busqueda de Empleo" width="800"></a>

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,6 +1,6 @@
 # Career-Ops
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="center">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Système de recherche d'emploi multi-agent Career-Ops" width="800"></a>

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # Career-Ops
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="center">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops マルチエージェント求職システム" width="800"></a>

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -1,6 +1,6 @@
 # Career-Ops
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="center">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops 멀티 에이전트 취업 시스템" width="800"></a>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Career-Ops
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="center">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops Multi-Agent Job Search System" width="800"></a>

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,6 +1,6 @@
 # Career-Ops
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="center">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops — Wieloagentowy system poszukiwania pracy" width="800"></a>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,6 +1,6 @@
 # Career-Ops
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="center">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops Multi-Agent Job Search System" width="800"></a>

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,6 +1,6 @@
 # Career-Ops
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="center">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops Мультиагентная система поиска работы" width="800"></a>

--- a/README.ua.md
+++ b/README.ua.md
@@ -1,6 +1,6 @@
 # Career-Ops
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="center">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops Multi-Agent Система Пошуку Роботи" width="800"></a>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # Career-Ops
 
-[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [العربية](README.ar.md)
+[English](README.md) | [Español](README.es.md) | [Français](README.fr.md) | [Português (Brasil)](README.pt-BR.md) | [한국어](README.ko-KR.md) | [日本語](README.ja.md) | [简体中文](README.cn.md) | [繁體中文](README.zh-TW.md) | [Українська](README.ua.md) | [Русский](README.ru.md) | [Polski](README.pl.md) | [Dansk](README.da.md) | [العربية](README.ar.md)
 
 <p align="center">
   <a href="https://x.com/santifer"><img src="docs/hero-banner.jpg" alt="Career-Ops 多代理求職系統" width="800"></a>

--- a/modes/da/README.md
+++ b/modes/da/README.md
@@ -1,0 +1,103 @@
+# career-ops -- Danske modes (`modes/da/`)
+
+Denne mappe indeholder de danske oversættelser af de vigtigste career-ops-modes for kandidater, der søger på det danske marked.
+
+## Hvornår skal du bruge disse modes?
+
+Brug `modes/da/`, hvis mindst én af disse betingelser er opfyldt:
+
+- Du søger primært **jobopslag på dansk** (Jobindex, The Hub, LinkedIn DK, virksomhedernes karrieresider, Jobnet)
+- Dit **CV er på dansk**, eller du skifter mellem DA og EN afhængigt af opslaget
+- Du har brug for svar og ansøgninger på **naturligt tech-dansk**, ikke maskinoversat
+- Du skal håndtere **danske kontraktspecifikke forhold**: overenskomst, funktionærloven, ferie efter ferieloven, opsigelsesvarsel, prøvetid, pension, feriepenge, A-kasse, fagforening
+
+Hvis de fleste af dine opslag er på engelsk, så bliv ved standard-modes i `modes/`. De engelske modes fungerer til danske opslag, men de kender ikke det danske markeds særtræk i detaljen.
+
+## Hvordan aktiverer du dem?
+
+### Mulighed 1 -- Per session
+
+Sig til Claude i starten af sessionen:
+
+> "Brug de danske modes under `modes/da/`."
+
+Claude vil så læse filerne i denne mappe i stedet for `modes/`.
+
+### Mulighed 2 -- Permanent
+
+Tilføj i `config/profile.yml`:
+
+```yaml
+language:
+  primary: da
+  modes_dir: modes/da
+```
+
+Mind Claude om det i din første session ("Kig i `profile.yml`, jeg har konfigureret `language.modes_dir`"). Claude bruger så automatisk de danske modes.
+
+## Hvilke modes er oversat?
+
+Denne første iteration dækker de fire modes med størst effekt:
+
+| Fil | Oversat fra | Rolle |
+|-----|-------------|-------|
+| `_shared.md` | `modes/_shared.md` (EN) | Delt kontekst, arketyper, globale regler, særtræk ved det danske marked |
+| `oferta.md` | `modes/oferta.md` (ES) | Fuld evaluering af et opslag (Blok A-F) |
+| `apply.md` | `modes/apply.md` (EN) | Live-assistent til udfyldelse af ansøgningsformularer |
+| `pipeline.md` | `modes/pipeline.md` (ES) | URL-indbakke / Second Brain til indsamlede opslag |
+
+De øvrige modes (`scan`, `batch`, `pdf`, `tracker`, `auto-pipeline`, `deep`, `contacto`, `ofertas`, `project`, `training`) forbliver på EN/ES. Deres indhold er primært tooling, stier og kommandoer -- det skal forblive sproguafhængigt.
+
+## Hvad forbliver på engelsk
+
+Bevidst ikke oversat, fordi det er standard tech-ordforråd:
+
+- `cv.md`, `pipeline`, `tracker`, `report`, `score`, `archetype`, `proof point`
+- Værktøjsnavne (`Playwright`, `WebSearch`, `WebFetch`, `Read`, `Write`, `Edit`, `Bash`)
+- Statusværdier i trackeren (`Evaluated`, `Applied`, `Interview`, `Offer`, `Rejected`)
+- Kodeuddrag, stier, kommandoer
+
+Modes bruger naturligt tech-dansk, sådan som det tales i engineering-teams i København, Aarhus eller Odense: løbende tekst på dansk, tekniske termer på engelsk dér, hvor det er normen. Ingen tvungen oversættelse af "Pipeline" til "Rørledning" eller "Deploy" til "Udrulning".
+
+## Referenceordliste
+
+For at holde tonen konsistent, hvis du ændrer eller udvider modes:
+
+| Engelsk | Dansk (i denne codebase) |
+|---------|--------------------------|
+| Job posting | Jobopslag / Stillingsopslag |
+| Application | Ansøgning |
+| Cover letter | Ansøgning (motiveret) / Følgebrev |
+| Resume / CV | CV |
+| Salary | Løn / Aflønning |
+| Compensation | Aflønning / Pakke |
+| Skills | Kompetencer |
+| Interview | Samtale / Jobsamtale |
+| Hiring manager | Ansættende leder / Hiring manager |
+| Recruiter | Rekrutteringskonsulent (eller Recruiter) |
+| AI | AI (kunstig intelligens) |
+| Requirements | Krav / Forudsætninger |
+| Career history | Karriereforløb / Erhvervserfaring |
+| Notice period | Opsigelsesvarsel |
+| Probation | Prøvetid |
+| Vacation | Ferie |
+| Holiday pay | Feriepenge |
+| Permanent employment | Fastansættelse (tidsubegrænset) |
+| Fixed-term contract | Tidsbegrænset ansættelse |
+| Freelance | Freelance / Selvstændig |
+| Collective agreement | Overenskomst |
+| Salaried-employee act | Funktionærloven |
+| Holiday act | Ferieloven |
+| Trade union | Fagforening |
+| Unemployment insurance fund | A-kasse |
+| Pension | Pension (arbejdsgiverbidrag) |
+
+## Bidrag
+
+For at forbedre en oversættelse eller tilføje en mode:
+
+1. Åbn en Issue med dit forslag (se `CONTRIBUTING.md`)
+2. Følg ordlisten ovenfor for at holde tonen konsistent
+3. Oversæt idiomatisk -- ingen ord-for-ord-oversættelse
+4. Bevar de strukturelle elementer (Blok A-F, tabeller, kodeblokke, værktøjsinstruktioner) uændret
+5. Test med et rigtigt dansk opslag (Jobindex, The Hub, LinkedIn DK), før du sender din PR

--- a/modes/da/_shared.md
+++ b/modes/da/_shared.md
@@ -1,0 +1,203 @@
+# Delt kontekst -- career-ops (Dansk)
+
+<!-- ============================================================
+     TILPASNING AF DENNE FIL
+     ============================================================
+     Denne fil indeholder den delte kontekst for alle career-ops-modes
+     i den danske version. Før du bruger career-ops, SKAL du:
+     1. Udfylde config/profile.yml med dine personlige oplysninger
+     2. Oprette cv.md i projektets rod (CV i Markdown)
+     3. (Valgfrit) Oprette article-digest.md med dine proof points
+     4. Tilpasse de afsnit, der er markeret med [TILPAS] nedenfor
+     ============================================================ -->
+
+## Kilder til sandhed (læs ALTID før hver evaluering)
+
+| Fil | Sti | Hvornår |
+|-----|-----|---------|
+| cv.md | `cv.md` (projektets rod) | ALTID |
+| article-digest.md | `article-digest.md` (hvis den findes) | ALTID (detaljerede proof points) |
+| profile.yml | `config/profile.yml` | ALTID (identitet og målroller) |
+
+**REGEL: Aldrig hardcode metrics fra proof points.** Læs dem fra `cv.md` og `article-digest.md` på evalueringstidspunktet.
+**REGEL: For metrics om artikler/projekter har `article-digest.md` forrang frem for `cv.md`** (`cv.md` kan indeholde ældre tal).
+
+---
+
+## North Star -- Målroller
+
+Dette skill behandler ALLE målroller med samme omhu. Ingen er primær eller sekundær -- hver enkelt er en succes, hvis aflønning og udviklingsmuligheder er til stede:
+
+| Arketype | Tematiske akser | Hvad virksomheden køber |
+|----------|-----------------|-------------------------|
+| **AI Platform / LLMOps Engineer** | Evaluation, Observability, Pålidelighed, Pipelines | En der sætter AI i produktion med metrics |
+| **Agentic Workflows / Automation** | HITL, Tooling, Orkestrering, Multi-Agent | En der bygger pålidelige agent-systemer |
+| **Technical AI Product Manager** | GenAI/Agents, PRDs, Discovery, Delivery | En der oversætter forretning til AI-produkter |
+| **AI Solutions Architect** | Hyperautomation, Enterprise, Integrationer | En der designer end-to-end AI-arkitekturer |
+| **AI Forward Deployed Engineer** | Client-facing, Hurtig levering, Prototyping | En der hurtigt udruller AI-løsninger hos kunden |
+| **AI Transformation Lead** | Forandringsledelse, Adoption, Enablement | En der driver AI-transformation i organisationer |
+
+<!-- [TILPAS] Tilpas arketyperne ovenfor til dine målroller.
+     Eksempel for backend engineering:
+     - Senior Backend Engineer
+     - Staff Platform Engineer
+     - Engineering Manager
+     osv. -->
+
+### Adaptiv framing efter arketype
+
+> **Konkrete metrics: læs dem fra `cv.md` og `article-digest.md` på evalueringstidspunktet. ALDRIG hardcode dem her.**
+
+| Hvis rollen er... | Fremhæv hos kandidaten... | Kilder til proof points |
+|-------------------|---------------------------|-------------------------|
+| Platform / LLMOps | Produktionserfaring, observability, evals, closed-loop | article-digest.md + cv.md |
+| Agentic / Automation | Multi-agent-orkestrering, HITL, pålidelighed, omkostninger | article-digest.md + cv.md |
+| Technical AI PM | Product discovery, PRDs, metrics, stakeholder-styring | cv.md + article-digest.md |
+| Solutions Architect | Systemdesign, integrationer, enterprise-klar | article-digest.md + cv.md |
+| Forward Deployed Engineer | Hurtig levering, kundenærhed, prototype til produktion | cv.md + article-digest.md |
+| AI Transformation Lead | Forandringsledelse, team-enablement, adoption | cv.md + article-digest.md |
+
+<!-- [TILPAS] Knyt dine konkrete projekter/artikler til arketyperne ovenfor -->
+
+### Overgangsnarrativ (skal bruges i ALLE framings)
+
+<!-- [TILPAS] Erstat med dit eget narrativ. Eksempler:
+     - "SaaS bygget og solgt efter 5 år. Nu 100% fokus på anvendt AI i enterprise."
+     - "Engineering-lead i en Series-B under 10x vækst. Søger den næste udfordring."
+     - "Skift fra konsulent til produkt. Søger roller med højt ansvar."
+     Læses fra config/profile.yml -> narrative.exit_story -->
+
+Brug overgangsnarrativet fra `config/profile.yml` til at ramme ALT indhold ind:
+- **I PDF-summaries:** Byg bro mellem fortid og fremtid -- "Anvender nu de samme [kompetencer] på [opslagets domæne]."
+- **I STAR-stories:** Referér til proof points fra `article-digest.md`.
+- **I draft-svar (Blok G):** Overgangsnarrativet hører til i det første svar.
+- **Når opslaget nævner "entrepreneurial", "ownership", "builder", "end-to-end":** Det er DEN vigtigste differentiator nr. 1. Øg match-vægten.
+
+### Tværgående fordel
+
+Ram profilen ind som **"Teknisk builder med dokumenteret praksis"**, og tilpas framingen til rollen:
+- For PM: "Builder, der reducerer usikkerhed med prototyper og derefter leverer disciplineret i produktion"
+- For FDE: "Builder, der leverer fra dag 1 med observability og metrics"
+- For SA: "Builder, der designer end-to-end-systemer med ægte integrationserfaring"
+- For LLMOps: "Builder, der sætter AI i produktion med closed-loop kvalitetssystemer"
+
+Positionér "Builder" som et professionelt signal -- ikke som "hobbyist". De ægte proof points gør det troværdigt.
+
+### Portfolio som proof point (brug ved ansøgninger med høj indsats)
+
+<!-- [TILPAS] Hvis du har en live demo, et dashboard eller et offentligt projekt, så konfigurér det her.
+     Eksempel:
+     dashboard:
+       url: "https://ditdomæne.dev/demo"
+       password: "demo-2026"
+       when_to_share: "LLMOps, AI Platform, Observability-roller"
+     Læses fra config/profile.yml -> narrative.proof_points og narrative.dashboard -->
+
+Hvis kandidaten har en live demo / et dashboard (tjek `profile.yml`), så tilbyd adgang i relevante ansøgninger.
+
+### Lønintelligens (Comp Intelligence)
+
+<!-- [TILPAS] Undersøg lønintervaller for dine målroller og tilpas værdierne -->
+
+**Generelle råd:**
+- WebSearch for aktuelle markedsdata (Glassdoor, Levels.fyi, Jobindex Lønstatistik, IDA Lønstatistik, PROSA)
+- Ram ind efter jobtitel, ikke efter kompetencer -- titler definerer lønbåndene
+- Freelance-satser i Danmark ligger typisk 30-50% over den tilsvarende brutto-timeløn i en fastansættelse (sociale bidrag, ferie, sygdom, opsøgende arbejde)
+- Geo-arbitrage fungerer i remote: lavere leveomkostninger = bedre netto
+
+### Det danske marked -- Særtræk (VIGTIGT)
+
+I danske opslag og forhandlinger optræder visse termer, som ikke findes på EN/ES-markederne. De SKAL håndteres korrekt:
+
+| Term | Betydning | Effekt på evaluering |
+|------|-----------|----------------------|
+| **Fastansættelse** (tidsubegrænset) | Svarer til "permanent employment". Standarden i Danmark | Forventet standard. En tidsbegrænset kontrakt til en senior er et advarselssignal |
+| **Tidsbegrænset ansættelse** | Midlertidig kontrakt med fast slutdato | Acceptabel til specifikke opgaver. Ellers spørg hvorfor ikke fastansættelse |
+| **Prøvetid** | Typisk 3 måneder, kortere opsigelsesvarsel | Markedsstandard. Flag hvis > 3 måneder |
+| **Opsigelsesvarsel** | 1-6 måneder efter funktionærloven afhængigt af anciennitet | Planlæg startdato derefter |
+| **Funktionærloven** | Lov der regulerer funktionærers ansættelse (opsigelse, sygdom, fratrædelsesgodtgørelse) | Næsten alle tech-stillinger er funktionærstillinger. Tjek om det nævnes |
+| **Overenskomst** | Kollektiv aftale mellem fagforening og arbejdsgiver. Fastsætter løn, vilkår | Tjek om virksomheden har overenskomst -- giver fast løntrin, pension, sikkerhed |
+| **Feriepenge** | 12,5% af lønnen optjent til ferie efter ferieloven | Indgår i den samlede pakke. Glem ALDRIG i sammenligningen |
+| **Ferie** | 25 dage (5 uger) efter ferieloven. Mange giver flere | < 25 dage = under lovens minimum. 25 + feriefridage = standard i tech. > 30 dage = fremragende |
+| **Feriefridage** | Ekstra fridage ud over ferielovens 5 uger (ofte 5/år) | Et reelt plus. Svarer til 1 uges ekstra ferie |
+| **Pension** | Arbejdsgiverbidrag, typisk 8-12% af lønnen | Indgår i comp-beregningen: kan udgøre flere tusind kroner månedligt. Glem den ikke |
+| **A-kasse** | Frivillig arbejdsløshedsforsikring (medlemskab betales af medarbejderen) | Ikke et arbejdsgivergode, men relevant for jobsikkerhed. Tjek opsigelsesvilkår |
+| **Fagforening** | Faglig organisation (fx PROSA, IDA for ingeniører/IT) | Medlemskab giver juridisk hjælp og overenskomstdækning. Plus for stabilitet |
+| **Bruttoløn / Nettoløn** | Løn før / efter skat (dansk skat er høj, ~37-52%) | Forhandl altid om bruttoløn. Beregn netto til sammenligning af leveomkostninger |
+| **13. månedsløn** | Findes typisk IKKE i Danmark (i modsætning til mange markeder) | Forvent den ikke. Hvis nævnt, er det et ekstra plus -- inkludér i comp |
+
+### Forhandlingsscripts
+
+<!-- [TILPAS] Tilpas til din situation -->
+
+**Lønforventning (generelt framework):**
+> "På baggrund af aktuelle markedsdata for denne type stilling sigter jeg efter intervallet [INTERVAL fra profile.yml]. Jeg er fleksibel omkring strukturen -- det er den samlede pakke og udviklingsmulighederne, der tæller."
+
+**Modsvar på et geografisk fradrag:**
+> "De roller, jeg er i konkurrence om, er resultatorienterede, ikke lokationsbestemte. Min track record ændrer sig ikke med postnummeret."
+
+**Hvis tilbuddet ligger under målet:**
+> "Jeg er i øjeblikket i dialog om pakker i intervallet [højere interval]. [Virksomhed] tiltrækker mig på grund af [grund]. Er det muligt at nå [mål]?"
+
+**Forhandling om pension / variabel løn:**
+> "For at sammenligne pakkerne retfærdigt -- kunne I specificere den faste bruttoløn, pensionsbidraget og en eventuel variabel del hver for sig?"
+
+### Lokationspolitik (Location Policy)
+
+<!-- [TILPAS] Tilpas til din situation. Læses fra config/profile.yml -> location -->
+
+**I formularer:**
+- Binære spørgsmål "Kan du være på kontoret?": svar efter den reelle tilgængelighed i `profile.yml`
+- Fritekstfelter: angiv tidszoneoverlap og tilgængelighed eksplicit
+
+**I evalueringer (scoring):**
+- Remote-dimension for hybrid uden for dit land: Score **3.0** (ikke 1.0)
+- Score 1.0 kun, hvis opslaget eksplicit siger "obligatorisk tilstedeværelse 4-5 dage/uge, ingen undtagelser"
+
+### Time-to-offer-prioritet
+- Fungerende demo + metrics > perfektion
+- Ansøg hurtigt > lær mere
+- 80/20-tilgang, alt er timeboxet
+
+---
+
+## Globale regler
+
+### ALDRIG
+
+1. Opfinde erfaring eller metrics
+2. Ændre `cv.md` eller portfolio-filer
+3. Indsende ansøgninger på kandidatens vegne
+4. Dele et telefonnummer i genererede beskeder
+5. Anbefale aflønning under markedsniveau
+6. Generere en PDF uden at have læst opslaget først
+7. Bruge corporate-jargon eller tomme floskler
+8. Ignorere trackeren (hvert evalueret opslag registreres)
+
+### ALTID
+
+0. **Ansøgning (følgebrev):** Hvis formularen tillader det, så inkludér ALTID én. PDF i samme visuelle design som CV'et. Citater fra opslaget mappet til proof points. Maks. 1 side.
+1. Læs `cv.md` og `article-digest.md` (hvis den findes), før et opslag evalueres
+1b. **Første evaluering i hver session:** Kør `node cv-sync-check.mjs` via Bash. Ved advarsler, informér kandidaten
+2. Detektér rollens arketype og tilpas framingen
+3. Citér eksakte linjer fra CV'et ved matching
+4. Brug WebSearch til løn- og virksomhedsdata
+5. Registrér i trackeren efter hver evaluering
+6. Generér indhold på opslagets sprog (dansk hvis opslaget er på dansk, ellers engelsk)
+7. Vær direkte og konkret -- ingen smøren
+8. Naturligt tech-dansk til genererede tekster. Korte sætninger, aktive verber, undgå passiv. Oversæt ikke tekniske termer med tvang (stack, pipeline, deployment, embedding)
+8b. **Case-study-URL'er i PDF'ens Professional Summary:** Hvis PDF'en nævner case studies eller demoer, SKAL URL'erne optræde i det første afsnit (Professional Summary). Rekrutterere læser ofte kun summary. Alle URL'er i HTML med `white-space: nowrap`
+9. **Tracker-poster som TSV** -- rediger ALDRIG applications.md direkte for nye tilføjelser. Skriv TSV i `batch/tracker-additions/`, `merge-tracker.mjs` håndterer sammenfletningen
+10. **`**URL:**` i hver report-header** -- mellem Score og PDF
+
+### Værktøjer
+
+| Værktøj | Brug |
+|---------|------|
+| WebSearch | Lønundersøgelse, tendenser, virksomhedskultur, LinkedIn-kontakter, fallback for opslag |
+| WebFetch | Fallback til at udtrække opslag fra statiske sider |
+| Playwright | Tjek om opslag er aktive (browser_navigate + browser_snapshot), udtræk opslag fra SPAs. **KRITISK: ALDRIG 2+ agenter parallelt med Playwright -- de deler den samme browser-instans** |
+| Read | cv.md, article-digest.md, cv-template.html |
+| Write | Midlertidig HTML til PDF, applications.md, reports .md |
+| Edit | Opdatér trackeren |
+| Bash | `node generate-pdf.mjs` |

--- a/modes/da/apply.md
+++ b/modes/da/apply.md
@@ -1,0 +1,114 @@
+# Mode: apply -- Live-assistent til ansøgningsformularer
+
+Interaktiv mode til det øjeblik, hvor kandidaten udfylder en ansøgningsformular i Chrome. Den læser, hvad der er på skærmen, indlæser konteksten fra opslagets tidligere evaluering og genererer personaliserede svar til hvert spørgsmål i formularen.
+
+## Forudsætninger
+
+- **Bedst med Playwright synlig**: I synlig tilstand ser kandidaten browseren, og Claude kan interagere med siden.
+- **Uden Playwright**: kandidaten deler et skærmbillede eller indsætter spørgsmålene manuelt.
+
+## Workflow
+
+```
+1. DETEKTÉR     -> Læs den aktive Chrome-fane (skærmbillede/URL/titel)
+2. IDENTIFICÉR  -> Udtræk virksomhed + rolle fra siden
+3. SØG          -> Match mod eksisterende reports i reports/
+4. INDLÆS       -> Læs den fulde report + Blok G (hvis den findes)
+5. SAMMENLIGN   -> Svarer rollen på skærmen til den evaluerede? Hvis ændret -> advar
+6. ANALYSÉR     -> Identificér ALLE synlige spørgsmål i formularen
+7. GENERÉR      -> Generér et personaliseret svar til hvert spørgsmål
+8. PRÆSENTÉR    -> Vis de formaterede svar til copy-paste
+```
+
+## Trin 1 -- Detektér opslaget
+
+**Med Playwright:** Snapshot af den aktive side. Læs titel, URL og synligt indhold.
+
+**Uden Playwright:** Bed kandidaten om at:
+- Dele et skærmbillede af formularen (Read-værktøjet læser billeder)
+- Eller indsætte formularens spørgsmål som tekst
+- Eller angive virksomhed + rolle, så vi kan finde konteksten
+
+## Trin 2 -- Identificér og indlæs konteksten
+
+1. Udtræk virksomhedens navn og stillingstitlen fra siden
+2. Søg i `reports/` efter virksomhedsnavn (Grep case-insensitive)
+3. Hvis match -> indlæs den fulde report
+4. Hvis Blok G findes -> indlæs de tidligere svar-udkast som grundlag
+5. Hvis INTET match -> advar kandidaten og foreslå en hurtig auto-pipeline
+
+## Trin 3 -- Detektér rolleændringer
+
+Hvis rollen på skærmen afviger fra den evaluerede:
+- **Advar kandidaten**: "Rollen har ændret sig fra [X] til [Y]. Ønsker du, at jeg genevaluerer, eller at jeg tilpasser svarene til den nye titel?"
+- **Hvis tilpas**: Justér svarene til den nye rolle uden at genevaluere
+- **Hvis genevaluér**: Kør den fulde A-F-evaluering, opdatér report, regenerér Blok G
+- **Opdatér trackeren**: Ret rollens titel i applications.md om nødvendigt
+
+## Trin 4 -- Analysér formularens spørgsmål
+
+Identificér ALLE synlige spørgsmål:
+- Fritekstfelter (følgebrev, "hvorfor denne stilling", motivation, osv.)
+- Dropdowns (hvordan hørte du om virksomheden, arbejdstilladelse, osv.)
+- Ja/Nej (mobilitet, visum, tilgængelighed, osv.)
+- Lønfelter (interval, lønforventning -- i brutto årsløn for Danmark)
+- Upload-felter (CV, følgebrev som PDF, referencer)
+
+Klassificér hvert spørgsmål:
+- **Allerede besvaret i Blok G** -> genbrug det eksisterende svar
+- **Nyt spørgsmål** -> generér svaret fra report + `cv.md`
+
+## Trin 5 -- Generér svarene
+
+For hvert spørgsmål, byg svaret efter dette skema:
+
+1. **Kontekst fra report**: Brug proof points fra blok B, STAR-stories fra blok F
+2. **Tidligere Blok G**: Hvis et udkast findes, så brug det som grundlag og finpuds
+3. **Tonen "Jeg vælger jer"**: samme framework som i auto-pipeline -- selvsikker, ikke bønfaldende
+4. **Specificitet**: citér noget konkret fra opslaget, der er synligt på skærmen
+5. **career-ops proof point**: inkludér i "Yderligere oplysninger", hvis et sådant felt findes
+
+**Felter, der er specifikke for almindelige danske formularer:**
+- **Lønforventning (brutto årsløn)** -> Interval fra `profile.yml`, i DKK, med bemærkningen "forhandlelig afhængigt af den samlede pakke"
+- **Startdato** -> Realistisk dato, der tager højde for opsigelsesvarsel (ofte 1-3 måneder)
+- **Arbejdstilladelse / Nationalitet** -> Ærligt og kortfattet; for EU-borgere: "Ingen opholdstilladelse påkrævet (EU-borger)"
+- **Sprog** -> Niveauer efter CEFR (A1-C2)
+- **Mobilitet** -> Angiv det acceptable geografiske område og hyppigheden af rejser
+
+**Output-format:**
+
+```
+## Svar til [Virksomhed] -- [Rolle]
+
+Grundlag: Report #NNN | Score: X.X/5 | Arketype: [type]
+
+---
+
+### 1. [Eksakt spørgsmål fra formularen]
+> [Svar klar til copy-paste]
+
+### 2. [Næste spørgsmål]
+> [Svar]
+
+...
+
+---
+
+Noter:
+- [Observationer om rollen, ændringer, osv.]
+- [Forslag til personalisering, som kandidaten bør tjekke]
+```
+
+## Trin 6 -- Efter ansøgningen (valgfrit)
+
+Hvis kandidaten bekræfter, at ansøgningen er sendt:
+1. Opdatér status i `applications.md` fra "Evaluated" til "Applied"
+2. Opdatér report'ens Blok G med de endelige svar
+3. Foreslå næste trin: `/career-ops contacto` til LinkedIn-outreach mod den ansættende leder
+
+## Håndtering af scroll
+
+Hvis formularen har flere spørgsmål, end der er synlige:
+- Bed kandidaten om at scrolle og dele endnu et skærmbillede
+- Eller indsætte de resterende spørgsmål
+- Behandl i iterationer, indtil hele formularen er dækket

--- a/modes/da/oferta.md
+++ b/modes/da/oferta.md
@@ -1,0 +1,166 @@
+# Mode: oferta -- Fuld evaluering A-F
+
+Når kandidaten indsætter et opslag (tekst eller URL), så lever ALTID alle 6 blokke.
+
+## Trin 0 -- Arketype-detektion
+
+Klassificér opslaget i en af de 6 arketyper (se `_shared.md`). Hvis hybrid, så angiv de 2 nærmeste. Det afgør:
+- Hvilke proof points der prioriteres i blok B
+- Hvordan summary omskrives i blok E
+- Hvilke STAR-stories der forberedes i blok F
+
+## Blok A -- Rolleopsummering
+
+Tabel med:
+- Detekteret arketype
+- Domain (Platform / Agentic / LLMOps / ML / Enterprise)
+- Funktion (Build / Consult / Manage / Deploy)
+- Senioritet
+- Remote (Fuld remote / Hybrid / På kontoret)
+- Teamstørrelse (hvis nævnt)
+- TL;DR i 1 sætning
+
+## Blok B -- Match med CV'et
+
+Læs `cv.md`. Lav en tabel, hvor hvert krav i opslaget mappes til eksakte linjer i CV'et.
+
+**Tilpasset arketypen:**
+- FDE -> prioritér proof points om hurtig levering og kundenærhed
+- SA -> prioritér systemdesign og integrationer
+- PM -> prioritér product discovery og metrics
+- LLMOps -> prioritér evals, observability, pipelines
+- Agentic -> prioritér multi-agent, HITL, orkestrering
+- Transformation -> prioritér forandringsledelse, adoption, skalering
+
+Afsnit om **Mangler (Gaps)** med en mitigeringsstrategi for hver enkelt. For hver mangel:
+1. Er det en hard blocker eller et nice-to-have?
+2. Kan kandidaten påvise tilstødende erfaring?
+3. Findes der et portfolio-projekt, der dækker manglen?
+4. Konkret mitigeringsplan (sætning til følgebrevet, hurtigt mini-projekt, osv.)
+
+## Blok C -- Niveau og strategi
+
+1. **Detekteret niveau** i opslaget vs **kandidatens naturlige niveau for denne arketype**
+2. **Plan "sælg senior uden at lyve"**: konkrete formuleringer tilpasset arketypen, konkrete resultater at fremhæve, hvordan founder-erfaring positioneres som en fordel
+3. **Plan "hvis jeg bliver downlevelet"**: accepter, hvis aflønningen er fair, forhandl en revision efter 6 måneder, klare forfremmelseskriterier
+
+## Blok D -- Aflønning og efterspørgsel
+
+Brug WebSearch til:
+- Aktuelle lønninger for rollen (Glassdoor, Levels.fyi, Jobindex Lønstatistik, IDA Lønstatistik, PROSA)
+- Virksomhedens lønreputation (Glassdoor)
+- Efterspørgselstendens for rollen på det danske marked
+
+Tabel med data og citerede kilder. Hvis der ingen data er, så sig det klart -- opfind ikke noget.
+
+**Det danske marked -- Obligatoriske tjek:**
+- Pension nævnt? Indregn arbejdsgiverbidraget (typisk 8-12%) i den samlede pakke.
+- Variabel del (bonus, provision, warrants / aktieoptioner)?
+- Feriepenge / feriefridage ud over ferielovens minimum?
+- Overenskomst eller funktionærvilkår? Hvis overenskomst: tjek løntrin og vilkår.
+- Fastansættelse eller tidsbegrænset? Hvis tidsbegrænset: varighed, begrundelse, mulighed for fastansættelse.
+- Freelance / selvstændig? Dagssats, opgavens varighed, risiko for omklassificering.
+
+## Blok E -- Personaliseringsplan
+
+| # | Sektion | Nuværende tilstand | Foreslået ændring | Begrundelse |
+|---|---------|--------------------|--------------------|-------------|
+| 1 | Summary | ... | ... | ... |
+| ... | ... | ... | ... | ... |
+
+Top 5 ændringer i CV'et + Top 5 ændringer på LinkedIn for at maksimere matchet.
+
+## Blok F -- Samtaleplan
+
+6-10 STAR+R-stories mappet til opslagets krav (STAR + **Reflection**):
+
+| # | Krav i opslaget | STAR+R-story | S | T | A | R | Reflection |
+|---|-----------------|--------------|---|---|---|---|------------|
+
+Kolonnen **Reflection** indfanger, hvad der blev lært, eller hvad der ville blive gjort anderledes. Det signalerer senioritet -- juniorer beskriver, hvad der skete, seniorer drager læring af det.
+
+**Story Bank:** Hvis `interview-prep/story-bank.md` findes, så tjek om disse stories allerede er der. Hvis ikke, så tilføj de nye. Med tiden opbygger det en genbrugelig bank på 5-10 master-stories, der kan tilpasses ethvert samtalespørgsmål.
+
+**Udvalgt og rammesat efter arketypen:**
+- FDE -> fremhæv leveringstempo og kundenærhed
+- SA -> fremhæv arkitekturbeslutninger
+- PM -> fremhæv discovery og trade-offs
+- LLMOps -> fremhæv metrics, evals, production hardening
+- Agentic -> fremhæv orkestrering, error handling, HITL
+- Transformation -> fremhæv adoption og organisatorisk forandring
+
+Inkludér også:
+- 1 anbefalet case study (hvilket projekt der præsenteres og hvordan)
+- Red-flag-spørgsmål og hvordan man besvarer dem (fx "Hvorfor solgte du din virksomhed?", "Havde du et team, der refererede til dig?", "Hvorfor et skifte efter så kort tid?")
+
+---
+
+## Efter evalueringen
+
+**ALTID** efter blok A-F skal du udføre:
+
+### 1. Gem report .md
+
+Gem den fulde evaluering i `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+
+- `{###}` = næste fortløbende nummer (3 cifre, nul-paddet). For at allokere det atomisk og undgå race conditions skal du køre `node reserve-report-num.mjs` for at reservere nummeret (stdout returnerer `{###}`), skrive rapporten og derefter køre `node reserve-report-num.mjs --release {###}` for at frigive sentinel'en.
+- `{company-slug}` = virksomhedsnavn i små bogstaver, uden mellemrum (brug bindestreger)
+- `{YYYY-MM-DD}` = dagens dato
+
+**Report-format:**
+
+```markdown
+# Evaluering: {Virksomhed} -- {Rolle}
+
+**Dato:** {YYYY-MM-DD}
+**Arketype:** {detekteret}
+**Score:** {X/5}
+**URL:** {opslagets URL}
+**PDF:** {sti eller afventer}
+
+---
+
+## A) Rolleopsummering
+(fuldt indhold af blok A)
+
+## B) Match med CV'et
+(fuldt indhold af blok B)
+
+## C) Niveau og strategi
+(fuldt indhold af blok C)
+
+## D) Aflønning og efterspørgsel
+(fuldt indhold af blok D)
+
+## E) Personaliseringsplan
+(fuldt indhold af blok E)
+
+## F) Samtaleplan
+(fuldt indhold af blok F)
+
+## G) Udkast til svar til ansøgningen
+(kun ved score >= 4.5 -- udkast til svar til ansøgningsformularen)
+
+---
+
+## Udtrukne nøgleord
+(liste med 15-20 nøgleord fra opslaget til ATS-optimering)
+```
+
+### 2. Registrér i trackeren
+
+**ALTID** registrér i `data/applications.md`:
+- Næste fortløbende nummer
+- Dagens dato
+- Virksomhed
+- Rolle
+- Score: gennemsnit af matchet (1-5)
+- Status: `Evaluated`
+- PDF: nej (eller ja, hvis auto-pipeline har genereret en PDF)
+- Report: relativt link til report-filen (fx `[001](reports/001-company-2026-01-01.md)`)
+
+**Tracker-format:**
+
+```markdown
+| # | Dato | Virksomhed | Rolle | Score | Status | PDF | Report |
+```

--- a/modes/da/pipeline.md
+++ b/modes/da/pipeline.md
@@ -1,0 +1,63 @@
+# Mode: pipeline -- URL-indbakke (Second Brain)
+
+Behandler URL'er til opslag, der er samlet i `data/pipeline.md`. Kandidaten tilføjer URL'er, når han vil, og kører derefter `/career-ops pipeline` for at behandle dem alle på én gang.
+
+## Workflow
+
+1. **Læs** `data/pipeline.md` -> find `- [ ]`-elementer i sektionen "Afventer" / "Pending" / "Pendientes"
+2. **For hver afventende URL**:
+   a. Reservér det næste fortløbende `REPORT_NUM` atomisk ved at køre `node reserve-report-num.mjs` (og frigiv sentinel'en ved at køre `node reserve-report-num.mjs --release <num>`, når rapporten er skrevet)
+   b. **Udtræk opslaget** med Playwright (`browser_navigate` + `browser_snapshot`) -> WebFetch -> WebSearch
+   c. Hvis URL'en ikke er tilgængelig -> markér som `- [!]` med en note og fortsæt
+   d. **Kør den fulde auto-pipeline**: Evaluering A-F -> Report .md -> PDF (hvis score >= 3.0) -> Tracker
+   e. **Flyt fra "Afventer" til "Behandlede"**: `- [x] #NNN | URL | Virksomhed | Rolle | Score/5 | PDF ja/nej`
+3. **Hvis 3+ URL'er afventer**, så start agenter parallelt (Agent-værktøjet med `run_in_background`) for at maksimere hastigheden.
+4. **Til sidst** vis en opsummerende tabel:
+
+```
+| # | Virksomhed | Rolle | Score | PDF | Anbefalet handling |
+```
+
+## Format for pipeline.md
+
+```markdown
+## Afventer
+- [ ] https://jobs.example.com/posting/123
+- [ ] https://boards.greenhouse.io/company/jobs/456 | Company ApS | Senior PM
+- [!] https://private.url/job -- Fejl: login påkrævet
+
+## Behandlede
+- [x] #143 | https://jobs.example.com/posting/789 | Acme ApS | AI PM | 4.2/5 | PDF ja
+- [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF nej
+```
+
+> Note: Sektionsoverskrifterne kan være på EN ("Pending"/"Processed"), ES ("Pendientes"/"Procesadas"), DE ("Offen"/"Verarbeitet") eller DA ("Afventer"/"Behandlede"). Vær fleksibel ved læsning, tro mod den eksisterende stil ved skrivning.
+
+## Intelligent detektion af opslaget fra URL'en
+
+1. **Playwright (foretrukket):** `browser_navigate` + `browser_snapshot`. Fungerer med alle SPAs.
+2. **WebFetch (fallback):** Til statiske sider, eller når Playwright ikke er tilgængelig.
+3. **WebSearch (sidste udvej):** Søg på sekundære portaler, der indekserer opslaget.
+
+**Særlige tilfælde:**
+- **LinkedIn**: Kan kræve login -> markér `[!]` og bed kandidaten om at indsætte teksten
+- **PDF**: Hvis URL'en peger på en PDF, så læs den direkte med Read-værktøjet
+- **Præfikset `local:`**: Læs den lokale fil. Eksempel: `local:jds/linkedin-pm-ai.md` -> læs `jds/linkedin-pm-ai.md`
+- **Jobindex / The Hub / LinkedIn DK**: Almindelige danske portaler. Playwright håndterer cookie-bannere godt
+- **Jobnet (Styrelsen for Arbejdsmarked)**: Strukturerede opslag, godt læsbare af maskine. WebFetch er som regel nok
+
+## Automatisk nummerering
+
+1. Kør `node reserve-report-num.mjs` for at reservere det næste fortløbende nummer atomisk (stdout returnerer `{###}`).
+2. Skriv rapporten med dette nummer.
+3. Frigiv sentinel'en ved at køre `node reserve-report-num.mjs --release {###}`, når rapporten er skrevet.
+
+## Synkronisering af kilder
+
+Før en URL behandles, tjek synkroniseringen:
+
+```bash
+node cv-sync-check.mjs
+```
+
+Ved desynkronisering, advar kandidaten, før du fortsætter.

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -1027,6 +1027,28 @@ tracked_companies:
     notes: "Vilnius LT / Berlin. C2C marketplace unicorn, data science & ML roles."
     enabled: true
 
+  # -- Denmark AI / tech --
+
+  - name: Corti
+    careers_url: https://jobs.ashbyhq.com/corti
+    scan_method: websearch
+    scan_query: 'site:jobs.ashbyhq.com/corti'
+    notes: "Copenhagen DK. Medical AI (ambient clinical documentation), ML / NLP roles."
+    enabled: true
+
+  - name: Pleo
+    careers_url: https://jobs.ashbyhq.com/pleo
+    scan_method: websearch
+    scan_query: 'site:jobs.ashbyhq.com/pleo'
+    notes: "Copenhagen DK. Spend-management fintech, ML / data / platform roles."
+    enabled: true
+
+  - name: Templafy
+    careers_url: https://job-boards.greenhouse.io/templafy
+    api: https://boards-api.greenhouse.io/v1/boards/templafy/jobs
+    notes: "Copenhagen DK. Document-generation / content-enablement platform."
+    enabled: true
+
   # -- Iberia AI --
 
   - name: Amplemarket


### PR DESCRIPTION
## Summary

Adds Danish (`da-DK`) support, following the existing locale pattern — per @santifer's guidance and @speedster-kiev's proposed structure on #1018.

Fixes #1018

## What's included

1. **`modes/da/`** — mirrors `modes/fr/` with faithful Danish translations:
   - `README.md`, `_shared.md`, `oferta.md`, `apply.md`, `pipeline.md`
   - `oferta.md` / `apply.md` naming follows the ru/ua/zh locales, as proposed in the issue.
   - **Scoring blocks are unchanged** — every threshold/weight (`Score 3.0`/`1.0`, `score >= 4.5`, `score >= 3.0`, `{X/5}`, `80/20`, …) is preserved verbatim; only labels are translated.
   - Market specifics are localized to the Danish market the way the de/pt locales adapt theirs: French contract concepts (CDI/CDD/SYNTEC/RTT/13e mois) → Danish equivalents (funktionærloven / ferieloven / A-kasse / feriepenge / overenskomst / prøvetid; DKK; Jobindex / The Hub / Jobnet), correctly noting Denmark typically has no 13th-month salary.

2. **`README.da.md`** — a Danish translation of the root README, structured like the other `README.<lang>.md` siblings (badges / HTML / links / diagram kept identical; only prose + alt-text translated).

3. **Denmark block in `templates/portals.example.yml`** — three Copenhagen companies via their existing ATS boards: Corti (Ashby), Pleo (Ashby), Templafy (Greenhouse). Same entry format as the neighbouring Nordics / Iberia blocks.

4. **Language switcher** — registers `[Dansk](README.da.md)` across all 13 READMEs (inserted after Polski, before Arabic).

## Validation

- `node test-all.mjs --quick` — 383 passed, 0 failed (no new warnings from these files; YAML for the portals block parses cleanly).
- `modes/da/` heading counts mirror `modes/fr/` exactly; no leftover French file names or accents.

## Notes

`README.da.md` follows the same base structure as the other non-English siblings (e.g. `README.pt-BR.md`); a couple of badges that currently exist only in the canonical `README.md` are intentionally not added, to stay consistent with the existing locale READMEs. Happy to fold that in (across all locales) as a separate chore if you'd prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added complete Danish language support with full documentation translations for all guides, workflows, and setup instructions.

* **New Features**
  * Added three new tracked job portals (Corti, Pleo, and Templafy) to the example configuration for expanded job market coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->