### PR TITLE
feat(providers): add Dassault Systèmes provider (Exalead card_search_api)

### DIFF
--- a/providers/dassault.mjs
+++ b/providers/dassault.mjs
@@ -1,0 +1,201 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Dassault Systèmes provider — hits the public Exalead "card search" API that
+// powers www.3ds.com/careers/jobs. Single-company provider (like ibm.mjs): the
+// endpoint is global to 3ds.com, so there's no per-tenant config.
+//
+//   GET https://www.3ds.com/apisearch/card_search_api
+//       ?lang=en
+//       &r=f/card_content_type/career                          # only career cards
+//       &r=f/card_content_categories_facet/cards language/en   # only the English copy
+//       &start={offset}                                        # 0-based, 10 hits/page
+//
+// The response is Exalead XML (Content-Type: application/javascript), not JSON.
+// We don't need a real XML parser — each posting is one <Hit>…</Hit> block whose
+// fields are <Meta name="…"><MetaString name="value">…</MetaString> pairs.
+//
+// Why BOTH refinements matter (learned the hard way):
+//   * The `type=career` URL shorthand returns a *global* career-content index
+//     (~43k hits) where Dassault's own jobs are a small minority ranked first and
+//     the rest is third-party aggregated content (bcit.ca, dejobs.org, …). Using
+//     the proper `f/card_content_type/career` facet instead narrows to Dassault's
+//     own postings (5340 hits, every cta_1 URL on 3ds.com).
+//   * Without the language refinement each job is duplicated across ~12 languages.
+//     `cards language/en` collapses that to the 445 English postings.
+// As a safety net we still keep only hits whose public URL is on *.3ds.com, so a
+// future index change can't leak foreign postings back in.
+//
+// The Taleo apply backend (talentacquisition.3ds.com) is out of scope — we list
+// from Exalead and link to the public 3ds.com job page.
+
+const BASE = 'https://www.3ds.com/apisearch/card_search_api';
+const REFINES = ['f/card_content_type/career', 'f/card_content_categories_facet/cards language/en'];
+const PAGE_SIZE = 10; // Exalead returns 10 hits/page
+const MAX_PAGES = 60; // safety cap on request count (~600 postings; the en set is ~445)
+const MAX_JOBS = 1000; // cap total postings pulled
+
+/** @param {number} start */
+export function buildUrl(start) {
+  const p = new URLSearchParams();
+  p.set('lang', 'en'); // keeps facet labels (Country/City/…) in English
+  for (const r of REFINES) p.append('r', r);
+  p.set('start', String(start));
+  return `${BASE}?${p.toString()}`;
+}
+
+// Minimal HTML entity decoder — titles/URLs/locations carry named (&amp;, &apos;)
+// and numeric (&#252; / &#xfc;) entities. Mirrors successfactors.mjs.
+const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+/** @param {string} s */
+function decodeEntities(s) {
+  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
+    if (body[0] === '#') {
+      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : m;
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
+  });
+}
+
+// Pull every <Meta name="X"><MetaString name="value">V</MetaString> pair from one
+// <Hit> block into a Map. First value per name wins.
+/** @param {string} hitXml @returns {Map<string,string>} */
+function metaMap(hitXml) {
+  const map = new Map();
+  const re = /<Meta name="([^"]+)"[^>]*>\s*<MetaString[^>]*name="value"[^>]*>([\s\S]*?)<\/MetaString>/g;
+  let m;
+  while ((m = re.exec(hitXml)) !== null) {
+    if (!map.has(m[1])) map.set(m[1], m[2]);
+  }
+  return map;
+}
+
+// content_categories is a flat "Label/Value Label/Value …" string. Values can hold
+// spaces and commas ("United Kingdom, Cambridge"), so we can't split on whitespace —
+// we anchor on the known label tokens and slice each value up to the next label.
+// Labels come back localized even at lang=en in some responses (the API has been
+// seen emitting Spanish País/Ciudad), so we accept the common locale variants.
+const LOC_LABELS = [
+  'Category', 'Type', 'Country', 'City', 'Products', 'Year', // en
+  'Categoría', 'Categoria', 'Tipo', 'País', 'Pais', 'Ciudad', 'Productos', 'Año', 'Ano', 'Área', 'Area', // es
+  'Catégorie', 'Pays', 'Ville', 'Produits', 'Année', 'Annee', // fr
+];
+const CITY_LABELS = new Set(['City', 'Ciudad', 'Ville']);
+const COUNTRY_LABELS = new Set(['Country', 'País', 'Pais', 'Pays']);
+const LABEL_RE = new RegExp('(^|\\s)(' + LOC_LABELS.join('|') + ')\\/', 'g');
+
+/** @param {string} categories @returns {{city: string, country: string}} */
+function parseCategories(categories) {
+  const marks = [];
+  let m;
+  LABEL_RE.lastIndex = 0;
+  while ((m = LABEL_RE.exec(categories)) !== null) {
+    marks.push({ label: m[2], keyStart: m.index + m[1].length, valStart: m.index + m[0].length });
+  }
+  let city = '';
+  let country = '';
+  for (let i = 0; i < marks.length; i++) {
+    const end = i + 1 < marks.length ? marks[i + 1].keyStart : categories.length;
+    const value = decodeEntities(categories.slice(marks[i].valStart, end)).trim();
+    if (!city && CITY_LABELS.has(marks[i].label)) city = value;
+    else if (!country && COUNTRY_LABELS.has(marks[i].label)) country = value;
+  }
+  return { city, country };
+}
+
+// "2026/07/03 18:22:13" → epoch ms (parsed as UTC so it's deterministic across
+// machine timezones; the API doesn't state a zone, and consumers only use this
+// for coarse recency ranking).
+/** @param {string} ts @returns {number | undefined} */
+function toEpochMs(ts) {
+  const m = /^(\d{4})\/(\d{2})\/(\d{2})[ T](\d{2}):(\d{2}):(\d{2})/.exec((ts || '').trim());
+  if (!m) return undefined;
+  const [, y, mo, d, h, mi, s] = m.map(Number);
+  const ms = Date.UTC(y, mo - 1, d, h, mi, s);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+/**
+ * Parse one Exalead card-search XML page into normalized jobs.
+ * Deduped by card_id within the page; the fetch loop dedups again across pages.
+ * Keeps only real Dassault-hosted postings (public URL on *.3ds.com).
+ * @param {string} xml @param {string} entryName
+ * @returns {Array<{title: string, url: string, company: string, location: string, postedAt?: number, _id: string}>}
+ */
+export function parseHits(xml, entryName) {
+  const hits = typeof xml === 'string' ? xml.match(/<Hit\b[\s\S]*?<\/Hit>/g) : null;
+  if (!hits) return [];
+
+  const byId = new Map();
+  for (const hit of hits) {
+    const meta = metaMap(hit);
+    const title = decodeEntities((meta.get('content_title') || '').replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
+    const url = decodeEntities((meta.get('content_cta_1_url') || '').trim());
+    if (!title || !url) continue;
+
+    // Safety net: only accept postings hosted on 3ds.com. The refined query
+    // already guarantees this, but a broadened index must never leak through.
+    let host;
+    try {
+      host = new URL(url).host.toLowerCase();
+    } catch {
+      continue;
+    }
+    if (host !== '3ds.com' && !host.endsWith('.3ds.com')) continue;
+
+    const { city, country } = parseCategories(meta.get('content_categories') || '');
+    const postedAt = toEpochMs(meta.get('content_start_datetime') || meta.get('card_update_timestamp') || '');
+    // card_id is the natural dedup key; fall back to the URL when absent.
+    const id = (meta.get('card_id') || '').trim() || url;
+    if (byId.has(id)) continue;
+
+    const job = { title, url, company: entryName || 'Dassault Systèmes', location: city || country, _id: id };
+    if (postedAt !== undefined) job.postedAt = postedAt;
+    byId.set(id, job);
+  }
+  return [...byId.values()];
+}
+
+/** @type {Provider} */
+export default {
+  id: 'dassault',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    // Match the host, not a path segment, so evil.com/x.3ds.com can't spoof it.
+    try {
+      const host = new URL(url).host.toLowerCase();
+      if (host === '3ds.com' || host.endsWith('.3ds.com')) return { url };
+    } catch {
+      /* not an absolute URL */
+    }
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const jobs = [];
+    const seen = new Set();
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const xml = await ctx.fetchText(buildUrl(page * PAGE_SIZE), {
+        redirect: 'error',
+        headers: { accept: 'application/xml, text/xml, */*' },
+      });
+      const parsed = parseHits(xml, entry.name);
+      if (parsed.length === 0) break; // past the last page
+
+      let fresh = 0;
+      for (const job of parsed) {
+        if (seen.has(job._id)) continue;
+        seen.add(job._id);
+        fresh++;
+        const { _id, ...clean } = job; // drop the internal dedup key
+        jobs.push(clean);
+      }
+      if (fresh === 0) break; // server ignored the offset / looped
+      if (jobs.length >= MAX_JOBS) break;
+    }
+    return jobs;
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -628,6 +628,11 @@ search_queries:
 #     categories: ["Software Engineering"]  # optional facet filter
 #   enabled: true
 #
+# - name: Dassault Systèmes              # single-company; Exalead card_search_api
+#   careers_url: https://www.3ds.com/careers/jobs   # auto-detects on *.3ds.com
+#   provider: dassault                    # optional — 3ds.com host also auto-detects
+#   enabled: true                         # ~445 English postings (zero-token XML)
+#
 # -- Remote-job feeds (no careers_url, no extra fields) --
 # title_filter / location_filter defined above still apply.
 #

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -11148,6 +11148,130 @@ try {
   fail(`avature provider tests crashed: ${e.message}`);
 }
 
+console.log('\n57. Provider — dassault (Exalead card_search_api XML parser)');
+try {
+  const dassault = (await import(pathToFileURL(join(ROOT, 'providers/dassault.mjs')).href)).default;
+  const { parseHits, buildUrl } = await import(pathToFileURL(join(ROOT, 'providers/dassault.mjs')).href);
+
+  if (dassault.id === 'dassault') pass('dassault.id is "dassault"');
+  else fail(`dassault.id is ${JSON.stringify(dassault.id)}`);
+
+  // Build a minimal Exalead <Hit> block from field values.
+  const mkHit = (f) => {
+    const meta = (n, v) => (v === undefined ? '' : `<Meta name="${n}"><MetaString name="value">${v}</MetaString></Meta>`);
+    return `<Hit did="d" url="x">${'<groups>ignored</groups>'}<metas>` +
+      meta('content_title', f.title) +
+      meta('content_cta_1_url', f.cta1) +
+      meta('content_categories', f.cats) +
+      meta('card_id', f.id) +
+      meta('content_start_datetime', f.start) +
+      meta('card_update_timestamp', f.update) +
+      `</metas></Hit>`;
+  };
+
+  // Happy path — 2 distinct hits: entity decode, location parse, date fields.
+  const xmlA = `<Answer nhits="2"><hits>` +
+    mkHit({ id: '111', title: 'Software Engineer &amp; Data', cta1: 'https://www.3ds.com/careers/jobs/x-111?a=1&amp;b=2', cats: 'Category/R&amp;D Type/Regular Country/Germany City/Germany, Munich Products/CATIA Year/4 to 5 years', update: '2026/07/03 18:22:13' }) +
+    mkHit({ id: '222', title: 'Data Scientist', cta1: 'https://www.3ds.com/careers/jobs/y-222', cats: 'Category/Sales Type/Regular Country/France City/France, Vélizy-Villacoublay Products/DELMIA', start: '2026/06/01 09:00:00' }) +
+    `</hits></Answer>`;
+  const a = parseHits(xmlA, 'Dassault Systèmes');
+  if (a.length === 2) pass('dassault.parseHits() extracts 2 jobs');
+  else fail(`dassault.parseHits() returned ${a.length} jobs`);
+
+  if (a[0]?.title === 'Software Engineer & Data') pass('dassault.parseHits() decodes &amp; in title');
+  else fail(`title = ${JSON.stringify(a[0]?.title)}`);
+
+  if (a[0]?.url === 'https://www.3ds.com/careers/jobs/x-111?a=1&b=2') pass('dassault.parseHits() decodes &amp; in url');
+  else fail(`url = ${JSON.stringify(a[0]?.url)}`);
+
+  if (a[0]?.location === 'Germany, Munich') pass('dassault.parseHits() parses City from content_categories');
+  else fail(`location = ${JSON.stringify(a[0]?.location)}`);
+
+  if (a[0]?.company === 'Dassault Systèmes') pass('dassault.parseHits() sets company from entry name');
+  else fail(`company = ${JSON.stringify(a[0]?.company)}`);
+
+  // postedAt: hit 0 falls back to card_update_timestamp; hit 1 prefers content_start_datetime.
+  if (a[0]?.postedAt === Date.UTC(2026, 6, 3, 18, 22, 13)) pass('dassault.parseHits() postedAt falls back to card_update_timestamp');
+  else fail(`postedAt[0] = ${JSON.stringify(a[0]?.postedAt)}`);
+
+  if (a[1]?.postedAt === Date.UTC(2026, 5, 1, 9, 0, 0)) pass('dassault.parseHits() postedAt prefers content_start_datetime');
+  else fail(`postedAt[1] = ${JSON.stringify(a[1]?.postedAt)}`);
+
+  if (a[1]?.location === 'France, Vélizy-Villacoublay') pass('dassault.parseHits() parses multi-word City value');
+  else fail(`location[1] = ${JSON.stringify(a[1]?.location)}`);
+
+  // parseHits carries an internal _id for cross-page dedup; fetch() strips it (asserted below).
+  if ('_id' in a[0]) pass('dassault.parseHits() exposes internal _id for cross-page dedup');
+  else fail('dassault.parseHits() should carry _id for the fetch loop');
+
+  // Dedup by card_id — two hits with the same id collapse to one job.
+  const xmlDup = `<Answer><hits>` +
+    mkHit({ id: '333', title: 'Role A', cta1: 'https://www.3ds.com/careers/jobs/a-333' }) +
+    mkHit({ id: '333', title: 'Role A (dup)', cta1: 'https://www.3ds.com/careers/jobs/a-333' }) +
+    `</hits></Answer>`;
+  const dup = parseHits(xmlDup, 'Dassault Systèmes');
+  if (dup.length === 1) pass('dassault.parseHits() dedups by card_id');
+  else fail(`dassault.parseHits() dedup returned ${dup.length} jobs`);
+
+  // Safety net — a non-3ds.com posting (aggregated third-party content) is dropped.
+  const xmlForeign = `<Answer><hits>` +
+    mkHit({ id: '444', title: 'Real 3DS Job', cta1: 'https://www.3ds.com/careers/jobs/real-444' }) +
+    mkHit({ id: 'abc', title: 'External Aggregated Job', cta1: 'https://careers.bcit.ca/postings/10516' }) +
+    `</hits></Answer>`;
+  const foreign = parseHits(xmlForeign, 'Dassault Systèmes');
+  if (foreign.length === 1 && foreign[0].title === 'Real 3DS Job') pass('dassault.parseHits() drops non-3ds.com postings');
+  else fail(`dassault.parseHits() foreign filter returned ${JSON.stringify(foreign.map(j => j.title))}`);
+
+  // Empty / hit-less XML → []
+  if (parseHits('', 'X').length === 0 && parseHits('<Answer nhits="0"><hits></hits></Answer>', 'X').length === 0) {
+    pass('dassault.parseHits() returns [] for empty / hit-less XML');
+  } else {
+    fail('dassault.parseHits() should return [] for empty / hit-less XML');
+  }
+
+  // buildUrl — both refinements + start offset, correctly encoded.
+  const u = buildUrl(20);
+  if (u.includes('start=20') && u.includes('card_content_type%2Fcareer') && u.includes('cards+language%2Fen')) {
+    pass('dassault.buildUrl() emits both refinements and the start offset');
+  } else {
+    fail(`dassault.buildUrl(20) = ${u}`);
+  }
+
+  // detect — *.3ds.com matches by host; spoofs and non-strings return null.
+  if (dassault.detect({ careers_url: 'https://www.3ds.com/careers/jobs' })) pass('dassault.detect() matches www.3ds.com');
+  else fail('dassault.detect() should match www.3ds.com');
+
+  if (dassault.detect({ api: 'https://talentacquisition.3ds.com/x' })) pass('dassault.detect() matches *.3ds.com subdomains');
+  else fail('dassault.detect() should match *.3ds.com');
+
+  if (dassault.detect({ careers_url: 'https://evil.com/x.3ds.com' }) === null) pass('dassault.detect() rejects path-spoofed host');
+  else fail('dassault.detect() should reject path-spoofed host');
+
+  if (dassault.detect({ careers_url: 'https://3ds.com.evil.com/x' }) === null) pass('dassault.detect() rejects suffix-spoofed host');
+  else fail('dassault.detect() should reject suffix-spoofed host');
+
+  if (dassault.detect({ careers_url: 42 }) === null && dassault.detect({}) === null) pass('dassault.detect() returns null for non-string / missing url');
+  else fail('dassault.detect() should return null for non-string / missing url');
+
+  // fetch — paginates via mock ctx, dedups across pages, stops on empty page.
+  const pages = [
+    `<Answer><hits>${mkHit({ id: 'p1', title: 'A', cta1: 'https://www.3ds.com/careers/jobs/a-p1' })}${mkHit({ id: 'p2', title: 'B', cta1: 'https://www.3ds.com/careers/jobs/b-p2' })}</hits></Answer>`,
+    `<Answer><hits>${mkHit({ id: 'p2', title: 'B dup', cta1: 'https://www.3ds.com/careers/jobs/b-p2' })}${mkHit({ id: 'p3', title: 'C', cta1: 'https://www.3ds.com/careers/jobs/c-p3' })}</hits></Answer>`,
+    `<Answer><hits></hits></Answer>`,
+  ];
+  let calls = 0;
+  const mockCtx = { fetchText: async () => pages[calls++] ?? '<Answer><hits></hits></Answer>' };
+  const fetched = await dassault.fetch({ name: 'Dassault Systèmes' }, mockCtx);
+  if (fetched.length === 3 && new Set(fetched.map(j => j.url)).size === 3) pass('dassault.fetch() paginates and dedups across pages');
+  else fail(`dassault.fetch() returned ${fetched.length} jobs (${JSON.stringify(fetched.map(j => j.title))})`);
+
+  if (fetched.every(j => !('_id' in j))) pass('dassault.fetch() strips the internal _id from returned jobs');
+  else fail('dassault.fetch() leaked _id into returned jobs');
+
+} catch (e) {
+  fail(`dassault provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What

Adds `providers/dassault.mjs` — a zero-token provider for **Dassault Systèmes'** public careers listing, closing the scanner's `no provider matched` skip for Dassault. Single-company provider in the spirit of `ibm.mjs`.

Dassault's public job list at `www.3ds.com/careers/jobs` is served by the **Exalead "card search" API** (`/apisearch/card_search_api`) — the response is **XML** (`Content-Type: application/javascript`), not JSON. The Taleo apply backend (`talentacquisition.3ds.com`) is out of scope; we list from Exalead and link to the public `3ds.com` job page.

## Query design (verified live against the API)

The naive `type=career` URL shorthand returns a **global career-content index** (~43k hits) dominated by third-party aggregated postings (`bcit.ca`, `dejobs.org`, Bombardier…), with Dassault's own jobs a small minority ranked first. Two refinements fix this:

- `r=f/card_content_type/career` — the proper content-type facet → narrows to Dassault's own postings (every `content_cta_1_url` on `3ds.com`).
- `r=f/card_content_categories_facet/cards language/en` — collapses the ~12-language duplication down to the **445 English postings** (`nhits=445`, all unique `card_id`, all `3ds.com`-hosted).

As a safety net, `parseHits` keeps only hits whose public URL is on `*.3ds.com`, so a future index change can't leak foreign postings back in.

## Parsing

Mirrors `successfactors.mjs`: iterate `<Hit>…</Hit>` blocks, pull `<Meta><MetaString>` pairs into a map, decode HTML entities, parse location out of the flat `content_categories` string (tolerant of localized labels — the API has been seen emitting Spanish `País/Ciudad`), and derive `postedAt` from `content_start_datetime` (fallback `card_update_timestamp`, parsed as UTC for determinism). Dedup by `card_id` within a page and by `url` across pages.

## Tests

Adds a **hermetic** test section (no network) covering: entity decode in title/URL, `content_categories` location parse (incl. multi-word city), both date fields + fallback, `card_id` dedup, the non-`3ds.com` safety filter, URL encoding of both refinements, host-based `detect()` (incl. path/suffix spoof rejection and non-string input), and cross-page pagination/dedup via a mock `ctx`. Full suite: **0 failed**.

Also documents the provider with a commented stanza in `templates/portals.example.yml`.

## Scan result (Dassault Systèmes)

- **Before:** skipped — `no provider matched`.
- **After:** matched, **445 postings** fetched (zero-token); after a PLM/leadership title filter this yields the expected handful of DACH survivors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Dassault Systèmes careers source.
  * Included a sample configuration showing how to enable this provider.
* **Bug Fixes**
  * Improved job result handling with better location, title, date, and URL normalization.
  * Added safeguards to avoid duplicate postings and filter out unrelated listings.
  * Enhanced detection and pagination behavior to return more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->