### PR TITLE
feat(providers): add jobvite provider (ATS platform)

### DIFF
--- a/providers/jobvite.mjs
+++ b/providers/jobvite.mjs
@@ -1,0 +1,185 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Jobvite provider — per-tenant public jobs JSON API.
+// Used by ~3,000 companies across a wide range of industries.
+//
+// API: GET https://jobs.jobvite.com/api/company/{companyId}/jobs
+// Response: { jobs: [ { id, title, category, location, country, jobType,
+//   date, applyURL } ] }
+//
+// Auto-detects from careers_url pattern:
+//   https://jobs.jobvite.com/{companyId}
+//   https://jobs.jobvite.com/{companyId}/jobs
+// The companyId is the slug segment immediately after the host.
+//
+// SSRF stance: API URL is constructed from the extracted slug only, never
+// from a user-supplied path; assertJobviteUrl() pins the hostname to
+// jobs.jobvite.com before every fetch. Job applyURLs are display-only
+// (written to pipeline/history, never fetched here) and accepted from any
+// https: URL returned by the already-validated tenant API response.
+//
+// Wire in via a `tracked_companies:` entry with:
+//   careers_url: https://jobs.jobvite.com/{companyId}
+// or explicitly with:
+//   provider: jobvite
+//   api: https://jobs.jobvite.com/api/company/{companyId}/jobs
+
+const ALLOWED_HOST = 'jobs.jobvite.com';
+
+/** @param {string} url */
+function assertJobviteUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`jobvite: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:')
+    throw new Error(`jobvite: URL must use HTTPS: ${url}`);
+  if (parsed.hostname !== ALLOWED_HOST)
+    throw new Error(`jobvite: untrusted hostname "${parsed.hostname}" — must be ${ALLOWED_HOST}`);
+  return url;
+}
+
+// NaN-safe Date.parse → epoch ms.
+/** @param {string} value */
+function toEpochMs(value) {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Extract the companyId slug from a careers_url or api URL.
+ *
+ * Accepted forms:
+ *   https://jobs.jobvite.com/{slug}
+ *   https://jobs.jobvite.com/{slug}/jobs
+ *   https://jobs.jobvite.com/api/company/{slug}/jobs  (explicit api: field)
+ *
+ * Returns null for any non-Jobvite or malformed URL.
+ *
+ * @param {import('./_types.js').PortalEntry} entry
+ * @returns {string | null}
+ */
+export function resolveCompanyId(entry) {
+  // Prefer an explicit api: URL (may be set by the user for custom slugs).
+  const raw = typeof entry.api === 'string' && entry.api
+    ? entry.api
+    : typeof entry.careers_url === 'string' ? entry.careers_url : '';
+  if (!raw) return null;
+
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:' || parsed.hostname !== ALLOWED_HOST) return null;
+
+  const segments = parsed.pathname.split('/').filter(Boolean);
+
+  // api: https://jobs.jobvite.com/api/company/{slug}/jobs → ['api','company',slug,'jobs']
+  const apiIdx = segments.indexOf('company');
+  if (apiIdx !== -1 && segments[apiIdx + 1]) {
+    return segments[apiIdx + 1];
+  }
+
+  // careers_url: https://jobs.jobvite.com/{slug}[/jobs] → [slug] or [slug, 'jobs']
+  if (segments.length >= 1 && segments[0] !== 'api') {
+    return segments[0];
+  }
+
+  return null;
+}
+
+/** @param {string} companyId */
+function buildApiUrl(companyId) {
+  return `https://${ALLOWED_HOST}/api/company/${encodeURIComponent(companyId)}/jobs`;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'jobvite',
+
+  detect(entry) {
+    const companyId = resolveCompanyId(entry);
+    return companyId ? { url: buildApiUrl(companyId) } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const companyId = resolveCompanyId(entry);
+    if (!companyId) throw new Error(`jobvite: cannot derive company ID for ${entry.name}`);
+    const apiUrl = buildApiUrl(companyId);
+    assertJobviteUrl(apiUrl);
+    // redirect:'error' prevents SSRF via server-side redirects; combined with
+    // assertJobviteUrl above it guarantees the final hostname stays pinned to
+    // jobs.jobvite.com.
+    const json = await ctx.fetchJson(apiUrl, { redirect: 'error' });
+    return parseJobviteResponse(json, entry.name);
+  },
+};
+
+/**
+ * Parse a Jobvite /api/company/{id}/jobs response. Exported for unit tests.
+ *
+ * Response shape: `{ jobs: [ { id, title, location, country, date, applyURL,
+ * category?, jobType? } ] }`. The `applyURL` is the per-job application page
+ * and is used as the posting URL and dedup key. It is accepted from any
+ * https: origin — per-job URLs in Jobvite commonly point to a branded company
+ * subdomain (e.g. careers.example.com/jobs/…) rather than jobs.jobvite.com,
+ * and these URLs are display-only (never fetched here), so host-pinning is not
+ * required. Non-https or malformed applyURLs are dropped.
+ *
+ * Field mapping:
+ *   title    ← `title`              (required; posting dropped when absent)
+ *   url      ← `applyURL`           (required; posting dropped when not a valid https: URL)
+ *   company  ← `entry.name`         (not in the API payload)
+ *   location ← `location` (city/region string) or `country` as fallback
+ *   postedAt ← `date` → epoch ms   (omitted when absent/unparseable)
+ *
+ * @param {unknown} json - raw parsed API response
+ * @param {string} companyName - value to write into job.company
+ * @returns {Array<{title: string, url: string, company: string, location: string, postedAt?: number}>}
+ */
+export function parseJobviteResponse(json, companyName) {
+  if (!json || typeof json !== 'object') return [];
+  const jobs = /** @type {any} */ (json).jobs;
+  if (!Array.isArray(jobs)) return [];
+
+  const out = [];
+  for (const j of jobs) {
+    if (!j || typeof j !== 'object') continue;
+
+    const title = typeof j.title === 'string' ? j.title.trim() : '';
+    if (!title) continue;
+
+    // Resolve and validate the application URL.
+    const rawUrl = typeof j.applyURL === 'string' ? j.applyURL.trim() : '';
+    let url = '';
+    if (rawUrl) {
+      try {
+        const p = new URL(rawUrl);
+        if (p.protocol === 'https:') url = p.href;
+      } catch {
+        // malformed URL — drop posting
+      }
+    }
+    if (!url) continue;
+
+    // Location: prefer the explicit location string, fall back to country.
+    const location =
+      (typeof j.location === 'string' && j.location.trim())
+        ? j.location.trim()
+        : (typeof j.country === 'string' ? j.country.trim() : '');
+
+    /** @type {import('./_types.js').Job & {postedAt?: number}} */
+    const job = { title, url, company: companyName, location };
+    const postedAt = toEpochMs(j.date);
+    if (postedAt !== undefined) job.postedAt = postedAt;
+
+    out.push(job);
+  }
+  return out;
+}

--- a/tests/providers/jobvite.test.mjs
+++ b/tests/providers/jobvite.test.mjs
@@ -1,0 +1,259 @@
+// tests/providers/jobvite.test.mjs — unit tests for the Jobvite provider.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — Jobvite');
+
+try {
+  const {
+    default: jobvite,
+    resolveCompanyId,
+    parseJobviteResponse,
+  } = await import(pathToFileURL(join(ROOT, 'providers/jobvite.mjs')).href);
+
+  // id
+  if (jobvite.id === 'jobvite') {
+    pass('jobvite.id is "jobvite"');
+  } else {
+    fail(`jobvite.id is "${jobvite.id}"`);
+  }
+
+  // ── resolveCompanyId ───────────────────────────────────────────
+
+  // careers_url bare slug
+  if (resolveCompanyId({ careers_url: 'https://jobs.jobvite.com/stripe' }) === 'stripe') {
+    pass('resolveCompanyId extracts slug from bare careers_url');
+  } else {
+    fail(`resolveCompanyId bare: ${resolveCompanyId({ careers_url: 'https://jobs.jobvite.com/stripe' })}`);
+  }
+
+  // careers_url with /jobs path
+  if (resolveCompanyId({ careers_url: 'https://jobs.jobvite.com/stripe/jobs' }) === 'stripe') {
+    pass('resolveCompanyId extracts slug from careers_url with /jobs suffix');
+  } else {
+    fail(`resolveCompanyId /jobs suffix: ${resolveCompanyId({ careers_url: 'https://jobs.jobvite.com/stripe/jobs' })}`);
+  }
+
+  // explicit api: URL takes precedence over careers_url
+  const apiEntry = {
+    api: 'https://jobs.jobvite.com/api/company/acme-corp/jobs',
+    careers_url: 'https://jobs.jobvite.com/other',
+  };
+  if (resolveCompanyId(apiEntry) === 'acme-corp') {
+    pass('resolveCompanyId prefers api: over careers_url');
+  } else {
+    fail(`resolveCompanyId api preference: ${resolveCompanyId(apiEntry)}`);
+  }
+
+  // null / wrong host / http / non-string
+  if (resolveCompanyId({}) === null) {
+    pass('resolveCompanyId returns null for empty entry');
+  } else {
+    fail('resolveCompanyId should return null for empty entry');
+  }
+  if (resolveCompanyId({ careers_url: 'https://evil.example.com/stripe' }) === null) {
+    pass('resolveCompanyId returns null for wrong host');
+  } else {
+    fail('resolveCompanyId should return null for wrong host (SSRF guard)');
+  }
+  if (resolveCompanyId({ careers_url: 'http://jobs.jobvite.com/stripe' }) === null) {
+    pass('resolveCompanyId returns null for non-https URL');
+  } else {
+    fail('resolveCompanyId should return null for non-https URL');
+  }
+  if (resolveCompanyId({ careers_url: null }) === null && resolveCompanyId({ careers_url: 42 }) === null) {
+    pass('resolveCompanyId returns null for non-string careers_url');
+  } else {
+    fail('resolveCompanyId should return null for non-string careers_url');
+  }
+
+  // ── detect() ───────────────────────────────────────────────────
+
+  const detectedUrl = jobvite.detect({ careers_url: 'https://jobs.jobvite.com/stripe' })?.url;
+  if (detectedUrl === 'https://jobs.jobvite.com/api/company/stripe/jobs') {
+    pass('jobvite.detect() builds correct API URL from careers_url');
+  } else {
+    fail(`jobvite.detect() url: ${JSON.stringify(detectedUrl)}`);
+  }
+
+  if (jobvite.detect({ careers_url: 'https://lever.co/stripe' }) === null) {
+    pass('jobvite.detect() returns null for non-Jobvite careers_url');
+  } else {
+    fail('jobvite.detect() should return null for non-Jobvite URL');
+  }
+
+  if (jobvite.detect({}) === null) {
+    pass('jobvite.detect() returns null for empty entry');
+  } else {
+    fail('jobvite.detect() should return null for empty entry');
+  }
+
+  // ── parseJobviteResponse ───────────────────────────────────────
+
+  // 6 jobs in the fixture; 3 are dropped (no-title, non-https, missing URL).
+  const SAMPLE_RESPONSE = {
+    jobs: [
+      {
+        id: 'jv-1',
+        title: 'Senior Software Engineer',
+        location: 'San Francisco, CA',
+        country: 'US',
+        date: 'Mon, 02 Jun 2025 10:00:00 +0000',
+        applyURL: 'https://jobs.jobvite.com/stripe/job/senior-swe',
+        category: 'Engineering',
+        jobType: 'Full-Time',
+      },
+      {
+        id: 'jv-2',
+        title: 'Product Manager',
+        location: '',
+        country: 'UK',
+        date: 'Mon, 02 Jun 2025 11:00:00 +0000',
+        applyURL: 'https://jobs.jobvite.com/stripe/job/pm',
+      },
+      {
+        // no title — must be dropped
+        id: 'jv-3',
+        title: '',
+        location: 'Remote',
+        applyURL: 'https://jobs.jobvite.com/stripe/job/no-title',
+      },
+      {
+        // non-https applyURL — must be dropped
+        id: 'jv-4',
+        title: 'Bad URL Role',
+        location: 'Remote',
+        applyURL: 'http://jobs.jobvite.com/stripe/job/bad-url',
+      },
+      {
+        // missing applyURL — must be dropped
+        id: 'jv-5',
+        title: 'No URL Role',
+        location: 'Remote',
+      },
+      {
+        // branded domain applyURL — must be accepted (display-only, never fetched)
+        id: 'jv-6',
+        title: 'Branded Domain Role',
+        location: 'New York, NY',
+        country: 'US',
+        date: 'Mon, 02 Jun 2025 12:00:00 +0000',
+        applyURL: 'https://careers.stripe.com/jobs/branded-role',
+      },
+    ],
+  };
+
+  const jobs = parseJobviteResponse(SAMPLE_RESPONSE, 'Stripe');
+
+  // count — dropped: no title, non-https URL, missing URL → 3 valid
+  if (jobs.length === 3) {
+    pass('parseJobviteResponse returns 3 jobs (drops no-title, non-https, missing URL)');
+  } else {
+    fail(`parseJobviteResponse count: ${jobs.length} (expected 3)`);
+  }
+
+  // job 0 — full field mapping
+  if (jobs[0]?.title === 'Senior Software Engineer') {
+    pass('parseJobviteResponse maps title correctly');
+  } else {
+    fail(`parseJobviteResponse title: ${JSON.stringify(jobs[0]?.title)}`);
+  }
+  if (jobs[0]?.url === 'https://jobs.jobvite.com/stripe/job/senior-swe') {
+    pass('parseJobviteResponse maps applyURL to url');
+  } else {
+    fail(`parseJobviteResponse url: ${JSON.stringify(jobs[0]?.url)}`);
+  }
+  if (jobs[0]?.company === 'Stripe') {
+    pass('parseJobviteResponse sets company from entry.name');
+  } else {
+    fail(`parseJobviteResponse company: ${JSON.stringify(jobs[0]?.company)}`);
+  }
+  if (jobs[0]?.location === 'San Francisco, CA') {
+    pass('parseJobviteResponse maps location field');
+  } else {
+    fail(`parseJobviteResponse location: ${JSON.stringify(jobs[0]?.location)}`);
+  }
+  if (Number.isInteger(jobs[0]?.postedAt)) {
+    pass('parseJobviteResponse parses date to postedAt epoch ms');
+  } else {
+    fail(`parseJobviteResponse postedAt: ${JSON.stringify(jobs[0]?.postedAt)}`);
+  }
+
+  // job 1 — location fallback to country when location is empty string
+  if (jobs[1]?.location === 'UK') {
+    pass('parseJobviteResponse falls back to country when location is empty');
+  } else {
+    fail(`parseJobviteResponse location fallback: ${JSON.stringify(jobs[1]?.location)}`);
+  }
+
+  // job 2 — branded domain applyURL accepted
+  if (jobs[2]?.url === 'https://careers.stripe.com/jobs/branded-role') {
+    pass('parseJobviteResponse accepts branded-domain applyURL (display-only)');
+  } else {
+    fail(`parseJobviteResponse branded URL: ${JSON.stringify(jobs[2]?.url)}`);
+  }
+
+  // null / bad input
+  if (parseJobviteResponse(null, 'X').length === 0) {
+    pass('parseJobviteResponse returns [] for null input');
+  } else {
+    fail('parseJobviteResponse should return [] for null input');
+  }
+  if (parseJobviteResponse({ jobs: 'not-an-array' }, 'X').length === 0) {
+    pass('parseJobviteResponse returns [] when jobs field is not an array');
+  } else {
+    fail('parseJobviteResponse returns [] when jobs is not an array');
+  }
+
+  // ── fetch() integration ────────────────────────────────────────
+
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const mockCtx = {
+    async fetchJson(url, opts) {
+      capturedUrl = url;
+      capturedOpts = opts;
+      return SAMPLE_RESPONSE;
+    },
+  };
+
+  const fetched = await jobvite.fetch(
+    { name: 'Stripe', careers_url: 'https://jobs.jobvite.com/stripe' },
+    mockCtx,
+  );
+
+  if (capturedUrl === 'https://jobs.jobvite.com/api/company/stripe/jobs') {
+    pass('jobvite.fetch() requests the correct API URL');
+  } else {
+    fail(`jobvite.fetch() fetched: ${JSON.stringify(capturedUrl)}`);
+  }
+
+  if (capturedOpts?.redirect === 'error') {
+    pass('jobvite.fetch() passes redirect:"error" to fetchJson');
+  } else {
+    fail(`jobvite.fetch() redirect option: ${JSON.stringify(capturedOpts?.redirect)}`);
+  }
+
+  if (fetched.length === 3) {
+    pass('jobvite.fetch() returns normalized jobs array');
+  } else {
+    fail(`jobvite.fetch() returned ${fetched.length} jobs (expected 3)`);
+  }
+
+  // fetch() throws when company ID cannot be resolved
+  let threw = false;
+  try {
+    await jobvite.fetch({ name: 'NoSlug' }, { async fetchJson() { return {}; } });
+  } catch {
+    threw = true;
+  }
+  if (threw) {
+    pass('jobvite.fetch() throws when company ID cannot be resolved');
+  } else {
+    fail('jobvite.fetch() should throw when company ID is missing');
+  }
+
+} catch (e) {
+  fail(`jobvite provider tests crashed: ${e.message}`);
+}


### PR DESCRIPTION
## What does this PR do?

Adds `providers/jobvite.mjs` — a zero-auth provider for the Jobvite ATS platform, used by ~3,000 companies. Supports automatic detection from `careers_url` (or explicit `provider: jobvite` + `api:` configuration), securely derives the tenant API endpoint, validates fetch targets to prevent SSRF, and parses Jobvite's public jobs JSON API into the standard job format.

## Related issue

No issue needed — new provider (exempt per CONTRIBUTING).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Implementation notes

### `providers/jobvite.mjs` (new provider)

Fetches `https://jobs.jobvite.com/api/company/{companyId}/jobs` — Jobvite's public, zero-auth per-tenant jobs API. No API key required.

Auto-detects Jobvite tenants from `careers_url` patterns such as `https://jobs.jobvite.com/{companyId}` or `https://jobs.jobvite.com/{companyId}/jobs`, while also supporting an explicit `api:` URL. The provider derives the tenant slug, constructs the canonical API endpoint, pins all fetches to `jobs.jobvite.com`, rejects non-HTTPS or untrusted hosts, and uses `redirect:"error"` to prevent SSRF via redirects. Job `applyURL` values are accepted from any valid HTTPS origin since they are display-only and never fetched.

### Test delta

`test-all.mjs` gains assertions covering `id`, `detect()` (careers URL, explicit API, invalid URLs), `resolveCompanyId()` (supported URL forms and malformed inputs), `parseJobviteResponse()` (field mapping, location fallback, date parsing, invalid/missing fields, HTTPS validation, empty/null input), and `fetch()` integration (correct API URL, `redirect:"error"`, normalized output).

**Results: 1109 passed, 47 failed** — the 47 failures are identical to the pre-PR baseline (missing `js-yaml`/`playwright` dev dependencies and Go binary in the sandbox; zero regressions introduced).

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new **Wellfound** (RSS) and **Jobvite** (API) job sources with detection, fetching, and feed/API parsing.
* **Bug Fixes**
  * Tightened trusted **HTTPS-only** URL validation and pinned-domain checks for job/feed links.
  * Improved job normalization (required fields, safer date parsing, and clearer company/location fallback behavior).
* **Refactor**
  * Centralized shared RSS/XML parsing helpers and reused them across existing providers.
* **Tests**
  * Added automated coverage for Wellfound and Jobvite detect, parse, and fetch flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->