### PR TITLE
Fix plugin manifest path traversal check for cross-platform paths (#1410)

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -116,23 +116,25 @@ Or paste a JD directly to run the full pipeline.
 
 After determining the mode, load the necessary files before executing:
 
+If `modes/_custom.md` exists, read it after `modes/_profile.md` and before the selected mode file. It contains user house rules and procedural preferences. It may override workflow/style defaults, but it never adds factual claims about the candidate.
+
 ### Modes that require `_shared.md` + their mode file:
-Read `modes/_shared.md` + `modes/{mode}.md`
+Read `modes/_shared.md` + `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
 
 Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
 
 ### Standalone modes (only their mode file):
-Read `modes/{mode}.md`
+Read `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
 
 Applies to: `tracker`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`
 
 ### Modes delegated to subagent:
-For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:
+For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `_profile.md` (if exists) + `_custom.md` (if exists) + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:
 
 ```
 Agent(
   subagent_type="general-purpose",
-  prompt="[content of modes/_shared.md]\n\n[content of modes/{mode}.md]\n\n[invocation-specific data]",
+  prompt="[content of modes/_shared.md]\n\n[content of modes/_profile.md if exists]\n\n[content of modes/_custom.md if exists]\n\n[content of modes/{mode}.md]\n\n[invocation-specific data]",
   description="career-ops {mode}"
 )
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,14 +13,14 @@ The portfolio that goes with this system is also open source: [cv-santiago](http
 There are two layers. Read `DATA_CONTRACT.md` for the full list.
 
 **User Layer (NEVER auto-updated, personalization goes HERE):**
-- `cv.md`, `config/profile.yml`, `modes/_profile.md`, `article-digest.md`, `portals.yml`
+- `cv.md`, `config/profile.yml`, `modes/_profile.md`, `modes/_custom.md`, `article-digest.md`, `portals.yml`
 - `data/*`, `reports/*`, `output/*`, `interview-prep/*`
 
 **System Layer (auto-updatable, DON'T put user data here):**
 - `modes/_shared.md`, `modes/oferta.md`, all other modes
 - `AGENTS.md`, `CLAUDE.md`, `CODEX.md`, `OPENCODE.md`, `*.mjs` scripts, `dashboard/*`, `templates/*`, `batch/*`
 
-**THE RULE: When the user asks to customize anything (archetypes, narrative, negotiation scripts, proof points, location policy, comp targets), ALWAYS write to `modes/_profile.md` or `config/profile.yml`. NEVER edit `modes/_shared.md` for user-specific content.** This ensures system updates don't overwrite their customizations.
+**THE RULE: When the user asks to customize facts or targeting (archetypes, narrative, negotiation scripts, proof points, location policy, comp targets), ALWAYS write to `modes/_profile.md` or `config/profile.yml`. When they ask for procedural house rules, custom workflows, output preferences, or automations, write to `modes/_custom.md` (copy it from `modes/_custom.template.md` if missing). NEVER edit `modes/_shared.md` for user-specific content.** This ensures system updates don't overwrite their customizations.
 
 ## Source-of-Truth Boundary (CRITICAL)
 
@@ -30,6 +30,7 @@ User-facing content (CV, cover letters, form answers, recruiter outreach, applic
 - `article-digest.md`
 - `config/profile.yml`
 - `modes/_profile.md`
+- `modes/_custom.md` (procedural/style rules only — governs workflow and output preferences, never introduces factual claims)
 - `writing-samples/`
 - `voice-dna.md` (voice/style only — governs *how* text reads, never introduces factual claims)
 - `interview-prep/story-bank.md` and `interview-prep/{company}-{role}.md` (the user's own STAR stories and interview-prep notes — same trust level as `cv.md`; consumed by the `interview` and `apply`/`match-star` modes)
@@ -129,6 +130,7 @@ node doctor.mjs --json
 Output: `{"onboardingNeeded": <bool>, "missing": [...], "warnings": [...]}`, where `missing` lists whichever of `cv.md`, `config/profile.yml`, `modes/_profile.md`, `portals.yml` are absent. `warnings` is reserved for non-blocking setup signals.
 
 - If `modes/_profile.md` is in `missing`, copy it silently from `modes/_profile.template.md` (the user's customization file — never overwritten by updates). It's then resolved.
+- If `modes/_custom.md` is missing, copy it silently from `modes/_custom.template.md` (the user's house rules / workflows file — never overwritten by updates).
 - **If, after that, `onboardingNeeded` is still true (any of `cv.md` / `config/profile.yml` / `portals.yml` is missing), enter onboarding mode.** Do NOT proceed with evaluations, scans, or any other mode until the basics are in place. Guide the user step by step:
 
 #### Step 0: Free Tier Check

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -23,6 +23,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { randomUUID } from 'node:crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const PDF_PAGE_MARGIN = '0.6in';
 
 // Ensure output directory exists (fresh setup)
 mkdirSync(resolve(__dirname, 'output'), { recursive: true });
@@ -190,6 +191,17 @@ export function repoRelativeManifestPath(pathValue) {
   const rel = relative(__dirname, resolve(pathValue));
   if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) return '';
   return rel.split(sep).join('/');
+}
+
+export function injectPrintPageCss(html, format = 'a4') {
+  const pageSize = format === 'letter' ? 'Letter' : 'A4';
+  const pageStyle = `<style id="career-ops-page-setup">\n@page { size: ${pageSize}; margin: ${PDF_PAGE_MARGIN}; }\n</style>`;
+
+  if (/<\/head>/i.test(html)) {
+    return html.replace(/<\/head>/i, `${pageStyle}\n</head>`);
+  }
+
+  return `${pageStyle}\n${html}`;
 }
 
 /**
@@ -375,6 +387,7 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
 
   mkdirSync(dirname(outputPath), { recursive: true });
 
+  html = injectPrintPageCss(html, format);
   html = await inlineLocalFonts(html);
 
   // Write HTML to a temp file in baseDir so page.goto() gives a file://
@@ -400,12 +413,12 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
       format: format,
       printBackground: true,
       margin: {
-        top: '0.6in',
-        right: '0.6in',
-        bottom: '0.6in',
-        left: '0.6in',
+        top: '0',
+        right: '0',
+        bottom: '0',
+        left: '0',
       },
-      preferCSSPageSize: false,
+      preferCSSPageSize: true,
     });
 
     // Write PDF

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -201,6 +201,10 @@ export function injectPrintPageCss(html, format = 'a4') {
     return html.replace(/<\/head>/i, `${pageStyle}\n</head>`);
   }
 
+  if (/<html\b[^>]*>/i.test(html)) {
+    return html.replace(/<html\b[^>]*>/i, match => `${match}\n<head>\n${pageStyle}\n</head>`);
+  }
+
   return `${pageStyle}\n${html}`;
 }
 

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -3,7 +3,7 @@
 <!-- ============================================================
      THIS FILE IS AUTO-UPDATABLE. Don't put personal data here.
      
-     Your customizations go in modes/_profile.md (never auto-updated).
+     Your customizations go in modes/_profile.md and modes/_custom.md (never auto-updated).
      This file contains system rules, scoring logic, and tool config
      that improve with each career-ops release.
      ============================================================ -->
@@ -18,6 +18,7 @@ The files below are the **ONLY** sources for user-facing content (CV, cover lett
 | article-digest.md | `article-digest.md` (if exists) | ALWAYS (detailed proof points) |
 | profile.yml | `config/profile.yml` | ALWAYS (candidate identity and targets) |
 | _profile.md | `modes/_profile.md` | ALWAYS (user archetypes, narrative, negotiation) |
+| _custom.md | `modes/_custom.md` (if exists) | ALWAYS (procedural house rules, custom workflows, output preferences) |
 | writing-samples/ | `writing-samples/` | When generating candidate-facing text — check `_profile.md` for cached `## Writing Style` first; only scan files if absent |
 | voice-dna.md | `voice-dna.md` (project root, if exists) | When generating candidate-facing text. Anti-AI-slop guardrail + voice. See Voice DNA precedence below. |
 | interview-prep | `interview-prep/story-bank.md`, `interview-prep/{company}-{role}.md` | When generating ATS form answers / interview content — the user's own STAR stories + prep notes (same trust as cv.md). Consumed by `apply`/`match-star` + interview modes |
@@ -25,6 +26,7 @@ The files below are the **ONLY** sources for user-facing content (CV, cover lett
 **RULE: NEVER hardcode metrics from proof points.** Read them from cv.md + article-digest.md at evaluation time.
 **RULE: For article/project metrics, article-digest.md takes precedence over cv.md.**
 **RULE: Read _profile.md AFTER this file. User customizations in _profile.md override defaults here.**
+**RULE: Read _custom.md AFTER _profile.md if it exists. It can override workflow/style/procedural defaults, but it never introduces factual claims about the candidate.**
 **RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
 **RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
 
@@ -90,7 +92,7 @@ Classify every offer into one of these types (or hybrid of 2):
 | AI Forward Deployed | "client-facing", "deploy", "prototype", "fast delivery", "field" |
 | AI Transformation | "change management", "adoption", "enablement", "transformation" |
 
-After detecting archetype, read `modes/_profile.md` for the user's specific framing and proof points for that archetype.
+After detecting archetype, read `modes/_profile.md` for the user's specific framing and proof points for that archetype, then read `modes/_custom.md` if it exists for procedural preferences.
 
 ## Global Rules
 
@@ -109,7 +111,7 @@ After detecting archetype, read `modes/_profile.md` for the user's specific fram
 ### ALWAYS
 
 0. **Cover letter:** If the form allows it, ALWAYS include one. Same visual design as CV. JD quotes mapped to proof points. 1 page max.
-1. Read cv.md, _profile.md, and article-digest.md (if exists) before evaluating
+1. Read cv.md, _profile.md, _custom.md (if exists), and article-digest.md (if exists) before evaluating
 1b. **First evaluation of each session:** Run `node cv-sync-check.mjs`. If warnings, notify user.
 2. Detect the role archetype and adapt framing per _profile.md
 3. Cite exact lines from CV when matching
@@ -129,7 +131,7 @@ After detecting archetype, read `modes/_profile.md` for the user's specific fram
 | WebSearch | Comp research, trends, company culture, LinkedIn contacts, fallback for JDs |
 | WebFetch | Fallback for extracting JDs from static pages |
 | Playwright | Verify offers (browser_navigate + browser_snapshot). **NEVER 2+ agents with Playwright in parallel.** |
-| Read | cv.md, _profile.md, article-digest.md, cv-template.html |
+| Read | cv.md, _profile.md, _custom.md (if exists), article-digest.md, cv-template.html |
 | Write | Temporary HTML for PDF, applications.md, reports .md |
 | Edit | Update tracker |
 | Canva MCP | Optional visual CV generation. Duplicate base design, edit text, export PDF. Requires `cv.canva_resume_design_id` in profile.yml. |

--- a/plugins/_engine.mjs
+++ b/plugins/_engine.mjs
@@ -62,6 +62,11 @@ function warnSkip(label, reason) {
   console.warn(`⚠️  ${label}: skipping — ${reason}`);
 }
 
+function isWithinDirectory(rootAbs, candidateAbs) {
+  const rel = path.relative(rootAbs, candidateAbs);
+  return rel === '' || (!rel.startsWith(`..${path.sep}`) && rel !== '..' && !path.isAbsolute(rel));
+}
+
 /**
  * Resolve the config/plugins.yml path for a given project root.
  * @param {string} root
@@ -116,6 +121,7 @@ export async function loadPluginConfig(root) {
  */
 export function validateManifest(m, dir, dirName) {
   const label = dirName;
+  const dirAbs = path.resolve(dir);
   if (!m || typeof m !== 'object') { warnSkip(label, 'manifest.json is not an object'); return null; }
 
   if (typeof m.id !== 'string' || !ID_RE.test(m.id)) { warnSkip(label, `invalid id ${JSON.stringify(m.id)} (need ^[a-z0-9][a-z0-9-]*$)`); return null; }
@@ -155,8 +161,8 @@ export function validateManifest(m, dir, dirName) {
 
   const entry = typeof m.entry === 'string' && m.entry.trim() ? m.entry : 'index.mjs';
   if (!entry.endsWith('.mjs')) { warnSkip(label, `entry "${entry}" must be a .mjs file`); return null; }
-  const entryAbs = path.resolve(dir, entry);
-  if (entryAbs !== dir && !entryAbs.startsWith(dir + path.sep)) { warnSkip(label, `entry "${entry}" escapes the plugin directory`); return null; }
+  const entryAbs = path.resolve(dirAbs, entry);
+  if (!isWithinDirectory(dirAbs, entryAbs)) { warnSkip(label, `entry "${entry}" escapes the plugin directory`); return null; }
 
   // Optional companion skill (Open-Agent-Skill-Standard SKILL.md). Traversal-
   // guarded like entry. Surfaced on-demand via `plugins.mjs skill <id>`; never
@@ -164,8 +170,8 @@ export function validateManifest(m, dir, dirName) {
   let skill = null;
   if (m.skill !== undefined) {
     if (typeof m.skill !== 'string' || !m.skill.endsWith('.md')) { warnSkip(label, 'skill must be a relative .md path'); return null; }
-    const skillAbs = path.resolve(dir, m.skill);
-    if (skillAbs !== dir && !skillAbs.startsWith(dir + path.sep)) { warnSkip(label, `skill "${m.skill}" escapes the plugin directory`); return null; }
+    const skillAbs = path.resolve(dirAbs, m.skill);
+    if (!isWithinDirectory(dirAbs, skillAbs)) { warnSkip(label, `skill "${m.skill}" escapes the plugin directory`); return null; }
     if (!existsSync(skillAbs)) { warnSkip(label, `skill file not found: ${m.skill}`); return null; }
     skill = m.skill;
   }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -792,6 +792,24 @@ try {
     fail('PDF renderer does not inject CSS page size/margins into the document head');
   }
 
+  const doctypeNoHead = injectPrintPageCss('<!doctype html><html lang="en"><body></body></html>');
+  if (
+    doctypeNoHead.startsWith('<!doctype html>') &&
+    doctypeNoHead.includes('<html lang="en">\n<head>\n<style id="career-ops-page-setup">') &&
+    doctypeNoHead.indexOf('<head>') < doctypeNoHead.indexOf('<body>')
+  ) {
+    pass('PDF renderer preserves doctype when injecting page CSS into full HTML without head');
+  } else {
+    fail('PDF renderer may insert page CSS before doctype for full HTML without head');
+  }
+
+  const fragmentPageCss = injectPrintPageCss('<section>CV</section>');
+  if (fragmentPageCss.startsWith('<style id="career-ops-page-setup">')) {
+    pass('PDF renderer still prepends page CSS for HTML fragments');
+  } else {
+    fail('PDF renderer no longer handles HTML fragments with fallback CSS injection');
+  }
+
   if (
     generatePdfScript.includes('preferCSSPageSize: true') &&
     generatePdfScript.includes("right: '0'") &&
@@ -832,12 +850,29 @@ if (
   updateSystemScript.includes('CAREER_OPS_GIT_TIMEOUT_MS') &&
   updateSystemScript.includes('CAREER_OPS_GIT_FETCH_TIMEOUT_MS') &&
   /args\[0\]\s*===\s*['"]fetch['"]/.test(updateSystemScript) &&
+  /gitTimeoutEnvVar\(args\)/.test(updateSystemScript) &&
   updateSystemScript.includes('timed out after') &&
-  updateSystemScript.includes('timeout: reexecTimeoutMs()')
+  updateSystemScript.includes('const timeout = reexecTimeoutMs()') &&
+  updateSystemScript.includes('Updater self-reexec timed out after')
 ) {
   pass('update-system gives fetch/reexec a longer configurable timeout with readable failures');
 } else {
   fail('update-system still risks a bare 30s git fetch timeout (#1393)');
+}
+
+try {
+  const { gitTimeoutMs, reexecTimeoutMs } = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+  const fetchTimeout = gitTimeoutMs(['fetch']);
+  const gitCommandTimeout = gitTimeoutMs(['checkout']);
+  const minimumReexecBudget = fetchTimeout + gitCommandTimeout * 3 + 60000 + 120000 + 60000 + 60000;
+
+  if (reexecTimeoutMs() >= minimumReexecBudget) {
+    pass('update-system sizes self-reexec timeout for downstream fetch/git/install/rebuild work');
+  } else {
+    fail('update-system self-reexec timeout budget is too small for downstream apply work');
+  }
+} catch (e) {
+  fail(`update-system timeout helper test crashed: ${e.message}`);
 }
 
 // ── 8. MODE FILE INTEGRITY ──────────────────────────────────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -552,7 +552,7 @@ console.log('\n5. Data contract validation');
 // Check system files exist
 const systemFiles = [
   'CLAUDE.md', 'CODEX.md', 'OPENCODE.md', 'VERSION', 'DATA_CONTRACT.md', 'docs/CODEX.md',
-  'modes/_shared.md', 'modes/_profile.template.md',
+  'modes/_shared.md', 'modes/_profile.template.md', 'modes/_custom.template.md',
   'modes/oferta.md', 'modes/pdf.md', 'modes/scan.md',
   'modes/heuristics/recruiter-side.md',
   'templates/states.yml', 'templates/cv-template.html',
@@ -573,7 +573,7 @@ for (const f of systemFiles) {
 
 // Check user files are NOT tracked (gitignored)
 const userFiles = [
-  'config/profile.yml', 'modes/_profile.md', 'portals.yml',
+  'config/profile.yml', 'modes/_profile.md', 'modes/_custom.md', 'portals.yml',
 ];
 for (const f of userFiles) {
   const tracked = run('git', ['ls-files', f]);
@@ -766,7 +766,7 @@ if (generatePdfScript.includes('opts.reportNum') && generatePdfScript.includes('
   fail('renderHtmlToPdf does not read manifest metadata from opts');
 }
 try {
-  const { repoRelativeManifestPath } = await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
+  const { repoRelativeManifestPath, injectPrintPageCss } = await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
   const insideHtmlPath = join(ROOT, 'templates', 'cv-template.html');
   const outsideHtmlPath = join(dirname(ROOT), 'outside-cv-template.html');
 
@@ -780,6 +780,26 @@ try {
     pass('PDF manifest leaves HTML column blank when source HTML is missing or outside the repo');
   } else {
     fail('PDF manifest mishandles missing or external source HTML paths');
+  }
+
+  const injectedPageCss = injectPrintPageCss('<html><head><title>CV</title></head><body></body></html>', 'letter');
+  if (
+    injectedPageCss.includes('@page { size: Letter; margin: 0.6in; }') &&
+    injectedPageCss.indexOf('career-ops-page-setup') < injectedPageCss.indexOf('</head>')
+  ) {
+    pass('PDF renderer injects CSS page size and margins before rendering');
+  } else {
+    fail('PDF renderer does not inject CSS page size/margins into the document head');
+  }
+
+  if (
+    generatePdfScript.includes('preferCSSPageSize: true') &&
+    generatePdfScript.includes("right: '0'") &&
+    generatePdfScript.includes('injectPrintPageCss(html, format)')
+  ) {
+    pass('PDF renderer uses CSS @page margins instead of Playwright margins');
+  } else {
+    fail('PDF renderer may clip right-aligned content by ignoring CSS page sizing (#1341)');
   }
 } catch (e) {
   fail(`PDF manifest path helper test crashed: ${e.message}`);
@@ -808,12 +828,24 @@ if (updateSystemScript.includes("'CODEX.md'")) {
   fail('update-system does not preserve CODEX.md');
 }
 
+if (
+  updateSystemScript.includes('CAREER_OPS_GIT_TIMEOUT_MS') &&
+  updateSystemScript.includes('CAREER_OPS_GIT_FETCH_TIMEOUT_MS') &&
+  /args\[0\]\s*===\s*['"]fetch['"]/.test(updateSystemScript) &&
+  updateSystemScript.includes('timed out after') &&
+  updateSystemScript.includes('timeout: reexecTimeoutMs()')
+) {
+  pass('update-system gives fetch/reexec a longer configurable timeout with readable failures');
+} else {
+  fail('update-system still risks a bare 30s git fetch timeout (#1393)');
+}
+
 // ── 8. MODE FILE INTEGRITY ──────────────────────────────────────
 
 console.log('\n8. Mode file integrity');
 
 const expectedModes = [
-  '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'scan.md',
+  '_shared.md', '_profile.template.md', '_custom.template.md', 'oferta.md', 'pdf.md', 'scan.md',
   'batch.md', 'apply.md', 'auto-pipeline.md', 'contacto.md', 'deep.md',
   'ofertas.md', 'pipeline.md', 'project.md', 'tracker.md', 'training.md',
   'interview.md', 'latex.md',
@@ -836,6 +868,12 @@ if (shared.includes('_profile.md')) {
   fail('_shared.md does NOT reference _profile.md');
 }
 
+if (shared.includes('_custom.md')) {
+  pass('_shared.md references _custom.md');
+} else {
+  fail('_shared.md does NOT reference _custom.md');
+}
+
 for (const skillPath of ['.claude/skills/career-ops/SKILL.md', '.agents/skills/career-ops/SKILL.md']) {
   if (!fileExists(skillPath)) {
     fail(`${skillPath} is missing`);
@@ -846,6 +884,15 @@ for (const skillPath of ['.claude/skills/career-ops/SKILL.md', '.agents/skills/c
     pass(`${skillPath} exposes /career-ops latex in discovery menu`);
   } else {
     fail(`${skillPath} does not expose /career-ops latex in discovery menu`);
+  }
+
+  if (
+    skill.includes('modes/_custom.md') &&
+    skill.includes('[content of modes/_custom.md if exists]')
+  ) {
+    pass(`${skillPath} loads modes/_custom.md for direct and delegated modes`);
+  } else {
+    fail(`${skillPath} does not load modes/_custom.md for career-ops modes (#1388)`);
   }
 }
 
@@ -5770,6 +5817,13 @@ try {
     pass('CLAUDE.md routes custom rules to modes/_custom.md + seeds it from the template');
   } else {
     fail('CLAUDE.md does not reference modes/_custom.md / its template — agents will not use it (#1198)');
+  }
+
+  const agentsMd = readFileSync(join(ROOT, 'AGENTS.md'), 'utf-8');
+  if (agentsMd.includes('modes/_custom.md') && agentsMd.includes('modes/_custom.template.md')) {
+    pass('AGENTS.md routes procedural customizations to modes/_custom.md');
+  } else {
+    fail('AGENTS.md does not document modes/_custom.md as a user-layer customization file (#1388)');
   }
 } catch (e) {
   fail(`custom instructions test crashed: ${e.message}`);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -38,6 +38,11 @@ const RELEASES_API = 'https://api.github.com/repos/santifer/career-ops/releases/
 // Anchoring on `(?:^|-)` lets the releases-API fallback parse our tags,
 // which Release Please always prefixes with the component name.
 export const SEMVER_RE = /(?:^|-)v?(\d+\.\d+\.\d+)$/i;
+const DEFAULT_GIT_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_GIT_TIMEOUT_MS, 30000);
+const DEFAULT_GIT_FETCH_TIMEOUT_MS = parsePositiveInt(
+  process.env.CAREER_OPS_GIT_FETCH_TIMEOUT_MS,
+  Math.max(DEFAULT_GIT_TIMEOUT_MS, 300000),
+);
 
 // System layer paths — ONLY these files get updated
 const SYSTEM_PATHS = [
@@ -268,8 +273,33 @@ function newestBackupBranch(branches) {
   return timestamped[0]?.branch || branchList[0];
 }
 
+export function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value || ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function gitTimeoutMs(args) {
+  return args[0] === 'fetch' ? DEFAULT_GIT_FETCH_TIMEOUT_MS : DEFAULT_GIT_TIMEOUT_MS;
+}
+
+export function reexecTimeoutMs() {
+  return Math.max(120000, DEFAULT_GIT_FETCH_TIMEOUT_MS + DEFAULT_GIT_TIMEOUT_MS + 60000);
+}
+
+function describeGitCommand(args) {
+  return `git ${args.join(' ')}`;
+}
+
 function gitIn(root, ...args) {
-  return execFileSync('git', args, { cwd: root, encoding: 'utf-8', timeout: 30000 }).trim();
+  const timeout = gitTimeoutMs(args);
+  try {
+    return execFileSync('git', args, { cwd: root, encoding: 'utf-8', timeout }).trim();
+  } catch (err) {
+    if (err?.code === 'ETIMEDOUT' || err?.signal === 'SIGTERM') {
+      throw new Error(`${describeGitCommand(args)} timed out after ${Math.round(timeout / 1000)}s. If your network is slow, retry or set CAREER_OPS_GIT_FETCH_TIMEOUT_MS to a larger value.`);
+    }
+    throw err;
+  }
 }
 
 function git(...args) {
@@ -599,7 +629,7 @@ async function apply() {
         execFileSync(process.execPath, ['update-system.mjs', 'apply'], {
           cwd: ROOT,
           stdio: 'inherit',
-          timeout: 120000,
+          timeout: reexecTimeoutMs(),
           env: {
             ...process.env,
             CAREER_OPS_UPDATE_REEXEC: '1',

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -43,6 +43,9 @@ const DEFAULT_GIT_FETCH_TIMEOUT_MS = parsePositiveInt(
   process.env.CAREER_OPS_GIT_FETCH_TIMEOUT_MS,
   Math.max(DEFAULT_GIT_TIMEOUT_MS, 300000),
 );
+const NPM_INSTALL_TIMEOUT_MS = 60000;
+const PLAYWRIGHT_INSTALL_TIMEOUT_MS = 120000;
+const DASHBOARD_REBUILD_TIMEOUT_MS = 60000;
 
 // System layer paths — ONLY these files get updated
 const SYSTEM_PATHS = [
@@ -283,11 +286,31 @@ export function gitTimeoutMs(args) {
 }
 
 export function reexecTimeoutMs() {
-  return Math.max(120000, DEFAULT_GIT_FETCH_TIMEOUT_MS + DEFAULT_GIT_TIMEOUT_MS + 60000);
+  return Math.max(
+    120000,
+    DEFAULT_GIT_FETCH_TIMEOUT_MS +
+      DEFAULT_GIT_TIMEOUT_MS * 3 +
+      NPM_INSTALL_TIMEOUT_MS +
+      PLAYWRIGHT_INSTALL_TIMEOUT_MS +
+      DASHBOARD_REBUILD_TIMEOUT_MS +
+      60000,
+  );
 }
 
 function describeGitCommand(args) {
   return `git ${args.join(' ')}`;
+}
+
+function isTimeoutLikeError(err) {
+  return err?.code === 'ETIMEDOUT' || err?.signal === 'SIGTERM';
+}
+
+function timeoutSeconds(timeout) {
+  return Math.round(timeout / 1000);
+}
+
+function gitTimeoutEnvVar(args) {
+  return args[0] === 'fetch' ? 'CAREER_OPS_GIT_FETCH_TIMEOUT_MS' : 'CAREER_OPS_GIT_TIMEOUT_MS';
 }
 
 function gitIn(root, ...args) {
@@ -295,8 +318,8 @@ function gitIn(root, ...args) {
   try {
     return execFileSync('git', args, { cwd: root, encoding: 'utf-8', timeout }).trim();
   } catch (err) {
-    if (err?.code === 'ETIMEDOUT' || err?.signal === 'SIGTERM') {
-      throw new Error(`${describeGitCommand(args)} timed out after ${Math.round(timeout / 1000)}s. If your network is slow, retry or set CAREER_OPS_GIT_FETCH_TIMEOUT_MS to a larger value.`);
+    if (isTimeoutLikeError(err)) {
+      throw new Error(`${describeGitCommand(args)} timed out after ${timeoutSeconds(timeout)}s. If your network is slow, retry or set ${gitTimeoutEnvVar(args)} to a larger value.`);
     }
     throw err;
   }
@@ -463,7 +486,7 @@ function rebuildDashboardBinaryIfNeeded() {
   try {
     execFileSync('go', ['build', '-o', 'career-dashboard', '.'], {
       cwd: join(ROOT, 'dashboard'),
-      timeout: 60000,
+      timeout: DASHBOARD_REBUILD_TIMEOUT_MS,
       stdio: 'pipe',
     });
     console.log('dashboard binary rebuilt');
@@ -626,10 +649,11 @@ async function apply() {
         // new top-level import can't reintroduce the self-reexec crash (#1245).
         const reexecFiles = resolveReexecCheckout('FETCH_HEAD', 'update-system.mjs');
         git('checkout', 'FETCH_HEAD', '--', ...reexecFiles);
+        const timeout = reexecTimeoutMs();
         execFileSync(process.execPath, ['update-system.mjs', 'apply'], {
           cwd: ROOT,
           stdio: 'inherit',
-          timeout: reexecTimeoutMs(),
+          timeout,
           env: {
             ...process.env,
             CAREER_OPS_UPDATE_REEXEC: '1',
@@ -638,6 +662,10 @@ async function apply() {
         });
         return;
       } catch (err) {
+        if (isTimeoutLikeError(err)) {
+          console.error(`Updater self-reexec timed out after ${timeoutSeconds(reexecTimeoutMs())}s.`);
+          throw err;
+        }
         console.error(`Updater self-reexec failed: ${err.message}`);
         throw err;
       }
@@ -746,14 +774,14 @@ async function apply() {
 
     // 5. Install any new dependencies
     try {
-      execSync('npm install --silent', { cwd: ROOT, timeout: 60000 });
+      execSync('npm install --silent', { cwd: ROOT, timeout: NPM_INSTALL_TIMEOUT_MS });
     } catch {
       console.log('npm install skipped (may need manual run)');
     }
 
     // 5b. Ensure Playwright browser binary is up to date after npm install
     try {
-      execSync('npx playwright install chromium', { cwd: ROOT, timeout: 120000, stdio: 'ignore' });
+      execSync('npx playwright install chromium', { cwd: ROOT, timeout: PLAYWRIGHT_INSTALL_TIMEOUT_MS, stdio: 'ignore' });
     } catch {
       console.log('playwright install skipped (run manually: npx playwright install chromium)');
     }


### PR DESCRIPTION
## Summary
- Fix Windows/drive-path edge case in plugin manifest validation that caused false-positive rejections in test case #1410.
- In `plugins/_engine.mjs`, normalize plugin directory paths and replace brittle string `startsWith` containment checks with a `path.relative`-based check.
- Apply the same safe check to both `entry` and optional `skill` path resolution.

Closes #1410


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a separate customization layer for workflow and style preferences, alongside existing profile-based settings.
  * Improved PDF generation so page size and margins are applied more consistently.

* **Bug Fixes**
  * Tightened plugin path checks to prevent loading content from outside the expected plugin folder.
  * Improved timeout handling and error messages for long-running update and install steps.

* **Documentation**
  * Updated guidance to clarify where different kinds of customization should be saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->