### PR TITLE
fix(generate-pdf): resolve reportNum ReferenceError in --report manifest write

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -288,7 +288,21 @@ async function generatePDF() {
     console.log(`🧹 ATS normalization: ${totalReplacements} replacements (${breakdown})`);
   }
 
-  return renderHtmlToPdf(html, outputPath, { format, baseDir: dirname(inputPath) });
+  const result = await renderHtmlToPdf(html, outputPath, { format, baseDir: dirname(inputPath) });
+
+  // Record the PDF<->report linkage for the dashboard's d/D regenerate hotkeys.
+  // Manifest bookkeeping lives here (the CLI entry) where reportNum + inputPath
+  // are in scope — not in renderHtmlToPdf, which is a reusable render primitive
+  // also called by generate-cover-letter.mjs (which has no report number).
+  try {
+    updatePDFManifest(reportNum, outputPath, inputPath, format);
+    console.log(`🔗 Manifest: data/pdf-index.tsv updated${reportNum ? ` (report ${reportNum})` : ' (no --report given)'}`);
+  } catch (err) {
+    // The PDF itself succeeded — never fail the run over manifest bookkeeping.
+    console.error(`⚠️  Manifest update failed: ${err.message}`);
+  }
+
+  return result;
 }
 
 /**
@@ -396,14 +410,6 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
     console.log(`✅ PDF generated: ${outputPath}`);
     console.log(`📊 Pages: ${pageCount}`);
     console.log(`📦 Size: ${(pdfBuffer.length / 1024).toFixed(1)} KB`);
-
-    try {
-      updatePDFManifest(reportNum, outputPath, inputPath, format);
-      console.log(`🔗 Manifest: data/pdf-index.tsv updated${reportNum ? ` (report ${reportNum})` : ' (no --report given)'}`);
-    } catch (err) {
-      // The PDF itself succeeded — never fail the run over manifest bookkeeping.
-      console.error(`⚠️  Manifest update failed: ${err.message}`);
-    }
 
     return { outputPath, pageCount, size: pdfBuffer.length };
   } finally {


### PR DESCRIPTION
## Problem

Running `generate-pdf.mjs … --report=NNN` always logs `⚠️ Manifest update failed: reportNum is not defined` and never writes the `data/pdf-index.tsv` row. As a result the PDF↔report linkage isn't recorded, so the dashboard's `d`/`D` "regenerate from report" hotkeys can't resolve a generated CV's report.

## Root cause

The manifest write was placed **inside `renderHtmlToPdf()`** — a reusable render primitive — but referenced `reportNum` and `inputPath`, which are locals of `generatePDF()` (the CLI entry) and don't exist in that scope. Every call threw a `ReferenceError`, which the surrounding try/catch swallowed and logged. `generate-cover-letter.mjs` (the other caller of `renderHtmlToPdf`) hit the same throw.

## Fix

Move the manifest write out of `renderHtmlToPdf()` and into `generatePDF()`, where `reportNum` / `inputPath` / `outputPath` / `format` are all in scope. `renderHtmlToPdf` is now a pure render function (matching its JSDoc, which documents only `{ outputPath, pageCount, size }`), and the cover-letter path no longer attempts a bogus manifest write.

## Verification

- `node generate-pdf.mjs <in.html> <out.pdf> --format=a4 --report=016` → `🔗 Manifest: data/pdf-index.tsv updated (report 016)`, no error; a keyed row is written.
- No-`--report` case still writes an unkeyed row without error.
- `node test-all.mjs --quick` → **847 passed, 0 failed**.

Single-file change (`generate-pdf.mjs`, +15/−9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)