### PR TITLE
feat(providers): SuccessFactors CSB strategy + bounded health-probe budget

### DIFF
--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -293,7 +293,7 @@ function resolveCsbMaxPages(entry) {
 async function fetchCsb(entry, cfg, ctx) {
   let locales = CSB_DEFAULT_LOCALES;
   try {
-    const html = await ctx.fetchText(cfg.searchPage, { headers: { accept: 'text/html' } });
+    const html = await ctx.fetchText(cfg.searchPage, { redirect: 'error', headers: { accept: 'text/html' } });
     const discovered = extractLocales(html);
     if (discovered.length) locales = discovered;
   } catch {

--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -322,8 +322,13 @@ async function fetchCsb(entry, cfg, ctx) {
       if (total === null) {
         total = typeof json?.totalJobs === 'number' ? json.totalJobs : null;
       }
+      // Page-fullness checks below use the raw response count, not rows.length:
+      // parseCsbJobs drops id/title-less records, and a full API page with a
+      // few dropped records would otherwise look "short" and stop pagination
+      // before reaching later pages that still hold valid jobs.
+      const rawCount = Array.isArray(json?.jobSearchResult) ? json.jobSearchResult.length : 0;
+      if (rawCount === 0) break;
       const rows = parseCsbJobs(json, cfg, locale);
-      if (rows.length === 0) break;
 
       for (const row of rows) {
         if (seen.has(row.id)) continue;
@@ -336,7 +341,7 @@ async function fetchCsb(entry, cfg, ctx) {
       if (jobs.length >= MAX_JOBS) break;
       // Stop once we've covered the reported total, or on a short page.
       if (total !== null && (page + 1) * CSB_PAGE_SIZE >= total) break;
-      if (rows.length < CSB_PAGE_SIZE) break;
+      if (rawCount < CSB_PAGE_SIZE) break;
     }
   }
   return jobs;

--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -26,9 +26,46 @@
 //
 // RMK carries no posting date in the list fragment, so postedAt is always
 // omitted (consumers treat an absent date as "unknown", never as stale).
+//
+// ── CSB (Career Site Builder) variant ────────────────────────────────────────
+// Newer SF tenants run the Career Site Builder "unified" search (jobs2web's
+// searchResultsUnify.js). Their /tile-search-results/ endpoint returns only a
+// 16-byte empty <!DOCTYPE html> shell — the jobs are loaded client-side from a
+// JSON API instead:
+//   POST {origin}/services/recruiting/v1/jobs
+//   Content-Type: application/json
+//   {"keywords":"","locale":"de_DE","location":"","pageNumber":0,"sortBy":"recent"}
+//   → {"jobSearchResult":[{"response":{id,unifiedStandardTitle,unifiedUrlTitle,
+//        jobLocationShort:[…],unifiedStandardStart:"6/18/26",…}}], "totalJobs":N}
+// 10 results/page; pageNumber is 0-based. The detail URL the site itself builds
+// (from searchResultsUnify.js) is {origin}/job/{urlTitle}/{id}-{locale}.
+//
+// CRITICAL — locale gating: the API only returns a posting under a locale it was
+// published in (each record carries `supportedLocales`). The same tenant reports
+// wildly different totals per locale — MAN: de_DE=601 but en_US=8; TRATON: en_US
+// only; Hexagon: en_GB only (de_DE/en_US both 0). A hardcoded locale would miss
+// entire tenants, so we DISCOVER each tenant's advertised locales from the
+// language switcher on {origin}/search/ (the `locale=xx_XX` links), query every
+// one, and dedup by job id. CSB carries a real posting date, so postedAt is set.
+//
+// Strategy selection: `sfVariant: csb` on the portal entry forces CSB directly;
+// otherwise the RMK tile path runs first and, only if it yields zero postings
+// (the empty-shell signature), we fall back to CSB automatically.
 
-const MAX_PAGES = 40; // safety cap on request count
-const MAX_JOBS = 1000; // cap total postings pulled per site
+const MAX_PAGES = 40; // safety cap on request count (RMK tile pagination)
+const MAX_JOBS = 1000; // cap total postings pulled per site (both strategies)
+
+// CSB knobs.
+const CSB_PAGE_SIZE = 10; // fixed by the /services/recruiting/v1/jobs API
+const CSB_MAX_PAGES_PER_LOCALE = 100; // safety cap per locale (100*10 = 1000 postings)
+const CSB_MAX_LOCALES = 16; // guard against a tenant advertising an absurd locale list
+// Locales tried when /search/ discovery yields nothing (fetch failed / markup
+// changed). de_DE + en_US cover the DACH targets this provider is aimed at.
+const CSB_DEFAULT_LOCALES = ['de_DE', 'en_US'];
+// Query order: the DACH-relevant, usually job-rich locales first, so a bounded
+// probe (max_pages:1) hits real postings early and dedup keeps a sensible URL
+// locale for jobs published in several languages.
+const CSB_LOCALE_PRIORITY = ['de_DE', 'en_US', 'en_GB', 'en_EN'];
 
 /** @param {import('./_types.js').PortalEntry} entry */
 function resolveConfig(entry) {
@@ -44,6 +81,8 @@ function resolveConfig(entry) {
     origin: u.origin,
     tileApi: `${u.origin}/tile-search-results/`,
     jobBase: u.origin,
+    jobsApi: `${u.origin}/services/recruiting/v1/jobs`,
+    searchPage: `${u.origin}/search/`,
   };
 }
 
@@ -140,6 +179,204 @@ export function parseTiles(htmlText, jobBase) {
   return out;
 }
 
+// ── CSB helpers ──────────────────────────────────────────────────────────────
+
+// Pull the tenant's advertised locales from the {origin}/search/ page. The CSB
+// language switcher renders them as `/search/?q=&startrow=0&locale=xx_XX` links
+// (HTML-escaped, so `&amp;` — the regex just anchors on `locale=`). Returns a
+// de-duped, priority-ordered list; empty when the markup carries none.
+/** @param {string} html */
+export function extractLocales(html) {
+  const found = new Set();
+  const re = /locale=([a-z]{2}_[A-Z]{2})\b/g;
+  let m;
+  while ((m = re.exec(html)) !== null) found.add(m[1]);
+  const all = [...found];
+  const prio = (loc) => {
+    const i = CSB_LOCALE_PRIORITY.indexOf(loc);
+    return i === -1 ? CSB_LOCALE_PRIORITY.length : i;
+  };
+  all.sort((a, b) => prio(a) - prio(b) || a.localeCompare(b));
+  return all.slice(0, CSB_MAX_LOCALES);
+}
+
+// CSB posting dates are rendered in the query locale's short format: US tenants
+// send M/D/YY with slashes ("6/18/26"), European (de_DE) tenants send D.M.YY
+// with dots ("20.11.23"). Infer the field order from the separator, treat a
+// 2-digit year as 20YY, and return epoch ms. Anything unexpected yields
+// undefined so a consumer sees "unknown date" rather than a bogus timestamp.
+/** @param {unknown} raw */
+export function parseCsbDate(raw) {
+  if (typeof raw !== 'string') return undefined;
+  const s = raw.trim();
+  let a, b, year;
+  let slash = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/);
+  let dot = s.match(/^(\d{1,2})\.(\d{1,2})\.(\d{2,4})$/);
+  if (slash) {
+    // M/D/Y
+    [, a, b, year] = slash;
+  } else if (dot) {
+    // D.M.Y — swap to month/day
+    [, b, a, year] = dot;
+  } else {
+    return undefined;
+  }
+  const month = Number(a);
+  const day = Number(b);
+  let y = Number(year);
+  if (y < 100) y += 2000;
+  if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
+  const ms = Date.UTC(y, month - 1, day);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+// jobLocationShort is an array of strings like "Karlovy Vary, CZE, 36004<br/>"
+// (one per work location). Strip the trailing <br/> and any other markup, drop
+// empties, and join multiple locations with " / ".
+/** @param {unknown} raw */
+export function cleanCsbLocation(raw) {
+  const parts = Array.isArray(raw) ? raw : raw == null ? [] : [raw];
+  const cleaned = [];
+  for (const p of parts) {
+    const s = clean(String(p));
+    if (s && !cleaned.includes(s)) cleaned.push(s);
+  }
+  return cleaned.join(' / ');
+}
+
+// Map one CSB jobs-API response to raw {id, title, url, location, postedAt}.
+// Records nest the useful fields under `.response`; a record without an id or a
+// title is skipped (can't build a stable dedup key or a meaningful listing).
+/** @param {any} json @param {{origin:string}} cfg @param {string} locale */
+export function parseCsbJobs(json, cfg, locale) {
+  const list = Array.isArray(json?.jobSearchResult) ? json.jobSearchResult : [];
+  const out = [];
+  for (const item of list) {
+    const r = item?.response;
+    if (!r) continue;
+    const id = r.id != null ? String(r.id) : '';
+    const title = clean(String(r.unifiedStandardTitle || r.jobTitle || ''));
+    if (!id || !title) continue;
+    // The site builds the slug from urlTitle/unifiedUrlTitle. The slug is purely
+    // cosmetic — the server keys only on the {id}-{locale} tail (a stub slug
+    // resolves the same posting) — but tenants render it inconsistently: some
+    // percent-encode it ("Oper%C3%A1tor-…"), others leave HTML entities in
+    // ("Mergers-&amp;-Acquisitions"). Decode entities, then drop the URL-
+    // structural chars (& ? #) a raw entity would otherwise inject into the
+    // path, leaving any existing %XX escapes untouched.
+    const slug = decodeEntities(String(r.unifiedUrlTitle || r.urlTitle || 'job'))
+      .replace(/[?#&]+/g, '-')
+      .replace(/-{2,}/g, '-');
+    const url = `${cfg.origin}/job/${slug}/${id}-${locale}`;
+    out.push({
+      id,
+      title,
+      url,
+      location: cleanCsbLocation(r.jobLocationShort),
+      postedAt: parseCsbDate(r.unifiedStandardStart),
+    });
+  }
+  return out;
+}
+
+/** Resolve the per-locale page cap: positive integer `max_pages`, else default. */
+function resolveCsbMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, CSB_MAX_PAGES_PER_LOCALE);
+  return CSB_MAX_PAGES_PER_LOCALE;
+}
+
+// CSB strategy: discover locales, paginate the JSON jobs API per locale, dedup
+// by id across locales+pages. `total` from the first page bounds pagination;
+// an empty/short page also stops the loop.
+/** @param {import('./_types.js').PortalEntry} entry @param {any} cfg @param {import('./_types.js').Context} ctx */
+async function fetchCsb(entry, cfg, ctx) {
+  let locales = CSB_DEFAULT_LOCALES;
+  try {
+    const html = await ctx.fetchText(cfg.searchPage, { headers: { accept: 'text/html' } });
+    const discovered = extractLocales(html);
+    if (discovered.length) locales = discovered;
+  } catch {
+    // Discovery is best-effort; fall back to the default locale set.
+  }
+
+  const maxPages = resolveCsbMaxPages(entry);
+  const jobs = [];
+  const seen = new Set();
+
+  for (const locale of locales) {
+    if (jobs.length >= MAX_JOBS) break;
+    let total = null;
+    for (let page = 0; page < maxPages; page++) {
+      let json;
+      try {
+        json = await ctx.fetchJson(cfg.jobsApi, {
+          method: 'POST',
+          redirect: 'error',
+          headers: { 'content-type': 'application/json', accept: 'application/json' },
+          body: JSON.stringify({ keywords: '', locale, location: '', pageNumber: page, sortBy: 'recent' }),
+        });
+      } catch {
+        break; // this locale failed (e.g. 307 legacy redirect) — try the next
+      }
+      if (total === null) {
+        total = typeof json?.totalJobs === 'number' ? json.totalJobs : null;
+      }
+      const rows = parseCsbJobs(json, cfg, locale);
+      if (rows.length === 0) break;
+
+      for (const row of rows) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        const job = { title: row.title, url: row.url, company: entry.name, location: row.location };
+        if (typeof row.postedAt === 'number') job.postedAt = row.postedAt;
+        jobs.push(job);
+        if (jobs.length >= MAX_JOBS) break;
+      }
+      if (jobs.length >= MAX_JOBS) break;
+      // Stop once we've covered the reported total, or on a short page.
+      if (total !== null && (page + 1) * CSB_PAGE_SIZE >= total) break;
+      if (rows.length < CSB_PAGE_SIZE) break;
+    }
+  }
+  return jobs;
+}
+
+// RMK strategy: the original /tile-search-results/ HTML-fragment scraper.
+/** @param {import('./_types.js').PortalEntry} entry @param {any} cfg @param {import('./_types.js').Context} ctx */
+async function fetchRmk(entry, cfg, ctx) {
+  const jobs = [];
+  const seen = new Set();
+  let startrow = 0;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const htmlText = await ctx.fetchText(`${cfg.tileApi}?startrow=${startrow}`, {
+      redirect: 'error',
+      headers: { accept: 'text/html' },
+    });
+    const tiles = parseTiles(htmlText, cfg.jobBase);
+    if (tiles.length === 0) break;
+
+    let fresh = 0;
+    for (const tile of tiles) {
+      if (seen.has(tile.id)) continue;
+      seen.add(tile.id);
+      fresh++;
+      jobs.push({
+        title: tile.title,
+        url: tile.url,
+        company: entry.name,
+        location: tile.location,
+      });
+    }
+    // No new ids this page → server ignored the offset (or we've looped). Stop.
+    if (fresh === 0) break;
+    if (jobs.length >= MAX_JOBS) break;
+    startrow += tiles.length;
+  }
+  // The cap is checked between pages, so the last page can overshoot it.
+  return jobs.slice(0, MAX_JOBS);
+}
+
 /** @type {Provider} */
 export default {
   id: 'successfactors',
@@ -154,35 +391,15 @@ export default {
     const cfg = resolveConfig(entry);
     if (!cfg) throw new Error(`successfactors: cannot resolve origin for ${entry.name}`);
 
-    const jobs = [];
-    const seen = new Set();
-    let startrow = 0;
-    for (let page = 0; page < MAX_PAGES; page++) {
-      const htmlText = await ctx.fetchText(`${cfg.tileApi}?startrow=${startrow}`, {
-        redirect: 'error',
-        headers: { accept: 'text/html' },
-      });
-      const tiles = parseTiles(htmlText, cfg.jobBase);
-      if (tiles.length === 0) break;
-
-      let fresh = 0;
-      for (const tile of tiles) {
-        if (seen.has(tile.id)) continue;
-        seen.add(tile.id);
-        fresh++;
-        jobs.push({
-          title: tile.title,
-          url: tile.url,
-          company: entry.name,
-          location: tile.location,
-        });
-      }
-      // No new ids this page → server ignored the offset (or we've looped). Stop.
-      if (fresh === 0) break;
-      if (jobs.length >= MAX_JOBS) break;
-      startrow += tiles.length;
+    // Explicit opt-in goes straight to CSB. RMK tenants (the majority) run the
+    // tile scraper; only when it comes back empty — the CSB empty-shell
+    // signature — do we auto-fall back to the JSON API, so an unflagged CSB
+    // tenant still works and a genuinely-empty RMK board costs one extra probe.
+    if (String(entry.sfVariant || '').toLowerCase() === 'csb') {
+      return fetchCsb(entry, cfg, ctx);
     }
-    // The cap is checked between pages, so the last page can overshoot it.
-    return jobs.slice(0, MAX_JOBS);
+    const rmkJobs = await fetchRmk(entry, cfg, ctx);
+    if (rmkJobs.length > 0) return rmkJobs;
+    return fetchCsb(entry, cfg, ctx);
   },
 };

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1724,7 +1724,7 @@ try {
   }
 
   // Tier 2: non-ATS companies are probed through the scanner's provider layer,
-  // bounded to the first page. Fake providers stand in for Workday/SF/etc.
+  // bounded to a few requests. Fake providers stand in for Workday/SF/etc.
   const fakeCtx = { transport: 'http', fetchJson: async () => ({}), fetchText: async () => ['x'] };
   const fakeProviders = new Map([
     ['fakeats', {
@@ -1741,7 +1741,7 @@ try {
     }],
     ['pager', {
       // Ignores maxPages and paginates forever; the probe's request budget must
-      // still cut it off after the first page and classify it live.
+      // still cut it off after the budgeted pages and classify it live.
       id: 'pager',
       detect: (e) => (/pager\.io/.test(e.careers_url || '') ? { url: e.careers_url } : null),
       fetch: async (e, ctx) => {
@@ -1750,12 +1750,27 @@ try {
         return jobs;
       },
     }],
+    ['swallower', {
+      // Mimics SuccessFactors CSB: burns the whole budget on discovery/locale
+      // requests that yield no jobs, swallowing every fetch error internally
+      // (per-locale try/catch). The probe must read "budget tripped + 0 jobs"
+      // as live/partial — the endpoint answered fine — never as 'empty'.
+      id: 'swallower',
+      detect: (e) => (/swallower\.io/.test(e.careers_url || '') ? { url: e.careers_url } : null),
+      fetch: async (e, ctx) => {
+        for (let p = 0; p < 50; p++) {
+          try { await ctx.fetchJson(`u?p=${p}`); } catch { break; }
+        }
+        return [];
+      },
+    }],
   ]);
   const provResults = await verifyCompanies([
     { name: 'PFull', careers_url: 'https://fakeats.io/full' },
     { name: 'PEmpty', careers_url: 'https://fakeats.io/empty' },
     { name: 'PDead', careers_url: 'https://fakeats.io/dead' },
     { name: 'PPager', careers_url: 'https://pager.io/board' },
+    { name: 'PSwallow', careers_url: 'https://swallower.io/board' },
     { name: 'NoProv', careers_url: 'https://unknown.example/careers' },
   ], { fetchJson: mockFetch, providers: fakeProviders, httpCtx: fakeCtx });
   const pv = Object.fromEntries(provResults.map((r) => [r.name, r]));
@@ -1764,9 +1779,10 @@ try {
     pv.PEmpty?.status === 'empty' &&
     pv.PDead?.status === 'missing' && pv.PDead?.errorKind === 'slug_gone' &&
     pv.PPager?.status === 'live' && pv.PPager?.partial === true &&
+    pv.PSwallow?.status === 'live' && pv.PSwallow?.partial === true &&
     pv.NoProv?.status === 'skipped'
   ) {
-    pass('verify-portals probes non-ATS boards via providers, bounded to first page');
+    pass('verify-portals probes non-ATS boards via providers, bounded to a request budget');
   } else {
     fail(`verify-portals provider-fallback wrong: ${JSON.stringify(pv)}`);
   }
@@ -10431,6 +10447,71 @@ try {
   // Empty fragment (MTU's zero-req case) → no jobs, no throw.
   if (parseTiles('<!DOCTYPE html>', jobBase).length === 0) pass('parseTiles returns [] for an empty fragment');
   else fail('parseTiles should return [] for an empty fragment');
+
+  // ── CSB (Career Site Builder) strategy — JSON jobs API ────────────────────
+  const { extractLocales, parseCsbDate, cleanCsbLocation, parseCsbJobs } =
+    await import(pathToFileURL(join(ROOT, 'providers/successfactors.mjs')).href);
+
+  // extractLocales — pull the language-switcher locales from a /search/ page,
+  // deduped and priority-ordered (de_DE, en_US first; then alphabetical).
+  const switcherHtml =
+    '<a href="/search/?q=&amp;startrow=0&amp;locale=fr_FR">FR</a>' +
+    '<a href="/search/?q=&amp;startrow=0&amp;locale=en_US">EN</a>' +
+    '<a href="/search/?q=&amp;startrow=0&amp;locale=de_DE">DE</a>' +
+    '<a href="/search/?q=&amp;startrow=0&amp;locale=de_DE">DE dup</a>';
+  const locs = extractLocales(switcherHtml);
+  if (JSON.stringify(locs) === JSON.stringify(['de_DE', 'en_US', 'fr_FR'])) {
+    pass('extractLocales dedups and priority-orders (de_DE, en_US, then alpha)');
+  } else {
+    fail(`extractLocales wrong: ${JSON.stringify(locs)}`);
+  }
+  if (extractLocales('<p>no locales here</p>').length === 0) pass('extractLocales returns [] when the page carries none');
+  else fail('extractLocales should return [] for a page with no locale links');
+
+  // parseCsbDate — locale-dependent short date; separator infers field order.
+  if (parseCsbDate('6/18/26') === Date.UTC(2026, 5, 18)) pass('parseCsbDate reads US M/D/YY');
+  else fail(`parseCsbDate US wrong: ${parseCsbDate('6/18/26')}`);
+  if (parseCsbDate('20.11.23') === Date.UTC(2023, 10, 20)) pass('parseCsbDate reads European D.M.YY (dots)');
+  else fail(`parseCsbDate DE wrong: ${parseCsbDate('20.11.23')}`);
+  if (parseCsbDate('garbage') === undefined && parseCsbDate('13/40/99') === undefined && parseCsbDate('') === undefined) {
+    pass('parseCsbDate returns undefined for junk / out-of-range / empty');
+  } else {
+    fail('parseCsbDate should reject junk, out-of-range, and empty input');
+  }
+
+  // cleanCsbLocation — array of "City, CC, ZIP<br/>" strings → joined, stripped.
+  if (cleanCsbLocation(['Karlovy Vary, CZE, 36004<br/>']) === 'Karlovy Vary, CZE, 36004') pass('cleanCsbLocation strips trailing <br/>');
+  else fail(`cleanCsbLocation single wrong: ${JSON.stringify(cleanCsbLocation(['Karlovy Vary, CZE, 36004<br/>']))}`);
+  if (cleanCsbLocation(['Munich<br/>', 'Berlin<br/>']) === 'Munich / Berlin') pass('cleanCsbLocation joins multiple locations with " / "');
+  else fail(`cleanCsbLocation multi wrong: ${JSON.stringify(cleanCsbLocation(['Munich<br/>', 'Berlin<br/>']))}`);
+  if (cleanCsbLocation(undefined) === '' && cleanCsbLocation([]) === '') pass('cleanCsbLocation tolerates missing/empty location');
+  else fail('cleanCsbLocation should return "" for missing/empty input');
+
+  // parseCsbJobs — map the {response:{…}} records; build {id}-{locale} URLs and
+  // sanitize the cosmetic slug (HTML entities, URL-structural chars).
+  const csbJson = {
+    totalJobs: 3,
+    jobSearchResult: [
+      { response: { id: '31099', unifiedStandardTitle: 'Analytical Lab Technician', unifiedUrlTitle: 'Analytical-Lab-Technician', jobLocationShort: ['Anyang, KOR, 14058<br/>'], unifiedStandardStart: '6/18/26' } },
+      { response: { id: '1283', unifiedStandardTitle: 'Senior Expert Mergers & Acquisitions (m/f/d)', unifiedUrlTitle: 'Senior-Expert-Mergers-&amp;-Acquisitions-%28mfd%29', jobLocationShort: ['Munich<br/>'], unifiedStandardStart: '4/21/26' } },
+      { response: { id: '', unifiedStandardTitle: 'No ID — dropped', unifiedUrlTitle: 'x' } },
+      { response: { id: '999', unifiedStandardTitle: '', unifiedUrlTitle: 'no-title-dropped' } },
+    ],
+  };
+  const csbCfg = { origin: 'https://jobs.example.com' };
+  const csbJobs = parseCsbJobs(csbJson, csbCfg, 'en_US');
+  if (csbJobs.length === 2) pass('parseCsbJobs drops records missing id or title');
+  else fail(`parseCsbJobs returned ${csbJobs.length}, expected 2`);
+  const c1 = csbJobs[0];
+  if (c1 && c1.url === 'https://jobs.example.com/job/Analytical-Lab-Technician/31099-en_US') pass('parseCsbJobs builds {origin}/job/{slug}/{id}-{locale}');
+  else fail(`parseCsbJobs url wrong: ${JSON.stringify(c1 && c1.url)}`);
+  if (c1 && c1.location === 'Anyang, KOR, 14058') pass('parseCsbJobs cleans jobLocationShort');
+  else fail(`parseCsbJobs location wrong: ${JSON.stringify(c1 && c1.location)}`);
+  if (c1 && c1.postedAt === Date.UTC(2026, 5, 18)) pass('parseCsbJobs sets postedAt from unifiedStandardStart');
+  else fail(`parseCsbJobs postedAt wrong: ${JSON.stringify(c1 && c1.postedAt)}`);
+  const c2 = csbJobs[1];
+  if (c2 && !/[?#&]|&amp;/.test(new URL(c2.url).pathname)) pass('parseCsbJobs sanitizes &amp; / URL-structural chars out of the slug');
+  else fail(`parseCsbJobs slug not sanitized: ${JSON.stringify(c2 && c2.url)}`);
 } catch (err) {
   fail(`successfactors provider test threw: ${err.message}`);
 }

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -227,30 +227,48 @@ async function discoverAlternates(name, { fetchJson }) {
 /**
  * A liveness probe must never paginate an entire board — that is slow and rude
  * to the careers site (many rate-limit or bot-block aggressively). We signal
- * this sentinel when a provider tries to fetch a second page; the probe reads it
- * as "the first page came back fine → the endpoint is live", we just don't learn
- * the exact total. Distinct from a real HTTP error, which means a broken board.
+ * this sentinel when a provider exhausts its request budget; the probe reads it
+ * as "the budgeted pages came back fine → the endpoint is live", we just don't
+ * learn the exact total. Distinct from a real HTTP error (a broken board).
  */
 class ProbePageBudgetReached extends Error {}
 
 /**
- * Wrap an http context so a provider gets exactly ONE successful list request.
+ * A handful of requests, not one: some providers must spend requests before
+ * the first job can arrive — SuccessFactors CSB does a locale-discovery GET,
+ * then one POST per advertised locale until it hits the job-bearing one. A
+ * 1-request budget would misreport every such tenant as 'empty'.
+ */
+const PROBE_REQUEST_BUDGET = 4;
+
+/**
+ * Wrap an http context so a provider gets a bounded number of successful list
+ * requests (PROBE_REQUEST_BUDGET).
  *
  * Cooperating providers also see `maxPages: 1` and stop on their own (we then
- * learn the first-page count). Providers that ignore the hint are cut off at
- * their second request via the sentinel above — so the probe is bounded for
- * every provider, whether or not it honors `maxPages`.
+ * learn the first-page count). Providers that ignore the hint are cut off via
+ * the sentinel above — so the probe is bounded for every provider, whether or
+ * not it honors `maxPages`. `wasTripped()` reports a cut-off even when the
+ * provider swallowed the sentinel internally (e.g. a per-locale try/catch).
  *
  * @param {import('./providers/_types.js').Context} base
+ * @returns {{ctx: import('./providers/_types.js').Context, wasTripped: () => boolean}}
  */
 function boundedProbeCtx(base) {
   let used = 0;
+  let tripped = false;
   const guard = (fn) => async (url, opts) => {
-    if (used >= 1) throw new ProbePageBudgetReached();
+    if (used >= PROBE_REQUEST_BUDGET) {
+      tripped = true;
+      throw new ProbePageBudgetReached();
+    }
     used += 1;
     return fn(url, opts);
   };
-  return { ...base, maxPages: 1, fetchJson: guard(base.fetchJson), fetchText: guard(base.fetchText) };
+  return {
+    ctx: { ...base, maxPages: 1, fetchJson: guard(base.fetchJson), fetchText: guard(base.fetchText) },
+    wasTripped: () => tripped,
+  };
 }
 
 /**
@@ -262,15 +280,21 @@ function boundedProbeCtx(base) {
  * @returns {Promise<{provider,status,jobCount?,partial?,httpStatus?,errorKind?,reason?}>}
  *   status is 'live' (postings found), 'empty' (endpoint OK, no postings), or
  *   'missing' (the board 404s/errors — the company would silently drop from
- *   every scan). `partial` marks a live board whose exact count the one-page
+ *   every scan). `partial` marks a live board whose exact count the bounded
  *   probe didn't measure.
  */
 export async function probeProvider(entry, provider, baseCtx) {
-  const ctx = boundedProbeCtx(baseCtx);
+  const { ctx, wasTripped } = boundedProbeCtx(baseCtx);
   try {
     const jobs = await provider.fetch(entry, ctx);
     const count = Array.isArray(jobs) ? jobs.length : 0;
-    return { provider: provider.id, status: count > 0 ? 'live' : 'empty', jobCount: count };
+    if (count > 0) return { provider: provider.id, status: 'live', jobCount: count };
+    // Zero jobs but the budget guard fired: the provider swallowed the sentinel
+    // (per-locale/per-page try/catch) after its budgeted requests all came back
+    // fine — the endpoint is reachable, we just never reached a job-bearing
+    // page. Same verdict as the propagated-sentinel case below.
+    if (wasTripped()) return { provider: provider.id, status: 'live', partial: true };
+    return { provider: provider.id, status: 'empty', jobCount: 0 };
   } catch (err) {
     if (err instanceof ProbePageBudgetReached) {
       return { provider: provider.id, status: 'live', partial: true };
@@ -293,7 +317,7 @@ export async function probeProvider(entry, provider, baseCtx) {
  *      with cross-probe suggestions when a slug 404s.
  *   2. Everything else is routed through the SAME provider plugins the scanner
  *      uses (Workday, SuccessFactors, SmartRecruiters, Avature, …), bounded to
- *      the first page. This catches broken non-ATS boards that used to be
+ *      a few requests. This catches broken non-ATS boards that used to be
  *      reported as an un-actionable "skipped".
  * A company reaches `skipped` only when no provider claims it. Probing is
  * sequential to stay gentle on rate limits.

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -288,7 +288,11 @@ export async function probeProvider(entry, provider, baseCtx) {
   try {
     const jobs = await provider.fetch(entry, ctx);
     const count = Array.isArray(jobs) ? jobs.length : 0;
-    if (count > 0) return { provider: provider.id, status: 'live', jobCount: count };
+    if (count > 0) {
+      const result = { provider: provider.id, status: 'live', jobCount: count };
+      if (wasTripped()) result.partial = true;
+      return result;
+    }
     // Zero jobs but the budget guard fired: the provider swallowed the sentinel
     // (per-locale/per-page try/catch) after its budgeted requests all came back
     // fine — the endpoint is reachable, we just never reached a job-bearing


### PR DESCRIPTION
## What

Six big-industrial SF tenants (MAN Truck & Bus, TRATON, Hexagon Manufacturing Intelligence, Wacker Chemie, Webasto, MTU Aero Engines) run the newer **Career Site Builder "unified" search**. Their RMK `/tile-search-results/` endpoint returns a 16-byte empty `<!DOCTYPE html>` shell, so the scanner reported 0 jobs on boards that actually carry hundreds of postings, and the portal health check showed them as *live but empty*.

### `providers/successfactors.mjs` — second strategy (CSB)

- `POST {origin}/services/recruiting/v1/jobs` — public no-auth JSON API (10/page, 0-based `pageNumber`), job URL `{origin}/job/{slug}/{id}-{locale}`.
- **Locale discovery** from the `{origin}/search/` language-switcher links. The API is locale-gated: MAN reports de_DE=601 but en_US=8; Hexagon publishes **only** under en_GB. A hardcoded locale silently misses entire tenants, so the provider queries every advertised locale and dedups by job id.
- Activation: `sfVariant: csb` on the portal entry, **plus automatic fallback** when the RMK tile scrape yields zero postings — unflagged CSB tenants still work, and a genuinely-empty RMK board costs one extra probe.
- CSB carries a real posting date; `parseCsbDate` handles the locale-dependent short formats (US `6/18/26` vs European `20.11.23`).

### `verify-portals.mjs` — probe budget 1 → 4 requests

The health probe capped providers at exactly one successful request. CSB spends its first request on locale discovery and swallows the budget sentinel inside its per-locale `try/catch`, so a 1-request probe misreported every CSB tenant as `empty`. Changes:

- `PROBE_REQUEST_BUDGET = 4` (still bounded, still rude-free).
- `probeProvider` treats *budget tripped + 0 jobs* as `live (partial)` via a new `wasTripped()` — the endpoint answered fine, the probe just never reached a job-bearing page.

## Tests

- Unit tests for the CSB parsers (`extractLocales`, `parseCsbDate`, `cleanCsbLocation`, `parseCsbJobs`) incl. slug sanitization (`&amp;`, percent-encoded slugs).
- New `swallower` fake provider asserting the tripped-budget probe semantics; existing `pager`/`fakeats` probes unchanged.
- `node test-all.mjs`: **1193 passed, 0 failed**.

## Verification (live, 2026-07-04)

`verify-portals` sweep after the change: MAN 30, TRATON 12, Hexagon 19 (en_GB-only tenant), Wacker 30, Webasto 30, MTU 20 — all previously *live but empty*. MTU turned out to be an RMK→CSB migration caught by the auto-fallback with no config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SuccessFactors “CSB” (JSON) job sourcing alongside existing HTML scraping, improving coverage for more career sites.
  * Job listings can now derive locale-aware URLs, normalized locations, and optional posted dates when available.

* **Bug Fixes**
  * Improved provider fallback: when the primary HTML approach yields an empty result set, the system can continue with CSB to retrieve jobs.
  * Refined portal probing to use a bounded multi-request budget, distinguishing fully empty boards from partially reachable ones.

* **Tests**
  * Expanded SuccessFactors CSB parsing and added fallback/probing scenarios to validate the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->