### PR TITLE
Fix: prevent notion plugin from mangling slash-formatted scores (#1414)

### DIFF
--- a/plugins/notion/index.mjs
+++ b/plugins/notion/index.mjs
@@ -38,7 +38,24 @@ async function applicationsDb(client) {
   return apps;
 }
 
+/**
+ * Parse a tracker score cell into a numeric value for the Notion DB Score property.
+ *
+ * Scores in applications.md may be formatted like `4.2/5`, `**4.2/5**`, `4.25`, etc.
+ * Strips formatting and extracts the first numeric value so slash-formatted
+ * scores (e.g. 4.2/5) are not mangled into 4.25 (#1414).
+ *
+ * @param {unknown} s - Raw score value from tracker row.
+ * @returns {number} Parsed score, or NaN if no valid number is present.
+ */
+export function parseScore(s) {
+  const m = String(s ?? '').replace(/\*\*/g, '').match(/([\d.]+)/);
+  return m ? parseFloat(m[1]) : NaN;
+}
+
 export default {
+  parseScore,
+
   /**
    * export: upsert each tracker row into the user's Notion Applications DB.
    * Receives a frozen read-only snapshot of the tracker — never a file handle.
@@ -60,7 +77,7 @@ export default {
       const props = { Role: { title: rich(role) }, Company: { rich_text: rich(company) } };
       const status = canonicalStatus(row.status);
       if (status) props.Status = { select: { name: status } };
-      const score = parseFloat(String(row.score ?? '').replace(/[^\d.]/g, ''));
+      const score = parseScore(row.score);
       if (Number.isFinite(score)) props.Score = { number: score };
 
       if (ctx?.dryRun) { ctx.log(`would push: ${company} — ${role}`); pushed++; continue; }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8808,6 +8808,14 @@ try {
   if (importOk) pass('every bundled plugin entry imports cleanly with a default hook export');
   else fail('a bundled plugin failed to import or lacks a default export');
 
+  const notionMod = await import(pathToFileURL(join(ROOT, 'plugins', 'notion', 'index.mjs')).href);
+  const notionParseScore = notionMod.parseScore || notionMod.default?.parseScore;
+  if (typeof notionParseScore === 'function' && notionParseScore('4.2/5') === 4.2 && notionParseScore('5/5') === 5 && notionParseScore('**4.2/5**') === 4.2) {
+    pass('notion plugin parseScore sanitizes slash-formatted scores cleanly (4.2/5 -> 4.2, 5/5 -> 5) (#1414)');
+  } else {
+    fail(`notion plugin parseScore broken: 4.2/5 -> ${notionParseScore?.('4.2/5')}, 5/5 -> ${notionParseScore?.('5/5')}`);
+  }
+
   // Recursively collect every .mjs under plugins/ (the deny-list must not be flat-only).
   const allPluginMjs = [];
   const walkMjs = (d) => {


### PR DESCRIPTION
### Summary
Fixes a bug where `plugins/notion/index.mjs` sanitized scores using `String(row.score ?? '').replace(/[^\d.]/g, '')`, which stripped the `/` character from slash-formatted scores (causing `4.2/5` to become `4.25` and `5/5` to become `55`).

### Changes
- **Notion Plugin ([plugins/notion/index.mjs](file:///c:/Users/monum/Desktop/Development/Open%20Source/career-ops/plugins/notion/index.mjs#L41-L55))**: Replaced the global regex `.replace(/[^\d.]/g, '')` with a clean `parseScore` helper function that strips markdown formatting (such as `**`) and extracts the first numeric value via `.match(/([\d.]+)/)`.
- **Exports**: Exported `parseScore` both as a named export and on the default export object so community plugins and tests can inherit the safe sanitization logic cleanly.
- **Test Suite ([test-all.mjs](file:///c:/Users/monum/Desktop/Development/Open%20Source/career-ops/test-all.mjs#L8811-L8818))**: Added a unit test asserting that `parseScore('4.2/5') === 4.2`, `parseScore('5/5') === 5`, and `parseScore('**4.2/5**') === 4.2`.

### Verification
- Run `node test-all.mjs --quick` -> All 912 tests passing, including the new assertion for notion plugin score sanitization.

Closes #1414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved score handling in Notion exports so values like `4.2/5` and `**4.2/5**` are saved correctly as numeric scores.
  * Prevents invalid or malformed score text from being written when no usable number is found.

* **Tests**
  * Added coverage for score parsing to ensure formatted and slash-based scores are converted consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->