### PR TITLE
feat(evals): golden-set eval harness for cheap-model routing (#1354)

### DIFF
--- a/eval-golden.mjs
+++ b/eval-golden.mjs
@@ -30,8 +30,7 @@ import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
-const GOLDEN_DIR  = join(ROOT, 'evals', 'golden');
-const FIXTURE_DIR = join(ROOT, 'evals', 'fixtures');
+const GOLDEN_DIR = join(ROOT, 'evals', 'golden');
 
 // ---------------------------------------------------------------------------
 // TODO(#1354): the four open design calls, surfaced as tunable constants.
@@ -61,6 +60,7 @@ if (args.includes('--help') || args.includes('-h')) {
   --live           Call the model live via openai-eval.mjs (needs key + cv.md)
   --model <id>     Candidate model id to evaluate (default: cheap-stub)
   --golden <dir>   Golden-set directory (default: evals/golden)
+  --fixtures <dir> Replay fixtures directory (default: sibling of --golden)
   --help           Show this help
 `);
   process.exit(0);
@@ -69,6 +69,9 @@ if (args.includes('--help') || args.includes('-h')) {
 const mode  = args.includes('--live') ? 'live' : 'replay';
 const model = argValue('--model') || 'cheap-stub';
 const goldenDir = argValue('--golden') || GOLDEN_DIR;
+// Keep fixtures next to the golden set so a custom --golden dir resolves its
+// own fixtures (the default lands on evals/fixtures); override with --fixtures.
+const fixtureDir = argValue('--fixtures') || join(dirname(goldenDir), 'fixtures');
 
 /**
  * Read the value following a `--flag` token in argv.
@@ -120,9 +123,9 @@ function parseSummary(text) {
  */
 function getCompletion(testCase) {
   if (mode === 'replay') {
-    const fixture = join(FIXTURE_DIR, `${testCase.id}__${model}.txt`);
+    const fixture = join(fixtureDir, `${testCase.id}__${model}.txt`);
     if (!existsSync(fixture)) {
-      throw new Error(`missing replay fixture: evals/fixtures/${testCase.id}__${model}.txt — record it or run --live`);
+      throw new Error(`missing replay fixture: ${fixture} — record it or run --live`);
     }
     return readFileSync(fixture, 'utf8');
   }
@@ -165,9 +168,24 @@ if (!existsSync(goldenDir)) {
   process.exit(1);
 }
 
-const cases = readdirSync(goldenDir)
-  .filter((f) => f.endsWith('.json'))
-  .map((f) => ({ ...JSON.parse(readFileSync(join(goldenDir, f), 'utf8')) }));
+let cases;
+try {
+  cases = readdirSync(goldenDir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => {
+      const parsed = JSON.parse(readFileSync(join(goldenDir, f), 'utf8'));
+      if (typeof parsed?.id !== 'string' ||
+          typeof parsed?.jd !== 'string' ||
+          typeof parsed?.label?.archetype !== 'string' ||
+          typeof parsed?.label?.score !== 'number') {
+        throw new Error(`invalid golden case ${f}: need string id/jd and label.{archetype:string, score:number}`);
+      }
+      return parsed;
+    });
+} catch (err) {
+  console.error(`❌  ${err.message || err}`);
+  process.exit(1);
+}
 
 if (cases.length === 0) {
   console.error(`❌  no golden cases (*.json) in ${goldenDir}`);

--- a/eval-golden.mjs
+++ b/eval-golden.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * eval-golden.mjs — golden-set eval harness for cheap-model routing (#1354)
+ *
+ * SCAFFOLDING. The *mechanism* in this file is design-invariant: load labeled
+ * golden cases, obtain each candidate model's `---SCORE_SUMMARY---` block
+ * (replayed from a recorded fixture for $0 deterministic CI, or live via
+ * openai-eval.mjs), compare it to the reference label, and exit 0/1 on an
+ * aggregate threshold. That part should hold regardless of the open design
+ * questions on #1354.
+ *
+ * What is deliberately left as TODO(#1354) pending maintainer steer — these are
+ * the four calls raised in the issue thread, surfaced as named constants /
+ * placeholder data so they are trivial to tune once decided:
+ *   - reference labels   → the `label` blocks in evals/golden/*.json
+ *   - SCORE agreement     → SCORE_TOLERANCE (exact vs band)
+ *   - CI gate threshold   → MIN_ARCHETYPE_AGREEMENT
+ *   - per-model $/run      → COST_PER_RUN_USD
+ *
+ * Usage:
+ *   node eval-golden.mjs --replay --model cheap-stub     # offline, deterministic ($0)
+ *   node eval-golden.mjs --live   --model gpt-4o-mini    # calls openai-eval.mjs (needs key + cv.md)
+ *   npm run eval:golden -- --replay --model cheap-stub
+ */
+
+import { readFileSync, readdirSync, existsSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const GOLDEN_DIR  = join(ROOT, 'evals', 'golden');
+const FIXTURE_DIR = join(ROOT, 'evals', 'fixtures');
+
+// ---------------------------------------------------------------------------
+// TODO(#1354): the four open design calls, surfaced as tunable constants.
+// ---------------------------------------------------------------------------
+
+/** Max |candidate.score - label.score| still counted as agreement.
+ *  TODO(#1354): maintainer to confirm exact-match (0) vs a tolerance band. */
+const SCORE_TOLERANCE = 0.5;
+
+/** Fraction of cases whose ARCHETYPE must match the label for the gate to pass.
+ *  ARCHETYPE exact-match is the clean 0/1 signal hinted at in the issue.
+ *  TODO(#1354): maintainer to confirm the CI threshold. */
+const MIN_ARCHETYPE_AGREEMENT = 0.8;
+
+/** Rough $/run per model id, for the cost column. Empty until rates are agreed.
+ *  TODO(#1354): populate from the providers we actually want to route to. */
+const COST_PER_RUN_USD = {};
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`eval-golden.mjs — golden-set eval harness (#1354, scaffolding)
+
+  --replay         Replay recorded fixtures (default; offline, $0, deterministic)
+  --live           Call the model live via openai-eval.mjs (needs key + cv.md)
+  --model <id>     Candidate model id to evaluate (default: cheap-stub)
+  --golden <dir>   Golden-set directory (default: evals/golden)
+  --help           Show this help
+`);
+  process.exit(0);
+}
+
+const mode  = args.includes('--live') ? 'live' : 'replay';
+const model = argValue('--model') || 'cheap-stub';
+const goldenDir = argValue('--golden') || GOLDEN_DIR;
+
+/**
+ * Read the value following a `--flag` token in argv.
+ *
+ * @param {string} flag - The flag whose following value to return.
+ * @returns {string|undefined} The value, or undefined if the flag is absent/last.
+ */
+function argValue(flag) {
+  const i = args.indexOf(flag);
+  return i >= 0 && i + 1 < args.length ? args[i + 1] : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Shared SCORE_SUMMARY parser — same contract every *-eval.mjs already emits.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the machine-readable summary block produced by the eval scripts.
+ *
+ * @param {string} text - Raw model output containing a SCORE_SUMMARY block.
+ * @returns {{score: number, archetype: string}} Parsed score/archetype; score
+ *   is NaN and archetype is "unknown" when the block is missing or malformed.
+ */
+function parseSummary(text) {
+  const block = text.match(/---SCORE_SUMMARY---\s*([\s\S]*?)---END_SUMMARY---/);
+  const field = (key) => {
+    const m = block && block[1].match(new RegExp(`${key}:\\s*(.+)`));
+    return m ? m[1].trim() : '';
+  };
+  return {
+    score:     parseFloat(field('SCORE')),
+    archetype: (field('ARCHETYPE') || 'unknown').toLowerCase(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Obtain one candidate completion (replay fixture or live openai-eval call).
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the candidate model's raw evaluation text for one golden case.
+ *
+ * In replay mode this reads a recorded fixture so the gate is offline and
+ * deterministic; in live mode it shells out to openai-eval.mjs, reusing the
+ * real prompt-assembly path rather than duplicating it here.
+ *
+ * @param {{id: string, jd: string}} testCase - The golden case being run.
+ * @returns {string} Raw model output (expected to contain a SCORE_SUMMARY block).
+ */
+function getCompletion(testCase) {
+  if (mode === 'replay') {
+    const fixture = join(FIXTURE_DIR, `${testCase.id}__${model}.txt`);
+    if (!existsSync(fixture)) {
+      throw new Error(`missing replay fixture: evals/fixtures/${testCase.id}__${model}.txt — record it or run --live`);
+    }
+    return readFileSync(fixture, 'utf8');
+  }
+
+  // live: write the JD to a temp file and run the existing evaluator.
+  const dir = mkdtempSync(join(tmpdir(), 'eval-golden-'));
+  try {
+    const jdFile = join(dir, 'jd.txt');
+    writeFileSync(jdFile, testCase.jd);
+    const res = spawnSync(process.execPath,
+      [join(ROOT, 'openai-eval.mjs'), '--file', jdFile, '--model', model, '--no-save'],
+      { encoding: 'utf8', env: process.env, timeout: 360000 });
+    if (res.status !== 0) {
+      throw new Error(`openai-eval.mjs exited ${res.status}: ${(res.stderr || '').slice(0, 200)}`);
+    }
+    return res.stdout || '';
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Median of a numeric array (0 for an empty array).
+ *
+ * @param {number[]} xs - Values to summarize.
+ * @returns {number} The median value.
+ */
+function median(xs) {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+if (!existsSync(goldenDir)) {
+  console.error(`❌  golden-set directory not found: ${goldenDir}`);
+  process.exit(1);
+}
+
+const cases = readdirSync(goldenDir)
+  .filter((f) => f.endsWith('.json'))
+  .map((f) => ({ ...JSON.parse(readFileSync(join(goldenDir, f), 'utf8')) }));
+
+if (cases.length === 0) {
+  console.error(`❌  no golden cases (*.json) in ${goldenDir}`);
+  process.exit(1);
+}
+
+console.log(`\ngolden-set eval — model "${model}" (${mode}), ${cases.length} case(s)\n`);
+
+let archetypeHits = 0;
+const deltas = [];
+const latencies = [];
+
+for (const tc of cases) {
+  const t0 = Date.now();
+  let parsed;
+  try {
+    parsed = parseSummary(getCompletion(tc));
+  } catch (err) {
+    console.log(`  ❌ ${tc.id}: ${err.message}`);
+    deltas.push(NaN);
+    continue;
+  }
+  const latencyMs = Date.now() - t0;
+  latencies.push(latencyMs);
+
+  const archetypeMatch = parsed.archetype === String(tc.label.archetype).toLowerCase();
+  const delta = Math.abs(parsed.score - tc.label.score);
+  const scoreOk = Number.isFinite(delta) && delta <= SCORE_TOLERANCE;
+  if (archetypeMatch) archetypeHits++;
+  deltas.push(delta);
+
+  const ok = archetypeMatch && scoreOk;
+  console.log(
+    `  ${ok ? '✅' : '❌'} ${tc.id}: ` +
+    `archetype ${parsed.archetype} vs ${String(tc.label.archetype).toLowerCase()} ` +
+    `(${archetypeMatch ? 'match' : 'MISS'}); ` +
+    `score ${parsed.score} vs ${tc.label.score} (Δ${Number.isFinite(delta) ? delta.toFixed(2) : 'n/a'}); ` +
+    `${mode === 'live' ? `${latencyMs}ms` : 'replay'}`,
+  );
+}
+
+const agreement = archetypeHits / cases.length;
+const finiteDeltas = deltas.filter(Number.isFinite);
+const meanDelta = finiteDeltas.length ? finiteDeltas.reduce((a, b) => a + b, 0) / finiteDeltas.length : NaN;
+const cost = COST_PER_RUN_USD[model];
+
+console.log('\n  ── summary ──');
+console.log(`  archetype agreement : ${(agreement * 100).toFixed(0)}%  (gate ≥ ${(MIN_ARCHETYPE_AGREEMENT * 100).toFixed(0)}%)`);
+console.log(`  mean |Δscore|       : ${Number.isFinite(meanDelta) ? meanDelta.toFixed(2) : 'n/a'}  (tolerance ±${SCORE_TOLERANCE})`);
+if (mode === 'live') console.log(`  median latency      : ${median(latencies)}ms`);
+console.log(`  est. $/run          : ${cost != null ? `$${cost}` : 'n/a — TODO(#1354)'}`);
+
+const passed = agreement >= MIN_ARCHETYPE_AGREEMENT;
+console.log(`\n  ${passed ? '✅ PASS' : '❌ FAIL'} — archetype agreement ${passed ? 'meets' : 'below'} gate\n`);
+process.exit(passed ? 0 : 1);

--- a/eval-golden.mjs
+++ b/eval-golden.mjs
@@ -84,6 +84,20 @@ function argValue(flag) {
   return i >= 0 && i + 1 < args.length ? args[i + 1] : undefined;
 }
 
+/**
+ * Flatten a model id into a filesystem-safe fixture token.
+ *
+ * Provider ids like "deepseek/deepseek-chat" contain slashes that would be read
+ * as path separators; collapse any non-[A-Za-z0-9._-] run to a single "-" so the
+ * fixture stays a single flat file.
+ *
+ * @param {string} m - The candidate model id.
+ * @returns {string} A path-safe token for the fixture filename.
+ */
+function fixtureModelId(m) {
+  return m.replace(/[^A-Za-z0-9._-]+/g, '-');
+}
+
 // ---------------------------------------------------------------------------
 // Shared SCORE_SUMMARY parser — same contract every *-eval.mjs already emits.
 // ---------------------------------------------------------------------------
@@ -123,7 +137,10 @@ function parseSummary(text) {
  */
 function getCompletion(testCase) {
   if (mode === 'replay') {
-    const fixture = join(fixtureDir, `${testCase.id}__${model}.txt`);
+    // Slash-form provider ids (e.g. "deepseek/deepseek-chat") must not become
+    // path separators, or the fixture lands in a phantom subdirectory. Sanitize
+    // to a flat filename — record fixtures under the same sanitized name.
+    const fixture = join(fixtureDir, `${testCase.id}__${fixtureModelId(model)}.txt`);
     if (!existsSync(fixture)) {
       throw new Error(`missing replay fixture: ${fixture} — record it or run --live`);
     }
@@ -231,11 +248,14 @@ for (const tc of cases) {
 const agreement = archetypeHits / cases.length;
 const finiteDeltas = deltas.filter(Number.isFinite);
 const meanDelta = finiteDeltas.length ? finiteDeltas.reduce((a, b) => a + b, 0) / finiteDeltas.length : NaN;
+// Cases whose SCORE was missing/malformed produce a NaN delta and drop out of
+// the mean — surface that count so a model can't hide failures behind a low mean.
+const unscored = cases.length - finiteDeltas.length;
 const cost = COST_PER_RUN_USD[model];
 
 console.log('\n  ── summary ──');
 console.log(`  archetype agreement : ${(agreement * 100).toFixed(0)}%  (gate ≥ ${(MIN_ARCHETYPE_AGREEMENT * 100).toFixed(0)}%)`);
-console.log(`  mean |Δscore|       : ${Number.isFinite(meanDelta) ? meanDelta.toFixed(2) : 'n/a'}  (tolerance ±${SCORE_TOLERANCE})`);
+console.log(`  mean |Δscore|       : ${Number.isFinite(meanDelta) ? meanDelta.toFixed(2) : 'n/a'}  over ${finiteDeltas.length}/${cases.length} scored${unscored ? ` (${unscored} unscored)` : ''}  (tolerance ±${SCORE_TOLERANCE})`);
 if (mode === 'live') console.log(`  median latency      : ${median(latencies)}ms`);
 console.log(`  est. $/run          : ${cost != null ? `$${cost}` : 'n/a — TODO(#1354)'}`);
 

--- a/eval-golden.mjs
+++ b/eval-golden.mjs
@@ -2,20 +2,20 @@
 /**
  * eval-golden.mjs — golden-set eval harness for cheap-model routing (#1354)
  *
- * SCAFFOLDING. The *mechanism* in this file is design-invariant: load labeled
- * golden cases, obtain each candidate model's `---SCORE_SUMMARY---` block
- * (replayed from a recorded fixture for $0 deterministic CI, or live via
- * openai-eval.mjs), compare it to the reference label, and exit 0/1 on an
- * aggregate threshold. That part should hold regardless of the open design
- * questions on #1354.
+ * The *mechanism* in this file is design-invariant: load labeled golden cases,
+ * obtain each candidate model's `---SCORE_SUMMARY---` block (replayed from a
+ * recorded fixture for $0 deterministic CI, or live via openai-eval.mjs),
+ * compare it to the reference label, and exit 0/1 on an aggregate threshold.
  *
- * What is deliberately left as TODO(#1354) pending maintainer steer — these are
- * the four calls raised in the issue thread, surfaced as named constants /
- * placeholder data so they are trivial to tune once decided:
- *   - reference labels   → the `label` blocks in evals/golden/*.json
- *   - SCORE agreement     → SCORE_TOLERANCE (exact vs band)
+ * Labels are frozen reference (Claude-tier) verdicts — the metric is
+ * agreement-with-reference, not absolute correctness (see evals/README.md).
+ * ARCHETYPE agreement is the gate; SCORE is a secondary tolerance-banded signal.
+ *
+ * The remaining knobs are surfaced as named constants so they stay trivial to
+ * tune, with safe v1 defaults:
+ *   - SCORE agreement     → SCORE_TOLERANCE (±band; distance-to-reference)
  *   - CI gate threshold   → MIN_ARCHETYPE_AGREEMENT
- *   - per-model $/run      → COST_PER_RUN_USD
+ *   - per-model $/run      → COST_PER_RUN_USD (empty until routing rates agreed)
  *
  * Usage:
  *   node eval-golden.mjs --replay --model cheap-stub     # offline, deterministic ($0)
@@ -33,20 +33,20 @@ const ROOT = dirname(fileURLToPath(import.meta.url));
 const GOLDEN_DIR = join(ROOT, 'evals', 'golden');
 
 // ---------------------------------------------------------------------------
-// TODO(#1354): the four open design calls, surfaced as tunable constants.
+// Tunable knobs (#1354), with safe v1 defaults — see evals/README.md.
 // ---------------------------------------------------------------------------
 
 /** Max |candidate.score - label.score| still counted as agreement.
- *  TODO(#1354): maintainer to confirm exact-match (0) vs a tolerance band. */
+ *  v1: a ±band, per the distance-to-reference metric (not exact match). */
 const SCORE_TOLERANCE = 0.5;
 
 /** Fraction of cases whose ARCHETYPE must match the label for the gate to pass.
  *  ARCHETYPE exact-match is the clean 0/1 signal hinted at in the issue.
- *  TODO(#1354): maintainer to confirm the CI threshold. */
+ *  v1 default: 0.8 — tunable when this is wired into the CI job. */
 const MIN_ARCHETYPE_AGREEMENT = 0.8;
 
-/** Rough $/run per model id, for the cost column. Empty until rates are agreed.
- *  TODO(#1354): populate from the providers we actually want to route to. */
+/** Rough $/run per model id, for the cost column. Empty until the routing
+ *  provider rates are agreed (#1354). */
 const COST_PER_RUN_USD = {};
 
 // ---------------------------------------------------------------------------
@@ -54,7 +54,7 @@ const COST_PER_RUN_USD = {};
 // ---------------------------------------------------------------------------
 const args = process.argv.slice(2);
 if (args.includes('--help') || args.includes('-h')) {
-  console.log(`eval-golden.mjs — golden-set eval harness (#1354, scaffolding)
+  console.log(`eval-golden.mjs — golden-set eval harness (#1354)
 
   --replay         Replay recorded fixtures (default; offline, $0, deterministic)
   --live           Call the model live via openai-eval.mjs (needs key + cv.md)
@@ -192,7 +192,8 @@ if (cases.length === 0) {
   process.exit(1);
 }
 
-console.log(`\ngolden-set eval — model "${model}" (${mode}), ${cases.length} case(s)\n`);
+console.log(`\ngolden-set eval — model "${model}" (${mode}), ${cases.length} case(s)`);
+console.log(`(row ✅ needs both archetype + score; the gate counts archetype agreement only)\n`);
 
 let archetypeHits = 0;
 const deltas = [];

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,69 @@
+# Golden-set eval for cheap-model routing (#1354)
+
+> **Status: scaffolding.** The *mechanism* (`eval-golden.mjs`) is design-invariant
+> and runs today. The reference labels and gate thresholds are placeholders pending
+> maintainer decisions — see **Open design questions** below.
+
+## What this is
+
+A small labeled golden-set plus a harness that measures how well a *candidate*
+cheap model agrees with reference labels, so "is model X good enough to route to?"
+becomes a number instead of a hunch. It reuses the `---SCORE_SUMMARY---` contract
+that every `*-eval.mjs` already emits (`SCORE` + `ARCHETYPE`), so there is no new
+scoring surface.
+
+## Layout
+
+```
+evals/
+  golden/      labeled cases — one JSON per case (synthetic JDs, no user data)
+  fixtures/    recorded candidate outputs for $0 deterministic replay in CI
+  README.md    this file
+eval-golden.mjs  the harness (root level, sibling to openai-eval.mjs)
+```
+
+### Golden case format (`evals/golden/*.json`)
+
+```json
+{
+  "id": "ai-platform-llmops",
+  "synthetic": true,
+  "jd": "<full synthetic job description text>",
+  "label": { "archetype": "AI Platform / LLMOps", "score": 4.2 }
+}
+```
+
+All JDs are **synthetic** so the set stays clear of the `no-user-data` guard.
+
+### Fixture format (`evals/fixtures/<case-id>__<model>.txt`)
+
+A recorded candidate-model output containing a `---SCORE_SUMMARY---` block. Only
+that block is parsed; surrounding prose is illustrative and trimmed.
+
+## Running
+
+```bash
+npm run eval:golden -- --replay --model cheap-stub   # offline, deterministic, $0
+npm run eval:golden -- --live   --model gpt-4o-mini  # real call via openai-eval.mjs (needs key + cv.md)
+```
+
+Replay is the CI-friendly path: no API keys, no `cv.md`, fully deterministic.
+The harness reports per-case archetype/score agreement, mean |Δscore|, median
+latency (live only), and a placeholder $/run, then exits `0/1` on the archetype
+agreement gate.
+
+## Open design questions (TODO #1354 — need maintainer steer)
+
+These are surfaced as named constants / placeholder data so they are trivial to
+tune once decided:
+
+| Question | Where it lives |
+|----------|----------------|
+| Reference labels: freeze Claude's verdict as ground truth, or hand-curate? | `label` blocks in `golden/*.json` |
+| `SCORE` agreement: exact match or a tolerance band (±0.5?)? | `SCORE_TOLERANCE` in `eval-golden.mjs` |
+| CI gate threshold for archetype agreement? | `MIN_ARCHETYPE_AGREEMENT` in `eval-golden.mjs` |
+| Per-model $/run rates, and how many cases to start (~8–12?) | `COST_PER_RUN_USD` + `golden/` |
+
+Wiring this into the required CI job (`.github/workflows/test.yml`) is intentionally
+deferred until the gate threshold is agreed, so a placeholder value can't make `main`
+go red.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,8 +1,9 @@
 # Golden-set eval for cheap-model routing (#1354)
 
-> **Status: scaffolding.** The *mechanism* (`eval-golden.mjs`) is design-invariant
-> and runs today. The reference labels and gate thresholds are placeholders pending
-> maintainer decisions — see **Open design questions** below.
+> **Status: v1.** The *mechanism* (`eval-golden.mjs`) is design-invariant and runs
+> today. Reference labels are now frozen (10 synthetic cases — see **Labeling
+> methodology** below); the gate threshold and per-model cost remain tunable
+> constants, and wiring into CI is still deferred (see **Open design questions**).
 
 ## What this is
 
@@ -11,6 +12,35 @@ cheap model agrees with reference labels, so "is model X good enough to route to
 becomes a number instead of a hunch. It reuses the `---SCORE_SUMMARY---` contract
 that every `*-eval.mjs` already emits (`SCORE` + `ARCHETYPE`), so there is no new
 scoring surface.
+
+## Labeling methodology (v1)
+
+The metric is **agreement-with-reference, not absolute correctness.** For #1354's
+purpose — *which cheap model can hold which task* — distance-to-reference is exactly
+the right measure: if a candidate model reproduces the reference verdict, it is safe
+to route that task to it.
+
+**v1 labels are the frozen verdict of a reference (Claude-tier / premium) evaluation**
+applied to each synthetic JD under the repo's own rubric (`modes/_shared.md` §
+Scoring System + § Archetype Detection):
+
+- **`archetype`** is the gate. It is a property of the JD alone (the 6-archetype
+  keyword taxonomy in `_shared.md`), so it is profile-independent and reproducible.
+- **`score`** (1–5) is the reference model's fit verdict. It is profile-relative by
+  construction, but because both reference and candidate are scored under the *same*
+  conditions, distance-to-reference stays meaningful regardless of whose profile
+  drives it. It is a secondary, tolerance-banded signal — it does **not** gate.
+
+The 10 cases cover all 6 archetypes and deliberately favor **edge archetypes over
+easy wins**: four are hybrids/ambiguous (`platform-agentic-hybrid`,
+`pm-architect-ambiguous`, `forward-deployed-vs-architect`, `transformation-vs-pm`)
+where a cheaper model is most likely to diverge, and scores span 3.2–4.3 so the
+tolerance band has real range to catch drift on red-flag postings.
+
+**Future upgrade path:** hand-curated labels. Freezing the reference verdict is the
+cheap, reproducible v1; a later pass can replace or reconcile individual labels with
+human-graded ground truth (flip `provenance` to `hand-curated`) without changing the
+harness.
 
 ## Layout
 
@@ -29,11 +59,15 @@ eval-golden.mjs  the harness (root level, sibling to openai-eval.mjs)
   "id": "ai-platform-llmops",
   "synthetic": true,
   "jd": "<full synthetic job description text>",
-  "label": { "archetype": "AI Platform / LLMOps", "score": 4.2 }
+  "label": { "archetype": "AI Platform / LLMOps", "score": 4.2, "provenance": "reference-frozen-v1" }
 }
 ```
 
-All JDs are **synthetic** so the set stays clear of the `no-user-data` guard.
+`provenance` records how the label was set (`reference-frozen-v1` today; future
+hand-curated labels flip it). Edge cases may also carry an `edge_note` explaining
+why the reference resolved an ambiguous JD the way it did. Both are advisory — the
+harness only requires `archetype` (string) and `score` (number). All JDs are
+**synthetic** so the set stays clear of the `no-user-data` guard.
 
 ### Fixture format (`evals/fixtures/<case-id>__<model>.txt`)
 
@@ -52,18 +86,24 @@ The harness reports per-case archetype/score agreement, mean |Δscore|, median
 latency (live only), and a placeholder $/run, then exits `0/1` on the archetype
 agreement gate.
 
-## Open design questions (TODO #1354 — need maintainer steer)
+## Open design questions (TODO #1354)
 
-These are surfaced as named constants / placeholder data so they are trivial to
-tune once decided:
+Resolved in v1:
 
-| Question | Where it lives |
-|----------|----------------|
-| Reference labels: freeze Claude's verdict as ground truth, or hand-curate? | `label` blocks in `golden/*.json` |
-| `SCORE` agreement: exact match or a tolerance band (±0.5?)? | `SCORE_TOLERANCE` in `eval-golden.mjs` |
-| CI gate threshold for archetype agreement? | `MIN_ARCHETYPE_AGREEMENT` in `eval-golden.mjs` |
-| Per-model $/run rates, and how many cases to start (~8–12?) | `COST_PER_RUN_USD` + `golden/` |
+- **Reference labels** — frozen reference (Claude-tier) verdict; see **Labeling
+  methodology** above. Hand-curation is the documented future upgrade path.
+- **Set size / spread** — grown from 2 to 10 cases across all 6 archetypes, favoring
+  edge/hybrid archetypes, scores spanning 3.2–4.3.
+
+Still tunable (named constants, safe defaults today):
+
+| Question | Where it lives | v1 default |
+|----------|----------------|------------|
+| `SCORE` agreement: tolerance band width | `SCORE_TOLERANCE` in `eval-golden.mjs` | ±0.5 (band, per distance-to-reference) |
+| CI gate threshold for archetype agreement | `MIN_ARCHETYPE_AGREEMENT` in `eval-golden.mjs` | 0.8 |
+| Per-model $/run rates | `COST_PER_RUN_USD` in `eval-golden.mjs` | empty — needs real provider rates |
 
 Wiring this into the required CI job (`.github/workflows/test.yml`) is intentionally
-deferred until the gate threshold is agreed, so a placeholder value can't make `main`
-go red.
+deferred until the gate threshold is confirmed, so a default value can't make `main`
+go red. The replay path is deterministic and $0, so it is ready to wire whenever the
+threshold is signed off.

--- a/evals/README.md
+++ b/evals/README.md
@@ -72,7 +72,10 @@ harness only requires `archetype` (string) and `score` (number). All JDs are
 ### Fixture format (`evals/fixtures/<case-id>__<model>.txt`)
 
 A recorded candidate-model output containing a `---SCORE_SUMMARY---` block. Only
-that block is parsed; surrounding prose is illustrative and trimmed.
+that block is parsed; surrounding prose is illustrative and trimmed. Slash-form
+provider ids (`deepseek/deepseek-chat`) are flattened to a path-safe token for the
+filename (`<case>__deepseek-deepseek-chat.txt`), so a fixture never lands in a
+phantom subdirectory.
 
 ## Running
 

--- a/evals/fixtures/agentic-automation__cheap-stub.txt
+++ b/evals/fixtures/agentic-automation__cheap-stub.txt
@@ -1,0 +1,14 @@
+[recorded fixture — candidate model "cheap-stub" output for golden case agentic-automation]
+[Only the ---SCORE_SUMMARY--- block is parsed by eval-golden.mjs; the prose above
+it is illustrative and intentionally trimmed so fixtures stay small and reviewable.]
+
+Multi-agent orchestration with HITL checkpoints and tool-calling integrations —
+a clear agentic/automation build role.
+
+---SCORE_SUMMARY---
+COMPANY: Northwind AI
+ROLE: Agent Engineer
+SCORE: 4.1
+ARCHETYPE: Agentic / Automation
+LEGITIMACY: High Confidence
+---END_SUMMARY---

--- a/evals/fixtures/ai-forward-deployed__cheap-stub.txt
+++ b/evals/fixtures/ai-forward-deployed__cheap-stub.txt
@@ -1,0 +1,14 @@
+[recorded fixture — candidate model "cheap-stub" output for golden case ai-forward-deployed]
+[Only the ---SCORE_SUMMARY--- block is parsed by eval-golden.mjs; the prose above
+it is illustrative and intentionally trimmed so fixtures stay small and reviewable.]
+
+Client-facing, embedded, prototype-and-deploy in the field with fast cycles — a
+forward-deployed engineering role.
+
+---SCORE_SUMMARY---
+COMPANY: Ridgeline
+ROLE: Forward Deployed AI Engineer
+SCORE: 4.2
+ARCHETYPE: AI Forward Deployed
+LEGITIMACY: High Confidence
+---END_SUMMARY---

--- a/evals/fixtures/ai-platform-llmops__cheap-stub.txt
+++ b/evals/fixtures/ai-platform-llmops__cheap-stub.txt
@@ -1,0 +1,14 @@
+[recorded fixture — candidate model "cheap-stub" output for golden case ai-platform-llmops]
+[Only the ---SCORE_SUMMARY--- block is parsed by eval-golden.mjs; the prose above
+it is illustrative and intentionally trimmed so fixtures stay small and reviewable.]
+
+This role centers on reliability, observability, and eval/monitoring of LLM
+inference pipelines — a platform mandate rather than research.
+
+---SCORE_SUMMARY---
+COMPANY: Meridian Labs
+ROLE: Senior AI Platform Engineer
+SCORE: 4.0
+ARCHETYPE: AI Platform / LLMOps
+LEGITIMACY: High Confidence
+---END_SUMMARY---

--- a/evals/fixtures/ai-solutions-architect__cheap-stub.txt
+++ b/evals/fixtures/ai-solutions-architect__cheap-stub.txt
@@ -1,0 +1,15 @@
+[recorded fixture — candidate model "cheap-stub" output for golden case ai-solutions-architect]
+[Only the ---SCORE_SUMMARY--- block is parsed by eval-golden.mjs; the prose above
+it is illustrative and intentionally trimmed so fixtures stay small and reviewable.]
+
+Owns the reference architecture and enterprise integration design across client
+accounts — a solutions-architect role. (Candidate model does not flag the
+utilization-tied comp / undisclosed base as a fit risk.)
+
+---SCORE_SUMMARY---
+COMPANY: Halgate Consulting
+ROLE: AI Solutions Architect
+SCORE: 4.0
+ARCHETYPE: AI Solutions Architect
+LEGITIMACY: High Confidence
+---END_SUMMARY---

--- a/evals/fixtures/ai-transformation__cheap-stub.txt
+++ b/evals/fixtures/ai-transformation__cheap-stub.txt
@@ -1,0 +1,14 @@
+[recorded fixture — candidate model "cheap-stub" output for golden case ai-transformation]
+[Only the ---SCORE_SUMMARY--- block is parsed by eval-golden.mjs; the prose above
+it is illustrative and intentionally trimmed so fixtures stay small and reviewable.]
+
+Change management, enablement, and adoption across a large enterprise — an AI
+transformation role, not a hands-on build seat.
+
+---SCORE_SUMMARY---
+COMPANY: Meadowbrook Group
+ROLE: AI Transformation Lead
+SCORE: 3.8
+ARCHETYPE: AI Transformation
+LEGITIMACY: Proceed with Caution
+---END_SUMMARY---

--- a/evals/fixtures/forward-deployed-vs-architect__cheap-stub.txt
+++ b/evals/fixtures/forward-deployed-vs-architect__cheap-stub.txt
@@ -1,0 +1,14 @@
+[recorded fixture — candidate model "cheap-stub" output for golden case forward-deployed-vs-architect]
+[Only the ---SCORE_SUMMARY--- block is parsed by eval-golden.mjs; the prose above
+it is illustrative and intentionally trimmed so fixtures stay small and reviewable.]
+
+Despite the integration-design language, the client-facing / embedded / field-
+delivery core dominates — candidate model resolves to forward-deployed.
+
+---SCORE_SUMMARY---
+COMPANY: Solstice Systems
+ROLE: Field AI Engineer
+SCORE: 3.9
+ARCHETYPE: AI Forward Deployed
+LEGITIMACY: High Confidence
+---END_SUMMARY---

--- a/evals/fixtures/platform-agentic-hybrid__cheap-stub.txt
+++ b/evals/fixtures/platform-agentic-hybrid__cheap-stub.txt
@@ -1,0 +1,15 @@
+[recorded fixture — candidate model "cheap-stub" output for golden case platform-agentic-hybrid]
+[Only the ---SCORE_SUMMARY--- block is parsed by eval-golden.mjs; the prose above
+it is illustrative and intentionally trimmed so fixtures stay small and reviewable.]
+
+Observability, evals, and reliability pipelines for a fleet of agents — the
+agentic surface is the domain, but the mandate is platform. Candidate model
+resolves the hybrid to the platform archetype here.
+
+---SCORE_SUMMARY---
+COMPANY: Fathom AI
+ROLE: Staff Engineer, Agent Reliability
+SCORE: 4.0
+ARCHETYPE: AI Platform / LLMOps
+LEGITIMACY: High Confidence
+---END_SUMMARY---

--- a/evals/fixtures/pm-architect-ambiguous__cheap-stub.txt
+++ b/evals/fixtures/pm-architect-ambiguous__cheap-stub.txt
@@ -1,0 +1,15 @@
+[recorded fixture — candidate model "cheap-stub" output for golden case pm-architect-ambiguous]
+[Only the ---SCORE_SUMMARY--- block is parsed by eval-golden.mjs; the prose above
+it is illustrative and intentionally trimmed so fixtures stay small and reviewable.]
+
+Roadmap, stakeholder alignment, and PRDs stand out to the candidate model, which
+reads this as a product role — missing that the accountable deliverable is the
+integration architecture. This is the archetype the cheap model gets wrong.
+
+---SCORE_SUMMARY---
+COMPANY: Northwind Enterprise
+ROLE: AI Solutions Lead
+SCORE: 3.9
+ARCHETYPE: Technical AI PM
+LEGITIMACY: High Confidence
+---END_SUMMARY---

--- a/evals/fixtures/technical-ai-pm__cheap-stub.txt
+++ b/evals/fixtures/technical-ai-pm__cheap-stub.txt
@@ -1,0 +1,14 @@
+[recorded fixture — candidate model "cheap-stub" output for golden case technical-ai-pm]
+[Only the ---SCORE_SUMMARY--- block is parsed by eval-golden.mjs; the prose above
+it is illustrative and intentionally trimmed so fixtures stay small and reviewable.]
+
+Roadmap ownership, PRDs, discovery with design partners, stakeholder alignment —
+a technical product-manager role, not a hands-on model seat.
+
+---SCORE_SUMMARY---
+COMPANY: Cobalt
+ROLE: Senior AI Product Manager
+SCORE: 4.1
+ARCHETYPE: Technical AI PM
+LEGITIMACY: High Confidence
+---END_SUMMARY---

--- a/evals/fixtures/transformation-vs-pm__cheap-stub.txt
+++ b/evals/fixtures/transformation-vs-pm__cheap-stub.txt
@@ -1,0 +1,15 @@
+[recorded fixture — candidate model "cheap-stub" output for golden case transformation-vs-pm]
+[Only the ---SCORE_SUMMARY--- block is parsed by eval-golden.mjs; the prose above
+it is illustrative and intentionally trimmed so fixtures stay small and reviewable.]
+
+Enablement, adoption, and change management across the org — candidate model gets
+the transformation archetype right, but over-scores the fit, not registering the
+vague comp and non-technical scope that the reference marks down.
+
+---SCORE_SUMMARY---
+COMPANY: Calderon Industries
+ROLE: AI Adoption Program Manager
+SCORE: 3.8
+ARCHETYPE: AI Transformation
+LEGITIMACY: Proceed with Caution
+---END_SUMMARY---

--- a/evals/golden/agentic-automation.json
+++ b/evals/golden/agentic-automation.json
@@ -1,0 +1,10 @@
+{
+  "id": "agentic-automation",
+  "synthetic": true,
+  "jd": "Agent Engineer — Northwind AI (Remote, EU hours)\n\nWe are building multi-agent automation for back-office operations. You will design and orchestrate agent workflows with human-in-the-loop (HITL) checkpoints, build tool-calling integrations, and ship orchestration logic that keeps long-running agents reliable. Expect to work on planning loops, retries, and guardrails for autonomous workflows that take real actions. We value people who have shipped production agentic systems and understand where to put a human approval step. Strong TypeScript or Python, experience with orchestration frameworks, and a healthy respect for failure modes in autonomous workflows.",
+  "label": {
+    "archetype": "Agentic / Automation",
+    "score": 3.9,
+    "_note": "TODO(#1354): placeholder reference label. Pending maintainer decision on (a) freeze-Claude-verdict vs hand-curated labels, and (b) the score scale / tolerance band."
+  }
+}

--- a/evals/golden/agentic-automation.json
+++ b/evals/golden/agentic-automation.json
@@ -5,6 +5,6 @@
   "label": {
     "archetype": "Agentic / Automation",
     "score": 3.9,
-    "_note": "TODO(#1354): placeholder reference label. Pending maintainer decision on (a) freeze-Claude-verdict vs hand-curated labels, and (b) the score scale / tolerance band."
+    "provenance": "reference-frozen-v1"
   }
 }

--- a/evals/golden/ai-forward-deployed.json
+++ b/evals/golden/ai-forward-deployed.json
@@ -1,0 +1,10 @@
+{
+  "id": "ai-forward-deployed",
+  "synthetic": true,
+  "jd": "Forward Deployed AI Engineer — Ridgeline (Remote + on-site sprints)\n\nWe embed engineers directly with our customers to get AI into production fast. You will be client-facing from week one: sit with the customer, understand their workflow, prototype a solution in days not months, and deploy it into their environment. This is field work — you own the last mile from demo to live usage, iterating tightly against real user feedback. Expect fast delivery cycles, occasional travel to customer sites for deployment sprints, and the satisfaction of shipping something that gets used the same week. Strong generalist engineering, comfort in ambiguous customer environments, and the instinct to prototype rather than over-design. Clear comp: $190k–$220k base, meaningful equity, travel fully covered.",
+  "label": {
+    "archetype": "AI Forward Deployed",
+    "score": 4.3,
+    "provenance": "reference-frozen-v1"
+  }
+}

--- a/evals/golden/ai-platform-llmops.json
+++ b/evals/golden/ai-platform-llmops.json
@@ -1,0 +1,10 @@
+{
+  "id": "ai-platform-llmops",
+  "synthetic": true,
+  "jd": "Senior AI Platform Engineer — Meridian Labs (Remote)\n\nWe run LLM products at scale and need someone who treats reliability as a feature. You will own our model observability stack: tracing, evals, and regression monitoring across our inference pipelines. Day to day you will build offline and online eval harnesses, wire up dashboards and alerting for latency and quality drift, and harden the pipelines that route requests across providers. We care about measurable quality gates in CI, reproducible benchmarks, and cost-per-request visibility. Strong Python, comfort with OpenAI-compatible APIs, and a track record of shipping monitoring/observability for ML or LLM systems. This is a platform role, not a research role.",
+  "label": {
+    "archetype": "AI Platform / LLMOps",
+    "score": 4.2,
+    "_note": "TODO(#1354): placeholder reference label. Pending maintainer decision on (a) freeze-Claude-verdict vs hand-curated labels, and (b) the score scale / tolerance band."
+  }
+}

--- a/evals/golden/ai-platform-llmops.json
+++ b/evals/golden/ai-platform-llmops.json
@@ -5,6 +5,6 @@
   "label": {
     "archetype": "AI Platform / LLMOps",
     "score": 4.2,
-    "_note": "TODO(#1354): placeholder reference label. Pending maintainer decision on (a) freeze-Claude-verdict vs hand-curated labels, and (b) the score scale / tolerance band."
+    "provenance": "reference-frozen-v1"
   }
 }

--- a/evals/golden/ai-solutions-architect.json
+++ b/evals/golden/ai-solutions-architect.json
@@ -1,0 +1,10 @@
+{
+  "id": "ai-solutions-architect",
+  "synthetic": true,
+  "jd": "AI Solutions Architect — Halgate Consulting (Hybrid, client sites)\n\nHalgate is a systems-integration vendor delivering AI programs for enterprise clients. As Solutions Architect you own the technical architecture end to end: you design the integration between the client's existing systems and our AI stack, produce the reference architecture and system diagrams, and make the build-vs-buy calls across a multi-quarter engagement. You will work across several client accounts at once, so billability and context-switching are part of the job. Enterprise integration experience is required — identity, data pipelines, security review, and the usual procurement gauntlet. This is an architecture and design role, not a delivery-engineer seat: you set the technical direction and hand implementation to the account's build team. Compensation is described as a 'comprehensive package' tied to utilization; base is not separately stated in the posting.",
+  "label": {
+    "archetype": "AI Solutions Architect",
+    "score": 3.4,
+    "provenance": "reference-frozen-v1"
+  }
+}

--- a/evals/golden/ai-transformation.json
+++ b/evals/golden/ai-transformation.json
@@ -1,0 +1,10 @@
+{
+  "id": "ai-transformation",
+  "synthetic": true,
+  "jd": "AI Transformation Lead — Meadowbrook Group (Hybrid)\n\nMeadowbrook is a 4,000-person traditional enterprise beginning its AI journey. We need a transformation lead to drive adoption across business units: run the change-management program, build enablement and training for non-technical teams, and shepherd the cultural shift toward AI-assisted ways of working. You will identify high-value adoption opportunities, stand up an internal enablement function, and measure organizational uptake rather than shipping code yourself. Success is a workforce that actually uses the tools, not a demo. Stakeholder influence across a large org, comfort with change-management frameworks, and patience for enterprise pace are essential. This is an enablement and transformation role, not a hands-on engineering seat. Salary described as competitive and commensurate with experience.",
+  "label": {
+    "archetype": "AI Transformation",
+    "score": 3.6,
+    "provenance": "reference-frozen-v1"
+  }
+}

--- a/evals/golden/forward-deployed-vs-architect.json
+++ b/evals/golden/forward-deployed-vs-architect.json
@@ -1,0 +1,11 @@
+{
+  "id": "forward-deployed-vs-architect",
+  "synthetic": true,
+  "jd": "Field AI Engineer — Solstice Systems (On-site rotations)\n\nYou are the person we send to the customer. Embedded on-site, you prototype against their real data, deploy the solution into their environment, and iterate in the field until it sticks. Part of the job is designing how our platform integrates with the client's existing architecture — you will sketch the integration and make systems-level calls — but this is not a back-office architect seat: you are client-facing, delivery is fast, and success is a working deployment the customer relies on, not a diagram. Heavy travel during deployment rotations. Generalist engineering strength, calm in messy client environments, and a bias toward shipping a rough prototype over perfecting a design doc. Base $180k–$205k; travel and per-diem covered. Note: on-site rotations can run three weeks at a stretch.",
+  "label": {
+    "archetype": "AI Forward Deployed",
+    "score": 3.9,
+    "provenance": "reference-frozen-v1",
+    "edge_note": "architecture/integration signals present, but reference resolves to Forward Deployed — client-facing + field delivery + prototype-first is the core; travel intensity is a mild fit drag"
+  }
+}

--- a/evals/golden/platform-agentic-hybrid.json
+++ b/evals/golden/platform-agentic-hybrid.json
@@ -1,0 +1,11 @@
+{
+  "id": "platform-agentic-hybrid",
+  "synthetic": true,
+  "jd": "Staff Engineer, Agent Reliability — Fathom AI (Remote)\n\nOur product is a fleet of production agents, and this role keeps them trustworthy. You will build the observability and evals layer for multi-agent workflows: tracing across orchestration steps, regression monitoring for agent behavior, and the reliability pipelines that catch a bad model swap before it ships. There is real agentic surface here — you will understand HITL checkpoints and orchestration internals — but the mandate is platform: instrument, measure, and harden the systems other teams' agents run on. You are the team that makes 'is this agent still behaving?' a dashboard, not a guess. Strong Python, distributed-systems instincts, and prior work on eval/monitoring for ML or LLM systems. Base $200k–$235k, equity, remote-first.",
+  "label": {
+    "archetype": "AI Platform / LLMOps",
+    "score": 4.1,
+    "provenance": "reference-frozen-v1",
+    "edge_note": "hybrid platform+agentic; reference resolves to the platform mandate (observability/evals/reliability) — agentic is the domain, not the job"
+  }
+}

--- a/evals/golden/pm-architect-ambiguous.json
+++ b/evals/golden/pm-architect-ambiguous.json
@@ -1,0 +1,11 @@
+{
+  "id": "pm-architect-ambiguous",
+  "synthetic": true,
+  "jd": "AI Solutions Lead — Northwind Enterprise (Hybrid)\n\nA senior role sitting between product and engineering for our enterprise AI offering. You will own the technical architecture of how our AI capabilities integrate into large-customer environments — the reference design, the integration patterns, the systems-level decisions — while also maintaining a lightweight roadmap and keeping stakeholders aligned on sequencing. There is a PRD-flavored side to this (you will write the occasional spec and run some discovery), but the center of gravity is architecture: customers buy the design, and you are accountable for the integration working across their systems. Enterprise integration depth is the hard requirement; product instincts are the multiplier. Base band published: $195k–$225k plus equity.",
+  "label": {
+    "archetype": "AI Solutions Architect",
+    "score": 3.7,
+    "provenance": "reference-frozen-v1",
+    "edge_note": "reads PM-adjacent (roadmap/stakeholder/PRD) but reference resolves to Architect — the accountable deliverable is the integration architecture, product work is secondary"
+  }
+}

--- a/evals/golden/technical-ai-pm.json
+++ b/evals/golden/technical-ai-pm.json
@@ -1,0 +1,10 @@
+{
+  "id": "technical-ai-pm",
+  "synthetic": true,
+  "jd": "Senior AI Product Manager — Cobalt (Remote, US/EU overlap)\n\nWe are hiring a technical product manager to own the roadmap for our applied-AI product line. You will run discovery with design partners, write the PRDs that turn fuzzy model capabilities into shippable features, and align engineering, research, and go-to-market stakeholders around a prioritized roadmap. Day to day you translate customer problems into product requirements, define success metrics, and make the call on what ships and what waits. We want someone fluent enough in LLM behavior to scope what is feasible, but this is a product manager role — you will spend your time on discovery, specs, and stakeholder alignment, not in the model training loop. Strong written communication, a track record of shipping AI or data products, and comfort saying no to good-but-off-roadmap ideas. Comp band is published: $185k–$215k base plus equity.",
+  "label": {
+    "archetype": "Technical AI PM",
+    "score": 4.0,
+    "provenance": "reference-frozen-v1"
+  }
+}

--- a/evals/golden/transformation-vs-pm.json
+++ b/evals/golden/transformation-vs-pm.json
@@ -1,0 +1,11 @@
+{
+  "id": "transformation-vs-pm",
+  "synthetic": true,
+  "jd": "AI Adoption Program Manager — Calderon Industries (Hybrid)\n\nWe are standing up AI across a large, change-resistant organization and need someone to make adoption actually happen. You will run the enablement program — training, internal champions, playbooks — drive change management across departments, and keep a rough roadmap of which teams onboard when. There is a program-management cadence to this (stakeholder updates, sequencing, status reporting), but the real deliverable is uptake: behavior change, not shipped software. You will not be hands-on with models or code; you orchestrate people and process. Expect long enablement cycles and heavy cross-functional stakeholder management in a slow-moving enterprise. Compensation is 'competitive' — no band is published, and the bonus is tied to adoption targets.",
+  "label": {
+    "archetype": "AI Transformation",
+    "score": 3.2,
+    "provenance": "reference-frozen-v1",
+    "edge_note": "PM-flavored (roadmap/stakeholder/status), but reference resolves to Transformation — enablement/adoption/change-management is the mandate; vague comp + non-technical scope drag the fit score below the core PM case"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ollama:eval": "node ollama-eval.mjs",
     "openai:eval": "node openai-eval.mjs",
     "openai:tailor": "node openai-tailor.mjs",
+    "eval:golden": "node eval-golden.mjs",
     "star": "node match-star.mjs",
     "archive": "node archive-posting.mjs",
     "prepare:application": "node prepare-application.mjs",

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -187,6 +187,8 @@ const SYSTEM_PATHS = [
   'ollama-eval.mjs',
   'openai-eval.mjs',
   'openai-tailor.mjs',
+  'eval-golden.mjs',
+  'evals/',
   'openrouter-runner.mjs',
   'test-all.mjs',
   'detect-reposts.test.mjs',


### PR DESCRIPTION
Implements #1354. Following your methodology call, the labels are now **frozen reference (Claude-tier) verdicts as ground-truth v1** and the golden set is grown to **10 cases**. Ready for review.

### What's here

A golden-set eval harness that makes "is cheap model X good enough to route to?" a number. It reuses the `---SCORE_SUMMARY---` contract every `*-eval.mjs` already emits (`SCORE` + `ARCHETYPE`) — **no new scoring surface**.

- `eval-golden.mjs` (root, sibling to `openai-eval.mjs`) — loads labeled golden cases, gets each candidate model's summary, compares to the reference label, exits `0/1` on an archetype-agreement gate. Reports per-case agreement, mean `|Δscore|`, median latency (live), and `$/run`.
- `evals/golden/*.json` — **10 synthetic** labeled cases (clear of the no-user-data guard).
- `evals/fixtures/*.txt` — recorded candidate outputs so CI replays at **$0, deterministic, no keys / no `cv.md`**.
- `evals/README.md` — labeling methodology + format + remaining tunables.
- `npm run eval:golden`.

```
npm run eval:golden -- --replay --model cheap-stub   # offline, deterministic, green
npm run eval:golden -- --live   --model gpt-4o-mini  # real call via openai-eval.mjs
```

### Labeling methodology (v1)

The metric is **agreement-with-reference, not absolute correctness** — for #1354's purpose (which cheap model can hold which task), distance-to-reference is exactly the right measure. v1 labels are the frozen verdict of a **reference (Claude-tier / premium) evaluation** applied per the repo's own rubric (`modes/_shared.md` § Scoring System + § Archetype Detection):

- **`archetype`** is the gate — a property of the JD alone (the 6-archetype keyword taxonomy), so it is **profile-independent and reproducible**.
- **`score`** (1–5) is the reference fit verdict — **profile-relative by construction**, a secondary tolerance-banded signal that does **not** gate.
- **Hand-curated labels** are the documented future upgrade path (flip `provenance` → `hand-curated`); freezing the reference verdict is the cheap, reproducible v1.

### The golden set (10 cases)

Covers all 6 archetypes and **favors edge archetypes over easy wins** — 4 of the 10 are hybrid/ambiguous, scores span 3.2–4.3 so the tolerance band has range to catch drift:

| Case | Label archetype | Score | Edge? |
|---|---|---|---|
| `ai-platform-llmops` | AI Platform / LLMOps | 4.2 | |
| `agentic-automation` | Agentic / Automation | 3.9 | |
| `technical-ai-pm` | Technical AI PM | 4.0 | |
| `ai-solutions-architect` | AI Solutions Architect | 3.4 | red-flag comp |
| `ai-forward-deployed` | AI Forward Deployed | 4.3 | |
| `ai-transformation` | AI Transformation | 3.6 | |
| `platform-agentic-hybrid` | AI Platform / LLMOps | 4.1 | ✅ platform vs agentic |
| `pm-architect-ambiguous` | AI Solutions Architect | 3.7 | ✅ PM vs architect |
| `forward-deployed-vs-architect` | AI Forward Deployed | 3.9 | ✅ FD vs architect |
| `transformation-vs-pm` | AI Transformation | 3.2 | ✅ transformation vs PM |

The demo model `cheap-stub` reproduces **9/10 archetypes** (it misses the hardest PM-vs-architect hybrid) and **over-scores the two red-flag postings** — so replay **PASSES the 0.8 gate at 90%** while proving the gate discriminates rather than rubber-stamps.

### Remaining tunables (safe v1 defaults)

Reference-labels + set-size are resolved. The rest stay named constants:

| Knob | Where | v1 default |
|---|---|---|
| `SCORE` tolerance band | `SCORE_TOLERANCE` | ±0.5 (per distance-to-reference) |
| CI archetype-agreement threshold | `MIN_ARCHETYPE_AGREEMENT` | 0.8 |
| Per-model `$/run` | `COST_PER_RUN_USD` | empty — needs real provider rates |

Wiring the gate into `test.yml` is still intentionally deferred until the threshold is signed off (deterministic $0 replay is ready to wire on your word).

### Tests

`node test-all.mjs` (full CI suite) → **1693 passed, 0 failed**. `npm run eval:golden -- --replay --model cheap-stub` → **90% archetype agreement, exit 0 (PASS)**; the `0/1` gate is verified both ways (green on the fixtures, exit 1 when agreement falls below the gate).

Closes #1354.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `eval:golden`/`eval-golden.mjs` golden-set evaluation with replay (fixtures) and live (API) modes.
  * Enforces an archetype routing gate and reports per-case results plus aggregated agreement, score deltas, and (live) median latency.
* **Documentation**
  * Added `evals/README.md` describing the golden-set format, metrics, and run instructions.
* **Chores**
  * Added golden JSON records and recorded fixture outputs for the eval set.
  * Updated system update handling to include the new eval assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
