### PR TITLE
feat(scan): opt-in CLI page extractor (browser-extract.mjs) — Phase 1 of #1449

### DIFF
--- a/browser-extract.mjs
+++ b/browser-extract.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * browser-extract.mjs — headless Playwright reader for the scan / JD-extraction
+ * path (the opt-in alternative to the browser MCP; see #1449).
+ *
+ * The token cost of the MCP path is `browser_snapshot` streaming a page's whole
+ * accessibility tree back to the model on every navigate. This helper renders
+ * the same page headlessly and returns COMPACT JSON — just the fields the agent
+ * needs — so the model processes a small result instead of a full snapshot.
+ *
+ * STRICTLY READ-ONLY: it navigates and reads the DOM. No clicks, typing, or form
+ * fills — that boundary is exactly what keeps this separate from `apply`.
+ *
+ * Usage:
+ *   node browser-extract.mjs <url> [--mode jd|listing] [--max N] [--timeout MS]
+ *
+ * Modes:
+ *   jd (default) — one posting page → { url, title, text }. `text` is the main
+ *                  visible text, whitespace-collapsed and length-capped. For the
+ *                  pipeline / oferta / auto-pipeline JD-extraction step.
+ *   listing      — a careers/board page → { url, jobs: [{ title, url }] }. Visible
+ *                  anchors that look like individual postings, deduped. For scan
+ *                  Level 1 (reading a company's open roles).
+ *
+ * Output: compact JSON to stdout. Exit 0 on success; exit 1 on a hard error,
+ * printing `{ "error": "...", "code": "..." }` (so a caller/mode can fall back
+ * to the MCP path silently). Reuses liveness-browser.mjs's SSRF host guard and
+ * realistic-UA context so it isn't instantly bot-walled.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import yaml from 'js-yaml';
+import { LIVENESS_CONTEXT_OPTIONS, rejectPrivateOrInvalid } from './liveness-browser.mjs';
+
+const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const HYDRATION_WAIT_MS = 2_000;
+const JD_TEXT_CAP = 12_000;     // plenty for a JD; a fraction of a full snapshot
+const DEFAULT_LISTING_MAX = 200;
+
+// Anchor labels that are navigation chrome, not job postings. Kept small and
+// lowercase; matched against the trimmed label.
+const NAV_LABEL_STOPWORDS = new Set([
+  'home', 'about', 'about us', 'contact', 'contact us', 'login', 'log in', 'sign in',
+  'sign up', 'register', 'privacy', 'privacy policy', 'terms', 'cookies', 'cookie policy',
+  'careers', 'jobs', 'search', 'menu', 'back', 'next', 'previous', 'apply', 'apply now',
+  'learn more', 'read more', 'faq', 'blog', 'news', 'help', 'support', 'english',
+]);
+
+/**
+ * Resolve the configured scan extractor: `cli` (this helper) or `mcp` (default).
+ * Reads `scan.extractor` from config/profile.yml; anything unrecognized — or a
+ * missing/unreadable file — yields `mcp` so behavior never breaks. Exported so
+ * doctor.mjs reports the same value.
+ * @param {string} [profilePath]
+ * @returns {'cli'|'mcp'}
+ */
+export function resolveExtractorMode(profilePath = join(CAREER_OPS, 'config/profile.yml')) {
+  try {
+    if (!existsSync(profilePath)) return 'mcp';
+    const raw = yaml.load(readFileSync(profilePath, 'utf-8')) || {};
+    const v = raw?.scan?.extractor;
+    return v === 'cli' ? 'cli' : 'mcp';
+  } catch {
+    return 'mcp';
+  }
+}
+
+// Collapse runs of whitespace and cap length so the JD text stays compact.
+export function compactText(s, cap = JD_TEXT_CAP) {
+  const text = String(s ?? '').replace(/[ \t ]+/g, ' ').replace(/\n{3,}/g, '\n\n').trim();
+  return text.length > cap ? `${text.slice(0, cap)}…` : text;
+}
+
+/**
+ * Shape a JD-mode result from the raw DOM read. Pure — exported for tests.
+ * @param {{ title?: string, text?: string }} raw
+ * @param {string} finalUrl
+ */
+export function normalizeJd(raw, finalUrl) {
+  return {
+    url: finalUrl,
+    title: compactText(raw?.title || '', 300),
+    text: compactText(raw?.text || ''),
+  };
+}
+
+/**
+ * Shape a listing-mode result: keep visible anchors that look like individual
+ * job postings, deduped by resolved URL, capped at `max`. Pure — exported for
+ * tests. Anchors are dropped when the label is empty/too short or a nav
+ * stopword, or the href isn't a resolvable http(s) URL.
+ * @param {Array<{ href?: string, label?: string }>} anchors
+ * @param {string} finalUrl - the page URL, used as the base to resolve relatives
+ * @param {number} [max]
+ */
+export function normalizeListing(anchors, finalUrl, max = DEFAULT_LISTING_MAX) {
+  const jobs = [];
+  const seen = new Set();
+  for (const a of Array.isArray(anchors) ? anchors : []) {
+    const label = String(a?.label ?? '').replace(/\s+/g, ' ').trim();
+    if (label.length < 3 || NAV_LABEL_STOPWORDS.has(label.toLowerCase())) continue;
+
+    let url;
+    try {
+      url = new URL(String(a?.href ?? ''), finalUrl).href;
+    } catch {
+      continue;
+    }
+    if (!/^https?:$/.test(new URL(url).protocol)) continue;
+    if (seen.has(url)) continue;
+    seen.add(url);
+    jobs.push({ title: label, url });
+    if (jobs.length >= max) break;
+  }
+  return { url: finalUrl, jobs };
+}
+
+// Read the raw DOM inside the page: title, main visible text, and visible
+// anchors. Runs in the browser context; returns plain data only.
+async function readDom(page) {
+  return page.evaluate(() => {
+    const title = (document.querySelector('h1')?.innerText || document.title || '').trim();
+
+    // Main text: prefer <main>/[role=main]/<article>, else body; strip nav chrome.
+    const root =
+      document.querySelector('main, [role="main"], article') || document.body;
+    let text = '';
+    if (root) {
+      const clone = root.cloneNode(true);
+      clone.querySelectorAll('script, style, nav, header, footer, noscript').forEach((el) => el.remove());
+      text = clone.innerText || '';
+    }
+
+    const anchors = Array.from(document.querySelectorAll('a[href]'))
+      .filter((el) => {
+        if (el.closest('nav, header, footer')) return false;
+        const style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        return el.getClientRects().length > 0;
+      })
+      .map((el) => ({ href: el.getAttribute('href') || '', label: (el.innerText || '').trim() }));
+
+    return { title, text, anchors };
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const url = args.find((a) => !a.startsWith('--'));
+  const mode = (args[args.indexOf('--mode') + 1] && args.includes('--mode')) ? args[args.indexOf('--mode') + 1] : 'jd';
+  const max = args.includes('--max') ? parseInt(args[args.indexOf('--max') + 1], 10) || DEFAULT_LISTING_MAX : DEFAULT_LISTING_MAX;
+  const timeout = args.includes('--timeout') ? parseInt(args[args.indexOf('--timeout') + 1], 10) || DEFAULT_TIMEOUT_MS : DEFAULT_TIMEOUT_MS;
+
+  if (!url) {
+    console.error(JSON.stringify({ error: 'usage: browser-extract.mjs <url> [--mode jd|listing] [--max N]', code: 'no_url' }));
+    process.exit(1);
+  }
+  if (mode !== 'jd' && mode !== 'listing') {
+    console.error(JSON.stringify({ error: `unknown mode "${mode}" (expected jd|listing)`, code: 'bad_mode' }));
+    process.exit(1);
+  }
+
+  const guard = rejectPrivateOrInvalid(url);
+  if (guard) {
+    console.error(JSON.stringify({ error: guard.reason, code: guard.code }));
+    process.exit(1);
+  }
+
+  let chromium;
+  try {
+    ({ chromium } = await import('playwright'));
+  } catch {
+    console.error(JSON.stringify({ error: 'playwright not installed', code: 'no_playwright' }));
+    process.exit(1);
+  }
+
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext(LIVENESS_CONTEXT_OPTIONS);
+    const page = await context.newPage();
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout });
+    await page.waitForTimeout(HYDRATION_WAIT_MS); // let SPAs hydrate
+    const finalUrl = page.url();
+    const raw = await readDom(page);
+
+    const result = mode === 'listing'
+      ? normalizeListing(raw.anchors, finalUrl, max)
+      : normalizeJd(raw, finalUrl);
+    process.stdout.write(JSON.stringify(result));
+  } catch (err) {
+    console.error(JSON.stringify({ error: `navigation error: ${String(err.message).split('\n')[0]}`, code: 'navigation_error' }));
+    process.exitCode = 1;
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+}
+
+// Only run main() when invoked directly, not when imported by tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/browser-extract.mjs
+++ b/browser-extract.mjs
@@ -119,6 +119,34 @@ export function normalizeListing(anchors, finalUrl, max = DEFAULT_LISTING_MAX) {
   return { url: finalUrl, jobs };
 }
 
+/**
+ * Parse CLI args into { url, mode, max, timeout }. Index-based so a flag value
+ * (e.g. the `listing` in `--mode listing`) is never mistaken for the URL, and an
+ * explicit `0` is honored instead of being silently replaced by the default.
+ * Exported for tests.
+ * @param {string[]} argv - process.argv.slice(2)
+ */
+export function parseArgs(argv) {
+  const FLAGS = new Set(['--mode', '--max', '--timeout']);
+  let url;
+  let mode = 'jd';
+  let max = DEFAULT_LISTING_MAX;
+  let timeout = DEFAULT_TIMEOUT_MS;
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i];
+    if (FLAGS.has(tok)) {
+      const val = argv[++i]; // consume the next token as this flag's value
+      const n = Number(val);
+      if (tok === '--mode' && val != null) mode = val;
+      else if (tok === '--max' && Number.isInteger(n) && n >= 0) max = n;
+      else if (tok === '--timeout' && Number.isInteger(n) && n > 0) timeout = n;
+    } else if (!tok.startsWith('--') && url === undefined) {
+      url = tok;
+    }
+  }
+  return { url, mode, max, timeout };
+}
+
 // Read the raw DOM inside the page: title, main visible text, and visible
 // anchors. Runs in the browser context; returns plain data only.
 async function readDom(page) {
@@ -149,11 +177,7 @@ async function readDom(page) {
 }
 
 async function main() {
-  const args = process.argv.slice(2);
-  const url = args.find((a) => !a.startsWith('--'));
-  const mode = (args[args.indexOf('--mode') + 1] && args.includes('--mode')) ? args[args.indexOf('--mode') + 1] : 'jd';
-  const max = args.includes('--max') ? parseInt(args[args.indexOf('--max') + 1], 10) || DEFAULT_LISTING_MAX : DEFAULT_LISTING_MAX;
-  const timeout = args.includes('--timeout') ? parseInt(args[args.indexOf('--timeout') + 1], 10) || DEFAULT_TIMEOUT_MS : DEFAULT_TIMEOUT_MS;
+  const { url, mode, max, timeout } = parseArgs(process.argv.slice(2));
 
   if (!url) {
     console.error(JSON.stringify({ error: 'usage: browser-extract.mjs <url> [--mode jd|listing] [--max N]', code: 'no_url' }));
@@ -182,10 +206,26 @@ async function main() {
   try {
     browser = await chromium.launch({ headless: true });
     const context = await browser.newContext(LIVENESS_CONTEXT_OPTIONS);
+    // Block every request (main navigation, redirect hop, or subresource) to a
+    // private/loopback/link-local or non-http(s) host. Guarding only the initial
+    // URL isn't enough once we return page CONTENT: a server-side redirect could
+    // otherwise steer the browser at internal infrastructure (SSRF).
+    await context.route('**/*', (route) => {
+      if (rejectPrivateOrInvalid(route.request().url())) return route.abort('blockedbyclient');
+      return route.continue();
+    });
     const page = await context.newPage();
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout });
     await page.waitForTimeout(HYDRATION_WAIT_MS); // let SPAs hydrate
+
+    // Belt-and-suspenders: never emit content read from a private final URL.
     const finalUrl = page.url();
+    const finalGuard = rejectPrivateOrInvalid(finalUrl);
+    if (finalGuard) {
+      console.error(JSON.stringify({ error: `blocked final URL: ${finalGuard.reason}`, code: finalGuard.code }));
+      process.exitCode = 1;
+      return;
+    }
     const raw = await readDom(page);
 
     const result = mode === 'listing'

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -159,6 +159,18 @@ cover_letter:
 #   # default_sender_note: "the email used to send this message"
 #   # signature_name: "Jane Smith"
 
+# ── Scan / JD extractor ─────────────────────────────────────────────────────
+#
+# How the scan and JD-extraction steps read SPA job pages.
+#   mcp (default) — the browser MCP (browser_navigate + browser_snapshot). Works
+#                   out of the box; the snapshot is token-heavy.
+#   cli           — the headless `browser-extract.mjs` helper: renders the page
+#                   and returns compact JSON, cutting per-page tokens ~2–5×. Opt-in.
+#                   If the helper isn't available, the modes fall back to mcp
+#                   silently, so nothing breaks. `doctor` reports the active mode.
+# scan:
+#   extractor: mcp   # mcp (default) | cli
+
 # ── Auto-PDF threshold ──────────────────────────────────────────────────────
 #
 # Auto-PDF threshold during evaluation (used by `/career-ops pipeline` and

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -20,6 +20,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run update` | `update-system.mjs apply` | Apply upstream update |
 | `npm run rollback` | `update-system.mjs rollback` | Rollback last update |
 | `npm run liveness` | `check-liveness.mjs` | Test if job URLs are still active |
+| `npm run extract` | `browser-extract.mjs` | Headless read-only page extractor (opt-in `scan.extractor: cli`) — compact JSON for scan/JD |
 | `npm run scan` | `scan.mjs` | Zero-token portal scanner |
 | `npm run scan:full` | `scan-ats-full.mjs` | Reverse ATS discovery scanner |
 | `npm run validate:portals` | `validate-portals.mjs` | Validate portals.yml shape before scanning |

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -10,6 +10,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import yaml from 'js-yaml';
 import { discoverPlugins, pluginRoots, pluginStatus } from './plugins/_engine.mjs';
+import { resolveExtractorMode } from './browser-extract.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const argv = process.argv.slice(2);
@@ -107,6 +108,25 @@ function playwrightMcpConfigured(root) {
     }
   }
   return false;
+}
+
+// Report which scan/JD extractor is active (config/profile.yml → scan.extractor).
+// `mcp` (default) uses the browser MCP; `cli` uses browser-extract.mjs. When cli
+// is selected but the helper is missing, the modes fall back to MCP — surface
+// that as a warning, never a failure.
+function checkScanExtractor(root) {
+  const mode = resolveExtractorMode(join(root, 'config', 'profile.yml'));
+  if (mode === 'cli') {
+    if (existsSync(join(root, 'browser-extract.mjs'))) {
+      return { pass: true, label: 'Scan extractor: cli (browser-extract.mjs)' };
+    }
+    return {
+      warn: true,
+      label: 'Scan extractor: cli set, but browser-extract.mjs is missing — falls back to MCP',
+      fix: ['Restore browser-extract.mjs, or set `scan.extractor: mcp` in config/profile.yml.'],
+    };
+  }
+  return { pass: true, label: 'Scan extractor: mcp (default)' };
 }
 
 function checkPlaywrightMcp(root) {
@@ -310,6 +330,7 @@ async function main() {
     checkDependencies(),
     await checkPlaywright(),
     checkPlaywrightMcp(projectRoot),
+    checkScanExtractor(projectRoot),
     ...USER_LAYER_PREREQS.map(checkPrereq),
     checkFonts(),
     checkAutoDir('data'),

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -74,6 +74,7 @@ you process the URL.
 ## Intelligent JD detection from URL
 
 1. **Playwright (preferred):** `browser_navigate` + `browser_snapshot`. Works with all SPAs.
+   - **Opt-in — CLI extractor (`scan.extractor: cli` in `config/profile.yml`):** run `node browser-extract.mjs <url>` (default `--mode jd`) instead; it returns compact `{ "url", "title", "text" }` — the JD main text at ~4–5× fewer tokens than a full snapshot. Use its `text` as the JD. **Fall back silently** to `browser_navigate` + `browser_snapshot` if it errors or is missing.
 2. **WebFetch (fallback):** For static pages or when Playwright is unavailable.
 3. **WebSearch (last resort):** Search in secondary portals that index the JD.
 

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -117,6 +117,8 @@ During the agent's scan, keep the **`local_parser_ok`** set in memory. This set 
 
 **Every company MUST have a `careers_url` in portals.yml.** If it does not, search for it once, save it, and use it in future scans.
 
+> **Opt-in — CLI extractor (`scan.extractor: cli`).** When `config/profile.yml` sets `scan.extractor: cli`, run `node browser-extract.mjs <careers_url> --mode listing` for each company instead of `browser_navigate` + `browser_snapshot`. It renders the page headlessly and returns compact JSON — `{ "url": ..., "jobs": [{ "title", "url" }] }` — so the listing enters context at a fraction of a full snapshot's tokens (~2–3× smaller here). Read the `jobs` array directly; then apply `title_filter` as usual. **Fall back silently** to `browser_navigate` + `browser_snapshot` if the command errors (it prints `{ "error", "code" }` and exits non-zero) or isn't present — never let the flag break a scan. Default (`scan.extractor` absent or `mcp`): the `browser_navigate` + `browser_snapshot` flow above.
+
 ### Level 2 — ATS APIs / Feeds (COMPLEMENTARY)
 
 For companies with a public API or structured feed **that are not in `local_parser_ok`**, use the JSON/XML response as a fast complement to Level 1. This is faster than Playwright and reduces visual scraping errors.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "update": "node update-system.mjs apply",
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
+    "extract": "node browser-extract.mjs",
     "scan": "node scan.mjs",
     "scan:full": "node scan-ats-full.mjs",
     "scan:seeds": "node scan-ats-full.mjs --seeds yc,a16z",

--- a/tests/browser-extract.test.mjs
+++ b/tests/browser-extract.test.mjs
@@ -11,7 +11,7 @@ console.log('\nbrowser-extract.mjs (config + normalizers)');
 
 try {
   const mod = await import(pathToFileURL(join(ROOT, 'browser-extract.mjs')).href);
-  const { resolveExtractorMode, compactText, normalizeJd, normalizeListing } = mod;
+  const { resolveExtractorMode, compactText, normalizeJd, normalizeListing, parseArgs } = mod;
 
   // resolveExtractorMode — default mcp, explicit cli, garbage → mcp, missing → mcp
   const tmp = mkdtempSync(join(tmpdir(), 'career-ops-extractor-'));
@@ -27,9 +27,25 @@ try {
     else fail('resolveExtractorMode should fall back to mcp on garbage');
     if (resolveExtractorMode(join(tmp, 'does-not-exist.yml')) === 'mcp') pass('resolveExtractorMode returns mcp when the profile is missing');
     else fail('resolveExtractorMode should return mcp for a missing file');
+    if (resolveExtractorMode(write('malformed.yml', 'scan:\n  extractor: [cli\n')) === 'mcp') pass('resolveExtractorMode falls back to mcp on malformed YAML (catch branch)');
+    else fail('resolveExtractorMode should return mcp when the YAML is invalid');
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
+
+  // parseArgs — index-based: a flag value is never mistaken for the URL, and 0 is honored
+  const flagsFirst = parseArgs(['--mode', 'listing', 'https://x/careers']);
+  if (flagsFirst.url === 'https://x/careers' && flagsFirst.mode === 'listing') pass('parseArgs finds the URL even when flags precede it');
+  else fail(`parseArgs flags-first => ${JSON.stringify(flagsFirst)}`);
+  const urlFirst = parseArgs(['https://x/1', '--mode', 'jd', '--max', '5']);
+  if (urlFirst.url === 'https://x/1' && urlFirst.mode === 'jd' && urlFirst.max === 5) pass('parseArgs handles url-first with flags');
+  else fail(`parseArgs url-first => ${JSON.stringify(urlFirst)}`);
+  const zeroMax = parseArgs(['https://x/1', '--max', '0']);
+  if (zeroMax.max === 0) pass('parseArgs honors --max 0 (not silently replaced by the default)');
+  else fail(`parseArgs --max 0 => ${zeroMax.max}`);
+  const badMax = parseArgs(['https://x/1', '--max', 'abc']);
+  if (badMax.max === 200) pass('parseArgs falls back to the default for a non-integer --max');
+  else fail(`parseArgs --max abc => ${badMax.max}`);
 
   // compactText — collapse whitespace + cap length
   if (compactText('a   b\t\tc') === 'a b c') pass('compactText collapses runs of whitespace');

--- a/tests/browser-extract.test.mjs
+++ b/tests/browser-extract.test.mjs
@@ -1,0 +1,88 @@
+// tests/browser-extract.test.mjs — unit coverage for the pure logic in
+// browser-extract.mjs (config resolution + result normalizers). The Playwright
+// navigation path is exercised live, not here.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+
+console.log('\nbrowser-extract.mjs (config + normalizers)');
+
+try {
+  const mod = await import(pathToFileURL(join(ROOT, 'browser-extract.mjs')).href);
+  const { resolveExtractorMode, compactText, normalizeJd, normalizeListing } = mod;
+
+  // resolveExtractorMode — default mcp, explicit cli, garbage → mcp, missing → mcp
+  const tmp = mkdtempSync(join(tmpdir(), 'career-ops-extractor-'));
+  try {
+    const write = (name, body) => { const p = join(tmp, name); writeFileSync(p, body); return p; };
+    if (resolveExtractorMode(write('cli.yml', 'scan:\n  extractor: cli\n')) === 'cli') pass('resolveExtractorMode reads scan.extractor: cli');
+    else fail('resolveExtractorMode should read cli');
+    if (resolveExtractorMode(write('mcp.yml', 'scan:\n  extractor: mcp\n')) === 'mcp') pass('resolveExtractorMode reads scan.extractor: mcp');
+    else fail('resolveExtractorMode should read mcp');
+    if (resolveExtractorMode(write('none.yml', 'candidate:\n  full_name: X\n')) === 'mcp') pass('resolveExtractorMode defaults to mcp when the key is absent');
+    else fail('resolveExtractorMode should default to mcp');
+    if (resolveExtractorMode(write('bad.yml', 'scan:\n  extractor: nonsense\n')) === 'mcp') pass('resolveExtractorMode falls back to mcp for an unknown value');
+    else fail('resolveExtractorMode should fall back to mcp on garbage');
+    if (resolveExtractorMode(join(tmp, 'does-not-exist.yml')) === 'mcp') pass('resolveExtractorMode returns mcp when the profile is missing');
+    else fail('resolveExtractorMode should return mcp for a missing file');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+
+  // compactText — collapse whitespace + cap length
+  if (compactText('a   b\t\tc') === 'a b c') pass('compactText collapses runs of whitespace');
+  else fail(`compactText => ${JSON.stringify(compactText('a   b\t\tc'))}`);
+  const capped = compactText('x'.repeat(50), 10);
+  if (capped.length === 11 && capped.endsWith('…')) pass('compactText caps length and appends an ellipsis');
+  else fail(`compactText cap => ${JSON.stringify(capped)}`);
+
+  // normalizeJd — shape { url, title, text }
+  const jd = normalizeJd({ title: '  Senior Go  Engineer ', text: 'Line1\n\n\n\nLine2   end' }, 'https://x/1');
+  if (jd.url === 'https://x/1' && jd.title === 'Senior Go Engineer' && jd.text === 'Line1\n\nLine2 end') {
+    pass('normalizeJd shapes { url, title, text } and compacts both');
+  } else {
+    fail(`normalizeJd => ${JSON.stringify(jd)}`);
+  }
+
+  // normalizeListing — resolve relatives, drop nav/short labels, dedup, cap
+  const anchors = [
+    { href: '/jobs/1', label: 'Staff Engineer' },
+    { href: 'https://x/jobs/1', label: 'Staff Engineer (dupe URL after resolve)' }, // different label, but…
+    { href: '/jobs/2', label: 'Careers' },       // nav stopword → dropped
+    { href: '/jobs/3', label: 'AI' },             // too short → dropped
+    { href: 'javascript:void(0)', label: 'Broken Protocol Role' }, // non-http → dropped
+    { href: '/jobs/4', label: 'ML Platform Lead' },
+  ];
+  const listed = normalizeListing(anchors, 'https://x/careers', 10);
+  const urls = listed.jobs.map((j) => j.url);
+  if (listed.url === 'https://x/careers' &&
+      listed.jobs.length === 2 &&
+      urls.includes('https://x/jobs/1') && urls.includes('https://x/jobs/4') &&
+      listed.jobs[0].title === 'Staff Engineer') {
+    pass('normalizeListing resolves relative URLs, dedups, drops nav/short/non-http anchors');
+  } else {
+    fail(`normalizeListing => ${JSON.stringify(listed.jobs)}`);
+  }
+
+  // dedup by resolved URL
+  const dup = normalizeListing(
+    [{ href: '/j/1', label: 'Role A' }, { href: 'https://x/j/1', label: 'Role A again' }],
+    'https://x/careers',
+  );
+  if (dup.jobs.length === 1) pass('normalizeListing dedups by resolved URL');
+  else fail(`normalizeListing dedup => ${JSON.stringify(dup.jobs)}`);
+
+  // max cap
+  const many = normalizeListing(
+    Array.from({ length: 20 }, (_, i) => ({ href: `/j/${i}`, label: `Role Number ${i}` })),
+    'https://x/careers',
+    5,
+  );
+  if (many.jobs.length === 5) pass('normalizeListing respects the max cap');
+  else fail(`normalizeListing max => ${many.jobs.length}`);
+
+} catch (e) {
+  fail(`browser-extract tests crashed: ${e.message}`);
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -147,6 +147,7 @@ const SYSTEM_PATHS = [
   'liveness-core.mjs',
   'liveness-api.mjs',
   'liveness-browser.mjs',
+  'browser-extract.mjs',
   'analyze-patterns.mjs',
   'stats.mjs',
   'detect-reposts.mjs',


### PR DESCRIPTION
Phase 1 of #1449, built to the scope you greenlit.

## What
An **opt-in, headless, strictly read-only** page extractor as an alternative to the browser MCP for the scan / JD-extraction steps. **MCP stays the default and the silent fallback; `apply` is untouched.**

- **`browser-extract.mjs`** mirrors `liveness-browser.mjs` (headless chromium, realistic-UA context) and **reuses its SSRF host guard** (`rejectPrivateOrInvalid`). It only navigates + reads the DOM — **no clicks, typing, or form fills** (that boundary is what keeps it clean next to `apply`). Two modes:
  - `jd` (default): a posting → `{ url, title, text }` (main visible text, collapsed + capped)
  - `listing`: a careers page → `{ url, jobs: [{ title, url }] }`
  - On any error it prints `{ error, code }` and exits non-zero, so a caller can fall back.
- **Opt-in flag** in `config/profile.yml`: `scan.extractor: cli | mcp` (**default `mcp`**). `doctor` reports the active mode. `scan.md` / `pipeline.md` branch on the flag and **fall back to `browser_navigate` + `browser_snapshot` silently** if the helper errors or is absent — nothing breaks.
- Registered in `SYSTEM_PATHS`, `npm run extract`, `docs/SCRIPTS.md`.

## Measured before/after (the numbers you asked me to hold this to)
Real comparison: the actual **`ariaSnapshot()`** (what `browser_snapshot` returns) vs this helper’s compact output, on the same rendered page:

| Page | `browser_snapshot` (ARIA) | CLI listing | CLI jd |
|---|---|---|---|
| Greenhouse listing (Anthropic) | ~6,900 tok | ~2,100 tok (**3.3×**) | ~1,230 tok (**5.6×**) |
| Ashby listing (Ramp) | ~12,660 tok | ~7,035 tok (**1.8×**) | ~3,150 tok (**4.0×**) |

Honest read: **~2–3× on listing pages and ~4–5× on JD pages** — more modest than my proposal’s rough 10–50× estimate (that was optimistic). The extra win not captured in the per-page number is that extraction now runs **outside the model context** entirely (Node parses the page; only the compact result enters context).

## Tests
`tests/browser-extract.test.mjs` — 11 checks (config resolution incl. missing/garbage → `mcp`; `compactText`; `normalizeJd`; `normalizeListing` relative-URL resolve, nav/short/non-http drops, dedup, max cap). Live-verified against real Greenhouse/Ashby/Lever boards. Full `--quick`: **1520 passed, 0 failed**.

## Scope guardrails honored
Opt-in (default mcp), silent MCP fallback, `apply` untouched, extractor strictly read-only (navigate + extract only). Phase 2 (broader coverage / flipping the default once proven in the wild) left for later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a headless extractor CLI that outputs compact JSON for either page text or job-listing links.
  * Introduced an optional `scan.extractor` setting to choose extractor mode (`cli` vs `mcp`) and documented the workflow.
  * Added an `npm run extract` shortcut to run the extractor.
* **Bug Fixes**
  * Added stronger URL validation to prevent private/invalid targets from being emitted, including checks after redirects.
  * Improved error handling with structured JSON and reliable fallback to the existing snapshot approach.
* **Documentation / Tests**
  * Updated script references and scan pipeline docs; added unit tests for extractor helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->