### PR TITLE
fix: preserve local CLAUDE.md additions during /career-ops update

### DIFF
--- a/modes/update.md
+++ b/modes/update.md
@@ -68,15 +68,17 @@ Ask the user for confirmation:
 
 If yes:
 1. Capture the current commit as a run-specific pre-update baseline before apply runs, e.g. `PRE_UPDATE_REF=$(git rev-parse HEAD)`. Don't rely on `backup-pre-update-{local}` alone — `update-system.mjs apply` reuses that branch if it already exists, so it may point at an older snapshot.
-2. Run `node update-system.mjs apply`
+2. **Save local CLAUDE.md additions.** `update-system.mjs apply` treats CLAUDE.md as a system file and resets it to the two-line template (`@AGENTS.md` + the local-additions comment). Before applying, read the current CLAUDE.md and save everything after that two-line header — it will need to be restored in step 4 below. If CLAUDE.md has nothing beyond the two-line header, note that there is nothing to restore.
+3. Run `node update-system.mjs apply`
    - If the command exits with a non-zero code, treat apply as failed. Show the captured output and offer:
      > "⚠️ Update apply failed. Want me to show the full error, or try `/career-ops update rollback`?"
    - Stop the flow here if apply failed — do not run doctor or reconciliation on a partially-applied update.
-3. Run `node doctor.mjs` to validate the installation
+4. **Restore local CLAUDE.md additions.** Re-read CLAUDE.md (it is now the blank template) and append the content saved in step 2 after the two-line header.
+5. Run `node doctor.mjs` to validate the installation
    - If the command exits with a non-zero code, treat validation as failed. Show the captured output and offer:
      > "⚠️ Validation failed after update. Want me to show the full error, or roll back with `/career-ops update rollback`?"
    - Stop the flow here if validation failed — do not run reconciliation or show the success message.
-4. If Step 3 flagged archetype/scoring changes, reconcile `modes/_profile.md` against the new `modes/_shared.md`:
+6. If Step 3 flagged archetype/scoring changes, reconcile `modes/_profile.md` against the new `modes/_shared.md`:
    - Read both the pre-update version (`git show $PRE_UPDATE_REF:modes/_shared.md`) and the post-update version of `modes/_shared.md`.
    - Extract the canonical archetype identifiers from each version (archetype headings/definitions, plus any slug/alias fields).
    - Read `modes/_profile.md` and look for tokens that match archetype names (inline text, Markdown links, YAML keys, code spans).
@@ -89,7 +91,7 @@ If yes:
        > "Your _profile.md references archetype '{old_name}' which was renamed to '{new_name}'. Want me to update it?"
      - For removals:
        > "Your _profile.md references archetype '{old_name}' which was removed in the new _shared.md. Want me to delete the reference or replace it with another archetype?"
-5. Show final status:
+7. Show final status:
    > "✅ Updated to v{version}. Run `node doctor.mjs` anytime to verify setup."
 
 If no:
@@ -106,7 +108,8 @@ If the user says "rollback" or runs `/career-ops update rollback`:
 
 - NEVER auto-modify User Layer files during update (cv.md, config/profile.yml, data/, reports/, output/, interview-prep/, jds/, article-digest.md, portals.yml)
 - `modes/_profile.md` is User Layer too: the compatibility check in Step 3 reads it strictly read-only
-- Exception: `modes/_profile.md` may be edited **only** in Step 4.3, and **only** after the user explicitly confirms each individual rename/removal. Never batch-edit without per-change consent.
+- Exception: `modes/_profile.md` may be edited **only** in Step 4.6, and **only** after the user explicitly confirms each individual rename/removal. Never batch-edit without per-change consent.
 - User-specific customizations (archetypes, scoring weights, narrative) belong in `modes/_profile.md` or `config/profile.yml`, never in `modes/_shared.md`
+- CLAUDE.md's local additions (everything after the two-line `@AGENTS.md` header) MUST be saved before apply and restored after (Step 4.2, Step 4.4). `update-system.mjs apply` has no awareness of this content and will silently discard it otherwise.
 - If anything goes wrong, tell the user to run `node update-system.mjs rollback`
 - Keep the output concise — users don't want walls of text during an update

--- a/modes/update.md
+++ b/modes/update.md
@@ -69,16 +69,17 @@ Ask the user for confirmation:
 If yes:
 1. Capture the current commit as a run-specific pre-update baseline before apply runs, e.g. `PRE_UPDATE_REF=$(git rev-parse HEAD)`. Don't rely on `backup-pre-update-{local}` alone — `update-system.mjs apply` reuses that branch if it already exists, so it may point at an older snapshot.
 2. **Save local CLAUDE.md additions.** `update-system.mjs apply` treats CLAUDE.md as a system file and resets it to the two-line template (`@AGENTS.md` + the local-additions comment). Before applying, read the current CLAUDE.md and save everything after that two-line header — it will need to be restored in step 4 below. If CLAUDE.md has nothing beyond the two-line header, note that there is nothing to restore.
-3. Run `node update-system.mjs apply`
-   - If the command exits with a non-zero code, treat apply as failed. Show the captured output and offer:
+3. Run `node update-system.mjs apply`, capturing its exit code without stopping on failure yet — the restore in step 4 must run either way.
+4. **Restore local CLAUDE.md additions**, regardless of whether step 3 succeeded or failed. `apply` resets CLAUDE.md before it can fail partway through, so a failed apply still leaves CLAUDE.md at the blank two-line template. Re-read CLAUDE.md and append the content saved in step 2 after the two-line header.
+5. Now check the exit code captured in step 3:
+   - If non-zero, treat apply as failed. Show the captured output and offer:
      > "⚠️ Update apply failed. Want me to show the full error, or try `/career-ops update rollback`?"
    - Stop the flow here if apply failed — do not run doctor or reconciliation on a partially-applied update.
-4. **Restore local CLAUDE.md additions.** Re-read CLAUDE.md (it is now the blank template) and append the content saved in step 2 after the two-line header.
-5. Run `node doctor.mjs` to validate the installation
+6. Run `node doctor.mjs` to validate the installation
    - If the command exits with a non-zero code, treat validation as failed. Show the captured output and offer:
      > "⚠️ Validation failed after update. Want me to show the full error, or roll back with `/career-ops update rollback`?"
    - Stop the flow here if validation failed — do not run reconciliation or show the success message.
-6. If Step 3 flagged archetype/scoring changes, reconcile `modes/_profile.md` against the new `modes/_shared.md`:
+7. If Step 3 flagged archetype/scoring changes, reconcile `modes/_profile.md` against the new `modes/_shared.md`:
    - Read both the pre-update version (`git show $PRE_UPDATE_REF:modes/_shared.md`) and the post-update version of `modes/_shared.md`.
    - Extract the canonical archetype identifiers from each version (archetype headings/definitions, plus any slug/alias fields).
    - Read `modes/_profile.md` and look for tokens that match archetype names (inline text, Markdown links, YAML keys, code spans).
@@ -91,7 +92,7 @@ If yes:
        > "Your _profile.md references archetype '{old_name}' which was renamed to '{new_name}'. Want me to update it?"
      - For removals:
        > "Your _profile.md references archetype '{old_name}' which was removed in the new _shared.md. Want me to delete the reference or replace it with another archetype?"
-7. Show final status:
+8. Show final status:
    > "✅ Updated to v{version}. Run `node doctor.mjs` anytime to verify setup."
 
 If no:
@@ -108,8 +109,8 @@ If the user says "rollback" or runs `/career-ops update rollback`:
 
 - NEVER auto-modify User Layer files during update (cv.md, config/profile.yml, data/, reports/, output/, interview-prep/, jds/, article-digest.md, portals.yml)
 - `modes/_profile.md` is User Layer too: the compatibility check in Step 3 reads it strictly read-only
-- Exception: `modes/_profile.md` may be edited **only** in Step 4.6, and **only** after the user explicitly confirms each individual rename/removal. Never batch-edit without per-change consent.
+- Exception: `modes/_profile.md` may be edited **only** in Step 4.7, and **only** after the user explicitly confirms each individual rename/removal. Never batch-edit without per-change consent.
 - User-specific customizations (archetypes, scoring weights, narrative) belong in `modes/_profile.md` or `config/profile.yml`, never in `modes/_shared.md`
-- CLAUDE.md's local additions (everything after the two-line `@AGENTS.md` header) MUST be saved before apply and restored after (Step 4.2, Step 4.4). `update-system.mjs apply` has no awareness of this content and will silently discard it otherwise.
+- CLAUDE.md's local additions (everything after the two-line `@AGENTS.md` header) MUST be saved before apply and restored immediately after — on both the success AND failure path (Step 4.2, Step 4.4). `update-system.mjs apply` resets CLAUDE.md before it can fail partway through, so a failed apply still needs the restore. `apply` has no awareness of this content and will silently discard it otherwise.
 - If anything goes wrong, tell the user to run `node update-system.mjs rollback`
 - Keep the output concise — users don't want walls of text during an update


### PR DESCRIPTION
## Summary

- `update-system.mjs apply` resets CLAUDE.md to the blank two-line template on every update — by design, since CLAUDE.md is system-layer.
- `/career-ops update` wraps `apply` with a nicer UX (diff preview, compat check, archetype reconciliation) but never accounted for this: any local content in CLAUDE.md (house rules, tool quirks, CLI-specific notes) silently disappears on update.
- Found this the hard way — had to manually save/restore CLAUDE.md content around an update, twice, before realizing the built-in update flow doesn't handle it either.
- Adds explicit save (before apply) / restore (after apply) steps to `modes/update.md`, matching the same pattern already used there for `_profile.md` archetype reconciliation.

## Test plan
- [x] `node test-all.mjs` — 985 passed, 0 failed (same baseline as main)
- [ ] Manually verify `/career-ops update` preserves CLAUDE.md local content end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the `/career-ops update` “Step 4 — Confirm and Apply” sequence, including when `CLAUDE.md` local additions are saved, applied, and restored on both success and failure.
  * Updated failure handling to halt immediately if the apply or validation steps fail.
  * Reorganized subsequent steps so reconciling `modes/_profile.md` happens after the apply/doctor success path.
  * Restricted when `modes/_profile.md` edits are allowed, requiring reconciling-step timing and per-change confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->