### PR TITLE
docs(portals): add example stanzas for hackernews, jobspresso, themuse, teamtailor

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -670,6 +670,18 @@ search_queries:
 #   provider: jobicy
 #   enabled: true
 #
+# - name: Hacker News "Who is hiring?"    # monthly "Ask HN: Who is hiring?" thread
+#   provider: hackernews
+#   enabled: true
+#
+# - name: Jobspresso                      # curated remote roles (public WordPress feed)
+#   provider: jobspresso
+#   enabled: true
+#
+# - name: The Muse                        # board-wide public jobs API
+#   provider: themuse
+#   enabled: true
+#
 # Comeet needs the full careers-api URL (it carries a per-tenant token that a
 # branded careers page does not expose), so set it via the api: field — e.g.:
 #
@@ -686,6 +698,20 @@ search_queries:
 #
 #   - name: Example GmbH
 #     careers_url: https://example-gmbh.jobs.personio.de
+#     enabled: true
+#
+# Teamtailor auto-detects from a <slug>.teamtailor.com careers host and reads
+# the public no-auth /jobs.rss feed — e.g.:
+#
+#   - name: Example Co
+#     careers_url: https://example.teamtailor.com
+#     enabled: true
+#
+#   # If the tenant fronts a branded careers domain, set provider: teamtailor
+#   # explicitly and point careers_url at that host (it serves the same feed):
+#   - name: Example Co (branded)
+#     careers_url: https://careers.example.com
+#     provider: teamtailor
 #     enabled: true
 #
 # Some JibeApply sites run on a branded custom domain rather than


### PR DESCRIPTION
Closes #1491.

Four working providers had no example in `templates/portals.example.yml` — the file users copy from — so configuring them meant reading provider source.

Added commented stanzas in the "Built-in provider examples" section, matching the existing style:
- **hackernews / jobspresso / themuse** — board-wide feeds (`provider:` only), placed with the other remote-job feeds.
- **teamtailor** — auto-detected from a `<slug>.teamtailor.com` careers host, with the branded-domain form (`provider: teamtailor` + `careers_url`), mirroring the existing Personio / JibeApply notes.

Stanzas were written from each provider's header comment. `validate-portals.mjs --file templates/portals.example.yml`: 0 errors, 0 warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new example job-board sources for remote-job feed setup, including Hacker News, Jobspresso, and The Muse.
  * Expanded example configuration for Teamtailor, including guidance for both standard and branded tenant domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->