### PR TITLE
fix(coverage): exclude .editorconfig so main is not red for every PR (#1613)

### DIFF
--- a/validate-system-paths-coverage.mjs
+++ b/validate-system-paths-coverage.mjs
@@ -41,6 +41,7 @@ const ALL_PATHS = [...SYSTEM_PATHS, ...USER_PATHS];
 
 const EXCLUDES = [
   '.coderabbit.yaml',
+  '.editorconfig',
   '.envrc',
   '.gitignore',
   '.npmignore',
@@ -83,6 +84,7 @@ if (process.argv.includes('--self-test')) {
   // Test explicitly excluded files
   assert(covered('.gitignore') === true, '.gitignore must be covered (excluded)');
   assert(covered('.coderabbit.yaml') === true, '.coderabbit.yaml must be covered (excluded)');
+  assert(covered('.editorconfig') === true, '.editorconfig must be covered (excluded — contributor tooling, #1613)');
 
   // Test exact matches in SYSTEM_PATHS / USER_PATHS
   assert(covered('CLAUDE.md') === true, 'CLAUDE.md must be covered (exact match)');


### PR DESCRIPTION
Closes #1613.

#1438 added `.editorconfig` but never registered it, so `validate-system-paths-coverage.mjs` fails on a clean checkout of `main`. Because the `test` job is PR-only, main's own push CI never catches it — but **every open PR that rebases/merges onto current main fails the `test` check** with `Coverage gap … .editorconfig`.

`.editorconfig` is contributor tooling (like `.coderabbit.yaml` / `.envrc`), so the fix is to add it to **`EXCLUDES`**, not `SYSTEM_PATHS` — putting it in `SYSTEM_PATHS` would ship it to client installs on `update-system apply`. Added the `EXCLUDES` entry plus the matching self-test assertion.

Verified: `validate-system-paths-coverage.mjs --self-test` passes, the real run reports `OK: … covered`, and full `--quick` is green (1281 passed, 0 failed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved path coverage validation to recognize an additional config file as intentionally excluded.
  * Updated automated self-checks to reflect the new coverage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->