### PR TITLE
feat(web): richer bug-report diagnostics — data-shape fingerprint, core version, API errors

### DIFF
--- a/web/src/app/api/report/shape/route.ts
+++ b/web/src/app/api/report/shape/route.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import { careerOpsRoot, doctorState, readApplications, readInbox, trackerCanDelete } from "@/lib/career-ops";
+import { scannerSupportsJson } from "@/lib/core/scan";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// STRUCTURAL diagnostics for the in-app bug reporter: shapes, counts and
+// capability probes only — never file contents. A malformed tracker shows up
+// here as "12 candidate rows, 5 parsed", which is exactly what triage needs,
+// without a single company name leaving the machine.
+
+function lineCount(rel: string, predicate: (l: string) => boolean): number {
+  try {
+    return fs
+      .readFileSync(path.join(careerOpsRoot(), rel), "utf8")
+      .split("\n")
+      .filter(predicate).length;
+  } catch {
+    return 0;
+  }
+}
+
+function dirCount(rel: string, ext: string): number {
+  try {
+    return fs.readdirSync(path.join(careerOpsRoot(), rel)).filter((f) => f.endsWith(ext)).length;
+  } catch {
+    return 0;
+  }
+}
+
+export async function GET() {
+  const doctor = doctorState();
+  // "candidate" = a line that LOOKS like a row; parsed = what the tolerant
+  // reader accepted. A gap between the two is the data-contract fingerprint.
+  const inboxCandidates = lineCount("data/pipeline.md", (l) => /^\s*-\s*\[[ xX]\]/.test(l));
+  const trackerCandidates = lineCount(
+    "data/applications.md",
+    (l) => l.trim().startsWith("|") && !/^\|\s*#\s*\|/.test(l.trim()) && !/^\|\s*:?-{2,}/.test(l.trim()),
+  );
+  return Response.json({
+    runtime: { node: process.version, platform: process.platform, arch: process.arch },
+    setup: {
+      phase: doctor.phase,
+      missing: doctor.missing, // system prereq FILENAMES only (cv.md, portals.yml…)
+      hasCv: doctor.hasCv,
+      hasData: doctor.hasData,
+    },
+    data: {
+      inbox: { candidates: inboxCandidates, parsed: readInbox().length },
+      tracker: { candidates: trackerCandidates, parsed: readApplications().length },
+      reports: dirCount("reports", ".md"),
+      pdfs: dirCount("output", ".pdf"),
+      followupsFile: fs.existsSync(path.join(careerOpsRoot(), "data", "follow-ups.md")),
+    },
+    capabilities: {
+      scanJson: scannerSupportsJson(),
+      trackerDelete: trackerCanDelete(),
+    },
+  });
+}

--- a/web/src/lib/core/scan.ts
+++ b/web/src/lib/core/scan.ts
@@ -59,7 +59,7 @@ function parseOfferLine(source: string, date: string, rest: string): Omit<Discov
 // Does the user's LOCAL scanner support the --json contract (#1199)? Probe the
 // source (cheap, no spawn) so older checkouts fall back instead of breaking on an
 // unknown flag — the web is local-first, so the version is whatever they installed.
-function scannerSupportsJson(): boolean {
+export function scannerSupportsJson(): boolean {
   try {
     const src = fs.readFileSync(rootScript("scan-ats-full"), "utf8");
     return src.includes("--json") && src.includes("capHit");

--- a/web/src/lib/report/logbuf.ts
+++ b/web/src/lib/report/logbuf.ts
@@ -26,6 +26,20 @@ if (typeof window !== "undefined" && !window.__coLogBufInstalled) {
     orig(...args);
   };
   window.addEventListener("error", (e) => push(`[onerror] ${e.message || ""} @ ${e.filename || ""}:${e.lineno || ""}`));
+  // Server-side failures are invisible to console.error — wrap fetch so a
+  // degraded API (500, or a route that answered but couldn't do its job) lands
+  // in the ring too. Pathname only: query strings can carry company names.
+  const origFetch = window.fetch.bind(window);
+  window.fetch = async (...args: Parameters<typeof fetch>) => {
+    const res = await origFetch(...args);
+    try {
+      const u = new URL(typeof args[0] === "string" ? args[0] : (args[0] as Request).url, location.origin);
+      if (u.pathname.startsWith("/api/") && !res.ok) push(`[api] ${u.pathname} → ${res.status}`);
+    } catch {
+      /* never break fetch */
+    }
+    return res;
+  };
   window.addEventListener("unhandledrejection", (e) => push(`[rejection] ${String((e as PromiseRejectionEvent).reason)}`));
 }
 

--- a/web/src/lib/report/report.ts
+++ b/web/src/lib/report/report.ts
@@ -12,8 +12,23 @@ export function scrub(s: string): string {
     .replace(/(sk|key|token|secret|bearer|api[-_]?key)([-_=:\s"']+)[A-Za-z0-9._-]{8,}/gi, "$1$2[redacted]");
 }
 
+/** Structural fingerprint from /api/report/shape — shapes/counts, never contents. */
+export type Shape = {
+  runtime?: { node?: string; platform?: string; arch?: string };
+  setup?: { phase?: string; missing?: string[]; hasCv?: boolean; hasData?: boolean };
+  data?: {
+    inbox?: { candidates?: number; parsed?: number };
+    tracker?: { candidates?: number; parsed?: number };
+    reports?: number;
+    pdfs?: number;
+    followupsFile?: boolean;
+  };
+  capabilities?: { scanJson?: boolean; trackerDelete?: boolean };
+};
+
 export type Diag = {
   version: string;
+  coreVersion: string;
   channel: string;
   sha: string;
   route: string;
@@ -21,21 +36,38 @@ export type Diag = {
   ua: string;
   viewport: string;
   logs: string[];
+  shape: Shape | null;
+  /** Whether the core follow-up cadence engine answered — false = engine degraded. */
+  followupsAvailable: boolean | null;
 };
 
 /** Gather a STRUCTURAL diagnostic snapshot. Deliberately excludes anything personal:
  *  no cv.md, no profile, no application answers, no job URLs, no report content. */
 export async function collect(): Promise<Diag> {
   let version = "";
+  let coreVersion = "";
   let channel = "stable";
   let sha = "";
   try {
     const d = await (await fetch("/api/version")).json();
     version = d.version || "";
+    coreVersion = d.coreVersion || "";
     channel = d.channel || "stable";
     sha = d.sha || "";
   } catch {
     /* keep defaults */
+  }
+  let shape: Shape | null = null;
+  try {
+    shape = (await (await fetch("/api/report/shape")).json()) as Shape;
+  } catch {
+    /* structural snapshot is best-effort */
+  }
+  let followupsAvailable: boolean | null = null;
+  try {
+    followupsAvailable = Boolean((await (await fetch("/api/followups")).json()).available);
+  } catch {
+    /* best-effort */
   }
   let cli = "";
   try {
@@ -45,6 +77,7 @@ export async function collect(): Promise<Diag> {
   }
   return {
     version,
+    coreVersion,
     channel,
     sha,
     route: scrub(location.pathname + location.search),
@@ -52,22 +85,38 @@ export async function collect(): Promise<Diag> {
     ua: navigator.userAgent,
     viewport: `${window.innerWidth}×${window.innerHeight}`,
     logs: recentLogs().map(scrub),
+    shape,
+    followupsAvailable,
   };
 }
 
 /** The EXACT markdown body the user reviews and that becomes the GitHub issue. */
 export function issueBody(d: Diag, description: string): string {
+  const s = d.shape;
+  const fmt = (n?: number) => (typeof n === "number" ? String(n) : "?");
+  const shapeLines = s
+    ? [
+        "## Data shape (counts only — no contents)",
+        `- **Setup:** ${s.setup?.phase || "?"}${s.setup?.missing?.length ? ` · missing: ${s.setup.missing.join(", ")}` : ""}`,
+        `- **Inbox:** ${fmt(s.data?.inbox?.parsed)}/${fmt(s.data?.inbox?.candidates)} rows parsed · **Tracker:** ${fmt(s.data?.tracker?.parsed)}/${fmt(s.data?.tracker?.candidates)} rows parsed`,
+        `- **Reports:** ${fmt(s.data?.reports)} · **PDFs:** ${fmt(s.data?.pdfs)} · **Follow-ups engine:** ${d.followupsAvailable === null ? "?" : d.followupsAvailable ? "ok" : "DEGRADED"}`,
+        `- **Core capabilities:** scan --json ${s.capabilities?.scanJson ? "yes" : "no"} · tracker delete ${s.capabilities?.trackerDelete ? "yes" : "no"}`,
+        `- **Server:** node ${s.runtime?.node || "?"} · ${s.runtime?.platform || "?"}/${s.runtime?.arch || "?"}`,
+        "",
+      ]
+    : [];
   return [
     "## What happened",
     scrub(description).trim() || "_(describe what you were doing and what went wrong)_",
     "",
     "## Environment",
-    `- **Version:** \`${d.version || "?"}\` · ${d.channel}${d.sha ? ` · \`${d.sha}\`` : ""}`,
+    `- **Version:** \`${d.version || "?"}\`${d.coreVersion ? ` · core \`${d.coreVersion}\`` : ""} · ${d.channel}${d.sha ? ` · \`${d.sha}\`` : ""}`,
     `- **CLI:** ${d.cli || "—"}`,
     `- **Screen:** \`${d.route}\``,
     `- **Browser:** ${scrub(d.ua)}`,
     `- **Viewport:** ${d.viewport}`,
     "",
+    ...shapeLines,
     "## Recent errors",
     d.logs.length ? "```\n" + d.logs.join("\n") + "\n```" : "_(none captured)_",
     "",


### PR DESCRIPTION
Makes the in-app bug reporter actually useful for triage, while staying strictly structural (no contents, preview-then-confirm unchanged).

**What the issue body gains:**
- **Core version next to the web version** — version-skew is the first triage question.
- **Data-shape fingerprint** (new `/api/report/shape`): parsed-vs-candidate row counts for inbox/tracker. A gap like `5/8 rows parsed` diagnoses a malformed `pipeline.md` without a single company name leaving the machine — verified against a hostile fixture root where it flagged exactly the poisoned rows.
- **Setup phase + missing prereqs** (doctor) — half of alpha reports will be incomplete setups.
- **Follow-ups engine health** — `DEGRADED` pinpoints the bad-date engine crash class (#1422 hardens it).
- **Core capability probes** (scan `--json`, tracker delete) and **server runtime** (node/platform/arch — the Windows-OOM class is invisible without it).
- **API failures in the error ring**: fetch is wrapped so non-ok `/api/*` responses (pathname only) reach the reporter — server-side failures were previously invisible to the client-only ring.

Verified: typecheck + production build clean; `/api/report/shape` exercised against both a healthy root and the hostile fixture root from the data-contract audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new diagnostics endpoint that returns a structural snapshot of the app’s data pipeline and environment.
  * Expanded report generation to include counts, capability checks, and follow-up availability.

* **Bug Fixes**
  * Improved resilience when reading missing or unreadable data sources.
  * Captured failed API requests in recent logs to make issues easier to spot.

* **Documentation**
  * Enhanced generated issue details with clearer data-shape and environment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->