### PR TITLE
feat(providers): honour api: on workday and smartrecruiters

### DIFF
--- a/providers/smartrecruiters.mjs
+++ b/providers/smartrecruiters.mjs
@@ -27,18 +27,24 @@ function assertSmartRecruitersUrl(url) {
 }
 
 function resolveSlug(entry) {
-  const raw = typeof entry.careers_url === 'string' ? entry.careers_url : '';
-  if (!raw) return null;
-  let parsed;
-  try {
-    parsed = new URL(raw);
-  } catch {
-    return null;
+  // entry.api takes precedence over careers_url (mirrors greenhouse/ashby) so a
+  // branded page (e.g. https://jobs.continental.com) can stay as careers_url
+  // while the SmartRecruiters slug is pinned via
+  // api: https://careers.smartrecruiters.com/<slug> in portals.yml.
+  for (const raw of [entry.api, entry.careers_url]) {
+    if (typeof raw !== 'string' || !raw) continue;
+    let parsed;
+    try {
+      parsed = new URL(raw);
+    } catch {
+      continue;
+    }
+    if (parsed.protocol !== 'https:') continue;
+    if (!SR_CAREERS_HOSTS.has(parsed.hostname)) continue;
+    const slug = parsed.pathname.split('/').filter(Boolean)[0];
+    if (slug) return slug;
   }
-  if (parsed.protocol !== 'https:') return null;
-  if (!SR_CAREERS_HOSTS.has(parsed.hostname)) return null;
-  const slug = parsed.pathname.split('/').filter(Boolean)[0];
-  return slug || null;
+  return null;
 }
 
 function buildPostingsUrl(slug, offset = 0) {

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -116,17 +116,25 @@ function pageIsPastWindow(pageJobs, sinceMs) {
 }
 
 function resolveEndpoint(entry) {
-  const url = entry.careers_url || '';
-  const m = url.match(/^https:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([^/?#]+)/);
-  if (!m) return null;
-  const [, tenant, instance, site] = m;
-  const origin = `https://${tenant}.${instance}.myworkdayjobs.com`;
-  return {
-    api: `${origin}/wday/cxs/${tenant}/${site}/jobs`,
-    // externalPath is relative to the site, not the host root — without the
-    // site segment the URL 404s.
-    jobBase: `${origin}/${site}`,
-  };
+  // Try api: first, then careers_url (mirrors greenhouse/ashby), returning the
+  // first that matches the Workday tenant pattern. This lets a branded page
+  // (e.g. https://www.ptc.com/en/careers) stay as careers_url while the Workday
+  // tenant URL is pinned via api: — and, because we fall through on a non-match,
+  // a non-Workday api: value doesn't shadow a valid careers_url.
+  for (const url of [entry.api, entry.careers_url]) {
+    if (typeof url !== 'string' || !url) continue;
+    const m = url.match(/^https:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([^/?#]+)/);
+    if (!m) continue;
+    const [, tenant, instance, site] = m;
+    const origin = `https://${tenant}.${instance}.myworkdayjobs.com`;
+    return {
+      api: `${origin}/wday/cxs/${tenant}/${site}/jobs`,
+      // externalPath is relative to the site, not the host root — without the
+      // site segment the URL 404s.
+      jobBase: `${origin}/${site}`,
+    };
+  }
+  return null;
 }
 
 function parsePostedOn(label) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2855,6 +2855,19 @@ try {
     fail('smartrecruiters.detect() should return null for non-SR URLs');
   }
 
+  // entry.api precedence: a branded careers_url is kept while the SR slug is
+  // pinned via api: (mirrors greenhouse/ashby).
+  const hitApi = sr.detect({
+    name: 'Continental',
+    careers_url: 'https://jobs.continental.com',
+    api: 'https://careers.smartrecruiters.com/Continental',
+  });
+  if (hitApi && hitApi.url.startsWith('https://api.smartrecruiters.com/v1/companies/Continental/postings')) {
+    pass('smartrecruiters.detect() honors api: over a branded careers_url');
+  } else {
+    fail(`smartrecruiters.detect(api-pinned) returned ${JSON.stringify(hitApi)}`);
+  }
+
   // parseSmartRecruitersResponse
   const sample = {
     content: [
@@ -10331,6 +10344,32 @@ try {
     pass('workday.detect() returns null for non-Workday URL');
   } else {
     fail('workday.detect() should return null for non-Workday URL');
+  }
+
+  // entry.api precedence: a branded careers_url is kept while the Workday tenant
+  // is pinned via api: (mirrors greenhouse/ashby).
+  const hitApiWd = workday.detect({
+    name: 'PTC',
+    careers_url: 'https://www.ptc.com/en/careers',
+    api: 'https://ptc.wd1.myworkdayjobs.com/PTC',
+  });
+  if (hitApiWd && hitApiWd.url === 'https://ptc.wd1.myworkdayjobs.com/wday/cxs/ptc/PTC/jobs') {
+    pass('workday.detect() honors api: over a branded careers_url');
+  } else {
+    fail(`workday.detect(api-pinned) returned ${JSON.stringify(hitApiWd)}`);
+  }
+
+  // A non-Workday api: must not shadow a valid Workday careers_url — resolution
+  // falls through to the next candidate instead of returning null.
+  const hitFallthrough = workday.detect({
+    name: 'Acme',
+    api: 'https://acme.com/careers',
+    careers_url: 'https://acme.wd12.myworkdayjobs.com/en-US/acme-jobs',
+  });
+  if (hitFallthrough && hitFallthrough.url === 'https://acme.wd12.myworkdayjobs.com/wday/cxs/acme/acme-jobs/jobs') {
+    pass('workday.detect() falls through a non-Workday api: to a valid careers_url');
+  } else {
+    fail(`workday.detect(fallthrough) returned ${JSON.stringify(hitFallthrough)}`);
   }
 
   // Path-spoofed URL: myworkdayjobs.com in path, not hostname


### PR DESCRIPTION
## What

`workday` and `smartrecruiters` resolved their endpoint from `careers_url` only. A company whose **public careers page is a branded domain** (e.g. `https://www.zeiss.com/career`, `https://www.brainlab.com/careers`) therefore couldn't be wired up — even though its jobs live on a supported ATS at a different host.

Every other HTTP provider that separates the public URL from the API host — **ashby, greenhouse, successfactors** — already lets an entry keep the branded `careers_url` and supply the ATS URL via `api:`. This aligns workday and smartrecruiters with that convention.

```yaml
- name: Carl Zeiss
  careers_url: https://www.zeiss.com/career          # stays the public page
  provider: workday
  api: https://zeissgroup.wd3.myworkdayjobs.com/External

- name: Brainlab
  careers_url: https://www.brainlab.com/careers/
  provider: smartrecruiters
  api: https://careers.smartrecruiters.com/brainlab
```

## How
- **workday**: `resolveEndpoint()` reads `entry.api || entry.careers_url`.
- **smartrecruiters**: `resolveSlug()` prefers `entry.api`, falling back to `careers_url`.

Host allow-listing and https-only checks are **unchanged** — a spoofed `api:` host still fails the `myworkdayjobs` / `SR_CAREERS_HOSTS` gate. This only widens *where* a valid ATS URL may be supplied, not what counts as valid.

## Changes
- `providers/workday.mjs`, `providers/smartrecruiters.mjs`
- `test-all.mjs`: `api:`-precedence assertions in both provider sections (branded `careers_url` + `api:` resolves to the API endpoint; a branded `careers_url` alone still returns `null`).

## Verification
`node test-all.mjs` → **1138 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job source detection for SmartRecruiters and Workday by prioritizing explicitly provided API URLs over branded careers links.
  * SmartRecruiters now derives the correct company slug from the first valid API-related URL; otherwise it safely returns no match.
  * Workday now resolves the correct jobs endpoint from the provided API when available, falling back to the careers URL only when needed.
* **Tests**
  * Added contract assertions to verify API precedence behavior for both providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->