### PR TITLE
fix(web): pin turbopack.root to prevent postcss worker OOM explosion

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,5 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Two lockfiles exist on purpose (repo root + web/), so Next would infer the
+  // repo root as the workspace root. On Windows that misinference can send
+  // Turbopack's postcss workers into an unbounded respawn loop that exhausts
+  // all RAM (vercel/next.js#92978) — pin the root to this app.
+  turbopack: { root: import.meta.dirname },
   // Allow a throwaway build dir (e.g. BUILD_DIST=.next-prod) so a production
   // `next build` can run without clobbering a live `next dev` .next.
   ...(process.env.BUILD_DIST ? { distDir: process.env.BUILD_DIST } : {}),


### PR DESCRIPTION
Fixes #1415

## What

One-line config fix: pin `turbopack.root` to the `web/` app in `web/next.config.mjs`.

## Why

career-ops intentionally ships two lockfiles (repo root for the core scripts + `web/package-lock.json` for reproducible RC installs, added in 1a14b28). Because of that, Next.js *infers* the repo root as the Turbopack workspace root and prints the "multiple lockfiles" warning on every `next dev`.

That inference is fragile: if the resolved workspace root ever disagrees with the persistent cache in `web/.next` (lockfile layout changes, config changes, parent-directory lockfiles on user machines), Turbopack's PostCSS child worker enters an **unbounded respawn loop** — the known failure mode of [vercel/next.js#92978](https://github.com/vercel/next.js/issues/92978). On Windows I measured 1 → 156 workers / 8.7 GB within 3 s of `Compiling /`, 272 workers / 16+ GB at 6 s, ending in V8 OOM fatal errors, a near-frozen machine, and orphaned worker processes that survive the crash (80 workers / ~5 GB found an hour later). Once triggered, the poisoned cache makes **every** subsequent `npm run dev` explode.

Pinning the root removes the inference entirely, so it can never flip under an existing cache. It also silences the startup warning.

## Reproduction

Deterministic repro and control matrix are in #1415. Short version: build `web/.next` under one workspace root, change the effective root without clearing the cache, request `/` → explosion within ~3 s (reproduced twice, monitored with a 12 GB kill-switch). Fresh-cache runs are healthy under either root setting.

## Verification

With this change and a fresh cache on Windows 11 / Node 22 / Next 16.2.3:

- `GET / 200` in **2.9 s** cold, **0.5 s** warm restart
- 1–3 postcss workers, ~1 GB total node memory (previously: unbounded)
- No multiple-lockfile warning

## Note for affected users

The pin prevents the poisoning but cannot heal an already-poisoned cache — anyone currently hitting the explosion also needs a one-time `rm -rf web/.next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup/build reliability by pinning the workspace root for the bundler, reducing misdetection issues in certain environments.
  * Added guidance to clarify the repository’s lockfile setup and prevent configuration-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->