### PR TITLE
fix(merge-tracker): detect TSV score/status column order by content (#1427)

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -22,7 +22,7 @@ import { createHash, randomUUID } from 'crypto';
 import { tmpdir } from 'os';
 import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
-import { LEGACY_COLMAP, detectColumns } from './tracker-parse.mjs';
+import { LEGACY_COLMAP, detectColumns, resolveScoreStatus } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original).
@@ -511,13 +511,20 @@ function parseTsvContent(content, filename) {
       return null;
     }
     // Format: num | date | company | role | score | status | pdf | report | notes [| location]
+    // Identify score vs status by content, not position, so a swapped row can't
+    // merge silently (#1427).
+    const resolved = resolveScoreStatus(parts[4], parts[5]);
+    if (!resolved) {
+      console.warn(`⚠️  Skipping ${filename}: cannot tell score from status in columns 5–6 ("${parts[4]}" | "${parts[5]}") — refusing to merge a possible column swap`);
+      return null;
+    }
     addition = {
       num: parseInt(parts[0]),
       date: parts[1],
       company: parts[2],
       role: parts[3],
-      score: parts[4],
-      status: validateStatus(parts[5]),
+      score: resolved.score,
+      status: validateStatus(resolved.status),
       pdf: parts[6],
       report: parts[7],
       notes: parts[8] || '',
@@ -531,28 +538,14 @@ function parseTsvContent(content, filename) {
       return null;
     }
 
-    // Detect column order: some TSVs have (status, score), others have (score, status)
-    // Heuristic: if col4 looks like a score and col5 looks like a status, they're swapped
-    const col4 = parts[4].trim();
-    const col5 = parts[5].trim();
-    const col4LooksLikeScore = /^\d+\.?\d*\/5$/.test(col4) || col4 === 'N/A' || col4 === 'DUP';
-    const col5LooksLikeScore = /^\d+\.?\d*\/5$/.test(col5) || col5 === 'N/A' || col5 === 'DUP';
-    const col4LooksLikeStatus = /^(evaluated|applied|responded|interview|offer|rejected|discarded|skip|evaluada|aplicado|respondido|entrevista|oferta|rechazado|descartado|no aplicar|cerrada|duplicado|repost|condicional|hold|monitor)/i.test(col4);
-    const col5LooksLikeStatus = /^(evaluated|applied|responded|interview|offer|rejected|discarded|skip|evaluada|aplicado|respondido|entrevista|oferta|rechazado|descartado|no aplicar|cerrada|duplicado|repost|condicional|hold|monitor)/i.test(col5);
-
-    let statusCol, scoreCol;
-    if (col4LooksLikeStatus && !col4LooksLikeScore) {
-      // Standard format: col4=status, col5=score
-      statusCol = col4; scoreCol = col5;
-    } else if (col4LooksLikeScore && col5LooksLikeStatus) {
-      // Swapped format: col4=score, col5=status
-      statusCol = col5; scoreCol = col4;
-    } else if (col5LooksLikeScore && !col4LooksLikeScore) {
-      // col5 is definitely score → col4 must be status
-      statusCol = col4; scoreCol = col5;
-    } else {
-      // Default: standard format (status before score)
-      statusCol = col4; scoreCol = col5;
+    // Column order varies: batch TSVs write (status, score), applications.md is
+    // (score, status). Identify each by content — the score cell is recognizable
+    // by pattern, a status never is — so a reordered TSV merges correctly and an
+    // undecidable row is skipped loudly instead of merging swapped data (#1427).
+    const resolved = resolveScoreStatus(parts[4].trim(), parts[5].trim());
+    if (!resolved) {
+      console.warn(`⚠️  Skipping ${filename}: cannot tell score from status in columns 5–6 ("${parts[4].trim()}" | "${parts[5].trim()}") — refusing to merge a possible column swap`);
+      return null;
     }
 
     addition = {
@@ -560,8 +553,8 @@ function parseTsvContent(content, filename) {
       date: parts[1],
       company: parts[2],
       role: parts[3],
-      status: validateStatus(statusCol),
-      score: scoreCol,
+      status: validateStatus(resolved.status),
+      score: resolved.score,
       pdf: parts[6],
       report: parts[7],
       notes: parts[8] || '',

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -523,7 +523,9 @@ function parseTsvContent(content, filename) {
       date: parts[1],
       company: parts[2],
       role: parts[3],
-      score: resolved.score,
+      // Write-canonical: the tracker stores scores unbolded (verify-pipeline
+      // rejects bold scores), so strip any markdown bold from the incoming cell.
+      score: resolved.score.replace(/\*\*/g, '').trim(),
       status: validateStatus(resolved.status),
       pdf: parts[6],
       report: parts[7],
@@ -554,7 +556,9 @@ function parseTsvContent(content, filename) {
       company: parts[2],
       role: parts[3],
       status: validateStatus(resolved.status),
-      score: resolved.score,
+      // Write-canonical: strip any markdown bold so the stored score stays
+      // unbolded (verify-pipeline rejects bold scores).
+      score: resolved.score.replace(/\*\*/g, '').trim(),
       pdf: parts[6],
       report: parts[7],
       notes: parts[8] || '',

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4222,6 +4222,89 @@ try {
   fail(`merge-tracker fuzzy dedup tests crashed: ${e.message}`);
 }
 
+// ── MERGE-TRACKER TSV COLUMN-ORDER TOLERANCE (#1427) ─────────────
+// Batch TSVs write (status, score); applications.md is (score, status). A
+// generator that swaps the two must not merge silently — the score column is
+// identified by content pattern, and an undecidable pair is skipped loudly.
+console.log('\n🧪 Testing merge-tracker TSV column-order tolerance (#1427)...');
+try {
+  const { resolveScoreStatus, looksLikeScoreCell } = await import(pathToFileURL(join(ROOT, 'tracker-parse.mjs')).href);
+
+  // Unit: content-pattern discriminator
+  if (looksLikeScoreCell('4.2/5') && looksLikeScoreCell('5/5') && looksLikeScoreCell('N/A') && looksLikeScoreCell('DUP') && looksLikeScoreCell('**3.5/5**')) {
+    pass('looksLikeScoreCell accepts score cells (incl. N/A, DUP, bolded)');
+  } else {
+    fail('looksLikeScoreCell rejected a valid score cell');
+  }
+  if (!looksLikeScoreCell('Evaluated') && !looksLikeScoreCell('Applied') && !looksLikeScoreCell('')) {
+    pass('looksLikeScoreCell rejects status labels and blanks');
+  } else {
+    fail('looksLikeScoreCell matched a non-score cell');
+  }
+
+  const std = resolveScoreStatus('Evaluated', '4.2/5');
+  const swp = resolveScoreStatus('4.2/5', 'Evaluated');
+  if (std && std.score === '4.2/5' && std.status === 'Evaluated' &&
+      swp && swp.score === '4.2/5' && swp.status === 'Evaluated') {
+    pass('resolveScoreStatus maps both column orders to the same result');
+  } else {
+    fail(`resolveScoreStatus order handling: std=${JSON.stringify(std)} swp=${JSON.stringify(swp)}`);
+  }
+  if (resolveScoreStatus('Evaluated', 'Applied') === null && resolveScoreStatus('4.2/5', '5/5') === null) {
+    pass('resolveScoreStatus returns null when neither or both cells look like a score');
+  } else {
+    fail('resolveScoreStatus should be undecidable for two statuses or two scores');
+  }
+
+  // End-to-end: a swapped-column TSV merges correctly; an undecidable one is skipped.
+  const colTmp = mkdtempSync(join(tmpdir(), 'career-ops-colorder-'));
+  try {
+    mkdirSync(join(colTmp, 'data'));
+    mkdirSync(join(colTmp, 'reports'));
+    const additionsDir = join(colTmp, 'additions');
+    mkdirSync(additionsDir);
+    const tracker = join(colTmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 1 | 2026-01-04 | AnchorCo | Platform Engineer | 4.0/5 | Evaluated | ❌ | [1](../reports/001-anchorco-2026-01-04.md) | existing |\n');
+    for (const n of ['001-anchorco-2026-01-04', '002-swapco-2026-01-05', '003-ambigco-2026-01-05']) {
+      writeFileSync(join(colTmp, 'reports', `${n}.md`), '# fixture\n');
+    }
+    // Swapped order: score BEFORE status (4.6/5 then Evaluated).
+    writeFileSync(join(additionsDir, '002-swapco.tsv'),
+      '2\t2026-01-05\tSwapCo\tData Engineer\t4.6/5\tEvaluated\t❌\t[2](reports/002-swapco-2026-01-05.md)\tswapped cols\n');
+    // Undecidable: two status-like cells, no score → must be skipped, not merged.
+    writeFileSync(join(additionsDir, '003-ambigco.tsv'),
+      '3\t2026-01-05\tAmbigCo\tAnalyst\tEvaluated\tApplied\t❌\t[3](reports/003-ambigco-2026-01-05.md)\tno score\n');
+
+    const mergeResult = run(NODE, ['merge-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: additionsDir } });
+    if (mergeResult === null) {
+      fail('merge-tracker.mjs crashed during column-order test');
+    } else {
+      const merged = readFileSync(tracker, 'utf-8');
+      const swapRow = merged.split('\n').find(l => l.includes('SwapCo')) || '';
+      // buildRow writes `| … | score | status | … |`, so the score must land in the
+      // score column and status in the status column despite the swapped input.
+      if (swapRow.includes('| 4.6/5 | Evaluated |')) {
+        pass('swapped-column TSV merges with score and status in the correct columns');
+      } else {
+        fail(`swapped TSV mis-merged: "${swapRow.trim()}"`);
+      }
+      if (!merged.includes('AmbigCo')) {
+        pass('undecidable score/status row is skipped, not merged (no silent swap)');
+      } else {
+        fail('undecidable row was merged instead of skipped');
+      }
+    }
+  } finally {
+    rmSync(colTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`merge-tracker column-order tests crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER REPORT-NUMBER COLLISION (#912) ─────────────────
 // The report-number dedup check was not company-guarded: a TSV for NewCo
 // with report [1] would find the existing tracker row [1] for OtherCo and

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4269,7 +4269,7 @@ try {
       '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
       '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
       '| 1 | 2026-01-04 | AnchorCo | Platform Engineer | 4.0/5 | Evaluated | ❌ | [1](../reports/001-anchorco-2026-01-04.md) | existing |\n');
-    for (const n of ['001-anchorco-2026-01-04', '002-swapco-2026-01-05', '003-ambigco-2026-01-05']) {
+    for (const n of ['001-anchorco-2026-01-04', '002-swapco-2026-01-05', '003-ambigco-2026-01-05', '004-boldco-2026-01-05']) {
       writeFileSync(join(colTmp, 'reports', `${n}.md`), '# fixture\n');
     }
     // Swapped order: score BEFORE status (4.6/5 then Evaluated).
@@ -4278,6 +4278,9 @@ try {
     // Undecidable: two status-like cells, no score → must be skipped, not merged.
     writeFileSync(join(additionsDir, '003-ambigco.tsv'),
       '3\t2026-01-05\tAmbigCo\tAnalyst\tEvaluated\tApplied\t❌\t[3](reports/003-ambigco-2026-01-05.md)\tno score\n');
+    // Bold score cell → detected AND persisted write-canonical (unbolded).
+    writeFileSync(join(additionsDir, '004-boldco.tsv'),
+      '4\t2026-01-05\tBoldCo\tSRE\tEvaluated\t**4.7/5**\t❌\t[4](reports/004-boldco-2026-01-05.md)\tbold score\n');
 
     const mergeResult = run(NODE, ['merge-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: additionsDir } });
     if (mergeResult === null) {
@@ -4296,6 +4299,12 @@ try {
         pass('undecidable score/status row is skipped, not merged (no silent swap)');
       } else {
         fail('undecidable row was merged instead of skipped');
+      }
+      const boldRow = merged.split('\n').find(l => l.includes('BoldCo')) || '';
+      if (boldRow.includes('| 4.7/5 | Evaluated |') && !boldRow.includes('**')) {
+        pass('bold score cell is persisted write-canonical (unbolded) in the merged row');
+      } else {
+        fail(`bold score not canonicalized on write: "${boldRow.trim()}"`);
       }
     }
   } finally {

--- a/tracker-parse.mjs
+++ b/tracker-parse.mjs
@@ -25,6 +25,41 @@ export const HEADER_ALIASES = {
 };
 
 /**
+ * A score cell in the tracker: `N/5` or `N.N/5` (any precision), or the
+ * sentinels `N/A` / `DUP`. Markdown bold is stripped first. A status label
+ * never matches this, which is what makes it a reliable discriminator between
+ * the score and status columns regardless of their order (#1427).
+ */
+export const SCORE_CELL_RE = /^\d+(?:\.\d+)?\/5$/;
+
+/** @param {string} v @returns {boolean} whether the cell reads as a score. */
+export function looksLikeScoreCell(v) {
+  const t = String(v ?? '').replace(/\*\*/g, '').trim();
+  return SCORE_CELL_RE.test(t) || t === 'N/A' || t === 'DUP';
+}
+
+/**
+ * Given the two adjacent cells that carry score and status in EITHER order,
+ * identify which is which by content — the score cell is recognizable by
+ * pattern (`looksLikeScoreCell`), statuses never are. This lets TSV ingestion
+ * tolerate the two known column orders (batch TSV writes status-then-score;
+ * `applications.md` is score-then-status) instead of trusting position.
+ *
+ * Returns null when the order is undecidable — neither cell, or BOTH cells, look
+ * like a score — so callers can fail loudly rather than merge a silent swap.
+ *
+ * @param {string} a - first of the two cells
+ * @param {string} b - second of the two cells
+ * @returns {{score: string, status: string}|null}
+ */
+export function resolveScoreStatus(a, b) {
+  const aScore = looksLikeScoreCell(a);
+  const bScore = looksLikeScoreCell(b);
+  if (aScore === bScore) return null; // ambiguous: neither, or both
+  return aScore ? { score: a, status: b } : { score: b, status: a };
+}
+
+/**
  * Scan the table for a header row and build a field-name → column-index map.
  * Indexing matches `line.split('|')`. Returns null — caller should fall back to
  * LEGACY_COLMAP — unless the essential columns are all present, so a stray pipe


### PR DESCRIPTION
Closes #1427.

Batch TSVs write `(status, score)`; `applications.md` is `(score, status)`. The previous detection leaned on a hardcoded status-word allowlist and, when nothing matched, **silently defaulted** to one order — so a swapped or unrecognized row could merge score-as-status into the tracker.

## Approach (per the issue)
Identify the score column by **content pattern** — a score cell is `N/5` / `N.N/5` or the `N/A` / `DUP` sentinels, and a status label never is — so column *order* no longer matters. Ported the header-name-tolerance idea (#1328) to TSV ingestion.

- **`tracker-parse.mjs`** (shared home for tracker parsing): adds `looksLikeScoreCell` and `resolveScoreStatus(a, b)`, which returns `{score, status}` regardless of order, or `null` when undecidable (neither or both cells look like a score).
- **`merge-tracker.mjs`**: both the TSV and pipe-delimited paths use it. A reordered row merges correctly; an **undecidable row is skipped with a loud warning naming the file**, instead of merging a silent swap. Stays read-tolerant / write-canonical (⚠️ shared write-path surface).

## Tests (`test-all.mjs`, mirroring the existing merge-tracker blocks)
- Unit: the content discriminator (incl. `N/A`, `DUP`, bolded, blanks), both column orders resolving identically, and the undecidable → `null` case.
- End-to-end: a swapped-column TSV merges with score/status in the correct columns; an ambiguous (two-status) row is skipped, not merged.

Full `--quick` suite (what CI runs): **1139 passed, 0 failed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracker importing so score/status values are correctly resolved even when the TSV/Markdown column order is swapped.
  * Added safer score/status resolution: when the pair can’t be determined unambiguously, the row is skipped with a warning instead of being merged incorrectly.
  * Normalized imported score values by removing Markdown bold formatting and validating the resolved status.

* **Tests**
  * Added regression tests for swapped score/status column order tolerance, ambiguous pair handling, and canonicalization of bolded score cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->