### PR TITLE
Add career-ops-plugin-markdown to the registry

### DIFF
--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -100,6 +100,20 @@
       "license": "MIT",
       "version": "0.1.0",
       "sha": "9252dc84c09dbb597c995190b82322109cf84805"
+    },
+    {
+      "name": "career-ops-plugin-markdown",
+      "id": "markdown",
+      "repo": "https://github.com/rubicon/career-ops-plugin-markdown",
+      "author": "rubicon",
+      "hooks": ["export"],
+      "description": "Export your cv.md to a clean, markdownlint-compliant Markdown resume, honoring #### nested sub-roles for fractional, interim, and umbrella engagements.",
+      "requiredEnv": [],
+      "allowedHosts": [],
+      "skill": true,
+      "license": "MIT",
+      "version": "0.1.0",
+      "sha": "d19e128135ee1b900e093a67311ca8d6251b9211"
     }
   ]
 }


### PR DESCRIPTION
## Plugin registry change

Paste the registry entry (one object), pinned to the exact reviewed commit:

```json
{
  "name": "career-ops-plugin-markdown",
  "id": "markdown",
  "repo": "https://github.com/rubicon/career-ops-plugin-markdown",
  "author": "rubicon",
  "hooks": ["export"],
  "description": "Export your cv.md to a clean, markdownlint-compliant Markdown resume, honoring #### nested sub-roles for fractional, interim, and umbrella engagements.",
  "requiredEnv": [],
  "allowedHosts": [],
  "skill": true,
  "license": "MIT",
  "version": "0.1.0",
  "sha": "d19e128135ee1b900e093a67311ca8d6251b9211"
}
```

### Maintainer review checklist

- [ ] Naming `career-ops-plugin-<name>`; `id` == name minus the prefix
- [ ] Minimum files present (manifest.json, index.mjs, README.md, LICENSE)
- [ ] Manifest valid: apiVersion 1, `humanInTheLoop: true`, hooks subset of {provider, ingest, search, notify, export}, no apply/submit
- [ ] MIT-compatible LICENSE; no personal data in the repo
- [ ] Egress: `allowedHosts` empty; no IP literals / metadata / `*.internal`; no localhost
- [ ] Static audit clean: no `child_process`/`playwright`/raw sockets/global `fetch`/`eval`/bare-dependency imports
- [ ] No core-owned secrets in `requiredEnv`
- [ ] Reads PUBLIC data or the user's OWN account only; no auto-submit
- [ ] No commercial / hosted-service / monetization wording
- [ ] If it ships a skill: domain-scoped, does not edit core files
- [ ] `sha` is pinned to the exact reviewed commit
- [ ] CI (`plugin-registry-validate`) is green

Closes #1579


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new community plugin for exporting resumes to clean Markdown format.
  * The plugin is now available in the plugin registry with pinned metadata and export support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
