### PR TITLE
Make updater timeout budgets configurable

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -849,6 +849,45 @@ if (updateSystemScript.includes("'CODEX.md'")) {
   fail('update-system does not preserve CODEX.md');
 }
 
+if (
+  updateSystemScript.includes('CAREER_OPS_GIT_TIMEOUT_MS') &&
+  updateSystemScript.includes('CAREER_OPS_GIT_FETCH_TIMEOUT_MS') &&
+  updateSystemScript.includes('CAREER_OPS_NPM_INSTALL_TIMEOUT_MS') &&
+  updateSystemScript.includes('CAREER_OPS_PLAYWRIGHT_INSTALL_TIMEOUT_MS') &&
+  updateSystemScript.includes('CAREER_OPS_DASHBOARD_REBUILD_TIMEOUT_MS') &&
+  /args\[0\]\s*===\s*['"]fetch['"]/.test(updateSystemScript) &&
+  /gitTimeoutEnvVar\(args\)/.test(updateSystemScript) &&
+  updateSystemScript.includes('timed out after') &&
+  updateSystemScript.includes('const timeout = reexecTimeoutMs()') &&
+  updateSystemScript.includes('Updater self-reexec timed out after')
+) {
+  pass('update-system gives fetch/reexec/install/build configurable timeouts with readable failures');
+} else {
+  fail('update-system still risks hardcoded timeout failures (#1393)');
+}
+
+try {
+  const { gitTimeoutMs, reexecTimeoutMs } = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+  const fetchTimeout = gitTimeoutMs(['fetch']);
+  const gitCommandTimeout = gitTimeoutMs(['checkout']);
+  const updatePathCount = 100;
+  const minimumReexecBudget = fetchTimeout + gitCommandTimeout * 3 + updatePathCount * 5000 + 60000 + 120000 + 60000 + 60000;
+
+  if (gitTimeoutMs(['fetch']) > gitTimeoutMs(['checkout'])) {
+    pass('update-system gives fetch a larger timeout than ordinary git commands');
+  } else {
+    fail('update-system fetch timeout is not larger than ordinary git command timeout');
+  }
+
+  if (reexecTimeoutMs(updatePathCount) >= minimumReexecBudget) {
+    pass('update-system sizes self-reexec timeout for downstream fetch/git/install/rebuild work');
+  } else {
+    fail('update-system self-reexec timeout budget is too small for downstream apply work');
+  }
+} catch (e) {
+  fail(`update-system timeout helper test crashed: ${e.message}`);
+}
+
 // ── 8. MODE FILE INTEGRITY ──────────────────────────────────────
 
 console.log('\n8. Mode file integrity');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -849,29 +849,34 @@ if (updateSystemScript.includes("'CODEX.md'")) {
   fail('update-system does not preserve CODEX.md');
 }
 
-if (
-  updateSystemScript.includes('CAREER_OPS_GIT_TIMEOUT_MS') &&
-  updateSystemScript.includes('CAREER_OPS_GIT_FETCH_TIMEOUT_MS') &&
-  updateSystemScript.includes('CAREER_OPS_NPM_INSTALL_TIMEOUT_MS') &&
-  updateSystemScript.includes('CAREER_OPS_PLAYWRIGHT_INSTALL_TIMEOUT_MS') &&
-  updateSystemScript.includes('CAREER_OPS_DASHBOARD_REBUILD_TIMEOUT_MS') &&
-  /args\[0\]\s*===\s*['"]fetch['"]/.test(updateSystemScript) &&
-  /gitTimeoutEnvVar\(args\)/.test(updateSystemScript) &&
-  updateSystemScript.includes('timed out after') &&
-  updateSystemScript.includes('const timeout = reexecTimeoutMs()') &&
-  updateSystemScript.includes('Updater self-reexec timed out after')
-) {
-  pass('update-system gives fetch/reexec/install/build configurable timeouts with readable failures');
-} else {
-  fail('update-system still risks hardcoded timeout failures (#1393)');
-}
-
 try {
-  const { gitTimeoutMs, reexecTimeoutMs } = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
+  const {
+    DASHBOARD_REBUILD_TIMEOUT_MS,
+    NPM_INSTALL_TIMEOUT_MS,
+    PLAYWRIGHT_INSTALL_TIMEOUT_MS,
+    REEXEC_BUFFER_TIMEOUT_MS,
+    UPDATE_PATH_CHECKOUT_BUDGET_MS,
+    gitTimeoutMs,
+    parsePositiveInt,
+    reexecTimeoutMs,
+  } = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
   const fetchTimeout = gitTimeoutMs(['fetch']);
   const gitCommandTimeout = gitTimeoutMs(['checkout']);
   const updatePathCount = 100;
-  const minimumReexecBudget = fetchTimeout + gitCommandTimeout * 3 + updatePathCount * 5000 + 60000 + 120000 + 60000 + 60000;
+  const minimumReexecBudget =
+    fetchTimeout +
+    gitCommandTimeout * 3 +
+    updatePathCount * UPDATE_PATH_CHECKOUT_BUDGET_MS +
+    NPM_INSTALL_TIMEOUT_MS +
+    PLAYWRIGHT_INSTALL_TIMEOUT_MS +
+    DASHBOARD_REBUILD_TIMEOUT_MS +
+    REEXEC_BUFFER_TIMEOUT_MS;
+
+  if (parsePositiveInt('42', 7) === 42 && parsePositiveInt('-1', 7) === 7 && parsePositiveInt('nope', 7) === 7) {
+    pass('update-system timeout parser accepts only positive integer overrides');
+  } else {
+    fail('update-system timeout parser does not preserve fallback semantics');
+  }
 
   if (gitTimeoutMs(['fetch']) > gitTimeoutMs(['checkout'])) {
     pass('update-system gives fetch a larger timeout than ordinary git commands');

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -38,15 +38,16 @@ const RELEASES_API = 'https://api.github.com/repos/santifer/career-ops/releases/
 // Anchoring on `(?:^|-)` lets the releases-API fallback parse our tags,
 // which Release Please always prefixes with the component name.
 export const SEMVER_RE = /(?:^|-)v?(\d+\.\d+\.\d+)$/i;
-const DEFAULT_GIT_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_GIT_TIMEOUT_MS, 30000);
-const DEFAULT_GIT_FETCH_TIMEOUT_MS = parsePositiveInt(
+export const DEFAULT_GIT_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_GIT_TIMEOUT_MS, 30000);
+export const DEFAULT_GIT_FETCH_TIMEOUT_MS = parsePositiveInt(
   process.env.CAREER_OPS_GIT_FETCH_TIMEOUT_MS,
   Math.max(DEFAULT_GIT_TIMEOUT_MS, 300000),
 );
-const NPM_INSTALL_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_NPM_INSTALL_TIMEOUT_MS, 60000);
-const PLAYWRIGHT_INSTALL_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_PLAYWRIGHT_INSTALL_TIMEOUT_MS, 120000);
-const DASHBOARD_REBUILD_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_DASHBOARD_REBUILD_TIMEOUT_MS, 60000);
-const UPDATE_PATH_CHECKOUT_BUDGET_MS = parsePositiveInt(process.env.CAREER_OPS_UPDATE_PATH_CHECKOUT_BUDGET_MS, 5000);
+export const NPM_INSTALL_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_NPM_INSTALL_TIMEOUT_MS, 60000);
+export const PLAYWRIGHT_INSTALL_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_PLAYWRIGHT_INSTALL_TIMEOUT_MS, 120000);
+export const DASHBOARD_REBUILD_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_DASHBOARD_REBUILD_TIMEOUT_MS, 60000);
+export const UPDATE_PATH_CHECKOUT_BUDGET_MS = parsePositiveInt(process.env.CAREER_OPS_UPDATE_PATH_CHECKOUT_BUDGET_MS, 5000);
+export const REEXEC_BUFFER_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_REEXEC_BUFFER_TIMEOUT_MS, 60000);
 
 // System layer paths — ONLY these files get updated
 const SYSTEM_PATHS = [
@@ -344,7 +345,7 @@ export function reexecTimeoutMs(updatePathCount = SYSTEM_PATHS.length + BOOTSTRA
       NPM_INSTALL_TIMEOUT_MS +
       PLAYWRIGHT_INSTALL_TIMEOUT_MS +
       DASHBOARD_REBUILD_TIMEOUT_MS +
-      60000,
+      REEXEC_BUFFER_TIMEOUT_MS,
   );
 }
 
@@ -693,6 +694,7 @@ async function apply() {
     git('fetch', CANONICAL_REPO, 'main');
 
     if (!isReexec) {
+      const timeout = reexecTimeoutMs();
       try {
         // The re-exec runs the TARGET updater, so every local module it imports
         // at load time must exist first. Resolve the fetched update-system.mjs's
@@ -700,7 +702,6 @@ async function apply() {
         // new top-level import can't reintroduce the self-reexec crash (#1245).
         const reexecFiles = resolveReexecCheckout('FETCH_HEAD', 'update-system.mjs');
         git('checkout', 'FETCH_HEAD', '--', ...reexecFiles);
-        const timeout = reexecTimeoutMs();
         execFileSync(process.execPath, ['update-system.mjs', 'apply'], {
           cwd: ROOT,
           stdio: 'inherit',
@@ -714,7 +715,7 @@ async function apply() {
         return;
       } catch (err) {
         if (isTimeoutLikeError(err)) {
-          console.error(`Updater self-reexec timed out after ${timeoutSeconds(reexecTimeoutMs())}s.`);
+          console.error(`Updater self-reexec timed out after ${timeoutSeconds(timeout)}s.`);
           throw err;
         }
         console.error(`Updater self-reexec failed: ${err.message}`);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -38,6 +38,15 @@ const RELEASES_API = 'https://api.github.com/repos/santifer/career-ops/releases/
 // Anchoring on `(?:^|-)` lets the releases-API fallback parse our tags,
 // which Release Please always prefixes with the component name.
 export const SEMVER_RE = /(?:^|-)v?(\d+\.\d+\.\d+)$/i;
+const DEFAULT_GIT_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_GIT_TIMEOUT_MS, 30000);
+const DEFAULT_GIT_FETCH_TIMEOUT_MS = parsePositiveInt(
+  process.env.CAREER_OPS_GIT_FETCH_TIMEOUT_MS,
+  Math.max(DEFAULT_GIT_TIMEOUT_MS, 300000),
+);
+const NPM_INSTALL_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_NPM_INSTALL_TIMEOUT_MS, 60000);
+const PLAYWRIGHT_INSTALL_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_PLAYWRIGHT_INSTALL_TIMEOUT_MS, 120000);
+const DASHBOARD_REBUILD_TIMEOUT_MS = parsePositiveInt(process.env.CAREER_OPS_DASHBOARD_REBUILD_TIMEOUT_MS, 60000);
+const UPDATE_PATH_CHECKOUT_BUDGET_MS = parsePositiveInt(process.env.CAREER_OPS_UPDATE_PATH_CHECKOUT_BUDGET_MS, 5000);
 
 // System layer paths — ONLY these files get updated
 const SYSTEM_PATHS = [
@@ -217,6 +226,34 @@ const SYSTEM_PATHS = [
   'config/plugins.example.yml',
 ];
 
+const BOOTSTRAP_PATHS = [
+  '.agents/',
+  '.opencode/skills/',
+  '.antigravitycli/skills/',
+  '.grok/skills/',
+  '.kimi/skills/',
+  'providers/',
+  'liveness-browser.mjs',
+  'tracker-links.mjs',
+  'role-matcher.mjs',
+  'tracker-utils.mjs',
+  'tracker-parse.mjs',
+  'scaffolder/',
+  'reserve-report-num.mjs',
+  'updater-migration-tests.mjs',
+  'validate-portals.mjs',
+  'tracker-columns-tests.mjs',
+  'plugins/',
+  'plugins.mjs',
+  'plugins-registry.json',
+  'plugin-install.mjs',
+  'plugin-audit.mjs',
+  'validate-plugin-registry.mjs',
+  'config/plugins.example.yml',
+  'agent-inbox.mjs',
+  'agent-inbox-tests.mjs',
+];
+
 // User layer paths — NEVER touch these (safety check)
 const USER_PATHS = [
   'cv.md',
@@ -289,8 +326,54 @@ function newestBackupBranch(branches) {
   return timestamped[0]?.branch || branchList[0];
 }
 
+export function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value || ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function gitTimeoutMs(args) {
+  return args[0] === 'fetch' ? DEFAULT_GIT_FETCH_TIMEOUT_MS : DEFAULT_GIT_TIMEOUT_MS;
+}
+
+export function reexecTimeoutMs(updatePathCount = SYSTEM_PATHS.length + BOOTSTRAP_PATHS.length) {
+  return Math.max(
+    120000,
+    DEFAULT_GIT_FETCH_TIMEOUT_MS +
+      DEFAULT_GIT_TIMEOUT_MS * 3 +
+      UPDATE_PATH_CHECKOUT_BUDGET_MS * Math.max(0, updatePathCount) +
+      NPM_INSTALL_TIMEOUT_MS +
+      PLAYWRIGHT_INSTALL_TIMEOUT_MS +
+      DASHBOARD_REBUILD_TIMEOUT_MS +
+      60000,
+  );
+}
+
+function describeGitCommand(args) {
+  return `git ${args.join(' ')}`;
+}
+
+function isTimeoutLikeError(err) {
+  return err?.code === 'ETIMEDOUT' || err?.signal === 'SIGTERM';
+}
+
+function timeoutSeconds(timeout) {
+  return Math.round(timeout / 1000);
+}
+
+function gitTimeoutEnvVar(args) {
+  return args[0] === 'fetch' ? 'CAREER_OPS_GIT_FETCH_TIMEOUT_MS' : 'CAREER_OPS_GIT_TIMEOUT_MS';
+}
+
 function gitIn(root, ...args) {
-  return execFileSync('git', args, { cwd: root, encoding: 'utf-8', timeout: 30000 }).trim();
+  const timeout = gitTimeoutMs(args);
+  try {
+    return execFileSync('git', args, { cwd: root, encoding: 'utf-8', timeout }).trim();
+  } catch (err) {
+    if (isTimeoutLikeError(err)) {
+      throw new Error(`${describeGitCommand(args)} timed out after ${timeoutSeconds(timeout)}s. If your network is slow, retry or set ${gitTimeoutEnvVar(args)} to a larger value.`);
+    }
+    throw err;
+  }
 }
 
 function git(...args) {
@@ -454,7 +537,7 @@ function rebuildDashboardBinaryIfNeeded() {
   try {
     execFileSync('go', ['build', '-o', 'career-dashboard', '.'], {
       cwd: join(ROOT, 'dashboard'),
-      timeout: 60000,
+      timeout: DASHBOARD_REBUILD_TIMEOUT_MS,
       stdio: 'pipe',
     });
     console.log('dashboard binary rebuilt');
@@ -617,10 +700,11 @@ async function apply() {
         // new top-level import can't reintroduce the self-reexec crash (#1245).
         const reexecFiles = resolveReexecCheckout('FETCH_HEAD', 'update-system.mjs');
         git('checkout', 'FETCH_HEAD', '--', ...reexecFiles);
+        const timeout = reexecTimeoutMs();
         execFileSync(process.execPath, ['update-system.mjs', 'apply'], {
           cwd: ROOT,
           stdio: 'inherit',
-          timeout: 120000,
+          timeout,
           env: {
             ...process.env,
             CAREER_OPS_UPDATE_REEXEC: '1',
@@ -629,6 +713,10 @@ async function apply() {
         });
         return;
       } catch (err) {
+        if (isTimeoutLikeError(err)) {
+          console.error(`Updater self-reexec timed out after ${timeoutSeconds(reexecTimeoutMs())}s.`);
+          throw err;
+        }
         console.error(`Updater self-reexec failed: ${err.message}`);
         throw err;
       }
@@ -648,7 +736,6 @@ async function apply() {
 
     // 3a. Keep bootstrap paths as a fallback for very old targets, but the
     // target updater's SYSTEM_PATHS is now the source of truth for new files.
-    const BOOTSTRAP_PATHS = ['.agents/', '.opencode/skills/', '.antigravitycli/skills/', '.grok/skills/', '.kimi/skills/', 'providers/', 'liveness-browser.mjs', 'tracker-links.mjs', 'role-matcher.mjs', 'tracker-utils.mjs', 'tracker-parse.mjs', 'scaffolder/', 'reserve-report-num.mjs', 'updater-migration-tests.mjs', 'validate-portals.mjs', 'tracker-columns-tests.mjs', 'plugins/', 'plugins.mjs', 'plugins-registry.json', 'plugin-install.mjs', 'plugin-audit.mjs', 'validate-plugin-registry.mjs', 'config/plugins.example.yml', 'agent-inbox.mjs', 'agent-inbox-tests.mjs'];
     const updatePaths = mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS);
 
     for (const path of updatePaths) {
@@ -737,14 +824,14 @@ async function apply() {
 
     // 5. Install any new dependencies
     try {
-      execSync('npm install --silent', { cwd: ROOT, timeout: 60000 });
+      execSync('npm install --silent', { cwd: ROOT, timeout: NPM_INSTALL_TIMEOUT_MS });
     } catch {
       console.log('npm install skipped (may need manual run)');
     }
 
     // 5b. Ensure Playwright browser binary is up to date after npm install
     try {
-      execSync('npx playwright install chromium', { cwd: ROOT, timeout: 120000, stdio: 'ignore' });
+      execSync('npx playwright install chromium', { cwd: ROOT, timeout: PLAYWRIGHT_INSTALL_TIMEOUT_MS, stdio: 'ignore' });
     } catch {
       console.log('playwright install skipped (run manually: npx playwright install chromium)');
     }


### PR DESCRIPTION
## Summary
- make git, fetch, npm install, Playwright install, dashboard rebuild, and update-path checkout timeout budgets configurable
- give git fetch and self-reexec more realistic budgets with clearer timeout errors
- size self-reexec around downstream update work instead of a fixed 120s cap

## Validation
- `node test-all.mjs --quick` (1183 passed, 0 failed, 1 warning: expected no-user-data check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updater operations now use configurable, environment-driven timeout settings for git, package installation, browser installation, and dashboard rebuild steps.
  * Self re-exec now uses a dynamically calculated timeout to better support larger updates.

* **Bug Fixes**
  * Timeout-related failures are detected more reliably and reported with clearer, timeout-specific messaging.

* **Tests**
  * Added coverage for timeout parsing and calculation to ensure override validation and computed timeout budgets behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->