### PR TITLE
feat(providers): Phenom People (phenom) + Radancy TalentBrew (radancy) providers

### DIFF
--- a/providers/phenom.mjs
+++ b/providers/phenom.mjs
@@ -1,0 +1,209 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Phenom People provider — the "CareerConnect" career sites many large
+// enterprises run (careers.allianz.com and countless others). The search SPA
+// talks to a public, no-auth JSON widget endpoint on the BRANDED host:
+//
+//   POST {origin}/widgets
+//   Content-Type: application/json
+//   {"lang":"en_global","country":"global","ddoKey":"refineSearch",
+//    "pageName":"search-results","siteType":"external","jobs":true,"counts":true,
+//    "from":0,"size":100,"keywords":"","selected_fields":{…facet filters…},
+//    "all_fields":["category","country","city"], …}
+//   → {"refineSearch":{"status":200,"totalHits":N,
+//        "data":{"jobs":[{"jobId":"98098","title":…,"city":…,"state":…,
+//          "country":…,"location":…,"postedDate":"…ISO…","applyUrl":…}]}}}
+//
+// `from` is a 0-based offset; `size` up to 100/page (verified). The public job
+// page the SPA links to is {origin}/{urlPrefix}/job/{jobId}/{slug} — the slug is
+// cosmetic (Phenom keys on jobId; a stub slug resolves the same posting), so we
+// slugify the title. applyUrl points at the downstream ATS (Allianz: SF
+// career5) and is NOT the public listing, so we don't use it as the job URL.
+//
+// Facets use human-readable values here (unlike CSOD/beesite numeric codes):
+// selected_fields:{"country":["Germany"]} narrows to the DACH set. A portals
+// entry configures the tenant via a `phenom:` block:
+//   phenom:
+//     lang: en_global        # widget locale (default en_global)
+//     country: global        # widget country scope (default global)
+//     urlPrefix: global/en   # public job-page path prefix (default global/en)
+//     selectedFields: { country: ["Germany"] }   # optional facet filter
+//
+// Detection: branded hosts carry no "phenom" token, so detect() only auto-claims
+// literal *.phenompeople.com URLs; branded tenants are wired with an explicit
+// `provider: phenom` (which bypasses detect()).
+
+const PAGE_SIZE = 100; // max the widget serves per page (verified)
+const MAX_PAGES = 40; // safety cap on request count (40*100 = 4000 postings)
+const MAX_JOBS = 1000; // cap total postings pulled per site
+const PAGE_DELAY_MS = 150; // polite pacing between page requests
+
+/** @param {import('./_types.js').PortalEntry} entry */
+export function resolveConfig(entry) {
+  const raw = entry.api || entry.careers_url || '';
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  const block = entry.phenom && typeof entry.phenom === 'object' ? entry.phenom : {};
+  const urlPrefix = String(block.urlPrefix || 'global/en').replace(/^\/+|\/+$/g, '');
+  return {
+    origin: u.origin,
+    widgetsApi: `${u.origin}/widgets`,
+    lang: typeof block.lang === 'string' ? block.lang : 'en_global',
+    country: typeof block.country === 'string' ? block.country : 'global',
+    urlPrefix,
+    selectedFields: block.selectedFields && typeof block.selectedFields === 'object' ? block.selectedFields : {},
+  };
+}
+
+// Slugify a title the way Phenom builds the cosmetic job-page slug: keep
+// alphanumerics, collapse every other run to a single hyphen, trim hyphens.
+/** @param {string} title */
+export function slugify(title) {
+  return String(title)
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '') // strip combining marks (ü→u, é→e)
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'job';
+}
+
+// Phenom postedDate is an ISO-8601 instant ("2026-05-07T18:25:30.000+0000").
+/** @param {unknown} raw @returns {number | undefined} */
+export function parsePhenomDate(raw) {
+  if (typeof raw !== 'string' || !raw.trim()) return undefined;
+  const ms = Date.parse(raw.trim());
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+// The widget returns a flat "City, State, Country" via several fields; prefer
+// the explicit `location`, else assemble from city/state/country. Strips markup
+// and collapses whitespace.
+/** @param {any} job @returns {string} */
+export function jobLocation(job) {
+  const direct = String(job?.location || job?.cityStateCountry || job?.cityState || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+  if (direct) return direct;
+  const parts = [job?.city, job?.state, job?.country].map((p) => String(p || '').trim()).filter(Boolean);
+  return [...new Set(parts)].join(', ');
+}
+
+/**
+ * Map one refineSearch response to {total, rows}. A record without a jobId or a
+ * title is skipped (no stable dedup key / no meaningful listing).
+ * @param {any} json @param {{origin:string, urlPrefix:string}} cfg
+ */
+export function parseRefineSearch(json, cfg) {
+  const rs = json?.refineSearch;
+  const total = typeof rs?.totalHits === 'number' ? rs.totalHits : null;
+  const list = Array.isArray(rs?.data?.jobs) ? rs.data.jobs : [];
+  const rows = [];
+  for (const job of list) {
+    if (!job || typeof job !== 'object') continue;
+    const id = job.jobId != null ? String(job.jobId) : '';
+    const title = String(job.title || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!id || !title) continue;
+    rows.push({
+      id,
+      title,
+      url: `${cfg.origin}/${cfg.urlPrefix}/job/${encodeURIComponent(id)}/${slugify(title)}`,
+      location: jobLocation(job),
+      postedAt: parsePhenomDate(job.postedDate || job.dateCreated),
+    });
+  }
+  return { total, rows };
+}
+
+/** Resolve the page cap: positive integer `max_pages`, else default. */
+function resolveMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES);
+  return MAX_PAGES;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'phenom',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    let host;
+    try {
+      host = new URL(url).hostname.toLowerCase();
+    } catch {
+      return null;
+    }
+    if (host === 'phenompeople.com' || host.endsWith('.phenompeople.com')) return { url };
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const cfg = resolveConfig(entry);
+    if (!cfg) throw new Error(`phenom: cannot resolve origin for ${entry.name}`);
+
+    const wait = (ms) => (ctx.sleep ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
+    const maxPages = resolveMaxPages(entry);
+    const jobs = [];
+    const seen = new Set();
+    let total = null;
+
+    for (let page = 0; page < maxPages; page++) {
+      if (page > 0) await wait(PAGE_DELAY_MS);
+      let json;
+      try {
+        json = await ctx.fetchJson(cfg.widgetsApi, {
+          method: 'POST',
+          redirect: 'error',
+          headers: { 'content-type': 'application/json', accept: 'application/json' },
+          body: JSON.stringify({
+            lang: cfg.lang,
+            deviceType: 'desktop',
+            country: cfg.country,
+            pageName: 'search-results',
+            ddoKey: 'refineSearch',
+            sortBy: '',
+            subsearch: '',
+            from: page * PAGE_SIZE,
+            jobs: true,
+            counts: true,
+            all_fields: ['category', 'country', 'city'],
+            size: PAGE_SIZE,
+            clearAll: false,
+            jdsource: 'facets',
+            isSliderEnable: false,
+            pageId: 'page10',
+            siteType: 'external',
+            keywords: '',
+            global: cfg.country === 'global',
+            selected_fields: cfg.selectedFields,
+            locationData: {},
+          }),
+        });
+      } catch {
+        break; // keep jobs collected so far — a transient mid-scan failure shouldn't discard earlier pages
+      }
+      const { total: pageTotal, rows } = parseRefineSearch(json, cfg);
+      if (total === null) total = pageTotal;
+      if (rows.length === 0) break;
+
+      let fresh = 0;
+      for (const row of rows) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        fresh++;
+        const job = { title: row.title, url: row.url, company: entry.name, location: row.location };
+        if (typeof row.postedAt === 'number') job.postedAt = row.postedAt;
+        jobs.push(job);
+        if (jobs.length >= MAX_JOBS) break;
+      }
+      if (fresh === 0) break; // server ignored `from` (or we've looped)
+      if (jobs.length >= MAX_JOBS) break;
+      if (total !== null && (page + 1) * PAGE_SIZE >= total) break;
+    }
+    return jobs;
+  },
+};

--- a/providers/radancy.mjs
+++ b/providers/radancy.mjs
@@ -74,8 +74,9 @@ export function parseResults(html, origin) {
     const link = block.match(/search-results-list__job-link[^"]*"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/);
     if (!link) continue;
     const href = decodeEntities(link[1]);
-    const idM = block.match(/data-job-id="([^"]+)"/) || href.match(/\/(\d+)(?:[/?#]|$)/);
-    const id = idM ? idM[1] : href;
+    const dataIdM = block.match(/data-job-id="([^"]+)"/);
+    const hrefIds = [...href.matchAll(/\/(\d+)(?=[/?#]|$)/g)];
+    const id = dataIdM ? dataIdM[1] : (hrefIds.length ? hrefIds[hrefIds.length - 1][1] : href);
     if (seen.has(id)) continue;
     const title = clean(link[2]);
     if (!title) continue;

--- a/providers/radancy.mjs
+++ b/providers/radancy.mjs
@@ -1,0 +1,146 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Radancy (TalentBrew) provider — the career sites Radancy hosts for large
+// employers (careers.munichre.com and its ERGO brands, plus many others). The
+// search-results page is SERVER-rendered and paginates over bare HTTP:
+//
+//   GET {origin}/{lang}/search-jobs?p={N}      # 1-based; past-the-end → empty
+//
+// Each posting is one <li class="search-results-list__item …"> holding:
+//   <a class="search-results-list__job-link …" href="/{lang}/job/{city}/{slug}/{cat}/{id}"
+//      data-job-id="{id}">{Title}</a>
+//   <li class="…__job-info--location"><i></i><span>{City, Country}</span></li>
+// The generic `search-results-list__` class prefix is the stable TalentBrew
+// markup (a second, module-numbered `job-list-NN-list__` prefix rides alongside
+// it and varies per site) — we anchor on the generic one for portability.
+//
+// The list carries no posting date, so postedAt is omitted. detect() can't be
+// host-based (branded domains), so tenants are wired with an explicit
+// `provider: radancy` + a search-jobs `api:`/`careers_url`.
+
+const MAX_PAGES = 200; // safety cap (~15/page ⇒ up to ~3000 postings)
+const MAX_JOBS = 2000; // cap total postings pulled
+const PAGE_DELAY_MS = 150; // polite pacing — full walks are >100 sequential requests
+
+// Minimal HTML entity decoder — mirrors the other HTML-scraping providers.
+const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+/** @param {string} s */
+function decodeEntities(s) {
+  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
+    if (body[0] === '#') {
+      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+      // String.fromCodePoint throws RangeError outside 0..0x10FFFF or on a lone
+      // surrogate half — a malformed/adversarial entity must degrade to the
+      // original text, never crash the whole parse.
+      const valid = Number.isFinite(code) && code >= 0 && code <= 0x10ffff && !(code >= 0xd800 && code <= 0xdfff);
+      return valid ? String.fromCodePoint(code) : m;
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
+  });
+}
+
+/** @param {string} s */
+function clean(s) {
+  return decodeEntities(s.replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
+}
+
+/** Resolve the search-jobs list URL from api:/careers_url; default /en. */
+export function resolveListUrl(entry) {
+  const raw = entry.api || entry.careers_url || '';
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  if (/\/search-jobs\/?$/.test(u.pathname)) return `${u.origin}${u.pathname.replace(/\/$/, '')}`;
+  const lang = (u.pathname.match(/^\/([a-z]{2})(\/|$)/) || [])[1] || 'en';
+  return `${u.origin}/${lang}/search-jobs`;
+}
+
+/**
+ * Parse one search-results page into raw {id, title, url, location} records.
+ * @param {string} html @param {string} origin
+ */
+export function parseResults(html, origin) {
+  if (typeof html !== 'string') return [];
+  const out = [];
+  const seen = new Set();
+  // Split on the stable generic list-item class; slice(0) is the page head.
+  const blocks = html.split(/<li class="search-results-list__item/).slice(1);
+  for (const block of blocks) {
+    const link = block.match(/search-results-list__job-link[^"]*"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/);
+    if (!link) continue;
+    const href = decodeEntities(link[1]);
+    const idM = block.match(/data-job-id="([^"]+)"/) || href.match(/\/(\d+)(?:[/?#]|$)/);
+    const id = idM ? idM[1] : href;
+    if (seen.has(id)) continue;
+    const title = clean(link[2]);
+    if (!title) continue;
+    let url;
+    try {
+      url = new URL(href, origin).href;
+    } catch {
+      continue;
+    }
+    const locM = block.match(/__job-info--location[\s\S]*?<span>([\s\S]*?)<\/span>/);
+    seen.add(id);
+    out.push({ id, title, url, location: locM ? clean(locM[1]) : '' });
+  }
+  return out;
+}
+
+/** Resolve the page cap: positive integer `max_pages`, else default. */
+function resolveMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES);
+  return MAX_PAGES;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'radancy',
+
+  detect() {
+    // Branded hosts carry no stable Radancy token in the URL — wire explicitly
+    // with `provider: radancy`. No auto-detection.
+    return null;
+  },
+
+  async fetch(entry, ctx) {
+    const listUrl = resolveListUrl(entry);
+    if (!listUrl) throw new Error(`radancy: cannot resolve search-jobs URL for ${entry.name}`);
+    const origin = new URL(listUrl).origin;
+
+    const wait = (ms) => (ctx.sleep ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
+    const maxPages = resolveMaxPages(entry);
+    const jobs = [];
+    const seen = new Set();
+
+    for (let page = 1; page <= maxPages; page++) {
+      if (page > 1) await wait(PAGE_DELAY_MS);
+      let rows;
+      try {
+        const html = await ctx.fetchText(`${listUrl}?p=${page}`, { headers: { accept: 'text/html' } });
+        rows = parseResults(html, origin);
+      } catch {
+        break; // keep jobs collected so far — a transient mid-scan failure shouldn't discard earlier pages
+      }
+      if (rows.length === 0) break; // past the last page
+
+      let fresh = 0;
+      for (const row of rows) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        fresh++;
+        jobs.push({ title: row.title, url: row.url, company: entry.name, location: row.location });
+      }
+      // No new ids → the server clamped ?p= to the last page (or looped). Stop.
+      if (fresh === 0) break;
+      if (jobs.length >= MAX_JOBS) break;
+    }
+    return jobs.slice(0, MAX_JOBS);
+  },
+};

--- a/tests/providers/phenom.test.mjs
+++ b/tests/providers/phenom.test.mjs
@@ -1,0 +1,103 @@
+// tests/providers/phenom.test.mjs — Phenom People CareerConnect widgets API.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — phenom (Phenom People CareerConnect widgets API)');
+try {
+  const phenomModule = await import(pathToFileURL(join(ROOT, 'providers/phenom.mjs')).href);
+  const phenom = phenomModule.default;
+  const { resolveConfig: phConfig, slugify, parsePhenomDate, jobLocation, parseRefineSearch } = phenomModule;
+
+  if (phenom.id === 'phenom') pass('phenom.id is "phenom"');
+  else fail(`phenom.id is ${JSON.stringify(phenom.id)}`);
+
+  // resolveConfig — defaults + phenom block overrides.
+  const phCfg = phConfig({ api: 'https://careers.allianz.com', phenom: { lang: 'en_global', country: 'global', urlPrefix: 'global/en', selectedFields: { country: ['Germany'] } } });
+  if (
+    phCfg && phCfg.widgetsApi === 'https://careers.allianz.com/widgets' && phCfg.urlPrefix === 'global/en' && phCfg.selectedFields.country[0] === 'Germany'
+  ) {
+    pass('phenom.resolveConfig() parses origin and the phenom config block');
+  } else {
+    fail(`phenom.resolveConfig() wrong: ${JSON.stringify(phCfg)}`);
+  }
+  const phDefault = phConfig({ careers_url: 'https://x.example.com' });
+  if (phDefault && phDefault.lang === 'en_global' && phDefault.country === 'global' && phDefault.urlPrefix === 'global/en') pass('phenom.resolveConfig() applies en_global/global/urlPrefix defaults');
+  else fail(`phenom.resolveConfig() defaults wrong: ${JSON.stringify(phDefault)}`);
+
+  // detect — hostname-anchored (not a raw-string regex): only literal
+  // *.phenompeople.com; branded tenants wire explicitly. A URL that merely
+  // contains "phenompeople.com" in its path/query on a different host must
+  // NOT match.
+  if (phenom.detect({ api: 'https://x.phenompeople.com/y' })) pass('phenom.detect() matches *.phenompeople.com');
+  else fail('phenom.detect() should match phenompeople.com');
+  if (phenom.detect({ careers_url: 'https://careers.allianz.com' }) === null) pass('phenom.detect() returns null for branded hosts (wire explicitly)');
+  else fail('phenom.detect() should not auto-claim a branded host');
+  if (phenom.detect({ careers_url: 'https://evil.com/x?y=phenompeople.com' }) === null) pass('phenom.detect() rejects a host that merely contains "phenompeople.com" in path/query');
+  else fail('phenom.detect() should check the hostname, not the raw URL string');
+  if (phenom.detect({ careers_url: 'https://phenompeople.com.evil.com/x' }) === null) pass('phenom.detect() rejects suffix-spoofed host');
+  else fail('phenom.detect() should reject suffix-spoofed host');
+
+  // slugify — strips umlauts and specials, collapses to hyphens.
+  if (slugify('Sr Economic & Financial Analyst') === 'Sr-Economic-Financial-Analyst') pass('phenom.slugify() collapses specials to hyphens');
+  else fail(`phenom.slugify() wrong: ${slugify('Sr Economic & Financial Analyst')}`);
+  if (slugify('München HR (m/w/d)') === 'Munchen-HR-m-w-d') pass('phenom.slugify() strips umlaut diacritics');
+  else fail(`phenom.slugify() umlaut wrong: ${slugify('München HR (m/w/d)')}`);
+  if (slugify('###') === 'job') pass('phenom.slugify() falls back to "job" for an all-symbol title');
+  else fail(`phenom.slugify() fallback wrong: ${slugify('###')}`);
+
+  if (parsePhenomDate('2026-05-07T18:25:30.000+0000') === Date.parse('2026-05-07T18:25:30.000+0000') && parsePhenomDate('') === undefined) pass('phenom.parsePhenomDate() reads ISO instants, rejects empty');
+  else fail('phenom.parsePhenomDate() wrong');
+
+  // jobLocation — prefers explicit location, else assembles city/state/country.
+  if (jobLocation({ location: 'Munich, Germany' }) === 'Munich, Germany') pass('phenom.jobLocation() prefers the explicit location field');
+  else fail('phenom.jobLocation() should prefer location');
+  if (jobLocation({ city: 'Munich', state: 'Bavaria', country: 'Germany' }) === 'Munich, Bavaria, Germany') pass('phenom.jobLocation() assembles from city/state/country');
+  else fail(`phenom.jobLocation() assembly wrong: ${jobLocation({ city: 'Munich', state: 'Bavaria', country: 'Germany' })}`);
+
+  // parseRefineSearch — id/title required; URL from origin+prefix+jobId+slug,
+  // with the jobId path segment percent-encoded.
+  const phJson = { refineSearch: { status: 200, totalHits: 42, data: { jobs: [
+    { jobId: '98098', title: 'Sr Analyst', location: 'France', postedDate: '2026-05-07T18:25:30.000+0000' },
+    { jobId: '', title: 'No id — dropped' },
+    { jobId: '5', title: '' },
+    { jobId: '12/34', title: 'Slash Id' },
+  ] } } };
+  const { total: phTotal, rows: phRows } = parseRefineSearch(phJson, { origin: 'https://careers.allianz.com', urlPrefix: 'global/en' });
+  if (phTotal === 42 && phRows.length === 2) pass('phenom.parseRefineSearch() reads totalHits and drops id/title-less records');
+  else fail(`phenom.parseRefineSearch() wrong: total=${phTotal} rows=${phRows.length}`);
+  if (phRows[0]?.url === 'https://careers.allianz.com/global/en/job/98098/Sr-Analyst') pass('phenom.parseRefineSearch() builds the {origin}/{prefix}/job/{id}/{slug} URL');
+  else fail(`phenom.parseRefineSearch() url wrong: ${JSON.stringify(phRows[0]?.url)}`);
+  if (phRows[1]?.url === 'https://careers.allianz.com/global/en/job/12%2F34/Slash-Id') pass('phenom.parseRefineSearch() percent-encodes a jobId path segment');
+  else fail(`phenom.parseRefineSearch() encoding wrong: ${JSON.stringify(phRows[1]?.url)}`);
+
+  // fetch — paginates by from/size until totalHits, dedups, sends the facet.
+  const mkJob = (id) => ({ jobId: String(id), title: `Job ${id}`, location: 'Germany', postedDate: '2026-05-07T18:25:30.000+0000' });
+  const phPage = (ids) => ({ refineSearch: { status: 200, totalHits: 150, data: { jobs: ids.map(mkJob) } } });
+  const phPages = [phPage(Array.from({ length: 100 }, (_, i) => i + 1)), phPage([100, 101, 102])];
+  let phCalls = 0;
+  let phSawFacet = null;
+  const phCtx = { sleep: async () => {}, fetchJson: async (url, opts) => { const b = JSON.parse(opts.body); phSawFacet = b.selected_fields; if (b.from !== phCalls * 100) throw new Error('bad from offset'); return phPages[phCalls++] ?? phPage([]); } };
+  const phJobs = await phenom.fetch({ name: 'Allianz', api: 'https://careers.allianz.com', phenom: { selectedFields: { country: ['Germany'] } } }, phCtx);
+  if (phJobs.length === 102 && phCalls === 2 && new Set(phJobs.map((j) => j.url)).size === 102) pass('phenom.fetch() paginates via from/size and dedups across pages');
+  else fail(`phenom.fetch() returned ${phJobs.length} jobs after ${phCalls} calls`);
+  if (phSawFacet && phSawFacet.country?.[0] === 'Germany') pass('phenom.fetch() forwards selected_fields facet filters');
+  else fail(`phenom.fetch() dropped the facet: ${JSON.stringify(phSawFacet)}`);
+
+  // fetch — a mid-scan failure preserves jobs already collected, never
+  // discards earlier pages.
+  let partialCalls = 0;
+  const partialCtx = {
+    sleep: async () => {},
+    fetchJson: async () => {
+      partialCalls++;
+      if (partialCalls === 1) return phPage(Array.from({ length: 100 }, (_, i) => i + 1));
+      throw new Error('network blip on page 2');
+    },
+  };
+  const partialJobs = await phenom.fetch({ name: 'Allianz', api: 'https://careers.allianz.com' }, partialCtx);
+  if (partialJobs.length === 100 && partialCalls === 2) pass('phenom.fetch() preserves jobs from earlier pages when a later page fetch throws');
+  else fail(`phenom.fetch() partial-failure handling wrong: ${partialJobs.length} jobs after ${partialCalls} calls`);
+} catch (e) {
+  fail(`phenom provider tests crashed: ${e.message}`);
+}

--- a/tests/providers/radancy.test.mjs
+++ b/tests/providers/radancy.test.mjs
@@ -1,0 +1,79 @@
+// tests/providers/radancy.test.mjs — Radancy (TalentBrew) SSR search-results parser.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — radancy (TalentBrew SSR search-results parser)');
+try {
+  const radancyModule = await import(pathToFileURL(join(ROOT, 'providers/radancy.mjs')).href);
+  const radancy = radancyModule.default;
+  const { resolveListUrl: radListUrl, parseResults } = radancyModule;
+
+  if (radancy.id === 'radancy') pass('radancy.id is "radancy"');
+  else fail(`radancy.id is ${JSON.stringify(radancy.id)}`);
+
+  // resolveListUrl — keeps explicit search-jobs URLs, defaults to /{lang}.
+  if (radListUrl({ api: 'https://careers.munichre.com/en/search-jobs' }) === 'https://careers.munichre.com/en/search-jobs') pass('radancy.resolveListUrl() keeps an explicit search-jobs URL');
+  else fail('radancy.resolveListUrl() should keep the search-jobs URL');
+  if (radListUrl({ careers_url: 'https://careers.munichre.com/de/some-page' }) === 'https://careers.munichre.com/de/search-jobs') pass('radancy.resolveListUrl() defaults to /{lang}/search-jobs');
+  else fail(`radancy.resolveListUrl() default wrong: ${radListUrl({ careers_url: 'https://careers.munichre.com/de/some-page' })}`);
+
+  // detect — never auto-claims (branded hosts, wire explicitly).
+  if (radancy.detect({ careers_url: 'https://careers.munichre.com/en/search-jobs' }) === null) pass('radancy.detect() returns null (explicit wiring only)');
+  else fail('radancy.detect() should not auto-claim');
+
+  // parseResults — the tricky part: anchor on the STABLE generic class prefix,
+  // read title + location within one <li>, resolve the relative href.
+  const card = (id, title, loc) =>
+    '<li class="search-results-list__item job-list-01-list__item">' +
+    '<div class="search-results-list__content">' +
+    `<h5 class="search-results-list__job-title"><a class="search-results-list__job-link job-card-brand-hover--x" href="/en/job/city/${id}-slug/3193/${id}" data-job-id="${id}" id="job-${id}">${title}</a></h5>` +
+    `<ul class="search-results-list__job-info-list"><li class="search-results-list__job-info job-list-01-list__job-info--location"><i class="icon"></i> <span>${loc}</span> </li></ul>` +
+    '</li>';
+  const html = '<html>' + card('40548453568', 'Innendienst f&#252;r Versicherungsagentur', 'Bingen am Rhein, Germany') + card('40546200896', 'Category Manager', 'London, United Kingdom') + '</html>';
+  const rows = parseResults(html, 'https://careers.munichre.com');
+  if (rows.length === 2) pass('radancy.parseResults() yields one row per search-results item');
+  else fail(`radancy.parseResults() returned ${rows.length}, expected 2`);
+  if (rows[0]?.title === 'Innendienst für Versicherungsagentur') pass('radancy.parseResults() decodes entities in titles');
+  else fail(`radancy.parseResults() title wrong: ${JSON.stringify(rows[0]?.title)}`);
+  if (rows[0]?.url === 'https://careers.munichre.com/en/job/city/40548453568-slug/3193/40548453568' && rows[0]?.location === 'Bingen am Rhein, Germany') pass('radancy.parseResults() builds absolute URLs and extracts the location span');
+  else fail(`radancy.parseResults() url/loc wrong: ${JSON.stringify(rows[0])}`);
+  if (parseResults('<html>no items</html>', 'https://x').length === 0 && parseResults(undefined, 'https://x').length === 0) pass('radancy.parseResults() returns [] for item-less / non-string input');
+  else fail('radancy.parseResults() should return [] without items');
+
+  // decodeEntities (exercised via parseResults) — a malformed/out-of-range
+  // numeric entity (a lone surrogate half) must degrade to the literal text,
+  // never throw RangeError and abort the whole parse.
+  const badEntityCard = card('999', 'Bad&#xD800;Entity', 'Berlin, Germany');
+  const badRows = parseResults('<html>' + badEntityCard + '</html>', 'https://careers.munichre.com');
+  if (badRows.length === 1 && badRows[0].title === 'Bad&#xD800;Entity') pass('radancy.parseResults() tolerates an invalid numeric entity (no RangeError crash)');
+  else fail(`radancy.parseResults() should degrade a malformed entity to literal text, got: ${JSON.stringify(badRows)}`);
+
+  // fetch — paginates ?p=N, stops when a page brings no fresh ids.
+  const radPages = [html, '<html>' + card('111', 'C', 'Kiel, Germany') + '</html>', '<html></html>'];
+  let radCalls = 0;
+  const radSeen = [];
+  const radCtx = { sleep: async () => {}, fetchText: async (url) => { radSeen.push(url); return radPages[radCalls++] ?? '<html></html>'; } };
+  const radJobs = await radancy.fetch({ name: 'Munich Re', api: 'https://careers.munichre.com/en/search-jobs' }, radCtx);
+  if (radJobs.length === 3 && radCalls === 3) pass('radancy.fetch() paginates and stops on the first empty page');
+  else fail(`radancy.fetch() returned ${radJobs.length} jobs after ${radCalls} calls`);
+  if (radSeen[0]?.endsWith('?p=1') && radSeen[1]?.endsWith('?p=2')) pass('radancy.fetch() pages via ?p=N (1-based)');
+  else fail(`radancy.fetch() paged wrong: ${JSON.stringify(radSeen)}`);
+
+  // fetch — a mid-scan failure preserves jobs already collected, never
+  // discards earlier pages.
+  let partialCalls = 0;
+  const partialCtx = {
+    sleep: async () => {},
+    fetchText: async () => {
+      partialCalls++;
+      if (partialCalls === 1) return html; // 2 jobs
+      throw new Error('network blip on page 2');
+    },
+  };
+  const partialJobs = await radancy.fetch({ name: 'Munich Re', api: 'https://careers.munichre.com/en/search-jobs' }, partialCtx);
+  if (partialJobs.length === 2 && partialCalls === 2) pass('radancy.fetch() preserves jobs from earlier pages when a later page fetch throws');
+  else fail(`radancy.fetch() partial-failure handling wrong: ${partialJobs.length} jobs after ${partialCalls} calls`);
+} catch (e) {
+  fail(`radancy provider tests crashed: ${e.message}`);
+}

--- a/tests/providers/radancy.test.mjs
+++ b/tests/providers/radancy.test.mjs
@@ -74,6 +74,17 @@ try {
   const partialJobs = await radancy.fetch({ name: 'Munich Re', api: 'https://careers.munichre.com/en/search-jobs' }, partialCtx);
   if (partialJobs.length === 2 && partialCalls === 2) pass('radancy.fetch() preserves jobs from earlier pages when a later page fetch throws');
   else fail(`radancy.fetch() partial-failure handling wrong: ${partialJobs.length} jobs after ${partialCalls} calls`);
+
+  // fetch — stops on a page whose ids are all already-seen (server clamped
+  // ?p= to the last page, or looped), NOT just on a literally empty page.
+  // fresh === 0 must halt pagination without appending duplicate jobs.
+  const dupPage = '<html>' + card('40548453568', 'Innendienst f&#252;r Versicherungsagentur', 'Bingen am Rhein, Germany') + '</html>';
+  const dupPages = [html, dupPage, '<html>' + card('999', 'Never reached', 'X') + '</html>'];
+  let dupCalls = 0;
+  const dupCtx = { sleep: async () => {}, fetchText: async () => dupPages[dupCalls++] ?? '<html></html>' };
+  const dupJobs = await radancy.fetch({ name: 'Munich Re', api: 'https://careers.munichre.com/en/search-jobs' }, dupCtx);
+  if (dupJobs.length === 2 && dupCalls === 2) pass('radancy.fetch() stops when a page brings only already-seen ids (fresh === 0), without appending duplicates');
+  else fail(`radancy.fetch() duplicate-page stop wrong: ${dupJobs.length} jobs after ${dupCalls} calls`);
 } catch (e) {
   fail(`radancy provider tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
## What

Two new zero-token scan sources for widely-deployed enterprise ATS platforms.

### `providers/phenom.mjs` — Phenom People "CareerConnect"

The career-site SPA (careers.allianz.com and many others) talks to a public JSON widget endpoint on the **branded** host:

- `POST {origin}/widgets` with `ddoKey: refineSearch` — no auth. `from`/`size` offset pagination (100/page), bounded by `totalHits`, dedup by `jobId`.
- Public job URL `{origin}/{urlPrefix}/job/{jobId}/{slug}`; the slug is cosmetic (Phenom keys on `jobId` — a stub slug resolves the same posting, verified), so the provider slugifies the title. `applyUrl` points at the downstream ATS (Allianz → SF `career5`), **not** the public listing, so it isn't used as the job URL.
- Facets take human-readable values (unlike CSOD/beesite numeric codes): a `phenom.selectedFields` block narrows the set. `lang`/`country`/`urlPrefix` are configurable:
  ```yaml
  phenom:
    lang: en_global
    country: global
    urlPrefix: global/en
    selectedFields: { country: ["Germany"] }
  ```
- `detect()` only auto-claims literal `*.phenompeople.com`; branded tenants wire explicitly with `provider: phenom`.
- **Verified live** against Allianz: 1881 global / 261 Germany postings; slugified detail URL returns 200.

### `providers/radancy.mjs` — Radancy (TalentBrew)

The `search-jobs` page (careers.munichre.com + its ERGO brands, and many other employers) is server-rendered and paginates over bare HTTP:

- `GET {origin}/{lang}/search-jobs?p={N}` — 1-based; past-the-end returns an empty list (clean stop condition).
- Parses the **stable generic** `search-results-list__` class prefix. A second, module-numbered `job-list-NN-list__` prefix rides alongside it and varies per site — anchoring on the generic one keeps the parser portable across TalentBrew tenants. Extracts title, location span, and the absolute job URL. Stops on the first no-fresh-ids page.
- `detect()` never auto-claims (branded hosts); wire with `provider: radancy` + a `search-jobs` URL.
- **Verified live** against Munich Re: 1638 postings; detail URL returns 200.

## Tests

Sections 62/63: config / slugify / date / location / result parsers, host-spoof and branded-host `detect()` rejection, `from`/`size` and `?p=N` pagination + dedup. `node test-all.mjs`: **1205 passed, 0 failed**.

## Verification (live, 2026-07-04)

`verify-portals` through the provider layer: `Allianz — phenom (246 live)`, `Munich Re — radancy (first page live)`. Bounded fetches returned clean titles/locations/dates with resolving detail URLs for both.

## Note

Trivially conflicts with #1549 / #1551 in `test-all.mjs` (all append provider test sections at the file end). Happy to rebase whichever lands last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for two new job providers, expanding job search coverage from additional career sites.
  - Jobs now include cleaner titles, locations, links, and posted dates where available.
  - Pagination and duplicate handling were improved to return more complete results from multi-page listings.

- **Bug Fixes**
  - Improved resilience when a page request fails, preserving jobs already collected instead of losing them.
  - Added better handling for malformed or missing job data so listings are skipped safely when incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->