### PR TITLE
feat(pdf): JD skill-gap checker — classify JD-required skills before CV generation, zero-LLM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `data/salary-observations.tsv` | Append-only salary observation log (user layer) |
 | `assessment-log.mjs` | Skills-assessment event logger — `add` appends platform/subject/threshold/score + candidate-observed staleness note to `data/assessments.tsv` (JSON or `--summary`) |
 | `data/assessments.tsv` | Append-only skills-assessment log (user layer, created on first `add`) |
+| `jd-skill-gap.mjs` | Zero-LLM JD skill-gap checker — classifies a JD's required skills against `cv.md` into existing / supportedByResume / gap so a CV can be tailored honestly (JSON or `--summary` output); never auto-adds a claim to `cv.md` |
 | `data/follow-ups.md` | Follow-up history tracker |
 | `data/blacklist.md` | Your do-not-apply company list (user layer, opt-in — never auto-populated; respected by `scan.mjs` and the `auto-pipeline`/`oferta`/`apply` gates) |
 | `scan.mjs` | Zero-token portal scanner — hits Greenhouse/Ashby/Lever APIs directly, zero LLM cost |

--- a/jd-skill-gap.mjs
+++ b/jd-skill-gap.mjs
@@ -266,13 +266,18 @@ Python, Docker, Zookeeper
 
 ## Requirements
 - Bachelor's degree required
-- 5+ years of experience
-- Strong communication skills
+- Experience with cross-functional teams (5+ years)
+- Communication skills and Ability to self-organize
 `;
+  // The asserted words are capitalized in the fixture on purpose:
+  // SKILL_TOKEN_RE only captures uppercase-leading tokens, so a lowercase
+  // "experience" would never become a candidate and the assertion would
+  // pass without exercising the STOPWORDS filter at all.
   const boilerplateSkills = extractJdSkills(boilerplateJd);
   eq('does not extract "Bachelor" as a skill', boilerplateSkills.includes('Bachelor'), false);
   eq('does not extract "Experience" as a skill', boilerplateSkills.includes('Experience'), false);
   eq('does not extract "Communication" as a skill', boilerplateSkills.includes('Communication'), false);
+  eq('does not extract "Ability" as a skill', boilerplateSkills.includes('Ability'), false);
 
   console.log(`\njd-skill-gap self-test: ${passed} passed, ${failed} failed`);
   if (failed > 0) process.exit(1);

--- a/jd-skill-gap.mjs
+++ b/jd-skill-gap.mjs
@@ -49,7 +49,16 @@ const BULLET_LINE_RE = /^\s*[-*•]\s*(.+)$/;
 // A conservative skill-token extractor: pulls comma/slash/and-separated
 // technical-looking tokens out of a requirement bullet, rather than treating
 // the whole bullet as one skill string (JD bullets are often full sentences).
-const SKILL_TOKEN_RE = /\b([A-Z][A-Za-z0-9+.#]{1,30}(?:\.[a-z]{2,4})?)\b/g;
+//
+// Trailing boundary: \b fails at symbol edges (\bC\+\+\b needs a word char
+// AFTER the +), so C++/C#/F# would never match standalone — same bug and fix
+// as upskill.mjs's SKILL_PATTERN, where (?!\w) is equivalent to \b for
+// word-char edges and correct for symbol edges. Because the char class here
+// is greedy and contains ".", the last token char is additionally pinned to
+// a word char / # / + so a sentence-ending period is never swallowed into
+// the token ("Docker." still extracts as "Docker"). The leading \b stays:
+// tokens start with [A-Z], a word char, where \b and (?<!\w) are equivalent.
+const SKILL_TOKEN_RE = /\b([A-Z][A-Za-z0-9+.#]{0,29}[A-Za-z0-9+#](?:\.[a-z]{2,4})?)(?!\w)/g;
 
 // Deliberately broad: this list exists specifically to stop generic
 // capitalized nouns/adjectives from JD bullets (e.g. "Bachelor's degree
@@ -278,6 +287,26 @@ Python, Docker, Zookeeper
   eq('does not extract "Experience" as a skill', boilerplateSkills.includes('Experience'), false);
   eq('does not extract "Communication" as a skill', boilerplateSkills.includes('Communication'), false);
   eq('does not extract "Ability" as a skill', boilerplateSkills.includes('Ability'), false);
+
+  // Regression: tokens ending in a symbol (C#, C++, F#). The original trailing
+  // \b needs a word char AFTER the symbol, so these never matched standalone —
+  // same bug upskill.mjs's SKILL_PATTERN fixed with a (?!\w) lookahead. The
+  // sentence-ending "Docker." assertion guards the other edge of the fix: the
+  // greedy char class contains ".", so the lookahead alone would swallow the
+  // trailing period into the token.
+  const symbolEdgeJd = `
+# Role
+
+## Requirements
+- C#, C++ or F# for backend services
+- Familiarity with Docker.
+`;
+  const symbolEdgeSkills = extractJdSkills(symbolEdgeJd);
+  eq('extracts C# standalone (symbol-edge boundary)', symbolEdgeSkills.includes('C#'), true);
+  eq('extracts C++ standalone (symbol-edge boundary)', symbolEdgeSkills.includes('C++'), true);
+  eq('extracts F# standalone (symbol-edge boundary)', symbolEdgeSkills.includes('F#'), true);
+  eq('sentence-ending token stays clean ("Docker", not "Docker.")', symbolEdgeSkills.includes('Docker'), true);
+  eq('trailing period is not swallowed into the token', symbolEdgeSkills.includes('Docker.'), false);
 
   console.log(`\njd-skill-gap self-test: ${passed} passed, ${failed} failed`);
   if (failed > 0) process.exit(1);

--- a/jd-skill-gap.mjs
+++ b/jd-skill-gap.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+/**
+ * jd-skill-gap.mjs — Zero-LLM JD skill-gap checker.
+ *
+ * Extracts an explicit skill/requirement list from a JD (regex-based, no LLM
+ * call — see extractJdSkills()), then classifies each one against cv.md into
+ * three buckets so a CV can be tailored honestly instead of guessed at:
+ *
+ *   existing            — already a named skill in cv.md's Skills section
+ *   supportedByResume    — not a named skill, but appears in prose elsewhere in cv.md
+ *   gap                  — JD requires it, cv.md has no trace of it at all
+ *   (nothing is ever auto-added — this tool only classifies and reports)
+ *
+ * Design note: the three-way classification (existing / supportedByResume / gap)
+ * is inspired by the skill-verification pattern in srbhr/Resume-Matcher
+ * (Apache-2.0) — specifically their four-way verify_skill_target_plan() split.
+ * This is an independent reimplementation, not a code port: different language,
+ * zero LLM calls, and folded down to three buckets because career-ops never
+ * auto-adds a claim to cv.md either way (their jd_added/unsupported distinction
+ * only matters if a tool is allowed to add something automatically).
+ *
+ * Usage:
+ *   node jd-skill-gap.mjs jds/acme.md
+ *   node jd-skill-gap.mjs jds/acme.md --summary
+ *   node jd-skill-gap.mjs --self-test
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+// ── Config ──────────────────────────────────────────────────────────
+
+const CV_PATH = 'cv.md';
+
+// ── JD skill extraction (regex, no LLM) ─────────────────────────────
+//
+// Looks for lines/phrases under common JD requirement headers and comma/
+// bullet-separated skill lists. Deliberately conservative: under-extracting
+// (missing a skill) is recoverable by the user reading the JD themselves;
+// over-extracting noise into "required skills" is not — it would misreport
+// gaps that aren't real.
+
+const REQUIREMENT_HEADER_RE =
+  /^#{0,4}\s*(required|requirements|qualifications|must[- ]have|preferred|nice[- ]to[- ]have)s?\b.*$/im;
+
+const BULLET_LINE_RE = /^\s*[-*•]\s*(.+)$/;
+
+// A conservative skill-token extractor: pulls comma/slash/and-separated
+// technical-looking tokens out of a requirement bullet, rather than treating
+// the whole bullet as one skill string (JD bullets are often full sentences).
+const SKILL_TOKEN_RE = /\b([A-Z][A-Za-z0-9+.#]{1,30}(?:\.[a-z]{2,4})?)\b/g;
+
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'with', 'you', 'your', 'our', 'this', 'that',
+  'must', 'able', 'strong', 'excellent', 'proven', 'a', 'an',
+]);
+
+/**
+ * Extract candidate skill tokens from a JD's requirement-style sections.
+ * @param {string} jdText
+ * @returns {string[]}
+ */
+function extractJdSkills(jdText) {
+  const lines = jdText.split('\n');
+  const skills = new Set();
+  let inRequirementsBlock = false;
+
+  for (const line of lines) {
+    if (REQUIREMENT_HEADER_RE.test(line)) {
+      inRequirementsBlock = true;
+      continue;
+    }
+    if (inRequirementsBlock && line.trim() === '') continue;
+    if (inRequirementsBlock && /^#{1,4}\s/.test(line) && !REQUIREMENT_HEADER_RE.test(line)) {
+      inRequirementsBlock = false;
+    }
+
+    const bulletMatch = BULLET_LINE_RE.exec(line);
+    if (inRequirementsBlock && bulletMatch) {
+      const bulletText = bulletMatch[1];
+      let m;
+      SKILL_TOKEN_RE.lastIndex = 0;
+      while ((m = SKILL_TOKEN_RE.exec(bulletText)) !== null) {
+        const token = m[1].trim();
+        if (!STOPWORDS.has(token.toLowerCase()) && token.length > 1) {
+          skills.add(token);
+        }
+      }
+    }
+  }
+  return [...skills];
+}
+
+// ── Word-boundary text matching (same technique as Resume-Matcher's
+//    _skill_mentioned_in_text — prevents "Java" matching inside "JavaScript") ──
+
+/**
+ * Word-boundary, case-insensitive check for whether a skill token appears in text.
+ * @param {string} skill
+ * @param {string} text
+ * @returns {boolean}
+ */
+function skillMentionedInText(skill, text) {
+  const escaped = skill.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(?<![\\w])${escaped}(?![\\w])`, 'i');
+  return re.test(text);
+}
+
+// ── Classification ───────────────────────────────────────────────────
+
+/**
+ * Classify each JD skill against cv.md into existing / supportedByResume / gap.
+ * @param {string[]} jdSkills
+ * @param {string} cvText
+ * @returns {{existing: string[], supportedByResume: string[], gap: string[]}}
+ */
+function classifySkillGaps(jdSkills, cvText) {
+  const skillsSectionMatch = cvText.match(/^#{1,4}\s*Skills\s*$([\s\S]*?)(?=^#{1,4}\s|\Z)/im);
+  const namedSkillsText = skillsSectionMatch ? skillsSectionMatch[1] : '';
+  const proseText = skillsSectionMatch
+    ? cvText.slice(0, skillsSectionMatch.index) + cvText.slice(skillsSectionMatch.index + skillsSectionMatch[0].length)
+    : cvText;
+
+  const existing = [];
+  const supportedByResume = [];
+  const gap = [];
+
+  for (const skill of jdSkills) {
+    if (skillMentionedInText(skill, namedSkillsText)) {
+      existing.push(skill);
+    } else if (skillMentionedInText(skill, proseText)) {
+      supportedByResume.push(skill);
+    } else {
+      gap.push(skill);
+    }
+  }
+
+  return { existing, supportedByResume, gap };
+}
+
+// ── Exports (for test-all.mjs and other consumers) ───────────────────
+export { extractJdSkills, skillMentionedInText, classifySkillGaps };
+
+// ── CLI ──────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const summaryMode = args.includes('--summary');
+const selfTestMode = args.includes('--self-test');
+const jdPathArg = args.find(a => !a.startsWith('--'));
+
+function runSelfTest() {
+  let passed = 0, failed = 0;
+  const eq = (label, actual, expected) => {
+    const a = JSON.stringify(actual), e = JSON.stringify(expected);
+    if (a === e) {
+      passed++;
+    } else {
+      failed++;
+      console.log(`  FAIL: ${label}\n    expected: ${e}\n    actual:   ${a}`);
+    }
+  };
+
+  const fakeJd = `
+# Senior Engineer — Fabrikam Inc.
+
+## Requirements
+- Python, FastAPI, PostgreSQL
+- Experience with Kubernetes
+- Strong communication skills
+`;
+  const fakeCv = `
+# Skills
+Python, PostgreSQL, Docker
+
+# Experience
+Deployed services onto Kubernetes clusters and wrote FastAPI endpoints for internal tools.
+`;
+
+  const jdSkills = extractJdSkills(fakeJd);
+  eq('extracts Python from requirements bullet', jdSkills.includes('Python'), true);
+  eq('extracts Kubernetes from a separate bullet', jdSkills.includes('Kubernetes'), true);
+  eq('does not extract stopword "Strong"', jdSkills.includes('Strong'), false);
+
+  const result = classifySkillGaps(['Python', 'PostgreSQL', 'Kubernetes', 'FastAPI', 'Rust'], fakeCv);
+  eq('Python classified as existing (named skill)', result.existing.includes('Python'), true);
+  eq('Kubernetes classified as supportedByResume (prose only)', result.supportedByResume.includes('Kubernetes'), true);
+  eq('FastAPI classified as supportedByResume (prose only)', result.supportedByResume.includes('FastAPI'), true);
+  eq('Rust classified as a real gap', result.gap.includes('Rust'), true);
+
+  console.log(`\njd-skill-gap self-test: ${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (selfTestMode) {
+  runSelfTest();
+} else {
+  if (!jdPathArg || !existsSync(jdPathArg)) {
+    console.error('Usage: node jd-skill-gap.mjs <jd-file> [--summary]');
+    console.error('       node jd-skill-gap.mjs --self-test');
+    process.exit(1);
+  }
+  if (!existsSync(CV_PATH)) {
+    console.error(`Error: ${CV_PATH} not found — this is a user-layer file, create it first.`);
+    process.exit(1);
+  }
+
+  const jdText = readFileSync(jdPathArg, 'utf-8');
+  const cvText = readFileSync(CV_PATH, 'utf-8');
+  const jdSkills = extractJdSkills(jdText);
+  const result = classifySkillGaps(jdSkills, cvText);
+
+  if (summaryMode) {
+    console.log(`\nJD Skill-Gap Check`);
+    console.log('─'.repeat(40));
+    console.log(`JD skills found: ${jdSkills.length}`);
+    console.log(`  ✅ Already in Skills section:   ${result.existing.join(', ') || '(none)'}`);
+    console.log(`  📝 Mentioned in resume prose:   ${result.supportedByResume.join(', ') || '(none)'}`);
+    console.log(`  ⚠️  Real gaps (not found anywhere): ${result.gap.join(', ') || '(none)'}`);
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}
+} // end CLI guard

--- a/jd-skill-gap.mjs
+++ b/jd-skill-gap.mjs
@@ -51,9 +51,21 @@ const BULLET_LINE_RE = /^\s*[-*•]\s*(.+)$/;
 // the whole bullet as one skill string (JD bullets are often full sentences).
 const SKILL_TOKEN_RE = /\b([A-Z][A-Za-z0-9+.#]{1,30}(?:\.[a-z]{2,4})?)\b/g;
 
+// Deliberately broad: this list exists specifically to stop generic
+// capitalized nouns/adjectives from JD bullets (e.g. "Bachelor's degree
+// required", "3+ years of experience") from being misreported as missing
+// "skills" — the exact failure mode this file's design note warns against.
 const STOPWORDS = new Set([
-  'the', 'and', 'for', 'with', 'you', 'your', 'our', 'this', 'that',
-  'must', 'able', 'strong', 'excellent', 'proven', 'a', 'an',
+  'the', 'and', 'for', 'with', 'you', 'your', 'our', 'this', 'that', 'these', 'those',
+  'must', 'able', 'ability', 'strong', 'excellent', 'proven', 'a', 'an', 'or', 'in', 'of', 'to', 'as', 'is', 'are',
+  // degree / education boilerplate
+  'bachelor', 'bachelors', 'master', 'masters', 'degree', 'diploma', 'certification', 'certificate',
+  // experience / seniority boilerplate
+  'experience', 'years', 'year', 'senior', 'junior', 'entry', 'level', 'minimum', 'preferred', 'required',
+  // generic sentence-starters that show up capitalized at the start of a bullet
+  'candidates', 'candidate', 'applicants', 'applicant', 'ideal', 'successful',
+  'knowledge', 'understanding', 'familiarity', 'exposure', 'background',
+  'skills', 'skill', 'communication', 'team', 'teams', 'work', 'working',
 ]);
 
 /**
@@ -107,6 +119,49 @@ function skillMentionedInText(skill, text) {
   return re.test(text);
 }
 
+// ── Skills-section split ─────────────────────────────────────────────
+//
+// Line-scan instead of a single regex: JS regex has no `\Z`-style
+// end-of-string anchor (unlike Python, where this pattern was designed),
+// so a lookahead built on `\Z` either fails to match a trailing Skills
+// section at all or matches a literal "Z" character later in the text.
+// Scanning line-by-line for the next heading avoids the anchor entirely.
+
+const SKILLS_HEADING_RE = /^#{1,4}\s*Skills\s*$/i;
+const ANY_HEADING_RE = /^#{1,4}\s/;
+
+/**
+ * Split cv.md into its named "Skills" section (if any) and the remaining
+ * prose, without relying on a Python-style end-of-string regex anchor.
+ * @param {string} cvText
+ * @returns {{namedSkillsText: string, proseText: string}}
+ */
+function splitSkillsSection(cvText) {
+  const lines = cvText.split('\n');
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (SKILLS_HEADING_RE.test(lines[i])) {
+      start = i + 1;
+      break;
+    }
+  }
+  if (start === -1) {
+    return { namedSkillsText: '', proseText: cvText };
+  }
+
+  let end = lines.length;
+  for (let i = start; i < lines.length; i++) {
+    if (ANY_HEADING_RE.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+
+  const namedSkillsText = lines.slice(start, end).join('\n');
+  const proseText = lines.slice(0, start - 1).concat(lines.slice(end)).join('\n');
+  return { namedSkillsText, proseText };
+}
+
 // ── Classification ───────────────────────────────────────────────────
 
 /**
@@ -116,11 +171,7 @@ function skillMentionedInText(skill, text) {
  * @returns {{existing: string[], supportedByResume: string[], gap: string[]}}
  */
 function classifySkillGaps(jdSkills, cvText) {
-  const skillsSectionMatch = cvText.match(/^#{1,4}\s*Skills\s*$([\s\S]*?)(?=^#{1,4}\s|\Z)/im);
-  const namedSkillsText = skillsSectionMatch ? skillsSectionMatch[1] : '';
-  const proseText = skillsSectionMatch
-    ? cvText.slice(0, skillsSectionMatch.index) + cvText.slice(skillsSectionMatch.index + skillsSectionMatch[0].length)
-    : cvText;
+  const { namedSkillsText, proseText } = splitSkillsSection(cvText);
 
   const existing = [];
   const supportedByResume = [];
@@ -187,6 +238,41 @@ Deployed services onto Kubernetes clusters and wrote FastAPI endpoints for inter
   eq('Kubernetes classified as supportedByResume (prose only)', result.supportedByResume.includes('Kubernetes'), true);
   eq('FastAPI classified as supportedByResume (prose only)', result.supportedByResume.includes('FastAPI'), true);
   eq('Rust classified as a real gap', result.gap.includes('Rust'), true);
+
+  // Regression: a Skills section that is the LAST section in cv.md, with no
+  // trailing heading after it. The original draft used a Python-style `\Z`
+  // end-of-string anchor, which JS regex has no equivalent for — it either
+  // failed to match this case at all, or matched a literal "Z" character
+  // later in the text. This fixture is that exact shape (Skills is last,
+  // and the text contains a "Z"-adjacent word to catch the literal-match
+  // failure mode too).
+  const trailingSkillsCv = `
+# Experience
+Worked with Rust in a prior role.
+
+# Skills
+Python, Docker, Zookeeper
+`;
+  const trailingResult = classifySkillGaps(['Python', 'Zookeeper'], trailingSkillsCv);
+  eq(
+    'trailing Skills section (last in doc, contains a "Z" word) is still captured as named skills',
+    trailingResult.existing.includes('Zookeeper'),
+    true
+  );
+
+  // Regression: generic JD boilerplate must not be misreported as a skill gap.
+  const boilerplateJd = `
+# Role
+
+## Requirements
+- Bachelor's degree required
+- 5+ years of experience
+- Strong communication skills
+`;
+  const boilerplateSkills = extractJdSkills(boilerplateJd);
+  eq('does not extract "Bachelor" as a skill', boilerplateSkills.includes('Bachelor'), false);
+  eq('does not extract "Experience" as a skill', boilerplateSkills.includes('Experience'), false);
+  eq('does not extract "Communication" as a skill', boilerplateSkills.includes('Communication'), false);
 
   console.log(`\njd-skill-gap self-test: ${passed} passed, ${failed} failed`);
   if (failed > 0) process.exit(1);

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -5,26 +5,30 @@
 1. Read `cv.md` as the source of truth
 2. Ask the user for the JD if it is not in context (text or URL)
 3. Extract 15-20 keywords from the JD
-4. Detect JD language → CV language (EN default)
-5. Detect company location → paper format:
+4. Run the zero-LLM skill-gap check before drafting anything: write the JD to a scratch file (e.g. `jds/{slug}.md`) if it isn't already one, then `node jd-skill-gap.mjs jds/{slug}.md --summary`. This classifies the JD's explicit requirements against `cv.md` into three buckets — never surface `result.gap` items as if the candidate has them:
+   - `existing` — already a named skill in cv.md's Skills section, safe to lead with
+   - `supportedByResume` — not a named skill yet, but cv.md's prose already demonstrates it; legitimate candidates for the Skills section in the user's own words (Step 12's competency grid draws from here first)
+   - `gap` — cv.md has no trace of it at all. **Tell the user explicitly which skills are gaps before generating the CV.** Never paper over a gap by inventing a claim, and never silently drop it from the conversation — the user decides whether to proceed, address it in the cover letter/interview, or skip the role
+5. Detect JD language → CV language (EN default)
+6. Detect company location → paper format:
    - US/Canada → `letter`
    - Rest of the world → `a4`
-6. Detect role archetype → adapt framing
-7. Build an internal recruiter-side risk map from the JD using `modes/heuristics/recruiter-side.md`: likely doubts, matching evidence, and which document section should address each doubt
-8. Rewrite Professional Summary by injecting JD keywords + exit narrative bridge ("Built and sold a business. Now applying systems thinking to [JD domain].")
-9. Select top 3-4 most relevant projects for the job
-10. Reorder experience bullets by JD relevance and by the risk map: strongest matching evidence first
-11. Build competency grid from JD requirements (6-8 keyword phrases)
-12. Inject keywords naturally into existing achievements (NEVER invent)
-13. Apply the six-second clarity gate from `modes/heuristics/recruiter-side.md`: top third must make target role, strongest fit, and proof obvious
-14. Read `name` from `config/profile.yml` → normalize to kebab-case lowercase (e.g. "John Doe" → "john-doe") → `{candidate}`
-15. Build the render payload (see the **JSON Input Schema** below) from the tailored content — emit compact structured JSON, **not** full HTML markup — and write it to `/tmp/cv-{candidate}-{company}.json`
-16. Run: `node build-cv-html.mjs /tmp/cv-{candidate}-{company}.json output/cv-{candidate}-{company}.html {template}` — where `{template}` is the path printed by **Selecting the template** below (omit the argument to use the base `cv-template.html`). The script merges the payload into that template, owning every tag, CSS class, and the HTML escaping. Write to `output/` (NOT a temp dir — the recorded HTML is what the dashboard's `D` hotkey regenerates from, so it must survive temp cleanup)
-17. Run the fact gate: `node verify-cv-facts.mjs output/cv-{candidate}-{company}.html`
+7. Detect role archetype → adapt framing
+8. Build an internal recruiter-side risk map from the JD using `modes/heuristics/recruiter-side.md`: likely doubts, matching evidence, and which document section should address each doubt
+9. Rewrite Professional Summary by injecting JD keywords + exit narrative bridge ("Built and sold a business. Now applying systems thinking to [JD domain].")
+10. Select top 3-4 most relevant projects for the job
+11. Reorder experience bullets by JD relevance and by the risk map: strongest matching evidence first
+12. Build competency grid from JD requirements (6-8 keyword phrases), prioritizing `existing` and `supportedByResume` skills from Step 4 — never a `gap` skill
+13. Inject keywords naturally into existing achievements (NEVER invent)
+14. Apply the six-second clarity gate from `modes/heuristics/recruiter-side.md`: top third must make target role, strongest fit, and proof obvious
+15. Read `name` from `config/profile.yml` → normalize to kebab-case lowercase (e.g. "John Doe" → "john-doe") → `{candidate}`
+16. Build the render payload (see the **JSON Input Schema** below) from the tailored content — emit compact structured JSON, **not** full HTML markup — and write it to `/tmp/cv-{candidate}-{company}.json`
+17. Run: `node build-cv-html.mjs /tmp/cv-{candidate}-{company}.json output/cv-{candidate}-{company}.html {template}` — where `{template}` is the path printed by **Selecting the template** below (omit the argument to use the base `cv-template.html`). The script merges the payload into that template, owning every tag, CSS class, and the HTML escaping. Write to `output/` (NOT a temp dir — the recorded HTML is what the dashboard's `D` hotkey regenerates from, so it must survive temp cleanup)
+18. Run the fact gate: `node verify-cv-facts.mjs output/cv-{candidate}-{company}.html`
     - This is a hard gate before PDF rendering.
     - If it fails, stop and fix the generated HTML by removing invented metrics or adding verified evidence to `cv.md`, `article-digest.md`, or `config/cv-facts.json`.
-18. Execute: `node generate-pdf.mjs output/cv-{candidate}-{company}.html output/cv-{candidate}-{company}-{YYYY-MM-DD}.pdf --format={letter|a4} --report={report number}` — `{report number}` is the NNN from the report filename/link (e.g. `008` for `reports/008-acme-….md`), not the tracker `#` column. Pass it whenever the application has (or will have) a report; it records the PDF↔report linkage in `data/pdf-index.tsv` so the dashboard can open and regenerate the exact PDF. Omit it only for one-off CVs with no tracker entry.
-19. Report: PDF path, number of pages, keyword coverage %
+19. Execute: `node generate-pdf.mjs output/cv-{candidate}-{company}.html output/cv-{candidate}-{company}-{YYYY-MM-DD}.pdf --format={letter|a4} --report={report number}` — `{report number}` is the NNN from the report filename/link (e.g. `008` for `reports/008-acme-….md`), not the tracker `#` column. Pass it whenever the application has (or will have) a report; it records the PDF↔report linkage in `data/pdf-index.tsv` so the dashboard can open and regenerate the exact PDF. Omit it only for one-off CVs with no tracker entry.
+20. Report: PDF path, number of pages, keyword coverage %, and any skill gaps from Step 4 still unaddressed
 
 ## ATS Rules (clean parsing)
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -157,6 +157,7 @@ const scripts = [
   { name: 'img-to-pdf.mjs --self-test', expectExit: 0 },
   { name: 'assessment-log.mjs --self-test', expectExit: 0 },
   { name: 'build-cv-html.mjs --test', expectExit: 0 },
+  { name: 'jd-skill-gap.mjs --self-test', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
   { name: 'agent-inbox-tests.mjs', expectExit: 0 },

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -156,6 +156,7 @@ const SYSTEM_PATHS = [
   'classify-tier.mjs',
   'scan-ats-full.mjs',
   'match-star.mjs',
+  'jd-skill-gap.mjs',
   'prepare-application.mjs',
   'providers/',
   'seeds/',


### PR DESCRIPTION
Closes #1558.

## What this does

Adds `jd-skill-gap.mjs`: a zero-LLM script that regex-extracts a JD's explicit skill/requirement tokens (from Requirements/Qualifications/Must-have/Preferred sections) and classifies each one against `cv.md` into three buckets:

- `existing` — already a named skill in cv.md's Skills section
- `supportedByResume` — not a named skill, but appears in cv.md's prose elsewhere (word-boundary match, so "Java" never matches inside "JavaScript")
- `gap` — the JD requires it, cv.md has no trace of it anywhere

Nothing is ever auto-added to `cv.md` — the tool only classifies and reports, per this project's "keywords get reformulated, never fabricated" rule.

CLI matches `match-star.mjs` (#1230) conventions exactly: `node jd-skill-gap.mjs <jd-file> [--summary]`, plus `node jd-skill-gap.mjs --self-test` with inline fixtures (fake JD for "Fabrikam Inc.", fake cv.md — placeholder names only).

## Integration

Wired into `modes/pdf.md` as a new Step 4, before any drafting begins:
- Writes the JD to a scratch file if needed, runs the check, and requires the agent to tell the user explicitly which skills are real gaps before generating the CV — never silently paper over one.
- The competency grid step (now Step 12) is updated to prioritize `existing`/`supportedByResume` skills from Step 4 and never draw from `gap`.
- The final report step (now Step 19) includes any unaddressed gaps.
- All subsequent steps renumbered by 1 to make room.

## Other changes

- Registered `jd-skill-gap.mjs` in `update-system.mjs`'s `SYSTEM_PATHS` (system-layer script, ships on `update-system.mjs apply`) and confirmed via `node validate-system-paths-coverage.mjs`.
- Added `{ name: 'jd-skill-gap.mjs --self-test', expectExit: 0 }` to `test-all.mjs`, matching `process-quality.mjs`'s registration style.
- Added a one-line Main Files table row to both `AGENTS.md` and `CLAUDE.md`.

## Design credit (not a code port)

The three-way classification is inspired by the skill-verification pattern in [srbhr/Resume-Matcher](https://github.com/srbhr/Resume-Matcher) (Apache-2.0) — specifically their four-way `verify_skill_target_plan()` split (`existing` / `jd_added` / `supported_by_resume` / `unsupported`). This PR folds their `jd_added` and `unsupported` into a single `gap` bucket, since career-ops never auto-adds a claim to `cv.md` either way — the distinction only matters if a tool is allowed to add something automatically, which this one deliberately isn't.

This is an independent reimplementation, not a code port: different language, zero LLM calls (their version is LLM-assisted), and adapted to reuse this repo's own regex/classification conventions (`match-star.mjs`). Crediting the source of the underlying idea since it's the right thing to do.

## Test plan

- [x] `node jd-skill-gap.mjs --self-test` — 7/7 passed
- [x] `node validate-system-paths-coverage.mjs` — OK, 558 tracked files covered
- [x] `node test-all.mjs --quick` — 1182 passed, 0 failed, 1 pre-existing warning (`cv-sync-check.mjs exited with error (expected without user data)` — expected in a workspace with no `cv.md`, unrelated to this change)

No real company names, people's names, or personal job-search details were used anywhere in code, comments, tests, or this description — placeholder names only (Fabrikam Inc., etc.), matching the issue's own draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an offline skill-gap checker that compares job description requirements with the CV.
  - Categorizes skills as existing, supported by the CV, or missing.
  - Supports formatted summaries, JSON output, input validation, and self-testing.

- **Improvements**
  - CV generation workflows now surface skill gaps before drafting and avoid adding unsupported claims.
  - Final reports include unresolved skill gaps.
  - Clarified PDF report-number handling for reliable CV-to-report tracking.

- **Tests**
  - Added the skill-gap checker to the comprehensive script test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->