### PR TITLE
ci: run Go dashboard tests in the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,3 +17,6 @@ jobs:
           go-version: '1.26'
       - run: npm install
       - run: node test-all.mjs --quick
+      - name: Go dashboard tests
+        run: go test ./...
+        working-directory: dashboard


### PR DESCRIPTION
## Summary

Fixes #1290. `.github/workflows/test.yml` ran only:

```yaml
- run: npm install
- run: node test-all.mjs --quick
```

`--quick` skips even the dashboard Go *build*, and `go test ./...` is invoked **nowhere** in CI — so the 8 `dashboard/**/*_test.go` files (including `internal/data/career_test.go`, which guards the status-write / `NormalizeStatus` path) gate **nothing** on a PR. A Go regression lands green.

The workflow *already* provisions Go (`actions/setup-go@v6`, go `1.26`) but nothing used it. This adds one step so that toolchain actually gates PRs:

```yaml
- name: Go dashboard tests
  run: go test ./...
  working-directory: dashboard
```

## Test plan
- [x] `go test ./...` in `dashboard/` passes locally (all packages with tests green)
- [x] `test.yml` parses as valid YAML
- [x] One-line CI addition, no source changes — uses infra already in the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated pull request validation to run the Go test suite for an additional app area, improving coverage before changes are merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->