### PR TITLE
feat(providers): add Rippling ATS provider (public zero-auth board API)

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -20,6 +20,7 @@ are shared helpers and are not loaded as providers.
 | Personio | RSS | Auto-detects `<slug>.jobs.personio.de` or `.com` hosts and parses the public XML jobs feed. |
 | Recruitee | API | Auto-detects `<slug>.recruitee.com` boards and uses the public per-tenant offers API. |
 | RemoteOK | API | Reads the board-wide `https://remoteok.com/api` JSON feed; scanner filters decide which rows are relevant. |
+| Rippling | API | Auto-detects `https://ats.rippling.com/<slug>/jobs` careers pages and reads the public zero-auth board API (`api.rippling.com/platform/api/ats/v1/board/<slug>/jobs`). |
 | Remotive | API | Reads the board-wide `https://remotive.com/api/remote-jobs` JSON feed, then applies local scanner filters. |
 | SmartRecruiters | API | Auto-detects SmartRecruiters careers URLs or uses `provider: smartrecruiters` for branded custom domains. |
 | SolidJobs | API | Auto-detects `https://solid.jobs/public-api/offers/<division>` and reads the public offers API. |

--- a/providers/rippling.mjs
+++ b/providers/rippling.mjs
@@ -86,10 +86,11 @@ export default {
  * The response is a top-level JSON ARRAY of postings. Field mapping → the
  * normalized Job shape:
  *   - title:    `name`, trimmed (postings without one are dropped).
- *   - url:      `url` — an absolute posting URL on `ats.rippling.com`. It is the
- *               dedup key (postings without a valid `https:` URL are dropped) and
- *               is display-only (written to the pipeline/history, never server-
- *               fetched here).
+ *   - url:      `url` — an absolute `https:` posting URL host-locked to
+ *               `ats.rippling.com` (Rippling always serves postings there, so an
+ *               off-host or non-https URL is untrusted and the posting is dropped).
+ *               It is the dedup key and is display-only (written to the
+ *               pipeline/history, never server-fetched here).
  *   - company:  the portal entry name (the feed is per-tenant and carries no
  *               company field, same as recruitee).
  *   - location: `workLocation.label` (e.g. "Remote (United States)"); falls back
@@ -106,12 +107,15 @@ export function parseRipplingResponse(json, companyName) {
       const title = typeof j?.name === 'string' ? j.name.trim() : '';
       if (!title) return null;
 
+      // url must be an absolute https posting link on ats.rippling.com — Rippling
+      // always serves postings there (no custom-domain case), so an off-host URL
+      // is untrusted and dropped. url is the dedup key.
       let url = '';
       const rawUrl = typeof j?.url === 'string' ? j.url.trim() : '';
       if (rawUrl) {
         try {
           const parsed = new URL(rawUrl);
-          if (parsed.protocol === 'https:') url = parsed.href;
+          if (parsed.protocol === 'https:' && parsed.hostname === CAREERS_HOST) url = parsed.href;
         } catch {
           // malformed URL → leave url = '' → dropped below
         }

--- a/providers/rippling.mjs
+++ b/providers/rippling.mjs
@@ -1,0 +1,132 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Rippling provider — hits the public per-tenant ATS board API.
+// Auto-detects from a careers_url like `https://ats.rippling.com/<slug>/jobs`
+// (the `<slug>` is the first path segment). Rippling's board API is public and
+// zero-auth:
+//   https://api.rippling.com/platform/api/ats/v1/board/<slug>/jobs
+// Response shape: a JSON ARRAY of
+//   { uuid, name, department: { id, label }, url, workLocation: { id, label } }
+//
+// The careers host (`ats.rippling.com`) and the API host (`api.rippling.com`)
+// are both fixed; the per-tenant slug is the only variable part. It is extracted
+// from the careers URL path and constrained to a safe token so it cannot inject
+// extra path segments or traversal into the API URL.
+
+const CAREERS_HOST = 'ats.rippling.com';
+const API_HOST = 'api.rippling.com';
+const API_BASE = `https://${API_HOST}/platform/api/ats/v1/board`;
+const SLUG_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/;
+
+/**
+ * Resolve the tenant slug (e.g. `just-appraised-jobs`) from a careers_url.
+ * Returns null for non-Rippling, malformed, or unsafe-slug URLs.
+ * @param {import('./_types.js').PortalEntry} entry
+ */
+function resolveSlug(entry) {
+  const raw = typeof entry.careers_url === 'string' ? entry.careers_url : '';
+  if (!raw) return null;
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:') return null;
+  if (parsed.hostname !== CAREERS_HOST) return null;
+  const segment = parsed.pathname.split('/').filter(Boolean)[0] || '';
+  if (!SLUG_RE.test(segment)) return null;
+  return segment;
+}
+
+/** Build the board API URL for a validated slug. */
+function apiUrlForSlug(slug) {
+  return `${API_BASE}/${encodeURIComponent(slug)}/jobs`;
+}
+
+/** @param {string} url */
+function assertRipplingApiUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`rippling: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`rippling: URL must use HTTPS: ${url}`);
+  if (parsed.hostname !== API_HOST) {
+    throw new Error(`rippling: untrusted hostname "${parsed.hostname}" — must be ${API_HOST}`);
+  }
+  return url;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'rippling',
+
+  detect(entry) {
+    const slug = resolveSlug(entry);
+    return slug ? { url: apiUrlForSlug(slug) } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const slug = resolveSlug(entry);
+    if (!slug) throw new Error(`rippling: cannot derive API URL for ${entry.name}`);
+    const apiUrl = apiUrlForSlug(slug);
+    assertRipplingApiUrl(apiUrl);
+    // redirect:'error' prevents SSRF via server-side redirects
+    const json = await ctx.fetchJson(apiUrl, { redirect: 'error' });
+    return parseRipplingResponse(json, entry.name);
+  },
+};
+
+/**
+ * Parse a Rippling board API response. Exported for unit tests.
+ *
+ * The response is a top-level JSON ARRAY of postings. Field mapping → the
+ * normalized Job shape:
+ *   - title:    `name`, trimmed (postings without one are dropped).
+ *   - url:      `url` — an absolute posting URL on `ats.rippling.com`. It is the
+ *               dedup key (postings without a valid `https:` URL are dropped) and
+ *               is display-only (written to the pipeline/history, never server-
+ *               fetched here).
+ *   - company:  the portal entry name (the feed is per-tenant and carries no
+ *               company field, same as recruitee).
+ *   - location: `workLocation.label` (e.g. "Remote (United States)"); falls back
+ *               to a bare string `workLocation`, else "".
+ *
+ * @param {any} json
+ * @param {string} companyName
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parseRipplingResponse(json, companyName) {
+  if (!Array.isArray(json)) return [];
+  return json
+    .map(j => {
+      const title = typeof j?.name === 'string' ? j.name.trim() : '';
+      if (!title) return null;
+
+      let url = '';
+      const rawUrl = typeof j?.url === 'string' ? j.url.trim() : '';
+      if (rawUrl) {
+        try {
+          const parsed = new URL(rawUrl);
+          if (parsed.protocol === 'https:') url = parsed.href;
+        } catch {
+          // malformed URL → leave url = '' → dropped below
+        }
+      }
+      if (!url) return null;
+
+      const wl = j?.workLocation;
+      const location =
+        wl && typeof wl === 'object' && typeof wl.label === 'string'
+          ? wl.label.trim()
+          : typeof wl === 'string'
+            ? wl.trim()
+            : '';
+
+      return { title, url, location, company: companyName };
+    })
+    .filter(Boolean);
+}

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -489,6 +489,7 @@ search_queries:
 #   solidjobs       solid.jobs/public-api/offers/<division>
 #   comeet          api: https://www.comeet.co/careers-api/2.0/company/<uid>/positions?token=<token>
 #   personio        <slug>.jobs.personio.(de|com)
+#   rippling        ats.rippling.com/<slug>/jobs
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
@@ -512,6 +513,10 @@ search_queries:
 #
 # - name: Example Breezy Co
 #   careers_url: https://exampleco.breezy.hr              # any *.breezy.hr host
+#   enabled: true
+#
+# - name: Example Rippling Co
+#   careers_url: https://ats.rippling.com/exampleco/jobs  # any ats.rippling.com/<slug>
 #   enabled: true
 #
 # - name: SolidJobs — Engineering

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5405,6 +5405,163 @@ try {
   fail(`weworkremotely provider tests crashed: ${e.message}`);
 }
 
+// ── 35. Provider — rippling ─────────────────────────────────────
+console.log('\n35. Provider — rippling');
+
+try {
+  const ripplingModule = await import(pathToFileURL(join(ROOT, 'providers/rippling.mjs')).href);
+  const rippling = ripplingModule.default;
+  const { parseRipplingResponse } = ripplingModule;
+
+  if (rippling.id === 'rippling') pass('rippling.id is "rippling"');
+  else fail(`rippling.id is ${JSON.stringify(rippling.id)}`);
+
+  // detect(): ats.rippling.com/<slug>/jobs → board API URL.
+  const hit = rippling.detect({ name: 'Acme', careers_url: 'https://ats.rippling.com/acme-corp/jobs' });
+  if (hit && hit.url === 'https://api.rippling.com/platform/api/ats/v1/board/acme-corp/jobs') {
+    pass('rippling.detect() resolves ats.rippling.com/<slug>/jobs → board API URL');
+  } else {
+    fail(`rippling.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  // detect() also works when careers_url is just /<slug> (no /jobs suffix).
+  const hitNoJobs = rippling.detect({ name: 'X', careers_url: 'https://ats.rippling.com/acme-corp' });
+  if (hitNoJobs && hitNoJobs.url === 'https://api.rippling.com/platform/api/ats/v1/board/acme-corp/jobs') {
+    pass('rippling.detect() derives the slug from the first path segment (no /jobs needed)');
+  } else {
+    fail(`rippling.detect() no-/jobs returned ${JSON.stringify(hitNoJobs)}`);
+  }
+
+  if (rippling.detect({ name: 'X', careers_url: 'https://example.com/acme/jobs' }) === null) {
+    pass('rippling.detect() returns null for non-rippling hosts');
+  } else {
+    fail('rippling.detect() should return null for non-rippling hosts');
+  }
+
+  // careers_url with non-string value → detect() returns null without crashing.
+  if (rippling.detect({ name: 'X', careers_url: null }) === null && rippling.detect({ name: 'X', careers_url: 7 }) === null) {
+    pass('rippling.detect() returns null for non-string careers_url (null and 7)');
+  } else {
+    fail('rippling.detect() should treat non-string careers_url as missing');
+  }
+
+  // SSRF/format: non-https, empty path (no slug), and host-spoof in the path.
+  if (rippling.detect({ name: 'X', careers_url: 'http://ats.rippling.com/acme/jobs' }) === null
+      && rippling.detect({ name: 'X', careers_url: 'https://ats.rippling.com/' }) === null
+      && rippling.detect({ name: 'X', careers_url: 'https://evil.example/ats.rippling.com/acme/jobs' }) === null) {
+    pass('rippling.detect() rejects non-https, empty-path, and path-spoofed URLs');
+  } else {
+    fail('rippling.detect() must reject non-https / empty-path / path-spoofed URLs');
+  }
+
+  // Slug safety: a first segment that is not a clean token (space, dot, hyphen-edged) is rejected.
+  if (rippling.detect({ name: 'X', careers_url: 'https://ats.rippling.com/a%20b/jobs' }) === null
+      && rippling.detect({ name: 'X', careers_url: 'https://ats.rippling.com/acme.corp/jobs' }) === null
+      && rippling.detect({ name: 'X', careers_url: 'https://ats.rippling.com/-acme/jobs' }) === null) {
+    pass('rippling.detect() rejects unsafe slugs (space, dot, leading hyphen)');
+  } else {
+    fail('rippling.detect() must reject unsafe slugs');
+  }
+
+  // Internal hyphens are valid.
+  if (rippling.detect({ name: 'X', careers_url: 'https://ats.rippling.com/just-appraised-jobs/jobs' })?.url
+      === 'https://api.rippling.com/platform/api/ats/v1/board/just-appraised-jobs/jobs') {
+    pass('rippling.detect() accepts slugs with internal hyphens');
+  } else {
+    fail('rippling.detect() should accept internal hyphens in the slug');
+  }
+
+  // parseRipplingResponse — deterministic sample (top-level array).
+  const sample = [
+    { uuid: '1', name: 'Account Executive', url: 'https://ats.rippling.com/acme/jobs/uuid-1', department: { label: 'Sales' }, workLocation: { label: 'Remote (United States)', id: 'x' } },
+    { uuid: '2', name: '  ML Engineer  ', url: '  https://ats.rippling.com/acme/jobs/uuid-2  ', workLocation: { label: 'Canada' } },
+    { uuid: '3', name: 'String Loc Role', url: 'https://ats.rippling.com/acme/jobs/uuid-3', workLocation: 'New York' }, // workLocation as bare string
+    { uuid: '4', name: 'No Loc Role', url: 'https://ats.rippling.com/acme/jobs/uuid-4', workLocation: null },           // null → ''
+    { uuid: '5', name: '', url: 'https://ats.rippling.com/acme/jobs/uuid-5' },                                          // drop: empty name
+    { uuid: '6', name: 'No URL Role' },                                                                                 // drop: no url
+    { uuid: '7', name: 'Insecure', url: 'http://ats.rippling.com/acme/jobs/uuid-7' },                                   // drop: non-https
+  ];
+  const jobs = parseRipplingResponse(sample, 'Acme');
+
+  if (jobs.length === 4) pass('parseRipplingResponse keeps 4 valid postings (drops empty-name / no-url / non-https)');
+  else fail(`parseRipplingResponse returned ${jobs.length} postings (expected 4)`);
+
+  if (jobs[0] && Object.keys(jobs[0]).sort().join(',') === 'company,location,title,url') {
+    pass('parseRipplingResponse returns the normalized { title, url, company, location } shape');
+  } else {
+    fail(`parseRipplingResponse row 0 keys = ${JSON.stringify(jobs[0] && Object.keys(jobs[0]))}`);
+  }
+
+  if (jobs[0]?.title === 'Account Executive'
+      && jobs[0]?.url === 'https://ats.rippling.com/acme/jobs/uuid-1'
+      && jobs[0]?.company === 'Acme'
+      && jobs[0]?.location === 'Remote (United States)') {
+    pass('parseRipplingResponse maps name→title, url, company from entry name, workLocation.label→location');
+  } else {
+    fail(`parseRipplingResponse row 0 = ${JSON.stringify(jobs[0])}`);
+  }
+
+  if (jobs[1]?.title === 'ML Engineer' && jobs[1]?.url === 'https://ats.rippling.com/acme/jobs/uuid-2') {
+    pass('parseRipplingResponse trims whitespace from name and url');
+  } else {
+    fail(`parseRipplingResponse row 1 title/url = ${JSON.stringify({ title: jobs[1]?.title, url: jobs[1]?.url })}`);
+  }
+
+  if (jobs[2]?.location === 'New York' && jobs[3]?.location === '') {
+    pass('parseRipplingResponse accepts a bare-string workLocation and yields "" when workLocation is null');
+  } else {
+    fail(`parseRipplingResponse loc fallbacks = ${JSON.stringify({ str: jobs[2]?.location, none: jobs[3]?.location })}`);
+  }
+
+  if (parseRipplingResponse({}, 'X').length === 0 && parseRipplingResponse(null, 'X').length === 0) {
+    pass('parseRipplingResponse: non-array input → empty result (no crash)');
+  } else {
+    fail('parseRipplingResponse should yield empty result for non-array input');
+  }
+
+  // fetch(): requests the derived API URL and passes the SSRF guard.
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const fetched = await rippling.fetch(
+    { name: 'Acme', careers_url: 'https://ats.rippling.com/acme-corp/jobs' },
+    { fetchJson: async (url, opts) => { capturedUrl = url; capturedOpts = opts; return sample; } },
+  );
+
+  if (capturedUrl === 'https://api.rippling.com/platform/api/ats/v1/board/acme-corp/jobs') {
+    pass('rippling.fetch() requests the derived board API URL');
+  } else {
+    fail(`rippling.fetch() requested ${JSON.stringify(capturedUrl)}`);
+  }
+
+  if (capturedOpts && capturedOpts.redirect === 'error') {
+    pass('rippling.fetch() passes redirect:"error" to fetchJson (SSRF guard)');
+  } else {
+    fail(`rippling.fetch() should pass redirect:"error", got: ${JSON.stringify(capturedOpts)}`);
+  }
+
+  if (fetched.length === 4 && fetched[0]?.company === 'Acme') {
+    pass('rippling.fetch() returns normalized jobs with company from entry name');
+  } else {
+    fail(`rippling.fetch() returned ${fetched.length} jobs, row 0 = ${JSON.stringify(fetched[0])}`);
+  }
+
+  // fetch(): a non-rippling careers_url cannot derive an endpoint → throws.
+  let badEntryThrew = false;
+  try {
+    await rippling.fetch(
+      { name: 'X', careers_url: 'https://example.com/careers' },
+      { fetchJson: async () => [] },
+    );
+  } catch (e) {
+    badEntryThrew = /cannot derive API URL/.test(e.message);
+  }
+  if (badEntryThrew) pass('rippling.fetch() throws when the careers_url is not an ats.rippling.com host');
+  else fail('rippling.fetch() should throw for a non-rippling careers_url');
+
+} catch (e) {
+  fail(`rippling provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5519,6 +5519,22 @@ try {
     fail('parseRipplingResponse should yield empty result for non-array input');
   }
 
+  // Regression: the per-item url is host-locked to ats.rippling.com — an external
+  // https URL is dropped, a valid ats.rippling.com posting URL is kept.
+  const hostLocked = parseRipplingResponse(
+    [
+      { name: 'External Host', url: 'https://evil.example/acme/jobs/uuid-x' },
+      { name: 'Valid Host', url: 'https://ats.rippling.com/acme/jobs/uuid-9' },
+    ],
+    'Acme',
+  );
+  if (hostLocked.length === 1 && hostLocked[0]?.title === 'Valid Host'
+      && hostLocked[0]?.url === 'https://ats.rippling.com/acme/jobs/uuid-9') {
+    pass('parseRipplingResponse host-locks the posting url to ats.rippling.com (drops external https URLs)');
+  } else {
+    fail(`parseRipplingResponse host-lock = ${JSON.stringify(hostLocked)}`);
+  }
+
   // fetch(): requests the derived API URL and passes the SSRF guard.
   let capturedUrl = null;
   let capturedOpts = null;


### PR DESCRIPTION
## What

Adds a **Rippling ATS** provider (`providers/rippling.mjs`). Rippling career sites at `https://ats.rippling.com/<slug>/jobs` expose a public, zero-auth board API at `https://api.rippling.com/platform/api/ats/v1/board/<slug>/jobs`, so this mirrors `providers/recruitee.mjs` / `providers/pinpoint.mjs` (per-tenant ATS).

- `detect()` auto-detects `ats.rippling.com/<slug>/jobs` careers URLs — the `<slug>` is the first path segment, constrained to a safe token (`^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$`) so it can't inject extra path segments or traversal into the API URL.
- Both hosts are fixed (careers `ats.rippling.com`, API `api.rippling.com`); the derived API URL is host-locked and fetched with `redirect:'error'` (SSRF guard).
- An exported `parseRipplingResponse()` maps each item of the top-level JSON **array** to `{ title, url, company, location }`:
  - `title` from `name`; `url` from `url` (absolute `https:`, display-only, dropped if missing/invalid).
  - `company` from the portal entry name (per-tenant feed, no company field — same as recruitee).
  - `location` from `workLocation.label` (e.g. "Remote (United States)"); a bare-string `workLocation` is accepted, and `null` → `""`.

## Files

- `providers/rippling.mjs` — new provider.
- `test-all.mjs` — new test block (section 35) mirroring the recruitee/pinpoint tests: detect + slug safety (rejects space/dot/leading-hyphen slugs, non-https, empty path, path-spoof; accepts internal hyphens), parser mapping/fallbacks/drops, fetch wiring.
- `docs/SUPPORTED_JOB_BOARDS.md` — register Rippling (the doc requires this in the same PR).
- `templates/portals.example.yml` — add Rippling to the auto-detected ATS host list + an example stanza.

## Testing

- `node test-all.mjs` → **562 passed, 0 failed** (18 new assertions).
- Live end-to-end against a real board (`https://ats.rippling.com/just-appraised-jobs/jobs`) returned 9 correctly-normalized postings.

Closes #1302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Rippling job board, including automatic detection of Rippling careers URLs and fetching roles from the corresponding public ATS board.
  * Updated supported-provider documentation and the example portal configuration to include Rippling.
* **Bug Fixes**
  * Improved job data normalization by trimming fields and filtering out invalid postings.
  * Strengthened URL safety by rejecting non-HTTPS, off-host, or malformed Rippling careers URLs and dropping external posting URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->