### PR TITLE
feat(providers): add Landing.jobs provider (public zero-auth job-board API)

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -15,6 +15,7 @@ are shared helpers and are not loaded as providers.
 | Greenhouse | API | Handles explicit `api:` URLs and auto-detects public Greenhouse board URLs for the boards API. |
 | IBM Careers | API | Posts to IBM's public careers search API and supports optional IBM facet filters in the portal entry. |
 | Jobstreet / SEEK | API | Uses the public SEEK chalice-search JSON API for Jobstreet and SEEK sites. Configure explicitly with `provider: jobstreet`. |
+| Landing.jobs | API | Reads the board-wide `https://landing.jobs/api/v1/jobs` JSON feed (tech, Europe). Configure with `provider: landingjobs`; company is derived from the posting URL slug. |
 | Lever | API | Auto-detects `https://jobs.lever.co/<slug>` boards and uses Lever's public postings endpoint. |
 | Local parser | Parser | Runs an in-repo parser command from `portals.yml`. Use this for stable SSR or HTML pages that need a custom extractor. |
 | Personio | RSS | Auto-detects `<slug>.jobs.personio.de` or `.com` hosts and parses the public XML jobs feed. |

--- a/providers/landingjobs.mjs
+++ b/providers/landingjobs.mjs
@@ -1,0 +1,130 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Landing.jobs provider — board-wide aggregator feed (tech, Europe-focused):
+// https://landing.jobs/api/v1/jobs
+// Response shape: a JSON ARRAY of
+//   { id, title, url, locations: [{ city, country_code }], remote, published_at,
+//     created_at, type, tags, gross_salary_low, gross_salary_high, ... }
+//
+// NOTE: the v1 feed carries no company-name field — the employer slug only
+// appears in the posting URL path (`https://landing.jobs/at/<slug>/<job>`), so
+// `company` is derived best-effort from that slug (humanized) and falls back to
+// the portal entry name. The whole active set is returned in one call.
+//
+// Wire in via a `job_boards:` entry with `provider: landingjobs`.
+
+const FEED_URL = 'https://landing.jobs/api/v1/jobs';
+const TRUSTED_HOST = 'landing.jobs';
+
+/** @param {string} url */
+function assertLandingUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`landingjobs: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`landingjobs: URL must use HTTPS: ${url}`);
+  if (parsed.hostname !== TRUSTED_HOST) {
+    throw new Error(`landingjobs: untrusted hostname "${parsed.hostname}" — must be ${TRUSTED_HOST}`);
+  }
+  return url;
+}
+
+// NaN-safe Date.parse.
+function toEpochMs(value) {
+  if (typeof value !== 'string' || !value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Derive a best-effort company name from a Landing.jobs posting URL.
+ * Posting URLs are `https://landing.jobs/at/<slug>/<job>`; the `<slug>` is
+ * humanized (hyphens/underscores → spaces, title-cased). Returns '' when the
+ * URL is not the expected `/at/<slug>/…` shape. Exported for unit tests.
+ * @param {string} url
+ */
+export function companyFromUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return '';
+  }
+  const segs = parsed.pathname.split('/').filter(Boolean);
+  if (segs[0] !== 'at' || !segs[1]) return '';
+  return segs[1]
+    .replace(/[-_]+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+/**
+ * Normalize a single Landing.jobs job. Exported for unit tests.
+ *
+ * Field mapping → the normalized Job shape:
+ *   - title:    `title`, trimmed (postings without one are dropped).
+ *   - url:      `url` — host-locked to `landing.jobs` (an off-host or non-https
+ *               URL drops the posting). It is the dedup key and is display-only.
+ *   - company:  derived from the URL slug (see companyFromUrl), falling back to
+ *               the portal entry name, then "Landing.jobs".
+ *   - location: first `locations[]` entry as "city, country_code"; "Remote" is
+ *               appended when `remote` is true.
+ *   - postedAt: `published_at` (else `created_at`) ISO date → epoch ms.
+ *
+ * @param {any} j
+ * @param {string} [fallbackCompany]
+ * @returns {{ title: string, url: string, company: string, location: string, postedAt?: number } | null}
+ */
+export function normalizeLandingJob(j, fallbackCompany) {
+  if (!j || typeof j !== 'object') return null;
+
+  const title = typeof j.title === 'string' ? j.title.trim() : '';
+  if (!title) return null;
+
+  let url = '';
+  const rawUrl = typeof j.url === 'string' ? j.url.trim() : '';
+  if (rawUrl) {
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol === 'https:' && parsed.hostname === TRUSTED_HOST) url = parsed.href;
+    } catch {
+      // malformed URL → leave url = '' → dropped below
+    }
+  }
+  if (!url) return null;
+
+  const company = companyFromUrl(url) || fallbackCompany || 'Landing.jobs';
+
+  const first = Array.isArray(j.locations) && j.locations[0] && typeof j.locations[0] === 'object' ? j.locations[0] : {};
+  const city = typeof first.city === 'string' ? first.city.trim() : '';
+  const country = typeof first.country_code === 'string' ? first.country_code.trim() : '';
+  const base = [city, country].filter(Boolean).join(', ');
+  const location = [base, j.remote === true ? 'Remote' : ''].filter(Boolean).join(', ');
+
+  /** @type {{ title: string, url: string, company: string, location: string, postedAt?: number }} */
+  const job = { title, url, company, location };
+  const postedAt = toEpochMs(j.published_at) ?? toEpochMs(j.created_at);
+  if (postedAt !== undefined) job.postedAt = postedAt;
+  return job;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'landingjobs',
+
+  async fetch(entry, ctx) {
+    assertLandingUrl(FEED_URL);
+    // redirect:'error' prevents SSRF via server-side redirects
+    const json = await ctx.fetchJson(FEED_URL, { redirect: 'error' });
+    if (!Array.isArray(json)) {
+      throw new Error(
+        `landingjobs: unexpected API response — expected a JSON array, got ${json === null ? 'null' : typeof json}`,
+      );
+    }
+    const fallbackCompany = entry?.name;
+    return json.map(j => normalizeLandingJob(j, fallbackCompany)).filter(Boolean);
+  },
+};

--- a/providers/landingjobs.mjs
+++ b/providers/landingjobs.mjs
@@ -96,7 +96,9 @@ export function normalizeLandingJob(j, fallbackCompany) {
   }
   if (!url) return null;
 
-  const company = companyFromUrl(url) || fallbackCompany || 'Landing.jobs';
+  const company =
+    companyFromUrl(url) ||
+    (typeof fallbackCompany === 'string' && fallbackCompany.trim() ? fallbackCompany.trim() : 'Landing.jobs');
 
   const first = Array.isArray(j.locations) && j.locations[0] && typeof j.locations[0] === 'object' ? j.locations[0] : {};
   const city = typeof first.city === 'string' ? first.city.trim() : '';

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -555,6 +555,10 @@ search_queries:
 # -- Remote-job feeds (no careers_url, no extra fields) --
 # title_filter / location_filter defined above still apply.
 #
+# - name: Landing.jobs                    # tech board, Europe-focused
+#   provider: landingjobs
+#   enabled: true
+#
 # - name: RemoteOK
 #   provider: remoteok
 #   enabled: true

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5405,6 +5405,118 @@ try {
   fail(`weworkremotely provider tests crashed: ${e.message}`);
 }
 
+// ── 37. Provider — landingjobs ──────────────────────────────────
+console.log('\n37. Provider — landingjobs');
+
+try {
+  const ljModule = await import(pathToFileURL(join(ROOT, 'providers/landingjobs.mjs')).href);
+  const landingjobs = ljModule.default;
+  const { normalizeLandingJob, companyFromUrl } = ljModule;
+
+  if (landingjobs.id === 'landingjobs') pass('landingjobs.id is "landingjobs"');
+  else fail(`landingjobs.id is ${JSON.stringify(landingjobs.id)}`);
+
+  // companyFromUrl — humanizes the /at/<slug>/ segment; '' for other shapes.
+  if (companyFromUrl('https://landing.jobs/at/damia-group-portugal/some-job') === 'Damia Group Portugal'
+      && companyFromUrl('https://landing.jobs/at/inscale/x') === 'Inscale'
+      && companyFromUrl('https://landing.jobs/jobs/123') === ''
+      && companyFromUrl('not a url') === '') {
+    pass('companyFromUrl humanizes the /at/<slug>/ segment and returns "" for other shapes');
+  } else {
+    fail(`companyFromUrl = ${JSON.stringify([
+      companyFromUrl('https://landing.jobs/at/damia-group-portugal/some-job'),
+      companyFromUrl('https://landing.jobs/jobs/123'),
+    ])}`);
+  }
+
+  // normalizeLandingJob — full mapping.
+  const full = normalizeLandingJob(
+    { title: '  Senior Java Dev  ', url: 'https://landing.jobs/at/inscale/senior-java-dev', locations: [{ city: 'Lisbon', country_code: 'PT' }], remote: false, published_at: '2025-02-26T09:38:38.127Z' },
+    'Fallback',
+  );
+  if (full && full.title === 'Senior Java Dev' && full.url === 'https://landing.jobs/at/inscale/senior-java-dev'
+      && full.company === 'Inscale' && full.location === 'Lisbon, PT'
+      && full.postedAt === Date.parse('2025-02-26T09:38:38.127Z')) {
+    pass('normalizeLandingJob maps title/url, derives company from slug, builds location, parses published_at');
+  } else {
+    fail(`normalizeLandingJob full row = ${JSON.stringify(full)}`);
+  }
+
+  // remote:true appends "Remote".
+  const remoteJob = normalizeLandingJob({ title: 'R', url: 'https://landing.jobs/at/acme/r', locations: [{ city: 'Berlin', country_code: 'DE' }], remote: true });
+  if (remoteJob?.location === 'Berlin, DE, Remote') pass('normalizeLandingJob appends "Remote" when remote is true');
+  else fail(`normalizeLandingJob remote location = ${JSON.stringify(remoteJob?.location)}`);
+
+  // company fallback: url is landing.jobs but not /at/<slug>/ → entry name, then "Landing.jobs".
+  const coEntry = normalizeLandingJob({ title: 'T', url: 'https://landing.jobs/jobs/99' }, 'Entry Name');
+  const coDefault = normalizeLandingJob({ title: 'T', url: 'https://landing.jobs/jobs/100' });
+  if (coEntry?.company === 'Entry Name' && coDefault?.company === 'Landing.jobs') {
+    pass('normalizeLandingJob falls back company → entry name → "Landing.jobs" when the slug is absent');
+  } else {
+    fail(`normalizeLandingJob company fallbacks = ${JSON.stringify({ a: coEntry?.company, b: coDefault?.company })}`);
+  }
+
+  // postedAt falls back to created_at; omitted when both absent.
+  const fromCreated = normalizeLandingJob({ title: 'T', url: 'https://landing.jobs/at/acme/cd', created_at: '2025-02-26T08:53:02.254Z' });
+  const noDate = normalizeLandingJob({ title: 'T', url: 'https://landing.jobs/at/acme/nd' });
+  if (fromCreated?.postedAt === Date.parse('2025-02-26T08:53:02.254Z') && noDate && !('postedAt' in noDate)) {
+    pass('normalizeLandingJob falls back to created_at and omits postedAt when both dates are absent');
+  } else {
+    fail(`normalizeLandingJob date handling = ${JSON.stringify({ created: fromCreated?.postedAt, none: noDate })}`);
+  }
+
+  // host-lock + drops: off-host, non-https, missing url, empty title, non-object.
+  const drops = [
+    normalizeLandingJob({ title: 'Off host', url: 'https://evil.example/at/acme/x' }),
+    normalizeLandingJob({ title: 'Insecure', url: 'http://landing.jobs/at/acme/x' }),
+    normalizeLandingJob({ title: 'No URL' }),
+    normalizeLandingJob({ title: '', url: 'https://landing.jobs/at/acme/x' }),
+    normalizeLandingJob(null),
+  ];
+  if (drops.every(r => r === null)) {
+    pass('normalizeLandingJob host-locks url to landing.jobs and drops off-host/non-https/no-url/empty-title/non-object');
+  } else {
+    fail(`normalizeLandingJob drops = ${JSON.stringify(drops)}`);
+  }
+
+  // fetch(): single call to the feed URL, normalized, with the SSRF guard.
+  const sample = [
+    { title: 'Role A', url: 'https://landing.jobs/at/acme/role-a', locations: [{ city: 'Porto', country_code: 'PT' }], remote: false, published_at: '2025-02-26T09:38:38.127Z' },
+    { title: '', url: 'https://landing.jobs/at/acme/bad' }, // dropped: empty title
+  ];
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const fetched = await landingjobs.fetch(
+    { name: 'Landing.jobs' },
+    { fetchJson: async (url, opts) => { capturedUrl = url; capturedOpts = opts; return sample; } },
+  );
+
+  if (capturedUrl === 'https://landing.jobs/api/v1/jobs') pass('landingjobs.fetch() requests the v1 feed URL');
+  else fail(`landingjobs.fetch() requested ${JSON.stringify(capturedUrl)}`);
+
+  if (capturedOpts && capturedOpts.redirect === 'error') pass('landingjobs.fetch() passes redirect:"error" (SSRF guard)');
+  else fail(`landingjobs.fetch() should pass redirect:"error", got: ${JSON.stringify(capturedOpts)}`);
+
+  if (fetched.length === 1 && fetched[0]?.company === 'Acme') {
+    pass('landingjobs.fetch() returns normalized jobs (drops the empty-title row, derives company)');
+  } else {
+    fail(`landingjobs.fetch() returned ${fetched.length} jobs, row 0 = ${JSON.stringify(fetched[0])}`);
+  }
+
+  // unexpected (non-array) response → throws.
+  let badThrew = false;
+  try {
+    await landingjobs.fetch({ name: 'X' }, { fetchJson: async () => ({ jobs: [] }) });
+  } catch (e) {
+    badThrew = /unexpected API response/.test(e.message);
+  }
+  if (badThrew) pass('landingjobs.fetch() throws on a non-array API response');
+  else fail('landingjobs.fetch() should throw when the response is not an array');
+
+} catch (e) {
+  fail(`landingjobs provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5450,10 +5450,11 @@ try {
   // company fallback: url is landing.jobs but not /at/<slug>/ → entry name, then "Landing.jobs".
   const coEntry = normalizeLandingJob({ title: 'T', url: 'https://landing.jobs/jobs/99' }, 'Entry Name');
   const coDefault = normalizeLandingJob({ title: 'T', url: 'https://landing.jobs/jobs/100' });
-  if (coEntry?.company === 'Entry Name' && coDefault?.company === 'Landing.jobs') {
-    pass('normalizeLandingJob falls back company → entry name → "Landing.jobs" when the slug is absent');
+  const coBlank = normalizeLandingJob({ title: 'T', url: 'https://landing.jobs/jobs/101' }, '   '); // whitespace-only → "Landing.jobs"
+  if (coEntry?.company === 'Entry Name' && coDefault?.company === 'Landing.jobs' && coBlank?.company === 'Landing.jobs') {
+    pass('normalizeLandingJob falls back company → entry name → "Landing.jobs" (whitespace-only entry name ignored)');
   } else {
-    fail(`normalizeLandingJob company fallbacks = ${JSON.stringify({ a: coEntry?.company, b: coDefault?.company })}`);
+    fail(`normalizeLandingJob company fallbacks = ${JSON.stringify({ a: coEntry?.company, b: coDefault?.company, c: coBlank?.company })}`);
   }
 
   // postedAt falls back to created_at; omitted when both absent.


### PR DESCRIPTION
## What

Adds a **Landing.jobs** board-wide aggregator provider (`providers/landingjobs.mjs`). Landing.jobs (tech, Europe-focused) publishes a public, zero-auth JSON feed at `https://landing.jobs/api/v1/jobs` (the active set in one array), so this mirrors `providers/remotive.mjs`.

- Normalizes each item to `{ title, url, company, location }` (+ optional `postedAt`):
  - `title` from `title`; `url` from `url`, **host-locked to `landing.jobs`** (off-host/non-https dropped; `url` is the dedup key).
  - `company` is **derived from the posting URL slug** — postings are `https://landing.jobs/at/<slug>/<job>` and the v1 feed exposes no company-name field, so `<slug>` is humanized (hyphens → spaces, title-cased); falls back to the entry name, then `"Landing.jobs"`.
  - `location` from the first `locations[]` entry as `"city, country_code"`, with `"Remote"` appended when `remote`.
  - `postedAt` from `published_at` (else `created_at`) ISO date → ms.
- Single call, host-locked to `landing.jobs` with `redirect:'error'` (SSRF guard).

## Files

- `providers/landingjobs.mjs` — new provider (exports `normalizeLandingJob` + `companyFromUrl`).
- `test-all.mjs` — new test block (section 37): `companyFromUrl` humanization, normalize mapping, company + date fallbacks, remote location, host-lock + drops, fetch wiring + SSRF guard, non-array throw.
- `docs/SUPPORTED_JOB_BOARDS.md` — register Landing.jobs (the doc requires this in the same PR).
- `templates/portals.example.yml` — add a Landing.jobs example.

## Testing

- `node test-all.mjs` → **555 passed, 0 failed** (11 new assertions).
- Live end-to-end against the real API returned 44 correctly-normalized jobs (all with `postedAt`; company derived e.g. "Inscale", "Damia Group Portugal").

## Note

The v1 feed has no company-name field, so `company` is a best-effort derivation from the URL slug. If you'd prefer `company` left empty (populated downstream) instead, happy to change it.

Closes #1306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Landing.jobs as a supported job board, including job normalization for title, company, location, and posting date.
* **Documentation**
  * Updated supported job boards documentation to describe the Landing.jobs feed source and company/location derivation.
* **Configuration**
  * Added a commented-out Landing.jobs example in the remote-job feeds template.
* **Bug Fixes**
  * Improved feed handling by validating HTTPS/trusted URLs and safely dropping malformed listings.
* **Tests**
  * Expanded unit tests for Landing.jobs URL parsing, normalization, and feed loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->