### PR TITLE
feat(templates): config-selectable CV and cover-letter templates

### DIFF
--- a/build-cv-latex.mjs
+++ b/build-cv-latex.mjs
@@ -6,6 +6,7 @@ import { resolve, dirname, basename, join } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
 import { escapeLatex, sanitizeUrl } from './lib/latex-escape.mjs';
+import { resolveTemplate } from './cv-templates.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_PATH = resolve(__dirname, 'templates', 'cv-template.tex');
@@ -98,12 +99,22 @@ async function main() {
     process.exit(1);
   }
 
-  if (!existsSync(TEMPLATE_PATH)) {
-    console.error(`Template not found: ${TEMPLATE_PATH}`);
+  // Honor a selected .tex template variant (cv.template default or --template=<name>),
+  // falling back to the base cv-template.tex when no variant exists.
+  const texName = (process.argv.find((a) => a.startsWith('--template=')) || '').split('=')[1];
+  let TEMPLATE_PATH_RESOLVED;
+  try {
+    TEMPLATE_PATH_RESOLVED = resolveTemplate('cv', texName, { format: 'tex', fallback: true });
+  } catch {
+    TEMPLATE_PATH_RESOLVED = TEMPLATE_PATH;
+  }
+
+  if (!existsSync(TEMPLATE_PATH_RESOLVED)) {
+    console.error(`Template not found: ${TEMPLATE_PATH_RESOLVED}`);
     process.exit(1);
   }
 
-  let template = await readFile(TEMPLATE_PATH, 'utf-8');
+  let template = await readFile(TEMPLATE_PATH_RESOLVED, 'utf-8');
 
   const emailUrl = sanitizeUrl(payload.email?.url || '');
   const emailDisplay = payload.email?.display || emailUrl;

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -106,6 +106,12 @@ cv:
   # Find it in your Canva design URL: https://www.canva.com/design/DAxxxxxxx/...
   # The ID starts with "D" and is 11 characters long.
   # canva_resume_design_id: "DAxxxxxxxxx"
+  # Which CV template to use by default. Value is the kebab-case name of a file
+  # in templates/ named cv-template.<name>.html (e.g. "modern" ->
+  # templates/cv-template.modern.html). Leave unset/commented to use the built-in
+  # templates/cv-template.html. You can also pick per-generation just by asking
+  # (e.g. "use the modern template").
+  # template: modern
 
 # ── Culture Screen ───────────────────────────────────────────────────────────
 #
@@ -136,6 +142,10 @@ cover_letter:
   # JD requests an immediate start. The user confirms the actual value before it
   # appears in the letter.
   notice_period_days: 30
+  # Which cover-letter template to use by default. Kebab-case name of a file in
+  # templates/ named cover-letter-template.<name>.html. Unset -> built-in
+  # templates/cover-letter-template.html.
+  # template: modern
 
   # Your current professional domain (used to detect domain gaps vs the JD).
   # Plain English, e.g. "digital media", "fintech", "healthcare IT".

--- a/cv-templates.mjs
+++ b/cv-templates.mjs
@@ -123,7 +123,7 @@ export function resolveTemplate(kind, name, opts = {}) {
   } = opts;
 
   const explicit = Boolean(name && String(name).trim());
-  let chosen = explicit ? kebab(name) : loadProfileDefault(kind, { profilePath }) || 'standard';
+  let chosen = kebab(explicit ? name : loadProfileDefault(kind, { profilePath }) || 'standard');
   const fileFor = (n) => (n === 'standard' ? `${cfg.prefix}.${format}` : `${cfg.prefix}.${n}.${format}`);
 
   let path = resolve(dir, fileFor(chosen));

--- a/cv-templates.mjs
+++ b/cv-templates.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// cv-templates.mjs — discover, resolve, and validate CV / cover-letter templates.
+// Single source of truth for "which template file, and is it usable?".
+// Backward-compatible: with no config and no named files, resolves the base
+// templates/cv-template.html (name "standard"), identical to prior behavior.
+
+import { readdirSync, readFileSync, existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import yaml from 'js-yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_TEMPLATES_DIR = resolve(__dirname, 'templates');
+const DEFAULT_PROFILE_PATH =
+  process.env.CAREER_OPS_PROFILE || resolve(__dirname, 'config', 'profile.yml');
+
+export const KINDS = {
+  cv: {
+    prefix: 'cv-template',
+    profileKey: ['cv', 'template'],
+    required: ['NAME', 'EXPERIENCE', 'EDUCATION'],
+  },
+  cover: {
+    prefix: 'cover-letter-template',
+    profileKey: ['cover_letter', 'template'],
+    required: ['NAME', 'ROLE_TITLE', 'OPENING'],
+  },
+};
+
+export function prettify(name) {
+  return name
+    .split('-')
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+export function kebab(display) {
+  return String(display)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// filename → {name, format} | null. Base "cv-template.html" → name "standard";
+// "cv-template.<name>.html" → that name. Only html/tex are recognized.
+function parseFilename(prefix, file) {
+  const m = file.match(new RegExp(`^${prefix}(?:\\.([a-z0-9-]+))?\\.(html|tex)$`));
+  if (!m) return null;
+  return { name: m[1] || 'standard', format: m[2] };
+}
+
+export function parseMeta(path) {
+  let text;
+  try {
+    text = readFileSync(path, 'utf-8');
+  } catch {
+    return {};
+  }
+  const block = text.match(/<!--\s*career-ops-template\s*([\s\S]*?)-->/);
+  if (!block) return {};
+  const meta = {};
+  for (const line of block[1].split(/\r?\n/)) {
+    const kv = line.match(/^\s*([a-zA-Z_]+)\s*:\s*(.+?)\s*$/);
+    if (kv) meta[kv[1].toLowerCase()] = kv[2];
+  }
+  return meta;
+}
+
+export function listTemplates(kind, { dir = DEFAULT_TEMPLATES_DIR, format = 'html' } = {}) {
+  const cfg = KINDS[kind];
+  if (!cfg) throw new Error(`Unknown template kind: ${kind}`);
+  if (!existsSync(dir)) return [];
+  const out = [];
+  for (const file of readdirSync(dir)) {
+    const parsed = parseFilename(cfg.prefix, file);
+    if (!parsed || parsed.format !== format) continue;
+    const path = resolve(dir, file);
+    const meta = parseMeta(path);
+    out.push({
+      name: parsed.name,
+      displayName: meta.name || prettify(parsed.name),
+      path,
+      format: parsed.format,
+      meta,
+    });
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function validateTemplate(path, kind) {
+  const cfg = KINDS[kind];
+  if (!cfg) throw new Error(`Unknown template kind: ${kind}`);
+  const text = readFileSync(path, 'utf-8');
+  const missing = cfg.required.filter((ph) => !text.includes(`{{${ph}}}`));
+  return { ok: missing.length === 0, missing };
+}
+
+export function loadProfileDefault(kind, { profilePath = DEFAULT_PROFILE_PATH } = {}) {
+  const cfg = KINDS[kind];
+  if (!cfg) throw new Error(`Unknown template kind: ${kind}`);
+  if (!existsSync(profilePath)) return null;
+  let doc;
+  try {
+    doc = yaml.load(readFileSync(profilePath, 'utf-8')) || {};
+  } catch {
+    return null;
+  }
+  let node = doc;
+  for (const key of cfg.profileKey) node = node?.[key];
+  return typeof node === 'string' && node.trim() ? node.trim() : null;
+}
+
+export function resolveTemplate(kind, name, opts = {}) {
+  const cfg = KINDS[kind];
+  if (!cfg) throw new Error(`Unknown template kind: ${kind}`);
+  const {
+    dir = DEFAULT_TEMPLATES_DIR,
+    format = 'html',
+    profilePath = DEFAULT_PROFILE_PATH,
+    fallback = false,
+  } = opts;
+
+  const explicit = Boolean(name && String(name).trim());
+  let chosen = explicit ? kebab(name) : loadProfileDefault(kind, { profilePath }) || 'standard';
+  const fileFor = (n) => (n === 'standard' ? `${cfg.prefix}.${format}` : `${cfg.prefix}.${n}.${format}`);
+
+  let path = resolve(dir, fileFor(chosen));
+  if (!existsSync(path)) {
+    if (fallback && chosen !== 'standard') {
+      chosen = 'standard';
+      path = resolve(dir, fileFor(chosen));
+    }
+    if (!existsSync(path)) {
+      throw new Error(`Template not found for kind=${kind} name=${chosen} (${fileFor(chosen)})`);
+    }
+  }
+  if (format === 'html') {
+    const v = validateTemplate(path, kind);
+    if (!v.ok) {
+      throw new Error(
+        `Template ${fileFor(chosen)} missing required placeholders: ${v.missing.map((m) => `{{${m}}}`).join(', ')}`
+      );
+    }
+  }
+  return path;
+}
+
+// ---- CLI ----
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const argv = process.argv.slice(2);
+  const cmd = argv[0];
+  const kind = argv[1];
+  const flags = Object.fromEntries(
+    argv.filter((a) => a.startsWith('--')).map((a) => {
+      const [k, v] = a.replace(/^--/, '').split('=');
+      return [k, v ?? true];
+    })
+  );
+  const positionals = argv.slice(2).filter((a) => !a.startsWith('--'));
+  const format = flags.format || 'html';
+  try {
+    if (cmd === 'list') {
+      const items = listTemplates(kind, { format }).map(({ name, displayName }) => ({ name, displayName }));
+      process.stdout.write(JSON.stringify(items, null, 2) + '\n');
+    } else if (cmd === 'resolve') {
+      const name = positionals[0];
+      process.stdout.write(resolveTemplate(kind, name, { format, fallback: Boolean(flags.fallback) }) + '\n');
+    } else {
+      process.stderr.write('Usage: node cv-templates.mjs <list|resolve> <cv|cover> [name] [--format=html|tex] [--fallback]\n');
+      process.exit(2);
+    }
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
+}

--- a/modes/cover.md
+++ b/modes/cover.md
@@ -265,6 +265,13 @@ End the draft with: "How does this read? Once you approve I'll generate the PDF.
 
 ---
 
+Resolve the cover-letter template with the shared resolver (do not hardcode `cover-letter-template.html`):
+
+- If the user named a template, run: `node cv-templates.mjs resolve cover "<name>"`
+- Otherwise run: `node cv-templates.mjs resolve cover` (returns the `cover_letter.template` default, or the base template when unset).
+
+Fill the resolved template's `{{...}}` placeholders. A non-zero exit means the named template is missing/invalid — surface it, do not silently fall back.
+
 ## Step 9 — Generate PDF
 
 Only after explicit user approval.

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -78,7 +78,20 @@ Examples of legitimate reformulation:
 
 **Before generating: read `modes/_custom.md` (if it exists) and apply its formatting/content house rules to every CV in this session — including every item of a batch.** Rules recorded there (date formats, section-order preferences, content to always/never include) are persistent user instructions, not suggestions; if the user corrects the same thing twice in conversation, write it into `modes/_custom.md` so it stops drifting.
 
-Use the template in `cv-template.html`. Replace the `{{...}}` placeholders with personalized content:
+### Selecting the template
+
+Resolve which template to fill with the shared resolver (do not hardcode `cv-template.html`):
+
+- If the user named a template this turn (e.g. "use the *modern* template"), run:
+  `node cv-templates.mjs resolve cv "<name>"`
+- Otherwise run: `node cv-templates.mjs resolve cv`
+  (this returns the `cv.template` default from `config/profile.yml`, or the base `cv-template.html` when unset).
+
+The command prints the absolute path of the template to fill; a non-zero exit means the named template is missing or invalid — surface that message to the user instead of silently falling back.
+
+To show the user their options (e.g. "what CV templates do I have?"), run `node cv-templates.mjs list cv` and present each `displayName`.
+
+Then fill the resolved template's `{{...}}` placeholders with personalized content:
 
 | Placeholder | Content |
 |-------------|-----------|

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7687,6 +7687,24 @@ try {
   fail(`titles mode registration checks crashed: ${e.message}`);
 }
 
+console.log('\n59. CV template resolver (cv-templates.mjs)');
+{
+  const unit = run(NODE, ['--test', 'test/cv-templates.test.mjs']);
+  if (unit !== null) pass('cv-templates.mjs unit tests pass');
+  else fail('cv-templates.mjs unit tests failed (run: node --test test/cv-templates.test.mjs)');
+
+  const listed = run(NODE, ['cv-templates.mjs', 'list', 'cv']);
+  if (listed && listed.includes('"name"')) pass('CLI: list cv returns JSON');
+  else fail('CLI: list cv did not return JSON');
+
+  // Hermetic: point at a nonexistent profile so this exercises the unset -> base
+  // fallback regardless of the developer's real config/profile.yml (cv.template).
+  const noProfile = { env: { ...process.env, CAREER_OPS_PROFILE: join(tmpdir(), 'career-ops-no-such-profile.yml') } };
+  const resolved = run(NODE, ['cv-templates.mjs', 'resolve', 'cv'], noProfile);
+  if (resolved && resolved.endsWith('cv-template.html')) pass('CLI: resolve cv (unset) -> base template');
+  else fail(`CLI: resolve cv (unset) unexpected: ${resolved}`);
+}
+
 console.log('\nTest layout guard (provider tests live in tests/providers/)');
 try {
   const src = readFileSync(join(ROOT, 'test-all.mjs'), 'utf-8');

--- a/test/cv-templates.test.mjs
+++ b/test/cv-templates.test.mjs
@@ -132,6 +132,12 @@ test('resolveTemplate: falls back to profile default when no name', () => {
   assert.ok(p.endsWith('cv-template.executive-authority.html'));
 });
 
+test('resolveTemplate: profile default is kebab-normalized (parity with explicit name)', () => {
+  const { dir, profile } = fixtureWithProfile('Executive Authority');
+  const p = resolveTemplate('cv', undefined, { dir, profilePath: profile });
+  assert.ok(p.endsWith('cv-template.executive-authority.html'));
+});
+
 test('resolveTemplate: base standard when nothing set (backward-compatible)', () => {
   const { dir, profile } = fixtureWithProfile(null);
   const p = resolveTemplate('cv', undefined, { dir, profilePath: profile });

--- a/test/cv-templates.test.mjs
+++ b/test/cv-templates.test.mjs
@@ -1,0 +1,174 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  prettify,
+  kebab,
+  KINDS,
+  listTemplates,
+  parseMeta,
+  validateTemplate,
+  resolveTemplate,
+  loadProfileDefault,
+} from '../cv-templates.mjs';
+
+test('prettify: kebab to Title Case', () => {
+  assert.equal(prettify('executive-authority'), 'Executive Authority');
+  assert.equal(prettify('standard'), 'Standard');
+});
+
+test('kebab: display name to kebab', () => {
+  assert.equal(kebab('Executive Authority'), 'executive-authority');
+  assert.equal(kebab('  Modern CV!  '), 'modern-cv');
+});
+
+test('KINDS defines cv and cover', () => {
+  assert.ok(KINDS.cv && KINDS.cover);
+  assert.equal(KINDS.cv.prefix, 'cv-template');
+  assert.equal(KINDS.cover.prefix, 'cover-letter-template');
+});
+
+function fixtureDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'cvt-'));
+  writeFileSync(join(dir, 'cv-template.html'), '{{NAME}}{{EXPERIENCE}}{{EDUCATION}}');
+  writeFileSync(
+    join(dir, 'cv-template.executive-authority.html'),
+    '<!-- career-ops-template\nname: Executive Authority\nversion: 1.0.0\n-->\n{{NAME}}{{EXPERIENCE}}{{EDUCATION}}'
+  );
+  writeFileSync(join(dir, 'cv-template.tex'), '{{NAME}}');
+  writeFileSync(join(dir, 'cover-letter-template.html'), '{{NAME}}{{ROLE_TITLE}}{{OPENING}}');
+  writeFileSync(
+    join(dir, 'cover-letter-template.formal.html'),
+    '<!-- career-ops-template\nname: Formal\nversion: 1.0.0\n-->\n{{NAME}}{{ROLE_TITLE}}{{OPENING}}'
+  );
+  writeFileSync(join(dir, 'unrelated.html'), 'nope');
+  return dir;
+}
+
+test('listTemplates: finds base (standard) + named html only', () => {
+  const dir = fixtureDir();
+  const cvs = listTemplates('cv', { dir });
+  const names = cvs.map((t) => t.name).sort();
+  assert.deepEqual(names, ['executive-authority', 'standard']);
+});
+
+test('listTemplates: displayName prefers meta name, else prettified filename', () => {
+  const dir = fixtureDir();
+  const cvs = listTemplates('cv', { dir });
+  assert.equal(cvs.find((t) => t.name === 'executive-authority').displayName, 'Executive Authority');
+  assert.equal(cvs.find((t) => t.name === 'standard').displayName, 'Standard');
+});
+
+test('listTemplates: format filter (tex) is separate from html', () => {
+  const dir = fixtureDir();
+  const tex = listTemplates('cv', { dir, format: 'tex' });
+  assert.deepEqual(tex.map((t) => t.name), ['standard']);
+});
+
+test('listTemplates: returns [] when the templates dir is absent', () => {
+  const dir = join(tmpdir(), 'cvt-does-not-exist-38f2a1');
+  assert.deepEqual(listTemplates('cv', { dir }), []);
+});
+
+test('listTemplates: cover kind uses the cover-letter-template prefix', () => {
+  const dir = fixtureDir();
+  const covers = listTemplates('cover', { dir });
+  const names = covers.map((t) => t.name).sort();
+  assert.deepEqual(names, ['formal', 'standard']);
+});
+
+test('parseMeta: reads header key/value, empty when absent', () => {
+  const dir = fixtureDir();
+  assert.equal(parseMeta(join(dir, 'cv-template.executive-authority.html')).name, 'Executive Authority');
+  assert.deepEqual(parseMeta(join(dir, 'cv-template.html')), {});
+});
+
+test('validateTemplate: ok when required placeholders present', () => {
+  const dir = fixtureDir();
+  const r = validateTemplate(join(dir, 'cv-template.html'), 'cv');
+  assert.deepEqual(r, { ok: true, missing: [] });
+});
+
+test('validateTemplate: reports missing placeholders', () => {
+  const dir = fixtureDir();
+  writeFileSync(join(dir, 'cv-template.broken.html'), '{{NAME}} only');
+  const r = validateTemplate(join(dir, 'cv-template.broken.html'), 'cv');
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.missing.sort(), ['EDUCATION', 'EXPERIENCE']);
+});
+
+test('validateTemplate: cover ok when cover placeholders present', () => {
+  const dir = fixtureDir();
+  const r = validateTemplate(join(dir, 'cover-letter-template.html'), 'cover');
+  assert.deepEqual(r, { ok: true, missing: [] });
+});
+
+test('validateTemplate: cover reports missing cover placeholders', () => {
+  const dir = fixtureDir();
+  writeFileSync(join(dir, 'cover-letter-template.broken.html'), '{{NAME}} only');
+  const r = validateTemplate(join(dir, 'cover-letter-template.broken.html'), 'cover');
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.missing.sort(), ['OPENING', 'ROLE_TITLE']);
+});
+
+function fixtureWithProfile(templateValue) {
+  const dir = fixtureDir();
+  const profile = join(dir, 'profile.yml');
+  writeFileSync(profile, templateValue == null ? 'cv: {}\n' : `cv:\n  template: ${templateValue}\n`);
+  return { dir, profile };
+}
+
+test('resolveTemplate: explicit name wins, kebab-normalized', () => {
+  const { dir, profile } = fixtureWithProfile(null);
+  const p = resolveTemplate('cv', 'Executive Authority', { dir, profilePath: profile });
+  assert.ok(p.endsWith('cv-template.executive-authority.html'));
+});
+
+test('resolveTemplate: falls back to profile default when no name', () => {
+  const { dir, profile } = fixtureWithProfile('executive-authority');
+  const p = resolveTemplate('cv', undefined, { dir, profilePath: profile });
+  assert.ok(p.endsWith('cv-template.executive-authority.html'));
+});
+
+test('resolveTemplate: base standard when nothing set (backward-compatible)', () => {
+  const { dir, profile } = fixtureWithProfile(null);
+  const p = resolveTemplate('cv', undefined, { dir, profilePath: profile });
+  assert.ok(p.endsWith('cv-template.html'));
+});
+
+test('resolveTemplate: missing named template throws (fail loud)', () => {
+  const { dir, profile } = fixtureWithProfile(null);
+  assert.throws(() => resolveTemplate('cv', 'nope', { dir, profilePath: profile }), /not found/);
+});
+
+test('resolveTemplate: fallback=true drops missing name to standard', () => {
+  const { dir, profile } = fixtureWithProfile(null);
+  const p = resolveTemplate('cv', 'nope', { dir, profilePath: profile, format: 'tex', fallback: true });
+  assert.ok(p.endsWith('cv-template.tex'));
+});
+
+test('resolveTemplate: html validation failure throws', () => {
+  const { dir, profile } = fixtureWithProfile(null);
+  writeFileSync(join(dir, 'cv-template.broken.html'), '{{NAME}} only');
+  assert.throws(() => resolveTemplate('cv', 'broken', { dir, profilePath: profile }), /missing required placeholders/);
+});
+
+test('resolveTemplate: cover explicit name selects the named cover template', () => {
+  const { dir, profile } = fixtureWithProfile(null);
+  const p = resolveTemplate('cover', 'Formal', { dir, profilePath: profile });
+  assert.ok(p.endsWith('cover-letter-template.formal.html'));
+});
+
+test('resolveTemplate: cover base standard when nothing set', () => {
+  const { dir, profile } = fixtureWithProfile(null);
+  const p = resolveTemplate('cover', undefined, { dir, profilePath: profile });
+  assert.ok(p.endsWith('cover-letter-template.html'));
+});
+
+test('loadProfileDefault: reads nested key, null when unset/missing', () => {
+  const { dir, profile } = fixtureWithProfile('executive-authority');
+  assert.equal(loadProfileDefault('cv', { profilePath: profile }), 'executive-authority');
+  assert.equal(loadProfileDefault('cv', { profilePath: join(dir, 'nope.yml') }), null);
+});

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -255,6 +255,8 @@ const SYSTEM_PATHS = [
   '.github/',
   'package.json',
   'build-cv-latex.mjs',
+  'cv-templates.mjs',
+  'test/cv-templates.test.mjs',
   'scaffolder/',
   'Dockerfile',
   'docker-compose.yml',


### PR DESCRIPTION
## What does this PR do?

Adds support for multiple CV and cover-letter templates. Templates are discovered by filename convention (`cv-template.<name>.html` / `cover-letter-template.<name>.html`), selected via a `profile.yml` default (`cv.template` / `cover_letter.template`) or conversationally, and resolved through one small shared module (`cv-templates.mjs`) reused by the `pdf`/`cover` modes and `build-cv-latex.mjs`. With nothing set it resolves to today's base template, so existing setups are unchanged. A concrete step under the #1219 user/system-boundary umbrella (customization moves into user-layer config instead of editing a system file).

Includes: `cv-templates.mjs` (+ CLI), `test/cv-templates.test.mjs`, its `test-all.mjs` registration, `pdf`/`cover`/`build-cv-latex.mjs` wiring, and the `config/profile.example.yml` docs. Flat-root preserved; no file relocation.

## Related issue

Closes #1690.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a template resolver CLI to list and resolve available CV and cover-letter templates, with support for selecting a LaTeX CV variant via `--template=<name>`.
  * Updated profile example settings to support default HTML template selection for both CVs and cover letters.
* **Bug Fixes**
  * Missing, invalid, or placeholder-incomplete templates now surface errors instead of silently continuing with a default.
* **Tests**
  * Added end-to-end tests for template discovery, metadata parsing, selection, fallback behavior, and validation.
* **Documentation**
  * Updated CV PDF and cover-letter generation guidance to use the resolver flow and placeholder requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->