### PR TITLE
fix(modes): bound subagent delegation to prevent research fan-out

### DIFF
--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -104,6 +104,7 @@ After detecting archetype, read `modes/_profile.md` for the user's specific fram
 6. Generate a PDF without reading the JD first
 7. Use corporate-speak
 8. Ignore the tracker (every evaluated offer gets registered)
+9. Spawn nested subagents, or hand company/role/comp research to an open-ended research skill — research is bounded and inline (see Tools → Subagent delegation)
 
 ### ALWAYS
 
@@ -133,6 +134,14 @@ After detecting archetype, read `modes/_profile.md` for the user's specific fram
 | Edit | Update tracker |
 | Canva MCP | Optional visual CV generation. Duplicate base design, edit text, export PDF. Requires `cv.canva_resume_design_id` in profile.yml. |
 | Bash | `node generate-pdf.mjs` |
+
+### Subagent delegation (cost guardrail)
+
+A mode may tell you to run work in a background subagent (e.g. `scan`, or parallel `pipeline` URLs) to spare the main agent's context. Any subagent you spawn for career-ops is a **single-pass worker**:
+
+- It MUST NOT spawn further subagents, and MUST NOT invoke other skills — especially open-ended or recursive research skills (e.g. a `deep-research` skill). Those fan out into nested agents and can burn tens of millions of tokens on one run.
+- Company, role, and compensation research is ALWAYS done **inline**, with the small explicit set of WebSearch/WebFetch queries the mode names (e.g. `oferta` Blocks C/D) — never delegated to a recursive research harness.
+- One `/career-ops <JD>` evaluates one role; it must never explode into a self-replicating swarm of agents. If you are about to delegate research or nest agents, stop and do it inline, bounded.
 
 ### Time-to-offer priority
 - Working demo + metrics > perfection

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -29,7 +29,7 @@ This complements — does not replace — the per-URL liveness gate in `auto-pip
    **About the PDF gate (configurable):** Read `config/profile.yml` → `auto_pdf_score_threshold`. If the key does not exist, default to `3.0` (this mode's original gate). If the evaluation score is less than the threshold, skip PDF generation: write the report normally, show in the header `**PDF:** not generated — run /career-ops pdf {company-slug} to create on demand`, and mark PDF ❌ in the tracker. If the score is ≥ threshold, generate the PDF as usual.
 
    **Tuning it:** Generating a tailored PDF costs ~30–60s per entry (Playwright launch + HTML render) and produces files that often go unused — most roles score in the 2.x/3.x range and never reach the application stage. Raise `auto_pdf_score_threshold` (e.g. `4.0`) to write only the report for marginal offers and produce the PDF on demand via `/career-ops pdf {slug}`; set `0` to generate one for every offer. Both modes (Path A `/career-ops pipeline` and Path B `batch/batch-runner.sh`) read the same key, so behavior is identical regardless of which path processes an offer.
-3. **If there are 3+ pending URLs**, launch agents in parallel (Agent tool with `run_in_background`) to maximize speed.
+3. **If there are 3+ pending URLs**, launch agents in parallel (Agent tool with `run_in_background`) to maximize speed — at most one agent per pending URL. Each is a **single-pass worker**: it evaluates its one URL and must **not** spawn further subagents or invoke other skills; its company/comp research stays inline and bounded (see `modes/_shared.md` → Subagent delegation). This keeps a pipeline run from fanning out into a recursive agent swarm.
 4. **At the end**, show summary table:
 
 ```

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -18,6 +18,8 @@ Agent(
 )
 ```
 
+The spawned subagent is a **single-pass worker**: it runs the scan with the parsers/APIs/Playwright/WebSearch named below, directly. It must **not** spawn further subagents or invoke other skills (see `modes/_shared.md` → Subagent delegation). Scanning is bounded by `portals.yml`; it is never an open-ended research task.
+
 ## Configuration
 
 Read `portals.yml` which contains:


### PR DESCRIPTION
## Problem

A single `/career-ops <JD>` run could fan out into dozens-to-hundreds of nested subagents and tens of millions of tokens, exhausting the Claude usage limit (#1235, reproduced twice on unrelated JDs).

## Root cause

Two modes spawn a **background subagent** to spare the main agent's context:

- `scan` (`modes/scan.md`) → `Agent(subagent_type="general-purpose", …)`
- `pipeline` (`modes/pipeline.md`) → "launch agents in parallel" for 3+ pending URLs

A `general-purpose` worker inherits the full tool set — including the `Agent` and `Skill` tools — so it can autonomously spawn **further** subagents or invoke an **open-ended research skill** (e.g. a `deep-research` harness). Company/compensation research then decomposes recursively, each sub-topic spawning more agents. Nothing bounded the delegation.

## Fix

Add a **Subagent delegation** cost guardrail to `modes/_shared.md` (the shared system context every mode reads), and reference it at the two spawn sites:

- Any subagent spawned for career-ops is a **single-pass worker**: it must not spawn further subagents or invoke other skills (especially recursive research skills).
- Company/role/compensation research stays **inline**, with the small explicit set of WebSearch/WebFetch queries the mode names (e.g. `oferta` Blocks C/D) — never delegated to a recursive harness.
- One `/career-ops <JD>` evaluates one role; it must never explode into a self-replicating agent swarm. `pipeline` is additionally capped at one agent per pending URL.

This is a prompt-level guardrail (CLI-agnostic — career-ops runs on any agent CLI, so it does not rely on a specific runtime's restricted agent types).

## Testing

`test-all.mjs`: **530 passed, 0 failed** (docs/prompt change; no code paths touched).

## Note

This bounds future runs from `main` onward. Anyone on an older release picks it up on their next `update`.

Fixes #1235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow guidance for AI-assisted operations.
  * Added stronger limits on delegated work so tasks stay bounded and do not chain into extra workers.
  * Updated scanning and multi-URL handling instructions to keep research inline and focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->