### PR TITLE
fix(updater): add .claude/settings.json to USER_PATHS (#1408)

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5961,6 +5961,14 @@ try {
     fail('modes/_custom.md is NOT in USER_PATHS — custom instructions would be wiped on update (#1198)');
   }
 
+  // .claude/settings.json holds user-configured permissions and hooks (e.g. auto-backup).
+  // It must be in USER_PATHS so the updater never overwrites it (#1408).
+  if (userBlock.includes("'.claude/settings.json'")) {
+    pass('.claude/settings.json is in USER_PATHS (user harness config protected from update-system.mjs)');
+  } else {
+    fail('.claude/settings.json is NOT in USER_PATHS — user harness config would be wiped on update (#1408)');
+  }
+
   // The template MUST be in SYSTEM_PATHS so updates deliver/refresh it.
   const sysBlock = (updater.match(/SYSTEM_PATHS\s*=\s*\[([\s\S]*?)\]/) || [, ''])[1];
   if (sysBlock.includes("'modes/_custom.template.md'")) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -222,6 +222,7 @@ const USER_PATHS = [
   'config/plugins.yml',
   'plugins.local/',
   'plugins.lock',
+  '.claude/settings.json',
 ];
 
 function parseVersionFile(raw) {

--- a/validate-system-paths-coverage.mjs
+++ b/validate-system-paths-coverage.mjs
@@ -86,6 +86,7 @@ if (process.argv.includes('--self-test')) {
 
   // Test exact matches in SYSTEM_PATHS / USER_PATHS
   assert(covered('CLAUDE.md') === true, 'CLAUDE.md must be covered (exact match)');
+  assert(covered('.claude/settings.json') === true, '.claude/settings.json must be covered (USER_PATHS exact match, #1408)');
 
   // Test directory prefix matches (which end in '/')
   assert(covered('providers/justjoin.mjs') === true, 'providers/justjoin.mjs must be covered (dir prefix match)');


### PR DESCRIPTION
Forks that track .claude/settings.json (e.g. for auto-backup hooks) failed the coverage validator with a spurious 'orphan file' error.

.claude/settings.json is user-owned harness config by definition: it holds permissions and hooks the user configured in Claude Code. The updater must never touch it, which is exactly the USER_PATHS contract.

Consistent with existing decisions in this repo:
- .gitignore already ignores settings.local.json and memory/ but deliberately leaves settings.json trackable
- SYSTEM_PATHS already contains .claude/skills/ (.claude/ is not off-limits)

Changes:
- update-system.mjs: add '.claude/settings.json' to USER_PATHS
- test-all.mjs: add USER_PATHS coverage assertion for the new entry
- validate-system-paths-coverage.mjs: add --self-test assertion

Closes #1408

## What does this PR do?

Adds `.claude/settings.json` to `USER_PATHS` in `update-system.mjs` so the auto-updater never overwrites user-configured Claude Code project settings. Also adds a regression test in `test-all.mjs` and a `--self-test` assertion in the coverage validator.

## Related issue

Closes #1408

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update safety so user settings are less likely to be overwritten during system updates.
  * If an update touches a protected user file unexpectedly, the update now stops and rolls back only system-side changes.

* **Tests**
  * Expanded update validation to cover user settings protection more thoroughly.
  * Added checks to ensure the updater continues to preserve custom user configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->