### PR TITLE
fix(scan): match title-filter keywords on word boundaries

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -121,14 +121,22 @@ function resolveProvider(entry, providers, { skipIds = [] } = {}) {
 
 // ── Title filter ────────────────────────────────────────────────────
 
+// Match a keyword only when it is not flanked by other letters, so short
+// acronyms ("CTO", "VP") don't match as substrings inside longer words
+// (e.g. "CTO" inside "direCTOr", which would let every Director role pass a
+// CTO-targeted filter). Surrounding spaces and punctuation still match.
+function boundaried(k) {
+  const esc = k.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?<![a-z])${esc}(?![a-z])`, 'i');
+}
+
 export function buildTitleFilter(titleFilter) {
-  const positive = (titleFilter?.positive || []).map(k => k.toLowerCase());
-  const negative = (titleFilter?.negative || []).map(k => k.toLowerCase());
+  const positive = (titleFilter?.positive || []).map(boundaried);
+  const negative = (titleFilter?.negative || []).map(boundaried);
 
   return (title) => {
-    const lower = title.toLowerCase();
-    const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
-    const hasNegative = negative.some(k => lower.includes(k));
+    const hasPositive = positive.length === 0 || positive.some(re => re.test(title));
+    const hasNegative = negative.some(re => re.test(title));
     return hasPositive && !hasNegative;
   };
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1251,12 +1251,35 @@ console.log('\n15. Location filter — always_allow tier');
 
 try {
   const {
+    buildTitleFilter,
     buildLocationFilter,
     buildContentFilter,
     shouldDedupScanHistoryRow,
     formatPipelineOffer,
     formatScanHistoryRow,
   } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+
+  // Title filter — keywords must match on word boundaries, not as substrings.
+  // Regression: the short keyword "CTO" matched inside "direCTOr", so every
+  // non-engineering Director role passed a CTO/Director-of-Engineering filter.
+  const titleFilter = buildTitleFilter({
+    positive: ['CTO', 'VP of Engineering', 'Director of Engineering', 'Head of Engineering'],
+    negative: ['VP Sales'],
+  });
+  if (titleFilter('Director of Analytics') === false) pass('"Director of Analytics" rejected — "CTO" no longer matches inside "direCTOr"');
+  else fail('"Director of Analytics" should be rejected (CTO substring bug)');
+  if (titleFilter('Director, FP&A - Growth') === false) pass('"Director, FP&A - Growth" rejected (no CTO substring match)');
+  else fail('"Director, FP&A - Growth" should be rejected');
+  if (titleFilter('CTO') === true) pass('"CTO" still matches as a whole word');
+  else fail('"CTO" should still match');
+  if (titleFilter('Chief Technology Officer (CTO)') === true) pass('"CTO" matches when flanked by punctuation/parens');
+  else fail('"CTO" in parentheses should still match');
+  if (titleFilter('VP of Engineering') === true) pass('"VP of Engineering" still matches');
+  else fail('"VP of Engineering" should match');
+  if (titleFilter('Director of Engineering') === true) pass('"Director of Engineering" still matches');
+  else fail('"Director of Engineering" should match');
+  if (titleFilter('VP Sales, Engineering Partnerships') === false) pass('negative keyword "VP Sales" still rejects on word boundary');
+  else fail('"VP Sales, Engineering Partnerships" should be rejected by negative keyword');
 
   const filter = buildLocationFilter({
     always_allow: ['belgium', 'brussels'],


### PR DESCRIPTION
Closes #1169.

## Problem

`buildTitleFilter` matched keywords with `String.includes`, a substring match. The keyword `CTO` matched inside `direCTOr`, so every Director-level title passed a filter that only listed engineering roles. Real-world scan output added these non-engineering roles to the pipeline:

- Director of Analytics
- Director, FP&A - Growth
- Director, Global Provider GTM
- Director, Provider Product Marketing
- Senior Director of Lifecycle Strategy

## Fix

Compile each positive/negative keyword to a regex that requires it not be flanked by other letters:

```js
new RegExp(`(?<![a-z])${escaped}(?![a-z])`, 'i')
```

Surrounding spaces and punctuation still match, so `Chief Technology Officer (CTO)`, `VP, Engineering`, and `VP Product & Engineering` are unaffected. Regex special characters in keywords are escaped.

## Tests

Added regression cases to `test-all.mjs` (section 15) covering:
- `Director of Analytics` / `Director, FP&A - Growth` now rejected (the bug)
- `CTO` still matches as a whole word, and when wrapped in parentheses
- `VP of Engineering` / `Director of Engineering` still match
- negative keyword `VP Sales` still rejects on a word boundary

`node test-all.mjs` -> 391 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Title keyword matching now recognizes whole words only, preventing false positives (e.g., "CTO" no longer matches inside "director").

* **Tests**
  * Added regression tests for word-boundary behavior in title filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->