### PR TITLE
chore(codeowners): scope review-gating to CI-blind + catastrophic paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,12 @@
-# CODEOWNERS — auto-requests review from a maintainer on sensitive paths.
+# CODEOWNERS — auto-requests maintainer review on sensitive paths.
 # Last matching pattern wins. See MAINTAINERS.md for the team + ladder.
+#
+# Scope principle: gate what CI can't catch (a bad change here passes the
+# tests silently) + the catastrophic updater + governance docs. Code that
+# test-all.mjs / Renovate / dependency-review already guard (scan.mjs,
+# generate-pdf.mjs, test-all.mjs, package.json) is intentionally NOT gated,
+# so routine contributor PRs aren't bottlenecked on a single owner. Broaden
+# this list once there is more than one code owner.
 
 # Repo docs & governance
 /README*.md            @santifer
@@ -8,21 +15,17 @@
 /ARCHITECTURE.md       @santifer
 /.github/CODEOWNERS    @santifer
 
-# Critical: agent behavior, scoring, and the data contract
+# Agent behavior & the multi-CLI contract (prompt layer — CI-blind)
 /CLAUDE.md             @santifer
 /AGENTS.md             @santifer
 /CODEX.md              @santifer
 /OPENCODE.md           @santifer
 /GEMINI.md             @santifer
+
+# Scoring & the system/user data contract (CI-blind; silent-danger)
 /modes/_shared.md      @santifer
 /DATA_CONTRACT.md      @santifer
 
-# High-blast-radius core scripts
+# The self-updater (catastrophic if wrong — touches user installs)
 /update-system.mjs     @santifer
-/scan.mjs              @santifer
-/scan-ats-full.mjs     @santifer
-/generate-pdf.mjs      @santifer
-/test-all.mjs          @santifer
 /updater-migration-tests.mjs  @santifer
-/batch/batch-runner.sh @santifer
-/package.json          @santifer


### PR DESCRIPTION
Narrows CODEOWNERS to the silent-danger files (prompt layer + scoring + data contract), the self-updater, and governance docs. Un-gates code that CI/Renovate already guard (scan.mjs, generate-pdf.mjs, test-all.mjs, package.json, batch-runner.sh) so routine contributor PRs aren't bottlenecked on a single owner. Rationale documented in the file header; broaden once there's >1 code owner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated review-routing rules for repository documentation and governance files.
  * Added maintainer review coverage for several prompt, data-contract, and updater-related documents and scripts.
  * Refined the policy notes to better describe which areas are protected by required review and which are intentionally left open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->