### PR TITLE
feat(oferta): warn candidate on employee-vs-contractor classification signals

### DIFF
--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -162,6 +162,25 @@ Analyze the job posting for signals that indicate whether this is a real, active
 - Does the role make sense for this company's business?
 - Is the seniority level one that legitimately takes longer to fill?
 
+**6. Employment Classification Risk** (from JD text; jurisdiction from `config/profile.yml` → `location.country`):
+
+Every jurisdiction splits work into two buckets under different names: an "employment contract" carrying statutory protections and benefits, vs. a "service/labour/consulting contract" that doesn't — even when the day-to-day work looks identical from the outside. Candidates routinely can't tell which one a JD is offering until tax time or until a benefit they assumed they had turns out not to exist. Check the JD text for jurisdiction-specific terms:
+- **Canada:** "T4A", "independent contractor", "self-employed", "invoice for services"
+- **US:** "1099", "independent contractor", "W-2 not provided"
+- **UK:** "self-employed", "umbrella company", "outside IR35" / "inside IR35"
+- **Other jurisdictions:** "labour contract" vs "employment contract" phrasing, "service agreement", "consulting agreement" (e.g., 劳务合同 vs 劳动合同 in China)
+
+Plus jurisdiction-agnostic structural signals:
+- "Contract position" combined with **absence** of benefits language, vacation/PTO mention, a defined end date, or standard employment-standards phrasing
+- No mention of statutory deductions/withholding where a fixed-term "contract" might otherwise imply a fixed-term *employee*
+- Role explicitly asks the candidate to "invoice" or operate as a "consultant"/"freelancer" rather than being "hired"/"employed"
+
+If any of these are present, append a short, non-alarmist note to the report (this is descriptive, never prescriptive — never tell the user to refuse a role):
+
+> ⚠️ **Employment classification signal:** This posting uses language associated with contractor/services status rather than standard employee status — e.g. "{specific phrase found}". If eligibility for programs like CEC/PR depends on employee status, or if you want statutory benefits, deductions, and protections, confirm classification directly with the employer before accepting.
+
+This signal does not change the High Confidence / Proceed with Caution / Suspicious tier below — it is orthogonal to ghost-job detection and is reported separately.
+
 ### Output format:
 
 **Assessment:** One of three tiers:

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -164,18 +164,18 @@ Analyze the job posting for signals that indicate whether this is a real, active
 
 **6. Employment Classification Risk** (from JD text; jurisdiction from `config/profile.yml` → `location.country`):
 
-Every jurisdiction splits work into two buckets under different names: an "employment contract" carrying statutory protections and benefits, vs. a "service/labour/consulting contract" that doesn't — even when the day-to-day work looks identical from the outside. Candidates routinely can't tell which one a JD is offering until tax time or until a benefit they assumed they had turns out not to exist. Check the JD text for jurisdiction-specific terms:
-- **Canada:** "T4A", "independent contractor", "self-employed", "invoice for services"
-- **US:** "1099", "independent contractor", "W-2 not provided"
-- **UK:** "self-employed", "umbrella company", "outside IR35" / "inside IR35"
-- **Other jurisdictions:** "labour contract" vs "employment contract" phrasing, "service agreement", "consulting agreement" (e.g., 劳务合同 vs 劳动合同 in China)
+Every jurisdiction splits work into two buckets under different names: an "employment contract" carrying statutory protections and benefits, vs. a "service/labour/consulting contract" that doesn't — even when the day-to-day work looks identical from the outside. Candidates routinely can't tell which one a JD is offering until tax time or until a benefit they assumed they had turns out not to exist. Check the JD text against the jurisdiction-specific term list below (add a new row to extend to another country — this table is a data reference, not instruction logic, so extending it never requires touching the rule text):
 
-Plus jurisdiction-agnostic structural signals:
-- "Contract position" combined with **absence** of benefits language, vacation/PTO mention, a defined end date, or standard employment-standards phrasing
-- No mention of statutory deductions/withholding where a fixed-term "contract" might otherwise imply a fixed-term *employee*
-- Role explicitly asks the candidate to "invoice" or operate as a "consultant"/"freelancer" rather than being "hired"/"employed"
+| Jurisdiction | Contractor/services-status terms |
+|---|---|
+| Canada | "T4A", "independent contractor", "self-employed", "invoice for services" |
+| US | "1099", "independent contractor", "W-2 not provided" |
+| UK | "self-employed", "umbrella company", "outside IR35" / "inside IR35" |
+| Other jurisdictions | "labour contract" vs "employment contract" phrasing, "service agreement", "consulting agreement" (e.g., 劳务合同 vs 劳动合同 in China) |
 
-If any of these are present, append a short, non-alarmist note to the report (this is descriptive, never prescriptive — never tell the user to refuse a role):
+Plus a jurisdiction-agnostic structural check — **"contract position" alone is not enough to trigger this**, since plenty of legitimate fixed-term *employee* roles use that phrase. Only flag when the JD has explicit contractor-status wording (asks the candidate to "invoice," or to operate as a "consultant"/"freelancer," rather than being "hired"/"employed") **and** at least one corroborating omission (no benefits language, no vacation/PTO mention, no defined end date, no standard employment-standards phrasing, no mention of statutory deductions/withholding).
+
+If this combination is present, append a short, non-alarmist note to the report (this is descriptive, never prescriptive — never tell the user to refuse a role):
 
 > ⚠️ **Employment classification signal:** This posting uses language associated with contractor/services status rather than standard employee status — e.g. "{specific phrase found}". If eligibility for programs like CEC/PR depends on employee status, or if you want statutory benefits, deductions, and protections, confirm classification directly with the employer before accepting.
 


### PR DESCRIPTION
## Summary
- Adds a new Block G signal (Employment Classification Risk) to `modes/oferta.md` that flags JD language associated with contractor/services status rather than standard employee status
- Covers Canada (T4A), US (1099), UK (self-employed/umbrella/IR35), and a generic labour-vs-employment-contract pattern for other jurisdictions, plus jurisdiction-agnostic structural signals (contract role missing benefits/PTO/end-date language)
- Output is descriptive ("this looks like X"), never prescriptive, and reported separately from the existing High Confidence / Proceed with Caution / Suspicious tier
- Zero-LLM philosophy preserved for v1: keyword/pattern based, term lists organized per-jurisdiction so adding a new country later is a data change, not a rewrite

Closes #1630

## Test plan
- [x] `node test-all.mjs` — 1291 passed, 0 failed (ran from a clean `upstream/main` worktree with a `node_modules` junction, no unrelated diff)
- [x] Manual read-through of the new Block G subsection against the existing 5 signals for tone/format consistency (numbered signal, "Present observations, not accusations" framing preserved)
- [ ] Maintainer judgment call on whether this belongs in Block G vs a standalone check (flagged as open question in #1630)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Signal `#6`, “Employment Classification Risk,” to review job descriptions for contractor vs. employee language using country-specific terminology.
  * The detection only triggers when explicit contractor-status wording appears alongside corroborating omissions (such as missing benefits, vacation/PTO, no end date, or employment-standards cues).
  * When triggered, the report includes a short, non-alarmist note that quotes the detected phrase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->