### PR TITLE
fix(web): contrast tokens — AA across both themes (ux audit #2, batch 1)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -8,7 +8,10 @@
 @theme {
   --color-brand: hsl(26 73% 51%);
   --color-brand-200: hsl(33 100% 60%); /* hover / lighter */
-  --color-brand-foreground: #ffffff;
+  /* Near-black on the brand orange: 5.2:1 on brand, 8.3:1 on brand-200 hover
+     (white was 3.14:1, an AA fail in BOTH themes since the button is the same).
+     The brand orange itself is untouched — only what sits on top of it. */
+  --color-brand-foreground: hsl(24 30% 12%);
   --color-brand-soft: hsl(26 73% 51% / 0.12);
   --color-brand-secondary: #fc7744;
 
@@ -28,6 +31,11 @@
   --color-muted: var(--muted);
   --color-faint: var(--faint);
   --color-landing: var(--landing); /* editorial olive (light) / cream (dark) — docs landing-foreground */
+  /* Brand as SMALL TEXT: the raw orange only passes AA in dark (4.95); in light
+     it's 2.6-3.1 on cream/white. brand-text darkens it for light and keeps the
+     raw brand in dark. Use for small text/badges; brand stays for accents,
+     surfaces, icons and large headings (≥24px passes at 3:1). */
+  --color-brand-text: var(--brand-text);
 }
 
 :root {
@@ -39,6 +47,7 @@
   --muted: hsl(35 9% 34%); /* darker than before for readable body text */
   --faint: hsl(35 7% 42%); /* AA: ~4.6:1 on #fff (was 50% ≈ 3.9:1, failed small text) */
   --landing: #59592a; /* olive editorial headline */
+  --brand-text: hsl(26 80% 36%); /* darkened brand for small text: 5.5 white / 5.1 cream / 4.7 surface-hover */
   --dot: 40 8% 42% / 0.09;
   --pre-bg: #f2f1ed;
   color-scheme: light;
@@ -53,6 +62,7 @@
   --muted: #a1a1aa;
   --faint: #8b8b95; /* AA: ~4.6:1 on #161616 (was #71717a ≈ 3.7:1, failed small text) */
   --landing: #e4e2d0; /* cream editorial headline */
+  --brand-text: hsl(26 73% 51%); /* raw brand already passes in dark (≥4.95 on bg/surface) */
   --dot: 240 5% 65% / 0.10;
   --pre-bg: #111111;
   color-scheme: dark;

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -44,14 +44,14 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                   className={cn(
                     "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
                     active
-                      ? "bg-brand-soft text-brand"
+                      ? "bg-brand-soft text-brand-text"
                       : "text-muted hover:bg-surface-hover hover:text-foreground",
                   )}
                 >
                   <Icon className="size-4" />
                   {label}
                   {chip && (
-                    <span className="ml-auto rounded-full border border-brand/30 bg-brand-soft px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-brand">
+                    <span className="ml-auto rounded-full border border-brand/30 bg-brand-soft px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-brand-text">
                       {chip}
                     </span>
                   )}

--- a/web/src/components/beta/beta-banner.tsx
+++ b/web/src/components/beta/beta-banner.tsx
@@ -91,11 +91,11 @@ export function BetaBanner() {
   return (
     <>
       <div className="fixed bottom-3 left-3 z-[70] flex items-center gap-2 rounded-full border border-brand/30 bg-surface/90 px-3 py-1.5 text-xs shadow-lg backdrop-blur-md">
-        <span className="flex items-center gap-1.5 font-medium text-brand">
+        <span className="flex items-center gap-1.5 font-medium text-brand-text">
           <span className="size-1.5 animate-pulse rounded-full bg-brand" /> {meta.version} · {meta.channel}
         </span>
         {meta.sha && <span className="hidden font-mono text-faint sm:inline">{meta.sha}</span>}
-        <button onClick={openReport} className="ml-1 inline-flex items-center gap-1 rounded-full bg-brand-soft px-2 py-0.5 font-medium text-brand transition-colors hover:bg-brand/15">
+        <button onClick={openReport} className="ml-1 inline-flex items-center gap-1 rounded-full bg-brand-soft px-2 py-0.5 font-medium text-brand-text transition-colors hover:bg-brand/15">
           <Bug className="size-3" /> Report a bug
         </button>
       </div>

--- a/web/src/components/cost/cost-badge.tsx
+++ b/web/src/components/cost/cost-badge.tsx
@@ -11,9 +11,9 @@ import { COST_META, type CostClass } from "@/lib/explore-cost";
 // stale-CSS HMR gotcha.
 const CSS = `
 .co-cost{display:inline-flex;align-items:center;gap:.28rem;border-radius:999px;font-weight:600;line-height:1;white-space:nowrap;border:1px solid transparent}
-.co-cost[data-size="xs"]{font-size:9.5px;padding:.16rem .4rem;letter-spacing:.04em;text-transform:uppercase}
+.co-cost[data-size="xs"]{font-size:10.5px;padding:.16rem .4rem;letter-spacing:.04em;text-transform:uppercase}
 .co-cost[data-size="sm"]{font-size:11px;padding:.24rem .5rem}
-.co-cost[data-tone="free"]{color:hsl(160 70% 38%);background:hsl(160 64% 46% / .12);border-color:hsl(160 64% 46% / .28)}
+.co-cost[data-tone="free"]{color:hsl(162 91% 24%);background:hsl(160 64% 46% / .12);border-color:hsl(160 64% 46% / .28)}
 html.dark .co-cost[data-tone="free"]{color:hsl(158 64% 60%);background:hsl(158 64% 52% / .13);border-color:hsl(158 64% 52% / .26)}
 .co-cost[data-tone="spend"]{color:hsl(35 9% 34%);background:hsl(35 8% 46% / .12);border-color:hsl(35 8% 46% / .26)}
 html.dark .co-cost[data-tone="spend"]{color:hsl(35 8% 70%);background:hsl(35 6% 60% / .12);border-color:hsl(35 6% 60% / .24)}

--- a/web/src/components/cv/cv-ingest.tsx
+++ b/web/src/components/cv/cv-ingest.tsx
@@ -210,7 +210,7 @@ export function CvIngest({ onSaved }: { onSaved?: () => void }) {
               type="button"
               disabled={!paste.trim()}
               onClick={() => ingestText(paste.trim())}
-              className="ml-auto inline-flex items-center gap-1.5 rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:brightness-110 disabled:opacity-50 max-sm:min-h-[44px]"
+              className="ml-auto inline-flex items-center gap-1.5 rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-brand-foreground shadow-sm transition hover:brightness-110 disabled:opacity-50 max-sm:min-h-[44px]"
             >
               Read my CV <ArrowRight className="size-4" />
             </button>
@@ -291,7 +291,7 @@ export function CvIngest({ onSaved }: { onSaved?: () => void }) {
           type="button"
           onClick={save}
           disabled={phase === "saving"}
-          className="inline-flex items-center gap-2 rounded-xl bg-brand px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-110 disabled:opacity-60"
+          className="inline-flex items-center gap-2 rounded-xl bg-brand px-5 py-2.5 text-sm font-semibold text-brand-foreground shadow-sm transition hover:brightness-110 disabled:opacity-60"
         >
           {phase === "saving" ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}
           Save &amp; find my matches

--- a/web/src/components/explore/ai-search-box.tsx
+++ b/web/src/components/explore/ai-search-box.tsx
@@ -84,7 +84,7 @@ export function AiSearchBox({
             type="button"
             disabled={!intent.trim()}
             onClick={onSubmit}
-            className="inline-flex items-center gap-2 rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:brightness-110 disabled:opacity-50"
+            className="inline-flex items-center gap-2 rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-brand-foreground shadow-sm transition hover:brightness-110 disabled:opacity-50"
           >
             Search the open web
             <CostBadge kind="spend" size="xs" />

--- a/web/src/components/explore/explorer-view.tsx
+++ b/web/src/components/explore/explorer-view.tsx
@@ -107,7 +107,7 @@ export function ExplorerView({
           <div className="flex items-center gap-2.5">
             <Compass className="size-6 text-brand" />
             <h1 className={`${instrumentSerif.className} text-3xl text-foreground`}>Explore</h1>
-            <span className="rounded-full border border-brand/30 bg-brand-soft px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-brand">New</span>
+            <span className="rounded-full border border-brand/30 bg-brand-soft px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-brand-text">New</span>
           </div>
           <div className="w-full sm:ml-auto sm:w-auto">
             <ExploreModeToggle mode={mode} onChange={setMode} cliConfigured={!!cli.id} />
@@ -242,7 +242,7 @@ function DiscoverBar({ canDiscover, onDiscover, label }: { canDiscover: boolean;
         type="button"
         disabled={!canDiscover}
         onClick={onDiscover}
-        className="inline-flex items-center gap-2 rounded-xl bg-brand px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-all hover:brightness-110 disabled:opacity-50"
+        className="inline-flex items-center gap-2 rounded-xl bg-brand px-5 py-2.5 text-sm font-semibold text-brand-foreground shadow-sm transition-all hover:brightness-110 disabled:opacity-50"
       >
         <Compass className="size-4" /> {label}
       </button>
@@ -345,7 +345,7 @@ function FailedCard({ msg, onRetry }: { msg: string; onRetry: () => void }) {
           update career-ops, or paste a job URL on the pipeline to evaluate it directly.
         </p>
         <div className="mt-4 flex flex-wrap justify-center gap-2">
-          <Link href="/pipeline" className="inline-flex items-center gap-1.5 rounded-lg bg-brand px-3.5 py-2 text-sm font-semibold text-white transition hover:brightness-110">
+          <Link href="/pipeline" className="inline-flex items-center gap-1.5 rounded-lg bg-brand px-3.5 py-2 text-sm font-semibold text-brand-foreground transition hover:brightness-110">
             Open pipeline
           </Link>
           <Link href="/config" className="inline-flex items-center gap-1.5 rounded-lg border border-border px-3.5 py-2 text-sm font-medium text-foreground transition hover:border-brand/40 hover:text-brand">
@@ -377,7 +377,7 @@ function BlockedCard() {
       <p className="mx-auto mt-1.5 max-w-md text-sm text-muted">
         Connect Claude Code, Gemini, or any agent CLI — your key, your tokens, your machine. The free Scan stays available without one.
       </p>
-      <Link href="/config" className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-brand px-3.5 py-2 text-sm font-semibold text-white transition hover:brightness-110">
+      <Link href="/config" className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-brand px-3.5 py-2 text-sm font-semibold text-brand-foreground transition hover:brightness-110">
         <Settings className="size-4" /> Open Config
       </Link>
     </div>

--- a/web/src/components/explore/first-score-view.tsx
+++ b/web/src/components/explore/first-score-view.tsx
@@ -173,7 +173,7 @@ export function FirstScoreView() {
                 close();
                 router.push("/pipeline?tab=EVALUATED");
               }}
-              className="inline-flex items-center gap-1.5 rounded-xl bg-brand px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-110"
+              className="inline-flex items-center gap-1.5 rounded-xl bg-brand px-4 py-2.5 text-sm font-semibold text-brand-foreground shadow-sm transition hover:brightness-110"
             >
               <FileText className="size-4" /> See the full report
             </button>

--- a/web/src/components/home/decision-card.tsx
+++ b/web/src/components/home/decision-card.tsx
@@ -60,7 +60,7 @@ export function DecisionCard({ app }: { app: Application }) {
           type="button"
           disabled={!!busy}
           onClick={() => setStatus("Applied")}
-          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md bg-brand-soft px-2.5 py-1.5 text-xs font-medium text-brand transition hover:bg-brand/15 disabled:opacity-60 max-sm:min-h-[44px]"
+          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md bg-brand-soft px-2.5 py-1.5 text-xs font-medium text-brand-text transition hover:bg-brand/15 disabled:opacity-60 max-sm:min-h-[44px]"
         >
           {busy === "Applied" ? <Loader2 className="size-3.5 animate-spin" /> : <Check className="size-3.5" />} Mark applied
         </button>

--- a/web/src/components/inbox/shortlist-tray.tsx
+++ b/web/src/components/inbox/shortlist-tray.tsx
@@ -76,7 +76,7 @@ export function ShortlistTray({
               className="inline-flex items-center gap-1.5 text-sm font-medium max-sm:min-h-[44px]"
             >
               <ChevronDown className={cn("size-4 text-muted transition-transform", open && "rotate-180")} />
-              Shortlist <span className="tabular-nums text-brand">({n})</span>
+              Shortlist <span className="tabular-nums text-brand-text">({n})</span>
             </button>
 
             {open && (

--- a/web/src/components/inbox/triage-row.tsx
+++ b/web/src/components/inbox/triage-row.tsx
@@ -76,7 +76,7 @@ export function TriageRow({
           {source && <span className="rounded bg-surface-hover px-1 py-px font-medium text-muted">{ATS_LABEL[source]}</span>}
           {ago && <span>{ago}</span>}
           {/* 🔴 CRUDA: honest "not scored" — no fabricated match%. */}
-          {!evaluated && <span className="italic text-faint/80">not scored</span>}
+          {!evaluated && <span className="italic text-muted">not scored</span>}
         </p>
       </div>
 

--- a/web/src/components/mobile-nav.tsx
+++ b/web/src/components/mobile-nav.tsx
@@ -160,13 +160,13 @@ export function MobileNav() {
                 aria-current={active ? "page" : undefined}
                 className={cn(
                   "flex items-center gap-3 rounded-lg px-3 py-3 text-[15px] transition-colors",
-                  active ? "bg-brand-soft text-brand" : "text-muted hover:bg-surface-hover hover:text-foreground",
+                  active ? "bg-brand-soft text-brand-text" : "text-muted hover:bg-surface-hover hover:text-foreground",
                 )}
               >
                 <Icon className="size-5" />
                 {label}
                 {chip && (
-                  <span className="ml-auto rounded-full border border-brand/30 bg-brand-soft px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-brand">
+                  <span className="ml-auto rounded-full border border-brand/30 bg-brand-soft px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-brand-text">
                     {chip}
                   </span>
                 )}


### PR DESCRIPTION
## What

Batch 1 of career-ops-ux's **second audit** (post-1.17, measured with axe-core 4.10.2 + computed WCAG ratios over ancestor-blended backgrounds). Kills **~30 color-contrast violations** across both themes with 3 token decisions + 2 component swaps:

| Change | Before | After (measured) |
|---|---|---|
| **P0-A** `--color-brand-foreground` white → near-black `hsl(24 30% 12%)` | 3.14:1 (fail, both themes) | **5.24** on brand · 8.25 on hover |
| **P0-C** new `--color-brand-text` (theme-aware) for small text | 2.6–3.1 in light | **4.87** active nav (light) · dark keeps raw brand (4.95) |
| **P1-A** CostBadge "Free" green + 9.5→10.5px | 2.64 | **4.82** on badge bg |
| **P1-B** inbox "not scored" `text-faint/80` → `text-muted italic` | double-degraded faint | muted (~6.7 class) |

## How

- The brand orange itself is **untouched** — only what sits on top of it (`-foreground`) and its small-text variant change. Keeps the docs-inherited "same orange in light+dark" brand decision.
- `brand-text` follows the existing `@theme inline` runtime-var pattern (like `--color-muted`): darkened orange in `:root`, raw brand under `.dark`.
- Swapped 7 hardcoded `text-white` on `bg-brand` CTAs → `text-brand-foreground` so the single token governs every CTA. **`co-mark` (logo) deliberately left white** — WCAG 1.4.3 exempts logo text and the mark is brand identity.
- `text-brand` stays for icons, accents and large headings (≥24px passes at 3:1); only the audit-enumerated small-text sites swapped to `brand-text`.

## Verification

- `typecheck` + `next build` green.
- Runtime-measured (getComputedStyle + ancestor alpha-blend): CTAs **5.24**, active nav **4.87**, Free badge **4.82** — all ≥4.5 AA.
- Design re-measure by career-ops-ux (the audit author) pending, as per the usual cadence.
- Token truth is shared with career-ops-docs → co-review requested.

Scope: `web/` only, no core root changes, no data-format changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated brand and accent text colors to better adapt across light and dark themes.
  * Improved the visual consistency of navigation, badges, and call-to-action buttons throughout the app.

* **Bug Fixes**
  * Refined contrast for several buttons and labels so text is easier to read on branded backgrounds.
  * Tweaked the appearance of cost and status badges for clearer presentation.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->