### PR TITLE
feat(oferta): flag 'remote' location field contradicted by JD-body signals

### DIFF
--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -46,6 +46,21 @@ Table with:
 - Team size (if mentioned)
 - TL;DR in 1 sentence
 
+### Geo-mismatch check
+
+After filling the Remote row, cross-check the posting's **structured location field** (the location/remote designation shown on the posting page or in ATS metadata — not the Remote row you just wrote) against the JD body:
+
+- **Contradiction** = the location field says remote, but the JD body states a **binding attendance requirement**: "hybrid", "X days per week/month" in office, "in-office", "onsite"/"on-site", mandatory office attendance, or a relocation requirement.
+- **Not a contradiction:** negations ("no onsite requirement"), optional or occasional in-person events ("quarterly offsites", "optional co-working space"), or generic benefits boilerplate.
+- If the JD body says nothing about location or attendance, emit no flag — silence is absence of signal, not agreement.
+- If the input has no structured location field (pasted JD text only), skip this check.
+
+On contradiction, add exactly one flag line at the top of Block B in the report, quoting the evidence **verbatim** (never paraphrase):
+
+`⚠️ **Geo-mismatch:** location field says remote, but JD body says "{verbatim JD line}"`
+
+The flag is an additive line only — Block B's existing content stays unchanged below it, and no flag line appears when there is no contradiction.
+
 ## Block B — Match with CV
 
 Read `cv.md`. Create a table with each JD requirement mapped to exact lines in the CV.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1038,6 +1038,17 @@ if (
   fail('eval modes do not bound company/comp research against recursive fanout (#1235)');
 }
 
+if (
+  ofertaMode.includes('### Geo-mismatch check') &&
+  ofertaMode.includes('binding attendance requirement') &&
+  ofertaMode.includes('⚠️ **Geo-mismatch:** location field says remote, but JD body says') &&
+  ofertaMode.includes('silence is absence of signal, not agreement')
+) {
+  pass('oferta cross-checks the remote location field against JD-body signals (#1433)');
+} else {
+  fail('oferta missing geo-mismatch cross-check of location field vs JD body (#1433)');
+}
+
 const pipelineMode = readFile('modes/pipeline.md');
 if (
   pipelineMode.includes('## Liveness sweep') &&


### PR DESCRIPTION
Closes #1433

## What

Adds a **geo-mismatch check** to `modes/oferta.md` Block A: when the posting's structured location field says remote but the JD body states a binding attendance requirement, the evaluation report gets one additive flag line at the top of Block B with the verbatim evidence quote:

> ⚠️ **Geo-mismatch:** location field says remote, but JD body says "{verbatim JD line}"

Honors the issue's constraint: **additive report content only** — the flag is a single conditional line, Block B's existing content is unmoved below it, and no line appears when there is no contradiction.

## Design decisions (tightenings beyond the issue text)

- **Location field defined explicitly** as the posting-page / ATS structured location or remote designation — not the Remote row the model itself just wrote in Block A (avoids the model auditing its own summary). Pasted JD text with no structured field skips the check.
- **Contradiction = binding attendance requirement** (hybrid, "X days per week/month", in-office, onsite, mandatory attendance, relocation). Explicit non-triggers to curb false positives: negations ("no onsite requirement"), optional/occasional in-person events (offsites, co-working), benefits boilerplate.
- **Silence handling:** JD body says nothing about location → no flag. Absence of signal is not agreement.
- **Verbatim quote required** — evidence, never paraphrase.

## Test

One `test-all.mjs` presence assertion labeled `(#1433)`, following the existing mode-content check convention (e.g. #1235). Note the known limit of that convention: it verifies the instruction exists, not LLM behavior — behavior isn't CI-verifiable for prompt files.

`node test-all.mjs`: **987 passed, 0 failed** (1 pre-existing warning: `cv-sync-check.mjs` without user data).

## Follow-up candidates (out of scope, flagging for maintainer)

- Mirror the check in `batch/batch-prompt.md` (high-volume path) and the language modes (`de`/`fr`/`ja`/…).
- Reverse direction: location field says "hybrid" but body describes a 5-day in-office mandate — same mismatch class.
- Deterministic pre-LLM screen at scan/pipeline time so a mismatch never costs an evaluation cycle (limited: prose signals need judgment; scan-time may lack JD body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Geo-mismatch check” step in the report flow to detect contradictions between a posting’s structured remote/location settings and binding attendance requirements found in the job description.
  * When a conflict is detected, the report automatically inserts exactly one warning flag line at the top of Block B quoting the conflicting job description evidence verbatim.
  * If no contradiction is found—or if structured location data is missing—the report is left unchanged.
* **Tests**
  * Updated automated checks to validate the presence and wording of the new geo-mismatch rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
