### PR TITLE
feat(apply): ATS behavioural question matcher — zero-LLM STAR story matching from story-bank.md

### DIFF
--- a/match-star.mjs
+++ b/match-star.mjs
@@ -25,8 +25,12 @@ const LIST_MODE  = args.includes('--list');
 const jdFlag     = args.indexOf('--jd');
 const jdPath     = jdFlag !== -1 ? args[jdFlag + 1] : null;
 const topFlag    = args.indexOf('--top');
-const TOP_N      = topFlag !== -1 ? parseInt(args[topFlag + 1]) || 1 : 1;
-const question   = args.filter(a => !a.startsWith('--') && a !== args[jdFlag + 1] && a !== args[topFlag + 1]).join(' ').trim();
+const topRaw     = topFlag !== -1 ? parseInt(args[topFlag + 1], 10) : NaN;
+const TOP_N      = Number.isInteger(topRaw) && topRaw > 0 ? topRaw : 1;
+// Only exclude flag values from positional args when the flags are actually present
+const question   = args
+  .filter(a => !a.startsWith('--') && a !== (jdFlag !== -1 ? args[jdFlag + 1] : null) && a !== (topFlag !== -1 ? args[topFlag + 1] : null))
+  .join(' ').trim();
 
 // ── Parser ───────────────────────────────────────────────────────────
 
@@ -126,10 +130,12 @@ function score(story, queryTokens, jdTokens) {
     if (bodyTokens.includes(token)) s += 1;
   }
 
-  // JD boost: if a tag appears in the JD, weight it higher
+  // JD boost: stopword-filtered JD tokens matched against tokenized tags (exact token overlap)
   if (jdTokens.length > 0) {
+    const jdSignal = new Set(jdTokens.filter(t => !STOPWORDS.has(t)));
     for (const tag of story.tags) {
-      if (jdTokens.some(t => tag.includes(t) || t.includes(tag))) s += 2;
+      const tagTokens = tokenize(tag);
+      if (tagTokens.some(t => jdSignal.has(t))) s += 2;
     }
   }
 
@@ -153,8 +159,13 @@ function formatAts(story, question) {
   if (story.result)    parts.push(story.result);
   if (story.reflection) parts.push(story.reflection);
 
-  const prose = parts.filter(Boolean).join(' ');
-  const words = prose.split(/\s+/).length;
+  const wordArr = parts.filter(Boolean).join(' ').split(/\s+/);
+  // Enforce 500-word ceiling; prose below 250 words gets a warning
+  const prose   = wordArr.slice(0, 500).join(' ');
+  const words   = Math.min(wordArr.length, 500);
+  const notice  = wordArr.length < 250
+    ? '\n   ⚠️  Under 250 words — consider expanding this story in story-bank.md.'
+    : '';
 
   return [
     `— ${story.title}${story.theme ? ` [${story.theme}]` : ''}`,
@@ -163,7 +174,7 @@ function formatAts(story, question) {
     '',
     prose,
     '',
-    `   (~${words} words)`,
+    `   (~${words} words)${notice}`,
   ].filter(s => s !== null).join('\n');
 }
 
@@ -231,6 +242,6 @@ for (let i = 0; i < ranked.length; i++) {
   console.log('');
 }
 
-if (ranked[0].score === 0) {
+if (ranked.length > 0 && ranked[0].score === 0) {
   console.log('⚠️  No strong match found. Consider adding a story to story-bank.md that covers this competency.');
 }

--- a/match-star.mjs
+++ b/match-star.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+/**
+ * match-star.mjs — Zero-LLM, zero-browser ATS behavioural question matcher.
+ *
+ * Parses interview-prep/story-bank.md, scores each STAR story against the
+ * question text (and optionally a JD file), and returns the top match(es)
+ * formatted to ATS paste length (250–500 words).
+ *
+ * Usage:
+ *   node match-star.mjs "Tell me about a time you led a project under pressure"
+ *   node match-star.mjs "Describe a conflict you resolved" --jd jds/acme.md
+ *   node match-star.mjs "Give an example of handling ambiguity" --top 2
+ *   node match-star.mjs --list    # list all stories with their tags
+ */
+
+import { readFileSync, existsSync } from 'fs';
+
+// ── Config ──────────────────────────────────────────────────────────
+
+const STORY_BANK_PATH = 'interview-prep/story-bank.md';
+
+const args       = process.argv.slice(2);
+const LIST_MODE  = args.includes('--list');
+const jdFlag     = args.indexOf('--jd');
+const jdPath     = jdFlag !== -1 ? args[jdFlag + 1] : null;
+const topFlag    = args.indexOf('--top');
+const TOP_N      = topFlag !== -1 ? parseInt(args[topFlag + 1]) || 1 : 1;
+const question   = args.filter(a => !a.startsWith('--') && a !== args[jdFlag + 1] && a !== args[topFlag + 1]).join(' ').trim();
+
+// ── Parser ───────────────────────────────────────────────────────────
+
+/**
+ * Parse story-bank.md into structured story objects.
+ * @param {string} content
+ * @returns {Array<{title, theme, source, situation, task, action, result, reflection, tags}>}
+ */
+function parseStories(content) {
+  const stories = [];
+  // Split on story headings: ### [Theme] Title
+  const blocks = content.split(/^### /m).slice(1);
+
+  for (const block of blocks) {
+    const lines  = block.trim().split('\n');
+    const header = lines[0].trim();
+
+    // Extract theme from [Theme] prefix if present
+    const themeMatch = header.match(/^\[([^\]]+)\]\s*(.+)/);
+    const theme = themeMatch ? themeMatch[1].trim() : '';
+    const title = themeMatch ? themeMatch[2].trim() : header;
+
+    const get = (label) => {
+      const re  = new RegExp(`\\*\\*${label}:\\*\\*\\s*(.+)`);
+      const hit = block.match(re);
+      return hit ? hit[1].trim() : '';
+    };
+
+    const tagsRaw = get('Best for questions about');
+    const tags    = tagsRaw
+      ? tagsRaw.split(/[,;]/).map(t => t.trim().toLowerCase()).filter(Boolean)
+      : [];
+
+    if (!title || (!get('A \\(Action\\)') && !get('Action'))) continue; // skip template/empty blocks
+
+    stories.push({
+      title,
+      theme,
+      source:     get('Source'),
+      situation:  get('S \\(Situation\\)') || get('Situation'),
+      task:       get('T \\(Task\\)') || get('Task'),
+      action:     get('A \\(Action\\)') || get('Action'),
+      result:     get('R \\(Result\\)') || get('Result'),
+      reflection: get('Reflection'),
+      tags,
+    });
+  }
+
+  return stories;
+}
+
+// ── Scoring ──────────────────────────────────────────────────────────
+
+/**
+ * Tokenize text into lowercase words, stripping punctuation.
+ * @param {string} text
+ * @returns {string[]}
+ */
+function tokenize(text) {
+  return text.toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter(Boolean);
+}
+
+const STOPWORDS = new Set([
+  'a','an','the','and','or','but','in','on','at','to','for','of','with',
+  'you','me','my','your','i','we','they','it','is','was','were','are',
+  'be','been','have','had','has','do','did','does','tell','about','time',
+  'when','how','give','example','describe','situation','where','what',
+]);
+
+/**
+ * Score a story against a question + optional JD text.
+ * Higher = better match.
+ * @param {object} story
+ * @param {string[]} queryTokens
+ * @param {string[]} jdTokens
+ * @returns {number}
+ */
+function score(story, queryTokens, jdTokens) {
+  const signal = queryTokens.filter(t => !STOPWORDS.has(t));
+  let s = 0;
+
+  // Tag match: highest weight (tags are explicit "best for" labels)
+  const tagText = story.tags.join(' ');
+  for (const token of signal) {
+    if (tagText.includes(token)) s += 3;
+  }
+
+  // Title/theme match
+  const titleTokens = tokenize(story.title + ' ' + story.theme);
+  for (const token of signal) {
+    if (titleTokens.includes(token)) s += 2;
+  }
+
+  // Action + result match (the most substantive parts)
+  const bodyTokens = tokenize(story.action + ' ' + story.result);
+  for (const token of signal) {
+    if (bodyTokens.includes(token)) s += 1;
+  }
+
+  // JD boost: if a tag appears in the JD, weight it higher
+  if (jdTokens.length > 0) {
+    for (const tag of story.tags) {
+      if (jdTokens.some(t => tag.includes(t) || t.includes(tag))) s += 2;
+    }
+  }
+
+  return s;
+}
+
+// ── Formatter ────────────────────────────────────────────────────────
+
+/**
+ * Format a STAR story as ATS-ready prose (250–500 words).
+ * @param {object} story
+ * @param {string} question
+ * @returns {string}
+ */
+function formatAts(story, question) {
+  const parts = [];
+
+  if (story.situation) parts.push(story.situation);
+  if (story.task)      parts.push(story.task);
+  if (story.action)    parts.push(story.action);
+  if (story.result)    parts.push(story.result);
+  if (story.reflection) parts.push(story.reflection);
+
+  const prose = parts.filter(Boolean).join(' ');
+  const words = prose.split(/\s+/).length;
+
+  return [
+    `— ${story.title}${story.theme ? ` [${story.theme}]` : ''}`,
+    story.source ? `   Source: ${story.source}` : '',
+    story.tags.length ? `   Tags: ${story.tags.join(', ')}` : '',
+    '',
+    prose,
+    '',
+    `   (~${words} words)`,
+  ].filter(s => s !== null).join('\n');
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+if (!existsSync(STORY_BANK_PATH)) {
+  console.error(`Error: ${STORY_BANK_PATH} not found.`);
+  console.error('Run /career-ops interview-prep on a role first to populate your story bank.');
+  process.exit(1);
+}
+
+const content = readFileSync(STORY_BANK_PATH, 'utf-8');
+const stories = parseStories(content);
+
+if (stories.length === 0) {
+  console.error('No stories found in story-bank.md yet.');
+  console.error('Run /career-ops interview-prep on a role to add your first stories.');
+  process.exit(1);
+}
+
+if (LIST_MODE) {
+  console.log(`\nStory Bank — ${stories.length} stories\n${'─'.repeat(40)}`);
+  stories.forEach((s, i) => {
+    console.log(`${i + 1}. ${s.title}${s.theme ? ` [${s.theme}]` : ''}`);
+    if (s.tags.length) console.log(`   Tags: ${s.tags.join(', ')}`);
+    if (s.source)      console.log(`   ${s.source}`);
+    console.log('');
+  });
+  process.exit(0);
+}
+
+if (!question) {
+  console.error('Usage: node match-star.mjs "<behavioural question>" [--jd <file>] [--top <n>]');
+  console.error('       node match-star.mjs --list');
+  process.exit(1);
+}
+
+const queryTokens = tokenize(question);
+let jdTokens = [];
+if (jdPath) {
+  if (!existsSync(jdPath)) {
+    console.error(`Error: JD file not found at ${jdPath}`);
+    process.exit(1);
+  }
+  jdTokens = tokenize(readFileSync(jdPath, 'utf-8'));
+}
+
+// Score and rank
+const ranked = stories
+  .map(s => ({ story: s, score: score(s, queryTokens, jdTokens) }))
+  .sort((a, b) => b.score - a.score)
+  .slice(0, TOP_N);
+
+console.log(`\nATS Behavioural Question Matcher`);
+console.log('─'.repeat(40));
+console.log(`Question: "${question}"`);
+if (jdPath) console.log(`JD:       ${jdPath}`);
+console.log(`Stories:  ${stories.length} in bank\n`);
+
+for (let i = 0; i < ranked.length; i++) {
+  const { story, score: s } = ranked[i];
+  console.log(`${'─'.repeat(40)}`);
+  console.log(`Match ${i + 1} of ${ranked.length} (score: ${s})\n`);
+  console.log(formatAts(story, question));
+  console.log('');
+}
+
+if (ranked[0].score === 0) {
+  console.log('⚠️  No strong match found. Consider adding a story to story-bank.md that covers this competency.');
+}

--- a/match-star.mjs
+++ b/match-star.mjs
@@ -27,9 +27,13 @@ const jdPath     = jdFlag !== -1 ? args[jdFlag + 1] : null;
 const topFlag    = args.indexOf('--top');
 const topRaw     = topFlag !== -1 ? parseInt(args[topFlag + 1], 10) : NaN;
 const TOP_N      = Number.isInteger(topRaw) && topRaw > 0 ? topRaw : 1;
-// Only exclude flag values from positional args when the flags are actually present
-const question   = args
-  .filter(a => !a.startsWith('--') && a !== (jdFlag !== -1 ? args[jdFlag + 1] : null) && a !== (topFlag !== -1 ? args[topFlag + 1] : null))
+// Exclude flag operands by index position, not by value, to preserve repeated text in the question
+const excludeIdx = new Set([
+  ...(jdFlag  !== -1 ? [jdFlag + 1]  : []),
+  ...(topFlag !== -1 ? [topFlag + 1] : []),
+]);
+const question = args
+  .filter((a, i) => !a.startsWith('--') && !excludeIdx.has(i))
   .join(' ').trim();
 
 // ── Parser ───────────────────────────────────────────────────────────
@@ -159,7 +163,7 @@ function formatAts(story, question) {
   if (story.result)    parts.push(story.result);
   if (story.reflection) parts.push(story.reflection);
 
-  const wordArr = parts.filter(Boolean).join(' ').split(/\s+/);
+  const wordArr = parts.filter(Boolean).join(' ').split(/\s+/).filter(Boolean);
   // Enforce 500-word ceiling; prose below 250 words gets a warning
   const prose   = wordArr.slice(0, 500).join(' ');
   const words   = Math.min(wordArr.length, 500);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "tracker": "node tracker.mjs",
     "patterns": "node analyze-patterns.mjs",
     "gemini:eval": "node gemini-eval.mjs",
+    "star": "node match-star.mjs",
     "postinstall": "npx playwright install chromium --with-deps || npx playwright install chromium --with-deps"
   },
   "keywords": [

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -97,6 +97,7 @@ const SYSTEM_PATHS = [
   'reserve-report-num.mjs',
   'scan.mjs',
   'scan-ats-full.mjs',
+  'match-star.mjs',
   'providers/',
   'doctor.mjs',
   'check-liveness.mjs',


### PR DESCRIPTION
## Summary

- Adds `match-star.mjs`: zero-LLM, zero-browser ATS behavioural question matcher
- Parses `interview-prep/story-bank.md` into structured STAR entries
- Keyword-scores each story against the question text — tags, title, action/result fields
- Optional `--jd` flag boosts stories whose competency tags appear in the JD
- Outputs top match(es) formatted for ATS paste (250–500 words)
- Optional `--list` flag lists all stories with their competency tags
- Adds `npm run star` script alias
- Zero new dependencies — pure Node.js string processing

## The insight

`story-bank.md` is a dual-use artifact:
- **Interview prep** (existing): recalled verbally in interviews
- **ATS mandatory fields** (new): the same story, reformatted and pasted into the text box

Nothing in the current system connected these two consumers. This script closes that loop without adding any new plumbing.

## Usage

```bash
node match-star.mjs "Tell me about a time you led a project under pressure"
node match-star.mjs "Describe a conflict you resolved" --jd jds/acme.md
node match-star.mjs "Give an example of handling ambiguity" --top 2
node match-star.mjs --list
```

## Test plan

- [ ] `--list` with populated story-bank.md prints all stories with tags
- [ ] `--list` with empty story-bank.md exits with clear message
- [ ] Question matching returns highest-scoring story first
- [ ] `--jd` flag boosts JD-relevant stories over equally-scored ones
- [ ] `--top 2` returns two stories
- [ ] Zero-score match prints the "no strong match" warning
- [ ] Missing story-bank.md exits with setup guidance

Closes #1228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool that ranks relevant STAR interview stories from the local story bank using a behavioural question.
  * Produces ATS-friendly STAR prose for the top matches, with a strict word limit and a warning for shorter outputs; alerts when no strong matches are found.
  * Supports `--list` to display stories and an optional job description file to improve ranking.
* **Chores**
  * Added an npm script to run the STAR matcher.
  * Ensured the new tool is included in the system update set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->