### PR TITLE
i18n: add German translations of interview modes (plan/practice/debrief)

### DIFF
--- a/modes/de/interview/debrief.md
+++ b/modes/de/interview/debrief.md
@@ -1,0 +1,200 @@
+# Mode: interview/debrief — Nachbereitung nach dem Interview
+
+Erfasse nach einem echten Interview, was gefragt wurde, bewerte, was gesessen hat und was nicht, schließe Lücken vor der nächsten Runde und aktualisiere die Question Bank.
+
+---
+
+## When to Run This Skill
+
+- Unmittelbar nach einem echten Interview (solange die Erinnerung frisch ist)
+- Nach einem Recruiter-Call, der neue Informationen über den Prozess zutage gefördert hat
+- Wenn der Kandidat das Format der nächsten Runde und den Interviewer erfährt
+
+---
+
+## Inputs
+
+1. **Debrief des Kandidaten** — welche Fragen gestellt wurden, wie er geantwortet hat, was sich stark oder schwach anfühlte
+2. **Name und Rolle des Interviewers** — informiert die Prognose der nächsten Runde
+3. **Ausgang der Runde** (falls bekannt) — weiter / abgelehnt / offen
+4. **Details zur nächsten Runde** (falls bekannt) — Format, Interviewer, Zeitplan
+5. **Question Bank** unter `interview-prep/question-bank.md` — mit echten Daten aktualisieren
+6. **Story Bank** unter `interview-prep/story-bank.md` — neue Stories ergänzen, falls welche auftauchen
+7. **Lebenslauf** unter `cv.md` + `article-digest.md` (falls vorhanden) — um vorgeschlagene Antworten in echter Erfahrung zu verankern
+8. **Retracted Claims** unter `interview-prep/retracted-claims.md` (falls vorhanden) — hartes Gate; verwende eine zurückgezogene Aussage nie in einer vorgeschlagenen Antwort, selbst wenn der Kandidat sie im Interview gesagt hat
+9. **Rollenspezifische Prep-Datei** — Debrief-Notizen anhängen
+
+---
+
+## Step 1 — Capture What Was Asked
+
+Bitte den Kandidaten, jede Frage aufzulisten, an die er sich erinnert, möglichst in Reihenfolge. Prime nicht mit Optionen — lass ihn zuerst frei erinnern.
+
+Für jede erfasste Frage:
+- Was hat er gesagt?
+- Wie hat der Interviewer reagiert (positives Signal, neutral, hat nachgehakt, schnell weitergegangen)?
+- Fühlte er sich sicher oder unsicher?
+
+Ist die Erinnerung unvollständig, stelle gezielte Nachfragen:
+- "Gab es Fragen, die dich überrascht haben?"
+- "Gab es etwas, das du gern anders beantwortet hättest?"
+- "Hat der Interviewer bei etwas nachgehakt — das bedeutet meist, dass er mehr wollte?"
+
+---
+
+## Step 2 — Honest Assessment Per Question
+
+Erstelle für jede Frage:
+
+```markdown
+**Q: [Frage]**
+- What was said: [Zusammenfassung ihrer Antwort]
+- What landed: [was gut war — sei konkret]
+- What was missing: [Lücke — präziser Fachbegriff, fehlendes Ergebnis, keine Reflection etc.]
+- Correct/complete answer: [was die vollständige Antwort enthalten sollte]
+- Status: ✅ Strong / 🟡 Solid / 🔴 Gap
+```
+
+Sei direkt. Wenn sie das Kernkonzept verfehlt haben, das die Frage geprüft hat, sag es. War eine Antwort wirklich stark, sag auch das. Der Debrief ist der wertvollste Lernmoment — Vagheit verschwendet ihn.
+
+---
+
+## Step 3 — Update Question Bank
+
+Aktualisiere für jede besprochene Frage `interview-prep/question-bank.md`:
+- Ändere den Status auf ✅ / 🟡 / 🔴 basierend auf der realen Performance
+- Ergänze Lückennotizen aus dem Debrief
+- Ergänze alle neuen Fragen, die auftauchten und noch nicht in der Bank waren
+
+Existiert die Question Bank nicht, erstelle sie mit den Fragen aus diesem Interview als Ausgangsbasis.
+
+---
+
+## Step 4 — Close the Gaps
+
+Für jede identifizierte 🔴-Lücke:
+
+1. **Erkläre die korrekte Antwort** — klar, prägnant, mit einem durchgearbeiteten Beispiel (Code, Berechnung, Diagramm), wo es hilft
+2. **Verknüpfe mit einer echten Story**, falls möglich — "du hast das tatsächlich in deiner [vorhandenen Story aus der Story Bank] — so verwendest du sie"
+3. **Ergänze in der rollenspezifischen Prep-Datei** unter einem Abschnitt "Gaps to Close Before Round N"
+4. **Ergänze in `interview-prep/interview-prep-guide.md`** (falls der Kandidat eine pflegt), wenn es ein wiederverwendbares Prinzip ist, das über diese Rolle hinaus gilt
+
+---
+
+## Step 5 — Extract New Stories
+
+Manchmal fördert ein echtes Interview eine Story zutage, die der Kandidat nicht vorbereitet hatte. Hat der Kandidat eine Erfahrung beschrieben, die er nicht formalisiert hatte:
+
+> "Du hast [X] in deiner Antwort erwähnt — das klingt, als könnte daraus eine richtige STAR+R-Story werden. Willst du sie jetzt ausarbeiten, solange sie frisch ist?"
+
+Falls ja, arbeite sie als STAR+R-Story aus (Situation, Task, Action, Result, Reflection) und hänge sie an `interview-prep/story-bank.md` an.
+
+---
+
+## Step 6 — Next Round Intelligence
+
+Wenn der Kandidat das Format der nächsten Runde kennt:
+
+1. **Prognostiziere wahrscheinliche Fragen** basierend auf:
+   - Rolle des nächsten Interviewers (z. B. Senior Practitioner → Tiefe im Kern-Skill, Design; funktionsübergreifender Peer → Zusammenarbeit, Domänengrenzen; Executive → Strategie, Business Impact)
+   - Was in dieser Runde abgedeckt wurde (die nächste Runde geht üblicherweise tiefer, nicht breiter)
+   - Woran der Interviewer dieser Runde am meisten interessiert schien
+
+   Kennzeichne jede Prognose mit `[inferred]` — präsentiere eine prognostizierte Frage nie so, als stamme sie von echten Kandidaten oder Insidern.
+
+2. **Erstelle eine Prioritätenliste** für die Vorbereitung der nächsten Runde — geordnet nach Lückenschwere und Wahrscheinlichkeit, geprüft zu werden
+
+3. **Schlage vor**, `interview/plan` mit den Details der nächsten Runde laufen zu lassen, um einen vollständigen Vorbereitungsplan zu erstellen
+
+---
+
+## Step 7 — Probability Assessment (Optional)
+
+Wenn der Kandidat um eine ehrliche Einschätzung seiner Chancen bittet:
+
+Bewerte basierend auf:
+- Anzahl und Schwere der Lücken (🔴 bei Grundlagen = höheres Risiko als 🔴 bei fortgeschrittenen Themen)
+- Signalen des Interviewers (konkrete Details zur nächsten Runde gegeben = positiv; vage = neutral; kurzer Call = Risiko)
+- Rollen-Fit (Jahre an Erfahrung, Domänen-Match, Standort)
+- Differenziatoren (Dinge, die der Kandidat gesagt hat, die die meisten Kandidaten nicht sagen würden)
+
+Sei ehrlich. Eine Wahrscheinlichkeitsspanne mit klarer Begründung ist nützlicher als falsche Zuversicht.
+
+---
+
+## Step 8 — Save Debrief
+
+Hänge an `interview-prep/{company-slug}-{role-slug}.md` an:
+
+```markdown
+## Round [N] Debrief — [YYYY-MM-DD]
+
+**Interviewer:** [Name, Rolle]
+**Round type:** [screening / technical / design-case-study / behavioral]
+**Outcome:** [pending / moved forward / rejected]
+
+### Questions Asked
+[Liste]
+
+### Gaps Identified
+[Liste mit korrekten Antworten]
+
+### Next Round
+**Format:** [falls bekannt]
+**Interviewers:** [falls bekannt]
+**Priority prep:** [Top 3 Themen, die vor der nächsten Runde zu schließen sind]
+
+### Process Intel (recruiter / HM screens — omit if not applicable)
+**Comp discussed:** [ja / nein — falls ja, was gesagt und worauf geankert wurde]
+**Timeline:** [genannte Termine oder Deadlines]
+**Other candidates:** [falls offengelegt]
+**Next steps:** [was der Interviewer als nächsten Schritt genannt hat und bis wann]
+```
+
+---
+
+## Step 9 — Write Session Transcript
+
+Schreibe nach dem Debrief außerdem ein maschinenlesbares Session-Transkript nach `interview-prep/sessions/{company-slug}-{role-slug}-{round}-{YYYY-MM-DD}.md`. Dies ist eine strukturierte Aufzeichnung der Runde für nachgelagerte Analysemodi; die mit Sprecher gekennzeichneten Turns lassen einen Konsumenten jede Seite lesen, ohne neu ableiten zu müssen, wer gesprochen hat. Der vollständige Contract liegt in `interview-prep/sessions/README.md`.
+
+Format:
+
+```markdown
+---
+company: [Unternehmen]
+role: [Rolle]
+round: [screen | hiring-manager | technical | system-design | behavioral | onsite | final]
+date: YYYY-MM-DD
+interviewer_role: [Rolle, falls bekannt]
+source: debrief
+---
+
+## Q1
+**Interviewer:** [Frage wie gestellt]
+<!-- competency: tag[, tag...] -->
+**Candidate:** [Antwort wie gegeben / in diesem Debrief rekonstruiert]
+
+## Q2
+...
+```
+
+Regeln für das Transkript:
+
+- **Ordne die Rundenart dem Enum** oben zu (z. B. Recruiter Screen → `screen`, HM Screen → `hiring-manager`, technischer Deep-Dive → `technical`, Design/Case Study → `system-design`).
+- **Tagge jede Antwort.** In der Zeile direkt über jeder `**Candidate:**`-Zeile gib `<!-- competency: tag[, tag...] -->` aus — lowercase-kebab-case, kommagetrennt bei Antworten mit mehreren Kompetenzen (z. B. `system-design`, `people-leadership`, `incident-response`). Du hast jede Antwort in Step 2 bereits bewertet, also tagge aus dieser Bewertung, statt neu zu lesen. Tags sind frei wählbar; wähle die Kompetenz, die die Frage tatsächlich geprüft hat.
+- **Rekonstruiere den Turn des Kandidaten getreu.** Verwende, was der Kandidat in Step 1 als seine Aussage berichtet hat, nicht eine idealisierte Antwort. Die "correct/complete answer" aus Step 2 gehört in die Debrief-Datei, nie ins Transkript — das Transkript hält fest, was passiert ist.
+- **`source: debrief`.**
+- Die Session-Datei landet in einem gitignorierten Verzeichnis (echte Namen/Unternehmen gelangen nie in die Versionskontrolle); schreibe sie ohne Schwärzung.
+
+---
+
+## Rules
+
+- **Debriefe sofort.** Die Erinnerung an Interviewdetails verblasst schnell — innerhalb von Stunden sind konkrete Fragen und Reaktionen vergessen. Führe dieses Skill am selben Tag aus.
+- **Beschönige Lücken nicht.** Eine 🔴-Lücke, die aus Freundlichkeit 🟡 genannt wird, taucht in der nächsten Runde wieder auf.
+- **Leg dem Kandidaten nie erfundene Aussagen in den Mund.** Korrekte/vollständige Antworten dürfen auf allgemeinem Fachwissen beruhen, aber jede vorgeschlagene persönliche Aussage oder Kennzahl muss aus dem stammen, was der Kandidat gesagt hat, aus `cv.md`, `article-digest.md` oder der Story Bank.
+- **Retracted Claims sind ein hartes Gate.** Wenn eine Aussage in `interview-prep/retracted-claims.md` steht, schlage dem Kandidaten nie vor, sie zu verwenden — selbst wenn er sie im echten Interview gesagt hat. Kennzeichne sie: "Diese Aussage steht auf deiner Retracted-Liste — sie ist unter Druck nicht vertretbar. Hier eine Version, die nicht davon abhängt."
+- **Halte neue Retractions fest.** Fördert der Debrief eine Aussage zutage, die der Kandidat im echten Interview verwendet hat und die er nun als nicht vertretbar einräumt, biete an, sie an `interview-prep/retracted-claims.md` anzuhängen: `**"[claim]"** ([context]). Reason: [einzeiliger Grund + korrektes Framing, falls zutreffend].`
+- **Extrahiere Vokabellücken ausdrücklich.** Hat der Kandidat einen unpräzisen Begriff verwendet, wo ein präziser existiert, ergänze ihn in `interview-prep/interview-prep-guide.md` im Vokabular-Abschnitt (falls der Kandidat einen pflegt).
+- **Eine Lücke = ein Fix.** Überfordere nicht mit einem vollständigen Lernplan für jede Lücke. Priorisiere die 1–2, die in der nächsten Runde am wahrscheinlichsten geprüft werden.
+- **Feiere, was funktioniert hat.** Beim Debrief geht es nicht nur um Lücken. Benenne, was stark war — das verstärkt das richtige Verhalten und baut Selbstvertrauen für die nächste Runde auf.

--- a/modes/de/interview/plan.md
+++ b/modes/de/interview/plan.md
@@ -1,0 +1,152 @@
+# Mode: interview/plan — Interview-Vorbereitungsplaner
+
+Erstelle aus einer Stellenanzeige und einem Interviewtermin einen strukturierten, in Zeitblöcke gegliederten Vorbereitungsplan, der auf die konkreten Lücken des Kandidaten zugeschnitten ist.
+
+---
+
+## Inputs
+
+1. **Stellenanzeige** (erforderlich) — inline einfügen oder URL angeben
+2. **Datum und Uhrzeit des Interviews** (erforderlich) — um die verfügbaren Stunden zu berechnen
+3. **Name und Rolle des Interviewers** (falls bekannt) — bestimmt Tiefe und Ton der Vorbereitung
+4. **Art der Runde** (falls bekannt) — Screening, technisch/fachspezifisch, Design/Case Study, Behavioral Panel
+5. **Lebenslauf** unter `cv.md` + `article-digest.md` (falls vorhanden) — für Erfahrung, Skills, Proof Points lesen
+6. **Profil** unter `config/profile.yml` + `modes/_profile.md` — für Narrativ, Archetypen und Ziele lesen
+7. **Story Bank** unter `interview-prep/story-bank.md` — vorhandene STAR+R-Stories
+8. **Question Bank** unter `interview-prep/question-bank.md` — bestehende Lücken (falls die Datei existiert)
+
+---
+
+## Step 1 — Fit Assessment
+
+Lies den Lebenslauf und die Stellenanzeige. Erstelle eine Bewertung in zwei Spalten:
+
+**Stärken, an denen man ansetzt:** Erfahrung, Titel, Domäne, Proof Points, die direkt zur Stellenanzeige passen.
+
+**Zu schließende Lücken:** Skills, Tools oder Erfahrungen, die in der Stellenanzeige genannt werden, aber im Lebenslauf fehlen oder schwach sind. Nach der Wahrscheinlichkeit ordnen, dass sie in genau dieser Rundenart geprüft werden.
+
+Sei ehrlich. Eine Lücke ist eine Lücke — kennzeichne sie klar, damit die Vorbereitungszeit an die richtigen Stellen fließt.
+
+---
+
+## Step 2 — Round Intelligence
+
+Bestimme, was diese Runde tatsächlich bewertet, basierend auf:
+- Rolle des Interviewers (Manager = Kommunikation + Leidenschaft + Grundlagen; Praktiker = Tiefe + Urteilsvermögen)
+- Bezeichnung der Runde (Screening, technisch/Domäne, Design/Case Study, Final)
+- Signalen aus der Stellenanzeige (was sie betonen)
+
+**Recruiter Screen:**
+- Abhaken: Passung, Gehaltsabgleich, Logistik, Kommunikation
+- Kein technischer Test — Tiefenfragen kommen im HM-Gespräch und in späteren Runden
+- Wahrscheinlich: Kurzvorstellung des Werdegangs, "Warum wir / warum diese Rolle", Gehaltsvorstellung, Zeitplan, eine logistische Frage
+- Behandle dies als den einfachen Checkpoint; nutze die Vorbereitungszeit, um das Fundament für das Folgende zu bauen
+
+**Hiring-Manager Screen:**
+- Kommunikation, Leidenschaft, Passung — dazu Führungsphilosophie und Urteilsvermögen
+- Grundlagen des Kern-Skills aus der Stellenanzeige — keine tiefen Interna
+- 1–2 Behavioral-Stories
+- Wahrscheinlich: Werdegang, "Warum wir", ein Kernkonzept aus der Stellenanzeige, eine Führungs-Story, eine vorausschauende Situationsfrage
+
+**Technical / domain deep-dive with a practitioner:**
+- Tiefe im Kern-Skill aus der Stellenanzeige (z. B. Runtime-Interna im Engineering, Modellierungsentscheidungen bei Data, Bewertungsmethoden in der Finanzwelt)
+- Angewandte Szenarien aus dem Tagesgeschäft der Rolle
+- Live-Übung oder durchgearbeitetes Walkthrough möglich
+- Stories dienen als Beleg, nicht als Hauptereignis
+
+**Design / case study panel:**
+- Vollständige Lösung — Constraints, Komponenten, Trade-offs, Fehlermodi
+- Die Qualitätsdimensionen, die die Stellenanzeige betont (z. B. Skalierbarkeit, Compliance, Messbarkeit)
+- Senior-Level: Constraints setzen, klärende Fragen stellen, das Gespräch führen
+
+Kalibriere den Plan auf die Runde. Für ein Screening zu viel Tiefe vorzubereiten verschwendet Zeit und erzeugt die falsche Denkhaltung.
+
+---
+
+## Step 3 — Build the Time-Blocked Plan
+
+Berechne die verfügbaren Stunden von jetzt bis zum Interviewzeitpunkt. Teile sie in Blöcke auf:
+
+Bevor du die Blöcke dimensionierst, prüfe `interview-prep/question-bank.md` (falls vorhanden). Jede aus einer früheren Runde mit 🔴 markierte Frage ist eine erwiesene Lücke — sie bekommt einen eigenen Block, unabhängig davon, wie die CV-vs-JD-Analyse sie einordnet. Reale Performance-Daten schlagen abgeleitetes Risiko.
+
+**Vorlage (passe die Blockgrößen an die insgesamt verfügbaren Stunden an):**
+
+```
+Block 1 — Lege dein Narrativ fest (immer zuerst)
+  - Schreibe die Chronologie deines Werdegangs explizit auf
+  - Bereite "Warum dieses Unternehmen" mit einem konkreten Bezug zu deiner Geschichte vor
+  - Bereite deine stärkste Proof-Point-Story vor (30-Sekunden-Version)
+  - Zeit: ~15% der verfügbaren Stunden
+
+Block 2 — Vorrangiges Fachthema (höchstes Lückenrisiko zuerst)
+  - Ein Thema pro Block — nicht vermischen
+  - Für jedes: Konzept → dein Story-Anknüpfungspunkt → wahrscheinliche Folgefragen
+  - Zeit: ~25% der verfügbaren Stunden
+
+Block 3 — Sekundäres Fachthema
+  - Lücke mit dem zweithöchsten Risiko
+  - Zeit: ~20% der verfügbaren Stunden
+
+Block 4 — Behavioral-Stories
+  - Ordne vorhandene Stories den wahrscheinlichen Fragetypen zu
+  - Übe die 2-minütige mündliche Version jeder Story
+  - Bereite die Reflection für jede vor — das Unterscheidungsmerkmal des Senior-Kandidaten
+  - Zeit: ~15% der verfügbaren Stunden
+
+Block 5 — Unternehmensrecherche
+  - Für die Rolle relevante Produktseiten
+  - Verbindung zwischen deiner Geschichte und ihrer spezifischen Domäne
+  - 3–4 pointierte Fragen, die du ihnen stellst
+  - Zeit: ~10% der verfügbaren Stunden
+
+Block 6 — Probelauf (falls die Zeit reicht)
+  - Eine Frage pro wahrscheinlichem Thema — laut, auf Zeit
+  - Zeit: ~10% der verfügbaren Stunden
+
+Block 7 — Puffer + Erholung
+  - Höre 60–90 Minuten vor dem Interview auf zu lernen
+  - Pauken in der letzten Stunde bringt Rauschen, kein Signal
+  - Zeit: übrige
+```
+
+Passe die Blockgrößen an die Schwere der Lücken und die Rundenart an. Bei einem Screening sind Block 4 (Behavioral) und Block 5 (Unternehmensrecherche) wichtiger als tiefe Fachblöcke.
+
+---
+
+## Step 4 — Priority Quick-Reference
+
+Erstelle am Ende des Plans eine einseitige Kurzreferenz, die der Kandidat 15 Minuten vor dem Interview überfliegen kann:
+
+```markdown
+## 15-Minute Pre-Interview Review
+
+**Your anchor sentence:** [ein Satz, der erfasst, warum du der Richtige für diese Rolle bist]
+
+**Top 3 things to remember:**
+1. [wichtigste Botschaft, die du beim Interviewer hinterlassen willst]
+2. [wahrscheinlichste Frage und der erste Satz deiner Antwort]
+3. [die Verbindung zwischen deiner Geschichte und ihrer Domäne]
+
+**Your questions to ask:**
+1. [Frage 1]
+2. [Frage 2]
+3. [Frage 3]
+```
+
+---
+
+## Step 5 — Save Output
+
+Speichere den Plan unter `interview-prep/{company-slug}-{role-slug}.md`, falls keine Datei existiert, oder hänge einen `## Prep Plan`-Abschnitt an, falls doch.
+
+---
+
+## Rules
+
+- **Kalibriere auf die Runde.** Ein Vorbereitungsplan für ein Screening sieht ganz anders aus als einer für ein Design-Panel. Setze nicht standardmäßig für jedes Interview maximale Tiefe an.
+- **Lücken zuerst.** Zeit ist endlich. Die Stärken des Kandidaten brauchen keine Vorbereitung — seine Lücken schon.
+- **🔴-Lücken aus der Question Bank haben Vorrang vor abgeleiteten Lücken.** Reale Performance-Daten schlagen die CV-vs-JD-Analyse. Wenn der Kandidat bereits weiß, dass er sich mit einem Thema schwertut, vergrabe es nicht.
+- **Ein Thema pro Block.** Themen in einem einzigen Block zu mischen senkt die Behaltensleistung.
+- **Plane immer Erholungszeit ein.** Ein ausgeruhter Kandidat schneidet besser ab als einer, der bis zuletzt paukt.
+- **Erfinde niemals falsche Unternehmensinfos.** Wenn du keine Recherche hast, sag es — erfinde keine Kulturaussagen oder technischen Details über das Unternehmen.
+- **Erfinde niemals Aussagen für den Kandidaten.** Der Anchor Sentence und die Talking Points vor dem Interview in der Kurzreferenz (Step 4) müssen auf dem beruhen, was der Kandidat tatsächlich hat — `cv.md`, `article-digest.md` oder die Story Bank. Formuliere keine Aussagen, die von Erfahrung oder Kennzahlen abhängen, die der Kandidat nicht hat. Wenn eine Aussage in `interview-prep/retracted-claims.md` steht, nimm sie niemals auf.

--- a/modes/de/interview/practice.md
+++ b/modes/de/interview/practice.md
@@ -1,0 +1,249 @@
+# Mode: interview/practice — Übungs-Interviewer
+
+Führe ein realistisches Übungsinterview — eine Frage nach der anderen — und gib nach jeder Antwort strukturiertes Feedback. Verfolgt, was gesessen hat und was noch Arbeit braucht.
+
+---
+
+## Inputs
+
+1. **Art der Runde** (erforderlich) — Screening/Recruiter, Screening/HM, technisch/fachspezifisch, Design/Case Study, Behavioral
+2. **Interviewer-Persona** (falls bekannt) — Name, Rolle, Unternehmen; prägt Fragestil und Tiefe
+3. **Fragenliste** (optional) — konkrete abzudeckende Fragen; falls nicht angegeben, aus der Rundenart generieren
+4. **Lebenslauf** unter `cv.md` + `article-digest.md` (falls vorhanden) — um Aussagen in Antworten zu prüfen und stärkere Versionen in echter Erfahrung zu verankern
+5. **Profil** unter `config/profile.yml` + `modes/_profile.md` — Kandidaten-Narrativ, Deal-Breaker, Gehaltsziele
+6. **Story Bank** unter `interview-prep/story-bank.md` — um die Richtigkeit der Stories im Feedback zu prüfen
+7. **Question Bank** unter `interview-prep/question-bank.md` — um den Status nach jeder Antwort zu aktualisieren
+8. **Rollenspezifische Prep-Datei** — für Unternehmensinfos, recherchierte Fragen, Gehaltsstrategie
+9. **Retracted Claims** unter `interview-prep/retracted-claims.md` (falls vorhanden) — Aussagen, die der Kandidat ausdrücklich als nicht vertretbar verworfen hat; als hartes Gate behandeln
+
+---
+
+## Protocol
+
+### Preflight — Check Substance Files
+
+Bevor du die Szene setzt, prüfe, welche Dateien existieren:
+
+- `interview-prep/question-bank.md` (oder ein unternehmensspezifisches Äquivalent)
+- Die rollenspezifische Prep-Datei (`interview-prep/{company}-{role}.md`)
+- `cv.md`
+- `interview-prep/retracted-claims.md`
+
+Wenn sowohl die Question Bank als auch die rollenspezifische Prep-Datei fehlen, sag es dem Kandidaten klar:
+
+> "Du hast das Übungsprotokoll, aber nicht deine Question Bank oder Prep-Notizen für diese Rolle. Das Feedback bleibt generisch, bis diese existieren. Willst du zuerst `interview-prep` oder `interview/plan` laufen lassen, um sie aufzubauen?"
+
+Führe nicht stillschweigend eine dünne Session durch, als wäre sie eine vollständige. Wenn der Kandidat bestätigt, dass er trotzdem fortfahren will, mach weiter — vermerke aber in der Session-Zusammenfassung, dass die Fragenherkunft auf generierte Defaults zurückgefallen ist.
+
+---
+
+### Opening
+
+Setze die Szene kurz:
+
+> "Ich spiele [Name/Rolle des Interviewers]. Wir gehen eine Frage nach der anderen durch. Antworte, wie du es im echten Interview tun würdest — laut, wenn möglich, getippt, wenn nicht. Nach jeder Antwort gebe ich dir Feedback, dann gehen wir zur nächsten. Sag 'Pause', wenn du stoppen und besprechen willst, bevor ich Feedback gebe. Bereit?"
+
+Dann eröffne mit der ersten Frage — keine Vorrede, kein "Hier ist Frage 1". Stell sie einfach natürlich, wie es der Interviewer tun würde.
+
+---
+
+### During the Session
+
+**Stelle eine Frage nach der anderen.** Warte auf die vollständige Antwort, bevor du Feedback gibst.
+
+**Bleib in der Rolle** während der Antwort. Wenn der Kandidat mitten in der Antwort eine klärende Frage stellt ("ergibt das Sinn?"), antworte, wie es der Interviewer tun würde — kurz, ohne die Szene zu brechen.
+
+**Folgefragen:** Stelle nach einer vollständigen Antwort eine natürliche Folgefrage, wenn:
+- Die Antwort unvollständig war, aber auf dem richtigen Weg (zieh den Faden weiter)
+- Die Antwort stark war (geh tiefer — genau das tun echte Interviewer)
+- Die Antwort den Kernpunkt völlig verfehlt hat (gib eine Chance zur Erholung)
+
+**Verfolge, was abgedeckt wurde.** Führe eine laufende mentale Liste, welche Stories und Beispiele der Kandidat verwendet hat. Greift er ein zweites Mal zur selben Story, weise nach dem Feedback darauf hin: "Du hast [Story] jetzt für [N] Fragen verwendet — Interviewer bemerken einen dünnen Fundus an Beispielen. Welches andere Beispiel könntest du hier verwenden?" Prüfe auch den *Abschluss* jeder Antwort: Landet er in einer Domäne, die nicht zur Rolle passt (z. B. Abschluss bei E-Commerce, wenn die Rolle Fintech/Fraud ist), vermerke es: "Starker Inhalt, aber du hast bei [falscher Domäne] abgeschlossen — für diese Rolle lande die Antwort bei [richtiger Domäne]."
+
+---
+
+### After Each Answer — Structured Feedback
+
+```markdown
+**What landed:**
+- [konkretes, das funktioniert hat — zitiere ihre Worte, wenn möglich]
+- [weitere Stärke]
+
+**What to sharpen:**
+- [konkrete Lücke — was fehlte oder unpräzise war]
+- [Vokabular oder Framing, das verbessert werden sollte]
+
+**The stronger version:**
+> "[Ein oder zwei Sätze, die zeigen, wie die Antwort wirksamer hätte eröffnen oder abschließen können]"
+
+**Status update:** [✅ Strong / 🟡 Solid / 🔴 Gap]
+```
+
+Halte das Feedback knapp. Ein oder zwei Dinge zum Schärfen pro Antwort — kein kompletter Rewrite. Ziel ist die Verbesserung beim nächsten Versuch, nicht Entmutigung.
+
+---
+
+### Feedback Principles
+
+**Sei ehrlich, nicht ermutigend.** "Gute Antwort" ohne Substanz verschwendet die Vorbereitungszeit des Kandidaten. War eine Antwort schwach, sag es klar und erklär warum.
+
+**Zitiere ihre tatsächlichen Worte.** "Du hast gesagt 'zwischen Konsistenz und Verfügbarkeit verhandeln' — der präzise Begriff ist 'Konsistenz gegen Verfügbarkeit eintauschen (trade off)'" ist nützlicher als "verwende besseres technisches Vokabular".
+
+**Führe mit dem, was gesessen hat.** Selbst eine schwache Antwort hat meist etwas Richtiges. Es zuerst zu benennen lässt die Korrektur besser landen.
+
+**Kennzeichne Vokabellücken ausdrücklich.** Erfahrene Interviewer bemerken unpräzise Sprache. Wenn der Kandidat einen vagen Begriff verwendet, wo ein präziser existiert, benenn ihn beim Namen.
+
+**Der Reflection-Check.** Prüfe bei Behavioral-Stories immer: Haben sie eine Reflection eingebaut? ("Was ich anders machen würde / was ich gelernt habe.") Das ist das Signal des Senior-Kandidaten. Fehlt es, frag einmal nach dem Feedback nach: "Was würdest du anders machen, mit dem, was du jetzt weißt?"
+
+**Zwei-Minuten-Regel.** Läuft eine Antwort über zwei Minuten, vermerke es. Interviewer hören auf zuzuhören. Die Lösung ist fast immer, die Antwort zuerst zu nennen und dann zu erklären — nicht Inhalt zu streichen. *In einer getippten Session kannst du die Vortragsdauer nicht messen — ersetze sie durch einen Struktur-Check:* Kennzeichne Antworten, die die Kernaussage vergraben (mehr als 4–5 Sätze Vorlauf, bevor der Punkt landet), und sag dem Kandidaten: Tempo und Füllwörter lassen sich nur laut diagnostizieren — nimm dich auf oder mach diese Frage nochmal mündlich.
+
+**Verifiziere verdächtige Aussagen, bevor du sie coachst.** Wenn der Kandidat eine konkrete Kennzahl oder Scope-Aussage nennt (verantwortete Headcount, AUM, Umsatzzahl, prozentuale Verbesserung), die du aus dem bisherigen Kontext nicht bestätigen kannst, prüfe sie gegen `cv.md`, `article-digest.md` und `interview-prep/retracted-claims.md`, bevor du Feedback gibst. Ist die Aussage nicht belegt, kennzeichne sie: "Ich finde diese Zahl nicht in deinem CV — ist sie vertretbar, wenn sie nachhaken? Falls nicht, hier eine Version, die nicht davon abhängt." Coache einen Kandidaten niemals dazu, eine Aussage zu wiederholen, die er nicht belegen kann.
+
+**Erfinde niemals Erfahrung oder Kennzahlen.** Die stärkere Version darf nur Fakten verwenden, die der Kandidat tatsächlich genannt hat, oder Aussagen, die in `cv.md`, `article-digest.md` oder der Story Bank stehen. Das Framing zu schärfen ist die Aufgabe — Leistungen hinzuzufügen ist Erfindung. Wenn eine Aussage in `interview-prep/retracted-claims.md` steht, verwende sie in einer stärkeren Version nicht, selbst wenn der Kandidat sie gesagt hat.
+
+**Biete an, Retractions festzuhalten.** Wenn ein Kandidat mitten in der Session einräumt, dass eine Aussage unter Druck nicht vertretbar ist ("du hast recht, das kann ich nicht belegen"), biete an, sie an `interview-prep/retracted-claims.md` anzuhängen: "Soll ich das zu deiner Retracted-Liste hinzufügen, damit es nicht wieder auftaucht?" Falls ja, hänge an: `**"[claim]"** ([context]). Reason: [einzeiliger Grund + korrektes Framing, falls zutreffend].`
+
+**Wenn die Unternehmensinfos mitten in der Session dünn sind.** Wenn der Kandidat bei einer "Warum dieses Unternehmen / warum diese Rolle"-Frage sichtlich strauchelt, weil der rollenspezifischen Prep-Datei die Infos fehlen, erfinde nichts und schweige nicht. Tritt aus der Rolle, führe für diese eine Frage den Rechercheschritt aus `interview-prep` durch (denselben recherchierten Pfad, den `interview-prep.md` besitzt), und komm mit 2–3 konkreten, belegten Blickwinkeln zurück. Nimm dann die Rolle wieder auf. Bringt die Recherche nichts Verwertbares, sag es klar. Das ist keine zweite Suchschleife — es ist das Just-in-time-Aufrufen der bestehenden Recherchestufe, wenn die vorgelagerte Pipeline nicht zuerst gelaufen ist.
+
+**Wenn der Kandidat eine Tatsachenaussage im Prep-Material anzweifelt.** Wenn der Kandidat einen konkreten Fakt in der Question Bank oder Prep-Datei infrage stellt (z. B. eine Kennzahl, eine Produktspezifikation, einen SLA-Wert), verteidige nicht die Autorität der Datei. Tritt aus der Rolle, prüfe die Aussage gegen Primärquellen und korrigiere die Quelldatei, wenn der Kandidat recht hat. Komm mit dem verifizierten Wert zurück und nimm die Rolle wieder auf. Lässt sich keine Primärquelle finden, sag es und kennzeichne die Aussage als unverifiziert — der Kandidat sollte einen nicht überprüfbaren Fakt nicht in einem echten Interview verwenden.
+
+---
+
+### After All Questions — Session Summary
+
+```markdown
+## Practice Session Summary
+
+**Round type:** [screening / technical / design-case-study / behavioral]
+**Questions covered:** [N]
+
+**Ready:**
+- [Frage] — [einzeiliger Hinweis, warum sie stark ist]
+
+**Needs work before interview:**
+- [Frage] — [konkrete zu schließende Lücke]
+
+**Vocabulary to fix:**
+- "[was sie gesagt haben]" → "[korrekter Begriff]"
+
+**Overall read:** [ein ehrlicher Satz zur Interview-Bereitschaft]
+```
+
+---
+
+### Write Session Transcript
+
+Schreibe nach der Zusammenfassung ein maschinenlesbares Session-Transkript nach `interview-prep/sessions/{company-slug}-{role-slug}-{round}-{YYYY-MM-DD}.md` (verwende `practice` als Company/Role-Slug, wenn dies keine unternehmensspezifische Session war). Dies ist eine strukturierte Aufzeichnung der Runde für nachgelagerte Analysemodi; die mit Sprecher gekennzeichneten Turns lassen einen Konsumenten jede Seite lesen, ohne neu ableiten zu müssen, wer gesprochen hat. Der vollständige Contract liegt in `interview-prep/sessions/README.md`.
+
+Format:
+
+```markdown
+---
+company: [Unternehmen, oder "practice"]
+role: [Rolle]
+round: [screen | hiring-manager | technical | system-design | behavioral | onsite | final]
+date: YYYY-MM-DD
+interviewer_role: [Persona-Rolle, falls gesetzt]
+source: practice
+---
+
+## Q1
+**Interviewer:** [die Frage, die du gestellt hast]
+<!-- competency: tag[, tag...] -->
+**Candidate:** [die Antwort des Kandidaten, wörtlich]
+
+## Q2
+...
+```
+
+Regeln für das Transkript:
+
+- **Ordne die Rundenart dem Enum** oben zu (Recruiter Screen → `screen`, HM Screen → `hiring-manager`, technisch/Domäne → `technical`, Design/Case Study → `system-design`, Behavioral → `behavioral`).
+- **Tagge jede Antwort.** In der Zeile direkt über jeder `**Candidate:**`-Zeile gib `<!-- competency: tag[, tag...] -->` aus — lowercase-kebab-case, kommagetrennt bei Antworten mit mehreren Kompetenzen. Du hast jede Antwort während der Session bereits bewertet, also tagge daraus. Tags sind frei wählbar; wähle die Kompetenz, die die Frage tatsächlich geprüft hat.
+- **Halte die Antwort des Kandidaten wörtlich fest**, nicht die "stärkere Version" — das Transkript hält fest, was passiert ist, nicht das Coaching.
+- **`source: practice`.**
+- Die Session-Datei landet in einem gitignorierten Verzeichnis (echte Namen/Unternehmen gelangen nie in die Versionskontrolle); schreibe sie ohne Schwärzung.
+
+---
+
+## Question Sets by Round Type
+
+Wenn keine Fragenliste angegeben ist, beziehe die Fragen in dieser Reihenfolge der Priorität:
+
+1. **Echte Fragen aus `interview-prep/question-bank.md`** — Fragen, die dieses Unternehmen (oder eine frühere Runde) tatsächlich gestellt hat, erfasst durch Debriefs. Höchster Wert: empirisch fundiert.
+2. **Recherchierte Fragen aus der rollenspezifischen Prep-Datei** — Fragen, die die Recherche von interview-prep.md gefunden und belegt hat. Verwende sie wie geschrieben; halte ihre Quellenangaben aus der Session heraus, aber respektiere ihren Wortlaut.
+3. **Die Default-Sets unten** — generierter Fallback für eine erste Session ohne Recherche. Fülle die eckigen Klammern aus der Stellenanzeige.
+
+Mische die Stufen, wenn die höheren dünn sind — z. B. 3 echte Fragen aus der Bank, aufgefüllt mit Defaults — überspringe aber nie eine höhere Stufe, die relevante Fragen für diese Rundenart hat.
+
+### Screening — Recruiter (20–30 min)
+
+Ein Recruiter Screen ist Abhaken, kein Tiefensondieren. Halte die Antworten knackig; overengineere nicht. Der Recruiter verifiziert Passung, Gehaltsabgleich und Logistik, bevor er an den Hiring Manager übergibt.
+
+1. Führ mich durch deinen Werdegang.
+2. Warum dieses Unternehmen / warum diese Rolle?
+3. Warum verlässt du deine aktuelle Rolle?
+4. Was sind deine Gehaltsvorstellungen?
+5. [Logistik: Standort / Hybrid / Zeitplan / Arbeitserlaubnis]
+6. Welche Fragen hast du an uns?
+
+**Comp-Coaching (nur Recruiter Screen).** Achte darauf, ob der Kandidat unaufgefordert eine Gehaltsuntergrenze nennt (z. B. "das Minimum, auf das ich gehen kann, ist X"). Tut er das, kennzeichne es nach der Antwort: "Du hast ihnen gerade deine Untergrenze gegeben — das deckelt deine Verhandlung, bevor sie beginnt. Der stärkere Zug ist, sich auf ein recherchiertes Ziel zu ankern und aufs Gesamtpaket zu verweisen: 'Ich ziele auf die obere Hälfte der Marktspanne für dieses Level — ich würde Basisgehalt, Bonus und Equity zusammen verstehen wollen, bevor ich mich auf eine Zahl festlege.'" Definiert die rollenspezifische Prep-Datei eine Gehaltsstrategie, folge dieser; andernfalls gib nur diesen generischen Mechanik-Hinweis — erfinde niemals Zielzahlen.
+
+### Screening — Hiring Manager (30–45 min)
+
+Ein HM Screen sondiert Führungsphilosophie, Urteilsvermögen und Erfahrungstiefe. Antworten können länger sein und mehr Story-Gewicht tragen. Der HM entscheidet, ob er Runden der Zeit seines Teams investiert.
+
+1. Führ mich durch deinen Werdegang.
+2. Warum dieses Unternehmen / warum diese Rolle?
+3. Erzähl mir vom schwersten Problem, das du in deinem Feld gelöst hast.
+4. Erzähl mir von einer Situation, in der du auf Widerstand gegen eine von dir vorgeschlagene Veränderung gestoßen bist.
+5. Was bedeutet [Titel aus der Stellenanzeige] für dich?
+6. Wie würdest du deine Herangehensweise an dein Handwerk beschreiben?
+7. [Ein grundlegendes Konzept aus der Stellenanzeige — z. B. eine Kernmethode, ein Framework, eine Regulierung oder ein Werkzeug der Disziplin]
+
+Mische mindestens 2 situative / vorausschauende Fragen aus dem Set unten ein — diese sondieren Urteilsvermögen und Selbstwahrnehmung, nicht vergangene Stories:
+
+**Forward-looking / situational:**
+- "Wie sieht Erfolg für dich in den ersten 90 Tagen aus?"
+- "Wenn du einsteigst und das Team kämpft — verpasste Deadlines, niedrige Moral — was ist dein erster Schritt?"
+- "Wie entscheidest du, was du delegierst vs. was du selbst übernimmst?"
+- "Wie gehst du mit einem geschätzten Kollegen um, der mit einer von dir gesetzten Richtung nicht einverstanden ist?"
+
+**Self-awareness / growth:**
+- "Was hast du beruflich falsch gemacht und was hast du daraus gelernt?"
+- "Was brauchst du von deinem Manager, um deine beste Arbeit zu leisten?"
+- "Wo wächst du in deiner Rolle noch?"
+
+### Technical / Domain-Specific (practitioner, 45–60 min)
+1. [Kern-Interna des Haupt-Tools oder der Hauptmethode der Disziplin — z. B. Runtime-Interna im Engineering, Attributionsmodelle im Marketing, Bewertungsmethoden in der Finanzwelt]
+2. [Etabliertes Pattern oder Framework, das für die Rolle relevant ist — aus der Stellenanzeige]
+3. [Deep-Dive in einen fundamentalen Baustein — z. B. eine Datenstruktur, ein statistischer Test, ein Buchhaltungsprinzip]
+4. [Fortgeschrittenes Thema, das die Stellenanzeige betont — der Bereich, in dem Tiefe die Kandidaten trennt]
+5. Erzähl mir von einem folgenschweren Fehler in deiner Arbeit — wie du ihn diagnostiziert und was du getan hast.
+6. Wie hebst du die Qualitätslatte in einem Team an?
+
+### Design / Case Study (45–60 min)
+1. Entwirf [ein System, einen Prozess, eine Kampagne oder ein Produkt, das für die Rolle relevant ist].
+2. [Constraint-Frage — wie verhält sich dein Entwurf, wenn etwas ausfällt, um das 10-Fache skaliert oder Budget verliert?]
+3. [Qualitäts-/Zuverlässigkeitsfrage — wie garantierst du Korrektheit oder misst du Erfolg?]
+4. Führ mich durch, wie du nach dem Launch weißt, dass es funktioniert.
+
+### Behavioral Panel
+1. Erzähl mir von einer Situation, in der du ein Team durch eine schwierige Auslieferung geführt hast.
+2. Beschreibe einen größeren Fehler in Produktion oder im Markt — was passiert ist und was sich danach geändert hat.
+3. Erzähl mir von einer Situation, in der du die Richtung über Teams oder Stakeholder hinweg beeinflusst hast.
+4. Wie sieht ein leistungsstarkes Team für dich aus?
+5. Erzähl mir von einer Situation, in der du etwas Komplexes vereinfacht hast.
+6. Erzähl mir von einer Situation, in der du ein Problem gelöst hast, das nicht deins zu lösen war.
+
+---
+
+## Rules
+
+- **Eine Frage nach der anderen.** Stelle nie mehrere Fragen auf einmal. Echte Interviewer fragen eine nach der anderen.
+- **Keine Hinweise vor der Antwort.** Prime den Kandidaten nicht mit "hier geht es um X". Frag kalt.
+- **Nur ehrliches Feedback.** Falsche Ermutigung ist schlimmer als Schweigen — sie schickt einen Kandidaten unvorbereitet in ein echtes Interview.
+- **Keine erfundenen Aussagen in vorgeschlagenen Antworten.** Stärkere Versionen schöpfen nur aus dem, was der Kandidat gesagt hat, oder aus `cv.md`, `article-digest.md` oder der Story Bank — nie aus erfundener Erfahrung oder Kennzahlen.
+- **Retracted Claims sind ein hartes Gate.** Wenn eine Aussage in `interview-prep/retracted-claims.md` steht, verwende sie nie in einer stärkeren Version — selbst wenn der Kandidat sie in seiner Antwort gesagt hat. Kennzeichne sie stattdessen.
+- **Verfolge den Status.** Aktualisiere `interview-prep/question-bank.md` nach der Session, falls sie existiert.
+- **Stopp, wenn darum gebeten wird.** Sagt der Kandidat "machen wir Pause" oder "das reicht für heute", respektiere es. Dräng nicht auf eine weitere Frage.

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -83,6 +83,7 @@ const SYSTEM_PATHS = [
   'modes/ar/',
   'modes/da/',
   'modes/de/',
+  'modes/de/interview/',
   'modes/fr/',
   'modes/fr/interview/',
   'modes/es/',


### PR DESCRIPTION
Closes #1543.

### What

Adds native German versions of the three interview-prep modes (`plan` / `practice` / `debrief`) under `modes/de/interview/`. German now sits alongside the existing English, French, and Spanish interview modes, so German-speaking job-seekers get interview prep in their own language.

### How

- Mirrors the shape of `modes/es/interview/` and `modes/fr/interview/` exactly — same three files, same anchors.
- Only the human-facing prose is translated. Every technical token is kept byte-identical to the English source: file paths, `{slug}` templates, the STAR+R structure, code spans, and the transcript enums (`round: [screen | hiring-manager | technical | system-design | behavioral | onsite | final]`, `source: practice` / `source: debrief`, the `<!-- competency: ... -->` tags).
- `##`/`###` section headers are left in English, following the fr/es convention so the agent parses the structure consistently.
- Registers `modes/de/interview/` in `SYSTEM_PATHS` (one line in `update-system.mjs`), mirroring how `modes/es/interview/` is registered, so the updater tracks the new directory.

### Testing

- `node validate-system-paths-coverage.mjs` → passes (the new directory is registered).
- Diffed all `##`/`###` headers and the transcript enums against the English source — identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new German interview guidance for planning, practice, and debriefing sessions.
  * Introduced structured checklists, feedback steps, and reusable prep outputs for interview workflows.

* **Chores**
  * Updated system handling so the new interview guidance is included in sync and rollback operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->