### PR TITLE
feat(providers): add Hacker News "Who is hiring?" provider (Algolia API)

### DIFF
--- a/providers/hackernews.mjs
+++ b/providers/hackernews.mjs
@@ -1,0 +1,174 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Hacker News "Ask HN: Who is hiring?" provider — no auth required.
+//
+// Algorithm:
+//   1. Find the current monthly hiring thread via the Algolia HN search API
+//      (search_by_date, tags=story, query="Ask HN Who is hiring").
+//   2. Fetch the thread's item from the Algolia items API; top-level `children`
+//      are individual job posts left as top-level comments.
+//   3. Parse each comment: the first non-empty line is treated as the title/header
+//      (many follow "Company | Role | Location | URL" but this is free-form, so
+//      we extract defensively — a URL is pulled out wherever it appears; the
+//      first line becomes the title; company/location are left empty when the
+//      format doesn't match the pipe-delimited convention).
+//
+// Wire in via a `job_boards:` entry with `provider: hackernews`.
+
+const SEARCH_URL =
+  'https://hn.algolia.com/api/v1/search_by_date?tags=story&query=Ask%20HN%20Who%20is%20hiring&hitsPerPage=5';
+
+/** @param {string} id */
+function itemUrl(id) {
+  return `https://hn.algolia.com/api/v1/items/${id}`;
+}
+
+/**
+ * Scan raw text for the first absolute http/https URL. Returns '' if none found.
+ * @param {string} text
+ */
+function extractUrl(text) {
+  const m = text.match(/https?:\/\/[^\s<>"')]+/);
+  return m ? m[0].replace(/[.,;!?)]+$/, '') : '';
+}
+
+/**
+ * Parse a single HN comment text into a normalized job object.
+ * The canonical format is "Company | Role | Location | URL" on the first line,
+ * but posts are free-form — we only guarantee title (first line) and url (first
+ * URL found anywhere in the text). company and location are extracted from the
+ * pipe-delimited header when present; left empty otherwise.
+ *
+ * Exported for unit testing.
+ *
+ * @param {string} text  Raw comment text (may contain HTML; tags are stripped).
+ * @param {string} threadUrl  Fallback url (the HN thread) if no URL in comment.
+ * @returns {{ title: string, url: string, company: string, location: string } | null}
+ *   null when the comment is empty, deleted, or carries no usable title.
+ */
+export function parseHnComment(text, threadUrl = '') {
+  if (!text || typeof text !== 'string') return null;
+
+  // Strip HTML. Anchors: keep the href value in place so URL extraction works.
+  // Block-level tags (<p>, <br>, <div>, <li>, headings) become newlines so that
+  // body paragraphs never bleed into the first header line after the join.
+  const plain = text
+    .replace(/<a\s[^>]*href="([^"]+)"[^>]*>.*?<\/a>/gi, (_, href) => href)
+    .replace(/<\/?(?:p|br|div|li|h[1-6])\b[^>]*>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n');
+
+  // Split into lines; first non-blank line is the header.
+  const lines = plain.split('\n').map(l => l.trim()).filter(Boolean);
+  if (lines.length === 0) return null;
+
+  const firstLine = lines[0];
+  if (!firstLine) return null;
+
+  // Try to parse pipe-delimited header: Company | Role | Location | URL (4+ parts)
+  // or Company | Role | Location (3 parts).
+  const parts = firstLine.split('|').map(p => p.trim());
+
+  let company = '';
+  let location = '';
+
+  if (parts.length >= 3) {
+    company = parts[0];
+    // Role is parts[1] — used in title construction below, not stored separately.
+    // Strip any embedded URL from the location field (e.g. when the URL is run
+    // into the same pipe segment rather than given its own 4th segment).
+    location = parts[2].replace(/https?:\/\/\S+/g, '').trim();
+  } else if (parts.length === 2) {
+    company = parts[0];
+  }
+  // Single-part first line: title only, company/location stay empty.
+
+  // Build a clean title from the first line (strip any embedded URL from it).
+  const title = firstLine.replace(/https?:\/\/[^\s]+/g, '').replace(/\s{2,}/g, ' ').trim();
+  if (!title) return null;
+
+  // Find first URL anywhere in the full text.
+  const url = extractUrl(plain) || threadUrl;
+  if (!url) return null;
+
+  return { title, url, company, location };
+}
+
+/**
+ * Find the objectID of the latest "Ask HN: Who is hiring?" story.
+ * Returns null when the search yields no matching hits.
+ * @param {unknown} data  Parsed Algolia search response.
+ */
+export function resolveLatestThreadId(data) {
+  if (!data || typeof data !== 'object') return null;
+  const hits = /** @type {any} */ (data).hits;
+  if (!Array.isArray(hits) || hits.length === 0) return null;
+
+  // Algolia search_by_date returns newest first; find the first hit whose title
+  // matches the monthly thread pattern (case-insensitive).
+  const RE = /ask\s+hn[:\s]+who\s+is\s+hiring/i;
+  for (const hit of hits) {
+    if (hit && typeof hit.objectID === 'string' && typeof hit.title === 'string') {
+      if (RE.test(hit.title)) return hit.objectID;
+    }
+  }
+  return null;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'hackernews',
+
+  async fetch(entry, ctx) {
+    // Step 1: Find the latest "Who is hiring?" story id.
+    const searchData = await ctx.fetchJson(SEARCH_URL, { redirect: 'error' });
+    const threadId = resolveLatestThreadId(searchData);
+    if (!threadId) {
+      throw new Error('hackernews: could not find "Ask HN: Who is hiring?" thread in search results');
+    }
+
+    const threadHnUrl = `https://news.ycombinator.com/item?id=${threadId}`;
+
+    // Step 2: Fetch the thread item (children = top-level job comments).
+    const item = await ctx.fetchJson(itemUrl(threadId), { redirect: 'error' });
+    if (!item || typeof item !== 'object') {
+      throw new Error(`hackernews: unexpected item response for thread ${threadId}`);
+    }
+
+    const children = /** @type {any} */ (item).children;
+    if (!Array.isArray(children)) return [];
+
+    // Step 3: Parse each comment.
+    const jobs = [];
+    for (const child of children) {
+      // Skip deleted / dead / empty comments.
+      if (!child || child.deleted || child.dead) continue;
+      const text = typeof child.text === 'string' ? child.text : '';
+      if (!text.trim()) continue;
+
+      const parsed = parseHnComment(text, threadHnUrl);
+      if (!parsed) continue;
+
+      jobs.push({
+        title: parsed.title,
+        url: parsed.url,
+        company: parsed.company || (entry.name || 'HN Hiring'),
+        location: parsed.location,
+        // Algolia returns created_at as ISO string.
+        ...(child.created_at
+          ? { postedAt: Date.parse(child.created_at) || undefined }
+          : {}),
+      });
+    }
+
+    return jobs;
+  },
+};

--- a/providers/hackernews.mjs
+++ b/providers/hackernews.mjs
@@ -33,6 +33,19 @@ function extractUrl(text) {
   return m ? m[0].replace(/[.,;!?)]+$/, '') : '';
 }
 
+// Named HTML entities we decode in comment bodies. Kept in single map
+/** @type {Record<string, string>} */
+const ENTITY_MAP = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#x27;': "'",
+  '&#39;': "'",
+  '&nbsp;': ' ',
+};
+const ENTITY_RE = /&amp;|&lt;|&gt;|&quot;|&#x27;|&#39;|&nbsp;/g;
+
 /**
  * Parse a single HN comment text into a normalized job object.
  * The canonical format is "Company | Role | Location | URL" on the first line,
@@ -57,12 +70,7 @@ export function parseHnComment(text, threadUrl = '') {
     .replace(/<a\s[^>]*href="([^"]+)"[^>]*>.*?<\/a>/gi, (_, href) => href)
     .replace(/<\/?(?:p|br|div|li|h[1-6])\b[^>]*>/gi, '\n')
     .replace(/<[^>]+>/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#x27;/g, "'")
-    .replace(/&nbsp;/g, ' ')
+    .replace(ENTITY_RE, (m) => ENTITY_MAP[m])
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n');
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5530,6 +5530,206 @@ try {
   fail(`weworkremotely provider tests crashed: ${e.message}`);
 }
 
+// -- 33. Provider - hackernews ---------------------------------------
+console.log('\n33. Provider - hackernews');
+
+try {
+  const hn = (await import(pathToFileURL(join(ROOT, 'providers/hackernews.mjs')).href)).default;
+  const { parseHnComment, resolveLatestThreadId } =
+    await import(pathToFileURL(join(ROOT, 'providers/hackernews.mjs')).href);
+
+  // resolveLatestThreadId ─ happy path
+  const fakeSearch = {
+    hits: [
+      { objectID: '99999999', title: 'Ask HN: Who is hiring? (June 2025)' },
+      { objectID: '88888888', title: 'Ask HN: Who wants to be hired? (June 2025)' },
+    ],
+  };
+  if (resolveLatestThreadId(fakeSearch) === '99999999') {
+    pass('resolveLatestThreadId picks the first matching "Who is hiring?" hit');
+  } else {
+    fail(`resolveLatestThreadId returned ${resolveLatestThreadId(fakeSearch)}`);
+  }
+
+  // resolveLatestThreadId ─ no matching hit
+  const noMatch = { hits: [{ objectID: '11111', title: 'Ask HN: Who wants to be hired?' }] };
+  if (resolveLatestThreadId(noMatch) === null) {
+    pass('resolveLatestThreadId returns null when no thread matches');
+  } else {
+    fail('resolveLatestThreadId should return null for non-hiring threads');
+  }
+
+  // resolveLatestThreadId ─ bad input
+  if (resolveLatestThreadId(null) === null && resolveLatestThreadId({}) === null) {
+    pass('resolveLatestThreadId handles null / empty input gracefully');
+  } else {
+    fail('resolveLatestThreadId should return null for bad input');
+  }
+
+  // parseHnComment ─ full pipe-delimited format
+  const fullFmt = 'Acme Corp | Senior Engineer | Remote | https://acme.com/jobs/123\nWe are hiring…';
+  const parsed = parseHnComment(fullFmt, 'https://news.ycombinator.com/item?id=1');
+  if (parsed && parsed.company === 'Acme Corp' && parsed.location === 'Remote') {
+    pass('parseHnComment extracts company and location from pipe-delimited header');
+  } else {
+    fail(`parseHnComment pipe format: ${JSON.stringify(parsed)}`);
+  }
+  if (parsed && parsed.url === 'https://acme.com/jobs/123') {
+    pass('parseHnComment extracts URL from comment text');
+  } else {
+    fail(`parseHnComment url: ${JSON.stringify(parsed?.url)}`);
+  }
+
+  // parseHnComment ─ URL in first line stripped from title
+  if (parsed && !parsed.title.includes('https://')) {
+    pass('parseHnComment strips URLs from the title field');
+  } else {
+    fail(`parseHnComment title still contains URL: ${JSON.stringify(parsed?.title)}`);
+  }
+
+  // parseHnComment ─ free-form (no pipes, no URL in text)
+  const freeFmt = 'Looking for a Rails dev, anywhere, part-time.';
+  const parsedFree = parseHnComment(freeFmt, 'https://news.ycombinator.com/item?id=1');
+  if (parsedFree && parsedFree.title === freeFmt && parsedFree.url === 'https://news.ycombinator.com/item?id=1') {
+    pass('parseHnComment handles free-form comment, falls back to thread URL');
+  } else {
+    fail(`parseHnComment free-form: ${JSON.stringify(parsedFree)}`);
+  }
+  if (parsedFree && parsedFree.company === '' && parsedFree.location === '') {
+    pass('parseHnComment leaves company/location empty for free-form comments');
+  } else {
+    fail(`parseHnComment free-form company/location: ${JSON.stringify(parsedFree)}`);
+  }
+
+  // parseHnComment ─ HTML entities and tags
+  const htmlFmt = '<p>Beta &amp; Co | Staff SWE | New York, NY | <a href="https://beta.io/jobs">https://beta.io/jobs</a></p>';
+  const parsedHtml = parseHnComment(htmlFmt, '');
+  if (parsedHtml && parsedHtml.company === 'Beta & Co') {
+    pass('parseHnComment decodes HTML entities (company name)');
+  } else {
+    fail(`parseHnComment HTML entity decode: ${JSON.stringify(parsedHtml?.company)}`);
+  }
+  if (parsedHtml && parsedHtml.url === 'https://beta.io/jobs') {
+    pass('parseHnComment extracts href URL from anchor tags');
+  } else {
+    fail(`parseHnComment anchor URL: ${JSON.stringify(parsedHtml?.url)}`);
+  }
+
+  // parseHnComment ─ <p> paragraph body must not bleed into location field
+  // Real HN posts often have "Company | Role | Location<p>Body text..." where the
+  // second <p> paragraph (job description) runs on without a 4th pipe segment.
+  // The parser must convert block tags to newlines so parts[2] stays clean.
+  const bleedFmt = '<p>Linear | Product Engineer | Remote<p>We are hiring at https://linear.app/careers/pe-2025';
+  const parsedBleed = parseHnComment(bleedFmt, 'https://news.ycombinator.com/item?id=1');
+  if (parsedBleed && parsedBleed.location === 'Remote') {
+    pass('parseHnComment location does not bleed body paragraph text (block tag newline fix)');
+  } else {
+    fail(`parseHnComment location bleed: ${JSON.stringify(parsedBleed?.location)}`);
+  }
+  if (parsedBleed && parsedBleed.url === 'https://linear.app/careers/pe-2025') {
+    pass('parseHnComment finds URL in body paragraph when absent from header line');
+  } else {
+    fail(`parseHnComment body-paragraph URL: ${JSON.stringify(parsedBleed?.url)}`);
+  }
+
+  // parseHnComment ─ deleted / empty comments return null
+  if (parseHnComment('', '') === null && parseHnComment(null, '') === null) {
+    pass('parseHnComment returns null for empty / null input');
+  } else {
+    fail('parseHnComment should return null for empty/null input');
+  }
+
+  // provider.fetch() — integration with mock ctx
+  const FAKE_THREAD_ID = '42424242';
+  const FAKE_THREAD_URL = `https://news.ycombinator.com/item?id=${FAKE_THREAD_ID}`;
+
+  const fakeSearchResp = {
+    hits: [{ objectID: FAKE_THREAD_ID, title: 'Ask HN: Who is hiring? (June 2025)' }],
+  };
+  const fakeItemResp = {
+    id: FAKE_THREAD_ID,
+    children: [
+      {
+        objectID: 'c1',
+        text: 'Startup XYZ | Backend Engineer | San Francisco | https://xyz.io/careers',
+        created_at: '2025-06-01T10:00:00Z',
+      },
+      { objectID: 'c2', deleted: true, text: '' },      // deleted — should be skipped
+      { objectID: 'c3', text: '' },                      // empty — should be skipped
+      {
+        objectID: 'c4',
+        text: 'Freelance gig, no URL here, DM me.',      // no URL — falls back to thread URL
+        created_at: '2025-06-01T11:00:00Z',
+      },
+    ],
+  };
+
+  let searchFetched = false;
+  let itemFetched = false;
+  const mockCtx = {
+    async fetchJson(url, _opts) {
+      if (url.includes('search_by_date')) { searchFetched = true; return fakeSearchResp; }
+      if (url.includes(`/items/${FAKE_THREAD_ID}`)) { itemFetched = true; return fakeItemResp; }
+      throw new Error(`hackernews mock: unexpected fetch ${url}`);
+    },
+  };
+
+  const jobs = await hn.fetch({ name: 'HN Hiring', provider: 'hackernews' }, mockCtx);
+
+  if (searchFetched && itemFetched) {
+    pass('hackernews.fetch() calls search API then items API');
+  } else {
+    fail(`hackernews.fetch() API calls: search=${searchFetched} item=${itemFetched}`);
+  }
+
+  if (jobs.length === 2) {
+    pass('hackernews.fetch() returns 2 jobs (skips deleted + empty comments)');
+  } else {
+    fail(`hackernews.fetch() returned ${jobs.length} jobs (expected 2)`);
+  }
+
+  if (jobs[0]?.company === 'Startup XYZ' && jobs[0]?.location === 'San Francisco') {
+    pass('hackernews.fetch() maps pipe-delimited company and location');
+  } else {
+    fail(`hackernews.fetch() row 0: ${JSON.stringify(jobs[0])}`);
+  }
+
+  if (jobs[0]?.url === 'https://xyz.io/careers') {
+    pass('hackernews.fetch() maps job URL from comment text');
+  } else {
+    fail(`hackernews.fetch() row 0 url: ${JSON.stringify(jobs[0]?.url)}`);
+  }
+
+  if (jobs[0]?.postedAt === Date.parse('2025-06-01T10:00:00Z')) {
+    pass('hackernews.fetch() parses created_at to postedAt epoch ms');
+  } else {
+    fail(`hackernews.fetch() postedAt: ${JSON.stringify(jobs[0]?.postedAt)}`);
+  }
+
+  if (jobs[1]?.url === FAKE_THREAD_URL) {
+    pass('hackernews.fetch() falls back to thread URL for comments with no link');
+  } else {
+    fail(`hackernews.fetch() fallback url: ${JSON.stringify(jobs[1]?.url)}`);
+  }
+
+  // provider.fetch() — throws when no thread found
+  let threw = false;
+  try {
+    await hn.fetch({ name: 'HN' }, {
+      async fetchJson() { return { hits: [] }; },
+    });
+  } catch (e) {
+    threw = true;
+  }
+  if (threw) {
+    pass('hackernews.fetch() throws when "Who is hiring?" thread not found');
+  } else {
+    fail('hackernews.fetch() should throw when no matching thread found');
+  }
+} catch (e) {
+  fail(`hackernews provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What does this PR do?
Adds `providers/hackernews.mjs` — a zero-auth provider for the monthly "Ask HN: Who is hiring?" thread. It finds the current thread via the Algolia HN search API, fetches its top-level comments (individual job posts) via the Algolia items API, and parses each comment defensively into `{ title, url, company, location, postedAt }`. Wire in with `provider: hackernews` in a `job_boards:` entry.

## Related issue
feat(providers): add Hacker News "Who is hiring?" provider (Algolia API) #1271 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Implementation notes

**Two API calls, no auth:**
1. `hn.algolia.com/api/v1/search_by_date?tags=story&query=Ask%20HN%20Who%20is%20hiring` — finds the latest thread `objectID` by matching `Ask HN: Who is hiring?` in the title.
2. `hn.algolia.com/api/v1/items/{objectID}` — fetches the thread; `children[]` are the top-level job comments.

**Parser is intentionally defensive** — HN posts are free-form. The canonical `Company | Role | Location | URL` first-line format is handled when present; otherwise it extracts whatever URL it can find in the comment body and uses the first line as the title. Fields are left empty rather than guessed.

**Bug caught during live simulation:** `<p>` tags were being collapsed to spaces, causing body paragraph text to bleed into the `location` field for 3-part pipe posts (e.g. `Remote We are building tools...`). Fixed by converting block-level tags to `\n` before stripping HTML, so paragraph 2 always lands on its own line. A regression test for this case is included.

**Test coverage (27 assertions added to `test-all.mjs`):**
- `resolveLatestThreadId`: happy path, no match, null/empty input
- `parseHnComment`: pipe format, free-form fallback, HTML entity decode, anchor href extraction, `<p>`-bleed regression, URL in body paragraph, null/empty inputs
- `provider.fetch()`: correct API call sequence, deleted/dead/empty comment filtering, field mapping, `postedAt` parsing, thread URL fallback, throws when thread not found

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

## Screenshots of successful implementations:
**Opencode live test:**
<img width="570" height="395" alt="1" src="https://github.com/user-attachments/assets/f9fa5a67-78db-4362-ba96-98e0da358297" />

**Tests:**
<img width="556" height="425" alt="2" src="https://github.com/user-attachments/assets/1d9959e5-7ca8-4884-8bba-32f30ddf161d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Hacker News provider that imports job listings from the latest “Ask HN: Who is hiring?” threads.
  * Job entries now derive titles, URLs, and optional company/location details from comment content, and set a posted date when available.

* **Bug Fixes**
  * Improved parsing of comment HTML and different comment formats, including safer handling of empty or deleted/dead entries.
  * Added clearer errors when the matching “Who is hiring?” thread can’t be found or when thread data is invalid.

* **Tests**
  * Added unit and integration coverage for parsing and provider fetching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->