### PR TITLE
feat(registry): add startup boards plugin

### DIFF
--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -72,6 +72,20 @@
       "allowedHosts": [],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1398",
       "addedAt": "2026-07-01"
+    },
+    {
+      "id": "startup-boards",
+      "name": "career-ops-plugin-startup-boards",
+      "version": "0.1.0",
+      "license": "MIT",
+      "description": "Opt-in scanner provider for YC, Getro, and Consider startup job boards.",
+      "repo": "https://github.com/giacomoguidotto/career-ops-plugin-startup-boards",
+      "sha": "66f61a66beb01eaa63dd01095f745be93fa694a5",
+      "hooks": ["provider"],
+      "requiredEnv": [],
+      "allowedHosts": [],
+      "registrationIssue": "https://github.com/santifer/career-ops/issues/1412",
+      "addedAt": "2026-07-02"
     }
   ]
 }


### PR DESCRIPTION
## Plugin registry change

Home issue: #1412

Paste the registry entry (one object), pinned to the exact reviewed commit:

```json
{
  "id": "startup-boards",
  "name": "career-ops-plugin-startup-boards",
  "version": "0.1.0",
  "license": "MIT",
  "description": "Opt-in scanner provider for YC, Getro, and Consider startup job boards.",
  "repo": "https://github.com/giacomoguidotto/career-ops-plugin-startup-boards",
  "sha": "66f61a66beb01eaa63dd01095f745be93fa694a5",
  "hooks": ["provider"],
  "requiredEnv": [],
  "allowedHosts": [],
  "registrationIssue": "https://github.com/santifer/career-ops/issues/1412",
  "addedAt": "2026-07-02"
}
```

Validation run locally:

- `npm run check` in `career-ops-plugin-startup-boards`
- `npm test` in `career-ops-plugin-startup-boards`
- `node plugin-audit.mjs /Users/giacomo/dev/life/career-ops-plugin-startup-boards`
- temporary career-ops engine discovery/merge check
- `node validate-plugin-registry.mjs`
- `node validate-plugin-registry.mjs --deep`

### Maintainer review checklist

- [ ] Naming `career-ops-plugin-<name>`; `id` == name minus the prefix
- [ ] Minimum files present (manifest.json, index.mjs, README.md, LICENSE)
- [ ] Manifest valid: apiVersion 1, `humanInTheLoop: true`, hooks subset of {provider, ingest, search, notify, export} — no apply/submit
- [ ] MIT-compatible LICENSE; no personal data in the repo
- [ ] Egress: `allowedHosts` are real public hosts; no IP literals / metadata / `*.internal`; no localhost without `allowsLocalhost` + a reason
- [ ] Static audit clean: no child_process/playwright/raw sockets/global fetch/eval/bare-dependency imports (egress only via `ctx.fetch`)
- [ ] No core-owned secrets in `requiredEnv`
- [ ] Reads PUBLIC data or the user's OWN account only — no centralized infrastructure, no auto-submit, no blind-apply
- [ ] No commercial / hosted-service / monetization wording (the project is free and local-first)
- [ ] If it ships a skill: domain-scoped — does not instruct the agent to edit core files, change scoring, reveal secrets, or act outside its hooks
- [ ] `sha` is pinned to the exact reviewed commit
- [ ] CI (`plugin-registry-validate`) is green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new bundled plugin to the available plugins list, expanding the app’s built-in capabilities.
  * Included complete plugin metadata (such as version/license and registration info) to improve discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->