### PR TITLE
fix(batch): harden status score handling

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -41,6 +41,7 @@ BATCH_PAUSED=false
 STATUS_ONLY=false
 WATCH_MODE=false
 
+# Return success for non-negative integer or decimal strings.
 is_decimal_number() {
   [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
 }
@@ -170,6 +171,7 @@ check_prerequisites() {
   mkdir -p "$LOGS_DIR" "$TRACKER_DIR" "$REPORTS_DIR"
 }
 
+# Status/watch mode only needs prior batch state, not worker prerequisites.
 check_status_prerequisites() {
   if [[ ! -f "$STATE_FILE" ]]; then
     echo "No state file found at $STATE_FILE"

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -41,6 +41,10 @@ BATCH_PAUSED=false
 STATUS_ONLY=false
 WATCH_MODE=false
 
+is_decimal_number() {
+  [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
+}
+
 usage() {
   cat <<'USAGE'
 career-ops batch runner — process job offers in batch via claude -p workers
@@ -115,6 +119,11 @@ if ! [[ "$RATE_LIMIT_SLEEP" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+if ! is_decimal_number "$MIN_SCORE"; then
+  echo "ERROR: --min-score must be a non-negative number."
+  exit 1
+fi
+
 # Lock file to prevent double execution
 acquire_lock() {
   if [[ -f "$LOCK_FILE" ]]; then
@@ -159,6 +168,13 @@ check_prerequisites() {
   fi
 
   mkdir -p "$LOGS_DIR" "$TRACKER_DIR" "$REPORTS_DIR"
+}
+
+check_status_prerequisites() {
+  if [[ ! -f "$STATE_FILE" ]]; then
+    echo "No state file found at $STATE_FILE"
+    exit 0
+  fi
 }
 
 # Initialize state file if it doesn't exist
@@ -484,8 +500,8 @@ process_offer() {
     fi
 
     # Check min-score gate
-    if [[ "$score" != "-" && -n "$score" ]] && awk "BEGIN{exit !($MIN_SCORE > 0)}"; then
-      if awk "BEGIN{exit !($score < $MIN_SCORE)}"; then
+    if is_decimal_number "$score" && awk -v min="$MIN_SCORE" 'BEGIN{exit !(min > 0)}'; then
+      if awk -v score="$score" -v min="$MIN_SCORE" 'BEGIN{exit !(score < min)}'; then
         update_state "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries"
         echo "    ⏭️  Skipped (score: $score < min-score: $MIN_SCORE)"
         return 0
@@ -536,8 +552,8 @@ print_summary() {
     total=$((total + 1))
     case "$sstatus" in
       completed) completed=$((completed + 1))
-        if [[ "$sscore" != "-" && -n "$sscore" ]]; then
-          score_sum=$(awk "BEGIN{print $score_sum + $sscore}" 2>/dev/null || echo "$score_sum")
+        if is_decimal_number "$sscore"; then
+          score_sum=$(awk -v sum="$score_sum" -v score="$sscore" 'BEGIN{print sum + score}' 2>/dev/null || echo "$score_sum")
           score_count=$((score_count + 1))
         fi
         ;;
@@ -551,7 +567,7 @@ print_summary() {
 
   if (( score_count > 0 )); then
     local avg
-    avg=$(awk "BEGIN{printf \"%.1f\", $score_sum / $score_count}" 2>/dev/null || echo "N/A")
+    avg=$(awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{printf "%.1f", sum / count}' 2>/dev/null || echo "N/A")
     echo "Average score: $avg/5 ($score_count scored)"
   fi
 }
@@ -581,8 +597,8 @@ print_status_table() {
     case "$sstatus" in
       completed)
         completed=$((completed + 1))
-        if [[ "$sscore" != "-" && -n "$sscore" ]]; then
-          score_sum=$(echo "$score_sum + $sscore" | bc 2>/dev/null || echo "$score_sum")
+        if is_decimal_number "$sscore"; then
+          score_sum=$(awk -v sum="$score_sum" -v score="$sscore" 'BEGIN{print sum + score}' 2>/dev/null || echo "$score_sum")
           score_count=$((score_count + 1))
         fi
         ;;
@@ -599,7 +615,7 @@ print_status_table() {
   echo "Total: $total | Completed: $completed | Processing: $processing | Failed: $failed | Pending: $pending | Skipped: $skipped | Rate Limited: $rate_limited | Paused: $paused_rate_limit"
   if (( score_count > 0 )); then
     local avg
-    avg=$(echo "scale=1; $score_sum / $score_count" | bc 2>/dev/null || echo "N/A")
+    avg=$(awk -v sum="$score_sum" -v count="$score_count" 'BEGIN{printf "%.1f", sum / count}' 2>/dev/null || echo "N/A")
     echo "Average score: $avg/5 ($score_count scored)"
   fi
   echo ""
@@ -665,17 +681,19 @@ watch_status() {
 
 # Main
 main() {
-  check_prerequisites
-
   if [[ "$STATUS_ONLY" == "true" ]]; then
+    check_status_prerequisites
     print_status_table
     exit 0
   fi
 
   if [[ "$WATCH_MODE" == "true" ]]; then
+    check_status_prerequisites
     watch_status
     exit 0
   fi
+
+  check_prerequisites
 
   if [[ "$DRY_RUN" == "false" ]]; then
     acquire_lock

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -494,6 +494,23 @@ if (/local total=0 completed=0 skipped=0 failed=0 pending=0/.test(batchRunnerSou
   fail('Batch summary can misreport skipped offers as pending');
 }
 
+if (!/\bbc\b/.test(batchRunnerSource)) {
+  pass('Batch runner does not depend on bc for score arithmetic');
+} else {
+  fail('Batch runner still depends on bc for score arithmetic');
+}
+
+if (
+  !/awk "BEGIN\{[^"]*\$MIN_SCORE/.test(batchRunnerSource) &&
+  !/awk "BEGIN\{[^"]*\$score/.test(batchRunnerSource) &&
+  !/awk "BEGIN\{[^"]*\$sscore/.test(batchRunnerSource) &&
+  /awk -v score="\$score" -v min="\$MIN_SCORE"/.test(batchRunnerSource)
+) {
+  pass('Batch runner passes score values to awk via -v');
+} else {
+  fail('Batch runner interpolates score values into awk programs');
+}
+
 // ── 6. PERSONAL DATA LEAK CHECK ─────────────────────────────────
 
 console.log('\n6. Personal data leak check');
@@ -3062,6 +3079,26 @@ try {
     pass('--resume-paused dry-run selects paused jobs only');
   } else {
     fail(`--resume-paused selection wrong: ${dry}`);
+  }
+
+  rmSync(join(batchDir, 'batch-input.tsv'), { force: true });
+  rmSync(join(batchDir, 'batch-prompt.md'), { force: true });
+  rmSync(join(fakeBin, 'claude'), { force: true });
+  writeFileSync(join(batchDir, 'batch-state.tsv'), [
+    'id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries',
+    '1\thttps://example.com/one\tcompleted\t2026-01-01T00:00:00Z\t2026-01-01T00:00:01Z\t001\t4.5\t-\t0',
+    '2\thttps://example.com/two\tcompleted\t2026-01-01T00:00:00Z\t2026-01-01T00:00:01Z\t002\tbad);system("oops")\t-\t0',
+    '3\thttps://example.com/three\tskipped\t2026-01-01T00:00:00Z\t2026-01-01T00:00:01Z\t003\t3.5\tbelow-min-score\t0',
+  ].join('\n') + '\n');
+  const statusOnly = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--status'], {
+    cwd: tmp,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) || '';
+  if (statusOnly.includes('Average score: 4.5/5 (1 scored)') && statusOnly.includes('bad);system("oops")')) {
+    pass('--status reads existing state without full batch prerequisites');
+  } else {
+    fail(`--status prerequisite/score handling wrong: ${statusOnly}`);
   }
 
   try { rmSync(tmp, { recursive: true, force: true }); } catch {}


### PR DESCRIPTION
## What

- validates score-shaped values before numeric comparisons or aggregation
- passes score values into awk with `-v` instead of interpolating shell/state data into awk programs
- removes the `bc` dependency from batch status/summary score averages
- lets `--status` and `--watch` read an existing `batch-state.tsv` without requiring `batch-input.tsv`, `batch-prompt.md`, or the `claude` CLI

Closes #1125.
Closes #1127.

## Why

`batch-runner.sh` previously treated CLI/state score data as awk source code in a few places, which created a code-injection surface. The read-only status paths also ran the full batch prerequisites and still used `bc`, making status inspection fail in minimal or post-cleanup environments.

## Validation

- `bash -n batch/batch-runner.sh`
- `git diff --check`
- `node verify-pipeline.mjs`
- `node test-all.mjs` reached the new batch assertions successfully; the overall local run reports `387 passed, 1 failed, 15 warnings` because the existing smoke step for `verify-portals.mjs` times out against my real `portals.yml`. Running `node verify-portals.mjs` directly completed successfully afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation for score-related command-line inputs and stricter handling of numeric comparisons
  * Improved batch `--status`/`--watch` behavior to avoid unnecessary prerequisite checks when state is unavailable
  * Updated summary and status score aggregation to use safer numeric evaluation and consistent `N/A` handling for missing values
* **Tests**
  * Added coverage to ensure score arithmetic doesn’t rely on `bc` and that score values are passed into `awk` safely
  * Extended batch status test to validate reading and reporting of existing `batch-state.tsv` contents
<!-- end of auto-generated comment: release notes by coderabbit.ai -->