### PR TITLE
fix: ignore logo cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ package-lock.json
 
 # Planning (local scratchpad)
 plan/
+
+# Web
+.career-ops-web/logo-cache/


### PR DESCRIPTION
## What does this PR do?

While checking portals health, the portals's logo icons get downloaded. these icons are though not gitignored. 
This PR ignores the `./career-ops-web/logo-cache/` directory.


## Related issue

Fixes #1577

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to prevent cached logo assets from being committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->