### PR TITLE
feat: add modes/_custom.md for user custom instructions (#1198)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,17 @@ The portfolio that goes with this system is also open source: [cv-santiago](http
 There are two layers. Read `DATA_CONTRACT.md` for the full list.
 
 **User Layer (NEVER auto-updated, personalization goes HERE):**
-- `cv.md`, `config/profile.yml`, `modes/_profile.md`, `article-digest.md`, `portals.yml`
+- `cv.md`, `config/profile.yml`, `modes/_profile.md`, `modes/_custom.md`, `article-digest.md`, `portals.yml`
 - `data/*`, `reports/*`, `output/*`, `interview-prep/*`
 
 **System Layer (auto-updatable, DON'T put user data here):**
 - `modes/_shared.md`, `modes/oferta.md`, all other modes
 - `CLAUDE.md`, `*.mjs` scripts, `dashboard/*`, `templates/*`, `batch/*`
 
-**THE RULE: When the user asks to customize anything (archetypes, narrative, negotiation scripts, proof points, location policy, comp targets), ALWAYS write to `modes/_profile.md` or `config/profile.yml`. NEVER edit `modes/_shared.md` for user-specific content.** This ensures system updates don't overwrite their customizations.
+**THE RULE: When the user asks to customize anything, write to the USER layer, NEVER to a system file — that is what survives `node update-system.mjs`.**
+- **Profile / evaluation content** (archetypes, narrative, negotiation scripts, proof points, location policy, comp targets) → `modes/_profile.md` or `config/profile.yml`.
+- **Procedural rules** (house rules, custom workflows, output preferences, "always/never do X" automations) → `modes/_custom.md` (create it from `modes/_custom.template.md` if missing).
+- **NEVER** edit `modes/_shared.md`, `CLAUDE.md`, or any other system file for user-specific content — those get overwritten on update.
 
 ## Update Check
 
@@ -112,6 +115,8 @@ node doctor.mjs --json
 Output: `{"onboardingNeeded": <bool>, "missing": [...], "warnings": [...]}`, where `missing` lists whichever of `cv.md`, `config/profile.yml`, `modes/_profile.md`, `portals.yml` are absent. `warnings` is reserved for non-blocking setup signals.
 
 If `modes/_profile.md` is missing, copy from `modes/_profile.template.md` silently. This is the user's customization file — it will never be overwritten by updates.
+
+If `modes/_custom.md` is missing, copy from `modes/_custom.template.md` silently — it holds the user's house rules / custom workflows / automations and is likewise never overwritten by updates.
 
 **If, after that, `onboardingNeeded` is still true (any of `cv.md` / `config/profile.yml` / `portals.yml` is missing), enter onboarding mode.** Do NOT proceed with evaluations, scans, or any other mode until the basics are in place. Guide the user step by step:
 

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -11,6 +11,7 @@ These files contain your personal data, customizations, and work product. Update
 | `cv.md` | Your CV in markdown |
 | `config/profile.yml` | Your identity, targets, comp range |
 | `modes/_profile.md` | Your archetypes, narrative, negotiation scripts |
+| `modes/_custom.md` | Your house rules, custom workflows & output preferences (procedural — survives updates) |
 | `voice-dna.md` | Your writing voice guardrail — banned words, anti-AI-slop rules, tone (optional) |
 | `article-digest.md` | Your proof points from portfolio |
 | `interview-prep/story-bank.md` | Your accumulated STAR+R stories |
@@ -33,6 +34,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | File | Purpose |
 |------|---------|
 | `modes/_shared.md` | Scoring system, global rules, tools |
+| `modes/_custom.template.md` | Template seed for the user's `modes/_custom.md` |
 | `modes/oferta.md` | Evaluation mode instructions |
 | `modes/pdf.md` | PDF generation instructions |
 | `modes/scan.md` | Portal scanner instructions |

--- a/modes/_custom.template.md
+++ b/modes/_custom.template.md
@@ -1,0 +1,60 @@
+# Custom Instructions -- career-ops
+
+<!-- ============================================================
+     THIS FILE IS YOURS. It will NEVER be auto-updated.
+
+     Put your own house rules, custom workflows, and automations
+     here -- anything you want the agent to ALWAYS do (or never do).
+
+     This is for PROCEDURAL rules ("HOW I want things done").
+     For WHO you are (archetypes, narrative, comp, negotiation),
+     use modes/_profile.md instead. Keeping the two separate keeps
+     each one readable.
+
+     The agent reads this file alongside the system instructions;
+     your rules here take precedence over the defaults, as long as
+     they don't break the Data Contract (your files are never
+     touched, and we never auto-submit an application for you).
+
+     Because this is a user-layer file, anything you write here
+     survives `node update-system.mjs`. Put customizations HERE,
+     not in CLAUDE.md / modes/_shared.md / other system files --
+     those get overwritten on update.
+     ============================================================ -->
+
+## House Rules
+
+<!-- Rules the agent should always follow. Examples:
+     - Always write evaluation summaries in British English.
+     - Never include a photo in my CV (US / ATS-first market).
+     - Cap each batch run at 20 listings unless I say otherwise.
+     - If a report scores below 6, skip the cover letter. -->
+
+(none yet -- add yours above)
+
+## Custom Workflows
+
+<!-- Multi-step routines you run often, given a short name. Examples:
+     - "weekly review": scan my saved portals, evaluate the new roles,
+       then give me a one-paragraph summary of the top 3.
+     - "prep <company>": pull the JD, generate STAR stories from
+       article-digest.md, and draft 5 likely interview questions. -->
+
+(none yet -- add yours above)
+
+## Output Preferences
+
+<!-- How you like results formatted. Examples:
+     - Reports: lead with the score and the one-line verdict.
+     - Show the per-step token breakdown after a batch run.
+     - Save PDFs date-first: YYYY-MM-DD-company.pdf -->
+
+(none yet -- add yours above)
+
+## Off-Limits
+
+<!-- Things the agent must never do for you. Examples:
+     - Never auto-fill or submit an application without showing me first.
+     - Never edit a system file to customize my setup -- put it here. -->
+
+(none yet -- add yours above)

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4642,6 +4642,49 @@ try {
   fail(`profile photo test crashed: ${e.message}`);
 }
 
+// ── 29. CUSTOM INSTRUCTIONS extension point (user-layer, #1198) ────
+
+console.log('\n29. Custom instructions extension point (modes/_custom.md, #1198)');
+
+try {
+  // The template MUST ship — it seeds the user file on first run.
+  if (existsSync(join(ROOT, 'modes', '_custom.template.md'))) {
+    pass('modes/_custom.template.md exists (seed for the user custom-instructions file)');
+  } else {
+    fail('modes/_custom.template.md is missing — the custom-instructions seed is not shipped (#1198)');
+  }
+
+  const updater = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
+
+  // The user file MUST be in USER_PATHS so update-system.mjs never overwrites
+  // the user's house rules — that is the whole point of #1198. Anchor to the
+  // USER_PATHS array block so a stray match elsewhere can't give a false pass.
+  const userBlock = (updater.match(/USER_PATHS\s*=\s*\[([\s\S]*?)\]/) || [, ''])[1];
+  if (userBlock.includes("'modes/_custom.md'")) {
+    pass('modes/_custom.md is in USER_PATHS (custom rules survive update-system.mjs)');
+  } else {
+    fail('modes/_custom.md is NOT in USER_PATHS — custom instructions would be wiped on update (#1198)');
+  }
+
+  // The template MUST be in SYSTEM_PATHS so updates deliver/refresh it.
+  const sysBlock = (updater.match(/SYSTEM_PATHS\s*=\s*\[([\s\S]*?)\]/) || [, ''])[1];
+  if (sysBlock.includes("'modes/_custom.template.md'")) {
+    pass('modes/_custom.template.md is in SYSTEM_PATHS (shipped + updatable)');
+  } else {
+    fail('modes/_custom.template.md is NOT in SYSTEM_PATHS — the seed never updates (#1198)');
+  }
+
+  // CLAUDE.md MUST route custom rules to the file AND seed it on onboarding.
+  const claudeMd = readFileSync(join(ROOT, 'CLAUDE.md'), 'utf-8');
+  if (claudeMd.includes('modes/_custom.md') && claudeMd.includes('modes/_custom.template.md')) {
+    pass('CLAUDE.md routes custom rules to modes/_custom.md + seeds it from the template');
+  } else {
+    fail('CLAUDE.md does not reference modes/_custom.md / its template — agents will not use it (#1198)');
+  }
+} catch (e) {
+  fail(`custom instructions test crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -43,6 +43,7 @@ export const SEMVER_RE = /(?:^|-)v?(\d+\.\d+\.\d+)$/i;
 const SYSTEM_PATHS = [
   'modes/_shared.md',
   'modes/_profile.template.md',
+  'modes/_custom.template.md',
   'modes/oferta.md',
   'modes/pdf.md',
   'modes/cover.md',
@@ -171,6 +172,7 @@ const USER_PATHS = [
   'cv.md',
   'config/profile.yml',
   'modes/_profile.md',
+  'modes/_custom.md',
   'voice-dna.md',
   'portals.yml',
   'article-digest.md',


### PR DESCRIPTION
## What does this PR do?
Adds `modes/_custom.md` — a dedicated user-layer file for **procedural custom instructions**: house rules, custom workflows, output preferences, and "always/never do X" automations. It's separate from `modes/_profile.md` (which holds profile/evaluation data) so each stays readable.

Like `_profile.md`, it lives in `USER_PATHS` so it **survives `node update-system.mjs`**, and it's seeded from `modes/_custom.template.md` (a `SYSTEM_PATHS` file) on first run. This gives users a sanctioned home for custom instructions instead of editing system files (`CLAUDE.md` / `_shared.md`) that get overwritten on update — the exact friction reported in #1198.

### Changes
- `modes/_custom.template.md` — new seeded template (House Rules / Custom Workflows / Output Preferences / Off-Limits)
- `update-system.mjs` — `_custom.md` → USER_PATHS, `_custom.template.md` → SYSTEM_PATHS
- `CLAUDE.md` — routes procedural customizations to `_custom.md`; onboarding seeds it from the template
- `DATA_CONTRACT.md` — documents both files
- `test-all.mjs` — §29 verifies the wiring (template ships, USER/SYSTEM_PATHS membership, CLAUDE.md references)

### Why additive & low-risk
No behavior change to existing flows — purely a new optional user file. No `BOOTSTRAP_PATHS` needed (it's data, not a re-exec module). Migration tests pass (no USER/SYSTEM collision). `test-all` 464/0.

Part of #1219. Closes #1198.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new user custom-instructions template with sections for house rules, workflows, output preferences, and off-limits items.
  * On first run, the app now creates the user custom-instructions file automatically if it’s missing.

* **Bug Fixes**
  * Updated guidance so user customizations are kept in user-owned files and are no longer placed in system-managed files.
  * Improved update behavior to protect personal custom settings while still refreshing the starter template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->