### PR TITLE
fix(pdf): write the PDF manifest — reportNum/inputPath were out of scope in renderHtmlToPdf

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -288,7 +288,12 @@ async function generatePDF() {
     console.log(`🧹 ATS normalization: ${totalReplacements} replacements (${breakdown})`);
   }
 
-  return renderHtmlToPdf(html, outputPath, { format, baseDir: dirname(inputPath) });
+  return renderHtmlToPdf(html, outputPath, {
+    format,
+    baseDir: dirname(inputPath),
+    reportNum,
+    sourceHtmlPath: inputPath,
+  });
 }
 
 /**
@@ -344,12 +349,16 @@ export async function inlineLocalFonts(html) {
  *
  * @param {string} html - Full HTML document to render.
  * @param {string} outputPath - Absolute path to write the PDF to.
- * @param {{format?: 'a4'|'letter', baseDir?: string}} [opts]
+ * @param {{format?: 'a4'|'letter', baseDir?: string, reportNum?: string, sourceHtmlPath?: string}} [opts]
  * @returns {Promise<{outputPath: string, pageCount: number, size: number}>}
  */
 export async function renderHtmlToPdf(html, outputPath, opts = {}) {
   const format = opts.format || 'a4';
   const baseDir = opts.baseDir || process.cwd();
+  const reportNum = opts.reportNum || '';
+  // Source HTML recorded for regeneration. Callers that render inline HTML with
+  // no on-disk source (e.g. cover letters) fall back to the PDF path.
+  const sourceHtmlPath = opts.sourceHtmlPath || outputPath;
 
   mkdirSync(dirname(outputPath), { recursive: true });
 
@@ -398,7 +407,7 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
     console.log(`📦 Size: ${(pdfBuffer.length / 1024).toFixed(1)} KB`);
 
     try {
-      updatePDFManifest(reportNum, outputPath, inputPath, format);
+      updatePDFManifest(reportNum, outputPath, sourceHtmlPath, format);
       console.log(`🔗 Manifest: data/pdf-index.tsv updated${reportNum ? ` (report ${reportNum})` : ' (no --report given)'}`);
     } catch (err) {
       // The PDF itself succeeded — never fail the run over manifest bookkeeping.


### PR DESCRIPTION
## Problem

`renderHtmlToPdf()` ends with:

```js
updatePDFManifest(reportNum, outputPath, inputPath, format);
```

but `reportNum` and `inputPath` are locals of `generatePDF()` — they are never passed into `renderHtmlToPdf`. So every render throws `ReferenceError: reportNum is not defined`, which the surrounding try/catch swallows:

```
⚠️  Manifest update failed: reportNum is not defined
```

The PDF is written fine, but `data/pdf-index.tsv` is never updated. The dashboard's PDF↔report linkage (the `d`/`D` regeneration hotkeys) silently breaks for every generated CV, and the inline-HTML caller `generate-cover-letter.mjs` hits the same error.

## Fix

Thread `reportNum` and the source HTML path through `opts`, with safe defaults so existing callers keep working:

- `reportNum` defaults to `''`
- `sourceHtmlPath` defaults to `outputPath` (for inline-HTML callers with no on-disk source, e.g. cover letters)

`generatePDF()` now passes `reportNum` and `sourceHtmlPath: inputPath`. This matches the documented design in the file header ("Without `--report` a manifest row is still written, just unkeyed").

## Verification

Before:

```
$ node generate-pdf.mjs output/cv.html output/cv.pdf --format=a4 --report=008
...
⚠️  Manifest update failed: reportNum is not defined
```

After:

```
$ node generate-pdf.mjs output/cv.html output/cv.pdf --format=a4 --report=008
...
🔗 Manifest: data/pdf-index.tsv updated (report 008)

# data/pdf-index.tsv
008	output/cv.pdf	output/cv.html	a4	2026-06-30
```

`node test-all.mjs` shows no change in pass/fail count from this change (no manifest-write test existed to catch this; the error was only ever surfaced as a runtime warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
