### PR TITLE
Fix PDF manifest update

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -288,7 +288,12 @@ async function generatePDF() {
     console.log(`🧹 ATS normalization: ${totalReplacements} replacements (${breakdown})`);
   }
 
-  return renderHtmlToPdf(html, outputPath, { format, baseDir: dirname(inputPath) });
+  return renderHtmlToPdf(html, outputPath, {
+    format,
+    baseDir: dirname(inputPath),
+    htmlPath: inputPath,
+    reportNum,
+  });
 }
 
 /**
@@ -350,6 +355,8 @@ export async function inlineLocalFonts(html) {
 export async function renderHtmlToPdf(html, outputPath, opts = {}) {
   const format = opts.format || 'a4';
   const baseDir = opts.baseDir || process.cwd();
+  const htmlPath = opts.htmlPath || '';
+  const reportNum = opts.reportNum || '';
 
   mkdirSync(dirname(outputPath), { recursive: true });
 
@@ -398,8 +405,12 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
     console.log(`📦 Size: ${(pdfBuffer.length / 1024).toFixed(1)} KB`);
 
     try {
-      updatePDFManifest(reportNum, outputPath, inputPath, format);
-      console.log(`🔗 Manifest: data/pdf-index.tsv updated${reportNum ? ` (report ${reportNum})` : ' (no --report given)'}`);
+      if (!htmlPath) {
+        console.warn('⚠️  Manifest update skipped: no source HTML path provided');
+      } else {
+        updatePDFManifest(reportNum, outputPath, htmlPath, format);
+        console.log(`🔗 Manifest: data/pdf-index.tsv updated${reportNum ? ` (report ${reportNum})` : ' (no --report given)'}`);
+      }
     } catch (err) {
       // The PDF itself succeeded — never fail the run over manifest bookkeeping.
       console.error(`⚠️  Manifest update failed: ${err.message}`);


### PR DESCRIPTION
Fixes PDF manifest updates after PDF generation.

renderHtmlToPdf() was referencing reportNum and inputPath from outside its scope, so PDF creation could succeed while manifest bookkeeping failed. This passes the source HTML path and report number through options and skips manifest updates when direct callers do not provide a source HTML path.

Verified with:
- node --check generate-pdf.mjs
- Docker PDF generation
- Docker doctor/liveness checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PDF generation now skips manifest updates when no source path is provided, preventing unexpected failures.
  * Added a warning when manifest tracking is skipped, while keeping PDF creation resilient if manifest handling errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->