### PR TITLE
fix(web): detect Windows-installed CLIs (claude.exe, agy.exe) in Config

### DIFF
--- a/web/src/lib/clis.ts
+++ b/web/src/lib/clis.ts
@@ -35,6 +35,17 @@ function searchDirs(): string[] {
     "/usr/local/bin",
     "/usr/bin",
   ];
+  if (process.platform === "win32") {
+    // Windows CLIs frequently install under per-user AppData roots and don't
+    // reliably add themselves to PATH (e.g. Antigravity → %LOCALAPPDATA%\agy\bin).
+    const localAppData = process.env.LOCALAPPDATA || path.join(home, "AppData", "Local");
+    const appData = process.env.APPDATA || path.join(home, "AppData", "Roaming");
+    extra.push(
+      path.join(localAppData, "agy", "bin"), // Antigravity CLI
+      path.join(localAppData, "Microsoft", "WindowsApps"), // winget/Store shims
+      path.join(appData, "npm"), // npm global prefix on Windows
+    );
+  }
   const fromPath = (process.env.PATH || "").split(path.delimiter).filter(Boolean);
   return [...new Set([...fromPath, ...extra])];
 }

--- a/web/src/lib/clis.ts
+++ b/web/src/lib/clis.ts
@@ -55,9 +55,16 @@ function searchDirs(): string[] {
 // found, not just an extensionless npm shim. On POSIX, "" keeps the bare name.
 function binCandidates(bin: string): string[] {
   if (process.platform !== "win32") return [bin];
-  const exts = (process.env.PATHEXT || ".EXE;.CMD;.BAT;.PS1").split(";").filter(Boolean);
-  // Try the bare name too (npm drops an extensionless sh shim on PATH).
-  return [bin, ...exts.map((ext) => bin + ext.toLowerCase())];
+  const pathext = process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD";
+  const exts = pathext
+    .split(";")
+    .map((e) => e.trim())
+    .filter(Boolean)
+    // Only include extensions that `child_process.spawn()` can execute directly.
+    .filter((e) => [".com", ".exe", ".bat", ".cmd"].includes(e.toLowerCase()));
+
+  // Try the bare name too (some environments provide an extensionless shim).
+  return [bin, ...exts.map((ext) => bin + ext)];
 }
 
 export function findBin(bin: string, dirs = searchDirs()): string | null {

--- a/web/src/lib/clis.ts
+++ b/web/src/lib/clis.ts
@@ -39,14 +39,26 @@ function searchDirs(): string[] {
   return [...new Set([...fromPath, ...extra])];
 }
 
+// On Windows, executables carry an extension (claude.exe, claude.cmd, ...).
+// Mirror the shell's PATHEXT resolution so a native-installer claude.exe is
+// found, not just an extensionless npm shim. On POSIX, "" keeps the bare name.
+function binCandidates(bin: string): string[] {
+  if (process.platform !== "win32") return [bin];
+  const exts = (process.env.PATHEXT || ".EXE;.CMD;.BAT;.PS1").split(";").filter(Boolean);
+  // Try the bare name too (npm drops an extensionless sh shim on PATH).
+  return [bin, ...exts.map((ext) => bin + ext.toLowerCase())];
+}
+
 export function findBin(bin: string, dirs = searchDirs()): string | null {
   for (const dir of dirs) {
-    const p = path.join(dir, bin);
-    try {
-      fs.accessSync(p, fs.constants.X_OK);
-      return p;
-    } catch {
-      /* not here */
+    for (const candidate of binCandidates(bin)) {
+      const p = path.join(dir, candidate);
+      try {
+        fs.accessSync(p, fs.constants.X_OK);
+        return p;
+      } catch {
+        /* not here */
+      }
     }
   }
   return null;


### PR DESCRIPTION
The CLI detector only probed for an extensionless binary name (e.g. "claude"), so a native-installer claude.exe in `~/.local/bin` was never found on Windows. npm-installed CLIs (codex, copilot) slipped through only because npm drops an extensionless sh shim on PATH.

`findBin` now expands each binary to its PATHEXT candidates on Windows (claude.exe/.cmd/.bat/.ps1) while keeping the bare name on POSIX, mirroring the resolution already used in scaffolder/bin/cli.mjs.