### PR TITLE
fix(dashboard): duplicate-alias headers resolve last-occurrence-wins, matching tracker-parse

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -621,9 +621,11 @@ func detectTrackerColumns(lines []string) map[string]int {
 		m := make(map[string]int)
 		for i, c := range cells {
 			if name, ok := trackerHeaderAliases[strings.ToLower(c)]; ok {
-				if _, seen := m[name]; !seen {
-					m[name] = i
-				}
+				// Unconditional assign: with a duplicated header name the LAST
+				// occurrence wins, matching detectColumns in tracker-parse.mjs
+				// (which this function mirrors) — first-wins here made the two
+				// runtimes map the same header row differently.
+				m[name] = i
 			}
 		}
 		complete := true

--- a/dashboard/internal/data/career_test.go
+++ b/dashboard/internal/data/career_test.go
@@ -264,3 +264,16 @@ func TestResolveTrackerColumns(t *testing.T) {
 		t.Errorf("fallback status index = %d, want 5 (legacy layout)", fallback["status"])
 	}
 }
+
+// A duplicated header name resolves to its LAST occurrence, matching
+// detectColumns in tracker-parse.mjs — the JS and Go readers must map an
+// identical header row identically.
+func TestResolveTrackerColumnsDuplicateHeaderLastWins(t *testing.T) {
+	dup := strings.Split(`| # | Notes | Company | Role | Score | Status | PDF | Report | Notes |
+|---|-------|---------|------|-------|--------|-----|--------|-------|
+| 1 | stray | Acme | Engineer | 4.0/5 | Applied | ✅ | — | real note |`, "\n")
+	cols := resolveTrackerColumns(dup)
+	if cols["notes"] != 8 {
+		t.Errorf("notes index = %d, want 8 (last occurrence wins, like tracker-parse.mjs)", cols["notes"])
+	}
+}


### PR DESCRIPTION
One-line parity fix, spotted during review of #1598 (flagged there as out of scope to keep that PR JS/TS-only).

`detectTrackerColumns` in `dashboard/internal/data/career.go` kept the **first** cell matching a header alias; `detectColumns` in `tracker-parse.mjs` — which the Go function documents itself as mirroring — assigns unconditionally, so the **last** occurrence wins. Given a tracker header with a duplicated column name, the Go dashboard and the Node tooling mapped the same row differently.

Aligned on last-wins + a duplicate-header regression test. `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate table headers now resolve to the last matching column instead of the first, improving tracker table parsing consistency.
  * Tracker column detection now matches the behavior used by the Node-based tracker tooling.
* **Tests**
  * Added coverage for duplicate header handling to verify the last occurrence is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->