### PR TITLE
feat(pdf): deterministic HTML CV renderer to cut PDF-step token burn (#557)

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -1,0 +1,431 @@
+#!/usr/bin/env node
+
+// Deterministic HTML CV renderer (#557 — the HTML twin of build-cv-latex.mjs).
+//
+// The agent reads cv.md + config/profile.yml, tailors the content, and writes a
+// compact JSON payload. This script merges that payload into the resolved CV
+// template (default templates/cv-template.html; pass a path resolved by
+// cv-templates.mjs to honor config-selectable templates, #1691) — it owns every
+// tag, class, and the HTML escaping,
+// so the model never has to emit the full document. That moves the PDF step's
+// output tokens from full HTML markup down to the structured JSON payload while
+// producing byte-for-byte the same ATS-safe template the agent fills today.
+//
+// The script does NOT parse cv.md / YAML: the authoritative read of the source
+// files stays in the agent (same contract as build-cv-latex.mjs / modes/latex.md).
+// generate-pdf.mjs remains the single PDF renderer and is unchanged.
+
+import { readFile, writeFile, stat, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { resolve, dirname, basename, join } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = resolve(__dirname, 'templates', 'cv-template.html');
+const PLACEHOLDER_RE = /\{\{[A-Z_]+\}\}/g;
+const CONTACT_ROW_RE = /<div class="contact-row">[\s\S]*?<\/div>/;
+
+const PAGE_WIDTHS = { letter: '8.5in', a4: '210mm' };
+
+const DEFAULT_SECTION_TITLES = {
+  summary: 'Professional Summary',
+  competencies: 'Core Competencies',
+  experience: 'Work Experience',
+  projects: 'Projects',
+  education: 'Education',
+  certifications: 'Certifications',
+  skills: 'Skills',
+};
+
+// Escape user text for HTML text/attribute context. Covers the five characters
+// that change meaning in markup so tailored bullets containing &, <, >, quotes
+// (e.g. "R&D", "scaled 10x < budget", 'the "north star" metric') render as
+// literal text instead of breaking the document or injecting tags.
+function escapeHtml(text) {
+  if (typeof text !== 'string') return '';
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Sanitize a URL for an href attribute: only allow the schemes the template's
+// contact row uses, coerce bare emails/domains, drop javascript:/data: and other
+// script-bearing schemes, then HTML-escape for the attribute context.
+function sanitizeUrl(url) {
+  if (typeof url !== 'string') return '';
+  url = url.trim();
+  if (!url) return '';
+  const allowedSchemes = ['mailto:', 'tel:', 'http:', 'https:'];
+  const lower = url.toLowerCase();
+  const hasScheme = allowedSchemes.some(s => lower.startsWith(s));
+  if (!hasScheme) {
+    if (/^[a-z][a-z0-9+.-]*:/i.test(url)) {
+      // An explicit but disallowed scheme (javascript:, data:, …) — reject it.
+      return '';
+    }
+    if (url.includes('@') && !url.includes('/')) {
+      url = 'mailto:' + url;
+    } else {
+      url = 'https://' + url;
+    }
+  }
+  return escapeHtml(url);
+}
+
+function joinItems(items) {
+  if (Array.isArray(items)) return items.join(', ');
+  return typeof items === 'string' ? items : '';
+}
+
+// --- Section builders: each returns the inner HTML for one {{PLACEHOLDER}}. ---
+
+function buildCompetencies(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return '';
+  return entries
+    .filter(Boolean)
+    .map(tag => `<span class="competency-tag">${escapeHtml(String(tag))}</span>`)
+    .join('\n      ');
+}
+
+function buildExperience(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return '';
+  return entries.filter(Boolean).map(e => {
+    const bullets = Array.isArray(e.bullets)
+      ? e.bullets.filter(Boolean).map(b => `        <li>${escapeHtml(b)}</li>`).join('\n')
+      : '';
+    const location = e.location
+      ? `\n    <div class="job-location">${escapeHtml(e.location)}</div>`
+      : '';
+    return `<div class="job">
+    <div class="job-header">
+      <span class="job-company">${escapeHtml(e.company)}</span>
+      <span class="job-period">${escapeHtml(e.dates || e.period || '')}</span>
+    </div>
+    <div class="job-role">${escapeHtml(e.role)}</div>${location}
+    <ul>
+${bullets}
+    </ul>
+  </div>`;
+  }).join('\n  ');
+}
+
+function buildProjects(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return '';
+  return entries.filter(Boolean).map(e => {
+    const badge = e.badge
+      ? `<span class="project-badge">${escapeHtml(e.badge)}</span>`
+      : '';
+    // Prefer a single description; fall back to joining bullets into one line so
+    // a bullets-shaped payload still renders inside the .project-desc block.
+    const descText = e.description
+      || (Array.isArray(e.bullets) ? e.bullets.filter(Boolean).join(' ') : '');
+    const desc = descText
+      ? `\n    <div class="project-desc">${escapeHtml(descText)}</div>`
+      : '';
+    const tech = e.tech
+      ? `\n    <div class="project-tech">${escapeHtml(e.tech)}</div>`
+      : '';
+    return `<div class="project">
+    <div class="project-title">${escapeHtml(e.name)}${badge}</div>${desc}${tech}
+  </div>`;
+  }).join('\n  ');
+}
+
+function buildEducation(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return '';
+  return entries.filter(Boolean).map(e => {
+    const org = e.org
+      ? ` <span class="edu-org">${escapeHtml(e.org)}</span>`
+      : '';
+    const desc = e.description
+      ? `\n    <div class="edu-desc">${escapeHtml(e.description)}</div>`
+      : '';
+    return `<div class="edu-item">
+    <div class="edu-header">
+      <div class="edu-title">${escapeHtml(e.title)}${org}</div>
+      <div class="edu-year">${escapeHtml(e.year || '')}</div>
+    </div>${desc}
+  </div>`;
+  }).join('\n  ');
+}
+
+function buildCertifications(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return '';
+  return entries.filter(Boolean).map(e => {
+    const org = e.org ? `<span class="cert-org">${escapeHtml(e.org)}</span>` : '<span class="cert-org"></span>';
+    const year = e.year ? `<span class="cert-year">${escapeHtml(e.year)}</span>` : '<span class="cert-year"></span>';
+    return `<div class="cert-item">
+      <span class="cert-title">${escapeHtml(e.title)}</span>
+      ${org}
+      ${year}
+    </div>`;
+  }).join('\n    ');
+}
+
+function buildSkills(categories) {
+  if (!Array.isArray(categories) || categories.length === 0) return '';
+  const items = categories.filter(Boolean).map(c => {
+    const cat = c.category
+      ? `<span class="skill-category">${escapeHtml(c.category)}:</span> `
+      : '';
+    return `    <div class="skill-item">${cat}${escapeHtml(joinItems(c.items))}</div>`;
+  }).join('\n');
+  return `<div class="skills-grid">
+${items}
+  </div>`;
+}
+
+// Rebuild the whole .contact-row block. Its markup uses fixed "|" separators
+// between phone / email / linkedin / portfolio / location, so an absent optional
+// field (phone, linkedin, portfolio) must drop BOTH its <a> and one separator.
+// Building the present items and joining them is more robust than excising
+// separators from the template one placeholder at a time.
+function buildContactRow(candidate) {
+  const c = candidate || {};
+  const items = [];
+  if (c.phone) {
+    const tel = sanitizeUrl('tel:' + String(c.phone).replace(/\s+/g, ''));
+    items.push(`<a href="${tel}">${escapeHtml(c.phone)}</a>`);
+  }
+  if (c.email) {
+    items.push(`<a href="${sanitizeUrl('mailto:' + c.email)}">${escapeHtml(c.email)}</a>`);
+  }
+  if (c.linkedin && c.linkedin.url) {
+    items.push(`<a href="${sanitizeUrl(c.linkedin.url)}">${escapeHtml(c.linkedin.display || c.linkedin.url)}</a>`);
+  }
+  if (c.portfolio && c.portfolio.url) {
+    items.push(`<a href="${sanitizeUrl(c.portfolio.url)}">${escapeHtml(c.portfolio.display || c.portfolio.url)}</a>`);
+  }
+  if (c.location) {
+    items.push(`<span>${escapeHtml(c.location)}</span>`);
+  }
+  const sep = '\n      <span class="separator">|</span>\n      ';
+  return `<div class="contact-row">\n      ${items.join(sep)}\n    </div>`;
+}
+
+function buildPhoto(candidate, name) {
+  const photo = candidate && candidate.photo;
+  if (!photo) return '';
+  return `<img class="cv-photo" src="${sanitizeUrl(photo)}" alt="${escapeHtml(name || '')}">`;
+}
+
+function renderReport(payload) {
+  const sectionTitles = { ...DEFAULT_SECTION_TITLES, ...(payload.sections || {}) };
+  const candidate = payload.candidate || {};
+  const pageWidth = PAGE_WIDTHS[payload.page_format] || PAGE_WIDTHS.letter;
+
+  const substitutions = {
+    LANG: escapeHtml(payload.lang || 'en'),
+    PAGE_WIDTH: pageWidth,
+    NAME: escapeHtml(candidate.name || ''),
+    SECTION_SUMMARY: escapeHtml(sectionTitles.summary),
+    SUMMARY_TEXT: escapeHtml(payload.summary || ''),
+    SECTION_COMPETENCIES: escapeHtml(sectionTitles.competencies),
+    COMPETENCIES: buildCompetencies(payload.competencies),
+    SECTION_EXPERIENCE: escapeHtml(sectionTitles.experience),
+    EXPERIENCE: buildExperience(payload.experience),
+    SECTION_PROJECTS: escapeHtml(sectionTitles.projects),
+    PROJECTS: buildProjects(payload.projects),
+    SECTION_EDUCATION: escapeHtml(sectionTitles.education),
+    EDUCATION: buildEducation(payload.education),
+    SECTION_CERTIFICATIONS: escapeHtml(sectionTitles.certifications),
+    CERTIFICATIONS: buildCertifications(payload.certifications),
+    SECTION_SKILLS: escapeHtml(sectionTitles.skills),
+    SKILLS: buildSkills(payload.skills),
+  };
+  return { substitutions, candidate };
+}
+
+// Merge a payload into the template and return the final HTML (throws on any
+// unresolved {{PLACEHOLDER}} so a malformed payload fails loudly, not silently).
+function renderHtml(template, payload) {
+  const { substitutions, candidate } = renderReport(payload);
+
+  // The contact row and photo carry conditional markup (dropped separators /
+  // no <img>), so they are rebuilt as whole blocks before placeholder fill.
+  let html = template.replace(CONTACT_ROW_RE, () => buildContactRow(candidate));
+  html = html.replace(/\{\{PHOTO\}\}/g, () => buildPhoto(candidate, candidate.name));
+
+  for (const [key, value] of Object.entries(substitutions)) {
+    html = html.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), () => value);
+  }
+
+  const unresolved = html.match(PLACEHOLDER_RE);
+  if (unresolved) {
+    throw new Error(`Unresolved placeholders: ${[...new Set(unresolved)].join(', ')}`);
+  }
+  return html;
+}
+
+function countBullets(payload) {
+  const ex = Array.isArray(payload.experience)
+    ? payload.experience.flatMap(e => (Array.isArray(e?.bullets) ? e.bullets : []))
+    : [];
+  return ex.length;
+}
+
+async function writeAndReport(html, absOutput, payload, extra = {}) {
+  const outDir = dirname(absOutput);
+  if (!existsSync(outDir)) await mkdir(outDir, { recursive: true });
+  await writeFile(absOutput, html, 'utf-8');
+
+  const fileInfo = await stat(absOutput);
+  const report = {
+    ...extra,
+    file: basename(absOutput),
+    path: absOutput,
+    sizeKB: parseFloat((fileInfo.size / 1024).toFixed(1)),
+    counts: {
+      competencies: (payload.competencies || []).length,
+      experienceEntries: (payload.experience || []).length,
+      projectEntries: (payload.projects || []).length,
+      educationEntries: (payload.education || []).length,
+      certificationEntries: (payload.certifications || []).length,
+      skillCategories: (payload.skills || []).length,
+      totalBullets: countBullets(payload),
+    },
+    valid: true,
+  };
+  console.log(JSON.stringify(report, null, 2));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes('--help')) {
+    console.error('Usage:');
+    console.error('  node build-cv-html.mjs <input.json> <output.html> [template.html]');
+    console.error('  node build-cv-html.mjs --test');
+    console.error('');
+    console.error('  [template.html] defaults to templates/cv-template.html. Pass the path');
+    console.error('  printed by `node cv-templates.mjs resolve cv` to use a selected template.');
+    process.exit(args.includes('--help') ? 0 : 1);
+  }
+
+  if (args.includes('--test')) {
+    await runSelfTest();
+    return;
+  }
+
+  const [inputPath, outputPath, templateArg] = args;
+  if (!inputPath || !outputPath) {
+    console.error('Usage: node build-cv-html.mjs <input.json> <output.html> [template.html]');
+    process.exit(1);
+  }
+
+  const absInput = resolve(inputPath);
+  const absOutput = resolve(outputPath);
+  const templatePath = templateArg ? resolve(templateArg) : TEMPLATE_PATH;
+
+  if (!existsSync(absInput)) {
+    console.error(`Input file not found: ${absInput}`);
+    process.exit(1);
+  }
+  if (!existsSync(templatePath)) {
+    console.error(`Template not found: ${templatePath}`);
+    process.exit(1);
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(await readFile(absInput, 'utf-8'));
+  } catch (err) {
+    console.error(`Failed to parse input JSON: ${err.message}`);
+    process.exit(1);
+  }
+
+  const template = await readFile(templatePath, 'utf-8');
+
+  let html;
+  try {
+    html = renderHtml(template, payload);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+
+  await writeAndReport(html, absOutput, payload);
+  process.exit(0);
+}
+
+async function runSelfTest() {
+  const sample = {
+    lang: 'en',
+    page_format: 'letter',
+    candidate: {
+      name: 'Test Candidate',
+      phone: '+1 234 567 8900',
+      email: 'test@example.com',
+      linkedin: { url: 'https://linkedin.com/in/test', display: 'linkedin.com/in/test' },
+      portfolio: { url: 'https://test.example.com', display: 'test.example.com' },
+      location: 'City, State',
+    },
+    summary: 'Backend engineer with a focus on R&D and cost-efficient "north star" systems.',
+    competencies: ['Cloud Architecture', 'RESTful API Design', 'Kubernetes & Docker'],
+    experience: [{
+      company: 'Test Corp',
+      role: 'Test Engineer',
+      location: 'Remote',
+      dates: 'June 2024 - Present',
+      bullets: [
+        'Built automated testing pipelines with CI/CD integration',
+        'Reduced regression test time by 60% through parallel execution',
+      ],
+    }],
+    projects: [{
+      name: 'Test Project',
+      badge: 'Open Source',
+      tech: 'Python, FastAPI, Docker',
+      description: 'Built a REST API with automated test coverage exceeding 90%.',
+    }],
+    education: [{
+      title: 'Bachelor of Science in Computer Science',
+      org: 'Test University',
+      year: '2024',
+      description: 'Coursework: Data Structures, Algorithms, Machine Learning.',
+    }],
+    certifications: [{ title: 'Certified Kubernetes Administrator', org: 'CNCF', year: '2025' }],
+    skills: [
+      { category: 'Languages', items: 'Python, JavaScript, TypeScript' },
+      { category: 'Frameworks', items: ['FastAPI', 'React', 'PyTorch'] },
+    ],
+  };
+
+  if (!existsSync(TEMPLATE_PATH)) {
+    console.error(`Self-test failed: template not found at ${TEMPLATE_PATH}`);
+    process.exit(1);
+  }
+
+  const template = await readFile(TEMPLATE_PATH, 'utf-8');
+
+  let html;
+  try {
+    html = renderHtml(template, sample);
+  } catch (err) {
+    console.error(`Self-test failed: ${err.message}`);
+    process.exit(1);
+  }
+
+  // Guard the escaping contract: the raw ampersand from "Kubernetes & Docker"
+  // must reach the output escaped, and no unescaped literal must survive.
+  if (!html.includes('Kubernetes &amp; Docker')) {
+    console.error('Self-test failed: HTML escaping did not apply to competency text');
+    process.exit(1);
+  }
+  if (/Kubernetes & Docker/.test(html)) {
+    console.error('Self-test failed: found an unescaped ampersand in output');
+    process.exit(1);
+  }
+
+  const absOutput = resolve(join(tmpdir(), 'build-cv-html-test.html'));
+  await writeAndReport(html, absOutput, sample, { status: 'self-test-passed' });
+
+  await import('fs/promises').then(fs => fs.rm(absOutput).catch(() => {}));
+  process.exit(0);
+}
+
+main();

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -17,9 +17,9 @@
 11. Build competency grid from JD requirements (6-8 keyword phrases)
 12. Inject keywords naturally into existing achievements (NEVER invent)
 13. Apply the six-second clarity gate from `modes/heuristics/recruiter-side.md`: top third must make target role, strongest fit, and proof obvious
-14. Generate full HTML from template + personalized content
-15. Read `name` from `config/profile.yml` → normalize to kebab-case lowercase (e.g. "John Doe" → "john-doe") → `{candidate}`
-16. Write HTML to `output/cv-{candidate}-{company}.html` (NOT a temp dir — the recorded HTML is what the dashboard's `D` hotkey regenerates from, so it must survive temp cleanup)
+14. Read `name` from `config/profile.yml` → normalize to kebab-case lowercase (e.g. "John Doe" → "john-doe") → `{candidate}`
+15. Build the render payload (see the **JSON Input Schema** below) from the tailored content — emit compact structured JSON, **not** full HTML markup — and write it to `/tmp/cv-{candidate}-{company}.json`
+16. Run: `node build-cv-html.mjs /tmp/cv-{candidate}-{company}.json output/cv-{candidate}-{company}.html {template}` — where `{template}` is the path printed by **Selecting the template** below (omit the argument to use the base `cv-template.html`). The script merges the payload into that template, owning every tag, CSS class, and the HTML escaping. Write to `output/` (NOT a temp dir — the recorded HTML is what the dashboard's `D` hotkey regenerates from, so it must survive temp cleanup)
 17. Run the fact gate: `node verify-cv-facts.mjs output/cv-{candidate}-{company}.html`
     - This is a hard gate before PDF rendering.
     - If it fails, stop and fix the generated HTML by removing invented metrics or adding verified evidence to `cv.md`, `article-digest.md`, or `config/cv-facts.json`.
@@ -91,35 +91,84 @@ The command prints the absolute path of the template to fill; a non-zero exit me
 
 To show the user their options (e.g. "what CV templates do I have?"), run `node cv-templates.mjs list cv` and present each `displayName`.
 
-Then fill the resolved template's `{{...}}` placeholders with personalized content:
+`build-cv-html.mjs` fills that resolved template from the JSON payload you build — it owns every tag, CSS class, and the HTML escaping, so you **never emit full HTML markup** and do **not** escape `&`/`<`/`>`/quotes yourself. Pass the resolved path as the third argument (`node build-cv-html.mjs <input.json> <output.html> <template.html>`); omit it to fall back to the base `cv-template.html`. This is the HTML twin of `build-cv-latex.mjs` (see `modes/latex.md`) and cuts the PDF step's output tokens from full markup down to the compact payload below (#557).
 
-| Placeholder | Content |
-|-------------|-----------|
-| `{{LANG}}` | CV language code (e.g. `en`, `es`, `ja`, `ar`). Drives language-specific CSS in the template: `ja` enables a CJK font fallback so Japanese renders instead of tofu (□); `ar` enables RTL + Arabic fonts. Use the BCP-47/ISO-639 code that matches the CV language. |
-| `{{PAGE_WIDTH}}` | `8.5in` (letter) or `210mm` (A4) |
-| `{{PHOTO}}` | Opt-in profile photo (#264). When `profile.yml` has a non-empty `candidate.photo`, replace with `<img class="cv-photo" src="<path-or-data-URL>" alt="{{NAME}}">`; otherwise **remove the whole `{{PHOTO}}` line** so no markup (and no `<img>`) is emitted. Opt-in for DACH/European markets — an absent photo renders identically (pixel-for-pixel) to the photoless layout (US/UK and many-market ATS penalize photos). |
-| `{{NAME}}` | (from profile.yml) |
-| `{{PHONE}}` | (from profile.yml — include with its separator only when `profile.yml` has a non-empty `phone` value; omit both the `<a href="tel:…">` element and the following `<span class="separator">` otherwise) |
-| `{{EMAIL}}` | (from profile.yml) |
-| `{{LINKEDIN_URL}}` | [from profile.yml] |
-| `{{LINKEDIN_DISPLAY}}` | [from profile.yml] |
-| `{{PORTFOLIO_URL}}` | [from profile.yml] (or /es depending on language) |
-| `{{PORTFOLIO_DISPLAY}}` | [from profile.yml] (or /es depending on language) |
-| `{{LOCATION}}` | [from profile.yml] |
-| `{{SECTION_SUMMARY}}` | Professional Summary |
-| `{{SUMMARY_TEXT}}` | Personalized summary with keywords |
-| `{{SECTION_COMPETENCIES}}` | Core Competencies |
-| `{{COMPETENCIES}}` | `<span class="competency-tag">keyword</span>` × 6-8 |
-| `{{SECTION_EXPERIENCE}}` | Work Experience |
-| `{{EXPERIENCE}}` | HTML for each job with reordered bullets |
-| `{{SECTION_PROJECTS}}` | Projects |
-| `{{PROJECTS}}` | HTML for top 3-4 projects |
-| `{{SECTION_EDUCATION}}` | Education |
-| `{{EDUCATION}}` | Education HTML |
-| `{{SECTION_CERTIFICATIONS}}` | Certifications |
-| `{{CERTIFICATIONS}}` | Certifications HTML |
-| `{{SECTION_SKILLS}}` | Skills |
-| `{{SKILLS}}` | Skills HTML |
+### JSON Input Schema
+
+Write a JSON file with this structure, then run `node build-cv-html.mjs <input.json> <output.html> [template.html]` (the optional third argument is the template path from **Selecting the template**; omit it for the base `cv-template.html`).
+
+```json
+{
+  "lang": "en",
+  "page_format": "letter",
+  "candidate": {
+    "name": "Jane Smith",
+    "phone": "+1 415 555 0100",
+    "email": "jane@example.com",
+    "linkedin": { "url": "https://linkedin.com/in/janesmith", "display": "linkedin.com/in/janesmith" },
+    "portfolio": { "url": "https://janesmith.dev", "display": "janesmith.dev" },
+    "location": "San Francisco, CA",
+    "photo": ""
+  },
+  "sections": {
+    "summary": "Professional Summary",
+    "competencies": "Core Competencies",
+    "experience": "Work Experience",
+    "projects": "Projects",
+    "education": "Education",
+    "certifications": "Certifications",
+    "skills": "Skills"
+  },
+  "summary": "Personalized summary with JD keywords injected (honest vs cv.md).",
+  "competencies": ["RAG Pipelines", "LLMOps", "Kubernetes & Docker"],
+  "experience": [
+    {
+      "company": "Company Name",
+      "role": "Job Title",
+      "location": "Remote",
+      "dates": "June 2022 - Present",
+      "bullets": ["Achievement bullet with JD keywords injected", "Another quantified-impact bullet"]
+    }
+  ],
+  "projects": [
+    { "name": "Project Name", "badge": "Open Source", "tech": "Python, FastAPI", "description": "What it does." }
+  ],
+  "education": [
+    { "title": "B.S. Computer Science", "org": "University Name", "year": "2022", "description": "Optional line." }
+  ],
+  "certifications": [
+    { "title": "Certified Kubernetes Administrator", "org": "CNCF", "year": "2024" }
+  ],
+  "skills": [
+    { "category": "Languages", "items": "Python, JavaScript, C++" },
+    { "category": "Frameworks", "items": ["FastAPI", "React", "PyTorch"] }
+  ]
+}
+```
+
+### Field reference
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `lang` | string | CV language code (`en`, `es`, `ja`, `ar`). Drives language-specific CSS: `ja` enables a CJK font fallback so Japanese renders instead of tofu (□); `ar` enables RTL + Arabic fonts. Defaults to `en`. |
+| `page_format` | string | `letter` → `8.5in` page width, `a4` → `210mm`. Defaults to `letter`. Pass the SAME value to `generate-pdf.mjs --format`. |
+| `candidate.name` | string | From `profile.yml`. |
+| `candidate.phone` | string | Optional — **omit or leave empty** to drop the `tel:` link and its separator (no empty cell). |
+| `candidate.email` | string | From `profile.yml`. |
+| `candidate.linkedin` | `{url, display}` | Optional — omit to drop the item and its separator. |
+| `candidate.portfolio` | `{url, display}` | Optional — omit to drop the item and its separator. |
+| `candidate.location` | string | From `profile.yml`. |
+| `candidate.photo` | string | Opt-in profile photo (#264): a local path or `data:` URL. Empty/absent emits **no `<img>`**, rendering pixel-for-pixel identical to the photoless layout (US/UK/many-market ATS penalize photos; opt in for DACH/European markets). |
+| `sections` | object | Optional localized section titles; any omitted key falls back to the English default shown above. |
+| `summary` | string | Personalized summary with keywords. |
+| `competencies` | string[] | 6-8 keyword phrases → competency tags. |
+| `experience[]` | object | `company`, `role`, `location` (optional), `dates`, `bullets` (reordered, keyword-injected). |
+| `projects[]` | object | `name`, `badge` (optional), `tech` (optional), `description` (a `bullets` array is also accepted and joined into the description line). |
+| `education[]` | object | `title` (degree), `org` (institution), `year`, `description` (optional). |
+| `certifications[]` | object | `title`, `org`, `year`. |
+| `skills[]` | object | `category` + `items` (comma-separated string or string array). |
+
+`build-cv-html.mjs` errors out (non-zero exit) if any template placeholder is left unresolved, so a malformed payload fails loudly instead of shipping a broken CV. Run `node build-cv-html.mjs --test` for a self-test render.
 
 ### Profile photo (opt-in, market-specific)
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -156,6 +156,7 @@ const scripts = [
   { name: 'funnel-velocity.mjs --self-test', expectExit: 0 },
   { name: 'img-to-pdf.mjs --self-test', expectExit: 0 },
   { name: 'assessment-log.mjs --self-test', expectExit: 0 },
+  { name: 'build-cv-html.mjs --test', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
   { name: 'agent-inbox-tests.mjs', expectExit: 0 },

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -257,6 +257,7 @@ const SYSTEM_PATHS = [
   '.github/',
   'package.json',
   'build-cv-latex.mjs',
+  'build-cv-html.mjs',
   'cv-templates.mjs',
   'test/cv-templates.test.mjs',
   'scaffolder/',


### PR DESCRIPTION
## What does this PR do?

Adds `build-cv-html.mjs` — a deterministic HTML CV renderer that is the **HTML twin of `build-cv-latex.mjs`** (#905). This is the "remaining half" of #557 that @santifer described: the LaTeX path already moved rendering off the model; this does the same for the default HTML/ATS path.

Today `modes/pdf.md` has the agent **write the full HTML document** by hand-filling `cv-template.html`'s placeholders, so the model pays output tokens for every tag, CSS class, and repeated section layout on each run. This moves that render into a script: the agent emits a **compact JSON payload**, and `build-cv-html.mjs` owns the tags and HTML escaping and merges it into the existing template.

**Output-token effect (same JD, before vs after the render step):** the agent goes from emitting the full **~14.2 KB** HTML document to a **~1.5 KB** JSON payload — a ~9× reduction on the render step, matching the LaTeX twin's measured `~8-10K → 2-3K` tokens. `generate-pdf.mjs` is unchanged.

### Changes

- **`build-cv-html.mjs`** (new): `<input.json> <output.html>`. HTML-escapes all user text (`& < > " '`), sanitizes hrefs (blocks `javascript:`/`data:`), rebuilds the conditional contact row (drops an absent phone/linkedin/portfolio **and its separator** — no empty cells) and the opt-in `{{PHOTO}}`, honors localized section titles and `lang`/`page_format`, **errors on any unresolved placeholder** so a malformed payload fails loudly, prints a counts report, and ships a `--test` self-test.
- **`modes/pdf.md`**: route the HTML build through the script (payload → `build-cv-html.mjs` → `generate-pdf.mjs`) and document the JSON input schema + field reference.
- **`update-system.mjs`**: register `build-cv-html.mjs` in `SYSTEM_PATHS`.
- **`test-all.mjs`**: wire `build-cv-html.mjs --test` into the self-test list so CI exercises the renderer, not just its syntax.

### Acceptance criteria (from the issue)

- [x] Documented render-payload schema the agent builds after reading `cv.md` / `profile.yml` (per-job summary, competencies, section titles, selected bullets) — in `modes/pdf.md`.
- [x] Script produces final HTML from **template + agent-supplied JSON only** — it does **not** parse `cv.md`/YAML (authoritative read stays in the agent, same contract as `build-cv-latex.mjs`).
- [x] Before/after token comparison noted (above).

### Verification

- `node build-cv-html.mjs --test` → self-test passes (asserts the escaping contract: `Kubernetes & Docker` → `&amp;`, no unescaped literal survives).
- End-to-end: sample payload → `build-cv-html.mjs` → `generate-pdf.mjs` → **1-page ATS PDF**; `pypdf`/`pdftotext` extraction is clean (`&` and `<` round-trip, no ligature/tofu corruption).
- **`node test-all.mjs`**: 1538 passed, 0 failed (the 1 warning is the pre-existing `cv-sync-check.mjs` "expected without user data" baseline).

### Related issue

Fixes #557

### Type of change

- [x] New feature (non-breaking)

### Checklist

- [x] I read `CONTRIBUTING.md`
- [x] Linked to a related issue (`Fixes #557`)
- [x] No personal data (synthetic sample payload only)
- [x] Ran `node test-all.mjs`
- [x] Respects the Data Contract (system-layer files only)

---

Kept as a **draft** for a first look. @DSnoNintendo — you mentioned on #557 you already had a working script hitting ~12K→4K; this took the `build-cv-latex.mjs` route @santifer pointed to (JSON payload → template merge, HTML escaping instead of LaTeX). Very happy to fold in anything from your version, or step aside if you'd rather land yours — just say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deterministic CV HTML generation from structured JSON data and a selected template.
  - Added support for rendering contact details, photo, experience, projects, education, certifications, competencies, and skills.
  - Added HTML escaping and safe URL handling for generated content.
  - Added validation for unresolved template placeholders.
  - Added a self-test mode for validating HTML generation.

- **Documentation**
  - Documented the JSON input format, rendering command, template options, and validation behavior.

- **Tests**
  - Integrated the CV renderer self-test into the full test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->