### PR TITLE
feat(profile): candidate contact-channel preference field for outreach/email drafts

### DIFF
--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -121,6 +121,19 @@ cover_letter:
       # Only trigger this entry when the JD location is in one of these countries.
       countries: [Spain, Mexico, Argentina, Colombia, Chile]
 
+# ── Contact Preferences ──────────────────────────────────────────────────────
+#
+# Used by `/career-ops contacto` (outreach CTA) and `/career-ops email` (contact
+# block) to steer drafted messages toward how you actually want to be reached.
+# Optional. Omit the whole block, or set preferred_channel to "either", to keep
+# today's behavior unchanged (no channel steering).
+#
+# contact_preferences:
+#   preferred_channel: "email"   # email | phone | either — default "either" if omitted
+#   # Optional. Surfaced near the contact block in `/career-ops email` drafts and
+#   # can inform the CTA wording in `/career-ops contacto`. Keep it one line.
+#   note: "Screens unknown numbers — please email or text first to schedule a call"
+
 # ── Outreach / greeting ─────────────────────────────────────────────────────
 #
 # Used by the greeting variant of `/career-ops contacto` (the short first-touch

--- a/modes/contacto.md
+++ b/modes/contacto.md
@@ -65,9 +65,10 @@ short message; otherwise run the LinkedIn power move below.
 `config/profile.yml`. If it is absent or set to `"either"`, write the CTA
 sentence exactly as specified above — no change. If it is set to `"email"` or
 `"phone"`, steer the CTA toward that channel instead of the generic default
-(e.g. Recruiter's CTA becomes "Happy to share more over email if this aligns"
-rather than defaulting to a call; Hiring Manager's CTA leans on "happy to
-continue this over email" instead of proposing a call). Keep the same
+(e.g. Recruiter's CTA becomes "Happy to share my CV over email if this aligns
+with what you're looking for" rather than defaulting to a call; Hiring
+Manager's CTA leans on "happy to continue this over email" instead of
+proposing a call). Keep the same
 3-sentence structure and per-persona emphasis -- only the channel named in the
 CTA changes. If `contact_preferences.note` is set, you may fold its intent into
 the CTA phrasing (e.g. "screens unknown numbers" → prefer email wording) but do

--- a/modes/contacto.md
+++ b/modes/contacto.md
@@ -61,6 +61,18 @@ short message; otherwise run the LinkedIn power move below.
 
 6. **Alternative targets** with justification for why they are good second choices
 
+**Contact channel preference:** Read `contact_preferences.preferred_channel` from
+`config/profile.yml`. If it is absent or set to `"either"`, write the CTA
+sentence exactly as specified above — no change. If it is set to `"email"` or
+`"phone"`, steer the CTA toward that channel instead of the generic default
+(e.g. Recruiter's CTA becomes "Happy to share more over email if this aligns"
+rather than defaulting to a call; Hiring Manager's CTA leans on "happy to
+continue this over email" instead of proposing a call). Keep the same
+3-sentence structure and per-persona emphasis -- only the channel named in the
+CTA changes. If `contact_preferences.note` is set, you may fold its intent into
+the CTA phrasing (e.g. "screens unknown numbers" → prefer email wording) but do
+not quote the note verbatim in a public-facing message.
+
 **Message rules:**
 - Maximum 300 characters (LinkedIn connection request limit)
 - NO corporate-speak

--- a/modes/email.md
+++ b/modes/email.md
@@ -223,7 +223,7 @@ one short line directly under the contact block naming that preference, e.g.:
 Contact:
 Email: jane@example.com
 Phone: +1-555-0123
-(Prefers email first -- happy to schedule a call from there.)
+(Prefers email first.)
 ```
 
 If `contact_preferences.note` is set, use its wording (or a close paraphrase)

--- a/modes/email.md
+++ b/modes/email.md
@@ -74,6 +74,8 @@ Use these optional fields when present:
 - `application_email.include_contact_block`
 - `application_email.include_attachment_checklist`
 - `application_email.signature_name`
+- `contact_preferences.preferred_channel`
+- `contact_preferences.note`
 
 If `candidate.wechat` is absent, omit WeChat. Do not invent one.
 
@@ -210,6 +212,23 @@ a concrete email address.
 
 If `application_email.include_contact_block` is `false`, use a normal signature
 only.
+
+**Contact channel preference:** If `application_email.include_contact_block` is
+`true` (or absent/default), check `contact_preferences.preferred_channel` in
+`config/profile.yml`. If it is absent or set to `"either"`, the contact block
+stays exactly as above — no change. If it is set to `"email"` or `"phone"`, add
+one short line directly under the contact block naming that preference, e.g.:
+
+```text
+Contact:
+Email: jane@example.com
+Phone: +1-555-0123
+(Prefers email first -- happy to schedule a call from there.)
+```
+
+If `contact_preferences.note` is set, use its wording (or a close paraphrase)
+for that line instead of a generic phrase. Keep it to one line, no bold, no
+extra emphasis -- it should read as a practical note, not a demand.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds an optional `contact_preferences` block to `config/profile.example.yml` (`preferred_channel: email|phone|either`, plus a free-text `note`). Default when the block is absent, or `preferred_channel` is `"either"`, is unchanged behavior.
- `modes/contacto.md`: when `preferred_channel` is `"email"` or `"phone"`, the per-persona CTA sentence (Recruiter/Hiring Manager/Peer/Interviewer) is steered toward that channel instead of the generic default. Structure and emphasis per persona are unchanged; only the channel named in the CTA changes.
- `modes/email.md`: when `application_email.include_contact_block` is true and `preferred_channel` is set to something other than `"either"`, a one-line preference note is added directly under the contact block/signature (using `contact_preferences.note` if provided).

## Why

An unrecognized incoming call reads identically to spam regardless of whether it's a real recruiter, so a candidate who screens calls risks missing a legitimate recruiter call. This lets career-ops-drafted outreach/emails proactively steer the recipient toward the candidate's actual preferred channel, without any new send/submit capability (both modes remain draft-only).

Closes #1556

## Test plan

- [x] Read `config/profile.example.yml`, `modes/contacto.md`, `modes/email.md` in full before editing; matched existing section-comment style and per-file prose voice.
- [x] Verified no existing convention in `AGENTS.md`/`CLAUDE.md` documents individual `config/profile.yml` fields, so no doc changes were added there (avoiding invented documentation surface).
- [x] `node test-all.mjs --quick` → 1180 passed, 0 failed (1 pre-existing warning unrelated to this change, about `cv-sync-check.mjs` with no user data present).
- [x] Confirmed default behavior is unchanged: no examples reference real company/personal data — only the repo's existing "Jane Smith" placeholder convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `contact_preferences.preferred_channel` support to tailor outreach to email, phone, or leave behavior unchanged for either.
  * Added optional `contact_preferences.note` to optionally include a brief, one-line preference note in contact/CTA text.
* **Documentation**
  * Updated the example profile to document the new contact preference fields.
  * Enhanced contact-related templates to apply these preferences only when configured, preserving existing output when unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->