### PR TITLE
fix(scan): trim title-filter keywords before compiling

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -139,8 +139,9 @@ export function buildTitleFilter(titleFilter) {
   // Normalize defensively: a malformed title_filter (a null, numeric, or otherwise
   // non-string entry in the YAML) must not crash the scan via k.toLowerCase().
   const normalize = (arr) => (Array.isArray(arr) ? arr : [])
-    .filter(k => typeof k === 'string' && k.length > 0)
-    .map(k => k.toLowerCase())
+    .filter(k => typeof k === 'string')
+    .map(k => k.trim().toLowerCase())
+    .filter(k => k.length > 0)
     .map(compileKeyword);
   const positive = normalize(titleFilter?.positive);
   const negative = normalize(titleFilter?.negative);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1812,6 +1812,16 @@ try {
   } else {
     fail('buildTitleFilter should ignore non-string/empty keyword entries');
   }
+
+  // Whitespace-only keywords must be trimmed away, not compiled into matchers.
+  // A bare-spaces negative keyword would otherwise reject any title containing
+  // a run of spaces (e.g. "   " matches "Senior   Engineer" via includes()).
+  const wsNegFilter = buildTitleFilter({ positive: [], negative: ['   '] });
+  if (wsNegFilter('Senior   Engineer') === true) {
+    pass('buildTitleFilter drops whitespace-only keywords instead of matching on spaces');
+  } else {
+    fail('buildTitleFilter should drop whitespace-only keywords');
+  }
 } catch (e) {
   fail(`title filter acronym tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
## What does this PR do?

A whitespace-only `title_filter` entry like `"   "` survives `buildTitleFilter`'s `normalize()` (length is checked *before* trimming), so it compiles into a matcher that behaves like `lower.includes("   ")`. As a **negative** keyword that wrongly rejects any title containing a run of spaces; as a **positive** keyword it skews matching. This trims each entry before the length filter so blank entries are dropped, then compiles only the survivors.

CodeRabbit surfaced this during review of #1015; it's a pre-existing edge in `buildTitleFilter`, so it's split out as its own small fix per the one-PR-per-item convention.

Adds a regression test: a `negative: ['   ']` filter no longer rejects `"Senior   Engineer"`.

## Related issue

Refs #586

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title keyword matching by trimming whitespace before case normalization.
  * Whitespace-only and non-string keyword entries are now ignored, preventing ineffective or overly restrictive matchers.

* **Tests**
  * Added an assertion to verify whitespace-only negative keywords no longer cause valid titles (including extra spacing) to be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->