### PR TITLE
fix(pdf): keep a right gutter so right-aligned CV content isn't clipped (#1341)

### DIFF
--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -344,8 +344,15 @@
       print-color-adjust: exact;
     }
 
+    /* Keep a small right gutter for the print box. Right-aligned content
+       (job periods, education years) right-aligns to the content-box edge,
+       and the rightmost glyph's side bearing can spill ~1px past it and get
+       clipped by Chromium's print clip. A plain `.page` padding is reset to 0
+       here for print, which is why padding set outside @media print has no
+       effect; restoring a right gutter inside the print rule fixes it without
+       re-centering the page or hard-coding a per-format max-width. See #1341. */
     .page {
-      padding: 0;
+      padding: 0 0.18in 0 0;
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Right-aligned CV content (job periods, education years) right-aligns to the print content-box edge, and the rightmost glyph's side bearing spills ~1px past it, getting clipped by Chromium's print clip. This restores a small **right gutter** inside the `@media print` rule so that content stays inside the clip box — for both `a4` and `letter`, without re-centering the page or hard-coding a per-format `max-width`.

Why a print-mode gutter (and why earlier padding attempts on the issue had no effect): the print rule resets `.page { padding: 0 }`, so any `.page` padding set outside `@media print` is wiped during PDF render. The fix adds the gutter *inside* the print rule. With the existing `box-sizing: border-box`, this narrows the content box rather than widening the page.

## Related issue

Fixes #1341

Thanks @hribcek for the precise diagnosis on the issue — this implements the "cap the content width" direction you identified as the one that actually clears it (the `@page` / `preferCSSPageSize` direction did **not** reflow the right edge in my testing, matching your note).

## Verification

The clip is a sub-pixel glyph overhang that rasterizers (`sips`/`qlmanage`) false-clean, as the issue notes — so I verified **deterministically** by extracting the rightmost right-aligned glyph's x-position from the generated PDF and comparing it to the print clip box (`MediaBox − 0.6in`):

| format | clip box | date right edge (before → after) | result |
|--------|---------:|----------------------------------|--------|
| a4     | 552.7pt  | 553.5pt → **540.5pt**            | CLIP → CLEAR (12.2pt gutter) |
| letter | 568.8pt  | 569.2pt → **556.3pt**            | CLIP → CLEAR (12.5pt gutter) |

- No pagination change (1 page before/after on the test CV).
- `node test-all.mjs` → **846 passed, 0 failed**.

**Left as a draft** pending a real-viewer confirmation (Preview/Skim), since the deterministic metric can't fully stand in for the visual check you offered to run — if you (or a maintainer) can confirm the clip is gone on a real CV, happy to flip it to ready. If your CV overhangs more than the test fixture, the gutter value (`0.18in`) is a one-line tweak.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] If this is a new feature or architecture change, I opened an issue first (this is a bug fix — exempt)
- [x] My PR does not include personal data (the verification CV is synthetic)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (only `templates/cv-template.html`, a system-layer file; no user-layer changes)
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved print layout spacing so the right edge of page content is less likely to be clipped in Chromium-based printouts.
  - Added a small right-side inset in print view for cleaner, more reliable printed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->