### PR TITLE
fix(tests): skip web-reader tests when web/ is absent (core-only installs)

### DIFF
--- a/tracker-columns-tests.mjs
+++ b/tracker-columns-tests.mjs
@@ -18,13 +18,22 @@
  */
 
 import { execFileSync } from 'child_process';
-import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, utimesSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, utimesSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const NODE = process.execPath;
+
+// web/ lives deliberately OUTSIDE the auto-updater's world (its own
+// release-please component; see validate-system-paths-coverage.mjs
+// EXCLUDE_PREFIXES), so installs updated via `update-system.mjs apply` have
+// the core WITHOUT the web/ tree. The web-reader tests below exercise the
+// real alias chain on fresh clones and CI, and skip cleanly on core-only
+// installs instead of crashing the whole suite with ERR_MODULE_NOT_FOUND.
+const HAS_WEB = existsSync(join(ROOT, 'web', 'src', 'lib', 'tracker-table.mjs'));
+function skipWeb(m) { console.log(`SKIP ${m} — web/ not present (core-only install; web/ is excluded from the auto-updater by design)`); }
 
 let passed = 0;
 let failed = 0;
@@ -249,7 +258,9 @@ const TSV_NO_LOCATION = '2\t2026-02-02\tGlobex\tManager\tApplied\tN/A\t✅\t—\
 // HEADER_ALIASES — instead of mirroring it. Passing ROOT here exercises the
 // REAL alias file, so an alias added/renamed there is either honored by the
 // web reader too or fails this test; a second drifting table can't come back.
-{
+if (!HAS_WEB) {
+  skipWeb('web reader: shared alias table tests');
+} else {
   const { parseApplications, loadHeaderAliases } = await import('./web/src/lib/tracker-table.mjs');
   const { HEADER_ALIASES } = await import('./tracker-parse.mjs');
   const WEB_10COL = `# Applications Tracker
@@ -488,7 +499,9 @@ const HEADER_VIA = `# Applications Tracker
 // mtime-keyed: a missing/corrupt file is NEVER cached — recovery is picked up
 // without a server restart — and a rewritten file (system update changing the
 // alias table) is re-read on the next call.
-{
+if (!HAS_WEB) {
+  skipWeb('web reader: alias cache refresh tests');
+} else {
   const { loadHeaderAliases } = await import('./web/src/lib/tracker-table.mjs');
   const dir = mkdtempSync(join(tmpdir(), 'co-alias-'));
   const aliasFile = join(dir, 'tracker-aliases.json');


### PR DESCRIPTION
Closes #1675

web/ is deliberately excluded from the auto-updater (its own release-please component; validate-system-paths-coverage.mjs EXCLUDE_PREFIXES), so installs updated via `update-system.mjs apply` have the core without the web/ tree. tracker-columns-tests.mjs imported `web/src/lib/tracker-table.mjs` unconditionally, crashing the whole suite with ERR_MODULE_NOT_FOUND on every updated install; fresh clones and CI were unaffected.

## Change

Guard Tests 8 and 16 behind an existsSync check (`HAS_WEB`): full alias-chain coverage still runs wherever web/ exists (fresh clones, CI), and core-only installs log SKIP lines instead of failing test-all. One file changed, +16/-3.

## Verification

- With web/ present: 38 passed, 0 failed, exit 0 (unchanged coverage)
- With web/ removed: 31 passed, 0 failed, 2 SKIP lines, exit 0
- Real-world origin: a v1.13.0 → v1.18.0 `apply` ("Updated 194 system paths") crashed test-all exactly here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved regression test handling so web-specific test suites are skipped when the web package isn’t installed.
  * Added clearer skip messaging for those cases, while keeping the existing test behavior unchanged when the web package is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->