### PR TITLE
docs: add docs/CODEX.md Codex guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The skill is defined using the open standard in `.agents/skills/career-ops/SKILL
 
 ## Codex Integration
 
-Career-ops supports Codex through the same shared router, but the invocation model is different from CLIs that auto-register slash commands.
+Career-ops supports Codex through the same shared router, but the invocation model is different from CLIs that auto-register slash commands. For the full guide, see [docs/CODEX.md](docs/CODEX.md).
 
 ### Interactive Codex
 

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -1,0 +1,46 @@
+# Codex Guide
+
+Career-ops supports Codex through the same shared router used by the other CLI integrations.
+
+## How Codex maps to career-ops
+
+- `AGENTS.md` is the shared instruction source.
+- Root `CODEX.md` is the thin Codex wrapper that imports `AGENTS.md`.
+- This file is the human-facing guide for running career-ops workflows from Codex.
+
+## Interactive Codex
+
+Start Codex in the repository root:
+
+```bash
+cd career-ops
+codex
+```
+
+Codex may not expose a native `/career-ops` slash command. When it does not, ask for the same workflow in plain language:
+
+```text
+Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123
+Run the career-ops scan mode and summarize new matches.
+Run the career-ops pipeline mode for data/pipeline.md.
+Run the career-ops pdf mode for the latest evaluated role.
+Run the career-ops tracker mode and summarize the current statuses.
+```
+
+## One-shot workers
+
+For single commands or batch workers, use `codex exec`:
+
+```bash
+codex exec "Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123"
+codex exec "Run career-ops scan mode in this repo and summarize new matches."
+codex exec "Run career-ops pipeline mode for data/pipeline.md."
+codex exec "Run career-ops pdf mode for the latest evaluated role."
+codex exec "Run career-ops tracker mode and summarize the current statuses."
+```
+
+## Notes
+
+- If your Codex environment exposes slash commands, the shared `/career-ops` router semantics still apply.
+- If it does not, use the same mode names through prompts or `codex exec`.
+- Browser-heavy flows such as `scan`, `pipeline`, and `apply` still depend on Playwright browser tools being available in the active agent setup.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -33,7 +33,7 @@ Run the career-ops pdf mode.
 Run the career-ops tracker mode.
 ```
 
-For one-shot workers or batch tasks in Codex, use `codex exec`:
+For one-shot workers or batch tasks in Codex, use `codex exec`. See [docs/CODEX.md](CODEX.md) for the full guide.
 
 ```bash
 codex exec "Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123"

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -463,7 +463,7 @@ console.log('\n5. Data contract validation');
 
 // Check system files exist
 const systemFiles = [
-  'CLAUDE.md', 'CODEX.md', 'OPENCODE.md', 'VERSION', 'DATA_CONTRACT.md',
+  'CLAUDE.md', 'CODEX.md', 'OPENCODE.md', 'VERSION', 'DATA_CONTRACT.md', 'docs/CODEX.md',
   'modes/_shared.md', 'modes/_profile.template.md',
   'modes/oferta.md', 'modes/pdf.md', 'modes/scan.md',
   'modes/heuristics/recruiter-side.md',
@@ -1161,6 +1161,18 @@ if (/^@(?:\.\/)?AGENTS\.md/m.test(codexWrapper)) {
   pass('CODEX.md imports AGENTS.md as a thin wrapper');
 } else {
   fail('CODEX.md is not a thin AGENTS.md wrapper');
+}
+
+const codexGuideDoc = fileExists('docs/CODEX.md') ? readFile('docs/CODEX.md') : '';
+if (
+  /AGENTS\.md/.test(codexGuideDoc) &&
+  /CODEX\.md/.test(codexGuideDoc) &&
+  /codex exec/.test(codexGuideDoc) &&
+  /Codex/i.test(codexGuideDoc)
+) {
+  pass('docs/CODEX.md is a complete Codex guide');
+} else {
+  fail('docs/CODEX.md is missing required content');
 }
 
 // ── 12. SKILL SYMLINK INTEGRITY ─────────────────────────────


### PR DESCRIPTION
Follow-up to #1269.

Adds `docs/CODEX.md` — a standalone human-facing guide for running career-ops workflows from Codex, covering interactive (`codex`) and headless (`codex exec`) usage with practical mode examples.

## Changes

- `docs/CODEX.md` — new guide explaining the `CODEX.md` wrapper relationship, interactive usage, one-shot `codex exec` examples, and notes on Playwright dependency
- `README.md` — adds `docs/CODEX.md` link in the Codex Integration section
- `docs/SETUP.md` — adds `docs/CODEX.md` link in the Codex setup section
- `test-all.mjs` — adds `docs/CODEX.md` to system files presence check and a content assertion

## Test plan

- [ ] `node test-all.mjs` — PASS
- [ ] `docs/CODEX.md` renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Codex guide with usage notes, routing details, example commands, and browser-tool requirements.
  * Updated setup and README guidance to point users to the new Codex documentation and clarify the recommended one-command workflow.

* **Tests**
  * Expanded validation to ensure the new Codex guide is present and includes key routing and usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->