### PR TITLE
chore(gitignore): ignore user-layer modes/_custom.md and data/follow-ups.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 cv.md
 data/applications.md
 data/applications.db
+data/follow-ups.md
 data/pipeline.md
 data/scan-history.tsv
 data/pdf-index.tsv
@@ -42,6 +43,7 @@ writing-samples/*
 config/profile.yml
 portals.yml
 modes/_profile.md
+modes/_custom.md
 .update-dismissed
 .update-lock
 


### PR DESCRIPTION
Two user-layer files written by recent features lack `.gitignore` entries, so they can be committed by accident:

- **`modes/_custom.md`** - the user custom-instructions file (added in #1198). Its sibling `modes/_profile.md` is already ignored; `_custom.md` should be too.
- **`data/follow-ups.md`** - the follow-up history written by the followup-cadence flow. Its sibling `data/applications.md` is already ignored; `follow-ups.md` should be too.

Both are personal/user-owned, the same class as the existing ignored entries. This adds each next to its sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored files so two local markdown files are no longer tracked by version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->