### PR TITLE
fix(providers): honor api: over careers_url in workday & smartrecruiters

### DIFF
--- a/providers/smartrecruiters.mjs
+++ b/providers/smartrecruiters.mjs
@@ -27,18 +27,24 @@ function assertSmartRecruitersUrl(url) {
 }
 
 function resolveSlug(entry) {
-  const raw = typeof entry.careers_url === 'string' ? entry.careers_url : '';
-  if (!raw) return null;
-  let parsed;
-  try {
-    parsed = new URL(raw);
-  } catch {
-    return null;
+  // entry.api takes precedence over careers_url (mirrors greenhouse/ashby) so a
+  // branded page (e.g. https://jobs.continental.com) can stay as careers_url
+  // while the SmartRecruiters slug is pinned via
+  // api: https://careers.smartrecruiters.com/<slug> in portals.yml.
+  for (const raw of [entry.api, entry.careers_url]) {
+    if (typeof raw !== 'string' || !raw) continue;
+    let parsed;
+    try {
+      parsed = new URL(raw);
+    } catch {
+      continue;
+    }
+    if (parsed.protocol !== 'https:') continue;
+    if (!SR_CAREERS_HOSTS.has(parsed.hostname)) continue;
+    const slug = parsed.pathname.split('/').filter(Boolean)[0];
+    if (slug) return slug;
   }
-  if (parsed.protocol !== 'https:') return null;
-  if (!SR_CAREERS_HOSTS.has(parsed.hostname)) return null;
-  const slug = parsed.pathname.split('/').filter(Boolean)[0];
-  return slug || null;
+  return null;
 }
 
 function buildPostingsUrl(slug, offset = 0) {

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -116,7 +116,10 @@ function pageIsPastWindow(pageJobs, sinceMs) {
 }
 
 function resolveEndpoint(entry) {
-  const url = entry.careers_url || '';
+  // entry.api takes precedence over careers_url (mirrors greenhouse/ashby) so a
+  // branded page (e.g. https://www.ptc.com/en/careers) can stay as careers_url
+  // while the Workday tenant URL is pinned via api: in portals.yml.
+  const url = entry.api || entry.careers_url || '';
   const m = url.match(/^https:\/\/([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([^/?#]+)/);
   if (!m) return null;
   const [, tenant, instance, site] = m;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2855,6 +2855,19 @@ try {
     fail('smartrecruiters.detect() should return null for non-SR URLs');
   }
 
+  // entry.api precedence: a branded careers_url is kept while the SR slug is
+  // pinned via api: (mirrors greenhouse/ashby).
+  const hitApi = sr.detect({
+    name: 'Continental',
+    careers_url: 'https://jobs.continental.com',
+    api: 'https://careers.smartrecruiters.com/Continental',
+  });
+  if (hitApi && hitApi.url.startsWith('https://api.smartrecruiters.com/v1/companies/Continental/postings')) {
+    pass('smartrecruiters.detect() honors api: over a branded careers_url');
+  } else {
+    fail(`smartrecruiters.detect(api-pinned) returned ${JSON.stringify(hitApi)}`);
+  }
+
   // parseSmartRecruitersResponse
   const sample = {
     content: [
@@ -10331,6 +10344,19 @@ try {
     pass('workday.detect() returns null for non-Workday URL');
   } else {
     fail('workday.detect() should return null for non-Workday URL');
+  }
+
+  // entry.api precedence: a branded careers_url is kept while the Workday tenant
+  // is pinned via api: (mirrors greenhouse/ashby).
+  const hitApiWd = workday.detect({
+    name: 'PTC',
+    careers_url: 'https://www.ptc.com/en/careers',
+    api: 'https://ptc.wd1.myworkdayjobs.com/PTC',
+  });
+  if (hitApiWd && hitApiWd.url === 'https://ptc.wd1.myworkdayjobs.com/wday/cxs/ptc/PTC/jobs') {
+    pass('workday.detect() honors api: over a branded careers_url');
+  } else {
+    fail(`workday.detect(api-pinned) returned ${JSON.stringify(hitApiWd)}`);
   }
 
   // Path-spoofed URL: myworkdayjobs.com in path, not hostname


### PR DESCRIPTION
## Problem

`greenhouse` and `ashby` already let a portal entry keep a **branded, human-facing** `careers_url` while pinning the actual API source via `api:`. `workday` and `smartrecruiters` did **not** — they resolved the endpoint solely from `careers_url`. So a natural entry like:

```yaml
- name: PTC
  careers_url: https://www.ptc.com/en/careers    # branded page (what a human clicks)
  provider: workday
  api: https://ptc.wd1.myworkdayjobs.com/PTC      # the real Workday tenant
```

failed with **`cannot derive CXS endpoint`** (workday) / **`cannot derive API URL`** (smartrecruiters), because the branded `careers_url` doesn't match the tenant/host pattern. The company then silently returns nothing on every scan — the exact "silent drop" failure the portal tooling is meant to prevent. This bites Workday/SmartRecruiters-heavy portal lists (large corporates that front their ATS behind a branded careers domain).

## Fix

- `workday` `resolveEndpoint()` and `smartrecruiters` `resolveSlug()` now try **`entry.api` first**, then fall back to `careers_url` — mirroring `greenhouse`/`ashby`.
- The SmartRecruiters host allowlist (`careers`/`jobs.smartrecruiters.com`) and the Workday tenant regex still gate the **resolved** URL. This only broadens *which field* is read, not *what* is accepted — no SSRF surface change.

## Verification

- Real first-page fetches: **PTC** (workday) → 20 live postings; **Continental** (smartrecruiters) → resolves and fetches.
- `node test-all.mjs` → **1161 passed, 0 failed** (1 pre-existing Playwright-MCP warning). New tests assert `api:`-over-`careers_url` precedence for both providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SmartRecruiters and Workday URL detection to prefer a provided API address when available.
  * Added safer handling for invalid, empty, or unsupported URLs so provider detection is more reliable.
  * Reduced false matches by ignoring untrusted or non-secure SmartRecruiters links before extracting company details.

* **Tests**
  * Expanded provider detection tests to verify API addresses take precedence over careers-site URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->