### PR TITLE
fix(updater): resolve self-reexec checkout from the import closure

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1290,6 +1290,44 @@ console.log('\n12b. Skill entrypoint bootstrap (npx / old releases)');
 }
 
 {
+  // Regression guard for #1245: the self-reexec checkout derives its file list
+  // from update-system.mjs's static relative imports, so the parser must catch
+  // every relative import/export form and ignore bare/package specifiers.
+  try {
+    const updater = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+    const sample = [
+      "import { a } from './scaffolder/bin/skill-entrypoints.mjs';",
+      'import b from "../lib/helper.mjs";',
+      "export { c } from './sibling.mjs';",
+      "import './side-effect.mjs';",
+      "import { readFileSync } from 'node:fs';",
+      "import yaml from 'js-yaml';",
+    ].join('\n');
+    const specs = updater.relativeImportSpecifiers(sample).sort();
+    const expected = [
+      '../lib/helper.mjs',
+      './scaffolder/bin/skill-entrypoints.mjs',
+      './sibling.mjs',
+      './side-effect.mjs',
+    ];
+    if (JSON.stringify(specs) === JSON.stringify(expected)) {
+      pass('relativeImportSpecifiers extracts relative imports, ignores bare/package (#1245)');
+    } else {
+      fail(`relativeImportSpecifiers mismatch: got ${JSON.stringify(specs)}`);
+    }
+
+    const liveSource = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
+    if (updater.relativeImportSpecifiers(liveSource).includes('./scaffolder/bin/skill-entrypoints.mjs')) {
+      pass('relativeImportSpecifiers picks up the live skill-entrypoints import (#1245)');
+    } else {
+      fail('relativeImportSpecifiers missed the live skill-entrypoints import');
+    }
+  } catch (e) {
+    fail(`relativeImportSpecifiers test crashed: ${e.message}`);
+  }
+}
+
+{
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-skills-unreadable-'));
   try {
     const canonicalDir = join(fixtureRoot, '.agents', 'skills', 'career-ops');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -17,7 +17,7 @@
 
 import { execFile, execFileSync, execSync } from 'child_process';
 import { readFileSync, writeFileSync, existsSync, unlinkSync, rmSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, posix as pathPosix } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import {
   ensureSkillEntrypoints,
@@ -277,6 +277,66 @@ function mergePathLists(...lists) {
   return merged;
 }
 
+// Files the self-reexec stage must check out so the TARGET update-system.mjs
+// loads without a missing-module crash. Today this is the entry plus its only
+// local import; resolveReexecCheckout derives the real set from the fetched
+// source, so this is only a defensive fallback if parsing ever misses one.
+const REEXEC_FALLBACK_FILES = ['update-system.mjs', 'scaffolder/bin/skill-entrypoints.mjs'];
+
+// Extracts static relative import/export specifiers ('./x.mjs', '../y.mjs')
+// from ESM source. Bare ('node:fs') and package ('js-yaml') specifiers are
+// ignored — only on-disk relative modules need to exist before re-exec.
+export function relativeImportSpecifiers(source) {
+  const specs = new Set();
+  const fromRe = /\b(?:import|export)\b[^;]*?\bfrom\s*['"]([^'"]+)['"]/g;
+  const bareRe = /\bimport\s*['"]([^'"]+)['"]/g;
+  let match;
+  while ((match = fromRe.exec(source))) specs.add(match[1]);
+  while ((match = bareRe.exec(source))) specs.add(match[1]);
+  return [...specs].filter((spec) => spec.startsWith('.'));
+}
+
+// Resolves the relative-import closure of `entry` within a git ref and returns
+// the repo-relative paths (forward-slash, Windows-safe) the re-exec stage must
+// check out. Only files actually present in the ref are returned; the known
+// fallback files are appended defensively. This generalizes the previously
+// hardcoded checkout list so a future new top-level import can't reintroduce
+// the self-reexec ERR_MODULE_NOT_FOUND crash (issue #1245).
+function resolveReexecCheckout(ref, entry) {
+  const visited = new Set();
+  const present = new Set();
+  const order = [];
+  const stack = [entry];
+  while (stack.length) {
+    const file = stack.pop();
+    if (visited.has(file)) continue;
+    visited.add(file);
+    let source;
+    try {
+      source = git('show', `${ref}:${file}`);
+    } catch {
+      continue; // absent in this ref — leave it to the normal update stage
+    }
+    present.add(file);
+    order.push(file);
+    const dir = pathPosix.dirname(file);
+    for (const spec of relativeImportSpecifiers(source)) {
+      stack.push(pathPosix.join(dir, spec));
+    }
+  }
+  for (const file of REEXEC_FALLBACK_FILES) {
+    if (present.has(file)) continue;
+    try {
+      git('show', `${ref}:${file}`);
+      order.push(file);
+      present.add(file);
+    } catch {
+      // Not in the target tree (older version) — nothing to check out.
+    }
+  }
+  return order;
+}
+
 function repoPath(root, path) {
   return join(root, ...path.split('/'));
 }
@@ -500,7 +560,12 @@ async function apply() {
 
     if (!isReexec) {
       try {
-        git('checkout', 'FETCH_HEAD', '--', 'update-system.mjs', 'scaffolder/bin/skill-entrypoints.mjs');
+        // The re-exec runs the TARGET updater, so every local module it imports
+        // at load time must exist first. Resolve the fetched update-system.mjs's
+        // relative-import closure and check out exactly those files, so a future
+        // new top-level import can't reintroduce the self-reexec crash (#1245).
+        const reexecFiles = resolveReexecCheckout('FETCH_HEAD', 'update-system.mjs');
+        git('checkout', 'FETCH_HEAD', '--', ...reexecFiles);
         execFileSync(process.execPath, ['update-system.mjs', 'apply'], {
           cwd: ROOT,
           stdio: 'inherit',

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -104,8 +104,16 @@ const twoPassManifestChecks = [
     pattern: /CAREER_OPS_UPDATE_REEXEC/,
   },
   {
-    name: 'apply first updates update-system.mjs from FETCH_HEAD',
-    pattern: /git\('checkout',\s*'FETCH_HEAD',\s*'--',\s*'update-system\.mjs',\s*'scaffolder\/bin\/skill-entrypoints\.mjs'\)/,
+    name: 'apply resolves the re-exec checkout closure from FETCH_HEAD (#1245)',
+    pattern: /resolveReexecCheckout\('FETCH_HEAD',\s*'update-system\.mjs'\)/,
+  },
+  {
+    name: 'apply checks out the resolved re-exec files from FETCH_HEAD (#1245)',
+    pattern: /git\('checkout',\s*'FETCH_HEAD',\s*'--',\s*\.\.\.reexecFiles\)/,
+  },
+  {
+    name: 're-exec fallback still covers the skill-entrypoints import (#1245)',
+    pattern: /REEXEC_FALLBACK_FILES\s*=\s*\[[^\]]*'scaffolder\/bin\/skill-entrypoints\.mjs'/,
   },
   {
     name: 'apply re-execs through the current Node binary',


### PR DESCRIPTION
## Problem

`node update-system.mjs apply` upgrading **1.12.0 → 1.13.0** crashes during the updater self-reexec with `ERR_MODULE_NOT_FOUND` for `scaffolder/bin/skill-entrypoints.mjs`, aborting the update mid-way (reported in #1245).

## Root cause

The self-reexec stage checks out a **hardcoded** file list before re-execing the fetched updater:

```js
git('checkout', 'FETCH_HEAD', '--', 'update-system.mjs', 'scaffolder/bin/skill-entrypoints.mjs');
execFileSync(process.execPath, ['update-system.mjs', 'apply'], { ... });
```

When a newer version adds a **new top-level import**, the *prior* version's updater re-execs the new `update-system.mjs` without that imported file on disk → crash. 1.12.0's updater only checked out `update-system.mjs`, and 1.13.0 introduced the `skill-entrypoints.mjs` import. Hardcoding the list means every future new import reopens the same failure for the version before it.

## Fix

Derive the checkout list from the fetched `update-system.mjs`'s **relative-import closure** instead of hardcoding it:

- `relativeImportSpecifiers(source)` — extracts static relative `import`/`export … from` and bare `import '…'` specifiers, ignoring `node:`/package specifiers.
- `resolveReexecCheckout(ref, entry)` — walks the closure within the git ref using POSIX paths (Windows-safe), returning only files present in the target; the previously hardcoded files remain a defensive fallback.

A future new top-level import is now picked up automatically and cannot reopen this crash.

**Behavior is unchanged today** — the closure resolves to exactly the same two files (verified against `HEAD`).

## Testing

- `test-all.mjs`: **530 passed, 0 failed** (adds two `relativeImportSpecifiers` unit tests — extraction correctness + that it sees the live `skill-entrypoints` import).
- `updater-migration-tests.mjs`: **62 passed, 0 failed** (updated the source-level check to assert the resolver wiring instead of the old hardcoded line).
- Functional proof: the resolver run against `HEAD` returns `["update-system.mjs", "scaffolder/bin/skill-entrypoints.mjs"]`.

## Note for anyone currently stuck on 1.12.0

This is a forward fix — it prevents the failure mode from recurring, but a machine already on 1.12.0 can't self-update past it (the broken stage ships in the old updater). Manual unblock:

```bash
git fetch https://github.com/santifer/career-ops main
git checkout FETCH_HEAD -- update-system.mjs scaffolder/bin/skill-entrypoints.mjs
node update-system.mjs apply
```

Fixes #1245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved updater re-execution so it now includes all required local modules before restarting, reducing “module not found” failures during updates.
  - Expanded import detection to better identify relative file references and avoid missing dependencies in the update flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->