### PR TITLE
feat(providers): add Personio ATS provider (#1223)

### DIFF
--- a/providers/personio.mjs
+++ b/providers/personio.mjs
@@ -1,0 +1,150 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Personio provider — hits the public, no-auth XML jobs feed at
+// `https://<slug>.jobs.personio.de/xml` (common across DACH/EU companies).
+// Auto-detects from a `<slug>.jobs.personio.(de|com)` careers host like
+// workable/recruitee. Per-tenant subdomains are the variable part, so the
+// SSRF defence is an anchored host regex rather than a static allowlist.
+//
+// The feed is a flat, well-defined XML document, so it is parsed in-process
+// with a tiny tag extractor (no new dependency — the repo ships none for XML).
+
+const PERSONIO_HOST_RE = /^[a-z0-9][a-z0-9-]*\.jobs\.personio\.(de|com)$/;
+
+/** @param {string} url */
+function assertPersonioUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`personio: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`personio: URL must use HTTPS: ${url}`);
+  if (!PERSONIO_HOST_RE.test(parsed.hostname))
+    throw new Error(`personio: untrusted hostname "${parsed.hostname}" — must match <slug>.jobs.personio.(de|com)`);
+  return url;
+}
+
+/**
+ * Resolve the tenant host (e.g. `acme.jobs.personio.de`) from a careers_url.
+ * Returns null for non-Personio or malformed URLs.
+ * @param {import('./_types.js').PortalEntry} entry
+ */
+function resolveHost(entry) {
+  const raw = typeof entry.careers_url === 'string' ? entry.careers_url : '';
+  if (!raw) return null;
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:') return null;
+  if (!PERSONIO_HOST_RE.test(parsed.hostname)) return null;
+  return parsed.hostname;
+}
+
+// NaN-safe Date.parse — `|| undefined` would also coerce a valid epoch 0.
+function toEpochMs(value) {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'personio',
+
+  detect(entry) {
+    const host = resolveHost(entry);
+    return host ? { url: `https://${host}/xml` } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const host = resolveHost(entry);
+    if (!host) throw new Error(`personio: cannot derive feed URL for ${entry.name}`);
+    const feedUrl = `https://${host}/xml`;
+    assertPersonioUrl(feedUrl);
+    // redirect:'error' prevents SSRF via server-side redirects; combined with
+    // assertPersonioUrl above it guarantees the final hostname stays in-domain.
+    const text = await ctx.fetchText(feedUrl, { redirect: 'error' });
+    return parsePersonioXml(text, entry.name, host);
+  },
+};
+
+// Decode the handful of XML entities that appear in Personio job text.
+// &amp; is decoded LAST so it doesn't double-decode (e.g. "&amp;lt;").
+function decodeXmlEntities(s) {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0*39;|&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+// Extract the text of the first <tag>…</tag> in a block, unwrapping a CDATA
+// section and decoding entities. Returns '' when the tag is absent.
+function tagText(block, tag) {
+  const m = block.match(new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)</${tag}>`));
+  if (!m) return '';
+  let inner = m[1];
+  const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
+  if (cdata) return cdata[1].trim();
+  return decodeXmlEntities(inner).trim();
+}
+
+/**
+ * Parse Personio's public XML jobs feed. Exported for unit tests.
+ *
+ * Shape: `<workzag-jobs><position>…</position>…</workzag-jobs>`, each position
+ * carrying `<id>`, `<name>`, `<office>` (+ optional `<additionalOffices><office>`),
+ * and `<createdAt>` (ISO 8601). The feed has NO per-job URL, so it is built from
+ * the already-validated tenant host: `https://<host>/job/<id>`.
+ *
+ * - title: `<name>` (required — positions without one are dropped).
+ * - url: `https://<host>/job/<id>` — only when `<id>` is a plain integer, so a
+ *   malformed id can never inject into the URL. url is the dedup key; a position
+ *   without a usable id is dropped.
+ * - location: every `<office>` in the block (primary + additionalOffices),
+ *   de-duplicated, joined with ", ".
+ * - postedAt: `<createdAt>` → epoch ms (omitted when unparseable/absent).
+ *
+ * @param {string} xml — raw XML feed body
+ * @param {string} companyName — value written into job.company
+ * @param {string} host — validated tenant host, e.g. `acme.jobs.personio.de`
+ * @returns {Array<{title: string, url: string, company: string, location: string, postedAt?: number}>}
+ */
+export function parsePersonioXml(xml, companyName, host) {
+  if (typeof xml !== 'string') return [];
+  const jobs = [];
+  const blocks = xml.match(/<position\b[^>]*>[\s\S]*?<\/position>/g) || [];
+  for (const block of blocks) {
+    const title = tagText(block, 'name');
+    if (!title) continue;
+
+    const id = tagText(block, 'id');
+    if (!/^\d+$/.test(id)) continue; // need a clean numeric id to build the url
+
+    // Collect every <office> (primary + additionalOffices), de-dupe, join.
+    const offices = [];
+    const seen = new Set();
+    for (const om of block.matchAll(/<office\b[^>]*>([\s\S]*?)<\/office>/g)) {
+      const name = decodeXmlEntities(om[1]).trim();
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        offices.push(name);
+      }
+    }
+
+    jobs.push({
+      title,
+      url: `https://${host}/job/${id}`,
+      location: offices.join(', '),
+      company: companyName,
+      postedAt: toEpochMs(tagText(block, 'createdAt')),
+    });
+  }
+  return jobs;
+}

--- a/providers/personio.mjs
+++ b/providers/personio.mjs
@@ -132,13 +132,14 @@ function tagText(block, tag) {
 export function parsePersonioXml(xml, companyName, host) {
   if (typeof xml !== 'string') return [];
   const jobs = [];
-  const blocks = xml.match(/<position\b[^>]*>[\s\S]*?<\/position>/g) || [];
-  for (const block of blocks) {
-    // Strip the <jobDescriptions> subtree before reading scalar fields: it holds
-    // per-section <name>/<value> pairs whose nested <name> would otherwise race
-    // the position's own <name> (and the same for any other scalar tag).
-    const scalar = block.replace(/<jobDescriptions\b[^>]*>[\s\S]*?<\/jobDescriptions>/gi, '');
-
+  // Strip every <jobDescriptions> subtree from the WHOLE feed before splitting
+  // into <position> blocks: descriptions are free-text HTML that can carry a
+  // literal "</position>" which would otherwise truncate the non-greedy block
+  // match. It also drops the per-section <name>/<value> pairs whose nested
+  // <name> would race the position's own <name> (same for any other scalar tag).
+  const stripped = xml.replace(/<jobDescriptions\b[^>]*>[\s\S]*?<\/jobDescriptions>/gi, '');
+  const blocks = stripped.match(/<position\b[^>]*>[\s\S]*?<\/position>/g) || [];
+  for (const scalar of blocks) {
     const title = tagText(scalar, 'name');
     if (!title) continue;
 

--- a/providers/personio.mjs
+++ b/providers/personio.mjs
@@ -73,26 +73,39 @@ export default {
   },
 };
 
-// Decode the handful of XML entities that appear in Personio job text.
-// &amp; is decoded LAST so it doesn't double-decode (e.g. "&amp;lt;").
+function fromCodePoint(cp) {
+  try {
+    return String.fromCodePoint(cp);
+  } catch {
+    return '';
+  }
+}
+
+// Decode the XML entities that appear in Personio job text: numeric (&#38; /
+// &#x27;) and the named five. Numeric forms are decoded first; &amp; is decoded
+// LAST so a literal "&amp;lt;" yields "&lt;" rather than over-decoding to "<".
 function decodeXmlEntities(s) {
   return s
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, d) => fromCodePoint(parseInt(d, 10)))
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
-    .replace(/&#0*39;|&apos;/g, "'")
+    .replace(/&apos;/g, "'")
     .replace(/&amp;/g, '&');
 }
 
-// Extract the text of the first <tag>…</tag> in a block, unwrapping a CDATA
-// section and decoding entities. Returns '' when the tag is absent.
-function tagText(block, tag) {
-  const m = block.match(new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)</${tag}>`));
-  if (!m) return '';
-  let inner = m[1];
+// Resolve a tag's inner text: unwrap a CDATA section, else decode entities.
+function extractText(inner) {
   const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
   if (cdata) return cdata[1].trim();
   return decodeXmlEntities(inner).trim();
+}
+
+// Extract the text of the first <tag>…</tag> in a block. Returns '' when absent.
+function tagText(block, tag) {
+  const m = block.match(new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)</${tag}>`));
+  return m ? extractText(m[1]) : '';
 }
 
 /**
@@ -121,17 +134,22 @@ export function parsePersonioXml(xml, companyName, host) {
   const jobs = [];
   const blocks = xml.match(/<position\b[^>]*>[\s\S]*?<\/position>/g) || [];
   for (const block of blocks) {
-    const title = tagText(block, 'name');
+    // Strip the <jobDescriptions> subtree before reading scalar fields: it holds
+    // per-section <name>/<value> pairs whose nested <name> would otherwise race
+    // the position's own <name> (and the same for any other scalar tag).
+    const scalar = block.replace(/<jobDescriptions\b[^>]*>[\s\S]*?<\/jobDescriptions>/gi, '');
+
+    const title = tagText(scalar, 'name');
     if (!title) continue;
 
-    const id = tagText(block, 'id');
+    const id = tagText(scalar, 'id');
     if (!/^\d+$/.test(id)) continue; // need a clean numeric id to build the url
 
     // Collect every <office> (primary + additionalOffices), de-dupe, join.
     const offices = [];
     const seen = new Set();
-    for (const om of block.matchAll(/<office\b[^>]*>([\s\S]*?)<\/office>/g)) {
-      const name = decodeXmlEntities(om[1]).trim();
+    for (const om of scalar.matchAll(/<office\b[^>]*>([\s\S]*?)<\/office>/g)) {
+      const name = extractText(om[1]);
       if (name && !seen.has(name)) {
         seen.add(name);
         offices.push(name);
@@ -143,7 +161,7 @@ export function parsePersonioXml(xml, companyName, host) {
       url: `https://${host}/job/${id}`,
       location: offices.join(', '),
       company: companyName,
-      postedAt: toEpochMs(tagText(block, 'createdAt')),
+      postedAt: toEpochMs(tagText(scalar, 'createdAt')),
     });
   }
   return jobs;

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -454,10 +454,18 @@ search_queries:
 #   workable        apply.workable.com/<slug>
 #   smartrecruiters (careers|jobs).smartrecruiters.com/<slug>
 #   recruitee       <slug>.recruitee.com
+#   personio        <slug>.jobs.personio.(de|com)
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
 # bypass detect(). The `provider:` field wins over auto-detection.
+#
+# Personio (common across DACH/EU) auto-detects from its careers host and
+# pulls the public no-auth XML feed at <slug>.jobs.personio.de/xml — e.g.:
+#
+#   - name: Example GmbH
+#     careers_url: https://example-gmbh.jobs.personio.de
+#     enabled: true
 
 tracked_companies:
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4806,6 +4806,30 @@ try {
     fail('empty / non-string feed should yield empty result');
   }
 
+  // Hardening: <jobDescriptions> carries per-section <name>/<value> pairs whose
+  // nested <name> must NOT be mistaken for the position's own title; numeric
+  // entities decode; an office wrapped in CDATA unwraps.
+  const tricky = `<workzag-jobs><position>
+    <id>42</id>
+    <office><![CDATA[München]]></office>
+    <name>Real Title &#38; More</name>
+    <jobDescriptions>
+      <jobDescription><name>Your tasks</name><value>do things</value></jobDescription>
+    </jobDescriptions>
+    <createdAt>2025-03-04T00:00:00+00:00</createdAt>
+  </position></workzag-jobs>`;
+  const tj = parsePersonioXml(tricky, 'Acme', HOST);
+  if (tj.length === 1 && tj[0].title === 'Real Title & More') {
+    pass('parsePersonioXml ignores nested <jobDescriptions><name> + decodes numeric entity');
+  } else {
+    fail(`tricky title = ${JSON.stringify(tj[0]?.title)} (len ${tj.length})`);
+  }
+  if (tj[0]?.location === 'München') {
+    pass('parsePersonioXml unwraps a CDATA <office>');
+  } else {
+    fail(`tricky location = ${JSON.stringify(tj[0]?.location)}`);
+  }
+
 } catch (e) {
   fail(`personio provider tests crashed: ${e.message}`);
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4685,6 +4685,131 @@ try {
   fail(`custom instructions test crashed: ${e.message}`);
 }
 
+// ── 30. Provider — personio ─────────────────────────────────────
+console.log('\n30. Provider — personio');
+
+try {
+  const personio = (await import(pathToFileURL(join(ROOT, 'providers/personio.mjs')).href)).default;
+  const { parsePersonioXml } = await import(pathToFileURL(join(ROOT, 'providers/personio.mjs')).href);
+
+  if (personio.id === 'personio') pass('personio.id is "personio"');
+  else fail(`personio.id is ${JSON.stringify(personio.id)}`);
+
+  // detect: <slug>.jobs.personio.de careers host → /xml feed
+  const hit = personio.detect({ name: 'Acme', careers_url: 'https://acme.jobs.personio.de/' });
+  if (hit && hit.url === 'https://acme.jobs.personio.de/xml') {
+    pass('personio.detect() resolves <slug>.jobs.personio.de → /xml feed');
+  } else {
+    fail(`personio.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  // detect: the .com TLD variant is also accepted
+  const comHit = personio.detect({ name: 'Acme', careers_url: 'https://acme.jobs.personio.com/jobs' });
+  if (comHit && comHit.url === 'https://acme.jobs.personio.com/xml') {
+    pass('personio.detect() accepts the .com TLD variant');
+  } else {
+    fail(`personio.detect() .com → ${JSON.stringify(comHit)}`);
+  }
+
+  if (personio.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('personio.detect() returns null for non-personio URLs');
+  } else {
+    fail('personio.detect() should return null for non-personio URLs');
+  }
+
+  if (personio.detect({ name: 'X', careers_url: null }) === null && personio.detect({ name: 'X', careers_url: 7 }) === null) {
+    pass('personio.detect() returns null for non-string careers_url (null and 7)');
+  } else {
+    fail('personio.detect() should treat non-string careers_url as missing');
+  }
+
+  // SSRF: jobs.personio.de in the PATH (not host) must not be detected.
+  if (personio.detect({ name: 'Spoof', careers_url: 'https://evil.example/acme.jobs.personio.de/xml' }) === null) {
+    pass('personio.detect() rejects path-spoofed URLs');
+  } else {
+    fail('personio.detect() must NOT misdetect path-spoofed URLs');
+  }
+
+  // SSRF: a look-alike host (suffix attack) must be rejected.
+  if (personio.detect({ name: 'Spoof', careers_url: 'https://acme.jobs.personio.de.evil.com/xml' }) === null) {
+    pass('personio.detect() rejects suffix-spoofed look-alike hosts');
+  } else {
+    fail('personio.detect() must reject suffix-spoofed hosts');
+  }
+
+  // parsePersonioXml — the real <workzag-jobs> shape (confirmed live)
+  const HOST = 'acme.jobs.personio.de';
+  const sample = `<?xml version="1.0" encoding="UTF-8"?>
+<workzag-jobs>
+<position>
+  <id>1834171</id>
+  <office>Munich</office>
+  <additionalOffices><office>Berlin</office></additionalOffices>
+  <name>Staff Software Engineer, Data &amp; Platform</name>
+  <createdAt>2024-11-13T14:10:41+00:00</createdAt>
+</position>
+<position>
+  <id>900100</id>
+  <office>Remote</office>
+  <name><![CDATA[Senior Engineer (m/f/d)]]></name>
+  <createdAt>2025-01-02T09:00:00+00:00</createdAt>
+</position>
+<position>
+  <id>777</id>
+  <office>Cologne</office>
+  <name></name>
+</position>
+<position>
+  <id>not-a-number</id>
+  <office>Hamburg</office>
+  <name>Bad ID Role</name>
+</position>
+</workzag-jobs>`;
+  const jobs = parsePersonioXml(sample, 'Acme', HOST);
+
+  if (jobs.length === 2) pass('parsePersonioXml keeps 2 positions (drops empty name + non-numeric id)');
+  else fail(`parsePersonioXml returned ${jobs.length} positions (expected 2)`);
+
+  if (jobs[0]?.title === 'Staff Software Engineer, Data & Platform' && jobs[0]?.company === 'Acme') {
+    pass('parsePersonioXml decodes &amp; in the title');
+  } else {
+    fail(`row 0 = ${JSON.stringify(jobs[0])}`);
+  }
+
+  if (jobs[0]?.url === 'https://acme.jobs.personio.de/job/1834171') {
+    pass('parsePersonioXml builds the job URL from host + numeric id');
+  } else {
+    fail(`row 0 url = ${JSON.stringify(jobs[0]?.url)}`);
+  }
+
+  if (jobs[0]?.location === 'Munich, Berlin') {
+    pass('parsePersonioXml joins primary + additionalOffices');
+  } else {
+    fail(`row 0 location = ${JSON.stringify(jobs[0]?.location)}, expected "Munich, Berlin"`);
+  }
+
+  if (jobs[0]?.postedAt === Date.parse('2024-11-13T14:10:41+00:00')) {
+    pass('parsePersonioXml parses createdAt → postedAt');
+  } else {
+    fail(`row 0 postedAt = ${JSON.stringify(jobs[0]?.postedAt)}`);
+  }
+
+  if (jobs[1]?.title === 'Senior Engineer (m/f/d)') {
+    pass('parsePersonioXml unwraps a CDATA name');
+  } else {
+    fail(`row 1 title = ${JSON.stringify(jobs[1]?.title)}`);
+  }
+
+  if (parsePersonioXml('', 'X', HOST).length === 0 && parsePersonioXml(null, 'X', HOST).length === 0) {
+    pass('empty / non-string feed → empty result (no crash)');
+  } else {
+    fail('empty / non-string feed should yield empty result');
+  }
+
+} catch (e) {
+  fail(`personio provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4830,6 +4830,34 @@ try {
     fail(`tricky location = ${JSON.stringify(tj[0]?.location)}`);
   }
 
+  // Hardening: a <jobDescriptions> value carrying a literal "</position>" must
+  // not truncate the block split. Stripping descriptions from the whole feed
+  // first keeps both positions intact.
+  const sneaky = `<workzag-jobs><position>
+    <id>1</id><name>First</name>
+    <jobDescriptions><jobDescription><name>About</name><value>uses &lt;/position&gt; literally: </position></value></jobDescription></jobDescriptions>
+  </position><position>
+    <id>2</id><name>Second</name>
+  </position></workzag-jobs>`;
+  const sj2 = parsePersonioXml(sneaky, 'Acme', HOST);
+  if (sj2.length === 2 && sj2[0].title === 'First' && sj2[1].title === 'Second') {
+    pass('parsePersonioXml survives a literal </position> inside <jobDescriptions>');
+  } else {
+    fail(`sneaky parse = ${JSON.stringify(sj2.map(j => j.title))} (len ${sj2.length})`);
+  }
+
+  // fetch() passes redirect:'error' to fetchText (SSRF hardening must not regress)
+  let capturedOpts = null;
+  await personio.fetch(
+    { name: 'Acme', careers_url: 'https://acme.jobs.personio.de/' },
+    { fetchText: async (_url, opts) => { capturedOpts = opts; return '<workzag-jobs></workzag-jobs>'; } },
+  );
+  if (capturedOpts && capturedOpts.redirect === 'error') {
+    pass('personio.fetch() passes redirect:"error" to fetchText');
+  } else {
+    fail(`personio.fetch() should pass redirect:"error", got: ${JSON.stringify(capturedOpts)}`);
+  }
+
 } catch (e) {
   fail(`personio provider tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
## What does this PR do?

Adds `providers/personio.mjs` — a zero-token scanner provider for the **Personio** ATS (common across DACH/EU), so companies hiring via Personio can be scanned like Greenhouse/Workable/Recruitee. Mirrors the existing `providers/` shape (`{ id, detect, fetch }` + an exported pure `parsePersonioXml`).

## Related issue

Part of #230 — implements #1223.

## Type of change

- [x] New feature

## Notes for review

- **Endpoint:** `https://<slug>.jobs.personio.de/xml` — public, no-auth XML feed. Confirmed live: `<workzag-jobs><position>` with `<id>`, `<name>`, `<office>` (+ optional `<additionalOffices><office>`), `<createdAt>` (ISO 8601). `detect()` auto-resolves the feed from a `<slug>.jobs.personio.(de|com)` careers host (like workable/recruitee).
- **Zero new dependency for XML** — the repo ships no XML parser and rejects undiscussed deps, so the flat, well-defined feed is parsed in-process with a tiny tag extractor (handles CDATA, the common XML entities, and multiple offices).
- **No per-job URL in the feed** → the posting URL is built from the **already-SSRF-validated tenant host** + a **strictly-numeric `<id>`** (`https://<host>/job/<id>`); a non-numeric/missing id can never inject into the URL and drops the row (url is the dedup key). Positions without a `<name>` are dropped too.
- **SSRF guard** — anchored host regex `^[a-z0-9][a-z0-9-]*\.jobs\.personio\.(de|com)$` + `redirect:'error'`. Tests cover path-spoof and suffix look-alike (`...personio.de.evil.com`) hosts.
- Example stanza added to `templates/portals.example.yml`; 16-assertion test added to `test-all.mjs`.

> Note: some tenants front their feed with an anti-bot checkpoint (HTTP 429); those simply fail to scan for that company, which the recall-first scanner tolerates. The canonical `*.jobs.personio.de/xml` host serves the raw feed directly.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] If this is a new feature or architecture change, I opened an issue first (this implements #1223)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass (479 passed, 0 failed)
- [x] My changes respect the Data Contract (System-Layer only: `providers/`, `templates/`, `test-all.mjs`)
- [x] My changes align with the project roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and importing jobs from Personio career pages, including auto-discovery of the public XML feed.
  * Job entries now include consistent titles, locations (office + additional offices), publish dates, and direct job links.

* **Bug Fixes**
  * Improved feed safety with stricter host and redirect handling to reduce spoofing and SSRF risk.
  * More robust XML parsing (entity decoding, CDATA handling) and hardened extraction against malformed content.

* **Documentation**
  * Updated provider setup examples to include Personio detection details and the expected XML feed URL pattern.

* **Tests**
  * Added coverage for Personio provider detection, XML parsing, and safe fetching/redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->