### PR TITLE
fix(dedup): require exact company+role match so distinct same-company roles aren't merged

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -2,9 +2,10 @@
 /**
  * dedup-tracker.mjs — Remove duplicate entries from applications.md
  *
- * Groups by normalized company + fuzzy role match.
- * Keeps entry with highest score. If discarded entry had more advanced status,
- * preserves that status. Merges notes.
+ * Groups by normalized company, then merges only rows whose full role title
+ * matches exactly (case- and whitespace-normalized). Keeps entry with highest
+ * score. If discarded entry had more advanced status, preserves that status.
+ * Merges notes.
  *
  * Run: node career-ops/dedup-tracker.mjs [--dry-run]
  */
@@ -12,7 +13,6 @@
 import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { roleFuzzyMatch } from './role-matcher.mjs';
 import { rebuildRow } from './tracker-utils.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 
@@ -156,7 +156,7 @@ function sameReportIdentity(a, b) {
 }
 
 /**
- * Build a stable key for logging one protected fuzzy pair only once.
+ * Build a stable key for logging one protected same-title pair only once.
  *
  * The nested dedup loop can encounter a protected pair during cluster building.
  * Sorting the row numbers produces the same key regardless of comparison order,
@@ -170,16 +170,42 @@ function pairKey(a, b) {
   return [a.num, b.num].sort((x, y) => x - y).join(':');
 }
 
-const protectedFuzzyPairs = new Set();
+const protectedTitlePairs = new Set();
+
+/**
+ * Normalize a role title into the key used for exact same-opening comparison.
+ *
+ * Deduplication must only collapse rows that describe the *same* opening, so
+ * the comparison is exact on the meaningful title text. Only presentation noise
+ * is removed — letter case and whitespace (leading, trailing, and repeated
+ * internal spaces). Distinguishing words such as seniority ("Senior") or the
+ * team suffix ("Data Infrastructure" vs "Agent Infrastructure") are preserved,
+ * so sibling roles at one company are never merged.
+ *
+ * @param {string} role - Role title from an applications.md row.
+ * @returns {string} Lowercase, whitespace-collapsed role key.
+ */
+function normalizeRole(role) {
+  return String(role ?? '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
 
 /**
  * Decide whether two same-company tracker rows should be deduplicated.
  *
- * The function first accepts exact report identity, then applies the shared
- * fuzzy role matcher. If either row is already Applied or later, fuzzy matching
- * alone is not enough; dedup keeps both rows and warns because deleting one
- * would lose application status, report link, and notes for a potentially
- * distinct opening.
+ * Rows merge only when they describe the same opening: either the exact same
+ * report identity (same tracker number or bracketed report number), or an exact
+ * role-title match after normalizing case and whitespace. Fuzzy title matching
+ * is deliberately NOT used here — it collapsed distinct sibling roles at one
+ * company (e.g. "Software Engineer, Data Infrastructure" vs "Senior Software
+ * Engineer, Agent Infrastructure"), causing real data loss.
+ *
+ * When titles match exactly but either row is already Applied or later, dedup
+ * still keeps both and warns: deleting an in-flight application would lose its
+ * status, report link, and notes unless the rows are the exact same report
+ * identity.
  *
  * @param {object} a - First parsed applications.md row.
  * @param {object} b - Second parsed applications.md row.
@@ -187,18 +213,18 @@ const protectedFuzzyPairs = new Set();
  */
 function roleMatch(a, b) {
   if (sameReportIdentity(a, b)) return true;
-  if (!roleFuzzyMatch(a.role, b.role)) return false;
+  if (normalizeRole(a.role) !== normalizeRole(b.role)) return false;
 
-  // Fuzzy title matches are intentionally conservative once either row has
-  // entered the real application pipeline. A user may already have applied to
-  // one sibling role, so deleting that row because a higher-scored sibling has
-  // similar wording would lose status, report, and notes. Keep both unless the
-  // rows point to the exact same report identity.
+  // Exact-title duplicates that have entered the real application pipeline are
+  // kept separate. A user may already have applied to one row; deleting it
+  // because a higher-scored exact-title sibling exists would lose status,
+  // report, and notes. Keep both unless the rows point to the exact same
+  // report identity.
   if (isAdvancedStatus(a.status) || isAdvancedStatus(b.status)) {
     const key = pairKey(a, b);
-    if (!protectedFuzzyPairs.has(key)) {
-      protectedFuzzyPairs.add(key);
-      console.warn(`⚠️  Keep #${a.num} and #${b.num}: fuzzy role match but advanced status requires exact report identity`);
+    if (!protectedTitlePairs.has(key)) {
+      protectedTitlePairs.add(key);
+      console.warn(`⚠️  Keep #${a.num} and #${b.num}: exact-title match but advanced status requires exact report identity`);
     }
     return false;
   }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3442,7 +3442,15 @@ try {
       '| 27 | 2026-01-08 | Acme | Solutions Engineer, Revenue | 3.0/5 | Applied | ❌ | [27](../reports/027-revenue-applied.md) | applied exact-title row |\n' +
       '| 28 | 2026-01-09 | Acme | Solutions Engineer, Revenue | 4.6/5 | Evaluated | ❌ | [28](../reports/028-revenue-eval.md) | evaluated exact-title row |\n' +
       '| 29 | 2026-01-08 | Acme | Data Engineer, Search | 3.1/5 | Applied | ❌ | [29](../reports/029-search-old.md) | malformed duplicate-number old row |\n' +
-      '| 29 | 2026-01-09 | Acme | Data Engineer, Search | 4.1/5 | Evaluated | ❌ | [30](../reports/030-search-new.md) | malformed duplicate-number new row |\n');
+      '| 29 | 2026-01-09 | Acme | Data Engineer, Search | 4.1/5 | Evaluated | ❌ | [30](../reports/030-search-new.md) | malformed duplicate-number new row |\n' +
+      // Distinct sibling roles at one company that the old fuzzy matcher
+      // false-merged (shared [software, engineer, infrastructure] → Jaccard 0.6).
+      // Exact company+title matching must keep both openings.
+      '| 31 | 2026-01-10 | Cohere | Software Engineer, Data Infrastructure | 3.4/5 | Evaluated | ❌ | [31](../reports/013-cohere-data-infra.md) | distinct role — must survive |\n' +
+      '| 32 | 2026-01-10 | Cohere | Senior Software Engineer, Agent Infrastructure | 4.0/5 | Evaluated | ❌ | [32](../reports/014-cohere-agent-infra.md) | distinct role — higher score |\n' +
+      // Exact company+role duplicate of #32 (same title, both Evaluated) — must
+      // collapse to one, keeping the higher score.
+      '| 33 | 2026-01-11 | Cohere | Senior Software Engineer, Agent Infrastructure | 3.7/5 | Evaluated | ❌ | [33](../reports/033-cohere-agent-dup.md) | exact-title duplicate |\n');
 
     const dedupResult = run(NODE, ['dedup-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
     if (dedupResult === null) {
@@ -3481,6 +3489,24 @@ try {
         pass('dedup-tracker handles duplicate tracker numbers using row-local line indexes');
       } else {
         fail(`dedup-tracker duplicate-number handling broken: ${searchRows.length} Search rows`);
+      }
+
+      // Regression: the old fuzzy matcher scored "Software Engineer, Data
+      // Infrastructure" and "Senior Software Engineer, Agent Infrastructure" at
+      // Jaccard 0.6 and deleted the lower-scored distinct role. Exact
+      // company+title matching must keep both openings.
+      const cohereDataInfra = deduped.split('\n').filter(l => l.includes('| Software Engineer, Data Infrastructure |'));
+      if (cohereDataInfra.length === 1) {
+        pass('dedup-tracker keeps distinct same-company Cohere role (Data Infrastructure) — no fuzzy false-merge');
+      } else {
+        fail(`dedup-tracker false-merged the distinct Cohere Data Infrastructure role: ${cohereDataInfra.length} rows`);
+      }
+
+      const cohereAgentInfra = deduped.split('\n').filter(l => l.includes('| Senior Software Engineer, Agent Infrastructure |'));
+      if (cohereAgentInfra.length === 1 && cohereAgentInfra[0].includes('4.0/5')) {
+        pass('dedup-tracker merges an exact company+role duplicate to one (keeps highest score)');
+      } else {
+        fail(`dedup-tracker exact-duplicate handling broken: ${cohereAgentInfra.length} Cohere Agent Infrastructure rows`);
       }
     }
   } finally {


### PR DESCRIPTION
## What does this PR do?

`dedup-tracker.mjs` now merges two same-company tracker rows only when they describe the **same opening** — exact report identity, or an exact role-title match (case/whitespace-normalized). It no longer uses the fuzzy `roleFuzzyMatch()`, which was silently deleting distinct sibling roles.

## Related issue

None — this is a **bug fix**, which CONTRIBUTING.md exempts from issue-first.

## The bug

`roleMatch()` used the shared fuzzy `roleFuzzyMatch()` to decide whether two same-company rows were duplicates. That matcher collapses distinct sibling roles that happen to share generic title words. Concrete case at Cohere:

| Role | Tokens (stopwords stripped) |
|------|------|
| `Software Engineer, Data Infrastructure` | `software, engineer, data, infrastructure` |
| `Senior Software Engineer, Agent Infrastructure` | `software, engineer, agent, infrastructure` |

Overlap `{software, engineer, infrastructure}` = 3, union = 5 → **Jaccard 3/5 = 0.6**, which hits the `>= 0.6` threshold, so the two are treated as the same job. Both rows were `Evaluated`, so the advanced-status guard never fired, and the lower-scored distinct role (its own evaluation + report) was **deleted**. In a real run this dropped 14 tracker rows when only ~1 was a genuine duplicate — data loss, not deduplication.

## The fix

- `roleMatch()` now merges only on **exact report identity** or an **exact role-title match**.
- New `normalizeRole()` normalizes **only** presentation noise — letter case and whitespace (leading/trailing/repeated). It never strips distinguishing words, so `Senior`, `Data Infrastructure` vs `Agent Infrastructure`, etc. keep sibling roles apart.
- All existing safety behavior is preserved: the `sameReportIdentity` bypass (duplicate tracker numbers), the Applied+ advanced-status guard, the highest-score / most-advanced-status tie-break, and the `applications.md.bak` backup-before-write.
- Removed the now-unused `roleFuzzyMatch` import. `role-matcher.mjs` is untouched — `merge-tracker.mjs` still uses it for repost detection, which is a different (append-time) decision.

## Verification

Extended the existing dedup fixture in `test-all.mjs` with the Cohere scenario:
1. `Software Engineer, Data Infrastructure` and `Senior Software Engineer, Agent Infrastructure` are **not** merged (distinct openings survive).
2. An exact company+role duplicate collapses to one, keeping the highest score.

`node test-all.mjs` → **987 passed, 0 failed**. The only non-pass is the Go dashboard build, which the suite gracefully **skips** when the Go toolchain isn't in the environment (unrelated to this change).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] Bug fix — issue-first not required (exempt per CONTRIBUTING.md)
- [x] My PR does not include personal data (only `dedup-tracker.mjs` + `test-all.mjs` changed)
- [x] I ran `node test-all.mjs` and all tests pass (dashboard build is skipped without the Go toolchain, as designed)
- [x] My changes respect the Data Contract (only system-layer files touched)
- [x] My changes align with the project roadmap (local-first, human-in-the-loop; protects the user's own pipeline data)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate row handling so only exact role-title matches are merged after normalization.
  * Prevented incorrect merges for similar-looking roles at the same company, while still combining true duplicates and keeping the higher-scoring entry.
  * Added safer handling for advanced-status records, reducing accidental data loss during deduplication.
* **Tests**
  * Expanded regression coverage for duplicate detection and exact-match behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->