### PR TITLE
fix: enforce _custom.md procedural overrides across mode files

### DIFF
--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -171,6 +171,7 @@ Analyze posting signals to assess whether this is a real, active opening.
 **Assessment:** Apply the same three tiers (High Confidence / Proceed with Caution / Suspicious), weighting available signals more heavily. If insufficient signals are available to make a determination, default to "Proceed with Caution" with a note about limited data.
 
 #### Score Global
+Read `modes/_custom.md` → Scoring Rules, if it exists, and apply its override here. Default (if absent or silent): calculate global score based on dimension scores below.
 
 | Dimensión | Score |
 |-----------|-------|

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -461,7 +461,7 @@ process_offer() {
   # Inject user-layer personalization into the temporary worker prompt.
   # The resolved prompt is gitignored runtime state, so user profile data stays
   # out of the system layer while batch scoring matches interactive scoring.
-  for context_file in "$PROJECT_DIR/modes/_profile.md" "$PROJECT_DIR/config/profile.yml"; do
+  for context_file in "$PROJECT_DIR/modes/_profile.md" "$PROJECT_DIR/config/profile.yml" "$PROJECT_DIR/modes/_custom.md"; do
     if [[ -f "$context_file" ]]; then
       {
         printf '\n\n---\n\n'

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -30,7 +30,7 @@ Do not continue to Step 1 until this gate is resolved.
 
 ## Step 1 — A-G Evaluation
 
-Execute the same as the `oferta` mode (read `modes/oferta.md` for all A-F blocks + Block G Posting Legitimacy).
+Execute the same as the `oferta` mode (read `modes/oferta.md` for all A-F blocks + Block G Posting Legitimacy). Read `modes/_custom.md` → Evaluation Rules, if it exists, and apply its override here. Default (if absent or silent): standard A-G evaluation.
 
 The evaluation inherits `oferta`'s bounded research budget. Company, compensation, and hiring-signal lookup must not invoke `deep-research`, must not spawn subagents, and must stop at the shared query cap instead of escalating into open-ended research.
 

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -303,7 +303,7 @@ Save full evaluation in `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 - Current date
 - Company
 - Role
-- Score: match average (1-5)
+- Score: match average (1-5) — Read `modes/_custom.md` → Scoring Rules, if it exists, and apply its override here. Default (if absent or silent): average of block scores.
 - Status: `Evaluated`
 - PDF: ❌ (or ✅ if auto-pipeline generated PDF)
 - Report: root-relative link `[001](reports/001-company-2026-01-01.md)` (when merged via `merge-tracker.mjs` it is normalized to be relative to the tracker's own dir, e.g. `../reports/...`; see #760)

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -23,7 +23,7 @@ This complements — does not replace — the per-URL liveness gate in `auto-pip
    a. Claim the next sequential `REPORT_NUM` atomically by running `node reserve-report-num.mjs` (and release the sentinel using `node reserve-report-num.mjs --release <num>` after the report is written)
    b. **Extract JD** using Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
    c. If the URL is not accessible → mark as `- [!]` with a note and continue
-   d. **Execute full auto-pipeline**: Evaluation A-F → Report .md → PDF (if score >= `auto_pdf_score_threshold`) → Tracker
+   d. **Execute full auto-pipeline**: Evaluation A-F → Report .md → PDF (if score >= `auto_pdf_score_threshold`) → Tracker. Read `modes/_custom.md` → Pipeline Rules, if it exists, and apply its override here. Default (if absent or silent): standard pipeline execution.
    e. **Move from "Pending" to "Processed"**: `- [x] #NNN | URL | Company | Role | Score/5 | PDF ✅/❌`
 
    **About the PDF gate (configurable):** Read `config/profile.yml` → `auto_pdf_score_threshold`. If the key does not exist, default to `3.0` (this mode's original gate). If the evaluation score is less than the threshold, skip PDF generation: write the report normally, show in the header `**PDF:** not generated — run /career-ops pdf {company-slug} to create on demand`, and mark PDF ❌ in the tracker. If the score is ≥ threshold, generate the PDF as usual.

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -174,6 +174,7 @@ const SYSTEM_PATHS = [
   'examples/',
   'config/profile.example.yml',
   '.env.example',
+  '.editorconfig',
   '.agents/',
   '.claude/skills/',
   '.opencode/skills/',


### PR DESCRIPTION
## Description
This PR resolves #1618 by ensuring that the user's custom house rules (`modes/_custom.md`) are deterministically read and applied in active workflows, rather than relying on the LLM to inspect them on its own initiative.

### Changes
*   **Batch Context Injection**: Added `modes/_custom.md` to the context-injection loop in `batch/batch-runner.sh` alongside `_profile.md` and `profile.yml` so headless workers receive these instructions during batch processes.
*   **Explicit Prompts in Mode Files**: Added deterministic pointers directing the agent to check `modes/_custom.md` and apply any overrides at key decision/evaluation points:
    *   `modes/oferta.md` (Scoring rules/block scoring)
    *   `modes/pipeline.md` (Pipeline execution rules)
    *   `modes/auto-pipeline.md` (Evaluation rules)
    *   `batch/batch-prompt.md` (Global scoring rules)

Closes #1618


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for applying custom rule overrides from `modes/_custom.md` to global scoring and pipeline execution (including A–G evaluation and per-record scoring).
  * Expanded the prompt context to include `modes/_custom.md` when available.
* **Documentation**
  * Clarified how scoring and auto-pipeline behavior changes when `modes/_custom.md` is present vs. absent.
* **Chores**
  * Included `.editorconfig` in system updates and rollback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->