### PR TITLE
feat(scan): optional Apify LinkedIn provider (#791)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,7 @@ OPENROUTER_API_KEY=sk-or-v1-paste-your-key-here
 
 # ── Other integrations (add your own below) ──────────────────────────────────
 # ANTHROPIC_API_KEY=your_anthropic_key_here   # For Claude-based workflows
+# APIFY_TOKEN=your_apify_token_here            # Required for LinkedIn Apify provider
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Plugins (opt-in) — keys for bundled plugins. Enable each in config/plugins.yml.

--- a/providers/linkedin-apify.mjs
+++ b/providers/linkedin-apify.mjs
@@ -1,0 +1,83 @@
+// @ts-check
+import dotenv from 'dotenv';
+try { dotenv.config(); } catch { /* optional */ }
+
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// LinkedIn Apify Provider — retrieves postings from LinkedIn using the Apify API.
+// Requires APIFY_TOKEN env var. If token is missing, silently returns [].
+
+function normalizeJob(item, entry) {
+  const title =
+    item.title || item.jobTitle || item.position || item.name || '';
+
+  const company =
+    item.companyName || item.company || item.employer ||
+    item.company_name || item.organizationName || entry.name || '';
+
+  const location =
+    item.location || item.jobLocation || item.place || '';
+
+  const url =
+    item.jobUrl || item.url || item.link || item.applyUrl ||
+    item.jobLink || item.externalUrl || '';
+
+  return { title, company, location, url };
+}
+
+/** @type {Provider} */
+export default {
+  id: 'linkedin-apify',
+
+  detect(entry) {
+    // Explicit provider only, no auto-detection from URL
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const token = process.env.APIFY_TOKEN;
+    if (!token || token === 'your_apify_token_here') {
+      // Silently skip if token is absent
+      return [];
+    }
+
+    const actorIdRaw = entry.apify_actor || 'bebity~linkedin-jobs-scraper';
+    const actorId = encodeURIComponent(actorIdRaw);
+    const query = entry.query || entry.scan_query || entry.search_query || entry.name || '';
+    const location = entry.location || '';
+    
+    const parsedMaxResults = Number(entry.max_results ?? entry.limit ?? 20);
+    const maxResults = Number.isFinite(parsedMaxResults) && parsedMaxResults > 0
+      ? Math.floor(parsedMaxResults)
+      : 20;
+
+    // Build actor input matching the target actor format
+    const input = {
+      searchQueries: [`${query}${location ? ' ' + location : ''}`],
+      location: location || undefined,
+      maxResults,
+      proxy: { useApifyProxy: true, apifyProxyGroups: ['RESIDENTIAL'] },
+    };
+
+    const apiUrl = new URL(`https://api.apify.com/v2/acts/${actorId}/run-sync-get-dataset-items`);
+    apiUrl.searchParams.set('token', token);
+
+    try {
+      const response = await ctx.fetchJson(apiUrl.toString(), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(input),
+        timeoutMs: 300000, // 5 minutes timeout for slow LinkedIn scrapes
+      });
+
+      const items = Array.isArray(response) ? response : (response?.data?.items || []);
+      return items.map(item => normalizeJob(item, entry)).filter(j => j.title && j.url);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`⚠️  linkedin-apify: failed to fetch for "${entry.name}" — ${message}`);
+      return [];
+    }
+  },
+};

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8238,6 +8238,99 @@ try {
   if (__pluginTmp) { try { rmSync(__pluginTmp, { recursive: true, force: true }); } catch {} }
 }
 
+// ── PROVIDER LINKEDIN-APIFY ──────────────────────────────────
+
+console.log('\nProvider — linkedin-apify');
+try {
+  const linkedinApify = (await import(pathToFileURL(join(ROOT, 'providers/linkedin-apify.mjs')).href)).default;
+
+  if (linkedinApify.id === 'linkedin-apify') {
+    pass('linkedin-apify.id is "linkedin-apify"');
+  } else {
+    fail(`linkedin-apify.id is ${JSON.stringify(linkedinApify.id)}`);
+  }
+
+  // detect() always returns null
+  if (linkedinApify.detect({ name: 'X', careers_url: 'https://linkedin.com' }) === null) {
+    pass('linkedin-apify.detect() always returns null');
+  } else {
+    fail('linkedin-apify.detect() should return null');
+  }
+
+  // When APIFY_TOKEN is absent, returns [] silently
+  const origToken = process.env.APIFY_TOKEN;
+  delete process.env.APIFY_TOKEN;
+  let result;
+  try {
+    result = await linkedinApify.fetch({ name: 'Test' }, {});
+  } finally {
+    process.env.APIFY_TOKEN = origToken;
+  }
+  if (Array.isArray(result) && result.length === 0) {
+    pass('linkedin-apify.fetch() returns [] when APIFY_TOKEN is absent');
+  } else {
+    fail(`linkedin-apify.fetch() expected [] when token is absent but got: ${JSON.stringify(result)}`);
+  }
+
+  // When APIFY_TOKEN is present, fetches via ctx.fetchJson
+  process.env.APIFY_TOKEN = 'mock-token';
+  let calledUrl = '';
+  let calledOpts = null;
+  const mockCtx = {
+    fetchJson: async (url, opts) => {
+      calledUrl = url;
+      calledOpts = opts;
+      return [
+        { title: 'Job 1', companyName: 'Company A', location: 'Remote', jobUrl: 'https://linkedin.com/jobs/1' },
+        { jobTitle: 'Job 2', company: 'Company B', url: 'https://linkedin.com/jobs/2' },
+        { name: 'Invalid Job' } // no url -> dropped
+      ];
+    }
+  };
+
+  let fetched;
+  try {
+    fetched = await linkedinApify.fetch({
+      name: 'Company Target',
+      query: 'Staff Engineer',
+      location: 'Europe',
+      max_results: 15
+    }, mockCtx);
+  } finally {
+    process.env.APIFY_TOKEN = origToken;
+  }
+
+  if (calledUrl === 'https://api.apify.com/v2/acts/bebity~linkedin-jobs-scraper/run-sync-get-dataset-items?token=mock-token') {
+    pass('linkedin-apify.fetch() uses correct API URL (properly URL-encoded)');
+  } else {
+    fail(`linkedin-apify.fetch() API URL wrong: ${calledUrl}`);
+  }
+
+  if (calledOpts && calledOpts.method === 'POST' && calledOpts.timeoutMs === 300000) {
+    pass('linkedin-apify.fetch() uses POST and sets high timeoutMs');
+  } else {
+    fail(`linkedin-apify.fetch() options wrong: ${JSON.stringify(calledOpts)}`);
+  }
+
+  const payload = JSON.parse(calledOpts?.body || '{}');
+  if (payload.searchQueries && payload.searchQueries[0] === 'Staff Engineer Europe' && payload.maxResults === 15) {
+    pass('linkedin-apify.fetch() passes correct input parameters');
+  } else {
+    fail(`linkedin-apify.fetch() request payload wrong: ${JSON.stringify(payload)}`);
+  }
+
+  if (fetched.length === 2 &&
+      fetched[0].title === 'Job 1' && fetched[0].company === 'Company A' &&
+      fetched[1].title === 'Job 2' && fetched[1].company === 'Company B') {
+    pass('linkedin-apify.fetch() normalizes and filters items correctly');
+  } else {
+    fail(`linkedin-apify.fetch() output wrong: ${JSON.stringify(fetched)}`);
+  }
+
+} catch (e) {
+  fail(`linkedin-apify provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
### Goal
Add optional Apify LinkedIn scanner integration as a Level 4 provider.

### Changes
- Add \providers/linkedin-apify.mjs\ calling Apify's LinkedIn scraper actor.
- Gated behind \APIFY_TOKEN\. If absent, silently skips and returns empty results.
- Add \APIFY_TOKEN\ to \.env.example\.
- Add tests to \	est-all.mjs\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new LinkedIn jobs integration backed by Apify.
  * Standardized job details into consistent fields for listing output.
* **Bug Fixes**
  * Disabled requests when the Apify token is missing or left as the placeholder.
  * Dropped incomplete job results to ensure only usable listings are returned.
* **Documentation**
  * Updated the example environment configuration with an Apify token entry.
* **Tests**
  * Added coverage for token handling, request behavior (including search parameters), and result normalization/filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->