### PR TITLE
feat(providers): add EchoJobs zero-auth JSON aggregator provider

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -15,6 +15,7 @@ are shared helpers and are not loaded as providers.
 | BambooHR | API | Auto-detects `<tenant>.bamboohr.com` careers pages, reads `/careers/list`, and follows public detail endpoints for job URLs. |
 | Breezy HR | API | Auto-detects `<tenant>.breezy.hr` boards and reads the public JSON position feed. |
 | Comeet / Spark Hire Recruit | API | Uses Comeet's public careers API. Provide the full API URL with `api:` or `careers_url`; it cannot derive the endpoint from a branded careers page. |
+| EchoJobs | API | Reads the board-wide `https://echojobs.io/api/jobs` JSON feed (tech jobs aggregated from company ATS boards). Configure with `provider: echojobs`; paginates `?page=N` up to `max_pages` (default 3), then scanner filters apply. Job URLs point at the original ATS posting. |
 | Get on Board | API | Reads the public `https://www.getonbrd.com/api/v0/categories/programming/jobs` JSON:API feed (remote/LatAm-heavy tech roles). Configure with `provider: getonbrd`; paginates `?page=N` up to `max_pages` (default 3) over the programming category (`expand[]=company`), then scanner filters apply. |
 | Glints | API | Uses Glints' public GraphQL job search endpoint. Configure with `provider: glints`; query and filters can be set on the portal entry. |
 | Greenhouse | API | Handles explicit `api:` URLs and auto-detects public Greenhouse board URLs for the boards API. |

--- a/providers/echojobs.mjs
+++ b/providers/echojobs.mjs
@@ -108,15 +108,15 @@ export default {
   },
 
   async fetch(entry, ctx) {
-    assertEchojobsUrl(FEED_BASE);
     const maxPages = resolveMaxPages(entry);
     const fallbackCompany = entry?.name;
     const out = [];
 
     for (let page = 1; page <= maxPages; page++) {
-      const url = `${FEED_BASE}?per_page=${PER_PAGE}&page=${page}`;
-      // redirect:'error' prevents SSRF via server-side redirects; combined with
-      // assertEchojobsUrl above it keeps the feed request pinned to echojobs.io.
+      // Validate the URL actually fetched (not just a constant) so the host pin
+      // is meaningful, then redirect:'error' blocks SSRF via server-side
+      // redirects — together they keep every page request on echojobs.io.
+      const url = assertEchojobsUrl(`${FEED_BASE}?per_page=${PER_PAGE}&page=${page}`);
       const json = /** @type {any} */ (await ctx.fetchJson(url, { redirect: 'error' }));
       if (!json || !Array.isArray(json.jobs)) {
         throw new Error(

--- a/providers/echojobs.mjs
+++ b/providers/echojobs.mjs
@@ -1,0 +1,134 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// EchoJobs provider — board-wide public JSON feed of tech jobs aggregated from
+// company ATS boards (https://echojobs.io/api/jobs). Public, zero-auth, paginated
+// (`?page=N&per_page=M`). The broad feed is fetched so scan.mjs's title_filter
+// gates on the configured titles; pages are pulled until one comes back short or
+// the page cap is reached (default 3, override with `max_pages`).
+//
+// Each row's `url` is the ORIGINAL ATS posting (e.g. jobs.ashbyhq.com/…), so —
+// unlike the feed host — job URLs are not pinned to echojobs.io; only the feed
+// fetch is host-locked. The url is display-only and never server-fetched here.
+//
+// Wire in via a `job_boards:` entry with `provider: echojobs`.
+
+const FEED_BASE = 'https://echojobs.io/api/jobs';
+const TRUSTED_HOST = 'echojobs.io';
+const PER_PAGE = 100;
+const DEFAULT_MAX_PAGES = 3;
+const MAX_PAGES_CAP = 50;
+
+/** @param {string} url */
+function assertEchojobsUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`echojobs: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`echojobs: URL must use HTTPS: ${url}`);
+  if (parsed.hostname !== TRUSTED_HOST) {
+    throw new Error(`echojobs: untrusted hostname "${parsed.hostname}" — must be ${TRUSTED_HOST}`);
+  }
+  return url;
+}
+
+/** Resolve the page cap: a positive integer `max_pages` on the entry, capped. */
+function resolveMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES_CAP);
+  return DEFAULT_MAX_PAGES;
+}
+
+/**
+ * Normalize a single EchoJobs feed item. Exported for tests.
+ *
+ * Field mapping → the normalized Job shape:
+ *   - title:    `title`, trimmed (items without one are dropped).
+ *   - url:      `url` — an absolute `https:` posting URL on the company's own ATS
+ *               host (NOT echojobs.io), used as the dedup key. Non-https/malformed
+ *               URLs drop the item.
+ *   - company:  `company_name`, falling back to the portal entry name, then "EchoJobs".
+ *   - location: the joined `locations` array; falls back to "Remote" when the
+ *               posting has no listed place but `remote_type` is remote/hybrid.
+ *   - postedAt: `posted_at` (already epoch ms) when a positive finite number.
+ *
+ * @param {any} j
+ * @param {string} [fallbackCompany]
+ * @returns {{ title: string, url: string, company: string, location: string, postedAt?: number } | null}
+ */
+export function normalizeEchojobsJob(j, fallbackCompany) {
+  if (!j || typeof j !== 'object') return null;
+
+  const title = typeof j.title === 'string' ? j.title.trim() : '';
+  if (!title) return null;
+
+  // url must be an absolute https link; it lives on the company's ATS host, so
+  // it is NOT restricted to echojobs.io.
+  let url = '';
+  const rawUrl = typeof j.url === 'string' ? j.url.trim() : '';
+  if (rawUrl) {
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol === 'https:') url = parsed.href;
+    } catch {
+      // malformed URL → leave url = '' → dropped below
+    }
+  }
+  if (!url) return null;
+
+  const company =
+    typeof j.company_name === 'string' && j.company_name.trim()
+      ? j.company_name.trim()
+      : fallbackCompany || 'EchoJobs';
+
+  let location = '';
+  if (Array.isArray(j.locations)) {
+    location = j.locations
+      .filter((l) => typeof l === 'string' && l.trim())
+      .map((l) => l.trim())
+      .join(', ');
+  }
+  if (!location && (j.remote_type === 'remote' || j.remote_type === 'hybrid')) location = 'Remote';
+
+  /** @type {{ title: string, url: string, company: string, location: string, postedAt?: number }} */
+  const job = { title, url, company, location };
+  // `posted_at` is already epoch milliseconds.
+  if (Number.isFinite(j.posted_at) && j.posted_at > 0) job.postedAt = j.posted_at;
+  return job;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'echojobs',
+
+  detect(entry) {
+    return entry?.provider === 'echojobs' ? { url: FEED_BASE } : null;
+  },
+
+  async fetch(entry, ctx) {
+    assertEchojobsUrl(FEED_BASE);
+    const maxPages = resolveMaxPages(entry);
+    const fallbackCompany = entry?.name;
+    const out = [];
+
+    for (let page = 1; page <= maxPages; page++) {
+      const url = `${FEED_BASE}?per_page=${PER_PAGE}&page=${page}`;
+      // redirect:'error' prevents SSRF via server-side redirects; combined with
+      // assertEchojobsUrl above it keeps the feed request pinned to echojobs.io.
+      const json = /** @type {any} */ (await ctx.fetchJson(url, { redirect: 'error' }));
+      if (!json || !Array.isArray(json.jobs)) {
+        throw new Error(
+          `echojobs: unexpected API response on page ${page} — expected { jobs: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`,
+        );
+      }
+      for (const j of json.jobs) {
+        const normalized = normalizeEchojobsJob(j, fallbackCompany);
+        if (normalized) out.push(normalized);
+      }
+      if (json.jobs.length < PER_PAGE) break; // short page → last page reached
+    }
+    return out;
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -672,6 +672,7 @@ search_queries:
 #
 # - name: EchoJobs                        # tech jobs aggregated from company ATS boards
 #   provider: echojobs
+#   max_pages: 3                          # 100 jobs/page; raise for deeper coverage
 #   enabled: true
 #
 # - name: Hacker News "Who is hiring?"    # monthly "Ask HN: Who is hiring?" thread

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -670,6 +670,10 @@ search_queries:
 #   provider: jobicy
 #   enabled: true
 #
+# - name: EchoJobs                        # tech jobs aggregated from company ATS boards
+#   provider: echojobs
+#   enabled: true
+#
 # - name: Hacker News "Who is hiring?"    # monthly "Ask HN: Who is hiring?" thread
 #   provider: hackernews
 #   enabled: true

--- a/tests/providers/echojobs.test.mjs
+++ b/tests/providers/echojobs.test.mjs
@@ -41,8 +41,12 @@ try {
 
   // remote fallback when no listed place
   const remote = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/1', locations: [], remote_type: 'remote' });
-  if (remote?.location === 'Remote') pass('normalizeEchojobsJob falls back to "Remote" for a placeless remote/hybrid role');
-  else fail(`remote fallback => ${JSON.stringify(remote?.location)}`);
+  const hybrid = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/2', remote_type: 'hybrid' });
+  if (remote?.location === 'Remote' && hybrid?.location === 'Remote') {
+    pass('normalizeEchojobsJob falls back to "Remote" for a placeless remote OR hybrid role');
+  } else {
+    fail(`remote/hybrid fallback => ${JSON.stringify([remote?.location, hybrid?.location])}`);
+  }
 
   // company fallback to the entry name
   const bare = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/1' }, 'EntryName');

--- a/tests/providers/echojobs.test.mjs
+++ b/tests/providers/echojobs.test.mjs
@@ -1,0 +1,101 @@
+// tests/providers/echojobs.test.mjs — provider-contract tests for the EchoJobs
+// board-wide JSON aggregator (providers/echojobs.mjs).
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — echojobs');
+
+try {
+  const echojobsModule = await import(pathToFileURL(join(ROOT, 'providers/echojobs.mjs')).href);
+  const echojobs = echojobsModule.default;
+  const { normalizeEchojobsJob } = echojobsModule;
+
+  if (echojobs.id === 'echojobs') pass('echojobs.id is "echojobs"');
+  else fail(`echojobs.id is ${JSON.stringify(echojobs.id)}`);
+
+  // detect() — explicit provider selection only (board-wide feed)
+  const hit = echojobs.detect({ name: 'EchoJobs', provider: 'echojobs' });
+  if (hit && hit.url === 'https://echojobs.io/api/jobs') pass('echojobs.detect() resolves provider:echojobs → feed URL');
+  else fail(`echojobs.detect() returned ${JSON.stringify(hit)}`);
+  if (echojobs.detect({ name: 'X' }) === null) pass('echojobs.detect() returns null without provider:echojobs');
+  else fail('echojobs.detect() should require provider:echojobs');
+
+  // normalizeEchojobsJob — field mapping, external ATS url kept, postedAt (ms)
+  const j = {
+    title: '  Senior Go Engineer  ',
+    url: 'https://jobs.ashbyhq.com/acme/abc-123',
+    company_name: 'Acme',
+    locations: ['San Francisco, CA', 'New York, NY'],
+    remote_type: 'on_site',
+    posted_at: 1783380913765,
+  };
+  const n = normalizeEchojobsJob(j, 'Fallback');
+  if (n && n.title === 'Senior Go Engineer' && n.company === 'Acme' &&
+      n.url === 'https://jobs.ashbyhq.com/acme/abc-123' && n.location === 'San Francisco, CA, New York, NY' &&
+      n.postedAt === 1783380913765) {
+    pass('normalizeEchojobsJob maps title/company/url/location/postedAt and keeps the external ATS URL');
+  } else {
+    fail(`normalizeEchojobsJob => ${JSON.stringify(n)}`);
+  }
+
+  // remote fallback when no listed place
+  const remote = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/1', locations: [], remote_type: 'remote' });
+  if (remote?.location === 'Remote') pass('normalizeEchojobsJob falls back to "Remote" for a placeless remote/hybrid role');
+  else fail(`remote fallback => ${JSON.stringify(remote?.location)}`);
+
+  // company fallback to the entry name
+  const bare = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/1' }, 'EntryName');
+  if (bare?.company === 'EntryName') pass('normalizeEchojobsJob falls back to the entry name for company');
+  else fail(`company fallback => ${JSON.stringify(bare?.company)}`);
+
+  // drops: no title, non-https url, missing url
+  if (normalizeEchojobsJob({ url: 'https://x/1' }) === null) pass('normalizeEchojobsJob drops a title-less item');
+  else fail('title-less item should be dropped');
+  if (normalizeEchojobsJob({ title: 'X', url: 'http://insecure/1' }) === null) pass('normalizeEchojobsJob drops a non-https url');
+  else fail('non-https url should be dropped');
+  if (normalizeEchojobsJob({ title: 'X' }) === null) pass('normalizeEchojobsJob drops an item with no url');
+  else fail('url-less item should be dropped');
+
+  // fetch() — pagination: accumulates across pages, stops on a short page, and
+  // pins the feed request to echojobs.io with redirect:'error'.
+  const page1 = { jobs: Array.from({ length: 100 }, (_, i) => ({ title: `Job ${i}`, url: `https://jobs.ashbyhq.com/acme/${i}`, company_name: 'Acme' })) };
+  const page2 = { jobs: [{ title: 'Last', url: 'https://jobs.ashbyhq.com/acme/last', company_name: 'Acme' }] };
+  const calls = [];
+  const ctx = {
+    transport: 'http',
+    fetchJson: async (url, options) => {
+      calls.push(url);
+      if (options?.redirect !== 'error') throw new Error(`fetchJson without redirect:'error': ${JSON.stringify(options)}`);
+      if (new URL(url).hostname !== 'echojobs.io') throw new Error(`fetchJson off-host: ${url}`);
+      return new URL(url).searchParams.get('page') === '1' ? page1 : page2;
+    },
+    fetchText: async () => { throw new Error('fetchText should not be called'); },
+  };
+  const jobs = await echojobs.fetch({ name: 'EchoJobs', provider: 'echojobs' }, ctx);
+  if (jobs.length === 101) pass('echojobs.fetch() accumulates across pages and stops on the short page (100 + 1)');
+  else fail(`echojobs.fetch() returned ${jobs.length} jobs, expected 101`);
+  if (calls.length === 2) pass('echojobs.fetch() stopped after the short second page (2 requests)');
+  else fail(`echojobs.fetch() made ${calls.length} page requests, expected 2`);
+
+  // max_pages override caps pagination
+  const cappedCalls = [];
+  await echojobs.fetch(
+    { name: 'EchoJobs', provider: 'echojobs', max_pages: 1 },
+    { transport: 'http', fetchJson: async (u) => { cappedCalls.push(u); return page1; }, fetchText: async () => {} },
+  );
+  if (cappedCalls.length === 1) pass('echojobs.fetch() respects max_pages (stops after 1 page)');
+  else fail(`echojobs.fetch() max_pages=1 made ${cappedCalls.length} page calls`);
+
+  // unexpected shape throws
+  let threw = false;
+  try {
+    await echojobs.fetch({ name: 'EchoJobs', provider: 'echojobs' },
+      { transport: 'http', fetchJson: async () => ({ oops: true }), fetchText: async () => {} });
+  } catch { threw = true; }
+  if (threw) pass('echojobs.fetch() throws on an unexpected API response shape');
+  else fail('echojobs.fetch() should throw when the response has no jobs array');
+
+} catch (e) {
+  fail(`echojobs provider tests crashed: ${e.message}`);
+}


### PR DESCRIPTION
Part of #230.

Adds a provider for **EchoJobs** (echojobs.io), a board-wide tech-job aggregator with a public, no-auth JSON feed at `https://echojobs.io/api/jobs` — a source the built-in providers do not cover.

## What's here
- **`providers/echojobs.mjs`** — paginates `?page=N&per_page=100` up to `max_pages` (default 3), accumulating until a short page. Normalizes to the standard Job shape: `company_name` → company, the `locations[]` array → location (with a `Remote` fallback for placeless remote/hybrid roles), `posted_at` (already epoch ms) → `postedAt`. The **feed fetch** is SSRF-pinned to `echojobs.io` with `redirect:'error'`, but **job URLs are not host-pinned** — each points at the company's own ATS posting (`jobs.ashbyhq.com`, `jobs.lever.co`, …), which is the dedup key.
- **`tests/providers/echojobs.test.mjs`** — auto-discovered contract test: id, detect (explicit provider), normalize mapping + external-URL keep, remote/company fallbacks, drop rules (no title / non-https / no url), pagination (accumulate, short-stop, `max_pages`), and a bad-shape throw.
- **Docs** — `SUPPORTED_JOB_BOARDS.md` row + `portals.example.yml` stanza.

Verified live against the real feed (100 jobs/page, correct fields). Full `--quick`: **1398 passed, 0 failed**. `validate-portals`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the EchoJobs job board, importing jobs from its public feed and preserving original job posting links.
  * Added page-based fetching with a configurable maximum page limit (with a sensible default cap).

* **Bug Fixes**
  * Improved job-field validation to accept only properly formatted HTTPS job URLs.
  * Improved normalization defaults for missing company and remote/hybrid location details.

* **Tests**
  * Added provider contract tests covering detection, normalization, pagination, caps, and invalid feed handling.

* **Documentation**
  * Updated the supported job boards list and added an (inactive) EchoJobs entry to the example portals template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->