### PR TITLE
feat(portals): probe non-ATS boards through the provider layer in verify-portals

### DIFF
--- a/providers/_registry.mjs
+++ b/providers/_registry.mjs
@@ -1,0 +1,94 @@
+// Provider registry — loading and routing shared by the scanner and the portal
+// health check. Files prefixed with _ are never loaded as providers by scan.mjs,
+// so this helper module lives safely alongside the provider plugins.
+//
+// Extracted from scan.mjs (#1451-era inline definitions) so verify-portals.mjs
+// can route non-ATS boards through the SAME provider layer the scanner uses,
+// without importing scan.mjs itself (which has top-level side effects and would
+// form an import cycle via classifyFetchError).
+
+import { existsSync, readdirSync } from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+/**
+ * Load every provider plugin in a directory into an id→provider Map.
+ *
+ * Alphabetical order so detect() priority is deterministic across machines.
+ * Malformed modules (wrong shape, duplicate id, import error) are logged and
+ * skipped, never fatal.
+ *
+ * @param {string} dir - Absolute path to the providers directory.
+ * @returns {Promise<Map<string, object>>}
+ */
+export async function loadProviders(dir) {
+  const providers = new Map();
+  if (!existsSync(dir)) return providers;
+  const entries = readdirSync(dir)
+    .filter(f => f.endsWith('.mjs') && !f.startsWith('_'))
+    .sort();
+  for (const file of entries) {
+    const full = path.join(dir, file);
+    let mod;
+    try {
+      mod = await import(pathToFileURL(full).href);
+    } catch (err) {
+      console.error(`⚠️  ${file}: failed to load — ${err.message}`);
+      continue;
+    }
+    const p = mod.default;
+    if (!p || typeof p.fetch !== 'function' || !p.id) {
+      console.error(`⚠️  ${file}: skipping — default export must be { id, fetch }`);
+      continue;
+    }
+    if (providers.has(p.id)) {
+      console.error(`⚠️  ${file}: duplicate provider id "${p.id}" — keeping first`);
+      continue;
+    }
+    providers.set(p.id, p);
+  }
+  return providers;
+}
+
+/**
+ * Resolve which provider handles a tracked_companies entry.
+ *   1. Explicit `provider:` field wins (skips detect()).
+ *   2. local-parser when parser.command + script are configured (before API detect).
+ *   3. Otherwise each provider's detect() runs in load order; first hit wins.
+ *
+ * @param {object} entry - tracked_companies entry.
+ * @param {Map<string, object>} providers - id→provider Map from loadProviders().
+ * @param {{skipIds?: string[]}} [opts] - Provider ids to skip (e.g. 'local-parser'
+ *   so a network-only health check never execs a configured local command).
+ * @returns {{provider: object}|{error: string}|null}
+ */
+export function resolveProvider(entry, providers, { skipIds = [] } = {}) {
+  if (entry.provider) {
+    const p = providers.get(entry.provider);
+    if (!p) return { error: `unknown provider: ${entry.provider}` };
+    return { provider: p };
+  }
+
+  const localParser = providers.get('local-parser');
+  if (localParser && !skipIds.includes('local-parser')) {
+    try {
+      const hit = localParser.detect?.(entry);
+      if (hit) return { provider: localParser };
+    } catch (err) {
+      console.error(`⚠️  local-parser: detect() threw for "${entry.name}" — ${err.message}`);
+    }
+  }
+
+  for (const p of providers.values()) {
+    if (skipIds.includes(p.id)) continue;
+    let hit;
+    try {
+      hit = p.detect?.(entry);
+    } catch (err) {
+      console.error(`⚠️  ${p.id}: detect() threw for "${entry.name}" — ${err.message}`);
+      continue;
+    }
+    if (hit) return { provider: p };
+  }
+  return null;
+}

--- a/providers/_types.js
+++ b/providers/_types.js
@@ -91,6 +91,13 @@
  * @property {('http')} transport
  * @property {(url: string, opts?: FetchOptions) => Promise<string>}  fetchText
  * @property {(url: string, opts?: FetchOptions) => Promise<unknown>} fetchJson
+ * @property {number} [maxPages] Optional pagination hint. When set (verify-portals.mjs's
+ *                              health probe passes 1), a paginating provider SHOULD stop
+ *                              after this many pages — the probe only needs the first page
+ *                              to tell a live board from a broken one, and must not walk an
+ *                              entire careers site. Providers that ignore it stay correct:
+ *                              the probe caps their requests defensively via the context's
+ *                              own fetch functions.
  */
 
 /**

--- a/scan.mjs
+++ b/scan.mjs
@@ -30,13 +30,14 @@
  *   node scan.mjs --verify --throttle=8000     # custom base gap in ms (waits base..2*base)
  */
 
-import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, readdirSync } from 'fs';
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
 import { pathToFileURL, fileURLToPath } from 'url';
 import path from 'path';
 import yaml from 'js-yaml';
 
 import { makeHttpCtx } from './providers/_http.mjs';
 import { buildTrustValidator } from './providers/_trust-validator.mjs';
+import { loadProviders, resolveProvider } from './providers/_registry.mjs';
 import { mergeProviderPlugins } from './plugins/_engine.mjs';
 import { classifyFetchError } from './verify-portals.mjs';
 
@@ -63,72 +64,9 @@ mkdirSync('data', { recursive: true });
 
 const CONCURRENCY = 10;
 
-// ── Provider loading ────────────────────────────────────────────────
-
-async function loadProviders(dir) {
-  const providers = new Map();
-  if (!existsSync(dir)) return providers;
-  // Alphabetical order so detect() priority is deterministic across machines.
-  const entries = readdirSync(dir)
-    .filter(f => f.endsWith('.mjs') && !f.startsWith('_'))
-    .sort();
-  for (const file of entries) {
-    const full = path.join(dir, file);
-    let mod;
-    try {
-      mod = await import(pathToFileURL(full).href);
-    } catch (err) {
-      console.error(`⚠️  ${file}: failed to load — ${err.message}`);
-      continue;
-    }
-    const p = mod.default;
-    if (!p || typeof p.fetch !== 'function' || !p.id) {
-      console.error(`⚠️  ${file}: skipping — default export must be { id, fetch }`);
-      continue;
-    }
-    if (providers.has(p.id)) {
-      console.error(`⚠️  ${file}: duplicate provider id "${p.id}" — keeping first`);
-      continue;
-    }
-    providers.set(p.id, p);
-  }
-  return providers;
-}
-
-// Resolve which provider handles a tracked_companies entry.
-// 1. Explicit `provider:` field wins (skips detect()).
-// 2. local-parser when parser.command + script are configured (before API detect).
-// 3. Otherwise each provider's detect() runs in load order; first hit wins.
-function resolveProvider(entry, providers, { skipIds = [] } = {}) {
-  if (entry.provider) {
-    const p = providers.get(entry.provider);
-    if (!p) return { error: `unknown provider: ${entry.provider}` };
-    return { provider: p };
-  }
-
-  const localParser = providers.get('local-parser');
-  if (localParser && !skipIds.includes('local-parser')) {
-    try {
-      const hit = localParser.detect?.(entry);
-      if (hit) return { provider: localParser };
-    } catch (err) {
-      console.error(`⚠️  local-parser: detect() threw for "${entry.name}" — ${err.message}`);
-    }
-  }
-
-  for (const p of providers.values()) {
-    if (skipIds.includes(p.id)) continue;
-    let hit;
-    try {
-      hit = p.detect?.(entry);
-    } catch (err) {
-      console.error(`⚠️  ${p.id}: detect() threw for "${entry.name}" — ${err.message}`);
-      continue;
-    }
-    if (hit) return { provider: p };
-  }
-  return null;
-}
+// Provider loading + routing live in providers/_registry.mjs so the portal
+// health check (verify-portals.mjs) can reuse the exact same layer without
+// importing this module.
 
 // ── Title filter ────────────────────────────────────────────────────
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1699,6 +1699,66 @@ try {
   } else {
     fail(`verify-portals classification wrong: ${JSON.stringify(byName)} (${results.length} rows)`);
   }
+
+  // Tier 2: non-ATS companies are probed through the scanner's provider layer,
+  // bounded to the first page. Fake providers stand in for Workday/SF/etc.
+  const fakeCtx = { transport: 'http', fetchJson: async () => ({}), fetchText: async () => ['x'] };
+  const fakeProviders = new Map([
+    ['fakeats', {
+      id: 'fakeats',
+      detect: (e) => (/fakeats\.io/.test(e.careers_url || '') ? { url: e.careers_url } : null),
+      fetch: async (e, ctx) => {
+        // The probe MUST bound pagination — a provider is never asked to walk a
+        // whole board for a health check.
+        if (ctx.maxPages !== 1) throw new Error('probe did not pass maxPages=1');
+        if (e.careers_url.includes('/full')) return [{ title: 'A' }, { title: 'B' }];
+        if (e.careers_url.includes('/empty')) return [];
+        const err = new Error('HTTP 404'); err.status = 404; throw err;
+      },
+    }],
+    ['pager', {
+      // Ignores maxPages and paginates forever; the probe's request budget must
+      // still cut it off after the first page and classify it live.
+      id: 'pager',
+      detect: (e) => (/pager\.io/.test(e.careers_url || '') ? { url: e.careers_url } : null),
+      fetch: async (e, ctx) => {
+        const jobs = [];
+        for (let p = 0; p < 50; p++) jobs.push(...(await ctx.fetchText(`u?p=${p}`)));
+        return jobs;
+      },
+    }],
+  ]);
+  const provResults = await verifyCompanies([
+    { name: 'PFull', careers_url: 'https://fakeats.io/full' },
+    { name: 'PEmpty', careers_url: 'https://fakeats.io/empty' },
+    { name: 'PDead', careers_url: 'https://fakeats.io/dead' },
+    { name: 'PPager', careers_url: 'https://pager.io/board' },
+    { name: 'NoProv', careers_url: 'https://unknown.example/careers' },
+  ], { fetchJson: mockFetch, providers: fakeProviders, httpCtx: fakeCtx });
+  const pv = Object.fromEntries(provResults.map((r) => [r.name, r]));
+  if (
+    pv.PFull?.status === 'live' && pv.PFull?.jobCount === 2 &&
+    pv.PEmpty?.status === 'empty' &&
+    pv.PDead?.status === 'missing' && pv.PDead?.errorKind === 'slug_gone' &&
+    pv.PPager?.status === 'live' && pv.PPager?.partial === true &&
+    pv.NoProv?.status === 'skipped'
+  ) {
+    pass('verify-portals probes non-ATS boards via providers, bounded to first page');
+  } else {
+    fail(`verify-portals provider-fallback wrong: ${JSON.stringify(pv)}`);
+  }
+
+  // Without a providers map, non-ATS entries must stay skipped (unchanged CLI
+  // behavior for the ATS-only unit path).
+  const noProv = await verifyCompanies(
+    [{ name: 'X', careers_url: 'https://fakeats.io/full' }],
+    { fetchJson: mockFetch },
+  );
+  if (noProv[0]?.status === 'skipped') {
+    pass('verify-portals stays skipped for non-ATS when no providers are supplied');
+  } else {
+    fail(`verify-portals should skip non-ATS without providers: ${JSON.stringify(noProv)}`);
+  }
 } catch (e) {
   fail(`portal slug validator tests crashed: ${e.message}`);
 }

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -26,13 +26,18 @@
  */
 
 import { existsSync, readFileSync } from 'fs';
-import { resolve } from 'path';
+import { dirname, resolve } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import yaml from 'js-yaml';
 
-import { fetchJson as defaultFetchJson } from './providers/_http.mjs';
+import { fetchJson as defaultFetchJson, makeHttpCtx } from './providers/_http.mjs';
+import { loadProviders, resolveProvider } from './providers/_registry.mjs';
 
 const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
+
+// The core providers/ directory — the SAME plugins the scanner loads. Resolved
+// from this file's location so it's independent of the caller's cwd.
+const PROVIDERS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), 'providers');
 
 // How to turn a slug into a probe URL, and where the job list lives in the
 // response, for each supported ATS. Greenhouse/Ashby wrap jobs in `{ jobs }`;
@@ -220,20 +225,88 @@ async function discoverAlternates(name, { fetchJson }) {
 }
 
 /**
- * Verify the ATS slug of each enabled tracked company.
+ * A liveness probe must never paginate an entire board — that is slow and rude
+ * to the careers site (many rate-limit or bot-block aggressively). We signal
+ * this sentinel when a provider tries to fetch a second page; the probe reads it
+ * as "the first page came back fine → the endpoint is live", we just don't learn
+ * the exact total. Distinct from a real HTTP error, which means a broken board.
+ */
+class ProbePageBudgetReached extends Error {}
+
+/**
+ * Wrap an http context so a provider gets exactly ONE successful list request.
  *
- * Companies whose careers_url/api is not a recognized ATS (branded pages,
- * Workday, job boards, websearch) are reported as `skipped` — out of scope for
- * slug probing, not failures. Probing is sequential to stay gentle on Ashby's
- * rate limit.
+ * Cooperating providers also see `maxPages: 1` and stop on their own (we then
+ * learn the first-page count). Providers that ignore the hint are cut off at
+ * their second request via the sentinel above — so the probe is bounded for
+ * every provider, whether or not it honors `maxPages`.
+ *
+ * @param {import('./providers/_types.js').Context} base
+ */
+function boundedProbeCtx(base) {
+  let used = 0;
+  const guard = (fn) => async (url, opts) => {
+    if (used >= 1) throw new ProbePageBudgetReached();
+    used += 1;
+    return fn(url, opts);
+  };
+  return { ...base, maxPages: 1, fetchJson: guard(base.fetchJson), fetchText: guard(base.fetchText) };
+}
+
+/**
+ * Probe one non-ATS company through the provider plugin the scanner would use.
+ *
+ * @param {object} entry - tracked_companies entry.
+ * @param {import('./providers/_types.js').Provider} provider
+ * @param {import('./providers/_types.js').Context} baseCtx
+ * @returns {Promise<{provider,status,jobCount?,partial?,httpStatus?,errorKind?,reason?}>}
+ *   status is 'live' (postings found), 'empty' (endpoint OK, no postings), or
+ *   'missing' (the board 404s/errors — the company would silently drop from
+ *   every scan). `partial` marks a live board whose exact count the one-page
+ *   probe didn't measure.
+ */
+export async function probeProvider(entry, provider, baseCtx) {
+  const ctx = boundedProbeCtx(baseCtx);
+  try {
+    const jobs = await provider.fetch(entry, ctx);
+    const count = Array.isArray(jobs) ? jobs.length : 0;
+    return { provider: provider.id, status: count > 0 ? 'live' : 'empty', jobCount: count };
+  } catch (err) {
+    if (err instanceof ProbePageBudgetReached) {
+      return { provider: provider.id, status: 'live', partial: true };
+    }
+    return {
+      provider: provider.id,
+      status: 'missing',
+      errorKind: classifyFetchError(err),
+      httpStatus: err?.status,
+      reason: err?.message || String(err),
+    };
+  }
+}
+
+/**
+ * Verify each enabled tracked company's board is reachable.
+ *
+ * Two tiers, cheapest first:
+ *   1. Greenhouse/Ashby/Lever slugs are probed directly (one JSON request each),
+ *      with cross-probe suggestions when a slug 404s.
+ *   2. Everything else is routed through the SAME provider plugins the scanner
+ *      uses (Workday, SuccessFactors, SmartRecruiters, Avature, …), bounded to
+ *      the first page. This catches broken non-ATS boards that used to be
+ *      reported as an un-actionable "skipped".
+ * A company reaches `skipped` only when no provider claims it. Probing is
+ * sequential to stay gentle on rate limits.
  *
  * @param {Array<object>} companies - tracked_companies entries.
- * @param {{fetchJson?: Function}} [deps]
+ * @param {{fetchJson?: Function, providers?: Map, httpCtx?: object}} [deps]
+ *   `providers`/`httpCtx` enable tier 2; omit them (as the ATS unit tests do) to
+ *   get tier-1-only behavior where non-ATS entries stay `skipped`.
  * @returns {Promise<Array<object>>} One result row per company.
  */
 export async function verifyCompanies(
   companies,
-  { fetchJson = defaultFetchJson } = {},
+  { fetchJson = defaultFetchJson, providers = null, httpCtx = null } = {},
 ) {
   const list = Array.isArray(companies) ? companies : [];
   const results = [];
@@ -243,28 +316,41 @@ export async function verifyCompanies(
     const name = typeof company.name === 'string' ? company.name : '(unnamed)';
     const match =
       parseAtsSlug(company.api) || parseAtsSlug(company.careers_url);
-    if (!match) {
-      results.push({
-        name,
-        status: 'skipped',
-        reason: 'no Greenhouse/Ashby/Lever slug in careers_url or api',
-      });
-      continue;
-    }
-    const probe = await probeSlug(match.ats, match.slug, { fetchJson });
-    if (probe.status === 'live' || probe.status === 'empty') {
+    if (match) {
+      const probe = await probeSlug(match.ats, match.slug, { fetchJson });
+      if (probe.status === 'live' || probe.status === 'empty') {
+        results.push({ name, ...probe });
+        continue;
+      }
+      // Wrong slug or ATS migration — cross-probe only for slug/unknown failures.
+      if (probe.errorKind === 'slug_gone' || probe.errorKind === 'unknown') {
+        const suggested = await discoverAlternates(name, { fetchJson });
+        if (suggested) {
+          results.push({ name, ...probe, suggested });
+          continue;
+        }
+      }
       results.push({ name, ...probe });
       continue;
     }
-    // Wrong slug or ATS migration — cross-probe only for slug/unknown failures.
-    if (probe.errorKind === 'slug_gone' || probe.errorKind === 'unknown') {
-      const suggested = await discoverAlternates(name, { fetchJson });
-      if (suggested) {
-        results.push({ name, ...probe, suggested });
+
+    // Tier 2: hand the entry to the scanner's provider layer. Skip the
+    // local-parser provider — a health check must stay network-only and never
+    // execute a configured local command.
+    if (providers && providers.size > 0) {
+      const resolved = resolveProvider(company, providers, { skipIds: ['local-parser'] });
+      if (resolved && resolved.provider) {
+        const probe = await probeProvider(company, resolved.provider, httpCtx || makeHttpCtx());
+        results.push({ name, ...probe });
         continue;
       }
     }
-    results.push({ name, ...probe });
+
+    results.push({
+      name,
+      status: 'skipped',
+      reason: 'no provider matched careers_url or api',
+    });
   }
   return results;
 }
@@ -279,14 +365,14 @@ export async function verifyCompanies(
  */
 export async function verifyPortalsFile(
   filePath,
-  { fetchJson = defaultFetchJson } = {},
+  { fetchJson = defaultFetchJson, providers = null, httpCtx = null } = {},
 ) {
   if (!existsSync(filePath)) return { found: false, results: [] };
   const config = yaml.load(readFileSync(filePath, 'utf-8'));
   const companies = Array.isArray(config?.tracked_companies)
     ? config.tracked_companies
     : [];
-  const results = await verifyCompanies(companies, { fetchJson });
+  const results = await verifyCompanies(companies, { fetchJson, providers, httpCtx });
   return { found: true, results };
 }
 
@@ -303,14 +389,16 @@ const ERROR_KIND_LABEL = {
 function printResults(results) {
   for (const r of results) {
     const icon = ICON[r.status] || '?';
+    // ATS rows carry ats/slug; provider-layer rows carry the provider id.
+    const source = r.ats ? `${r.ats}/${r.slug}` : (r.provider || '?');
     let detail;
     if (r.status === 'live') {
-      detail = `${r.ats}/${r.slug} (${r.jobCount} live)`;
+      detail = r.partial ? `${source} (first page live)` : `${source} (${r.jobCount} live)`;
     } else if (r.status === 'empty') {
-      detail = `${r.ats}/${r.slug} (live but empty)`;
+      detail = `${source} (live but empty)`;
     } else if (r.status === 'missing') {
       const kind = ERROR_KIND_LABEL[r.errorKind] || 'unresolved';
-      detail = `${r.ats || '?'}/${r.slug || '?'} (${kind}) — ${r.reason || 'unresolved'}`;
+      detail = `${source} (${kind}) — ${r.reason || 'unresolved'}`;
       if (r.suggested) {
         detail += ` → try ${r.suggested.ats}/${r.suggested.slug}`;
       }
@@ -373,7 +461,12 @@ async function main() {
     fileFlag === -1 ? DEFAULT_PORTALS_PATH : args[fileFlag + 1] || '',
   );
 
-  const { found, results } = await verifyPortalsFile(filePath, { fetchJson });
+  // Load the scanner's provider plugins so non-ATS boards (Workday,
+  // SuccessFactors, SmartRecruiters, …) get a real reachability probe instead
+  // of an un-actionable "skipped".
+  const providers = await loadProviders(PROVIDERS_DIR);
+  const httpCtx = makeHttpCtx();
+  const { found, results } = await verifyPortalsFile(filePath, { fetchJson, providers, httpCtx });
   if (!found) {
     // Graceful no-op: fresh setups (and CI, which ships no portals.yml) have
     // nothing to verify. Not an error.
@@ -402,7 +495,7 @@ async function main() {
     .map(([k, n]) => `${n} ${ERROR_KIND_LABEL[k]}`)
     .join(', ');
   console.log(
-    `\n${live} live, ${empty} live-but-empty, ${missing.length} unresolved${breakdown ? ` (${breakdown})` : ''}, ${skipped} non-ATS (skipped)`,
+    `\n${live} live, ${empty} live-but-empty, ${missing.length} unresolved${breakdown ? ` (${breakdown})` : ''}, ${skipped} no-provider (skipped)`,
   );
 
   if (strict && missing.length > 0) {


### PR DESCRIPTION
## Problem

`verify-portals.mjs` (and the web UI's **Check portal health** button, which shells out to it) only understood **Greenhouse / Ashby / Lever** slugs. Every other board — Workday, SuccessFactors, SmartRecruiters, Avature, BambooHR, Amazon, … — was reported as an un-actionable **"skipped (no ATS)"**.

On a portal list that leans non-ATS (e.g. a DACH/industrial target list), that means almost everything shows grey and the panel reads **"1 live"**, badly understating real coverage — and, worse, hiding genuinely broken non-ATS endpoints that silently drop from every scan.

## Change

`verify-portals` now falls back to the **same provider plugins the scanner uses**. Non-ATS entries are routed through `resolveProvider()` and probed for reachability, classified `live` / `empty` (`🟡`) / `missing` (`❌`) just like ATS slugs. A company only reaches `skipped` when **no** provider claims it.

The probe is bounded to the **first page**, two ways:
- it passes `ctx.maxPages = 1` — cooperating providers stop and report a real first-page count;
- for providers that ignore the hint, a **request-budget wrapper** cuts them off at their second page and classifies the board `live` (we know the first page came back fine, we just don't measure the total).

Either way a health check **never paginates an entire careers site** — important for sites that rate-limit or bot-block. The `local-parser` provider is skipped so the check stays network-only and never execs a configured command.

## Real-world result

A live sweep of a 60-company non-ATS-heavy `portals.yml`:

```
before:  1 live,  0 empty,  0 unresolved, 59 non-ATS (skipped)
after:  27 live,  2 empty,  1 unresolved, 30 no-provider (skipped)
```

The 30 remaining `skipped` genuinely have no matching provider (bespoke career portals) — honest, and now visibly distinct from boards that work.

## Files

- **scan.mjs** — export `loadProviders` / `resolveProvider` (reuse the scanner's routing; no duplicated logic).
- **verify-portals.mjs** — `probeProvider()` + bounded probe context; tier-2 provider fallback in `verifyCompanies`; provider-aware detail lines. **ATS fast path is unchanged.**
- **providers/_types.js** — document the optional `ctx.maxPages` hint.
- **test-all.mjs** — cover live/empty/broken/no-provider fallback, and assert the request budget bounds a provider that ignores `maxPages`.

No provider files were modified, so this is independent of any in-flight per-provider work.

## Testing

- `node test-all.mjs` → 988 passed, 0 failed (1 pre-existing Playwright-MCP warning).
- New unit tests use injected fake providers — no network, not flaky.
- Verified against a real `portals.yml` (numbers above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-ATS portal entries (e.g., `careers_url`/`api`) are now verified via available provider plugins instead of being skipped.
  * Provider probing is bounded to the first page; “live” partial results are labeled as “first page live”.
  * Added a shared provider registry to load providers and resolve the best provider for an entry.

* **Bug Fixes**
  * Updated output formatting and final summary labeling for provider-layer vs ATS results.
  * Improved behavior when no provider map is provided (non-ATS entries remain `skipped`).

* **Tests**
  * Extended Tier 2 coverage for fallback verification paths and pagination limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->