### PR TITLE
feat(scan): add --json output, --include-undated, and --shuffle to scan-ats-full

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -138,34 +138,66 @@ function parseArgs(argv) {
     liveness: args.includes('--liveness'),
     verbose: args.includes('--verbose'),
     mdOut: valueOf('--md-out'),
+    json: args.includes('--json'),
+    includeUndated: args.includes('--include-undated'),
+    shuffle: args.includes('--shuffle'),
   };
 }
 
 // ── Company list cache (24h TTL) ────────────────────────────────────
 
+// Returns { list, status } where status is:
+//   'ok'    — fresh fetch, or a cache entry still within TTL
+//   'stale' — network fetch failed; falling back to an expired cache
+//   'empty' — no data at all (no cache, fetch failed/non-array)
+// The status lets callers (and --json) distinguish a degraded scan from an empty one.
 async function loadCompanyList(name, url) {
   mkdirSync(CACHE_DIR, { recursive: true });
   const cacheFile = path.join(CACHE_DIR, `${name}.json`);
   if (existsSync(cacheFile)) {
     const ageHours = (Date.now() - statSync(cacheFile).mtimeMs) / 3_600_000;
     if (ageHours < CACHE_TTL_HOURS) {
-      try { return JSON.parse(readFileSync(cacheFile, 'utf-8')); } catch { /* refetch below */ }
+      try { return { list: JSON.parse(readFileSync(cacheFile, 'utf-8')), status: 'ok' }; } catch { /* refetch below */ }
     }
   }
   try {
     const data = await fetchJson(url, { timeoutMs: 30_000 });
     if (Array.isArray(data)) {
       writeFileSync(cacheFile, JSON.stringify(data), 'utf-8');
-      return data;
+      return { list: data, status: 'ok' };
     }
   } catch (err) {
     console.error(`⚠️  ${name}: could not download company list — ${err.message}`);
   }
   // Stale cache beats nothing.
   if (existsSync(cacheFile)) {
-    try { return JSON.parse(readFileSync(cacheFile, 'utf-8')); } catch { /* fall through */ }
+    try { return { list: JSON.parse(readFileSync(cacheFile, 'utf-8')), status: 'stale' }; } catch { /* fall through */ }
   }
-  return [];
+  return { list: [], status: 'empty' };
+}
+
+// Date gate for one posting in a reverse (fresh-first) scan:
+//   'stale'   — dated, but older than the cutoff → always dropped
+//   'undated' — no usable publish date → dropped by default, kept with --include-undated
+//   'keep'    — dated and within the window
+export function classifyPostingDate(job, cutoff) {
+  if (job.postedAt && job.postedAt < cutoff) return 'stale';
+  if (!job.postedAt) return 'undated';
+  return 'keep';
+}
+
+// Cap-aware company sampling. Default: the dataset's natural (alphabetical)
+// prefix. With --shuffle: a random sample of `limit` companies, so a capped
+// scan isn't always biased to the same alphabetical-first slice. Pure; returns
+// a new array and never mutates `list`.
+export function sampleCompanies(list, limit, shuffle) {
+  if (!shuffle || limit >= list.length) return list.slice(0, limit);
+  const copy = list.slice();
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy.slice(0, limit);
 }
 
 // ── Parallel fetch with concurrency limit ───────────────────────────
@@ -194,7 +226,7 @@ async function filterLive(offers) {
       { cause: err },
     );
   }
-  console.log(`\nVerifying liveness of ${offers.length} match(es) with Playwright (sequential)...`);
+  console.error(`\nVerifying liveness of ${offers.length} match(es) with Playwright (sequential)...`);
   const browser = await chromium.launch({ headless: true });
   const live = [];
   try {
@@ -203,13 +235,13 @@ async function filterLive(offers) {
     for (const offer of offers) {
       const { result, reason } = await checkUrlLiveness(page, offer.url);
       const icon = result === 'active' ? '✅' : result === 'expired' ? '❌' : '⚠️';
-      console.log(`  ${icon} ${result.padEnd(9)} ${offer.company} | ${offer.title}${result === 'expired' ? ` (${reason})` : ''}`);
+      console.error(`  ${icon} ${result.padEnd(9)} ${offer.company} | ${offer.title}${result === 'expired' ? ` (${reason})` : ''}`);
       if (result !== 'expired') live.push(offer); // keep 'uncertain' — transient errors retry next scan
     }
   } finally {
     await browser.close();
   }
-  console.log(`  → ${live.length}/${offers.length} passed liveness`);
+  console.error(`  → ${live.length}/${offers.length} passed liveness`);
   return live;
 }
 
@@ -218,6 +250,10 @@ async function filterLive(offers) {
 async function main() {
   const opts = parseArgs(process.argv);
   const cutoff = Date.now() - opts.sinceDays * 86_400_000;
+  // In --json mode, stdout is reserved for the single machine-readable result,
+  // so every human-facing line goes to stderr instead.
+  const log = opts.json ? (...a) => console.error(...a) : (...a) => console.log(...a);
+  const progress = (s) => { if (!opts.json) process.stdout.write(s); };
 
   if (!existsSync(PORTALS_PATH)) {
     console.error('Error: portals.yml not found. Run onboarding first — the reverse scan reuses its title_filter/location_filter.');
@@ -230,22 +266,29 @@ async function main() {
     console.error('⚠️  portals.yml has no title_filter.positive — every fresh posting on every board will match. Consider adding keywords.');
   }
 
-  console.log(`Reverse ATS scan — sources: ${opts.ats.join(', ')} | since ${opts.sinceDays}d${opts.limit < Infinity ? ` | limit ${opts.limit}/ats` : ''}${opts.liveness ? ' | liveness' : ''}${opts.dryRun ? ' | DRY RUN' : ''}`);
+  log(`Reverse ATS scan — sources: ${opts.ats.join(', ')} | since ${opts.sinceDays}d${opts.limit < Infinity ? ` | limit ${opts.limit}/ats` : ''}${opts.shuffle ? ' | shuffled' : ''}${opts.includeUndated ? ' | +undated' : ''}${opts.liveness ? ' | liveness' : ''}${opts.dryRun ? ' | DRY RUN' : ''}`);
 
   const { seen: seenUrls } = loadSeenUrls();
   const ctx = makeHttpCtx();
   const date = new Date().toISOString().slice(0, 10);
 
   const newOffers = [];
-  let totalCompanies = 0;
+  let totalCompaniesScanned = 0;
+  let totalCompaniesAvailable = 0;
   let totalErrors = 0;
+  let droppedNoDate = 0;
+  let capHit = false;
+  const datasetStatus = {};
 
   for (const name of opts.ats) {
     const source = SOURCES[name];
-    const list = await loadCompanyList(name, source.dataset);
-    const entries = list.slice(0, opts.limit).map(source.toEntry).filter(Boolean);
-    totalCompanies += entries.length;
-    console.log(`\n⚙  ${name} — ${entries.length} companies`);
+    const { list, status } = await loadCompanyList(name, source.dataset);
+    datasetStatus[name] = status;
+    totalCompaniesAvailable += list.length;
+    if (opts.limit < list.length) capHit = true;
+    const entries = sampleCompanies(list, opts.limit, opts.shuffle).map(source.toEntry).filter(Boolean);
+    totalCompaniesScanned += entries.length;
+    log(`\n⚙  ${name} — ${entries.length} companies${status !== 'ok' ? ` (dataset: ${status})` : ''}`);
 
     let done = 0;
     let errors = 0;
@@ -254,12 +297,17 @@ async function main() {
         const jobs = await source.provider.fetch(entry, ctx);
         for (const job of jobs) {
           if (!job.url || !job.title) continue;
-          if (!job.postedAt || job.postedAt < cutoff) continue;
+          // Confirmed-stale postings are always dropped. Undated postings are
+          // dropped by default (a reverse scan targets *fresh* roles) but
+          // COUNTED so callers see the gap; --include-undated keeps them, marked.
+          const dateClass = classifyPostingDate(job, cutoff);
+          if (dateClass === 'stale') continue;
+          if (dateClass === 'undated' && !opts.includeUndated) { droppedNoDate++; continue; }
           if (!titleFilter(job.title)) continue;
           if (!locationFilter(job.location)) continue;
           if (seenUrls.has(job.url)) continue;
           seenUrls.add(job.url); // intra-scan dedup
-          newOffers.push({ ...job, source: `${name}-full` });
+          newOffers.push({ ...job, source: `${name}-full`, dateStatus: job.postedAt ? 'dated' : 'unknown' });
         }
       } catch (err) {
         // Mostly defunct boards in the public dataset — expected noise, so the
@@ -269,73 +317,105 @@ async function main() {
       }
       done++;
       if (done % 200 === 0 || done === entries.length) {
-        process.stdout.write(`  ${done}/${entries.length} scanned, ${newOffers.length} total matches\r`);
+        progress(`  ${done}/${entries.length} scanned, ${newOffers.length} total matches\r`);
       }
     });
     totalErrors += errors;
-    console.log(`\n  done (${errors} unreachable boards skipped)`);
+    log(`\n  done (${errors} unreachable boards skipped)`);
   }
 
-  console.log(`\n${'━'.repeat(45)}`);
-  console.log(`Reverse ATS Scan — ${date}`);
-  console.log(`${'━'.repeat(45)}`);
-  console.log(`Companies scanned:  ${totalCompanies}`);
-  console.log(`Unreachable boards: ${totalErrors}`);
-  console.log(`New matches:        ${newOffers.length}`);
-
-  if (newOffers.length === 0) {
-    console.log('\nNothing new.');
-    return;
-  }
-
-  const offers = opts.liveness ? await filterLive(newOffers) : newOffers;
-  if (offers.length === 0) {
-    console.log('\nAll matches expired after liveness check.');
-    return;
-  }
-
+  let offers = newOffers;
+  if (offers.length && opts.liveness) offers = await filterLive(newOffers);
   offers.sort((a, b) => (b.postedAt || 0) - (a.postedAt || 0));
-  console.log('\nNew offers:');
-  for (const o of offers) {
-    const posted = o.postedAt ? new Date(o.postedAt).toISOString().slice(0, 10) : 'n/a';
-    console.log(`  + [${o.source}] ${posted} | ${o.company} | ${o.title} | ${o.location || 'N/A'}\n    ${o.url}`);
-  }
 
-  if (opts.dryRun) {
-    console.log('\n(dry run — run without --dry-run to save results)');
-    return;
-  }
+  log(`\n${'━'.repeat(45)}`);
+  log(`Reverse ATS Scan — ${date}`);
+  log(`${'━'.repeat(45)}`);
+  log(`Companies scanned:  ${totalCompaniesScanned}${capHit ? ` of ${totalCompaniesAvailable} (capped)` : ''}`);
+  log(`Unreachable boards: ${totalErrors}`);
+  if (droppedNoDate) log(`Undated dropped:    ${droppedNoDate}${opts.includeUndated ? '' : ' (use --include-undated to keep)'}`);
+  log(`New matches:        ${offers.length}`);
 
-  // appendToPipeline assumes the file exists (onboarding creates it) — cover fresh setups.
-  if (!existsSync(PIPELINE_PATH)) {
-    mkdirSync(path.dirname(PIPELINE_PATH), { recursive: true });
-    writeFileSync(PIPELINE_PATH, '# Pipeline\n\n## Pendientes\n', 'utf-8');
-  }
-  appendToPipeline(offers);
-  appendToScanHistory(offers, date);
-  console.log(`\nResults saved to ${PIPELINE_PATH} and data/scan-history.tsv`);
-
-  if (opts.mdOut) {
-    try {
-      mkdirSync(opts.mdOut, { recursive: true });
-      const digest = [
-        `# Reverse ATS Scan — ${date}`,
-        `> ${offers.length} jobs | since ${opts.sinceDays}d | ${opts.liveness ? 'liveness ✓' : 'no liveness check'}`,
-        '',
-        ...offers.map(o => {
-          const posted = o.postedAt ? new Date(o.postedAt).toISOString().slice(0, 10) : 'n/a';
-          return `- [${o.title} @ ${o.company}](${o.url}) — ${o.location || 'N/A'} | ${o.source} | ${posted}`;
-        }),
-        '',
-      ].join('\n');
-      writeFileSync(path.join(opts.mdOut, `${date}.md`), digest, 'utf-8');
-      console.log(`Markdown digest saved to ${path.join(opts.mdOut, `${date}.md`)}`);
-    } catch (err) {
-      console.error(`⚠️  Could not write markdown digest: ${err.message}`);
+  if (offers.length) {
+    log('\nNew offers:');
+    for (const o of offers) {
+      const posted = o.postedAt ? new Date(o.postedAt).toISOString().slice(0, 10) : 'n/a';
+      log(`  + [${o.source}] ${posted} | ${o.company} | ${o.title} | ${o.location || 'N/A'}\n    ${o.url}`);
     }
   }
 
-  console.log(`\n→ Run /career-ops pipeline to evaluate new offers.`);
+  // Persist (unless dry-run, or nothing to save).
+  let saved = false;
+  if (offers.length && !opts.dryRun) {
+    // appendToPipeline assumes the file exists (onboarding creates it) — cover fresh setups.
+    if (!existsSync(PIPELINE_PATH)) {
+      mkdirSync(path.dirname(PIPELINE_PATH), { recursive: true });
+      writeFileSync(PIPELINE_PATH, '# Pipeline\n\n## Pendientes\n', 'utf-8');
+    }
+    appendToPipeline(offers);
+    appendToScanHistory(offers, date);
+    saved = true;
+    log(`\nResults saved to ${PIPELINE_PATH} and data/scan-history.tsv`);
+
+    if (opts.mdOut) {
+      try {
+        mkdirSync(opts.mdOut, { recursive: true });
+        const digest = [
+          `# Reverse ATS Scan — ${date}`,
+          `> ${offers.length} jobs | since ${opts.sinceDays}d | ${opts.liveness ? 'liveness ✓' : 'no liveness check'}`,
+          '',
+          ...offers.map(o => {
+            const posted = o.postedAt ? new Date(o.postedAt).toISOString().slice(0, 10) : 'n/a';
+            return `- [${o.title} @ ${o.company}](${o.url}) — ${o.location || 'N/A'} | ${o.source} | ${posted}`;
+          }),
+          '',
+        ].join('\n');
+        writeFileSync(path.join(opts.mdOut, `${date}.md`), digest, 'utf-8');
+        log(`Markdown digest saved to ${path.join(opts.mdOut, `${date}.md`)}`);
+      } catch (err) {
+        console.error(`⚠️  Could not write markdown digest: ${err.message}`);
+      }
+    }
+  }
+
+  // The authoritative machine-readable result: lets a caller (e.g. the web)
+  // tell a *degraded* scan (capped / stale dataset / undated dropped) apart
+  // from a genuinely *empty* one. In --json mode stdout carries ONLY this.
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({
+      date,
+      sources: opts.ats,
+      sinceDays: opts.sinceDays,
+      companiesAvailable: totalCompaniesAvailable,
+      companiesScanned: totalCompaniesScanned,
+      capHit,
+      datasetStatus,
+      postingsKept: offers.length,
+      postingsDroppedNoDate: droppedNoDate,
+      unreachableBoards: totalErrors,
+      saved,
+      offers: offers.map(o => ({
+        company: o.company,
+        title: o.title,
+        url: o.url,
+        location: o.location || null,
+        postedAt: o.postedAt ? new Date(o.postedAt).toISOString().slice(0, 10) : null,
+        dateStatus: o.dateStatus || (o.postedAt ? 'dated' : 'unknown'),
+        source: o.source,
+      })),
+    }) + '\n');
+    return;
+  }
+
+  if (!offers.length) {
+    log('\nNothing new.');
+    return;
+  }
+  if (opts.dryRun) {
+    log('\n(dry run — run without --dry-run to save results)');
+    return;
+  }
+  log(`\n→ Run /career-ops pipeline to evaluate new offers.`);
 }
 
 // Only run main() when invoked directly, not when imported by tests.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -859,6 +859,34 @@ try {
   fail(`scan-ats-full host-guard test crashed: ${e.message}`);
 }
 
+// Reverse-scan date gate (--include-undated) + cap-aware sampling (--shuffle).
+try {
+  const { classifyPostingDate, sampleCompanies } = await import(pathToFileURL(join(ROOT, 'scan-ats-full.mjs')).href);
+  const cutoff = 1_000_000;
+  const dateOk =
+    classifyPostingDate({ postedAt: 2_000_000 }, cutoff) === 'keep' &&
+    classifyPostingDate({ postedAt: 500_000 }, cutoff) === 'stale' &&
+    classifyPostingDate({}, cutoff) === 'undated' &&
+    classifyPostingDate({ postedAt: null }, cutoff) === 'undated';
+  if (dateOk) pass('scan-ats-full classifyPostingDate: fresh→keep, old→stale, no-date→undated (the --include-undated gate)');
+  else fail('scan-ats-full classifyPostingDate gate is wrong');
+
+  const list = ['a', 'b', 'c', 'd', 'e'];
+  const prefix = sampleCompanies(list, 3, false);
+  const all = sampleCompanies(list, 99, false);
+  const shuffled = sampleCompanies(list, 3, true);
+  const sampleOk =
+    JSON.stringify(prefix) === JSON.stringify(['a', 'b', 'c']) &&        // default = alphabetical prefix
+    all.length === 5 &&                                                  // limit >= length → all
+    shuffled.length === 3 &&                                             // --shuffle still respects the cap
+    shuffled.every((x) => list.includes(x)) &&                           // --shuffle preserves membership
+    JSON.stringify(list) === JSON.stringify(['a', 'b', 'c', 'd', 'e']);  // never mutates the input
+  if (sampleOk) pass('scan-ats-full sampleCompanies: alphabetical prefix by default; capped, membership-preserving, non-mutating on --shuffle');
+  else fail('scan-ats-full sampleCompanies behaves wrong');
+} catch (e) {
+  fail(`scan-ats-full date-gate/sampling test crashed: ${e.message}`);
+}
+
 // ── 10. PORTALS CONFIG VALIDATOR ────────────────────────────────
 
 console.log('\n10. Portals config validator');


### PR DESCRIPTION
## Why

The reverse scanner (`scan-ats-full.mjs`) only emitted human-readable markdown, and it silently dropped every posting with no publish date. That left a caller (the web's Discover view, or a script) unable to tell a **degraded** scan — capped company list, stale dataset, undated postings hidden — from a genuinely **empty** one. Same number on screen, very different reality.

## What

- **`--json`** — emit one JSON object to stdout: `companiesAvailable` vs `companiesScanned` (+ a `capHit` flag), per-source `datasetStatus` (`ok`/`stale`/`empty`), `postingsKept`, `postingsDroppedNoDate`, `unreachableBoards`, `saved`, and the `offers`. Human progress is routed to **stderr** so stdout stays clean, parseable JSON.
- **`--include-undated`** — keep postings with no publish date (marked `dateStatus: "unknown"`, sorted last) instead of dropping them. The default still drops them (a reverse scan targets *fresh* roles) but now always **counts** them (`postingsDroppedNoDate`), so the gap is visible even without the flag.
- **`--shuffle`** — sample a capped scan randomly rather than always hitting the same alphabetical-first companies. (`--limit` is still uncapped by default; the cap is the caller's choice.)

## Notes

- `classifyPostingDate` and `sampleCompanies` are exported + unit-tested; `node test-all.mjs` → **424/0**.
- **No behavior change without the new flags.**
- Verified end-to-end: `--json --dry-run` emits clean JSON; on a live greenhouse fetch, `companiesAvailable=8333` and `capHit` flips correctly with `--limit`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON output for machine-readable scan results.
  * Added options to include undated jobs and shuffle company sampling.
  * Scan results now include clearer status details for job dates and dataset availability.
* **Bug Fixes**
  * Improved handling of missing or expired company directory data.
  * Jobs older than the cutoff are now consistently excluded, with undated jobs handled predictably.
* **Documentation**
  * Added more structured output fields for easier downstream use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->