### PR TITLE
fix(plugin): drop non-schema skills/permissions keys from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,14 +5,5 @@
   "author": {
     "name": "santifer",
     "url": "https://santifer.io"
-  },
-  "skills": true,
-  "permissions": {
-    "allow": [
-      "Bash(node:*)",
-      "WebFetch(domain:boards-api.greenhouse.io)",
-      "WebFetch(domain:jobs.ashbyhq.com)",
-      "WebSearch"
-    ]
   }
 }


### PR DESCRIPTION
## What does this PR do?

Removes two top-level keys from `.claude-plugin/plugin.json` that aren't part of the Claude Code plugin manifest schema, making the manifest spec-compliant with **no behavior change**.

- **`"skills": true`** — `skills` is typed `string | array` of *extra skill-directory paths*, not a boolean. career-ops ships a single root `SKILL.md` (plus a `skills/` dir), which Claude Code auto-discovers (v2.1.142+), so the field isn't needed and `true` isn't a valid value for it.
- **`"permissions": { "allow": [...] }`** — `permissions` is a **settings.json** key, not a plugin-manifest key. Inside `plugin.json` it's an unrecognized field and a runtime no-op.

Both are silently ignored at runtime today, but `claude plugin validate` reports them as **unrecognized-field warnings** (and they fail `claude plugin validate --strict`). Skills still load via auto-discovery, and no permissions are lost — the manifest block was never actually applied.

Schema references:
- `skills` is `string|array` of paths → https://code.claude.com/docs/en/plugins-reference#component-path-fields
- Complete manifest schema (no `permissions` key) → https://code.claude.com/docs/en/plugins-reference#complete-schema

## Related issue

None — a small manifest fix with no behavior change (issue-first applies to new features/architecture, not fixes).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (exempt — this is a no-behavior-change manifest fix)
- [x] My PR does not include personal data (touches only `.claude-plugin/plugin.json`)
- [x] I ran `node test-all.mjs` and all tests pass (464 passed, 0 failed)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin configuration to remove unused skill and permission declarations.
  * Simplified the plugin’s setup by trimming unnecessary access settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->