### PR TITLE
fix(cv-template): keep role titles from orphaning at page breaks

### DIFF
--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -367,6 +367,7 @@
      orphaned at the bottom of a page. */
   .section-title,
   .job-company,
+  .job-role,
   .project-title {
     break-after: avoid;
     page-break-after: avoid;


### PR DESCRIPTION
## Problem

`templates/cv-template.html` already guards against orphaned section headers at page breaks with `break-after: avoid` on `.section-title`, `.job-company`, and `.project-title`. But `.job-role` (the role title line, a sibling of the bullet list) is not in that list, so a job's role title can be stranded at the bottom of a page while its bullets flow to the next page.

## Fix

Add `.job-role` to the existing `break-after: avoid` / `page-break-after: avoid` rule so the role title always travels to the next page with its first bullet.

```css
.section-title,
.job-company,
.job-role,
.project-title {
  break-after: avoid;
  page-break-after: avoid;
}
```

One-line change, consistent with the orphan-guard intent documented in the same CSS comment ("Keep a heading attached to the content that follows it, so headings are not orphaned at the bottom of a page").

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved print layout so job role text stays together on the same page instead of being split across page breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->