### PR TITLE
feat(offer-prep): negotiation reply-draft step — draft-only email from "Items to raise" (#1663)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,7 @@ Default modes are in `modes/` (English). Additional language-specific modes are 
 | Processes pending URLs | `pipeline` |
 | Batch processes offers | `batch` |
 | Asks about rejection patterns, wants to improve targeting, or wants to match interview answers to best-fit roles | `patterns` |
-| Receives an offer/contract and wants help understanding it before signing | `offer-prep` — clause walk with neutral tags + lawyer question list; describes, never judges; no verdicts, no online research |
+| Receives an offer/contract and wants help understanding it before signing | `offer-prep` — clause walk with neutral tags + lawyer question list; describes, never judges; no verdicts, no online research; optional draft-only negotiation reply email from the "Items to raise" list |
 | Wants to broaden the search with adjacent job titles suggested from the CV | `titles` |
 | Asks about follow-ups or application cadence | `followup` |
 | Wants to classify application replies and review updates | `reply-watch` — classifies candidate replies, matches them to applications, and suggests tracker updates |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ Default modes are in `modes/` (English). Language-specific modes live in `modes/
 | Processes pending URLs | `pipeline` |
 | Batch processes offers | `batch` |
 | Asks about rejection patterns, wants to improve targeting, or wants to match interview answers to best-fit roles | `patterns` |
-| Receives an offer/contract and wants help understanding it before signing | `offer-prep` — clause walk with neutral tags + lawyer question list; describes, never judges; no verdicts, no online research |
+| Receives an offer/contract and wants help understanding it before signing | `offer-prep` — clause walk with neutral tags + lawyer question list; describes, never judges; no verdicts, no online research; optional draft-only negotiation reply email from the "Items to raise" list |
 | Wants to broaden the search with adjacent job titles suggested from the CV | `titles` |
 | Asks about follow-ups or application cadence | `followup` |
 

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -27,7 +27,7 @@ These files contain your personal data, customizations, and work product. Update
 | `data/scan-history.tsv` | Your scan history |
 | `data/scan-runs.tsv` | Your per-run scan counters (appended by `scan.mjs`, read by `stats.mjs`) |
 | `data/follow-ups.md` | Your follow-up history |
-| `data/offers/*` | Your received offers/contracts, promise notes, and prep reports (PII — gitignored, written by the `offer-prep` mode) |
+| `data/offers/*` | Your received offers/contracts, promise notes, prep reports, and reply drafts (PII — gitignored, written by the `offer-prep` mode) |
 | `writing-samples/*` | Your personal writing samples for style calibration (except `writing-samples/README.md`, which is system-owned documentation delivered by updates) |
 | `reports/*` | Your evaluation reports |
 | `output/*` | Your generated PDFs |

--- a/modes/offer-prep.md
+++ b/modes/offer-prep.md
@@ -49,6 +49,8 @@ It is NOT:
    into `data/offers/{company-slug}/`
 3. `/career-ops offer-prep` — ask for the document
 4. Proactively: when a tracker row is being set to `Offer`, suggest this mode.
+5. `/career-ops offer-prep reply {company-slug}` — Step 8 on demand: draft
+   the negotiation reply email from an existing prep report.
 
 If the candidate asks "should I sign?": run the mode, and state plainly that
 that question belongs to the candidate and their lawyer — the output is the
@@ -244,6 +246,57 @@ already; Notes column links the prep file relative to the tracker
 (`offers/{company-slug}/prep-{date}.md`). Canonical states per
 `templates/states.yml`.
 
+## Step 8 — Reply draft (optional, on request)
+
+After delivering the prep report, offer once: "Want me to draft the reply
+email that raises these items with the employer?" Also runs on demand later
+(invocation 5, or the candidate asking in conversation). Never auto-generate
+— the candidate must ask or accept the offer.
+
+**Input gate (hard):** an existing `data/offers/{company-slug}/prep-{date}.md`
+is required — no prep report, no reply draft; run the prep first. Use the
+most recent prep file for the company unless the candidate points at another.
+
+**Traceability (hard):** every raised item in the draft must
+trace back to a line in the prep report's "Items to raise with the employer"
+section, plus anything the candidate adds in this conversation. Nothing new
+is introduced. If the candidate wants to raise something that isn't in the
+report, add it to that section first, then draft.
+
+**Posture (inherited from the hard guards above — each still absolute):**
+
+- Questions and topics, never demands: "Could we discuss the exercise
+  window?", never "I require…".
+- **Never submit. Never send email. Never click send.** Draft only — same
+  posture as `email` mode. The candidate reviews and sends manually.
+- No legal claims and no cited law in the reply — legal questions stay in
+  the lawyer list; the employer email never argues law.
+- No verdict or severity language — the draft raises items; it does not
+  characterize the contract.
+- `voice-dna.md` may inform tone if present (style only — it never
+  introduces factual claims).
+- Source-of-truth boundary applies: content comes exclusively from the prep
+  report, in-scope user files, and the current conversation.
+
+Write `data/offers/{company-slug}/reply-draft-{YYYY-MM-DD}.md`:
+
+```markdown
+# Reply Draft — {Company} — {Role}
+**Date:** {date} · **Source:** prep-{date}.md · draft only — review and send manually
+
+Subject: {subject}
+
+{email body — greeting; thanks and continued interest; each item as a
+question or topic, one short paragraph or bullet; collaborative close;
+signature}
+
+## Before you send
+- [ ] Every item is one you actually want to raise, phrased in your words
+- [ ] Lawyer questions answered first where the answer would change an ask
+- [ ] Names, dates, and figures checked against the contract
+- [ ] Sent from your own email client — this file sends nothing
+```
+
 ## Error handling
 
 - **No contract, only "I got an offer"** → run Steps 3–4 against notes.md /
@@ -254,3 +307,5 @@ already; Notes column links the prep file relative to the tracker
 - **Candidate pushes for a verdict** ("just tell me if it's fine") → restate
   the posture in one line and point at the two lists. Do not soften into an
   implied verdict.
+- **Reply draft requested, no prep report exists** → the Step 8 gate applies:
+  say so and offer to run the prep first. Never draft from the raw contract.

--- a/modes/offer-prep.md
+++ b/modes/offer-prep.md
@@ -275,8 +275,9 @@ report, add it to that section first, then draft.
   characterize the contract.
 - `voice-dna.md` may inform tone if present (style only — it never
   introduces factual claims).
-- Source-of-truth boundary applies: content comes exclusively from the prep
-  report, in-scope user files, and the current conversation.
+- Source-of-truth boundary (tighter for this step): content comes
+  exclusively from the prep report and the current conversation — no other
+  files. `voice-dna.md` above is a style channel, never a content source.
 
 Write `data/offers/{company-slug}/reply-draft-{YYYY-MM-DD}.md`:
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1192,6 +1192,23 @@ if (
   fail('offer-prep mode missing gates, promises file, absences/referenced-docs handling, lawyer list, fixed disclaimer, or attribution');
 }
 
+// --- offer-prep reply-draft step (#1663): opt-in, prep-gated, draft-only ---
+if (
+  offerPrepMode.includes('Step 8 — Reply draft (optional, on request)') &&
+  offerPrepMode.includes('Never auto-generate') &&
+  offerPrepMode.includes('no prep report, no reply draft') &&
+  offerPrepMode.includes('data/offers/{company-slug}/reply-draft-{YYYY-MM-DD}.md') &&
+  offerPrepMode.includes('trace back to a line in the prep report') &&
+  offerPrepMode.includes('Never submit. Never send email. Never click send.') &&
+  offerPrepMode.includes('never demands') &&
+  offerPrepMode.includes('No legal claims and no cited law in the reply') &&
+  offerPrepMode.includes('Before you send')
+) {
+  pass('offer-prep reply-draft step is opt-in, prep-report-gated, traceable, questions-not-demands, draft-only, and law-free (#1663)');
+} else {
+  fail('offer-prep reply-draft step missing (or lost its prep-report gate, reply-draft path, traceability rule, never-send guard, questions-not-demands framing, no-legal-claims rule, or checklist) (#1663)');
+}
+
 const routerSkill = readFile('.agents/skills/career-ops/SKILL.md');
 if (
   /argument-hint:.*offer-prep/.test(routerSkill) &&

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1193,6 +1193,9 @@ if (
 }
 
 // --- offer-prep reply-draft step (#1663): opt-in, prep-gated, draft-only ---
+const replyDraftStep = offerPrepMode.includes('Step 8 — Reply draft')
+  ? offerPrepMode.slice(offerPrepMode.indexOf('Step 8 — Reply draft'), offerPrepMode.indexOf('## Error handling'))
+  : '';
 if (
   offerPrepMode.includes('Step 8 — Reply draft (optional, on request)') &&
   offerPrepMode.includes('Never auto-generate') &&
@@ -1202,11 +1205,13 @@ if (
   offerPrepMode.includes('Never submit. Never send email. Never click send.') &&
   offerPrepMode.includes('never demands') &&
   offerPrepMode.includes('No legal claims and no cited law in the reply') &&
-  offerPrepMode.includes('Before you send')
+  offerPrepMode.includes('Before you send') &&
+  replyDraftStep.includes('exclusively from the prep report and the current conversation') &&
+  !replyDraftStep.includes('in-scope user files')
 ) {
-  pass('offer-prep reply-draft step is opt-in, prep-report-gated, traceable, questions-not-demands, draft-only, and law-free (#1663)');
+  pass('offer-prep reply-draft step is opt-in, prep-report-gated, traceable, questions-not-demands, draft-only, law-free, and sourced from prep report + conversation only (#1663)');
 } else {
-  fail('offer-prep reply-draft step missing (or lost its prep-report gate, reply-draft path, traceability rule, never-send guard, questions-not-demands framing, no-legal-claims rule, or checklist) (#1663)');
+  fail('offer-prep reply-draft step missing (or lost its prep-report gate, reply-draft path, traceability rule, never-send guard, questions-not-demands framing, no-legal-claims rule, checklist, or prep-report+conversation-only source boundary) (#1663)');
 }
 
 const routerSkill = readFile('.agents/skills/career-ops/SKILL.md');


### PR DESCRIPTION
## Summary

Adds the reply-draft step announced in offer-prep v1's follow-up candidates (#1608): **Step 8 — Reply draft (optional, on request)** in `modes/offer-prep.md`. On request — offered once after the prep report is delivered, or on demand later — it drafts the negotiation reply email from the prep report's "Items to raise with the employer" section, writing `data/offers/{company-slug}/reply-draft-{date}.md` with subject + body + a short "before you send" checklist.

Posture (inherited from v1, restated as hard rules in the step):

- **Prep-report gate:** an existing `data/offers/{company-slug}/prep-{date}.md` is required — no prep report, no reply draft. Requesting a draft without one routes to running the prep first (new Error-handling bullet), never to drafting from the raw contract.
- **Never auto-generated** — the candidate must ask or accept the one-time offer.
- **Traceability:** every raised item traces back to a line in the prep report's "Items to raise" section (plus what the candidate says in conversation); nothing new is introduced.
- **Questions and topics, never demands** — "Could we discuss the exercise window?", never "I require…".
- **Draft-only, `email`-mode posture:** never submits, never sends, never clicks send; the candidate reviews and sends manually.
- **No legal claims or cited law in the reply** — legal questions stay in the lawyer list; **no verdict/severity language** — the draft raises items, it does not characterize the contract.
- `voice-dna.md` informs tone only (never facts); source-of-truth boundary applies.

Supporting changes:

- `modes/offer-prep.md` — new invocation entry (`offer-prep reply {company-slug}`) and Error-handling bullet for the missing-prep case.
- `test-all.mjs` — mode-integrity check in the existing offer-prep block asserting the step exists, is prep-gated, writes the `reply-draft-` path, keeps the never-send guard, questions-not-demands framing, no-legal-claims rule, traceability, and the checklist.
- `CLAUDE.md` / `AGENTS.md` — offer-prep Skill Modes rows extended in sync ("optional draft-only negotiation reply email from the \"Items to raise\" list").
- `DATA_CONTRACT.md` — `data/offers/*` row now mentions reply drafts (still PII, still gitignored).

Closes #1663

## Validation

- `node test-all.mjs` → **1497 passed, 0 failed, 2 warnings** (env-only: `cv-sync-check.mjs` without user data, Playwright MCP detection).
- New check green: `offer-prep reply-draft step is opt-in, prep-report-gated, traceable, questions-not-demands, draft-only, and law-free (#1663)`.
- 55b posture freeze untouched and green — no verdict vocabulary or severity symbols introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “offer-prep” skill mode with an optional Step 8 to draft a negotiation reply email on request.
  * Reply drafting is gated to an existing prep report (not the raw contract) and restricted to traceable “items to raise.”
  * Added a dedicated on-demand command to generate the reply draft by company and date.
* **Documentation**
  * Updated mode guidance and the “NEVER auto-updated” data list to reflect reply draft artifacts.
* **Tests**
  * Expanded automated contract validation to ensure the exact wording, output location, and safety/traceability guardrails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->