### PR TITLE
fix(web): pin turbopack.root to prevent postcss worker OOM on Windows

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,5 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Two lockfiles exist on purpose (repo root + web/), so Next would infer the
+  // repo root as the workspace root. On Windows that misinference can send
+  // Turbopack's postcss workers into an unbounded respawn loop that exhausts
+  // all RAM (vercel/next.js#92978) — pin the root to this app.
+  turbopack: { root: import.meta.dirname },
   // Allow a throwaway build dir (e.g. BUILD_DIST=.next-prod) so a production
   // `next build` can run without clobbering a live `next dev` .next.
   ...(process.env.BUILD_DIST ? { distDir: process.env.BUILD_DIST } : {}),


### PR DESCRIPTION
Forward-ports **@Scott-Emberson's #1416** now that the web lives on main and the retarget window passed — credit preserved via `Co-authored-by`.

Two lockfiles (repo root + `web/`) make Next infer the repo root as the Turbopack workspace root; on Windows a cache/root mismatch sends the postcss child workers into an unbounded respawn loop that exhausts RAM ([vercel/next.js#92978](https://github.com/vercel/next.js/issues/92978); Scott measured 156 workers / 8.7 GB within 3s). Pinning `turbopack.root` to the app removes the inference entirely, and silences the multiple-lockfile dev warning.

One line. @Scott-Emberson — thank you; this closes out #1416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app build and development consistency in the web workspace, reducing issues caused by incorrect project root detection in monorepo setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->