### PR TITLE
Document agent-inbox usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Fills out application form | `apply` |
 | Searches for new offers | `scan` |
 | Processes pending URLs | `pipeline` |
+| Queues something for later or checks the inbox | `agent-inbox` — append-only checklist for requests between sessions; the agent drains it at the start of the next session, and nothing auto-submits |
 | Batch processes offers | `batch` |
 | Asks about rejection patterns, wants to improve targeting, or wants to match interview answers to best-fit roles | `patterns` |
 | Asks about follow-ups or application cadence | `followup` |

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ npx playwright install chromium   # only needed for PDF generation
 
 # 2. Check setup
 npm run doctor                     # Validates all prerequisites
+node agent-inbox.mjs add "..."      # Queue a request between sessions; appends to the inbox the agent drains next session, and nothing auto-submits
 
 # 3. Configure
 cp config/profile.example.yml config/profile.yml  # Edit with your details


### PR DESCRIPTION
## What does this PR do?

* Add `agent-inbox` to the `AGENTS.md` skill mode routing table.
* Document `node agent-inbox.mjs add "..."` in `README.md`.
* Clarify that the inbox is an append-only checklist, is drained by the agent in the next session, and never auto-submits.
* Confirmed `agent-inbox` appears in both `README.md` and `AGENTS.md`.


## Related issue

Closes #1485

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ x ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [ x ] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ x ] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [ x ] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ x ] I ran `node test-all.mjs` and all tests pass
- [ x ] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ x ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for queuing requests to be handled in the next session.
  * Clarified that the inbox is append-only, is processed at the start of the next session, and does not auto-submit requests.
  * Updated the quick start steps with an explicit command for adding a request to the inbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->