### PR TITLE
test(providers): cover remoteok, greenhouse, lever, ashby modules (#1499)

### DIFF
--- a/providers/ashby.mjs
+++ b/providers/ashby.mjs
@@ -83,7 +83,10 @@ function resolveApiUrl(entry) {
   return `https://api.ashbyhq.com/posting-api/job-board/${match[1]}?includeCompensation=true`;
 }
 
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+function sleep(ms, ctx) {
+  if (typeof ctx?.sleep === 'function') return ctx.sleep(ms);
+  return new Promise((r) => setTimeout(r, ms));
+}
 
 // NaN-safe Date.parse — `|| undefined` would also coerce a valid epoch 0.
 function toEpochMs(value) {
@@ -135,7 +138,7 @@ export default {
       if (attempt > 0) {
         // exponential backoff + jitter — spaces out retries to dodge Ashby rate-limiting
         const backoff = 1000 * 2 ** (attempt - 1) + Math.floor(Math.random() * 500);
-        await sleep(backoff);
+        await sleep(backoff, ctx);
       }
       try {
         const json = /** @type {any} */ (await ctx.fetchJson(apiUrl, { timeoutMs: ASHBY_TIMEOUT_MS, redirect: 'error' }));

--- a/tests/providers/ashby.test.mjs
+++ b/tests/providers/ashby.test.mjs
@@ -171,20 +171,23 @@ try {
 
   // Retry loop — a transient failure on the first attempt recovers
   // transparently on the second (ASHBY_RETRIES=2 allows up to 3 attempts).
-  // Note: the backoff uses a real setTimeout (~1s here), not ctx.sleep.
+  // ctx.sleep replaces the real backoff setTimeout so the suite doesn't wait.
   let recoverAttempts = 0;
+  const recoverSleeps = [];
   const recovered = await ashby.fetch(
     { name: 'Acme', careers_url: 'https://jobs.ashbyhq.com/acme' },
-    { fetchJson: async () => {
+    { sleep: async (ms) => { recoverSleeps.push(ms); },
+      fetchJson: async () => {
         recoverAttempts++;
         if (recoverAttempts === 1) throw new Error('HTTP 429');
         return { jobs: [{ title: 'Recovered Role', jobUrl: 'https://jobs.ashbyhq.com/acme/r1' }] };
       } },
   );
-  if (recoverAttempts === 2 && recovered.length === 1 && recovered[0].title === 'Recovered Role') {
-    pass('ashby.fetch() retries a failed request and recovers transparently (2 attempts)');
+  if (recoverAttempts === 2 && recovered.length === 1 && recovered[0].title === 'Recovered Role'
+      && recoverSleeps.length === 1 && recoverSleeps[0] >= 1000) {
+    pass('ashby.fetch() retries a failed request and recovers transparently (2 attempts, 1 backoff via ctx.sleep)');
   } else {
-    fail(`ashby.fetch() retry recovery: attempts=${recoverAttempts}, jobs=${JSON.stringify(recovered)}`);
+    fail(`ashby.fetch() retry recovery: attempts=${recoverAttempts}, sleeps=${JSON.stringify(recoverSleeps)}, jobs=${JSON.stringify(recovered)}`);
   }
 
   // Retry loop — persistent failure exhausts all 3 attempts and rethrows the
@@ -193,7 +196,8 @@ try {
   try {
     await ashby.fetch(
       { name: 'Acme', careers_url: 'https://jobs.ashbyhq.com/acme' },
-      { fetchJson: async () => { exhaustAttempts++; throw new Error(`boom #${exhaustAttempts}`); } },
+      { sleep: async () => {},
+        fetchJson: async () => { exhaustAttempts++; throw new Error(`boom #${exhaustAttempts}`); } },
     );
     fail('ashby.fetch() should rethrow after exhausting retries');
   } catch (e) {

--- a/tests/providers/ashby.test.mjs
+++ b/tests/providers/ashby.test.mjs
@@ -1,0 +1,225 @@
+// tests/providers/ashby.test.mjs — direct provider-contract tests (#1499).
+// Covers the id/detect/fetch contract scan.mjs calls plus the exported
+// parseCompensation() normalizer: careers_url detection, the posting-api
+// request shape (includeCompensation, 30s timeout, redirect:'error'),
+// secondary-location folding, salary annualization, and the retry loop's
+// recover/exhaust behavior.
+// (Indirect coverage elsewhere: tests/providers/ats-ssrf-hardening.test.mjs
+// asserts the redirect:'error' guard; this file tests the module contract.)
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — ashby');
+
+try {
+  const ashbyModule = await import(pathToFileURL(join(ROOT, 'providers/ashby.mjs')).href);
+  const ashby = ashbyModule.default;
+  const { parseCompensation } = ashbyModule;
+
+  if (ashby.id === 'ashby') pass('ashby.id is "ashby"');
+  else fail(`ashby.id is ${JSON.stringify(ashby.id)}`);
+
+  // detect() — positive / negative cases.
+  const hit = ashby.detect({ name: 'Acme', careers_url: 'https://jobs.ashbyhq.com/acme' });
+  if (hit && hit.url === 'https://api.ashbyhq.com/posting-api/job-board/acme?includeCompensation=true') {
+    pass('ashby.detect() resolves jobs.ashbyhq.com/<slug> → posting-api URL with includeCompensation=true');
+  } else {
+    fail(`ashby.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  if (ashby.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('ashby.detect() returns null for a non-ashby careers_url');
+  } else {
+    fail('ashby.detect() should return null for non-ashby URLs');
+  }
+
+  if (ashby.detect({ name: 'X' }) === null && ashby.detect({ name: 'X', careers_url: null }) === null) {
+    pass('ashby.detect() returns null for missing / null careers_url');
+  } else {
+    fail('ashby.detect() should return null when careers_url is absent');
+  }
+
+  // parseCompensation() — annualization, coercion, and rejection paths.
+  const annual = parseCompensation({ compensation: { interval: '1 YEAR', minValue: 90000, maxValue: 120000, currency: 'usd' } });
+  if (annual && annual.min === 90000 && annual.max === 120000 && annual.currency === 'USD') {
+    pass('parseCompensation() keeps annual values as-is and uppercases the currency');
+  } else {
+    fail(`parseCompensation(annual) = ${JSON.stringify(annual)}`);
+  }
+
+  const hourly = parseCompensation({ compensation: { interval: '1 HOUR', minValue: 50, maxValue: 70, currency: 'USD' } });
+  if (hourly && hourly.min === 50 * 2080 && hourly.max === 70 * 2080) {
+    pass('parseCompensation() annualizes hourly compensation at 2080 hours/year');
+  } else {
+    fail(`parseCompensation(hourly) = ${JSON.stringify(hourly)}`);
+  }
+
+  const noInterval = parseCompensation({ compensation: { minValue: 80000, maxValue: 100000, currency: 'EUR' } });
+  if (noInterval && noInterval.min === 80000 && noInterval.max === 100000) {
+    pass('parseCompensation() defaults a missing interval to 1 YEAR');
+  } else {
+    fail(`parseCompensation(no interval) = ${JSON.stringify(noInterval)}`);
+  }
+
+  if (parseCompensation({ compensation: { interval: '7 MOON', minValue: 1, maxValue: 2 } }) === null) {
+    pass('parseCompensation() returns null for an unknown interval');
+  } else {
+    fail('parseCompensation() should reject unknown intervals');
+  }
+
+  if (parseCompensation({}) === null && parseCompensation(null) === null && parseCompensation({ compensation: null }) === null) {
+    pass('parseCompensation() returns null when compensation is absent (job {}, null job, null comp)');
+  } else {
+    fail('parseCompensation() should return null without compensation data');
+  }
+
+  if (parseCompensation({ compensation: { interval: '1 YEAR', minValue: '', maxValue: null, currency: 'USD' } }) === null) {
+    pass('parseCompensation() returns null when neither min nor max is a usable number');
+  } else {
+    fail('parseCompensation() should reject empty-string/null min and max');
+  }
+
+  const coerced = parseCompensation({ compensation: { interval: '1 YEAR', minValue: '-5', maxValue: '110000', currency: 'usd' } });
+  if (coerced && coerced.min === 110000 && coerced.max === 110000) {
+    pass('parseCompensation() coerces numeric strings, drops negatives, and collapses to the surviving bound');
+  } else {
+    fail(`parseCompensation(coerced) = ${JSON.stringify(coerced)}`);
+  }
+
+  const swapped = parseCompensation({ compensation: { interval: '1 YEAR', minValue: 120000, maxValue: 90000, currency: 'USD' } });
+  if (swapped && swapped.min === 90000 && swapped.max === 120000) {
+    pass('parseCompensation() reorders an inverted min/max pair');
+  } else {
+    fail(`parseCompensation(swapped) = ${JSON.stringify(swapped)}`);
+  }
+
+  // fetch() — request shape and normalization from the real posting-api
+  // payload: { jobs: [{ title, jobUrl, location, secondaryLocations, publishedAt, compensation }] }.
+  const sample = {
+    jobs: [
+      {
+        title: 'Head of Applied AI',
+        jobUrl: 'https://jobs.ashbyhq.com/acme/1234',
+        location: 'Canada',
+        secondaryLocations: [
+          { location: 'Europe', address: { postalAddress: { addressLocality: 'Berlin', addressCountry: 'Germany' } } },
+          { location: 'Canada' },       // duplicate of the primary — must dedup
+          null,                          // malformed secondary — must be skipped
+        ],
+        publishedAt: '2026-07-02T00:00:00.000Z',
+        compensation: { interval: '1 YEAR', minValue: 150000, maxValue: 180000, currency: 'usd' },
+      },
+      {
+        // no title/jobUrl → '' ; no locations → '' ; bad publishedAt → undefined ; no comp → null
+        publishedAt: 'soon',
+      },
+    ],
+  };
+
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const fetched = await ashby.fetch(
+    { name: 'Acme', careers_url: 'https://jobs.ashbyhq.com/acme' },
+    { fetchJson: async (url, opts) => { capturedUrl = url; capturedOpts = opts; return sample; } },
+  );
+
+  if (capturedUrl === 'https://api.ashbyhq.com/posting-api/job-board/acme?includeCompensation=true') {
+    pass('ashby.fetch() hits the derived posting-api URL with includeCompensation=true');
+  } else {
+    fail(`ashby.fetch() requested ${JSON.stringify(capturedUrl)}`);
+  }
+
+  if (capturedOpts?.redirect === 'error' && capturedOpts?.timeoutMs === 30_000) {
+    pass('ashby.fetch() passes redirect:"error" (SSRF guard) and the 30s Ashby timeout');
+  } else {
+    fail(`ashby.fetch() opts = ${JSON.stringify(capturedOpts)}`);
+  }
+
+  if (fetched.length === 2)
+    pass('ashby.fetch() returns one normalized row per job');
+  else fail(`ashby.fetch() returned ${fetched.length} rows (expected 2)`);
+
+  if (fetched[0]?.title === 'Head of Applied AI'
+      && fetched[0]?.url === 'https://jobs.ashbyhq.com/acme/1234'
+      && fetched[0]?.company === 'Acme'
+      && fetched[0]?.postedAt === Date.parse('2026-07-02T00:00:00.000Z')
+      && fetched[0]?.salary && fetched[0].salary.min === 150000 && fetched[0].salary.max === 180000 && fetched[0].salary.currency === 'USD')
+    pass('ashby.fetch() maps title/jobUrl/entry.name/publishedAt/compensation');
+  else fail(`ashby.fetch() row 0 = ${JSON.stringify(fetched[0])}`);
+
+  if (fetched[0]?.location === 'Canada · Europe · Berlin · Germany')
+    pass('ashby.fetch() folds secondaryLocations (region/locality/country) into location, deduped, " · "-joined');
+  else fail(`ashby.fetch() row 0 location = ${JSON.stringify(fetched[0]?.location)}`);
+
+  if (fetched[1]?.title === '' && fetched[1]?.url === '' && fetched[1]?.location === ''
+      && fetched[1]?.salary === null && fetched[1]?.postedAt === undefined)
+    pass('ashby.fetch() tolerates a sparse job (empty strings, null salary, undefined postedAt for a bad date)');
+  else fail(`ashby.fetch() row 1 = ${JSON.stringify(fetched[1])}`);
+
+  // Malformed response bodies → [], no crash.
+  const emptyCases = [null, {}, { jobs: null }, { jobs: 'nope' }];
+  let emptyOk = true;
+  for (const body of emptyCases) {
+    const out = await ashby.fetch(
+      { name: 'Acme', careers_url: 'https://jobs.ashbyhq.com/acme' },
+      { fetchJson: async () => body },
+    );
+    if (!Array.isArray(out) || out.length !== 0) { emptyOk = false; fail(`ashby.fetch() body=${JSON.stringify(body)} → ${JSON.stringify(out)}`); break; }
+  }
+  if (emptyOk) pass('ashby.fetch() returns [] for null / {} / non-array jobs response bodies');
+
+  // Retry loop — a transient failure on the first attempt recovers
+  // transparently on the second (ASHBY_RETRIES=2 allows up to 3 attempts).
+  // Note: the backoff uses a real setTimeout (~1s here), not ctx.sleep.
+  let recoverAttempts = 0;
+  const recovered = await ashby.fetch(
+    { name: 'Acme', careers_url: 'https://jobs.ashbyhq.com/acme' },
+    { fetchJson: async () => {
+        recoverAttempts++;
+        if (recoverAttempts === 1) throw new Error('HTTP 429');
+        return { jobs: [{ title: 'Recovered Role', jobUrl: 'https://jobs.ashbyhq.com/acme/r1' }] };
+      } },
+  );
+  if (recoverAttempts === 2 && recovered.length === 1 && recovered[0].title === 'Recovered Role') {
+    pass('ashby.fetch() retries a failed request and recovers transparently (2 attempts)');
+  } else {
+    fail(`ashby.fetch() retry recovery: attempts=${recoverAttempts}, jobs=${JSON.stringify(recovered)}`);
+  }
+
+  // Retry loop — persistent failure exhausts all 3 attempts and rethrows the
+  // LAST error (lastErr), not the first.
+  let exhaustAttempts = 0;
+  try {
+    await ashby.fetch(
+      { name: 'Acme', careers_url: 'https://jobs.ashbyhq.com/acme' },
+      { fetchJson: async () => { exhaustAttempts++; throw new Error(`boom #${exhaustAttempts}`); } },
+    );
+    fail('ashby.fetch() should rethrow after exhausting retries');
+  } catch (e) {
+    if (exhaustAttempts === 3 && e.message === 'boom #3') {
+      pass('ashby.fetch() exhausts 3 attempts (ASHBY_RETRIES=2) and rethrows the last error');
+    } else {
+      fail(`ashby.fetch() retry exhaustion: attempts=${exhaustAttempts}, error=${e.message}`);
+    }
+  }
+
+  // Underivable entry → typed error before any request (and before the retry loop).
+  let underiveFetchCalled = false;
+  try {
+    await ashby.fetch(
+      { name: 'NoBoard', careers_url: 'https://example.com/careers' },
+      { fetchJson: async () => { underiveFetchCalled = true; return { jobs: [] }; } },
+    );
+    fail('ashby.fetch() should throw when no API URL can be derived');
+  } catch (e) {
+    if (!underiveFetchCalled && /cannot derive API URL for NoBoard/.test(e.message)) {
+      pass('ashby.fetch() throws "cannot derive API URL" before fetching for an undetectable entry');
+    } else {
+      fail(`ashby.fetch() underivable entry: fetchCalled=${underiveFetchCalled}, error=${e.message}`);
+    }
+  }
+
+} catch (e) {
+  fail(`ashby provider tests crashed: ${e.message}`);
+}

--- a/tests/providers/greenhouse.test.mjs
+++ b/tests/providers/greenhouse.test.mjs
@@ -1,0 +1,193 @@
+// tests/providers/greenhouse.test.mjs — direct provider-contract tests (#1499).
+// Covers the id/detect/fetch contract scan.mjs calls: api: precedence with the
+// host allowlist, careers_url auto-detection, normalization from the
+// boards-api JSON shape, and the guard chain running before any request.
+// (Indirect coverage elsewhere: liveness tests exercise Greenhouse URL
+// resolution; this file tests the provider module itself.)
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — greenhouse');
+
+try {
+  const greenhouseModule = await import(pathToFileURL(join(ROOT, 'providers/greenhouse.mjs')).href);
+  const greenhouse = greenhouseModule.default;
+
+  if (greenhouse.id === 'greenhouse') pass('greenhouse.id is "greenhouse"');
+  else fail(`greenhouse.id is ${JSON.stringify(greenhouse.id)}`);
+
+  // detect() — careers_url auto-detection (job-boards host → boards-api endpoint)
+  const hit = greenhouse.detect({ name: 'Acme', careers_url: 'https://job-boards.greenhouse.io/acme' });
+  if (hit && hit.url === 'https://boards-api.greenhouse.io/v1/boards/acme/jobs') {
+    pass('greenhouse.detect() resolves job-boards.greenhouse.io/<slug> → boards-api jobs endpoint');
+  } else {
+    fail(`greenhouse.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  const hitEu = greenhouse.detect({ name: 'EuCo', careers_url: 'https://job-boards.eu.greenhouse.io/euco' });
+  if (hitEu && hitEu.url === 'https://boards-api.greenhouse.io/v1/boards/euco/jobs') {
+    pass('greenhouse.detect() extracts the slug from a job-boards.eu.greenhouse.io careers_url');
+  } else {
+    fail(`greenhouse.detect(eu) returned ${JSON.stringify(hitEu)}`);
+  }
+
+  // detect() — api: takes precedence over careers_url and is used verbatim
+  // when its host is on the allowlist.
+  const hitApi = greenhouse.detect({
+    name: 'Pinned',
+    careers_url: 'https://www.pinned.example/careers',
+    api: 'https://boards-api.greenhouse.io/v1/boards/pinned/jobs',
+  });
+  if (hitApi && hitApi.url === 'https://boards-api.greenhouse.io/v1/boards/pinned/jobs') {
+    pass('greenhouse.detect() honors an allowlisted api: over a branded careers_url');
+  } else {
+    fail(`greenhouse.detect(api-pinned) returned ${JSON.stringify(hitApi)}`);
+  }
+
+  // detect() — api: with an untrusted host must NOT be claimed (SSRF guard).
+  if (greenhouse.detect({ name: 'Evil', api: 'https://evil.example/v1/boards/acme/jobs' }) === null) {
+    pass('greenhouse.detect() returns null for an api: on an untrusted host');
+  } else {
+    fail('greenhouse.detect() must reject an untrusted api: host');
+  }
+
+  // detect() — api: must be HTTPS.
+  if (greenhouse.detect({ name: 'Insecure', api: 'http://boards-api.greenhouse.io/v1/boards/acme/jobs' }) === null) {
+    pass('greenhouse.detect() returns null for a non-HTTPS api:');
+  } else {
+    fail('greenhouse.detect() must reject an http:// api:');
+  }
+
+  // detect() — malformed api: URL → null, not a crash.
+  if (greenhouse.detect({ name: 'Broken', api: 'not a url' }) === null) {
+    pass('greenhouse.detect() returns null for a malformed api: URL');
+  } else {
+    fail('greenhouse.detect() should treat a malformed api: as unclaimable');
+  }
+
+  // detect() — negative and non-string careers_url cases.
+  if (greenhouse.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('greenhouse.detect() returns null for a non-greenhouse careers_url');
+  } else {
+    fail('greenhouse.detect() should return null for non-greenhouse URLs');
+  }
+
+  if (greenhouse.detect({ name: 'X' }) === null
+      && greenhouse.detect({ name: 'X', careers_url: null }) === null
+      && greenhouse.detect({ name: 'X', careers_url: 7 }) === null) {
+    pass('greenhouse.detect() returns null for missing / null / non-string careers_url');
+  } else {
+    fail('greenhouse.detect() should treat non-string careers_url as missing');
+  }
+
+  // fetch() — request URL, SSRF guard, and normalization from the real
+  // boards-api shape: { jobs: [{ title, absolute_url, location: {name}, first_published }] }.
+  const sample = {
+    jobs: [
+      {
+        id: 101,
+        title: 'Senior Backend Engineer',
+        absolute_url: 'https://job-boards.greenhouse.io/acme/jobs/101',
+        location: { name: 'Berlin, Germany' },
+        first_published: '2026-07-01T09:30:00-04:00',
+      },
+      {
+        id: 102,
+        // no title → '' ; no location → '' ; no first_published → postedAt undefined
+        absolute_url: 'https://job-boards.greenhouse.io/acme/jobs/102',
+      },
+      { id: 103, title: 'Ghost Role' },                                    // no absolute_url — dropped
+      { id: 104, title: 'Bad Date', absolute_url: 'https://job-boards.greenhouse.io/acme/jobs/104', first_published: 'not-a-date' },
+    ],
+  };
+
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const fetched = await greenhouse.fetch(
+    { name: 'Acme', careers_url: 'https://job-boards.greenhouse.io/acme' },
+    { fetchJson: async (url, opts) => { capturedUrl = url; capturedOpts = opts; return sample; } },
+  );
+
+  if (capturedUrl === 'https://boards-api.greenhouse.io/v1/boards/acme/jobs' && capturedOpts?.redirect === 'error') {
+    pass('greenhouse.fetch() hits the derived boards-api URL with redirect:"error" (SSRF guard)');
+  } else {
+    fail(`greenhouse.fetch() url=${JSON.stringify(capturedUrl)} opts=${JSON.stringify(capturedOpts)}`);
+  }
+
+  if (fetched.length === 3)
+    pass('greenhouse.fetch() drops rows without absolute_url (3 of 4 kept)');
+  else fail(`greenhouse.fetch() returned ${fetched.length} jobs (expected 3)`);
+
+  if (fetched[0]?.title === 'Senior Backend Engineer'
+      && fetched[0]?.url === 'https://job-boards.greenhouse.io/acme/jobs/101'
+      && fetched[0]?.company === 'Acme'
+      && fetched[0]?.location === 'Berlin, Germany'
+      && fetched[0]?.postedAt === Date.parse('2026-07-01T09:30:00-04:00'))
+    pass('greenhouse.fetch() maps title/absolute_url/entry.name/location.name/first_published');
+  else fail(`greenhouse.fetch() row 0 = ${JSON.stringify(fetched[0])}`);
+
+  if (fetched[1]?.title === '' && fetched[1]?.location === '' && fetched[1]?.postedAt === undefined)
+    pass('greenhouse.fetch() defaults missing title/location to "" and omits postedAt when first_published is absent');
+  else fail(`greenhouse.fetch() row 1 = ${JSON.stringify(fetched[1])}`);
+
+  if (fetched[2]?.postedAt === undefined)
+    pass('greenhouse.fetch() yields undefined postedAt for an unparseable first_published (NaN-safe)');
+  else fail(`greenhouse.fetch() row 2 postedAt = ${JSON.stringify(fetched[2]?.postedAt)}`);
+
+  // Epoch-0 first_published must survive (the `|| undefined` trap toEpochMs avoids).
+  const epochZero = await greenhouse.fetch(
+    { name: 'Acme', careers_url: 'https://job-boards.greenhouse.io/acme' },
+    { fetchJson: async () => ({ jobs: [{ title: 'Old', absolute_url: 'https://job-boards.greenhouse.io/acme/jobs/1', first_published: '1970-01-01T00:00:00.000Z' }] }) },
+  );
+  if (epochZero[0]?.postedAt === 0)
+    pass('greenhouse.fetch() preserves a valid epoch-0 first_published as postedAt 0');
+  else fail(`greenhouse.fetch() epoch-0 postedAt = ${JSON.stringify(epochZero[0]?.postedAt)}`);
+
+  // Malformed response bodies → empty result, no crash.
+  const emptyCases = [null, {}, { jobs: null }, { jobs: 'nope' }];
+  let emptyOk = true;
+  for (const body of emptyCases) {
+    const out = await greenhouse.fetch(
+      { name: 'Acme', careers_url: 'https://job-boards.greenhouse.io/acme' },
+      { fetchJson: async () => body },
+    );
+    if (!Array.isArray(out) || out.length !== 0) { emptyOk = false; fail(`greenhouse.fetch() body=${JSON.stringify(body)} → ${JSON.stringify(out)}`); break; }
+  }
+  if (emptyOk) pass('greenhouse.fetch() returns [] for null / {} / non-array jobs response bodies');
+
+  // Guard chain runs BEFORE any request: an untrusted api: must throw without
+  // ever calling fetchJson.
+  let untrustedFetchCalled = false;
+  try {
+    await greenhouse.fetch(
+      { name: 'Evil', api: 'https://evil.example/v1/boards/acme/jobs' },
+      { fetchJson: async () => { untrustedFetchCalled = true; return { jobs: [] }; } },
+    );
+    fail('greenhouse.fetch() should throw for an untrusted api: host');
+  } catch (e) {
+    if (!untrustedFetchCalled && /untrusted hostname/.test(e.message)) {
+      pass('greenhouse.fetch() throws on an untrusted api: host before any request is made');
+    } else {
+      fail(`greenhouse.fetch() untrusted api: fetchCalled=${untrustedFetchCalled}, error=${e.message}`);
+    }
+  }
+
+  // Underivable entry → typed error, no request.
+  try {
+    await greenhouse.fetch(
+      { name: 'NoBoard', careers_url: 'https://example.com/careers' },
+      { fetchJson: async () => { throw new Error('must not be called'); } },
+    );
+    fail('greenhouse.fetch() should throw when no API URL can be derived');
+  } catch (e) {
+    if (/cannot derive API URL for NoBoard/.test(e.message)) {
+      pass('greenhouse.fetch() throws "cannot derive API URL" for an undetectable entry');
+    } else {
+      fail(`greenhouse.fetch() threw the wrong error: ${e.message}`);
+    }
+  }
+
+} catch (e) {
+  fail(`greenhouse provider tests crashed: ${e.message}`);
+}

--- a/tests/providers/lever.test.mjs
+++ b/tests/providers/lever.test.mjs
@@ -1,0 +1,153 @@
+// tests/providers/lever.test.mjs — direct provider-contract tests (#1499).
+// Covers the id/detect/fetch contract scan.mjs calls: hostname-anchored
+// detection for both jobs.lever.co and jobs.eu.lever.co, normalization from
+// the v0 postings shape (including the free descriptionPlain for
+// content_filter), and malformed-input tolerance.
+// (Indirect coverage elsewhere: tests/providers/ats-ssrf-hardening.test.mjs
+// asserts the redirect:'error' guard per instance; liveness tests cover URL
+// resolution. This file tests the provider module contract itself.)
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — lever');
+
+try {
+  const leverModule = await import(pathToFileURL(join(ROOT, 'providers/lever.mjs')).href);
+  const lever = leverModule.default;
+
+  if (lever.id === 'lever') pass('lever.id is "lever"');
+  else fail(`lever.id is ${JSON.stringify(lever.id)}`);
+
+  // detect() — positive cases, both instances.
+  const hit = lever.detect({ name: 'Acme', careers_url: 'https://jobs.lever.co/acme' });
+  if (hit && hit.url === 'https://api.lever.co/v0/postings/acme') {
+    pass('lever.detect() resolves jobs.lever.co/<slug> → api.lever.co postings endpoint');
+  } else {
+    fail(`lever.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  const hitEu = lever.detect({ name: 'EuCo', careers_url: 'https://jobs.eu.lever.co/euco/some-posting' });
+  if (hitEu && hitEu.url === 'https://api.eu.lever.co/v0/postings/euco') {
+    pass('lever.detect() resolves jobs.eu.lever.co → api.eu.lever.co and takes the first path segment as slug');
+  } else {
+    fail(`lever.detect(eu) returned ${JSON.stringify(hitEu)}`);
+  }
+
+  // detect() — negative / spoof / degenerate cases.
+  if (lever.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('lever.detect() returns null for a non-lever careers_url');
+  } else {
+    fail('lever.detect() should return null for non-lever URLs');
+  }
+
+  if (lever.detect({ name: 'Spoof', careers_url: 'https://jobs.lever.co.evil.example/acme' }) === null) {
+    pass('lever.detect() rejects a hostname-suffix spoof (jobs.lever.co.evil.example)');
+  } else {
+    fail('lever.detect() must NOT detect hostname-suffix spoofs');
+  }
+
+  if (lever.detect({ name: 'PathSpoof', careers_url: 'https://evil.example/jobs.lever.co/acme' }) === null) {
+    pass('lever.detect() rejects a path-spoofed URL (lever host in path, not hostname)');
+  } else {
+    fail('lever.detect() must NOT detect path-spoofed URLs');
+  }
+
+  if (lever.detect({ name: 'NoSlug', careers_url: 'https://jobs.lever.co/' }) === null) {
+    pass('lever.detect() returns null when the URL has no board slug');
+  } else {
+    fail('lever.detect() should return null for a slug-less lever URL');
+  }
+
+  if (lever.detect({ name: 'X' }) === null
+      && lever.detect({ name: 'X', careers_url: null }) === null
+      && lever.detect({ name: 'X', careers_url: 7 }) === null) {
+    pass('lever.detect() returns null for missing / null / non-string careers_url');
+  } else {
+    fail('lever.detect() should treat non-string careers_url as missing');
+  }
+
+  // fetch() — request URL, SSRF guard, and normalization from the real v0
+  // postings shape: [{ text, hostedUrl, categories: {location}, descriptionPlain, createdAt }].
+  const sample = [
+    {
+      text: 'Staff Platform Engineer',
+      hostedUrl: 'https://jobs.lever.co/acme/1111-staff-platform-engineer',
+      categories: { location: 'Remote — Europe', team: 'Platform', commitment: 'Full-time' },
+      descriptionPlain: 'Build the platform that powers everything.',
+      createdAt: 1751328000000,
+    },
+    {
+      // no text/hostedUrl → '' ; no categories → location '' ;
+      // descriptionPlain non-string → '' ; createdAt non-number → undefined
+      descriptionPlain: { html: true },
+      createdAt: '2026-07-01',
+    },
+    {},                                                                   // fully empty posting object
+  ];
+
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const fetched = await lever.fetch(
+    { name: 'Acme', careers_url: 'https://jobs.lever.co/acme' },
+    { fetchJson: async (url, opts) => { capturedUrl = url; capturedOpts = opts; return sample; } },
+  );
+
+  if (capturedUrl === 'https://api.lever.co/v0/postings/acme' && capturedOpts?.redirect === 'error') {
+    pass('lever.fetch() hits the derived api.lever.co URL with redirect:"error" (SSRF guard)');
+  } else {
+    fail(`lever.fetch() url=${JSON.stringify(capturedUrl)} opts=${JSON.stringify(capturedOpts)}`);
+  }
+
+  if (fetched.length === 3)
+    pass('lever.fetch() returns one normalized row per posting (no silent drops)');
+  else fail(`lever.fetch() returned ${fetched.length} rows (expected 3)`);
+
+  if (fetched[0]?.title === 'Staff Platform Engineer'
+      && fetched[0]?.url === 'https://jobs.lever.co/acme/1111-staff-platform-engineer'
+      && fetched[0]?.company === 'Acme'
+      && fetched[0]?.location === 'Remote — Europe'
+      && fetched[0]?.description === 'Build the platform that powers everything.'
+      && fetched[0]?.postedAt === 1751328000000)
+    pass('lever.fetch() maps text/hostedUrl/entry.name/categories.location/descriptionPlain/createdAt');
+  else fail(`lever.fetch() row 0 = ${JSON.stringify(fetched[0])}`);
+
+  if (fetched[1]?.description === '' && fetched[1]?.postedAt === undefined)
+    pass('lever.fetch() coerces a non-string descriptionPlain to "" and a non-number createdAt to undefined');
+  else fail(`lever.fetch() row 1 = ${JSON.stringify(fetched[1])}`);
+
+  if (fetched[2]?.title === '' && fetched[2]?.url === '' && fetched[2]?.location === ''
+      && fetched[2]?.company === 'Acme' && fetched[2]?.description === '' && fetched[2]?.postedAt === undefined)
+    pass('lever.fetch() maps an empty posting object to empty-string fields without crashing');
+  else fail(`lever.fetch() row 2 = ${JSON.stringify(fetched[2])}`);
+
+  // Non-array response bodies → [], no crash.
+  const emptyCases = [null, {}, { postings: [] }, 'nope'];
+  let emptyOk = true;
+  for (const body of emptyCases) {
+    const out = await lever.fetch(
+      { name: 'Acme', careers_url: 'https://jobs.lever.co/acme' },
+      { fetchJson: async () => body },
+    );
+    if (!Array.isArray(out) || out.length !== 0) { emptyOk = false; fail(`lever.fetch() body=${JSON.stringify(body)} → ${JSON.stringify(out)}`); break; }
+  }
+  if (emptyOk) pass('lever.fetch() returns [] for non-array response bodies (null / {} / string)');
+
+  // Underivable entry → typed error before any request.
+  try {
+    await lever.fetch(
+      { name: 'NoBoard', careers_url: 'https://example.com/careers' },
+      { fetchJson: async () => { throw new Error('must not be called'); } },
+    );
+    fail('lever.fetch() should throw when no API URL can be derived');
+  } catch (e) {
+    if (/cannot derive API URL for NoBoard/.test(e.message)) {
+      pass('lever.fetch() throws "cannot derive API URL" before fetching for an undetectable entry');
+    } else {
+      fail(`lever.fetch() threw the wrong error: ${e.message}`);
+    }
+  }
+
+} catch (e) {
+  fail(`lever provider tests crashed: ${e.message}`);
+}

--- a/tests/providers/remoteok.test.mjs
+++ b/tests/providers/remoteok.test.mjs
@@ -1,0 +1,130 @@
+// tests/providers/remoteok.test.mjs — direct provider-contract tests (#1499).
+// RemoteOK is a board-wide aggregator feed: no detect(), a fixed FEED_URL, and
+// an API quirk — index 0 of the returned array is a {last_updated, legal}
+// metadata object, not a job. These tests pin the id/fetch contract that
+// scan.mjs relies on, with a deterministic mock ctx (no network).
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — remoteok');
+
+try {
+  const remoteokModule = await import(pathToFileURL(join(ROOT, 'providers/remoteok.mjs')).href);
+  const remoteok = remoteokModule.default;
+
+  if (remoteok.id === 'remoteok') pass('remoteok.id is "remoteok"');
+  else fail(`remoteok.id is ${JSON.stringify(remoteok.id)}`);
+
+  // Board-wide feed: no detect() — wired in explicitly via `provider: remoteok`.
+  if (remoteok.detect === undefined && typeof remoteok.fetch === 'function') {
+    pass('remoteok exposes fetch() only (no detect — explicit provider: wiring)');
+  } else {
+    fail(`remoteok surface: detect=${typeof remoteok.detect}, fetch=${typeof remoteok.fetch}`);
+  }
+
+  // Deterministic sample payload mirroring the real feed shape: metadata object
+  // at index 0, then job rows keyed by `position` (not `title`).
+  const sample = [
+    { last_updated: 1751500000, legal: 'API terms...' },                 // metadata row — must be dropped
+    {
+      slug: 'acme-staff-ai-engineer',
+      position: 'Staff AI Engineer',
+      company: 'Acme Corp',
+      location: 'Worldwide',
+      url: 'https://remoteok.com/remote-jobs/acme-staff-ai-engineer',
+      date: '2026-07-01T00:00:00+00:00',
+    },
+    {
+      position: '  Platform Engineer  ',                                 // whitespace → trimmed
+      company: '   ',                                                    // whitespace-only → falls back to entry.name
+      location: null,                                                    // non-string → ''
+      url: '  https://remoteok.com/remote-jobs/beta-platform-engineer  ',
+    },
+    null,                                                                // null row — must be skipped
+    'not-an-object',                                                     // non-object row — must be skipped
+    { position: '', url: 'https://remoteok.com/remote-jobs/empty' },     // empty position — skip
+    { position: 'Relative URL Role', url: '/remote-jobs/relative' },     // non-absolute url — skip
+    { position: 'No URL Role' },                                         // missing url — skip
+  ];
+
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const fetched = await remoteok.fetch(
+    { name: 'RemoteOK Board', provider: 'remoteok' },
+    { fetchJson: async (url, opts) => { capturedUrl = url; capturedOpts = opts; return sample; } },
+  );
+
+  if (capturedUrl === 'https://remoteok.com/api')
+    pass('remoteok.fetch() requests the fixed board-wide feed URL');
+  else fail(`remoteok.fetch() requested ${JSON.stringify(capturedUrl)}`);
+
+  if (capturedOpts && capturedOpts.redirect === 'error')
+    pass('remoteok.fetch() passes redirect:"error" to fetchJson (SSRF guard)');
+  else fail(`remoteok.fetch() should pass redirect:"error", got: ${JSON.stringify(capturedOpts)}`);
+
+  if (fetched.length === 2)
+    pass('remoteok.fetch() keeps 2 valid jobs (drops metadata row, null, non-object, empty-position, bad-url rows)');
+  else fail(`remoteok.fetch() returned ${fetched.length} jobs (expected 2): ${JSON.stringify(fetched)}`);
+
+  // Normalized shape: exactly { title, url, company, location }.
+  if (fetched[0] && Object.keys(fetched[0]).sort().join(',') === 'company,location,title,url')
+    pass('remoteok.fetch() returns the normalized { title, url, company, location } shape');
+  else fail(`remoteok.fetch() row 0 keys = ${JSON.stringify(fetched[0] && Object.keys(fetched[0]))}`);
+
+  if (fetched[0]?.title === 'Staff AI Engineer'
+      && fetched[0]?.url === 'https://remoteok.com/remote-jobs/acme-staff-ai-engineer'
+      && fetched[0]?.company === 'Acme Corp'
+      && fetched[0]?.location === 'Worldwide')
+    pass('remoteok.fetch() maps position/url/company/location for a full row');
+  else fail(`remoteok.fetch() row 0 = ${JSON.stringify(fetched[0])}`);
+
+  if (fetched[1]?.title === 'Platform Engineer'
+      && fetched[1]?.url === 'https://remoteok.com/remote-jobs/beta-platform-engineer')
+    pass('remoteok.fetch() trims whitespace from title and url');
+  else fail(`remoteok.fetch() row 1 title/url = ${JSON.stringify({ title: fetched[1]?.title, url: fetched[1]?.url })}`);
+
+  if (fetched[1]?.company === 'RemoteOK Board')
+    pass('remoteok.fetch() falls back to entry.name when company is whitespace-only');
+  else fail(`remoteok.fetch() row 1 company = ${JSON.stringify(fetched[1]?.company)}`);
+
+  if (fetched[1]?.location === '')
+    pass('remoteok.fetch() yields empty location for a non-string location value');
+  else fail(`remoteok.fetch() row 1 location = ${JSON.stringify(fetched[1]?.location)}`);
+
+  // company default when both the row's company and entry.name are missing → 'RemoteOK'.
+  const noName = await remoteok.fetch(
+    {},
+    { fetchJson: async () => [{ position: 'Role', url: 'https://remoteok.com/remote-jobs/x' }] },
+  );
+  if (noName[0]?.company === 'RemoteOK')
+    pass('remoteok.fetch() defaults company to "RemoteOK" when company and entry.name are both missing');
+  else fail(`remoteok.fetch() default company = ${JSON.stringify(noName[0]?.company)}`);
+
+  // Non-array API response → typed error, not a silent empty result.
+  let badResponseThrew = false;
+  try {
+    await remoteok.fetch(
+      { name: 'X', provider: 'remoteok' },
+      { fetchJson: async () => ({ jobs: [] }) },
+    );
+  } catch (e) {
+    badResponseThrew = /unexpected API response/.test(e.message);
+  }
+  if (badResponseThrew) pass('remoteok.fetch() throws on a non-array API response');
+  else fail('remoteok.fetch() should throw when the response is not an array');
+
+  // null response → the error message must say "null", not "object".
+  let nullResponseMsg = '';
+  try {
+    await remoteok.fetch({ name: 'X' }, { fetchJson: async () => null });
+  } catch (e) {
+    nullResponseMsg = e.message;
+  }
+  if (/unexpected API response/.test(nullResponseMsg) && /got null/.test(nullResponseMsg))
+    pass('remoteok.fetch() reports "null" (not "object") for a null API response');
+  else fail(`remoteok.fetch() null-response error = ${JSON.stringify(nullResponseMsg)}`);
+
+} catch (e) {
+  fail(`remoteok provider tests crashed: ${e.message}`);
+}


### PR DESCRIPTION
Closes #1499

Adds direct provider-contract tests for the four uncovered provider modules. Each file is a self-contained, auto-discovered addition under `tests/providers/` — zero shared-line edits, no registration anywhere (exactly the workflow the #1440 split exists to enable).

## Coverage

| File | Assertions | Covers |
|------|-----------|--------|
| `tests/providers/remoteok.test.mjs` | 13 | Fixed feed URL + `redirect:'error'`; the index-0 `{last_updated, legal}` metadata-row quirk; junk-row filtering (null, non-object, empty position, non-absolute URL); `position`→`title` mapping + trims; company fallback chain (`entry.name` → `'RemoteOK'`); typed errors for non-array and null responses |
| `tests/providers/greenhouse.test.mjs` | 18 | `detect()` for `job-boards(.eu).greenhouse.io` careers_url and `api:` precedence; host-allowlist / HTTPS / malformed `api:` rejection; boards-api normalization (`absolute_url` filter, `location.name`, NaN-safe `first_published` incl. epoch-0); untrusted `api:` throws **before** any request; malformed bodies → `[]` |
| `tests/providers/lever.test.mjs` | 15 | Anchored-hostname `detect()` for US + EU instances, hostname-suffix and path spoof rejection, slug-less URL; v0 postings normalization (`text`/`hostedUrl`/`categories.location`/`descriptionPlain` string-coercion/`createdAt` number-coercion); non-array bodies → `[]`; cannot-derive throws before fetching |
| `tests/providers/ashby.test.mjs` | 22 | `detect()`; `parseCompensation()` (annualization incl. 2080h hourly, interval default + unknown rejection, numeric-string coercion, negative rejection, inverted min/max reorder); posting-api request shape (`includeCompensation=true`, 30s Ashby timeout, `redirect:'error'`); `secondaryLocations` folding (dedup, `" · "` join, malformed-entry skip); retry loop recover (2 attempts) and exhaust (3 attempts, last error rethrown); cannot-derive throws before the retry loop |

**Total: 68 assertions**, all complementing (not duplicating) the indirect coverage in `ats-ssrf-hardening.test.mjs` and the liveness sections — these test the id/detect/normalize/fetch contract paths `scan.mjs` actually calls.

## Validation

- `node test-all.mjs --only providers/{remoteok,greenhouse,lever,ashby}` — 13/18/15/22 passed, 0 failed each
- Full `node test-all.mjs` — **1356 passed, 0 failed** (2 pre-existing environment warnings: cv-sync without user data)

## Observations surfaced while writing (not changed here — happy to file follow-ups)

- `providers/ashby.mjs` `detect()` throws a `TypeError` on a non-string `careers_url` (e.g. a number) — every other provider returns `null` (greenhouse via try/catch, lever via `new URL` catch, recruitee/workday explicitly). Its careers_url regex is also unanchored (host-in-path spoof still resolves a slug, though the API host is fixed so it's slug-misdetection, not SSRF), and its retry backoff uses a module-level native `setTimeout` instead of the `ctx.sleep` pacing hook.
- `providers/greenhouse.mjs` and `providers/lever.mjs` `fetch()` throw a `TypeError` if the API returns an array containing `null` elements (`jobs.filter(j => j.absolute_url)` / `json.map(j => ({ title: j.text ... }))`) — unlike remoteok/workday, which skip them.
- `providers/greenhouse.mjs` resolves a `job-boards.eu.greenhouse.io` careers_url to the **US** `boards-api.greenhouse.io` host (and `boards.greenhouse.io` careers_urls don't auto-detect at all, only via `api:`) — may be intentional, flagging in case EU boards need `boards-api.eu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end contract coverage for Ashby, Greenhouse, Lever, and RemoteOK job providers.
  * Verified provider detection and strict API URL derivation, including SSRF guardrails and request safety.
  * Confirmed fetch normalization across providers (titles/URLs/companies/locations, date parsing, and compensation interval/currency handling).
  * Ensured resilience to malformed or sparse responses and validated retry behavior for transient failures.
* **Chores**
  * Updated Ashby retry backoff to support context-driven sleep for more controllable timing in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->