### PR TITLE
test: cover 4dayweek provider detection

### DIFF
--- a/providers/4dayweek.mjs
+++ b/providers/4dayweek.mjs
@@ -25,6 +25,25 @@ const DEFAULT_MAX_PAGES = 3;
 const MAX_PAGES_CAP = 50;
 const SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
 
+function detectFourDayEntry(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  if (entry.provider === '4dayweek') return { url: FEED_BASE };
+  if (entry.provider) return null;
+
+  for (const value of [entry.api, entry.careers_url]) {
+    if (typeof value !== 'string') continue;
+    try {
+      const parsed = new URL(value);
+      if (parsed.protocol === 'https:' && parsed.hostname === TRUSTED_HOST) {
+        return { url: FEED_BASE };
+      }
+    } catch {
+      // Ignore malformed URLs; another provider may still claim the entry.
+    }
+  }
+  return null;
+}
+
 /** @param {string} url */
 function assertFourDayUrl(url) {
   let parsed;
@@ -109,6 +128,8 @@ export function normalize4dwJob(j, fallbackCompany) {
 /** @type {Provider} */
 export default {
   id: '4dayweek',
+
+  detect: detectFourDayEntry,
 
   async fetch(entry, ctx) {
     assertFourDayUrl(FEED_BASE);

--- a/tests/providers/4dayweek.test.mjs
+++ b/tests/providers/4dayweek.test.mjs
@@ -1,7 +1,5 @@
 // tests/providers/4dayweek.test.mjs — renamed from fourdayweek.test.mjs to match
 // the provider id, so `--only providers/4dayweek` discovers it (#1657).
-// Note: providers/4dayweek.mjs has no detect() method (unlike echojobs.mjs), so
-// there's no detect() contract to test here — same as tests/providers/thehub.test.mjs.
 import { pass, fail, ROOT } from '../helpers.mjs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
@@ -10,11 +8,51 @@ console.log('\nProvider — 4dayweek');
 
 try {
   const fdwModule = await import(pathToFileURL(join(ROOT, 'providers/4dayweek.mjs')).href);
+  const { resolveProvider } = await import(pathToFileURL(join(ROOT, 'providers/_registry.mjs')).href);
   const fourdayweek = fdwModule.default;
   const { normalize4dwJob } = fdwModule;
 
   if (fourdayweek.id === '4dayweek') pass('4dayweek.id is "4dayweek"');
   else fail(`4dayweek.id is ${JSON.stringify(fourdayweek.id)}`);
+
+  const explicitHit = fourdayweek.detect({ name: '4 Day Week', provider: '4dayweek' });
+  if (explicitHit?.url === 'https://4dayweek.io/api/jobs') {
+    pass('4dayweek.detect() claims explicit provider config');
+  } else {
+    fail(`4dayweek.detect() explicit provider = ${JSON.stringify(explicitHit)}`);
+  }
+
+  const careersHit = fourdayweek.detect({ name: '4 Day Week', careers_url: 'https://4dayweek.io/jobs' });
+  const apiHit = fourdayweek.detect({ name: '4 Day Week', api: 'https://4dayweek.io/api/jobs' });
+  if (careersHit?.url === 'https://4dayweek.io/api/jobs' && apiHit?.url === 'https://4dayweek.io/api/jobs') {
+    pass('4dayweek.detect() maps trusted 4dayweek.io URLs to the feed URL');
+  } else {
+    fail(`4dayweek.detect() trusted URLs = ${JSON.stringify({ careersHit, apiHit })}`);
+  }
+
+  const detectMisses = [
+    fourdayweek.detect({ name: 'X' }),
+    fourdayweek.detect({ name: 'Other', provider: 'echojobs', careers_url: 'https://4dayweek.io/jobs' }),
+    fourdayweek.detect({ name: 'Path spoof', careers_url: 'https://evil.example/4dayweek.io/jobs' }),
+    fourdayweek.detect({ name: 'Suffix spoof', careers_url: 'https://4dayweek.io.evil.example/jobs' }),
+    fourdayweek.detect({ name: 'HTTP', careers_url: 'http://4dayweek.io/jobs' }),
+    fourdayweek.detect({ name: 'Non-string', careers_url: 42 }),
+  ];
+  if (detectMisses.every(hit => hit === null)) {
+    pass('4dayweek.detect() rejects missing, other-provider, spoofed, http, and non-string URLs');
+  } else {
+    fail(`4dayweek.detect() misses = ${JSON.stringify(detectMisses)}`);
+  }
+
+  const resolved = resolveProvider(
+    { name: '4 Day Week', careers_url: 'https://4dayweek.io/jobs' },
+    new Map([['4dayweek', fourdayweek]]),
+  );
+  if (resolved && 'provider' in resolved && resolved.provider === fourdayweek) {
+    pass('provider registry dispatches 4dayweek.detect() for trusted 4dayweek.io URLs');
+  } else {
+    fail(`provider registry did not dispatch 4dayweek.detect(): ${JSON.stringify(resolved)}`);
+  }
 
   // normalize4dwJob — full mapping (url is BUILT from slug; feed has no url).
   const full = normalize4dwJob(


### PR DESCRIPTION
## Summary
- add `detect()` support for the 4dayweek board provider
- cover explicit provider config, trusted 4dayweek URLs, spoof/non-HTTPS/non-string rejects
- add a registry-level assertion that `resolveProvider()` dispatches `4dayweek.detect()` for trusted 4dayweek.io URLs

## Validation
- `node test-all.mjs --only providers/4dayweek` ✅
- `git diff --check origin/main...HEAD` ✅

Follow-up to #1674 / #1657.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection for 4dayweek job sources, recognizing feeds from trusted careers and API URLs.
  * Improved provider selection so matching feeds are identified without manual configuration.

* **Bug Fixes**
  * Strengthened URL validation to ignore unsafe, non-HTTPS, or spoofed inputs.

* **Tests**
  * Expanded test coverage to verify detection behavior and correct provider dispatch via the provider registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->