### PR TITLE
fix: word-boundary matching for short location_filter keywords

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -185,17 +185,21 @@ function normalizeKeywordList(value) {
 
 export function buildLocationFilter(locationFilter) {
   if (!locationFilter) return () => true;
-  const alwaysAllow = normalizeKeywordList(locationFilter.always_allow);
-  const allow = normalizeKeywordList(locationFilter.allow);
-  const block = normalizeKeywordList(locationFilter.block);
+  // compileKeyword gives 2-3 letter all-letter keywords (e.g. "PA", "NY", "US")
+  // word-boundary matching instead of a bare substring match — without it,
+  // "PA" would false-match inside "Japan" or "Spain". See title filter above
+  // for the same pattern.
+  const alwaysAllow = normalizeKeywordList(locationFilter.always_allow).map(compileKeyword);
+  const allow = normalizeKeywordList(locationFilter.allow).map(compileKeyword);
+  const block = normalizeKeywordList(locationFilter.block).map(compileKeyword);
 
   return (location) => {
     if (typeof location !== 'string' || location.trim() === '') return true;
     const lower = location.toLowerCase();
-    if (alwaysAllow.length > 0 && alwaysAllow.some(k => lower.includes(k))) return true;
-    if (block.length > 0 && block.some(k => lower.includes(k))) return false;
+    if (alwaysAllow.length > 0 && alwaysAllow.some(m => m(lower))) return true;
+    if (block.length > 0 && block.some(m => m(lower))) return false;
     if (allow.length === 0) return true;
-    return allow.some(k => lower.includes(k));
+    return allow.some(m => m(lower));
   };
 }
 


### PR DESCRIPTION
## Summary
- `buildLocationFilter` matched `always_allow`/`allow`/`block` keywords via plain substring search, so a short state code like `PA` would false-match inside unrelated words (e.g. `PA` inside `Japan` or `Spain`).
- The title filter already solves this class of bug with `compileKeyword`, which applies word-boundary regex matching to 2-3 letter all-letter keywords. This reuses that same helper for `buildLocationFilter` so the two filters behave consistently.

Found while configuring a `location_filter` for a real user (Pittsburgh, PA + remote-US) — `Tokyo, Japan` was incorrectly passing the filter because `"PA"` matched inside `"Japan"`.

## Test plan
- [x] `node test-all.mjs` — 973 passed, 0 failed (existing location-filter suite in section 13 still green)
- [x] Manual check: `Tokyo, Japan` / `Madrid, Spain` now correctly rejected; `Pittsburgh, PA` / `Reading, PA` still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location keyword matching to reduce false positives in search/filter results.
  * Short acronym-like location terms now match as whole words, while longer or multi-word terms still use flexible matching.
  * Existing allow/block handling and behavior for blank or non-text locations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->