### PR TITLE
fix(web): ux-audit cleanup — CostBadge global CSS + last sub-44 stragglers

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -199,3 +199,13 @@ html {
 }
 .report-prose tbody tr:hover { background: color-mix(in srgb, var(--fg) 3%, transparent); }
 .report-prose img { border-radius: 0.5rem; }
+
+/* CostBadge (co-located → global): cost color-semantics, see cost-badge.tsx */
+.co-cost{display:inline-flex;align-items:center;gap:.28rem;border-radius:999px;font-weight:600;line-height:1;white-space:nowrap;border:1px solid transparent}
+.co-cost[data-size="xs"]{font-size:10.5px;padding:.16rem .4rem;letter-spacing:.04em;text-transform:uppercase}
+.co-cost[data-size="sm"]{font-size:11px;padding:.24rem .5rem}
+.co-cost[data-tone="free"]{color:hsl(162 91% 24%);background:hsl(160 64% 46% / .12);border-color:hsl(160 64% 46% / .28)}
+html.dark .co-cost[data-tone="free"]{color:hsl(158 64% 60%);background:hsl(158 64% 52% / .13);border-color:hsl(158 64% 52% / .26)}
+.co-cost[data-tone="spend"]{color:hsl(35 9% 34%);background:hsl(35 8% 46% / .12);border-color:hsl(35 8% 46% / .26)}
+html.dark .co-cost[data-tone="spend"]{color:hsl(35 8% 70%);background:hsl(35 6% 60% / .12);border-color:hsl(35 6% 60% / .24)}
+.co-cost svg{width:.85em;height:.85em}

--- a/web/src/components/cost/cost-badge.tsx
+++ b/web/src/components/cost/cost-badge.tsx
@@ -7,18 +7,7 @@ import { COST_META, type CostClass } from "@/lib/explore-cost";
 // celebrate, and crucially it must NOT be brand-orange: orange is reserved for
 // the primary action (e.g. "Run your first FREE scan"), so an orange spend badge
 // would collide ("go/free" vs "costs") and shout louder than the action itself.
-// Muted spend AA-verified in both themes. Co-located style per the Tailwind v4
-// stale-CSS HMR gotcha.
-const CSS = `
-.co-cost{display:inline-flex;align-items:center;gap:.28rem;border-radius:999px;font-weight:600;line-height:1;white-space:nowrap;border:1px solid transparent}
-.co-cost[data-size="xs"]{font-size:10.5px;padding:.16rem .4rem;letter-spacing:.04em;text-transform:uppercase}
-.co-cost[data-size="sm"]{font-size:11px;padding:.24rem .5rem}
-.co-cost[data-tone="free"]{color:hsl(162 91% 24%);background:hsl(160 64% 46% / .12);border-color:hsl(160 64% 46% / .28)}
-html.dark .co-cost[data-tone="free"]{color:hsl(158 64% 60%);background:hsl(158 64% 52% / .13);border-color:hsl(158 64% 52% / .26)}
-.co-cost[data-tone="spend"]{color:hsl(35 9% 34%);background:hsl(35 8% 46% / .12);border-color:hsl(35 8% 46% / .26)}
-html.dark .co-cost[data-tone="spend"]{color:hsl(35 8% 70%);background:hsl(35 6% 60% / .12);border-color:hsl(35 6% 60% / .24)}
-.co-cost svg{width:.85em;height:.85em}
-`;
+// Muted spend AA-verified in both themes. Styles live in globals.css (.co-cost).
 
 export function CostBadge({ kind, size = "sm", className = "" }: { kind: CostClass; size?: "xs" | "sm"; className?: string }) {
   const tone = kind === "spend" ? "spend" : "free";
@@ -26,7 +15,6 @@ export function CostBadge({ kind, size = "sm", className = "" }: { kind: CostCla
   const meta = COST_META[kind];
   return (
     <span className={`co-cost ${className}`} data-tone={tone} data-size={size} title={meta.tip}>
-      <style>{CSS}</style>
       <Icon aria-hidden />
       {meta.label}
     </span>

--- a/web/src/components/explore/discovery-card.tsx
+++ b/web/src/components/explore/discovery-card.tsx
@@ -66,7 +66,7 @@ export function DiscoveryCard({ offer, inPipeline, evaluatedN }: { offer: Discov
     <div className="co-rise group flex min-w-0 flex-col gap-2.5 rounded-xl border border-border bg-surface/40 p-3.5 text-left transition-all hover:-translate-y-0.5 hover:border-brand/30 hover:shadow-sm">
       <div className="flex items-start gap-3">
         <Logo company={offer.company} />
-        <a href={offer.url} target="_blank" rel="noopener noreferrer" className="block min-w-0 flex-1">
+        <a href={offer.url} target="_blank" rel="noopener noreferrer" className="block min-w-0 flex-1 max-sm:min-h-[44px]">
           <h3 className={`${instrumentSerif.className} truncate text-[17px] leading-tight text-foreground transition-colors group-hover:text-brand`}>{offer.title}</h3>
           <p className="mt-0.5 truncate text-[13px] text-muted">
             {offer.company}

--- a/web/src/components/explore/explorer-view.tsx
+++ b/web/src/components/explore/explorer-view.tsx
@@ -242,7 +242,7 @@ function DiscoverBar({ canDiscover, onDiscover, label }: { canDiscover: boolean;
         type="button"
         disabled={!canDiscover}
         onClick={onDiscover}
-        className="inline-flex items-center gap-2 rounded-xl bg-brand px-5 py-2.5 text-sm font-semibold text-brand-foreground shadow-sm transition-all hover:brightness-110 disabled:opacity-50"
+        className="inline-flex items-center gap-2 rounded-xl bg-brand px-5 py-2.5 text-sm font-semibold text-brand-foreground shadow-sm transition-all hover:brightness-110 disabled:opacity-50 max-sm:min-h-[44px]"
       >
         <Compass className="size-4" /> {label}
       </button>

--- a/web/src/components/explore/filter-builder.tsx
+++ b/web/src/components/explore/filter-builder.tsx
@@ -182,7 +182,7 @@ export function FilterBuilder({
       <button
         type="button"
         onClick={() => setAdvanced((v) => !v)}
-        className="inline-flex items-center gap-1.5 text-[12px] text-muted hover:text-foreground transition-colors"
+        className="inline-flex items-center gap-1.5 text-[12px] text-muted hover:text-foreground transition-colors max-sm:min-h-[44px]"
       >
         <SlidersHorizontal className="size-3.5" />
         Location &amp; scope


### PR DESCRIPTION
## What

The agreed post-audit cleanup (audit #2 residue + the maintainer's gate-sweep catches):

- **P2-C** — CostBadge injected a `<style>` **per instance** (N badges = N style nodes, polluted textContent). Rules moved **verbatim** to `globals.css` (incl. `html.dark` variants); the component renders markup only. Was deferred until #1627 merged (conflicting `cost-badge.tsx` edits).
- **"Location & scope" toggle** (filter-builder) 18px → 44 on mobile — the worst remaining target in the app.
- **DiscoverBar** "Discover (free)" / "Re-cast (free)" 40 → 44 (one button component covers both labels).
- **DiscoveryCard title link** 43 → 44 — the audit's 1px note. Note: the component is shared by Today's fresh matches **and** Explore, so both surfaces align at 44 (mobile-only, `max-sm:`).

With this, **/explore joins pipeline and portals at 0 sub-44 controls**.

## Not in this PR (own follow-up)

Migrating hand-rolled buttons to the shared `Button` primitive (which now carries 44 defaults) — structural, dozens of call-sites, better as its own mechanical reviewable diff.

## Verification

typecheck + `next build` green · `.co-cost` rules byte-identical after the move · class-only + CSS relocation, zero logic changes, desktop untouched. ux design-review pending per the usual cadence.

Scope: `web/` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved global styling for cost badges, including compact sizing, free/spend color variants, dark mode support, and icon sizing.
* **Refactor**
  * Simplified cost badge rendering to use shared styles instead of embedded styling, with no change to how it looks or behaves.
* **Bug Fixes**
  * Updated key buttons and links in explore-related views to meet minimum touch-target height on small screens for better mobile usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->