### PR TITLE
Persist apply answers in reports

### DIFF
--- a/application-answers.mjs
+++ b/application-answers.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+export const APPLICATION_ANSWERS_HEADING = '## Application Answers';
+
+const VALID_STATES = new Set(['filled', 'submitted']);
+
+function inline(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function valueText(value) {
+  if (Array.isArray(value)) return value.map(inline).filter(Boolean).join(', ');
+  return String(value ?? '').trim();
+}
+
+function pick(object, keys) {
+  for (const key of keys) {
+    const value = object?.[key];
+    if (Array.isArray(value)) {
+      if (value.length > 0) return value;
+      continue;
+    }
+    if (value !== undefined && value !== null && String(value).trim()) return value;
+  }
+  return '';
+}
+
+function list(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeState(state) {
+  const normalized = inline(state || 'filled').toLowerCase();
+  if (!VALID_STATES.has(normalized)) {
+    throw new Error(`Application answer state must be one of: ${[...VALID_STATES].join(', ')}`);
+  }
+  return normalized;
+}
+
+function normalizeDate(date) {
+  return inline(date || new Date().toISOString().slice(0, 10));
+}
+
+function quoteBlock(value) {
+  const text = String(value ?? '').replace(/\r\n/g, '\n').trim();
+  if (!text) return '> Not recorded.';
+  return text.split('\n').map((line) => `> ${line}`).join('\n');
+}
+
+function qaLines(entries, { labelKeys, valueKeys, fallback }) {
+  if (entries.length === 0) return ['- None captured.'];
+
+  return entries.flatMap((entry, index) => {
+    const label = inline(pick(entry, labelKeys)) || `${fallback} ${index + 1}`;
+    const answer = pick(entry, valueKeys);
+    return [
+      `${index + 1}. **${label}**`,
+      '',
+      quoteBlock(answer),
+      '',
+    ];
+  }).slice(0, -1);
+}
+
+function compactLines(entries, { labelKeys, valueKeys, fallback }) {
+  if (entries.length === 0) return ['- None captured.'];
+
+  return entries.map((entry, index) => {
+    const label = inline(pick(entry, labelKeys)) || `${fallback} ${index + 1}`;
+    const value = valueText(pick(entry, valueKeys)) || 'Not recorded';
+    return `${index + 1}. **${label}:** ${value}`;
+  });
+}
+
+function fileLines(entries) {
+  if (entries.length === 0) return ['- None captured.'];
+
+  return entries.map((entry, index) => {
+    const label = inline(pick(entry, ['field', 'name', 'label', 'type'])) || `File ${index + 1}`;
+    const file = inline(pick(entry, ['path', 'file', 'filename', 'url'])) || 'Not recorded';
+    const version = inline(pick(entry, ['version', 'variant']));
+    return `${index + 1}. **${label}:** ${version ? `${file} (${version})` : file}`;
+  });
+}
+
+export function normalizeApplicationAnswersSnapshot(snapshot = {}) {
+  return {
+    date: normalizeDate(snapshot.date),
+    state: normalizeState(snapshot.state),
+    freeText: list(snapshot.freeText ?? snapshot.freeTextAnswers ?? snapshot.answers),
+    selections: list(snapshot.selections ?? snapshot.selectedOptions),
+    fieldValues: list(snapshot.fieldValues ?? snapshot.otherFields ?? snapshot.fields),
+    files: list(snapshot.files ?? snapshot.uploads ?? snapshot.filesUsed),
+  };
+}
+
+export function formatApplicationAnswersSection(snapshot = {}) {
+  const normalized = normalizeApplicationAnswersSnapshot(snapshot);
+  const lines = [
+    APPLICATION_ANSWERS_HEADING,
+    '',
+    `**Date:** ${normalized.date}`,
+    `**State:** ${normalized.state}`,
+    '',
+    '### Free-text answers',
+    '',
+    ...qaLines(normalized.freeText, {
+      labelKeys: ['question', 'field', 'label', 'prompt'],
+      valueKeys: ['answer', 'response', 'value', 'text'],
+      fallback: 'Answer',
+    }),
+    '',
+    '### Selections made',
+    '',
+    ...compactLines(normalized.selections, {
+      labelKeys: ['question', 'field', 'label', 'prompt'],
+      valueKeys: ['selection', 'selected', 'answer', 'value', 'options'],
+      fallback: 'Selection',
+    }),
+    '',
+    '### Other field values',
+    '',
+    ...compactLines(normalized.fieldValues, {
+      labelKeys: ['question', 'field', 'label', 'prompt'],
+      valueKeys: ['answer', 'response', 'value', 'text'],
+      fallback: 'Field',
+    }),
+    '',
+    '### Files used',
+    '',
+    ...fileLines(normalized.files),
+  ];
+
+  return `${lines.join('\n').replace(/\n{3,}/g, '\n\n').trim()}\n`;
+}
+
+export function upsertApplicationAnswersSection(reportText, snapshot = {}) {
+  const report = String(reportText ?? '').replace(/\r\n/g, '\n');
+  const section = formatApplicationAnswersSection(snapshot).trimEnd();
+  const heading = /^## Application Answers\s*$/m.exec(report);
+
+  if (!heading) {
+    return `${report.trimEnd()}\n\n${section}\n`;
+  }
+
+  const start = heading.index;
+  const afterHeading = start + heading[0].length;
+  const nextHeading = /^## .+$/m.exec(report.slice(afterHeading));
+  const end = nextHeading ? afterHeading + nextHeading.index : report.length;
+  const before = report.slice(0, start).trimEnd();
+  const after = report.slice(end).trimStart();
+
+  return [before, section, after].filter(Boolean).join('\n\n') + '\n';
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') args.help = true;
+    else if (arg.startsWith('--')) args[arg.slice(2)] = argv[++i] ?? '';
+  }
+  return args;
+}
+
+function usage() {
+  return [
+    'Usage: node application-answers.mjs --report <report.md> --input <answers.json> [--state filled|submitted] [--date YYYY-MM-DD]',
+    '',
+    'The input JSON may contain: freeText, selections, fieldValues, files, date, state.',
+  ].join('\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+  if (!args.report || !args.input) {
+    console.error(usage());
+    process.exitCode = 1;
+    return;
+  }
+
+  const inputText = args.input === '-' ? readFileSync(0, 'utf-8') : readFileSync(resolve(args.input), 'utf-8');
+  const input = JSON.parse(inputText);
+  const snapshot = {
+    ...input,
+    date: args.date || input.date,
+    state: args.state || input.state,
+  };
+  const reportPath = resolve(args.report);
+  const updated = upsertApplicationAnswersSection(readFileSync(reportPath, 'utf-8'), snapshot);
+  writeFileSync(reportPath, updated, 'utf-8');
+
+  const normalized = normalizeApplicationAnswersSnapshot(snapshot);
+  console.log(JSON.stringify({ report: reportPath, date: normalized.date, state: normalized.state }, null, 2));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err.message);
+    process.exitCode = 1;
+  });
+}

--- a/application-answers.mjs
+++ b/application-answers.mjs
@@ -162,7 +162,14 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--help' || arg === '-h') args.help = true;
-    else if (arg.startsWith('--')) args[arg.slice(2)] = argv[++i] ?? '';
+    else if (arg.startsWith('--')) {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      args[arg.slice(2)] = value;
+      i += 1;
+    }
   }
   return args;
 }
@@ -176,7 +183,14 @@ function usage() {
 }
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2));
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`${err.message}\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
   if (args.help) {
     console.log(usage());
     return;

--- a/modes/apply.md
+++ b/modes/apply.md
@@ -15,11 +15,12 @@ Interactive mode for when the candidate is filling out an application form in Ch
 1. DETECT      → Read active Chrome tab (screenshot/URL/title)
 2. IDENTIFY    → Extract company + role from the page
 3. SEARCH      → Match against existing reports in reports/
-4. LOAD        → Read full report + Section G (if it exists)
+4. LOAD        → Read full report + Section H / Application Answers (if they exist)
 5. PREFLIGHT   → Confirm posting liveness + company/role match before drafting
 6. ANALYZE     → Identify ALL visible form questions
 7. GENERATE    → For each question, generate a personalized response
 8. PRESENT     → Show formatted responses for copy-paste
+9. PERSIST     → Save the final filled/submitted answers into the report
 ```
 
 ## Step 5 — Preflight gate
@@ -54,7 +55,7 @@ Do not continue to Step 6 until this preflight is resolved.
 1. Extract company name and role title from the page
 2. Search in `reports/` by company name (case-insensitive grep)
 3. If there is a match → load the full report
-4. If there is a Section G → load previous draft answers as a base
+4. If there is a Section H or `## Application Answers` → load previous answers as a base
 5. If there is NO match → notify and offer to run a quick auto-pipeline
 
 ## Step 3 — Detect changes in the role
@@ -62,7 +63,7 @@ Do not continue to Step 6 until this preflight is resolved.
 If the role on screen differs from the one evaluated:
 - **Notify the candidate**: "The role has changed from [X] to [Y]. Do you want me to re-evaluate or adapt the responses to the new title?"
 - **If adapt**: Adjust responses to the new role without re-evaluating, only after the candidate explicitly accepts the mismatch
-- **If re-evaluate**: Execute full A-F evaluation, update report, regenerate Section G
+- **If re-evaluate**: Execute full A-F evaluation, update report, regenerate Section H
 - **Update tracker**: Change role title in applications.md if applicable
 
 ## Step 6 — Analyze form questions
@@ -75,7 +76,7 @@ Identify ALL visible questions:
 - Upload fields (resume, cover letter PDF)
 
 Classify each question:
-- **Already answered in Section G** → adapt the existing response
+- **Already answered in Section H or `## Application Answers`** → adapt the existing response
 - **New question** → generate response from the report + cv.md
 
 For each field, preserve the application form contract:
@@ -93,7 +94,7 @@ Never invent answers for legal, demographic, work-authorization, visa/sponsorshi
 For each question, generate the response following:
 
 1. **Report context**: Use proof points from block B, STAR stories from block F
-2. **Previous Section G**: If a draft response exists, use it as a base and refine
+2. **Previous Section H / Application Answers**: If a draft or final response exists, use it as a base and refine
 3. **"I'm choosing you" tone**: Same auto-pipeline framework
 4. **Specificity**: Reference something specific from the JD visible on screen
 5. **career-ops proof point**: Include in "Additional info" if there is a field for it
@@ -124,11 +125,31 @@ Notes:
 - [Personalization suggestions the candidate should review]
 ```
 
-## Step 8 — Post-apply (optional)
+## Step 8 — Persist application snapshot
+
+After the final answers are filled into the form or handed to the candidate for copy-paste, update the matched report with an additive `## Application Answers` section. If the candidate later confirms submission, update that same section from `filled` to `submitted`.
+
+The section must include:
+- `**Date:** YYYY-MM-DD`
+- `**State:** filled` or `**State:** submitted`
+- Free-text answers exactly as submitted
+- Dropdown/radio/checkbox selections made
+- Number or short-answer fields such as compensation, availability, start date, and work authorization
+- Files used, including CV, cover letter, portfolio, or other uploads with version/path when known
+
+Write the section at the end of the report, or replace only the existing `## Application Answers` section if it already exists. Do not rename, reorder, or edit the existing A-H report blocks or `## Keywords extracted`.
+
+Use `application-answers.mjs` when possible to format/upsert the section:
+
+```bash
+node application-answers.mjs --report reports/NNN-company-role-date.md --input answers.json --state filled
+```
+
+## Step 9 — Post-apply (optional)
 
 If the candidate confirms that they submitted the application:
 1. Update status in `applications.md` from "Evaluated" to "Applied"
-2. Update Section G of the report with the final responses
+2. Refresh the report's `## Application Answers` section with the final field values and `**State:** submitted`
 3. Suggest next step: run the `contacto` mode (`/career-ops contacto` where available) for LinkedIn outreach
 
 ## Scroll handling

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -446,7 +446,8 @@ try {
 if (!QUICK) {
   console.log('\n4. Dashboard build');
   const isWindows = process.platform === 'win32';
-  const outPath = isWindows ? 'career-dashboard-test.exe' : join(tmpdir(), 'career-dashboard-test');
+  const dashboardBuildTmp = mkdtempSync(join(tmpdir(), 'career-dashboard-build-'));
+  const outPath = join(dashboardBuildTmp, isWindows ? 'career-dashboard-test.exe' : 'career-dashboard-test');
   const goEnv = { ...process.env };
   if (isWindows && !goEnv.GOCACHE) {
     goEnv.GOCACHE = join(tmpdir(), 'career-ops-go-build-cache');
@@ -462,14 +463,11 @@ if (!QUICK) {
   });
   if (goBuild !== null) {
     pass('Dashboard compiles');
-    if (isWindows) {
-      try { rmSync(join(ROOT, 'dashboard', 'career-dashboard-test.exe'), { force: true }); } catch (e) {}
-    } else {
-      try { rmSync(outPath, { force: true }); } catch (e) {}
-    }
+    try { rmSync(outPath, { force: true }); } catch (e) {}
   } else {
     fail('Dashboard build failed');
   }
+  try { rmSync(dashboardBuildTmp, { recursive: true, force: true }); } catch (e) {}
 } else {
   console.log('\n4. Dashboard build (skipped --quick)');
 }
@@ -827,6 +825,15 @@ try {
   }
 } catch (e) {
   fail(`application answers helper crashed: ${e.message}`);
+}
+
+if (
+  run(NODE, ['application-answers.mjs', '--report', '--input'], { stdio: ['pipe', 'pipe', 'pipe'] }) === null &&
+  run(NODE, ['application-answers.mjs', '--report', '--input', 'answers.json'], { stdio: ['pipe', 'pipe', 'pipe'] }) === null
+) {
+  pass('application-answers CLI rejects missing option values');
+} else {
+  fail('application-answers CLI accepted a missing option value');
 }
 
 const ofertaMode = readFile('modes/oferta.md');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -446,12 +446,26 @@ try {
 if (!QUICK) {
   console.log('\n4. Dashboard build');
   const isWindows = process.platform === 'win32';
-  const outPath = isWindows ? 'career-dashboard-test.exe' : '/tmp/career-dashboard-test';
-  const goBuild = run(`cd dashboard && go build -o ${outPath} . 2>&1`);
+  const outPath = isWindows ? 'career-dashboard-test.exe' : join(tmpdir(), 'career-dashboard-test');
+  const goEnv = { ...process.env };
+  if (isWindows && !goEnv.GOCACHE) {
+    goEnv.GOCACHE = join(tmpdir(), 'career-ops-go-build-cache');
+  }
+  if (goEnv.GOCACHE) {
+    try { mkdirSync(goEnv.GOCACHE, { recursive: true }); } catch (e) {}
+  }
+  const goBuild = run('go', ['build', '-o', outPath, '.'], {
+    cwd: join(ROOT, 'dashboard'),
+    env: goEnv,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 60000,
+  });
   if (goBuild !== null) {
     pass('Dashboard compiles');
     if (isWindows) {
       try { rmSync(join(ROOT, 'dashboard', 'career-dashboard-test.exe'), { force: true }); } catch (e) {}
+    } else {
+      try { rmSync(outPath, { force: true }); } catch (e) {}
     }
   } else {
     fail('Dashboard build failed');
@@ -708,6 +722,111 @@ if (
   pass('apply mode includes liveness and role-match preflight gate');
 } else {
   fail('apply mode missing liveness/role-match preflight gate');
+}
+
+if (
+  applyMode.includes('## Application Answers') &&
+  applyMode.includes('**State:** filled') &&
+  applyMode.includes('**State:** submitted') &&
+  applyMode.includes('Do not rename, reorder, or edit the existing A-H report blocks') &&
+  applyMode.includes('application-answers.mjs')
+) {
+  pass('apply mode persists filled/submitted answers in an additive report section');
+} else {
+  fail('apply mode missing additive Application Answers persistence instructions');
+}
+
+try {
+  const {
+    formatApplicationAnswersSection,
+    upsertApplicationAnswersSection,
+  } = await import(pathToFileURL(join(ROOT, 'application-answers.mjs')).href);
+
+  const snapshot = {
+    date: '2026-06-30',
+    state: 'submitted',
+    freeText: [
+      { question: 'Why this role?', answer: 'I want to apply production AI agent experience here.' },
+    ],
+    selections: [
+      { field: 'Technical areas', selected: ['Node.js', 'Go', 'LLM evaluation'] },
+    ],
+    fieldValues: [
+      { field: 'Compensation expectation', value: '$150k base' },
+    ],
+    files: [
+      { field: 'CV', path: 'output/acme-cv.pdf', version: 'v3' },
+      { field: 'Cover letter', path: 'output/acme-cover-letter.pdf' },
+    ],
+  };
+
+  const section = formatApplicationAnswersSection(snapshot);
+  if (
+    section.includes('## Application Answers') &&
+    section.includes('**Date:** 2026-06-30') &&
+    section.includes('**State:** submitted') &&
+    section.includes('Why this role?') &&
+    section.includes('Node.js, Go, LLM evaluation') &&
+    section.includes('Compensation expectation') &&
+    section.includes('output/acme-cv.pdf (v3)')
+  ) {
+    pass('application answers formatter captures free text, selections, field values, files, date, and state');
+  } else {
+    fail(`application answers formatter dropped expected data:\n${section}`);
+  }
+
+  const report = [
+    '# Evaluation: Acme - Staff Engineer',
+    '',
+    '## G) Posting Legitimacy',
+    'original G content',
+    '',
+    '## H) Draft Application Answers',
+    'draft H content',
+    '',
+    '## Keywords extracted',
+    'agentic systems, node, go',
+    '',
+  ].join('\n');
+  const updated = upsertApplicationAnswersSection(report, snapshot);
+  const existingBlocksPreserved =
+    updated.includes('## G) Posting Legitimacy\noriginal G content') &&
+    updated.includes('## H) Draft Application Answers\ndraft H content') &&
+    updated.includes('## Keywords extracted\nagentic systems, node, go');
+  const existingOrderPreserved =
+    updated.indexOf('## G) Posting Legitimacy') < updated.indexOf('## H) Draft Application Answers') &&
+    updated.indexOf('## H) Draft Application Answers') < updated.indexOf('## Keywords extracted') &&
+    updated.indexOf('## Keywords extracted') < updated.indexOf('## Application Answers');
+  if (existingBlocksPreserved && existingOrderPreserved) {
+    pass('application answers upsert appends without changing existing report blocks');
+  } else {
+    fail(`application answers upsert disturbed report blocks:\n${updated}`);
+  }
+
+  const refreshed = upsertApplicationAnswersSection([
+    report.trimEnd(),
+    '',
+    '## Application Answers',
+    '',
+    'old filled snapshot',
+    '',
+    '## Later Additive Section',
+    'later content',
+    '',
+  ].join('\n'), snapshot);
+  const applicationAnswerHeadings = refreshed.match(/^## Application Answers$/gm) || [];
+  if (
+    applicationAnswerHeadings.length === 1 &&
+    !refreshed.includes('old filled snapshot') &&
+    refreshed.includes('## Later Additive Section\nlater content') &&
+    refreshed.indexOf('## Application Answers') < refreshed.indexOf('## Later Additive Section')
+  ) {
+    pass('application answers upsert refreshes only the existing Application Answers section');
+  } else {
+    fail(`application answers upsert did not replace only its own section:\n${refreshed}`);
+  }
+} catch (e) {
+  fail(`application answers helper crashed: ${e.message}`);
 }
 
 const ofertaMode = readFile('modes/oferta.md');
@@ -7906,12 +8025,14 @@ console.log('\n49. Plugin engine (contract + sandbox + firewall)');
 
 const __origWarn = console.warn;
 let __pluginTmp = null;
+let __manifestTmp = null;
 try {
   const eng = await import(pathToFileURL(join(ROOT, 'plugins/_engine.mjs')).href);
   const { validateManifest, discoverPlugins, pluginRoots, buildCtx, mergeProviderPlugins } = eng;
 
   const base = { id: 'x', apiVersion: 1, description: 'one line', hooks: ['ingest'], requiredEnv: [], allowedHosts: [], humanInTheLoop: true };
-  const vm = (m, dirName = 'x') => validateManifest(m, join('/tmp', dirName), dirName);
+  __manifestTmp = mkdtempSync(join(tmpdir(), 'co-plugin-manifest-'));
+  const vm = (m, dirName = 'x') => validateManifest(m, join(__manifestTmp, dirName), dirName);
 
   // Manifest validation (warnings are expected here — suppress to keep output clean).
   console.warn = () => {};
@@ -8206,6 +8327,7 @@ try {
 } finally {
   console.warn = __origWarn;
   if (__pluginTmp) { try { rmSync(__pluginTmp, { recursive: true, force: true }); } catch {} }
+  if (__manifestTmp) { try { rmSync(__manifestTmp, { recursive: true, force: true }); } catch {} }
 }
 
 // ── SUMMARY ─────────────────────────────────────────────────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -644,11 +644,48 @@ if (!/waitUntil:\s*['"]networkidle['"]/.test(generatePdfScript)) {
 } else {
   fail('generate-pdf still waits for networkidle');
 }
-const renderHtmlToPdfCall = generatePdfScript.match(/renderHtmlToPdf\(html,\s*outputPath,\s*\{([\s\S]*?)\}\)/);
-if (renderHtmlToPdfCall && /\breportNum\b/.test(renderHtmlToPdfCall[1]) && /\binputPath\b/.test(renderHtmlToPdfCall[1])) {
+
+function extractRenderHtmlToPdfOptions(source) {
+  const call = /renderHtmlToPdf\s*\(\s*html\s*,\s*outputPath\s*,/g.exec(source);
+  if (!call) return '';
+  const objectStart = source.indexOf('{', call.index + call[0].length);
+  if (objectStart === -1) return '';
+
+  let depth = 0;
+  let quote = '';
+  let escaped = false;
+  for (let i = objectStart; i < source.length; i += 1) {
+    const ch = source[i];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === quote) quote = '';
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(objectStart + 1, i);
+    }
+  }
+  return '';
+}
+
+const renderHtmlToPdfOptions = extractRenderHtmlToPdfOptions(generatePdfScript);
+if (renderHtmlToPdfOptions && /\breportNum\b/.test(renderHtmlToPdfOptions) && /\binputPath\b/.test(renderHtmlToPdfOptions)) {
   pass('generate-pdf threads reportNum/inputPath into renderHtmlToPdf');
 } else {
   fail('generate-pdf does not pass reportNum/inputPath into renderHtmlToPdf');
+}
+const nestedRenderOptions = extractRenderHtmlToPdfOptions('return renderHtmlToPdf(html, outputPath, { format, metadata: { reportNum, inputPath } });');
+if (/\breportNum\b/.test(nestedRenderOptions) && /\binputPath\b/.test(nestedRenderOptions)) {
+  pass('generate-pdf renderHtmlToPdf option matcher handles nested object literals');
+} else {
+  fail('generate-pdf renderHtmlToPdf option matcher fails on nested object literals');
 }
 if (generatePdfScript.includes('opts.reportNum') && generatePdfScript.includes('opts.inputPath')) {
   pass('renderHtmlToPdf reads manifest metadata from opts');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -88,6 +88,7 @@ const SYSTEM_PATHS = [
   'generate-pdf.mjs',
   'generate-latex.mjs',
   'archive-posting.mjs',
+  'application-answers.mjs',
   'generate-cover-letter.mjs',
   'merge-tracker.mjs',
   'tracker-links.mjs',


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- Link the issue this PR addresses, if it has one. Format: Fixes #123 / Closes #123 -->
<!-- Issue-first is asked for NEW FEATURES, new modes/commands, and architecture changes — it saves you from building something we'd have to redirect. -->
<!-- No issue needed, send the PR straight in: bug fixes, new zero-auth scanner providers, docs, and translations. We don't want to slow these down. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

  ## Summary
  - add an Application Answers helper that upserts a dedicated report section
  - update apply mode to persist filled/submitted answer snapshots instead of mutating existing report blocks
  - test free-text answers, selections, field values, uploaded files, date/state, and additive report behavior

  Closes santifer/career-ops#1362

  ## Tests
  - node test-all.mjs
  
  ---
  
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated generation and upsert of an **Application Answers** section in reports from JSON input, including normalized dates, `filled|submitted` state, text responses, selections, and uploaded files.
  * Updated the application workflow to reuse the saved **Application Answers** section when continuing/editing, and to persist a fresh snapshot after apply, then finalize to `submitted` after confirmation.
* **Bug Fixes**
  * Improved report refreshing to update only the **Application Answers** section without overwriting surrounding content.
  * Enhanced reliability of generation/validation across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->