### PR TITLE
feat(oferta): flag JDs where AI/transformation buzzwords don't match company infrastructure

### DIFF
--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -190,6 +190,22 @@ If this combination is present, append a short, non-alarmist note to the report 
 
 This signal does not change the High Confidence / Proceed with Caution / Suspicious tier below — it is orthogonal to ghost-job detection and is reported separately.
 
+**7. AI-Buzzword vs. Infrastructure Mismatch** (from JD text, plus Block D research already gathered — no additional queries):
+
+Some JDs describe the company the org *wants to become*, not the org as it is: heavy "AI enablement / digital transformation / process innovation" language sitting on top of infrastructure that is nowhere near ready for it. The candidate finds out only after burning a prescreen (or more) that the "AI" role is really digitization and backlog-cleanup work first, AI work maybe eventually. That can still be a fine role — but the candidate should know before applying, not after.
+
+Check the JD for these three signal classes:
+
+- **Buzzword density vs. role scope:** AI/transformation/innovation/enablement language is prominent, but the actual seniority, title, or listed responsibilities don't match ownership of transformation outcomes (e.g., a mid-level individual-contributor role expected to "drive AI transformation across the organization").
+- **Team-size mismatch:** the JD mentions a small team (roughly 5 people or fewer) expected to own "transformation" outcomes for a large org — a common tell that the mandate outstrips the resourcing.
+- **Industry base rate:** the company is in a traditional/legacy-heavy industry (manufacturing, aerospace/defense, industrial, heavy logistics) where basic digitization is often still incomplete — AI is being bolted onto a foundation that may not exist yet. This is a base rate, not a verdict: plenty of legacy-industry roles are genuine; it only counts as a signal in combination with the others.
+
+**Only flag when 2+ of the three signal classes are present.** If flagged, append a short, non-alarmist note to the report (descriptive, never prescriptive — this can be exactly the kind of high-impact greenfield role some candidates want):
+
+> ⚠️ **Buzzword/infrastructure mismatch signal:** This JD leans on AI/transformation language ("{specific phrases found}") while {signals observed: small team owning transformation outcomes / scope-seniority mismatch / legacy-heavy industry}. The day-to-day may be foundational digitization and backlog cleanup before any AI work. If you proceed, probe the actual state of their systems directly in interviews — e.g. "What are the top 3 most urgent things this role needs to fix right now?", "Which systems would I be working with, and how mature are they?" — rather than relying on the JD's framing.
+
+This signal does not change the High Confidence / Proceed with Caution / Suspicious tier below — the posting can be entirely real and still oversell its AI maturity. It is orthogonal to ghost-job detection and is reported separately.
+
 ### Output format:
 
 **Assessment:** One of three tiers:


### PR DESCRIPTION
## Problem

A recurring pattern from recent manufacturing/aerospace interviews: the JD leans heavily on "AI enablement / digital transformation / process innovation" language, but the org's actual state is nowhere close — training records still in paper binders, HR unable to name their own HCM system. The JD describes who the company wants to become, not what it is. The candidate finds out only after burning a prescreen (or more) that the "AI" role is really digitization/backlog-cleanup work first, AI work maybe eventually.

## What this adds

A new prompt-level signal — **7. AI-Buzzword vs. Infrastructure Mismatch** — in `modes/oferta.md` Block G (Posting Legitimacy), following the exact pattern of the Employment Classification Risk signal (#1631):

Three signal classes checked against the JD text (plus Block D research already gathered — no additional queries):

1. **Buzzword density vs. role scope** — AI/transformation language prominent, but seniority/title/responsibilities don't match ownership of transformation outcomes
2. **Team-size mismatch** — a small team (~5 or fewer) expected to own "transformation" outcomes for a large org
3. **Industry base rate** — traditional/legacy-heavy industries (manufacturing, aerospace/defense, industrial) where basic digitization is often still incomplete; explicitly framed as a base rate, not a verdict

**2+ signal classes present → flag.** The report gets a short, non-alarmist note naming the specific phrases and signals found, plus suggested interview probes ("What are the top 3 most urgent things this role needs to fix right now?") instead of trusting the JD's framing.

Consistent with #1631's conventions: descriptive, never prescriptive; does **not** change the High Confidence / Proceed with Caution / Suspicious tier (the posting can be entirely real and still oversell its AI maturity — orthogonal to ghost-job detection, reported separately); no score auto-downgrade.

## Scope

- `modes/oferta.md` only — Block G signal 7. Matches #1631 precedent: batch prompt's condensed Block G and language modes are untouched (neither mirrors per-signal detail).
- No new files, so no `update-system.mjs` SYSTEM_PATHS registration needed.

## Tests

`node test-all.mjs`: **1533 passed**, 1 failed (known local batch-rate-limit `ENOENT batch-state.tsv` flake, unrelated), 1 warning (cv-sync-check without user data, expected).

Closes #1683

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new job-posting legitimacy signal to help identify listings that use heavy AI or transformation language without matching the role’s scope, seniority, team size, or likely industry context.
  * Introduced clearer reporting guidance for when this signal should be flagged, including a standard note format with matched phrases and supporting observations.
  * Clarified that this signal is reported separately and does not affect the overall legitimacy tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->