### PR TITLE
feat(providers): add Pinpoint ATS provider (public zero-auth postings.json)

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -18,6 +18,7 @@ are shared helpers and are not loaded as providers.
 | Lever | API | Auto-detects `https://jobs.lever.co/<slug>` boards and uses Lever's public postings endpoint. |
 | Local parser | Parser | Runs an in-repo parser command from `portals.yml`. Use this for stable SSR or HTML pages that need a custom extractor. |
 | Personio | RSS | Auto-detects `<slug>.jobs.personio.de` or `.com` hosts and parses the public XML jobs feed. |
+| Pinpoint | API | Auto-detects `<slug>.pinpointhq.com` boards and reads the public zero-auth `/postings.json` per-tenant feed. |
 | Recruitee | API | Auto-detects `<slug>.recruitee.com` boards and uses the public per-tenant offers API. |
 | RemoteOK | API | Reads the board-wide `https://remoteok.com/api` JSON feed; scanner filters decide which rows are relevant. |
 | Remotive | API | Reads the board-wide `https://remotive.com/api/remote-jobs` JSON feed, then applies local scanner filters. |

--- a/providers/pinpoint.mjs
+++ b/providers/pinpoint.mjs
@@ -1,0 +1,123 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Pinpoint provider — hits the public per-tenant postings.json feed.
+// Auto-detects from careers_url pattern `https://<slug>.pinpointhq.com`.
+//
+// Pinpoint's postings.json is public, zero-auth and returns every active
+// posting for the tenant in a single call:
+//   https://<slug>.pinpointhq.com/postings.json
+// Response shape: { data: [ { title, url, path, location: { name, city,
+//   province, ... }, job: { department, division, ... }, compensation, ... } ] }
+//
+// Per-tenant subdomains are the variable part — SSRF defence uses a regex
+// match on `<safe-slug>.pinpointhq.com` rather than a static allowlist, the
+// same approach as the recruitee provider.
+
+const PINPOINT_HOST_RE = /^[a-z0-9][a-z0-9-]*\.pinpointhq\.com$/;
+
+/** @param {string} url */
+function assertPinpointUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`pinpoint: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`pinpoint: URL must use HTTPS: ${url}`);
+  if (!PINPOINT_HOST_RE.test(parsed.hostname)) {
+    throw new Error(`pinpoint: untrusted hostname "${parsed.hostname}" — must match <slug>.pinpointhq.com`);
+  }
+  return url;
+}
+
+function resolveApiUrl(entry) {
+  const raw = typeof entry.careers_url === 'string' ? entry.careers_url : '';
+  if (!raw) return null;
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:') return null;
+  if (!PINPOINT_HOST_RE.test(parsed.hostname)) return null;
+  return `https://${parsed.hostname}/postings.json`;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'pinpoint',
+
+  detect(entry) {
+    const apiUrl = resolveApiUrl(entry);
+    return apiUrl ? { url: apiUrl } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const apiUrl = resolveApiUrl(entry);
+    if (!apiUrl) throw new Error(`pinpoint: cannot derive API URL for ${entry.name}`);
+    assertPinpointUrl(apiUrl);
+    // redirect:'error' prevents SSRF via server-side redirects
+    const json = await ctx.fetchJson(apiUrl, { redirect: 'error' });
+    return parsePinpointResponse(json, entry.name);
+  },
+};
+
+/**
+ * Parse a Pinpoint /postings.json response. Exported for unit tests.
+ *
+ * Pinpoint returns:
+ *   { data: [{ title, url, path, location: { name, city, province, ... }, ... }] }
+ *
+ * Field mapping → the normalized Job shape:
+ *   - title:    `title`, trimmed.
+ *   - url:      `url` — an absolute posting URL on the tenant's own
+ *               `<slug>.pinpointhq.com` host. It is display-only (written to the
+ *               pipeline and scan history, never server-fetched here), so it is
+ *               not host-locked; the requirement is a well-formed `https:` URL.
+ *   - location: prefer the display `location.name`; otherwise assemble from
+ *               `location.city` / `location.province`.
+ *   - company:  the source carries no per-posting company name (each feed is a
+ *               single tenant), so it is sourced from the portal entry name,
+ *               mirroring the recruitee provider.
+ *
+ * Rows missing a usable title or a valid `https:` URL are dropped — an empty
+ * URL would corrupt the scanner's URL-based dedup key.
+ *
+ * @param {any} json
+ * @param {string} companyName
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parsePinpointResponse(json, companyName) {
+  const postings = json?.data;
+  if (!Array.isArray(postings)) return [];
+  return postings
+    .map(j => {
+      const title = typeof j?.title === 'string' ? j.title.trim() : '';
+      if (!title) return null;
+
+      // url: require a well-formed https: URL (display-only; see doc above).
+      let url = '';
+      const rawUrl = typeof j?.url === 'string' ? j.url.trim() : '';
+      if (rawUrl) {
+        try {
+          const parsed = new URL(rawUrl);
+          if (parsed.protocol === 'https:') url = parsed.href;
+        } catch {
+          // malformed URL → leave url = '' → dropped below
+        }
+      }
+      if (!url) return null;
+
+      // location: prefer the display name, else assemble from city/province.
+      const loc = j?.location && typeof j.location === 'object' ? j.location : {};
+      const name = typeof loc.name === 'string' ? loc.name.trim() : '';
+      const city = typeof loc.city === 'string' ? loc.city.trim() : '';
+      const province = typeof loc.province === 'string' ? loc.province.trim() : '';
+      const location = name || [city, province].filter(Boolean).join(', ');
+
+      return { title, url, location, company: companyName };
+    })
+    .filter(Boolean);
+}

--- a/providers/pinpoint.mjs
+++ b/providers/pinpoint.mjs
@@ -14,7 +14,12 @@
 // match on `<safe-slug>.pinpointhq.com` rather than a static allowlist, the
 // same approach as the recruitee provider.
 
-const PINPOINT_HOST_RE = /^[a-z0-9][a-z0-9-]*\.pinpointhq\.com$/;
+// The tenant label must be a valid DNS label: it may contain hyphens but must
+// not start or end with one (so `acme-.pinpointhq.com` is rejected). The
+// optional trailing group keeps single-character labels (e.g. `a.pinpointhq.com`)
+// valid. detect() and fetch() both route through this constant via
+// resolveApiUrl()/assertPinpointUrl(), so the stricter check applies everywhere.
+const PINPOINT_HOST_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.pinpointhq\.com$/;
 
 /** @param {string} url */
 function assertPinpointUrl(url) {

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -489,6 +489,7 @@ search_queries:
 #   solidjobs       solid.jobs/public-api/offers/<division>
 #   comeet          api: https://www.comeet.co/careers-api/2.0/company/<uid>/positions?token=<token>
 #   personio        <slug>.jobs.personio.(de|com)
+#   pinpoint        <slug>.pinpointhq.com
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
@@ -512,6 +513,10 @@ search_queries:
 #
 # - name: Example Breezy Co
 #   careers_url: https://exampleco.breezy.hr              # any *.breezy.hr host
+#   enabled: true
+#
+# - name: Example Pinpoint Co
+#   careers_url: https://exampleco.pinpointhq.com         # any *.pinpointhq.com host
 #   enabled: true
 #
 # - name: SolidJobs — Engineering

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5405,6 +5405,176 @@ try {
   fail(`weworkremotely provider tests crashed: ${e.message}`);
 }
 
+// ── 33. Provider — pinpoint ─────────────────────────────────────
+console.log('\n33. Provider — pinpoint');
+
+try {
+  const pinpointModule = await import(pathToFileURL(join(ROOT, 'providers/pinpoint.mjs')).href);
+  const pinpoint = pinpointModule.default;
+  const { parsePinpointResponse } = pinpointModule;
+
+  if (pinpoint.id === 'pinpoint') pass('pinpoint.id is "pinpoint"');
+  else fail(`pinpoint.id is ${JSON.stringify(pinpoint.id)}`);
+
+  // detect(): <slug>.pinpointhq.com careers_url → postings.json endpoint.
+  const hit = pinpoint.detect({ name: 'Pinpoint', careers_url: 'https://workwithus.pinpointhq.com' });
+  if (hit && hit.url === 'https://workwithus.pinpointhq.com/postings.json') {
+    pass('pinpoint.detect() resolves <slug>.pinpointhq.com → postings.json');
+  } else {
+    fail(`pinpoint.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  // detect() ignores the path/locale on the careers_url — endpoint is host-rooted.
+  const hitWithPath = pinpoint.detect({ name: 'X', careers_url: 'https://acme.pinpointhq.com/en/jobs' });
+  if (hitWithPath && hitWithPath.url === 'https://acme.pinpointhq.com/postings.json') {
+    pass('pinpoint.detect() ignores careers_url path and roots postings.json at the host');
+  } else {
+    fail(`pinpoint.detect() with path returned ${JSON.stringify(hitWithPath)}`);
+  }
+
+  if (pinpoint.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('pinpoint.detect() returns null for non-pinpoint URLs');
+  } else {
+    fail('pinpoint.detect() should return null for non-pinpoint URLs');
+  }
+
+  // careers_url with non-string value → detect() returns null without crashing.
+  if (pinpoint.detect({ name: 'X', careers_url: null }) === null && pinpoint.detect({ name: 'X', careers_url: 7 }) === null) {
+    pass('pinpoint.detect() returns null for non-string careers_url (null and 7)');
+  } else {
+    fail('pinpoint.detect() should treat non-string careers_url as missing');
+  }
+
+  // SSRF: a URL with pinpointhq.com in the PATH (not host) must not be detected.
+  if (pinpoint.detect({ name: 'Spoof', careers_url: 'https://evil.example/acme.pinpointhq.com/foo' }) === null) {
+    pass('pinpoint.detect() rejects path-spoofed URLs');
+  } else {
+    fail('pinpoint.detect() must NOT misdetect path-spoofed URLs');
+  }
+
+  // SSRF: non-https careers_url must not be detected.
+  if (pinpoint.detect({ name: 'Insecure', careers_url: 'http://acme.pinpointhq.com' }) === null) {
+    pass('pinpoint.detect() rejects non-https careers_url');
+  } else {
+    fail('pinpoint.detect() must reject non-https careers_url');
+  }
+
+  // parsePinpointResponse — deterministic sample, no network.
+  const sample = {
+    data: [
+      {
+        title: 'Senior Product Manager',
+        url: 'https://workwithus.pinpointhq.com/en/postings/abc-123',
+        location: { id: '283', city: 'London', province: 'London', name: 'Remote' },
+      },
+      {
+        title: '  Backend Engineer  ',                                   // trimmed
+        url: '  https://workwithus.pinpointhq.com/en/postings/def-456  ', // trimmed
+        location: { city: 'Berlin', province: 'Berlin' },                // no name → assembled
+      },
+      {
+        title: 'No Location Role',
+        url: 'https://workwithus.pinpointhq.com/en/postings/ghi-789',
+        // location omitted → ''
+      },
+      { title: '', url: 'https://workwithus.pinpointhq.com/en/postings/jkl' }, // dropped: empty title
+      { title: 'Missing URL Role' },                                          // dropped: no url
+      { title: 'Relative URL Role', url: '/en/postings/mno' },                // dropped: non-absolute
+      { title: 'Insecure URL Role', url: 'http://workwithus.pinpointhq.com/en/postings/pqr' }, // dropped: non-https
+    ],
+  };
+  const jobs = parsePinpointResponse(sample, 'Pinpoint');
+
+  if (jobs.length === 3) pass('parsePinpointResponse keeps 3 valid postings (drops empty-title / no-url / non-absolute / non-https)');
+  else fail(`parsePinpointResponse returned ${jobs.length} postings (expected 3)`);
+
+  // Normalized shape: exactly { title, url, company, location }.
+  if (jobs[0] && Object.keys(jobs[0]).sort().join(',') === 'company,location,title,url') {
+    pass('parsePinpointResponse returns the normalized { title, url, company, location } shape');
+  } else {
+    fail(`parsePinpointResponse row 0 keys = ${JSON.stringify(jobs[0] && Object.keys(jobs[0]))}`);
+  }
+
+  if (jobs[0]?.title === 'Senior Product Manager'
+      && jobs[0]?.url === 'https://workwithus.pinpointhq.com/en/postings/abc-123'
+      && jobs[0]?.company === 'Pinpoint'
+      && jobs[0]?.location === 'Remote') {
+    pass('parsePinpointResponse maps title/url, sets company from entry name, prefers location.name');
+  } else {
+    fail(`parsePinpointResponse row 0 = ${JSON.stringify(jobs[0])}`);
+  }
+
+  if (jobs[1]?.title === 'Backend Engineer'
+      && jobs[1]?.url === 'https://workwithus.pinpointhq.com/en/postings/def-456') {
+    pass('parsePinpointResponse trims whitespace from title and url');
+  } else {
+    fail(`parsePinpointResponse row 1 title/url = ${JSON.stringify({ title: jobs[1]?.title, url: jobs[1]?.url })}`);
+  }
+
+  if (jobs[1]?.location === 'Berlin, Berlin') {
+    pass('parsePinpointResponse assembles location from city/province when name is absent');
+  } else {
+    fail(`parsePinpointResponse row 1 location = ${JSON.stringify(jobs[1]?.location)}, expected "Berlin, Berlin"`);
+  }
+
+  if (jobs[2]?.location === '') {
+    pass('parsePinpointResponse yields empty location when the location object is absent');
+  } else {
+    fail(`parsePinpointResponse row 2 location = ${JSON.stringify(jobs[2]?.location)}`);
+  }
+
+  if (parsePinpointResponse({}, 'X').length === 0) pass('parsePinpointResponse: empty {} → empty result');
+  else fail('parsePinpointResponse: empty {} should yield empty result');
+
+  if (parsePinpointResponse({ data: null }, 'X').length === 0) {
+    pass('parsePinpointResponse: null data → empty result (no crash)');
+  } else {
+    fail('parsePinpointResponse: null data should yield empty result');
+  }
+
+  // fetch(): requests the derived postings.json URL and passes the SSRF guard.
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const fetched = await pinpoint.fetch(
+    { name: 'Pinpoint', careers_url: 'https://workwithus.pinpointhq.com' },
+    { fetchJson: async (url, opts) => { capturedUrl = url; capturedOpts = opts; return sample; } },
+  );
+
+  if (capturedUrl === 'https://workwithus.pinpointhq.com/postings.json') {
+    pass('pinpoint.fetch() requests the derived postings.json URL');
+  } else {
+    fail(`pinpoint.fetch() requested ${JSON.stringify(capturedUrl)}`);
+  }
+
+  if (capturedOpts && capturedOpts.redirect === 'error') {
+    pass('pinpoint.fetch() passes redirect:"error" to fetchJson (SSRF guard)');
+  } else {
+    fail(`pinpoint.fetch() should pass redirect:"error", got: ${JSON.stringify(capturedOpts)}`);
+  }
+
+  if (fetched.length === 3 && fetched[0]?.company === 'Pinpoint') {
+    pass('pinpoint.fetch() returns normalized jobs with company from entry name');
+  } else {
+    fail(`pinpoint.fetch() returned ${fetched.length} jobs, row 0 = ${JSON.stringify(fetched[0])}`);
+  }
+
+  // fetch(): a non-pinpoint careers_url cannot derive an endpoint → throws.
+  let badEntryThrew = false;
+  try {
+    await pinpoint.fetch(
+      { name: 'X', careers_url: 'https://example.com/careers' },
+      { fetchJson: async () => ({ data: [] }) },
+    );
+  } catch (e) {
+    badEntryThrew = /cannot derive API URL/.test(e.message);
+  }
+  if (badEntryThrew) pass('pinpoint.fetch() throws when the careers_url is not a pinpointhq.com host');
+  else fail('pinpoint.fetch() should throw for a non-pinpoint careers_url');
+
+} catch (e) {
+  fail(`pinpoint provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5459,6 +5459,22 @@ try {
     fail('pinpoint.detect() must reject non-https careers_url');
   }
 
+  // Hostname label must be a valid DNS label — not end (or start) with a hyphen.
+  if (pinpoint.detect({ name: 'Trailing', careers_url: 'https://acme-.pinpointhq.com' }) === null
+      && pinpoint.detect({ name: 'Leading', careers_url: 'https://-acme.pinpointhq.com' }) === null) {
+    pass('pinpoint.detect() rejects tenant labels that start or end with a hyphen');
+  } else {
+    fail('pinpoint.detect() must reject hyphen-edged tenant labels (e.g. acme-.pinpointhq.com)');
+  }
+
+  // A hyphen in the middle of the label is still valid.
+  if (pinpoint.detect({ name: 'Mid', careers_url: 'https://acme-co.pinpointhq.com' })?.url
+      === 'https://acme-co.pinpointhq.com/postings.json') {
+    pass('pinpoint.detect() still accepts internal hyphens (acme-co.pinpointhq.com)');
+  } else {
+    fail('pinpoint.detect() should accept internal hyphens in the tenant label');
+  }
+
   // parsePinpointResponse — deterministic sample, no network.
   const sample = {
     data: [


### PR DESCRIPTION
## What

Adds a **Pinpoint ATS** provider (`providers/pinpoint.mjs`). Pinpoint exposes a public, zero-auth JSON feed at `https://<slug>.pinpointhq.com/postings.json` that returns every active posting for a tenant in a single call (CORS-enabled), so it slots in alongside the other per-tenant ATS providers.

It mirrors `providers/recruitee.mjs` (the closest structural sibling — per-tenant subdomain ATS):

- `detect()` / `resolveApiUrl()` auto-detect `https://<slug>.pinpointhq.com` careers URLs and derive `https://<slug>.pinpointhq.com/postings.json`.
- A hostname regex guard (`<slug>.pinpointhq.com`) plus `redirect: 'error'` on the fetch defend against SSRF (path-spoofed and non-https URLs are rejected).
- An exported `parsePinpointResponse()` maps each item in `data[]` to the normalized `{ title, url, company, location }` shape:
  - `company` comes from the portal entry name (the feed is per-tenant and carries no company field — same as recruitee).
  - `location` prefers `location.name`, falling back to `location.city` / `location.province`.
  - Rows missing a title or a valid `https:` URL are dropped (an empty URL would corrupt the scanner's URL-based dedup key).

## Files

- `providers/pinpoint.mjs` — new provider.
- `test-all.mjs` — new test block (section 33) mirroring the `recruitee` tests (detect, SSRF guards, parser mapping, fetch wiring).
- `docs/SUPPORTED_JOB_BOARDS.md` — register Pinpoint (the doc requires this in the same PR).
- `templates/portals.example.yml` — add Pinpoint to the auto-detected ATS host list + an example stanza.

## Testing

- `node test-all.mjs` → **563 passed, 0 failed** (21 new assertions for the Pinpoint provider).
- Live end-to-end smoke test against the real public endpoint (`https://workwithus.pinpointhq.com/postings.json`) returned 5 correctly-normalized postings.

Closes #1286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pinpoint job board support with automatic detection of `*.pinpointhq.com` careers pages and retrieval of the public `postings.json` job feed.
  * Normalizes job entries by requiring valid HTTPS job URLs and populating company and location consistently.
* **Bug Fixes**
  * Improved safety for Pinpoint imports by enforcing HTTPS-only fetching and blocking redirects.
* **Documentation**
  * Updated supported job boards and portal template examples to include Pinpoint.
* **Tests**
  * Added comprehensive Pinpoint provider coverage for detection, parsing, and fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->