### PR TITLE
feat(scoring): add structural Culture Screen dimension

### DIFF
--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -92,6 +92,20 @@ cv:
   # The ID starts with "D" and is 11 characters long.
   # canva_resume_design_id: "DAxxxxxxxxx"
 
+# ── Culture Screen ───────────────────────────────────────────────────────────
+#
+# Enforces structural capping on the "Cultural signals" dimension during evaluation.
+#
+# culture_screen:
+#   # What you actively look for in a team culture (e.g. org size, meeting frequency, async-first).
+#   # If absent/commented, the dimension is scored qualitatively without a hard cap.
+#   require:
+#     - "Small, flat teams (under 15 engineers)"
+#     - "Async-first communication, low meeting overhead"
+#   # If true, the dimension is capped at 2/5 if the JD lacks any evidence for the required criteria.
+#   # If false (or absent), lack of evidence defaults to a neutral 3/5.
+#   deprioritize_if_absent: true
+
 # ── Cover Letter Settings ──────────────────────────────────────────────────
 #
 # Used by `/career-ops cover` and the cover letter sub-flow in `/career-ops pdf`.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -10,6 +10,7 @@ Key sections:
 - **narrative**: Your headline, exit story, superpowers, proof points
 - **compensation**: Target range, minimum, currency
 - **location**: Country, timezone, visa status, on-site availability
+- **culture_screen**: Structural criteria for team culture (the `deprioritize_if_absent` strict flag caps the culture score at 2/5 if evidence is entirely missing)
 
 ## Target Roles (modes/_profile.md)
 

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -54,7 +54,7 @@ The evaluation uses 6 blocks (A-F) with a global score of 1-5:
 2. Actively look for evidence in the JD + Block G company research: team size mentions, org-chart depth/manager layers, meeting-culture language ("daily standups," "cross-functional alignment," "stakeholder management" as a core duty), company size/stage, async vs. sync-heavy language.
 3. **If 2+ of the 3 `require` criteria have positive evidence** → score 4-5.
 4. **If 1 criterion has positive evidence, none contradicted** → score 3.
-5. **If evidence points the other way (large corporate, heavy management layers, explicit politics/stakeholder-heavy language) or `deprioritize_if_absent: true` and no evidence either way** → **cap this dimension at 2/5**, and add an explicit line to Block A's Culture Screen field (see `oferta.md`) naming what's missing or contradicted. Do not let a strong CV-match score silently compensate for this — surface it, don't bury it.
+5. **If evidence points the other way (large corporate, heavy management layers, explicit politics/stakeholder-heavy language) or `culture_screen.deprioritize_if_absent: true` and no evidence either way** → **cap this dimension at 2/5**, and add an explicit line to Block A's Culture Screen field (see `oferta.md`) naming what's missing or contradicted. Do not let a strong CV-match score silently compensate for this — surface it, don't bury it.
 6. A role scoring 4.5+ overall but 2 or below on Cultural signals must carry an explicit warning in the report: "High technical fit, unconfirmed/poor culture fit — verify before applying."
 
 ## Posting Legitimacy (Block G)

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -50,11 +50,11 @@ The evaluation uses 6 blocks (A-F) with a global score of 1-5:
 - Below 3.5 → Recommend against applying (see Ethical Use in AGENTS.md)
 
 **How to score the "Cultural signals" dimension:**
-1. Read `culture_screen.require` from `config/profile.yml` (flat hierarchy, async-first/remote-native, small team). If `culture_screen` is missing or empty, skip the structural capping and score the dimension qualitatively based on company size, remote policy, and stability.
-2. Actively look for evidence in the JD + Block G company research: team size mentions, org-chart depth/manager layers, meeting-culture language ("daily standups," "cross-functional alignment," "stakeholder management" as a core duty), company size/stage, async vs. sync-heavy language.
-3. **If 2+ of the 3 `require` criteria have positive evidence** → score 4-5.
-4. **If 1 criterion has positive evidence, none contradicted** → score 3.
-5. **If evidence points the other way (large corporate, heavy management layers, explicit politics/stakeholder-heavy language) or `culture_screen.deprioritize_if_absent: true` and no evidence either way** → **cap this dimension at 2/5**, and add an explicit line to Block A's Culture Screen field (see `oferta.md`) naming what's missing or contradicted. Do not let a strong CV-match score silently compensate for this — surface it, don't bury it.
+1. Read `culture_screen.require` from `config/profile.yml`. If `culture_screen` is missing or empty, skip the structural capping and score the dimension qualitatively based on company size, remote policy, and stability.
+2. Actively look for evidence in the JD + Block G company research corresponding to those requirements (e.g., team size mentions, org-chart depth/manager layers, meeting-culture language, company stage).
+3. **If a majority of the `require` criteria have positive evidence** → score 4-5.
+4. **If some criteria have positive evidence, and none are contradicted** → score 3.
+5. **If evidence contradicts the `require` criteria or `culture_screen.deprioritize_if_absent: true` is set and no evidence exists either way** → **cap this dimension at 2/5**, and add an explicit line to Block A's Culture Screen field (see `oferta.md`) naming what's missing or contradicted. Do not let a strong CV-match score silently compensate for this — surface it, don't bury it.
 6. A role scoring 4.5+ overall but 2 or below on Cultural signals must carry an explicit warning in the report: "High technical fit, unconfirmed/poor culture fit — verify before applying."
 
 ## Posting Legitimacy (Block G)

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -52,10 +52,11 @@ The evaluation uses 6 blocks (A-F) with a global score of 1-5:
 **How to score the "Cultural signals" dimension:**
 1. Read `culture_screen.require` from `config/profile.yml`. If `culture_screen` is missing or empty, skip the structural capping and score the dimension qualitatively based on company size, remote policy, and stability.
 2. Actively look for evidence in the JD + Block G company research corresponding to those requirements (e.g., team size mentions, org-chart depth/manager layers, meeting-culture language, company stage).
-3. **If a majority of the `require` criteria have positive evidence** → score 4-5.
+3. **If most `require` criteria have positive evidence** → score 4-5.
 4. **If some criteria have positive evidence, and none are contradicted** → score 3.
-5. **If evidence contradicts the `require` criteria or `culture_screen.deprioritize_if_absent: true` is set and no evidence exists either way** → **cap this dimension at 2/5**, and add an explicit line to Block A's Culture Screen field (see `oferta.md`) naming what's missing or contradicted. Do not let a strong CV-match score silently compensate for this — surface it, don't bury it.
-6. A role scoring 4.5+ overall but 2 or below on Cultural signals must carry an explicit warning in the report: "High technical fit, unconfirmed/poor culture fit — verify before applying."
+5. **If evidence contradicts the `require` criteria** → **cap this dimension at 2/5**, and add an explicit line to Block A's Culture Screen field (see `oferta.md`) naming what's missing or contradicted. Do not let a strong CV-match score silently compensate for this — surface it, don't bury it.
+6. **If no evidence exists for any `require` criterion** → score 3 by default, unless `culture_screen.deprioritize_if_absent: true` is set, in which case **cap this dimension at 2/5**.
+7. A role scoring 4.5+ overall but 2 or below on Cultural signals must carry an explicit warning in the report: "High technical fit, unconfirmed/poor culture fit — verify before applying."
 
 ## Posting Legitimacy (Block G)
 

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -49,6 +49,14 @@ The evaluation uses 6 blocks (A-F) with a global score of 1-5:
 - 3.5-3.9 → Decent but not ideal, apply only if specific reason
 - Below 3.5 → Recommend against applying (see Ethical Use in AGENTS.md)
 
+**How to score the "Cultural signals" dimension:**
+1. Read `culture_screen.require` from `config/profile.yml` (flat hierarchy, async-first/remote-native, small team).
+2. Actively look for evidence in the JD + Block G company research: team size mentions, org-chart depth/manager layers, meeting-culture language ("daily standups," "cross-functional alignment," "stakeholder management" as a core duty), company size/stage, async vs. sync-heavy language.
+3. **If 2+ of the 3 `require` criteria have positive evidence** → score 4-5.
+4. **If 1 criterion has positive evidence, none contradicted** → score 3.
+5. **If evidence points the other way (large corporate, heavy management layers, explicit politics/stakeholder-heavy language) or `deprioritize_if_absent: true` and no evidence either way** → **cap this dimension at 2/5**, and add an explicit line to Block A's Culture Screen field (see `oferta.md`) naming what's missing or contradicted. Do not let a strong CV-match score silently compensate for this — surface it, don't bury it.
+6. A role scoring 4.5+ overall but 2 or below on Cultural signals must carry an explicit warning in the report: "High technical fit, unconfirmed/poor culture fit — verify before applying."
+
 ## Posting Legitimacy (Block G)
 
 Block G assesses whether a posting is likely a real, active opening. It does NOT affect the 1-5 global score -- it is a separate qualitative assessment.

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -50,7 +50,7 @@ The evaluation uses 6 blocks (A-F) with a global score of 1-5:
 - Below 3.5 → Recommend against applying (see Ethical Use in AGENTS.md)
 
 **How to score the "Cultural signals" dimension:**
-1. Read `culture_screen.require` from `config/profile.yml` (flat hierarchy, async-first/remote-native, small team).
+1. Read `culture_screen.require` from `config/profile.yml` (flat hierarchy, async-first/remote-native, small team). If `culture_screen` is missing or empty, skip the structural capping and score the dimension qualitatively based on company size, remote policy, and stability.
 2. Actively look for evidence in the JD + Block G company research: team size mentions, org-chart depth/manager layers, meeting-culture language ("daily standups," "cross-functional alignment," "stakeholder management" as a core duty), company size/stage, async vs. sync-heavy language.
 3. **If 2+ of the 3 `require` criteria have positive evidence** → score 4-5.
 4. **If 1 criterion has positive evidence, none contradicted** → score 3.

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -44,7 +44,7 @@ Table with:
 - Seniority
 - Remote (full/hybrid/onsite)
 - Team size (if mentioned)
-- **Culture screen** (see `_shared.md` § Culture Screen): pass / caution / fail, with the specific evidence found or missing — not just a score, name what you saw
+- **Culture screen** (see `_shared.md` § Scoring System): pass / caution / fail, with the specific evidence found or missing — not just a score, name what you saw
 - TL;DR in 1 sentence
 
 ### Geo-mismatch check

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -44,6 +44,7 @@ Table with:
 - Seniority
 - Remote (full/hybrid/onsite)
 - Team size (if mentioned)
+- **Culture screen** (see `_shared.md` § Culture Screen): pass / caution / fail, with the specific evidence found or missing — not just a score, name what you saw
 - TL;DR in 1 sentence
 
 ### Geo-mismatch check


### PR DESCRIPTION
## Problem
The current scoring logic doesn't structurally penalize a role that has a very high technical/skills match but is a fundamentally poor culture/environment fit. Previously, "Cultural signals" was largely an unscored vibe check, allowing roles to score artificially high.

## Solution
This PR introduces a structured "Cultural signals" scoring dimension that acts as a cap:
- Reads `culture_screen.require` criteria from the user's `profile.yml`.
- Cross-references these requirements against JD evidence (org chart depth, meeting-heavy language, team size).
- If the evidence actively points the wrong way, the culture score is **capped at 2/5**.
- Adds a mandatory `Culture screen` row to the Block A summary so this mismatch is surfaced visibly.
- Forces an explicit warning for any role that scores 4.5+ overall but fails the culture screen.


## Issue 

[Feature: Add "Culture Screen" scoring dimension to evaluation logic
 #1643](https://github.com/santifer/career-ops/issues/1643)
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced an explicit rubric for evaluating **“Cultural signals”**, including evidence collection against culture-screen requirements and clear score mapping.
  * Added stronger handling for missing or contradictory culture evidence, including score caps and a mandatory warning when overall fit is high but **“Cultural signals”** is low.
  * Updated Block A **Culture screen** to require **pass/caution/fail** plus the specific evidence found (or explicitly noted as missing/contradicted).

* **Documentation**
  * Added **culture_screen** configuration guidance to the example profile and customization documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->