### PR TITLE
fix(web): portals copy + analytics semantics (ux audit #2, batch 3)

### DIFF
--- a/web/src/app/analytics/page.tsx
+++ b/web/src/app/analytics/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { pipelineSummary } from "@/lib/career-ops";
 import { canonStatus, scoreNum } from "@/lib/format";
 
@@ -47,16 +48,31 @@ export default function Analytics() {
       <p className="mt-1 text-sm text-muted">Across {total} tracked evaluations.</p>
 
       {/* headline stats */}
-      <div className="mt-6 grid gap-4 sm:grid-cols-4">
+      <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
         <Stat value={total} label="evaluated" />
         <Stat value={avg ? avg.toFixed(2) : "—"} label="avg score" />
-        <Stat value={interviews} label="interviews" />
-        <Stat value={offers} label="offers" />
+        <Stat
+          value={interviews}
+          label="interviews"
+          hint={interviews === 0 ? "Interviews follow replies — keep follow-ups warm →" : undefined}
+        />
+        <Stat
+          value={offers}
+          label="offers"
+          hint={offers === 0 ? "Offers follow interviews — keep the conversations going →" : undefined}
+        />
       </div>
 
       <Section title="Pipeline by stage">
         {stageCounts.map((s) => (
-          <Bar key={s.key} label={s.label} value={s.n} pct={(s.n / maxStage) * 100} total={total} />
+          <Bar
+            key={s.key}
+            label={s.label}
+            value={s.n}
+            pct={(s.n / maxStage) * 100}
+            total={total}
+            tone={s.key === "OFFER" ? "positive" : "neutral"}
+          />
         ))}
       </Section>
 
@@ -75,11 +91,16 @@ export default function Analytics() {
   );
 }
 
-function Stat({ value, label }: { value: number | string; label: string }) {
+function Stat({ value, label, hint }: { value: number | string; label: string; hint?: string }) {
   return (
     <div className="rounded-2xl border border-border bg-surface/50 p-4">
       <div className="text-3xl font-semibold tabular-nums">{value}</div>
       <div className="mt-1 text-xs text-faint">{label}</div>
+      {hint && (
+        <Link href="/" className="mt-2 block text-xs text-muted transition-colors hover:text-brand">
+          {hint}
+        </Link>
+      )}
     </div>
   );
 }
@@ -93,14 +114,30 @@ function Section({ title, children, id }: { title: string; children: React.React
   );
 }
 
-function Bar({ label, value, pct, total }: { label: string; value: number; pct: number; total?: number }) {
+function Bar({
+  label,
+  value,
+  pct,
+  total,
+  tone = "neutral",
+}: {
+  label: string;
+  value: number;
+  pct: number;
+  total?: number;
+  tone?: "neutral" | "positive";
+}) {
   const share = total && total > 0 ? Math.round((value / total) * 100) : null;
+  const fill =
+    tone === "positive"
+      ? "bg-gradient-to-r from-emerald-500/60 to-emerald-500/30"
+      : "bg-gradient-to-r from-foreground/25 to-foreground/10";
   return (
     <div className="flex items-center gap-3">
       <div className="w-32 shrink-0 truncate text-sm text-muted">{label}</div>
       <div className="relative h-7 flex-1 overflow-hidden rounded-md bg-surface">
         <div
-          className="h-full rounded-md bg-gradient-to-r from-brand/70 to-brand/40"
+          className={`h-full rounded-md ${fill}`}
           style={{ width: `${Math.max(pct, value > 0 ? 4 : 0)}%` }}
         />
       </div>

--- a/web/src/app/portals/page.tsx
+++ b/web/src/app/portals/page.tsx
@@ -11,9 +11,11 @@ export default function PortalsPage() {
         <h1 className="font-display text-2xl tracking-tight text-landing">Portals</h1>
       </div>
       <p className="mt-1.5 max-w-xl text-sm text-muted">
-        The companies the scanner watches for new roles (<code className="text-foreground">portals.yml</code>). Run a
-        health check to catch ATS slugs that have quietly broken — a 404 means that company silently disappears from
-        every future scan.
+        The companies career-ops watches for new roles. Run a health check to catch company boards that have quietly
+        broken — a broken link means that company silently disappears from every future scan.
+      </p>
+      <p className="mt-1.5 text-xs text-faint">
+        Backed by <code className="text-muted">portals.yml</code> — edit it directly or ask the assistant.
       </p>
       <div className="mt-6">
         <PortalsView />

--- a/web/src/components/portals-view.tsx
+++ b/web/src/components/portals-view.tsx
@@ -88,8 +88,8 @@ export function PortalsView() {
                 scan
               </span>{" "}
               <span className="text-muted">
-                — their ATS slug 404s. Fix the <code>careers_url</code> in <code>portals.yml</code> (or ask the assistant
-                to repair them).
+                — their careers link is broken. Fix the <code>careers_url</code> in <code>portals.yml</code> (or ask the
+                assistant to repair them).
               </span>
             </div>
           )}


### PR DESCRIPTION
## What

Batch 3 of career-ops-ux's second audit — copy & polish (P2-A + P2-B).

**Portals (P2-A):** the intro led with CLI-author jargon (`portals.yml`, "ATS slugs", "a 404 means"). Now user-first: *"The companies career-ops watches for new roles. Run a health check to catch company boards that have quietly broken — a broken link means that company silently disappears from every future scan."* The file-truth stays for devs, demoted to a secondary note (*"Backed by `portals.yml` — edit it directly or ask the assistant."*). Same treatment in the broken-companies banner.

**Analytics (P2-B):**
- "Pipeline by stage" bars were **brand orange for neutral data** — violating the app's orange=action semantic lock. Neutral foreground fade now; only OFFER keeps a positive emerald.
- Zero tiles ("0 interviews / 0 offers") now carry a next-step hint linking to Today (*"Interviews follow replies — keep follow-ups warm →"*) instead of a dead zero.
- Stat tiles: 2×2 on mobile (were 4 stacked full-width).

**P2-C (CostBadge per-instance `<style>` → global CSS) deliberately deferred** — it touches `cost-badge.tsx`, which #1627 (batch 1) edits in flight; follow-up after that merges.

## Verification

- typecheck + `next build` green.
- Design re-measure/review by career-ops-ux (audit author) pending, per the usual cadence.

Scope: `web/` only. No tokens, no data formats, no core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics now shows clickable hint text when interviews or offers are at zero, helping users navigate to next steps.
  * Pipeline bars now use clearer color tones to better distinguish offer-stage progress.

* **Bug Fixes**
  * Updated broken-link messaging to be more user-friendly and consistent across portal pages.

* **Documentation**
  * Refined the Portals page copy to better explain how portal links are managed and where to update them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->