### PR TITLE
Add seniority tier filter

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,7 @@
+title_filter: {
+  positive: [],
+  negative: [],
+  seniority: {
+    tiers: ['intern', 'junior', 'mid-level', 'senior', 'executive']
+  }
+}

--- a/filters.js
+++ b/filters.js
@@ -1,0 +1,10 @@
+function filterListings(listings) {
+  const seniorityTier = config.title_filter.seniority.tiers;
+  listings = listings.filter(listing => {
+    if (config.title_filter.seniority && !seniorityTier.includes(listing.seniority)) {
+      return false;
+    }
+    // ... existing code
+  });
+  return listings;
+}


### PR DESCRIPTION
## What was broken
Missing seniority tier filter
## What changed
Added seniority tier helper
## How to test
Test with example usage

---
_Opened by autonomous agent. Human review required before merge._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable title filtering with supported seniority tiers: intern, junior, mid-level, senior, and executive.
  * Listings are now filtered to show only entries matching the allowed seniority levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->