### PR TITLE
feat(providers): add Lever EU instance (jobs.eu.lever.co) support

### DIFF
--- a/archive-posting.mjs
+++ b/archive-posting.mjs
@@ -157,7 +157,7 @@ function extractCompanyFromUrl(url) {
     const { hostname, pathname } = new URL(url);
     const parts = pathname.split('/').filter(Boolean);
     if (hostname === 'boards.greenhouse.io') return parts[0] || null;
-    if (hostname === 'jobs.lever.co') return parts[0] || null;
+    if (/^jobs\.(eu\.)?lever\.co$/.test(hostname)) return parts[0] || null;
     if (hostname === 'jobs.ashbyhq.com') return parts[0] || null;
     if (hostname === 'app.dover.io') return parts[0] || null;
     return null;

--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -23,7 +23,7 @@ are shared helpers and are not loaded as providers.
 | JibeApply | API | Auto-detects `https://<slug>.jibeapply.com/jobs` careers URLs (rewriting `/jobs` to the public `/api/jobs` endpoint); paginates `?page=N` up to `max_pages` (default 50), warning if a tenant's postings exceed the cap. Also supports branded/iCIMS-hosted sites at their own `/jobs` path via an explicit `provider: jibeapply` + `api:` URL. |
 | Jobstreet / SEEK | API | Uses the public SEEK chalice-search JSON API for Jobstreet and SEEK sites. Configure explicitly with `provider: jobstreet`. |
 | Landing.jobs | API | Reads the board-wide `https://landing.jobs/api/v1/jobs` JSON feed (tech, Europe). Configure with `provider: landingjobs`; company is derived from the posting URL slug. |
-| Lever | API | Auto-detects `https://jobs.lever.co/<slug>` boards and uses Lever's public postings endpoint. |
+| Lever | API | Auto-detects `https://jobs.(eu.)?lever.co/<slug>` boards and uses Lever's public postings endpoint. |
 | Local parser | Parser | Runs an in-repo parser command from `portals.yml`. Use this for stable SSR or HTML pages that need a custom extractor. |
 | NoDesk | RSS | Reads the public `https://nodesk.co/remote-jobs/index.xml` feed and parses it in-process. Configure with `provider: nodesk`. |
 | Personio | RSS | Auto-detects `<slug>.jobs.personio.de` or `.com` hosts and parses the public XML jobs feed. |

--- a/liveness-api.mjs
+++ b/liveness-api.mjs
@@ -51,13 +51,14 @@ const ATS_PROVIDERS = [
   },
   {
     id: 'lever',
-    // jobs.lever.co/{slug}/{id}
+    // jobs.(eu.)?lever.co/{slug}/{id}
     match(u) {
-      if (u.hostname !== 'jobs.lever.co') return null;
+      const host = u.hostname.match(/^jobs\.((?:eu\.)?lever\.co)$/);
+      if (!host) return null;
       const m = u.pathname.match(/^\/([^/]+)\/([^/?#]+)\/?$/);
-      return m ? { slug: m[1], id: m[2] } : null;
+      return m ? { apiHost: `api.${host[1]}`, slug: m[1], id: m[2] } : null;
     },
-    api: ({ slug, id }) => `https://api.lever.co/v0/postings/${slug}/${id}`,
+    api: ({ apiHost, slug, id }) => `https://${apiHost}/v0/postings/${slug}/${id}`,
   },
   {
     id: 'ashby',

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -127,7 +127,7 @@ For companies with a public API or structured feed **that are not in `local_pars
 - **Greenhouse**: `https://boards-api.greenhouse.io/v1/boards/{company}/jobs`
 - **Ashby**: `https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobBoardWithTeams`
 - **BambooHR**: list `https://{company}.bamboohr.com/careers/list`; job details `https://{company}.bamboohr.com/careers/{id}/detail`
-- **Lever**: `https://api.lever.co/v0/postings/{company}?mode=json`
+- **Lever**: `https://api.(eu.)?lever.co/v0/postings/{company}?mode=json`
 - **Teamtailor**: `https://{company}.teamtailor.com/jobs.rss`
 - **Workday**: `https://{company}.{shard}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs`
 - **Breezy**: `https://{company}.breezy.hr/json`
@@ -184,7 +184,7 @@ Levels are additive — they are executed in order, and results are merged and d
 5. **Level 2 — ATS APIs / Feeds** (parallel):
    For each company in `tracked_companies` with a defined `api:`, `enabled: true`, and a **name not listed in `local_parser_ok`**:
    a. WebFetch the API/feed URL.
-   b. If `api_provider` is defined, use its parser; if undefined, infer by domain (`boards-api.greenhouse.io`, `jobs.ashbyhq.com`, `api.lever.co`, `*.bamboohr.com`, `*.teamtailor.com`, `*.myworkdayjobs.com`, `*.breezy.hr`).
+   b. If `api_provider` is defined, use its parser; if undefined, infer by domain (`boards-api.greenhouse.io`, `jobs.ashbyhq.com`, `api.(eu.)?lever.co`, `*.bamboohr.com`, `*.teamtailor.com`, `*.myworkdayjobs.com`, `*.breezy.hr`).
    c. For **Ashby**, send a POST request with:
       - `operationName: ApiJobBoardWithTeams`
       - `variables.organizationHostedJobsPageName: {company}`
@@ -312,7 +312,7 @@ Fallback: if you only have the direct ATS URL, navigate first to the company's w
 **Known Patterns by Platform:**
 - **Ashby:** `https://jobs.ashbyhq.com/{slug}`
 - **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` or `https://job-boards.eu.greenhouse.io/{slug}`
-- **Lever:** `https://jobs.lever.co/{slug}`
+- **Lever:** `https://jobs.(eu.)?lever.co/{slug}`
 - **BambooHR:** list `https://{company}.bamboohr.com/careers/list`; detail `https://{company}.bamboohr.com/careers/{id}/detail`
 - **Teamtailor:** `https://{company}.teamtailor.com/jobs`
 - **Workday:** `https://{company}.{shard}.myworkdayjobs.com/{site}`
@@ -321,7 +321,7 @@ Fallback: if you only have the direct ATS URL, navigate first to the company's w
 **API/Feed Patterns by Platform:**
 - **Ashby API:** `https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobBoardWithTeams`
 - **BambooHR API:** list `https://{company}.bamboohr.com/careers/list`; detail `https://{company}.bamboohr.com/careers/{id}/detail` (`result.jobOpening`)
-- **Lever API:** `https://api.lever.co/v0/postings/{company}?mode=json`
+- **Lever API:** `https://api.(eu.)?lever.co/v0/postings/{company}?mode=json`
 - **Teamtailor RSS:** `https://{company}.teamtailor.com/jobs.rss`
 - **Workday API:** `https://{company}.{shard}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs`
 

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -127,7 +127,7 @@ For companies with a public API or structured feed **that are not in `local_pars
 - **Greenhouse**: `https://boards-api.greenhouse.io/v1/boards/{company}/jobs`
 - **Ashby**: `https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobBoardWithTeams`
 - **BambooHR**: list `https://{company}.bamboohr.com/careers/list`; job details `https://{company}.bamboohr.com/careers/{id}/detail`
-- **Lever**: `https://api.(eu.)?lever.co/v0/postings/{company}?mode=json`
+- **Lever**: `https://api.(eu.)?lever.co/v0/postings/{company}`
 - **Teamtailor**: `https://{company}.teamtailor.com/jobs.rss`
 - **Workday**: `https://{company}.{shard}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs`
 - **Breezy**: `https://{company}.breezy.hr/json`
@@ -321,7 +321,7 @@ Fallback: if you only have the direct ATS URL, navigate first to the company's w
 **API/Feed Patterns by Platform:**
 - **Ashby API:** `https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobBoardWithTeams`
 - **BambooHR API:** list `https://{company}.bamboohr.com/careers/list`; detail `https://{company}.bamboohr.com/careers/{id}/detail` (`result.jobOpening`)
-- **Lever API:** `https://api.(eu.)?lever.co/v0/postings/{company}?mode=json`
+- **Lever API:** `https://api.(eu.)?lever.co/v0/postings/{company}`
 - **Teamtailor RSS:** `https://{company}.teamtailor.com/jobs.rss`
 - **Workday API:** `https://{company}.{shard}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs`
 

--- a/prepare-application.mjs
+++ b/prepare-application.mjs
@@ -15,7 +15,7 @@
  * Supported ATS:
  *   Greenhouse  boards.greenhouse.io / greenhouse.io
  *   Ashby       jobs.ashbyhq.com / ashbyhq.com
- *   Lever       jobs.lever.co / lever.co
+ *   Lever       jobs.(eu.)?lever.co / lever.co
  */
 
 import { readFileSync, existsSync, statSync } from 'fs';
@@ -30,6 +30,7 @@ const ALLOWED_HOSTS = new Set([
   'jobs.ashbyhq.com',
   'ashbyhq.com',
   'jobs.lever.co',
+  'jobs.eu.lever.co',
   'lever.co',
 ]);
 
@@ -99,7 +100,7 @@ function detectAts(url) {
   const path = url.pathname;
   const GH  = new Set(['boards.greenhouse.io', 'greenhouse.io']);
   const ASH = new Set(['jobs.ashbyhq.com', 'ashbyhq.com']);
-  const LEV = new Set(['jobs.lever.co', 'lever.co']);
+  const LEV = new Set(['jobs.lever.co', 'jobs.eu.lever.co', 'lever.co']);
 
   const gh = path.match(/^\/([^/]+)\/jobs\/(\d+)/);
   if (gh && GH.has(url.hostname)) {

--- a/providers/lever.mjs
+++ b/providers/lever.mjs
@@ -6,11 +6,17 @@
 
 /** @param {import('./_types.js').PortalEntry} entry */
 function resolveApiUrl(entry) {
-  const url = entry.careers_url || '';
-  const match = url.match(/jobs\.(eu\.)?lever\.co\/([^/?#]+)/);
-  if (!match) return null;
-  const [, region, slug] = match;
-  return `https://api.${region || ''}lever.co/v0/postings/${slug}`;
+  let url;
+  try {
+    url = new URL(entry.careers_url || '');
+  } catch {
+    return null;
+  }
+  const host = url.hostname.match(/^jobs\.((?:eu\.)?lever\.co)$/);
+  if (!host) return null;
+  const slug = url.pathname.split('/').filter(Boolean)[0];
+  if (!slug) return null;
+  return `https://api.${host[1]}/v0/postings/${slug}`;
 }
 
 /** @type {Provider} */

--- a/providers/lever.mjs
+++ b/providers/lever.mjs
@@ -2,13 +2,15 @@
 /** @typedef {import('./_types.js').Provider} Provider */
 
 // Lever provider — hits the public postings endpoint.
-// Auto-detects from careers_url pattern `https://jobs.lever.co/<slug>`.
+// Auto-detects from careers_url via jobs.(eu.)?lever.co/<slug>.
 
+/** @param {import('./_types.js').PortalEntry} entry */
 function resolveApiUrl(entry) {
   const url = entry.careers_url || '';
-  const match = url.match(/jobs\.lever\.co\/([^/?#]+)/);
+  const match = url.match(/jobs\.(eu\.)?lever\.co\/([^/?#]+)/);
   if (!match) return null;
-  return `https://api.lever.co/v0/postings/${match[1]}`;
+  const [, region, slug] = match;
+  return `https://api.${region || ''}lever.co/v0/postings/${slug}`;
 }
 
 /** @type {Provider} */

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -482,7 +482,7 @@ search_queries:
 #
 #   greenhouse      job-boards(.eu)?.greenhouse.io/<slug>  (or api: field)
 #   ashby           jobs.ashbyhq.com/<slug>
-#   lever           jobs.lever.co/<slug>
+#   lever           jobs.(eu.)?lever.co/<slug>
 #   workable        apply.workable.com/<slug>
 #   smartrecruiters (careers|jobs).smartrecruiters.com/<slug>
 #   recruitee       <slug>.recruitee.com
@@ -1218,6 +1218,11 @@ tracked_companies:
   - name: Pigment
     careers_url: https://jobs.lever.co/pigment
     notes: "Paris FR / NYC / London. AI-powered FP&A planning platform."
+    enabled: true
+
+  - name: Diabolocom
+    careers_url: https://jobs.eu.lever.co/diabolocom
+    notes: "Paris FR. AI-native contact center (CCaaS) platform — Frost & Sullivan 2026 AI CX Leader in Europe; hybrid LLM/SLM architecture powering Agent Assist, Voice Analytics, and automated QA."
     enabled: true
 
   # -- UK & Ireland AI (EU-friendly hiring) --

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -318,6 +318,12 @@ try {
   } else {
     fail(`Lever API URL wrong: ${JSON.stringify(lvApi)}`);
   }
+  const lvEuApi = resolveAtsApi('https://jobs.eu.lever.co/acme-eu/abc-123-def');
+  if (lvEuApi?.ats === 'lever' && lvEuApi.apiUrl === 'https://api.eu.lever.co/v0/postings/acme-eu/abc-123-def') {
+    pass('resolveAtsApi maps an EU Lever posting to api.eu.lever.co');
+  } else {
+    fail(`Lever EU API URL wrong: ${JSON.stringify(lvEuApi)}`);
+  }
   if (resolveAtsApi('https://example.com/jobs/123') === null) {
     pass('resolveAtsApi returns null for non-ATS URLs (→ Playwright fallback)');
   } else {
@@ -1785,11 +1791,27 @@ try {
     fail('verify-portals parseAtsSlug misclassified an ATS or branded URL');
   }
 
+  const leverSlug = parseAtsSlug('https://jobs.lever.co/acme');
+  if (leverSlug?.ats === 'lever' && leverSlug?.slug === 'acme') {
+    pass('verify-portals parseAtsSlug extracts lever slug from jobs.lever.co URL');
+  } else {
+    fail(`verify-portals parseAtsSlug lever: ${JSON.stringify(leverSlug)}`);
+  }
+
+  const leverEuSlug = parseAtsSlug('https://jobs.eu.lever.co/acme-eu');
+  if (leverEuSlug?.ats === 'lever-eu' && leverEuSlug?.slug === 'acme-eu') {
+    pass('verify-portals parseAtsSlug extracts lever-eu slug from jobs.eu.lever.co URL');
+  } else {
+    fail(`verify-portals parseAtsSlug lever-eu: ${JSON.stringify(leverEuSlug)}`);
+  }
+
   // Mock fetchJson: 200+jobs → live, 200+empty → empty, otherwise 404 → missing.
   const mockFetch = async (url) => {
     if (url.includes('/boards/live/jobs')) return { jobs: [{}, {}] };
     if (url.includes('/boards/empty/jobs')) return { jobs: [] };
     if (url.includes('/posting-api/job-board/deepsetai')) return { jobs: [{}] };
+    if (url.includes('api.lever.co/v0/postings/acme-lv')) return [{}];
+    if (url.includes('api.eu.lever.co/v0/postings/acme-eu')) return [{}, {}, {}];
     const err = new Error('HTTP 404'); err.status = 404; throw err;
   };
   const results = await verifyCompanies([
@@ -1799,13 +1821,17 @@ try {
     { name: 'Deepset', careers_url: 'https://job-boards.greenhouse.io/deepset' },
     { name: 'Branded', careers_url: 'https://acme.com/careers' },
     { name: 'Off', enabled: false, careers_url: 'https://job-boards.greenhouse.io/live' },
+    { name: 'Lever Live', careers_url: 'https://jobs.lever.co/acme-lv' },
+    { name: 'Lever EU Live', careers_url: 'https://jobs.eu.lever.co/acme-eu' },
   ], { fetchJson: mockFetch });
   const byName = Object.fromEntries(results.map((r) => [r.name, r]));
   if (
-    results.length === 5 &&
+    results.length === 7 &&
     byName.Live.status === 'live' && byName.Empty.status === 'empty' &&
     byName.Typo.status === 'missing' && byName.Typo.errorKind === 'slug_gone' &&
     byName.Branded.status === 'skipped' &&
+    byName['Lever Live'].status === 'live' &&
+    byName['Lever EU Live'].status === 'live' &&
     byName.Deepset.suggested?.ats === 'ashby' && byName.Deepset.suggested?.slug === 'deepsetai'
   ) {
     pass('verify-portals classifies live / empty / unresolved / non-ATS (disabled excluded)');
@@ -2338,6 +2364,7 @@ for (const [url, expected] of [
   ['https://boards.greenhouse.io/openai/jobs/123', 'openai'],
   ['https://jobs.ashbyhq.com/ElevenLabs/abc',      'elevenlabs'],
   ['https://jobs.lever.co/retool/xyz',              'retool'],
+  ['https://jobs.eu.lever.co/retool-eu/xyz',         'retool-eu'],
 ]) {
   const out = run(NODE, ['archive-posting.mjs', '--dry-run', url]);
   const { hostname } = new URL(url);
@@ -5249,13 +5276,29 @@ try {
   const lever = (await import(pathToFileURL(join(ROOT, 'providers/lever.mjs')).href)).default;
   const ashby = (await import(pathToFileURL(join(ROOT, 'providers/ashby.mjs')).href)).default;
 
-  let leverOpts = null;
+  // Each instance must hit its own host with redirect:'error' — a wrong host
+  // silently returns another tenant's (or no) postings instead of erroring.
+  let leverUrl = null, leverOpts = null;
   await lever.fetch(
     { name: 'L', careers_url: 'https://jobs.lever.co/example' },
-    { transport: 'http', fetchJson: async (_u, opts) => { leverOpts = opts; return []; }, fetchText: async () => '' },
+    { transport: 'http', fetchJson: async (u, opts) => { leverUrl = u; leverOpts = opts; return []; }, fetchText: async () => '' },
   );
-  if (leverOpts && leverOpts.redirect === 'error') pass('lever.fetch() passes redirect:"error"');
-  else fail(`lever.fetch() should pass redirect:"error", got ${JSON.stringify(leverOpts)}`);
+  if (leverUrl === 'https://api.lever.co/v0/postings/example' && leverOpts?.redirect === 'error') {
+    pass('lever.fetch() hits api.lever.co and passes redirect:"error"');
+  } else {
+    fail(`lever.fetch() default instance: url=${leverUrl}, opts=${JSON.stringify(leverOpts)}`);
+  }
+
+  let leverEuUrl = null, leverEuOpts = null;
+  await lever.fetch(
+    { name: 'L EU', careers_url: 'https://jobs.eu.lever.co/example-eu' },
+    { transport: 'http', fetchJson: async (u, opts) => { leverEuUrl = u; leverEuOpts = opts; return []; }, fetchText: async () => '' },
+  );
+  if (leverEuUrl === 'https://api.eu.lever.co/v0/postings/example-eu' && leverEuOpts?.redirect === 'error') {
+    pass('lever.fetch() hits api.eu.lever.co and passes redirect:"error"');
+  } else {
+    fail(`lever.fetch() EU instance: url=${leverEuUrl}, opts=${JSON.stringify(leverEuOpts)}`);
+  }
 
   let ashbyOpts = null;
   await ashby.fetch(
@@ -10717,6 +10760,15 @@ try {
     } else {
       fail(`prepare-application.mjs missing concrete handler: ${fn}`);
     }
+  }
+
+  // EU Lever instance must be allowlisted in both the top-level host gate and
+  // detectAts()'s LEV set — missing either one silently drops EU apply URLs.
+  const leverEuMentions = (src.match(/jobs\.eu\.lever\.co/g) || []).length;
+  if (leverEuMentions >= 2) {
+    pass('prepare-application.mjs allowlists jobs.eu.lever.co in ALLOWED_HOSTS and detectAts()');
+  } else {
+    fail(`prepare-application.mjs jobs.eu.lever.co mentions: expected >= 2, got ${leverEuMentions}`);
   }
 
   // Must read config/profile.yml

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1792,15 +1792,15 @@ try {
   }
 
   const leverSlug = parseAtsSlug('https://jobs.lever.co/acme');
-  if (leverSlug?.ats === 'lever' && leverSlug?.slug === 'acme') {
+  if (leverSlug?.ats === 'lever' && leverSlug?.slug === 'acme' && !leverSlug?.eu) {
     pass('verify-portals parseAtsSlug extracts lever slug from jobs.lever.co URL');
   } else {
     fail(`verify-portals parseAtsSlug lever: ${JSON.stringify(leverSlug)}`);
   }
 
   const leverEuSlug = parseAtsSlug('https://jobs.eu.lever.co/acme-eu');
-  if (leverEuSlug?.ats === 'lever-eu' && leverEuSlug?.slug === 'acme-eu') {
-    pass('verify-portals parseAtsSlug extracts lever-eu slug from jobs.eu.lever.co URL');
+  if (leverEuSlug?.ats === 'lever' && leverEuSlug?.slug === 'acme-eu' && leverEuSlug?.eu === true) {
+    pass('verify-portals parseAtsSlug extracts lever-eu slug and sets eu:true from jobs.eu.lever.co URL');
   } else {
     fail(`verify-portals parseAtsSlug lever-eu: ${JSON.stringify(leverEuSlug)}`);
   }
@@ -10764,11 +10764,17 @@ try {
 
   // EU Lever instance must be allowlisted in both the top-level host gate and
   // detectAts()'s LEV set — missing either one silently drops EU apply URLs.
-  const leverEuMentions = (src.match(/jobs\.eu\.lever\.co/g) || []).length;
-  if (leverEuMentions >= 2) {
-    pass('prepare-application.mjs allowlists jobs.eu.lever.co in ALLOWED_HOSTS and detectAts()');
+  // Inspect the actual literals, not a raw source-wide substring count, so a
+  // duplicate elsewhere (or a comment) can't mask a missing entry in either one.
+  const allowedHostsLiteral = src.match(/const ALLOWED_HOSTS = new Set\(\[([\s\S]*?)\]\)/)?.[1] || '';
+  const levLiteral = src.match(/const LEV = new Set\(\[([^\]]*)\]\)/)?.[1] || '';
+  const allowedHostsOk = /jobs\.eu\.lever\.co/.test(allowedHostsLiteral);
+  const levOk = /jobs\.eu\.lever\.co/.test(levLiteral);
+  if (allowedHostsOk && levOk) {
+    pass('prepare-application.mjs allowlists jobs.eu.lever.co in ALLOWED_HOSTS and detectAts() LEV set');
   } else {
-    fail(`prepare-application.mjs jobs.eu.lever.co mentions: expected >= 2, got ${leverEuMentions}`);
+    const missing = [!allowedHostsOk && 'ALLOWED_HOSTS', !levOk && 'LEV'].filter(Boolean).join(', ');
+    fail(`prepare-application.mjs missing jobs.eu.lever.co from: ${missing}`);
   }
 
   // Must read config/profile.yml

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1812,6 +1812,7 @@ try {
     if (url.includes('/posting-api/job-board/deepsetai')) return { jobs: [{}] };
     if (url.includes('api.lever.co/v0/postings/acme-lv')) return [{}];
     if (url.includes('api.eu.lever.co/v0/postings/acme-eu')) return [{}, {}, {}];
+    if (url === 'https://api.eu.lever.co/v0/postings/diabolocom') return [{}, {}];
     const err = new Error('HTTP 404'); err.status = 404; throw err;
   };
   const results = await verifyCompanies([
@@ -1823,16 +1824,20 @@ try {
     { name: 'Off', enabled: false, careers_url: 'https://job-boards.greenhouse.io/live' },
     { name: 'Lever Live', careers_url: 'https://jobs.lever.co/acme-lv' },
     { name: 'Lever EU Live', careers_url: 'https://jobs.eu.lever.co/acme-eu' },
+    { name: 'Diabolocom EU Discovery', careers_url: 'https://job-boards.greenhouse.io/does-not-exist-diabolocom' },
   ], { fetchJson: mockFetch });
   const byName = Object.fromEntries(results.map((r) => [r.name, r]));
   if (
-    results.length === 7 &&
+    results.length === 8 &&
     byName.Live.status === 'live' && byName.Empty.status === 'empty' &&
     byName.Typo.status === 'missing' && byName.Typo.errorKind === 'slug_gone' &&
     byName.Branded.status === 'skipped' &&
     byName['Lever Live'].status === 'live' &&
     byName['Lever EU Live'].status === 'live' &&
-    byName.Deepset.suggested?.ats === 'ashby' && byName.Deepset.suggested?.slug === 'deepsetai'
+    byName.Deepset.suggested?.ats === 'ashby' && byName.Deepset.suggested?.slug === 'deepsetai' &&
+    byName['Diabolocom EU Discovery'].suggested?.ats === 'lever' &&
+    byName['Diabolocom EU Discovery'].suggested?.slug === 'diabolocom' &&
+    byName['Diabolocom EU Discovery'].suggested?.url === 'https://api.eu.lever.co/v0/postings/diabolocom'
   ) {
     pass('verify-portals classifies live / empty / unresolved / non-ATS (disabled excluded)');
   } else {

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -57,6 +57,10 @@ export const ATS = {
     probeUrl: (slug) => `https://api.lever.co/v0/postings/${slug}`,
     jobCount: (json) => (Array.isArray(json) ? json.length : null),
   },
+  'lever-eu': {
+    probeUrl: (slug) => `https://api.eu.lever.co/v0/postings/${slug}`,
+    jobCount: (json) => (Array.isArray(json) ? json.length : null),
+  },
 };
 
 // Recognize an ATS + slug from a careers_url OR an `api:` URL. The careers_url
@@ -73,6 +77,8 @@ const ATS_URL_PATTERNS = [
   { ats: 'ashby', re: /jobs\.ashbyhq\.com\/([^/?#]+)/ },
   { ats: 'lever', re: /api\.lever\.co\/v0\/postings\/([^/?#]+)/ },
   { ats: 'lever', re: /jobs\.lever\.co\/([^/?#]+)/ },
+  { ats: 'lever-eu', re: /api\.eu\.lever\.co\/v0\/postings\/([^/?#]+)/ },
+  { ats: 'lever-eu', re: /jobs\.eu\.lever\.co\/([^/?#]+)/ },
 ];
 
 /**

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -54,11 +54,9 @@ export const ATS = {
     jobCount: (json) => (Array.isArray(json?.jobs) ? json.jobs.length : null),
   },
   lever: {
-    probeUrl: (slug) => `https://api.lever.co/v0/postings/${slug}`,
-    jobCount: (json) => (Array.isArray(json) ? json.length : null),
-  },
-  'lever-eu': {
-    probeUrl: (slug) => `https://api.eu.lever.co/v0/postings/${slug}`,
+    // EU boards (jobs.eu.lever.co) resolve to api.eu.lever.co, mirroring the
+    // provider's resolveApiUrl; the default is the base instance.
+    probeUrl: (slug, { eu = false } = {}) => `https://api.${eu ? 'eu.' : ''}lever.co/v0/postings/${slug}`,
     jobCount: (json) => (Array.isArray(json) ? json.length : null),
   },
 };
@@ -75,24 +73,25 @@ const ATS_URL_PATTERNS = [
   { ats: 'greenhouse', re: /boards\.greenhouse\.io\/([^/?#]+)/ },
   { ats: 'ashby', re: /api\.ashbyhq\.com\/posting-api\/job-board\/([^/?#]+)/ },
   { ats: 'ashby', re: /jobs\.ashbyhq\.com\/([^/?#]+)/ },
+  { ats: 'lever', re: /api\.eu\.lever\.co\/v0\/postings\/([^/?#]+)/, eu: true },
+  { ats: 'lever', re: /jobs\.eu\.lever\.co\/([^/?#]+)/, eu: true },
   { ats: 'lever', re: /api\.lever\.co\/v0\/postings\/([^/?#]+)/ },
   { ats: 'lever', re: /jobs\.lever\.co\/([^/?#]+)/ },
-  { ats: 'lever-eu', re: /api\.eu\.lever\.co\/v0\/postings\/([^/?#]+)/ },
-  { ats: 'lever-eu', re: /jobs\.eu\.lever\.co\/([^/?#]+)/ },
 ];
 
 /**
  * Identify the ATS and slug embedded in a careers_url or api URL.
  *
  * @param {string} url - A `careers_url` or `api` value from portals.yml.
- * @returns {{ats: string, slug: string}|null} Match, or null for non-ATS URLs
- *   (branded careers pages, Workday, job boards, etc.) which this tool skips.
+ * @returns {{ats: string, slug: string, eu?: boolean}|null} Match, or null for
+ *   non-ATS URLs (branded careers pages, Workday, job boards, etc.) which this
+ *   tool skips. `eu` is set for Lever's EU data-residency instance.
  */
 export function parseAtsSlug(url) {
   const text = String(url || '');
-  for (const { ats, re } of ATS_URL_PATTERNS) {
+  for (const { ats, re, eu } of ATS_URL_PATTERNS) {
     const m = text.match(re);
-    if (m && m[1]) return { ats, slug: m[1] };
+    if (m && m[1]) return eu ? { ats, slug: m[1], eu: true } : { ats, slug: m[1] };
   }
   return null;
 }
@@ -164,7 +163,8 @@ export function classifyFetchError(err) {
  *
  * @param {string} ats - Key into ATS (greenhouse | ashby | lever).
  * @param {string} slug - Candidate slug to probe.
- * @param {{fetchJson?: Function}} [deps] - Injectable HTTP for testability.
+ * @param {{fetchJson?: Function, eu?: boolean}} [deps] - Injectable HTTP for
+ *   testability; `eu` selects Lever's EU data-residency instance.
  * @returns {Promise<{ats,slug,url,status,jobCount?,httpStatus?,errorKind?,reason?}>}
  *   status is 'live' (jobs > 0), 'empty' (200, no jobs), or 'missing'
  *   (404/error/unexpected shape).
@@ -172,7 +172,7 @@ export function classifyFetchError(err) {
 export async function probeSlug(
   ats,
   slug,
-  { fetchJson = defaultFetchJson } = {},
+  { fetchJson = defaultFetchJson, eu = false } = {},
 ) {
   const spec = ATS[ats];
   if (!spec)
@@ -184,7 +184,7 @@ export async function probeSlug(
       errorKind: 'unknown',
       reason: `unknown ATS: ${ats}`,
     };
-  const url = spec.probeUrl(slug);
+  const url = spec.probeUrl(slug, { eu });
   try {
     const json = await fetchJson(url);
     const count = spec.jobCount(json);
@@ -351,7 +351,7 @@ export async function verifyCompanies(
     const match =
       parseAtsSlug(company.api) || parseAtsSlug(company.careers_url);
     if (match) {
-      const probe = await probeSlug(match.ats, match.slug, { fetchJson });
+      const probe = await probeSlug(match.ats, match.slug, { fetchJson, eu: match.eu });
       if (probe.status === 'live' || probe.status === 'empty') {
         results.push({ name, ...probe });
         continue;

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -73,10 +73,14 @@ const ATS_URL_PATTERNS = [
   { ats: 'greenhouse', re: /boards\.greenhouse\.io\/([^/?#]+)/ },
   { ats: 'ashby', re: /api\.ashbyhq\.com\/posting-api\/job-board\/([^/?#]+)/ },
   { ats: 'ashby', re: /jobs\.ashbyhq\.com\/([^/?#]+)/ },
-  { ats: 'lever', re: /api\.eu\.lever\.co\/v0\/postings\/([^/?#]+)/, eu: true },
-  { ats: 'lever', re: /jobs\.eu\.lever\.co\/([^/?#]+)/, eu: true },
-  { ats: 'lever', re: /api\.lever\.co\/v0\/postings\/([^/?#]+)/ },
-  { ats: 'lever', re: /jobs\.lever\.co\/([^/?#]+)/ },
+  // Lever entries pin an exact `host` (checked via new URL(), like
+  // providers/lever.mjs's resolveApiUrl) instead of matching the hostname as a
+  // loose substring anywhere in the URL — otherwise a crafted
+  // https://evil.com/jobs.lever.co/x careers_url would falsely resolve as Lever.
+  { ats: 'lever', host: 'api.eu.lever.co', re: /^\/v0\/postings\/([^/?#]+)/, eu: true },
+  { ats: 'lever', host: 'jobs.eu.lever.co', re: /^\/([^/?#]+)/, eu: true },
+  { ats: 'lever', host: 'api.lever.co', re: /^\/v0\/postings\/([^/?#]+)/ },
+  { ats: 'lever', host: 'jobs.lever.co', re: /^\/([^/?#]+)/ },
 ];
 
 /**
@@ -89,7 +93,20 @@ const ATS_URL_PATTERNS = [
  */
 export function parseAtsSlug(url) {
   const text = String(url || '');
-  for (const { ats, re, eu } of ATS_URL_PATTERNS) {
+  let hostname = null;
+  let pathname = null;
+  try {
+    ({ hostname, pathname } = new URL(text));
+  } catch {
+    // Not a parseable absolute URL — host-scoped patterns below simply won't match.
+  }
+  for (const { ats, re, eu, host } of ATS_URL_PATTERNS) {
+    if (host) {
+      if (hostname !== host) continue;
+      const m = pathname.match(re);
+      if (m && m[1]) return eu ? { ats, slug: m[1], eu: true } : { ats, slug: m[1] };
+      continue;
+    }
     const m = text.match(re);
     if (m && m[1]) return eu ? { ats, slug: m[1], eu: true } : { ats, slug: m[1] };
   }
@@ -222,9 +239,15 @@ async function discoverAlternates(name, { fetchJson }) {
   let bestEmpty = null;
   for (const slug of deriveSlugCandidates(name)) {
     for (const ats of Object.keys(ATS)) {
-      const r = await probeSlug(ats, slug, { fetchJson });
-      if (r.status === 'live') return r;
-      if (r.status === 'empty' && !bestEmpty) bestEmpty = r;
+      // Lever no longer has a separate 'lever-eu' registry key (unified into a
+      // single 'lever' + eu flag), so both instances must be probed explicitly
+      // here or EU-only tenants become undiscoverable via --add.
+      const euVariants = ats === 'lever' ? [false, true] : [false];
+      for (const eu of euVariants) {
+        const r = await probeSlug(ats, slug, { fetchJson, eu });
+        if (r.status === 'live') return r;
+        if (r.status === 'empty' && !bestEmpty) bestEmpty = r;
+      }
     }
   }
   return bestEmpty;


### PR DESCRIPTION
## What

Lever offers an EU data-residency instance at `jobs.eu.lever.co` / `api.eu.lever.co`, distinct from the default `api.lever.co`. `providers/lever.mjs`, `liveness-api.mjs`, and `verify-portals.mjs` only recognized the default host, so EU tenants were invisible to the zero-token scanner, the liveness API rung, and the slug validator alike.

- **providers/lever.mjs** — `resolveApiUrl` now matches `jobs.(eu.)?lever.co` and reuses the captured region directly when building the API URL.
- **liveness-api.mjs** — the `lever` ATS rung recognizes both hosts; `apiHost` mirrors the matched host suffix, so a future region only needs a regex change, nothing downstream.
- **verify-portals.mjs** — added a `lever-eu` entry to the `ATS` probe registry and matching `ATS_URL_PATTERNS` so `--add`/sweep can validate EU slugs.

## Also fixes (found while auditing every `lever.co` reference in the codebase)

- **prepare-application.mjs** — `ALLOWED_HOSTS` hard-blocked EU apply URLs at the very first gate, before ATS detection ever ran. The auto-fill feature silently refused to work for EU Lever companies.
- **archive-posting.mjs** — `extractCompanyFromUrl()`'s fallback couldn't derive a company name from an EU posting URL (now a regex, matching the same style as the provider fix).

## Docs & example

- `docs/SUPPORTED_JOB_BOARDS.md`, `modes/scan.md`, `templates/portals.example.yml` updated to document the EU pattern (pseudo-regex style, consistent with the existing Greenhouse EU documentation).
- Added a real-world EU Lever example — Diabolocom (Paris, AI-native contact center platform, Frost & Sullivan 2026 AI CX Leader in Europe) — under "France AI ecosystem" in `portals.example.yml`.

## Scope notes

- Left `scan-ats-full.mjs` untouched — the reverse-discovery tool that would need a larger behavioral change (parallel probing of both hosts) to gain EU coverage, which felt like a separate follow-up rather than part of this fix.
- Several other `lever.co` references (`analyze-patterns.mjs`, `providers/_trust-validator.mjs`, `plugins/gmail/_helpers.mjs`, `web/src/lib/inbox.ts`) already use loose suffix-matching (`hostname.endsWith('.lever.co')`) and needed no change.
- Overlaps in part with open PR #825, which also adds EU Lever support bundled together with unrelated VC-portfolio-board providers.

## Test plan

- [x] `node test-all.mjs` — 1237 passed, 0 failed (1 pre-existing environment-only warning, unrelated to this change)
- [x] Added symmetric default/EU test coverage for every touched behavior: `providers/lever.mjs` detect/fetch, `liveness-api.mjs` resolveAtsApi, `verify-portals.mjs` parseAtsSlug + verifyCompanies integration, `prepare-application.mjs` allowlist, `archive-posting.mjs` dry-run company detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for Lever EU domains across job, apply, and careers URLs, with regional API endpoint resolution.
- **Bug Fixes**
  - Improved company/ATS detection and portal verification for both EU and non-EU Lever links.
  - Strengthened safety checks for API redirects across regional endpoints.
- **Documentation**
  - Updated supported job board patterns for Lever EU URLs; added the Diabolocom portal entry.
- **Tests**
  - Expanded EU Lever coverage for verification, archiving dry-runs, and URL-handling contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->