### PR TITLE
feat(pipeline): preserve an optional per-offer note through to pipeline.md

### DIFF
--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -44,6 +44,7 @@ This complements — does not replace — the per-URL liveness gate in `auto-pip
 - [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
 - [ ] https://jobs.ashbyhq.com/acme/789 | Acme Corp | Solutions Architect | Remote (US)
 - [ ] https://jobs.ashbyhq.com/acme/790 | Acme Corp | AI Engineer | Remote (US) | 180000-220000 USD
+- [ ] https://jobs.ashbyhq.com/acme/791 | Acme Corp | Staff PM | note: curated shortlist
 - [!] https://private.url/job — Error: login required
 
 ## Processed
@@ -61,6 +62,14 @@ maximum (canonical) shape, not the only one. The columns are positional, so a ro
 carrying compensation always includes the location cell (empty if unknown); a row
 with only a location stays 4 columns. Existing shorter rows remain valid and are
 read as having empty values for the missing trailing columns.
+
+One further trailing segment is optional and **labeled**, not positional:
+`| note: {text}`. Unlike the positional cells above, it can ride on any row shape
+(`- [ ] {url} | {company} | {title} | note: curated shortlist` is valid), because
+the `note:` prefix identifies it regardless of column position. It carries a
+free-text ranking signal an importer attached to the offer (the deterministic
+scanner never sets it). Treat it as a hint when triaging; it does not change how
+you process the URL.
 
 ## Intelligent JD detection from URL
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -637,8 +637,16 @@ export function formatPipelineOffer(offer) {
   const location = typeof offer.location === 'string' ? sanitizeMarkdownField(offer.location) : '';
   const compensation = formatCompensation(offer.salary);
   const base = `- [ ] ${url} | ${company} | ${title}`;
-  if (compensation) return `${base} | ${location} | ${compensation}`;
-  return location ? `${base} | ${location}` : base;
+  let line = base;
+  if (compensation) line = `${base} | ${location} | ${compensation}`;
+  else if (location) line = `${base} | ${location}`;
+  // Optional free-text ranking signal (e.g. a curated-list flag an importer
+  // attaches). Labeled — not positional like location/compensation — so it can
+  // ride on any row shape (bare URL, 3-, 4-, or 5-column) without a reader
+  // confusing it for a positional cell, and it stays generic: nothing here is
+  // source-specific, and an offer without `note` produces byte-identical output.
+  const note = typeof offer.note === 'string' ? sanitizeMarkdownField(offer.note) : '';
+  return note ? `${line} | note: ${note}` : line;
 }
 
 export function formatScanHistoryRow(offer, date, status = 'added') {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1123,6 +1123,28 @@ try {
   } else {
     fail(`scan.mjs compensation column wrong: "${compRange}" / "${compSingle}" / "${compNone}" / "${compZeroMin}" / "${withComp}" / "${compNoLoc}"`);
   }
+
+  // pipeline.md optional note (#1142): formatPipelineOffer preserves an optional
+  // free-text ranking signal as a labeled `| note: {text}` segment. It rides on
+  // any row shape, an absent/empty note is byte-identical to today's output, and
+  // the note is sanitized like every other field (a `|` can't inject a column).
+  const noteFull = formatPipelineOffer({ url: 'https://x/6', company: 'Acme', title: 'AI Eng', location: 'Remote', salary: { min: 180000, max: 220000, currency: 'USD' }, note: 'curated shortlist' });
+  const noteBare = formatPipelineOffer({ url: 'https://x/7', company: 'Acme', title: 'PM', note: 'Top pick' });
+  const noteAbsent = formatPipelineOffer({ url: 'https://x/8', company: 'Acme', title: 'PM' });
+  const noteEmpty = formatPipelineOffer({ url: 'https://x/8', company: 'Acme', title: 'PM', note: '' });
+  const noteNonString = formatPipelineOffer({ url: 'https://x/8', company: 'Acme', title: 'PM', note: 42 });
+  const notePipe = formatPipelineOffer({ url: 'https://x/9', company: 'Acme', title: 'PM', note: 'A | B' });
+  if (
+    noteFull === '- [ ] https://x/6 | Acme | AI Eng | Remote | 180000-220000 USD | note: curated shortlist' &&
+    noteBare === '- [ ] https://x/7 | Acme | PM | note: Top pick' &&
+    noteEmpty === noteAbsent &&
+    noteNonString === noteAbsent &&
+    notePipe === '- [ ] https://x/9 | Acme | PM | note: A / B'
+  ) {
+    pass('scan.mjs formatPipelineOffer preserves an optional labeled note (#1142; absent = byte-identical, sanitized)');
+  } else {
+    fail(`scan.mjs note segment wrong: "${noteFull}" / "${noteBare}" / "${noteEmpty}" / "${noteNonString}" / "${notePipe}"`);
+  }
 } catch (err) {
   fail(`scan.mjs formatPipelineOffer import failed: ${err.message}`);
 }

--- a/web/src/lib/core/pipeline.ts
+++ b/web/src/lib/core/pipeline.ts
@@ -27,6 +27,9 @@ export function addOffersToPipeline(offers: DiscoveredOffer[]): Promise<AddResul
       title: o.title || "",
       location: o.location || "",
       source: o.source || o.ats || "explorer",
+      // Preserve the optional per-offer signal so it survives to pipeline.md.
+      // The core writer treats an empty note as absent (byte-identical output).
+      note: o.note || "",
     }));
   if (clean.length === 0) return Promise.resolve({ added: 0 });
 

--- a/web/src/lib/explore.ts
+++ b/web/src/lib/explore.ts
@@ -49,6 +49,10 @@ export type DiscoveredOffer = {
   source: string;
   /** which positive keyword matched the title (transparency, e.g. "ai" in "Nail") */
   matchedKeyword?: string;
+  /** optional free-text ranking signal preserved to pipeline.md by the canonical
+   *  writer (scan.mjs formatPipelineOffer). Generic and source-agnostic — an
+   *  importer can attach a note; the deterministic scan omits it. */
+  note?: string;
   // ── AI-search (modes/discover.md) additions — all optional, so the
   //    deterministic scan offer is unaffected (fields simply absent). ──
   /** present ONLY on AI offers → drives the "unverified" badge. AI finds can't be


### PR DESCRIPTION
## What does this PR do?

Adds an optional, generic `note` field to the canonical pipeline writer so an offer can carry a free-text ranking signal into `pipeline.md`. Today `formatPipelineOffer` (and the web `addOffersToPipeline` that calls it) keep only url/company/title/location/compensation, so there is nowhere for a per-offer signal to live. Offers without a note are unchanged: the output is byte-identical to today.

## Related issue

Closes #1482. Proposed in discussion #1142, the small writer enhancement I offered there. Nothing in this PR is source-specific.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Details

- `scan.mjs`: `formatPipelineOffer` renders a non-empty `note` as a trailing `| note: {text}` segment. I made it labeled rather than positional (the way location and compensation are) so it can ride on any row shape, from a bare URL to a full 5-column row, without a reader mistaking it for a positional cell. It goes through `sanitizeMarkdownField` like every other field, so a pipe in the note collapses to `/` and cannot inject a phantom column. An absent, empty, or non-string note produces the exact output it does today.
- `web/`: `addOffersToPipeline` passes the field through its whitelist, and `DiscoveredOffer` gains an optional `note`, so a web-side add preserves the signal through the same canonical writer instead of dropping it. The scanner never sets the field; only an explicit importer does.
- `modes/pipeline.md`: documents the segment and shows an example row.

## Tests

Added assertions in `test-all.mjs` covering a note on a full row and on a bare row, byte-identical output when the note is absent/empty/non-string, and pipe sanitization. Full suite: 1059 passed, 0 failed.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional note on pipeline entries, shown as a trailing `note:` label.
  * Preserved notes in offer data so they can appear in exported pipeline output.

* **Documentation**
  * Updated pipeline format guidance and examples to describe the new note field and how it is displayed.

* **Tests**
  * Added coverage for note handling, including empty or invalid values and sanitization of special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->