### PR TITLE
fix(scan): use local liveness fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,12 +309,14 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 
 ## Offer Verification -- MANDATORY
 
-**NEVER trust WebSearch/WebFetch to verify if an offer is still active.** ALWAYS use Playwright:
-1. `browser_navigate` to the URL
-2. `browser_snapshot` to read content
-3. Only footer/navbar without JD = closed. Title + description + Apply = active.
+Verify a posting is still live before applying, using the cheapest conclusive check:
 
-**Exception for batch workers (headless mode):** Playwright is not available in headless pipe mode. Use WebFetch as fallback and mark the report header with `**Verification:** unconfirmed (batch mode)`. The user can verify manually later.
+1. **Standard liveness gate:** run `node check-liveness.mjs <url>`. The checker uses a public ATS API when supported and falls back to repository-local Playwright when needed.
+2. **Interactive inspection:** when browser tools are available and JD content must be inspected, use `browser_navigate` and `browser_snapshot`. Only footer/navbar without JD means closed; title + description + Apply means active.
+
+**NEVER decide liveness from a bare WebSearch/WebFetch snippet.** Accept only a conclusive checker or interactive-browser verdict. Keep `uncertain` results unconfirmed; never reinterpret them as expired.
+
+**Exception for batch workers (headless mode):** The ATS API rung still works. If a non-ATS page cannot launch local Playwright, use WebFetch only to extract content and mark the report header with `**Verification:** unconfirmed (batch mode)`.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-06-browser-liveness-fallback.md
+++ b/docs/superpowers/plans/2026-07-06-browser-liveness-fallback.md
@@ -1,0 +1,222 @@
+# Browser Liveness Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make scan-mode WebSearch liveness verification work without interactive browser tools by routing it through the existing repository-local checker.
+
+**Architecture:** Keep `check-liveness.mjs` as the single liveness entrypoint. Align the agent instructions and doctor warning with its ATS API plus local Playwright ladder, and lock the behavior with text-contract assertions in the existing test harness.
+
+**Tech Stack:** Node.js ESM, Playwright, Markdown agent instructions, `test-all.mjs`
+
+---
+
+### Task 1: Add instruction-contract regression coverage
+
+**Files:**
+- Modify: `test-all.mjs:1185-1198`
+- Test: `test-all.mjs`
+
+- [ ] **Step 1: Write the failing regression assertion**
+
+Add this block after the existing pipeline liveness assertion:
+
+```js
+const agentsInstructions = readFile('AGENTS.md');
+const scanMode = readFile('modes/scan.md');
+const doctorInstructions = readFile('doctor.mjs');
+if (
+  agentsInstructions.includes('node check-liveness.mjs <url>') &&
+  agentsInstructions.includes('NEVER decide liveness from a bare WebSearch/WebFetch snippet') &&
+  scanMode.includes('node check-liveness.mjs <url>') &&
+  scanMode.includes('skipped_unconfirmed') &&
+  scanMode.includes('never reinterpret `uncertain` as expired') &&
+  doctorInstructions.includes('check-liveness.mjs remains available')
+) {
+  pass('scan verification falls back to the repo-local liveness checker');
+} else {
+  fail('scan verification still depends exclusively on interactive browser tools');
+}
+```
+
+- [ ] **Step 2: Run the suite and verify the new assertion fails**
+
+Run:
+
+```bash
+node test-all.mjs
+```
+
+Expected: the suite reports
+`FAIL: scan verification still depends exclusively on interactive browser tools`.
+
+- [ ] **Step 3: Commit the failing regression test**
+
+```bash
+git add test-all.mjs
+git commit -m "test(scan): require local liveness fallback"
+```
+
+### Task 2: Align offer-verification and scan instructions
+
+**Files:**
+- Modify: `AGENTS.md:308-315`
+- Modify: `modes/scan.md:226-250`
+- Test: `test-all.mjs`
+
+- [ ] **Step 1: Replace the stale `AGENTS.md` verification block**
+
+Use this content:
+
+```markdown
+## Offer Verification -- MANDATORY
+
+Verify a posting is still live before applying, using the cheapest conclusive check:
+
+1. **Standard liveness gate:** run `node check-liveness.mjs <url>`. The checker uses a public ATS API when supported and falls back to repository-local Playwright when needed.
+2. **Interactive inspection:** when browser tools are available and JD content must be inspected, use `browser_navigate` and `browser_snapshot`. Only footer/navbar without JD means closed; title + description + Apply means active.
+
+**NEVER decide liveness from a bare WebSearch/WebFetch snippet.** Accept only a conclusive checker or interactive-browser verdict. Keep `uncertain` results unconfirmed; never reinterpret them as expired.
+
+**Exception for batch workers (headless mode):** The ATS API rung still works. If a non-ATS page cannot launch local Playwright, use WebFetch only to extract content and mark the report header with `**Verification:** unconfirmed (batch mode)`.
+```
+
+- [ ] **Step 2: Replace scan Level 3 verification**
+
+Use this workflow:
+
+```markdown
+7.5. **Verify Liveness of WebSearch Results (Level 3)** — BEFORE adding to pipeline:
+
+   WebSearch results can be outdated. Verify every new Level 3 URL with the repository-local liveness gate. Levels 1 and 2 are inherently real-time and do not require this verification.
+
+   For each new Level 3 URL, sequentially run:
+
+   ```bash
+   node check-liveness.mjs <url>
+   ```
+
+   The checker tries a public ATS API first and launches local Playwright only when the API is unavailable or inconclusive.
+
+   - **Active:** continue to step 8.
+   - **Expired:** record `skipped_expired` in `scan-history.tsv` and discard.
+   - **Uncertain or checker failure:** record `skipped_unconfirmed`, keep the URL out of `pipeline.md`, and report it for later confirmation. Never reinterpret `uncertain` as expired.
+
+   Direct `browser_navigate` + `browser_snapshot` remains valid when interactive browser tools are available and the agent needs to inspect the JD. It is not required solely for liveness.
+
+   If the managed sandbox blocks Chromium launch, request approval for the narrowly scoped `node check-liveness.mjs` command and retry. Do not interrupt the entire scan when one URL remains unconfirmed.
+```
+
+Update the summary status list with:
+
+```markdown
+11. **Expired offers (Level 3)**: record with status `skipped_expired`.
+12. **Unconfirmed offers (Level 3)**: record with status `skipped_unconfirmed`.
+```
+
+- [ ] **Step 3: Run the regression suite**
+
+Run:
+
+```bash
+node test-all.mjs
+```
+
+Expected: the new local-liveness fallback assertion passes and no existing assertion fails.
+
+- [ ] **Step 4: Commit the aligned instructions**
+
+```bash
+git add AGENTS.md modes/scan.md
+git commit -m "fix(scan): use local liveness fallback"
+```
+
+### Task 3: Clarify doctor guidance
+
+**Files:**
+- Modify: `doctor.mjs:85-123`
+- Test: `test-all.mjs`
+
+- [ ] **Step 1: Narrow the warning to interactive browser capabilities**
+
+Keep MCP detection unchanged. Replace the warning guidance with:
+
+```js
+fix: [
+  'Interactive browser tools for SPA career-page discovery and JD extraction need a',
+  'Playwright MCP server. No project-level MCP config was detected in `.mcp.json`',
+  'or `.claude/settings*.json`. Repository-local liveness verification through',
+  '`node check-liveness.mjs <url>` remains available via ATS APIs and local Playwright.',
+  'Tracking: https://github.com/santifer/career-ops/issues/506',
+],
+```
+
+Update the preceding comment so it no longer says pipeline liveness checks require MCP.
+
+- [ ] **Step 2: Run startup diagnostics**
+
+Run:
+
+```bash
+node doctor.mjs --json
+```
+
+Expected: onboarding remains complete; the non-fatal MCP warning remains present because interactive browser tools are not configured.
+
+- [ ] **Step 3: Run the full regression suite**
+
+Run:
+
+```bash
+node test-all.mjs
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 4: Commit the doctor clarification**
+
+```bash
+git add doctor.mjs
+git commit -m "fix(doctor): clarify Playwright fallback"
+```
+
+### Task 4: Verify both liveness rungs and final scope
+
+**Files:**
+- Verify: `check-liveness.mjs`
+- Verify: `AGENTS.md`
+- Verify: `modes/scan.md`
+- Verify: `doctor.mjs`
+- Verify: `test-all.mjs`
+
+- [ ] **Step 1: Verify ATS API and browser fallback**
+
+Run:
+
+```bash
+node check-liveness.mjs --no-fallback \
+  https://jobs.lever.co/conversica/9749af99-df67-458a-8195-9749fe0b9ee0 \
+  https://jobs.lever.co/agiloft/f6709ce0-427b-4d6f-bcad-e7db2172ac0b/apply
+```
+
+Expected: both URLs report `active`; Conversica is marked `(api)` and Agiloft is verified by local Chromium.
+
+- [ ] **Step 2: Verify formatting and scope**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; only intended branch changes plus the user's pre-existing untracked data files are present.
+
+- [ ] **Step 3: Run final pipeline health check**
+
+Run:
+
+```bash
+node verify-pipeline.mjs
+```
+
+Expected: zero errors and zero warnings.

--- a/docs/superpowers/specs/2026-07-06-browser-liveness-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-06-browser-liveness-fallback-design.md
@@ -1,0 +1,77 @@
+# Browser Liveness Fallback Design
+
+## Problem
+
+Career-ops scan mode currently treats the interactive browser tools as the only
+acceptable way to verify search-engine-only job leads. In Codex sessions where
+the in-app browser backend is not registered, this causes the agent to leave
+potential leads unverified even though the repository already ships a working
+Playwright-based liveness checker.
+
+The behavior is caused by instruction drift:
+
+- `CLAUDE.md` and `modes/pipeline.md` already direct agents to
+  `check-liveness.mjs`.
+- `AGENTS.md` and `modes/scan.md` still require direct
+  `browser_navigate`/`browser_snapshot` calls.
+- `doctor.mjs` warns when Playwright MCP is absent without distinguishing
+  interactive extraction from repo-local liveness verification.
+
+## Goal
+
+Ensure scan mode can verify search-engine-only leads when interactive browser
+tools are unavailable, without weakening the rule against trusting search
+snippets as liveness evidence.
+
+## Design
+
+Use the existing `check-liveness.mjs` command as the standard liveness gate:
+
+1. Run `node check-liveness.mjs <url>` for each search-engine-only lead.
+2. Accept `active` results from either the ATS API rung or the script's local
+   Playwright rung.
+3. Discard only definitive `expired` results.
+4. Keep `uncertain` results out of the pipeline until they can be confirmed;
+   never rewrite uncertainty as expiration.
+5. Use direct interactive browser tools when they are available and JD content
+   must be inspected, but do not require them solely for liveness.
+
+No new verification script or dependency will be introduced.
+
+## Changes
+
+- Align `AGENTS.md` offer-verification rules with the existing API-first,
+  local-Playwright fallback documented in `CLAUDE.md`.
+- Update `modes/scan.md` Level 3 verification to call
+  `check-liveness.mjs` when direct browser tools are unavailable.
+- Clarify the `doctor.mjs` warning: Playwright MCP is required for interactive
+  browser extraction, while `check-liveness.mjs` remains available for
+  liveness checks.
+- Extend `test-all.mjs` with regression assertions covering the fallback and
+  uncertainty handling.
+
+## Error Handling
+
+- An `active` verdict permits the lead to enter `data/pipeline.md`.
+- An `expired` verdict records `skipped_expired`.
+- An `uncertain` verdict or checker failure does not enter the pipeline and is
+  reported for later confirmation.
+- Sandbox-denied browser launches should be retried with explicit approval for
+  the narrowly scoped `node check-liveness.mjs` command.
+
+## Verification
+
+- Run the new regression assertions and confirm they fail before the
+  documentation changes.
+- Run `node test-all.mjs`.
+- Run `node doctor.mjs --json` and confirm its warning accurately describes the
+  remaining limitation.
+- Run `node check-liveness.mjs` against one ATS-hosted lead and one lead that
+  requires local Chromium, confirming both verification rungs work.
+
+## Non-Goals
+
+- Installing or registering a Playwright MCP server.
+- Restoring a Codex in-app browser target from repository code.
+- Replacing the existing liveness classifier.
+- Automatically adding every search result without verification.

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -82,12 +82,12 @@ async function checkPlaywright() {
   }
 }
 
-// The browser tools (`browser_navigate` / `browser_snapshot`) that scan / pipeline /
-// apply rely on are provided by the Playwright MCP server, usually registered through a
-// project-level MCP config (for example `.mcp.json`, `.claude/settings.json`, or
-// `.claude/settings.local.json`). When no common config is detected, SPA job boards can
-// silently return empty or stale content (#522), so doctor surfaces a non-fatal warning
-// instead of letting it fail invisibly.
+// Interactive browser tools (`browser_navigate` / `browser_snapshot`) for SPA discovery
+// and JD extraction are provided by the Playwright MCP server, usually registered
+// through a project-level MCP config (for example `.mcp.json`,
+// `.claude/settings.json`, or `.claude/settings.local.json`). Repository-local
+// liveness checks do not require MCP: check-liveness.mjs uses ATS APIs and falls back
+// to its own Playwright browser. Doctor keeps this warning non-fatal.
 const PLAYWRIGHT_MCP_WARNING = 'Playwright MCP tools not detected';
 
 function playwrightMcpConfigured(root) {
@@ -117,9 +117,10 @@ function checkPlaywrightMcp(root) {
     warn: true,
     label: PLAYWRIGHT_MCP_WARNING,
     fix: [
-      'Browser-driven JD fetching and liveness checks (scan / pipeline / apply) need the',
+      'Interactive browser tools for SPA career-page discovery and JD extraction need a',
       'Playwright MCP server. No project-level MCP config was detected in `.mcp.json`',
-      'or `.claude/settings*.json`, so SPA job boards may return empty or stale content.',
+      'or `.claude/settings*.json`. Use `node check-liveness.mjs <url>` for repository-local',
+      'verification; check-liveness.mjs remains available via ATS APIs and local Playwright.',
       'Tracking: https://github.com/santifer/career-ops/issues/506',
     ],
   };

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -229,21 +229,23 @@ Levels are additive — they are executed in order, and results are merged and d
 
 7.5. **Verify Liveness of WebSearch Results (Level 3)** — BEFORE adding to pipeline:
 
-   WebSearch results can be outdated (Google caches results for weeks or months). To avoid evaluating expired offers, verify every new URL coming from Level 3 using Playwright. Levels 1 and 2 are inherently real-time and do not require this verification.
+   WebSearch results can be outdated. Verify every new Level 3 URL with the repository-local liveness gate. Levels 1 and 2 are inherently real-time and do not require this verification.
 
-   For each new Level 3 URL (sequential — NEVER parallel Playwright):
-   a. `browser_navigate` to the URL.
-   b. `browser_snapshot` to read the content.
-   c. Classify:
-      - **Active**: visible job title + role description + visible Apply/Submit/Apply Now control inside the main content area. Do not count generic header/navbar/footer text.
-      - **Expired** (any of these signals):
-        - Final URL contains `?error=true` (Greenhouse redirects here when an offer is closed).
-        - Page contains: "job no longer available" / "no longer open" / "position has been filled" / "this job has expired" / "page not found".
-        - Only navbar and footer are visible, with no JD content (content < ~300 characters).
-   d. If expired: record in `scan-history.tsv` with status `skipped_expired` and discard.
-   e. If active: continue to step 8.
+   For each new Level 3 URL, sequentially run:
 
-   **Do not interrupt the entire scan if a single URL fails.** If `browser_navigate` errors (timeout, 403, etc.), mark as `skipped_expired` and continue with the next one.
+   ```bash
+   node check-liveness.mjs <url>
+   ```
+
+   The checker tries a public ATS API first and launches local Playwright only when the API is unavailable or inconclusive.
+
+   - **Active:** continue to step 8.
+   - **Expired:** record `skipped_expired` in `scan-history.tsv` and discard.
+   - **Uncertain or checker failure:** record `skipped_unconfirmed`, keep the URL out of `pipeline.md`, report it for later confirmation, and never reinterpret `uncertain` as expired.
+
+   Direct `browser_navigate` + `browser_snapshot` remains valid when interactive browser tools are available and the agent needs to inspect the JD. It is not required solely for liveness.
+
+   If the managed sandbox blocks Chromium launch, request approval for the narrowly scoped `node check-liveness.mjs` command and retry. Do not interrupt the entire scan when one URL remains unconfirmed.
 
 8. **For each new verified offer that passes filters**:
    a. Add to the `pipeline.md` "Pending" section: `- [ ] {url} | {company} | {title}`
@@ -252,6 +254,7 @@ Levels are additive — they are executed in order, and results are merged and d
 9. **Offers filtered by title**: record in `scan-history.tsv` with status `skipped_title`.
 10. **Duplicate offers**: record with status `skipped_dup`.
 11. **Expired offers (Level 3)**: record with status `skipped_expired`.
+12. **Unconfirmed offers (Level 3)**: record with status `skipped_unconfirmed`.
 
 ## Extraction of Title and Company from WebSearch Results
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1141,6 +1141,22 @@ if (
   fail('pipeline mode missing batch liveness sweep for unconfirmed entries');
 }
 
+const agentsInstructions = readFile('AGENTS.md');
+const scanModeInstructions = readFile('modes/scan.md');
+const doctorInstructions = readFile('doctor.mjs');
+if (
+  agentsInstructions.includes('node check-liveness.mjs <url>') &&
+  agentsInstructions.includes('NEVER decide liveness from a bare WebSearch/WebFetch snippet') &&
+  scanModeInstructions.includes('node check-liveness.mjs <url>') &&
+  scanModeInstructions.includes('skipped_unconfirmed') &&
+  scanModeInstructions.includes('never reinterpret `uncertain` as expired') &&
+  doctorInstructions.includes('check-liveness.mjs remains available')
+) {
+  pass('scan verification falls back to the repo-local liveness checker');
+} else {
+  fail('scan verification still depends exclusively on interactive browser tools');
+}
+
 // ── 9. LOCAL PARSER CONTRACT ────────────────────────────────────
 
 console.log('\n9. Local parser contract');


### PR DESCRIPTION
## Summary

- route Level 3 WebSearch liveness checks through the existing repository-local checker when interactive browser tools are unavailable
- preserve uncertain results as unconfirmed instead of misclassifying them as expired
- align AGENTS.md, scan mode, and doctor guidance with the ATS API plus local Playwright fallback
- add an instruction-contract regression test

Follow-up to #522. This addresses scan liveness verification only; interactive SPA discovery and JD extraction still require browser tooling.

## Test plan

- [x] node test-all.mjs — 1293 passed, 0 failed
- [x] node check-liveness.mjs against one Lever API URL and one local-Chromium URL
- [x] node doctor.mjs --json
- [x] node verify-pipeline.mjs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified verification guidance for checking job offers and scan results, including when to use local liveness checks versus interactive browser inspection.
  * Updated scan workflow notes to handle unconfirmed results separately and avoid treating uncertain checks as expired.

* **Tests**
  * Added coverage to ensure the documented liveness-verification fallback remains in place across key instructions and guidance files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->