### PR TITLE
docs(portals): add config examples for all built-in providers (#1224)

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -454,10 +454,86 @@ search_queries:
 #   workable        apply.workable.com/<slug>
 #   smartrecruiters (careers|jobs).smartrecruiters.com/<slug>
 #   recruitee       <slug>.recruitee.com
+#   bamboohr        <tenant>.bamboohr.com               (or api: field)
+#   breezy          <tenant>.breezy.hr                  (or api: field)
+#   solidjobs       solid.jobs/public-api/offers/<division>
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
 # bypass detect(). The `provider:` field wins over auto-detection.
+#
+# Some providers are job boards / aggregators with no per-company careers
+# URL to detect, so they must be selected with an explicit `provider:`
+# field: arbeitsagentur, glints, jobstreet, ibm, remoteok, remotive,
+# workingnomads. Examples for every built-in provider are below.
+
+# ── Built-in provider examples ────────────────────────────────────
+# Commented config for each provider in providers/. Copy a stanza into
+# tracked_companies, uncomment, and adjust. Auto-detected providers only
+# need careers_url; the rest need provider: plus any fields shown.
+#
+# -- Auto-detected company ATS (careers_url is enough) --
+#
+# - name: Example BambooHR Co
+#   careers_url: https://exampleco.bamboohr.com/careers   # any *.bamboohr.com host
+#   enabled: true
+#
+# - name: Example Breezy Co
+#   careers_url: https://exampleco.breezy.hr              # any *.breezy.hr host
+#   enabled: true
+#
+# - name: SolidJobs — Engineering
+#   # division path is required; one of:
+#   # it, engineering, marketing, sales, hr, logistics, finances, other
+#   careers_url: https://solid.jobs/public-api/offers/engineering
+#   enabled: true
+#
+# -- Job boards / aggregators (no careers_url; set provider: explicitly) --
+#
+# - name: Arbeitsagentur — AI Roles      # German federal jobs API
+#   provider: arbeitsagentur
+#   arbeitsagentur:
+#     keywords: ["AI Engineer", "Machine Learning"]  # required (>=1)
+#     wo: Berlin          # optional anchor city ('' / omit = all of Germany)
+#     umkreis: 50         # optional km radius (used with wo)
+#     days: 30            # optional recency window
+#     size: 100           # optional results per keyword (1-100)
+#   enabled: true
+#
+# - name: Glints — Indonesia             # SE-Asia aggregator (SG/ID/MY/VN)
+#   provider: glints
+#   searchKeywords: "AI Engineer"
+#   countryCode: ID       # optional 2-letter code (default ID)
+#   enabled: true
+#
+# - name: Jobstreet — Indonesia          # SEEK aggregator
+#   provider: jobstreet
+#   searchKeywords: "Software Engineer"
+#   siteKey: ID-Main      # optional SEEK site key (default ID-Main)
+#   searchLocation: ""    # optional location filter
+#   enabled: true
+#
+# - name: IBM — Germany SWE              # IBM global careers
+#   provider: ibm
+#   ibm:
+#     country: Germany                      # optional facet filter
+#     categories: ["Software Engineering"]  # optional facet filter
+#   enabled: true
+#
+# -- Remote-job feeds (no careers_url, no extra fields) --
+# title_filter / location_filter defined above still apply.
+#
+# - name: RemoteOK
+#   provider: remoteok
+#   enabled: true
+#
+# - name: Remotive
+#   provider: remotive
+#   enabled: true
+#
+# - name: Working Nomads
+#   provider: workingnomads
+#   enabled: true
 
 tracked_companies:
 

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -495,8 +495,8 @@ search_queries:
 #   arbeitsagentur:
 #     keywords: ["AI Engineer", "Machine Learning"]  # required (>=1)
 #     wo: Berlin          # optional anchor city ('' / omit = all of Germany)
-#     umkreis: 50         # optional km radius (used with wo)
-#     days: 30            # optional recency window
+#     umkreis: 50         # optional km radius around wo (0-1000)
+#     days: 30            # optional recency window (1-1000)
 #     size: 100           # optional results per keyword (1-100)
 #   enabled: true
 #


### PR DESCRIPTION
## What does this PR do?

Documents config for every built-in scanner provider in `templates/portals.example.yml`. Previously only 6 (greenhouse, ashby, lever, recruitee, smartrecruiters, workable) were shown; this adds the auto-detect URL patterns for **bamboohr / breezy / solidjobs**, and a new commented **"Built-in provider examples"** block with a copy-paste stanza for all 10 previously-undocumented providers — including the job-board/aggregator ones (arbeitsagentur, glints, jobstreet, ibm, remoteok, remotive, workingnomads) that need an explicit `provider:` field. Each stanza's fields were read off each provider's `detect`/`fetch` so they match the real config surface.

Comments/config only — no code logic, no behavior change.

## Related issue

Fixes #1224

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (this is docs — and is tracked by #1224)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (464 passed, 0 failed; `validate-portals` accepts the edited example file)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (System Layer only — `templates/`)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded provider auto-detection guidance with additional URL patterns for BambooHR, Breezy, and SolidJobs.
  * Added a “Built-in provider examples” section with commented YAML stanzas for ATS-style providers, job boards/aggregators, and remote-job feeds.
  * Clarified that explicitly setting `provider:` overrides auto-detection, including branded custom-domain scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->