### PR TITLE
refactor(tracker): share header-name column mapping across all tracker readers

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -16,6 +16,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { load as yamlLoad } from 'js-yaml';
+import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -153,18 +154,12 @@ next_action: "Follow up on ticket #42 with tailored CV"
 function parseTracker() {
   if (!existsSync(APPS_FILE)) return [];
   const content = readFileSync(APPS_FILE, 'utf-8');
+  const lines = content.split('\n');
+  const colmap = resolveColumns(lines);
   const entries = [];
-  for (const line of content.split('\n')) {
-    if (!line.startsWith('|')) continue;
-    const parts = line.split('|').map(s => s.trim());
-    if (parts.length < 9) continue;
-    const num = parseInt(parts[1]);
-    if (isNaN(num)) continue;
-    entries.push({
-      num, date: parts[2], company: parts[3], role: parts[4],
-      score: parts[5], status: parts[6], pdf: parts[7], report: parts[8],
-      notes: parts[9] || '',
-    });
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (row) entries.push(row);
   }
   return entries;
 }

--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -14,6 +14,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { roleFuzzyMatch } from './role-matcher.mjs';
 import { rebuildRow } from './tracker-utils.mjs';
+import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md
@@ -231,22 +232,7 @@ function parseScore(s) {
  * @returns {object|null} Parsed tracker row, or null for non-application lines.
  */
 function parseAppLine(line) {
-  const parts = line.split('|').map(s => s.trim());
-  if (parts.length < 9) return null;
-  const num = parseInt(parts[1]);
-  if (isNaN(num)) return null;
-  return {
-    num,
-    date: parts[2],
-    company: parts[3],
-    role: parts[4],
-    score: parts[5],
-    status: parts[6],
-    pdf: parts[7],
-    report: parts[8],
-    notes: parts[9] || '',
-    raw: line,
-  };
+  return parseTrackerRow(line, COLMAP);
 }
 
 // Read
@@ -256,6 +242,8 @@ if (!existsSync(APPS_FILE)) {
 }
 const content = readFileSync(APPS_FILE, 'utf-8');
 const lines = content.split('\n');
+// Header-aware column map (tolerates an inserted Location column, etc.).
+const COLMAP = resolveColumns(lines);
 
 // Parse all entries
 const entries = [];
@@ -323,7 +311,7 @@ for (const [company, companyEntries] of groups) {
       const lineIdx = keeper.lineIdx;
       if (lineIdx !== undefined) {
         const parts = lines[lineIdx].split('|').map(s => s.trim());
-        parts[6] = bestStatus;
+        parts[COLMAP.status] = bestStatus;
         lines[lineIdx] = rebuildRow(parts);
         console.log(`  📝 #${keeper.num}: status promoted to "${bestStatus}" (from #${cluster.find(e => e.status === bestStatus)?.num})`);
       }

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -15,6 +15,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname, relative, sep } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import yaml from 'js-yaml';
+import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -139,18 +140,12 @@ export function addDays(date, days) {
 function parseTracker() {
   if (!existsSync(APPS_FILE)) return [];
   const content = readFileSync(APPS_FILE, 'utf-8');
+  const lines = content.split('\n');
+  const colmap = resolveColumns(lines);
   const entries = [];
-  for (const line of content.split('\n')) {
-    if (!line.startsWith('|')) continue;
-    const parts = line.split('|').map(s => s.trim());
-    if (parts.length < 9) continue;
-    const num = parseInt(parts[1]);
-    if (isNaN(num)) continue;
-    entries.push({
-      num, date: parts[2], company: parts[3], role: parts[4],
-      score: parts[5], status: parts[6], pdf: parts[7], report: parts[8],
-      notes: parts[9] || '',
-    });
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (row) entries.push(row);
   }
   return entries;
 }

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -22,6 +22,7 @@ import { createHash, randomUUID } from 'crypto';
 import { tmpdir } from 'os';
 import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
+import { LEGACY_COLMAP, detectColumns } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original).
@@ -427,31 +428,11 @@ function parseScore(s) {
 // position so both work — fixed-position indexing would otherwise read, say,
 // Location where it expects Score. Falls back to the legacy layout when no
 // recognizable header row is found.
-const LEGACY_COLMAP = { num: 1, date: 2, company: 3, role: 4, score: 5, status: 6, pdf: 7, report: 8, notes: 9 };
+// LEGACY_COLMAP, HEADER_ALIASES and detectColumns are the shared header-name
+// mapping, now sourced from tracker-parse.mjs so every tracker reader stays in
+// lockstep (see imports above). COLMAP stays mutable here — it is reassigned to
+// the detected layout once the table is read (below).
 let COLMAP = LEGACY_COLMAP;
-
-const HEADER_ALIASES = {
-  '#': 'num', 'num': 'num', 'date': 'date', 'company': 'company', 'empresa': 'company',
-  'role': 'role', 'puesto': 'role', 'location': 'location', 'score': 'score',
-  'status': 'status', 'pdf': 'pdf', 'report': 'report', 'notes': 'notes',
-};
-
-// Scan the table for a header row and build a header-name → column-index map.
-// Indexing matches `line.split('|')` (leading empty cell before the first pipe),
-// the same split parseAppLine uses. Returns null — caller keeps the legacy
-// layout — unless the essential columns are all present, so a stray pipe line
-// can't yield a bogus mapping.
-function detectColumns(lines) {
-  for (const line of lines) {
-    if (!line.startsWith('|')) continue;
-    const cells = line.split('|').map(s => s.trim().toLowerCase());
-    if (!cells.includes('company') || !cells.includes('role')) continue;
-    const map = {};
-    cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
-    if (['num', 'company', 'role', 'score', 'status'].every(k => map[k] != null)) return map;
-  }
-  return null;
-}
 
 // Build a tracker row string matching the detected layout (with or without the
 // optional Location column) so writes round-trip through the same schema.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2782,6 +2782,89 @@ try {
   fail(`tracker-utils rebuildRow unit test crashed: ${e.message}`);
 }
 
+// #946/#954 header-name column mapping lived only in merge-tracker; followup-cadence,
+// analyze-patterns and dedup-tracker still parsed by fixed index, so an inserted
+// Location column mis-parsed (Location read as Score, etc.). The logic is now shared
+// in tracker-parse.mjs and all four readers use it.
+console.log('\n🧪 Testing shared tracker-parse column mapping...');
+try {
+  const { resolveColumns, parseTrackerRow, LEGACY_COLMAP } = await import(pathToFileURL(join(ROOT, 'tracker-parse.mjs')).href);
+
+  const withLocation = [
+    '| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|----------|-------|--------|-----|--------|-------|',
+    '| 7 | 2026-06-28 | Acme | Eng | Berlin | 4.5/5 | Applied | ✅ | [7](r.md) | keep |',
+  ];
+  const cmLoc = resolveColumns(withLocation);
+  const rowLoc = parseTrackerRow(withLocation[2], cmLoc);
+  if (rowLoc && rowLoc.score === '4.5/5' && rowLoc.status === 'Applied' && rowLoc.location === 'Berlin') {
+    pass('tracker-parse maps columns by header — inserted Location column does not shift Score/Status');
+  } else {
+    fail(`tracker-parse mis-parsed a Location-column row: ${JSON.stringify(rowLoc)}`);
+  }
+
+  const legacy = [
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|-------|--------|-----|--------|-------|',
+    '| 8 | 2026-06-28 | Beta | PM | 3.0/5 | Evaluated | ❌ | [8](r.md) | n |',
+  ];
+  const rowLeg = parseTrackerRow(legacy[2], resolveColumns(legacy));
+  if (rowLeg && rowLeg.score === '3.0/5' && rowLeg.status === 'Evaluated' && rowLeg.location === undefined) {
+    pass('tracker-parse still parses the legacy fixed layout correctly');
+  } else {
+    fail(`tracker-parse broke the legacy layout: ${JSON.stringify(rowLeg)}`);
+  }
+
+  // No header row → falls back to legacy map; header/separator/stray rows → null.
+  if (resolveColumns(['| 9 | … |']) === LEGACY_COLMAP &&
+      parseTrackerRow(legacy[0], LEGACY_COLMAP) === null &&
+      parseTrackerRow(legacy[1], LEGACY_COLMAP) === null &&
+      parseTrackerRow('not a table row', LEGACY_COLMAP) === null) {
+    pass('tracker-parse falls back to legacy map and rejects header/separator/non-rows');
+  } else {
+    fail('tracker-parse fallback / non-row rejection wrong');
+  }
+} catch (e) {
+  fail(`tracker-parse unit test crashed: ${e.message}`);
+}
+
+// dedup-tracker reads AND writes by column; with a Location column its status
+// promotion must target the Status cell, not fixed parts[6].
+console.log('\n🧪 Testing dedup-tracker with an inserted Location column...');
+try {
+  const locTmp = mkdtempSync(join(tmpdir(), 'career-ops-dedup-loc-'));
+  try {
+    mkdirSync(join(locTmp, 'data'));
+    const tracker = join(locTmp, 'data', 'applications.md');
+    // Two dup rows (same company+role) with a Location column. Keeper #60 has the
+    // higher score but the lower status; dedup must promote its Status cell.
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|----------|-------|--------|-----|--------|-------|\n' +
+      '| 60 | 2026-02-01 | Globex | Widget Engineer | Berlin | 4.5/5 | Rejected | ❌ | [60](r.md) | LOC_SENTINEL |\n' +
+      '| 61 | 2026-02-02 | Globex | Widget Engineer | Berlin | 3.0/5 | Evaluated | ❌ | [61](r.md) | dup |\n');
+
+    const r = run(NODE, ['dedup-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
+    if (r === null) {
+      fail('dedup-tracker crashed on a Location-column tracker');
+    } else {
+      const out = readFileSync(tracker, 'utf-8');
+      const keeper = out.split('\n').find(l => l.includes('| 60 |'));
+      // Status cell promoted to Evaluated; Location (Berlin) and the score untouched.
+      if (keeper && keeper.includes('Berlin') && keeper.includes('4.5/5') && keeper.includes('Evaluated') && keeper.includes('LOC_SENTINEL')) {
+        pass('dedup-tracker promotes the Status cell (not a fixed index) on a Location-column tracker');
+      } else {
+        fail(`dedup-tracker mis-handled a Location-column row: "${keeper}"`);
+      }
+    }
+  } finally {
+    rmSync(locTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`dedup-tracker Location-column test crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER FUZZY DEDUP (#751 / #721 family) ──────────────
 // roleFuzzyMatch over-matched whenever the token overlap dominated the
 // SMALLER side: two distinct roles sharing a long prefix ("Full-Stack

--- a/tracker-parse.mjs
+++ b/tracker-parse.mjs
@@ -1,0 +1,88 @@
+/**
+ * tracker-parse.mjs — shared header-aware column mapping for `data/applications.md`.
+ *
+ * The tracker is a markdown table that several scripts read. #946/#954 made the
+ * column layout customizable (e.g. an inserted Location column) by mapping
+ * columns *by header name* instead of fixed position — but that logic only
+ * lived in `merge-tracker.mjs`. This module is the single home for it, so every
+ * reader (merge-tracker, dedup-tracker, followup-cadence, analyze-patterns)
+ * tolerates the same layouts and can't drift apart.
+ *
+ * Indexing matches `line.split('|')`: index 0 is the empty cell before the
+ * leading pipe, so the first real column ("#"/num) is index 1.
+ */
+
+/** The original fixed 9-column layout (num … notes at indices 1 … 9). */
+export const LEGACY_COLMAP = {
+  num: 1, date: 2, company: 3, role: 4, score: 5, status: 6, pdf: 7, report: 8, notes: 9,
+};
+
+/** Header text (lowercased) → canonical field name. Includes ES aliases. */
+export const HEADER_ALIASES = {
+  '#': 'num', 'num': 'num', 'date': 'date', 'company': 'company', 'empresa': 'company',
+  'role': 'role', 'puesto': 'role', 'location': 'location', 'score': 'score',
+  'status': 'status', 'pdf': 'pdf', 'report': 'report', 'notes': 'notes',
+};
+
+/**
+ * Scan the table for a header row and build a field-name → column-index map.
+ * Indexing matches `line.split('|')`. Returns null — caller should fall back to
+ * LEGACY_COLMAP — unless the essential columns are all present, so a stray pipe
+ * line can't yield a bogus mapping.
+ *
+ * @param {string[]} lines - All lines of applications.md.
+ * @returns {Object<string,number>|null}
+ */
+export function detectColumns(lines) {
+  for (const line of lines) {
+    if (!line.startsWith('|')) continue;
+    const cells = line.split('|').map(s => s.trim().toLowerCase());
+    if (!cells.includes('company') || !cells.includes('role')) continue;
+    const map = {};
+    cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
+    if (['num', 'company', 'role', 'score', 'status'].every(k => map[k] != null)) return map;
+  }
+  return null;
+}
+
+/**
+ * Convenience: detect the header layout, falling back to the legacy fixed one.
+ * @param {string[]} lines
+ * @returns {Object<string,number>}
+ */
+export function resolveColumns(lines) {
+  return detectColumns(lines) || LEGACY_COLMAP;
+}
+
+/**
+ * Parse one markdown table row into a tracker object using a column map.
+ *
+ * Header and separator rows (non-numeric `num` cell) and malformed rows return
+ * null. The raw line is preserved so callers can locate/replace the exact line.
+ *
+ * @param {string} line - One line from applications.md.
+ * @param {Object<string,number>} [colmap] - From resolveColumns(); defaults to legacy.
+ * @returns {object|null} `{num,date,company,role,score,status,pdf,report,notes,location?,raw}`.
+ */
+export function parseTrackerRow(line, colmap = LEGACY_COLMAP) {
+  if (typeof line !== 'string' || !line.startsWith('|')) return null;
+  const parts = line.split('|').map(s => s.trim());
+  if (parts.length < 9) return null;
+  const num = parseInt(parts[colmap.num], 10);
+  if (isNaN(num)) return null;
+  const at = (k) => (colmap[k] != null ? (parts[colmap[k]] ?? '') : '');
+  const row = {
+    num,
+    date: at('date'),
+    company: at('company'),
+    role: at('role'),
+    score: at('score'),
+    status: at('status'),
+    pdf: at('pdf'),
+    report: at('report'),
+    notes: at('notes'),
+    raw: line,
+  };
+  if (colmap.location != null) row.location = at('location');
+  return row;
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -94,6 +94,7 @@ const SYSTEM_PATHS = [
   'dedup-tracker.mjs',
   'role-matcher.mjs',
   'tracker-utils.mjs',
+  'tracker-parse.mjs',
   'normalize-statuses.mjs',
   'cv-sync-check.mjs',
   'update-system.mjs',
@@ -603,7 +604,7 @@ async function apply() {
 
     // 3a. Keep bootstrap paths as a fallback for very old targets, but the
     // target updater's SYSTEM_PATHS is now the source of truth for new files.
-    const BOOTSTRAP_PATHS = ['.agents/', '.opencode/skills/', '.antigravitycli/skills/', '.grok/skills/', '.kimi/skills/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'role-matcher.mjs', 'tracker-utils.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs', 'tracker-columns-tests.mjs'];
+    const BOOTSTRAP_PATHS = ['.agents/', '.opencode/skills/', '.antigravitycli/skills/', '.grok/skills/', '.kimi/skills/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'role-matcher.mjs', 'tracker-utils.mjs', 'tracker-parse.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs', 'tracker-columns-tests.mjs'];
     const updatePaths = mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS);
 
     for (const path of updatePaths) {

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -84,6 +84,7 @@ const requiredBootstrapPaths = [
   'liveness-browser.mjs',
   'role-matcher.mjs',
   'tracker-utils.mjs',
+  'tracker-parse.mjs',
   'updater-migration-tests.mjs',
   'tracker-columns-tests.mjs',
 ];


### PR DESCRIPTION
## Summary

Fixes #1291. #946/#954 made the tracker tolerant of customized column layouts (e.g. an inserted **Location** column) by mapping columns **by header name** — but only `merge-tracker.mjs` got that treatment. Three other readers still parsed by fixed position:

- `followup-cadence.mjs` — `score: parts[5], status: parts[6], …`
- `analyze-patterns.mjs` — `score: parts[5], status: parts[6], …`
- `dedup-tracker.mjs` — `score: parts[5]`, `status: parts[6]`, **and** wrote `parts[6] = bestStatus` on status promotion

So a user who adds a Location column (which `merge-tracker` supports) got **silently mis-parsed** rows in those three, and dedup's status-write corrupted the wrong cell. The exact #946 bug, half-fixed.

## Change

- **New `tracker-parse.mjs`** — the single home for `LEGACY_COLMAP`, `HEADER_ALIASES`, `detectColumns()` (extracted verbatim from `merge-tracker`), plus a `parseTrackerRow(line, colmap)` / `resolveColumns(lines)` helper. Mirrors how `tracker-utils.mjs` was extracted in #1103/#1104.
- `merge-tracker.mjs` imports the shared detection (its write path / `parseAppLine` / `buildRow` are **unchanged** — the pure detection logic is just no longer duplicated).
- `followup-cadence.mjs`, `analyze-patterns.mjs`, `dedup-tracker.mjs` parse through `resolveColumns` + `parseTrackerRow`; dedup's status promotion now targets `parts[COLMAP.status]`.
- `tracker-parse.mjs` registered with the auto-updater (`SYSTEM_PATHS` + `BOOTSTRAP_PATHS` + `requiredSystemPaths`), mirroring `role-matcher`/`tracker-utils`.

## Test plan
- [x] New tracker-parse unit tests: header-mapped Location row keeps Score/Status correct; legacy fixed layout still parses; fallback to legacy + header/separator/non-row rejection
- [x] New dedup integration test: status promotion targets the Status cell (not fixed `parts[6]`) on a Location-column tracker
- [x] `node test-all.mjs --quick` → **547 passed, 0 failed**; `updater-migration-tests` 63/0; `tracker-columns-tests` 7/0
- [x] No behavior change for the default 9-column layout; `merge-tracker` write path untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared tracker parsing support that automatically recognizes tracker table headers and handles an inserted Location column.
  * Improved update handling so the new tracker parsing logic is included in system updates.

* **Bug Fixes**
  * Fixed status updates and deduplication to write changes to the correct column even when tracker columns shift.

* **Tests**
  * Added regression coverage for header-aware tracker parsing and deduplication with reordered columns.
  * Added coverage for correct handling of legacy headers and invalid/non-row inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->