### PR TITLE
docs(scan): align provider parse conventions with the fields scan.mjs consumes

### DIFF
--- a/modes/scan.md
+++ b/modes/scan.md
@@ -135,12 +135,12 @@ For companies with a public API or structured feed **that are not in `local_pars
 - **Breezy**: `https://{company}.breezy.hr/json`
 
 **Parsing Conventions by Provider:**
-- `greenhouse`: `jobs[]` → `title`, `absolute_url`
-- `ashby`: GET REST API → `jobs[]` with `title`, `jobUrl`, `location`, `publishedAt`; slug derived from `careers_url` pattern `jobs.ashbyhq.com/{slug}`
-- `bamboohr`: list `result[]` → `jobOpeningName`, `id`; build detail URL `https://{company}.bamboohr.com/careers/{id}/detail`; to read full JD, make a GET request to the detail URL and use `result.jobOpening` (`jobOpeningName`, `description`, `datePosted`, `minimumExperience`, `compensation`, `jobOpeningShareUrl`)
-- `lever`: root array `[]` → `text`, `hostedUrl` (fallback: `applyUrl`)
-- `teamtailor`: RSS items → `title`, `link`
-- `workday`: `jobPostings[]`/`jobPostings` (based on tenant) → `title`, `externalPath` or URL built from the host
+- `greenhouse`: `jobs[]` → `title`, `absolute_url`, `location.name`
+- `ashby`: GET REST API → `jobs[]` with `title`, `jobUrl`, `location` (fold in `secondaryLocations[]` — Ashby lists extra hiring regions there), `compensation` (`minValue`/`maxValue`/`currency`; already fetched via `?includeCompensation=true`), `publishedAt`; slug derived from `careers_url` pattern `jobs.ashbyhq.com/{slug}`
+- `bamboohr`: list `result[]` → `jobOpeningName`, `id`, `location` (city + state; append "Remote" when `isRemote`); build detail URL `https://{company}.bamboohr.com/careers/{id}/detail`; to read full JD, make a GET request to the detail URL and use `result.jobOpening` (`jobOpeningName`, `description`, `datePosted`, `minimumExperience`, `compensation`, `jobOpeningShareUrl`)
+- `lever`: root array `[]` → `text`, `hostedUrl` (fallback: `applyUrl`), `categories.location`, `descriptionPlain` (the list API ships the JD body — feeds `content_filter` and the #1597 cross-listing fingerprint)
+- `teamtailor`: RSS items → `title`, `link`, `location` (from the `tt:` block — `tt:city` / `tt:country`)
+- `workday`: `jobPostings[]`/`jobPostings` (based on tenant) → `title`, `externalPath` or URL built from the host, `locationsText` (fallback: derive from the URL path)
 - `breezy`: top-level array `[]` → `name`, `url` (absolute), `location.name` (or city/state/country + `is_remote`), `published_date`
 
 > **Caution — do not infer absence from a truncated read.** Careers SPAs paginate and lazy-load; a `browser_snapshot` or WebFetch of the page (and any LLM summary of that HTML) can silently drop rows, showing only the first screen of roles. Never conclude "role X is not posted" or "only N roles exist" from such a read. When the company has a public ATS API, hit it directly (append `?content=true` where the provider supports it) before making any presence/absence claim — the API returns the full board in one structured response.
@@ -191,10 +191,10 @@ Levels are additive — they are executed in order, and results are merged and d
    For each company in `tracked_companies` with a defined `api:`, `enabled: true`, and a **name not listed in `local_parser_ok`**:
    a. WebFetch the API/feed URL.
    b. If `api_provider` is defined, use its parser; if undefined, infer by domain (`boards-api.greenhouse.io`, `api.ashbyhq.com`, `api.(eu.)?lever.co`, `*.bamboohr.com`, `*.teamtailor.com`, `*.myworkdayjobs.com`, `*.breezy.hr`).
-   c. For **Ashby**, send a GET request to `https://api.ashbyhq.com/posting-api/job-board/{slug}?includeCompensation=true` (slug from `careers_url`). Parse `jobs[]` → `title`, `jobUrl`, `location`. No GraphQL needed.
+   c. For **Ashby**, send a GET request to `https://api.ashbyhq.com/posting-api/job-board/{slug}?includeCompensation=true` (slug from `careers_url`). Parse `jobs[]` → `title`, `jobUrl`, `location` (fold in `secondaryLocations[]`), `compensation`. No GraphQL needed.
    d. For **BambooHR**, the list only returns basic metadata. For each relevant item, retrieve the `id`, make a GET request to `https://{company}.bamboohr.com/careers/{id}/detail`, and extract the full JD from `result.jobOpening`. Use `jobOpeningShareUrl` as the public URL if present; otherwise, use the detail URL.
    e. For **Workday**, send a JSON POST request with at least `{"appliedFacets":{},"limit":20,"offset":0,"searchText":""}` and paginate by `offset` until results are exhausted.
-   f. For each job, extract and normalize: `{title, url, company}`.
+   f. For each job, extract and normalize: `{title, url, company, location}`.
    g. Accumulate in the candidates list (deduplicated against Level 1).
 
 6. **Level 3 — WebSearch Queries** (parallel if possible):

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1503,6 +1503,17 @@ if (
   fail('scan.md missing local_parser_ok skip rules for agent scan');
 }
 
+// Guard against scan.md's manual-parse conventions drifting from what providers/*.mjs
+// emit and scan.mjs's filters consume (location/salary/description). We assert the two
+// most specific, consumed-field tokens: Ashby `secondaryLocations` (location_filter) and
+// Lever `descriptionPlain` (content_filter + #1597 cross-listing dedup). Raw API
+// identifiers → language-neutral, low-brittleness.
+if (scanMode.includes('secondaryLocations') && scanMode.includes('descriptionPlain')) {
+  pass('scan.md parse conventions document consumed provider fields (ashby secondaryLocations, lever descriptionPlain)');
+} else {
+  fail('scan.md parse conventions drifted from providers/*.mjs — missing secondaryLocations (ashby) or descriptionPlain (lever) that scan.mjs filters consume');
+}
+
 if (!fileExists('scripts/parsers/cohere_jobs.py')) {
   pass('Cohere parser example is not bundled as a runtime script');
 } else {


### PR DESCRIPTION
Fixes #1688

## What

`modes/scan.md`'s Level-2 **manual-parse contract** (the "Parsing Conventions by Provider" table + steps 5c/5f) had drifted from what `providers/*.mjs` emit — and, critically, from the fields `scan.mjs`'s filters actually consume. This aligns the doc with the code, using the fully-documented `breezy` line as the template.

`scan.mjs` runs three peer opt-in filters back-to-back on every job:
`location_filter(job.location)` · `salary_filter(job.salary)` · `content_filter(job.description)`. The doc documented roughly `{title, url}` per provider, so an agent doing the manual parse dropped the fields those filters need.

## Verified divergences (against `origin/main`)

| Provider | Emits (file:line) | doc said | added |
|---|---|---|---|
| lever | `categories.location` (`lever.mjs:40`), `descriptionPlain` (`:43`) | `text, hostedUrl` | `location` + `description` |
| greenhouse | `location.name` (`greenhouse.mjs:72`) | `title, absolute_url` | `location` |
| teamtailor | `resolveLocation` `tt:city`/`tt:country` (`teamtailor.mjs:154-192`) | `title, link` | `location` |
| workday | `locationsText` (`workday.mjs:171`) | `title, externalPath` | `location` |
| bamboohr | list `location` city+state+Remote (`bamboohr.mjs:100-108`) | `jobOpeningName, id` | list `location` |
| ashby | `secondaryLocations[]` fold (`ashby.mjs:106-122`) + `compensation` (`:151`) | `title, jobUrl, location, publishedAt` | `secondaryLocations` fold + `compensation` |

Plus **step 5f** normalized to `{title, url, company}` — dropping `location` outright; now `{title, url, company, location}`.

## Why it matters

- Empty `location` always passes `location_filter` → `allow`/`block` rules silently no-op → off-target roles leak in (**false positives**).
- Lever `description` feeds `content_filter` **and** the #1597 SimHash cross-listing dedup — `scan.md:230` already says Lever's list API ships the JD body, yet the parse line omitted it (self-contradiction).
- Ashby `secondaryLocations` → a multi-region role read as primary-only is wrongly dropped (**false negatives**, the #1073 bug on the agent path); Ashby `compensation` was fetched via `?includeCompensation=true` but never parsed, so `salary_filter` no-oped.

The provider behaviour is already unit-tested (`tests/providers/ashby.test.mjs` asserts the `secondaryLocations` fold) — only the agent-facing doc was stale, because the provider fixes (e.g. #1078) never mirrored into `scan.md`.

## Guard

Added a small `test-all.mjs` assertion (mirrors the existing `scan.md` check at ~:1481) that fails if the two most-specific consumed-field tokens — Ashby `secondaryLocations` and Lever `descriptionPlain` — disappear from `scan.md`. Both are net-new tokens (reverting the doc flips the guard to `fail`), so the doc can't silently drift again.

## Scope / notes

- **Docs-only + one guard.** `git diff --stat`: `modes/scan.md` (16) + `test-all.mjs` (+11). No `.mjs` reads `scan.md` at runtime, so zero behavioural change.
- **English-only** — no `modes/<lang>/scan.md` exists. Heads-up: open **#1666** (Turkish i18n) introduces `modes/tr/scan.md` carrying the same gap — a merge-order coordination item, not a conflict.
- `node test-all.mjs --quick`: **1535 passed, 0 failed** (the one warning is the pre-existing `cv-sync-check` "no user data" notice).
- Out of scope (documented in the issue): `postedAt` (not filtered), the pre-existing stale lever `(fallback: applyUrl)` wording, and the BambooHR public-vs-detail URL nuance — candidates for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified scan workflow guidance for Level 2 ATS feed parsing and normalization.
  * Expanded provider-specific field handling so job details, locations, compensation, and publish dates are captured more consistently.

* **Tests**
  * Added coverage to detect drift between parsing instructions and the fields used during processing.
  * The test suite now flags missing provider field references with clearer failure messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->