### PR TITLE
Codex/local git setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Personal data (user fills these)
 cv.md
+article-digest.md
 data/applications.md
 data/applications.db
 data/pipeline.md
@@ -16,6 +17,8 @@ batch/logs/*
 !batch/logs/.gitkeep
 batch/batch-state.tsv
 batch/batch-input.tsv
+batch/pipeline-*.json
+batch/pipeline-*.tsv
 batch/tracker-additions/**/*.tsv
 !batch/tracker-additions/.gitkeep
 jds/*
@@ -60,6 +63,8 @@ reports/*-RESERVED.md
 *.mp4
 
 # CLI-specific local config
+.codex/
+.mcp.json
 .claude/settings.local.json
 .claude/memory/
 .opencode/settings.local.json

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -211,7 +211,7 @@ Levels are additive — they are executed in order, and results are merged and d
 
 6b. **Filter by Location (Optional)** using `location_filter` from `portals.yml`:
    - If the `location_filter` block is absent, all locations pass (default behavior).
-   - Empty location on a posting → passes (do not penalize missing data).
+   - Empty location on a posting → rejects when `require_location: true`; otherwise passes.
    - Any keyword from `block` present → reject (precedes allow).
    - Empty `allow` → passes (already cleared block).
    - Non-empty `allow` → must match at least one keyword.

--- a/scan.mjs
+++ b/scan.mjs
@@ -157,8 +157,8 @@ export function buildTitleFilter(titleFilter) {
 // ── Location filter ─────────────────────────────────────────────────
 // Optional. If `location_filter` is absent from portals.yml, all locations pass.
 // Semantics (case-insensitive substring, in this order):
-//   - Empty / whitespace-only / non-string location → pass (don't penalize
-//     missing or malformed provider data)
+//   - Empty / whitespace-only / non-string location → reject when
+//     `require_location: true`; otherwise pass
 //   - `always_allow` matches → pass (takes precedence over `block` — lets a
 //     multi-location string like "Remote, Belgium or France" through because
 //     the home region is an option, even though "france" is blocked)
@@ -183,12 +183,13 @@ function normalizeKeywordList(value) {
 
 export function buildLocationFilter(locationFilter) {
   if (!locationFilter) return () => true;
+  const requireLocation = locationFilter.require_location === true;
   const alwaysAllow = normalizeKeywordList(locationFilter.always_allow);
   const allow = normalizeKeywordList(locationFilter.allow);
   const block = normalizeKeywordList(locationFilter.block);
 
   return (location) => {
-    if (typeof location !== 'string' || location.trim() === '') return true;
+    if (typeof location !== 'string' || location.trim() === '') return !requireLocation;
     const lower = location.toLowerCase();
     if (alwaysAllow.length > 0 && alwaysAllow.some(k => lower.includes(k))) return true;
     if (block.length > 0 && block.some(k => lower.includes(k))) return false;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1670,6 +1670,22 @@ try {
   if (filter('') === true) pass('empty location passes (unchanged semantics)');
   else fail('empty location should pass');
 
+  // Case 4b: strict mode holds empty/unknown locations for verification
+  const strictFilter = buildLocationFilter({
+    require_location: true,
+    allow: ['united states', 'us remote'],
+  });
+  if (strictFilter('') === false && strictFilter(null) === false) {
+    pass('require_location rejects empty and non-string locations');
+  } else {
+    fail('require_location should reject unknown locations');
+  }
+  if (strictFilter('Remote') === false && strictFilter('US Remote') === true) {
+    pass('strict mode rejects generic Remote but allows explicit US Remote');
+  } else {
+    fail('strict mode should distinguish generic Remote from US Remote');
+  }
+
   // Case 5: case-insensitivity
   if (filter('BRUSSELS, BELGIUM') === true) pass('case-insensitive match works');
   else fail('case-insensitive match failed');

--- a/validate-portals.mjs
+++ b/validate-portals.mjs
@@ -125,6 +125,9 @@ export async function validatePortalsConfig(config, { providerIds = new Set() } 
       validateKeywordList(config.location_filter.always_allow, 'location_filter.always_allow', errors);
       validateKeywordList(config.location_filter.allow, 'location_filter.allow', errors);
       validateKeywordList(config.location_filter.block, 'location_filter.block', errors);
+      if (config.location_filter.require_location !== undefined && typeof config.location_filter.require_location !== 'boolean') {
+        add(errors, 'location_filter.require_location', 'must be a boolean when set');
+      }
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- Link the issue this PR addresses, if it has one. Format: Fixes #123 / Closes #123 -->
<!-- Issue-first is asked for NEW FEATURES, new modes/commands, and architecture changes — it saves you from building something we'd have to redirect. -->
<!-- No issue needed, send the PR straight in: bug fixes, new zero-auth scanner providers, docs, and translations. We don't want to slow these down. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [ ] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ ] I ran `node test-all.mjs` and all tests pass
- [ ] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Location filtering now treats empty or invalid locations more strictly when strict location checks are enabled, while preserving existing behavior for other cases.
  * Config validation now checks that the strict location setting uses a valid boolean value.

* **Tests**
  * Added coverage for strict location filtering, including empty, non-string, and remote location cases.

* **Chores**
  * Updated ignore rules for new local and batch-generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->