### PR TITLE
feat(scan): add re-apply cooldown window filtering (#571)

### DIFF
--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -138,3 +138,33 @@ cover_letter:
 # half-point scores like 3.5/5 occur in evaluations). Set it to 0 to
 # generate a PDF for every offer.
 # auto_pdf_score_threshold: 4.0
+
+
+# ── Re-apply Cooldown Windows ────────────────────────────────────────────
+#
+# Used by scan.mjs to skip postings from companies where you're inside a
+# declared re-apply cooldown period. This prevents wasting evaluation tokens
+# on positions you cannot apply to yet.
+#
+# Each entry follows this schema:
+#   CompanyName:
+#     same_role_days:       <number>  # Cooldown period in days for the same role
+#     cross_role_bucket:    <string>  # (Optional) Keyword matching a family of roles
+#     applied_to:           [list]    # (Optional) Specific role titles you applied to
+#     last_apply_date:      "YYYY-MM-DD"  # When you last applied
+#     source:               <string>  # (Optional) Where this cooldown was declared
+#
+# Tip: You can auto-populate this via node audit-reapply.mjs after scanning
+# saved JDs from jds/*.json (future feature). For now, fill it manually.
+#
+# re_apply_windows:
+#   Anthropic:
+#     same_role_days: 180
+#     cross_role_bucket: "all_EM_roles"
+#     applied_to: ["Senior Software Engineer"]
+#     last_apply_date: "2026-03-15"
+#     source: "Job description cooldown clause"
+#   OpenAI:
+#     same_role_days: 90
+#     applied_to: ["Staff Engineer"]
+#     last_apply_date: "2026-01-20"

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -1,4 +1,4 @@
-# Career-Ops Profile Configuration
+﻿# Career-Ops Profile Configuration
 # Copy this file to config/profile.yml and fill in your details.
 # This is the single source of truth for your personal data across all modes.
 
@@ -160,7 +160,7 @@ cover_letter:
 # re_apply_windows:
 #   Anthropic:
 #     same_role_days: 180
-#     cross_role_bucket: "all_EM_roles"
+#     cross_role_bucket: "engineering manager"
 #     applied_to: ["Senior Software Engineer"]
 #     last_apply_date: "2026-03-15"
 #     source: "Job description cooldown clause"
@@ -168,3 +168,4 @@ cover_letter:
 #     same_role_days: 90
 #     applied_to: ["Staff Engineer"]
 #     last_apply_date: "2026-01-20"
+

--- a/scan.mjs
+++ b/scan.mjs
@@ -1037,11 +1037,10 @@ async function main() {
   if (!dryRun && expiredForHistory.length > 0) {
     appendToScanHistory(expiredForHistory, date, 'skipped_expired');
   }
-  // Cooldown-skipped offers recorded so subsequent scans re-evaluate after window expires.
+  // Cooldown-skipped offers recorded with status='added' so they flow through the normal
+  // recheckAfterDays mechanism. The cooldown filter re-evaluates them when the URL is re-fetched.
   if (!dryRun && cooldownOffers.length > 0) {
-    for (var k = 0; k < cooldownOffers.length; k++) {
-      appendToScanHistory([cooldownOffers[k]], date, cooldownOffers[k].cooldownReason || 'skipped_cooldown');
-    }
+    appendToScanHistory(cooldownOffers, date, 'added');
   }
   // Pages that loaded but had no Apply control: record so we don't re-verify
   // them next scan, but never let them reach pipeline.md.
@@ -1155,3 +1154,5 @@ if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
     process.exit(1);
   });
 }
+
+

--- a/scan.mjs
+++ b/scan.mjs
@@ -759,7 +759,7 @@ export function buildCooldownFilter(reApplyWindows) {
     if (!win.last_apply_date) continue;
     const lastApply = new Date(win.last_apply_date);
     if (isNaN(lastApply.getTime())) continue;
-    const sameRoleDays = win.same_role_days || 0;
+    const sameRoleDays = Math.max(0, parseInt(win.same_role_days, 10) || 0);
     const crossRoleBucket = win.cross_role_bucket || null;
     const cooldownUntil = new Date(lastApply);
     cooldownUntil.setDate(cooldownUntil.getDate() + sameRoleDays);

--- a/scan.mjs
+++ b/scan.mjs
@@ -46,6 +46,7 @@ const PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
 const SCAN_HISTORY_PATH = 'data/scan-history.tsv';
 const PIPELINE_PATH = 'data/pipeline.md';
 const APPLICATIONS_PATH = 'data/applications.md';
+const PROFILE_PATH = 'config/profile.yml';
 const PROVIDERS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'providers');
 
 // Ensure required directories exist (fresh setup)
@@ -725,6 +726,58 @@ function guardStatusFor(code) {
   return 'skipped_invalid_url';
 }
 
+/**
+ * buildCooldownFilter — Creates a cooldown-checking function from re_apply_windows config.
+ *
+ * Reads re_apply_windows from config/profile.yml (if present). Returns a function
+ * that checks each offer's company + role against declared cooldown windows.
+ *
+ * @param {Object} reApplyWindows - from config/profile.yml.re_apply_windows
+ * @returns {(offer: Object) => { cooldown: boolean, reason: string|null }}
+ */
+export function buildCooldownFilter(reApplyWindows) {
+  if (!reApplyWindows || typeof reApplyWindows !== 'object' || Object.keys(reApplyWindows).length === 0) {
+    return () => ({ cooldown: false, reason: null });
+  }
+
+  // Pre-compute cooldown thresholds at build time
+  const thresholds = {};
+  for (const [company, win] of Object.entries(reApplyWindows)) {
+    if (!win.last_apply_date) continue;
+    const lastApply = new Date(win.last_apply_date);
+    if (isNaN(lastApply.getTime())) continue;
+    const sameRoleDays = win.same_role_days || 0;
+    const crossRoleBucket = win.cross_role_bucket || null;
+    const cooldownUntil = new Date(lastApply);
+    cooldownUntil.setDate(cooldownUntil.getDate() + sameRoleDays);
+    thresholds[company.toLowerCase()] = { cooldownUntil, crossRoleBucket: crossRoleBucket ? crossRoleBucket.toLowerCase() : null, appliedTo: Array.isArray(win.applied_to) ? win.applied_to.map(function(r) { return r.toLowerCase(); }) : [] };
+  }
+
+  return function(offer) {
+    var name = (offer.company || '').toLowerCase();
+    var title = (offer.title || '').toLowerCase();
+    var entry = thresholds[name];
+    if (!entry) return { cooldown: false, reason: null };
+    if (new Date() < entry.cooldownUntil) {
+      if (entry.appliedTo.length > 0) {
+        for (var r = 0; r < entry.appliedTo.length; r++) {
+          if (title.indexOf(entry.appliedTo[r]) !== -1) {
+            return { cooldown: true, reason: 'cooldown:' + name + ':same_role:' + entry.cooldownUntil.toISOString().slice(0, 10) };
+          }
+        }
+      }
+      if (entry.crossRoleBucket && title.indexOf(entry.crossRoleBucket) !== -1) {
+        return { cooldown: true, reason: 'cooldown:' + name + ':cross_role:' + entry.cooldownUntil.toISOString().slice(0, 10) };
+      }
+      if (entry.appliedTo.length === 0 && !entry.crossRoleBucket) {
+        return { cooldown: true, reason: 'cooldown:' + name + ':blanket:' + entry.cooldownUntil.toISOString().slice(0, 10) };
+      }
+    }
+    return { cooldown: false, reason: null };
+  };
+}
+
+
 async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
@@ -772,6 +825,21 @@ async function main() {
   const salaryFilter = buildSalaryFilter(config.salary_filter);
   const trustValidator = buildTrustValidator(config.trust_filter);
   const contentFilter = buildContentFilter(config.content_filter);
+
+  // ── Cooldown / re-apply window filter ──
+  var cooldownFilter;
+  try {
+    if (existsSync(PROFILE_PATH)) {
+      var profileRaw = readFileSync(PROFILE_PATH, 'utf-8');
+      var profile = parseYaml(profileRaw);
+      cooldownFilter = buildCooldownFilter(profile != null ? profile.re_apply_windows : null);
+    } else {
+      cooldownFilter = buildCooldownFilter(null);
+    }
+  } catch (err) {
+    console.error('Warning: failed to load cooldown config from ' + PROFILE_PATH + ': ' + err.message);
+    cooldownFilter = buildCooldownFilter(null);
+  }
 
   // 3. Resolve a provider for each enabled company / board
   const targets = [];
@@ -845,7 +913,9 @@ async function main() {
   let totalFilteredSalary = 0;
   let totalFilteredContent = 0;
   let totalDupes = 0;
+  var totalFilteredCooldown = 0;
   const newOffers = [];
+  var cooldownOffers = [];
   const errors = [...resolveErrors];
 
   const tasks = targets.map(company => async () => {
@@ -894,6 +964,13 @@ async function main() {
         }
         if (!contentFilter(job.description)) {
           totalFilteredContent++;
+          continue;
+        }
+        // Cooldown filter: skip if user is inside a re-apply cooldown window
+        var cooldownResult = cooldownFilter(job);
+        if (cooldownResult.cooldown) {
+          totalFilteredCooldown++;
+          cooldownOffers.push({ company: job.company, title: job.title, url: job.url, cooldownReason: cooldownResult.reason });
           continue;
         }
         if (seenUrls.has(job.url)) {
@@ -960,6 +1037,12 @@ async function main() {
   if (!dryRun && expiredForHistory.length > 0) {
     appendToScanHistory(expiredForHistory, date, 'skipped_expired');
   }
+  // Cooldown-skipped offers recorded so subsequent scans re-evaluate after window expires.
+  if (!dryRun && cooldownOffers.length > 0) {
+    for (var k = 0; k < cooldownOffers.length; k++) {
+      appendToScanHistory([cooldownOffers[k]], date, cooldownOffers[k].cooldownReason || 'skipped_cooldown');
+    }
+  }
   // Pages that loaded but had no Apply control: record so we don't re-verify
   // them next scan, but never let them reach pipeline.md.
   if (!dryRun && droppedOffers.length > 0) {
@@ -994,6 +1077,7 @@ async function main() {
   console.log(`Filtered by location:  ${totalFilteredLocation} removed`);
   console.log(`Filtered by salary:   ${totalFilteredSalary} removed`);
   console.log(`Filtered by content:  ${totalFilteredContent} removed`);
+  console.log('Filtered by cooldown:  ' + totalFilteredCooldown + ' removed');
   console.log(`Duplicates:            ${totalDupes} skipped`);
   if (historyPolicy.recheckAfterDays != null) {
     console.log(`Recheck eligible:      ${seenUrlState.recheckEligible} old scan-history URL(s)`);

--- a/scan.mjs
+++ b/scan.mjs
@@ -393,6 +393,19 @@ function daysBetweenIsoDates(start, end) {
 
 export function shouldDedupScanHistoryRow({ firstSeen, status = 'added' }, { recheckAfterDays = null, today = new Date().toISOString().slice(0, 10) } = {}) {
   if (PERMANENT_SCAN_HISTORY_STATUSES.has(status)) return true;
+  // Cooldown statuses embed a cooldownUntil date in the format:
+  //   cooldown:{company}:{type}:{YYYY-MM-DD}
+  // Treat them as temporary: once the embedded date has passed, the URL is
+  // recheck-eligible so the cooldown filter re-evaluates it next scan.
+  if (typeof status === 'string' && status.startsWith('cooldown:')) {
+    const parts = status.split(':');
+    const cooldownDate = parts[parts.length - 1];
+    if (/^\d{4}-\d{2}-\d{2}$/.test(cooldownDate)) {
+      // Dedup while still in cooldown; allow recheck after it expires
+      return cooldownDate >= today;
+    }
+    return true;
+  }
   if (status !== 'added') return true;
   if (recheckAfterDays == null) return true;
   const ageDays = daysBetweenIsoDates(firstSeen, today);
@@ -970,7 +983,7 @@ async function main() {
         var cooldownResult = cooldownFilter(job);
         if (cooldownResult.cooldown) {
           totalFilteredCooldown++;
-          cooldownOffers.push({ company: job.company, title: job.title, url: job.url, cooldownReason: cooldownResult.reason });
+          cooldownOffers.push({ company: job.company, title: job.title, url: job.url, location: job.location, source: sourceName, cooldownReason: cooldownResult.reason });
           continue;
         }
         if (seenUrls.has(job.url)) {
@@ -1037,10 +1050,13 @@ async function main() {
   if (!dryRun && expiredForHistory.length > 0) {
     appendToScanHistory(expiredForHistory, date, 'skipped_expired');
   }
-  // Cooldown-skipped offers recorded with status='added' so they flow through the normal
-  // recheckAfterDays mechanism. The cooldown filter re-evaluates them when the URL is re-fetched.
+  // Cooldown-skipped offers recorded with cooldown reason so subsequent scans
+  // can re-evaluate after the window expires. The cooldown status embeds the
+  // cooldownUntil date; shouldDedupScanHistoryRow treats it as temporary.
   if (!dryRun && cooldownOffers.length > 0) {
-    appendToScanHistory(cooldownOffers, date, 'added');
+    for (var k = 0; k < cooldownOffers.length; k++) {
+      appendToScanHistory([cooldownOffers[k]], date, cooldownOffers[k].cooldownReason || 'skipped_cooldown');
+    }
   }
   // Pages that loaded but had no Apply control: record so we don't re-verify
   // them next scan, but never let them reach pipeline.md.


### PR DESCRIPTION
## Problem

scan.mjs 扫描时返回所有活跃职位，不检查用户是否在冷却期内不能再次申请。这导致每次扫描浪费数千 token 去评估"永远无法提交申请"的职位，同时产生无用的 PDF 生成开销。

## Solution

在 scan.mjs 现有过滤链中新增 `buildCooldownFilter` 函数，从 `config/profile.yml` 读取 `re_apply_windows` 配置，在扫描阶段就过滤掉冷却中的职位。

选择「内嵌方案」而非「独立模块」的原因：当前只有一个消费者（scan.mjs），独立模块过度设计，内嵌方案改动集中、与现有过滤模式一致、PR review 更轻松。

## Changes

- **scan.mjs**: 新增 `buildCooldownFilter()` 函数，支持 same_role / cross_role_bucket / blanket 三种冷却模式
- **scan.mjs**: 在 contentFilter 后、dedup 前插入 cooldown 过滤步骤
- **scan.mjs**: 冷却中的 posting 不进入 pipeline，记录到 scan-history.tsv（带 cooldown 原因）
- **scan.mjs**: 扫描摘要新增 cooldown 过滤计数行
- **config/profile.example.yml**: 新增 `re_apply_windows` 配置示例块
- 完全向后兼容：无 re_apply_windows 配置时行为不变

## Testing

- `node --check scan.mjs` — 语法检查通过
- 6 个单元测试全部 PASS：
  1. null config → 不过滤
  2. empty config → 不过滤
  3. same-role 冷却中 → 过滤
  4. unknown company → 不过滤
  5. cross-role bucket 匹配 → 过滤
  6. cooldown expired → 不过滤

## Notes for Reviewer

- `buildCooldownFilter` 的设计与现有 `buildTitleFilter` / `buildContentFilter` 同构，纯函数、无副作用
- `re_apply_windows` 的 YAML schema 完全可选，已有 profile.yml 的用户不受影响
- cross_role_bucket 使用子串匹配（如 "engineering manager" 匹配 "Staff Engineering Manager"），有意保持宽松以减少误杀
- 冷却中的记录写入 scan-history.tsv 确保后续扫描可重新评估（冷却期过期后自动重入）

Closes #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable re-application cooldown windows to job scanning, skipping offers per company until the defined wait period expires.
  * Matching supports same-role rules plus optional cross-role bucket logic and related “applied to” constraints.
  * Cooldown-skipped offers are recorded in scan history with an explanatory status for future re-evaluation.
* **Bug Fixes**
  * When the profile configuration is missing or invalid, scanning automatically falls back to disabling cooldown filtering.
  * Console results now include a “Filtered by cooldown” count.
* **Documentation**
  * Updated the example profile to include UTF-8 BOM and added a `re_apply_windows` configuration section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->