### PR TITLE
feat(liveness): zero-token ATS API check before Playwright (closes #574)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,12 +255,14 @@ Default modes are in `modes/` (English). Language-specific modes live in `modes/
 
 ## Offer Verification -- MANDATORY
 
-**NEVER trust WebSearch/WebFetch to verify if an offer is still active.** ALWAYS use Playwright:
-1. `browser_navigate` to the URL
-2. `browser_snapshot` to read content
-3. Only footer/navbar without JD = closed. Title + description + Apply = active.
+Verify a posting is still live before applying — using the cheapest check that works (a false "expired" is worse than a slow check: it makes the user miss a real job):
 
-**Exception for batch workers (`claude -p`):** Playwright is not available in headless pipe mode. Use WebFetch as fallback and mark the report header with `**Verification:** unconfirmed (batch mode)`. The user can verify manually later.
+1. **ATS-hosted postings (Greenhouse, Lever, ...) — API first, zero tokens:** run `node check-liveness.mjs <url>`. It hits the posting's public ATS JSON API directly (no browser, no tokens) and reports `active`/`expired`, falling back to a browser only when the API is inconclusive. A definitive `expired` from the API is authoritative.
+2. **Non-ATS pages, or when the API is inconclusive — Playwright:** `browser_navigate` to the URL + `browser_snapshot`. Only footer/navbar without JD = closed; title + description + Apply = active.
+
+**NEVER decide liveness from a bare WebSearch/WebFetch snippet** — use `check-liveness.mjs` (which does the API rung) or Playwright.
+
+**Exception for batch workers (`claude -p`):** Playwright is unavailable in headless pipe mode. The API rung above still works for ATS postings; for non-ATS pages use WebFetch as a fallback and mark the report header `**Verification:** unconfirmed (batch mode)`.
 
 ---
 

--- a/check-liveness.mjs
+++ b/check-liveness.mjs
@@ -5,7 +5,8 @@
  *
  * Tests whether job posting URLs are still active or have expired.
  * Uses the same detection logic as scan.md step 7.5.
- * Zero Claude API tokens — pure Playwright.
+ * Zero Claude API tokens. Two rungs: a free ATS API check first
+ * (Greenhouse/Lever — no browser), then Playwright for everything else.
  *
  * Usage:
  *   node check-liveness.mjs <url1> [url2] ...
@@ -23,6 +24,7 @@ import {
   jitteredDelayMs,
   sleep,
 } from './liveness-browser.mjs';
+import { checkLivenessViaApi } from './liveness-api.mjs';
 
 async function main() {
   const args = process.argv.slice(2);
@@ -58,32 +60,52 @@ async function main() {
   ].filter(Boolean);
   console.log(`Checking ${urls.length} URL(s)...${notes.length ? ` (${notes.join(', ')})` : ''}\n`);
 
-  const browser = await chromium.launch({ headless: true });
-  const page = await newLivenessPage(browser);
-  const headed = noFallback ? null : createHeadedPageProvider(chromium);
-  const getHeadedPage = headed ? () => headed.get() : undefined;
+  // Lazy browser: the API rung resolves ATS postings with no browser at all, so we
+  // only launch Playwright if a URL actually needs the fallback.
+  let browser = null, page = null, headed = null;
+  async function ensureBrowser() {
+    if (browser) return;
+    browser = await chromium.launch({ headless: true });
+    page = await newLivenessPage(browser);
+    headed = noFallback ? null : createHeadedPageProvider(chromium);
+  }
 
-  let active = 0, expired = 0, uncertain = 0;
+  let active = 0, expired = 0, uncertain = 0, viaApi = 0;
 
   // Sequential — project rule: never Playwright in parallel
   for (let i = 0; i < urls.length; i++) {
     const url = urls[i];
-    const { result, reason } = await checkUrlLivenessWithFallback(page, url, { getHeadedPage });
+    let result, reason, usedBrowser = false;
+
+    // Rung 1: zero-token ATS API check. A conclusive active/expired wins; otherwise fall through.
+    const api = await checkLivenessViaApi(url);
+    if (api) {
+      ({ result, reason } = api);
+      viaApi++;
+    } else {
+      // Rung 2: Playwright — handles non-ATS pages and inconclusive API results.
+      await ensureBrowser();
+      const getHeadedPage = headed ? () => headed.get() : undefined;
+      ({ result, reason } = await checkUrlLivenessWithFallback(page, url, { getHeadedPage }));
+      usedBrowser = true;
+    }
+
     const icon = { active: '✅', expired: '❌', uncertain: '⚠️' }[result];
-    console.log(`${icon} ${result.padEnd(10)} ${url}`);
+    console.log(`${icon} ${result.padEnd(10)} ${api ? '(api) ' : '      '}${url}`);
     if (result !== 'active') console.log(`           ${reason}`);
     if (result === 'active') active++;
     else if (result === 'expired') expired++;
     else uncertain++;
 
-    const wait = i < urls.length - 1 ? jitteredDelayMs(throttleBaseMs) : 0;
+    // Throttle only matters between browser checks (the API is cheap, not WAF-rate-limited).
+    const wait = usedBrowser && i < urls.length - 1 ? jitteredDelayMs(throttleBaseMs) : 0;
     if (wait) await sleep(wait);
   }
 
   if (headed) await headed.close();
-  await browser.close();
+  if (browser) await browser.close();
 
-  console.log(`\nResults: ${active} active  ${expired} expired  ${uncertain} uncertain`);
+  console.log(`\nResults: ${active} active  ${expired} expired  ${uncertain} uncertain  (${viaApi} via API, no browser)`);
   if (expired > 0 || uncertain > 0) process.exit(1);
 }
 

--- a/liveness-api.mjs
+++ b/liveness-api.mjs
@@ -1,0 +1,114 @@
+// @ts-check
+/**
+ * liveness-api.mjs — zero-token liveness check for ATS-hosted job postings.
+ *
+ * Many postings live on ATS platforms (Greenhouse, Lever, ...) that expose a
+ * public per-job JSON endpoint. We can confirm whether a posting is still live by
+ * hitting that endpoint directly — no browser, no LLM tokens — and only fall back
+ * to the Playwright check (liveness-browser.mjs) for non-ATS pages or when the API
+ * is inconclusive. This is the cheap first rung of the liveness ladder.
+ *
+ * CONSERVATIVE BY DESIGN: a false "expired" is worse than the status quo (the user
+ * misses a real job). So this returns `expired` ONLY on a definitive 404/410,
+ * `active` ONLY on a 200, and `null` (→ caller falls back to Playwright) for
+ * anything ambiguous (unknown ATS, redirect, 429/5xx, network/timeout).
+ *
+ * SSRF-safe by construction: the request URL is built from a FIXED, hard-coded API
+ * host plus path segments extracted from the posting URL with a strict charset
+ * (no slashes / traversal), and server-side redirects are refused.
+ */
+
+const TIMEOUT_MS = 8_000;
+// Strict path-segment charset. Anything with a slash, dot-dot, or other char is
+// rejected before it can reach the fixed-host API URL template.
+const SAFE_SEGMENT = /^[A-Za-z0-9._-]+$/;
+
+// Each ATS: detect its posting URL, then map to the public per-job API URL.
+// `match` returns the extracted path params (or null); `api` builds the FIXED-host URL.
+const ATS_PROVIDERS = [
+  {
+    id: 'greenhouse',
+    // boards.greenhouse.io/{board}/jobs/{id} · job-boards[.eu].greenhouse.io/{board}/jobs/{id}
+    match(u) {
+      if (!/(^|\.)greenhouse\.io$/.test(u.hostname)) return null;
+      const m = u.pathname.match(/^\/([^/]+)\/jobs\/(\d+)\/?$/);
+      return m ? { board: m[1], id: m[2] } : null;
+    },
+    api: ({ board, id }) => `https://boards-api.greenhouse.io/v1/boards/${board}/jobs/${id}`,
+  },
+  {
+    id: 'lever',
+    // jobs.lever.co/{slug}/{id}
+    match(u) {
+      if (u.hostname !== 'jobs.lever.co') return null;
+      const m = u.pathname.match(/^\/([^/]+)\/([^/?#]+)\/?$/);
+      return m ? { slug: m[1], id: m[2] } : null;
+    },
+    api: ({ slug, id }) => `https://api.lever.co/v0/postings/${slug}/${id}`,
+  },
+];
+
+/**
+ * Map a posting URL to its ATS per-job API URL, or null if it isn't a known ATS
+ * posting (or any extracted segment fails the strict charset). Pure + deterministic.
+ * @param {string} rawUrl
+ * @returns {{ ats: string, apiUrl: string } | null}
+ */
+export function resolveAtsApi(rawUrl) {
+  let u;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'https:') return null;
+  for (const provider of ATS_PROVIDERS) {
+    const parts = provider.match(u);
+    if (!parts) continue;
+    // SSRF guard: every derived segment must be a single safe path segment.
+    if (!Object.values(parts).every((v) => SAFE_SEGMENT.test(v) && !v.includes('..'))) return null;
+    return { ats: provider.id, apiUrl: provider.api(parts) };
+  }
+  return null;
+}
+
+/** True if `url` is an ATS posting we can check via API (lets callers stay lazy about the browser). */
+export function isAtsPosting(url) {
+  return resolveAtsApi(url) !== null;
+}
+
+/**
+ * Zero-token liveness check via the posting's ATS API.
+ * @param {string} url
+ * @returns {Promise<{ result: 'active' | 'expired', code: string, reason: string } | null>}
+ *   null = not a known ATS posting, or inconclusive → caller should fall back to Playwright.
+ */
+export async function checkLivenessViaApi(url) {
+  const resolved = resolveAtsApi(url);
+  if (!resolved) return null;
+  const { ats, apiUrl } = resolved;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  let res;
+  try {
+    res = await fetch(apiUrl, {
+      method: 'GET',
+      headers: { 'user-agent': 'career-ops-liveness/1.0', accept: 'application/json' },
+      redirect: 'error', // refuse server-side redirects (SSRF + ambiguity guard)
+      signal: controller.signal,
+    });
+  } catch {
+    return null; // network / timeout / redirect → inconclusive, let Playwright decide
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (res.status === 404 || res.status === 410) {
+    return { result: 'expired', code: `${ats}_api_gone`, reason: `ATS API ${res.status} — posting removed` };
+  }
+  if (res.status === 200) {
+    return { result: 'active', code: `${ats}_api_ok`, reason: 'ATS API returns the posting (live)' };
+  }
+  return null; // 429/5xx/other → inconclusive, fall back to the browser check
+}

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -264,6 +264,34 @@ try {
     fail(`Polish apply control not recognized: ${activePolishPosting.result} (${activePolishPosting.code})`);
   }
 
+  // Liveness API rung (liveness-api.mjs) — the zero-token ATS first rung. We test the
+  // pure URL→API resolution + SSRF guard; the network fetch is conservative by
+  // construction (only 404/410→expired, 200→active, else null→Playwright fallback).
+  const { resolveAtsApi } = await import(pathToFileURL(join(ROOT, 'liveness-api.mjs')).href);
+  const ghApi = resolveAtsApi('https://boards.greenhouse.io/acme/jobs/4567890');
+  if (ghApi?.ats === 'greenhouse' && ghApi.apiUrl === 'https://boards-api.greenhouse.io/v1/boards/acme/jobs/4567890') {
+    pass('resolveAtsApi maps a Greenhouse posting to its per-job API URL');
+  } else {
+    fail(`Greenhouse API URL wrong: ${JSON.stringify(ghApi)}`);
+  }
+  const lvApi = resolveAtsApi('https://jobs.lever.co/acme/abc-123-def');
+  if (lvApi?.ats === 'lever' && lvApi.apiUrl === 'https://api.lever.co/v0/postings/acme/abc-123-def') {
+    pass('resolveAtsApi maps a Lever posting to its per-job API URL');
+  } else {
+    fail(`Lever API URL wrong: ${JSON.stringify(lvApi)}`);
+  }
+  if (resolveAtsApi('https://example.com/jobs/123') === null) {
+    pass('resolveAtsApi returns null for non-ATS URLs (→ Playwright fallback)');
+  } else {
+    fail('resolveAtsApi should return null for an unknown host');
+  }
+  if (resolveAtsApi('https://boards.greenhouse.io/acme/jobs/not-a-number') === null
+      && resolveAtsApi('http://boards.greenhouse.io/acme/jobs/123') === null) {
+    pass('resolveAtsApi rejects non-numeric Greenhouse ids and non-https (SSRF guard)');
+  } else {
+    fail('resolveAtsApi guard failed (bad id or http accepted)');
+  }
+
   // Headed-fallback-on-challenge path (liveness-browser.mjs). Fake Playwright
   // pages script the goto/evaluate calls so we can exercise the wrapper without
   // launching a browser. checkUrlLiveness reads body text first, apply controls

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -90,6 +90,7 @@ const SYSTEM_PATHS = [
   'check-liveness.mjs',
   'liveness-core.mjs',
   'liveness-browser.mjs',
+  'liveness-api.mjs',
   'analyze-patterns.mjs',
   'followup-cadence.mjs',
   'gemini-eval.mjs',


### PR DESCRIPTION
## What

Adds a zero-token **ATS API liveness check** as the first rung before Playwright. Closes #574.

A common complaint: you go to apply and the posting has already expired. Offer Verification mandated Playwright (a browser + tokens) for *every* liveness check. But for ATS-hosted postings, the public per-job JSON API already tells us whether a posting is live — instantly, no browser, no tokens. So we check the API first and only fall back to Playwright for non-ATS pages or inconclusive results.

## Conservative by design
A false "expired" is worse than a slow check — it hides a real job from the user. So the API rung returns:
- `expired` **only** on a definitive 404/410
- `active` **only** on a 200
- `null` (→ Playwright fallback) for anything ambiguous (unknown ATS, redirect, 429/5xx, network error)

SSRF-safe by construction: the request URL is a fixed, hard-coded API host plus path segments extracted with a strict charset (no slashes / traversal), redirects refused.

## Coverage (honest)
- ✅ Canonical `*.greenhouse.io/{board}/jobs/{id}` and `jobs.lever.co/{slug}/{id}` URLs use the API rung.
- ↪️ Branded company-domain URLs (e.g. `stripe.com/jobs?gh_jid=…`) fall back to Playwright — they don't carry the board token needed to build the API URL. Safe, just no speedup for those.
- Follow-ups: Ashby, Workable, SmartRecruiters, Workday (same pattern).

## Verified against the live API
- `gitlab`, `figma` (canonical URLs) → `active` ✓
- removed posting (bogus id) → 404 → `expired` ✓
- `example.com` + branded URLs → `null` → Playwright fallback ✓
- `test-all.mjs`: **389 passed / 0 failed** (includes new URL-resolution + SSRF-guard tests)

Prompted by @AKhozya's analysis in #574 — thank you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
