### PR TITLE
chore(gitignore): ignore common PII document filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,14 @@ batch/tracker-additions/**/*.tsv
 jds/*
 !jds/.gitkeep
 
+# Personal documents — never commit scans or copies of these (PII).
+# Catches common identity/credential filenames so they can't be staged by accident.
+*passport*
+*diploma*
+*简历*
+*学位*
+*成绩单*
+
 # Interview prep (accumulated STAR+R stories — user data)
 interview-prep/*
 !interview-prep/.gitkeep


### PR DESCRIPTION
Adds `*passport*`, `*diploma*`, and CJK `*简历*`/`*学位*`/`*成绩单*` (resume/degree/transcript) patterns to `.gitignore` so a user can't accidentally stage scans of personal identity documents.

Harvests the PII-protection intent from #859 by @qrx-joe. Verified no tracked file is newly ignored; `*resume*` was deliberately left out (it would match tracked `resume-example.md`/`resume-template.html`). The original PR also bundled a broad .gitignore rewrite and an example-password change that aren't adopted here — `demo-2026` is an intentional template placeholder for the user's own demo-site password (read from profile.yml), not a secret.

Closes #859.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded ignore rules to prevent accidentally committing sensitive personal documents and credential-related files.
  * Added broader coverage for common passport, diploma, transcript, and resume-related filenames, including some non-English variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->