### PR TITLE
feat(followup): seed follow-ups.md pin on Applied transition (#1430)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `interview-prep/{company}-{role}.md` | Company-specific interview intel reports |
 | `analyze-patterns.mjs` | Pattern analysis script (JSON output). Includes ATS channel analysis (per-vendor advance rate; motivated by Bommasani et al., Algorithmic Monocultures in Hiring, FAccT 2026). |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
+| `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON output) |
 | `detect-reposts.mjs` | Repost detector — flags roles re-listed 2+ times in 90 days from scan-history.tsv (JSON or `--summary` table output) |
 | `process-quality.mjs` | Recruiting-process friction aggregator — parses `[process-friction]` tags candidates add to `data/active-interviews.md` Notes and reports per-company friction rate (JSON or `--summary` table output) |
 | `data/follow-ups.md` | Follow-up history tracker |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `interview-prep/{company}-{role}.md` | Company-specific interview intel reports |
 | `analyze-patterns.mjs` | Pattern analysis script (JSON output). Includes ATS channel analysis (per-vendor advance rate; motivated by Bommasani et al., Algorithmic Monocultures in Hiring, FAccT 2026). |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
+| `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON output) |
 | `data/follow-ups.md` | Follow-up history tracker |
 | `scan.mjs` | Zero-token portal scanner — hits Greenhouse/Ashby/Lever APIs directly, zero LLM cost |
 | `check-liveness.mjs` | Job posting liveness checker |

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -175,6 +175,42 @@ function parseFollowups() {
   return entries;
 }
 
+// --- Next-date overrides (pins) ---
+// A user can PIN an application's next follow-up date, taking precedence over
+// the computed cadence (a pin even revives a cold application) until a
+// follow-up logged on/after the pin's set-date resumes the normal schedule.
+// Stored in data/follow-ups.md as directive lines:
+//   - next #42 2026-07-10 (set 2026-07-02)
+// The `(set …)` part records when the pin was made; if omitted (hand-written)
+// it defaults to the pinned date itself. The LAST pin line per application wins.
+const OVERRIDE_RE = /^-\s+next\s+#(\d+)\s+(\d{4}-\d{2}-\d{2})(?:\s+\(set\s+(\d{4}-\d{2}-\d{2})\))?\s*$/i;
+
+export function parseNextOverrides(content) {
+  const byApp = new Map();
+  for (const line of content.split('\n')) {
+    const m = line.match(OVERRIDE_RE);
+    if (!m) continue;
+    const date = m[2];
+    if (!parseDate(date)) continue; // an impossible pinned date never poisons the analysis
+    const appNum = parseInt(m[1]);
+    byApp.set(appNum, { appNum, date, setDate: m[3] || date });
+  }
+  return byApp;
+}
+
+// The pin applies until a follow-up is logged AFTER it. Ties favor the pin:
+// "log a follow-up, then pin the next date" is the common same-day flow.
+export function resolveNextOverride(override, lastFollowupDate) {
+  if (!override) return null;
+  if (lastFollowupDate && lastFollowupDate > override.setDate) return null;
+  return override.date;
+}
+
+function parseOverrides() {
+  if (!existsSync(FOLLOWUPS_FILE)) return new Map();
+  return parseNextOverrides(readFileSync(FOLLOWUPS_FILE, 'utf-8'));
+}
+
 // --- Extract contacts from notes ---
 function extractContacts(notes) {
   if (!notes) return [];
@@ -252,6 +288,7 @@ function analyze() {
   }
 
   const followups = parseFollowups();
+  const overrides = parseOverrides();
 
   // Group follow-ups by app number
   const followupsByApp = new Map();
@@ -286,8 +323,18 @@ function analyze() {
       if (lastDate) daysSinceLastFollowup = daysBetween(lastDate, now);
     }
 
-    const urgency = computeUrgency(normalized, daysSinceApp, daysSinceLastFollowup, followupCount);
-    const nextFollowupDate = computeNextFollowupDate(normalized, appliedDate, lastFollowupDate, followupCount);
+    let urgency = computeUrgency(normalized, daysSinceApp, daysSinceLastFollowup, followupCount);
+    let nextFollowupDate = computeNextFollowupDate(normalized, appliedDate, lastFollowupDate, followupCount);
+
+    // A pinned next-date takes precedence over the computed cadence (explicit
+    // user intent — it even revives a cold application) until a follow-up
+    // logged after the pin resumes the normal schedule.
+    const nextOverride = resolveNextOverride(overrides.get(app.num), lastFollowupDate);
+    if (nextOverride) {
+      nextFollowupDate = nextOverride;
+      urgency = daysBetween(parseDate(nextOverride), now) >= 0 ? 'overdue' : 'waiting';
+    }
+
     const nextDate = nextFollowupDate ? parseDate(nextFollowupDate) : null;
     const daysUntilNext = nextDate ? daysBetween(now, nextDate) : null;
 
@@ -310,6 +357,7 @@ function analyze() {
       followupCount,
       urgency,
       nextFollowupDate,
+      nextOverride,
       daysUntilNext,
     });
   }

--- a/followup-seed-tests.mjs
+++ b/followup-seed-tests.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+
+/**
+ * followup-seed-tests.mjs — regression tests for followup-seed.mjs (#1430).
+ *
+ * Marking a tracker row Applied used to leave data/follow-ups.md untouched
+ * until the user ran the `followup` mode by hand — the seed step never ran on
+ * its own. These tests drive followup-seed.mjs's CLI (via execFileSync, like
+ * tracker-columns-tests.mjs) end-to-end against sandboxed fixtures, plus a few
+ * direct unit-level imports of the exported functions.
+ *
+ * Run: node followup-seed-tests.mjs
+ */
+
+import { execFileSync } from 'child_process';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { parseNextOverrides, resolveNextOverride, normalizeStatus, addDays, parseDate } from './followup-cadence.mjs';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const NODE = process.execPath;
+const SCRIPT = join(ROOT, 'followup-seed.mjs');
+
+let passed = 0;
+let failed = 0;
+function pass(m) { console.log(`PASS ${m}`); passed++; }
+function fail(m) { console.error(`FAIL ${m}`); failed++; }
+
+function todayStr() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// --- sandbox helpers --------------------------------------------------------
+
+function makeSandbox() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-seed-'));
+  const tracker = join(dir, 'applications.md');
+  const followups = join(dir, 'follow-ups.md');
+  const lock = join(dir, `career-ops-followups-test-${Math.random().toString(36).slice(2)}.lock`);
+  return { dir, tracker, followups, lock };
+}
+
+function writeTracker(sandbox, rows) {
+  const header = [
+    '# Applications Tracker',
+    '',
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|-------|--------|-----|--------|-------|',
+    ...rows,
+    '',
+  ].join('\n');
+  writeFileSync(sandbox.tracker, header);
+}
+
+function trackerRow(num, date, company, role, score, status, notes) {
+  return `| ${num} | ${date} | ${company} | ${role} | ${score} | ${status} | ❌ | — | ${notes} |`;
+}
+
+// Run followup-seed.mjs against a sandbox. Returns { code, stdout, stderr }.
+function run(args, sandbox, extraEnv = {}) {
+  const env = {
+    ...process.env,
+    CAREER_OPS_TRACKER: sandbox.tracker,
+    CAREER_OPS_FOLLOWUPS: sandbox.followups,
+    CAREER_OPS_FOLLOWUPS_LOCK: sandbox.lock,
+    ...extraEnv,
+  };
+  try {
+    const stdout = execFileSync(NODE, [SCRIPT, ...args], {
+      cwd: ROOT, env, encoding: 'utf-8', timeout: 30000,
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (e) {
+    return { code: e.status ?? 1, stdout: e.stdout || '', stderr: e.stderr || '' };
+  }
+}
+
+function cleanup(sandbox) {
+  rmSync(sandbox.dir, { recursive: true, force: true });
+  rmSync(sandbox.lock, { recursive: true, force: true });
+}
+
+// ── Test 1: round-trip — pin date derives from notes, not the tracker date column ──
+{
+  const sb = makeSandbox();
+  // Tracker date column (2026-05-01) is deliberately earlier than the notes'
+  // "Applied 2026-06-20" — the seed must use the notes date, never the column.
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20. Great team.')]);
+
+  const res = run(['1', '--json'], sb);
+  if (res.code !== 0) {
+    fail(`1. round-trip seed exits 0 (got ${res.code})\n${res.stdout}${res.stderr}`);
+  } else {
+    pass('1. round-trip seed exits 0');
+    const content = readFileSync(sb.followups, 'utf-8');
+    const overrides = parseNextOverrides(content);
+    const override = overrides.get(1);
+    if (override) {
+      pass('1. pin parses via parseNextOverrides');
+      const resolved = resolveNextOverride(override, null);
+      const expectedNext = addDays(parseDate('2026-06-20'), 7); // default applied_first
+      if (resolved === expectedNext) pass(`1. resolved next date is applied-date + applied_first (${expectedNext})`);
+      else fail(`1. resolved next date — expected ${expectedNext}, got ${resolved}`);
+      if (override.setDate === todayStr()) pass('1. setDate is today');
+      else fail(`1. setDate — expected ${todayStr()}, got ${override.setDate}`);
+    } else {
+      fail('1. pin parses via parseNextOverrides — no override found for #1');
+    }
+  }
+  cleanup(sb);
+}
+
+// ── Test 2: seeded line matches OVERRIDE_RE, never starts with '|' ──────────
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  run(['1'], sb);
+  const content = readFileSync(sb.followups, 'utf-8');
+  const lines = content.split('\n').filter(l => l.trim().startsWith('- next'));
+  if (lines.length === 1 && /^-\s+next\s+#\d+\s+\d{4}-\d{2}-\d{2}(\s+\(set\s+\d{4}-\d{2}-\d{2}\))?\s*$/i.test(lines[0])) {
+    pass('2. seeded line matches OVERRIDE_RE');
+  } else {
+    fail(`2. seeded line matches OVERRIDE_RE — got: ${JSON.stringify(lines)}`);
+  }
+  if (!lines[0]?.startsWith('|')) pass('2. seeded line does not start with |');
+  else fail('2. seeded line does not start with |');
+  cleanup(sb);
+}
+
+// ── Test 3: idempotency + --force appends a second pin (last wins) ─────────
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  const first = run(['1', '--json'], sb);
+  const second = run(['1', '--json'], sb);
+  if (second.code === 0 && JSON.parse(second.stdout).seeded === false) {
+    pass('3. second seed is a no-op (seeded:false)');
+  } else {
+    fail(`3. second seed is a no-op — code ${second.code}, stdout ${second.stdout}`);
+  }
+
+  // Pre-existing table row for the appNum should also block seeding.
+  const sb2 = makeSandbox();
+  writeTracker(sb2, [trackerRow(2, '2026-05-01', 'Globex', 'Manager', '4.0/5', 'Applied', 'Applied 2026-06-01.')]);
+  const tableHeader = [
+    '# Follow-ups',
+    '',
+    '| num | appNum | date | company | role | channel | contact | notes |',
+    '|---|---|---|---|---|---|---|---|',
+    '| 1 | 2 | 2026-06-10 | Globex | Manager | email | recruiter@globex.com | sent |',
+    '',
+  ].join('\n');
+  writeFileSync(sb2.followups, tableHeader);
+  const blocked = run(['2', '--json'], sb2);
+  if (blocked.code === 0 && JSON.parse(blocked.stdout).seeded === false) {
+    pass('3. pre-existing table row blocks seeding');
+  } else {
+    fail(`3. pre-existing table row blocks seeding — code ${blocked.code}, stdout ${blocked.stdout}`);
+  }
+  cleanup(sb2);
+
+  const forced = run(['1', '--force', '--json'], sb);
+  if (forced.code === 0 && JSON.parse(forced.stdout).seeded === true) {
+    pass('3. --force appends a fresh pin');
+  } else {
+    fail(`3. --force appends a fresh pin — code ${forced.code}, stdout ${forced.stdout}`);
+  }
+  const content = readFileSync(sb.followups, 'utf-8');
+  const overrides = parseNextOverrides(content);
+  const pinLines = content.split('\n').filter(l => l.trim().startsWith('- next #1 '));
+  if (pinLines.length === 2) pass('3. two pin lines now present for #1');
+  else fail(`3. two pin lines now present for #1 — got ${pinLines.length}`);
+  // parseNextOverrides keeps the LAST pin per app.
+  const lastPin = pinLines[pinLines.length - 1];
+  const lastDateMatch = lastPin.match(/#1\s+(\d{4}-\d{2}-\d{2})/);
+  if (overrides.get(1)?.date === lastDateMatch?.[1]) pass('3. parseNextOverrides returns the LAST pin');
+  else fail(`3. parseNextOverrides returns the LAST pin — got ${JSON.stringify(overrides.get(1))} vs last line ${lastPin}`);
+  cleanup(sb);
+}
+
+// ── Test 4: date resolution order — --date beats notes; notes beat today; column never used ──
+{
+  const sb = makeSandbox();
+  // Column date is 2026-01-01 (would be very wrong if ever used).
+  writeTracker(sb, [trackerRow(1, '2026-01-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  const withDate = run(['1', '--date', '2026-06-25', '--json'], sb);
+  const parsed = JSON.parse(withDate.stdout);
+  if (parsed.appliedDate === '2026-06-25') pass('4. --date beats notes date');
+  else fail(`4. --date beats notes date — got ${parsed.appliedDate}`);
+  if (parsed.appliedDate !== '2026-01-01') pass('4. tracker date column never used');
+  else fail('4. tracker date column never used — got column date');
+  cleanup(sb);
+
+  // Unit-level: resolveAppliedDate directly.
+  const mod = await import(pathToFileURL(SCRIPT).href);
+  const rowWithNotes = { notes: 'Applied 2026-06-20. Some other text.' };
+  if (mod.resolveAppliedDate(rowWithNotes, null) === '2026-06-20') pass('4. resolveAppliedDate: notes beat today (no explicit date)');
+  else fail('4. resolveAppliedDate: notes beat today');
+  if (mod.resolveAppliedDate(rowWithNotes, '2026-07-01') === '2026-07-01') pass('4. resolveAppliedDate: explicit date wins over notes');
+  else fail('4. resolveAppliedDate: explicit date wins over notes');
+  const rowNoNotes = { notes: 'no date here' };
+  if (mod.resolveAppliedDate(rowNoNotes, null) === todayStr()) pass('4. resolveAppliedDate: falls back to today');
+  else fail('4. resolveAppliedDate: falls back to today');
+}
+
+// ── Test 5: missing file gets exact canonical header; append preserves bytes ──
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  run(['1'], sb);
+  const content = readFileSync(sb.followups, 'utf-8');
+  const expectedHeader = [
+    '# Follow-ups',
+    '',
+    '| num | appNum | date | company | role | channel | contact | notes |',
+    '|---|---|---|---|---|---|---|---|',
+  ].join('\n');
+  if (content.startsWith(expectedHeader)) pass('5. missing file created with exact canonical header');
+  else fail(`5. missing file created with exact canonical header — got:\n${content.slice(0, 200)}`);
+
+  // Now append a second app; prior bytes (header + first pin) must be preserved exactly.
+  const before = readFileSync(sb.followups, 'utf-8');
+  writeTracker(sb, [
+    trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.'),
+    trackerRow(2, '2026-05-01', 'Globex', 'Manager', '4.0/5', 'Applied', 'Applied 2026-06-15.'),
+  ]);
+  run(['2'], sb);
+  const after = readFileSync(sb.followups, 'utf-8');
+  if (after.startsWith(before)) pass('5. appending to existing file preserves prior bytes exactly');
+  else fail('5. appending to existing file preserves prior bytes exactly');
+  cleanup(sb);
+}
+
+// ── Test 6: impossible calendar date rejected ───────────────────────────────
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  const res = run(['1', '--date', '2026-02-31'], sb);
+  if (res.code === 1) pass('6. --date 2026-02-31 exits 1');
+  else fail(`6. --date 2026-02-31 exits 1 — got ${res.code}`);
+  cleanup(sb);
+}
+
+// ── Test 7: non-Applied row rejected without --force, accepted with --force ──
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Evaluated', 'no applied date yet')]);
+  const res = run(['1'], sb);
+  if (res.code === 1) pass('7. non-Applied row rejected without --force (exit 1)');
+  else fail(`7. non-Applied row rejected without --force — got ${res.code}`);
+  const forced = run(['1', '--force', '--json'], sb);
+  if (forced.code === 0 && JSON.parse(forced.stdout).seeded === true) pass('7. non-Applied row succeeds with --force');
+  else fail(`7. non-Applied row succeeds with --force — code ${forced.code}, stdout ${forced.stdout}`);
+  cleanup(sb);
+}
+
+// ── Test 8: --backfill seeds only unpinned Applied rows; re-run seeds 0 ────
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [
+    trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-01.'),   // Applied, unpinned
+    trackerRow(2, '2026-05-01', 'Globex', 'Manager', '4.0/5', 'Applied', 'Applied 2026-06-05.'),  // Applied, will be pre-pinned
+    trackerRow(3, '2026-05-01', 'Initech', 'Analyst', '3.0/5', 'Evaluated', 'not applied'),        // Evaluated
+    trackerRow(4, '2026-05-01', 'Umbrella', 'Scientist', '2.0/5', 'Rejected', 'Applied 2026-04-01. rejected'), // Rejected
+  ]);
+  // Pre-seed #2 with a pin so backfill must skip it.
+  run(['2'], sb);
+
+  const res = run(['--backfill', '--json'], sb);
+  if (res.code !== 0) fail(`8. --backfill exits 0 (got ${res.code})\n${res.stdout}${res.stderr}`);
+  else {
+    const parsed = JSON.parse(res.stdout);
+    if (parsed.seeded.length === 1 && parsed.seeded[0].appNum === 1) pass('8. --backfill seeds exactly the 1 unpinned Applied row');
+    else fail(`8. --backfill seeds exactly the 1 unpinned Applied row — got ${JSON.stringify(parsed.seeded)}`);
+    if (parsed.skipped.some(s => s.appNum === 2)) pass('8. --backfill skips the already-pinned Applied row');
+    else fail(`8. --backfill skips the already-pinned Applied row — got ${JSON.stringify(parsed.skipped)}`);
+  }
+
+  const rerun = run(['--backfill', '--json'], sb);
+  const rerunParsed = JSON.parse(rerun.stdout);
+  if (rerun.code === 0 && rerunParsed.seeded.length === 0) pass('8. re-run backfill seeds 0');
+  else fail(`8. re-run backfill seeds 0 — got ${JSON.stringify(rerunParsed)}`);
+  cleanup(sb);
+}
+
+// ── Test 9: lock held by a live pid → exit 4 ────────────────────────────────
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  mkdirSync(sb.lock, { recursive: true });
+  writeFileSync(join(sb.lock, 'owner.json'), JSON.stringify({ pid: process.pid, token: 'x', startedAt: new Date().toISOString() }));
+  const res = run(['1'], sb, { CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS: '200' });
+  if (res.code === 4) pass('9. lock held by live pid → exit 4');
+  else fail(`9. lock held by live pid → exit 4 — got ${res.code}\n${res.stdout}${res.stderr}`);
+  cleanup(sb);
+}
+
+// ── Test 10: stale-pin harmlessness — pin still parses after status flips to Rejected ──
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  run(['1'], sb);
+  // Flip status to Rejected — the pin is inert (cadence analysis only consumes
+  // actionable statuses), but the pin line itself must still parse fine.
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Rejected', 'Applied 2026-06-20. rejected after onsite')]);
+  const content = readFileSync(sb.followups, 'utf-8');
+  const overrides = parseNextOverrides(content);
+  if (overrides.has(1)) pass('10. stale pin still parses via parseNextOverrides');
+  else fail('10. stale pin still parses via parseNextOverrides');
+  if (normalizeStatus('Rejected') === 'rejected') pass('10. normalizeStatus(Rejected) === rejected (not actionable)');
+  else fail(`10. normalizeStatus(Rejected) — got ${normalizeStatus('Rejected')}`);
+  cleanup(sb);
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/followup-seed-tests.mjs
+++ b/followup-seed-tests.mjs
@@ -314,5 +314,60 @@ function cleanup(sandbox) {
   cleanup(sb);
 }
 
+// ── Test 11: impossible "Applied" date in notes → INVALID_DATE, no garbage pin ──
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-02-31. Bad date.')]);
+  const res = run(['1', '--json'], sb);
+  if (res.code === 1) pass('11. impossible notes date → exit 1');
+  else fail(`11. impossible notes date → exit 1 — got ${res.code}\n${res.stdout}${res.stderr}`);
+  if ((res.stdout + res.stderr).includes('impossible')) pass('11. error names the invalid date problem');
+  else fail(`11. error names the invalid date problem — got\n${res.stdout}${res.stderr}`);
+  // An explicit valid --date must rescue the row (notes date is skipped entirely).
+  const rescued = run(['1', '--date', '2026-06-20', '--json'], sb);
+  let rescuedOk = false;
+  try { rescuedOk = rescued.code === 0 && JSON.parse(rescued.stdout).seeded === true; } catch { /* fall through */ }
+  if (rescuedOk) pass('11. explicit --date rescues a row with bad notes date');
+  else fail(`11. explicit --date rescues — got code ${rescued.code}\n${rescued.stdout}${rescued.stderr}`);
+  cleanup(sb);
+}
+
+// ── Test 12: backfill skips (not aborts on) a row with an impossible notes date ──
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [
+    trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-02-31. Bad date.'),
+    trackerRow(2, '2026-05-02', 'Globex', 'Engineer', '4.2/5', 'Applied', 'Applied 2026-06-20.'),
+  ]);
+  const res = run(['--backfill', '--json'], sb);
+  if (res.code === 0) pass('12. backfill with one bad-notes row exits 0');
+  else fail(`12. backfill with one bad-notes row exits 0 — got ${res.code}\n${res.stdout}${res.stderr}`);
+  try {
+    const out = JSON.parse(res.stdout);
+    if (out.seeded.length === 1 && out.seeded[0].appNum === 2) pass('12. good row still seeded');
+    else fail(`12. good row still seeded — got ${JSON.stringify(out.seeded)}`);
+    if (out.skipped.length === 1 && out.skipped[0].appNum === 1 && out.skipped[0].reason === 'invalid-notes-date') {
+      pass('12. bad row skipped with reason invalid-notes-date');
+    } else {
+      fail(`12. bad row skipped with reason invalid-notes-date — got ${JSON.stringify(out.skipped)}`);
+    }
+  } catch (e) {
+    fail(`12. backfill JSON parses — ${e.message}\n${res.stdout}`);
+  }
+  cleanup(sb);
+}
+
+// ── Test 13: --date combined with --backfill is a usage error ──
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  const res = run(['--backfill', '--date', '2026-06-20'], sb);
+  if (res.code === 1) pass('13. --backfill --date → exit 1');
+  else fail(`13. --backfill --date → exit 1 — got ${res.code}\n${res.stdout}${res.stderr}`);
+  if (res.stderr.includes('--date cannot be combined with --backfill')) pass('13. usage error explains the rejection');
+  else fail(`13. usage error explains the rejection — got\n${res.stderr}`);
+  cleanup(sb);
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/followup-seed.mjs
+++ b/followup-seed.mjs
@@ -1,0 +1,618 @@
+#!/usr/bin/env node
+/**
+ * followup-seed.mjs — Seed data/follow-ups.md when a row is marked Applied (#1430)
+ *
+ * WHY: the follow-up system was "born dead". Marking a tracker row Applied only
+ * updated applications.md — data/follow-ups.md stayed empty until the user ran
+ * the `followup` mode by hand and it happened to notice the row. In practice
+ * that meant most applications never got a scheduled next-follow-up date at
+ * all, silently defeating the entire cadence feature. This script closes that
+ * gap: given an appNum (or --backfill for the whole tracker), it computes the
+ * cadence-default next-follow-up date and writes it as a PIN DIRECTIVE line —
+ * never a table row, because a table row in follow-ups.md means "a follow-up
+ * was SENT", which seeding must not claim.
+ *
+ * Pin format (parsed by `parseNextOverrides` in followup-cadence.mjs):
+ *   - next #<appNum> <YYYY-MM-DD> (set <YYYY-MM-DD>)
+ * First date = seeded next-follow-up date. `(set …)` = the day the pin was
+ * written. The LAST pin per application wins, so re-seeding with --force is
+ * always safe — it just appends a fresh pin.
+ *
+ * Apply-date resolution order (see resolveAppliedDate): explicit --date, then
+ * "Applied YYYY-MM-DD" in the row's notes, then today. The tracker's `date`
+ * column is NEVER used as a fallback — it is usually the evaluation date, not
+ * the date the application actually went out.
+ *
+ * Idempotency: by default, seeding a given appNum is a NO-OP FOREVER once
+ * either a pin or a follow-up table row exists for it (exit 0, seeded:false).
+ * Pass --force to append a fresh pin anyway.
+ *
+ * Usage:
+ *   node followup-seed.mjs <appNum> [--date YYYY-MM-DD] [--force] [--dry-run] [--json]
+ *   node followup-seed.mjs --backfill [--dry-run] [--json]
+ *
+ * Exit codes:
+ *   0 success or idempotent no-op
+ *   1 usage or validation error (incl. impossible --date, non-Applied row
+ *     without --force, unknown flag)
+ *   2 row not found (or tracker missing)
+ *   4 lock timeout
+ *
+ * Env overrides (mirroring merge-tracker.mjs / followup-cadence.mjs):
+ *   CAREER_OPS_TRACKER                     tracker path
+ *   CAREER_OPS_FOLLOWUPS                   follow-ups path
+ *   CAREER_OPS_PROFILE                     profile.yml path (cadence overrides)
+ *   CAREER_OPS_FOLLOWUPS_LOCK              lock directory override
+ *   CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS   lock acquire timeout
+ *   CAREER_OPS_FOLLOWUPS_LOCK_RETRY_MS     lock retry interval
+ *   CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS     stale-lock recovery threshold
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, rmSync, statSync, realpathSync } from 'fs';
+import { join, dirname, basename, resolve, isAbsolute, relative, sep } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { createHash, randomUUID } from 'crypto';
+import { tmpdir } from 'os';
+import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import {
+  resolveCadenceConfig,
+  normalizeStatus,
+  parseAppliedDate,
+  parseNextOverrides,
+  parseDate,
+  addDays,
+} from './followup-cadence.mjs';
+
+const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+
+/** Canonical header written when data/follow-ups.md doesn't exist yet. */
+export const FOLLOWUPS_HEADER = [
+  '# Follow-ups',
+  '',
+  '| num | appNum | date | company | role | channel | contact | notes |',
+  '|---|---|---|---|---|---|---|---|',
+].join('\n');
+
+const FOLLOWUPS_LOCK_PREFIX = 'career-ops-followups-';
+
+/** Structured error carrying an exit-code-mapping `code`. */
+export class SeedError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'SeedError';
+    this.code = code;
+  }
+}
+
+function todayStr() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Validate a `YYYY-MM-DD` string is both well-formed AND a real calendar date.
+ *
+ * `parseDate` (followup-cadence.mjs) happily accepts `2026-02-31` because the
+ * underlying `Date` constructor silently rolls invalid days over into the next
+ * month. Round-tripping the parsed date back through `toISOString` catches
+ * that: a real date always survives the round trip unchanged.
+ *
+ * @param {string} str
+ * @returns {boolean}
+ */
+export function isValidCalendarDate(str) {
+  if (typeof str !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(str)) return false;
+  const d = parseDate(str);
+  if (!d || isNaN(d)) return false;
+  return d.toISOString().slice(0, 10) === str;
+}
+
+/**
+ * Resolve the date an application was actually submitted, in strict priority
+ * order: explicit `--date` > "Applied YYYY-MM-DD" in the tracker row's notes >
+ * today. The tracker's `date` column is never consulted — it is usually the
+ * evaluation date, not the submission date (see followup-cadence.mjs).
+ *
+ * @param {{notes?: string}} row - Parsed tracker row (or any object with `notes`).
+ * @param {string|null|undefined} explicitDate - `--date` value, already validated.
+ * @returns {string} YYYY-MM-DD
+ */
+export function resolveAppliedDate(row, explicitDate) {
+  if (explicitDate) return explicitDate;
+  const notesDate = parseAppliedDate(row?.notes);
+  if (notesDate) return notesDate;
+  return todayStr();
+}
+
+/**
+ * Format one pin directive line. The parser side lives in
+ * followup-cadence.mjs's `OVERRIDE_RE` / `parseNextOverrides`.
+ *
+ * @param {number} appNum
+ * @param {string} nextDate - YYYY-MM-DD
+ * @param {string} setDate - YYYY-MM-DD
+ * @returns {string}
+ */
+export function formatPinLine(appNum, nextDate, setDate) {
+  return `- next #${appNum} ${nextDate} (set ${setDate})`;
+}
+
+// --- Path resolution (env override → option override → default) -----------
+
+function resolveTrackerPath(override) {
+  if (override) return override;
+  if (process.env.CAREER_OPS_TRACKER) return process.env.CAREER_OPS_TRACKER;
+  return existsSync(join(CAREER_OPS, 'data/applications.md'))
+    ? join(CAREER_OPS, 'data/applications.md')
+    : join(CAREER_OPS, 'applications.md');
+}
+
+function resolveFollowupsPath(override) {
+  if (override) return override;
+  if (process.env.CAREER_OPS_FOLLOWUPS) return process.env.CAREER_OPS_FOLLOWUPS;
+  return join(CAREER_OPS, 'data/follow-ups.md');
+}
+
+function envInt(name, fallback) {
+  const v = process.env[name];
+  if (v === undefined || v === '') return fallback;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+// --- Tracker reading ---------------------------------------------------
+
+function readTrackerRows(trackerPath) {
+  const content = readFileSync(trackerPath, 'utf-8');
+  const lines = content.split('\n');
+  const colmap = resolveColumns(lines);
+  const rows = [];
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
+// --- Idempotency: pin OR follow-up table row already exists for appNum ----
+
+// Mirrors followup-cadence.mjs's parseFollowups: a `|`-delimited row whose 3rd
+// cell (index 2 after split('|').map(trim) — index 0 is the empty cell before
+// the leading pipe, index 1 is the follow-up's own `num`) is the appNum.
+function hasFollowupTableRow(content, appNum) {
+  for (const line of content.split('\n')) {
+    if (!line.startsWith('|')) continue;
+    const parts = line.split('|').map(s => s.trim());
+    if (parts.length < 8) continue;
+    const rowAppNum = parseInt(parts[2], 10);
+    if (!isNaN(rowAppNum) && rowAppNum === appNum) return true;
+  }
+  return false;
+}
+
+function isAlreadySeeded(content, appNum) {
+  if (!content) return false;
+  if (parseNextOverrides(content).has(appNum)) return true;
+  return hasFollowupTableRow(content, appNum);
+}
+
+// --- Locking (mirrors merge-tracker.mjs's tracker lock, scoped to follow-ups) --
+
+function pathIsInside(childPath, parentDir) {
+  const relativePath = relative(parentDir, childPath);
+  return relativePath === '' || (relativePath !== '..' && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath));
+}
+
+function resolveFollowupsLockDir(envValue, lockKey) {
+  const tmpRoot = realpathSync(tmpdir());
+  const fallback = join(tmpRoot, `${FOLLOWUPS_LOCK_PREFIX}${lockKey}.lock`);
+  if (!envValue || !isAbsolute(envValue)) return fallback;
+
+  const candidate = resolve(envValue);
+  const parentDir = dirname(candidate);
+  const canonicalParent = existsSync(parentDir) ? realpathSync(parentDir) : resolve(parentDir);
+  if (!pathIsInside(canonicalParent, tmpRoot)) return fallback;
+  if (!basename(candidate).startsWith(FOLLOWUPS_LOCK_PREFIX)) return fallback;
+  return candidate;
+}
+
+function resolveLockDir(explicitLockDir, followupsPath) {
+  if (explicitLockDir) return explicitLockDir;
+  const lockKey = createHash('sha256').update(followupsPath).digest('hex').slice(0, 16);
+  return resolveFollowupsLockDir(process.env.CAREER_OPS_FOLLOWUPS_LOCK, lockKey);
+}
+
+function sleep(ms) {
+  return new Promise(res => setTimeout(res, ms));
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === 'EPERM';
+  }
+}
+
+function readLockOwner(lockDir) {
+  try {
+    return JSON.parse(readFileSync(join(lockDir, 'owner.json'), 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function lockCanRecover(lockDir, staleMs) {
+  const owner = readLockOwner(lockDir);
+  if (owner?.pid) return !processIsAlive(owner.pid);
+  try {
+    return Date.now() - statSync(lockDir).mtimeMs > staleMs;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Acquire an exclusive filesystem lock covering the read-check-append
+ * critical section for data/follow-ups.md. Mirrors merge-tracker.mjs's
+ * tracker lock: atomic `mkdirSync`, an `owner.json` with pid/timestamp,
+ * pid-alive detection, stale-lock recovery, and retry/backoff.
+ *
+ * @param {string} lockDir
+ * @param {string} followupsPath - Recorded in owner.json for diagnostics.
+ * @param {{timeoutMs?: number, retryMs?: number, staleMs?: number}} [options]
+ * @returns {Promise<{release: Function}>}
+ */
+async function acquireFollowupsLock(lockDir, followupsPath, options = {}) {
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const retryMs = options.retryMs ?? 75;
+  const staleMs = options.staleMs ?? 10 * 60_000;
+  const recoverGuardDir = `${lockDir}.recover`;
+  const token = randomUUID();
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      mkdirSync(lockDir);
+      writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
+        pid: process.pid,
+        token,
+        startedAt: new Date().toISOString(),
+        followups: followupsPath,
+      }, null, 2));
+
+      let released = false;
+      return {
+        release() {
+          if (released) return;
+          released = true;
+          const owner = readLockOwner(lockDir);
+          if (owner?.token === token) {
+            rmSync(lockDir, { recursive: true, force: true });
+          }
+        },
+      };
+    } catch (err) {
+      if (err?.code !== 'EEXIST') throw err;
+
+      let hasRecoverGuard = false;
+      try {
+        mkdirSync(recoverGuardDir);
+        hasRecoverGuard = true;
+      } catch (guardErr) {
+        if (guardErr?.code !== 'EEXIST') throw guardErr;
+      }
+
+      if (hasRecoverGuard) {
+        try {
+          if (lockCanRecover(lockDir, staleMs)) {
+            rmSync(lockDir, { recursive: true, force: true });
+            continue;
+          }
+        } finally {
+          rmSync(recoverGuardDir, { recursive: true, force: true });
+        }
+      }
+
+      await sleep(retryMs);
+    }
+  }
+
+  throw new SeedError('LOCK_TIMEOUT', `Timed out waiting for follow-ups lock at ${lockDir}`);
+}
+
+// --- Atomic write (mirrors writeFileAtomic in tracker.mjs / merge-tracker.mjs) --
+
+function writeFileAtomic(filePath, content) {
+  const tmpPath = join(dirname(filePath), `.${basename(filePath)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`);
+  try {
+    writeFileSync(tmpPath, content);
+    renameSync(tmpPath, filePath);
+  } catch (err) {
+    rmSync(tmpPath, { force: true });
+    throw err;
+  }
+}
+
+function appendPins(existingContent, pinLines) {
+  const joined = pinLines.join('\n');
+  if (existingContent == null) {
+    return `${FOLLOWUPS_HEADER}\n${joined}\n`;
+  }
+  return existingContent + (existingContent.endsWith('\n') ? '' : '\n') + joined + '\n';
+}
+
+// --- Core: seed one application --------------------------------------------
+
+/**
+ * Seed data/follow-ups.md with a pin directive for one Applied application.
+ *
+ * Silent-no-op-forever by default: once a pin or a follow-up table row exists
+ * for `appNum`, subsequent calls return `{seeded:false, reason:'already-seeded'}`
+ * without touching the file, unless `options.force` is set.
+ *
+ * @param {number} appNum
+ * @param {object} [options]
+ * @param {string} [options.date] - Explicit apply date (YYYY-MM-DD), already validated.
+ * @param {boolean} [options.force] - Bypass idempotency guard and the Applied-status guard.
+ * @param {boolean} [options.dryRun] - Compute and report, but write nothing (no lock taken).
+ * @param {string} [options.trackerPath]
+ * @param {string} [options.followupsPath]
+ * @param {string} [options.profilePath]
+ * @param {string} [options.lockDir]
+ * @param {number} [options.lockTimeoutMs]
+ * @param {number} [options.lockRetryMs]
+ * @param {number} [options.lockStaleMs]
+ * @returns {Promise<object>}
+ */
+export async function seedFollowup(appNum, options = {}) {
+  if (!Number.isInteger(appNum) || appNum <= 0) {
+    throw new SeedError('USAGE', `Invalid appNum: ${appNum}`);
+  }
+  if (options.date != null && !isValidCalendarDate(options.date)) {
+    throw new SeedError('INVALID_DATE', `--date must be a real calendar date in YYYY-MM-DD form: ${options.date}`);
+  }
+
+  const trackerPath = resolveTrackerPath(options.trackerPath);
+  const followupsPath = resolveFollowupsPath(options.followupsPath);
+
+  if (!existsSync(trackerPath)) {
+    throw new SeedError('ROW_NOT_FOUND', `Tracker not found at ${trackerPath}`);
+  }
+  const rows = readTrackerRows(trackerPath);
+  const row = rows.find(r => r.num === appNum);
+  if (!row) {
+    throw new SeedError('ROW_NOT_FOUND', `Application #${appNum} not found in ${trackerPath}`);
+  }
+
+  const normalized = normalizeStatus(row.status);
+  if (normalized !== 'applied' && !options.force) {
+    throw new SeedError('NOT_APPLIED', `Application #${appNum} is not Applied (status: "${row.status.trim()}"); use --force to seed anyway`);
+  }
+
+  const appliedDate = resolveAppliedDate(row, options.date);
+  const cadence = resolveCadenceConfig({ profilePath: options.profilePath });
+  const nextDate = addDays(parseDate(appliedDate), cadence.applied_first);
+  const setDate = todayStr();
+  const pin = formatPinLine(appNum, nextDate, setDate);
+
+  if (options.dryRun) {
+    const existingContent = existsSync(followupsPath) ? readFileSync(followupsPath, 'utf-8') : '';
+    if (isAlreadySeeded(existingContent, appNum) && !options.force) {
+      return { seeded: false, appNum, pin: null, nextDate, appliedDate, setDate, reason: 'already-seeded', dryRun: true };
+    }
+    return { seeded: true, appNum, pin, nextDate, appliedDate, setDate, dryRun: true };
+  }
+
+  const lockDir = resolveLockDir(options.lockDir, followupsPath);
+  const lock = await acquireFollowupsLock(lockDir, followupsPath, {
+    timeoutMs: options.lockTimeoutMs ?? envInt('CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS', 60_000),
+    retryMs: options.lockRetryMs ?? envInt('CAREER_OPS_FOLLOWUPS_LOCK_RETRY_MS', 75),
+    staleMs: options.lockStaleMs ?? envInt('CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS', 10 * 60_000),
+  });
+
+  try {
+    const existingContent = existsSync(followupsPath) ? readFileSync(followupsPath, 'utf-8') : null;
+    if (existingContent != null && isAlreadySeeded(existingContent, appNum) && !options.force) {
+      return { seeded: false, appNum, pin: null, nextDate, appliedDate, setDate, reason: 'already-seeded' };
+    }
+
+    mkdirSync(dirname(followupsPath), { recursive: true });
+    writeFileAtomic(followupsPath, appendPins(existingContent, [pin]));
+    return { seeded: true, appNum, pin, nextDate, appliedDate, setDate };
+  } finally {
+    lock.release();
+  }
+}
+
+// --- Core: backfill all Applied rows ---------------------------------------
+
+/**
+ * Seed every tracker row whose status normalizes to `applied` that doesn't
+ * already have a pin or follow-up table row. Non-Applied rows are skipped
+ * silently. Idempotent — re-running seeds nothing new.
+ *
+ * @param {object} [options] - Same shape as seedFollowup's options (minus `date`/appNum).
+ * @returns {Promise<{seeded: object[], skipped: object[]}>}
+ */
+export async function seedBackfill(options = {}) {
+  const trackerPath = resolveTrackerPath(options.trackerPath);
+  const followupsPath = resolveFollowupsPath(options.followupsPath);
+
+  if (!existsSync(trackerPath)) {
+    throw new SeedError('ROW_NOT_FOUND', `Tracker not found at ${trackerPath}`);
+  }
+  const rows = readTrackerRows(trackerPath);
+  const appliedRows = rows.filter(r => normalizeStatus(r.status) === 'applied');
+  const cadence = resolveCadenceConfig({ profilePath: options.profilePath });
+  const setDate = todayStr();
+
+  function planFor(row) {
+    const appliedDate = resolveAppliedDate(row, null);
+    const nextDate = addDays(parseDate(appliedDate), cadence.applied_first);
+    return { appNum: row.num, pin: formatPinLine(row.num, nextDate, setDate), nextDate, appliedDate, setDate };
+  }
+
+  if (options.dryRun) {
+    const existingContent = existsSync(followupsPath) ? readFileSync(followupsPath, 'utf-8') : '';
+    const seeded = [];
+    const skipped = [];
+    for (const row of appliedRows) {
+      if (isAlreadySeeded(existingContent, row.num) && !options.force) {
+        skipped.push({ appNum: row.num, reason: 'already-seeded' });
+      } else {
+        seeded.push({ ...planFor(row), dryRun: true });
+      }
+    }
+    return { seeded, skipped, dryRun: true };
+  }
+
+  const lockDir = resolveLockDir(options.lockDir, followupsPath);
+  const lock = await acquireFollowupsLock(lockDir, followupsPath, {
+    timeoutMs: options.lockTimeoutMs ?? envInt('CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS', 60_000),
+    retryMs: options.lockRetryMs ?? envInt('CAREER_OPS_FOLLOWUPS_LOCK_RETRY_MS', 75),
+    staleMs: options.lockStaleMs ?? envInt('CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS', 10 * 60_000),
+  });
+
+  try {
+    const existingContent = existsSync(followupsPath) ? readFileSync(followupsPath, 'utf-8') : null;
+    const checkContent = existingContent ?? '';
+    const seeded = [];
+    const skipped = [];
+    const newPins = [];
+    for (const row of appliedRows) {
+      if (isAlreadySeeded(checkContent, row.num) && !options.force) {
+        skipped.push({ appNum: row.num, reason: 'already-seeded' });
+        continue;
+      }
+      const plan = planFor(row);
+      seeded.push(plan);
+      newPins.push(plan.pin);
+    }
+
+    if (newPins.length > 0) {
+      mkdirSync(dirname(followupsPath), { recursive: true });
+      writeFileAtomic(followupsPath, appendPins(existingContent, newPins));
+    }
+
+    return { seeded, skipped };
+  } finally {
+    lock.release();
+  }
+}
+
+// --- CLI ---------------------------------------------------------------
+
+function parseCliArgs(argv) {
+  const opts = { force: false, dryRun: false, json: false, backfill: false, date: null, appNum: null };
+  const positionals = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--date') {
+      i++;
+      if (argv[i] === undefined) throw new SeedError('USAGE', '--date requires a value');
+      opts.date = argv[i];
+    } else if (a === '--force') {
+      opts.force = true;
+    } else if (a === '--dry-run') {
+      opts.dryRun = true;
+    } else if (a === '--json') {
+      opts.json = true;
+    } else if (a === '--backfill') {
+      opts.backfill = true;
+    } else if (a.startsWith('--')) {
+      throw new SeedError('USAGE', `Unknown flag: ${a}`);
+    } else {
+      positionals.push(a);
+    }
+  }
+
+  if (opts.backfill) {
+    if (positionals.length !== 0) {
+      throw new SeedError('USAGE', '--backfill does not take a positional appNum');
+    }
+  } else {
+    if (positionals.length !== 1) {
+      throw new SeedError('USAGE', 'Usage: node followup-seed.mjs <appNum> [--date YYYY-MM-DD] [--force] [--dry-run] [--json]');
+    }
+    const raw = positionals[0];
+    const n = parseInt(raw, 10);
+    if (isNaN(n) || n <= 0 || String(n) !== raw.trim()) {
+      throw new SeedError('USAGE', `Invalid appNum: ${raw}`);
+    }
+    opts.appNum = n;
+  }
+
+  return opts;
+}
+
+const EXIT_CODES = {
+  USAGE: 1,
+  INVALID_DATE: 1,
+  NOT_APPLIED: 1,
+  ROW_NOT_FOUND: 2,
+  LOCK_TIMEOUT: 4,
+};
+
+function failWith(exitCode, code, message, json) {
+  if (json) console.log(JSON.stringify({ error: message, code }));
+  console.error(`❌ ${message}`);
+  process.exit(exitCode);
+}
+
+function reportSingle(result, json) {
+  if (json) {
+    console.log(JSON.stringify(result));
+    return;
+  }
+  const dryTag = result.dryRun ? ' [dry-run]' : '';
+  if (result.seeded) {
+    console.log(`✅ Seeded #${result.appNum}: next follow-up ${result.nextDate} (applied ${result.appliedDate}, set ${result.setDate})${dryTag}`);
+  } else {
+    console.log(`⏭️  #${result.appNum} already seeded — no-op (${result.reason})${dryTag}`);
+  }
+}
+
+function reportBackfill(result, json) {
+  if (json) {
+    console.log(JSON.stringify(result));
+    return;
+  }
+  const dryTag = result.dryRun ? ' [dry-run]' : '';
+  console.log(`✅ Backfill${dryTag}: seeded ${result.seeded.length}, skipped ${result.skipped.length}`);
+  for (const s of result.seeded) console.log(`  + #${s.appNum}: next ${s.nextDate}`);
+  for (const s of result.skipped) console.log(`  - #${s.appNum}: ${s.reason}`);
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const jsonRequested = argv.includes('--json');
+  let opts;
+  try {
+    opts = parseCliArgs(argv);
+  } catch (err) {
+    failWith(EXIT_CODES[err.code] ?? 1, err.code || 'USAGE', err.message, jsonRequested);
+    return;
+  }
+
+  try {
+    if (opts.backfill) {
+      const result = await seedBackfill({ dryRun: opts.dryRun, force: opts.force });
+      reportBackfill(result, opts.json);
+    } else {
+      const result = await seedFollowup(opts.appNum, { date: opts.date, force: opts.force, dryRun: opts.dryRun });
+      reportSingle(result, opts.json);
+    }
+    process.exit(0);
+  } catch (err) {
+    const code = err.code || 'ERROR';
+    const exitCode = EXIT_CODES[code] ?? 1;
+    failWith(exitCode, code, err.message, opts.json);
+  }
+}
+
+// Run (CLI only; guarded so the module is safely importable for tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/followup-seed.mjs
+++ b/followup-seed.mjs
@@ -112,14 +112,24 @@ export function isValidCalendarDate(str) {
  * today. The tracker's `date` column is never consulted — it is usually the
  * evaluation date, not the submission date (see followup-cadence.mjs).
  *
- * @param {{notes?: string}} row - Parsed tracker row (or any object with `notes`).
+ * A notes date that isn't a real calendar date (e.g. "Applied 2026-02-31")
+ * throws rather than falling through: `parseDate` would return null for it and
+ * the pin would be written with a literal "null" next-date.
+ *
+ * @param {{num?: number, notes?: string}} row - Parsed tracker row (or any object with `notes`).
  * @param {string|null|undefined} explicitDate - `--date` value, already validated.
  * @returns {string} YYYY-MM-DD
+ * @throws {SeedError} INVALID_DATE when the notes carry an impossible date.
  */
 export function resolveAppliedDate(row, explicitDate) {
   if (explicitDate) return explicitDate;
   const notesDate = parseAppliedDate(row?.notes);
-  if (notesDate) return notesDate;
+  if (notesDate) {
+    if (!isValidCalendarDate(notesDate)) {
+      throw new SeedError('INVALID_DATE', `Application #${row?.num ?? '?'} notes carry an impossible "Applied ${notesDate}" date; fix the notes or pass --date`);
+    }
+    return notesDate;
+  }
   return todayStr();
 }
 
@@ -461,8 +471,16 @@ export async function seedBackfill(options = {}) {
     for (const row of appliedRows) {
       if (isAlreadySeeded(existingContent, row.num) && !options.force) {
         skipped.push({ appNum: row.num, reason: 'already-seeded' });
-      } else {
+        continue;
+      }
+      try {
         seeded.push({ ...planFor(row), dryRun: true });
+      } catch (err) {
+        if (err instanceof SeedError && err.code === 'INVALID_DATE') {
+          skipped.push({ appNum: row.num, reason: 'invalid-notes-date', detail: err.message });
+        } else {
+          throw err;
+        }
       }
     }
     return { seeded, skipped, dryRun: true };
@@ -486,7 +504,16 @@ export async function seedBackfill(options = {}) {
         skipped.push({ appNum: row.num, reason: 'already-seeded' });
         continue;
       }
-      const plan = planFor(row);
+      let plan;
+      try {
+        plan = planFor(row);
+      } catch (err) {
+        if (err instanceof SeedError && err.code === 'INVALID_DATE') {
+          skipped.push({ appNum: row.num, reason: 'invalid-notes-date', detail: err.message });
+          continue;
+        }
+        throw err;
+      }
       seeded.push(plan);
       newPins.push(plan.pin);
     }
@@ -531,6 +558,9 @@ function parseCliArgs(argv) {
   if (opts.backfill) {
     if (positionals.length !== 0) {
       throw new SeedError('USAGE', '--backfill does not take a positional appNum');
+    }
+    if (opts.date != null) {
+      throw new SeedError('USAGE', '--date cannot be combined with --backfill (each row resolves its own apply date from its notes)');
     }
   } else {
     if (positionals.length !== 1) {

--- a/modes/apply.md
+++ b/modes/apply.md
@@ -167,8 +167,9 @@ node application-answers.mjs --report reports/NNN-company-role-date.md --input a
 
 If the candidate confirms that they submitted the application:
 1. Update status in `applications.md` from "Evaluated" to "Applied"
-2. Refresh the report's `## Application Answers` section with the final field values and `**State:** submitted`
-3. Suggest next step: run the `contacto` mode (`/career-ops contacto` where available) for LinkedIn outreach
+2. Seed the follow-up schedule: run `node followup-seed.mjs {num} --json` (where `{num}` is the tracker row number). If the candidate applied on a different day than today, pass `--date YYYY-MM-DD` with the actual submission date. It's idempotent, so re-running is safe.
+3. Refresh the report's `## Application Answers` section with the final field values and `**State:** submitted`
+4. Suggest next step: run the `contacto` mode (`/career-ops contacto` where available) for LinkedIn outreach
 
 ## Scroll handling
 

--- a/modes/followup.md
+++ b/modes/followup.md
@@ -131,6 +131,7 @@ After the user reviews and says they've sent a follow-up, record it:
 
 1. If `data/follow-ups.md` doesn't exist, create it (this exact header — the
    same one the web UI writes; `followup-cadence.mjs` parses these columns):
+
    ```markdown
    # Follow-ups
 
@@ -157,7 +158,7 @@ After the user reviews and says they've sent a follow-up, record it:
 `data/follow-ups.md` also supports pin lines that override the computed
 schedule for a single application:
 
-```
+```text
 - next #42 2026-07-10 (set 2026-07-02)
 ```
 

--- a/modes/followup.md
+++ b/modes/followup.md
@@ -129,27 +129,49 @@ For each draft, show:
 
 After the user reviews and says they've sent a follow-up, record it:
 
-1. If `data/follow-ups.md` doesn't exist, create it:
+1. If `data/follow-ups.md` doesn't exist, create it (this exact header — the
+   same one the web UI writes; `followup-cadence.mjs` parses these columns):
    ```markdown
-   # Follow-up History
+   # Follow-ups
 
-   | # | App# | Date | Company | Role | Channel | Contact | Notes |
-   |---|------|------|---------|------|---------|---------|-------|
+   | num | appNum | date | company | role | channel | contact | notes |
+   |---|---|---|---|---|---|---|---|
    ```
 
 2. Append a row with:
-   - `#` = next sequential number in the follow-ups table
-   - `App#` = application number from tracker
-   - `Date` = today's date
-   - `Company` = company name
-   - `Role` = role title
-   - `Channel` = Email / LinkedIn / Other
-   - `Contact` = who it was sent to
-   - `Notes` = brief note (e.g., "First follow-up, referenced Barbeiro.app")
+   - `num` = next sequential number in the follow-ups table
+   - `appNum` = application number from tracker
+   - `date` = today's date (YYYY-MM-DD)
+   - `company` = company name
+   - `role` = role title
+   - `channel` = Email / LinkedIn / Other
+   - `contact` = who it was sent to
+   - `notes` = brief note (e.g., "First follow-up, referenced Barbeiro.app")
 
 3. Optionally update the Notes column in `data/applications.md` with "Follow-up {N} sent {YYYY-MM-DD}"
 
 **IMPORTANT:** Only record follow-ups the user confirms they actually sent. Never record a draft as sent.
+
+### Pinned next dates & automatic seeding
+
+`data/follow-ups.md` also supports pin lines that override the computed
+schedule for a single application:
+
+```
+- next #42 2026-07-10 (set 2026-07-02)
+```
+
+`#42` is the application number, the first date is the pinned NEXT follow-up
+date, and `(set …)` is the day the pin was made. Pins take precedence over
+the computed schedule until a follow-up is logged on or after the set-date;
+the latest pin per application wins; deleting the line clears the pin.
+
+Pins may be seeded AUTOMATICALLY when an application turns Applied —
+`node followup-seed.mjs <num>` (run by the `apply` mode's Step 9) appends a
+pin scheduling the first follow-up at apply date + the `applied_first`
+cadence. Seeding is idempotent, and a stale pin left behind by a later
+Rejected/Discarded transition is harmless because the cadence analysis
+ignores non-actionable statuses.
 
 ## Step 6 — Summary
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -184,6 +184,7 @@ const scripts = [
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
   { name: 'agent-inbox-tests.mjs', expectExit: 0 },
+  { name: 'followup-seed-tests.mjs', expectExit: 0 },
   { name: 'validate-portals.mjs --file templates/portals.example.yml', expectExit: 0 },
   { name: 'validate-system-paths-coverage.mjs --self-test', expectExit: 0 },
   { name: 'validate-system-paths-coverage.mjs', expectExit: 0 },

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -130,6 +130,8 @@ const SYSTEM_PATHS = [
   'followup-cadence.mjs',
   'followup-cadence.test.mjs',
   'agent-inbox.mjs',
+  'followup-seed.mjs',
+  'followup-seed-tests.mjs',
   'gemini-eval.mjs',
   'ollama-eval.mjs',
   'openai-eval.mjs',


### PR DESCRIPTION
## Problem

The follow-up system is born dead (#1430): marking a tracker row `Applied` updates `data/applications.md`, but `data/follow-ups.md` only ever gets entries when the `followup` mode is run by hand. Most applications never get a scheduled next-follow-up date at all, silently defeating the cadence feature.

## What this adds

**`followup-seed.mjs`** — a small CLI + importable module that seeds `data/follow-ups.md` the moment a row turns Applied:

```
node followup-seed.mjs <appNum> [--date YYYY-MM-DD] [--force] [--dry-run] [--json]
node followup-seed.mjs --backfill [--dry-run] [--json]
```

Exit codes: `0` success/no-op · `1` usage/validation · `2` row not found · `4` lock timeout.

## Design decisions

- **Pin, not table row.** The seed writes a pin directive line — `- next #42 2026-07-10 (set 2026-07-03)` — never a table row. Table rows in `follow-ups.md` mean "a follow-up was SENT": they increment `followupCount`, skip the first reminder, and burn the max-followup budget. A pin schedules without claiming.
- **Apply-date resolution** (exported as `resolveAppliedDate(row, explicitDate)`): explicit `--date` → `Applied YYYY-MM-DD` in the row's notes (`parseAppliedDate`) → today. The tracker date column is **never** used — it is usually the evaluation date. The export is the contract for the `set-status.mjs` retrofit (see out of scope).
- **Seeded date** = resolved apply date + `cadence.applied_first` via `resolveCadenceConfig()`, so `config/profile.yml` overrides apply.
- **Idempotency / staleness.** Once a pin or any follow-up row exists for an appNum, seeding is a silent no-op forever (exit 0, `{"seeded": false}`); `--force` appends a fresh pin (last pin per app wins). A stale pin left behind by a later Rejected/Discarded transition is harmless: cadence analysis only consumes actionable statuses.
- **Status guard.** The target row must normalize to `Applied` (exit 1 otherwise); `--force` overrides.
- **Backfill.** `--backfill` seeds every Applied row lacking pins/rows; re-runs are no-ops.
- **Locking + atomic write.** The web UI (#1422) writes this file too, so the read-check-append runs under an exclusive lockdir (`owner.json`, pid-liveness check, stale recovery — mirrors `merge-tracker.mjs`) and the file is replaced via same-directory tmp + rename. Prior content round-trips byte-identical; the seed is append-only.

## Pin consumer forward-port (why `followup-cadence.mjs` changes)

The pin parser (`OVERRIDE_RE`, `parseNextOverrides`, `resolveNextOverride`, `parseOverrides`) and the `analyze()` override wiring do not exist on `main` yet — they live on the `feat/web-followup-tracker` branch (PR #1422). Without them, a seeded pin would be inert on `main` and this PR would close #1430 while changing no observable behavior. So the consumer is forward-ported here, **byte-identical** to the already-reviewed version on that branch (nothing else from it — no bullet parsing, no other rewrites). That branch's next rebase hits a trivial conflict that resolves to identical content.

## Wiring & docs

- `modes/apply.md` Step 9: run `node followup-seed.mjs {num} --json` after the status flips to Applied (`--date` when the user applied on a different day).
- `modes/followup.md`: canonical `# Follow-ups` header (same one the web UI writes), plus a section documenting pin lines, automatic seeding, and how to clear a pin (delete the line).
- `CLAUDE.md` / `AGENTS.md`: Main Files table rows.
- `update-system.mjs`: both new files registered in `SYSTEM_PATHS`.

## Tests

`followup-seed-tests.mjs` (registered in `test-all.mjs`) — 27 assertions across 10 cases, all against temp-dir fixtures:

1. Round-trip: seed → `parseNextOverrides` → `resolveNextOverride` → date = apply date + `applied_first`, set-date = today
2. Seeded line matches `OVERRIDE_RE` and never starts with `|`
3. Idempotency: re-seed no-ops; pre-existing table row blocks; `--force` appends and last pin wins
4. Date-resolution order incl. proof the tracker date column is never used
5. Missing file created with the exact canonical header; append preserves prior bytes exactly
6. Impossible date (`2026-02-31`) rejected (exit 1)
7. Non-Applied row refused without `--force`, seeded with it
8. Backfill seeds only unpinned Applied rows; re-run seeds 0
9. Lock held by a live pid → clean exit 4
10. Stale-pin harmlessness after Applied → Rejected

Suite result: `988 passed, 1 failed` — the single failure is the pre-existing `.npmignore` SYSTEM_PATHS coverage gap already present on `main` (fixed separately in #1453); this PR adds no failures. `verify-pipeline.mjs` passes.

## Out of scope

- **Localized apply modes** (12 language variants) — needs a follow-up issue to wire the seeding step into `modes/{de,fr,ar,ja,tr,…}/`.
- **`set-status.mjs` in-process call** — after #1428/#1460 merges, `feat/set-status` gets retrofitted to call `seedFollowup()` directly (it already emits `followupSeedCandidate: true` as the hook point); the shared `resolveAppliedDate` export is the contract.

Closes #1430

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic follow-up schedule seeding after application submission, with JSON output and optional submission-date override.
  * Introduced pinned “next follow-up” directives that override computed cadence (latest pin wins) until follow-ups are logged.
* **Bug Fixes**
  * Improved next-date override resolution using last logged follow-up date, including overdue handling.
  * Strengthened idempotency, locking, and `--backfill` behavior (skipping invalid note dates where appropriate).
* **Documentation**
  * Updated the follow-ups file format/schema and added guidance for pinned next dates.
* **Tests**
  * Added end-to-end regression coverage for seeding, pin precedence, validation, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->