### PR TITLE
fix(analyzer): resolve report paths relative to applications.md track…

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -14,7 +14,7 @@
  */
 
 import { readFileSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, relative, sep } from 'path';
 import { fileURLToPath } from 'url';
 import { load as yamlLoad } from 'js-yaml';
 import { resolveColumns, parseTrackerRow, normalizeVia } from './tracker-parse.mjs';
@@ -510,7 +510,12 @@ function analyze() {
     let reportPath = null;
     if (reportMatch) {
       const fromTracker = join(dirname(APPS_FILE), reportMatch[1]);
-      reportPath = existsSync(fromTracker) ? fromTracker : join(CAREER_OPS, reportMatch[1]);
+      const candidate = existsSync(fromTracker) ? fromTracker : join(CAREER_OPS, reportMatch[1]);
+      
+      const repoRelative = relative(CAREER_OPS, candidate).split(sep).join('/');
+      if (repoRelative.startsWith('reports/') && !repoRelative.includes('..')) {
+        reportPath = existsSync(candidate) ? candidate : null;
+      }
     }
     const reportData = reportPath ? parseReport(reportPath) : null;
     const outcome = classifyOutcome(e.status);

--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -504,7 +504,14 @@ function analyze() {
   // Enrich entries with report data and classification
   const enriched = entries.map(e => {
     const reportMatch = e.report.match(/\]\(([^)]+)\)/);
-    const reportPath = reportMatch ? join(CAREER_OPS, reportMatch[1]) : null;
+    // Tracker links are relative to the tracker file's own directory (see
+    // merge-tracker.mjs link normalization); fall back to repo root for
+    // legacy root-relative links.
+    let reportPath = null;
+    if (reportMatch) {
+      const fromTracker = join(dirname(APPS_FILE), reportMatch[1]);
+      reportPath = existsSync(fromTracker) ? fromTracker : join(CAREER_OPS, reportMatch[1]);
+    }
     const reportData = reportPath ? parseReport(reportPath) : null;
     const outcome = classifyOutcome(e.status);
     const trackerScore = parseFloat(e.score);


### PR DESCRIPTION
### Description
This PR resolves #1679.

The pattern analyzer (`analyze-patterns.mjs`) previously attempted to resolve tracker report links using `join(CAREER_OPS, reportMatch[1])` (resolving against the repository root). However, `merge-tracker.mjs` normalizes links relative to the location of `data/applications.md` (resulting in paths like `../reports/041-acme-2025-12-01.md`). 

This path mismatch caused the `existsSync()` checks to fail, preventing `parseReport()` from executing and resulting in archetype and blocker analytics silently falling back to `"Unknown"`.

### Changes
- Updated `analyze-patterns.mjs` to resolve report paths against `dirname(APPS_FILE)` first.
- Added a fallback to `CAREER_OPS` (repo root) to maintain backwards compatibility with legacy root-relative links written prior to the link normalization update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report link handling so links now resolve correctly from the tracker file’s location when available.
  * Preserved support for older root-relative links as a fallback, reducing broken or misdirected report links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->