### PR TITLE
Use CSS page setup for PDF margins

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -194,7 +194,8 @@ export function repoRelativeManifestPath(pathValue) {
 }
 
 export function injectPrintPageCss(html, format = 'a4') {
-  const pageSize = format === 'letter' ? 'Letter' : 'A4';
+  const normalizedFormat = String(format || 'a4').toLowerCase();
+  const pageSize = normalizedFormat === 'letter' ? 'Letter' : 'A4';
   const pageStyle = `<style id="career-ops-page-setup">\n@page { size: ${pageSize}; margin: ${PDF_PAGE_MARGIN}; }\n</style>`;
 
   if (/<\/head>/i.test(html)) {

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -23,6 +23,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { randomUUID } from 'node:crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const PDF_PAGE_MARGIN = '0.6in';
 
 // Ensure output directory exists (fresh setup)
 mkdirSync(resolve(__dirname, 'output'), { recursive: true });
@@ -190,6 +191,21 @@ export function repoRelativeManifestPath(pathValue) {
   const rel = relative(__dirname, resolve(pathValue));
   if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) return '';
   return rel.split(sep).join('/');
+}
+
+export function injectPrintPageCss(html, format = 'a4') {
+  const pageSize = format === 'letter' ? 'Letter' : 'A4';
+  const pageStyle = `<style id="career-ops-page-setup">\n@page { size: ${pageSize}; margin: ${PDF_PAGE_MARGIN}; }\n</style>`;
+
+  if (/<\/head>/i.test(html)) {
+    return html.replace(/<\/head>/i, `${pageStyle}\n</head>`);
+  }
+
+  if (/<html\b[^>]*>/i.test(html)) {
+    return html.replace(/<html\b[^>]*>/i, match => `${match}\n<head>\n${pageStyle}\n</head>`);
+  }
+
+  return `${pageStyle}\n${html}`;
 }
 
 /**
@@ -378,6 +394,7 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
 
   mkdirSync(dirname(outputPath), { recursive: true });
 
+  html = injectPrintPageCss(html, format);
   html = await inlineLocalFonts(html);
 
   // Write HTML to a temp file in baseDir so page.goto() gives a file://
@@ -400,15 +417,14 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
 
     // Generate PDF
     const pdfBuffer = await page.pdf({
-      format: format,
       printBackground: true,
       margin: {
-        top: '0.6in',
-        right: '0.6in',
-        bottom: '0.6in',
-        left: '0.6in',
+        top: '0',
+        right: '0',
+        bottom: '0',
+        left: '0',
       },
-      preferCSSPageSize: false,
+      preferCSSPageSize: true,
     });
 
     // Write PDF

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -807,7 +807,7 @@ if (generatePdfScript.includes('opts.reportNum') && generatePdfScript.includes('
   fail('renderHtmlToPdf does not read manifest metadata from opts');
 }
 try {
-  const { repoRelativeManifestPath } = await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
+  const { repoRelativeManifestPath, injectPrintPageCss } = await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
   const insideHtmlPath = join(ROOT, 'templates', 'cv-template.html');
   const outsideHtmlPath = join(dirname(ROOT), 'outside-cv-template.html');
 
@@ -821,6 +821,45 @@ try {
     pass('PDF manifest leaves HTML column blank when source HTML is missing or outside the repo');
   } else {
     fail('PDF manifest mishandles missing or external source HTML paths');
+  }
+
+  const injectedPageCss = injectPrintPageCss('<html><head><title>CV</title></head><body></body></html>', 'letter');
+  if (
+    injectedPageCss.includes('@page { size: Letter; margin: 0.6in; }') &&
+    injectedPageCss.indexOf('career-ops-page-setup') < injectedPageCss.indexOf('</head>')
+  ) {
+    pass('PDF renderer injects CSS page size and margins before rendering');
+  } else {
+    fail('PDF renderer does not inject CSS page size/margins into the document head');
+  }
+
+  const doctypeNoHead = injectPrintPageCss('<!doctype html><html lang="en"><body></body></html>');
+  if (
+    doctypeNoHead.startsWith('<!doctype html>') &&
+    doctypeNoHead.includes('<html lang="en">\n<head>\n<style id="career-ops-page-setup">') &&
+    doctypeNoHead.indexOf('<head>') < doctypeNoHead.indexOf('<body>')
+  ) {
+    pass('PDF renderer preserves doctype when injecting page CSS into full HTML without head');
+  } else {
+    fail('PDF renderer may insert page CSS before doctype for full HTML without head');
+  }
+
+  const fragmentPageCss = injectPrintPageCss('<section>CV</section>');
+  if (fragmentPageCss.startsWith('<style id="career-ops-page-setup">')) {
+    pass('PDF renderer still prepends page CSS for HTML fragments');
+  } else {
+    fail('PDF renderer no longer handles HTML fragments with fallback CSS injection');
+  }
+
+  if (
+    generatePdfScript.includes('preferCSSPageSize: true') &&
+    generatePdfScript.includes("right: '0'") &&
+    generatePdfScript.includes('injectPrintPageCss(html, format)') &&
+    !/page\.pdf\(\{\s*format:/s.test(generatePdfScript)
+  ) {
+    pass('PDF renderer uses CSS @page margins instead of Playwright margins');
+  } else {
+    fail('PDF renderer may clip right-aligned content by ignoring CSS page sizing (#1341)');
   }
 } catch (e) {
   fail(`PDF manifest path helper test crashed: ${e.message}`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -833,6 +833,13 @@ try {
     fail('PDF renderer does not inject CSS page size/margins into the document head');
   }
 
+  const mixedCasePageCss = injectPrintPageCss('<html><head></head><body></body></html>', 'Letter');
+  if (mixedCasePageCss.includes('@page { size: Letter; margin: 0.6in; }')) {
+    pass('PDF renderer treats page format case-insensitively');
+  } else {
+    fail('PDF renderer falls back to A4 for mixed-case letter format');
+  }
+
   const doctypeNoHead = injectPrintPageCss('<!doctype html><html lang="en"><body></body></html>');
   if (
     doctypeNoHead.startsWith('<!doctype html>') &&


### PR DESCRIPTION
## Summary
- inject `@page` CSS for A4/Letter page size and 0.6in margins before PDF rendering
- switch Playwright PDF output to `preferCSSPageSize` with zero browser margins
- cover head/no-head/fragment HTML cases and remove the now-misleading `page.pdf({ format })` option

## Validation
- `node test-all.mjs --quick` (1182 passed, 0 failed, 2 warnings: expected no-user-data/archive reachability warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF exports now apply page size and margins using embedded print CSS, ensuring consistent output for both Letter and A4 layouts.

* **Bug Fixes**
  * Reduced the chance of right-side clipping during PDF generation by relying on document print styling for sizing.
  * Improved preparation of HTML inputs with or without a `<head>` element so print styling is injected reliably.

* **Tests**
  * Expanded automated checks to cover full HTML documents (with/without `<head>`) and HTML fragments, plus validation of CSS-based page sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->