### PR TITLE
docs: add try online badge to all readmes (#1013)

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -15,6 +15,9 @@
 <p align="center">
   <a href="https://claude.com/claude-code"><img src="https://img.shields.io/badge/Built_with-Claude_Code-000?style=for-the-badge&logo=anthropic&logoColor=white" alt="Built with Claude Code"></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center">
   <sub>يعمل أيضاً على أي واجهة سطر أوامر تدعم معيار agent-skill</sub><br>

--- a/README.cn.md
+++ b/README.cn.md
@@ -17,6 +17,9 @@
   &nbsp;&nbsp;
   <a href="https://www.producthunt.com/products/santifer-io?utm_source=badge-featured&utm_medium=badge" target="_blank"><img src="docs/press/producthunt.svg" alt="Career-Ops on Claude | Product Hunt" style="width: 206px; height: 54px; vertical-align: middle;" width="206" height="54"/></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center"><sub>媒体报道</sub></p>
 

--- a/README.es.md
+++ b/README.es.md
@@ -17,6 +17,9 @@
   &nbsp;&nbsp;
   <a href="https://www.producthunt.com/products/santifer-io?utm_source=badge-featured&utm_medium=badge" target="_blank"><img src="docs/press/producthunt.svg" alt="Career-Ops on Claude | Product Hunt" style="width: 206px; height: 54px; vertical-align: middle;" width="206" height="54"/></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center"><sub>APARECE EN</sub></p>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -19,6 +19,9 @@
 <p align="center">
   <a href="https://www.producthunt.com/products/santifer-io?utm_source=badge-featured&utm_medium=badge" target="_blank"><img src="docs/press/producthunt.svg" alt="Career-Ops sur Claude | Product Hunt" style="width: 206px; height: 54px; vertical-align: middle;" width="206" height="54"/></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center"><sub>PRÉSENTÉ DANS</sub></p>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -17,6 +17,9 @@
   &nbsp;&nbsp;
   <a href="https://www.producthunt.com/products/santifer-io?utm_source=badge-featured&utm_medium=badge" target="_blank"><img src="docs/press/producthunt.svg" alt="Career-Ops on Claude | Product Hunt" style="width: 206px; height: 54px; vertical-align: middle;" width="206" height="54"/></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center"><sub>掲載メディア</sub></p>
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -17,6 +17,9 @@
   &nbsp;&nbsp;
   <a href="https://www.producthunt.com/products/santifer-io?utm_source=badge-featured&utm_medium=badge" target="_blank"><img src="docs/press/producthunt.svg" alt="Career-Ops on Claude | Product Hunt" style="width: 206px; height: 54px; vertical-align: middle;" width="206" height="54"/></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center"><sub>소개된 매체</sub></p>
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 <p align="center">
   <a href="https://www.producthunt.com/products/santifer-io?utm_source=badge-featured&utm_medium=badge" target="_blank" rel="noopener noreferrer"><img src="docs/press/producthunt.svg" alt="Career-Ops on Claude | Product Hunt" style="width: 206px; height: 54px; vertical-align: middle;" width="206" height="54"/></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center"><sub>FEATURED IN</sub></p>
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -15,6 +15,9 @@
 <p align="center">
   <a href="https://trendshift.io/repositories/25195" target="_blank"><img src="https://trendshift.io/api/badge/repositories/25195" alt="santifer%2Fcareer-ops | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center"><sub>OBECNY W MEDIACH</sub></p>
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -17,6 +17,9 @@
   &nbsp;&nbsp;
   <a href="https://www.producthunt.com/products/santifer-io?utm_source=badge-featured&utm_medium=badge" target="_blank"><img src="docs/press/producthunt.svg" alt="Career-Ops on Claude | Product Hunt" style="width: 206px; height: 54px; vertical-align: middle;" width="206" height="54"/></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center"><sub>DESTAQUE EM</sub></p>
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -17,6 +17,9 @@
   &nbsp;&nbsp;
   <a href="https://www.producthunt.com/products/santifer-io?utm_source=badge-featured&utm_medium=badge" target="_blank"><img src="docs/press/producthunt.svg" alt="Career-Ops on Claude | Product Hunt" style="width: 206px; height: 54px; vertical-align: middle;" width="206" height="54"/></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center"><sub>УПОМИНАНИЯ В СМИ</sub></p>
 

--- a/README.ua.md
+++ b/README.ua.md
@@ -17,6 +17,9 @@
   &nbsp;&nbsp;
   <a href="https://www.producthunt.com/products/santifer-io?utm_source=badge-featured&utm_medium=badge" target="_blank"><img src="docs/press/producthunt.svg" alt="Career-Ops on Claude | Product Hunt" style="width: 206px; height: 54px; vertical-align: middle;" width="206" height="54"/></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center"><sub>Згадані у</sub></p>
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -17,6 +17,9 @@
   &nbsp;&nbsp;
   <a href="https://www.producthunt.com/products/santifer-io?utm_source=badge-featured&utm_medium=badge" target="_blank"><img src="docs/press/producthunt.svg" alt="Career-Ops on Claude | Product Hunt" style="width: 206px; height: 54px; vertical-align: middle;" width="206" height="54"/></a>
 </p>
+<p align="center">
+  <a href="https://socialistic.ai/en/skill/career-ops-8025e8?utm_source=github&amp;utm_medium=readme&amp;utm_campaign=try-online" target="_blank" rel="noopener noreferrer"><img src="https://socialistic.ai/api/embed/career-ops-8025e8?lang=en" alt="Try career-ops on Socialistic" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
 <p align="center"><sub>媒體報導</sub></p>
 


### PR DESCRIPTION
## What

- Added a Product Hunt-style Socialistic 'Try Online' badge to all 12 translated README documentation files.
- Links to the official cloud playground instance: https://socialistic.ai/en/skill/career-ops-8025e8

Closes #1013.

## Why

Ensures users viewing documentation in any of the supported languages can launch the interactive online simulator directly.

## Validation

- Visually checked badge links and rendering across README files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new centered promotional badge/link near the top of the main README and multiple translated README files.
  * The badge appears in the early header area across languages, improving visibility of the linked experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->