### PR TITLE
docs(contributing): keep third-party hosted entry-points off the README + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS — front-page and contributor-policy surfaces require maintainer review.
+#
+# Rationale: the README is career-ops's front page. Changes to it (badges, links,
+# branding, third-party embeds) are maintainer calls, not drive-by edits — this file
+# auto-requests maintainer review on those surfaces so they don't land unseen.
+# See CONTRIBUTING.md → "What we do NOT accept".
+
+# READMEs — front page + all localized variants
+/README*.md          @santifer
+
+# Contributor policy + this ownership file
+/CONTRIBUTING.md     @santifer
+/.github/CODEOWNERS  @santifer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ Rule of thumb before you build: **provider modules, languages, CLI support, mode
 - **PRs that enable auto-submitting applications** without human review. career-ops is a decision-support tool, not a spam bot.
 - **PRs that add external API dependencies** without prior discussion in an issue.
 - **PRs that add centralized or hosted infrastructure to the core** (proxies, aggregation services, shared Workers). That's the separate opt-in service, not the open-core — bring it to the [direction discussion](https://github.com/santifer/career-ops/discussions/904) first.
+- **PRs that add third-party hosted entry-points or service badges to the README** — links or embeds that route users' resumes or job data through a service the project doesn't operate. The README stays to assets the project controls, and the official online experience is something we keep first-party (see [The Vision](https://github.com/santifer/career-ops/discussions/156)). Projects built on career-ops are welcome — share them in the [Discord](https://discord.gg/8pRpHETxa4) or Discussions, just not on the front page.
 - **PRs containing personal data** (real CVs, emails, phone numbers). Use `examples/` with fictional data instead.
 
 ## Development


### PR DESCRIPTION
Implements the front-page policy:

- **CONTRIBUTING.md** → new "What we do NOT accept" entry: third-party hosted entry-points / service badges that route users' resumes or job data through a service the project doesn't operate don't belong on the README. Points contributors to Discord/Discussions for community projects built on career-ops.
- **.github/CODEOWNERS** (new) → README*.md + CONTRIBUTING.md auto-request maintainer review, so front-page/branding changes don't land unseen.

Docs + config only. Local test-all: 442/0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer contribution guidance about acceptable README links and disallowed third-party hosted entry points or badges.
* **Chores**
  * Added review rules so updates to key front-page documentation require maintainer approval.
  * Established ownership for README-related and contribution policy files to keep guidance consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->