### PR TITLE
feat(registry): add career-ops-plugin-linkedin-alerts v0.1.0

### DIFF
--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -29,6 +29,20 @@
       "allowedHosts": ["oauth2.googleapis.com", "www.googleapis.com"],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1346",
       "addedAt": "2026-06-29"
+    },
+    {
+      "id": "linkedin-alerts",
+      "name": "career-ops-plugin-linkedin-alerts",
+      "version": "0.1.0",
+      "license": "MIT",
+      "description": "LinkedIn job alert ingest — parse LinkedIn alert emails from your Gmail inbox, normalize tracking links to canonical job URLs, and surface them in the career-ops pipeline.",
+      "repo": "https://github.com/Schlaflied/career-ops-plugin-linkedin-alerts",
+      "sha": "de54949b7dc642a6f6106a0ce18f0031e46f61ee",
+      "hooks": ["ingest"],
+      "requiredEnv": ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "GMAIL_REFRESH_TOKEN"],
+      "allowedHosts": ["oauth2.googleapis.com", "gmail.googleapis.com"],
+      "registrationIssue": "https://github.com/santifer/career-ops/issues/1394",
+      "addedAt": "2026-07-01"
     }
   ]
 }


### PR DESCRIPTION
## Registry addition

Adds `career-ops-plugin-linkedin-alerts` v0.1.0 to the plugin registry.

- **Registration issue:** #1394
- **Repo:** https://github.com/Schlaflied/career-ops-plugin-linkedin-alerts
- **Pinned SHA:** `de54949b7dc642a6f6106a0ce18f0031e46f61ee`
- **Hook:** `ingest` — parses LinkedIn job alert emails from the user's own Gmail inbox (read-only scope), normalizes tracking links to canonical `linkedin.com/jobs/view/{id}` URLs, returns `Job[]`
- **Hosts:** `oauth2.googleapis.com`, `gmail.googleapis.com` only — never touches LinkedIn's servers
- **Relation to bundled `plugins/gmail` seed:** complementary specialist, not a successor — sender-based query (no label setup), LinkedIn URL canonicalization + dedup, LinkedIn subject-format parsing. Can share `GMAIL_*` credentials with the seed.
- Closes the ingest half of #660
- `humanInTheLoop: true`, MIT, 15/15 smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new bundled plugin for LinkedIn alert ingestion, including support for Gmail-based alert processing and related external service access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->