### PR TITLE
feat(providers): add The Muse provider (public zero-auth API) (#1270)

### DIFF
--- a/providers/themuse.mjs
+++ b/providers/themuse.mjs
@@ -75,8 +75,8 @@ export default {
           `themuse: unexpected API response on page ${page} — expected { results: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`,
         );
       }
-      if (page === 0 && typeof json.page_count === 'number' && json.page_count > 1) {
-        pageCount = json.page_count;
+      if (page === 0 && Number.isInteger(json.page_count) && json.page_count > 1) {
+        pageCount = Math.min(json.page_count, 100);
       }
       allResults.push(...json.results);
     }

--- a/providers/themuse.mjs
+++ b/providers/themuse.mjs
@@ -2,12 +2,13 @@
 /** @typedef {import('./_types.js').Provider} Provider */
 
 // The Muse provider — public, zero-auth JSON jobs feed.
-// Endpoint: https://www.themuse.com/api/public/jobs?page=0
-// Response shape: { results: [...], page: 0, page_count: N }
+// Endpoint: https://www.themuse.com/api/public/jobs?page={n}
+// Response shape: { results: [...], page: n, page_count: N }
+// All pages are fetched sequentially and aggregated before normalizing.
 //
 // Wire in via a `job_boards:` entry with `provider: themuse`.
 
-const FEED_URL = 'https://www.themuse.com/api/public/jobs?page=0';
+const FEED_BASE = 'https://www.themuse.com/api/public/jobs';
 const TRUSTED_HOST = 'www.themuse.com';
 
 /** @param {string} url */
@@ -61,14 +62,24 @@ export default {
   id: 'themuse',
 
   async fetch(_entry, ctx) {
-    assertMuseUrl(FEED_URL);
-    // redirect:'error' prevents SSRF via server-side redirects
-    const json = await ctx.fetchJson(FEED_URL, { redirect: 'error' });
-    if (!json || !Array.isArray(json.results)) {
-      throw new Error(
-        `themuse: unexpected API response — expected { results: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`,
-      );
+    assertMuseUrl(FEED_BASE);
+    const allResults = [];
+    // Fetch page 0 first to discover page_count, then iterate remaining pages.
+    let pageCount = 1;
+    for (let page = 0; page < pageCount; page++) {
+      const url = `${FEED_BASE}?page=${page}`;
+      // redirect:'error' prevents SSRF via server-side redirects
+      const json = await ctx.fetchJson(url, { redirect: 'error' });
+      if (!json || !Array.isArray(json.results)) {
+        throw new Error(
+          `themuse: unexpected API response on page ${page} — expected { results: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`,
+        );
+      }
+      if (page === 0 && typeof json.page_count === 'number' && json.page_count > 1) {
+        pageCount = json.page_count;
+      }
+      allResults.push(...json.results);
     }
-    return json.results.map(normalizeMuseJob).filter(Boolean);
+    return allResults.map(normalizeMuseJob).filter(Boolean);
   },
 };

--- a/providers/themuse.mjs
+++ b/providers/themuse.mjs
@@ -1,0 +1,74 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// The Muse provider — public, zero-auth JSON jobs feed.
+// Endpoint: https://www.themuse.com/api/public/jobs?page=0
+// Response shape: { results: [...], page: 0, page_count: N }
+//
+// Wire in via a `job_boards:` entry with `provider: themuse`.
+
+const FEED_URL = 'https://www.themuse.com/api/public/jobs?page=0';
+const TRUSTED_HOST = 'www.themuse.com';
+
+/** @param {string} url */
+function assertMuseUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`themuse: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`themuse: URL must use HTTPS: ${url}`);
+  if (parsed.hostname !== TRUSTED_HOST) {
+    throw new Error(`themuse: untrusted hostname "${parsed.hostname}" — must be ${TRUSTED_HOST}`);
+  }
+  return url;
+}
+
+/**
+ * Normalize a single result from the Muse API response. Exported for unit tests.
+ *
+ * Field mapping:
+ *   name              → title
+ *   refs.landing_page → url
+ *   company.name      → company
+ *   locations[0].name → location
+ *
+ * Returns null when required fields (title or url) are missing or invalid.
+ *
+ * @param {any} j
+ * @returns {{ title: string, url: string, company: string, location: string } | null}
+ */
+export function normalizeMuseJob(j) {
+  if (!j || typeof j !== 'object') return null;
+  const title = typeof j.name === 'string' ? j.name.trim() : '';
+  if (!title) return null;
+  const url = typeof j.refs?.landing_page === 'string' ? j.refs.landing_page.trim() : '';
+  if (!url || !/^https?:\/\//i.test(url)) return null;
+  const company =
+    typeof j.company?.name === 'string' && j.company.name.trim()
+      ? j.company.name.trim()
+      : 'The Muse';
+  const location =
+    Array.isArray(j.locations) && j.locations.length > 0 && typeof j.locations[0]?.name === 'string'
+      ? j.locations[0].name.trim()
+      : '';
+  return { title, url, company, location };
+}
+
+/** @type {Provider} */
+export default {
+  id: 'themuse',
+
+  async fetch(_entry, ctx) {
+    assertMuseUrl(FEED_URL);
+    // redirect:'error' prevents SSRF via server-side redirects
+    const json = await ctx.fetchJson(FEED_URL, { redirect: 'error' });
+    if (!json || !Array.isArray(json.results)) {
+      throw new Error(
+        `themuse: unexpected API response — expected { results: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`,
+      );
+    }
+    return json.results.map(normalizeMuseJob).filter(Boolean);
+  },
+};

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5405,6 +5405,128 @@ try {
   fail(`weworkremotely provider tests crashed: ${e.message}`);
 }
 
+// ── 33. Provider — themuse ─────────────────────────────────────
+console.log('\n33. Provider — themuse');
+
+try {
+  const museModule = await import(pathToFileURL(join(ROOT, 'providers/themuse.mjs')).href);
+  const themuse = museModule.default;
+  const { normalizeMuseJob } = museModule;
+
+  if (themuse.id === 'themuse') pass('themuse.id is "themuse"');
+  else fail(`themuse.id is ${JSON.stringify(themuse.id)}`);
+
+  // normalizeMuseJob — field mapping
+  const job = normalizeMuseJob({
+    name: 'Staff AI Engineer',
+    refs: { landing_page: 'https://www.themuse.com/jobs/acme/staff-ai-engineer' },
+    company: { name: 'Acme Corp' },
+    locations: [{ name: 'Remote' }],
+  });
+  if (job?.title === 'Staff AI Engineer') pass('normalizeMuseJob maps name → title');
+  else fail(`normalizeMuseJob title = ${JSON.stringify(job?.title)}`);
+
+  if (job?.url === 'https://www.themuse.com/jobs/acme/staff-ai-engineer')
+    pass('normalizeMuseJob maps refs.landing_page → url');
+  else fail(`normalizeMuseJob url = ${JSON.stringify(job?.url)}`);
+
+  if (job?.company === 'Acme Corp') pass('normalizeMuseJob maps company.name → company');
+  else fail(`normalizeMuseJob company = ${JSON.stringify(job?.company)}`);
+
+  if (job?.location === 'Remote') pass('normalizeMuseJob maps locations[0].name → location');
+  else fail(`normalizeMuseJob location = ${JSON.stringify(job?.location)}`);
+
+  // Missing/invalid field handling
+  if (normalizeMuseJob({ name: '', refs: { landing_page: 'https://www.themuse.com/jobs/x' }, company: { name: 'X' }, locations: [] }) === null)
+    pass('normalizeMuseJob drops entries with empty title');
+  else fail('normalizeMuseJob should return null for empty title');
+
+  if (normalizeMuseJob({ name: 'Role', refs: { landing_page: '/relative' }, company: { name: 'X' }, locations: [] }) === null)
+    pass('normalizeMuseJob drops entries with a non-absolute landing_page URL');
+  else fail('normalizeMuseJob should return null for a relative URL');
+
+  const noLoc = normalizeMuseJob({
+    name: 'Role', refs: { landing_page: 'https://www.themuse.com/jobs/x' }, company: { name: 'X' }, locations: [],
+  });
+  if (noLoc?.location === '') pass('normalizeMuseJob returns empty location when locations array is empty');
+  else fail(`normalizeMuseJob location for empty locations = ${JSON.stringify(noLoc?.location)}`);
+
+  const noCompany = normalizeMuseJob({
+    name: 'Role', refs: { landing_page: 'https://www.themuse.com/jobs/x' }, company: null, locations: [{ name: 'NYC' }],
+  });
+  if (noCompany?.company === 'The Muse') pass('normalizeMuseJob falls back to "The Muse" when company.name is missing');
+  else fail(`normalizeMuseJob company fallback = ${JSON.stringify(noCompany?.company)}`);
+
+  if (normalizeMuseJob(null) === null && normalizeMuseJob('string') === null)
+    pass('normalizeMuseJob returns null for non-object inputs');
+  else fail('normalizeMuseJob should return null for null/non-object input');
+
+  // fetch() — mock ctx
+  const sampleResults = [
+    {
+      name: 'Staff AI Engineer',
+      refs: { landing_page: 'https://www.themuse.com/jobs/acme/staff-ai-engineer' },
+      company: { name: 'Acme Corp' },
+      locations: [{ name: 'Remote' }],
+    },
+    {
+      name: 'Platform Engineer',
+      refs: { landing_page: 'https://www.themuse.com/jobs/beta/platform-engineer' },
+      company: { name: 'Beta Inc' },
+      locations: [],
+    },
+    {
+      name: '',
+      refs: { landing_page: 'https://www.themuse.com/jobs/bad/role' },
+      company: { name: 'Bad Co' },
+      locations: [],
+    },
+  ];
+
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const fetched = await themuse.fetch(
+    { name: 'The Muse Board', provider: 'themuse' },
+    {
+      fetchJson: async (url, opts) => {
+        capturedUrl = url; capturedOpts = opts;
+        return { results: sampleResults, page: 0, page_count: 10 };
+      },
+    },
+  );
+
+  if (capturedUrl === 'https://www.themuse.com/api/public/jobs?page=0')
+    pass('themuse.fetch() requests the correct API endpoint');
+  else fail(`themuse.fetch() requested ${JSON.stringify(capturedUrl)}`);
+
+  if (capturedOpts && capturedOpts.redirect === 'error')
+    pass('themuse.fetch() passes redirect:"error" to fetchJson');
+  else fail(`themuse.fetch() should pass redirect:"error", got: ${JSON.stringify(capturedOpts)}`);
+
+  if (fetched.length === 2)
+    pass('themuse.fetch() normalizes 2 valid jobs (drops the empty-title entry)');
+  else fail(`themuse.fetch() returned ${fetched.length} jobs (expected 2)`);
+
+  if (fetched[0]?.title === 'Staff AI Engineer' && fetched[0]?.company === 'Acme Corp')
+    pass('themuse.fetch() returns correct title and company for first result');
+  else fail(`themuse.fetch() row 0 = ${JSON.stringify(fetched[0])}`);
+
+  let badResponseThrew = false;
+  try {
+    await themuse.fetch(
+      { name: 'X', provider: 'themuse' },
+      { fetchJson: async () => ({ wrong: true }) },
+    );
+  } catch (e) {
+    badResponseThrew = /unexpected API response/.test(e.message);
+  }
+  if (badResponseThrew) pass('themuse.fetch() throws on unexpected API response shape');
+  else fail('themuse.fetch() should throw when results array is absent');
+
+} catch (e) {
+  fail(`themuse provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5490,7 +5490,7 @@ try {
     {
       fetchJson: async (url, opts) => {
         capturedUrl = url; capturedOpts = opts;
-        return { results: sampleResults, page: 0, page_count: 10 };
+        return { results: sampleResults, page: 0, page_count: 1 };
       },
     },
   );
@@ -5510,6 +5510,30 @@ try {
   if (fetched[0]?.title === 'Staff AI Engineer' && fetched[0]?.company === 'Acme Corp')
     pass('themuse.fetch() returns correct title and company for first result');
   else fail(`themuse.fetch() row 0 = ${JSON.stringify(fetched[0])}`);
+
+  // Pagination: page_count > 1 causes all pages to be fetched and aggregated.
+  const paginationCalls = [];
+  const page1Result = { name: 'Data Engineer', refs: { landing_page: 'https://www.themuse.com/jobs/acme/de' }, company: { name: 'Acme' }, locations: [] };
+  const paginatedJobs = await themuse.fetch(
+    { name: 'The Muse Board', provider: 'themuse' },
+    {
+      fetchJson: async (url, opts) => {
+        paginationCalls.push(url);
+        const page = parseInt(new URL(url).searchParams.get('page') ?? '0', 10);
+        if (page === 0) return { results: [sampleResults[0]], page: 0, page_count: 2 };
+        return { results: [page1Result], page: 1, page_count: 2 };
+      },
+    },
+  );
+  if (paginationCalls.length === 2 &&
+      paginationCalls[0] === 'https://www.themuse.com/api/public/jobs?page=0' &&
+      paginationCalls[1] === 'https://www.themuse.com/api/public/jobs?page=1')
+    pass('themuse.fetch() iterates all pages when page_count > 1');
+  else fail(`themuse.fetch() pagination calls = ${JSON.stringify(paginationCalls)}`);
+
+  if (paginatedJobs.length === 2 && paginatedJobs[1]?.title === 'Data Engineer')
+    pass('themuse.fetch() aggregates results from all pages');
+  else fail(`themuse.fetch() paginated results = ${JSON.stringify(paginatedJobs.map(j => j.title))}`);
 
   let badResponseThrew = false;
   try {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5535,6 +5535,24 @@ try {
     pass('themuse.fetch() aggregates results from all pages');
   else fail(`themuse.fetch() paginated results = ${JSON.stringify(paginatedJobs.map(j => j.title))}`);
 
+  // page_count cap: a huge value must be clamped to 100, not cause unbounded requests.
+  let cappedCalls = 0;
+  await themuse.fetch(
+    { name: 'X', provider: 'themuse' },
+    { fetchJson: async () => { cappedCalls++; return { results: [], page: 0, page_count: 99999 }; } },
+  );
+  if (cappedCalls === 100) pass('themuse.fetch() clamps page_count to 100 (prevents unbounded requests)');
+  else fail(`themuse.fetch() made ${cappedCalls} requests for page_count=99999 (expected 100)`);
+
+  // Non-integer page_count must be ignored (NaN passes typeof==='number' but not Number.isInteger).
+  let nonIntCalls = 0;
+  await themuse.fetch(
+    { name: 'X', provider: 'themuse' },
+    { fetchJson: async () => { nonIntCalls++; return { results: [], page: 0, page_count: 1.5 }; } },
+  );
+  if (nonIntCalls === 1) pass('themuse.fetch() ignores non-integer page_count (fetches only page 0)');
+  else fail(`themuse.fetch() made ${nonIntCalls} requests for page_count=1.5 (expected 1)`);
+
   let badResponseThrew = false;
   try {
     await themuse.fetch(


### PR DESCRIPTION
## What does this PR do?

Adds `providers/themuse.mjs` — a public, zero-auth JSON provider for [The Muse](https://www.themuse.com/api/public/jobs?page=0) jobs feed. No API key or authentication required.

Field mapping (per issue spec):
- `name` → title
- `refs.landing_page` → url
- `company.name` → company
- `locations[0].name` → location

Follows the same structure as the recently merged `weworkremotely.mjs` and `personio.mjs` providers, including SSRF hardening (`assertMuseUrl` host-pin + `redirect: 'error'`). Wire in via `provider: themuse` in portals.yml.

## Related issue

Closes #1270

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Themuse job provider to fetch public job listings.
  * Normalized listings into a consistent format (title, company, location, and link) and aggregated results across multiple pages (with page_count clamped to 100).

* **Bug Fixes**
  * Added stricter validation for required fields and HTTPS-only trusted feed URLs.
  * Improved handling of unexpected API responses by failing fast.

* **Tests**
  * Added provider tests for normalization edge cases, mocked fetch flow, pagination behavior, clamping, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->