### PR TITLE
feat(i18n): translate interview modes to French

### DIFF
--- a/modes/fr/interview/debrief.md
+++ b/modes/fr/interview/debrief.md
@@ -1,0 +1,204 @@
+# Mode: interview/debrief — Débriefing post-entretien
+
+Après un véritable entretien, capturez ce qui a été demandé, évaluez ce qui a fonctionné et ce qui n'a pas fonctionné, comblez les lacunes avant le prochain round et mettez à jour la banque de questions.
+
+---
+
+## When to Run This Skill
+
+- Immédiatement après un vrai entretien (pendant que la mémoire est fraîche)
+- Après un appel avec un recruteur qui a fait remonter de nouvelles informations sur le processus
+- Lorsque le candidat apprend le format du prochain round et le nom de l'intervieweur
+
+---
+
+## Inputs
+
+1. **Débriefing de l'entretien par le candidat** — quelles questions ont été posées, comment il a répondu, ce qui a semblé solide ou faible
+2. **Nom et rôle de l'intervieweur** — informe la prédiction pour le prochain round
+3. **Résultat du round** (si connu) — avance / rejeté / en attente
+4. **Détails du prochain round** (si connu) — format, intervieweurs, calendrier
+5. **Banque de questions** dans `interview-prep/question-bank.md` — mise à jour avec de vraies données
+6. **Banque d'histoires** dans `interview-prep/story-bank.md` — ajoute de nouvelles histoires si elles font surface
+7. **CV** dans `cv.md` + `article-digest.md` (si présent) — pour ancrer les réponses suggérées dans une expérience réelle
+8. **Affirmations rétractées** dans `interview-prep/retracted-claims.md` (si présent) — barrière stricte ; n'utilisez jamais une affirmation rétractée dans une réponse suggérée même si le candidat l'a dite pendant l'entretien
+9. **Fichier de préparation spécifique au rôle** — ajoutez les notes de débriefing
+
+---
+
+## Step 1 — Capture What Was Asked
+
+Demandez au candidat d'énumérer toutes les questions dont il se souvient, dans l'ordre si possible. Ne suggérez pas d'options — laissez-le d'abord se souvenir librement.
+
+Pour chaque question capturée :
+
+- Qu'ont-ils dit ?
+- Comment l'intervieweur a-t-il réagi (signal positif, neutre, a repoussé, est passé rapidement à autre chose) ?
+- Se sont-ils sentis confiants ou incertains ?
+
+Si la mémoire est incomplète, posez des questions ciblées :
+
+- "Y a-t-il eu des questions qui vous ont pris au dépourvu ?"
+- "Y a-t-il quelque chose auquel vous auriez souhaité répondre différemment ?"
+- "L'intervieweur a-t-il relancé sur quoi que ce soit — cela signifie généralement qu'il en voulait plus ?"
+
+---
+
+## Step 2 — Honest Assessment Per Question
+
+Pour chaque question, produisez :
+
+```markdown
+**Q: [question]**
+- Ce qui a été dit : [résumé de leur réponse]
+- Ce qui a fonctionné : [ce qui était bon — soyez spécifique]
+- Ce qui manquait : [lacune — terme technique précis, résultat manquant, pas de réflexion, etc.]
+- Réponse correcte/complète : [ce que la réponse complète devrait inclure]
+- Statut : ✅ Solide / 🟡 Correct / 🔴 Lacune
+```
+
+Soyez direct. S'ils ont raté le concept central que la question testait, dites-le. Si une réponse était véritablement forte, dites-le aussi. Le débriefing est le moment d'apprentissage le plus précieux — l'imprécision le gaspille.
+
+---
+
+## Step 3 — Update Question Bank
+
+Pour chaque question débriefée, mettez à jour `interview-prep/question-bank.md` :
+
+- Changez le statut en ✅ / 🟡 / 🔴 en fonction de la performance réelle
+- Ajoutez des notes de lacune à partir du débriefing
+- Ajoutez toute nouvelle question qui est apparue et qui n'était pas encore dans la banque
+
+Si la banque de questions n'existe pas, créez-la avec les questions de cet entretien comme point de départ.
+
+---
+
+## Step 4 — Close the Gaps
+
+Pour chaque 🔴 lacune identifiée :
+
+1. **Expliquez la bonne réponse** — claire, concise, avec un exemple travaillé (code, calcul, diagramme) là où cela aide
+2. **Connectez à une vraie histoire** si possible — "vous avez en fait cela dans votre [histoire existante de la banque d'histoires] — voici comment l'utiliser"
+3. **Ajoutez au fichier de préparation spécifique au rôle** sous une section "Lacunes à combler avant le round N"
+4. **Ajoutez à `interview-prep/interview-prep-guide.md`** (si le candidat en maintient un) quand il s'agit d'un principe réutilisable qui s'applique au-delà de ce rôle
+
+---
+
+## Step 5 — Extract New Stories
+
+Parfois, un vrai entretien fait ressortir une histoire que le candidat n'avait pas préparée. Si le candidat a décrit une expérience qu'il n'avait pas formalisée :
+
+> "Vous avez mentionné [X] dans votre réponse — cela ressemble à ce qui pourrait devenir une vraie histoire STAR+R. Voulez-vous la construire maintenant pendant que c'est frais ?"
+
+Si oui, construisez-la comme une histoire STAR+R (Situation, Tâche, Action, Résultat, Réflexion) et ajoutez-la à `interview-prep/story-bank.md`.
+
+---
+
+## Step 6 — Next Round Intelligence
+
+Si le candidat connaît le format du prochain round :
+
+1. **Prévoyez les questions probables** en fonction de :
+   - Le rôle du prochain intervieweur (par ex., praticien senior → profondeur dans la compétence centrale, conception ; pair interfonctionnel → collaboration, limites du domaine ; dirigeant → stratégie, impact sur l'entreprise)
+   - Ce qui a été couvert dans ce round (le round suivant va généralement plus en profondeur, pas en largeur)
+   - Ce qui a semblé le plus intéresser l'intervieweur dans ce round
+
+   Étiquetez chaque prédiction `[inferred]` — ne présentez jamais une question prédite comme si elle provenait de vrais candidats ou d'initiés.
+
+2. **Créez une liste de priorités** pour la préparation du prochain round — ordonnée par gravité de la lacune et probabilité d'être testée
+
+3. **Suggérez d'exécuter** `interview/plan` avec les détails du prochain round pour construire un plan de préparation complet
+
+---
+
+## Step 7 — Probability Assessment (Optional)
+
+Si le candidat demande une lecture honnête de ses chances :
+
+Évaluez en fonction de :
+
+- Nombre et gravité des lacunes (🔴 sur les fondamentaux = risque plus élevé que 🔴 sur les sujets avancés)
+- Signaux de l'intervieweur (a donné des détails spécifiques sur le prochain round = positif ; vague = neutre ; appel court = risque)
+- Adéquation au rôle (années d'expérience, correspondance de domaine, localisation)
+- Différenciateurs (choses que le candidat a dites et que la plupart des candidats ne diraient pas)
+
+Soyez honnête. Une fourchette de probabilité avec un raisonnement clair est plus utile qu'une fausse confiance.
+
+---
+
+## Step 8 — Save Debrief
+
+Ajoutez à `interview-prep/{company-slug}-{role-slug}.md` :
+
+```markdown
+## Round [N] Debrief — [YYYY-MM-DD]
+
+**Intervieweur :** [nom, rôle]
+**Type de round :** [screening / technical / design-case-study / behavioral]
+**Résultat :** [pending / moved forward / rejected]
+
+### Questions Asked
+[liste]
+
+### Gaps Identified
+[liste avec les bonnes réponses]
+
+### Next Round
+**Format :** [si connu]
+**Intervieweurs :** [si connu]
+**Préparation prioritaire :** [top 3 des sujets à combler avant le prochain round]
+
+### Process Intel (recruiter / HM screens — omit if not applicable)
+**Rémunération discutée :** [oui / non — si oui, ce qui a été dit et ce qui a été ancré]
+**Calendrier :** [toutes les dates ou échéances mentionnées]
+**Autres candidats :** [si divulgué]
+**Prochaines étapes :** [ce que l'intervieweur a dit qu'il se passerait ensuite et d'ici quand]
+```
+
+---
+
+## Step 9 — Write Session Transcript
+
+Après le débriefing, rédigez également une transcription de session lisible par machine vers `interview-prep/sessions/{company-slug}-{role-slug}-{round}-{YYYY-MM-DD}.md`. C'est un enregistrement structuré du round pour les modes d'analyse en aval ; les tours étiquetés par l'intervenant permettent à un consommateur de lire les deux côtés sans réinférer qui a parlé. Le contrat complet se trouve dans `interview-prep/sessions/README.md`.
+
+Format :
+
+```markdown
+---
+company: [company]
+role: [role]
+round: [screen | hiring-manager | technical | system-design | behavioral | onsite | final]
+date: YYYY-MM-DD
+interviewer_role: [rôle, si connu]
+source: debrief
+---
+
+## Q1
+**Interviewer:** [question telle que posée]
+<!-- competency: tag[, tag...] -->
+**Candidate:** [réponse telle que livrée / reconstruite dans ce débriefing]
+
+## Q2
+...
+```
+
+Règles pour la transcription :
+
+- **Mappez le type de round à l'énumération** ci-dessus (par ex. recruteur screen → `screen`, HM screen → `hiring-manager`, plongée technique approfondie → `technical`, conception/étude de cas → `system-design`).
+- **Taguez chaque réponse.** Sur la ligne juste au-dessus de chaque ligne `**Candidate:**`, émettez `<!-- competency: tag[, tag...] -->` — en minuscules kebab-case, séparés par des virgules pour les réponses multi-compétences (par ex. `system-design`, `people-leadership`, `incident-response`). Vous avez déjà évalué chaque réponse à l'étape 2, donc taguez à partir de cette évaluation plutôt que de relire. Les tags sont libres ; choisissez la compétence que la question a réellement testée.
+- **Reconstruisez fidèlement le tour du candidat.** Utilisez ce que le candidat a déclaré avoir dit à l'étape 1, et non une réponse idéalisée. La "réponse correcte/complète" de l'étape 2 appartient au fichier de débriefing, jamais dans la transcription — la transcription enregistre ce qui s'est passé.
+- **`source: debrief`.**
+- Le fichier de session atterrit dans un répertoire gitignored (les vrais noms/entreprises n'entrent jamais dans le contrôle de version) ; rédigez-le sans expurger.
+
+---
+
+## Rules
+
+- **Débriefez immédiatement.** Le souvenir des détails de l'entretien se dégrade vite — en quelques heures, les questions et réactions spécifiques sont oubliées. Exécutez cette compétence le même jour.
+- **Ne minimisez pas les lacunes.** Une 🔴 lacune qui est qualifiée de 🟡 par gentillesse réapparaîtra lors du prochain round.
+- **Ne mettez jamais d'affirmations inventées dans la bouche du candidat.** Les réponses correctes/complètes peuvent s'appuyer sur des connaissances générales du domaine, mais toute affirmation personnelle ou mesure suggérée doit provenir de ce que le candidat a dit, de `cv.md`, de `article-digest.md` ou de la banque d'histoires.
+- **Les affirmations rétractées sont une barrière stricte.** Si une affirmation apparaît dans `interview-prep/retracted-claims.md`, ne suggérez jamais au candidat de l'utiliser — même s'il l'a dite lors du vrai entretien. Signalez-le : "Cette affirmation est dans votre liste rétractée — elle n'est pas défendable sous pression. Voici une version qui n'en dépend pas."
+- **Enregistrez de nouvelles rétractations.** Si le débriefing révèle une affirmation que le candidat a utilisée lors du vrai entretien et qu'il accepte maintenant de ne pas être défendable, proposez de l'ajouter à `interview-prep/retracted-claims.md` : `**"[affirmation]"** ([contexte]). Raison : [raison d'une ligne + formulation correcte si applicable].`
+- **Extrayez explicitement les lacunes de vocabulaire.** Si le candidat a utilisé un terme imprécis là où un terme précis existe, ajoutez-le à `interview-prep/interview-prep-guide.md` sous la section vocabulaire (si le candidat en maintient un).
+- **Une lacune = un correctif.** Ne surchargez pas avec un plan d'étude complet pour chaque lacune. Donnez la priorité à la ou aux deux plus susceptibles d'être testées lors du prochain round.
+- **Célébrez ce qui a fonctionné.** Le débriefing ne concerne pas seulement les lacunes. Nommez ce qui était solide — cela renforce le bon comportement et donne confiance pour le prochain round.

--- a/modes/fr/interview/plan.md
+++ b/modes/fr/interview/plan.md
@@ -1,0 +1,157 @@
+# Mode: interview/plan — Planificateur de préparation d'entretien
+
+Étant donné une description de poste et la date/heure de l'entretien, créez un plan de préparation structuré et organisé par blocs de temps, adapté aux lacunes spécifiques du candidat.
+
+---
+
+## Inputs
+
+1. **Description de poste** (requis) — collez en ligne ou fournissez l'URL
+2. **Date et heure de l'entretien** (requis) — pour calculer les heures disponibles
+3. **Nom et rôle de l'intervieweur** (si connu) — oriente la profondeur et le ton de la préparation
+4. **Type de round** (si connu) — sélection (screening), technique/spécifique au domaine, conception/étude de cas, panel comportemental
+5. **CV** dans `cv.md` + `article-digest.md` (si présent) — lire pour l'expérience, les compétences, les points de preuve
+6. **Profil** dans `config/profile.yml` + `modes/_profile.md` — lire pour la narration, les archétypes et les cibles
+7. **Banque d'histoires** dans `interview-prep/story-bank.md` — histoires STAR+R existantes
+8. **Banque de questions** dans `interview-prep/question-bank.md` — lacunes existantes (si le fichier existe)
+
+---
+
+## Step 1 — Fit Assessment
+
+Lisez le CV et la JD (description de poste). Produisez une évaluation sur deux colonnes :
+
+**Points forts sur lesquels s'appuyer :** expérience, titres, domaine, points de preuve qui correspondent directement à la JD.
+
+**Lacunes à combler :** compétences, outils ou expériences mentionnés dans la JD qui sont absents ou faibles dans le CV. Classez par probabilité d'être testés dans ce type spécifique de round.
+
+Soyez honnête. Une lacune est une lacune — signalez-la clairement pour que le temps de préparation soit alloué aux bons endroits.
+
+---
+
+## Step 2 — Round Intelligence
+
+Identifiez ce que ce round évalue réellement en fonction de :
+
+- Le rôle de l'intervieweur (manager = communication + passion + fondamentaux ; praticien = profondeur + jugement)
+- L'étiquette du round (sélection, technique/domaine, conception/étude de cas, final)
+- Les signaux de la JD (ce qu'ils mettent en évidence)
+
+**Recruiter screen :**
+
+- Coche les cases : adéquation, alignement de la rémunération, logistique, communication
+- Ce n'est pas un test technique — les questions approfondies viennent avec le Hiring Manager et dans les rounds suivants
+- Probable : pitch de présentation, "pourquoi nous / pourquoi ce rôle", attente salariale, calendrier, une question logistique
+- Traitez ceci comme le point de contrôle facile ; utilisez le temps de préparation pour construire les fondations de ce qui vient ensuite
+
+**Hiring-manager screen :**
+
+- Communication, passion, adéquation — plus la philosophie de leadership et le jugement
+- Fondamentaux de la compétence principale de la JD — pas les composants internes profonds
+- 1–2 histoires comportementales
+- Probable : parcours, "pourquoi nous", un concept central de la JD, une histoire de leadership, une question de mise en situation orientée vers l'avenir
+
+**Technical / domain deep-dive with a practitioner :**
+
+- Profondeur dans la compétence principale de la JD (par ex., fonctionnement interne pour l'ingénierie, choix de modélisation pour la data, méthodes d'évaluation pour la finance)
+- Scénarios appliqués issus du quotidien du rôle
+- Exercice en direct ou explication d'un cas travaillé possible
+- Les histoires sont utilisées comme preuves, pas comme événement principal
+
+**Design / case study panel :**
+
+- Solution complète — contraintes, composants, compromis, modes de défaillance
+- Les dimensions de qualité que la JD souligne (par ex., scalabilité, conformité, mesurabilité)
+- Niveau senior : définir les contraintes, poser des questions de clarification, mener la conversation
+
+Calibrez le plan au round. Trop préparer en profondeur pour un round de sélection fait perdre du temps et crée le mauvais état d'esprit.
+
+---
+
+## Step 3 — Build the Time-Blocked Plan
+
+Calculez les heures disponibles entre maintenant et l'heure de l'entretien. Divisez en blocs :
+
+Avant de dimensionner les blocs, vérifiez `interview-prep/question-bank.md` (s'il existe). Toute question marquée 🔴 lors d'un round précédent est une lacune prouvée — elle obtient un bloc dédié indépendamment de la façon dont l'analyse CV-vs-JD la classe. Les données de performance réelles priment sur le risque inféré.
+
+**Modèle (ajustez la taille des blocs en fonction des heures totales disponibles) :**
+
+```text
+Block 1 — Fixez votre narration (en premier, toujours)
+  - Rédigez explicitement la chronologie de votre parcours
+  - Préparez "pourquoi cette entreprise" avec un lien spécifique à votre histoire
+  - Préparez l'histoire de votre point de preuve le plus fort (version de 30 secondes)
+  - Temps : ~15% des heures disponibles
+
+Block 2 — Sujet de domaine prioritaire (lacune à plus haut risque en premier)
+  - Un sujet par bloc — ne mélangez pas
+  - Pour chacun : concept → votre accroche d'histoire → questions de suivi probables
+  - Temps : ~25% des heures disponibles
+
+Block 3 — Sujet de domaine secondaire
+  - Lacune avec le deuxième risque le plus élevé
+  - Temps : ~20% des heures disponibles
+
+Block 4 — Histoires comportementales
+  - Associez les histoires existantes aux types de questions probables
+  - Pratiquez la version verbale de 2 minutes pour chacune
+  - Préparez la Réflexion pour chacune — l'élément différenciateur du candidat senior
+  - Temps : ~15% des heures disponibles
+
+Block 5 — Recherche sur l'entreprise
+  - Pages de produits pertinentes pour le rôle
+  - Lien entre votre parcours et leur domaine spécifique
+  - 3–4 questions pointues à leur poser
+  - Temps : ~10% des heures disponibles
+
+Block 6 — Test pratique (si le temps le permet)
+  - Une question par sujet probable — à voix haute, chronométrée
+  - Temps : ~10% des heures disponibles
+
+Block 7 — Marge + repos
+  - Arrêtez d'étudier 60–90 minutes avant l'entretien
+  - Bachoter dans la dernière heure ajoute du bruit, pas du signal
+  - Temps : restant
+```
+
+Ajustez la taille des blocs en fonction de la gravité des lacunes et du type de round. S'il s'agit d'une sélection (screening), le Block 4 (comportemental) et le Block 5 (recherche sur l'entreprise) sont plus importants que les blocs approfondis du domaine.
+
+---
+
+## Step 4 — Priority Quick-Reference
+
+À la fin du plan, produisez une référence rapide d'une page que le candidat peut parcourir 15 minutes avant l'entretien :
+
+```markdown
+## 15-Minute Pre-Interview Review
+
+**Votre phrase d'ancrage :** [une phrase qui capture pourquoi vous êtes le candidat idéal pour ce rôle]
+
+**Les 3 choses principales à retenir :**
+1. [message le plus important avec lequel laisser l'intervieweur]
+2. [question la plus probable et la première phrase de votre réponse]
+3. [le lien entre votre parcours et leur domaine]
+
+**Vos questions à poser :**
+1. [question 1]
+2. [question 2]
+3. [question 3]
+```
+
+---
+
+## Step 5 — Save Output
+
+Sauvegardez le plan dans `interview-prep/{company-slug}-{role-slug}.md` si un fichier n'existe pas, ou ajoutez une section `## Prep Plan` s'il existe.
+
+---
+
+## Rules
+
+- **Calibrez en fonction du round.** Un plan de préparation de screening est très différent d'un plan pour un panel de conception. Ne prenez pas par défaut une profondeur maximale pour chaque entretien.
+- **Les lacunes d'abord.** Le temps est limité. Les points forts du candidat n'ont pas besoin de préparation — ses lacunes, si.
+- **Les lacunes 🔴 de la banque de questions priment sur les lacunes déduites.** Les données réelles de performance valent mieux que l'analyse CV-vs-JD. Si le candidat sait déjà qu'il a des difficultés sur un sujet, ne l'ignorez pas.
+- **Un sujet par bloc.** Mélanger les sujets dans un seul bloc réduit la rétention.
+- **Prévoyez toujours du temps de repos.** Un candidat reposé est plus performant qu'un candidat qui a bachoté.
+- **Ne générez jamais de fausses informations sur l'entreprise.** Si vous n'avez pas fait de recherches, dites-le — n'inventez pas d'affirmations sur la culture ou de détails techniques sur l'entreprise.
+- **N'inventez jamais d'affirmations pour le candidat.** La phrase d'ancrage et les points de discussion pré-entretien dans la référence rapide (Step 4) doivent être fondés sur ce que le candidat a réellement — `cv.md`, `article-digest.md` ou la banque d'histoires. Ne rédigez pas d'affirmations qui dépendent d'une expérience ou de mesures que le candidat n'a pas. Si une affirmation apparaît dans `interview-prep/retracted-claims.md`, ne l'incluez jamais.

--- a/modes/fr/interview/practice.md
+++ b/modes/fr/interview/practice.md
@@ -1,0 +1,255 @@
+# Mode: interview/practice — Interviewer d'entraînement
+
+Dirigez un entretien d'entraînement réaliste — une question à la fois — et donnez des retours structurés après chaque réponse. Suit ce qui a fonctionné et ce qui doit être amélioré.
+
+---
+
+## Inputs
+
+1. **Type de round** (requis) — sélection/recruteur, sélection/HM, technique/spécifique au domaine, conception/étude de cas, comportemental
+2. **Persona de l'intervieweur** (si connu) — nom, rôle, entreprise ; oriente le style et la profondeur des questions
+3. **Liste de questions** (facultatif) — questions spécifiques à couvrir ; si non fournie, générez-les à partir du type de round
+4. **CV** dans `cv.md` + `article-digest.md` (si présent) — pour vérifier les affirmations dans les réponses et ancrer des versions plus solides dans une expérience réelle
+5. **Profil** dans `config/profile.yml` + `modes/_profile.md` — narration du candidat, critères rédhibitoires, cibles de rémunération
+6. **Banque d'histoires** dans `interview-prep/story-bank.md` — pour vérifier l'exactitude de l'histoire dans les retours
+7. **Banque de questions** dans `interview-prep/question-bank.md` — pour mettre à jour le statut après chaque réponse
+8. **Fichier de préparation spécifique au rôle** — pour les informations sur l'entreprise, les questions sourcées, la stratégie de rémunération
+9. **Affirmations rétractées** dans `interview-prep/retracted-claims.md` (si présent) — affirmations que le candidat a explicitement rejetées comme indéfendables ; traitez comme une barrière stricte
+
+---
+
+## Protocol
+
+### Preflight — Check Substance Files
+
+Avant de planter le décor, confirmez quels fichiers existent :
+
+- `interview-prep/question-bank.md` (ou un équivalent spécifique à l'entreprise)
+- Le fichier de préparation spécifique au rôle (`interview-prep/{company}-{role}.md`)
+- `cv.md`
+- `interview-prep/retracted-claims.md`
+
+Si la banque de questions et le fichier de préparation spécifique au rôle sont tous les deux absents, dites au candidat clairement :
+
+> "Vous avez le protocole d'entraînement mais pas votre banque de questions ou vos notes de préparation pour ce rôle. Les retours seront génériques jusqu'à ce que ceux-ci existent. Voulez-vous exécuter `interview-prep` ou `interview/plan` d'abord pour les créer ?"
+
+Ne dirigez pas silencieusement une session superficielle comme s'il s'agissait d'une session complète. Si le candidat confirme qu'il veut continuer quand même, continuez — mais notez dans le résumé de la session que la source des questions s'est rabattue sur les valeurs par défaut générées.
+
+---
+
+### Opening
+
+Plantez le décor brièvement :
+
+> "Je vais jouer le rôle de [nom de l'intervieweur/rôle]. Nous allons procéder une question à la fois. Répondez comme vous le feriez dans le véritable entretien — à voix haute si possible, tapé sinon. Après chaque réponse, je vous donnerai des retours, puis nous passerons à la suivante. Dites 'pause' si vous voulez vous arrêter et discuter avant que je ne donne mes retours. Prêt ?"
+
+Ensuite, commencez avec la première question — pas de préambule, pas de "voici la question 1". Posez-la simplement naturellement comme le ferait l'intervieweur.
+
+---
+
+### During the Session
+
+**Posez une question à la fois.** Attendez la réponse complète avant de donner des retours.
+
+**Restez dans le personnage** pendant la réponse. Si le candidat pose une question de clarification au milieu de sa réponse ("est-ce que cela a du sens ?"), répondez comme le ferait l'intervieweur — brièvement, sans rompre la scène.
+
+**Questions de suivi :** après une réponse complète, posez un suivi naturel si :
+
+- La réponse était incomplète mais sur la bonne voie (tirez le fil)
+- La réponse était forte (allez plus en profondeur — c'est ce que font les vrais intervieweurs)
+- La réponse a complètement raté le point clé (donnez-leur une chance de se rattraper)
+
+**Suivez ce qui a été couvert.** Gardez une liste mentale des histoires et exemples que le candidat a utilisés. S'ils reprennent la même histoire une deuxième fois, signalez-le après le retour : "Vous avez utilisé [histoire] pour [N] questions maintenant — les intervieweurs remarquent un ensemble d'exemples limité. Quel serait un exemple différent que vous pourriez utiliser ici ?" Vérifiez également la *fin* de chaque réponse : si elle atterrit sur un domaine qui ne correspond pas au rôle (par ex., terminer sur le commerce électronique quand le rôle est fintech/fraude), notez-le : "Contenu solide, mais vous avez conclu sur [mauvais domaine] — pour ce rôle, orientez la réponse sur [bon domaine]."
+
+---
+
+### After Each Answer — Structured Feedback
+
+```markdown
+**Ce qui a fonctionné :**
+- [chose spécifique qui a marché — citez leurs mots si possible]
+- [un autre point fort]
+
+**Ce qui doit être affûté :**
+- [lacune spécifique — ce qui manquait ou était imprécis]
+- [vocabulaire ou formulation à améliorer]
+
+**La version plus solide :**
+> "[Une ou deux phrases montrant comment la réponse aurait pu s'ouvrir ou se conclure plus efficacement]"
+
+**Mise à jour du statut :** [✅ Solide / 🟡 Correct / 🔴 Lacune]
+```
+
+Gardez les retours concis. Une ou deux choses à affûter par réponse — pas une réécriture complète. Le but est l'amélioration à la prochaine tentative, pas le découragement.
+
+---
+
+### Feedback Principles
+
+**Soyez honnête, pas encourageant.** "Bonne réponse" sans substance fait perdre le temps de préparation du candidat. Si une réponse était faible, dites-le clairement et expliquez pourquoi.
+
+**Citez leurs propres mots.** "Vous avez dit 'négocier entre cohérence et disponibilité' — le terme précis est 'faire un compromis entre cohérence et disponibilité'" est plus utile que "utilisez un meilleur vocabulaire technique."
+
+**Commencez par ce qui a fonctionné.** Même une réponse faible a généralement quelque chose de juste. Le nommer en premier permet de mieux faire passer la correction.
+
+**Signalez explicitement les lacunes de vocabulaire.** Les intervieweurs experts remarquent le langage imprécis. Lorsque le candidat utilise un terme vague là où un terme précis existe, signalez-le nommément.
+
+**La vérification de Réflexion.** Pour les histoires comportementales, vérifiez toujours : ont-ils inclus une Réflexion ? ("Ce que je ferais différemment / ce que j'ai appris.") C'est le signal du candidat senior. S'il manque, demandez une fois après le retour : "Que feriez-vous différemment en sachant ce que vous savez maintenant ?"
+
+**La règle des deux minutes.** Si une réponse dépasse deux minutes, notez-le. Les intervieweurs arrêtent d'écouter. La solution est presque toujours d'énoncer la réponse d'abord, puis d'expliquer — pas de couper du contenu. *Dans une session tapée, vous ne pouvez pas chronométrer la livraison — substituez une vérification de structure à la place :* signalez les réponses qui enterrent le message principal (plus de 4–5 phrases d'introduction avant que le point n'arrive) et dites au candidat : le rythme et les mots de remplissage ne peuvent être diagnostiqués qu'à voix haute — enregistrez-vous ou repassez cette question verbalement.
+
+**Vérifiez les affirmations suspectes avant de les coacher.** Lorsque le candidat énonce une mesure ou une portée spécifique (effectif géré, AUM, chiffre d'affaires, pourcentage d'amélioration) que vous ne pouvez pas confirmer par le contexte précédent, vérifiez-la par rapport à `cv.md`, `article-digest.md` et `interview-prep/retracted-claims.md` avant de donner des retours. Si l'affirmation n'est pas étayée, signalez-le : "Je ne trouve pas ce chiffre dans votre CV — est-ce défendable s'ils insistent ? Si ce n'est pas le cas, voici une version qui n'en dépend pas." Ne coachez jamais un candidat pour répéter une affirmation qu'il ne peut pas prouver.
+
+**N'inventez jamais d'expérience ou de mesures.** La version plus solide ne peut utiliser que des faits que le candidat a réellement énoncés, ou des affirmations qui existent dans `cv.md`, `article-digest.md` ou la banque d'histoires. Resserrez la formulation est le travail — ajouter des accomplissements est une fabrication. Si une affirmation apparaît dans `interview-prep/retracted-claims.md`, ne l'utilisez pas dans une version plus solide même si le candidat l'a dite.
+
+**Proposez d'enregistrer les rétractations.** Lorsqu'un candidat concède au milieu d'une session qu'une affirmation n'est pas défendable sous la pression ("vous avez raison, je ne peux pas prouver ça"), proposez de l'ajouter à `interview-prep/retracted-claims.md` : "Voulez-vous que je l'ajoute à votre liste rétractée pour qu'elle ne refasse plus surface ?" Si oui, ajoutez : `**"[affirmation]"** ([contexte]). Raison : [raison d'une ligne + formulation correcte si applicable].`
+
+**Lorsque les informations sur l'entreprise sont minces en pleine session.** Si le candidat a visiblement du mal sur une question "pourquoi cette entreprise / pourquoi ce rôle" parce que le fichier de préparation spécifique au rôle manque d'informations, n'inventez pas et ne restez pas silencieux. Sortez de votre personnage, exécutez l'étape de recherche `interview-prep` pour cette seule question (le même chemin de recherche sourcée que possède `interview-prep.md`), et revenez avec 2–3 angles concrets et cités. Ensuite, reprenez le personnage. Si la recherche ne donne rien d'utilisable, dites-le clairement. Il ne s'agit pas d'une deuxième boucle de recherche — c'est invoquer l'étape de recherche existante juste à temps lorsque le pipeline en amont n'a pas été exécuté en premier.
+
+**Lorsque le candidat conteste une affirmation factuelle dans les documents de préparation.** Si le candidat conteste un fait spécifique dans la banque de questions ou le fichier de préparation (par ex., une métrique, une spécification de produit, un chiffre de SLA), ne défendez pas l'autorité du fichier. Sortez de votre personnage, vérifiez l'affirmation par rapport aux sources primaires et corrigez le fichier source si le candidat a raison. Revenez avec le chiffre vérifié et reprenez. Si aucune source primaire ne peut être trouvée, dites-le et marquez l'affirmation comme non vérifiée — le candidat ne devrait pas utiliser un fait invérifiable dans un vrai entretien.
+
+---
+
+### After All Questions — Session Summary
+
+```markdown
+## Practice Session Summary
+
+**Type de round :** [screening / technical / design-case-study / behavioral]
+**Questions couvertes :** [N]
+
+**Prêt :**
+- [question] — [note d'une ligne sur pourquoi c'est solide]
+
+**À travailler avant l'entretien :**
+- [question] — [lacune spécifique à combler]
+
+**Vocabulaire à corriger :**
+- "[ce qu'ils ont dit]" → "[terme correct]"
+
+**Lecture globale :** [une phrase honnête sur la préparation à l'entretien]
+```
+
+---
+
+### Write Session Transcript
+
+Après le résumé, rédigez une transcription de session lisible par machine vers `interview-prep/sessions/{company-slug}-{role-slug}-{round}-{YYYY-MM-DD}.md` (utilisez `practice` pour le slug entreprise/rôle s'il ne s'agissait pas d'une session spécifique à l'entreprise). C'est un enregistrement structuré du round pour les modes d'analyse en aval ; les tours étiquetés par l'intervenant permettent à un consommateur de lire les deux côtés sans réinférer qui a parlé. Le contrat complet se trouve dans `interview-prep/sessions/README.md`.
+
+Format :
+
+```markdown
+---
+company: [company, ou "practice"]
+role: [role]
+round: [screen | hiring-manager | technical | system-design | behavioral | onsite | final]
+date: YYYY-MM-DD
+interviewer_role: [rôle du persona, si défini]
+source: practice
+---
+
+## Q1
+**Interviewer:** [la question que vous avez posée]
+<!-- competency: tag[, tag...] -->
+**Candidate:** [la réponse du candidat, mot pour mot]
+
+## Q2
+...
+```
+
+Règles pour la transcription :
+
+- **Mappez le type de round à l'énumération** ci-dessus (recruteur screen → `screen`, HM screen → `hiring-manager`, technique/domaine → `technical`, conception/étude de cas → `system-design`, comportemental → `behavioral`).
+- **Taguez chaque réponse.** Sur la ligne juste au-dessus de chaque ligne `**Candidate:**`, émettez `<!-- competency: tag[, tag...] -->` — en minuscules kebab-case, séparés par des virgules pour les réponses multi-compétences. Vous avez déjà évalué chaque réponse pendant la session, donc taguez à partir de là. Les tags sont libres ; choisissez la compétence que la question a réellement testée.
+- **Enregistrez la réponse du candidat mot pour mot**, pas la "version plus solide" — la transcription enregistre ce qui s'est passé, pas le coaching.
+- **`source: practice`.**
+- Le fichier de session atterrit dans un répertoire gitignored (les vrais noms/entreprises n'entrent jamais dans le contrôle de version) ; rédigez-le sans expurger.
+
+---
+
+## Question Sets by Round Type
+
+Si aucune liste de questions n'est fournie, sourcez les questions dans cet ordre de priorité :
+
+1. **Vraies questions de `interview-prep/question-bank.md`** — questions que cette entreprise (ou lors d'un round précédent) a réellement posées, capturées par les débriefings. La valeur la plus élevée : empiriquement fondé.
+2. **Questions sourcées du fichier de préparation spécifique au rôle** — questions que la recherche interview-prep.md a trouvées et citées. Utilisez-les telles quelles ; gardez leurs citations hors de la session mais respectez leur formulation.
+3. **Les ensembles par défaut ci-dessous** — solution de repli générée pour une première session sans recherche préalable. Remplissez les emplacements entre crochets à partir de la JD.
+
+Mélangez les niveaux lorsque les niveaux supérieurs sont minces — par ex., 3 vraies questions de la banque complétées par des valeurs par défaut — mais ne sautez jamais un niveau supérieur qui a des questions pertinentes pour ce type de round.
+
+### Screening — Recruiter (20–30 min)
+
+Un screen de recruteur est une vérification de cases, pas un sondage en profondeur. Gardez les réponses nettes ; ne les sur-concevez pas. Le recruteur vérifie l'adéquation, l'alignement de la rémunération et la logistique avant de passer le relais au Hiring Manager.
+
+1. Parlez-moi de votre parcours.
+2. Pourquoi cette entreprise / pourquoi ce rôle ?
+3. Pourquoi quittez-vous votre rôle actuel ?
+4. Quelles sont vos attentes salariales ?
+5. [Logistique : emplacement / hybride / calendrier / autorisation de travail]
+6. Quelles questions avez-vous pour nous ?
+
+**Coaching de rémunération (recruiter screen uniquement).** Surveillez si le candidat donne de lui-même un plancher salarial non sollicité (par ex., "le minimum auquel je peux descendre est X"). S'il le fait, signalez-le après la réponse : "Vous venez de leur donner votre plancher — cela plafonne votre négociation avant qu'elle ne commence. Le mouvement le plus fort est de s'ancrer sur une cible étudiée et de reporter au package global : 'Je cible la moitié supérieure de la fourchette du marché pour ce niveau — je voudrais comprendre le salaire de base, le bonus et les actions ensemble avant de me fixer sur un chiffre.'" Si le fichier de préparation spécifique au rôle définit une stratégie de rémunération, suivez-la ; sinon donnez uniquement cette note mécanique générique — n'inventez jamais de chiffres cibles.
+
+### Screening — Hiring Manager (30–45 min)
+
+Un screen de HM sonde la philosophie de leadership, le jugement et la profondeur de l'expérience. Les réponses peuvent être plus longues et avoir plus de poids narratif. Le HM décide s'il doit investir le temps de son équipe dans des rounds supplémentaires.
+
+1. Parlez-moi de votre parcours.
+2. Pourquoi cette entreprise / pourquoi ce rôle ?
+3. Parlez-moi du problème le plus difficile que vous ayez résolu dans votre domaine.
+4. Parlez-moi d'une fois où vous avez fait face à une résistance par rapport à un changement que vous proposiez.
+5. Que signifie [titre de la JD] pour vous ?
+6. Comment décririez-vous votre approche de votre métier ?
+7. [Un concept fondamental de la JD — par ex., une méthode centrale, un framework, une réglementation ou un outil de la discipline]
+
+Incorporez au moins 2 questions situationnelles / orientées vers l'avenir de l'ensemble ci-dessous — celles-ci sondent le jugement et la conscience de soi, pas les histoires passées :
+
+**Forward-looking / situational :**
+
+- "À quoi ressemble le succès pour vous dans les 90 premiers jours ?"
+- "Si vous rejoignez et que l'équipe est en difficulté — délais manqués, moral bas — quelle est votre première action ?"
+- "Comment décidez-vous ce qu'il faut déléguer par rapport à ce qu'il faut posséder soi-même ?"
+- "Comment gérez-vous un collègue respecté qui n'est pas d'accord avec une direction que vous avez fixée ?"
+
+**Self-awareness / growth :**
+
+- "Qu'est-ce que vous avez mal fait professionnellement et qu'avez-vous appris ?"
+- "De quoi avez-vous besoin de la part de votre manager pour faire votre meilleur travail ?"
+- "Où êtes-vous encore en train de grandir dans votre rôle ?"
+
+### Technical / Domain-Specific (practitioner, 45–60 min)
+
+1. [Internes centraux du principal outil ou méthode de la discipline — par ex., internes de fonctionnement pour l'ingénierie, modèles d'attribution pour le marketing, méthodes d'évaluation pour la finance]
+2. [Modèle ou framework établi pertinent pour le rôle — à partir de la JD]
+3. [Exploration en profondeur d'un bloc de construction fondamental — par ex., une structure de données, un test statistique, un principe comptable]
+4. [Sujet avancé que la JD met en avant — le domaine où la profondeur sépare les candidats]
+5. Parlez-moi d'un échec aux enjeux élevés dans votre travail — comment vous l'avez diagnostiqué et ce que vous avez fait.
+6. Comment relevez-vous la barre de qualité dans une équipe ?
+
+### Design / Case Study (45–60 min)
+
+1. Concevez [un système, un processus, une campagne ou un produit pertinent pour le rôle].
+2. [Question de contrainte — comment se comporte votre conception lorsque quelque chose échoue, évolue de 10x ou perd son budget ?]
+3. [Question de qualité/fiabilité — comment garantissez-vous l'exactitude ou mesurez-vous le succès ?]
+4. Expliquez-moi comment vous sauriez que cela fonctionne après le lancement.
+
+### Behavioral Panel
+
+1. Parlez-moi d'une fois où vous avez dirigé une équipe à travers une livraison difficile.
+2. Décrivez un échec majeur en production ou sur le marché — que s'est-il passé et qu'est-ce qui a changé après ?
+3. Parlez-moi d'une fois où vous avez influencé la direction à travers les équipes ou les parties prenantes.
+4. À quoi ressemble une équipe très performante pour vous ?
+5. Parlez-moi d'une fois où vous avez simplifié quelque chose de complexe.
+6. Parlez-moi d'une fois où vous avez résolu un problème qui n'était pas le vôtre à résoudre.
+
+---
+
+## Rules
+
+- **Une question à la fois.** Ne donnez jamais plusieurs questions en avance. Les vrais intervieweurs demandent une chose à la fois.
+- **Aucun indice avant la réponse.** Ne préparez pas le candidat avec "c'est à propos de X". Demandez froidement.
+- **Retours honnêtes uniquement.** Un faux encouragement est pire que le silence — il envoie un candidat dans un vrai entretien sous-préparé.
+- **Aucune affirmation fabriquée dans les réponses suggérées.** Les versions plus solides ne s'appuient que sur ce que le candidat a dit ou ce qui est dans `cv.md`, `article-digest.md` ou la banque d'histoires — jamais d'expérience ou de mesures inventées.
+- **Les affirmations rétractées sont une barrière stricte.** Si une affirmation apparaît dans `interview-prep/retracted-claims.md`, ne l'utilisez jamais dans une version plus solide — même si le candidat l'a dite dans sa réponse. Signalez-le à la place.
+- **Suivre le statut.** Mettez à jour `interview-prep/question-bank.md` après la session s'il existe.
+- **Arrêtez lorsqu'on vous le demande.** Si le candidat dit "faisons une pause" ou "c'est suffisant pour aujourd'hui", respectez-le. N'insistez pas pour une question de plus.

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -73,6 +73,7 @@ const SYSTEM_PATHS = [
   'modes/da/',
   'modes/de/',
   'modes/fr/',
+  'modes/fr/interview/',
   'modes/es/',
   'modes/it/',
   'modes/ja/',


### PR DESCRIPTION
## What does this PR do?

The interview pipeline previously only existed in English, meaning Francophone users experienced a sudden switch to English mid-pipeline. This PR brings the three core interview modes (`plan.md`, `practice.md`, and `debrief.md`) to the French ecosystem for a seamless native experience, while strictly preserving all English technical tokens and file paths for the AI agents.

## Related issue

Fixes #1489

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)