### PR TITLE
fix: load .env in scan.mjs

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -40,6 +40,13 @@ import { buildTrustValidator } from './providers/_trust-validator.mjs';
 import { mergeProviderPlugins } from './plugins/_engine.mjs';
 import { classifyFetchError } from './verify-portals.mjs';
 
+try {
+  const { config } = await import('dotenv');
+  config();
+} catch {
+  // dotenv is optional — fall back to process.env if not installed
+}
+
 const parseYaml = yaml.load;
 
 // ── Config ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `scan.mjs` never called `dotenv.config()`, so credentials in `.env` (`ADZUNA_APP_ID`/`APP_KEY`, `REED_API_KEY`, `APIFY_API_KEY`) were silently ignored unless already exported in the shell — affected providers report "missing credentials" even with a correctly filled-in `.env`.
- `gemini-eval.mjs` already loads dotenv this way; this brings `scan.mjs` in line with that existing pattern. Falls back silently to `process.env` if `dotenv` isn't installed.

## Test plan
- [x] `node scan.mjs` with valid `.env` values for `ADZUNA_APP_ID`/`APP_KEY`, `REED_API_KEY`, `APIFY_API_KEY` and no shell-exported equivalents — confirmed all three providers pick up credentials and return real results instead of "missing credentials" errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior so scanning continues even when environment variable support is not installed.
  * Made the scan process more resilient by handling missing optional configuration automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->