### PR TITLE
fix: prevent role-matcher from collapsing different seniorities

### DIFF
--- a/role-matcher.mjs
+++ b/role-matcher.mjs
@@ -7,6 +7,11 @@
  * path would silently delete with weaker matching rules.
  */
 
+export const SENIORITY_TOKENS = new Set([
+  'junior', 'mid', 'middle', 'senior', 'staff', 'principal', 'lead', 'head',
+  'chief', 'associate', 'intern', 'entry'
+]);
+
 // Tokens that almost every role shares must not count as strong matching
 // signal. This set covers seniority, work mode, contract shape, locations, and
 // other words that frequently appear in titles without identifying the opening.
@@ -69,6 +74,17 @@ export function roleTokens(role) {
     .filter(w => (w.length > 3 || SHORT_SPECIALTY.has(w)) && !ROLE_STOPWORDS.has(w));
 }
 
+function extractSeniorities(title) {
+  const text = typeof title === 'string' ? title : String(title ?? '');
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter(w => SENIORITY_TOKENS.has(w))
+  );
+}
+
 /**
  * Decide whether two role titles are likely the same opening.
  *
@@ -83,6 +99,18 @@ export function roleTokens(role) {
  * @returns {boolean} True when the titles are similar enough to deduplicate.
  */
 export function roleFuzzyMatch(a, b) {
+  const senA = extractSeniorities(a);
+  const senB = extractSeniorities(b);
+
+  // If both titles explicitly specify seniority, they MUST overlap in at least one seniority token.
+  // e.g. "Senior" vs "Principal" -> differ, return false.
+  // e.g. "Senior" vs "Senior Staff" -> overlap, proceed to Jaccard check.
+  // e.g. "Engineer" vs "Senior Engineer" -> one lacks seniority, proceed to Jaccard check.
+  if (senA.size > 0 && senB.size > 0) {
+    const hasOverlap = [...senA].some(s => senB.has(s));
+    if (!hasOverlap) return false;
+  }
+
   const wordsA = [...new Set(roleTokens(a))];
   const wordsB = [...new Set(roleTokens(b))];
   if (wordsA.length === 0 || wordsB.length === 0) return false;

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -174,6 +174,7 @@ const SYSTEM_PATHS = [
   'examples/',
   'config/profile.example.yml',
   '.env.example',
+  '.editorconfig',
   '.agents/',
   '.claude/skills/',
   '.opencode/skills/',


### PR DESCRIPTION
## Description
This PR resolves #1616 by preventing `merge-tracker` and `dedup-tracker` from collapsing same-role but different-seniority job openings (e.g., *Senior Private Cloud Engineer* vs. *Principal Private Cloud Engineer*) which previously resulted in silent data loss in `applications.md`.

### Changes
*   **Added Seniority Tokens Set**: Declared `SENIORITY_TOKENS` containing common levels (`senior`, `staff`, `principal`, `junior`, etc.) in `role-matcher.mjs`.
*   **Seniority Gate**: Added `extractSeniorities(title)` and injected a gate in `roleFuzzyMatch(a, b)`. If both titles explicitly contain seniority tokens, they must share at least one; otherwise, the matcher immediately returns `false` before Jaccard calculation.
*   **Maintained Repost Matching**: If seniority is unspecified on one of the titles, it proceeds to the standard Jaccard calculation to ensure reposts still merge correctly.
*   **CI Path Coverage**: Fixed a missing `.editorconfig` path mapping in `update-system.mjs` to keep system path validation tests clean.

Closes #1616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate matching for role titles by better recognizing seniority levels, reducing incorrect merges between titles like junior, senior, and lead.
  * Included editor configuration settings in system updates, so they stay in sync when updating the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->