### PR TITLE
fix(web): support multi-delimiter split on paste and drop stray tokens

### DIFF
--- a/web/src/components/explore/filter-builder.tsx
+++ b/web/src/components/explore/filter-builder.tsx
@@ -36,8 +36,23 @@ function KeywordField({
   onChange: (v: string[]) => void;
 }) {
   const [draft, setDraft] = useState("");
-  const commit = (text: string) => {
-    const parts = text.split(",");
+  const commit = (text: string, isPaste = false) => {
+    let parts: string[] = [];
+    if (isPaste) {
+      const hasStrictDelimiters = /[,;\n\r\t]/.test(text);
+      if (hasStrictDelimiters) {
+        parts = text.split(/[,;\n\r\t]+/);
+      } else {
+        const words = text.trim().split(/\s+/);
+        if (words.length > 3) {
+          parts = words;
+        } else {
+          parts = [text];
+        }
+      }
+    } else {
+      parts = text.split(/[,;\n\r\t]+/);
+    }
     const next = cleanChips([...values, ...parts]);
     onChange(next);
     setDraft("");
@@ -57,7 +72,7 @@ function KeywordField({
         value={draft}
         onChange={(e) => {
           const val = e.target.value;
-          if (val.endsWith(",")) commit(val);
+          if (val.endsWith(",") || val.endsWith(";")) commit(val);
           else setDraft(val);
         }}
         onKeyDown={(e) => {
@@ -70,10 +85,8 @@ function KeywordField({
         }}
         onPaste={(e) => {
           const text = e.clipboardData.getData("text");
-          if (text.includes(",")) {
-            e.preventDefault();
-            commit(draft + text);
-          }
+          e.preventDefault();
+          commit(draft + text, true);
         }}
         onBlur={() => draft.trim() && commit(draft)}
         placeholder={values.length ? "" : placeholder}

--- a/web/src/lib/explore.ts
+++ b/web/src/lib/explore.ts
@@ -89,6 +89,7 @@ export function cleanChips(v: unknown): string[] {
     if (typeof item !== "string") continue;
     const k = item.trim();
     if (!k) continue;
+    if (!/[\p{L}\p{N}]/u.test(k)) continue;
     const key = k.toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);


### PR DESCRIPTION
## What does this PR do?

This PR updates the keyword chip creation logic to allow splitting pasted location/exclude filters on multiple delimiters (commas, semicolons, tabs, newlines, and spaces if pasting a multi-word list), while dropping non-alphanumeric stray tokens like `*`.

- Updated `KeywordField`'s `commit` inside `web/src/components/explore/filter-builder.tsx` to handle smart splitting on paste:
  - Splits on commas, semicolons, newlines, and tabs.
  - If no strict delimiters are present, splits on spaces only if the pasted text contains more than 3 words (to keep multi-word terms like `"New York City"` intact).
- Changed `onPaste` handler to intercept the paste event and pass it to the updated `commit` logic.
- Updated `cleanChips` in `web/src/lib/explore.ts` to filter out non-alphanumeric chips (like `*` or empty inputs) using the Unicode property escape check: `/[\p{L}\p{N}]/u`.

## Related issue

Fixes #1147

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)