### PR TITLE
docs(web): add the web/ README (alpha status, quick start, safety, feedback)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,54 @@
+# career-ops web (alpha)
+
+An **experimental, opt-in web UI** for career-ops. It is a local-first *view* over
+the exact same files the CLI reads and writes (`data/pipeline.md`,
+`data/applications.md`, `reports/`, `config/`): no parallel engine, no separate
+database, no server. If you never run it, nothing about your CLI workflow changes.
+
+> **Status: alpha.** Expect rough edges. Feedback →
+> [Discussion #1142](https://github.com/santifer/career-ops/discussions/1142) ·
+> roadmap context → [Discussion #156](https://github.com/santifer/career-ops/discussions/156).
+
+## Quick start
+
+Requires Node 20+.
+
+```bash
+cd web
+npm ci
+npm run dev
+```
+
+Open http://localhost:3000. The app reads the career-ops checkout it lives in
+(the parent directory) — your existing CV, pipeline and reports appear as-is.
+
+## What works today
+
+- **Pipeline** — your tracker as a sortable, filterable table; status changes
+  write back through the core's own scripts.
+- **Explore** — the free reverse-ATS scan with an honest partial-dataset
+  indicator, plus AI-assisted discovery (bring your own CLI/keys).
+- **Apply** — assisted form prefill with a hard rule inherited from the core:
+  **it never submits for you** — you always press the button.
+- **Today / Analytics / CV / Config** — action queue, funnel, CV editing with
+  preview, settings.
+
+## Safety
+
+- **Local-first:** the local web app runs entirely on your machine — no cloud,
+  no account needed. Your CV and data stay in your own files.
+- **Never auto-submits:** the apply flow drafts and prefills; submitting is
+  always a human action.
+- **Additive:** the web is isolated from the core's packaging, CI and release
+  automation. The CLI works exactly the same without it.
+
+## Development
+
+```bash
+npm run dev          # dev server (Turbopack)
+npx tsc --noEmit     # typecheck
+npm run build        # production build
+```
+
+Set `CAREER_OPS_ROOT=/path/to/checkout` in `web/.env.local` to point the app at
+a different career-ops directory (useful for testing against sample data).


### PR DESCRIPTION
Adds the `web/README.md` that the web-alpha landing plan promised and the merged snapshot (#1451) left out.

Covers: what the web UI is (local-first view over the same canonical files, opt-in alpha), the quick start (`cd web && npm ci && npm run dev`), what works today, the safety guarantees (local-first, **never auto-submits**, additive), and where feedback goes (#1142 / #156).

Unblocks the root-README link line (maintainer's, lands after this merges).

First web PR through the new web-on-main flow — path-filtered web-ci should be the only CI that runs the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a README for the experimental web interface, including setup steps, local development commands, and environment configuration.
  * Documented the main areas available in the UI, such as Pipeline, Explore, Apply, Today, Analytics, CV, and Config.
  * Clarified safety and usage notes, including local-only behavior, opt-in use, and that submissions are never automatic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->