### PR TITLE
Fix Antigravity Gemini context duplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ To rollback: `node update-system.mjs rollback`
 
 ## What is career-ops
 
-AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluation, CV generation, portal scanning, batch processing. Runs on any AI coding CLI that follows the [open agent skill standard](https://agentskills.io) (Claude Code, Codex, Gemini, OpenCode, Qwen, Copilot, Kimi, Antigravity CLI).
+AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluation, CV generation, portal scanning, batch processing. Runs on any AI coding CLI that follows the [open agent skill standard](https://agentskills.io) (Claude Code, Codex, OpenCode, Qwen, Copilot, Kimi, Antigravity CLI). Legacy Gemini API evaluation remains available through `gemini-eval.mjs`.
 
 ### Main Files
 
@@ -277,7 +277,6 @@ When spawning headless workers for batch processing, use the appropriate command
 |-----|---------|
 | Claude Code | `claude -p "prompt"` |
 | **OpenCode** | `opencode run "prompt"` |
-| Gemini CLI | `gemini -p "prompt"` |
 | Copilot CLI | `copilot -p "prompt"` |
 | Codex | `codex exec "prompt"` |
 | Qwen | `qwen -p "prompt"` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,9 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `liveness-core.mjs` | Shared liveness logic (expired signals win over generic Apply text) |
 | `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`). Blocks A-F + G (Posting Legitimacy), plus `## Machine Summary` YAML for downstream scripts. Header includes `**Legitimacy:** {tier}`. |
 
-### OpenCode & Gemini CLI Commands
+### OpenCode & Antigravity CLI Commands
 
-Both [OpenCode](https://opencode.ai) and [Gemini CLI](https://github.com/google-gemini/gemini-cli) natively support the open agent skill standard (`agentskills.io`). 
+Both [OpenCode](https://opencode.ai) and Antigravity CLI natively support the open agent skill standard (`agentskills.io`).
 
 Instead of registering individual `.toml` files for every slash command, all subcommands are routed through the single unified skill defined in `.agents/skills/career-ops/SKILL.md`.
 
@@ -99,7 +99,7 @@ You can invoke the command center or any of its modes directly within your CLI:
 * `followup` — Update and calculate follow-ups
 * `update` — Update system files
 
-All `modes/*` files and prompt contexts (e.g., `GEMINI.md`) are shared across Claude Code, OpenCode, and Gemini CLI.
+All `modes/*` files and prompt contexts are shared across Claude Code, OpenCode, and Antigravity CLI. `GEMINI.md` remains only as a legacy no-op guard so Antigravity does not duplicate the full project instructions.
 
 ### First Run — Onboarding (IMPORTANT)
 

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -55,6 +55,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/ru/*` | Russian language modes |
 | `CLAUDE.md` | Agent instructions (Claude Code) |
 | `OPENCODE.md` | Agent instructions (OpenCode) |
+| `GEMINI.md` | Legacy no-op context guard (prevents Antigravity duplicate imports) |
 | `AGENTS.md` | Canonical agent instructions (imported by CLI-specific wrappers) |
 | `*.mjs` | Utility scripts |
 | `batch/batch-prompt.md` | Batch worker prompt |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,2 +1,7 @@
-@./AGENTS.md
-<!-- Add anything Gemini specific that other agents don't need -->
+# Legacy Gemini CLI context
+
+Gemini CLI consumer access has transitioned to Antigravity CLI. This file is
+intentionally a no-op so Antigravity does not load the full project instructions
+twice when it reads both AGENTS.md and GEMINI.md.
+
+Use AGENTS.md and the Antigravity skill entrypoint instead.

--- a/OPENCODE.md
+++ b/OPENCODE.md
@@ -1,2 +1,2 @@
 @AGENTS.md
-<!-- OpenCode config — imports AGENTS.md, same as CLAUDE.md / GEMINI.md -->
+<!-- OpenCode config — imports AGENTS.md, same as CLAUDE.md -->

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@
   <sub>Also runs on any agent-skill-standard CLI</sub><br>
   <img src="https://img.shields.io/badge/Claude_Code-000?style=flat&logo=anthropic&logoColor=white" alt="Claude Code">
   <img src="https://img.shields.io/badge/OpenCode-111827?style=flat&logo=terminal&logoColor=white" alt="OpenCode">
-  <img src="https://img.shields.io/badge/Gemini_CLI-4285F4?style=flat&logo=google&logoColor=white" alt="Gemini CLI">
   <img src="https://img.shields.io/badge/Antigravity_CLI-4285F4?style=flat&logo=google&logoColor=white" alt="Antigravity CLI">
   <img src="https://img.shields.io/badge/Codex-412991?style=flat&logo=openai&logoColor=white" alt="Codex">
   <img src="https://img.shields.io/badge/Qwen-615CED?style=flat" alt="Qwen">
@@ -168,23 +167,20 @@ opencode # Or use OpenCode
 
 See [docs/SETUP.md](docs/SETUP.md) for the full setup guide.
 
-## Gemini & Antigravity CLI Integration
+## Antigravity CLI Integration
 
-Career-ops supports [Gemini CLI](https://github.com/google-gemini/gemini-cli) and Antigravity CLI natively, the same way it supports Claude Code and OpenCode. All 15 slash commands are available, using the same `modes/*.md` evaluation logic.
+Career-ops supports Antigravity CLI natively, the same way it supports Claude Code and OpenCode. All slash commands are available through the shared skill entrypoint, using the same `modes/*.md` evaluation logic.
 
-### Option A: Native Gemini CLI (Recommended)
+Google has transitioned consumer Gemini CLI access to Antigravity CLI. `GEMINI.md` is now a no-op compatibility guard so Antigravity does not duplicate the full project instructions when it reads both `AGENTS.md` and `GEMINI.md`.
+
+### Native Antigravity CLI
 
 ```bash
-# 1. Install Gemini CLI (requires Node.js 20+)
-npm install -g @google/gemini-cli
-# or: npx @google/gemini-cli --version
-
-# 2. Run in the career-ops directory — on first launch, sign in with your
-#    Google account (free) to authenticate
+# 1. Run in the career-ops directory
 cd career-ops
-gemini
+agy
 
-# 3. Use the unified /career-ops command with subcommands:
+# 2. Use the unified /career-ops command with subcommands:
 /career-ops "Senior AI Engineer at Anthropic..."
 /career-ops pipeline
 /career-ops scan
@@ -192,9 +188,9 @@ gemini
 /career-ops tracker
 ```
 
-The `GEMINI.md` file is auto-loaded as context. The skill is defined using the open standard in `.agents/skills/career-ops/SKILL.md` and symlinked/referenced for each supported CLI (e.g. `.claude/`, `.qwen/`, `.antigravitycli/`).
+The skill is defined using the open standard in `.agents/skills/career-ops/SKILL.md` and symlinked/referenced for each supported CLI (e.g. `.claude/`, `.qwen/`, `.antigravitycli/`).
 
-### Option B: Standalone API Script (No CLI install needed)
+### Standalone Gemini API Script (No CLI install needed)
 
 ```bash
 # 1. Get a free API key at https://aistudio.google.com/apikey
@@ -298,6 +294,7 @@ career-ops/
 ├── AGENTS.md                    # Canonical agent instructions (all CLIs)
 ├── CLAUDE.md                    # Claude Code wrapper (imports AGENTS.md)
 ├── OPENCODE.md                  # OpenCode wrapper (imports AGENTS.md)
+├── GEMINI.md                    # Legacy no-op guard to avoid Antigravity duplicate context
 ├── cv.md                        # Your CV (create this)
 ├── article-digest.md            # Your proof points (optional)
 ├── config/

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -159,9 +159,10 @@ const scripts = [
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
   { name: 'validate-portals.mjs --file templates/portals.example.yml', expectExit: 0 },
-  // Bare run: no portals.yml in the repo, so it must exit 0 gracefully (and hit
-  // no network). The probe logic itself is unit-tested below with a mock.
-  { name: 'verify-portals.mjs', expectExit: 0 },
+  // Missing-file run: must exit 0 gracefully and hit no network. Do not use the
+  // default portals.yml because end-user workspaces often have a real user-layer
+  // portals file that would trigger a live remote sweep during tests.
+  { name: 'verify-portals.mjs --file .tmp-test-missing-portals.yml', expectExit: 0 },
   { name: 'update-system.mjs check', expectExit: 0 },
 ];
 
@@ -996,7 +997,7 @@ for (const section of requiredSections) {
 
 console.log('\n11. CLI wrapper file integrity');
 
-const cliWrappers = ['CLAUDE.md', 'OPENCODE.md', 'GEMINI.md'];
+const cliWrappers = ['CLAUDE.md', 'OPENCODE.md'];
 for (const f of cliWrappers) {
   if (!fileExists(f)) {
     fail(`Missing CLI wrapper: ${f}`);
@@ -1007,6 +1008,16 @@ for (const f of cliWrappers) {
     pass(`${f} references AGENTS.md`);
   } else {
     fail(`${f} does NOT reference AGENTS.md`);
+  }
+}
+if (!fileExists('GEMINI.md')) {
+  fail('Missing legacy Gemini context guard: GEMINI.md');
+} else {
+  const geminiContext = readFile('GEMINI.md');
+  if (/^@(?:\.\/)?AGENTS\.md/m.test(geminiContext)) {
+    fail('GEMINI.md imports AGENTS.md and duplicates Antigravity context');
+  } else {
+    pass('GEMINI.md is a no-op context guard for Antigravity');
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #1159. Antigravity reads both `AGENTS.md` and `GEMINI.md`, while `GEMINI.md` imported `AGENTS.md`, causing the full project instructions to be loaded twice.

## Changes

- Convert `GEMINI.md` into a no-op legacy context guard instead of an `AGENTS.md` import wrapper.
- Update wrapper integrity tests so Claude/OpenCode still import `AGENTS.md`, while `GEMINI.md` must not import it.
- Update README, AGENTS, OPENCODE, and DATA_CONTRACT wording so Antigravity is the supported CLI path and Gemini remains only as the standalone API script / legacy guard.
- Isolate `test-all.mjs` from user-layer `portals.yml` by checking `verify-portals.mjs` against a known missing temp file, avoiding accidental live portal sweeps in provisioned workspaces.

## Validation

- `node --check test-all.mjs`
- `git diff --check`
- `node test-all.mjs` → 385 passed, 0 failed, 15 existing warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup and command guidance to prioritize Antigravity as the primary CLI experience.
  * Removed Gemini CLI “native” workflow and related badges/tables, replacing it with legacy compatibility guidance plus the existing standalone Gemini API script option.
  * Clarified shared slash-command access via the unified Antigravity skill entrypoint and noted Gemini content as a no-op guard to prevent duplicated instructions.

* **Tests**
  * Improved “missing portals” verification to exit cleanly without triggering external/network checks.
  * Strengthened CLI wrapper integrity checks, including dedicated validation for legacy Gemini guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->