### PR TITLE
feat(pdf): allow intentional CV section reordering via --allow-reorder

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -4,12 +4,18 @@
  * generate-pdf.mjs — HTML → PDF via Playwright
  *
  * Usage:
- *   node career-ops/generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN]
+ *   node career-ops/generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder]
  *
  * --report links the generated PDF to its tracker/report number and records
  * the linkage in data/pdf-index.tsv so downstream tools (e.g. the TUI
  * dashboard's `d`/`D` hotkeys) can locate the exact PDF for an application.
  * Without --report a manifest row is still written, just unkeyed.
+ *
+ * --allow-reorder downgrades the CV section-order guard from a thrown error
+ * to a console warning, for JDs where the section order was deliberately
+ * tailored (e.g. Projects moved ahead of Education for a technical-heavy
+ * role) rather than accidentally scrambled by an agent. Without this flag,
+ * any divergence from cv.md's section order still fails generation.
  *
  * Requires: @playwright/test (or playwright) installed.
  * Uses Chromium headless to render the HTML and produce a clean, ATS-parseable PDF.
@@ -156,7 +162,16 @@ function extractSourceSectionOrder(markdown) {
   return sections;
 }
 
-function validateCvSectionOrder(html, cvMarkdown) {
+/**
+ * @param {string} html
+ * @param {string} cvMarkdown
+ * @param {{ allowReorder?: boolean }} [options] - `allowReorder` downgrades a
+ *   detected divergence from a thrown error to a console warning, for JDs
+ *   where the section order was deliberately tailored (e.g. Projects moved
+ *   ahead of Education for a technical-heavy role) rather than accidentally
+ *   scrambled by an agent. See #1646.
+ */
+export function validateCvSectionOrder(html, cvMarkdown, { allowReorder = false } = {}) {
   const rendered = extractRenderedSectionOrder(html);
   const source = extractSourceSectionOrder(cvMarkdown);
   if (rendered.length < 2 || source.length < 2) return;
@@ -174,7 +189,12 @@ function validateCvSectionOrder(html, cvMarkdown) {
         .filter(section => renderedComparable.some(renderedSection => renderedSection.key === section.key))
         .map(section => section.title)
         .join(' -> ');
-      throw new Error(`CV section order diverges from cv.md: rendered ${renderedOrder}; cv.md ${sourceOrder}`);
+      const message = `CV section order diverges from cv.md: rendered ${renderedOrder}; cv.md ${sourceOrder}`;
+      if (allowReorder) {
+        console.warn(`⚠️  ${message} (proceeding — --allow-reorder set)`);
+        return;
+      }
+      throw new Error(message);
     }
   }
 }
@@ -261,13 +281,15 @@ async function generatePDF() {
   const args = process.argv.slice(2);
 
   // Parse arguments
-  let inputPath, outputPath, format = 'a4', reportNum = '';
+  let inputPath, outputPath, format = 'a4', reportNum = '', allowReorder = false;
 
   for (const arg of args) {
     if (arg.startsWith('--format=')) {
       format = arg.split('=')[1].toLowerCase();
     } else if (arg.startsWith('--report=')) {
       reportNum = arg.split('=')[1].trim();
+    } else if (arg === '--allow-reorder') {
+      allowReorder = true;
     } else if (!inputPath) {
       inputPath = arg;
     } else if (!outputPath) {
@@ -276,7 +298,7 @@ async function generatePDF() {
   }
 
   if (!inputPath || !outputPath) {
-    console.error('Usage: node generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN]');
+    console.error('Usage: node generate-pdf.mjs <input.html> <output.pdf> [--format=letter|a4] [--report=NNN] [--allow-reorder]');
     process.exit(1);
   }
 
@@ -317,7 +339,7 @@ async function generatePDF() {
   } catch (err) {
     if (err?.code !== 'ENOENT') throw err;
   }
-  validateCvSectionOrder(html, cvMarkdown);
+  validateCvSectionOrder(html, cvMarkdown, { allowReorder });
 
   // Normalize text for ATS compatibility (issue #1)
   const normalized = normalizeTextForATS(html);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -752,6 +752,49 @@ if (generatePdfScript.includes('opts.reportNum') && generatePdfScript.includes('
 } else {
   fail('renderHtmlToPdf does not read manifest metadata from opts');
 }
+
+if (generatePdfScript.includes('--allow-reorder')) {
+  pass('generate-pdf documents --allow-reorder in its usage strings');
+} else {
+  fail('generate-pdf is missing --allow-reorder from its usage strings');
+}
+
+try {
+  const { validateCvSectionOrder } = await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
+  const cvMarkdown = '# Education\ntext\n# Work Experience\ntext\n# Projects\ntext';
+  const reorderedHtml = '<div class="section-title">Projects</div><div class="section-title">Education</div>';
+
+  let threw = false;
+  try {
+    validateCvSectionOrder(reorderedHtml, cvMarkdown);
+  } catch {
+    threw = true;
+  }
+  if (threw) {
+    pass('validateCvSectionOrder throws on a reordered CV by default (--allow-reorder unset)');
+  } else {
+    fail('validateCvSectionOrder should throw by default when section order diverges from cv.md');
+  }
+
+  const originalWarn = console.warn;
+  let warned = false;
+  console.warn = () => { warned = true; };
+  let threwWithFlag = false;
+  try {
+    validateCvSectionOrder(reorderedHtml, cvMarkdown, { allowReorder: true });
+  } catch {
+    threwWithFlag = true;
+  } finally {
+    console.warn = originalWarn;
+  }
+  if (!threwWithFlag && warned) {
+    pass('validateCvSectionOrder({ allowReorder: true }) warns instead of throwing on a reordered CV');
+  } else {
+    fail('validateCvSectionOrder({ allowReorder: true }) should warn, not throw, and should not silently do neither');
+  }
+} catch (e) {
+  fail(`validateCvSectionOrder allowReorder tests crashed: ${e.message}`);
+}
 try {
   const { repoRelativeManifestPath, injectPrintPageCss } = await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
   const insideHtmlPath = join(ROOT, 'templates', 'cv-template.html');


### PR DESCRIPTION
## Summary
- \`validateCvSectionOrder()\` (added in #817 to catch an agent accidentally scrambling CV sections) throws whenever the generated HTML's section order diverges from \`cv.md\`, with no way to distinguish that from a **deliberate**, JD-driven reorder (e.g. moving "Projects" ahead of "Education" for a technical-heavy role).
- This is a documented, standard tailoring practice, not an edge case — see citations in #1646.
- Adds an \`--allow-reorder\` CLI flag to \`generate-pdf.mjs\`. Without it, behavior is unchanged (any divergence throws, blocking generation — #817's original protection stays intact). With it, the divergence is downgraded to \`console.warn\` so generation proceeds, but the reorder is still visibly logged, not silently bypassed.
- \`validateCvSectionOrder\` is now exported for direct testing.

## Test plan
- [x] Default behavior unchanged: a reordered CV still throws without the flag
- [x] With \`{ allowReorder: true }\`, the same reorder warns instead of throwing
- [x] \`--allow-reorder\` documented in the file header usage block and the CLI usage error string
- [x] \`node test-all.mjs\` — 1294 passed / 0 failed

Fixes #1646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line option to allow CV section reordering during PDF generation.
  * When enabled, section order mismatches now show a warning instead of stopping the process.
* **Bug Fixes**
  * Improved validation behavior for reordered CV content, giving users more control over how mismatches are handled.
* **Tests**
  * Added coverage for the new option, including default failure behavior and warning-based handling when reordering is allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->