### PR TITLE
chore(updater): register KIMI.md + .kimi/skills/ in SYSTEM_PATHS

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -81,6 +81,7 @@ const SYSTEM_PATHS = [
   'OPENCODE.md',
   'AGENTS.md',
   'GEMINI.md',
+  'KIMI.md',
   'generate-pdf.mjs',
   'generate-latex.mjs',
   'archive-posting.mjs',
@@ -133,6 +134,7 @@ const SYSTEM_PATHS = [
   '.qwen/',
   '.antigravitycli/skills/',
   '.grok/skills/',
+  '.kimi/skills/',
   'docs/',
   'writing-samples/README.md',
   'VERSION',
@@ -601,7 +603,7 @@ async function apply() {
 
     // 3a. Keep bootstrap paths as a fallback for very old targets, but the
     // target updater's SYSTEM_PATHS is now the source of truth for new files.
-    const BOOTSTRAP_PATHS = ['.agents/', '.opencode/skills/', '.antigravitycli/skills/', '.grok/skills/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'role-matcher.mjs', 'tracker-utils.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs', 'tracker-columns-tests.mjs'];
+    const BOOTSTRAP_PATHS = ['.agents/', '.opencode/skills/', '.antigravitycli/skills/', '.grok/skills/', '.kimi/skills/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'role-matcher.mjs', 'tracker-utils.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs', 'tracker-columns-tests.mjs'];
     const updatePaths = mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS);
 
     for (const path of updatePaths) {


### PR DESCRIPTION
Follow-up to #1193: registers the Kimi wrapper + skills entrypoint in SYSTEM_PATHS/BOOTSTRAP_PATHS so the updater ships them, matching CODEX/grok. No behavior change; test-all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded automatic system updates to include additional KIMI-related files and skills content.
  * Older update targets now also refresh the KIMI skills directory during fallback updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->