### PR TITLE
fix(template): emit mailto:/tel: links for email and phone in CV header

### DIFF
--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -70,7 +70,7 @@ Use the template in `cv-template.html`. Replace the `{{...}}` placeholders with 
 | `{{LANG}}` | CV language code (e.g. `en`, `es`, `ja`, `ar`). Drives language-specific CSS in the template: `ja` enables a CJK font fallback so Japanese renders instead of tofu (□); `ar` enables RTL + Arabic fonts. Use the BCP-47/ISO-639 code that matches the CV language. |
 | `{{PAGE_WIDTH}}` | `8.5in` (letter) or `210mm` (A4) |
 | `{{NAME}}` | (from profile.yml) |
-| `{{PHONE}}` | (from profile.yml — include with its separator only when `profile.yml` has a non-empty `phone` value; omit both `<span>` and `<span class="separator">` otherwise) |
+| `{{PHONE}}` | (from profile.yml — include with its separator only when `profile.yml` has a non-empty `phone` value; omit both the `<a href="tel:…">` element and the following `<span class="separator">` otherwise) |
 | `{{EMAIL}}` | (from profile.yml) |
 | `{{LINKEDIN_URL}}` | [from profile.yml] |
 | `{{LINKEDIN_DISPLAY}}` | [from profile.yml] |

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -402,9 +402,9 @@
     <h1>{{NAME}}</h1>
     <div class="header-gradient"></div>
     <div class="contact-row">
-      <span>{{PHONE}}</span>
+      <a href="tel:{{PHONE}}">{{PHONE}}</a>
       <span class="separator">|</span>
-      <span>{{EMAIL}}</span>
+      <a href="mailto:{{EMAIL}}">{{EMAIL}}</a>
       <span class="separator">|</span>
       <a href="{{LINKEDIN_URL}}">{{LINKEDIN_DISPLAY}}</a>
       <span class="separator">|</span>


### PR DESCRIPTION
Closes #1166.

### What
Wraps the header `{{EMAIL}}` and `{{PHONE}}` placeholders in `mailto:` / `tel:` anchors so exported CV PDFs carry machine-readable contact annotations.

### Why
ATS parsers that read the PDF annotation layer to fill contact fields previously found no email or phone (only the LinkedIn/portfolio https links were anchored). See linked issue.

### Verification
Rendered a fixed-data sample through `generate-pdf.mjs` and confirmed via `pypdf` that the output now contains `tel:` and `mailto:` annotations alongside the existing https links. Visual layout unchanged (`.contact-row a` already styles anchors like the surrounding text).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CV contact information is now interactive and more accessible. Phone numbers appear as clickable links that initiate direct phone calls, while email addresses are clickable links that open your default email client. This makes it easier for potential employers to contact you directly from your CV.
* **Documentation**
  * Updated PDF template-placeholder guidance to clarify what to omit when phone data is missing, including the phone link and its separator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->