### PR TITLE
feat(providers): add Comeet ATS provider (#1222)

### DIFF
--- a/providers/comeet.mjs
+++ b/providers/comeet.mjs
@@ -31,26 +31,26 @@ function assertComeetUrl(url) {
   try {
     parsed = new URL(url);
   } catch {
-    throw new Error(`comeet: invalid URL: ${url}`);
+    throw new Error(`comeet: invalid URL: ${redactToken(url)}`);
   }
-  if (parsed.protocol !== 'https:') throw new Error(`comeet: URL must use HTTPS: ${url}`);
+  if (parsed.protocol !== 'https:') throw new Error(`comeet: URL must use HTTPS: ${redactToken(url)}`);
   if (parsed.hostname !== COMEET_API_HOST)
     throw new Error(`comeet: untrusted hostname "${parsed.hostname}" — must be ${COMEET_API_HOST}`);
   if (!parsed.pathname.startsWith('/careers-api/'))
-    throw new Error(`comeet: URL path must be the careers-api endpoint: ${url}`);
+    throw new Error(`comeet: URL path must be the careers-api endpoint: ${redactToken(url)}`);
   return url;
 }
 
-// Redact the per-tenant ?token= so the (informational, possibly-logged)
-// DetectHit url never carries the secret. Best-effort: returns the input
-// unchanged if it can't be parsed.
+// Redact the per-tenant ?token= so neither the (informational, possibly-logged)
+// DetectHit url nor a thrown validation error carries the secret. Best-effort:
+// falls back to a regex strip when the value can't be parsed as a URL.
 function redactToken(url) {
   try {
     const parsed = new URL(url);
     if (parsed.searchParams.has('token')) parsed.searchParams.set('token', 'REDACTED');
     return parsed.href;
   } catch {
-    return url;
+    return typeof url === 'string' ? url.replace(/([?&]token=)[^&#]*/gi, '$1REDACTED') : url;
   }
 }
 
@@ -115,7 +115,9 @@ export default {
 export function parseComeetResponse(json, companyName) {
   const positions = Array.isArray(json) ? json : [];
   return positions
-    .map(j => {
+    .map(row => {
+      // Coerce each row to a safe object so null / non-object members can't throw.
+      const j = (row && typeof row === 'object') ? row : {};
       // Resolve a display-only https URL; drop the position if none is usable.
       let url = '';
       const rawUrl = j.url_active_page || j.url_comeet_hosted_page || '';
@@ -137,12 +139,12 @@ export function parseComeetResponse(json, companyName) {
         : base;
 
       return {
-        title: j.name || '',
+        title: (typeof j.name === 'string' ? j.name.trim() : ''),
         url,
         location,
         company: companyName,
         postedAt: toEpochMs(j.time_updated),
       };
     })
-    .filter(job => job.url);
+    .filter(job => job.title && job.url);
 }

--- a/providers/comeet.mjs
+++ b/providers/comeet.mjs
@@ -1,0 +1,132 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Comeet (Spark Hire Recruit) provider — hits the public, no-auth careers API.
+//
+// The positions endpoint needs BOTH a company-uid and a per-tenant token:
+//   https://www.comeet.co/careers-api/2.0/company/<uid>/positions?token=<token>
+// Neither is derivable from a branded careers URL, so unlike greenhouse/recruitee
+// there is no slug→API shortcut: the full API URL must be supplied via the
+// `api:` field (or pasted into `careers_url`). The API host is a single fixed
+// origin, so the SSRF defence pins hostname to www.comeet.co AND requires the
+// /careers-api/ path prefix (rather than a per-tenant subdomain regex).
+
+const COMEET_API_HOST = 'www.comeet.co';
+
+/** @param {unknown} raw */
+function isComeetApiUrl(raw) {
+  if (typeof raw !== 'string' || !raw) return false;
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === 'https:' && parsed.hostname === COMEET_API_HOST && parsed.pathname.startsWith('/careers-api/');
+}
+
+/** @param {string} url */
+function assertComeetUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`comeet: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`comeet: URL must use HTTPS: ${url}`);
+  if (parsed.hostname !== COMEET_API_HOST)
+    throw new Error(`comeet: untrusted hostname "${parsed.hostname}" — must be ${COMEET_API_HOST}`);
+  if (!parsed.pathname.startsWith('/careers-api/'))
+    throw new Error(`comeet: URL path must be the careers-api endpoint: ${url}`);
+  return url;
+}
+
+/** @param {import('./_types.js').PortalEntry} entry */
+function resolveApiUrl(entry) {
+  if (isComeetApiUrl(entry.api)) return entry.api;
+  // Fall back to careers_url only when it already IS the full careers-api URL
+  // (the branded www.comeet.com/jobs/... page carries no token, so it can't be
+  // turned into an API call).
+  if (isComeetApiUrl(entry.careers_url)) return entry.careers_url;
+  return null;
+}
+
+// NaN-safe Date.parse — `|| undefined` would also coerce a valid epoch 0.
+function toEpochMs(value) {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'comeet',
+
+  detect(entry) {
+    const apiUrl = resolveApiUrl(entry);
+    return apiUrl ? { url: apiUrl } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const apiUrl = resolveApiUrl(entry);
+    if (!apiUrl) throw new Error(`comeet: cannot derive API URL for ${entry.name} (set api: to the full careers-api positions URL)`);
+    assertComeetUrl(apiUrl);
+    // redirect:'error' prevents SSRF via server-side redirects; combined with
+    // assertComeetUrl above it guarantees the final hostname stays www.comeet.co.
+    const json = await ctx.fetchJson(apiUrl, { redirect: 'error' });
+    return parseComeetResponse(json, entry.name);
+  },
+};
+
+/**
+ * Parse a Comeet careers-api positions response. Exported for unit tests.
+ *
+ * Comeet returns a top-level ARRAY of position objects:
+ *   [{ name, location: { name, is_remote }, url_active_page,
+ *      url_comeet_hosted_page, time_updated, ... }]
+ *
+ * - url: prefer `url_active_page` (the tenant's live careers page), fall back to
+ *   `url_comeet_hosted_page` (the Comeet-hosted page). Both are public, display-
+ *   only URLs (recorded in the pipeline/history, never server-fetched here), so
+ *   they are NOT host-locked. Require a well-formed https: URL; a position whose
+ *   URL is missing/non-https/malformed is dropped (url is the dedup key).
+ * - location: `location.name`, appending "Remote" when `location.is_remote`.
+ *
+ * @param {any} json
+ * @param {string} companyName
+ * @returns {Array<{title: string, url: string, company: string, location: string, postedAt?: number}>}
+ */
+export function parseComeetResponse(json, companyName) {
+  const positions = Array.isArray(json) ? json : [];
+  return positions
+    .map(j => {
+      // Resolve a display-only https URL; drop the position if none is usable.
+      let url = '';
+      const rawUrl = j.url_active_page || j.url_comeet_hosted_page || '';
+      if (typeof rawUrl === 'string' && rawUrl) {
+        try {
+          const parsed = new URL(rawUrl);
+          if (parsed.protocol === 'https:') url = parsed.href;
+        } catch {
+          // malformed URL → leave url = ''
+        }
+      }
+
+      const loc = j.location || {};
+      const remote = loc.is_remote ? 'Remote' : '';
+      const base = (typeof loc.name === 'string' && loc.name.trim()) ? loc.name.trim() : '';
+      // Append "Remote" only when the base location doesn't already say so.
+      const location = remote && !/remote/i.test(base)
+        ? [base, remote].filter(Boolean).join(', ')
+        : base;
+
+      return {
+        title: j.name || '',
+        url,
+        location,
+        company: companyName,
+        postedAt: toEpochMs(j.time_updated),
+      };
+    })
+    .filter(job => job.url);
+}

--- a/providers/comeet.mjs
+++ b/providers/comeet.mjs
@@ -41,6 +41,19 @@ function assertComeetUrl(url) {
   return url;
 }
 
+// Redact the per-tenant ?token= so the (informational, possibly-logged)
+// DetectHit url never carries the secret. Best-effort: returns the input
+// unchanged if it can't be parsed.
+function redactToken(url) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.searchParams.has('token')) parsed.searchParams.set('token', 'REDACTED');
+    return parsed.href;
+  } catch {
+    return url;
+  }
+}
+
 /** @param {import('./_types.js').PortalEntry} entry */
 function resolveApiUrl(entry) {
   if (isComeetApiUrl(entry.api)) return entry.api;
@@ -64,7 +77,10 @@ export default {
 
   detect(entry) {
     const apiUrl = resolveApiUrl(entry);
-    return apiUrl ? { url: apiUrl } : null;
+    // The DetectHit url is informational (the framework may log it), so strip
+    // the secret ?token= before returning it — fetch() re-resolves the real
+    // URL from the entry, so redaction here is safe.
+    return apiUrl ? { url: redactToken(apiUrl) } : null;
   },
 
   async fetch(entry, ctx) {

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -454,10 +454,22 @@ search_queries:
 #   workable        apply.workable.com/<slug>
 #   smartrecruiters (careers|jobs).smartrecruiters.com/<slug>
 #   recruitee       <slug>.recruitee.com
+#   comeet          api: https://www.comeet.co/careers-api/2.0/company/<uid>/positions?token=<token>
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
 # bypass detect(). The `provider:` field wins over auto-detection.
+#
+# Comeet needs the full careers-api URL (it carries a per-tenant token that a
+# branded careers page does not expose), so set it via the api: field — e.g.:
+#
+#   - name: Spark Hire
+#     careers_url: https://www.comeet.com/jobs/spark-hire/30.005
+#     api: https://www.comeet.co/careers-api/2.0/company/30.005/positions?token=YOUR_TOKEN
+#     enabled: true
+#
+# Find <uid> and <token> in Comeet under Settings → Sourcing → Careers Website →
+# Integrated website → Careers API.
 
 tracked_companies:
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4804,6 +4804,22 @@ try {
   if (noDup[0]?.location === 'Remote, EMEA') pass('parseComeetResponse does not double-append Remote');
   else fail(`expected "Remote, EMEA", got ${JSON.stringify(noDup[0]?.location)}`);
 
+  // malformed members (null / non-object / whitespace-only name) must neither
+  // throw nor slip through: a row needs a non-empty trimmed title AND a url.
+  const dirty = [
+    null,
+    'not an object',
+    42,
+    { name: '   ', url_active_page: 'https://www.comeet.com/jobs/x/blank' }, // blank title → dropped
+    { name: '  Padded Role  ', url_active_page: 'https://www.comeet.com/jobs/x/p', location: {} }, // trimmed, kept
+  ];
+  const cleaned = parseComeetResponse(dirty, 'X');
+  if (cleaned.length === 1 && cleaned[0].title === 'Padded Role') {
+    pass('parseComeetResponse skips null/non-object/blank-title rows and trims the title');
+  } else {
+    fail(`dirty parse = ${JSON.stringify(cleaned)} (expected 1 row "Padded Role")`);
+  }
+
 } catch (e) {
   fail(`comeet provider tests crashed: ${e.message}`);
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4685,6 +4685,121 @@ try {
   fail(`custom instructions test crashed: ${e.message}`);
 }
 
+// ── 30. Provider — comeet ───────────────────────────────────────
+console.log('\n30. Provider — comeet');
+
+try {
+  const comeet = (await import(pathToFileURL(join(ROOT, 'providers/comeet.mjs')).href)).default;
+  const { parseComeetResponse } = await import(pathToFileURL(join(ROOT, 'providers/comeet.mjs')).href);
+
+  if (comeet.id === 'comeet') pass('comeet.id is "comeet"');
+  else fail(`comeet.id is ${JSON.stringify(comeet.id)}`);
+
+  // detect: explicit api: careers-api URL is honoured
+  const apiUrl = 'https://www.comeet.co/careers-api/2.0/company/30.005/positions?token=ABC123';
+  const apiHit = comeet.detect({ name: 'Spark Hire', api: apiUrl, careers_url: 'https://www.comeet.com/jobs/spark-hire/30.005' });
+  if (apiHit && apiHit.url === apiUrl) {
+    pass('comeet.detect() resolves an explicit api: careers-api URL');
+  } else {
+    fail(`comeet.detect() api: → ${JSON.stringify(apiHit)}`);
+  }
+
+  // detect: full careers-api URL pasted into careers_url is also accepted
+  const cuHit = comeet.detect({ name: 'X', careers_url: apiUrl });
+  if (cuHit && cuHit.url === apiUrl) {
+    pass('comeet.detect() accepts a careers-api URL in careers_url');
+  } else {
+    fail(`comeet.detect() careers_url → ${JSON.stringify(cuHit)}`);
+  }
+
+  // detect: a branded www.comeet.com/jobs page carries no token → not claimed
+  if (comeet.detect({ name: 'X', careers_url: 'https://www.comeet.com/jobs/spark-hire/30.005' }) === null) {
+    pass('comeet.detect() returns null for a branded careers page (no token)');
+  } else {
+    fail('comeet.detect() should not claim a tokenless branded careers page');
+  }
+
+  if (comeet.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('comeet.detect() returns null for non-comeet URLs');
+  } else {
+    fail('comeet.detect() should return null for non-comeet URLs');
+  }
+
+  if (comeet.detect({ name: 'X', careers_url: null }) === null && comeet.detect({ name: 'X', api: 7 }) === null) {
+    pass('comeet.detect() returns null for non-string url fields (null and 7)');
+  } else {
+    fail('comeet.detect() should treat non-string url fields as missing');
+  }
+
+  // SSRF: comeet.co in the PATH (not host) must not be detected.
+  if (comeet.detect({ name: 'Spoof', api: 'https://evil.example/www.comeet.co/careers-api/2.0/company/x/positions' }) === null) {
+    pass('comeet.detect() rejects path-spoofed URLs');
+  } else {
+    fail('comeet.detect() must NOT misdetect path-spoofed URLs');
+  }
+
+  // SSRF: the wrong comeet host (www.comeet.com, the hosted-page origin) is rejected.
+  if (comeet.detect({ name: 'Spoof', api: 'https://www.comeet.com/careers-api/2.0/company/x/positions?token=y' }) === null) {
+    pass('comeet.detect() pins to www.comeet.co (rejects www.comeet.com)');
+  } else {
+    fail('comeet.detect() must pin to www.comeet.co');
+  }
+
+  // parseComeetResponse — top-level array (real shape, confirmed live)
+  const sample = [
+    {
+      name: 'AI Engineer',
+      url_active_page: 'https://www.comeet.com/jobs/spark-hire/30.005/ai-engineer/F1.B67',
+      url_comeet_hosted_page: 'https://www.comeet.com/jobs/spark-hire/30.005/ai-engineer/F1.B67',
+      time_updated: '2026-06-11T07:49:20Z',
+      location: { name: 'Tel Aviv, Israel', is_remote: true },
+    },
+    {
+      name: 'Backend Engineer',
+      url_comeet_hosted_page: 'https://www.comeet.com/jobs/spark-hire/30.005/backend/AB.C12',
+      location: { name: 'Berlin, Germany', is_remote: false },
+    },
+    { name: 'No URL row', location: { name: 'Remote' } },
+    { name: 'Insecure URL', url_active_page: 'http://www.comeet.com/jobs/x', location: {} },
+  ];
+  const jobs = parseComeetResponse(sample, 'Spark Hire');
+
+  if (jobs.length === 2) pass('parseComeetResponse keeps 2 rows (drops missing/non-https url)');
+  else fail(`parseComeetResponse returned ${jobs.length} rows (expected 2)`);
+
+  if (jobs[0]?.title === 'AI Engineer' && jobs[0]?.company === 'Spark Hire' && jobs[0]?.location === 'Tel Aviv, Israel, Remote') {
+    pass('parseComeetResponse maps name/location.name and appends Remote');
+  } else {
+    fail(`row 0 = ${JSON.stringify(jobs[0])}`);
+  }
+
+  if (jobs[0]?.postedAt === Date.parse('2026-06-11T07:49:20Z')) {
+    pass('parseComeetResponse parses time_updated → postedAt');
+  } else {
+    fail(`row 0 postedAt = ${JSON.stringify(jobs[0]?.postedAt)}`);
+  }
+
+  if (jobs[1]?.url === 'https://www.comeet.com/jobs/spark-hire/30.005/backend/AB.C12' && jobs[1]?.location === 'Berlin, Germany' && jobs[1]?.postedAt === undefined) {
+    pass('parseComeetResponse falls back to url_comeet_hosted_page and omits absent postedAt');
+  } else {
+    fail(`row 1 = ${JSON.stringify(jobs[1])}`);
+  }
+
+  if (parseComeetResponse(null, 'X').length === 0 && parseComeetResponse({}, 'X').length === 0) {
+    pass('non-array payload → empty result (no crash)');
+  } else {
+    fail('non-array payload should yield empty result');
+  }
+
+  // a location already containing "Remote" must not get a duplicate suffix
+  const noDup = parseComeetResponse([{ name: 'R', url_active_page: 'https://www.comeet.com/jobs/x/r', location: { name: 'Remote, EMEA', is_remote: true } }], 'X');
+  if (noDup[0]?.location === 'Remote, EMEA') pass('parseComeetResponse does not double-append Remote');
+  else fail(`expected "Remote, EMEA", got ${JSON.stringify(noDup[0]?.location)}`);
+
+} catch (e) {
+  fail(`comeet provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4695,18 +4695,26 @@ try {
   if (comeet.id === 'comeet') pass('comeet.id is "comeet"');
   else fail(`comeet.id is ${JSON.stringify(comeet.id)}`);
 
-  // detect: explicit api: careers-api URL is honoured
+  // detect: explicit api: careers-api URL is honoured (and the secret token is
+  // redacted from the informational DetectHit url).
   const apiUrl = 'https://www.comeet.co/careers-api/2.0/company/30.005/positions?token=ABC123';
   const apiHit = comeet.detect({ name: 'Spark Hire', api: apiUrl, careers_url: 'https://www.comeet.com/jobs/spark-hire/30.005' });
-  if (apiHit && apiHit.url === apiUrl) {
-    pass('comeet.detect() resolves an explicit api: careers-api URL');
+  if (apiHit && apiHit.url === 'https://www.comeet.co/careers-api/2.0/company/30.005/positions?token=REDACTED') {
+    pass('comeet.detect() resolves an explicit api: URL and redacts the token');
   } else {
     fail(`comeet.detect() api: → ${JSON.stringify(apiHit)}`);
   }
 
+  // the DetectHit url must not leak the real token (it may be logged)
+  if (apiHit && !apiHit.url.includes('ABC123')) {
+    pass('comeet.detect() does not leak the real token in the DetectHit url');
+  } else {
+    fail(`comeet.detect() leaked the token: ${JSON.stringify(apiHit)}`);
+  }
+
   // detect: full careers-api URL pasted into careers_url is also accepted
   const cuHit = comeet.detect({ name: 'X', careers_url: apiUrl });
-  if (cuHit && cuHit.url === apiUrl) {
+  if (cuHit && cuHit.url === 'https://www.comeet.co/careers-api/2.0/company/30.005/positions?token=REDACTED') {
     pass('comeet.detect() accepts a careers-api URL in careers_url');
   } else {
     fail(`comeet.detect() careers_url → ${JSON.stringify(cuHit)}`);


### PR DESCRIPTION
## What does this PR do?

Adds `providers/comeet.mjs` — a zero-token scanner provider for the **Comeet (Spark Hire Recruit)** ATS, so companies on Comeet can be scanned like Greenhouse/Ashby/Lever/Recruitee. Mirrors the existing `providers/` shape (`{ id, detect, fetch }` + an exported pure `parseComeetResponse`).

## Related issue

Part of #230 — implements #1222.

## Type of change

- [x] New feature

## Notes for review

- **Endpoint:** `https://www.comeet.co/careers-api/2.0/company/<uid>/positions?token=<token>` — public, no-auth. Confirmed against a live tenant: the response is a **top-level JSON array** of positions with `name`, `location.name`/`is_remote`, `url_active_page` (fallback `url_comeet_hosted_page`), and `time_updated` (ISO).
- **⚠️ Needs manual config (not slug-derivable):** unlike greenhouse/lever, the endpoint needs a company-uid **and** a per-tenant token that a branded `www.comeet.com/jobs/...` careers page does not expose. So this provider is configured by pasting the full careers-api URL into the **`api:` field** (uid + token found in Comeet → Settings → Sourcing → Careers Website → Integrated website → Careers API). `detect()` only claims an entry once that full URL is present; a tokenless branded page returns `null` so other scan methods handle it.
- **SSRF guard** — hostname pinned to `www.comeet.co` **and** path required to start with `/careers-api/`, plus `redirect:'error'`. Tests cover path-spoofing and the wrong-host (`www.comeet.com`) case.
- **Token hygiene** — `detect()`'s informational url has its `?token=` redacted (the framework may log DetectHit urls); `fetch()` re-resolves the real URL from the entry.
- Example stanza added to `templates/portals.example.yml`; 16-assertion test added to `test-all.mjs`.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] If this is a new feature or architecture change, I opened an issue first (this implements #1222)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass (478 passed, 0 failed)
- [x] My changes respect the Data Contract (System-Layer only: `providers/`, `templates/`, `test-all.mjs`)
- [x] My changes align with the project roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Comeet careers provider with automatic detection and job fetching, including normalized job titles, application URLs, locations, and posting dates.
* **Bug Fixes**
  * Improved security for URL handling by validating HTTPS-only, pinning to Comeet’s careers API endpoint format, and preventing sensitive token leakage in detection links and messages.
* **Documentation**
  * Added configuration guidance and examples for the Comeet provider, including how to supply the `api`/token details.
* **Tests**
  * Added comprehensive provider and response-parsing test coverage, including SSRF hardening cases and edge-condition parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->