### PR TITLE
fix updater reexec import bootstrap

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1244,6 +1244,32 @@ console.log('\n12a. Skill entrypoint materialization');
   }
 }
 
+{
+  try {
+    const updater = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+    const fixtureSource = `
+      import { execFileSync } from 'child_process';
+      import defaultThing from './scaffolder/bin/skill-entrypoints.mjs';
+      import { helper } from "./lib/helper.mjs";
+      import data from '../outside.mjs';
+      import yaml from 'js-yaml';
+    `;
+    const imports = updater.extractStaticLocalImportPaths(fixtureSource).sort();
+    const expected = [
+      'lib/helper.mjs',
+      'scaffolder/bin/skill-entrypoints.mjs',
+    ];
+
+    if (JSON.stringify(imports) === JSON.stringify(expected)) {
+      pass('update-system extracts static local import paths for re-exec bootstrap (#1245)');
+    } else {
+      fail(`unexpected static local imports: ${JSON.stringify(imports)}`);
+    }
+  } catch (e) {
+    fail(`static local import extraction test crashed: ${e.message}`);
+  }
+}
+
 console.log('\n12b. Skill entrypoint bootstrap (npx / old releases)');
 
 {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -238,6 +238,27 @@ function newestBackupBranch(branches) {
   return timestamped[0]?.branch || branchList[0];
 }
 
+export function extractStaticLocalImportPaths(source) {
+  const paths = new Set();
+  const importRe = /\bimport\s+(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]/g;
+  const exportRe = /\bexport\s+[^'"]*?\s+from\s+['"]([^'"]+)['"]/g;
+
+  for (const re of [importRe, exportRe]) {
+    for (const match of source.matchAll(re)) {
+      const specifier = match[1];
+      if (!specifier.startsWith('./')) continue;
+      const normalized = specifier
+        .replace(/^\.\//, '')
+        .replace(/\\/g, '/')
+        .replace(/\/+/g, '/');
+      if (!normalized || normalized.startsWith('../') || normalized.includes('/../')) continue;
+      paths.add(normalized);
+    }
+  }
+
+  return [...paths].sort();
+}
+
 function gitIn(root, ...args) {
   return execFileSync('git', args, { cwd: root, encoding: 'utf-8', timeout: 30000 }).trim();
 }
@@ -500,7 +521,9 @@ async function apply() {
 
     if (!isReexec) {
       try {
-        git('checkout', 'FETCH_HEAD', '--', 'update-system.mjs', 'scaffolder/bin/skill-entrypoints.mjs');
+        const remoteUpdaterSource = git('show', 'FETCH_HEAD:update-system.mjs');
+        const bootstrapImportPaths = ['update-system.mjs', ...extractStaticLocalImportPaths(remoteUpdaterSource)];
+        git('checkout', 'FETCH_HEAD', '--', ...bootstrapImportPaths);
         execFileSync(process.execPath, ['update-system.mjs', 'apply'], {
           cwd: ROOT,
           stdio: 'inherit',

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -104,8 +104,12 @@ const twoPassManifestChecks = [
     pattern: /CAREER_OPS_UPDATE_REEXEC/,
   },
   {
-    name: 'apply first updates update-system.mjs from FETCH_HEAD',
-    pattern: /git\('checkout',\s*'FETCH_HEAD',\s*'--',\s*'update-system\.mjs',\s*'scaffolder\/bin\/skill-entrypoints\.mjs'\)/,
+    name: 'apply reads target updater imports before self re-exec (#1245)',
+    pattern: /extractStaticLocalImportPaths\(remoteUpdaterSource\)/,
+  },
+  {
+    name: 'apply bootstraps target updater import closure before self re-exec (#1245)',
+    pattern: /git\('checkout',\s*'FETCH_HEAD',\s*'--',\s*\.\.\.bootstrapImportPaths\)/,
   },
   {
     name: 'apply re-execs through the current Node binary',


### PR DESCRIPTION
## Summary

- Resolve the fetched updater's static local import paths before self re-exec
- Checkout `update-system.mjs` plus its local import closure from `FETCH_HEAD` instead of a hard-coded dependency list
- Add tests for import-path extraction and the updater migration contract

## Why

Fixes #1245 for future updater hops. The previous self re-exec step hard-coded `update-system.mjs` plus one known helper, which can break again whenever a future updater gains another top-level local import.

## Validation

- `node updater-migration-tests.mjs` → 61 passed, 0 failed
- `node test-all.mjs --quick` → 528 passed, 0 failed, 16 warnings
- `node test-all.mjs` → 529 passed, 0 failed, 16 warnings
