### PR TITLE
feat(web): pipeline empty-state offers an in-web free scan (self-sufficient)

### DIFF
--- a/web/src/components/pipeline-view.tsx
+++ b/web/src/components/pipeline-view.tsx
@@ -347,11 +347,9 @@ function InboxEmpty({ count, filtered }: { count: number; filtered: boolean }) {
         <span className="size-2.5 rounded-full bg-foreground/15" aria-hidden="true" />
         <span className="size-2.5 rounded-full bg-foreground/15" aria-hidden="true" />
         <span className="size-2.5 rounded-full bg-foreground/15" aria-hidden="true" />
-        <span className="ml-3 font-mono text-xs tracking-wide text-muted">
-          <span className="text-foreground/40">&gt;_</span> career-ops
-        </span>
+        <span className="ml-3 font-mono text-xs tracking-wide text-muted">career-ops · inbox</span>
       </div>
-      <div className="px-6 py-12 text-center">
+      <div className="px-6 py-10 text-center">
         <p className="font-display text-lg">
           Your <span className="text-brand">inbox</span> is empty.
         </p>
@@ -362,11 +360,11 @@ function InboxEmpty({ count, filtered }: { count: number; filtered: boolean }) {
             <p className="mx-auto mt-2 max-w-sm text-sm text-muted">Find roles that match your CV — free, no tokens spent.</p>
             <Link
               href="/explore?run=1"
-              className="mt-5 inline-flex items-center gap-2 rounded-full bg-brand px-5 py-2.5 text-sm font-medium text-brand-foreground shadow-sm transition-colors hover:bg-brand-200"
+              className="mt-5 inline-flex items-center gap-2 rounded-full bg-brand px-5 py-2.5 text-sm font-medium text-brand-foreground shadow-sm transition-all duration-200 hover:bg-brand-200 hover:-translate-y-0.5 hover:shadow-md"
             >
               <Compass className="size-4" /> Run your first free scan <ArrowRight className="size-4" />
             </Link>
-            <p className="mx-auto mt-4 max-w-sm text-xs text-faint">
+            <p className="mx-auto mt-4 max-w-sm text-xs text-muted">
               Prefer the terminal? Run <code className="rounded bg-surface-hover px-1 py-0.5 font-mono">career-ops scan</code>, or add job URLs to{" "}
               <code className="rounded bg-surface-hover px-1 py-0.5 font-mono">data/pipeline.md</code>.
             </p>

--- a/web/src/components/pipeline-view.tsx
+++ b/web/src/components/pipeline-view.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Search, ExternalLink, ChevronsUpDown, Sparkles, Loader2, X } from "lucide-react";
+import { Search, ExternalLink, ChevronsUpDown, Sparkles, Loader2, X, Compass, ArrowRight } from "lucide-react";
 import type { Application, InboxJob } from "@/lib/career-ops";
 import { Badge } from "@/components/ui/badge";
 import { useJobs } from "@/components/jobs/job-store";
@@ -330,7 +330,8 @@ export function PipelineView({
   );
 }
 
-// Empty inbox = the app's terminal-card cue (CLI heritage spent once, honestly).
+// Empty inbox. Self-sufficient for the mainstream user (a primary in-web action),
+// honest for devs (the CLI/file path stays, demoted to progressive transparency).
 function InboxEmpty({ count, filtered }: { count: number; filtered: boolean }) {
   if (filtered) {
     return (
@@ -347,25 +348,30 @@ function InboxEmpty({ count, filtered }: { count: number; filtered: boolean }) {
         <span className="size-2.5 rounded-full bg-foreground/15" aria-hidden="true" />
         <span className="size-2.5 rounded-full bg-foreground/15" aria-hidden="true" />
         <span className="ml-3 font-mono text-xs tracking-wide text-muted">
-          <span className="text-foreground/40">&gt;_</span> career-ops scan
+          <span className="text-foreground/40">&gt;_</span> career-ops
         </span>
       </div>
       <div className="px-6 py-12 text-center">
         <p className="font-display text-lg">
           Your <span className="text-brand">inbox</span> is empty.
         </p>
-        <p className="mx-auto mt-2 max-w-sm text-sm text-muted">
-          {count > 0
-            ? "Nothing pending right now."
-            : "Run a scan or drop job URLs into data/pipeline.md to fill it."}
-        </p>
-        <p className="mt-4 font-mono text-xs text-faint">
-          $ career-ops scan
-          <span
-            aria-hidden="true"
-            className="cli-cursor ml-0.5 inline-block h-[1em] w-[0.35em] bg-current align-middle"
-          />
-        </p>
+        {count > 0 ? (
+          <p className="mx-auto mt-2 max-w-sm text-sm text-muted">Nothing pending right now.</p>
+        ) : (
+          <>
+            <p className="mx-auto mt-2 max-w-sm text-sm text-muted">Find roles that match your CV — free, no tokens spent.</p>
+            <Link
+              href="/explore?run=1"
+              className="mt-5 inline-flex items-center gap-2 rounded-full bg-brand px-5 py-2.5 text-sm font-medium text-brand-foreground shadow-sm transition-colors hover:bg-brand-200"
+            >
+              <Compass className="size-4" /> Run your first free scan <ArrowRight className="size-4" />
+            </Link>
+            <p className="mx-auto mt-4 max-w-sm text-xs text-faint">
+              Prefer the terminal? Run <code className="rounded bg-surface-hover px-1 py-0.5 font-mono">career-ops scan</code>, or add job URLs to{" "}
+              <code className="rounded bg-surface-hover px-1 py-0.5 font-mono">data/pipeline.md</code>.
+            </p>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
**UX audit P0.1 — CPO priority #1.** The empty inbox showed only a terminal `$ career-ops scan` as its affordance — a non-executable command stranding the web-native user right after the 'no setup' onboarding (the "CLI-author DNA leak" the audit named).

**Fix, to the CPO's refined north ("self-sufficient for mainstream, honest for devs"):**
- **Adds** a primary `Run your first free scan →` button → `/explore?run=1`, which auto-fires the deterministic free scan (reuses the onboarding auto-run hand-off already wired in explorer-view). One click, no tokens.
- **Demotes** (does not delete) the `career-ops scan` command + `data/pipeline.md` hint to a faint secondary line — file-truth as progressive-disclosure transparency for the dev audience.

Kept the terminal-card aesthetic (the audit praised the Linear-style dark glow). Verified E2E: button renders in the empty inbox, deep-link returns 200 and auto-runs; typecheck clean.

design-review → @career-ops-ux (async). 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the empty inbox experience with clearer messaging and a guided next step.
  * Added a call-to-action link to help users run an initial free scan.

* **Bug Fixes**
  * Updated the empty-state copy to better reflect the current inbox count and reduce confusion.
  * Replaced terminal-style guidance with simpler, more actionable instructions (including the relevant scan command and where to add job URLs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->