### PR TITLE
docs: surface agent-inbox in README and AGENTS.md router table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,6 +284,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Asks about follow-ups or application cadence | `followup` |
 | Wants to update the system | `update` |
 | Wants to queue a request for later / check the inbox between sessions | `agent-inbox` — append-only checklist the agent drains at the start of the next session; nothing auto-submits |
+
 ### CV Source of Truth
 
 - `cv.md` in project root is the canonical CV

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,7 +283,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Asks about rejection patterns, wants to improve targeting, or wants to match interview answers to best-fit roles | `patterns` |
 | Asks about follow-ups or application cadence | `followup` |
 | Wants to update the system | `update` |
-
+| Wants to queue a request for later / check the inbox between sessions | `agent-inbox` — append-only checklist the agent drains at the start of the next session; nothing auto-submits |
 ### CV Source of Truth
 
 - `cv.md` in project root is the canonical CV

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ npm install
 # 3. Evaluate a job description
 node gemini-eval.mjs "We are looking for a Senior AI Engineer..."
 node gemini-eval.mjs --file ./jds/my-job.txt
+node agent-inbox.mjs add "..."   # queue a request for the next session
 npm run gemini:eval -- "JD text here"
 ```
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change in 1-3 sentences -->
Adds `agent-inbox` to the AGENTS.md skill mode routing table and adds 
a one-liner to README.md showing `node agent-inbox.mjs add "..."` 
alongside the other CLI utilities, so users can discover the inbox 
without reading the full mode file

## Related issue
Closes #1485 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ ] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated `AGENTS.md` with a new “Skill Modes” entry for `agent-inbox`, describing it as an append-only inbox checklist drained at the start of the next session (no auto-submission).
  * Expanded the README “Standalone Gemini API Script” instructions with an additional step to queue a request for the next session using `node agent-inbox.mjs add "..."`.
  * Clarified how deferred request/session handling works for this mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->