### PR TITLE
fix(security): harden batch tmpfile, PDF output path, and tracker cells

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -415,7 +415,11 @@ process_offer() {
   report_num=$(reserve_report_num "$id" "$url" "$started_at" "$retries")
   local date
   date=$(date +%Y-%m-%d)
-  local jd_file="/tmp/batch-jd-${id}.txt"
+  # Use mktemp instead of a predictable /tmp path: a fixed name like
+  # /tmp/batch-jd-${id}.txt is guessable, so an attacker on a shared machine
+  # could pre-create it as a symlink and redirect or clobber the write.
+  local jd_file
+  jd_file="$(mktemp "${TMPDIR:-/tmp}/batch-jd-${id}.XXXXXX")"
 
   echo "--- Processing offer #$id: $url (report $report_num, attempt $((retries + 1)))"
 

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -251,6 +251,14 @@ async function generatePDF() {
   inputPath = resolve(inputPath);
   outputPath = resolve(outputPath);
 
+  // Path-traversal guard: keep the PDF write inside the project directory so a
+  // crafted output argument (e.g. "../../etc/cron.d/x") can't escape the repo.
+  const relOut = relative(process.cwd(), outputPath);
+  if (relOut === '' || relOut.startsWith('..') || isAbsolute(relOut)) {
+    console.error(`Refusing to write the PDF outside the project directory: ${outputPath}`);
+    process.exit(1);
+  }
+
   // Validate format
   const validFormats = ['a4', 'letter'];
   if (!validFormats.includes(format)) {

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -434,13 +434,23 @@ function parseScore(s) {
 // the detected layout once the table is read (below).
 let COLMAP = LEGACY_COLMAP;
 
+// Neutralize characters that would corrupt the applications.md table. Both this
+// file and tracker-parse.mjs read rows with a raw `line.split('|')`, so a literal
+// pipe or a newline in a free-text value (company/role/location/notes) would shift
+// every later column. Replace rather than backslash-escape: `\|` would still split
+// on the inner pipe. This is additive — normal cells are unchanged; only values
+// that would already break the table get sanitized (also keeps the web reader safe).
+function cell(v) {
+  return String(v ?? '').replace(/[\r\n]+/g, ' ').replace(/\s*\|\s*/g, ' / ').trim();
+}
+
 // Build a tracker row string matching the detected layout (with or without the
 // optional Location column) so writes round-trip through the same schema.
 function buildRow(o) {
   if (COLMAP.location != null) {
-    return `| ${o.num} | ${o.date} | ${o.company} | ${o.role} | ${o.location || '—'} | ${o.score} | ${o.status} | ${o.pdf} | ${o.report} | ${o.notes} |`;
+    return `| ${o.num} | ${o.date} | ${cell(o.company)} | ${cell(o.role)} | ${cell(o.location) || '—'} | ${o.score} | ${o.status} | ${o.pdf} | ${o.report} | ${cell(o.notes)} |`;
   }
-  return `| ${o.num} | ${o.date} | ${o.company} | ${o.role} | ${o.score} | ${o.status} | ${o.pdf} | ${o.report} | ${o.notes} |`;
+  return `| ${o.num} | ${o.date} | ${cell(o.company)} | ${cell(o.role)} | ${o.score} | ${o.status} | ${o.pdf} | ${o.report} | ${cell(o.notes)} |`;
 }
 
 /**


### PR DESCRIPTION
## What

Three small security-hardening fixes, harvested from the diagnosis in #133 (@dean985) onto current `main`.

1. **`batch/batch-runner.sh` — mktemp for the batch JD file.** The runner wrote to a predictable `/tmp/batch-jd-${id}.txt`; on a shared machine that's guessable and pre-creatable as a symlink (redirect/clobber). Now uses `mktemp "${TMPDIR:-/tmp}/batch-jd-${id}.XXXXXX"`.
2. **`generate-pdf.mjs` — path-traversal guard.** A crafted output argument (e.g. `../../etc/cron.d/x`) would `resolve()` to anywhere. Now rejects any output path that lands outside the project directory. Normal `output/` and `reports/` writes are unaffected (verified).
3. **`merge-tracker.mjs` — sanitize table cells.** Both `merge-tracker.mjs` and `tracker-parse.mjs` read rows with a raw `line.split('|')`, so a literal `|` (or a newline) in a free-text value — company/role/location/notes — would shift every later column and corrupt `applications.md`. Free-text cells are now sanitized (pipe → `/`, newline → space).

## Why harvest instead of merge #133

#133 was ~380 commits behind `main` and couldn't be rebased cleanly (5/6 of its files were heavily refactored since April), and about half of its original scope already landed via later work. These are the three fixes that are genuinely still absent. Full credit to **@dean985** for spotting them. The contentious `--permission-mode=default` change from the original is intentionally **not** included (the batch runner bypasses it on purpose for headless `-p` mode).

## Notes

- Fix #3 touches the web-facing `applications.md` writer, but it's **additive-safe**: normal cells are unchanged; only values that would already break the table get sanitized (which strictly *improves* parsing for any `|`-split reader, including the web).
- No new top-level files. `node test-all.mjs` → 727 passed, 0 failed. Path-guard and cell-sanitizer verified against allow/reject cases.

Closes #133.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when handling temporary files and PDF output paths, reducing the risk of accidental file overwrites.
  * Added safeguards so PDF generation stops if the output would be written outside the expected project folder.
  * Cleaned up table text handling so Markdown exports render correctly even when fields contain special characters or line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->