### PR TITLE
docs: add community plugins table to PLUGINS.md (#1418)

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -104,6 +104,20 @@ you edit `plugins.local/` or your `plugins.lock`, you're choosing to run your ow
 version, exactly as you always could. Removing a successor restores the bundled
 reference.
 
+## Community plugins
+
+Every community plugin in the registry is reviewed and pinned to an exact commit (see [Trust badges](#trust-badges) and [Publishing + getting approved](#publishing--getting-approved)).
+
+| Plugin | What it does | Hooks | Keys needed | Author |
+| --- | --- | --- | --- | --- |
+| [career-ops-plugin-tavily](https://github.com/Schlaflied/career-ops-plugin-tavily) | Tavily search/extract for job scanning, liveness checks, and company research. | search | `TAVILY_API_KEY` | @Schlaflied |
+| [career-ops-plugin-google-calendar](https://github.com/Schlaflied/career-ops-plugin-google-calendar) | Google Calendar ingest — detect upcoming interview events and surface them in the career-ops pipeline. | ingest | `GOOGLE_CALENDAR_CLIENT_ID`, `GOOGLE_CALENDAR_CLIENT_SECRET`, `GOOGLE_CALENDAR_REFRESH_TOKEN` | @Schlaflied |
+| [career-ops-plugin-linkedin-alerts](https://github.com/Schlaflied/career-ops-plugin-linkedin-alerts) | LinkedIn job alert ingest — parse LinkedIn alert emails from your Gmail inbox, normalize tracking links to canonical job URLs, and surface them in the career-ops pipeline. | ingest | `GMAIL_CLIENT_ID`, `GMAIL_CLIENT_SECRET`, `GMAIL_REFRESH_TOKEN` | @Schlaflied |
+| [career-ops-plugin-outlook-interviews](https://github.com/Schlaflied/career-ops-plugin-outlook-interviews) | Outlook interview ingest — detect interview invitation emails via Microsoft Graph, extract company / role / meeting link, and surface them in the career-ops pipeline. | ingest | `MSGRAPH_CLIENT_ID`, `MSGRAPH_REFRESH_TOKEN` (optional: `MSGRAPH_CLIENT_SECRET`) | @Schlaflied |
+| [career-ops-plugin-obsidian](https://github.com/Schlaflied/career-ops-plugin-obsidian) | Obsidian export — mirror the tracker into your vault as frontmatter notes queryable by Dataview/Bases; frontmatter belongs to the machine, the note body belongs to you. | export | None | @Schlaflied |
+
+To add your own plugin to the registry, follow the [Publishing + getting approved](#publishing--getting-approved) flow above.
+
 ## Not a plugin
 
 - **Centralized infrastructure** the project would run (hosted aggregation,


### PR DESCRIPTION
## What does this PR do?

Adds a **Community plugins** section and discovery table to `docs/PLUGINS.md` to showcase approved community plugins from the registry (`tavily`, `google-calendar`, `linkedin-alerts`, `outlook-interviews`, and `obsidian`). The table mirrors the tone and discipline of the provider table in `docs/SUPPORTED_JOB_BOARDS.md`, credits the authors, links plugin names directly to their GitHub repositories, and references the existing trust/review model and publishing flow.

## Related issue

Closes #1418

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Community plugins” section to the plugins guide.
  * Included a curated table of registry-reviewed, pinned community plugins with links and key details.
  * Pointed readers to the publishing and approval flow for submitting their own plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->