### PR TITLE
feat(registry): add career-ops-plugin-tavily — Tavily search/extract

### DIFF
--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -9,7 +9,9 @@
       "repo": "Schlaflied/career-ops-plugin-tavily",
       "sha": "446ea4fffc66e058481e7a595ee9d46636b03d71",
       "hooks": [
-        "search"
+        "search",
+        "checkLiveness",
+        "researchCompany"
       ],
       "requiredEnv": [
         "TAVILY_API_KEY"

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -1,0 +1,25 @@
+{
+  "registryVersion": 1,
+  "_comment": "Curated list of community plugins career-ops has reviewed. Each entry is approved at an exact, pinned commit. Users install with `node plugins.mjs add <name>`. Entries are added ONLY via a reviewed PR (see docs/PLUGIN_REVIEW.md). The bundled plugins (apify/gmail/notion) live in plugins/ and are NOT listed here.",
+  "plugins": [
+    {
+      "id": "tavily",
+      "name": "tavily",
+      "version": "0.1.0",
+      "repo": "Schlaflied/career-ops-plugin-tavily",
+      "sha": "446ea4fffc66e058481e7a595ee9d46636b03d71",
+      "hooks": [
+        "search"
+      ],
+      "requiredEnv": [
+        "TAVILY_API_KEY"
+      ],
+      "allowedHosts": [
+        "api.tavily.com"
+      ],
+      "trust": "approved",
+      "registrationIssue": 1344,
+      "description": "Tavily search/extract for job scanning, liveness checks, and company research"
+    }
+  ]
+}

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -4,24 +4,17 @@
   "plugins": [
     {
       "id": "tavily",
-      "name": "tavily",
+      "name": "career-ops-plugin-tavily",
       "version": "0.1.0",
-      "repo": "Schlaflied/career-ops-plugin-tavily",
+      "license": "MIT",
+      "description": "Tavily search/extract for job scanning, liveness checks, and company research.",
+      "repo": "https://github.com/Schlaflied/career-ops-plugin-tavily",
       "sha": "446ea4fffc66e058481e7a595ee9d46636b03d71",
-      "hooks": [
-        "search",
-        "checkLiveness",
-        "researchCompany"
-      ],
-      "requiredEnv": [
-        "TAVILY_API_KEY"
-      ],
-      "allowedHosts": [
-        "api.tavily.com"
-      ],
-      "trust": "approved",
-      "registrationIssue": 1344,
-      "description": "Tavily search/extract for job scanning, liveness checks, and company research"
+      "hooks": ["search", "checkLiveness", "researchCompany"],
+      "requiredEnv": ["TAVILY_API_KEY"],
+      "allowedHosts": ["api.tavily.com"],
+      "registrationIssue": "https://github.com/santifer/career-ops/issues/1344",
+      "addedAt": "2026-06-29"
     }
   ]
 }


### PR DESCRIPTION
## Plugin registration — `tavily`

Adds `career-ops-plugin-tavily` to the community registry.

**Registration issue:** #1344
**Plugin repo:** https://github.com/Schlaflied/career-ops-plugin-tavily
**Pinned commit:** `446ea4fffc66e058481e7a595ee9d46636b03d71`

### What it does

Supplements ATS API scanning with web search via the Tavily API:
- `search` hook — finds job postings across LinkedIn, Greenhouse, Lever, Ashby
- `checkLiveness` — fallback liveness check for non-ATS postings
- `researchCompany` — company research queries for `deep` mode

### Checklist

- [x] Named `career-ops-plugin-<name>`
- [x] `manifest.json` present and valid
- [x] `index.mjs` default export with declared hooks
- [x] `README.md` present
- [x] `LICENSE` MIT
- [x] `skill.md` present
- [x] `test/smoke.mjs` passing (12/12)
- [x] Network access only via `ctx.fetch`, allowedHosts: `api.tavily.com`
- [x] Keys via `ctx.env.TAVILY_API_KEY`
- [x] No auto-submit hook
- [x] Original issue: #673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a curated plugins registry configuration with a pinned, approved plugin entry.
  * Included plugin metadata (version, allowed host, required environment variable, and trust/registration details) to support safer plugin installation and use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->