### PR TITLE
feat(i18n): translate interview modes to Spanish

### DIFF
--- a/modes/es/interview/debrief.md
+++ b/modes/es/interview/debrief.md
@@ -1,0 +1,200 @@
+# Mode: interview/debrief — Análisis Posterior a la Entrevista (Debrief)
+
+Después de una entrevista real, captura qué se preguntó, evalúa qué funcionó y qué no, cubre las carencias antes de la siguiente ronda y actualiza el banco de preguntas.
+
+---
+
+## When to Run This Skill
+
+- Inmediatamente después de una entrevista real (mientras la memoria está fresca)
+- Después de una llamada con el reclutador que haya revelado nueva información sobre el proceso
+- Cuando el candidato conozca el formato y el entrevistador de la siguiente ronda
+
+---
+
+## Inputs
+
+1. **Análisis de la entrevista del candidato (Debrief)** — qué preguntas se hicieron, cómo respondió, qué sintió que fue sólido o débil
+2. **Nombre y rol del entrevistador** — informa la predicción de la siguiente ronda
+3. **Resultado de la ronda** (si se conoce) — avanzó / rechazado / pendiente
+4. **Detalles de la siguiente ronda** (si se conocen) — formato, entrevistadores, plazos
+5. **Banco de preguntas** en `interview-prep/question-bank.md` — actualizar con datos reales
+6. **Banco de historias** en `interview-prep/story-bank.md` — agregar nuevas historias si surgieron
+7. **CV** en `cv.md` + `article-digest.md` (si está presente) — para fundamentar las respuestas sugeridas en la experiencia real
+8. **Afirmaciones retractadas** en `interview-prep/retracted-claims.md` (si está presente) — barrera estricta (hard gate); nunca uses una afirmación retractada en una respuesta sugerida, incluso si el candidato la dijo en la entrevista
+9. **Archivo de preparación específico del rol** — para adjuntar las notas del análisis
+
+---
+
+## Step 1 — Capture What Was Asked
+
+Pide al candidato que enumere cada pregunta que recuerde, en orden si es posible. No le sugieras opciones — deja que recuerde libremente primero.
+
+Para cada pregunta capturada:
+- ¿Qué dijeron?
+- ¿Cómo reaccionó el entrevistador (señal positiva, neutral, mostró rechazo, pasó a otra cosa rápidamente)?
+- ¿Se sintieron seguros o con dudas?
+
+Si la memoria está incompleta, haz preguntas dirigidas:
+- "¿Hubo alguna pregunta que te tomó por sorpresa?"
+- "¿Hubo algo que desearías haber respondido de otra manera?"
+- "¿El entrevistador hizo preguntas de seguimiento (follow-up) sobre algo? — eso generalmente significa que querían más."
+
+---
+
+## Step 2 — Honest Assessment Per Question
+
+Para cada pregunta, produce:
+
+```markdown
+**Q: [pregunta]**
+- What was said: [resumen de su respuesta]
+- What landed: [qué fue bueno — sé específico]
+- What was missing: [carencia — término técnico preciso, resultado faltante, sin reflexión, etc.]
+- Correct/complete answer: [lo que la respuesta completa debería incluir]
+- Status: ✅ Strong / 🟡 Solid / 🔴 Gap
+```
+
+Sé directo. Si perdieron el concepto central que la pregunta estaba evaluando, dilo. Si una respuesta fue genuinamente sólida, dilo también. El análisis es el momento de aprendizaje más valioso — la vaguedad lo desperdicia.
+
+---
+
+## Step 3 — Update Question Bank
+
+Para cada pregunta analizada, actualiza `interview-prep/question-bank.md`:
+- Cambia el estado a ✅ / 🟡 / 🔴 según el rendimiento real
+- Agrega notas de carencias del análisis
+- Agrega cualquier nueva pregunta que haya aparecido y que aún no estuviera en el banco
+
+Si el banco de preguntas no existe, créalo con las preguntas de esta entrevista como semilla.
+
+---
+
+## Step 4 — Close the Gaps
+
+Para cada 🔴 carencia identificada:
+
+1. **Explica la respuesta correcta** — clara, concisa, con un ejemplo desarrollado (código, cálculo, diagrama) si es útil
+2. **Conecta con una historia real** si es posible — "realmente tienes esto en tu [historia existente del banco de historias] — aquí te muestro cómo usarlo"
+3. **Agrega al archivo de preparación del rol** bajo una sección "Gaps to Close Before Round N"
+4. **Agrega a `interview-prep/interview-prep-guide.md`** (si el candidato mantiene uno) cuando sea un principio reutilizable que se aplique más allá de este rol
+
+---
+
+## Step 5 — Extract New Stories
+
+A veces, una entrevista real saca a relucir una historia que el candidato no había preparado. Si el candidato describió una experiencia que no había formalizado:
+
+> "Mencionaste [X] en tu respuesta — parece que podría convertirse en una historia STAR+R adecuada. ¿Quieres desarrollarla ahora que está fresca?"
+
+Si dice que sí, desarróllala como una historia STAR+R (Situación, Tarea, Acción, Resultado, Reflexión) y agrégala a `interview-prep/story-bank.md`.
+
+---
+
+## Step 6 — Next Round Intelligence
+
+Si el candidato conoce el formato de la próxima ronda:
+
+1. **Predice posibles preguntas** basándote en:
+   - El rol del próximo entrevistador (ej., practitioner senior → profundidad en la habilidad central, diseño; colega interfuncional → colaboración, límites del dominio; ejecutivo → estrategia, impacto en el negocio)
+   - Lo que se cubrió en esta ronda (la próxima ronda suele profundizar, no abarcar más)
+   - En lo que el entrevistador de esta ronda pareció más interesado
+
+   Etiqueta cada predicción con `[inferred]` — nunca presentes una pregunta predicha como si se hubiera obtenido de candidatos reales o expertos internos.
+
+2. **Construye una lista de prioridades** para la preparación de la próxima ronda — ordenada por gravedad de la carencia y probabilidad de ser evaluada
+
+3. **Sugiere ejecutar** `interview/plan` con los detalles de la próxima ronda para crear un plan de preparación completo
+
+---
+
+## Step 7 — Probability Assessment (Optional)
+
+Si el candidato pide una lectura honesta sobre sus posibilidades:
+
+Evalúa en base a:
+- Número y gravedad de las carencias (🔴 en fundamentos = mayor riesgo que 🔴 en temas avanzados)
+- Señales del entrevistador (dio detalles específicos de la siguiente ronda = positivo; vago = neutral; llamada corta = riesgo)
+- Ajuste al rol (años de experiencia, coincidencia de dominio, ubicación)
+- Diferenciadores (cosas que dijo el candidato que la mayoría de los candidatos no dirían)
+
+Sé honesto. Un rango de probabilidad con un razonamiento claro es más útil que la falsa confianza.
+
+---
+
+## Step 8 — Save Debrief
+
+Agrega a `interview-prep/{company-slug}-{role-slug}.md`:
+
+```markdown
+## Round [N] Debrief — [YYYY-MM-DD]
+
+**Interviewer:** [nombre, rol]
+**Round type:** [screening / technical / design-case-study / behavioral]
+**Outcome:** [pending / moved forward / rejected]
+
+### Questions Asked
+[lista]
+
+### Gaps Identified
+[lista con las respuestas correctas]
+
+### Next Round
+**Format:** [si se conoce]
+**Interviewers:** [si se conocen]
+**Priority prep:** [los 3 temas principales a cubrir antes de la siguiente ronda]
+
+### Process Intel (recruiter / HM screens — omit if not applicable)
+**Comp discussed:** [sí / no — si es sí, qué se dijo y en qué se ancló]
+**Timeline:** [cualquier fecha o plazo mencionado]
+**Other candidates:** [si se revelaron]
+**Next steps:** [lo que el entrevistador dijo que sucede a continuación y para cuándo]
+```
+
+---
+
+## Step 9 — Write Session Transcript
+
+Después del análisis, escribe también una transcripción de la sesión legible por máquina en `interview-prep/sessions/{company-slug}-{role-slug}-{round}-{YYYY-MM-DD}.md`. Este es un registro estructurado de la ronda para modos de análisis posteriores; los turnos etiquetados por hablante permiten a un consumidor leer cualquier lado sin tener que volver a inferir quién habló. El contrato completo vive en `interview-prep/sessions/README.md`.
+
+Formato:
+
+```markdown
+---
+company: [empresa]
+role: [rol]
+round: [screen | hiring-manager | technical | system-design | behavioral | onsite | final]
+date: YYYY-MM-DD
+interviewer_role: [rol, si se conoce]
+source: debrief
+---
+
+## Q1
+**Interviewer:** [pregunta tal como se hizo]
+<!-- competency: tag[, tag...] -->
+**Candidate:** [respuesta tal como se entregó / reconstruida en este análisis]
+
+## Q2
+...
+```
+
+Reglas para la transcripción:
+
+- **Asigna el tipo de ronda al enum** anterior (ej. filtro del reclutador → `screen`, filtro del HM → `hiring-manager`, inmersión técnica → `technical`, diseño/estudio de caso → `system-design`).
+- **Etiqueta cada respuesta.** En la línea directamente arriba de cada línea `**Candidate:**`, emite `<!-- competency: tag[, tag...] -->` — en minúsculas (lowercase-kebab-case), separado por comas para respuestas con múltiples competencias (ej. `system-design`, `people-leadership`, `incident-response`). Ya evaluaste cada respuesta en el Step 2, así que etiqueta a partir de esa evaluación en lugar de volver a leer. Las etiquetas son de formato libre; elige la competencia que la pregunta realmente evaluó.
+- **Reconstruye el turno del candidato fielmente.** Usa lo que el candidato informó haber dicho en el Step 1, no una respuesta idealizada. La "respuesta correcta/completa" del Step 2 pertenece al archivo de análisis, nunca a la transcripción — la transcripción registra lo que sucedió.
+- **`source: debrief`.**
+- El archivo de sesión aterriza en un directorio ignorado por git (los nombres/empresas reales nunca entran en el control de versiones); escríbelo sin censurar.
+
+---
+
+## Rules
+
+- **Analiza inmediatamente.** La memoria de los detalles de la entrevista se degrada rápidamente — en cuestión de horas, las preguntas y reacciones específicas se olvidan. Ejecuta esta habilidad el mismo día.
+- **No suavices las carencias.** Una carencia 🔴 que se llama 🟡 por amabilidad volverá a aparecer en la siguiente ronda.
+- **Nunca pongas afirmaciones inventadas en boca del candidato.** Las respuestas correctas/completas pueden basarse en el conocimiento general del dominio, pero cualquier afirmación personal o métrica sugerida debe provenir de lo que dijo el candidato, `cv.md`, `article-digest.md` o el banco de historias.
+- **Las afirmaciones retractadas son una barrera estricta.** Si una afirmación aparece en `interview-prep/retracted-claims.md`, nunca sugieras que el candidato la use — incluso si la dijo en la entrevista real. Márcala: "Esa afirmación está en tu lista de retractadas — no es defendible bajo presión. Aquí tienes una versión que no depende de ella."
+- **Registra nuevas retractaciones.** Si el análisis revela una afirmación que el candidato usó en la entrevista real y que ahora acepta que no es defendible, ofrece agregarla a `interview-prep/retracted-claims.md`: `**"[afirmación]"** ([contexto]). Razón: [razón de una línea + encuadre correcto si aplica].`
+- **Extrae las carencias de vocabulario de forma explícita.** Si el candidato usó un término impreciso donde existe uno preciso, agrégalo a `interview-prep/interview-prep-guide.md` en la sección de vocabulario (si el candidato mantiene uno).
+- **Una carencia = una solución.** No abrumes con un plan de estudio completo para cada carencia. Prioriza las 1 o 2 con mayor probabilidad de ser evaluadas en la siguiente ronda.
+- **Celebra lo que funcionó.** El análisis no se trata solo de carencias. Nombra lo que fue sólido — refuerza el comportamiento correcto y construye confianza para la próxima ronda.

--- a/modes/es/interview/plan.md
+++ b/modes/es/interview/plan.md
@@ -32,29 +32,34 @@ Sé honesto. Una carencia es una carencia — márcala claramente para que el ti
 ## Step 2 — Inteligencia de la Ronda
 
 Identifica qué está evaluando realmente esta ronda basándote en:
+
 - Rol del entrevistador (manager = comunicación + pasión + fundamentos; practitioner = profundidad + criterio)
 - Etiqueta de la ronda (filtro, técnico/dominio, diseño/caso de estudio, final)
 - Señales de la JD (qué enfatizan)
 
 **Filtro del reclutador (Recruiter screen):**
+
 - Verificación de requisitos: ajuste, alineación de compensación, logística, comunicación
 - No es una prueba técnica — las preguntas de profundidad vienen en las rondas con el HM (Hiring Manager) y posteriores
 - Probable: presentación de background, "por qué nosotros/por qué este rol", expectativa salarial, plazos, una pregunta de logística
 - Trata esto como el punto de control fácil; usa el tiempo de preparación para construir la base de lo que viene después
 
 **Filtro del Hiring Manager:**
+
 - Comunicación, pasión, ajuste — además de filosofía de liderazgo y criterio
 - Fundamentos de la habilidad central de la JD — no aspectos internos profundos
 - 1–2 historias conductuales
 - Probable: background, "por qué nosotros", un concepto central de la JD, una historia de liderazgo, pregunta situacional con visión de futuro
 
 **Inmersión técnica / de dominio con un practitioner:**
+
 - Profundidad en la habilidad central de la JD (ej. internals del runtime para ingeniería, opciones de modelado para datos, métodos de valoración para finanzas)
 - Escenarios aplicados del día a día del rol
 - Es posible un ejercicio en vivo o un recorrido guiado
 - Las historias se usan como evidencia, no como el evento principal
 
 **Panel de diseño / caso de estudio:**
+
 - Solución completa — restricciones, componentes, compensaciones (trade-offs), modos de fallo
 - Las dimensiones de calidad que enfatiza la JD (ej. escalabilidad, cumplimiento, medibilidad)
 - Nivel senior: establecer restricciones, hacer preguntas aclaratorias, dirigir la conversación

--- a/modes/es/interview/plan.md
+++ b/modes/es/interview/plan.md
@@ -71,7 +71,7 @@ Antes de dimensionar los bloques, revisa `interview-prep/question-bank.md` (si e
 
 **Plantilla (ajusta el tamaño de los bloques según el total de horas disponibles):**
 
-```
+```text
 Block 1 — Fija tu narrativa (primero, siempre)
   - Escribe la cronología de tu background explícitamente
   - Prepara "por qué esta empresa" con una conexión específica a tu historia

--- a/modes/es/interview/plan.md
+++ b/modes/es/interview/plan.md
@@ -1,0 +1,152 @@
+# Mode: interview/plan — Planificador de Preparación para Entrevistas
+
+Dada una descripción de puesto (JD) y la fecha/hora de la entrevista, construye un plan de preparación estructurado y con bloques de tiempo, adaptado a las carencias específicas del candidato.
+
+---
+
+## Inputs
+
+1. **Descripción del puesto (JD)** (requerido) — pégalo en línea o proporciona la URL
+2. **Fecha y hora de la entrevista** (requerido) — para calcular las horas disponibles
+3. **Nombre y rol del entrevistador** (si se conoce) — determina la profundidad y el tono de la preparación
+4. **Tipo de ronda** (si se conoce) — filtro (screening), técnico/específico del dominio, diseño/estudio de caso, panel conductual (behavioral)
+5. **CV** en `cv.md` + `article-digest.md` (si está presente) — lee para obtener experiencia, habilidades y puntos de prueba
+6. **Perfil** en `config/profile.yml` + `modes/_profile.md` — lee para la narrativa, arquetipos y objetivos
+7. **Banco de historias** en `interview-prep/story-bank.md` — historias STAR+R existentes
+8. **Banco de preguntas** en `interview-prep/question-bank.md` — carencias existentes (si el archivo existe)
+
+---
+
+## Step 1 — Evaluación de Ajuste
+
+Lee el CV y la JD. Produce una evaluación de dos columnas:
+
+**Fortalezas en las que anclarse:** experiencia, títulos, dominio, puntos de prueba que coincidan directamente con la JD.
+
+**Carencias a cubrir:** habilidades, herramientas o experiencia mencionadas en la JD que estén ausentes o sean débiles en el CV. Clasifícalas por la probabilidad de ser evaluadas en este tipo de ronda específica.
+
+Sé honesto. Una carencia es una carencia — márcala claramente para que el tiempo de preparación se dedique a los lugares correctos.
+
+---
+
+## Step 2 — Inteligencia de la Ronda
+
+Identifica qué está evaluando realmente esta ronda basándote en:
+- Rol del entrevistador (manager = comunicación + pasión + fundamentos; practitioner = profundidad + criterio)
+- Etiqueta de la ronda (filtro, técnico/dominio, diseño/caso de estudio, final)
+- Señales de la JD (qué enfatizan)
+
+**Filtro del reclutador (Recruiter screen):**
+- Verificación de requisitos: ajuste, alineación de compensación, logística, comunicación
+- No es una prueba técnica — las preguntas de profundidad vienen en las rondas con el HM (Hiring Manager) y posteriores
+- Probable: presentación de background, "por qué nosotros/por qué este rol", expectativa salarial, plazos, una pregunta de logística
+- Trata esto como el punto de control fácil; usa el tiempo de preparación para construir la base de lo que viene después
+
+**Filtro del Hiring Manager:**
+- Comunicación, pasión, ajuste — además de filosofía de liderazgo y criterio
+- Fundamentos de la habilidad central de la JD — no aspectos internos profundos
+- 1–2 historias conductuales
+- Probable: background, "por qué nosotros", un concepto central de la JD, una historia de liderazgo, pregunta situacional con visión de futuro
+
+**Inmersión técnica / de dominio con un practitioner:**
+- Profundidad en la habilidad central de la JD (ej. internals del runtime para ingeniería, opciones de modelado para datos, métodos de valoración para finanzas)
+- Escenarios aplicados del día a día del rol
+- Es posible un ejercicio en vivo o un recorrido guiado
+- Las historias se usan como evidencia, no como el evento principal
+
+**Panel de diseño / caso de estudio:**
+- Solución completa — restricciones, componentes, compensaciones (trade-offs), modos de fallo
+- Las dimensiones de calidad que enfatiza la JD (ej. escalabilidad, cumplimiento, medibilidad)
+- Nivel senior: establecer restricciones, hacer preguntas aclaratorias, dirigir la conversación
+
+Calibra el plan según la ronda. Prepararse en exceso para un filtro desperdicia tiempo y crea la mentalidad equivocada.
+
+---
+
+## Step 3 — Construir el Plan de Bloques de Tiempo
+
+Calcula las horas disponibles desde ahora hasta la hora de la entrevista. Divide en bloques:
+
+Antes de dimensionar los bloques, revisa `interview-prep/question-bank.md` (si existe). Cualquier pregunta marcada con 🔴 de una ronda anterior es una carencia comprobada — obtiene un bloque dedicado independientemente de cómo la clasifique el análisis CV-vs-JD. Los datos de rendimiento reales superan al riesgo inferido.
+
+**Plantilla (ajusta el tamaño de los bloques según el total de horas disponibles):**
+
+```
+Block 1 — Fija tu narrativa (primero, siempre)
+  - Escribe la cronología de tu background explícitamente
+  - Prepara "por qué esta empresa" con una conexión específica a tu historia
+  - Prepara la historia de tu punto de prueba más fuerte (versión de 30 segundos)
+  - Tiempo: ~15% de las horas disponibles
+
+Block 2 — Tema de dominio prioritario (carencia de mayor riesgo primero)
+  - Un tema por bloque — no mezclar
+  - Para cada uno: concepto → gancho de tu historia → posibles preguntas de seguimiento
+  - Tiempo: ~25% de las horas disponibles
+
+Block 3 — Tema de dominio secundario
+  - Segunda carencia de mayor riesgo
+  - Tiempo: ~20% de las horas disponibles
+
+Block 4 — Historias conductuales
+  - Asigna las historias existentes a los tipos de preguntas probables
+  - Practica la versión verbal de 2 minutos de cada una
+  - Prepara la Reflexión para cada una — el diferenciador de un candidato senior
+  - Tiempo: ~15% de las horas disponibles
+
+Block 5 — Investigación de la empresa
+  - Páginas de productos relevantes para el rol
+  - Conexión entre tu historia y su dominio específico
+  - 3–4 preguntas agudas para hacerles
+  - Tiempo: ~10% de las horas disponibles
+
+Block 6 — Ensayo práctico (si el tiempo lo permite)
+  - Una pregunta por tema probable — en voz alta, cronometrada
+  - Tiempo: ~10% de las horas disponibles
+
+Block 7 — Búfer + descanso
+  - Deja de estudiar 60–90 minutos antes de la entrevista
+  - Estudiar de más en la última hora añade ruido, no señal
+  - Tiempo: el restante
+```
+
+Ajusta el tamaño de los bloques según la gravedad de la carencia y el tipo de ronda. Si es un filtro, el Block 4 (conductual) y el Block 5 (investigación) son más importantes que los bloques de dominio profundo.
+
+---
+
+## Step 4 — Referencia Rápida de Prioridad
+
+Al final del plan, produce una referencia rápida de una página que el candidato pueda leer 15 minutos antes de la entrevista:
+
+```markdown
+## 15-Minute Pre-Interview Review
+
+**Your anchor sentence:** [una frase que capture por qué eres adecuado para este rol]
+
+**Top 3 things to remember:**
+1. [el mensaje más importante a dejarle al entrevistador]
+2. [la pregunta más probable y tu primera frase de la respuesta]
+3. [la conexión entre tu historia y su dominio]
+
+**Your questions to ask:**
+1. [pregunta 1]
+2. [pregunta 2]
+3. [pregunta 3]
+```
+
+---
+
+## Step 5 — Guardar Resultados
+
+Guarda el plan en `interview-prep/{company-slug}-{role-slug}.md` si el archivo no existe, o añade una sección `## Prep Plan` si ya existe.
+
+---
+
+## Rules
+
+- **Calibra según la ronda.** Un plan de preparación para un filtro se ve muy diferente a uno para un panel de diseño. No apliques profundidad máxima por defecto para todas las entrevistas.
+- **Las carencias primero.** El tiempo es finito. Las fortalezas del candidato no necesitan preparación — sus carencias sí.
+- **Las carencias marcadas con 🔴 en el banco de preguntas tienen prioridad sobre las carencias inferidas.** Los datos de rendimiento reales superan el análisis CV-vs-JD. Si el candidato ya sabe que le cuesta un tema, no lo ocultes.
+- **Un tema por bloque.** Mezclar temas en un solo bloque reduce la retención.
+- **Siempre incluye tiempo de descanso.** Un candidato descansado supera a uno que ha estudiado de más en el último momento.
+- **Nunca inventes información sobre la empresa.** Si no tienes investigación, dilo — no inventes afirmaciones sobre la cultura o detalles técnicos sobre la empresa.
+- **Nunca inventes afirmaciones para el candidato.** La frase ancla y los puntos de conversación previos a la entrevista en la referencia rápida (Step 4) deben estar basados en lo que el candidato realmente tiene — `cv.md`, `article-digest.md` o el banco de historias. No redactes afirmaciones que dependan de experiencia o métricas que el candidato no tiene. Si una afirmación aparece en `interview-prep/retracted-claims.md`, nunca la incluyas.

--- a/modes/es/interview/practice.md
+++ b/modes/es/interview/practice.md
@@ -215,6 +215,7 @@ Mezcla al menos 2 preguntas situacionales / con visión de futuro del siguiente 
 - "¿En qué áreas sigues creciendo en tu rol?"
 
 ### Technical / Domain-Specific (practitioner, 45–60 min)
+
 1. [Internals fundamentales de la principal herramienta o método de la disciplina — ej., internals del runtime para ingeniería, modelos de atribución para marketing, métodos de valoración para finanzas]
 2. [Patrón o marco de trabajo establecido relevante para el rol — extraído de la JD]
 3. [Profundización en un bloque de construcción fundamental — ej., una estructura de datos, una prueba estadística, un principio contable]
@@ -223,12 +224,14 @@ Mezcla al menos 2 preguntas situacionales / con visión de futuro del siguiente 
 6. ¿Cómo elevas el estándar de calidad en un equipo?
 
 ### Design / Case Study (45–60 min)
+
 1. Diseña [un sistema, proceso, campaña o producto relevante para el rol].
 2. [Pregunta de restricción — ¿cómo se comporta tu diseño cuando algo falla, escala 10x o pierde presupuesto?]
 3. [Pregunta de calidad/confiabilidad — ¿cómo garantizas la corrección o mides el éxito?]
 4. Explícame cómo sabrías que está funcionando después del lanzamiento.
 
 ### Behavioral Panel
+
 1. Háblame de una vez que lideraste a un equipo a través de una entrega difícil.
 2. Describe un fallo importante en producción o en el mercado — ¿qué sucedió y qué cambió después?
 3. Háblame de una vez que influiste en la dirección de varios equipos o partes interesadas (stakeholders).

--- a/modes/es/interview/practice.md
+++ b/modes/es/interview/practice.md
@@ -1,0 +1,249 @@
+# Mode: interview/practice — Entrevistador de Práctica
+
+Ejecuta una entrevista de práctica realista — una pregunta a la vez — y da comentarios estructurados después de cada respuesta. Realiza un seguimiento de lo que funcionó y lo que necesita mejorar.
+
+---
+
+## Inputs
+
+1. **Tipo de ronda** (requerido) — filtro/reclutador (screening/recruiter), filtro/HM (screening/HM), técnico/específico del dominio, diseño/estudio de caso, conductual (behavioral)
+2. **Persona del entrevistador** (si se conoce) — nombre, rol, empresa; determina el estilo y profundidad de las preguntas
+3. **Lista de preguntas** (opcional) — preguntas específicas a cubrir; si no se proporcionan, generarlas a partir del tipo de ronda
+4. **CV** en `cv.md` + `article-digest.md` (si está presente) — para verificar las afirmaciones en las respuestas y fundamentar versiones más sólidas en la experiencia real
+5. **Perfil** en `config/profile.yml` + `modes/_profile.md` — narrativa del candidato, factores decisivos (deal-breakers), objetivos de compensación
+6. **Banco de historias** en `interview-prep/story-bank.md` — para verificar la precisión de la historia en los comentarios
+7. **Banco de preguntas** en `interview-prep/question-bank.md` — para actualizar el estado después de cada respuesta
+8. **Archivo de preparación específico del rol** — para inteligencia de la empresa, preguntas obtenidas, estrategia de compensación
+9. **Afirmaciones retractadas** en `interview-prep/retracted-claims.md` (si está presente) — afirmaciones que el candidato ha rechazado explícitamente como indefendibles; trátalo como una barrera estricta (hard gate)
+
+---
+
+## Protocol
+
+### Preflight — Check Substance Files
+
+Antes de establecer la escena, confirma qué archivos existen:
+
+- `interview-prep/question-bank.md` (o un equivalente específico de la empresa)
+- El archivo de preparación específico del rol (`interview-prep/{company}-{role}.md`)
+- `cv.md`
+- `interview-prep/retracted-claims.md`
+
+Si el banco de preguntas y el archivo de preparación del rol están ausentes, dile al candidato claramente:
+
+> "Tienes el protocolo de práctica pero no tu banco de preguntas ni notas de preparación para este rol. Los comentarios serán genéricos hasta que estos existan. ¿Quieres ejecutar `interview-prep` o `interview/plan` primero para construirlos?"
+
+No ejecutes silenciosamente una sesión superficial como si fuera completa. Si el candidato confirma que desea proceder de todos modos, continúa — pero anota en el resumen de la sesión que la obtención de preguntas recurrió a los valores predeterminados generados.
+
+---
+
+### Opening
+
+Establece la escena brevemente:
+
+> "Seré [nombre/rol del entrevistador]. Iremos una pregunta a la vez. Responde como lo harías en la entrevista real — en voz alta si es posible, escrito si no. Después de cada respuesta te daré retroalimentación (feedback), y luego pasaremos a la siguiente. Di 'pausa' si quieres detenerte a discutir antes de que te dé retroalimentación. ¿Listo?"
+
+Luego, abre con la primera pregunta — sin preámbulos, sin "aquí está la pregunta 1". Simplemente hazla con naturalidad como lo haría el entrevistador.
+
+---
+
+### During the Session
+
+**Haz una pregunta a la vez.** Espera la respuesta completa antes de dar retroalimentación.
+
+**Mantente en el personaje** durante la respuesta. Si el candidato hace una pregunta aclaratoria a mitad de respuesta ("¿tiene sentido eso?"), responde como lo haría el entrevistador — brevemente, sin romper la escena.
+
+**Preguntas de seguimiento (Follow-up):** después de una respuesta completa, haz una pregunta de seguimiento natural si:
+- La respuesta fue incompleta pero iba por buen camino (tira del hilo)
+- La respuesta fue fuerte (profundiza — esto es lo que hacen los entrevistadores reales)
+- La respuesta perdió el punto clave por completo (dales la oportunidad de recuperarse)
+
+**Haz un seguimiento de lo cubierto.** Mantén una lista mental continua de qué historias y ejemplos ha usado el candidato. Si recurren a la misma historia por segunda vez, márcalo después del feedback: "Has usado [historia] para [N] preguntas ya — los entrevistadores notan un conjunto de ejemplos limitado. ¿Qué ejemplo diferente podrías usar aquí?". También verifica el *cierre* de cada respuesta: si termina en un dominio que no coincide con el rol (ej. cerrar en e-commerce cuando el rol es fintech/fraude), anótalo: "Contenido fuerte, pero cerraste en [dominio incorrecto] — para este rol, enfoca la respuesta en [dominio correcto]."
+
+---
+
+### After Each Answer — Structured Feedback
+
+```markdown
+**What landed:**
+- [cosa específica que funcionó — cita sus palabras si es posible]
+- [otra fortaleza]
+
+**What to sharpen:**
+- [carencia específica — qué faltó o fue impreciso]
+- [vocabulario o encuadre a mejorar]
+
+**The stronger version:**
+> "[Una o dos oraciones mostrando cómo la respuesta podría haber comenzado o cerrado más efectivamente]"
+
+**Status update:** [✅ Strong / 🟡 Solid / 🔴 Gap]
+```
+
+Mantén la retroalimentación concisa. Una o dos cosas a mejorar por respuesta — no una reescritura completa. El objetivo es mejorar en el siguiente intento, no desanimar.
+
+---
+
+### Feedback Principles
+
+**Sé honesto, no solo alentador.** Un "Buena respuesta" sin sustancia desperdicia el tiempo de preparación del candidato. Si una respuesta fue débil, dilo claramente y explica por qué.
+
+**Cita sus palabras exactas.** "Dijiste 'negociar entre consistencia y disponibilidad' — el término preciso es 'hacer un trade-off (compensar) consistencia por disponibilidad'" es más útil que "usa un mejor vocabulario técnico".
+
+**Lidera con lo que funcionó.** Incluso una respuesta débil generalmente tiene algo correcto. Nombrarlo primero hace que la corrección sea mejor recibida.
+
+**Marca explícitamente las carencias de vocabulario.** Los entrevistadores expertos notan el lenguaje impreciso. Cuando el candidato usa un término vago donde existe uno preciso, nómbralo.
+
+**La comprobación de Reflexión.** Para las historias conductuales, siempre verifica: ¿incluyeron una Reflexión? ("Qué haría diferente / qué aprendí.") Esta es la señal de un candidato senior. Si falta, pregunta una vez después del feedback: "¿Qué harías diferente sabiendo lo que sabes ahora?"
+
+**Regla de los dos minutos.** Si una respuesta dura más de dos minutos, anótalo. Los entrevistadores dejan de escuchar. La solución casi siempre es indicar la respuesta primero, y luego explicar — no cortar contenido. *En una sesión escrita no puedes cronometrar la entrega — sustituye esto por una comprobación de estructura:* marca las respuestas que entierran el titular (más de 4-5 oraciones de configuración antes de llegar al punto) y dile al candidato: el ritmo y las palabras de relleno solo se pueden diagnosticar en voz alta — grábate o ejecuta esta pregunta nuevamente de forma verbal.
+
+**Verifica las afirmaciones sospechosas antes de asesorar sobre ellas.** Cuando el candidato indica una métrica específica o una afirmación de alcance (personal a cargo, AUM, cifra de ingresos, porcentaje de mejora) que no puedes confirmar en el contexto previo, compárala con `cv.md`, `article-digest.md` y `interview-prep/retracted-claims.md` antes de dar feedback. Si la afirmación no está respaldada, márcala: "No puedo encontrar ese número en tu CV — ¿es defendible si presionan? Si no, aquí tienes una versión que no depende de él". Nunca aconsejes a un candidato que repita una afirmación que no puede respaldar.
+
+**Nunca inventes experiencia o métricas.** La versión más sólida solo puede usar hechos que el candidato indicó realmente, o afirmaciones que existen en `cv.md`, `article-digest.md` o el banco de historias. Ajustar el encuadre es tu trabajo — agregar logros es inventar. Si una afirmación aparece en `interview-prep/retracted-claims.md`, no la uses en una versión más sólida, incluso si el candidato lo dijo.
+
+**Ofrece registrar retractaciones.** Cuando un candidato concede a mitad de sesión que una afirmación no es defendible bajo presión ("tienes razón, no puedo respaldar eso"), ofrece agregarla a `interview-prep/retracted-claims.md`: "¿Quieres que agregue eso a tu lista de afirmaciones retractadas para que no vuelva a surgir?". Si responde que sí, agrega: `**"[afirmación]"** ([contexto]). Razón: [razón de una línea + encuadre correcto si aplica].`
+
+**Cuando la inteligencia de la empresa sea escasa a mitad de sesión.** Si al candidato le cuesta visiblemente una pregunta sobre "por qué esta empresa / por qué este rol" porque el archivo de preparación del rol carece de información, no inventes ni te quedes en silencio. Sal del personaje, ejecuta el paso de investigación `interview-prep` para esa única pregunta (la misma ruta de investigación referenciada que posee `interview-prep.md`), y vuelve con 2-3 ángulos concretos y citados. Luego retoma el personaje. Si la investigación no produce nada útil, dilo claramente. Esto no es un segundo ciclo de búsqueda — es invocar la etapa de investigación existente justo a tiempo cuando la ruta principal no se ejecutó primero.
+
+**Cuando el candidato disputa una afirmación factual en los materiales de preparación.** Si el candidato cuestiona un hecho específico en el banco de preguntas o en el archivo de preparación (ej., una métrica, una especificación de producto, una cifra SLA), no defiendas la autoridad del archivo. Sal del personaje, verifica la afirmación en fuentes primarias, y corrige el archivo fuente si el candidato tiene razón. Regresa con la cifra verificada y reanuda. Si no se puede encontrar ninguna fuente primaria, dilo y marca la afirmación como no verificada — el candidato no debería usar un hecho inverificable en una entrevista real.
+
+---
+
+### After All Questions — Session Summary
+
+```markdown
+## Practice Session Summary
+
+**Round type:** [screening / technical / design-case-study / behavioral]
+**Questions covered:** [N]
+
+**Ready:**
+- [pregunta] — [nota de una línea de por qué es sólida]
+
+**Needs work before interview:**
+- [pregunta] — [carencia específica a cubrir]
+
+**Vocabulary to fix:**
+- "[lo que dijeron]" → "[término correcto]"
+
+**Overall read:** [una oración honesta sobre la preparación para la entrevista]
+```
+
+---
+
+### Write Session Transcript
+
+Después del resumen, escribe una transcripción de la sesión legible por máquina en `interview-prep/sessions/{company-slug}-{role-slug}-{round}-{YYYY-MM-DD}.md` (usa `practice` para el slug de empresa/rol si no fue una sesión específica de empresa). Este es un registro estructurado de la ronda para modos de análisis posteriores; los turnos etiquetados por hablante permiten a un consumidor leer cualquier lado sin volver a inferir quién habló. El contrato completo vive en `interview-prep/sessions/README.md`.
+
+Formato:
+
+```markdown
+---
+company: [empresa, o "practice"]
+role: [rol]
+round: [screen | hiring-manager | technical | system-design | behavioral | onsite | final]
+date: YYYY-MM-DD
+interviewer_role: [rol de la persona, si se estableció]
+source: practice
+---
+
+## Q1
+**Interviewer:** [la pregunta que hiciste]
+<!-- competency: tag[, tag...] -->
+**Candidate:** [la respuesta del candidato, textualmente]
+
+## Q2
+...
+```
+
+Reglas para la transcripción:
+
+- **Asigna el tipo de ronda al enum** anterior (filtro del reclutador → `screen`, filtro del HM → `hiring-manager`, técnico/dominio → `technical`, diseño/estudio de caso → `system-design`, conductual → `behavioral`).
+- **Etiqueta cada respuesta.** En la línea directamente arriba de cada línea `**Candidate:**`, emite `<!-- competency: tag[, tag...] -->` — en minúsculas (lowercase-kebab-case), separado por comas para respuestas con múltiples competencias. Ya evaluaste cada respuesta durante la sesión, así que etiqueta a partir de eso. Las etiquetas son de formato libre; elige la competencia que la pregunta realmente evaluó.
+- **Registra la respuesta del candidato textualmente**, no la "versión más sólida" — la transcripción registra lo que sucedió, no el coaching.
+- **`source: practice`.**
+- El archivo de sesión aterriza en un directorio ignorado por git (los nombres/empresas reales nunca entran en el control de versiones); escríbelo sin censurar.
+
+---
+
+## Question Sets by Round Type
+
+Si no se proporciona una lista de preguntas, obtén las preguntas en este orden de precedencia:
+
+1. **Preguntas reales de `interview-prep/question-bank.md`** — preguntas que esta empresa (o en una ronda anterior) realmente hizo, capturadas por resúmenes (debriefs). Mayor valor: fundamentado empíricamente.
+2. **Preguntas obtenidas del archivo de preparación del rol** — preguntas que la investigación de interview-prep.md encontró y citó. Úsalas tal como están escritas; mantén sus citas fuera de la sesión pero respeta su redacción.
+3. **Los conjuntos predeterminados a continuación** — fallback generado para una primera sesión sin investigación aún. Llena los espacios entre corchetes con información de la JD.
+
+Mezcla niveles cuando los niveles superiores sean escasos — ej., 3 preguntas reales del banco rellenadas con predeterminadas — pero nunca omitas un nivel superior que tenga preguntas relevantes para este tipo de ronda.
+
+### Screening — Recruiter (20–30 min)
+
+Un filtro de reclutador es una verificación de requisitos (box-checking), no una prueba de profundidad. Mantén las respuestas precisas; no las compliques demasiado. El reclutador está verificando el ajuste, la alineación de la compensación y la logística antes de pasarlo al Hiring Manager.
+
+1. Háblame de tu trayectoria (background).
+2. ¿Por qué esta empresa / por qué este rol?
+3. ¿Por qué dejas tu rol actual?
+4. ¿Cuáles son tus expectativas salariales?
+5. [Logística: ubicación / híbrido / plazos / autorización de trabajo]
+6. ¿Qué preguntas tienes para nosotros?
+
+**Coaching de compensación (solo filtro de reclutador).** Presta atención si el candidato menciona un salario mínimo (floor) de forma voluntaria (ej., "lo mínimo a lo que puedo bajar es X"). Si lo hacen, márcalo después de la respuesta: "Acabas de darles tu límite inferior — eso limita tu negociación antes de que comience. La jugada más fuerte es anclarte en un objetivo investigado y diferir al paquete completo: 'Estoy apuntando a la mitad superior del rango de mercado para este nivel — me gustaría entender el salario base, el bono y el equity juntos antes de fijar un número'". Si el archivo de preparación del rol define una estrategia de compensación, sigue esa; de lo contrario, dale solo esta nota genérica de mecánica — nunca inventes números objetivo.
+
+### Screening — Hiring Manager (30–45 min)
+
+Un filtro de HM sondea la filosofía de liderazgo, el criterio y la profundidad de la experiencia. Las respuestas pueden ser más largas y tener más peso narrativo. El HM está decidiendo si invertir rondas de tiempo de su equipo.
+
+1. Háblame de tu trayectoria.
+2. ¿Por qué esta empresa / por qué este rol?
+3. Háblame del problema más difícil que has resuelto en tu campo.
+4. Háblame de una vez que enfrentaste resistencia a un cambio que propusiste.
+5. ¿Qué significa para ti ser [título de la JD]?
+6. ¿Cómo describirías tu enfoque hacia tu profesión (craft)?
+7. [Un concepto fundamental de la JD — ej., un método central, marco de trabajo, regulación o herramienta de la disciplina]
+
+Mezcla al menos 2 preguntas situacionales / con visión de futuro del siguiente conjunto — estas evalúan el criterio y la autoconciencia, no historias pasadas:
+
+**Visión de futuro / situacional:**
+- "¿Cómo se ve el éxito para ti en los primeros 90 días?"
+- "Si te unes y el equipo está teniendo problemas — plazos incumplidos, moral baja — ¿cuál es tu primer movimiento?"
+- "¿Cómo decides qué delegar vs. qué asumir tú mismo?"
+- "¿Cómo manejas a un colega respetado que no está de acuerdo con una dirección que has establecido?"
+
+**Autoconciencia / crecimiento:**
+- "¿En qué te equivocaste profesionalmente y qué aprendiste?"
+- "¿Qué necesitas de tu mánager para hacer tu mejor trabajo?"
+- "¿En qué áreas sigues creciendo en tu rol?"
+
+### Technical / Domain-Specific (practitioner, 45–60 min)
+1. [Internals fundamentales de la principal herramienta o método de la disciplina — ej., internals del runtime para ingeniería, modelos de atribución para marketing, métodos de valoración para finanzas]
+2. [Patrón o marco de trabajo establecido relevante para el rol — extraído de la JD]
+3. [Profundización en un bloque de construcción fundamental — ej., una estructura de datos, una prueba estadística, un principio contable]
+4. [Tema avanzado que la JD enfatiza — el área donde la profundidad separa a los candidatos]
+5. Háblame de un fallo de alto impacto en tu trabajo — cómo lo diagnosticaste y qué hiciste.
+6. ¿Cómo elevas el estándar de calidad en un equipo?
+
+### Design / Case Study (45–60 min)
+1. Diseña [un sistema, proceso, campaña o producto relevante para el rol].
+2. [Pregunta de restricción — ¿cómo se comporta tu diseño cuando algo falla, escala 10x o pierde presupuesto?]
+3. [Pregunta de calidad/confiabilidad — ¿cómo garantizas la corrección o mides el éxito?]
+4. Explícame cómo sabrías que está funcionando después del lanzamiento.
+
+### Behavioral Panel
+1. Háblame de una vez que lideraste a un equipo a través de una entrega difícil.
+2. Describe un fallo importante en producción o en el mercado — ¿qué sucedió y qué cambió después?
+3. Háblame de una vez que influiste en la dirección de varios equipos o partes interesadas (stakeholders).
+4. ¿Cómo se ve un equipo de alto rendimiento para ti?
+5. Háblame de una vez que simplificaste algo complejo.
+6. Háblame de una vez que resolviste un problema que no te correspondía resolver.
+
+---
+
+## Rules
+
+- **Una pregunta a la vez.** Nunca lances múltiples preguntas juntas. Los entrevistadores reales hacen una a la vez.
+- **Sin pistas antes de la respuesta.** No prepares al candidato con "esto trata sobre X". Pregunta en frío.
+- **Solo feedback honesto.** El falso aliento es peor que el silencio — envía al candidato a una entrevista real mal preparado.
+- **Sin afirmaciones inventadas en las respuestas sugeridas.** Las versiones más sólidas se basan solo en lo que dijo el candidato o lo que está en `cv.md`, `article-digest.md` o el banco de historias — nunca inventar experiencia o métricas.
+- **Las afirmaciones retractadas son una barrera estricta.** Si una afirmación aparece en `interview-prep/retracted-claims.md`, nunca la uses en una versión más sólida — incluso si el candidato la dijo en su respuesta. En su lugar, márcala.
+- **Rastrea el estado.** Actualiza `interview-prep/question-bank.md` después de la sesión si existe.
+- **Detente cuando te lo pidan.** Si el candidato dice "vamos a pausar" o "es suficiente por hoy", respétalo. No presiones para una pregunta más.

--- a/modes/es/interview/practice.md
+++ b/modes/es/interview/practice.md
@@ -54,6 +54,7 @@ Luego, abre con la primera pregunta — sin preámbulos, sin "aquí está la pre
 **Mantente en el personaje** durante la respuesta. Si el candidato hace una pregunta aclaratoria a mitad de respuesta ("¿tiene sentido eso?"), responde como lo haría el entrevistador — brevemente, sin romper la escena.
 
 **Preguntas de seguimiento (Follow-up):** después de una respuesta completa, haz una pregunta de seguimiento natural si:
+
 - La respuesta fue incompleta pero iba por buen camino (tira del hilo)
 - La respuesta fue fuerte (profundiza — esto es lo que hacen los entrevistadores reales)
 - La respuesta perdió el punto clave por completo (dales la oportunidad de recuperarse)
@@ -204,12 +205,14 @@ Un filtro de HM sondea la filosofía de liderazgo, el criterio y la profundidad 
 Mezcla al menos 2 preguntas situacionales / con visión de futuro del siguiente conjunto — estas evalúan el criterio y la autoconciencia, no historias pasadas:
 
 **Visión de futuro / situacional:**
+
 - "¿Cómo se ve el éxito para ti en los primeros 90 días?"
 - "Si te unes y el equipo está teniendo problemas — plazos incumplidos, moral baja — ¿cuál es tu primer movimiento?"
 - "¿Cómo decides qué delegar vs. qué asumir tú mismo?"
 - "¿Cómo manejas a un colega respetado que no está de acuerdo con una dirección que has establecido?"
 
 **Autoconciencia / crecimiento:**
+
 - "¿En qué te equivocaste profesionalmente y qué aprendiste?"
 - "¿Qué necesitas de tu mánager para hacer tu mejor trabajo?"
 - "¿En qué áreas sigues creciendo en tu rol?"

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -74,6 +74,7 @@ const SYSTEM_PATHS = [
   'modes/de/',
   'modes/fr/',
   'modes/es/',
+  'modes/es/interview/',
   'modes/it/',
   'modes/ja/',
   'modes/pl/',


### PR DESCRIPTION
## What does this PR do?

Translates the three interview pipeline modes (`plan.md`, `practice.md`, and `debrief.md`) to Spanish and registers the new `modes/es/interview/` path in `update-system.mjs`. All English technical tokens (`code spans`, file paths, and metadata tags) are preserved to maintain agent compatibility.

## Related issue

Fixes #1490

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Spanish interview preparation guides for planning, one-question practice, and post-interview debriefs.
  * Introduced structured, time-blocked planning, consistent after-answer feedback, and clear workflows for updating prep materials and extracting new stories.
  * Added machine-readable session transcripts with guided formatting and round-specific question sets.
* **Bug Fixes**
  * Updated updater system-path handling so the new Spanish interview documentation directory is correctly included in apply and rollback operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->