### PR TITLE
feat(add): /career-ops add — fetch a project/paper/role into cv.md + article-digest.md

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -4,7 +4,7 @@ description: AI job search command center -- evaluate offers, generate CVs, scan
 arguments: mode
 user_invocable: true
 user-invocable: true
-argument-hint: "[scan | deep | pdf | latex | cover | eu-swe | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | followup | update]"
+argument-hint: "[scan | deep | pdf | latex | cover | add | eu-swe | oferta | ofertas | apply | batch | tracker | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | followup | update]"
 license: MIT
 ---
 
@@ -60,6 +60,7 @@ Determine the mode from `$mode`:
 | `followup` | `followup` |
 | `update` | `update` |
 | `cover` | `cover` |
+| `add` | `add` |
 
 **Auto-pipeline detection:** If `$mode` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
 
@@ -102,6 +103,7 @@ Available commands:
   /career-ops pdf       → PDF only, ATS-optimized CV
   /career-ops latex     → Export CV as LaTeX/Overleaf .tex
   /career-ops cover     → Cover letter: standalone JD paste or /career-ops cover {slug}
+  /career-ops add       → Add a project/paper/role to your CV (fetch + preview + confirm)
   /career-ops training  → Evaluate course/cert against North Star
   /career-ops project   → Evaluate portfolio project idea
   /career-ops tracker   → Application status overview
@@ -130,7 +132,7 @@ Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `p
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`
 
-Applies to: `tracker`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`
+Applies to: `tracker`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`, `add`
 
 ### Modes delegated to subagent:
 For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:

--- a/add-entry.mjs
+++ b/add-entry.mjs
@@ -75,13 +75,26 @@ export function locateSection(md, section) {
   return null;
 }
 
+// The identifiers an entry can be recognized by within a section: bold spans
+// (**Name**) and any sub-headings (### / ####). Matching dedup against these
+// discrete names — not the raw section text — stops a short key like "AI" from
+// colliding with an unrelated substring (e.g. the "ai" inside "email").
+export function extractIdentifiers(body) {
+  const ids = [];
+  for (const m of body.matchAll(/\*\*([^*]+)\*\*/g)) ids.push(m[1]);
+  for (const m of body.matchAll(/^#{3,}\s+(.*\S)\s*$/gm)) ids.push(m[1]);
+  return ids;
+}
+
 // Does the named CV section already contain an entry matching dedupKey?
+// Compares the key against each entry's identifier (normalized equality), not a
+// substring of the whole section body.
 export function cvHasEntry(md, section, dedupKey) {
   const key = normalizeKey(dedupKey);
   if (!key) return false;
   const loc = locateSection(md, section);
   if (!loc) return false;
-  return normalizeKey(loc.body).includes(key);
+  return extractIdentifiers(loc.body).some(id => normalizeKey(id) === key);
 }
 
 // Insert a pre-formatted entry under `## <section>`, creating the section at
@@ -102,12 +115,19 @@ export function insertIntoCvSection(md, section, entry) {
   return rebuilt.replace(/\n{3,}/g, '\n\n');
 }
 
-// article-digest.md is a sequence of `## <name>` blocks separated by `---`.
+// article-digest.md is a sequence of `## <name> -- <tagline>` blocks separated
+// by `---`. Dedup on the name (the heading text before the dash), matched by
+// normalized equality or prefix so "## FraudShield -- Detection" matches the key
+// "FraudShield" without a short key colliding on unrelated heading text.
 export function articleDigestHasEntry(md, dedupKey) {
   const key = normalizeKey(dedupKey);
   if (!key) return false;
-  const headings = md.match(/^##\s+.*$/gm) || [];
-  return headings.some(h => normalizeKey(h).includes(key));
+  for (const m of md.matchAll(/^##\s+(.*\S)\s*$/gm)) {
+    const name = m[1].split(/\s+[—–-]{1,2}\s+/)[0];
+    const n = normalizeKey(name);
+    if (n === key || n.startsWith(key)) return true;
+  }
+  return false;
 }
 
 export function appendArticleDigest(md, entry) {
@@ -134,6 +154,9 @@ export function applyAdd(payload, { cvText = null, articleText = null } = {}) {
   if (payload.cv) {
     const { section, dedupKey, entry } = payload.cv;
     if (!section || !entry) throw new Error('payload.cv requires { section, entry }');
+    // dedupKey is what makes the insert idempotent — refuse to add without one
+    // rather than silently allowing duplicate re-runs.
+    if (!normalizeKey(dedupKey)) throw new Error('payload.cv requires a non-empty dedupKey (used for dedup/idempotency)');
     if (cvText === null) throw new Error(`cv.md not found — cannot add to a CV that does not exist`);
     if (cvHasEntry(cvText, section, dedupKey)) {
       result.cv = { status: 'duplicate', section };
@@ -146,6 +169,7 @@ export function applyAdd(payload, { cvText = null, articleText = null } = {}) {
   if (payload.articleDigest) {
     const { dedupKey, entry } = payload.articleDigest;
     if (!entry) throw new Error('payload.articleDigest requires { entry }');
+    if (!normalizeKey(dedupKey)) throw new Error('payload.articleDigest requires a non-empty dedupKey (used for dedup/idempotency)');
     // article-digest.md is optional; create it from a header when missing.
     const current = articleText === null
       ? '# Article Digest -- Proof Points\n\nCompact proof points from portfolio projects. Read by career-ops at evaluation time.\n'
@@ -200,13 +224,20 @@ async function main() {
   }
 
   if (!dryRun) {
+    // Track what actually landed so a failure on the second write reports which
+    // file was already mutated (the two writes aren't transactional).
+    const written = [];
     try {
-      if (payload.cv && out.result.cv?.status === 'added') writeFileSync(CV_FILE, out.cv);
+      if (payload.cv && out.result.cv?.status === 'added') {
+        writeFileSync(CV_FILE, out.cv);
+        written.push('cv.md');
+      }
       if (payload.articleDigest && (out.result.articleDigest?.status === 'added' || out.result.articleDigest?.status === 'created')) {
         writeFileSync(ARTICLE_DIGEST_FILE, out.articleDigest);
+        written.push('article-digest.md');
       }
     } catch (e) {
-      console.error(`add-entry: write failed: ${e.message}`);
+      console.error(`add-entry: write failed after writing [${written.join(', ') || 'nothing'}]: ${e.message}`);
       process.exit(1);
     }
   }

--- a/add-entry.mjs
+++ b/add-entry.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * add-entry.mjs — Deterministic dedup + insertion for `/career-ops add`.
+ *
+ * The `add` mode (agent) does the fetching, extraction, ATS-bullet writing,
+ * preview, and confirm-before-write gate. This helper does ONE thing: take a
+ * structured payload of already-written markdown and insert it into the user's
+ * `cv.md` and/or `article-digest.md` idempotently — skipping anything that is
+ * already there. It never fabricates or rewrites content; it only places the
+ * blocks the agent produced.
+ *
+ * Usage:
+ *   node add-entry.mjs <payload.json> [--dry-run]
+ *   node add-entry.mjs --stdin [--dry-run]        (read payload JSON from stdin)
+ *
+ * Payload shape (both keys optional, at least one required):
+ *   {
+ *     "cv": {
+ *       "section": "Projects",                 // heading to insert under (## Projects)
+ *       "dedupKey": "FraudShield",             // used to detect an existing entry
+ *       "entry": "- **FraudShield** (Open Source) -- Real-time fraud detection..."
+ *     },
+ *     "articleDigest": {
+ *       "dedupKey": "FraudShield",
+ *       "entry": "## FraudShield -- Real-Time Fraud Detection\n\n**Hero metrics:** ..."
+ *     }
+ *   }
+ *
+ * Output: a JSON result to stdout, e.g.
+ *   { "dryRun": false,
+ *     "cv": { "status": "added", "section": "Projects" },
+ *     "articleDigest": { "status": "duplicate" } }
+ *
+ * Exit codes: 0 on success (including a no-op "duplicate"); non-zero only on a
+ * hard error (bad/empty payload, a requested target file missing, unwritable).
+ *
+ * Test isolation: CAREER_OPS_CV / CAREER_OPS_ARTICLE_DIGEST override the target
+ * files so tests never touch a real user CV.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+
+const CV_FILE = process.env.CAREER_OPS_CV || join(CAREER_OPS, 'cv.md');
+const ARTICLE_DIGEST_FILE = process.env.CAREER_OPS_ARTICLE_DIGEST || join(CAREER_OPS, 'article-digest.md');
+
+// Normalize a title/heading for duplicate detection: lowercase, collapse to
+// alphanumerics only. "FraudShield", "Fraud-Shield", "fraud shield" all match.
+export function normalizeKey(s) {
+  return typeof s === 'string' ? s.toLowerCase().replace(/[^a-z0-9]+/g, '') : '';
+}
+
+// Split a markdown doc into the block belonging to a `## <section>` heading:
+// { before, heading, body, after }. `body` runs up to the next `## ` heading
+// (or EOF). Returns null when the section is absent.
+export function locateSection(md, section) {
+  const target = normalizeKey(section);
+  const lines = md.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^##\s+(.*\S)\s*$/);
+    if (m && normalizeKey(m[1]) === target) {
+      let end = i + 1;
+      while (end < lines.length && !/^##\s+/.test(lines[end])) end++;
+      return {
+        before: lines.slice(0, i).join('\n'),
+        heading: lines[i],
+        body: lines.slice(i + 1, end).join('\n'),
+        after: lines.slice(end).join('\n'),
+      };
+    }
+  }
+  return null;
+}
+
+// Does the named CV section already contain an entry matching dedupKey?
+export function cvHasEntry(md, section, dedupKey) {
+  const key = normalizeKey(dedupKey);
+  if (!key) return false;
+  const loc = locateSection(md, section);
+  if (!loc) return false;
+  return normalizeKey(loc.body).includes(key);
+}
+
+// Insert a pre-formatted entry under `## <section>`, creating the section at
+// end-of-file when absent. Trailing whitespace inside the section is trimmed so
+// entries stack cleanly with a single blank line between the heading and body.
+export function insertIntoCvSection(md, section, entry) {
+  const block = entry.replace(/\s+$/, '');
+  const loc = locateSection(md, section);
+  if (!loc) {
+    const base = md.replace(/\s+$/, '');
+    return `${base}\n\n## ${section}\n\n${block}\n`;
+  }
+  const body = loc.body.replace(/\s+$/, '');
+  const newBody = body ? `${body}\n${block}` : block;
+  const parts = [loc.before, loc.heading, '', newBody, ''];
+  const after = loc.after.replace(/^\n+/, '');
+  const rebuilt = parts.join('\n') + (after ? `\n${after}` : '');
+  return rebuilt.replace(/\n{3,}/g, '\n\n');
+}
+
+// article-digest.md is a sequence of `## <name>` blocks separated by `---`.
+export function articleDigestHasEntry(md, dedupKey) {
+  const key = normalizeKey(dedupKey);
+  if (!key) return false;
+  const headings = md.match(/^##\s+.*$/gm) || [];
+  return headings.some(h => normalizeKey(h).includes(key));
+}
+
+export function appendArticleDigest(md, entry) {
+  const block = entry.replace(/\s+$/, '');
+  const base = md.replace(/\s+$/, '');
+  // Keep the existing `---`-separated block rhythm.
+  return `${base}\n\n---\n\n${block}\n`;
+}
+
+/**
+ * Pure core: given the current file contents and a payload, compute the new
+ * contents and a per-target status. No I/O — this is what the tests exercise.
+ * @returns {{ cv: string, articleDigest: string, result: object }}
+ */
+export function applyAdd(payload, { cvText = null, articleText = null } = {}) {
+  if (!payload || typeof payload !== 'object' || (!payload.cv && !payload.articleDigest)) {
+    throw new Error('payload must include at least one of: cv, articleDigest');
+  }
+
+  const result = {};
+  let cv = cvText;
+  let articleDigest = articleText;
+
+  if (payload.cv) {
+    const { section, dedupKey, entry } = payload.cv;
+    if (!section || !entry) throw new Error('payload.cv requires { section, entry }');
+    if (cvText === null) throw new Error(`cv.md not found — cannot add to a CV that does not exist`);
+    if (cvHasEntry(cvText, section, dedupKey)) {
+      result.cv = { status: 'duplicate', section };
+    } else {
+      cv = insertIntoCvSection(cvText, section, entry);
+      result.cv = { status: 'added', section };
+    }
+  }
+
+  if (payload.articleDigest) {
+    const { dedupKey, entry } = payload.articleDigest;
+    if (!entry) throw new Error('payload.articleDigest requires { entry }');
+    // article-digest.md is optional; create it from a header when missing.
+    const current = articleText === null
+      ? '# Article Digest -- Proof Points\n\nCompact proof points from portfolio projects. Read by career-ops at evaluation time.\n'
+      : articleText;
+    if (articleDigestHasEntry(current, dedupKey)) {
+      result.articleDigest = { status: 'duplicate' };
+      articleDigest = articleText;
+    } else {
+      articleDigest = appendArticleDigest(current, entry);
+      result.articleDigest = { status: articleText === null ? 'created' : 'added' };
+    }
+  }
+
+  return { cv, articleDigest, result };
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const useStdin = args.includes('--stdin');
+  const fileArg = args.find(a => !a.startsWith('--'));
+
+  if (!useStdin && !fileArg) {
+    console.error('Usage: node add-entry.mjs <payload.json> [--dry-run]  (or --stdin)');
+    process.exit(1);
+  }
+
+  let payload;
+  try {
+    const raw = useStdin ? await readStdin() : readFileSync(fileArg, 'utf-8');
+    payload = JSON.parse(raw);
+  } catch (e) {
+    console.error(`add-entry: could not read/parse payload: ${e.message}`);
+    process.exit(1);
+  }
+
+  const cvText = existsSync(CV_FILE) ? readFileSync(CV_FILE, 'utf-8') : null;
+  const articleText = existsSync(ARTICLE_DIGEST_FILE) ? readFileSync(ARTICLE_DIGEST_FILE, 'utf-8') : null;
+
+  let out;
+  try {
+    out = applyAdd(payload, { cvText, articleText });
+  } catch (e) {
+    console.error(`add-entry: ${e.message}`);
+    process.exit(1);
+  }
+
+  if (!dryRun) {
+    try {
+      if (payload.cv && out.result.cv?.status === 'added') writeFileSync(CV_FILE, out.cv);
+      if (payload.articleDigest && (out.result.articleDigest?.status === 'added' || out.result.articleDigest?.status === 'created')) {
+        writeFileSync(ARTICLE_DIGEST_FILE, out.articleDigest);
+      }
+    } catch (e) {
+      console.error(`add-entry: write failed: ${e.message}`);
+      process.exit(1);
+    }
+  }
+
+  console.log(JSON.stringify({ dryRun, ...out.result }, null, 2));
+}
+
+// Only run main() when invoked directly, not when imported by tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -15,6 +15,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run build:latex` | `build-cv-latex.mjs` | Build .tex from structured JSON payload |
 | `npm run sync-check` | `cv-sync-check.mjs` | Validate CV/profile consistency |
 | `npm run patterns` | `analyze-patterns.mjs` | Analyze tracker outcomes and report patterns |
+| `npm run add` | `add-entry.mjs` | Dedup + insert a `/career-ops add` entry into cv.md / article-digest.md |
 | `npm run update:check` | `update-system.mjs check` | Check for upstream updates |
 | `npm run update` | `update-system.mjs apply` | Apply upstream update |
 | `npm run rollback` | `update-system.mjs rollback` | Rollback last update |

--- a/modes/add.md
+++ b/modes/add.md
@@ -1,0 +1,105 @@
+# Mode: add — Add a project, paper, or role to your CV
+
+Fetch a finished project / paper / internship from a link (or plain text), turn
+it into ATS-style CV content **grounded only in what the source actually says**,
+preview it, and — after you confirm — append it to `cv.md` and (for projects)
+`article-digest.md`. Deterministic dedup and insertion are handled by
+`add-entry.mjs`, so re-adding the same thing is a safe no-op.
+
+> **Non-negotiables (from the project's source-of-truth rules in `_shared.md`):**
+> - **Confirm before write.** Never touch `cv.md` / `article-digest.md` until the
+>   user approves the preview.
+> - **Never fabricate.** Every bullet, metric, and date must be backed by the
+>   fetched page or the user's own words. If the source doesn't state it, it does
+>   not go in. Keywords get reformulated, never invented.
+> - **Zero-key, local.** Use only public, no-auth fetches (GitHub's public API,
+>   WebFetch). No API keys, no third-party services.
+
+## Input
+
+`$mode` after `add` is the source. Accept any of:
+- a **GitHub repo URL** (`github.com/<owner>/<repo>`)
+- a **paper / publication link** (arXiv, DOI, journal, personal page)
+- a **project / portfolio page URL**
+- **plain text** the user pastes describing the work
+
+If no source was given, ask the user for one.
+
+## Pipeline
+
+1. **Load context.** Read `cv.md` (its existing section names and formatting are
+   the template to match) and `article-digest.md` if present.
+2. **Fetch the source (zero-key):**
+   - **GitHub repo** → the public REST API (`https://api.github.com/repos/<owner>/<repo>`
+     for name/description/topics/language/stars/timestamps) **plus** the README
+     via WebFetch. No token required for public repos.
+   - **Any other link** → WebFetch. Only fall back to Playwright if the page is
+     JS-rendered and WebFetch returns nothing useful.
+   - **Plain text** → use it directly as the source; do not invent beyond it.
+3. **Extract structured facts** actually present in the source: name, dates /
+   period, tech stack, role, and concrete outcomes/metrics. Leave anything the
+   source doesn't state **blank** — do not guess.
+4. **Classify the entry type → target CV section** (see table). Placement is
+   inferred, but shown in the preview; only ask the user when it's genuinely
+   ambiguous.
+5. **Write ATS bullets from the extracted facts** — 2–4 concise, quantified-where-the-
+   source-supports-it bullets, matching the bullet style already used in `cv.md`.
+   For a **project**, also compose an `article-digest.md` block (`## <Name> — <tagline>`
+   with `**Hero metrics:**`, `**Architecture:**`, `**Key decisions:**`,
+   `**Proof points:**`), filling only what the source supports.
+6. **Preview.** Show, as a diff-style preview: the inferred CV section, the exact
+   markdown to be inserted into `cv.md`, and (for projects) the `article-digest.md`
+   block. Flag anything you could not source.
+7. **Confirm gate.** Ask the user to approve, edit, or cancel. Do **not** proceed
+   without an explicit yes.
+8. **Write via the helper.** Build the payload (schema below), write it to
+   `/tmp/add-<slug>.json`, then run:
+   ```bash
+   node add-entry.mjs /tmp/add-<slug>.json
+   ```
+   (Add `--dry-run` first if the user wants to see the file-level change without
+   writing.)
+9. **Report** the helper's JSON result. If a target comes back `duplicate`, tell
+   the user it was already present and nothing was changed.
+
+## Section inference
+
+| Source is… | CV section |
+|------------|------------|
+| a code project / repo / tool | `Projects` |
+| a paper / publication / preprint | `Publications` (create if absent) |
+| an internship / job / role | `Work Experience` |
+| a talk / course / certification | `Education` (or ask if unclear) |
+
+`add-entry.mjs` creates the section heading if it doesn't exist yet, so a new
+`## Publications` is fine.
+
+## Payload schema (input to `add-entry.mjs`)
+
+Both keys optional; provide at least one. `articleDigest` is for projects only.
+
+```json
+{
+  "cv": {
+    "section": "Projects",
+    "dedupKey": "<short canonical name, e.g. the repo/project name>",
+    "entry": "<exact markdown to insert — a bullet for Projects, or a\n### Org — Location / **Title** / dates / bullets block for Work Experience>"
+  },
+  "articleDigest": {
+    "dedupKey": "<same canonical name>",
+    "entry": "## <Name> — <tagline>\n\n**Hero metrics:** ...\n\n**Architecture:** ...\n\n**Key decisions:**\n- ...\n\n**Proof points:**\n- ..."
+  }
+}
+```
+
+`dedupKey` is normalized (case- and punctuation-insensitive) to detect an entry
+that's already there, so the command is idempotent.
+
+## Rules
+
+- Match the existing `cv.md` formatting exactly (heading levels, bullet style,
+  date format) — the file is the template.
+- One entry per run. To add several, run `add` per item.
+- If the fetch fails or the page has no usable content, say so and stop — never
+  synthesize an entry from nothing.
+- Personal data (the CV itself) stays local; the fetch only reads public sources.

--- a/modes/add.md
+++ b/modes/add.md
@@ -54,9 +54,11 @@ If no source was given, ask the user for one.
    without an explicit yes.
 8. **Write via the helper.** Build the payload (schema below), write it to
    `/tmp/add-<slug>.json`, then run:
+
    ```bash
    node add-entry.mjs /tmp/add-<slug>.json
    ```
+
    (Add `--dry-run` first if the user wants to see the file-level change without
    writing.)
 9. **Report** the helper's JSON result. If a target comes back `duplicate`, tell

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "tracker": "node tracker.mjs",
     "find": "node find.mjs",
     "patterns": "node analyze-patterns.mjs",
+    "add": "node add-entry.mjs",
     "reposts": "node detect-reposts.mjs",
     "gemini:eval": "node gemini-eval.mjs",
     "ollama:eval": "node ollama-eval.mjs",

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3336,6 +3336,13 @@ try {
   if (cvHasEntry(cvWithEmail, 'Projects', 'Mailer')) pass('cvHasEntry still matches the real bold identifier');
   else fail('cvHasEntry should match the bold entry name');
 
+  // Same collision guard for article-digest headings (name before the dash).
+  const adWithMailer = '# Article Digest\n\n---\n\n## Mailer -- Email digests\n\n**Hero metrics:** x\n';
+  if (!articleDigestHasEntry(adWithMailer, 'AI')) pass('articleDigestHasEntry does not false-match a short key against a heading');
+  else fail('articleDigestHasEntry should not match "AI" against the "Mailer -- Email digests" heading');
+  if (articleDigestHasEntry(adWithMailer, 'Mailer')) pass('articleDigestHasEntry matches the real heading name');
+  else fail('articleDigestHasEntry should match the heading name before the dash');
+
   // CLI wiring: --dry-run reports without writing; a real run writes and is then
   // idempotent. Exercised against isolated fixture files via env overrides.
   const cliTmp = mkdtempSync(join(tmpdir(), 'career-ops-add-cli-'));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3322,6 +3322,53 @@ try {
   if (threwEmpty) pass('applyAdd rejects an empty payload');
   else fail('applyAdd should reject an empty payload');
 
+  // dedupKey is required — idempotency depends on it, so a missing one fails fast.
+  let threwNoKey = false;
+  try { applyAdd({ cv: { section: 'Projects', entry: '- **X** -- y' } }, { cvText: sampleCv }); } catch { threwNoKey = true; }
+  if (threwNoKey) pass('applyAdd requires a dedupKey for a cv target');
+  else fail('applyAdd should throw when cv.dedupKey is missing');
+
+  // Short-key dedup must NOT collide with unrelated substrings (e.g. "ai" in a
+  // bullet that mentions "email"). Regression for the identifier-based matcher.
+  const cvWithEmail = '# CV\n\n## Projects\n\n- **Mailer** (OSS) -- sends email digests\n';
+  if (!cvHasEntry(cvWithEmail, 'Projects', 'AI')) pass('cvHasEntry does not false-match a short key against unrelated text');
+  else fail('cvHasEntry should not match "AI" against "email"');
+  if (cvHasEntry(cvWithEmail, 'Projects', 'Mailer')) pass('cvHasEntry still matches the real bold identifier');
+  else fail('cvHasEntry should match the bold entry name');
+
+  // CLI wiring: --dry-run reports without writing; a real run writes and is then
+  // idempotent. Exercised against isolated fixture files via env overrides.
+  const cliTmp = mkdtempSync(join(tmpdir(), 'career-ops-add-cli-'));
+  try {
+    const cvPath = join(cliTmp, 'cv.md');
+    const adPath = join(cliTmp, 'article-digest.md');
+    writeFileSync(cvPath, '# CV\n\n## Projects\n\n- **Existing** (OSS) -- here\n');
+    const payloadPath = join(cliTmp, 'p.json');
+    writeFileSync(payloadPath, JSON.stringify({
+      cv: { section: 'Projects', dedupKey: 'CliProj', entry: '- **CliProj** (OSS) -- desc' },
+      articleDigest: { dedupKey: 'CliProj', entry: '## CliProj -- Tagline\n\n**Hero metrics:** x' },
+    }));
+    const env = { ...process.env, CAREER_OPS_CV: cvPath, CAREER_OPS_ARTICLE_DIGEST: adPath };
+
+    execFileSync(NODE, [join(ROOT, 'add-entry.mjs'), payloadPath, '--dry-run'], { env, encoding: 'utf-8' });
+    if (!readFileSync(cvPath, 'utf-8').includes('CliProj') && !existsSync(adPath)) pass('add-entry CLI --dry-run writes nothing');
+    else fail('add-entry CLI --dry-run should not write');
+
+    const realOut = JSON.parse(execFileSync(NODE, [join(ROOT, 'add-entry.mjs'), payloadPath], { env, encoding: 'utf-8' }));
+    if (realOut.cv.status === 'added' && realOut.articleDigest.status === 'created' &&
+        readFileSync(cvPath, 'utf-8').includes('- **CliProj**') && readFileSync(adPath, 'utf-8').includes('## CliProj')) {
+      pass('add-entry CLI real run writes cv.md + creates article-digest.md');
+    } else {
+      fail(`add-entry CLI real run => ${JSON.stringify(realOut)}`);
+    }
+
+    const rerun = JSON.parse(execFileSync(NODE, [join(ROOT, 'add-entry.mjs'), payloadPath], { env, encoding: 'utf-8' }));
+    if (rerun.cv.status === 'duplicate' && rerun.articleDigest.status === 'duplicate') pass('add-entry CLI re-run is idempotent');
+    else fail(`add-entry CLI re-run => ${JSON.stringify(rerun)}`);
+  } finally {
+    rmSync(cliTmp, { recursive: true, force: true });
+  }
+
 } catch (e) {
   fail(`add-entry tests crashed: ${e.message}`);
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -847,7 +847,7 @@ const expectedModes = [
   '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'scan.md',
   'batch.md', 'apply.md', 'auto-pipeline.md', 'contacto.md', 'deep.md',
   'ofertas.md', 'pipeline.md', 'project.md', 'tracker.md', 'training.md',
-  'interview.md', 'latex.md',
+  'interview.md', 'latex.md', 'add.md',
   'regional/eu-swe.md',
 ];
 
@@ -3217,6 +3217,113 @@ try {
 
 } catch (e) {
   fail(`teamtailor provider tests crashed: ${e.message}`);
+}
+
+// ── 14b. ADD-ENTRY (/career-ops add) ────────────────────────────────
+
+console.log('\n14b. add-entry.mjs (dedup + insertion)');
+
+try {
+  const addMod = await import(pathToFileURL(join(ROOT, 'add-entry.mjs')).href);
+  const { normalizeKey, locateSection, cvHasEntry, insertIntoCvSection, articleDigestHasEntry, applyAdd } = addMod;
+
+  if (normalizeKey('Fraud-Shield!') === 'fraudshield') pass('normalizeKey strips punctuation/case');
+  else fail(`normalizeKey => ${normalizeKey('Fraud-Shield!')}`);
+
+  const sampleCv = [
+    '# CV -- Test',
+    '',
+    '## Work Experience',
+    '',
+    '### Acme -- Remote',
+    '',
+    '**Engineer**',
+    '2020-2022',
+    '',
+    '- Did things',
+    '',
+    '## Projects',
+    '',
+    '- **Existing** (OSS) -- already here',
+    '',
+    '## Education',
+    '',
+    '- BS CS',
+    '',
+  ].join('\n');
+
+  // locateSection isolates the right block
+  const loc = locateSection(sampleCv, 'Projects');
+  if (loc && loc.body.includes('Existing') && !loc.body.includes('BS CS')) pass('locateSection isolates the Projects block');
+  else fail(`locateSection => ${JSON.stringify(loc && loc.body)}`);
+
+  // insertion appends within section and preserves later sections
+  const inserted = insertIntoCvSection(sampleCv, 'Projects', '- **FraudShield** (OSS) -- fraud detection');
+  if (inserted.includes('- **Existing**') && inserted.includes('- **FraudShield**') &&
+      inserted.indexOf('FraudShield') < inserted.indexOf('## Education') &&
+      inserted.includes('## Education')) {
+    pass('insertIntoCvSection appends under Projects and keeps Education intact');
+  } else {
+    fail('insertIntoCvSection placement wrong');
+  }
+
+  // missing section is created at EOF
+  const withPubs = insertIntoCvSection(sampleCv, 'Publications', '- **A Paper** (2026) -- venue');
+  if (withPubs.includes('## Publications') && withPubs.includes('- **A Paper**')) pass('insertIntoCvSection creates a missing section');
+  else fail('insertIntoCvSection did not create missing section');
+
+  // dedup detection is punctuation/case-insensitive
+  if (cvHasEntry(sampleCv, 'Projects', 'existing') && !cvHasEntry(sampleCv, 'Projects', 'FraudShield')) {
+    pass('cvHasEntry detects an existing entry and misses a new one');
+  } else {
+    fail('cvHasEntry dedup logic wrong');
+  }
+
+  // applyAdd: fresh add to cv + article-digest (article-digest absent → created)
+  const added = applyAdd(
+    {
+      cv: { section: 'Projects', dedupKey: 'FraudShield', entry: '- **FraudShield** (OSS) -- fraud detection' },
+      articleDigest: { dedupKey: 'FraudShield', entry: '## FraudShield -- Detection\n\n**Hero metrics:** 99.7%' },
+    },
+    { cvText: sampleCv, articleText: null },
+  );
+  if (added.result.cv.status === 'added' && added.result.articleDigest.status === 'created' &&
+      added.cv.includes('FraudShield') && added.articleDigest.includes('## FraudShield')) {
+    pass('applyAdd adds a new CV entry and creates article-digest.md when absent');
+  } else {
+    fail(`applyAdd fresh-add => ${JSON.stringify(added.result)}`);
+  }
+
+  // applyAdd: idempotent — same payload against updated files is a no-op
+  const again = applyAdd(
+    {
+      cv: { section: 'Projects', dedupKey: 'FraudShield', entry: '- **FraudShield** (OSS) -- fraud detection' },
+      articleDigest: { dedupKey: 'FraudShield', entry: '## FraudShield -- Detection\n\n**Hero metrics:** 99.7%' },
+    },
+    { cvText: added.cv, articleText: added.articleDigest },
+  );
+  if (again.result.cv.status === 'duplicate' && again.result.articleDigest.status === 'duplicate') {
+    pass('applyAdd is idempotent (duplicate/duplicate on re-run)');
+  } else {
+    fail(`applyAdd re-run => ${JSON.stringify(again.result)}`);
+  }
+
+  if (articleDigestHasEntry(added.articleDigest, 'fraud shield')) pass('articleDigestHasEntry matches normalized heading');
+  else fail('articleDigestHasEntry failed to match');
+
+  // guardrails: cv add against a missing cv.md throws; empty payload throws
+  let threwNoCv = false;
+  try { applyAdd({ cv: { section: 'Projects', dedupKey: 'X', entry: '- x' } }, { cvText: null }); } catch { threwNoCv = true; }
+  if (threwNoCv) pass('applyAdd refuses to add to a missing cv.md');
+  else fail('applyAdd should throw when cv.md is absent');
+
+  let threwEmpty = false;
+  try { applyAdd({}, { cvText: sampleCv }); } catch { threwEmpty = true; }
+  if (threwEmpty) pass('applyAdd rejects an empty payload');
+  else fail('applyAdd should reject an empty payload');
+
+} catch (e) {
+  fail(`add-entry tests crashed: ${e.message}`);
 }
 
 // ── 12. TRACKER REPORT LINK NORMALIZATION (#760) ────────────────

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -101,6 +101,7 @@ const SYSTEM_PATHS = [
   'verify-pipeline.mjs',
   'reconcile-pipeline.mjs',
   'dedup-tracker.mjs',
+  'add-entry.mjs',
   'role-matcher.mjs',
   'tracker-utils.mjs',
   'tracker-parse.mjs',

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -47,6 +47,7 @@ const SYSTEM_PATHS = [
   'modes/oferta.md',
   'modes/pdf.md',
   'modes/cover.md',
+  'modes/add.md',
   'modes/scan.md',
   'modes/batch.md',
   'modes/apply.md',


### PR DESCRIPTION
Closes #646.

Adds `/career-ops add`: append a finished project, paper, or role to the CV without hand-editing, keeping the confirm-before-write and never-fabricate rules.

## What's here
- **`modes/add.md`** — agent flow: fetch a GitHub repo (public API + README), paper link, project page (WebFetch; Playwright only if needed), or plain text → extract facts actually present → write ATS bullets grounded in the source → infer the target CV section (shown in the preview) → **confirm gate** → call the helper. Zero-key, local-only.
- **`add-entry.mjs`** — small deterministic dedup + insertion helper (spirit of `dedup-tracker.mjs`, as you suggested). Inserts the agent's markdown under the right `cv.md` section (creating it if absent) and appends a project block to `article-digest.md`; idempotent via a normalized `dedupKey`. It never rewrites content — the agent owns wording, the helper owns placement. `CAREER_OPS_CV` / `CAREER_OPS_ARTICLE_DIGEST` isolate tests.
- Registered: `SKILL.md` router (arg-hint, routing table, discovery menu, standalone context group), `SYSTEM_PATHS`, `npm run add`, `docs/SCRIPTS.md`.

## Non-negotiables honored
- Confirm-before-write gate before any file change.
- Bullets sourced only from what the fetched page actually says (never fabricated).
- Section placement inferred, shown in preview, only asks when genuinely ambiguous.

## Tests
10 checks in `test-all.mjs` (section location/insertion, missing-section creation, punctuation-insensitive dedup, idempotency, guardrails) + `add.md` mode-integrity. Full suite: **1069 passed, 0 failed**.

Per your note, the LaTeX/Jake's-Resume cleanup is left out of scope; happy to file it separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **add** workflow to ingest project/paper/role inputs and append CV entries, plus an article-digest block when applicable.
  * Introduced `npm run add` / CLI support for idempotent inserts with `--dry-run`.
  * Extended mode routing so `/career-ops add` is available across user-facing surfaces.
* **Documentation**
  * Documented the **add** mode workflow, payload schema, and preview/confirm gate.
* **Tests**
  * Added validation for insertion logic, dedup/idempotency, and CLI behavior; included the new mode in mode-file integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->