### PR TITLE
fix(scan-ats-full): reject unrecognized CLI flags instead of silently ignoring them

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -25,6 +25,7 @@
  *   node scan-ats-full.mjs --liveness           # Playwright-verify matches before writing
  *   node scan-ats-full.mjs --verbose            # log per-board fetch failures
  *   node scan-ats-full.mjs --md-out <dir>       # also write a dated markdown digest to <dir>
+ *   node scan-ats-full.mjs --help               # print this usage block and exit
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync } from 'fs';
@@ -114,8 +115,36 @@ const SOURCES = {
 
 // ── CLI args ────────────────────────────────────────────────────────
 
+const KNOWN_FLAGS = [
+  '--since', '--limit', '--ats', '--seeds', '--dry-run', '--liveness',
+  '--verbose', '--md-out', '--json', '--include-undated', '--shuffle',
+  '--help', '-h',
+];
+
+const USAGE = `Usage:
+  node scan-ats-full.mjs                      # scan all ATS directories, last 3 days
+  node scan-ats-full.mjs --since 7            # postings from the last 7 days
+  node scan-ats-full.mjs --ats greenhouse,workday  # subset of sources
+  node scan-ats-full.mjs --limit 200          # max companies per ATS (default: all)
+  node scan-ats-full.mjs --dry-run            # preview without writing files
+  node scan-ats-full.mjs --liveness           # Playwright-verify matches before writing
+  node scan-ats-full.mjs --verbose            # log per-board fetch failures
+  node scan-ats-full.mjs --md-out <dir>       # also write a dated markdown digest to <dir>`;
+
 function parseArgs(argv) {
   const args = argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  const unknownFlags = args.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a.split('=')[0]));
+  if (unknownFlags.length) {
+    console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
+    process.exit(1);
+  }
+
   const valueOf = (flag) => {
     const idx = args.indexOf(flag);
     if (idx !== -1 && args[idx + 1] && !args[idx + 1].startsWith('--')) return args[idx + 1];

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -121,6 +121,10 @@ const KNOWN_FLAGS = [
   '--help', '-h',
 ];
 
+// Flags that consume the next argv token as a value (space-separated form —
+// the `--flag=value` form is self-contained and never needs this).
+const VALUE_FLAGS = ['--since', '--limit', '--ats', '--seeds', '--md-out'];
+
 const USAGE = `Usage:
   node scan-ats-full.mjs                      # scan all ATS directories, last 3 days
   node scan-ats-full.mjs --since 7            # postings from the last 7 days
@@ -129,7 +133,8 @@ const USAGE = `Usage:
   node scan-ats-full.mjs --dry-run            # preview without writing files
   node scan-ats-full.mjs --liveness           # Playwright-verify matches before writing
   node scan-ats-full.mjs --verbose            # log per-board fetch failures
-  node scan-ats-full.mjs --md-out <dir>       # also write a dated markdown digest to <dir>`;
+  node scan-ats-full.mjs --md-out <dir>       # also write a dated markdown digest to <dir>
+  node scan-ats-full.mjs --help               # print this usage block and exit`;
 
 function parseArgs(argv) {
   const args = argv.slice(2);
@@ -139,7 +144,19 @@ function parseArgs(argv) {
     process.exit(0);
   }
 
-  const unknownFlags = args.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a.split('=')[0]));
+  // A value-taking flag's space-separated value (e.g. the `-tmp` in
+  // `--md-out -tmp`) must not be mistaken for an unrecognized flag just
+  // because it happens to start with `-`. Mirrors valueOf()'s own adjacency
+  // rule below so `--flag value` and `--flag=value` are validated consistently.
+  const consumedValueIndices = new Set();
+  args.forEach((a, idx) => {
+    if (VALUE_FLAGS.includes(a) && args[idx + 1] !== undefined && !args[idx + 1].startsWith('--')) {
+      consumedValueIndices.add(idx + 1);
+    }
+  });
+
+  const unknownFlags = args.filter((a, idx) =>
+    a.startsWith('-') && !consumedValueIndices.has(idx) && !KNOWN_FLAGS.includes(a.split('=')[0]));
   if (unknownFlags.length) {
     console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
     process.exit(1);


### PR DESCRIPTION
## Summary
- `parseArgs()` in `scan-ats-full.mjs` only validated the *values* passed to `--ats`/`--seeds`, never whether the flags themselves were recognized — a typo, or a common convention like `--help`, silently fell through to default behavior: a full live scan of every ATS source (no `--dry-run`).
- Adds an explicit `KNOWN_FLAGS` allowlist and rejects any unrecognized `-`/`--` prefixed arg with a hard error (exit 1).
- Adds a real `--help`/`-h` that prints the usage block (previously only in the file's header comment) and exits 0.

## Test plan
- [x] `node scan-ats-full.mjs --help` prints usage, exits 0, no network calls
- [x] `node scan-ats-full.mjs --hepl` (typo) errors with the flag list, exits 1
- [x] `node scan-ats-full.mjs --dry-run --limit 1` still parses normally (existing flags unaffected)
- [x] `node test-all.mjs` — 1291 passed / 0 failed

Fixes #1633

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in help output with support for `--help` and `-h`.
  * Improved command-line argument handling to clearly list supported flags.
* **Bug Fixes**
  * Unrecognized flags are now rejected with a clear error message.
  * Flag validation now catches unsupported `--name=value` style inputs as invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->