### PR TITLE
feat(tracker): add delete --num N to remove an application row safely

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -887,6 +887,35 @@ try {
   fail(`scan-ats-full date-gate/sampling test crashed: ${e.message}`);
 }
 
+// tracker.mjs delete: removeRowByNum removes the right row, preserves the rest.
+try {
+  const { removeRowByNum } = await import(pathToFileURL(join(ROOT, 'tracker.mjs')).href);
+  const md = [
+    '# Applications',
+    '',
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|-------|--------|-----|--------|-------|',
+    '| 1 | 2026-06-01 | Acme | Dev | 4.0/5 | Evaluated | y | [r1](reports/1.md) | a |',
+    '| 2 | 2026-06-02 | Beta | Eng | 3.5/5 | Applied | y | [r2](reports/2.md) | b |',
+    '| 3 | 2026-06-03 | Gamma | Lead | 4.5/5 | Interview | y | [r3](reports/3.md) | c |',
+    '',
+  ].join('\n');
+  const r2 = removeRowByNum(md, 2);
+  const miss = removeRowByNum(md, 99);
+  const ok =
+    r2.removed && r2.removedCount === 1 &&
+    r2.report === '[r2](reports/2.md)' &&            // report column (index 7) surfaced for orphan note
+    !r2.newContent.includes('| 2 |') &&              // the target row is gone
+    r2.newContent.includes('| 1 |') && r2.newContent.includes('| 3 |') && // other rows kept
+    r2.newContent.includes('# Applications') &&      // non-table line preserved
+    r2.newContent.includes('|---|') &&               // separator preserved
+    miss.removed === false && miss.newContent === md; // no-op on a missing number
+  if (ok) pass('tracker.mjs removeRowByNum: removes the matching row, preserves header/separator/other rows, no-op on miss');
+  else fail('tracker.mjs removeRowByNum behaves wrong');
+} catch (e) {
+  fail(`tracker.mjs removeRowByNum test crashed: ${e.message}`);
+}
+
 // ── 10. PORTALS CONFIG VALIDATOR ────────────────────────────────
 
 console.log('\n10. Portals config validator');

--- a/tracker.mjs
+++ b/tracker.mjs
@@ -28,14 +28,15 @@
  *                          [--since 2026-01-01] [--id N] [--limit 20] [--json]
  *   node tracker.mjs history --id N             # status transition log observed across syncs
  *   node tracker.mjs export [--out FILE]        # inverse: applications.db → canonical markdown (stdout by default)
+ *   node tracker.mjs delete --num N [--dry-run] # remove one application row from applications.md + reindex
  *
  * query/history auto-resync when applications.md changed since the last sync,
  * so the index can never serve stale reads.
  */
 
-import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync, statSync } from 'fs';
+import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync, statSync, renameSync, rmSync } from 'fs';
 import { createHash } from 'crypto';
-import { dirname, resolve } from 'path';
+import { dirname, resolve, join, basename } from 'path';
 import { pathToFileURL } from 'url';
 import yaml from 'js-yaml';
 
@@ -170,6 +171,31 @@ function parseMarkdownRows(text, diag) {
     rows.push(cells);
   }
   return rows;
+}
+
+// Remove every table row whose first cell (the application number) equals `num`,
+// preserving the rest of the file (header, separators, spacing, other rows)
+// byte-for-byte. Pure: returns { removed, removedCount, report, newContent }.
+// `report` is the report-column value of the first removed row, so callers can
+// surface the now-orphaned report file. Numbers are unique in practice, but any
+// duplicates are all removed.
+export function removeRowByNum(content, num) {
+  const target = String(num).trim();
+  let removedCount = 0;
+  let report = null;
+  const kept = content.split('\n').filter((line) => {
+    const t = line.trim();
+    if (!t.startsWith('|')) return true; // non-table line — keep verbatim
+    const cells = t.replace(/^\|/, '').replace(/\|$/, '').split('|').map((c) => c.trim());
+    if (cells[0] === '#' || /^[-: ]*$/.test(cells.join(''))) return true; // header / separator
+    if (cells[0] === target) {
+      removedCount++;
+      if (report === null) report = cells[7] || null; // report column (index 7)
+      return false;
+    }
+    return true;
+  });
+  return { removed: removedCount > 0, removedCount, report, newContent: kept.join('\n') };
 }
 
 // Parse + normalize the markdown into index-ready rows. The markdown itself is
@@ -430,13 +456,67 @@ async function exportMd(args) {
 
 // ── Main ────────────────────────────────────────────────────────────
 
-const COMMANDS = { sync, query, history, export: exportMd };
+// Atomic file replace via a same-directory temp file + rename, so a reader never
+// sees a partially written applications.md (mirrors merge-tracker's writer).
+function writeFileAtomic(filePath, content) {
+  const tmp = join(dirname(filePath), `.${basename(filePath)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    writeFileSync(tmp, content);
+    renameSync(tmp, filePath);
+  } catch (err) {
+    rmSync(tmp, { force: true });
+    throw err;
+  }
+}
+
+// `delete --num N` removes one application row from applications.md and rebuilds
+// the derived index. The markdown stays the source of truth: callers (incl. the
+// web) orchestrate this script rather than editing applications.md directly, so
+// the write-gate holds. The write is atomic; callers should still avoid running
+// a delete concurrently with a scan-merge (they share the same file — serialize
+// at the orchestration layer; a shared lock is a follow-up once merge-tracker is
+// import-safe).
+async function deleteApp(args) {
+  const num = flagValue(args, '--num');
+  if (!num) {
+    console.error('Usage: node tracker.mjs delete --num <N> [--dry-run]   (remove one application row by its number)');
+    process.exit(1);
+  }
+  if (!existsSync(MD_PATH)) {
+    console.error(`Error: ${MD_PATH} not found — nothing to delete.`);
+    process.exit(1);
+  }
+  const { removed, removedCount, report, newContent } = removeRowByNum(readFileSync(MD_PATH, 'utf-8'), num);
+  if (!removed) {
+    console.error(`No application numbered ${num} in ${MD_PATH}.`);
+    process.exit(1);
+  }
+  if (args.includes('--dry-run')) {
+    console.error(`Would remove application ${num} (${removedCount} row${removedCount > 1 ? 's' : ''}) from ${MD_PATH}.`);
+    if (report) console.error(`(report file would be orphaned: ${report})`);
+    return;
+  }
+  writeFileAtomic(MD_PATH, newContent);
+  // Rebuild the derived SQLite index from the now-updated markdown.
+  try {
+    const states = loadStates();
+    const DatabaseSync = await loadSqlite();
+    const db = openDb(DatabaseSync);
+    syncIndex(db, states);
+  } catch (e) {
+    console.error(`(row removed; index resync skipped: ${e.message})`);
+  }
+  console.error(`Removed application ${num} (${removedCount} row${removedCount > 1 ? 's' : ''}) from ${MD_PATH} and reindexed.`);
+  if (report) console.error(`Note: report file may now be orphaned — ${report}`);
+}
+
+const COMMANDS = { sync, query, history, export: exportMd, delete: deleteApp };
 
 async function main() {
   const [command, ...args] = process.argv.slice(2);
   const fn = COMMANDS[command];
   if (!fn) {
-    console.log('Usage: node tracker.mjs <sync|query|history|export> [flags]');
+    console.log('Usage: node tracker.mjs <sync|query|history|export|delete> [flags]');
     console.log('See the header comment of this file for examples, or docs/SCRIPTS.md.');
     process.exit(command ? 1 : 0);
   }


### PR DESCRIPTION
## Why

An orchestrator (the web, a script) needs to remove an application that landed in the tracker by mistake — e.g. a row written as `Evaluated` just before a CLI run errored out. The web must never edit `applications.md` directly (that bypasses the write-gate / source-of-truth), so it needs a core operation to orchestrate.

## What

`node tracker.mjs delete --num N [--dry-run]`:
- Removes the row whose number is `N`, preserving the header, separator, and every other row **byte-for-byte**.
- **Atomic write** (temp file + rename) so a reader never sees a half-written `applications.md`.
- Rebuilds the derived SQLite index from the updated markdown.
- Reports the now-orphaned report file so the caller can clean it up.
- `--dry-run` previews without writing; a missing number exits 1.

`removeRowByNum` is exported and unit-tested; verified end-to-end (dry-run leaves the file untouched; a real delete removes only the target row and reindexes).

## Notes

- `node test-all.mjs` → **425/0**.
- **Markdown stays the source of truth** — the web orchestrates this, never edits the file directly.
- A shared lock with `merge-tracker` is a deliberate follow-up: `merge-tracker.mjs` isn't import-safe yet (it runs its merge at module top-level), so reusing its lock means refactoring it first. The write here is atomic; callers should serialize a delete against a concurrent scan-merge at the orchestration layer (realistic usage is a discrete, user-initiated delete).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to delete a single application row by number from the tracker.
  * Added a dry-run option so you can preview the change before saving it.

* **Bug Fixes**
  * Improved tracker updates to preserve the rest of the markdown content while removing the selected row.
  * Kept the tracker index in sync after deletions.

* **Tests**
  * Added coverage for row removal behavior, including missing-row no-ops and content preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->