### PR TITLE
Add application email draft mode

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -107,7 +107,7 @@ Available commands:
   /career-ops pdf       → PDF only, ATS-optimized CV
   /career-ops latex     → Export CV as LaTeX/Overleaf .tex
   /career-ops cover     → Cover letter: standalone JD paste or /career-ops cover {slug}
-  /career-ops email     → Formal application email draft (report/JD → subject + body + attachment checklist)
+  /career-ops email     → Formal application email draft (draft-only; never sends, submits, or clicks)
   /career-ops add       → Add a project/paper/role to your CV (fetch + preview + confirm)
   /career-ops training  → Evaluate course/cert against North Star
   /career-ops project   → Evaluate portfolio project idea

--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -4,7 +4,7 @@ description: AI job search command center -- evaluate offers, generate CVs, scan
 arguments: mode
 user_invocable: true
 user-invocable: true
-argument-hint: "[scan | deep | pdf | latex | cover | add | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | followup | update]"
+argument-hint: "[scan | deep | pdf | latex | cover | email | add | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | followup | update]"
 license: MIT
 ---
 
@@ -49,6 +49,7 @@ Determine the mode from `$mode`:
 | `interview/debrief` | `interview/debrief` |
 | `pdf` | `pdf` |
 | `latex` | `latex` |
+| `email` | `email` |
 | `training` | `training` |
 | `project` | `project` |
 | `tracker` | `tracker` |
@@ -81,6 +82,7 @@ Concrete equivalents for Codex prompt-driven sessions:
 /career-ops scan           ↔ "Run the career-ops scan mode and summarize new matches."
 /career-ops pipeline       ↔ "Run the career-ops pipeline mode for data/pipeline.md."
 /career-ops pdf            ↔ "Run the career-ops pdf mode for the latest evaluated role."
+/career-ops email          ↔ "Run the career-ops email mode for the latest evaluated role."
 /career-ops tracker        ↔ "Run the career-ops tracker mode and summarize the current statuses."
 ```
 
@@ -105,6 +107,7 @@ Available commands:
   /career-ops pdf       → PDF only, ATS-optimized CV
   /career-ops latex     → Export CV as LaTeX/Overleaf .tex
   /career-ops cover     → Cover letter: standalone JD paste or /career-ops cover {slug}
+  /career-ops email     → Formal application email draft (report/JD → subject + body + attachment checklist)
   /career-ops add       → Add a project/paper/role to your CV (fetch + preview + confirm)
   /career-ops training  → Evaluate course/cert against North Star
   /career-ops project   → Evaluate portfolio project idea
@@ -135,7 +138,7 @@ Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `p
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`
 
-Applies to: `tracker`, `agent-inbox`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`, `add`
+Applies to: `tracker`, `agent-inbox`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`, `email`, `add`
 
 ### Modes delegated to subagent:
 For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,7 +267,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Asks to evaluate offer | `oferta` |
 | Asks to compare offers | `ofertas` |
 | Wants LinkedIn outreach | `contacto` — identifies hiring manager, recruiter, or team peers via web search; drafts a ≤300-char message tailored to the contact type (recruiter / hiring manager / peer / interviewer) |
-| Wants a formal application email | `email` — drafts a subject, body, attachment checklist, and contact block from a report or JD; never sends email |
+| Wants a formal application email | `email` — draft-only subject, body, attachment checklist, and contact block from a report or JD; never sends, submits, or clicks anything |
 | Asks for company research | `deep` — generates a structured 6-axis research prompt covering AI strategy, recent moves, engineering culture, likely challenges, competitors, and the candidate's angle given their profile |
 | Preps for interview at specific company | `interview-prep` |
 | Wants a time-blocked prep plan for an upcoming interview | `interview/plan` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ There are two layers. Read `DATA_CONTRACT.md` for the full list.
 
 ## Source-of-Truth Boundary (CRITICAL)
 
-User-facing content (CV, cover letters, form answers, recruiter outreach, application form responses) is generated **exclusively** from these files plus statements the user makes directly in the current conversation:
+User-facing content (CV, cover letters, application emails, form answers, recruiter outreach, application form responses) is generated **exclusively** from these files plus statements the user makes directly in the current conversation:
 
 - `cv.md`
 - `article-digest.md`
@@ -267,6 +267,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Asks to evaluate offer | `oferta` |
 | Asks to compare offers | `ofertas` |
 | Wants LinkedIn outreach | `contacto` — identifies hiring manager, recruiter, or team peers via web search; drafts a ≤300-char message tailored to the contact type (recruiter / hiring manager / peer / interviewer) |
+| Wants a formal application email | `email` — drafts a subject, body, attachment checklist, and contact block from a report or JD; never sends email |
 | Asks for company research | `deep` — generates a structured 6-axis research prompt covering AI strategy, recent moves, engineering culture, likely challenges, competitors, and the candidate's angle given their profile |
 | Preps for interview at specific company | `interview-prep` |
 | Wants a time-blocked prep plan for an upcoming interview | `interview/plan` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ You can invoke the command center or any of its modes directly within your CLI:
 * `pdf` — Generate ATS-optimized CV PDF
 * `latex` — Export CV as LaTeX/Overleaf .tex
 * `cover` — Generate cover letter
-* `email` — Draft formal application email
+* `email` — Draft formal application email only; never sends, submits, or clicks
 * `interview-prep` — Generate interview preparation guide
 * `interview` — Onboarding/on-demand interview
 * `contacto` — Generate LinkedIn outreach message
@@ -260,7 +260,7 @@ Default modes are in `modes/` (English). Language-specific modes live in `modes/
 | Asks to evaluate offer | `oferta` |
 | Asks to compare offers | `ofertas` |
 | Wants LinkedIn outreach | `contacto` |
-| Wants a formal application email | `email` |
+| Wants a formal application email | `email` — draft-only; never sends, submits, or clicks anything |
 | Asks for company research | `deep` |
 | Preps for interview at specific company | `interview-prep` |
 | Wants interactive profile/CV onboarding | `interview` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ There are two layers. Read `DATA_CONTRACT.md` for the full list.
 
 ## Source-of-Truth Boundary (CRITICAL)
 
-User-facing content (CV, cover letters, form answers, recruiter outreach, application form responses) is generated **exclusively** from these files plus statements the user makes directly in the current conversation:
+User-facing content (CV, cover letters, application emails, form answers, recruiter outreach, application form responses) is generated **exclusively** from these files plus statements the user makes directly in the current conversation:
 
 - `cv.md`
 - `article-digest.md`
@@ -129,6 +129,7 @@ You can invoke the command center or any of its modes directly within your CLI:
 * `pdf` — Generate ATS-optimized CV PDF
 * `latex` — Export CV as LaTeX/Overleaf .tex
 * `cover` — Generate cover letter
+* `email` — Draft formal application email
 * `interview-prep` — Generate interview preparation guide
 * `interview` — Onboarding/on-demand interview
 * `contacto` — Generate LinkedIn outreach message
@@ -259,6 +260,7 @@ Default modes are in `modes/` (English). Language-specific modes live in `modes/
 | Asks to evaluate offer | `oferta` |
 | Asks to compare offers | `ofertas` |
 | Wants LinkedIn outreach | `contacto` |
+| Wants a formal application email | `email` |
 | Asks for company research | `deep` |
 | Preps for interview at specific company | `interview-prep` |
 | Wants interactive profile/CV onboarding | `interview` |

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -46,6 +46,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `modes/apply.md` | Application assistant instructions |
 | `modes/auto-pipeline.md` | Auto-pipeline instructions |
 | `modes/contacto.md` | LinkedIn outreach instructions |
+| `modes/email.md` | Formal application email draft instructions |
 | `modes/deep.md` | Research prompt instructions |
 | `modes/regional/*` | Regional market calibration modes |
 | `modes/ofertas.md` | Comparison instructions |

--- a/README.md
+++ b/README.md
@@ -105,12 +105,13 @@ Built by someone who used it to evaluate 740+ job offers, generate 100+ tailored
 | **Negotiation Scripts**  | Salary negotiation frameworks, geographic discount pushback, competing offer leverage                                                    |
 | **ATS PDF Generation**   | Keyword-injected CVs with Space Grotesk + DM Sans design                                                                                 |
 | **Cover Letter Generator** | Research-backed cover letters with keyword mirroring, four interactive angle prompts (why/problems/approach/tone), draft-in-chat approval gate, and A4 PDF via the same HTML + Playwright pipeline as CVs. Auto-drafts on every evaluation; complete and generate on demand via `/career-ops cover` |
+| **Application Email Drafts** | Formal recruiter/referral/cold application emails from a report or pasted JD, with subject line, attachment checklist, source-backed fit points, and a profile-driven contact block. Drafts only -- career-ops never sends email. |
 | **Portal Scanner**       | 45+ companies pre-configured (Anthropic, OpenAI, ElevenLabs, Retool, n8n...) + custom queries across Ashby, Greenhouse, Lever, Wellfound |
 | **Batch Processing**     | Parallel evaluation with headless CLI workers (`claude -p` / `opencode run`)                                                             |
 | **Dashboard TUI**        | Terminal UI to browse, filter, and sort your pipeline                                                                                    |
 | **Human-in-the-Loop**    | AI evaluates and recommends, you decide and act. The system never submits an application -- you always have the final call               |
 | **Pipeline Integrity**   | Automated merge, dedup, status normalization, health checks                                                                              |
-| **Beyond the CV**        | Company research ([`deep`](modes/deep.md)) surfaces AI strategy, recent moves, engineering culture, and the angle your profile should take. Contact discovery ([`contacto`](modes/contacto.md)) identifies the hiring manager, recruiter, or team peer worth reaching out to and drafts a ≤300-character LinkedIn message tuned to each contact type. Applications get you in the queue; research gets you a conversation. |
+| **Beyond the CV**        | Company research ([`deep`](modes/deep.md)) surfaces AI strategy, recent moves, engineering culture, and the angle your profile should take. Contact discovery ([`contacto`](modes/contacto.md)) identifies the hiring manager, recruiter, or team peer worth reaching out to and drafts a ≤300-character LinkedIn message tuned to each contact type. Formal application email drafts ([`email`](modes/email.md)) turn an evaluated report or pasted JD into a subject line, body, and attachment checklist without sending anything. Applications get you in the queue; research gets you a conversation. |
 
 ## Quick Start
 
@@ -279,6 +280,7 @@ Career-ops uses a shared command router. In CLIs that register slash commands, i
 /career-ops scan           → Scan portals for new offers
 /career-ops pdf            → Generate ATS-optimized CV
 /career-ops cover          → Cover letter generator (paste JD or /career-ops cover {slug})
+/career-ops email          → Formal application email draft (report/JD → subject + body + attachment checklist)
 /career-ops batch          → Batch evaluate multiple offers
 /career-ops tracker        → View application status
 /career-ops apply          → Fill application forms with AI
@@ -364,11 +366,12 @@ career-ops/
 ├── article-digest.md            # Your proof points (optional)
 ├── config/
 │   └── profile.example.yml      # Template for your profile
-├── modes/                       # 15 skill modes
+├── modes/                       # Skill modes
 │   ├── _shared.md               # Shared context (customize this)
 │   ├── oferta.md                # Single evaluation
 │   ├── pdf.md                   # PDF generation
 │   ├── cover.md                 # Cover letter generation
+│   ├── email.md                 # Formal application email drafts
 │   ├── scan.md                  # Portal scanner
 │   ├── batch.md                 # Batch processing
 │   └── ...

--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ Built by someone who used it to evaluate 740+ job offers, generate 100+ tailored
 | **Negotiation Scripts**  | Salary negotiation frameworks, geographic discount pushback, competing offer leverage                                                    |
 | **ATS PDF Generation**   | Keyword-injected CVs with Space Grotesk + DM Sans design                                                                                 |
 | **Cover Letter Generator** | Research-backed cover letters with keyword mirroring, four interactive angle prompts (why/problems/approach/tone), draft-in-chat approval gate, and A4 PDF via the same HTML + Playwright pipeline as CVs. Auto-drafts on every evaluation; complete and generate on demand via `/career-ops cover` |
-| **Application Email Drafts** | Formal recruiter/referral/cold application emails from a report or pasted JD, with subject line, attachment checklist, source-backed fit points, and a profile-driven contact block. Drafts only -- career-ops never sends email. |
+| **Application Email Drafts** | Formal recruiter/referral/cold application emails from a report or pasted JD, with subject line, attachment checklist, source-backed fit points, and a profile-driven contact block. Draft-only -- career-ops never sends, submits, or clicks anything. |
 | **Portal Scanner**       | 45+ companies pre-configured (Anthropic, OpenAI, ElevenLabs, Retool, n8n...) + custom queries across Ashby, Greenhouse, Lever, Wellfound |
 | **Batch Processing**     | Parallel evaluation with headless CLI workers (`claude -p` / `opencode run`)                                                             |
 | **Dashboard TUI**        | Terminal UI to browse, filter, and sort your pipeline                                                                                    |
 | **Human-in-the-Loop**    | AI evaluates and recommends, you decide and act. The system never submits an application -- you always have the final call               |
 | **Pipeline Integrity**   | Automated merge, dedup, status normalization, health checks                                                                              |
-| **Beyond the CV**        | Company research ([`deep`](modes/deep.md)) surfaces AI strategy, recent moves, engineering culture, and the angle your profile should take. Contact discovery ([`contacto`](modes/contacto.md)) identifies the hiring manager, recruiter, or team peer worth reaching out to and drafts a ≤300-character LinkedIn message tuned to each contact type. Formal application email drafts ([`email`](modes/email.md)) turn an evaluated report or pasted JD into a subject line, body, and attachment checklist without sending anything. Applications get you in the queue; research gets you a conversation. |
+| **Beyond the CV**        | Company research ([`deep`](modes/deep.md)) surfaces AI strategy, recent moves, engineering culture, and the angle your profile should take. Contact discovery ([`contacto`](modes/contacto.md)) identifies the hiring manager, recruiter, or team peer worth reaching out to and drafts a ≤300-character LinkedIn message tuned to each contact type. Formal application email drafts ([`email`](modes/email.md)) turn an evaluated report or pasted JD into a subject line, body, and attachment checklist without sending, submitting, or clicking anything. Applications get you in the queue; research gets you a conversation. |
 
 ## Quick Start
 
@@ -280,7 +280,7 @@ Career-ops uses a shared command router. In CLIs that register slash commands, i
 /career-ops scan           → Scan portals for new offers
 /career-ops pdf            → Generate ATS-optimized CV
 /career-ops cover          → Cover letter generator (paste JD or /career-ops cover {slug})
-/career-ops email          → Formal application email draft (report/JD → subject + body + attachment checklist)
+/career-ops email          → Formal application email draft (draft-only; never sends, submits, or clicks)
 /career-ops batch          → Batch evaluate multiple offers
 /career-ops tracker        → View application status
 /career-ops apply          → Fill application forms with AI

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -6,6 +6,9 @@ candidate:
   full_name: "Jane Smith"
   email: "jane@example.com"
   phone: "+1-555-0123"
+  # Optional. Used by `/career-ops email` contact blocks in markets where WeChat
+  # is an expected recruiting channel. Omit or leave blank if not applicable.
+  wechat: ""
   location: "San Francisco, CA"
   linkedin: "linkedin.com/in/janesmith"
   portfolio_url: "https://janesmith.dev"
@@ -128,6 +131,20 @@ cover_letter:
 # match the platform you're messaging on.
 # outreach:
 #   greeting_max_chars: 150
+
+# ── Application Email Drafts ────────────────────────────────────────────────
+#
+# Used by `/career-ops email` when drafting formal application emails. This is
+# separate from `contacto` short outreach and `cover` full cover letters.
+# All fields are optional.
+#
+# application_email:
+#   include_contact_block: true
+#   include_attachment_checklist: true
+#   # Use this when you want the email body to say "the email used to send this
+#   # message" instead of printing a concrete email address from candidate.email.
+#   # default_sender_note: "the email used to send this message"
+#   # signature_name: "Jane Smith"
 
 # ── Auto-PDF threshold ──────────────────────────────────────────────────────
 #

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -24,7 +24,7 @@ Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123
 Run the career-ops scan mode and summarize new matches.
 Run the career-ops pipeline mode for data/pipeline.md.
 Run the career-ops pdf mode for the latest evaluated role.
-Run the career-ops email mode for the latest evaluated role.
+Run the career-ops email mode for the latest evaluated role. Draft only; never sends, submits, or clicks.
 Run the career-ops tracker mode and summarize the current statuses.
 ```
 
@@ -37,7 +37,7 @@ codex exec "Evaluate this JD with career-ops auto-pipeline: https://company.com/
 codex exec "Run career-ops scan mode in this repo and summarize new matches."
 codex exec "Run career-ops pipeline mode for data/pipeline.md."
 codex exec "Run career-ops pdf mode for the latest evaluated role."
-codex exec "Run career-ops email mode for the latest evaluated role."
+codex exec "Run career-ops email mode for the latest evaluated role. Draft only; do not send, submit, or click anything."
 codex exec "Run career-ops tracker mode and summarize the current statuses."
 ```
 

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -24,6 +24,7 @@ Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123
 Run the career-ops scan mode and summarize new matches.
 Run the career-ops pipeline mode for data/pipeline.md.
 Run the career-ops pdf mode for the latest evaluated role.
+Run the career-ops email mode for the latest evaluated role.
 Run the career-ops tracker mode and summarize the current statuses.
 ```
 
@@ -36,6 +37,7 @@ codex exec "Evaluate this JD with career-ops auto-pipeline: https://company.com/
 codex exec "Run career-ops scan mode in this repo and summarize new matches."
 codex exec "Run career-ops pipeline mode for data/pipeline.md."
 codex exec "Run career-ops pdf mode for the latest evaluated role."
+codex exec "Run career-ops email mode for the latest evaluated role."
 codex exec "Run career-ops tracker mode and summarize the current statuses."
 ```
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -30,6 +30,7 @@ Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123
 Run the career-ops scan mode.
 Run the career-ops pipeline mode.
 Run the career-ops pdf mode.
+Run the career-ops email mode for the latest evaluated role.
 Run the career-ops tracker mode.
 ```
 
@@ -40,6 +41,7 @@ codex exec "Evaluate this JD with career-ops auto-pipeline: https://company.com/
 codex exec "Run career-ops scan mode in this repo."
 codex exec "Run career-ops pipeline mode for data/pipeline.md."
 codex exec "Run career-ops pdf mode for the latest evaluated role."
+codex exec "Run career-ops email mode for the latest evaluated role."
 codex exec "Run career-ops tracker mode and summarize the current statuses."
 ```
 
@@ -74,6 +76,7 @@ npx playwright install chromium
 | Search for offers | `/career-ops scan` or ask the agent to run `scan` |
 | Process pending URLs | `/career-ops pipeline` or ask the agent to run `pipeline` |
 | Generate a PDF | `/career-ops pdf` or ask the agent to run `pdf` |
+| Draft application email | `/career-ops email` or ask the agent to run `email` |
 | Batch evaluate | `/career-ops batch` or use `codex exec "Run career-ops batch mode ..."` |
 | Check tracker status | `/career-ops tracker` or ask the agent to run `tracker` |
 | Fill application form | `/career-ops apply` or ask the agent to run `apply` |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -30,7 +30,7 @@ Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123
 Run the career-ops scan mode.
 Run the career-ops pipeline mode.
 Run the career-ops pdf mode.
-Run the career-ops email mode for the latest evaluated role.
+Run the career-ops email mode for the latest evaluated role. Draft only; never sends, submits, or clicks.
 Run the career-ops tracker mode.
 ```
 
@@ -41,7 +41,7 @@ codex exec "Evaluate this JD with career-ops auto-pipeline: https://company.com/
 codex exec "Run career-ops scan mode in this repo."
 codex exec "Run career-ops pipeline mode for data/pipeline.md."
 codex exec "Run career-ops pdf mode for the latest evaluated role."
-codex exec "Run career-ops email mode for the latest evaluated role."
+codex exec "Run career-ops email mode for the latest evaluated role. Draft only; do not send, submit, or click anything."
 codex exec "Run career-ops tracker mode and summarize the current statuses."
 ```
 
@@ -76,7 +76,7 @@ npx playwright install chromium
 | Search for offers | `/career-ops scan` or ask the agent to run `scan` |
 | Process pending URLs | `/career-ops pipeline` or ask the agent to run `pipeline` |
 | Generate a PDF | `/career-ops pdf` or ask the agent to run `pdf` |
-| Draft application email | `/career-ops email` or ask the agent to run `email` |
+| Draft application email | `/career-ops email` or ask the agent to run `email`; draft-only, never sends, submits, or clicks |
 | Batch evaluate | `/career-ops batch` or use `codex exec "Run career-ops batch mode ..."` |
 | Check tracker status | `/career-ops tracker` or ask the agent to run `tracker` |
 | Fill application form | `/career-ops apply` or ask the agent to run `apply` |

--- a/modes/email.md
+++ b/modes/email.md
@@ -109,7 +109,7 @@ never fabricate.
 If a report has a score:
 - `>= 4.5`: confident, priority application.
 - `4.0-4.4`: good match, worth applying.
-- `< 4.0`: restrained; do not oversell. If below 3.5, warn the user before
+- `< 4.0`: restrained; do not oversell. If below 4.0, warn the user before
   drafting that career-ops normally recommends against applying.
 
 ---
@@ -190,18 +190,18 @@ Use:
 
 ```text
 联系方式：
-微信：{candidate.wechat}
-手机号：{candidate.phone}
-邮箱：{candidate.email or application_email.default_sender_note}
+{if candidate.wechat}微信：{candidate.wechat}{/if}
+{if candidate.phone}手机号：{candidate.phone}{/if}
+{if candidate.email or application_email.default_sender_note}邮箱：{candidate.email or application_email.default_sender_note}{/if}
 ```
 
 For English:
 
 ```text
 Contact:
-WeChat: {candidate.wechat}
-Phone: {candidate.phone}
-Email: {candidate.email or application_email.default_sender_note}
+{if candidate.wechat}WeChat: {candidate.wechat}{/if}
+{if candidate.phone}Phone: {candidate.phone}{/if}
+{if candidate.email or application_email.default_sender_note}Email: {candidate.email or application_email.default_sender_note}{/if}
 ```
 
 If `application_email.default_sender_note` is set in `config/profile.yml` to a

--- a/modes/email.md
+++ b/modes/email.md
@@ -1,0 +1,240 @@
+# Mode: email — Application Email Drafts
+
+Generate a formal application email body that the candidate can paste into an
+email client. This mode is for direct application emails, recruiter follow-up
+emails with a CV attached, referral request emails, and cold application emails.
+
+It is NOT:
+- `contacto`: short LinkedIn / BOSS Zhipin / chat-style outreach.
+- `cover`: a full cover letter PDF.
+- `apply`: live application form filling.
+
+**Never submit. Never send email. Never click send.** Draft only. The candidate
+must review and send manually.
+
+---
+
+## Invocation
+
+Supported inputs:
+
+1. `/career-ops email {report-number-or-slug}`
+   - Load the matching `reports/{NNN}-*.md`.
+   - Use the report header, score, archetype, PDF status, and evaluation content.
+   - If `data/pdf-index.tsv` contains a PDF for that report, mention it as the CV
+     attachment candidate. If no PDF is indexed, say that the CV should be
+     generated first via `/career-ops pdf {slug}` or attached manually.
+
+2. `/career-ops email {pasted JD}`
+   - Use the pasted JD directly.
+   - Do not create a report, tracker row, PDF, or cover letter.
+   - Ask for company name if the JD lacks it and the email would otherwise read
+     generic.
+
+3. `/career-ops email`
+   - If there is a most recent evaluated tracker row, offer to draft from that
+     row.
+   - If no usable context exists, ask for a report number, slug, or JD.
+
+---
+
+## Step 1 — Load Context
+
+Read:
+- `config/profile.yml`
+- `cv.md`
+- `article-digest.md` if it exists
+- `modes/_profile.md` if it exists
+- `modes/_custom.md` if it exists
+- `voice-dna.md` if it exists, for writing style only
+- The selected report if invoked by report number or slug
+- `data/pdf-index.tsv` if present, to find generated PDF attachments
+
+Use `modes/_custom.md` only for procedural output preferences such as whether to
+include a contact block, whether to show an attachment checklist, or how concise
+the email should be. It must never introduce contact details, work experience,
+or other factual claims.
+
+Use `voice-dna.md` only as a writing guardrail. It must never introduce factual
+claims.
+
+### Profile fields
+
+Use these optional fields when present:
+- `candidate.full_name`
+- `candidate.chinese_name`
+- `candidate.email`
+- `candidate.phone`
+- `candidate.wechat`
+- `candidate.location`
+- `candidate.linkedin`
+- `candidate.github`
+- `candidate.portfolio_url`
+- `application_email.default_sender_note`
+- `application_email.include_contact_block`
+- `application_email.include_attachment_checklist`
+- `application_email.signature_name`
+
+If `candidate.wechat` is absent, omit WeChat. Do not invent one.
+
+---
+
+## Step 2 — Classify Email Type
+
+Choose one of three variants from user wording or context:
+
+| Variant | When | Tone |
+|---|---|---|
+| `hr_application` | Default. Sending CV to HR/recruiter for a posted role. | Formal, concise, screening-friendly |
+| `referral_request` | User asks for referral, internal contact, friend, alumni, or former colleague. | Warm, low-pressure, easy to forward |
+| `cold_application` | No posted role, speculative reach-out, "cold email". | Direct, value-first, no desperation |
+
+If unclear, default to `hr_application`.
+
+---
+
+## Step 3 — Extract Fit Points
+
+From the report/JD and source-of-truth files, select 2-3 fit points:
+
+- One role-to-profile match: stack, domain, workflow, product type, or delivery
+  style.
+- One proof point: project, metric, open-source contribution, or shipped system.
+- One differentiator: business ownership, domain knowledge, communication,
+  open-source ecosystem, or production handover.
+
+Use only facts from source-of-truth files. Reformulate keywords from the JD;
+never fabricate.
+
+If a report has a score:
+- `>= 4.5`: confident, priority application.
+- `4.0-4.4`: good match, worth applying.
+- `< 4.0`: restrained; do not oversell. If below 3.5, warn the user before
+  drafting that career-ops normally recommends against applying.
+
+---
+
+## Step 4 — Attachment Checklist
+
+Before the draft, output:
+
+```text
+Attachments to include:
+- CV: {pdf path or "attach your tailored CV"}
+- Cover letter: {path if known, otherwise "optional / not generated"}
+```
+
+Rules:
+- If `application_email.include_attachment_checklist` is `false`, omit this
+  checklist.
+- Mention only files that exist or are indexed. Do not claim a cover letter
+  exists unless it does.
+- Do not attach files or send anything.
+
+---
+
+## Step 5 — Draft Structure
+
+Always output:
+
+```text
+Subject: {subject}
+
+{email body}
+```
+
+### HR application structure
+
+1. Greeting
+2. Role intent and attachment sentence
+3. 2-3 fit points in one short paragraph or compact bullets
+4. Why this role is relevant, using JD language
+5. Contact block and signature
+
+### Referral request structure
+
+1. Greeting
+2. One-line context: role and company
+3. 2 concise proof points that are easy to forward
+4. Low-pressure ask: "If this looks aligned, would you be comfortable referring
+   me or pointing me to the right person?"
+5. Contact block and signature
+
+### Cold application structure
+
+1. Greeting
+2. Value proposition first, not "I am looking for a job"
+3. 2 proof points tied to the company/domain
+4. Specific ask: short call, right contact, or permission to send CV
+5. Contact block and signature
+
+---
+
+## Language
+
+- Match the JD/report language.
+- If the JD is Chinese, use Simplified Chinese.
+- If the company/recruiter language is unknown, default to the user's language.
+- Keep the subject line in the same language as the body unless the user asks
+  otherwise.
+
+---
+
+## Contact Block
+
+Default behavior:
+- Include contact block for direct application emails.
+- Omit phone in short social outreach; this mode is not short social outreach.
+
+Use:
+
+```text
+联系方式：
+微信：{candidate.wechat}
+手机号：{candidate.phone}
+邮箱：{candidate.email or application_email.default_sender_note}
+```
+
+For English:
+
+```text
+Contact:
+WeChat: {candidate.wechat}
+Phone: {candidate.phone}
+Email: {candidate.email or application_email.default_sender_note}
+```
+
+If `application_email.default_sender_note` is set in `config/profile.yml` to a
+phrase such as "the email used to send this message", use that phrase instead of
+a concrete email address.
+
+If `application_email.include_contact_block` is `false`, use a normal signature
+only.
+
+---
+
+## Style Rules
+
+- No corporate-speak.
+- No "passionate about", "perfect fit", "unique opportunity", or vague praise.
+- No exaggerated authorship claims.
+- Short paragraphs. Prefer 150-250 words for HR applications.
+- Keep the proof easy to scan.
+- Do not include salary unless the user asks.
+- Do not include private references, ID numbers, or unsupported claims.
+
+---
+
+## Output
+
+Return in this order:
+
+1. Context line:
+   - `Source: report {NNN}` or `Source: pasted JD`
+   - Variant
+   - Language
+2. Attachment checklist, unless disabled
+3. Subject and email body
+4. One-line note with any missing inputs or assumptions
+
+Do not write files unless the user explicitly asks to save the draft.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -849,7 +849,7 @@ const expectedModes = [
   '_shared.md', '_profile.template.md', 'oferta.md', 'pdf.md', 'scan.md',
   'batch.md', 'apply.md', 'auto-pipeline.md', 'contacto.md', 'deep.md',
   'ofertas.md', 'pipeline.md', 'project.md', 'tracker.md', 'training.md',
-  'interview.md', 'latex.md', 'add.md',
+  'interview.md', 'latex.md', 'email.md', 'add.md',
   'regional/eu-swe.md',
 ];
 
@@ -880,6 +880,38 @@ for (const skillPath of ['.claude/skills/career-ops/SKILL.md', '.agents/skills/c
   } else {
     fail(`${skillPath} does not expose /career-ops latex in discovery menu`);
   }
+  if (
+    skill.includes('email') &&
+    skill.includes('| `email` | `email` |') &&
+    skill.includes('/career-ops email') &&
+    /Standalone modes[\s\S]*Applies to:[^\n]*`email`/.test(skill)
+  ) {
+    pass(`${skillPath} exposes /career-ops email in routing, discovery, and standalone loading`);
+  } else {
+    fail(`${skillPath} does not fully expose /career-ops email`);
+  }
+}
+
+const emailMode = readFile('modes/email.md');
+if (
+  emailMode.includes('Application Email Drafts') &&
+  emailMode.includes('Never submit') &&
+  emailMode.includes('Never send email') &&
+  emailMode.includes('hr_application') &&
+  emailMode.includes('referral_request') &&
+  emailMode.includes('cold_application') &&
+  emailMode.includes('Attachment checklist') &&
+  emailMode.includes('candidate.wechat') &&
+  emailMode.includes('data/pdf-index.tsv') &&
+  emailMode.includes('voice-dna.md') &&
+  emailMode.includes('cv.md') &&
+  emailMode.includes('article-digest.md') &&
+  emailMode.includes('config/profile.yml') &&
+  emailMode.includes('modes/_profile.md')
+) {
+  pass('email mode covers formal drafts, no-send safety, variants, attachments, contact fields, and source boundaries');
+} else {
+  fail('email mode missing required application-email behavior');
 }
 
 const applyMode = readFile('modes/apply.md');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -897,6 +897,7 @@ if (
   emailMode.includes('Application Email Drafts') &&
   emailMode.includes('Never submit') &&
   emailMode.includes('Never send email') &&
+  emailMode.includes('Never click send') &&
   emailMode.includes('hr_application') &&
   emailMode.includes('referral_request') &&
   emailMode.includes('cold_application') &&

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -47,6 +47,7 @@ const SYSTEM_PATHS = [
   'modes/oferta.md',
   'modes/pdf.md',
   'modes/cover.md',
+  'modes/email.md',
   'modes/add.md',
   'modes/scan.md',
   'modes/batch.md',

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -46,6 +46,7 @@ const userPaths = extractArray('USER_PATHS');
 const bootstrapPaths = extractArray('BOOTSTRAP_PATHS');
 
 const requiredSystemPaths = [
+  'modes/email.md',
   'modes/followup.md',
   'modes/interview.md',
   'modes/interview-prep.md',


### PR DESCRIPTION
## Summary
- add `/career-ops email` as a standalone mode for formal application email drafts
- define HR application, referral request, and cold application variants
- add attachment checklist and profile-driven contact block behavior, including optional `candidate.wechat`
- wire the mode through the shared router, docs, updater coverage, and tests

## Safety
- drafts only; the mode explicitly never sends, submits, or clicks send
- factual contact details come from `config/profile.yml`; `_custom.md` can only control procedural formatting preferences
- email content follows the same source-of-truth boundary as other user-facing application content

## Validation
- `git diff --check`
- `node validate-system-paths-coverage.mjs --self-test`
- `node validate-system-paths-coverage.mjs`
- `node updater-migration-tests.mjs`
- `node test-all.mjs --quick`
- `node test-all.mjs` (1138 passed, 0 failed, 1 expected warning for missing user data)

Closes #1511
Closes #1512
Closes #1513
Closes #1514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `email` mode to draft formal application emails (HR application/referral/cold variants) from a report or pasted job description, with strict draft-only behavior (never sends/submits/clicks), plus fit-point guidance and an optional attachment checklist and contact block.
* **Documentation**
  * Updated router/Codex/README and setup materials to document `/career-ops email`, the new mode, and reinforced that user-facing output is generated exclusively from in-scope project files and your current conversation.
  * Expanded configuration/profile examples (including optional WeChat contact and commented email settings).
* **Tests**
  * Extended mode integrity and content validation to cover the new email mode, and updated system-path migration checks for `modes/email.md`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->