### PR TITLE
feat(registry): add serper and theirstack provider plugins

### DIFF
--- a/plugins-registry/serper.json
+++ b/plugins-registry/serper.json
@@ -1,0 +1,14 @@
+{
+  "id": "serper",
+  "name": "career-ops-plugin-serper",
+  "version": "0.1.0",
+  "license": "MIT",
+  "description": "Google Search provider via Serper.dev — drop-in replacement for the discontinued serpapi provider, with isFallback detect so free ATS providers are never shadowed.",
+  "repo": "https://github.com/uelkerd/career-ops-plugin-serper",
+  "sha": "ed769c59601d26b6cf2e48cf5e621f7b4f9e5aa5",
+  "hooks": ["provider"],
+  "requiredEnv": ["SERPER_API_KEY"],
+  "allowedHosts": ["google.serper.dev"],
+  "registrationIssue": "https://github.com/santifer/career-ops/issues/1645",
+  "addedAt": "2026-07-07"
+}

--- a/plugins-registry/theirstack.json
+++ b/plugins-registry/theirstack.json
@@ -1,0 +1,14 @@
+{
+  "id": "theirstack",
+  "name": "career-ops-plugin-theirstack",
+  "version": "0.1.0",
+  "license": "MIT",
+  "description": "TheirStack API provider — structured job search across 50k+ sources with title/country/remote filters; handles both string and object company response shapes.",
+  "repo": "https://github.com/uelkerd/career-ops-plugin-theirstack",
+  "sha": "a0e5add9bb7bd6f115392535c298bb4b7058c945",
+  "hooks": ["provider"],
+  "requiredEnv": ["THEIRSTACK_API_KEY"],
+  "allowedHosts": ["api.theirstack.com"],
+  "registrationIssue": "https://github.com/santifer/career-ops/pull/1680",
+  "addedAt": "2026-07-07"
+}

--- a/plugins-registry/theirstack.json
+++ b/plugins-registry/theirstack.json
@@ -9,6 +9,6 @@
   "hooks": ["provider"],
   "requiredEnv": ["THEIRSTACK_API_KEY"],
   "allowedHosts": ["api.theirstack.com"],
-  "registrationIssue": "https://github.com/santifer/career-ops/pull/1680",
+  "registrationIssue": "https://github.com/santifer/career-ops/issues/1697",
   "addedAt": "2026-07-07"
 }


### PR DESCRIPTION
Registry PR: two new provider plugins for keyed APIs that cannot live in the zero-keys open core.

### career-ops-plugin-serper
Repo: https://github.com/uelkerd/career-ops-plugin-serper

Key: SERPER_API_KEY | Egress: google.serper.dev
Google Search via Serper.dev, drop-in for discontinued serpapi. isFallback detect so free ATS providers
are never shadowed. Packaged form of #1645 .

### career-ops-plugin-theirstack
Repo: https://github.com/uelkerd/career-ops-plugin-theirstack

Key: THEIRSTACK_API_KEY | Egress: api.theirstack.com
TheirStack structured job search, 50k+ sources, pre-structured results. Supports job_title_or,
job_country_code_or, remote, posted_at_max_age_days, limit filters. Closes #1697

### Checklist
- [x] Repos named career-ops-plugin-<name>
- [x] manifest.json — apiVersion, requiredEnv, allowedHosts, humanInTheLoop: true
- [x] index.mjs uses ctx.fetchJson/ctx.env, no bare fetch, no node:http/net
- [x] skill.md, test/smoke.mjs (passes), README.md, LICENSE (MIT)
- [x] Entries pinned to exact commit SHA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added plugin registry entries for two new provider integrations: **serper** and **theirstack**.
  * Each integration includes provider metadata, requires an environment-variable API key, limits outbound requests to approved hosts, and includes a registration reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->