### PR TITLE
docs: re-sort SUPPORTED_JOB_BOARDS table alphabetically

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -23,11 +23,11 @@ are shared helpers and are not loaded as providers.
 | Pinpoint | API | Auto-detects `<slug>.pinpointhq.com` boards and reads the public zero-auth `/postings.json` per-tenant feed. |
 | Recruitee | API | Auto-detects `<slug>.recruitee.com` boards and uses the public per-tenant offers API. |
 | RemoteOK | API | Reads the board-wide `https://remoteok.com/api` JSON feed; scanner filters decide which rows are relevant. |
-| Rippling | API | Auto-detects `https://ats.rippling.com/<slug>/jobs` careers pages and reads the public zero-auth board API (`api.rippling.com/platform/api/ats/v1/board/<slug>/jobs`). |
 | Remotive | API | Reads the board-wide `https://remotive.com/api/remote-jobs` JSON feed, then applies local scanner filters. |
+| Rippling | API | Auto-detects `https://ats.rippling.com/<slug>/jobs` careers pages and reads the public zero-auth board API (`api.rippling.com/platform/api/ats/v1/board/<slug>/jobs`). |
 | SmartRecruiters | API | Auto-detects SmartRecruiters careers URLs or uses `provider: smartrecruiters` for branded custom domains. |
-| The Hub | API | Reads the board-wide `https://thehub.io/api/jobs` JSON feed (Nordic/EU startups). Configure with `provider: thehub`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
 | SolidJobs | API | Auto-detects `https://solid.jobs/public-api/offers/<division>` and reads the public offers API. |
+| The Hub | API | Reads the board-wide `https://thehub.io/api/jobs` JSON feed (Nordic/EU startups). Configure with `provider: thehub`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
 | We Work Remotely | RSS | Reads the public `https://weworkremotely.com/remote-jobs.rss` feed and parses it in-process. |
 | Workable | Parser | Auto-detects `https://apply.workable.com/<slug>` and parses Workable's public markdown jobs feed. |
 | Workday | API | Auto-detects Workday `myworkdayjobs.com` careers URLs and posts to the public CXS jobs endpoint. |


### PR DESCRIPTION
## What

Two rows in `docs/SUPPORTED_JOB_BOARDS.md` ended up out of alphabetical order after the recent provider-stack merges:

- **Rippling** preceded **Remotive** → now Remotive, then Rippling.
- **The Hub** preceded **SolidJobs** → now SolidJobs, then The Hub.

Swapped both so the Board column is fully alphabetical again (verified end-to-end). Docs-only, 4-line diff, no behavior change.

## Notes

- Independent of the open provider PRs — these rows are in different regions of the table than #1318's new "4 Day Week" row, so it should merge cleanly in any order.
- `node test-all.mjs` → green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the job boards reference by reordering several entries in the supported providers table. No content, links, or guidance changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->