### PR TITLE
fix(pdf): implement MD->HTML->PDF pipeline bridging

### DIFF
--- a/build-cv.mjs
+++ b/build-cv.mjs
@@ -75,7 +75,7 @@ async function main() {
   const expToken = '___EXPERIENCE___';
   templateHtml = templateHtml.replace('{{EXPERIENCE}}', expToken);
   templateHtml = templateHtml.replace(/\{\{[^}]+\}\}/g, '');
-  templateHtml = templateHtml.replace(expToken, parsedHtml);
+  templateHtml = templateHtml.replace(expToken, () => parsedHtml);
 
   // Determine output path based on filename regex: reports/NNN-company-YYYY-MM-DD.md
   const base = basename(mdPath);

--- a/build-cv.mjs
+++ b/build-cv.mjs
@@ -11,6 +11,7 @@ import { execSync } from 'child_process';
 import os from 'os';
 import { renderHtmlToPdf } from './generate-pdf.mjs';
 import { marked } from 'marked';
+import sanitizeHtml from 'sanitize-html';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -63,53 +64,41 @@ async function main() {
   console.log(`📄 Reading markdown: ${mdPath}`);
   const mdContent = readFileSync(mdPath, 'utf-8');
   
-  // Convert MD to HTML
-  const parsedHtml = marked.parse(mdContent);
+  // Convert MD to HTML and sanitize it to prevent script injection
+  const parsedHtml = sanitizeHtml(marked.parse(mdContent));
 
   // Load resume template
   const templatePath = resolve(__dirname, 'templates', 'resume-template.html');
   let templateHtml = readFileSync(templatePath, 'utf-8');
 
-  // Inject into template. We replace {{EXPERIENCE}} with the content, and strip out the other template sections.
-  templateHtml = templateHtml.replace('{{EXPERIENCE}}', parsedHtml);
-  // Strip remaining placeholders to keep the output clean
+  // Protect {{EXPERIENCE}}, strip remaining placeholders, then inject HTML
+  const expToken = '___EXPERIENCE___';
+  templateHtml = templateHtml.replace('{{EXPERIENCE}}', expToken);
   templateHtml = templateHtml.replace(/\{\{[^}]+\}\}/g, '');
+  templateHtml = templateHtml.replace(expToken, parsedHtml);
 
-  // Write intermediate HTML to os.tmpdir()
-  const tmpHtmlPath = join(os.tmpdir(), `build-cv-${Date.now()}.html`);
-  writeFileSync(tmpHtmlPath, templateHtml, 'utf-8');
-
-  try {
-    // Determine output path based on filename regex: reports/NNN-company-YYYY-MM-DD.md
-    const base = basename(mdPath);
-    const match = base.match(/^\d+-(.+)-(\d{4}-\d{2}-\d{2})\.md$/);
-    
-    let pdfPath;
-    if (match) {
-      const company = match[1];
-      const date = match[2];
-      pdfPath = resolve(__dirname, 'output', `cv-candidate-${company}-${date}.pdf`);
-    } else {
-      const date = new Date().toISOString().slice(0, 10);
-      const safeBase = base.replace(/\.md$/, '');
-      pdfPath = resolve(__dirname, 'output', `cv-candidate-unknown-${safeBase}-${date}.pdf`);
-      console.warn(`⚠️  Filename ${base} does not match expected format. Using fallback: ${basename(pdfPath)}`);
-    }
-
-    // Generate PDF using exported function
-    await renderHtmlToPdf(templateHtml, pdfPath, { 
-      format: 'letter', 
-      baseDir: os.tmpdir(), 
-      inputPath: mdPath 
-    });
-
-  } finally {
-    try {
-      rmSync(tmpHtmlPath);
-    } catch (e) {
-      // Ignore cleanup errors
-    }
+  // Determine output path based on filename regex: reports/NNN-company-YYYY-MM-DD.md
+  const base = basename(mdPath);
+  const match = base.match(/^\d+-(.+)-(\d{4}-\d{2}-\d{2})\.md$/);
+  
+  let pdfPath;
+  if (match) {
+    const company = match[1];
+    const date = match[2];
+    pdfPath = resolve(__dirname, 'output', `cv-candidate-${company}-${date}.pdf`);
+  } else {
+    const date = new Date().toISOString().slice(0, 10);
+    const safeBase = base.replace(/\.md$/, '');
+    pdfPath = resolve(__dirname, 'output', `cv-candidate-unknown-${safeBase}-${date}.pdf`);
+    console.warn(`⚠️  Filename ${base} does not match expected format. Using fallback: ${basename(pdfPath)}`);
   }
+
+  // Generate PDF using exported function
+  await renderHtmlToPdf(templateHtml, pdfPath, { 
+    format: 'letter', 
+    baseDir: os.tmpdir(), 
+    inputPath: mdPath 
+  });
 }
 
 main().catch(err => {

--- a/build-cv.mjs
+++ b/build-cv.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+/**
+ * build-cv.mjs — Markdown -> HTML -> PDF pipeline
+ */
+
+import { resolve, dirname, basename, join } from 'path';
+import { readFileSync, writeFileSync, readdirSync, statSync, rmSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+import os from 'os';
+import { renderHtmlToPdf } from './generate-pdf.mjs';
+import { marked } from 'marked';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function main() {
+  let mdPath = process.argv[2];
+
+  if (!mdPath) {
+    const reportsDir = resolve(__dirname, 'reports');
+    let files = [];
+    try {
+      files = readdirSync(reportsDir).filter(f => f.endsWith('.md'));
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+    }
+
+    if (files.length === 0) {
+      console.error('❌ No markdown report provided and reports/ is empty.');
+      process.exit(1);
+    }
+
+    // Sort by mtime descending
+    files.sort((a, b) => statSync(join(reportsDir, b)).mtimeMs - statSync(join(reportsDir, a)).mtimeMs);
+    let newest = files[0];
+
+    // If identical mtimes, fallback to git log
+    if (files.length > 1 && statSync(join(reportsDir, files[0])).mtimeMs === statSync(join(reportsDir, files[1])).mtimeMs) {
+      try {
+        const out = execSync(`git log -1 --name-only --format= -- reports/`, { encoding: 'utf-8' }).trim();
+        if (out && out.endsWith('.md')) {
+          newest = basename(out);
+        }
+      } catch (e) {
+        // fallback to mtime sort if git fails
+      }
+    }
+    
+    mdPath = join(reportsDir, newest);
+  }
+
+  mdPath = resolve(mdPath);
+  if (!mdPath.endsWith('.md')) {
+    console.error(`❌ Input file must be a markdown file (.md). Got: ${mdPath}`);
+    process.exit(1);
+  }
+  if (!statSync(mdPath, { throwIfNoEntry: false })) {
+    console.error(`❌ Input file not found: ${mdPath}`);
+    process.exit(1);
+  }
+
+  console.log(`📄 Reading markdown: ${mdPath}`);
+  const mdContent = readFileSync(mdPath, 'utf-8');
+  
+  // Convert MD to HTML
+  const parsedHtml = marked.parse(mdContent);
+
+  // Load resume template
+  const templatePath = resolve(__dirname, 'templates', 'resume-template.html');
+  let templateHtml = readFileSync(templatePath, 'utf-8');
+
+  // Inject into template. We replace {{EXPERIENCE}} with the content, and strip out the other template sections.
+  templateHtml = templateHtml.replace('{{EXPERIENCE}}', parsedHtml);
+  // Strip remaining placeholders to keep the output clean
+  templateHtml = templateHtml.replace(/\{\{[^}]+\}\}/g, '');
+
+  // Write intermediate HTML to os.tmpdir()
+  const tmpHtmlPath = join(os.tmpdir(), `build-cv-${Date.now()}.html`);
+  writeFileSync(tmpHtmlPath, templateHtml, 'utf-8');
+
+  try {
+    // Determine output path based on filename regex: reports/NNN-company-YYYY-MM-DD.md
+    const base = basename(mdPath);
+    const match = base.match(/^\d+-(.+)-(\d{4}-\d{2}-\d{2})\.md$/);
+    
+    let pdfPath;
+    if (match) {
+      const company = match[1];
+      const date = match[2];
+      pdfPath = resolve(__dirname, 'output', `cv-candidate-${company}-${date}.pdf`);
+    } else {
+      const date = new Date().toISOString().slice(0, 10);
+      const safeBase = base.replace(/\.md$/, '');
+      pdfPath = resolve(__dirname, 'output', `cv-candidate-unknown-${safeBase}-${date}.pdf`);
+      console.warn(`⚠️  Filename ${base} does not match expected format. Using fallback: ${basename(pdfPath)}`);
+    }
+
+    // Generate PDF using exported function
+    await renderHtmlToPdf(templateHtml, pdfPath, { 
+      format: 'letter', 
+      baseDir: os.tmpdir(), 
+      inputPath: mdPath 
+    });
+
+  } finally {
+    try {
+      rmSync(tmpHtmlPath);
+    } catch (e) {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+main().catch(err => {
+  console.error('❌ PDF pipeline failed:', err.message);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dedup": "node dedup-tracker.mjs",
     "merge": "node merge-tracker.mjs",
     "reconcile": "node reconcile-pipeline.mjs",
-    "pdf": "node generate-pdf.mjs",
+    "pdf": "node build-cv.mjs",
     "cover-letter": "node generate-cover-letter.mjs --payload",
     "sync-check": "node cv-sync-check.mjs",
     "update:check": "node update-system.mjs check",
@@ -66,5 +66,8 @@
     "dotenv": "^17.0.0",
     "js-yaml": "^4.1.1",
     "playwright": "1.61.1"
+  },
+  "devDependencies": {
+    "marked": "^18.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,9 +65,8 @@
     "@google/generative-ai": "^0.24.1",
     "dotenv": "^17.0.0",
     "js-yaml": "^4.1.1",
-    "playwright": "1.61.1"
-  },
-  "devDependencies": {
-    "marked": "^18.0.5"
+    "marked": "^18.0.5",
+    "playwright": "1.61.1",
+    "sanitize-html": "^2.17.5"
   }
 }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -106,6 +106,7 @@ const SYSTEM_PATHS = [
   'KIMI.md',
   'build-dashboard.mjs',
   'generate-pdf.mjs',
+  'build-cv.mjs',
   'generate-latex.mjs',
   'archive-posting.mjs',
   'application-answers.mjs',


### PR DESCRIPTION
## What does this PR do?

Implements the MD->HTML->PDF pipeline bridging to resolve the broken PDF generation. Created the `build-cv.mjs` script that accepts a markdown report, parses it to HTML using `marked`, injects it into `resume-template.html`, and compiles it safely via Playwright while gracefully handling filename parsing and manifest upserts.

## Related issue

Fixes #1510

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

**Notes:** `renderHtmlToPdf` has a pre-existing manifest side effect (`data/pdf-index.tsv`) not mentioned in the original issue. Verified it's gitignored, upserts correctly by PDF path (tested with 2 distinct reports), and that the dashboard's Go parser explicitly tolerates a blank report-number field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to generate a CV PDF from a Markdown report.
  * If no input is provided, the latest Markdown report is selected automatically and a dated PDF name is created.
* **Chores**
  * Updated the `pdf` npm script to use the new CV builder command.
  * Extended the system-update scope to include the new CV builder script.
* **Dependencies**
  * Added libraries for Markdown-to-HTML conversion and HTML sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->