### PR TITLE
feat: Gmail label email-driven ingestion into pipeline (#810)

### DIFF
--- a/plugins/gmail/_helpers.mjs
+++ b/plugins/gmail/_helpers.mjs
@@ -51,12 +51,18 @@ export function isCleanUrl(url) {
  */
 export function isAuthenticEmail(headers) {
   if (!Array.isArray(headers)) return false;
+  let hasPass = false;
   for (const h of headers) {
-    if (h.name && h.name.toLowerCase() === 'authentication-results') {
-      if (h.value && /dmarc=pass/i.test(h.value)) return true;
+    if (h.name && h.name.toLowerCase() === 'authentication-results' && h.value) {
+      if (/dmarc=fail/i.test(h.value)) {
+        return false;
+      }
+      if (/dmarc=pass/i.test(h.value)) {
+        hasPass = true;
+      }
     }
   }
-  return false;
+  return hasPass;
 }
 
 /**

--- a/plugins/gmail/index.mjs
+++ b/plugins/gmail/index.mjs
@@ -121,7 +121,10 @@ export default {
 
       const seed = parseRoleAtCompany(subject);
       const cleanUrls = extractUrls(getMessageBody(msg.payload)).filter(isCleanUrl);
-      for (const url of cleanUrls) {
+      for (let url of cleanUrls) {
+        if (url.includes('|')) {
+          url = url.replace(/\|/g, '%7C');
+        }
         if (seenUrls.has(url)) continue;
         seenUrls.add(url);
         jobs.push({

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8238,6 +8238,71 @@ try {
   if (__pluginTmp) { try { rmSync(__pluginTmp, { recursive: true, force: true }); } catch {} }
 }
 
+// ── GMAIL INGESTION HELPERS ──────────────────────────────────
+
+console.log('\nGmail Ingestion Helpers');
+try {
+  const { extractUrls, isCleanUrl, isAuthenticEmail, parseRoleAtCompany } = await import(pathToFileURL(join(ROOT, 'plugins/gmail/_helpers.mjs')).href);
+
+  // extractUrls
+  const sampleBody = 'Check this: https://boards.greenhouse.io/acme/jobs/123. Also tracking link: https://click.email.com/abc?q=1&amp;u=2';
+  const urls = extractUrls(sampleBody);
+  if (urls.length === 2 && urls[0] === 'https://boards.greenhouse.io/acme/jobs/123' && urls[1] === 'https://click.email.com/abc?q=1&u=2') {
+    pass('extractUrls extracts and cleans URLs from body');
+  } else {
+    fail(`extractUrls extracted wrong: ${JSON.stringify(urls)}`);
+  }
+
+  // isCleanUrl
+  if (isCleanUrl('https://boards.greenhouse.io/acme/jobs/123') === true &&
+      isCleanUrl('https://jobs.lever.co/acme/123') === true &&
+      isCleanUrl('https://click.email.com/abc') === false &&
+      isCleanUrl('https://sendgrid.com/track') === false &&
+      isCleanUrl('https://linkedin.com/settings/privacy') === false &&
+      isCleanUrl('https://example.com/careers/role') === true) {
+    pass('isCleanUrl correctly identifies job posting URLs vs tracking/settings links');
+  } else {
+    fail('isCleanUrl failed validation cases');
+  }
+
+  // isAuthenticEmail
+  const headersPass = [{ name: 'Authentication-Results', value: 'dkim=pass dmarc=pass' }];
+  const headersFail = [{ name: 'Authentication-Results', value: 'spf=pass dmarc=fail' }];
+  const headersMissing = [];
+  const headersNoPass = [{ name: 'Authentication-Results', value: 'spf=pass dmarc=none' }];
+  const headersConflicting = [
+    { name: 'Authentication-Results', value: 'dkim=pass dmarc=pass' },
+    { name: 'Authentication-Results', value: 'spf=fail dmarc=fail' }
+  ];
+  if (isAuthenticEmail(headersPass) === true &&
+      isAuthenticEmail(headersFail) === false &&
+      isAuthenticEmail(headersMissing) === false &&
+      isAuthenticEmail(headersNoPass) === false &&
+      isAuthenticEmail(headersConflicting) === false) {
+    pass('isAuthenticEmail is fail-closed, requiring dmarc=pass and rejecting conflicting headers');
+  } else {
+    fail('isAuthenticEmail fail-closed/contradiction check failed');
+  }
+
+  // parseRoleAtCompany
+  const sub1 = 'New match: Senior Staff AI Engineer at Cohere';
+  const sub2 = 'Job alert: Engineering Manager at Google - Job Details';
+  const sub3 = 'Fwd: Software Engineer at Stripe | Remote';
+  const parsed1 = parseRoleAtCompany(sub1);
+  const parsed2 = parseRoleAtCompany(sub2);
+  const parsed3 = parseRoleAtCompany(sub3);
+  if (parsed1?.role === 'Senior Staff AI Engineer' && parsed1?.company === 'Cohere' &&
+      parsed2?.role === 'Engineering Manager' && parsed2?.company === 'Google' &&
+      parsed3?.role === 'Software Engineer' && parsed3?.company === 'Stripe') {
+    pass('parseRoleAtCompany extracts role and company from typical subject lines');
+  } else {
+    fail(`parseRoleAtCompany failed: p1=${JSON.stringify(parsed1)}, p2=${JSON.stringify(parsed2)}, p3=${JSON.stringify(parsed3)}`);
+  }
+
+} catch (e) {
+  fail(`gmail helpers tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
### Goal
Add Gmail inbox push integration to turn labeled job alert emails into pipeline entries.

### Changes
- Add \gmail-helpers.mjs\ for URL extraction, tracking link denylist, DMARC alignment checks, and subject parsing.
- Add \gmail-ingest.mjs\ CLI runner to sync labeled emails.
- Add \gmail_ingest\ configuration block to \config/profile.example.yml\.
- Add tests to \	est-all.mjs\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gmail job ingestion to handle certain URLs more reliably, including proper encoding for special characters and better duplicate detection.
  * Strengthened email authenticity checks so messages with conflicting or failed authentication are handled more safely.

* **Tests**
  * Added coverage for URL extraction, clean URL detection, email authenticity checks, and role/company parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->