### PR TITLE
feat(providers): add Breezy HR provider

### DIFF
--- a/modes/scan.md
+++ b/modes/scan.md
@@ -126,6 +126,7 @@ For companies with a public API or structured feed **that are not in `local_pars
 - **Lever**: `https://api.lever.co/v0/postings/{company}?mode=json`
 - **Teamtailor**: `https://{company}.teamtailor.com/jobs.rss`
 - **Workday**: `https://{company}.{shard}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs`
+- **Breezy**: `https://{company}.breezy.hr/json`
 
 **Parsing Conventions by Provider:**
 - `greenhouse`: `jobs[]` → `title`, `absolute_url`
@@ -134,6 +135,7 @@ For companies with a public API or structured feed **that are not in `local_pars
 - `lever`: root array `[]` → `text`, `hostedUrl` (fallback: `applyUrl`)
 - `teamtailor`: RSS items → `title`, `link`
 - `workday`: `jobPostings[]`/`jobPostings` (based on tenant) → `title`, `externalPath` or URL built from the host
+- `breezy`: top-level array `[]` → `name`, `url` (absolute), `location.name` (or city/state/country + `is_remote`), `published_date`
 
 ### Level 3 — WebSearch Queries (BROAD DISCOVERY)
 
@@ -178,7 +180,7 @@ Levels are additive — they are executed in order, and results are merged and d
 5. **Level 2 — ATS APIs / Feeds** (parallel):
    For each company in `tracked_companies` with a defined `api:`, `enabled: true`, and a **name not listed in `local_parser_ok`**:
    a. WebFetch the API/feed URL.
-   b. If `api_provider` is defined, use its parser; if undefined, infer by domain (`boards-api.greenhouse.io`, `jobs.ashbyhq.com`, `api.lever.co`, `*.bamboohr.com`, `*.teamtailor.com`, `*.myworkdayjobs.com`).
+   b. If `api_provider` is defined, use its parser; if undefined, infer by domain (`boards-api.greenhouse.io`, `jobs.ashbyhq.com`, `api.lever.co`, `*.bamboohr.com`, `*.teamtailor.com`, `*.myworkdayjobs.com`, `*.breezy.hr`).
    c. For **Ashby**, send a POST request with:
       - `operationName: ApiJobBoardWithTeams`
       - `variables.organizationHostedJobsPageName: {company}`

--- a/providers/breezy.mjs
+++ b/providers/breezy.mjs
@@ -1,0 +1,136 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Breezy HR provider — hits the public per-tenant board feed.
+// Auto-detects from careers_url pattern `https://<tenant>.breezy.hr[/...]`.
+// Per-tenant subdomains are the variable part, so SSRF defence uses a regex
+// match on `<safe-tenant>.breezy.hr` rather than a static allowlist (same
+// approach as the recruitee / bamboohr providers).
+//
+// Breezy boards expose every published position as a public JSON array at
+// `<tenant>.breezy.hr/json` — title, absolute url, location, and a published
+// date, all in the list payload at zero token cost (no per-job request, so the
+// scanner stays zero-token). Breezy's authenticated REST API (api.breezy.hr) is
+// intentionally NOT used; only the public board feed.
+
+const BREEZY_HOST_RE = /^[a-z0-9][a-z0-9-]*\.breezy\.hr$/;
+
+/** @param {string} url */
+function assertBreezyUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`breezy: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`breezy: URL must use HTTPS: ${url}`);
+  if (!BREEZY_HOST_RE.test(parsed.hostname)) {
+    throw new Error(`breezy: untrusted hostname "${parsed.hostname}" — must match <tenant>.breezy.hr`);
+  }
+  return url;
+}
+
+/**
+ * Resolve the tenant origin (`https://<tenant>.breezy.hr`) from an entry.
+ * Honours an explicit `api:` URL, else parses `careers_url`.
+ * @param {import('./_types.js').PortalEntry} entry
+ * @returns {string | null}
+ */
+function resolveOrigin(entry) {
+  const rawApi = typeof entry.api === 'string' ? entry.api : '';
+  const rawCareers = typeof entry.careers_url === 'string' ? entry.careers_url : '';
+  const raw = (rawApi || rawCareers).trim();
+  if (!raw) return null;
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:') return null;
+  if (!BREEZY_HOST_RE.test(parsed.hostname)) return null;
+  return `https://${parsed.hostname}`;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'breezy',
+
+  detect(entry) {
+    const origin = resolveOrigin(entry);
+    return origin ? { url: `${origin}/json` } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const origin = resolveOrigin(entry);
+    if (!origin) throw new Error(`breezy: cannot derive API URL for ${entry.name}`);
+    const apiUrl = `${origin}/json`;
+    assertBreezyUrl(apiUrl);
+    // redirect:'error' + the host check above keep the final hostname pinned to
+    // the tenant — a server-side redirect can't bounce us off-domain (SSRF).
+    const json = /** @type {any} */ (await ctx.fetchJson(apiUrl, { redirect: 'error' }));
+    return parseBreezyResponse(json, entry.name);
+  },
+};
+
+/**
+ * Parse a Breezy `<tenant>.breezy.hr/json` response. Exported for unit tests.
+ *
+ * Breezy returns a top-level array of positions:
+ *   [{ name, url, published_date?,
+ *      location: { name?, city?, state?, country?: { name }, is_remote? } }]
+ *
+ * - url: Breezy supplies an absolute posting URL on the tenant domain
+ *   (`https://<tenant>.breezy.hr/p/<id>-<slug>`); it is the Job contract's dedup
+ *   key. The per-offer URL is display-only (recorded in the pipeline/history,
+ *   never server-fetched here), so it is not host-locked — only a well-formed
+ *   `https:` URL is required; rows without one are dropped.
+ * - location: prefer the ready-made `location.name`; else assemble from
+ *   city / state / country.name, appending "Remote" when `is_remote` is truthy.
+ * - postedAt: parsed from the ISO `published_date` when present and valid — Breezy
+ *   gives it for free in the list payload, so recency consumers can use it.
+ *
+ * @param {any} json
+ * @param {string} companyName
+ * @returns {Array<{title: string, url: string, company: string, location: string, postedAt?: number}>}
+ */
+export function parseBreezyResponse(json, companyName) {
+  const rows = Array.isArray(json) ? json : [];
+  const out = [];
+  for (const j of rows) {
+    if (!j || !j.name) continue;
+
+    // Resolve the posting URL (dedup key). Require a well-formed https: URL;
+    // a non-https or malformed/missing URL drops the row.
+    let url = '';
+    const rawUrl = typeof j.url === 'string' ? j.url : '';
+    if (rawUrl) {
+      try {
+        const parsed = new URL(rawUrl);
+        if (parsed.protocol === 'https:') url = parsed.href;
+      } catch { /* malformed → drop */ }
+    }
+    if (!url) continue;
+
+    const loc = j.location || {};
+    const remote = loc.is_remote ? 'Remote' : '';
+    const assembled = [loc.city, loc.state, loc.country?.name].filter(Boolean).join(', ');
+    const base = (typeof loc.name === 'string' && loc.name.trim()) ? loc.name.trim() : assembled;
+    const location = remote && !/remote/i.test(base)
+      ? [base, remote].filter(Boolean).join(', ')
+      : base;
+
+    const job = {
+      title: String(j.name),
+      url,
+      company: companyName,
+      location,
+    };
+
+    const ts = Date.parse(j.published_date);
+    if (!Number.isNaN(ts)) job.postedAt = ts;
+
+    out.push(job);
+  }
+  return out;
+}

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4198,6 +4198,111 @@ try {
   fail(`ATS ligature suppression test crashed: ${e.message}`);
 }
 
+// ── 27. Provider — breezy ───────────────────────────────────────
+console.log('\n27. Provider — breezy');
+
+try {
+  const breezy = (await import(pathToFileURL(join(ROOT, 'providers/breezy.mjs')).href)).default;
+  const { parseBreezyResponse } = await import(pathToFileURL(join(ROOT, 'providers/breezy.mjs')).href);
+
+  if (breezy.id === 'breezy') pass('breezy.id is "breezy"');
+  else fail(`breezy.id is ${JSON.stringify(breezy.id)}`);
+
+  // detect: careers_url with a path still resolves the tenant /json feed
+  const hit = breezy.detect({ name: 'New Incentives', careers_url: 'https://new-incentives.breezy.hr/' });
+  if (hit && hit.url === 'https://new-incentives.breezy.hr/json') {
+    pass('breezy.detect() resolves <tenant>.breezy.hr → /json feed');
+  } else {
+    fail(`breezy.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  // detect: explicit api: URL is honoured over careers_url
+  const apiHit = breezy.detect({ name: 'X', api: 'https://acme.breezy.hr', careers_url: 'https://example.com' });
+  if (apiHit && apiHit.url === 'https://acme.breezy.hr/json') {
+    pass('breezy.detect() honours an explicit api: URL');
+  } else {
+    fail(`breezy.detect() api: → ${JSON.stringify(apiHit)}`);
+  }
+
+  if (breezy.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('breezy.detect() returns null for non-breezy URLs');
+  } else {
+    fail('breezy.detect() should return null for non-breezy URLs');
+  }
+
+  if (breezy.detect({ name: 'X', careers_url: null }) === null && breezy.detect({ name: 'X', careers_url: 7 }) === null) {
+    pass('breezy.detect() returns null for non-string careers_url (null and 7)');
+  } else {
+    fail('breezy.detect() should treat non-string careers_url as missing');
+  }
+
+  // SSRF: breezy.hr in the PATH (not host) must not be detected.
+  if (breezy.detect({ name: 'Spoof', careers_url: 'https://evil.example/acme.breezy.hr/json' }) === null) {
+    pass('breezy.detect() rejects path-spoofed URLs');
+  } else {
+    fail('breezy.detect() must NOT misdetect path-spoofed URLs');
+  }
+
+  // parseBreezyResponse — top-level array
+  const sample = [
+    {
+      name: 'Assistant Field Manager',
+      url: 'https://new-incentives.breezy.hr/p/b8e6-assistant-field-manager',
+      published_date: '2026-05-25T14:45:23.799Z',
+      location: { name: 'Niger, Sokoto, NG', city: 'Niger', country: { name: 'NG' }, is_remote: false },
+    },
+    {
+      name: 'Remote Backend Engineer',
+      url: 'https://new-incentives.breezy.hr/p/aa01-backend',
+      location: { city: 'Lagos', state: 'Lagos', country: { name: 'NG' }, is_remote: true },
+    },
+    { name: 'No URL row', location: { name: 'Remote' } },
+    { name: 'Insecure URL', url: 'http://new-incentives.breezy.hr/p/x', location: {} },
+  ];
+  const jobs = parseBreezyResponse(sample, 'New Incentives');
+
+  if (jobs.length === 2) pass('parseBreezyResponse keeps 2 rows (drops missing/non-https url)');
+  else fail(`parseBreezyResponse returned ${jobs.length} rows (expected 2)`);
+
+  if (jobs[0]?.title === 'Assistant Field Manager' && jobs[0]?.company === 'New Incentives' && jobs[0]?.location === 'Niger, Sokoto, NG') {
+    pass('parseBreezyResponse prefers ready-made location.name');
+  } else {
+    fail(`row 0 = ${JSON.stringify(jobs[0])}`);
+  }
+
+  if (jobs[0]?.postedAt === Date.parse('2026-05-25T14:45:23.799Z')) {
+    pass('parseBreezyResponse parses published_date → postedAt');
+  } else {
+    fail(`row 0 postedAt = ${JSON.stringify(jobs[0]?.postedAt)}`);
+  }
+
+  if (jobs[1]?.location === 'Lagos, Lagos, NG, Remote') {
+    pass('parseBreezyResponse assembles city/state/country and appends Remote');
+  } else {
+    fail(`row 1 location = ${JSON.stringify(jobs[1]?.location)}, expected "Lagos, Lagos, NG, Remote"`);
+  }
+
+  if (jobs[1]?.postedAt === undefined) {
+    pass('parseBreezyResponse omits postedAt when published_date is absent');
+  } else {
+    fail(`row 1 postedAt should be undefined, got ${JSON.stringify(jobs[1]?.postedAt)}`);
+  }
+
+  if (parseBreezyResponse(null, 'X').length === 0 && parseBreezyResponse({}, 'X').length === 0) {
+    pass('non-array payload → empty result (no crash)');
+  } else {
+    fail('non-array payload should yield empty result');
+  }
+
+  // a row already containing "Remote" must not get a duplicate "Remote" suffix
+  const noDup = parseBreezyResponse([{ name: 'R', url: 'https://acme.breezy.hr/p/r', location: { name: 'Remote, EMEA', is_remote: true } }], 'X');
+  if (noDup[0]?.location === 'Remote, EMEA') pass('parseBreezyResponse does not double-append Remote');
+  else fail(`expected "Remote, EMEA", got ${JSON.stringify(noDup[0]?.location)}`);
+
+} catch (e) {
+  fail(`breezy provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What does this PR do?

Adds a zero-token **Breezy HR** provider (`providers/breezy.mjs`). Breezy boards expose every published position as a public JSON array at `https://<tenant>.breezy.hr/json` — title, absolute url, location, and a published date, all in the list payload at zero token cost. This extends the provider roster under #230, in the same spirit as #1141 (BambooHR) and #1120 (Teamtailor).

## Related issue

Part of #230 (Scanner & Job Board Providers umbrella).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## How it works

- `detect()` resolves `https://<tenant>.breezy.hr[/...]` (and an explicit `api:` URL) → `<tenant>.breezy.hr/json`.
- `fetch()` reads the public `/json` board feed (a top-level array of `{ name, url, location, published_date }`) and maps to the `Job` contract. No per-job request is made, so the scanner stays zero-token.
- `postedAt` is populated from the ISO `published_date` (free in the list payload) — recency consumers like `scan-ats-full.mjs` can use it.
- `location` prefers the ready-made `location.name`, else assembles `city / state / country.name` and appends "Remote" when `is_remote` is set (no double-"Remote").
- Public posting `url` is absolute on the tenant domain and used as the dedup key; rows without a well-formed `https:` url are dropped.
- **SSRF defence:** `<tenant>.breezy.hr` host regex + `redirect: 'error'`, mirroring the recruitee / bamboohr providers. Breezy's authenticated REST API (`api.breezy.hr`) is intentionally **not** used — only the public board feed.
- No `scan.mjs` change — providers auto-load from `providers/*.mjs`.
- `modes/scan.md`: Breezy added to the ATS endpoint catalog, the parser-conventions list, and the domain-inference list (`*.breezy.hr`).

## Tests

13 unit tests in `test-all.mjs` (section 27): detect routing, explicit `api:`, non-breezy / null / non-string rejection, path-spoof SSRF rejection, and parser behaviour (`location.name` preference, city/state/country assembly + Remote, `postedAt` parse/omit, no double-Remote, drop missing/non-https url, non-array payload). Full suite green locally (`429 passed, 0 failed`; the 16 warnings are pre-existing).

Validated live against the public `new-incentives.breezy.hr` board — 16 jobs, all with a valid title + HTTPS url.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I linked a related issue above
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Breezy ATS, enabling automatic detection and processing of Breezy-hosted career pages and JSON feeds.

* **Tests**
  * Added comprehensive test coverage for the Breezy provider, including feed URL resolution, parsing behavior, and security-related URL validation.  

* **Documentation**
  * Updated scan instructions to include Breezy in the Level 2 ATS APIs/feeds workflow and parsing conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->