### PR TITLE
feat(contacto): add a short-greeting variant for chat-style outreach

### DIFF
--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -118,6 +118,17 @@ cover_letter:
       # Only trigger this entry when the JD location is in one of these countries.
       countries: [Spain, Mexico, Argentina, Colombia, Chile]
 
+# ── Outreach / greeting ─────────────────────────────────────────────────────
+#
+# Used by the greeting variant of `/career-ops contacto` (the short first-touch
+# message for BOSS Zhipin 打招呼, job-board chat, or a cold-email opener).
+#
+# greeting_max_chars is the hard character budget for that message. Default when
+# the key is absent: 150 (BOSS Zhipin's greeting limit). Raise or lower it to
+# match the platform you're messaging on.
+# outreach:
+#   greeting_max_chars: 150
+
 # ── Auto-PDF threshold ──────────────────────────────────────────────────────
 #
 # Auto-PDF threshold during evaluation (used by `/career-ops pipeline` and

--- a/modes/contacto.md
+++ b/modes/contacto.md
@@ -1,6 +1,21 @@
-# Mode: contacto -- LinkedIn Power Move
+# Mode: contacto -- Outreach messages
 
 > Apply `voice-dna.md` (if present) to every generated message — full guardrail, conversational voice included (Tier 1 + Tier 2). See `_shared.md` → Voice DNA.
+
+This mode has two variants that share the same persona engine (recruiter → hard
+requirements; hiring manager → impact/vision):
+
+- **LinkedIn power move** (default) — find contacts and draft a ≤300-char message
+  tied to a specific application/interview. This is the flow below.
+- **Greeting** — a single ultra-short first-touch message for platforms with a hard
+  character budget (BOSS Zhipin 打招呼, job-board chat, a cold-email opener). No
+  contact discovery. See **Greeting variant** at the end of this file.
+
+**Pick the variant:** use **Greeting** when the user says "greeting" / "打招呼" /
+"cold opener", names a chat-style platform (e.g. BOSS Zhipin), or asks for a very
+short message; otherwise run the LinkedIn power move below.
+
+## LinkedIn power move (default)
 
 1. **Identify targets** via WebSearch:
    - Hiring manager of the team
@@ -53,3 +68,49 @@
 - Something that makes them want to respond
 - NEVER share phone number
 - The contact type changes the EMPHASIS, not the structure
+
+---
+
+## Greeting variant
+
+A single, punchy first-touch message for platforms where the opener has a hard
+character budget — BOSS Zhipin's 打招呼, job-board chat boxes, or the first line
+of a cold email. Reuses the persona engine above; the difference is brevity, and
+that there is **no contact discovery**.
+
+1. **Skip target identification.** There is no WebSearch/contact-finding step —
+   the message goes to whoever the platform connects you with (usually the poster
+   or the recruiter). Do not fabricate a named recipient.
+
+2. **Classify the recipient's persona** from context (default to **Recruiter** if
+   unknown) and set the emphasis exactly as above:
+   - **Recruiter** → hard requirements met (role, years, stack, location, availability)
+   - **Hiring Manager / Founder** → impact and vision (a result that maps to their goal)
+
+3. **Synthesize the top 3 match points** between the JD and `cv.md` (same JD↔profile
+   fit logic the LinkedIn flow uses). These are the raw material — you will surface
+   only the strongest one or two that fit the budget.
+
+4. **Compose ONE message within the character budget.**
+   - **Budget:** read `outreach.greeting_max_chars` from `config/profile.yml`.
+     **Default 150** when the key is absent. The message MUST fit — count and trim.
+   - **Lead with a specific value proposition** (the single strongest match point),
+     not an introduction. Punchy sentences, not paragraphs.
+   - **Language:** match the JD / platform language (e.g. Simplified Chinese for
+     BOSS Zhipin). Character count applies to the output language.
+
+5. **No-fluff policy (hard):** remove filler and replace it with a concrete value
+   prop. Ban phrases like "I'm looking for a job", "I'm passionate about",
+   "I hope to have the opportunity", generic self-description. Every clause must
+   earn its characters.
+
+6. **Output:** the greeting, its character count vs the budget, and a one-line note
+   of which match point(s) it used. Offer a shorter fallback if it's near the limit.
+
+**Greeting rules:**
+- Platform-agnostic — never assume LinkedIn; works for any chat/opener surface.
+- Within `outreach.greeting_max_chars` (default 150). Never exceed it.
+- Same non-fabrication rule as the rest of career-ops: reformulate real experience
+  from `cv.md`, never invent a skill, metric, or claim.
+- NO corporate-speak, NO "I'm passionate about...", NEVER share a phone number.
+- Persona changes the EMPHASIS, not the structure.


### PR DESCRIPTION
Closes #593.

Per your steer, this **extends the existing `contacto` mode** with a greeting variant rather than adding a new mode — reusing its persona engine and avoiding router/test churn.

## What's here
- **`modes/contacto.md`** — retitled "Outreach messages" with a variant selector. The default LinkedIn power move is unchanged. The new **Greeting variant** is a single ultra-short first-touch message (BOSS Zhipin 打招呼, job-board chat, cold-email opener): skips contact discovery, reuses the recruiter/hiring-manager persona emphasis, synthesizes the top-3 JD↔CV match points, leads with a concrete value prop, enforces a no-fluff policy, and matches the JD/platform language.
- Platform-agnostic; hard character budget from **`outreach.greeting_max_chars` in `config/profile.yml`, defaulting to 150** when absent.
- **`config/profile.example.yml`** documents the optional knob.

## Rules honored
- Same non-fabrication rule as the rest of career-ops (reformulate real `cv.md` experience, never invent a skill/metric/claim).

## Tests
Full suite: **1057 passed, 0 failed**. No new mode = no router/`expectedModes` churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Greeting” variant for contact outreach messages, designed for first-touch introductions without target discovery.
  * Clarified how to choose between the default LinkedIn outreach flow and the Greeting variant based on the user’s request and context.
  * Added support for an optional character limit for greeting messages, with a default budget when not configured.

* **Documentation**
  * Expanded guidance for outreach message formatting, including output requirements and stricter tone and content constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->