### PR TITLE
feat(providers): add Teamtailor ATS provider (public zero-auth jobs.rss)

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -23,6 +23,7 @@ are shared helpers and are not loaded as providers.
 | Remotive | API | Reads the board-wide `https://remotive.com/api/remote-jobs` JSON feed, then applies local scanner filters. |
 | SmartRecruiters | API | Auto-detects SmartRecruiters careers URLs or uses `provider: smartrecruiters` for branded custom domains. |
 | SolidJobs | API | Auto-detects `https://solid.jobs/public-api/offers/<division>` and reads the public offers API. |
+| Teamtailor | RSS | Auto-detects `<slug>.teamtailor.com` career sites and parses the public zero-auth `/jobs.rss` feed in-process. |
 | We Work Remotely | RSS | Reads the public `https://weworkremotely.com/remote-jobs.rss` feed and parses it in-process. |
 | Workable | Parser | Auto-detects `https://apply.workable.com/<slug>` and parses Workable's public markdown jobs feed. |
 | Workday | API | Auto-detects Workday `myworkdayjobs.com` careers URLs and posts to the public CXS jobs endpoint. |

--- a/providers/teamtailor.mjs
+++ b/providers/teamtailor.mjs
@@ -1,0 +1,204 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Teamtailor provider — hits the public, no-auth RSS jobs feed at
+// `https://<slug>.teamtailor.com/jobs.rss`. Teamtailor's JSON API requires an
+// API token, but every career site exposes this zero-auth RSS feed with the
+// full posting list (title, link, location, department, pubDate).
+//
+// Auto-detects from a `<slug>.teamtailor.com` careers host like personio. Per-
+// tenant subdomains are the variable part, so the SSRF defence is an anchored
+// host regex rather than a static allowlist. The tenant label must be a valid
+// DNS label — it may contain internal hyphens but must not start or end with
+// one (so `acme-.teamtailor.com` is rejected); the optional trailing group
+// keeps single-character labels valid.
+//
+// The feed is a flat RSS document, so it is parsed in-process with a tiny tag
+// extractor (no new dependency — the repo ships none for XML).
+
+const TEAMTAILOR_HOST_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.teamtailor\.com$/;
+
+/** @param {string} url */
+function assertTeamtailorUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`teamtailor: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`teamtailor: URL must use HTTPS: ${url}`);
+  if (!TEAMTAILOR_HOST_RE.test(parsed.hostname))
+    throw new Error(`teamtailor: untrusted hostname "${parsed.hostname}" — must match <slug>.teamtailor.com`);
+  return url;
+}
+
+/**
+ * Resolve the tenant host (e.g. `acme.teamtailor.com`) from a careers_url.
+ * Returns null for non-Teamtailor or malformed URLs.
+ * @param {import('./_types.js').PortalEntry} entry
+ */
+function resolveHost(entry) {
+  const raw = typeof entry.careers_url === 'string' ? entry.careers_url : '';
+  if (!raw) return null;
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:') return null;
+  if (!TEAMTAILOR_HOST_RE.test(parsed.hostname)) return null;
+  return parsed.hostname;
+}
+
+// NaN-safe Date.parse — `|| undefined` would also coerce a valid epoch 0.
+function toEpochMs(value) {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'teamtailor',
+
+  detect(entry) {
+    const host = resolveHost(entry);
+    return host ? { url: `https://${host}/jobs.rss` } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const host = resolveHost(entry);
+    if (!host) throw new Error(`teamtailor: cannot derive feed URL for ${entry.name}`);
+    const feedUrl = `https://${host}/jobs.rss`;
+    assertTeamtailorUrl(feedUrl);
+    // redirect:'error' prevents SSRF via server-side redirects; combined with
+    // assertTeamtailorUrl above it guarantees the final hostname stays in-domain.
+    const text = await ctx.fetchText(feedUrl, { redirect: 'error' });
+    return parseTeamtailorRss(text, entry.name);
+  },
+};
+
+function fromCodePoint(cp) {
+  try {
+    return String.fromCodePoint(cp);
+  } catch {
+    return '';
+  }
+}
+
+// Decode the XML entities that appear in Teamtailor job text: numeric (&#38; /
+// &#x27;) and the named five. Numeric forms are decoded first; &amp; is decoded
+// LAST so a literal "&amp;lt;" yields "&lt;" rather than over-decoding to "<".
+function decodeXmlEntities(s) {
+  return s
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, d) => fromCodePoint(parseInt(d, 10)))
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+// Resolve a tag's inner text: unwrap a CDATA section, else decode entities.
+function extractText(inner) {
+  const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
+  if (cdata) return cdata[1].trim();
+  return decodeXmlEntities(inner).trim();
+}
+
+// Extract the text of the first <tag>…</tag> in a block. Returns '' when absent.
+// `tag` may be namespaced (e.g. `tt:name`); the colon is a literal in the regex.
+function tagText(block, tag) {
+  const m = block.match(new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)</${tag}>`));
+  return m ? extractText(m[1]) : '';
+}
+
+/**
+ * Parse Teamtailor's public RSS jobs feed. Exported for unit tests.
+ *
+ * Shape: `<rss><channel><title>Company</title>…<item>…</item>…</channel></rss>`,
+ * each `<item>` carrying `<title>`, `<link>`, `<pubDate>` (RFC 822), an HTML
+ * `<description>`, and a `<tt:locations><tt:location>` block with `<tt:name>`,
+ * `<tt:city>`, `<tt:country>`, `<tt:department>` (the `tt:` namespace is
+ * `https://teamtailor.com/locations`).
+ *
+ * Field mapping → the normalized Job shape:
+ *   - title:    `<title>`, entity-decoded (items without one are dropped).
+ *   - url:      `<link>` — an absolute posting URL. Teamtailor career sites can
+ *               run on a custom domain, so it is NOT host-locked; the requirement
+ *               is a well-formed `https:` URL. It is the dedup key, so an item
+ *               without one is dropped. url is display-only (written to the
+ *               pipeline/history, never server-fetched here).
+ *   - company:  the channel `<title>` (the company's own name), falling back to
+ *               the portal entry name when the channel omits it.
+ *   - location: every `<tt:name>` in the item (primary + extra locations),
+ *               de-duplicated and joined with ", "; falls back to assembling the
+ *               first location's `<tt:city>` / `<tt:country>` when no name.
+ *   - postedAt: `<pubDate>` → epoch ms (omitted when unparseable/absent).
+ *
+ * @param {string} xml — raw RSS feed body
+ * @param {string} companyName — fallback value written into job.company
+ * @returns {Array<{title: string, url: string, company: string, location: string, postedAt?: number}>}
+ */
+export function parseTeamtailorRss(xml, companyName) {
+  if (typeof xml !== 'string') return [];
+
+  // The company name is the channel <title>; read it from the channel header
+  // (everything before the first <item>) so it can't be shadowed by an item's
+  // own <title>. Fall back to the portal entry name.
+  const channelHead = xml.split(/<item\b/)[0];
+  const company = tagText(channelHead, 'title') || companyName || '';
+
+  // Strip <description> subtrees from the whole feed before splitting into
+  // <item> blocks: descriptions are large HTML blobs we don't map, and dropping
+  // them keeps the non-greedy block match cheap and robust.
+  const stripped = xml.replace(/<description\b[^>]*>[\s\S]*?<\/description>/gi, '');
+  const blocks = stripped.match(/<item\b[^>]*>[\s\S]*?<\/item>/g) || [];
+
+  const jobs = [];
+  for (const item of blocks) {
+    const title = tagText(item, 'title');
+    if (!title) continue;
+
+    // url: require a well-formed https: URL (display-only; custom domains allowed).
+    let url = '';
+    const rawUrl = tagText(item, 'link');
+    if (rawUrl) {
+      try {
+        const parsed = new URL(rawUrl);
+        if (parsed.protocol === 'https:') url = parsed.href;
+      } catch {
+        // malformed URL → leave url = '' → dropped below
+      }
+    }
+    if (!url) continue;
+
+    // location: collect every <tt:name> (primary + extra locations), de-dupe.
+    const names = [];
+    const seen = new Set();
+    for (const m of item.matchAll(/<tt:name\b[^>]*>([\s\S]*?)<\/tt:name>/g)) {
+      const name = extractText(m[1]);
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        names.push(name);
+      }
+    }
+    let location = names.join(', ');
+    if (!location) {
+      const city = tagText(item, 'tt:city');
+      const country = tagText(item, 'tt:country');
+      location = [city, country].filter(Boolean).join(', ');
+    }
+
+    jobs.push({
+      title,
+      url,
+      location,
+      company,
+      postedAt: toEpochMs(tagText(item, 'pubDate')),
+    });
+  }
+  return jobs;
+}

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -489,6 +489,7 @@ search_queries:
 #   solidjobs       solid.jobs/public-api/offers/<division>
 #   comeet          api: https://www.comeet.co/careers-api/2.0/company/<uid>/positions?token=<token>
 #   personio        <slug>.jobs.personio.(de|com)
+#   teamtailor      <slug>.teamtailor.com
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
@@ -512,6 +513,10 @@ search_queries:
 #
 # - name: Example Breezy Co
 #   careers_url: https://exampleco.breezy.hr              # any *.breezy.hr host
+#   enabled: true
+#
+# - name: Example Teamtailor Co
+#   careers_url: https://exampleco.teamtailor.com         # any *.teamtailor.com host
 #   enabled: true
 #
 # - name: SolidJobs — Engineering

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5405,6 +5405,219 @@ try {
   fail(`weworkremotely provider tests crashed: ${e.message}`);
 }
 
+// ── 34. Provider — teamtailor ───────────────────────────────────
+console.log('\n34. Provider — teamtailor');
+
+try {
+  const teamtailorModule = await import(pathToFileURL(join(ROOT, 'providers/teamtailor.mjs')).href);
+  const teamtailor = teamtailorModule.default;
+  const { parseTeamtailorRss } = teamtailorModule;
+
+  if (teamtailor.id === 'teamtailor') pass('teamtailor.id is "teamtailor"');
+  else fail(`teamtailor.id is ${JSON.stringify(teamtailor.id)}`);
+
+  // detect(): <slug>.teamtailor.com careers_url → jobs.rss feed.
+  const hit = teamtailor.detect({ name: 'Acme', careers_url: 'https://acme.teamtailor.com' });
+  if (hit && hit.url === 'https://acme.teamtailor.com/jobs.rss') {
+    pass('teamtailor.detect() resolves <slug>.teamtailor.com → jobs.rss');
+  } else {
+    fail(`teamtailor.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  // detect() ignores the path on the careers_url — feed is host-rooted.
+  const hitWithPath = teamtailor.detect({ name: 'X', careers_url: 'https://acme.teamtailor.com/jobs' });
+  if (hitWithPath && hitWithPath.url === 'https://acme.teamtailor.com/jobs.rss') {
+    pass('teamtailor.detect() ignores careers_url path and roots jobs.rss at the host');
+  } else {
+    fail(`teamtailor.detect() with path returned ${JSON.stringify(hitWithPath)}`);
+  }
+
+  if (teamtailor.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('teamtailor.detect() returns null for non-teamtailor URLs');
+  } else {
+    fail('teamtailor.detect() should return null for non-teamtailor URLs');
+  }
+
+  // careers_url with non-string value → detect() returns null without crashing.
+  if (teamtailor.detect({ name: 'X', careers_url: null }) === null && teamtailor.detect({ name: 'X', careers_url: 7 }) === null) {
+    pass('teamtailor.detect() returns null for non-string careers_url (null and 7)');
+  } else {
+    fail('teamtailor.detect() should treat non-string careers_url as missing');
+  }
+
+  // SSRF: a URL with teamtailor.com in the PATH (not host) must not be detected.
+  if (teamtailor.detect({ name: 'Spoof', careers_url: 'https://evil.example/acme.teamtailor.com/foo' }) === null) {
+    pass('teamtailor.detect() rejects path-spoofed URLs');
+  } else {
+    fail('teamtailor.detect() must NOT misdetect path-spoofed URLs');
+  }
+
+  // SSRF: non-https careers_url must not be detected.
+  if (teamtailor.detect({ name: 'Insecure', careers_url: 'http://acme.teamtailor.com' }) === null) {
+    pass('teamtailor.detect() rejects non-https careers_url');
+  } else {
+    fail('teamtailor.detect() must reject non-https careers_url');
+  }
+
+  // Hostname label must be a valid DNS label — not start or end with a hyphen.
+  if (teamtailor.detect({ name: 'Trailing', careers_url: 'https://acme-.teamtailor.com' }) === null
+      && teamtailor.detect({ name: 'Leading', careers_url: 'https://-acme.teamtailor.com' }) === null) {
+    pass('teamtailor.detect() rejects tenant labels that start or end with a hyphen');
+  } else {
+    fail('teamtailor.detect() must reject hyphen-edged tenant labels (e.g. acme-.teamtailor.com)');
+  }
+
+  // A hyphen in the middle of the label is still valid.
+  if (teamtailor.detect({ name: 'Mid', careers_url: 'https://acme-co.teamtailor.com' })?.url
+      === 'https://acme-co.teamtailor.com/jobs.rss') {
+    pass('teamtailor.detect() still accepts internal hyphens (acme-co.teamtailor.com)');
+  } else {
+    fail('teamtailor.detect() should accept internal hyphens in the tenant label');
+  }
+
+  // parseTeamtailorRss — deterministic sample, no network. The first item's
+  // <description> hides an ENCODED "</item>" to prove description-stripping keeps
+  // the block split robust.
+  const sampleRss = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:tt="https://teamtailor.com/locations">',
+    '  <channel>',
+    '    <title>Acme Inc</title>',
+    '    <description>Our job openings</description>',
+    '    <link>https://acme.teamtailor.com/jobs</link>',
+    '    <item>',
+    '      <title>Staff AI Engineer &amp; Lead</title>',
+    '      <description>&lt;p&gt;body with &lt;/item&gt; trap&lt;/p&gt;</description>',
+    '      <pubDate>Wed, 25 Feb 2026 18:22:13 +0100</pubDate>',
+    '      <link>https://acme.teamtailor.com/jobs/1-staff-ai-engineer</link>',
+    '      <tt:locations><tt:location>',
+    '        <tt:name>Cologne, Germany</tt:name>',
+    '        <tt:city>Cologne</tt:city><tt:country>Germany</tt:country>',
+    '      </tt:location></tt:locations>',
+    '    </item>',
+    '    <item>',
+    '      <title>Platform Engineer</title>',
+    '      <description>plain</description>',
+    '      <link>https://acme.teamtailor.com/jobs/2-platform-engineer</link>',
+    '      <tt:locations><tt:location>',
+    '        <tt:city>Berlin</tt:city><tt:country>Germany</tt:country>',
+    '      </tt:location></tt:locations>',
+    '    </item>',
+    '    <item>',
+    '      <title>No URL Role</title><description>x</description>',
+    '    </item>',
+    '    <item>',
+    '      <title></title>',
+    '      <link>https://acme.teamtailor.com/jobs/4-empty-title</link>',
+    '    </item>',
+    '    <item>',
+    '      <title>Insecure URL Role</title>',
+    '      <link>http://acme.teamtailor.com/jobs/5-insecure</link>',
+    '    </item>',
+    '  </channel>',
+    '</rss>',
+  ].join('\n');
+
+  const jobs = parseTeamtailorRss(sampleRss, 'Entry Fallback');
+
+  if (jobs.length === 2) pass('parseTeamtailorRss keeps 2 valid items (drops no-url / empty-title / non-https)');
+  else fail(`parseTeamtailorRss returned ${jobs.length} items (expected 2)`);
+
+  if (jobs[0]?.title === 'Staff AI Engineer & Lead'
+      && jobs[0]?.url === 'https://acme.teamtailor.com/jobs/1-staff-ai-engineer') {
+    pass('parseTeamtailorRss maps title (entity-decoded) and link, and the encoded </item> in description does not split the block');
+  } else {
+    fail(`parseTeamtailorRss row 0 title/url = ${JSON.stringify({ title: jobs[0]?.title, url: jobs[0]?.url })}`);
+  }
+
+  if (jobs[0]?.company === 'Acme Inc') {
+    pass('parseTeamtailorRss sets company from the channel <title>');
+  } else {
+    fail(`parseTeamtailorRss row 0 company = ${JSON.stringify(jobs[0]?.company)} (expected channel title "Acme Inc")`);
+  }
+
+  if (jobs[0]?.location === 'Cologne, Germany') {
+    pass('parseTeamtailorRss prefers the <tt:name> location');
+  } else {
+    fail(`parseTeamtailorRss row 0 location = ${JSON.stringify(jobs[0]?.location)}`);
+  }
+
+  if (jobs[0]?.postedAt === Date.parse('Wed, 25 Feb 2026 18:22:13 +0100')) {
+    pass('parseTeamtailorRss parses <pubDate> into postedAt epoch ms');
+  } else {
+    fail(`parseTeamtailorRss row 0 postedAt = ${JSON.stringify(jobs[0]?.postedAt)}`);
+  }
+
+  if (jobs[1]?.location === 'Berlin, Germany') {
+    pass('parseTeamtailorRss assembles location from tt:city/tt:country when no tt:name');
+  } else {
+    fail(`parseTeamtailorRss row 1 location = ${JSON.stringify(jobs[1]?.location)}, expected "Berlin, Germany"`);
+  }
+
+  if (jobs[1]?.postedAt === undefined) {
+    pass('parseTeamtailorRss leaves postedAt undefined when <pubDate> is absent');
+  } else {
+    fail(`parseTeamtailorRss row 1 postedAt = ${JSON.stringify(jobs[1]?.postedAt)} (expected undefined)`);
+  }
+
+  // company falls back to the entry name when the channel has no <title>.
+  const noTitleFeed = '<rss><channel><item><title>Role</title><link>https://acme.teamtailor.com/jobs/9</link></item></channel></rss>';
+  const fallbackJobs = parseTeamtailorRss(noTitleFeed, 'Entry Name');
+  if (fallbackJobs[0]?.company === 'Entry Name') {
+    pass('parseTeamtailorRss falls back to entry name when the channel omits <title>');
+  } else {
+    fail(`parseTeamtailorRss fallback company = ${JSON.stringify(fallbackJobs[0]?.company)}`);
+  }
+
+  if (parseTeamtailorRss('', 'X').length === 0 && parseTeamtailorRss(null, 'X').length === 0) {
+    pass('parseTeamtailorRss: empty / non-string feed → empty result (no crash)');
+  } else {
+    fail('parseTeamtailorRss should yield empty result for empty / non-string input');
+  }
+
+  // fetch(): requests the derived jobs.rss URL and passes the SSRF guard.
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const fetched = await teamtailor.fetch(
+    { name: 'Acme', careers_url: 'https://acme.teamtailor.com' },
+    { fetchText: async (url, opts) => { capturedUrl = url; capturedOpts = opts; return sampleRss; } },
+  );
+
+  if (capturedUrl === 'https://acme.teamtailor.com/jobs.rss') {
+    pass('teamtailor.fetch() requests the derived jobs.rss URL');
+  } else {
+    fail(`teamtailor.fetch() requested ${JSON.stringify(capturedUrl)}`);
+  }
+
+  if (capturedOpts && capturedOpts.redirect === 'error') {
+    pass('teamtailor.fetch() passes redirect:"error" to fetchText (SSRF guard)');
+  } else {
+    fail(`teamtailor.fetch() should pass redirect:"error", got: ${JSON.stringify(capturedOpts)}`);
+  }
+
+  if (fetched.length === 2 && fetched[0]?.company === 'Acme Inc') {
+    pass('teamtailor.fetch() returns normalized jobs with company from the channel title');
+  } else {
+    fail(`teamtailor.fetch() returned ${fetched.length} jobs, row 0 = ${JSON.stringify(fetched[0])}`);
+  }
+
+  // fetch(): a non-teamtailor careers_url cannot derive a feed → throws.
+  let badEntryThrew = false;
+  try {
+    await teamtailor.fetch(
+      { name: 'X', careers_url: 'https://example.com/careers' },
+      { fetchText: async () => '' },
+    );
+  } catch (e) {
+    badEntryThrew = /cannot derive feed URL/.test(e.message);
+  }
+  if (badEntryThrew) pass('teamtailor.fetch() throws when the careers_url is not a teamtailor.com host');
+  else fail('teamtailor.fetch() should throw for a non-teamtailor careers_url');
+
+} catch (e) {
+  fail(`teamtailor provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What

Adds a **Teamtailor ATS** provider (`providers/teamtailor.mjs`). Teamtailor's JSON API requires an API token, but every career site exposes a public, zero-auth RSS feed at `https://<slug>.teamtailor.com/jobs.rss` carrying the full posting list, so this mirrors `providers/personio.mjs` (the closest structural sibling — a per-tenant subdomain XML/RSS feed parsed in-process).

- `detect()` / `resolveHost()` auto-detect `https://<slug>.teamtailor.com` careers URLs and derive `https://<slug>.teamtailor.com/jobs.rss`.
- A hostname regex guard plus `redirect: 'error'` on the fetch defend against SSRF. The regex requires a valid DNS label, so path-spoofed, non-https, and hyphen-edged hosts (e.g. `acme-.teamtailor.com`) are rejected.
- An exported `parseTeamtailorRss()` maps each `<item>` to the normalized `{ title, url, company, location }` shape (plus optional `postedAt`):
  - `title` from `<title>` (entity-decoded); `url` from `<link>` (well-formed `https:`, display-only — Teamtailor career sites can run on custom domains, so it is not host-locked).
  - `company` from the channel `<title>` (the company's own name), falling back to the portal entry name.
  - `location` from the `<tt:name>` value(s) under `<tt:locations>`, falling back to `<tt:city>` / `<tt:country>`.
  - `postedAt` from `<pubDate>`.
  - Items without a title or a valid `https:` URL are dropped; `<description>` subtrees are stripped before splitting into items so an encoded `</item>` inside the HTML body can't truncate a block.

## Files

- `providers/teamtailor.mjs` — new provider.
- `test-all.mjs` — new test block (section 34) mirroring the `personio` tests (detect, SSRF/hyphen-edge guards, parser mapping incl. the encoded-`</item>` robustness case, fetch wiring).
- `docs/SUPPORTED_JOB_BOARDS.md` — register Teamtailor (the doc requires this in the same PR).
- `templates/portals.example.yml` — add Teamtailor to the auto-detected ATS host list + an example stanza.

## Testing

- `node test-all.mjs` → **566 passed, 0 failed** (22 new assertions for the Teamtailor provider).
- Live end-to-end smoke test against a real career site (`https://polestar.teamtailor.com/jobs.rss`) returned 29 correctly-normalized postings.

Closes #1288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Teamtailor job boards, including automatic detection of Teamtailor career sites and loading available jobs from their public RSS feed.
  * Job listings now include company name, locations, titles, and posted dates when available.

* **Bug Fixes**
  * Improved handling of invalid or incomplete feed entries, with safer URL validation and better parsing of special characters and dates.
  * Added protections to avoid accepting unsupported or malformed career site URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->