### PR TITLE
feat(providers): SAP SuccessFactors (RMK) zero-token provider

### DIFF
--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -1,0 +1,187 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// SAP SuccessFactors provider — Recruiting Marketing (RMK, ex-jobs2web) career
+// sites (Career Site Builder's branded job boards). These are the portals big
+// German industrials run at their own domains (jobs.zf.com, jobs.schaeffler.com,
+// jobs.hensoldt.net, jobs.sap.com, …) — all served by the same SF RMK backend.
+//
+// The RMK backend exposes a public, no-auth job-list fragment endpoint:
+//   GET {origin}/tile-search-results/?startrow={N}
+// It returns an HTML fragment (not JSON) of <li class="job-tile job-id-{id}">
+// blocks, each carrying data-url (job path), the title link, and — when the
+// tenant configures it — a rendered city field. We parse those out; the scanner
+// contract only needs {title, url, company, location, postedAt}.
+//
+// Pagination: startrow is a plain row offset, and page size is tenant-specific
+// (Schaeffler serves 100/page, most others 25). We never assume a page size —
+// each loop advances startrow by the number of tiles actually returned, and a
+// per-id dedup set guards against overlap or a server that ignores the offset.
+//
+// Detection: branded RMK hosts (jobs.zf.com) contain no "successfactors" string,
+// so detect() only auto-claims literal *.successfactors.eu/.com and jobs2web
+// URLs. The branded portals are wired up with an explicit `provider:
+// successfactors` in portals.yml (which bypasses detect()); `api:` may override
+// careers_url when the public careers_url isn't the RMK origin.
+//
+// RMK carries no posting date in the list fragment, so postedAt is always
+// omitted (consumers treat an absent date as "unknown", never as stale).
+
+const MAX_PAGES = 40; // safety cap on request count
+const MAX_JOBS = 1000; // cap total postings pulled per site
+
+/** @param {import('./_types.js').PortalEntry} entry */
+function resolveConfig(entry) {
+  const raw = entry.api || entry.careers_url || '';
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  return {
+    origin: u.origin,
+    tileApi: `${u.origin}/tile-search-results/`,
+    jobBase: u.origin,
+  };
+}
+
+// Minimal HTML entity decoder — titles carry named (&amp;) and numeric
+// (&#252; / &#xfc;) entities. We only need the handful that show up in job
+// titles; anything else is left as-is.
+const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+/** @param {string} s */
+function decodeEntities(s) {
+  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
+    if (body[0] === '#') {
+      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : m;
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
+  });
+}
+
+/** @param {string} s */
+function clean(s) {
+  return decodeEntities(s.replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
+}
+
+// RMK job paths encode the city as the leading slug segment:
+//   /job/{City-Words}-{Title-Words}-{reqCode}/{id}/
+// When the tenant doesn't render a dedicated city field we recover the city by
+// stripping the title (and trailing code) off the front slug. We anchor on the
+// first two title words — a prefix the slug always reproduces verbatim, unlike
+// the title's tail where punctuation like "(m/w/d)" gets mangled.
+/** @param {string} dataUrl @param {string} title */
+export function cityFromSlug(dataUrl, title) {
+  let path;
+  try {
+    path = decodeURIComponent(dataUrl);
+  } catch {
+    path = dataUrl;
+  }
+  const m = path.match(/\/job\/([^/]+)\//);
+  if (!m) return '';
+  const slug = m[1].toLowerCase();
+  const words = title.toLowerCase().match(/[\p{L}\p{N}]+/gu);
+  if (!words || !words.length) return '';
+  // Anchor on the first two title words, but allow ANY run of non-alphanumerics
+  // between them — in the slug those words may be joined by "-", "-amp-" (a
+  // decoded "&"), or several hyphens, none of which survive the title's word
+  // split. A rigid "word-word" anchor would miss "Program & Release" → "program-&amp;-release".
+  const esc = (w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  let anchorRe;
+  try {
+    anchorRe = new RegExp(words.slice(0, 2).map(esc).join('[^\\p{L}\\p{N}]+'), 'u');
+  } catch {
+    return '';
+  }
+  const hit = slug.match(anchorRe);
+  if (!hit || hit.index === undefined || hit.index <= 0) return '';
+  return slug
+    .slice(0, hit.index)
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+// Parse one page fragment into raw {id, title, url, city} records.
+// Each posting renders three responsive copies (desktop/tablet/mobile) inside
+// one <li>; a single <li> per id means the top-level dedup already collapses
+// them, and within a block the first match of each field wins.
+/** @param {string} htmlText @param {string} jobBase */
+export function parseTiles(htmlText, jobBase) {
+  const out = [];
+  const tileRe = /<li class="job-tile job-id-(\d+)\b[\s\S]*?<\/li>/g;
+  let t;
+  while ((t = tileRe.exec(htmlText)) !== null) {
+    const id = t[1];
+    const block = t[0];
+    const urlM = block.match(/data-url="([^"]+)"/);
+    if (!urlM) continue;
+    const titleM = block.match(/class="jobTitle-link[^"]*"[^>]*>([\s\S]*?)<\/a>/);
+    const title = titleM ? clean(titleM[1]) : '';
+    if (!title) continue;
+    // data-url is an HTML attribute, so a literal "&" in the path arrives as
+    // &amp;. Decode entities (but not percent-encoding — %28 etc. stays) before
+    // both URL building and slug parsing, so the "amp" of &amp; can't leak into
+    // the recovered city.
+    const path = decodeEntities(urlM[1]);
+    // Anchor on id="…-section-city-value"> — the value div. The sibling label
+    // span references the same id via aria-describedby, so a looser match would
+    // swallow the "City" label text too.
+    const cityM = block.match(/id="[^"]*-section-city-value">([\s\S]*?)<\/div>/);
+    const city = cityM ? clean(cityM[1]) : cityFromSlug(path, title);
+    const url = /^https?:\/\//i.test(path) ? path : jobBase + (path.startsWith('/') ? path : '/' + path);
+    out.push({ id, title, url, location: city });
+  }
+  return out;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'successfactors',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (/successfactors\.(eu|com)|jobs2web\.com/i.test(url)) return { url };
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const cfg = resolveConfig(entry);
+    if (!cfg) throw new Error(`successfactors: cannot resolve origin for ${entry.name}`);
+
+    const jobs = [];
+    const seen = new Set();
+    let startrow = 0;
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const htmlText = await ctx.fetchText(`${cfg.tileApi}?startrow=${startrow}`, {
+        redirect: 'error',
+        headers: { accept: 'text/html' },
+      });
+      const tiles = parseTiles(htmlText, cfg.jobBase);
+      if (tiles.length === 0) break;
+
+      let fresh = 0;
+      for (const tile of tiles) {
+        if (seen.has(tile.id)) continue;
+        seen.add(tile.id);
+        fresh++;
+        jobs.push({
+          title: tile.title,
+          url: tile.url,
+          company: entry.name,
+          location: tile.location,
+        });
+      }
+      // No new ids this page → server ignored the offset (or we've looped). Stop.
+      if (fresh === 0) break;
+      if (jobs.length >= MAX_JOBS) break;
+      startrow += tiles.length;
+    }
+    return jobs;
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -495,6 +495,8 @@ search_queries:
 #   rippling        ats.rippling.com/<slug>/jobs
 #   jibeapply       <slug>.jibeapply.com/jobs  (or provider: jibeapply + api: for a branded host's own /jobs path)
 #   workday         <tenant>.wd<N>.myworkdayjobs.com[/<locale>]/<board>
+#   successfactors  *.successfactors.(eu|com) / *.jobs2web.com  (SAP SF Recruiting Marketing / RMK boards;
+#                   branded hosts like jobs.<company>.com need provider: successfactors + api: <board origin>)
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
@@ -541,6 +543,17 @@ search_queries:
 #   max_pages: 100         # optional page cap (20 jobs/page, default 100, max 1500) —
 #                          # raise it for a tenant with 2000+ open postings (a warning
 #                          # is logged if the cap truncates real results)
+#   enabled: true
+#
+# - name: Example SuccessFactors Co
+#   # SAP SuccessFactors Recruiting Marketing (RMK, ex-jobs2web) branded board —
+#   # what many large industrials run at their own domain (jobs.<company>.com).
+#   # Branded hosts carry no "successfactors" string, so set provider: explicitly
+#   # and point api: at the board origin (host only, no path). The provider pulls
+#   # the public /tile-search-results fragment (zero-token, no auth).
+#   careers_url: https://www.exampleco.com/careers   # public/branded careers page
+#   provider: successfactors
+#   api: https://jobs.exampleco.com                  # RMK board origin
 #   enabled: true
 #
 # - name: SolidJobs — Engineering

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9628,6 +9628,103 @@ if (!fileExists('interview-prep/sessions/README.md')) {
   }
 }
 
+console.log('\n53. Provider — successfactors (SAP RMK tile parser)');
+
+try {
+  const sf = (await import(pathToFileURL(join(ROOT, 'providers/successfactors.mjs')).href)).default;
+  const { parseTiles, cityFromSlug } = await import(pathToFileURL(join(ROOT, 'providers/successfactors.mjs')).href);
+
+  if (sf.id === 'successfactors') pass('successfactors.id is "successfactors"');
+  else fail(`successfactors.id is ${JSON.stringify(sf.id)}`);
+
+  // detect() — literal SF hosts auto-claim; branded RMK hosts (jobs.zf.com) do
+  // NOT (they carry no "successfactors" string and rely on explicit provider:).
+  if (sf.detect({ name: 'X', careers_url: 'https://acme.successfactors.eu/careers' })) {
+    pass('successfactors.detect() claims a *.successfactors.eu URL');
+  } else {
+    fail('successfactors.detect() should claim *.successfactors.eu');
+  }
+  if (sf.detect({ name: 'X', api: 'https://company.jobs2web.com/x' })) {
+    pass('successfactors.detect() claims a jobs2web.com URL');
+  } else {
+    fail('successfactors.detect() should claim jobs2web.com');
+  }
+  if (sf.detect({ name: 'ZF', careers_url: 'https://jobs.zf.com' }) === null) {
+    pass('successfactors.detect() returns null for a branded RMK host (needs explicit provider:)');
+  } else {
+    fail('successfactors.detect() must not auto-claim branded hosts');
+  }
+
+  // cityFromSlug — recover the city prefix from an RMK /job/{City}-{Title}-{code}/ slug.
+  if (cityFromSlug('/job/Hyderabad-Specialist-Low-Level-Driver-Development-TG-500032/1399717233/', 'Specialist -Low Level Driver Development') === 'Hyderabad') {
+    pass('cityFromSlug extracts a single-word city');
+  } else {
+    fail(`cityFromSlug single-word wrong: ${cityFromSlug('/job/Hyderabad-Specialist-Low-Level-Driver-Development-TG-500032/1399717233/', 'Specialist -Low Level Driver Development')}`);
+  }
+  // Multi-word city (Levallois-Perret) — anchoring on the title's first two
+  // words means the full city prefix survives, not just the first token.
+  if (cityFromSlug('/job/Levallois-Perret-Data-Management-Engagement-Architect-92300/1400945133/', 'Data Management Engagement Architect') === 'Levallois Perret') {
+    pass('cityFromSlug extracts a multi-word city');
+  } else {
+    fail(`cityFromSlug multi-word wrong: ${cityFromSlug('/job/Levallois-Perret-Data-Management-Engagement-Architect-92300/1400945133/', 'Data Management Engagement Architect')}`);
+  }
+  // Accented title (Ingénieur) — unicode word matching keeps the anchor intact.
+  if (cityFromSlug('/job/Massy-Ing%C3%A9nieur-Commercial-91743/1351400755/', 'Ingénieur Commercial') === 'Massy') {
+    pass('cityFromSlug handles accented (unicode) titles');
+  } else {
+    fail(`cityFromSlug accented wrong: ${cityFromSlug('/job/Massy-Ing%C3%A9nieur-Commercial-91743/1351400755/', 'Ingénieur Commercial')}`);
+  }
+
+  // parseTiles — a compact fragment covering the three things that bit during
+  // development: the city-value div (not its "City" label), an &amp; in the
+  // data-url path, a slug fallback when no city div is rendered, an entity in
+  // the title, desktop/mobile duplication collapsed to one <li>, and a
+  // title-less tile that must be dropped.
+  const jobBase = 'https://jobs.example.com';
+  const fragment = `
+    <ul>
+      <li class="job-tile job-id-111 job-row-index-1" data-url="/job/Schweinfurt-Ferienarbeiter-97421/111/">
+        <a class="jobTitle-link fontcolorx" href="/job/Schweinfurt-Ferienarbeiter-97421/111/">Ferienarbeiter (m&#47;w&#47;d)</a>
+        <div id="job-111-desktop-section-city" class="section-field city">
+          <span id="job-111-desktop-section-city-label" aria-describedby="job-111-desktop-section-city-value" class="section-label sr-only">City</span>
+          <div id="job-111-desktop-section-city-value">Schweinfurt                 </div>
+        </div>
+      </li>
+      <li class="job-tile job-id-222 job-row-index-2" data-url="/job/Palo-Alto-Program-&amp;-Release-Manager-CA-94304/222/">
+        <a class="jobTitle-link fontcolorx" href="/x">Program &amp; Release Manager</a>
+      </li>
+      <li class="job-tile job-id-333 job-row-index-3" data-url="/job/no-title/333/">
+      </li>
+    </ul>`;
+  const parsed = parseTiles(fragment, jobBase);
+
+  if (parsed.length === 2) pass('parseTiles returns 2 jobs (title-less tile dropped)');
+  else fail(`parseTiles returned ${parsed.length} jobs, expected 2`);
+
+  const j1 = parsed.find((j) => j.url.includes('/111/'));
+  if (j1 && j1.title === 'Ferienarbeiter (m/w/d)') pass('parseTiles decodes entity in title');
+  else fail(`parseTiles title wrong: ${JSON.stringify(j1 && j1.title)}`);
+  if (j1 && j1.location === 'Schweinfurt') pass('parseTiles reads the city-value div, not the "City" label');
+  else fail(`parseTiles city wrong: ${JSON.stringify(j1 && j1.location)}`);
+  if (j1 && j1.url === 'https://jobs.example.com/job/Schweinfurt-Ferienarbeiter-97421/111/') pass('parseTiles builds an absolute URL from data-url');
+  else fail(`parseTiles url wrong: ${JSON.stringify(j1 && j1.url)}`);
+
+  const j2 = parsed.find((j) => j.url.includes('/222/'));
+  if (j2 && j2.url === 'https://jobs.example.com/job/Palo-Alto-Program-&-Release-Manager-CA-94304/222/') {
+    pass('parseTiles decodes &amp; in the data-url path');
+  } else {
+    fail(`parseTiles &amp; url wrong: ${JSON.stringify(j2 && j2.url)}`);
+  }
+  if (j2 && j2.location === 'Palo Alto') pass('parseTiles falls back to slug city when no city div is present');
+  else fail(`parseTiles slug-fallback city wrong: ${JSON.stringify(j2 && j2.location)}`);
+
+  // Empty fragment (MTU's zero-req case) → no jobs, no throw.
+  if (parseTiles('<!DOCTYPE html>', jobBase).length === 0) pass('parseTiles returns [] for an empty fragment');
+  else fail('parseTiles should return [] for an empty fragment');
+} catch (err) {
+  fail(`successfactors provider test threw: ${err.message}`);
+}
+
 // ── match-star.mjs — fixture story-bank + top match assertion ───────────────
 
 console.log('\n🧪 Testing match-star.mjs keyword scorer...');


### PR DESCRIPTION
## What

Adds `providers/successfactors.mjs` — a zero-token HTTP provider for **SAP SuccessFactors Recruiting Marketing (RMK, ex-jobs2web)** career sites. These are the branded job boards big industrials run at their own domains (jobs.zf.com, jobs.schaeffler.com, jobs.hensoldt.net, jobs.sap.com, jobs.knds.de, careers.liebherr.com, …), which the scanner previously skipped with *"no provider matched"*.

## How it works

The RMK backend exposes a public, no-auth job-list **fragment** endpoint:

```
GET {origin}/tile-search-results/?startrow=N
```

It returns HTML `<li class="job-tile job-id-{id}">` blocks (not JSON). The provider parses **title**, **job URL** and — when the tenant renders it — **city** out of each tile. Pagination advances `startrow` by the number of tiles *actually returned*, because page size is tenant-specific (**Schaeffler serves 100/page, most others 25**); a per-id dedup set guards against a server that ignores the offset. `MAX_PAGES`/`MAX_JOBS` cap the pull at ~1000 postings.

Detection only auto-claims literal `*.successfactors.(eu|com)` and `jobs2web.com` URLs. Branded RMK hosts (e.g. `jobs.zf.com`) carry no `successfactors` string, so they're wired up with an explicit `provider: successfactors` + `api:` (board origin) in `portals.yml`.

## Changes

- **`providers/successfactors.mjs`** — provider + exported `parseTiles` / `cityFromSlug` helpers (structure mirrors `workday.mjs`).
- **`test-all.mjs`** — section 53, 14 hermetic assertions: detect routing, city recovery (single-word / multi-word / accented), tile parsing (city-value div vs. "City" label), `&amp;` URL decoding, slug fallback, dedup, empty fragment.
- **`templates/portals.example.yml`** — host-pattern reference line + a copy-paste example stanza.

## Verification

Live-tested (zero-token) against real boards:

| Company | Board | Jobs |
|---|---|---|
| SAP | jobs.sap.com | 1000 (capped) |
| Schaeffler | jobs.schaeffler.com | 728 |
| ZF | jobs.zf.com | 705 |
| Hensoldt | jobs.hensoldt.net | 493 |
| KNDS | jobs.knds.de | 281 |
| Liebherr | careers.liebherr.com | 1000 (capped) |

`node test-all.mjs` → **1000 passed, 0 failed**.

**Note:** MTU's RMK board (`jobs.mtu.de`, company `mtuaeroeng`) is reachable and on the same j2w platform but currently publishes **0 public reqs** — the provider returns `[]` cleanly rather than erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SAP SuccessFactors Recruiting Marketing (RMK) / Jobs2Web job board support with automatic host detection and tile-based job fetching (including pagination and deduplication).
  * Improved location extraction by deriving city from job URLs when needed, with support for multi-word and accented titles.
* **Documentation**
  * Updated portal configuration guidance for branded SuccessFactors sites, including required provider and API/board origin settings.
* **Tests**
  * Added tests for provider detection, city derivation, tile parsing (with HTML/entity decoding), and behavior on empty or incomplete fragments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->