### PR TITLE
chore(security): replace demo password placeholders in example docs

### DIFF
--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -56,7 +56,7 @@ narrative:
   # Optional: dashboard/demo URL with credentials
   # dashboard:
   #   url: "https://janesmith.dev/demo"
-  #   password: "demo-2026"
+  #   password: "YOUR_DEMO_PASSWORD"
 
 compensation:
   target_range: "$150K-200K"     # Your target total comp

--- a/examples/dual-track-engineer-instructor/profile.yml
+++ b/examples/dual-track-engineer-instructor/profile.yml
@@ -86,7 +86,7 @@ narrative:
   # Optional dashboard / live demo
   # dashboard:
   #   url: "https://sam-rivera.example.dev/demo"
-  #   password: "demo-2026"
+  #   password: "YOUR_DEMO_PASSWORD"
 
 compensation:
   # Default range = engineering range (typically higher).

--- a/modes/_profile.template.md
+++ b/modes/_profile.template.md
@@ -62,7 +62,7 @@ Frame profile as **"Technical builder with real-world proof"** that adapts frami
 
 <!-- If you have a live demo, dashboard, or public project:
      url: https://yoursite.dev/demo
-     password: demo-2026
+     password: YOUR_DEMO_PASSWORD
      when_to_share: "LLMOps, AI Platform roles" -->
 
 If you have a live demo/dashboard (check profile.yml), offer access in applications for relevant roles.

--- a/modes/da/_shared.md
+++ b/modes/da/_shared.md
@@ -89,7 +89,7 @@ Positionér "Builder" som et professionelt signal -- ikke som "hobbyist". De æg
      Eksempel:
      dashboard:
        url: "https://ditdomæne.dev/demo"
-       password: "demo-2026"
+       password: "YOUR_DEMO_PASSWORD"
        when_to_share: "LLMOps, AI Platform, Observability-roller"
      Læses fra config/profile.yml -> narrative.proof_points og narrative.dashboard -->
 

--- a/modes/de/_shared.md
+++ b/modes/de/_shared.md
@@ -89,7 +89,7 @@ Profil framen als **"Technischer Builder mit nachweisbarer Praxis"**, der das Fr
      Beispiel:
      dashboard:
        url: "https://deinedomain.dev/demo"
-       password: "demo-2026"
+       password: "YOUR_DEMO_PASSWORD"
        when_to_share: "LLMOps, AI-Platform, Observability-Rollen"
      Wird gelesen aus config/profile.yml → narrative.proof_points und narrative.dashboard -->
 

--- a/modes/es/_shared.md
+++ b/modes/es/_shared.md
@@ -89,7 +89,7 @@ Posicionar "Builder" como señal profesional — no como "artesano improvisado".
      Ejemplo:
      dashboard:
        url: "https://tudominio.dev/demo"
-       password: "demo-2026"
+       password: "YOUR_DEMO_PASSWORD"
        when_to_share: "Roles LLMOps, AI Platform, Observability"
      Leído desde config/profile.yml -> narrative.proof_points y narrative.dashboard -->
 

--- a/modes/fr/_shared.md
+++ b/modes/fr/_shared.md
@@ -89,7 +89,7 @@ Positionner "Builder" comme signal professionnel -- pas comme "bricoleur". Les p
      Exemple :
      dashboard:
        url: "https://tondomaine.dev/demo"
-       password: "demo-2026"
+       password: "YOUR_DEMO_PASSWORD"
        when_to_share: "Roles LLMOps, AI Platform, Observability"
      Lu depuis config/profile.yml -> narrative.proof_points et narrative.dashboard -->
 

--- a/modes/it/_shared.md
+++ b/modes/it/_shared.md
@@ -89,7 +89,7 @@ Posizionare "Builder" come segnale professionale -- non come hobby. I proof poin
      Esempio:
      dashboard:
        url: "https://tuodominio.dev/demo"
-       password: "demo-2026"
+       password: "YOUR_DEMO_PASSWORD"
        when_to_share: "Ruoli LLMOps, AI Platform, Observability"
      Letto da config/profile.yml -> narrative.proof_points e narrative.dashboard -->
 

--- a/modes/pl/_shared.md
+++ b/modes/pl/_shared.md
@@ -89,7 +89,7 @@ Pozycjonuj "Builder" jako sygnał profesjonalny -- a nie jako "majsterkowicza". 
      Przykład:
      dashboard:
        url: "https://twojadomena.dev/demo"
-       password: "demo-2026"
+       password: "YOUR_DEMO_PASSWORD"
        when_to_share: "Role LLMOps, AI Platform, Observability"
      Czytane z config/profile.yml -> narrative.proof_points i narrative.dashboard -->
 

--- a/modes/pt/_shared.md
+++ b/modes/pt/_shared.md
@@ -107,7 +107,7 @@ Posicionar "Builder" como sinal profissional — não como "hobbyista". Proof po
      Exemplo:
      dashboard:
        url: "https://seudominio.dev/demo"
-       password: "demo-2026"
+       password: "YOUR_DEMO_PASSWORD"
        when_to_share: "LLMOps, AI-Platform, vagas de Observability"
      Lido de config/profile.yml -> narrative.proof_points e narrative.dashboard -->
 


### PR DESCRIPTION
## Summary

Replaces literal `demo-2026` password strings in example docs and mode templates with a neutral `YOUR_DEMO_PASSWORD` placeholder.

These values are documentation examples only, but literal demo passwords can:
- Trigger secret scanners and pre-commit hooks (false positives)
- Be mistaken for real credentials when copied into profiles

## Files changed

- `config/profile.example.yml`
- `examples/dual-track-engineer-instructor/profile.yml`
- `modes/_profile.template.md`
- `modes/da/_shared.md`, `modes/de/_shared.md`, `modes/es/_shared.md`, `modes/fr/_shared.md`, `modes/it/_shared.md`, `modes/pl/_shared.md`, `modes/pt/_shared.md`

## Test plan

- [x] Docs-only change; no runtime behavior affected
- [x] Verified placeholders remain clearly instructional


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example profile and dashboard setup snippets across multiple locales to use a generic password placeholder instead of a fixed demo value.
  * Makes sample configurations safer to copy and easier to customize for your own setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->