### PR TITLE
ci: skip Playwright browser download in the Tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
-      - run: npm install
+      # Skip the postinstall (npx playwright install chromium); the tests
+      # never launch a browser, so the ~170 MB download is pure CI overhead.
+      - run: npm install --ignore-scripts
       - run: node test-all.mjs --quick
       - name: Go dashboard tests
         run: go test ./...


### PR DESCRIPTION
The Tests workflow reinstalls the Playwright Chromium build on every run. `npm install` triggers the root `postinstall`, which runs `npx playwright install chromium --with-deps`, and CI runners start clean with no browser cache, so that pulls roughly 170 MB plus system packages each time. The job only runs `test-all.mjs --quick` and the Go dashboard tests, and neither launches a browser, so the download is pure overhead.

This changes the install step to `npm install --ignore-scripts`, which skips the postinstall. Everything the tests need is still installed; only the browser download is skipped.

Setting `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` would not work here. That variable only suppresses Playwright's own automatic download during package install. The postinstall calls `playwright install` explicitly, and the CLI ignores the variable, so the only reliable way to skip it in CI is to not run the script.

Local development is unaffected. A normal `npm install` still runs the postinstall and installs Chromium for `generate-pdf.mjs`. The change is limited to the CI workflow.

I verified the suite passes with no browser available by running `test-all.mjs --quick` with `PLAYWRIGHT_BROWSERS_PATH` pointed at an empty directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated test setup to skip unnecessary install steps, making CI runs faster and more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->