### PR TITLE
Fix plugin manifest path containment

### DIFF
--- a/plugins/_engine.mjs
+++ b/plugins/_engine.mjs
@@ -67,14 +67,25 @@ function isWithinDirectory(rootAbs, candidateAbs) {
   return rel === '' || (!rel.startsWith(`..${path.sep}`) && rel !== '..' && !path.isAbsolute(rel));
 }
 
+function nearestExistingPath(absPath) {
+  let current = path.resolve(absPath);
+  while (!existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+  return current;
+}
+
 function isSafePluginPath(rootAbs, candidateAbs) {
   const rootResolved = path.resolve(rootAbs);
   const candidateResolved = path.resolve(candidateAbs);
   if (!isWithinDirectory(rootResolved, candidateResolved)) return false;
 
-  if (!existsSync(candidateResolved)) return true;
+  const nearestExisting = nearestExistingPath(candidateResolved);
+  if (!nearestExisting) return false;
   try {
-    return isWithinDirectory(realpathSync(rootResolved), realpathSync(candidateResolved));
+    return isWithinDirectory(realpathSync(rootResolved), realpathSync(nearestExisting));
   } catch {
     return false;
   }

--- a/plugins/_engine.mjs
+++ b/plugins/_engine.mjs
@@ -24,7 +24,7 @@
  * all reuse it with no prod-vs-test drift.
  */
 
-import { existsSync, readdirSync, readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, realpathSync } from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
 import { resolveAndValidate } from './_net.mjs';
@@ -60,6 +60,24 @@ function isReservedEnv(name) {
 
 function warnSkip(label, reason) {
   console.warn(`⚠️  ${label}: skipping — ${reason}`);
+}
+
+function isWithinDirectory(rootAbs, candidateAbs) {
+  const rel = path.relative(rootAbs, candidateAbs);
+  return rel === '' || (!rel.startsWith(`..${path.sep}`) && rel !== '..' && !path.isAbsolute(rel));
+}
+
+function isSafePluginPath(rootAbs, candidateAbs) {
+  const rootResolved = path.resolve(rootAbs);
+  const candidateResolved = path.resolve(candidateAbs);
+  if (!isWithinDirectory(rootResolved, candidateResolved)) return false;
+
+  if (!existsSync(candidateResolved)) return true;
+  try {
+    return isWithinDirectory(realpathSync(rootResolved), realpathSync(candidateResolved));
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -156,7 +174,7 @@ export function validateManifest(m, dir, dirName) {
   const entry = typeof m.entry === 'string' && m.entry.trim() ? m.entry : 'index.mjs';
   if (!entry.endsWith('.mjs')) { warnSkip(label, `entry "${entry}" must be a .mjs file`); return null; }
   const entryAbs = path.resolve(dir, entry);
-  if (entryAbs !== dir && !entryAbs.startsWith(dir + path.sep)) { warnSkip(label, `entry "${entry}" escapes the plugin directory`); return null; }
+  if (!isSafePluginPath(dir, entryAbs)) { warnSkip(label, `entry "${entry}" escapes the plugin directory`); return null; }
 
   // Optional companion skill (Open-Agent-Skill-Standard SKILL.md). Traversal-
   // guarded like entry. Surfaced on-demand via `plugins.mjs skill <id>`; never
@@ -165,7 +183,7 @@ export function validateManifest(m, dir, dirName) {
   if (m.skill !== undefined) {
     if (typeof m.skill !== 'string' || !m.skill.endsWith('.md')) { warnSkip(label, 'skill must be a relative .md path'); return null; }
     const skillAbs = path.resolve(dir, m.skill);
-    if (skillAbs !== dir && !skillAbs.startsWith(dir + path.sep)) { warnSkip(label, `skill "${m.skill}" escapes the plugin directory`); return null; }
+    if (!isSafePluginPath(dir, skillAbs)) { warnSkip(label, `skill "${m.skill}" escapes the plugin directory`); return null; }
     if (!existsSync(skillAbs)) { warnSkip(label, `skill file not found: ${m.skill}`); return null; }
     skill = m.skill;
   }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -13,7 +13,7 @@
 
 
 import { execSync, execFileSync, spawn } from 'child_process';
-import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, unlinkSync, realpathSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, unlinkSync, realpathSync, symlinkSync } from 'fs';
 import { join, dirname, delimiter } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -9208,6 +9208,19 @@ try {
   else fail('valid keyed manifest should be accepted');
   if (vm({ ...base, entry: '../../scan.mjs' }) === null) pass('entry escaping the plugin directory is rejected (traversal guard)');
   else fail('entry traversal should be rejected');
+  mkdirSync(join(__manifestTmp, 'x'), { recursive: true });
+  writeFileSync(join(__manifestTmp, 'outside.mjs'), 'export default {};');
+  writeFileSync(join(__manifestTmp, 'outside.md'), '# outside\n');
+  try {
+    symlinkSync(join(__manifestTmp, 'outside.mjs'), join(__manifestTmp, 'x', 'linked-entry.mjs'));
+    symlinkSync(join(__manifestTmp, 'outside.md'), join(__manifestTmp, 'x', 'linked-skill.md'));
+    if (vm({ ...base, entry: 'linked-entry.mjs' }) === null) pass('entry symlink escaping the plugin directory is rejected');
+    else fail('entry symlink traversal should be rejected');
+    if (vm({ ...base, skill: 'linked-skill.md' }) === null) pass('skill symlink escaping the plugin directory is rejected');
+    else fail('skill symlink traversal should be rejected');
+  } catch (e) {
+    warn(`symlink traversal test skipped: ${e.message}`);
+  }
   if (validateManifest({ ...base, id: 'y' }, '/tmp/x', 'x') === null) pass('manifest id must equal the directory name');
   else fail('id != dirname should be rejected');
   if (vm({ ...base, apiVersion: 2 }) === null) pass('unknown apiVersion is rejected (forward-compat gate)');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9190,6 +9190,7 @@ try {
 
   const base = { id: 'x', apiVersion: 1, description: 'one line', hooks: ['ingest'], requiredEnv: [], allowedHosts: [], humanInTheLoop: true };
   __manifestTmp = mkdtempSync(join(tmpdir(), 'co-plugin-manifest-'));
+  mkdirSync(join(__manifestTmp, 'x'), { recursive: true });
   const vm = (m, dirName = 'x') => validateManifest(m, join(__manifestTmp, dirName), dirName);
 
   // Manifest validation (warnings are expected here — suppress to keep output clean).
@@ -9208,16 +9209,19 @@ try {
   else fail('valid keyed manifest should be accepted');
   if (vm({ ...base, entry: '../../scan.mjs' }) === null) pass('entry escaping the plugin directory is rejected (traversal guard)');
   else fail('entry traversal should be rejected');
-  mkdirSync(join(__manifestTmp, 'x'), { recursive: true });
   writeFileSync(join(__manifestTmp, 'outside.mjs'), 'export default {};');
   writeFileSync(join(__manifestTmp, 'outside.md'), '# outside\n');
+  mkdirSync(join(__manifestTmp, 'outside-dir'), { recursive: true });
   try {
     symlinkSync(join(__manifestTmp, 'outside.mjs'), join(__manifestTmp, 'x', 'linked-entry.mjs'));
     symlinkSync(join(__manifestTmp, 'outside.md'), join(__manifestTmp, 'x', 'linked-skill.md'));
+    symlinkSync(join(__manifestTmp, 'outside-dir'), join(__manifestTmp, 'x', 'linked-dir'), 'dir');
     if (vm({ ...base, entry: 'linked-entry.mjs' }) === null) pass('entry symlink escaping the plugin directory is rejected');
     else fail('entry symlink traversal should be rejected');
     if (vm({ ...base, skill: 'linked-skill.md' }) === null) pass('skill symlink escaping the plugin directory is rejected');
     else fail('skill symlink traversal should be rejected');
+    if (vm({ ...base, entry: 'linked-dir/missing-entry.mjs' }) === null) pass('missing entry under an escaping symlink directory is rejected');
+    else fail('missing entry under symlink traversal should be rejected');
   } catch (e) {
     warn(`symlink traversal test skipped: ${e.message}`);
   }


### PR DESCRIPTION
## Summary
- Replace string-prefix plugin manifest containment checks with a path.relative-based helper.
- Resolve existing entry and skill paths through realpath before accepting them, so symlink escapes are rejected.
- Add plugin engine tests for entry and skill symlinks that point outside the plugin directory.

This is the isolated security fix requested from #1481 and avoids bundling unrelated _custom.md, PDF, or updater timeout changes.

Closes #1410

## Testing
- node --check plugins/_engine.mjs
- node test-all.mjs --quick (1164 passed, 0 failed, 1 expected warning for missing local CV)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened plugin `manifest.json` validation to ensure `entry` and optional `skill` paths remain within the plugin directory, including when symlinks or resolved paths are involved.
  * Improved protection against path traversal by using resolved-path containment rather than simple prefix checks.

* **Tests**
  * Added regression tests covering symlink-based traversal scenarios to verify invalid plugin `entry`/`skill` paths are rejected.
  * Automatically skips symlink traversal assertions if the runtime filesystem doesn’t support symlink operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->