### PR TITLE
fix(liveness): add Ashby API rung so live jobs.ashbyhq.com postings aren't false-expired

### DIFF
--- a/liveness-api.mjs
+++ b/liveness-api.mjs
@@ -2,16 +2,25 @@
 /**
  * liveness-api.mjs — zero-token liveness check for ATS-hosted job postings.
  *
- * Many postings live on ATS platforms (Greenhouse, Lever, ...) that expose a
- * public per-job JSON endpoint. We can confirm whether a posting is still live by
- * hitting that endpoint directly — no browser, no LLM tokens — and only fall back
- * to the Playwright check (liveness-browser.mjs) for non-ATS pages or when the API
- * is inconclusive. This is the cheap first rung of the liveness ladder.
+ * Many postings live on ATS platforms (Greenhouse, Lever, Ashby, ...) that expose
+ * a public JSON endpoint. We can confirm whether a posting is still live by hitting
+ * that endpoint directly — no browser, no LLM tokens — and only fall back to the
+ * Playwright check (liveness-browser.mjs) for non-ATS pages or when the API is
+ * inconclusive. This is the cheap first rung of the liveness ladder.
  *
  * CONSERVATIVE BY DESIGN: a false "expired" is worse than the status quo (the user
- * misses a real job). So this returns `expired` ONLY on a definitive 404/410,
- * `active` ONLY on a 200, and `null` (→ caller falls back to Playwright) for
- * anything ambiguous (unknown ATS, redirect, 429/5xx, network/timeout).
+ * misses a real job). So on a definitive 404/410 we return `expired`, and for
+ * anything ambiguous (unknown ATS, redirect, 429/5xx, network/timeout) we return
+ * `null` (→ caller falls back to Playwright).
+ *
+ * Two endpoint shapes:
+ *   - Per-job (Greenhouse, Lever): the URL maps to a single-job endpoint, so a 200
+ *     is itself proof the posting is live.
+ *   - Org-level (Ashby): the URL maps to the org's whole job board. A 200 only
+ *     proves the board exists, so the provider's `interpret` step parses the board
+ *     and confirms THIS posting is still listed before returning active/expired.
+ *     (Ashby pages are JS-rendered, so the browser/static rung sees only nav/footer
+ *     and false-reports live postings as expired — this API rung is authoritative.)
  *
  * SSRF-safe by construction: the request URL is built from a FIXED, hard-coded API
  * host plus path segments extracted from the posting URL with a strict charset
@@ -23,8 +32,12 @@ const TIMEOUT_MS = 8_000;
 // rejected before it can reach the fixed-host API URL template.
 const SAFE_SEGMENT = /^[A-Za-z0-9._-]+$/;
 
-// Each ATS: detect its posting URL, then map to the public per-job API URL.
+// Each ATS: detect its posting URL, then map to a public JSON API URL.
 // `match` returns the extracted path params (or null); `api` builds the FIXED-host URL.
+// Optional per-provider fields:
+//   `timeoutMs`  — override the default fetch timeout (slow/rate-limited APIs).
+//   `interpret`  — read the 200 response body to decide liveness (org-level APIs
+//                  where a 200 alone doesn't prove THIS posting is live).
 const ATS_PROVIDERS = [
   {
     id: 'greenhouse',
@@ -46,13 +59,64 @@ const ATS_PROVIDERS = [
     },
     api: ({ slug, id }) => `https://api.lever.co/v0/postings/${slug}/${id}`,
   },
+  {
+    id: 'ashby',
+    // jobs.ashbyhq.com/{org}/{jobId}[/application]. Ashby's public posting API is
+    // ORG-level (the whole job board), not per-job — so `api` maps to the board and
+    // `interpret` confirms this {jobId} is still listed. Only {org} reaches the
+    // fixed-host URL; {jobId} is used solely to filter the parsed board (SAFE_SEGMENT
+    // still validates both).
+    match(u) {
+      if (u.hostname !== 'jobs.ashbyhq.com') return null;
+      const m = u.pathname.match(/^\/([^/]+)\/([^/]+)(?:\/application)?\/?$/);
+      return m ? { org: m[1], jobId: m[2] } : null;
+    },
+    api: ({ org }) => `https://api.ashbyhq.com/posting-api/job-board/${org}`,
+    // Ashby's posting-api has a server-side latency floor and rate-limits repeated
+    // unauthenticated hits (see providers/ashby.mjs). Give it more room than the ATS
+    // default so a slow-but-live board doesn't time out into a Playwright fallback.
+    timeoutMs: 20_000,
+    async interpret(res, { jobId }) {
+      let json;
+      try {
+        json = await res.json();
+      } catch {
+        return null; // unparseable body → inconclusive, let the browser decide
+      }
+      return classifyAshbyBoard(json, jobId);
+    },
+  },
 ];
 
 /**
- * Map a posting URL to its ATS per-job API URL, or null if it isn't a known ATS
- * posting (or any extracted segment fails the strict charset). Pure + deterministic.
+ * Decide liveness for one Ashby posting from its org's job-board API payload.
+ * Pure + deterministic (no I/O), mirroring classifyLiveness in liveness-core.mjs.
+ *
+ * The public board lists only currently-published postings, so a posting that is
+ * absent (or explicitly `isListed: false`) has been removed/unlisted → expired.
+ * A present, listed posting → active. An unexpected shape → null (inconclusive),
+ * so a future API change degrades to a Playwright fallback rather than a false
+ * "expired".
+ *
+ * @param {any} json - parsed job-board response, expected shape `{ jobs: [...] }`
+ * @param {string} jobId - the {jobId} from jobs.ashbyhq.com/{org}/{jobId}
+ * @returns {{ result: 'active' | 'expired', code: string, reason: string } | null}
+ */
+export function classifyAshbyBoard(json, jobId) {
+  if (!json || !Array.isArray(json.jobs)) return null; // unexpected shape → fall back
+  const target = String(jobId).toLowerCase();
+  const job = json.jobs.find((j) => typeof j?.id === 'string' && j.id.toLowerCase() === target);
+  if (job && job.isListed !== false) {
+    return { result: 'active', code: 'ashby_api_ok', reason: 'Ashby posting is listed on the board (live)' };
+  }
+  return { result: 'expired', code: 'ashby_api_unlisted', reason: 'Ashby posting not listed on the board — removed/unlisted' };
+}
+
+/**
+ * Map a posting URL to its ATS API URL, or null if it isn't a known ATS posting
+ * (or any extracted segment fails the strict charset). Pure + deterministic.
  * @param {string} rawUrl
- * @returns {{ ats: string, apiUrl: string } | null}
+ * @returns {{ ats: string, apiUrl: string, parts: Record<string, string>, timeoutMs?: number, interpret?: (res: Response, parts: Record<string, string>) => Promise<{ result: 'active' | 'expired', code: string, reason: string } | null> } | null}
  */
 export function resolveAtsApi(rawUrl) {
   let u;
@@ -67,7 +131,7 @@ export function resolveAtsApi(rawUrl) {
     if (!parts) continue;
     // SSRF guard: every derived segment must be a single safe path segment.
     if (!Object.values(parts).every((v) => SAFE_SEGMENT.test(v) && !v.includes('..'))) return null;
-    return { ats: provider.id, apiUrl: provider.api(parts) };
+    return { ats: provider.id, apiUrl: provider.api(parts), parts, timeoutMs: provider.timeoutMs, interpret: provider.interpret };
   }
   return null;
 }
@@ -86,29 +150,38 @@ export function isAtsPosting(url) {
 export async function checkLivenessViaApi(url) {
   const resolved = resolveAtsApi(url);
   if (!resolved) return null;
-  const { ats, apiUrl } = resolved;
+  const { ats, apiUrl, parts, interpret, timeoutMs } = resolved;
 
+  // The timeout guards the whole classification (fetch + any `interpret` body read),
+  // since aborting the shared signal also tears down an in-flight res.json().
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
-  let res;
+  const timer = setTimeout(() => controller.abort(), timeoutMs || TIMEOUT_MS);
   try {
-    res = await fetch(apiUrl, {
-      method: 'GET',
-      headers: { 'user-agent': 'career-ops-liveness/1.0', accept: 'application/json' },
-      redirect: 'error', // refuse server-side redirects (SSRF + ambiguity guard)
-      signal: controller.signal,
-    });
+    let res;
+    try {
+      res = await fetch(apiUrl, {
+        method: 'GET',
+        headers: { 'user-agent': 'career-ops-liveness/1.0', accept: 'application/json' },
+        redirect: 'error', // refuse server-side redirects (SSRF + ambiguity guard)
+        signal: controller.signal,
+      });
+    } catch {
+      return null; // network / timeout / redirect → inconclusive, let Playwright decide
+    }
+
+    if (res.status === 404 || res.status === 410) {
+      return { result: 'expired', code: `${ats}_api_gone`, reason: `ATS API ${res.status} — posting removed` };
+    }
+    if (res.status === 200) {
+      // Org-level APIs (Ashby) inspect the body to confirm THIS posting; per-job
+      // APIs (Greenhouse, Lever) treat a 200 as proof the posting is live.
+      if (interpret) return await interpret(res, parts);
+      return { result: 'active', code: `${ats}_api_ok`, reason: 'ATS API returns the posting (live)' };
+    }
+    return null; // 429/5xx/other → inconclusive, fall back to the browser check
   } catch {
-    return null; // network / timeout / redirect → inconclusive, let Playwright decide
+    return null; // interpret abort / unexpected error → inconclusive
   } finally {
     clearTimeout(timer);
   }
-
-  if (res.status === 404 || res.status === 410) {
-    return { result: 'expired', code: `${ats}_api_gone`, reason: `ATS API ${res.status} — posting removed` };
-  }
-  if (res.status === 200) {
-    return { result: 'active', code: `${ats}_api_ok`, reason: 'ATS API returns the posting (live)' };
-  }
-  return null; // 429/5xx/other → inconclusive, fall back to the browser check
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -347,6 +347,10 @@ try {
     const cvAshbyLive = await checkLivenessViaApi(`https://jobs.ashbyhq.com/deepgram/${AS_UUID}`);
     globalThis.fetch = async () => ({ status: 200, json: async () => ({ jobs: [] }) });
     const cvAshbyGone = await checkLivenessViaApi(`https://jobs.ashbyhq.com/deepgram/${AS_UUID}`);
+    // 200 but a malformed board (no `jobs` array): interpret returns null, so the
+    // orchestration must fall through to null (→ Playwright), not a false verdict.
+    globalThis.fetch = async () => ({ status: 200, json: async () => ({}) });
+    const cvAshbyMalformed = await checkLivenessViaApi(`https://jobs.ashbyhq.com/deepgram/${AS_UUID}`);
     globalThis.fetch = async () => ({ status: 200 });
     const cvGhLive = await checkLivenessViaApi('https://boards.greenhouse.io/acme/jobs/4567890');
     globalThis.fetch = async () => ({ status: 404 });
@@ -355,12 +359,13 @@ try {
     const cvErr = await checkLivenessViaApi('https://boards.greenhouse.io/acme/jobs/4567890');
     if (cvAshbyLive?.result === 'active' && cvAshbyLive?.code === 'ashby_api_ok'
         && cvAshbyGone?.result === 'expired' && cvAshbyGone?.code === 'ashby_api_unlisted'
+        && cvAshbyMalformed === null
         && cvGhLive?.result === 'active'
         && cvGone?.result === 'expired'
         && cvErr === null) {
-      pass('checkLivenessViaApi: 200→interpret (Ashby), greenhouse 200→active, 404→expired, fetch error→null');
+      pass('checkLivenessViaApi: 200→interpret (Ashby), malformed→null, greenhouse 200→active, 404→expired, fetch error→null');
     } else {
-      fail(`checkLivenessViaApi wrong: ashbyLive=${JSON.stringify(cvAshbyLive)} ashbyGone=${JSON.stringify(cvAshbyGone)} ghLive=${JSON.stringify(cvGhLive)} gone=${JSON.stringify(cvGone)} err=${JSON.stringify(cvErr)}`);
+      fail(`checkLivenessViaApi wrong: ashbyLive=${JSON.stringify(cvAshbyLive)} ashbyGone=${JSON.stringify(cvAshbyGone)} malformed=${JSON.stringify(cvAshbyMalformed)} ghLive=${JSON.stringify(cvGhLive)} gone=${JSON.stringify(cvGone)} err=${JSON.stringify(cvErr)}`);
     }
   } finally {
     globalThis.fetch = origFetch;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -273,7 +273,7 @@ try {
   // Liveness API rung (liveness-api.mjs) — the zero-token ATS first rung. We test the
   // pure URL→API resolution + SSRF guard; the network fetch is conservative by
   // construction (only 404/410→expired, 200→active, else null→Playwright fallback).
-  const { resolveAtsApi } = await import(pathToFileURL(join(ROOT, 'liveness-api.mjs')).href);
+  const { resolveAtsApi, classifyAshbyBoard } = await import(pathToFileURL(join(ROOT, 'liveness-api.mjs')).href);
   const ghApi = resolveAtsApi('https://boards.greenhouse.io/acme/jobs/4567890');
   if (ghApi?.ats === 'greenhouse' && ghApi.apiUrl === 'https://boards-api.greenhouse.io/v1/boards/acme/jobs/4567890') {
     pass('resolveAtsApi maps a Greenhouse posting to its per-job API URL');
@@ -296,6 +296,45 @@ try {
     pass('resolveAtsApi rejects non-numeric Greenhouse ids and non-https (SSRF guard)');
   } else {
     fail('resolveAtsApi guard failed (bad id or http accepted)');
+  }
+  // Ashby: org-level board endpoint. Ashby pages are JS-rendered, so the browser/
+  // static rung sees only nav/footer and false-reports live postings as expired —
+  // the API rung must resolve the org board and confirm the specific job id.
+  const AS_UUID = '00fd8024-7804-4278-a38b-c9d60d929dbb';
+  const asApi = resolveAtsApi(`https://jobs.ashbyhq.com/deepgram/${AS_UUID}`);
+  if (asApi?.ats === 'ashby'
+      && asApi.apiUrl === 'https://api.ashbyhq.com/posting-api/job-board/deepgram'
+      && asApi.parts?.jobId === AS_UUID
+      && typeof asApi.interpret === 'function') {
+    pass('resolveAtsApi maps an Ashby posting to its org job-board API URL');
+  } else {
+    fail(`Ashby API URL wrong: ${JSON.stringify(asApi)}`);
+  }
+  // The /application apply-link variant must resolve to the same org + job id.
+  const asApply = resolveAtsApi(`https://jobs.ashbyhq.com/deepgram/${AS_UUID}/application`);
+  if (asApply?.ats === 'ashby' && asApply.parts?.org === 'deepgram' && asApply.parts?.jobId === AS_UUID) {
+    pass('resolveAtsApi handles the Ashby /application apply-link variant');
+  } else {
+    fail(`Ashby /application variant not resolved: ${JSON.stringify(asApply)}`);
+  }
+  // A bare board root (no job id) isn't a specific posting → null → Playwright.
+  if (resolveAtsApi('https://jobs.ashbyhq.com/deepgram') === null) {
+    pass('resolveAtsApi returns null for an Ashby board root (no job id)');
+  } else {
+    fail('resolveAtsApi should not treat an Ashby board root as a posting');
+  }
+  // classifyAshbyBoard — pure per-job liveness from the board payload.
+  const asListed = classifyAshbyBoard({ jobs: [{ id: AS_UUID, isListed: true }] }, AS_UUID);
+  const asAbsent = classifyAshbyBoard({ jobs: [{ id: 'other-id', isListed: true }] }, AS_UUID);
+  const asUnlisted = classifyAshbyBoard({ jobs: [{ id: AS_UUID, isListed: false }] }, AS_UUID);
+  const asBadShape = classifyAshbyBoard({ notJobs: [] }, AS_UUID);
+  if (asListed?.result === 'active'
+      && asAbsent?.result === 'expired'
+      && asUnlisted?.result === 'expired'
+      && asBadShape === null) {
+    pass('classifyAshbyBoard: listed→active, absent/unlisted→expired, bad shape→null');
+  } else {
+    fail(`classifyAshbyBoard wrong: listed=${JSON.stringify(asListed)} absent=${JSON.stringify(asAbsent)} unlisted=${JSON.stringify(asUnlisted)} badShape=${JSON.stringify(asBadShape)}`);
   }
 
   // Headed-fallback-on-challenge path (liveness-browser.mjs). Fake Playwright

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -273,7 +273,7 @@ try {
   // Liveness API rung (liveness-api.mjs) — the zero-token ATS first rung. We test the
   // pure URL→API resolution + SSRF guard; the network fetch is conservative by
   // construction (only 404/410→expired, 200→active, else null→Playwright fallback).
-  const { resolveAtsApi, classifyAshbyBoard } = await import(pathToFileURL(join(ROOT, 'liveness-api.mjs')).href);
+  const { resolveAtsApi, classifyAshbyBoard, checkLivenessViaApi } = await import(pathToFileURL(join(ROOT, 'liveness-api.mjs')).href);
   const ghApi = resolveAtsApi('https://boards.greenhouse.io/acme/jobs/4567890');
   if (ghApi?.ats === 'greenhouse' && ghApi.apiUrl === 'https://boards-api.greenhouse.io/v1/boards/acme/jobs/4567890') {
     pass('resolveAtsApi maps a Greenhouse posting to its per-job API URL');
@@ -335,6 +335,35 @@ try {
     pass('classifyAshbyBoard: listed→active, absent/unlisted→expired, bad shape→null');
   } else {
     fail(`classifyAshbyBoard wrong: listed=${JSON.stringify(asListed)} absent=${JSON.stringify(asAbsent)} unlisted=${JSON.stringify(asUnlisted)} badShape=${JSON.stringify(asBadShape)}`);
+  }
+  // checkLivenessViaApi — the fetch/Response orchestration around the pure helpers:
+  // a 200 with an org-level `interpret` (Ashby) is awaited and parsed, a per-job 200
+  // (Greenhouse) is live as-is, 404 is expired, and a rejected fetch (network error,
+  // or an aborted timeout — same code path) is inconclusive → null. Mock global.fetch
+  // so no network is hit; restore it in finally.
+  const origFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async () => ({ status: 200, json: async () => ({ jobs: [{ id: AS_UUID, isListed: true }] }) });
+    const cvAshbyLive = await checkLivenessViaApi(`https://jobs.ashbyhq.com/deepgram/${AS_UUID}`);
+    globalThis.fetch = async () => ({ status: 200, json: async () => ({ jobs: [] }) });
+    const cvAshbyGone = await checkLivenessViaApi(`https://jobs.ashbyhq.com/deepgram/${AS_UUID}`);
+    globalThis.fetch = async () => ({ status: 200 });
+    const cvGhLive = await checkLivenessViaApi('https://boards.greenhouse.io/acme/jobs/4567890');
+    globalThis.fetch = async () => ({ status: 404 });
+    const cvGone = await checkLivenessViaApi('https://boards.greenhouse.io/acme/jobs/4567890');
+    globalThis.fetch = async () => { throw new Error('network down'); };
+    const cvErr = await checkLivenessViaApi('https://boards.greenhouse.io/acme/jobs/4567890');
+    if (cvAshbyLive?.result === 'active' && cvAshbyLive?.code === 'ashby_api_ok'
+        && cvAshbyGone?.result === 'expired' && cvAshbyGone?.code === 'ashby_api_unlisted'
+        && cvGhLive?.result === 'active'
+        && cvGone?.result === 'expired'
+        && cvErr === null) {
+      pass('checkLivenessViaApi: 200→interpret (Ashby), greenhouse 200→active, 404→expired, fetch error→null');
+    } else {
+      fail(`checkLivenessViaApi wrong: ashbyLive=${JSON.stringify(cvAshbyLive)} ashbyGone=${JSON.stringify(cvAshbyGone)} ghLive=${JSON.stringify(cvGhLive)} gone=${JSON.stringify(cvGone)} err=${JSON.stringify(cvErr)}`);
+    }
+  } finally {
+    globalThis.fetch = origFetch;
   }
 
   // Headed-fallback-on-challenge path (liveness-browser.mjs). Fake Playwright


### PR DESCRIPTION
## What does this PR do?

Adds an Ashby rung to the zero-token liveness API check (`liveness-api.mjs`), so live `jobs.ashbyhq.com` postings are no longer false-reported as expired.

## Related issue

None — this is a **bug fix**, which CONTRIBUTING.md exempts from issue-first. It directly extends #1181, which added the Greenhouse/Lever rung.

## The bug

The API liveness rung only knew Greenhouse and Lever; every other ATS fell through to the Playwright/static rung. Ashby posting pages are JS-rendered, so that rung sees only the nav/footer shell and returns `insufficient_content → expired` for postings that are actually **live**.

Per the Offer Verification guidance, a false "expired" is worse than a slow check — it makes the user skip a real job. And since the scanner already supports Ashby (`providers/ashby.mjs`), the system happily *finds* Ashby jobs and then wrongly marks them expired at verification time. That inconsistency is the bug.

Reproduced across Decagon, Deepgram, Clay, Cohere, and ElevenLabs.

## The fix

- New `ashby` provider in `liveness-api.mjs`. Ashby's public posting API is **org-level** (a job board), not per-job like Greenhouse/Lever — so a `200` only proves the board exists, not that *this* posting is live.
- New pure helper `classifyAshbyBoard(json, jobId)` (mirrors `classifyLiveness` in `liveness-core.mjs`): confirms the specific `{jobId}` is present **and** `isListed` before returning `active`/`expired`. An unexpected payload shape returns `null` (→ Playwright fallback) rather than a false `expired`, so a future API change degrades safely.
- **SSRF guard intact:** only `{org}` reaches the fixed-host API URL; `{jobId}` is used solely to filter the parsed board (both still pass `SAFE_SEGMENT`).
- Ashby's API has a server-side latency floor and rate-limits repeated hits, so it gets a longer per-provider timeout that also covers the `interpret` body read.
- Handles the `/{org}/{jobId}/application` apply-link URL variant.

## Verification

Verified against the **live** Ashby API:

| URL | Result |
|-----|--------|
| known live job | `active` (via API, no browser) |
| removed/fabricated jobId | `expired` (`ashby_api_unlisted`) |
| nonexistent org | `expired` (`ashby_api_gone`, 404) |

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] Bug fix — issue-first not required (exempt per CONTRIBUTING.md)
- [x] My PR does not include personal data (only `liveness-api.mjs` + `test-all.mjs` changed)
- [x] I ran `node test-all.mjs` — all tests pass, incl. the new liveness tests. The only failure locally is the dashboard build, which needs the Go toolchain I don't have installed; it's unrelated to this change and passes on CI.
- [x] My changes respect the Data Contract (only system-layer files touched)
- [x] My changes align with the project roadmap (local-first, zero-keys — reads a public job-listing API)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added liveness checking support for an additional ATS provider, including org-level interpretation from posting and application links.
  * Extended resolved-provider metadata with optional per-provider timeout overrides and an optional interpretation hook for successful responses.
* **Bug Fixes**
  * Improved active vs expired classification, including correct handling of absent/unlisted postings and malformed/unexpected provider payloads.
  * Refined fetch/timeout behavior to abort and avoid excessive inconclusive results.
* **Tests**
  * Expanded the liveness test suite with provider-specific resolution and classification scenarios, including active/expired/null and network/error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->