### PR TITLE
fix(providers): avature parser tolerates two live tenant markup variants

### DIFF
--- a/providers/avature.mjs
+++ b/providers/avature.mjs
@@ -82,13 +82,21 @@ function parseLocation(block) {
 /** @param {string} htmlText @param {string} origin */
 export function parseArticles(htmlText, origin) {
   const out = [];
-  const re = /<article class="article article--result"[\s\S]*?<\/article>/g;
+  // Tenants vary the result class: Synopsys uses `article--result`, Siemens
+  // appends a position index (`article--result 1`). Accept any suffix.
+  const re = /<article class="article article--result[^"]*"[\s\S]*?<\/article>/g;
   let a;
   while ((a = re.exec(htmlText)) !== null) {
     const block = a[0];
     // JobDetail path may or may not sit under /careers/ (branded tenants vary),
-    // so anchor on JobDetail/ itself rather than a fixed prefix.
-    const urlM = block.match(/<a[^>]*class="link"[^>]*href="([^"]*\/JobDetail\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/);
+    // so anchor on JobDetail/ itself rather than a fixed prefix. Prefer the
+    // `class="link"` title anchor (most tenants); fall back to any JobDetail
+    // anchor for tenants (e.g. Rohde & Schwarz) whose title link carries no
+    // class. Share/mailto buttons url-encode the path (%2FJobDetail%2F) so they
+    // never match the literal `/JobDetail/` and can't be mistaken for the title.
+    const urlM =
+      block.match(/<a[^>]*class="link"[^>]*href="([^"]*\/JobDetail\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/) ||
+      block.match(/<a[^>]*href="([^"]*\/JobDetail\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/);
     if (!urlM) continue;
     const title = clean(urlM[2]);
     if (!title) continue;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -11184,6 +11184,24 @@ try {
   else fail(`parseArticles location wrong: ${JSON.stringify(a2 && a2.location)}`);
   if (parseArticles('<div>no articles</div>', origin).length === 0) pass('parseArticles returns [] when no articles present');
   else fail('parseArticles should return [] for markup with no articles');
+
+  // Tenant markup variants: Siemens appends a position index to the result
+  // class ("article--result 1"); Rohde & Schwarz renders the title anchor with
+  // no class="link". Both must still parse. (Regressions found on live tenants.)
+  const variants = `
+    <article class="article article--result 1" id="article--1">
+      <h3 class="title"><a class="link" href="https://acme.avature.net/en_US/externaljobs/JobDetail/Head-of-PLM/511918">Head of PLM</a></h3>
+    </article>
+    <article class="article article--result" id="article--2">
+      <h3 class="title"><a href="https://acme.avature.net/en_US/careers/JobDetail/Director-Platform/13672">Director Platform Engineering</a></h3>
+    </article>`;
+  const vArts = parseArticles(variants, origin);
+  const vSuffix = vArts.find((a) => a.id === '511918');
+  if (vSuffix && vSuffix.title === 'Head of PLM') pass('parseArticles handles the "article--result 1" class suffix (Siemens)');
+  else fail(`parseArticles missed the class-suffix variant: ${JSON.stringify(vArts.map((a) => a.id))}`);
+  const vNoClass = vArts.find((a) => a.id === '13672');
+  if (vNoClass && vNoClass.title === 'Director Platform Engineering') pass('parseArticles falls back to a JobDetail anchor without class="link" (Rohde & Schwarz)');
+  else fail(`parseArticles missed the no-class-link variant: ${JSON.stringify(vArts.map((a) => a.id))}`);
 } catch (e) {
   fail(`avature provider tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
## Problem

`avature.mjs`'s `parseArticles` was too strict for two real Avature career-site tenants — both returned **zero jobs** despite correct `provider: avature` + `api:` config:

- **Siemens** (`jobs.siemens.com`) renders `<article class="article article--result 1">` — a trailing position index that the exact-match `article--result"` regex rejected.
- **Rohde & Schwarz** (`jobs.rohde-schwarz.com`) renders the title anchor with **no** `class="link"`, which the link regex required.

Both are branded Avature portals (not `*.avature.net`), so they're wired up with an explicit `provider: avature` + `api: .../SearchJobs` — but the parser then silently dropped every article.

## Fix

Two backward-compatible relaxations in `parseArticles`:

1. **Article class** — accept any suffix after `article--result` (`article--result[^"]*"`). Matches `article--result`, `article--result 1`, etc.
2. **Title link** — prefer the `class="link"` anchor (unchanged for existing tenants like Synopsys), then **fall back** to any `/JobDetail/` anchor. Share/mailto buttons url-encode the path (`%2FJobDetail%2F`), so they never match the literal `/JobDetail/` and can't be mistaken for the title.

Existing tenants are unaffected (the relaxations are supersets of the old patterns).

## Verification

- Live boards: **Siemens** and **Rohde & Schwarz** now return postings (R&S ~300; first page parses cleanly). Confirmed via the real provider with a page-bounded context.
- `node test-all.mjs` → **1161 passed, 0 failed** (1 pre-existing Playwright-MCP warning). Added `parseArticles` regression tests for **both** markup variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job listing parsing to handle Avature page markup variations more reliably.
  * Made job detail link detection more flexible so listings are still captured when the preferred link format changes.
* **Tests**
  * Added coverage for additional Avature HTML variants to verify parsing remains accurate across different tenant layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->