### PR TITLE
feat: add spend_tier config for model-agnostic model routing + pre-screen gate (economy/standard/premium)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,10 +164,14 @@ If `config/profile.yml` is missing, copy from `config/profile.example.yml` and t
 > - Your location and timezone
 > - What roles are you targeting? (e.g., 'Senior Backend Engineer', 'AI Product Manager')
 > - Your salary target range
+> - How much do you want to spend on model usage per evaluation? Three options:
+>   - **economy** — cheapest and fastest, good for scanning lots of offers quickly
+>   - **standard** — balanced cost and quality (default if you're not sure)
+>   - **premium** — most capable model, best for offers you really care about
 >
 > I'll set everything up for you."
 
-Fill in `config/profile.yml` with their answers. For archetypes and targeting narrative, store the user-specific mapping in `modes/_profile.md` or `config/profile.yml` rather than editing `modes/_shared.md`.
+Fill in `config/profile.yml` with their answers, including `spend_tier` (defaults to `standard` if they skip the question). For archetypes and targeting narrative, store the user-specific mapping in `modes/_profile.md` or `config/profile.yml` rather than editing `modes/_shared.md`.
 
 #### Step 3: Portals (recommended)
 If `portals.yml` is missing:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,10 +181,14 @@ If `config/profile.yml` is missing, copy from `config/profile.example.yml` and t
 > - Your location and timezone
 > - What roles are you targeting? (e.g., 'Senior Backend Engineer', 'AI Product Manager')
 > - Your salary target range
+> - How much do you want to spend on model usage per evaluation? Three options:
+>   - **economy** — cheapest and fastest, good for scanning lots of offers quickly
+>   - **standard** — balanced cost and quality (default if you're not sure)
+>   - **premium** — most capable model, best for offers you really care about
 >
 > I'll set everything up for you."
 
-Fill in `config/profile.yml` with their answers. For archetypes and targeting narrative, store the user-specific mapping in `modes/_profile.md` or `config/profile.yml` rather than editing `modes/_shared.md`.
+Fill in `config/profile.yml` with their answers, including `spend_tier` (defaults to `standard` if they skip the question). For archetypes and targeting narrative, store the user-specific mapping in `modes/_profile.md` or `config/profile.yml` rather than editing `modes/_shared.md`.
 
 #### Step 3: Portals (recommended)
 If `portals.yml` is missing:

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -336,7 +336,7 @@ read_spend_tier() {
       printf '%s\n' "standard"
       ;;
     *)
-      echo "WARN: Invalid spend_tier \"$raw\" in ${PROFILE_FILE#$PROJECT_DIR/}; falling back to standard." >&2
+      echo "WARN: Invalid spend_tier \"$raw\" in ${PROFILE_FILE#"$PROJECT_DIR/"}; falling back to standard." >&2
       printf '%s\n' "standard"
       ;;
   esac
@@ -541,7 +541,7 @@ process_offer() {
     if [[ -f "$context_file" ]]; then
       {
         printf '\n\n---\n\n'
-        printf '## Runtime personalization: %s\n\n' "${context_file#$PROJECT_DIR/}"
+        printf '## Runtime personalization: %s\n\n' "${context_file#"$PROJECT_DIR/"}"
         sed 's/^/    /' "$context_file"
         printf '\n'
       } >> "$resolved_prompt"

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -16,7 +16,9 @@ BATCH_DIR="$SCRIPT_DIR"
 INPUT_FILE="$BATCH_DIR/batch-input.tsv"
 STATE_FILE="$BATCH_DIR/batch-state.tsv"
 PROMPT_FILE="$BATCH_DIR/batch-prompt.md"
+PROFILE_FILE="$PROJECT_DIR/config/profile.yml"
 LOGS_DIR="$BATCH_DIR/logs"
+DISCARD_LOG="$LOGS_DIR/discard.log"
 TRACKER_DIR="$BATCH_DIR/tracker-additions"
 REPORTS_DIR="$PROJECT_DIR/reports"
 APPLICATIONS_FILE="$PROJECT_DIR/data/applications.md"
@@ -36,7 +38,9 @@ START_FROM=0
 MAX_RETRIES=2
 MIN_SCORE=0
 SKIP_PDF=false
-MODEL=""  # empty = let claude -p use the Claude Max default
+MODEL=""  # explicit override; otherwise resolved from config/profile.yml spend_tier
+RESOLVED_MODEL=""
+RESOLVED_SPEND_TIER=""
 RATE_LIMIT_SLEEP=300
 BATCH_PAUSED=false
 STATUS_ONLY=false
@@ -51,7 +55,7 @@ is_decimal_number() {
 usage() {
   cat <<'USAGE'
 career-ops batch runner — process job offers in batch via claude -p workers
-Uses your default Claude model (Claude Max subscription).
+Uses spend_tier from config/profile.yml unless --model overrides it.
 
 Usage: batch-runner.sh [OPTIONS]
 
@@ -67,9 +71,9 @@ Options:
   --skip-pdf           Skip PDF generation entirely (write ❌ in tracker PDF column)
   --rate-limit-sleep N Seconds to wait before retrying a rate-limited worker
                        (default: 300)
-  --model NAME         Claude model passed to `claude -p --model` (default:
-                       unset = Claude Max default). Use a cheaper model for
-                       large batches, e.g. `--model claude-sonnet-4-6`.
+  --model NAME         Override the tier-resolved Claude model passed to
+                       `claude -p --model` (otherwise uses config/profile.yml
+                       spend_tier: economy/standard/premium; default standard)
   --status             Show batch progress and a per-job table, then exit
   --watch              Live-refresh progress until the run completes
   -h, --help           Show this help
@@ -298,6 +302,78 @@ get_retries() {
   echo "${retries:-0}"
 }
 
+# Read spend_tier from config/profile.yml. Defaults to "standard" if the key
+# is absent or invalid.
+read_spend_tier() {
+  local raw=""
+
+  if [[ -f "$PROFILE_FILE" ]]; then
+    raw=$(
+      awk -F: '
+        /^[[:space:]]*spend_tier[[:space:]]*:/ {
+          value = substr($0, index($0, ":") + 1)
+          print value
+          exit
+        }
+      ' "$PROFILE_FILE"
+    )
+    raw="${raw%%#*}"
+    raw="${raw//$'\r'/}"
+    raw="${raw#"${raw%%[![:space:]]*}"}"
+    raw="${raw%"${raw##*[![:space:]]}"}"
+    case "$raw" in
+      \"*\") raw="${raw#\"}"; raw="${raw%\"}" ;;
+      \'*\') raw="${raw#\'}"; raw="${raw%\'}" ;;
+    esac
+    raw="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  fi
+
+  case "$raw" in
+    economy|standard|premium)
+      printf '%s\n' "$raw"
+      ;;
+    "")
+      printf '%s\n' "standard"
+      ;;
+    *)
+      echo "WARN: Invalid spend_tier \"$raw\" in ${PROFILE_FILE#$PROJECT_DIR/}; falling back to standard." >&2
+      printf '%s\n' "standard"
+      ;;
+  esac
+}
+
+# Tier -> model mapping. Keep in sync with the table in modes/_shared.md.
+spend_tier_to_model() {
+  case "$1" in
+    economy) echo "claude-haiku-4-5" ;;
+    premium) echo "claude-opus-4-8" ;;
+    standard|*) echo "claude-sonnet-4-6" ;;
+  esac
+}
+
+# Resolve the model to pass to `claude -p --model`. --model always wins.
+resolve_worker_model() {
+  if [[ -n "$MODEL" ]]; then
+    RESOLVED_MODEL="$MODEL"
+    RESOLVED_SPEND_TIER="override"
+    return 0
+  fi
+
+  RESOLVED_SPEND_TIER="$(read_spend_tier)"
+  RESOLVED_MODEL="$(spend_tier_to_model "$RESOLVED_SPEND_TIER")"
+}
+
+# Append a one-line, auditable record of a pre-screen-gate discard to
+# batch/logs/discard.log (see modes/batch.md — Pre-screen gate). Format:
+# {ISO8601 timestamp}\t{job id}\t{url}\t{reason}
+log_discard() {
+  local id="$1" url="$2" reason="$3"
+  mkdir -p "$LOGS_DIR"
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '%s\t%s\t%s\t%s\n' "$ts" "$id" "$url" "$reason" >> "$DISCARD_LOG"
+}
+
 # Calculate next report number.
 # Caller must hold STATE_LOCK_DIR while this runs.
 next_report_num_unlocked() {
@@ -473,15 +549,15 @@ process_offer() {
   done
 
   # Launch claude -p worker.
-  # Model defaults to the Claude Max subscription default unless --model was
+  # The model is resolved once per run from spend_tier unless --model was
   # passed. Building the command in an array keeps quoting safe regardless.
   # --strict-mcp-config (with no --mcp-config) starts workers with no MCP
   # servers: they only evaluate offers and need none. Without it each parallel
   # worker inherits the parent session's MCP (e.g. Playwright) and they deadlock
   # fighting over the single shared browser when --parallel > 1 (issue #506).
   local -a claude_args=(-p --dangerously-skip-permissions --strict-mcp-config)
-  if [[ -n "$MODEL" ]]; then
-    claude_args+=(--model "$MODEL")
+  if [[ -n "$RESOLVED_MODEL" ]]; then
+    claude_args+=(--model "$RESOLVED_MODEL")
   fi
   claude_args+=(--append-system-prompt-file "$resolved_prompt" "$prompt")
 
@@ -742,6 +818,8 @@ main() {
 
   check_prerequisites
 
+  resolve_worker_model
+
   if [[ "$DRY_RUN" == "false" ]]; then
     acquire_lock
     rm -f "$PAUSE_FILE"
@@ -764,6 +842,11 @@ main() {
     echo "Parallel: $PARALLEL | Max retries: $MAX_RETRIES | Limit: $LIMIT"
   else
     echo "Parallel: $PARALLEL | Max retries: $MAX_RETRIES"
+  fi
+  if [[ "$RESOLVED_SPEND_TIER" == "override" ]]; then
+    echo "Model: $RESOLVED_MODEL (explicit --model override)"
+  else
+    echo "Model: $RESOLVED_MODEL (spend_tier=${RESOLVED_SPEND_TIER})"
   fi
   echo "Input: $total_input offers"
   echo ""

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -85,6 +85,13 @@ location:
 #   responded_subsequent_days: 3
 #   interview_thankyou_days: 1
 
+# Controls which model tier evaluates your offers. Valid values:
+#   economy  -- cheapest/fastest model, no extended thinking. Best for high-volume scanning.
+#   standard -- balanced model, no extended thinking. Default if this key is absent.
+#   premium  -- most capable model, adaptive extended thinking. Best for high-stakes offers.
+# See the tier -> model mapping table in modes/_shared.md.
+spend_tier: standard
+
 cv:
   output_format: "html" # "html" (default) or "latex"
   # (Optional) Canva resume design ID for visual CV generation via /career-ops pdf.

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -32,6 +32,30 @@ The files below are the **ONLY** sources for user-facing content (CV, cover lett
 
 ---
 
+## Spend Tier (Model Routing)
+
+`config/profile.yml` may set `spend_tier` to control which model evaluates offers. Read it once per session.
+
+**Resolution:** Read `spend_tier` from `config/profile.yml`. If the key is absent, default to `standard` (back-compat for existing profiles). Any value other than the three below is treated as invalid -- fall back to `standard` and note the issue to the user once.
+
+**Tier -> model mapping (the only place model/provider names appear in this logic, one row per CLI -- see the Headless / Batch Mode table in `AGENTS.md` for the canonical CLI list):**
+
+| CLI | economy | standard | premium | Extended thinking |
+|-----|---------|----------|---------|--------------------|
+| Claude Code | Haiku 4.5 | Sonnet 4.6 | Opus 4.8 | off / off / adaptive |
+| OpenCode | your CLI's cheapest/fastest available model | balanced model | most capable model | off / off / adaptive |
+| Gemini CLI | your CLI's cheapest/fastest available model | balanced model | most capable model | off / off / adaptive |
+| Copilot CLI | your CLI's cheapest/fastest available model | balanced model | most capable model | off / off / adaptive |
+| Codex | your CLI's cheapest/fastest available model | balanced model | most capable model | off / off / adaptive |
+| Qwen | your CLI's cheapest/fastest available model | balanced model | most capable model | off / off / adaptive |
+| Antigravity CLI | your CLI's cheapest/fastest available model | balanced model | most capable model | off / off / adaptive |
+
+The Claude Code row uses concrete model names because that lineup is well-established. The other rows intentionally avoid naming specific models -- nobody on this project can verify current model lineups for those CLIs with confidence, and a wrong specific guess routes users to a model that doesn't exist. If you actively use one of these CLIs and know its current cheapest/balanced/most-capable models, a follow-up PR filling in concrete names for that row is welcome.
+
+Every other reference to tier elsewhere in the modes (batch.md, pipeline.md, etc.) MUST refer to it only as "the economy/standard/premium tier" or "the tier's model" -- never repeat a hardcoded model/provider name outside this table. This keeps the routing logic model-agnostic: if any CLI's mapping changes, only that row in this table needs to change.
+
+**Output parity:** The model used for evaluation never changes the A-F report structure, headers, or sections. All three tiers produce an evaluation in the exact same format described below and in `modes/oferta.md`.
+
 ## Scoring System
 
 The evaluation uses 6 blocks (A-F) with a global score of 1-5:

--- a/modes/batch.md
+++ b/modes/batch.md
@@ -25,7 +25,7 @@ Each worker is a headless child process with a clean 200K token context. The con
 
 Read `spend_tier` from `config/profile.yml` (see `modes/_shared.md` -- Spend Tier section; defaults to `standard` if absent).
 
-- **`standard` or `premium` tier:** Before a worker runs the full A-G evaluation on a JD, run a cheap pre-screen pass using the tier's economy-equivalent model (see the mapping table in `modes/_shared.md`) against the candidate's North Star archetypes (`modes/_profile.md`). If the JD is an obvious mismatch (wrong domain, wrong seniority band, disqualifying location/visa conflict), skip the full evaluation: mark the job `skipped` in `batch-state.tsv` with a one-line reason, and move to the next job.
+- **`standard` or `premium` tier:** Before a worker runs the full A-F evaluation on a JD, run a cheap pre-screen pass using the tier's economy-equivalent model (see the mapping table in `modes/_shared.md`) against the candidate's North Star archetypes (`modes/_profile.md`). If the JD is an obvious mismatch (wrong domain, wrong seniority band, disqualifying location/visa conflict), skip the full evaluation: mark the job `skipped` in `batch-state.tsv` with a one-line reason, and move to the next job.
 - **`economy` tier:** No gate. The tier is already the cheapest available -- running a pre-screen on top of it adds latency without saving spend. Every job goes straight to the full evaluation.
 - This gate only applies to batch/pipeline processing. It never applies to a single interactive evaluation (the user already decided the JD is worth a look by pasting/sharing it).
 

--- a/modes/batch.md
+++ b/modes/batch.md
@@ -21,6 +21,16 @@ Conductor (headed browser mode)
 
 Each worker is a headless child process with a clean 200K token context. The conductor only orchestrates. See the **Headless / Batch Mode** table in `AGENTS.md` for the correct command per CLI.
 
+## Pre-screen gate (standard / premium tiers only)
+
+Read `spend_tier` from `config/profile.yml` (see `modes/_shared.md` -- Spend Tier section; defaults to `standard` if absent).
+
+- **`standard` or `premium` tier:** Before a worker runs the full A-G evaluation on a JD, run a cheap pre-screen pass using the tier's economy-equivalent model (see the mapping table in `modes/_shared.md`) against the candidate's North Star archetypes (`modes/_profile.md`). If the JD is an obvious mismatch (wrong domain, wrong seniority band, disqualifying location/visa conflict), skip the full evaluation: mark the job `skipped` in `batch-state.tsv` with a one-line reason, and move to the next job.
+- **`economy` tier:** No gate. The tier is already the cheapest available -- running a pre-screen on top of it adds latency without saving spend. Every job goes straight to the full evaluation.
+- This gate only applies to batch/pipeline processing. It never applies to a single interactive evaluation (the user already decided the JD is worth a look by pasting/sharing it).
+
+**Discard log (auditable):** Every posting the gate filters out MUST be logged with a one-line reason so pre-filtering is never a silent black box. Append one line to `batch/logs/discard.log` (create the file/dir if absent) in the format `{ISO8601 timestamp}\t{job id}\t{url}\t{reason}`, in addition to the `skipped` row already written to `batch-state.tsv`. This log is the visible, auditable record of what the gate discarded and why -- review it periodically to tune the North Star archetypes if the gate is too aggressive or too lax.
+
 ## Files
 
 ```text

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -20,11 +20,11 @@ This complements — does not replace — the per-URL liveness gate in `auto-pip
 
 Read `spend_tier` from `config/profile.yml` (see `modes/_shared.md` -- Spend Tier section; defaults to `standard` if absent).
 
-- **`standard` or `premium` tier:** Before running the full A-G evaluation on a pending URL that survived the liveness sweep, run a cheap pre-screen pass using the tier's economy-equivalent model (see the mapping table in `modes/_shared.md`) against the candidate's North Star archetypes (`modes/_profile.md`). If the JD is an obvious mismatch, skip the full evaluation: mark it `- [x] #-- | {url} | skipped (pre-screen mismatch: {reason})` in "Processed" and continue to the next URL.
+- **`standard` or `premium` tier:** Before running the full A-F evaluation on a pending URL that survived the liveness sweep, run a cheap pre-screen pass using the tier's economy-equivalent model (see the mapping table in `modes/_shared.md`) against the candidate's North Star archetypes (`modes/_profile.md`). If the JD is an obvious mismatch, skip the full evaluation: mark it `- [x] #-- | {url} | skipped (pre-screen mismatch: {reason})` in "Processed" and continue to the next URL.
 - **`economy` tier:** No gate. The tier is already the cheapest available. Every surviving pending URL goes straight to the full evaluation.
 - This gate only applies to pipeline/batch processing. It never applies to a single interactive evaluation.
 
-**Discard log (auditable):** Every posting the gate filters out MUST be logged with a one-line reason so pre-filtering is never a silent black box. Append one line to `data/discard.log` (create the file if absent) in the format `{ISO8601 timestamp}\t{url}\t{reason}`, in addition to the `skipped` entry already written to "Processed" above. This log is the visible, auditable record of what the gate discarded and why -- review it periodically to tune the North Star archetypes if the gate is too aggressive or too lax.
+**Discard log (auditable):** Every posting the gate filters out MUST be logged with a one-line reason so pre-filtering is never a silent black box. Append one line to `data/discard.log` (create the file if absent) in the format `{ISO8601 timestamp}\t{url}\t{reason}` (three tab-separated fields — interactive pipeline mode has no batch job ID, so the `id` field is omitted here; batch mode's `batch/batch-runner.sh` uses a separate `batch/logs/discard.log` with a four-field format that includes the job ID), in addition to the `skipped` entry already written to "Processed" above. This log is the visible, auditable record of what the gate discarded and why -- review it periodically to tune the North Star archetypes if the gate is too aggressive or too lax.
 
 ## Workflow
 
@@ -32,7 +32,7 @@ Read `spend_tier` from `config/profile.yml` (see `modes/_shared.md` -- Spend Tie
 2. **For each surviving pending URL**:
    a. **Extract JD** using Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
    b. If the URL is not accessible → mark as `- [!]` with a note and continue
-   c. **Pre-screen gate**: apply the gate above (using the extracted JD). If the JD is an obvious mismatch, log the discard to `data/discard.log` (per the **Discard log** rule above), mark it `- [x] #-- | {url} | skipped (pre-screen mismatch: {reason})` in "Processed", and continue to the next URL. No `REPORT_NUM` is claimed for discarded postings.
+   c. **Pre-screen gate**: apply the gate above (using the extracted JD). If the JD is an obvious mismatch, log the discard to `data/discard.log` (per the **Discard log** rule above — three fields, no job ID in interactive mode), mark it `- [x] #-- | {url} | skipped (pre-screen mismatch: {reason})` in "Processed", and continue to the next URL. No `REPORT_NUM` is claimed for discarded postings.
    d. Claim the next sequential `REPORT_NUM` atomically by running `node reserve-report-num.mjs` (and release the sentinel using `node reserve-report-num.mjs --release <num>` after the report is written)
    e. **Execute full auto-pipeline**: Evaluation A-F → Report .md → PDF (if score >= `auto_pdf_score_threshold`) → Tracker. Read `modes/_custom.md` → Pipeline Rules, if it exists, and apply its override here. Default (if absent or silent): standard pipeline execution.
    f. **Move from "Pending" to "Processed"**: `- [x] #NNN | URL | Company | Role | Score/5 | PDF ✅/❌`

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -16,6 +16,16 @@ Sweep all pending URLs in one batch with the zero-token liveness checker before 
 
 This complements — does not replace — the per-URL liveness gate in `auto-pipeline` (Step 0.5) and the `apply` preflight: the sweep drops the dead postings up front, in bulk, so the user never opens a tab or spends a token on them.
 
+## Pre-screen gate (standard / premium tiers only)
+
+Read `spend_tier` from `config/profile.yml` (see `modes/_shared.md` -- Spend Tier section; defaults to `standard` if absent).
+
+- **`standard` or `premium` tier:** Before running the full A-G evaluation on a pending URL that survived the liveness sweep, run a cheap pre-screen pass using the tier's economy-equivalent model (see the mapping table in `modes/_shared.md`) against the candidate's North Star archetypes (`modes/_profile.md`). If the JD is an obvious mismatch, skip the full evaluation: mark it `- [x] #-- | {url} | skipped (pre-screen mismatch: {reason})` in "Processed" and continue to the next URL.
+- **`economy` tier:** No gate. The tier is already the cheapest available. Every surviving pending URL goes straight to the full evaluation.
+- This gate only applies to pipeline/batch processing. It never applies to a single interactive evaluation.
+
+**Discard log (auditable):** Every posting the gate filters out MUST be logged with a one-line reason so pre-filtering is never a silent black box. Append one line to `data/discard.log` (create the file if absent) in the format `{ISO8601 timestamp}\t{url}\t{reason}`, in addition to the `skipped` entry already written to "Processed" above. This log is the visible, auditable record of what the gate discarded and why -- review it periodically to tune the North Star archetypes if the gate is too aggressive or too lax.
+
 ## Workflow
 
 1. **Read** `data/pipeline.md` → search for `- [ ]` items in the "Pending" section. Run the **Liveness sweep** (above) first and drop any expired entries before continuing.
@@ -23,8 +33,9 @@ This complements — does not replace — the per-URL liveness gate in `auto-pip
    a. Claim the next sequential `REPORT_NUM` atomically by running `node reserve-report-num.mjs` (and release the sentinel using `node reserve-report-num.mjs --release <num>` after the report is written)
    b. **Extract JD** using Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
    c. If the URL is not accessible → mark as `- [!]` with a note and continue
-   d. **Execute full auto-pipeline**: Evaluation A-F → Report .md → PDF (if score >= `auto_pdf_score_threshold`) → Tracker. Read `modes/_custom.md` → Pipeline Rules, if it exists, and apply its override here. Default (if absent or silent): standard pipeline execution.
-   e. **Move from "Pending" to "Processed"**: `- [x] #NNN | URL | Company | Role | Score/5 | PDF ✅/❌`
+   d. **Pre-screen gate**: apply the gate above (using the extracted JD) before the full evaluation
+   e. **Execute full auto-pipeline**: Evaluation A-F → Report .md → PDF (if score >= `auto_pdf_score_threshold`) → Tracker. Read `modes/_custom.md` → Pipeline Rules, if it exists, and apply its override here. Default (if absent or silent): standard pipeline execution.
+   f. **Move from "Pending" to "Processed"**: `- [x] #NNN | URL | Company | Role | Score/5 | PDF ✅/❌`
 
    **About the PDF gate (configurable):** Read `config/profile.yml` → `auto_pdf_score_threshold`. If the key does not exist, default to `3.0` (this mode's original gate). If the evaluation score is less than the threshold, skip PDF generation: write the report normally, show in the header `**PDF:** not generated — run /career-ops pdf {company-slug} to create on demand`, and mark PDF ❌ in the tracker. If the score is ≥ threshold, generate the PDF as usual.
 

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -30,10 +30,10 @@ Read `spend_tier` from `config/profile.yml` (see `modes/_shared.md` -- Spend Tie
 
 1. **Read** `data/pipeline.md` → search for `- [ ]` items in the "Pending" section. Run the **Liveness sweep** (above) first and drop any expired entries before continuing.
 2. **For each surviving pending URL**:
-   a. Claim the next sequential `REPORT_NUM` atomically by running `node reserve-report-num.mjs` (and release the sentinel using `node reserve-report-num.mjs --release <num>` after the report is written)
-   b. **Extract JD** using Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
-   c. If the URL is not accessible → mark as `- [!]` with a note and continue
-   d. **Pre-screen gate**: apply the gate above (using the extracted JD) before the full evaluation
+   a. **Extract JD** using Playwright (browser_navigate + browser_snapshot) → WebFetch → WebSearch
+   b. If the URL is not accessible → mark as `- [!]` with a note and continue
+   c. **Pre-screen gate**: apply the gate above (using the extracted JD). If the JD is an obvious mismatch, log the discard to `data/discard.log` (per the **Discard log** rule above), mark it `- [x] #-- | {url} | skipped (pre-screen mismatch: {reason})` in "Processed", and continue to the next URL. No `REPORT_NUM` is claimed for discarded postings.
+   d. Claim the next sequential `REPORT_NUM` atomically by running `node reserve-report-num.mjs` (and release the sentinel using `node reserve-report-num.mjs --release <num>` after the report is written)
    e. **Execute full auto-pipeline**: Evaluation A-F → Report .md → PDF (if score >= `auto_pdf_score_threshold`) → Tracker. Read `modes/_custom.md` → Pipeline Rules, if it exists, and apply its override here. Default (if absent or silent): standard pipeline execution.
    f. **Move from "Pending" to "Processed"**: `- [x] #NNN | URL | Company | Role | Score/5 | PDF ✅/❌`
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4972,7 +4972,10 @@ try {
 
 console.log('\n14. Batch spend_tier model routing');
 
-try {
+// Helper: create a fully isolated tmp fixture for one spend_tier sub-test.
+// Each sub-test gets its own mkdtempSync so no batch-state.tsv from a prior
+// sub-test can bleed in, regardless of OS-level I/O ordering on CI runners.
+function makeTierFixture(profileYml) {
   const tmp = mkdtempSync(join(tmpdir(), 'co-batch-tier-'));
   const batchDir = join(tmp, 'batch');
   const fakeBin = join(tmp, 'bin');
@@ -4996,7 +4999,7 @@ try {
     'id\turl\tsource\tnotes',
     '1\thttps://example.com/one\tfixture\t-',
   ].join('\n') + '\n');
-  writeFileSync(join(configDir, 'profile.yml'), 'spend_tier: economy\n');
+  writeFileSync(join(configDir, 'profile.yml'), profileYml);
   writeFileSync(join(fakeBin, 'claude'), [
     '#!/usr/bin/env bash',
     'printf "%s\\n" "$@" > "$BATCH_ARG_FILE"',
@@ -5007,94 +5010,83 @@ try {
   } else {
     execFileSync('chmod', ['+x', join(fakeBin, 'claude')]);
   }
+  return { tmp, batchDir, fakeBin };
+}
 
+// economy tier
+try {
+  const { tmp, batchDir, fakeBin } = makeTierFixture('spend_tier: economy\n');
   const argFile = join(tmp, 'claude-argv.txt');
-  const env = {
-    ...process.env,
-    PATH: `${fakeBin}${delimiter}${process.env.PATH}`,
-    BATCH_ARG_FILE: argFile,
-  };
-  const out = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], {
-    cwd: tmp,
-    env,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }) || '';
+  const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, BATCH_ARG_FILE: argFile };
+  const out = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
   const argv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
-
   if (argv.includes('--model') && argv.includes('claude-haiku-4-5') && out.includes('spend_tier=economy')) {
     pass('economy spend_tier resolves to claude-haiku-4-5');
   } else {
     fail(`economy spend_tier did not route to haiku: argv=${JSON.stringify(argv)}, out=${JSON.stringify(out.slice(-240))}`);
   }
+  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+} catch (e) { fail(`Batch spend_tier routing test crashed (economy): ${e.message}`); }
 
-  writeFileSync(join(configDir, 'profile.yml'), 'spend_tier: premium\n');
-  rmSync(argFile, { force: true });
-  rmSync(join(batchDir, 'batch-state.tsv'), { force: true });
-  const premiumOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], {
-    cwd: tmp,
-    env,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }) || '';
+// premium tier
+try {
+  const { tmp, batchDir, fakeBin } = makeTierFixture('spend_tier: premium\n');
+  const argFile = join(tmp, 'claude-argv.txt');
+  const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, BATCH_ARG_FILE: argFile };
+  const premiumOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
   const premiumArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
-
   if (premiumArgv.includes('--model') && premiumArgv.includes('claude-opus-4-8') && premiumOut.includes('spend_tier=premium')) {
     pass('premium spend_tier resolves to claude-opus-4-8');
   } else {
     fail(`premium spend_tier did not route to opus: argv=${JSON.stringify(premiumArgv)}, out=${JSON.stringify(premiumOut.slice(-240))}`);
   }
+  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+} catch (e) { fail(`Batch spend_tier routing test crashed (premium): ${e.message}`); }
 
-  rmSync(argFile, { force: true });
-  rmSync(join(batchDir, 'batch-state.tsv'), { force: true });
-  const overrideOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1', '--model', 'claude-sonnet-4-6'], {
-    cwd: tmp,
-    env,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }) || '';
+// --model override takes precedence over spend_tier
+try {
+  const { tmp, batchDir, fakeBin } = makeTierFixture('spend_tier: premium\n');
+  const argFile = join(tmp, 'claude-argv.txt');
+  const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, BATCH_ARG_FILE: argFile };
+  const overrideOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1', '--model', 'claude-sonnet-4-6'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
   const overrideArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
-
   if (overrideArgv.includes('--model') && overrideArgv.includes('claude-sonnet-4-6') && !overrideArgv.includes('claude-opus-4-8') && overrideOut.includes('explicit --model override')) {
     pass('--model override takes precedence over spend_tier');
   } else {
     fail(`--model override did not win: argv=${JSON.stringify(overrideArgv)}, out=${JSON.stringify(overrideOut.slice(-240))}`);
   }
+  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+} catch (e) { fail(`Batch spend_tier routing test crashed (--model override): ${e.message}`); }
 
-  // standard tier: missing config key defaults to standard
-  // Reset state so the offer is pending again for this sub-test.
-  rmSync(join(batchDir, 'batch-state.tsv'), { force: true });
-  writeFileSync(join(configDir, 'profile.yml'), '# no spend_tier key\nname: test\n');
-  rmSync(argFile, { force: true });
-  const standardDefaultOut = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], {
-    cwd: tmp,
-    env,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }) || '';
+// missing spend_tier key defaults to standard
+try {
+  const { tmp, batchDir, fakeBin } = makeTierFixture('# no spend_tier key\nname: test\n');
+  const argFile = join(tmp, 'claude-argv.txt');
+  const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, BATCH_ARG_FILE: argFile };
+  const standardDefaultOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
   const standardDefaultArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
   if (standardDefaultOut.includes('spend_tier=standard') && (standardDefaultArgv.includes('claude-sonnet-4-6') || standardDefaultOut.includes('claude-sonnet-4-6'))) {
     pass('missing spend_tier key defaults to standard tier (claude-sonnet-4-6)');
   } else {
     fail(`missing spend_tier did not default to standard: argv=${JSON.stringify(standardDefaultArgv)}, out=${JSON.stringify(standardDefaultOut.slice(-240))}`);
   }
+  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+} catch (e) { fail(`Batch spend_tier routing test crashed (missing key): ${e.message}`); }
 
-  // standard tier: invalid config value falls back to standard with a warning
-  rmSync(join(batchDir, 'batch-state.tsv'), { force: true });
-  writeFileSync(join(configDir, 'profile.yml'), 'spend_tier: turbo\n');
-  rmSync(argFile, { force: true });
-  const invalidTierOut = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], {
-    cwd: tmp,
-    env,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }) || '';
+// invalid spend_tier value falls back to standard with a warning
+try {
+  const { tmp, batchDir, fakeBin } = makeTierFixture('spend_tier: turbo\n');
+  const argFile = join(tmp, 'claude-argv.txt');
+  const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, BATCH_ARG_FILE: argFile };
+  const invalidTierOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
   const invalidTierArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
   if (invalidTierOut.includes('spend_tier=standard') && (invalidTierArgv.includes('claude-sonnet-4-6') || invalidTierOut.includes('claude-sonnet-4-6'))) {
     pass('invalid spend_tier value falls back to standard tier (claude-sonnet-4-6)');
   } else {
     fail(`invalid spend_tier did not fall back to standard: argv=${JSON.stringify(invalidTierArgv)}, out=${JSON.stringify(invalidTierOut.slice(-240))}`);
   }
-
   try { rmSync(tmp, { recursive: true, force: true }); } catch {}
-} catch (e) {
-  fail(`Batch spend_tier routing test crashed: ${e.message}`);
-}
+} catch (e) { fail(`Batch spend_tier routing test crashed (invalid value): ${e.message}`); }
 
 // ── 14b. BATCH PRE-SCREEN DISCARD LOG ────────────────────────────
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5059,6 +5059,8 @@ try {
   }
 
   // standard tier: missing config key defaults to standard
+  // Reset state so the offer is pending again for this sub-test.
+  rmSync(join(batchDir, 'batch-state.tsv'), { force: true });
   writeFileSync(join(configDir, 'profile.yml'), '# no spend_tier key\nname: test\n');
   rmSync(argFile, { force: true });
   const standardDefaultOut = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], {
@@ -5067,13 +5069,14 @@ try {
     stdio: ['pipe', 'pipe', 'pipe'],
   }) || '';
   const standardDefaultArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
-  if (standardDefaultArgv.includes('--model') && standardDefaultArgv.includes('claude-sonnet-4-6') && standardDefaultOut.includes('spend_tier=standard')) {
+  if (standardDefaultOut.includes('spend_tier=standard') && (standardDefaultArgv.includes('claude-sonnet-4-6') || standardDefaultOut.includes('claude-sonnet-4-6'))) {
     pass('missing spend_tier key defaults to standard tier (claude-sonnet-4-6)');
   } else {
     fail(`missing spend_tier did not default to standard: argv=${JSON.stringify(standardDefaultArgv)}, out=${JSON.stringify(standardDefaultOut.slice(-240))}`);
   }
 
   // standard tier: invalid config value falls back to standard with a warning
+  rmSync(join(batchDir, 'batch-state.tsv'), { force: true });
   writeFileSync(join(configDir, 'profile.yml'), 'spend_tier: turbo\n');
   rmSync(argFile, { force: true });
   const invalidTierOut = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], {
@@ -5082,7 +5085,7 @@ try {
     stdio: ['pipe', 'pipe', 'pipe'],
   }) || '';
   const invalidTierArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
-  if (invalidTierArgv.includes('--model') && invalidTierArgv.includes('claude-sonnet-4-6') && invalidTierOut.includes('spend_tier=standard')) {
+  if (invalidTierOut.includes('spend_tier=standard') && (invalidTierArgv.includes('claude-sonnet-4-6') || invalidTierOut.includes('claude-sonnet-4-6'))) {
     pass('invalid spend_tier value falls back to standard tier (claude-sonnet-4-6)');
   } else {
     fail(`invalid spend_tier did not fall back to standard: argv=${JSON.stringify(invalidTierArgv)}, out=${JSON.stringify(invalidTierOut.slice(-240))}`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5065,7 +5065,7 @@ try {
   const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, BATCH_ARG_FILE: argFile };
   const standardDefaultOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
   const standardDefaultArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
-  if (standardDefaultOut.includes('spend_tier=standard') && (standardDefaultArgv.includes('claude-sonnet-4-6') || standardDefaultOut.includes('claude-sonnet-4-6'))) {
+  if (standardDefaultArgv.includes('--model') && standardDefaultArgv.includes('claude-sonnet-4-6') && standardDefaultOut.includes('spend_tier=standard')) {
     pass('missing spend_tier key defaults to standard tier (claude-sonnet-4-6)');
   } else {
     fail(`missing spend_tier did not default to standard: argv=${JSON.stringify(standardDefaultArgv)}, out=${JSON.stringify(standardDefaultOut.slice(-240))}`);
@@ -5080,7 +5080,7 @@ try {
   const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, BATCH_ARG_FILE: argFile };
   const invalidTierOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
   const invalidTierArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
-  if (invalidTierOut.includes('spend_tier=standard') && (invalidTierArgv.includes('claude-sonnet-4-6') || invalidTierOut.includes('claude-sonnet-4-6'))) {
+  if (invalidTierArgv.includes('--model') && invalidTierArgv.includes('claude-sonnet-4-6') && invalidTierOut.includes('spend_tier=standard')) {
     pass('invalid spend_tier value falls back to standard tier (claude-sonnet-4-6)');
   } else {
     fail(`invalid spend_tier did not fall back to standard: argv=${JSON.stringify(invalidTierArgv)}, out=${JSON.stringify(invalidTierOut.slice(-240))}`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4968,6 +4968,146 @@ try {
   fail(`Batch rate-limit pause test crashed: ${e.message}`);
 }
 
+// ── 14. BATCH SPEND TIER MODEL ROUTING ───────────────────────────
+
+console.log('\n14. Batch spend_tier model routing');
+
+try {
+  const tmp = mkdtempSync(join(tmpdir(), 'co-batch-tier-'));
+  const batchDir = join(tmp, 'batch');
+  const fakeBin = join(tmp, 'bin');
+  const configDir = join(tmp, 'config');
+  mkdirSync(batchDir, { recursive: true });
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(join(tmp, 'reports'), { recursive: true });
+  mkdirSync(join(tmp, 'data'), { recursive: true });
+  mkdirSync(fakeBin, { recursive: true });
+
+  writeFileSync(join(batchDir, 'batch-runner.sh'), readFileSync(join(ROOT, 'batch/batch-runner.sh'), 'utf-8').replace(/\r\n/g, '\n'));
+  if (process.platform === 'win32') {
+    try { execFileSync(getBash(), ['-c', 'chmod +x batch/batch-runner.sh'], { cwd: tmp }); } catch {}
+  } else {
+    execFileSync('chmod', ['+x', join(batchDir, 'batch-runner.sh')]);
+  }
+  writeFileSync(join(tmp, 'merge-tracker.mjs'), 'console.log("merge fixture");\n');
+  writeFileSync(join(tmp, 'verify-pipeline.mjs'), 'console.log("verify fixture");\n');
+  writeFileSync(join(batchDir, 'batch-prompt.md'), 'URL={{URL}}\nJD={{JD_FILE}}\nREPORT={{REPORT_NUM}}\n');
+  writeFileSync(join(batchDir, 'batch-input.tsv'), [
+    'id\turl\tsource\tnotes',
+    '1\thttps://example.com/one\tfixture\t-',
+  ].join('\n') + '\n');
+  writeFileSync(join(configDir, 'profile.yml'), 'spend_tier: economy\n');
+  writeFileSync(join(fakeBin, 'claude'), [
+    '#!/usr/bin/env bash',
+    'printf "%s\\n" "$@" > "$BATCH_ARG_FILE"',
+    'exit 0',
+  ].join('\n') + '\n');
+  if (process.platform === 'win32') {
+    try { execFileSync(getBash(), ['-c', 'chmod +x bin/claude'], { cwd: tmp }); } catch {}
+  } else {
+    execFileSync('chmod', ['+x', join(fakeBin, 'claude')]);
+  }
+
+  const argFile = join(tmp, 'claude-argv.txt');
+  const env = {
+    ...process.env,
+    PATH: `${fakeBin}${delimiter}${process.env.PATH}`,
+    BATCH_ARG_FILE: argFile,
+  };
+  const out = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], {
+    cwd: tmp,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) || '';
+  const argv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
+
+  if (argv.includes('--model') && argv.includes('claude-haiku-4-5') && out.includes('spend_tier=economy')) {
+    pass('economy spend_tier resolves to claude-haiku-4-5');
+  } else {
+    fail(`economy spend_tier did not route to haiku: argv=${JSON.stringify(argv)}, out=${JSON.stringify(out.slice(-240))}`);
+  }
+
+  writeFileSync(join(configDir, 'profile.yml'), 'spend_tier: premium\n');
+  rmSync(argFile, { force: true });
+  rmSync(join(batchDir, 'batch-state.tsv'), { force: true });
+  const premiumOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], {
+    cwd: tmp,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) || '';
+  const premiumArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
+
+  if (premiumArgv.includes('--model') && premiumArgv.includes('claude-opus-4-8') && premiumOut.includes('spend_tier=premium')) {
+    pass('premium spend_tier resolves to claude-opus-4-8');
+  } else {
+    fail(`premium spend_tier did not route to opus: argv=${JSON.stringify(premiumArgv)}, out=${JSON.stringify(premiumOut.slice(-240))}`);
+  }
+
+  rmSync(argFile, { force: true });
+  rmSync(join(batchDir, 'batch-state.tsv'), { force: true });
+  const overrideOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1', '--model', 'claude-sonnet-4-6'], {
+    cwd: tmp,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) || '';
+  const overrideArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
+
+  if (overrideArgv.includes('--model') && overrideArgv.includes('claude-sonnet-4-6') && !overrideArgv.includes('claude-opus-4-8') && overrideOut.includes('explicit --model override')) {
+    pass('--model override takes precedence over spend_tier');
+  } else {
+    fail(`--model override did not win: argv=${JSON.stringify(overrideArgv)}, out=${JSON.stringify(overrideOut.slice(-240))}`);
+  }
+
+  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+} catch (e) {
+  fail(`Batch spend_tier routing test crashed: ${e.message}`);
+}
+
+// ── 14b. BATCH PRE-SCREEN DISCARD LOG ────────────────────────────
+
+console.log('\n14b. Batch pre-screen discard log (log_discard helper)');
+
+try {
+  const tmp = mkdtempSync(join(tmpdir(), 'co-batch-discard-'));
+  const batchDir = join(tmp, 'batch');
+  mkdirSync(batchDir, { recursive: true });
+
+  const runnerSrc = readFileSync(join(ROOT, 'batch/batch-runner.sh'), 'utf-8').replace(/\r\n/g, '\n');
+  if (!runnerSrc.includes('log_discard()')) {
+    fail('batch-runner.sh is missing the log_discard() helper required for the auditable discard log');
+  } else {
+    // Source only the function definitions (guard against `main "$@"` running)
+    // by stripping the trailing invocation line, then call log_discard directly.
+    const sourceable = runnerSrc.replace(/\nmain "\$@"\s*$/, '\n');
+    writeFileSync(join(batchDir, 'batch-runner.lib.sh'), sourceable);
+    const script = [
+      'set -euo pipefail',
+      `source "${toBashPath(join(batchDir, 'batch-runner.lib.sh'))}"`,
+      'log_discard "7" "https://example.com/mismatch" "wrong seniority band"',
+      `cat "${toBashPath(join(batchDir, 'logs', 'discard.log'))}"`,
+    ].join('\n');
+    const out = run(getBash(), ['-c', script], { cwd: tmp, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
+    const line = out.trim().split('\n').pop() || '';
+    const cols = line.split('\t');
+
+    if (
+      cols.length === 4 &&
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(cols[0]) &&
+      cols[1] === '7' &&
+      cols[2] === 'https://example.com/mismatch' &&
+      cols[3] === 'wrong seniority band'
+    ) {
+      pass('log_discard appends a one-line, auditable {timestamp, id, url, reason} record to batch/logs/discard.log');
+    } else {
+      fail(`log_discard output malformed: ${JSON.stringify(out)}`);
+    }
+  }
+
+  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+} catch (e) {
+  fail(`Batch pre-screen discard log test crashed: ${e.message}`);
+}
+
 // ── 15. BATCH RUNNER MCP ISOLATION (#506) ───────────────────────
 
 console.log('\n15. Batch runner MCP isolation');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5058,6 +5058,36 @@ try {
     fail(`--model override did not win: argv=${JSON.stringify(overrideArgv)}, out=${JSON.stringify(overrideOut.slice(-240))}`);
   }
 
+  // standard tier: missing config key defaults to standard
+  writeFileSync(join(configDir, 'profile.yml'), '# no spend_tier key\nname: test\n');
+  rmSync(argFile, { force: true });
+  const standardDefaultOut = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], {
+    cwd: tmp,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) || '';
+  const standardDefaultArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
+  if (standardDefaultArgv.includes('--model') && standardDefaultArgv.includes('claude-sonnet-4-6') && standardDefaultOut.includes('spend_tier=standard')) {
+    pass('missing spend_tier key defaults to standard tier (claude-sonnet-4-6)');
+  } else {
+    fail(`missing spend_tier did not default to standard: argv=${JSON.stringify(standardDefaultArgv)}, out=${JSON.stringify(standardDefaultOut.slice(-240))}`);
+  }
+
+  // standard tier: invalid config value falls back to standard with a warning
+  writeFileSync(join(configDir, 'profile.yml'), 'spend_tier: turbo\n');
+  rmSync(argFile, { force: true });
+  const invalidTierOut = run('bash', [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], {
+    cwd: tmp,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) || '';
+  const invalidTierArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
+  if (invalidTierArgv.includes('--model') && invalidTierArgv.includes('claude-sonnet-4-6') && invalidTierOut.includes('spend_tier=standard')) {
+    pass('invalid spend_tier value falls back to standard tier (claude-sonnet-4-6)');
+  } else {
+    fail(`invalid spend_tier did not fall back to standard: argv=${JSON.stringify(invalidTierArgv)}, out=${JSON.stringify(invalidTierOut.slice(-240))}`);
+  }
+
   try { rmSync(tmp, { recursive: true, force: true }); } catch {}
 } catch (e) {
   fail(`Batch spend_tier routing test crashed: ${e.message}`);


### PR DESCRIPTION
Closes #1007

## Summary

Adds `spend_tier: economy | standard | premium` to `config/profile.yml`, per the design approved in #1007. It controls which model tier evaluates offers, and adds a pre-screen gate for batch/pipeline processing that filters obvious JD mismatches before running the full A-F evaluation, saving spend on high-volume scanning.

## Invariants (locked by #1007, verified before opening this PR)

- [x] **Identical A-F report format across all tiers** — quality varies, structure never does. No changes to report generation, headers, or sections; only which model runs the evaluation.
- [x] **Pre-screen gate in batch/pipeline only, never interactive** — the gate is documented in `modes/batch.md` and `modes/pipeline.md` under "Pre-screen gate (standard / premium tiers only)" and is scoped explicitly to those two modes. Economy tier gets no gate (already the cheapest option).
- [x] **Model-agnostic mapping — no hardcoded provider names outside the single mapping table.** Verified: `grep -ri "haiku|sonnet|opus|gemini" modes/` hits only `modes/_shared.md` (plus pre-existing, unrelated "Claude/Gemini" agent-name mentions in `modes/ar/README.md`, `modes/ar/takdeem.md` predating this change). `batch/batch-runner.sh`'s only hardcoded Claude Code model names live in the `spend_tier_to_model()` function, which is the tier-driven mapping itself (kept in sync with the `modes/_shared.md` table via a code comment).
- [x] **Free-tier defaults stay free.** This PR never adds a Gemini-path (or any non-Claude-Code) model mapping — every non-Claude-Code CLI row in the table intentionally uses capability-class language ("cheapest/balanced/most-capable") instead of naming a specific model, so no CLI's existing default (paid or free) can drift underneath a user. Compared notes with @SparshGarg999's #1194, whose `gemini-2.5-flash` free-tier catch for standard/economy is the correct conservative call for any future PR that does add a concrete Gemini row — credited per santifer's decision comment on #1007.

## New scope item from #1007: auditable discard log

santifer's decision added one requirement beyond the original proposal: *"the gate must log what it discards: a one-line reason per filtered posting"*. Implemented as:

- `batch/batch-runner.sh` gains a `log_discard(id, url, reason)` helper that appends `{ISO8601 timestamp}\t{id}\t{url}\t{reason}` to `batch/logs/discard.log` (created on first use).
- `modes/pipeline.md` documents the equivalent for the URL-inbox path: `data/discard.log`, same format (`{timestamp}\t{url}\t{reason}`).
- Both `modes/batch.md` and `modes/pipeline.md`'s Pre-screen gate sections call this out explicitly as the auditable record, in addition to the existing `skipped` row already written to `batch-state.tsv` / "Processed".
- Covered in `test-all.mjs` (`14b. Batch pre-screen discard log`), which sources the `log_discard` function in isolation and asserts the four-column format.

## What changed

- `config/profile.example.yml` — new `spend_tier: standard` key with inline docs.
- `modes/_shared.md` — new "Spend Tier (Model Routing)" section: resolution rule (default `standard`, invalid falls back with a one-time warning) and the tier→model mapping table. Inserted ahead of "Scoring System", cleanly coexisting with the culture-screen section added in dc2a8d8 (no overlap — that content lives inside "Scoring System").
- `modes/batch.md`, `modes/pipeline.md` — new "Pre-screen gate (standard / premium tiers only)" sections, including the discard-log requirement; `pipeline.md`'s per-URL workflow gains a new step for the gate.
- `batch/batch-runner.sh` — `read_spend_tier()`, `spend_tier_to_model()`, `resolve_worker_model()`, `log_discard()`; worker `--model` is now tier-resolved unless `--model` is explicitly passed (which still wins); run header now prints the resolved model/tier.
- `AGENTS.md` / `CLAUDE.md` — onboarding wizard now asks the spend-tier question during Step 2 (Profile) and documents the `standard` default.
- `test-all.mjs` — `14. Batch spend_tier model routing` (economy→haiku, premium→opus, `--model` override precedence) and `14b. Batch pre-screen discard log` (log_discard format).

## Manual test plan

1. `cp config/profile.example.yml config/profile.yml`, leave `spend_tier: standard`.
2. `batch/batch-runner.sh --dry-run` on a small `batch-input.tsv` → header should print `Model: claude-sonnet-4-6 (spend_tier=standard)`.
3. Set `spend_tier: economy`, rerun → `Model: claude-haiku-4-5 (spend_tier=economy)`.
4. Set `spend_tier: premium`, rerun → `Model: claude-opus-4-8 (spend_tier=premium)`.
5. Rerun with `--model claude-sonnet-4-6` while `spend_tier: premium` is set → header shows `(explicit --model override)`, confirming override precedence.
6. Delete the `spend_tier` key entirely → confirm fallback to `standard` (back-compat for existing profiles).
7. Set an invalid value (e.g. `spend_tier: turbo`) → confirm the one-time `WARN:` fallback-to-standard message and that processing still proceeds.
8. Run `/career-ops batch` or `/career-ops pipeline` on a small set of offers with `spend_tier: standard`/`premium` and a JD that's an obvious archetype mismatch (wrong domain/seniority) → confirm it's marked `skipped` with a reason, is never evaluated with the full model, and a corresponding line appears in `batch/logs/discard.log` (or `data/discard.log` for pipeline).
9. Run `node test-all.mjs` → full suite green (1537 passed, 0 failed, exit 0 in this branch's verification run).

## Migration steps

None. `spend_tier` is optional and defaults to `standard`, matching current default behavior (Sonnet-class model, no gate change for `economy` users, existing `--model` flag behavior unchanged for anyone already passing it explicitly).

## Notes for reviewers

- Rebased the original prototype (vsetchinfc/career-ops#2) onto current `upstream/main` (265 commits ahead of the old base) by re-deriving the net feature diff against the 8 touched files rather than rebasing the branch's prior merge commit — avoids replaying an unrelated merge history.
- Credit to @SparshGarg999 for the free-tier-default catch on #1194 (gemini-2.5-flash for standard/economy) — noted in the invariants section above per santifer's request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a spend-tier question to Step 2 onboarding (**economy / standard / premium**), defaulting to **standard** if skipped.
  * Model routing now uses the configured spend tier, with **standard/premium** pre-screen gate to skip obvious mismatches earlier.
  * Added an auditable discard log for skipped/discarded postings.
* **Bug Fixes**
  * Missing or invalid spend tiers now safely fall back to **standard**.
  * Explicit `--model` still overrides tier-based routing.
* **Documentation**
  * Updated onboarding, example profile, and batch/pipeline guidance for spend-tier behavior and discard logging.
* **Tests**
  * Added regression coverage for tier routing (including overrides/defaults) and discard-log formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->