### PR TITLE
fix(update-system): add .claude/hooks/ to USER_PATHS

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -299,6 +299,7 @@ const USER_PATHS = [
   'plugins.local/',
   'plugins.lock',
   '.claude/settings.json',
+  '.claude/hooks/',
 ];
 
 function parseVersionFile(raw) {

--- a/validate-system-paths-coverage.mjs
+++ b/validate-system-paths-coverage.mjs
@@ -89,6 +89,7 @@ if (process.argv.includes('--self-test')) {
   // Test exact matches in SYSTEM_PATHS / USER_PATHS
   assert(covered('CLAUDE.md') === true, 'CLAUDE.md must be covered (exact match)');
   assert(covered('.claude/settings.json') === true, '.claude/settings.json must be covered (USER_PATHS exact match, #1408)');
+  assert(covered('.claude/hooks/pre-push-backup.sh') === true, '.claude/hooks/ scripts must be covered (USER_PATHS dir prefix match, same class as #1408)');
 
   // Test directory prefix matches (which end in '/')
   assert(covered('providers/justjoin.mjs') === true, 'providers/justjoin.mjs must be covered (dir prefix match)');


### PR DESCRIPTION
Closes #1676

Same class as #1408 (.claude/settings.json): user forks track their own Claude Code hook scripts under .claude/hooks/ — e.g. a backup or publish-gate hook whose loss silently disables the mechanism itself. The repo ships no hooks (.claude/ contains only skills/), so any tracked hook is user harness config by definition, and validate-system-paths-coverage.mjs (and therefore test-all.mjs) hard-fails the fork with a coverage-gap error.

## Change

- `update-system.mjs`: add `'.claude/hooks/'` to USER_PATHS (dir prefix match)
- `validate-system-paths-coverage.mjs`: mirror the #1408 self-test assertion for the new prefix

Because USER_PATHS also drives the apply-time safety validation, this additionally guarantees the updater can never ship files into a user's .claude/hooks/.

## Verification

- `node validate-system-paths-coverage.mjs --self-test`: ALL SELF-TESTS PASSED
- Controlled repro: with a hook staged and WITHOUT the fix → exit 1, "Coverage gap: .claude/hooks/pre-push-backup.sh"; WITH the fix → exit 0, "OK: 665 tracked files covered"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened safety checks so changes in protected user-area locations are now blocked and rolled back instead of being applied.
  * Improved path coverage validation to recognize additional protected hook-related locations, reducing the chance of unsafe updates slipping through.

* **Tests**
  * Added coverage checks to verify the new protected-path behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->