### PR TITLE
feat(registry): add career-ops-plugin-outlook-interviews v0.1.0

### DIFF
--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -83,6 +83,9 @@
         "MSGRAPH_CLIENT_ID",
         "MSGRAPH_REFRESH_TOKEN"
       ],
+      "optionalEnv": [
+        "MSGRAPH_CLIENT_SECRET"
+      ],
       "allowedHosts": [
         "login.microsoftonline.com",
         "graph.microsoft.com"

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -29,6 +29,20 @@
       "allowedHosts": ["oauth2.googleapis.com", "www.googleapis.com"],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1346",
       "addedAt": "2026-06-29"
+    },
+    {
+      "id": "linkedin-alerts",
+      "name": "career-ops-plugin-linkedin-alerts",
+      "version": "0.1.0",
+      "license": "MIT",
+      "description": "LinkedIn job alert ingest — parse LinkedIn alert emails from your Gmail inbox, normalize tracking links to canonical job URLs, and surface them in the career-ops pipeline.",
+      "repo": "https://github.com/Schlaflied/career-ops-plugin-linkedin-alerts",
+      "sha": "de54949b7dc642a6f6106a0ce18f0031e46f61ee",
+      "hooks": ["ingest"],
+      "requiredEnv": ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "GMAIL_REFRESH_TOKEN"],
+      "allowedHosts": ["oauth2.googleapis.com", "gmail.googleapis.com"],
+      "registrationIssue": "https://github.com/santifer/career-ops/issues/1394",
+      "addedAt": "2026-07-01"
     }
   ]
 }

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -10,9 +10,15 @@
       "description": "Tavily search/extract for job scanning, liveness checks, and company research.",
       "repo": "https://github.com/Schlaflied/career-ops-plugin-tavily",
       "sha": "79cc4bcab0f746ca27ee8ce5a01d53e709946eac",
-      "hooks": ["search"],
-      "requiredEnv": ["TAVILY_API_KEY"],
-      "allowedHosts": ["api.tavily.com"],
+      "hooks": [
+        "search"
+      ],
+      "requiredEnv": [
+        "TAVILY_API_KEY"
+      ],
+      "allowedHosts": [
+        "api.tavily.com"
+      ],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1344",
       "addedAt": "2026-06-29"
     },
@@ -24,9 +30,18 @@
       "description": "Google Calendar ingest — detect upcoming interview events and surface them in the career-ops pipeline.",
       "repo": "https://github.com/Schlaflied/career-ops-plugin-google-calendar",
       "sha": "d4b8cf40f5090b58510affbad9379570a23b34d2",
-      "hooks": ["ingest"],
-      "requiredEnv": ["GOOGLE_CALENDAR_CLIENT_ID", "GOOGLE_CALENDAR_CLIENT_SECRET", "GOOGLE_CALENDAR_REFRESH_TOKEN"],
-      "allowedHosts": ["oauth2.googleapis.com", "www.googleapis.com"],
+      "hooks": [
+        "ingest"
+      ],
+      "requiredEnv": [
+        "GOOGLE_CALENDAR_CLIENT_ID",
+        "GOOGLE_CALENDAR_CLIENT_SECRET",
+        "GOOGLE_CALENDAR_REFRESH_TOKEN"
+      ],
+      "allowedHosts": [
+        "oauth2.googleapis.com",
+        "www.googleapis.com"
+      ],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1346",
       "addedAt": "2026-06-29"
     },
@@ -38,23 +53,40 @@
       "description": "LinkedIn job alert ingest — parse LinkedIn alert emails from your Gmail inbox, normalize tracking links to canonical job URLs, and surface them in the career-ops pipeline.",
       "repo": "https://github.com/Schlaflied/career-ops-plugin-linkedin-alerts",
       "sha": "de54949b7dc642a6f6106a0ce18f0031e46f61ee",
-      "hooks": ["ingest"],
-      "requiredEnv": ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "GMAIL_REFRESH_TOKEN"],
-      "allowedHosts": ["oauth2.googleapis.com", "gmail.googleapis.com"],
+      "hooks": [
+        "ingest"
+      ],
+      "requiredEnv": [
+        "GMAIL_CLIENT_ID",
+        "GMAIL_CLIENT_SECRET",
+        "GMAIL_REFRESH_TOKEN"
+      ],
+      "allowedHosts": [
+        "oauth2.googleapis.com",
+        "gmail.googleapis.com"
+      ],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1394",
       "addedAt": "2026-07-01"
     },
     {
       "id": "outlook-interviews",
       "name": "career-ops-plugin-outlook-interviews",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "description": "Outlook interview ingest — detect interview invitation emails via Microsoft Graph, extract company / role / meeting link, and surface them in the career-ops pipeline.",
       "repo": "https://github.com/Schlaflied/career-ops-plugin-outlook-interviews",
-      "sha": "07fcd1352a0a4bb8be72322b7bf33acc09696920",
-      "hooks": ["ingest"],
-      "requiredEnv": ["MSGRAPH_CLIENT_ID", "MSGRAPH_REFRESH_TOKEN"],
-      "allowedHosts": ["login.microsoftonline.com", "graph.microsoft.com"],
+      "sha": "ac70c743a28733eeb9602b3f620689e4d01bc26c",
+      "hooks": [
+        "ingest"
+      ],
+      "requiredEnv": [
+        "MSGRAPH_CLIENT_ID",
+        "MSGRAPH_REFRESH_TOKEN"
+      ],
+      "allowedHosts": [
+        "login.microsoftonline.com",
+        "graph.microsoft.com"
+      ],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1396",
       "addedAt": "2026-07-01"
     }

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -43,6 +43,20 @@
       "allowedHosts": ["oauth2.googleapis.com", "gmail.googleapis.com"],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1394",
       "addedAt": "2026-07-01"
+    },
+    {
+      "id": "outlook-interviews",
+      "name": "career-ops-plugin-outlook-interviews",
+      "version": "0.1.0",
+      "license": "MIT",
+      "description": "Outlook interview ingest — detect interview invitation emails via Microsoft Graph, extract company / role / meeting link, and surface them in the career-ops pipeline.",
+      "repo": "https://github.com/Schlaflied/career-ops-plugin-outlook-interviews",
+      "sha": "07fcd1352a0a4bb8be72322b7bf33acc09696920",
+      "hooks": ["ingest"],
+      "requiredEnv": ["MSGRAPH_CLIENT_ID", "MSGRAPH_REFRESH_TOKEN"],
+      "allowedHosts": ["login.microsoftonline.com", "graph.microsoft.com"],
+      "registrationIssue": "https://github.com/santifer/career-ops/issues/1396",
+      "addedAt": "2026-07-01"
     }
   ]
 }


### PR DESCRIPTION
## Registry addition

Adds `career-ops-plugin-outlook-interviews` v0.1.0 to the plugin registry.

> **Stacked on #1395** — this branch includes the linkedin-alerts entry from that PR to avoid a registry-array merge conflict. Once #1395 merges, this PR's diff shrinks to just the outlook-interviews entry. Merge #1395 first.

- **Registration issue:** #1396
- **Repo:** https://github.com/Schlaflied/career-ops-plugin-outlook-interviews
- **Pinned SHA:** `07fcd1352a0a4bb8be72322b7bf33acc09696920`
- **Hook:** `ingest` — detects interview invitation emails in the user's own Outlook mailbox via Microsoft Graph (read-only `Mail.Read`), extracts company / role / meeting link (Teams/Zoom/Meet/Whereby), returns `Job[]`
- **Hosts:** `login.microsoftonline.com`, `graph.microsoft.com` only
- Works with personal outlook.com accounts and enterprise Azure AD tenants (public or confidential app registration)
- Completes the mailbox trio: google-calendar (#1346) + linkedin-alerts (#1394) + outlook-interviews
- Closes the Outlook-mail half of #664
- `humanInTheLoop: true`, MIT, 16/16 smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new plugins to the available plugins list: one for LinkedIn alerts and one for Outlook interviews.
  * Each plugin is now selectable with the proper sign-in and access configuration, including the required OAuth settings and supported service access rules.  
* **Chores**
  * Reformatted existing plugin configuration entries for improved readability (no functional change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->