### PR TITLE
fix(dashboard): rewrite only the Status cell on status update (#1180)

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -606,10 +606,72 @@ func UpdateApplicationStatus(careerOpsPath string, app model.CareerApplication, 
 	return os.WriteFile(filePath, []byte(strings.Join(lines, "\n")), 0644)
 }
 
-// replaceStatusInLine replaces the old status with new status in a table line.
+// replaceStatusInLine rewrites only the Status cell of a tracker row, leaving
+// every other cell untouched. The previous implementation used
+// strings.Replace(line, oldStatus, …, 1), which replaces the first occurrence of
+// the status text anywhere in the row — so a status word appearing as a
+// substring of an earlier cell (e.g. Company "Applied Materials") was rewritten
+// instead of the Status cell, corrupting that cell while the status appeared to
+// stay unchanged (#1180). Matching is whole-cell (never a substring) and, as the
+// old comment claimed but the code did not, case-insensitive.
 func replaceStatusInLine(line, oldStatus, newStatus string) string {
-	// Case-insensitive replacement of the status field
-	return strings.Replace(line, oldStatus, newStatus, 1)
+	want := strings.TrimSpace(oldStatus)
+
+	// Mixed "| " + tab-separated format (mirrors ParseApplications). The Status
+	// field is index 5 of the tab-split body.
+	if strings.Contains(line, "\t") {
+		prefix, body, found := strings.Cut(line, "|")
+		if !found {
+			return line
+		}
+		cells := strings.Split(body, "\t")
+		if idx := statusCellIndex(cells, 5, want); idx >= 0 {
+			cells[idx] = spliceCellValue(cells[idx], newStatus)
+			return prefix + "|" + strings.Join(cells, "\t")
+		}
+		return line
+	}
+
+	// Pure pipe format. strings.Split keeps the segments between pipes; content
+	// cell N is segment N+1 (segment 0 is the empty text before the leading
+	// pipe), so the canonical Status column (ParseApplications field 5) is
+	// segment 6.
+	segments := strings.Split(line, "|")
+	if idx := statusCellIndex(segments, 6, want); idx >= 0 {
+		segments[idx] = spliceCellValue(segments[idx], newStatus)
+		return strings.Join(segments, "|")
+	}
+	return line
+}
+
+// statusCellIndex returns the index of the Status cell. It prefers the canonical
+// column (canonicalIdx, matching ParseApplications) and verifies it by value; if
+// that doesn't match — e.g. a custom tracker layout — it falls back to the first
+// cell that equals want exactly. Matching is whole-cell and case-insensitive,
+// never a substring, so a status word inside an earlier cell is never hit.
+// Returns -1 when nothing matches, so the caller leaves the row untouched rather
+// than corrupt a guess.
+func statusCellIndex(cells []string, canonicalIdx int, want string) int {
+	if canonicalIdx < len(cells) && strings.EqualFold(strings.TrimSpace(cells[canonicalIdx]), want) {
+		return canonicalIdx
+	}
+	for i, c := range cells {
+		if strings.EqualFold(strings.TrimSpace(c), want) {
+			return i
+		}
+	}
+	return -1
+}
+
+// spliceCellValue swaps a cell's inner value while preserving its surrounding
+// whitespace, so "| Applied |" becomes "| Interview |" rather than "|Interview|".
+func spliceCellValue(cell, newVal string) string {
+	trimmed := strings.TrimSpace(cell)
+	if trimmed == "" {
+		return cell
+	}
+	start := strings.Index(cell, trimmed)
+	return cell[:start] + newVal + cell[start+len(trimmed):]
 }
 
 // cleanTableCell removes trailing pipes and whitespace from a table cell value.

--- a/dashboard/internal/data/career_test.go
+++ b/dashboard/internal/data/career_test.go
@@ -3,8 +3,64 @@ package data
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// Regression for #1180: a status word appearing as a substring of an earlier
+// cell (Company "Applied Materials" contains "Applied") must not be rewritten;
+// only the Status column changes.
+func TestUpdateApplicationStatusOnlyRewritesStatusColumn(t *testing.T) {
+	tempDir := t.TempDir()
+	dataDir := filepath.Join(tempDir, "data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("failed to create data dir: %v", err)
+	}
+
+	applications := `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 7 | 2026-06-23 | Applied Materials | Staff Android Engineer | 4.2/5 | Applied | ✅ | [7](reports/007.md) | substring trap |
+`
+	path := filepath.Join(dataDir, "applications.md")
+	if err := os.WriteFile(path, []byte(applications), 0o644); err != nil {
+		t.Fatalf("failed to write tracker: %v", err)
+	}
+
+	apps := ParseApplications(tempDir)
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 parsed application, got %d", len(apps))
+	}
+
+	if err := UpdateApplicationStatus(tempDir, apps[0], "Interview"); err != nil {
+		t.Fatalf("UpdateApplicationStatus: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	out := string(got)
+
+	if !strings.Contains(out, "| Applied Materials |") {
+		t.Errorf("Company cell was corrupted, file now:\n%s", out)
+	}
+	if !strings.Contains(out, "| Interview |") {
+		t.Errorf("Status cell was not updated to Interview, file now:\n%s", out)
+	}
+	if strings.Contains(out, "Interview Materials") {
+		t.Errorf("status word was replaced inside the Company cell, file now:\n%s", out)
+	}
+
+	reparsed := ParseApplications(tempDir)
+	if reparsed[0].Company != "Applied Materials" {
+		t.Errorf("company = %q, want \"Applied Materials\"", reparsed[0].Company)
+	}
+	if reparsed[0].Status != "Interview" {
+		t.Errorf("status = %q, want \"Interview\"", reparsed[0].Status)
+	}
+}
 
 func TestParseApplicationsUsesTrackerNumberColumn(t *testing.T) {
 	tempDir := t.TempDir()


### PR DESCRIPTION
## What

Fixes #1180 — `UpdateApplicationStatus` could rewrite the wrong cell of a tracker row, corrupting an earlier column while the Status appeared unchanged.

`replaceStatusInLine` used:

```go
strings.Replace(line, oldStatus, newStatus, 1)
```

which replaces the first occurrence of the status text **anywhere** in the row. When an earlier cell contains the status word as a substring — e.g. Company **"Applied Materials"** with Status **"Applied"** — the Company cell is rewritten to "Interview Materials" and the Status silently stays "Applied".

## Fix

Make the replacement **column-aware**, exactly as the issue suggested: tokenize the row with the same pipe/tab logic `ParseApplications` uses, match the Status cell on its **whole, trimmed value** (case-insensitive — as the old comment claimed but the code wasn't), and rewrite **only** that cell while preserving surrounding whitespace.

- Prefers the canonical Status column (field index 5, matching `ParseApplications`) and verifies it by value.
- Falls back to the first cell that equals the old status exactly — whole-cell only, never a substring — so custom layouts still work and `"Applied Materials"` can never be hit.
- Returns the row untouched when nothing matches, rather than corrupt a guess.

## Tests

Adds `TestUpdateApplicationStatusOnlyRewritesStatusColumn`, which reproduces the "Applied Materials" case end-to-end (parse → update → re-parse) and asserts the Company cell is intact and the Status became `Interview`. Full dashboard suite green:

```
ok  github.com/santifer/career-ops/dashboard
ok  github.com/santifer/career-ops/dashboard/internal/data
ok  github.com/santifer/career-ops/dashboard/internal/ui/screens
```

`go vet ./internal/data/` clean, `go build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where updating an application's status could unintentionally modify other fields (such as company name) if they contained the same text substring. Status updates now target only the Status column with precise matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->