### PR TITLE
fix: normalize report links from data files

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -12,7 +12,7 @@
  */
 
 import { readFileSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, relative, sep } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import yaml from 'js-yaml';
 
@@ -198,15 +198,15 @@ function extractContacts(notes) {
 }
 
 // --- Resolve report path ---
-function resolveReportPath(reportField) {
+export function resolveReportPath(reportField, appsFile = APPS_FILE, repoRoot = CAREER_OPS) {
   const match = reportField.match(/\]\(([^)]+)\)/);
   if (!match) return null;
   // Report links in the tracker are normalized relative to the tracker file's
   // own directory (see PR #760 — `merge-tracker.mjs --migrate`). Resolve against
   // dirname(APPS_FILE), not the project root, otherwise relative paths like
   // `../reports/...` (the data/applications.md layout) escape above the project.
-  const fullPath = join(dirname(APPS_FILE), match[1]);
-  return existsSync(fullPath) ? match[1] : null;
+  const fullPath = join(dirname(appsFile), match[1]);
+  return existsSync(fullPath) ? relative(repoRoot, fullPath).split(sep).join('/') : null;
 }
 
 // --- Compute urgency ---

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -206,7 +206,9 @@ export function resolveReportPath(reportField, appsFile = APPS_FILE, repoRoot = 
   // dirname(APPS_FILE), not the project root, otherwise relative paths like
   // `../reports/...` (the data/applications.md layout) escape above the project.
   const fullPath = join(dirname(appsFile), match[1]);
-  return existsSync(fullPath) ? relative(repoRoot, fullPath).split(sep).join('/') : null;
+  const repoRelative = relative(repoRoot, fullPath).split(sep).join('/');
+  if (repoRelative.startsWith('../') || repoRelative === '..' || !repoRelative.startsWith('reports/')) return null;
+  return existsSync(fullPath) ? repoRelative : null;
 }
 
 // --- Compute urgency ---

--- a/reconcile-pipeline.mjs
+++ b/reconcile-pipeline.mjs
@@ -24,6 +24,7 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, copyFileSync, realpathSync, statSync } from 'fs';
 import { join, dirname, resolve, relative, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
+import { normalizeReportLink } from './tracker-links.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -226,7 +227,8 @@ for (let i = pendStart + 1; i < pendEnd; i++) {
   const pdf = resolvePdf(reportFile);
   const num = parseInt(done.reportNum, 10);
 
-  movedProcLines.push(`- [x] [${num}](reports/${reportFile}) | ${url} | ${company} | ${role} | ${score} | PDF ${pdf}`);
+  const reportLink = normalizeReportLink(`[${num}](reports/${reportFile})`, dirname(PIPELINE_FILE), CAREER_OPS);
+  movedProcLines.push(`- [x] ${reportLink} | ${url} | ${company} | ${role} | ${score} | PDF ${pdf}`);
   moved.push({ url, company, role, num, score });
   procUrls.add(url);
   removeIdx.add(i);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2105,6 +2105,13 @@ try {
     fail(`non-report link altered: ${other}`);
   }
 
+  const pipelineProcessed = normalizeReportLink('[12](reports/012-acme-2026-01-04.md)', join(repo, 'data'), repo);
+  if (pipelineProcessed === '[12](../reports/012-acme-2026-01-04.md)') {
+    pass('pipeline processed links are relative to data/pipeline.md (#1126)');
+  } else {
+    fail(`pipeline processed link normalization wrong (#1126): ${pipelineProcessed}`);
+  }
+
   // End-to-end migration against a fictional fixture tracker (no personal data)
   const tmpDir = mkdtempSync(join(tmpdir(), 'career-ops-migrate-'));
   try {
@@ -2128,6 +2135,24 @@ try {
     }
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  const { resolveReportPath } = await import(pathToFileURL(join(ROOT, 'followup-cadence.mjs')).href);
+  const followupTmp = mkdtempSync(join(tmpdir(), 'career-ops-followup-link-'));
+  try {
+    mkdirSync(join(followupTmp, 'data'), { recursive: true });
+    mkdirSync(join(followupTmp, 'reports'), { recursive: true });
+    const reportFile = join(followupTmp, 'reports', '012-acme-2026-01-04.md');
+    writeFileSync(reportFile, '# fixture\n');
+    const appsFile = join(followupTmp, 'data', 'applications.md');
+    const resolved = resolveReportPath('[12](../reports/012-acme-2026-01-04.md)', appsFile, followupTmp);
+    if (resolved === 'reports/012-acme-2026-01-04.md') {
+      pass('follow-up reportPath is repo-root relative for data/ tracker links (#1126)');
+    } else {
+      fail(`follow-up reportPath wrong (#1126): ${resolved}`);
+    }
+  } finally {
+    rmSync(followupTmp, { recursive: true, force: true });
   }
 } catch (e) {
   fail(`tracker-link normalization tests crashed: ${e.message}`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2151,6 +2151,12 @@ try {
     } else {
       fail(`follow-up reportPath wrong (#1126): ${resolved}`);
     }
+    const escaped = resolveReportPath('[99](../../outside.md)', appsFile, followupTmp);
+    if (escaped === null) {
+      pass('follow-up reportPath rejects links outside reports/ (#1126)');
+    } else {
+      fail(`follow-up reportPath allowed escaped link (#1126): ${escaped}`);
+    }
   } finally {
     rmSync(followupTmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What

- writes `reconcile-pipeline.mjs` processed report links relative to the pipeline file location
- returns `followup-cadence.mjs` `reportPath` values relative to the repo root after validating the tracker-relative link exists
- adds regression coverage for both `data/pipeline.md` and `data/applications.md` layouts

Closes #1126.

## Why

Markdown links inside files under `data/` resolve relative to those files. `reconcile-pipeline.mjs` was writing `reports/...` into `data/pipeline.md`, which points at `data/reports/...`. `followup-cadence.mjs` correctly validated `../reports/...` relative to `data/applications.md`, but returned that raw tracker-relative path to JSON consumers that read from the repo root.

## Validation

- `node --check reconcile-pipeline.mjs && node --check followup-cadence.mjs && node --check test-all.mjs`
- `git diff --check`
- `node verify-pipeline.mjs`
- `node test-all.mjs | rg "Tracker report-link|#1126|Results:"` shows the new #1126 assertions passing; the local full suite still reports the existing `verify-portals.mjs` smoke timeout against my real `portals.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown report link resolution and normalization across tracking flows, including correct handling of links originating from `data/` paths.
  * Added stricter path validation so malformed links that could escape the intended `reports/` area are safely rejected.

* **Tests**
  * Expanded automated coverage for report link normalization and resolution, including new cases for `data/`-origin paths and “escape attempt” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->