### PR TITLE
docs(portals): add example stanzas for 6 single-company/branded providers

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -633,6 +633,36 @@ search_queries:
 #   provider: dassault                    # optional — 3ds.com host also auto-detects
 #   enabled: true                         # ~445 English postings (zero-token XML)
 #
+# - name: Deutsche Bahn                   # single-company; db.jobs Avature front
+#   careers_url: https://db.jobs          # auto-detects; SSR search, paginated over HTTP
+#   provider: deutschebahn                # optional — db.jobs host also auto-detects
+#   enabled: true
+#
+# - name: Heckler & Koch                  # single-company; SSR Nuxt vacancy list
+#   careers_url: https://www.heckler-koch.com/de/Karriere/Stellenangebote
+#   provider: hecklerkoch                 # optional — heckler-koch.com host also auto-detects
+#   enabled: true
+#
+# - name: Rheinmetall                     # single-company; SSR Nuxt vacancy list
+#   careers_url: https://www.rheinmetall.com/en/career/vacancies
+#   provider: rheinmetall                 # optional — rheinmetall.com host also auto-detects
+#   enabled: true
+#
+# - name: OHB                             # Cornerstone OnDemand (csod) branded site
+#   careers_url: https://career-ohb.csod.com/ux/ats/careersite/4/home?c=career-ohb
+#   provider: csod                        # anonymous-JWT bootstrap, then public search API
+#   enabled: true
+#
+# - name: RENK                            # softgarden hosted job widget
+#   careers_url: https://renk-group.softgarden.io/de/widgets/jobs
+#   provider: softgarden
+#   enabled: true
+#
+# - name: Mercedes-Benz                   # BeeSite (milch & zucker) search backend
+#   careers_url: https://mercedes-benz.app.beesite.de   # the *.app.beesite.de host, not the branded front
+#   provider: beesite
+#   enabled: true
+#
 # -- Remote-job feeds (no careers_url, no extra fields) --
 # title_filter / location_filter defined above still apply.
 #


### PR DESCRIPTION
Companion to the provider docs. Six providers had no example in `templates/portals.example.yml`, so configuring them meant reading source. Added commented stanzas in the built-in examples section — **each verified** to auto-detect via the provider's `detect()` with the shown `careers_url` (I ran each locally):

- **Deutsche Bahn** (`deutschebahn`) — `careers_url: https://db.jobs`
- **Heckler & Koch** (`hecklerkoch`) — `heckler-koch.com/…/Stellenangebote`
- **Rheinmetall** (`rheinmetall`) — `rheinmetall.com/en/career/vacancies`
- **Cornerstone OnDemand** (`csod`) — `<tenant>.csod.com/ux/ats/careersite/…`
- **softgarden** — `<tenant>.softgarden.io/<lang>/widgets/jobs`
- **BeeSite** (`beesite`) — the `<tenant>.app.beesite.de` host (not the branded front)

Deliberately **skipped** `radancy` / `phenom` / `tkms`: their `detect()` only matches specific hosts (e.g. phenom matches `phenompeople.com`, not the branded `careers.*`) or needs a config block I couldn't exemplify accurately — better no stanza than a wrong one. `validate-portals`: 0 errors, 0 warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six new example tracked-company entries for major employers, each with enabled status, careers links, and provider routing support.
  * Expanded the sample portal configuration to cover more company career sites before the remote-job feeds section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->