### PR TITLE
fix(providers): harden workday pagination against 429s, API caps, and dateless tenants

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -35,7 +35,7 @@ are shared helpers and are not loaded as providers.
 | The Hub | API | Reads the board-wide `https://thehub.io/api/jobs` JSON feed (Nordic/EU startups). Configure with `provider: thehub`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
 | We Work Remotely | RSS | Reads the public `https://weworkremotely.com/remote-jobs.rss` feed and parses it in-process. |
 | Workable | Parser | Auto-detects `https://apply.workable.com/<slug>` and parses Workable's public markdown jobs feed. |
-| Workday | API | Auto-detects Workday `myworkdayjobs.com` careers URLs and posts to the public CXS jobs endpoint. |
+| Workday | API | Auto-detects `<tenant>.<instance>.myworkdayjobs.com[/<locale>]/<site>` careers URLs and posts to the public CXS jobs endpoint; paginates via offset up to `max_pages` (default 50), warning if a tenant's postings exceed the cap. |
 | Working Nomads | API | Reads the board-wide `https://www.workingnomads.com/api/exposed_jobs/` JSON feed, then applies scanner filters. |
 
 When adding a new provider, add a new non-helper module under `providers/` and

--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -35,7 +35,7 @@ are shared helpers and are not loaded as providers.
 | The Hub | API | Reads the board-wide `https://thehub.io/api/jobs` JSON feed (Nordic/EU startups). Configure with `provider: thehub`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. |
 | We Work Remotely | RSS | Reads the public `https://weworkremotely.com/remote-jobs.rss` feed and parses it in-process. |
 | Workable | Parser | Auto-detects `https://apply.workable.com/<slug>` and parses Workable's public markdown jobs feed. |
-| Workday | API | Auto-detects `<tenant>.<instance>.myworkdayjobs.com[/<locale>]/<site>` careers URLs and posts to the public CXS jobs endpoint; paginates via offset up to `max_pages` (default 50), warning if a tenant's postings exceed the cap. |
+| Workday | API | Auto-detects `<tenant>.<instance>.myworkdayjobs.com[/<locale>]/<site>` careers URLs and posts to the public CXS jobs endpoint; paginates via offset up to `max_pages` (default 100), warning if a tenant's postings exceed the cap. |
 | Working Nomads | API | Reads the board-wide `https://www.workingnomads.com/api/exposed_jobs/` JSON feed, then applies scanner filters. |
 
 When adding a new provider, add a new non-helper module under `providers/` and

--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -17,10 +17,15 @@ async function fetchWithTimeout(url, { timeoutMs = DEFAULT_TIMEOUT_MS, headers =
     });
     if (!res.ok) {
       const responseText = await res.text().catch(() => '');
-      const snippet = responseText.replace(/\s+/g, ' ').trim().slice(0, 300);
-      const err = new Error(snippet ? `HTTP ${res.status}: ${snippet}` : `HTTP ${res.status}`);
+      // WAF/CDN challenge pages (seen live: Workday 429s) carry no actionable
+      // text — HTML markup or a generic interstitial message, not worth
+      // parsing or displaying. The status code and its standard reason
+      // phrase are what a log line needs; the raw body is still attached as
+      // err.body for callers that want to inspect it.
+      const err = new Error(`HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ''}`);
       err.status = res.status;
       err.body = responseText;
+      err.retryAfter = res.headers.get('retry-after');
       throw err;
     }
     return res;

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -95,7 +95,12 @@ async function fetchPageWithRetry(ctx, api, opts) {
       lastErr = err;
       if (attempt === MAX_RETRIES || !isRetryableError(err)) throw err;
       const backoff = Math.min(RETRY_BASE_DELAY_MS * 2 ** attempt, RETRY_MAX_DELAY_MS);
-      const delayMs = parseRetryAfterMs(err?.retryAfter) ?? (backoff + Math.random() * 250);
+      // A server-supplied Retry-After is honored, but still clamped — an
+      // unbounded value (hostile or just misconfigured: Retry-After: 86400)
+      // would otherwise stall this tenant's fetch for as long as the server
+      // says, defeating the whole point of a bounded backoff.
+      const retryAfterMs = parseRetryAfterMs(err?.retryAfter);
+      const delayMs = retryAfterMs !== null ? Math.min(retryAfterMs, RETRY_MAX_DELAY_MS * 4) : (backoff + Math.random() * 250);
       await sleep(delayMs, ctx);
     }
   }
@@ -202,7 +207,7 @@ export default {
     // Some tenants' CXS responses never include postedOn at all (e.g.
     // adventhealth, on every page). Early-stop can't apply then — there's
     // no dated posting to recognize as "past the window".
-    let sawAnyDatedPosting = jobs.some((j) => typeof j.postedAt === 'number');
+    const sawAnyDatedPosting = jobs.some((j) => typeof j.postedAt === 'number');
 
     // Zero dated postings on page 0, --include-undated off, --since-bounded
     // scan: further pagination is pure waste — every posting from this
@@ -234,7 +239,6 @@ export default {
         }
         const pageJobs = parseWorkdayResponse(json, entry);
         jobs.push(...pageJobs);
-        if (!sawAnyDatedPosting && pageJobs.some((j) => typeof j.postedAt === 'number')) sawAnyDatedPosting = true;
         if (total === null) {
           const postings = Array.isArray(json?.jobPostings) ? json.jobPostings : [];
           if (postings.length < PAGE_SIZE) break; // short page → last page reached

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -18,14 +18,96 @@ const PAGE_SIZE = 20;
 // keep coming back), so a misbehaving/compromised API can't drive this into
 // fetching an unbounded number of pages. Override with `max_pages` on the
 // portal entry for a tenant that genuinely exceeds it.
-const DEFAULT_MAX_PAGES = 50;
-const MAX_PAGES_CAP = 500;
+const DEFAULT_MAX_PAGES = 100;
+// Hard ceiling even for an explicit override. 1500 pages (30,000 postings)
+// covers known large tenants (dollartree: 23,609; oreillyauto: 17,061;
+// cvshealth: ~16,800) with headroom — not a completeness guarantee, since a
+// company directory this size has no fixed upper bound.
+const MAX_PAGES_CAP = 1500;
+
+// Retry policy for transient page failures (429 rate-limit, 5xx, timeouts/aborts).
+// Workday's CXS API is fronted by a WAF that rate-limits in bursts; without
+// retry, a single 429 silently truncates an entire tenant (e.g. a
+// 3,383-posting tenant reduced to 20 jobs on page 2). Non-transient errors
+// (4xx other than 429) are not retried — retrying a malformed request just
+// wastes the budget.
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 500;
+const RETRY_MAX_DELAY_MS = 8_000;
+
+// Delay between successive pages *within one tenant's own pagination loop*
+// (not between tenants — that's scan-ats-full.mjs's concurrency, a separate
+// knob). A burst of same-host requests with zero delay risks Workday's
+// WAF-level rate limiting on any tenant that paginates several pages deep
+// (large boards like rollsroyce, sec, roche). Only tenants that loop past
+// page 1 pay this; no-date-skip and early-stopped tenants never do.
+const INTER_PAGE_DELAY_MS = 150;
+
+// Workday returns postings newest-first, so pagination can stop once a
+// page's oldest *dated* posting is well past --since — no point paying for
+// (and rate-limit-risking) pages that are entirely stale. Only unambiguous
+// numeric ages ("Posted N Days Ago", N < 30) count for this; the unbounded
+// "30+ Days Ago" bucket never triggers it, so a wide --since (>=30 days)
+// simply never early-stops rather than risk a false stop.
+//
+// The sort isn't perfectly monotonic day-to-day — some tenants (e.g. Adobe)
+// return day-labels slightly out of order across consecutive postings ("27
+// Days Ago | 26 Days Ago | 27 Days Ago"), roughly 1 day of jitter. The
+// margin only needs to clear that; 2 is double it as a plain safety factor,
+// not a second measurement.
+const EARLY_STOP_MARGIN_MS = 2 * 86_400_000;
 
 /** Resolve the page cap: a positive integer `max_pages` on the entry, capped. */
 function resolveMaxPages(entry) {
   const v = entry?.max_pages;
   if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES_CAP);
   return DEFAULT_MAX_PAGES;
+}
+
+function sleep(ms, ctx) {
+  if (typeof ctx?.sleep === 'function') return ctx.sleep(ms);
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Parses a `Retry-After` header value (seconds, or an HTTP-date) to ms, or null. */
+function parseRetryAfterMs(value) {
+  if (!value) return null;
+  const secs = Number(value);
+  if (Number.isFinite(secs) && secs >= 0) return secs * 1000;
+  const dateMs = Date.parse(value);
+  return Number.isFinite(dateMs) ? Math.max(0, dateMs - Date.now()) : null;
+}
+
+function isRetryableError(err) {
+  const status = err?.status;
+  if (status === 429) return true;
+  if (typeof status === 'number' && status >= 500) return true;
+  return status === undefined; // network error / timeout / abort — no status set
+}
+
+/** Fetches a single page, retrying transient failures with backoff. */
+async function fetchPageWithRetry(ctx, api, opts) {
+  let lastErr;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return await ctx.fetchJson(api, opts);
+    } catch (err) {
+      lastErr = err;
+      if (attempt === MAX_RETRIES || !isRetryableError(err)) throw err;
+      const backoff = Math.min(RETRY_BASE_DELAY_MS * 2 ** attempt, RETRY_MAX_DELAY_MS);
+      const delayMs = parseRetryAfterMs(err?.retryAfter) ?? (backoff + Math.random() * 250);
+      await sleep(delayMs, ctx);
+    }
+  }
+  throw lastErr;
+}
+
+/** True once a page's oldest unambiguously-dated posting is past the --since window. */
+function pageIsPastWindow(pageJobs, sinceMs) {
+  if (typeof sinceMs !== 'number') return false;
+  const dated = pageJobs.map((j) => j.postedAt).filter((v) => typeof v === 'number');
+  if (dated.length === 0) return false;
+  return Math.min(...dated) < sinceMs - EARLY_STOP_MARGIN_MS;
 }
 
 function resolveEndpoint(entry) {
@@ -95,8 +177,9 @@ export default {
 
     const postOpts = { method: 'POST', redirect: 'error', headers: { 'content-type': 'application/json', accept: 'application/json' } };
     const makeBody = (offset) => JSON.stringify({ limit: PAGE_SIZE, offset, searchText: '', appliedFacets: {} });
+    const sinceMs = typeof ctx?.sinceMs === 'number' ? ctx.sinceMs : null;
 
-    const first = await ctx.fetchJson(ep.api, { ...postOpts, body: makeBody(0) });
+    const first = await fetchPageWithRetry(ctx, ep.api, { ...postOpts, body: makeBody(0) });
     const jobs = parseWorkdayResponse(first, entry);
 
     const total = typeof first?.total === 'number' ? first.total : null;
@@ -111,40 +194,88 @@ export default {
       ? Math.min(Math.ceil(total / PAGE_SIZE), maxPages)
       : (firstPostings.length >= PAGE_SIZE ? maxPages : 1);
 
+    // Why pagination stopped — drives which warning (if any) fires below.
+    // 'fetch-error' must NOT produce the "raise max_pages" advice: that knob
+    // does nothing for a tenant that died on a rate limit rather than hit the cap.
+    let stopReason = 'complete';
+    if (pageIsPastWindow(jobs, sinceMs)) stopReason = 'early-stop';
+    // Some tenants' CXS responses never include postedOn at all (e.g.
+    // adventhealth, on every page). Early-stop can't apply then — there's
+    // no dated posting to recognize as "past the window".
+    let sawAnyDatedPosting = jobs.some((j) => typeof j.postedAt === 'number');
+
+    // Zero dated postings on page 0, --include-undated off, --since-bounded
+    // scan: further pagination is pure waste — every posting from this
+    // tenant will be dropped downstream as undated regardless of page count
+    // (newest-first sort means if the *freshest* postings lack a date, older
+    // ones will too). Return page 0's results instead of grinding to maxPages.
+    if (stopReason === 'complete' && sinceMs !== null && ctx?.includeUndated !== true
+      && !sawAnyDatedPosting && jobs.length > 0) {
+      stopReason = 'no-date-skip';
+    }
+
     // Sequential, not concurrent (mirrors providers/4dayweek.mjs, thehub.mjs,
     // arbeitnow.mjs, jibeapply.mjs) — a single tenant's API has no reason to
     // receive a burst of parallel requests, and a mid-run failure stops
     // cleanly with whatever pages were already gathered instead of
     // discarding them (Promise.all would fail the whole batch on one error).
     let page = 1;
-    for (; page < pagesToFetch; page++) {
-      let json;
-      try {
-        json = await ctx.fetchJson(ep.api, { ...postOpts, body: makeBody(page * PAGE_SIZE) });
-      } catch (err) {
-        console.error(`⚠️  workday: ${entry.name} page ${page + 1} fetch failed — ${err.message} (returning ${jobs.length} jobs fetched so far)`);
-        break;
+    if (stopReason === 'complete') {
+      for (; page < pagesToFetch; page++) {
+        await sleep(INTER_PAGE_DELAY_MS, ctx);
+        let json;
+        try {
+          json = await fetchPageWithRetry(ctx, ep.api, { ...postOpts, body: makeBody(page * PAGE_SIZE) });
+        } catch (err) {
+          const jobsSummary = `${jobs.length}${total !== null ? ` of ${total}` : ''} jobs`;
+          console.error(`⚠️  workday: ${entry.name} truncated at ${page + 1} of ${pagesToFetch} pages after ${MAX_RETRIES + 1} attempts (${jobsSummary}): ${err.message}`);
+          stopReason = 'fetch-error';
+          break;
+        }
+        const pageJobs = parseWorkdayResponse(json, entry);
+        jobs.push(...pageJobs);
+        if (!sawAnyDatedPosting && pageJobs.some((j) => typeof j.postedAt === 'number')) sawAnyDatedPosting = true;
+        if (total === null) {
+          const postings = Array.isArray(json?.jobPostings) ? json.jobPostings : [];
+          if (postings.length < PAGE_SIZE) break; // short page → last page reached
+        }
+        if (pageIsPastWindow(pageJobs, sinceMs)) { stopReason = 'early-stop'; break; }
       }
-      jobs.push(...parseWorkdayResponse(json, entry));
-      if (total === null) {
-        const postings = Array.isArray(json?.jobPostings) ? json.jobPostings : [];
-        if (postings.length < PAGE_SIZE) break; // short page → last page reached
+      if (stopReason === 'complete' && page === pagesToFetch && pagesToFetch === maxPages) {
+        stopReason = 'cap';
       }
     }
 
-    // The cap is silent by design (it's a safety net, not a working limit),
-    // but a tenant that actually exceeds it needs to be surfaced — otherwise
-    // the user has no way to notice postings are missing from their scan.
-    const truncated = total !== null
-      ? Math.ceil(total / PAGE_SIZE) > maxPages
-      : page === pagesToFetch && pagesToFetch === maxPages;
-    if (truncated) {
-      console.error(
-        `⚠️  workday: ${entry.name} has more postings than max_pages allows ` +
-        `(fetched ${jobs.length}${total !== null ? ` of ${total}` : ''}) — ` +
-        `set max_pages on this portal entry to raise the cap (current: ${maxPages})`,
-      );
+    // The cap is a safety net, not a working limit — silent by design, but a
+    // tenant that actually hits it needs to be surfaced, in one short line
+    // (a full-directory scan can hit this on dozens of tenants).
+    //
+    // "raise max_pages" only applies when `entry` is a real portals.yml
+    // tracked_companies entry (scan.mjs, sinceMs === null). scan-ats-full.mjs's
+    // reverse scan (the only caller that sets ctx.sinceMs) synthesizes entries
+    // from the external dataset — there's no portal entry to edit, and no
+    // fixed cap can guarantee full coverage of an unbounded company
+    // directory anyway, so there's nothing else to suggest.
+    if (stopReason === 'cap') {
+      const jobsSummary = `${jobs.length}${total !== null ? ` of ${total}` : ''} jobs`;
+      if (sinceMs === null) {
+        console.error(`⚠️  workday: ${entry.name} truncated at max_pages=${maxPages} (${jobsSummary}) — raise max_pages on this entry for more`);
+      } else {
+        // Workday's CXS backend can report `total` as exactly
+        // maxPages*PAGE_SIZE when the real count is far higher (e.g.
+        // dickssportinggoods: total=2000, public site lists 7,120; requests
+        // at offset 2000/4000 return the same first posting as offset 0).
+        // Flag it, don't explain it here.
+        const suspectTag = total !== null && total === maxPages * PAGE_SIZE ? ' (total may be Workday-capped, not real)' : '';
+        console.error(`⚠️  workday: ${entry.name} truncated at ${maxPages} pages (${jobsSummary})${suspectTag}`);
+      }
     }
+    // 'no-date-skip' hits many tenants in a full-directory scan (a company
+    // with several Workday sites, like a1group or ashealthnet, triggers it
+    // once per site) — a console.error per hit would repeat thousands of
+    // times, so tag the array instead; scan-ats-full.mjs aggregates it into
+    // one summary line.
+    if (stopReason === 'no-date-skip') jobs.workdayNoDateSkip = true;
 
     return jobs;
   },

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -12,7 +12,21 @@
 // and omitted for the unbounded "30+ Days Ago" form.
 
 const PAGE_SIZE = 20;
-const MAX_PAGES = 50; // safety cap — at most 1000 postings per site
+
+// Safety cap on pagination — applied regardless of what the upstream reports
+// as `total` (or, when `total` is absent, regardless of how many full pages
+// keep coming back), so a misbehaving/compromised API can't drive this into
+// fetching an unbounded number of pages. Override with `max_pages` on the
+// portal entry for a tenant that genuinely exceeds it.
+const DEFAULT_MAX_PAGES = 50;
+const MAX_PAGES_CAP = 500;
+
+/** Resolve the page cap: a positive integer `max_pages` on the entry, capped. */
+function resolveMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES_CAP);
+  return DEFAULT_MAX_PAGES;
+}
 
 function resolveEndpoint(entry) {
   const url = entry.careers_url || '';
@@ -37,6 +51,32 @@ function parsePostedOn(label) {
   return Date.now() - Number(m[1]) * 86_400_000;
 }
 
+// Workday URL path encodes location as /job/{Location-Slug}/{title-slug}.
+// Use it as fallback when locationsText is absent (common on some tenants).
+function locationFromPath(externalPath) {
+  const m = String(externalPath || '').match(/\/job\/([^/]+)\//);
+  return m ? decodeURIComponent(m[1]).replace(/-/g, ' ') : '';
+}
+
+export function parseWorkdayResponse(json, entry) {
+  const ep = resolveEndpoint(entry);
+  const jobBase = ep?.jobBase || '';
+  const postings = Array.isArray(json?.jobPostings) ? json.jobPostings : [];
+  const jobs = [];
+  for (const j of postings) {
+    if (j == null) continue;
+    if (!j.externalPath || !String(j.title || '').trim()) continue;
+    jobs.push({
+      title: j.title || '',
+      url: jobBase + j.externalPath,
+      company: entry.name,
+      location: j.locationsText || locationFromPath(j.externalPath),
+      postedAt: parsePostedOn(j.postedOn),
+    });
+  }
+  return jobs;
+}
+
 /** @type {Provider} */
 export default {
   id: 'workday',
@@ -50,33 +90,59 @@ export default {
     const ep = resolveEndpoint(entry);
     if (!ep) throw new Error(`workday: cannot derive CXS endpoint for ${entry.name}`);
 
-    const jobs = [];
-    for (let page = 0; page < MAX_PAGES; page++) {
-      const body = JSON.stringify({
-        limit: PAGE_SIZE,
-        offset: page * PAGE_SIZE,
-        searchText: '',
-        appliedFacets: {},
-      });
-      const json = await ctx.fetchJson(ep.api, {
-        method: 'POST',
-        redirect: 'error',
-        body,
-        headers: { 'content-type': 'application/json', accept: 'application/json' },
-      });
-      const postings = Array.isArray(json?.jobPostings) ? json.jobPostings : [];
-      for (const j of postings) {
-        if (!j.externalPath) continue;
-        jobs.push({
-          title: j.title || '',
-          url: ep.jobBase + j.externalPath,
-          company: entry.name,
-          location: j.locationsText || '',
-          postedAt: parsePostedOn(j.postedOn),
-        });
+    const postOpts = { method: 'POST', redirect: 'error', headers: { 'content-type': 'application/json', accept: 'application/json' } };
+    const makeBody = (offset) => JSON.stringify({ limit: PAGE_SIZE, offset, searchText: '', appliedFacets: {} });
+
+    const first = await ctx.fetchJson(ep.api, { ...postOpts, body: makeBody(0) });
+    const jobs = parseWorkdayResponse(first, entry);
+
+    const total = typeof first?.total === 'number' ? first.total : null;
+    const firstPostings = Array.isArray(first?.jobPostings) ? first.jobPostings : [];
+    const maxPages = resolveMaxPages(entry);
+
+    // How many pages to fetch in total (including the first, already-fetched
+    // one): bounded by `total` when the server reports it, always capped at
+    // maxPages. When `total` is absent, only probe further pages if the first
+    // one was full — a short first page already means there's nothing more.
+    const pagesToFetch = total !== null
+      ? Math.min(Math.ceil(total / PAGE_SIZE), maxPages)
+      : (firstPostings.length >= PAGE_SIZE ? maxPages : 1);
+
+    // Sequential, not concurrent (mirrors providers/4dayweek.mjs, thehub.mjs,
+    // arbeitnow.mjs, jibeapply.mjs) — a single tenant's API has no reason to
+    // receive a burst of parallel requests, and a mid-run failure stops
+    // cleanly with whatever pages were already gathered instead of
+    // discarding them (Promise.all would fail the whole batch on one error).
+    let page = 1;
+    for (; page < pagesToFetch; page++) {
+      let json;
+      try {
+        json = await ctx.fetchJson(ep.api, { ...postOpts, body: makeBody(page * PAGE_SIZE) });
+      } catch (err) {
+        console.error(`⚠️  workday: ${entry.name} page ${page + 1} fetch failed — ${err.message} (returning ${jobs.length} jobs fetched so far)`);
+        break;
       }
-      if (postings.length < PAGE_SIZE) break;
+      jobs.push(...parseWorkdayResponse(json, entry));
+      if (total === null) {
+        const postings = Array.isArray(json?.jobPostings) ? json.jobPostings : [];
+        if (postings.length < PAGE_SIZE) break; // short page → last page reached
+      }
     }
+
+    // The cap is silent by design (it's a safety net, not a working limit),
+    // but a tenant that actually exceeds it needs to be surfaced — otherwise
+    // the user has no way to notice postings are missing from their scan.
+    const truncated = total !== null
+      ? Math.ceil(total / PAGE_SIZE) > maxPages
+      : page === pagesToFetch && pagesToFetch === maxPages;
+    if (truncated) {
+      console.error(
+        `⚠️  workday: ${entry.name} has more postings than max_pages allows ` +
+        `(fetched ${jobs.length}${total !== null ? ` of ${total}` : ''}) — ` +
+        `set max_pages on this portal entry to raise the cap (current: ${maxPages})`,
+      );
+    }
+
     return jobs;
   },
 };

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -55,7 +55,10 @@ function parsePostedOn(label) {
 // Use it as fallback when locationsText is absent (common on some tenants).
 function locationFromPath(externalPath) {
   const m = String(externalPath || '').match(/\/job\/([^/]+)\//);
-  return m ? decodeURIComponent(m[1]).replace(/-/g, ' ') : '';
+  if (!m) return '';
+  let segment;
+  try { segment = decodeURIComponent(m[1]); } catch { segment = m[1]; }
+  return segment.replace(/-/g, ' ');
 }
 
 export function parseWorkdayResponse(json, entry) {

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -376,7 +376,12 @@ async function main() {
   log(`Reverse ATS scan — ${sourcesSummary} | since ${opts.sinceDays}d${opts.limit < Infinity ? ` | limit ${opts.limit}/ats` : ''}${opts.shuffle ? ' | shuffled' : ''}${opts.includeUndated ? ' | +undated' : ''}${opts.liveness ? ' | liveness' : ''}${opts.dryRun ? ' | DRY RUN' : ''}`);
 
   const { seen: seenUrls } = loadSeenUrls();
-  const ctx = makeHttpCtx();
+  // sinceMs and includeUndated let providers (currently only workday.mjs)
+  // stop paginating a tenant early instead of always walking to max_pages:
+  // sinceMs once postings are confidently past the --since window, and
+  // includeUndated (when false) for a tenant that exposes no postedOn at
+  // all, since its postings would all be dropped as undated below anyway.
+  const ctx = { ...makeHttpCtx(), sinceMs: cutoff, includeUndated: opts.includeUndated };
   const date = new Date().toISOString().slice(0, 10);
 
   const newOffers = [];
@@ -385,6 +390,12 @@ async function main() {
   let totalErrors = 0;
   let droppedNoDate = 0;
   let capHit = false;
+  // Aggregated from providers/workday.mjs's jobs.workdayNoDateSkip tag — see
+  // there for why this is a counter instead of a per-company console.error
+  // (thousands of tenants hit this on a full directory scan; one line each
+  // would just be the same message repeated thousands of times).
+  let noDateSkipCompanies = 0;
+  let noDateSkipJobs = 0;
   const datasetStatus = {};
 
   for (const name of opts.ats) {
@@ -402,6 +413,7 @@ async function main() {
     await parallelEach(entries, CONCURRENCY, async (entry) => {
       try {
         const jobs = await source.provider.fetch(entry, ctx);
+        if (jobs.workdayNoDateSkip) { noDateSkipCompanies++; noDateSkipJobs += jobs.length; }
         for (const job of jobs) {
           if (!job.url || !job.title) continue;
           // Confirmed-stale postings are always dropped. Undated postings are
@@ -453,7 +465,16 @@ async function main() {
   log(`${'━'.repeat(45)}`);
   log(`Companies scanned:  ${totalCompaniesScanned}${capHit ? ` of ${totalCompaniesAvailable} (capped)` : ''}`);
   log(`Unreachable boards: ${totalErrors}`);
-  if (droppedNoDate) log(`Undated dropped:    ${droppedNoDate}${opts.includeUndated ? '' : ' (use --include-undated to keep)'}`);
+  // noDateSkipJobs is a subset of droppedNoDate, not a separate pool: every
+  // no-postedOn workday posting counted here also hits the per-job undated
+  // filter in the scan loop above and gets dropped there too. Report it as
+  // a breakdown, not a second count — the two aren't additive.
+  if (droppedNoDate) {
+    const breakdown = noDateSkipCompanies
+      ? ` (incl. ${noDateSkipJobs} from ${noDateSkipCompanies} workday companies with no postedOn)`
+      : '';
+    log(`Undated dropped: ${droppedNoDate}${breakdown}${opts.includeUndated ? '' : '. Use --include-undated to keep'}`);
+  }
   log(`New matches:        ${offers.length}`);
 
   if (offers.length) {

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -538,8 +538,8 @@ search_queries:
 #
 # - name: Example Workday Co
 #   careers_url: https://exampleco.wd5.myworkdayjobs.com/en-US/exampleco-careers  # any <tenant>.wd<N>.myworkdayjobs.com
-#   max_pages: 50          # optional page cap (20 jobs/page, default 50, max 500) —
-#                          # raise it for a tenant with 1000+ open postings (a warning
+#   max_pages: 100         # optional page cap (20 jobs/page, default 100, max 1500) —
+#                          # raise it for a tenant with 2000+ open postings (a warning
 #                          # is logged if the cap truncates real results)
 #   enabled: true
 #

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -494,6 +494,7 @@ search_queries:
 #   pinpoint        <slug>.pinpointhq.com
 #   rippling        ats.rippling.com/<slug>/jobs
 #   jibeapply       <slug>.jibeapply.com/jobs  (or provider: jibeapply + api: for a branded host's own /jobs path)
+#   workday         <tenant>.wd<N>.myworkdayjobs.com[/<locale>]/<board>
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
@@ -532,6 +533,13 @@ search_queries:
 #   careers_url: https://exampleco.jibeapply.com/jobs     # any *.jibeapply.com/jobs host
 #   max_pages: 50          # optional page cap (10 jobs/page, default 50, max 500) —
 #                          # raise it for a tenant with 500+ open postings (a warning
+#                          # is logged if the cap truncates real results)
+#   enabled: true
+#
+# - name: Example Workday Co
+#   careers_url: https://exampleco.wd5.myworkdayjobs.com/en-US/exampleco-careers  # any <tenant>.wd<N>.myworkdayjobs.com
+#   max_pages: 50          # optional page cap (20 jobs/page, default 50, max 500) —
+#                          # raise it for a tenant with 1000+ open postings (a warning
 #                          # is logged if the cap truncates real results)
 #   enabled: true
 #

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4432,17 +4432,18 @@ try {
   fail(`solidjobs provider tests crashed: ${e.message}`);
 }
 
-// ── 16. SSRF redirect hardening (lever / ashby / workday) ───────
+// ── 16. SSRF redirect hardening (lever / ashby) ──────────────────
 // _http.mjs defaults to redirect:'follow', so a server-side redirect from any
 // of these ATS APIs to an internal address is an SSRF vector. Every other GET
-// provider passes redirect:'error'; these three were missing it.
+// provider passes redirect:'error'; these two were missing it.
+// (workday's redirect:'error' coverage lives in its own "Provider — workday"
+// section below, checked across every paginated request, not just the first.)
 
-console.log('\n16. Provider — SSRF redirect hardening (lever / ashby / workday)');
+console.log('\n16. Provider — SSRF redirect hardening (lever / ashby)');
 
 try {
   const lever = (await import(pathToFileURL(join(ROOT, 'providers/lever.mjs')).href)).default;
   const ashby = (await import(pathToFileURL(join(ROOT, 'providers/ashby.mjs')).href)).default;
-  const workday = (await import(pathToFileURL(join(ROOT, 'providers/workday.mjs')).href)).default;
 
   let leverOpts = null;
   await lever.fetch(
@@ -4459,14 +4460,6 @@ try {
   );
   if (ashbyOpts && ashbyOpts.redirect === 'error') pass('ashby.fetch() passes redirect:"error"');
   else fail(`ashby.fetch() should pass redirect:"error", got ${JSON.stringify(ashbyOpts)}`);
-
-  let workdayOpts = null;
-  await workday.fetch(
-    { name: 'W', careers_url: 'https://example.wd5.myworkdayjobs.com/careers' },
-    { transport: 'http', fetchJson: async (_u, opts) => { workdayOpts = opts; return { jobPostings: [] }; }, fetchText: async () => '' },
-  );
-  if (workdayOpts && workdayOpts.redirect === 'error') pass('workday.fetch() passes redirect:"error"');
-  else fail(`workday.fetch() should pass redirect:"error", got ${JSON.stringify(workdayOpts)}`);
 } catch (e) {
   fail(`SSRF redirect hardening tests crashed: ${e.message}`);
 }
@@ -9739,6 +9732,269 @@ try {
   }
 } catch (e) {
   fail(`prepare-application contract check crashed: ${e.message}`);
+}
+
+// ── 53. PROVIDER — WORKDAY ────────────────────────────────────────
+
+console.log('\n53. Provider — workday');
+
+try {
+  const workday = (await import(pathToFileURL(join(ROOT, 'providers/workday.mjs')).href)).default;
+  const { parseWorkdayResponse } = await import(pathToFileURL(join(ROOT, 'providers/workday.mjs')).href);
+
+  if (workday.id === 'workday') pass('workday.id is "workday"');
+  else fail(`workday.id is ${JSON.stringify(workday.id)}`);
+
+  // detect() — valid Workday URLs
+  const hitUs = workday.detect({ name: 'Acme', careers_url: 'https://acme.wd12.myworkdayjobs.com/en-US/acme-jobs' });
+  if (hitUs && hitUs.url === 'https://acme.wd12.myworkdayjobs.com/wday/cxs/acme/acme-jobs/jobs') {
+    pass('workday.detect() resolves wd12 URL to CXS API endpoint');
+  } else {
+    fail(`workday.detect(wd12) returned ${JSON.stringify(hitUs)}`);
+  }
+
+  const hitNoLocale = workday.detect({ name: 'Test', careers_url: 'https://test.wd5.myworkdayjobs.com/TestBoard' });
+  if (hitNoLocale && hitNoLocale.url === 'https://test.wd5.myworkdayjobs.com/wday/cxs/test/TestBoard/jobs') {
+    pass('workday.detect() works without locale segment in path');
+  } else {
+    fail(`workday.detect(no-locale) returned ${JSON.stringify(hitNoLocale)}`);
+  }
+
+  // detect() — null cases
+  if (workday.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('workday.detect() returns null for non-Workday URL');
+  } else {
+    fail('workday.detect() should return null for non-Workday URL');
+  }
+
+  // Path-spoofed URL: myworkdayjobs.com in path, not hostname
+  if (workday.detect({ name: 'Spoof', careers_url: 'https://evil.example/test.wd5.myworkdayjobs.com/en-US/board' }) === null) {
+    pass('workday.detect() rejects path-spoofed URL');
+  } else {
+    fail('workday.detect() must NOT detect path-spoofed URLs');
+  }
+
+  // Non-string careers_url
+  if (workday.detect({ name: 'X', careers_url: null }) === null && workday.detect({ name: 'X' }) === null) {
+    pass('workday.detect() returns null for null / missing careers_url');
+  } else {
+    fail('workday.detect() should return null for non-string careers_url');
+  }
+
+  // parseWorkdayResponse — normalization
+  const sampleJson = {
+    jobPostings: [
+      { title: 'Senior QA Engineer', externalPath: '/job/board/Senior-QA-Engineer_JR001', locationsText: 'Berlin, Germany', postedOn: 'Posted 2 Days Ago' },
+      { title: 'Lead Developer', externalPath: '/job/board/Lead-Developer_JR002', locationsText: 'Remote' },
+      { title: '', externalPath: '/job/board/No-Title_JR003' },          // no title — skip
+      { title: 'No Path Role', externalPath: '' },                        // no externalPath — skip
+      { title: 'Also No Path' },                                          // undefined externalPath — skip
+    ],
+  };
+  const entry = { name: 'Acme', careers_url: 'https://acme.wd12.myworkdayjobs.com/en-US/acme-jobs' };
+  const parsed = parseWorkdayResponse(sampleJson, entry);
+
+  if (parsed.length === 2) pass('parseWorkdayResponse extracts 2 valid jobs (skips missing title/path)');
+  else fail(`parseWorkdayResponse returned ${parsed.length} jobs, expected 2`);
+
+  if (parsed[0].title === 'Senior QA Engineer' && parsed[0].location === 'Berlin, Germany') {
+    pass('parseWorkdayResponse maps title and location');
+  } else {
+    fail(`row 0 = ${JSON.stringify(parsed[0])}`);
+  }
+
+  if (parsed[0].url.includes('acme-jobs') && parsed[0].url.includes('/job/board/Senior-QA-Engineer_JR001')) {
+    pass('parseWorkdayResponse builds URL from jobBase + externalPath');
+  } else {
+    fail(`row 0 url = ${JSON.stringify(parsed[0].url)}`);
+  }
+
+  if (parsed[0].company === 'Acme') pass('parseWorkdayResponse sets company from entry.name');
+  else fail(`parseWorkdayResponse company = ${JSON.stringify(parsed[0].company)}`);
+
+  // parseWorkdayResponse — location fallback from URL path
+  const noLocEntry = { name: 'Globex', careers_url: 'https://globex.wd103.myworkdayjobs.com/globexcareers' };
+  const noLocJson = {
+    jobPostings: [
+      { title: 'Quality Engineer', externalPath: '/job/Mumbai/Quality-Engineer_ATCI-123' },           // no locationsText
+      { title: 'Test Lead', externalPath: '/job/Remote-Poland/Test-Lead_ATCI-456', locationsText: '' }, // empty locationsText
+      { title: 'QA Analyst', externalPath: '/job/Remote-Hungary/QA-Analyst_ATCI-789', locationsText: 'Remote, Hungary' }, // has locationsText — use it
+    ],
+  };
+  const noLocParsed = parseWorkdayResponse(noLocJson, noLocEntry);
+  if (noLocParsed[0]?.location === 'Mumbai') pass('parseWorkdayResponse falls back to URL path location when locationsText absent');
+  else fail(`parseWorkdayResponse path fallback: expected "Mumbai", got ${JSON.stringify(noLocParsed[0]?.location)}`);
+  if (noLocParsed[1]?.location === 'Remote Poland') pass('parseWorkdayResponse falls back to URL path location when locationsText empty');
+  else fail(`parseWorkdayResponse path fallback empty: expected "Remote Poland", got ${JSON.stringify(noLocParsed[1]?.location)}`);
+  if (noLocParsed[2]?.location === 'Remote, Hungary') pass('parseWorkdayResponse prefers locationsText over URL path when present');
+  else fail(`parseWorkdayResponse locationsText priority: expected "Remote, Hungary", got ${JSON.stringify(noLocParsed[2]?.location)}`);
+
+  // parseWorkdayResponse — empty / malformed input
+  if (parseWorkdayResponse({}, entry).length === 0) pass('parseWorkdayResponse({}) → empty result');
+  else fail('parseWorkdayResponse({}) should be empty');
+
+  if (parseWorkdayResponse({ jobPostings: null }, entry).length === 0) {
+    pass('parseWorkdayResponse handles null jobPostings');
+  } else {
+    fail('parseWorkdayResponse null jobPostings should be empty');
+  }
+
+  // fetch() with mock ctx — uses total field to bound sequential pagination
+  let postRequests = 0;
+  const capturedRedirects = [];
+  const mockCtx = {
+    transport: 'http',
+    fetchText: async () => { throw new Error('fetchText should not be called'); },
+    fetchJson: async (_url, opts) => {
+      postRequests++;
+      capturedRedirects.push(opts?.redirect);
+      const body = JSON.parse(opts.body);
+      if (body.offset === 0) {
+        return { total: 30, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job P1-${i}`, externalPath: `/job/board/p1-${i}` })) };
+      }
+      return { total: 30, jobPostings: Array.from({ length: 10 }, (_, i) => ({ title: `Job P2-${i}`, externalPath: `/job/board/p2-${i}` })) };
+    },
+  };
+  const fetchedJobs = await workday.fetch(entry, mockCtx);
+  if (postRequests === 2 && fetchedJobs.length === 30) {
+    pass('workday.fetch() uses total field to fetch exact pages sequentially (20+10=30)');
+  } else {
+    fail(`fetch pagination: requests=${postRequests}, total=${fetchedJobs.length} (expected 2 requests / 30 jobs)`);
+  }
+
+  if (capturedRedirects.length === 2 && capturedRedirects.every(r => r === 'error')) {
+    pass('workday.fetch() passes redirect:"error" on every page (SSRF guard)');
+  } else {
+    fail(`workday.fetch() redirect opts across pages = ${JSON.stringify(capturedRedirects)}`);
+  }
+
+  // parseWorkdayResponse — null/undefined entries in jobPostings must be
+  // skipped, not crash
+  const sparseWorkday = { jobPostings: [null, undefined, { title: 'Real Job', externalPath: '/job/board/real-job' }] };
+  try {
+    const parsedSparseWorkday = parseWorkdayResponse(sparseWorkday, entry);
+    if (parsedSparseWorkday.length === 1 && parsedSparseWorkday[0].title === 'Real Job') {
+      pass('parseWorkdayResponse skips null/undefined entries without crashing');
+    } else {
+      fail(`parseWorkdayResponse sparse result = ${JSON.stringify(parsedSparseWorkday)}`);
+    }
+  } catch (e2) {
+    fail(`parseWorkdayResponse should not throw on null/undefined entries: ${e2.message}`);
+  }
+
+  // fetch() pagination cap — an inflated `total` must not trigger unbounded
+  // requests (DEFAULT_MAX_PAGES = 50 in providers/workday.mjs), and hitting
+  // the cap must be visible (console.error), not silent — a real tenant
+  // (Deutsche Bank, total=1030) already exceeds the 50-page/1000-job default.
+  let hugeWorkdayRequests = 0;
+  const capturedWarnings = [];
+  const originalConsoleError = console.error;
+  console.error = (msg) => capturedWarnings.push(msg);
+  let fetchedHugeWorkday;
+  try {
+    fetchedHugeWorkday = await workday.fetch(entry, {
+      transport: 'http',
+      fetchText: async () => { throw new Error('not expected'); },
+      fetchJson: async () => {
+        hugeWorkdayRequests++;
+        return { total: 1_000_000, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}` })) };
+      },
+    });
+  } finally {
+    console.error = originalConsoleError;
+  }
+  if (hugeWorkdayRequests === 50 && fetchedHugeWorkday.length === 1000) {
+    pass('workday.fetch() caps pagination at DEFAULT_MAX_PAGES despite an inflated total');
+  } else {
+    fail(`workday fetch pagination cap: requests=${hugeWorkdayRequests}, total=${fetchedHugeWorkday.length} (expected 50/1000)`);
+  }
+  if (capturedWarnings.some(w => /has more postings than max_pages allows/.test(w))) {
+    pass('workday.fetch() warns (console.error) when the cap truncates real results');
+  } else {
+    fail(`workday fetch cap: expected a truncation warning, got ${JSON.stringify(capturedWarnings)}`);
+  }
+
+  // fetch() pagination cap — entry.max_pages raises the cap for a genuinely
+  // large tenant (e.g. Deutsche Bank-scale postings)
+  let overriddenWorkdayRequests = 0;
+  const bigWorkdayEntry = { name: 'BigCo', careers_url: 'https://bigco.wd5.myworkdayjobs.com/careers', max_pages: 80 };
+  const fetchedOverriddenWorkday = await workday.fetch(bigWorkdayEntry, {
+    transport: 'http',
+    fetchText: async () => { throw new Error('not expected'); },
+    fetchJson: async () => {
+      overriddenWorkdayRequests++;
+      return { total: 1_000_000, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}` })) };
+    },
+  });
+  if (overriddenWorkdayRequests === 80 && fetchedOverriddenWorkday.length === 1600) {
+    pass('workday.fetch() honors entry.max_pages to raise the cap above the default');
+  } else {
+    fail(`workday fetch max_pages override: requests=${overriddenWorkdayRequests}, total=${fetchedOverriddenWorkday.length} (expected 80/1600)`);
+  }
+
+  // fetch() pagination — a failure on a later page returns the jobs gathered
+  // so far instead of discarding everything (sequential, not Promise.all),
+  // and the failure itself is visible (console.error), not silent.
+  let flakyWorkdayRequests = 0;
+  const flakyWarnings = [];
+  console.error = (msg) => flakyWarnings.push(msg);
+  let flakyWorkdayJobs;
+  try {
+    flakyWorkdayJobs = await workday.fetch(entry, {
+      transport: 'http',
+      fetchText: async () => { throw new Error('not expected'); },
+      fetchJson: async (_url, opts) => {
+        flakyWorkdayRequests++;
+        const body = JSON.parse(opts.body);
+        const page = body.offset / 20; // PAGE_SIZE in providers/workday.mjs
+        if (page === 2) throw new Error('HTTP 503');
+        return { total: 80, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job p${page}-${i}`, externalPath: `/job/board/p${page}-${i}` })) };
+      },
+    });
+  } finally {
+    console.error = originalConsoleError;
+  }
+  if (flakyWorkdayRequests === 3 && flakyWorkdayJobs.length === 40) {
+    pass('workday.fetch() returns partial results when a later page fails');
+  } else {
+    fail(`workday fetch partial failure: requests=${flakyWorkdayRequests}, total=${flakyWorkdayJobs.length} (expected 3/40)`);
+  }
+  if (flakyWarnings.some(w => /page \d+ fetch failed/.test(w))) {
+    pass('workday.fetch() warns (console.error) when a page fetch fails mid-pagination');
+  } else {
+    fail(`workday fetch page failure: expected a fetch-failed warning, got ${JSON.stringify(flakyWarnings)}`);
+  }
+
+  // Verify POST method was used
+  let capturedMethod = null;
+  await workday.fetch(entry, {
+    transport: 'http',
+    fetchText: async () => '',
+    fetchJson: async (_url, opts) => { capturedMethod = opts?.method; return { total: 0, jobPostings: [] }; },
+  });
+  if (capturedMethod === 'POST') pass('workday.fetch() uses POST method');
+  else fail(`workday.fetch() method is ${JSON.stringify(capturedMethod)}, expected POST`);
+
+  // Fallback: no total field — paginate sequentially until short page
+  let fallbackRequests = 0;
+  const fallbackJobs = await workday.fetch(entry, {
+    transport: 'http',
+    fetchText: async () => { throw new Error('not expected'); },
+    fetchJson: async (_url, opts) => {
+      fallbackRequests++;
+      const body = JSON.parse(opts.body);
+      if (body.offset === 0) return { jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `FB P1-${i}`, externalPath: `/job/board/fb-${i}` })) };
+      return { jobPostings: Array.from({ length: 5 }, (_, i) => ({ title: `FB P2-${i}`, externalPath: `/job/board/fb2-${i}` })) };
+    },
+  });
+  if (fallbackRequests === 2 && fallbackJobs.length === 25) {
+    pass('workday.fetch() fallback (no total): paginates sequentially, stops on short page (20+5=25)');
+  } else {
+    fail(`fallback pagination: requests=${fallbackRequests}, jobs=${fallbackJobs.length} (expected 2/25)`);
+  }
+
+} catch (e) {
+  fail(`workday provider tests crashed: ${e.message}`);
 }
 
 // ── SUMMARY ─────────────────────────────────────────────────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10051,6 +10051,24 @@ try {
     fail(`workday retry-after: expected first backoff delay 1000ms, got ${JSON.stringify(retrySleepCalls)}`);
   }
 
+  // fetch() retry — a hostile or misconfigured Retry-After (e.g. 86400s = a
+  // full day) must not be honored verbatim: it's clamped to
+  // RETRY_MAX_DELAY_MS * 4 (32s) so a single bad header can't stall a
+  // tenant's fetch indefinitely, defeating the point of a bounded backoff.
+  let hostileRetrySleepCalls = [];
+  let hostileRetryAttempts = 0;
+  const hostileRetryEntry = { name: 'HostileRetryCo', careers_url: 'https://hostileretryco.wd5.myworkdayjobs.com/careers' };
+  await workday.fetch(hostileRetryEntry, mkWorkdayCtx(async () => {
+    hostileRetryAttempts++;
+    if (hostileRetryAttempts === 1) { const err = new Error('HTTP 429'); err.status = 429; err.retryAfter = '86400'; throw err; }
+    return { total: 0, jobPostings: [] };
+  }, { sleep: async (ms) => { hostileRetrySleepCalls.push(ms); } }));
+  if (hostileRetrySleepCalls[0] === 32_000) {
+    pass('workday.fetch() clamps an oversized Retry-After to RETRY_MAX_DELAY_MS * 4');
+  } else {
+    fail(`workday retry-after clamp: expected 32000ms, got ${JSON.stringify(hostileRetrySleepCalls)}`);
+  }
+
   // fetch() retry — a non-retryable 4xx (e.g. malformed request) breaks
   // immediately, without wasting retry attempts.
   let non429Attempts = 0;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9742,6 +9742,13 @@ try {
   const workday = (await import(pathToFileURL(join(ROOT, 'providers/workday.mjs')).href)).default;
   const { parseWorkdayResponse } = await import(pathToFileURL(join(ROOT, 'providers/workday.mjs')).href);
 
+  // Shared mock ctx shape for workday.fetch() calls below — only fetchJson varies per test.
+  const mkWorkdayCtx = (fetchJson) => ({
+    transport: 'http',
+    fetchText: async () => { throw new Error('fetchText should not be called'); },
+    fetchJson,
+  });
+
   if (workday.id === 'workday') pass('workday.id is "workday"');
   else fail(`workday.id is ${JSON.stringify(workday.id)}`);
 
@@ -9842,20 +9849,15 @@ try {
   // fetch() with mock ctx — uses total field to bound sequential pagination
   let postRequests = 0;
   const capturedRedirects = [];
-  const mockCtx = {
-    transport: 'http',
-    fetchText: async () => { throw new Error('fetchText should not be called'); },
-    fetchJson: async (_url, opts) => {
-      postRequests++;
-      capturedRedirects.push(opts?.redirect);
-      const body = JSON.parse(opts.body);
-      if (body.offset === 0) {
-        return { total: 30, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job P1-${i}`, externalPath: `/job/board/p1-${i}` })) };
-      }
-      return { total: 30, jobPostings: Array.from({ length: 10 }, (_, i) => ({ title: `Job P2-${i}`, externalPath: `/job/board/p2-${i}` })) };
-    },
-  };
-  const fetchedJobs = await workday.fetch(entry, mockCtx);
+  const fetchedJobs = await workday.fetch(entry, mkWorkdayCtx(async (_url, opts) => {
+    postRequests++;
+    capturedRedirects.push(opts?.redirect);
+    const body = JSON.parse(opts.body);
+    if (body.offset === 0) {
+      return { total: 30, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job P1-${i}`, externalPath: `/job/board/p1-${i}` })) };
+    }
+    return { total: 30, jobPostings: Array.from({ length: 10 }, (_, i) => ({ title: `Job P2-${i}`, externalPath: `/job/board/p2-${i}` })) };
+  }));
   if (postRequests === 2 && fetchedJobs.length === 30) {
     pass('workday.fetch() uses total field to fetch exact pages sequentially (20+10=30)');
   } else {
@@ -9892,14 +9894,10 @@ try {
   console.error = (msg) => capturedWarnings.push(msg);
   let fetchedHugeWorkday;
   try {
-    fetchedHugeWorkday = await workday.fetch(entry, {
-      transport: 'http',
-      fetchText: async () => { throw new Error('not expected'); },
-      fetchJson: async () => {
-        hugeWorkdayRequests++;
-        return { total: 1_000_000, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}` })) };
-      },
-    });
+    fetchedHugeWorkday = await workday.fetch(entry, mkWorkdayCtx(async () => {
+      hugeWorkdayRequests++;
+      return { total: 1_000_000, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}` })) };
+    }));
   } finally {
     console.error = originalConsoleError;
   }
@@ -9918,18 +9916,47 @@ try {
   // large tenant (e.g. Deutsche Bank-scale postings)
   let overriddenWorkdayRequests = 0;
   const bigWorkdayEntry = { name: 'BigCo', careers_url: 'https://bigco.wd5.myworkdayjobs.com/careers', max_pages: 80 };
-  const fetchedOverriddenWorkday = await workday.fetch(bigWorkdayEntry, {
-    transport: 'http',
-    fetchText: async () => { throw new Error('not expected'); },
-    fetchJson: async () => {
-      overriddenWorkdayRequests++;
-      return { total: 1_000_000, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}` })) };
-    },
-  });
+  const fetchedOverriddenWorkday = await workday.fetch(bigWorkdayEntry, mkWorkdayCtx(async () => {
+    overriddenWorkdayRequests++;
+    return { total: 1_000_000, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}` })) };
+  }));
   if (overriddenWorkdayRequests === 80 && fetchedOverriddenWorkday.length === 1600) {
     pass('workday.fetch() honors entry.max_pages to raise the cap above the default');
   } else {
     fail(`workday fetch max_pages override: requests=${overriddenWorkdayRequests}, total=${fetchedOverriddenWorkday.length} (expected 80/1600)`);
+  }
+
+  // entry.max_pages is itself capped (MAX_PAGES_CAP = 500) — an absurd override
+  // can't turn this into an unbounded scan either.
+  let absurdWorkdayRequests = 0;
+  const absurdWorkdayEntry = { name: 'AbsurdCo', careers_url: 'https://absurdco.wd5.myworkdayjobs.com/careers', max_pages: 100_000 };
+  const fetchedAbsurdWorkday = await workday.fetch(absurdWorkdayEntry, mkWorkdayCtx(async () => {
+    absurdWorkdayRequests++;
+    return { total: 10_000_000, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}` })) };
+  }));
+  if (absurdWorkdayRequests === 500 && fetchedAbsurdWorkday.length === 10_000) {
+    pass('workday.fetch() caps an absurd entry.max_pages at MAX_PAGES_CAP');
+  } else {
+    fail(`workday fetch max_pages hard cap: requests=${absurdWorkdayRequests}, total=${fetchedAbsurdWorkday.length} (expected 500/10000)`);
+  }
+
+  // Invalid max_pages values (negative, zero, non-numeric) fall back to
+  // DEFAULT_MAX_PAGES, same as omitting max_pages entirely.
+  for (const invalidMaxPages of [-5, 0, 'abc', NaN, null]) {
+    let invalidRequests = 0;
+    const invalidEntry = { name: 'InvalidCo', careers_url: 'https://invalidco.wd5.myworkdayjobs.com/careers', max_pages: invalidMaxPages };
+    const fetchedInvalid = await workday.fetch(invalidEntry, mkWorkdayCtx(async () => {
+      invalidRequests++;
+      return { total: 1_000_000, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}` })) };
+    }));
+    // Number.isNaN(NaN) is true but JSON.stringify(NaN) === 'null', which would
+    // be indistinguishable from the literal `null` case in the log below.
+    const label = Number.isNaN(invalidMaxPages) ? 'NaN' : JSON.stringify(invalidMaxPages);
+    if (invalidRequests === 50 && fetchedInvalid.length === 1000) {
+      pass(`workday.fetch() falls back to DEFAULT_MAX_PAGES for invalid max_pages=${label}`);
+    } else {
+      fail(`workday fetch invalid max_pages=${label}: requests=${invalidRequests}, total=${fetchedInvalid.length} (expected 50/1000)`);
+    }
   }
 
   // fetch() pagination — a failure on a later page returns the jobs gathered
@@ -9940,17 +9967,13 @@ try {
   console.error = (msg) => flakyWarnings.push(msg);
   let flakyWorkdayJobs;
   try {
-    flakyWorkdayJobs = await workday.fetch(entry, {
-      transport: 'http',
-      fetchText: async () => { throw new Error('not expected'); },
-      fetchJson: async (_url, opts) => {
-        flakyWorkdayRequests++;
-        const body = JSON.parse(opts.body);
-        const page = body.offset / 20; // PAGE_SIZE in providers/workday.mjs
-        if (page === 2) throw new Error('HTTP 503');
-        return { total: 80, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job p${page}-${i}`, externalPath: `/job/board/p${page}-${i}` })) };
-      },
-    });
+    flakyWorkdayJobs = await workday.fetch(entry, mkWorkdayCtx(async (_url, opts) => {
+      flakyWorkdayRequests++;
+      const body = JSON.parse(opts.body);
+      const page = body.offset / 20; // PAGE_SIZE in providers/workday.mjs
+      if (page === 2) throw new Error('HTTP 503');
+      return { total: 80, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job p${page}-${i}`, externalPath: `/job/board/p${page}-${i}` })) };
+    }));
   } finally {
     console.error = originalConsoleError;
   }
@@ -9967,26 +9990,18 @@ try {
 
   // Verify POST method was used
   let capturedMethod = null;
-  await workday.fetch(entry, {
-    transport: 'http',
-    fetchText: async () => '',
-    fetchJson: async (_url, opts) => { capturedMethod = opts?.method; return { total: 0, jobPostings: [] }; },
-  });
+  await workday.fetch(entry, mkWorkdayCtx(async (_url, opts) => { capturedMethod = opts?.method; return { total: 0, jobPostings: [] }; }));
   if (capturedMethod === 'POST') pass('workday.fetch() uses POST method');
   else fail(`workday.fetch() method is ${JSON.stringify(capturedMethod)}, expected POST`);
 
   // Fallback: no total field — paginate sequentially until short page
   let fallbackRequests = 0;
-  const fallbackJobs = await workday.fetch(entry, {
-    transport: 'http',
-    fetchText: async () => { throw new Error('not expected'); },
-    fetchJson: async (_url, opts) => {
-      fallbackRequests++;
-      const body = JSON.parse(opts.body);
-      if (body.offset === 0) return { jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `FB P1-${i}`, externalPath: `/job/board/fb-${i}` })) };
-      return { jobPostings: Array.from({ length: 5 }, (_, i) => ({ title: `FB P2-${i}`, externalPath: `/job/board/fb2-${i}` })) };
-    },
-  });
+  const fallbackJobs = await workday.fetch(entry, mkWorkdayCtx(async (_url, opts) => {
+    fallbackRequests++;
+    const body = JSON.parse(opts.body);
+    if (body.offset === 0) return { jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `FB P1-${i}`, externalPath: `/job/board/fb-${i}` })) };
+    return { jobPostings: Array.from({ length: 5 }, (_, i) => ({ title: `FB P2-${i}`, externalPath: `/job/board/fb2-${i}` })) };
+  }));
   if (fallbackRequests === 2 && fallbackJobs.length === 25) {
     pass('workday.fetch() fallback (no total): paginates sequentially, stops on short page (20+5=25)');
   } else {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9743,10 +9743,13 @@ try {
   const { parseWorkdayResponse } = await import(pathToFileURL(join(ROOT, 'providers/workday.mjs')).href);
 
   // Shared mock ctx shape for workday.fetch() calls below — only fetchJson varies per test.
-  const mkWorkdayCtx = (fetchJson) => ({
+  // sleep is a no-op so retry-backoff delays don't slow the test suite down.
+  const mkWorkdayCtx = (fetchJson, extra = {}) => ({
     transport: 'http',
     fetchText: async () => { throw new Error('fetchText should not be called'); },
     fetchJson,
+    sleep: async () => {},
+    ...extra,
   });
 
   if (workday.id === 'workday') pass('workday.id is "workday"');
@@ -9905,9 +9908,10 @@ try {
   }
 
   // fetch() pagination cap — an inflated `total` must not trigger unbounded
-  // requests (DEFAULT_MAX_PAGES = 50 in providers/workday.mjs), and hitting
-  // the cap must be visible (console.error), not silent — a real tenant
-  // (Deutsche Bank, total=1030) already exceeds the 50-page/1000-job default.
+  // requests (DEFAULT_MAX_PAGES = 100 in providers/workday.mjs), and hitting
+  // the cap must be visible (console.error), not silent — real tenants
+  // (Dollar Tree, total=23,609; CVS Health, total=16,974) already exceed the
+  // 100-page/2000-job default.
   let hugeWorkdayRequests = 0;
   const capturedWarnings = [];
   const originalConsoleError = console.error;
@@ -9921,12 +9925,12 @@ try {
   } finally {
     console.error = originalConsoleError;
   }
-  if (hugeWorkdayRequests === 50 && fetchedHugeWorkday.length === 1000) {
+  if (hugeWorkdayRequests === 100 && fetchedHugeWorkday.length === 2000) {
     pass('workday.fetch() caps pagination at DEFAULT_MAX_PAGES despite an inflated total');
   } else {
-    fail(`workday fetch pagination cap: requests=${hugeWorkdayRequests}, total=${fetchedHugeWorkday.length} (expected 50/1000)`);
+    fail(`workday fetch pagination cap: requests=${hugeWorkdayRequests}, total=${fetchedHugeWorkday.length} (expected 100/2000)`);
   }
-  if (capturedWarnings.some(w => /has more postings than max_pages allows/.test(w))) {
+  if (capturedWarnings.some(w => /truncated at max_pages=\d+/.test(w))) {
     pass('workday.fetch() warns (console.error) when the cap truncates real results');
   } else {
     fail(`workday fetch cap: expected a truncation warning, got ${JSON.stringify(capturedWarnings)}`);
@@ -9946,18 +9950,18 @@ try {
     fail(`workday fetch max_pages override: requests=${overriddenWorkdayRequests}, total=${fetchedOverriddenWorkday.length} (expected 80/1600)`);
   }
 
-  // entry.max_pages is itself capped (MAX_PAGES_CAP = 500) — an absurd override
-  // can't turn this into an unbounded scan either.
+  // entry.max_pages is itself capped (MAX_PAGES_CAP = 1500) — an absurd
+  // override can't turn this into an unbounded scan either.
   let absurdWorkdayRequests = 0;
   const absurdWorkdayEntry = { name: 'AbsurdCo', careers_url: 'https://absurdco.wd5.myworkdayjobs.com/careers', max_pages: 100_000 };
   const fetchedAbsurdWorkday = await workday.fetch(absurdWorkdayEntry, mkWorkdayCtx(async () => {
     absurdWorkdayRequests++;
     return { total: 10_000_000, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}` })) };
   }));
-  if (absurdWorkdayRequests === 500 && fetchedAbsurdWorkday.length === 10_000) {
+  if (absurdWorkdayRequests === 1500 && fetchedAbsurdWorkday.length === 30_000) {
     pass('workday.fetch() caps an absurd entry.max_pages at MAX_PAGES_CAP');
   } else {
-    fail(`workday fetch max_pages hard cap: requests=${absurdWorkdayRequests}, total=${fetchedAbsurdWorkday.length} (expected 500/10000)`);
+    fail(`workday fetch max_pages hard cap: requests=${absurdWorkdayRequests}, total=${fetchedAbsurdWorkday.length} (expected 1500/30000)`);
   }
 
   // Invalid max_pages values (negative, zero, non-numeric) fall back to
@@ -9972,16 +9976,19 @@ try {
     // Number.isNaN(NaN) is true but JSON.stringify(NaN) === 'null', which would
     // be indistinguishable from the literal `null` case in the log below.
     const label = Number.isNaN(invalidMaxPages) ? 'NaN' : JSON.stringify(invalidMaxPages);
-    if (invalidRequests === 50 && fetchedInvalid.length === 1000) {
+    if (invalidRequests === 100 && fetchedInvalid.length === 2000) {
       pass(`workday.fetch() falls back to DEFAULT_MAX_PAGES for invalid max_pages=${label}`);
     } else {
-      fail(`workday fetch invalid max_pages=${label}: requests=${invalidRequests}, total=${fetchedInvalid.length} (expected 50/1000)`);
+      fail(`workday fetch invalid max_pages=${label}: requests=${invalidRequests}, total=${fetchedInvalid.length} (expected 100/2000)`);
     }
   }
 
-  // fetch() pagination — a failure on a later page returns the jobs gathered
-  // so far instead of discarding everything (sequential, not Promise.all),
-  // and the failure itself is visible (console.error), not silent.
+  // fetch() pagination — a failure that persists across every retry attempt
+  // on a later page returns the jobs gathered so far instead of discarding
+  // everything (sequential, not Promise.all), retries MAX_RETRIES+1=4 times
+  // on that page before giving up, and the failure itself is visible
+  // (console.error), not silent. The truncation ("raise max_pages") warning
+  // must NOT also fire — that knob does nothing for a rate-limited tenant.
   let flakyWorkdayRequests = 0;
   const flakyWarnings = [];
   console.error = (msg) => flakyWarnings.push(msg);
@@ -9991,21 +9998,274 @@ try {
       flakyWorkdayRequests++;
       const body = JSON.parse(opts.body);
       const page = body.offset / 20; // PAGE_SIZE in providers/workday.mjs
-      if (page === 2) throw new Error('HTTP 503');
+      if (page === 2) { const err = new Error('HTTP 503'); err.status = 503; throw err; }
       return { total: 80, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job p${page}-${i}`, externalPath: `/job/board/p${page}-${i}` })) };
     }));
   } finally {
     console.error = originalConsoleError;
   }
-  if (flakyWorkdayRequests === 3 && flakyWorkdayJobs.length === 40) {
-    pass('workday.fetch() returns partial results when a later page fails');
+  if (flakyWorkdayRequests === 6 && flakyWorkdayJobs.length === 40) {
+    pass('workday.fetch() retries a failing page 4x then returns partial results');
   } else {
-    fail(`workday fetch partial failure: requests=${flakyWorkdayRequests}, total=${flakyWorkdayJobs.length} (expected 3/40)`);
+    fail(`workday fetch partial failure: requests=${flakyWorkdayRequests}, total=${flakyWorkdayJobs.length} (expected 6/40)`);
   }
-  if (flakyWarnings.some(w => /page \d+ fetch failed/.test(w))) {
-    pass('workday.fetch() warns (console.error) when a page fetch fails mid-pagination');
+  if (flakyWarnings.some(w => /truncated at \d+ of \d+ pages after 4 attempts/.test(w))) {
+    pass('workday.fetch() warns (console.error) when a page fetch fails after exhausting retries, with the attempt count');
   } else {
     fail(`workday fetch page failure: expected a fetch-failed warning, got ${JSON.stringify(flakyWarnings)}`);
+  }
+  // The failure message must show scale — which page out of how many were
+  // planned, and how many jobs came back out of the tenant's real total —
+  // not just "page 3, 40 jobs" with no sense of how much was actually lost.
+  // Same "truncated at ... (N of M jobs)" shape as the cap-hit warning below,
+  // so the two read consistently.
+  if (flakyWarnings.some(w => /truncated at 3 of 4 pages after 4 attempts \(40 of 80 jobs\): HTTP 503/.test(w))) {
+    pass('workday.fetch() fetch-failure warning reports scale (page X of Y, N of total jobs)');
+  } else {
+    fail(`workday fetch-failure warning missing scale context: ${JSON.stringify(flakyWarnings)}`);
+  }
+  if (!flakyWarnings.some(w => /raise max_pages/.test(w))) {
+    pass('workday.fetch() does NOT fire the "raise max_pages" warning on a fetch-error stop');
+  } else {
+    fail(`workday fetch-error stop should not also warn about max_pages: ${JSON.stringify(flakyWarnings)}`);
+  }
+
+  // fetch() retry — a 429 that succeeds on a later attempt is transparent to
+  // the caller (no jobs lost, no error surfaced) and respects Retry-After.
+  let retrySleepCalls = [];
+  let retryAttempts = 0;
+  const retryEntry = { name: 'RetryCo', careers_url: 'https://retryco.wd5.myworkdayjobs.com/careers' };
+  const retryJobs = await workday.fetch(retryEntry, mkWorkdayCtx(async () => {
+    retryAttempts++;
+    if (retryAttempts === 1) { const err = new Error('HTTP 429'); err.status = 429; err.retryAfter = '1'; throw err; }
+    return { total: 1, jobPostings: [{ title: 'Recovered Job', externalPath: '/job/board/recovered' }] };
+  }, { sleep: async (ms) => { retrySleepCalls.push(ms); } }));
+  if (retryAttempts === 2 && retryJobs.length === 1 && retryJobs[0].title === 'Recovered Job') {
+    pass('workday.fetch() retries a 429 and recovers transparently');
+  } else {
+    fail(`workday 429 retry: attempts=${retryAttempts}, jobs=${JSON.stringify(retryJobs)}`);
+  }
+  if (retrySleepCalls[0] === 1000) {
+    pass('workday.fetch() honors Retry-After header for backoff delay');
+  } else {
+    fail(`workday retry-after: expected first backoff delay 1000ms, got ${JSON.stringify(retrySleepCalls)}`);
+  }
+
+  // fetch() retry — a non-retryable 4xx (e.g. malformed request) breaks
+  // immediately, without wasting retry attempts.
+  let non429Attempts = 0;
+  const non429Warnings = [];
+  console.error = (msg) => non429Warnings.push(msg);
+  let non429Jobs;
+  try {
+    non429Jobs = await workday.fetch(entry, mkWorkdayCtx(async (_url, opts) => {
+      non429Attempts++;
+      const body = JSON.parse(opts.body);
+      if (body.offset === 0) return { total: 40, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}` })) };
+      const err = new Error('HTTP 400: bad request'); err.status = 400; throw err;
+    }));
+  } finally {
+    console.error = originalConsoleError;
+  }
+  if (non429Attempts === 2 && non429Jobs.length === 20) {
+    pass('workday.fetch() does not retry a non-retryable 4xx error');
+  } else {
+    fail(`workday non-retryable 4xx: attempts=${non429Attempts}, jobs=${non429Jobs.length} (expected 2/20)`);
+  }
+
+  // fetch() early-stop — once a page's postings are all clearly past
+  // ctx.sinceMs, pagination stops without hitting max_pages, and the
+  // "raise max_pages" warning does NOT fire (this isn't a cap hit).
+  const SINCE_DAYS = 3; // mirrors scan-ats-full.mjs's --since default
+  const nowMs = Date.now();
+  const sinceMs = nowMs - SINCE_DAYS * 86_400_000;
+  let earlyStopRequests = 0;
+  const earlyStopWarnings = [];
+  console.error = (msg) => earlyStopWarnings.push(msg);
+  let earlyStopJobs;
+  try {
+    earlyStopJobs = await workday.fetch(entry, mkWorkdayCtx(async (_url, opts) => {
+      earlyStopRequests++;
+      const body = JSON.parse(opts.body);
+      const page = body.offset / 20;
+      if (page === 0) {
+        // Page 0: fresh postings, well within the window.
+        return { total: 1_000_000, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Fresh ${i}`, externalPath: `/job/board/fresh-${i}`, postedOn: 'Posted Today' })) };
+      }
+      // Every later page: clearly stale (well past sinceMs - margin) — if
+      // early-stop didn't work, this mock would be asked for 100 pages.
+      return { total: 1_000_000, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Stale ${i}`, externalPath: `/job/board/stale-${i}`, postedOn: 'Posted 20 Days Ago' })) };
+    }, { sinceMs }));
+  } finally {
+    console.error = originalConsoleError;
+  }
+  if (earlyStopRequests === 2 && earlyStopJobs.length === 40) {
+    pass('workday.fetch() stops paginating once a page is past --since (early-stop)');
+  } else {
+    fail(`workday early-stop: requests=${earlyStopRequests}, jobs=${earlyStopJobs.length} (expected 2/40)`);
+  }
+  if (!earlyStopWarnings.some(w => /truncated at/.test(w))) {
+    pass('workday.fetch() does NOT warn about max_pages when it stopped early on --since');
+  } else {
+    fail(`workday early-stop should not warn about max_pages: ${JSON.stringify(earlyStopWarnings)}`);
+  }
+
+  // fetch() early-stop — a wide --since window (>= 30 days) never triggers
+  // early-stop off the unbounded "30+ Days Ago" bucket; pagination still
+  // proceeds until max_pages/total, as before. includeUndated: true isolates
+  // this from the no-date-skip optimization tested separately below — every
+  // posting here is undated ("30+"), which would otherwise short-circuit
+  // after page 1 regardless of --since width.
+  const WIDE_SINCE_DAYS = 90; // >= 30 — past the "30+ Days Ago" bucket's ambiguity threshold
+  const wideSinceMs = nowMs - WIDE_SINCE_DAYS * 86_400_000;
+  let wideRequests = 0;
+  const wideJobs = await workday.fetch(entry, mkWorkdayCtx(async (_url, opts) => {
+    wideRequests++;
+    const body = JSON.parse(opts.body);
+    if (body.offset === 0) {
+      return { total: 40, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Old ${i}`, externalPath: `/job/board/old-${i}`, postedOn: 'Posted 30+ Days Ago' })) };
+    }
+    return { total: 40, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Old2 ${i}`, externalPath: `/job/board/old2-${i}`, postedOn: 'Posted 30+ Days Ago' })) };
+  }, { sinceMs: wideSinceMs, includeUndated: true }));
+  if (wideRequests === 2 && wideJobs.length === 40) {
+    pass('workday.fetch() never early-stops off the unbounded "30+ Days Ago" bucket');
+  } else {
+    fail(`workday wide-since: requests=${wideRequests}, jobs=${wideJobs.length} (expected 2/40)`);
+  }
+
+  // fetch() cap-hit warning — reverse-scan context (ctx.sinceMs set, as
+  // scan-ats-full.mjs always does) where entries are synthesized from an
+  // external dataset, not portals.yml: there's no portal entry to edit, and
+  // — per the "no fixed cap can guarantee full coverage" conclusion — no
+  // fix to advise at all, so the message is just the short fact, with
+  // neither "raise max_pages" nor a portals.yml edit suggested.
+  // includeUndated: true forces this past the no-date-skip short-circuit
+  // (tested separately below) so the fetch actually reaches the cap.
+  const noDateSinceMs = nowMs - SINCE_DAYS * 86_400_000;
+  const noDateWarnings = [];
+  console.error = (msg) => noDateWarnings.push(msg);
+  try {
+    await workday.fetch(entry, mkWorkdayCtx(async () => ({
+      total: 1_000_000,
+      jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `NoDate ${i}`, externalPath: `/job/board/nodate-${i}` })), // no postedOn
+    }), { sinceMs: noDateSinceMs, includeUndated: true }));
+  } finally {
+    console.error = originalConsoleError;
+  }
+  if (noDateWarnings.some(w => /truncated at \d+ pages/.test(w))) {
+    pass('workday.fetch() cap-hit warning fires in reverse-scan context (tenant has no dates, includeUndated on)');
+  } else {
+    fail(`workday no-date cap warning missing: ${JSON.stringify(noDateWarnings)}`);
+  }
+  if (!noDateWarnings.some(w => /raise max_pages|portal entry|portals\.yml/.test(w))) {
+    pass('workday.fetch() reverse-scan cap warning gives no inactionable advice (no portal entry to edit)');
+  } else {
+    fail(`workday reverse-scan cap warning should not suggest editing a portal entry: ${JSON.stringify(noDateWarnings)}`);
+  }
+
+  // fetch() no-date-skip — the default case (includeUndated NOT set, as
+  // scan-ats-full.mjs leaves it by default): a tenant whose first page has
+  // zero dated postings stops right there instead of grinding through up to
+  // maxPages requests whose results would all be dropped as 'undated'
+  // downstream anyway. Only 1 request should fire, not maxPages (100).
+  const skipSinceMs = nowMs - SINCE_DAYS * 86_400_000;
+  let skipRequests = 0;
+  const skipWarnings = [];
+  console.error = (msg) => skipWarnings.push(msg);
+  let skipJobs;
+  try {
+    skipJobs = await workday.fetch(entry, mkWorkdayCtx(async () => {
+      skipRequests++;
+      return {
+        total: 1_000_000,
+        jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `NoDate ${i}`, externalPath: `/job/board/skip-${i}` })), // no postedOn
+      };
+    }, { sinceMs: skipSinceMs })); // includeUndated intentionally omitted — the default, falsy case
+  } finally {
+    console.error = originalConsoleError;
+  }
+  if (skipRequests === 1 && skipJobs.length === 20) {
+    pass('workday.fetch() skips pagination after page 1 when includeUndated is off and the tenant has no dated postings');
+  } else {
+    fail(`workday no-date-skip: requests=${skipRequests}, jobs=${skipJobs.length} (expected 1/20)`);
+  }
+  // A full-directory scan hits this on a large fraction of tenants — a
+  // console.error per occurrence would just be the same line thousands of
+  // times, so the signal is a tag on the returned array instead (aggregated
+  // by scan-ats-full.mjs into one summary line at the end of the run).
+  if (skipJobs.workdayNoDateSkip === true) {
+    pass('workday.fetch() tags the returned jobs array for no-date-skip aggregation');
+  } else {
+    fail(`workday no-date-skip tag missing: jobs.workdayNoDateSkip = ${JSON.stringify(skipJobs.workdayNoDateSkip)}`);
+  }
+  if (skipWarnings.length === 0) {
+    pass('workday.fetch() does not console.error per-company on a no-date-skip (aggregated instead)');
+  } else {
+    fail(`workday no-date-skip should not log anything directly: ${JSON.stringify(skipWarnings)}`);
+  }
+
+  // fetch() no-date-skip — does NOT trigger when includeUndated is true (the
+  // "hit the cap while genuinely undated" scenario above already covers that
+  // the fetch continues in that case); this just re-confirms the gate.
+  let noSkipWithIncludeUndatedRequests = 0;
+  const noSkipJobs = await workday.fetch(entry, mkWorkdayCtx(async (_url, opts) => {
+    noSkipWithIncludeUndatedRequests++;
+    const body = JSON.parse(opts.body);
+    if (body.offset === 0) return { total: 40, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `ND ${i}`, externalPath: `/job/board/nd-${i}` })) };
+    return { total: 40, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `ND2 ${i}`, externalPath: `/job/board/nd2-${i}` })) };
+  }, { sinceMs: skipSinceMs, includeUndated: true }));
+  if (noSkipWithIncludeUndatedRequests === 2 && noSkipJobs.length === 40) {
+    pass('workday.fetch() does not no-date-skip when includeUndated is true');
+  } else {
+    fail(`workday no-date-skip gate: requests=${noSkipWithIncludeUndatedRequests}, jobs=${noSkipJobs.length} (expected 2/40)`);
+  }
+
+  // fetch() cap-hit warning — reverse-scan context, tenant genuinely has
+  // more within --since than the cap allows (total far above the window,
+  // e.g. cvshealth-scale): short line, no suspect-cap tag.
+  const datedCapSinceMs = nowMs - SINCE_DAYS * 86_400_000;
+  const datedCapWarnings = [];
+  console.error = (msg) => datedCapWarnings.push(msg);
+  try {
+    await workday.fetch(entry, mkWorkdayCtx(async () => ({
+      total: 1_000_000,
+      jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Fresh ${i}`, externalPath: `/job/board/fresh-${i}`, postedOn: 'Posted Today' })),
+    }), { sinceMs: datedCapSinceMs }));
+  } finally {
+    console.error = originalConsoleError;
+  }
+  if (datedCapWarnings.some(w => /truncated at \d+ pages \(2000 of 1000000 jobs\)/.test(w))) {
+    pass('workday.fetch() cap-hit warning reports the short "truncated at N pages" form');
+  } else {
+    fail(`workday dated cap-hit warning mismatch: ${JSON.stringify(datedCapWarnings)}`);
+  }
+  if (!datedCapWarnings.some(w => /Workday-capped/.test(w))) {
+    pass('workday.fetch() cap-hit warning omits the suspected-Workday-cap tag when total is far above the window');
+  } else {
+    fail(`workday cap-hit warning should not suspect a Workday-side cap here (total=1,000,000, window=2,000): ${JSON.stringify(datedCapWarnings)}`);
+  }
+
+  // fetch() cap-hit warning — Workday's own CXS backend has been observed
+  // reporting `total` as exactly maxPages*PAGE_SIZE even when the real count
+  // is far higher (verified live: dickssportinggoods reported total=2000 but
+  // its public careers page listed 7,120 openings, and offset=2000/4000
+  // requests returned the same first posting as offset=0 instead of new
+  // results). This exact-match case must carry a distinct, short tag.
+  const suspectCapSinceMs = nowMs - SINCE_DAYS * 86_400_000;
+  const suspectCapWarnings = [];
+  console.error = (msg) => suspectCapWarnings.push(msg);
+  try {
+    await workday.fetch(entry, mkWorkdayCtx(async () => ({
+      total: 2000, // === DEFAULT_MAX_PAGES (100) * PAGE_SIZE (20)
+      jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Suspect ${i}`, externalPath: `/job/board/suspect-${i}`, postedOn: 'Posted Today' })),
+    }), { sinceMs: suspectCapSinceMs }));
+  } finally {
+    console.error = originalConsoleError;
+  }
+  if (suspectCapWarnings.some(w => /\(total may be Workday-capped, not real\)/.test(w))) {
+    pass('workday.fetch() cap-hit warning flags a suspected Workday-side total cap when total === maxPages*PAGE_SIZE');
+  } else {
+    fail(`workday suspected-cap tag missing: ${JSON.stringify(suspectCapWarnings)}`);
   }
 
   // Verify POST method was used
@@ -10030,6 +10290,75 @@ try {
 
 } catch (e) {
   fail(`workday provider tests crashed: ${e.message}`);
+}
+
+// ── 54. _http.mjs — error messages are status code + reason phrase only ──
+// WAF challenge pages (seen live: Workday 429s) carry no actionable text —
+// whether it's raw HTML markup or a human-readable challenge page ("Security
+// Check ... Support ID: ... Client IP: ..."), neither tells the caller
+// anything useful. The status code and its standard reason phrase carry the
+// signal instead; the raw body is still attached as err.body for callers
+// that parse it (providers/glints.mjs does, for its own error detail
+// extraction).
+
+console.log('\n54. _http.mjs — error message is status + reason phrase only');
+
+try {
+  const { fetchJson } = await import(pathToFileURL(join(ROOT, 'providers/_http.mjs')).href);
+  const originalFetch = globalThis.fetch;
+
+  const mockFetch = (status, statusText, body, headers = {}) => async () => ({
+    ok: false,
+    status,
+    statusText,
+    text: async () => body,
+    headers: { get: (name) => headers[name.toLowerCase()] ?? null },
+  });
+
+  try {
+    globalThis.fetch = mockFetch(429, 'Too Many Requests', '<!DOCTYPE html><html><body><style>body{color:red}</style>Security Check Enable JavaScript and cookies to continue Support ID: 0000000000000000 – Client IP: 203.0.113.42</body></html>', { 'content-type': 'text/html; charset=utf-8' });
+    let err;
+    try { await fetchJson('https://example.com/api'); } catch (e2) { err = e2; }
+    if (err?.message === 'HTTP 429 Too Many Requests') {
+      pass('_http.mjs builds the error message from status + reason phrase only');
+    } else {
+      fail(`error message = ${JSON.stringify(err?.message)}, expected "HTTP 429 Too Many Requests"`);
+    }
+    if (err && !/Security Check|Support ID|Client IP|<style>|<html/i.test(err.message)) {
+      pass('_http.mjs excludes the response body from the error message entirely (HTML or plain text)');
+    } else {
+      fail(`error message should not contain any body text: ${JSON.stringify(err?.message)}`);
+    }
+    if (err?.status === 429) pass('_http.mjs sets err.status from the response');
+    else fail(`err.status = ${JSON.stringify(err?.status)}, expected 429`);
+    if (err?.body?.includes('Support ID')) {
+      pass('_http.mjs still attaches the raw body as err.body for callers that need it (e.g. providers/glints.mjs)');
+    } else {
+      fail(`err.body missing or altered: ${JSON.stringify(err?.body)}`);
+    }
+
+    // No statusText available (some mocked/edge responses omit it) — falls
+    // back to just the status code, no trailing space or "undefined".
+    globalThis.fetch = mockFetch(503, '', 'irrelevant body');
+    let noReasonErr;
+    try { await fetchJson('https://example.com/api'); } catch (e2) { noReasonErr = e2; }
+    if (noReasonErr?.message === 'HTTP 503') {
+      pass('_http.mjs falls back to just the status code when statusText is empty');
+    } else {
+      fail(`error message = ${JSON.stringify(noReasonErr?.message)}, expected "HTTP 503"`);
+    }
+
+    // Retry-After header is captured onto the error for callers (workday.mjs) to use.
+    globalThis.fetch = mockFetch(429, 'Too Many Requests', '', { 'retry-after': '7' });
+    let retryAfterErr;
+    try { await fetchJson('https://example.com/api'); } catch (e2) { retryAfterErr = e2; }
+    if (retryAfterErr?.retryAfter === '7') pass('_http.mjs captures the Retry-After header onto the error');
+    else fail(`err.retryAfter = ${JSON.stringify(retryAfterErr?.retryAfter)}, expected "7"`);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+} catch (e) {
+  fail(`_http.mjs error message tests crashed: ${e.message}`);
 }
 
 // ── SUMMARY ─────────────────────────────────────────────────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9836,6 +9836,26 @@ try {
   if (noLocParsed[2]?.location === 'Remote, Hungary') pass('parseWorkdayResponse prefers locationsText over URL path when present');
   else fail(`parseWorkdayResponse locationsText priority: expected "Remote, Hungary", got ${JSON.stringify(noLocParsed[2]?.location)}`);
 
+  // parseWorkdayResponse — malformed percent-encoding in the URL path segment
+  // must not throw (decodeURIComponent) and must not abort processing of
+  // other job records in the same response.
+  const malformedPathJson = {
+    jobPostings: [
+      { title: 'Broken Encoding', externalPath: '/job/%E0%A4%A/Broken-Encoding_JR1' },
+      { title: 'Fine Job', externalPath: '/job/Berlin/Fine-Job_JR2' },
+    ],
+  };
+  try {
+    const malformedParsed = parseWorkdayResponse(malformedPathJson, entry);
+    if (malformedParsed.length === 2 && malformedParsed[1].location === 'Berlin') {
+      pass('parseWorkdayResponse tolerates malformed percent-encoding without dropping other records');
+    } else {
+      fail(`parseWorkdayResponse malformed encoding result = ${JSON.stringify(malformedParsed)}`);
+    }
+  } catch (e4) {
+    fail(`parseWorkdayResponse should not throw on malformed percent-encoding: ${e4.message}`);
+  }
+
   // parseWorkdayResponse — empty / malformed input
   if (parseWorkdayResponse({}, entry).length === 0) pass('parseWorkdayResponse({}) → empty result');
   else fail('parseWorkdayResponse({}) should be empty');


### PR DESCRIPTION
## What does this PR do?

The Workday provider's pagination cap was fixed at `MAX_PAGES=50 * PAGE_SIZE=20 = 1000` postings per tenant, with no signal when a tenant actually exceeds it — postings just silently disappeared from the scan. Verified live: Deutsche Bank's board (`db.wd3.myworkdayjobs.com`) currently reports **1036 open postings**, so this wasn't a hypothetical edge case.

## Related issue

N/A — bug fix, exempt from the issue-first requirement per CONTRIBUTING.md.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Changes

- `providers/workday.mjs`:
  - Uses the response's `total` field to fetch the exact number of pages needed (fewer wasted requests for tenants under the cap) instead of always looping up to `MAX_PAGES`
  - Adds an optional `max_pages` portal-entry override (capped at 1500) for tenants that genuinely exceed the default 100-page/2000-job cap
  - Logs a `console.error` warning when the cap truncates real results, or when a page fetch fails mid-pagination — previously both failure modes were silent
  - Pages are fetched sequentially (mirrors `4dayweek.mjs`/`thehub.mjs`/`arbeitnow.mjs`/`jibeapply.mjs`), so a mid-run failure returns partial results instead of discarding everything
  - Adds a location fallback parsed from the job URL path when `locationsText` is absent
  - Guards against `null`/`undefined` entries in `jobPostings`
- `test-all.mjs`: new "Provider — workday" section (23 tests: detect, `parseWorkdayResponse` normalization/edge cases, pagination via `total`, the `max_pages` cap + override, truncation/failure warnings, SSRF `redirect:'error'` across every page). Also removes the now-redundant single-request workday assertion from the shared SSRF-hardening section (superseded by the per-page check in the new section).
- `docs/SUPPORTED_JOB_BOARDS.md`, `templates/portals.example.yml`: document the URL pattern precisely and the `max_pages` option, with an example stanza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workday provider improvements: more precise careers URL auto-detection and configurable pagination with safer bounds.
* **Bug Fixes**
  * Workday job normalization now skips malformed postings and more reliably derives location and posted dates.
  * Pagination stops earlier when appropriate, handles transient page failures with partial results, and warns on truncation.
  * ATS full scans now pass scan-window options through and provide clearer “undated dropped” reporting for Workday.
* **Documentation**
  * Updated Workday URL pattern docs and added a Workday example configuration.
* **Tests**
  * Expanded Workday and HTTP error-handling coverage, including pagination/redirect edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
