### PR TITLE
feat: fail-closed triage scorer, auto-apply rewire, finder expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ reports/*.md
 !reports/.gitkeep
 output/*
 !output/.gitkeep
+cover-letters/*
+!cover-letters/.gitkeep
 batch/logs/*
 !batch/logs/.gitkeep
 batch/batch-state.tsv

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ cv.md
 data/applications.md
 data/pipeline.md
 data/scan-history.tsv
+data/last-digest.json
+data/telegram-offset.txt
 reports/*.md
 !reports/.gitkeep
 output/*
@@ -29,6 +31,7 @@ modes/_profile.md
 
 # Secrets (never commit — use .env.example as template)
 .env
+auth/
 
 # Generated
 .resolved-prompt-*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,16 @@ This fork has user-specific customizations that change defaults from the upstrea
 
 3. **Reports are in English.** The system-layer `modes/*.md` files were translated to English on 2026-05-17 (originally Spanish from upstream author). If `node update-system.mjs apply` is run, modes/ will revert to Spanish — re-apply translations from `project_careerops_english_modes.md` in memory, or override at write-time using the translation table in `modes/_profile.md` "Report Output Language" section.
 
+### Voice engine — anti-AI-tell rules (added 2026-06-06)
+
+Companies reject AI-written cover letters and smart readers recognize Claude/ChatGPT cadence. A 3-pass adversarial audit this session hardened the voice engine. **Before returning ANY candidate-facing text (CV summary/bullets, cover letters, application answers, outreach):**
+
+- **Apply `modes/_profile.md` → "Structural & Rhythmic Tells" and run its MANDATORY pre-send self-audit.** It targets *structure*, not just words — banned constructions with counted budgets: negation-elevation ("X isn't A — it's B"), "same X / instinct / muscle" transfer-bridges, meta-signposting ("Two honest notes.", "Reliability:" labels), the uniform clause—dash—appositive sentence shape, tricolon-as-beat.
+- **Bundle dedup is the loudest single-generator signal.** A CV + cover letter + essays generated in one run must not recycle a phrase, a narrative arc, *or the skeleton* (concede→reframe→wry-kicker) across docs. Make each doc handle its gap, contrast, and closing differently.
+- **Ceiling rule (learned the hard way over 3 passes: HIGH→MEDIUM→MEDIUM, 5.75→6.0).** An AI scrubbing its own draft tops out at "competent-generic," not "unmistakably Patrick" — each pass trades a loud tell for a subtler one. After **≤2 structural passes, STOP and hand to Patrick** for ONE real voice beat (genuine enthusiasm / a car-engine-whiteboard analogy, in his words). Do NOT manufacture it — performed folksiness ("those reps would be new for me") becomes the next tell. **Never claim "LOW / undetectable" from automation alone.**
+- **Upstream fix (open TODO):** populate `writing-samples/` with real Patrick writing (an old cover letter, a Slack post, a lab note) so the engine imitates his actual voice instead of an inferred profile — the only thing that raises the ceiling.
+- System-layer wiring (`modes/_shared.md`, `cover-letter.md`, `apply.md`, `auto-pipeline.md`, `pdf.md`, and this CLAUDE.md subsection) reverts on `update-system.mjs apply` — re-apply per `memory/project_voice_engine_upgrade.md`. The `modes/_profile.md` rules persist (user layer).
+
 ### Patrick-specific workflow
 
 - **MacBook destination for review artifacts**: `~/Documents/career-ops-2026-05-17/` (or roll forward by date). Push via `scp` to `patrick@10.1.1.134`. Mirror structure: `reports/`, `output/`, `cover-letters/`, `interview-prep/`, plus the tracker at the root.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,9 @@ All scripts are Node `.mjs` modules exposed via `npm run`. Run from `career-ops/
 | `npm run update:check` / `npm run update` / `npm run rollback` | Self-update against upstream (system-layer files only). |
 | `node apply-auto.mjs <url> <pdf> [opts]` | Server-side ATS form filler (Ashby/Greenhouse/Lever). Runs on CT 203. |
 | `node browser-login.mjs [--profile=name]` | Interactive auth session with remote debugging for CT 203 headless browser. |
+| `npm run prep -- --num N` / `--company NAME` / `--check` | Generate interview prep docs from evaluation reports. `--check` finds Interview/Responded without prep. |
+| `npm run followup` / `... -- --days 7 --dry-run` | Check for applications needing follow-up (default: 5 business days). |
+| `bash daily-pipeline.sh` | Full daily chain: scan → notify → followup → prep-check. Runs on CT 203 via cron. |
 
 Test suite (run before any PR — CI runs `--quick`):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ All scripts are Node `.mjs` modules exposed via `npm run`. Run from `career-ops/
 | `npm run sync-check` | Validate cv.md / profile.yml consistency, no hardcoded metrics. |
 | `npm run liveness -- <url>...` / `... --file urls.txt` | Check whether job URLs are still active. |
 | `npm run update:check` / `npm run update` / `npm run rollback` | Self-update against upstream (system-layer files only). |
+| `node apply-auto.mjs <url> <pdf> [opts]` | Server-side ATS form filler (Ashby/Greenhouse/Lever). Runs on CT 203. |
+| `node browser-login.mjs [--profile=name]` | Interactive auth session with remote debugging for CT 203 headless browser. |
 
 Test suite (run before any PR — CI runs `--quick`):
 
@@ -74,6 +76,54 @@ JD text/URL ──► archetype detect ──► A–F evaluation (reads cv.md +
 - **Offer verification uses Playwright, not WebFetch.** AGENTS.md mandates `browser_navigate` + `browser_snapshot` for liveness; only the headless batch worker may fall back to WebFetch and must mark the report `**Verification:** unconfirmed (batch mode)`.
 - **Update prompt on first message:** AGENTS.md instructs running `node update-system.mjs check` silently each session and only surfacing the `update-available` case. Don't surface `up-to-date`, `dismissed`, `offline`, or `no-remote-version`.
 - **Onboarding gate:** if `cv.md`, `config/profile.yml`, `modes/_profile.md`, or `portals.yml` are missing, AGENTS.md requires entering onboarding mode before any evaluation/scan. `modes/_profile.md` should be silently copied from `modes/_profile.template.md` if absent.
+
+## Server-side application automation (CT 203)
+
+Two scripts enable fully server-side job applications from Proxmox CT 203 — no MacBook involvement:
+
+### `apply-auto.mjs` — ATS form filler
+
+Fills ATS application forms, uploads resume/cover letter, and optionally submits. Reads candidate data from `config/profile.yml`.
+
+```bash
+node apply-auto.mjs <url> <pdf-path> [options]
+
+Options:
+  --cover-letter=path   Upload cover letter (PDF/DOCX/MD)
+  --submit              Click submit after filling (default: pause for review)
+  --screenshot=path     Save screenshot of filled form
+  --auth=path           Load saved browser state (cookies) for authenticated sessions
+```
+
+**Supported platforms:**
+| Platform | Detection | Strategy |
+|----------|-----------|----------|
+| Ashby | `jobs.ashbyhq.com` | Upload resume first (triggers parser autofill), wait for parser, then overwrite fields. Handles React comboboxes, Yes/No button pairs. |
+| Greenhouse | `boards.greenhouse.io` or `grnhse_iframe` | Detects iframe embedding (e.g. Stripe). React-Select dropdowns via keyboard (ArrowDown → type → Enter). Scoped option search to avoid phone country selector pollution. |
+| Stripe | `stripe.com/jobs` | Greenhouse-in-iframe variant. 20+ fields including custom dropdowns, checkboxes, file uploads. |
+| Lever | `jobs.lever.co` | Standard form fill by field ID/name. |
+| Generic | fallback | Best-effort label/placeholder/name matching. |
+
+**Key implementation details:**
+- React-Select dropdowns use keyboard interaction (not mouse events) because raw DOM events don't trigger React's synthetic event system
+- `document.execCommand('insertText')` used for React input fields instead of `.value =` assignment
+- Phone intl-tel-input country selectors (244 options) are excluded from option searches by scoping to `[id^="react-select-{inputId}-option"]`
+- Ashby resume parser creates a race condition — script uploads first, waits for "Parsing" banner to disappear, then fills fields
+
+### `browser-login.mjs` — Interactive auth session
+
+Launches headless Chromium with remote debugging so you can log into sites (LinkedIn, etc.) from your MacBook via SSH tunnel. Saves cookies for `apply-auto.mjs --auth`.
+
+```bash
+node browser-login.mjs [--profile=name] [--port=9222] [--url=https://linkedin.com/login]
+
+# Then from MacBook:
+ssh -L 9222:localhost:9222 root@10.1.30.50
+# Open http://localhost:9222 in Chrome → interact with remote browser
+# Press Enter in terminal when done → saves to auth/{profile}-state.json
+```
+
+Saved state is loaded by `apply-auto.mjs --auth=auth/linkedin-state.json` for authenticated sessions (e.g. LinkedIn Easy Apply).
 
 ## Session continuity — read this first when picking up Patrick's fork
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,8 +194,8 @@ This fork has user-specific customizations that change defaults from the upstrea
 
 ### Known bugs to work around
 
-- **`merge-tracker.mjs` dedup is too aggressive.** When a new TSV's `company + significant-title-substring` overlaps an existing tracker row, it treats it as UPDATE not ADD. Workaround: verify `data/applications.md` diff after every merge; hand-edit if a row was unexpectedly overwritten. Hit on 2026-05-17 when adding Anthropic Application Security Engineer (#7) which got merged onto existing Staff+ Software Security Engineer (#5). See `feedback_merge_tracker_dedup_bug.md` in memory.
-- **`scan.mjs` still writes Spanish section headers** (`## Pendientes` / `## Procesadas`) into `data/pipeline.md` even though `modes/*.md` is in English. System-layer script, not patched. Cosmetic only; doesn't break workflow.
+- **`merge-tracker.mjs` dedup was too aggressive (FIXED 2026-05-25).** Switched `roleFuzzyMatch()` from min-ratio to Jaccard similarity (0.75 threshold). Same-company different-roles are now correctly treated as separate entries. Regression tests added to `test-all.mjs`. Still worth verifying `data/applications.md` diff after merges — see `feedback_merge_tracker_dedup_bug.md` in memory.
+- **`scan.mjs` Spanish headers (FIXED 2026-05-25).** Now writes `## Pending` / `## Processed` with backward-compat fallback for legacy `## Pendientes` / `## Procesadas`.
 
 ### Where the scanner lives + how to refresh it
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 @AGENTS.md
-<!-- Add anything Claude Code specific that other agents don't need -->
+
+<!--
+The line above imports the canonical agent guide. AGENTS.md is shared across
+all AI coding CLIs (Claude, Codex, Gemini, OpenCode, Qwen, Copilot) and is the
+source of truth for: data contract, modes, scoring, onboarding, headless/batch
+mode, pipeline integrity, and ethical use. Read it before doing real work.
+
+Everything below is a Claude-Code-specific quick reference and only adds what
+is not already in AGENTS.md.
+-->
+
+## Repo orientation
+
+The actual project lives in [career-ops/](career-ops/), not the parent dir. All paths in AGENTS.md are relative to that subdirectory — `cd career-ops` (or operate with absolute paths) before running scripts.
+
+## Common commands
+
+All scripts are Node `.mjs` modules exposed via `npm run`. Run from `career-ops/`:
+
+| Command | Purpose |
+|---|---|
+| `npm run doctor` | Validate setup (Node ≥18, Playwright chromium, required user files). Run first on a fresh checkout. |
+| `npm run scan` | Zero-token portal scanner (hits Greenhouse/Ashby/Lever APIs directly). |
+| `npm run verify` | Pipeline integrity check on `data/applications.md` (statuses, dupes, links). |
+| `npm run merge` / `... -- --dry-run` / `... -- --verify` | Merge `batch/tracker-additions/*.tsv` into the tracker. |
+| `npm run normalize` / `npm run dedup` | Fix non-canonical statuses / remove duplicate rows. Both create `.bak`. |
+| `npm run pdf -- input.html output.pdf [--format=a4\|letter]` | Render HTML CV to ATS-parseable PDF. |
+| `npm run sync-check` | Validate cv.md / profile.yml consistency, no hardcoded metrics. |
+| `npm run liveness -- <url>...` / `... --file urls.txt` | Check whether job URLs are still active. |
+| `npm run update:check` / `npm run update` / `npm run rollback` | Self-update against upstream (system-layer files only). |
+
+Test suite (run before any PR — CI runs `--quick`):
+
+```bash
+node test-all.mjs          # full suite (includes dashboard build)
+node test-all.mjs --quick  # skip Go build; matches CI
+```
+
+There is no single-test runner — `test-all.mjs` is a sequential script of ~63 checks (syntax, scripts, data contract, paths). To iterate on one area, comment out the unrelated sections locally or run the underlying script directly (e.g. `node verify-pipeline.mjs`).
+
+Dashboard (Go TUI, separate module):
+
+```bash
+cd dashboard && go build -o career-dashboard . && ./career-dashboard --path ..
+```
+
+## Architecture in one screen
+
+```
+JD text/URL ──► archetype detect ──► A–F evaluation (reads cv.md + article-digest.md + _profile.md)
+                                          │
+                                          ├─► reports/{NNN}-{slug}-{date}.md
+                                          ├─► output/cv-...-{slug}-{date}.pdf  (generate-pdf.mjs)
+                                          └─► batch/tracker-additions/{NNN}-{slug}.tsv
+                                                  │
+                                          merge-tracker.mjs ──► data/applications.md
+```
+
+- **Two layers, hard rule:** `cv.md`, `config/profile.yml`, `modes/_profile.md`, `data/*`, `reports/*`, `output/*`, `portals.yml` are the **user layer** — never edited by the update process. Everything in `modes/` (except `_profile.md`), all `*.mjs`, `templates/`, `dashboard/`, `batch/` (except your TSVs) are **system layer** — replaced on update. See [DATA_CONTRACT.md](career-ops/DATA_CONTRACT.md). When personalizing, always write to the user layer.
+- **Modes are markdown prompts, not code.** [modes/_shared.md](career-ops/modes/_shared.md) holds scoring rules; per-mode files (`oferta.md`, `scan.md`, `batch.md`, …) are the per-skill instructions Claude reads when invoked. The slash command router lives in [.claude/skills/career-ops/SKILL.md](career-ops/.claude/skills/career-ops/SKILL.md).
+- **Tracker is append-only via TSV.** Never hand-add rows to `data/applications.md` — write a 9-column TSV in `batch/tracker-additions/` and let `merge-tracker.mjs` do the merge (it handles the column-order swap between TSV and the markdown table). You may edit existing rows to update status/notes.
+- **Canonical statuses** live in [templates/states.yml](career-ops/templates/states.yml): `Evaluated`, `Applied`, `Responded`, `Interview`, `Offer`, `Rejected`, `Discarded`, `SKIP`. No bold, no dates, no extra text in the status column.
+- **Reports** must include `**URL:**` and `**Legitimacy:** {tier}` headers and are numbered sequentially `{max+1}` zero-padded to 3 digits.
+
+## Claude-Code-specific notes
+
+- **Slash command:** `/career-ops [args]` is provided by [.claude/skills/career-ops/SKILL.md](career-ops/.claude/skills/career-ops/SKILL.md). Bare `/career-ops` shows discovery; `/career-ops <JD or URL>` triggers auto-pipeline; sub-commands match the modes table in AGENTS.md.
+- **Headless / batch workers:** spawn with `claude -p "prompt"` (the row in AGENTS.md's "Headless / Batch Mode" table for Claude Code). [batch/batch-runner.sh](career-ops/batch/batch-runner.sh) already invokes this.
+- **Offer verification uses Playwright, not WebFetch.** AGENTS.md mandates `browser_navigate` + `browser_snapshot` for liveness; only the headless batch worker may fall back to WebFetch and must mark the report `**Verification:** unconfirmed (batch mode)`.
+- **Update prompt on first message:** AGENTS.md instructs running `node update-system.mjs check` silently each session and only surfacing the `update-available` case. Don't surface `up-to-date`, `dismissed`, `offline`, or `no-remote-version`.
+- **Onboarding gate:** if `cv.md`, `config/profile.yml`, `modes/_profile.md`, or `portals.yml` are missing, AGENTS.md requires entering onboarding mode before any evaluation/scan. `modes/_profile.md` should be silently copied from `modes/_profile.template.md` if absent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,51 @@ ssh -L 9222:localhost:9222 root@10.1.30.50
 
 Saved state is loaded by `apply-auto.mjs --auth=auth/linkedin-state.json` for authenticated sessions (e.g. LinkedIn Easy Apply).
 
+### Auto-apply pipeline
+
+Two-tier automation — configured in `config/profile.yml` under `search:`:
+
+| Tier | Trigger | Threshold | Config key |
+|------|---------|-----------|------------|
+| 1 — Auto-apply | Daily scan pipeline | score ≥ 4.5 | `auto_apply_threshold` |
+| 2 — Telegram reply | Patrick replies "apply #N" to digest | score ≥ 4.0 | `apply_threshold` |
+
+**Components:**
+
+| File | Purpose |
+|------|---------|
+| `lib/telegram.mjs` | Shared Telegram Bot API helper (sendMessage, getUpdates, loadEnv) |
+| `apply-orchestrator.mjs` | Shared apply pipeline: eval → CV → CL → apply-auto.mjs → tracker |
+| `telegram-listener.mjs` | Long-polling listener for Telegram reply commands |
+| `career-ops-listener.service` | systemd unit for the listener on CT 203 |
+
+**Telegram commands** (reply to any bot message):
+- `apply` — apply to highest-scoring unapplied job from latest digest
+- `apply #3` — apply to job #3 from the digest
+- `skip #3` — mark job #3 as skipped
+- `status` — pipeline status summary
+- `help` — list commands
+
+**Data files** (gitignored, CT 203 only):
+- `data/last-digest.json` — structured job list from latest notify-telegram.mjs send (maps "#N" → URL)
+- `data/telegram-offset.txt` — last processed update_id for crash recovery
+
+**Flow (daily cron):**
+```
+scan.mjs → auto-pipeline.mjs:
+  ├─ evaluate via claude -p
+  ├─ generate CV + CL for ≥ 4.0
+  ├─ auto-apply via apply-orchestrator.mjs for ≥ 4.5
+  ├─ merge tracker
+  └─ send numbered Telegram digest (writes last-digest.json)
+
+telegram-listener.mjs (always-on):
+  ├─ "apply #N" → look up URL from last-digest.json → apply-orchestrator.mjs
+  └─ "status" → pipeline summary
+```
+
+**Master switch:** `auto_apply_enabled: true` in profile.yml. Set to `false` to disable auto-apply but keep Telegram reply trigger. CLI overrides: `--auto-apply` / `--no-auto-apply` on auto-pipeline.mjs.
+
 ## Session continuity — read this first when picking up Patrick's fork
 
 This fork has user-specific customizations that change defaults from the upstream career-ops project. **Read these before running any evaluation.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,3 +74,39 @@ JD text/URL ──► archetype detect ──► A–F evaluation (reads cv.md +
 - **Offer verification uses Playwright, not WebFetch.** AGENTS.md mandates `browser_navigate` + `browser_snapshot` for liveness; only the headless batch worker may fall back to WebFetch and must mark the report `**Verification:** unconfirmed (batch mode)`.
 - **Update prompt on first message:** AGENTS.md instructs running `node update-system.mjs check` silently each session and only surfacing the `update-available` case. Don't surface `up-to-date`, `dismissed`, `offline`, or `no-remote-version`.
 - **Onboarding gate:** if `cv.md`, `config/profile.yml`, `modes/_profile.md`, or `portals.yml` are missing, AGENTS.md requires entering onboarding mode before any evaluation/scan. `modes/_profile.md` should be silently copied from `modes/_profile.template.md` if absent.
+
+## Session continuity — read this first when picking up Patrick's fork
+
+This fork has user-specific customizations that change defaults from the upstream career-ops project. **Read these before running any evaluation.**
+
+### Hard rules that override the system
+
+1. **Location is a HARD constraint** (added 2026-05-17, hardened EOD same day). Patrick is Denver-based with family; **not relocating**. The rule covers more than "no relocation" — it also covers **no required travel to non-Denver offices**, even if a role is tagged "Remote-Friendly (Travel-Required)." If a JD requires *any* cadence of office time at a non-Denver hub, it's a SKIP, score 1.0/5, regardless of comp or company tier. Even Anthropic ($405K+ base) was disqualified. See `feedback_location_policy.md` in memory + `modes/_profile.md` "Your Location Policy" section.
+
+2. **Comp floor is $160K base USD.** If the JD lists a comp range and `max < $160K`, output a 1-sentence SKIP verdict — do NOT generate a full A-G evaluation. Token-wasteful otherwise. See `modes/_profile.md` "Your Comp Targets" section.
+
+3. **Reports are in English.** The system-layer `modes/*.md` files were translated to English on 2026-05-17 (originally Spanish from upstream author). If `node update-system.mjs apply` is run, modes/ will revert to Spanish — re-apply translations from `project_careerops_english_modes.md` in memory, or override at write-time using the translation table in `modes/_profile.md` "Report Output Language" section.
+
+### Patrick-specific workflow
+
+- **MacBook destination for review artifacts**: `~/Documents/career-ops-2026-05-17/` (or roll forward by date). Push via `scp` to `patrick@10.1.1.134`. Mirror structure: `reports/`, `output/`, `cover-letters/`, `interview-prep/`, plus the tracker at the root.
+- **Dual CV output**: produce BOTH the ATS-PDF (existing HTML/Playwright flow) AND a polished `.docx` via `anthropic-skills:docx` (skill is loaded, no install). Per `feedback_cv_output_format.md` in memory.
+- **Telegram alerts**: career-ops scanner sends daily fits via `@career_ops_bot_bot` (token in `/opt/career-ops/.env` on LXC CT 203). Infra alerts via the openclaw bot. Don't confuse the two.
+- **OpenRouter for LLM calls outside this session**: key at `~/.secrets/openrouter.txt` (mode 600). Default model `anthropic/claude-haiku-4.5` for cheap one-shot stuff (refresh-now, cybersec digest). See `reference_openrouter_key.md` in memory. **Patrick does NOT have an Anthropic API key** — Claude Max ≠ API access.
+
+### Known bugs to work around
+
+- **`merge-tracker.mjs` dedup is too aggressive.** When a new TSV's `company + significant-title-substring` overlaps an existing tracker row, it treats it as UPDATE not ADD. Workaround: verify `data/applications.md` diff after every merge; hand-edit if a row was unexpectedly overwritten. Hit on 2026-05-17 when adding Anthropic Application Security Engineer (#7) which got merged onto existing Staff+ Software Security Engineer (#5). See `feedback_merge_tracker_dedup_bug.md` in memory.
+- **`scan.mjs` still writes Spanish section headers** (`## Pendientes` / `## Procesadas`) into `data/pipeline.md` even though `modes/*.md` is in English. System-layer script, not patched. Cosmetic only; doesn't break workflow.
+
+### Where the scanner lives + how to refresh it
+
+- Always-on scanner on LXC CT 203 at `10.1.30.50`, daily cron 07:00 MDT via `systemctl start career-scan.service`.
+- Sync changes via: `scp $FILE root@10.1.30.11:/tmp/ && ssh root@10.1.30.11 "pct push 203 /tmp/$FILE /opt/career-ops/$RELATIVE_PATH"`
+- Trigger a test scan: `ssh root@10.1.30.50 "systemctl start career-scan.service"` — completes in ~10s.
+
+### Default workflow for picking up
+
+1. Read `MEMORY.md` first (auto-loaded — has the index of all memory files).
+2. Read `TODO.md` in repo root for the active session checklist.
+3. Status of viable applications + open SKIPs is in `data/applications.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,8 +210,17 @@ Companies reject AI-written cover letters and smart readers recognize Claude/Cha
 ### Where the scanner lives + how to refresh it
 
 - Always-on scanner on LXC CT 203 at `10.1.30.50`, daily cron 07:00 MDT via `systemctl start career-scan.service`.
-- Sync changes via: `scp $FILE root@10.1.30.11:/tmp/ && ssh root@10.1.30.11 "pct push 203 /tmp/$FILE /opt/career-ops/$RELATIVE_PATH"`
-- Trigger a test scan: `ssh root@10.1.30.50 "systemctl start career-scan.service"` — completes in ~10s.
+- Sync changes via direct `scp $FILE root@10.1.30.50:/opt/career-ops/$RELATIVE_PATH` (the pct-push-via-10.1.30.11 dance is unnecessary).
+- Trigger a test scan: `ssh root@10.1.30.50 "systemctl start career-scan.service"`.
+- **Data sync (added 2026-07-06):** `./sync-ct203.sh pull` at session start, `push` after local merges, `status` to md5-compare pipeline scripts. CT 203 is the daily tracker writer (triage merges rows there); local sessions must pull before evaluating or numbering diverges — that split-brain once cost a month of results.
+
+### Triage scorer + auto-apply (hardened 2026-07-06)
+
+- **The scorer is fail-closed now.** `lib/location-gate.mjs` (18 self-tests: `node lib/location-gate.mjs`) hard-skips %-in-office and "Remote-Friendly (Travel-Required)" JDs pre-LLM; `openrouter-eval.mjs` `enforcePolicy()` caps any eval whose own LOCATION_POLICY extraction violates the hard rules to 1.0/SKIP in code, and UNCLEAR locations to ≤3.9. The model advises, the code decides — don't undo this by trusting raw scores.
+- **Auto-apply is wired into triage** (`triage.mjs` → `apply-orchestrator.mjs --submit`) for score ≥4.5 when the gate verdict AND the eval's LOCATION_POLICY are both clean and the platform is in `auto_apply_platforms`. `--no-auto-apply` disables per-run. On CT 203 there is no `claude -p`, so CV falls back to newest `output/cv-*.pdf` and no cover letter is generated (intentional — voice-engine ceiling rule).
+- Eval model: `anthropic/claude-sonnet-5` via OpenRouter (~$0.09/eval, 1–5 survivors/day typical). Override with `OPENROUTER_MODEL`.
+- Finder: Workday boards use `api_type: workday` + cxs `api:` in portals.yml (Tempus/CrowdStrike/DaVita wired); `scan-builtin.mjs` scrapes Built In Colorado (Denver) — its cron step lives in `/usr/local/bin/career-scan` (staged as `/opt/career-ops/career-scan.new` if not yet installed).
+- Gotcha: scan.mjs stamps rows with the **UTC** date — an evening MDT run writes tomorrow's date, so `triage --date` must match (`date -u +%F`).
 
 ### Default workflow for picking up
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,34 +7,37 @@
 ## 🔴 IMMEDIATE — Apply to open roles
 
 ### Abridge (2 roles, both 4.7/4.6, remote, founding security team)
-- [ ] Submit Abridge AppSec (#2, score 4.7) via apply-auto.mjs on CT 203
-- [ ] Submit Abridge InfraSec (#3, score 4.6) via apply-auto.mjs on CT 203
-- [ ] Verify both Ashby forms still active (liveness check)
+- [x] Submit Abridge AppSec (#2, score 4.7) via apply-auto.mjs on CT 203 ✅ 2026-05-25
+- [x] Submit Abridge InfraSec (#3, score 4.6) via apply-auto.mjs on CT 203 ✅ 2026-05-25
+- [x] Verify both Ashby forms still active (liveness check) ✅
 - [ ] Tailor custom Ashby question answers using evaluation Block H + voice profile
 
 ### Stale candidates from last session
-- [ ] Evaluate: Turo — Staff Security Engineer, Infrastructure (Denver) — `https://wellfound.com/jobs/3104118-staff-security-engineer-infrastructure`
-- [ ] Evaluate: Diligente Technologies — Sr. Cloud Security Engineer/Architect (Remote) — `https://www.dice.com/job-detail/0f3c58fc-7fc0-4879-b38c-91a2fdd22cb2`
+- [x] ~~Turo — Staff Security Engineer, Infrastructure (Denver)~~ — DEAD (HTTP 410) ✅
+- [x] ~~Diligente Technologies — Sr. Cloud Security Engineer/Architect~~ — DEAD (page nav-only, no JD) ✅
 
 ---
 
 ## 🟡 PIPELINE IMPROVEMENTS — Make the automation smarter
 
-### Follow-up automation (wire existing followup-cadence.mjs into Telegram)
-- [ ] Create `followup-tracker.mjs` — monitors `data/applications.md` for "Applied" rows older than 5 business days with no status change
-- [ ] Telegram notification: "Stripe hasn't responded in 5 days. Reply 'follow up' to send email, or 'wait' to extend."
-- [ ] Draft follow-up email templates (short, Patrick's voice, not desperate)
-- [ ] Wire into `telegram-listener.mjs` — add "follow up #N" command
-- [ ] Track follow-up history in `data/follow-ups.md`
+### Follow-up automation ~~(wire existing followup-cadence.mjs into Telegram)~~
+- [x] Create `followup-check.mjs` — monitors Applied rows >5 biz days, Telegram reminders ✅ 2026-05-25
+- [x] Telegram notification with "follow up #N" / "wait #N" instructions ✅
+- [x] Draft follow-up email templates in `templates/follow-up-emails.md` ✅ 2026-05-25
+- [x] Wire into `telegram-listener.mjs` — "follow up #N", "wait #N", status commands ✅
+- [x] Track follow-up history in `data/follow-ups.md` ✅
+- [x] Daily cron: scan → notify → followup-check chain ✅
 
 ### Interview prep auto-generation
-- [ ] Trigger on status change: "Responded" or "Interview" → auto-generate company-specific prep doc
-- [ ] STAR stories mapped to their specific JD requirements (pull from story-bank.md)
-- [ ] Likely interview panel (scrape company LinkedIn for hiring manager + team)
-- [ ] Company culture signals (Glassdoor, recent news, tech blog)
-- [ ] Salary negotiation anchors (comp range from JD + market data)
-- [ ] Save to `interview-prep/{company}-{role}.md`
-- [ ] Telegram: "Interview prep ready for [Company]. Key: [3 bullet summary]"
+- [x] `generate-interview-prep.mjs` — auto-generates prep docs from eval reports ✅ 2026-05-25
+- [x] Trigger: `--check` mode detects Interview/Responded without existing prep ✅
+- [x] Trigger: Telegram "interview #N" auto-fires prep generation ✅
+- [x] telegram-listener.mjs now updates tracker status AND triggers prep ✅
+- [x] Daily pipeline chain includes `--check` step ✅
+- [x] npm scripts: `npm run prep`, `npm run prep:check`, `npm run followup` ✅
+- [ ] Story bank population (currently empty — needs first interview cycle)
+- [ ] LinkedIn scrape for hiring manager (blocked on LinkedIn auth)
+- [ ] Company culture signals (Glassdoor, tech blog) — inferred from JD for now
 
 ### LinkedIn Easy Apply automation
 - [ ] Extend `apply-auto.mjs` with LinkedIn Easy Apply platform detection (`linkedin.com/jobs/view/`)
@@ -86,25 +89,27 @@
 ## 🔧 SYSTEM FIXES — Known bugs and tech debt
 
 ### merge-tracker.mjs dedup bug
-- [ ] Fix: same-company different-title treated as UPDATE not ADD
-- [ ] Root cause: company-name matching is too fuzzy (substring match)
-- [ ] Fix approach: require company + role title match (not just company)
-- [ ] Add test case: two Anthropic roles should both exist in tracker
-- [ ] Verify with existing data (Anthropic has 3 rows that previously collided)
+- [x] Fix: switched roleFuzzyMatch from min-ratio to Jaccard similarity (0.75 threshold) ✅ 2026-05-25
+- [x] Root cause: overlap/minLen gave false positives for shared generic words ✅
+- [x] Test cases pass: Abridge AppSec vs InfraSec correctly treated as different ✅
+- [x] test-all.mjs passes (72/72) ✅
+- [ ] Add regression test to test-all.mjs (roleFuzzyMatch unit tests)
 
 ### scan.mjs Spanish headers
-- [ ] `## Pendientes` / `## Procesadas` in pipeline.md — should be English
-- [ ] Cosmetic fix in scan.mjs output section
-- [ ] Won't survive upstream update, but keeps local consistent
+- [x] `## Pendientes` → `## Pending` in pipeline.md ✅ 2026-05-25
+- [x] scan.mjs updated to write English headers (backward compat with legacy Spanish) ✅
+- [ ] Won't survive upstream update — re-apply after `update-system.mjs apply`
 
 ### Playwright version sync
 - [ ] CT 203 and local now both on 1.60.0 ✅
 - [ ] Add to `npm run doctor` check: warn if CT 203 version differs from local
 
 ### Built In Colorado scanner
-- [ ] Agent-mode scan with Playwright on Built In Colorado category pages
-- [ ] Extract individual job URLs (WebSearch only returned BIC category landing pages last session)
-- [ ] Add to portals.yml as a new source
+- [x] `scan-builtin.mjs` — Playwright scraper for Built In Colorado search pages ✅ 2026-05-25
+- [x] 7 search categories: Security, Cloud Security, AI, DevSecOps/SRE, Platform, InfraSec, Cybersec ✅
+- [x] Reuses portals.yml title filters and scan-history.tsv dedup ✅
+- [x] Added to daily-pipeline.sh (step 2/5) ✅
+- [ ] Test on CT 203 (needs Playwright chromium on the container)
 
 ---
 
@@ -129,8 +134,8 @@ These items are blocked on info only Patrick has:
 | Metric | Value |
 |--------|-------|
 | Total evaluated | 10 |
-| Applied | 2 (Stripe, WorkOS) |
-| Ready to apply | 2 (Abridge ×2) |
+| Applied | 4 (Stripe, WorkOS, Abridge ×2) |
+| Ready to apply | 0 |
 | Auto-apply live | ✅ threshold ≥ 4.5 |
 | Telegram listener | ✅ running on CT 203 |
 | Platforms automated | 4 (Ashby, Greenhouse, Stripe, Lever) |

--- a/TODO.md
+++ b/TODO.md
@@ -1,76 +1,161 @@
-# Career-Ops — Next Session TODO
+# Career-Ops — Master TODO
 
-> Last updated 2026-05-17 EOD. Owned by Patrick; Claude works through these next session.
+> Updated 2026-05-25. Owned by Patrick + Claude.
 
 ---
 
-## 🔴 Items from Patrick (gathering these meaningfully improves the Abridge applications)
+## 🔴 IMMEDIATE — Apply to open roles
 
-### Critical
-- [ ] **Writing samples** — drop 1-3 examples into `~/CareerOps/career-ops/writing-samples/`: past cover letter, LinkedIn About, substantive email, blog post, etc. The `_shared.md` calibration protocol auto-extracts voice patterns into `_profile.md` so future cover letters / form answers sound like Patrick.
-- [ ] **References** — 2-3 names with title, relationship, and "pre-notified Y/N" — Director of IT and Security at Viecure plus an Envision peer at minimum.
-- [ ] **Notice period + earliest start date** — standard 2 weeks at Viecure, or longer given the 3-person team?
-- [ ] **Verify cv.md dates/titles**:
-  - Viecure: *Security & Reliability Engineer · Jul 2025 – Present*
-  - Envision Cloud Security Engineer II: *Jul 2024 – Jul 2025*
-  - Envision Sysadmin → System Engineer I: *May 2018 – Jul 2024*
-- [ ] **Abridge connections** — any LinkedIn 1st/2nd connections, ex-Envision colleagues now there, anyone met at conferences?
+### Abridge (2 roles, both 4.7/4.6, remote, founding security team)
+- [ ] Submit Abridge AppSec (#2, score 4.7) via apply-auto.mjs on CT 203
+- [ ] Submit Abridge InfraSec (#3, score 4.6) via apply-auto.mjs on CT 203
+- [ ] Verify both Ashby forms still active (liveness check)
+- [ ] Tailor custom Ashby question answers using evaluation Block H + voice profile
 
-### Helpful (deepens specific stories)
-- [ ] **Fill `[TBD]` slots in `article-digest.md`** — specifically: PR-agent comment volume / pattern types, Claude Code platform user count, plugin+skill count shipped org-wide, App Insights week-1 specific wins, anonymized security-review artifacts.
-- [ ] **Bug bounty exposure** — any HackerOne/Bugcrowd submissions, internal tabletop pen-tests, CTF participation? Even tangential.
-- [ ] **Cover letter framing review** — read the 3 cover letters at `~/Documents/career-ops-2026-05-17/cover-letters/`. Anything off, missing, or to remove?
+### Stale candidates from last session
+- [ ] Evaluate: Turo — Staff Security Engineer, Infrastructure (Denver) — `https://wellfound.com/jobs/3104118-staff-security-engineer-infrastructure`
+- [ ] Evaluate: Diligente Technologies — Sr. Cloud Security Engineer/Architect (Remote) — `https://www.dice.com/job-detail/0f3c58fc-7fc0-4879-b38c-91a2fdd22cb2`
 
-### Nice to have
+---
+
+## 🟡 PIPELINE IMPROVEMENTS — Make the automation smarter
+
+### Follow-up automation (wire existing followup-cadence.mjs into Telegram)
+- [ ] Create `followup-tracker.mjs` — monitors `data/applications.md` for "Applied" rows older than 5 business days with no status change
+- [ ] Telegram notification: "Stripe hasn't responded in 5 days. Reply 'follow up' to send email, or 'wait' to extend."
+- [ ] Draft follow-up email templates (short, Patrick's voice, not desperate)
+- [ ] Wire into `telegram-listener.mjs` — add "follow up #N" command
+- [ ] Track follow-up history in `data/follow-ups.md`
+
+### Interview prep auto-generation
+- [ ] Trigger on status change: "Responded" or "Interview" → auto-generate company-specific prep doc
+- [ ] STAR stories mapped to their specific JD requirements (pull from story-bank.md)
+- [ ] Likely interview panel (scrape company LinkedIn for hiring manager + team)
+- [ ] Company culture signals (Glassdoor, recent news, tech blog)
+- [ ] Salary negotiation anchors (comp range from JD + market data)
+- [ ] Save to `interview-prep/{company}-{role}.md`
+- [ ] Telegram: "Interview prep ready for [Company]. Key: [3 bullet summary]"
+
+### LinkedIn Easy Apply automation
+- [ ] Extend `apply-auto.mjs` with LinkedIn Easy Apply platform detection (`linkedin.com/jobs/view/`)
+- [ ] Map LinkedIn form fields (resume upload, phone, address, work auth, cover letter toggle)
+- [ ] Use existing `auth/linkedin-state.json` cookies
+- [ ] Test on a throwaway application first
+- [ ] Add `linkedin` to `auto_apply_platforms` in profile.yml
+
+### Recruiter outreach engine
+- [ ] After applying, auto-find hiring manager/recruiter on LinkedIn (from job posting or company page)
+- [ ] Draft connection request note (1-2 sentences, Patrick's voice): "Applied to [Role] — [one proof point]."
+- [ ] Telegram: "Found recruiter [Name] at [Company]. Reply 'connect' to send request."
+- [ ] Wire into `telegram-listener.mjs` — add "connect #N" command
+- [ ] Rate limit: max 5 connection requests/day to avoid LinkedIn jail
+
+### Response tracking (email → status updates)
+- [ ] Set up forwarding rule: recruiter replies → specific label/folder
+- [ ] Parse inbound for signals: "schedule", "interview", "unfortunately", "move forward"
+- [ ] Auto-update tracker status: reply detected → "Responded", interview invite → "Interview", rejection → "Rejected"
+- [ ] Telegram notification on every status change
+- [ ] Fallback: manual "responded #N" / "interview #N" / "rejected #N" commands in listener
+
+---
+
+## 🟢 DIFFERENTIATION — Stand out from other candidates
+
+### Portfolio writeup (moorelab.cloud)
+- [ ] Write a case study for moorelab.cloud: "I built a system that auto-evaluates jobs, generates tailored resumes, and submits applications via headless Playwright — all from a Proxmox container, triggered by Telegram"
+- [ ] Include architecture diagram (scan → evaluate → apply flow)
+- [ ] Metrics: X evaluations, Y auto-applies, Z platforms supported
+- [ ] Frame as: "This is what I do at work — build AI agents that automate complex workflows in regulated environments. Here's one I built for myself."
+- [ ] Link from cover letters: "moorelab.cloud has the details"
+
+### Competitive intelligence layer
+- [ ] For each applied company, auto-pull: recent funding, headcount growth, Glassdoor trends
+- [ ] Add to interview-prep docs
+- [ ] Feed into cover letter generation (reference company's recent moves)
+- [ ] Check for recent security incidents (shows awareness, potential conversation starter)
+- [ ] Sources: Crunchbase API (free tier), Glassdoor scrape, Google News
+
+### Score recalibration from outcomes
+- [ ] After 20+ applications, analyze: which scores correlate with callbacks?
+- [ ] Track: score → response rate → interview rate → offer rate
+- [ ] Auto-adjust thresholds based on actual outcomes
+- [ ] Monthly Telegram report: "Your 4.3+ roles get callbacks 60% of the time. Consider lowering auto-apply to 4.3."
+
+---
+
+## 🔧 SYSTEM FIXES — Known bugs and tech debt
+
+### merge-tracker.mjs dedup bug
+- [ ] Fix: same-company different-title treated as UPDATE not ADD
+- [ ] Root cause: company-name matching is too fuzzy (substring match)
+- [ ] Fix approach: require company + role title match (not just company)
+- [ ] Add test case: two Anthropic roles should both exist in tracker
+- [ ] Verify with existing data (Anthropic has 3 rows that previously collided)
+
+### scan.mjs Spanish headers
+- [ ] `## Pendientes` / `## Procesadas` in pipeline.md — should be English
+- [ ] Cosmetic fix in scan.mjs output section
+- [ ] Won't survive upstream update, but keeps local consistent
+
+### Playwright version sync
+- [ ] CT 203 and local now both on 1.60.0 ✅
+- [ ] Add to `npm run doctor` check: warn if CT 203 version differs from local
+
+### Built In Colorado scanner
+- [ ] Agent-mode scan with Playwright on Built In Colorado category pages
+- [ ] Extract individual job URLs (WebSearch only returned BIC category landing pages last session)
+- [ ] Add to portals.yml as a new source
+
+---
+
+## 📋 PATRICK'S INPUT NEEDED
+
+These items are blocked on info only Patrick has:
+
+- [ ] **References** — 2-3 names (Viecure Director of IT + Security, Envision peer, anyone else)
+- [ ] **Notice period** — 2 weeks standard, or longer for 3-person team?
+- [ ] **Verify cv.md dates/titles** — Viecure Jul 2025–Present, Envision Jul 2024–Jul 2025, etc.
+- [ ] **Abridge connections** — any LinkedIn 1st/2nd at Abridge?
+- [ ] **Fill `[TBD]` slots in article-digest.md** — PR-agent comment volume, Claude Code platform user count, plugin+skill count, App Insights week-1 wins
+- [ ] **Open to contract-to-hire?** — Probably no, confirm
+- [x] **Writing samples** — voice profile calibrated 2026-05-23 ✅
+- [ ] **Portfolio writeup review** — once drafted, Patrick reviews tone on moorelab.cloud
 - [ ] **Pronouns / EEO self-ID preferences** for form fields
-- [ ] **"How did you hear about Abridge?"** framing — career-ops scanner (honest) vs softer framing
-- [ ] **Open to contract-to-hire?** Probably no — confirm
 
 ---
 
-## 🟢 Tasks Claude will run next session
+## 📊 METRICS (updated 2026-05-25)
 
-### Tier 1 — apply pipeline
-- [ ] Walk the Abridge Ashby form (both AppSec + InfraSec) — extract custom questions, tailor answers using Block H prose and the refreshed cover letters
-- [ ] Evaluate the 2 new candidates surfaced from agent-mode scan:
-  - **Turo — Staff Security Engineer, Infrastructure (Denver)** — `https://wellfound.com/jobs/3104118-staff-security-engineer-infrastructure` — likely Denver-based Staff InfraSec, direct fit pattern
-  - **Diligente Technologies — Sr. Cloud Security Engineer/Architect (Remote)** — `https://www.dice.com/job-detail/0f3c58fc-7fc0-4879-b38c-91a2fdd22cb2` — Azure-preferred, consultancy-flavored
-
-### Tier 2 — funnel
-- [ ] Once writing samples are dropped, re-run cover letter generation with calibrated voice
-- [ ] Ask MongoDB recruiter (#5 in heuristic top) whether the SRE/InfraSec remote-US restriction (ET/CT only) flexes to Denver MT
-- [ ] Agent-mode scan with Playwright follow-up on Built In Colorado category pages to extract individual job URLs (WebSearch only returned BIC category landing pages last session)
-
-### Tier 3 — system improvements
-- [ ] Patch `merge-tracker.mjs` dedup bug (added 2026-05-17) — currently treats same-company different-title as UPDATE not ADD. Workaround: hand-edit `data/applications.md` for same-company overlaps. See `feedback_merge_tracker_dedup_bug.md` in memory.
-- [ ] Re-evaluate `scan.mjs` Spanish-headers issue — currently writes `## Pendientes` / `## Procesadas` into `data/pipeline.md` even though modes/ is translated. Cosmetic, not blocking.
-- [ ] Confirm Telegram delivery from yesterday's test scan landed
-- [ ] (Long-term) Set up LinkedIn email-alerts → forwarding to auto-parse into pipeline.md, if Patrick wants hands-off LinkedIn ingestion
+| Metric | Value |
+|--------|-------|
+| Total evaluated | 10 |
+| Applied | 2 (Stripe, WorkOS) |
+| Ready to apply | 2 (Abridge ×2) |
+| Auto-apply live | ✅ threshold ≥ 4.5 |
+| Telegram listener | ✅ running on CT 203 |
+| Platforms automated | 4 (Ashby, Greenhouse, Stripe, Lever) |
+| Daily scanner | ✅ 07:00 MDT cron |
+| Voice profile | ✅ calibrated |
+| Cover letters generated | 4 (Abridge ×2, Stripe, WorkOS) |
 
 ---
 
-## 📌 Open application status (after location-policy hardening EOD 2026-05-17)
+## 🗓️ PRIORITY ORDER
 
-| # | Company | Role | Score | Status |
-|---|---|---|---|---|
-| 2 | **Abridge** | Sr/Staff Application Security Engineer | **4.7** | 🟢 Ready to apply (remote ✓) |
-| 3 | **Abridge** | Sr/Staff Infrastructure Security Engineer | **4.6** | 🟢 Ready to apply (remote ✓) |
-| 1, 4, 5, 7 | Anthropic ×3, CoreWeave | various | 1.0 | 🔴 SKIP — required travel to non-Denver offices |
-| 6 | Cohere Health | Lead SA | 3.5 | 🔴 SKIP — comp below $160K floor |
-
-**Two viable, both fully remote, both at Abridge.** All packages on Mac at `~/Documents/career-ops-2026-05-17/`:
-- ATS-PDF + polished DOCX per role
-- Tailored cover letter per role
-- Combined Abridge interview-prep brief
+1. **Now:** Submit Abridge applications (2 roles, highest scores in pipeline)
+2. **Today:** Evaluate Turo + Diligente candidates
+3. **This week:** Follow-up automation, interview prep auto-gen, portfolio writeup
+4. **Next week:** LinkedIn Easy Apply, recruiter outreach, response tracking
+5. **Ongoing:** Score recalibration, competitive intel, system fixes
 
 ---
 
 ## 🧠 Memory pointers (for next session's Claude)
 
-These are key memory files the next Claude should read up front:
 - `MEMORY.md` — index (auto-loaded)
-- `feedback_location_policy.md` — hard rule: remote-or-Denver only, no required travel to non-Denver hubs (hardened 2026-05-17 EOD)
-- `feedback_cv_output_format.md` — produce BOTH PDF (ATS) and DOCX (polished) via `anthropic-skills:docx`
+- `feedback_location_policy.md` — hard rule: remote-or-Denver only, no required travel
+- `feedback_cv_output_format.md` — produce BOTH PDF (ATS) and DOCX (polished)
 - `project_careerops_english_modes.md` — modes/ is translated, will revert on upstream update
 - `feedback_merge_tracker_dedup_bug.md` — verify diff after every merge-tracker run
-- `reference_job_sources.md` — 37 search queries + 99 tracked companies inventory
+- `reference_job_sources.md` — 37 search queries + 99 tracked companies
+- `voice_profile.md` — calibrated writing voice for CV/cover letter generation

--- a/TODO.md
+++ b/TODO.md
@@ -65,11 +65,12 @@
 ## 🟢 DIFFERENTIATION — Stand out from other candidates
 
 ### Portfolio writeup (moorelab.cloud)
-- [ ] Write a case study for moorelab.cloud: "I built a system that auto-evaluates jobs, generates tailored resumes, and submits applications via headless Playwright — all from a Proxmox container, triggered by Telegram"
-- [ ] Include architecture diagram (scan → evaluate → apply flow)
-- [ ] Metrics: X evaluations, Y auto-applies, Z platforms supported
-- [ ] Frame as: "This is what I do at work — build AI agents that automate complex workflows in regulated environments. Here's one I built for myself."
-- [ ] Link from cover letters: "moorelab.cloud has the details"
+- [x] Case study drafted: `output/portfolio-case-study-career-ops.md` ✅ 2026-05-25
+- [x] Architecture diagram (ASCII, scan → evaluate → apply → followup → prep) ✅
+- [x] Metrics table (10 evals, 4 applied, 4 platforms, 99 companies, 77 tests) ✅
+- [x] Framing: "same pattern I apply at work — regulated-env AI automation with HITL" ✅
+- [x] Cover letters already link moorelab.cloud ✅
+- [ ] **PATRICK:** Review tone, publish to moorelab.cloud, add screenshots of auto-apply
 
 ### Competitive intelligence layer
 - [ ] For each applied company, auto-pull: recent funding, headcount growth, Glassdoor trends
@@ -134,24 +135,30 @@ These items are blocked on info only Patrick has:
 | Metric | Value |
 |--------|-------|
 | Total evaluated | 10 |
-| Applied | 4 (Stripe, WorkOS, Abridge ×2) |
-| Ready to apply | 0 |
+| Applied | 4 (Stripe, WorkOS, Abridge AppSec, Abridge InfraSec) |
+| Ready to apply | 0 (all viable candidates applied) |
 | Auto-apply live | ✅ threshold ≥ 4.5 |
 | Telegram listener | ✅ running on CT 203 |
 | Platforms automated | 4 (Ashby, Greenhouse, Stripe, Lever) |
 | Daily scanner | ✅ 07:00 MDT cron |
 | Voice profile | ✅ calibrated |
 | Cover letters generated | 4 (Abridge ×2, Stripe, WorkOS) |
+| Story bank stories | 7 (STAR+R format) |
+| Interview prep docs | 1 (Abridge) |
+| Telegram commands | 12 |
+| Test suite | 77 checks |
+| Portfolio case study | ✅ drafted |
 
 ---
 
 ## 🗓️ PRIORITY ORDER
 
-1. **Now:** Submit Abridge applications (2 roles, highest scores in pipeline)
-2. **Today:** Evaluate Turo + Diligente candidates
-3. **This week:** Follow-up automation, interview prep auto-gen, portfolio writeup
-4. **Next week:** LinkedIn Easy Apply, recruiter outreach, response tracking
-5. **Ongoing:** Score recalibration, competitive intel, system fixes
+1. ~~**Now:** Submit Abridge applications~~ ✅ Done (both applied 2026-05-25)
+2. ~~**Today:** Evaluate Turo + Diligente~~ ✅ Both expired
+3. ~~**This week:** Follow-up automation, interview prep, portfolio~~ ✅ All built
+4. **Next:** LinkedIn Easy Apply automation, recruiter outreach engine
+5. **Waiting on Patrick:** Portfolio review/publish, references, cv.md date verify, EEO prefs
+6. **Ongoing:** Score recalibration (needs 20+ applications), competitive intel
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,76 @@
+# Career-Ops — Next Session TODO
+
+> Last updated 2026-05-17 EOD. Owned by Patrick; Claude works through these next session.
+
+---
+
+## 🔴 Items from Patrick (gathering these meaningfully improves the Abridge applications)
+
+### Critical
+- [ ] **Writing samples** — drop 1-3 examples into `~/CareerOps/career-ops/writing-samples/`: past cover letter, LinkedIn About, substantive email, blog post, etc. The `_shared.md` calibration protocol auto-extracts voice patterns into `_profile.md` so future cover letters / form answers sound like Patrick.
+- [ ] **References** — 2-3 names with title, relationship, and "pre-notified Y/N" — Director of IT and Security at Viecure plus an Envision peer at minimum.
+- [ ] **Notice period + earliest start date** — standard 2 weeks at Viecure, or longer given the 3-person team?
+- [ ] **Verify cv.md dates/titles**:
+  - Viecure: *Security & Reliability Engineer · Jul 2025 – Present*
+  - Envision Cloud Security Engineer II: *Jul 2024 – Jul 2025*
+  - Envision Sysadmin → System Engineer I: *May 2018 – Jul 2024*
+- [ ] **Abridge connections** — any LinkedIn 1st/2nd connections, ex-Envision colleagues now there, anyone met at conferences?
+
+### Helpful (deepens specific stories)
+- [ ] **Fill `[TBD]` slots in `article-digest.md`** — specifically: PR-agent comment volume / pattern types, Claude Code platform user count, plugin+skill count shipped org-wide, App Insights week-1 specific wins, anonymized security-review artifacts.
+- [ ] **Bug bounty exposure** — any HackerOne/Bugcrowd submissions, internal tabletop pen-tests, CTF participation? Even tangential.
+- [ ] **Cover letter framing review** — read the 3 cover letters at `~/Documents/career-ops-2026-05-17/cover-letters/`. Anything off, missing, or to remove?
+
+### Nice to have
+- [ ] **Pronouns / EEO self-ID preferences** for form fields
+- [ ] **"How did you hear about Abridge?"** framing — career-ops scanner (honest) vs softer framing
+- [ ] **Open to contract-to-hire?** Probably no — confirm
+
+---
+
+## 🟢 Tasks Claude will run next session
+
+### Tier 1 — apply pipeline
+- [ ] Walk the Abridge Ashby form (both AppSec + InfraSec) — extract custom questions, tailor answers using Block H prose and the refreshed cover letters
+- [ ] Evaluate the 2 new candidates surfaced from agent-mode scan:
+  - **Turo — Staff Security Engineer, Infrastructure (Denver)** — `https://wellfound.com/jobs/3104118-staff-security-engineer-infrastructure` — likely Denver-based Staff InfraSec, direct fit pattern
+  - **Diligente Technologies — Sr. Cloud Security Engineer/Architect (Remote)** — `https://www.dice.com/job-detail/0f3c58fc-7fc0-4879-b38c-91a2fdd22cb2` — Azure-preferred, consultancy-flavored
+
+### Tier 2 — funnel
+- [ ] Once writing samples are dropped, re-run cover letter generation with calibrated voice
+- [ ] Ask MongoDB recruiter (#5 in heuristic top) whether the SRE/InfraSec remote-US restriction (ET/CT only) flexes to Denver MT
+- [ ] Agent-mode scan with Playwright follow-up on Built In Colorado category pages to extract individual job URLs (WebSearch only returned BIC category landing pages last session)
+
+### Tier 3 — system improvements
+- [ ] Patch `merge-tracker.mjs` dedup bug (added 2026-05-17) — currently treats same-company different-title as UPDATE not ADD. Workaround: hand-edit `data/applications.md` for same-company overlaps. See `feedback_merge_tracker_dedup_bug.md` in memory.
+- [ ] Re-evaluate `scan.mjs` Spanish-headers issue — currently writes `## Pendientes` / `## Procesadas` into `data/pipeline.md` even though modes/ is translated. Cosmetic, not blocking.
+- [ ] Confirm Telegram delivery from yesterday's test scan landed
+- [ ] (Long-term) Set up LinkedIn email-alerts → forwarding to auto-parse into pipeline.md, if Patrick wants hands-off LinkedIn ingestion
+
+---
+
+## 📌 Open application status (after location-policy hardening EOD 2026-05-17)
+
+| # | Company | Role | Score | Status |
+|---|---|---|---|---|
+| 2 | **Abridge** | Sr/Staff Application Security Engineer | **4.7** | 🟢 Ready to apply (remote ✓) |
+| 3 | **Abridge** | Sr/Staff Infrastructure Security Engineer | **4.6** | 🟢 Ready to apply (remote ✓) |
+| 1, 4, 5, 7 | Anthropic ×3, CoreWeave | various | 1.0 | 🔴 SKIP — required travel to non-Denver offices |
+| 6 | Cohere Health | Lead SA | 3.5 | 🔴 SKIP — comp below $160K floor |
+
+**Two viable, both fully remote, both at Abridge.** All packages on Mac at `~/Documents/career-ops-2026-05-17/`:
+- ATS-PDF + polished DOCX per role
+- Tailored cover letter per role
+- Combined Abridge interview-prep brief
+
+---
+
+## 🧠 Memory pointers (for next session's Claude)
+
+These are key memory files the next Claude should read up front:
+- `MEMORY.md` — index (auto-loaded)
+- `feedback_location_policy.md` — hard rule: remote-or-Denver only, no required travel to non-Denver hubs (hardened 2026-05-17 EOD)
+- `feedback_cv_output_format.md` — produce BOTH PDF (ATS) and DOCX (polished) via `anthropic-skills:docx`
+- `project_careerops_english_modes.md` — modes/ is translated, will revert on upstream update
+- `feedback_merge_tracker_dedup_bug.md` — verify diff after every merge-tracker run
+- `reference_job_sources.md` — 37 search queries + 99 tracked companies inventory

--- a/TODO.md
+++ b/TODO.md
@@ -1,20 +1,24 @@
 # Career-Ops — Master TODO
 
-> Updated 2026-05-25. Owned by Patrick + Claude.
+> Updated 2026-07-06. Owned by Patrick + Claude.
 
 ---
 
-## 🔴 IMMEDIATE — Apply to open roles
+## 🔴 IMMEDIATE
 
-### Abridge (2 roles, both 4.7/4.6, remote, founding security team)
-- [x] Submit Abridge AppSec (#2, score 4.7) via apply-auto.mjs on CT 203 ✅ 2026-05-25
-- [x] Submit Abridge InfraSec (#3, score 4.6) via apply-auto.mjs on CT 203 ✅ 2026-05-25
-- [x] Verify both Ashby forms still active (liveness check) ✅
-- [ ] Tailor custom Ashby question answers using evaluation Block H + voice profile
+### Pipeline hardening (2026-07-06) — done, one manual step left
+- [x] Scorer fail-closed: location gate + enforcePolicy() + Sonnet 5 eval ✅ deployed to CT 203
+- [x] Auto-apply rewired: triage ≥4.5 → apply-orchestrator (gate+eval both clean) ✅ live for tomorrow's 07:00 cron
+- [x] Data layer repaired: tracker restored on CT 203, reports renumbered 015-024, sync-ct203.sh ✅
+- [x] Finder expanded: Workday (Tempus/CrowdStrike/DaVita), OpenAI/Twilio/SentinelOne/HiddenLayer/Gong/Dialpad/LivePerson boards, BIC scraper fixed ✅
+- [ ] **PATRICK:** install the BIC cron step: `ssh root@10.1.30.50 "cp /opt/career-ops/career-scan.new /usr/local/bin/career-scan && chmod +x /usr/local/bin/career-scan"`
+- [ ] Fresh base CV PDF for unattended applies (current fallback = Stripe-tailored from 05-25); name it to sort last in output/, e.g. `cv-patrick-moore-zz-base-<date>.pdf`
 
-### Stale candidates from last session
-- [x] ~~Turo — Staff Security Engineer, Infrastructure (Denver)~~ — DEAD (HTTP 410) ✅
-- [x] ~~Diligente Technologies — Sr. Cloud Security Engineer/Architect~~ — DEAD (page nav-only, no JD) ✅
+### Follow-ups overdue (31 business days, no responses)
+- [ ] Stripe / WorkOS / Abridge ×2 — followup-check now works again (tracker was missing on CT 203); Telegram reminder fires with tomorrow's cron. Decide: follow up or let die.
+
+### Backlog shortlist (verified live 2026-07-06, deprioritized by Patrick — apply via "apply #N" or ask Claude)
+- Hightouch EM Agents 4.6 (remote NA, $220-400K) · Cloudflare DistSys 4.1 (Denver office!) · Vercel Security Cloud 4.3 (remote US) · Snowflake FDE 4.3 (remote US) · Komodo FDE 4.5→4.0 re-eval (remote US) · Databricks FDE 4.1 (20% customer travel — gray)
 
 ---
 

--- a/apply-auto.mjs
+++ b/apply-auto.mjs
@@ -1,0 +1,1016 @@
+#!/usr/bin/env node
+
+/**
+ * apply-auto.mjs — Server-side application automation via Playwright
+ *
+ * Runs entirely on Proxmox (CT 203). No MacBook needed.
+ * Fills ATS forms, uploads resume PDF, takes screenshot for review.
+ *
+ * Usage:
+ *   node apply-auto.mjs <url> <pdf-path> [--cover-letter=path] [--submit] [--screenshot=path]
+ *
+ * Supported platforms:
+ *   - Ashby (jobs.ashbyhq.com)
+ *   - Greenhouse (boards.greenhouse.io)
+ *   - Lever (jobs.lever.co)
+ *   - Generic (best-effort field detection)
+ *
+ * Without --submit, fills the form and pauses for review (takes screenshot).
+ * With --submit, clicks the submit button after filling.
+ *
+ * Requires: playwright installed with chromium browser.
+ */
+
+import { chromium } from 'playwright';
+import { resolve, dirname } from 'path';
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Parse CLI args ──────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const flags = {};
+const positional = [];
+
+for (const arg of args) {
+  if (arg.startsWith('--')) {
+    const [key, val] = arg.slice(2).split('=');
+    flags[key] = val ?? true;
+  } else {
+    positional.push(arg);
+  }
+}
+
+const url = positional[0];
+const pdfPath = positional[1];
+const coverLetterPath = flags['cover-letter'];
+const shouldSubmit = flags.submit === true;
+const screenshotPath = flags.screenshot || 'output/apply-screenshot.png';
+const authStatePath = flags.auth || null; // Path to saved browser state (from browser-login.mjs)
+
+if (!url || !pdfPath) {
+  console.error('Usage: node apply-auto.mjs <url> <pdf-path> [--cover-letter=path] [--submit] [--screenshot=path]');
+  process.exit(1);
+}
+
+if (!existsSync(pdfPath)) {
+  console.error(`PDF not found: ${pdfPath}`);
+  process.exit(1);
+}
+
+// ── Load profile data ───────────────────────────────────────────
+
+async function loadProfile() {
+  const profilePath = resolve(__dirname, 'config/profile.yml');
+  const raw = await readFile(profilePath, 'utf-8');
+  // Simple YAML parser for our flat structure
+  const profile = {};
+  const lines = raw.split('\n');
+  let currentSection = null;
+
+  for (const line of lines) {
+    if (line.startsWith('#') || line.trim() === '') continue;
+
+    // Top-level key
+    const topMatch = line.match(/^(\w[\w_]*)\s*:/);
+    if (topMatch && !line.includes('"') && !line.includes("'")) {
+      currentSection = topMatch[1];
+      profile[currentSection] = {};
+      continue;
+    }
+
+    // Nested key-value
+    const kvMatch = line.match(/^\s+(\w[\w_]*)\s*:\s*"?([^"]*)"?\s*$/);
+    if (kvMatch && currentSection) {
+      profile[currentSection][kvMatch[1]] = kvMatch[2].replace(/^['"]|['"]$/g, '');
+    }
+  }
+
+  return profile;
+}
+
+// ── Load cover letter text ──────────────────────────────────────
+
+async function loadCoverLetter(path) {
+  if (!path || !existsSync(path)) return null;
+  const raw = await readFile(path, 'utf-8');
+  // Strip markdown header and signature
+  const lines = raw.split('\n');
+  const bodyLines = [];
+  let inBody = false;
+  for (const line of lines) {
+    if (line.startsWith('---')) {
+      if (inBody) break; // end of body
+      inBody = true;
+      continue;
+    }
+    if (inBody && !line.startsWith('#') && !line.startsWith('**Patrick')) {
+      bodyLines.push(line);
+    }
+  }
+  return bodyLines.join('\n').trim() || raw;
+}
+
+// ── Platform detection ──────────────────────────────────────────
+
+function detectPlatform(pageUrl) {
+  if (pageUrl.includes('ashbyhq.com')) return 'ashby';
+  if (pageUrl.includes('greenhouse.io') || pageUrl.includes('boards.greenhouse')) return 'greenhouse';
+  if (pageUrl.includes('lever.co')) return 'lever';
+  if (pageUrl.includes('myworkdayjobs.com') || pageUrl.includes('workday.com')) return 'workday';
+  if (pageUrl.includes('stripe.com')) return 'stripe';
+  return 'generic';
+}
+
+// ── Ashby form filler ───────────────────────────────────────────
+
+async function fillAshby(page, profile, pdfPath, coverLetter) {
+  const c = profile.candidate || {};
+  console.log('🔧 Platform: Ashby');
+
+  // Ashby uses React — no <form> tag. Wait for input fields directly.
+  await page.waitForSelector('input[type="text"], input[type="email"]', { timeout: 15000 });
+  await page.waitForTimeout(1500); // Let React finish rendering
+
+  // ── Step 1: Upload resume FIRST so Ashby's parser runs ────────
+  // Ashby parses uploaded resumes and autofills fields. We upload first,
+  // wait for parsing to finish, THEN overwrite with our clean data.
+  console.log('  📤 Uploading resume first (Ashby parses and autofills)...');
+  const fileInput = await page.$('input[type="file"]');
+  if (fileInput) {
+    await fileInput.setInputFiles(resolve(pdfPath));
+    console.log(`  ✅ Resume uploaded: ${pdfPath}`);
+  } else {
+    console.log('  ⚠️ No file input found — trying Upload button...');
+    const uploadBtn = await page.$('button:has-text("Upload"), label:has-text("Upload")');
+    if (uploadBtn) {
+      const [fileChooser] = await Promise.all([
+        page.waitForEvent('filechooser', { timeout: 5000 }),
+        uploadBtn.click(),
+      ]);
+      await fileChooser.setFiles(resolve(pdfPath));
+      console.log(`  ✅ Resume uploaded via file chooser: ${pdfPath}`);
+    }
+  }
+
+  // Wait for Ashby's resume parser to finish autofilling
+  // The banner "Parsing your resume. Autofilling key fields..." disappears when done
+  console.log('  ⏳ Waiting for Ashby resume parser to finish...');
+  try {
+    await page.waitForSelector('text=Parsing your resume', { timeout: 5000 });
+    // Now wait for it to disappear (parsing done)
+    await page.waitForSelector('text=Parsing your resume', { state: 'hidden', timeout: 15000 });
+    console.log('  ✅ Resume parsing complete');
+  } catch {
+    // Parser banner might not appear or might already be done
+    console.log('  ⏩ Resume parser banner not detected — continuing');
+  }
+  await page.waitForTimeout(1000); // Extra settle time
+
+  // ── Step 2: Fill all text inputs (overwriting parser autofill) ─
+  const allInputs = await page.$$('input:not([type="hidden"]):not([type="submit"]):not([type="file"]):not([type="checkbox"]):not([type="radio"])');
+
+  for (const input of allInputs) {
+    const label = await getFieldLabel(page, input);
+    const placeholder = (await input.getAttribute('placeholder')) || '';
+    const type = (await input.getAttribute('type')) || 'text';
+    const hint = `${label} ${placeholder}`.toLowerCase();
+
+    if (hint.includes('name') && !hint.includes('linkedin') && !hint.includes('github') && type === 'text' && (hint.includes('type here') || hint.includes('name'))) {
+      await input.fill('');
+      await input.fill(c.full_name || 'Patrick Moore');
+      console.log(`  ✅ Name: ${c.full_name}`);
+    } else if (type === 'email' || hint.includes('email') || hint.includes('hello@')) {
+      await input.fill('');
+      await input.fill(c.email || 'patrick.james.moore@protonmail.com');
+      console.log(`  ✅ Email: ${c.email}`);
+    } else if (type === 'tel' || hint.includes('phone') || hint.includes('1-415')) {
+      await input.fill('');
+      await input.fill(c.phone || '303-514-3586');
+      console.log(`  ✅ Phone: ${c.phone}`);
+    } else if (hint.includes('linkedin')) {
+      await input.fill('');
+      await input.fill(`https://${c.linkedin || 'linkedin.com/in/patrick-moore-25a13a16'}`);
+      console.log(`  ✅ LinkedIn`);
+    } else if (hint.includes('github')) {
+      await input.fill('');
+      await input.fill(`https://${c.github || 'github.com/tricheboars'}`);
+      console.log(`  ✅ GitHub`);
+    } else if (hint.includes('portfolio')) {
+      await input.fill('');
+      await input.fill(c.portfolio_url || 'https://moorelab.cloud');
+      console.log(`  ✅ Portfolio`);
+    }
+  }
+
+  // ── Step 3: Location combobox ─────────────────────────────────
+  // Ashby uses a combobox. Type slowly, wait for dropdown, pick exact match via evaluate.
+  const locationInput = await page.$('input[placeholder*="Start typing"], input[role="combobox"]');
+  if (locationInput) {
+    await locationInput.click();
+    await locationInput.fill('');
+    await page.waitForTimeout(300);
+    await locationInput.type('Denver, Col', { delay: 100 }); // Type slowly for autocomplete
+    await page.waitForTimeout(2000); // Wait for dropdown to populate
+
+    // Use evaluate to find and click the exact Denver option from the dropdown
+    const locationSelected = await page.evaluate(() => {
+      // Find all role="option" elements
+      const options = document.querySelectorAll('[role="option"]');
+      for (const opt of options) {
+        const text = opt.textContent.trim();
+        if (text.startsWith('Denver, Colorado')) {
+          opt.click();
+          return text;
+        }
+      }
+      // Fallback: find any li or div in a listbox that mentions Denver
+      const listItems = document.querySelectorAll('[role="listbox"] > *, ul[class*="dropdown"] > li, div[class*="option"]');
+      for (const item of listItems) {
+        const text = item.textContent.trim();
+        if (text.includes('Denver') && text.includes('Colorado') && text.length < 100) {
+          item.click();
+          return text;
+        }
+      }
+      return null;
+    });
+
+    if (locationSelected) {
+      console.log(`  ✅ Location: ${locationSelected}`);
+    } else {
+      // Last resort: press down arrow + enter to select first suggestion
+      await locationInput.press('ArrowDown');
+      await page.waitForTimeout(200);
+      await locationInput.press('Enter');
+      console.log('  ⚠️ Location: Denver (arrow-down + enter fallback)');
+    }
+  }
+
+  // ── Step 4: Work authorization Yes/No buttons ─────────────────
+  // Ashby renders Yes/No as styled <button> elements in question blocks.
+  // Strategy: find all Yes/No button PAIRS, then identify which question
+  // each pair belongs to by scanning nearby text nodes.
+  await page.waitForTimeout(500);
+
+  const buttonsResult = await page.evaluate(() => {
+    // Find all button groups that contain exactly Yes + No buttons
+    const allButtons = Array.from(document.querySelectorAll('button'));
+    const results = { auth: false, sponsor: false };
+
+    // Group buttons by their parent container
+    const buttonGroups = new Map();
+    for (const btn of allButtons) {
+      const text = btn.textContent.trim();
+      if (text === 'Yes' || text === 'No') {
+        const parent = btn.parentElement;
+        if (!buttonGroups.has(parent)) {
+          buttonGroups.set(parent, []);
+        }
+        buttonGroups.get(parent).push(btn);
+      }
+    }
+
+    // For each Yes/No pair, find the question it belongs to
+    const groups = Array.from(buttonGroups.entries());
+    for (const [parent, buttons] of groups) {
+      const yesBtn = buttons.find(b => b.textContent.trim() === 'Yes');
+      const noBtn = buttons.find(b => b.textContent.trim() === 'No');
+      if (!yesBtn || !noBtn) continue;
+
+      // Walk up to find nearby question text
+      let container = parent;
+      let questionText = '';
+      for (let i = 0; i < 6; i++) {
+        container = container.parentElement;
+        if (!container) break;
+        questionText = container.textContent || '';
+        // Stop walking up once we have enough context to identify the question
+        if (questionText.includes('authorized') || questionText.includes('sponsorship')) break;
+      }
+
+      if (questionText.includes('legally authorized') && !results.auth) {
+        yesBtn.click();
+        results.auth = true;
+      } else if (questionText.includes('sponsorship') && !results.sponsor) {
+        noBtn.click();
+        results.sponsor = true;
+      }
+    }
+
+    return results;
+  });
+
+  if (buttonsResult.auth) {
+    console.log('  ✅ Work authorization: Yes');
+  } else {
+    console.log('  ⚠️ Work authorization: Yes button not found');
+  }
+  if (buttonsResult.sponsor) {
+    console.log('  ✅ Sponsorship required: No');
+  } else {
+    console.log('  ⚠️ Sponsorship: No button not found');
+  }
+
+  // ── Step 5: Cover letter / additional info textarea ───────────
+  if (coverLetter) {
+    const textareas = await page.$$('textarea');
+    for (const ta of textareas) {
+      const label = await getFieldLabel(page, ta);
+      const labelLower = label.toLowerCase();
+      if (labelLower.includes('cover') || labelLower.includes('additional') || labelLower.includes('anything else') || labelLower.includes('why')) {
+        await ta.fill(coverLetter);
+        console.log(`  ✅ Cover letter filled in "${label}"`);
+        break;
+      }
+    }
+  }
+}
+
+// ── Greenhouse form filler ──────────────────────────────────────
+
+async function fillGreenhouse(page, profile, pdfPath, coverLetter) {
+  const c = profile.candidate || {};
+  console.log('🔧 Platform: Greenhouse');
+
+  await page.waitForSelector('#first_name, #application_form, form', { timeout: 10000 });
+  await page.waitForTimeout(1000);
+
+  // Greenhouse uses specific IDs
+  const fieldMap = {
+    '#first_name': c.full_name?.split(' ')[0] || 'Patrick',
+    '#last_name': c.full_name?.split(' ').pop() || 'Moore',
+    '#email': c.email || 'patrick.james.moore@protonmail.com',
+    '#phone': c.phone || '303-514-3586',
+  };
+
+  for (const [selector, value] of Object.entries(fieldMap)) {
+    const field = await page.$(selector);
+    if (field) {
+      await field.fill(value);
+      console.log(`  ✅ ${selector}: ${value}`);
+    }
+  }
+
+  // Location (City) — Greenhouse autocomplete
+  const locationField = await page.$('#candidate-location');
+  if (locationField) {
+    await locationField.fill('');
+    await locationField.type('Denver, CO', { delay: 80 });
+    await page.waitForTimeout(1500);
+    // Try to click autocomplete suggestion
+    const locSuggestion = await page.$('.autocomplete-results li, [class*="suggestion"], [role="option"]');
+    if (locSuggestion) {
+      await locSuggestion.click();
+      console.log('  ✅ Location: Denver, CO (selected from autocomplete)');
+    } else {
+      console.log('  ✅ Location: Denver, CO (typed)');
+    }
+  }
+
+  // Resume upload
+  const resumeInput = await page.$('#resume, input[type="file"][name*="resume"], input[type="file"]:first-of-type');
+  if (resumeInput) {
+    await resumeInput.setInputFiles(resolve(pdfPath));
+    console.log(`  ✅ Resume uploaded: ${pdfPath}`);
+  }
+
+  // Cover letter — Greenhouse has a dedicated file input #cover_letter
+  if (coverLetter || coverLetterPath) {
+    const coverFileInput = await page.$('#cover_letter, input[type="file"][name*="cover"]');
+    if (coverFileInput && coverLetterPath && existsSync(coverLetterPath)) {
+      await coverFileInput.setInputFiles(resolve(coverLetterPath));
+      console.log('  ✅ Cover letter file uploaded');
+    }
+  }
+
+  // LinkedIn URL
+  const linkedinField = await page.$('input[name*="linkedin"], input[id*="linkedin"]');
+  if (linkedinField) {
+    await linkedinField.fill(`https://${c.linkedin}`);
+    console.log(`  ✅ LinkedIn: ${c.linkedin}`);
+  }
+
+  // Website
+  const websiteField = await page.$('input[name*="website"], input[id*="website"], input[name*="portfolio"]');
+  if (websiteField) {
+    await websiteField.fill(c.portfolio_url || 'https://moorelab.cloud');
+    console.log(`  ✅ Website: ${c.portfolio_url}`);
+  }
+}
+
+// ── Stripe (Greenhouse embed) form filler ──────────────────────
+
+async function fillStripe(page, profile, pdfPath, coverLetter) {
+  const c = profile.candidate || {};
+  console.log('🔧 Platform: Stripe (Greenhouse embed in iframe)');
+
+  // Stripe embeds Greenhouse in an iframe. Find and switch to it.
+  let frame = page;
+  const ghFrame = page.frames().find(f => f.url().includes('greenhouse.io'));
+  if (ghFrame) {
+    frame = ghFrame;
+    console.log('  🔗 Switched to Greenhouse iframe');
+  } else {
+    console.log('  ⚠️ No Greenhouse iframe found — trying main page');
+  }
+
+  await frame.waitForSelector('#first_name', { timeout: 15000 });
+  await frame.waitForTimeout(1000);
+
+  // ── Basic contact fields ──────────────────────────────────────
+  const basicFields = {
+    '#first_name': c.full_name?.split(' ')[0] || 'Patrick',
+    '#last_name': c.full_name?.split(' ').pop() || 'Moore',
+    '#email': c.email || 'patrick.james.moore@protonmail.com',
+    '#phone': c.phone || '303-514-3586',
+  };
+
+  for (const [sel, val] of Object.entries(basicFields)) {
+    const field = await frame.$(sel);
+    if (field) {
+      await field.fill(val);
+      console.log(`  ✅ ${sel}: ${val}`);
+    }
+  }
+
+  // ── Country — text input with autocomplete (not React-Select) ──
+  await safeField(frame, async () => {
+    const countryInput = await frame.$('#country');
+    if (countryInput) {
+      await frame.evaluate(() => {
+        const el = document.querySelector('#country');
+        if (el) el.scrollIntoView({ block: 'center' });
+      });
+      await frame.waitForTimeout(300);
+      await countryInput.evaluate(el => el.focus());
+      await countryInput.fill('');
+      await countryInput.type('United States', { delay: 50 });
+      await frame.waitForTimeout(1000);
+      // Click autocomplete suggestion if present
+      const suggestion = await frame.$('[role="option"]:has-text("United States"), .autocomplete-results li, li:has-text("United States")');
+      if (suggestion) {
+        await suggestion.click({ force: true });
+      } else {
+        await countryInput.press('Enter');
+      }
+      console.log('  ✅ Country: United States');
+    }
+  }, 'Country');
+
+  // ── Close any overlays (phone intl-tel-input etc.) ────────────
+  await frame.evaluate(() => {
+    document.querySelectorAll('.iti__country-list').forEach(dd => dd.style.display = 'none');
+    document.querySelectorAll('[class*="select__menu"]').forEach(m => m.remove());
+    document.body.click();
+  });
+  await frame.waitForTimeout(500);
+
+  // ── Location (City) autocomplete ──────────────────────────────
+  await safeField(frame, async () => {
+    const locationField = await frame.$('#candidate-location');
+    if (locationField) {
+      await frame.evaluate(() => {
+        const el = document.querySelector('#candidate-location');
+        if (el) el.scrollIntoView({ block: 'center' });
+      });
+      await frame.waitForTimeout(300);
+      await locationField.evaluate(el => el.focus());
+      await locationField.fill('');
+      await locationField.type('Denver, CO', { delay: 80 });
+      await frame.waitForTimeout(1500);
+      const locOption = await frame.$('.autocomplete-results li, [role="option"]:has-text("Denver")');
+      if (locOption) {
+        await locOption.click({ force: true });
+        console.log('  ✅ Location: Denver, CO (autocomplete)');
+      } else {
+        console.log('  ✅ Location: Denver, CO (typed)');
+      }
+    }
+  }, 'Location');
+
+  // ── Resume upload ─────────────────────────────────────────────
+  await safeField(frame, async () => {
+    const resumeInput = await frame.$('#resume');
+    if (resumeInput) {
+      await resumeInput.setInputFiles(resolve(pdfPath));
+      console.log(`  ✅ Resume uploaded: ${pdfPath}`);
+      await frame.waitForTimeout(1000);
+    }
+  }, 'Resume');
+
+  // ── Cover letter upload ───────────────────────────────────────
+  await safeField(frame, async () => {
+    const coverInput = await frame.$('#cover_letter');
+    if (coverInput && coverLetterPath && existsSync(coverLetterPath)) {
+      await coverInput.setInputFiles(resolve(coverLetterPath));
+      console.log('  ✅ Cover letter uploaded');
+    }
+  }, 'Cover letter');
+
+  // ── Stripe-specific dropdown questions (React-Select) ────────
+
+  // Country of residence (Stripe uses "US" not "United States" in this dropdown)
+  await safeField(frame, () => ghSelectDropdown(frame, '#question_65731084', 'US'), 'Country of residence');
+
+  // Eligible to work: check "US" checkbox
+  await safeField(frame, async () => {
+    const usCheckbox = await frame.$('input[id*="question_65731085"][id*="712517093"]');
+    if (usCheckbox) {
+      await frame.evaluate(() => {
+        const el = document.querySelector('input[id*="question_65731085"][id*="712517093"]');
+        if (el) el.scrollIntoView({ block: 'center' });
+      });
+      await frame.waitForTimeout(300);
+      const checked = await usCheckbox.isChecked();
+      if (!checked) await usCheckbox.check({ force: true });
+      console.log('  ✅ Eligible to work: US (checked)');
+    }
+  }, 'Work eligibility');
+
+  // Work authorization → Yes
+  await safeField(frame, () => ghSelectDropdown(frame, '#question_65731086', 'Yes'), 'Work authorization');
+
+  // Sponsorship → No
+  await safeField(frame, () => ghSelectDropdown(frame, '#question_65731087', 'No'), 'Sponsorship');
+
+  // Remote work → Yes
+  await safeField(frame, () => ghSelectDropdown(frame, '#question_65731088', 'Yes'), 'Remote work');
+
+  // Previously employed at Stripe → No
+  await safeField(frame, () => ghSelectDropdown(frame, '#question_65731089', 'No'), 'Previously at Stripe');
+
+  // Text fields
+  await safeField(frame, async () => {
+    await ghFillText(frame, '#question_65731090', 'Viecure', 'Current employer');
+    await ghFillText(frame, '#question_65731091', 'Security & Reliability Engineer', 'Job title');
+    await ghFillText(frame, '#question_65731092', c.education_school || 'University of Denver', 'School');
+    await ghFillText(frame, '#question_65731093', c.education_degree || 'Computer Science', 'Degree');
+    await ghFillText(frame, '#question_66034237', 'Denver, Colorado', 'US city/state');
+  }, 'Text questions');
+
+  // WhatsApp opt-in → No
+  await safeField(frame, () => ghSelectDropdown(frame, '#question_65731094', 'No'), 'WhatsApp opt-in');
+
+  // Skip voluntary self-identification
+  console.log('  ⏭️  Skipping voluntary self-identification (optional)');
+}
+
+// ── Helper: safely fill a text field in Greenhouse ─────────────
+
+async function ghFillText(frame, selector, value, label) {
+  const field = await frame.$(selector);
+  if (field) {
+    await frame.evaluate((sel) => {
+      const el = document.querySelector(sel);
+      if (el) el.scrollIntoView({ block: 'center' });
+    }, selector);
+    await frame.waitForTimeout(200);
+    await field.evaluate(el => el.focus());
+    await field.fill(value);
+    console.log(`  ✅ ${label}: ${value}`);
+  }
+}
+
+// ── Helper: wrap a field action in try/catch ───────────────────
+
+async function safeField(frame, fn, label) {
+  try {
+    await fn();
+  } catch (err) {
+    console.log(`  ⚠️ ${label}: ${err.message.split('\n')[0]}`);
+  }
+}
+
+// ── Helper: select a Greenhouse custom dropdown option ─────────
+
+async function ghSelectDropdown(frame, inputSelector, optionText) {
+  // Greenhouse uses React-Select for dropdown questions.
+  // Raw DOM events (mousedown, click) don't reliably trigger React's event system.
+  //
+  // Strategy: keyboard-based interaction, which React-Select handles natively.
+  //   1. Scroll the field into view
+  //   2. Focus the React-Select's internal search input
+  //   3. Press ArrowDown to open the menu (or Space)
+  //   4. Clear any existing value, type the desired option text to filter
+  //   5. Press Enter to select the first filtered match
+
+  // Step 1: Scroll to the field
+  const found = await frame.evaluate((sel) => {
+    const input = document.querySelector(sel);
+    if (!input) return false;
+    // Walk up to find the field container
+    let el = input;
+    for (let i = 0; i < 10; i++) {
+      el = el.parentElement;
+      if (!el) break;
+      if (el.classList.contains('field') || el.classList.contains('field-wrapper')) {
+        el.scrollIntoView({ behavior: 'instant', block: 'center' });
+        return true;
+      }
+    }
+    input.scrollIntoView({ behavior: 'instant', block: 'center' });
+    return true;
+  }, inputSelector);
+
+  if (!found) {
+    console.log(`  ⚠️ ${inputSelector}: not found`);
+    return false;
+  }
+
+  await frame.waitForTimeout(400);
+
+  // Step 2: Close any open menus first
+  await frame.evaluate(() => {
+    document.body.click();
+  });
+  await frame.waitForTimeout(300);
+
+  // Step 3: Focus the input and use keyboard to open + search + select
+  // React-Select's search input might be the one with our selector ID,
+  // or a sibling input with class select__input
+  const inputHandle = await frame.$(inputSelector);
+  if (!inputHandle) {
+    console.log(`  ⚠️ ${inputSelector}: input element not found`);
+    return false;
+  }
+
+  // Focus the input — try evaluate first (works even on hidden elements)
+  await frame.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (el) {
+      el.focus();
+      // Also try focusing the container to make React-Select aware
+      const control = el.closest('[class*="select__control"]') ||
+                      el.parentElement?.querySelector('[class*="select__control"]');
+      if (control) {
+        control.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+      }
+    }
+  }, inputSelector);
+  await frame.waitForTimeout(300);
+
+  // Press ArrowDown or Space to open the dropdown menu
+  await frame.press(inputSelector, 'ArrowDown');
+  await frame.waitForTimeout(600);
+
+  // Check if the menu opened (look for scoped options)
+  const inputId = inputSelector.replace('#', '');
+  let optionCount = await frame.evaluate((id) => {
+    return document.querySelectorAll(`[id^="react-select-${id}-option"]`).length;
+  }, inputId);
+
+  if (optionCount === 0) {
+    // Try clicking the dropdown indicator arrow
+    await frame.evaluate((sel) => {
+      const input = document.querySelector(sel);
+      if (!input) return;
+      let el = input;
+      for (let i = 0; i < 10; i++) {
+        el = el.parentElement;
+        if (!el) return;
+        const indicator = el.querySelector('[class*="indicatorContainer"], [class*="dropdown-indicator"]');
+        if (indicator) {
+          indicator.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+          indicator.click();
+          return;
+        }
+      }
+    }, inputSelector);
+    await frame.waitForTimeout(600);
+    optionCount = await frame.evaluate((id) => {
+      return document.querySelectorAll(`[id^="react-select-${id}-option"]`).length;
+    }, inputId);
+  }
+
+  if (optionCount > 0) {
+    // Menu is open. Type to filter (DON'T use fill() — it resets React-Select).
+    // React-Select accepts keystrokes on the focused input for live filtering.
+    await frame.type(inputSelector, optionText, { delay: 50 });
+    await frame.waitForTimeout(700);
+
+    // Check filtered results — find the best match
+    const matchResult = await frame.evaluate(({ id, text }) => {
+      const options = Array.from(document.querySelectorAll(`[id^="react-select-${id}-option"]`));
+      if (options.length === 0) return { count: 0, first: null, exactIdx: -1 };
+
+      // Look for exact or starts-with match
+      const exactIdx = options.findIndex(o => {
+        const t = o.textContent.trim();
+        return t === text || t.startsWith(text);
+      });
+
+      return {
+        count: options.length,
+        first: options[0]?.textContent.trim(),
+        exactIdx,
+        exactText: exactIdx >= 0 ? options[exactIdx].textContent.trim() : null,
+      };
+    }, { id: inputId, text: optionText });
+
+    if (matchResult.count > 0) {
+      if (matchResult.exactIdx === 0) {
+        // First option is our match — just press Enter
+        await frame.press(inputSelector, 'Enter');
+        await frame.waitForTimeout(300);
+        console.log(`  ✅ ${inputSelector}: ${matchResult.exactText}`);
+        return true;
+      } else if (matchResult.exactIdx > 0) {
+        // Need to ArrowDown to the right option
+        for (let i = 0; i < matchResult.exactIdx; i++) {
+          await frame.press(inputSelector, 'ArrowDown');
+          await frame.waitForTimeout(100);
+        }
+        await frame.press(inputSelector, 'Enter');
+        await frame.waitForTimeout(300);
+        console.log(`  ✅ ${inputSelector}: ${matchResult.exactText}`);
+        return true;
+      } else {
+        // No exact match — select first option as best guess
+        await frame.press(inputSelector, 'Enter');
+        await frame.waitForTimeout(300);
+        console.log(`  ⚠️ ${inputSelector}: ${matchResult.first} (closest match for "${optionText}")`);
+        return true;
+      }
+    }
+  }
+
+  // Fallback: try using tab/click to dismiss and accept whatever was typed
+  try {
+    await frame.press(inputSelector, 'Tab');
+  } catch {}
+  await frame.waitForTimeout(200);
+  console.log(`  ⚠️ ${inputSelector}: ${optionText} (keyboard fallback, ${optionCount} options)`);
+  return false;
+}
+
+// ── Generic form filler (best-effort) ───────────────────────────
+
+async function fillGeneric(page, profile, pdfPath, coverLetter) {
+  const c = profile.candidate || {};
+  console.log('🔧 Platform: Generic (best-effort)');
+
+  await page.waitForSelector('form, [role="form"], input[type="text"], input[type="email"]', { timeout: 15000 });
+
+  // Find all inputs and match by label/placeholder/name
+  const inputs = await page.$$('input:not([type="hidden"]):not([type="submit"]):not([type="checkbox"]):not([type="radio"])');
+
+  for (const input of inputs) {
+    const label = await getFieldLabel(page, input);
+    const placeholder = await input.getAttribute('placeholder') || '';
+    const name = await input.getAttribute('name') || '';
+    const type = await input.getAttribute('type') || 'text';
+    const hint = `${label} ${placeholder} ${name}`.toLowerCase();
+
+    if (type === 'file') {
+      await input.setInputFiles(resolve(pdfPath));
+      console.log(`  ✅ File uploaded: ${pdfPath}`);
+      continue;
+    }
+
+    if (hint.includes('first') && hint.includes('name')) {
+      await input.fill(c.full_name?.split(' ')[0] || 'Patrick');
+      console.log(`  ✅ First name`);
+    } else if (hint.includes('last') && hint.includes('name')) {
+      await input.fill(c.full_name?.split(' ').pop() || 'Moore');
+      console.log(`  ✅ Last name`);
+    } else if (hint.includes('full') && hint.includes('name')) {
+      await input.fill(c.full_name || 'Patrick Moore');
+      console.log(`  ✅ Full name`);
+    } else if (type === 'email' || hint.includes('email')) {
+      await input.fill(c.email || 'patrick.james.moore@protonmail.com');
+      console.log(`  ✅ Email`);
+    } else if (type === 'tel' || hint.includes('phone')) {
+      await input.fill(c.phone || '303-514-3586');
+      console.log(`  ✅ Phone`);
+    } else if (hint.includes('linkedin')) {
+      await input.fill(`https://${c.linkedin}`);
+      console.log(`  ✅ LinkedIn`);
+    } else if (hint.includes('github')) {
+      await input.fill(`https://${c.github}`);
+      console.log(`  ✅ GitHub`);
+    } else if (hint.includes('website') || hint.includes('portfolio') || hint.includes('url')) {
+      await input.fill(c.portfolio_url || 'https://moorelab.cloud');
+      console.log(`  ✅ Website/Portfolio`);
+    } else if (hint.includes('location') || hint.includes('city')) {
+      await input.fill(c.location || 'Denver, CO');
+      console.log(`  ✅ Location`);
+    }
+  }
+
+  // Cover letter in textarea
+  if (coverLetter) {
+    const textareas = await page.$$('textarea');
+    for (const ta of textareas) {
+      const label = await getFieldLabel(page, ta);
+      if (label.toLowerCase().includes('cover') || label.toLowerCase().includes('additional') || label.toLowerCase().includes('why')) {
+        await ta.fill(coverLetter);
+        console.log(`  ✅ Cover letter filled`);
+        break;
+      }
+    }
+  }
+}
+
+// ── Utility: get label text for a form field ────────────────────
+
+async function getFieldLabel(page, element) {
+  try {
+    // Try aria-label
+    const ariaLabel = await element.getAttribute('aria-label');
+    if (ariaLabel) return ariaLabel;
+
+    // Try associated <label> via id
+    const id = await element.getAttribute('id');
+    if (id) {
+      const label = await page.$(`label[for="${id}"]`);
+      if (label) return (await label.textContent()) || '';
+    }
+
+    // Try parent label
+    const parentLabel = await element.evaluate(el => {
+      const label = el.closest('label');
+      return label ? label.textContent : '';
+    });
+    if (parentLabel) return parentLabel;
+
+    // Try preceding sibling or nearby text
+    const nearbyText = await element.evaluate(el => {
+      const prev = el.previousElementSibling;
+      if (prev && (prev.tagName === 'LABEL' || prev.tagName === 'SPAN' || prev.tagName === 'DIV')) {
+        return prev.textContent;
+      }
+      const parent = el.parentElement;
+      if (parent) {
+        const label = parent.querySelector('label, .label, [class*="label"]');
+        if (label) return label.textContent;
+      }
+      return '';
+    });
+    return nearbyText || '';
+  } catch {
+    return '';
+  }
+}
+
+// ── Main ────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('🚀 apply-auto.mjs — Server-side application automation');
+  console.log(`📍 URL: ${url}`);
+  console.log(`📄 PDF: ${pdfPath}`);
+  console.log(`📝 Cover letter: ${coverLetterPath || 'none'}`);
+  console.log(`🔒 Submit: ${shouldSubmit ? 'YES' : 'NO (review only)'}`);
+  console.log('');
+
+  const profile = await loadProfile();
+  const coverLetter = await loadCoverLetter(coverLetterPath);
+  const platform = detectPlatform(url);
+
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  const contextOptions = {
+    viewport: { width: 1280, height: 900 },
+    userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+  };
+
+  // Load saved auth state (cookies/localStorage from browser-login.mjs)
+  if (authStatePath && existsSync(authStatePath)) {
+    contextOptions.storageState = authStatePath;
+    console.log(`🔑 Auth state loaded: ${authStatePath}`);
+  }
+
+  const context = await browser.newContext(contextOptions);
+
+  const page = await context.newPage();
+
+  try {
+    console.log(`🌐 Navigating to ${url}...`);
+    await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+    console.log(`✅ Page loaded: ${await page.title()}`);
+    console.log('');
+
+    // Some sites show JD first with an "Apply" button. Click it if no form is visible.
+    const hasForm = await page.$('form');
+    if (!hasForm) {
+      console.log('📋 No form found on page — looking for Apply button...');
+      const applyBtn = await page.$('a:has-text("Apply"), button:has-text("Apply"), a[href*="application"], a[href*="apply"]');
+      if (applyBtn) {
+        const href = await applyBtn.getAttribute('href');
+        if (href && (href.startsWith('http') || href.startsWith('/'))) {
+          // It's a link — navigate to it
+          const applyUrl = href.startsWith('http') ? href : new URL(href, url).toString();
+          console.log(`  🔗 Found apply link: ${applyUrl}`);
+          await page.goto(applyUrl, { waitUntil: 'networkidle', timeout: 30000 });
+        } else {
+          // It's a button — click it
+          console.log('  🖱️ Clicking Apply button...');
+          await applyBtn.click();
+          await page.waitForTimeout(3000);
+        }
+        console.log(`  ✅ Now on: ${await page.title()}`);
+        // Re-detect platform after navigation
+        const newUrl = page.url();
+        const newPlatform = detectPlatform(newUrl);
+        if (newPlatform !== platform) {
+          console.log(`  🔄 Platform changed: ${platform} → ${newPlatform}`);
+        }
+      } else {
+        console.log('  ⚠️ No Apply button found either. Taking screenshot for manual review.');
+      }
+    }
+
+    // Fill based on platform (re-detect from current URL)
+    const currentPlatform = detectPlatform(page.url());
+    // Wait for form to appear after potential navigation
+    try {
+      await page.waitForSelector('form, [role="form"], input[type="text"], input[type="email"]', { timeout: 10000 });
+    } catch {
+      console.log('  ⚠️ No form elements found after navigation.');
+    }
+
+    switch (currentPlatform) {
+      case 'ashby':
+        await fillAshby(page, profile, pdfPath, coverLetter);
+        break;
+      case 'greenhouse':
+        await fillGreenhouse(page, profile, pdfPath, coverLetter);
+        break;
+      case 'stripe':
+        await fillStripe(page, profile, pdfPath, coverLetter);
+        break;
+      case 'lever':
+      case 'generic':
+      default:
+        await fillGeneric(page, profile, pdfPath, coverLetter);
+        break;
+    }
+
+    // Take screenshot for review
+    const ssPath = resolve(__dirname, screenshotPath);
+    await page.screenshot({ path: ssPath, fullPage: true });
+    console.log('');
+    console.log(`📸 Screenshot saved: ${ssPath}`);
+
+    // Submit if flagged
+    if (shouldSubmit) {
+      console.log('');
+      console.log('⚠️  Submitting application...');
+
+      // For Stripe/iframe forms, search for the submit button in iframes too
+      let submitBtn = await page.$('button[type="submit"], input[type="submit"], button:has-text("Submit"), button:has-text("Apply")');
+
+      // Check iframes if not found on main page
+      if (!submitBtn) {
+        for (const frame of page.frames()) {
+          submitBtn = await frame.$('button[type="submit"], input[type="submit"], button:has-text("Submit Application"), button:has-text("Submit"), button:has-text("Apply")');
+          if (submitBtn) {
+            // Scroll submit button into view
+            await frame.evaluate(() => {
+              const btn = document.querySelector('button[type="submit"], input[type="submit"]');
+              if (btn) btn.scrollIntoView({ block: 'center' });
+            });
+            await frame.waitForTimeout(500);
+            break;
+          }
+        }
+      }
+
+      if (submitBtn) {
+        await submitBtn.click({ force: true });
+        await page.waitForTimeout(5000);
+        const confirmSS = ssPath.replace('.png', '-confirmed.png');
+        await page.screenshot({ path: confirmSS, fullPage: true });
+        console.log(`✅ Application submitted!`);
+        console.log(`📸 Confirmation screenshot: ${confirmSS}`);
+      } else {
+        console.log('❌ Could not find submit button');
+      }
+    } else {
+      console.log('');
+      console.log('⏸️  Form filled but NOT submitted. Review the screenshot.');
+      console.log('   Re-run with --submit to submit, or apply manually.');
+    }
+
+  } catch (err) {
+    console.error(`❌ Error: ${err.message}`);
+    // Take error screenshot
+    try {
+      await page.screenshot({ path: resolve(__dirname, 'output/apply-error.png'), fullPage: true });
+      console.log('📸 Error screenshot saved to output/apply-error.png');
+    } catch {}
+    process.exit(1);
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apply-orchestrator.mjs
+++ b/apply-orchestrator.mjs
@@ -1,0 +1,488 @@
+#!/usr/bin/env node
+
+/**
+ * apply-orchestrator.mjs — Shared apply pipeline for auto-apply + Telegram reply
+ *
+ * Encapsulates: evaluate → generate CV/CL → apply-auto.mjs → tracker update.
+ * Called by auto-pipeline.mjs (tier 1: score ≥ threshold) and
+ * telegram-listener.mjs (tier 2: Patrick replies "apply #N").
+ *
+ * Usage (standalone):
+ *   node apply-orchestrator.mjs --url <url> --dry-run
+ *   node apply-orchestrator.mjs --url <url> --submit
+ *
+ * As a module:
+ *   import { runApplyPipeline, evaluateAndMaybeApply } from './apply-orchestrator.mjs';
+ */
+
+import { execSync, spawnSync } from 'child_process';
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from 'fs';
+import { join, resolve } from 'path';
+import { loadEnv } from './lib/telegram.mjs';
+
+const PROJECT_DIR = resolve(import.meta.dirname || '.');
+const REPORTS_DIR = join(PROJECT_DIR, 'reports');
+const OUTPUT_DIR = join(PROJECT_DIR, 'output');
+const COVER_LETTERS_DIR = join(PROJECT_DIR, 'output/cover-letters');
+const TRACKER_DIR = join(PROJECT_DIR, 'batch/tracker-additions');
+const TRACKER_FILE = join(PROJECT_DIR, 'data/applications.md');
+const PROFILE_PATH = join(PROJECT_DIR, 'config/profile.yml');
+
+// ── Config reader ────────────────────────────────────────────────────
+
+function readProfile() {
+  if (!existsSync(PROFILE_PATH)) return {};
+  const raw = readFileSync(PROFILE_PATH, 'utf-8');
+  // Minimal YAML parse for the fields we need
+  const get = (key) => {
+    const m = raw.match(new RegExp(`^\\s*${key}:\\s*["']?(.+?)["']?\\s*$`, 'm'));
+    return m ? m[1] : '';
+  };
+  return {
+    full_name: get('full_name'),
+    email: get('email'),
+    phone: get('phone'),
+    location: get('location'),
+    linkedin: get('linkedin'),
+    portfolio_url: get('portfolio_url'),
+    auto_apply_threshold: parseFloat(get('auto_apply_threshold')) || 4.5,
+    auto_apply_enabled: get('auto_apply_enabled') !== 'false',
+    apply_threshold: parseFloat(get('apply_threshold')) || 4.0,
+  };
+}
+
+// ── Report reader ────────────────────────────────────────────────────
+
+function findReportForUrl(url) {
+  if (!existsSync(REPORTS_DIR)) return null;
+  for (const file of readdirSync(REPORTS_DIR).sort().reverse()) {
+    if (!file.endsWith('.md')) continue;
+    const content = readFileSync(join(REPORTS_DIR, file), 'utf-8');
+    if (content.includes(url)) {
+      const scoreMatch = content.match(/\*\*Score:\*\*\s*([0-9.]+)\/5/);
+      const headerMatch = content.match(/# (?:Evaluation|Evaluación):\s*(.+?)\s*[—–-]\s*(.+)/);
+      const numMatch = file.match(/^(\d+)/);
+      return {
+        file,
+        path: join(REPORTS_DIR, file),
+        score: scoreMatch ? parseFloat(scoreMatch[1]) : 0,
+        company: headerMatch ? headerMatch[1].trim() : 'Unknown',
+        role: headerMatch ? headerMatch[2].trim() : 'Unknown',
+        num: numMatch ? numMatch[1] : '000',
+      };
+    }
+  }
+  return null;
+}
+
+function nextReportNum() {
+  let max = 0;
+  if (existsSync(REPORTS_DIR)) {
+    for (const f of readdirSync(REPORTS_DIR)) {
+      const m = f.match(/^(\d+)/);
+      if (m) max = Math.max(max, parseInt(m[1], 10));
+    }
+  }
+  return String(max + 1).padStart(3, '0');
+}
+
+// ── Tracker helpers ──────────────────────────────────────────────────
+
+function isAlreadyApplied(url) {
+  if (!existsSync(TRACKER_FILE)) return false;
+  const content = readFileSync(TRACKER_FILE, 'utf-8');
+  return content.includes(url) && content.includes('Applied');
+}
+
+function slugify(text) {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+// ── Detect platform ──────────────────────────────────────────────────
+
+function detectPlatform(url) {
+  if (/jobs\.ashbyhq\.com/i.test(url)) return 'ashby';
+  if (/stripe\.com\/jobs/i.test(url)) return 'stripe';
+  if (/boards\.greenhouse\.io/i.test(url)) return 'greenhouse';
+  if (/jobs\.lever\.co/i.test(url)) return 'lever';
+  return 'generic';
+}
+
+// ── Core pipeline ────────────────────────────────────────────────────
+
+/**
+ * Run the full apply pipeline for a single job.
+ *
+ * @param {object} opts
+ * @param {string} opts.url — Job posting URL
+ * @param {string} [opts.company] — Company name (extracted from report if not provided)
+ * @param {string} [opts.role] — Role title (extracted from report if not provided)
+ * @param {number} [opts.score] — Score (extracted from report if not provided)
+ * @param {string} [opts.reportPath] — Path to existing report (skips evaluation)
+ * @param {string} [opts.reportNum] — Report number
+ * @param {boolean} [opts.dryRun=false] — Print what would happen, don't execute
+ * @param {boolean} [opts.submit=true] — Pass --submit to apply-auto.mjs
+ * @returns {Promise<{success: boolean, pdfPath?: string, coverLetterPath?: string, screenshotPath?: string, error?: string}>}
+ */
+export async function runApplyPipeline(opts) {
+  const {
+    url,
+    dryRun = false,
+    submit = true,
+  } = opts;
+  let { company, role, score, reportPath, reportNum } = opts;
+
+  const today = new Date().toISOString().slice(0, 10);
+  const platform = detectPlatform(url);
+
+  // Check if already applied
+  if (isAlreadyApplied(url)) {
+    return { success: false, error: `Already applied to ${url}` };
+  }
+
+  // Find or use existing report
+  if (!reportPath) {
+    const existing = findReportForUrl(url);
+    if (existing) {
+      reportPath = existing.path;
+      company = company || existing.company;
+      role = role || existing.role;
+      score = score || existing.score;
+      reportNum = reportNum || existing.num;
+    } else {
+      return { success: false, error: `No evaluation report found for ${url}. Run evaluation first.` };
+    }
+  }
+
+  const slug = slugify(company || 'unknown');
+  const pdfName = `cv-patrick-moore-${slug}-${today}.pdf`;
+  const pdfPath = join(OUTPUT_DIR, pdfName);
+  const clName = `cl-${slug}-${today}.md`;
+  const clPath = join(COVER_LETTERS_DIR, clName);
+  const screenshotPath = join(OUTPUT_DIR, `apply-screenshot-${slug}-${today}.png`);
+
+  console.log(`\n📋 Apply pipeline: ${company} — ${role} (${score}/5)`);
+  console.log(`   Platform: ${platform}`);
+  console.log(`   URL: ${url}`);
+
+  if (dryRun) {
+    console.log('   [DRY RUN] Would generate CV, cover letter, and submit application.');
+    return { success: true, pdfPath, coverLetterPath: clPath, screenshotPath };
+  }
+
+  // Step 1: Generate tailored CV PDF (if not already exists)
+  if (!existsSync(pdfPath)) {
+    console.log('   Step 1: Generating tailored CV PDF...');
+    try {
+      const cvPrompt = `Generate a tailored CV for Patrick Moore for this role:
+Company: ${company}
+Role: ${role}
+Report: ${reportPath}
+
+Read cv.md for the base CV content.
+Read modes/pdf.md for the PDF generation instructions.
+Read modes/_profile.md for Patrick's narrative framing.
+Read the evaluation report at ${reportPath} for match analysis.
+
+Generate the tailored HTML CV and save it as a PDF using:
+  node generate-pdf.mjs <html-file> ${pdfPath}
+
+IMPORTANT: The output PDF must be saved at exactly: ${pdfPath}`;
+
+      execSync(`claude -p --dangerously-skip-permissions "${cvPrompt.replace(/"/g, '\\"')}"`, {
+        cwd: PROJECT_DIR,
+        timeout: 180000, // 3 min
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      if (existsSync(pdfPath)) {
+        console.log(`   ✅ CV PDF: ${pdfName}`);
+      } else {
+        console.log('   ⚠️  CV generation completed but PDF not found. Using most recent CV...');
+        // Fall back to most recent CV PDF
+        const existingPdfs = existsSync(OUTPUT_DIR) ?
+          readdirSync(OUTPUT_DIR).filter(f => f.startsWith('cv-') && f.endsWith('.pdf')).sort().reverse() : [];
+        if (existingPdfs.length > 0) {
+          const fallback = join(OUTPUT_DIR, existingPdfs[0]);
+          console.log(`   Using fallback: ${existingPdfs[0]}`);
+          // We'll use the fallback path below
+        }
+      }
+    } catch (err) {
+      console.error(`   ❌ CV generation failed: ${err.message?.slice(0, 100)}`);
+    }
+  } else {
+    console.log(`   Step 1: CV PDF already exists: ${pdfName}`);
+  }
+
+  // Step 2: Generate cover letter (if not already exists)
+  if (!existsSync(clPath)) {
+    console.log('   Step 2: Generating cover letter...');
+    try {
+      const clPrompt = `Generate a cover letter for Patrick Moore for this role:
+Company: ${company}
+Role: ${role}
+URL: ${url}
+
+Read the evaluation report at: ${reportPath}
+Read cv.md for proof points.
+Read article-digest.md for detailed proof points.
+Read modes/_profile.md "Writing Style" section for voice rules.
+Read modes/cover-letter.md for the full cover letter mode instructions.
+
+Output ONLY the cover letter in the format specified in modes/cover-letter.md.
+Save it to: ${clPath}
+
+IMPORTANT: Follow Patrick's voice rules EXACTLY. No corporate speak. No "leveraging."
+Short punchy sentences. Concrete specifics. Casual confidence. 75-120 words, 5-6 sentences.`;
+
+      mkdirSync(COVER_LETTERS_DIR, { recursive: true });
+      execSync(`claude -p --dangerously-skip-permissions "${clPrompt.replace(/"/g, '\\"')}"`, {
+        cwd: PROJECT_DIR,
+        timeout: 120000, // 2 min
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      if (existsSync(clPath)) {
+        console.log(`   ✅ Cover letter: ${clName}`);
+      } else {
+        console.log('   ⚠️  Cover letter generation completed but file not found.');
+      }
+    } catch (err) {
+      console.error(`   ❌ Cover letter failed: ${err.message?.slice(0, 100)}`);
+    }
+  } else {
+    console.log(`   Step 2: Cover letter already exists: ${clName}`);
+  }
+
+  // Find the actual PDF to use (generated or fallback)
+  let actualPdf = pdfPath;
+  if (!existsSync(pdfPath)) {
+    const existingPdfs = existsSync(OUTPUT_DIR) ?
+      readdirSync(OUTPUT_DIR).filter(f => f.startsWith('cv-') && f.endsWith('.pdf')).sort().reverse() : [];
+    if (existingPdfs.length > 0) {
+      actualPdf = join(OUTPUT_DIR, existingPdfs[0]);
+    } else {
+      return { success: false, error: 'No CV PDF available. Generate one first.' };
+    }
+  }
+
+  // Step 3: Run apply-auto.mjs
+  console.log(`   Step 3: Filling application form (${platform})...`);
+  try {
+    const applyArgs = [
+      'apply-auto.mjs',
+      url,
+      actualPdf,
+      `--screenshot=${screenshotPath}`,
+    ];
+    if (submit) applyArgs.push('--submit');
+    if (existsSync(clPath)) applyArgs.push(`--cover-letter=${clPath}`);
+
+    // Check for auth state
+    const authPaths = [
+      join(PROJECT_DIR, 'auth/linkedin-state.json'),
+      join(PROJECT_DIR, 'auth/browser-state.json'),
+    ];
+    for (const auth of authPaths) {
+      if (existsSync(auth)) {
+        applyArgs.push(`--auth=${auth}`);
+        break;
+      }
+    }
+
+    const result = spawnSync('node', applyArgs, {
+      cwd: PROJECT_DIR,
+      timeout: 300000, // 5 min
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    if (result.status === 0) {
+      console.log('   ✅ Application submitted successfully');
+    } else {
+      const stderr = (result.stderr || '').trim();
+      const stdout = (result.stdout || '').trim();
+
+      // Check for CAPTCHA or known failures
+      if (/captcha|recaptcha|hcaptcha|turnstile/i.test(stderr + stdout)) {
+        return {
+          success: false,
+          error: `CAPTCHA detected on ${platform}. Apply manually: ${url}`,
+          screenshotPath: existsSync(screenshotPath) ? screenshotPath : undefined,
+        };
+      }
+
+      return {
+        success: false,
+        error: `apply-auto.mjs exited with code ${result.status}: ${stderr.slice(0, 200)}`,
+        screenshotPath: existsSync(screenshotPath) ? screenshotPath : undefined,
+      };
+    }
+  } catch (err) {
+    return {
+      success: false,
+      error: `apply-auto.mjs error: ${err.message?.slice(0, 200)}`,
+      screenshotPath: existsSync(screenshotPath) ? screenshotPath : undefined,
+    };
+  }
+
+  // Step 4: Update tracker
+  console.log('   Step 4: Updating tracker...');
+  try {
+    mkdirSync(TRACKER_DIR, { recursive: true });
+    const tsvLine = [
+      reportNum || nextReportNum(),
+      today,
+      company,
+      role,
+      'Applied',
+      `${score}/5`,
+      '✅',
+      `[${reportNum}](reports/${reportNum}-${slug}-${today}.md)`,
+      `Auto-applied ${today} via apply-orchestrator (${platform}); score ${score}/5`,
+    ].join('\t');
+
+    const tsvPath = join(TRACKER_DIR, `${reportNum}-${slug}.tsv`);
+    writeFileSync(tsvPath, tsvLine + '\n');
+    console.log(`   ✅ Tracker TSV written: ${tsvPath}`);
+
+    // Run merge
+    execSync('node merge-tracker.mjs', {
+      cwd: PROJECT_DIR,
+      timeout: 30000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    console.log('   ✅ Tracker merged');
+  } catch (err) {
+    console.error(`   ⚠️  Tracker update failed: ${err.message?.slice(0, 100)}`);
+  }
+
+  return {
+    success: true,
+    pdfPath: existsSync(actualPdf) ? actualPdf : undefined,
+    coverLetterPath: existsSync(clPath) ? clPath : undefined,
+    screenshotPath: existsSync(screenshotPath) ? screenshotPath : undefined,
+  };
+}
+
+/**
+ * Evaluate a job URL and auto-apply if score meets threshold.
+ *
+ * @param {object} opts
+ * @param {string} opts.url — Job posting URL
+ * @param {string} [opts.company] — Company name hint
+ * @param {string} [opts.title] — Role title hint
+ * @param {boolean} [opts.dryRun=false]
+ * @returns {Promise<{score: number, applied: boolean, report?: string, error?: string}>}
+ */
+export async function evaluateAndMaybeApply(opts) {
+  const { url, company, title, dryRun = false } = opts;
+  const profile = readProfile();
+
+  // Check if already evaluated
+  const existing = findReportForUrl(url);
+  if (existing) {
+    console.log(`Already evaluated: ${existing.company} — ${existing.role} (${existing.score}/5)`);
+
+    if (existing.score >= profile.auto_apply_threshold && profile.auto_apply_enabled) {
+      console.log(`Score ${existing.score} >= ${profile.auto_apply_threshold} threshold — auto-applying...`);
+      const result = await runApplyPipeline({
+        url,
+        company: existing.company,
+        role: existing.role,
+        score: existing.score,
+        reportPath: existing.path,
+        reportNum: existing.num,
+        dryRun,
+      });
+      return { score: existing.score, applied: result.success, report: existing.path, error: result.error };
+    }
+
+    return { score: existing.score, applied: false, report: existing.path };
+  }
+
+  // Run evaluation via claude -p
+  const reportNum = nextReportNum();
+  const today = new Date().toISOString().slice(0, 10);
+
+  console.log(`Evaluating: ${company || 'Unknown'} — ${title || 'Unknown'}...`);
+
+  if (dryRun) {
+    console.log('[DRY RUN] Would evaluate and potentially auto-apply.');
+    return { score: 0, applied: false };
+  }
+
+  const evalPrompt = `Evaluate this job offer using the full career-ops pipeline.
+
+URL: ${url}
+Report number: ${reportNum}
+Date: ${today}
+
+Follow the instructions in modes/oferta.md for the A-G evaluation.
+Read cv.md, article-digest.md, modes/_shared.md, and modes/_profile.md.
+Save the report to: reports/${reportNum}-{company-slug}-${today}.md
+Write the tracker TSV to: batch/tracker-additions/${reportNum}-{company-slug}.tsv
+
+IMPORTANT: Include **Score:** and **URL:** headers in the report.`;
+
+  try {
+    execSync(`claude -p --dangerously-skip-permissions "${evalPrompt.replace(/"/g, '\\"')}"`, {
+      cwd: PROJECT_DIR,
+      timeout: 300000, // 5 min
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    return { score: 0, applied: false, error: `Evaluation failed: ${err.message?.slice(0, 200)}` };
+  }
+
+  // Read the result
+  const report = findReportForUrl(url);
+  if (!report) {
+    return { score: 0, applied: false, error: 'Evaluation completed but no report found.' };
+  }
+
+  console.log(`Evaluation complete: ${report.company} — ${report.role} (${report.score}/5)`);
+
+  // Auto-apply gate
+  if (report.score >= profile.auto_apply_threshold && profile.auto_apply_enabled) {
+    console.log(`Score ${report.score} >= ${profile.auto_apply_threshold} threshold — auto-applying...`);
+    const result = await runApplyPipeline({
+      url,
+      company: report.company,
+      role: report.role,
+      score: report.score,
+      reportPath: report.path,
+      reportNum: report.num,
+    });
+    return { score: report.score, applied: result.success, report: report.path, error: result.error };
+  }
+
+  return { score: report.score, applied: false, report: report.path };
+}
+
+// ── CLI entry point ──────────────────────────────────────────────────
+
+if (import.meta.url === `file://${process.argv[1]}` ||
+    process.argv[1]?.endsWith('apply-orchestrator.mjs')) {
+  const args = process.argv.slice(2);
+  const urlArg = args.find(a => a.startsWith('--url='))?.split('=')[1];
+  const dryRun = args.includes('--dry-run');
+  const submit = args.includes('--submit');
+
+  if (!urlArg) {
+    console.log('Usage: node apply-orchestrator.mjs --url <url> [--submit] [--dry-run]');
+    process.exit(1);
+  }
+
+  evaluateAndMaybeApply({ url: urlArg, dryRun })
+    .then(result => {
+      console.log('\nResult:', JSON.stringify(result, null, 2));
+      process.exit(result.error ? 1 : 0);
+    })
+    .catch(err => {
+      console.error('Fatal:', err);
+      process.exit(1);
+    });
+}

--- a/apply-orchestrator.mjs
+++ b/apply-orchestrator.mjs
@@ -377,7 +377,7 @@ Short punchy sentences. Concrete specifics. Casual confidence. 75-120 words, 5-6
  * @returns {Promise<{score: number, applied: boolean, report?: string, error?: string}>}
  */
 export async function evaluateAndMaybeApply(opts) {
-  const { url, company, title, dryRun = false } = opts;
+  const { url, company, title, dryRun = false, submit = true } = opts;
   const profile = readProfile();
 
   // Check if already evaluated
@@ -395,6 +395,7 @@ export async function evaluateAndMaybeApply(opts) {
         reportPath: existing.path,
         reportNum: existing.num,
         dryRun,
+        submit,
       });
       return { score: existing.score, applied: result.success, report: existing.path, error: result.error };
     }
@@ -455,6 +456,7 @@ IMPORTANT: Include **Score:** and **URL:** headers in the report.`;
       score: report.score,
       reportPath: report.path,
       reportNum: report.num,
+      submit,
     });
     return { score: report.score, applied: result.success, report: report.path, error: result.error };
   }
@@ -476,7 +478,9 @@ if (import.meta.url === `file://${process.argv[1]}` ||
     process.exit(1);
   }
 
-  evaluateAndMaybeApply({ url: urlArg, dryRun })
+  // --submit is required for an actual submission: without it the form is filled and
+  // screenshotted but NOT submitted (review-first default per AGENTS.md).
+  evaluateAndMaybeApply({ url: urlArg, dryRun, submit })
     .then(result => {
       console.log('\nResult:', JSON.stringify(result, null, 2));
       process.exit(result.error ? 1 : 0);

--- a/article-digest.md
+++ b/article-digest.md
@@ -1,0 +1,214 @@
+# Article Digest — Patrick Moore
+
+> Compact proof points with metrics. Career-ops reads this AT evaluation time
+> instead of hardcoding numbers in modes/_shared.md. Update as you ship work.
+>
+> Status: **in-progress** — drafted from resume content on 2026-05-08; metric
+> fields marked `[TBD]` are awaiting Patrick's input via the article-digest
+> walkthrough.
+
+---
+
+## /viecure — current role (Jul 2025 – Present)
+
+**Important framing — the agents are not the whole job.** Patrick is on a 3-person platform/security team at Viecure and the role is broad. The Claude agent fleet (next subsection) is **only the last several weeks** of the work; the bulk of the role is steady-state cloud security, platform engineering, governance authorship, and operating the internal Claude Code platform. When evaluating roles, weight the security/platform/governance work first; surface the agent fleet as evidence of recent execution velocity, not as the whole job description.
+
+**Product context:** Viecure is building a **brand-new oncology EMR** ground-up — Azure SaaS, MS SQL Server, AI-native by design — under HIPAA / HITRUST / SOC 2-track controls. Two environments today (dev + stg); **"stg is effectively prod"** because the EMR hasn't shipped yet, so stg carries production-grade load and data shapes.
+
+### What Patrick actually does day-to-day at Viecure
+
+| Layer | What he owns / contributes |
+|---|---|
+| **Security stack** | Selected, deployed, and operates Microsoft Defender suite (Cloud, Endpoint, Identity), Taegis XDR, Palo Alto. Vuln scanning, EDR, SIEM, IAM/governance. |
+| **Network & cloud arch** | Firewall + NSG rules, secure connectivity for clinical workloads, Terraform for networking and app infra (App Services, AKS, Functions, SQL). |
+| **Compliance & policy** | Authored ransomware, IAM/access, and HIPAA documentation for the SOC 2 / HITRUST cert effort. Authored the org-wide AI acceptable usage policy. Designed the agent identity / service-account model and the security review process for new agent deployments. |
+| **Internal Claude Code platform** | Org-wide Claude Code plugins for API-key users + org-wide Claude Code skills for OAuth users. Drives all AI coding at Viecure. |
+| **MCP / agent infra** | 3 Key Vaults, 3 Function Apps, 2 proxy MCP servers (ADO + Figma), service hooks/webhooks across ADO/Jira/Figma/Slack. |
+| **Agent fleet (recent)** | Three Claude agents shipped to production in the last several weeks (see below). |
+| **Admin** | Azure DevOps, Jira, Intune administration for the engineering organization. |
+
+**Strongest single proof of value at Viecure:** *"most of the company's daily Claude usage flows through MCP servers, agents, and governance built and operated by Patrick"* — this is true across all the layers above, not just the agents.
+
+---
+
+## /viecure — Claude agent fleet (recent: last several weeks of 2026)
+
+**Three agents in production**, plus the MCP servers, proxy infra, and governance underneath. **This is the most recent work** at Viecure, not the steady-state job — frame it as "shipped this in the last several weeks" rather than "this is what I do."
+
+### Patrick's design philosophy (load-bearing for senior AI roles)
+
+> "I try to make everyone better at their job by making agents to empower them in automated ways so they don't have to interact with AI — it interacts with them."
+
+That framing changes what the fleet is *for*: it's not a chatbot suite, it's invisible automation that comes to engineers/designers/ops people on their existing surfaces (PR, Jira ticket, Figma comment, Slack post) and **raises the floor** of what every team member ships. Use this quote in interviews and apply-form prose for AI/agentic roles — it's a stronger differentiator than any KPI.
+
+### Agent 1 — PR Review Agent
+- **Status:** Live in production since April 2026.
+- **Architecture:** Anthropic Managed Agent on Sonnet 4.6.
+- **What it does:** Reviews pull requests in Azure DevOps and posts structured feedback automatically.
+- **Cost signal:** Was costing **~$100/day** (~$36K/yr) on Sonnet 4.6 — a real, defensible inference budget for one agent in healthcare prod. (Cost optimization is an ongoing effort — see calibration notes below.)
+- **Volume:** **~100 PRs reviewed per day** (~25–30K/yr).
+- **Trust signal & adoption posture:** Feedback is **opt-in** — devs can ignore. Even skeptics liked the info. The intent is "raising the floor" so every dev gets automated feedback without it being mandatory; not gating merges, not replacing human review. Front-end devs found the (initially back-end-leaning) framing less useful — calibration is **ongoing** with input from the dev org.
+- **Resume framing (Patrick's preferred angle):** Lead with the *philosophy* and the *adoption posture* (opt-in, raises the floor, 100/day, devs trust the info even when they don't act on it) rather than a single percentage. The "skeptics liked the info" line is the strongest qualitative signal.
+- **Architecture note:** No proxy needed for ADO — Azure DevOps integrates directly. (Compare with Figma below.)
+
+### Agent 2 — Product Review Agent (Jira + Figma)
+- **Status:** In production.
+- **What it does:** Reviews product/design work — wired into Figma for design review and into Jira for ticket triage.
+- **Where feedback lands:** Jira comments; ticket state transitions when needed (moves tickets if a triage decision implies a status change); inline comments alongside the PR Review agent's feedback in the related PR when design intent and code diverge.
+- **MCP architecture (the differentiator):** Patrick built an **Azure-hosted MCP proxy** for Figma so the agent doesn't hit Figma data directly. Original problem: **the Figma data path was hitting 429 rate limits from Anthropic servers** and disrupting the Anthropic Managed Agent. Patrick designed and deployed a proxy MCP server inside Viecure's Azure tenant that fronts Figma and feeds the agent only what it needs — fixing the rate-limit problem and gaining a controlled audit/security boundary for Figma data in a HIPAA/HITRUST environment.
+- **Atlassian / Jira side:** **No proxy needed** — Atlassian's MCP support is mature; Jira flows directly. Concrete contrast Patrick can use in interviews: "Figma needed an MCP proxy to clear 429s, Atlassian was native."
+- **Volume / lead metric:** [TBD — Patrick may not track these as discrete numbers; the philosophy framing is the primary pitch]
+
+### Agent 3 — App Insights Agent (the operational loop)
+- **Status:** In production. **Recently shipped — not yet in the public resume.** First week already produced devs finding real performance improvements off the back of its output.
+- **Environments watched:** **Dev + Stg.** Because Viecure is building a brand-new EMR, **stg is effectively prod** (production-grade load and data). Read this as "the agent watches our most production-like environment for a healthcare product about to ship," not "the agent watches test envs."
+- **What it does:** Runs daily at **7am** and produces a structured analysis posted to Slack. Slack readers can spawn Jira tickets directly from the post.
+- **Daily output includes:**
+  - Most-used APIs
+  - Slowest APIs
+  - Error roll-ups
+  - **7-day and 30-day error baselines** (so spikes vs ambient noise are obvious)
+- **The closed loop (this is the differentiator):**
+  1. Analyzes Dev + Stg App Insights → posts daily report to Slack.
+  2. Slack readers can request a Jira ticket from the post.
+  3. Agent **writes the ticket** (description, repro context from App Insights).
+  4. Agent **analyzes ticket audience** and assigns the right engineer.
+  5. Agent **tags** the ticket appropriately.
+  6. Agent **updates Slack** to inform readers a ticket has been created and assigned.
+- **Early ROI (week 1):** Devs already found ways to improve app performance from the daily reports. The 7-day/30-day baseline is the first thing teams reach for in performance triage.
+- **Why this is more than another agent:** It's not "Claude reads logs and summarizes." It's a multi-step operational workflow with HITL (humans approve ticket creation), agent-driven assignment, and bidirectional Slack ↔ Jira sync. It's the kind of thing FDE / Applied-AI / AI-Platform hiring managers ask about because most teams *talk* about "AI ops" but very few have it actually wired in production.
+- **Lead metric:** Lead with the architecture (closed loop, dev/stg coverage, baseline-aware) and the week-1 ROI; specific numbers can come from interview follow-ups.
+
+### Underlying infra — what Patrick built and operates org-wide
+
+For all three agents and the broader org's Claude usage:
+
+| Component | Count / detail |
+|---|---|
+| **Azure Key Vaults** | 3 |
+| **Azure Function Apps** | 3 |
+| **Service hooks** | "where needed" — into ADO, Jira, Figma, Slack |
+| **Webhooks** | "where needed" — same surfaces |
+| **Proxy MCP servers** | 2 — Azure DevOps proxy + Figma proxy |
+
+The Figma proxy MCP is the single most "show, don't tell" engineering proof point in the fleet — it's a real-world workaround for an Anthropic-side 429 issue, built inside a regulated tenant, and it's the right architecture *anyway* (audit boundary, controlled data flow, HIPAA/HITRUST friendly).
+
+**Adoption signal:** "most of the company's daily Claude usage flows through MCP servers, agents, and governance built and operated by Patrick" (cv.md).
+
+### Underlying ops — AI Governance
+- **Authored:** AI usage policy (org-wide, the canonical document), agent identity / service-account model, security review process for new agent deployments.
+- **Audience:** Whole engineering org.
+- **Hero metric:** [TBD — # of agents reviewed/approved under this process, # of policy violations caught/prevented]
+
+### Internal Claude Code platform — org-wide developer enablement
+
+This is a separate proof point from the agent fleet — Patrick operates an **internal Claude Code platform** for the whole engineering org, and **drives all AI coding efforts** at Viecure.
+
+| Layer | What Patrick built | Who it's for |
+|---|---|---|
+| **Org-wide Claude Code plugins** | Custom plugins (hooks, MCPs, behavior extensions) shipped org-wide | API-key users (developers running Claude Code with their own API keys) |
+| **Org-wide Claude Code skills** | Custom user-invocable skills (`/...` commands, workflows) shipped org-wide | OAuth users (developers on the Claude.ai Pro/Max subscription path) |
+| **AI acceptable usage policy** | Authored the canonical policy that governs both groups | Whole org |
+| **AI coding leadership** | Owns and drives all AI coding efforts at the company | Engineering org |
+
+**Why this matters in interviews:** Most candidates can talk about *using* Claude Code. Very few can describe *operating it as a platform* for an engineering org — managing both the API-key path and the OAuth path, shipping plugins and skills as internal products, and authoring the policy that controls how the team uses AI. This is exactly what AI Platform / Developer Experience / AI Enablement teams at AI labs hire for.
+
+**Lead framing for senior AI Platform / DX roles:** "I run an internal Claude Code platform for ~N engineers. We operate two access paths (API-key plugins for developers, OAuth skills for everyone else), with the AI usage policy I authored as the connective tissue."
+
+- **Headcount served:** [TBD — engineers + others on the OAuth path]
+- **Plugin / skill count:** [TBD — how many shipped to date]
+- **Adoption signal:** "most of the company's daily Claude usage flows through MCP servers, agents, and governance built and operated by Patrick" already covers this — but a number on plugins/skills shipped + usage frequency would be even better when you have a moment.
+
+---
+
+## /viecure — Security stack maturation
+
+**One-liner:** Took a previously messy Azure environment to SOC 2 / HITRUST track shape on a 3-person team. Selected, deployed, and operates the security stack end-to-end.
+
+- **Stack stood up / matured:** Microsoft Defender suite (Cloud, Endpoint, Identity), Taegis XDR, Palo Alto.
+- **Coverage:** Vuln scanning, EDR, SIEM, IAM/governance.
+- **Network:** Firewall + NSG rules, secure connectivity for clinical workloads, Terraform for networking + app infra (App Services, AKS, Functions, SQL).
+- **Hero metric:** [TBD — vulns closed, controls now in scope, time-to-detect improvement, etc.]
+- **Compliance docs authored:** Ransomware, IAM/access, HIPAA — feeding the SOC 2 / HITRUST cert effort underway.
+
+---
+
+## /envision-healthcare — Cloud Security Engineer II (2018–2025)
+
+**One-liner:** Six years across HIPAA & HITRUST-regulated cloud security at Envision Healthcare, promoted twice (Sysadmin → System Engineer I → Cloud Security Engineer II). The years where Patrick built the security DNA that the Viecure work sits on top of.
+
+### Security stack operated end-to-end
+- Wiz, AWS Security Hub, Zscaler, Tanium, SentinelOne, Rapid7 — selected, deployed, and operated in production.
+- This is the toolchain hiring managers want operator-level fluency in for senior cloud security roles. Patrick has it.
+
+### IAM-as-code rollout
+- **What it replaced:** A manual ticket-driven access process across AWS and Azure.
+- **What it became:** Version-controlled IAM policy automation in **Terraform + PowerShell** — codified, auditable, peer-reviewable.
+- **Why it matters:** This is the direct ancestor of the agent work at Viecure. Same instinct (automate the toil), same toolchain (Terraform / scripts), seven years earlier with a security framing.
+- **Scale at peak:** **30,000 employees** (clinical + non-clinical) under management. **95% AWS** primary CSP. **~100 AWS accounts across 3 tenants** — this is a real enterprise control plane, not a small-shop deployment.
+- **Resume framing:** "I codified IAM policy across ~100 AWS accounts in 3 tenants serving 30,000 employees" is the line — concrete, verifiable enterprise scale.
+
+### Automation that retired ops toil — the war story
+
+Patrick's lead Envision proof point in his own words: **"built automated processes that eliminated teams."**
+
+This is a powerful business outcome but **needs careful framing in interviews and apply prose** because "eliminated teams" can read two ways:
+- **(A) Efficiency win** — automation removed the *need* for repetitive-ops headcount; the company reorganized accordingly. Strong signal for hiring managers focused on AI/automation ROI.
+- **(B) Job displacement** — same fact stated bluntly. Some hiring managers (especially at AI-ethics-conscious or unionized orgs) will read this as a red flag about how the candidate frames human cost.
+
+**Recommended interview framing options** (Patrick to pick whichever is most accurate):
+- *"I built automation that retired hundreds of FTE-hours per week of repetitive ops work — the org reorganized around the freed-up capacity."*
+- *"The work I automated at Envision was real, ongoing toil — by the end, the manual processes I replaced no longer required dedicated teams."*
+- *"My automation work eliminated the need for the manual processes those teams ran. That's the throughline to the agent work at Viecure: I make repetitive work disappear."*
+
+In **resume bullet form**, lean toward outcome rather than headcount: *"PowerShell, Bash, and Python automation that retired hundreds of FTE-hours/week of repetitive security operations work — direct ancestor of the agent work shipped at Viecure."*
+
+The verbatim phrase "eliminated teams" is the right thing for *Patrick's own* notes (it's how he experienced the impact) but reframe outward depending on audience.
+
+### Tanium + 3-MDM rollout
+- **Co-led enterprise Tanium rollout** across the org.
+- **Stood up three MDM platforms** (Intune, Jamf, Mosyle) covering Windows and macOS clinical fleets — three different platforms because clinical hardware is heterogeneous.
+- **Scale:** **Tens of thousands of endpoints** under management. **99% Windows** fleet (the macOS slice is the smaller clinical/exec set that Jamf and Mosyle covered).
+- **Why it matters:** Demonstrates ability to roll out endpoint management at scale across mixed fleets in healthcare — tens of thousands of endpoints is a real enterprise number that maps directly to the multi-tenant / multi-stack work AI infra and security platform teams hire for.
+
+### Promotions / longevity signal
+- Sysadmin (2018) → System Engineer I (\~2022) → Cloud Security Engineer II (Jul 2024). Two promotions in six years on automation and ownership; not a "hop and dash" candidate.
+
+---
+
+## /moorelab.cloud — personal site & lab
+
+**One-liner:** Personal portfolio + auto-regenerated /now block + lab notes; signals "builder who runs systems for fun, not just at work."
+
+- **URL:** https://moorelab.cloud
+- **Stack:** Static site, regenerated weekly by `build/refresh-dynamic.py` pulling recent GitHub activity + curated notes. The /now block is dynamic and reflects current focus.
+- **Sub-properties:** [hackerzork.moorelab.cloud/play](https://hackerzork.moorelab.cloud/play) — playable text-adventure game built alongside Claude.
+- **Resume:** The site hosts four role-tabbed resume variants (AI & Security, Cloud, Condensed, Detailed Full History). Note: as of 2026-05-08 the page is **stale relative to cv.md** — doesn't yet mention the App Insights agent, the Claude Code platform work, or the security-first framing.
+- **Homelab proof point:** HA Proxmox + OPNsense (the same lab now running the career-ops scanner LXC), self-hosted AI tooling, multi-VLAN segmentation. This is the unspoken half of "security engineer first" — Patrick designs and operates secure networks for fun.
+
+---
+
+## /github.com/tricheboars
+
+**One-liner:** Public homelab tooling, self-hosted AI infra, MCP/agent prototypes — visible builder signal that backs up the resume.
+
+- **URL:** https://github.com/tricheboars/
+- **Why it matters in evaluations:** Hiring managers at AI labs and dev-tools companies look at GitHub activity for builder signal. Patrick has public repos around homelab IaC, MCP/agent prototypes, and the hackerzork text-adventure — concrete evidence that the "agents in production at work" claim isn't a one-off.
+- **Hero repos:** [TBD — pick 2–3 most representative when prompted; hackerzork is the one with public traction]
+
+---
+
+## Cross-cutting narrative
+
+**Patrick is a security engineer first.** That's the foundation — the lens, the identity, the throughline across 25+ years of healthcare, finance, defense, and government cyber.
+
+The other hats are layered on top, in order:
+
+1. **Security engineer** (foundation) — HIPAA / HITRUST / SOC 2 documentation personally authored; Defender / Taegis / Palo Alto / Wiz operated end-to-end; AWS SAA-C03; AI usage policy authoring.
+2. **System engineer** (built on #1) — 3 Key Vaults, 3 Function Apps, 2 proxy MCP servers, IAM-as-code in Terraform + PowerShell, Tanium + 3-MDM rollouts, HA Proxmox / OPNsense homelab.
+3. **AI engineer** (built on #1 + #2) — three Claude agents in production, internal Claude Code platform (org-wide plugins for API users + skills for OAuth users), MCP server author, agent identity / service-account model designer.
+4. **Social engineer / "the glue"** (what makes it ship) — brought skeptical devs along on the PR review agent ("even skeptics liked the info"), iterating with front-end devs on calibration mismatch, drives consensus on AI policy, ships across team boundaries. Double meaning intentional: security discipline + people glue.
+
+**That stack on the same person is rare.** Most candidates split cleanly into one bucket — the security person who *talks* about AI, the AI person who *skips* compliance, the solo builder who can't bring others along. Patrick has all four functions on one resume, with seven years of healthcare-regulated cloud security as the foundation everything else stands on.
+
+**Lead with security DNA.** The pitch order is "security engineer who *also* ships Claude agents in prod and runs Claude Code as a platform" — never "AI engineer with security background." The security identity is foundational, not flavor.

--- a/article-digest.md
+++ b/article-digest.md
@@ -31,6 +31,33 @@
 
 ---
 
+## /viecure — Ambient AI Transcription System (current build, 2026)
+
+**One-liner:** Built an Azure-native GPU training system for an ambient AI model that transcribes and records oncology clinical visits, integrating directly into the EMR.
+
+**What it is:** A purpose-built system to train an ambient AI listening model for oncology doctors. Transcribes clinical visits — diagnosis, note-taking, patient interactions — and feeds structured output directly into the Viecure EMR. This is a separate workstream from the Claude agent fleet; it's a custom ML training pipeline, not a prompt-engineering exercise.
+
+**Architecture (Patrick built and operates all of this):**
+- **Compute:** Azure VMSS with A100 GPUs running Ubuntu VMs (H100s also in scope)
+- **Queue:** 3 RabbitMQ servers for job queuing and training orchestration
+- **Services:** 3 Docker containers running on the VMSS GPU VM, operating in concert with the GPU for model training
+- **Scale:** **80+ Azure resources** in a dedicated resource group Patrick created
+- **Platform:** Fully Azure-hosted, designed within Viecure's HIPAA/HITRUST compliance boundary
+- **Current state:** Attempting to break the 3 services out of the GPU VM into separate infrastructure (hit Envoy networking bugs in Azure — active debugging as of late May 2026)
+
+**Why this matters for job applications:**
+- Proves Patrick operates at the ML-infra / AI-platform level, not just the prompt-engineering / agent-orchestration level
+- A100/H100 GPU fleet management is a differentiator for senior AI infrastructure roles
+- Healthcare-specific ambient AI (clinical transcription) is a hot market — direct overlap with Abridge, Suki, Ambience Healthcare, Augmedix
+- The 80+ resource count demonstrates real IaC/cloud-architecture complexity, not a weekend project
+- RabbitMQ + Docker + VMSS shows distributed systems thinking
+
+**Lead framing for AI Platform / ML Infra roles:** "I built the GPU training infrastructure for an ambient clinical AI model — A100 VMSS, RabbitMQ job queuing, 80+ Azure resources in a resource group I designed from scratch. It trains a transcription model that feeds directly into our oncology EMR."
+
+**Lead framing for Healthcare AI roles:** "We're building an ambient AI model for oncology doctors — transcribes clinical visits and integrates directly into the EMR. I built the full training infrastructure in Azure: GPU VMSS, RabbitMQ orchestration, Docker services, all under HIPAA/HITRUST controls."
+
+---
+
 ## /viecure — Claude agent fleet (recent: last several weeks of 2026)
 
 **Three agents in production**, plus the MCP servers, proxy infra, and governance underneath. **This is the most recent work** at Viecure, not the steady-state job — frame it as "shipped this in the last several weeks" rather than "this is what I do."

--- a/auto-pipeline.mjs
+++ b/auto-pipeline.mjs
@@ -32,6 +32,7 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 import { join, resolve } from 'path';
+import { runApplyPipeline } from './apply-orchestrator.mjs';
 
 const PROJECT_DIR = resolve(import.meta.dirname || '.');
 const PIPELINE_PATH = join(PROJECT_DIR, 'data/pipeline.md');
@@ -54,7 +55,23 @@ function readEnv(path = join(PROJECT_DIR, '.env')) {
   return env;
 }
 
-// ── Location gate ─────────���──────────────────────────────────────────────
+// ── Auto-apply config ────────────────────────────────────────────────────
+
+function readAutoApplyConfig() {
+  const profilePath = join(PROJECT_DIR, 'config/profile.yml');
+  if (!existsSync(profilePath)) return { enabled: false, threshold: 4.5 };
+  const raw = readFileSync(profilePath, 'utf-8');
+  const get = (key) => {
+    const m = raw.match(new RegExp(`^\\s*${key}:\\s*["']?(.+?)["']?\\s*$`, 'm'));
+    return m ? m[1] : '';
+  };
+  return {
+    enabled: get('auto_apply_enabled') !== 'false',
+    threshold: parseFloat(get('auto_apply_threshold')) || 4.5,
+  };
+}
+
+// ── Location gate ────────────────────────────────────────────────────────
 
 // Non-Denver cities — if the title explicitly names one of these (in parens
 // or after a pipe/dash), it's a non-Denver on-site role. Denver/Remote pass.
@@ -576,6 +593,59 @@ async function main() {
 
   if (highReports.length === 0) {
     console.log('  No roles scored ≥4.0 — no cover letters generated.');
+  }
+
+  // Step 5b: Auto-apply for high scorers (≥ threshold)
+  const autoApplyOverride = args.includes('--auto-apply') ? true :
+                            args.includes('--no-auto-apply') ? false : null;
+  const autoConfig = readAutoApplyConfig();
+  const doAutoApply = autoApplyOverride !== null ? autoApplyOverride : autoConfig.enabled;
+  const autoThreshold = autoConfig.threshold;
+
+  if (doAutoApply) {
+    const autoApplyCandidates = highReports.filter(r => r.score >= autoThreshold);
+    if (autoApplyCandidates.length > 0) {
+      console.log(`\n── Step 5b: Auto-applying (≥${autoThreshold}) ──\n`);
+      console.log(`  ${autoApplyCandidates.length} candidate(s) for auto-apply\n`);
+
+      for (const r of autoApplyCandidates) {
+        if (dryRun) {
+          console.log(`  [DRY RUN] Would auto-apply: ${r.company} — ${r.role} (${r.score}/5)`);
+          continue;
+        }
+
+        try {
+          const result = await runApplyPipeline({
+            url: r.url,
+            company: r.company,
+            role: r.role,
+            score: r.score,
+            reportPath: r.reportPath,
+            reportNum: r.file.match(/^(\d+)/)?.[1],
+            submit: true,
+          });
+
+          if (result.success) {
+            console.log(`  ✅ Auto-applied: ${r.company} — ${r.role}`);
+            clResults.push({ ...r, autoApplied: true });
+          } else {
+            console.log(`  ❌ Auto-apply failed: ${r.company} — ${result.error}`);
+          }
+        } catch (err) {
+          console.error(`  ❌ Auto-apply error: ${r.company} — ${err.message?.slice(0, 100)}`);
+        }
+
+        // 30s cooldown between applications to avoid ATS rate limits
+        if (autoApplyCandidates.indexOf(r) < autoApplyCandidates.length - 1) {
+          console.log('  ⏳ 30s cooldown...');
+          await new Promise(resolve => setTimeout(resolve, 30000));
+        }
+      }
+    } else {
+      console.log(`\n── Step 5b: No roles scored ≥${autoThreshold} for auto-apply ──\n`);
+    }
+  } else {
+    console.log('\n── Step 5b: Auto-apply disabled ──\n');
   }
 
   // Step 7: Merge tracker

--- a/auto-pipeline.mjs
+++ b/auto-pipeline.mjs
@@ -1,0 +1,621 @@
+#!/usr/bin/env node
+
+/**
+ * auto-pipeline.mjs — Full auto-pipeline orchestrator
+ *
+ * Reads unchecked entries from pipeline.md, applies pre-LLM gates,
+ * feeds qualifying roles into the batch evaluator, generates cover
+ * letters for high scorers (≥4.0), and sends a Telegram summary.
+ *
+ * Usage:
+ *   node auto-pipeline.mjs                  # full pipeline
+ *   node auto-pipeline.mjs --prepare-only   # just write batch-input.tsv, don't run
+ *   node auto-pipeline.mjs --cover-letters  # only generate CLs for existing high-scoring reports
+ *   node auto-pipeline.mjs --notify         # only send Telegram results digest
+ *   node auto-pipeline.mjs --dry-run        # show what would be processed
+ *   node auto-pipeline.mjs --max N          # limit to N roles (default: 10)
+ *   node auto-pipeline.mjs --sync           # pull pipeline.md from CT 203 first
+ *
+ * Requires:
+ *   - claude CLI in PATH (for batch evaluation + cover letter generation)
+ *   - .env with TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID (for notifications)
+ *
+ * Flow:
+ *   1. Read pipeline.md → filter unchecked entries
+ *   2. Apply pre-LLM gates (location keywords, title filter)
+ *   3. Write batch-input.tsv with qualifying URLs
+ *   4. Run batch-runner.sh (evaluates via claude -p)
+ *   5. Read completed evaluations → for score ≥ 4.0, generate cover letter
+ *   6. Send Telegram digest with results
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from 'fs';
+import { execSync, spawn } from 'child_process';
+import { join, resolve } from 'path';
+
+const PROJECT_DIR = resolve(import.meta.dirname || '.');
+const PIPELINE_PATH = join(PROJECT_DIR, 'data/pipeline.md');
+const BATCH_INPUT = join(PROJECT_DIR, 'batch/batch-input.tsv');
+const BATCH_STATE = join(PROJECT_DIR, 'batch/batch-state.tsv');
+const REPORTS_DIR = join(PROJECT_DIR, 'reports');
+const OUTPUT_DIR = join(PROJECT_DIR, 'output');
+const TRACKER_DIR = join(PROJECT_DIR, 'batch/tracker-additions');
+const COVER_LETTERS_DIR = join(PROJECT_DIR, 'output/cover-letters');
+
+// ── Config ───────────────────────────────────────────────────────────────
+
+function readEnv(path = join(PROJECT_DIR, '.env')) {
+  if (!existsSync(path)) return {};
+  const env = {};
+  for (const line of readFileSync(path, 'utf-8').split('\n')) {
+    const m = line.match(/^([A-Z_]+)\s*=\s*(.+)$/);
+    if (m) env[m[1]] = m[2].trim().replace(/^["']|["']$/g, '');
+  }
+  return env;
+}
+
+// ── Location gate ─────────���──────────────────────────────────────────────
+
+// Non-Denver cities — if the title explicitly names one of these (in parens
+// or after a pipe/dash), it's a non-Denver on-site role. Denver/Remote pass.
+const NON_DENVER_CITIES = [
+  'san francisco', 'sf', 'nyc', 'new york', 'seattle', 'austin', 'boston',
+  'chicago', 'los angeles', 'la', 'london', 'berlin', 'paris', 'tokyo',
+  'munich', 'amsterdam', 'warsaw', 'palo alto', 'menlo park', 'sunnyvale',
+  'mountain view', 'cupertino', 'redwood city', 'foster city',
+  'livingston', 'kenilworth', 'bellevue', 'kirkland',
+  'portland', 'atlanta', 'miami', 'phoenix', 'salt lake city',
+  'raleigh', 'charlotte', 'dallas', 'houston',
+  'washington', 'dc', 'd.c.', 'arlington',
+  'toronto', 'vancouver', 'montreal',
+  'hyderabad', 'bangalore', 'mumbai', 'india', 'gurugram',
+  'uk', 'germany', 'france', 'japan', 'qatar', 'doha',
+  'europe', 'apac', 'emea', 'apj',
+  'argentina', 'brazil', 'israel', 'singapore', 'australia',
+  'florida', 'new jersey', 'nj', 'virginia',
+];
+
+// Build regex: match city names in parens, after |, or at end
+const cityPattern = new RegExp(
+  `(?:\\(|\\||,|—|–|-)\\s*(?:${NON_DENVER_CITIES.join('|')})`,
+  'i'
+);
+
+function locationGate(title, company) {
+  const combined = `${title}`;
+
+  // If it says Denver or Remote explicitly, always pass
+  if (/denver|remote|distributed|anywhere|united states remote/i.test(combined)) return 'pass';
+
+  // If it names a non-Denver city in the title, skip
+  if (cityPattern.test(combined)) return 'skip-location';
+
+  // Special: "US-XX-" pattern (like US-CA-Remote) — check if it has a state
+  const stateMatch = combined.match(/US-([A-Z]{2})/);
+  if (stateMatch && stateMatch[1] !== 'CO') {
+    // Non-Colorado state... but might be remote
+    if (/remote/i.test(combined)) return 'pass';
+    return 'skip-location';
+  }
+
+  // No location signal — assume it could be remote (eval will verify)
+  return 'pass';
+}
+
+// ── Title pre-filter (mirrors scan.mjs positive/negative) ────────────────
+
+// Negative keywords — mirrors portals.yml negatives + Patrick-specific exclusions
+const TITLE_NEGATIVES = [
+  /machine learning/i, /\bml engineer/i, /\bml scientist/i, /\bml researcher/i,
+  /research scientist/i, /research engineer/i, /data scientist/i, /data analyst/i,
+  /\bmlops\b/i, /nlp engineer/i, /computer vision/i, /deep learning/i,
+  /product manager/i, /program manager/i, /\bvp\b/i, /vice president/i,
+  /\bchief\b/i, /partner development/i, /partnerships manager/i, /business development/i,
+  /\bgtm\b/i, /frontend/i, /front-end/i, /\bui engineer/i, /\bux\b/i,
+  /\bintern\b/i, /working student/i, /\bjunior\b/i,
+];
+
+function titleGate(title) {
+  for (const pat of TITLE_NEGATIVES) {
+    if (pat.test(title)) return 'skip-title';
+  }
+  return 'pass';
+}
+
+// ── Pipeline reader ──────────────────────────────────────────────────────
+
+const SCAN_HISTORY_PATH = join(PROJECT_DIR, 'data/scan-history.tsv');
+
+/**
+ * Read today's new scan results from scan-history.tsv.
+ * This is the primary source — only processes roles that came in TODAY
+ * (or a specified date), not the entire historical pipeline.
+ */
+function readTodaysScanResults(targetDate) {
+  if (!existsSync(SCAN_HISTORY_PATH)) return [];
+
+  return readFileSync(SCAN_HISTORY_PATH, 'utf-8')
+    .split('\n')
+    .slice(1) // skip header
+    .filter(Boolean)
+    .map(line => {
+      const [url, first_seen, portal, title, company] = line.split('\t');
+      return { url, first_seen, portal, title: (title || '').trim(), company: (company || '').trim() };
+    })
+    .filter(r => r.first_seen === targetDate && r.url && r.title);
+}
+
+/**
+ * Fallback: read the full pipeline.md (all unchecked entries regardless of date).
+ * Used with --all flag for catch-up processing.
+ */
+function readFullPipeline() {
+  if (!existsSync(PIPELINE_PATH)) return [];
+
+  const content = readFileSync(PIPELINE_PATH, 'utf-8');
+  const entries = [];
+
+  for (const line of content.split('\n')) {
+    const m = line.match(/^- \[ \] (.+?) \| (.+?) \| (.+)$/);
+    if (m) {
+      entries.push({
+        url: m[1].trim(),
+        company: m[2].trim(),
+        title: m[3].trim(),
+      });
+    }
+  }
+
+  return entries;
+}
+
+// ── Already-processed detection ──────────────────────────────────────────
+
+function getProcessedUrls() {
+  const processed = new Set();
+
+  // Check batch-state.tsv for already-processed URLs
+  if (existsSync(BATCH_STATE)) {
+    const lines = readFileSync(BATCH_STATE, 'utf-8').split('\n').slice(1);
+    for (const line of lines) {
+      const [, url, status] = line.split('\t');
+      if (url && (status === 'completed' || status === 'skipped')) {
+        processed.add(url);
+      }
+    }
+  }
+
+  // Check existing reports for URLs
+  if (existsSync(REPORTS_DIR)) {
+    for (const file of readdirSync(REPORTS_DIR)) {
+      if (!file.endsWith('.md')) continue;
+      const content = readFileSync(join(REPORTS_DIR, file), 'utf-8');
+      const urlMatch = content.match(/\*\*URL:\*\*\s*(.+)/);
+      if (urlMatch) processed.add(urlMatch[1].trim());
+    }
+  }
+
+  return processed;
+}
+
+// ── Batch input writer ───────────────────────────────────────────────────
+
+function writeBatchInput(entries) {
+  mkdirSync(join(PROJECT_DIR, 'batch'), { recursive: true });
+
+  let tsv = 'id\turl\tsource\tnotes\n';
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    tsv += `${i + 1}\t${e.url}\t${e.company}\t${e.title}\n`;
+  }
+
+  writeFileSync(BATCH_INPUT, tsv);
+  return entries.length;
+}
+
+// ── Cover letter generator ───────────────────────────────────────────────
+
+function getHighScoringReports(minScore = 4.0) {
+  if (!existsSync(REPORTS_DIR)) return [];
+
+  const reports = [];
+  const today = new Date().toISOString().slice(0, 10);
+
+  for (const file of readdirSync(REPORTS_DIR)) {
+    if (!file.endsWith('.md')) continue;
+
+    const content = readFileSync(join(REPORTS_DIR, file), 'utf-8');
+
+    // Extract score
+    const scoreMatch = content.match(/\*\*Score:\*\*\s*([0-9.]+)\/5/);
+    if (!scoreMatch) continue;
+    const score = parseFloat(scoreMatch[1]);
+    if (score < minScore) continue;
+
+    // Extract company and role
+    const headerMatch = content.match(/# (?:Evaluation|Evaluación):\s*(.+?)\s*[—–-]\s*(.+)/);
+    if (!headerMatch) continue;
+
+    // Extract URL
+    const urlMatch = content.match(/\*\*URL:\*\*\s*(.+)/);
+
+    // Check if cover letter already exists
+    const company = headerMatch[1].trim();
+    const role = headerMatch[2].trim();
+    const slug = company.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    const clPath = join(COVER_LETTERS_DIR, `cl-${slug}-${today}.md`);
+
+    if (existsSync(clPath)) continue; // already generated
+
+    reports.push({
+      file,
+      score,
+      company,
+      role,
+      url: urlMatch ? urlMatch[1].trim() : '',
+      slug,
+      reportPath: join(REPORTS_DIR, file),
+    });
+  }
+
+  return reports.sort((a, b) => b.score - a.score);
+}
+
+function generateCoverLetter(report, dryRun = false) {
+  mkdirSync(COVER_LETTERS_DIR, { recursive: true });
+
+  const today = new Date().toISOString().slice(0, 10);
+  const outputPath = join(COVER_LETTERS_DIR, `cl-${report.slug}-${today}.md`);
+
+  if (dryRun) {
+    console.log(`  [dry-run] Would generate CL for ${report.company} — ${report.role} (${report.score}/5)`);
+    return null;
+  }
+
+  const prompt = `Generate a cover letter for Patrick Moore for this role:
+Company: ${report.company}
+Role: ${report.role}
+URL: ${report.url}
+
+Read the evaluation report at: ${report.reportPath}
+Read cv.md for proof points.
+Read article-digest.md for detailed proof points.
+Read modes/_profile.md "Writing Style" section for voice rules.
+Read modes/cover-letter.md for the full cover letter mode instructions.
+
+Output ONLY the cover letter in the format specified in modes/cover-letter.md.
+Save it to: ${outputPath}
+
+IMPORTANT: Follow Patrick's voice rules EXACTLY. No corporate speak. No "leveraging."
+Short punchy sentences. Concrete specifics. Casual confidence. 200-300 words max.`;
+
+  try {
+    console.log(`  Generating CL: ${report.company} — ${report.role} (${report.score}/5)...`);
+    execSync(`claude -p --dangerously-skip-permissions "${prompt.replace(/"/g, '\\"')}"`, {
+      cwd: PROJECT_DIR,
+      timeout: 120000, // 2 min per cover letter
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    if (existsSync(outputPath)) {
+      console.log(`  ✅ Cover letter saved: ${outputPath}`);
+      return outputPath;
+    } else {
+      console.log(`  ⚠️  CL generation completed but file not found at ${outputPath}`);
+      return null;
+    }
+  } catch (err) {
+    console.error(`  ❌ CL generation failed for ${report.company}: ${err.message?.slice(0, 100)}`);
+    return null;
+  }
+}
+
+// ── Telegram notification ────────────────────────────────────────────────
+
+async function sendResultsDigest(results, dryRun = false) {
+  const env = readEnv();
+  const TOKEN = env.TELEGRAM_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN;
+  const CHAT_ID = env.TELEGRAM_CHAT_ID || process.env.TELEGRAM_CHAT_ID;
+
+  if (!TOKEN || !CHAT_ID) {
+    console.log('  No Telegram credentials — skipping notification.');
+    return;
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const highScorers = results.filter(r => r.score >= 4.0);
+  const midScorers = results.filter(r => r.score >= 3.0 && r.score < 4.0);
+  const skipped = results.filter(r => r.score < 3.0 || r.status === 'skipped');
+
+  let msg = `<b>🎯 auto-pipeline results · ${today}</b>\n`;
+  msg += `${results.length} evaluated`;
+  if (highScorers.length > 0) msg += ` · <b>${highScorers.length} high-fit</b>`;
+  msg += '\n━━━━━━━━━━━━━━━━━━━━━━\n';
+
+  if (highScorers.length > 0) {
+    msg += '\n🟢 <b>HIGH FIT (≥4.0) — CV + CL generated</b>\n';
+    for (const r of highScorers) {
+      msg += `• <b>${r.company}</b> — ${r.role}\n`;
+      msg += `  Score: ${r.score}/5`;
+      if (r.coverLetter) msg += ' · CL ✅';
+      if (r.pdf) msg += ' · PDF ✅';
+      msg += '\n';
+    }
+  }
+
+  if (midScorers.length > 0) {
+    msg += '\n🟡 <b>MAYBE (3.0–3.9)</b>\n';
+    for (const r of midScorers.slice(0, 5)) {
+      msg += `• ${r.company} — ${r.role} (${r.score}/5)\n`;
+    }
+    if (midScorers.length > 5) msg += `  <i>+${midScorers.length - 5} more</i>\n`;
+  }
+
+  if (skipped.length > 0) {
+    msg += `\n⚪ ${skipped.length} below threshold or skipped\n`;
+  }
+
+  msg += '\n<i>Review artifacts in output/cover-letters/</i>';
+
+  if (dryRun) {
+    console.log('\n── Results digest (dry run) ──\n');
+    console.log(msg);
+    return;
+  }
+
+  try {
+    const resp = await fetch(`https://api.telegram.org/bot${TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: CHAT_ID,
+        text: msg,
+        parse_mode: 'HTML',
+        disable_web_page_preview: true,
+      }),
+    });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    console.log('  ✓ Results digest sent to Telegram');
+  } catch (err) {
+    console.error(`  ❌ Telegram send failed: ${err.message}`);
+  }
+}
+
+// ── Sync from CT 203 ─────────────────────────────────────────────────────
+
+function syncFromScanner() {
+  console.log('Syncing pipeline.md from CT 203...');
+  try {
+    execSync('scp root@10.1.30.50:/opt/career-ops/data/pipeline.md data/pipeline.md', {
+      cwd: PROJECT_DIR,
+      timeout: 15000,
+      stdio: 'pipe',
+    });
+    execSync('scp root@10.1.30.50:/opt/career-ops/data/scan-history.tsv data/scan-history.tsv', {
+      cwd: PROJECT_DIR,
+      timeout: 15000,
+      stdio: 'pipe',
+    });
+    console.log('  ✓ Synced from scanner');
+  } catch (err) {
+    console.error(`  ⚠️  Sync failed (continuing with local data): ${err.message?.slice(0, 80)}`);
+  }
+}
+
+// ── Run batch evaluation ─────────────────────────────────────────────────
+
+function runBatchEvaluation(dryRun = false) {
+  const batchRunner = join(PROJECT_DIR, 'batch/batch-runner.sh');
+
+  if (dryRun) {
+    console.log('\n[dry-run] Would run: batch-runner.sh');
+    return [];
+  }
+
+  console.log('\nRunning batch evaluation...');
+  try {
+    const output = execSync(`bash "${batchRunner}"`, {
+      cwd: PROJECT_DIR,
+      timeout: 600000, // 10 min max for batch
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    console.log(output);
+  } catch (err) {
+    console.error(`Batch runner error: ${err.message?.slice(0, 200)}`);
+  }
+
+  // Read results from batch-state.tsv
+  if (!existsSync(BATCH_STATE)) return [];
+
+  return readFileSync(BATCH_STATE, 'utf-8')
+    .split('\n')
+    .slice(1)
+    .filter(Boolean)
+    .map(line => {
+      const [id, url, status, , , reportNum, score] = line.split('\t');
+      return { id, url, status, reportNum, score: parseFloat(score) || 0 };
+    });
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const prepareOnly = args.includes('--prepare-only');
+  const coverLettersOnly = args.includes('--cover-letters');
+  const notifyOnly = args.includes('--notify');
+  const doSync = args.includes('--sync');
+  const useAll = args.includes('--all'); // process full pipeline, not just today
+  const maxIdx = args.indexOf('--max');
+  const maxRoles = maxIdx !== -1 ? parseInt(args[maxIdx + 1]) : 10;
+  const dateIdx = args.indexOf('--date');
+  const targetDate = dateIdx !== -1 ? args[dateIdx + 1] : new Date().toISOString().slice(0, 10);
+
+  console.log('═══════════════════════════════════════════');
+  console.log(' career-ops AUTO-PIPELINE');
+  console.log(`═══════════════════════════════════════════`);
+  console.log(`Mode: ${dryRun ? 'DRY RUN' : coverLettersOnly ? 'COVER LETTERS ONLY' : notifyOnly ? 'NOTIFY ONLY' : prepareOnly ? 'PREPARE ONLY' : 'FULL PIPELINE'}`);
+  console.log(`Date: ${targetDate} ${useAll ? '(--all: full pipeline)' : '(today only)'}`);
+  console.log(`Max roles: ${maxRoles}`);
+  console.log('');
+
+  // Step 0: Sync from scanner if requested
+  if (doSync) syncFromScanner();
+
+  // Cover letters only mode — just generate CLs for existing high-scoring reports
+  if (coverLettersOnly) {
+    console.log('── Generating cover letters for high-scoring reports ──\n');
+    const reports = getHighScoringReports(4.0);
+    if (reports.length === 0) {
+      console.log('No high-scoring reports without cover letters.');
+      return;
+    }
+    console.log(`Found ${reports.length} high-scoring reports needing cover letters:\n`);
+    for (const r of reports.slice(0, maxRoles)) {
+      generateCoverLetter(r, dryRun);
+    }
+    return;
+  }
+
+  // Notify only mode — send digest of existing results
+  if (notifyOnly) {
+    const reports = getHighScoringReports(0);
+    await sendResultsDigest(reports.map(r => ({
+      company: r.company,
+      role: r.role,
+      score: r.score,
+      coverLetter: existsSync(join(COVER_LETTERS_DIR, `cl-${r.slug}-${new Date().toISOString().slice(0, 10)}.md`)),
+      pdf: true,
+    })), dryRun);
+    return;
+  }
+
+  // Step 1: Read pipeline (today's results by default, or full pipeline with --all)
+  console.log('── Step 1: Reading pipeline ──\n');
+  const pipeline = useAll ? readFullPipeline() : readTodaysScanResults(targetDate);
+  console.log(`  ${useAll ? 'Full pipeline' : `Scan results for ${targetDate}`}: ${pipeline.length}`);
+
+  // Step 2: Filter already-processed
+  const processed = getProcessedUrls();
+  const unprocessed = pipeline.filter(e => !processed.has(e.url));
+  console.log(`  Already processed: ${processed.size}`);
+  console.log(`  New/unprocessed: ${unprocessed.length}`);
+
+  // Step 3: Apply pre-LLM gates
+  console.log('\n── Step 2: Applying pre-LLM gates ──\n');
+  const qualifying = [];
+  const gateResults = { pass: 0, 'skip-title': 0, 'skip-location': 0 };
+
+  for (const entry of unprocessed) {
+    const titleResult = titleGate(entry.title);
+    if (titleResult !== 'pass') {
+      gateResults[titleResult]++;
+      continue;
+    }
+
+    const locResult = locationGate(entry.title, entry.company);
+    if (locResult !== 'pass') {
+      gateResults[locResult]++;
+      continue;
+    }
+
+    qualifying.push(entry);
+    gateResults.pass++;
+  }
+
+  console.log(`  Title filter blocked: ${gateResults['skip-title']}`);
+  console.log(`  Location filter blocked: ${gateResults['skip-location'] || 0}`);
+  console.log(`  Qualifying: ${qualifying.length}`);
+
+  // Cap at maxRoles
+  const batch = qualifying.slice(0, maxRoles);
+  if (qualifying.length > maxRoles) {
+    console.log(`  Capped to --max ${maxRoles} (${qualifying.length - maxRoles} deferred)`);
+  }
+
+  if (batch.length === 0) {
+    console.log('\n  No new qualifying roles to process.');
+    return;
+  }
+
+  // Step 4: Write batch-input.tsv
+  console.log('\n── Step 3: Writing batch input ──\n');
+  const count = writeBatchInput(batch);
+  console.log(`  Wrote ${count} entries to batch/batch-input.tsv`);
+
+  if (dryRun) {
+    console.log('\n── Qualifying roles (dry run) ──\n');
+    for (const e of batch) {
+      console.log(`  ${e.company} — ${e.title}`);
+      console.log(`    ${e.url}`);
+    }
+    return;
+  }
+
+  if (prepareOnly) {
+    console.log('\n  --prepare-only: batch-input.tsv ready. Run batch-runner.sh manually.');
+    return;
+  }
+
+  // Step 5: Run batch evaluation
+  console.log('\n── Step 4: Running batch evaluation ──\n');
+  const evalResults = runBatchEvaluation(dryRun);
+  console.log(`  Completed evaluations: ${evalResults.filter(r => r.status === 'completed').length}`);
+
+  // Step 6: Generate cover letters for high scorers
+  console.log('\n── Step 5: Generating cover letters (≥4.0) ─��\n');
+  const highReports = getHighScoringReports(4.0);
+  const clResults = [];
+
+  for (const r of highReports.slice(0, maxRoles)) {
+    const clPath = generateCoverLetter(r, dryRun);
+    clResults.push({ ...r, coverLetter: !!clPath });
+  }
+
+  if (highReports.length === 0) {
+    console.log('  No roles scored ≥4.0 — no cover letters generated.');
+  }
+
+  // Step 7: Merge tracker
+  console.log('\n── Step 6: Merging tracker ──\n');
+  try {
+    execSync('node merge-tracker.mjs', { cwd: PROJECT_DIR, stdio: 'inherit' });
+  } catch {
+    console.log('  ⚠️  Merge encountered issues (check output above)');
+  }
+
+  // Step 8: Send Telegram digest
+  console.log('\n── Step 7: Sending results digest ──\n');
+  const allResults = evalResults.map(r => {
+    const report = highReports.find(h => h.reportPath?.includes(r.reportNum));
+    return {
+      company: report?.company || 'Unknown',
+      role: report?.role || 'Unknown',
+      score: r.score,
+      status: r.status,
+      coverLetter: clResults.some(c => c.reportPath?.includes(r.reportNum) && c.coverLetter),
+      pdf: r.status === 'completed',
+    };
+  });
+
+  await sendResultsDigest(allResults, dryRun);
+
+  // Summary
+  console.log('\n═══════════════════════════════════════════');
+  console.log(' PIPELINE COMPLETE');
+  console.log('═══════════════════════════════════════════');
+  const completed = evalResults.filter(r => r.status === 'completed').length;
+  const high = highReports.length;
+  console.log(`  Evaluated: ${completed}`);
+  console.log(`  High-fit (≥4.0): ${high}`);
+  console.log(`  Cover letters: ${clResults.filter(c => c.coverLetter).length}`);
+  console.log(`  Artifacts: output/cover-letters/`);
+  console.log('');
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/browser-login.mjs
+++ b/browser-login.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+/**
+ * browser-login.mjs — Interactive browser session on CT 203
+ *
+ * Launches Playwright Chromium with remote debugging so you can
+ * log into sites (LinkedIn, etc.) from your MacBook via SSH tunnel.
+ *
+ * Usage:
+ *   1. On CT 203:  node browser-login.mjs [--port=9222] [--url=https://linkedin.com/login]
+ *   2. On MacBook:  ssh -L 9222:localhost:9222 root@10.1.30.50
+ *   3. Open Chrome on MacBook → navigate to http://localhost:9222
+ *      (or chrome://inspect → Configure → localhost:9222 → Inspect)
+ *   4. Log into LinkedIn in the remote browser
+ *   5. Press Enter in the terminal to save session and exit
+ *
+ * Saves browser state (cookies, localStorage) to auth/browser-state.json.
+ * apply-auto.mjs loads this state for authenticated sessions.
+ *
+ * Supports --profile=<name> for multiple saved sessions:
+ *   node browser-login.mjs --profile=linkedin
+ *   → saves to auth/linkedin-state.json
+ */
+
+import { chromium } from 'playwright';
+import { resolve, dirname } from 'path';
+import { mkdirSync, existsSync } from 'fs';
+import { createInterface } from 'readline';
+import { fileURLToPath } from 'url';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Parse args
+const args = process.argv.slice(2);
+const flags = {};
+const positional = [];
+
+for (const arg of args) {
+  if (arg.startsWith('--')) {
+    const [key, val] = arg.slice(2).split('=');
+    flags[key] = val ?? true;
+  } else {
+    positional.push(arg);
+  }
+}
+
+const port = parseInt(flags.port || '9222', 10);
+const profileName = flags.profile || 'browser';
+const startUrl = flags.url || positional[0] || 'https://www.linkedin.com/login';
+const authDir = resolve(__dirname, 'auth');
+const statePath = resolve(authDir, `${profileName}-state.json`);
+const userDataDir = resolve(authDir, `${profileName}-profile`);
+
+// Ensure auth directory exists
+mkdirSync(authDir, { recursive: true });
+
+async function main() {
+  console.log('🌐 browser-login.mjs — Interactive browser session');
+  console.log('');
+  console.log(`  Profile:    ${profileName}`);
+  console.log(`  State file: ${statePath}`);
+  console.log(`  Debug port: ${port}`);
+  console.log(`  Start URL:  ${startUrl}`);
+  console.log('');
+
+  // Launch with persistent context (preserves cookies across sessions)
+  // AND remote debugging so MacBook can connect
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    headless: true,
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      `--remote-debugging-port=${port}`,
+      '--remote-debugging-address=0.0.0.0',
+    ],
+    viewport: { width: 1280, height: 900 },
+    userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    ignoreHTTPSErrors: true,
+  });
+
+  const page = context.pages()[0] || await context.newPage();
+  await page.goto(startUrl, { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+  console.log('✅ Browser launched with remote debugging.');
+  console.log('');
+  console.log('📋 Connect from your MacBook:');
+  console.log('');
+  console.log(`   1. SSH tunnel:  ssh -L ${port}:localhost:${port} root@10.1.30.50`);
+  console.log(`   2. Open in Chrome:  http://localhost:${port}`);
+  console.log('      → Click the page URL to interact with the remote browser');
+  console.log('');
+  console.log('   Log into LinkedIn (or any site you need), then come back here.');
+  console.log('');
+
+  // Wait for user to press Enter
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  await new Promise((resolve) => {
+    rl.question('⏎  Press Enter when done to save session and exit... ', () => {
+      rl.close();
+      resolve();
+    });
+  });
+
+  // Save storage state (cookies + localStorage)
+  await context.storageState({ path: statePath });
+  console.log('');
+  console.log(`💾 Session saved to ${statePath}`);
+
+  // Show what cookies we captured
+  const cookies = await context.cookies();
+  const linkedinCookies = cookies.filter(c => c.domain.includes('linkedin'));
+  console.log(`   ${cookies.length} total cookies, ${linkedinCookies.length} LinkedIn cookies`);
+
+  if (linkedinCookies.length > 0) {
+    console.log('   ✅ LinkedIn session captured — apply-auto.mjs can now use authenticated LinkedIn');
+  } else {
+    console.log('   ⚠️ No LinkedIn cookies found. Did you log in?');
+  }
+
+  await context.close();
+  console.log('');
+  console.log('Done. The persistent browser profile is at:');
+  console.log(`   ${userDataDir}`);
+  console.log('');
+  console.log('To re-use this session in apply-auto.mjs:');
+  console.log(`   node apply-auto.mjs <url> <pdf> --auth=${statePath}`);
+}
+
+main().catch(err => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/career-ops-listener.service
+++ b/career-ops-listener.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=career-ops Telegram reply listener
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/career-ops
+ExecStart=/usr/bin/node telegram-listener.mjs
+Restart=always
+RestartSec=10
+EnvironmentFile=/opt/career-ops/.env
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=career-ops-listener
+
+[Install]
+WantedBy=multi-user.target

--- a/daily-pipeline.sh
+++ b/daily-pipeline.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# daily-pipeline.sh — Daily career-ops pipeline chain
+#
+# Runs on CT 203 via cron: 07:00 MDT daily
+#   0 7 * * * /opt/career-ops/daily-pipeline.sh >> /var/log/career-ops-daily.log 2>&1
+#
+# Chain: API scan → BIC scan → notify → followup → interview-prep-check
+# Each step runs even if the previous fails (||true guards).
+
+set -u
+cd /opt/career-ops || exit 1
+
+DATE=$(date +%Y-%m-%d)
+echo "━━━ career-ops daily pipeline — $DATE ━━━"
+
+# Step 1: Scan portals via API (Greenhouse/Ashby/Lever)
+echo "→ [1/5] Scanning portal APIs..."
+node scan.mjs 2>&1 || true
+
+# Step 2: Scan Built In Colorado via Playwright (Denver-specific)
+echo "→ [2/5] Scanning Built In Colorado..."
+node scan-builtin.mjs 2>&1 || true
+
+# Step 3: Send Telegram digest of new finds
+echo "→ [3/5] Sending Telegram digest..."
+node notify-telegram.mjs 2>&1 || true
+
+# Step 4: Check for applications needing follow-up (5+ business days)
+echo "→ [4/5] Checking follow-ups..."
+node followup-check.mjs 2>&1 || true
+
+# Step 5: Generate interview prep for any new Interview/Responded entries
+echo "→ [5/5] Checking interview prep..."
+node generate-interview-prep.mjs --check 2>&1 || true
+
+echo "━━━ pipeline complete — $DATE ━━━"

--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -88,11 +88,16 @@ function roleMatch(a, b) {
 
   if (wordsA.length === 0 || wordsB.length === 0) return false;
 
-  const overlap = wordsA.filter(w => wordsB.some(wb => wb === w));
-  const smaller = Math.min(wordsA.length, wordsB.length);
-  const ratio = overlap.length / smaller;
-
-  return overlap.length >= 2 && ratio >= 0.6;
+  const setB = new Set(wordsB);
+  const overlap = wordsA.filter(w => setB.has(w)).length;
+  if (overlap === 0) return false;
+  // Jaccard similarity (overlap/union), matching merge-tracker.mjs roleFuzzyMatch. The old
+  // min-based ratio (overlap/smaller >= 0.6) false-matched same-company, different-domain
+  // roles — e.g. Abridge "Application Security Engineer" vs "Infrastructure Security Engineer"
+  // (overlap=2, smaller=3 → 0.67 >= 0.6) and silently dropped one on every `npm run dedup` /
+  // test-all run. Jaccard: overlap=2, union=4 → 0.5 < 0.75 → correctly kept distinct.
+  const union = new Set([...wordsA, ...wordsB]).size;
+  return overlap >= 2 && overlap / union >= 0.75;
 }
 
 function parseScore(s) {

--- a/followup-check.mjs
+++ b/followup-check.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+
+/**
+ * followup-check.mjs — Check for applications needing follow-up
+ *
+ * Scans data/applications.md for "Applied" rows older than N business days
+ * without a status change. Sends Telegram notification for each.
+ *
+ * Usage:
+ *   node followup-check.mjs              # check and notify (default: 5 business days)
+ *   node followup-check.mjs --days 7     # custom threshold
+ *   node followup-check.mjs --dry-run    # show what would notify, don't send
+ *
+ * Designed to run daily via cron on CT 203 (after the scanner).
+ * Wire into telegram-listener.mjs for "follow up" / "status" replies.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join, resolve } from 'path';
+import { loadTelegramConfig, sendMessage } from './lib/telegram.mjs';
+
+const PROJECT_DIR = resolve(import.meta.dirname || '.');
+const TRACKER_FILE = join(PROJECT_DIR, 'data/applications.md');
+const FOLLOWUP_FILE = join(PROJECT_DIR, 'data/follow-ups.md');
+
+// ── Parse args ────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const daysIdx = args.indexOf('--days');
+const THRESHOLD_DAYS = daysIdx !== -1 ? parseInt(args[daysIdx + 1]) : 5;
+
+// ── Business day calculator ───────────────────────────────────────────
+
+function businessDaysBetween(startDate, endDate) {
+  let count = 0;
+  const cur = new Date(startDate);
+  const end = new Date(endDate);
+  while (cur < end) {
+    cur.setDate(cur.getDate() + 1);
+    const day = cur.getDay();
+    if (day !== 0 && day !== 6) count++;
+  }
+  return count;
+}
+
+// ── Tracker parser ────────────────────────────────────────────────────
+
+function getAppliedRows() {
+  if (!existsSync(TRACKER_FILE)) return [];
+
+  const content = readFileSync(TRACKER_FILE, 'utf-8');
+  const rows = [];
+
+  for (const line of content.split('\n')) {
+    if (!line.startsWith('|') || line.includes('---') || line.includes('Date')) continue;
+
+    const cells = line.split('|').map(c => c.trim()).filter(Boolean);
+    if (cells.length < 9) continue;
+
+    const [num, date, company, role, score, status, , , notes] = cells;
+    if (status !== 'Applied') continue;
+
+    // Extract application date from notes (e.g., "Applied 2026-05-25 via...")
+    const appDateMatch = notes?.match(/Applied (\d{4}-\d{2}-\d{2})/);
+    const appliedDate = appDateMatch ? appDateMatch[1] : date;
+
+    rows.push({ num, date: appliedDate, company, role, score, notes });
+  }
+
+  return rows;
+}
+
+// ── Follow-up history ─────────────────────────────────────────────────
+
+function getFollowUpHistory() {
+  if (!existsSync(FOLLOWUP_FILE)) return {};
+  const content = readFileSync(FOLLOWUP_FILE, 'utf-8');
+  const history = {};
+
+  for (const line of content.split('\n')) {
+    const m = line.match(/^\| (\d+) \| (.+?) \| (.+?) \| (.+?) \| (.+?) \|$/);
+    if (m) {
+      const [, num, date, company, , action] = m;
+      if (!history[num]) history[num] = [];
+      history[num].push({ date, company, action });
+    }
+  }
+  return history;
+}
+
+function recordFollowUp(num, company, role, action) {
+  const today = new Date().toISOString().slice(0, 10);
+  mkdirSync(join(PROJECT_DIR, 'data'), { recursive: true });
+
+  let content = '';
+  if (existsSync(FOLLOWUP_FILE)) {
+    content = readFileSync(FOLLOWUP_FILE, 'utf-8');
+  } else {
+    content = `# Follow-Up History\n\n| # | Date | Company | Role | Action |\n|---|------|---------|------|--------|\n`;
+  }
+
+  content += `| ${num} | ${today} | ${company} | ${role} | ${action} |\n`;
+  writeFileSync(FOLLOWUP_FILE, content);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+async function main() {
+  const today = new Date().toISOString().slice(0, 10);
+  const applied = getAppliedRows();
+  const history = getFollowUpHistory();
+
+  if (applied.length === 0) {
+    console.log('No "Applied" rows in tracker.');
+    return;
+  }
+
+  console.log(`📋 Checking ${applied.length} applied roles (threshold: ${THRESHOLD_DAYS} business days)\n`);
+
+  const needsFollowUp = [];
+
+  for (const row of applied) {
+    const daysSince = businessDaysBetween(row.date, today);
+    const prevFollowUps = history[row.num] || [];
+    const lastFollowUp = prevFollowUps[prevFollowUps.length - 1];
+
+    // Check if we've already notified recently (within 3 business days of last notification)
+    if (lastFollowUp) {
+      const daysSinceLastFollowUp = businessDaysBetween(lastFollowUp.date, today);
+      if (daysSinceLastFollowUp < 3) {
+        console.log(`  ⏭️ #${row.num} ${row.company} — followed up ${daysSinceLastFollowUp}d ago, skipping`);
+        continue;
+      }
+    }
+
+    if (daysSince >= THRESHOLD_DAYS) {
+      needsFollowUp.push({ ...row, daysSince, followUpCount: prevFollowUps.length });
+      console.log(`  ⏰ #${row.num} ${row.company} — ${row.role} (${daysSince} business days, ${prevFollowUps.length} prior follow-ups)`);
+    } else {
+      console.log(`  ✅ #${row.num} ${row.company} — ${daysSince}/${THRESHOLD_DAYS} days (not yet)`);
+    }
+  }
+
+  if (needsFollowUp.length === 0) {
+    console.log('\n✅ No applications need follow-up yet.');
+    return;
+  }
+
+  // Build Telegram message
+  let msg = `<b>📬 Follow-up reminder</b>\n━━━━━━━━━━━━━━━━━━━━━━\n\n`;
+  msg += `${needsFollowUp.length} application${needsFollowUp.length !== 1 ? 's' : ''} with no response:\n\n`;
+
+  for (const row of needsFollowUp) {
+    msg += `<b>#${row.num} ${row.company}</b> — ${row.role}\n`;
+    msg += `  Applied ${row.daysSince} business days ago`;
+    if (row.followUpCount > 0) msg += ` (${row.followUpCount} prior follow-up${row.followUpCount !== 1 ? 's' : ''})`;
+    msg += '\n';
+  }
+
+  msg += `\n<i>Reply "follow up #N" to send a follow-up, or "wait #N" to snooze.</i>`;
+
+  if (dryRun) {
+    console.log('\n── DRY RUN ──\n');
+    console.log(msg);
+    return;
+  }
+
+  // Send notification
+  const config = loadTelegramConfig(join(PROJECT_DIR, '.env'));
+  if (!config.token || !config.chatId) {
+    console.log('No Telegram credentials — printing instead:');
+    console.log(msg);
+    return;
+  }
+
+  try {
+    await sendMessage(config, config.chatId, msg);
+    console.log(`\n✅ Follow-up reminder sent to Telegram (${needsFollowUp.length} roles)`);
+
+    // Record that we notified
+    for (const row of needsFollowUp) {
+      recordFollowUp(row.num, row.company, row.role, 'reminder-sent');
+    }
+  } catch (err) {
+    console.error(`❌ Telegram send failed: ${err.message}`);
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/generate-interview-prep.mjs
+++ b/generate-interview-prep.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+
+/**
+ * generate-interview-prep.mjs — Auto-generate interview prep docs
+ *
+ * Triggered when an application status changes to "Responded" or "Interview".
+ * Reads the evaluation report, invokes Claude headless to run the interview-prep
+ * mode, and notifies via Telegram.
+ *
+ * Usage:
+ *   node generate-interview-prep.mjs --num 8               # generate prep for application #8
+ *   node generate-interview-prep.mjs --company WorkOS      # match by company name
+ *   node generate-interview-prep.mjs --check               # scan tracker for new Interview/Responded entries without prep
+ *   node generate-interview-prep.mjs --dry-run             # show what would generate, don't execute
+ *
+ * Designed to run:
+ *   - Manually: after updating status to "Interview" or "Responded"
+ *   - Via telegram-listener: when "interview #N" command is received
+ *   - Via daily cron: with --check flag to catch manual status edits
+ *
+ * Config (.env):
+ *   TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID (optional — skips notify if missing)
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from 'fs';
+import { join, resolve } from 'path';
+import { execFileSync } from 'child_process';
+import { loadTelegramConfig, sendMessage } from './lib/telegram.mjs';
+
+const PROJECT_DIR = resolve(import.meta.dirname || '.');
+const TRACKER_FILE = join(PROJECT_DIR, 'data/applications.md');
+const REPORTS_DIR = join(PROJECT_DIR, 'reports');
+const PREP_DIR = join(PROJECT_DIR, 'interview-prep');
+const CV_FILE = join(PROJECT_DIR, 'cv.md');
+const PROFILE_FILE = join(PROJECT_DIR, 'config/profile.yml');
+const STORY_BANK = join(PROJECT_DIR, 'interview-prep/story-bank.md');
+const INTERVIEW_MODE = join(PROJECT_DIR, 'modes/interview-prep.md');
+
+// ── Parse args ───────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const CHECK_MODE = args.includes('--check');
+
+function getArgValue(flag) {
+  const idx = args.indexOf(flag);
+  return idx !== -1 && args[idx + 1] ? args[idx + 1] : null;
+}
+
+const targetNum = getArgValue('--num') ? parseInt(getArgValue('--num')) : null;
+const targetCompany = getArgValue('--company');
+
+// ── Tracker parser ───────────────────────────────────────────────────
+
+function parseTrackerRows() {
+  if (!existsSync(TRACKER_FILE)) return [];
+
+  const content = readFileSync(TRACKER_FILE, 'utf-8');
+  const rows = [];
+
+  for (const line of content.split('\n')) {
+    if (!line.startsWith('|') || line.includes('---') || line.includes('Date')) continue;
+
+    const cells = line.split('|').map(c => c.trim()).filter(Boolean);
+    if (cells.length < 9) continue;
+
+    const [num, date, company, role, score, status, pdf, report, notes] = cells;
+    rows.push({
+      num: parseInt(num),
+      date,
+      company,
+      role,
+      score,
+      status,
+      report,
+      notes,
+      raw: line,
+    });
+  }
+
+  return rows;
+}
+
+// ── Check which rows need prep ───────────────────────────────────────
+
+function getExistingPrepFiles() {
+  if (!existsSync(PREP_DIR)) return [];
+  return readdirSync(PREP_DIR).filter(f => f.endsWith('.md') && f !== 'story-bank.md');
+}
+
+function slugify(s) {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+}
+
+function hasPrepFile(company, role) {
+  const existing = getExistingPrepFiles();
+  const companySlug = slugify(company);
+  // Check if any existing prep file matches this company
+  return existing.some(f => f.includes(companySlug));
+}
+
+function getReportPath(reportCell) {
+  // reportCell looks like: [008](reports/008-workos-detection-response-2026-05-25.md)
+  const match = reportCell.match(/\(([^)]+)\)/);
+  if (!match) return null;
+  const relPath = match[1];
+  const fullPath = join(PROJECT_DIR, relPath);
+  return existsSync(fullPath) ? fullPath : null;
+}
+
+// ── Interview prep generation ────────────────────────────────────────
+
+function buildPrompt(row, reportContent) {
+  const cv = existsSync(CV_FILE) ? readFileSync(CV_FILE, 'utf-8') : '';
+  const storyBank = existsSync(STORY_BANK) ? readFileSync(STORY_BANK, 'utf-8') : '';
+  const mode = existsSync(INTERVIEW_MODE) ? readFileSync(INTERVIEW_MODE, 'utf-8') : '';
+
+  const outputFile = `interview-prep/${slugify(row.company)}-${slugify(row.role)}.md`;
+
+  return `You are generating an interview prep document for a specific company and role.
+
+COMPANY: ${row.company}
+ROLE: ${row.role}
+SCORE: ${row.score}
+DATE APPLIED: ${row.date}
+
+--- EVALUATION REPORT ---
+${reportContent}
+
+--- CANDIDATE CV ---
+${cv.slice(0, 4000)}
+
+--- STORY BANK ---
+${storyBank.slice(0, 3000)}
+
+--- INTERVIEW PREP MODE INSTRUCTIONS ---
+${mode}
+
+--- INSTRUCTIONS ---
+Generate a complete interview prep document following the mode instructions above.
+Focus on actionable, specific preparation — not generic advice.
+The candidate is Patrick Moore, Denver-based, security + AI + healthcare background.
+
+Key things to include:
+1. Company research summary (what they do, recent news, tech stack)
+2. Likely interview process and rounds
+3. Top 10 questions they'll probably ask (with suggested answers from CV/report)
+4. Story bank mapping (which STAR stories from the story bank fit which questions)
+5. Technical prep checklist (based on JD requirements)
+6. Questions Patrick should ask them
+7. Red flags / things to address proactively (gaps noted in the evaluation)
+
+Output the full markdown document. Start with:
+# Interview Intel: ${row.company} — ${row.role}
+
+Save nothing — just output the complete markdown.`;
+}
+
+async function generatePrep(row) {
+  const reportPath = getReportPath(row.report);
+  if (!reportPath) {
+    console.log(`  ⚠️  No report found for #${row.num} ${row.company}. Skipping.`);
+    return null;
+  }
+
+  const reportContent = readFileSync(reportPath, 'utf-8');
+  const prompt = buildPrompt(row, reportContent);
+  const outputSlug = `${slugify(row.company)}-${slugify(row.role)}`;
+  const outputPath = join(PREP_DIR, `${outputSlug}.md`);
+
+  console.log(`  📝 Generating interview prep for ${row.company} — ${row.role}...`);
+
+  if (DRY_RUN) {
+    console.log(`  [DRY RUN] Would generate: ${outputPath}`);
+    console.log(`  [DRY RUN] Prompt length: ${prompt.length} chars`);
+    return outputPath;
+  }
+
+  try {
+    // Use claude -p for headless generation
+    const result = execFileSync('claude', ['-p', prompt], {
+      cwd: PROJECT_DIR,
+      encoding: 'utf-8',
+      timeout: 120_000, // 2 min max
+      maxBuffer: 1024 * 1024, // 1MB output buffer
+    });
+
+    // Extract just the markdown content (strip any preamble)
+    let content = result;
+    const mdStart = content.indexOf('# Interview Intel:');
+    if (mdStart > 0) {
+      content = content.slice(mdStart);
+    }
+
+    // Add metadata header if not present
+    if (!content.includes('**Researched:**')) {
+      const today = new Date().toISOString().slice(0, 10);
+      const header = `# Interview Intel: ${row.company} — ${row.role}\n\n**Report:** ${row.report}\n**Researched:** ${today}\n**Auto-generated:** Yes (generate-interview-prep.mjs)\n\n---\n\n`;
+      if (content.startsWith('# Interview Intel:')) {
+        // Replace the first line with our enriched header
+        content = header + content.split('\n').slice(1).join('\n');
+      } else {
+        content = header + content;
+      }
+    }
+
+    mkdirSync(PREP_DIR, { recursive: true });
+    writeFileSync(outputPath, content);
+    console.log(`  ✅ Saved: ${outputPath}`);
+    return outputPath;
+  } catch (err) {
+    console.error(`  ❌ Generation failed: ${err.message?.slice(0, 200)}`);
+    return null;
+  }
+}
+
+// ── Telegram notification ────────────────────────────────────────────
+
+async function notifyTelegram(row, prepPath) {
+  const config = loadTelegramConfig(join(PROJECT_DIR, '.env'));
+  if (!config.token || !config.chatId) return;
+
+  let msg = `<b>📋 Interview prep ready</b>\n━━━━━━━━━━━━━━━━━━━━━━\n\n`;
+  msg += `<b>#${row.num} ${row.company}</b> — ${row.role}\n`;
+  msg += `Score: ${row.score} | Status: ${row.status}\n\n`;
+  msg += `<i>Prep doc generated. Key areas:\n`;
+  msg += `• Company research + recent signals\n`;
+  msg += `• Likely questions + suggested answers\n`;
+  msg += `• Story bank mapping\n`;
+  msg += `• Technical prep checklist</i>\n\n`;
+  msg += `Review on MacBook: <code>interview-prep/${prepPath ? prepPath.split('/').pop() : '?'}</code>`;
+
+  try {
+    await sendMessage(config, config.chatId, msg);
+    console.log(`  📱 Telegram notification sent`);
+  } catch (err) {
+    console.error(`  ⚠️  Telegram notify failed: ${err.message}`);
+  }
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  const rows = parseTrackerRows();
+
+  if (rows.length === 0) {
+    console.log('No applications in tracker.');
+    return;
+  }
+
+  let targets = [];
+
+  if (targetNum) {
+    // Generate prep for specific application number
+    const row = rows.find(r => r.num === targetNum);
+    if (!row) {
+      console.error(`❌ No application #${targetNum} in tracker.`);
+      process.exit(1);
+    }
+    targets = [row];
+  } else if (targetCompany) {
+    // Match by company name (case-insensitive)
+    targets = rows.filter(r =>
+      r.company.toLowerCase().includes(targetCompany.toLowerCase()) &&
+      ['Responded', 'Interview', 'Applied'].includes(r.status)
+    );
+    if (targets.length === 0) {
+      console.error(`❌ No matching applications for "${targetCompany}".`);
+      process.exit(1);
+    }
+  } else if (CHECK_MODE) {
+    // Find all "Responded" or "Interview" rows without existing prep
+    targets = rows.filter(r => {
+      if (!['Responded', 'Interview'].includes(r.status)) return false;
+      return !hasPrepFile(r.company, r.role);
+    });
+
+    if (targets.length === 0) {
+      console.log('✅ All Interview/Responded applications already have prep docs.');
+      return;
+    }
+  } else {
+    console.error('Usage: node generate-interview-prep.mjs --num N | --company NAME | --check [--dry-run]');
+    process.exit(1);
+  }
+
+  console.log(`\n📋 Generating interview prep for ${targets.length} application${targets.length !== 1 ? 's' : ''}\n`);
+
+  for (const row of targets) {
+    console.log(`━━━ #${row.num} ${row.company} — ${row.role} (${row.status}) ━━━`);
+
+    // Skip if prep already exists (unless explicitly targeting by --num)
+    if (!targetNum && hasPrepFile(row.company, row.role)) {
+      console.log(`  ⏭️  Prep already exists, skipping.`);
+      continue;
+    }
+
+    const prepPath = await generatePrep(row);
+
+    if (prepPath && !DRY_RUN) {
+      await notifyTelegram(row, prepPath);
+    }
+
+    console.log('');
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/interview-prep/abridge-2026-05-17.md
+++ b/interview-prep/abridge-2026-05-17.md
@@ -1,0 +1,271 @@
+# Interview Prep — Abridge (founding security team, both roles)
+
+**Compiled:** 2026-05-17 from reports [002](../reports/002-abridge-appsec-2026-05-17.md) + [003](../reports/003-abridge-infrasec-2026-05-17.md)
+
+**Applying to:**
+- [Senior/Staff Application Security Engineer](https://jobs.ashbyhq.com/abridge/57967034-08cb-4cfe-8243-4e9564acc32e) — score 4.7/5
+- [Senior/Staff Infrastructure Security Engineer](https://jobs.ashbyhq.com/abridge/b55901ff-e42e-44bc-b2ec-c2c40410b6e7) — score 4.6/5
+
+Both: **$214.2K–$252K base + equity** · **Fully remote** · Founding-team Security hire · Pittsburgh/SF/NYC offices for those who want hubs.
+
+---
+
+## Patrick's elevator pitch (1 paragraph — tailor to whichever role first surfaces in conversation)
+
+> "I'm a security engineer who ships AI agents in regulated healthcare production. Last year I joined a 3-person platform/security team at an AI-native oncology EMR being built ground-up — I drove the security stack maturation (Defender, Taegis, Palo Alto), authored the AI acceptable usage policy, designed the agent identity / service-account model, and shipped three Claude agents into HIPAA/HITRUST-track production. Built an Azure-hosted MCP proxy server specifically to clear Anthropic-side 429 rate limits on one of the agents — it doubles as a HIPAA/HITRUST audit boundary for Figma data. What I want next is a founding-team security role at a company that's already further along the healthcare-AI curve than where I am today, where I can keep building the secure-by-default substrate. That's what Abridge described in the JD."
+
+If asked which role you prefer: be honest — *"both. The AppSec role maps more directly to the agent-governance and threat-modeling work I'm doing today. The InfraSec role maps more directly to the IaC and security-platform work I'm doing today. I'd take either — they're complementary, and you're probably going to fill both with one person and one tighter scope."*
+
+---
+
+## Abridge — what to know before any call
+
+| Fact | Source |
+|---|---|
+| Founded **2018**. Mission: "powering deeper understanding in healthcare." | JD |
+| AI-powered platform purpose-built for **medical conversations** → real-time clinical documentation with **deep EMR integrations**. | JD |
+| **Linked Evidence**: maps AI-generated summaries to ground truth — auditability is the moat. | JD |
+| Setting industry standards for **responsible deployment of AI across health systems** — they self-position as the standard-setters, not the disruptors. | JD |
+| Offices: **Mission District SF · SoHo NYC · East Liberty Pittsburgh**. Remote-first per the role listing (`isRemote: true`). | JD + Ashby API |
+| Growing team: **practicing MDs, AI scientists, PhDs, technologists, engineers**. | JD |
+| **Founding-team Security build-out underway** — both AppSec and InfraSec roles open simultaneously, framed as "one of the first engineers on the Abridge Security team." | JD (both postings) |
+| **Pre-call to-do:** glance at their engineering blog, recent press, and any conference talks. Bonus: who's the head of security (if named on LinkedIn) — what's their background? |
+
+---
+
+## Likely interview rounds + per-round prep
+
+A founding-security-team hire at a healthcare-AI scale-up typically runs 4–6 rounds. Best-guess sequence:
+
+### Round 1 — Recruiter screen (~30 min)
+**Likely questions + your answers:**
+
+- *"Walk me through your background."* → Lead with the elevator pitch above. Lowercase what they care about (years), uppercase what differentiates (3 Claude agents in HIPAA prod, MCP-proxy story, AI usage policy authorship).
+- *"What attracted you to Abridge specifically?"* → "I'm already shipping AI security in regulated healthcare. Abridge is further along the healthcare-AI curve than where I am, the founding-security-team posture is exactly the shape of work I do today, and the Linked Evidence framing tells me you take auditability seriously — which is what I've been authoring policy for."
+- *"Comp expectations?"* → Anchor: **$245K base + equity in the upper half of the band.** Your minimum is $160K; never quote below your target. "I'm targeting upper $200s on base given the AI-in-healthcare specialization, with equity in the upper half of the band."
+- *"Are you flexible on location?"* → Confirm fully remote. Mention DTC current commute. **DO NOT** open to relocation — your location policy is hard.
+- *"Why are you leaving Viecure?"* → "I've shipped what I came to ship — security stack maturation, the three agents, the Claude Code platform, the AI policy. The next 12 months at Viecure is more of the same. Abridge is the next layer."
+- *"Timeline?"* → "I'm actively interviewing, so let's set expectations early. I'd want to wrap your loop within ~3 weeks if it moves."
+
+### Round 2 — Hiring manager (~45–60 min)
+
+Likely Abridge's head of security or a security-engineering lead. They'll probe the depth of the agent-governance + cloud-security work.
+
+**Likely questions:**
+
+- *"Walk me through the most interesting security thing you've shipped in the last year."* → Lead with **the Azure-hosted MCP proxy for Figma 429s** (Story #1 below). It's the cleanest engineering proof point and combines AppSec/InfraSec/AI-security in one narrative.
+- *"How do you think about AI-agent security in production?"* → Quote your design philosophy verbatim: *"I try to make everyone better at their job by making agents to empower them in automated ways so they don't have to interact with AI — it interacts with them."* Then tie to the agent identity / service-account model + the security review process.
+- *"How would you approach building out the AppSec [or InfraSec] program at Abridge in your first 90 days?"* → 30-60-90 plan (sketch below).
+- *"What's your biggest gap for this role?"* → Be specific and honest. For AppSec: "Pen-testing engagements aren't my lead skill — I operate the vuln-management toolchain, but leading pen-test ops is a ramp." For InfraSec: "GCP at depth — I'm AWS+Azure deep, GCP would be 4-6 weeks of ramp on muscle memory."
+
+### Round 3 — Tech panel / system design (~60–90 min)
+
+Expect a question shape like: *"You're brought in to design the security review process for a new Claude-powered agent that's going to ship into our clinical-summary pipeline. Walk us through how you'd think about it end-to-end."*
+
+**Your move:**
+1. **Threat model first.** Who's the agent talking to (Anthropic API? internal Llama? both?), where does its data come from (patient transcripts? PHI?), what can it write to (Jira? EMR? Slack?), who can invoke it (engineers? clinicians? auto-trigger?).
+2. **Identity boundary.** Service account vs OAuth-on-behalf-of-user — your agent identity model at Viecure gives you a story here.
+3. **Data path.** What sees what? Where do the audit logs live? If Anthropic-side rate-limits hit, what's the fallback? (This is where your MCP-proxy story plugs in naturally.)
+4. **Adoption posture.** Gate or floor? Recommend **floor** (opt-in, raises the baseline) and tell them why — bring-skeptics-along story from PR Review agent.
+5. **HIPAA/HITRUST audit boundary.** Show them you think about the audit story BEFORE the security story.
+
+### Round 4 — Cross-functional partner round (~45 min)
+
+A Product or Engineering peer will probe how you partner with non-security folks. They want to know you're not a "no" gate.
+
+**Likely questions:**
+- *"How do you handle an engineering team that wants to ship something you'd flag as risky?"* → Don't say no — say "let's design the smaller version that ships next week." Reference the opt-in PR Review agent adoption posture.
+- *"How do you communicate security trade-offs to product?"* → "I frame it as throughput, not risk. 'If we ship X without Y, the on-call burden is Z' beats 'don't ship X.'"
+
+### Round 5 — Bar raiser / leadership (~45 min)
+
+Often an exec or senior IC outside the immediate team. Tests cultural fit and ceiling.
+
+**Likely questions:**
+- *"What does great look like in this role in 18 months?"* → "Three agents in production with the supporting security platform that engineering teams actually use, an AI security review process that ships agents in days not weeks, and an audit-ready posture across the existing Linked Evidence pipeline."
+- *"Why Abridge over Anthropic or OpenAI?"* → "Anthropic and OpenAI are model providers. Abridge ships product into the daily lives of clinicians. The work I want to do is at the application layer in healthcare, not the model layer at a research lab. The healthcare-AI-in-prod proof points I have are more relevant to you than they are to them."
+
+### Round 6 — References / final
+
+Standard. Make sure your references (Viecure Director of IT and Security; an Envision peer) know to expect a call.
+
+---
+
+## Story bank (use these as STAR+R)
+
+### Story 1 — Azure-hosted MCP proxy for Figma (clear 429s + audit boundary)
+**Best for:** "Most interesting security thing you've built" · "Describe a system you designed end-to-end" · "Solve an integration problem under regulatory constraints"
+
+**S — Situation:** Viecure's Product Review agent (combined Figma design review + Jira triage) was hitting Anthropic-side 429 rate limits when pulling Figma data directly. Disrupting the Managed Agent flow.
+
+**T — Task:** Unblock the agent without losing the Figma data shape. Bonus if I could gain a security/audit boundary in the process.
+
+**A — Action:** Designed and deployed a proxy MCP server inside Viecure's Azure tenant. Fronts Figma, feeds the agent only what it needs. Made a deliberate, documented contrast with the Atlassian/Jira side, which doesn't need a proxy because Atlassian's MCP support is mature.
+
+**R — Result:** 429s cleared, agent restored to flow. Bonus outcome: the proxy doubles as a HIPAA/HITRUST audit boundary for Figma data in a regulated tenant.
+
+**Reflection:** When an integration's data path causes a problem, the right fix is often the proxy you'd want for compliance reasons anyway. The cleanest line: *"Figma needed an MCP proxy to clear 429s, Atlassian was native — same agent, two architectures, both shipped."*
+
+---
+
+### Story 2 — Security review process for new agent deployments
+**Best for:** "How do you think about AI agent security?" · "Tell me about a governance system you built" · "Threat modeling at scale"
+
+**S:** New agent deployments at Viecure needed a governance layer in a HIPAA/HITRUST-track environment. We had no formal review process.
+
+**T:** Author the security review process and the agent identity / service-account model. Make it work on a 3-person team without becoming a bottleneck.
+
+**A:** Designed the security review process; designed the agent identity / service-account model that every Claude agent in prod ships through. Made the review process light enough that we could ship in days, not weeks.
+
+**R:** All three agents in production went through this review. No governance escapes in stg-as-prod. Audit-ready posture.
+
+**Reflection:** AI governance is most useful when it ships *with* the first agent, not retro-fitted. The process is the product — it's the artifact you hand to a HITRUST auditor, not a doc you write after the fact.
+
+---
+
+### Story 3 — Drove security stack maturation in a messy Azure environment
+**Best for:** "Founding-team posture" · "Inherited mess, what did you do" · "Pick paved-road tooling"
+
+**S:** Joined Viecure as the security-engineering hire on a 3-person platform/security team. Inherited a previously-messy Azure environment with weak coverage across vuln scanning, EDR, SIEM, IAM/governance.
+
+**T:** Mature the security stack to SOC 2 / HITRUST track shape.
+
+**A:** Selected and deployed Microsoft Defender suite (Cloud, Endpoint, Identity), Taegis XDR, and Palo Alto. Picked tools that integrate with the regulatory work already in flight — not best-of-breed silos.
+
+**R:** Stack operates end-to-end across vuln scanning, EDR, SIEM, IAM/governance. Matured to SOC 2 / HITRUST-track shape. HIPAA/IAM/ransomware/AI policy documentation authored alongside.
+
+**Reflection:** Tool sprawl is the second-biggest enemy after coverage gaps. Pick paved-road tooling that integrates with the regulatory work already in flight — coverage compounds, sprawl doesn't.
+
+---
+
+### Story 4 — PR Review agent + bringing skeptical devs along
+**Best for:** "Tell me about adoption" · "Cross-functional influence" · "How do you handle pushback"
+
+**S:** Initial PR Review agent (Anthropic Managed Agent on Sonnet 4.6, ~100 PRs/day in ADO) was back-end-leaning in its framing. Front-end devs found the feedback less useful.
+
+**T:** Keep opt-in adoption rising without making the agent mandatory. Iterate the prompt, not the policy.
+
+**A:** Sat with front-end devs to understand the calibration mismatch. Iterated the system prompt and review structure based on their input. Kept the opt-in posture intact throughout.
+
+**R:** "Even skeptics liked the info" became the qualitative signal. Adoption held; the agent is still live in production at ~100 PRs/day, cost ~$100/day on Sonnet 4.6.
+
+**Reflection:** The agent is the easy part; bringing the dev org along is the work. Opt-in adoption is a signal you can read — if the right surface is opting out, the prompt (not the policy) needs to change.
+
+---
+
+### Story 5 — App Insights closed-loop ops agent
+**Best for:** "Take a project from exploration to production" · "Describe a non-obvious AI architecture" · "Multi-step HITL"
+
+**S:** Dev + stg App Insights data at Viecure was rich but nobody read it. Perf and error issues caught reactively after incidents.
+
+**T:** Build an agent that turns telemetry into actionable engineering work end-to-end, not just summarized reports.
+
+**A:** Daily 7am run against dev + stg App Insights → structured Slack post (top APIs, slowest APIs, error roll-ups, 7d + 30d baselines). Slack readers can request a Jira ticket from the post; the agent writes the ticket with App Insights repro context, picks the assignee, tags it, and confirms back in Slack.
+
+**R:** Week-1 wins: engineers identifying real performance improvements off the daily reports. The 7-day/30-day baseline became the first thing teams reach for in performance triage.
+
+**Reflection:** Most candidates pitch "Claude reads logs and summarizes." This is multi-step HITL: agent → human approval → agent action → confirmation. The meaningful unit isn't "AI summary," it's "AI workflow with humans at the inflection points."
+
+---
+
+### Story 6 — Envision IAM-as-code at ~100 AWS accounts / 30K employees
+**Best for:** "Tell me about scale" · "IaC at enterprise size" · "Long-horizon automation impact"
+
+**S:** Manual ticket-driven IAM access process across AWS + Azure at Envision Healthcare (HIPAA + HITRUST estate).
+
+**T:** Codify IAM policy as code; replace the ticket process with version-controlled automation.
+
+**A:** Built and shipped IAM policy automation in Terraform + PowerShell across AWS + Azure. Peer-reviewable, auditable, repeatable.
+
+**R:** Replaced a manual process across **~100 AWS accounts in 3 tenants serving 30,000 employees**. Direct ancestor of the agent work at Viecure — same instinct (automate the toil), same toolchain (Terraform / scripts), seven years earlier with a security framing.
+
+**Reflection:** Every "agent" pattern is a generalization of a "scripted automation" pattern. The toolchain changed, the impulse didn't.
+
+---
+
+### Story 7 — Internal Claude Code platform (org-wide plugins + skills + AI policy)
+**Best for:** "Operate AI as a platform, not a tool" · "Cross-functional product ownership" · "AI vendor evaluation"
+
+**S:** Viecure engineering had inconsistent Claude Code usage — some on API keys, some on OAuth (Pro/Max), no shared standards, rising risk of inconsistent or non-compliant usage.
+
+**T:** Operate Claude Code as a platform org-wide — not as a tool — so both access paths are consistent, governed, and improvable.
+
+**A:** Shipped org-wide Claude Code **plugins** (API-key path) and **skills** (OAuth path) as internal products. Authored the **AI acceptable usage policy** as the connective tissue. Drove all AI coding efforts at Viecure.
+
+**R:** Most of the company's daily Claude usage flows through tooling, plugins, skills, agents, and governance I built.
+
+**Reflection:** When adoption is uneven and policy is missing, ship both products and policy together — neither alone changes behavior.
+
+---
+
+## Red-flag question handlers
+
+| Question | Answer |
+|---|---|
+| *"You don't have biomedical research credentials. How do you feel about clinical workflows?"* | "I ship AI agents inside an oncology EMR every day. I'm not a biomedical researcher — I'm the engineer who works alongside clinical-workflow stakeholders to ship the substrate they use." |
+| *"You're not a pen-tester by trade. How do you think about that gap?"* | "Honest: pen-test engagements aren't my lead skill. I operate the vuln-management toolchain end-to-end and run the security review process for agent deployments. Lead-pen-test ops is something I'd ramp into on the AppSec side — partner with a pen-test specialist or vendor in the meantime." |
+| *"7+ years cloud security but you've been on a 3-person team. Can you operate at Abridge's scale?"* | "3-person at Viecure is by choice — small team that ships AI security in regulated prod. Before that I was at Envision Healthcare for 7 years operating IAM-as-code across ~100 AWS accounts and 30,000 employees. Scale is in my history; small-team posture is a recent intentional move." |
+| *"Are you sure about remote-only / Denver?"* | "Yes. Family is in Denver. I'm not relocating. I'd visit your hubs for onsites, all-hands, and team meetings on a normal cadence — that's expected and easy. But the day-to-day is remote." |
+| *"What's your salary expectation?"* | "Targeting upper $200s base given the AI-in-healthcare specialization, with equity in the upper half of the band. Anchor $245K." Don't quote below this. |
+| *"Why are you leaving Viecure?"* | "I've shipped what I came to ship — security stack maturation, three agents in production, Claude Code platform, AI policy. The next 12 months at Viecure is more of the same. Abridge is the next layer — already further along the healthcare-AI curve with a similar founding-security-team posture." |
+| *"What's your biggest weakness?"* | Pick a real one with a real mitigation. Suggestion: "I'm faster at shipping than at writing it down. I've gotten better — the SOC 2 / HITRUST documentation work at Viecure forced the muscle — but if you watch me work, I'll produce the artifact second and the system first." |
+
+---
+
+## Questions to ask THEM (end of every round)
+
+Pick 2-3 per round. **Don't repeat questions across rounds** — the panel compares notes.
+
+**For the recruiter:**
+- "What's the most common reason candidates fall off this loop?"
+- "Anything about my background you'd want me to address proactively in the next round?"
+- "How fast does this loop typically move once it starts?"
+
+**For the hiring manager:**
+- "What does the current security team look like — am I the founding-IC or are there 1-2 others?"
+- "What's your biggest unsolved security problem right now?"
+- "How does Abridge balance the speed of shipping AI features against the audit posture? Where does that tension surface most?"
+- "What's your stance on engineering teams owning their own security vs central security gating?"
+
+**For the tech panel:**
+- "Walk me through how a security review of a new product feature actually happens today — who's involved, what's the artifact?"
+- "Where does Abridge sit on the build-vs-buy spectrum for security tooling?"
+- "Tell me about Linked Evidence from a security angle — how do you guarantee provenance under load?"
+
+**For the bar raiser:**
+- "What was the most surprising thing about scaling the security work at Abridge as the company grew?"
+- "Who are the security engineers you've seen succeed here vs the ones who haven't?"
+- "What's your honest read on whether the Senior or the Staff title fits me?"
+
+**Always close with:** "Are there any concerns I haven't addressed? I'd rather hear them now than have them go unsaid."
+
+---
+
+## 30-60-90 sketch (have this ready, don't lead with it)
+
+**Days 1-30 — Listen + map.**
+- Sit with the dev org. Understand how features currently get from idea → prod. Where's the friction? Where's the over-investment?
+- Read the existing AI security artifacts (if any). What's documented, what's tribal?
+- Inventory the current cloud security tooling stack — Defender / Wiz / Snyk / whatever. What's coverage vs sprawl?
+- Talk to the Linked Evidence team specifically. Their security model is core to the product.
+- **Output:** a written gap analysis the hiring manager can use to prioritize.
+
+**Days 30-60 — Ship the first paved road.**
+- For AppSec: a security-review process for new product features that ships in days, not weeks. Modeled on the agent-deployment review at Viecure.
+- For InfraSec: an IaC golden-path module (probably IAM or networking) that engineers actually want to use because it's faster than rolling their own.
+- Push the first audit-boundary improvement — pick the highest-PHI-exposure surface and harden it.
+
+**Days 60-90 — Adopt + measure.**
+- Get the paved road into the actual product pipeline; track adoption.
+- Measure something concrete — time-to-security-sign-off, % of new features going through the path, vuln-closure SLAs.
+- Surface to the security leadership: "here's what we built, here's what's next."
+
+---
+
+## Final reminders
+
+- **Lead with proof points, not framing.** "I built X that does Y" beats "I'm passionate about Z."
+- **Cost honesty is your friend.** "$100/day on Sonnet 4.6 for the PR Review agent" is a real-deal signal most candidates can't ground.
+- **Don't pretend Rust/eBPF/SPIFFE depth you don't have.** That'll burn you in a Staff+ panel.
+- **Lowercase identifiers.** Patrick is "security engineer first, AI engineer alongside." Order matters.
+- **You have the agent governance framework most candidates don't.** Use it. The AI usage policy + agent identity model + security review process triad is the most differentiated artifact on your resume — bring it up early in every round.

--- a/interview-prep/story-bank.md
+++ b/interview-prep/story-bank.md
@@ -13,14 +13,77 @@ This file accumulates your best interview stories over time. Each evaluation (Bl
 
 ## Stories
 
-<!-- Stories will be added here as you evaluate offers -->
-<!-- Format:
-### [Theme] Story Title
-**Source:** Report #NNN — Company — Role
-**S (Situation):** ...
-**T (Task):** ...
-**A (Action):** ...
-**R (Result):** ...
-**Reflection:** What I learned / what I'd do differently
-**Best for questions about:** [list of question types this story answers]
--->
+### [AI Security] Azure-hosted MCP proxy for Figma (clear 429s + audit boundary)
+**Source:** Reports #002/#003 — Abridge — AppSec/InfraSec
+**S (Situation):** Viecure's Product Review agent (Figma design review + Jira triage) was hitting Anthropic-side 429 rate limits when pulling Figma data directly.
+**T (Task):** Unblock the agent without losing the Figma data shape. Gain a security/audit boundary in the process.
+**A (Action):** Designed and deployed a proxy MCP server inside Viecure's Azure tenant. Fronts Figma, feeds the agent only what it needs. Deliberate contrast with Atlassian/Jira side which doesn't need a proxy (mature MCP support).
+**R (Result):** 429s cleared, agent restored. The proxy doubles as a HIPAA/HITRUST audit boundary for Figma data in a regulated tenant.
+**Reflection:** When an integration's data path causes a problem, the right fix is often the proxy you'd want for compliance reasons anyway.
+**Best for questions about:** system design, security architecture, AI agent integrations, regulatory constraints, creative problem-solving
+
+---
+
+### [AI Governance] Security review process for new agent deployments
+**Source:** Reports #002/#003 — Abridge — AppSec/InfraSec
+**S (Situation):** New agent deployments at Viecure needed a governance layer in a HIPAA/HITRUST-track environment. No formal review process existed.
+**T (Task):** Author the security review process and agent identity / service-account model. Make it work on a 3-person team without becoming a bottleneck.
+**A (Action):** Designed the security review process and agent identity model that every Claude agent in prod ships through. Light enough to ship agents in days, not weeks.
+**R (Result):** All three agents in production went through this review. No governance escapes. Audit-ready posture.
+**Reflection:** AI governance is most useful when it ships with the first agent, not retro-fitted. The process is the product — the artifact you hand to a HITRUST auditor.
+**Best for questions about:** AI governance, threat modeling, founding-team security, regulatory compliance, process design
+
+---
+
+### [Founding Security] Security stack maturation in a messy Azure environment
+**Source:** Reports #002/#003 — Abridge — AppSec/InfraSec
+**S (Situation):** Joined Viecure as security-engineering hire on a 3-person platform/security team. Inherited a messy Azure environment with weak coverage.
+**T (Task):** Mature the security stack to SOC 2 / HITRUST track shape.
+**A (Action):** Selected and deployed Microsoft Defender suite (Cloud, Endpoint, Identity), Taegis XDR, and Palo Alto. Picked tools that integrate with regulatory work already in flight.
+**R (Result):** Stack operates end-to-end: vuln scanning, EDR, SIEM, IAM/governance. SOC 2 / HITRUST-track shape. Policy documentation authored alongside.
+**Reflection:** Tool sprawl is the second-biggest enemy after coverage gaps. Pick paved-road tooling that integrates with the regulatory work — coverage compounds, sprawl doesn't.
+**Best for questions about:** founding-team security, inheriting a mess, tool selection, SOC 2/HITRUST, security program maturation
+
+---
+
+### [Adoption] PR Review agent + bringing skeptical devs along
+**Source:** Reports #002/#003 — Abridge — AppSec/InfraSec
+**S (Situation):** PR Review agent (Managed Agent on Sonnet 4.6, ~100 PRs/day in ADO) was back-end-leaning. Front-end devs found feedback less useful.
+**T (Task):** Keep opt-in adoption rising without making the agent mandatory. Iterate the prompt, not the policy.
+**A (Action):** Sat with front-end devs to understand calibration mismatch. Iterated the system prompt and review structure. Kept opt-in posture intact.
+**R (Result):** "Even skeptics liked the info." Adoption held. Agent still live at ~100 PRs/day, ~$100/day on Sonnet 4.6.
+**Reflection:** The agent is the easy part; bringing the dev org along is the work. Opt-in adoption is a signal — if the right surface is opting out, the prompt needs to change, not the policy.
+**Best for questions about:** cross-functional influence, handling pushback, AI adoption, iterating on product, stakeholder management
+
+---
+
+### [AI Ops] App Insights closed-loop ops agent
+**Source:** Reports #002/#003 — Abridge — AppSec/InfraSec
+**S (Situation):** Dev + stg App Insights data at Viecure was rich but nobody read it. Perf and error issues caught reactively.
+**T (Task):** Build an agent that turns telemetry into actionable engineering work end-to-end, not just summaries.
+**A (Action):** Daily 7am run against App Insights — structured Slack post (top APIs, slowest APIs, error roll-ups, 7d + 30d baselines). Readers can request a Jira ticket; agent writes it with repro context, picks assignee, confirms back in Slack.
+**R (Result):** Week-1 wins: engineers identifying real perf improvements. The 7d/30d baseline became the go-to for performance triage.
+**Reflection:** This is multi-step HITL: agent → human approval → agent action → confirmation. The meaningful unit isn't "AI summary," it's "AI workflow with humans at the inflection points."
+**Best for questions about:** exploration to production, non-obvious AI architecture, multi-step HITL, observability, proactive engineering
+
+---
+
+### [Scale] Envision IAM-as-code at ~100 AWS accounts / 30K employees
+**Source:** Reports #002/#003 — Abridge — AppSec/InfraSec
+**S (Situation):** Manual ticket-driven IAM access process across AWS + Azure at Envision Healthcare (HIPAA + HITRUST estate).
+**T (Task):** Codify IAM policy as code; replace the ticket process with version-controlled automation.
+**A (Action):** Built IAM policy automation in Terraform + PowerShell across AWS + Azure. Peer-reviewable, auditable, repeatable.
+**R (Result):** Replaced manual process across ~100 AWS accounts in 3 tenants serving 30,000 employees.
+**Reflection:** Every "agent" pattern is a generalization of a "scripted automation" pattern. The toolchain changed, the impulse didn't.
+**Best for questions about:** scale, IaC at enterprise size, long-horizon automation impact, career arc
+
+---
+
+### [Platform] Internal Claude Code platform (org-wide plugins + skills + AI policy)
+**Source:** Reports #002/#003 — Abridge — AppSec/InfraSec
+**S (Situation):** Inconsistent Claude Code usage at Viecure — some on API keys, some on OAuth, no shared standards, rising compliance risk.
+**T (Task):** Operate Claude Code as a platform org-wide — not as a tool — so both access paths are consistent, governed, and improvable.
+**A (Action):** Shipped org-wide Claude Code plugins (API-key path) and skills (OAuth path) as internal products. Authored the AI acceptable usage policy as connective tissue.
+**R (Result):** Most of the company's daily Claude usage flows through tooling, plugins, skills, agents, and governance Patrick built.
+**Reflection:** When adoption is uneven and policy is missing, ship both products and policy together — neither alone changes behavior.
+**Best for questions about:** operating AI as a platform, cross-functional product ownership, AI vendor evaluation, governance at scale

--- a/lib/ats-fetch.mjs
+++ b/lib/ats-fetch.mjs
@@ -1,0 +1,118 @@
+/**
+ * lib/ats-fetch.mjs — zero-token JD fetcher for Greenhouse / Ashby / Lever.
+ *
+ * Returns a normalized shape so the location gate and the LLM eval can consume any ATS:
+ *   { ok, url, ats, company, title, location, workplaceType, isRemote,
+ *     secondaryLocations, comp, text, error }
+ *
+ * Used by triage.mjs (batch scoring of scanned jobs) and openrouter-eval.mjs (--url mode).
+ */
+
+const deent = (s) => (s || '')
+  .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"')
+  .replace(/&#0?39;|&#x27;|&apos;/g, "'").replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&');
+export const stripHtml = (h) => deent(h || '')
+  .replace(/<[^>]+>/g, ' ').replace(/&[a-z#0-9]+;/g, ' ').replace(/\s+/g, ' ').trim();
+
+const COMP_RE = /\$\s?\d{2,3}[,.]?\d{0,3}\s?[kK]?\s?[-–to]+\s?\$?\s?\d{2,3}[,.]?\d{0,3}\s?[kK]?/;
+export const findComp = (t) => { const m = (t || '').match(COMP_RE); return m ? m[0].trim() : ''; };
+
+// Company-embedded Greenhouse boards where the board token isn't in the URL.
+const GH_BOARD_MAP = {
+  'databricks.com': 'databricks', 'mongodb.com': 'mongodb', 'datadoghq.com': 'datadog',
+  'stripe.com': 'stripe', 'boomi.com': 'boomi', 'elastic.co': 'elastic', 'helsing.ai': 'helsing',
+  'coreweave.com': 'coreweave', 'snowflake.com': 'snowflake', 'gitlab.com': 'gitlab',
+};
+
+export function detectAts(url = '') {
+  let m;
+  if ((m = url.match(/jobs\.ashbyhq\.com\/([^/]+)\/([0-9a-f-]{36})/i)))
+    return { ats: 'ashby', org: m[1], id: m[2] };
+  if ((m = url.match(/jobs\.lever\.co\/([^/]+)\/([0-9a-f-]{36})/i)) ||
+      (m = url.match(/api\.lever\.co\/v0\/postings\/([^/]+)\/([0-9a-f-]+)/i)))
+    return { ats: 'lever', org: m[1], id: m[2] };
+  // Greenhouse hosted: boards.greenhouse.io/{board}/jobs/{id} or job-boards.greenhouse.io/{board}/jobs/{id}
+  if ((m = url.match(/(?:job-)?boards(?:-api)?\.greenhouse\.io\/(?:v1\/boards\/)?([^/?]+)\/jobs\/(\d+)/i)))
+    return { ats: 'greenhouse', board: m[1], id: m[2] };
+  // Greenhouse embedded on a company domain: {company}.com/...?gh_jid={id}
+  if ((m = url.match(/gh_jid=(\d+)/i))) {
+    const id = m[1];
+    const host = (url.match(/https?:\/\/(?:www\.)?([^/]+)/i) || [])[1] || '';
+    const domain = Object.keys(GH_BOARD_MAP).find(d => host.endsWith(d));
+    if (domain) return { ats: 'greenhouse', board: GH_BOARD_MAP[domain], id };
+    return { ats: 'greenhouse', board: null, id }; // board unknown — caller may supply opts.board
+  }
+  return { ats: null };
+}
+
+async function getJson(u, tries = 3) {
+  let lastErr;
+  for (let i = 0; i < tries; i++) {
+    try {
+      const r = await fetch(u, { headers: { 'accept': 'application/json' } });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return await r.json();
+    } catch (e) {
+      lastErr = e;
+      // Retry transient network failures ("fetch failed"); don't retry real HTTP errors.
+      if (/^HTTP \d/.test(e.message) || i === tries - 1) throw e;
+      await new Promise(res => setTimeout(res, 300 * (i + 1)));
+    }
+  }
+  throw lastErr;
+}
+
+export async function fetchJob(url, opts = {}) {
+  const d = detectAts(url);
+  const board = opts.board || d.board;
+  try {
+    if (d.ats === 'ashby') {
+      let bd = null;
+      for (const name of [d.org, d.org[0].toUpperCase() + d.org.slice(1)]) {
+        try { bd = await getJson(`https://api.ashbyhq.com/posting-api/job-board/${name}?includeCompensation=true`); break; } catch {}
+      }
+      if (!bd) return { ok: false, url, ats: 'ashby', error: 'board not found' };
+      const p = (bd.jobs || []).find(x => (x.jobUrl || '').includes(d.id) || (x.applyUrl || '').includes(d.id) || x.id === d.id);
+      if (!p) return { ok: false, url, ats: 'ashby', error: 'posting not found' };
+      const text = stripHtml(p.descriptionHtml || p.descriptionPlain || '');
+      return {
+        ok: true, url, ats: 'ashby', company: opts.company || d.org, title: p.title,
+        location: p.location || '', workplaceType: p.workplaceType || '', isRemote: p.isRemote === true,
+        secondaryLocations: (p.secondaryLocations || []).map(s => s.location).filter(Boolean),
+        comp: p.compensation?.compensationTierSummary || p.compensationTierSummary || findComp(text), text,
+      };
+    }
+    if (d.ats === 'lever') {
+      const p = await getJson(`https://api.lever.co/v0/postings/${d.org}/${d.id}`);
+      const text = stripHtml(p.descriptionPlain || p.description || (p.lists || []).map(l => l.content).join(' '));
+      const location = p.categories?.location || (p.categories?.allLocations || []).join(' | ') || '';
+      return {
+        ok: true, url, ats: 'lever', company: opts.company || d.org, title: p.text,
+        location, workplaceType: p.workplaceType || '', isRemote: /remote/i.test(p.workplaceType || ''),
+        secondaryLocations: (p.categories?.allLocations || []).slice(1),
+        comp: p.salaryRange ? `$${p.salaryRange.min}-${p.salaryRange.max}` : findComp(text), text,
+      };
+    }
+    if (d.ats === 'greenhouse') {
+      if (!board) return { ok: false, url, ats: 'greenhouse', error: 'board token unknown (embedded gh_jid)' };
+      const p = await getJson(`https://boards-api.greenhouse.io/v1/boards/${board}/jobs/${d.id}?content=true`);
+      const text = stripHtml(p.content || '');
+      return {
+        ok: true, url, ats: 'greenhouse', company: opts.company || board, title: p.title,
+        location: p.location?.name || '', workplaceType: '', isRemote: /remote/i.test(p.location?.name || ''),
+        secondaryLocations: [], comp: findComp(text), text,
+      };
+    }
+    return { ok: false, url, ats: null, error: 'unrecognized ATS url' };
+  } catch (e) {
+    return { ok: false, url, ats: d.ats, error: String(e.message || e).slice(0, 80) };
+  }
+}
+
+// CLI: node lib/ats-fetch.mjs <url>
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const url = process.argv[2];
+  if (!url) { console.error('usage: node lib/ats-fetch.mjs <job-url>'); process.exit(1); }
+  const r = await fetchJob(url);
+  console.log(JSON.stringify({ ...r, text: (r.text || '').slice(0, 300) + '…' }, null, 2));
+}

--- a/lib/ats-fetch.mjs
+++ b/lib/ats-fetch.mjs
@@ -42,6 +42,10 @@ export function detectAts(url = '') {
     if (domain) return { ats: 'greenhouse', board: GH_BOARD_MAP[domain], id };
     return { ats: 'greenhouse', board: null, id }; // board unknown — caller may supply opts.board
   }
+  // Workday hosted: {tenant}.wd{N}.myworkdayjobs.com/[{locale}/]{site}/job/{loc-slug}/{title}_{reqid}
+  if ((m = url.match(/https?:\/\/([a-z0-9-]+)\.(wd\d+)\.myworkdayjobs\.com\/(?:([a-z]{2}-[A-Z]{2})\/)?([^/]+)(\/job\/.+)$/i))) {
+    return { ats: 'workday', tenant: m[1], host: `${m[1]}.${m[2]}.myworkdayjobs.com`, site: m[4], path: m[5] };
+  }
   return { ats: null };
 }
 
@@ -101,6 +105,19 @@ export async function fetchJob(url, opts = {}) {
         ok: true, url, ats: 'greenhouse', company: opts.company || board, title: p.title,
         location: p.location?.name || '', workplaceType: '', isRemote: /remote/i.test(p.location?.name || ''),
         secondaryLocations: [], comp: findComp(text), text,
+      };
+    }
+    if (d.ats === 'workday') {
+      // cxs detail endpoint mirrors the public path with the locale segment replaced.
+      const p = await getJson(`https://${d.host}/wday/cxs/${d.tenant}/${d.site}${d.path}`);
+      const info = p.jobPostingInfo || {};
+      const text = stripHtml(info.jobDescription || '');
+      const location = [info.location, ...(info.additionalLocations || [])].filter(Boolean).join(' | ');
+      return {
+        ok: true, url, ats: 'workday', company: opts.company || d.tenant, title: info.title || '',
+        location, workplaceType: info.remoteType || '',
+        isRemote: /remote/i.test(info.remoteType || '') || /remote/i.test(location),
+        secondaryLocations: info.additionalLocations || [], comp: findComp(text), text,
       };
     }
     return { ok: false, url, ats: null, error: 'unrecognized ATS url' };

--- a/lib/location-gate.mjs
+++ b/lib/location-gate.mjs
@@ -1,0 +1,188 @@
+/**
+ * lib/location-gate.mjs — JD-body-aware location gate for Patrick's HARD location policy.
+ *
+ * WHY THIS EXISTS: the old auto-pipeline locationGate() only looked at the job TITLE,
+ * and naive ATS checks trust the Ashby `isRemote` flag. Both miss in-office mandates
+ * buried in the JD body. On 2026-06-04 two Replit roles returned isRemote:true but the
+ * JD said "in-office requirement of Monday, Wednesday, and Friday" (Foster City) — hard
+ * SKIPs that a flag-only gate waves through. See memory: reference_ashby_isremote_unreliable.
+ *
+ * POLICY (modes/_profile.md "Your Location Policy"):
+ *   - Remote (US-friendly) ......................... PASS  (score 5.0)
+ *   - On-site/hybrid within ~30min of Denver ....... PASS  (score 4.5-5.0)
+ *   - On-site/hybrid outside Denver metro .......... SKIP  (score 2.0, hard-blocker)
+ *   - Requires relocation (non-CO) or non-US ....... SKIP  (score 1.0, HARD SKIP)
+ *   - Multi-location: viable if >=1 option is remote OR Denver-metro.
+ *
+ * assessLocation() returns { verdict, score, reason }:
+ *   verdict 'pass-remote'  -> genuinely remote, US-eligible
+ *   verdict 'pass-denver'  -> Denver / CO / Denver-metro on-site OK
+ *   verdict 'skip'         -> hard location blocker (non-Denver onsite/hybrid, or non-US)
+ *   verdict 'confirm'      -> contradictory/ambiguous metadata; needs human/recruiter confirm
+ *                            (do NOT auto-apply; do NOT auto-skip)
+ *   verdict 'unknown'      -> no location signal at all; let the LLM eval verify
+ *
+ * Trust order: JD-body in-office mandate > explicit non-US/city > Denver > remote-in-text
+ * > sole non-Denver US city > Hybrid+city. The `isRemote` flag is used ONLY as a weak
+ * tiebreaker to soften a city-SKIP to 'confirm' when no in-office mandate is present.
+ */
+
+// Denver / Colorado / Denver-metro (≤30min per _profile.md) — explicit YES for on-site.
+const DENVER_METRO = [
+  'denver', 'colorado', 'dtc', 'denver tech center', 'aurora', 'centennial',
+  'englewood', 'greenwood village', 'highlands ranch', 'lakewood', 'cherry creek',
+  'westminster', 'arvada', 'littleton', 'broomfield',
+];
+const DENVER_RE = new RegExp(`\\b(?:${DENVER_METRO.join('|')})\\b`, 'i');
+// ", CO" / "CO 80202" — Colorado as a state abbreviation in a LOCATION string. Deliberately
+// NOT bare "\bco\b": JD pay-transparency sections list "Colorado"/"CO" rates and would false-positive.
+const CO_RE = /,\s*co\b|\bco\s+\d{5}\b/i;
+
+// Non-US signals (countries / regions / well-known non-US hubs). If these appear in the
+// LOCATION field, it's relocation/non-US -> HARD SKIP.
+const NON_US = [
+  'canada', 'toronto', 'ottawa', 'vancouver', 'montreal', 'united kingdom', '\\buk\\b',
+  'london', 'ireland', 'dublin', 'cork', 'germany', 'munich', 'berlin', 'france', 'paris',
+  'netherlands', 'amsterdam', 'spain', 'madrid', 'barcelona', 'portugal', 'lisbon',
+  'india', 'hyderabad', 'bangalore', 'bengaluru', 'singapore', 'australia', 'sydney',
+  'melbourne', 'japan', 'tokyo', 'korea', 'seoul', 'china', 'beijing', 'shanghai',
+  'brazil', 'sao paulo', 'mexico', 'mexico city', 'israel', 'tel aviv', 'emea', 'apac',
+  'apj', 'latam', 'benelux', 'thailand', 'malaysia', 'hong kong', 'switzerland', 'zurich',
+];
+const NON_US_RE = new RegExp(`\\b(?:${NON_US.join('|')})\\b`, 'i');
+
+// Non-Denver US cities/states that imply on-site/relocation when they're the sole location.
+const NON_DENVER_US = [
+  'san francisco', 'sf office', 'bay area', 'foster city', 'palo alto', 'menlo park',
+  'mountain view', 'sunnyvale', 'san jose', 'south san francisco', 'new york', 'nyc',
+  'brooklyn', 'manhattan', 'seattle', 'bellevue', 'redmond', 'boston', 'cambridge',
+  'austin', 'dallas', 'houston', 'chicago', 'atlanta', 'miami', 'los angeles',
+  'san diego', 'washington', '\\bd\\.?c\\.?\\b', 'arlington', 'reston', 'pittsburgh',
+  'cincinnati', 'indianapolis', 'raleigh', 'charlotte', 'phoenix', 'salt lake city',
+  '\\bnj\\b', 'new jersey', 'virginia', 'florida',
+];
+const NON_DENVER_US_RE = new RegExp(`(?:${NON_DENVER_US.join('|')})`, 'i');
+// US-XX- structured location (e.g. "US-CA-Menlo Park"); capture the state.
+const US_STATE_RE = /\bUS[-\s]([A-Z]{2})\b/;
+
+// Genuine remote signals — must appear in the JD TEXT or an unambiguous location string,
+// NOT merely an isRemote boolean.
+const REMOTE_TEXT_RE = new RegExp([
+  'fully remote', 'remote[- ]first', 'work from anywhere', 'remote \\(us', 'us[- ]remote',
+  'remote, us', 'remote[- ]friendly', 'remote[- ]flexible', 'this role is (?:fully )?remote',
+  'can be (?:done|performed|held) (?:fully )?remotely', 'open to remote',
+  'remote within the (?:us|united states)', '#li-remote', 'distributed team',
+  'does not require (?:regular )?travel',
+].join('|'), 'i');
+
+// Explicit in-office MANDATE in the JD body — the strongest signal, overrides isRemote.
+const IN_OFFICE_RE = new RegExp([
+  'in[- ]office requirement', 'in the office \\d+', 'on-?site \\d+ days?',
+  '\\d+ days? (?:a|per) week (?:in|on-?site|in-office|in the office)',
+  '(?:one|two|three|four|five) days? (?:a|per) week (?:in|on-?site|in-office)',
+  'required to be (?:in[- ]?office|on-?site)', 'must be (?:located|based) in',
+  'relocat', 'mondays?,? wednesdays?,? (?:and )?fridays?',
+  'hybrid (?:role|position).{0,40}\\d+ days?',
+].join('|'), 'i');
+
+/**
+ * @param {object} j
+ * @param {string} [j.title]
+ * @param {string} [j.location]          ATS location string
+ * @param {string} [j.workplaceType]     Ashby: 'Remote' | 'Hybrid' | 'Onsite'
+ * @param {boolean}[j.isRemote]          Ashby flag (UNRELIABLE — weak signal only)
+ * @param {string[]}[j.secondaryLocations]
+ * @param {string} [j.text]              JD body (plain text)
+ * @returns {{verdict:string, score:number, reason:string}}
+ */
+export function assessLocation(j = {}) {
+  const loc = `${j.location || ''} ${(j.secondaryLocations || []).join(' ')}`.trim();
+  const text = j.text || '';
+  // Denver signal must come from the LOCATION field, not the JD body — pay-transparency
+  // sections list many states (incl. Colorado), which would false-positive against prose.
+  const hasDenver = DENVER_RE.test(loc) || CO_RE.test(loc);
+
+  // 1. Explicit in-office mandate in the JD body, not Denver -> HARD SKIP. (Catches Replit.)
+  if (IN_OFFICE_RE.test(text) && !hasDenver) {
+    const m = text.match(IN_OFFICE_RE);
+    return { verdict: 'skip', score: 1.0,
+      reason: `JD body mandates on-site/relocation ("${(m && m[0] || '').slice(0, 40)}") at a non-Denver location` };
+  }
+
+  // 2. Non-US location -> HARD SKIP (relocation, no remote-US escape in the location).
+  if (NON_US_RE.test(loc) && !DENVER_RE.test(loc) && !/\b(?:us|united states)\b/i.test(loc)) {
+    // unless the body clearly offers a remote-US option
+    if (!/remote.{0,20}(?:us|united states)|us.{0,10}remote/i.test(text)) {
+      return { verdict: 'skip', score: 1.0,
+        reason: `Location is non-US (${loc}) — relocation off the table` };
+    }
+  }
+
+  // 3. Denver / CO / Denver-metro in the location -> PASS (on-site OK; multi-loc w/ Denver is viable).
+  if (hasDenver) {
+    return { verdict: 'pass-denver', score: 4.8, reason: `Denver/CO-metro location (${loc})` };
+  }
+
+  // 4. Genuine remote signal in the TEXT (or unambiguous "Remote" location).
+  const locIsRemote = /^remote\b/i.test(loc) || /\bremote\b/i.test(loc) && !NON_DENVER_US_RE.test(loc) && !NON_US_RE.test(loc);
+  if (REMOTE_TEXT_RE.test(text) || (locIsRemote && /remote/i.test(loc))) {
+    if (NON_US_RE.test(loc) && !/\b(?:us|united states)\b/i.test(loc)) {
+      return { verdict: 'confirm', score: 3.0, reason: `Remote signal but location is non-US (${loc}) — confirm US-remote eligibility` };
+    }
+    return { verdict: 'pass-remote', score: 5.0, reason: `Genuine remote (US) signal in JD${loc ? ` (loc: ${loc})` : ''}` };
+  }
+
+  // 5. Sole non-Denver US city / US-XX state, no remote signal.
+  const stateM = loc.match(US_STATE_RE);
+  const isNonDenverUsCity = NON_DENVER_US_RE.test(loc) || (stateM && stateM[1] !== 'CO');
+  if (isNonDenverUsCity) {
+    // isRemote flag with NO in-office mandate -> soften to 'confirm' (e.g. Abridge: SF Office
+    // + isRemote:true + no in-office text + prior remote applications to the same company).
+    if (j.isRemote === true && !IN_OFFICE_RE.test(text)) {
+      return { verdict: 'confirm', score: 3.5,
+        reason: `Non-Denver US city (${loc}) but isRemote=true and no in-office mandate in JD — CONFIRM remote (flag is unreliable)` };
+    }
+    return { verdict: 'skip', score: 2.0, reason: `On-site/hybrid at a non-Denver US location (${loc}), no remote option` };
+  }
+
+  // 6. workplaceType Hybrid with no parseable Denver/remote -> needs confirmation.
+  if (/hybrid/i.test(j.workplaceType || '') || /hybrid/i.test(loc)) {
+    return { verdict: 'confirm', score: 3.0,
+      reason: `Hybrid with no Denver/remote signal (loc: ${loc || '?'}) — confirm there's a Denver or remote option` };
+  }
+
+  // 7. No location signal at all — let the LLM eval verify.
+  return { verdict: 'unknown', score: 0, reason: 'No location signal in metadata or JD body' };
+}
+
+export const PASS_VERDICTS = new Set(['pass-remote', 'pass-denver']);
+export const isLocationViable = (r) => PASS_VERDICTS.has(r.verdict) || r.verdict === 'confirm' || r.verdict === 'unknown';
+
+// ── Self-test: real cases from the 2026-06-04 backlog eval ───────────────────
+const CASES = [
+  { name: 'Replit Vuln Mgmt', in: { location: 'Foster City, CA | Remote', workplaceType: 'Hybrid', isRemote: true, text: 'This is a full-time role that can be held from our Foster City, CA office. The role has an in-office requirement of Monday, Wednesday, and Friday.' }, want: 'skip' },
+  { name: 'Replit Staff Infra', in: { location: 'Foster City, CA', workplaceType: 'Hybrid', isRemote: true, text: 'in-office requirement of Monday, Wednesday, and Friday' }, want: 'skip' },
+  { name: 'Abridge Enterprise (ambiguous)', in: { location: 'SF Office', workplaceType: 'Hybrid', isRemote: true, secondaryLocations: [], text: 'About Abridge ... founding security team ...' }, want: 'confirm' },
+  { name: 'Komodo FDE', in: { location: 'United States', isRemote: undefined, text: 'This role is remote. #LI-Remote. This role does not require regular travel.' }, want: 'pass-remote' },
+  { name: 'Supabase ProdSec', in: { location: 'Remote', isRemote: true, text: 'We are a fully remote company with no offices.' }, want: 'pass-remote' },
+  { name: 'Cohere Mgr (US|Canada remote)', in: { location: 'United States | Canada', isRemote: false, text: 'Remote-flexible, offices in Toronto, NY, SF, London, Paris.' }, want: 'pass-remote' },
+  { name: 'MongoDB ProdSec (Cork)', in: { location: 'Cork', workplaceType: 'Onsite', text: 'Join our Server security team in Cork.' }, want: 'skip' },
+  { name: 'Truveta M365 (Hyderabad)', in: { location: 'Hyderabad, India', text: 'Security administration role based in Hyderabad.' }, want: 'skip' },
+  { name: 'Anthropic EM (SF|NYC)', in: { location: 'San Francisco, CA | New York City, NY', workplaceType: 'Hybrid', text: 'We expect staff in-office 25% of the time.' }, want: 'skip' },
+  { name: 'Snowflake (Menlo Park)', in: { location: 'US-CA-Menlo Park', text: 'Database engineering at our Menlo Park HQ.' }, want: 'skip' },
+  { name: 'Databricks FDE (Sydney)', in: { location: 'Sydney, Australia', text: 'Forward Deployed Engineer for ANZ customers.' }, want: 'skip' },
+  { name: 'Denver on-site', in: { location: 'Denver, CO', text: 'Hybrid, 2 days a week in our Denver office.' }, want: 'pass-denver' },
+  { name: 'Cloudflare bare Hybrid', in: { location: 'Hybrid', workplaceType: 'Hybrid', text: 'Systems Engineer, Data.' }, want: 'confirm' },
+];
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  let pass = 0;
+  for (const c of CASES) {
+    const r = assessLocation(c.in);
+    const ok = r.verdict === c.want;
+    if (ok) pass++;
+    console.log(`${ok ? '✅' : '❌'} ${c.name.padEnd(32)} got=${r.verdict.padEnd(12)} want=${c.want.padEnd(12)} ${ok ? '' : '← MISMATCH'}\n     ${r.reason}`);
+  }
+  console.log(`\n${pass}/${CASES.length} cases pass`);
+  process.exit(pass === CASES.length ? 0 : 1);
+}

--- a/lib/location-gate.mjs
+++ b/lib/location-gate.mjs
@@ -48,8 +48,18 @@ const NON_US = [
   'melbourne', 'japan', 'tokyo', 'korea', 'seoul', 'china', 'beijing', 'shanghai',
   'brazil', 'sao paulo', 'mexico', 'mexico city', 'israel', 'tel aviv', 'emea', 'apac',
   'apj', 'latam', 'benelux', 'thailand', 'malaysia', 'hong kong', 'switzerland', 'zurich',
+  // Leaked through the 2026-07-06 scan sweep — Nordic/Gulf/CEE/LatAm/ANZ additions:
+  'sweden', 'stockholm', 'norway', 'oslo', 'denmark', 'copenhagen', 'finland', 'helsinki',
+  'poland', 'warsaw', 'krakow', 'czech', 'prague', 'austria', 'vienna', 'italy', 'milan',
+  'rome', 'belgium', 'brussels', 'romania', 'bucharest', 'hungary', 'budapest', 'greece',
+  'athens', 'estonia', 'tallinn', 'ukraine', 'kyiv', 'turkey', 'istanbul', 'scotland',
+  'edinburgh', 'glasgow', '\\buae\\b', 'dubai', 'abu dhabi', 'saudi', 'riyadh', 'qatar',
+  'doha', '\\bmena\\b', 'egypt', 'cairo', 'nigeria', 'lagos', 'south africa', 'cape town',
+  'johannesburg', 'argentina', 'buenos aires', 'colombia', 'bogota', 'chile', 'santiago',
+  'peru', 'lima', 'costa rica', 'philippines', 'manila', 'vietnam', 'indonesia', 'jakarta',
+  'taiwan', 'taipei', 'new zealand', 'auckland', 'wellington',
 ];
-const NON_US_RE = new RegExp(`\\b(?:${NON_US.join('|')})\\b`, 'i');
+export const NON_US_RE = new RegExp(`\\b(?:${NON_US.join('|')})\\b`, 'i');
 
 // Non-Denver US cities/states that imply on-site/relocation when they're the sole location.
 const NON_DENVER_US = [
@@ -66,16 +76,20 @@ const NON_DENVER_US_RE = new RegExp(`(?:${NON_DENVER_US.join('|')})`, 'i');
 const US_STATE_RE = /\bUS[-\s]([A-Z]{2})\b/;
 
 // Genuine remote signals — must appear in the JD TEXT or an unambiguous location string,
-// NOT merely an isRemote boolean.
+// NOT merely an isRemote boolean. 'remote-friendly' must NOT match Anthropic's
+// "Remote-Friendly (Travel-Required)" tag — that tag is a policy SKIP, not a remote signal.
 const REMOTE_TEXT_RE = new RegExp([
   'fully remote', 'remote[- ]first', 'work from anywhere', 'remote \\(us', 'us[- ]remote',
-  'remote, us', 'remote[- ]friendly', 'remote[- ]flexible', 'this role is (?:fully )?remote',
+  'remote, us', 'remote[- ]friendly(?!\\s*\\(travel)', 'remote[- ]flexible', 'this role is (?:fully )?remote',
   'can be (?:done|performed|held) (?:fully )?remotely', 'open to remote',
   'remote within the (?:us|united states)', '#li-remote', 'distributed team',
   'does not require (?:regular )?travel',
 ].join('|'), 'i');
 
 // Explicit in-office MANDATE in the JD body — the strongest signal, overrides isRemote.
+// Includes percentage-based hybrid policies ("in one of our offices at least 25% of the
+// time", "25% on-site minimum") — the Anthropic pattern that slipped through on 2026-06-11
+// and scored 4.8 on a Zürich role.
 const IN_OFFICE_RE = new RegExp([
   'in[- ]office requirement', 'in the office \\d+', 'on-?site \\d+ days?',
   '\\d+ days? (?:a|per) week (?:in|on-?site|in-office|in the office)',
@@ -83,7 +97,16 @@ const IN_OFFICE_RE = new RegExp([
   'required to be (?:in[- ]?office|on-?site)', 'must be (?:located|based) in',
   'relocat', 'mondays?,? wednesdays?,? (?:and )?fridays?',
   'hybrid (?:role|position).{0,40}\\d+ days?',
+  'in (?:one of )?(?:our|the) offices? (?:at least )?\\d{1,2}\\s*%',
+  'in[- ]?office (?:at least |minimum )?\\d{1,2}\\s*%',
+  '\\d{1,2}\\s*%\\s*(?:of (?:the|their|your) time\\s*)?(?:in[- ]?(?:the )?office|on[- ]?site)',
+  'on[- ]?site \\d{1,2}\\s*%', '\\d{1,2}\\s*% on[- ]?site',
 ].join('|'), 'i');
+
+// Anthropic-style location tag that Patrick's policy names as a SKIP: "Remote-Friendly
+// (Travel-Required)" = recurring travel to a non-Denver hub. Checked against BOTH the
+// location string and the JD body.
+const TRAVEL_REQUIRED_TAG_RE = /remote[- ]friendly\s*\(travel[- ]required\)/i;
 
 /**
  * @param {object} j
@@ -102,11 +125,20 @@ export function assessLocation(j = {}) {
   // sections list many states (incl. Colorado), which would false-positive against prose.
   const hasDenver = DENVER_RE.test(loc) || CO_RE.test(loc);
 
-  // 1. Explicit in-office mandate in the JD body, not Denver -> HARD SKIP. (Catches Replit.)
+  // 1. Explicit in-office mandate in the JD body, not Denver -> HARD SKIP. (Catches Replit
+  //    and Anthropic's "at least 25% of the time in one of our offices".)
   if (IN_OFFICE_RE.test(text) && !hasDenver) {
     const m = text.match(IN_OFFICE_RE);
     return { verdict: 'skip', score: 1.0,
       reason: `JD body mandates on-site/relocation ("${(m && m[0] || '').slice(0, 40)}") at a non-Denver location` };
+  }
+
+  // 1b. "Remote-Friendly (Travel-Required)" tag (location string or body), not Denver ->
+  //     HARD SKIP per policy: recurring travel to a non-Denver hub. Even $405K Anthropic
+  //     roles with this tag were disqualified (2026-05-17 policy hardening).
+  if (!hasDenver && (TRAVEL_REQUIRED_TAG_RE.test(loc) || TRAVEL_REQUIRED_TAG_RE.test(text))) {
+    return { verdict: 'skip', score: 1.0,
+      reason: `"Remote-Friendly (Travel-Required)" tag — recurring travel to a non-Denver hub, hard SKIP per policy` };
   }
 
   // 2. Non-US location -> HARD SKIP (relocation, no remote-US escape in the location).
@@ -151,6 +183,19 @@ export function assessLocation(j = {}) {
       reason: `Hybrid with no Denver/remote signal (loc: ${loc || '?'}) — confirm there's a Denver or remote option` };
   }
 
+  // 6b. Location metadata empty, but the head of the JD names a city. JDs state location
+  //     early; benefits/EEO boilerplate (which false-positives on country names) comes late.
+  //     No remote signal + non-US or non-Denver-US city in the head -> needs confirmation,
+  //     NOT 'unknown'. (The Zürich 4.8 and Austin 4.3 both entered through the empty-loc hole.)
+  if (!loc) {
+    const head = text.slice(0, 1000);
+    const cityM = head.match(NON_US_RE) || head.match(NON_DENVER_US_RE);
+    if (cityM) {
+      return { verdict: 'confirm', score: 3.0,
+        reason: `No location metadata but JD head mentions "${cityM[0]}" and no remote signal — confirm location before considering` };
+    }
+  }
+
   // 7. No location signal at all — let the LLM eval verify.
   return { verdict: 'unknown', score: 0, reason: 'No location signal in metadata or JD body' };
 }
@@ -173,6 +218,12 @@ const CASES = [
   { name: 'Databricks FDE (Sydney)', in: { location: 'Sydney, Australia', text: 'Forward Deployed Engineer for ANZ customers.' }, want: 'skip' },
   { name: 'Denver on-site', in: { location: 'Denver, CO', text: 'Hybrid, 2 days a week in our Denver office.' }, want: 'pass-denver' },
   { name: 'Cloudflare bare Hybrid', in: { location: 'Hybrid', workplaceType: 'Hybrid', text: 'Systems Engineer, Data.' }, want: 'confirm' },
+  // ── Regressions from the 2026-06/07 triage misses (scored 4.1–4.8 despite hard blockers) ──
+  { name: 'Anthropic Zürich 25% (was 4.8)', in: { location: '', text: 'Location: Zürich, CH. About the role ... Currently, we expect all staff to be in one of our offices at least 25% of the time.' }, want: 'skip' },
+  { name: 'Anthropic Travel-Required tag (was 4.8)', in: { location: 'Boston, MA | New York City, NY | Remote-Friendly (Travel-Required) | Washington, DC', isRemote: true, text: 'IT Systems Engineer, Client Platform.' }, want: 'skip' },
+  { name: 'Perplexity SF onsite-implied (was 4.6)', in: { location: 'San Francisco, CA', text: 'Member of Technical Staff. Build agent capabilities.' }, want: 'skip' },
+  { name: 'Austin via empty-loc hole (was 4.3)', in: { location: '', text: 'Customer Reliability Engineer. Location: Hybrid, Austin, Texas. About the team ...' }, want: 'confirm' },
+  { name: '25% on-site minimum phrasing', in: { location: 'New York', text: 'This is a hybrid role: 25% on-site minimum at our NYC office.' }, want: 'skip' },
 ];
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/lib/telegram.mjs
+++ b/lib/telegram.mjs
@@ -1,0 +1,107 @@
+/**
+ * lib/telegram.mjs — Shared Telegram Bot API helper
+ *
+ * Used by notify-telegram.mjs, auto-pipeline.mjs, apply-orchestrator.mjs,
+ * and telegram-listener.mjs. Centralizes .env reading, sendMessage, and
+ * getUpdates so the Telegram logic isn't duplicated across four scripts.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+// ── Config ────────────────────────────────────────────────────────────
+
+/**
+ * Read .env file and return key-value pairs.
+ * @param {string} envPath — path to .env file (default: .env in cwd)
+ */
+export function loadEnv(envPath = '.env') {
+  if (!existsSync(envPath)) return {};
+  const env = {};
+  for (const line of readFileSync(envPath, 'utf-8').split('\n')) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)\s*=\s*(.+)$/);
+    if (m) env[m[1]] = m[2].trim().replace(/^["']|["']$/g, '');
+  }
+  return env;
+}
+
+/**
+ * Load Telegram config from .env or process.env.
+ * @param {string} envPath — path to .env file
+ * @returns {{ token: string, chatId: string }}
+ */
+export function loadTelegramConfig(envPath = '.env') {
+  const env = loadEnv(envPath);
+  return {
+    token: env.TELEGRAM_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN || '',
+    chatId: env.TELEGRAM_CHAT_ID || process.env.TELEGRAM_CHAT_ID || '',
+  };
+}
+
+// ── API calls ─────────────────────────────────────────────────────────
+
+const API_BASE = 'https://api.telegram.org/bot';
+
+/**
+ * Send a message to a Telegram chat.
+ * @param {{ token: string }} config
+ * @param {string} chatId
+ * @param {string} text — HTML-formatted message body
+ * @param {object} [options] — extra options (reply_to_message_id, etc.)
+ * @returns {Promise<object>} — Telegram API response with message_id
+ */
+export async function sendMessage(config, chatId, text, options = {}) {
+  const body = {
+    chat_id: chatId,
+    text,
+    parse_mode: 'HTML',
+    disable_web_page_preview: true,
+    ...options,
+  };
+
+  const resp = await fetch(`${API_BASE}${config.token}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok) {
+    throw new Error(`Telegram sendMessage error ${resp.status}: ${JSON.stringify(data)}`);
+  }
+  return data.result;
+}
+
+/**
+ * Send a reply to a specific message.
+ */
+export async function sendReply(config, chatId, text, replyToMessageId) {
+  return sendMessage(config, chatId, text, {
+    reply_to_message_id: replyToMessageId,
+  });
+}
+
+/**
+ * Long-poll for new updates from the Telegram Bot API.
+ * @param {{ token: string }} config
+ * @param {number} offset — update_id offset (last processed + 1)
+ * @param {number} [timeout=30] — long-poll timeout in seconds
+ * @returns {Promise<Array>} — array of update objects
+ */
+export async function getUpdates(config, offset, timeout = 30) {
+  const params = new URLSearchParams({
+    timeout: String(timeout),
+    allowed_updates: JSON.stringify(['message']),
+  });
+  if (offset) params.set('offset', String(offset));
+
+  const resp = await fetch(`${API_BASE}${config.token}/getUpdates?${params}`, {
+    signal: AbortSignal.timeout((timeout + 10) * 1000), // extra 10s for network
+  });
+
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok) {
+    throw new Error(`Telegram getUpdates error ${resp.status}: ${JSON.stringify(data)}`);
+  }
+  return data.result || [];
+}

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -245,7 +245,7 @@ const existingApps = [];
 let maxNum = 0;
 
 for (const line of appLines) {
-  if (line.startsWith('|') && !line.includes('---') && !line.includes('Empresa')) {
+  if (line.startsWith('|') && !line.includes('---') && !line.includes('Company') && !line.includes('Empresa')) {
     const app = parseAppLine(line);
     if (app) {
       existingApps.push(app);

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -107,17 +107,24 @@ function roleFuzzyMatch(a, b) {
   const wordsB = roleTokens(b);
   if (wordsA.length === 0 || wordsB.length === 0) return false;
 
+  const setA = new Set(wordsA);
   const setB = new Set(wordsB);
   const overlap = wordsA.filter(w => setB.has(w)).length;
   if (overlap === 0) return false;
 
-  // Jaccard-style ratio on content tokens. Two roles are "the same" only
-  // when the overlap dominates the smaller side — not when they just share
-  // a location + "engineer".
-  const minLen = Math.min(wordsA.length, wordsB.length);
-  const ratio = overlap / minLen;
+  // True Jaccard similarity: overlap / union.
+  // Previous min-based ratio (overlap/minLen) caused false positives when
+  // two roles shared generic words ("security", "engineer") but differed in
+  // the domain word ("application" vs "infrastructure"). Jaccard penalizes
+  // the non-overlapping terms properly.
+  // Example that previously false-matched:
+  //   "Application Security Engineer" vs "Infrastructure Security Engineer"
+  //   tokens: [application, security, engineer] vs [infrastructure, security, engineer]
+  //   overlap=2, union=4, Jaccard=0.5 → correctly rejected (< 0.75)
+  const union = new Set([...wordsA, ...wordsB]).size;
+  const jaccard = overlap / union;
 
-  return overlap >= 2 && ratio >= 0.6;
+  return overlap >= 2 && jaccard >= 0.75;
 }
 
 function extractReportNum(reportStr) {

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -30,7 +30,7 @@ The evaluation uses 6 blocks (A-F) with a global score of 1-5:
 
 | Dimension | What it measures |
 |-----------|-----------------|
-| Match con CV | Skills, experience, proof points alignment |
+| CV Match | Skills, experience, proof points alignment |
 | North Star alignment | How well the role fits the user's target archetypes (from _profile.md) |
 | Comp | Salary vs market (5=top quartile, 1=well below) |
 | Cultural signals | Company culture, growth, stability, remote policy |

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -226,12 +226,14 @@ These rules apply to ALL generated text that ends up in candidate-facing documen
 - "demonstrated ability to" / "best practices" (name the practice)
 
 ### Unicode normalization for ATS
-`generate-pdf.mjs` automatically normalizes em-dashes, smart quotes, and zero-width characters to ASCII equivalents for maximum ATS compatibility. But avoid generating them in the first place.
+`generate-pdf.mjs` automatically normalizes em-dashes, smart quotes, and zero-width characters to ASCII equivalents for maximum ATS compatibility. But avoid generating them in the first place. Note: normalizing the em-dash GLYPH to a hyphen does NOT remove the tell — the appositive RHYTHM (clause — dash — elaboration) is what a human reader notices. Fix the construction at generation time; never rely on the normalizer to launder it.
 
-### Vary sentence structure
+### Vary sentence SHAPE, not just length
 - Don't start every bullet with the same verb
 - Mix sentence lengths (short. Then longer with context. Short again.)
 - Don't always use "X, Y, and Z" — sometimes two items, sometimes four
+- Mixing lengths is NOT enough — vary SHAPE. Don't run three "clause — dash — appositive" sentences in a row; include at least one plain subject-verb-object paragraph with no dash, colon, or list.
+- **Canonical structural rules live in `modes/_profile.md` "Structural & Rhythmic Tells"**: the banned constructions (negation-elevation, "same X" bridge, meta-labels), the counted per-artifact + per-bundle budgets, and the MANDATORY pre-send self-audit. Apply them to ALL candidate-facing text, in every mode.
 
 ### Prefer specifics over abstractions
 - "Cut p95 latency from 2.1s to 380ms" beats "improved performance"

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -65,6 +65,8 @@ If the final score is >= 4.5, generate a draft of answers for the application fo
 
 **Language**: Always in the language of the JD (EN default). Apply `/tech-translate`.
 
+**Voice (MANDATORY):** form answers are candidate-facing. Apply the "Structural & Rhythmic Tells" rules and run the pre-send self-audit in `modes/_profile.md`. Do NOT reuse a phrasing or punchline across the CV summary, cover letter, and these answers — run the cross-artifact dedup so the bundle doesn't read as one generator.
+
 ## Step 5 — Update Tracker
 Register in `data/applications.md` with all columns including Report and PDF as ✅.
 

--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -1,43 +1,43 @@
-# Modo: auto-pipeline — Pipeline Completo Automático
+# Mode: auto-pipeline — Full Automatic Pipeline
 
-Cuando el usuario pega un JD (texto o URL) sin sub-comando explícito, ejecutar TODO el pipeline en secuencia:
+When the user pastes a JD (text or URL) without an explicit sub-command, run the FULL pipeline in sequence:
 
-## Paso 0 — Extraer JD
+## Step 0 — Extract JD
 
-Si el input es una **URL** (no texto de JD pegado), seguir esta estrategia para extraer el contenido:
+If the input is a **URL** (not pasted JD text), follow this extraction strategy:
 
-**Orden de prioridad:**
+**Priority order:**
 
-1. **Playwright (preferido):** La mayoría de portales de empleo (Lever, Ashby, Greenhouse, Workday) son SPAs. Usar `browser_navigate` + `browser_snapshot` para renderizar y leer el JD.
-2. **WebFetch (fallback):** Para páginas estáticas (ZipRecruiter, WeLoveProduct, company career pages).
-3. **WebSearch (último recurso):** Buscar título del rol + empresa en portales secundarios que indexan el JD en HTML estático.
+1. **Playwright (preferred):** Most job portals (Lever, Ashby, Greenhouse, Workday) are SPAs. Use `browser_navigate` + `browser_snapshot` to render and read the JD.
+2. **WebFetch (fallback):** For static pages (ZipRecruiter, WeLoveProduct, company career pages).
+3. **WebSearch (last resort):** Search for role title + company on secondary portals that index the JD in static HTML.
 
-**Si ningún método funciona:** Pedir al candidato que pegue el JD manualmente o comparta un screenshot.
+**If no method works:** Ask the candidate to paste the JD manually or share a screenshot.
 
-**Si el input es texto de JD** (no URL): usar directamente, sin necesidad de fetch.
+**If the input is JD text** (not a URL): use it directly, no need to fetch.
 
-## Paso 1 — Evaluación A-G
-Ejecutar exactamente igual que el modo `oferta` (leer `modes/oferta.md` para todos los bloques A-F + Block G Posting Legitimacy).
+## Step 1 — A-G Evaluation
+Run exactly like the `oferta` mode (read `modes/oferta.md` for all blocks A-F + Block G Posting Legitimacy).
 
-## Paso 2 — Guardar Report .md
-Guardar la evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (ver formato en `modes/oferta.md`).
+## Step 2 — Save the Report .md
+Save the full evaluation to `reports/{###}-{company-slug}-{YYYY-MM-DD}.md` (see format in `modes/oferta.md`).
 Include Block G in the saved report. Add `**Legitimacy:** {tier}` to the report header.
 
-## Paso 3 — Generar PDF
+## Step 3 — Generate PDF
 Read `config/profile.yml`. Check `cv.output_format`:
 
 - If `"latex"`, execute the full pipeline from `modes/latex.md`
 - Otherwise (default), execute the full pipeline from `modes/pdf.md`
 
-## Paso 4 — Draft Application Answers (solo si score >= 4.5)
+## Step 4 — Draft Application Answers (only if score >= 4.5)
 
-Si el score final es >= 4.5, generar borrador de respuestas para el formulario de aplicación:
+If the final score is >= 4.5, generate a draft of answers for the application form:
 
-1. **Extraer preguntas del formulario**: Usar Playwright para navegar al formulario y hacer snapshot. Si no se pueden extraer, usar las preguntas genéricas.
-2. **Generar respuestas** siguiendo el tono (ver abajo).
-3. **Guardar en el report** como sección `## H) Draft Application Answers`.
+1. **Extract form questions**: Use Playwright to navigate to the form and snapshot it. If they can't be extracted, use the generic questions.
+2. **Generate answers** following the tone (see below).
+3. **Save in the report** as section `## H) Draft Application Answers`.
 
-### Preguntas genéricas (usar si no se pueden extraer del formulario)
+### Generic questions (use if not extractable from the form)
 
 - Why are you interested in this role?
 - Why do you want to work at [Company]?
@@ -45,27 +45,27 @@ Si el score final es >= 4.5, generar borrador de respuestas para el formulario d
 - What makes you a good fit for this position?
 - How did you hear about this role?
 
-### Tono para Form Answers
+### Tone for Form Answers
 
-**Posición: "I'm choosing you."** el candidato tiene opciones y está eligiendo esta empresa por razones concretas.
+**Position: "I'm choosing you."** the candidate has options and is choosing this company for concrete reasons.
 
-**Reglas de tono:**
-- **Confiado sin arrogancia**: "I've spent the past year building production AI agent systems — your role is where I want to apply that experience next"
-- **Selectivo sin soberbia**: "I've been intentional about finding a team where I can contribute meaningfully from day one"
-- **Específico y concreto**: Siempre referenciar algo REAL del JD o de la empresa, y algo REAL de la experiencia del candidato
-- **Directo, sin fluff**: 2-4 frases por respuesta. Sin "I'm passionate about..." ni "I would love the opportunity to..."
-- **El hook es la prueba, no la afirmación**: En vez de "I'm great at X", decir "I built X that does Y"
+**Tone rules:**
+- **Confident without arrogance**: "I've spent the past year building production AI agent systems — your role is where I want to apply that experience next"
+- **Selective without conceit**: "I've been intentional about finding a team where I can contribute meaningfully from day one"
+- **Specific and concrete**: Always reference something REAL from the JD or company, and something REAL from the candidate's experience
+- **Direct, no fluff**: 2-4 sentences per answer. No "I'm passionate about..." or "I would love the opportunity to..."
+- **The hook is the proof, not the claim**: Instead of "I'm great at X", say "I built X that does Y"
 
-**Framework por pregunta:**
+**Framework per question:**
 - **Why this role?** → "Your [specific thing] maps directly to [specific thing I built]."
-- **Why this company?** → Mencionar algo concreto sobre la empresa. "I've been using [product] for [time/purpose]."
-- **Relevant experience?** → Un proof point cuantificado. "Built [X] that [metric]. Sold the company in 2025."
+- **Why this company?** → Mention something concrete about the company. "I've been using [product] for [time/purpose]."
+- **Relevant experience?** → One quantified proof point. "Built [X] that [metric]. Sold the company in 2025."
 - **Good fit?** → "I sit at the intersection of [A] and [B], which is exactly where this role lives."
-- **How did you hear?** → Honesto: "Found through [portal/scan], evaluated against my criteria, and it scored highest."
+- **How did you hear?** → Honest: "Found through [portal/scan], evaluated against my criteria, and it scored highest."
 
-**Idioma**: Siempre en el idioma del JD (EN default). Aplicar `/tech-translate`.
+**Language**: Always in the language of the JD (EN default). Apply `/tech-translate`.
 
-## Paso 5 — Actualizar Tracker
-Registrar en `data/applications.md` con todas las columnas incluyendo Report y PDF en ✅.
+## Step 5 — Update Tracker
+Register in `data/applications.md` with all columns including Report and PDF as ✅.
 
-**Si algún paso falla**, continuar con los siguientes y marcar el paso fallido como pendiente en el tracker.
+**If any step fails**, continue with the next ones and mark the failed step as pending in the tracker.

--- a/modes/contacto.md
+++ b/modes/contacto.md
@@ -1,53 +1,53 @@
-# Modo: contacto -- LinkedIn Power Move
+# Mode: contacto -- LinkedIn Power Move
 
-1. **Identificar targets** via WebSearch:
-   - Hiring manager del equipo
-   - Recruiter asignado
-   - 2-3 peers del equipo (gente con rol similar)
-   - Interviewer (si el candidato ya tiene entrevista programada)
+1. **Identify targets** via WebSearch:
+   - Hiring manager of the team
+   - Assigned recruiter
+   - 2-3 peers on the team (people with a similar role)
+   - Interviewer (if the candidate already has a scheduled interview)
 
-2. **Clasificar tipo de contacto** -- preguntar al candidato o inferir del contexto:
-   - **Recruiter** -- persona cuyo rol es talent acquisition, sourcing, o recruiting
-   - **Hiring Manager** -- la persona que lidera el equipo que contrata
-   - **Peer** -- alguien con un rol similar en el equipo (referral indirecto)
-   - **Interviewer** -- alguien que va a entrevistar al candidato (fecha conocida)
+2. **Classify contact type** -- ask the candidate or infer from context:
+   - **Recruiter** -- person whose role is talent acquisition, sourcing, or recruiting
+   - **Hiring Manager** -- the person who leads the team that's hiring
+   - **Peer** -- someone with a similar role on the team (indirect referral)
+   - **Interviewer** -- someone who is going to interview the candidate (known date)
 
-3. **Seleccionar target primario**: la persona que mas se beneficiaria de que el candidato estuviera alli
+3. **Select primary target**: the person who would benefit most from the candidate being there
 
-4. **Generar mensaje** con framework de 3 frases adaptado al tipo de contacto:
+4. **Generate message** with a 3-sentence framework adapted to the contact type:
 
    ### Recruiter
-   - **Frase 1 (Fit)**: Criterios de match directo -- rol, experiencia relevante, disponibilidad o ubicacion
-   - **Frase 2 (Prueba)**: Dato que responda sus preguntas de screening antes de que las hagan (ej: "5 years building ML pipelines, currently in Berlin, available immediately")
-   - **Frase 3 (CTA)**: "Happy to share my CV if this aligns with what you're looking for"
+   - **Sentence 1 (Fit)**: Direct match criteria -- role, relevant experience, availability or location
+   - **Sentence 2 (Proof)**: Data point that answers their screening questions before they ask them (e.g. "5 years building ML pipelines, currently in Berlin, available immediately")
+   - **Sentence 3 (CTA)**: "Happy to share my CV if this aligns with what you're looking for"
 
    ### Hiring Manager
-   - **Frase 1 (Gancho)**: Reto especifico que enfrenta su equipo (extraido del JD, company blog, o noticias)
-   - **Frase 2 (Prueba)**: Mayor logro cuantificable del candidato que demuestre que ha resuelto problemas similares
-   - **Frase 3 (CTA)**: "Would love to hear how your team is approaching [reto especifico]"
+   - **Sentence 1 (Hook)**: Specific challenge facing their team (pulled from the JD, company blog, or news)
+   - **Sentence 2 (Proof)**: The candidate's biggest quantifiable achievement that shows they've solved similar problems
+   - **Sentence 3 (CTA)**: "Would love to hear how your team is approaching [specific challenge]"
 
    ### Peer (referral)
-   - **Frase 1 (Interes)**: Referencia genuina a su trabajo -- blog post, charla, proyecto open source, o publicacion
-   - **Frase 2 (Conexion)**: Algo que el candidato esta haciendo en el mismo espacio (NO un pitch de empleo)
-   - **Frase 3 (CTA)**: "I've been working on similar problems at [empresa], would love to hear your take on [tema]"
-   - **Nota**: NO pedir empleo. La referral ocurre naturalmente si la conversacion fluye.
+   - **Sentence 1 (Interest)**: Genuine reference to their work -- blog post, talk, open-source project, or publication
+   - **Sentence 2 (Connection)**: Something the candidate is doing in the same space (NOT a job pitch)
+   - **Sentence 3 (CTA)**: "I've been working on similar problems at [company], would love to hear your take on [topic]"
+   - **Note**: DON'T ask for a job. The referral happens naturally if the conversation flows.
 
-   ### Interviewer (pre-entrevista)
-   - **Frase 1 (Research)**: Referencia a algo especifico de su trabajo o trayectoria
-   - **Frase 2 (Contexto)**: Conexion ligera con la experiencia del candidato en ese tema
-   - **Frase 3 (CTA)**: "Looking forward to our conversation on [fecha]"
-   - **Nota**: Tono ligero, no desesperado. El objetivo es que sepan que te preparaste.
+   ### Interviewer (pre-interview)
+   - **Sentence 1 (Research)**: Reference to something specific about their work or background
+   - **Sentence 2 (Context)**: Light connection with the candidate's experience on that topic
+   - **Sentence 3 (CTA)**: "Looking forward to our conversation on [date]"
+   - **Note**: Light tone, not desperate. The goal is to let them know you prepared.
 
-5. **Versiones**:
+5. **Versions**:
    - EN (default)
-   - ES (si empresa espanola)
+   - ES (if Spanish-speaking company)
 
-6. **Targets alternativos** con justificacion de por que son buenos second choices
+6. **Alternative targets** with justification for why they're good second choices
 
-**Reglas del mensaje:**
-- Maximo 300 caracteres (LinkedIn connection request limit)
+**Message rules:**
+- Max 300 characters (LinkedIn connection request limit)
 - NO corporate-speak
 - NO "I'm passionate about..."
-- Algo que haga que quieran responder
-- NUNCA compartir telefono
-- El tipo de contacto cambia el ENFASIS, no la estructura
+- Something that makes them want to reply
+- NEVER share phone
+- Contact type changes the EMPHASIS, not the structure

--- a/modes/cover-letter.md
+++ b/modes/cover-letter.md
@@ -1,0 +1,102 @@
+# Mode: cover-letter — Generate Tailored Cover Letter
+
+Generate a cover letter for the given role using Patrick's calibrated voice. The cover letter must sound like a human wrote it — specifically, like Patrick wrote it.
+
+## Inputs Required
+
+1. **JD text or URL** — the role to target
+2. **cv.md** — read for proof points
+3. **article-digest.md** — read for detailed proof points
+4. **modes/_profile.md** — read the "Writing Style" section for voice rules
+5. **Report** (if exists) — use the evaluation's archetype detection and match analysis
+
+## Structure: 3 Short Paragraphs
+
+### Paragraph 1 — Hook (2-3 sentences)
+Identity + time-in-grade + what's specific about THIS company/role.
+
+Pattern: "I've been [doing X] for [time]. The last chapter is [current work]. [Company]'s [specific thing from JD] is why I'm writing."
+
+DO NOT start with "Dear Hiring Manager" — start with the hook directly.
+DO NOT use "I am writing to express my interest in..." 
+
+### Paragraph 2 — Proof (3-5 sentences)
+Map 2-3 concrete proof points from cv.md/article-digest.md directly to specific JD requirements. Use the archetype framing from _profile.md to pick which proof points to lead with.
+
+Rules:
+- Name technologies, numbers, outcomes
+- "I built X" not "I leveraged X"
+- Connect each proof point to what THEY need, not just what you did
+- One analogy or "signature line" from _profile.md if it fits naturally
+
+### Paragraph 3 — Close (1-2 sentences)
+Direct. No corporate valediction. Signal availability and enthusiasm without groveling.
+
+Pattern: "I'd like to talk about [specific thing you'd do for them]. [One-sentence availability or link to portfolio]."
+
+NEVER end with:
+- "I look forward to discussing how my skills can contribute..."
+- "Thank you for your time and consideration..."
+- "I am confident that my background makes me an ideal candidate..."
+
+## Voice Rules (from _profile.md — abbreviated)
+
+**DO:** Short punchy sentences, direct verbs (built/shipped/run/operate), concrete specifics (A100 GPUs, 80+ resources), casual confidence, vary sentence structure, show personality.
+
+**NEVER:** Leveraging, spearheading, pioneering, orchestrating, passionate about driving innovation, cross-functional collaboration, proven track record, state-of-the-art, perfect parallel structure, corporate valedictions.
+
+## Output Format
+
+```
+---
+To: {company} — {role}
+Date: {YYYY-MM-DD}
+---
+
+{paragraph 1}
+
+{paragraph 2}
+
+{paragraph 3}
+
+Patrick Moore
+303-514-3586 · moorelab.cloud
+```
+
+## Length Target
+
+**200-300 words total.** Not a page. Not a memo. A recruiter reads 50 cover letters a day — respect their time. Hit hard, hit fast, get out.
+
+## Archetype-specific hooks
+
+| Archetype | Lead with... |
+|-----------|-------------|
+| AI/Agentic | "Three Claude agents in production at a regulated healthcare company" |
+| Cloud/Platform | "7 years across AWS+Azure in HIPAA/HITRUST environments" |
+| Security | "Security engineer for 25+ years — hardening regulated environments is what I do" |
+| FDE/SA | "Builder who turns messy environments into working systems" |
+| Healthcare | "Running security and AI for an oncology EMR built from scratch" |
+
+## Example (calibrated to Patrick's voice)
+
+```
+I've been building and securing production systems for 28 years. The last chapter
+is AI agents and GPU training infra in a regulated healthcare environment — three
+Claude agents in production, with MCP infra and governance I built underneath.
+{Company}'s {specific thing from JD} is why I'm writing.
+
+At Viecure I shipped a PR review agent doing ~100 reviews/day, a combined design
+review system across Figma and Jira via an Azure-hosted MCP proxy I built to clear
+429 rate limits, and an App Insights operational loop that posts daily analysis to
+Slack and lets engineers spawn Jira tickets directly from the report. The proxy
+doubles as a HIPAA/HITRUST audit boundary. I also built the GPU training
+infrastructure for an ambient AI transcription model — A100 VMSS, 3 RabbitMQ
+servers, 80+ Azure resources, fully compliant. {Connect to what they need.}
+
+I'd like to talk about how {specific value for them}. My portfolio is at
+moorelab.cloud and I'm available anytime this week.
+```
+
+## File output
+
+Save to: `output/cl-{company-slug}-{date}.md`

--- a/modes/cover-letter.md
+++ b/modes/cover-letter.md
@@ -32,7 +32,9 @@ NEVER end with:
 
 **DO:** Short punchy sentences, direct verbs (built/shipped/run/operate), concrete specifics (A100 GPUs, 80+ resources), casual confidence, vary sentence structure, show personality.
 
-**NEVER:** Leveraging, spearheading, pioneering, orchestrating, passionate about driving innovation, cross-functional collaboration, proven track record, state-of-the-art, perfect parallel structure, corporate valedictions.
+**NEVER (lexical):** Leveraging, spearheading, pioneering, orchestrating, passionate about driving innovation, cross-functional collaboration, proven track record, state-of-the-art, perfect parallel structure, corporate valedictions.
+
+**NEVER (structural — the bigger tells):** negation-elevation ("X isn't A — it's B"), the "same X / same instinct / same muscle" transfer-bridge, meta-labels ("Straight answer:", "Two honest notes.", "Reliability:"), stacked "X, not Y" contrasts, abstract clause-tricolons, and the same "clause — dash — appositive" sentence shape on repeat. **Apply the full "Structural & Rhythmic Tells" rules and run the MANDATORY pre-send self-audit in `modes/_profile.md` before returning the letter.**
 
 ## Output Format
 
@@ -56,6 +58,8 @@ Patrick Moore
 
 **75-120 words. 5-6 sentences.** A recruiter reads 50 cover letters a day — this one takes 15 seconds. Hit hard, get out.
 
+**This cap applies to EVERY path that emits a cover letter.** `apply` and `auto-pipeline` must route through these rules — never generate a 5-paragraph essay. For a senior role with a dedicated cover-letter upload you may stretch to ~180 words / 3 short paragraphs max, but the structural budgets in `_profile.md` apply at any length.
+
 ## Archetype-specific hooks
 
 | Archetype | Lead with... |
@@ -69,16 +73,16 @@ Patrick Moore
 ## Example (calibrated to Patrick's voice)
 
 ```
-I've been building and securing production systems for 28 years — the last chapter
-is three Claude agents in production at a regulated healthcare company, with the
-MCP infra and governance underneath. {Company}'s {specific thing} is why I'm writing.
-At Viecure I run a PR review agent at ~100 PRs/day, an Azure-hosted MCP proxy that
-doubles as a HIPAA audit boundary, and the GPU training infra for an ambient AI
-transcription model (A100s, 80+ Azure resources). Happy to talk — moorelab.cloud
-has the details.
+{Company}'s {specific thing} is the customer-facing version of something I already run.
+At Viecure I built two proxy MCP servers and three Claude agents that ship into a
+HIPAA/HITRUST production stack: a PR-review agent on ~100 PRs a day, plus a Figma proxy
+I stood up to clear Anthropic-side 429s that ended up doubling as an audit boundary.
+I've done security in regulated healthcare for 25 years. The new thing here is doing it
+in {their context} instead of my own, and that's the part I'd be learning fast.
+moorelab.cloud has the rest.
 ```
 
-That's 6 sentences. 95 words. Done.
+That's ~7 sentences, ~100 words. Note the shapes vary (a plain opener, a colon list, a short declarative) — no negation-elevation, no "same X", no signpost label, no tricolon-as-beat. Open a DIFFERENT way each time (see `_profile.md` "Cover letter openers — ROTATE").
 
 ## File output
 

--- a/modes/cover-letter.md
+++ b/modes/cover-letter.md
@@ -10,29 +10,18 @@ Generate a cover letter for the given role using Patrick's calibrated voice. The
 4. **modes/_profile.md** — read the "Writing Style" section for voice rules
 5. **Report** (if exists) — use the evaluation's archetype detection and match analysis
 
-## Structure: 3 Short Paragraphs
+## Structure: 5-6 sentences. That's it.
 
-### Paragraph 1 — Hook (2-3 sentences)
-Identity + time-in-grade + what's specific about THIS company/role.
+Three beats: **why I'm writing → proof → let's talk.** No paragraphs. No filler. A cold pitch, not an essay.
 
-Pattern: "I've been [doing X] for [time]. The last chapter is [current work]. [Company]'s [specific thing from JD] is why I'm writing."
+| Beat | Sentences | What it does |
+|------|-----------|--------------|
+| Hook | 1-2 | Identity + what's specific about THIS role |
+| Proof | 2-3 | Concrete numbers/outcomes mapped to their JD |
+| Close | 1 | Let's talk + portfolio link |
 
 DO NOT start with "Dear Hiring Manager" — start with the hook directly.
-DO NOT use "I am writing to express my interest in..." 
-
-### Paragraph 2 — Proof (3-5 sentences)
-Map 2-3 concrete proof points from cv.md/article-digest.md directly to specific JD requirements. Use the archetype framing from _profile.md to pick which proof points to lead with.
-
-Rules:
-- Name technologies, numbers, outcomes
-- "I built X" not "I leveraged X"
-- Connect each proof point to what THEY need, not just what you did
-- One analogy or "signature line" from _profile.md if it fits naturally
-
-### Paragraph 3 — Close (1-2 sentences)
-Direct. No corporate valediction. Signal availability and enthusiasm without groveling.
-
-Pattern: "I'd like to talk about [specific thing you'd do for them]. [One-sentence availability or link to portfolio]."
+DO NOT use "I am writing to express my interest in..."
 
 NEVER end with:
 - "I look forward to discussing how my skills can contribute..."
@@ -65,7 +54,7 @@ Patrick Moore
 
 ## Length Target
 
-**200-300 words total.** Not a page. Not a memo. A recruiter reads 50 cover letters a day — respect their time. Hit hard, hit fast, get out.
+**75-120 words. 5-6 sentences.** A recruiter reads 50 cover letters a day — this one takes 15 seconds. Hit hard, get out.
 
 ## Archetype-specific hooks
 
@@ -80,22 +69,16 @@ Patrick Moore
 ## Example (calibrated to Patrick's voice)
 
 ```
-I've been building and securing production systems for 28 years. The last chapter
-is AI agents and GPU training infra in a regulated healthcare environment — three
-Claude agents in production, with MCP infra and governance I built underneath.
-{Company}'s {specific thing from JD} is why I'm writing.
-
-At Viecure I shipped a PR review agent doing ~100 reviews/day, a combined design
-review system across Figma and Jira via an Azure-hosted MCP proxy I built to clear
-429 rate limits, and an App Insights operational loop that posts daily analysis to
-Slack and lets engineers spawn Jira tickets directly from the report. The proxy
-doubles as a HIPAA/HITRUST audit boundary. I also built the GPU training
-infrastructure for an ambient AI transcription model — A100 VMSS, 3 RabbitMQ
-servers, 80+ Azure resources, fully compliant. {Connect to what they need.}
-
-I'd like to talk about how {specific value for them}. My portfolio is at
-moorelab.cloud and I'm available anytime this week.
+I've been building and securing production systems for 28 years — the last chapter
+is three Claude agents in production at a regulated healthcare company, with the
+MCP infra and governance underneath. {Company}'s {specific thing} is why I'm writing.
+At Viecure I run a PR review agent at ~100 PRs/day, an Azure-hosted MCP proxy that
+doubles as a HIPAA audit boundary, and the GPU training infra for an ambient AI
+transcription model (A100s, 80+ Azure resources). Happy to talk — moorelab.cloud
+has the details.
 ```
+
+That's 6 sentences. 95 words. Done.
 
 ## File output
 

--- a/modes/deep.md
+++ b/modes/deep.md
@@ -1,47 +1,47 @@
-# Modo: deep — Deep Research Prompt
+# Mode: deep — Deep Research Prompt
 
-Genera un prompt estructurado para Perplexity/Claude/ChatGPT con 6 ejes:
+Generates a structured prompt for Perplexity/Claude/ChatGPT with 6 axes:
 
 ```
-## Deep Research: [Empresa] — [Rol]
+## Deep Research: [Company] — [Role]
 
-Contexto: Estoy evaluando una candidatura para [rol] en [empresa]. Necesito información accionable para la entrevista.
+Context: I'm evaluating a candidacy for [role] at [company]. I need actionable information for the interview.
 
-### 1. Estrategia AI
-- ¿Qué productos/features usan AI/ML?
-- ¿Cuál es su stack de AI? (modelos, infra, tools)
-- ¿Tienen blog de engineering? ¿Qué publican?
-- ¿Qué papers o talks han dado sobre AI?
+### 1. AI Strategy
+- Which products/features use AI/ML?
+- What is their AI stack? (models, infra, tools)
+- Do they have an engineering blog? What do they publish?
+- What papers or talks have they given on AI?
 
-### 2. Movimientos recientes (últimos 6 meses)
-- ¿Contrataciones relevantes en AI/ML/product?
-- ¿Acquisitions o partnerships?
-- ¿Product launches o pivots?
-- ¿Rondas de funding o cambios de liderazgo?
+### 2. Recent moves (last 6 months)
+- Relevant hires in AI/ML/product?
+- Acquisitions or partnerships?
+- Product launches or pivots?
+- Funding rounds or leadership changes?
 
-### 3. Cultura de engineering
-- ¿Cómo shipean? (cadencia de deploy, CI/CD)
-- ¿Mono-repo o multi-repo?
-- ¿Qué lenguajes/frameworks usan?
-- ¿Remote-first o office-first?
-- ¿Glassdoor/Blind reviews sobre eng culture?
+### 3. Engineering culture
+- How do they ship? (deploy cadence, CI/CD)
+- Mono-repo or multi-repo?
+- What languages/frameworks do they use?
+- Remote-first or office-first?
+- Glassdoor/Blind reviews on eng culture?
 
-### 4. Retos probables
-- ¿Qué problemas de scaling tienen?
-- ¿Reliability, cost, latency challenges?
-- ¿Están migrando algo? (infra, models, platforms)
-- ¿Qué pain points menciona la gente en reviews?
+### 4. Likely challenges
+- What scaling problems do they have?
+- Reliability, cost, latency challenges?
+- Are they migrating something? (infra, models, platforms)
+- What pain points does the community mention in reviews?
 
-### 5. Competidores y diferenciación
-- ¿Quiénes son sus main competitors?
-- ¿Cuál es su moat/diferenciador?
-- ¿Cómo se posicionan vs competencia?
+### 5. Competitors and differentiation
+- Who are their main competitors?
+- What's their moat/differentiator?
+- How do they position vs competition?
 
-### 6. Ángulo del candidato
-Dado mi perfil (read from cv.md and profile.yml for specific experience):
-- ¿Qué valor único aporto a este equipo?
-- ¿Qué proyectos míos son más relevantes?
-- ¿Qué historia debería contar en la entrevista?
+### 6. Candidate angle
+Given my profile (read from cv.md and profile.yml for specific experience):
+- What unique value do I bring to this team?
+- Which of my projects are most relevant?
+- What story should I tell in the interview?
 ```
 
-Personalizar cada sección con el contexto específico de la oferta evaluada.
+Personalize each section with the specific context of the evaluated offer.

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -1,91 +1,91 @@
-# Modo: oferta — Evaluación Completa A-G
+# Mode: oferta — Full A-G Evaluation
 
-Cuando el candidato pega una oferta (texto o URL), entregar SIEMPRE los 7 bloques (A-F evaluation + G legitimacy):
+When the candidate pastes an offer (text or URL), ALWAYS deliver the 7 blocks (A-F evaluation + G legitimacy):
 
-## Paso 0 — Detección de Arquetipo
+## Step 0 — Archetype Detection
 
-Clasificar la oferta en uno de los 6 arquetipos (ver `_shared.md`). Si es híbrido, indicar los 2 más cercanos. Esto determina:
-- Qué proof points priorizar en bloque B
-- Cómo reescribir el summary en bloque E
-- Qué historias STAR preparar en bloque F
+Classify the offer into one of the 6 archetypes (see `_shared.md`). If it's a hybrid, indicate the 2 closest. This determines:
+- Which proof points to prioritize in Block B
+- How to rewrite the summary in Block E
+- Which STAR stories to prepare in Block F
 
-## Bloque A — Resumen del Rol
+## Block A — Role Summary
 
-Tabla con:
-- Arquetipo detectado
+Table with:
+- Detected archetype
 - Domain (platform/agentic/LLMOps/ML/enterprise)
 - Function (build/consult/manage/deploy)
 - Seniority
 - Remote (full/hybrid/onsite)
-- Team size (si se menciona)
-- TL;DR en 1 frase
+- Team size (if mentioned)
+- TL;DR in 1 sentence
 
-## Bloque B — Match con CV
+## Block B — CV Match
 
-Lee `cv.md`. Crea tabla con cada requisito del JD mapeado a líneas exactas del CV.
+Read `cv.md`. Create a table mapping each JD requirement to exact CV lines.
 
-**Adaptado al arquetipo:**
-- Si FDE → priorizar proof points de delivery rápida y client-facing
-- Si SA → priorizar diseño de sistemas e integrations
-- Si PM → priorizar product discovery y métricas
-- Si LLMOps → priorizar evals, observability, pipelines
-- Si Agentic → priorizar multi-agent, HITL, orchestration
-- Si Transformation → priorizar change management, adoption, scaling
+**Adapted to the archetype:**
+- If FDE → prioritize proof points around fast delivery and client-facing work
+- If SA → prioritize systems design and integrations
+- If PM → prioritize product discovery and metrics
+- If LLMOps → prioritize evals, observability, pipelines
+- If Agentic → prioritize multi-agent, HITL, orchestration
+- If Transformation → prioritize change management, adoption, scaling
 
-Sección de **gaps** con estrategia de mitigación para cada uno. Para cada gap:
-1. ¿Es un hard blocker o un nice-to-have?
-2. ¿Puede el candidato demostrar experiencia adyacente?
-3. ¿Hay un proyecto portfolio que cubra este gap?
-4. Plan de mitigación concreto (frase para cover letter, proyecto rápido, etc.)
+**Gaps** section with mitigation strategy for each. For each gap:
+1. Is it a hard blocker or a nice-to-have?
+2. Can the candidate demonstrate adjacent experience?
+3. Is there a portfolio project that covers this gap?
+4. Concrete mitigation plan (cover-letter phrase, quick project, etc).
 
-## Bloque C — Nivel y Estrategia
+## Block C — Level & Strategy
 
-1. **Nivel detectado** en el JD vs **nivel natural del candidato para ese arquetipo**
-2. **Plan "vender senior sin mentir"**: frases específicas adaptadas al arquetipo, logros concretos a destacar, cómo posicionar la experiencia de founder como ventaja
-3. **Plan "si me downlevelan"**: aceptar si comp es justa, negociar review a 6 meses, criterios de promoción claros
+1. **Detected level** in the JD vs **candidate's natural level for this archetype**
+2. **"Sell senior without lying" plan**: specific phrases adapted to the archetype, concrete achievements to highlight, how to position founder experience as an advantage
+3. **"If I get downleveled" plan**: accept if comp is fair, negotiate 6-month review, clear promotion criteria
 
-## Bloque D — Comp y Demanda
+## Block D — Comp & Demand
 
-Usar WebSearch para:
-- Salarios actuales del rol (Glassdoor, Levels.fyi, Blind)
-- Reputación de compensación de la empresa
-- Tendencia de demanda del rol
+Use WebSearch for:
+- Current salaries for the role (Glassdoor, Levels.fyi, Blind)
+- Company compensation reputation
+- Role demand trend
 
-Tabla con datos y fuentes citadas. Si no hay datos, decirlo en vez de inventar.
+Table with data and cited sources. If no data is available, say so instead of inventing.
 
-## Bloque E — Plan de Personalización
+## Block E — Personalization Plan
 
-| # | Sección | Estado actual | Cambio propuesto | Por qué |
-|---|---------|---------------|------------------|---------|
+| # | Section | Current state | Proposed change | Why |
+|---|---------|---------------|------------------|-----|
 | 1 | Summary | ... | ... | ... |
 | ... | ... | ... | ... | ... |
 
-Top 5 cambios al CV + Top 5 cambios a LinkedIn para maximizar match.
+Top 5 CV changes + Top 5 LinkedIn changes to maximize match.
 
-## Bloque F — Plan de Entrevistas
+## Block F — Interview Plan
 
-6-10 historias STAR+R mapeadas a requisitos del JD (STAR + **Reflection**):
+6-10 STAR+R stories mapped to JD requirements (STAR + **Reflection**):
 
-| # | Requisito del JD | Historia STAR+R | S | T | A | R | Reflection |
-|---|-----------------|-----------------|---|---|---|---|------------|
+| # | JD requirement | STAR+R story | S | T | A | R | Reflection |
+|---|---------------|--------------|---|---|---|---|------------|
 
 The **Reflection** column captures what was learned or what would be done differently. This signals seniority — junior candidates describe what happened, senior candidates extract lessons.
 
 **Story Bank:** If `interview-prep/story-bank.md` exists, check if any of these stories are already there. If not, append new ones. Over time this builds a reusable bank of 5-10 master stories that can be adapted to any interview question.
 
-**Seleccionadas y enmarcadas según el arquetipo:**
-- FDE → enfatizar velocidad de entrega y client-facing
-- SA → enfatizar decisiones de arquitectura
-- PM → enfatizar discovery y trade-offs
-- LLMOps → enfatizar métricas, evals, production hardening
-- Agentic → enfatizar orchestration, error handling, HITL
-- Transformation → enfatizar adopción, cambio organizacional
+**Selected and framed by archetype:**
+- FDE → emphasize delivery speed and client-facing work
+- SA → emphasize architecture decisions
+- PM → emphasize discovery and trade-offs
+- LLMOps → emphasize metrics, evals, production hardening
+- Agentic → emphasize orchestration, error handling, HITL
+- Transformation → emphasize adoption, organizational change
 
-Incluir también:
-- 1 case study recomendado (cuál de sus proyectos presentar y cómo)
-- Preguntas red-flag y cómo responderlas (ej: "¿por qué vendiste tu empresa?", "¿tienes equipo de reports?")
+Also include:
+- 1 recommended case study (which of their projects to present and how)
+- Red-flag questions and how to answer them (e.g. "why did you sell your company?", "do you have direct reports?")
 
-## Bloque G — Posting Legitimacy
+## Block G — Posting Legitimacy
 
 Analyze the job posting for signals that indicate whether this is a real, active opening. This helps the user prioritize their effort on opportunities most likely to result in a hiring process.
 
@@ -93,7 +93,7 @@ Analyze the job posting for signals that indicate whether this is a real, active
 
 ### Signals to analyze (in order):
 
-**1. Posting Freshness** (from Playwright snapshot, already captured in Paso 0):
+**1. Posting Freshness** (from Playwright snapshot, already captured in Step 0):
 - Date posted or "X days ago" -- extract from page
 - Apply button state (active / closed / missing / redirects to generic page)
 - If URL redirected to generic careers page, note it
@@ -142,75 +142,75 @@ Analyze the job posting for signals that indicate whether this is a real, active
 
 ---
 
-## Post-evaluación
+## Post-evaluation
 
-**SIEMPRE** después de generar los bloques A-G:
+**ALWAYS** after generating Blocks A-G:
 
-### 1. Guardar report .md
+### 1. Save the report .md
 
-Guardar evaluación completa en `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
+Save the full evaluation in `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 
-- `{###}` = siguiente número secuencial (3 dígitos, zero-padded)
-- `{company-slug}` = nombre de empresa en lowercase, sin espacios (usar guiones)
-- `{YYYY-MM-DD}` = fecha actual
+- `{###}` = next sequential number (3 digits, zero-padded)
+- `{company-slug}` = company name in lowercase, no spaces (use hyphens)
+- `{YYYY-MM-DD}` = current date
 
-**Formato del report:**
+**Report format:**
 
 ```markdown
-# Evaluación: {Empresa} — {Rol}
+# Evaluation: {Company} — {Role}
 
-**Fecha:** {YYYY-MM-DD}
-**Arquetipo:** {detectado}
+**Date:** {YYYY-MM-DD}
+**Archetype:** {detected}
 **Score:** {X/5}
 **Legitimacy:** {High Confidence | Proceed with Caution | Suspicious}
-**PDF:** {ruta o pendiente}
+**PDF:** {path or pending}
 
 ---
 
-## A) Resumen del Rol
-(contenido completo del bloque A)
+## A) Role Summary
+(full content of Block A)
 
-## B) Match con CV
-(contenido completo del bloque B)
+## B) CV Match
+(full content of Block B)
 
-## C) Nivel y Estrategia
-(contenido completo del bloque C)
+## C) Level & Strategy
+(full content of Block C)
 
-## D) Comp y Demanda
-(contenido completo del bloque D)
+## D) Comp & Demand
+(full content of Block D)
 
-## E) Plan de Personalización
-(contenido completo del bloque E)
+## E) Personalization Plan
+(full content of Block E)
 
-## F) Plan de Entrevistas
-(contenido completo del bloque F)
+## F) Interview Plan
+(full content of Block F)
 
 ## G) Posting Legitimacy
-(contenido completo del bloque G)
+(full content of Block G)
 
 ## H) Draft Application Answers
-(solo si score >= 4.5 — borradores de respuestas para el formulario de aplicación)
+(only if score >= 4.5 — draft answers for the application form)
 
 ---
 
-## Keywords extraídas
-(lista de 15-20 keywords del JD para ATS optimization)
+## Keywords Extracted
+(list of 15-20 keywords from the JD for ATS optimization)
 ```
 
-### 2. Registrar en tracker
+### 2. Register in tracker
 
-**SIEMPRE** registrar en `data/applications.md`:
-- Siguiente número secuencial
-- Fecha actual
-- Empresa
-- Rol
-- Score: promedio de match (1-5)
-- Estado: `Evaluada`
-- PDF: ❌ (o ✅ si auto-pipeline generó PDF)
-- Report: link relativo al report .md (ej: `[001](reports/001-company-2026-01-01.md)`)
+**ALWAYS** register in `data/applications.md`:
+- Next sequential number
+- Current date
+- Company
+- Role
+- Score: match average (1-5)
+- Status: `Evaluated`
+- PDF: ❌ (or ✅ if auto-pipeline generated a PDF)
+- Report: relative link to the report .md (e.g. `[001](reports/001-company-2026-01-01.md)`)
 
-**Formato del tracker:**
+**Tracker format:**
 
 ```markdown
-| # | Fecha | Empresa | Rol | Score | Estado | PDF | Report |
+| # | Date | Company | Role | Score | Status | PDF | Report |
 ```

--- a/modes/ofertas.md
+++ b/modes/ofertas.md
@@ -1,21 +1,21 @@
-# Modo: ofertas — Comparación Multi-Oferta
+# Mode: ofertas — Multi-Offer Comparison
 
-Scoring matrix de 10 dimensiones ponderadas:
+Scoring matrix with 10 weighted dimensions:
 
-| Dimensión | Peso | Criterios 1-5 |
-|-----------|------|----------------|
-| Alineación North Star | 25% | 5=rol target exacto, 1=no relacionado |
-| Match CV | 15% | 5=90%+ match, 1=<40% match |
-| Nivel (senior+) | 15% | 5=staff+, 4=senior, 3=mid-senior, 2=mid, 1=junior |
-| Comp estimada | 10% | 5=top quartile, 1=below market |
-| Trayectoria crecimiento | 10% | 5=clear path to next level, 1=dead end |
-| Calidad remoto | 5% | 5=full remote async, 1=onsite only |
-| Reputación empresa | 5% | 5=top employer, 1=red flags |
-| Modernidad tech stack | 5% | 5=cutting edge AI/ML, 1=legacy |
-| Velocidad a oferta | 5% | 5=fast process, 1=6+ months |
-| Señales culturales | 5% | 5=builder culture, 1=bureaucratic |
+| Dimension | Weight | 1-5 criteria |
+|-----------|--------|--------------|
+| North Star alignment | 25% | 5=exact target role, 1=unrelated |
+| CV match | 15% | 5=90%+ match, 1=<40% match |
+| Level (senior+) | 15% | 5=staff+, 4=senior, 3=mid-senior, 2=mid, 1=junior |
+| Estimated comp | 10% | 5=top quartile, 1=below market |
+| Growth trajectory | 10% | 5=clear path to next level, 1=dead end |
+| Remote quality | 5% | 5=full remote async, 1=onsite only |
+| Company reputation | 5% | 5=top employer, 1=red flags |
+| Tech stack modernity | 5% | 5=cutting edge AI/ML, 1=legacy |
+| Speed to offer | 5% | 5=fast process, 1=6+ months |
+| Cultural signals | 5% | 5=builder culture, 1=bureaucratic |
 
-Para cada oferta: score en cada dimensión, score ponderado total.
-Ranking final + recomendación con consideraciones de time-to-offer.
+For each offer: score on each dimension, total weighted score.
+Final ranking + recommendation with time-to-offer considerations.
 
-Pedir al usuario las ofertas si no están en contexto. Puede ser texto, URLs, o referencias a ofertas ya evaluadas en el tracker.
+Ask the user for the offers if they're not in context. Can be text, URLs, or references to offers already evaluated in the tracker.

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -1,96 +1,96 @@
-# Modo: pdf — Generación de PDF ATS-Optimizado
+# Mode: pdf — ATS-Optimized PDF Generation
 
-## Pipeline completo
+## Full pipeline
 
-1. Lee `cv.md` como fuentes de verdad
-2. Pide al usuario el JD si no está en contexto (texto o URL)
-3. Extrae 15-20 keywords del JD
-4. Detecta idioma del JD → idioma del CV (EN default)
-5. Detecta ubicación empresa → formato papel:
+1. Read `cv.md` as the source of truth
+2. Ask the user for the JD if it's not in context (text or URL)
+3. Extract 15-20 keywords from the JD
+4. Detect JD language → CV language (EN default)
+5. Detect company location → paper format:
    - US/Canada → `letter`
-   - Resto del mundo → `a4`
-6. Detecta arquetipo del rol → adapta framing
-7. Reescribe Professional Summary inyectando keywords del JD + exit narrative bridge ("Built and sold a business. Now applying systems thinking to [domain del JD].")
-8. Selecciona top 3-4 proyectos más relevantes para la oferta
-9. Reordena bullets de experiencia por relevancia al JD
-10. Construye competency grid desde requisitos del JD (6-8 keyword phrases)
-11. Inyecta keywords naturalmente en logros existentes (NUNCA inventa)
-12. Genera HTML completo desde template + contenido personalizado
-13. Lee `name` de `config/profile.yml` → normaliza a kebab-case lowercase (e.g. "John Doe" → "john-doe") → `{candidate}`
-14. Escribe HTML a `/tmp/cv-{candidate}-{company}.html`
-15. Ejecuta: `node generate-pdf.mjs /tmp/cv-{candidate}-{company}.html output/cv-{candidate}-{company}-{YYYY-MM-DD}.pdf --format={letter|a4}`
-15. Reporta: ruta del PDF, nº páginas, % cobertura de keywords
+   - Rest of world → `a4`
+6. Detect role archetype → adapt framing
+7. Rewrite the Professional Summary injecting JD keywords + exit narrative bridge ("Built and sold a business. Now applying systems thinking to [JD domain].")
+8. Select the top 3-4 most relevant projects for the offer
+9. Reorder experience bullets by relevance to the JD
+10. Build a competency grid from the JD requirements (6-8 keyword phrases)
+11. Inject keywords naturally into existing achievements (NEVER invent)
+12. Generate the full HTML from the template + personalized content
+13. Read `name` from `config/profile.yml` → normalize to kebab-case lowercase (e.g. "John Doe" → "john-doe") → `{candidate}`
+14. Write HTML to `/tmp/cv-{candidate}-{company}.html`
+15. Run: `node generate-pdf.mjs /tmp/cv-{candidate}-{company}.html output/cv-{candidate}-{company}-{YYYY-MM-DD}.pdf --format={letter|a4}`
+15. Report: PDF path, page count, % keyword coverage
 
-## Reglas ATS (parseo limpio)
+## ATS rules (clean parsing)
 
-- Layout single-column (sin sidebars, sin columnas paralelas)
-- Headers estándar: "Professional Summary", "Work Experience", "Education", "Skills", "Certifications", "Projects"
-- Sin texto en imágenes/SVGs
-- Sin info crítica en headers/footers del PDF (ATS los ignora)
-- UTF-8, texto seleccionable (no rasterizado)
-- Sin tablas anidadas
-- Keywords del JD distribuidas: Summary (top 5), primer bullet de cada rol, Skills section
+- Single-column layout (no sidebars, no parallel columns)
+- Standard headers: "Professional Summary", "Work Experience", "Education", "Skills", "Certifications", "Projects"
+- No text in images/SVGs
+- No critical info in the PDF header/footer (ATS ignores them)
+- UTF-8, selectable text (not rasterized)
+- No nested tables
+- JD keywords distributed: Summary (top 5), first bullet of each role, Skills section
 
-## Diseño del PDF
+## PDF design
 
 - **Fonts**: Space Grotesk (headings, 600-700) + DM Sans (body, 400-500)
-- **Fonts self-hosted**: `fonts/`
-- **Header**: nombre en Space Grotesk 24px bold + línea gradiente `linear-gradient(to right, hsl(187,74%,32%), hsl(270,70%,45%))` 2px + fila de contacto
+- **Self-hosted fonts**: `fonts/`
+- **Header**: name in Space Grotesk 24px bold + gradient line `linear-gradient(to right, hsl(187,74%,32%), hsl(270,70%,45%))` 2px + contact row
 - **Section headers**: Space Grotesk 13px, uppercase, letter-spacing 0.05em, color cyan primary
 - **Body**: DM Sans 11px, line-height 1.5
 - **Company names**: color accent purple `hsl(270,70%,45%)`
-- **Márgenes**: 0.6in
-- **Background**: blanco puro
+- **Margins**: 0.6in
+- **Background**: pure white
 
-## Orden de secciones (optimizado "6-second recruiter scan")
+## Section order (optimized for "6-second recruiter scan")
 
-1. Header (nombre grande, gradiente, contacto, link portfolio)
-2. Professional Summary (3-4 líneas, keyword-dense)
-3. Core Competencies (6-8 keyword phrases en flex-grid)
-4. Work Experience (cronológico inverso)
-5. Projects (top 3-4 más relevantes)
+1. Header (large name, gradient, contact, portfolio link)
+2. Professional Summary (3-4 lines, keyword-dense)
+3. Core Competencies (6-8 keyword phrases in a flex grid)
+4. Work Experience (reverse chronological)
+5. Projects (top 3-4 most relevant)
 6. Education & Certifications
-7. Skills (idiomas + técnicos)
+7. Skills (languages + technical)
 
-## Estrategia de keyword injection (ético, basado en verdad)
+## Keyword injection strategy (ethical, truth-grounded)
 
-Ejemplos de reformulación legítima:
-- JD dice "RAG pipelines" y CV dice "LLM workflows with retrieval" → cambiar a "RAG pipeline design and LLM orchestration workflows"
-- JD dice "MLOps" y CV dice "observability, evals, error handling" → cambiar a "MLOps and observability: evals, error handling, cost monitoring"
-- JD dice "stakeholder management" y CV dice "collaborated with team" → cambiar a "stakeholder management across engineering, operations, and business"
+Examples of legitimate rephrasing:
+- JD says "RAG pipelines" and CV says "LLM workflows with retrieval" → change to "RAG pipeline design and LLM orchestration workflows"
+- JD says "MLOps" and CV says "observability, evals, error handling" → change to "MLOps and observability: evals, error handling, cost monitoring"
+- JD says "stakeholder management" and CV says "collaborated with team" → change to "stakeholder management across engineering, operations, and business"
 
-**NUNCA añadir skills que el candidato no tiene. Solo reformular experiencia real con el vocabulario exacto del JD.**
+**NEVER add skills the candidate doesn't have. Only rephrase real experience using the JD's exact vocabulary.**
 
-## Template HTML
+## HTML template
 
-Usar el template en `cv-template.html`. Reemplazar los placeholders `{{...}}` con contenido personalizado:
+Use the template at `cv-template.html`. Replace the `{{...}}` placeholders with personalized content:
 
-| Placeholder | Contenido |
-|-------------|-----------|
-| `{{LANG}}` | `en` o `es` |
-| `{{PAGE_WIDTH}}` | `8.5in` (letter) o `210mm` (A4) |
+| Placeholder | Content |
+|-------------|---------|
+| `{{LANG}}` | `en` or `es` |
+| `{{PAGE_WIDTH}}` | `8.5in` (letter) or `210mm` (A4) |
 | `{{NAME}}` | (from profile.yml) |
 | `{{PHONE}}` | (from profile.yml — include with its separator only when `profile.yml` has a non-empty `phone` value; omit both `<span>` and `<span class="separator">` otherwise) |
 | `{{EMAIL}}` | (from profile.yml) |
 | `{{LINKEDIN_URL}}` | [from profile.yml] |
 | `{{LINKEDIN_DISPLAY}}` | [from profile.yml] |
-| `{{PORTFOLIO_URL}}` | [from profile.yml] (o /es según idioma) |
-| `{{PORTFOLIO_DISPLAY}}` | [from profile.yml] (o /es según idioma) |
+| `{{PORTFOLIO_URL}}` | [from profile.yml] (or /es for Spanish) |
+| `{{PORTFOLIO_DISPLAY}}` | [from profile.yml] (or /es for Spanish) |
 | `{{LOCATION}}` | [from profile.yml] |
 | `{{SECTION_SUMMARY}}` | Professional Summary / Resumen Profesional |
-| `{{SUMMARY_TEXT}}` | Summary personalizado con keywords |
+| `{{SUMMARY_TEXT}}` | Summary personalized with keywords |
 | `{{SECTION_COMPETENCIES}}` | Core Competencies / Competencias Core |
 | `{{COMPETENCIES}}` | `<span class="competency-tag">keyword</span>` × 6-8 |
 | `{{SECTION_EXPERIENCE}}` | Work Experience / Experiencia Laboral |
-| `{{EXPERIENCE}}` | HTML de cada trabajo con bullets reordenados |
+| `{{EXPERIENCE}}` | HTML of each job with reordered bullets |
 | `{{SECTION_PROJECTS}}` | Projects / Proyectos |
-| `{{PROJECTS}}` | HTML de top 3-4 proyectos |
+| `{{PROJECTS}}` | HTML of top 3-4 projects |
 | `{{SECTION_EDUCATION}}` | Education / Formación |
-| `{{EDUCATION}}` | HTML de educación |
+| `{{EDUCATION}}` | HTML of education |
 | `{{SECTION_CERTIFICATIONS}}` | Certifications / Certificaciones |
-| `{{CERTIFICATIONS}}` | HTML de certificaciones |
+| `{{CERTIFICATIONS}}` | HTML of certifications |
 | `{{SECTION_SKILLS}}` | Skills / Competencias |
-| `{{SKILLS}}` | HTML de skills |
+| `{{SKILLS}}` | HTML of skills |
 
 ## Canva CV Generation (optional)
 
@@ -174,6 +174,6 @@ d. Report: PDF path, file size, Canva design URL (for manual tweaking)
 - If `find_and_replace_text` finds no matches → try broader substring matching
 - Always provide the Canva design URL so the user can edit manually if auto-edit fails
 
-## Post-generación
+## Post-generation
 
-Actualizar tracker si la oferta ya está registrada: cambiar PDF de ❌ a ✅.
+Update the tracker if the offer is already registered: change PDF from ❌ to ✅.

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -10,7 +10,7 @@
    - US/Canada → `letter`
    - Rest of world → `a4`
 6. Detect role archetype → adapt framing
-7. Rewrite the Professional Summary injecting JD keywords + exit narrative bridge ("Built and sold a business. Now applying systems thinking to [JD domain].")
+7. Rewrite the Professional Summary injecting JD keywords + Patrick's REAL exit-narrative bridge (security-engineer-first → AI agents in regulated production; see `modes/_profile.md` "Your Exit Narrative" — do NOT use a canned bridge, and the "Built and sold a business" line is not Patrick). The summary is the single most-read line on the CV: keep it plain, and apply the "Structural & Rhythmic Tells" rules + pre-send self-audit from `modes/_profile.md` (no negation-elevation, no slogan, no recycled cover-letter line).
 8. Select the top 3-4 most relevant projects for the offer
 9. Reorder experience bullets by relevance to the JD
 10. Build a competency grid from the JD requirements (6-8 keyword phrases)

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -1,57 +1,62 @@
-# Modo: pipeline — Inbox de URLs (Second Brain)
+# Mode: pipeline — URL Inbox (Second Brain)
 
-Procesa URLs de ofertas acumuladas en `data/pipeline.md`. El usuario agrega URLs cuando quiera y luego ejecuta `/career-ops pipeline` para procesarlas todas.
+Process offer URLs accumulated in `data/pipeline.md`. The user adds URLs whenever they want and then runs `/career-ops pipeline` to process them all.
 
 ## Workflow
 
-1. **Leer** `data/pipeline.md` → buscar items `- [ ]` en la sección "Pendientes"
-2. **Para cada URL pendiente**:
-   a. Calcular siguiente `REPORT_NUM` secuencial (leer `reports/`, tomar el número más alto + 1)
-   b. **Extraer JD** usando Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
-   c. Si la URL no es accesible → marcar como `- [!]` con nota y continuar
-   d. **Ejecutar auto-pipeline completo**: Evaluación A-F → Report .md → PDF (si score >= 3.0) → Tracker
-   e. **Mover de "Pendientes" a "Procesadas"**: `- [x] #NNN | URL | Empresa | Rol | Score/5 | PDF ✅/❌`
-3. **Si hay 3+ URLs pendientes**, lanzar agentes en paralelo (Agent tool con `run_in_background`) para maximizar velocidad.
-4. **Al terminar**, mostrar tabla resumen:
+1. **Read** `data/pipeline.md` → find `- [ ]` items in the "Pending" section
+2. **For each pending URL**:
+   a. Compute the next sequential `REPORT_NUM` (read `reports/`, take the highest number + 1)
+   b. **Extract the JD** using Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
+   c. If the URL isn't accessible → mark as `- [!]` with a note and continue
+   d. **Run the full auto-pipeline**: A-F Evaluation → Report .md → PDF (if score >= 3.0) → Tracker
+   e. **Move from "Pending" to "Processed"**: `- [x] #NNN | URL | Company | Role | Score/5 | PDF ✅/❌`
+3. **If there are 3+ pending URLs**, launch agents in parallel (Agent tool with `run_in_background`) to maximize speed.
+4. **When done**, show a summary table:
 
 ```
-| # | Empresa | Rol | Score | PDF | Acción recomendada |
+| # | Company | Role | Score | PDF | Recommended action |
 ```
 
-## Formato de pipeline.md
+## pipeline.md format
 
 ```markdown
-## Pendientes
+## Pending
 - [ ] https://jobs.example.com/posting/123
 - [ ] https://boards.greenhouse.io/company/jobs/456 | Company Inc | Senior PM
 - [!] https://private.url/job — Error: login required
 
-## Procesadas
+## Processed
 - [x] #143 | https://jobs.example.com/posting/789 | Acme Corp | AI PM | 4.2/5 | PDF ✅
 - [x] #144 | https://boards.greenhouse.io/xyz/jobs/012 | BigCo | SA | 2.1/5 | PDF ❌
 ```
 
-## Detección inteligente de JD desde URL
+## Smart JD detection from URL
 
-1. **Playwright (preferido):** `browser_navigate` + `browser_snapshot`. Funciona con todas las SPAs.
-2. **WebFetch (fallback):** Para páginas estáticas o cuando Playwright no está disponible.
-3. **WebSearch (último recurso):** Buscar en portales secundarios que indexan el JD.
+1. **Playwright (preferred):** `browser_navigate` + `browser_snapshot`. Works with all SPAs.
+2. **WebFetch (fallback):** For static pages or when Playwright isn't available.
+3. **WebSearch (last resort):** Search secondary portals that index the JD.
 
-**Casos especiales:**
-- **LinkedIn**: Puede requerir login → marcar `[!]` y pedir al usuario que pegue el texto
-- **PDF**: Si la URL apunta a un PDF, leerlo directamente con Read tool
-- **`local:` prefix**: Leer el archivo local. Ejemplo: `local:jds/linkedin-pm-ai.md` → leer `jds/linkedin-pm-ai.md`
+**Special cases:**
+- **LinkedIn**: Most LinkedIn job URLs require login. Workflow:
+  1. Try WebFetch first — public canonical URLs (`linkedin.com/jobs/view/{id}`) sometimes return enough JD to evaluate.
+  2. If login-walled (or returns generic boilerplate), mark `[!]` next to the entry and ask the user to paste the JD text or save it to `jds/linkedin-{slug}.md`.
+  3. Once pasted, treat as if the JD were in-context — proceed with auto-pipeline normally.
+  4. **Tip for the user**: when finding interesting LinkedIn jobs, the cleanest path is to paste the JD text directly into a new pipeline entry rather than the URL. Format: `- [ ] local:jds/linkedin-{company}-{role-slug}.md | {company} | {title}` after saving the JD text to that file.
+  5. **Do not** scrape LinkedIn with authenticated sessions or scraper services — violates LinkedIn ToS.
+- **PDF**: If the URL points to a PDF, read it directly with the Read tool
+- **`local:` prefix**: Read the local file. Example: `local:jds/linkedin-pm-ai.md` → read `jds/linkedin-pm-ai.md`
 
-## Numeración automática
+## Automatic numbering
 
-1. Listar todos los archivos en `reports/`
-2. Extraer el número del prefijo (e.g., `142-medispend...` → 142)
-3. Nuevo número = máximo encontrado + 1
+1. List all files in `reports/`
+2. Extract the number from the prefix (e.g. `142-medispend...` → 142)
+3. New number = max found + 1
 
-## Sincronización de fuentes
+## Source synchronization
 
-Antes de procesar cualquier URL, verificar sync:
+Before processing any URL, verify sync:
 ```bash
 node cv-sync-check.mjs
 ```
-Si hay desincronización, advertir al usuario antes de continuar.
+If there's a desync, warn the user before continuing.

--- a/modes/project.md
+++ b/modes/project.md
@@ -1,30 +1,30 @@
-# Modo: project — Evaluación de Proyecto Portfolio
+# Mode: project — Portfolio Project Evaluation
 
-Scoring 6 dimensiones (1-5):
+Scoring on 6 dimensions (1-5):
 
-| Dimensión | Peso | 5 = ... | 1 = ... |
-|-----------|------|---------|---------|
-| Señal para roles target | 25% | Directamente demuestra skill del JD | No relacionado |
-| Unicidad | 20% | Nadie ha hecho esto | Todo el mundo lo tiene |
-| Demo-ability | 20% | Live demo en 2 min | Solo código, no visual |
-| Potencial de métricas | 15% | Métricas claras (latency, cost, accuracy) | Sin métricas posibles |
-| Tiempo a MVP | 10% | 1 semana | 3+ meses |
-| Potencial de historia STAR | 10% | Historia rica con trade-offs | Solo implementación |
+| Dimension | Weight | 5 = ... | 1 = ... |
+|-----------|--------|---------|---------|
+| Signal for target roles | 25% | Directly demonstrates a JD skill | Unrelated |
+| Uniqueness | 20% | Nobody has done this | Everybody has it |
+| Demo-ability | 20% | Live demo in 2 min | Code only, no visual |
+| Metric potential | 15% | Clear metrics (latency, cost, accuracy) | No metrics possible |
+| Time to MVP | 10% | 1 week | 3+ months |
+| STAR-story potential | 10% | Rich story with trade-offs | Only implementation |
 
-## Requisitos de "Interview Pack"
+## "Interview Pack" requirements
 
-Para cada proyecto aprobado:
-1. **One-pager**: producto + arquitectura + métricas + plan de evaluación
-2. **Demo**: URL live o walkthrough grabado de 2 min
-3. **Postmortem**: qué funcionó, qué no, mitigaciones
+For each approved project:
+1. **One-pager**: product + architecture + metrics + evaluation plan
+2. **Demo**: live URL or 2-min recorded walkthrough
+3. **Postmortem**: what worked, what didn't, mitigations
 
-## Plan 80/20
+## 80/20 plan
 
-- Semana 1 → MVP con métrica core
-- Semana 2 → polish + interview pack
+- Week 1 → MVP with core metric
+- Week 2 → polish + interview pack
 
-## Veredictos
+## Verdicts
 
-- **CONSTRUIR** → plan con milestones semanales
-- **SKIP** → por qué y qué hacer en su lugar
-- **PIVOTAR A [alternativa]** → variante más impactante
+- **BUILD** → plan with weekly milestones
+- **SKIP** → why and what to do instead
+- **PIVOT TO [alternative]** → more impactful variant

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -1,165 +1,165 @@
-# Modo: scan — Portal Scanner (Descubrimiento de Ofertas)
+# Mode: scan — Portal Scanner (Offer Discovery)
 
-Escanea portales de empleo configurados, filtra por relevancia de título, y añade nuevas ofertas al pipeline para evaluación posterior.
+Scans configured job portals, filters by title relevance, and adds new offers to the pipeline for later evaluation.
 
-> **Nota (v1.5+):** El escáner por defecto (`scan.mjs` / `npm run scan`) es **zero-token** y sólo consulta directamente las APIs públicas de Greenhouse, Ashby y Lever. Los niveles con Playwright/WebSearch descritos abajo son el flujo **agente** (ejecutado por Claude/Codex), no lo que hace `scan.mjs`. Si una empresa no tiene API Greenhouse/Ashby/Lever, `scan.mjs` la ignorará; para esos casos, el agente debe completar manualmente el Nivel 1 (Playwright) o Nivel 3 (WebSearch).
+> **Note (v1.5+):** The default scanner (`scan.mjs` / `npm run scan`) is **zero-token** and only queries the public APIs of Greenhouse, Ashby, and Lever directly. The Playwright/WebSearch levels described below are the **agent** flow (executed by Claude/Codex), not what `scan.mjs` does. If a company doesn't have a Greenhouse/Ashby/Lever API, `scan.mjs` will skip it; for those cases, the agent should manually run Level 1 (Playwright) or Level 3 (WebSearch).
 
-## Ejecución recomendada
+## Recommended execution
 
-Ejecutar como subagente para no consumir contexto del main:
+Run as a subagent so it doesn't consume the main context:
 
 ```
 Agent(
     subagent_type="general-purpose",
-    prompt="[contenido de este archivo + datos específicos]",
+    prompt="[contents of this file + specific data]",
     run_in_background=True
 )
 ```
 
-## Configuración
+## Configuration
 
-Leer `portals.yml` que contiene:
-- `search_queries`: Lista de queries WebSearch con `site:` filters por portal (descubrimiento amplio)
-- `tracked_companies`: Empresas específicas con `careers_url` para navegación directa
-- `title_filter`: Keywords positive/negative/seniority_boost para filtrado de títulos
+Read `portals.yml` which contains:
+- `search_queries`: List of WebSearch queries with `site:` filters per portal (broad discovery)
+- `tracked_companies`: Specific companies with `careers_url` for direct navigation
+- `title_filter`: positive/negative/seniority_boost keywords for title filtering
 
-## Estrategia de descubrimiento (3 niveles)
+## Discovery strategy (3 levels)
 
-### Nivel 1 — Playwright directo (PRINCIPAL)
+### Level 1 — Direct Playwright (PRIMARY)
 
-**Para cada empresa en `tracked_companies`:** Navegar a su `careers_url` con Playwright (`browser_navigate` + `browser_snapshot`), leer TODOS los job listings visibles, y extraer título + URL de cada uno. Este es el método más fiable porque:
-- Ve la página en tiempo real (no resultados cacheados de Google)
-- Funciona con SPAs (Ashby, Lever, Workday)
-- Detecta ofertas nuevas al instante
-- No depende de la indexación de Google
+**For each company in `tracked_companies`:** Navigate to their `careers_url` with Playwright (`browser_navigate` + `browser_snapshot`), read ALL visible job listings, and extract title + URL of each. This is the most reliable method because:
+- Sees the page in real time (not Google's cached results)
+- Works with SPAs (Ashby, Lever, Workday)
+- Detects new offers instantly
+- Doesn't depend on Google indexing
 
-**Cada empresa DEBE tener `careers_url` en portals.yml.** Si no la tiene, buscarla una vez, guardarla, y usar en futuros scans.
+**Every company MUST have `careers_url` in portals.yml.** If not, search for it once, save it, and use it in future scans.
 
-### Nivel 2 — ATS APIs / Feeds (COMPLEMENTARIO)
+### Level 2 — ATS APIs / Feeds (COMPLEMENTARY)
 
-Para empresas con API pública o feed estructurado, usar la respuesta JSON/XML como complemento rápido de Nivel 1. Es más rápido que Playwright y reduce errores de scraping visual.
+For companies with a public API or structured feed, use the JSON/XML response as a fast complement to Level 1. It's faster than Playwright and reduces visual-scraping errors.
 
-**Soporte actual (variables entre `{}`):**
+**Current support (variables in `{}`):**
 - **Greenhouse**: `https://boards-api.greenhouse.io/v1/boards/{company}/jobs`
 - **Ashby**: `https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobBoardWithTeams`
-- **BambooHR**: lista `https://{company}.bamboohr.com/careers/list`; detalle de una oferta `https://{company}.bamboohr.com/careers/{id}/detail`
+- **BambooHR**: list `https://{company}.bamboohr.com/careers/list`; offer detail `https://{company}.bamboohr.com/careers/{id}/detail`
 - **Lever**: `https://api.lever.co/v0/postings/{company}?mode=json`
 - **Teamtailor**: `https://{company}.teamtailor.com/jobs.rss`
 - **Workday**: `https://{company}.{shard}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs`
 
-**Convención de parsing por provider:**
+**Parsing conventions by provider:**
 - `greenhouse`: `jobs[]` → `title`, `absolute_url`
-- `ashby`: GraphQL `ApiJobBoardWithTeams` con `organizationHostedJobsPageName={company}` → `jobBoard.jobPostings[]` (`title`, `id`; construir URL pública si no viene en payload)
-- `bamboohr`: lista `result[]` → `jobOpeningName`, `id`; construir URL de detalle `https://{company}.bamboohr.com/careers/{id}/detail`; para leer el JD completo, hacer GET del detalle y usar `result.jobOpening` (`jobOpeningName`, `description`, `datePosted`, `minimumExperience`, `compensation`, `jobOpeningShareUrl`)
-- `lever`: array raíz `[]` → `text`, `hostedUrl` (fallback: `applyUrl`)
+- `ashby`: GraphQL `ApiJobBoardWithTeams` with `organizationHostedJobsPageName={company}` → `jobBoard.jobPostings[]` (`title`, `id`; build the public URL if not in payload)
+- `bamboohr`: list `result[]` → `jobOpeningName`, `id`; build detail URL `https://{company}.bamboohr.com/careers/{id}/detail`; to read the full JD, GET the detail and use `result.jobOpening` (`jobOpeningName`, `description`, `datePosted`, `minimumExperience`, `compensation`, `jobOpeningShareUrl`)
+- `lever`: root array `[]` → `text`, `hostedUrl` (fallback: `applyUrl`)
 - `teamtailor`: RSS items → `title`, `link`
-- `workday`: `jobPostings[]`/`jobPostings` (según tenant) → `title`, `externalPath` o URL construida desde el host
+- `workday`: `jobPostings[]`/`jobPostings` (depending on tenant) → `title`, `externalPath` or URL built from the host
 
-### Nivel 3 — WebSearch queries (DESCUBRIMIENTO AMPLIO)
+### Level 3 — WebSearch queries (BROAD DISCOVERY)
 
-Los `search_queries` con `site:` filters cubren portales de forma transversal (todos los Ashby, todos los Greenhouse, etc.). Útil para descubrir empresas NUEVAS que aún no están en `tracked_companies`, pero los resultados pueden estar desfasados.
+The `search_queries` with `site:` filters cover portals horizontally (all of Ashby, all of Greenhouse, etc.). Useful to discover NEW companies not yet in `tracked_companies`, but results may be stale.
 
-**Prioridad de ejecución:**
-1. Nivel 1: Playwright → todas las `tracked_companies` con `careers_url`
-2. Nivel 2: API → todas las `tracked_companies` con `api:`
-3. Nivel 3: WebSearch → todos los `search_queries` con `enabled: true`
+**Execution priority:**
+1. Level 1: Playwright → all `tracked_companies` with `careers_url`
+2. Level 2: API → all `tracked_companies` with `api:`
+3. Level 3: WebSearch → all `search_queries` with `enabled: true`
 
-Los niveles son aditivos — se ejecutan todos, los resultados se mezclan y deduplicar.
+The levels are additive — all run, results are merged and deduplicated.
 
 ## Workflow
 
-1. **Leer configuración**: `portals.yml`
-2. **Leer historial**: `data/scan-history.tsv` → URLs ya vistas
-3. **Leer dedup sources**: `data/applications.md` + `data/pipeline.md`
+1. **Read configuration**: `portals.yml`
+2. **Read history**: `data/scan-history.tsv` → URLs already seen
+3. **Read dedup sources**: `data/applications.md` + `data/pipeline.md`
 
-4. **Nivel 1 — Playwright scan** (paralelo en batches de 3-5):
-   Para cada empresa en `tracked_companies` con `enabled: true` y `careers_url` definida:
-   a. `browser_navigate` a la `careers_url`
-   b. `browser_snapshot` para leer todos los job listings
-   c. Si la página tiene filtros/departamentos, navegar las secciones relevantes
-   d. Para cada job listing extraer: `{title, url, company}`
-   e. Si la página pagina resultados, navegar páginas adicionales
-   f. Acumular en lista de candidatos
-   g. Si `careers_url` falla (404, redirect), intentar `scan_query` como fallback y anotar para actualizar la URL
+4. **Level 1 — Playwright scan** (parallel in batches of 3-5):
+   For each company in `tracked_companies` with `enabled: true` and `careers_url` defined:
+   a. `browser_navigate` to the `careers_url`
+   b. `browser_snapshot` to read all job listings
+   c. If the page has filters/departments, navigate the relevant sections
+   d. For each job listing extract: `{title, url, company}`
+   e. If the page paginates, navigate additional pages
+   f. Accumulate into candidate list
+   g. If `careers_url` fails (404, redirect), try `scan_query` as fallback and note it for URL update
 
-5. **Nivel 2 — ATS APIs / feeds** (paralelo):
-   Para cada empresa en `tracked_companies` con `api:` definida y `enabled: true`:
-   a. WebFetch de la URL de API/feed
-   b. Si `api_provider` está definido, usar su parser; si no está definido, inferir por dominio (`boards-api.greenhouse.io`, `jobs.ashbyhq.com`, `api.lever.co`, `*.bamboohr.com`, `*.teamtailor.com`, `*.myworkdayjobs.com`)
-   c. Para **Ashby**, enviar POST con:
+5. **Level 2 — ATS APIs / feeds** (parallel):
+   For each company in `tracked_companies` with `api:` defined and `enabled: true`:
+   a. WebFetch the API/feed URL
+   b. If `api_provider` is defined, use its parser; if not, infer by domain (`boards-api.greenhouse.io`, `jobs.ashbyhq.com`, `api.lever.co`, `*.bamboohr.com`, `*.teamtailor.com`, `*.myworkdayjobs.com`)
+   c. For **Ashby**, send POST with:
       - `operationName: ApiJobBoardWithTeams`
       - `variables.organizationHostedJobsPageName: {company}`
-      - query GraphQL de `jobBoardWithTeams` + `jobPostings { id title locationName employmentType compensationTierSummary }`
-   d. Para **BambooHR**, la lista solo trae metadatos básicos. Para cada item relevante, leer `id`, hacer GET a `https://{company}.bamboohr.com/careers/{id}/detail`, y extraer el JD completo desde `result.jobOpening`. Usar `jobOpeningShareUrl` como URL pública si viene; si no, usar la URL de detalle.
-   e. Para **Workday**, enviar POST JSON con al menos `{"appliedFacets":{},"limit":20,"offset":0,"searchText":""}` y paginar por `offset` hasta agotar resultados
-   f. Para cada job extraer y normalizar: `{title, url, company}`
-   g. Acumular en lista de candidatos (dedup con Nivel 1)
+      - GraphQL query for `jobBoardWithTeams` + `jobPostings { id title locationName employmentType compensationTierSummary }`
+   d. For **BambooHR**, the list only carries basic metadata. For each relevant item, read `id`, GET `https://{company}.bamboohr.com/careers/{id}/detail`, and extract the full JD from `result.jobOpening`. Use `jobOpeningShareUrl` as the public URL if available; otherwise use the detail URL.
+   e. For **Workday**, send a POST JSON with at least `{"appliedFacets":{},"limit":20,"offset":0,"searchText":""}` and paginate by `offset` until results exhaust
+   f. For each job extract and normalize: `{title, url, company}`
+   g. Accumulate into candidate list (dedup with Level 1)
 
-6. **Nivel 3 — WebSearch queries** (paralelo si posible):
-   Para cada query en `search_queries` con `enabled: true`:
-   a. Ejecutar WebSearch con el `query` definido
-   b. De cada resultado extraer: `{title, url, company}`
-      - **title**: del título del resultado (antes del " @ " o " | ")
-      - **url**: URL del resultado
-      - **company**: después del " @ " en el título, o extraer del dominio/path
-   c. Acumular en lista de candidatos (dedup con Nivel 1+2)
+6. **Level 3 — WebSearch queries** (parallel if possible):
+   For each query in `search_queries` with `enabled: true`:
+   a. Run WebSearch with the defined `query`
+   b. From each result extract: `{title, url, company}`
+      - **title**: from the result title (before the " @ " or " | ")
+      - **url**: URL of the result
+      - **company**: after the " @ " in the title, or extract from the domain/path
+   c. Accumulate into candidate list (dedup with Level 1+2)
 
-6. **Filtrar por título** usando `title_filter` de `portals.yml`:
-   - Al menos 1 keyword de `positive` debe aparecer en el título (case-insensitive)
-   - 0 keywords de `negative` deben aparecer
-   - `seniority_boost` keywords dan prioridad pero no son obligatorios
+6. **Filter by title** using `title_filter` from `portals.yml`:
+   - At least 1 `positive` keyword must appear in the title (case-insensitive)
+   - 0 `negative` keywords must appear
+   - `seniority_boost` keywords give priority but aren't required
 
-7. **Deduplicar** contra 3 fuentes:
-   - `scan-history.tsv` → URL exacta ya vista
-   - `applications.md` → empresa + rol normalizado ya evaluado
-   - `pipeline.md` → URL exacta ya en pendientes o procesadas
+7. **Deduplicate** against 3 sources:
+   - `scan-history.tsv` → exact URL already seen
+   - `applications.md` → company + normalized role already evaluated
+   - `pipeline.md` → exact URL already pending or processed
 
-7.5. **Verificar liveness de resultados de WebSearch (Nivel 3)** — ANTES de añadir a pipeline:
+7.5. **Verify liveness of WebSearch results (Level 3)** — BEFORE adding to pipeline:
 
-   Los resultados de WebSearch pueden estar desactualizados (Google cachea resultados durante semanas o meses). Para evitar evaluar ofertas expiradas, verificar con Playwright cada URL nueva que provenga del Nivel 3. Los Niveles 1 y 2 son inherentemente en tiempo real y no requieren esta verificación.
+   WebSearch results can be stale (Google caches results for weeks or months). To avoid evaluating expired offers, verify with Playwright every new URL coming from Level 3. Levels 1 and 2 are inherently real-time and don't require this check.
 
-   Para cada URL nueva de Nivel 3 (secuencial — NUNCA Playwright en paralelo):
-   a. `browser_navigate` a la URL
-   b. `browser_snapshot` para leer el contenido
-   c. Clasificar:
-      - **Activa**: título del puesto visible + descripción del rol + control visible de Apply/Submit/Solicitar dentro del contenido principal. No contar texto genérico de header/navbar/footer.
-      - **Expirada** (cualquiera de estas señales):
-        - URL final contiene `?error=true` (Greenhouse redirige así cuando la oferta está cerrada)
-        - Página contiene: "job no longer available" / "no longer open" / "position has been filled" / "this job has expired" / "page not found"
-        - Solo navbar y footer visibles, sin contenido JD (contenido < ~300 chars)
-   d. Si expirada: registrar en `scan-history.tsv` con status `skipped_expired` y descartar
-   e. Si activa: continuar al paso 8
+   For each new Level 3 URL (sequential — NEVER Playwright in parallel):
+   a. `browser_navigate` to the URL
+   b. `browser_snapshot` to read the content
+   c. Classify:
+      - **Active**: role title visible + role description + visible Apply/Submit/Apply Now control inside the main content. Don't count generic header/navbar/footer text.
+      - **Expired** (any of these signals):
+        - Final URL contains `?error=true` (Greenhouse redirects this way when the offer is closed)
+        - Page contains: "job no longer available" / "no longer open" / "position has been filled" / "this job has expired" / "page not found"
+        - Only navbar and footer visible, no JD content (content < ~300 chars)
+   d. If expired: register in `scan-history.tsv` with status `skipped_expired` and discard
+   e. If active: continue to step 8
 
-   **No interrumpir el scan entero si una URL falla.** Si `browser_navigate` da error (timeout, 403, etc.), marcar como `skipped_expired` y continuar con la siguiente.
+   **Don't interrupt the whole scan if a URL fails.** If `browser_navigate` errors (timeout, 403, etc.), mark as `skipped_expired` and continue with the next.
 
-8. **Para cada oferta nueva verificada que pase filtros**:
-   a. Añadir a `pipeline.md` sección "Pendientes": `- [ ] {url} | {company} | {title}`
-   b. Registrar en `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
+8. **For each new verified offer that passes filters**:
+   a. Add to `pipeline.md` "Pending" section: `- [ ] {url} | {company} | {title}`
+   b. Register in `scan-history.tsv`: `{url}\t{date}\t{query_name}\t{title}\t{company}\tadded`
 
-9. **Ofertas filtradas por título**: registrar en `scan-history.tsv` con status `skipped_title`
-10. **Ofertas duplicadas**: registrar con status `skipped_dup`
-11. **Ofertas expiradas (Nivel 3)**: registrar con status `skipped_expired`
+9. **Offers filtered by title**: register in `scan-history.tsv` with status `skipped_title`
+10. **Duplicate offers**: register with status `skipped_dup`
+11. **Expired offers (Level 3)**: register with status `skipped_expired`
 
-## Extracción de título y empresa de WebSearch results
+## Title and company extraction from WebSearch results
 
-Los resultados de WebSearch vienen en formato: `"Job Title @ Company"` o `"Job Title | Company"` o `"Job Title — Company"`.
+WebSearch results come in the format: `"Job Title @ Company"` or `"Job Title | Company"` or `"Job Title — Company"`.
 
-Patrones de extracción por portal:
+Extraction patterns per portal:
 - **Ashby**: `"Senior AI PM (Remote) @ EverAI"` → title: `Senior AI PM`, company: `EverAI`
 - **Greenhouse**: `"AI Engineer at Anthropic"` → title: `AI Engineer`, company: `Anthropic`
 - **Lever**: `"Product Manager - AI @ Temporal"` → title: `Product Manager - AI`, company: `Temporal`
 
-Regex genérico: `(.+?)(?:\s*[@|—–-]\s*|\s+at\s+)(.+?)$`
+Generic regex: `(.+?)(?:\s*[@|—–-]\s*|\s+at\s+)(.+?)$`
 
-## URLs privadas
+## Private URLs
 
-Si se encuentra una URL no accesible públicamente:
-1. Guardar el JD en `jds/{company}-{role-slug}.md`
-2. Añadir a pipeline.md como: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title}`
+If a URL isn't publicly accessible:
+1. Save the JD to `jds/{company}-{role-slug}.md`
+2. Add to pipeline.md as: `- [ ] local:jds/{company}-{role-slug}.md | {company} | {title}`
 
 ## Scan History
 
-`data/scan-history.tsv` trackea TODAS las URLs vistas:
+`data/scan-history.tsv` tracks ALL URLs seen:
 
 ```
 url	first_seen	portal	title	company	status
@@ -169,72 +169,72 @@ https://...	2026-02-10	Ashby — AI PM	SA AI	OldCo	skipped_dup
 https://...	2026-02-10	WebSearch — AI PM	PM AI	ClosedCo	skipped_expired
 ```
 
-## Resumen de salida
+## Output summary
 
 ```
 Portal Scan — {YYYY-MM-DD}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━
-Queries ejecutados: N
-Ofertas encontradas: N total
-Filtradas por título: N relevantes
-Duplicadas: N (ya evaluadas o en pipeline)
-Expiradas descartadas: N (links muertos, Nivel 3)
-Nuevas añadidas a pipeline.md: N
+Queries run: N
+Offers found: N total
+Filtered by title: N relevant
+Duplicates: N (already evaluated or in pipeline)
+Expired discarded: N (dead links, Level 3)
+New added to pipeline.md: N
 
   + {company} | {title} | {query_name}
   ...
 
-→ Ejecuta /career-ops pipeline para evaluar las nuevas ofertas.
+→ Run /career-ops pipeline to evaluate the new offers.
 ```
 
-## Gestión de careers_url
+## careers_url management
 
-Cada empresa en `tracked_companies` debe tener `careers_url` — la URL directa a su página de ofertas. Esto evita buscarlo cada vez.
+Each company in `tracked_companies` must have `careers_url` — the direct URL to their careers page. This avoids searching for it every time.
 
-**REGLA: Usa siempre la URL corporativa de la empresa; recurre al endpoint ATS solo si no existe página corporativa propia.**
+**RULE: Always use the company's corporate URL; fall back to the ATS endpoint only if no corporate page exists.**
 
-El `careers_url` debe apuntar a la página de empleo propia de la empresa siempre que esté disponible. Muchas empresas usan Workday, Greenhouse o Lever por debajo, pero exponen los IDs de las vacantes solo a través de su dominio corporativo. Usar la URL ATS directa cuando existe una página corporativa puede causar falsos errores 410 porque los IDs de los puestos no coinciden.
+`careers_url` should point to the company's own careers page whenever available. Many companies use Workday, Greenhouse, or Lever under the hood, but expose job IDs only through their corporate domain. Using the direct ATS URL when a corporate page exists can cause false 410 errors because the job IDs don't match.
 
-| ✅ Correcto (corporativa) | ❌ Incorrecto como primera opción (ATS directo) |
+| ✅ Correct (corporate) | ❌ Wrong as first choice (direct ATS) |
 |---|---|
 | `https://careers.mastercard.com` | `https://mastercard.wd1.myworkdayjobs.com` |
 | `https://openai.com/careers` | `https://job-boards.greenhouse.io/openai` |
 | `https://stripe.com/jobs` | `https://jobs.lever.co/stripe` |
 
-Fallback: si solo tienes la URL ATS directa, navega primero al sitio web de la empresa y localiza su página corporativa de empleo. Usa la URL ATS directa únicamente si la empresa no tiene página corporativa propia.
+Fallback: if you only have the direct ATS URL, first navigate to the company's website and locate its corporate careers page. Use the direct ATS URL only if the company has no corporate page of its own.
 
-**Patrones conocidos por plataforma:**
+**Known patterns per platform:**
 - **Ashby:** `https://jobs.ashbyhq.com/{slug}`
-- **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` o `https://job-boards.eu.greenhouse.io/{slug}`
+- **Greenhouse:** `https://job-boards.greenhouse.io/{slug}` or `https://job-boards.eu.greenhouse.io/{slug}`
 - **Lever:** `https://jobs.lever.co/{slug}`
-- **BambooHR:** lista `https://{company}.bamboohr.com/careers/list`; detalle `https://{company}.bamboohr.com/careers/{id}/detail`
+- **BambooHR:** list `https://{company}.bamboohr.com/careers/list`; detail `https://{company}.bamboohr.com/careers/{id}/detail`
 - **Teamtailor:** `https://{company}.teamtailor.com/jobs`
 - **Workday:** `https://{company}.{shard}.myworkdayjobs.com/{site}`
-- **Custom:** La URL propia de la empresa (ej: `https://openai.com/careers`)
+- **Custom:** The company's own URL (e.g. `https://openai.com/careers`)
 
-**Patrones de API/feed por plataforma:**
+**API/feed patterns per platform:**
 - **Ashby API:** `https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobBoardWithTeams`
-- **BambooHR API:** lista `https://{company}.bamboohr.com/careers/list`; detalle `https://{company}.bamboohr.com/careers/{id}/detail` (`result.jobOpening`)
+- **BambooHR API:** list `https://{company}.bamboohr.com/careers/list`; detail `https://{company}.bamboohr.com/careers/{id}/detail` (`result.jobOpening`)
 - **Lever API:** `https://api.lever.co/v0/postings/{company}?mode=json`
 - **Teamtailor RSS:** `https://{company}.teamtailor.com/jobs.rss`
 - **Workday API:** `https://{company}.{shard}.myworkdayjobs.com/wday/cxs/{company}/{site}/jobs`
 
-**Si `careers_url` no existe** para una empresa:
-1. Intentar el patrón de su plataforma conocida
-2. Si falla, hacer un WebSearch rápido: `"{company}" careers jobs`
-3. Navegar con Playwright para confirmar que funciona
-4. **Guardar la URL encontrada en portals.yml** para futuros scans
+**If `careers_url` doesn't exist** for a company:
+1. Try its known platform pattern
+2. If that fails, do a quick WebSearch: `"{company}" careers jobs`
+3. Navigate with Playwright to confirm it works
+4. **Save the found URL in portals.yml** for future scans
 
-**Si `careers_url` devuelve 404 o redirect:**
-1. Anotar en el resumen de salida
-2. Intentar scan_query como fallback
-3. Marcar para actualización manual
+**If `careers_url` returns 404 or redirect:**
+1. Note in the output summary
+2. Try scan_query as fallback
+3. Mark for manual update
 
-## Mantenimiento del portals.yml
+## portals.yml maintenance
 
-- **SIEMPRE guardar `careers_url`** cuando se añade una empresa nueva
-- Añadir nuevos queries según se descubran portales o roles interesantes
-- Desactivar queries con `enabled: false` si generan demasiado ruido
-- Ajustar keywords de filtrado según evolucionen los roles target
-- Añadir empresas a `tracked_companies` cuando interese seguirlas de cerca
-- Verificar `careers_url` periódicamente — las empresas cambian de plataforma ATS
+- **ALWAYS save `careers_url`** when a new company is added
+- Add new queries as you discover portals or interesting roles
+- Disable queries with `enabled: false` if they generate too much noise
+- Adjust filter keywords as target roles evolve
+- Add companies to `tracked_companies` when worth tracking closely
+- Verify `careers_url` periodically — companies change ATS platforms

--- a/modes/tracker.md
+++ b/modes/tracker.md
@@ -1,23 +1,23 @@
-# Modo: tracker — Tracker de Aplicaciones
+# Mode: tracker — Application Tracker
 
-Lee y muestra `data/applications.md`.
+Read and display `data/applications.md`.
 
-**Formato del tracker:**
+**Tracker format:**
 ```markdown
-| # | Fecha | Empresa | Rol | Score | Estado | PDF | Report |
+| # | Date | Company | Role | Score | Status | PDF | Report |
 ```
 
-Estados posibles: `Evaluada` → `Aplicado` → `Respondido` → `Contacto` → `Entrevista` → `Oferta` / `Rechazada` / `Descartada` / `NO APLICAR`
+Possible statuses: `Evaluated` → `Applied` → `Responded` → `Contacted` → `Interview` → `Offer` / `Rejected` / `Discarded` / `SKIP`
 
-- `Aplicado` = el candidato envió su candidatura
-- `Respondido` = Un recruiter/empresa contactó y el candidato respondió (inbound)
-- `Contacto` = El candidato contactó proactivamente a alguien de la empresa (outbound, ej: LinkedIn power move)
+- `Applied` = the candidate sent in their application
+- `Responded` = A recruiter/company reached out and the candidate replied (inbound)
+- `Contacted` = The candidate proactively contacted someone at the company (outbound, e.g. LinkedIn power move)
 
-Si el usuario pide actualizar un estado, editar la fila correspondiente.
+If the user asks to update a status, edit the corresponding row.
 
-Mostrar también estadísticas:
-- Total de aplicaciones
-- Por estado
-- Score promedio
-- % con PDF generado
-- % con report generado
+Also show statistics:
+- Total applications
+- By status
+- Average score
+- % with PDF generated
+- % with report generated

--- a/modes/training.md
+++ b/modes/training.md
@@ -1,27 +1,27 @@
-# Modo: training — Evaluación de Formación
+# Mode: training — Training Evaluation
 
-Para cada curso/cert que el candidato pregunte, evaluar 6 dimensiones:
+For each course/cert the candidate asks about, evaluate 6 dimensions:
 
-| Dimensión | Qué evalúa |
-|-----------|------------|
-| Alineación North Star | ¿Acerca o aleja del objetivo? |
-| Señal recruiter | ¿Qué piensan HMs al ver esto en un CV? |
-| Tiempo y esfuerzo | Semanas × horas/semana |
-| Coste de oportunidad | ¿Qué no puede hacer durante ese tiempo? |
-| Riesgos | ¿Contenido outdated? ¿Brand débil? ¿Demasiado básico? |
-| Entregable portfolio | ¿Produce un artefacto demostrable? |
+| Dimension | What it evaluates |
+|-----------|-------------------|
+| North Star alignment | Does it move toward or away from the goal? |
+| Recruiter signal | What do HMs think when they see this on a CV? |
+| Time and effort | Weeks × hours/week |
+| Opportunity cost | What can't they do during that time? |
+| Risks | Outdated content? Weak brand? Too basic? |
+| Portfolio deliverable | Does it produce a demonstrable artifact? |
 
-## Veredictos
+## Verdicts
 
-- **HACER** → plan de 4-12 semanas con entregables semanales y scoreboard
-- **NO HACER** → alternativa mejor con justificación
-- **HACER CON TIMEBOX** (máx X semanas) → plan condensado, solo lo esencial
+- **DO IT** → 4-12 week plan with weekly deliverables and a scoreboard
+- **DON'T DO IT** → better alternative with justification
+- **DO WITH TIMEBOX** (max X weeks) → condensed plan, only the essentials
 
-## Prioridad
+## Priority
 
-Formación que mejore credibilidad en "production-grade AI":
-1. Evals y testing de LLMs
-2. Observability y monitoring
+Training that improves credibility in "production-grade AI":
+1. Evals and LLM testing
+2. Observability and monitoring
 3. Cost/reliability trade-offs
-4. AI governance y safety
+4. AI governance and safety
 5. Enterprise AI architecture

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -102,7 +102,7 @@ for (let i = 0; i < lines.length; i++) {
   if (!line.startsWith('|')) continue;
 
   const parts = line.split('|').map(s => s.trim());
-  // Format: ['', '#', 'fecha', 'empresa', 'rol', 'score', 'STATUS', 'pdf', 'report', 'notas', '']
+  // Format: ['', '#', 'date', 'company', 'role', 'score', 'STATUS', 'pdf', 'report', 'notes', '']
   if (parts.length < 9) continue;
   if (parts[1] === '#' || parts[1] === '---' || parts[1] === '') continue;
 

--- a/notify-telegram.mjs
+++ b/notify-telegram.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+/**
+ * notify-telegram.mjs — Daily Telegram digest for career-ops
+ *
+ * Reads today's new entries from data/scan-history.tsv, classifies
+ * each by archetype, and sends a formatted digest to Telegram.
+ * Zero API tokens — pure heuristics + Telegram Bot API.
+ *
+ * Config (in .env):
+ *   TELEGRAM_BOT_TOKEN=bot123456:ABC-...
+ *   TELEGRAM_CHAT_ID=123456789
+ *
+ * To find your chat ID:
+ *   1. Start a conversation with @career_ops_bot_bot
+ *   2. Visit https://api.telegram.org/bot<TOKEN>/getUpdates
+ *   3. Copy "chat":{"id": <NUMBER>} from the response
+ *
+ * Usage:
+ *   node notify-telegram.mjs              # today's new matches
+ *   node notify-telegram.mjs --date 2026-05-23   # specific date
+ *   node notify-telegram.mjs --dry-run    # print message, don't send
+ */
+
+import { readFileSync, existsSync } from 'fs';
+
+// ── Config ────────────────────────────────────────────────────────────
+
+const SCAN_HISTORY_PATH = 'data/scan-history.tsv';
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function readEnv(path = '.env') {
+  if (!existsSync(path)) return {};
+  const env = {};
+  for (const line of readFileSync(path, 'utf-8').split('\n')) {
+    const m = line.match(/^([A-Z_]+)\s*=\s*(.+)$/);
+    if (m) env[m[1]] = m[2].trim().replace(/^["']|["']$/g, '');
+  }
+  return env;
+}
+
+function todayDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// Dream-tier companies — surface these first regardless of archetype
+const DREAM_TIER = new Set([
+  'anthropic', 'openai', 'google deepmind', 'mistral ai', 'cohere',
+  'lakera', 'robust intelligence', 'hiddenlayer', 'crowdstrike',
+  'sentinelone', 'ping identity', 'tempus', 'abridge', 'ambience healthcare',
+]);
+
+function isDream(company) {
+  return DREAM_TIER.has(company.toLowerCase().trim());
+}
+
+// Heuristic archetype from job title — ordered most-specific first
+function archetype(title) {
+  const t = title.toLowerCase();
+  if (/clinical ai|healthcare ai|health ai|oncology|ehr|emr/.test(t))  return 'Healthcare AI';
+  if (/ai security|llm security|model security|ai guard|ai safety/.test(t)) return 'AI Security';
+  if (/ai governance|ai policy|ai compliance/.test(t))                  return 'AI Governance';
+  if (/llm|llmops|mlops|applied ai|ai platform|ai infra|agentic|genai|generative ai|mcp/.test(t)) return 'AI Platform';
+  if (/agent/.test(t))                                                  return 'AI Agent';
+  if (/identity|zero trust|sso|saml/.test(t))                          return 'Identity/IAM';
+  if (/cloud security|devsecops|appsec|security engineer|cybersecurity|cspm|siem|\biam\b/.test(t)) return 'Cloud Security';
+  if (/site reliability|sre|reliability engineer|platform engineer/.test(t)) return 'SRE/Platform';
+  if (/solutions architect|forward deployed|customer engineer|deployed engineer/.test(t)) return 'Solutions Arch';
+  if (/automation engineer/.test(t))                                    return 'Automation';
+  if (/\bai\b|machine learning|\bml\b/.test(t))                         return 'AI/ML';
+  return 'Engineering';
+}
+
+// Truncate URLs for display (keep portal domain + ID)
+function shortUrl(url) {
+  try {
+    const u = new URL(url);
+    return u.host.replace('job-boards.', '').replace('jobs.', '') + u.pathname.slice(0, 40);
+  } catch {
+    return url.slice(0, 60);
+  }
+}
+
+// ── Telegram sender ───────────────────────────────────────────────────
+
+async function sendTelegram(token, chatId, text) {
+  const resp = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text,
+      parse_mode: 'HTML',
+      disable_web_page_preview: true,
+    }),
+  });
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({}));
+    throw new Error(`Telegram error ${resp.status}: ${JSON.stringify(err)}`);
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const dateIdx = args.indexOf('--date');
+const dateArg = args.find(a => a.startsWith('--date='))?.split('=')[1]
+  ?? (dateIdx !== -1 ? args[dateIdx + 1] : undefined);
+const targetDate = dateArg || todayDate();
+
+const env = readEnv('.env');
+const TOKEN = env.TELEGRAM_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN;
+const CHAT_ID = env.TELEGRAM_CHAT_ID || process.env.TELEGRAM_CHAT_ID;
+
+if (!dryRun && (!TOKEN || !CHAT_ID)) {
+  console.error('Missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID in .env');
+  console.error('Add them to .env or set as env vars. Run with --dry-run to test without sending.');
+  process.exit(1);
+}
+
+if (!existsSync(SCAN_HISTORY_PATH)) {
+  console.log('No scan history yet — run `node scan.mjs` first.');
+  process.exit(0);
+}
+
+// Parse scan-history.tsv — header: url\tfirst_seen\tportal\ttitle\tcompany\tstatus
+const rows = readFileSync(SCAN_HISTORY_PATH, 'utf-8')
+  .split('\n')
+  .slice(1)               // skip header
+  .filter(Boolean)
+  .map(line => {
+    const [url, first_seen, portal, title, company] = line.split('\t');
+    return { url, first_seen, portal, title: (title || '').trim(), company: (company || '').trim() };
+  })
+  .filter(r => r.first_seen === targetDate);
+
+if (rows.length === 0) {
+  console.log(`No new matches for ${targetDate} — nothing to send.`);
+  process.exit(0);
+}
+
+// Classify + sort: dream-tier first, then by archetype
+const classified = rows.map(r => ({
+  ...r,
+  arch: archetype(r.title),
+  dream: isDream(r.company),
+}));
+classified.sort((a, b) => {
+  if (a.dream !== b.dream) return a.dream ? -1 : 1;
+  return a.arch.localeCompare(b.arch);
+});
+
+// Build message (cap at 20 jobs to stay under Telegram's 4096-char limit)
+const MAX_JOBS = 20;
+const shown = classified.slice(0, MAX_JOBS);
+const overflow = classified.length - shown.length;
+
+const dreamJobs = shown.filter(j => j.dream);
+const otherJobs = shown.filter(j => !j.dream);
+
+let msg = `<b>career-ops scan · ${targetDate}</b>\n`;
+msg += `${classified.length} new match${classified.length !== 1 ? 'es' : ''}\n`;
+msg += '━━━━━━━━━━━━━━━━━━━━━━\n';
+
+if (dreamJobs.length > 0) {
+  msg += '\n⭐ <b>DREAM TIER</b>\n';
+  for (const j of dreamJobs) {
+    msg += `• <b>${j.company}</b> — ${j.title}\n`;
+    msg += `  [${j.arch}] <a href="${j.url}">${shortUrl(j.url)}</a>\n`;
+  }
+}
+
+if (otherJobs.length > 0) {
+  let lastArch = '';
+  for (const j of otherJobs) {
+    if (j.arch !== lastArch) {
+      msg += `\n<b>${j.arch}</b>\n`;
+      lastArch = j.arch;
+    }
+    msg += `• <b>${j.company}</b> — ${j.title}\n`;
+    msg += `  <a href="${j.url}">${shortUrl(j.url)}</a>\n`;
+  }
+}
+
+if (overflow > 0) {
+  msg += `\n<i>+${overflow} more — check pipeline.md</i>\n`;
+}
+
+msg += `\n<i>→ /career-ops pipeline to evaluate</i>`;
+
+if (dryRun) {
+  console.log('\n── DRY RUN — message that would be sent ──\n');
+  console.log(msg);
+  console.log('\n──────────────────────────────────────────');
+} else {
+  await sendTelegram(TOKEN, CHAT_ID, msg);
+  console.log(`✓ Sent digest to Telegram: ${classified.length} matches for ${targetDate}`);
+}

--- a/notify-telegram.mjs
+++ b/notify-telegram.mjs
@@ -22,7 +22,8 @@
  *   node notify-telegram.mjs --dry-run    # print message, don't send
  */
 
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
 
 // ── Config ────────────────────────────────────────────────────────────
 
@@ -95,10 +96,11 @@ async function sendTelegram(token, chatId, text) {
       disable_web_page_preview: true,
     }),
   });
+  const data = await resp.json().catch(() => ({}));
   if (!resp.ok) {
-    const err = await resp.json().catch(() => ({}));
-    throw new Error(`Telegram error ${resp.status}: ${JSON.stringify(err)}`);
+    throw new Error(`Telegram error ${resp.status}: ${JSON.stringify(data)}`);
   }
+  return data.result; // includes message_id for reply tracking
 }
 
 // ── Main ──────────────────────────────────────────────────────────────
@@ -157,17 +159,21 @@ const MAX_JOBS = 20;
 const shown = classified.slice(0, MAX_JOBS);
 const overflow = classified.length - shown.length;
 
-const dreamJobs = shown.filter(j => j.dream);
-const otherJobs = shown.filter(j => !j.dream);
+// Number all jobs sequentially for "apply #N" replies
+let jobIndex = 0;
 
 let msg = `<b>career-ops scan · ${targetDate}</b>\n`;
 msg += `${classified.length} new match${classified.length !== 1 ? 'es' : ''}\n`;
 msg += '━━━━━━━━━━━━━━━━━━━━━━\n';
 
+const dreamJobs = shown.filter(j => j.dream);
+const otherJobs = shown.filter(j => !j.dream);
+
 if (dreamJobs.length > 0) {
   msg += '\n⭐ <b>DREAM TIER</b>\n';
   for (const j of dreamJobs) {
-    msg += `• <b>${j.company}</b> — ${j.title}\n`;
+    jobIndex++;
+    msg += `<b>#${jobIndex}</b> <b>${j.company}</b> — ${j.title}\n`;
     msg += `  [${j.arch}] <a href="${j.url}">${shortUrl(j.url)}</a>\n`;
   }
 }
@@ -179,7 +185,8 @@ if (otherJobs.length > 0) {
       msg += `\n<b>${j.arch}</b>\n`;
       lastArch = j.arch;
     }
-    msg += `• <b>${j.company}</b> — ${j.title}\n`;
+    jobIndex++;
+    msg += `<b>#${jobIndex}</b> <b>${j.company}</b> — ${j.title}\n`;
     msg += `  <a href="${j.url}">${shortUrl(j.url)}</a>\n`;
   }
 }
@@ -188,13 +195,35 @@ if (overflow > 0) {
   msg += `\n<i>+${overflow} more — check pipeline.md</i>\n`;
 }
 
-msg += `\n<i>→ /career-ops pipeline to evaluate</i>`;
+msg += `\n<i>Reply "apply #N" to apply · "status" for pipeline info</i>`;
+
+// Build structured digest for telegram-listener.mjs
+const digestData = {
+  date: targetDate,
+  message_id: null, // populated after send
+  jobs: shown.map((j, i) => ({
+    index: i + 1,
+    url: j.url,
+    company: j.company,
+    title: j.title,
+    archetype: j.arch,
+    dream: j.dream,
+    score: null, // populated after evaluation
+  })),
+};
 
 if (dryRun) {
   console.log('\n── DRY RUN — message that would be sent ──\n');
   console.log(msg);
   console.log('\n──────────────────────────────────────────');
+  console.log(`\nWould save ${digestData.jobs.length} jobs to data/last-digest.json`);
 } else {
-  await sendTelegram(TOKEN, CHAT_ID, msg);
+  const result = await sendTelegram(TOKEN, CHAT_ID, msg);
   console.log(`✓ Sent digest to Telegram: ${classified.length} matches for ${targetDate}`);
+
+  // Save digest for telegram-listener.mjs "apply #N" lookups
+  digestData.message_id = result?.message_id || null;
+  mkdirSync('data', { recursive: true });
+  writeFileSync(join('data', 'last-digest.json'), JSON.stringify(digestData, null, 2));
+  console.log(`✓ Saved last-digest.json: ${digestData.jobs.length} jobs`);
 }

--- a/openrouter-eval.mjs
+++ b/openrouter-eval.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * openrouter-eval.mjs — OpenRouter-powered job evaluator for career-ops. Library + CLI.
+ *
+ * The keyless-of-Anthropic eval path: runs the full A–G evaluation on CT 203 (no Anthropic
+ * API key — Claude Max ≠ API access) via Patrick's OpenRouter key. This is the missing
+ * "evaluate" step the deployed scanner never ran (memory: project_scanner_no_eval).
+ * A cousin of gemini-eval.mjs with two fixes: (1) ALSO reads modes/_profile.md (Patrick's
+ * HARD rules — location, $160K floor, archetypes, security-first identity), and (2) pre-gates
+ * location via lib/location-gate.mjs (JD-body aware) so disqualified roles cost zero tokens.
+ *
+ * As a LIBRARY (imported by triage.mjs):
+ *   evaluateJD({ jdText, company, url, locVerdict, model }) -> { result, text }
+ *   buildReportMarkdown({ result, text, url, locVerdict, model, date }) -> string
+ *   jobToJdText(job), nextReportNumber(), slugify(), REPORTS_DIR
+ *
+ * As a CLI:
+ *   node openrouter-eval.mjs "<JD text>"
+ *   node openrouter-eval.mjs --file <path>
+ *   node openrouter-eval.mjs --url <ats-url> [--json] [--no-save] [--company NAME] [--model NAME]
+ *
+ * Key: OPENROUTER_API_KEY env, or ~/.secrets/openrouter.txt. Default model: anthropic/claude-haiku-4.5.
+ */
+
+import { readFileSync, existsSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { homedir } from 'os';
+import { fetchJob } from './lib/ats-fetch.mjs';
+import { assessLocation } from './lib/location-gate.mjs';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+export const REPORTS_DIR = join(ROOT, 'reports');
+const P = {
+  shared:  join(ROOT, 'modes', '_shared.md'),
+  oferta:  join(ROOT, 'modes', 'oferta.md'),
+  profile: join(ROOT, 'modes', '_profile.md'),
+  cv:      join(ROOT, 'cv.md'),
+  digest:  join(ROOT, 'article-digest.md'),
+};
+export const DEFAULT_MODEL = process.env.OPENROUTER_MODEL || 'anthropic/claude-haiku-4.5';
+
+export function loadKey() {
+  if (process.env.OPENROUTER_API_KEY) return process.env.OPENROUTER_API_KEY.trim();
+  const f = join(homedir(), '.secrets', 'openrouter.txt');
+  if (existsSync(f)) return readFileSync(f, 'utf-8').trim();
+  throw new Error('No OpenRouter key (set OPENROUTER_API_KEY or ~/.secrets/openrouter.txt)');
+}
+
+const readFile = (p, label) => existsSync(p) ? readFileSync(p, 'utf-8').trim() : `[${label} not found]`;
+
+export function nextReportNumber() {
+  if (!existsSync(REPORTS_DIR)) return '001';
+  const n = readdirSync(REPORTS_DIR).filter(f => /^\d{3}-/.test(f)).map(f => parseInt(f.slice(0, 3))).filter(x => !isNaN(x));
+  return n.length ? String(Math.max(...n) + 1).padStart(3, '0') : '001';
+}
+export const slugify = (s) => (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 44);
+export const jobToJdText = (job) =>
+  `Company: ${job.company}\nTitle: ${job.title}\nLocation: ${job.location}${job.comp ? `\nComp: ${job.comp}` : ''}\n\n${job.text}`;
+
+function buildSystemPrompt(locVerdict) {
+  return `You are career-ops, evaluating a job offer against Patrick's CV using the A–G scoring system. Follow the methodology exactly.
+
+═══ SYSTEM (_shared.md) ═══
+${readFile(P.shared, '_shared.md')}
+
+═══ USER HARD RULES & ARCHETYPES (_profile.md) — THESE OVERRIDE EVERYTHING ═══
+${readFile(P.profile, '_profile.md')}
+
+═══ EVALUATION MODE (oferta.md) ═══
+${readFile(P.oferta, 'oferta.md')}
+
+═══ CANDIDATE CV (cv.md) ═══
+${readFile(P.cv, 'cv.md')}
+
+═══ PROOF POINTS (article-digest.md) ═══
+${readFile(P.digest, 'article-digest.md')}
+
+═══ OPERATING RULES ═══
+1. Reports in ENGLISH. Apply the security-engineer-first lens from _profile.md.
+2. Enforce HARD rules: location policy (Denver-only/remote; non-Denver onsite or non-US = SKIP 1.0) and the $160K comp floor (if comp_max < $160K → 1-line SKIP, no full eval).
+3. No WebSearch/Playwright here: estimate comp from training data (note as estimate); judge legitimacy from JD text only.
+${locVerdict ? `4. LOCATION PRE-CLEARED by the orchestrator: verdict="${locVerdict.verdict}", note="${locVerdict.reason}". Trust this; if "confirm", flag "confirm remote" in Block A but do not auto-skip.` : ''}
+5. START your reply with EXACTLY this machine-readable block (so it survives truncation), THEN write the full A–G report below it:
+---SCORE_SUMMARY---
+COMPANY: <name>
+ROLE: <title>
+SCORE: <decimal e.g. 4.2>
+ARCHETYPE: <one of the four from _profile.md>
+LEGITIMACY: <High Confidence | Proceed with Caution | Suspicious>
+---END_SUMMARY---`;
+}
+
+function parseSummary(text, fallbackCompany, url, locVerdict) {
+  const sm = text.match(/---SCORE_SUMMARY---\s*([\s\S]*?)---END_SUMMARY---/);
+  const get = (k) => { const m = (sm?.[1] || '').match(new RegExp(`${k}:\\s*(.+)`)); return m ? m[1].trim() : 'unknown'; };
+  const c = get('COMPANY');
+  return {
+    company: c !== 'unknown' ? c : (fallbackCompany || 'unknown'),
+    role: get('ROLE'), score: get('SCORE'), archetype: get('ARCHETYPE'),
+    legitimacy: get('LEGITIMACY'), url: url || undefined, location_verdict: locVerdict?.verdict,
+  };
+}
+
+/** Core evaluator — one OpenRouter call. Returns { result, text }. */
+export async function evaluateJD({ jdText, company, url, locVerdict = null, model = DEFAULT_MODEL }) {
+  const r = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${loadKey()}`, 'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://moorelab.cloud', 'X-Title': 'career-ops' },
+    body: JSON.stringify({
+      model, temperature: 0.4, max_tokens: 12000,
+      messages: [
+        { role: 'system', content: buildSystemPrompt(locVerdict) },
+        { role: 'user', content: `JOB DESCRIPTION TO EVALUATE:\n\n${jdText}` },
+      ],
+    }),
+  });
+  if (!r.ok) throw new Error(`OpenRouter ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  const j = await r.json();
+  const text = j.choices?.[0]?.message?.content || '';
+  if (!text) throw new Error('Empty response from OpenRouter');
+  return { result: parseSummary(text, company, url, locVerdict), text };
+}
+
+export function buildReportMarkdown({ result, text, url, locVerdict, model = DEFAULT_MODEL, date }) {
+  return `# Evaluation: ${result.company} — ${result.role}
+
+**Date:** ${date}
+**URL:** ${url || 'n/a'}
+**Archetype:** ${result.archetype}
+**Score:** ${result.score}/5
+**Legitimacy:** ${result.legitimacy}
+**PDF:** pending
+**Tool:** OpenRouter (${model})${locVerdict ? `\n**Location gate:** ${locVerdict.verdict} — ${locVerdict.reason}` : ''}
+
+---
+
+${text.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').trim()}
+`;
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+async function main() {
+  const args = process.argv.slice(2);
+  if (!args.length || args[0] === '--help' || args[0] === '-h') {
+    console.log(`career-ops OpenRouter evaluator
+  node openrouter-eval.mjs "<JD text>"
+  node openrouter-eval.mjs --file <path>
+  node openrouter-eval.mjs --url <ats-url> [--json] [--no-save] [--company NAME] [--model NAME]
+  Key: OPENROUTER_API_KEY or ~/.secrets/openrouter.txt`);
+    return;
+  }
+  let jdText = '', url = '', company = '', model = DEFAULT_MODEL, save = true, jsonOnly = false;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--file') jdText = readFileSync(args[++i], 'utf-8').trim();
+    else if (a === '--url') url = args[++i];
+    else if (a === '--company') company = args[++i];
+    else if (a === '--model') model = args[++i];
+    else if (a === '--no-save') save = false;
+    else if (a === '--json') jsonOnly = true;
+    else if (!a.startsWith('--')) jdText += (jdText ? '\n' : '') + a;
+  }
+  const log = (...m) => { if (!jsonOnly) console.log(...m); };
+
+  let locVerdict = null;
+  if (url) {
+    log(`🌐 Fetching ${url} …`);
+    const job = await fetchJob(url, company ? { company } : {});
+    if (!job.ok) { console.error(`❌ fetch failed: ${job.error}`); process.exit(1); }
+    company = company || job.company;
+    jdText = jobToJdText(job);
+    locVerdict = assessLocation(job);
+    log(`📍 Location gate: ${locVerdict.verdict} (${locVerdict.reason})`);
+    if (locVerdict.verdict === 'skip') {
+      const out = { company: job.company, role: job.title, score: 1.0, archetype: 'n/a',
+        legitimacy: 'n/a', verdict: 'SKIP-location', reason: locVerdict.reason };
+      if (jsonOnly) console.log(JSON.stringify(out));
+      else log(`\n⛔ HARD location SKIP (1.0) — ${locVerdict.reason}\n   No LLM tokens spent.`);
+      return;
+    }
+  }
+  if (!jdText) { console.error('❌ No JD provided.'); process.exit(1); }
+
+  log(`🤖 Evaluating via OpenRouter (${model}) …`);
+  let result, text;
+  try { ({ result, text } = await evaluateJD({ jdText, company, url, locVerdict, model })); }
+  catch (e) { console.error('❌', e.message); process.exit(1); }
+
+  if (jsonOnly) { console.log(JSON.stringify(result)); return; }
+
+  console.log('\n' + '═'.repeat(60) + `\n  CAREER-OPS EVALUATION — OpenRouter (${model})\n` + '═'.repeat(60) + '\n');
+  console.log(text);
+
+  if (save) {
+    if (!existsSync(REPORTS_DIR)) mkdirSync(REPORTS_DIR, { recursive: true });
+    const num = nextReportNumber();
+    const date = process.env.EVAL_DATE || new Date().toISOString().split('T')[0];
+    const fn = `${num}-${slugify(result.company + '-' + result.role)}-${date}.md`;
+    writeFileSync(join(REPORTS_DIR, fn), buildReportMarkdown({ result, text, url, locVerdict, model, date }), 'utf-8');
+    console.log(`\n✅ Report saved: reports/${fn}`);
+    console.log(`📊 TSV → batch/tracker-additions/${num}-${slugify(result.company + '-' + result.role)}.tsv:`);
+    console.log(`   ${num}\t${date}\t${result.company}\t${result.role}\tEvaluated\t${result.score}/5\t❌\t[${num}](reports/${fn})\t<note>`);
+  }
+  console.log(`\n  Score: ${result.score}/5 | Archetype: ${result.archetype} | Legitimacy: ${result.legitimacy}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/openrouter-eval.mjs
+++ b/openrouter-eval.mjs
@@ -38,7 +38,11 @@ const P = {
   cv:      join(ROOT, 'cv.md'),
   digest:  join(ROOT, 'article-digest.md'),
 };
-export const DEFAULT_MODEL = process.env.OPENROUTER_MODEL || 'anthropic/claude-haiku-4.5';
+// Sonnet 5 over Haiku 4.5: ~$0.09/eval at current volume (1–3 survivors/day). Haiku
+// scored 4.8 on hard-policy violations even with the rules in-prompt (2026-06/07 misses);
+// the deterministic enforcePolicy() cap is the real guard, but a stronger judge means
+// fewer wrong-side-of-threshold scores on the roles that DO pass the gates.
+export const DEFAULT_MODEL = process.env.OPENROUTER_MODEL || 'anthropic/claude-sonnet-5';
 
 export function loadKey() {
   if (process.env.OPENROUTER_API_KEY) return process.env.OPENROUTER_API_KEY.trim();
@@ -80,7 +84,7 @@ ${readFile(P.digest, 'article-digest.md')}
 1. Reports in ENGLISH. Apply the security-engineer-first lens from _profile.md.
 2. Enforce HARD rules: location policy (Denver-only/remote; non-Denver onsite or non-US = SKIP 1.0) and the $160K comp floor (if comp_max < $160K → 1-line SKIP, no full eval).
 3. No WebSearch/Playwright here: estimate comp from training data (note as estimate); judge legitimacy from JD text only.
-${locVerdict ? `4. LOCATION PRE-CLEARED by the orchestrator: verdict="${locVerdict.verdict}", note="${locVerdict.reason}". Trust this; if "confirm", flag "confirm remote" in Block A but do not auto-skip.` : ''}
+${buildLocationRule(locVerdict)}
 5. START your reply with EXACTLY this machine-readable block (so it survives truncation), THEN write the full A–G report below it:
 ---SCORE_SUMMARY---
 COMPANY: <name>
@@ -88,7 +92,66 @@ ROLE: <title>
 SCORE: <decimal e.g. 4.2>
 ARCHETYPE: <one of the four from _profile.md>
 LEGITIMACY: <High Confidence | Proceed with Caution | Suspicious>
----END_SUMMARY---`;
+LOCATION_POLICY: <REMOTE_US | DENVER_METRO | NON_DENVER_OFFICE | NON_US | TRAVEL_REQUIRED | UNCLEAR>
+LOCATION_EVIDENCE: <the JD phrase you based LOCATION_POLICY on, max 15 words, or "none">
+COMP_MAX_K: <max base salary in $K as integer, e.g. 250, or UNKNOWN>
+---END_SUMMARY---
+
+LOCATION_POLICY definitions — judge from the JD text ONLY, no benefit of the doubt:
+- REMOTE_US: genuinely remote for US employees, NO required office cadence, NO required travel to specific offices.
+- DENVER_METRO: office/hybrid within ~30min of Denver, CO.
+- NON_DENVER_OFFICE: any required on-site or hybrid presence (any %, any days/week) at a non-Denver office.
+- NON_US: role is located outside the US or not US-remote-eligible.
+- TRAVEL_REQUIRED: "remote-friendly" but with required recurring travel to non-Denver offices (e.g. "Remote-Friendly (Travel-Required)", "25% of time in one of our offices").
+- UNCLEAR: the JD genuinely does not say. Do NOT guess REMOTE_US from an isRemote flag or vibes.`;
+}
+
+function buildLocationRule(locVerdict) {
+  const v = locVerdict?.verdict;
+  if (v === 'pass-remote' || v === 'pass-denver') {
+    return `4. LOCATION PRE-CLEARED by the orchestrator: verdict="${v}", note="${locVerdict.reason}". Trust this for Block A.`;
+  }
+  if (locVerdict) {
+    return `4. LOCATION NOT VERIFIED (gate verdict="${v}": ${locVerdict.reason}). You MUST determine the working-location policy from the JD text yourself and enforce the HARD location rule: any required office presence or recurring travel to a non-Denver-metro office, or a non-US location, means SCORE: 1.0 and the matching LOCATION_POLICY value. If you cannot tell, use UNCLEAR — never assume remote.`;
+  }
+  return `4. No location pre-check was run. Determine the working-location policy from the JD text and enforce the HARD location rule (non-Denver office/hybrid/travel or non-US → SCORE: 1.0).`;
+}
+
+/**
+ * Deterministic policy enforcement AFTER the LLM eval — the model advises, this decides.
+ * Rationale: on 2026-06-11/13 Haiku scored 4.8 on roles whose own reports said "Zürich,
+ * 25% on-site" and "Remote-Friendly (Travel-Required)". Never again: a policy-violating
+ * LOCATION_POLICY caps the score to 1.0/SKIP in code, and an UNCLEAR location caps below
+ * the 4.0 apply threshold, regardless of what the model scored.
+ */
+export function enforcePolicy(result, locVerdict = null) {
+  const gatePassed = locVerdict && (locVerdict.verdict === 'pass-remote' || locVerdict.verdict === 'pass-denver');
+  const lp = (result.location_policy || 'UNCLEAR').toUpperCase();
+  const score = parseFloat(result.score);
+  result.status = 'Evaluated';
+
+  if (['NON_DENVER_OFFICE', 'NON_US', 'TRAVEL_REQUIRED'].includes(lp)) {
+    if (!(score <= 1.0)) result.original_score = result.score;
+    result.score = '1.0';
+    result.status = 'SKIP';
+    result.policy_reason = `HARD LOCATION SKIP (${lp}${result.location_evidence && result.location_evidence !== 'none' ? `: "${result.location_evidence}"` : ''})`;
+  } else if (lp === 'UNCLEAR' && !gatePassed && score > 3.9) {
+    result.original_score = result.score;
+    result.score = '3.9';
+    result.needs_confirm = true;
+    result.policy_reason = 'Location UNCLEAR and gate did not pass — capped below apply threshold until location is confirmed';
+  } else if (!gatePassed && locVerdict?.verdict === 'confirm') {
+    result.needs_confirm = true;
+  }
+
+  const compK = parseInt(result.comp_max_k, 10);
+  if (!isNaN(compK) && compK > 0 && compK < 160 && result.status !== 'SKIP') {
+    if (!result.original_score) result.original_score = result.score;
+    result.score = '1.0';
+    result.status = 'SKIP';
+    result.policy_reason = `Comp max $${compK}K below $160K floor`;
+  }
+  return result;
 }
 
 function parseSummary(text, fallbackCompany, url, locVerdict) {
@@ -99,6 +162,8 @@ function parseSummary(text, fallbackCompany, url, locVerdict) {
     company: c !== 'unknown' ? c : (fallbackCompany || 'unknown'),
     role: get('ROLE'), score: get('SCORE'), archetype: get('ARCHETYPE'),
     legitimacy: get('LEGITIMACY'), url: url || undefined, location_verdict: locVerdict?.verdict,
+    location_policy: get('LOCATION_POLICY'), location_evidence: get('LOCATION_EVIDENCE'),
+    comp_max_k: get('COMP_MAX_K'),
   };
 }
 
@@ -109,7 +174,9 @@ export async function evaluateJD({ jdText, company, url, locVerdict = null, mode
     headers: { 'Authorization': `Bearer ${loadKey()}`, 'Content-Type': 'application/json',
       'HTTP-Referer': 'https://moorelab.cloud', 'X-Title': 'career-ops' },
     body: JSON.stringify({
-      model, temperature: 0.4, max_tokens: 12000,
+      // 0.2, not 0.4: at 0.4 the same JD scored 3.7 and 4.2 in back-to-back runs —
+      // enough wobble to flip the ≥4.0 alert threshold. Lower temp = stabler scores.
+      model, temperature: 0.2, max_tokens: 12000,
       messages: [
         { role: 'system', content: buildSystemPrompt(locVerdict) },
         { role: 'user', content: `JOB DESCRIPTION TO EVALUATE:\n\n${jdText}` },
@@ -120,7 +187,8 @@ export async function evaluateJD({ jdText, company, url, locVerdict = null, mode
   const j = await r.json();
   const text = j.choices?.[0]?.message?.content || '';
   if (!text) throw new Error('Empty response from OpenRouter');
-  return { result: parseSummary(text, company, url, locVerdict), text };
+  const result = enforcePolicy(parseSummary(text, company, url, locVerdict), locVerdict);
+  return { result, text };
 }
 
 export function buildReportMarkdown({ result, text, url, locVerdict, model = DEFAULT_MODEL, date }) {
@@ -132,7 +200,7 @@ export function buildReportMarkdown({ result, text, url, locVerdict, model = DEF
 **Score:** ${result.score}/5
 **Legitimacy:** ${result.legitimacy}
 **PDF:** pending
-**Tool:** OpenRouter (${model})${locVerdict ? `\n**Location gate:** ${locVerdict.verdict} — ${locVerdict.reason}` : ''}
+**Tool:** OpenRouter (${model})${locVerdict ? `\n**Location gate:** ${locVerdict.verdict} — ${locVerdict.reason}` : ''}${result.location_policy ? `\n**Location policy (eval):** ${result.location_policy}${result.location_evidence && result.location_evidence !== 'none' ? ` — "${result.location_evidence}"` : ''}` : ''}${result.policy_reason ? `\n**⛔ POLICY CAP:** score forced to ${result.score} (model scored ${result.original_score ?? result.score}) — ${result.policy_reason}` : ''}
 
 ---
 
@@ -201,7 +269,7 @@ async function main() {
     writeFileSync(join(REPORTS_DIR, fn), buildReportMarkdown({ result, text, url, locVerdict, model, date }), 'utf-8');
     console.log(`\n✅ Report saved: reports/${fn}`);
     console.log(`📊 TSV → batch/tracker-additions/${num}-${slugify(result.company + '-' + result.role)}.tsv:`);
-    console.log(`   ${num}\t${date}\t${result.company}\t${result.role}\tEvaluated\t${result.score}/5\t❌\t[${num}](reports/${fn})\t<note>`);
+    console.log(`   ${num}\t${date}\t${result.company}\t${result.role}\t${result.status || 'Evaluated'}\t${result.score}/5\t❌\t[${num}](reports/${fn})\t<note>`);
   }
   console.log(`\n  Score: ${result.score}/5 | Archetype: ${result.archetype} | Legitimacy: ${result.legitimacy}\n`);
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "auto:prepare": "node auto-pipeline.mjs --prepare-only",
     "auto:cl": "node auto-pipeline.mjs --cover-letters",
     "auto:notify": "node auto-pipeline.mjs --notify",
-    "gemini:eval": "node gemini-eval.mjs"
+    "gemini:eval": "node gemini-eval.mjs",
+    "prep": "node generate-interview-prep.mjs",
+    "prep:check": "node generate-interview-prep.mjs --check",
+    "followup": "node followup-check.mjs"
   },
   "keywords": [
     "ai",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "rollback": "node update-system.mjs rollback",
     "liveness": "node check-liveness.mjs",
     "scan": "node scan.mjs",
+    "auto": "node auto-pipeline.mjs",
+    "auto:prepare": "node auto-pipeline.mjs --prepare-only",
+    "auto:cl": "node auto-pipeline.mjs --cover-letters",
+    "auto:notify": "node auto-pipeline.mjs --notify",
     "gemini:eval": "node gemini-eval.mjs"
   },
   "keywords": [

--- a/scan-builtin.mjs
+++ b/scan-builtin.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+
+/**
+ * scan-builtin.mjs — Playwright-based scanner for Built In Colorado
+ *
+ * Built In Colorado doesn't have a public API, so this uses Playwright
+ * to scrape job listings from their search pages. Applies the same
+ * title filters from portals.yml and deduplicates against scan-history.tsv.
+ *
+ * Usage:
+ *   node scan-builtin.mjs                  # scan all configured search URLs
+ *   node scan-builtin.mjs --dry-run        # preview without writing files
+ *
+ * Built In Colorado search URL format:
+ *   https://www.builtincolorado.com/jobs/remote/dev-engineering+security
+ *   https://www.builtincolorado.com/jobs?search=security+engineer
+ *
+ * Designed to run as part of daily-pipeline.sh on CT 203.
+ * Requires: Playwright with Chromium (same as apply-auto.mjs)
+ */
+
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
+import yaml from 'js-yaml';
+
+const PORTALS_PATH = 'portals.yml';
+const SCAN_HISTORY_PATH = 'data/scan-history.tsv';
+const PIPELINE_PATH = 'data/pipeline.md';
+const APPLICATIONS_PATH = 'data/applications.md';
+
+mkdirSync('data', { recursive: true });
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+
+// ── Built In Colorado search URLs ────────────────────────────────────
+// These are the category/search pages to scrape.
+// Each yields multiple job cards.
+
+const SEARCH_PAGES = [
+  {
+    name: 'Security Engineering',
+    url: 'https://www.builtincolorado.com/jobs?search=security+engineer&per_page=50',
+  },
+  {
+    name: 'Cloud Security',
+    url: 'https://www.builtincolorado.com/jobs?search=cloud+security&per_page=50',
+  },
+  {
+    name: 'AI Engineer',
+    url: 'https://www.builtincolorado.com/jobs?search=AI+engineer&per_page=50',
+  },
+  {
+    name: 'DevSecOps / SRE',
+    url: 'https://www.builtincolorado.com/jobs?search=DevSecOps+OR+SRE+OR+reliability&per_page=50',
+  },
+  {
+    name: 'Platform Engineer',
+    url: 'https://www.builtincolorado.com/jobs?search=platform+engineer&per_page=50',
+  },
+  {
+    name: 'Infrastructure Security',
+    url: 'https://www.builtincolorado.com/jobs?search=infrastructure+security&per_page=50',
+  },
+  {
+    name: 'Cybersecurity',
+    url: 'https://www.builtincolorado.com/jobs?search=cybersecurity&per_page=50',
+  },
+];
+
+// ── Title filter (reuse from portals.yml) ────────────────────────────
+
+function buildTitleFilter() {
+  if (!existsSync(PORTALS_PATH)) return () => true;
+  const config = yaml.load(readFileSync(PORTALS_PATH, 'utf-8'));
+  const titleFilter = config.title_filter || {};
+  const positive = (titleFilter.positive || []).map(k => k.toLowerCase());
+  const negative = (titleFilter.negative || []).map(k => k.toLowerCase());
+
+  return (title) => {
+    const lower = title.toLowerCase();
+    const hasPositive = positive.length === 0 || positive.some(k => lower.includes(k));
+    const hasNegative = negative.some(k => lower.includes(k));
+    return hasPositive && !hasNegative;
+  };
+}
+
+// ── Dedup (same logic as scan.mjs) ───────────────────────────────────
+
+function loadSeenUrls() {
+  const seen = new Set();
+
+  if (existsSync(SCAN_HISTORY_PATH)) {
+    const lines = readFileSync(SCAN_HISTORY_PATH, 'utf-8').split('\n');
+    for (const line of lines.slice(1)) {
+      const url = line.split('\t')[0];
+      if (url) seen.add(url);
+    }
+  }
+
+  if (existsSync(PIPELINE_PATH)) {
+    const text = readFileSync(PIPELINE_PATH, 'utf-8');
+    for (const match of text.matchAll(/- \[[ x]\] (https?:\/\/\S+)/g)) {
+      seen.add(match[1]);
+    }
+  }
+
+  if (existsSync(APPLICATIONS_PATH)) {
+    const text = readFileSync(APPLICATIONS_PATH, 'utf-8');
+    for (const match of text.matchAll(/https?:\/\/[^\s|)]+/g)) {
+      seen.add(match[0]);
+    }
+  }
+
+  return seen;
+}
+
+// ── Pipeline writer ──────────────────────────────────────────────────
+
+function appendToPipeline(offers) {
+  if (offers.length === 0) return;
+
+  let text = readFileSync(PIPELINE_PATH, 'utf-8');
+  const marker = '## Pending';
+  const legacyMarker = '## Pendientes';
+  let idx = text.indexOf(marker);
+  if (idx === -1) idx = text.indexOf(legacyMarker);
+
+  if (idx === -1) {
+    let procIdx = text.indexOf('## Processed');
+    if (procIdx === -1) procIdx = text.indexOf('## Procesadas');
+    const insertAt = procIdx === -1 ? text.length : procIdx;
+    const block = `\n${marker}\n\n` + offers.map(o =>
+      `- [ ] ${o.url} | ${o.company} | ${o.title}`
+    ).join('\n') + '\n\n';
+    text = text.slice(0, insertAt) + block + text.slice(insertAt);
+  } else {
+    const usedMarker = text.includes(marker) ? marker : legacyMarker;
+    const afterMarker = idx + usedMarker.length;
+    const nextSection = text.indexOf('\n## ', afterMarker);
+    const insertAt = nextSection === -1 ? text.length : nextSection;
+    const block = '\n' + offers.map(o =>
+      `- [ ] ${o.url} | ${o.company} | ${o.title}`
+    ).join('\n') + '\n';
+    text = text.slice(0, insertAt) + block + text.slice(insertAt);
+  }
+
+  writeFileSync(PIPELINE_PATH, text, 'utf-8');
+}
+
+function appendToScanHistory(offers, date) {
+  if (!existsSync(SCAN_HISTORY_PATH)) {
+    writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\n', 'utf-8');
+  }
+  const lines = offers.map(o =>
+    `${o.url}\t${date}\tbuiltin-colorado\t${o.title}\t${o.company}\tadded`
+  ).join('\n') + '\n';
+  appendFileSync(SCAN_HISTORY_PATH, lines, 'utf-8');
+}
+
+// ── Playwright scraper ───────────────────────────────────────────────
+
+async function scrapeSearchPage(browser, searchPage) {
+  const page = await browser.newPage();
+  const jobs = [];
+
+  try {
+    console.log(`  → ${searchPage.name}: ${searchPage.url}`);
+    await page.goto(searchPage.url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+
+    // Wait for job cards to load
+    await page.waitForTimeout(2000);
+
+    // Built In uses various card layouts. Try multiple selectors.
+    // Common patterns: .job-card, [data-id="job-card"], article with job link
+    const cards = await page.evaluate(() => {
+      const results = [];
+
+      // Strategy 1: Look for job card links with structured data
+      const jobLinks = document.querySelectorAll('a[href*="/job/"], a[href*="/jobs/"]');
+      for (const link of jobLinks) {
+        const href = link.getAttribute('href');
+        if (!href || href.includes('/jobs?') || href === '/jobs' || href === '/jobs/') continue;
+
+        // Get title from the link text or a nearby heading
+        const titleEl = link.querySelector('h2, h3, h4, [class*="title"]') || link;
+        const title = titleEl.textContent?.trim();
+
+        // Get company name from nearby elements
+        const card = link.closest('article, [class*="card"], [class*="job"], div[class*="result"]') || link.parentElement;
+        const companyEl = card?.querySelector('[class*="company"], [class*="employer"], span[class*="name"]');
+        const company = companyEl?.textContent?.trim() || '';
+
+        if (title && title.length > 3 && !results.some(r => r.url === href)) {
+          results.push({
+            title: title.replace(/\s+/g, ' ').slice(0, 200),
+            company: company.replace(/\s+/g, ' ').slice(0, 100),
+            url: href,
+          });
+        }
+      }
+
+      // Strategy 2: Look for structured job listing elements
+      if (results.length === 0) {
+        const articles = document.querySelectorAll('article, [data-testid*="job"], [class*="job-listing"]');
+        for (const article of articles) {
+          const link = article.querySelector('a[href*="/job/"]');
+          if (!link) continue;
+
+          const titleEl = article.querySelector('h2, h3, h4');
+          const companyEl = article.querySelector('[class*="company"], [class*="employer"]');
+
+          const title = titleEl?.textContent?.trim() || link.textContent?.trim();
+          const company = companyEl?.textContent?.trim() || '';
+          const url = link.getAttribute('href');
+
+          if (title && url && !results.some(r => r.url === url)) {
+            results.push({
+              title: title.replace(/\s+/g, ' ').slice(0, 200),
+              company: company.replace(/\s+/g, ' ').slice(0, 100),
+              url,
+            });
+          }
+        }
+      }
+
+      return results;
+    });
+
+    // Normalize URLs to absolute
+    for (const card of cards) {
+      if (card.url.startsWith('/')) {
+        card.url = `https://www.builtincolorado.com${card.url}`;
+      }
+      jobs.push(card);
+    }
+
+    console.log(`    Found ${jobs.length} job cards`);
+  } catch (err) {
+    console.error(`    Error: ${err.message?.slice(0, 100)}`);
+  } finally {
+    await page.close();
+  }
+
+  return jobs;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('🏔️  Built In Colorado Scanner\n');
+
+  // Dynamic import — Playwright may not be installed in all environments
+  let chromium;
+  try {
+    const pw = await import('playwright');
+    chromium = pw.chromium;
+  } catch {
+    console.error('❌ Playwright not installed. Run: npx playwright install chromium');
+    process.exit(1);
+  }
+
+  const titleFilter = buildTitleFilter();
+  const seenUrls = loadSeenUrls();
+  const date = new Date().toISOString().slice(0, 10);
+
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  });
+
+  let totalFound = 0;
+  let totalFiltered = 0;
+  let totalDupes = 0;
+  const newOffers = [];
+
+  try {
+    for (const searchPage of SEARCH_PAGES) {
+      const jobs = await scrapeSearchPage(browser, searchPage);
+      totalFound += jobs.length;
+
+      for (const job of jobs) {
+        if (!titleFilter(job.title)) {
+          totalFiltered++;
+          continue;
+        }
+        if (seenUrls.has(job.url)) {
+          totalDupes++;
+          continue;
+        }
+        seenUrls.add(job.url);
+        newOffers.push({ ...job, source: 'builtin-colorado' });
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  // Write results
+  if (!DRY_RUN && newOffers.length > 0) {
+    appendToPipeline(newOffers);
+    appendToScanHistory(newOffers, date);
+  }
+
+  // Summary
+  console.log(`\n${'━'.repeat(45)}`);
+  console.log(`Built In Colorado Scan — ${date}`);
+  console.log(`${'━'.repeat(45)}`);
+  console.log(`Search pages:          ${SEARCH_PAGES.length}`);
+  console.log(`Total jobs found:      ${totalFound}`);
+  console.log(`Filtered by title:     ${totalFiltered} removed`);
+  console.log(`Duplicates:            ${totalDupes} skipped`);
+  console.log(`New offers added:      ${newOffers.length}`);
+
+  if (newOffers.length > 0) {
+    console.log('\nNew offers:');
+    for (const o of newOffers) {
+      console.log(`  + ${o.company} | ${o.title}`);
+    }
+    if (DRY_RUN) {
+      console.log('\n(dry run — run without --dry-run to save results)');
+    }
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/scan-builtin.mjs
+++ b/scan-builtin.mjs
@@ -175,6 +175,28 @@ async function scrapeSearchPage(browser, searchPage) {
     const cards = await page.evaluate(() => {
       const results = [];
 
+      // Strategy 0: current Built In DOM (verified 2026-07-06) — job cards carry
+      // data-id hooks: [data-id="job-card"] > a[data-id="job-card-title"] +
+      // a[data-id="company-title"]. Location/remote text lives in the
+      // bounded-attribute-section column.
+      for (const card of document.querySelectorAll('[data-id="job-card"]')) {
+        const titleLink = card.querySelector('a[data-id="job-card-title"]');
+        const href = titleLink?.getAttribute('href');
+        if (!titleLink || !href) continue;
+        const company = card.querySelector('a[data-id="company-title"]')?.textContent?.trim() || '';
+        const attrText = card.querySelector('[class*="bounded-attribute-section"]')?.textContent || '';
+        const location = attrText.replace(/\s+/g, ' ').trim().slice(0, 120);
+        if (!results.some(r => r.url === href)) {
+          results.push({
+            title: titleLink.textContent.replace(/\s+/g, ' ').trim().slice(0, 200),
+            company: company.replace(/\s+/g, ' ').slice(0, 100),
+            url: href,
+            location,
+          });
+        }
+      }
+      if (results.length > 0) return results;
+
       // Strategy 1: Look for job card links with structured data
       const jobLinks = document.querySelectorAll('a[href*="/job/"], a[href*="/jobs/"]');
       for (const link of jobLinks) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -190,20 +190,25 @@ function appendToPipeline(offers) {
 
   let text = readFileSync(PIPELINE_PATH, 'utf-8');
 
-  // Find "## Pendientes" section and append after it
-  const marker = '## Pendientes';
-  const idx = text.indexOf(marker);
+  // Find "## Pending" section (or legacy Spanish "## Pendientes") and append after it
+  const marker = '## Pending';
+  const legacyMarker = '## Pendientes';
+  let idx = text.indexOf(marker);
+  if (idx === -1) idx = text.indexOf(legacyMarker); // backward compat with old pipeline.md
+
   if (idx === -1) {
-    // No Pendientes section — append at end before Procesadas
-    const procIdx = text.indexOf('## Procesadas');
+    // No Pending section — append at end before Processed/Procesadas
+    let procIdx = text.indexOf('## Processed');
+    if (procIdx === -1) procIdx = text.indexOf('## Procesadas');
     const insertAt = procIdx === -1 ? text.length : procIdx;
     const block = `\n${marker}\n\n` + offers.map(o =>
       `- [ ] ${o.url} | ${o.company} | ${o.title}`
     ).join('\n') + '\n\n';
     text = text.slice(0, insertAt) + block + text.slice(insertAt);
   } else {
-    // Find the end of existing Pendientes content (next ## or end)
-    const afterMarker = idx + marker.length;
+    // Find the end of existing Pending content (next ## or end)
+    const usedMarker = text.includes(marker) ? marker : legacyMarker;
+    const afterMarker = idx + usedMarker.length;
     const nextSection = text.indexOf('\n## ', afterMarker);
     const insertAt = nextSection === -1 ? text.length : nextSection;
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -17,7 +17,16 @@
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
 import yaml from 'js-yaml';
+import { NON_US_RE } from './lib/location-gate.mjs';
 const parseYaml = yaml.load;
+
+// ── Location pre-filter ─────────────────────────────────────────────
+// Drop clearly-non-US postings at scan time so the daily digest and triage funnel
+// aren't dominated by Singapore/EMEA/India roles (user policy: US-remote or Denver).
+// Conservative on purpose: any US/remote-US/NA hint keeps the posting — the triage
+// location gate does the strict check with the full JD body.
+const US_HINT_RE = /\b(?:us|u\.s\.|usa|united states|north america|amer|denver|colorado)\b|remote\s*-\s*(?:us|north america)/i;
+const clearlyNonUS = (loc) => !!loc && NON_US_RE.test(loc) && !US_HINT_RE.test(loc);
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -35,6 +44,11 @@ const FETCH_TIMEOUT_MS = 10_000;
 // ── API detection ───────────────────────────────────────────────────
 
 function detectApi(company) {
+  // Workday: explicit opt-in via api_type (endpoint shape isn't inferable from careers_url)
+  if (company.api_type === 'workday' && company.api) {
+    return { type: 'workday', url: company.api };
+  }
+
   // Greenhouse: explicit api field
   if (company.api && company.api.includes('greenhouse')) {
     return { type: 'greenhouse', url: company.api };
@@ -105,6 +119,41 @@ function parseLever(json, companyName) {
 }
 
 const PARSERS = { greenhouse: parseGreenhouse, ashby: parseAshby, lever: parseLever };
+
+// Workday cxs API: POST with pagination (20/page), unlike the GET-based ATSes above.
+// portals.yml entry needs: api_type: workday, api: <cxs .../jobs endpoint>,
+// careers_url: <public board base, e.g. https://tempus.wd5.myworkdayjobs.com/en-US/Tempus_Careers>
+async function fetchWorkdayJobs(company) {
+  const jobs = [];
+  const base = (company.careers_url || '').replace(/\/$/, '');
+  for (let offset = 0; offset < 400; offset += 20) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(company.api, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ limit: 20, offset, searchText: '' }),
+        signal: controller.signal,
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const j = await res.json();
+      const posts = j.jobPostings || [];
+      for (const p of posts) {
+        jobs.push({
+          title: p.title || '',
+          url: base + (p.externalPath || ''),
+          company: company.name,
+          location: p.locationsText || '',
+        });
+      }
+      if (!posts.length || offset + 20 >= (j.total || 0)) break;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  return jobs;
+}
 
 // ── Fetch with timeout ──────────────────────────────────────────────
 
@@ -290,6 +339,7 @@ async function main() {
   const date = new Date().toISOString().slice(0, 10);
   let totalFound = 0;
   let totalFiltered = 0;
+  let totalLocFiltered = 0;
   let totalDupes = 0;
   const newOffers = [];
   const errors = [];
@@ -297,13 +347,18 @@ async function main() {
   const tasks = targets.map(company => async () => {
     const { type, url } = company._api;
     try {
-      const json = await fetchJson(url);
-      const jobs = PARSERS[type](json, company.name);
+      const jobs = type === 'workday'
+        ? await fetchWorkdayJobs(company)
+        : PARSERS[type](await fetchJson(url), company.name);
       totalFound += jobs.length;
 
       for (const job of jobs) {
         if (!titleFilter(job.title)) {
           totalFiltered++;
+          continue;
+        }
+        if (clearlyNonUS(job.location)) {
+          totalLocFiltered++;
           continue;
         }
         if (seenUrls.has(job.url)) {
@@ -340,6 +395,7 @@ async function main() {
   console.log(`Companies scanned:     ${targets.length}`);
   console.log(`Total jobs found:      ${totalFound}`);
   console.log(`Filtered by title:     ${totalFiltered} removed`);
+  console.log(`Filtered by location:  ${totalLocFiltered} removed (clearly non-US)`);
   console.log(`Duplicates:            ${totalDupes} skipped`);
   console.log(`New offers added:      ${newOffers.length}`);
 

--- a/sync-ct203.sh
+++ b/sync-ct203.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# sync-ct203.sh — keep local checkout and the CT 203 scanner (10.1.30.50) in sync.
+#
+# CT 203 is the daily writer (triage.mjs adds tracker rows + reports via cron).
+# Local sessions are interactive writers (in-session evals). To avoid split-brain:
+#   - START of a local work session:  ./sync-ct203.sh pull
+#   - END of a local work session:    ./sync-ct203.sh push
+#   - Any time:                       ./sync-ct203.sh status
+#
+# pull   = CT 203 → local   (tracker, reports, scan data, digests, follow-ups)
+# push   = local → CT 203   (tracker, reports)
+# status = md5sum compare of pipeline scripts both sides
+
+set -euo pipefail
+CT=root@10.1.30.50
+REMOTE=/opt/career-ops
+LOCAL="$(cd "$(dirname "$0")" && pwd)"
+
+SCRIPTS=(scan.mjs triage.mjs openrouter-eval.mjs notify-telegram.mjs followup-check.mjs \
+         merge-tracker.mjs telegram-listener.mjs apply-orchestrator.mjs apply-auto.mjs \
+         lib/location-gate.mjs lib/ats-fetch.mjs lib/telegram.mjs)
+
+case "${1:-}" in
+  pull)
+    echo "⬇️  Pulling data from CT 203..."
+    rsync -az "$CT:$REMOTE/data/applications.md" "$LOCAL/data/"
+    rsync -az "$CT:$REMOTE/data/scan-history.tsv" "$LOCAL/data/"
+    rsync -az "$CT:$REMOTE/data/pipeline.md" "$LOCAL/data/" 2>/dev/null || true
+    rsync -az "$CT:$REMOTE/data/last-digest.json" "$LOCAL/data/" 2>/dev/null || true
+    rsync -az "$CT:$REMOTE/data/follow-ups.md" "$LOCAL/data/" 2>/dev/null || true
+    rsync -az "$CT:$REMOTE/reports/" "$LOCAL/reports/"
+    echo "✅ Pulled. Tracker rows: $(grep -c '^|' "$LOCAL/data/applications.md")"
+    ;;
+  push)
+    echo "⬆️  Pushing tracker + reports to CT 203..."
+    rsync -az "$LOCAL/data/applications.md" "$CT:$REMOTE/data/"
+    rsync -az "$LOCAL/reports/" "$CT:$REMOTE/reports/"
+    echo "✅ Pushed."
+    ;;
+  status)
+    for f in "${SCRIPTS[@]}"; do
+      L=$(md5sum "$LOCAL/$f" 2>/dev/null | cut -d' ' -f1 || true)
+      R=$(ssh "$CT" "md5sum $REMOTE/$f 2>/dev/null" | cut -d' ' -f1 || true)
+      if [ -n "$L" ] && [ "$L" = "$R" ]; then echo "SAME  $f"; else echo "DIFF  $f"; fi
+    done
+    ;;
+  *)
+    echo "Usage: $0 pull|push|status"; exit 1 ;;
+esac

--- a/telegram-listener.mjs
+++ b/telegram-listener.mjs
@@ -26,6 +26,7 @@
 
 import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
 import { join, resolve } from 'path';
+import { execFileSync } from 'child_process';
 import { loadTelegramConfig, sendReply, getUpdates } from './lib/telegram.mjs';
 import { runApplyPipeline, evaluateAndMaybeApply } from './apply-orchestrator.mjs';
 
@@ -265,10 +266,55 @@ async function handleStatusUpdate(chatId, messageId, newStatus, index) {
     'offer': 'Offer',
   };
   const canonical = statusMap[newStatus] || newStatus;
+
+  // Update tracker status in data/applications.md
+  if (existsSync(TRACKER_FILE)) {
+    let content = readFileSync(TRACKER_FILE, 'utf-8');
+    const lines = content.split('\n');
+    let updated = false;
+
+    for (let i = 0; i < lines.length; i++) {
+      if (!lines[i].startsWith('|') || lines[i].includes('---') || lines[i].includes('Date')) continue;
+      const cells = lines[i].split('|').map(c => c.trim()).filter(Boolean);
+      if (cells.length >= 6 && parseInt(cells[0]) === index) {
+        // Replace status (column 6, index 5)
+        cells[5] = canonical;
+        lines[i] = '| ' + cells.join(' | ') + ' |';
+        updated = true;
+        break;
+      }
+    }
+
+    if (updated) {
+      writeFileSync(TRACKER_FILE, lines.join('\n'));
+    }
+  }
+
   await sendReply(config, chatId,
     `✅ Updated #${index} status → <b>${canonical}</b>`,
     messageId);
-  // TODO: actually update data/applications.md programmatically
+
+  // Auto-trigger interview prep generation for Interview/Responded
+  if ((newStatus === 'interview' || newStatus === 'responded') && !DRY_RUN) {
+    await sendReply(config, chatId,
+      `📋 Generating interview prep for #${index}...`,
+      messageId);
+
+    try {
+      execFileSync('node', [join(PROJECT_DIR, 'generate-interview-prep.mjs'), '--num', String(index)], {
+        cwd: PROJECT_DIR,
+        timeout: 150_000,
+        encoding: 'utf-8',
+      });
+      await sendReply(config, chatId,
+        `✅ Interview prep generated for #${index}. Check interview-prep/ folder.`,
+        messageId);
+    } catch (err) {
+      await sendReply(config, chatId,
+        `⚠️ Prep generation failed: ${err.message?.slice(0, 150)}`,
+        messageId);
+    }
+  }
 }
 
 async function handleHelp(chatId, messageId) {

--- a/telegram-listener.mjs
+++ b/telegram-listener.mjs
@@ -376,11 +376,11 @@ async function handlePrep(chatId, messageId, index) {
 
 async function handleHelp(chatId, messageId) {
   const msg = `<b>career-ops bot commands</b>
-━━━━━━━━━━━━━━━━━━━━��━
+━━━━━━━━━━━━━━━━━━━━━━
 
 <b>apply</b> — Apply to top unapplied job
 <b>apply #N</b> — Apply to job #N from digest
-<b>skip #N</b> ��� Mark job #N as skipped
+<b>skip #N</b> — Mark job #N as skipped
 <b>follow up #N</b> — Send follow-up for application #N
 <b>wait #N</b> — Snooze follow-up reminder
 <b>responded #N</b> — Mark as responded

--- a/telegram-listener.mjs
+++ b/telegram-listener.mjs
@@ -88,6 +88,18 @@ function parseCommand(text) {
   const skipMatch = t.match(/^skip\s+#?(\d+)$/);
   if (skipMatch) return { action: 'skip', index: parseInt(skipMatch[1], 10) };
 
+  // "follow up #3" or "followup 3"
+  const followUpMatch = t.match(/^(?:follow\s*up|followup)\s+#?(\d+)$/);
+  if (followUpMatch) return { action: 'followup', index: parseInt(followUpMatch[1], 10) };
+
+  // "wait #3" — snooze follow-up
+  const waitMatch = t.match(/^wait\s+#?(\d+)$/);
+  if (waitMatch) return { action: 'wait', index: parseInt(waitMatch[1], 10) };
+
+  // "responded #3" / "interview #3" / "rejected #3" — manual status update
+  const statusUpdateMatch = t.match(/^(responded|interview|rejected|offer)\s+#?(\d+)$/);
+  if (statusUpdateMatch) return { action: 'status-update', status: statusUpdateMatch[1], index: parseInt(statusUpdateMatch[2], 10) };
+
   // "status"
   if (t === 'status') return { action: 'status' };
 
@@ -231,13 +243,46 @@ async function handleStatus(chatId, messageId) {
   await sendReply(config, chatId, msg, messageId);
 }
 
+async function handleFollowUp(chatId, messageId, index) {
+  // index here refers to tracker row number, not digest index
+  await sendReply(config, chatId,
+    `📬 Follow-up for #${index} noted. Will draft and send a polite check-in.`,
+    messageId);
+  // TODO: wire to email sending when email integration is ready
+}
+
+async function handleWait(chatId, messageId, index) {
+  await sendReply(config, chatId,
+    `⏸️ Snoozed follow-up for #${index}. Will remind again in 3 business days.`,
+    messageId);
+}
+
+async function handleStatusUpdate(chatId, messageId, newStatus, index) {
+  const statusMap = {
+    'responded': 'Responded',
+    'interview': 'Interview',
+    'rejected': 'Rejected',
+    'offer': 'Offer',
+  };
+  const canonical = statusMap[newStatus] || newStatus;
+  await sendReply(config, chatId,
+    `✅ Updated #${index} status → <b>${canonical}</b>`,
+    messageId);
+  // TODO: actually update data/applications.md programmatically
+}
+
 async function handleHelp(chatId, messageId) {
   const msg = `<b>career-ops bot commands</b>
-━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━��━
 
 <b>apply</b> — Apply to top unapplied job
 <b>apply #N</b> — Apply to job #N from digest
-<b>skip #N</b> — Mark job #N as skipped
+<b>skip #N</b> ��� Mark job #N as skipped
+<b>follow up #N</b> — Send follow-up for application #N
+<b>wait #N</b> — Snooze follow-up reminder
+<b>responded #N</b> — Mark as responded
+<b>interview #N</b> — Mark as in interview
+<b>rejected #N</b> — Mark as rejected
 <b>status</b> — Pipeline status summary
 <b>help</b> — This message
 
@@ -306,6 +351,15 @@ async function pollLoop() {
             break;
           case 'skip':
             await handleSkip(msg.chat.id, msg.message_id, cmd.index);
+            break;
+          case 'followup':
+            await handleFollowUp(msg.chat.id, msg.message_id, cmd.index);
+            break;
+          case 'wait':
+            await handleWait(msg.chat.id, msg.message_id, cmd.index);
+            break;
+          case 'status-update':
+            await handleStatusUpdate(msg.chat.id, msg.message_id, cmd.status, cmd.index);
             break;
           case 'status':
             await handleStatus(msg.chat.id, msg.message_id);

--- a/telegram-listener.mjs
+++ b/telegram-listener.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+
+/**
+ * telegram-listener.mjs — Long-polling Telegram bot listener
+ *
+ * Watches for Patrick's replies to digest messages and triggers
+ * the apply pipeline. Runs as a systemd service on CT 203.
+ *
+ * Commands:
+ *   "apply"       → apply to highest-scoring unapplied job from latest digest
+ *   "apply #3"    → apply to job #3 from the latest digest
+ *   "apply 3"     → same as above
+ *   "skip #3"     → mark job #3 as SKIP
+ *   "status"      → show pipeline status
+ *   "help"        → list commands
+ *
+ * Usage:
+ *   node telegram-listener.mjs              # start listener
+ *   node telegram-listener.mjs --dry-run    # log commands, don't execute
+ *   node telegram-listener.mjs --test       # process one poll cycle and exit
+ *
+ * Config (.env):
+ *   TELEGRAM_BOT_TOKEN=bot123456:ABC-...
+ *   TELEGRAM_CHAT_ID=123456789
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { join, resolve } from 'path';
+import { loadTelegramConfig, sendReply, getUpdates } from './lib/telegram.mjs';
+import { runApplyPipeline, evaluateAndMaybeApply } from './apply-orchestrator.mjs';
+
+const PROJECT_DIR = resolve(import.meta.dirname || '.');
+const OFFSET_FILE = join(PROJECT_DIR, 'data/telegram-offset.txt');
+const DIGEST_FILE = join(PROJECT_DIR, 'data/last-digest.json');
+const TRACKER_FILE = join(PROJECT_DIR, 'data/applications.md');
+const REPORTS_DIR = join(PROJECT_DIR, 'reports');
+
+// ── Config ────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const TEST_MODE = args.includes('--test');
+const config = loadTelegramConfig(join(PROJECT_DIR, '.env'));
+
+if (!config.token || !config.chatId) {
+  console.error('❌ Missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID in .env');
+  process.exit(1);
+}
+
+// ── Offset persistence ────────────────────────────────────────────────
+
+function loadOffset() {
+  if (existsSync(OFFSET_FILE)) {
+    const val = readFileSync(OFFSET_FILE, 'utf-8').trim();
+    return parseInt(val, 10) || 0;
+  }
+  return 0;
+}
+
+function saveOffset(offset) {
+  writeFileSync(OFFSET_FILE, String(offset));
+}
+
+// ── Last digest reader ────────────────────────────────────────────────
+
+function loadLastDigest() {
+  if (!existsSync(DIGEST_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(DIGEST_FILE, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+// ── Command parser ────────────────────────────────────────────────────
+
+function parseCommand(text) {
+  const t = text.trim().toLowerCase();
+
+  // "apply" — apply to highest-scoring unapplied
+  if (t === 'apply') return { action: 'apply', index: null };
+
+  // "apply #3" or "apply 3"
+  const applyMatch = t.match(/^apply\s+#?(\d+)$/);
+  if (applyMatch) return { action: 'apply', index: parseInt(applyMatch[1], 10) };
+
+  // "skip #3" or "skip 3"
+  const skipMatch = t.match(/^skip\s+#?(\d+)$/);
+  if (skipMatch) return { action: 'skip', index: parseInt(skipMatch[1], 10) };
+
+  // "status"
+  if (t === 'status') return { action: 'status' };
+
+  // "help"
+  if (t === 'help' || t === '/help' || t === '/start') return { action: 'help' };
+
+  return null; // unrecognized
+}
+
+// ── Command handlers ──────────────────────────────────────────────────
+
+async function handleApply(chatId, messageId, index) {
+  const digest = loadLastDigest();
+
+  if (!digest || !digest.jobs || digest.jobs.length === 0) {
+    await sendReply(config, chatId, '⚠️ No jobs in the latest digest. Run a scan first.', messageId);
+    return;
+  }
+
+  let job;
+  if (index === null) {
+    // Find highest-scoring unapplied job
+    // If scores aren't available, pick the first one
+    job = digest.jobs.find(j => !isApplied(j.url));
+    if (!job) {
+      await sendReply(config, chatId, '✅ Already applied to all jobs in the latest digest.', messageId);
+      return;
+    }
+  } else {
+    if (index < 1 || index > digest.jobs.length) {
+      await sendReply(config, chatId,
+        `⚠️ Invalid index #${index}. Latest digest has ${digest.jobs.length} jobs (use #1-${digest.jobs.length}).`,
+        messageId);
+      return;
+    }
+    job = digest.jobs[index - 1];
+  }
+
+  if (isApplied(job.url)) {
+    await sendReply(config, chatId,
+      `✅ Already applied to <b>${job.company}</b> — ${job.title}.`,
+      messageId);
+    return;
+  }
+
+  // Acknowledge
+  await sendReply(config, chatId,
+    `⏳ Applying to <b>${job.company}</b> — ${job.title}...`,
+    messageId);
+
+  if (DRY_RUN) {
+    await sendReply(config, chatId,
+      `[DRY RUN] Would apply to ${job.company} — ${job.title}\nURL: ${job.url}`,
+      messageId);
+    return;
+  }
+
+  try {
+    const result = await evaluateAndMaybeApply({
+      url: job.url,
+      company: job.company,
+      title: job.title,
+    });
+
+    if (result.applied) {
+      let msg = `✅ <b>Applied!</b>\n`;
+      msg += `<b>${job.company}</b> — ${job.title}\n`;
+      msg += `Score: ${result.score}/5\n`;
+      if (result.report) msg += `Report: ${result.report}`;
+      await sendReply(config, chatId, msg, messageId);
+    } else if (result.error) {
+      let msg = `❌ <b>Apply failed</b>\n`;
+      msg += `<b>${job.company}</b> — ${job.title}\n`;
+      msg += `Error: ${result.error}\n`;
+      msg += `Apply manually: ${job.url}`;
+      await sendReply(config, chatId, msg, messageId);
+    } else {
+      let msg = `📊 <b>Evaluated</b> (not auto-applied)\n`;
+      msg += `<b>${job.company}</b> — ${job.title}\n`;
+      msg += `Score: ${result.score}/5\n`;
+      msg += `Below auto-apply threshold. Reply "apply #${index || '?'}" to apply manually.`;
+      await sendReply(config, chatId, msg, messageId);
+    }
+  } catch (err) {
+    await sendReply(config, chatId,
+      `❌ Error: ${err.message?.slice(0, 200)}\nApply manually: ${job.url}`,
+      messageId);
+  }
+}
+
+async function handleSkip(chatId, messageId, index) {
+  const digest = loadLastDigest();
+
+  if (!digest || !digest.jobs || digest.jobs.length === 0) {
+    await sendReply(config, chatId, '⚠️ No jobs in the latest digest.', messageId);
+    return;
+  }
+
+  if (index < 1 || index > digest.jobs.length) {
+    await sendReply(config, chatId,
+      `⚠️ Invalid index #${index}. Latest digest has ${digest.jobs.length} jobs.`,
+      messageId);
+    return;
+  }
+
+  const job = digest.jobs[index - 1];
+  await sendReply(config, chatId,
+    `⏭️ Skipped <b>${job.company}</b> — ${job.title}`,
+    messageId);
+}
+
+async function handleStatus(chatId, messageId) {
+  let msg = '<b>📊 Pipeline Status</b>\n━━━━━━━━━━━━━━━━━━━━━━\n';
+
+  // Count tracker entries
+  if (existsSync(TRACKER_FILE)) {
+    const content = readFileSync(TRACKER_FILE, 'utf-8');
+    const rows = content.split('\n').filter(l => l.startsWith('|') && !l.includes('---') && !l.includes('Date'));
+    const applied = rows.filter(r => r.includes('Applied')).length;
+    const evaluated = rows.filter(r => r.includes('Evaluated')).length;
+    const skipped = rows.filter(r => r.includes('SKIP')).length;
+    msg += `\nApplications: ${rows.length} total\n`;
+    msg += `  Applied: ${applied}\n`;
+    msg += `  Evaluated: ${evaluated}\n`;
+    msg += `  Skipped: ${skipped}\n`;
+  }
+
+  // Latest digest info
+  const digest = loadLastDigest();
+  if (digest) {
+    msg += `\nLatest digest: ${digest.date}\n`;
+    msg += `  Jobs: ${digest.jobs?.length || 0}\n`;
+  }
+
+  // Report count
+  if (existsSync(REPORTS_DIR)) {
+    const reports = readdirSync(REPORTS_DIR).filter(f => f.endsWith('.md'));
+    msg += `\nReports: ${reports.length}`;
+  }
+
+  await sendReply(config, chatId, msg, messageId);
+}
+
+async function handleHelp(chatId, messageId) {
+  const msg = `<b>career-ops bot commands</b>
+━━━━━━━━━━━━━━━━━━━━━━
+
+<b>apply</b> — Apply to top unapplied job
+<b>apply #N</b> — Apply to job #N from digest
+<b>skip #N</b> — Mark job #N as skipped
+<b>status</b> — Pipeline status summary
+<b>help</b> — This message
+
+Auto-apply is ON for scores ≥ 4.5.
+Jobs scoring 4.0-4.4 appear in digests — reply "apply #N" to submit.`;
+
+  await sendReply(config, chatId, msg, messageId);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function isApplied(url) {
+  if (!existsSync(TRACKER_FILE)) return false;
+  const content = readFileSync(TRACKER_FILE, 'utf-8');
+  // Check if this URL's company+role is marked Applied
+  // Simple heuristic: if the URL domain+path appears in an Applied row
+  return content.includes('Applied') && content.split('\n').some(line =>
+    line.includes('Applied') && line.includes(url.split('/').slice(-1)[0]?.slice(0, 20) || '')
+  );
+}
+
+// ── Main loop ─────────────────────────────────────────────────────────
+
+let heartbeatCount = 0;
+const HEARTBEAT_INTERVAL = 720; // Send heartbeat every 720 polls (~6 hours at 30s each)
+
+async function pollLoop() {
+  let offset = loadOffset();
+  console.log(`🤖 career-ops Telegram listener started`);
+  console.log(`   Chat ID: ${config.chatId}`);
+  console.log(`   Offset: ${offset}`);
+  console.log(`   Mode: ${DRY_RUN ? 'DRY RUN' : 'LIVE'}`);
+  console.log('   Listening for commands...\n');
+
+  while (true) {
+    try {
+      const updates = await getUpdates(config, offset, 30);
+
+      for (const update of updates) {
+        offset = update.update_id + 1;
+        saveOffset(offset);
+
+        const msg = update.message;
+        if (!msg || !msg.text) continue;
+
+        // Only process messages from our chat
+        if (String(msg.chat.id) !== String(config.chatId)) {
+          console.log(`   Ignoring message from chat ${msg.chat.id} (not ${config.chatId})`);
+          continue;
+        }
+
+        const text = msg.text.trim();
+        console.log(`📩 ${new Date().toISOString()} — "${text}"`);
+
+        const cmd = parseCommand(text);
+        if (!cmd) {
+          console.log('   (unrecognized command, ignoring)');
+          continue;
+        }
+
+        console.log(`   → ${cmd.action}${cmd.index ? ` #${cmd.index}` : ''}`);
+
+        switch (cmd.action) {
+          case 'apply':
+            await handleApply(msg.chat.id, msg.message_id, cmd.index);
+            break;
+          case 'skip':
+            await handleSkip(msg.chat.id, msg.message_id, cmd.index);
+            break;
+          case 'status':
+            await handleStatus(msg.chat.id, msg.message_id);
+            break;
+          case 'help':
+            await handleHelp(msg.chat.id, msg.message_id);
+            break;
+        }
+      }
+
+      // Heartbeat
+      heartbeatCount++;
+      if (heartbeatCount >= HEARTBEAT_INTERVAL) {
+        heartbeatCount = 0;
+        console.log(`💓 ${new Date().toISOString()} — Heartbeat (listener alive)`);
+      }
+
+      if (TEST_MODE) {
+        console.log('Test mode: exiting after one poll cycle.');
+        break;
+      }
+
+    } catch (err) {
+      console.error(`⚠️  Poll error: ${err.message}`);
+      // Wait 5s before retrying on error
+      await new Promise(r => setTimeout(r, 5000));
+    }
+  }
+}
+
+pollLoop().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/telegram-listener.mjs
+++ b/telegram-listener.mjs
@@ -104,6 +104,13 @@ function parseCommand(text) {
   // "status"
   if (t === 'status') return { action: 'status' };
 
+  // "patterns" / "analytics"
+  if (t === 'patterns' || t === 'analytics') return { action: 'patterns' };
+
+  // "prep #3" — generate interview prep for a specific application
+  const prepMatch = t.match(/^prep\s+#?(\d+)$/);
+  if (prepMatch) return { action: 'prep', index: parseInt(prepMatch[1], 10) };
+
   // "help"
   if (t === 'help' || t === '/help' || t === '/start') return { action: 'help' };
 
@@ -317,6 +324,56 @@ async function handleStatusUpdate(chatId, messageId, newStatus, index) {
   }
 }
 
+async function handlePatterns(chatId, messageId) {
+  try {
+    const output = execFileSync('node', [join(PROJECT_DIR, 'analyze-patterns.mjs'), '--summary'], {
+      cwd: PROJECT_DIR,
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+
+    // Truncate for Telegram (4096 char limit)
+    const lines = output.split('\n');
+    let msg = '<b>📊 Pattern Analysis</b>\n<pre>';
+    let charCount = 30;
+    for (const line of lines) {
+      if (charCount + line.length + 1 > 3800) {
+        msg += '\n... (truncated)';
+        break;
+      }
+      msg += line + '\n';
+      charCount += line.length + 1;
+    }
+    msg += '</pre>';
+    await sendReply(config, chatId, msg, messageId);
+  } catch (err) {
+    await sendReply(config, chatId,
+      `❌ Pattern analysis failed: ${err.message?.slice(0, 150)}`,
+      messageId);
+  }
+}
+
+async function handlePrep(chatId, messageId, index) {
+  await sendReply(config, chatId,
+    `📋 Generating interview prep for #${index}...`,
+    messageId);
+
+  try {
+    execFileSync('node', [join(PROJECT_DIR, 'generate-interview-prep.mjs'), '--num', String(index)], {
+      cwd: PROJECT_DIR,
+      timeout: 150_000,
+      encoding: 'utf-8',
+    });
+    await sendReply(config, chatId,
+      `✅ Interview prep generated for #${index}. Check interview-prep/ folder.`,
+      messageId);
+  } catch (err) {
+    await sendReply(config, chatId,
+      `❌ Prep generation failed: ${err.message?.slice(0, 150)}`,
+      messageId);
+  }
+}
+
 async function handleHelp(chatId, messageId) {
   const msg = `<b>career-ops bot commands</b>
 ━━━━━━━━━━━━━━━━━━━━��━
@@ -329,6 +386,8 @@ async function handleHelp(chatId, messageId) {
 <b>responded #N</b> — Mark as responded
 <b>interview #N</b> — Mark as in interview
 <b>rejected #N</b> — Mark as rejected
+<b>prep #N</b> — Generate interview prep doc
+<b>patterns</b> — Conversion funnel + targeting analysis
 <b>status</b> — Pipeline status summary
 <b>help</b> — This message
 
@@ -409,6 +468,12 @@ async function pollLoop() {
             break;
           case 'status':
             await handleStatus(msg.chat.id, msg.message_id);
+            break;
+          case 'patterns':
+            await handlePatterns(msg.chat.id, msg.message_id);
+            break;
+          case 'prep':
+            await handlePrep(msg.chat.id, msg.message_id, cmd.index);
             break;
           case 'help':
             await handleHelp(msg.chat.id, msg.message_id);

--- a/templates/follow-up-emails.md
+++ b/templates/follow-up-emails.md
@@ -1,0 +1,66 @@
+# Follow-Up Email Templates
+
+Short, direct, Patrick's voice. No desperation. No "just checking in."
+
+---
+
+## Template 1 — First follow-up (5-7 business days after applying)
+
+**Subject:** {Role} application — Patrick Moore
+
+Hi {Recruiter/Team},
+
+I applied for {Role} on {date}. Quick note: I run security and cloud infrastructure for an AI-native oncology EMR — three Claude agents in HIPAA/HITRUST-track production, the security review process I authored, and the agent identity model underneath. The founding-team security posture you described is the same shape of work I do today.
+
+Happy to talk whenever makes sense.
+
+Patrick Moore
+moorelab.cloud
+
+---
+
+## Template 2 — Second follow-up (10-12 business days, only if no response to first)
+
+**Subject:** Re: {Role} application — Patrick Moore
+
+Following up once more on {Role}. I understand hiring timelines shift — if the role is still active and you'd like to talk, I'm available this week or next.
+
+Patrick Moore
+moorelab.cloud
+
+---
+
+## Template 3 — After interview / responded (following up on next steps)
+
+**Subject:** Re: {Role} — next steps
+
+Thanks for the conversation on {date}. I'm still interested and ready for the next round whenever you are.
+
+One thing I didn't get to mention: {one specific proof point relevant to the conversation — e.g., "the MCP proxy architecture I described also serves as our HIPAA audit boundary, which directly maps to the compliance work you mentioned."}
+
+Patrick Moore
+moorelab.cloud
+
+---
+
+## Template 4 — After technical round (thank you + signal)
+
+**Subject:** Re: {Role} — thanks for the deep dive
+
+Thanks for the technical discussion. I appreciated {specific thing — e.g., "the system design question about agent identity boundaries" or "the candid discussion about your current security posture"}.
+
+The problem space is exactly what I want to work on. Looking forward to next steps.
+
+Patrick Moore
+moorelab.cloud
+
+---
+
+## Usage notes
+
+- **Tone:** Direct, short, no filler words, no "hope this finds you well"
+- **Always include** moorelab.cloud — it's the portfolio that differentiates
+- **Never send** more than 2 follow-ups for an application with no response
+- **Timing:** First follow-up at 5-7 business days, second at 10-12 if no response
+- **Personalization:** Replace {brackets} with actual context. Generic follow-ups are worse than none.
+- **Subject line:** Keep it simple — role name + your name. Threading ("Re:") only if you have a prior email.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -314,6 +314,73 @@ if (fileExists('VERSION')) {
   fail('VERSION file missing');
 }
 
+// ── 11. Merge-tracker dedup regression ──────────────────────────
+
+console.log('\n11. Merge-tracker dedup regression');
+
+// Test that roleFuzzyMatch correctly rejects same-company different-roles
+// Regression: Abridge AppSec vs InfraSec were falsely treated as same role
+try {
+  // Import the function by reading the file and extracting the logic
+  const mergeContent = readFile('merge-tracker.mjs');
+
+  // Extract ROLE_STOPWORDS and functions using eval-in-module approach
+  // Simpler: just test the Jaccard condition directly
+  const ROLE_STOPWORDS = new Set([
+    'junior', 'mid', 'middle', 'senior', 'staff', 'principal', 'lead', 'head',
+    'chief', 'associate', 'intern', 'entry', 'level',
+    'remote', 'hybrid', 'onsite', 'contract', 'contractor', 'freelance',
+    'fulltime', 'parttime', 'permanent', 'temporary', 'internship',
+    'role', 'position', 'opportunity', 'team', 'based',
+    'with', 'from', 'into', 'over', 'this', 'that',
+  ]);
+
+  function roleTokens(s) {
+    return s.toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/)
+      .filter(w => w.length > 3 && !ROLE_STOPWORDS.has(w));
+  }
+
+  function roleFuzzyMatch(a, b) {
+    const wordsA = roleTokens(a);
+    const wordsB = roleTokens(b);
+    if (wordsA.length === 0 || wordsB.length === 0) return false;
+    const setB = new Set(wordsB);
+    const overlap = wordsA.filter(w => setB.has(w)).length;
+    if (overlap === 0) return false;
+    const union = new Set([...wordsA, ...wordsB]).size;
+    const jaccard = overlap / union;
+    return overlap >= 2 && jaccard >= 0.75;
+  }
+
+  // Should NOT match (the bug case)
+  const bugCase = roleFuzzyMatch(
+    'Senior/Staff Application Security Engineer',
+    'Senior/Staff Infrastructure Security Engineer'
+  );
+  if (!bugCase) {
+    pass('AppSec vs InfraSec correctly treated as different roles');
+  } else {
+    fail('REGRESSION: AppSec vs InfraSec falsely matched as same role');
+  }
+
+  // Should match (same role, minor wording)
+  const sameRole = roleFuzzyMatch('Security Engineer', 'Security Engineer');
+  if (sameRole) {
+    pass('Identical roles correctly matched');
+  } else {
+    fail('Identical roles failed to match');
+  }
+
+  // Verify merge-tracker.mjs uses Jaccard (not min-ratio)
+  if (mergeContent.includes('jaccard') && !mergeContent.includes('overlap / minLen')) {
+    pass('merge-tracker.mjs uses Jaccard similarity (not min-ratio)');
+  } else {
+    fail('merge-tracker.mjs may still use old min-ratio logic');
+  }
+} catch (err) {
+  fail(`Dedup regression test error: ${err.message}`);
+}
+
 // ── SUMMARY ─────────────────────────────────────────────────────
 
 console.log('\n' + '='.repeat(50));

--- a/triage.mjs
+++ b/triage.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * triage.mjs — the missing "evaluate" step for the CT 203 daily pipeline.
+ *
+ * The deployed scanner does scan → notify → followup but never SCORES anything
+ * (see memory: project_scanner_no_eval — every digest job is score:null). This
+ * closes that gap with a cheap funnel:
+ *
+ *   scan-history rows → title gate → fetch JD → location gate (JD-body aware,
+ *   lib/location-gate.mjs) → comp floor → OpenRouter A–G eval on survivors only.
+ *
+ * Hard gates run with ZERO LLM cost and kill the ~90% that are presales/territory/
+ * non-US/onsite/sub-floor; only genuine contenders reach the (paid) LLM eval.
+ *
+ * Usage:
+ *   node triage.mjs --date 2026-06-04            # one scan day
+ *   node triage.mjs --since 2026-05-26           # a backlog range
+ *   node triage.mjs --since 2026-05-26 --dry-run # gates only, no LLM, no cost
+ *   node triage.mjs --date 2026-06-04 --write    # also write reports + TSVs for >=4.0
+ *   node triage.mjs --date 2026-06-04 --update-digest  # backfill scores into last-digest.json
+ *
+ * Needs OPENROUTER_API_KEY (or ~/.secrets/openrouter.txt) unless --dry-run.
+ */
+import { readFileSync, existsSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execFileSync } from 'child_process';
+import { fetchJob } from './lib/ats-fetch.mjs';
+import { assessLocation } from './lib/location-gate.mjs';
+import { evaluateJD, buildReportMarkdown, jobToJdText, nextReportNumber, slugify, REPORTS_DIR, DEFAULT_MODEL } from './openrouter-eval.mjs';
+import { loadTelegramConfig, sendMessage } from './lib/telegram.mjs';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const SCAN = join(ROOT, 'data/scan-history.tsv');
+const TRACKER = join(ROOT, 'data/applications.md');
+const DIGEST = join(ROOT, 'data/last-digest.json');
+
+const args = process.argv.slice(2);
+const opt = (k, d) => { const i = args.indexOf(k); return i >= 0 ? args[i + 1] : d; };
+const has = (k) => args.includes(k);
+const onDate = opt('--date', null);
+const sinceDate = opt('--since', null);
+const limit = parseInt(opt('--limit', '0')) || Infinity;
+const dryRun = has('--dry-run');
+const doWrite = has('--write');
+const updateDigest = has('--update-digest');
+const COMP_FLOOR = 160; // $160K base, per modes/_profile.md
+
+// Presales / territory / off-archetype title negatives (the big SKIP bucket).
+const TITLE_NEG = [
+  /solutions?\s+(architect|engineer|consultant)/i, /customer engineer/i, /sales engineer/i,
+  /account (exec|manager)/i, /presales|pre-sales/i, /field (solutions?|engineer)/i, /\bgtm\b/i,
+  /business development/i, /\bpartner\b/i, /developer relations|devrel|advocate/i,
+  /machine learning|\bml engineer\b|data scientist|data analyst|research (scientist|engineer)/i,
+  /product manager|program manager|\bvp\b|vice president|\bchief\b/i,
+  /frontend|front-end|\bux\b|design systems/i, /\bintern\b|working student|\bjunior\b|associate/i,
+];
+const titleSkip = (t) => (TITLE_NEG.find(re => re.test(t)) || null) && TITLE_NEG.find(re => re.test(t)).source;
+
+// Parse a single comp token to $K. Handles "214.2K", "$252K", "120,000", "$140,000".
+function tokenToK(tok) {
+  const hasK = /[kK]/.test(tok);
+  const v = parseFloat(tok.replace(/[$,\skK]/g, '')); // strip $ , whitespace K
+  if (isNaN(v)) return null;
+  return (!hasK && v > 900) ? v / 1000 : v; // bare full-dollar amount -> K
+}
+function compGate(comp) {
+  if (!comp) return { ok: true, note: 'no comp listed' };
+  const toks = comp.match(/\$?\s?\d{2,3}(?:[.,]\d{1,3})?\s?[kK]?/g) || [];
+  const nums = toks.map(tokenToK).filter(n => n != null && n >= 50 && n <= 900);
+  if (!nums.length) return { ok: true, note: 'comp unparsed' };
+  const max = Math.round(Math.max(...nums));
+  return max < COMP_FLOOR ? { ok: false, note: `comp max $${max}K < $${COMP_FLOOR}K floor` } : { ok: true, note: `comp max $${max}K` };
+}
+
+// Dedup against tracker (company+role already evaluated/applied).
+function trackerKeys() {
+  if (!existsSync(TRACKER)) return new Set();
+  const keys = new Set();
+  for (const line of readFileSync(TRACKER, 'utf-8').split('\n')) {
+    const m = line.match(/^\|\s*\d+\s*\|[^|]*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|/);
+    if (m) keys.add((m[1] + '|' + m[2]).toLowerCase().replace(/[^a-z0-9|]/g, ''));
+  }
+  return keys;
+}
+const seen = trackerKeys();
+const inTracker = (company, title) => seen.has((company + '|' + title).toLowerCase().replace(/[^a-z0-9|]/g, ''));
+
+function rows() {
+  if (!existsSync(SCAN)) { console.error('no scan-history.tsv'); process.exit(1); }
+  return readFileSync(SCAN, 'utf-8').split('\n').slice(1).filter(Boolean)
+    .map(l => { const [url, date, portal, title, company] = l.split('\t'); return { url, date, portal, title, company }; })
+    .filter(r => r.title && r.date !== 'first_seen' &&
+      (onDate ? r.date === onDate : sinceDate ? r.date >= sinceDate : true));
+}
+
+const escapeHtml = (s) => (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+async function telegramAlert(scored) {
+  const cfg = loadTelegramConfig(join(ROOT, '.env'));
+  if (!cfg.token || !cfg.chatId) { console.log('(no telegram config — skipping alert)'); return; }
+  const apply = scored.filter(s => parseFloat(s.score) >= 4.0).sort((a, b) => parseFloat(b.score) - parseFloat(a.score));
+  let msg = `<b>career-ops triage</b> — ${scored.length} evaluated, ${apply.length} ≥4.0`;
+  if (apply.length) for (const s of apply)
+    msg += `\n\n🎯 <b>${s.score}</b> — ${escapeHtml(s.company)}: ${escapeHtml(s.role)}${s.location_verdict === 'confirm' ? ' ⚠️confirm-remote' : ''}\n${s.url}`;
+  else msg += `\nNothing ≥4.0 today.`;
+  try { await sendMessage(cfg, cfg.chatId, msg); console.log('📨 Telegram alert sent'); }
+  catch (e) { console.error('telegram failed:', e.message); }
+}
+
+// ── run ──────────────────────────────────────────────────────────────────
+const all = rows().slice(0, limit === Infinity ? undefined : limit);
+const buckets = { 'skip-title': 0, 'skip-location': 0, 'skip-comp': 0, 'in-tracker': 0, 'fetch-fail': 0, survivors: 0 };
+const survivors = [];
+
+console.log(`\n🔎 triage: ${all.length} scanned jobs ${onDate ? `on ${onDate}` : sinceDate ? `since ${sinceDate}` : '(all)'}${dryRun ? '  [DRY-RUN: gates only]' : ''}\n`);
+
+for (const r of all) {
+  if (titleSkip(r.title)) { buckets['skip-title']++; continue; }
+  if (inTracker(r.company, r.title)) { buckets['in-tracker']++; continue; }
+  const job = await fetchJob(r.url, { company: r.company });
+  if (!job.ok) { buckets['fetch-fail']++; console.log(`  ⚠️  fetch-fail: ${r.company} — ${r.title} (${job.error})`); continue; }
+  const loc = assessLocation(job);
+  if (loc.verdict === 'skip') { buckets['skip-location']++; continue; }
+  const cg = compGate(job.comp);
+  if (!cg.ok) { buckets['skip-comp']++; console.log(`  💸 skip-comp: ${r.company} — ${r.title} (${cg.note})`); continue; }
+  buckets.survivors++;
+  survivors.push({ ...r, job, loc, cg });
+  console.log(`  ✅ survivor: ${r.company} — ${r.title}  [loc:${loc.verdict}, ${cg.note}]`);
+}
+
+console.log(`\n── Funnel ──`);
+for (const [k, v] of Object.entries(buckets)) console.log(`  ${k.padEnd(14)} ${v}`);
+
+if (dryRun) { console.log(`\n(dry-run — ${survivors.length} would go to LLM eval)\n`); process.exit(0); }
+if (!survivors.length) { console.log('\nNo survivors to evaluate.\n'); process.exit(0); }
+
+console.log(`\n── Evaluating ${survivors.length} survivors via OpenRouter (${DEFAULT_MODEL}) ──\n`);
+const scored = [];
+for (const s of survivors) {
+  let result, text;
+  try { ({ result, text } = await evaluateJD({ jdText: jobToJdText(s.job), company: s.company, url: s.url, locVerdict: s.loc })); }
+  catch (e) { console.log(`  ❌ ${s.company} — ${s.title}: ${e.message}`); continue; }
+  scored.push({ ...s, ...result, text });
+  console.log(`  ${parseFloat(result.score) >= 4.0 ? '🟢' : '⚪'} ${result.score}/5  ${s.company} — ${result.role}  [${result.location_verdict}]`);
+}
+scored.sort((a, b) => parseFloat(b.score) - parseFloat(a.score));
+
+// Auto-write reports + TSVs for >=4.0, then merge once.
+if (doWrite) {
+  const today = onDate || new Date().toISOString().split('T')[0];
+  let num = parseInt(nextReportNumber(), 10);
+  let written = 0;
+  for (const s of scored.filter(x => parseFloat(x.score) >= 4.0)) {
+    const n = String(num++).padStart(3, '0');
+    const slug = slugify(s.company + '-' + s.role);
+    const fn = `${n}-${slug}-${today}.md`;
+    writeFileSync(join(REPORTS_DIR, fn), buildReportMarkdown({ result: s, text: s.text, url: s.url, locVerdict: s.loc, date: today }), 'utf-8');
+    const note = `Auto-eval (OpenRouter ${DEFAULT_MODEL}): ${s.archetype}; loc:${s.location_verdict}; ${s.cg.note}`.replace(/[\t\n]/g, ' ').slice(0, 200);
+    writeFileSync(join(ROOT, 'batch/tracker-additions', `${n}-${slug}.tsv`),
+      `${n}\t${today}\t${s.company}\t${s.role}\tEvaluated\t${s.score}/5\t❌\t[${n}](reports/${fn})\t${note}\n`, 'utf-8');
+    written++;
+    console.log(`  📝 report ${n} + TSV: ${s.company} — ${s.role} (${s.score})`);
+  }
+  if (written) { try { execFileSync('node', [join(ROOT, 'merge-tracker.mjs')], { cwd: ROOT, stdio: 'inherit' }); } catch (e) { console.error('  merge failed:', e.message); } }
+}
+
+// Backfill digest scores.
+if ((updateDigest || doWrite) && existsSync(DIGEST)) {
+  try {
+    const d = JSON.parse(readFileSync(DIGEST, 'utf-8'));
+    for (const j of d.jobs || []) { const hit = scored.find(s => s.url === j.url); if (hit) j.score = parseFloat(hit.score); }
+    writeFileSync(DIGEST, JSON.stringify(d, null, 2));
+    console.log(`📝 Backfilled scores into data/last-digest.json`);
+  } catch (e) { console.error('digest backfill failed:', e.message); }
+}
+
+const apply = scored.filter(s => parseFloat(s.score) >= 4.0);
+console.log(`\n🎯 ${apply.length} role(s) ≥ 4.0:`);
+for (const s of apply) console.log(`   ${s.score}  ${s.company} — ${s.role}  ${s.url}`);
+
+if (doWrite) await telegramAlert(scored);
+console.log('');

--- a/triage.mjs
+++ b/triage.mjs
@@ -153,7 +153,7 @@ function digestIndexMap() {
     return new Map((d.jobs || []).map(j => [j.url, j.index]));
   } catch { return new Map(); }
 }
-async function telegramAlert(scored, autoApplied = []) {
+async function telegramAlert(scored, autoApplied = [], quotaNote = '') {
   const cfg = loadTelegramConfig(join(ROOT, '.env'));
   if (!cfg.token || !cfg.chatId) { console.log('(no telegram config — skipping alert)'); return; }
   const idx = digestIndexMap();
@@ -170,6 +170,7 @@ async function telegramAlert(scored, autoApplied = []) {
   }
   else msg += `\nNothing ≥4.0 today.`;
   if (capped.length) msg += `\n\n⛔ ${capped.length} policy-capped (location/comp): ${capped.map(s => escapeHtml(s.company)).join(', ')}`;
+  if (quotaNote) msg += `\n\n${quotaNote}`;
   try { await sendMessage(cfg, cfg.chatId, msg); console.log('📨 Telegram alert sent'); }
   catch (e) { console.error('telegram failed:', e.message); }
 }
@@ -205,10 +206,20 @@ if (!survivors.length) { console.log('\nNo survivors to evaluate.\n'); process.e
 
 console.log(`\n── Evaluating ${survivors.length} survivors via OpenRouter (${DEFAULT_MODEL}) ──\n`);
 const scored = [];
+let quotaHit = false;
+let unevaluated = 0;
 for (const s of survivors) {
+  if (quotaHit) { unevaluated++; continue; }
   let result, text;
   try { ({ result, text } = await evaluateJD({ jdText: jobToJdText(s.job), company: s.company, url: s.url, locVerdict: s.loc })); }
-  catch (e) { console.log(`  ❌ ${s.company} — ${s.title}: ${e.message}`); continue; }
+  catch (e) {
+    console.log(`  ❌ ${s.company} — ${s.title}: ${e.message}`);
+    // OpenRouter weekly key limit: every further call fails identically (2026-07-07: 46
+    // survivors burned through as 403s). Abort the loop; unevaluated roles aren't written
+    // to triage-history, so they retry automatically once the key has budget again.
+    if (/Key limit exceeded|402|credit/i.test(e.message)) { quotaHit = true; unevaluated++; }
+    continue;
+  }
   recordEvaluated(s.url, s.date, result.score, result.status || 'Evaluated');
   scored.push({ ...s, ...result, text });
   if (result.policy_reason) {
@@ -286,5 +297,10 @@ const apply = scored.filter(s => parseFloat(s.score) >= 4.0);
 console.log(`\n🎯 ${apply.length} role(s) ≥ 4.0:`);
 for (const s of apply) console.log(`   ${s.score}  ${s.company} — ${s.role}  ${s.url}`);
 
-if (doWrite) await telegramAlert(scored, autoApplied);
+const quotaNote = quotaHit
+  ? `🚫 <b>OpenRouter key limit exhausted</b> — ${unevaluated} survivor(s) NOT evaluated (auto-retry next run). Raise the weekly limit at openrouter.ai → Keys.`
+  : '';
+if (quotaHit) console.log(`\n🚫 OpenRouter key limit — aborted with ${unevaluated} survivors unevaluated (will retry next run).`);
+
+if (doWrite) await telegramAlert(scored, autoApplied, quotaNote);
 console.log('');

--- a/triage.mjs
+++ b/triage.mjs
@@ -21,7 +21,7 @@
  *
  * Needs OPENROUTER_API_KEY (or ~/.secrets/openrouter.txt) unless --dry-run.
  */
-import { readFileSync, existsSync, writeFileSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync, appendFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
@@ -44,18 +44,55 @@ const limit = parseInt(opt('--limit', '0')) || Infinity;
 const dryRun = has('--dry-run');
 const doWrite = has('--write');
 const updateDigest = has('--update-digest');
+const noAutoApply = has('--no-auto-apply');
 const COMP_FLOOR = 160; // $160K base, per modes/_profile.md
+
+// ── Auto-apply config (tier 1: unattended submit) ─────────────────────────
+// Reads profile.yml search: block. Only fires when BOTH the deterministic gate AND the
+// eval's own location extraction agree the role is policy-clean (belt and suspenders —
+// the 2026-06 Haiku misses are why neither signal is trusted alone).
+function loadApplyConfig() {
+  const p = join(ROOT, 'config/profile.yml');
+  if (!existsSync(p)) return { enabled: false };
+  const raw = readFileSync(p, 'utf-8');
+  const get = (k) => { const m = raw.match(new RegExp(`^\\s*${k}:\\s*["']?(.+?)["']?\\s*(?:#.*)?$`, 'm')); return m ? m[1].trim() : ''; };
+  const platBlock = raw.match(/auto_apply_platforms:[ \t]*(?:#.*)?\n((?:[ \t]+-[ \t]+\w+[ \t]*(?:#.*)?\n)+)/);
+  const platforms = platBlock ? [...platBlock[1].matchAll(/-\s+(\w+)/g)].map(m => m[1]) : [];
+  return {
+    enabled: get('auto_apply_enabled') === 'true',
+    threshold: parseFloat(get('auto_apply_threshold')) || 4.5,
+    platforms,
+  };
+}
+function detectPlatform(url) {
+  if (/jobs\.ashbyhq\.com/i.test(url)) return 'ashby';
+  if (/stripe\.com\/jobs/i.test(url)) return 'stripe';
+  if (/greenhouse\.io/i.test(url)) return 'greenhouse';
+  if (/jobs\.lever\.co/i.test(url)) return 'lever';
+  return 'generic';
+}
 
 // Presales / territory / off-archetype title negatives (the big SKIP bucket).
 const TITLE_NEG = [
-  /solutions?\s+(architect|engineer|consultant)/i, /customer engineer/i, /sales engineer/i,
+  /sales engineer/i, /solutions? consultant/i,
   /account (exec|manager)/i, /presales|pre-sales/i, /field (solutions?|engineer)/i, /\bgtm\b/i,
   /business development/i, /\bpartner\b/i, /developer relations|devrel|advocate/i,
   /machine learning|\bml engineer\b|data scientist|data analyst|research (scientist|engineer)/i,
   /product manager|program manager|\bvp\b|vice president|\bchief\b/i,
   /frontend|front-end|\bux\b|design systems/i, /\bintern\b|working student|\bjunior\b|associate/i,
+  /new grad|entry.level/i,
 ];
-const titleSkip = (t) => (TITLE_NEG.find(re => re.test(t)) || null) && TITLE_NEG.find(re => re.test(t)).source;
+// Solutions Architect/Engineer + Customer Engineer are only presales-SKIP when they lack a
+// technical qualifier — "AI Solutions Architect / FDE" is one of Patrick's ARCHETYPES
+// (Komodo 4.5), so a blanket kill contradicts the profile. Generic territory SA/SE still dies.
+const PRESALES_SOFT = /solutions?\s+(architect|engineer)|customer engineer/i;
+const TECH_HINT = /\b(ai|ml|llm|agent|agentic|security|cloud|platform|infra(structure)?|data|devops|sre)\b/i;
+const titleSkip = (t) => {
+  const hit = TITLE_NEG.find(re => re.test(t));
+  if (hit) return hit.source;
+  if (PRESALES_SOFT.test(t) && !TECH_HINT.test(t)) return 'presales SA/SE without technical qualifier';
+  return null;
+};
 
 // Parse a single comp token to $K. Handles "214.2K", "$252K", "120,000", "$140,000".
 function tokenToK(tok) {
@@ -71,6 +108,20 @@ function compGate(comp) {
   if (!nums.length) return { ok: true, note: 'comp unparsed' };
   const max = Math.round(Math.max(...nums));
   return max < COMP_FLOOR ? { ok: false, note: `comp max $${max}K < $${COMP_FLOOR}K floor` } : { ok: true, note: `comp max $${max}K` };
+}
+
+// Eval history: URLs triage has already spent LLM tokens on. Only ≥4.0 evals land in the
+// tracker, so without this a sub-4.0 role gets re-fetched and re-evaluated on every run
+// that covers its scan date (same-day re-runs, UTC-date overlap) — duplicate spend and,
+// at temperature wobble, flip-flopping alerts.
+const TRIAGE_HIST = join(ROOT, 'data/triage-history.tsv');
+function evaluatedUrls() {
+  if (!existsSync(TRIAGE_HIST)) return new Set();
+  return new Set(readFileSync(TRIAGE_HIST, 'utf-8').split('\n').slice(1).map(l => l.split('\t')[0]).filter(Boolean));
+}
+function recordEvaluated(url, date, score, status) {
+  if (!existsSync(TRIAGE_HIST)) writeFileSync(TRIAGE_HIST, 'url\tdate\tscore\tstatus\n', 'utf-8');
+  appendFileSync(TRIAGE_HIST, `${url}\t${date}\t${score}\t${status}\n`, 'utf-8');
 }
 
 // Dedup against tracker (company+role already evaluated/applied).
@@ -95,28 +146,46 @@ function rows() {
 }
 
 const escapeHtml = (s) => (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-async function telegramAlert(scored) {
+// url → digest index, so the alert can say `reply "apply N"` and the listener resolves it.
+function digestIndexMap() {
+  try {
+    const d = JSON.parse(readFileSync(DIGEST, 'utf-8'));
+    return new Map((d.jobs || []).map(j => [j.url, j.index]));
+  } catch { return new Map(); }
+}
+async function telegramAlert(scored, autoApplied = []) {
   const cfg = loadTelegramConfig(join(ROOT, '.env'));
   if (!cfg.token || !cfg.chatId) { console.log('(no telegram config — skipping alert)'); return; }
+  const idx = digestIndexMap();
+  const appliedUrls = new Map(autoApplied.map(a => [a.url, a.applyOk]));
   const apply = scored.filter(s => parseFloat(s.score) >= 4.0).sort((a, b) => parseFloat(b.score) - parseFloat(a.score));
+  const capped = scored.filter(s => s.policy_reason && s.status === 'SKIP');
   let msg = `<b>career-ops triage</b> — ${scored.length} evaluated, ${apply.length} ≥4.0`;
-  if (apply.length) for (const s of apply)
-    msg += `\n\n🎯 <b>${s.score}</b> — ${escapeHtml(s.company)}: ${escapeHtml(s.role)}${s.location_verdict === 'confirm' ? ' ⚠️confirm-remote' : ''}\n${s.url}`;
+  if (apply.length) for (const s of apply) {
+    msg += `\n\n🎯 <b>${s.score}</b> — ${escapeHtml(s.company)}: ${escapeHtml(s.role)}`;
+    if (appliedUrls.has(s.url)) msg += appliedUrls.get(s.url) ? '\n🚀 <b>auto-applied ✅</b>' : '\n🚀 auto-apply FAILED — apply manually';
+    else if (s.needs_confirm) msg += `\n⚠️ location unconfirmed — verify before applying${idx.has(s.url) ? `, then reply "apply ${idx.get(s.url)}"` : ''}`;
+    else if (idx.has(s.url)) msg += `\n▶️ reply "apply ${idx.get(s.url)}" to apply`;
+    msg += `\n${s.url}`;
+  }
   else msg += `\nNothing ≥4.0 today.`;
+  if (capped.length) msg += `\n\n⛔ ${capped.length} policy-capped (location/comp): ${capped.map(s => escapeHtml(s.company)).join(', ')}`;
   try { await sendMessage(cfg, cfg.chatId, msg); console.log('📨 Telegram alert sent'); }
   catch (e) { console.error('telegram failed:', e.message); }
 }
 
 // ── run ──────────────────────────────────────────────────────────────────
 const all = rows().slice(0, limit === Infinity ? undefined : limit);
-const buckets = { 'skip-title': 0, 'skip-location': 0, 'skip-comp': 0, 'in-tracker': 0, 'fetch-fail': 0, survivors: 0 };
+const buckets = { 'skip-title': 0, 'skip-location': 0, 'skip-comp': 0, 'in-tracker': 0, 'already-evaled': 0, 'fetch-fail': 0, survivors: 0 };
 const survivors = [];
+const evaluated = evaluatedUrls();
 
 console.log(`\n🔎 triage: ${all.length} scanned jobs ${onDate ? `on ${onDate}` : sinceDate ? `since ${sinceDate}` : '(all)'}${dryRun ? '  [DRY-RUN: gates only]' : ''}\n`);
 
 for (const r of all) {
   if (titleSkip(r.title)) { buckets['skip-title']++; continue; }
   if (inTracker(r.company, r.title)) { buckets['in-tracker']++; continue; }
+  if (evaluated.has(r.url)) { buckets['already-evaled']++; continue; }
   const job = await fetchJob(r.url, { company: r.company });
   if (!job.ok) { buckets['fetch-fail']++; console.log(`  ⚠️  fetch-fail: ${r.company} — ${r.title} (${job.error})`); continue; }
   const loc = assessLocation(job);
@@ -125,7 +194,7 @@ for (const r of all) {
   if (!cg.ok) { buckets['skip-comp']++; console.log(`  💸 skip-comp: ${r.company} — ${r.title} (${cg.note})`); continue; }
   buckets.survivors++;
   survivors.push({ ...r, job, loc, cg });
-  console.log(`  ✅ survivor: ${r.company} — ${r.title}  [loc:${loc.verdict}, ${cg.note}]`);
+  console.log(`  ✅ survivor: ${r.company} — ${r.title}  [loc:${loc.verdict}, ${cg.note}]\t${r.url}`);
 }
 
 console.log(`\n── Funnel ──`);
@@ -140,8 +209,13 @@ for (const s of survivors) {
   let result, text;
   try { ({ result, text } = await evaluateJD({ jdText: jobToJdText(s.job), company: s.company, url: s.url, locVerdict: s.loc })); }
   catch (e) { console.log(`  ❌ ${s.company} — ${s.title}: ${e.message}`); continue; }
+  recordEvaluated(s.url, s.date, result.score, result.status || 'Evaluated');
   scored.push({ ...s, ...result, text });
-  console.log(`  ${parseFloat(result.score) >= 4.0 ? '🟢' : '⚪'} ${result.score}/5  ${s.company} — ${result.role}  [${result.location_verdict}]`);
+  if (result.policy_reason) {
+    console.log(`  ⛔ ${result.score}/5 (model said ${result.original_score ?? result.score})  ${s.company} — ${result.role}  [${result.policy_reason}]`);
+  } else {
+    console.log(`  ${parseFloat(result.score) >= 4.0 ? '🟢' : '⚪'} ${result.score}/5  ${s.company} — ${result.role}  [gate:${result.location_verdict}, eval:${result.location_policy}${result.needs_confirm ? ', ⚠️confirm' : ''}]`);
+  }
 }
 scored.sort((a, b) => parseFloat(b.score) - parseFloat(a.score));
 
@@ -155,13 +229,47 @@ if (doWrite) {
     const slug = slugify(s.company + '-' + s.role);
     const fn = `${n}-${slug}-${today}.md`;
     writeFileSync(join(REPORTS_DIR, fn), buildReportMarkdown({ result: s, text: s.text, url: s.url, locVerdict: s.loc, date: today }), 'utf-8');
-    const note = `Auto-eval (OpenRouter ${DEFAULT_MODEL}): ${s.archetype}; loc:${s.location_verdict}; ${s.cg.note}`.replace(/[\t\n]/g, ' ').slice(0, 200);
+    const note = `Auto-eval (OpenRouter ${DEFAULT_MODEL}): ${s.archetype}; loc:${s.location_verdict}/${s.location_policy}; ${s.cg.note}${s.needs_confirm ? '; CONFIRM location before applying' : ''}`.replace(/[\t\n]/g, ' ').slice(0, 200);
     writeFileSync(join(ROOT, 'batch/tracker-additions', `${n}-${slug}.tsv`),
-      `${n}\t${today}\t${s.company}\t${s.role}\tEvaluated\t${s.score}/5\t❌\t[${n}](reports/${fn})\t${note}\n`, 'utf-8');
+      `${n}\t${today}\t${s.company}\t${s.role}\t${s.status || 'Evaluated'}\t${s.score}/5\t❌\t[${n}](reports/${fn})\t${note}\n`, 'utf-8');
     written++;
     console.log(`  📝 report ${n} + TSV: ${s.company} — ${s.role} (${s.score})`);
   }
   if (written) { try { execFileSync('node', [join(ROOT, 'merge-tracker.mjs')], { cwd: ROOT, stdio: 'inherit' }); } catch (e) { console.error('  merge failed:', e.message); } }
+}
+
+// ── Tier-1 auto-apply: score ≥ threshold AND gate+eval BOTH policy-clean ──────
+// Runs AFTER merge so apply-orchestrator finds the report/tracker row (its claude -p
+// eval fallback doesn't exist on CT 203). CV falls back to the latest output/cv-*.pdf
+// and the cover letter is skipped when claude CLI is unavailable — by design: the voice
+// engine's ceiling rule forbids unattended LLM cover letters anyway.
+const autoApplied = [];
+if (doWrite && !noAutoApply) {
+  const cfg = loadApplyConfig();
+  const PASS_GATE = new Set(['pass-remote', 'pass-denver']);
+  const PASS_EVAL = new Set(['REMOTE_US', 'DENVER_METRO']);
+  const candidates = !cfg.enabled ? [] : scored.filter(s =>
+    (s.status || 'Evaluated') !== 'SKIP' && !s.needs_confirm &&
+    parseFloat(s.score) >= cfg.threshold &&
+    PASS_GATE.has(s.loc.verdict) &&
+    PASS_EVAL.has((s.location_policy || '').toUpperCase()) &&
+    cfg.platforms.includes(detectPlatform(s.url)));
+  if (!cfg.enabled) console.log('\n(auto-apply disabled in profile.yml)');
+  else if (!candidates.length) console.log(`\n(no auto-apply candidates ≥ ${cfg.threshold} with clean location + supported platform)`);
+  for (const s of candidates) {
+    console.log(`\n🚀 auto-apply (${s.score} ≥ ${cfg.threshold}): ${s.company} — ${s.role}`);
+    try {
+      const out = execFileSync('node',
+        [join(ROOT, 'apply-orchestrator.mjs'), `--url=${s.url}`, '--submit'],
+        { cwd: ROOT, encoding: 'utf-8', timeout: 600000 });
+      const ok = /Application submitted successfully|"applied":\s*true/.test(out);
+      autoApplied.push({ ...s, applyOk: ok });
+      console.log(ok ? '   ✅ submitted' : `   ⚠️ not submitted — ${(out.match(/error[":\s]+([^\n"]{0,120})/i) || [])[1] || 'see log'}`);
+    } catch (e) {
+      autoApplied.push({ ...s, applyOk: false });
+      console.log(`   ❌ apply failed: ${(e.stdout || e.message || '').toString().slice(-200)}`);
+    }
+  }
 }
 
 // Backfill digest scores.
@@ -178,5 +286,5 @@ const apply = scored.filter(s => parseFloat(s.score) >= 4.0);
 console.log(`\n🎯 ${apply.length} role(s) ≥ 4.0:`);
 for (const s of apply) console.log(`   ${s.score}  ${s.company} — ${s.role}  ${s.url}`);
 
-if (doWrite) await telegramAlert(scored);
+if (doWrite) await telegramAlert(scored, autoApplied);
 console.log('');

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -152,7 +152,7 @@ if (badScores === 0) ok('All scores valid');
 let badRows = 0;
 for (const line of lines) {
   if (!line.startsWith('|')) continue;
-  if (line.includes('---') || line.includes('Empresa')) continue;
+  if (line.includes('---') || line.includes('Company') || line.includes('Empresa')) continue;
   const parts = line.split('|');
   if (parts.length < 9) {
     error(`Row with <9 columns: ${line.substring(0, 80)}...`);


### PR DESCRIPTION
## Why

A month of daily scans produced zero applications and untrustworthy scores. Root causes: the June 5 triage rewrite never wired auto-apply back in; the Haiku eval scored 4.8 on roles that violate the hard location policy (Zürich 25% on-site, "Remote-Friendly (Travel-Required)"); and the finder was blind to 10 boards it thought it was scanning.

## Scorer — fail-closed at three layers

- **`lib/location-gate.mjs`**: %-in-office regexes ("in one of our offices at least 25%"), an explicit Remote-Friendly-(Travel-Required) tag rule, and a head-of-JD city scan when location metadata is empty. +5 regression cases from the real misses; 18/18 self-tests (`node lib/location-gate.mjs`).
- **`openrouter-eval.mjs`**: prompt no longer tells the model unverified locations were "pre-cleared"; SCORE_SUMMARY now carries `LOCATION_POLICY` / `LOCATION_EVIDENCE` / `COMP_MAX_K`; new `enforcePolicy()` caps NON_US / NON_DENVER_OFFICE / TRAVEL_REQUIRED to 1.0/SKIP **in code** and UNCLEAR locations below the apply threshold. Model advises, code decides.
- Default model Haiku 4.5 → Sonnet 5 (~$0.09/eval at 1–5 survivors/day); temperature 0.4 → 0.2 (same JD scored 3.7 and 4.2 back-to-back across the 4.0 alert threshold).
- Validated live: the known-bad backlog roles (two Anthropic 4.8s, Replit 4.6, Cloudflare Austin 4.3) now die at the gate or get code-capped; known-good Komodo passes untouched.

## Auto-apply — reconnected

- `triage.mjs` calls `apply-orchestrator.mjs --submit` for score ≥ `auto_apply_threshold` when the gate verdict AND the eval's LOCATION_POLICY are both clean and the platform is whitelisted. `--no-auto-apply` flag for manual runs.
- Orchestrator CLI `--submit` was parsed but never threaded through (every CLI call submitted). Now bare CLI = fill-only, review-first per AGENTS.md.

## Finder

- Workday cxs support: paginated board parser in `scan.mjs` (`api_type: workday`) + JD detail fetch in `lib/ats-fetch.mjs`.
- Scan-time non-US location pre-filter (~500–700 drops/day before the digest).
- `scan-builtin.mjs` fixed for Built In's current DOM (`data-id` hooks — company names were coming back empty).
- Triage no longer blanket-kills Solutions Architect/Engineer titles (an explicit user archetype) — only presales SA/SE without a technical qualifier.
- Eval-history gate (`data/triage-history.tsv`) stops re-paying for sub-4.0 evals on date-overlapping runs, and quota errors (OpenRouter 403 weekly limit) abort the loop with a Telegram notice instead of burning the survivor list.
- Telegram triage alert now maps roles to digest indices (`reply "apply N"`) and reports auto-apply outcomes.

## Ops

- `sync-ct203.sh` (pull/push/status) to keep the local checkout and the CT 203 scanner from diverging — the prior split-brain silently ate a month of results.
- CLAUDE.md + TODO.md refreshed for the new pipeline state.

## Testing

- `node test-all.mjs --quick`: 79 passed, 0 failed
- `node lib/location-gate.mjs`: 18/18
- Live end-to-end on CT 203: scan (79 boards, Workday included) → gates → Sonnet evals → policy caps firing on real JDs (Bangalore role, 25–50%-travel role) → tracker merge → Telegram alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTGWV9jMVSqusDvjp9krhq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more automated job-search workflow, including scanning, triage, follow-up reminders, interview prep generation, and optional application submission.
  * Added Telegram-based digests and command handling for faster review and actioning.

* **Bug Fixes**
  * Improved role deduplication and row parsing to reduce false matches and formatting issues.
  * Added location and compensation filtering to better exclude unsuitable roles earlier.

* **Documentation**
  * Expanded and translated workflow guidance and interview-prep content for clearer end-to-end use.

* **Chores**
  * Updated ignore rules for generated files, auth data, and output folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->