### PR TITLE
feat(providers): avature self-heals jobOffset→offset pagination

### DIFF
--- a/providers/_types.js
+++ b/providers/_types.js
@@ -102,6 +102,10 @@
  *                              entire careers site. Providers that ignore it stay correct:
  *                              the probe caps their requests defensively via the context's
  *                              own fetch functions.
+ * @property {(ms: number) => Promise<void>} [sleep] Optional cross-provider pacing hook used by
+ *                              paginating providers (avature, workday) to throttle between page
+ *                              requests. May be absent — providers fall back to a native
+ *                              `setTimeout`-based delay.
  */
 
 /**

--- a/providers/_types.js
+++ b/providers/_types.js
@@ -61,6 +61,10 @@
  * @property {string}             [api]            JSON API URL; used directly by greenhouse/ashby providers.
  * @property {string}             [provider]       Explicit provider id — bypasses detect().
  * @property {('http')}           [transport]      Default: 'http'. Reserved for future transports.
+ * @property {number}             [max_pages]      Provider-specific pagination cap (avature, workday).
+ * @property {string}             [offset_param]   avature only: pins the pagination query key and disables the
+ *                                                 provider's jobOffset→offset self-heal. Rarely needed — an
+ *                                                 escape hatch for a tenant the auto-switch can't resolve.
  */
 
 /**

--- a/providers/avature.mjs
+++ b/providers/avature.mjs
@@ -14,6 +14,15 @@
 // heavy for large boards; max_pages (default 50 → ~300 postings) bounds it and
 // can be raised per entry.
 //
+// Pagination parameter name is `jobOffset` on classic tenants, but some branded
+// tenants ignore it and page via a bare `offset` instead (e.g. jobs.siemens.com:
+// `?jobOffset=6` returns page 1 unchanged, `?offset=6` advances). This is
+// self-healing: we start with `jobOffset`, and if the first paginated page comes
+// back identical to page 0 (every id already seen → the param is inert), we
+// retry that page once with `offset` and adopt whichever key actually advances.
+// So a new branded tenant needs no configuration. An entry can still pin the key
+// explicitly via `offset_param` (disables the auto-switch) as an escape hatch.
+//
 // Location isn't rendered in every tenant's list (the subtitle is Job ID /
 // hire-type / posted-date); we extract it when a marker is present and leave it
 // empty otherwise. postedAt comes from the "Posted DD-Mon-YYYY" subtitle.
@@ -21,6 +30,13 @@
 const PAGE_SIZE = 6; // Avature serves exactly 6 results per page
 const DEFAULT_MAX_PAGES = 50; // ~300 postings; override via entry.max_pages
 const HARD_MAX_PAGES = 200;
+// Pause between successive page requests. Avature's 6-results-per-page cap makes
+// large boards request-heavy (a 999+ board is ~170 pages); firing those with no
+// gap risks the tenant's WAF rate-limiting the burst. Mirrors workday's
+// INTER_PAGE_DELAY_MS — only boards that paginate past page 0 pay it.
+const INTER_PAGE_DELAY_MS = 150;
+// The bare key we self-heal to when the primary (`jobOffset`) proves inert.
+const FALLBACK_OFFSET_PARAM = 'offset';
 
 const MONTHS = { jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5, jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11 };
 
@@ -138,16 +154,27 @@ export default {
       Number.isFinite(entry.max_pages) && entry.max_pages > 0 ? Number(entry.max_pages) : DEFAULT_MAX_PAGES,
     );
 
+    // Pagination key. An explicit `offset_param` pins it (and disables the
+    // auto-switch below); otherwise start with `jobOffset` and self-heal. A
+    // non-string/empty override falls back to the default so a malformed entry
+    // can't produce `?=N`.
+    const pinned = typeof entry.offset_param === 'string' && entry.offset_param.trim();
+    let offsetParam = pinned ? entry.offset_param.trim() : 'jobOffset';
+    let canHeal = !pinned; // once the key is pinned, never auto-switch
+
     const jobs = [];
     const seen = new Set();
-    for (let page = 0; page < maxPages; page++) {
-      const htmlText = await ctx.fetchText(`${cfg.searchUrl}?jobOffset=${page * PAGE_SIZE}`, {
+    const sleep = (ms) => (typeof ctx?.sleep === 'function' ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
+
+    const getPage = async (param, page) => {
+      const htmlText = await ctx.fetchText(`${cfg.searchUrl}?${param}=${page * PAGE_SIZE}`, {
         redirect: 'error',
         headers: { accept: 'text/html' },
       });
-      const articles = parseArticles(htmlText, cfg.origin);
-      if (articles.length === 0) break;
-
+      return parseArticles(htmlText, cfg.origin);
+    };
+    // Absorb a page's articles, returning how many were not already seen.
+    const absorb = (articles) => {
       let fresh = 0;
       for (const art of articles) {
         if (seen.has(art.id)) continue;
@@ -161,7 +188,33 @@ export default {
           postedAt: art.postedAt,
         });
       }
-      if (fresh === 0) break; // looped / offset ignored
+      return fresh;
+    };
+
+    for (let page = 0; page < maxPages; page++) {
+      if (page > 0) await sleep(INTER_PAGE_DELAY_MS);
+      let articles = await getPage(offsetParam, page);
+      if (articles.length === 0) break; // ran off the end
+      let fresh = absorb(articles);
+
+      // Self-heal: the first paginated page came back identical to page 0
+      // (nothing fresh) → the primary key is inert. Retry this page once with
+      // the fallback key; if it advances, adopt it for the remainder. Only on
+      // page 1 — inert pagination manifests immediately, so a later all-dup
+      // page is a genuine end-of-board, not a key mismatch.
+      if (fresh === 0 && canHeal && page === 1) {
+        canHeal = false;
+        await sleep(INTER_PAGE_DELAY_MS);
+        const altArticles = await getPage(FALLBACK_OFFSET_PARAM, page);
+        const altFresh = absorb(altArticles);
+        if (altFresh > 0) {
+          offsetParam = FALLBACK_OFFSET_PARAM;
+          articles = altArticles;
+          fresh = altFresh;
+        }
+      }
+
+      if (fresh === 0) break; // looped / offset ignored / last page
       if (articles.length < PAGE_SIZE) break; // last page
     }
     return jobs;

--- a/providers/avature.mjs
+++ b/providers/avature.mjs
@@ -194,14 +194,16 @@ export default {
     for (let page = 0; page < maxPages; page++) {
       if (page > 0) await sleep(INTER_PAGE_DELAY_MS);
       let articles = await getPage(offsetParam, page);
-      if (articles.length === 0) break; // ran off the end
       let fresh = absorb(articles);
 
-      // Self-heal: the first paginated page came back identical to page 0
-      // (nothing fresh) → the primary key is inert. Retry this page once with
-      // the fallback key; if it advances, adopt it for the remainder. Only on
-      // page 1 — inert pagination manifests immediately, so a later all-dup
-      // page is a genuine end-of-board, not a key mismatch.
+      // Self-heal: the first paginated page didn't advance — either it repeated
+      // page 0 (all-dup) or came back empty because the primary key is inert
+      // (some tenants echo page 0 for an unknown param, others return nothing).
+      // Retry this page once with the fallback key; if it advances, adopt it for
+      // the remainder. Only on page 1 — inert pagination manifests immediately,
+      // so a later non-advancing page is a genuine end-of-board, not a mismatch.
+      // NOTE: fresh === 0 must be evaluated before the empty-page break below,
+      // or an inert key that returns an empty page 1 would exit without healing.
       if (fresh === 0 && canHeal && page === 1) {
         canHeal = false;
         await sleep(INTER_PAGE_DELAY_MS);
@@ -214,7 +216,7 @@ export default {
         }
       }
 
-      if (fresh === 0) break; // looped / offset ignored / last page
+      if (fresh === 0) break; // empty page / looped / offset ignored / last page
       if (articles.length < PAGE_SIZE) break; // last page
     }
     return jobs;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -11562,6 +11562,30 @@ try {
   const worked = await avature.fetch({ name: 'X', api: base }, workingCtx);
   if (worked.length === 14 && workingCtx.calls.every((u) => /[?&]jobOffset=/.test(u))) pass('avature.fetch() does not self-heal when jobOffset already advances');
   else fail(`avature.fetch() spurious self-heal: ${worked.length} jobs, calls ${JSON.stringify(workingCtx.calls.map((u) => u.split('?')[1]))}`);
+
+  // Self-heal must fire even when the inert primary key returns an EMPTY page 1
+  // (not a repeat of page 0) — the empty-page break must not pre-empt the heal.
+  const emptyP1Ctx = {
+    calls: [],
+    sleep: async () => {},
+    fetchText: async function (url) {
+      this.calls.push(url);
+      const u = new URL(url);
+      const jo = u.searchParams.get('jobOffset');
+      const of = u.searchParams.get('offset');
+      if (jo !== null) return Number(jo) === 0 ? mkHtml([1, 2, 3, 4, 5, 6]) : mkHtml([]); // page 1+ empty
+      if (of !== null) {
+        const n = Number(of) / 6;
+        if (n === 1) return mkHtml([7, 8, 9, 10, 11, 12]);
+        if (n === 2) return mkHtml([13, 14]);
+        return mkHtml([]);
+      }
+      return '<div>no articles</div>';
+    },
+  };
+  const emptyHealed = await avature.fetch({ name: 'X', api: base }, emptyP1Ctx);
+  if (emptyHealed.length === 14 && emptyP1Ctx.calls.some((u) => /[?&]offset=/.test(u))) pass('avature.fetch() self-heals when the inert key returns an empty page 1');
+  else fail(`avature.fetch() failed to heal empty page 1: ${emptyHealed.length} jobs`);
 } catch (e) {
   fail(`avature provider tests crashed: ${e.message}`);
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -11492,6 +11492,76 @@ try {
   const vNoClass = vArts.find((a) => a.id === '13672');
   if (vNoClass && vNoClass.title === 'Director Platform Engineering') pass('parseArticles falls back to a JobDetail anchor without class="link" (Rohde & Schwarz)');
   else fail(`parseArticles missed the no-class-link variant: ${JSON.stringify(vArts.map((a) => a.id))}`);
+
+  // Pagination key — default `jobOffset`, self-heals to `offset` for tenants
+  // that ignore it (Siemens). Mock fetchText with an article-less page so
+  // fetch() stops after one request and we can read the URL it built.
+  const captureFirstUrl = async (entry) => {
+    let firstUrl;
+    const ctx = { sleep: async () => {}, fetchText: async (url) => { if (firstUrl === undefined) firstUrl = url; return '<div>no articles</div>'; } };
+    await avature.fetch(entry, ctx);
+    return firstUrl;
+  };
+  const base = 'https://acme.avature.net/careers/SearchJobs';
+  if (await captureFirstUrl({ name: 'X', api: base }) === `${base}?jobOffset=0`) pass('avature.fetch() defaults pagination to ?jobOffset=N');
+  else fail('avature.fetch() should default to jobOffset');
+  if (await captureFirstUrl({ name: 'X', api: base, offset_param: 'offset' }) === `${base}?offset=0`) pass('avature.fetch() honours offset_param override (Siemens: ?offset=N)');
+  else fail('avature.fetch() should use offset_param when set');
+  if (await captureFirstUrl({ name: 'X', api: base, offset_param: '  ' }) === `${base}?jobOffset=0`) pass('avature.fetch() falls back to jobOffset for a blank offset_param');
+  else fail('avature.fetch() should ignore a blank offset_param');
+
+  // Self-heal — jobOffset→offset when the primary key is inert.
+  const originB = 'https://acme.avature.net';
+  const mkHtml = (ids) => ids.map((id) =>
+    `<article class="article article--result"><h3 class="title"><a class="link" href="${originB}/careers/JobDetail/Role-${id}/${id}">Role ${id}</a></h3></article>`).join('');
+  // Build a ctx whose fetchText answers from a {param: (pageIndex)=>ids} map.
+  const mkCtx = () => {
+    const calls = [];
+    let sleeps = 0;
+    const ctx = {
+      sleep: async () => { sleeps += 1; },
+      fetchText: async (url) => {
+        calls.push(url);
+        const u = new URL(url);
+        const jo = u.searchParams.get('jobOffset');
+        const of = u.searchParams.get('offset');
+        if (jo !== null) return mkHtml([1, 2, 3, 4, 5, 6]); // jobOffset inert: always page 0
+        if (of !== null) {
+          const n = Number(of) / 6;
+          if (n === 0) return mkHtml([1, 2, 3, 4, 5, 6]);
+          if (n === 1) return mkHtml([7, 8, 9, 10, 11, 12]); // offset advances
+          if (n === 2) return mkHtml([13, 14]); // partial → last page
+          return mkHtml([]);
+        }
+        return '<div>no articles</div>';
+      },
+    };
+    return { ctx, calls, sleeps: () => sleeps };
+  };
+  const heal = mkCtx();
+  const healed = await avature.fetch({ name: 'X', api: base }, heal.ctx);
+  if (healed.length === 14) pass('avature.fetch() self-heals jobOffset→offset and walks the full board (14 jobs)');
+  else fail(`avature.fetch() self-heal wrong count: ${healed.length} (expected 14)`);
+  if (heal.calls.some((u) => /[?&]offset=/.test(u))) pass('avature.fetch() self-heal retries with ?offset=N');
+  else fail('avature.fetch() self-heal should retry with offset');
+  if (heal.sleeps() > 0) pass('avature.fetch() throttles between pages (sleep called)');
+  else fail('avature.fetch() should sleep between pages');
+
+  // No self-heal when jobOffset works: offset= must never be requested.
+  const workingCtx = {
+    calls: [],
+    sleep: async () => {},
+    fetchText: async function (url) {
+      this.calls.push(url);
+      const n = Number(new URL(url).searchParams.get('jobOffset')) / 6;
+      if (n === 0) return mkHtml([1, 2, 3, 4, 5, 6]);
+      if (n === 1) return mkHtml([7, 8, 9, 10, 11, 12]);
+      return mkHtml([13, 14]); // last (partial)
+    },
+  };
+  const worked = await avature.fetch({ name: 'X', api: base }, workingCtx);
+  if (worked.length === 14 && workingCtx.calls.every((u) => /[?&]jobOffset=/.test(u))) pass('avature.fetch() does not self-heal when jobOffset already advances');
+  else fail(`avature.fetch() spurious self-heal: ${worked.length} jobs, calls ${JSON.stringify(workingCtx.calls.map((u) => u.split('?')[1]))}`);
 } catch (e) {
   fail(`avature provider tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
## Problem

Some branded Avature tenants ignore the classic `jobOffset` pagination param and page via a bare `offset` instead. `jobs.siemens.com` is one: `?jobOffset=6` returns page 1 unchanged, so the provider's dedup collapses the whole **999+ marketplace to the first 6 postings**.

## Fix

Make pagination **self-healing**: start with `jobOffset`, and if the first paginated page comes back identical to page 0 (every id already seen → the key is inert), retry that page once with `offset` and adopt whichever key actually advances. A new branded tenant needs **no configuration** — Siemens now enumerates its full board (verified live: **1020 postings** vs 6 before). An entry can still pin the key via `offset_param` (disables the auto-switch) as an escape hatch.

Also adds an **inter-page throttle** (150 ms, mirroring the `workday` provider): large Avature boards are ~170 pages at 6/page, and firing them with no gap risks the tenant's WAF rate-limiting the burst.

## Tests

Seven new tests in `test-all.mjs`: default key, `offset_param` override, blank-value fallback, self-heal walk + retry + throttle, and no-spurious-heal when `jobOffset` already works. Full suite green (1187 passed, 0 failed).

## Compat

Backward compatible — classic tenants (Synopsys, Rohde & Schwarz) keep paging on `jobOffset` and never trigger the self-heal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Avature job-board pagination with support for a provider-specific pagination query key override and optional maximum-page limits.

* **Bug Fixes**
  * Improved resiliency when pagination stalls: automatically retries using an alternate pagination parameter when the first paged results bring no new listings, then continues with the corrected parameter as needed.

* **Performance / Reliability**
  * Added controlled pacing between page requests to reduce the likelihood of issues on large result sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->