### PR TITLE
feat(providers): add Arbeitnow provider (public zero-auth job-board API)

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -6,6 +6,7 @@ are shared helpers and are not loaded as providers.
 
 | Board | Type (API / RSS / parser) | Notes |
 | --- | --- | --- |
+| Arbeitnow | API | Reads the public `https://www.arbeitnow.com/api/job-board-api` JSON feed (EU/DACH-heavy, newest-first). Configure with `provider: arbeitnow`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
 | Arbeitsagentur | API | Uses the public Bundesagentur fuer Arbeit Jobsuche REST API. Configure with `provider: arbeitsagentur`; title, location, and dedup filters run after fetch. |
 | Ashby | API | Auto-detects `https://jobs.ashbyhq.com/<slug>` boards and uses Ashby's public posting API. |
 | BambooHR | API | Auto-detects `<tenant>.bamboohr.com` careers pages, reads `/careers/list`, and follows public detail endpoints for job URLs. |

--- a/providers/arbeitnow.mjs
+++ b/providers/arbeitnow.mjs
@@ -1,0 +1,125 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Arbeitnow provider — board-wide aggregator feed (EU/DACH-heavy, but
+// international): https://www.arbeitnow.com/api/job-board-api
+// Response shape: { data: [ { slug, company_name, title, description, remote,
+//   url, tags, job_types, location, created_at } ], links, meta }
+//
+// Jobs are ordered newest-first, 100 per page. The API echoes a rotating
+// featured `?search=` term into links.next, so page URLs are built directly as
+// `?page=N` (never by following links.next) to keep the FULL board in view —
+// scan.mjs's title_filter then gates on the configured titles. Pages are fetched
+// until one comes back short/empty or the page cap is reached (default 3,
+// override with `max_pages` on the portal entry).
+//
+// Wire in via a `job_boards:` entry with `provider: arbeitnow`.
+
+const FEED_BASE = 'https://www.arbeitnow.com/api/job-board-api';
+const TRUSTED_HOST = 'www.arbeitnow.com';
+const PER_PAGE = 100;
+const DEFAULT_MAX_PAGES = 3;
+const MAX_PAGES_CAP = 50;
+
+/** @param {string} url */
+function assertArbeitnowUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`arbeitnow: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`arbeitnow: URL must use HTTPS: ${url}`);
+  if (parsed.hostname !== TRUSTED_HOST) {
+    throw new Error(`arbeitnow: untrusted hostname "${parsed.hostname}" — must be ${TRUSTED_HOST}`);
+  }
+  return url;
+}
+
+/** Resolve the page cap: a positive integer `max_pages` on the entry, capped. */
+function resolveMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES_CAP);
+  return DEFAULT_MAX_PAGES;
+}
+
+/**
+ * Normalize a single Arbeitnow job. Exported for unit tests.
+ *
+ * Field mapping → the normalized Job shape:
+ *   - title:    `title`, trimmed (items without one are dropped).
+ *   - url:      `url` — an absolute posting URL on www.arbeitnow.com. It is the
+ *               dedup key (items without a valid `https:` URL are dropped) and is
+ *               display-only (written to the pipeline/history, never server-
+ *               fetched here).
+ *   - company:  `company_name`, falling back to the portal entry name, then
+ *               "Arbeitnow".
+ *   - location: `location`, with "Remote" appended when `remote` is true.
+ *   - postedAt: `created_at` (epoch SECONDS) → epoch ms (omitted when absent).
+ *
+ * @param {any} j
+ * @param {string} [fallbackCompany]
+ * @returns {{ title: string, url: string, company: string, location: string, postedAt?: number } | null}
+ */
+export function normalizeArbeitnowJob(j, fallbackCompany) {
+  if (!j || typeof j !== 'object') return null;
+
+  const title = typeof j.title === 'string' ? j.title.trim() : '';
+  if (!title) return null;
+
+  let url = '';
+  const rawUrl = typeof j.url === 'string' ? j.url.trim() : '';
+  if (rawUrl) {
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol === 'https:') url = parsed.href;
+    } catch {
+      // malformed URL → leave url = '' → dropped below
+    }
+  }
+  if (!url) return null;
+
+  const company =
+    typeof j.company_name === 'string' && j.company_name.trim()
+      ? j.company_name.trim()
+      : fallbackCompany || 'Arbeitnow';
+
+  const baseLocation = typeof j.location === 'string' ? j.location.trim() : '';
+  const location = [baseLocation, j.remote === true ? 'Remote' : ''].filter(Boolean).join(', ');
+
+  /** @type {{ title: string, url: string, company: string, location: string, postedAt?: number }} */
+  const job = { title, url, company, location };
+  if (Number.isFinite(j.created_at)) job.postedAt = j.created_at * 1000; // epoch seconds → ms
+  return job;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'arbeitnow',
+
+  async fetch(entry, ctx) {
+    assertArbeitnowUrl(FEED_BASE);
+    const maxPages = resolveMaxPages(entry);
+    const fallbackCompany = entry?.name;
+    const out = [];
+
+    for (let page = 1; page <= maxPages; page++) {
+      // Build the page URL directly (do NOT follow links.next — it carries a
+      // featured `?search=` term that would narrow the board).
+      const url = `${FEED_BASE}?page=${page}`;
+      // redirect:'error' prevents SSRF via server-side redirects
+      const json = await ctx.fetchJson(url, { redirect: 'error' });
+      if (!json || !Array.isArray(json.data)) {
+        throw new Error(
+          `arbeitnow: unexpected API response on page ${page} — expected { data: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`,
+        );
+      }
+      for (const j of json.data) {
+        const normalized = normalizeArbeitnowJob(j, fallbackCompany);
+        if (normalized) out.push(normalized);
+      }
+      if (json.data.length < PER_PAGE) break; // short page → last page reached
+    }
+    return out;
+  },
+};

--- a/providers/arbeitnow.mjs
+++ b/providers/arbeitnow.mjs
@@ -48,10 +48,10 @@ function resolveMaxPages(entry) {
  *
  * Field mapping → the normalized Job shape:
  *   - title:    `title`, trimmed (items without one are dropped).
- *   - url:      `url` — an absolute posting URL on www.arbeitnow.com. It is the
- *               dedup key (items without a valid `https:` URL are dropped) and is
- *               display-only (written to the pipeline/history, never server-
- *               fetched here).
+ *   - url:      `url` — an absolute `https:` posting URL host-locked to
+ *               www.arbeitnow.com (an off-host or non-https URL is untrusted and
+ *               drops the item). It is the dedup key and is display-only (written
+ *               to the pipeline/history, never server-fetched here).
  *   - company:  `company_name`, falling back to the portal entry name, then
  *               "Arbeitnow".
  *   - location: `location`, with "Remote" appended when `remote` is true.
@@ -67,12 +67,14 @@ export function normalizeArbeitnowJob(j, fallbackCompany) {
   const title = typeof j.title === 'string' ? j.title.trim() : '';
   if (!title) return null;
 
+  // url must be an absolute https posting link on www.arbeitnow.com — Arbeitnow
+  // always serves postings there, so an off-host URL is untrusted and dropped.
   let url = '';
   const rawUrl = typeof j.url === 'string' ? j.url.trim() : '';
   if (rawUrl) {
     try {
       const parsed = new URL(rawUrl);
-      if (parsed.protocol === 'https:') url = parsed.href;
+      if (parsed.protocol === 'https:' && parsed.hostname === TRUSTED_HOST) url = parsed.href;
     } catch {
       // malformed URL → leave url = '' → dropped below
     }

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -522,6 +522,11 @@ search_queries:
 #
 # -- Job boards / aggregators (no careers_url; set provider: explicitly) --
 #
+# - name: Arbeitnow                       # EU/DACH-heavy board, newest-first
+#   provider: arbeitnow
+#   max_pages: 3          # optional page cap (100 jobs/page, default 3, max 50)
+#   enabled: true
+#
 # - name: Arbeitsagentur — AI Roles      # German federal jobs API
 #   provider: arbeitsagentur
 #   arbeitsagentur:

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5405,6 +5405,121 @@ try {
   fail(`weworkremotely provider tests crashed: ${e.message}`);
 }
 
+// ── 34. Provider — arbeitnow ────────────────────────────────────
+console.log('\n34. Provider — arbeitnow');
+
+try {
+  const arbeitnowModule = await import(pathToFileURL(join(ROOT, 'providers/arbeitnow.mjs')).href);
+  const arbeitnow = arbeitnowModule.default;
+  const { normalizeArbeitnowJob } = arbeitnowModule;
+
+  if (arbeitnow.id === 'arbeitnow') pass('arbeitnow.id is "arbeitnow"');
+  else fail(`arbeitnow.id is ${JSON.stringify(arbeitnow.id)}`);
+
+  // normalizeArbeitnowJob — field mapping.
+  const full = normalizeArbeitnowJob(
+    { title: '  Staff AI Engineer  ', url: '  https://www.arbeitnow.com/jobs/x1  ', company_name: '  Acme Co  ', location: '  Berlin  ', remote: false, created_at: 1782693032 },
+    'Fallback',
+  );
+  if (full && full.title === 'Staff AI Engineer' && full.url === 'https://www.arbeitnow.com/jobs/x1'
+      && full.company === 'Acme Co' && full.location === 'Berlin' && full.postedAt === 1782693032000) {
+    pass('normalizeArbeitnowJob maps + trims title/url/company/location and converts created_at seconds → ms');
+  } else {
+    fail(`normalizeArbeitnowJob full row = ${JSON.stringify(full)}`);
+  }
+
+  // remote:true appends "Remote" to the location.
+  const remoteJob = normalizeArbeitnowJob({ title: 'R', url: 'https://www.arbeitnow.com/jobs/r', location: 'Munich', remote: true }, 'X');
+  if (remoteJob?.location === 'Munich, Remote') pass('normalizeArbeitnowJob appends "Remote" when remote is true');
+  else fail(`normalizeArbeitnowJob remote location = ${JSON.stringify(remoteJob?.location)}`);
+
+  // remote-only (no base location) → "Remote".
+  const remoteOnly = normalizeArbeitnowJob({ title: 'R', url: 'https://www.arbeitnow.com/jobs/r2', remote: true }, 'X');
+  if (remoteOnly?.location === 'Remote') pass('normalizeArbeitnowJob yields "Remote" when remote is true and location is absent');
+  else fail(`normalizeArbeitnowJob remote-only location = ${JSON.stringify(remoteOnly?.location)}`);
+
+  // company fallbacks: entry name, then "Arbeitnow".
+  const coFromEntry = normalizeArbeitnowJob({ title: 'T', url: 'https://www.arbeitnow.com/jobs/c1', company_name: '' }, 'Entry Name');
+  const coDefault = normalizeArbeitnowJob({ title: 'T', url: 'https://www.arbeitnow.com/jobs/c2' });
+  if (coFromEntry?.company === 'Entry Name' && coDefault?.company === 'Arbeitnow') {
+    pass('normalizeArbeitnowJob falls back company → entry name → "Arbeitnow"');
+  } else {
+    fail(`normalizeArbeitnowJob company fallbacks = ${JSON.stringify({ a: coFromEntry?.company, b: coDefault?.company })}`);
+  }
+
+  // drops: empty title, missing url, non-https url, malformed url, non-object.
+  const drops = [
+    normalizeArbeitnowJob({ title: '', url: 'https://www.arbeitnow.com/jobs/d1' }),
+    normalizeArbeitnowJob({ title: 'No URL' }),
+    normalizeArbeitnowJob({ title: 'Insecure', url: 'http://www.arbeitnow.com/jobs/d3' }),
+    normalizeArbeitnowJob({ title: 'Relative', url: '/jobs/d4' }),
+    normalizeArbeitnowJob(null),
+  ];
+  if (drops.every(r => r === null)) pass('normalizeArbeitnowJob drops empty-title / no-url / non-https / relative / non-object');
+  else fail(`normalizeArbeitnowJob drops = ${JSON.stringify(drops)}`);
+
+  // missing created_at → no postedAt key.
+  const noDate = normalizeArbeitnowJob({ title: 'T', url: 'https://www.arbeitnow.com/jobs/nd' });
+  if (noDate && !('postedAt' in noDate)) pass('normalizeArbeitnowJob omits postedAt when created_at is absent');
+  else fail(`normalizeArbeitnowJob postedAt presence = ${JSON.stringify(noDate)}`);
+
+  // fetch(): pagination by self-built ?page=N, stop on a short page.
+  const mk = (i) => ({ title: `Role ${i}`, url: `https://www.arbeitnow.com/jobs/x${i}`, company_name: `Co ${i}`, location: 'Berlin', remote: false, created_at: 1782693032 + i });
+  const page1 = Array.from({ length: 100 }, (_, i) => mk(i));            // full page → continue
+  const page2 = [mk(100), mk(101), { title: '', url: 'https://www.arbeitnow.com/jobs/bad' }]; // short page (3 < 100) → stop; 1 drop
+  const requested = [];
+  const pagedFetch = async (url, opts) => {
+    requested.push({ url, redirect: opts?.redirect });
+    const u = new URL(url);
+    const page = Number(u.searchParams.get('page'));
+    // links.next deliberately points at a featured ?search= URL to prove we DON'T follow it.
+    if (page === 1) return { data: page1, links: { next: 'https://www.arbeitnow.com/api/job-board-api?search=foo&page=2' }, meta: {} };
+    if (page === 2) return { data: page2, links: { next: null }, meta: {} };
+    return { data: [], links: {}, meta: {} };
+  };
+
+  const paged = await arbeitnow.fetch({ name: 'Arbeitnow' }, { fetchJson: pagedFetch });
+
+  if (requested.length === 2
+      && requested[0].url === 'https://www.arbeitnow.com/api/job-board-api?page=1'
+      && requested[1].url === 'https://www.arbeitnow.com/api/job-board-api?page=2') {
+    pass('arbeitnow.fetch() builds ?page=N URLs itself (ignores links.next) and stops after the short page');
+  } else {
+    fail(`arbeitnow.fetch() requested = ${JSON.stringify(requested.map(r => r.url))}`);
+  }
+
+  if (requested.every(r => r.redirect === 'error')) pass('arbeitnow.fetch() passes redirect:"error" on every page (SSRF guard)');
+  else fail(`arbeitnow.fetch() redirect opts = ${JSON.stringify(requested.map(r => r.redirect))}`);
+
+  if (paged.length === 102) pass('arbeitnow.fetch() aggregates valid jobs across pages (100 + 2, dropping the empty-title row)');
+  else fail(`arbeitnow.fetch() returned ${paged.length} jobs (expected 102)`);
+
+  // max_pages cap: only the first page is requested even though it is full.
+  const capRequested = [];
+  await arbeitnow.fetch(
+    { name: 'Arbeitnow', max_pages: 1 },
+    { fetchJson: async (url, opts) => { capRequested.push(url); return { data: Array.from({ length: 100 }, (_, i) => mk(i)) }; } },
+  );
+  if (capRequested.length === 1 && capRequested[0] === 'https://www.arbeitnow.com/api/job-board-api?page=1') {
+    pass('arbeitnow.fetch() honors max_pages (stops at the cap even on a full page)');
+  } else {
+    fail(`arbeitnow.fetch() max_pages:1 requested ${JSON.stringify(capRequested)}`);
+  }
+
+  // unexpected API response → throws.
+  let badThrew = false;
+  try {
+    await arbeitnow.fetch({ name: 'X' }, { fetchJson: async () => ({ wrong: true }) });
+  } catch (e) {
+    badThrew = /unexpected API response/.test(e.message);
+  }
+  if (badThrew) pass('arbeitnow.fetch() throws on unexpected API response shape');
+  else fail('arbeitnow.fetch() should throw when the data array is absent');
+
+} catch (e) {
+  fail(`arbeitnow provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5453,9 +5453,10 @@ try {
     normalizeArbeitnowJob({ title: 'No URL' }),
     normalizeArbeitnowJob({ title: 'Insecure', url: 'http://www.arbeitnow.com/jobs/d3' }),
     normalizeArbeitnowJob({ title: 'Relative', url: '/jobs/d4' }),
+    normalizeArbeitnowJob({ title: 'Off host', url: 'https://evil.example/jobs/d5' }), // host-lock: external https dropped
     normalizeArbeitnowJob(null),
   ];
-  if (drops.every(r => r === null)) pass('normalizeArbeitnowJob drops empty-title / no-url / non-https / relative / non-object');
+  if (drops.every(r => r === null)) pass('normalizeArbeitnowJob drops empty-title / no-url / non-https / relative / off-host / non-object');
   else fail(`normalizeArbeitnowJob drops = ${JSON.stringify(drops)}`);
 
   // missing created_at → no postedAt key.


### PR DESCRIPTION
## What

Adds an **Arbeitnow** board-wide aggregator provider (`providers/arbeitnow.mjs`). Arbeitnow publishes a public, zero-auth JSON feed at `https://www.arbeitnow.com/api/job-board-api` (EU/DACH-heavy but international, updated hourly, newest-first), so this mirrors `providers/remotive.mjs`.

- Reads `?page=N` (100 jobs/page) and normalizes each `data[]` item to `{ title, url, company, location }` (+ optional `postedAt`):
  - `title` from `title`; `url` from `url` (absolute `https:`, display-only, dropped if missing/invalid).
  - `company` from `company_name`, falling back to the portal entry name, then `"Arbeitnow"`.
  - `location` from `location`, with `"Remote"` appended when `remote` is true.
  - `postedAt` from `created_at` (epoch **seconds**) → ms.
- **Pagination builds `?page=N` URLs directly** rather than following `links.next` — the API injects a rotating featured `?search=` term into `links.next`, which would silently narrow the board. It paginates up to `max_pages` (default 3, cap 50), stopping early on a short/empty page (the API exposes no total and asks callers not to abuse it).
- Host-locked to `www.arbeitnow.com` with `redirect:'error'` on every request (SSRF guard).

## Files

- `providers/arbeitnow.mjs` — new provider.
- `test-all.mjs` — new test block (section 34): normalize mapping/trim/drops, remote-location formatting, company fallbacks, pagination + stop-on-short + `max_pages` cap (asserts `links.next` is ignored), SSRF guard, bad-response throw.
- `docs/SUPPORTED_JOB_BOARDS.md` — register Arbeitnow (the doc requires this in the same PR).
- `templates/portals.example.yml` — add an Arbeitnow example with `max_pages`.

## Testing

- `node test-all.mjs` → **556 passed, 0 failed** (12 new assertions; verified stable across 5 runs).
- Live end-to-end against the real API returned 200 correctly-normalized jobs across 2 pages (all with `postedAt`; remote rows formatted e.g. `"Munich, Remote"`).

Closes #1300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Arbeitnow job board provider to aggregate listings, including paginated retrieval with a configurable maximum page cap.
  - Added a commented Arbeitnow configuration example for easy setup guidance.

- **Documentation**
  - Documented Arbeitnow in the supported job boards list, including pagination and filtering behavior.

- **Bug Fixes**
  - Improved normalization and cleanup of listing fields (including consistent company/location formatting and posted-date conversion).
  - Added stricter validation for accepted posting URLs and safe handling of unexpected feed responses.

- **Tests**
  - Added/expanded automated coverage for Arbeitnow normalization, pagination limits, invalid-row rejection, and response-shape handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->