### PR TITLE
feat(providers): add Teamtailor zero-auth RSS provider

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -29,6 +29,7 @@ are shared helpers and are not loaded as providers.
 | Rippling | API | Auto-detects `https://ats.rippling.com/<slug>/jobs` careers pages and reads the public zero-auth board API (`api.rippling.com/platform/api/ats/v1/board/<slug>/jobs`). |
 | SmartRecruiters | API | Auto-detects SmartRecruiters careers URLs or uses `provider: smartrecruiters` for branded custom domains. |
 | SolidJobs | API | Auto-detects `https://solid.jobs/public-api/offers/<division>` and reads the public offers API. |
+| Teamtailor | RSS | Auto-detects `<slug>.teamtailor.com` career sites and reads the public zero-auth `/jobs.rss` per-tenant feed. Job links may point at a branded custom domain; location comes from the `tt:` city/country tags. |
 | The Hub | API | Reads the board-wide `https://thehub.io/api/jobs` JSON feed (Nordic/EU startups). Configure with `provider: thehub`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
 | We Work Remotely | RSS | Reads the public `https://weworkremotely.com/remote-jobs.rss` feed and parses it in-process. |
 | Workable | Parser | Auto-detects `https://apply.workable.com/<slug>` and parses Workable's public markdown jobs feed. |

--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -29,7 +29,7 @@ are shared helpers and are not loaded as providers.
 | Rippling | API | Auto-detects `https://ats.rippling.com/<slug>/jobs` careers pages and reads the public zero-auth board API (`api.rippling.com/platform/api/ats/v1/board/<slug>/jobs`). |
 | SmartRecruiters | API | Auto-detects SmartRecruiters careers URLs or uses `provider: smartrecruiters` for branded custom domains. |
 | SolidJobs | API | Auto-detects `https://solid.jobs/public-api/offers/<division>` and reads the public offers API. |
-| Teamtailor | RSS | Auto-detects `<slug>.teamtailor.com` career sites and reads the public zero-auth `/jobs.rss` per-tenant feed. Job links may point at a branded custom domain; location comes from the `tt:` city/country tags. |
+| Teamtailor | RSS | Auto-detects `<slug>.teamtailor.com` career sites and reads the public zero-auth `/jobs.rss` per-tenant feed. For a branded careers domain, set `provider: teamtailor` and it reads `/jobs.rss` off that host. Job links may point at a branded custom domain; location comes from the `tt:` city/country tags. |
 | The Hub | API | Reads the board-wide `https://thehub.io/api/jobs` JSON feed (Nordic/EU startups). Configure with `provider: thehub`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
 | We Work Remotely | RSS | Reads the public `https://weworkremotely.com/remote-jobs.rss` feed and parses it in-process. |
 | Workable | Parser | Auto-detects `https://apply.workable.com/<slug>` and parses Workable's public markdown jobs feed. |

--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -29,7 +29,7 @@ are shared helpers and are not loaded as providers.
 | Rippling | API | Auto-detects `https://ats.rippling.com/<slug>/jobs` careers pages and reads the public zero-auth board API (`api.rippling.com/platform/api/ats/v1/board/<slug>/jobs`). |
 | SmartRecruiters | API | Auto-detects SmartRecruiters careers URLs or uses `provider: smartrecruiters` for branded custom domains. |
 | SolidJobs | API | Auto-detects `https://solid.jobs/public-api/offers/<division>` and reads the public offers API. |
-| Teamtailor | RSS | Auto-detects `<slug>.teamtailor.com` career sites and reads the public zero-auth `/jobs.rss` per-tenant feed. For a branded careers domain, set `provider: teamtailor` and it reads `/jobs.rss` off that host. Job links may point at a branded custom domain; location comes from the `tt:` city/country tags. |
+| Teamtailor | RSS | Auto-detects `<slug>.teamtailor.com` career sites and reads the public zero-auth `/jobs.rss` per-tenant feed. For a branded careers domain, set `provider: teamtailor` and it reads `/jobs.rss` off that host. Job links may point at a branded custom domain; location comes from the `tt:` city/country tags, falling back to `Remote` when a posting carries no `tt:city`/`tt:country` but its `remoteStatus` is remote (`fully` or `temporary`). |
 | The Hub | API | Reads the board-wide `https://thehub.io/api/jobs` JSON feed (Nordic/EU startups). Configure with `provider: thehub`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
 | We Work Remotely | RSS | Reads the public `https://weworkremotely.com/remote-jobs.rss` feed and parses it in-process. |
 | Workable | Parser | Auto-detects `https://apply.workable.com/<slug>` and parses Workable's public markdown jobs feed. |

--- a/providers/teamtailor.mjs
+++ b/providers/teamtailor.mjs
@@ -1,0 +1,182 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Teamtailor provider — per-tenant public RSS feed.
+//
+// Every Teamtailor career site exposes a zero-auth XML jobs feed at
+// `https://<slug>.teamtailor.com/jobs.rss`. The feed is public and no-auth, so
+// it is parsed in-process with the same tiny tag extractor as
+// providers/nodesk.mjs / providers/personio.mjs rather than adding an XML
+// dependency.
+//
+// Auto-detects `https://<slug>.teamtailor.com/...` careers URLs; you can also
+// wire it in explicitly with `provider: teamtailor` plus a `careers_url` (or
+// `api:`) on the same host. Job `<link>`s may point at a branded custom domain
+// (e.g. careers.acme.com), so only the feed URL is host-pinned — the SSRF
+// guard sits on the fetch, not on the emitted job URLs.
+
+const TEAMTAILOR_HOST_RE = /^([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.teamtailor\.com$/i;
+
+/** @param {string} url */
+function assertTeamtailorUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`teamtailor: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`teamtailor: URL must use HTTPS: ${url}`);
+  if (!TEAMTAILOR_HOST_RE.test(parsed.hostname)) {
+    throw new Error(`teamtailor: untrusted hostname "${parsed.hostname}" — must be <slug>.teamtailor.com`);
+  }
+  return url;
+}
+
+// Derive the RSS feed URL from a tracked_companies entry. Accepts an explicit
+// `api:`/`careers_url` on a *.teamtailor.com host and normalizes any path to
+// /jobs.rss. Returns null when the entry isn't a Teamtailor career site.
+/** @param {import('./_types.js').PortalEntry} entry */
+function resolveFeedUrl(entry) {
+  const raw = entry?.api || entry?.careers_url || '';
+  if (!raw) return null;
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:') return null;
+  if (!TEAMTAILOR_HOST_RE.test(parsed.hostname)) return null;
+  return `https://${parsed.hostname}/jobs.rss`;
+}
+
+function fallbackCompany(entry) {
+  return typeof entry?.name === 'string' && entry.name.trim() ? entry.name.trim() : 'Teamtailor';
+}
+
+/** @type {Provider} */
+export default {
+  id: 'teamtailor',
+
+  detect(entry) {
+    const url = resolveFeedUrl(entry);
+    return url ? { url } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const feedUrl = resolveFeedUrl(entry);
+    if (!feedUrl) throw new Error(`teamtailor: cannot derive jobs.rss URL for ${fallbackCompany(entry)}`);
+    assertTeamtailorUrl(feedUrl);
+    // redirect:'error' prevents SSRF via server-side redirects; combined with
+    // assertTeamtailorUrl above it keeps the request pinned to a
+    // <slug>.teamtailor.com host.
+    const text = await ctx.fetchText(feedUrl, { redirect: 'error' });
+    return parseTeamtailorFeed(text, fallbackCompany(entry));
+  },
+};
+
+function fromCodePoint(cp) {
+  try {
+    return String.fromCodePoint(cp);
+  } catch {
+    return '';
+  }
+}
+
+// Decode the XML entities that appear in RSS text: numeric (&#38; / &#x27;)
+// and the named five. Numeric forms are decoded first; &amp; is decoded LAST
+// so a literal "&amp;lt;" yields "&lt;" rather than over-decoding to "<".
+function decodeXmlEntities(s) {
+  return s
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, d) => fromCodePoint(parseInt(d, 10)))
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+// Resolve a tag's inner text: unwrap a CDATA section, else decode entities.
+function extractText(inner) {
+  const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
+  if (cdata) return cdata[1].trim();
+  return decodeXmlEntities(inner).trim();
+}
+
+// Extract the text of the first <tag>...</tag> in a block. Returns '' when
+// absent. Tag names may contain a namespace colon (e.g. tt:city).
+function tagText(block, tag) {
+  const m = block.match(new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)</${tag}>`, 'i'));
+  return m ? extractText(m[1]) : '';
+}
+
+// NaN-safe Date.parse — `|| undefined` would also coerce a valid epoch 0.
+function toEpochMs(value) {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+// Keep only absolute HTTPS links. Teamtailor job URLs frequently live on a
+// branded custom domain, so — unlike the feed host — the link host is not
+// pinned; we only require a well-formed https URL.
+function cleanUrl(value) {
+  if (!value) return '';
+  try {
+    const parsed = new URL(value.trim());
+    return parsed.protocol === 'https:' ? parsed.href : '';
+  } catch {
+    return '';
+  }
+}
+
+// Build a human location from the first <tt:location> (city, country). Falls
+// back to "Remote" when the posting carries no place but is flagged remote.
+function resolveLocation(item) {
+  const city = tagText(item, 'tt:city');
+  const country = tagText(item, 'tt:country');
+  const place = [city, country].filter(Boolean).join(', ');
+  if (place) return place;
+  const remote = tagText(item, 'remoteStatus').toLowerCase();
+  return remote === 'fully' || remote === 'temporary' ? 'Remote' : '';
+}
+
+/**
+ * Parse a Teamtailor public RSS jobs feed. Exported for unit tests.
+ *
+ * Shape: `<rss><channel><item>...</item>...</channel></rss>`. Each item
+ * exposes `<title>`, `<link>`, `<pubDate>`, an optional `<remoteStatus>`, and
+ * a `tt:` locations block (`<tt:city>`, `<tt:country>`). The company is not in
+ * the item, so the tracked_companies `name` is used.
+ *
+ * @param {string} xml - raw RSS feed body
+ * @param {string} [defaultCompany] - company label for every posting
+ * @returns {Array<{title: string, url: string, company: string, location: string, postedAt?: number}>}
+ */
+export function parseTeamtailorFeed(xml, defaultCompany = 'Teamtailor') {
+  if (typeof xml !== 'string') return [];
+  const company = typeof defaultCompany === 'string' && defaultCompany.trim() ? defaultCompany.trim() : 'Teamtailor';
+  const jobs = [];
+  const blocks = xml.match(/<item\b[^>]*>[\s\S]*?<\/item>/gi) || [];
+
+  for (const item of blocks) {
+    const url = cleanUrl(tagText(item, 'link'));
+    if (!url) continue;
+
+    const title = tagText(item, 'title');
+    if (!title) continue;
+
+    const postedAt = toEpochMs(tagText(item, 'pubDate'));
+    const job = {
+      title,
+      company,
+      location: resolveLocation(item),
+      url,
+    };
+    if (postedAt !== undefined) job.postedAt = postedAt;
+    jobs.push(job);
+  }
+
+  return jobs;
+}

--- a/providers/teamtailor.mjs
+++ b/providers/teamtailor.mjs
@@ -9,16 +9,28 @@
 // providers/nodesk.mjs / providers/personio.mjs rather than adding an XML
 // dependency.
 //
-// Auto-detects `https://<slug>.teamtailor.com/...` careers URLs; you can also
-// wire it in explicitly with `provider: teamtailor` plus a `careers_url` (or
-// `api:`) on the same host. Job `<link>`s may point at a branded custom domain
-// (e.g. careers.acme.com), so only the feed URL is host-pinned — the SSRF
-// guard sits on the fetch, not on the emitted job URLs.
+// Auto-detects `https://<slug>.teamtailor.com/...` careers URLs. Many tenants
+// front the same feed on a branded domain (e.g. careers.acme.com also serves
+// /jobs.rss), so an entry with an explicit `provider: teamtailor` may point its
+// `careers_url` (or `api:`) at that branded host and it will be used directly.
+//
+// SSRF stance mirrors the other providers: auto-detection stays pinned to
+// `*.teamtailor.com` so untrusted careers URLs can never steer the fetch at an
+// arbitrary host; a branded host is honored only when the user opted in with an
+// explicit `provider: teamtailor`. Either way the fetch is HTTPS-only with
+// `redirect: 'error'`. Job `<link>`s (branded domains) are emitted as-is and
+// never fetched.
 
 const TEAMTAILOR_HOST_RE = /^([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.teamtailor\.com$/i;
 
-/** @param {string} url */
-function assertTeamtailorUrl(url) {
+/**
+ * Validate a feed URL before fetching. Always HTTPS-only. The hostname is
+ * pinned to `*.teamtailor.com` for auto-detected entries; an explicit
+ * `provider: teamtailor` entry may use its configured branded host.
+ * @param {string} url
+ * @param {{ explicit?: boolean }} [opts]
+ */
+function assertFeedUrl(url, { explicit = false } = {}) {
   let parsed;
   try {
     parsed = new URL(url);
@@ -26,19 +38,23 @@ function assertTeamtailorUrl(url) {
     throw new Error(`teamtailor: invalid URL: ${url}`);
   }
   if (parsed.protocol !== 'https:') throw new Error(`teamtailor: URL must use HTTPS: ${url}`);
-  if (!TEAMTAILOR_HOST_RE.test(parsed.hostname)) {
-    throw new Error(`teamtailor: untrusted hostname "${parsed.hostname}" — must be <slug>.teamtailor.com`);
+  if (!explicit && !TEAMTAILOR_HOST_RE.test(parsed.hostname)) {
+    throw new Error(`teamtailor: untrusted hostname "${parsed.hostname}" — must be <slug>.teamtailor.com (or set "provider: teamtailor" to use a branded careers domain)`);
   }
   return url;
 }
 
-// Derive the RSS feed URL from a tracked_companies entry. Accepts an explicit
-// `api:`/`careers_url` on a *.teamtailor.com host and normalizes any path to
-// /jobs.rss. Returns null when the entry isn't a Teamtailor career site.
-/** @param {import('./_types.js').PortalEntry} entry */
-function resolveFeedUrl(entry) {
+// Derive the RSS feed URL from a tracked_companies entry by normalizing any
+// path on the configured host to /jobs.rss. Auto-detection (explicit=false)
+// only claims *.teamtailor.com hosts; an explicit `provider: teamtailor` entry
+// (explicit=true) may use a branded careers host. Returns null otherwise.
+/**
+ * @param {import('./_types.js').PortalEntry} entry
+ * @param {{ explicit?: boolean }} [opts]
+ */
+function resolveFeedUrl(entry, { explicit = false } = {}) {
   const raw = entry?.api || entry?.careers_url || '';
-  if (!raw) return null;
+  if (typeof raw !== 'string' || !raw) return null;
   let parsed;
   try {
     parsed = new URL(raw);
@@ -46,7 +62,7 @@ function resolveFeedUrl(entry) {
     return null;
   }
   if (parsed.protocol !== 'https:') return null;
-  if (!TEAMTAILOR_HOST_RE.test(parsed.hostname)) return null;
+  if (!explicit && !TEAMTAILOR_HOST_RE.test(parsed.hostname)) return null;
   return `https://${parsed.hostname}/jobs.rss`;
 }
 
@@ -59,17 +75,19 @@ export default {
   id: 'teamtailor',
 
   detect(entry) {
-    const url = resolveFeedUrl(entry);
+    // Auto-detection never claims a branded host — only *.teamtailor.com.
+    const url = resolveFeedUrl(entry, { explicit: false });
     return url ? { url } : null;
   },
 
   async fetch(entry, ctx) {
-    const feedUrl = resolveFeedUrl(entry);
+    const explicit = entry?.provider === 'teamtailor';
+    const feedUrl = resolveFeedUrl(entry, { explicit });
     if (!feedUrl) throw new Error(`teamtailor: cannot derive jobs.rss URL for ${fallbackCompany(entry)}`);
-    assertTeamtailorUrl(feedUrl);
+    assertFeedUrl(feedUrl, { explicit });
     // redirect:'error' prevents SSRF via server-side redirects; combined with
-    // assertTeamtailorUrl above it keeps the request pinned to a
-    // <slug>.teamtailor.com host.
+    // assertFeedUrl above it keeps the request pinned to the trusted host
+    // (*.teamtailor.com, or the branded host the user explicitly configured).
     const text = await ctx.fetchText(feedUrl, { redirect: 'error' });
     return parseTeamtailorFeed(text, fallbackCompany(entry));
   },

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2621,6 +2621,134 @@ try {
   fail(`recruitee provider tests crashed: ${e.message}`);
 }
 
+// ── 14. PROVIDERS — Teamtailor ──────────────────────────────────────
+
+console.log('\n14. Provider — teamtailor');
+
+try {
+  const teamtailor = (await import(pathToFileURL(join(ROOT, 'providers/teamtailor.mjs')).href)).default;
+  const { parseTeamtailorFeed } = await import(pathToFileURL(join(ROOT, 'providers/teamtailor.mjs')).href);
+
+  if (teamtailor.id === 'teamtailor') pass('teamtailor.id is "teamtailor"');
+  else fail(`teamtailor.id is ${JSON.stringify(teamtailor.id)}`);
+
+  // detect() — auto-detection from a <slug>.teamtailor.com careers_url, with
+  // any path normalized to /jobs.rss.
+  const hit = teamtailor.detect({ name: 'Podimo', careers_url: 'https://podimo.teamtailor.com/jobs' });
+  if (hit && hit.url === 'https://podimo.teamtailor.com/jobs.rss') {
+    pass('teamtailor.detect() resolves <slug>.teamtailor.com → /jobs.rss feed');
+  } else {
+    fail(`teamtailor.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  if (teamtailor.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('teamtailor.detect() returns null for non-teamtailor URLs');
+  } else {
+    fail('teamtailor.detect() should return null for non-teamtailor URLs');
+  }
+
+  // non-string careers_url → detect() returns null without crashing
+  if (teamtailor.detect({ name: 'X', careers_url: null }) === null && teamtailor.detect({ name: 'X', careers_url: 7 }) === null) {
+    pass('teamtailor.detect() returns null for non-string careers_url (null and 7)');
+  } else {
+    fail('teamtailor.detect() should treat non-string careers_url as missing');
+  }
+
+  // SSRF: teamtailor.com in the PATH (not host) must not be detected.
+  if (teamtailor.detect({ name: 'Spoof', careers_url: 'https://evil.example/podimo.teamtailor.com/jobs' }) === null) {
+    pass('teamtailor.detect() rejects path-spoofed URLs');
+  } else {
+    fail('teamtailor.detect() must NOT misdetect path-spoofed URLs');
+  }
+
+  // non-https careers_url is rejected
+  if (teamtailor.detect({ name: 'X', careers_url: 'http://podimo.teamtailor.com/jobs' }) === null) {
+    pass('teamtailor.detect() rejects non-https careers_url');
+  } else {
+    fail('teamtailor.detect() should reject non-https careers_url');
+  }
+
+  // parseTeamtailorFeed — RSS with tt: locations block and branded job link
+  const sampleXml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:tt="https://teamtailor.com/locations"><channel>',
+    '<title>Podimo</title>',
+    '<item>',
+    '  <title>Sales Director &amp; Lead</title>',
+    '  <link>https://careers.podimo.com/jobs/7950030-sales-director</link>',
+    '  <pubDate>Mon, 22 Jun 2026 13:45:57 +0200</pubDate>',
+    '  <remoteStatus>hybrid</remoteStatus>',
+    '  <tt:locations><tt:location><tt:city>Oslo</tt:city><tt:country>Norway</tt:country></tt:location></tt:locations>',
+    '</item>',
+    '<item>',
+    '  <title>Remote Engineer</title>',
+    '  <link>https://podimo.teamtailor.com/jobs/123-remote-engineer</link>',
+    '  <remoteStatus>fully</remoteStatus>',
+    '</item>',
+    '</channel></rss>',
+  ].join('\n');
+
+  const jobs = parseTeamtailorFeed(sampleXml, 'Podimo');
+  if (jobs.length === 2) pass('parseTeamtailorFeed extracts 2 jobs from 2-item feed');
+  else fail(`parseTeamtailorFeed returned ${jobs.length} jobs, expected 2`);
+
+  if (jobs[0]?.title === 'Sales Director & Lead' && jobs[0]?.company === 'Podimo' && jobs[0]?.url === 'https://careers.podimo.com/jobs/7950030-sales-director') {
+    pass('parseTeamtailorFeed decodes title entities, sets company, keeps branded-domain link');
+  } else {
+    fail(`row 0 = ${JSON.stringify(jobs[0])}`);
+  }
+
+  if (jobs[0]?.location === 'Oslo, Norway') {
+    pass('parseTeamtailorFeed builds location from tt:city + tt:country');
+  } else {
+    fail(`row 0 location = ${JSON.stringify(jobs[0]?.location)}, expected "Oslo, Norway"`);
+  }
+
+  if (jobs[0]?.postedAt === Date.parse('Mon, 22 Jun 2026 13:45:57 +0200')) {
+    pass('parseTeamtailorFeed parses pubDate → postedAt epoch ms');
+  } else {
+    fail(`row 0 postedAt = ${JSON.stringify(jobs[0]?.postedAt)}`);
+  }
+
+  if (jobs[1]?.location === 'Remote' && jobs[1]?.postedAt === undefined) {
+    pass('parseTeamtailorFeed falls back to "Remote" for fully-remote item with no place/date');
+  } else {
+    fail(`row 1 = ${JSON.stringify(jobs[1])}`);
+  }
+
+  // Robustness
+  if (parseTeamtailorFeed('', 'X').length === 0) pass('empty input → empty result');
+  else fail('empty input should yield empty result');
+
+  if (parseTeamtailorFeed(null, 'X').length === 0) pass('null input → empty result (no crash)');
+  else fail('null input should yield empty result without crashing');
+
+  // A well-formed item with no <link> is skipped, not emitted with a blank URL.
+  const noLink = parseTeamtailorFeed('<item><title>Ghost</title></item>', 'X');
+  if (noLink.length === 0) pass('item without <link> is dropped');
+  else fail(`item without <link> should be dropped, got ${JSON.stringify(noLink)}`);
+
+  // fetch() pins the request to the teamtailor.com host on the happy path.
+  const fetchJobs = await teamtailor.fetch(
+    { name: 'Podimo', careers_url: 'https://podimo.teamtailor.com/jobs' },
+    {
+      transport: 'http',
+      fetchText: async (url) => {
+        if (url !== 'https://podimo.teamtailor.com/jobs.rss') {
+          throw new Error(`fetchText called with unexpected URL: ${url}`);
+        }
+        return sampleXml;
+      },
+      fetchJson: async () => { throw new Error('fetchJson should not be called'); },
+    },
+  );
+  if (fetchJobs.length === 2) pass('teamtailor.fetch() hits /jobs.rss and returns parsed jobs');
+  else fail(`teamtailor.fetch() returned ${fetchJobs.length} jobs, expected 2`);
+
+} catch (e) {
+  fail(`teamtailor provider tests crashed: ${e.message}`);
+}
+
 // ── 12. TRACKER REPORT LINK NORMALIZATION (#760) ────────────────
 
 console.log('\n12. Tracker report-link normalization');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2728,22 +2728,71 @@ try {
   if (noLink.length === 0) pass('item without <link> is dropped');
   else fail(`item without <link> should be dropped, got ${JSON.stringify(noLink)}`);
 
-  // fetch() pins the request to the teamtailor.com host on the happy path.
+  // fetch() pins the request to the teamtailor.com host on the happy path and
+  // must pass redirect:'error' (asserting the SSRF guard, not just the URL).
   const fetchJobs = await teamtailor.fetch(
     { name: 'Podimo', careers_url: 'https://podimo.teamtailor.com/jobs' },
     {
       transport: 'http',
-      fetchText: async (url) => {
+      fetchText: async (url, options) => {
         if (url !== 'https://podimo.teamtailor.com/jobs.rss') {
           throw new Error(`fetchText called with unexpected URL: ${url}`);
+        }
+        if (options?.redirect !== 'error') {
+          throw new Error(`fetchText called without redirect:'error': ${JSON.stringify(options)}`);
         }
         return sampleXml;
       },
       fetchJson: async () => { throw new Error('fetchJson should not be called'); },
     },
   );
-  if (fetchJobs.length === 2) pass('teamtailor.fetch() hits /jobs.rss and returns parsed jobs');
+  if (fetchJobs.length === 2) pass('teamtailor.fetch() hits /jobs.rss with redirect:error and returns parsed jobs');
   else fail(`teamtailor.fetch() returned ${fetchJobs.length} jobs, expected 2`);
+
+  // Branded careers domain: auto-detection must NOT claim it (stays pinned to
+  // *.teamtailor.com), but an explicit `provider: teamtailor` entry may fetch
+  // the same /jobs.rss off the branded host the user configured.
+  if (teamtailor.detect({ name: 'Podimo', careers_url: 'https://careers.podimo.com/jobs' }) === null) {
+    pass('teamtailor.detect() does NOT auto-claim a branded (non-teamtailor.com) host');
+  } else {
+    fail('teamtailor.detect() must not auto-detect branded hosts');
+  }
+
+  const brandedJobs = await teamtailor.fetch(
+    { name: 'Podimo', provider: 'teamtailor', careers_url: 'https://careers.podimo.com/jobs' },
+    {
+      transport: 'http',
+      fetchText: async (url, options) => {
+        if (url !== 'https://careers.podimo.com/jobs.rss') {
+          throw new Error(`fetchText called with unexpected URL: ${url}`);
+        }
+        if (options?.redirect !== 'error') {
+          throw new Error(`fetchText called without redirect:'error': ${JSON.stringify(options)}`);
+        }
+        return sampleXml;
+      },
+      fetchJson: async () => { throw new Error('fetchJson should not be called'); },
+    },
+  );
+  if (brandedJobs.length === 2) pass('explicit provider:teamtailor fetches /jobs.rss off a branded careers host');
+  else fail(`branded-host fetch returned ${brandedJobs.length} jobs, expected 2`);
+
+  // A branded host WITHOUT the explicit provider opt-in must still be refused by fetch().
+  let brandedRefused = false;
+  try {
+    await teamtailor.fetch(
+      { name: 'Podimo', careers_url: 'https://careers.podimo.com/jobs' },
+      {
+        transport: 'http',
+        fetchText: async () => { throw new Error('fetchText should not be reached'); },
+        fetchJson: async () => { throw new Error('fetchJson should not be called'); },
+      },
+    );
+  } catch {
+    brandedRefused = true;
+  }
+  if (brandedRefused) pass('teamtailor.fetch() refuses a branded host without explicit provider:teamtailor');
+  else fail('teamtailor.fetch() should refuse a branded host when not explicitly configured');
 
 } catch (e) {
   fail(`teamtailor provider tests crashed: ${e.message}`);


### PR DESCRIPTION
Closes #1119. Adds a zero-auth Teamtailor provider that reads the public per-tenant /jobs.rss feed, parsed in-process (no XML dep) like nodesk.mjs. Auto-detects <slug>.teamtailor.com; SSRF guard pins the fetch host while leaving branded-domain job links intact. Location from tt: city/country with a Remote fallback. Adds a 15-assertion test block to test-all.mjs and a docs/SUPPORTED_JOB_BOARDS.md row. Verified live against podimo.teamtailor.com (12 jobs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Teamtailor job board, including automatic detection of public career sites and importing jobs from their public RSS feed.
  * Enriched job listings with company, posted date, and location (including clearer handling of fully/temporary remote roles).

* **Bug Fixes**
  * Improved validation and safety when fetching job feeds and extracting job links.
  * More robust parsing, including HTML entity decoding and NaN-safe date handling with sensible fallbacks.

* **Documentation**
  * Updated supported job boards guidance for Teamtailor, including branded domain behavior.

* **Tests**
  * Added a dedicated Teamtailor provider test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->