### PR TITLE
fix(pdf): restore pdf manifest updates

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -179,6 +179,20 @@ function validateCvSectionOrder(html, cvMarkdown) {
 }
 
 /**
+ * Convert a path to a repo-relative manifest entry, or blank if it is unknown
+ * or outside the career-ops repository.
+ *
+ * @param {string} pathValue - Absolute or cwd-relative filesystem path.
+ * @returns {string} Repo-relative path using forward slashes, or an empty string.
+ */
+export function repoRelativeManifestPath(pathValue) {
+  if (!pathValue) return '';
+  const rel = relative(__dirname, resolve(pathValue));
+  if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) return '';
+  return rel.split(sep).join('/');
+}
+
+/**
  * Record a generated PDF in data/pdf-index.tsv so tools can map a tracker
  * report number to the exact PDF (and its source HTML for regeneration).
  *
@@ -192,7 +206,7 @@ function updatePDFManifest(reportNum, pdfPath, htmlPath, format) {
   const manifestPath = resolve(__dirname, 'data', 'pdf-index.tsv');
   const toRel = (p) => relative(__dirname, p).split(sep).join('/');
   const relPDF = toRel(pdfPath);
-  const relHTML = toRel(htmlPath);
+  const relHTML = repoRelativeManifestPath(htmlPath);
   const date = new Date().toISOString().slice(0, 10);
   // "008" and "8" are the same report — zero-padded report-link form vs
   // unpadded tracker-# form. Normalize so replacement rows match.
@@ -220,6 +234,12 @@ function updatePDFManifest(reportNum, pdfPath, htmlPath, format) {
   return relPDF;
 }
 
+/**
+ * CLI entrypoint that reads an HTML file, applies ATS-safe normalization, and
+ * renders the PDF while preserving report/source metadata for the manifest.
+ *
+ * @returns {Promise<{outputPath: string, pageCount: number, size: number}>}
+ */
 async function generatePDF() {
   const args = process.argv.slice(2);
 
@@ -288,7 +308,7 @@ async function generatePDF() {
     console.log(`🧹 ATS normalization: ${totalReplacements} replacements (${breakdown})`);
   }
 
-  return renderHtmlToPdf(html, outputPath, { format, baseDir: dirname(inputPath) });
+  return renderHtmlToPdf(html, outputPath, { format, baseDir: dirname(inputPath), reportNum, inputPath });
 }
 
 /**
@@ -344,12 +364,14 @@ export async function inlineLocalFonts(html) {
  *
  * @param {string} html - Full HTML document to render.
  * @param {string} outputPath - Absolute path to write the PDF to.
- * @param {{format?: 'a4'|'letter', baseDir?: string}} [opts]
+ * @param {{format?: 'a4'|'letter', baseDir?: string, reportNum?: string, inputPath?: string}} [opts]
  * @returns {Promise<{outputPath: string, pageCount: number, size: number}>}
  */
 export async function renderHtmlToPdf(html, outputPath, opts = {}) {
   const format = opts.format || 'a4';
   const baseDir = opts.baseDir || process.cwd();
+  const reportNum = opts.reportNum || '';
+  const inputPath = opts.inputPath || '';
 
   mkdirSync(dirname(outputPath), { recursive: true });
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -632,6 +632,36 @@ if (!/waitUntil:\s*['"]networkidle['"]/.test(generatePdfScript)) {
 } else {
   fail('generate-pdf still waits for networkidle');
 }
+const renderHtmlToPdfCall = generatePdfScript.match(/renderHtmlToPdf\(html,\s*outputPath,\s*\{([\s\S]*?)\}\)/);
+if (renderHtmlToPdfCall && /\breportNum\b/.test(renderHtmlToPdfCall[1]) && /\binputPath\b/.test(renderHtmlToPdfCall[1])) {
+  pass('generate-pdf threads reportNum/inputPath into renderHtmlToPdf');
+} else {
+  fail('generate-pdf does not pass reportNum/inputPath into renderHtmlToPdf');
+}
+if (generatePdfScript.includes('opts.reportNum') && generatePdfScript.includes('opts.inputPath')) {
+  pass('renderHtmlToPdf reads manifest metadata from opts');
+} else {
+  fail('renderHtmlToPdf does not read manifest metadata from opts');
+}
+try {
+  const { repoRelativeManifestPath } = await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
+  const insideHtmlPath = join(ROOT, 'templates', 'cv-template.html');
+  const outsideHtmlPath = join(dirname(ROOT), 'outside-cv-template.html');
+
+  if (repoRelativeManifestPath(insideHtmlPath) === 'templates/cv-template.html') {
+    pass('PDF manifest records repo-local source HTML paths');
+  } else {
+    fail('PDF manifest does not normalize repo-local source HTML paths');
+  }
+
+  if (repoRelativeManifestPath('') === '' && repoRelativeManifestPath(outsideHtmlPath) === '') {
+    pass('PDF manifest leaves HTML column blank when source HTML is missing or outside the repo');
+  } else {
+    fail('PDF manifest mishandles missing or external source HTML paths');
+  }
+} catch (e) {
+  fail(`PDF manifest path helper test crashed: ${e.message}`);
+}
 
 // ── 7c. UPDATER DASHBOARD REBUILD ─────────────────────────────────
 


### PR DESCRIPTION
## Summary
- thread `reportNum` and source HTML path from the CLI into `renderHtmlToPdf`
- keep the manifest HTML column blank for inline render callers with no source file
- add regression checks to `test-all.mjs` for the manifest metadata path

## Root cause
`renderHtmlToPdf` wrote `data/pdf-index.tsv` using `reportNum` and `inputPath`, but those variables only existed in the CLI caller and were never passed through `opts`. The surrounding manifest try/catch swallowed the resulting ReferenceError, so PDF generation succeeded while the index was never updated.

Fixes #1365.

## Validation
- `node --check generate-pdf.mjs`
- `node --check test-all.mjs`
- `node test-all.mjs --quick`
- `node generate-pdf.mjs templates/cv-template.html output/manifest-regression.pdf --format=a4 --report=999`
- inline `renderHtmlToPdf(...)` smoke test for callers without source HTML

`test-all --quick` passed with 849 passed, 0 failed, 15 existing personal-data warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PDF export manifest handling to better preserve report linkage and the originating HTML reference when available.
  - If no source HTML path is provided (or it’s outside the repo), the manifest now leaves the HTML field blank rather than writing an incorrect value.
- **Tests**
  - Added automated checks to verify PDF generation contract behavior and manifest output, including threading `reportNum` and `inputPath` through HTML-to-PDF rendering and normalizing repo-relative HTML paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->