### PR TITLE
fix(test-all): try cygpath before wslpath in toBashPath()

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -113,16 +113,23 @@ const BASH = (() => {
 
 function toBashPath(wpath) {
   if (process.platform !== 'win32') return wpath;
+  const forwardSlashed = wpath.replace(/\\/g, '/');
+  // Try cygpath first: it ships with Git for Windows, which is also what
+  // provides `bash` on PATH on most Windows dev machines (see BASH const
+  // above). cygpath emits /c/... paths that match Git Bash's mount scheme.
+  // wslpath emits /mnt/c/... paths, which only resolve inside WSL's own
+  // bash -- if WSL happens to be installed but `bash` on PATH still
+  // resolves to Git Bash, a wslpath-first order silently produces a path
+  // Git Bash can't find (see #1409). Only fall back to wslpath (and only
+  // pay the cost of booting the WSL VM) when cygpath is unavailable.
   try {
-    execSync('wsl -e bash -c "true"', { stdio: 'ignore' });
-    const forwardSlashed = wpath.replace(/\\/g, '/');
-    const out = execSync(`wsl wslpath -u "${forwardSlashed}"`, { stdio: ['pipe', 'pipe', 'ignore'] }).toString().trim();
+    const cygpathCmd = existsSync('C:\\Program Files\\Git\\usr\\bin\\cygpath.exe') ? '"C:\\Program Files\\Git\\usr\\bin\\cygpath.exe"' : 'cygpath';
+    const out = execSync(`${cygpathCmd} -u "${forwardSlashed}"`, { stdio: ['pipe', 'pipe', 'ignore'] }).toString().trim();
     if (out) return out;
   } catch {}
   try {
-    const forwardSlashed = wpath.replace(/\\/g, '/');
-    const cygpathCmd = existsSync('C:\\Program Files\\Git\\usr\\bin\\cygpath.exe') ? '"C:\\Program Files\\Git\\usr\\bin\\cygpath.exe"' : 'cygpath';
-    const out = execSync(`${cygpathCmd} -u "${forwardSlashed}"`, { stdio: ['pipe', 'pipe', 'ignore'] }).toString().trim();
+    execSync('wsl -e bash -c "true"', { stdio: 'ignore' });
+    const out = execSync(`wsl wslpath -u "${forwardSlashed}"`, { stdio: ['pipe', 'pipe', 'ignore'] }).toString().trim();
     if (out) return out;
   } catch {}
   return wpath.replace(/^[A-Za-z]:/, m => '/' + m[0].toLowerCase()).replace(/\\/g, '/');


### PR DESCRIPTION
## Summary

Closes #1409.

`toBashPath()` in `test-all.mjs` tried `wsl wslpath -u` first and only fell back to `cygpath`. When WSL is installed, `wslpath` succeeds and returns a WSL-style path (`/mnt/c/Users/...`), but the batch test spawns `run('bash', [toBashPath(...)])`, and `bash` resolves via PATH to **Git Bash** (`C:\Program Files\Git\usr\bin\bash.exe`), which mounts drives at `/c/...` — not `/mnt/c/...`. The path style and the bash consuming it disagreed exactly when WSL was present, `run()` swallowed the resulting error, `batch-state.tsv` was never written, and the "Batch rate-limit pause" test crashed with `ENOENT`.

This implements the fix suggested in the issue by @rrraadddii, who correctly diagnosed the root cause: swap the order so `cygpath` (which ships with Git for Windows — the same toolchain that provides `bash` on PATH on most Windows dev machines) is tried first, falling back to `wslpath` only if `cygpath` is unavailable. This also avoids the side effect of booting the WSL VM on every test run when `cygpath` is present.

## Verification

I have a Windows 11 + WSL2 (Ubuntu) machine with Git Bash first on PATH — the exact configuration described in the issue — so I reproduced this directly rather than just reading the code:

- `wsl wslpath -u` on a Temp path → `/mnt/c/Users/.../co-test-1409.sh` → running that through the PATH-resolved `bash` (Git Bash) → `No such file or directory`, exit 127.
- `cygpath -u` on the same path → `/c/Users/.../co-test-1409.sh` → running that through the same `bash` → executes cleanly, exit 0.

After the fix, `node test-all.mjs` reproduces the exact scenario from the issue and passes:

```
13. Batch rate-limit pause
  ✅ session-limit pauses batch without consuming retry budget or scheduling more jobs
  ✅ --resume-paused dry-run selects paused jobs only
  ✅ --status reads existing state without full batch prerequisites
```

Full suite: `1134 passed, 0 failed, 1 warnings` (the one warning is a pre-existing, unrelated workday `max_pages` note, not a regression).

## Test plan

- [x] `node test-all.mjs` — full suite passes on Windows 11 + WSL2 (Ubuntu), Git Bash first on PATH
- [x] Manually reproduced the `/mnt/c` vs `/c` path mismatch and confirmed cygpath-first resolves it
- [x] Confirmed no other callers of `toBashPath()` depend on WSL-style path output (only the batch-runner tests call it, and they consume whatever `bash` on PATH actually is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path handling so file paths are more reliably converted to bash-style paths.
  * Prioritized a more appropriate conversion path first, with a fallback for environments where that option is unavailable.
  * Normalized path separators earlier to avoid incorrect path results in some Windows setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->