### PR TITLE
feat(registry): add google-calendar plugin v0.1.0

### DIFF
--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -1,5 +1,18 @@
 {
   "registryVersion": 1,
   "_comment": "Curated list of community plugins career-ops has reviewed. Each entry is approved at an exact, pinned commit. Users install with `node plugins.mjs add <name>`. Entries are added ONLY via a reviewed PR (see docs/PLUGIN_REVIEW.md). The bundled plugins (apify/gmail/notion) live in plugins/ and are NOT listed here.",
-  "plugins": []
+  "plugins": [
+    {
+      "id": "google-calendar",
+      "name": "google-calendar",
+      "description": "Google Calendar ingest — detect upcoming interview events and surface them in the career-ops pipeline.",
+      "repo": "https://github.com/Schlaflied/career-ops-plugin-google-calendar",
+      "sha": "0953aaa6d153e663b6f4f6fb130d6ecd7bca5e07",
+      "hooks": ["ingest"],
+      "requiredEnv": ["GOOGLE_CALENDAR_CLIENT_ID", "GOOGLE_CALENDAR_CLIENT_SECRET", "GOOGLE_CALENDAR_REFRESH_TOKEN"],
+      "allowedHosts": ["oauth2.googleapis.com", "www.googleapis.com"],
+      "registrationIssue": "https://github.com/santifer/career-ops/issues/1346",
+      "addedAt": "2026-06-29"
+    }
+  ]
 }

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -9,7 +9,7 @@
       "license": "MIT",
       "description": "Google Calendar ingest — detect upcoming interview events and surface them in the career-ops pipeline.",
       "repo": "https://github.com/Schlaflied/career-ops-plugin-google-calendar",
-      "sha": "0953aaa6d153e663b6f4f6fb130d6ecd7bca5e07",
+      "sha": "d4b8cf41cfd0b5ff31dfe79f5acd16d5c67aef9b",
       "hooks": ["ingest"],
       "requiredEnv": ["GOOGLE_CALENDAR_CLIENT_ID", "GOOGLE_CALENDAR_CLIENT_SECRET", "GOOGLE_CALENDAR_REFRESH_TOKEN"],
       "allowedHosts": ["oauth2.googleapis.com", "www.googleapis.com"],

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -4,7 +4,9 @@
   "plugins": [
     {
       "id": "google-calendar",
-      "name": "google-calendar",
+      "name": "career-ops-plugin-google-calendar",
+      "version": "0.1.0",
+      "license": "MIT",
       "description": "Google Calendar ingest — detect upcoming interview events and surface them in the career-ops pipeline.",
       "repo": "https://github.com/Schlaflied/career-ops-plugin-google-calendar",
       "sha": "0953aaa6d153e663b6f4f6fb130d6ecd7bca5e07",

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -9,7 +9,7 @@
       "license": "MIT",
       "description": "Google Calendar ingest — detect upcoming interview events and surface them in the career-ops pipeline.",
       "repo": "https://github.com/Schlaflied/career-ops-plugin-google-calendar",
-      "sha": "d4b8cf41cfd0b5ff31dfe79f5acd16d5c67aef9b",
+      "sha": "d4b8cf40f5090b58510affbad9379570a23b34d2",
       "hooks": ["ingest"],
       "requiredEnv": ["GOOGLE_CALENDAR_CLIENT_ID", "GOOGLE_CALENDAR_CLIENT_SECRET", "GOOGLE_CALENDAR_REFRESH_TOKEN"],
       "allowedHosts": ["oauth2.googleapis.com", "www.googleapis.com"],


### PR DESCRIPTION
## Summary

Adds `career-ops-plugin-google-calendar` to the community registry.

- **Repo:** https://github.com/Schlaflied/career-ops-plugin-google-calendar
- **Hook:** `ingest`
- **Hosts:** `oauth2.googleapis.com`, `www.googleapis.com`
- **Registration issue:** #1346
- **Pinned SHA:** `0953aaa6d153e663b6f4f6fb130d6ecd7bca5e07`

## What it does

Reads upcoming events from the user's primary Google Calendar, filters by interview keywords (EN + ZH), extracts join URLs (Meet / Teams / Zoom), and returns `Job[]` for the career-ops pipeline.

OAuth is implemented as a pure REST refresh-token exchange via `ctx.fetch` — no googleapis SDK, so it works within the plugin contract.

## Test plan

- [ ] `node test/smoke.mjs` — 13/13 passing (verified locally)
- [ ] Manifest fields match plugin spec
- [ ] SHA pinned to exact commit
- [ ] Registration issue filed (#1346)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **Google Calendar** integration to the available plugins list.
  * Included complete plugin configuration details, such as version/licensing metadata and the calendar ingest capability.
  * Added required OAuth environment variables and restricted approved OAuth hosts for a safer sign-in experience.
  * Provided registration information for onboarding the integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->