### PR TITLE
fix(web): pin Turbopack workspace root to web/

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,5 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Pin the workspace root to THIS dir. Otherwise, if a package-lock.json exists
+  // one level up (e.g. after `npm install` at the repo root, needed by the core
+  // CLI/scanner), Turbopack infers the PARENT as the workspace root and tries to
+  // watch/compile the entire tree (its node_modules, .git, output/) — a runaway
+  // multi-GB memory blowup. Pinning here keeps dev scoped to web/.
+  turbopack: { root: import.meta.dirname },
   // Allow a throwaway build dir (e.g. BUILD_DIST=.next-prod) so a production
   // `next build` can run without clobbering a live `next dev` .next.
   ...(process.env.BUILD_DIST ? { distDir: process.env.BUILD_DIST } : {}),


### PR DESCRIPTION
## What does this PR do?

Pins Turbopack's workspace root to the `web/` directory in `web/next.config.mjs`, so the dev server stays scoped to `web/` instead of inferring the repo root and compiling the entire tree.

## Related issue

Closes #1486.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Details

Without the pin, a `package-lock.json` at the repo root (present after a root-level `npm install` for the CLI and scanner) makes Next.js / Turbopack infer the repo root as its workspace root and watch and compile the entire tree, including root `node_modules`, `.git`, and `output/`. That is a multi-GB memory blowup that makes `next dev` unusable. Setting `turbopack.root` to the web directory scopes it back to `web/`.

Backward compatible: with no parent lockfile present the behavior is unchanged, this just makes the intended root explicit. `next dev` and `next build` both work with the pin in place.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)
