### PR TITLE
feat(providers): beesite (milch & zucker) + softgarden providers

### DIFF
--- a/providers/beesite.mjs
+++ b/providers/beesite.mjs
@@ -1,0 +1,177 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// beesite (milch & zucker GJB) provider — the search backend behind branded
+// portals like jobs.mercedes-benz.com. The SPA calls a public, no-auth JSON
+// endpoint on the tenant's *.app.beesite.de host:
+//
+//   GET {origin}/search?data={URL-encoded JSON}
+//   data = {"LanguageCode":"EN",
+//           "SearchParameters":{"FirstItem":1,"CountItem":100,
+//             "Sort":[{"Criterion":"PublicationStartDate","Direction":"DESC"}],
+//             "MatchedObjectDescriptor":[…field list…]},
+//           "SearchCriteria":[…optional facet filters…]}
+//   → {"SearchResult":{"SearchResultCount":N,"SearchResultCountAll":TOTAL,
+//        "SearchResultItems":[{"MatchedObjectId":"200325",
+//          "MatchedObjectDescriptor":{"PositionID":"mer0003yhd",
+//            "PositionTitle":…,"PositionURI":"https://jobs.mercedes-benz.com/…",
+//            "PositionLocation":[{"CityName":"Bremen"}],
+//            "PublicationStartDate":"2026-07-04"}}]}}
+//
+// PositionURI is the BRANDED job page (jobs.mercedes-benz.com/…), so listings
+// link straight to the public posting. FirstItem is 1-based; requesting past
+// the end returns an empty item list. We sort newest-first so a bounded walk
+// (max_pages / MAX_JOBS) keeps the most recent postings.
+//
+// Facet criteria use tenant-internal numeric term codes (Mercedes: country
+// 329 = Germany, discoverable via MatchedObjectDescriptor "Facet:…" queries).
+// A portals.yml entry can pin them via:
+//   beesite:
+//     searchCriteria:
+//       - { CriterionName: PositionLocation.Country, CriterionValue: [329] }
+
+const PAGE_SIZE = 100; // verified: the endpoint happily serves 100+/page
+const MAX_PAGES = 40; // safety cap on request count (40*100 = 4000 postings)
+const MAX_JOBS = 1000; // cap total postings pulled (newest-first sort)
+const PAGE_DELAY_MS = 150; // polite pacing between page requests
+
+const DESCRIPTOR = [
+  'PositionID',
+  'PositionTitle',
+  'PositionURI',
+  'PositionLocation.CityName',
+  'PublicationStartDate',
+];
+
+/** @param {import('./_types.js').PortalEntry} entry */
+export function resolveConfig(entry) {
+  const raw = entry.api || entry.careers_url || '';
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  const host = u.host.toLowerCase();
+  if (host !== 'beesite.de' && !host.endsWith('.beesite.de')) return null;
+  const cfgBlock = entry.beesite && typeof entry.beesite === 'object' ? entry.beesite : {};
+  return {
+    searchApi: `${u.origin}/search`,
+    languageCode: typeof cfgBlock.languageCode === 'string' ? cfgBlock.languageCode : 'EN',
+    searchCriteria: Array.isArray(cfgBlock.searchCriteria) ? cfgBlock.searchCriteria : [],
+  };
+}
+
+/** Build the ?data= payload for one page. @param {any} cfg @param {number} firstItem */
+export function buildSearchUrl(cfg, firstItem) {
+  const data = {
+    LanguageCode: cfg.languageCode,
+    SearchParameters: {
+      FirstItem: firstItem,
+      CountItem: PAGE_SIZE,
+      Sort: [{ Criterion: 'PublicationStartDate', Direction: 'DESC' }],
+      MatchedObjectDescriptor: DESCRIPTOR,
+    },
+    SearchCriteria: cfg.searchCriteria,
+  };
+  return `${cfg.searchApi}?data=${encodeURIComponent(JSON.stringify(data))}`;
+}
+
+// "2026-07-04" → epoch ms (UTC for determinism).
+/** @param {unknown} raw @returns {number | undefined} */
+export function parseBeesiteDate(raw) {
+  const m = typeof raw === 'string' ? raw.trim().match(/^(\d{4})-(\d{2})-(\d{2})$/) : null;
+  if (!m) return undefined;
+  const ms = Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+/**
+ * Map one search response to raw {id, title, url, location, postedAt} records.
+ * @param {any} json
+ * @returns {{total: number|null, rows: Array<{id:string,title:string,url:string,location:string,postedAt?:number}>}}
+ */
+export function parseSearchResult(json) {
+  const sr = json?.SearchResult;
+  const total = typeof sr?.SearchResultCountAll === 'number' ? sr.SearchResultCountAll : null;
+  const items = Array.isArray(sr?.SearchResultItems) ? sr.SearchResultItems : [];
+  const rows = [];
+  for (const item of items) {
+    const d = item?.MatchedObjectDescriptor;
+    if (!d) continue;
+    const id = item.MatchedObjectId != null ? String(item.MatchedObjectId) : String(d.PositionID || '');
+    const title = String(d.PositionTitle || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    const url = String(d.PositionURI || '').trim();
+    if (!id || !title || !/^https?:\/\//i.test(url)) continue;
+    const locs = Array.isArray(d.PositionLocation) ? d.PositionLocation : [];
+    const cities = [];
+    for (const l of locs) {
+      const c = String(l?.CityName || '').trim();
+      if (c && !cities.includes(c)) cities.push(c);
+    }
+    rows.push({
+      id,
+      title,
+      url,
+      location: cities.join(' / '),
+      postedAt: parseBeesiteDate(d.PublicationStartDate),
+    });
+  }
+  return { total, rows };
+}
+
+/** Resolve the page cap: positive integer `max_pages`, else default. */
+function resolveMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES);
+  return MAX_PAGES;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'beesite',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    return resolveConfig({ api: url }) ? { url } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const cfg = resolveConfig(entry);
+    if (!cfg) throw new Error(`beesite: cannot resolve search host for ${entry.name}`);
+
+    const wait = (ms) => (ctx.sleep ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
+    const maxPages = resolveMaxPages(entry);
+    const jobs = [];
+    const seen = new Set();
+    let total = null;
+
+    for (let page = 0; page < maxPages; page++) {
+      if (page > 0) await wait(PAGE_DELAY_MS);
+      const json = await ctx.fetchJson(buildSearchUrl(cfg, page * PAGE_SIZE + 1), {
+        redirect: 'error',
+        headers: { accept: 'application/json' },
+      });
+      const { total: pageTotal, rows } = parseSearchResult(json);
+      if (total === null) total = pageTotal;
+      if (rows.length === 0) break; // past the last page
+
+      let fresh = 0;
+      for (const row of rows) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        fresh++;
+        const job = { title: row.title, url: row.url, company: entry.name, location: row.location };
+        if (typeof row.postedAt === 'number') job.postedAt = row.postedAt;
+        jobs.push(job);
+        if (jobs.length >= MAX_JOBS) break;
+      }
+      if (fresh === 0) break; // server ignored FirstItem (or we've looped)
+      if (jobs.length >= MAX_JOBS) break;
+      if (total !== null && (page + 1) * PAGE_SIZE >= total) break;
+    }
+    return jobs;
+  },
+};

--- a/providers/beesite.mjs
+++ b/providers/beesite.mjs
@@ -83,7 +83,10 @@ export function buildSearchUrl(cfg, firstItem) {
 export function parseBeesiteDate(raw) {
   const m = typeof raw === 'string' ? raw.trim().match(/^(\d{4})-(\d{2})-(\d{2})$/) : null;
   if (!m) return undefined;
-  const ms = Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
+  const ms = Date.UTC(Number(m[1]), month - 1, day);
   return Number.isFinite(ms) ? ms : undefined;
 }
 

--- a/providers/softgarden.mjs
+++ b/providers/softgarden.mjs
@@ -33,7 +33,7 @@ function decodeEntities(s) {
   return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
     if (body[0] === '#') {
       const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
-      return Number.isFinite(code) ? String.fromCodePoint(code) : m;
+      return Number.isInteger(code) && code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : m;
     }
     return NAMED_ENTITIES[body.toLowerCase()] ?? m;
   });

--- a/providers/softgarden.mjs
+++ b/providers/softgarden.mjs
@@ -1,0 +1,159 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// softgarden provider — the hosted job widgets at
+// https://{tenant}.softgarden.io/{lang}/widgets/jobs (e.g. RENK:
+// renk-group.softgarden.io/de/widgets/jobs). Companies embed this Wicket page
+// as an iframe on their branded career sites; fetched directly it is a plain
+// server-rendered document that lists EVERY posting — no auth, no JS, no
+// pagination observed (filtering happens client-side via AJAX we don't need).
+//
+// One posting renders as:
+//   <div class="matchElement" id="job_id_{id}">
+//     <div class="matchValue date">04.07.26</div>
+//     <div class="matchValue title">
+//       <a href="../../job/{id}/{slug}?jobDbPVId=…&l=de">{Title}</a></div>
+//     <div class="matchValue audience">…</div>
+//     <div class="matchValue ProjectGeoLocationCity">…
+//       <span class="location-view-item">{City}</span>…</div>
+//   </div>
+//
+// The href is relative to the /{lang}/widgets/ path — we resolve it against
+// the widget URL so it lands on {origin}/job/{id}/{slug}?… (verified live).
+// The date is the locale's short form (de: D.M.YY with dots; en variants use
+// slashes M/D/YY) — same heuristic as the successfactors CSB parser.
+
+const MAX_JOBS = 1000; // cap postings taken from one widget page
+
+// Minimal HTML entity decoder — titles carry named (&amp;) and numeric
+// (&#252; / &#xfc;) entities. Mirrors successfactors.mjs / dassault.mjs.
+const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+/** @param {string} s */
+function decodeEntities(s) {
+  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
+    if (body[0] === '#') {
+      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : m;
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
+  });
+}
+
+/** @param {string} s */
+function clean(s) {
+  return decodeEntities(s.replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
+}
+
+/** Resolve the widget URL: explicit /widgets/jobs URLs pass through, any other
+ * *.softgarden.io URL defaults to the German jobs widget. */
+export function resolveWidgetUrl(entry) {
+  const raw = entry.api || entry.careers_url || '';
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  const host = u.host.toLowerCase();
+  if (host !== 'softgarden.io' && !host.endsWith('.softgarden.io')) return null;
+  if (/\/widgets\/jobs\/?$/.test(u.pathname)) return `${u.origin}${u.pathname.replace(/\/$/, '')}`;
+  const lang = (u.pathname.match(/^\/([a-z]{2})(\/|$)/) || [])[1] || 'de';
+  return `${u.origin}/${lang}/widgets/jobs`;
+}
+
+// Widget dates are the locale's SHORT form: de widgets emit D.M.YY with dots,
+// en variants M/D/YY with slashes. Separator infers the field order; 2-digit
+// years are 20YY. Junk → undefined ("unknown date", never a bogus timestamp).
+/** @param {unknown} raw @returns {number | undefined} */
+export function parseSoftgardenDate(raw) {
+  if (typeof raw !== 'string') return undefined;
+  const s = raw.trim();
+  let a, b, year;
+  const slash = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/);
+  const dot = s.match(/^(\d{1,2})\.(\d{1,2})\.(\d{2,4})$/);
+  if (slash) {
+    [, a, b, year] = slash; // M/D/Y
+  } else if (dot) {
+    [, b, a, year] = dot; // D.M.Y → swap to month/day
+  } else {
+    return undefined;
+  }
+  const month = Number(a);
+  const day = Number(b);
+  let y = Number(year);
+  if (y < 100) y += 2000;
+  if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
+  const ms = Date.UTC(y, month - 1, day);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+/**
+ * Parse the widget page into raw {id, title, url, location, postedAt} records.
+ * @param {string} html @param {string} widgetUrl
+ */
+export function parseWidget(html, widgetUrl) {
+  if (typeof html !== 'string') return [];
+  const out = [];
+  const seen = new Set();
+  const blocks = html.split(/<div class="matchElement" id="job_id_/).slice(1);
+  for (const block of blocks) {
+    const id = (block.match(/^(\d+)"/) || [])[1];
+    if (!id || seen.has(id)) continue;
+    const linkM = block.match(/<a href="([^"]*\/job\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/);
+    if (!linkM) continue;
+    const title = clean(linkM[2]);
+    if (!title) continue;
+    let url;
+    try {
+      // hrefs are relative to the /{lang}/widgets/ path ("../../job/…").
+      url = new URL(decodeEntities(linkM[1]), widgetUrl).href;
+    } catch {
+      continue;
+    }
+    const cities = [];
+    const cityRe = /class="location-view-item"[^>]*>([\s\S]*?)<\/span>/g;
+    let cm;
+    while ((cm = cityRe.exec(block)) !== null) {
+      const c = clean(cm[1]);
+      if (c && !cities.includes(c)) cities.push(c);
+    }
+    const dateM = block.match(/class="matchValue date"[^>]*>([\s\S]*?)<\/div>/);
+    seen.add(id);
+    out.push({
+      id,
+      title,
+      url,
+      location: cities.join(' / '),
+      postedAt: parseSoftgardenDate(dateM ? clean(dateM[1]) : undefined),
+    });
+  }
+  return out;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'softgarden',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    return resolveWidgetUrl({ api: url }) ? { url } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const widgetUrl = resolveWidgetUrl(entry);
+    if (!widgetUrl) throw new Error(`softgarden: cannot resolve widget URL for ${entry.name}`);
+
+    const html = await ctx.fetchText(widgetUrl, { headers: { accept: 'text/html' } });
+    const rows = parseWidget(html, widgetUrl);
+    const jobs = [];
+    for (const row of rows) {
+      const job = { title: row.title, url: row.url, company: entry.name, location: row.location };
+      if (typeof row.postedAt === 'number') job.postedAt = row.postedAt;
+      jobs.push(job);
+      if (jobs.length >= MAX_JOBS) break;
+    }
+    return jobs;
+  },
+};

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -11620,6 +11620,132 @@ try {
   fail(`dassault provider tests crashed: ${e.message}`);
 }
 
+console.log('\n60. Provider — beesite (milch & zucker GJB search API)');
+try {
+  const beesite = (await import(pathToFileURL(join(ROOT, 'providers/beesite.mjs')).href)).default;
+  const { resolveConfig: beeConfig, buildSearchUrl, parseBeesiteDate, parseSearchResult } =
+    await import(pathToFileURL(join(ROOT, 'providers/beesite.mjs')).href);
+
+  if (beesite.id === 'beesite') pass('beesite.id is "beesite"');
+  else fail(`beesite.id is ${JSON.stringify(beesite.id)}`);
+
+  // resolveConfig — host-anchored, config block passthrough.
+  const bCfg = beeConfig({
+    api: 'https://mercedes-benz-beesite-production-gjb.app.beesite.de',
+    beesite: { languageCode: 'DE', searchCriteria: [{ CriterionName: 'PositionLocation.Country', CriterionValue: [329] }] },
+  });
+  if (bCfg && bCfg.searchApi === 'https://mercedes-benz-beesite-production-gjb.app.beesite.de/search' && bCfg.languageCode === 'DE' && bCfg.searchCriteria.length === 1) {
+    pass('beesite.resolveConfig() parses host and passes the beesite config block through');
+  } else {
+    fail(`beesite.resolveConfig() wrong: ${JSON.stringify(bCfg)}`);
+  }
+  if (beesite.detect({ careers_url: 'https://evil.com/x.beesite.de' }) === null && beesite.detect({ careers_url: 'https://beesite.de.evil.com/x' }) === null) {
+    pass('beesite.detect() rejects path- and suffix-spoofed hosts');
+  } else {
+    fail('beesite.detect() should reject spoofed hosts');
+  }
+
+  // buildSearchUrl — FirstItem lands in the encoded payload.
+  const bUrl = buildSearchUrl(bCfg, 101);
+  if (bUrl.startsWith(bCfg.searchApi + '?data=') && decodeURIComponent(bUrl).includes('"FirstItem":101') && decodeURIComponent(bUrl).includes('"CriterionValue":[329]')) {
+    pass('beesite.buildSearchUrl() encodes FirstItem and the pinned criteria');
+  } else {
+    fail(`beesite.buildSearchUrl() wrong: ${bUrl.slice(0, 140)}`);
+  }
+
+  if (parseBeesiteDate('2026-07-04') === Date.UTC(2026, 6, 4) && parseBeesiteDate('junk') === undefined) pass('beesite.parseBeesiteDate() reads YYYY-MM-DD, rejects junk');
+  else fail('beesite.parseBeesiteDate() wrong');
+
+  // parseSearchResult — id/title/absolute-URL required, cities joined.
+  const mkItem = (id, title, uri) => ({ MatchedObjectId: String(id), MatchedObjectDescriptor: { PositionID: `x${id}`, PositionTitle: title, PositionURI: uri, PositionLocation: [{ CityName: 'Bremen' }, { CityName: 'Berlin' }], PublicationStartDate: '2026-07-04' } });
+  const beeJson = { SearchResult: { SearchResultCount: 2, SearchResultCountAll: 42, SearchResultItems: [
+    mkItem(1, 'IT Architect', 'https://jobs.example.com/a-1'),
+    { MatchedObjectId: '2', MatchedObjectDescriptor: { PositionTitle: 'No URI — dropped', PositionURI: '/relative' } },
+  ] } };
+  const { total: beeTotal, rows: beeRows } = parseSearchResult(beeJson);
+  if (beeTotal === 42 && beeRows.length === 1 && beeRows[0].location === 'Bremen / Berlin' && beeRows[0].postedAt === Date.UTC(2026, 6, 4)) {
+    pass('beesite.parseSearchResult() maps items, joins cities, drops non-absolute URIs');
+  } else {
+    fail(`beesite.parseSearchResult() wrong: total=${beeTotal} rows=${JSON.stringify(beeRows)}`);
+  }
+
+  // fetch — paginates by FirstItem until SearchResultCountAll, dedups.
+  const beePage = (ids) => ({ SearchResult: { SearchResultCount: ids.length, SearchResultCountAll: 150, SearchResultItems: ids.map((i) => mkItem(i, `Job ${i}`, `https://jobs.example.com/j-${i}`)) } });
+  const beePages = [beePage(Array.from({ length: 100 }, (_, i) => i + 1)), beePage([100, 101, 102])];
+  let beeCalls = 0;
+  const beeSeen = [];
+  const beeCtx = { sleep: async () => {}, fetchJson: async (url) => { beeSeen.push(decodeURIComponent(url)); return beePages[beeCalls++] ?? beePage([]); } };
+  const beeJobs = await beesite.fetch({ name: 'MB', api: 'https://x.app.beesite.de' }, beeCtx);
+  if (beeJobs.length === 102 && beeCalls === 2 && beeSeen[1].includes('"FirstItem":101')) pass('beesite.fetch() paginates via FirstItem and dedups across pages');
+  else fail(`beesite.fetch() returned ${beeJobs.length} jobs after ${beeCalls} calls`);
+} catch (e) {
+  fail(`beesite provider tests crashed: ${e.message}`);
+}
+
+console.log('\n61. Provider — softgarden (hosted jobs widget parser)');
+try {
+  const softgarden = (await import(pathToFileURL(join(ROOT, 'providers/softgarden.mjs')).href)).default;
+  const { resolveWidgetUrl, parseSoftgardenDate, parseWidget } =
+    await import(pathToFileURL(join(ROOT, 'providers/softgarden.mjs')).href);
+
+  if (softgarden.id === 'softgarden') pass('softgarden.id is "softgarden"');
+  else fail(`softgarden.id is ${JSON.stringify(softgarden.id)}`);
+
+  // resolveWidgetUrl — widget URLs pass through, other tenant URLs default,
+  // spoofed hosts rejected.
+  if (resolveWidgetUrl({ api: 'https://renk-group.softgarden.io/de/widgets/jobs' }) === 'https://renk-group.softgarden.io/de/widgets/jobs') pass('softgarden.resolveWidgetUrl() keeps explicit widget URLs');
+  else fail('softgarden.resolveWidgetUrl() should keep the widget URL');
+  if (resolveWidgetUrl({ careers_url: 'https://acme.softgarden.io/en/vacancies' }) === 'https://acme.softgarden.io/en/widgets/jobs') pass('softgarden.resolveWidgetUrl() defaults other tenant URLs to the lang widget');
+  else fail(`softgarden.resolveWidgetUrl() default wrong: ${resolveWidgetUrl({ careers_url: 'https://acme.softgarden.io/en/vacancies' })}`);
+  if (softgarden.detect({ careers_url: 'https://evil.com/x.softgarden.io' }) === null && softgarden.detect({ careers_url: 'https://softgarden.io.evil.com/x' }) === null) {
+    pass('softgarden.detect() rejects path- and suffix-spoofed hosts');
+  } else {
+    fail('softgarden.detect() should reject spoofed hosts');
+  }
+
+  if (parseSoftgardenDate('04.07.26') === Date.UTC(2026, 6, 4) && parseSoftgardenDate('7/4/26') === Date.UTC(2026, 6, 4) && parseSoftgardenDate('junk') === undefined) {
+    pass('softgarden.parseSoftgardenDate() reads D.M.YY and M/D/YY, rejects junk');
+  } else {
+    fail('softgarden.parseSoftgardenDate() wrong');
+  }
+
+  // parseWidget — matchElement blocks; relative ../../job/ hrefs resolve
+  // against the widget path; entities decoded; multi-city joined.
+  const sgCard = (id, title, cities) =>
+    `<div class="matchElement" id="job_id_${id}">` +
+    `<div class="matchValue date">04.07.26</div>` +
+    `<div target="_blank" class="matchValue title"><a href="../../job/${id}/slug-${id}?jobDbPVId=9${id}&amp;l=de" target="_blank">${title}</a></div>` +
+    `<div class="matchValue audience">Berufserfahrene</div>` +
+    `<div class="matchValue ProjectGeoLocationCity"><div><div class="location-container">${cities.map((c) => `<span class="location-view-item">${c}</span>`).join('')}</div></div></div>` +
+    `</div>`;
+  const sgHtml = '<html>' + sgCard('111', 'Fachkraft (m/w/d) f&#252;r Export &amp; Zoll', ['Hannover']) + sgCard('222', 'SAP Consultant', ['Augsburg', 'M&#252;nchen']) + '</html>';
+  const sgRows = parseWidget(sgHtml, 'https://renk-group.softgarden.io/de/widgets/jobs');
+  if (sgRows.length === 2) pass('softgarden.parseWidget() yields one row per matchElement');
+  else fail(`softgarden.parseWidget() returned ${sgRows.length}, expected 2`);
+  if (sgRows[0]?.title === 'Fachkraft (m/w/d) für Export & Zoll') pass('softgarden.parseWidget() decodes entities in titles');
+  else fail(`softgarden.parseWidget() title wrong: ${JSON.stringify(sgRows[0]?.title)}`);
+  if (sgRows[0]?.url === 'https://renk-group.softgarden.io/job/111/slug-111?jobDbPVId=9111&l=de') pass('softgarden.parseWidget() resolves ../../job/ hrefs against the widget path');
+  else fail(`softgarden.parseWidget() url wrong: ${JSON.stringify(sgRows[0]?.url)}`);
+  if (sgRows[1]?.location === 'Augsburg / München' && sgRows[0]?.postedAt === Date.UTC(2026, 6, 4)) pass('softgarden.parseWidget() joins cities and parses the date');
+  else fail(`softgarden.parseWidget() fields wrong: ${JSON.stringify(sgRows[1])}`);
+  if (parseWidget('<html>none</html>', 'https://x.softgarden.io/de/widgets/jobs').length === 0 && parseWidget(undefined, 'https://x').length === 0) {
+    pass('softgarden.parseWidget() returns [] for card-less / non-string input');
+  } else {
+    fail('softgarden.parseWidget() should return [] without cards');
+  }
+
+  // fetch — single widget request, jobs normalized.
+  const sgCtx = { fetchText: async () => sgHtml };
+  const sgJobs = await softgarden.fetch({ name: 'Renk', api: 'https://renk-group.softgarden.io/de/widgets/jobs' }, sgCtx);
+  if (sgJobs.length === 2 && sgJobs[0].company === 'Renk' && sgJobs.every((j) => j.url.startsWith('https://renk-group.softgarden.io/job/'))) {
+    pass('softgarden.fetch() returns normalized jobs from one widget request');
+  } else {
+    fail(`softgarden.fetch() wrong: ${JSON.stringify(sgJobs)}`);
+  }
+} catch (e) {
+  fail(`softgarden provider tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## What

Two new zero-token scan sources for widely-deployed German ATS platforms.

### `providers/beesite.mjs` — milch & zucker GJB search backend

Behind branded portals like `jobs.mercedes-benz.com` sits a public JSON API on the tenant's `{tenant}.app.beesite.de` host:

- `GET {origin}/search?data={URL-encoded JSON}` — no auth. Sorted newest-first, `FirstItem`/`CountItem` pagination (100/page) bounded by `SearchResultCountAll`, dedup by `MatchedObjectId`.
- `PositionURI` links land on the **branded** job pages (`jobs.mercedes-benz.com/…`), so listings point straight at the public posting.
- Facet criteria use tenant-internal numeric term codes (discoverable via `MatchedObjectDescriptor: ["Facet:…"]` queries); a portals entry can pin them:
  ```yaml
  beesite:
    searchCriteria:
      - { CriterionName: PositionLocation.Country, CriterionValue: [329] }  # Mercedes: 329 = Germany
  ```

### `providers/softgarden.mjs` — hosted jobs widgets

`{tenant}.softgarden.io/{lang}/widgets/jobs` is the Wicket page companies iframe on their branded career sites. Fetched directly it's **one server-rendered document listing every posting** — no auth, no JS, no pagination. Especially useful when the branded site itself is bot-gated: RENK's `renk.com` sits behind a Cloudflare challenge, but its widget host `renk-group.softgarden.io` is open.

- Parses the `matchElement` blocks: id, title (entities decoded), `D.M.YY`/`M/D/YY` date, multi-city locations.
- Resolves the relative `../../job/{id}/{slug}?jobDbPVId=…` hrefs against the widget path (verified: resulting URLs return 200).

Both `detect()` hooks are host-anchored (`evil.com/x.beesite.de` and suffix-spoofs rejected, covered by tests).

## Tests

Sections 60/61: config/URL-builder/date/result parsers, spoof rejection, `FirstItem` pagination + dedup (beesite), widget parsing incl. relative-href resolution and entity decoding (softgarden). `node test-all.mjs`: **1198 passed, 0 failed**.

## Verification (live, 2026-07-04)

- Mercedes-Benz: 3398 postings total, 1759 with the Germany criterion; 200 pulled over 2 bounded pages with cities + `PublicationStartDate`; branded detail URL returns 200.
- RENK: 66 postings from one widget request, cities (Hannover/Augsburg/…) and dates populated; detail URL returns 200.
- `verify-portals` through the provider layer: `Mercedes-Benz Group — beesite (first page live)`, `Renk — softgarden (66 live)`.

## Note

Trivially conflicts with #1549 in `test-all.mjs` (both append provider test sections at the file end). Happy to rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Beesite and Softgarden job sources, including tenant-aware URL detection and normalized job outputs (title, URL, company, location, and optional posted date).
  * Implemented provider-specific parsing for Beesite search results and Softgarden hosted widget HTML, including date handling and link normalization.
* **Tests**
  * Added end-to-end validation for provider detection, URL building, pagination/dedup behavior, date parsing, and widget/response parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->