### PR TITLE
feat(stats): lifetime pipeline stats aggregator (#1604, PR-1 of 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `interview-prep/story-bank.md` | Accumulated STAR+R stories across evaluations |
 | `interview-prep/{company}-{role}.md` | Company-specific interview intel reports |
 | `analyze-patterns.mjs` | Pattern analysis script (JSON output). Includes ATS channel analysis (per-vendor advance rate; motivated by Bommasani et al., Algorithmic Monocultures in Hiring, FAccT 2026). |
+| `stats.mjs` | Lifetime pipeline stats aggregator (JSON or `--summary`) — tracker roll-up, canonical `ever*` funnel, lifetime scan totals, portal coverage, follow-up compliance |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON output) |
 | `detect-reposts.mjs` | Repost detector — flags roles re-listed 2+ times in 90 days from scan-history.tsv (JSON or `--summary` table output) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `interview-prep/story-bank.md` | Accumulated STAR+R stories across evaluations |
 | `interview-prep/{company}-{role}.md` | Company-specific interview intel reports |
 | `analyze-patterns.mjs` | Pattern analysis script (JSON output). Includes ATS channel analysis (per-vendor advance rate; motivated by Bommasani et al., Algorithmic Monocultures in Hiring, FAccT 2026). |
+| `stats.mjs` | Lifetime pipeline stats aggregator (JSON or `--summary`) — tracker roll-up, canonical `ever*` funnel, lifetime scan totals, portal coverage, follow-up compliance |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON output) |
 | `data/follow-ups.md` | Follow-up history tracker |

--- a/modes/tracker.md
+++ b/modes/tracker.md
@@ -27,3 +27,7 @@ Also show statistics:
 - Average score
 - % with PDF generated
 - % with report generated
+
+For the full lifetime stats view (cumulative funnel, scanner totals, portal
+coverage, follow-up compliance), run `node stats.mjs --summary` and present its
+output. Zero tokens — never recompute these numbers manually.

--- a/stats.mjs
+++ b/stats.mjs
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+/**
+ * stats.mjs — Lifetime pipeline stats aggregator (zero-token). #1604
+ *
+ * One JSON contract for "how is my pipeline doing, lifetime": tracker roll-up,
+ * cumulative funnel, lifetime scanner totals from scan-history.tsv, portal
+ * coverage from portals.yml, and follow-up compliance. Reads durable data
+ * files only — no LLM cost anywhere.
+ *
+ * Run: node stats.mjs             (JSON to stdout)
+ *      node stats.mjs --summary   (human-readable table)
+ *
+ * Sections degrade to null when their source file is missing, and
+ * `metadata.sources` says which files were found — a fresh clone with zero
+ * user data emits the full contract shape with null sections.
+ *
+ * `runs` is always null in this version: it is reserved for per-run scan
+ * counters from data/scan-runs.tsv, which lands with the scan.mjs write path
+ * in a follow-up PR (see #1604 — the file is a data-contract change and ships
+ * separately). The key exists now so the contract is stable for consumers.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import yaml from 'js-yaml';
+import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { normalizeStatus } from './followup-cadence.mjs';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const APPS_FILE = join(ROOT, 'data', 'applications.md');
+const SCAN_HISTORY_FILE = join(ROOT, 'data', 'scan-history.tsv');
+const FOLLOWUPS_FILE = join(ROOT, 'data', 'follow-ups.md');
+const SCAN_RUNS_FILE = join(ROOT, 'data', 'scan-runs.tsv');
+const PORTALS_FILE = join(ROOT, 'portals.yml');
+
+const CANONICAL_STATUSES = ['Evaluated', 'Applied', 'Responded', 'Interview', 'Offer', 'Rejected', 'Discarded', 'SKIP'];
+
+// In-flight applications. Deliberately NARROWER than the dashboard's
+// ActiveApps (which also counts Evaluated): an evaluated-but-never-sent row is
+// a candidate, not an application in flight.
+const ACTIVE_STATUSES = new Set(['Applied', 'Responded', 'Interview', 'Offer']);
+
+// Rows that count toward avgScoreApplied — jobs the user actually pursued.
+// Plain avgScore mixes in SKIP/Discarded and understates real fit.
+const PURSUED_STATUSES = new Set(['Applied', 'Responded', 'Interview', 'Offer', 'Rejected']);
+
+const round1 = (n) => Math.round(n * 10) / 10;
+const pct = (part, total) => (total > 0 ? round1((part / total) * 100) : 0);
+
+/** Canonical display form ("aplicado" → "Applied", "skip" → "SKIP"); unknown → "Unknown" (counted, never dropped). */
+function canonicalStatus(raw) {
+  const norm = normalizeStatus(String(raw ?? ''));
+  if (norm === 'skip') return 'SKIP';
+  const cased = norm.charAt(0).toUpperCase() + norm.slice(1);
+  return CANONICAL_STATUSES.includes(cased) ? cased : 'Unknown';
+}
+
+// ── Tracker roll-up ─────────────────────────────────────────────────
+
+/**
+ * Roll up applications.md: counts per canonical status, score stats, pdf and
+ * report coverage, in-flight count. Header-aware via tracker-parse.mjs; CRLF
+ * input is normalized first (Windows checkouts).
+ *
+ * @param {string} content - Raw applications.md text.
+ */
+export function computeTrackerStats(content) {
+  const lines = String(content ?? '').replace(/\r/g, '').split('\n');
+  const colmap = resolveColumns(lines);
+  const byStatus = Object.fromEntries(CANONICAL_STATUSES.map((s) => [s, 0]));
+  let total = 0, scoreSum = 0, scoreCount = 0, topScore = 0, withPdf = 0, withReport = 0, activeApps = 0;
+  let pursuedSum = 0, pursuedCount = 0;
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (!row) continue;
+    total++;
+    const status = canonicalStatus(row.status);
+    byStatus[status] = (byStatus[status] || 0) + 1;
+    if (ACTIVE_STATUSES.has(status)) activeApps++;
+    const score = parseFloat(String(row.score || '').replace(/\*/g, ''));
+    if (!Number.isNaN(score) && score > 0) {
+      scoreSum += score;
+      scoreCount++;
+      if (score > topScore) topScore = score;
+      if (PURSUED_STATUSES.has(status)) { pursuedSum += score; pursuedCount++; }
+    }
+    if ((row.pdf || '').includes('✅')) withPdf++;
+    if (/\[.*\]\(.*\)/.test(row.report || '')) withReport++;
+  }
+  return {
+    total,
+    byStatus,
+    avgScore: scoreCount > 0 ? round1(scoreSum / scoreCount) : null,
+    avgScoreApplied: pursuedCount > 0 ? round1(pursuedSum / pursuedCount) : null,
+    topScore: topScore > 0 ? topScore : null,
+    pdfPct: pct(withPdf, total),
+    reportPct: pct(withReport, total),
+    activeApps,
+  };
+}
+
+/** Map of tracker number → canonical status (for follow-up compliance). */
+export function trackerStatusByNum(content) {
+  const lines = String(content ?? '').replace(/\r/g, '').split('\n');
+  const colmap = resolveColumns(lines);
+  const byNum = new Map();
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (row) byNum.set(row.num, canonicalStatus(row.status));
+  }
+  return byNum;
+}
+
+// ── Cumulative funnel ───────────────────────────────────────────────
+
+/**
+ * Cumulative funnel: everX = "reached stage X or beyond, ever". The math
+ * mirrors the dashboard's ComputeProgressMetrics (career.go): Rejected counts
+ * into everApplied (a rejection proves a submission), and each later stage
+ * sums itself plus everything beyond it. Rates are relative to everApplied.
+ *
+ * Keys are deliberately NOT bare status names — `tracker.byStatus.Applied` is
+ * "currently in Applied" while `everApplied` is "ever applied"; the same word
+ * for two different numbers would read as a bug.
+ *
+ * Known limitation: statuses are snapshots, so a Rejected row that never got a
+ * response is indistinguishable from one rejected after interviews — middle
+ * stages are lower bounds until status-transition logging exists (#1428).
+ *
+ * This is the canonical funnel definition for career-ops going forward;
+ * dashboard/web consuming this JSON instead of keeping independent copies is
+ * a named follow-up in #1604.
+ */
+export function computeFunnel(byStatus) {
+  const n = (k) => byStatus[k] || 0;
+  const everApplied = n('Applied') + n('Responded') + n('Interview') + n('Offer') + n('Rejected');
+  const everResponded = n('Responded') + n('Interview') + n('Offer');
+  const everInterview = n('Interview') + n('Offer');
+  const everOffer = n('Offer');
+  return {
+    everApplied,
+    everResponded,
+    everInterview,
+    everOffer,
+    responseRate: pct(everResponded, everApplied),
+    interviewRate: pct(everInterview, everApplied),
+    offerRate: pct(everOffer, everApplied),
+    smallSample: everApplied < 10,
+  };
+}
+
+// ── Lifetime scanner totals ─────────────────────────────────────────
+
+/** ISO week key ("2026-W27") for a YYYY-MM-DD string; null for bad input. Exported for the year-boundary tests. */
+export function isoWeek(dateStr) {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return null;
+  const day = (d.getUTCDay() + 6) % 7; // Mon=0
+  d.setUTCDate(d.getUTCDate() - day + 3); // nearest Thursday decides the ISO year
+  const jan4 = new Date(Date.UTC(d.getUTCFullYear(), 0, 4));
+  const week = 1 + Math.round(((d - jan4) / 86400000 - 3 + ((jan4.getUTCDay() + 6) % 7)) / 7);
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+
+/**
+ * Lifetime totals from scan-history.tsv. Malformed rows (no URL in column 0)
+ * are skipped rather than crashing — a torn row from an interrupted append
+ * must never poison the aggregate. Extra trailing columns (e.g. the
+ * fingerprint column, #1597) are ignored.
+ *
+ * @param {string} content - Raw scan-history.tsv text.
+ * @param {{weeks?: number}} [opts] - How many trailing weeks of addedPerWeek to keep.
+ */
+export function computeScanStats(content, { weeks = 8 } = {}) {
+  const lines = String(content ?? '').replace(/\r/g, '').split('\n').filter((l) => l.trim());
+  const byPortal = {}, byStatus = {};
+  const companies = new Set();
+  const weekCounts = new Map();
+  let totalRecorded = 0, added = 0, firstSeen = null, lastSeen = null;
+  for (const line of lines) {
+    const cols = line.split('\t');
+    if (cols[0] === 'url') continue; // header
+    if (!/^https?:\/\//.test(cols[0])) continue; // torn/malformed row
+    totalRecorded++;
+    const [, date, portal, , company, statusRaw] = cols;
+    const status = (statusRaw || 'added').trim() || 'added';
+    byStatus[status] = (byStatus[status] || 0) + 1;
+    if (portal) byPortal[portal] = (byPortal[portal] || 0) + 1;
+    if (company) companies.add(company.toLowerCase());
+    if (status === 'added') {
+      added++;
+      const wk = isoWeek(date);
+      if (wk) weekCounts.set(wk, (weekCounts.get(wk) || 0) + 1);
+    }
+    if (date && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      if (!firstSeen || date < firstSeen) firstSeen = date;
+      if (!lastSeen || date > lastSeen) lastSeen = date;
+    }
+  }
+  const addedPerWeek = [...weekCounts.entries()]
+    .sort((a, b) => (a[0] < b[0] ? -1 : 1))
+    .slice(-weeks)
+    .map(([week, count]) => ({ week, count }));
+  return { totalRecorded, added, byStatus, byPortal, distinctCompanies: companies.size, firstSeen, lastSeen, addedPerWeek };
+}
+
+/** Lowercased set of company names that ever appeared in scan-history.tsv. */
+export function scanCompanyNames(content) {
+  const names = new Set();
+  for (const line of String(content ?? '').replace(/\r/g, '').split('\n')) {
+    const cols = line.split('\t');
+    if (!/^https?:\/\//.test(cols[0] || '')) continue;
+    const company = (cols[4] || '').trim();
+    if (company) names.add(company.toLowerCase());
+  }
+  return [...names];
+}
+
+// ── Portal coverage ─────────────────────────────────────────────────
+
+/**
+ * Configured-vs-producing portal coverage.
+ *
+ * producingPct = share of configured tracked_companies whose name has EVER
+ * appeared as a scanned job's company. A low number usually means "no matching
+ * openings from that company yet", NOT a broken portal — the --summary label
+ * carries the same caveat. Matching is exact-lowercase between portals.yml
+ * `name` and the scanner's company string; that undercounts when names differ
+ * ("Acme" vs "Acme, Inc."). Documented v1 contract — no silent fuzzy-matching.
+ *
+ * @param {string} portalsYmlContent - Raw portals.yml text.
+ * @param {object|null} scanStats - Result of computeScanStats (for activePortals).
+ * @param {string[]} [producingCompanyNames] - From scanCompanyNames().
+ */
+export function computePortalStats(portalsYmlContent, scanStats, producingCompanyNames = []) {
+  let cfg;
+  try {
+    cfg = yaml.load(String(portalsYmlContent ?? '')) || {};
+  } catch {
+    return null; // malformed YAML → no portal section rather than a crash
+  }
+  const companies = Array.isArray(cfg.tracked_companies) ? cfg.tracked_companies : [];
+  const boards = Array.isArray(cfg.job_boards) ? cfg.job_boards : [];
+  const configuredNames = new Set(
+    companies.map((c) => String(c?.name || '').toLowerCase()).filter(Boolean),
+  );
+  const producing = new Set(producingCompanyNames.map((n) => String(n).toLowerCase()));
+  let producingCompanies = 0;
+  for (const name of configuredNames) if (producing.has(name)) producingCompanies++;
+  return {
+    configuredCompanies: companies.length,
+    configuredBoards: boards.length,
+    activePortals: Object.keys(scanStats?.byPortal || {}).length,
+    producingCompanies,
+    producingPct: pct(producingCompanies, configuredNames.size),
+  };
+}
+
+// ── Follow-up compliance ────────────────────────────────────────────
+
+/**
+ * Follow-up compliance from follow-ups.md (same table shape followup-cadence
+ * parses: | num | appNum | date | company | role | channel | contact | notes |).
+ * appliedWithoutFollowup counts tracker rows currently in Applied with zero
+ * logged follow-ups — the rows the followup mode would flag as aging silently.
+ *
+ * @param {string} followupsContent - Raw follow-ups.md text.
+ * @param {Map<number,string>} trackerByNum - From trackerStatusByNum().
+ */
+export function computeFollowupStats(followupsContent, trackerByNum) {
+  const byApp = new Map();
+  let totalFollowups = 0;
+  for (const line of String(followupsContent ?? '').replace(/\r/g, '').split('\n')) {
+    if (!line.startsWith('|')) continue;
+    const parts = line.split('|').map((s) => s.trim());
+    if (parts.length < 8) continue;
+    const num = parseInt(parts[1], 10);
+    const appNum = parseInt(parts[2], 10);
+    if (Number.isNaN(num) || Number.isNaN(appNum)) continue; // header/separator
+    totalFollowups++;
+    byApp.set(appNum, (byApp.get(appNum) || 0) + 1);
+  }
+  let appliedWithoutFollowup = 0;
+  for (const [num, status] of trackerByNum) {
+    if (status === 'Applied' && !byApp.has(num)) appliedWithoutFollowup++;
+  }
+  return {
+    totalFollowups,
+    appsWithFollowups: byApp.size,
+    appliedWithoutFollowup,
+    avgPerApp: byApp.size > 0 ? round1(totalFollowups / byApp.size) : 0,
+  };
+}
+
+// ── Assembler + CLI ─────────────────────────────────────────────────
+
+/**
+ * Assemble the full stats contract. Every section is null when its source
+ * file is missing; metadata.sources records what was found.
+ */
+export function computeAllStats({
+  appsFile = APPS_FILE,
+  scanHistoryFile = SCAN_HISTORY_FILE,
+  followupsFile = FOLLOWUPS_FILE,
+  scanRunsFile = SCAN_RUNS_FILE,
+  portalsFile = PORTALS_FILE,
+} = {}) {
+  const read = (f) => (existsSync(f) ? readFileSync(f, 'utf-8') : null);
+  const apps = read(appsFile);
+  const scanHist = read(scanHistoryFile);
+  const fups = read(followupsFile);
+  const portals = read(portalsFile);
+  const tracker = apps ? computeTrackerStats(apps) : null;
+  const scan = scanHist ? computeScanStats(scanHist) : null;
+  return {
+    metadata: {
+      generatedAt: new Date().toISOString().slice(0, 10),
+      sources: {
+        tracker: !!apps,
+        scanHistory: !!scanHist,
+        followups: !!fups,
+        portals: !!portals,
+        scanRuns: existsSync(scanRunsFile),
+      },
+    },
+    tracker,
+    funnel: tracker ? computeFunnel(tracker.byStatus) : null,
+    scan,
+    portals: portals ? computePortalStats(portals, scan, scanHist ? scanCompanyNames(scanHist) : []) : null,
+    followups: fups && apps ? computeFollowupStats(fups, trackerStatusByNum(apps)) : null,
+    // Reserved for data/scan-runs.tsv per-run counters (PR-2 of #1604). The
+    // key ships now so the contract shape is stable for consumers.
+    runs: null,
+  };
+}
+
+/** Human-readable table. pdfPct/reportPct are JSON-only by design — no job-search decision follows from them. */
+function printSummary(stats) {
+  const line = '━'.repeat(45);
+  console.log(`\n${line}`);
+  console.log(`Pipeline Stats — ${stats.metadata.generatedAt}`);
+  console.log(line);
+  const t = stats.tracker;
+  if (t) {
+    const fit = t.avgScore != null
+      ? ` | avg fit ${t.avgScore}/5${t.avgScoreApplied != null ? ` (pursued roles ${t.avgScoreApplied}/5)` : ''} | top ${t.topScore}`
+      : '';
+    console.log(`Tracker:    ${t.total} total | ${t.activeApps} active${fit}`);
+    const statusLine = Object.entries(t.byStatus).filter(([, c]) => c > 0).map(([s, c]) => `${s} ${c}`).join(' · ');
+    if (statusLine) console.log(`Status:     ${statusLine}`);
+  } else {
+    console.log('Tracker:    — no data (data/applications.md missing)');
+  }
+  const f = stats.funnel;
+  if (f) {
+    const small = f.smallSample ? ' (small sample — rates indicative only)' : '';
+    console.log(`Funnel:     ever applied ${f.everApplied} → responded ${f.everResponded} (${f.responseRate}%) → interview ${f.everInterview} (${f.interviewRate}%) → offer ${f.everOffer} (${f.offerRate}%)${small}`);
+  }
+  const s = stats.scan;
+  if (s) {
+    const portalsLine = Object.entries(s.byPortal).sort((a, b) => b[1] - a[1]).slice(0, 5).map(([p, c]) => `${p} ${c}`).join(' · ');
+    console.log(`Scanner:    ${s.totalRecorded} jobs recorded${s.firstSeen ? ` since ${s.firstSeen}` : ''} | ${s.added} added | ${s.distinctCompanies} companies${portalsLine ? ` | ${portalsLine}` : ''}`);
+  } else {
+    console.log('Scanner:    — no data (data/scan-history.tsv missing)');
+  }
+  const p = stats.portals;
+  if (p) {
+    console.log(`Portals:    ${p.configuredCompanies} companies + ${p.configuredBoards} boards configured | ${p.producingCompanies} have produced a match (${p.producingPct}%) — low ≠ broken, may just be no openings`);
+  } else {
+    console.log('Portals:    — no data (portals.yml missing)');
+  }
+  const fu = stats.followups;
+  if (fu) {
+    console.log(`Follow-ups: ${fu.totalFollowups} sent across ${fu.appsWithFollowups} apps | ${fu.appliedWithoutFollowup} Applied apps with none | avg ${fu.avgPerApp}/app`);
+  } else {
+    console.log('Follow-ups: — no data (data/follow-ups.md missing)');
+  }
+  console.log('Runs:       — no data (data/scan-runs.tsv pending; see #1604 PR-2)');
+  console.log('');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const stats = computeAllStats();
+  if (process.argv.includes('--summary')) printSummary(stats);
+  else console.log(JSON.stringify(stats, null, 2));
+}

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12081,6 +12081,128 @@ try {
   fail(`softgarden provider tests crashed: ${e.message}`);
 }
 
+console.log('\n62. stats.mjs — lifetime pipeline stats aggregator (#1604)');
+try {
+  const stats = await import(pathToFileURL(join(ROOT, 'stats.mjs')).href);
+
+  // Tracker roll-up — CRLF input on purpose (Windows checkouts).
+  const trackerMd = [
+    '# Applications Tracker',
+    '',
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|-------|--------|-----|--------|-------|',
+    '| 1 | 2026-06-01 | Acme | Eng | 4.5/5 | Applied | ✅ | [1](../reports/001-acme-2026-06-01.md) | note |',
+    '| 2 | 2026-06-02 | Beta | Eng | 3.8/5 | Evaluated | ❌ | [2](../reports/002-beta-2026-06-02.md) | note |',
+    '| 3 | 2026-06-03 | Gama | Eng | 4.2/5 | Interview | ✅ | ❌ | note |',
+  ].join('\r\n');
+  const t = stats.computeTrackerStats(trackerMd);
+  if (t.total === 3 && t.byStatus.Applied === 1 && t.byStatus.Evaluated === 1
+      && t.byStatus.Interview === 1 && t.avgScore === 4.2 && t.avgScoreApplied === 4.4
+      && t.topScore === 4.5 && t.pdfPct === 66.7 && t.reportPct === 66.7 && t.activeApps === 2) {
+    pass('computeTrackerStats counts statuses, scores, pdf/report pct, active apps (CRLF input)');
+  } else {
+    fail(`computeTrackerStats wrong output: ${JSON.stringify(t)}`);
+  }
+
+  // Funnel — Rejected counts into everApplied (mirrors dashboard ComputeProgressMetrics).
+  const f = stats.computeFunnel({ Applied: 4, Responded: 2, Interview: 1, Offer: 1, Rejected: 2, Evaluated: 9 });
+  if (f.everApplied === 10 && f.everResponded === 4 && f.everInterview === 2 && f.everOffer === 1
+      && f.responseRate === 40 && f.offerRate === 10 && f.smallSample === false) {
+    pass('computeFunnel cumulative ever* stages match the dashboard math');
+  } else {
+    fail(`computeFunnel wrong output: ${JSON.stringify(f)}`);
+  }
+  if (stats.computeFunnel({ Applied: 3 }).smallSample === true) {
+    pass('computeFunnel flags small samples (everApplied < 10)');
+  } else {
+    fail('computeFunnel should flag everApplied < 10 as smallSample');
+  }
+
+  // Lifetime scan totals — CRLF input, torn row skipped, fingerprint column tolerated.
+  const scanTsv = [
+    'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation',
+    'https://a/1\t2026-06-20\tgreenhouse\tEng\tAcme\tadded\tRemote',
+    'https://a/2\t2026-06-21\tgreenhouse\tEng2\tAcme\tadded\tRemote\tdeadbeefdeadbeef',
+    'https://b/1\t2026-06-22\tashby\tEng\tBeta\tskipped_expired\tNY',
+    'https://c/1\t2026-06-2',
+  ].join('\r\n');
+  const s = stats.computeScanStats(scanTsv);
+  if (s.totalRecorded === 4 && s.added === 3 && s.byPortal.greenhouse === 2
+      && s.byStatus.skipped_expired === 1 && s.distinctCompanies === 2
+      && s.firstSeen === '2026-06-20' && s.lastSeen === '2026-06-22'
+      && s.addedPerWeek.some(w => w.week === '2026-W25' && w.count === 2)) {
+    pass('computeScanStats lifetime totals from scan-history.tsv (CRLF, extra fingerprint col)');
+  } else {
+    fail(`computeScanStats wrong output: ${JSON.stringify(s)}`);
+  }
+
+  // ISO week year-boundary — the one place hand-rolled week math fails.
+  const wk = [stats.isoWeek('2025-12-29'), stats.isoWeek('2026-01-01'), stats.isoWeek('2024-12-31'), stats.isoWeek('2027-01-01')];
+  if (wk[0] === '2026-W01' && wk[1] === '2026-W01' && wk[2] === '2025-W01' && wk[3] === '2026-W53') {
+    pass('isoWeek handles year boundaries');
+  } else {
+    fail(`isoWeek boundary math wrong: ${JSON.stringify(wk)}`);
+  }
+
+  // Portal coverage — real portals.yml keys (tracked_companies / job_boards).
+  const portalsYml = [
+    'tracked_companies:',
+    '  - name: Acme',
+    '    careers_url: https://boards.greenhouse.io/acme',
+    '  - name: Beta',
+    '    careers_url: https://jobs.ashbyhq.com/beta',
+    '  - name: Gama',
+    '    careers_url: https://gama.example.com/jobs',
+    'job_boards:',
+    '  - name: BigBoard',
+    '    url: https://bigboard.example.com',
+  ].join('\n');
+  const p = stats.computePortalStats(portalsYml, { byPortal: { greenhouse: 5, ashby: 2 } }, ['acme', 'beta']);
+  if (p.configuredCompanies === 3 && p.configuredBoards === 1
+      && p.activePortals === 2 && p.producingCompanies === 2 && p.producingPct === 66.7) {
+    pass('computePortalStats configured vs producing coverage');
+  } else {
+    fail(`computePortalStats wrong output: ${JSON.stringify(p)}`);
+  }
+
+  // Follow-up compliance.
+  const followupsMd = [
+    '# Follow-ups',
+    '| # | App | Date | Company | Role | Channel | Contact | Notes |',
+    '|---|-----|------|---------|------|---------|---------|-------|',
+    '| 1 | 1 | 2026-06-10 | Acme | Eng | email | jane | pinged |',
+    '| 2 | 1 | 2026-06-17 | Acme | Eng | email | jane | pinged again |',
+    '| 3 | 3 | 2026-06-12 | Gama | Eng | linkedin | bob | intro |',
+  ].join('\n');
+  const trackerByNum = new Map([[1, 'Applied'], [2, 'Applied'], [3, 'Interview']]);
+  const fu = stats.computeFollowupStats(followupsMd, trackerByNum);
+  if (fu.totalFollowups === 3 && fu.appsWithFollowups === 2
+      && fu.appliedWithoutFollowup === 1 && fu.avgPerApp === 1.5) {
+    pass('computeFollowupStats compliance from follow-ups.md');
+  } else {
+    fail(`computeFollowupStats wrong output: ${JSON.stringify(fu)}`);
+  }
+
+  // CLI smoke — must emit the full contract with null sections in a checkout
+  // with no user data (exactly the CI environment).
+  const cliOut = run(NODE, [join(ROOT, 'stats.mjs')]);
+  const parsed = JSON.parse(cliOut);
+  if (parsed && parsed.metadata && 'tracker' in parsed && 'scan' in parsed && 'portals' in parsed
+      && 'followups' in parsed && 'funnel' in parsed && 'runs' in parsed) {
+    pass('stats.mjs CLI emits the full JSON contract (sections null when sources missing)');
+  } else {
+    fail(`stats.mjs CLI missing sections: ${parsed ? Object.keys(parsed).join(',') : cliOut}`);
+  }
+  const summaryOut = run(NODE, [join(ROOT, 'stats.mjs'), '--summary']);
+  if (summaryOut && summaryOut.includes('Pipeline Stats')) {
+    pass('stats.mjs --summary renders the human table');
+  } else {
+    fail('stats.mjs --summary missing header');
+  }
+} catch (e) {
+  fail(`stats.mjs tests crashed: ${e.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -138,6 +138,7 @@ const SYSTEM_PATHS = [
   'liveness-api.mjs',
   'liveness-browser.mjs',
   'analyze-patterns.mjs',
+  'stats.mjs',
   'detect-reposts.mjs',
   'process-quality.mjs',
   'process-quality.test.mjs',


### PR DESCRIPTION
PR-1 of the two-PR plan in #1604 — the **read-only aggregator**, zero data-contract change. PR-2 (scan-run persistence: `data/scan-runs.tsv` + the `scan.mjs` write path) waits for the schema discussion on the issue.

**The surface question from #1604 stands**: if you'd rather this live as a section in `analyze-patterns.mjs` than a new script, happy to rework — the functions are pure and move cheaply.

## What

`node stats.mjs` → full JSON contract; `--summary` → human table. Reads durable files only (`applications.md`, `scan-history.tsv`, `follow-ups.md`, `portals.yml`); zero LLM cost; every section degrades to `null` with `metadata.sources` saying why — a fresh clone with no user data emits the full contract shape (that's the CI path, and it's tested).

| Section | New information |
|---|---|
| `tracker` | roll-up: canonical byStatus, `avgScore` vs `avgScoreApplied` (pursued rows only), pdf/report coverage, in-flight count |
| `funnel` | **canonical `ever*` funnel** — cumulative stages, math mirrors dashboard `ComputeProgressMetrics` (Rejected counts into `everApplied`); `smallSample` guard < 10; keys deliberately not bare status names so "currently Applied" ≠ "ever applied" never collide |
| `scan` | **lifetime scanner totals** (today printed once by scan.mjs and lost): per-portal split, distinct companies, added-per-week backfilled from `first_seen` |
| `portals` | **configured-vs-producing coverage** with the "low ≠ broken" caveat; exact-lowercase name matching documented as the v1 contract |
| `followups` | compliance: Applied rows with zero logged follow-ups |
| `runs` | always `null` here — reserved for PR-2's `scan-runs.tsv`; key ships now so the contract is stable |

Robustness baked in per the issue: header-aware tracker parsing (`tracker-parse.mjs`), CRLF stripping everywhere, torn scan-history rows skipped, extra columns tolerated (incl. the #1597 fingerprint column), unknown statuses counted under `Unknown` rather than dropped, ISO-week math with year-boundary tests.

## Tests

9 new assertions in the suite: tracker roll-up on CRLF input, funnel math + small-sample flag, scan totals with torn row + extra column, isoWeek year boundaries (2025-12-29→2026-W01, 2024-12-31→2025-W01, 2027-01-01→2026-W53), portal coverage on real `tracked_companies`/`job_boards` keys, follow-up compliance, CLI + `--summary` smoke on the no-data path. Full suite: **1240 passed / 0 failed**. Registered in the updater SYSTEM_PATHS manifest (coverage validator green).

## Docs

Main Files row in AGENTS.md/CLAUDE.md; `modes/tracker.md` points the tracker mode at `node stats.mjs --summary` instead of recomputing numbers by hand.

Closes nothing — #1604 stays open for PR-2 and the surface question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new lifetime statistics command that produces JSON or a compact summary view.
  * Included broader reporting for application funnel totals, scan history, portal coverage, and follow-up tracking.

* **Documentation**
  * Updated tracker guidance to point to the new lifetime statistics output for consistent reporting.
  * Added the new stats command to project reference docs.

* **Tests**
  * Expanded automated coverage for the new statistics output and summary format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->