### PR TITLE
feat(scan): JD-aware two-stage relevance filter (loose on titles, strict on JD bodies)

### DIFF
--- a/modes/scan.md
+++ b/modes/scan.md
@@ -104,10 +104,35 @@ Los niveles son aditivos — se ejecutan todos, los resultados se mezclan y dedu
       - **company**: después del " @ " en el título, o extraer del dominio/path
    c. Acumular en lista de candidatos (dedup con Nivel 1+2)
 
-6. **Filtrar por título** usando `title_filter` de `portals.yml`:
-   - Al menos 1 keyword de `positive` debe aparecer en el título (case-insensitive)
-   - 0 keywords de `negative` deben aparecer
-   - `seniority_boost` keywords dan prioridad pero no son obligatorios
+6. **Filtrar por relevancia (dos etapas)** usando `relevance_filter` de `portals.yml`.
+   Filosofía: **laxo en títulos, estricto en el cuerpo del JD.** Los mejores puestos
+   de dispositivos tienen títulos genéricos ("Device Design Engineer"); la señal
+   discriminante (microfluidic, MEMS, acoustofluidic, PDMS, cleanroom) vive en el JD.
+
+   - **Etapa 1 — `title_exclude`:** rechazar si el TÍTULO contiene cualquier término
+     (seniority, función incorrecta, dominios 2B: catéter/semi/manufactura/Process Engineer).
+   - **Etapa 1.5 — `title_require_any`:** el título debe nombrar un rol de
+     ingeniería/fabricación (o un término de dominio core). Descarta roles de función
+     incorrecta (Scientist, Chemist, Biologist) cuyo JD sólo menciona el dominio como
+     boilerplate corporativo. Es un filtro FUNCIONAL, no de keyword de dominio.
+   - **Etapa 2 — `jd_require_any`:** el cuerpo del JD (título + descripción) debe
+     contener ≥1 término core, o se descarta.
+   - **Etapa 2b — `jd_deprioritize_any`:** rechazo por dominancia (agresivo). Si el JD
+     nombra tantos o más términos de medtech intervencionista (catéter/endovascular/
+     ablación/stent) como términos core, descartar. Sólo términos intervencionistas —
+     wafer/etch/packaging son técnicas MEMS legítimas y quedan a nivel de título.
+   - **Etapa 2c — `jd_exclude_any`:** rechazo duro (ciudadanía/clearance que Nicole no puede cumplir).
+
+   **Coste del JD-gate por fuente (importante para el límite de 45 min de scan):**
+   - **`scan.mjs` (Greenhouse/Ashby/Lever):** el JD llega gratis en la MISMA llamada
+     de API (`?content=true` en Greenhouse; `descriptionPlain` en Lever/Ashby). Aplicar
+     las 4 etapas en el scan. Sin peticiones extra, sin coste de tiempo.
+   - **Fuentes de navegador (LinkedIn / hiring.cafe / Playwright):** NO abrir cada JD
+     en el scan (multiplicaría navegaciones y agotaría el presupuesto de 45 min).
+     Aplicar sólo Etapa 1 + 1.5 (sobre el título, gratis) al añadir a `pipeline.md`.
+     La Etapa 2 (JD-require) se aplica como **early-exit en el momento de evaluación**
+     (ver `modes/pipeline.md`): el eval ya descarga el JD, así que si no hay término
+     core → marcar `SKIP` inmediatamente sin escribir el reporte A–G completo.
 
 6b. **Filtrar por ubicación (opcional)** usando `location_filter` de `portals.yml`:
    - Si el bloque `location_filter` está ausente, todas las ubicaciones pasan (comportamiento por defecto)

--- a/scan.mjs
+++ b/scan.mjs
@@ -34,10 +34,16 @@ const FETCH_TIMEOUT_MS = 10_000;
 
 // ── API detection ───────────────────────────────────────────────────
 
+// Append a query param, respecting any existing query string.
+function withParam(url, key, value) {
+  return url + (url.includes('?') ? '&' : '?') + `${key}=${value}`;
+}
+
 function detectApi(company) {
-  // Greenhouse: explicit api field
+  // Greenhouse: explicit api field. content=true returns the full JD body inline
+  // in the SAME call (no extra requests) so the JD-relevance filter is free.
   if (company.api && company.api.includes('greenhouse')) {
-    return { type: 'greenhouse', url: company.api };
+    return { type: 'greenhouse', url: withParam(company.api, 'content', 'true') };
   }
 
   const url = company.careers_url || '';
@@ -65,7 +71,7 @@ function detectApi(company) {
   if (ghEuMatch && !company.api) {
     return {
       type: 'greenhouse',
-      url: `https://boards-api.greenhouse.io/v1/boards/${ghEuMatch[1]}/jobs`,
+      url: `https://boards-api.greenhouse.io/v1/boards/${ghEuMatch[1]}/jobs?content=true`,
     };
   }
 
@@ -81,6 +87,7 @@ function parseGreenhouse(json, companyName) {
     url: j.absolute_url || '',
     company: companyName,
     location: j.location?.name || '',
+    content: j.content || '',            // HTML-encoded JD body (content=true)
   }));
 }
 
@@ -91,6 +98,7 @@ function parseAshby(json, companyName) {
     url: j.jobUrl || '',
     company: companyName,
     location: j.location || '',
+    content: j.descriptionPlain || j.descriptionHtml || j.description || '',
   }));
 }
 
@@ -101,6 +109,7 @@ function parseLever(json, companyName) {
     url: j.hostedUrl || '',
     company: companyName,
     location: j.categories?.location || '',
+    content: j.descriptionPlain || j.description || '',
   }));
 }
 
@@ -120,17 +129,65 @@ async function fetchJson(url) {
   }
 }
 
-// ── Title filter ────────────────────────────────────────────────────
+// ── Relevance filter (two-stage: title reject → JD require) ──────────
+// Returns { pass, reason }. Reasons: 'title_exclude' | 'jd_exclude' |
+// 'no_core' | 'deprioritized'. See relevance_filter docs in portals.yml.
+//
+// Philosophy: LOOSE on titles, STRICT on JD bodies. A generic title
+// ("Device Design Engineer") passes Stage 1; the JD body must then carry a
+// core term (Stage 2). This keeps generic-title dream jobs whose JD says
+// "MEMS" and drops generic-title roles whose JD never mentions the domain.
 
-function buildTitleFilter(titleFilter) {
+function buildRelevanceFilter(rf) {
+  const titleExclude = (rf.title_exclude || []).map(k => k.toLowerCase());
+  const titleRequire = (rf.title_require_any || []).map(k => k.toLowerCase());
+  const requireAny   = (rf.jd_require_any || []).map(k => k.toLowerCase());
+  const deprioAny    = (rf.jd_deprioritize_any || []).map(k => k.toLowerCase());
+  const jdExclude    = (rf.jd_exclude_any || []).map(k => k.toLowerCase());
+
+  return (title, content = '') => {
+    const t = (title || '').toLowerCase();
+    const c = (content || '').toLowerCase();
+    const hay = t + ' \n ' + c;   // title + JD body — a term in either satisfies require
+
+    // Stage 1 — title reject
+    if (titleExclude.some(k => t.includes(k))) return { pass: false, reason: 'title_exclude' };
+
+    // Stage 1.5 — title must name an engineering/fab role (functional gate)
+    if (titleRequire.length > 0 && !titleRequire.some(k => t.includes(k)))
+      return { pass: false, reason: 'title_no_role' };
+
+    // Stage 2c — hard JD reject (citizenship/clearance blockers)
+    if (jdExclude.some(k => c.includes(k))) return { pass: false, reason: 'jd_exclude' };
+
+    // Stage 2 — require ≥1 core term in title or JD body
+    const coreHits = requireAny.filter(k => hay.includes(k)).length;
+    if (requireAny.length > 0 && coreHits === 0) return { pass: false, reason: 'no_core' };
+
+    // Stage 2b — aggressive dominance: drop JDs where interventional-medtech terms
+    // are as prevalent as core terms (only when a JD body is available to judge).
+    if (c) {
+      const deprioHits = deprioAny.filter(k => c.includes(k)).length;
+      if (deprioHits > 0 && deprioHits >= coreHits) return { pass: false, reason: 'deprioritized' };
+    }
+
+    return { pass: true };
+  };
+}
+
+// Legacy fallback: old title_filter (positive/negative on title only), wrapped
+// in the same { pass, reason } contract so main() stays uniform.
+function buildLegacyTitleFilter(titleFilter) {
   const positive = (titleFilter?.positive || []).map(k => k.toLowerCase());
   const negative = (titleFilter?.negative || []).map(k => k.toLowerCase());
 
   return (title) => {
-    const lower = title.toLowerCase();
+    const lower = (title || '').toLowerCase();
     const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
     const hasNegative = negative.some(k => lower.includes(k));
-    return hasPositive && !hasNegative;
+    return (hasPositive && !hasNegative)
+      ? { pass: true }
+      : { pass: false, reason: 'title' };
   };
 }
 
@@ -288,7 +345,10 @@ async function main() {
 
   const config = parseYaml(readFileSync(PORTALS_PATH, 'utf-8'));
   const companies = config.tracked_companies || [];
-  const titleFilter = buildTitleFilter(config.title_filter);
+  // Prefer the new two-stage relevance_filter; fall back to legacy title_filter.
+  const relevanceFilter = config.relevance_filter
+    ? buildRelevanceFilter(config.relevance_filter)
+    : buildLegacyTitleFilter(config.title_filter);
   const locationFilter = buildLocationFilter(config.location_filter);
 
   // 2. Filter to enabled companies with detectable APIs
@@ -310,7 +370,7 @@ async function main() {
   // 4. Fetch all APIs
   const date = new Date().toISOString().slice(0, 10);
   let totalFound = 0;
-  let totalFilteredTitle = 0;
+  let totalFilteredRelevance = 0;
   let totalFilteredLocation = 0;
   let totalDupes = 0;
   const newOffers = [];
@@ -324,8 +384,8 @@ async function main() {
       totalFound += jobs.length;
 
       for (const job of jobs) {
-        if (!titleFilter(job.title)) {
-          totalFilteredTitle++;
+        if (!relevanceFilter(job.title, job.content).pass) {
+          totalFilteredRelevance++;
           continue;
         }
         if (!locationFilter(job.location)) {
@@ -344,7 +404,9 @@ async function main() {
         // Mark as seen to avoid intra-scan dupes
         seenUrls.add(job.url);
         seenCompanyRoles.add(key);
-        newOffers.push({ ...job, source: `${type}-api` });
+        // Drop the (large) JD body before persisting — only used for filtering.
+        const { content, ...lean } = job;
+        newOffers.push({ ...lean, source: `${type}-api` });
       }
     } catch (err) {
       errors.push({ company: company.name, error: err.message });
@@ -365,7 +427,7 @@ async function main() {
   console.log(`${'━'.repeat(45)}`);
   console.log(`Companies scanned:     ${targets.length}`);
   console.log(`Total jobs found:      ${totalFound}`);
-  console.log(`Filtered by title:     ${totalFilteredTitle} removed`);
+  console.log(`Filtered by relevance: ${totalFilteredRelevance} removed (title reject + JD gate)`);
   console.log(`Filtered by location:  ${totalFilteredLocation} removed`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
   console.log(`New offers added:      ${newOffers.length}`);

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -15,7 +15,7 @@
 #
 # HOW TO CUSTOMIZE:
 #   1. Copy this file to portals.yml in the project root
-#   2. Edit title_filter.positive with YOUR target role keywords
+#   2. Edit relevance_filter (jd_require_any = YOUR core terms; title_exclude = wrong roles)
 #   3. Add/remove companies in tracked_companies
 #   4. Adjust search_queries for your preferred job boards
 #   5. Set enabled: false on companies you don't care about
@@ -53,57 +53,30 @@
 #     - "Brazil"
 #     - "Australia"
 
-# -- Title filter --
-# The scanner uses these keywords to decide if a title is relevant.
-# At least 1 positive must match AND 0 negatives must match (case-insensitive).
+# -- Relevance filter (two-stage: title reject → JD require) -- RECOMMENDED
+# Philosophy: LOOSE on titles, STRICT on JD bodies. The best-fit roles often carry
+# generic titles ("Solutions Engineer", "Member of Technical Staff") while the
+# discriminating signal lives in the JD body. Title-only filtering forces a bad
+# trade: loose enough to catch them = flooded with noise; tight enough to kill
+# noise = drops the good ones. So reject on titles, REQUIRE on JD content.
+#
+# scan.mjs reads the JD body for free from the ATS API payload (Greenhouse
+# `?content=true`, Lever/Ashby `descriptionPlain`) — no extra HTTP calls, no
+# measurable time cost. Browser sources (LinkedIn/hiring.cafe) apply Stage 1 at
+# scan time and defer the JD gate to evaluation time (see modes/scan.md).
+#
+#   STAGE 1   title_exclude       reject if the TITLE contains any term
+#   STAGE 1.5 title_require_any   (optional) TITLE must name a target role/term
+#   STAGE 2   jd_require_any      JD body (title+description) must contain ≥1 term
+#   STAGE 2b  jd_deprioritize_any (optional) drop JDs where these terms rival core terms
+#   STAGE 2c  jd_exclude_any      (optional) hard reject on any JD term
+#
+# If `relevance_filter` is absent, scan.mjs falls back to the legacy `title_filter`
+# (positive/negative on title only) shown commented at the bottom of this section.
 
-title_filter:
-  positive:
-    # [CUSTOMIZE] Add keywords matching YOUR target roles
-    # -- AI/ML roles --
-    - "AI"
-    - "ML"
-    - "LLM"
-    - "Agent"
-    - "Agentic"
-    - "GenAI"
-    - "Generative AI"
-    - "NLP"
-    - "LLMOps"
-    - "MLOps"
-    - "Voice AI"
-    - "Conversational AI"
-    - "Speech"
-    # -- German AI/ML keywords (DACH market) --
-    - "KI"
-    - "Künstliche Intelligenz"
-    - "KI Engineer"
-    - "KI Trainer"
-    - "Dozent"
-    - "Weiterbildung"
-    # -- Engineering roles --
-    - "Platform Engineer"
-    - "Solutions Architect"
-    - "Solutions Engineer"
-    - "Forward Deployed"
-    - "Deployed Engineer"
-    - "Customer Engineer"
-    - "Integration Engineer"
-    # -- Product roles --
-    - "Product Manager"
-    - "Technical PM"
-    # -- Automation roles --
-    - "Automation"
-    - "Hyperautomation"
-    - "Low-Code"
-    - "No-Code"
-    - "GTM Engineer"
-    - "RevOps"
-    - "Business Systems"
-    - "Internal Tools"
-    - "Transformation"
-  negative:
-    # [CUSTOMIZE] Add keywords for roles you want to exclude
+relevance_filter:
+  # STAGE 1 — title reject only (fast, no fetch)
+  title_exclude:
     - "Junior"
     - "Intern"
     - ".NET"
@@ -124,13 +97,50 @@ title_filter:
     - "Oracle EBS"
     - "Mainframe"
     - "COBOL"
-  seniority_boost:
-    # These prefixes add relevance but are not required
-    - "Senior"
-    - "Staff"
-    - "Principal"
-    - "Lead"
-    - "Head"
+
+  # STAGE 1.5 (optional) — title must name a target ROLE (functional gate). Kills
+  # wrong-function roles whose JD mentions your domain only as company boilerplate.
+  # Omit the whole key to disable this stage.
+  # title_require_any:
+  #   - "engineer"
+  #   - "architect"
+  #   - "product manager"
+
+  # STAGE 2 — JD body must contain ≥1 of these core terms
+  jd_require_any:
+    - "LLM"
+    - "large language model"
+    - "machine learning"
+    - "generative ai"
+    - "agentic"
+    - "NLP"
+    - "MLOps"
+    - "automation"
+
+  # STAGE 2b (optional) — dominance reject: drop JDs where these terms are as
+  # prevalent as core terms (a role that only name-drops your domain once).
+  # jd_deprioritize_any:
+  #   - "blockchain"
+  #   - "web3"
+
+  # STAGE 2c (optional) — hard JD reject (e.g. blockers you cannot meet)
+  # jd_exclude_any:
+  #   - "u.s. citizenship required"
+  #   - "security clearance required"
+
+# -- Title filter (LEGACY fallback) --
+# Used ONLY when relevance_filter is absent. At least 1 positive must match AND
+# 0 negatives must match (case-insensitive, title only).
+# title_filter:
+#   positive:
+#     - "AI"
+#     - "Product Manager"
+#   negative:
+#     - "Junior"
+#     - "Intern"
+#   seniority_boost:
+#     - "Senior"
+#     - "Staff"
     - "Director"
 
 # -- Search queries --


### PR DESCRIPTION
## What

Adds a two-stage `relevance_filter` to the zero-token scanner (`scan.mjs`) that filters on **JD body content**, not just titles.

**Motivation.** Title-only filtering forces a bad trade for many fields: the best-fit roles often carry generic titles ("Device Design Engineer", "Solutions Engineer", "Member of Technical Staff") while the discriminating signal lives in the job description. A positive-title keyword list loose enough to catch those floods the pipeline; tight enough to stay clean drops them.

**Approach — loose on titles, strict on JDs:**
- **Stage 1 `title_exclude`** — reject titles that are unambiguously wrong (seniority, function, unwanted domains).
- **Stage 1.5 `title_require_any`** (optional) — functional gate: the title must name a target role, killing wrong-function roles (e.g. a wet-lab Scientist) whose JD mentions the domain only as company boilerplate.
- **Stage 2 `jd_require_any`** — the JD body (title + description) must contain ≥1 core term.
- **Stage 2b `jd_deprioritize_any`** (optional) — dominance reject for JDs where off-target terms rival core terms.
- **Stage 2c `jd_exclude_any`** (optional) — hard reject (e.g. citizenship/clearance blockers).

**Zero added cost.** The JD body arrives in the *same* API call the scanner already makes — Greenhouse via `?content=true`, Lever/Ashby via `descriptionPlain`. No extra HTTP requests; matching is a local string scan.

## Backward compatibility

Fully backward compatible. If `relevance_filter` is absent, `scan.mjs` falls back to the existing `title_filter` (positive/negative on title only). Existing configs keep working unchanged.

## Changes
- `scan.mjs` — append `?content=true` for Greenhouse; parsers surface the JD `content`; new `buildRelevanceFilter()` (two-stage) with a legacy `buildLegacyTitleFilter()` fallback; summary line reports relevance filtering.
- `templates/portals.example.yml` — documents `relevance_filter` as the recommended format; keeps `title_filter` as a documented legacy fallback.
- `modes/scan.md` — documents the two-stage filter and the browser-source eval-time gate (with the 45-min scan-budget rationale).

## Testing
- `node test-all.mjs` → 71 passed, 0 failed.
- `node scan.mjs --dry-run` against Greenhouse boards (10x Genomics, Twist, Xaira): JD bodies fetched inline (verified ~7.7 KB content per posting in one call), two-stage filter drops boilerplate-only and wrong-function matches while keeping generic-title, JD-matched roles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new relevance-based scan filter that checks both job titles and job description content.
  * Jobs can now be matched more accurately using core role/domain terms, with stricter exclusion and deprioritization rules.
  * Updated scan results to show “filtered by relevance” in the summary.

* **Bug Fixes**
  * Improved parsing of job listings so descriptions are included more consistently during scanning.
  * Reduced storage of unnecessary content in saved scan outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->