### PR TITLE
feat(web): mobile tap-targets >=44px + FAB clearance + a CLI-DNA leak (ux mobile audit)

### DIFF
--- a/web/src/components/cv/cv-ingest.tsx
+++ b/web/src/components/cv/cv-ingest.tsx
@@ -198,7 +198,7 @@ export function CvIngest({ onSaved }: { onSaved?: () => void }) {
             <button
               type="button"
               onClick={() => fileRef.current?.click()}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-surface/50 px-3 py-1.5 text-xs font-medium text-foreground transition hover:border-brand/40 hover:text-brand"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-surface/50 px-3 py-1.5 text-xs font-medium text-foreground transition hover:border-brand/40 hover:text-brand max-sm:min-h-[44px] max-sm:px-4"
             >
               <Upload className="size-3.5" /> Upload PDF / file
             </button>
@@ -210,7 +210,7 @@ export function CvIngest({ onSaved }: { onSaved?: () => void }) {
               type="button"
               disabled={!paste.trim()}
               onClick={() => ingestText(paste.trim())}
-              className="ml-auto inline-flex items-center gap-1.5 rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:brightness-110 disabled:opacity-50"
+              className="ml-auto inline-flex items-center gap-1.5 rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:brightness-110 disabled:opacity-50 max-sm:min-h-[44px]"
             >
               Read my CV <ArrowRight className="size-4" />
             </button>

--- a/web/src/components/home/decision-card.tsx
+++ b/web/src/components/home/decision-card.tsx
@@ -60,7 +60,7 @@ export function DecisionCard({ app }: { app: Application }) {
           type="button"
           disabled={!!busy}
           onClick={() => setStatus("Applied")}
-          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md bg-brand-soft px-2.5 py-1.5 text-xs font-medium text-brand transition hover:bg-brand/15 disabled:opacity-60"
+          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md bg-brand-soft px-2.5 py-1.5 text-xs font-medium text-brand transition hover:bg-brand/15 disabled:opacity-60 max-sm:min-h-[44px]"
         >
           {busy === "Applied" ? <Loader2 className="size-3.5 animate-spin" /> : <Check className="size-3.5" />} Mark applied
         </button>
@@ -68,11 +68,11 @@ export function DecisionCard({ app }: { app: Application }) {
           type="button"
           disabled={!!busy}
           onClick={() => setStatus("Discarded")}
-          className="inline-flex items-center justify-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-muted transition hover:text-foreground disabled:opacity-60"
+          className="inline-flex items-center justify-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-muted transition hover:text-foreground disabled:opacity-60 max-sm:min-h-[44px] max-sm:px-4"
         >
           {busy === "Discarded" ? <Loader2 className="size-3.5 animate-spin" /> : <X className="size-3.5" />} Skip
         </button>
-        <a href={`/pipeline/${app.n}`} title="Open report" className="shrink-0 rounded p-1.5 text-faint transition hover:text-brand">
+        <a href={`/pipeline/${app.n}`} title="Open report" aria-label="Open report" className="inline-flex shrink-0 items-center justify-center rounded p-1.5 text-faint transition hover:text-brand max-sm:min-h-[44px] max-sm:min-w-[44px]">
           <FileText className="size-4" />
         </a>
       </div>

--- a/web/src/components/home/today-dashboard.tsx
+++ b/web/src/components/home/today-dashboard.tsx
@@ -71,7 +71,7 @@ export function TodayDashboard({
   const inboxUrls = useMemo(() => new Set(inbox.map((j) => j.url)), [inbox]);
 
   return (
-    <div className="mx-auto max-w-5xl px-6 py-10">
+    <div className="mx-auto max-w-5xl px-6 py-10 max-sm:pb-24">
       <section className="dot-bg relative overflow-hidden rounded-2xl border border-border bg-surface/40 px-7 py-10 md:px-10 md:py-12">
         <HeroGlow />
         {/* Readability scrim between the animated glow (z-0) and the copy (z-10). */}
@@ -116,7 +116,7 @@ export function TodayDashboard({
 
       {/* A. Follow-ups due (demand loop) */}
       {followups.length > 0 && (
-        <Section icon={Bell} title="Follow-ups due" hint="Keep your applications alive · data/follow-ups.md">
+        <Section icon={Bell} title="Follow-ups due" hint="Keep your applications alive — a nudge beats silence">
           <div className="grid gap-2.5">
             {followups.map((f) => (
               <FollowUpCard key={`${f.num}-${f.company}`} followup={f} onLogged={() => setOverdue((n) => Math.max(0, n - 1))} />

--- a/web/src/components/mobile-nav.tsx
+++ b/web/src/components/mobile-nav.tsx
@@ -116,7 +116,7 @@ export function MobileNav() {
             onClick={() => setOpen(true)}
             aria-label="Open menu"
             aria-expanded={open}
-            className="relative inline-flex items-center justify-center rounded-md p-2 text-muted transition-colors hover:bg-surface-hover hover:text-foreground"
+            className="relative inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md p-2 text-muted transition-colors hover:bg-surface-hover hover:text-foreground"
           >
             <Menu className="size-5" />
             {running > 0 && <span aria-hidden className="co-pulse absolute right-1.5 top-1.5 size-2 rounded-full bg-brand ring-2 ring-surface" />}
@@ -143,7 +143,7 @@ export function MobileNav() {
             type="button"
             onClick={() => setOpen(false)}
             aria-label="Close menu"
-            className="rounded-md p-1.5 text-muted transition-colors hover:bg-surface-hover hover:text-foreground"
+            className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md p-1.5 text-muted transition-colors hover:bg-surface-hover hover:text-foreground"
           >
             <X className="size-5" />
           </button>

--- a/web/src/components/pipeline-view.tsx
+++ b/web/src/components/pipeline-view.tsx
@@ -138,7 +138,7 @@ export function PipelineView({
   }, [applications, tab, q, sort, minFilter]);
 
   return (
-    <div className="mx-auto max-w-6xl px-6 py-8">
+    <div className="mx-auto max-w-6xl px-6 py-8 max-sm:pb-24">
       <div className="flex items-end justify-between gap-4">
         <div>
           <h1 className="font-display text-2xl tracking-tight text-landing">Pipeline</h1>
@@ -256,7 +256,7 @@ export function PipelineView({
                       <button
                         type="button"
                         onClick={launch}
-                        className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-muted transition-colors hover:bg-surface-hover hover:text-brand"
+                        className="inline-flex items-center justify-center gap-1 rounded-md px-2 py-1 text-xs text-muted transition-colors hover:bg-surface-hover hover:text-brand max-sm:min-h-[44px] max-sm:min-w-[44px]"
                         title="Evaluate this posting — spins up a worker on your CLI"
                       >
                         <Sparkles className="size-3.5" />
@@ -267,7 +267,7 @@ export function PipelineView({
                       href={j.url}
                       target="_blank"
                       rel="noreferrer"
-                      className="rounded-md p-1 text-faint transition-colors hover:text-brand"
+                      className="inline-flex items-center justify-center rounded-md p-1 text-faint transition-colors hover:text-brand max-sm:min-h-[44px] max-sm:min-w-[44px]"
                       aria-label={`Open ${j.company} posting`}
                     >
                       <ExternalLink className="size-4" />

--- a/web/src/components/theme-toggle.tsx
+++ b/web/src/components/theme-toggle.tsx
@@ -35,7 +35,7 @@ export function ThemeToggle({ className }: { className?: string }) {
       aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
       title={dark ? "Light mode" : "Dark mode"}
       className={cn(
-        "inline-flex items-center justify-center rounded-md p-1.5 text-muted transition-colors hover:bg-surface-hover hover:text-foreground",
+        "inline-flex items-center justify-center rounded-md p-1.5 text-muted transition-colors hover:bg-surface-hover hover:text-foreground max-sm:min-h-[44px] max-sm:min-w-[44px]",
         className,
       )}
     >


### PR DESCRIPTION
Implements **career-ops-ux's mobile audit** (measured at 390x844 / 360x740 with real JS). Headline finding: systematic sub-44px touch targets → mis-taps on mobile triage.

**Fix — propagate ux's own validated `min-h-[44px]` pattern** (the report `<details>`, which he measured at 44px) to the offenders, **mobile-only via `max-sm:`** so desktop density (which ux confirmed renders great) is untouched:
- DecisionCard "Mark applied" / "Skip" / open-report icon (was 28-30px)
- pipeline per-row Evaluate + posting-link icons (was 24-36px, ~124 of them)
- mobile-nav hamburger + close, theme toggle (was 28-36px)
- onboarding "Upload PDF" / "Read my CV" (was 30-36px)

**Minors from the same audit:**
- `max-sm:pb-24` clearance on the home + pipeline lists so the floating "Ask" FAB never lands on a card action when scrolled.
- Humanized the "Follow-ups due" hint (`...· data/follow-ups.md` → `...a nudge beats silence`) — a small CLI-DNA leak.

**What ux confirmed holds and I did NOT touch:** zero horizontal scroll at 390/360, the contained Machine Summary YAML, and P0.3/P1.4/P1.6 which render great on mobile.

tsc clean; classes present in rendered HTML. The 44px value is the pattern ux measured — his mobile pixel-pass re-confirms computed sizes.

design-review → @career-ops-ux (async). 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile usability across several screens with larger tap targets and better spacing for buttons, links, and navigation controls.
  * Added extra bottom spacing on smaller screens to reduce content crowding near the bottom of pages.

* **Bug Fixes**
  * Updated dashboard helper text to a cleaner, more user-friendly message.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->