### PR TITLE
feat(providers): add HigherEdJobs RSS provider

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -15,6 +15,7 @@ are shared helpers and are not loaded as providers.
 | Comeet / Spark Hire Recruit | API | Uses Comeet's public careers API. Provide the full API URL with `api:` or `careers_url`; it cannot derive the endpoint from a branded careers page. |
 | Glints | API | Uses Glints' public GraphQL job search endpoint. Configure with `provider: glints`; query and filters can be set on the portal entry. |
 | Greenhouse | API | Handles explicit `api:` URLs and auto-detects public Greenhouse board URLs for the boards API. |
+| HigherEdJobs | RSS | Reads the public `https://www.higheredjobs.com/rss/categoryFeed.cfm?catID={catID}` feed and parses it in-process. Configure with `provider: higheredjobs` and optional `cat_id` (default 68 = Higher Education). Not auto-detected — requires explicit `provider:` config. |
 | IBM Careers | API | Posts to IBM's public careers search API and supports optional IBM facet filters in the portal entry. |
 | Jobstreet / SEEK | API | Uses the public SEEK chalice-search JSON API for Jobstreet and SEEK sites. Configure explicitly with `provider: jobstreet`. |
 | Landing.jobs | API | Reads the board-wide `https://landing.jobs/api/v1/jobs` JSON feed (tech, Europe). Configure with `provider: landingjobs`; company is derived from the posting URL slug. |

--- a/providers/higheredjobs.mjs
+++ b/providers/higheredjobs.mjs
@@ -1,0 +1,152 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// HigherEdJobs.com RSS category feed provider.
+// (https://www.higheredjobs.com/rss/categoryFeed.cfm?catID=68). The feed is
+// public, no-auth, and XML, so it is parsed in-process with the same tiny tag
+// extractor approach as providers/weworkremotely.mjs rather than adding an
+// XML dependency.
+//
+// Wire in via a `job_boards:` entry with `provider: higheredjobs`.
+
+const DEFAULT_CAT_ID = 68; // Higher Education category
+const TRUSTED_HOST = 'www.higheredjobs.com';
+
+function feedUrlFor(catId) {
+  const catID = typeof catId === 'number' && Number.isFinite(catId) ? catId : DEFAULT_CAT_ID;
+  return `https://www.higheredjobs.com/rss/categoryFeed.cfm?catID=${catID}`;
+}
+
+// NaN-safe Date.parse - `|| undefined` would also coerce a valid epoch 0.
+function toEpochMs(value) {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function fallbackCompany(entry) {
+  return typeof entry?.name === 'string' && entry.name.trim() ? entry.name.trim() : 'HigherEdJobs';
+}
+
+/** @type {Provider} */
+export default {
+  id: 'higheredjobs',
+
+  detect(entry) {
+    if (entry?.provider !== 'higheredjobs') return null;
+    return { url: feedUrlFor(entry.cat_id) };
+  },
+
+  async fetch(entry, ctx) {
+    const feedUrl = feedUrlFor(entry?.cat_id);
+    // redirect:'error' prevents SSRF via server-side redirects; combined with
+    // cleanUrl below it keeps the request pinned to www.higheredjobs.com.
+    const text = await ctx.fetchText(feedUrl, { redirect: 'error' });
+    return parseHigherEdJobsFeed(text, fallbackCompany(entry));
+  },
+};
+
+function fromCodePoint(cp) {
+  try {
+    return String.fromCodePoint(cp);
+  } catch {
+    return '';
+  }
+}
+
+// Decode the XML entities that appear in RSS text: numeric (&#38; / &#x27;)
+// and the named five. Numeric forms are decoded first; &amp; is decoded LAST
+// so a literal "&amp;lt;" yields "&lt;" rather than over-decoding to "<".
+function decodeXmlEntities(s) {
+  return s
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, d) => fromCodePoint(parseInt(d, 10)))
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+// Resolve a tag's inner text: unwrap a CDATA section, else decode entities.
+function extractText(inner) {
+  const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
+  if (cdata) return cdata[1].trim();
+  return decodeXmlEntities(inner).trim();
+}
+
+// Extract the text of the first <tag>...</tag> in a block. Returns '' when absent.
+function tagText(block, tag) {
+  const m = block.match(new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)</${tag}>`, 'i'));
+  return m ? extractText(m[1]) : '';
+}
+
+function cleanUrl(value) {
+  if (!value) return '';
+  const trimmed = value.trim();
+  try {
+    const parsed = new URL(trimmed);
+    const host = parsed.hostname.toLowerCase();
+    // Exact-match host (no subdomain wildcard): higheredjobs serves only
+    // www.higheredjobs.com for posting URLs.
+    const trusted = host === TRUSTED_HOST;
+    return parsed.protocol === 'https:' && trusted ? parsed.href : '';
+  } catch {
+    return '';
+  }
+}
+
+// HigherEdJobs <description> is "Institution Name (City, ST)". Split on the
+// last " (" to separate company from location. When no parens are present the
+// whole description is treated as the company and location is empty.
+function splitDescription(rawDescription, defaultCompany) {
+  const text = rawDescription.trim();
+  const open = text.lastIndexOf(' (');
+  if (open > 0) {
+    const close = text.lastIndexOf(')');
+    const company = text.slice(0, open).trim();
+    const location = close > open ? text.slice(open + 2, close).trim() : text.slice(open + 2).trim();
+    if (company) return { company, location };
+  }
+  return { company: text || defaultCompany, location: '' };
+}
+
+/**
+ * Parse HigherEdJobs' public RSS category feed. Exported for unit tests.
+ *
+ * Shape: `<rss><channel><item>...</item>...</channel></rss>`, each item
+ * carrying `<title>` (plain job title), `<description>` ("Institution (City,
+ * ST)"), `<link>`, `<pubDate>`, and `<guid>`. Company and location are
+ * derived from <description>. The RSS <link> is the dedup key; items without
+ * a usable absolute URL on www.higheredjobs.com are dropped.
+ *
+ * @param {string} xml - raw RSS feed body
+ * @param {string} [defaultCompany] - fallback company for empty descriptions
+ * @returns {Array<{title: string, url: string, company: string, location: string, postedAt?: number}>}
+ */
+export function parseHigherEdJobsFeed(xml, defaultCompany = 'HigherEdJobs') {
+  if (typeof xml !== 'string') return [];
+  const fallback = typeof defaultCompany === 'string' && defaultCompany.trim() ? defaultCompany.trim() : 'HigherEdJobs';
+  const jobs = [];
+  const blocks = xml.match(/<item\b[^>]*>[\s\S]*?<\/item>/gi) || [];
+
+  for (const item of blocks) {
+    const url = cleanUrl(tagText(item, 'link'));
+    if (!url) continue;
+
+    const title = tagText(item, 'title');
+    if (!title) continue;
+
+    const { company, location } = splitDescription(tagText(item, 'description'), fallback);
+
+    jobs.push({
+      title,
+      company,
+      location,
+      url,
+      postedAt: toEpochMs(tagText(item, 'pubDate')),
+    });
+  }
+
+  return jobs;
+}

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -1540,3 +1540,14 @@ job_boards:
     maxPages: 3
     enabled: false
     notes: "SEA job platform covering ID/SG/MY/VN. Undocumented public GraphQL API — adjust graphqlQuery if schema changes."
+
+  # ── HigherEdJobs (university / higher-ed RSS) ────────────────────────
+  # Public no-auth RSS category feed. cat_id selects the HigherEdJobs
+  # category. Common ones:
+  #   68 = Higher Education, 64 = Educational Administration, 22 = Career Development
+  # Full list: https://www.higheredjobs.com/rss/
+
+  # - name: HigherEdJobs — Higher Education
+  #   provider: higheredjobs
+  #   cat_id: 68
+  #   enabled: true

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8208,6 +8208,146 @@ try {
   if (__pluginTmp) { try { rmSync(__pluginTmp, { recursive: true, force: true }); } catch {} }
 }
 
+// -- 50. Provider - higheredjobs -----------------------------------------
+console.log('\n50. Provider - higheredjobs');
+
+try {
+  const hejModule = await import(pathToFileURL(join(ROOT, 'providers/higheredjobs.mjs')).href);
+  const higheredjobs = hejModule.default;
+  const { parseHigherEdJobsFeed } = hejModule;
+
+  if (higheredjobs.id === 'higheredjobs') pass('higheredjobs.id is "higheredjobs"');
+  else fail(`higheredjobs.id is ${JSON.stringify(higheredjobs.id)}`);
+
+  const hit = higheredjobs.detect({ name: 'HEJ', provider: 'higheredjobs', cat_id: 64 });
+  if (hit && hit.url === 'https://www.higheredjobs.com/rss/categoryFeed.cfm?catID=64') {
+    pass('higheredjobs.detect() claims explicit provider config (returns URL with catID)');
+  } else {
+    fail(`higheredjobs.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  const hitDefault = higheredjobs.detect({ name: 'HEJ', provider: 'higheredjobs' });
+  if (hitDefault && hitDefault.url === 'https://www.higheredjobs.com/rss/categoryFeed.cfm?catID=68') {
+    pass('higheredjobs.detect() with no cat_id returns default URL with catID=68');
+  } else {
+    fail(`higheredjobs.detect() default returned ${JSON.stringify(hitDefault)}`);
+  }
+
+  if (higheredjobs.detect({ name: 'Remote Board', provider: 'remoteok' }) === null) {
+    pass('higheredjobs.detect() ignores other provider ids');
+  } else {
+    fail('higheredjobs.detect() should only claim provider: higheredjobs');
+  }
+
+  const sample = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title><![CDATA[Director of AI Strategy]]></title>
+      <description><![CDATA[Curry College (Milton, MA)]]></description>
+      <link>https://www.higheredjobs.com/details.cfm?JobCode=17899012</link>
+      <pubDate>Thu, 13 Nov 2025 14:10:41 +0000</pubDate>
+      <guid>https://www.higheredjobs.com/details.cfm?JobCode=17899012</guid>
+    </item>
+    <item>
+      <title>Dean of Engineering &amp; Computing</title>
+      <description>State University System Office</description>
+      <link>https://www.higheredjobs.com/details.cfm?JobCode=17899044</link>
+      <pubDate>Fri, 02 Jan 2026 09:00:00 +0000</pubDate>
+      <guid>https://www.higheredjobs.com/details.cfm?JobCode=17899044</guid>
+    </item>
+    <item>
+      <title>Missing Link Role</title>
+      <description>Ghost College (Nowhere, ZZ)</description>
+      <pubDate>Fri, 02 Jan 2026 09:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>Relative Link Role</title>
+      <description>Relative U (Somewhere, ST)</description>
+      <link>/details.cfm?JobCode=bad-relative</link>
+      <pubDate>Fri, 02 Jan 2026 09:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>Off Host Role</title>
+      <description>Off Host Inst (Elsewhere, ST)</description>
+      <link>https://example.com/details.cfm?JobCode=off-host</link>
+      <pubDate>Fri, 02 Jan 2026 09:00:00 +0000</pubDate>
+    </item>
+  </channel>
+</rss>`;
+  const jobs = parseHigherEdJobsFeed(sample, 'HEJ Board');
+
+  if (jobs.length === 2) pass('parseHigherEdJobsFeed keeps 2 items (drops missing/relative/off-host links)');
+  else fail(`parseHigherEdJobsFeed returned ${jobs.length} jobs (expected 2)`);
+
+  if (jobs.every(({ url }) => {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'https:' && parsed.hostname === 'www.higheredjobs.com';
+    } catch {
+      return false;
+    }
+  })) pass('parseHigherEdJobsFeed only emits HTTPS URLs pinned to www.higheredjobs.com');
+  else fail('parseHigherEdJobsFeed emitted an off-host or non-HTTPS URL');
+
+  if (jobs[0]?.title === 'Director of AI Strategy' && jobs[0]?.company === 'Curry College' && jobs[0]?.location === 'Milton, MA') {
+    pass('parseHigherEdJobsFeed parses title + "Institution (City, ST)" description -> company/title/location');
+  } else {
+    fail(`row 0 = ${JSON.stringify(jobs[0])}`);
+  }
+
+  if (jobs[0]?.url === 'https://www.higheredjobs.com/details.cfm?JobCode=17899012') {
+    pass('parseHigherEdJobsFeed maps <link> to url');
+  } else {
+    fail(`row 0 url = ${JSON.stringify(jobs[0]?.url)}`);
+  }
+
+  if (jobs[0]?.postedAt === Date.parse('Thu, 13 Nov 2025 14:10:41 +0000')) {
+    pass('parseHigherEdJobsFeed parses pubDate -> postedAt');
+  } else {
+    fail(`row 0 postedAt = ${JSON.stringify(jobs[0]?.postedAt)}`);
+  }
+
+  if (jobs[1]?.company === 'State University System Office' && jobs[1]?.location === '' && jobs[1]?.title === 'Dean of Engineering & Computing') {
+    pass('parseHigherEdJobsFeed falls back to whole description as company when no parens (empty location)');
+  } else {
+    fail(`row 1 = ${JSON.stringify(jobs[1])}`);
+  }
+
+  if (parseHigherEdJobsFeed('', 'X').length === 0 && parseHigherEdJobsFeed(null, 'X').length === 0) {
+    pass('parseHigherEdJobsFeed empty / non-string feed -> empty result (no crash)');
+  } else {
+    fail('parseHigherEdJobsFeed empty / non-string feed should yield empty result');
+  }
+
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const fetched = await higheredjobs.fetch(
+    { name: 'HEJ Board', provider: 'higheredjobs', cat_id: 64 },
+    { fetchText: async (url, opts) => { capturedUrl = url; capturedOpts = opts; return sample; } },
+  );
+
+  if (capturedUrl === 'https://www.higheredjobs.com/rss/categoryFeed.cfm?catID=64') {
+    pass('higheredjobs.fetch() requests the feed URL for cat_id 64');
+  } else {
+    fail(`higheredjobs.fetch() requested ${JSON.stringify(capturedUrl)}`);
+  }
+
+  if (capturedOpts && capturedOpts.redirect === 'error') {
+    pass('higheredjobs.fetch() passes redirect:"error" to fetchText');
+  } else {
+    fail(`higheredjobs.fetch() should pass redirect:"error", got: ${JSON.stringify(capturedOpts)}`);
+  }
+
+  if (fetched[0]?.company === 'Curry College' && fetched[0]?.title === 'Director of AI Strategy' && fetched[0]?.location === 'Milton, MA') {
+    pass('provider: higheredjobs config returns normalized jobs');
+  } else {
+    fail(`higheredjobs.fetch() normalized row = ${JSON.stringify(fetched[0])}`);
+  }
+} catch (e) {
+  fail(`higheredjobs provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What

Adds a new zero-auth RSS provider for [HigherEdJobs.com](https://www.higheredjobs.com), the largest higher education job board. This gives career-ops users access to university and college job postings — faculty, administrative, executive, and staff positions.

## Why

career-ops currently has no higher-education-focused provider. HigherEdJobs hosts 50+ categories of university jobs with public, no-auth RSS feeds — a clean fit for the existing provider architecture.

## Changes

- **`providers/higheredjobs.mjs`** (new) — RSS 2.0 feed parser following the `providers/weworkremotely.mjs` pattern (in-process XML parsing, no new dependency). Category is configurable via `cat_id` in `portals.yml` (default 68 = Higher Education). Full category list at https://www.higheredjobs.com/rss/
- **`test-all.mjs`** — 14 assertions: id check, detect() with/without cat_id, detect() ignoring other providers, feed parsing (5-item fixture, 2 survive), host-pinning invariant (every emitted URL is HTTPS + pinned to www.higheredjobs.com), empty/null safety, fetch URL + redirect:"error" verification
- **`templates/portals.example.yml`** — commented example entry with common category IDs
- **`docs/SUPPORTED_JOB_BOARDS.md`** — support matrix entry noting explicit `provider:` config required

## Security

- Feed URL host-pinned to `www.higheredjobs.com` (exact match, no subdomain wildcard)
- `redirect: 'error'` on feed fetch (prevents SSRF via server-side redirects)
- `cleanUrl()` enforces HTTPS + exact hostname match before emitting job URLs
- Test asserts host-pinning invariant directly (not just job count)

## Test results

```
50. Provider - higheredjobs
  14/14 passed

Results: 860 passed, 0 failed, 16 warnings (pre-existing)
```

No issue opened — per CONTRIBUTING.md, new zero-auth scanner providers can go straight to PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the HigherEdJobs job board, including RSS-based job discovery and a configurable category ID.
  * Included an example configuration snippet for enabling HigherEdJobs in portal setups.

* **Bug Fixes**
  * Improved feed handling to ignore invalid or off-site listings and normalize job details consistently.
  * Added safer date parsing and fallback behavior when feed content is incomplete.

* **Tests**
  * Expanded automated coverage for HigherEdJobs detection, feed parsing, and feed fetching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->