### PR TITLE
fix(scan): guard title-filter keyword normalization against non-string config values

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -135,8 +135,14 @@ export function compileKeyword(kw) {
 }
 
 export function buildTitleFilter(titleFilter) {
-  const positive = (titleFilter?.positive || []).map(k => k.toLowerCase()).map(compileKeyword);
-  const negative = (titleFilter?.negative || []).map(k => k.toLowerCase()).map(compileKeyword);
+  // Normalize defensively: a malformed title_filter (a null, numeric, or otherwise
+  // non-string entry in the YAML) must not crash the scan via k.toLowerCase().
+  const normalize = (arr) => (Array.isArray(arr) ? arr : [])
+    .filter(k => typeof k === 'string' && k.length > 0)
+    .map(k => k.toLowerCase())
+    .map(compileKeyword);
+  const positive = normalize(titleFilter?.positive);
+  const negative = normalize(titleFilter?.negative);
 
   return (title) => {
     const lower = (title || '').toLowerCase();

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1569,6 +1569,14 @@ try {
   } else {
     fail('compileKeyword("cfo") boundary behavior wrong');
   }
+
+  // A malformed title_filter (null / numeric / empty entries) must not crash.
+  const messyFilter = buildTitleFilter({ positive: ['cfo', null, 123, '', 'head of'] });
+  if (messyFilter('Group CFO') === true && messyFilter('Marketing Coordinator') === false) {
+    pass('buildTitleFilter ignores non-string/empty keyword entries without crashing');
+  } else {
+    fail('buildTitleFilter should ignore non-string/empty keyword entries');
+  }
 } catch (e) {
   fail(`title filter acronym tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
## What
Hardens `buildTitleFilter` so a malformed `title_filter` (a null, numeric, or otherwise non-string keyword entry in the YAML) no longer crashes the scan at startup via `k.toLowerCase()`. Non-string and empty entries are filtered out before lowercasing and compiling.

## Why
Follow-up to the CodeRabbit review comment on #1102. The `.toLowerCase()` call predates that PR (substring matching already did it), but the bot's point is valid, and this makes keyword normalization defensive, in line with the repo guideline to handle bad or missing data gracefully.

## Details
- `buildTitleFilter` runs positives and negatives through a small `normalize()` that keeps only non-empty strings before `toLowerCase` + `compileKeyword`.
- `test-all.mjs` section 11b gains a case proving a mixed `['cfo', null, 123, '', 'head of']` filter is handled without crashing and still matches correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced error handling for title filters to gracefully manage invalid or malformed entries—including null values, empty strings, and non-string types—preventing application crashes and ensuring stable, consistent behavior regardless of configuration variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->