### PR TITLE
feat(providers): Amazon (amazon.jobs) and Avature zero-token providers

### DIFF
--- a/providers/amazon.mjs
+++ b/providers/amazon.mjs
@@ -1,0 +1,107 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Amazon / AWS provider — hits the public amazon.jobs search JSON API.
+// Auto-detects from a careers_url on `amazon.jobs`; the whole board is one
+// global endpoint, so a tracked_companies entry narrows it with an `amazon:`
+// config block whose keys are passed straight through as query params:
+//
+//   - name: Amazon / AWS
+//     provider: amazon
+//     amazon:
+//       loc_query: Germany          # free-text location filter
+//       base_query: machine learning  # optional keyword filter
+//       category: software-development # optional facet (repeatable via array)
+//
+// The board is enormous (100k+ postings), so a location and/or keyword filter
+// is effectively required — without one the MAX_PAGES cap just returns the most
+// recent slice. result_limit is fixed at 100 (the API's hard per-page max;
+// larger values return an empty `jobs`), and we page via `offset`.
+
+const PAGE_SIZE = 100; // amazon.jobs caps result_limit at 100
+const MAX_PAGES = 20; // safety cap — at most 2000 postings per entry
+const ORIGIN = 'https://www.amazon.jobs';
+
+/** @param {import('./_types.js').PortalEntry & {amazon?: Record<string, unknown>}} entry */
+function buildQuery(entry, offset) {
+  const cfg = entry.amazon && typeof entry.amazon === 'object' ? entry.amazon : {};
+  const params = new URLSearchParams();
+  // Pass config keys through verbatim (base_query, loc_query, category, …).
+  // Array values are amazon.jobs facet filters and MUST use the `key[]=`
+  // bracket form to filter (e.g. normalized_country_code[]=DEU); a bare
+  // `key=DEU` is silently ignored and the board stays global.
+  for (const [k, v] of Object.entries(cfg)) {
+    if (v == null) continue;
+    if (Array.isArray(v)) {
+      const name = k.endsWith('[]') ? k : `${k}[]`;
+      for (const item of v) params.append(name, String(item));
+    } else {
+      params.append(k, String(v));
+    }
+  }
+  if (!params.has('base_query')) params.set('base_query', '');
+  if (!params.has('loc_query')) params.set('loc_query', '');
+  params.set('sort', cfg.sort ? String(cfg.sort) : 'recent');
+  params.set('result_limit', String(PAGE_SIZE));
+  params.set('offset', String(offset));
+  return `${ORIGIN}/en/search.json?${params.toString()}`;
+}
+
+// amazon.jobs posted_date reads "July  3, 2026" (note the padded day);
+// Date.parse handles it once whitespace is collapsed. (updated_time is a
+// relative string like "10 minutes" / "about 1 hour" — unparseable, skip it.)
+function toEpochMs(job) {
+  const raw = job.posted_date;
+  if (!raw || typeof raw !== 'string') return undefined;
+  const parsed = Date.parse(raw.replace(/\s+/g, ' ').trim());
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'amazon',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    // Match the host, not a path segment, to avoid spoofed URLs.
+    try {
+      const host = new URL(url).host.toLowerCase();
+      if (host === 'amazon.jobs' || host.endsWith('.amazon.jobs')) return { url };
+    } catch {
+      /* not an absolute URL */
+    }
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const jobs = [];
+    const seen = new Set();
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const url = buildQuery(entry, page * PAGE_SIZE);
+      const json = /** @type {any} */ (await ctx.fetchJson(url, { redirect: 'error' }));
+      const postings = Array.isArray(json?.jobs) ? json.jobs : [];
+      if (postings.length === 0) break;
+
+      let fresh = 0;
+      for (const j of postings) {
+        const path = j.job_path;
+        if (!path || typeof path !== 'string') continue;
+        const url2 = /^https?:\/\//i.test(path) ? path : ORIGIN + (path.startsWith('/') ? path : '/' + path);
+        if (seen.has(url2)) continue;
+        seen.add(url2);
+        fresh++;
+        jobs.push({
+          title: (j.title || '').trim(),
+          url: url2,
+          company: j.company_name || entry.name,
+          location: (j.normalized_location || j.location || '').trim(),
+          postedAt: toEpochMs(j),
+        });
+      }
+      if (fresh === 0) break; // API ignored offset / looped
+      if (postings.length < PAGE_SIZE) break; // last page
+    }
+    return jobs;
+  },
+};

--- a/providers/avature.mjs
+++ b/providers/avature.mjs
@@ -1,0 +1,161 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Avature provider — parses the public Avature career-site job list.
+// Auto-detects from a careers_url on `*.avature.net`; a branded custom domain
+// that proxies Avature needs an explicit `provider: avature` + `api:` pointing
+// at the Avature origin (or its /careers/SearchJobs URL).
+//
+//   GET {origin}/careers/SearchJobs?jobOffset=N
+//
+// returns a server-rendered page of <article class="article--result"> blocks.
+// Avature hard-caps the page at 6 results (a jobRecordsPerPage override is
+// ignored), and paginates via jobOffset in steps of 6 — so this is request-
+// heavy for large boards; max_pages (default 50 → ~300 postings) bounds it and
+// can be raised per entry.
+//
+// Location isn't rendered in every tenant's list (the subtitle is Job ID /
+// hire-type / posted-date); we extract it when a marker is present and leave it
+// empty otherwise. postedAt comes from the "Posted DD-Mon-YYYY" subtitle.
+
+const PAGE_SIZE = 6; // Avature serves exactly 6 results per page
+const DEFAULT_MAX_PAGES = 50; // ~300 postings; override via entry.max_pages
+const HARD_MAX_PAGES = 200;
+
+const MONTHS = { jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5, jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11 };
+
+/** @param {import('./_types.js').PortalEntry} entry */
+function resolveConfig(entry) {
+  const raw = entry.api || entry.careers_url || '';
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  // Honour an explicit SearchJobs path (branded tenants may prefix a locale,
+  // e.g. /en_US/searchjobs/SearchJobs); otherwise default to the classic path.
+  const searchPath = /\/SearchJobs\b/i.test(u.pathname) ? u.pathname.replace(/\/+$/, '') : '/careers/SearchJobs';
+  return { searchUrl: `${u.origin}${searchPath}`, origin: u.origin };
+}
+
+const NAMED = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ', '#8226': '•' };
+/** @param {string} s */
+function decodeEntities(s) {
+  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z0-9]+);/g, (m, body) => {
+    if (body[0] === '#') {
+      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : m;
+    }
+    return NAMED[body.toLowerCase()] ?? m;
+  });
+}
+
+/** @param {string} s */
+function clean(s) {
+  return decodeEntities(s.replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
+}
+
+// "Posted 02-May-2026" → epoch ms (UTC midnight). Undefined when absent/unparseable.
+/** @param {string} block */
+function parsePosted(block) {
+  const m = block.match(/Posted\s+(\d{1,2})-([A-Za-z]{3})-(\d{4})/);
+  if (!m) return undefined;
+  const mon = MONTHS[m[2].toLowerCase()];
+  if (mon === undefined) return undefined;
+  const ms = Date.UTC(Number(m[3]), mon, Number(m[1]));
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+// Best-effort location: some tenants tag it with a list-item-location span or a
+// map-marker glyph; most (e.g. Synopsys) render none, so this returns ''.
+/** @param {string} block */
+function parseLocation(block) {
+  const m =
+    block.match(/list-item-location[^>]*>([\s\S]*?)<\/span>/i) ||
+    block.match(/class="[^"]*\blocation\b[^"]*"[^>]*>([\s\S]*?)<\/(?:span|div|li)>/i) ||
+    block.match(/glyphicon-map-marker[\s\S]{0,80}?>([^<]{2,60})</i);
+  return m ? clean(m[1]) : '';
+}
+
+/** @param {string} htmlText @param {string} origin */
+export function parseArticles(htmlText, origin) {
+  const out = [];
+  const re = /<article class="article article--result"[\s\S]*?<\/article>/g;
+  let a;
+  while ((a = re.exec(htmlText)) !== null) {
+    const block = a[0];
+    // JobDetail path may or may not sit under /careers/ (branded tenants vary),
+    // so anchor on JobDetail/ itself rather than a fixed prefix.
+    const urlM = block.match(/<a[^>]*class="link"[^>]*href="([^"]*\/JobDetail\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/);
+    if (!urlM) continue;
+    const title = clean(urlM[2]);
+    if (!title) continue;
+    let url = decodeEntities(urlM[1]);
+    if (!/^https?:\/\//i.test(url)) url = origin + (url.startsWith('/') ? url : '/' + url);
+    const idM = url.match(/\/JobDetail\/[^/]*\/(\d+)/);
+    out.push({
+      id: idM ? idM[1] : url,
+      title,
+      url,
+      location: parseLocation(block),
+      postedAt: parsePosted(block),
+    });
+  }
+  return out;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'avature',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    try {
+      const host = new URL(url).host.toLowerCase();
+      if (host === 'avature.net' || host.endsWith('.avature.net')) return { url };
+    } catch {
+      /* not absolute */
+    }
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const cfg = resolveConfig(entry);
+    if (!cfg) throw new Error(`avature: cannot resolve origin for ${entry.name}`);
+    const maxPages = Math.min(
+      HARD_MAX_PAGES,
+      Number.isFinite(entry.max_pages) && entry.max_pages > 0 ? Number(entry.max_pages) : DEFAULT_MAX_PAGES,
+    );
+
+    const jobs = [];
+    const seen = new Set();
+    for (let page = 0; page < maxPages; page++) {
+      const htmlText = await ctx.fetchText(`${cfg.searchUrl}?jobOffset=${page * PAGE_SIZE}`, {
+        redirect: 'error',
+        headers: { accept: 'text/html' },
+      });
+      const articles = parseArticles(htmlText, cfg.origin);
+      if (articles.length === 0) break;
+
+      let fresh = 0;
+      for (const art of articles) {
+        if (seen.has(art.id)) continue;
+        seen.add(art.id);
+        fresh++;
+        jobs.push({
+          title: art.title,
+          url: art.url,
+          company: entry.name,
+          location: art.location,
+          postedAt: art.postedAt,
+        });
+      }
+      if (fresh === 0) break; // looped / offset ignored
+      if (articles.length < PAGE_SIZE) break; // last page
+    }
+    return jobs;
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -495,6 +495,8 @@ search_queries:
 #   rippling        ats.rippling.com/<slug>/jobs
 #   jibeapply       <slug>.jibeapply.com/jobs  (or provider: jibeapply + api: for a branded host's own /jobs path)
 #   workday         <tenant>.wd<N>.myworkdayjobs.com[/<locale>]/<board>
+#   avature         <tenant>.avature.net  (branded host → provider: avature + api: the /careers/SearchJobs URL)
+#   amazon          amazon.jobs           (global board; provider: amazon + an amazon: filter block, see below)
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
@@ -543,6 +545,14 @@ search_queries:
 #                          # is logged if the cap truncates real results)
 #   enabled: true
 #
+# - name: Example Avature Co
+#   # Avature career site. Auto-detects any *.avature.net host; for a branded
+#   # host that proxies Avature, set provider: avature + api: the SearchJobs URL.
+#   careers_url: https://exampleco.avature.net/careers/SearchJobs
+#   max_pages: 50          # optional page cap (only 6 jobs/page — Avature's hard
+#                          # limit — so ~300 postings by default, max 200 pages)
+#   enabled: true
+#
 # - name: SolidJobs — Engineering
 #   # division path is required; one of:
 #   # it, engineering, marketing, sales, hr, logistics, finances, other
@@ -550,6 +560,15 @@ search_queries:
 #   enabled: true
 #
 # -- Job boards / aggregators (no careers_url; set provider: explicitly) --
+#
+# - name: Amazon / AWS                    # global amazon.jobs board
+#   provider: amazon
+#   amazon:                # keys pass straight through to the search.json API
+#     normalized_country_code: [DEU]   # array → facet filter (…[]=DEU); REQUIRED-ish,
+#                                       # the board is 100k+ postings otherwise
+#     base_query: machine learning      # optional keyword filter
+#     # loc_query: Berlin               # optional free-text location (fuzzy, not a hard filter)
+#   enabled: true
 #
 # - name: 4 Day Week                      # 4-day-week / reduced-hours roles
 #   provider: 4dayweek

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10564,6 +10564,112 @@ try {
   fail(`getonbrd provider tests crashed: ${e.message}`);
 }
 
+console.log('\n55. Provider — amazon (amazon.jobs search.json)');
+
+try {
+  const amazon = (await import(pathToFileURL(join(ROOT, 'providers/amazon.mjs')).href)).default;
+
+  if (amazon.id === 'amazon') pass('amazon.id is "amazon"');
+  else fail(`amazon.id is ${JSON.stringify(amazon.id)}`);
+
+  // detect() — host match, not path-spoof, https + non-string safe
+  if (amazon.detect({ name: 'X', careers_url: 'https://www.amazon.jobs/en/search' })) pass('amazon.detect() claims an amazon.jobs URL');
+  else fail('amazon.detect() should claim amazon.jobs');
+  if (amazon.detect({ name: 'X', careers_url: 'https://evil.example/www.amazon.jobs/x' }) === null) pass('amazon.detect() rejects a path-spoofed URL');
+  else fail('amazon.detect() must reject path-spoofed URLs');
+  if (amazon.detect({ name: 'X', careers_url: 42 }) === null) pass('amazon.detect() returns null for non-string careers_url');
+  else fail('amazon.detect() should return null for non-string careers_url');
+
+  // fetch() with a mock ctx — captures the request URL (to assert facet
+  // bracket-encoding) and returns a canned page, exercising the real mapping.
+  const calls = [];
+  const page1 = {
+    jobs: [
+      { title: '  Automation Engineer  ', job_path: '/en/jobs/111/automation-engineer', normalized_location: 'Erfurt, Thuringia, DEU', posted_date: 'July  1, 2026', updated_time: '10 minutes', company_name: 'Amazon' },
+      { title: 'SDE', job_path: 'https://www.amazon.jobs/en/jobs/222/sde', location: 'Berlin, DEU', posted_date: 'June 29, 2026' },
+      { title: 'No Path', normalized_location: 'X' }, // dropped — no job_path
+    ],
+  };
+  const mockCtx = {
+    transport: 'http',
+    async fetchJson(url) { calls.push(url); return calls.length === 1 ? page1 : { jobs: [] }; },
+    async fetchText() { return ''; },
+  };
+  const jobs = await amazon.fetch({ name: 'Amazon', amazon: { normalized_country_code: ['DEU'], base_query: 'engineer' } }, mockCtx);
+
+  if (jobs.length === 2) pass('amazon.fetch maps valid jobs, drops job_path-less entries');
+  else fail(`amazon.fetch returned ${jobs.length} jobs, expected 2`);
+  if (calls[0] && calls[0].includes('normalized_country_code%5B%5D=DEU')) pass('amazon.fetch bracket-encodes array facets (normalized_country_code[]=DEU)');
+  else fail(`amazon.fetch facet encoding wrong: ${calls[0]}`);
+  if (calls[0] && calls[0].includes('result_limit=100')) pass('amazon.fetch requests result_limit=100');
+  else fail('amazon.fetch should set result_limit=100');
+  const j1 = jobs.find((j) => j.url.includes('/111/'));
+  if (j1 && j1.title === 'Automation Engineer') pass('amazon.fetch trims the title');
+  else fail(`amazon.fetch title wrong: ${JSON.stringify(j1 && j1.title)}`);
+  if (j1 && j1.url === 'https://www.amazon.jobs/en/jobs/111/automation-engineer') pass('amazon.fetch builds an absolute URL from job_path');
+  else fail(`amazon.fetch url wrong: ${JSON.stringify(j1 && j1.url)}`);
+  if (j1 && j1.postedAt === Date.parse('July 1, 2026')) pass('amazon.fetch parses posted_date (ignores relative updated_time)');
+  else fail(`amazon.fetch postedAt wrong: ${JSON.stringify(j1 && j1.postedAt)}`);
+  const j2 = jobs.find((j) => j.url.includes('/222/'));
+  if (j2 && j2.url === 'https://www.amazon.jobs/en/jobs/222/sde') pass('amazon.fetch keeps an already-absolute job_path');
+  else fail(`amazon.fetch absolute url wrong: ${JSON.stringify(j2 && j2.url)}`);
+} catch (e) {
+  fail(`amazon provider tests crashed: ${e.message}`);
+}
+
+console.log('\n56. Provider — avature (career-site SearchJobs parser)');
+
+try {
+  const avature = (await import(pathToFileURL(join(ROOT, 'providers/avature.mjs')).href)).default;
+  const { parseArticles } = await import(pathToFileURL(join(ROOT, 'providers/avature.mjs')).href);
+
+  if (avature.id === 'avature') pass('avature.id is "avature"');
+  else fail(`avature.id is ${JSON.stringify(avature.id)}`);
+
+  if (avature.detect({ name: 'X', careers_url: 'https://acme.avature.net/careers/SearchJobs' })) pass('avature.detect() claims a *.avature.net URL');
+  else fail('avature.detect() should claim *.avature.net');
+  if (avature.detect({ name: 'X', careers_url: 'https://evil.example/x.avature.net/y' }) === null) pass('avature.detect() rejects a path-spoofed URL');
+  else fail('avature.detect() must reject path-spoofed URLs');
+
+  // parseArticles — a compact fragment: one article with a locale-prefixed
+  // JobDetail path + a posted date, one with no JobDetail link (dropped).
+  const origin = 'https://acme.avature.net';
+  const fragment = `
+    <article class="article article--result" id="article--1">
+      <div class="article__header"><div class="article__header__text">
+        <h3 class="title"><a class="link" href="https://acme.avature.net/careers/JobDetail/Senior-PLM-Engineer-17304/17304?businessTitle=PLM">Senior PLM Engineer &amp; Architect</a></h3>
+        <div class="article__header__text__subtitle"><span class="list-item-jobId">Job ID 17304</span><span class="list-item-posted">Posted 02-May-2026</span></div>
+      </div></div>
+    </article>
+    <article class="article article--result" id="article--2">
+      <h3 class="title"><a class="link" href="/en_US/searchjobs/JobDetail/Data-Engineer-900/900">Data Engineer</a></h3>
+      <span class="list-item-location">Munich, Germany</span>
+    </article>
+    <article class="article article--result" id="article--3">
+      <h3 class="title"><span>No link here</span></h3>
+    </article>`;
+  const arts = parseArticles(fragment, origin);
+
+  if (arts.length === 2) pass('parseArticles returns 2 articles (link-less one dropped)');
+  else fail(`parseArticles returned ${arts.length}, expected 2`);
+  const a1 = arts.find((a) => a.id === '17304');
+  if (a1 && a1.title === 'Senior PLM Engineer & Architect') pass('parseArticles decodes the title entity');
+  else fail(`parseArticles title wrong: ${JSON.stringify(a1 && a1.title)}`);
+  if (a1 && a1.url === 'https://acme.avature.net/careers/JobDetail/Senior-PLM-Engineer-17304/17304?businessTitle=PLM') pass('parseArticles keeps the absolute JobDetail URL');
+  else fail(`parseArticles url wrong: ${JSON.stringify(a1 && a1.url)}`);
+  if (a1 && a1.postedAt === Date.UTC(2026, 4, 2)) pass('parseArticles parses "Posted 02-May-2026"');
+  else fail(`parseArticles postedAt wrong: ${JSON.stringify(a1 && a1.postedAt)}`);
+  const a2 = arts.find((a) => a.id === '900');
+  if (a2 && a2.url === 'https://acme.avature.net/en_US/searchjobs/JobDetail/Data-Engineer-900/900') pass('parseArticles resolves a relative locale-prefixed JobDetail path');
+  else fail(`parseArticles relative url wrong: ${JSON.stringify(a2 && a2.url)}`);
+  if (a2 && a2.location === 'Munich, Germany') pass('parseArticles extracts a rendered location when present');
+  else fail(`parseArticles location wrong: ${JSON.stringify(a2 && a2.location)}`);
+  if (parseArticles('<div>no articles</div>', origin).length === 0) pass('parseArticles returns [] when no articles present');
+  else fail('parseArticles should return [] for markup with no articles');
+} catch (e) {
+  fail(`avature provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What

Two new zero-token HTTP providers, each unlocking companies the scanner previously skipped as *"no provider matched"*:

### `amazon` — amazon.jobs
Hits the public `amazon.jobs/en/search.json` API (offset-paginated, `result_limit=100`). The board is one global endpoint (100k+ postings), so a `tracked_companies` entry narrows it with an `amazon:` config block whose keys pass straight through as query params:

```yaml
- name: Amazon / AWS
  provider: amazon
  amazon:
    normalized_country_code: [DEU]   # array → facet filter normalized_country_code[]=DEU
    base_query: machine learning     # optional keyword filter
```

Array values are **bracket-encoded** as facet filters (`normalized_country_code[]=DEU`) — a bare `key=DEU` is silently ignored and the board stays global (this bit me during development; there's a test for it). `postedAt` comes from `posted_date` (`updated_time` is a relative string like `"10 minutes"`, so it's skipped).

### `avature` — Avature career sites
Parses the public job list at `{origin}/careers/SearchJobs?jobOffset=N`. Auto-detects any `*.avature.net` host; a branded tenant sets `provider: avature` + `api:` the SearchJobs URL (a locale-prefixed `/…/searchjobs/SearchJobs` path is honoured). Avature hard-caps the page at **6 results** and paginates by 6, so it's request-heavy — `max_pages` (default 50 → ~300 postings) bounds it. `postedAt` from the `"Posted DD-Mon-YYYY"` subtitle; location extracted when the tenant renders it.

## Changes
- `providers/amazon.mjs`, `providers/avature.mjs` (avature exports `parseArticles`)
- `test-all.mjs`: sections 55 (amazon) + 56 (avature) — **21 hermetic assertions** (detect host-match & spoof-reject, facet bracket-encoding via a mock ctx, absolute-URL building, date parsing, article parsing, empty-input handling)
- `templates/portals.example.yml`: host-pattern rows + example stanzas

## Verification
- **Amazon**: DEU facet returns 73 postings for `base_query=engineer`, **0 non-DE leak**, dates parse.
- **Avature**: `synopsys.avature.net` → ~590 postings, titles + posted dates parse.
- `node test-all.mjs` → **1079 passed, 0 failed**.

**Note:** Siemens Healthineers is Avature but the newer *"Careers Marketplace"* variant (different pagination/paths) — out of scope for v1; the provider returns `[]` rather than erroring, same as an empty board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing jobs from Amazon/AWS job searches and Avature career sites.
  * Improved job details shown to users, including better location handling and posted date information where available.

* **Documentation**
  * Expanded provider setup examples to include Amazon/AWS and Avature configurations.

* **Tests**
  * Added coverage for provider detection, job parsing, pagination, URL handling, and date extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->