### PR TITLE
feat(verify): detect duplicate reports and orphan reports (#1425)

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -40,7 +40,7 @@ npm run doctor
 
 ## verify
 
-Health check for pipeline data integrity. Validates `data/applications.md` against seven rules: canonical statuses (per `templates/states.yml`), no duplicate company+role pairs, all report links point to existing files, scores match `X.XX/5` / `N/A` / `DUP`, rows have proper pipe-delimited format, no pending TSVs in `batch/tracker-additions/`, and no markdown bold in scores.
+Health check for pipeline data integrity. Validates `data/applications.md` against nine rules: canonical statuses (per `templates/states.yml`), no duplicate company+role pairs, all report links point to existing files, scores match `X.XX/5` / `N/A` / `DUP`, rows have proper pipe-delimited format, no pending TSVs in `batch/tracker-additions/`, no markdown bold in scores, no two `reports/*.md` files covering the same company+role, and no orphan reports without a tracker row (#1425). The report checks are warning-level: duplicate reports can be legitimate (re-evaluation after a JD change), so they never fail the run.
 
 ```bash
 npm run verify

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3289,6 +3289,82 @@ try {
   fail(`tracker-link normalization tests crashed: ${e.message}`);
 }
 
+// ── VERIFY-PIPELINE REPORT CHECKS (#1425) ───────────────────────
+// Parallel evaluators can write two reports for the same company+role, and
+// tracker dedup can leave a report file with no tracker row. verify-pipeline
+// must surface both as warnings (not errors — re-evaluations are legitimate).
+console.log('\n🧪 Testing verify-pipeline duplicate/orphan report checks...');
+try {
+  const vpTmp = mkdtempSync(join(tmpdir(), 'career-ops-verify-reports-'));
+  try {
+    const vpReports = join(vpTmp, 'reports');
+    mkdirSync(vpReports, { recursive: true });
+    const vpTracker = join(vpTmp, 'applications.md');
+    const vpEnv = { ...process.env, CAREER_OPS_TRACKER: vpTracker, CAREER_OPS_REPORTS: vpReports };
+
+    const report = (company, role) =>
+      `# Evaluación: ${company} — ${role}\n\n## Machine Summary\n\n\`\`\`yaml\ncompany: "${company}"\nrole: "${role}"\nscore: 4.2\n\`\`\`\n`;
+
+    // #1 and #3 are the same role at Acme written by two concurrent workers;
+    // #2 is a different Acme role (must NOT be flagged as duplicate);
+    // #3 also has no tracker row (orphan — tracker dedup kept #1).
+    writeFileSync(join(vpReports, '001-acme-2026-01-04.md'), report('Acme', 'Staff AI Engineer'));
+    writeFileSync(join(vpReports, '002-acme-2026-01-05.md'), report('Acme', 'Platform Engineer'));
+    writeFileSync(join(vpReports, '003-acme-2026-01-05.md'), report('Acme', 'Staff AI Engineer'));
+
+    writeFileSync(vpTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 1 | 2026-01-04 | Acme | Staff AI Engineer | 4.2/5 | Evaluated | ❌ | [1](reports/001-acme-2026-01-04.md) | ok |\n' +
+      '| 2 | 2026-01-05 | Acme | Platform Engineer | 4.0/5 | Evaluated | ❌ | [2](reports/002-acme-2026-01-05.md) | ok |\n');
+
+    const vpOut = run(NODE, ['verify-pipeline.mjs'], { env: vpEnv, stdio: ['pipe', 'pipe', 'pipe'] });
+    if (vpOut === null) {
+      fail('verify-pipeline crashed on duplicate/orphan report fixture');
+    } else {
+      if (vpOut.includes('Duplicate reports for same company+role') &&
+          vpOut.includes('001-acme-2026-01-04.md') && vpOut.includes('003-acme-2026-01-05.md')) {
+        pass('duplicate reports for the same company+role are flagged (#1425)');
+      } else {
+        fail('duplicate company+role reports not flagged');
+      }
+      if (vpOut.includes('002-acme-2026-01-05.md') && /Duplicate reports[^\n]*002-acme/.test(vpOut)) {
+        fail('different role at the same company falsely flagged as duplicate report');
+      } else {
+        pass('different role at the same company is not flagged as duplicate');
+      }
+      if (/Orphan report[^\n]*#3[^\n]*003-acme-2026-01-05\.md/.test(vpOut)) {
+        pass('orphan report with no tracker row is flagged (#1425)');
+      } else {
+        fail('orphan report not flagged');
+      }
+      if (/Orphan report[^\n]*(001|002)-acme/.test(vpOut)) {
+        fail('referenced report falsely flagged as orphan');
+      } else {
+        pass('referenced reports are not flagged as orphans');
+      }
+      // run() returns non-null only on exit 0 — warnings must not fail the check.
+      pass('duplicate/orphan report findings stay warning-level (exit 0)');
+    }
+
+    // Clean fixture: one row, one report — both checks must pass green.
+    rmSync(join(vpReports, '003-acme-2026-01-05.md'));
+    const vpClean = run(NODE, ['verify-pipeline.mjs'], { env: vpEnv, stdio: ['pipe', 'pipe', 'pipe'] });
+    if (vpClean !== null &&
+        vpClean.includes('No duplicate reports for the same company+role') &&
+        vpClean.includes('No orphan reports')) {
+      pass('clean tracker+reports fixture passes both report checks');
+    } else {
+      fail('clean fixture did not pass duplicate/orphan report checks');
+    }
+  } finally {
+    rmSync(vpTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`verify-pipeline report checks crashed: ${e.message}`);
+}
+
 // ── SHARED ROLE MATCHER + DEDUP-TRACKER SAFETY (#947) ───────────
 // dedup-tracker.mjs used to ship an older fuzzy role matcher than
 // merge-tracker.mjs. That weaker matcher collapsed sibling roles at the same

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -10,6 +10,9 @@
  * 5. All rows have proper pipe-delimited format
  * 6. No pending TSVs in tracker-additions/ (only in merged/ or archived/)
  * 7. states.yml canonical IDs for cross-system consistency
+ * 8. Stale report-number reservation sentinels are garbage-collected
+ * 9. No two report files cover the same company+role (warning — see #1425)
+ * 10. Every report file has a tracker row referencing it (warning — see #1425)
  *
  * Run: node career-ops/verify-pipeline.mjs
  */
@@ -27,7 +30,8 @@ const APPS_FILE = process.env.CAREER_OPS_TRACKER
     ? join(CAREER_OPS, 'data/applications.md')
     : join(CAREER_OPS, 'applications.md');
 const ADDITIONS_DIR = join(CAREER_OPS, 'batch/tracker-additions');
-const REPORTS_DIR = join(CAREER_OPS, 'reports');
+// CAREER_OPS_REPORTS overrides the reports dir (used by tests, mirrors CAREER_OPS_TRACKER).
+const REPORTS_DIR = process.env.CAREER_OPS_REPORTS || join(CAREER_OPS, 'reports');
 const STATES_FILE = existsSync(join(CAREER_OPS, 'templates/states.yml'))
   ? join(CAREER_OPS, 'templates/states.yml')
   : join(CAREER_OPS, 'states.yml');
@@ -247,6 +251,86 @@ if (existsSync(REPORTS_DIR)) {
   }
 }
 if (staleSentinels === 0) ok('No stale reservation sentinels');
+
+// --- Check 9: Duplicate reports for the same company+role (#1425) ---
+// Two concurrent evaluators can each write a report for the same role.
+// merge-tracker dedups the TRACKER, but nothing watched reports/ itself.
+// Warning-level, not error: duplicates can be legitimate (re-evaluation
+// after a JD change).
+const REPORT_FILE_RE = /^(\d+)-(.+)-\d{4}-\d{2}-\d{2}\.md$/;
+const normalizeKey = s => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+// Role comes from the report body: the Machine Summary YAML fence when
+// present (field names are exact by contract), else the title line
+// "# Evaluación: {Company} — {Role}". Reports where neither parses are
+// skipped rather than grouped by company alone, which would false-positive
+// on two different roles at the same company.
+function extractRole(reportContent) {
+  const fence = reportContent.match(/##\s*Machine Summary\s*\n+```(?:yaml|yml|json)?\s*\n([\s\S]*?)\n```/i);
+  if (fence) {
+    const m = fence[1].match(/^role:\s*["']?(.+?)["']?\s*$/m);
+    if (m && m[1].trim()) return m[1].trim();
+  }
+  const title = reportContent.split('\n').find(l => l.startsWith('# '));
+  if (title) {
+    const parts = title.split(/[—–]/);
+    if (parts.length >= 2 && parts[parts.length - 1].trim()) return parts[parts.length - 1].trim();
+  }
+  return null;
+}
+
+const reportFiles = existsSync(REPORTS_DIR)
+  ? readdirSync(REPORTS_DIR).filter(f => REPORT_FILE_RE.test(f))
+  : [];
+
+let dupReports = 0;
+const reportsByRole = new Map();
+for (const name of reportFiles) {
+  const companySlug = name.match(REPORT_FILE_RE)[2];
+  let role = null;
+  try {
+    role = extractRole(readFileSync(join(REPORTS_DIR, name), 'utf-8'));
+  } catch {
+    // Unreadable report — the orphan check below still sees it.
+  }
+  if (!role) continue;
+  const key = normalizeKey(companySlug) + '::' + normalizeKey(role);
+  if (!reportsByRole.has(key)) reportsByRole.set(key, []);
+  reportsByRole.get(key).push(name);
+}
+for (const group of reportsByRole.values()) {
+  if (group.length > 1) {
+    warn(`Duplicate reports for same company+role: ${group.join(', ')}`);
+    dupReports++;
+  }
+}
+if (dupReports === 0) ok('No duplicate reports for the same company+role');
+
+// --- Check 10: Orphan reports with no tracker row (#1425) ---
+// Every reports/NNN-*.md should be referenced by a tracker row — by the row's
+// own number, the [NNN] link text, or the NNN- prefix of the linked filename.
+// A report none of them reference is usually the loser of a tracker dedup.
+const referencedNums = new Set();
+for (const e of entries) {
+  referencedNums.add(e.num);
+  const linkText = e.report.match(/\[(\d+)\]/);
+  if (linkText) referencedNums.add(parseInt(linkText[1], 10));
+  const linkTarget = e.report.match(/\]\(([^)]+)\)/);
+  if (linkTarget) {
+    const m = linkTarget[1].split('/').pop().match(/^(\d+)-/);
+    if (m) referencedNums.add(parseInt(m[1], 10));
+  }
+}
+
+let orphanReports = 0;
+for (const name of reportFiles) {
+  const num = parseInt(name.match(REPORT_FILE_RE)[1], 10);
+  if (!referencedNums.has(num)) {
+    warn(`Orphan report — no tracker row references #${num}: reports/${name}`);
+    orphanReports++;
+  }
+}
+if (orphanReports === 0) ok('No orphan reports');
 
 // --- Summary ---
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
Closes #1425

## What

Two new **warning-level** checks in `verify-pipeline.mjs`, covering the gap surfaced by the apply-run field test (parallel fan-out wrote two reports for the same role; both slipped past `merge-tracker` dedup and the existing tracker checks):

- **Duplicate reports (Check 9):** report files are grouped by `(company-slug, role)`. Company slug comes from the filename; role comes from the `## Machine Summary` YAML fence (exact field names by contract), falling back to the legacy `# Evaluación: {Company} — {Role}` title line. Groups with >1 file warn. Reports whose role can't be parsed are *skipped* rather than grouped by company alone — grouping by company would false-positive on sibling roles at the same company.
- **Orphan reports (Check 10):** every `reports/NNN-*.md` must be referenced by a tracker row — by the row's own number, the `[NNN]` link text, or the `NNN-` prefix of the linked filename. Unreferenced reports warn (typically the loser of a tracker dedup).

Both are warnings, not errors, exactly as proposed — duplicates can be legitimate (re-evaluation after a JD change), so the exit code stays `0`.

## Testability

Added a `CAREER_OPS_REPORTS` env override for the reports dir, mirroring the existing `CAREER_OPS_TRACKER` pattern, so fixture tests can exercise the checks without touching the real workspace.

## Tests

6 new fixture assertions in `test-all.mjs` (duplicate flagged, sibling role NOT flagged, orphan flagged, referenced reports not flagged, warnings keep exit 0, clean fixture passes green). Full suite: **978 passed, 0 failed**.

Sample output on the field-test scenario (two reports for the same role, tracker deduped to one row):

```
⚠️  Duplicate reports for same company+role: 001-acme-2026-01-04.md, 003-acme-2026-01-05.md
⚠️  Orphan report — no tracker row references #3: reports/003-acme-2026-01-05.md
📊 Pipeline Health: 0 errors, 2 warnings
```

Also updates the `verify` section of `docs/SCRIPTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added warnings for duplicate report files covering the same company and role.
  - Added warnings for report files that no longer match any tracker entry.
  - Improved pipeline checks to better validate report-tracking consistency.

- **Documentation**
  - Updated verification docs to reflect the expanded set of checks and clarify that warning-level report duplicates do not fail a clean run.

- **Tests**
  - Added regression coverage for duplicate, orphan, and clean report scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->