### PR TITLE
feat(arbeitsagentur): config-driven remoteMatch + server-side homeoffice filter

### DIFF
--- a/providers/arbeitsagentur.mjs
+++ b/providers/arbeitsagentur.mjs
@@ -18,7 +18,13 @@
 //       umkreis: 50             # km radius around `wo` (default 50)
 //       days: 30                # recency window in days (default 30)
 //       size: 100               # results per keyword (1–100, default 100)
-//       remoteNationwide: true  # also run a nationwide pass keeping remote-titled hits
+//       remoteNationwide: true  # also run a nationwide pass keeping remote-eligible hits
+//       remoteMatch: filter     # how that pass detects remote (default 'title'):
+//                               #   'filter' — server-side `homeoffice=nv_true` query + pagination; every hit is
+//                               #              remote-eligible, cheap (no per-job calls). Recommended.
+//                               #   'title'  — regex on the job title only (cheap; misses body-level remote)
+//                               #   'off'    — skip the remote pass entirely
+//       remoteMaxPages: 10      # 'filter' mode: max pages to paginate (size each); default 1
 //     enabled: true
 
 const API_URL = 'https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobs';
@@ -37,7 +43,7 @@ function intInRange(val, def, min, max) {
 /**
  * Reads and sanitizes the entry's `arbeitsagentur:` config block.
  * @param {{ arbeitsagentur?: any }} entry
- * @returns {{ keywords: string[], wo: string, umkreis: number, days: number, size: number, remoteNationwide: boolean }}
+ * @returns {{ keywords: string[], wo: string, umkreis: number, days: number, size: number, remoteNationwide: boolean, remoteMatch: 'title'|'filter'|'off', remoteMaxPages: number }}
  */
 export function parseArbeitsagenturConfig(entry) {
   const cfg = (entry && entry.arbeitsagentur) || {};
@@ -51,6 +57,9 @@ export function parseArbeitsagenturConfig(entry) {
     days: intInRange(cfg.days, 30, 1, 1000),       // recency window
     size: intInRange(cfg.size, 100, 1, 100),       // results per keyword (API max 100)
     remoteNationwide: cfg.remoteNationwide === true,
+    // Remote-detection mode is config-driven (not hardcoded).
+    remoteMatch: ['title', 'filter', 'off'].includes(cfg.remoteMatch) ? cfg.remoteMatch : 'title',
+    remoteMaxPages: intInRange(cfg.remoteMaxPages, 1, 1, 20),
   };
 }
 
@@ -99,7 +108,7 @@ export default {
    * @returns {Promise<Array<{title: string, url: string, company: string, location: string}>>}
    */
   async fetch(entry, ctx) {
-    const { keywords, wo, umkreis, days, size, remoteNationwide } = parseArbeitsagenturConfig(entry);
+    const { keywords, wo, umkreis, days, size, remoteNationwide, remoteMatch, remoteMaxPages } = parseArbeitsagenturConfig(entry);
     if (!keywords.length) {
       throw new Error(`arbeitsagentur: entry "${entry.name || '(unnamed)'}" has no arbeitsagentur.keywords[]`);
     }
@@ -139,20 +148,43 @@ export default {
         errors.push(`"${kw}": ${(err && err.message) || err}`);
         continue;
       }
-      // Pass B (optional): nationwide, keep only explicitly remote-titled hits
-      // (captures remote roles hosted at a far HQ). Its failure must NOT discard
-      // the primary results already fetched above.
+      // Pass B (optional): a nationwide pass for remote roles hosted at a far HQ
+      // (which the radius pass misses). Detection is config-driven via `remoteMatch`:
+      //   'filter' — server-side `homeoffice=nv_true` query + pagination (every hit is remote)
+      //   'title'  — keep only nationwide hits whose title matches the remote regex
+      // Its failure must NOT discard the primary results already fetched above.
       let wide = [];
-      if (wo && remoteNationwide) {
+      if (wo && remoteNationwide && remoteMatch !== 'off') {
         try {
-          wide = (await fetchKeyword(kw)).filter(j => REMOTE_RE.test(String((j && j.titel) || '')));
+          if (remoteMatch === 'filter') {
+            // Server-side home-office filter: every hit is remote-eligible, so just
+            // paginate and keep them all — no per-job calls, no title regex.
+            for (let page = 1; page <= remoteMaxPages; page++) {
+              const res = await fetchKeyword(kw, { homeoffice: 'nv_true', page: String(page) });
+              wide.push(...res);
+              if (res.length < size) break; // short page → done
+            }
+          } else { // 'title'
+            const nationwide = await fetchKeyword(kw);
+            wide = nationwide.filter(j => REMOTE_RE.test(String((j && j.titel) || '')));
+          }
         } catch (err) {
           errors.push(`"${kw}" (remote pass): ${(err && err.message) || err}`);
         }
       }
-      for (const raw of [...primary, ...wide]) {
+      // Pass A (commutable) keeps its city as-is. Pass B roles are remote, so we
+      // append a `Deutschlandweit (Homeoffice)` marker — remote ignores distance,
+      // and this lets scan.mjs's commute-based location_filter pass them via its
+      // always_allow rescue instead of dropping them on the far office city.
+      for (const raw of primary) {
         const job = normalizeJob(raw);
         if (job && !byRef.has(job.refnr)) byRef.set(job.refnr, job);
+      }
+      for (const raw of wide) {
+        const job = normalizeJob(raw);
+        if (!job) continue;
+        job.location = job.location ? `${job.location} · Deutschlandweit (Homeoffice)` : 'Deutschlandweit (Homeoffice)';
+        if (!byRef.has(job.refnr)) byRef.set(job.refnr, job);
       }
     }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3999,6 +3999,49 @@ try {
     fail(`aa.fetch() remoteNationwide = ${calls} calls, ${JSON.stringify(remoteFetched.map(j => j.url))}`);
   }
 
+  // parseArbeitsagenturConfig — remoteMatch mode + remoteMaxPages (config-driven remote detection)
+  const rcfg = parseArbeitsagenturConfig({ arbeitsagentur: { keywords: ['ML'], remoteMatch: 'filter', remoteMaxPages: 50 } });
+  if (rcfg.remoteMatch === 'filter' && rcfg.remoteMaxPages === 20) {
+    pass('parseArbeitsagenturConfig parses remoteMatch and clamps remoteMaxPages');
+  } else {
+    fail(`parseArbeitsagenturConfig remoteMatch/maxPages = ${JSON.stringify({ m: rcfg.remoteMatch, p: rcfg.remoteMaxPages })}`);
+  }
+  const rdef = parseArbeitsagenturConfig({ arbeitsagentur: { keywords: ['ML'], remoteMatch: 'bogus' } });
+  if (rdef.remoteMatch === 'title' && rdef.remoteMaxPages === 1) {
+    pass('parseArbeitsagenturConfig defaults remoteMatch to "title" and remoteMaxPages to 1');
+  } else {
+    fail(`parseArbeitsagenturConfig remote defaults = ${JSON.stringify({ m: rdef.remoteMatch, p: rdef.remoteMaxPages })}`);
+  }
+
+  // fetch() — remoteMatch:'filter' uses server-side homeoffice filter, paginates, and tags remote roles
+  let usedHomeoffice = false;
+  const pagesSeen = new Set();
+  const filterFetched = await aa.fetch(
+    { name: 'AA', arbeitsagentur: { keywords: ['ML'], wo: 'Berlin', remoteNationwide: true, remoteMatch: 'filter', remoteMaxPages: 5, size: 2 } },
+    {
+      fetchJson: async (url) => {
+        const sp = new URL(url).searchParams;
+        if (sp.has('wo')) {
+          return { stellenangebote: [{ refnr: 'L', titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'Berlin' } }] };
+        }
+        usedHomeoffice = usedHomeoffice || sp.get('homeoffice') === 'nv_true';
+        pagesSeen.add(sp.get('page'));
+        return Number(sp.get('page')) === 1
+          ? { stellenangebote: [ // full page (== size) → pagination continues
+              { refnr: 'R1', titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'München' } },
+              { refnr: 'R2', titel: 'ML Scientist', arbeitgeber: 'Co', arbeitsort: { ort: 'Stuttgart' } },
+            ] }
+          : { stellenangebote: [{ refnr: 'R3', titel: 'NLP Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'Köln' } }] }; // short → stop
+      },
+    },
+  );
+  const munich = filterFetched.find(j => j.url.endsWith('R1'));
+  if (usedHomeoffice && pagesSeen.has('1') && pagesSeen.has('2') && munich && /Deutschlandweit \(Homeoffice\)/.test(munich.location)) {
+    pass('aa.fetch() remoteMatch:filter sends homeoffice=nv_true, paginates, and tags far-city remote roles');
+  } else {
+    fail(`aa.fetch() filter mode = ${JSON.stringify({ usedHomeoffice, pages: [...pagesSeen], munichLoc: munich?.location })}`);
+  }
+
   // fetch() — no keywords throws; total outage throws (not silent)
   let noKw = false;
   try { await aa.fetch({ name: 'AA', arbeitsagentur: {} }, mkCtx({})); } catch { noKw = true; }


### PR DESCRIPTION
Closes #1188.

## Problem
The `arbeitsagentur` provider's nationwide remote pass (`remoteNationwide: true`) only kept a job when a remote keyword appeared in the **job title** (hardcoded regex). German postings put remote info in the **body** ("mobiles Arbeiten" / "Homeoffice"), so fully-remote roles hosted at an HQ outside the `wo`/`umkreis` radius (e.g. a Munich-HQ'd remote role with `wo: Magdeburg`) were silently dropped.

## Change
A config-driven `remoteMatch` on the `arbeitsagentur:` block:
| mode | behaviour |
|---|---|
| `title` | **default, unchanged** — regex on the job title (backward compatible) |
| `filter` | server-side `homeoffice=nv_true` facet + pagination (`remoteMaxPages`); every hit is remote-eligible, no per-job calls |
| `off` | skip the remote pass |

Remote-pass results are tagged `· Deutschlandweit (Homeoffice)` so scan.mjs's commute-based `location_filter` passes them regardless of office city (remote ignores distance).

- **No new external dependency** — uses the existing Arbeitsagentur search endpoint's `homeoffice` facet.
- **Backward compatible** — default `remoteMatch: title` reproduces current behaviour.
- **Tested** — adds 3 tests (config parsing/clamping; `filter` sends `homeoffice=nv_true`, paginates, and tags far-city remote roles). `node test-all.mjs` green for the provider block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced remote job search with configurable matching modes: server-side filtering, title-based regex search, or disabled.
  * Remote positions are now clearly labeled as “Deutschlandweit (Homeoffice)” for better visibility.
  * Added configurable pagination limits for remote job results, including safe defaults and validation.
* **Tests**
  * Expanded provider coverage for remote matching mode and pagination limit handling, plus end-to-end fetch regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->