### PR TITLE
docs(modes): add field-tested scan/apply cautions

### DIFF
--- a/modes/apply.md
+++ b/modes/apply.md
@@ -211,3 +211,15 @@ Field-tested across ~12 Playwright-driven applications (Ashby, Greenhouse, Lever
 - **Symptom:** Country, university, or field-of-study dropdowns contain thousands of `<option>` entries. Snapshotting them floods context and stalls the agent.
 - **Agent:** Use `select_option` directly by value or visible label. Never snapshot the full option list. If the exact label is unknown, ask the candidate for the value instead of dumping options into context.
 - **Candidate:** Provides the correct label when the agent cannot infer it from `config/profile.yml`.
+
+### Job-board host ≠ application host — re-check the URL after "Apply"
+
+- **Symptom:** The posting is discovered on one ATS, but clicking **Apply** hands off to a *different* ATS for the actual form. Enterprise career sites (commonly Phenom-, iCIMS-, or Radancy-hosted) frequently redirect into a Workday, Greenhouse, or SmartRecruiters application flow. Choosing fill tactics from the *board* URL applies the wrong quirks.
+- **Agent:** After the Step 5 preflight, follow the Apply button/redirect and read the URL of the page that actually renders the form fields. Match your fill tactics to *that* host — not the board the job was discovered on. A `myworkdayjobs.com` handoff in particular means the Workday quirk below applies.
+- **Candidate:** Confirms the destination page looks like the right company/role before the agent starts filling.
+
+### Workday — set-value doesn't register on React fields
+
+- **Symptom:** Setting a Workday text field's value programmatically (without real keystrokes) leaves it visually filled but empty to Workday's validation — the React `onChange` never fires, so Save throws "required" on a visibly-filled field. Yes/No dropdowns also vary their option order per question, so a positional click can select the wrong answer (e.g. "No" on *are you authorized to work?*).
+- **Agent:** For required text fields, **type** real keystrokes (focus → select-all → type), or verify each value registered before Save. Survey the whole step top-to-bottom first (the address block is often below the fold) and fill from the candidate's saved profile (`config/profile.yml` / `cv.md`) proactively, rather than discovering fields via validation errors. For dropdowns, use **type-ahead** (open → type the option text → confirm the highlight) instead of positional clicks, and verify each selection.
+- **Candidate:** Reviews the filled step — especially work-authorization/sponsorship dropdowns and any EEO/legal attestations — before Save/Submit.

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -141,9 +141,13 @@ For companies with a public API or structured feed **that are not in `local_pars
 - `workday`: `jobPostings[]`/`jobPostings` (based on tenant) → `title`, `externalPath` or URL built from the host
 - `breezy`: top-level array `[]` → `name`, `url` (absolute), `location.name` (or city/state/country + `is_remote`), `published_date`
 
+> **Caution — do not infer absence from a truncated read.** Careers SPAs paginate and lazy-load; a `browser_snapshot` or WebFetch of the page (and any LLM summary of that HTML) can silently drop rows, showing only the first screen of roles. Never conclude "role X is not posted" or "only N roles exist" from such a read. When the company has a public ATS API, hit it directly (append `?content=true` where the provider supports it) before making any presence/absence claim — the API returns the full board in one structured response.
+
 ### Level 3 — WebSearch Queries (BROAD DISCOVERY)
 
 The `search_queries` with `site:` filters cover portals transversally (all Ashby, all Greenhouse, etc.). Useful for discovering NEW companies that are not yet in `tracked_companies`, but results might be outdated. After filtering out hits from companies in `local_parser_ok`, the remaining results are deduplicated with Levels 0–2.
+
+> **Caution — Level-3 hits can be weeks stale.** WebSearch is fed by a search index that lags the live board, so a result can describe a posting that has already closed. Treat every Level-3 hit as unverified: before adding it to `data/pipeline.md` or evaluating it, confirm liveness against the real posting (`node check-liveness.mjs <url>` for ATS-hosted pages, or Playwright for non-ATS pages). Unlike the real-time ATS responses in Level 2, a Level-3 snippet is never proof a role is still open.
 
 **Execution Priority:**
 1. Level 0: Local Parser → companies with a configured `parser:` and existing script; build `local_parser_ok`


### PR DESCRIPTION
Closes #1560

## What
Docs-only. Four field-tested cautions distilled from real scan/apply runs:

**`modes/scan.md`**
- **Level 2 caution** — don't infer a role's absence from a truncated SPA/WebFetch read; hit the ATS API (`?content=true` where supported) for any presence/absence claim.
- **Level 3 caution** — treat WebSearch hits as unverified (search-index lag); confirm liveness (`node check-liveness.mjs <url>`, or Playwright for non-ATS pages) before adding to `data/pipeline.md` or evaluating.

**`modes/apply.md` — Known ATS Quirks**
- **Job-board host ≠ application host** — re-check the URL after "Apply"; Phenom/iCIMS/Radancy boards commonly redirect to Workday/Greenhouse/SmartRecruiters.
- **Workday — set-value doesn't fire React `onChange`** — type real keystrokes for required fields; use type-ahead for order-varying Yes/No dropdowns; survey the whole step first.

## Why
Each is a silent failure that produces a wrong result rather than an error: a fabricated "not posted," a dead posting queued as live, the wrong fill adapter, or a "required" error on a visibly-filled field. The Workday entry also fills a gap — the quirks section had no Workday coverage despite the shipped `providers/workday.mjs`.

## Scope / safety
- **Docs-only** — no code, config, or behavior changes (+16 lines across 2 files).
- No new dependencies. Fully consistent with the existing zero-token / API-first scan philosophy.
- `test-all.mjs`: doc/mode-existence tests pass; the diff introduces no new failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Known ATS Quirks” guidance for handling apply redirects when the job host differs from the application form host.
  * Added Workday-specific tips for avoiding false “filled” fields that fail validation, including real typing/type-ahead and confirming critical attestations before submission.

* **Bug Fixes**
  * Strengthened scan cautions against missing job presence due to truncated/partial SPA-cached reads.
  * Clarified that Level 3 results can be stale/expired and must be liveness-verified before use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->