### PR TITLE
fix(web): resolve report by the tracker row's link, not the row number (#1623)

### DIFF
--- a/tracker-columns-tests.mjs
+++ b/tracker-columns-tests.mjs
@@ -284,6 +284,37 @@ const TSV_NO_LOCATION = '2\t2026-02-02\tGlobex\tManager\tApplied\tN/A\t✅\t—\
   }
 }
 
+// ── Test 8b (#1623): report resolves by the row's link, not the row number ──
+// The web report page resolved a report purely by tracker row number, assuming
+// row `#N` maps to report file `N`. Those are separate counters that drift, so
+// the row's own Report-cell link is authoritative. reportLinkTarget() extracts
+// that link's basename (findReportFile in career-ops.ts then joins it under
+// reports/ and only falls back to the number scan when the cell has no link).
+{
+  const { reportLinkTarget } = await import('./web/src/lib/tracker-table.mjs');
+  const cases = [
+    // [reportCell, expected]
+    ['[006](../reports/006-acme-2026-01-01.md)', '006-acme-2026-01-01.md'], // drift: row #7 → report 006
+    ['[6](reports/006-acme-2026-01-01.md)', '006-acme-2026-01-01.md'],      // root-relative link
+    ['❌', null],                                                            // no PDF/report yet
+    ['—', null],                                                            // em-dash placeholder
+    ['', null],                                                             // empty cell
+    ['006', null],                                                          // bare number, no link
+  ];
+  let ok = true;
+  for (const [cell, expected] of cases) {
+    const got = reportLinkTarget(cell);
+    if (got !== expected) { ok = false; fail(`reportLinkTarget(${JSON.stringify(cell)}) → ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`); }
+  }
+  if (ok) pass('reportLinkTarget: extracts the linked report basename, null when the cell has no .md link (#1623)');
+  // Traversal safety: the basename is bare, so a link can't escape reports/.
+  if (reportLinkTarget('[x](../../etc/passwd.md)') === 'passwd.md') {
+    pass('reportLinkTarget: strips leading path — resolution can never escape reports/');
+  } else {
+    fail(`reportLinkTarget: path not stripped — got ${JSON.stringify(reportLinkTarget('[x](../../etc/passwd.md)'))}`);
+  }
+}
+
 // ═══ Stage 2 (#1596): Via column ════════════════════════════════════════════
 
 const HEADER_VIA = `# Applications Tracker

--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { atomicWrite } from "@/lib/core/safe-write";
-import { parseApplications } from "@/lib/tracker-table.mjs";
+import { parseApplications, reportLinkTarget } from "@/lib/tracker-table.mjs";
 
 /**
  * Resolve the career-ops "home" — the directory holding the user's sibling
@@ -197,6 +197,16 @@ export type ReportData = { content: string; file: string };
 /** Locate the evaluation report for an application number
  *  (reports/{n}-{slug}-{date}.md; the leading number may be zero-padded). */
 export function findReportFile(n: string): string | null {
+  // The tracker row's own Report link is authoritative: a report's leading
+  // number and its tracker row number (`#`) are separate counters that can
+  // drift, so resolving purely by row number can open a different role's report
+  // (#1623). Only fall back to the leading-number scan when the row has no
+  // usable link — an older row, or a report generated after the row was added.
+  const linked = reportLinkTarget(findApplication(n)?.report ?? "");
+  if (linked) {
+    const file = path.join(careerOpsRoot(), "reports", linked);
+    if (fs.existsSync(file)) return file;
+  }
   const target = parseInt(n, 10);
   if (Number.isNaN(target)) return null;
   let files: string[];

--- a/web/src/lib/tracker-table.mjs
+++ b/web/src/lib/tracker-table.mjs
@@ -137,3 +137,22 @@ export function parseApplications(md, rootDir) {
   }
   return rows;
 }
+
+/**
+ * Extract the report FILE NAME a tracker row's Report cell links to.
+ *
+ * The row's Report cell (e.g. `[006](../reports/006-acme-2026-01.md)`) is the
+ * authoritative pointer to that row's report: a report's leading number and the
+ * tracker row number (`#`) are two independent counters that can drift, so
+ * resolving a report purely by row number can surface a different role's report
+ * (#1623). The returned value is always a bare basename (any leading `../` path
+ * is stripped), so callers join it under a known `reports/` dir — a link can
+ * never escape that directory.
+ * @param {string} reportCell - the row's Report column text.
+ * @returns {string | null} the linked file's basename ("006-acme-2026-01.md"),
+ *   or null when the cell has no `.md` link (empty, "—", or a bare "❌").
+ */
+export function reportLinkTarget(reportCell) {
+  const match = String(reportCell ?? "").match(/\(([^()\s]+\.md)\)/);
+  return match ? match[1].split("/").pop() : null;
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the web report page opening the **wrong role's report**. `findReportFile(n)` resolved a report by assuming the tracker row number (`#`) equals the report file's leading number, but those are two independent sequential counters and drift in practice (e.g. row `#7` links report `006`). It now resolves via the row's own **Report-column link** — which already points at the correct file — and only falls back to the leading-number scan when the row has no usable link.

## Related issue

Fixes #1623

Root-cause diagnosis and the fallback approach credit to **@gdiab** in the issue.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## How

- Add `reportLinkTarget()` to `web/src/lib/tracker-table.mjs` — a pure, Node-importable helper (the same `.mjs`-so-tests-can-import-it pattern the file already documents) that pulls the linked report's basename out of a Report cell. It returns a **bare basename**, so a link can never escape `reports/`.
- `findReportFile()` in `web/src/lib/career-ops.ts` prefers that link and keeps the leading-number scan as a fallback (older rows, or a report generated after the row was inserted). Existing behavior is unchanged when there is no link.

## Testing

- Added regression checks in `tracker-columns-tests.mjs` (Test 8b): the drift case, root-relative links, empty / `❌` / `—` / bare-number cells, and path-traversal safety.
- `node test-all.mjs` → **1535 passed, 0 failed** (the single warning is the pre-existing `cv-sync-check.mjs` "expected without user data" note on a fresh clone).
- `web` `tsc --noEmit` clean; `web` unit tests 19/19.
- Ran on Node 22.5+ (required by `tracker.mjs`'s `node:sqlite` in the suite).

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (this is a bug fix — exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter parsing of report links in the web reader (supports linked markdown targets and root-relative links).
  * Report lookup now prefers the report linked from the tracker when determining which report file to open.

* **Bug Fixes**
  * Improved handling of missing, placeholder, and non-link report values.
  * Added safeguards to prevent unsafe path traversal when resolving linked report targets.

* **Tests**
  * Added regression tests covering report link extraction and linked report file matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->