### PR TITLE
docs: surface research/outreach path as first-class feature (#1448)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,8 +265,8 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Pastes JD or URL | auto-pipeline (evaluate + report + PDF + tracker) |
 | Asks to evaluate offer | `oferta` |
 | Asks to compare offers | `ofertas` |
-| Wants LinkedIn outreach | `contacto` |
-| Asks for company research | `deep` |
+| Wants LinkedIn outreach | `contacto` — identifies hiring manager, recruiter, or team peers via web search; drafts a ≤300-char message tailored to the contact type (recruiter / hiring manager / peer / interviewer) |
+| Asks for company research | `deep` — generates a structured 6-axis research prompt covering AI strategy, recent moves, engineering culture, likely challenges, competitors, and the candidate's angle given their profile |
 | Preps for interview at specific company | `interview-prep` |
 | Wants a time-blocked prep plan for an upcoming interview | `interview/plan` |
 | Wants to run practice interview questions with feedback | `interview/practice` |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Career-Ops ([career-ops.org](https://career-ops.org), also known as **careerops*
 - **Scans portals** automatically (Greenhouse, Ashby, Lever, company pages)
 - **Processes in batch** -- evaluate 10+ offers in parallel with sub-agents
 - **Tracks everything** in a single source of truth with integrity checks
+- **Researches companies and finds the right person to contact** -- applications get you in the queue; research gets you a conversation
 
 > **Important: This is NOT a spray-and-pray tool.** Career-ops is a filter -- it helps you find the few offers worth your time out of hundreds. The system strongly recommends against applying to anything scoring below 4.0/5. Your time is valuable, and so is the recruiter's. Always review before submitting.
 
@@ -109,6 +110,7 @@ Built by someone who used it to evaluate 740+ job offers, generate 100+ tailored
 | **Dashboard TUI**        | Terminal UI to browse, filter, and sort your pipeline                                                                                    |
 | **Human-in-the-Loop**    | AI evaluates and recommends, you decide and act. The system never submits an application -- you always have the final call               |
 | **Pipeline Integrity**   | Automated merge, dedup, status normalization, health checks                                                                              |
+| **Beyond the CV**        | Company research ([`deep`](modes/deep.md)) surfaces AI strategy, recent moves, engineering culture, and the angle your profile should take. Contact discovery ([`contacto`](modes/contacto.md)) identifies the hiring manager, recruiter, or team peer worth reaching out to and drafts a ≤300-character LinkedIn message tuned to each contact type. Applications get you in the queue; research gets you a conversation. |
 
 ## Quick Start
 
@@ -281,8 +283,8 @@ Career-ops uses a shared command router. In CLIs that register slash commands, i
 /career-ops tracker        → View application status
 /career-ops apply          → Fill application forms with AI
 /career-ops pipeline       → Process pending URLs
-/career-ops contacto       → LinkedIn outreach message
-/career-ops deep           → Deep company research
+/career-ops contacto       → Find hiring manager / recruiter / peer + draft a ≤300-char LinkedIn message per contact type
+/career-ops deep           → Generate a structured 6-axis research prompt (AI strategy, recent moves, culture, challenges, competitors, candidate angle)
 /career-ops training       → Evaluate a course/cert
 /career-ops project        → Evaluate a portfolio project
 ```


### PR DESCRIPTION
## Summary

Closes #1448

The `deep` (company research) and `contacto` (LinkedIn outreach) modes were
the most underrepresented features in the docs — listed in the Usage command
block with no description, and absent from the feature table entirely.
A community hire this week explicitly attributed their winning offer to the
research/contact-discovery step, not the CV. This PR surfaces that path.

## Changes

### README.md
- **Intro list** (`What Is This`): added a sixth bullet for the research →
  outreach path with the framing phrase _"applications get you in the queue;
  research gets you a conversation"_
- **Features table**: new **Beyond the CV** row describing what `deep` and
  `contacto` actually do, with direct links to their mode files
- **Usage command block**: replaced the bare one-word labels for `/career-ops
  contacto` and `/career-ops deep` with accurate, informative descriptions

### AGENTS.md
- **Skill Modes routing table**: expanded the `contacto` and `deep` rows from
  bare mode names to full one-liners matching what the mode files specify

## No new claims
All descriptions were written after reading `modes/deep.md` and
`modes/contacto.md` directly. Nothing invented.

## Links verified
- [`modes/deep.md`](modes/deep.md) ✅
- [`modes/contacto.md`](modes/contacto.md) ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for two workflow modes in the docs.
  * Expanded the product overview and feature list with company research, contact discovery, and tailored message drafting.
  * Updated command descriptions so users know what each mode now helps them do.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->