### PR TITLE
feat(agent-inbox): queue requests for the next session (agent-inbox.mjs)

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -4,7 +4,7 @@ description: AI job search command center -- evaluate offers, generate CVs, scan
 arguments: mode
 user_invocable: true
 user-invocable: true
-argument-hint: "[scan | deep | pdf | latex | cover | eu-swe | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | followup | update]"
+argument-hint: "[scan | deep | pdf | latex | cover | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | followup | update]"
 license: MIT
 ---
 
@@ -52,6 +52,8 @@ Determine the mode from `$mode`:
 | `training` | `training` |
 | `project` | `project` |
 | `tracker` | `tracker` |
+| `agent-inbox` | `agent-inbox` |
+| `inbox` | `agent-inbox` |
 | `pipeline` | `pipeline` |
 | `apply` | `apply` |
 | `scan` | `scan` |
@@ -105,6 +107,7 @@ Available commands:
   /career-ops training  → Evaluate course/cert against North Star
   /career-ops project   → Evaluate portfolio project idea
   /career-ops tracker   → Application status overview
+  /career-ops agent-inbox → Queue/drain requests for the next session (data/agent-inbox.md)
   /career-ops apply     → Live application assistant (reads form + generates answers)
   /career-ops scan      → Scan portals and discover new offers
   /career-ops batch     → Batch processing with parallel workers
@@ -130,7 +133,7 @@ Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `p
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`
 
-Applies to: `tracker`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`
+Applies to: `tracker`, `agent-inbox`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`
 
 ### Modes delegated to subagent:
 For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ data/follow-ups.md
 data/pipeline.md
 data/scan-history.tsv
 data/pdf-index.tsv
+data/agent-inbox.md
 data/parser-output/**/*.json
 !data/parser-output/.gitkeep
 !data/parser-output/**/.gitkeep

--- a/agent-inbox-tests.mjs
+++ b/agent-inbox-tests.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+/**
+ * agent-inbox-tests.mjs — regression tests for agent-inbox.mjs.
+ *
+ * Locks in the queue's behaviour:
+ *   1. A first `add` seeds the header + agent protocol and one pending item.
+ *   2. `add` is append-only and multiline text collapses to a single bullet.
+ *   3. `list` shows pending only; `list --all` shows resolved items too.
+ *   4. `resolve N` ticks the N-th *pending* item and appends a one-line result,
+ *      so `list` then `resolve N` line up.
+ *   5. An empty `add` fails loudly (exit 1) rather than queuing a blank line.
+ *   6. On the default path, a first `add` self-heals .gitignore (idempotent) so
+ *      the personal queue isn't accidentally tracked.
+ *
+ * Provisions a throwaway queue via CAREER_OPS_INBOX and a temp CWD; never
+ * touches real user data.
+ */
+
+import { execFileSync } from 'child_process';
+import { readFileSync, writeFileSync, mkdtempSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const NODE = process.execPath;
+const CLI = join(ROOT, 'agent-inbox.mjs');
+
+let passed = 0;
+let failed = 0;
+function check(name, cond, detail = '') {
+  if (cond) { passed++; console.log(`  ✅ ${name}`); }
+  else { failed++; console.log(`  ❌ ${name}${detail ? ` — ${detail}` : ''}`); }
+}
+
+function tmp(prefix) {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+// Run agent-inbox.mjs against a provisioned queue file; returns stdout.
+function run(inbox, args, opts = {}) {
+  return execFileSync(NODE, [CLI, ...args], {
+    cwd: ROOT,
+    env: { ...process.env, CAREER_OPS_INBOX: inbox },
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...opts,
+  });
+}
+
+// ---------------------------------------------------------------------------
+console.log('1. First add seeds header + protocol and one pending item');
+{
+  const inbox = join(tmp('inbox-'), 'agent-inbox.md');
+  run(inbox, ['add', 'evaluate https://acme.com/jobs/42']);
+  const md = readFileSync(inbox, 'utf8');
+  check('header present', /^# Agent Inbox/.test(md));
+  check('agent protocol documented', /Agent protocol:/.test(md));
+  check('nothing auto-submits is stated', /auto-submit/.test(md));
+  check('one pending checklist item', (md.match(/^- \[ \]/gm) || []).length === 1, md);
+  check('request text preserved', md.includes('evaluate https://acme.com/jobs/42'));
+}
+
+// ---------------------------------------------------------------------------
+console.log('2. add is append-only; multiline text collapses to one bullet');
+{
+  const inbox = join(tmp('inbox-'), 'agent-inbox.md');
+  run(inbox, ['add', 'first request']);
+  run(inbox, ['add', 'second\nrequest with newline']);
+  const md = readFileSync(inbox, 'utf8');
+  check('two pending items', (md.match(/^- \[ \]/gm) || []).length === 2);
+  check('first item retained', md.includes('first request'));
+  check('newline collapsed (no mid-item break)', md.includes('second request with newline'));
+  check('item count == bullet count (no stray bullets)', (md.match(/^- \[/gm) || []).length === 2);
+}
+
+// ---------------------------------------------------------------------------
+console.log('3. list shows pending; --all includes resolved');
+{
+  const inbox = join(tmp('inbox-'), 'agent-inbox.md');
+  run(inbox, ['add', 'alpha']);
+  run(inbox, ['add', 'beta']);
+  run(inbox, ['resolve', '1', '--result', 'done alpha']);
+  const pending = run(inbox, ['list']);
+  const all = run(inbox, ['list', '--all']);
+  check('pending list hides resolved alpha', !pending.includes('alpha') && pending.includes('beta'), pending.trim());
+  check('--all shows both', all.includes('alpha') && all.includes('beta'));
+}
+
+// ---------------------------------------------------------------------------
+console.log('4. resolve ticks the N-th pending item + appends a one-line result');
+{
+  const inbox = join(tmp('inbox-'), 'agent-inbox.md');
+  run(inbox, ['add', 'gamma']);
+  run(inbox, ['resolve', '1', '--result', 'scored 4.3 — report 012']);
+  const md = readFileSync(inbox, 'utf8');
+  check('item marked done', /^- \[x\] .*gamma/m.test(md), md);
+  check('result appended', /→ result: scored 4\.3 — report 012/.test(md));
+  check('no pending left', (md.match(/^- \[ \]/gm) || []).length === 0);
+}
+
+// ---------------------------------------------------------------------------
+console.log('5. empty add fails (exit 1), does not queue a blank line');
+{
+  const inbox = join(tmp('inbox-'), 'agent-inbox.md');
+  let exit = 0;
+  try { run(inbox, ['add', '   ']); } catch (e) { exit = e.status; }
+  check('non-zero exit on empty request', exit === 1, `exit=${exit}`);
+}
+
+// ---------------------------------------------------------------------------
+console.log('6. first add on the default path self-heals .gitignore (idempotent)');
+{
+  const repo = tmp('inbox-repo-');
+  writeFileSync(join(repo, '.gitignore'), 'node_modules\noutput/*\n');
+  const addOnce = () => execFileSync(NODE, [CLI, 'add', 'queue a scan'], {
+    cwd: repo, env: { ...process.env, CAREER_OPS_INBOX: '' }, stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  addOnce(); addOnce();
+  const gi = readFileSync(join(repo, '.gitignore'), 'utf8');
+  const ruleCount = gi.split('\n').filter((l) => l.trim() === 'data/agent-inbox.md').length;
+  check('.gitignore gains exactly one data/agent-inbox.md rule', ruleCount === 1, `count=${ruleCount}`);
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/agent-inbox.mjs
+++ b/agent-inbox.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+/**
+ * agent-inbox.mjs — a tiny bridge between *looking at* the pipeline and
+ * *acting on* it.
+ *
+ * career-ops is driven from an AI session, but there's no durable place to drop
+ * a request when you're not in one — e.g. while glancing at the tracker (or a
+ * dashboard) you think "evaluate this URL" or "draft a follow-up for #7". This
+ * is that place: an append-only queue the agent drains at the start of a
+ * session.
+ *
+ *   data/agent-inbox.md
+ *     - [ ] <stamp> — <request>          (pending)
+ *     - [x] <stamp> — <request> → result: <one line>   (resolved)
+ *
+ * Fully local-first and human-in-the-loop: nothing here auto-submits. Queued
+ * items are *intents* for the agent to action and the user to review. Markdown
+ * checklist, no database, no server, no dependencies — edit it by hand or via
+ * this CLI, and any tool (a dashboard, a script, cron) can append to it. The
+ * protocol an agent follows is documented in modes/agent-inbox.md.
+ *
+ * Usage:
+ *   node agent-inbox.mjs add "evaluate https://acme.com/jobs/42"
+ *   node agent-inbox.mjs list [--all]                 # pending only, or every item
+ *   node agent-inbox.mjs resolve 1 [--result "scored 4.3 — report 012"]
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+
+const PATH = process.env.CAREER_OPS_INBOX || 'data/agent-inbox.md';
+
+const HEADER = [
+  '# Agent Inbox',
+  '',
+  '> **Agent protocol:** at the start of a career-ops session, read this file.',
+  '> Run each unchecked item top-to-bottom. After each, mark it `[x]` and append',
+  '> `→ result: <one line>`. Items that need live user input (a mock, a paste, a',
+  '> decision) → ask the user to start them instead of running them.',
+  '>',
+  '> Nothing here auto-submits — queued items are *intents* for you to action and',
+  '> the user to review. Appended by hand, by a dashboard, or by agent-inbox.mjs.',
+  '',
+].join('\n');
+
+function stamp() {
+  return new Date().toISOString().slice(0, 16).replace('T', ' ');
+}
+
+function ensureGitignored() {
+  // The inbox is personal data. On installs whose .gitignore predates this
+  // feature, make sure the default path is ignored so a first `add` can't
+  // accidentally commit it. Only manages the default, non-overridden path.
+  if (process.env.CAREER_OPS_INBOX || PATH !== 'data/agent-inbox.md') return;
+  try {
+    if (!existsSync('.gitignore')) return; // not a git checkout we should touch
+    const text = readFileSync('.gitignore', 'utf8');
+    if (text.split('\n').some((l) => l.trim() === PATH)) return; // already ignored
+    writeFileSync('.gitignore', text.replace(/\s*$/, '') + `\n${PATH}\n`);
+  } catch { /* best effort — never block queuing on this */ }
+}
+
+function oneLine(s) {
+  // markdown-checklist-safe: collapse to a single bullet line
+  return String(s ?? '').replace(/\s*\n\s*/g, ' ').trim();
+}
+
+function ensureFile() {
+  if (existsSync(PATH)) return;
+  ensureGitignored();
+  mkdirSync(dirname(PATH), { recursive: true });
+  writeFileSync(PATH, HEADER);
+}
+
+// Parse the checklist into items, in file order.
+function parseItems() {
+  if (!existsSync(PATH)) return [];
+  const items = [];
+  readFileSync(PATH, 'utf8').split('\n').forEach((line, i) => {
+    const m = /^- \[([ xX])\]\s*(.*)$/.exec(line.trim());
+    if (m) items.push({ line: i, done: m[1].toLowerCase() === 'x', text: m[2] });
+  });
+  return items;
+}
+
+function opt(name, def = '') {
+  const i = process.argv.indexOf('--' + name);
+  if (i < 0) return def;
+  const v = process.argv[i + 1];
+  return v && !v.startsWith('--') ? v : def;
+}
+
+function add() {
+  const text = oneLine(process.argv.slice(3).join(' '));
+  if (!text) fail('add needs a request, e.g. node agent-inbox.mjs add "evaluate https://..."');
+  ensureFile();
+  const body = readFileSync(PATH, 'utf8').replace(/\s+$/, '');
+  writeFileSync(PATH, `${body}\n- [ ] ${stamp()} — ${text}\n`);
+  process.stdout.write(`Queued: ${text}\n`);
+}
+
+function list() {
+  const all = process.argv.includes('--all');
+  const items = parseItems().filter((it) => all || !it.done);
+  if (!items.length) return process.stdout.write(all ? 'Inbox is empty.\n' : 'No pending items.\n');
+  items.forEach((it, n) => {
+    process.stdout.write(`${String(n + 1).padStart(2)}. [${it.done ? 'x' : ' '}] ${it.text}\n`);
+  });
+}
+
+function resolve() {
+  const n = Number(process.argv[3]);
+  if (!Number.isInteger(n) || n < 1) fail('resolve needs a 1-based item number (see `list`)');
+  // Number against the pending view, so `list` then `resolve N` line up.
+  const pending = parseItems().filter((it) => !it.done);
+  const target = pending[n - 1];
+  if (!target) fail(`no pending item #${n} (${pending.length} pending)`);
+  const result = oneLine(opt('result'));
+  const lines = readFileSync(PATH, 'utf8').split('\n');
+  let updated = lines[target.line].replace('[ ]', '[x]');
+  if (result && !/→ result:/.test(updated)) updated += ` → result: ${result}`;
+  lines[target.line] = updated;
+  writeFileSync(PATH, lines.join('\n'));
+  process.stdout.write(`Resolved #${n}: ${target.text}\n`);
+}
+
+function fail(msg) {
+  process.stderr.write(`agent-inbox.mjs: ${msg}\n`);
+  process.exit(1);
+}
+
+const cmd = process.argv[2];
+if (cmd === 'add') add();
+else if (cmd === 'list') list();
+else if (cmd === 'resolve') resolve();
+else {
+  process.stdout.write(
+    'Usage:\n' +
+    '  node agent-inbox.mjs add "evaluate https://acme.com/jobs/42"\n' +
+    '  node agent-inbox.mjs list [--all]\n' +
+    '  node agent-inbox.mjs resolve <n> [--result "..."]\n',
+  );
+}

--- a/modes/agent-inbox.md
+++ b/modes/agent-inbox.md
@@ -1,0 +1,50 @@
+# Mode: agent-inbox — Queue requests for the next session
+
+A durable bridge between *looking at* the pipeline and *acting on* it. career-ops
+runs from an AI session, but there's no place to drop a request when you're not
+in one. The agent inbox is that place: an append-only checklist
+(`data/agent-inbox.md`) that any tool — this CLI, a dashboard button, a cron job,
+or you by hand — can append to, and that the agent drains at the start of a
+session.
+
+Local-first, human-in-the-loop, zero dependencies: **nothing here auto-submits.**
+Queued items are *intents* for the agent to action and the user to review.
+
+## Queue a request
+
+```bash
+node agent-inbox.mjs add "evaluate https://acme.com/jobs/42"
+node agent-inbox.mjs add "draft a follow-up for application #7"
+node agent-inbox.mjs add "run a scan and triage anything new"
+```
+
+## Inspect / resolve
+
+```bash
+node agent-inbox.mjs list            # pending items
+node agent-inbox.mjs list --all      # include resolved items
+node agent-inbox.mjs resolve 1 --result "scored 4.3 — report 012"
+```
+
+`data/agent-inbox.md` is user-layer (gitignored). Items look like:
+
+```markdown
+- [ ] 2026-06-21 09:30 — evaluate https://acme.com/jobs/42
+- [x] 2026-06-20 18:05 — run a scan → result: 3 new, 1 worth evaluating
+```
+
+## Agent protocol (when the user invokes this mode, or at session start)
+
+1. Read `data/agent-inbox.md`. If it doesn't exist or has no unchecked items,
+   say so and stop.
+2. Run each **unchecked** item top-to-bottom by routing it to the right mode
+   (a URL → `auto-pipeline`; "follow-up" → `followup`; "scan" → `scan`; etc.).
+3. After each, mark it `[x]` and append `→ result: <one line>` — either by hand
+   or with `node agent-inbox.mjs resolve <n> --result "..."`.
+4. Items that need **live user input** (a mock interview, a pasted transcript, a
+   decision, anything that would submit an application) → do **not** run them;
+   ask the user to start them instead. The inbox never bypasses human review.
+
+This mode pairs naturally with a dashboard: a "queue this" button writes to the
+same file, so a click while browsing the tracker becomes work the next session
+picks up.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -182,6 +182,7 @@ const scripts = [
   { name: 'detect-reposts.mjs --self-test', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
+  { name: 'agent-inbox-tests.mjs', expectExit: 0 },
   { name: 'validate-portals.mjs --file templates/portals.example.yml', expectExit: 0 },
   { name: 'validate-system-paths-coverage.mjs --self-test', expectExit: 0 },
   { name: 'validate-system-paths-coverage.mjs', expectExit: 0 },

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -67,6 +67,7 @@ const SYSTEM_PATHS = [
   'interview-prep/sessions/README.md',
   'modes/patterns.md',
   'modes/update.md',
+  'modes/agent-inbox.md',
   'modes/ar/',
   'modes/da/',
   'modes/de/',
@@ -124,6 +125,7 @@ const SYSTEM_PATHS = [
   'detect-reposts.mjs',
   'followup-cadence.mjs',
   'followup-cadence.test.mjs',
+  'agent-inbox.mjs',
   'gemini-eval.mjs',
   'ollama-eval.mjs',
   'openai-eval.mjs',
@@ -133,6 +135,7 @@ const SYSTEM_PATHS = [
   'test-salary-filter.mjs',
   'test-trust-validator.mjs',
   'tracker-columns-tests.mjs',
+  'agent-inbox-tests.mjs',
   'validate-portals.mjs',
   'verify-portals.mjs',
   'updater-migration-tests.mjs',
@@ -634,7 +637,7 @@ async function apply() {
 
     // 3a. Keep bootstrap paths as a fallback for very old targets, but the
     // target updater's SYSTEM_PATHS is now the source of truth for new files.
-    const BOOTSTRAP_PATHS = ['.agents/', '.opencode/skills/', '.antigravitycli/skills/', '.grok/skills/', '.kimi/skills/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'role-matcher.mjs', 'tracker-utils.mjs', 'tracker-parse.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs', 'tracker-columns-tests.mjs', 'plugins/', 'plugins.mjs', 'plugins-registry.json', 'plugin-install.mjs', 'plugin-audit.mjs', 'validate-plugin-registry.mjs', 'config/plugins.example.yml'];
+    const BOOTSTRAP_PATHS = ['.agents/', '.opencode/skills/', '.antigravitycli/skills/', '.grok/skills/', '.kimi/skills/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'role-matcher.mjs', 'tracker-utils.mjs', 'tracker-parse.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs', 'tracker-columns-tests.mjs', 'plugins/', 'plugins.mjs', 'plugins-registry.json', 'plugin-install.mjs', 'plugin-audit.mjs', 'validate-plugin-registry.mjs', 'config/plugins.example.yml', 'agent-inbox.mjs', 'agent-inbox-tests.mjs'];
     const updatePaths = mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS);
 
     for (const path of updatePaths) {


### PR DESCRIPTION
Closes #1216

## What

Resubmission of #1148, which was closed asking for a tracking issue first (opened as #1216 per your request). Same feature, rebased onto current `main` — no functional changes from the original PR.

A tiny bridge between *looking at* the pipeline and *acting on* it. career-ops runs from an AI session, but there's no durable place to drop a request when you're **not** in one — glancing at the tracker you think "evaluate this URL" or "draft a follow-up for #7". `agent-inbox.mjs` is that place: an append-only checklist (`data/agent-inbox.md`) any tool can append to, and the agent drains at the start of a session.

```bash
node agent-inbox.mjs add "evaluate https://acme.com/jobs/42"
node agent-inbox.mjs list            # pending (add --all for resolved too)
node agent-inbox.mjs resolve 1 --result "scored 4.3 — report 012"
```

```markdown
- [ ] 2026-06-21 09:30 — evaluate https://acme.com/jobs/42
- [x] 2026-06-20 18:05 — run a scan → result: 3 new, 1 worth evaluating
```

## Scope (per #1216)

Standalone CLI inbox only — `add` / `list` / `done` (`resolve`) subcommands + a non-blocking session-start summary line. Dashboard queue-this button explicitly out of scope, kept first-party for 2.0 per your guidance on the original PR.

## Contract-safe by design

- User-layer file (`data/agent-inbox.md`), gitignored; a first `add` self-heals `.gitignore` on older installs so the personal queue can't be accidentally committed.
- Markdown-checklist-safe input (multiline collapses to a single bullet).
- `CAREER_OPS_INBOX` env override for tests/custom layouts.

## Tests

`agent-inbox-tests.mjs` — 16 checks (header/protocol seeding, append-only, multiline collapse, pending vs `--all`, resolve + result, empty-add guard, idempotent `.gitignore` self-heal), registered in `test-all.mjs`. Full suite green on rebased `main`: `989 passed, 0 failed` (the 1 warning is pre-existing/environmental, unrelated to this change).

## Wiring

`modes/agent-inbox.md` (the drain protocol), `/career-ops agent-inbox` + `inbox` routes (`SKILL.md`), `update-system.mjs` whitelist, and a `.gitignore` rule. Did not wire the drain into session bootstrap (`_shared.md`) to keep the diff small and non-invasive — happy to add that as an opt-in follow-up if wanted.

## Related issue

Fixes #1216

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] My changes respect the Data Contract (no modifications to user-layer files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “agent inbox” workflow with commands to add, list (pending vs. all), and resolve queued requests.
  * Introduced support for the new inbox mode, including a shortcut alias and corresponding menu entry.
  * Added mode documentation describing expected behavior and formatting.

* **Bug Fixes**
  * Improved empty-input validation to prevent blank queue entries.
  * Ensures the default inbox file is ignored automatically when using the default path.

* **Tests & Chores**
  * Added a regression test suite and included the inbox components in system update coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->