### PR TITLE
feat(patterns): recruiting-process friction signal — closes #1466

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `analyze-patterns.mjs` | Pattern analysis script (JSON output). Includes ATS channel analysis (per-vendor advance rate; motivated by Bommasani et al., Algorithmic Monocultures in Hiring, FAccT 2026). |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `detect-reposts.mjs` | Repost detector — flags roles re-listed 2+ times in 90 days from scan-history.tsv (JSON or `--summary` table output) |
+| `process-quality.mjs` | Recruiting-process friction aggregator — parses `[process-friction]` tags candidates add to `data/active-interviews.md` Notes and reports per-company friction rate (JSON or `--summary` table output) |
 | `data/follow-ups.md` | Follow-up history tracker |
 | `scan.mjs` | Zero-token portal scanner — hits Greenhouse/Ashby/Lever APIs directly, zero LLM cost |
 | `check-liveness.mjs` | Job posting liveness checker |

--- a/process-quality.mjs
+++ b/process-quality.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * process-quality.mjs — Recruiting-Process Friction Aggregator for career-ops
+ *
+ * Parses data/active-interviews.md, extracts inline `[process-friction]` tags
+ * from the Notes column, and aggregates them per company into a friction
+ * signal — independent of company/role fit (#960) and interviewer red-flag
+ * behavior (#1232). This tracks a third, distinct axis: is the *recruiting
+ * process itself* (scheduling, communication clarity, tooling) well-run?
+ *
+ * Tagging convention (candidate-authored, in the Notes column of
+ * data/active-interviews.md):
+ *   [process-friction]                          — friction occurred, no detail
+ *   [process-friction: <short reason>]           — friction occurred, with detail
+ *
+ * This is a company/process-level signal only — never tied to a named
+ * individual recruiter. See issue #1466.
+ *
+ * Run: node process-quality.mjs             (JSON to stdout)
+ *      node process-quality.mjs --summary   (human-readable table)
+ *      node process-quality.mjs --min-threshold 2  (min total interviews per company to report)
+ *      node process-quality.mjs --self-test
+ *
+ * Issue #1466 — github.com/santifer/career-ops
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+const ACTIVE_INTERVIEWS_PATH = existsSync(join(CAREER_OPS, 'data/active-interviews.md'))
+  ? join(CAREER_OPS, 'data/active-interviews.md')
+  : join(CAREER_OPS, 'active-interviews.md');
+
+const FRICTION_TAG = /\[process-friction(?::\s*([^\]]+))?\]/i;
+
+// --- CLI args ---
+const args = process.argv.slice(2);
+const summaryMode = args.includes('--summary');
+const selfTestMode = args.includes('--self-test');
+const minThresholdIdx = args.indexOf('--min-threshold');
+const MIN_THRESHOLD = minThresholdIdx !== -1 && args[minThresholdIdx + 1] !== undefined
+  ? (Number.isNaN(parseInt(args[minThresholdIdx + 1], 10)) ? 1 : parseInt(args[minThresholdIdx + 1], 10))
+  : 1;
+
+// --- Parse data/active-interviews.md ---
+//
+// Table format: `| Company | Role | Round | Date/Time | Interviewer | Status | Notes |`
+// A separator row (all dashes/colons/pipes) follows the header and is skipped.
+// Only well-formed rows (same column count as the header) are kept; malformed
+// rows are silently dropped rather than crashing the parser.
+//
+// Exported so external tests can call parseActiveInterviews() directly on a
+// markdown string.
+export function parseActiveInterviews(content) {
+  if (typeof content !== 'string' || !content.trim()) return [];
+
+  const lines = content.split('\n');
+  const tableLines = lines.filter(line => /^\s*\|.*\|\s*$/.test(line));
+  if (tableLines.length < 2) return [];
+
+  const splitRow = line =>
+    line
+      .trim()
+      .replace(/^\|/, '')
+      .replace(/\|$/, '')
+      .split('|')
+      .map(cell => cell.trim());
+
+  const isSeparatorRow = cells => cells.every(cell => /^:?-+:?$/.test(cell));
+
+  const header = splitRow(tableLines[0]);
+  const colCount = header.length;
+  if (colCount === 0) return [];
+
+  const rows = [];
+  for (const line of tableLines.slice(1)) {
+    const cells = splitRow(line);
+    if (isSeparatorRow(cells)) continue;
+    if (cells.length !== colCount) continue;
+
+    const row = {};
+    header.forEach((col, i) => {
+      row[col] = cells[i];
+    });
+    rows.push(row);
+  }
+  return rows;
+}
+
+// --- Friction extraction ---
+//
+// Reads the Notes column (case-insensitive lookup, since header wording is
+// candidate-editable free text) and pulls out the [process-friction] tag if
+// present. Returns { hasFriction, reason } — reason is '' when the tag is
+// present without a detail string.
+export function extractFriction(row) {
+  if (!row || typeof row !== 'object') return { hasFriction: false, reason: '' };
+  const notesKey = Object.keys(row).find(k => k.trim().toLowerCase() === 'notes');
+  const notes = notesKey ? String(row[notesKey] ?? '') : '';
+  const match = notes.match(FRICTION_TAG);
+  if (!match) return { hasFriction: false, reason: '' };
+  return { hasFriction: true, reason: (match[1] || '').trim() };
+}
+
+// --- Core aggregation ---
+//
+// Groups rows by company (case-insensitive, trimmed), counts total
+// interview rows and friction-tagged rows per company, and returns only
+// companies with totalInterviews >= minThreshold. Companies are sorted by
+// frictionCount descending, then frictionRate descending, then company name
+// ascending (stable, deterministic ordering for tests and CLI output).
+//
+// Exported so external tests can call aggregateProcessQuality() directly on
+// a parsed row list.
+export function aggregateProcessQuality(rows, minThreshold = 1) {
+  if (!Array.isArray(rows)) return [];
+  const threshold = Number.isFinite(minThreshold) && minThreshold >= 0 ? minThreshold : 1;
+
+  const companyKey = row => {
+    const keys = Object.keys(row || {});
+    const key = keys.find(k => k.trim().toLowerCase() === 'company');
+    return key ? String(row[key] ?? '').trim() : '';
+  };
+
+  const byCompany = new Map();
+  for (const row of rows) {
+    if (!row || typeof row !== 'object') continue;
+    const company = companyKey(row);
+    if (!company) continue;
+
+    const dedupeKey = company.toLowerCase();
+    if (!byCompany.has(dedupeKey)) {
+      byCompany.set(dedupeKey, { company, total: 0, frictionCount: 0, reasons: [] });
+    }
+    const entry = byCompany.get(dedupeKey);
+    entry.total += 1;
+
+    const { hasFriction, reason } = extractFriction(row);
+    if (hasFriction) {
+      entry.frictionCount += 1;
+      if (reason) entry.reasons.push(reason);
+    }
+  }
+
+  const results = [...byCompany.values()]
+    .filter(entry => entry.total >= threshold)
+    .map(entry => ({
+      company: entry.company,
+      totalInterviews: entry.total,
+      frictionCount: entry.frictionCount,
+      frictionRate: entry.total > 0 ? Math.round((entry.frictionCount / entry.total) * 100) / 100 : 0,
+      reasons: entry.reasons,
+    }));
+
+  results.sort((a, b) => {
+    if (b.frictionCount !== a.frictionCount) return b.frictionCount - a.frictionCount;
+    if (b.frictionRate !== a.frictionRate) return b.frictionRate - a.frictionRate;
+    return a.company.localeCompare(b.company);
+  });
+
+  return results;
+}
+
+function loadActiveInterviews(path = ACTIVE_INTERVIEWS_PATH) {
+  if (!existsSync(path)) return [];
+  return parseActiveInterviews(readFileSync(path, 'utf-8'));
+}
+
+// --- Summary mode ---
+function printSummary(signals) {
+  console.log(`\n${'='.repeat(78)}`);
+  console.log('  Process Quality Signal — career-ops');
+  console.log(`  min threshold: ${MIN_THRESHOLD} interview(s) | companies: ${signals.length}`);
+  console.log(`${'='.repeat(78)}\n`);
+
+  if (signals.length === 0) {
+    console.log('  No process-friction signal found (or no companies met the threshold).\n');
+    return;
+  }
+
+  const header =
+    '  ' +
+    'Company'.padEnd(26) +
+    'Interviews'.padEnd(12) +
+    'Friction'.padEnd(10) +
+    'Rate';
+  console.log(header);
+  console.log('  ' + '-'.repeat(70));
+
+  for (const s of signals) {
+    const company = (s.company || '').substring(0, 24).padEnd(26);
+    const total = String(s.totalInterviews).padEnd(12);
+    const friction = String(s.frictionCount).padEnd(10);
+    const rate = `${Math.round(s.frictionRate * 100)}%`;
+    console.log('  ' + company + total + friction + rate);
+    for (const reason of s.reasons) {
+      console.log(`      ↳ ${reason}`);
+    }
+  }
+  console.log('');
+}
+
+// --- Self-test ---
+function runSelfTest() {
+  const md = [
+    '# Active Interviews',
+    '',
+    '| Company | Role | Round | Date/Time | Interviewer | Status | Notes |',
+    '|---------|------|-------|-----------|-------------|--------|-------|',
+    '| Acme | Backend Engineer | Prescreen | 2026-06-01 | Jane (recruiter) | Scheduled | Clean process, no issues |',
+    '| Acme | Backend Engineer | Round 1 | 2026-06-08 | Panel | Scheduled | Confirmed quickly, no friction |',
+    '| Beta Corp | Coordinator | Prescreen | 2026-06-10 | Sasha (bot) | Scheduled | [process-friction: stated availability overridden twice before confirming] |',
+    '| Beta Corp | Coordinator | Round 1 | 2026-06-17 | HM | Scheduled | Went smoothly this round |',
+    '| Gamma Inc | Analyst | Prescreen | 2026-06-12 | Recruiter | Rejected | [process-friction] |',
+    '| Malformed row with too few cells |',
+  ].join('\n');
+
+  const rows = parseActiveInterviews(md);
+  const signals = aggregateProcessQuality(rows, 1);
+
+  let pass = 0;
+  let fail = 0;
+  const check = (cond, label) => {
+    if (cond) { pass += 1; } else { fail += 1; console.error(`  FAIL: ${label}`); }
+  };
+
+  check(rows.length === 5, 'parses 5 well-formed rows, drops the malformed one');
+
+  const beta = signals.find(s => s.company === 'Beta Corp');
+  check(!!beta, 'Beta Corp appears in aggregated signals');
+  if (beta) {
+    check(beta.totalInterviews === 2, 'Beta Corp has 2 total interview rows');
+    check(beta.frictionCount === 1, 'Beta Corp has 1 friction-tagged row');
+    check(beta.frictionRate === 0.5, 'Beta Corp friction rate is 0.5');
+    check(beta.reasons.length === 1 && beta.reasons[0].includes('overridden'), 'Beta Corp friction reason captured');
+  }
+
+  const gamma = signals.find(s => s.company === 'Gamma Inc');
+  check(!!gamma, 'Gamma Inc appears in aggregated signals');
+  if (gamma) {
+    check(gamma.frictionCount === 1, 'Gamma Inc has 1 friction-tagged row (bare tag, no reason)');
+    check(gamma.reasons.length === 0, 'bare [process-friction] tag produces no reason string');
+  }
+
+  const acme = signals.find(s => s.company === 'Acme');
+  check(!!acme, 'Acme appears in aggregated signals');
+  if (acme) {
+    check(acme.frictionCount === 0, 'Acme has 0 friction (no tags present)');
+    check(acme.frictionRate === 0, 'Acme friction rate is 0');
+  }
+
+  check(aggregateProcessQuality([]).length === 0, 'empty input returns no signals');
+  check(aggregateProcessQuality(null).length === 0, 'null input returns no signals (no crash)');
+  check(parseActiveInterviews('').length === 0, 'empty markdown returns no rows');
+  check(parseActiveInterviews(null).length === 0, 'non-string input returns no rows (no crash)');
+
+  // Threshold filtering: companies with fewer interviews than minThreshold are excluded.
+  const highThreshold = aggregateProcessQuality(rows, 2);
+  check(highThreshold.some(s => s.company === 'Beta Corp'), 'threshold=2: Beta Corp (2 rows) included');
+  check(highThreshold.some(s => s.company === 'Acme'), 'threshold=2: Acme (2 rows) included');
+  check(!highThreshold.some(s => s.company === 'Gamma Inc'), 'threshold=2: Gamma Inc (1 row) excluded');
+
+  console.log(`\n  process-quality self-test: ${pass} passed, ${fail} failed\n`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+// --- Run (CLI only; guarded so the module is safely importable for tests) ---
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  if (selfTestMode) {
+    runSelfTest();
+  }
+
+  const rows = loadActiveInterviews();
+  const signals = aggregateProcessQuality(rows, MIN_THRESHOLD);
+
+  if (summaryMode) {
+    printSummary(signals);
+  } else {
+    console.log(JSON.stringify({
+      metadata: {
+        minThreshold: MIN_THRESHOLD,
+        totalRows: rows.length,
+        companies: signals.length,
+      },
+      signals,
+    }, null, 2));
+  }
+}

--- a/process-quality.mjs
+++ b/process-quality.mjs
@@ -40,9 +40,21 @@ const args = process.argv.slice(2);
 const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
 const minThresholdIdx = args.indexOf('--min-threshold');
-const MIN_THRESHOLD = minThresholdIdx !== -1 && args[minThresholdIdx + 1] !== undefined
-  ? (Number.isNaN(parseInt(args[minThresholdIdx + 1], 10)) ? 1 : parseInt(args[minThresholdIdx + 1], 10))
+const rawMinThreshold = minThresholdIdx !== -1 && args[minThresholdIdx + 1] !== undefined
+  ? parseInt(args[minThresholdIdx + 1], 10)
   : 1;
+// Clamped here (not just inside aggregateProcessQuality) so printSummary's
+// displayed threshold always matches the threshold actually applied.
+const MIN_THRESHOLD = Number.isFinite(rawMinThreshold) && rawMinThreshold >= 0 ? rawMinThreshold : 1;
+
+// Case-insensitive column lookup shared by extractFriction and
+// aggregateProcessQuality — the header wording comes from a candidate-edited
+// markdown file, so "Notes" vs "notes" vs " Notes " must all resolve the
+// same way. Centralized here so both call sites can never drift apart.
+function findColumn(row, name) {
+  const key = Object.keys(row || {}).find(k => k.trim().toLowerCase() === name);
+  return key ? String(row[key] ?? '') : '';
+}
 
 // --- Parse data/active-interviews.md ---
 //
@@ -51,13 +63,29 @@ const MIN_THRESHOLD = minThresholdIdx !== -1 && args[minThresholdIdx + 1] !== un
 // Only well-formed rows (same column count as the header) are kept; malformed
 // rows are silently dropped rather than crashing the parser.
 //
+// Only the FIRST contiguous block of pipe-formatted lines is parsed as the
+// table. This intentionally stops at the first non-table line rather than
+// collecting every pipe-formatted line in the file — a document with more
+// than one markdown table (e.g. a second table added later, or Landmines-
+// style tables from other files if ever concatenated) must not have its
+// unrelated rows merged into the active-interviews result.
+//
 // Exported so external tests can call parseActiveInterviews() directly on a
 // markdown string.
 export function parseActiveInterviews(content) {
   if (typeof content !== 'string' || !content.trim()) return [];
 
   const lines = content.split('\n');
-  const tableLines = lines.filter(line => /^\s*\|.*\|\s*$/.test(line));
+  const isTableLine = line => /^\s*\|.*\|\s*$/.test(line);
+
+  const startIdx = lines.findIndex(isTableLine);
+  if (startIdx === -1) return [];
+
+  const tableLines = [];
+  for (let i = startIdx; i < lines.length; i++) {
+    if (!isTableLine(lines[i])) break;
+    tableLines.push(lines[i]);
+  }
   if (tableLines.length < 2) return [];
 
   const splitRow = line =>
@@ -97,8 +125,7 @@ export function parseActiveInterviews(content) {
 // present without a detail string.
 export function extractFriction(row) {
   if (!row || typeof row !== 'object') return { hasFriction: false, reason: '' };
-  const notesKey = Object.keys(row).find(k => k.trim().toLowerCase() === 'notes');
-  const notes = notesKey ? String(row[notesKey] ?? '') : '';
+  const notes = findColumn(row, 'notes');
   const match = notes.match(FRICTION_TAG);
   if (!match) return { hasFriction: false, reason: '' };
   return { hasFriction: true, reason: (match[1] || '').trim() };
@@ -118,11 +145,7 @@ export function aggregateProcessQuality(rows, minThreshold = 1) {
   if (!Array.isArray(rows)) return [];
   const threshold = Number.isFinite(minThreshold) && minThreshold >= 0 ? minThreshold : 1;
 
-  const companyKey = row => {
-    const keys = Object.keys(row || {});
-    const key = keys.find(k => k.trim().toLowerCase() === 'company');
-    return key ? String(row[key] ?? '').trim() : '';
-  };
+  const companyKey = row => findColumn(row, 'company').trim();
 
   const byCompany = new Map();
   for (const row of rows) {
@@ -255,6 +278,14 @@ function runSelfTest() {
   check(aggregateProcessQuality(null).length === 0, 'null input returns no signals (no crash)');
   check(parseActiveInterviews('').length === 0, 'empty markdown returns no rows');
   check(parseActiveInterviews(null).length === 0, 'non-string input returns no rows (no crash)');
+
+  // A second, unrelated table later in the same document must NOT be merged
+  // into the parsed rows — only the first contiguous table block is parsed.
+  const twoTablesMd = md + '\n\nSome other section.\n\n' +
+    '| Foo | Bar |\n|-----|-----|\n| unrelated | table |\n';
+  const twoTablesRows = parseActiveInterviews(twoTablesMd);
+  check(twoTablesRows.length === 5, 'a second markdown table later in the document is not merged in');
+  check(!twoTablesRows.some(r => r.Company === undefined && 'Foo' in r), 'second-table columns (Foo/Bar) never appear in the result');
 
   // Threshold filtering: companies with fewer interviews than minThreshold are excluded.
   const highThreshold = aggregateProcessQuality(rows, 2);

--- a/process-quality.mjs
+++ b/process-quality.mjs
@@ -19,6 +19,7 @@
  * Run: node process-quality.mjs             (JSON to stdout)
  *      node process-quality.mjs --summary   (human-readable table)
  *      node process-quality.mjs --min-threshold 2  (min total interviews per company to report)
+ *      node process-quality.mjs --file path/to/active-interviews.md  (override the data path; test isolation)
  *      node process-quality.mjs --self-test
  *
  * Issue #1466 — github.com/santifer/career-ops
@@ -29,7 +30,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
-const ACTIVE_INTERVIEWS_PATH = existsSync(join(CAREER_OPS, 'data/active-interviews.md'))
+const DEFAULT_ACTIVE_INTERVIEWS_PATH = existsSync(join(CAREER_OPS, 'data/active-interviews.md'))
   ? join(CAREER_OPS, 'data/active-interviews.md')
   : join(CAREER_OPS, 'active-interviews.md');
 
@@ -39,6 +40,14 @@ const FRICTION_TAG = /\[process-friction(?::\s*([^\]]+))?\]/i;
 const args = process.argv.slice(2);
 const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
+// --file overrides the data path — mirrors validate-portals.mjs / verify-portals.mjs's
+// --file convention. Primarily for test isolation: it lets tests point at a
+// controlled temp path instead of depending on whatever data/active-interviews.md
+// happens to exist (or not) in the caller's real workspace.
+const fileIdx = args.indexOf('--file');
+const ACTIVE_INTERVIEWS_PATH = fileIdx !== -1 && args[fileIdx + 1] !== undefined
+  ? args[fileIdx + 1]
+  : DEFAULT_ACTIVE_INTERVIEWS_PATH;
 const minThresholdIdx = args.indexOf('--min-threshold');
 const rawMinThreshold = minThresholdIdx !== -1 && args[minThresholdIdx + 1] !== undefined
   ? parseInt(args[minThresholdIdx + 1], 10)

--- a/process-quality.test.mjs
+++ b/process-quality.test.mjs
@@ -14,6 +14,8 @@ import { parseActiveInterviews, extractFriction, aggregateProcessQuality } from 
 import { execFileSync } from 'child_process';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
 
 let passed = 0;
 let failed = 0;
@@ -293,15 +295,46 @@ ok('default has metadata', 'metadata' in defaultJson);
 ok('default has signals array', 'signals' in defaultJson && Array.isArray(defaultJson.signals));
 eq('default minThreshold = 1', defaultJson.metadata.minThreshold, 1);
 
-// Missing-file CLI behavior: data/active-interviews.md is candidate-authored
-// user data and is never present in a fresh repo checkout (it has no shipped
-// template, unlike applications.md/pipeline.md). Running the CLI here — a
-// checkout with no such file — exercises loadActiveInterviews()'s missing-path
-// branch for real, deterministically, without needing a temp-dir workaround
-// (the script resolves its data path relative to its own location, not cwd).
-ok('missing data/active-interviews.md: CLI does not throw', !!defaultOut);
-eq('missing data/active-interviews.md: totalRows = 0', defaultJson.metadata.totalRows, 0);
-eq('missing data/active-interviews.md: signals = []', defaultJson.signals, []);
+// Missing-file CLI behavior, isolated via --file pointing at a path that
+// deliberately does not exist inside a fresh temp dir. This must NOT depend
+// on whether the caller's real data/active-interviews.md happens to exist —
+// a contributor running this suite with real interview data in their own
+// workspace must get the same result as CI.
+const missingFileTmpDir = mkdtempSync(join(tmpdir(), 'process-quality-missing-'));
+const missingFilePath = join(missingFileTmpDir, 'does-not-exist.md');
+try {
+  const missingOut = execFileSync('node', [scriptPath, '--file', missingFilePath], {
+    encoding: 'utf-8', timeout: 10000,
+    cwd: dirname(scriptPath),
+  });
+  ok('missing --file path: CLI does not throw', !!missingOut);
+  const missingJson = JSON.parse(missingOut);
+  eq('missing --file path: totalRows = 0', missingJson.metadata.totalRows, 0);
+  eq('missing --file path: signals = []', missingJson.signals, []);
+} finally {
+  rmSync(missingFileTmpDir, { recursive: true, force: true });
+}
+
+// --file also works as a positive-path override: point it at a controlled
+// fixture file and confirm the CLI reads exactly that file, isolated from
+// whatever the caller's real workspace contains.
+const fixtureTmpDir = mkdtempSync(join(tmpdir(), 'process-quality-fixture-'));
+const fixturePath = join(fixtureTmpDir, 'active-interviews.md');
+try {
+  writeFileSync(fixturePath, table([
+    '| FixtureCo | Role | Prescreen | 2026-07-01 | Someone | Scheduled | [process-friction: fixture reason] |',
+  ]));
+  const fixtureOut = execFileSync('node', [scriptPath, '--file', fixturePath], {
+    encoding: 'utf-8', timeout: 10000,
+    cwd: dirname(scriptPath),
+  });
+  const fixtureJson = JSON.parse(fixtureOut);
+  eq('--file fixture: totalRows = 1', fixtureJson.metadata.totalRows, 1);
+  eq('--file fixture: 1 signal (FixtureCo)', fixtureJson.signals.length, 1);
+  eq('--file fixture: FixtureCo friction captured', fixtureJson.signals[0]?.reasons?.[0], 'fixture reason');
+} finally {
+  rmSync(fixtureTmpDir, { recursive: true, force: true });
+}
 
 const thresholdOut = execFileSync('node', [scriptPath, '--min-threshold', '3'], {
   encoding: 'utf-8', timeout: 10000,

--- a/process-quality.test.mjs
+++ b/process-quality.test.mjs
@@ -1,0 +1,306 @@
+/**
+ * process-quality.test.mjs — Systematic test suite for process-quality.mjs
+ *
+ * Tests every exported function across:
+ * - Markdown table parsing (well-formed, malformed, empty, header-only)
+ * - Friction tag extraction (bare tag, tag with reason, no tag, case sensitivity)
+ * - Aggregation (grouping, dedup, threshold filtering, sort order)
+ * - CLI behavior (args, flags, missing file)
+ *
+ * Run: node process-quality.test.mjs
+ */
+
+import { parseActiveInterviews, extractFriction, aggregateProcessQuality } from './process-quality.mjs';
+import { execFileSync } from 'child_process';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function ok(label, cond) {
+  if (cond) {
+    passed++;
+  } else {
+    failed++;
+    failures.push(label);
+    console.log(`  FAIL: ${label}`);
+  }
+}
+
+function eq(label, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    passed++;
+  } else {
+    failed++;
+    failures.push(label);
+    console.log(`  FAIL: ${label}`);
+    console.log(`    expected: ${e}`);
+    console.log(`    actual:   ${a}`);
+  }
+}
+
+function table(rows) {
+  const header = '| Company | Role | Round | Date/Time | Interviewer | Status | Notes |';
+  const sep = '|---------|------|-------|-----------|-------------|--------|-------|';
+  return [header, sep, ...rows].join('\n');
+}
+
+// ============================================================================
+// 1. parseActiveInterviews — input validation
+// ============================================================================
+console.log('\n--- 1. parseActiveInterviews input validation ---');
+
+eq('null input -> empty', parseActiveInterviews(null), []);
+eq('undefined input -> empty', parseActiveInterviews(undefined), []);
+eq('empty string -> empty', parseActiveInterviews(''), []);
+eq('whitespace-only -> empty', parseActiveInterviews('   \n  \n'), []);
+eq('non-string input (number) -> empty', parseActiveInterviews(42), []);
+eq('non-string input (object) -> empty', parseActiveInterviews({}), []);
+eq('prose with no table -> empty', parseActiveInterviews('# Active Interviews\n\nNothing here yet.'), []);
+eq('header only, no rows -> empty', parseActiveInterviews(table([])), []);
+
+// ============================================================================
+// 2. parseActiveInterviews — well-formed rows
+// ============================================================================
+console.log('\n--- 2. well-formed rows ---');
+
+const basic = parseActiveInterviews(table([
+  '| Acme | Backend Engineer | Prescreen | 2026-06-01 | Jane | Scheduled | Clean process |',
+]));
+eq('parses 1 row', basic.length, 1);
+eq('row has Company field', basic[0].Company, 'Acme');
+eq('row has Role field', basic[0].Role, 'Backend Engineer');
+eq('row has Notes field', basic[0].Notes, 'Clean process');
+
+const multi = parseActiveInterviews(table([
+  '| Acme | Backend Engineer | Prescreen | 2026-06-01 | Jane | Scheduled | note 1 |',
+  '| Beta | Coordinator | Round 1 | 2026-06-08 | HM | Scheduled | note 2 |',
+]));
+eq('parses 2 rows', multi.length, 2);
+
+// ============================================================================
+// 3. parseActiveInterviews — malformed / edge-case rows
+// ============================================================================
+console.log('\n--- 3. malformed rows ---');
+
+const withMalformed = parseActiveInterviews(table([
+  '| Acme | Backend Engineer | Prescreen | 2026-06-01 | Jane | Scheduled | ok |',
+  '| Too | Few | Cells |',
+  '| Beta | Coordinator | Round 1 | 2026-06-08 | HM | Scheduled | ok 2 |',
+]));
+eq('malformed (wrong column count) row is dropped, valid rows kept', withMalformed.length, 2);
+
+const preambleAndTable = parseActiveInterviews(
+  '# Active Interviews\n\nSome free text here.\n\n' + table([
+    '| Acme | Backend Engineer | Prescreen | 2026-06-01 | Jane | Scheduled | ok |',
+  ])
+);
+eq('non-table prose lines before the table are ignored', preambleAndTable.length, 1);
+
+const noSeparator = parseActiveInterviews(
+  '| Company | Role | Round | Date/Time | Interviewer | Status | Notes |\n' +
+  '| Acme | Backend Engineer | Prescreen | 2026-06-01 | Jane | Scheduled | ok |'
+);
+ok('table without a separator row still parses the data row', noSeparator.length === 1);
+
+// ============================================================================
+// 4. extractFriction
+// ============================================================================
+console.log('\n--- 4. extractFriction ---');
+
+eq('null row -> no friction', extractFriction(null), { hasFriction: false, reason: '' });
+eq('undefined row -> no friction', extractFriction(undefined), { hasFriction: false, reason: '' });
+eq('row with no Notes key -> no friction', extractFriction({ Company: 'Acme' }), { hasFriction: false, reason: '' });
+eq('empty Notes -> no friction', extractFriction({ Notes: '' }), { hasFriction: false, reason: '' });
+eq('Notes without tag -> no friction', extractFriction({ Notes: 'Everything went smoothly' }), { hasFriction: false, reason: '' });
+
+eq('bare tag -> friction, no reason', extractFriction({ Notes: '[process-friction]' }), { hasFriction: true, reason: '' });
+eq('tag with reason -> friction + reason', extractFriction({ Notes: '[process-friction: recruiter overrode stated availability]' }),
+  { hasFriction: true, reason: 'recruiter overrode stated availability' });
+eq('tag embedded mid-sentence', extractFriction({ Notes: 'Confirmed Wed 2pm. [process-friction: took 3 rounds to land a time] Prep done.' }),
+  { hasFriction: true, reason: 'took 3 rounds to land a time' });
+eq('tag is case-insensitive', extractFriction({ Notes: '[PROCESS-FRICTION: caps test]' }),
+  { hasFriction: true, reason: 'caps test' });
+eq('tag lookup is case-insensitive on the Notes key', extractFriction({ notes: '[process-friction: lowercase key]' }),
+  { hasFriction: true, reason: 'lowercase key' });
+eq('reason with internal whitespace is trimmed', extractFriction({ Notes: '[process-friction:   padded reason   ]' }),
+  { hasFriction: true, reason: 'padded reason' });
+
+// ============================================================================
+// 5. aggregateProcessQuality — input validation
+// ============================================================================
+console.log('\n--- 5. aggregateProcessQuality input validation ---');
+
+eq('null input -> empty', aggregateProcessQuality(null), []);
+eq('undefined input -> empty', aggregateProcessQuality(undefined), []);
+eq('empty array -> empty', aggregateProcessQuality([]), []);
+eq('rows missing Company field are skipped', aggregateProcessQuality([{ Notes: 'x' }, null, undefined]), []);
+eq('row with empty Company is skipped', aggregateProcessQuality([{ Company: '', Notes: 'x' }]), []);
+eq('row with whitespace-only Company is skipped', aggregateProcessQuality([{ Company: '   ', Notes: 'x' }]), []);
+
+// ============================================================================
+// 6. aggregateProcessQuality — grouping and counting
+// ============================================================================
+console.log('\n--- 6. grouping and counting ---');
+
+const rows = [
+  { Company: 'Acme', Notes: 'no issue' },
+  { Company: 'Acme', Notes: '[process-friction: reason A]' },
+  { Company: 'acme', Notes: 'no issue either' }, // case-insensitive grouping
+  { Company: 'Beta', Notes: '[process-friction]' },
+];
+const agg = aggregateProcessQuality(rows, 1);
+
+const acmeSignal = agg.find(s => s.company.toLowerCase() === 'acme');
+ok('Acme/acme grouped into a single entry', !!acmeSignal);
+if (acmeSignal) {
+  eq('Acme total interviews = 3 (case-insensitive dedup)', acmeSignal.totalInterviews, 3);
+  eq('Acme friction count = 1', acmeSignal.frictionCount, 1);
+  eq('Acme friction rate = 0.33', acmeSignal.frictionRate, 0.33);
+  eq('Acme reasons = ["reason A"]', acmeSignal.reasons, ['reason A']);
+}
+
+const betaSignal = agg.find(s => s.company === 'Beta');
+ok('Beta present', !!betaSignal);
+if (betaSignal) {
+  eq('Beta total interviews = 1', betaSignal.totalInterviews, 1);
+  eq('Beta friction count = 1', betaSignal.frictionCount, 1);
+  eq('Beta friction rate = 1', betaSignal.frictionRate, 1);
+  eq('Beta reasons empty (bare tag)', betaSignal.reasons, []);
+}
+
+// Company name in output preserves the first-seen casing.
+eq('output company name preserves first-seen casing', acmeSignal.company, 'Acme');
+
+// ============================================================================
+// 7. aggregateProcessQuality — threshold filtering
+// ============================================================================
+console.log('\n--- 7. threshold filtering ---');
+
+const thresholdRows = [
+  { Company: 'OneShot', Notes: '[process-friction]' },
+  { Company: 'TwoShot', Notes: '[process-friction]' },
+  { Company: 'TwoShot', Notes: 'fine' },
+];
+
+eq('threshold=1: both companies included', aggregateProcessQuality(thresholdRows, 1).map(s => s.company).sort(), ['OneShot', 'TwoShot']);
+eq('threshold=2: only TwoShot included', aggregateProcessQuality(thresholdRows, 2).map(s => s.company), ['TwoShot']);
+eq('threshold=3: neither included', aggregateProcessQuality(thresholdRows, 3), []);
+eq('negative threshold falls back to 1', aggregateProcessQuality(thresholdRows, -5).map(s => s.company).sort(), ['OneShot', 'TwoShot']);
+eq('non-numeric threshold falls back to 1', aggregateProcessQuality(thresholdRows, NaN).map(s => s.company).sort(), ['OneShot', 'TwoShot']);
+eq('threshold=0: all companies included', aggregateProcessQuality(thresholdRows, 0).map(s => s.company).sort(), ['OneShot', 'TwoShot']);
+
+// ============================================================================
+// 8. aggregateProcessQuality — sort order
+// ============================================================================
+console.log('\n--- 8. sort order ---');
+
+const sortRows = [
+  { Company: 'LowFriction', Notes: '[process-friction]' },
+  { Company: 'LowFriction', Notes: 'fine' },
+  { Company: 'LowFriction', Notes: 'fine' },
+  { Company: 'LowFriction', Notes: 'fine' },
+  { Company: 'HighFriction', Notes: '[process-friction]' },
+  { Company: 'HighFriction', Notes: '[process-friction]' },
+  { Company: 'HighFriction', Notes: '[process-friction]' },
+  { Company: 'NoFriction', Notes: 'fine' },
+  { Company: 'AlphabeticalTieA', Notes: '[process-friction]' },
+  { Company: 'AlphabeticalTieB', Notes: '[process-friction]' },
+];
+const sorted = aggregateProcessQuality(sortRows, 1);
+eq('sorted by frictionCount descending first', sorted[0].company, 'HighFriction');
+ok('NoFriction sorts last (frictionCount 0)', sorted[sorted.length - 1].company === 'NoFriction');
+
+// Alphabetical tie-break when frictionCount and frictionRate are equal.
+const tieIdxA = sorted.findIndex(s => s.company === 'AlphabeticalTieA');
+const tieIdxB = sorted.findIndex(s => s.company === 'AlphabeticalTieB');
+ok('alphabetical tie-break: TieA before TieB', tieIdxA < tieIdxB);
+
+// ============================================================================
+// 9. Integration — full markdown round-trip
+// ============================================================================
+console.log('\n--- 9. integration round-trip ---');
+
+const fullMd = table([
+  '| Sun Life | Regional Coordinator | Prescreen | 2026-07-08 | Sasha (bot) | Scheduled | [process-friction: stated availability overridden across multiple rounds] |',
+  '| Sun Life | Digital Employee Experience | Prescreen | 2026-06-16 | Recruiter | Rejected | clean process |',
+  '| Rentsync | Onboarding Specialist | Intro Call | 2026-06-25 | Evan | Scheduled | clean process |',
+]);
+const fullRows = parseActiveInterviews(fullMd);
+const fullSignals = aggregateProcessQuality(fullRows, 1);
+
+eq('round-trip: 3 rows parsed', fullRows.length, 3);
+const sunLife = fullSignals.find(s => s.company === 'Sun Life');
+ok('round-trip: Sun Life signal present', !!sunLife);
+if (sunLife) {
+  eq('round-trip: Sun Life total = 2', sunLife.totalInterviews, 2);
+  eq('round-trip: Sun Life friction = 1', sunLife.frictionCount, 1);
+  eq('round-trip: Sun Life reason captured', sunLife.reasons[0], 'stated availability overridden across multiple rounds');
+}
+const rentsync = fullSignals.find(s => s.company === 'Rentsync');
+ok('round-trip: Rentsync signal present', !!rentsync);
+if (rentsync) {
+  eq('round-trip: Rentsync friction = 0', rentsync.frictionCount, 0);
+}
+
+// ============================================================================
+// 10. CLI behavior
+// ============================================================================
+console.log('\n--- 10. CLI behavior ---');
+
+const scriptPath = join(dirname(fileURLToPath(import.meta.url)), 'process-quality.mjs');
+
+try {
+  execFileSync('node', [scriptPath, '--self-test'], { encoding: 'utf-8', timeout: 10000 });
+  ok('--self-test exits 0', true);
+} catch (e) {
+  ok('--self-test exits 0', false);
+  console.log(`    exit code: ${e.status}, stderr: ${e.stderr?.slice(0, 200)}`);
+}
+
+const defaultOut = execFileSync('node', [scriptPath], {
+  encoding: 'utf-8', timeout: 10000,
+  cwd: dirname(scriptPath),
+});
+const defaultJson = JSON.parse(defaultOut);
+ok('default produces valid JSON', typeof defaultJson === 'object');
+ok('default has metadata', 'metadata' in defaultJson);
+ok('default has signals array', 'signals' in defaultJson && Array.isArray(defaultJson.signals));
+eq('default minThreshold = 1', defaultJson.metadata.minThreshold, 1);
+
+const thresholdOut = execFileSync('node', [scriptPath, '--min-threshold', '3'], {
+  encoding: 'utf-8', timeout: 10000,
+  cwd: dirname(scriptPath),
+});
+const thresholdJson = JSON.parse(thresholdOut);
+eq('--min-threshold sets minThreshold in metadata', thresholdJson.metadata.minThreshold, 3);
+
+const badThresholdOut = execFileSync('node', [scriptPath, '--min-threshold', 'abc'], {
+  encoding: 'utf-8', timeout: 10000,
+  cwd: dirname(scriptPath),
+});
+const badThresholdJson = JSON.parse(badThresholdOut);
+eq('--min-threshold abc falls back to 1', badThresholdJson.metadata.minThreshold, 1);
+
+const summaryOut = execFileSync('node', [scriptPath, '--summary'], {
+  encoding: 'utf-8', timeout: 10000,
+  cwd: dirname(scriptPath),
+});
+ok('--summary produces human-readable output', summaryOut.includes('Process Quality Signal'));
+
+// ============================================================================
+// RESULTS
+// ============================================================================
+console.log(`\n${'='.repeat(78)}`);
+console.log(`  Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  console.log(`\n  Failed tests:`);
+  for (const f of failures) console.log(`    - ${f}`);
+}
+console.log(`${'='.repeat(78)}`);
+
+process.exit(failed > 0 ? 1 : 0);

--- a/process-quality.test.mjs
+++ b/process-quality.test.mjs
@@ -107,6 +107,27 @@ const noSeparator = parseActiveInterviews(
 );
 ok('table without a separator row still parses the data row', noSeparator.length === 1);
 
+// A second, unrelated markdown table later in the document must not be
+// merged into the parsed rows — only the first contiguous table block is
+// scoped as "the" table (CodeRabbit review, PR #1467).
+const twoTables = parseActiveInterviews(
+  table(['| Acme | Backend Engineer | Prescreen | 2026-06-01 | Jane | Scheduled | ok |']) +
+  '\n\nSome unrelated section.\n\n' +
+  '| Foo | Bar |\n|-----|-----|\n| unrelated | table |\n'
+);
+eq('second markdown table later in the document is not merged in', twoTables.length, 1);
+ok('second-table columns (Foo/Bar) never leak into the result', !('Foo' in twoTables[0]));
+
+// A blank-line gap between two table blocks still stops at the first block
+// (blank lines are not pipe-formatted, so they naturally break contiguity).
+const gappedTables = parseActiveInterviews(
+  table(['| Acme | Backend Engineer | Prescreen | 2026-06-01 | Jane | Scheduled | ok |']) +
+  '\n\n' +
+  table(['| Beta | Coordinator | Round 1 | 2026-06-08 | HM | Scheduled | ok 2 |'])
+);
+eq('a gapped second table block is excluded, only first block parsed', gappedTables.length, 1);
+eq('first block company preserved', gappedTables[0].Company, 'Acme');
+
 // ============================================================================
 // 4. extractFriction
 // ============================================================================
@@ -271,6 +292,16 @@ ok('default produces valid JSON', typeof defaultJson === 'object');
 ok('default has metadata', 'metadata' in defaultJson);
 ok('default has signals array', 'signals' in defaultJson && Array.isArray(defaultJson.signals));
 eq('default minThreshold = 1', defaultJson.metadata.minThreshold, 1);
+
+// Missing-file CLI behavior: data/active-interviews.md is candidate-authored
+// user data and is never present in a fresh repo checkout (it has no shipped
+// template, unlike applications.md/pipeline.md). Running the CLI here — a
+// checkout with no such file — exercises loadActiveInterviews()'s missing-path
+// branch for real, deterministically, without needing a temp-dir workaround
+// (the script resolves its data path relative to its own location, not cwd).
+ok('missing data/active-interviews.md: CLI does not throw', !!defaultOut);
+eq('missing data/active-interviews.md: totalRows = 0', defaultJson.metadata.totalRows, 0);
+eq('missing data/active-interviews.md: signals = []', defaultJson.signals, []);
 
 const thresholdOut = execFileSync('node', [scriptPath, '--min-threshold', '3'], {
   encoding: 'utf-8', timeout: 10000,

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -180,6 +180,7 @@ const scripts = [
   { name: 'reconcile-pipeline.mjs --dry-run', expectExit: 0 },
   { name: 'analyze-patterns.mjs --self-test', expectExit: 0 },
   { name: 'detect-reposts.mjs --self-test', expectExit: 0 },
+  { name: 'process-quality.mjs --self-test', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
   { name: 'validate-portals.mjs --file templates/portals.example.yml', expectExit: 0 },

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -122,6 +122,8 @@ const SYSTEM_PATHS = [
   'liveness-browser.mjs',
   'analyze-patterns.mjs',
   'detect-reposts.mjs',
+  'process-quality.mjs',
+  'process-quality.test.mjs',
   'followup-cadence.mjs',
   'followup-cadence.test.mjs',
   'gemini-eval.mjs',


### PR DESCRIPTION
## Summary
- Adds `process-quality.mjs` — a company/process-level friction aggregator, distinct from #1232 (danger-signal red flags from interviewer behavior) and #960 (role-fit targeting correction). Tracks a third axis: is the *recruiting process itself* (scheduling, comms clarity, tooling) well-run, independent of whether the company or role is a good fit.
- Candidates tag friction inline in `data/active-interviews.md`'s Notes column: `[process-friction]` or `[process-friction: short reason]`. The script parses the table, aggregates friction rate per company (case-insensitive dedup), and outputs JSON or a `--summary` table.
- **Company/process-level only, never a named-individual-recruiter signal** — consistent with the project's Ethical Use principles (respect recruiters' time, no adversarial candidate-side tooling). See the "Not in scope" section of #1466.
- Sits under the same umbrella as #1232/#960/#1242 (shared session-transcript/interview-log signal source).

## Implementation notes
- `parseActiveInterviews()`, `extractFriction()`, `aggregateProcessQuality()` are exported for testing, mirroring `detect-reposts.mjs`'s module shape (same author's prior PR, same conventions: CLI args, `--self-test`, JSON/`--summary` output modes).
- Malformed rows (wrong column count, no table found) are silently dropped rather than crashing the parser.
- `aggregateProcessQuality()` supports `--min-threshold N` to filter out companies with too few data points to be meaningful (default 1).
- Sort order: friction count desc → friction rate desc → company name asc (deterministic).

## Test plan
- [x] `node process-quality.mjs --self-test` — 19 checks, all passing
- [x] `node process-quality.test.mjs` — standalone 68-case suite (parsing, tag extraction, grouping/dedup, threshold filtering, sort order, CLI), mirrors `detect-reposts.test.mjs`'s coverage shape
- [x] Wired `process-quality.mjs --self-test` into `test-all.mjs`'s CI-gated script list
- [x] `node test-all.mjs --quick` — full suite passes except one pre-existing, unrelated Windows/WSL flake (#1409, batch rate-limit pause test) present on `main` before this change
- [x] Documented in `AGENTS.md`'s Main Files table

Closes #1466.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a process-quality report that computes per-company “process friction” signals from active interview notes, available as JSON or a readable summary table.
  * Added a self-check mode to validate parsing and output consistency.
* **Tests**
  * Added a comprehensive test suite covering table parsing, friction extraction, aggregation, threshold filtering, CLI output, and edge cases.
  * Updated the automated test run to execute the new self-check.
* **Chores**
  * Expanded the system update allowlist to include the new report and its test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->