### PR TITLE
feat(web): humanize the Config AI-engine microcopy (P1.5, ux spec)

### DIFF
--- a/web/src/components/config-form.tsx
+++ b/web/src/components/config-form.tsx
@@ -87,26 +87,26 @@ export function ConfigForm() {
     <div className="mx-auto max-w-2xl px-6 py-10">
       <h1 className="font-display text-2xl tracking-tight text-landing">Config</h1>
       <p className="mt-1 text-sm text-muted">
-        career-ops is CLI-agnostic — it runs on your own AI, locally. Nothing leaves your machine.
+        Run career-ops on your own AI, right on your computer. Your CV and data never leave your machine.
       </p>
 
       {/* Engine mode */}
       <label className="mt-8 mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-muted">
-        Engine
+        AI Engine
       </label>
       <div className="grid gap-2 sm:grid-cols-3">
         <ModeCard
           active={mode === "cli"}
           onClick={() => setMode("cli")}
           icon={Terminal}
-          title="Installed CLI"
+          title="Use an AI tool you have"
           hint="Recommended"
         />
         <ModeCard
           active={mode === "key"}
           onClick={() => setMode("key")}
           icon={KeyRound}
-          title="API key"
+          title="Paste an AI key"
           hint="Coming soon"
           disabled
         />
@@ -114,7 +114,7 @@ export function ConfigForm() {
           active={mode === "manual"}
           onClick={() => setMode("manual")}
           icon={TerminalSquare}
-          title="Keyless"
+          title="No setup needed"
           hint="Coming soon"
           disabled
         />
@@ -123,13 +123,20 @@ export function ConfigForm() {
       <div className="mt-6">
         {mode === "cli" && (
           <div>
-            <p className="mb-3 text-sm text-muted">
-              career-ops runs through whichever AI coding CLI you already use — already authenticated,
-              your own tokens, nothing to paste. Detected on this machine:
+            <p className="mb-1 text-sm text-muted">
+              career-ops uses an AI tool you already have — signed in, your own usage, nothing to paste.
             </p>
+            <p className="mb-3 text-xs text-faint">Works with Claude Code, Codex, OpenCode and more — free ones work great.</p>
             {clis === null ? (
               <div className="flex items-center gap-2 text-sm text-muted">
-                <Loader2 className="size-4 animate-spin" /> Scanning your PATH…
+                <Loader2 className="size-4 animate-spin" /> Checking what&apos;s on your computer…
+              </div>
+            ) : installed.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-border bg-surface/30 p-4 text-sm text-muted">
+                No AI tool yet? Free options like <span className="text-foreground">OpenCode</span> with Qwen or GLM work great.{" "}
+                <a href="https://career-ops.org/docs" target="_blank" rel="noreferrer" className="inline-flex items-center gap-0.5 text-brand hover:underline">
+                  Get one free <ExternalLink className="size-3" />
+                </a>
               </div>
             ) : (
               <div className="space-y-2">
@@ -227,9 +234,10 @@ export function ConfigForm() {
               </div>
             </div>
             <div>
-              <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-muted">
-                API key
+              <label className="mb-1 block text-xs font-semibold uppercase tracking-[0.18em] text-muted">
+                Paste an AI key
               </label>
+              <p className="mb-2 text-xs text-faint">Bring a key from OpenAI, Anthropic, and others.</p>
               <input
                 type="password"
                 value={apiKey}
@@ -247,8 +255,7 @@ export function ConfigForm() {
 
         {mode === "manual" && (
           <div className="rounded-xl border border-dashed border-border bg-surface/30 p-4 text-sm text-muted">
-            Keyless mode: career-ops generates the prompts and you paste them into whichever AI tool
-            you already use, then paste the result back. Zero keys, zero cost beyond what you already pay.
+            The easiest way in — no keys, nothing to set up. On the roadmap.
           </div>
         )}
       </div>
@@ -293,7 +300,7 @@ export function ConfigForm() {
           {saved ? <Check className="size-4" /> : null}
           {saved ? "Saved" : "Save config"}
         </button>
-        <span className="text-xs text-faint">Local-first · on the #156 roadmap</span>
+        <span className="text-xs text-faint">Local-first · on our roadmap</span>
       </div>
     </div>
   );


### PR DESCRIPTION
**UX audit P1.5 — CPO priority #5.** The engine section spoke dev (CLI-agnostic, PATH, issue #156). Implements **career-ops-ux's microcopy spec** — human, benefit-first, and turns the dead-end into a guided on-ramp that names the FREE options:

- intro → *"Run career-ops on your own AI, right on your computer. Your CV and data never leave your machine."*
- label "Engine" → "AI Engine"; cards → "Use an AI tool you have" / "Paste an AI key" / "No setup needed"
- detection copy drops PATH/authenticated jargon → *"an AI tool you already have — signed in, your own usage, nothing to paste"*; scanning → *"Checking what's on your computer…"*
- **NEW no-tool-found on-ramp**: *"Free options like OpenCode with Qwen or GLM work great"* + a "Get one free" link (the community's Santiago-endorsed free stack — turns a dead-end into a path forward, and speaks to the #1 token-cost pain)
- footer "#156 roadmap" → "on our roadmap"

**FIREWALL:** the "No setup needed" card stays deliberately vague (no mechanism); re-scanned clean (no hosted/subsidy/tiers/revenue/employer-pay). Naming free third-party tools is public + safe. Verified E2E: all new copy renders, all old jargon (CLI-agnostic/PATH/#156) gone; typecheck clean.

Spec by @career-ops-ux; the "Get one free" link points at the docs for now (adjustable — Santiago/ux call). 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated AI Engine configuration wording across the setup flow for clearer mode labels, hints, and descriptions.
  * Refined the CLI, key, and manual mode messages, including the empty-state and checking states.
  * Added a “Get one free” link in the CLI flow and shortened the Local-first footer text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->