### PR TITLE
feat(web): inbox triage — Abundance → Triage → Shortlist → Opt-in Score

### DIFF
--- a/web/src/components/inbox/facet-chips.tsx
+++ b/web/src/components/inbox/facet-chips.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+import type { AtsSource } from "@/lib/explore";
+import { ATS_LABEL } from "@/lib/explore";
+import { FRESHNESS_WINDOWS, SENIORITY_LABEL, type Seniority } from "@/lib/inbox";
+import { CostBadge } from "@/components/cost/cost-badge";
+import { cn } from "@/lib/cn";
+
+// Free, client-side facets over the raw firehose — 0 tokens, instant. Mirrors the
+// Explore chip language so the two surfaces read as one system. On mobile the chip
+// row scrolls INSIDE its own container (never the page).
+export function FacetChips({
+  within,
+  setWithin,
+  sources,
+  toggleSource,
+  seniorities,
+  toggleSeniority,
+  locQ,
+  setLocQ,
+  kw,
+  setKw,
+  availSources,
+  availSeniorities,
+  resultCount,
+  totalCount,
+  anyActive,
+  onClear,
+}: {
+  within: number | null;
+  setWithin: (d: number | null) => void;
+  sources: Set<AtsSource>;
+  toggleSource: (s: AtsSource) => void;
+  seniorities: Set<Seniority>;
+  toggleSeniority: (s: Seniority) => void;
+  locQ: string;
+  setLocQ: (v: string) => void;
+  kw: string;
+  setKw: (v: string) => void;
+  availSources: AtsSource[];
+  availSeniorities: Seniority[];
+  resultCount: number;
+  totalCount: number;
+  anyActive: boolean;
+  onClear: () => void;
+}) {
+  return (
+    <div className="space-y-2.5">
+      {/* keyword search + live count */}
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-faint" />
+          <input
+            value={kw}
+            onChange={(e) => setKw(e.target.value)}
+            placeholder="Filter by company or role…"
+            className="w-full rounded-lg border border-border bg-surface/60 py-2 pl-9 pr-3 text-sm outline-none transition-colors placeholder:text-faint focus:border-brand/50 focus-visible:ring-2 focus-visible:ring-brand/40 max-sm:min-h-[44px]"
+          />
+        </div>
+        <span className="shrink-0 text-xs text-muted">
+          <span className="tabular-nums text-foreground">{resultCount}</span>
+          <span className="text-faint">/{totalCount}</span>
+        </span>
+      </div>
+
+      {/* chip row — desktop wraps, mobile scrolls inside the container */}
+      <div className="flex items-center gap-2 overflow-x-auto pb-1 sm:flex-wrap sm:overflow-visible sm:pb-0">
+        {/* freshness (single-select segmented; click active to clear) */}
+        <div className="inline-flex shrink-0 rounded-lg border border-border bg-surface/40 p-0.5">
+          {FRESHNESS_WINDOWS.map((w) => (
+            <button
+              key={w.days}
+              type="button"
+              onClick={() => setWithin(within === w.days ? null : w.days)}
+              className={cn(
+                "rounded-md px-2.5 text-xs font-medium transition-colors max-sm:min-h-[40px]",
+                within === w.days ? "bg-brand-soft text-brand" : "text-muted hover:text-foreground",
+              )}
+            >
+              {w.label}
+            </button>
+          ))}
+        </div>
+
+        {availSources.map((s) => (
+          <Pill key={s} on={sources.has(s)} onClick={() => toggleSource(s)}>
+            {ATS_LABEL[s]}
+          </Pill>
+        ))}
+
+        {availSeniorities.map((s) => (
+          <Pill key={s} on={seniorities.has(s)} onClick={() => toggleSeniority(s)}>
+            {SENIORITY_LABEL[s]}
+          </Pill>
+        ))}
+
+        {/* location contains */}
+        <input
+          value={locQ}
+          onChange={(e) => setLocQ(e.target.value)}
+          placeholder="location…"
+          className="w-28 shrink-0 rounded-full border border-border bg-surface/40 px-3 text-xs outline-none transition-colors placeholder:text-faint focus:border-brand/40 max-sm:min-h-[40px] py-1"
+        />
+
+        {anyActive && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="inline-flex shrink-0 items-center gap-1 rounded-full px-2 text-xs text-faint transition-colors hover:text-foreground max-sm:min-h-[40px]"
+          >
+            <X className="size-3" /> Clear
+          </button>
+        )}
+
+        <span className="ml-auto hidden shrink-0 items-center gap-1.5 pl-2 sm:inline-flex">
+          <CostBadge kind="free" size="xs" />
+          <span className="text-[11px] text-faint">filtering is free</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function Pill({ on, onClick, children }: { on: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "shrink-0 rounded-full border px-2.5 text-xs font-medium transition-colors max-sm:min-h-[40px]",
+        on ? "border-brand/40 bg-brand-soft text-brand" : "border-border text-muted hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/web/src/components/inbox/facet-chips.tsx
+++ b/web/src/components/inbox/facet-chips.tsx
@@ -74,7 +74,7 @@ export function FacetChips({
               type="button"
               onClick={() => setWithin(within === w.days ? null : w.days)}
               className={cn(
-                "rounded-md px-2.5 text-xs font-medium transition-colors max-sm:min-h-[40px]",
+                "rounded-md px-2.5 text-xs font-medium transition-colors max-sm:min-h-[44px]",
                 within === w.days ? "bg-brand-soft text-brand" : "text-muted hover:text-foreground",
               )}
             >
@@ -100,23 +100,25 @@ export function FacetChips({
           value={locQ}
           onChange={(e) => setLocQ(e.target.value)}
           placeholder="location…"
-          className="w-28 shrink-0 rounded-full border border-border bg-surface/40 px-3 text-xs outline-none transition-colors placeholder:text-faint focus:border-brand/40 max-sm:min-h-[40px] py-1"
+          className="w-28 shrink-0 rounded-full border border-border bg-surface/40 px-3 text-xs outline-none transition-colors placeholder:text-faint focus:border-brand/40 max-sm:min-h-[44px] py-1"
         />
 
         {anyActive && (
           <button
             type="button"
             onClick={onClear}
-            className="inline-flex shrink-0 items-center gap-1 rounded-full px-2 text-xs text-faint transition-colors hover:text-foreground max-sm:min-h-[40px]"
+            className="inline-flex shrink-0 items-center gap-1 rounded-full px-2 text-xs text-faint transition-colors hover:text-foreground max-sm:min-h-[44px]"
           >
             <X className="size-3" /> Clear
           </button>
         )}
+      </div>
 
-        <span className="ml-auto hidden shrink-0 items-center gap-1.5 pl-2 sm:inline-flex">
-          <CostBadge kind="free" size="xs" />
-          <span className="text-[11px] text-faint">filtering is free</span>
-        </span>
+      {/* Token-honesty is bidirectional: the "free" reassurance is as always-visible
+          as the tray's "spend" cue (mobile + desktop) — never desktop-only. */}
+      <div className="flex items-center gap-1.5">
+        <CostBadge kind="free" size="xs" />
+        <span className="text-[11px] text-faint">Filtering is free — only scoring uses tokens.</span>
       </div>
     </div>
   );
@@ -128,7 +130,7 @@ function Pill({ on, onClick, children }: { on: boolean; onClick: () => void; chi
       type="button"
       onClick={onClick}
       className={cn(
-        "shrink-0 rounded-full border px-2.5 text-xs font-medium transition-colors max-sm:min-h-[40px]",
+        "shrink-0 rounded-full border px-2.5 text-xs font-medium transition-colors max-sm:min-h-[44px]",
         on ? "border-brand/40 bg-brand-soft text-brand" : "border-border text-muted hover:text-foreground",
       )}
     >

--- a/web/src/components/inbox/inbox-triage.tsx
+++ b/web/src/components/inbox/inbox-triage.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Undo2 } from "lucide-react";
+import { useJobs } from "@/components/jobs/job-store";
+import type { InboxJob } from "@/lib/career-ops";
+import type { AtsSource } from "@/lib/explore";
+import { ATS_SOURCES } from "@/lib/explore";
+import { daysSince, seniorityFromTitle, sourceFromUrl, SENIORITY_ORDER, type Seniority } from "@/lib/inbox";
+import { FacetChips } from "./facet-chips";
+import { TriageRow, type RowScore } from "./triage-row";
+import { ShortlistTray, type ShortItem } from "./shortlist-tray";
+import { cn } from "@/lib/cn";
+
+const SHORTLIST_KEY = "career-ops:shortlist";
+const HIDDEN_KEY = "career-ops:hidden";
+const CONFIG_KEY = "career-ops:config";
+const BATCH = 20;
+
+// The inbox as a TRIAGE surface: Abundance → Triage → Shortlist → Opt-in Score.
+// Default is a small fresh batch (never the full wall); free facets + Save/Skip narrow
+// it; only "Score shortlist" spends tokens. 🔴 The shell is agnostic to what makes a
+// role relevant — order is freshness with a single documented plug point.
+export function InboxTriage({ inbox }: { inbox: InboxJob[] }) {
+  const { jobs, startJob } = useJobs();
+
+  // facets
+  const [within, setWithin] = useState<number | null>(null);
+  const [sources, setSources] = useState<Set<AtsSource>>(() => new Set());
+  const [seniorities, setSeniorities] = useState<Set<Seniority>>(() => new Set());
+  const [locQ, setLocQ] = useState("");
+  const [kw, setKw] = useState("");
+  const [showAll, setShowAll] = useState(false);
+
+  // persisted triage state + ephemeral selection/undo
+  const [shortlist, setShortlist] = useState<ShortItem[]>([]);
+  const [hidden, setHidden] = useState<string[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+  const [undo, setUndo] = useState<{ label: string; fn: () => void } | null>(null);
+  const [hasCli, setHasCli] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    try {
+      const s = localStorage.getItem(SHORTLIST_KEY);
+      if (s) setShortlist(JSON.parse(s));
+      const h = localStorage.getItem(HIDDEN_KEY);
+      if (h) setHidden(JSON.parse(h));
+      const c = localStorage.getItem(CONFIG_KEY);
+      setHasCli(!!(c && JSON.parse(c).cliId));
+    } catch {
+      /* ignore */
+    }
+    setLoaded(true);
+  }, []);
+  useEffect(() => {
+    if (loaded) try { localStorage.setItem(SHORTLIST_KEY, JSON.stringify(shortlist)); } catch { /* quota */ }
+  }, [shortlist, loaded]);
+  useEffect(() => {
+    if (loaded) try { localStorage.setItem(HIDDEN_KEY, JSON.stringify(hidden)); } catch { /* quota */ }
+  }, [hidden, loaded]);
+  // auto-dismiss the undo toast
+  useEffect(() => {
+    if (!undo) return;
+    const t = setTimeout(() => setUndo(null), 5000);
+    return () => clearTimeout(t);
+  }, [undo]);
+
+  // stable "now" for freshness (per mount)
+  const now = useMemo(() => Date.now(), []);
+
+  // Dedupe by URL — pipeline.md can list the same posting twice; it's one job, so it
+  // triages once (and Save/Skip/score, all keyed by URL, act on it coherently).
+  const enriched = useMemo(() => {
+    const seen = new Set<string>();
+    const out: { job: InboxJob; source: AtsSource | null; seniority: Seniority | null; age: number | null }[] = [];
+    for (const job of inbox) {
+      if (seen.has(job.url)) continue;
+      seen.add(job.url);
+      out.push({ job, source: sourceFromUrl(job.url), seniority: seniorityFromTitle(job.role), age: daysSince(job.postedAt, now) });
+    }
+    return out;
+  }, [inbox, now]);
+
+  // EVALUADA lookup: the latest evaluate worker per posting URL (running → badge).
+  const scoreByUrl = useMemo(() => {
+    const best = new Map<string, (typeof jobs)[number]>();
+    for (const j of jobs) {
+      if (!j.input || j.kind !== "evaluate") continue;
+      const ex = best.get(j.input);
+      if (!ex || j.startedAt > ex.startedAt) best.set(j.input, j);
+    }
+    const m = new Map<string, RowScore>();
+    for (const [url, j] of best) {
+      m.set(url, { score: j.result?.score ?? null, tone: j.result?.tone ?? "muted", jobId: j.id, running: j.status === "running" });
+    }
+    return m;
+  }, [jobs]);
+
+  // facet options — only surface what's actually present in the (non-hidden) data
+  const availSources = useMemo(() => {
+    const set = new Set<AtsSource>();
+    for (const e of enriched) if (e.source && !hidden.includes(e.job.url)) set.add(e.source);
+    return ATS_SOURCES.filter((s) => set.has(s));
+  }, [enriched, hidden]);
+  const availSeniorities = useMemo(() => {
+    const set = new Set<Seniority>();
+    for (const e of enriched) if (e.seniority && !hidden.includes(e.job.url)) set.add(e.seniority);
+    return SENIORITY_ORDER.filter((s) => set.has(s));
+  }, [enriched, hidden]);
+
+  const filtered = useMemo(
+    () =>
+      enriched.filter((e) => {
+        if (hidden.includes(e.job.url)) return false;
+        if (within != null && (e.age == null || e.age > within)) return false;
+        if (sources.size && (!e.source || !sources.has(e.source))) return false;
+        if (seniorities.size && (!e.seniority || !seniorities.has(e.seniority))) return false;
+        if (locQ.trim() && !(e.job.location || "").toLowerCase().includes(locQ.trim().toLowerCase())) return false;
+        if (kw.trim() && !`${e.job.company} ${e.job.role}`.toLowerCase().includes(kw.trim().toLowerCase())) return false;
+        return true;
+      }),
+    [enriched, hidden, within, sources, seniorities, locQ, kw],
+  );
+
+  // 🔴 SINGLE ORDER PLUG POINT — freshness only (newest first_seen first; unknown last).
+  // A smarter ranker replaces ONLY this comparator; facets/triage/shortlist/score never
+  // touch relevance. This is the whole firewall in one line.
+  const ordered = useMemo(() => [...filtered].sort((a, b) => (a.age ?? Infinity) - (b.age ?? Infinity)), [filtered]);
+
+  const anyFacet = within != null || sources.size > 0 || seniorities.size > 0 || locQ.trim() !== "" || kw.trim() !== "";
+  const capped = !showAll && !anyFacet;
+  const visible = capped ? ordered.slice(0, BATCH) : ordered;
+  const hiddenCount = hidden.length;
+
+  const isShortlisted = (url: string) => shortlist.some((s) => s.url === url);
+
+  const save = (job: InboxJob) => {
+    if (isShortlisted(job.url)) return;
+    setShortlist((s) => [...s, { url: job.url, company: job.company, role: job.role }]);
+  };
+  const skip = (job: InboxJob) => {
+    setHidden((h) => (h.includes(job.url) ? h : [...h, job.url]));
+    setUndo({ label: `Skipped ${job.company}`, fn: () => setHidden((h) => h.filter((u) => u !== job.url)) });
+  };
+  const toggleSelect = (url: string) =>
+    setSelected((s) => {
+      const n = new Set(s);
+      if (n.has(url)) n.delete(url);
+      else n.add(url);
+      return n;
+    });
+  const saveSelected = () => {
+    const add = enriched
+      .filter((e) => selected.has(e.job.url) && !isShortlisted(e.job.url))
+      .map((e) => ({ url: e.job.url, company: e.job.company, role: e.job.role }));
+    if (add.length) setShortlist((s) => [...s, ...add]);
+    setSelected(new Set());
+  };
+
+  const estimate = useMemo(() => {
+    const samples = jobs.filter((j) => j.kind === "evaluate" && j.status === "done" && j.cost?.tokens).map((j) => j.cost!);
+    if (!samples.length || shortlist.length === 0) return {};
+    const avgT = samples.reduce((a, c) => a + c.tokens, 0) / samples.length;
+    const usds = samples.filter((s) => s.usd != null).map((s) => s.usd!);
+    const avgUsd = usds.length ? usds.reduce((a, c) => a + c, 0) / usds.length : undefined;
+    return { tokens: Math.round(avgT * shortlist.length), usd: avgUsd != null ? +(avgUsd * shortlist.length).toFixed(2) : undefined };
+  }, [jobs, shortlist.length]);
+
+  const scoreShortlist = () => {
+    const batchId = `shortlist-${Date.now()}`;
+    for (const it of shortlist) {
+      startJob({ title: `Score · ${it.company}`, subtitle: it.role, kind: "evaluate", input: it.url, page: "/pipeline", batchId });
+    }
+    setShortlist([]); // sent — the rows flip to Scoring… → badge via scoreByUrl
+  };
+
+  // The parent (PipelineView) renders the rich empty-inbox card; here we always
+  // have ≥1 raw posting.
+  if (inbox.length === 0) return null;
+
+  return (
+    <div className={cn("mx-auto mt-4 max-w-3xl", shortlist.length > 0 && "pb-28 sm:pb-24")}>
+      <FacetChips
+        within={within}
+        setWithin={setWithin}
+        sources={sources}
+        toggleSource={(s) => setSources((set) => { const n = new Set(set); n.has(s) ? n.delete(s) : n.add(s); return n; })}
+        seniorities={seniorities}
+        toggleSeniority={(s) => setSeniorities((set) => { const n = new Set(set); n.has(s) ? n.delete(s) : n.add(s); return n; })}
+        locQ={locQ}
+        setLocQ={setLocQ}
+        kw={kw}
+        setKw={setKw}
+        availSources={availSources}
+        availSeniorities={availSeniorities}
+        resultCount={filtered.length}
+        totalCount={enriched.length - hiddenCount}
+        anyActive={anyFacet}
+        onClear={() => { setWithin(null); setSources(new Set()); setSeniorities(new Set()); setLocQ(""); setKw(""); }}
+      />
+
+      {/* batch header: fresh slice by default, or the full filtered set */}
+      <div className="mt-4 flex items-baseline justify-between gap-3">
+        <p className="text-sm font-medium text-foreground">
+          {capped ? "Fresh — worth a look" : anyFacet ? `${filtered.length} match${filtered.length === 1 ? "" : "es"}` : "All roles"}
+        </p>
+        {hiddenCount > 0 && (
+          <button type="button" onClick={() => setHidden([])} className="text-xs text-faint transition-colors hover:text-foreground">
+            {hiddenCount} hidden · restore
+          </button>
+        )}
+      </div>
+
+      {/* multi-select action bar */}
+      {selected.size > 0 && (
+        <div className="mt-2 flex items-center gap-3 rounded-lg border border-brand/30 bg-brand-soft px-3 py-2 text-sm">
+          <span className="font-medium text-brand tabular-nums">{selected.size} selected</span>
+          <button type="button" onClick={saveSelected} className="rounded-md bg-brand px-2.5 py-1 text-xs font-medium text-brand-foreground max-sm:min-h-[44px]">
+            Save to shortlist
+          </button>
+          <button type="button" onClick={() => setSelected(new Set())} className="text-xs text-muted hover:text-foreground max-sm:min-h-[44px]">
+            Clear
+          </button>
+        </div>
+      )}
+
+      {visible.length > 0 ? (
+        <ul className="mt-3 divide-y divide-border overflow-hidden rounded-2xl border border-border bg-surface/40">
+          {visible.map((e) => (
+            <TriageRow
+              key={e.job.url}
+              job={e.job}
+              source={e.source}
+              age={e.age}
+              scored={scoreByUrl.get(e.job.url)}
+              selected={selected.has(e.job.url)}
+              shortlisted={isShortlisted(e.job.url)}
+              onToggleSelect={() => toggleSelect(e.job.url)}
+              onSave={() => save(e.job)}
+              onSkip={() => skip(e.job)}
+            />
+          ))}
+        </ul>
+      ) : (
+        <div className="mt-3 rounded-2xl border border-dashed border-border bg-surface/30 px-6 py-10 text-center">
+          <p className="font-display text-lg">No matches</p>
+          <p className="mx-auto mt-1 max-w-sm text-sm text-muted">Loosen the filters to see more of your inbox.</p>
+        </div>
+      )}
+
+      {/* "See all N" — only when the fresh batch is capping a larger list */}
+      {capped && ordered.length > BATCH && (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="mt-3 inline-flex w-full items-center justify-center gap-1 rounded-xl border border-border bg-surface/40 py-2.5 text-sm font-medium text-muted transition-colors hover:border-brand/40 hover:text-brand max-sm:min-h-[44px]"
+        >
+          See all {ordered.length} in inbox →
+        </button>
+      )}
+
+      {/* empty-shortlist guidance (only once there's nothing saved) */}
+      {shortlist.length === 0 && (
+        <p className="mt-4 text-center text-xs text-faint">Save roles worth a look, then score them together — one token spend.</p>
+      )}
+
+      {/* undo toast (sits above the tray) */}
+      {undo && (
+        <div className={cn("fixed inset-x-0 z-40 flex justify-center px-4", shortlist.length > 0 ? "bottom-24 sm:bottom-24" : "bottom-6")}>
+          <div className="inline-flex items-center gap-3 rounded-full border border-border bg-surface px-4 py-2 text-sm shadow-lg">
+            <span className="text-muted">{undo.label}</span>
+            <button type="button" onClick={() => { undo.fn(); setUndo(null); }} className="inline-flex items-center gap-1 font-medium text-brand max-sm:min-h-[44px]">
+              <Undo2 className="size-3.5" /> Undo
+            </button>
+          </div>
+        </div>
+      )}
+
+      <ShortlistTray
+        items={shortlist}
+        estimate={estimate}
+        hasCli={hasCli}
+        onRemove={(url) => setShortlist((s) => s.filter((x) => x.url !== url))}
+        onClear={() => setShortlist([])}
+        onScore={scoreShortlist}
+      />
+    </div>
+  );
+}

--- a/web/src/components/inbox/shortlist-tray.tsx
+++ b/web/src/components/inbox/shortlist-tray.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ChevronDown, Coins, Settings, Sparkles, X } from "lucide-react";
+import { CompanyLogo } from "@/components/company-logo";
+import { CostBadge } from "@/components/cost/cost-badge";
+import { cn } from "@/lib/cn";
+
+export type ShortItem = { url: string; company: string; role: string };
+
+function fmtTokens(t: number): string {
+  if (t >= 1_000_000) return `${(t / 1_000_000).toFixed(1)}M`;
+  if (t >= 1_000) return `${Math.round(t / 1_000)}k`;
+  return `${t}`;
+}
+
+// The persistent shortlist tray — bottom-sheet on mobile (thumb-zone), floating card
+// on desktop. "Score shortlist" is the ONLY token spend in the whole inbox: cost is
+// shown BEFORE the click and gated behind an explicit confirm (never spend by surprise).
+export function ShortlistTray({
+  items,
+  estimate,
+  hasCli,
+  onRemove,
+  onClear,
+  onScore,
+}: {
+  items: ShortItem[];
+  estimate: { tokens?: number; usd?: number };
+  hasCli: boolean;
+  onRemove: (url: string) => void;
+  onClear: () => void;
+  onScore: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  if (items.length === 0) return null;
+
+  const n = items.length;
+  const costText = estimate.tokens
+    ? `≈ ${fmtTokens(estimate.tokens)} tokens${estimate.usd != null ? ` · ≈ $${estimate.usd.toFixed(2)}` : ""}`
+    : "uses your tokens";
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-30 sm:bottom-4">
+      <div className="mx-auto max-w-3xl sm:px-6">
+        <div className="border-t border-border bg-surface shadow-lg shadow-black/10 sm:rounded-2xl sm:border">
+          {/* expandable saved-items list */}
+          {open && (
+            <ul className="max-h-64 divide-y divide-border overflow-y-auto px-3 py-1">
+              {items.map((it) => (
+                <li key={it.url} className="flex items-center gap-2.5 py-2">
+                  <CompanyLogo name={it.company} size={18} />
+                  <span className="min-w-0 flex-1 truncate text-sm">
+                    <span className="font-medium">{it.company}</span> <span className="text-muted">· {it.role}</span>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onRemove(it.url)}
+                    aria-label={`Remove ${it.company}`}
+                    className="inline-flex items-center justify-center rounded-md p-1 text-faint transition-colors hover:text-foreground max-sm:min-h-[44px] max-sm:min-w-[44px]"
+                  >
+                    <X className="size-4" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* the persistent bar */}
+          <div className="flex items-center gap-3 px-3 py-2.5 sm:px-4">
+            <button
+              type="button"
+              onClick={() => setOpen((v) => !v)}
+              className="inline-flex items-center gap-1.5 text-sm font-medium max-sm:min-h-[44px]"
+            >
+              <ChevronDown className={cn("size-4 text-muted transition-transform", open && "rotate-180")} />
+              Shortlist <span className="tabular-nums text-brand">({n})</span>
+            </button>
+
+            {open && (
+              <button type="button" onClick={onClear} className="text-xs text-faint transition-colors hover:text-foreground max-sm:min-h-[44px]">
+                Clear
+              </button>
+            )}
+
+            <div className="ml-auto flex items-center gap-2">
+              {!confirming ? (
+                <button
+                  type="button"
+                  onClick={() => setConfirming(true)}
+                  className="inline-flex items-center gap-2 rounded-full bg-brand px-4 py-2 text-sm font-medium text-brand-foreground transition-colors hover:bg-brand-200 max-sm:min-h-[44px]"
+                >
+                  <Sparkles className="size-4" />
+                  <span>Score {n}</span>
+                  <span className="hidden text-xs font-normal text-brand-foreground/80 sm:inline">· {costText}</span>
+                </button>
+              ) : (
+                <ConfirmScore n={n} costText={costText} hasCli={hasCli} onCancel={() => setConfirming(false)} onConfirm={() => { setConfirming(false); onScore(); }} />
+              )}
+            </div>
+          </div>
+
+          {/* cost line — always visible on mobile (where it doesn't fit in the button) */}
+          <div className="flex items-center gap-2 border-t border-border/60 px-3 py-1.5 text-[11px] text-muted sm:hidden">
+            <CostBadge kind="spend" size="xs" />
+            <span>{costText} — the only step that spends</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConfirmScore({
+  n,
+  costText,
+  hasCli,
+  onCancel,
+  onConfirm,
+}: {
+  n: number;
+  costText: string;
+  hasCli: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  if (!hasCli) {
+    return (
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-muted">No AI configured.</span>
+        <Link href="/config" className="inline-flex items-center gap-1 rounded-full border border-brand/40 bg-brand-soft px-3 py-1.5 font-medium text-brand max-sm:min-h-[44px]">
+          <Settings className="size-3.5" /> Set up
+        </Link>
+        <button type="button" onClick={onCancel} className="text-faint hover:text-foreground max-sm:min-h-[44px]">
+          Cancel
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <span className="hidden items-center gap-1 text-[11px] text-muted sm:inline-flex">
+        <Coins className="size-3.5 text-brand" /> {costText}
+      </span>
+      <button
+        type="button"
+        onClick={onConfirm}
+        className="inline-flex items-center gap-1.5 rounded-full bg-brand px-4 py-2 text-sm font-medium text-brand-foreground transition-colors hover:bg-brand-200 max-sm:min-h-[44px]"
+      >
+        Score {n} now
+      </button>
+      <button type="button" onClick={onCancel} className="rounded-full px-2 py-2 text-xs text-faint transition-colors hover:text-foreground max-sm:min-h-[44px]">
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/inbox/triage-row.tsx
+++ b/web/src/components/inbox/triage-row.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { Bookmark, BookmarkCheck, Loader2, X } from "lucide-react";
+import type { InboxJob } from "@/lib/career-ops";
+import type { AtsSource } from "@/lib/explore";
+import { ATS_LABEL } from "@/lib/explore";
+import { Badge } from "@/components/ui/badge";
+import { CompanyLogo } from "@/components/company-logo";
+import { cn } from "@/lib/cn";
+
+export type RowScore = { score: number | null; tone: "good" | "warn" | "bad" | "muted"; jobId: string; running: boolean };
+
+function agoLabel(age: number | null): string | null {
+  if (age == null) return null;
+  if (age <= 0) return "today";
+  if (age === 1) return "yesterday";
+  if (age < 7) return `${age}d ago`;
+  if (age < 30) return `${Math.floor(age / 7)}w ago`;
+  return `${Math.floor(age / 30)}mo ago`;
+}
+
+// One raw posting in the triage list. Shows ONLY cheap, free signals + an honest
+// "not scored" (CRUDA) — never a fake match%. Once its shortlist eval finishes it
+// flips to EVALUADA (a real A–F badge). Save→shortlist / Skip→hidden are free + undoable.
+export function TriageRow({
+  job,
+  source,
+  age,
+  scored,
+  selected,
+  shortlisted,
+  onToggleSelect,
+  onSave,
+  onSkip,
+}: {
+  job: InboxJob;
+  source: AtsSource | null;
+  age: number | null;
+  scored?: RowScore;
+  selected: boolean;
+  shortlisted: boolean;
+  onToggleSelect: () => void;
+  onSave: () => void;
+  onSkip: () => void;
+}) {
+  const ago = agoLabel(age);
+  const evaluated = !!scored && (scored.running || scored.score != null);
+
+  return (
+    <li
+      className={cn(
+        "flex items-center gap-2.5 px-3 py-2.5 transition-colors sm:gap-3 sm:px-4",
+        selected ? "bg-brand-soft/50" : "hover:bg-surface-hover",
+        evaluated && "opacity-95",
+      )}
+    >
+      {/* multi-select — power-user batch to shortlist */}
+      <input
+        type="checkbox"
+        checked={selected}
+        onChange={onToggleSelect}
+        aria-label={`Select ${job.company} ${job.role}`}
+        className="size-4 shrink-0 accent-brand max-sm:min-h-[44px] max-sm:min-w-[24px]"
+      />
+
+      <CompanyLogo name={job.company} size={20} />
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm">
+          <span className="font-medium text-foreground">{job.company}</span>
+          <span className="text-muted"> · {job.role}</span>
+        </p>
+        <p className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-faint">
+          {job.location && <span className="truncate">{job.location}</span>}
+          {source && <span className="rounded bg-surface-hover px-1 py-px font-medium text-muted">{ATS_LABEL[source]}</span>}
+          {ago && <span>{ago}</span>}
+          {/* 🔴 CRUDA: honest "not scored" — no fabricated match%. */}
+          {!evaluated && <span className="italic text-faint/80">not scored</span>}
+        </p>
+      </div>
+
+      {/* EVALUADA state (right-aligned, visually distinct from raw rows) */}
+      {evaluated ? (
+        <Link href={`/jobs/${scored!.jobId}`} className="flex shrink-0 items-center gap-1.5 text-xs">
+          {scored!.running ? (
+            <>
+              <Loader2 className="size-3.5 animate-spin text-brand" />
+              <span className="text-brand max-sm:hidden">Scoring…</span>
+            </>
+          ) : (
+            <Badge tone={scored!.tone}>{scored!.score}/5</Badge>
+          )}
+        </Link>
+      ) : (
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={onSave}
+            title={shortlisted ? "In your shortlist" : "Save to shortlist"}
+            aria-pressed={shortlisted}
+            className={cn(
+              "inline-flex items-center justify-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors max-sm:min-h-[44px] max-sm:min-w-[44px]",
+              shortlisted ? "text-brand" : "text-muted hover:bg-surface-hover hover:text-brand",
+            )}
+          >
+            {shortlisted ? <BookmarkCheck className="size-4" /> : <Bookmark className="size-4" />}
+            <span className="max-sm:hidden">{shortlisted ? "Saved" : "Save"}</span>
+          </button>
+          <button
+            type="button"
+            onClick={onSkip}
+            title="Skip — hide from the inbox"
+            className="inline-flex items-center justify-center rounded-md p-1 text-faint transition-colors hover:bg-surface-hover hover:text-foreground max-sm:min-h-[44px] max-sm:min-w-[44px]"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}

--- a/web/src/components/pipeline-view.tsx
+++ b/web/src/components/pipeline-view.tsx
@@ -3,16 +3,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Search, ExternalLink, ChevronsUpDown, Sparkles, Loader2, X, Compass, ArrowRight } from "lucide-react";
+import { Search, ChevronsUpDown, X, Compass, ArrowRight } from "lucide-react";
 import type { Application, InboxJob } from "@/lib/career-ops";
 import { Badge } from "@/components/ui/badge";
-import { CostBadge } from "@/components/cost/cost-badge";
-import { useJobs } from "@/components/jobs/job-store";
 import { CompanyLogo } from "@/components/company-logo";
 import { canonStatus, scoreNum, scoreTone, statusDot } from "@/lib/format";
+import { InboxTriage } from "@/components/inbox/inbox-triage";
 import { cn } from "@/lib/cn";
 
-// INBOX (the action queue) is the default tab; the rest filter the tracker.
+// INBOX (the triage queue) is the default tab; the rest filter the tracker.
 const TABS = [
   "INBOX",
   "ALL",
@@ -37,7 +36,6 @@ export function PipelineView({
   applications: Application[];
   inbox: InboxJob[];
 }) {
-  const { jobs, startJob } = useJobs();
   const params = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -78,38 +76,18 @@ export function PipelineView({
     [params, router, pathname],
   );
 
-  const pendingInbox = useMemo(() => inbox.filter((j) => !j.done), [inbox]);
-
-  // Link each inbox posting to its worker (by URL) so the row can show
-  // Evaluate → Evaluating… → processed·score.
-  const jobByUrl = useMemo(() => {
-    const m = new Map<string, (typeof jobs)[number]>();
-    for (const j of jobs) {
-      if (!j.input || j.kind === "research") continue;
-      const ex = m.get(j.input);
-      if (!ex || j.startedAt > ex.startedAt) m.set(j.input, j);
+  // Pending + deduped by URL (pipeline.md can list the same posting twice) so the
+  // header count, the tab count and the triage list all agree on one number.
+  const pendingInbox = useMemo(() => {
+    const seen = new Set<string>();
+    const out: InboxJob[] = [];
+    for (const j of inbox) {
+      if (j.done || seen.has(j.url)) continue;
+      seen.add(j.url);
+      out.push(j);
     }
-    return m;
-  }, [jobs]);
-
-  const processedCount = useMemo(
-    () => pendingInbox.filter((j) => jobByUrl.get(j.url)?.status === "done").length,
-    [pendingInbox, jobByUrl],
-  );
-
-  const filteredInbox = useMemo(() => {
-    let list = pendingInbox;
-    if (q.trim()) {
-      const needle = q.toLowerCase();
-      list = list.filter((j) => `${j.company} ${j.role}`.toLowerCase().includes(needle));
-    }
-    // processed (done) rows sink to the bottom — the inbox drains toward processed
-    return [...list].sort((a, b) => {
-      const pa = jobByUrl.get(a.url)?.status === "done" ? 1 : 0;
-      const pb = jobByUrl.get(b.url)?.status === "done" ? 1 : 0;
-      return pa - pb;
-    });
-  }, [pendingInbox, q, jobByUrl]);
+    return out;
+  }, [inbox]);
 
   const filtered = useMemo(() => {
     if (tab === "INBOX") return [];
@@ -143,25 +121,22 @@ export function PipelineView({
         <div>
           <h1 className="font-display text-2xl tracking-tight text-landing">Pipeline</h1>
           <p className="mt-1 text-sm text-muted">
-            <span className="tabular-nums">{pendingInbox.length - processedCount}</span> in inbox
-            {processedCount > 0 && (
-              <>
-                {" "}
-                · <span className="tabular-nums text-brand">{processedCount}</span> processed
-              </>
-            )}{" "}
-            · <span className="tabular-nums">{applications.length}</span> tracked
+            <span className="tabular-nums">{pendingInbox.length}</span> in inbox ·{" "}
+            <span className="tabular-nums">{applications.length}</span> tracked
           </p>
         </div>
-        <div className="relative w-64 max-w-[40vw]">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-faint" />
-          <input
-            value={q}
-            onChange={(e) => setQ(e.target.value)}
-            placeholder="Search company or role…"
-            className="w-full rounded-md border border-border bg-surface/60 py-2 pl-9 pr-3 text-sm outline-none transition-colors placeholder:text-faint focus:border-brand/50 focus-visible:ring-2 focus-visible:ring-brand/40"
-          />
-        </div>
+        {/* the tracker has its own search; the inbox brings its own facet filters */}
+        {tab !== "INBOX" && (
+          <div className="relative w-64 max-w-[40vw]">
+            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-faint" />
+            <input
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="Search company or role…"
+              className="w-full rounded-md border border-border bg-surface/60 py-2 pl-9 pr-3 text-sm outline-none transition-colors placeholder:text-faint focus:border-brand/50 focus-visible:ring-2 focus-visible:ring-brand/40"
+            />
+          </div>
+        )}
       </div>
 
       {/* tabs */}
@@ -169,7 +144,7 @@ export function PipelineView({
         {TABS.map((t) => {
           const count =
             t === "INBOX"
-              ? pendingInbox.length - processedCount
+              ? pendingInbox.length
               : t === "ALL"
                 ? applications.length
                 : applications.filter((r) => canonStatus(r.status).includes(t)).length;
@@ -206,80 +181,11 @@ export function PipelineView({
       )}
 
       {tab === "INBOX" ? (
-        /* ── Inbox: the action queue with worker triggers ── */
-        filteredInbox.length > 0 ? (
-          <>
-          {/* Cost cue ONCE for the whole inbox, not per row — teaches the free/
-              spend boundary (Explore's model) without stacking brand badges. */}
-          <p className="mt-4 flex items-center gap-1.5 px-1 text-xs text-faint">
-            <CostBadge kind="spend" size="xs" /> Evaluating a role runs your AI — the scan that filled this inbox was free.
-          </p>
-          <ul className="mt-2 divide-y divide-border overflow-hidden rounded-2xl border border-border bg-surface/40">
-            {filteredInbox.slice(0, 60).map((j, i) => {
-              const job = jobByUrl.get(j.url);
-              const processed = job?.status === "done";
-              const launch = () =>
-                startJob({ title: `Evaluate · ${j.company}`, subtitle: j.role, kind: "evaluate", input: j.url, page: "/pipeline" });
-              return (
-                <li
-                  key={`${j.url}-${i}`}
-                  className={cn(
-                    "flex items-center justify-between gap-4 px-4 py-2.5 transition-colors hover:bg-surface-hover",
-                    processed && "opacity-60",
-                  )}
-                >
-                  <div className="flex min-w-0 items-center gap-2.5">
-                    <CompanyLogo name={j.company} size={20} />
-                    <span className="shrink-0 text-sm font-medium">{j.company}</span>
-                    <span className="truncate text-sm text-muted">{j.role}</span>
-                    {j.location && <span className="hidden shrink-0 text-xs text-faint sm:inline">· {j.location}</span>}
-                    {j.compensation && <span className="hidden shrink-0 text-xs font-medium text-muted sm:inline">· {j.compensation}</span>}
-                  </div>
-                  <div className="flex shrink-0 items-center gap-1.5">
-                    {job?.status === "running" ? (
-                      <Link
-                        href={`/jobs/${job.id}`}
-                        className="inline-flex items-center gap-1.5 text-xs font-medium text-brand"
-                      >
-                        <Loader2 className="size-3.5 animate-spin" /> Evaluating…
-                      </Link>
-                    ) : job?.status === "done" ? (
-                      <Link href={`/jobs/${job.id}`} className="inline-flex items-center gap-1.5 text-xs">
-                        {job.result?.score != null && <Badge tone={job.result.tone}>{job.result.score}/5</Badge>}
-                        <span className="text-faint">processed</span>
-                      </Link>
-                    ) : job?.status === "error" ? (
-                      <button type="button" onClick={launch} className="text-xs text-red-400 transition-colors hover:underline">
-                        Retry
-                      </button>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={launch}
-                        className="inline-flex items-center justify-center gap-1 rounded-md px-2 py-1 text-xs text-muted transition-colors hover:bg-surface-hover hover:text-brand max-sm:min-h-[44px] max-sm:min-w-[44px]"
-                        title="Evaluate this posting — spins up a worker on your CLI"
-                      >
-                        <Sparkles className="size-3.5" />
-                        <span className="hidden sm:inline">Evaluate</span>
-                      </button>
-                    )}
-                    <a
-                      href={j.url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="inline-flex items-center justify-center rounded-md p-1 text-faint transition-colors hover:text-brand max-sm:min-h-[44px] max-sm:min-w-[44px]"
-                      aria-label={`Open ${j.company} posting`}
-                    >
-                      <ExternalLink className="size-4" />
-                    </a>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-          </>
+        /* ── Inbox: the triage surface (Abundance → Triage → Shortlist → Score) ── */
+        pendingInbox.length > 0 ? (
+          <InboxTriage inbox={pendingInbox} />
         ) : (
-          <InboxEmpty count={pendingInbox.length} filtered={q.trim().length > 0} />
+          <InboxEmpty count={0} filtered={false} />
         )
       ) : filtered.length > 0 ? (
         /* ── Tracker table ── */

--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -44,7 +44,7 @@ function read(rel: string): string | null {
   }
 }
 
-export type InboxJob = { url: string; company: string; role: string; location?: string; compensation?: string; done: boolean };
+export type InboxJob = { url: string; company: string; role: string; location?: string; compensation?: string; done: boolean; postedAt?: string };
 
 /** Parse data/pipeline.md — `- [ ] URL | Company | Role [| Location [| Compensation]]`.
  *  Positional split (NOT a greedy trailing group): the optional 4th `location`
@@ -69,6 +69,32 @@ export function readInbox(): InboxJob[] {
     });
   }
   return jobs;
+}
+
+/**
+ * Read data/scan-history.tsv → Map<url, first_seen(YYYY-MM-DD)>. The scanner
+ * already stamps every discovered posting with the date it was first seen
+ * (col 2), so we derive the inbox's freshness signal here WITHOUT touching the
+ * core (see the inbox-triage build: freshness = option A, no scanner change).
+ * Tolerant by construction: no file → empty map (freshness facet just hides);
+ * a malformed row is skipped, never thrown (missing ≠ corrupt).
+ */
+export function readScanDates(): Map<string, string> {
+  const tsv = read("data/scan-history.tsv");
+  const dates = new Map<string, string>();
+  if (!tsv) return dates;
+  const lines = tsv.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line || (i === 0 && line.startsWith("url\t"))) continue; // skip header
+    const tab = line.indexOf("\t");
+    if (tab < 1) continue;
+    const url = line.slice(0, tab);
+    const firstSeen = line.slice(tab + 1).split("\t")[0]?.trim();
+    // keep the EARLIEST first_seen if a url recurs (it's "first" seen, after all)
+    if (/^\d{4}-\d{2}-\d{2}$/.test(firstSeen) && !dates.has(url)) dates.set(url, firstSeen);
+  }
+  return dates;
 }
 
 export type Application = {
@@ -162,10 +188,13 @@ export type PipelineSummary = {
 
 export function pipelineSummary(): PipelineSummary {
   const root = careerOpsRoot();
+  const scanDates = readScanDates();
   return {
     root,
     rootExists: fs.existsSync(root),
-    inbox: readInbox(),
+    // join the freshness date (first_seen) onto each raw posting — the inbox's
+    // triage view orders/faceted-filters on it entirely client-side.
+    inbox: readInbox().map((j) => ({ ...j, postedAt: scanDates.get(j.url) })),
     applications: readApplications(),
   };
 }

--- a/web/src/lib/inbox.ts
+++ b/web/src/lib/inbox.ts
@@ -1,0 +1,65 @@
+// Pure, client-side derivations for the inbox triage view. Every signal here is
+// FREE — parsed from data the raw posting already carries (URL host, title text,
+// first_seen date). 🔴 None of this ranks or scores relevance; it only labels and
+// buckets so the cheap facet filters can narrow the firehose with zero tokens.
+
+import type { AtsSource } from "@/lib/explore";
+
+/** Which ATS a posting lives on, derived from its URL host (0 tokens, no network). */
+export function sourceFromUrl(url: string): AtsSource | null {
+  let host = "";
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  if (host.includes("greenhouse.io")) return "greenhouse";
+  if (host.includes("lever.co")) return "lever";
+  if (host.includes("ashbyhq.com")) return "ashby";
+  if (host.includes("myworkdayjobs.com") || host.includes("workday")) return "workday";
+  return null;
+}
+
+// Coarse seniority buckets, detected from the title. Ordered senior→junior so the
+// facet chips read top-down; a title that matches nothing gets no tag (still shows,
+// just untagged). We only ever surface buckets that actually appear in the data.
+export type Seniority = "lead" | "staff" | "senior" | "mid" | "junior" | "intern";
+export const SENIORITY_ORDER: Seniority[] = ["lead", "staff", "senior", "mid", "junior", "intern"];
+export const SENIORITY_LABEL: Record<Seniority, string> = {
+  lead: "Lead / Mgr",
+  staff: "Staff+",
+  senior: "Senior",
+  mid: "Mid",
+  junior: "Junior",
+  intern: "Intern",
+};
+
+export function seniorityFromTitle(title: string): Seniority | null {
+  const t = ` ${title.toLowerCase()} `;
+  if (/\b(head|vp|vice president|director|chief|manager|mgr|lead)\b/.test(t)) return "lead";
+  if (/\b(staff|principal|distinguished|fellow|architect)\b/.test(t)) return "staff";
+  if (/\b(senior|sr\.?|snr)\b/.test(t)) return "senior";
+  if (/\b(junior|jr\.?|entry|graduate|associate)\b/.test(t)) return "junior";
+  if (/\b(intern|internship|working student|apprentice)\b/.test(t)) return "intern";
+  // an untagged IC role sits in the broad middle
+  if (/\b(engineer|developer|scientist|designer|analyst|manager|specialist|consultant)\b/.test(t)) return "mid";
+  return null;
+}
+
+/** Whole days between an ISO date (YYYY-MM-DD) and now; null if unparseable. */
+export function daysSince(iso: string | undefined, now: number): number | null {
+  if (!iso || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) return null;
+  const t = Date.parse(`${iso}T00:00:00Z`);
+  if (Number.isNaN(t)) return null;
+  return Math.floor((now - t) / 86_400_000);
+}
+
+// Freshness windows mirror the Explore "posted within" segmented control so the two
+// surfaces feel like one system. A posting passes a window if its age ≤ the window.
+export const FRESHNESS_WINDOWS = [
+  { label: "24h", days: 1 },
+  { label: "3d", days: 3 },
+  { label: "7d", days: 7 },
+  { label: "14d", days: 14 },
+  { label: "30d", days: 30 },
+] as const;

--- a/web/src/lib/inbox.ts
+++ b/web/src/lib/inbox.ts
@@ -5,7 +5,10 @@
 
 import type { AtsSource } from "@/lib/explore";
 
-/** Which ATS a posting lives on, derived from its URL host (0 tokens, no network). */
+/** Which ATS a posting lives on, derived from its URL host (0 tokens, no network).
+ *  Matches on the registrable domain anchored at a dot boundary (host === base OR
+ *  host ends with ".base") — never a bare substring, so "greenhouse.io.evil.com"
+ *  or "notlever.co" can't be misread as that ATS. */
 export function sourceFromUrl(url: string): AtsSource | null {
   let host = "";
   try {
@@ -13,10 +16,11 @@ export function sourceFromUrl(url: string): AtsSource | null {
   } catch {
     return null;
   }
-  if (host.includes("greenhouse.io")) return "greenhouse";
-  if (host.includes("lever.co")) return "lever";
-  if (host.includes("ashbyhq.com")) return "ashby";
-  if (host.includes("myworkdayjobs.com") || host.includes("workday")) return "workday";
+  const domainIs = (base: string) => host === base || host.endsWith(`.${base}`);
+  if (domainIs("greenhouse.io")) return "greenhouse";
+  if (domainIs("lever.co")) return "lever";
+  if (domainIs("ashbyhq.com")) return "ashby";
+  if (domainIs("myworkdayjobs.com") || domainIs("workday.com")) return "workday";
   return null;
 }
 


### PR DESCRIPTION
## What

Reframes the inbox from a **firehose wall** into a **triage surface** — implements career-ops-ux's spec (`inbox-triage-spec.md`, audit item **P1.7**). Turns token-anxiety into token-control.

**Flow:** default = a small **fresh batch** (never the full list) + `See all N →` · free **facets** (freshness / source / seniority / location / keyword — client-side, 0 tokens) narrow the firehose · per-item **Save → shortlist** / **Skip → hidden** (free, undo, multi-select) · a persistent **Shortlist tray** runs ONE action: **`Score shortlist · N · ~cost · [Score]`** — the *only* step that spends tokens, cost shown + explicit confirm.

**Token honesty:** raw rows show an honest **"not scored"** (CRUDA) — never a fabricated match%; once scored they flip to a real A–F badge (EVALUADA). Cost estimate is derived from your own past evaluations when available, else a qualitative "uses your tokens".

## How

- **Freshness = option A** (maintainer-decided, no core change): `readScanDates()` joins the `first_seen` date from `data/scan-history.tsv` web-side; `InboxJob.postedAt` populated in `pipelineSummary()`.
- **Source** derived from the URL host; **seniority** parsed from the title — all free, client-side (`lib/inbox.ts`).
- `components/inbox/`: `InboxTriage` (shell) + `FacetChips` + `TriageRow` + `ShortlistTray`. Reuses the Explore chip language + the `job-store` (Score = fan-out of `evaluate` workers under one `batchId`) + the `CostBadge` free/spend primitive.
- `pipeline-view.tsx`: the INBOX tab now delegates to `<InboxTriage>`; the tracker table + URL-source-of-truth logic are unchanged.

## 🔴 Firewall

**ZERO ranking / relevance logic.** The shell is agnostic to the order signal — there is exactly **one documented plug point** (the freshness comparator in `inbox-triage.tsx`); a smarter ranker would replace only that line. Facets, triage, shortlist and score never touch relevance. No revenue / hosted / ranking language in code or copy.

## Verification

- `typecheck` + `next build` green.
- Driven against `test-data` (168 postings → **114 after URL-dedupe**): fresh batch caps at **20**, `See all 114`, facets + Save/Skip + shortlist + multi-select work, **source** (Lever/Greenhouse/…) and **freshness** ("2w ago") derive correctly, tray shows token-honest **"Score 1 · uses your tokens"**. Runtime console clean (fixed a duplicate-React-key bug surfaced by dupes in `pipeline.md`).

## Review

- **Design authority = career-ops-ux** — reviews against the 6 acceptance anchors in the spec + a measured mobile pass (390/360). One honest note for that review: the inbox is **server-rendered + client-filtered (both instant)**, so there is no async load → no loading-skeleton/spinner by design; happy to add a client refetch (with skeleton/error+retry) if ux prefers.

Scope: `web/` only, no core root changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an inbox triage UI with “free” facet filtering (freshness, source, seniority, location, keyword), per-row save/skip controls, and multi-select actions.
  * Introduced a persistent shortlist tray with remove/clear and a guided “score shortlist” flow, including cost messaging.

* **Bug Fixes**
  * Updated inbox badge/count behavior to reflect pending, deduplicated items and improved “no matches”/evaluated state presentation.

* **Refactor**
  * Simplified the INBOX pipeline surface to delegate inbox handling to the new triage UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->