### PR TITLE
Apply compensation reliability checks to batch workers

### DIFF
--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -135,6 +135,49 @@ Sección de **gaps** con estrategia de mitigación para cada uno:
 
 Usar WebSearch para salarios actuales (Glassdoor, Levels.fyi, Blind), reputación comp de la empresa, tendencia demanda. Tabla con datos y fuentes citadas. Si no hay datos, decirlo.
 
+Antes de interpretar cualquier salario, clasifica el **tipo de empresa / hiring entity**. El salario público es una señal, no una promesa contractual.
+
+**Company type classification (required):**
+
+| Company type | Typical comp reliability | Signals |
+|--------------|--------------------------|---------|
+| Public big tech / mature tech | High to medium | Public company, structured levels, large engineering org, repeatable hiring process |
+| Growth-stage startup / VC-backed startup | Medium | Funded startup, competitive hiring market, may mix base + equity + bonus |
+| Early-stage startup / pre-revenue startup | Medium to low | Small team, vague role scope, equity-heavy promises, unclear bands |
+| Enterprise / traditional corporate | Medium | Formal HR process, stable base, slower bands, bonus may be discretionary |
+| Agency / outsourcing / consulting vendor | Medium to low | Client allocation, project-based work, billability pressure, variable bonus |
+| Local SMB / service business | Low | Small company, broad role, informal HR, "comprehensive salary" language |
+| Sales / commission-heavy org | Low unless base is explicit | OTE, uncapped commission, performance bonus, target-based pay |
+| Recruiter / staffing listing | Low to medium | Third-party posting, range may reflect client budget rather than offer terms |
+| Government / academic / nonprofit | Medium to high | Published grades/bands, but lower market competitiveness |
+| Open-source community / education community | Medium to low | Community-led org, foundation/association sponsor, campus/community operations, unclear employment entity |
+
+If the brand differs from the legal employer or posting entity, classify the **actual contract / hiring entity** first and mention the brand relationship separately. If the company type is uncertain, mark it as `Unknown` and default compensation reliability to the conservative canonical tier: `Low` until evidence improves it.
+
+**Compensation reliability (required):**
+
+First check whether the JD itself states a salary figure. If no advertised number exists, collapse this section to exactly two concise lines after the demand trend:
+
+- **Company type:** {category or `Unknown`} — {confidence + one evidence phrase}
+- **Compensation reliability:** {tier} — no advertised salary figure; skip component split, detailed market rows, and HR verification questions
+
+When an advertised salary figure exists, split compensation into:
+- **Advertised range:** the JD's own salary/range, copied verbatim
+- **Likely guaranteed base:** conservative estimate of fixed contract salary
+- **Variable / conditional cash components:** bonus, commission, allowance, attendance bonus, KPI bonus, overtime, 13th salary, sign-on, or other cash tied to conditions
+- **Expected stable cash:** what is likely recurring and reliable in cash, before tax unless local data supports a net estimate; exclude benefits
+- **Non-cash benefits:** equity, insurance, pension, meals, transport, wellness, learning budget, equipment, or other benefits that are not guaranteed cash
+
+Reliability tier:
+- **High:** salary is stated as base or backed by structured public bands / multiple consistent sources
+- **Medium:** range is plausible but components are not fully separated
+- **Low:** public number likely includes variable, attendance, commission, subsidy, or "up to" components
+- **Unknown:** no usable salary data
+
+Treat "comprehensive salary", "total package", "up to", "OTE", "uncapped", "allowances included", "attendance bonus", "KPI bonus", "base + variable", "base + commission", and unusually wide ranges as low-reliability unless fixed base is separated.
+
+When a salary figure exists, include 3-6 HR verification questions tailored to the company type. Do not present advertised compensation as real take-home pay unless the source explicitly supports that interpretation.
+
 Score de comp (1-5): 5=top quartile, 4=above market, 3=median, 2=slightly below, 1=well below.
 
 #### Bloque E — Plan de Personalización

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1353,6 +1353,27 @@ if (
   fail('_shared.md missing canonical company-type compensation reliability framework');
 }
 
+const batchPromptDoc = readFile('batch/batch-prompt.md');
+if (
+  batchPromptDoc.includes('Company type classification (required)') &&
+  batchPromptDoc.includes('actual contract / hiring entity') &&
+  batchPromptDoc.includes('default compensation reliability to the conservative canonical tier: `Low`') &&
+  batchPromptDoc.includes('Compensation reliability (required)') &&
+  batchPromptDoc.includes('If no advertised number exists, collapse this section to exactly two concise lines') &&
+  batchPromptDoc.includes('skip component split, detailed market rows, and HR verification questions') &&
+  batchPromptDoc.includes('Advertised range') &&
+  batchPromptDoc.includes('Likely guaranteed base') &&
+  batchPromptDoc.includes('Variable / conditional cash components') &&
+  batchPromptDoc.includes('Expected stable cash') &&
+  batchPromptDoc.includes('Non-cash benefits') &&
+  batchPromptDoc.includes('When a salary figure exists, include 3-6 HR verification questions') &&
+  batchPromptDoc.includes('Do not present advertised compensation as real take-home pay')
+) {
+  pass('batch workers inherit company-type compensation reliability checks');
+} else {
+  fail('batch prompt missing company-type compensation reliability checks');
+}
+
 const pipelineMode = readFile('modes/pipeline.md');
 if (
   pipelineMode.includes('## Liveness sweep') &&
@@ -1369,8 +1390,6 @@ if (
 // --- salary tracking mode wiring (#1656 PR-2) ---
 const trackerModeDoc = readFile('modes/tracker.md');
 const patternsModeDoc = readFile('modes/patterns.md');
-const batchPromptDoc = readFile('batch/batch-prompt.md');
-
 if (
   ofertaMode.includes('Advertised (JD)') &&
   ofertaMode.includes('salary-observations.tsv') &&


### PR DESCRIPTION
## Summary

- add company-type compensation reliability checks to the self-contained batch worker prompt
- require batch Block D to split advertised salary, likely base, variable components, and stable cash
- add a mode integrity assertion so batch evaluations do not drift from the default salary skepticism behavior

## Context

Closes #1588.

Batch workers use `batch/batch-prompt.md` as a self-contained prompt, so they can miss evaluation behavior added only to the default mode files. This PR makes the salary reliability fix apply to batch evaluations too.

## Validation

- `npm install`
- `node test-all.mjs` -> 1234 passed, 0 failed, 1 warning

The warning is the expected clean-worktree warning from `cv-sync-check.mjs` when user-layer files are absent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced compensation interpretation with a required contract “company type” classification step before analyzing salary details.
  - Added a “Compensation reliability” tier system (High/Medium/Low/Unknown) with stricter handling of ambiguous, capped, commission/variable-heavy, or unusually broad salary wording.
  - If a salary figure is present, compensation guidance is now structured into advertised range, likely guaranteed base, variable/conditional cash, expected stable cash, and non-cash benefits, plus company-type-specific HR verification questions; advertised pay is not treated as guaranteed take-home without explicit support.

- **Tests**
  - Updated batch prompt integrity checks to verify the new company-type compensation reliability guidance text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->