### PR TITLE
feat(scan): scope content_filter per title-category via by_title_keyword

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -103,15 +103,30 @@ export function buildTitleFilter(titleFilter) {
   };
 }
 
+// Compiled-matcher cache for matchedTitleKeywords(), keyed by the
+// `title_filter.positive` array reference. The scan loop calls this once per
+// job with the same titleFilter config object, so caching avoids recompiling
+// every keyword (compileKeyword()) on every single job.
+const compiledPositiveCache = new WeakMap();
+
+function compiledPositiveMatchers(positiveList) {
+  if (compiledPositiveCache.has(positiveList)) return compiledPositiveCache.get(positiveList);
+  const compiled = positiveList
+    .filter(k => typeof k === 'string' && k.trim().length > 0)
+    .map(k => ({ raw: k, match: compileKeyword(k.trim().toLowerCase()) }));
+  compiledPositiveCache.set(positiveList, compiled);
+  return compiled;
+}
+
 // Returns the raw (as-written in portals.yml) `title_filter.positive` keywords
 // that matched a given title — used to scope `content_filter.by_title_keyword`
 // overrides to only the categories that opted into a stricter content check.
 export function matchedTitleKeywords(title, titleFilter) {
   const raw = Array.isArray(titleFilter?.positive) ? titleFilter.positive : [];
   const lower = (title || '').toLowerCase();
-  return raw
-    .filter(k => typeof k === 'string' && k.trim().length > 0)
-    .filter(k => compileKeyword(k.trim().toLowerCase())(lower));
+  return compiledPositiveMatchers(raw)
+    .filter(({ match }) => match(lower))
+    .map(({ raw: kw }) => kw);
 }
 
 // ── Location filter ─────────────────────────────────────────────────
@@ -190,7 +205,7 @@ export function buildContentFilter(contentFilter) {
   const negative = normalizeKeywordList(contentFilter.negative);
 
   const byTitleKeyword = new Map();
-  if (contentFilter.by_title_keyword && typeof contentFilter.by_title_keyword === 'object') {
+  if (contentFilter.by_title_keyword && typeof contentFilter.by_title_keyword === 'object' && !Array.isArray(contentFilter.by_title_keyword)) {
     for (const [kw, rule] of Object.entries(contentFilter.by_title_keyword)) {
       if (typeof kw !== 'string' || !kw.trim()) continue;
       byTitleKeyword.set(kw.trim().toLowerCase(), {
@@ -200,11 +215,11 @@ export function buildContentFilter(contentFilter) {
     }
   }
 
-  return (description, matchedTitleKeywords = []) => {
+  return (description, matchedKeywords = []) => {
     if (typeof description !== 'string' || description.trim() === '') return true;
     const lower = description.toLowerCase();
 
-    const overrides = matchedTitleKeywords
+    const overrides = matchedKeywords
       .filter(k => typeof k === 'string')
       .map(k => byTitleKeyword.get(k.trim().toLowerCase()))
       .filter(Boolean);

--- a/scan.mjs
+++ b/scan.mjs
@@ -103,6 +103,17 @@ export function buildTitleFilter(titleFilter) {
   };
 }
 
+// Returns the raw (as-written in portals.yml) `title_filter.positive` keywords
+// that matched a given title — used to scope `content_filter.by_title_keyword`
+// overrides to only the categories that opted into a stricter content check.
+export function matchedTitleKeywords(title, titleFilter) {
+  const raw = Array.isArray(titleFilter?.positive) ? titleFilter.positive : [];
+  const lower = (title || '').toLowerCase();
+  return raw
+    .filter(k => typeof k === 'string' && k.trim().length > 0)
+    .filter(k => compileKeyword(k.trim().toLowerCase())(lower));
+}
+
 // ── Location filter ─────────────────────────────────────────────────
 // Optional. If `location_filter` is absent from portals.yml, all locations pass.
 // Semantics (case-insensitive substring, in this order):
@@ -158,6 +169,16 @@ export function buildLocationFilter(locationFilter) {
 //   - `positive` empty → pass (already cleared negatives)
 //   - `positive` non-empty → at least one keyword must be present
 //
+// `content_filter.by_title_keyword` (optional): scopes a stricter positive/
+// negative pair to only the jobs whose title matched a specific
+// `title_filter.positive` keyword, so e.g. an "AI Engineer" title-match can
+// require the description to actually mention a concrete AI tool, without
+// that requirement leaking onto unrelated categories like "Instructional
+// Designer". When one or more of a job's matched title keywords has an
+// override, the overrides govern (any override passing is enough); the
+// global `positive`/`negative` pair is the fallback for jobs whose matched
+// keyword(s) have no override entry.
+//
 // Provider support: only providers whose list API ships the description for
 // free (no extra per-job request, which would break the zero-token design)
 // populate `job.description`. Lever (`descriptionPlain`) does today; others
@@ -168,9 +189,34 @@ export function buildContentFilter(contentFilter) {
   const positive = normalizeKeywordList(contentFilter.positive);
   const negative = normalizeKeywordList(contentFilter.negative);
 
-  return (description) => {
+  const byTitleKeyword = new Map();
+  if (contentFilter.by_title_keyword && typeof contentFilter.by_title_keyword === 'object') {
+    for (const [kw, rule] of Object.entries(contentFilter.by_title_keyword)) {
+      if (typeof kw !== 'string' || !kw.trim()) continue;
+      byTitleKeyword.set(kw.trim().toLowerCase(), {
+        positive: normalizeKeywordList(rule?.positive),
+        negative: normalizeKeywordList(rule?.negative),
+      });
+    }
+  }
+
+  return (description, matchedTitleKeywords = []) => {
     if (typeof description !== 'string' || description.trim() === '') return true;
     const lower = description.toLowerCase();
+
+    const overrides = matchedTitleKeywords
+      .filter(k => typeof k === 'string')
+      .map(k => byTitleKeyword.get(k.trim().toLowerCase()))
+      .filter(Boolean);
+
+    if (overrides.length > 0) {
+      return overrides.some(rule => {
+        if (rule.negative.length > 0 && rule.negative.some(k => lower.includes(k))) return false;
+        if (rule.positive.length === 0) return true;
+        return rule.positive.some(k => lower.includes(k));
+      });
+    }
+
     if (negative.length > 0 && negative.some(k => lower.includes(k))) return false;
     if (positive.length === 0) return true;
     return positive.some(k => lower.includes(k));
@@ -1013,7 +1059,7 @@ async function main() {
           totalFilteredSalary++;
           continue;
         }
-        if (!contentFilter(job.description)) {
+        if (!contentFilter(job.description, matchedTitleKeywords(job.title, config.title_filter))) {
           totalFilteredContent++;
           continue;
         }

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -145,6 +145,22 @@
 #   negative:
 #     - "php"
 #     - "wordpress"
+#
+# by_title_keyword (optional): scope a stricter positive/negative pair to only
+# the jobs matched via a specific title_filter.positive keyword, instead of
+# applying it to every scanned job. Useful when a title keyword is broad
+# enough to need extra confirmation from the description (e.g. "AI Engineer"
+# roles where you want the JD to actually mention a concrete AI tool) without
+# that same requirement leaking onto unrelated categories (Instructional
+# Designer, HR Coordinator, ...). Jobs matched via a keyword with no entry
+# here fall back to the global positive/negative pair above.
+# content_filter:
+#   by_title_keyword:
+#     "AI Engineer":
+#       positive:
+#         - "gpt"
+#         - "llm"
+#         - "claude"
 
 # -- Title filter --
 # The scanner uses these keywords to decide if a title is relevant.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1592,6 +1592,7 @@ try {
   const emptyKeywordPath = join(tmp, 'empty-keyword.yml');
   const duplicateCompanyPath = join(tmp, 'duplicate-company.yml');
   const badContentFilterPath = join(tmp, 'bad-content-filter.yml');
+  const deadByTitleKeywordPath = join(tmp, 'dead-by-title-keyword.yml');
 
   writeFileSync(validPath, `
 title_filter:
@@ -1641,6 +1642,21 @@ tracked_companies:
     careers_url: "https://jobs.lever.co/acme"
 `, 'utf-8');
 
+  // by_title_keyword.<kw> that doesn't match any title_filter.positive entry
+  // (typo, or a keyword later removed from title_filter) is dead config — it
+  // will never fire. Should warn, not error (#1636 CodeRabbit follow-up).
+  writeFileSync(deadByTitleKeywordPath, `
+title_filter:
+  positive: ["AI Engineer"]
+content_filter:
+  by_title_keyword:
+    "AI Enginer":
+      positive: ["gpt"]
+tracked_companies:
+  - name: "Acme"
+    careers_url: "https://jobs.lever.co/acme"
+`, 'utf-8');
+
   const validResult = run(NODE, ['validate-portals.mjs', '--file', validPath]);
   if (validResult !== null && validResult.includes('0 errors')) {
     pass('validate-portals accepts a minimal valid portals file');
@@ -1681,6 +1697,13 @@ tracked_companies:
     pass('validate-portals rejects empty content_filter keywords');
   } else {
     fail('validate-portals should reject empty content_filter keywords');
+  }
+
+  const deadByTitleKeywordResult = run(NODE, ['validate-portals.mjs', '--file', deadByTitleKeywordPath]);
+  if (deadByTitleKeywordResult !== null && deadByTitleKeywordResult.includes('1 warning')) {
+    pass('validate-portals warns on a by_title_keyword entry with no matching title_filter.positive keyword');
+  } else {
+    fail('validate-portals should warn (not error) on a dead by_title_keyword entry');
   }
 
   rmSync(tmp, { recursive: true, force: true });
@@ -2688,6 +2711,22 @@ try {
     pass('content_filter global negative still applies to jobs without a matching override');
   } else {
     fail('content_filter global negative should still gate jobs with no by_title_keyword override');
+  }
+
+  // A malformed by_title_keyword (an array instead of an object) must not be
+  // silently iterated via Object.entries as if it were a keyed map — it
+  // should be treated as absent (no overrides), same as the validator rejects it.
+  const arrayGuardCf = buildContentFilter({
+    positive: ['rust'],
+    by_title_keyword: ['not', 'an', 'object'],
+  });
+  if (
+    arrayGuardCf('We write everything in Rust', ['AI Engineer']) === true &&
+    arrayGuardCf('A Python and Go team', ['AI Engineer']) === false
+  ) {
+    pass('content_filter.by_title_keyword as an array is ignored (falls back to global rule), not silently iterated');
+  } else {
+    fail('content_filter.by_title_keyword array should be ignored, not treated as a keyed override map');
   }
 
 } catch (e) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2637,6 +2637,59 @@ try {
     fail('content_filter should be case-insensitive');
   }
 
+  // ── content_filter.by_title_keyword (#1636) ──
+  const { matchedTitleKeywords } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+
+  // matchedTitleKeywords returns the raw positive keywords that matched a title.
+  const tf = { positive: ['AI Engineer', 'Instructional Designer'] };
+  if (
+    JSON.stringify(matchedTitleKeywords('Senior AI Engineer', tf)) === JSON.stringify(['AI Engineer']) &&
+    matchedTitleKeywords('Instructional Designer II', tf).length === 1 &&
+    matchedTitleKeywords('HR Coordinator', tf).length === 0
+  ) {
+    pass('matchedTitleKeywords returns the title_filter.positive keyword(s) that matched');
+  } else {
+    fail('matchedTitleKeywords did not return expected matches');
+  }
+
+  const scopedCf = buildContentFilter({
+    by_title_keyword: {
+      'AI Engineer': { positive: ['gpt', 'llm', 'claude'] },
+    },
+  });
+
+  // A job matched via "AI Engineer" is held to the stricter override — no
+  // AI-tool mention in the description → rejected, even with no global positive set.
+  if (
+    scopedCf('Build internal tools, no ML involved', ['AI Engineer']) === false &&
+    scopedCf('Fine-tune LLM pipelines with GPT-4', ['AI Engineer']) === true
+  ) {
+    pass('content_filter.by_title_keyword applies its stricter rule only to jobs matched via that keyword');
+  } else {
+    fail('content_filter.by_title_keyword override did not gate AI Engineer jobs correctly');
+  }
+
+  // A job matched via a keyword with NO override (e.g. Instructional Designer)
+  // must NOT inherit the AI Engineer override — falls back to the global rule
+  // (absent here, so it passes).
+  if (scopedCf('Designs onboarding curricula', ['Instructional Designer']) === true) {
+    pass('content_filter.by_title_keyword does not leak onto unrelated title keywords');
+  } else {
+    fail('content_filter.by_title_keyword leaked its override onto an unrelated keyword');
+  }
+
+  // Global negative still applies as a backstop even when overrides exist,
+  // for jobs whose matched keyword has no override entry.
+  const scopedCfWithGlobal = buildContentFilter({
+    negative: ['wordpress'],
+    by_title_keyword: { 'AI Engineer': { positive: ['gpt'] } },
+  });
+  if (scopedCfWithGlobal('WordPress plugin maintenance', ['Instructional Designer']) === false) {
+    pass('content_filter global negative still applies to jobs without a matching override');
+  } else {
+    fail('content_filter global negative should still gate jobs with no by_title_keyword override');
+  }
+
 } catch (e) {
   fail(`always_allow tests crashed: ${e.message}`);
 }

--- a/validate-portals.mjs
+++ b/validate-portals.mjs
@@ -134,6 +134,21 @@ export async function validatePortalsConfig(config, { providerIds = new Set() } 
     } else {
       validateKeywordList(config.content_filter.positive, 'content_filter.positive', errors);
       validateKeywordList(config.content_filter.negative, 'content_filter.negative', errors);
+      if (config.content_filter.by_title_keyword !== undefined) {
+        if (!isObject(config.content_filter.by_title_keyword)) {
+          add(errors, 'content_filter.by_title_keyword', 'by_title_keyword must be an object keyed by title_filter.positive keyword');
+        } else {
+          for (const [kw, rule] of Object.entries(config.content_filter.by_title_keyword)) {
+            const path = `content_filter.by_title_keyword.${kw}`;
+            if (!isObject(rule)) {
+              add(errors, path, 'must be an object with positive/negative keyword lists');
+              continue;
+            }
+            validateKeywordList(rule.positive, `${path}.positive`, errors);
+            validateKeywordList(rule.negative, `${path}.negative`, errors);
+          }
+        }
+      }
     }
   }
 

--- a/validate-portals.mjs
+++ b/validate-portals.mjs
@@ -138,8 +138,16 @@ export async function validatePortalsConfig(config, { providerIds = new Set() } 
         if (!isObject(config.content_filter.by_title_keyword)) {
           add(errors, 'content_filter.by_title_keyword', 'by_title_keyword must be an object keyed by title_filter.positive keyword');
         } else {
+          const titlePositive = new Set(
+            (Array.isArray(config.title_filter?.positive) ? config.title_filter.positive : [])
+              .filter(k => typeof k === 'string')
+              .map(k => k.trim().toLowerCase())
+          );
           for (const [kw, rule] of Object.entries(config.content_filter.by_title_keyword)) {
             const path = `content_filter.by_title_keyword.${kw}`;
+            if (!titlePositive.has(kw.trim().toLowerCase())) {
+              add(warnings, path, `"${kw}" does not match any title_filter.positive keyword and will never apply`);
+            }
             if (!isObject(rule)) {
               add(errors, path, 'must be an object with positive/negative keyword lists');
               continue;


### PR DESCRIPTION
## Summary
- `content_filter` in `portals.yml` previously applied globally to every scanned job regardless of which `title_filter.positive` keyword matched it — a stricter content rule scoped to one title category (e.g. requiring "AI Engineer" JDs to mention a real AI tool) would silently apply to unrelated categories too (Instructional Designer, HR Coordinator, ...) and break their matching.
- Adds `content_filter.by_title_keyword`: an optional map from a `title_filter.positive` keyword to its own `positive`/`negative` pair.
- `buildContentFilter()` now takes an optional second arg — the title keywords that matched the job — and a new `matchedTitleKeywords()` helper computes that list at the call site.
- Jobs matched via a keyword with no override entry fall back to the existing global `positive`/`negative` behavior. Fully backward compatible: the second arg defaults to `[]`, so any existing caller of `contentFilter(description)` is unaffected.
- Wires validation into `validate-portals.mjs` and documents the shape in `templates/portals.example.yml`.

## Test plan
- [x] `matchedTitleKeywords()` returns the raw matched keyword(s) for a title
- [x] `by_title_keyword` override gates a job matched via that keyword (requires its own positive list)
- [x] override does NOT leak onto jobs matched via a different, unrelated keyword
- [x] global `negative` still applies as a backstop for jobs whose matched keyword has no override
- [x] `node test-all.mjs` — 1295 passed / 0 failed

Fixes #1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for title-aware content filtering overrides using per-title keyword rules.
  * Expanded the configuration template to include optional `by_title_keyword` settings.

* **Bug Fixes**
  * Improved filtering so title-matched overrides are evaluated correctly, with global rules used as a fallback.

* **Documentation**
  * Updated the portals example configuration to document the new `by_title_keyword` option.

* **Tests**
  * Added coverage for validation and override behavior, including cases where title keywords have no matching configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->