### PR TITLE
scan.mjs: report unreachable boards in every run + doctor sweep

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -236,7 +236,11 @@ async function checkPortalSlugs(root) {
       pass: false,
       label: `${unresolved.length} ATS slug(s) in portals.yml do not resolve`,
       fix: [
-        ...unresolved.map((r) => `${r.name}: ${r.ats || '?'}/${r.slug || '?'} — ${r.reason || 'unresolved'}`),
+        ...unresolved.map((r) => {
+          let line = `${r.name}: ${r.ats || '?'}/${r.slug || '?'} — ${r.reason || 'unresolved'}`;
+          if (r.suggested) line += ` → try ${r.suggested.ats}/${r.suggested.slug}`;
+          return line;
+        }),
         'Probe variants with: node verify-portals.mjs --add "<company>"',
       ],
     };

--- a/scan.mjs
+++ b/scan.mjs
@@ -38,6 +38,7 @@ import yaml from 'js-yaml';
 import { makeHttpCtx } from './providers/_http.mjs';
 import { buildTrustValidator } from './providers/_trust-validator.mjs';
 import { mergeProviderPlugins } from './plugins/_engine.mjs';
+import { classifyFetchError } from './verify-portals.mjs';
 
 const parseYaml = yaml.load;
 
@@ -1002,6 +1003,7 @@ async function main() {
   let totalDupes = 0;
   const newOffers = [];
   const errors = [...resolveErrors];
+  const emptyBoards = [];
 
   const tasks = targets.map(company => async () => {
     let provider = company._provider;
@@ -1027,6 +1029,9 @@ async function main() {
         throw new Error(`${provider.id}: fetch() did not return an array`);
       }
       totalFound += jobs.length;
+      if (!company._isBoard && jobs.length === 0) {
+        emptyBoards.push(company.name);
+      }
 
       for (const job of jobs) {
         // Trust enrichment — runs before filters, never drops
@@ -1088,7 +1093,11 @@ async function main() {
         });
       }
     } catch (err) {
-      errors.push({ company: company.name, error: err.message });
+      errors.push({
+        company: company.name,
+        error: err.message,
+        kind: classifyFetchError(err),
+      });
     }
   });
 
@@ -1223,9 +1232,26 @@ async function main() {
     }
   }
 
-  if (errors.length > 0) {
-    console.log(`\nErrors (${errors.length}):`);
-    for (const e of errors) {
+  const unreachableBoards = errors.filter((e) => e.kind === 'slug_gone');
+  const networkBoards = errors.filter((e) => e.kind === 'network');
+  const otherErrors = errors.filter((e) => e.kind !== 'slug_gone' && e.kind !== 'network');
+
+  if (unreachableBoards.length > 0) {
+    const names = unreachableBoards.map((e) => e.company).join(', ');
+    console.log(`\n⚠️  ${unreachableBoards.length} board(s) unreachable (slug?): ${names} — run: node verify-portals.mjs`);
+  }
+  if (emptyBoards.length > 0) {
+    console.log(`🟡 ${emptyBoards.length} board(s) live but empty: ${emptyBoards.join(', ')}`);
+  }
+  if (networkBoards.length > 0) {
+    console.log(`\nNetwork errors (${networkBoards.length}):`);
+    for (const e of networkBoards) {
+      console.log(`  ✗ ${e.company}: ${e.error}`);
+    }
+  }
+  if (otherErrors.length > 0) {
+    console.log(`\nErrors (${otherErrors.length}):`);
+    for (const e of otherErrors) {
       console.log(`  ✗ ${e.company}: ${e.error}`);
     }
   }

--- a/scan.mjs
+++ b/scan.mjs
@@ -1003,7 +1003,7 @@ async function main() {
   let totalDupes = 0;
   const newOffers = [];
   const errors = [...resolveErrors];
-  const emptyBoards = [];
+  const emptyTargets = [];
 
   const tasks = targets.map(company => async () => {
     let provider = company._provider;
@@ -1030,7 +1030,7 @@ async function main() {
       }
       totalFound += jobs.length;
       if (!company._isBoard && jobs.length === 0) {
-        emptyBoards.push(company.name);
+        emptyTargets.push(company.name);
       }
 
       for (const job of jobs) {
@@ -1232,20 +1232,20 @@ async function main() {
     }
   }
 
-  const unreachableBoards = errors.filter((e) => e.kind === 'slug_gone');
-  const networkBoards = errors.filter((e) => e.kind === 'network');
+  const unreachableTargets = errors.filter((e) => e.kind === 'slug_gone');
+  const networkTargets = errors.filter((e) => e.kind === 'network');
   const otherErrors = errors.filter((e) => e.kind !== 'slug_gone' && e.kind !== 'network');
 
-  if (unreachableBoards.length > 0) {
-    const names = unreachableBoards.map((e) => e.company).join(', ');
-    console.log(`\n⚠️  ${unreachableBoards.length} board(s) unreachable (slug?): ${names} — run: node verify-portals.mjs`);
+  if (unreachableTargets.length > 0) {
+    const names = unreachableTargets.map((e) => e.company).join(', ');
+    console.log(`\n⚠️  ${unreachableTargets.length} target(s) unreachable (slug?): ${names} — run: node verify-portals.mjs`);
   }
-  if (emptyBoards.length > 0) {
-    console.log(`🟡 ${emptyBoards.length} board(s) live but empty: ${emptyBoards.join(', ')}`);
+  if (emptyTargets.length > 0) {
+    console.log(`🟡 ${emptyTargets.length} target(s) live but empty: ${emptyTargets.join(', ')}`);
   }
-  if (networkBoards.length > 0) {
-    console.log(`\nNetwork errors (${networkBoards.length}):`);
-    for (const e of networkBoards) {
+  if (networkTargets.length > 0) {
+    console.log(`\nNetwork errors (${networkTargets.length}):`);
+    for (const e of networkTargets) {
       console.log(`  ✗ ${e.company}: ${e.error}`);
     }
   }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1621,9 +1621,9 @@ try {
 
   // Mock fetchJson: 200+jobs → live, 200+empty → empty, otherwise 404 → missing.
   const mockFetch = async (url) => {
-    if (url.includes('/boards/live/')) return { jobs: [{}, {}] };
-    if (url.includes('/boards/empty/')) return { jobs: [] };
-    if (url.includes('ashbyhq.com') && url.includes('deepsetai')) return { jobs: [{}] };
+    if (url.includes('/boards/live/jobs')) return { jobs: [{}, {}] };
+    if (url.includes('/boards/empty/jobs')) return { jobs: [] };
+    if (url.includes('/posting-api/job-board/deepsetai')) return { jobs: [{}] };
     const err = new Error('HTTP 404'); err.status = 404; throw err;
   };
   const results = await verifyCompanies([

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1581,14 +1581,31 @@ tracked_companies:
 console.log('\n10b. Portal slug validator');
 
 try {
-  const { deriveSlugCandidates, parseAtsSlug, verifyCompanies } =
+  const { deriveSlugCandidates, parseAtsSlug, verifyCompanies, classifyFetchError } =
     await import(pathToFileURL(join(ROOT, 'verify-portals.mjs')).href);
 
   const slugs = deriveSlugCandidates('Acme Corp!');
-  if (JSON.stringify(slugs) === JSON.stringify(['acmecorp', 'acme-corp', 'acme_corp', 'acme'])) {
+  const baseSlugs = ['acmecorp', 'acme-corp', 'acme_corp', 'acme'];
+  if (baseSlugs.every((s) => slugs.includes(s)) && slugs.includes('acmeai') && slugs.includes('acme.tech')) {
     pass('verify-portals derives slug candidates from a company name');
   } else {
     fail(`verify-portals slug candidates wrong: ${JSON.stringify(slugs)}`);
+  }
+
+  if (deriveSlugCandidates('Deepset').includes('deepsetai')) {
+    pass('verify-portals derives common slug suffixes (e.g. deepsetai)');
+  } else {
+    fail('verify-portals missing deepsetai suffix for Deepset');
+  }
+
+  if (
+    classifyFetchError({ status: 404 }) === 'slug_gone' &&
+    classifyFetchError({ name: 'AbortError' }) === 'network' &&
+    classifyFetchError({ status: 503 }) === 'server'
+  ) {
+    pass('verify-portals classifies fetch errors by kind');
+  } else {
+    fail('verify-portals classifyFetchError misclassified HTTP errors');
   }
 
   if (
@@ -1606,20 +1623,24 @@ try {
   const mockFetch = async (url) => {
     if (url.includes('/boards/live/')) return { jobs: [{}, {}] };
     if (url.includes('/boards/empty/')) return { jobs: [] };
+    if (url.includes('ashbyhq.com') && url.includes('deepsetai')) return { jobs: [{}] };
     const err = new Error('HTTP 404'); err.status = 404; throw err;
   };
   const results = await verifyCompanies([
     { name: 'Live', careers_url: 'https://job-boards.greenhouse.io/live' },
     { name: 'Empty', careers_url: 'https://job-boards.greenhouse.io/empty' },
     { name: 'Typo', careers_url: 'https://job-boards.greenhouse.io/nope' },
+    { name: 'Deepset', careers_url: 'https://job-boards.greenhouse.io/deepset' },
     { name: 'Branded', careers_url: 'https://acme.com/careers' },
     { name: 'Off', enabled: false, careers_url: 'https://job-boards.greenhouse.io/live' },
   ], { fetchJson: mockFetch });
-  const byName = Object.fromEntries(results.map((r) => [r.name, r.status]));
+  const byName = Object.fromEntries(results.map((r) => [r.name, r]));
   if (
-    results.length === 4 &&
-    byName.Live === 'live' && byName.Empty === 'empty' &&
-    byName.Typo === 'missing' && byName.Branded === 'skipped'
+    results.length === 5 &&
+    byName.Live.status === 'live' && byName.Empty.status === 'empty' &&
+    byName.Typo.status === 'missing' && byName.Typo.errorKind === 'slug_gone' &&
+    byName.Branded.status === 'skipped' &&
+    byName.Deepset.suggested?.ats === 'ashby' && byName.Deepset.suggested?.slug === 'deepsetai'
   ) {
     pass('verify-portals classifies live / empty / unresolved / non-ATS (disabled excluded)');
   } else {

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -10,7 +10,7 @@
  * Greenhouse / Ashby / Lever endpoints for a company's slug (or for candidate
  * slugs derived from its name) and reports which resolve.
  *
- * A 200 that returns an empty job list is reported as "live but empty" — a
+ * A 200 that returns an empty job list is reported as 'live but empty' — a
  * legitimate state during between-hires periods — kept distinct from an
  * unresolved (404/wrong) slug so a quiet board isn't mistaken for a typo.
  *
@@ -25,14 +25,14 @@
  * through an injectable `fetchJson`, so the pure logic is testable offline.
  */
 
-import { existsSync, readFileSync } from "fs";
-import { resolve } from "path";
-import { fileURLToPath, pathToFileURL } from "url";
-import yaml from "js-yaml";
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import yaml from 'js-yaml';
 
-import { fetchJson as defaultFetchJson } from "./providers/_http.mjs";
+import { fetchJson as defaultFetchJson } from './providers/_http.mjs';
 
-const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || "portals.yml";
+const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
 
 // How to turn a slug into a probe URL, and where the job list lives in the
 // response, for each supported ATS. Greenhouse/Ashby wrap jobs in `{ jobs }`;
@@ -59,15 +59,15 @@ export const ATS = {
 // cover entries that pin the resolved endpoint directly. First match wins.
 const ATS_URL_PATTERNS = [
   {
-    ats: "greenhouse",
+    ats: 'greenhouse',
     re: /boards-api\.greenhouse\.io\/v1\/boards\/([^/?#]+)/,
   },
-  { ats: "greenhouse", re: /job-boards(?:\.eu)?\.greenhouse\.io\/([^/?#]+)/ },
-  { ats: "greenhouse", re: /boards\.greenhouse\.io\/([^/?#]+)/ },
-  { ats: "ashby", re: /api\.ashbyhq\.com\/posting-api\/job-board\/([^/?#]+)/ },
-  { ats: "ashby", re: /jobs\.ashbyhq\.com\/([^/?#]+)/ },
-  { ats: "lever", re: /api\.lever\.co\/v0\/postings\/([^/?#]+)/ },
-  { ats: "lever", re: /jobs\.lever\.co\/([^/?#]+)/ },
+  { ats: 'greenhouse', re: /job-boards(?:\.eu)?\.greenhouse\.io\/([^/?#]+)/ },
+  { ats: 'greenhouse', re: /boards\.greenhouse\.io\/([^/?#]+)/ },
+  { ats: 'ashby', re: /api\.ashbyhq\.com\/posting-api\/job-board\/([^/?#]+)/ },
+  { ats: 'ashby', re: /jobs\.ashbyhq\.com\/([^/?#]+)/ },
+  { ats: 'lever', re: /api\.lever\.co\/v0\/postings\/([^/?#]+)/ },
+  { ats: 'lever', re: /jobs\.lever\.co\/([^/?#]+)/ },
 ];
 
 /**
@@ -78,7 +78,7 @@ const ATS_URL_PATTERNS = [
  *   (branded careers pages, Workday, job boards, etc.) which this tool skips.
  */
 export function parseAtsSlug(url) {
-  const text = String(url || "");
+  const text = String(url || '');
   for (const { ats, re } of ATS_URL_PATTERNS) {
     const m = text.match(re);
     if (m && m[1]) return { ats, slug: m[1] };
@@ -91,33 +91,33 @@ export function parseAtsSlug(url) {
  *
  * Slugs are conventionally the company name lowercased with separators dropped
  * or dashed, so we generate the common shapes plus the first word alone (many
- * boards use just the brand, e.g. "Acme Corp" → "acme"). Order is deterministic
+ * boards use just the brand, e.g. 'Acme Corp' → 'acme'). Order is deterministic
  * and duplicates are removed so `--add` probes each distinct candidate once.
  *
  * @param {string} name - Company display name.
  * @returns {string[]} Distinct candidate slugs, most-specific first.
  */
-const SLUG_SUFFIXES = ["ai", "tech", "io", "hq", "labs"];
+const SLUG_SUFFIXES = ['ai', 'tech', 'io', 'hq', 'labs'];
 
 export function deriveSlugCandidates(name) {
-  const lower = String(name || "")
+  const lower = String(name || '')
     .toLowerCase()
     .trim();
   if (!lower) return [];
   const words = lower
-    .replace(/[^a-z0-9\s]/g, " ")
-    .replace(/\s+/g, " ")
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
     .trim()
-    .split(" ")
+    .split(' ')
     .filter(Boolean);
   if (words.length === 0) return [];
   const candidates = [
-    words.join(""), // acmecorp
-    words.join("-"), // acme-corp
-    words.join("_"), // acme_corp
+    words.join(''), // acmecorp
+    words.join('-'), // acme-corp
+    words.join('_'), // acme_corp
     words[0], // acme
   ];
-  const bases = [words.join(""), words[0]].filter(Boolean);
+  const bases = [words.join(''), words[0]].filter(Boolean);
   for (const base of bases) {
     for (const suf of SLUG_SUFFIXES) candidates.push(`${base}${suf}`);
     candidates.push(`${base}.tech`, `${base}.io`);
@@ -132,20 +132,20 @@ export function deriveSlugCandidates(name) {
  * @returns {'slug_gone'|'auth'|'network'|'server'|'unknown'}
  */
 export function classifyFetchError(err) {
-  if (!err) return "unknown";
-  if (err.name === "AbortError") return "network";
+  if (!err) return 'unknown';
+  if (err.name === 'AbortError') return 'network';
   const msg = String(err.message || err);
   if (/ECONNREFUSED|ENOTFOUND|ETIMEDOUT|fetch failed|network/i.test(msg)) {
-    return "network";
+    return 'network';
   }
   const status = err.status;
-  if (status === 404 || status === 410) return "slug_gone";
-  if (status === 401 || status === 403) return "auth";
-  if (typeof status === "number" && status >= 500) return "server";
-  if (/HTTP 404|HTTP 410/.test(msg)) return "slug_gone";
-  if (/HTTP 401|HTTP 403/.test(msg)) return "auth";
-  if (/HTTP 5\d\d/.test(msg)) return "server";
-  return "unknown";
+  if (status === 404 || status === 410) return 'slug_gone';
+  if (status === 401 || status === 403) return 'auth';
+  if (typeof status === 'number' && status >= 500) return 'server';
+  if (/HTTP 404|HTTP 410/.test(msg)) return 'slug_gone';
+  if (/HTTP 401|HTTP 403/.test(msg)) return 'auth';
+  if (/HTTP 5\d\d/.test(msg)) return 'server';
+  return 'unknown';
 }
 
 /**
@@ -168,9 +168,9 @@ export async function probeSlug(
     return {
       ats,
       slug,
-      url: "",
-      status: "missing",
-      errorKind: "unknown",
+      url: '',
+      status: 'missing',
+      errorKind: 'unknown',
       reason: `unknown ATS: ${ats}`,
     };
   const url = spec.probeUrl(slug);
@@ -182,15 +182,15 @@ export async function probeSlug(
         ats,
         slug,
         url,
-        status: "missing",
-        errorKind: "unknown",
-        reason: "unexpected response shape",
+        status: 'missing',
+        errorKind: 'unknown',
+        reason: 'unexpected response shape',
       };
     return {
       ats,
       slug,
       url,
-      status: count > 0 ? "live" : "empty",
+      status: count > 0 ? 'live' : 'empty',
       jobCount: count,
     };
   } catch (err) {
@@ -198,7 +198,7 @@ export async function probeSlug(
       ats,
       slug,
       url,
-      status: "missing",
+      status: 'missing',
       errorKind: classifyFetchError(err),
       httpStatus: err?.status,
       reason: err?.message || String(err),
@@ -208,14 +208,15 @@ export async function probeSlug(
 
 /** Probe slug variants across all ATSes; prefer live boards over empty ones. */
 async function discoverAlternates(name, { fetchJson }) {
-  const hits = [];
+  let bestEmpty = null;
   for (const slug of deriveSlugCandidates(name)) {
     for (const ats of Object.keys(ATS)) {
       const r = await probeSlug(ats, slug, { fetchJson });
-      if (r.status !== "missing") hits.push(r);
+      if (r.status === 'live') return r;
+      if (r.status === 'empty' && !bestEmpty) bestEmpty = r;
     }
   }
-  return hits.find((h) => h.status === "live") || hits[0] || null;
+  return bestEmpty;
 }
 
 /**
@@ -237,27 +238,26 @@ export async function verifyCompanies(
   const list = Array.isArray(companies) ? companies : [];
   const results = [];
   for (const company of list) {
-    if (!company || typeof company !== "object") continue;
+    if (!company || typeof company !== 'object') continue;
     if (company.enabled === false) continue;
-    const name = typeof company.name === "string" ? company.name : "(unnamed)";
+    const name = typeof company.name === 'string' ? company.name : '(unnamed)';
     const match =
       parseAtsSlug(company.api) || parseAtsSlug(company.careers_url);
     if (!match) {
       results.push({
         name,
-        status: "skipped",
-        reason: "no Greenhouse/Ashby/Lever slug in careers_url or api",
+        status: 'skipped',
+        reason: 'no Greenhouse/Ashby/Lever slug in careers_url or api',
       });
       continue;
     }
     const probe = await probeSlug(match.ats, match.slug, { fetchJson });
-    if (probe.status === "live" || probe.status === "empty") {
+    if (probe.status === 'live' || probe.status === 'empty') {
       results.push({ name, ...probe });
       continue;
     }
-    // Wrong slug or ATS migration — cross-probe variants unless the failure
-    // looks transient (network / server error on the configured board).
-    if (probe.errorKind !== "network" && probe.errorKind !== "server") {
+    // Wrong slug or ATS migration — cross-probe only for slug/unknown failures.
+    if (probe.errorKind === 'slug_gone' || probe.errorKind === 'unknown') {
       const suggested = await discoverAlternates(name, { fetchJson });
       if (suggested) {
         results.push({ name, ...probe, suggested });
@@ -282,7 +282,7 @@ export async function verifyPortalsFile(
   { fetchJson = defaultFetchJson } = {},
 ) {
   if (!existsSync(filePath)) return { found: false, results: [] };
-  const config = yaml.load(readFileSync(filePath, "utf-8"));
+  const config = yaml.load(readFileSync(filePath, 'utf-8'));
   const companies = Array.isArray(config?.tracked_companies)
     ? config.tracked_companies
     : [];
@@ -290,32 +290,32 @@ export async function verifyPortalsFile(
   return { found: true, results };
 }
 
-const ICON = { live: "✅", empty: "🟡", missing: "❌", skipped: "➖" };
+const ICON = { live: '✅', empty: '🟡', missing: '❌', skipped: '➖' };
 
 const ERROR_KIND_LABEL = {
-  slug_gone: "slug not found",
-  auth: "auth blocked",
-  network: "network error",
-  server: "server error",
-  unknown: "unresolved",
+  slug_gone: 'slug not found',
+  auth: 'auth blocked',
+  network: 'network error',
+  server: 'server error',
+  unknown: 'unresolved',
 };
 
 function printResults(results) {
   for (const r of results) {
-    const icon = ICON[r.status] || "?";
+    const icon = ICON[r.status] || '?';
     let detail;
-    if (r.status === "live") {
+    if (r.status === 'live') {
       detail = `${r.ats}/${r.slug} (${r.jobCount} live)`;
-    } else if (r.status === "empty") {
+    } else if (r.status === 'empty') {
       detail = `${r.ats}/${r.slug} (live but empty)`;
-    } else if (r.status === "missing") {
-      const kind = ERROR_KIND_LABEL[r.errorKind] || "unresolved";
-      detail = `${r.ats || "?"}/${r.slug || "?"} (${kind}) — ${r.reason || "unresolved"}`;
+    } else if (r.status === 'missing') {
+      const kind = ERROR_KIND_LABEL[r.errorKind] || 'unresolved';
+      detail = `${r.ats || '?'}/${r.slug || '?'} (${kind}) — ${r.reason || 'unresolved'}`;
       if (r.suggested) {
         detail += ` → try ${r.suggested.ats}/${r.suggested.slug}`;
       }
     } else {
-      detail = r.reason || "";
+      detail = r.reason || '';
     }
     console.log(`  ${icon} ${r.name} — ${detail}`);
   }
@@ -324,22 +324,22 @@ function printResults(results) {
 async function runAdd(name, { fetchJson }) {
   const candidates = deriveSlugCandidates(name);
   if (candidates.length === 0) {
-    console.error("verify-portals: --add needs a company name");
+    console.error('verify-portals: --add needs a company name');
     process.exit(1);
   }
   console.log(
-    `Probing ${candidates.length} slug candidate(s) for "${name}" across Greenhouse/Ashby/Lever...\n`,
+    `Probing ${candidates.length} slug candidate(s) for '${name}' across Greenhouse/Ashby/Lever...\n`,
   );
   const hits = [];
   for (const slug of candidates) {
     for (const ats of Object.keys(ATS)) {
       const r = await probeSlug(ats, slug, { fetchJson });
-      if (r.status !== "missing") {
+      if (r.status !== 'missing') {
         hits.push(r);
         console.log(
           `  ${ICON[r.status]} ${ats}: ${slug}` +
-            (r.status === "empty"
-              ? " (live but empty)"
+            (r.status === 'empty'
+              ? ' (live but empty)'
               : ` (${r.jobCount} jobs)`),
         );
       }
@@ -347,30 +347,30 @@ async function runAdd(name, { fetchJson }) {
   }
   if (hits.length === 0) {
     console.log(
-      "  ❌ No slug variant resolved on any ATS. Check the careers_url manually.",
+      '  ❌ No slug variant resolved on any ATS. Check the careers_url manually.',
     );
   } else {
-    const best = hits.find((h) => h.status === "live") || hits[0];
+    const best = hits.find((h) => h.status === 'live') || hits[0];
     console.log(
-      `\nSuggested: careers_url for ${best.ats} → slug "${best.slug}"`,
+      `\nSuggested: careers_url for ${best.ats} → slug '${best.slug}'`,
     );
   }
 }
 
 async function main() {
   const args = process.argv.slice(2);
-  const strict = args.includes("--strict");
+  const strict = args.includes('--strict');
   const fetchJson = defaultFetchJson;
 
-  const addFlag = args.indexOf("--add");
+  const addFlag = args.indexOf('--add');
   if (addFlag !== -1) {
-    await runAdd(args[addFlag + 1] || "", { fetchJson });
+    await runAdd(args[addFlag + 1] || '', { fetchJson });
     return;
   }
 
-  const fileFlag = args.indexOf("--file");
+  const fileFlag = args.indexOf('--file');
   const filePath = resolve(
-    fileFlag === -1 ? DEFAULT_PORTALS_PATH : args[fileFlag + 1] || "",
+    fileFlag === -1 ? DEFAULT_PORTALS_PATH : args[fileFlag + 1] || '',
   );
 
   const { found, results } = await verifyPortalsFile(filePath, { fetchJson });
@@ -386,25 +386,34 @@ async function main() {
   console.log(`verify-portals: ${filePath}\n`);
   printResults(results);
 
-  const live = results.filter((r) => r.status === "live").length;
-  const empty = results.filter((r) => r.status === "empty").length;
-  const missing = results.filter((r) => r.status === "missing");
-  const skipped = results.filter((r) => r.status === "skipped").length;
-  const slugGone = missing.filter((r) => r.errorKind === "slug_gone").length;
-  const network = missing.filter((r) => r.errorKind === "network").length;
+  const live = results.filter((r) => r.status === 'live').length;
+  const empty = results.filter((r) => r.status === 'empty').length;
+  const missing = results.filter((r) => r.status === 'missing');
+  const skipped = results.filter((r) => r.status === 'skipped').length;
+  const kindCounts = Object.fromEntries(
+    Object.keys(ERROR_KIND_LABEL).map((k) => [k, 0]),
+  );
+  for (const r of missing) {
+    const k = r.errorKind && ERROR_KIND_LABEL[r.errorKind] ? r.errorKind : 'unknown';
+    kindCounts[k]++;
+  }
+  const breakdown = Object.entries(kindCounts)
+    .filter(([, n]) => n > 0)
+    .map(([k, n]) => `${n} ${ERROR_KIND_LABEL[k]}`)
+    .join(', ');
   console.log(
-    `\n${live} live, ${empty} live-but-empty, ${missing.length} unresolved (${slugGone} slug, ${network} network), ${skipped} non-ATS (skipped)`,
+    `\n${live} live, ${empty} live-but-empty, ${missing.length} unresolved${breakdown ? ` (${breakdown})` : ''}, ${skipped} non-ATS (skipped)`,
   );
 
   if (strict && missing.length > 0) {
-    console.log("🔴 Unresolved slugs found (--strict).");
+    console.log('🔴 Unresolved slugs found (--strict).');
     process.exit(1);
   }
 }
 
 // Only run main() when invoked directly (`node verify-portals.mjs`), not when
 // imported by tests. `|| ''` guards `node -e` invocations with no script arg.
-if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
   main().catch((err) => {
     console.error(`verify-portals failed: ${err.message}`);
     process.exit(1);

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -25,25 +25,27 @@
  * through an injectable `fetchJson`, so the pure logic is testable offline.
  */
 
-import { existsSync, readFileSync } from 'fs';
-import { resolve } from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import yaml from "js-yaml";
 
-import { fetchJson as defaultFetchJson } from './providers/_http.mjs';
+import { fetchJson as defaultFetchJson } from "./providers/_http.mjs";
 
-const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
+const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || "portals.yml";
 
 // How to turn a slug into a probe URL, and where the job list lives in the
 // response, for each supported ATS. Greenhouse/Ashby wrap jobs in `{ jobs }`;
 // Lever returns a bare array. `includeCompensation` mirrors the ashby provider.
 export const ATS = {
   greenhouse: {
-    probeUrl: (slug) => `https://boards-api.greenhouse.io/v1/boards/${slug}/jobs`,
+    probeUrl: (slug) =>
+      `https://boards-api.greenhouse.io/v1/boards/${slug}/jobs`,
     jobCount: (json) => (Array.isArray(json?.jobs) ? json.jobs.length : null),
   },
   ashby: {
-    probeUrl: (slug) => `https://api.ashbyhq.com/posting-api/job-board/${slug}?includeCompensation=true`,
+    probeUrl: (slug) =>
+      `https://api.ashbyhq.com/posting-api/job-board/${slug}?includeCompensation=true`,
     jobCount: (json) => (Array.isArray(json?.jobs) ? json.jobs.length : null),
   },
   lever: {
@@ -56,13 +58,16 @@ export const ATS = {
 // patterns mirror the provider `resolveApiUrl` regexes; the api-URL patterns
 // cover entries that pin the resolved endpoint directly. First match wins.
 const ATS_URL_PATTERNS = [
-  { ats: 'greenhouse', re: /boards-api\.greenhouse\.io\/v1\/boards\/([^/?#]+)/ },
-  { ats: 'greenhouse', re: /job-boards(?:\.eu)?\.greenhouse\.io\/([^/?#]+)/ },
-  { ats: 'greenhouse', re: /boards\.greenhouse\.io\/([^/?#]+)/ },
-  { ats: 'ashby', re: /api\.ashbyhq\.com\/posting-api\/job-board\/([^/?#]+)/ },
-  { ats: 'ashby', re: /jobs\.ashbyhq\.com\/([^/?#]+)/ },
-  { ats: 'lever', re: /api\.lever\.co\/v0\/postings\/([^/?#]+)/ },
-  { ats: 'lever', re: /jobs\.lever\.co\/([^/?#]+)/ },
+  {
+    ats: "greenhouse",
+    re: /boards-api\.greenhouse\.io\/v1\/boards\/([^/?#]+)/,
+  },
+  { ats: "greenhouse", re: /job-boards(?:\.eu)?\.greenhouse\.io\/([^/?#]+)/ },
+  { ats: "greenhouse", re: /boards\.greenhouse\.io\/([^/?#]+)/ },
+  { ats: "ashby", re: /api\.ashbyhq\.com\/posting-api\/job-board\/([^/?#]+)/ },
+  { ats: "ashby", re: /jobs\.ashbyhq\.com\/([^/?#]+)/ },
+  { ats: "lever", re: /api\.lever\.co\/v0\/postings\/([^/?#]+)/ },
+  { ats: "lever", re: /jobs\.lever\.co\/([^/?#]+)/ },
 ];
 
 /**
@@ -73,7 +78,7 @@ const ATS_URL_PATTERNS = [
  *   (branded careers pages, Workday, job boards, etc.) which this tool skips.
  */
 export function parseAtsSlug(url) {
-  const text = String(url || '');
+  const text = String(url || "");
   for (const { ats, re } of ATS_URL_PATTERNS) {
     const m = text.match(re);
     if (m && m[1]) return { ats, slug: m[1] };
@@ -92,18 +97,55 @@ export function parseAtsSlug(url) {
  * @param {string} name - Company display name.
  * @returns {string[]} Distinct candidate slugs, most-specific first.
  */
+const SLUG_SUFFIXES = ["ai", "tech", "io", "hq", "labs"];
+
 export function deriveSlugCandidates(name) {
-  const lower = String(name || '').toLowerCase().trim();
+  const lower = String(name || "")
+    .toLowerCase()
+    .trim();
   if (!lower) return [];
-  const words = lower.replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  const words = lower
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean);
   if (words.length === 0) return [];
   const candidates = [
-    words.join(''),    // acmecorp
-    words.join('-'),   // acme-corp
-    words.join('_'),   // acme_corp
-    words[0],          // acme
+    words.join(""), // acmecorp
+    words.join("-"), // acme-corp
+    words.join("_"), // acme_corp
+    words[0], // acme
   ];
+  const bases = [words.join(""), words[0]].filter(Boolean);
+  for (const base of bases) {
+    for (const suf of SLUG_SUFFIXES) candidates.push(`${base}${suf}`);
+    candidates.push(`${base}.tech`, `${base}.io`);
+  }
   return [...new Set(candidates)].filter(Boolean);
+}
+
+/**
+ * Classify a fetch/probe failure for scan summaries and slug diagnostics.
+ *
+ * @param {Error|{status?: number, name?: string, message?: string}|null|undefined} err
+ * @returns {'slug_gone'|'auth'|'network'|'server'|'unknown'}
+ */
+export function classifyFetchError(err) {
+  if (!err) return "unknown";
+  if (err.name === "AbortError") return "network";
+  const msg = String(err.message || err);
+  if (/ECONNREFUSED|ENOTFOUND|ETIMEDOUT|fetch failed|network/i.test(msg)) {
+    return "network";
+  }
+  const status = err.status;
+  if (status === 404 || status === 410) return "slug_gone";
+  if (status === 401 || status === 403) return "auth";
+  if (typeof status === "number" && status >= 500) return "server";
+  if (/HTTP 404|HTTP 410/.test(msg)) return "slug_gone";
+  if (/HTTP 401|HTTP 403/.test(msg)) return "auth";
+  if (/HTTP 5\d\d/.test(msg)) return "server";
+  return "unknown";
 }
 
 /**
@@ -112,22 +154,68 @@ export function deriveSlugCandidates(name) {
  * @param {string} ats - Key into ATS (greenhouse | ashby | lever).
  * @param {string} slug - Candidate slug to probe.
  * @param {{fetchJson?: Function}} [deps] - Injectable HTTP for testability.
- * @returns {Promise<{ats,slug,url,status,jobCount?,httpStatus?,reason?}>}
+ * @returns {Promise<{ats,slug,url,status,jobCount?,httpStatus?,errorKind?,reason?}>}
  *   status is 'live' (jobs > 0), 'empty' (200, no jobs), or 'missing'
  *   (404/error/unexpected shape).
  */
-export async function probeSlug(ats, slug, { fetchJson = defaultFetchJson } = {}) {
+export async function probeSlug(
+  ats,
+  slug,
+  { fetchJson = defaultFetchJson } = {},
+) {
   const spec = ATS[ats];
-  if (!spec) return { ats, slug, url: '', status: 'missing', reason: `unknown ATS: ${ats}` };
+  if (!spec)
+    return {
+      ats,
+      slug,
+      url: "",
+      status: "missing",
+      errorKind: "unknown",
+      reason: `unknown ATS: ${ats}`,
+    };
   const url = spec.probeUrl(slug);
   try {
     const json = await fetchJson(url);
     const count = spec.jobCount(json);
-    if (count == null) return { ats, slug, url, status: 'missing', reason: 'unexpected response shape' };
-    return { ats, slug, url, status: count > 0 ? 'live' : 'empty', jobCount: count };
+    if (count == null)
+      return {
+        ats,
+        slug,
+        url,
+        status: "missing",
+        errorKind: "unknown",
+        reason: "unexpected response shape",
+      };
+    return {
+      ats,
+      slug,
+      url,
+      status: count > 0 ? "live" : "empty",
+      jobCount: count,
+    };
   } catch (err) {
-    return { ats, slug, url, status: 'missing', httpStatus: err?.status, reason: err?.message || String(err) };
+    return {
+      ats,
+      slug,
+      url,
+      status: "missing",
+      errorKind: classifyFetchError(err),
+      httpStatus: err?.status,
+      reason: err?.message || String(err),
+    };
   }
+}
+
+/** Probe slug variants across all ATSes; prefer live boards over empty ones. */
+async function discoverAlternates(name, { fetchJson }) {
+  const hits = [];
+  for (const slug of deriveSlugCandidates(name)) {
+    for (const ats of Object.keys(ATS)) {
+      const r = await probeSlug(ats, slug, { fetchJson });
+      if (r.status !== "missing") hits.push(r);
+    }
+  }
+  return hits.find((h) => h.status === "live") || hits[0] || null;
 }
 
 /**
@@ -142,19 +230,40 @@ export async function probeSlug(ats, slug, { fetchJson = defaultFetchJson } = {}
  * @param {{fetchJson?: Function}} [deps]
  * @returns {Promise<Array<object>>} One result row per company.
  */
-export async function verifyCompanies(companies, { fetchJson = defaultFetchJson } = {}) {
+export async function verifyCompanies(
+  companies,
+  { fetchJson = defaultFetchJson } = {},
+) {
   const list = Array.isArray(companies) ? companies : [];
   const results = [];
   for (const company of list) {
-    if (!company || typeof company !== 'object') continue;
+    if (!company || typeof company !== "object") continue;
     if (company.enabled === false) continue;
-    const name = typeof company.name === 'string' ? company.name : '(unnamed)';
-    const match = parseAtsSlug(company.api) || parseAtsSlug(company.careers_url);
+    const name = typeof company.name === "string" ? company.name : "(unnamed)";
+    const match =
+      parseAtsSlug(company.api) || parseAtsSlug(company.careers_url);
     if (!match) {
-      results.push({ name, status: 'skipped', reason: 'no Greenhouse/Ashby/Lever slug in careers_url or api' });
+      results.push({
+        name,
+        status: "skipped",
+        reason: "no Greenhouse/Ashby/Lever slug in careers_url or api",
+      });
       continue;
     }
     const probe = await probeSlug(match.ats, match.slug, { fetchJson });
+    if (probe.status === "live" || probe.status === "empty") {
+      results.push({ name, ...probe });
+      continue;
+    }
+    // Wrong slug or ATS migration — cross-probe variants unless the failure
+    // looks transient (network / server error on the configured board).
+    if (probe.errorKind !== "network" && probe.errorKind !== "server") {
+      const suggested = await discoverAlternates(name, { fetchJson });
+      if (suggested) {
+        results.push({ name, ...probe, suggested });
+        continue;
+      }
+    }
     results.push({ name, ...probe });
   }
   return results;
@@ -168,24 +277,46 @@ export async function verifyCompanies(companies, { fetchJson = defaultFetchJson 
  * @returns {Promise<{found: boolean, results: Array<object>}>} found=false when
  *   the file is absent (a graceful no-op for fresh setups / CI).
  */
-export async function verifyPortalsFile(filePath, { fetchJson = defaultFetchJson } = {}) {
+export async function verifyPortalsFile(
+  filePath,
+  { fetchJson = defaultFetchJson } = {},
+) {
   if (!existsSync(filePath)) return { found: false, results: [] };
-  const config = yaml.load(readFileSync(filePath, 'utf-8'));
-  const companies = Array.isArray(config?.tracked_companies) ? config.tracked_companies : [];
+  const config = yaml.load(readFileSync(filePath, "utf-8"));
+  const companies = Array.isArray(config?.tracked_companies)
+    ? config.tracked_companies
+    : [];
   const results = await verifyCompanies(companies, { fetchJson });
   return { found: true, results };
 }
 
-const ICON = { live: '✅', empty: '🟡', missing: '❌', skipped: '➖' };
+const ICON = { live: "✅", empty: "🟡", missing: "❌", skipped: "➖" };
+
+const ERROR_KIND_LABEL = {
+  slug_gone: "slug not found",
+  auth: "auth blocked",
+  network: "network error",
+  server: "server error",
+  unknown: "unresolved",
+};
 
 function printResults(results) {
   for (const r of results) {
-    const icon = ICON[r.status] || '?';
-    const detail =
-      r.status === 'live' ? `${r.ats}/${r.slug} (${r.jobCount} live)` :
-      r.status === 'empty' ? `${r.ats}/${r.slug} (live but empty)` :
-      r.status === 'missing' ? `${r.ats || '?'}/${r.slug || '?'} — ${r.reason || 'unresolved'}` :
-      r.reason || '';
+    const icon = ICON[r.status] || "?";
+    let detail;
+    if (r.status === "live") {
+      detail = `${r.ats}/${r.slug} (${r.jobCount} live)`;
+    } else if (r.status === "empty") {
+      detail = `${r.ats}/${r.slug} (live but empty)`;
+    } else if (r.status === "missing") {
+      const kind = ERROR_KIND_LABEL[r.errorKind] || "unresolved";
+      detail = `${r.ats || "?"}/${r.slug || "?"} (${kind}) — ${r.reason || "unresolved"}`;
+      if (r.suggested) {
+        detail += ` → try ${r.suggested.ats}/${r.suggested.slug}`;
+      }
+    } else {
+      detail = r.reason || "";
+    }
     console.log(`  ${icon} ${r.name} — ${detail}`);
   }
 }
@@ -193,68 +324,87 @@ function printResults(results) {
 async function runAdd(name, { fetchJson }) {
   const candidates = deriveSlugCandidates(name);
   if (candidates.length === 0) {
-    console.error('verify-portals: --add needs a company name');
+    console.error("verify-portals: --add needs a company name");
     process.exit(1);
   }
-  console.log(`Probing ${candidates.length} slug candidate(s) for "${name}" across Greenhouse/Ashby/Lever...\n`);
+  console.log(
+    `Probing ${candidates.length} slug candidate(s) for "${name}" across Greenhouse/Ashby/Lever...\n`,
+  );
   const hits = [];
   for (const slug of candidates) {
     for (const ats of Object.keys(ATS)) {
       const r = await probeSlug(ats, slug, { fetchJson });
-      if (r.status !== 'missing') {
+      if (r.status !== "missing") {
         hits.push(r);
-        console.log(`  ${ICON[r.status]} ${ats}: ${slug}` + (r.status === 'empty' ? ' (live but empty)' : ` (${r.jobCount} jobs)`));
+        console.log(
+          `  ${ICON[r.status]} ${ats}: ${slug}` +
+            (r.status === "empty"
+              ? " (live but empty)"
+              : ` (${r.jobCount} jobs)`),
+        );
       }
     }
   }
   if (hits.length === 0) {
-    console.log('  ❌ No slug variant resolved on any ATS. Check the careers_url manually.');
+    console.log(
+      "  ❌ No slug variant resolved on any ATS. Check the careers_url manually.",
+    );
   } else {
-    const best = hits.find(h => h.status === 'live') || hits[0];
-    console.log(`\nSuggested: careers_url for ${best.ats} → slug "${best.slug}"`);
+    const best = hits.find((h) => h.status === "live") || hits[0];
+    console.log(
+      `\nSuggested: careers_url for ${best.ats} → slug "${best.slug}"`,
+    );
   }
 }
 
 async function main() {
   const args = process.argv.slice(2);
-  const strict = args.includes('--strict');
+  const strict = args.includes("--strict");
   const fetchJson = defaultFetchJson;
 
-  const addFlag = args.indexOf('--add');
+  const addFlag = args.indexOf("--add");
   if (addFlag !== -1) {
-    await runAdd(args[addFlag + 1] || '', { fetchJson });
+    await runAdd(args[addFlag + 1] || "", { fetchJson });
     return;
   }
 
-  const fileFlag = args.indexOf('--file');
-  const filePath = resolve(fileFlag === -1 ? DEFAULT_PORTALS_PATH : args[fileFlag + 1] || '');
+  const fileFlag = args.indexOf("--file");
+  const filePath = resolve(
+    fileFlag === -1 ? DEFAULT_PORTALS_PATH : args[fileFlag + 1] || "",
+  );
 
   const { found, results } = await verifyPortalsFile(filePath, { fetchJson });
   if (!found) {
     // Graceful no-op: fresh setups (and CI, which ships no portals.yml) have
     // nothing to verify. Not an error.
-    console.log(`verify-portals: no portals file at ${filePath} — nothing to verify (run onboarding first).`);
+    console.log(
+      `verify-portals: no portals file at ${filePath} — nothing to verify (run onboarding first).`,
+    );
     return;
   }
 
   console.log(`verify-portals: ${filePath}\n`);
   printResults(results);
 
-  const live = results.filter(r => r.status === 'live').length;
-  const empty = results.filter(r => r.status === 'empty').length;
-  const missing = results.filter(r => r.status === 'missing');
-  const skipped = results.filter(r => r.status === 'skipped').length;
-  console.log(`\n${live} live, ${empty} live-but-empty, ${missing.length} unresolved, ${skipped} non-ATS (skipped)`);
+  const live = results.filter((r) => r.status === "live").length;
+  const empty = results.filter((r) => r.status === "empty").length;
+  const missing = results.filter((r) => r.status === "missing");
+  const skipped = results.filter((r) => r.status === "skipped").length;
+  const slugGone = missing.filter((r) => r.errorKind === "slug_gone").length;
+  const network = missing.filter((r) => r.errorKind === "network").length;
+  console.log(
+    `\n${live} live, ${empty} live-but-empty, ${missing.length} unresolved (${slugGone} slug, ${network} network), ${skipped} non-ATS (skipped)`,
+  );
 
   if (strict && missing.length > 0) {
-    console.log('🔴 Unresolved slugs found (--strict).');
+    console.log("🔴 Unresolved slugs found (--strict).");
     process.exit(1);
   }
 }
 
 // Only run main() when invoked directly (`node verify-portals.mjs`), not when
 // imported by tests. `|| ''` guards `node -e` invocations with no script arg.
-if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
   main().catch((err) => {
     console.error(`verify-portals failed: ${err.message}`);
     process.exit(1);


### PR DESCRIPTION

## What does this PR do?

Wires verify-portals into scan.mjs so bad slugs and empty boards show up with clear signals and suggested fixes, instead of failing silently.

## Related issue

Fixes #1432 

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced portal slug verification with broader candidate generation and smarter alternate cross-checking.
  * Improved results output with per-error categorization and clearer “try ATS/slug” suggestions.
  * Added end-of-run visibility for live targets that return no jobs.
* **Bug Fixes**
  * More accurate classification of probe failures (e.g., slug gone vs network/server) and improved missing/unresolved reporting.
  * Expanded checklist details in the strict slug validator flow.
* **Tests**
  * Expanded coverage for slug candidate derivation, failure classification, and richer per-company suggestion/status assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->