### PR TITLE
fix(web): restore the report-a-bug kit lost between the RC branch and main

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,54 @@
+# career-ops web (alpha)
+
+An **experimental, opt-in web UI** for career-ops. It is a local-first *view* over
+the exact same files the CLI reads and writes (`data/pipeline.md`,
+`data/applications.md`, `reports/`, `config/`): no parallel engine, no separate
+database, no server. If you never run it, nothing about your CLI workflow changes.
+
+> **Status: alpha.** Expect rough edges. Feedback →
+> [Discussion #1142](https://github.com/santifer/career-ops/discussions/1142) ·
+> roadmap context → [Discussion #156](https://github.com/santifer/career-ops/discussions/156).
+
+## Quick start
+
+Requires Node 20+.
+
+```bash
+cd web
+npm ci
+npm run dev
+```
+
+Open http://localhost:3000. The app reads the career-ops checkout it lives in
+(the parent directory) — your existing CV, pipeline and reports appear as-is.
+
+## What works today
+
+- **Pipeline** — your tracker as a sortable, filterable table; status changes
+  write back through the core's own scripts.
+- **Explore** — the free reverse-ATS scan with an honest partial-dataset
+  indicator, plus AI-assisted discovery (bring your own CLI/keys).
+- **Apply** — assisted form prefill with a hard rule inherited from the core:
+  **it never submits for you** — you always press the button.
+- **Today / Analytics / CV / Config** — action queue, funnel, CV editing with
+  preview, settings.
+
+## Safety
+
+- **Local-first:** the local web app runs entirely on your machine — no cloud,
+  no account needed. Your CV and data stay in your own files.
+- **Never auto-submits:** the apply flow drafts and prefills; submitting is
+  always a human action.
+- **Additive:** the web is isolated from the core's packaging, CI and release
+  automation. The CLI works exactly the same without it.
+
+## Development
+
+```bash
+npm run dev          # dev server (Turbopack)
+npx tsc --noEmit     # typecheck
+npm run build        # production build
+```
+
+Set `CAREER_OPS_ROOT=/path/to/checkout` in `web/.env.local` to point the app at
+a different career-ops directory (useful for testing against sample data).

--- a/web/src/app/api/version/route.ts
+++ b/web/src/app/api/version/route.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+
+// The WEB build's own version + channel (NOT the user's data checkout) — read from
+// the repo's VERSION (parent of the web/ cwd). The channel is derived from a
+// pre-release suffix (`-rc`/`-beta`) so the UI can show a beta banner + the bug
+// reporter can tag the right release. Invisible to stable installs (the updater
+// reads VERSION from `main`, which stays stable while the bundle lives on a branch).
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function readVersion(): string {
+  const candidates = [path.join(process.cwd(), "..", "VERSION"), path.join(process.cwd(), "VERSION")];
+  for (const p of candidates) {
+    try {
+      const v = fs.readFileSync(p, "utf8").split(/\s+/)[0].trim();
+      if (v) return v;
+    } catch {
+      /* next candidate */
+    }
+  }
+  return "";
+}
+
+function shortSha(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", { cwd: process.cwd(), stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+  } catch {
+    return "";
+  }
+}
+
+function webVersion(): string {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8"));
+    return typeof pkg.version === "string" ? pkg.version : "";
+  } catch {
+    return "";
+  }
+}
+
+export async function GET() {
+  const coreVersion = readVersion();
+  const web = webVersion();
+  const m = coreVersion.match(/-(rc|beta|alpha|next)\b/i);
+  // Channel precedence: an explicit core pre-release suffix wins (RC installs);
+  // otherwise the web component's own maturity decides — pre-1.0 on main IS the
+  // alpha (release-please versions web/ independently), and the banner/bug-report
+  // stay visible until the web graduates to 1.0.
+  const channel = m ? m[1].toLowerCase() : web && /^0\./.test(web) ? "alpha" : "stable";
+  const version = web ? `web ${web}` : coreVersion;
+  return Response.json({ version, coreVersion, channel, sha: shortSha() });
+}

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -12,6 +12,7 @@ import { PipelineProvider } from "@/components/pipeline/pipeline-provider";
 import { ApplyProvider } from "@/components/apply/apply-provider";
 import { ExploreProvider } from "@/components/explore/explore-provider";
 import { FirstScoreView } from "@/components/explore/first-score-view";
+import { BetaBanner } from "@/components/beta/beta-banner";
 import { WorkerPills } from "@/components/jobs/worker-pills";
 import { UsageMeter } from "@/components/usage-meter";
 import { instrumentSerif } from "@/lib/fonts";
@@ -72,6 +73,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <main className="flex-1 overflow-x-hidden">{children}</main>
         <AssistantConsole />
         <FirstScoreView />
+        <BetaBanner />
       </div>
       </ExploreProvider>
       </ApplyProvider>

--- a/web/src/components/beta/beta-banner.tsx
+++ b/web/src/components/beta/beta-banner.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Bug, X, ShieldCheck } from "lucide-react";
+import { collect, issueBody, issueUrl, type Diag } from "@/lib/report/report";
+import "@/lib/report/logbuf"; // install the client error ring-buffer (side-effect)
+
+// Beta/RC differentiator: a small version+channel pill (only on a pre-release
+// channel) + a one-click "Report a bug" that opens a PRE-FILLED GitHub issue. No
+// telemetry to any server (local-first / firewall) — the user reviews the exact,
+// PII-scrubbed payload (preview-then-confirm) and clicks to open the issue himself.
+export function BetaBanner() {
+  const [meta, setMeta] = useState<{ version: string; channel: string; sha: string } | null>(null);
+  const [open, setOpen] = useState(false);
+  const [desc, setDesc] = useState("");
+  const [diag, setDiag] = useState<Diag | null>(null);
+
+  useEffect(() => {
+    fetch("/api/version")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d?.channel && d.channel !== "stable") setMeta(d);
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const openReport = async () => {
+    setDiag(await collect());
+    setOpen(true);
+  };
+
+  if (!meta) return null;
+
+  return (
+    <>
+      <div className="fixed bottom-3 left-3 z-[70] flex items-center gap-2 rounded-full border border-brand/30 bg-surface/90 px-3 py-1.5 text-xs shadow-lg backdrop-blur-md">
+        <span className="flex items-center gap-1.5 font-medium text-brand">
+          <span className="size-1.5 animate-pulse rounded-full bg-brand" /> {meta.version} · {meta.channel}
+        </span>
+        {meta.sha && <span className="hidden font-mono text-faint sm:inline">{meta.sha}</span>}
+        <button onClick={openReport} className="ml-1 inline-flex items-center gap-1 rounded-full bg-brand-soft px-2 py-0.5 font-medium text-brand transition-colors hover:bg-brand/15">
+          <Bug className="size-3" /> Report a bug
+        </button>
+      </div>
+
+      {open && diag && (
+        <div className="fixed inset-0 z-[96] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label="Report a bug" onClick={() => setOpen(false)}>
+          <div className="w-full max-w-lg rounded-2xl border border-border bg-[var(--bg)] p-5 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+            <div className="mb-3 flex items-center gap-2">
+              <Bug className="size-4 text-brand" />
+              <h2 className="text-sm font-semibold text-foreground">Report a bug · {diag.channel}</h2>
+              <button onClick={() => setOpen(false)} aria-label="Close" className="ml-auto text-faint transition-colors hover:text-foreground">
+                <X className="size-4" />
+              </button>
+            </div>
+            <textarea
+              value={desc}
+              onChange={(e) => setDesc(e.target.value)}
+              rows={4}
+              autoFocus
+              placeholder="What were you doing, and what went wrong?"
+              className="w-full resize-none rounded-lg border border-border bg-surface/60 px-3 py-2 text-sm outline-none transition focus:border-brand/50 focus:ring-2 focus:ring-brand/20"
+            />
+            <details className="mt-3 rounded-lg border border-border bg-surface/40">
+              <summary className="cursor-pointer select-none px-3 py-2 text-xs font-medium text-muted">Exactly what gets attached — review before sending ↓</summary>
+              <pre className="max-h-52 overflow-auto whitespace-pre-wrap border-t border-border px-3 py-2 font-mono text-[11px] leading-relaxed text-muted">{issueBody(diag, desc)}</pre>
+            </details>
+            <p className="mt-2 flex items-start gap-1.5 text-[11px] text-faint">
+              <ShieldCheck className="mt-px size-3.5 shrink-0 text-emerald-500" /> Opens a GitHub issue you confirm — nothing is sent until you click. NEVER includes your CV, profile, application answers, or job URLs.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button onClick={() => setOpen(false)} className="rounded-full px-4 py-2 text-sm text-muted transition-colors hover:text-foreground">
+                Cancel
+              </button>
+              <a
+                href={issueUrl(diag, desc)}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() => setOpen(false)}
+                className="inline-flex items-center gap-1.5 rounded-full bg-brand px-4 py-2 text-sm font-medium text-brand-foreground transition-colors hover:bg-brand-200"
+              >
+                <Bug className="size-4" /> Open GitHub issue
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/lib/report/logbuf.ts
+++ b/web/src/lib/report/logbuf.ts
@@ -1,0 +1,34 @@
+// A tiny client-side ring buffer of recent ERRORS (not arbitrary logs → far less
+// PII surface) for the in-app bug reporter. Installed once on first import.
+const MAX = 20;
+const BUF: string[] = [];
+
+function push(s: string) {
+  BUF.push(s.replace(/\s+/g, " ").slice(0, 300));
+  if (BUF.length > MAX) BUF.shift();
+}
+
+declare global {
+  interface Window {
+    __coLogBufInstalled?: boolean;
+  }
+}
+
+if (typeof window !== "undefined" && !window.__coLogBufInstalled) {
+  window.__coLogBufInstalled = true;
+  const orig = console.error.bind(console);
+  console.error = (...args: unknown[]) => {
+    try {
+      push("[error] " + args.map((a) => (a instanceof Error ? `${a.message}` : String(a))).join(" "));
+    } catch {
+      /* never break logging */
+    }
+    orig(...args);
+  };
+  window.addEventListener("error", (e) => push(`[onerror] ${e.message || ""} @ ${e.filename || ""}:${e.lineno || ""}`));
+  window.addEventListener("unhandledrejection", (e) => push(`[rejection] ${String((e as PromiseRejectionEvent).reason)}`));
+}
+
+export function recentLogs(): string[] {
+  return BUF.slice();
+}

--- a/web/src/lib/report/report.ts
+++ b/web/src/lib/report/report.ts
@@ -1,0 +1,85 @@
+import { recentLogs } from "./logbuf";
+
+const REPO = "santifer/career-ops";
+
+/** Strip PII / secrets that could ride in error text, paths or logs BEFORE anything
+ *  leaves the machine. Defence-in-depth — the user also reviews the full payload
+ *  (preview-then-confirm) before the issue opens. */
+export function scrub(s: string): string {
+  return (s || "")
+    .replace(/\/Users\/[^/\s"']+/g, "~")
+    .replace(/\/home\/[^/\s"']+/g, "~")
+    .replace(/(sk|key|token|secret|bearer|api[-_]?key)([-_=:\s"']+)[A-Za-z0-9._-]{8,}/gi, "$1$2[redacted]");
+}
+
+export type Diag = {
+  version: string;
+  channel: string;
+  sha: string;
+  route: string;
+  cli: string;
+  ua: string;
+  viewport: string;
+  logs: string[];
+};
+
+/** Gather a STRUCTURAL diagnostic snapshot. Deliberately excludes anything personal:
+ *  no cv.md, no profile, no application answers, no job URLs, no report content. */
+export async function collect(): Promise<Diag> {
+  let version = "";
+  let channel = "stable";
+  let sha = "";
+  try {
+    const d = await (await fetch("/api/version")).json();
+    version = d.version || "";
+    channel = d.channel || "stable";
+    sha = d.sha || "";
+  } catch {
+    /* keep defaults */
+  }
+  let cli = "";
+  try {
+    cli = JSON.parse(localStorage.getItem("career-ops:config") || "{}").cliId || "";
+  } catch {
+    /* none */
+  }
+  return {
+    version,
+    channel,
+    sha,
+    route: scrub(location.pathname + location.search),
+    cli,
+    ua: navigator.userAgent,
+    viewport: `${window.innerWidth}×${window.innerHeight}`,
+    logs: recentLogs().map(scrub),
+  };
+}
+
+/** The EXACT markdown body the user reviews and that becomes the GitHub issue. */
+export function issueBody(d: Diag, description: string): string {
+  return [
+    "## What happened",
+    scrub(description).trim() || "_(describe what you were doing and what went wrong)_",
+    "",
+    "## Environment",
+    `- **Version:** \`${d.version || "?"}\` · ${d.channel}${d.sha ? ` · \`${d.sha}\`` : ""}`,
+    `- **CLI:** ${d.cli || "—"}`,
+    `- **Screen:** \`${d.route}\``,
+    `- **Browser:** ${scrub(d.ua)}`,
+    `- **Viewport:** ${d.viewport}`,
+    "",
+    "## Recent errors",
+    d.logs.length ? "```\n" + d.logs.join("\n") + "\n```" : "_(none captured)_",
+    "",
+    "---",
+    "_Filed from the in-app bug reporter. Contains NO CV, profile, application answers, or job URLs._",
+  ]
+    .join("\n")
+    .slice(0, 6000);
+}
+
+export function issueUrl(d: Diag, description: string): string {
+  const title = `[web ${d.channel}] ${(scrub(description) || "bug report").replace(/\s+/g, " ").trim().slice(0, 70)}`;
+  const params = new URLSearchParams({ title, body: issueBody(d, description), labels: "web-alpha,area:web" });
+  return `https://github.com/${REPO}/issues/new?${params.toString()}`;
+}


### PR DESCRIPTION
Found during the post-merge verification sweep: the **version pill + one-click "Report a bug"** (pre-filled GitHub issue, PII-scrubbed payload with preview-then-confirm, zero server telemetry) shipped on `release/2.0.0-rc.1` but never lived on the working branch — so the #1451 snapshot silently dropped it. This restores it, adapted to the web-on-main model:

- `/api/version` reports the web component's own version (from `web/package.json`, release-please-managed) alongside the core `VERSION`; the channel derives from a core pre-release suffix when present, otherwise **`alpha` while the web is pre-1.0** — so the pill and bug reporter stay active exactly until the web graduates.
- Bug-report labels: `2.0-beta` → `web-alpha` (label created).
- `BetaBanner` mounted in the app shell, as it was on the RC.

Verified live: `/api/version` → `{"version":"web 0.0.0","coreVersion":"1.16.0","channel":"alpha"}`, typecheck clean.

Note for the maintainer: `.github/ISSUE_TEMPLATE/web-beta-bug.yml` also stayed behind on the RC branch (root — your lane); the reporter works without it (query-param issue), but the form template is nicer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a beta banner that shows the current app version/channel and a bug-report flow for non-stable builds.
  * Added an in-app issue reporter that collects basic diagnostics and pre-fills a GitHub issue.
  * Added a version endpoint so the app can display build and release-channel information.

* **Documentation**
  * Rewrote the web app README with setup, usage, feature coverage, safety notes, and local configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->