### PR TITLE
chore(gitignore): universal **/.env.local + *.tsbuildinfo safety net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ modes/_profile.md
 
 # Secrets (never commit — use .env.example as template)
 .env
+# Universal safety net — protects ALL checkouts/branches, incl. untracked subprojects
+# (e.g. web/ before it graduates to main). Never commit local env files or TS build caches.
+**/.env.local
+**/.env*.local
+**/*.tsbuildinfo
 
 # Generated
 .resolved-prompt-*


### PR DESCRIPTION
Adds a universal ignore net to the root .gitignore so local env files and TS build caches can never be accidentally committed from any checkout or branch — including untracked subprojects (e.g. `web/` before it lands in main). The existing `.env` rule didn't cover `.env.local`.

Verified: `git check-ignore` now ignores `web/.env.local` and `web/tsconfig.tsbuildinfo`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to keep local environment files and TypeScript build cache artifacts out of source control.
  * Added broader protection against accidentally committing `.env` files and build output across different checkouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->