### PR TITLE
Add reply-watch scaffold for post-application updates

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -4,7 +4,7 @@ description: AI job search command center -- evaluate offers, generate CVs, scan
 arguments: mode
 user_invocable: true
 user-invocable: true
-argument-hint: "[scan | deep | pdf | latex | cover | email | add | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | followup | update]"
+argument-hint: "[scan | deep | pdf | latex | cover | email | reply-watch | add | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | followup | update]"
 license: MIT
 ---
 
@@ -50,6 +50,8 @@ Determine the mode from `$mode`:
 | `pdf` | `pdf` |
 | `latex` | `latex` |
 | `email` | `email` |
+| `reply-watch` | `reply-watch` |
+| `inbox-watch` | `reply-watch` |
 | `training` | `training` |
 | `project` | `project` |
 | `tracker` | `tracker` |
@@ -83,6 +85,7 @@ Concrete equivalents for Codex prompt-driven sessions:
 /career-ops pipeline       ↔ "Run the career-ops pipeline mode for data/pipeline.md."
 /career-ops pdf            ↔ "Run the career-ops pdf mode for the latest evaluated role."
 /career-ops email          ↔ "Run the career-ops email mode for the latest evaluated role."
+/career-ops reply-watch    ↔ "Run the career-ops reply-watch mode and summarize employer replies."
 /career-ops tracker        ↔ "Run the career-ops tracker mode and summarize the current statuses."
 ```
 
@@ -108,6 +111,7 @@ Available commands:
   /career-ops latex     → Export CV as LaTeX/Overleaf .tex
   /career-ops cover     → Cover letter: standalone JD paste or /career-ops cover {slug}
   /career-ops email     → Formal application email draft (draft-only; never sends, submits, or clicks)
+  /career-ops reply-watch → Employer reply digest (read-only; recommends tracker updates for review)
   /career-ops add       → Add a project/paper/role to your CV (fetch + preview + confirm)
   /career-ops training  → Evaluate course/cert against North Star
   /career-ops project   → Evaluate portfolio project idea
@@ -138,7 +142,7 @@ Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `p
 ### Standalone modes (only their mode file):
 Read `modes/{mode}.md`
 
-Applies to: `tracker`, `agent-inbox`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`, `email`, `add`
+Applies to: `tracker`, `agent-inbox`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `training`, `project`, `patterns`, `followup`, `cover`, `email`, `reply-watch`, `add`
 
 ### Modes delegated to subagent:
 For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `detect-reposts.mjs` | Repost detector — flags roles re-listed 2+ times in 90 days from scan-history.tsv (JSON or `--summary` table output) |
 | `process-quality.mjs` | Recruiting-process friction aggregator — parses `[process-friction]` tags candidates add to `data/active-interviews.md` Notes and reports per-company friction rate (JSON or `--summary` table output) |
 | `data/follow-ups.md` | Follow-up history tracker |
+| `modes/reply-watch.md` | Employer reply digest instructions |
 | `scan.mjs` | Zero-token portal scanner — hits Greenhouse/Ashby/Lever APIs directly, zero LLM cost |
 | `check-liveness.mjs` | Job posting liveness checker |
 | `liveness-core.mjs` | Shared liveness logic (expired signals win over generic Apply text) |
@@ -269,6 +270,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Asks to compare offers | `ofertas` |
 | Wants LinkedIn outreach | `contacto` — identifies hiring manager, recruiter, or team peers via web search; drafts a ≤300-char message tailored to the contact type (recruiter / hiring manager / peer / interviewer) |
 | Wants a formal application email | `email` — draft-only subject, body, attachment checklist, and contact block from a report or JD; never sends, submits, or clicks anything |
+| Wants to know whether employers/recruiters replied by email | `reply-watch` — read-only employer reply digest; classifies interview invites, human replies, rejections, action requests, and auto-confirmations; tracker changes require confirmation |
 | Asks for company research | `deep` — generates a structured 6-axis research prompt covering AI strategy, recent moves, engineering culture, likely challenges, competitors, and the candidate's angle given their profile |
 | Preps for interview at specific company | `interview-prep` |
 | Wants a time-blocked prep plan for an upcoming interview | `interview/plan` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ You can invoke the command center or any of its modes directly within your CLI:
 * `latex` — Export CV as LaTeX/Overleaf .tex
 * `cover` — Generate cover letter
 * `email` — Draft formal application email only; never sends, submits, or clicks
+* `reply-watch` — Summarize employer inbox replies; read-only unless tracker updates are confirmed
 * `interview-prep` — Generate interview preparation guide
 * `interview` — Onboarding/on-demand interview
 * `contacto` — Generate LinkedIn outreach message
@@ -262,6 +263,7 @@ Default modes are in `modes/` (English). Language-specific modes live in `modes/
 | Asks to compare offers | `ofertas` |
 | Wants LinkedIn outreach | `contacto` |
 | Wants a formal application email | `email` — draft-only; never sends, submits, or clicks anything |
+| Wants to know whether employers/recruiters replied by email | `reply-watch` — read-only employer reply digest; tracker changes require confirmation |
 | Asks for company research | `deep` |
 | Preps for interview at specific company | `interview-prep` |
 | Wants interactive profile/CV onboarding | `interview` |

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Built by someone who used it to evaluate 740+ job offers, generate 100+ tailored
 | **ATS PDF Generation**   | Keyword-injected CVs with Space Grotesk + DM Sans design                                                                                 |
 | **Cover Letter Generator** | Research-backed cover letters with keyword mirroring, four interactive angle prompts (why/problems/approach/tone), draft-in-chat approval gate, and A4 PDF via the same HTML + Playwright pipeline as CVs. Auto-drafts on every evaluation; complete and generate on demand via `/career-ops cover` |
 | **Application Email Drafts** | Formal recruiter/referral/cold application emails from a report or pasted JD, with subject line, attachment checklist, source-backed fit points, and a profile-driven contact block. Draft-only -- career-ops never sends, submits, or clicks anything. |
+| **Reply Watch**        | Read-only employer reply digest that classifies interview invites, human replies, rejections, action requests, and auto-confirmations. It recommends tracker updates, but only applies them after review. |
 | **Portal Scanner**       | 45+ companies pre-configured (Anthropic, OpenAI, ElevenLabs, Retool, n8n...) + custom queries across Ashby, Greenhouse, Lever, Wellfound |
 | **Batch Processing**     | Parallel evaluation with headless CLI workers (`claude -p` / `opencode run`)                                                             |
 | **Dashboard TUI**        | Terminal UI to browse, filter, and sort your pipeline                                                                                    |
@@ -281,6 +282,7 @@ Career-ops uses a shared command router. In CLIs that register slash commands, i
 /career-ops pdf            → Generate ATS-optimized CV
 /career-ops cover          → Cover letter generator (paste JD or /career-ops cover {slug})
 /career-ops email          → Formal application email draft (draft-only; never sends, submits, or clicks)
+/career-ops reply-watch    → Employer reply digest (read-only; tracker updates require review)
 /career-ops batch          → Batch evaluate multiple offers
 /career-ops tracker        → View application status
 /career-ops apply          → Fill application forms with AI
@@ -372,6 +374,7 @@ career-ops/
 │   ├── pdf.md                   # PDF generation
 │   ├── cover.md                 # Cover letter generation
 │   ├── email.md                 # Formal application email drafts
+│   ├── reply-watch.md           # Employer reply digest
 │   ├── scan.md                  # Portal scanner
 │   ├── batch.md                 # Batch processing
 │   └── ...

--- a/modes/reply-watch.md
+++ b/modes/reply-watch.md
@@ -1,0 +1,170 @@
+# Mode: reply-watch -- Employer Reply Digest
+
+Summarize recruiting-related inbox replies so the candidate can answer one
+daily question: "Do any employer replies need my attention?"
+
+This mode is read-only by default. It never sends email, never clicks links,
+never submits applications, and never changes tracker state without explicit
+user confirmation.
+
+Related planning issues:
+- #1582 -- umbrella
+- #1583 -- read-only Gmail reply scanner
+- #1584 -- match reply candidates to tracker entries
+- #1585 -- classify replies and generate a daily action digest
+
+## Purpose
+
+Detect and summarize replies from employers, recruiters, hiring managers, and
+companies after the candidate has applied or followed up.
+
+## Inputs
+
+Read:
+- `data/applications.md` -- application tracker
+- `data/follow-ups.md` if present -- prior outreach history
+- `config/profile.yml` if present -- candidate identity and optional email
+  preferences
+- `modes/_custom.md` if present -- procedural preferences only
+- Normalized reply candidates supplied by an opt-in connector, plugin, or manual
+  paste/export
+
+Do not read arbitrary files outside the career-ops project for content claims.
+Do not use memory as a source for facts about applications.
+
+## Invocation
+
+Supported forms:
+
+1. `/career-ops reply-watch`
+   - Use available normalized reply candidates from the configured inbox
+     connector, if one exists.
+   - If no connector is configured, explain that the mode can still classify
+     pasted/exported message summaries and point to the read-only Gmail scanner
+     planning issue (#1583).
+
+2. `/career-ops reply-watch {pasted email summaries}`
+   - Treat the pasted content as candidate-supplied context for this run only.
+   - Extract sender, subject, date, snippet/body summary, and any visible company
+     or role signals.
+
+3. `/career-ops inbox-watch`
+   - Alias for `reply-watch`.
+
+## Step 1 -- Collect Reply Candidates
+
+Accept normalized candidates with fields like:
+
+```json
+{
+  "messageId": "provider-specific-id",
+  "date": "YYYY-MM-DD",
+  "from": "Recruiter Name <recruiter@example.com>",
+  "subject": "Re: Senior AI Engineer application",
+  "snippet": "Could you share availability for a first conversation?",
+  "bodySummary": "Optional short summary from the connector",
+  "source": "gmail"
+}
+```
+
+If the data source is unavailable, do not fail the whole mode. Say:
+
+> "No inbox connector is configured yet. Paste the message summaries here, or
+> enable a read-only inbox plugin when one is available."
+
+## Step 2 -- Match to Applications
+
+Match candidates against `data/applications.md` using conservative signals:
+
+- company name in sender, subject, snippet, body summary, or sender domain
+- role title overlap
+- ATS or recruiter domain hints
+- application date before message date
+- known contacts from tracker notes or `data/follow-ups.md`
+
+Use confidence buckets:
+
+| Confidence | Meaning |
+|------------|---------|
+| `high` | Multiple strong signals identify one tracker row |
+| `medium` | One strong signal or several weak signals identify one likely row |
+| `low` | Recruiting-related, but the tracker row is ambiguous |
+| `unmatched` | No plausible tracker row |
+
+Prefer false negatives over false positives. Never update the tracker from a
+`medium`, `low`, or `unmatched` candidate without asking the user to choose the
+row.
+
+## Step 3 -- Classify Reply Type
+
+Classify each candidate:
+
+| Type | Use when |
+|------|----------|
+| `Interview` | The message invites the candidate to interview, screen, or schedule a call |
+| `Need Action` | The candidate must pick times, complete a form, provide documents, or reply by a deadline |
+| `Responded` | A human reply or next-step conversation that is not clearly an interview |
+| `Rejected` | The candidate is rejected, the role is closed for them, or the company will not proceed |
+| `Auto-confirmation` | Automated application receipt, newsletter, alert, or no-reply confirmation |
+| `Unknown` | Recruiting-related but not confidently classifiable |
+
+Auto-confirmations are useful context but should not be counted as employer
+responses needing action.
+
+## Step 4 -- Display Daily Digest
+
+Show urgent/actionable replies first, then informational items.
+
+Use this shape:
+
+```text
+Reply Watch -- {date}
+{N} recruiting replies reviewed, {M} need attention
+
+1. {Company} -- {Role} (#{num or "unmatched"})
+   Type: {Interview | Need Action | Responded | Rejected | Auto-confirmation | Unknown}
+   Match: {high | medium | low | unmatched}; signals: {signals}
+   Summary: {one sentence}
+   Suggested tracker update: {Interview | Responded | Rejected | none | ask user}
+   Recommended action: {reply today | review manually | no action}
+```
+
+Keep summaries short. Do not quote long email bodies. If the pasted message
+contains sensitive personal data, paraphrase rather than repeating it.
+
+## Step 5 -- Human-in-the-Loop Tracker Updates
+
+Suggest tracker updates, but do not apply them unless the user explicitly says
+to update the tracker.
+
+Suggested mapping:
+
+| Reply type | Suggested tracker state |
+|------------|-------------------------|
+| `Interview` | `Interview` |
+| `Need Action` for scheduling/interview | `Interview` |
+| `Responded` | `Responded` |
+| `Rejected` | `Rejected` |
+| `Auto-confirmation` | no status change |
+| `Unknown` | no status change |
+
+If the user approves a tracker update:
+
+1. Update the existing row in `data/applications.md`.
+2. Do not create a new application row.
+3. Keep statuses canonical from `templates/states.yml`.
+4. Add a short note such as `Reply Watch: interview invite 2026-07-06`.
+5. Run `node verify-pipeline.mjs`.
+
+## Step 6 -- Summary
+
+End with:
+
+- number of replies reviewed
+- number needing action today
+- recommended tracker updates waiting for confirmation
+- unmatched replies the user should review manually
+
+If no actionable replies are found, say:
+
+> "No employer replies need action today."

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -58,6 +58,7 @@ const SYSTEM_PATHS = [
   'modes/pdf.md',
   'modes/cover.md',
   'modes/email.md',
+  'modes/reply-watch.md',
   'modes/add.md',
   'modes/scan.md',
   'modes/batch.md',


### PR DESCRIPTION
## Summary

Adds the first core scaffold for `reply-watch`: a post-application update workflow that helps candidates check whether employers or recruiting systems replied after a resume/application was submitted.

This is intentionally distinct from the existing Gmail job-lead ingestion plugin:

```text
Gmail job-lead ingest:
email label → job URLs → data/pipeline.md

reply-watch:
existing tracker row → employer/recruiting reply → classified update → human confirmation → tracker status
```

This PR does not implement the Gmail scanner yet. It defines the mode contract, routing, documentation, and update-system coverage so follow-up PRs can implement inbox scanning, matching, classification, and human-in-the-loop tracker updates.

## What changed

- Added `modes/reply-watch.md` with the read-only post-application reply-watch contract.
- Routed `/career-ops reply-watch` and `/career-ops inbox-watch` through the shared career-ops skill router.
- Documented the mode in `AGENTS.md`, `CLAUDE.md`, and `README.md`.
- Registered `modes/reply-watch.md` in `update-system.mjs` so it is treated as system-layer/updatable content.

## Intended follow-up behavior

Follow-up implementation should let career-ops answer:

> I submitted my resume. Did the company reply, and what does that reply mean?

The eventual workflow should:

1. Read existing applications from `data/applications.md`.
2. Search an opt-in mailbox connector for related employer/recruiting-system messages.
3. Classify replies as `Interview`, `Responded`, `Rejected`, `Offer`, `Needs Review`, or `Noise`.
4. Distinguish job-lead marketing from actual post-application progress.
5. Write proposed updates to a review queue/digest first.
6. Update `data/applications.md` only after explicit user confirmation.

## Classification examples to preserve in follow-up PRs

High-confidence interview:

```text
恭喜简历通过，杭州赢云贸易有限公司邀您面试
AI微信小程序面试
```

Noise / job lead, not an interview:

```text
邀请投递
抢面试先机
立即投递
```

Needs review / process activity:

```text
邀请您在面试/入职之前更新或补充最新的应聘信息
```

## Safety

- No email sending.
- No email reply/archive/delete/label actions.
- No application submission.
- No bundled Gmail plugin behavior changes in this scaffold.
- Tracker updates are recommendations only unless the user explicitly confirms.

## Related issues

Refs #1582
Refs #1583
Refs #1584
Refs #1585

## Validation

- `node validate-system-paths-coverage.mjs`
- `node test-all.mjs --quick` — 1232 passed, 0 failed, 1 expected warning for missing user CV in a clean repo
