### PR TITLE
feat(providers): add JibeApply provider

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -17,6 +17,7 @@ are shared helpers and are not loaded as providers.
 | Greenhouse | API | Handles explicit `api:` URLs and auto-detects public Greenhouse board URLs for the boards API. |
 | HigherEdJobs | RSS | Reads the public `https://www.higheredjobs.com/rss/categoryFeed.cfm?catID={catID}` feed and parses it in-process. Configure with `provider: higheredjobs` and optional `cat_id` (default 68 = Higher Education). Not auto-detected — requires explicit `provider:` config. |
 | IBM Careers | API | Posts to IBM's public careers search API and supports optional IBM facet filters in the portal entry. |
+| JibeApply | API | Auto-detects `https://<slug>.jibeapply.com/jobs` careers URLs (rewriting `/jobs` to the public `/api/jobs` endpoint); paginates `?page=N` up to `max_pages` (default 50), warning if a tenant's postings exceed the cap. Also supports branded/iCIMS-hosted sites at their own `/jobs` path via an explicit `provider: jibeapply` + `api:` URL. |
 | Jobstreet / SEEK | API | Uses the public SEEK chalice-search JSON API for Jobstreet and SEEK sites. Configure explicitly with `provider: jobstreet`. |
 | Landing.jobs | API | Reads the board-wide `https://landing.jobs/api/v1/jobs` JSON feed (tech, Europe). Configure with `provider: landingjobs`; company is derived from the posting URL slug. |
 | Lever | API | Auto-detects `https://jobs.lever.co/<slug>` boards and uses Lever's public postings endpoint. |

--- a/providers/jibeapply.mjs
+++ b/providers/jibeapply.mjs
@@ -1,0 +1,142 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// JibeApply provider — hits the /api/jobs endpoint on the same hostname.
+// Auto-detects from careers_url pattern `https://<slug>.jibeapply.com`.
+// iCIMS acquired Jibe in 2019; some tenants run it on a branded custom
+// domain instead. The JSON API at /api/jobs is stable across all tenants.
+
+// Safety cap on pagination — applied regardless of what the upstream reports
+// as totalCount, so a misbehaving/compromised API can't drive this into
+// fetching thousands of pages. Every known real tenant (10/page) stays well
+// under the default of 50 pages (500 jobs); override with `max_pages` on the
+// portal entry for a tenant that genuinely exceeds it — each page is a
+// sequential round-trip, so raising the default for everyone isn't free.
+const DEFAULT_MAX_PAGES = 50;
+const MAX_PAGES_CAP = 500;
+
+// Fallback page size when a response carries no jobs and no usable `count`
+// (e.g. an empty first page). Confirmed live against real tenants — JibeApply
+// reports this as `filter.displayLimit` and it has been 10 on every tenant
+// observed so far.
+const DEFAULT_PAGE_SIZE = 10;
+
+/** Resolve the page cap: a positive integer `max_pages` on the entry, capped. */
+function resolveMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES_CAP);
+  return DEFAULT_MAX_PAGES;
+}
+
+function toApiUrl(rawUrl) {
+  let u;
+  try { u = new URL(rawUrl); } catch { return null; }
+  if (u.protocol !== 'https:') return null;
+  if (!/^[a-z0-9-]+\.jibeapply\.com$/i.test(u.hostname)) return null;
+  if (!u.pathname.startsWith('/api/')) {
+    u.pathname = '/api' + (u.pathname.startsWith('/') ? u.pathname : '/' + u.pathname);
+  }
+  return u.href;
+}
+
+// Validate an explicit entry.api URL (any HTTPS hostname — used for iCIMS-hosted,
+// branded JibeApply sites that share the same JSON schema).
+function validateExplicitApi(apiUrl) {
+  let u;
+  try { u = new URL(apiUrl); } catch { return null; }
+  return u.protocol === 'https:' ? u.href : null;
+}
+
+export function parseJibeapplyResponse(json, entry) {
+  let origin = '';
+  try { origin = new URL(entry.careers_url || '').origin; } catch { /* ignore */ }
+  // careers_url isn't required to be a well-formed absolute URL for fetch()
+  // to succeed (an explicit entry.api bypasses it entirely — see toApiUrl
+  // callers below) — fall back to api's origin so job URLs stay absolute
+  // instead of silently degrading to a relative "/jobs/<slug>" path.
+  if (!origin) {
+    try { origin = new URL(entry.api || '').origin; } catch { /* ignore */ }
+  }
+  const items = Array.isArray(json?.jobs) ? json.jobs : [];
+  return items
+    .map(item => {
+      if (item == null) return null;
+      const d = item.data ?? item;
+      const title = String(d.title || '').trim();
+      const slug = d.slug || d.req_id;
+      if (!title || !slug) return null;
+      return {
+        title,
+        url: `${origin}/jobs/${encodeURIComponent(slug)}`,
+        company: String(d.hiring_organization || entry.name || '').trim(),
+        location: d.full_location || [d.city, d.country].filter(Boolean).join(', '),
+      };
+    })
+    .filter(Boolean);
+}
+
+/** @type {Provider} */
+export default {
+  id: 'jibeapply',
+
+  detect(entry) {
+    const url = entry.careers_url;
+    if (typeof url !== 'string') return null;
+    const apiUrl = toApiUrl(url);
+    if (!apiUrl) return null;
+    return { url: apiUrl };
+  },
+
+  async fetch(entry, ctx) {
+    const url = entry.careers_url;
+    if (typeof url !== 'string' || !url) throw new Error('jibeapply: careers_url required');
+
+    // Prefer an explicit entry.api (allows iCIMS-hosted, branded JibeApply sites
+    // that share the same JSON schema but aren't on jibeapply.com).
+    const apiUrl = (typeof entry.api === 'string' && validateExplicitApi(entry.api))
+      || toApiUrl(url);
+    if (!apiUrl) throw new Error(`jibeapply: cannot derive API URL for ${entry.name}`);
+    const first = await ctx.fetchJson(apiUrl, { redirect: 'error' });
+    const total = first.totalCount ?? 0;
+    // Use the actual number of items returned as page size — some implementations
+    // set `count` to the total rather than the per-page count.
+    const pageSize = first.jobs?.length || first.count || DEFAULT_PAGE_SIZE;
+    const allJobs = [...(first.jobs ?? [])];
+
+    if (total > pageSize && pageSize > 0) {
+      const maxPages = resolveMaxPages(entry);
+      const pages = Math.min(Math.ceil(total / pageSize), maxPages);
+      // Sequential, not concurrent (mirrors providers/4dayweek.mjs, thehub.mjs,
+      // arbeitnow.mjs, workday.mjs) — a single tenant's API has no reason to
+      // receive a burst of parallel requests, and a mid-run failure stops
+      // cleanly with whatever pages were already gathered instead of
+      // discarding them (Promise.all would fail the whole batch on one error).
+      for (let page = 2; page <= pages; page++) {
+        const u2 = new URL(apiUrl);
+        u2.searchParams.set('page', String(page));
+        let json;
+        try {
+          json = await ctx.fetchJson(u2.toString(), { redirect: 'error' });
+        } catch (err) {
+          console.error(`⚠️  jibeapply: ${entry.name} page ${page} fetch failed — ${err.message} (returning ${allJobs.length} jobs fetched so far)`);
+          break;
+        }
+        allJobs.push(...(json.jobs ?? []));
+      }
+
+      // The cap is silent by design (it's a safety net, not a working limit),
+      // but a tenant that actually exceeds it needs to be surfaced —
+      // otherwise the user has no way to notice postings are missing from
+      // their scan.
+      if (Math.ceil(total / pageSize) > maxPages) {
+        console.error(
+          `⚠️  jibeapply: ${entry.name} has more postings than max_pages allows ` +
+          `(fetched ${allJobs.length} of ${total}) — ` +
+          `set max_pages on this portal entry to raise the cap (current: ${maxPages})`,
+        );
+      }
+    }
+
+    return parseJibeapplyResponse({ jobs: allJobs }, entry);
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -491,6 +491,7 @@ search_queries:
 #   personio        <slug>.jobs.personio.(de|com)
 #   pinpoint        <slug>.pinpointhq.com
 #   rippling        ats.rippling.com/<slug>/jobs
+#   jibeapply       <slug>.jibeapply.com/jobs  (or provider: jibeapply + api: for a branded host's own /jobs path)
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
@@ -523,6 +524,13 @@ search_queries:
 #
 # - name: Example Rippling Co
 #   careers_url: https://ats.rippling.com/exampleco/jobs  # any ats.rippling.com/<slug>
+#   enabled: true
+#
+# - name: Example JibeApply Co
+#   careers_url: https://exampleco.jibeapply.com/jobs     # any *.jibeapply.com/jobs host
+#   max_pages: 50          # optional page cap (10 jobs/page, default 50, max 500) —
+#                          # raise it for a tenant with 500+ open postings (a warning
+#                          # is logged if the cap truncates real results)
 #   enabled: true
 #
 # - name: SolidJobs — Engineering
@@ -627,6 +635,17 @@ search_queries:
 #
 #   - name: Example GmbH
 #     careers_url: https://example-gmbh.jobs.personio.de
+#     enabled: true
+#
+# Some JibeApply sites run on a branded custom domain rather than
+# *.jibeapply.com (iCIMS acquired Jibe in 2019, and tenants can front the
+# same API on their own domain). Set provider: jibeapply and point api: at
+# the branded host's /api/jobs endpoint — e.g.:
+#
+#   - name: Booking.com
+#     careers_url: https://jobs.booking.com/booking/jobs
+#     api: https://jobs.booking.com/api/jobs
+#     provider: jibeapply
 #     enabled: true
 
 tracked_companies:

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8992,6 +8992,313 @@ try {
   fail(`higheredjobs provider tests crashed: ${e.message}`);
 }
 
+// ── 51. PROVIDERS — JibeApply ────────────────────────────────────
+
+console.log('\n51. Provider — jibeapply');
+
+try {
+  const jibeapply = (await import(pathToFileURL(join(ROOT, 'providers/jibeapply.mjs')).href)).default;
+  const { parseJibeapplyResponse } = await import(pathToFileURL(join(ROOT, 'providers/jibeapply.mjs')).href);
+
+  if (jibeapply.id === 'jibeapply') pass('jibeapply.id is "jibeapply"');
+  else fail(`jibeapply.id is ${JSON.stringify(jibeapply.id)}`);
+
+  // detect() — /jobs path → /api/jobs
+  const hit = jibeapply.detect({ name: 'Acme', careers_url: 'https://acme.jibeapply.com/jobs?location=Germany' });
+  if (hit && hit.url === 'https://acme.jibeapply.com/api/jobs?location=Germany') {
+    pass('jibeapply.detect() rewrites /jobs → /api/jobs');
+  } else {
+    fail(`jibeapply.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  // detect() — /api/jobs already present (idempotent)
+  const hitApi = jibeapply.detect({ name: 'X', careers_url: 'https://acme.jibeapply.com/api/jobs' });
+  if (hitApi && hitApi.url === 'https://acme.jibeapply.com/api/jobs') {
+    pass('jibeapply.detect() leaves already-correct /api/jobs URL unchanged');
+  } else {
+    fail(`jibeapply.detect(api) returned ${JSON.stringify(hitApi)}`);
+  }
+
+  // detect() — null cases
+  if (jibeapply.detect({ name: 'X', careers_url: 'https://example.com/jobs' }) === null) {
+    pass('jibeapply.detect() returns null for non-jibeapply URL');
+  } else {
+    fail('jibeapply.detect() should return null for non-jibeapply URL');
+  }
+
+  // Path-spoofed: jibeapply.com in path, not host
+  if (jibeapply.detect({ name: 'Spoof', careers_url: 'https://evil.example/acme.jibeapply.com/jobs' }) === null) {
+    pass('jibeapply.detect() rejects path-spoofed URL');
+  } else {
+    fail('jibeapply.detect() must NOT detect path-spoofed URLs');
+  }
+
+  // Non-string careers_url
+  if (jibeapply.detect({ name: 'X', careers_url: 42 }) === null) {
+    pass('jibeapply.detect() returns null for non-string careers_url');
+  } else {
+    fail('jibeapply.detect() should return null for non-string careers_url');
+  }
+
+  // HTTP (non-HTTPS) must not be detected
+  if (jibeapply.detect({ name: 'X', careers_url: 'http://acme.jibeapply.com/jobs' }) === null) {
+    pass('jibeapply.detect() rejects HTTP (non-HTTPS) URL');
+  } else {
+    fail('jibeapply.detect() should reject HTTP URLs');
+  }
+
+  // parseJibeapplyResponse — normalization
+  const entry = { name: 'Acme', careers_url: 'https://acme.jibeapply.com/jobs' };
+  const sampleJson = {
+    jobs: [
+      { title: 'Senior QA', slug: 'senior-qa-berlin', city: 'Berlin', country: 'Germany', hiring_organization: 'Acme GmbH' },
+      { title: 'Backend Dev', req_id: 'REQ-123', full_location: 'Remote, Germany' },
+      { data: { title: 'Wrapped Job', slug: 'wrapped-job', city: 'Munich', country: 'Germany' } },
+      { title: '', slug: 'no-title' },          // missing title — skip
+      { title: 'No Slug' },                      // missing slug/req_id — skip
+    ],
+  };
+  const parsedJibe = parseJibeapplyResponse(sampleJson, entry);
+
+  if (parsedJibe.length === 3) pass('parseJibeapplyResponse extracts 3 valid jobs');
+  else fail(`parseJibeapplyResponse returned ${parsedJibe.length} jobs, expected 3`);
+
+  if (parsedJibe[0].url === 'https://acme.jibeapply.com/jobs/senior-qa-berlin') {
+    pass('parseJibeapplyResponse builds URL from origin + /jobs/ + slug');
+  } else {
+    fail(`row 0 url = ${JSON.stringify(parsedJibe[0].url)}`);
+  }
+
+  if (parsedJibe[0].location === 'Berlin, Germany') {
+    pass('parseJibeapplyResponse builds location from city/country');
+  } else {
+    fail(`row 0 location = ${JSON.stringify(parsedJibe[0].location)}`);
+  }
+
+  if (parsedJibe[0].company === 'Acme GmbH') {
+    pass('parseJibeapplyResponse uses hiring_organization when present');
+  } else {
+    fail(`row 0 company = ${JSON.stringify(parsedJibe[0].company)}`);
+  }
+
+  if (parsedJibe[1].url.includes('REQ-123') && parsedJibe[1].location === 'Remote, Germany') {
+    pass('parseJibeapplyResponse uses req_id and full_location');
+  } else {
+    fail(`row 1 = ${JSON.stringify(parsedJibe[1])}`);
+  }
+
+  if (parsedJibe[2].title === 'Wrapped Job') {
+    pass('parseJibeapplyResponse unwraps item.data');
+  } else {
+    fail(`row 2 title = ${JSON.stringify(parsedJibe[2].title)}`);
+  }
+
+  // parseJibeapplyResponse — falls back to entry.name when hiring_organization missing
+  const noOrg = parseJibeapplyResponse({ jobs: [{ title: 'Dev', slug: 'dev', city: 'Berlin', country: 'Germany' }] }, entry);
+  if (noOrg[0].company === 'Acme') {
+    pass('parseJibeapplyResponse falls back to entry.name when hiring_organization missing');
+  } else {
+    fail(`fallback company = ${JSON.stringify(noOrg[0].company)}`);
+  }
+
+  // parseJibeapplyResponse — empty input
+  if (parseJibeapplyResponse({}, entry).length === 0) pass('parseJibeapplyResponse({}) → empty result');
+  else fail('parseJibeapplyResponse({}) should be empty');
+
+  // parseJibeapplyResponse — falls back to entry.api's origin when careers_url
+  // can't be parsed, so job URLs stay absolute instead of degrading to "/jobs/<slug>"
+  const malformedCareersEntry = { name: 'Widget Co', careers_url: 'jobs.widgetco.com', api: 'https://jobs.widgetco.com/api/jobs' };
+  const apiOriginFallback = parseJibeapplyResponse({ jobs: [{ title: 'Dev', slug: 'dev-1' }] }, malformedCareersEntry);
+  if (apiOriginFallback[0]?.url === 'https://jobs.widgetco.com/jobs/dev-1') {
+    pass('parseJibeapplyResponse falls back to entry.api origin for a malformed careers_url');
+  } else {
+    fail(`parseJibeapplyResponse api-origin fallback: url = ${JSON.stringify(apiOriginFallback[0]?.url)}`);
+  }
+
+  // parseJibeapplyResponse — null/undefined entries in jobs must be skipped, not crash
+  const sparseJson = { jobs: [null, undefined, { title: 'Real Job', slug: 'real-job' }] };
+  try {
+    const parsedSparse = parseJibeapplyResponse(sparseJson, entry);
+    if (parsedSparse.length === 1 && parsedSparse[0].title === 'Real Job') {
+      pass('parseJibeapplyResponse skips null/undefined entries without crashing');
+    } else {
+      fail(`parseJibeapplyResponse sparse result = ${JSON.stringify(parsedSparse)}`);
+    }
+  } catch (e3) {
+    fail(`parseJibeapplyResponse should not throw on null/undefined entries: ${e3.message}`);
+  }
+
+  // fetch() pagination — 2 pages
+  let pageRequests = 0;
+  const fetchedJibe = await jibeapply.fetch(entry, {
+    transport: 'http',
+    fetchText: async () => { throw new Error('fetchText not expected'); },
+    fetchJson: async (url) => {
+      pageRequests++;
+      const u = new URL(url);
+      const page = parseInt(u.searchParams.get('page') || '1', 10);
+      if (page === 1) {
+        return { totalCount: 15, count: 10, jobs: Array.from({ length: 10 }, (_, i) => ({ title: `Job ${i}`, slug: `job-${i}` })) };
+      }
+      return { totalCount: 15, count: 10, jobs: Array.from({ length: 5 }, (_, i) => ({ title: `Job p2-${i}`, slug: `job-p2-${i}` })) };
+    },
+  });
+  if (pageRequests === 2 && fetchedJibe.length === 15) {
+    pass('jibeapply.fetch() paginates across 2 pages (10+5=15)');
+  } else {
+    fail(`jibeapply fetch pagination: requests=${pageRequests}, total=${fetchedJibe.length} (expected 2/15)`);
+  }
+
+  // fetch() pagination cap — an inflated totalCount must not trigger unbounded
+  // concurrent requests (MAX_PAGES = 50 in providers/jibeapply.mjs), and
+  // hitting the cap must be visible (console.error), not silent.
+  let hugeRequests = 0;
+  const jibeCapWarnings = [];
+  const originalConsoleError = console.error;
+  console.error = (msg) => jibeCapWarnings.push(msg);
+  let fetchedHuge;
+  try {
+    fetchedHuge = await jibeapply.fetch(entry, {
+      transport: 'http',
+      fetchText: async () => { throw new Error('fetchText not expected'); },
+      fetchJson: async () => {
+        hugeRequests++;
+        return { totalCount: 1_000_000, count: 10, jobs: Array.from({ length: 10 }, (_, i) => ({ title: `Job ${i}`, slug: `job-${i}` })) };
+      },
+    });
+  } finally {
+    console.error = originalConsoleError;
+  }
+  if (hugeRequests === 50 && fetchedHuge.length === 500) {
+    pass('jibeapply.fetch() caps pagination at MAX_PAGES despite an inflated totalCount');
+  } else {
+    fail(`jibeapply fetch pagination cap: requests=${hugeRequests}, total=${fetchedHuge.length} (expected 50/500)`);
+  }
+  if (jibeCapWarnings.some(w => /has more postings than max_pages allows/.test(w))) {
+    pass('jibeapply.fetch() warns (console.error) when the cap truncates real results');
+  } else {
+    fail(`jibeapply fetch cap: expected a truncation warning, got ${JSON.stringify(jibeCapWarnings)}`);
+  }
+
+  // fetch() pagination cap — entry.max_pages raises the cap for a genuinely
+  // large tenant (e.g. a Workday-scale Deutsche Bank equivalent on JibeApply)
+  let overriddenRequests = 0;
+  const bigEntry = { name: 'BigCo', careers_url: 'https://bigco.jibeapply.com/jobs', max_pages: 80 };
+  const fetchedOverridden = await jibeapply.fetch(bigEntry, {
+    transport: 'http',
+    fetchText: async () => { throw new Error('fetchText not expected'); },
+    fetchJson: async () => {
+      overriddenRequests++;
+      return { totalCount: 1_000_000, count: 10, jobs: Array.from({ length: 10 }, (_, i) => ({ title: `Job ${i}`, slug: `job-${i}` })) };
+    },
+  });
+  if (overriddenRequests === 80 && fetchedOverridden.length === 800) {
+    pass('jibeapply.fetch() honors entry.max_pages to raise the cap above the default');
+  } else {
+    fail(`jibeapply fetch max_pages override: requests=${overriddenRequests}, total=${fetchedOverridden.length} (expected 80/800)`);
+  }
+
+  // entry.max_pages is itself capped (MAX_PAGES_CAP = 500) — an absurd override
+  // can't turn this into an unbounded scan either
+  let cappedOverrideRequests = 0;
+  const absurdEntry = { name: 'AbsurdCo', careers_url: 'https://absurdco.jibeapply.com/jobs', max_pages: 100_000 };
+  const fetchedAbsurd = await jibeapply.fetch(absurdEntry, {
+    transport: 'http',
+    fetchText: async () => { throw new Error('fetchText not expected'); },
+    fetchJson: async () => {
+      cappedOverrideRequests++;
+      return { totalCount: 10_000_000, count: 10, jobs: Array.from({ length: 10 }, (_, i) => ({ title: `Job ${i}`, slug: `job-${i}` })) };
+    },
+  });
+  if (cappedOverrideRequests === 500 && fetchedAbsurd.length === 5000) {
+    pass('jibeapply.fetch() caps an absurd entry.max_pages at MAX_PAGES_CAP');
+  } else {
+    fail(`jibeapply fetch max_pages hard cap: requests=${cappedOverrideRequests}, total=${fetchedAbsurd.length} (expected 500/5000)`);
+  }
+
+  // fetch() pagination — a failure on a later page returns the jobs gathered
+  // so far instead of discarding everything (sequential, not Promise.all),
+  // and the failure itself is visible (console.error), not silent.
+  let flakyRequests = 0;
+  const jibeFlakyWarnings = [];
+  console.error = (msg) => jibeFlakyWarnings.push(msg);
+  let fetchedFlaky;
+  try {
+    fetchedFlaky = await jibeapply.fetch(entry, {
+      transport: 'http',
+      fetchText: async () => { throw new Error('fetchText not expected'); },
+      fetchJson: async (url) => {
+        flakyRequests++;
+        const u = new URL(url);
+        const page = parseInt(u.searchParams.get('page') || '1', 10);
+        if (page === 3) throw new Error('HTTP 503');
+        return { totalCount: 40, count: 10, jobs: Array.from({ length: 10 }, (_, i) => ({ title: `Job p${page}-${i}`, slug: `job-p${page}-${i}` })) };
+      },
+    });
+  } finally {
+    console.error = originalConsoleError;
+  }
+  if (flakyRequests === 3 && fetchedFlaky.length === 20) {
+    pass('jibeapply.fetch() returns partial results when a later page fails');
+  } else {
+    fail(`jibeapply fetch partial failure: requests=${flakyRequests}, total=${fetchedFlaky.length} (expected 3/20)`);
+  }
+  if (jibeFlakyWarnings.some(w => /page \d+ fetch failed/.test(w))) {
+    pass('jibeapply.fetch() warns (console.error) when a page fetch fails mid-pagination');
+  } else {
+    fail(`jibeapply fetch page failure: expected a fetch-failed warning, got ${JSON.stringify(jibeFlakyWarnings)}`);
+  }
+
+  // fetch() with explicit entry.api (non-jibeapply.com host)
+  let explicitApiUrl = null;
+  const brandedEntry = { name: 'Widget Co', careers_url: 'https://jobs.widgetco.com/jobs', api: 'https://jobs.widgetco.com/api/jobs?internal=false' };
+  await jibeapply.fetch(brandedEntry, {
+    transport: 'http',
+    fetchText: async () => { throw new Error('fetchText not expected'); },
+    fetchJson: async (url) => { explicitApiUrl = url; return { totalCount: 3, count: 3, jobs: [{ title: 'Dev', slug: 'dev-1' }] }; },
+  });
+  if (explicitApiUrl && explicitApiUrl.startsWith('https://jobs.widgetco.com/api/jobs')) {
+    pass('jibeapply.fetch() uses entry.api for non-jibeapply.com hosts');
+  } else {
+    fail(`jibeapply.fetch() with entry.api called url=${JSON.stringify(explicitApiUrl)}`);
+  }
+
+  // fetch() with entry.api — iCIMS-hosted JibeApply pattern: count === totalCount but jobs.length < count
+  let brandedRequests = 0;
+  const fetchedBranded = await jibeapply.fetch(brandedEntry, {
+    transport: 'http',
+    fetchText: async () => { throw new Error('fetchText not expected'); },
+    fetchJson: async (url) => {
+      brandedRequests++;
+      const u = new URL(url);
+      const page = parseInt(u.searchParams.get('page') || '1', 10);
+      // count === totalCount (iCIMS-hosted pattern), jobs only has page-worth of items
+      if (page === 1) return { totalCount: 15, count: 15, jobs: Array.from({ length: 10 }, (_, i) => ({ title: `J${i}`, slug: `j-${i}` })) };
+      return { totalCount: 15, count: 15, jobs: Array.from({ length: 5 }, (_, i) => ({ title: `J2-${i}`, slug: `j2-${i}` })) };
+    },
+  });
+  if (brandedRequests === 2 && fetchedBranded.length === 15) {
+    pass('jibeapply.fetch() paginates when count===totalCount but jobs.length < count');
+  } else {
+    fail(`jibeapply fetch iCIMS pattern: requests=${brandedRequests}, total=${fetchedBranded.length} (expected 2/15)`);
+  }
+
+  // fetch() throws when both entry.api is HTTP and careers_url is non-jibeapply.com
+  // (no valid API URL can be derived from either source)
+  try {
+    await jibeapply.fetch({ name: 'X', careers_url: 'https://jobs.example.com/jobs', api: 'http://evil.com/api/jobs' }, {
+      fetchText: async () => '', fetchJson: async () => { throw new Error('should not reach'); },
+    });
+    fail('jibeapply.fetch() should throw when no valid API URL can be derived');
+  } catch (e2) {
+    if (/cannot derive API URL/i.test(e2.message)) pass('jibeapply.fetch() throws when HTTP entry.api and non-jibeapply careers_url');
+    else fail(`jibeapply.fetch() wrong error: ${e2.message}`);
+  }
+
+} catch (e) {
+  fail(`jibeapply provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What does this PR do?

Adds a zero-token JibeApply provider that reads the public `/api/jobs` endpoint.
Auto-detects `<slug>.jibeapply.com` careers URLs; branded/iCIMS-hosted sites
(iCIMS acquired Jibe in 2019 — e.g. Booking.com) are supported via an explicit
`provider: jibeapply` + `api:` URL.

## Related issue

N/A — new zero-auth scanner provider, exempt from the issue-first requirement per CONTRIBUTING.md.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Changes

- `providers/jibeapply.mjs`: `detect()` rewrites `/jobs` → `/api/jobs` on `*.jibeapply.com` hosts (HTTPS-only, rejects path-spoofed URLs); `fetch()` paginates and normalizes title/url/company/location; `entry.api` lets branded/iCIMS-hosted tenants (non-`jibeapply.com` hosts) opt in explicitly
- `test-all.mjs`: 18 tests covering `detect()`, `parseJibeapplyResponse()`, and `fetch()` pagination (including the `count === totalCount` edge case seen on branded hosts)
- `docs/SUPPORTED_JOB_BOARDS.md`: add JibeApply row
- `templates/portals.example.yml`: auto-detect pattern comment, an auto-detected example stanza, and a real branded-host example (Booking.com — verified against a live tenant)

Scoped to just this provider, keeping blast radius small per prior review feedback on #1120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the JibeApply job board, including automatic detection of `*.jibeapply.com` careers URLs and importing from the public jobs API.
  * Added support for branded/custom-domain JibeApply sites via explicit `provider: jibeapply` configuration and an optional `api` override.
* **Documentation**
  * Updated supported job board documentation and portal examples with JibeApply setup and custom-domain guidance.
* **Tests**
  * Added tests covering JibeApply URL detection, job normalization, and pagination (including caps and partial results), plus configuration/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->