### PR TITLE
feat(find): resolve a company/role/number query to its full pipeline identity

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -23,6 +23,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run scan:full` | `scan-ats-full.mjs` | Reverse ATS discovery scanner |
 | `npm run validate:portals` | `validate-portals.mjs` | Validate portals.yml shape before scanning |
 | `npm run tracker` | `tracker.mjs` | SQLite derived index over applications.md — sync/query/history/export |
+| `npm run find` | `find.mjs` | Resolve a report#/tracker#/company query to its full pipeline identity |
 
 ---
 
@@ -299,3 +300,22 @@ node tracker.mjs export --out repaired.md # write to a file (existing file backe
 `export` is the inverse of `sync` (round-trip `md → db → md` is lossless for clean input — enforced by `test-all.mjs`). It writes to stdout by default and never touches `applications.md` unless you explicitly pass it as `--out`. Phase 2 of #918 (DB becomes source of truth, markdown becomes a rendered view) is a separate, explicit per-user opt-in — not part of this script yet.
 
 **Exit codes:** `0` success, `1` validation error, missing prerequisites (Node < 22.5, no `applications.md` to index), or corruption found by `sync --check`.
+
+---
+
+## find
+
+Resolves a report number, tracker number, or company/role fragment to its full pipeline identity: company, role, tracker#, report#, canonical status, PDF path (from `data/pdf-index.tsv`), and report path. "Apply to #13" is ambiguous — report numbers and tracker row numbers diverge — and answering it used to require opening three files; this does it in one read-only lookup.
+
+Zero dependencies, strictly read-only. Numeric queries match **both** the tracker # column and the report number from the Report link (`012` and `12` are the same number), so collisions between the two numbering schemes surface as multiple rows instead of a silent wrong pick. Text queries match company/role by case-insensitive substring, with the shared fuzzy matcher (`role-matcher.mjs`) as fallback for multi-word phrases.
+
+```bash
+node find.mjs 13                # report# OR tracker# 13 — shows both if they differ
+node find.mjs acme              # company fragment
+node find.mjs "data engineer"   # role phrase (fuzzy via role-matcher)
+node find.mjs acme --json       # machine-readable output
+```
+
+Multiple matches print as a table; zero matches print a clean message.
+
+**Exit codes:** `0` at least one match, `1` no match, missing query, or no `applications.md`.

--- a/find.mjs
+++ b/find.mjs
@@ -131,13 +131,15 @@ function main() {
   const query = args.filter(a => a !== '--json').join(' ').trim();
   if (!query) {
     console.log('Usage: node find.mjs <report# | tracker# | company/role fragment> [--json]');
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const trackerPath = process.env.CAREER_OPS_TRACKER || resolve(ROOT, 'data', 'applications.md');
   if (!existsSync(trackerPath)) {
     console.error(`Error: ${trackerPath} not found — nothing to search.`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
   const rows = parseTrackerRows(readFileSync(trackerPath, 'utf-8'));
 
@@ -149,11 +151,13 @@ function main() {
   const matches = findMatches(rows, query, pdfIndex);
   if (json) {
     console.log(JSON.stringify(matches, null, 2));
-    process.exit(matches.length ? 0 : 1);
+    if (matches.length === 0) process.exitCode = 1;
+    return;
   }
   if (matches.length === 0) {
     console.log(`No application matches "${query}" — try a report #, tracker #, or company fragment.`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const headers = ['Tracker#', 'Report#', 'Company', 'Role', 'Status', 'PDF', 'Report'];

--- a/find.mjs
+++ b/find.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+/**
+ * find.mjs — resolve a company/role/number query to its full pipeline identity (#1431).
+ *
+ * "Apply to #13" is ambiguous: report numbers and tracker row numbers diverge,
+ * and mapping company ↔ report# ↔ tracker# ↔ PDF used to require opening three
+ * files (applications.md, reports/, data/pdf-index.tsv). This read-only tool
+ * answers it in one lookup.
+ *
+ * Usage:
+ *   node find.mjs <query> [--json]
+ *
+ * <query> is a report number, tracker number, or company/role fragment.
+ * A numeric query matches BOTH the tracker # column and the report number in
+ * the Report link ("012" and "12" are the same number), so a collision between
+ * the two numbering schemes surfaces as multiple rows instead of a silent wrong
+ * pick. A text query matches company/role by case-insensitive substring, with
+ * the shared fuzzy matcher (role-matcher.mjs) as fallback for multi-word
+ * phrases.
+ *
+ * Zero dependencies and strictly read-only: parses data/applications.md via
+ * the shared header-aware column mapping (tracker-parse.mjs) and the PDF
+ * manifest data/pdf-index.tsv (written by generate-pdf.mjs).
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { roleFuzzyMatch } from './role-matcher.mjs';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+
+// "008" and "8" are the same report — zero-padded report-link form vs unpadded
+// tracker-# form (same normalization as the manifest writer in generate-pdf.mjs).
+const normNum = (s) => String(s ?? '').trim().replace(/^0+(?=\d)/, '');
+
+// Same status hygiene as tracker.mjs: strip markdown bold and stray dates so a
+// messy cell still prints as its canonical label.
+const cleanStatus = (s) =>
+  String(s ?? '').replace(/\*\*/g, '').replace(/\(?\d{4}-\d{2}-\d{2}\)?/g, '').trim();
+
+/**
+ * Parse the tracker markdown into lookup rows.
+ *
+ * The report number and path come from the Report cell's markdown link. The
+ * path is normalized to be root-relative: trackers at `data/applications.md`
+ * carry `../reports/...` links (relative to the tracker file, see #760), which
+ * would be misleading when printed from the career-ops root.
+ *
+ * @param {string} text - Full contents of applications.md.
+ * @returns {Array<{trackerNum:number,date:string,company:string,role:string,score:string,status:string,reportNum:string|null,reportPath:string|null}>}
+ */
+export function parseTrackerRows(text) {
+  const lines = String(text ?? '').split('\n');
+  const colmap = resolveColumns(lines);
+  const rows = [];
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (!row) continue;
+    const link = row.report.match(/\[(\d+)\]\(([^)]+)\)/);
+    rows.push({
+      trackerNum: row.num,
+      date: row.date,
+      company: row.company,
+      role: row.role,
+      score: row.score,
+      status: cleanStatus(row.status),
+      reportNum: link ? normNum(link[1]) : null,
+      reportPath: link ? link[2].replace(/^(\.\.\/)+/, '') : null,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Parse data/pdf-index.tsv (report \t pdf \t html \t format \t date) into a
+ * normalized-report# → PDF-path map. Comment lines and rows generated without
+ * a report number are skipped.
+ *
+ * @param {string} text - Full contents of pdf-index.tsv.
+ * @returns {Map<string,string>}
+ */
+export function parsePdfIndex(text) {
+  const map = new Map();
+  for (const line of String(text ?? '').split('\n')) {
+    if (!line.trim() || line.startsWith('#')) continue;
+    const fields = line.split('\t');
+    if (!fields[0]?.trim() || !fields[1]) continue;
+    map.set(normNum(fields[0]), fields[1]);
+  }
+  return map;
+}
+
+/**
+ * Resolve a query against parsed tracker rows.
+ *
+ * @param {ReturnType<typeof parseTrackerRows>} rows
+ * @param {string} query - Report#, tracker#, or company/role fragment.
+ * @param {Map<string,string>} [pdfIndex] - From parsePdfIndex().
+ * @returns {Array<object>} Matching rows, each augmented with `pdfPath` (null when no PDF is indexed for its report).
+ */
+export function findMatches(rows, query, pdfIndex = new Map()) {
+  const q = String(query ?? '').trim();
+  if (!q) return [];
+
+  let hits;
+  if (/^\d+$/.test(q)) {
+    const nq = normNum(q);
+    hits = rows.filter(r => String(r.trackerNum) === nq || r.reportNum === nq);
+  } else {
+    const ql = q.toLowerCase();
+    hits = rows.filter(r =>
+      r.company.toLowerCase().includes(ql) ||
+      r.role.toLowerCase().includes(ql) ||
+      roleFuzzyMatch(r.company, q) ||
+      roleFuzzyMatch(r.role, q));
+  }
+  return hits.map(r => ({
+    ...r,
+    pdfPath: (r.reportNum !== null && pdfIndex.get(r.reportNum)) || null,
+  }));
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────
+
+function main() {
+  const args = process.argv.slice(2);
+  const json = args.includes('--json');
+  const query = args.filter(a => a !== '--json').join(' ').trim();
+  if (!query) {
+    console.log('Usage: node find.mjs <report# | tracker# | company/role fragment> [--json]');
+    process.exit(1);
+  }
+
+  const trackerPath = process.env.CAREER_OPS_TRACKER || resolve(ROOT, 'data', 'applications.md');
+  if (!existsSync(trackerPath)) {
+    console.error(`Error: ${trackerPath} not found — nothing to search.`);
+    process.exit(1);
+  }
+  const rows = parseTrackerRows(readFileSync(trackerPath, 'utf-8'));
+
+  const manifestPath = resolve(ROOT, 'data', 'pdf-index.tsv');
+  const pdfIndex = existsSync(manifestPath)
+    ? parsePdfIndex(readFileSync(manifestPath, 'utf-8'))
+    : new Map();
+
+  const matches = findMatches(rows, query, pdfIndex);
+  if (json) {
+    console.log(JSON.stringify(matches, null, 2));
+    process.exit(matches.length ? 0 : 1);
+  }
+  if (matches.length === 0) {
+    console.log(`No application matches "${query}" — try a report #, tracker #, or company fragment.`);
+    process.exit(1);
+  }
+
+  const headers = ['Tracker#', 'Report#', 'Company', 'Role', 'Status', 'PDF', 'Report'];
+  const table = matches.map(m => [
+    String(m.trackerNum), m.reportNum ?? '—', m.company, m.role,
+    m.status || '—', m.pdfPath ?? '—', m.reportPath ?? '—',
+  ]);
+  const widths = headers.map((h, i) => Math.max(h.length, ...table.map(r => r[i].length)));
+  const fmt = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join('  ').trimEnd();
+  console.log(fmt(headers));
+  console.log(fmt(widths.map(w => '-'.repeat(w))));
+  for (const r of table) console.log(fmt(r));
+  console.error(`\n${matches.length} match(es)`); // stderr so stdout stays pipeable
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main();
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "validate:portals": "node validate-portals.mjs",
     "verify:portals": "node verify-portals.mjs",
     "tracker": "node tracker.mjs",
+    "find": "node find.mjs",
     "patterns": "node analyze-patterns.mjs",
     "reposts": "node detect-reposts.mjs",
     "gemini:eval": "node gemini-eval.mjs",

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3506,6 +3506,72 @@ try {
   fail(`tracker-parse unit test crashed: ${e.message}`);
 }
 
+// #1431 "Apply to #13" is ambiguous: report numbers and tracker row numbers
+// diverge, and mapping company ↔ report# ↔ tracker# ↔ PDF used to require
+// opening three files. find.mjs resolves a report#, tracker#, or company/role
+// fragment to the full pipeline identity in one read-only lookup.
+console.log('\n🧪 Testing find.mjs pipeline identity lookup...');
+try {
+  const { parseTrackerRows, parsePdfIndex, findMatches } = await import(pathToFileURL(join(ROOT, 'find.mjs')).href);
+
+  // Tracker# and report# intentionally diverge: row 3 carries report 12, and a
+  // different row is numbered 12 — the exact friction the tool exists to solve.
+  const rows = parseTrackerRows([
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|-------|--------|-----|--------|-------|',
+    '| 3 | 2026-06-01 | Acme Labs | Platform Engineer | 4.2/5 | **Applied** (2026-06-02) | ✅ | [12](reports/012-acme-labs-2026-06-01.md) | strong fit |',
+    '| 12 | 2026-06-10 | Globex | Data Engineer | 3.8/5 | Evaluated | ❌ | [15](reports/015-globex-2026-06-10.md) | — |',
+  ].join('\n'));
+  const pdfIndex = parsePdfIndex(
+    '# report\tpdf\thtml\tformat\tdate — written by generate-pdf.mjs, do not edit\n' +
+    '012\toutput/cv-acme-labs.pdf\toutput/cv-acme-labs.html\tats\t2026-06-01\n');
+
+  const byTracker = findMatches(rows, '3', pdfIndex);
+  if (byTracker.length === 1 && byTracker[0].company === 'Acme Labs' &&
+      byTracker[0].trackerNum === 3 && byTracker[0].reportNum === '12' &&
+      byTracker[0].reportPath === 'reports/012-acme-labs-2026-06-01.md' &&
+      byTracker[0].status === 'Applied' &&
+      byTracker[0].pdfPath === 'output/cv-acme-labs.pdf') {
+    pass('find.mjs resolves a tracker# to company, report#, canonical status, and PDF path');
+  } else {
+    fail(`find.mjs tracker# lookup wrong: ${JSON.stringify(byTracker)}`);
+  }
+
+  // "12" is both Acme's report# and Globex's tracker# — both rows must surface
+  // (with the zero-padded "012" report-link form treated as the same number).
+  const ambiguous = findMatches(rows, '012', pdfIndex);
+  const companies = ambiguous.map(m => m.company).sort();
+  if (ambiguous.length === 2 && companies[0] === 'Acme Labs' && companies[1] === 'Globex') {
+    pass('find.mjs surfaces report#/tracker# collisions as multiple matches (zero-pad normalized)');
+  } else {
+    fail(`find.mjs numeric collision lookup wrong: ${JSON.stringify(ambiguous)}`);
+  }
+
+  const byFragment = findMatches(rows, 'acme', pdfIndex);
+  if (byFragment.length === 1 && byFragment[0].company === 'Acme Labs') {
+    pass('find.mjs matches a case-insensitive company fragment');
+  } else {
+    fail(`find.mjs company fragment lookup wrong: ${JSON.stringify(byFragment)}`);
+  }
+
+  // Fuzzy multi-word lookup reuses role-matcher.mjs (stopwords like "remote"
+  // dropped) instead of reinventing matching.
+  const byFuzzy = findMatches(rows, 'remote data engineer', pdfIndex);
+  if (byFuzzy.length === 1 && byFuzzy[0].company === 'Globex' && byFuzzy[0].pdfPath === null) {
+    pass('find.mjs fuzzy-matches a role phrase via role-matcher and reports a missing PDF');
+  } else {
+    fail(`find.mjs fuzzy role lookup wrong: ${JSON.stringify(byFuzzy)}`);
+  }
+
+  if (findMatches(rows, 'no-such-company', pdfIndex).length === 0) {
+    pass('find.mjs returns zero matches cleanly for an unknown query');
+  } else {
+    fail('find.mjs matched a query that exists nowhere in the tracker');
+  }
+} catch (e) {
+  fail(`find.mjs unit test crashed: ${e.message}`);
+}
+
 // dedup-tracker reads AND writes by column; with a Location column its status
 // promotion must target the Status cell, not fixed parts[6].
 console.log('\n🧪 Testing dedup-tracker with an inserted Location column...');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -97,6 +97,7 @@ const SYSTEM_PATHS = [
   'merge-tracker.mjs',
   'tracker-links.mjs',
   'tracker.mjs',
+  'find.mjs',
   'verify-pipeline.mjs',
   'reconcile-pipeline.mjs',
   'dedup-tracker.mjs',


### PR DESCRIPTION
Closes #1431

## Summary

- New `node find.mjs <query>` — a read-only, zero-dep lookup that resolves a report#, tracker#, or company/role fragment to its full pipeline identity: company, role, tracker#, report#, canonical status, PDF path (from `data/pdf-index.tsv`), and report path.
- Numeric queries match **both** numbering schemes with zero-pad normalization (`012` == `12`), so a report#/tracker# collision surfaces as multiple rows instead of a silent wrong pick — the exact "Apply to #13" friction from the issue.
- Text queries match company/role by case-insensitive substring, falling back to the shared fuzzy matcher in `role-matcher.mjs` for multi-word phrases (not reinvented). Tracker parsing goes through the shared header-aware column mapping in `tracker-parse.mjs`, so custom layouts (e.g. an inserted Location column) parse correctly.
- Multiple matches print an aligned table; zero matches print a clean message and exit 1; `--json` gives machine-readable output. Report links are normalized to root-relative for display (`../reports/...` → `reports/...`).
- Registered in `SYSTEM_PATHS` (auto-updater), `package.json` (`npm run find`), and `docs/SCRIPTS.md`.

## Acceptance criteria from #1431

- [x] Exact report#/tracker# lookups + fuzzy company fragment
- [x] Multiple matches → table, zero matches → clean message
- [x] Read-only, zero-dep, column-mapped by header name like `tracker-parse.mjs`
- [x] Reuses `role-matcher.mjs` for fuzzy matching
- [x] Test block in `test-all.mjs` with an inline fixture (tracker# 3 carrying report# 12 alongside a row numbered 12)

## Test Plan

- [x] `node test-all.mjs` — 978 passed, 0 failed (972 baseline + new assertions; test block written first and watched fail before implementation)
- [x] `node validate-system-paths-coverage.mjs` — 391 tracked files covered
- [x] CLI smoke-tested: numeric collision shows both rows, `--json` output, zero-match exits 1 with clean message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `find` command to look up matches by report number, tracker number, or company/role fragment.
  * Supports output as a formatted table or `--json`, with distinct behavior for zero, one, or multiple matches.

* **Documentation**
  * Updated the scripts guide with the new command, examples, and exit-code semantics.

* **Bug Fixes**
  * Improved query resolution and matching behavior, including collision/ambiguity handling for numeric queries and correct reporting when a matching PDF is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->