### PR TITLE
fix(template): scope break-inside to atomic units to stop page-break whitespace inflation

### DIFF
--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -322,13 +322,26 @@
   }
 
   /* === PAGE BREAK CONTROL === */
-  .avoid-break,
-  .job,
-  .project,
+  /* Only avoid breaking small atomic units (a cert row, an education line, the
+     header, a single competency or skill).  Sections and multi-bullet roles are
+     allowed to flow across a page boundary so content packs tight instead of
+     jumping wholesale and leaving large bottom gaps. */
+  .header,
   .edu-item,
-  .cert-item {
+  .cert-item,
+  .competency-tag,
+  .skill-item {
     break-inside: avoid;
     page-break-inside: avoid;
+  }
+
+  /* Keep a heading attached to the content that follows it, so headings are not
+     orphaned at the bottom of a page. */
+  .section-title,
+  .job-company,
+  .project-title {
+    break-after: avoid;
+    page-break-after: avoid;
   }
 
   /* === RTL (Arabic) Support === */

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -411,7 +411,7 @@
 <div class="page">
 
   <!-- HEADER -->
-  <div class="header avoid-break">
+  <div class="header">
     <h1>{{NAME}}</h1>
     <div class="header-gradient"></div>
     <div class="contact-row">
@@ -428,7 +428,7 @@
   </div>
 
   <!-- PROFESSIONAL SUMMARY -->
-  <div class="section avoid-break">
+  <div class="section">
     <div class="section-title">{{SECTION_SUMMARY}}</div>
     <div class="summary-text">{{SUMMARY_TEXT}}</div>
   </div>
@@ -448,25 +448,25 @@
   </div>
 
   <!-- PROJECTS -->
-  <div class="section avoid-break">
+  <div class="section">
     <div class="section-title">{{SECTION_PROJECTS}}</div>
     {{PROJECTS}}
   </div>
 
   <!-- EDUCATION -->
-  <div class="section avoid-break">
+  <div class="section">
     <div class="section-title">{{SECTION_EDUCATION}}</div>
     {{EDUCATION}}
   </div>
 
   <!-- CERTIFICATIONS -->
-  <div class="section avoid-break">
+  <div class="section">
     <div class="section-title">{{SECTION_CERTIFICATIONS}}</div>
     <div class="cert-table">{{CERTIFICATIONS}}</div>
   </div>
 
   <!-- SKILLS -->
-  <div class="section avoid-break">
+  <div class="section">
     <div class="section-title">{{SECTION_SKILLS}}</div>
     {{SKILLS}}
   </div>


### PR DESCRIPTION
## What does this PR do?

Scopes `break-inside: avoid` in the CV template down to small atomic units (the header, cert and education rows, a single competency or skill) so whole sections and multi-bullet roles can flow across page boundaries instead of jumping wholesale and leaving large bottom gaps. A representative CV that rendered to 5 or 6 mostly-blank pages now renders to 2 balanced pages. Adds `break-after: avoid` on `.section-title`, `.job-company`, and `.project-title` so headings are not orphaned. Only the print/PDF pagination path is affected; single-page visual styling is unchanged.

## Related issue

Closes #1145.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved print pagination behavior in the CV template for a cleaner layout.
  * Updated page-break avoidance to apply only to specific atomic elements (such as headers, education/certification entries, and skills) rather than broad container rules.
  * Adjusted heading behavior so section and title elements avoid breaking away from the content that follows.
  * Simplified section class usage to ensure the refined print rules take effect consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->