### PR TITLE
feat(providers): TKMS, Heckler & Koch, and Deutsche Bahn providers

### DIFF
--- a/providers/_html-entities.mjs
+++ b/providers/_html-entities.mjs
@@ -20,7 +20,7 @@ const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp:
 
 /** @param {string} s */
 export function decodeEntities(s) {
-  return s.replace(/&(#x[0-9a-fA-F]+|#[0-9]+|[a-zA-Z]+);/g, (m, body) => {
+  return s.replace(/&(#[xX][0-9a-fA-F]+|#[0-9]+|[a-zA-Z]+);/g, (m, body) => {
     if (body[0] === '#') {
       const isHex = body[1] === 'x' || body[1] === 'X';
       const code = parseInt(body.slice(isHex ? 2 : 1), isHex ? 16 : 10);

--- a/providers/_html-entities.mjs
+++ b/providers/_html-entities.mjs
@@ -1,0 +1,36 @@
+// @ts-check
+// Minimal HTML entity decoder shared by the scraping providers whose sources
+// return raw HTML (as opposed to a JSON API). Handles named entities (&amp;,
+// &lt;, …) and numeric entities (&#252; / &#xfc;).
+//
+// Previously duplicated verbatim across deutschebahn.mjs and hecklerkoch.mjs
+// (CodeRabbit finding on #1555) — same drift risk flagged separately on
+// successfactors.mjs/dassault.mjs/softgarden.mjs/rheinmetall.mjs (#1639),
+// where a numeric-entity range guard drifted out of sync between copies:
+// checking only Number.isFinite still lets String.fromCodePoint throw a
+// RangeError for a code point above 0x10FFFF (e.g. `&#99999999;`), crashing
+// the entire parse for a single malformed/adversarial entity. Centralized
+// here so the guard can't diverge again.
+//
+// The hex/decimal alternatives are matched separately (not "#x?[0-9a-fA-F]+")
+// so a decimal entity can never absorb trailing hex letters — "&#1a2;" no
+// longer silently parses as codepoint 1 and drops "a2"; it just fails to
+// match and passes through untouched, same as any other malformed entity.
+const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+
+/** @param {string} s */
+export function decodeEntities(s) {
+  return s.replace(/&(#x[0-9a-fA-F]+|#[0-9]+|[a-zA-Z]+);/g, (m, body) => {
+    if (body[0] === '#') {
+      const isHex = body[1] === 'x' || body[1] === 'X';
+      const code = parseInt(body.slice(isHex ? 2 : 1), isHex ? 16 : 10);
+      // A lone surrogate half (0xD800-0xDFFF) is a valid codepoint per spec —
+      // fromCodePoint won't throw for it — but it's not a valid Unicode scalar
+      // value, so we still reject it defensively rather than emit an
+      // ill-formed string.
+      const valid = Number.isFinite(code) && code >= 0 && code <= 0x10ffff && !(code >= 0xd800 && code <= 0xdfff);
+      return valid ? String.fromCodePoint(code) : m;
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
+  });
+}

--- a/providers/deutschebahn.mjs
+++ b/providers/deutschebahn.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
+import { decodeEntities } from './_html-entities.mjs';
 
 // Deutsche Bahn provider — single-company (pattern: ibm/dassault/rheinmetall).
 // DB's careers run on the custom db.jobs portal (the branded Avature front,
@@ -23,22 +24,6 @@ const ITEMS_PER_PAGE = 20; // DB's default page size
 const MAX_PAGES = 60; // safety cap on request count (60*20 = 1200 postings)
 const MAX_JOBS = 1000; // cap total postings pulled
 const PAGE_DELAY_MS = 150; // polite pacing between page requests
-
-const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
-/** @param {string} s */
-function decodeEntities(s) {
-  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
-    if (body[0] === '#') {
-      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
-      // String.fromCodePoint throws RangeError outside 0..0x10FFFF or on a lone
-      // surrogate half — a malformed/adversarial entity must degrade to the
-      // original text, never crash the whole parse.
-      const valid = Number.isFinite(code) && code >= 0 && code <= 0x10ffff && !(code >= 0xd800 && code <= 0xdfff);
-      return valid ? String.fromCodePoint(code) : m;
-    }
-    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
-  });
-}
 
 /** @param {string} s */
 function clean(s) {

--- a/providers/deutschebahn.mjs
+++ b/providers/deutschebahn.mjs
@@ -1,0 +1,153 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Deutsche Bahn provider — single-company (pattern: ibm/dassault/rheinmetall).
+// DB's careers run on the custom db.jobs portal (the branded Avature front,
+// jobs.deutschebahngroup.careers, just 302-redirects into it). The search page
+// exposes a server-rendered results endpoint that paginates over bare HTTP:
+//
+//   GET {origin}/service/search/de-de/{searchId}?query=&sort=score&itemsPerPage=20&pageNum={N}
+//
+// {searchId} is the DB search-config id (5441588 at time of writing) — it's
+// stable per portal, so we pin it via the api:/careers_url. Each result is:
+//   <a href="/de-de/Suche/{slug}-{routeId}?jobId={jobId}" data-job-id="{jobId}" …>
+//     <h3 class="m-search-hit__title"><span class="m-search-hit__title-text">{Title}</span>…</h3>
+//     …<ul class="m-search-hit__items"><li …><i aria-label="Arbeitsort"></i> {City, Country} </li>…</ul>
+//   </a>
+// data-job-id is the dedup key; the href resolves to the public posting.
+//
+// The board is large (thousands of postings, mostly rail operations) — rely on
+// title/location filters; MAX_JOBS + max_pages bound the walk.
+
+const ITEMS_PER_PAGE = 20; // DB's default page size
+const MAX_PAGES = 60; // safety cap on request count (60*20 = 1200 postings)
+const MAX_JOBS = 1000; // cap total postings pulled
+const PAGE_DELAY_MS = 150; // polite pacing between page requests
+
+const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+/** @param {string} s */
+function decodeEntities(s) {
+  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
+    if (body[0] === '#') {
+      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+      // String.fromCodePoint throws RangeError outside 0..0x10FFFF or on a lone
+      // surrogate half — a malformed/adversarial entity must degrade to the
+      // original text, never crash the whole parse.
+      const valid = Number.isFinite(code) && code >= 0 && code <= 0x10ffff && !(code >= 0xd800 && code <= 0xdfff);
+      return valid ? String.fromCodePoint(code) : m;
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
+  });
+}
+
+/** @param {string} s */
+function clean(s) {
+  return decodeEntities(s.replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
+}
+
+// Resolve the search-config base from api:/careers_url. Accepts either a full
+// /service/search/de-de/{id} URL, or any db.jobs URL that carries the numeric
+// search id in its path; falls back to the well-known DB id.
+/** @param {import('./_types.js').PortalEntry} entry */
+export function resolveConfig(entry) {
+  const raw = entry.api || entry.careers_url || '';
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  const host = u.host.toLowerCase();
+  if (host !== 'db.jobs' && !host.endsWith('.db.jobs')) return null;
+  const idM = u.pathname.match(/\/service\/search\/de-de\/(\d+)/) || u.pathname.match(/\/(\d{6,})(?:[/?]|$)/);
+  const searchId = idM ? idM[1] : '5441588';
+  return {
+    origin: u.origin,
+    searchBase: `${u.origin}/service/search/de-de/${searchId}`,
+  };
+}
+
+/**
+ * Parse one search-results fragment into raw {id, title, url, location}.
+ * @param {string} html @param {string} origin
+ */
+export function parseHits(html, origin) {
+  if (typeof html !== 'string') return [];
+  const out = [];
+  const seen = new Set();
+  // Each hit is an <a class="m-search-hit" href data-job-id> … </a>.
+  const re = /<a\b[^>]*class="[^"]*m-search-hit\b[^"]*"[^>]*>([\s\S]*?)<\/a>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const anchor = m[0];
+    const inner = m[1];
+    const hrefM = anchor.match(/href="([^"]+)"/);
+    const idM = anchor.match(/data-job-id="([^"]+)"/);
+    if (!hrefM) continue;
+    const href = decodeEntities(hrefM[1]);
+    const id = idM ? idM[1] : href;
+    if (seen.has(id)) continue;
+    const titleM = inner.match(/m-search-hit__title-text"[^>]*>([\s\S]*?)<\/span>/i);
+    const title = titleM ? clean(titleM[1]) : '';
+    if (!title) continue;
+    // Location: the <li> whose icon is aria-label="Arbeitsort".
+    const locM = inner.match(/aria-label="Arbeitsort"[^>]*><\/i>([\s\S]*?)<\/li>/i);
+    let url;
+    try {
+      url = new URL(href, origin).href;
+    } catch {
+      continue;
+    }
+    seen.add(id);
+    out.push({ id, title, url, location: locM ? clean(locM[1]) : '' });
+  }
+  return out;
+}
+
+/** Resolve the page cap: positive integer `max_pages`, else default. */
+function resolveMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES);
+  return MAX_PAGES;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'deutschebahn',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    return resolveConfig({ api: url }) ? { url } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const cfg = resolveConfig(entry);
+    if (!cfg) throw new Error(`deutschebahn: cannot resolve db.jobs search id for ${entry.name}`);
+
+    const wait = (ms) => (ctx.sleep ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
+    const maxPages = resolveMaxPages(entry);
+    const jobs = [];
+    const seen = new Set();
+
+    for (let page = 0; page < maxPages; page++) {
+      if (page > 0) await wait(PAGE_DELAY_MS);
+      const url = `${cfg.searchBase}?qli=true&query=&sort=score&itemsPerPage=${ITEMS_PER_PAGE}&pageNum=${page}`;
+      const html = await ctx.fetchText(url, { headers: { accept: 'text/html' } });
+      const rows = parseHits(html, cfg.origin);
+      if (rows.length === 0) break; // past the last page
+
+      let fresh = 0;
+      for (const row of rows) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        fresh++;
+        jobs.push({ title: row.title, url: row.url, company: entry.name, location: row.location });
+      }
+      if (fresh === 0) break; // server clamped pageNum / looped
+      if (jobs.length >= MAX_JOBS) break;
+    }
+    return jobs.slice(0, MAX_JOBS);
+  },
+};

--- a/providers/hecklerkoch.mjs
+++ b/providers/hecklerkoch.mjs
@@ -1,0 +1,112 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Heckler & Koch provider — single-company (pattern: ibm/dassault/rheinmetall).
+// The vacancy list at heckler-koch.com/de/Karriere/Stellenangebote is a Nuxt
+// page whose job cards are SERVER-rendered, so a single bare-HTTP GET returns
+// every posting (small board, ~32 roles, all in Oberndorf a. N. / Vöhringen).
+// The apply backend lives on karriere.heckler-koch.com/jobposting/{hash}; the
+// listing links straight to it, so that hash is our stable id + job URL.
+//
+// Card markup:
+//   <a href="https://karriere.heckler-koch.com/jobposting/{hash}" …>
+//     <div class="text-secondary font-medium">
+//       <p> {Field} | {Type} </p>
+//       <h3 class="text-lg md:text-2xl">{Title}</h3>
+//     </div> …
+//   </a>
+//
+// The list carries no explicit location or date; H&K is effectively
+// single-site (Oberndorf), and titles often name the site, so we leave location
+// empty rather than guess. detect() claims the heckler-koch.com host.
+
+const MAX_JOBS = 500; // generous cap; the board is tiny
+
+// Minimal HTML entity decoder — mirrors the other HTML-scraping providers.
+const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+/** @param {string} s */
+function decodeEntities(s) {
+  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
+    if (body[0] === '#') {
+      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+      // String.fromCodePoint throws RangeError outside 0..0x10FFFF or on a lone
+      // surrogate half — a malformed/adversarial entity must degrade to the
+      // original text, never crash the whole parse.
+      const valid = Number.isFinite(code) && code >= 0 && code <= 0x10ffff && !(code >= 0xd800 && code <= 0xdfff);
+      return valid ? String.fromCodePoint(code) : m;
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
+  });
+}
+
+/** @param {string} s */
+function clean(s) {
+  return decodeEntities(s.replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
+}
+
+/** Resolve the vacancy-list URL from api:/careers_url; default the DE list. */
+export function resolveListUrl(entry) {
+  const raw = entry.api || entry.careers_url || '';
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  const host = u.host.toLowerCase();
+  if (host !== 'heckler-koch.com' && !host.endsWith('.heckler-koch.com')) return null;
+  // A Stellenangebote path passes through; anything else on the host defaults.
+  if (/Stellenangebote/i.test(u.pathname)) return `${u.origin}${u.pathname}`;
+  return `${u.origin}/de/Karriere/Stellenangebote`;
+}
+
+/**
+ * Parse the SSR listing into raw {id, title, url} records. Anchors on the
+ * karriere.heckler-koch.com/jobposting/{hash} link (the stable id + URL), then
+ * reads the sibling <h3> title inside the same anchor.
+ * @param {string} html
+ */
+export function parseListing(html) {
+  if (typeof html !== 'string') return [];
+  const out = [];
+  const seen = new Set();
+  const re = /<a\b[^>]*href="(https:\/\/karriere\.heckler-koch\.com\/jobposting\/([a-z0-9]+))"[\s\S]*?<\/a>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const url = decodeEntities(m[1]);
+    const id = m[2];
+    if (seen.has(id)) continue;
+    const block = m[0];
+    const titleM = block.match(/<h3\b[^>]*>([\s\S]*?)<\/h3>/i);
+    const title = titleM ? clean(titleM[1]) : '';
+    if (!title) continue;
+    seen.add(id);
+    out.push({ id, title, url });
+  }
+  return out;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'hecklerkoch',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    return resolveListUrl({ api: url }) ? { url } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const listUrl = resolveListUrl(entry);
+    if (!listUrl) throw new Error(`hecklerkoch: cannot resolve vacancy list for ${entry.name}`);
+    const html = await ctx.fetchText(listUrl, { headers: { accept: 'text/html' } });
+    const rows = parseListing(html);
+    const jobs = [];
+    for (const row of rows) {
+      jobs.push({ title: row.title, url: row.url, company: entry.name, location: '' });
+      if (jobs.length >= MAX_JOBS) break;
+    }
+    return jobs;
+  },
+};

--- a/providers/hecklerkoch.mjs
+++ b/providers/hecklerkoch.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
+import { decodeEntities } from './_html-entities.mjs';
 
 // Heckler & Koch provider — single-company (pattern: ibm/dassault/rheinmetall).
 // The vacancy list at heckler-koch.com/de/Karriere/Stellenangebote is a Nuxt
@@ -21,23 +22,6 @@
 // empty rather than guess. detect() claims the heckler-koch.com host.
 
 const MAX_JOBS = 500; // generous cap; the board is tiny
-
-// Minimal HTML entity decoder — mirrors the other HTML-scraping providers.
-const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
-/** @param {string} s */
-function decodeEntities(s) {
-  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
-    if (body[0] === '#') {
-      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
-      // String.fromCodePoint throws RangeError outside 0..0x10FFFF or on a lone
-      // surrogate half — a malformed/adversarial entity must degrade to the
-      // original text, never crash the whole parse.
-      const valid = Number.isFinite(code) && code >= 0 && code <= 0x10ffff && !(code >= 0xd800 && code <= 0xdfff);
-      return valid ? String.fromCodePoint(code) : m;
-    }
-    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
-  });
-}
 
 /** @param {string} s */
 function clean(s) {

--- a/providers/tkms.mjs
+++ b/providers/tkms.mjs
@@ -34,7 +34,7 @@ export function resolveConfig(entry) {
   } catch {
     return null;
   }
-  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  if (u.protocol !== 'https:') return null;
   const host = u.host.toLowerCase();
   if (host !== 'jobs.tkmsgroup.com') return null;
   const block = entry.tkms && typeof entry.tkms === 'object' ? entry.tkms : {};

--- a/providers/tkms.mjs
+++ b/providers/tkms.mjs
@@ -1,0 +1,171 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// TKMS (thyssenkrupp Marine Systems) provider — the careers app at
+// jobs.tkmsgroup.com. Single-employer, but the backend is a shared job-board
+// platform keyed by a `subclient` param, so the provider takes the subclient
+// (and locale) from a config block for reuse if another tenant on the same
+// platform ever needs it.
+//
+//   POST {origin}/api/filter/query
+//   Content-Type: application/json
+//   {"searchQuery":"","filter":{},"subclient":"tkms","locale":"en","page":0}
+//   → {"jobs":[{"_geoloc":[…],"data":{id,title,city,country,state,company,
+//        postingDate:"2026-07-02T22:00:00",locations:[{city,cityState,…}],…}}],
+//      "page":0,"jobsPerPage":20,"nextPage":1,"totalHits":330}
+//
+// `page` is 0-based; `nextPage` is null on the last page. The public job page is
+// {origin}/{locale}/job/{slug}/{id} — the slug is cosmetic (a stub resolves the
+// same posting, verified), so we slugify the title.
+//
+// Detection: jobs.tkmsgroup.com is the only known host, and it carries no
+// generic platform token, so detect() claims that host explicitly.
+
+const MAX_PAGES = 60; // safety cap on request count (60*20 = 1200 postings)
+const MAX_JOBS = 1000; // cap total postings pulled
+const PAGE_DELAY_MS = 150; // polite pacing between page requests
+
+/** @param {import('./_types.js').PortalEntry} entry */
+export function resolveConfig(entry) {
+  const raw = entry.api || entry.careers_url || '';
+  let u;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  const host = u.host.toLowerCase();
+  if (host !== 'jobs.tkmsgroup.com') return null;
+  const block = entry.tkms && typeof entry.tkms === 'object' ? entry.tkms : {};
+  const locale = typeof block.locale === 'string' ? block.locale : 'en';
+  return {
+    origin: u.origin,
+    queryApi: `${u.origin}/api/filter/query`,
+    subclient: typeof block.subclient === 'string' ? block.subclient : 'tkms',
+    locale,
+  };
+}
+
+// Slugify a title for the cosmetic job-page slug (TKMS uses `_` for the
+// gender marker and `-` between words; a stub slug also resolves, so exactness
+// doesn't matter — we just produce a clean, hyphenated string).
+/** @param {string} title */
+export function slugify(title) {
+  return String(title)
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'job';
+}
+
+// postingDate is a naive ISO local timestamp ("2026-07-02T22:00:00"); prefer
+// the epoch-seconds `postingDate_timestamp` when present.
+/** @param {any} data @returns {number | undefined} */
+export function parseTkmsDate(data) {
+  const ts = data?.postingDate_timestamp;
+  if (typeof ts === 'number' && Number.isFinite(ts)) return ts * 1000;
+  const raw = data?.postingDate;
+  if (typeof raw === 'string' && raw.trim()) {
+    const ms = Date.parse(raw.trim() + 'Z'); // treat naive stamp as UTC for determinism
+    if (Number.isFinite(ms)) return ms;
+  }
+  return undefined;
+}
+
+// Location: prefer the `locations` array (cityState per site), else the flat
+// city/country fields. Joined with " / ", deduped.
+/** @param {any} data @returns {string} */
+export function tkmsLocation(data) {
+  const locs = Array.isArray(data?.locations) ? data.locations : [];
+  const out = [];
+  for (const l of locs) {
+    const s = String(l?.cityState || l?.city || '').trim();
+    if (s && !out.includes(s)) out.push(s);
+  }
+  if (out.length) return out.join(' / ');
+  const flat = [data?.city, data?.country].map((p) => String(p || '').trim()).filter(Boolean);
+  return [...new Set(flat)].join(', ');
+}
+
+/**
+ * Map one query response to {total, nextPage, rows}. A record without an id or
+ * title is skipped.
+ * @param {any} json @param {{origin:string, locale:string}} cfg
+ */
+export function parseQuery(json, cfg) {
+  const total = typeof json?.totalHits === 'number' ? json.totalHits : null;
+  const nextPage = typeof json?.nextPage === 'number' ? json.nextPage : null;
+  const list = Array.isArray(json?.jobs) ? json.jobs : [];
+  const rows = [];
+  for (const item of list) {
+    const d = item?.data;
+    if (!d) continue;
+    const id = d.id != null ? String(d.id) : '';
+    const title = String(d.title || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!id || !title) continue;
+    rows.push({
+      id,
+      title,
+      url: `${cfg.origin}/${encodeURIComponent(cfg.locale)}/job/${slugify(title)}/${encodeURIComponent(id)}`,
+      location: tkmsLocation(d),
+      postedAt: parseTkmsDate(d),
+    });
+  }
+  return { total, nextPage, rows };
+}
+
+/** Resolve the page cap: positive integer `max_pages`, else default. */
+function resolveMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES);
+  return MAX_PAGES;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'tkms',
+
+  detect(entry) {
+    const url = entry.api || entry.careers_url || '';
+    if (typeof url !== 'string') return null;
+    return resolveConfig({ api: url }) ? { url } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const cfg = resolveConfig(entry);
+    if (!cfg) throw new Error(`tkms: cannot resolve jobs host for ${entry.name}`);
+
+    const wait = (ms) => (ctx.sleep ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
+    const maxPages = resolveMaxPages(entry);
+    const jobs = [];
+    const seen = new Set();
+
+    for (let page = 0; page < maxPages; page++) {
+      if (page > 0) await wait(PAGE_DELAY_MS);
+      const json = await ctx.fetchJson(cfg.queryApi, {
+        method: 'POST',
+        redirect: 'error',
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
+        body: JSON.stringify({ searchQuery: '', filter: {}, subclient: cfg.subclient, locale: cfg.locale, page }),
+      });
+      const { nextPage, rows } = parseQuery(json, cfg);
+      if (rows.length === 0) break;
+
+      let fresh = 0;
+      for (const row of rows) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        fresh++;
+        const job = { title: row.title, url: row.url, company: entry.name, location: row.location };
+        if (typeof row.postedAt === 'number') job.postedAt = row.postedAt;
+        jobs.push(job);
+        if (jobs.length >= MAX_JOBS) break;
+      }
+      if (fresh === 0) break; // server looped / ignored page
+      if (jobs.length >= MAX_JOBS) break;
+      if (nextPage === null) break; // last page
+    }
+    return jobs;
+  },
+};

--- a/tests/providers/_html-entities.test.mjs
+++ b/tests/providers/_html-entities.test.mjs
@@ -1,0 +1,45 @@
+// tests/providers/_html-entities.test.mjs — direct coverage for the shared
+// entity decoder (providers/_html-entities.mjs), extracted out of
+// deutschebahn.mjs / hecklerkoch.mjs so the numeric-entity guard can't drift
+// out of sync between copies again (#1555). CodeRabbit asked for this as a
+// dedicated, provider-independent test for a "safety-critical" shared module.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — _html-entities (shared HTML entity decoder)');
+try {
+  const { decodeEntities } = await import(pathToFileURL(join(ROOT, 'providers/_html-entities.mjs')).href);
+
+  if (decodeEntities('Program &amp; Release') === 'Program & Release') pass('decodeEntities decodes named entities (&amp;)');
+  else fail(`named entity wrong: ${JSON.stringify(decodeEntities('Program &amp; Release'))}`);
+
+  if (decodeEntities('f&#252;r Z&#xfc;rich') === 'für Zürich') pass('decodeEntities decodes decimal and hex numeric entities');
+  else fail(`numeric entity wrong: ${JSON.stringify(decodeEntities('f&#252;r Z&#xfc;rich'))}`);
+
+  if (decodeEntities('Z&#Xfc;rich') === 'Zürich') pass('decodeEntities decodes an uppercase hex marker (&#X..;)');
+  else fail(`uppercase hex entity wrong: ${JSON.stringify(decodeEntities('Z&#Xfc;rich'))}`);
+
+  // A numeric entity above 0x10FFFF is the one that actually throws
+  // RangeError out of String.fromCodePoint; a lone surrogate half
+  // (0xD800-0xDFFF) does not throw by itself but is rejected defensively
+  // since it isn't a valid Unicode scalar value. Both must degrade to the
+  // literal source text rather than crash.
+  if (decodeEntities('Huge&#x110000;Entity') === 'Huge&#x110000;Entity') pass('decodeEntities degrades an out-of-range numeric entity (no RangeError crash)');
+  else fail(`out-of-range entity wrong: ${JSON.stringify(decodeEntities('Huge&#x110000;Entity'))}`);
+
+  if (decodeEntities('Bad&#xD800;Entity') === 'Bad&#xD800;Entity') pass('decodeEntities degrades a lone surrogate half');
+  else fail(`surrogate entity wrong: ${JSON.stringify(decodeEntities('Bad&#xD800;Entity'))}`);
+
+  if (decodeEntities('Negative&#-1;Entity') === 'Negative&#-1;Entity') pass('decodeEntities leaves a non-matching negative entity untouched');
+  else fail(`negative entity wrong: ${JSON.stringify(decodeEntities('Negative&#-1;Entity'))}`);
+
+  // Regression: the hex-charset alternative used to match decimal-looking
+  // bodies too ("#x?[0-9a-fA-F]+"), so parseInt(…, 10) silently stopped at
+  // the first hex letter and dropped the rest — "&#1a2;" decoded to "\x01"
+  // and swallowed "a2" instead of passing the malformed entity through.
+  if (decodeEntities('X&#1a2;Y') === 'X&#1a2;Y') pass('decodeEntities does not let hex letters leak into the decimal branch');
+  else fail(`decimal/hex leak regression: ${JSON.stringify(decodeEntities('X&#1a2;Y'))}`);
+} catch (e) {
+  fail(`_html-entities tests crashed: ${e.message}`);
+}

--- a/tests/providers/deutschebahn.test.mjs
+++ b/tests/providers/deutschebahn.test.mjs
@@ -1,0 +1,77 @@
+// tests/providers/deutschebahn.test.mjs — db.jobs search-fragment parser.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — deutschebahn (db.jobs search-fragment parser)');
+try {
+  const dbModule = await import(pathToFileURL(join(ROOT, 'providers/deutschebahn.mjs')).href);
+  const db = dbModule.default;
+  const { resolveConfig: dbConfig, parseHits: dbParseHits } = dbModule;
+
+  if (db.id === 'deutschebahn') pass('deutschebahn.id is "deutschebahn"');
+  else fail(`deutschebahn.id is ${JSON.stringify(db.id)}`);
+
+  // resolveConfig — pins the search id from the URL, defaults when absent.
+  const dbCfg = dbConfig({ api: 'https://db.jobs/service/search/de-de/5441588' });
+  if (dbCfg && dbCfg.searchBase === 'https://db.jobs/service/search/de-de/5441588') pass('deutschebahn.resolveConfig() pins the search id from the URL');
+  else fail(`deutschebahn.resolveConfig() wrong: ${JSON.stringify(dbCfg)}`);
+  if (db.detect({ careers_url: 'https://evil.com/x.db.jobs' }) === null && db.detect({ careers_url: 'https://db.jobs.evil.com/x' }) === null) {
+    pass('deutschebahn.detect() rejects spoofed hosts');
+  } else {
+    fail('deutschebahn.detect() should reject spoofed hosts');
+  }
+
+  // parseHits — the real markup shape: an <a class="m-search-hit" data-job-id>
+  // wrapping the title span and an Arbeitsort <li>.
+  const dbHit = (id, title, loc) =>
+    `<div class="o-searchpage__item o-searchpage__item--careers"><a href="/de-de/Suche/${title.replace(/[^A-Za-z]+/g, '-')}-1396${id}?jobId=${id}" aria-label="Zum Stellenangebot" class="m-search-hit" data-job-id="${id}" data-unpub-external-date="31.12.2026"><header class="m-search-hit__header"><h3 class="m-search-hit__title"><span class="m-search-hit__title-text" > ${title} </span><span class="m-search-hit__badge">neu</span></h3></header><ul class="m-search-hit__items"><li class="m-search-hit__item"><i class="g-ficon" aria-label="Arbeitsort"></i> ${loc} </li><li class="m-search-hit__item"><i aria-label="Arbeitgeber:in"></i> DB InfraGO AG </li></ul></a></div>`;
+  const dbHtml = '<html>' + dbHit('630365', 'Teilprojektleiter:in Tunnel / Logistik', 'München, Deutschland') + dbHit('631112', 'Bauleiter:in Vegetation', 'Koblenz, Deutschland') + '</html>';
+  const dbRows = dbParseHits(dbHtml, 'https://db.jobs');
+  if (dbRows.length === 2) pass('deutschebahn.parseHits() yields one row per m-search-hit anchor');
+  else fail(`deutschebahn.parseHits() returned ${dbRows.length}, expected 2`);
+  if (dbRows[0]?.title === 'Teilprojektleiter:in Tunnel / Logistik' && dbRows[0]?.location === 'München, Deutschland') pass('deutschebahn.parseHits() extracts the title span and the Arbeitsort location');
+  else fail(`deutschebahn.parseHits() fields wrong: ${JSON.stringify(dbRows[0])}`);
+  if (dbRows[0]?.url === 'https://db.jobs/de-de/Suche/Teilprojektleiter-in-Tunnel-Logistik-1396630365?jobId=630365') pass('deutschebahn.parseHits() builds the absolute posting URL');
+  else fail(`deutschebahn.parseHits() url wrong: ${JSON.stringify(dbRows[0]?.url)}`);
+  if (dbParseHits('<html>no hits</html>', 'https://db.jobs').length === 0 && dbParseHits(undefined, 'https://db.jobs').length === 0) pass('deutschebahn.parseHits() returns [] for hit-less / non-string input');
+  else fail('deutschebahn.parseHits() should return [] without hits');
+
+  // decodeEntities (exercised via parseHits) — a malformed/out-of-range
+  // numeric entity (a lone surrogate half) must degrade to the literal text,
+  // never throw RangeError and abort the whole parse.
+  const badHtml = '<html>' + dbHit('700001', 'Bad&#xD800;Entity', 'Berlin, Deutschland') + '</html>';
+  const badRows = dbParseHits(badHtml, 'https://db.jobs');
+  if (badRows.length === 1 && badRows[0].title === 'Bad&#xD800;Entity') pass('deutschebahn.parseHits() tolerates an invalid numeric entity (no RangeError crash)');
+  else fail(`deutschebahn.parseHits() should degrade a malformed entity to literal text, got: ${JSON.stringify(badRows)}`);
+
+  // fetch — paginates ?pageNum=N, stops on the first no-fresh-ids page.
+  const dbPages = [dbHtml, '<html>' + dbHit('700000', 'C', 'Berlin, Deutschland') + '</html>', '<html></html>'];
+  let dbCalls = 0;
+  const dbSeen = [];
+  const dbCtx = { sleep: async () => {}, fetchText: async (url) => { dbSeen.push(url); return dbPages[dbCalls++] ?? '<html></html>'; } };
+  const dbJobs = await db.fetch({ name: 'Deutsche Bahn', api: 'https://db.jobs/service/search/de-de/5441588' }, dbCtx);
+  if (dbJobs.length === 3 && dbCalls === 3) pass('deutschebahn.fetch() paginates and stops on the first empty page');
+  else fail(`deutschebahn.fetch() returned ${dbJobs.length} jobs after ${dbCalls} calls`);
+  if (dbSeen[0]?.includes('pageNum=0') && dbSeen[1]?.includes('pageNum=1')) pass('deutschebahn.fetch() pages via pageNum=N (0-based)');
+  else fail(`deutschebahn.fetch() paged wrong: ${JSON.stringify(dbSeen.map((u) => u.match(/pageNum=\d+/)?.[0]))}`);
+
+  // max_pages safety valve — a small explicit cap stops the walk even though
+  // every page keeps returning fresh ids (DB's board runs into the thousands,
+  // so this cap is the only thing bounding a runaway scan).
+  let capCalls = 0;
+  const capCtx = { sleep: async () => {}, fetchText: async () => { capCalls++; return dbHit(String(700100 + capCalls), `Job ${capCalls}`, 'Berlin, Deutschland'); } };
+  const cappedJobs = await db.fetch({ name: 'Deutsche Bahn', api: 'https://db.jobs/service/search/de-de/5441588', max_pages: 3 }, capCtx);
+  if (cappedJobs.length === 3 && capCalls === 3) pass('deutschebahn.fetch() honors entry.max_pages and stops even with more pages available');
+  else fail(`deutschebahn.fetch() max_pages cap wrong: ${cappedJobs.length} jobs after ${capCalls} calls`);
+
+  // Non-positive/non-integer max_pages falls back to the provider default
+  // (60) rather than collapsing to zero pages.
+  let fallbackCalls = 0;
+  const fallbackCtx = { sleep: async () => {}, fetchText: async () => { fallbackCalls++; return fallbackCalls <= 5 ? dbHit(String(700200 + fallbackCalls), `Job ${fallbackCalls}`, 'Berlin, Deutschland') : '<html></html>'; } };
+  const fallbackJobs = await db.fetch({ name: 'Deutsche Bahn', api: 'https://db.jobs/service/search/de-de/5441588', max_pages: 0 }, fallbackCtx);
+  if (fallbackJobs.length === 5 && fallbackCalls === 6) pass('deutschebahn.fetch() falls back to the default page cap for a non-positive max_pages');
+  else fail(`deutschebahn.fetch() max_pages fallback wrong: ${fallbackJobs.length} jobs after ${fallbackCalls} calls`);
+} catch (e) {
+  fail(`deutschebahn provider tests crashed: ${e.message}`);
+}

--- a/tests/providers/hecklerkoch.test.mjs
+++ b/tests/providers/hecklerkoch.test.mjs
@@ -1,0 +1,52 @@
+// tests/providers/hecklerkoch.test.mjs — SSR Stellenangebote parser.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — hecklerkoch (SSR Stellenangebote parser)');
+try {
+  const hkModule = await import(pathToFileURL(join(ROOT, 'providers/hecklerkoch.mjs')).href);
+  const hk = hkModule.default;
+  const { resolveListUrl: hkListUrl, parseListing } = hkModule;
+
+  if (hk.id === 'hecklerkoch') pass('hecklerkoch.id is "hecklerkoch"');
+  else fail(`hecklerkoch.id is ${JSON.stringify(hk.id)}`);
+
+  if (hkListUrl({ careers_url: 'https://www.heckler-koch.com/en/Career' }) === 'https://www.heckler-koch.com/de/Karriere/Stellenangebote') pass('hecklerkoch.resolveListUrl() defaults to the Stellenangebote list');
+  else fail(`hecklerkoch.resolveListUrl() default wrong: ${hkListUrl({ careers_url: 'https://www.heckler-koch.com/en/Career' })}`);
+  if (hk.detect({ careers_url: 'https://evil.com/x.heckler-koch.com' }) === null && hk.detect({ careers_url: 'https://heckler-koch.com.evil.com/x' }) === null) {
+    pass('hecklerkoch.detect() rejects spoofed hosts');
+  } else {
+    fail('hecklerkoch.detect() should reject spoofed hosts');
+  }
+
+  // parseListing — anchor on the jobposting/{hash} link, read the <h3> title.
+  const hkCard = (hash, title) =>
+    `<a to="[object Object]" href="https://karriere.heckler-koch.com/jobposting/${hash}" target="_blank" rel="noreferrer" class="group flex"><div class="text-secondary font-medium"><p> Produktion | Direkteinstieg </p><h3 class="text-lg md:text-2xl">${title}</h3></div><i class="pl-4 icon-chevron"></i></a>`;
+  const hkHtml = '<html>' + hkCard('d1be4446a082dd289578456f38fb82473beedb350', 'Maschineneinrichter (m/w/d) - Fr&#228;sen') + hkCard('ba2bf2265bc08d4d5df5993b33a0f4d05e4bd7ed0', 'Werkstudent Arbeitssicherheit (m/w/d)') + '</html>';
+  const hkRows = parseListing(hkHtml);
+  if (hkRows.length === 2) pass('hecklerkoch.parseListing() yields one row per jobposting link');
+  else fail(`hecklerkoch.parseListing() returned ${hkRows.length}, expected 2`);
+  if (hkRows[0]?.title === 'Maschineneinrichter (m/w/d) - Fräsen' && hkRows[0]?.url === 'https://karriere.heckler-koch.com/jobposting/d1be4446a082dd289578456f38fb82473beedb350') {
+    pass('hecklerkoch.parseListing() decodes the title and keeps the jobposting URL/id');
+  } else {
+    fail(`hecklerkoch.parseListing() row wrong: ${JSON.stringify(hkRows[0])}`);
+  }
+  if (parseListing('<html>no jobs</html>').length === 0 && parseListing(undefined).length === 0) pass('hecklerkoch.parseListing() returns [] for job-less / non-string input');
+  else fail('hecklerkoch.parseListing() should return [] without jobs');
+
+  // decodeEntities (exercised via parseListing) — a malformed/out-of-range
+  // numeric entity (a lone surrogate half) must degrade to the literal text,
+  // never throw RangeError and abort the whole parse.
+  const badCard = hkCard('badhash0000000000000000000000000000000000', 'Bad&#xD800;Entity');
+  const badRows = parseListing('<html>' + badCard + '</html>');
+  if (badRows.length === 1 && badRows[0].title === 'Bad&#xD800;Entity') pass('hecklerkoch.parseListing() tolerates an invalid numeric entity (no RangeError crash)');
+  else fail(`hecklerkoch.parseListing() should degrade a malformed entity to literal text, got: ${JSON.stringify(badRows)}`);
+
+  // fetch — single request, jobs normalized (location empty by design).
+  const hkJobs = await hk.fetch({ name: 'Heckler & Koch', api: 'https://www.heckler-koch.com/de/Karriere/Stellenangebote' }, { fetchText: async () => hkHtml });
+  if (hkJobs.length === 2 && hkJobs[0].company === 'Heckler & Koch' && hkJobs[0].location === '') pass('hecklerkoch.fetch() returns normalized jobs from one request');
+  else fail(`hecklerkoch.fetch() wrong: ${JSON.stringify(hkJobs)}`);
+} catch (e) {
+  fail(`hecklerkoch provider tests crashed: ${e.message}`);
+}

--- a/tests/providers/tkms.test.mjs
+++ b/tests/providers/tkms.test.mjs
@@ -1,0 +1,67 @@
+// tests/providers/tkms.test.mjs — TKMS filter/query JSON API.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — tkms (filter/query JSON API)');
+try {
+  const tkmsModule = await import(pathToFileURL(join(ROOT, 'providers/tkms.mjs')).href);
+  const tkms = tkmsModule.default;
+  const { resolveConfig: tkConfig, slugify: tkSlug, parseTkmsDate, tkmsLocation, parseQuery } = tkmsModule;
+
+  if (tkms.id === 'tkms') pass('tkms.id is "tkms"');
+  else fail(`tkms.id is ${JSON.stringify(tkms.id)}`);
+
+  const tkCfg = tkConfig({ api: 'https://jobs.tkmsgroup.com/en', tkms: { subclient: 'tkms', locale: 'en' } });
+  if (tkCfg && tkCfg.queryApi === 'https://jobs.tkmsgroup.com/api/filter/query' && tkCfg.subclient === 'tkms' && tkCfg.locale === 'en') {
+    pass('tkms.resolveConfig() parses host, subclient, locale');
+  } else {
+    fail(`tkms.resolveConfig() wrong: ${JSON.stringify(tkCfg)}`);
+  }
+  if (tkms.detect({ careers_url: 'https://evil.com/x.jobs.tkmsgroup.com' }) === null && tkms.detect({ careers_url: 'https://jobs.tkmsgroup.com.evil.com/x' }) === null) {
+    pass('tkms.detect() rejects spoofed hosts');
+  } else {
+    fail('tkms.detect() should reject spoofed hosts');
+  }
+
+  if (tkSlug('Systemingenieur IT (m/w/d)') === 'Systemingenieur-IT-m-w-d') pass('tkms.slugify() builds a clean slug');
+  else fail(`tkms.slugify() wrong: ${tkSlug('Systemingenieur IT (m/w/d)')}`);
+
+  if (parseTkmsDate({ postingDate_timestamp: 1783029600 }) === 1783029600000) pass('tkms.parseTkmsDate() prefers the epoch-seconds timestamp');
+  else fail('tkms.parseTkmsDate() timestamp wrong');
+  if (parseTkmsDate({ postingDate: '2026-07-02T22:00:00' }) === Date.parse('2026-07-02T22:00:00Z')) pass('tkms.parseTkmsDate() falls back to the ISO stamp (as UTC)');
+  else fail('tkms.parseTkmsDate() ISO fallback wrong');
+
+  if (tkmsLocation({ locations: [{ cityState: 'Kiel, Schleswig-Holstein' }, { cityState: 'Emden, Lower Saxony' }] }) === 'Kiel, Schleswig-Holstein / Emden, Lower Saxony') pass('tkms.tkmsLocation() joins the locations array');
+  else fail('tkms.tkmsLocation() array join wrong');
+  if (tkmsLocation({ city: 'Kiel', country: 'Germany' }) === 'Kiel, Germany') pass('tkms.tkmsLocation() falls back to flat city/country');
+  else fail('tkms.tkmsLocation() flat fallback wrong');
+
+  // parseQuery — id/title required; URL from origin+locale+slug+id, with the
+  // locale and id path segments percent-encoded.
+  const tkJson = { totalHits: 330, nextPage: 1, jobs: [
+    { data: { id: '964694', title: 'Schiffbauer (m/w/d)', city: 'Kiel', country: 'Germany', postingDate_timestamp: 1783029600, locations: [{ cityState: 'Kiel, Schleswig-Holstein' }] } },
+    { data: { id: '', title: 'No id' } },
+    { data: { id: '5', title: '' } },
+    { data: { id: '12/34', title: 'Slash Id' } },
+  ] };
+  const { total: tkTotal, nextPage: tkNext, rows: tkRows } = parseQuery(tkJson, { origin: 'https://jobs.tkmsgroup.com', locale: 'en' });
+  if (tkTotal === 330 && tkNext === 1 && tkRows.length === 2) pass('tkms.parseQuery() reads total/nextPage and drops id/title-less records');
+  else fail(`tkms.parseQuery() wrong: total=${tkTotal} next=${tkNext} rows=${tkRows.length}`);
+  if (tkRows[0]?.url === 'https://jobs.tkmsgroup.com/en/job/Schiffbauer-m-w-d/964694') pass('tkms.parseQuery() builds {origin}/{locale}/job/{slug}/{id}');
+  else fail(`tkms.parseQuery() url wrong: ${JSON.stringify(tkRows[0]?.url)}`);
+  if (tkRows[1]?.url === 'https://jobs.tkmsgroup.com/en/job/Slash-Id/12%2F34') pass('tkms.parseQuery() percent-encodes an id path segment');
+  else fail(`tkms.parseQuery() encoding wrong: ${JSON.stringify(tkRows[1]?.url)}`);
+
+  // fetch — paginates by page until nextPage===null, dedups, sends subclient.
+  const tkPage = (ids, next) => ({ totalHits: 40, nextPage: next, jobs: ids.map((i) => ({ data: { id: String(i), title: `Job ${i}`, city: 'Kiel', country: 'Germany' } })) });
+  const tkPages = [tkPage([1, 2], 1), tkPage([2, 3], null)];
+  let tkCalls = 0;
+  let tkSawSub = null;
+  const tkCtx = { sleep: async () => {}, fetchJson: async (url, opts) => { const b = JSON.parse(opts.body); tkSawSub = b.subclient; if (b.page !== tkCalls) throw new Error('bad page'); return tkPages[tkCalls++] ?? tkPage([], null); } };
+  const tkJobs = await tkms.fetch({ name: 'TKMS', api: 'https://jobs.tkmsgroup.com/en' }, tkCtx);
+  if (tkJobs.length === 3 && tkCalls === 2 && tkSawSub === 'tkms') pass('tkms.fetch() paginates via page/nextPage, dedups, sends subclient');
+  else fail(`tkms.fetch() returned ${tkJobs.length} jobs after ${tkCalls} calls (sub=${tkSawSub})`);
+} catch (e) {
+  fail(`tkms provider tests crashed: ${e.message}`);
+}

--- a/tests/providers/tkms.test.mjs
+++ b/tests/providers/tkms.test.mjs
@@ -24,6 +24,12 @@ try {
     fail('tkms.detect() should reject spoofed hosts');
   }
 
+  // resolveConfig — HTTPS-only. The API fetch uses redirect: 'error', so a
+  // plain-HTTP origin would both send the request in cleartext and hard-fail
+  // on any HTTPS redirect; reject it up front instead.
+  if (tkConfig({ api: 'http://jobs.tkmsgroup.com/en' }) === null) pass('tkms.resolveConfig() rejects a plain-HTTP origin');
+  else fail('tkms.resolveConfig() should reject http:');
+
   if (tkSlug('Systemingenieur IT (m/w/d)') === 'Systemingenieur-IT-m-w-d') pass('tkms.slugify() builds a clean slug');
   else fail(`tkms.slugify() wrong: ${tkSlug('Systemingenieur IT (m/w/d)')}`);
 


### PR DESCRIPTION
## What

Three new zero-token scan sources for German industrial/defense employers.

### `providers/tkms.mjs` — thyssenkrupp Marine Systems

`jobs.tkmsgroup.com` exposes a public JSON API:
- `POST /api/filter/query` with `{searchQuery, filter, subclient, locale, page}` — 20/page, 0-based, `nextPage: null` on the last page. `subclient`/`locale` are configurable via a `tkms:` block (the backend is a shared platform).
- Public job URL `{origin}/{locale}/job/{slug}/{id}`; the slug is cosmetic (stub resolves, verified), so the provider slugifies the title. `postingDate_timestamp`/`postingDate` → `postedAt`; `locations[].cityState` joined.
- **Verified live**: ~330 postings across TKMS GmbH / ATLAS ELEKTRONIK / Wismar. Strong PLM/Teamcenter overlap in naval engineering.

### `providers/hecklerkoch.mjs` — Heckler & Koch (single-company, SSR)

`heckler-koch.com/de/Karriere/Stellenangebote` is server-rendered — one GET yields every posting. The parser anchors on the `karriere.heckler-koch.com/jobposting/{hash}` link (stable id + job URL) and reads the sibling `<h3>` title. Small board (~32 roles), single-site (Oberndorf/Vöhringen) so location is left empty rather than guessed. **Verified live**: 32 jobs.

### `providers/deutschebahn.mjs` — Deutsche Bahn (single-company)

DB's branded Avature front (`jobs.deutschebahngroup.careers`) just 302-redirects into the custom **db.jobs** portal. The provider parses the server-rendered `/service/search/de-de/{searchId}` fragment (`m-search-hit` anchors: title span, `Arbeitsort` `<li>`, `data-job-id`), paginating `?pageNum=N`. `searchId` pinned via `api:`.

> **CAVEAT** (documented in the portals note): db.jobs is Akamai bot-protected and serves a challenge page to datacenter IPs — the same class as BMW in this repo. The `parseHits` parser is **unit-tested against the real `m-search-hit` markup** and works from residential IPs / the maintainer's environment, but a datacenter scan may return 0. The provider degrades gracefully (returns `[]`).

Also worth noting (no code change): **Siemens Healthineers** turned out to be branded Avature (`jobs.siemens-healthineers.com/en_US/searchjobs/SearchJobs`) and works with the existing `avature` provider — a portals-only wiring, not part of this PR.

## Tests

Sections 64/65/66: config / detect (host-spoof rejection) / slug / date / location parsers, plus JSON and SSR pagination + dedup for all three. DB's `parseHits` is validated against the real `m-search-hit` markup shape. `node test-all.mjs`: **1207 passed, 0 failed**.

## Verification (live, 2026-07-04)

`verify-portals` through the provider layer: `TKMS — tkms (first page live)`, `Heckler & Koch — hecklerkoch (32 live)`, `Siemens Healthineers — avature (first page live)`. Deutsche Bahn reports `live but empty` from the datacenter IP (Akamai challenge, as documented) — the parser is proven correct against captured real markup.

## Note

Trivially conflicts with #1549 / #1551 / #1554 in `test-all.mjs` (all append provider test sections at the file end). Happy to rebase whichever lands last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new job board support for Deutsche Bahn, Heckler & Koch, and TKMS, including parsing and normalization of job title, posting URL, company, location, and posting date when available.
* **New Features**
  * Added shared HTML entity decoding to improve robustness of scraped text.
* **Tests**
  * Added coverage for all three providers plus the shared entity decoder, including detection, listing parsing, pagination, deduplication, and resilient text normalization (including malformed entities).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->