### PR TITLE
fix(merge-tracker): guard tier-3 fuzzy dedup with req/job numbers

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -407,6 +407,34 @@ function extractReportNum(reportStr) {
   return m ? parseInt(m[1]) : null;
 }
 
+// Matches the req/job-number labels actually seen in this tracker's free-text
+// Notes column: `R_1488728`, `Req PRACT011038`, `Req #1311`, `REQ-2026-32061`,
+// `Job 202606-116491`, `Job ID 65136`, `Posting ID 5340`, `JR00124259`,
+// `Ref R2857957`. The label is required so we don't grab an unrelated number
+// (a salary figure, a date fragment) — only text explicitly tagged as a
+// req/job/posting/reference id counts.
+const REQ_NUMBER_RE = /\b(?:job\s*id|posting\s*id|requisition|req|jr|job|posting|ref(?:erence)?|r_)[\s:#_-]*([a-z][a-z0-9-]*\d[a-z0-9-]*|\d[a-z0-9-]*)\b/i;
+
+/**
+ * Extract a req/job/posting number from a tracker Notes cell, if present.
+ *
+ * Tier-3 duplicate detection (company + fuzzy role match) has no awareness of
+ * req numbers on its own, which lets two distinct postings at the same company
+ * with similarly-worded titles collapse into one row (#1524 — e.g. two TD Bank
+ * L&D postings distinguished only by `R_1494379` vs `R_1488728`). This helper
+ * pulls out that number so the caller can treat a confirmed mismatch as proof
+ * the rows are NOT duplicates, without touching cases where no number is
+ * present on either side.
+ *
+ * @param {string} notes - Raw Notes cell from a tracker row or TSV addition.
+ * @returns {string|null} Uppercased req/job number, or null when none is found.
+ */
+function extractReqNumber(notes) {
+  if (!notes) return null;
+  const m = String(notes).match(REQ_NUMBER_RE);
+  return m ? m[1].toUpperCase() : null;
+}
+
 /**
  * Parse a score cell into a numeric value for score-upgrade decisions.
  *
@@ -706,9 +734,20 @@ for (const file of tsvFiles) {
   if (!duplicate) {
     // Company + role fuzzy match
     const normCompany = normalizeCompany(addition.company);
+    const additionReqNum = extractReqNumber(addition.notes);
     duplicate = existingApps.find(app => {
       if (normalizeCompany(app.company) !== normCompany) return false;
-      return roleFuzzyMatch(addition.role, app.role);
+      if (!roleFuzzyMatch(addition.role, app.role)) return false;
+      // Req/job-number guard (#1524): a similarly-worded title at the same
+      // company can still be a genuinely distinct posting when a req/job
+      // number in the Notes column proves it (employers like TD commonly run
+      // concurrent near-identical L&D/HR titles distinguished only by req#).
+      // Only treat this as evidence the rows differ when BOTH sides carry an
+      // extractable number and they disagree — if either side has none, fall
+      // back to today's fuzzy-match-only behavior unchanged.
+      const appReqNum = extractReqNumber(app.notes);
+      if (additionReqNum && appReqNum && additionReqNum !== appReqNum) return false;
+      return true;
     });
   }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4228,6 +4228,103 @@ try {
   fail(`merge-tracker report-number collision test crashed: ${e.message}`);
 }
 
+// ── MERGE-TRACKER REQ/JOB-NUMBER DEDUP GUARD (#1524) ─────────────────────
+// Tier-3 dedup (company + fuzzy role match) had no req/job-number awareness:
+// two distinct postings at the same company with similarly-worded titles were
+// silently collapsed into one row whenever a req/job number in the Notes
+// column was the only thing distinguishing them. Covers: (a) same-looking
+// titles + different req numbers → NOT a duplicate, (b) same-looking titles +
+// same req number → still a duplicate, (c) no req number on either side →
+// existing fuzzy-match behavior unchanged, (d) req number on only one side →
+// falls back to fuzzy-match behavior (can't prove a mismatch without both).
+console.log('\n🧪 Testing merge-tracker req/job-number dedup guard (#1524)...');
+try {
+  const reqTmp = mkdtempSync(join(tmpdir(), 'career-ops-merge-1524-'));
+  try {
+    mkdirSync(join(reqTmp, 'data'));
+    mkdirSync(join(reqTmp, 'reports'));
+    const reqAdditions = join(reqTmp, 'additions');
+    mkdirSync(reqAdditions);
+    const reqTracker = join(reqTmp, 'data', 'applications.md');
+    writeFileSync(reqTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 1 | 2026-01-01 | Fabrikam | Learning Development Designer III | 3.8/5 | Evaluated | ❌ | [1](../reports/001-fabrikam-2026-01-01.md) | Req R_1000001 |\n' +
+      '| 2 | 2026-01-01 | Fabrikam | Curriculum Program Coordinator | 3.5/5 | Evaluated | ❌ | [2](../reports/002-fabrikam-2026-01-01.md) | no req number here |\n' +
+      '| 3 | 2026-01-01 | Northwind | Operations Analyst | 3.6/5 | Evaluated | ❌ | [3](../reports/003-northwind-2026-01-01.md) | Job 2026-55501 |\n');
+    for (const n of [
+      '001-fabrikam-2026-01-01', '002-fabrikam-2026-01-01', '003-northwind-2026-01-01',
+      '004-fabrikam-2026-01-02', '005-fabrikam-2026-01-02', '006-fabrikam-2026-01-02', '007-northwind-2026-01-02',
+    ]) {
+      writeFileSync(join(reqTmp, 'reports', `${n}.md`), '# fixture\n');
+    }
+
+    // (a) Same-looking title, DIFFERENT req number → must NOT be treated as a duplicate.
+    writeFileSync(join(reqAdditions, '004-fabrikam.tsv'),
+      '4\t2026-01-02\tFabrikam\tLearning Development Curriculum Designer\tEvaluated\t4.5/5\t❌\t[4](reports/004-fabrikam-2026-01-02.md)\tReq R_1000002 — distinct posting (#1524)\n');
+    // (b) Same-looking title, SAME req number → still a duplicate (lower score → skipped, row untouched).
+    writeFileSync(join(reqAdditions, '005-fabrikam.tsv'),
+      '5\t2026-01-02\tFabrikam\tLearning Development Designer III (Repost)\tEvaluated\t3.0/5\t❌\t[5](reports/005-fabrikam-2026-01-02.md)\tReq R_1000001 — same posting repost\n');
+    // (c) No req number on either side → existing fuzzy-match behavior unchanged (still deduped).
+    writeFileSync(join(reqAdditions, '006-fabrikam.tsv'),
+      '6\t2026-01-02\tFabrikam\tCurriculum Program Coordinator II\tEvaluated\t3.9/5\t❌\t[6](reports/006-fabrikam-2026-01-02.md)\tno req number, higher score\n');
+    // (d) Req number on only one side → can't prove a mismatch, falls back to fuzzy-match (still deduped).
+    writeFileSync(join(reqAdditions, '007-northwind.tsv'),
+      '7\t2026-01-02\tNorthwind\tOperations Analyst\tEvaluated\t3.2/5\t❌\t[7](reports/007-northwind-2026-01-02.md)\tno req number on this side\n');
+
+    const reqResult = run(NODE, ['merge-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: reqTracker, CAREER_OPS_ADDITIONS: reqAdditions } });
+    if (reqResult === null) {
+      fail('merge-tracker.mjs crashed during req/job-number dedup guard test (#1524)');
+    } else {
+      const reqMerged = readFileSync(reqTracker, 'utf-8');
+      const reqRows = reqMerged.split('\n').filter(l => l.startsWith('| ') && !l.startsWith('| #') && !l.startsWith('|---'));
+
+      // (a) Different req numbers: distinct posting added as a NEW row, existing #1 left untouched.
+      const distinctRow = reqRows.find(r => r.includes('Learning Development Curriculum Designer'));
+      const originalRow1 = reqRows.find(r => r.includes('Learning Development Designer III') && !r.includes('(Repost)') && !r.includes('Curriculum Designer'));
+      if (distinctRow && originalRow1 && originalRow1.includes('3.8/5') && originalRow1.includes('R_1000001')) {
+        pass('(#1524a) different req numbers on similar titles → NOT deduped, both rows present');
+      } else {
+        fail('(#1524a) different req numbers on similar titles were incorrectly deduped');
+      }
+
+      // (b) Same req number: still recognized as a duplicate — no separate "(Repost)" row,
+      // and since the new score (3.0) is lower than the existing (3.8), the existing row is left as-is.
+      const repostRow = reqRows.find(r => r.includes('(Repost)'));
+      if (!repostRow && originalRow1 && originalRow1.includes('3.8/5')) {
+        pass('(#1524b) same req number on similar titles → still deduped (skipped, lower score)');
+      } else {
+        fail('(#1524b) same req number should have been deduped away, not added as a new row');
+      }
+
+      // (c) No req number on either side: existing fuzzy-match-only behavior preserved — deduped and
+      // updated in place (higher score), not appended as a new row.
+      const coordinatorRows = reqRows.filter(r => r.includes('Curriculum Program Coordinator'));
+      if (coordinatorRows.length === 1 && coordinatorRows[0].includes('3.9/5')) {
+        pass('(#1524c) no req number on either side → fuzzy-match behavior unchanged (updated in place)');
+      } else {
+        fail(`(#1524c) fuzzy-match-only behavior regressed: expected 1 'Curriculum Program Coordinator' row at 3.9/5, got ${coordinatorRows.length}`);
+      }
+
+      // (d) Req number on only one side (existing row has "Job 2026-55501", addition has none):
+      // can't prove a mismatch without both numbers, so falls back to fuzzy match → still deduped
+      // into exactly one row. The addition's score (3.2) is lower than the existing (3.6), so the
+      // existing row is left as-is rather than updated.
+      const opsAnalystRows = reqRows.filter(r => r.includes('Operations Analyst'));
+      if (opsAnalystRows.length === 1 && opsAnalystRows[0].includes('3.6/5')) {
+        pass('(#1524d) req number on only one side → falls back to fuzzy match, still deduped');
+      } else {
+        fail(`(#1524d) one-sided req number should fall back to fuzzy match: expected 1 'Operations Analyst' row at 3.6/5, got ${opsAnalystRows.length}`);
+      }
+    }
+  } finally {
+    rmSync(reqTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`merge-tracker req/job-number dedup guard test crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER CONCURRENT WRITES (#781 follow-up) ─────────────────────
 // Report-number reservation is atomic now (#803), but tracker merges are a
 // separate read/modify/write step. If two merge-tracker processes read the same


### PR DESCRIPTION
## Summary

Closes #1524.

`merge-tracker.mjs`'s tier-3 duplicate detection (company match + `roleFuzzyMatch`) had no req/job-number awareness. Two distinct postings at the same company with similarly-worded titles could collapse into a single tracker row whenever a req/job number in the free-text Notes column was the only thing actually distinguishing them — e.g. two L&D-type postings at the same employer with near-identical generic titles, different req numbers (`R_1494379` vs `R_1488728` in the reported case).

## Fix

- Added `extractReqNumber(notes)` in `merge-tracker.mjs`, which pulls a req/job/posting number out of a Notes cell.
- Wired it into the tier-3 fuzzy-match block: if **both** sides of a fuzzy-matched candidate have an extractable number and the numbers **differ**, the candidate is treated as **not** a duplicate (falls through to "new entry" / keeps searching). If **either side has no extractable number**, today's fuzzy-match-only behavior is unchanged.

## Req/job-number formats found in use

Grepped this project's own `data/applications.md` Notes column (not the three examples in the issue alone) to build the extraction regex against real formats rather than guessing:

- `R_1488728` (underscore prefix)
- `Req 1084`, `Req #1311`, `Req PRACT011038`, `Req SENIO001021` (bare/hash/alphanumeric)
- `REQ-056759`, `REQ-1000049295`, `REQ-2026-32061` (uppercase, hyphenated)
- `Job 202606-116491`, `Job #31786`, `Job ID 65136` (bare / hash / two-word "Job ID")
- `Posting ID 5340`, `Posting #114148`, `Posting 26-36`
- `JR00124259`, `JR6497` (no separator)
- `Ref R2857957`, `Ref 2026-45698`

`extractReqNumber()`'s regex covers all of these label prefixes (`R_`, `Req`/`REQ`/`Requisition`, `JR`, `Job`, `Job ID`, `Posting`, `Posting ID`, `Ref`/`Reference`) with a required trailing digit so it doesn't accidentally match unrelated words like "Required" or "Reference Program" that merely start with the same letters.

## Edge case: number on only one side

The issue doesn't fully spec this. I chose to fall back to existing fuzzy-match behavior (still treat as a duplicate if the fuzzy match says so) — you can't prove a mismatch without both numbers, and the issue is explicit that the fix should only *prevent false positives*, never introduce new false negatives on cases that already work today.

## Tests

Added a self-test block to `test-all.mjs` (mirroring the existing `#751`/`#912` merge-tracker regression blocks, same temp-fixture pattern) covering:

- (a) same-looking titles, different req numbers → NOT a duplicate, both rows survive
- (b) same-looking titles, same req number → still a duplicate (lower score → skipped, no extra row)
- (c) no req number on either side → existing fuzzy-match behavior unchanged (still deduped/updated)
- (d) req number on only one side → falls back to fuzzy match, still deduped

All example/test data uses invented placeholder companies (Fabrikam, Northwind) — no real company names or personal job-search data.

## Test plan

- [x] `node test-all.mjs --quick` — 1158 passed, 0 failed, 1 warning (pre-existing/expected warnings only — no rate-limit flake observed)
- [x] New req/job-number dedup self-test block passes all 4 cases (a)-(d)
- [x] Manually verified merge-tracker output against a debug fixture before finalizing assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate handling in the tracker so similar entries with different request/job identifiers are no longer incorrectly merged.
  * Existing duplicate detection still works when identifiers match, and behavior now falls back safely when identifiers are missing on one or both sides.
  * Added coverage for key merge scenarios to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->