### PR TITLE
docs: add Source-of-Truth Boundary (anti-fabrication guardrail)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ User-facing content (CV, cover letters, form answers, recruiter outreach, applic
 - `modes/_profile.md`
 - `writing-samples/`
 - `voice-dna.md` (voice/style only — governs *how* text reads, never introduces factual claims)
+- `interview-prep/story-bank.md` and `interview-prep/{company}-{role}.md` (the user's own STAR stories and interview-prep notes — same trust level as `cv.md`; consumed by the `interview` and `apply`/`match-star` modes)
 
 Anything not in this list is **out of scope for content generation**, including:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ User-facing content (CV, cover letters, form answers, recruiter outreach, applic
 - `config/profile.yml`
 - `modes/_profile.md`
 - `writing-samples/`
+- `voice-dna.md` (voice/style only — governs *how* text reads, never introduces factual claims)
 
 Anything not in this list is **out of scope for content generation**, including:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,42 @@ There are two layers. Read `DATA_CONTRACT.md` for the full list.
 
 **THE RULE: When the user asks to customize anything (archetypes, narrative, negotiation scripts, proof points, location policy, comp targets), ALWAYS write to `modes/_profile.md` or `config/profile.yml`. NEVER edit `modes/_shared.md` for user-specific content.** This ensures system updates don't overwrite their customizations.
 
+## Source-of-Truth Boundary (CRITICAL)
+
+User-facing content (CV, cover letters, form answers, recruiter outreach, application form responses) is generated **exclusively** from these files plus statements the user makes directly in the current conversation:
+
+- `cv.md`
+- `article-digest.md`
+- `config/profile.yml`
+- `modes/_profile.md`
+- `writing-samples/`
+
+Anything not in this list is **out of scope for content generation**, including:
+
+- Auto-memory at `~/.claude/projects/.../memory/` — see scope clarification below
+- Any directory outside the career-ops project — for example, parent-directory repos containing the user's product code, sibling project directories, or other unrelated codebases on the same machine
+- Cross-session inferences about the user's work that have not been written into one of the in-scope files
+- Knowledge from other Claude Code projects on the same machine
+
+**Rule from the original design (santifer's case study):** *"Keywords get reformulated, never fabricated."* Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If they cannot or do not want to add it, the output goes without it. Silence on a topic is fine; manufactured detail is not.
+
+**Authorship claims are non-negotiable.** Never claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in `cv.md` or `article-digest.md`. Tool-of-trade conflation (the user uses X → the user built X) is the most common fabrication pattern and is explicitly forbidden.
+
+### Auto-memory scope (clarification, not exception)
+
+The auto-memory layer at `~/.claude/projects/.../memory/` is reserved for **behavioural steering only**:
+
+- User preferences (style, tone, formatting, communication cadence)
+- Process rules and corrections (don't do X, always do Y)
+- Operational state (active relationships, applied roles, observed patterns, outcome learnings)
+- External references (where to find things in other systems)
+
+Auto-memory **never** holds content claims about the user's work, technical accomplishments, authorship, or anything that would appear verbatim or near-verbatim in CV/cover output. If a fact belongs in user-facing content, it lives in the user-layer files, not in memory.
+
+### Where rules live
+
+Rules belong in files the harness reads automatically — `CLAUDE.md`, `AGENTS.md`, `modes/*.md`, `MEMORY.md`. Do not create sidecar documentation that requires manual loading. Reinforcement-without-enforcement decays.
+
 ## Update Check
 
 On the first message of each session, run the update checker silently:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ User-facing content (CV, cover letters, form answers, recruiter outreach, applic
 - `config/profile.yml`
 - `modes/_profile.md`
 - `writing-samples/`
+- `voice-dna.md` (voice/style only — governs *how* text reads, never introduces factual claims)
 
 Anything not in this list is **out of scope for content generation**, including:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,42 @@ There are two layers. Read `DATA_CONTRACT.md` for the full list.
 - **Procedural rules** (house rules, custom workflows, output preferences, "always/never do X" automations) → `modes/_custom.md` (create it from `modes/_custom.template.md` if missing).
 - **NEVER** edit `modes/_shared.md`, `CLAUDE.md`, or any other system file for user-specific content — those get overwritten on update.
 
+## Source-of-Truth Boundary (CRITICAL)
+
+User-facing content (CV, cover letters, form answers, recruiter outreach, application form responses) is generated **exclusively** from these files plus statements the user makes directly in the current conversation:
+
+- `cv.md`
+- `article-digest.md`
+- `config/profile.yml`
+- `modes/_profile.md`
+- `writing-samples/`
+
+Anything not in this list is **out of scope for content generation**, including:
+
+- Auto-memory at `~/.claude/projects/.../memory/` — see scope clarification below
+- Any directory outside the career-ops project — for example, parent-directory repos containing the user's product code, sibling project directories, or other unrelated codebases on the same machine
+- Cross-session inferences about the user's work that have not been written into one of the in-scope files
+- Knowledge from other Claude Code projects on the same machine
+
+**Rule from the original design (santifer's case study):** *"Keywords get reformulated, never fabricated."* Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If they cannot or do not want to add it, the output goes without it. Silence on a topic is fine; manufactured detail is not.
+
+**Authorship claims are non-negotiable.** Never claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in `cv.md` or `article-digest.md`. Tool-of-trade conflation (the user uses X → the user built X) is the most common fabrication pattern and is explicitly forbidden.
+
+### Auto-memory scope (clarification, not exception)
+
+The auto-memory layer at `~/.claude/projects/.../memory/` is reserved for **behavioural steering only**:
+
+- User preferences (style, tone, formatting, communication cadence)
+- Process rules and corrections (don't do X, always do Y)
+- Operational state (active relationships, applied roles, observed patterns, outcome learnings)
+- External references (where to find things in other systems)
+
+Auto-memory **never** holds content claims about the user's work, technical accomplishments, authorship, or anything that would appear verbatim or near-verbatim in CV/cover output. If a fact belongs in user-facing content, it lives in the user-layer files, not in memory.
+
+### Where rules live
+
+Rules belong in files the harness reads automatically — `CLAUDE.md`, `AGENTS.md`, `modes/*.md`, `MEMORY.md`. Do not create sidecar documentation that requires manual loading. Reinforcement-without-enforcement decays.
+
 ## Update Check
 
 On the first message of each session, run the update checker silently:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ User-facing content (CV, cover letters, form answers, recruiter outreach, applic
 - `modes/_profile.md`
 - `writing-samples/`
 - `voice-dna.md` (voice/style only — governs *how* text reads, never introduces factual claims)
+- `interview-prep/story-bank.md` and `interview-prep/{company}-{role}.md` (the user's own STAR stories and interview-prep notes — same trust level as `cv.md`; consumed by the `interview` and `apply`/`match-star` modes)
 
 Anything not in this list is **out of scope for content generation**, including:
 

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -24,7 +24,7 @@ The files below are the **ONLY** sources for user-facing content (CV, cover lett
 **RULE: NEVER hardcode metrics from proof points.** Read them from cv.md + article-digest.md at evaluation time.
 **RULE: For article/project metrics, article-digest.md takes precedence over cv.md.**
 **RULE: Read _profile.md AFTER this file. User customizations in _profile.md override defaults here.**
-**RULE: NEVER claim authorship of a project, repo, library, tool, or artefact unless explicitly attributed to the user in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
 **RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
 
 ---

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -20,6 +20,7 @@ The files below are the **ONLY** sources for user-facing content (CV, cover lett
 | _profile.md | `modes/_profile.md` | ALWAYS (user archetypes, narrative, negotiation) |
 | writing-samples/ | `writing-samples/` | When generating candidate-facing text — check `_profile.md` for cached `## Writing Style` first; only scan files if absent |
 | voice-dna.md | `voice-dna.md` (project root, if exists) | When generating candidate-facing text. Anti-AI-slop guardrail + voice. See Voice DNA precedence below. |
+| interview-prep | `interview-prep/story-bank.md`, `interview-prep/{company}-{role}.md` | When generating ATS form answers / interview content — the user's own STAR stories + prep notes (same trust as cv.md). Consumed by `apply`/`match-star` + interview modes |
 
 **RULE: NEVER hardcode metrics from proof points.** Read them from cv.md + article-digest.md at evaluation time.
 **RULE: For article/project metrics, article-digest.md takes precedence over cv.md.**

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -8,7 +8,9 @@
      that improve with each career-ops release.
      ============================================================ -->
 
-## Sources of Truth
+## Sources of Truth (EXCLUSIVE)
+
+The files below are the **ONLY** sources for user-facing content (CV, cover letters, form answers, recruiter outreach). Auto-memory, parent-directory repos, and cross-session inferences are out of scope. See "Source-of-Truth Boundary" in `AGENTS.md` / `CLAUDE.md` for the full rule.
 
 | File | Path | When |
 |------|------|------|
@@ -22,6 +24,8 @@
 **RULE: NEVER hardcode metrics from proof points.** Read them from cv.md + article-digest.md at evaluation time.
 **RULE: For article/project metrics, article-digest.md takes precedence over cv.md.**
 **RULE: Read _profile.md AFTER this file. User customizations in _profile.md override defaults here.**
+**RULE: NEVER claim authorship of a project, repo, library, tool, or artefact unless explicitly attributed to the user in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an explicit **Source-of-Truth Boundary** to `CLAUDE.md` / `AGENTS.md`, with a matching short-form guardrail in `modes/_shared.md`. It names the exact files an agent may draw on when producing candidate-facing content, and forbids fabrication, authorship conflation, and out-of-scope sourcing.

Pure documentation — 3 files, +77/−1, no code or behavioral change to existing flows.

## The scenario

career-ops doesn't just track applications — it **generates candidate-facing content**: CVs, cover letters, application-form answers, recruiter outreach. That content gets read by real hiring managers and, increasingly, verified at background-check stage.

Modern setups give the agent a wide surface to "help" from:

- an **auto-memory** layer (`~/.claude/projects/.../memory/`) accumulating cross-session notes,
- **sibling/parent directories** that often contain the user's actual product code,
- **cross-session inferences** about what the user has worked on.

All of that is useful for *steering the agent's behavior* — but dangerous if it leaks into *content claims*.

## The problem

Without an explicit boundary, an agent will happily turn ambient context into résumé statements. The highest-stakes failure mode for a job-search tool:

- **Authorship conflation** — the user *uses* a tool/library/framework, and the agent writes that they *built* it (e.g. "the user uses a popular open-source library" → the CV claims they "authored" it). This is the single most common fabrication pattern.
- **Out-of-scope sourcing** — the agent reads a product repo sitting in the parent directory and infers accomplishments that were never put in the CV.
- **Auto-memory leakage** — a behavioral note ("user prefers concise cover letters") or an operational inference gets surfaced verbatim as a CV bullet.
- **Cross-session bleed** — "knowledge" from an unrelated project on the same machine shows up as experience.

A fabricated line is worse than a missing one: it fails at interview or background-check, and it undermines the engineering-trustworthiness signal the whole CV is trying to send.

## Before / After

| | Before | After |
|---|---|---|
| **In-scope sources** | Implied, scattered across modes | One explicit allow-list: `cv.md`, `article-digest.md`, `config/profile.yml`, `modes/_profile.md`, `writing-samples/` + the live conversation |
| **Out-of-scope sources** | Undefined → agent may use auto-memory, sibling repos, inferences | Explicitly named and forbidden for content generation |
| **Authorship claims** | No rule | "Never claim authorship unless attributed in `cv.md`/`article-digest.md`"; tool-of-trade conflation explicitly banned |
| **Auto-memory** | Role ambiguous | Scoped to behavioral steering only; never content claims |
| **Fallback when a claim is unbacked** | Undefined | Ask the user; if no answer, omit. Silence beats manufactured detail |

## What changed

- `CLAUDE.md` / `AGENTS.md`: new `## Source-of-Truth Boundary (CRITICAL)` section + an "Auto-memory scope (clarification)" subsection + "Where rules live."
- `modes/_shared.md`: retitle `Sources of Truth` → `Sources of Truth (EXCLUSIVE)` with a one-line pointer, plus two `RULE` lines (no authorship conflation; "keywords reformulated, never fabricated").

## Related / prior art

Complements the **#1219 `[Umbrella] User/System boundary`** work. That umbrella tracks the *persistence* direction of the boundary — keeping a user's own customizations legible and safe across `update-system.mjs` (e.g. the `modes/_custom.md` home, #1198 → #1220).

This PR addresses the **inverse direction**, which no existing issue covers: not "what's mine vs the system's," but **"what may the agent treat as a source of truth when it writes content for me."** Both are the same root concern — a clear user/system boundary — approached from opposite ends. Happy to file a tracking issue and link it here if the maintainer prefers an issue-first flow.

## Why it's safe to merge

- **Additive only** — no existing instruction is removed or altered; no script/flow touched.
- **Generic** — references only the standard template filenames; nothing user- or deployment-specific.
- **Reinforces an existing principle** — it makes the repo's existing "keywords reformulated, never fabricated" maxim enforceable by giving it a concrete allow-list and failure-mode list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified a strict “Source-of-Truth Boundary” for user-facing content, limiting generation to a defined allowlist and excluding local auto-memory details and cross-session inferences.
  * Strengthened non-fabrication rules (no invented keywords/claims) and tightened authorship attribution (no project/tool claims unless explicitly supported).
  * Defined auto-memory as behavioral steering only, disallowing identity/accomplishment-style claims in CV/cover outputs.
  * Expanded allowed sources to include additional interview/ATS prep materials within the approved scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->