### PR TITLE
feat(providers): add The Hub provider (public zero-auth job-board API)

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -22,6 +22,7 @@ are shared helpers and are not loaded as providers.
 | RemoteOK | API | Reads the board-wide `https://remoteok.com/api` JSON feed; scanner filters decide which rows are relevant. |
 | Remotive | API | Reads the board-wide `https://remotive.com/api/remote-jobs` JSON feed, then applies local scanner filters. |
 | SmartRecruiters | API | Auto-detects SmartRecruiters careers URLs or uses `provider: smartrecruiters` for branded custom domains. |
+| The Hub | API | Reads the board-wide `https://thehub.io/api/jobs` JSON feed (Nordic/EU startups). Configure with `provider: thehub`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
 | SolidJobs | API | Auto-detects `https://solid.jobs/public-api/offers/<division>` and reads the public offers API. |
 | We Work Remotely | RSS | Reads the public `https://weworkremotely.com/remote-jobs.rss` feed and parses it in-process. |
 | Workable | Parser | Auto-detects `https://apply.workable.com/<slug>` and parses Workable's public markdown jobs feed. |

--- a/providers/thehub.mjs
+++ b/providers/thehub.mjs
@@ -1,0 +1,138 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// The Hub provider — board-wide aggregator feed (Nordic / EU startups):
+// https://thehub.io/api/jobs
+// Response shape: { docs: [ { id, key, title, company: { name, ... },
+//   location: { address, locality, country }, absoluteJobUrl, isRemote,
+//   publishedAt, createdAt, ... } ], total, page, pages, limit }
+//
+// Paginated 15/page via `?page=N` (1-indexed); the response carries `pages`, so
+// iteration is bounded by min(pages, max_pages). Default cap is modest (the
+// board is ~1000 jobs / ~67 pages); override with `max_pages` on the entry.
+//
+// Wire in via a `job_boards:` entry with `provider: thehub`.
+
+const FEED_BASE = 'https://thehub.io/api/jobs';
+const TRUSTED_HOST = 'thehub.io';
+const PER_PAGE = 15;
+const DEFAULT_MAX_PAGES = 3;
+const MAX_PAGES_CAP = 67;
+
+/** @param {string} url */
+function assertHubUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`thehub: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`thehub: URL must use HTTPS: ${url}`);
+  if (parsed.hostname !== TRUSTED_HOST) {
+    throw new Error(`thehub: untrusted hostname "${parsed.hostname}" — must be ${TRUSTED_HOST}`);
+  }
+  return url;
+}
+
+/** Resolve the page cap: a positive integer `max_pages` on the entry, capped. */
+function resolveMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES_CAP);
+  return DEFAULT_MAX_PAGES;
+}
+
+// NaN-safe Date.parse — `|| undefined` would also coerce a valid epoch 0.
+function toEpochMs(value) {
+  if (typeof value !== 'string' || !value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Normalize a single The Hub job. Exported for unit tests.
+ *
+ * Field mapping → the normalized Job shape:
+ *   - title:    `title`, trimmed (postings without one are dropped).
+ *   - url:      `absoluteJobUrl` — host-locked to `thehub.io` (The Hub always
+ *               serves its canonical posting page there; the per-posting `link`
+ *               field is an external apply URL and is NOT used). An off-host or
+ *               non-https URL drops the posting. url is the dedup key and is
+ *               display-only (written to the pipeline/history, never fetched here).
+ *   - company:  `company.name`, falling back to the portal entry name, then
+ *               "The Hub".
+ *   - location: `location.address`, else assembled from `location.locality` /
+ *               `location.country`; "Remote" is appended when `isRemote` is true.
+ *   - postedAt: `publishedAt` (else `createdAt`) ISO date → epoch ms (omitted
+ *               when absent/unparseable).
+ *
+ * @param {any} j
+ * @param {string} [fallbackCompany]
+ * @returns {{ title: string, url: string, company: string, location: string, postedAt?: number } | null}
+ */
+export function normalizeHubJob(j, fallbackCompany) {
+  if (!j || typeof j !== 'object') return null;
+
+  const title = typeof j.title === 'string' ? j.title.trim() : '';
+  if (!title) return null;
+
+  let url = '';
+  const rawUrl = typeof j.absoluteJobUrl === 'string' ? j.absoluteJobUrl.trim() : '';
+  if (rawUrl) {
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol === 'https:' && parsed.hostname === TRUSTED_HOST) url = parsed.href;
+    } catch {
+      // malformed URL → leave url = '' → dropped below
+    }
+  }
+  if (!url) return null;
+
+  const company =
+    j.company && typeof j.company === 'object' && typeof j.company.name === 'string' && j.company.name.trim()
+      ? j.company.name.trim()
+      : fallbackCompany || 'The Hub';
+
+  const loc = j.location && typeof j.location === 'object' ? j.location : {};
+  const address = typeof loc.address === 'string' ? loc.address.trim() : '';
+  const locality = typeof loc.locality === 'string' ? loc.locality.trim() : '';
+  const country = typeof loc.country === 'string' ? loc.country.trim() : '';
+  const base = address || [locality, country].filter(Boolean).join(', ');
+  const location = [base, j.isRemote === true ? 'Remote' : ''].filter(Boolean).join(', ');
+
+  /** @type {{ title: string, url: string, company: string, location: string, postedAt?: number }} */
+  const job = { title, url, company, location };
+  const postedAt = toEpochMs(j.publishedAt) ?? toEpochMs(j.createdAt);
+  if (postedAt !== undefined) job.postedAt = postedAt;
+  return job;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'thehub',
+
+  async fetch(entry, ctx) {
+    assertHubUrl(FEED_BASE);
+    const maxPages = resolveMaxPages(entry);
+    const fallbackCompany = entry?.name;
+    const out = [];
+
+    for (let page = 1; page <= maxPages; page++) {
+      const url = `${FEED_BASE}?page=${page}`;
+      // redirect:'error' prevents SSRF via server-side redirects
+      const json = await ctx.fetchJson(url, { redirect: 'error' });
+      if (!json || !Array.isArray(json.docs)) {
+        throw new Error(
+          `thehub: unexpected API response on page ${page} — expected { docs: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`,
+        );
+      }
+      for (const j of json.docs) {
+        const normalized = normalizeHubJob(j, fallbackCompany);
+        if (normalized) out.push(normalized);
+      }
+      // Stop at the last page: a short page, or page >= the reported total pages.
+      if (json.docs.length < PER_PAGE) break;
+      if (Number.isInteger(json.pages) && page >= json.pages) break;
+    }
+    return out;
+  },
+};

--- a/providers/thehub.mjs
+++ b/providers/thehub.mjs
@@ -90,7 +90,9 @@ export function normalizeHubJob(j, fallbackCompany) {
   const company =
     j.company && typeof j.company === 'object' && typeof j.company.name === 'string' && j.company.name.trim()
       ? j.company.name.trim()
-      : fallbackCompany || 'The Hub';
+      : typeof fallbackCompany === 'string' && fallbackCompany.trim()
+        ? fallbackCompany.trim()
+        : 'The Hub';
 
   const loc = j.location && typeof j.location === 'object' ? j.location : {};
   const address = typeof loc.address === 'string' ? loc.address.trim() : '';

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -522,6 +522,11 @@ search_queries:
 #
 # -- Job boards / aggregators (no careers_url; set provider: explicitly) --
 #
+# - name: The Hub                         # Nordic/EU startup board
+#   provider: thehub
+#   max_pages: 3          # optional page cap (15 jobs/page, default 3, max 67)
+#   enabled: true
+#
 # - name: Arbeitsagentur — AI Roles      # German federal jobs API
 #   provider: arbeitsagentur
 #   arbeitsagentur:

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -496,7 +496,7 @@ search_queries:
 #
 # Some providers are job boards / aggregators with no per-company careers
 # URL to detect, so they must be selected with an explicit `provider:`
-# field: arbeitsagentur, glints, jobstreet, ibm, remoteok, remotive,
+# field: arbeitsagentur, glints, jobstreet, ibm, remoteok, remotive, thehub,
 # weworkremotely, workingnomads. Examples for every built-in provider are below.
 
 # ── Built-in provider examples ────────────────────────────────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5437,10 +5437,11 @@ try {
   // company fallbacks: entry name, then "The Hub".
   const coEntry = normalizeHubJob({ title: 'T', absoluteJobUrl: 'https://thehub.io/jobs/c1', company: {} }, 'Entry Name');
   const coDefault = normalizeHubJob({ title: 'T', absoluteJobUrl: 'https://thehub.io/jobs/c2' });
-  if (coEntry?.company === 'Entry Name' && coDefault?.company === 'The Hub') {
-    pass('normalizeHubJob falls back company → entry name → "The Hub"');
+  const coBlank = normalizeHubJob({ title: 'T', absoluteJobUrl: 'https://thehub.io/jobs/c3' }, '   '); // whitespace-only → "The Hub"
+  if (coEntry?.company === 'Entry Name' && coDefault?.company === 'The Hub' && coBlank?.company === 'The Hub') {
+    pass('normalizeHubJob falls back company → entry name → "The Hub" (whitespace-only entry name ignored)');
   } else {
-    fail(`normalizeHubJob company fallbacks = ${JSON.stringify({ a: coEntry?.company, b: coDefault?.company })}`);
+    fail(`normalizeHubJob company fallbacks = ${JSON.stringify({ a: coEntry?.company, b: coDefault?.company, c: coBlank?.company })}`);
   }
 
   // postedAt falls back to createdAt; omitted when both absent.
@@ -5515,6 +5516,34 @@ try {
     pass('thehub.fetch() honors max_pages (stops at the cap even on a full page)');
   } else {
     fail(`thehub.fetch() max_pages:1 requested ${JSON.stringify(capReq)}`);
+  }
+
+  // A full page with a large `pages` (so neither short-stop nor pages-stop fires)
+  // lets us assert the implicit default cap and the hard cap purely on page count.
+  const fullDeepPage = (page) => ({ docs: Array.from({ length: 15 }, (_, i) => mk(page * 100 + i)), page, pages: 999, limit: 15 });
+
+  // Default max_pages (no override) → exactly 3 pages.
+  const defReq = [];
+  await thehub.fetch(
+    { name: 'The Hub' },
+    { fetchJson: async (url) => { defReq.push(Number(new URL(url).searchParams.get('page'))); return fullDeepPage(defReq.length); } },
+  );
+  if (defReq.length === 3 && defReq[0] === 1 && defReq[2] === 3) {
+    pass('thehub.fetch() defaults to 3 pages when max_pages is not set');
+  } else {
+    fail(`thehub.fetch() default-cap requested ${JSON.stringify(defReq)} (expected pages 1..3)`);
+  }
+
+  // max_pages above the hard cap → clamped to 67 pages.
+  const cap67Req = [];
+  await thehub.fetch(
+    { name: 'The Hub', max_pages: 1000 },
+    { fetchJson: async (url) => { cap67Req.push(Number(new URL(url).searchParams.get('page'))); return fullDeepPage(cap67Req.length); } },
+  );
+  if (cap67Req.length === 67 && cap67Req[0] === 1 && cap67Req[66] === 67) {
+    pass('thehub.fetch() clamps max_pages to the hard cap of 67');
+  } else {
+    fail(`thehub.fetch() hard-cap requested ${cap67Req.length} pages (expected 67)`);
   }
 
   // unexpected API response → throws.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5405,6 +5405,132 @@ try {
   fail(`weworkremotely provider tests crashed: ${e.message}`);
 }
 
+// ── 36. Provider — thehub ───────────────────────────────────────
+console.log('\n36. Provider — thehub');
+
+try {
+  const thehubModule = await import(pathToFileURL(join(ROOT, 'providers/thehub.mjs')).href);
+  const thehub = thehubModule.default;
+  const { normalizeHubJob } = thehubModule;
+
+  if (thehub.id === 'thehub') pass('thehub.id is "thehub"');
+  else fail(`thehub.id is ${JSON.stringify(thehub.id)}`);
+
+  // normalizeHubJob — full mapping.
+  const full = normalizeHubJob(
+    { title: '  Staff Engineer  ', absoluteJobUrl: 'https://thehub.io/jobs/abc123', company: { name: '  Light  ' }, location: { address: '  London, UK  ' }, publishedAt: '2026-06-02T06:59:54.025Z' },
+    'Fallback',
+  );
+  if (full && full.title === 'Staff Engineer' && full.url === 'https://thehub.io/jobs/abc123'
+      && full.company === 'Light' && full.location === 'London, UK'
+      && full.postedAt === Date.parse('2026-06-02T06:59:54.025Z')) {
+    pass('normalizeHubJob maps title/absoluteJobUrl/company.name/location.address + publishedAt → postedAt');
+  } else {
+    fail(`normalizeHubJob full row = ${JSON.stringify(full)}`);
+  }
+
+  // location assembled from locality/country, "Remote" appended when isRemote.
+  const assembled = normalizeHubJob({ title: 'R', absoluteJobUrl: 'https://thehub.io/jobs/r', location: { locality: 'Berlin', country: 'Germany' }, isRemote: true }, 'X');
+  if (assembled?.location === 'Berlin, Germany, Remote') pass('normalizeHubJob assembles locality/country and appends "Remote" when isRemote');
+  else fail(`normalizeHubJob assembled location = ${JSON.stringify(assembled?.location)}`);
+
+  // company fallbacks: entry name, then "The Hub".
+  const coEntry = normalizeHubJob({ title: 'T', absoluteJobUrl: 'https://thehub.io/jobs/c1', company: {} }, 'Entry Name');
+  const coDefault = normalizeHubJob({ title: 'T', absoluteJobUrl: 'https://thehub.io/jobs/c2' });
+  if (coEntry?.company === 'Entry Name' && coDefault?.company === 'The Hub') {
+    pass('normalizeHubJob falls back company → entry name → "The Hub"');
+  } else {
+    fail(`normalizeHubJob company fallbacks = ${JSON.stringify({ a: coEntry?.company, b: coDefault?.company })}`);
+  }
+
+  // postedAt falls back to createdAt; omitted when both absent.
+  const fromCreated = normalizeHubJob({ title: 'T', absoluteJobUrl: 'https://thehub.io/jobs/cd', createdAt: '2026-06-01T00:00:00.000Z' });
+  const noDate = normalizeHubJob({ title: 'T', absoluteJobUrl: 'https://thehub.io/jobs/nd' });
+  if (fromCreated?.postedAt === Date.parse('2026-06-01T00:00:00.000Z') && noDate && !('postedAt' in noDate)) {
+    pass('normalizeHubJob falls back to createdAt and omits postedAt when both dates are absent');
+  } else {
+    fail(`normalizeHubJob date handling = ${JSON.stringify({ created: fromCreated?.postedAt, none: noDate })}`);
+  }
+
+  // host-lock + drops: off-host url, non-https url, missing url, empty title, non-object.
+  const drops = [
+    normalizeHubJob({ title: 'Off host', absoluteJobUrl: 'https://evil.example/jobs/x' }),
+    normalizeHubJob({ title: 'Insecure', absoluteJobUrl: 'http://thehub.io/jobs/x' }),
+    normalizeHubJob({ title: 'No URL' }),
+    normalizeHubJob({ title: '', absoluteJobUrl: 'https://thehub.io/jobs/x' }),
+    normalizeHubJob(null),
+  ];
+  if (drops.every(r => r === null)) {
+    pass('normalizeHubJob host-locks absoluteJobUrl to thehub.io and drops off-host/non-https/no-url/empty-title/non-object');
+  } else {
+    fail(`normalizeHubJob drops = ${JSON.stringify(drops)}`);
+  }
+
+  // fetch(): pagination by ?page=N, stop on a short page.
+  const mk = (i) => ({ title: `Role ${i}`, absoluteJobUrl: `https://thehub.io/jobs/x${i}`, company: { name: `Co ${i}` }, location: { address: 'Copenhagen, Denmark' }, publishedAt: '2026-06-02T00:00:00.000Z' });
+  const hubPage1 = { docs: Array.from({ length: 15 }, (_, i) => mk(i)), page: 1, pages: 3, total: 33, limit: 15 };
+  const hubPage2 = { docs: [mk(15), mk(16), { title: '', absoluteJobUrl: 'https://thehub.io/jobs/bad' }], page: 2, pages: 3, limit: 15 }; // short → stop; 1 drop
+  const requested = [];
+  const pagedFetch = async (url, opts) => {
+    requested.push({ url, redirect: opts?.redirect });
+    const page = Number(new URL(url).searchParams.get('page'));
+    return page === 1 ? hubPage1 : hubPage2;
+  };
+  const paged = await thehub.fetch({ name: 'The Hub' }, { fetchJson: pagedFetch });
+
+  if (requested.length === 2
+      && requested[0].url === 'https://thehub.io/api/jobs?page=1'
+      && requested[1].url === 'https://thehub.io/api/jobs?page=2') {
+    pass('thehub.fetch() builds ?page=N URLs and stops after the short page');
+  } else {
+    fail(`thehub.fetch() requested = ${JSON.stringify(requested.map(r => r.url))}`);
+  }
+
+  if (requested.every(r => r.redirect === 'error')) pass('thehub.fetch() passes redirect:"error" on every page (SSRF guard)');
+  else fail(`thehub.fetch() redirect opts = ${JSON.stringify(requested.map(r => r.redirect))}`);
+
+  if (paged.length === 17) pass('thehub.fetch() aggregates valid jobs across pages (15 + 2, dropping the empty-title row)');
+  else fail(`thehub.fetch() returned ${paged.length} jobs (expected 17)`);
+
+  // Stops at the reported total pages even when every page is full.
+  const fullReq = [];
+  const fullPage = (page) => ({ docs: Array.from({ length: 15 }, (_, i) => mk(page * 100 + i)), page, pages: 2, limit: 15 });
+  await thehub.fetch(
+    { name: 'The Hub', max_pages: 10 },
+    { fetchJson: async (url) => { const p = Number(new URL(url).searchParams.get('page')); fullReq.push(p); return fullPage(p); } },
+  );
+  if (fullReq.length === 2 && fullReq[0] === 1 && fullReq[1] === 2) {
+    pass('thehub.fetch() stops at the reported total pages (pages:2) even with a higher max_pages');
+  } else {
+    fail(`thehub.fetch() pages-stop requested ${JSON.stringify(fullReq)}`);
+  }
+
+  // max_pages cap: only the first page is requested.
+  const capReq = [];
+  await thehub.fetch(
+    { name: 'The Hub', max_pages: 1 },
+    { fetchJson: async (url) => { capReq.push(url); return { docs: Array.from({ length: 15 }, (_, i) => mk(i)), page: 1, pages: 67, limit: 15 }; } },
+  );
+  if (capReq.length === 1 && capReq[0] === 'https://thehub.io/api/jobs?page=1') {
+    pass('thehub.fetch() honors max_pages (stops at the cap even on a full page)');
+  } else {
+    fail(`thehub.fetch() max_pages:1 requested ${JSON.stringify(capReq)}`);
+  }
+
+  // unexpected API response → throws.
+  let badThrew = false;
+  try {
+    await thehub.fetch({ name: 'X' }, { fetchJson: async () => ({ wrong: true }) });
+  } catch (e) {
+    badThrew = /unexpected API response/.test(e.message);
+  }
+  if (badThrew) pass('thehub.fetch() throws on unexpected API response shape');
+  else fail('thehub.fetch() should throw when the docs array is absent');
+
+} catch (e) {
+  fail(`thehub provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What

Adds a **The Hub** board-wide aggregator provider (`providers/thehub.mjs`). The Hub (Nordic/EU startup jobs) publishes a public, zero-auth JSON feed at `https://thehub.io/api/jobs`, so this mirrors `providers/remotive.mjs` with bounded pagination like `providers/arbeitnow.mjs`.

- Reads `?page=N` (15 jobs/page, 1-indexed) and normalizes each `docs[]` item to `{ title, url, company, location }` (+ optional `postedAt`):
  - `title` from `title`.
  - `url` from `absoluteJobUrl`, **host-locked to `thehub.io`** (the per-posting `link` field is an external apply URL — deliberately not used). Off-host/non-https URLs drop the posting; `url` is the dedup key.
  - `company` from `company.name`, falling back to the entry name, then `"The Hub"`.
  - `location` from `location.address` (else `location.locality` / `location.country`), with `"Remote"` appended when `isRemote`.
  - `postedAt` from `publishedAt` (else `createdAt`) ISO date → ms.
- Paginates up to `max_pages` (default 3, cap 67), stopping early on a short page **or** when `page >= pages` (the response reports `pages`/`total`). Host-locked to `thehub.io` with `redirect:'error'` on every request (SSRF guard).

## Files

- `providers/thehub.mjs` — new provider.
- `test-all.mjs` — new test block (section 36): normalize mapping, company + date fallbacks, host-lock + drops, pagination (short-stop, pages-stop, `max_pages` cap), SSRF guard, bad-response throw.
- `docs/SUPPORTED_JOB_BOARDS.md` — register The Hub (the doc requires this in the same PR).
- `templates/portals.example.yml` — add a The Hub example with `max_pages`.

## Testing

- `node test-all.mjs` → **556 passed, 0 failed** (12 new assertions).
- Live end-to-end against the real API returned 30 correctly-normalized jobs across 2 pages (all with `postedAt`; real company names).

Closes #1304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for “The Hub” as a new job board provider, including paginated job fetching and normalization of job fields (title, company, location, and posted date).

* **Documentation**
  * Documented The Hub’s API details, pagination/max-pages behavior, and when filtering is applied.
  * Updated the portal configuration example to include The Hub.

* **Tests**
  * Added automated coverage for provider identity, job normalization rules and input hardening, pagination stop/max-page capping, and handling unexpected API response shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->