### PR TITLE
fix(providers): workday honors ctx.maxPages so the liveness probe stops cleanly

### DIFF
--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -195,9 +195,22 @@ export default {
     // one): bounded by `total` when the server reports it, always capped at
     // maxPages. When `total` is absent, only probe further pages if the first
     // one was full — a short first page already means there's nothing more.
-    const pagesToFetch = total !== null
+    let pagesToFetch = total !== null
       ? Math.min(Math.ceil(total / PAGE_SIZE), maxPages)
       : (firstPostings.length >= PAGE_SIZE ? maxPages : 1);
+
+    // Honor a context page cap — verify-portals' liveness probe sets
+    // `ctx.maxPages: 1` so it only needs to know a board is live, not its full
+    // count. Without this we'd fetch page 0, then request page 1 and trip the
+    // probe's second-request sentinel; fetchPageWithRetry treats that abort as
+    // transient and retries it MAX_RETRIES times (with backoff) before giving up
+    // — noisy in the logs and rude to the tenant. Capping here makes workday a
+    // "cooperating provider" that stops after one page and reports an exact
+    // first-page count. Kept separate from `maxPages` so the entry-cap warning
+    // below (pagesToFetch === maxPages) stays quiet. No effect on real scans,
+    // which don't set ctx.maxPages.
+    const ctxCap = typeof ctx?.maxPages === 'number' && ctx.maxPages > 0 ? ctx.maxPages : Infinity;
+    pagesToFetch = Math.min(pagesToFetch, ctxCap);
 
     // Why pagination stopped — drives which warning (if any) fires below.
     // 'fetch-error' must NOT produce the "raise max_pages" advice: that knob

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -209,7 +209,7 @@ export default {
     // first-page count. Kept separate from `maxPages` so the entry-cap warning
     // below (pagesToFetch === maxPages) stays quiet. No effect on real scans,
     // which don't set ctx.maxPages.
-    const ctxCap = typeof ctx?.maxPages === 'number' && ctx.maxPages > 0 ? ctx.maxPages : Infinity;
+    const ctxCap = Number.isInteger(ctx?.maxPages) && ctx.maxPages > 0 ? ctx.maxPages : Infinity;
     pagesToFetch = Math.min(pagesToFetch, ctxCap);
 
     // Why pagination stopped — drives which warning (if any) fires below.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -11152,6 +11152,37 @@ try {
     fail(`fallback pagination: requests=${fallbackRequests}, jobs=${fallbackJobs.length} (expected 2/25)`);
   }
 
+  // fetch() honors ctx.maxPages — verify-portals' liveness probe sets maxPages:1.
+  // It must stop after the first page and NOT request page 2, which would trip
+  // the probe's second-request sentinel; fetchPageWithRetry treats that abort as
+  // transient and retries it MAX_RETRIES times (4 requests) plus a truncation
+  // warning. Even though total=173 implies 9 pages, the cap must win at 1.
+  let probeRequests = 0;
+  const probeWarnings = [];
+  const probeErr = console.error;
+  console.error = (m) => probeWarnings.push(m);
+  let probeJobs;
+  try {
+    probeJobs = await workday.fetch(entry, mkWorkdayCtx(async (_url, opts) => {
+      probeRequests++;
+      // Simulate the probe sentinel: any request past the first throws.
+      if (JSON.parse(opts.body).offset > 0) throw new Error('probe budget: no second page');
+      return { total: 173, jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}` })) };
+    }, { maxPages: 1 }));
+  } finally {
+    console.error = probeErr;
+  }
+  if (probeRequests === 1 && probeJobs.length === 20) {
+    pass('workday.fetch() honors ctx.maxPages=1 — one request, no second-page retry storm');
+  } else {
+    fail(`workday probe cap: requests=${probeRequests} (expected 1), jobs=${probeJobs?.length} (expected 20)`);
+  }
+  if (!probeWarnings.some((w) => /truncated/.test(String(w)))) {
+    pass('workday.fetch() stays silent (no truncation warning) under the liveness probe cap');
+  } else {
+    fail(`workday probe should emit no warning, got: ${JSON.stringify(probeWarnings)}`);
+  }
+
 } catch (e) {
   fail(`workday provider tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
## Problem

verify-portals' liveness probe (`boundedProbeCtx`) allows exactly **one** list request (`maxPages: 1`) and throws a sentinel on the second — the comment states cooperating providers "also see `maxPages: 1` and stop on their own."

**workday didn't cooperate.** It sizes pagination from `total` (e.g. PTC: 173 jobs → 9 pages), fetches page 0, then requests page 1 → trips the sentinel. Because `fetchPageWithRetry` treats a status-less abort as transient, it **retries the sentinel `MAX_RETRIES` times** (4 requests against the real tenant, with backoff) before giving up with a misleading `⚠️ workday: PTC truncated at 2 of 9 pages after 4 attempts` warning.

So every portal health check hammered each multi-page workday tenant (PTC, Autodesk, Airbus, Rolls-Royce, …) with wasted retries + backoff and emitted an error-looking log line — the exact "rude to the careers site" behavior the probe is designed to avoid.

## Fix

Cap `pagesToFetch` by `ctx.maxPages` when present. The probe stops after one page, reports an **exact** first-page count (instead of a retry-truncated partial), and stays silent. Kept separate from the entry `max_pages` cap so the "raise max_pages" warning doesn't fire under the probe.

**No effect on real scans** — they don't set `ctx.maxPages`.

## Verification

Against the **live PTC tenant** with a `maxPages: 1` probe ctx:

| | before | after |
|---|---|---|
| requests | 5 (1 + 4 retries) | **1** |
| truncation warnings | 1 | **0** |
| result | live (partial) | live, exact count (20) |

New test asserts exactly one request and no truncation warning under `ctx.maxPages: 1`. Full suite green (1182 passed, 0 failed).

## Note

Other paginating providers (avature, successfactors, dassault) also ignore `ctx.maxPages`, but they have no retry loop, so the sentinel cuts them off cleanly (→ `live, partial`) with no noise — out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workday data fetching now respects a maximum page limit from the current request context, preventing unnecessary extra page requests in capped scenarios.
  * Liveness probe runs no longer trigger a page-fetch storm when the first page indicates many results.

* **Tests**
  * Added coverage to verify only one page is requested under a context page cap.
  * Confirmed returned results remain intact and no truncation warning appears in this scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->