### PR TITLE
feat(invite-match): fuzzy-match interview-invite emails to tracker entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON output) |
 | `set-status.mjs` | Canonical CLI to update a tracker row: `node set-status.mjs <report#\|company> <State> [--note]` — strict states.yml validation, shared tracker lock, atomic write |
+| `invite-match.mjs` | Fuzzy-matches a pasted interview-invite email (company name, date, req ID) against `data/applications.md`, ranking candidates when a company has multiple tracker entries (JSON or `--summary` table output) |
 | `detect-reposts.mjs` | Repost detector — flags roles re-listed 2+ times in 90 days from scan-history.tsv (JSON or `--summary` table output) |
 | `process-quality.mjs` | Recruiting-process friction aggregator — parses `[process-friction]` tags candidates add to `data/active-interviews.md` Notes and reports per-company friction rate (JSON or `--summary` table output) |
 | `salary-gap.mjs` | Desired/advertised/actual compensation gap analyzer — folds report `advertised_comp` + `data/salary-observations.tsv` (JSON or `--summary`) |

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -26,6 +26,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run validate:portals` | `validate-portals.mjs` | Validate portals.yml shape before scanning |
 | `npm run tracker` | `tracker.mjs` | SQLite derived index over applications.md — sync/query/history/export |
 | `npm run find` | `find.mjs` | Resolve a report#/tracker#/company query to its full pipeline identity |
+| `npm run invite-match` | `invite-match.mjs` | Fuzzy-match a pasted interview-invite email against `data/applications.md` |
 
 ---
 

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -37,6 +37,10 @@ const args = process.argv.slice(2);
 const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
 const fileIdx = args.indexOf('--file');
+if (fileIdx !== -1 && args[fileIdx + 1] === undefined) {
+  console.error('invite-match: --file requires a path argument');
+  process.exit(1);
+}
 const filePathArg = fileIdx !== -1 ? args[fileIdx + 1] : null;
 
 // Statuses ranked above others when disambiguating same-company candidates —
@@ -61,21 +65,37 @@ function normalizeStatusKey(status) {
     .toLowerCase();
 }
 
-// Common corporate suffixes that vary between how a recruiter signs an email
-// ("Acme Corp") and how the tracker recorded the company ("Acme Inc.") —
-// stripped before comparison so they don't cause false negatives.
-const CORPORATE_SUFFIXES = [
+// True legal-entity suffixes, stripped repeatedly (chained) since a name can
+// legitimately carry more than one ("Acme Holdings Inc." → "acme holdings").
+// These are unambiguous enough that removing several in a row is safe.
+const LEGAL_SUFFIXES = [
   'incorporated', 'inc', 'corporation', 'corp', 'company', 'co',
-  'limited', 'ltd', 'llc', 'llp', 'lp', 'plc', 'group', 'holdings',
-  'technologies', 'technology', 'solutions', 'canada', 'international',
+  'limited', 'ltd', 'llc', 'llp', 'lp', 'plc',
+];
+
+// Generic business-descriptor words that vary between how a recruiter signs
+// an email and how the tracker recorded the company, but are common enough
+// as substantive parts of a name (e.g. "Data Solutions" vs "Data Corp") that
+// chaining their removal risks collapsing two different companies to the
+// same key. Stripped at most once, and only after legal suffixes are gone —
+// never chained with each other or with LEGAL_SUFFIXES.
+const GENERIC_DESCRIPTORS = [
+  'group', 'holdings', 'technologies', 'technology', 'solutions',
+  'canada', 'international',
 ];
 
 /**
  * Normalize a company name for matching: lowercase, strip punctuation and
- * parentheticals, collapse whitespace, and drop trailing corporate suffixes
- * one at a time (so "Acme Technologies Inc." reduces the same way as
- * "Acme"). Mirrors the normalization dedup-tracker.mjs applies to tracker
- * rows, so the same two names collapse to the same key on both sides.
+ * parentheticals, collapse whitespace, chain-strip trailing legal-entity
+ * suffixes (so "Acme Technologies Inc." reduces to "acme technologies"),
+ * then strip at most one trailing generic descriptor word. Mirrors the
+ * normalization dedup-tracker.mjs applies to tracker rows, so the same two
+ * names collapse to the same key on both sides.
+ *
+ * Generic descriptors are deliberately stripped only once (not chained) and
+ * only after legal suffixes, so two distinct companies that happen to both
+ * end in a generic word (e.g. "Data Solutions" vs "Data Corp") don't
+ * collapse to the same "data" key — see issue discussion on PR #1497.
  *
  * @param {string} name
  * @returns {string}
@@ -92,7 +112,7 @@ export function normalizeCompanyName(name) {
   let changed = true;
   while (changed) {
     changed = false;
-    for (const suffix of CORPORATE_SUFFIXES) {
+    for (const suffix of LEGAL_SUFFIXES) {
       const re = new RegExp(`\\s${suffix}$`);
       if (re.test(key)) {
         key = key.replace(re, '').trim();
@@ -100,6 +120,15 @@ export function normalizeCompanyName(name) {
       }
     }
   }
+
+  for (const word of GENERIC_DESCRIPTORS) {
+    const re = new RegExp(`\\s${word}$`);
+    if (re.test(key)) {
+      key = key.replace(re, '').trim();
+      break;
+    }
+  }
+
   return key;
 }
 
@@ -143,7 +172,7 @@ export function companySimilarity(a, b) {
 // the result, not this heuristic alone.
 const COMPANY_LINE_PATTERNS = [
   /(?:^|\n)\s*company\s*[:\-]\s*(.+)/i,
-  /interview(?:ing)?\s+(?:with|at)\s+([A-Z][\w.,&' -]{1,60}?)(?:[.,\n]|\s+for\s|\s+regarding\s|$)/,
+  /interview(?:ing)?\s+(?:with|at)\s+([A-Z][\w.,&' -]{1,60}?)(?:[.,\n]|\s+for\s|\s+regarding\s|$)/i,
   /(?:phone screen|screening|interview)\s*[-–—:]\s*([A-Z][\w.,&' -]{1,60}?)(?:\s+opportunity)?(?:[.,\n]|$)/i,
   /schedule your (?:phone screen|interview)\s*(?:[-–—:]\s*)?([A-Z][\w.,&' -]{1,60}?)\s*opportunity/i,
 ];
@@ -407,6 +436,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   } else {
     let text;
     if (filePathArg) {
+      if (!existsSync(filePathArg)) {
+        console.error(`invite-match: file not found: ${filePathArg}`);
+        process.exit(1);
+      }
       text = readFileSync(filePathArg, 'utf-8');
     } else {
       text = readFileSync(0, 'utf-8'); // stdin

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -1,0 +1,423 @@
+#!/usr/bin/env node
+/**
+ * invite-match.mjs — Interview-Invite → Tracker Matcher for career-ops
+ *
+ * Recruiter calendar/ATS invite emails frequently name only the company
+ * (generic subject lines like "Schedule Your Phone Screen") with no job
+ * title or req number. Finding which `data/applications.md` row an invite
+ * belongs to otherwise means a manual grep every time.
+ *
+ * This script extracts a company name (and, if present, a date and a
+ * req/job-ID-looking token) from pasted invite text, fuzzy-matches it
+ * against the tracker's Company column, and ranks candidates when the same
+ * company has multiple applications — which is common. A silent wrong guess
+ * is worse than showing a short ranked list, so ambiguous input always
+ * returns all plausible candidates rather than picking one.
+ *
+ * Run: node invite-match.mjs < invite.txt          (JSON to stdout)
+ *      node invite-match.mjs --file invite.txt
+ *      echo "..." | node invite-match.mjs --summary
+ *      node invite-match.mjs --self-test
+ *
+ * Issue #1495 — github.com/santifer/career-ops
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+
+const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
+  ? join(CAREER_OPS, 'data/applications.md')
+  : join(CAREER_OPS, 'applications.md');
+
+// --- CLI args ---
+const args = process.argv.slice(2);
+const summaryMode = args.includes('--summary');
+const selfTestMode = args.includes('--self-test');
+const fileIdx = args.indexOf('--file');
+const filePathArg = fileIdx !== -1 ? args[fileIdx + 1] : null;
+
+// Statuses ranked above others when disambiguating same-company candidates —
+// an active application is a far more likely invite match than one already
+// rejected or discarded, even if the rejected row is textually a closer date.
+const STATUS_PRIORITY = {
+  interview: 0,
+  responded: 1,
+  applied: 2,
+  evaluated: 3,
+  offer: 4,
+  rejected: 5,
+  discarded: 6,
+  skip: 7,
+};
+
+function normalizeStatusKey(status) {
+  return String(status ?? '')
+    .replace(/\*\*/g, '')
+    .replace(/\s+\d{4}-\d{2}-\d{2}.*$/, '')
+    .trim()
+    .toLowerCase();
+}
+
+// Common corporate suffixes that vary between how a recruiter signs an email
+// ("Acme Corp") and how the tracker recorded the company ("Acme Inc.") —
+// stripped before comparison so they don't cause false negatives.
+const CORPORATE_SUFFIXES = [
+  'incorporated', 'inc', 'corporation', 'corp', 'company', 'co',
+  'limited', 'ltd', 'llc', 'llp', 'lp', 'plc', 'group', 'holdings',
+  'technologies', 'technology', 'solutions', 'canada', 'international',
+];
+
+/**
+ * Normalize a company name for matching: lowercase, strip punctuation and
+ * parentheticals, collapse whitespace, and drop trailing corporate suffixes
+ * one at a time (so "Acme Technologies Inc." reduces the same way as
+ * "Acme"). Mirrors the normalization dedup-tracker.mjs applies to tracker
+ * rows, so the same two names collapse to the same key on both sides.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function normalizeCompanyName(name) {
+  let key = String(name ?? '')
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9 ]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const suffix of CORPORATE_SUFFIXES) {
+      const re = new RegExp(`\\s${suffix}$`);
+      if (re.test(key)) {
+        key = key.replace(re, '').trim();
+        changed = true;
+      }
+    }
+  }
+  return key;
+}
+
+/**
+ * Token-overlap similarity between two normalized company-name strings.
+ * Returns 1 for an exact match, otherwise the fraction of the shorter name's
+ * tokens found in the longer name (order-independent), and 0 when there is
+ * no overlap at all. Deliberately simple — this is a "does this look like
+ * the same company" check, not a general string-distance metric.
+ *
+ * @param {string} a - Already-normalized name.
+ * @param {string} b - Already-normalized name.
+ * @returns {number} 0..1
+ */
+export function companySimilarity(a, b) {
+  if (!a || !b) return 0;
+  if (a === b) return 1;
+
+  const tokensA = a.split(' ').filter(Boolean);
+  const tokensB = b.split(' ').filter(Boolean);
+  if (tokensA.length === 0 || tokensB.length === 0) return 0;
+
+  const [shorter, longer] = tokensA.length <= tokensB.length ? [tokensA, tokensB] : [tokensB, tokensA];
+  const longerSet = new Set(longer);
+  const overlap = shorter.filter(t => longerSet.has(t)).length;
+  if (overlap === 0) return 0;
+
+  // Dice coefficient (2 * overlap / total tokens), not overlap/shorter-length:
+  // a full-containment match ("acme" inside "acme corp") still scores below
+  // an exact match, so when the tracker has both an exact-name row and a
+  // longer-name row for the same company, the exact match ranks first.
+  return (2 * overlap) / (tokensA.length + tokensB.length);
+}
+
+// --- Extract signals from invite text ---
+
+// Matches the first "Company: X" / "at X" / "with X" style line, and falls
+// back to the invite subject-style first line otherwise. Invite emails vary
+// too much for one regex to be authoritative, so this is a best-effort
+// extraction — the fuzzy match against the tracker is what actually decides
+// the result, not this heuristic alone.
+const COMPANY_LINE_PATTERNS = [
+  /(?:^|\n)\s*company\s*[:\-]\s*(.+)/i,
+  /interview(?:ing)?\s+(?:with|at)\s+([A-Z][\w.,&' -]{1,60}?)(?:[.,\n]|\s+for\s|\s+regarding\s|$)/,
+  /(?:phone screen|screening|interview)\s*[-–—:]\s*([A-Z][\w.,&' -]{1,60}?)(?:\s+opportunity)?(?:[.,\n]|$)/i,
+  /schedule your (?:phone screen|interview)\s*(?:[-–—:]\s*)?([A-Z][\w.,&' -]{1,60}?)\s*opportunity/i,
+];
+
+/**
+ * Best-effort extraction of the company name from raw invite email text.
+ * Tries a handful of common invite phrasings; returns null if nothing
+ * plausible is found (caller should surface that to the user rather than
+ * guessing further).
+ *
+ * @param {string} text - Raw pasted invite email text.
+ * @returns {string|null}
+ */
+export function extractCompany(text) {
+  if (!text) return null;
+  for (const pattern of COMPANY_LINE_PATTERNS) {
+    const m = text.match(pattern);
+    if (m && m[1]) {
+      const candidate = m[1].trim().replace(/[.,;:]+$/, '');
+      if (candidate.length >= 2 && candidate.length <= 60) return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Best-effort extraction of a date mentioned in the invite (interview date,
+ * not necessarily the email send date). Only matches unambiguous ISO or
+ * "Month D, YYYY" forms — anything else is left for the human to read.
+ *
+ * @param {string} text
+ * @returns {string|null} YYYY-MM-DD or null.
+ */
+export function extractDate(text) {
+  if (!text) return null;
+  const iso = text.match(/\b(\d{4})-(\d{2})-(\d{2})\b/);
+  if (iso) return iso[0];
+
+  const months = 'January|February|March|April|May|June|July|August|September|October|November|December';
+  const named = text.match(new RegExp(`\\b(${months})\\s+(\\d{1,2}),?\\s+(\\d{4})\\b`, 'i'));
+  if (named) {
+    const monthIdx = new Date(`${named[1]} 1, 2000`).getMonth() + 1;
+    const day = String(named[2]).padStart(2, '0');
+    const month = String(monthIdx).padStart(2, '0');
+    return `${named[3]}-${month}-${day}`;
+  }
+  return null;
+}
+
+/**
+ * Best-effort extraction of a req/job-ID-looking token (e.g. "R260013984",
+ * "Req 32807", "Job ID: 43683", "JR12352") — present in a minority of
+ * invites but a strong disambiguator when it is, since it can be cross-
+ * checked against the tracker's notes column.
+ *
+ * @param {string} text
+ * @returns {string|null}
+ */
+export function extractReqId(text) {
+  if (!text) return null;
+  const m = text.match(/\b(?:req(?:uisition)?\.?\s*(?:id)?[:\s#]*|job\s*id[:\s#]*)([A-Z]{0,3}\d{3,10})\b/i)
+    || text.match(/\b([A-Z]{1,3}\d{5,10})\b/);
+  return m ? m[1] : null;
+}
+
+// --- Tracker loading ---
+function loadTracker(appsFile = APPS_FILE) {
+  if (!existsSync(appsFile)) return [];
+  const content = readFileSync(appsFile, 'utf-8');
+  const lines = content.split('\n');
+  const colmap = resolveColumns(lines);
+  const entries = [];
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (row) entries.push(row);
+  }
+  return entries;
+}
+
+/**
+ * Core matcher: given extracted invite signals and a list of tracker rows,
+ * return ranked candidates. Exported so tests can drive it directly against
+ * fixture rows without touching the real tracker file.
+ *
+ * @param {{company: string|null, date: string|null, reqId: string|null}} signals
+ * @param {Array<object>} trackerRows - Rows from parseTrackerRow().
+ * @returns {Array<object>} Ranked candidates, highest confidence first.
+ */
+export function matchInvite(signals, trackerRows) {
+  if (!signals || !signals.company || !Array.isArray(trackerRows)) return [];
+
+  const targetKey = normalizeCompanyName(signals.company);
+  if (!targetKey) return [];
+
+  const scored = [];
+  for (const row of trackerRows) {
+    const rowKey = normalizeCompanyName(row.company);
+    const nameScore = companySimilarity(targetKey, rowKey);
+    if (nameScore <= 0) continue;
+
+    let confidence = nameScore;
+
+    // A req/job ID appearing verbatim in the row's notes is a near-certain
+    // match — boost it above any name-only match (including another exact
+    // name match without the req ID). matchConfidence is a ranking score,
+    // not a probability, so it's intentionally allowed to exceed 1 here.
+    if (signals.reqId && row.notes && row.notes.includes(signals.reqId)) {
+      confidence += 0.5;
+    }
+
+    // Prefer rows in an active/actionable status over closed-out ones when
+    // the same company has multiple tracker entries.
+    const statusRank = STATUS_PRIORITY[normalizeStatusKey(row.status)] ?? 8;
+    confidence += (7 - Math.min(statusRank, 7)) * 0.01; // tiny tiebreaker, never dominates nameScore
+
+    scored.push({
+      appNumber: row.num,
+      company: row.company,
+      role: row.role,
+      status: row.status,
+      date: row.date,
+      matchConfidence: Math.round(confidence * 1000) / 1000,
+    });
+  }
+
+  scored.sort((a, b) => b.matchConfidence - a.matchConfidence);
+  return scored;
+}
+
+/**
+ * End-to-end: parse invite text, load the tracker, return ranked candidates
+ * plus the signals that were extracted (so the caller/CLI can show what was
+ * understood from the email, not just the result).
+ *
+ * @param {string} text - Raw invite email text.
+ * @param {Array<object>} [trackerRows] - Injectable for tests; defaults to loadTracker().
+ * @returns {{signals: object, candidates: Array<object>}}
+ */
+export function analyzeInvite(text, trackerRows = null) {
+  const signals = {
+    company: extractCompany(text),
+    date: extractDate(text),
+    reqId: extractReqId(text),
+  };
+  const rows = trackerRows ?? loadTracker();
+  const candidates = matchInvite(signals, rows);
+  return { signals, candidates };
+}
+
+// --- Summary mode ---
+function printSummary(result) {
+  console.log(`\n${'='.repeat(70)}`);
+  console.log('  Interview Invite Matcher — career-ops');
+  console.log(`${'='.repeat(70)}\n`);
+
+  console.log(`  Extracted company: ${result.signals.company || '(not found)'}`);
+  console.log(`  Extracted date:    ${result.signals.date || '(not found)'}`);
+  console.log(`  Extracted req ID:  ${result.signals.reqId || '(not found)'}\n`);
+
+  if (!result.signals.company) {
+    console.log('  Could not find a company name in the invite text — paste more context or check manually.\n');
+    return;
+  }
+
+  if (result.candidates.length === 0) {
+    console.log('  No matching tracker entries found for this company.\n');
+    return;
+  }
+
+  console.log('  ' + '#'.padEnd(6) + 'Company'.padEnd(20) + 'Role'.padEnd(34) + 'Status'.padEnd(12) + 'Confidence');
+  console.log('  ' + '-'.repeat(88));
+  for (const c of result.candidates.slice(0, 5)) {
+    console.log(
+      '  ' +
+      String(c.appNumber).padEnd(6) +
+      c.company.substring(0, 18).padEnd(20) +
+      c.role.substring(0, 32).padEnd(34) +
+      c.status.padEnd(12) +
+      String(c.matchConfidence)
+    );
+  }
+  console.log('');
+}
+
+// --- Self-test ---
+function runSelfTest() {
+  let pass = 0;
+  let fail = 0;
+  const check = (cond, label) => {
+    if (cond) { pass += 1; } else { fail += 1; console.error(`  FAIL: ${label}`); }
+  };
+
+  // --- normalizeCompanyName ---
+  check(normalizeCompanyName('Acme Corp.') === 'acme', 'strips "Corp." suffix');
+  check(normalizeCompanyName('Acme Technologies Inc.') === 'acme', 'strips chained suffixes');
+  check(normalizeCompanyName('Acme (Example Group)') === 'acme', 'drops parenthetical branding');
+  check(normalizeCompanyName('Acme & Co') === normalizeCompanyName('Acme and Co'), '"&" normalizes the same as "and"');
+  check(normalizeCompanyName('  ACME   ') === 'acme', 'trims and lowercases whitespace-padded input');
+
+  // --- companySimilarity ---
+  check(companySimilarity('acme', 'acme') === 1, 'identical strings score 1');
+  check(companySimilarity('acme example', 'acme') > 0.5, 'substring containment scores high');
+  check(companySimilarity('acme', 'globex') === 0, 'unrelated names score 0');
+  check(companySimilarity('', 'acme') === 0, 'empty string never matches');
+
+  // --- extractCompany ---
+  check(extractCompany('Company: Example Industries\nRole: Analyst') === 'Example Industries', 'extracts from "Company:" line');
+  check(extractCompany('Schedule Your Phone Screen – Acme Opportunity') === 'Acme', 'extracts from generic "Schedule Your Phone Screen" subject');
+  check(extractCompany('Looking forward to interviewing with Example Corp for the role.') === 'Example Corp', 'extracts from "interviewing with X" phrasing');
+  check(extractCompany('no company signal here at all') === null, 'returns null when nothing plausible is found');
+
+  // --- extractDate ---
+  check(extractDate('Interview scheduled for 2026-07-09 at 4pm') === '2026-07-09', 'extracts ISO date');
+  check(extractDate('See you on July 9, 2026') === '2026-07-09', 'extracts named-month date');
+  check(extractDate('no date mentioned') === null, 'returns null when no date is present');
+
+  // --- extractReqId ---
+  check(extractReqId('Req ID: R260013984') === 'R260013984', 'extracts "Req ID:" token');
+  check(extractReqId('Job ID: 43683') === '43683', 'extracts "Job ID:" token');
+  check(extractReqId('no id here') === null, 'returns null when no req-like token is present');
+
+  // --- matchInvite (fixture rows, no real tracker data) ---
+  const fixtureRows = [
+    { num: 101, company: 'Example Industries', role: 'Training Coordinator', status: 'Applied', date: '2026-06-01', notes: 'Req EX9001' },
+    { num: 102, company: 'Example Industries', role: 'HR Generalist', status: 'Rejected', date: '2026-05-10', notes: 'Rejected 2026-05-20' },
+    { num: 103, company: 'Acme Corp', role: 'Program Coordinator', status: 'Interview', date: '2026-06-15', notes: '' },
+    { num: 104, company: 'Globex LLC', role: 'Analyst', status: 'Applied', date: '2026-06-20', notes: '' },
+  ];
+
+  const noSignal = matchInvite({ company: null, date: null, reqId: null }, fixtureRows);
+  check(noSignal.length === 0, 'no company signal → no candidates');
+
+  const acmeMatch = matchInvite({ company: 'Acme Corp.', date: null, reqId: null }, fixtureRows);
+  check(acmeMatch.length === 1 && acmeMatch[0].appNumber === 103, 'matches "Acme Corp." to the Acme Corp tracker row despite suffix punctuation');
+
+  const exampleMatch = matchInvite({ company: 'Example Industries', date: null, reqId: null }, fixtureRows);
+  check(exampleMatch.length === 2, 'same company with multiple tracker rows returns all candidates, not just one');
+  check(exampleMatch[0].appNumber === 101, 'active (Applied) row ranks above the Rejected row for the same company when name-match is tied');
+
+  const reqBoosted = matchInvite({ company: 'Example Industries', date: null, reqId: 'EX9001' }, fixtureRows);
+  check(reqBoosted[0].appNumber === 101 && reqBoosted[0].matchConfidence > exampleMatch[0].matchConfidence, 'a req ID found in notes boosts that candidate\'s confidence');
+
+  const noMatch = matchInvite({ company: 'Totally Unrelated Co', date: null, reqId: null }, fixtureRows);
+  check(noMatch.length === 0, 'unrelated company name returns no candidates');
+
+  // --- analyzeInvite (end-to-end with injected rows, no file I/O) ---
+  const fullText = 'Schedule Your Phone Screen – Acme Opportunity\nInterview scheduled for 2026-07-09.';
+  const result = analyzeInvite(fullText, fixtureRows);
+  check(result.signals.company === 'Acme', 'analyzeInvite extracts company end-to-end');
+  check(result.signals.date === '2026-07-09', 'analyzeInvite extracts date end-to-end');
+  check(result.candidates.length === 1 && result.candidates[0].appNumber === 103, 'analyzeInvite returns the matched candidate end-to-end');
+
+  console.log(`\n  invite-match self-test: ${pass} passed, ${fail} failed\n`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+// --- Run (CLI only; guarded so the module is safely importable for tests) ---
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  if (selfTestMode) {
+    runSelfTest();
+  } else {
+    let text;
+    if (filePathArg) {
+      text = readFileSync(filePathArg, 'utf-8');
+    } else {
+      text = readFileSync(0, 'utf-8'); // stdin
+    }
+
+    const result = analyzeInvite(text);
+
+    if (summaryMode) {
+      printSummary(result);
+    } else {
+      console.log(JSON.stringify(result, null, 2));
+    }
+  }
+}

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -37,7 +37,10 @@ const args = process.argv.slice(2);
 const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
 const fileIdx = args.indexOf('--file');
-if (fileIdx !== -1 && args[fileIdx + 1] === undefined) {
+// Treat a following recognized flag (e.g. `--file --summary`) the same as a
+// missing value — otherwise it's silently accepted as the path and produces
+// a confusing "file not found: --summary" instead of the clearer error below.
+if (fileIdx !== -1 && (args[fileIdx + 1] === undefined || args[fileIdx + 1].startsWith('--'))) {
   console.error('invite-match: --file requires a path argument');
   process.exit(1);
 }

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -91,9 +91,11 @@ const GENERIC_DESCRIPTORS = [
  * Normalize a company name for matching: lowercase, strip punctuation and
  * parentheticals, collapse whitespace, chain-strip trailing legal-entity
  * suffixes (so "Acme Technologies Inc." reduces to "acme technologies"),
- * then strip at most one trailing generic descriptor word. Mirrors the
- * normalization dedup-tracker.mjs applies to tracker rows, so the same two
- * names collapse to the same key on both sides.
+ * then strip at most one trailing generic descriptor word. Deliberately
+ * stricter than dedup-tracker.mjs's normalizeCompany (which only lowercases
+ * and strips punctuation): invite emails quote company names more loosely
+ * than tracker rows quote each other, so matching across the two sources
+ * needs the extra suffix-stripping that same-source dedup does not.
  *
  * Generic descriptors are deliberately stripped only once (not chained) and
  * only after legal suffixes, so two distinct companies that happen to both
@@ -278,11 +280,14 @@ export function matchInvite(signals, trackerRows) {
 
     let confidence = nameScore;
 
-    // A req/job ID appearing verbatim in the row's notes is a near-certain
-    // match — boost it above any name-only match (including another exact
-    // name match without the req ID). matchConfidence is a ranking score,
-    // not a probability, so it's intentionally allowed to exceed 1 here.
-    if (signals.reqId && row.notes && row.notes.includes(signals.reqId)) {
+    // A req/job ID appearing in the row's notes is a near-certain match —
+    // boost it above any name-only match (including another exact name
+    // match without the req ID). Compared case-insensitively: the invite
+    // and the notes may case the same ID differently ("jr12352" vs
+    // "JR12352"). matchConfidence is a ranking score, not a probability,
+    // so it's intentionally allowed to exceed 1 here.
+    if (signals.reqId && row.notes
+      && row.notes.toLowerCase().includes(signals.reqId.toLowerCase())) {
       confidence += 0.5;
     }
 

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -1,0 +1,63 @@
+/**
+ * invite-match.test.mjs — regression tests for invite-match.mjs's ambiguous-
+ * match ranking, which is the part most likely to silently regress: a wrong
+ * top candidate is worse than no candidate at all.
+ *
+ * Run: node invite-match.test.mjs
+ */
+
+import { matchInvite, normalizeCompanyName } from './invite-match.mjs';
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function eq(label, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    passed++;
+  } else {
+    failed++;
+    failures.push(label);
+    console.log(`  FAIL: ${label}`);
+    console.log(`    expected: ${e}`);
+    console.log(`    actual:   ${a}`);
+  }
+}
+
+const rows = [
+  { num: 201, company: 'Northwind Traders', role: 'Ops Coordinator', status: 'Applied', date: '2026-05-01', notes: '' },
+  { num: 202, company: 'Northwind Traders', role: 'HR Assistant', status: 'Interview', date: '2026-05-15', notes: '' },
+  { num: 203, company: 'Northwind Traders', role: 'Analyst', status: 'Rejected', date: '2026-04-10', notes: 'Rejected 2026-04-20' },
+];
+
+// Three tracker rows for the same company at three different statuses — the
+// Interview row must outrank both Applied and Rejected, since an in-progress
+// interview is the most likely thing a new invite email is about.
+const result = matchInvite({ company: 'Northwind Traders', date: null, reqId: null }, rows);
+eq('all three same-company candidates are returned, not just the top one', result.length, 3);
+eq('Interview-status row ranks first among same-name candidates', result[0].appNumber, 202);
+eq('Rejected-status row ranks last among same-name candidates', result[result.length - 1].appNumber, 203);
+
+// A company name that only partially overlaps (e.g. recruiter drops a
+// division name) must still resolve, but must not outrank an exact match
+// when both are present in the tracker.
+const mixedRows = [
+  ...rows,
+  { num: 204, company: 'Northwind', role: 'Coordinator', status: 'Applied', date: '2026-06-01', notes: '' },
+];
+const partial = matchInvite({ company: 'Northwind', date: null, reqId: null }, mixedRows);
+eq('exact "Northwind" match outranks the longer "Northwind Traders" partial matches', partial[0].appNumber, 204);
+
+// normalizeCompanyName must be idempotent — normalizing an already-normalized
+// string must return it unchanged, otherwise repeated normalization could
+// drift the matching key across call sites.
+const once = normalizeCompanyName('Acme Technologies Inc.');
+eq('normalizeCompanyName is idempotent', normalizeCompanyName(once), once);
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  console.log('Failures:', failures.join(', '));
+  process.exit(1);
+}

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -67,6 +67,13 @@ const reqIdRows = [
 const reqIdResult = matchInvite({ company: 'Fabrikam', date: null, reqId: 'R-4821' }, reqIdRows);
 eq('row with matching reqId in notes outranks identical-name row without it', reqIdResult[0].appNumber, 302);
 
+// The req-ID boost must be case-insensitive: the invite and the tracker
+// notes may case the same ID differently ("r-4821" vs "R-4821"), and a
+// casing mismatch silently dropping the strongest signal is exactly the
+// kind of regression this suite exists to catch.
+const reqIdCaseResult = matchInvite({ company: 'Fabrikam', date: null, reqId: 'r-4821' }, reqIdRows);
+eq('reqId boost still applies when invite cases the ID differently than the notes', reqIdCaseResult[0].appNumber, 302);
+
 // Two distinct companies that each end in a *different pair* of chained
 // generic descriptor words must not erode down to the same root — this is
 // the actual over-stripping bug raised on PR #1497: chaining generic-word

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -56,6 +56,30 @@ eq('exact "Northwind" match outranks the longer "Northwind Traders" partial matc
 const once = normalizeCompanyName('Acme Technologies Inc.');
 eq('normalizeCompanyName is idempotent', normalizeCompanyName(once), once);
 
+// A req ID that appears verbatim in a row's notes must outrank a same-name
+// row without it, even though both have identical name similarity — this is
+// the strongest disambiguation signal the matcher has, so it must actually
+// move the ranking, not just add a negligible tiebreaker.
+const reqIdRows = [
+  { num: 301, company: 'Fabrikam', role: 'Engineer', status: 'Applied', date: '2026-05-01', notes: '' },
+  { num: 302, company: 'Fabrikam', role: 'Engineer II', status: 'Applied', date: '2026-05-02', notes: 'req R-4821 mentioned' },
+];
+const reqIdResult = matchInvite({ company: 'Fabrikam', date: null, reqId: 'R-4821' }, reqIdRows);
+eq('row with matching reqId in notes outranks identical-name row without it', reqIdResult[0].appNumber, 302);
+
+// Two distinct companies that each end in a *different pair* of chained
+// generic descriptor words must not erode down to the same root — this is
+// the actual over-stripping bug raised on PR #1497: chaining generic-word
+// removal (not just legal-suffix removal) let "X Solutions Group" and
+// "X Technologies Holdings" both collapse all the way to "x". Limiting
+// generic-descriptor stripping to a single, non-chained pass stops at the
+// first strip instead of eating through both words.
+eq(
+  'chained generic descriptors ("Solutions Group" vs "Technologies Holdings") do not erode to the same key',
+  normalizeCompanyName('Northwind Solutions Group') === normalizeCompanyName('Northwind Technologies Holdings'),
+  false
+);
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) {
   console.log('Failures:', failures.join(', '));

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "patterns": "node analyze-patterns.mjs",
     "add": "node add-entry.mjs",
     "reposts": "node detect-reposts.mjs",
+    "invite-match": "node invite-match.mjs",
     "gemini:eval": "node gemini-eval.mjs",
     "ollama:eval": "node ollama-eval.mjs",
     "openai:eval": "node openai-eval.mjs",

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -161,6 +161,8 @@ const SYSTEM_PATHS = [
   'salary-gap.mjs',
   'followup-cadence.mjs',
   'followup-cadence.test.mjs',
+  'invite-match.mjs',
+  'invite-match.test.mjs',
   'agent-inbox.mjs',
   'followup-seed.mjs',
   'followup-seed-tests.mjs',


### PR DESCRIPTION
Closes #1495.

## Problem

Interview invite emails frequently don't state the job title or req number — only the company name and maybe a date. Matching the invite back to the right `data/applications.md` entry currently requires a manual grep every time.

## Approach

`invite-match.mjs` extracts a company name (plus an optional date and req/job-ID-looking token) from pasted invite text and fuzzy-matches it against the tracker's Company column:

- Company names are normalized (lowercased, punctuation/parentheticals stripped, corporate suffixes like Inc/Corp/LLC/Technologies chained-stripped) so "Acme Corp." and "Acme Technologies Inc." both collapse to "acme".
- Matching uses a Dice-coefficient token overlap rather than raw substring containment, so an exact-name tracker row outranks a longer partial-name row for the same company (e.g. "Acme" vs. "Acme Regional Office").
- When a company has multiple tracker rows (common — this happens whenever someone applies to the same company more than once), **all plausible candidates are returned, ranked** rather than picking one: active statuses (Interview/Responded/Applied) outrank closed ones (Rejected/Discarded), and a req ID found verbatim in a row's notes boosts that row further. A silent wrong guess is worse than a short ranked list.
- Follows the `followup-cadence.mjs` / `detect-reposts.mjs` precedent already in this repo: standalone `.mjs`, exported pure functions, JSON stdout by default, `--summary` for a human-readable table, `--self-test` with inline fixtures (so no real tracker data is needed or shipped), CLI execution guarded by the `import.meta.url` pattern so the module stays cleanly importable for tests.

## Usage

```
node invite-match.mjs < invite.txt
node invite-match.mjs --file invite.txt --summary
node invite-match.mjs --self-test
```

## Files

- `invite-match.mjs` — the matcher
- `invite-match.test.mjs` — focused regression tests for the ranking logic most likely to silently drift (status-priority ordering, exact-vs-partial name match ranking)
- Registered in `update-system.mjs` `SYSTEM_PATHS`, `package.json` (`npm run invite-match`), `docs/SCRIPTS.md`, `AGENTS.md`

## Test plan

- [x] `node invite-match.mjs --self-test` — 28/28 passed
- [x] `node invite-match.test.mjs` — 5/5 passed
- [x] `node validate-system-paths-coverage.mjs` — 541 files covered (was 539 before this PR's two new tracked files)
- [x] `node test-all.mjs --quick` — 1132/1133 passed; the 1 failure is a pre-existing, unrelated Windows temp-dir `ENOENT` in the batch rate-limit test — verified it also fails on a clean `upstream/main` checkout with none of this PR's changes applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `invite-match` command to fuzzy-match interview-invite text (company/date/ID signals) against tracked applications and rank likely candidates.
  * Supports JSON output or a human-readable top summary table.
* **Tests**
  * Added regression tests for matching and ranking, company-name normalization, and req-ID boosting.
* **Documentation**
  * Updated guides/quick reference to document the new `invite-match` command.
* **Chores**
  * Included `invite-match.mjs` and its tests in the system-path allowlist for the standard update workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->