### PR TITLE
feat(scan): persist per-run counters to data/scan-runs.tsv (#1604, PR-2 of 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ data/applications.db
 data/follow-ups.md
 data/pipeline.md
 data/scan-history.tsv
+data/scan-runs.tsv
 data/pdf-index.tsv
 data/agent-inbox.md
 data/parser-output/**/*.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,8 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `interview-prep/story-bank.md` | Accumulated STAR+R stories across evaluations |
 | `interview-prep/{company}-{role}.md` | Company-specific interview intel reports |
 | `analyze-patterns.mjs` | Pattern analysis script (JSON output). Includes ATS channel analysis (per-vendor advance rate; motivated by Bommasani et al., Algorithmic Monocultures in Hiring, FAccT 2026). |
-| `stats.mjs` | Lifetime pipeline stats aggregator (JSON or `--summary`) — tracker roll-up, canonical `ever*` funnel, lifetime scan totals, portal coverage, follow-up compliance |
+| `stats.mjs` | Lifetime pipeline stats aggregator (JSON or `--summary`) — tracker roll-up, canonical `ever*` funnel, lifetime scan totals, portal coverage, follow-up compliance, scan-run trends |
+| `data/scan-runs.tsv` | Per-run scan counters (appended by `scan.mjs`, read by `stats.mjs`) |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON output) |
 | `detect-reposts.mjs` | Repost detector — flags roles re-listed 2+ times in 90 days from scan-history.tsv (JSON or `--summary` table output) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,8 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `interview-prep/story-bank.md` | Accumulated STAR+R stories across evaluations |
 | `interview-prep/{company}-{role}.md` | Company-specific interview intel reports |
 | `analyze-patterns.mjs` | Pattern analysis script (JSON output). Includes ATS channel analysis (per-vendor advance rate; motivated by Bommasani et al., Algorithmic Monocultures in Hiring, FAccT 2026). |
-| `stats.mjs` | Lifetime pipeline stats aggregator (JSON or `--summary`) — tracker roll-up, canonical `ever*` funnel, lifetime scan totals, portal coverage, follow-up compliance |
+| `stats.mjs` | Lifetime pipeline stats aggregator (JSON or `--summary`) — tracker roll-up, canonical `ever*` funnel, lifetime scan totals, portal coverage, follow-up compliance, scan-run trends |
+| `data/scan-runs.tsv` | Per-run scan counters (appended by `scan.mjs`, read by `stats.mjs`) |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON output) |
 | `data/follow-ups.md` | Follow-up history tracker |

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -25,6 +25,7 @@ These files contain your personal data, customizations, and work product. Update
 | `data/applications.db` | Derived query index over `applications.md` (SQLite, rebuilt by `node tracker.mjs sync` — safe to delete) |
 | `data/pipeline.md` | Your URL inbox |
 | `data/scan-history.tsv` | Your scan history |
+| `data/scan-runs.tsv` | Your per-run scan counters (appended by `scan.mjs`, read by `stats.mjs`) |
 | `data/follow-ups.md` | Your follow-up history |
 | `writing-samples/*` | Your personal writing samples for style calibration (except `writing-samples/README.md`, which is system-owned documentation delivered by updates) |
 | `reports/*` | Your evaluation reports |

--- a/scan.mjs
+++ b/scan.mjs
@@ -677,6 +677,28 @@ export function appendToScanHistory(offers, date, status = 'added') {
   appendFileSync(SCAN_HISTORY_PATH, lines, 'utf-8');
 }
 
+// ── Scan-run persistence (#1604) ────────────────────────────────────
+
+const SCAN_RUNS_PATH = 'data/scan-runs.tsv';
+
+// One row of run counters per non-dry scan — today these numbers are printed
+// once in the summary and lost when the terminal scrolls. Full ISO timestamp
+// (two scans in one day must not collapse). `status` is reserved: always
+// 'completed' in v1; a follow-up wires failure-path writes so trend stats can
+// exclude survivorship bias. Consumers MUST parse by header name, never by
+// position — columns may be appended in later versions.
+export const SCAN_RUNS_HEADER = 'timestamp\tstatus\tcompanies\tboards\tfound\tfiltered_title\tfiltered_tier\tfiltered_location\tfiltered_salary\tfiltered_content\tfiltered_cooldown\tdupes\tnew_added\terrors\n';
+
+export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
+  if (!existsSync(filePath)) writeFileSync(filePath, SCAN_RUNS_HEADER, 'utf-8');
+  const row = [
+    c.timestamp, c.status ?? 'completed', c.companies, c.boards, c.found,
+    c.filteredTitle, c.filteredTier, c.filteredLocation, c.filteredSalary,
+    c.filteredContent, c.filteredCooldown, c.dupes, c.newAdded, c.errors,
+  ].join('\t') + '\n';
+  appendFileSync(filePath, row, 'utf-8');
+}
+
 // ── Parallel fetch with concurrency limit ───────────────────────────
 
 async function parallelFetch(tasks, limit) {
@@ -1226,6 +1248,19 @@ async function main() {
     } else {
       console.log(`\nResults saved to ${PIPELINE_PATH} and ${SCAN_HISTORY_PATH}`);
     }
+  }
+
+  // Persist this run's counters (#1604) — guarded exactly like the other
+  // writes; a --dry-run must leave no trace.
+  if (!dryRun) {
+    appendScanRunSummary({
+      timestamp: new Date().toISOString(), status: 'completed',
+      companies: summaryCompanies, boards: summaryBoards, found: totalFound,
+      filteredTitle: totalFilteredTitle, filteredTier: totalFilteredTier,
+      filteredLocation: totalFilteredLocation, filteredSalary: totalFilteredSalary,
+      filteredContent: totalFilteredContent, filteredCooldown: totalFilteredCooldown,
+      dupes: totalDupes, newAdded: verifiedOffers.length, errors: errors.length,
+    });
   }
 
   console.log(`\n→ Run /career-ops pipeline to evaluate new offers.`);

--- a/stats.mjs
+++ b/stats.mjs
@@ -14,10 +14,8 @@
  * `metadata.sources` says which files were found — a fresh clone with zero
  * user data emits the full contract shape with null sections.
  *
- * `runs` is always null in this version: it is reserved for per-run scan
- * counters from data/scan-runs.tsv, which lands with the scan.mjs write path
- * in a follow-up PR (see #1604 — the file is a data-contract change and ships
- * separately). The key exists now so the contract is stable for consumers.
+ * `runs` aggregates data/scan-runs.tsv (per-run counters written by scan.mjs,
+ * #1604 PR-2) — null until the first non-dry scan creates the file.
  */
 
 import { readFileSync, existsSync } from 'fs';
@@ -293,6 +291,54 @@ export function computeFollowupStats(followupsContent, trackerByNum) {
   };
 }
 
+// ── Scan-run trends ─────────────────────────────────────────────────
+
+/**
+ * Aggregate data/scan-runs.tsv (written by scan.mjs, one row per non-dry run).
+ *
+ * Header-name parsing, NEVER positional: columns may be appended in later
+ * schema versions and a positional slice would silently miscount from then on.
+ * Torn rows (crash mid-append) and rows with a bad timestamp are skipped;
+ * failed runs count in totalRuns/failedRuns but are excluded from averages so
+ * an aborted run doesn't drag the trend down.
+ *
+ * @param {string} content - Raw scan-runs.tsv text.
+ * @returns {object|null} null for empty/unknown-schema files.
+ */
+export function computeRunStats(content) {
+  const lines = String(content ?? '').replace(/\r/g, '').split('\n').filter((l) => l.trim());
+  if (lines.length < 2) return null;
+  const header = lines[0].split('\t');
+  const idx = Object.fromEntries(header.map((h, i) => [h, i]));
+  if (idx.timestamp == null || idx.found == null) return null; // unknown schema
+  const filterCols = header.filter((h) => h.startsWith('filtered_'));
+  const rows = [];
+  for (const line of lines.slice(1)) {
+    const cols = line.split('\t');
+    if (cols.length < header.length) continue; // torn row
+    if (!/^\d{4}-\d{2}-\d{2}/.test(cols[idx.timestamp] || '')) continue;
+    const num = (name) => { const v = Number(cols[idx[name]]); return Number.isNaN(v) ? 0 : v; };
+    rows.push({
+      date: cols[idx.timestamp].slice(0, 10),
+      status: idx.status != null ? cols[idx.status] : 'completed',
+      found: num('found'),
+      filtered: filterCols.reduce((a, h) => a + num(h), 0),
+      newAdded: num('new_added'),
+    });
+  }
+  if (rows.length === 0) return null;
+  const completed = rows.filter((r) => r.status !== 'failed');
+  const sum = (arr, k) => arr.reduce((a, r) => a + r[k], 0);
+  return {
+    totalRuns: rows.length,
+    failedRuns: rows.length - completed.length,
+    lastRunDate: rows.map((r) => r.date).sort().at(-1),
+    avgFoundPerRun: completed.length ? round1(sum(completed, 'found') / completed.length) : 0,
+    avgNewPerRun: completed.length ? round1(sum(completed, 'newAdded') / completed.length) : 0,
+    filterRemovalPct: pct(sum(completed, 'filtered'), sum(completed, 'found')),
+  };
+}
+
 // ── Assembler + CLI ─────────────────────────────────────────────────
 
 /**
@@ -311,6 +357,7 @@ export function computeAllStats({
   const scanHist = read(scanHistoryFile);
   const fups = read(followupsFile);
   const portals = read(portalsFile);
+  const runs = read(scanRunsFile);
   const tracker = apps ? computeTrackerStats(apps) : null;
   const scan = scanHist ? computeScanStats(scanHist) : null;
   return {
@@ -321,7 +368,7 @@ export function computeAllStats({
         scanHistory: !!scanHist,
         followups: !!fups,
         portals: !!portals,
-        scanRuns: existsSync(scanRunsFile),
+        scanRuns: !!runs,
       },
     },
     tracker,
@@ -329,9 +376,7 @@ export function computeAllStats({
     scan,
     portals: portals ? computePortalStats(portals, scan, scanHist ? scanCompanyNames(scanHist) : []) : null,
     followups: fups && apps ? computeFollowupStats(fups, trackerStatusByNum(apps)) : null,
-    // Reserved for data/scan-runs.tsv per-run counters (PR-2 of #1604). The
-    // key ships now so the contract shape is stable for consumers.
-    runs: null,
+    runs: runs ? computeRunStats(runs) : null,
   };
 }
 
@@ -376,7 +421,13 @@ function printSummary(stats) {
   } else {
     console.log('Follow-ups: — no data (data/follow-ups.md missing)');
   }
-  console.log('Runs:       — no data (data/scan-runs.tsv pending; see #1604 PR-2)');
+  const r = stats.runs;
+  if (r) {
+    const failed = r.failedRuns > 0 ? ` | ${r.failedRuns} failed` : '';
+    console.log(`Runs:       ${r.totalRuns} recorded (last ${r.lastRunDate})${failed} | avg ${r.avgFoundPerRun} found / ${r.avgNewPerRun} new per run | filters remove ${r.filterRemovalPct}%`);
+  } else {
+    console.log('Runs:       — no data (data/scan-runs.tsv missing; created by the next scan)');
+  }
   console.log('');
 }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5941,6 +5941,7 @@ try {
 
   // computeRunStats: header-name parsing, torn rows skipped, failed runs
   // excluded from averages.
+  const stats = await import(pathToFileURL(join(ROOT, 'stats.mjs')).href);
   const runsTsv = [
     'timestamp\tstatus\tcompanies\tboards\tfound\tfiltered_title\tfiltered_tier\tfiltered_location\tfiltered_salary\tfiltered_content\tfiltered_cooldown\tdupes\tnew_added\terrors',
     '2026-07-01T08:00:00Z\tcompleted\t45\t3\t100\t30\t5\t20\t2\t6\t1\t30\t6\t0',

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5917,6 +5917,52 @@ try {
   } else {
     fail('provider test section found in test-all.mjs — add a tests/providers/{name}.test.mjs file instead (auto-discovered, no registration)');
   }
+
+  // Scan-run persistence (#1604 PR-2): appender writes header once, one row per run.
+  const { appendScanRunSummary, SCAN_RUNS_HEADER } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+  const runsTmp = mkdtempSync(join(tmpdir(), 'scanruns-'));
+  const runsFile = join(runsTmp, 'scan-runs.tsv');
+  const counters = {
+    timestamp: '2026-07-03T14:02:11Z', status: 'completed', companies: 45, boards: 3, found: 120,
+    filteredTitle: 40, filteredTier: 5, filteredLocation: 20, filteredSalary: 2,
+    filteredContent: 6, filteredCooldown: 1, dupes: 38, newAdded: 8, errors: 0,
+  };
+  appendScanRunSummary(counters, runsFile);
+  appendScanRunSummary({ ...counters, timestamp: '2026-07-04T09:00:00Z' }, runsFile);
+  const runRows = readFileSync(runsFile, 'utf-8').trim().split('\n');
+  if (runRows[0] === SCAN_RUNS_HEADER.trim() && runRows.length === 3
+      && runRows[1].startsWith('2026-07-03T14:02:11Z\tcompleted\t45\t3\t120\t')
+      && runRows[2].startsWith('2026-07-04T09:00:00Z\t')) {
+    pass('appendScanRunSummary writes the header once, appends one row per run');
+  } else {
+    fail(`appendScanRunSummary wrong file contents: ${JSON.stringify(runRows)}`);
+  }
+  rmSync(runsTmp, { recursive: true, force: true });
+
+  // computeRunStats: header-name parsing, torn rows skipped, failed runs
+  // excluded from averages.
+  const runsTsv = [
+    'timestamp\tstatus\tcompanies\tboards\tfound\tfiltered_title\tfiltered_tier\tfiltered_location\tfiltered_salary\tfiltered_content\tfiltered_cooldown\tdupes\tnew_added\terrors',
+    '2026-07-01T08:00:00Z\tcompleted\t45\t3\t100\t30\t5\t20\t2\t6\t1\t30\t6\t0',
+    '2026-07-03T08:00:00Z\tcompleted\t45\t3\t140\t50\t5\t20\t2\t6\t1\t46\t10\t1',
+    '2026-07-03T09:00:00Z\tfailed\t45\t3\t0\t0\t0\t0\t0\t0\t0\t0\t0\t1',
+    '2026-07-03T10:0', // torn row from a crashed append — must be skipped, not crash
+  ].join('\r\n');
+  const r = stats.computeRunStats(runsTsv);
+  // filtered row1 = 30+5+20+2+6+1 = 64; row2 = 50+5+20+2+6+1 = 84; sum 148
+  // found sum (completed only) = 240 → filterRemovalPct = 148/240 = 61.7
+  // avgFound = 240/2 = 120; avgNew = (6+10)/2 = 8; failed run excluded from averages
+  if (r.totalRuns === 3 && r.failedRuns === 1 && r.lastRunDate === '2026-07-03'
+      && r.avgFoundPerRun === 120 && r.avgNewPerRun === 8 && r.filterRemovalPct === 61.7) {
+    pass('computeRunStats aggregates scan-runs.tsv by header name, skips torn rows (CRLF input)');
+  } else {
+    fail(`computeRunStats wrong output: ${JSON.stringify(r)}`);
+  }
+  if (stats.computeRunStats('timestamp\tstatus\n') === null && stats.computeRunStats('') === null) {
+    pass('computeRunStats returns null for empty/unknown-schema files');
+  } else {
+    fail('computeRunStats should return null for empty/unknown-schema input');
+  }
 } catch (e) {
   fail(`test layout guard: ${e.message}`);
 }

--- a/validate-system-paths-coverage.mjs
+++ b/validate-system-paths-coverage.mjs
@@ -84,6 +84,7 @@ if (process.argv.includes('--self-test')) {
   // Test explicitly excluded files
   assert(covered('.gitignore') === true, '.gitignore must be covered (excluded)');
   assert(covered('.coderabbit.yaml') === true, '.coderabbit.yaml must be covered (excluded)');
+  assert(covered('.editorconfig') === true, '.editorconfig must be covered (excluded, #1438/#1613)');
 
   // Test exact matches in SYSTEM_PATHS / USER_PATHS
   assert(covered('CLAUDE.md') === true, 'CLAUDE.md must be covered (exact match)');


### PR DESCRIPTION
PR-2 of #1604 — the **data-contract change**, split out per the issue so the read-only aggregator (#1605) isn't blocked on this schema discussion. **Stacked on #1605** (contains its commits; review from `feat(scan): persist per-run counters` only).

## What

Every non-dry `scan.mjs` run appends one row of its summary counters to a new user-layer **`data/scan-runs.tsv`** — today those numbers are printed once and lost when the terminal scrolls:

```
timestamp	status	companies	boards	found	filtered_title	…	dupes	new_added	errors
2026-07-03T14:02:11Z	completed	45	3	120	40	…	38	8	0
```

Schema commitments (the reason this is its own PR):

- **Full ISO timestamp** — two scans in one day never collapse.
- **`status` reserved now, written `completed` always in v1** — a follow-up wires failure-path writes so trend stats can exclude survivorship bias. Schema is forever; writes can wait.
- **Consumers parse by header name, never position** — columns may be appended later. `computeRunStats` in `stats.mjs` (the `runs` section, null until the file exists) does exactly that, skips torn rows from a crash mid-append, and excludes failed runs from averages.
- `--dry-run` leaves no trace (guarded like every other scan write; verified).
- New user-layer file → `.gitignore` + `DATA_CONTRACT.md` + Main Files entries included.

## Note for merge order

`scan.mjs` is also touched by #1601 (fingerprinting) in a different region — whichever merges second gets a trivial rebase.

## Tests

3 new assertions: appender writes the header once + one row per run; `computeRunStats` header-name aggregation with torn-row skip and failed-run exclusion (fixture arithmetic: 148/240 = 61.7% filter removal); null for empty/unknown-schema files. Full suite: **1242 passed / 0 failed**; SYSTEM_PATHS coverage validator green.

Closes #1604 together with #1605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scan-run persistence to a new TSV history file for real scans only (no trace on dry-runs).
  * Extended the human-readable summary with lifetime run trends, per-run averages, last run date, failed-run counts, and filter-removal percentage.
* **Bug Fixes**
  * Improved run-stats aggregation by safely handling empty/unknown schemas, skipping torn/invalid rows, and excluding failed runs from average calculations.
* **Documentation**
  * Updated documentation and file listings to include the new scan-run history file, and added an ignore rule for local checkouts.
* **Tests**
  * Added integration tests covering TSV persistence and run-stats aggregation parsing (including CRLF input).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->