### PR TITLE
Add career-ops-plugin-docx to the registry

### DIFF
--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -86,6 +86,20 @@
       "allowedHosts": [],
       "registrationIssue": "https://github.com/santifer/career-ops/issues/1412",
       "addedAt": "2026-07-02"
+    },
+    {
+      "name": "career-ops-plugin-docx",
+      "id": "docx",
+      "repo": "https://github.com/rubicon/career-ops-plugin-docx",
+      "author": "rubicon",
+      "hooks": ["export"],
+      "description": "Export your cv.md to a clean, ATS-friendly Word .docx, honoring #### nested sub-roles for fractional, interim, and umbrella engagements.",
+      "requiredEnv": [],
+      "allowedHosts": [],
+      "skill": true,
+      "license": "MIT",
+      "version": "0.1.0",
+      "sha": "9252dc84c09dbb597c995190b82322109cf84805"
     }
   ]
 }


### PR DESCRIPTION
## Plugin registry change

Home issue: #1508

Paste the registry entry (one object), pinned to the exact reviewed commit:

```json
{
  "name": "career-ops-plugin-docx",
  "id": "docx",
  "repo": "https://github.com/rubicon/career-ops-plugin-docx",
  "author": "rubicon",
  "hooks": ["export"],
  "description": "Export your cv.md to a clean, ATS-friendly Word .docx, honoring #### nested sub-roles for fractional, interim, and umbrella engagements.",
  "requiredEnv": [],
  "allowedHosts": [],
  "skill": true,
  "license": "MIT",
  "version": "0.1.0",
  "sha": "9252dc84c09dbb597c995190b82322109cf84805"
}
```

### Maintainer review checklist

- [ ] Naming `career-ops-plugin-<name>`; `id` == name minus the prefix
- [ ] Minimum files present (manifest.json, index.mjs, README.md, LICENSE)
- [ ] Manifest valid: apiVersion 1, `humanInTheLoop: true`, hooks subset of {provider, ingest, search, notify, export}, no apply/submit
- [ ] MIT-compatible LICENSE; no personal data in the repo
- [ ] Egress: `allowedHosts` are real public hosts; no IP literals / metadata / `*.internal`; no localhost without `allowsLocalhost` + a reason
- [ ] Static audit clean: no `child_process`/`playwright`/raw sockets/global `fetch`/`eval`/bare-dependency imports (egress only via `ctx.fetch`)
- [ ] No core-owned secrets in `requiredEnv`
- [ ] Reads PUBLIC data or the user's OWN account only, no centralized infrastructure, no auto-submit, no blind-apply
- [ ] No commercial / hosted-service / monetization wording
- [ ] If it ships a skill: domain-scoped, does not instruct the agent to edit core files, change scoring, reveal secrets, or act outside its hooks
- [ ] `sha` is pinned to the exact reviewed commit
- [ ] CI (`plugin-registry-validate`) is green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `docx` plugin to the plugin registry, enabling export of CV content to ATS-friendly Word documents.
  * The new plugin supports structured role hierarchies, including nested sub-roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->