### PR TITLE
fix(web): point the 'Get one free' link at opencode.ai, not generic docs

### DIFF
--- a/web/src/components/config-form.tsx
+++ b/web/src/components/config-form.tsx
@@ -134,7 +134,7 @@ export function ConfigForm() {
             ) : installed.length === 0 ? (
               <div className="rounded-xl border border-dashed border-border bg-surface/30 p-4 text-sm text-muted">
                 No AI tool yet? Free options like <span className="text-foreground">OpenCode</span> with Qwen or GLM work great.{" "}
-                <a href="https://career-ops.org/docs" target="_blank" rel="noreferrer" className="inline-flex items-center gap-0.5 text-brand hover:underline">
+                <a href="https://opencode.ai" target="_blank" rel="noreferrer" className="inline-flex items-center gap-0.5 text-brand hover:underline">
                   Get one free <ExternalLink className="size-3" />
                 </a>
               </div>

--- a/web/src/components/config-form.tsx
+++ b/web/src/components/config-form.tsx
@@ -134,7 +134,7 @@ export function ConfigForm() {
             ) : installed.length === 0 ? (
               <div className="rounded-xl border border-dashed border-border bg-surface/30 p-4 text-sm text-muted">
                 No AI tool yet? Free options like <span className="text-foreground">OpenCode</span> with Qwen or GLM work great.{" "}
-                <a href="https://opencode.ai" target="_blank" rel="noreferrer" className="inline-flex items-center gap-0.5 text-brand hover:underline">
+                <a href="https://career-ops.org/docs/free-ai-engine" target="_blank" rel="noreferrer" className="inline-flex items-center gap-0.5 text-brand hover:underline">
                   Get one free <ExternalLink className="size-3" />
                 </a>
               </div>


### PR DESCRIPTION
Follow-up to #1538 (P1.5), per @career-ops-ux's design call: a generic `career-ops.org/docs` destination **breaks the promise** — the user clicks "Get one free" expecting an actual free AI tool and lands on generic docs (expectation break, P6). **opencode.ai** delivers on it (the community's Santiago-endorsed free option).

ux is raising a first-party "Set up a free AI engine" guide as his first cross-surface docs item; the FINAL destination is Santiago's call (public copy that names free tools). This is the honest interim.

**Verification note (honest):** the no-CLI-found on-ramp where this link lives can't be runtime-triggered on a machine that has AI CLIs installed (detection finds them via known locations regardless of PATH). tsc is clean; the change is a one-line href inside a tsc-validated conditional branch. A pixel pass on a CLI-less environment confirms the display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “OpenCode” link in the CLI configuration panel to point to the correct website (“No AI tool yet?” external link).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->