### PR TITLE
fix(web): prevent closed stream controller TypeError in cv/ingest API

### DIFF
--- a/web/src/app/api/cv/ingest/route.ts
+++ b/web/src/app/api/cv/ingest/route.ts
@@ -126,9 +126,11 @@ export async function POST(req: Request) {
   }
 
   const encoder = new TextEncoder();
+  let closed = false;
+  let safeClose = () => {};
+
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
-      let closed = false;
       let buf = "";
       let emitted = false;
       const killer = setTimeout(() => {
@@ -138,7 +140,7 @@ export async function POST(req: Request) {
           /* ignore */
         }
       }, 240_000);
-      const safeClose = () => {
+      safeClose = () => {
         if (!closed) {
           closed = true;
           clearTimeout(killer);
@@ -199,7 +201,7 @@ export async function POST(req: Request) {
       } catch {
         /* ignore */
       }
-      if (tempFile) cleanupTemp(tempFile);
+      safeClose();
     },
   });
 


### PR DESCRIPTION
## What does this PR do?

This PR implements a streaming lifecycle race condition fix in `web/src/app/api/cv/ingest/route.ts` where the server attempts to enqueue data to a closed connection when a CV ingest command yields no output or is cancelled by the client.

- Moved `closed` and `safeClose` declaration outside the `ReadableStream` start block.
- Implemented `safeClose()` logic within the stream's `cancel` callback hook.
- This ensures that if the client cancels the stream connection, the `closed` flag is set to `true`, preventing subsequent child process handlers from writing to the closed controller.

## Related issue

Fixes #1155

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)