### PR TITLE
feat(registry): add career-ops-plugin-obsidian v0.1.0

### DIFF
--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -47,11 +47,11 @@
     {
       "id": "outlook-interviews",
       "name": "career-ops-plugin-outlook-interviews",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "description": "Outlook interview ingest — detect interview invitation emails via Microsoft Graph, extract company / role / meeting link, and surface them in the career-ops pipeline.",
       "repo": "https://github.com/Schlaflied/career-ops-plugin-outlook-interviews",
-      "sha": "07fcd1352a0a4bb8be72322b7bf33acc09696920",
+      "sha": "ac70c743a28733eeb9602b3f620689e4d01bc26c",
       "hooks": ["ingest"],
       "requiredEnv": ["MSGRAPH_CLIENT_ID", "MSGRAPH_REFRESH_TOKEN"],
       "allowedHosts": ["login.microsoftonline.com", "graph.microsoft.com"],

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -29,6 +29,20 @@
       "allowedHosts": ["oauth2.googleapis.com", "www.googleapis.com"],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1346",
       "addedAt": "2026-06-29"
+    },
+    {
+      "id": "linkedin-alerts",
+      "name": "career-ops-plugin-linkedin-alerts",
+      "version": "0.1.0",
+      "license": "MIT",
+      "description": "LinkedIn job alert ingest — parse LinkedIn alert emails from your Gmail inbox, normalize tracking links to canonical job URLs, and surface them in the career-ops pipeline.",
+      "repo": "https://github.com/Schlaflied/career-ops-plugin-linkedin-alerts",
+      "sha": "de54949b7dc642a6f6106a0ce18f0031e46f61ee",
+      "hooks": ["ingest"],
+      "requiredEnv": ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "GMAIL_REFRESH_TOKEN"],
+      "allowedHosts": ["oauth2.googleapis.com", "gmail.googleapis.com"],
+      "registrationIssue": "https://github.com/santifer/career-ops/issues/1394",
+      "addedAt": "2026-07-01"
     }
   ]
 }

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -54,6 +54,7 @@
       "sha": "ac70c743a28733eeb9602b3f620689e4d01bc26c",
       "hooks": ["ingest"],
       "requiredEnv": ["MSGRAPH_CLIENT_ID", "MSGRAPH_REFRESH_TOKEN"],
+      "optionalEnv": ["MSGRAPH_CLIENT_SECRET"],
       "allowedHosts": ["login.microsoftonline.com", "graph.microsoft.com"],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1396",
       "addedAt": "2026-07-01"

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -57,6 +57,20 @@
       "allowedHosts": ["login.microsoftonline.com", "graph.microsoft.com"],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1396",
       "addedAt": "2026-07-01"
+    },
+    {
+      "id": "obsidian",
+      "name": "career-ops-plugin-obsidian",
+      "version": "0.1.0",
+      "license": "MIT",
+      "description": "Obsidian export — mirror the tracker into your vault as frontmatter notes queryable by Dataview/Bases; frontmatter belongs to the machine, the note body belongs to you.",
+      "repo": "https://github.com/Schlaflied/career-ops-plugin-obsidian",
+      "sha": "bda96c17579bd850034d183829cf2369a779072c",
+      "hooks": ["export"],
+      "requiredEnv": [],
+      "allowedHosts": [],
+      "registrationIssue": "https://github.com/santifer/career-ops/issues/1398",
+      "addedAt": "2026-07-01"
     }
   ]
 }

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -43,6 +43,20 @@
       "allowedHosts": ["oauth2.googleapis.com", "gmail.googleapis.com"],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1394",
       "addedAt": "2026-07-01"
+    },
+    {
+      "id": "outlook-interviews",
+      "name": "career-ops-plugin-outlook-interviews",
+      "version": "0.1.0",
+      "license": "MIT",
+      "description": "Outlook interview ingest — detect interview invitation emails via Microsoft Graph, extract company / role / meeting link, and surface them in the career-ops pipeline.",
+      "repo": "https://github.com/Schlaflied/career-ops-plugin-outlook-interviews",
+      "sha": "07fcd1352a0a4bb8be72322b7bf33acc09696920",
+      "hooks": ["ingest"],
+      "requiredEnv": ["MSGRAPH_CLIENT_ID", "MSGRAPH_REFRESH_TOKEN"],
+      "allowedHosts": ["login.microsoftonline.com", "graph.microsoft.com"],
+      "registrationIssue": "https://github.com/santifer/career-ops/issues/1396",
+      "addedAt": "2026-07-01"
     }
   ]
 }


### PR DESCRIPTION
## Registry addition

Adds `career-ops-plugin-obsidian` v0.1.0 to the plugin registry.

> **Stacked on #1397** (which stacks on #1395) — includes both pending entries to avoid registry-array merge conflicts. Merge order: #1395 → #1397 → this. Each PR's diff shrinks to its own entry as the previous one merges.

- **Registration issue:** #1398
- **Repo:** https://github.com/Schlaflied/career-ops-plugin-obsidian
- **Pinned SHA:** `bda96c17579bd850034d183829cf2369a779072c`
- **Hook:** `export` — consumes the engine's read-only tracker snapshot, writes one frontmatter note per application into the user's Obsidian vault (Dataview/Bases-queryable), plus an optional MOC index
- **Hosts:** none — **zero network**, empty `allowedHosts`, no env keys; writes only inside the user-configured `vaultPath`
- Contract: frontmatter belongs to the machine, note body belongs to the human — re-exports never touch user-written content
- Active-pipeline filter by default; `dryRun` supported; idempotent upsert
- `humanInTheLoop: true`, MIT, 25/25 smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new curated plugins to the available plugin catalog: LinkedIn alerts, Outlook interviews, and Obsidian.
  * Expanded the set of integrations users can discover and install, including updated environment and host requirements for each plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->