### PR TITLE
fix(dashboard): map tracker columns by header name (#1327)

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -64,6 +64,12 @@ func ParseApplications(careerOpsPath string) []model.CareerApplication {
 	apps := make([]model.CareerApplication, 0)
 	num := 0
 
+	// Map columns by header name rather than fixed position, so a customized or
+	// reordered tracker (e.g. an inserted Location column) does not desync the
+	// reader. Falls back to the legacy fixed layout when no header is present.
+	// This matches the Node tracker tooling, which became header-aware in #954.
+	cols := resolveTrackerColumns(lines)
+
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "# ") || strings.HasPrefix(line, "|---") || strings.HasPrefix(line, "| #") {
@@ -73,46 +79,35 @@ func ParseApplications(careerOpsPath string) []model.CareerApplication {
 			continue
 		}
 
-		// Detect delimiter: if line contains tabs, use tab-aware splitting
-		var fields []string
-		if strings.Contains(line, "\t") {
-			// Mixed format: starts with "| " then tab-separated
-			line = strings.TrimPrefix(line, "|")
-			line = strings.TrimSpace(line)
-			parts := strings.Split(line, "\t")
-			for _, p := range parts {
-				fields = append(fields, strings.TrimSpace(strings.Trim(p, "|")))
-			}
-		} else {
-			// Pure pipe format
-			line = strings.Trim(line, "|")
-			parts := strings.Split(line, "|")
-			for _, p := range parts {
-				fields = append(fields, strings.TrimSpace(p))
-			}
-		}
-
+		fields := splitTrackerRow(line)
 		if len(fields) < 8 {
 			continue
 		}
 
+		at := func(name string) string {
+			if idx, ok := cols[name]; ok && idx >= 0 && idx < len(fields) {
+				return fields[idx]
+			}
+			return ""
+		}
+
 		num++
 		trackerNumber := num
-		if parsedNumber, err := strconv.Atoi(fields[0]); err == nil {
+		if parsedNumber, err := strconv.Atoi(at("num")); err == nil {
 			trackerNumber = parsedNumber
 		}
 		app := model.CareerApplication{
 			Number:  trackerNumber,
-			Date:    fields[1],
-			Company: fields[2],
-			Role:    fields[3],
-			Status:  fields[5],
-			HasPDF:  strings.Contains(fields[6], "\u2705"),
+			Date:    at("date"),
+			Company: at("company"),
+			Role:    at("role"),
+			Status:  at("status"),
+			HasPDF:  strings.Contains(at("pdf"), "\u2705"),
 		}
 
-		// Parse score (field 4 = Score column)
-		app.ScoreRaw = fields[4]
-		if sm := reScoreValue.FindStringSubmatch(fields[4]); sm != nil {
+		// Parse score from the Score column.
+		app.ScoreRaw = at("score")
+		if sm := reScoreValue.FindStringSubmatch(at("score")); sm != nil {
 			app.Score, _ = strconv.ParseFloat(sm[1], 64)
 		}
 
@@ -122,15 +117,13 @@ func ParseApplications(careerOpsPath string) []model.CareerApplication {
 		// back to a careerOpsPath-relative path, which is what every
 		// consumer joins against. Legacy root-relative links are kept as a
 		// fallback when the resolved file does not exist.
-		if rm := reReportLink.FindStringSubmatch(fields[7]); rm != nil {
+		if rm := reReportLink.FindStringSubmatch(at("report")); rm != nil {
 			app.ReportNumber = rm[1]
 			app.ReportPath = resolveReportPath(careerOpsPath, filePath, rm[2])
 		}
 
-		// Notes (field 8 if exists)
-		if len(fields) > 8 {
-			app.Notes = fields[8]
-		}
+		// Notes column, when present.
+		app.Notes = at("notes")
 
 		// Lift location / work mode / pay / last-contact out of the notes free-text
 		deriveNoteFields(&app)
@@ -571,6 +564,91 @@ func LoadReportSummary(careerOpsPath, reportPath string) (archetype, tldr, remot
 	return
 }
 
+// splitTrackerRow splits a tracker table line into trimmed cell values, using
+// the same delimiter logic as ParseApplications: a mixed "| " + tab-separated
+// body, or a pure pipe-delimited row. Field 0 is the first real column (num), so
+// the returned indices match the legacy layout (Status is field 5).
+func splitTrackerRow(line string) []string {
+	line = strings.TrimSpace(line)
+	var fields []string
+	if strings.Contains(line, "\t") {
+		// Mixed format: starts with "| " then tab-separated.
+		line = strings.TrimPrefix(line, "|")
+		line = strings.TrimSpace(line)
+		for _, p := range strings.Split(line, "\t") {
+			fields = append(fields, strings.TrimSpace(strings.Trim(p, "|")))
+		}
+	} else {
+		// Pure pipe format.
+		line = strings.Trim(line, "|")
+		for _, p := range strings.Split(line, "|") {
+			fields = append(fields, strings.TrimSpace(p))
+		}
+	}
+	return fields
+}
+
+// trackerHeaderAliases maps a lowercased header cell to a canonical field name.
+// Mirrors HEADER_ALIASES in tracker-parse.mjs (including the Spanish aliases) so
+// the Go data layer tolerates the same customized layouts as the Node tracker
+// tooling after #954.
+var trackerHeaderAliases = map[string]string{
+	"#": "num", "num": "num", "date": "date",
+	"company": "company", "empresa": "company",
+	"role": "role", "puesto": "role",
+	"location": "location", "score": "score", "status": "status",
+	"pdf": "pdf", "report": "report", "notes": "notes",
+}
+
+// legacyTrackerColumns is the original fixed layout in splitTrackerRow field
+// space (num=0 … notes=8), used when no recognizable header row is present.
+var legacyTrackerColumns = map[string]int{
+	"num": 0, "date": 1, "company": 2, "role": 3, "score": 4,
+	"status": 5, "pdf": 6, "report": 7, "notes": 8,
+}
+
+// detectTrackerColumns scans for the table header row and maps canonical field
+// names to column indices in splitTrackerRow field space. It returns nil unless
+// the essential columns are all present, so a stray pipe line cannot yield a
+// bogus mapping and the caller falls back to legacyTrackerColumns. Mirrors
+// detectColumns in tracker-parse.mjs (#954).
+func detectTrackerColumns(lines []string) map[string]int {
+	for _, line := range lines {
+		if !strings.HasPrefix(strings.TrimSpace(line), "|") {
+			continue
+		}
+		cells := splitTrackerRow(line)
+		m := make(map[string]int)
+		for i, c := range cells {
+			if name, ok := trackerHeaderAliases[strings.ToLower(c)]; ok {
+				if _, seen := m[name]; !seen {
+					m[name] = i
+				}
+			}
+		}
+		complete := true
+		for _, k := range []string{"num", "company", "role", "score", "status"} {
+			if _, ok := m[k]; !ok {
+				complete = false
+				break
+			}
+		}
+		if complete {
+			return m
+		}
+	}
+	return nil
+}
+
+// resolveTrackerColumns returns the header-detected column map, falling back to
+// the legacy fixed layout when no header row is found.
+func resolveTrackerColumns(lines []string) map[string]int {
+	if m := detectTrackerColumns(lines); m != nil {
+		return m
+	}
+	return legacyTrackerColumns
+}
+
 // UpdateApplicationStatus updates the status of an application in applications.md.
 func UpdateApplicationStatus(careerOpsPath string, app model.CareerApplication, newStatus string) error {
 	filePath := filepath.Join(careerOpsPath, "applications.md")
@@ -586,6 +664,11 @@ func UpdateApplicationStatus(careerOpsPath string, app model.CareerApplication, 
 	lines := strings.Split(string(content), "\n")
 	found := false
 
+	// Locate the Status column by header name so a customized layout (e.g. an
+	// inserted Location column) is written to the right cell. Falls back to the
+	// legacy fixed index when no header is present.
+	statusIdx := resolveTrackerColumns(lines)["status"]
+
 	for i, line := range lines {
 		if !strings.HasPrefix(strings.TrimSpace(line), "|") {
 			continue
@@ -593,7 +676,7 @@ func UpdateApplicationStatus(careerOpsPath string, app model.CareerApplication, 
 		// Match by report number
 		if app.ReportNumber != "" && strings.Contains(line, fmt.Sprintf("[%s]", app.ReportNumber)) {
 			// Replace the status field
-			lines[i] = replaceStatusInLine(line, app.Status, newStatus)
+			lines[i] = replaceStatusInLine(line, app.Status, newStatus, statusIdx)
 			found = true
 			break
 		}
@@ -614,18 +697,22 @@ func UpdateApplicationStatus(careerOpsPath string, app model.CareerApplication, 
 // instead of the Status cell, corrupting that cell while the status appeared to
 // stay unchanged (#1180). Matching is whole-cell (never a substring) and, as the
 // old comment claimed but the code did not, case-insensitive.
-func replaceStatusInLine(line, oldStatus, newStatus string) string {
+//
+// statusField is the Status column index in splitTrackerRow field space (5 in
+// the legacy layout), resolved from the table header so a customized layout
+// (e.g. an inserted Location column) targets the right cell.
+func replaceStatusInLine(line, oldStatus, newStatus string, statusField int) string {
 	want := strings.TrimSpace(oldStatus)
 
-	// Mixed "| " + tab-separated format (mirrors ParseApplications). The Status
-	// field is index 5 of the tab-split body.
+	// Mixed "| " + tab-separated format (mirrors ParseApplications). The body is
+	// tab-split, so cell index equals the field index.
 	if strings.Contains(line, "\t") {
 		prefix, body, found := strings.Cut(line, "|")
 		if !found {
 			return line
 		}
 		cells := strings.Split(body, "\t")
-		if idx := statusCellIndex(cells, 5, want); idx >= 0 {
+		if idx := statusCellIndex(cells, statusField, want); idx >= 0 {
 			cells[idx] = spliceCellValue(cells[idx], newStatus)
 			return prefix + "|" + strings.Join(cells, "\t")
 		}
@@ -634,10 +721,9 @@ func replaceStatusInLine(line, oldStatus, newStatus string) string {
 
 	// Pure pipe format. strings.Split keeps the segments between pipes; content
 	// cell N is segment N+1 (segment 0 is the empty text before the leading
-	// pipe), so the canonical Status column (ParseApplications field 5) is
-	// segment 6.
+	// pipe), so the Status field maps to segment statusField+1.
 	segments := strings.Split(line, "|")
-	if idx := statusCellIndex(segments, 6, want); idx >= 0 {
+	if idx := statusCellIndex(segments, statusField+1, want); idx >= 0 {
 		segments[idx] = spliceCellValue(segments[idx], newStatus)
 		return strings.Join(segments, "|")
 	}

--- a/dashboard/internal/data/career_test.go
+++ b/dashboard/internal/data/career_test.go
@@ -151,3 +151,116 @@ func TestParseApplicationsResolvesTrackerRelativeReportLinks(t *testing.T) {
 		}
 	}
 }
+
+// writeTracker writes applications.md under data/ and returns the temp root and
+// the tracker path.
+func writeTracker(t *testing.T, body string) (string, string) {
+	t.Helper()
+	tempDir := t.TempDir()
+	dataDir := filepath.Join(tempDir, "data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dataDir, "applications.md")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write tracker: %v", err)
+	}
+	return tempDir, path
+}
+
+const insertedColumnTracker = `# Applications Tracker
+
+| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|----------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-01 | Acme | VP Marketing | Remote | 4.5/5 | Applied | ✅ | [1](reports/001.md) | hot lead |
+`
+
+// A tracker with a Location column inserted before Score (the customized layout
+// the Node tracker tooling supports since #954) must not desync the Go reader.
+// Without header-aware mapping, Status reads the Score cell and the report link
+// reads the PDF cell, so ReportNumber comes back empty.
+func TestParseApplicationsMapsColumnsByHeader(t *testing.T) {
+	tempDir, _ := writeTracker(t, insertedColumnTracker)
+
+	apps := ParseApplications(tempDir)
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 application, got %d", len(apps))
+	}
+	a := apps[0]
+	if a.Company != "Acme" {
+		t.Errorf("Company = %q, want \"Acme\"", a.Company)
+	}
+	if a.Role != "VP Marketing" {
+		t.Errorf("Role = %q, want \"VP Marketing\"", a.Role)
+	}
+	if a.Status != "Applied" {
+		t.Errorf("Status = %q, want \"Applied\"", a.Status)
+	}
+	if a.ScoreRaw != "4.5/5" {
+		t.Errorf("ScoreRaw = %q, want \"4.5/5\"", a.ScoreRaw)
+	}
+	if !a.HasPDF {
+		t.Errorf("HasPDF = false, want true")
+	}
+	if a.ReportNumber != "1" {
+		t.Errorf("ReportNumber = %q, want \"1\"", a.ReportNumber)
+	}
+}
+
+// End-to-end status update on the inserted-column layout: parse, update, and
+// re-parse. Only the Status cell may change; every other cell stays intact.
+func TestUpdateApplicationStatusInsertedColumn(t *testing.T) {
+	tempDir, path := writeTracker(t, insertedColumnTracker)
+
+	apps := ParseApplications(tempDir)
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 application, got %d", len(apps))
+	}
+	if err := UpdateApplicationStatus(tempDir, apps[0], "Interview"); err != nil {
+		t.Fatalf("UpdateApplicationStatus: %v", err)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "| Interview |") {
+		t.Errorf("Status cell not updated to Interview, file now:\n%s", got)
+	}
+	if strings.Count(got, "Interview") != 1 {
+		t.Errorf("write touched an unintended cell; %d occurrences of Interview:\n%s", strings.Count(got, "Interview"), got)
+	}
+	for _, cell := range []string{"| Acme |", "| VP Marketing |", "| Remote |", "| 4.5/5 |", "| ✅ |"} {
+		if !strings.Contains(got, cell) {
+			t.Errorf("expected intact cell %q missing after write:\n%s", cell, got)
+		}
+	}
+
+	reparsed := ParseApplications(tempDir)
+	if reparsed[0].Status != "Interview" {
+		t.Errorf("reparsed Status = %q, want \"Interview\"", reparsed[0].Status)
+	}
+	if reparsed[0].ScoreRaw != "4.5/5" {
+		t.Errorf("reparsed ScoreRaw = %q, want \"4.5/5\"", reparsed[0].ScoreRaw)
+	}
+}
+
+// resolveTrackerColumns detects the header layout, and falls back to the legacy
+// fixed layout when no recognizable header row is present.
+func TestResolveTrackerColumns(t *testing.T) {
+	header := strings.Split(insertedColumnTracker, "\n")
+	cols := resolveTrackerColumns(header)
+	if cols["status"] != 6 {
+		t.Errorf("status index = %d, want 6 (inserted Location column)", cols["status"])
+	}
+	if cols["score"] != 5 {
+		t.Errorf("score index = %d, want 5", cols["score"])
+	}
+
+	headerless := []string{"| 1 | 2026-06-01 | Acme | VP Marketing | 4.5/5 | Applied | ✅ | [1](reports/001.md) | note |"}
+	fallback := resolveTrackerColumns(headerless)
+	if fallback["status"] != 5 {
+		t.Errorf("fallback status index = %d, want 5 (legacy layout)", fallback["status"])
+	}
+}


### PR DESCRIPTION
## What

Fixes #1327. The Go data layer in `dashboard/internal/data/career.go` locates tracker columns by fixed index, so a customized layout breaks it. `ParseApplications` reads Status from field 5 and Score from field 4, and the status writer keys off the same fixed positions.

A tracker with an inserted Location column (the layout the Node tracker tooling supports since #954) shifts every field. Status is read from the Score cell, the report link from the PDF cell, and `ReportNumber` comes back empty. Status updates then either fail with `application not found` or rewrite the wrong cell, because `replaceStatusInLine` prefers the canonical index and verifies it by value.

Reproduction on `main`, with a Location column inserted after Role:

| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |
|---|------|---------|------|----------|-------|--------|-----|--------|-------|
| 1 | 2026-06-01 | Acme | VP Marketing | Remote | 4.5/5 | Applied | ✅ | [1](reports/001.md) | hot lead |

`ParseApplications` returns `Status="4.5/5"`, `ScoreRaw="Remote"`, `HasPDF=false`, and an empty `ReportNumber`.

## Fix

Detect the column order from the table header row once, build a name to index map, and use it in both `ParseApplications` and the status writer through one shared helper. This mirrors `detectColumns` and `HEADER_ALIASES` in `tracker-parse.mjs`, including the Spanish header aliases, so the Go side tolerates the same layouts as the Node tooling after #954.

- `splitTrackerRow` factors out the existing pipe and tab cell splitting so the header row and data rows index identically.
- `detectTrackerColumns` requires num, company, role, score, and status to be present, otherwise it returns nil and the caller falls back to the legacy fixed layout, so existing trackers are unaffected.
- The status writer resolves the Status column index from the header and passes it to `replaceStatusInLine`, which keeps the whole-cell, case-insensitive matching and the untouched-on-no-match safety from #1186.

## Tests

Adds to `internal/data/career_test.go`:

- `TestParseApplicationsMapsColumnsByHeader`: the inserted-column layout parses every field correctly.
- `TestUpdateApplicationStatusInsertedColumn`: parse, update, and re-parse on the inserted-column layout; only the Status cell changes and the row round-trips.
- `TestResolveTrackerColumns`: header detection maps the shifted indices, and a headerless input falls back to the legacy layout.

Full dashboard suite green, `go vet ./...` clean, and `npm run build:dashboard` succeeds:

```text
ok  github.com/santifer/career-ops/dashboard
ok  github.com/santifer/career-ops/dashboard/internal/data
ok  github.com/santifer/career-ops/dashboard/internal/ui/screens
```

Closes #1327
