### PR TITLE
Fix dashboard international pay and location parsing

### DIFF
--- a/dashboard/internal/data/derive.go
+++ b/dashboard/internal/data/derive.go
@@ -10,17 +10,21 @@ import (
 
 // The tracker's Notes column is free-text, but evaluations write it with stable
 // conventions: work mode ("Remote US", "Charlotte NC (Hybrid)"), a pay range
-// ("$140-210K (POSTED)" / "~$150-220K (est)") and event dates ("Rejected
+// ("$140-210K (POSTED)" / "€130-170K (est)") and event dates ("Rejected
 // 2026-06-04"). These regexes lift that structure back out so the dashboard can
 // show Location / Pay / Last-contact columns without a tracker schema change.
 var (
-	// $-amounts, optionally a range: "$140-210K", "$174,986-209,983", "~$124.2-198.7K"
-	reMoneySpan = regexp.MustCompile(`~?\$\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*\$?\d[\d,]*(?:\.\d+)?[KkMm]?)?`)
+	// Currency amounts, optionally a range: "$140-210K", "€130-170K",
+	// "CHF 165-185K", "$174,986-209,983", "~$124.2-198.7K"
+	reMoneySpan = regexp.MustCompile(`~?(?:[$€£]|CHF|EUR|GBP|USD)\s*\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*(?:[$€£]|CHF|EUR|GBP|USD)?\s*\d[\d,]*(?:\.\d+)?[KkMm]?)?`)
 	// ISO dates embedded in notes ("Rejected 2026-06-04", "viewed 2026-06-04")
 	reISODate = regexp.MustCompile(`\b20\d{2}-\d{2}-\d{2}\b`)
 	// "City ST" / "City, ST" with a strict two-letter US state code so prose like
 	// "Sams AI" or "Kerin Colby DONE" can't false-positive.
 	reCityState = regexp.MustCompile(`\b([A-Z][A-Za-z.'-]+(?: [A-Z][A-Za-z.'-]+){0,2}),? (A[KLRZ]|C[AOT]|D[CE]|FL|GA|HI|I[ADLN]|K[SY]|LA|M[ADEINOST]|N[CDEHJMVY]|O[HKR]|PA|RI|S[CD]|T[NX]|UT|V[AT]|W[AIVY])\b`)
+	// International city fallback. Keep this as explicit city names, not countries,
+	// so prose like "Portugal eligible" or "Europe remote" does not become a location.
+	reIntlCity = regexp.MustCompile(`\b(Amsterdam|Antwerp|Barcelona|Berlin|Bristol|Brussels|Cambridge|Cologne|Copenhagen|Dublin|Dusseldorf|Edinburgh|Frankfurt|Geneva|Ghent|Gothenburg|Hamburg|Helsinki|Lisbon|London|Luxembourg|Madrid|Malmo|Manchester|Melbourne|Milan|Montreal|Munich|Oslo|Oxford|Paris|Porto|Prague|Riga|Rome|Rotterdam|Singapore|Stockholm|Sydney|Tallinn|Tokyo|Toronto|Utrecht|Valencia|Vancouver|Vienna|Vilnius|Warsaw|Zurich)\b`)
 	// Individual amounts inside an already-matched span: "140", "210K", "209,983"
 	reMoneyPart = regexp.MustCompile(`(\d[\d,]*(?:\.\d+)?)\s*([KkMm]?)`)
 	// Estimate markers: "(est)", "(est;", "market est)" or "market" as its own
@@ -28,8 +32,8 @@ var (
 	reEstHint = regexp.MustCompile(`\(est[),;. ]|\best\)|\bmarket\b`)
 )
 
-// payCeiling converts a matched pay span to its top dollar amount for sorting:
-// "$140-210K" → 210000, "$174,986-209,983" → 209983, "$170K" → 170000.
+// payCeiling converts a matched pay span to its top numeric amount for sorting:
+// "$140-210K" -> 210000, "€130-170K" -> 170000, "$170K" -> 170000.
 func payCeiling(span string) float64 {
 	top := 0.0
 	for _, p := range reMoneyPart.FindAllStringSubmatch(span, -1) {
@@ -50,18 +54,30 @@ func payCeiling(span string) float64 {
 	return top
 }
 
+func deriveLocation(notes, role string) string {
+	if m := reCityState.FindStringSubmatch(notes); m != nil {
+		return m[1] + ", " + m[2]
+	}
+	if m := reCityState.FindStringSubmatch(role); m != nil {
+		return m[1] + ", " + m[2]
+	}
+	if m := reIntlCity.FindStringSubmatch(notes); m != nil {
+		return m[1]
+	}
+	if m := reIntlCity.FindStringSubmatch(role); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
 // deriveNoteFields populates Location, WorkMode, PayRange, PaySource and
 // LastContact from the application's Notes (plus Role for work-mode keywords).
 func deriveNoteFields(app *model.CareerApplication) {
 	lower := strings.ToLower(app.Role + " " + app.Notes)
 
-	// Location: first "City, ST" in the notes, falling back to the role title
-	// (some tracker rows carry the city there, e.g. "... — Charlotte, NC").
-	if m := reCityState.FindStringSubmatch(app.Notes); m != nil {
-		app.Location = m[1] + ", " + m[2]
-	} else if m := reCityState.FindStringSubmatch(app.Role); m != nil {
-		app.Location = m[1] + ", " + m[2]
-	}
+	// Location: first "City, ST" in notes/role, then an explicit international
+	// city fallback (some tracker rows carry the city in the role title).
+	app.Location = deriveLocation(app.Notes, app.Role)
 
 	// Work mode: hybrid beats remote ("Remote/hybrid" means office days exist);
 	// "remote-first" / "remote + flex" is softer than fully remote;
@@ -82,8 +98,8 @@ func deriveNoteFields(app *model.CareerApplication) {
 		app.WorkMode = "Full"
 	}
 
-	// Pay: prefer the first $-range; fall back to the first lone $-amount
-	// (e.g. "$170K min floor") only when no range exists.
+	// Pay: prefer the first currency range; fall back to the first lone amount
+	// (e.g. "$170K min floor" or "EUR 170K") only when no range exists.
 	matches := reMoneySpan.FindAllString(app.Notes, -1)
 	for _, mm := range matches {
 		if strings.ContainsAny(mm, "-–") {

--- a/dashboard/internal/data/derive_test.go
+++ b/dashboard/internal/data/derive_test.go
@@ -104,6 +104,55 @@ func TestDeriveNoteFields(t *testing.T) {
 			workMode: "",
 			last:     "2026-06-01",
 		},
+		{
+			name: "international city with euro posted range",
+			app: model.CareerApplication{
+				Date:  "2026-06-07",
+				Notes: "Berlin (Hybrid). Base €130-170K (POSTED). Via Ashby",
+			},
+			location: "Berlin",
+			workMode: "Hybrid",
+			payRange: "€130-170K",
+			paySrc:   "POSTED",
+			last:     "2026-06-07",
+		},
+		{
+			name: "role title international city with gbp range",
+			app: model.CareerApplication{
+				Date:  "2026-06-08",
+				Role:  "Staff AI Engineer - London",
+				Notes: "Remote-first UK. Comp £175-225K (market est)",
+			},
+			location: "London",
+			workMode: "RemoteFlex",
+			payRange: "£175-225K",
+			paySrc:   "est",
+			last:     "2026-06-08",
+		},
+		{
+			name: "chf code range with space",
+			app: model.CareerApplication{
+				Date:  "2026-06-09",
+				Notes: "Zurich onsite. Salary CHF 165-185K (POSTED)",
+			},
+			location: "Zurich",
+			workMode: "Full",
+			payRange: "CHF 165-185K",
+			paySrc:   "POSTED",
+			last:     "2026-06-09",
+		},
+		{
+			name: "country names are not international city fallback",
+			app: model.CareerApplication{
+				Date:  "2026-06-10",
+				Notes: "Remote EU. Portugal eligible. Salary EUR 95-120K (est)",
+			},
+			location: "",
+			workMode: "Remote",
+			payRange: "EUR 95-120K",
+			paySrc:   "est",
+			last:     "2026-06-10",
+		},
 	}
 
 	for _, tc := range cases {
@@ -138,6 +187,11 @@ func TestPayCeiling(t *testing.T) {
 		"~$124.2-198.7K":   198_700,
 		"$170K":            170_000,
 		"$95-159K":         159_000,
+		"€130-170K":        170_000,
+		"£175-225K":        225_000,
+		"CHF 165-185K":     185_000,
+		"EUR 95-120K":      120_000,
+		"USD 180-220K":     220_000,
 		"":                 0,
 	}
 	for span, want := range cases {

--- a/dashboard/internal/model/career.go
+++ b/dashboard/internal/model/career.go
@@ -15,10 +15,10 @@ type CareerApplication struct {
 	Notes        string
 	JobURL       string // URL of the original job posting
 	// Derived from Notes free-text (see data.deriveNoteFields)
-	Location    string  // "City, ST" when a US city+state appears in the notes
+	Location    string  // "City, ST" or explicit international city derived from notes/role
 	WorkMode    string  // "Remote" | "Hybrid" | "Full" (onsite), "" when unknown
-	PayRange    string  // first $-range found in the notes, e.g. "$140-210K"
-	PayMax      float64 // top of PayRange in dollars (sort key), 0 when unknown
+	PayRange    string  // first currency range found in the notes, e.g. "$140-210K"
+	PayMax      float64 // top of PayRange as numeric magnitude (sort key), 0 when unknown
 	PaySource   string  // "POSTED" when the JD listed it, "est" for estimates, "" unknown
 	LastContact string  // max YYYY-MM-DD found in notes (falls back to applied date)
 	// Enrichment (lazy loaded from report)


### PR DESCRIPTION
## Summary

Fixes #1156. The dashboard derived PAY and LOCATION columns were only parsing US-style notes: dollar ranges and `City, ST` locations. This extends the note parser so international tracker rows can populate those columns too.

## Changes

- Parse common currency symbols and codes for pay spans: `$`, `€`, `£`, `CHF`, `EUR`, `GBP`, and `USD`.
- Keep `payCeiling` currency-naive as a numeric sort key while supporting the new matched spans.
- Add an explicit international-city fallback after the existing US `City, ST` parser, using city names rather than bare country names to reduce prose false positives.
- Cover euro, pound, CHF, EUR, USD, role-title city fallback, and country-name non-matches in derive tests.

## Validation

- `go test ./...` from `dashboard/` passes.
- `git diff --check` passes.
- `node verify-portals.mjs --file templates/portals.example.yml` exits 0 locally, though it reports current remote ATS 404/fetch failures for some configured slugs.
- `node test-all.mjs` reached 384 passed checks but reported `verify-portals.mjs crashed`; rerunning that command directly completed successfully after a longer external network scan, so this appears unrelated to the dashboard parser change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended salary range parsing to support multiple currencies (EUR, GBP, CHF) in addition to USD
  * Enhanced location detection with improved support for international city names
  * Improved flexibility in salary range format parsing

* **Documentation**
  * Clarified how Location and PayMax fields are derived from application data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->