### PR TITLE
feat(portals): standalone fix-slugs.mjs — auto-write ATS slug fixes to portals.yml

### DIFF
--- a/fix-slugs.mjs
+++ b/fix-slugs.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+/**
+ * fix-slugs.mjs — write verify-portals.mjs's suggested ATS slug fixes back
+ * into portals.yml.
+ *
+ * verify-portals.mjs already probes every tracked company's ATS slug and, for
+ * a failing Greenhouse/Ashby/Lever entry, cross-probes slug variants across
+ * all three ATSes and attaches `suggested: { ats, slug }` when one resolves
+ * (see discoverAlternates() in verify-portals.mjs). That tool is read-only —
+ * this script is the write side: it reuses the SAME probe/suggestion logic
+ * (no re-implementation, no HTML scraping, no hardcoded company list) and
+ * patches the matching `tracked_companies` entry in portals.yml.
+ *
+ * Only entries verify-portals classifies as `missing` AND carries a
+ * `suggested` alternate for are touched. Live/empty entries and genuinely
+ * unresolved entries (no suggestion found) are left completely alone.
+ *
+ * The file is edited as text (line-level surgery inside the matching
+ * company's block), not via full YAML parse+dump — portals.yml is full of
+ * hand-written comments and documentation blocks that a `yaml.dump()`
+ * round-trip would silently discard.
+ *
+ * Usage:
+ *   node fix-slugs.mjs               # dry run (default, safe) — prints the diff, writes nothing
+ *   node fix-slugs.mjs --dry-run     # same as above, explicit
+ *   node fix-slugs.mjs --fix         # write the resolved slugs back to portals.yml
+ *   node fix-slugs.mjs --apply       # alias for --fix
+ *   node fix-slugs.mjs --file <path> # use a specific portals file
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+import { pathToFileURL } from 'url';
+
+import { verifyPortalsFile } from './verify-portals.mjs';
+
+const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
+
+/** Matches a `tracked_companies` list-item start line: `  - name: Foo`. */
+const NAME_LINE_RE = /^([ \t]*)-\s*name:\s*(.+?)\s*$/;
+
+/**
+ * Split a portals.yml's raw text into per-company blocks, keyed by the exact
+ * `name:` value, so a fix can be applied with plain line edits instead of a
+ * full YAML re-serialization (which would drop every comment in the file).
+ * Commented-out example entries (`# - name: ...`) never match — the regex
+ * requires the line to start with `-` after only whitespace.
+ *
+ * @param {string} text - Raw portals.yml contents.
+ * @returns {{lines: string[], blocks: Array<{name: string, indent: string, startLine: number, endLine: number}>}}
+ */
+export function splitCompanyBlocks(text) {
+  const lines = text.split('\n');
+  const blocks = [];
+  let current = null;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(NAME_LINE_RE);
+    if (m) {
+      if (current) {
+        current.endLine = i;
+        blocks.push(current);
+      }
+      current = { name: m[2].trim(), indent: m[1], startLine: i, endLine: null };
+    }
+  }
+  if (current) {
+    current.endLine = lines.length;
+    blocks.push(current);
+  }
+  return { lines, blocks };
+}
+
+/** Build the replacement careers_url/api pair for a resolved {ats, slug}. */
+function resolvedUrls({ ats, slug, eu }) {
+  if (ats === 'greenhouse') {
+    return {
+      careersUrl: `https://job-boards.greenhouse.io/${slug}`,
+      api: `https://boards-api.greenhouse.io/v1/boards/${slug}/jobs`,
+    };
+  }
+  if (ats === 'ashby') {
+    return { careersUrl: `https://jobs.ashbyhq.com/${slug}`, api: null };
+  }
+  // lever
+  return {
+    careersUrl: `https://jobs.${eu ? 'eu.' : ''}lever.co/${slug}`,
+    api: null,
+  };
+}
+
+/**
+ * Find an existing `field: value` line within a block's line range.
+ *
+ * @returns {number} Line index, or -1 if the field isn't present in the block.
+ */
+function findFieldLine(lines, startLine, endLine, fieldIndent, field) {
+  const re = new RegExp(`^${fieldIndent}${field}:\\s*(.*)$`);
+  for (let i = startLine; i < endLine; i++) {
+    if (re.test(lines[i])) return i;
+  }
+  return -1;
+}
+
+/**
+ * Apply one resolved suggestion to a company's block in-place (mutates `lines`).
+ *
+ * @param {string[]} lines - Full file, split by line (mutated).
+ * @param {{name: string, indent: string, startLine: number, endLine: number}} block
+ * @param {{ats: string, slug: string, eu?: boolean}} suggested - The new ATS/slug.
+ * @param {string} oldAts - The ATS the entry used to resolve to (for the note).
+ * @param {string} dateStr - YYYY-MM-DD, embedded in the migration note.
+ * @returns {{careersUrlOld: string, careersUrlNew: string}} Summary for the diff printout.
+ */
+function applyFix(lines, block, suggested, oldAts, dateStr) {
+  const fieldIndent = `${block.indent}  `;
+  const { careersUrl, api } = resolvedUrls(suggested);
+
+  const careersLine = findFieldLine(lines, block.startLine, block.endLine, fieldIndent, 'careers_url');
+  const careersUrlOld = careersLine !== -1 ? lines[careersLine].split(':').slice(1).join(':').trim() : '';
+  let insertAfter = careersLine;
+  if (careersLine !== -1) {
+    lines[careersLine] = `${fieldIndent}careers_url: ${careersUrl}`;
+  } else {
+    lines.splice(block.startLine + 1, 0, `${fieldIndent}careers_url: ${careersUrl}`);
+    insertAfter = block.startLine + 1;
+    block.endLine += 1;
+  }
+
+  const apiLine = findFieldLine(lines, block.startLine, block.endLine, fieldIndent, 'api');
+  if (api) {
+    if (apiLine !== -1) {
+      lines[apiLine] = `${fieldIndent}api: ${api}`;
+    } else {
+      lines.splice(insertAfter + 1, 0, `${fieldIndent}api: ${api}`);
+      block.endLine += 1;
+      insertAfter += 1;
+    }
+  } else if (apiLine !== -1) {
+    // Migrating away from Greenhouse — a stale `api:` field would point at a
+    // dead boards-api.greenhouse.io endpoint the scanner would still try.
+    lines.splice(apiLine, 1);
+    block.endLine -= 1;
+  }
+
+  const note = `(slug migrated ${oldAts}->${suggested.ats} ${dateStr}, verify-portals)`;
+  const notesLine = findFieldLine(lines, block.startLine, block.endLine, fieldIndent, 'notes');
+  if (notesLine !== -1) {
+    const raw = lines[notesLine].slice(lines[notesLine].indexOf('notes:') + 'notes:'.length).trim();
+    const quoted = raw.startsWith('"') && raw.endsWith('"');
+    const inner = quoted ? raw.slice(1, -1) : raw;
+    lines[notesLine] = `${fieldIndent}notes: "${inner} ${note}"`;
+  } else {
+    lines.splice(insertAfter + 1, 0, `${fieldIndent}notes: "${note}"`);
+    block.endLine += 1;
+  }
+
+  return { careersUrlOld, careersUrlNew: careersUrl };
+}
+
+/**
+ * Compute the set of fixes to apply from a verify-portals run, and (unless
+ * dryRun) write them into the raw text.
+ *
+ * @param {string} rawText - Current portals.yml contents.
+ * @param {Array<object>} results - verifyCompanies()/verifyPortalsFile() rows.
+ * @param {{dryRun?: boolean, dateStr?: string}} [opts]
+ * @returns {{text: string, fixes: Array<{name: string, oldAts: string, newAts: string, careersUrlOld: string, careersUrlNew: string}>}}
+ */
+export function computeFixes(rawText, results, { dateStr = new Date().toISOString().slice(0, 10) } = {}) {
+  const { lines, blocks } = splitCompanyBlocks(rawText);
+  const blocksByName = new Map(blocks.map((b) => [b.name, b]));
+  const fixes = [];
+
+  for (const r of results) {
+    if (r.status !== 'missing' || !r.suggested) continue;
+    const block = blocksByName.get(r.name);
+    if (!block) continue; // name mismatch — leave untouched rather than guess
+    const { careersUrlOld, careersUrlNew } = applyFix(lines, block, r.suggested, r.ats || 'unknown', dateStr);
+    fixes.push({
+      name: r.name,
+      oldAts: r.ats || 'unknown',
+      newAts: r.suggested.ats,
+      careersUrlOld,
+      careersUrlNew,
+    });
+  }
+
+  return { text: lines.join('\n'), fixes };
+}
+
+function printDiff(fixes, { dryRun }) {
+  if (fixes.length === 0) {
+    console.log('No resolvable slug fixes found — nothing to do.');
+    return;
+  }
+  console.log(`${dryRun ? '[dry run] Would fix' : 'Fixed'} ${fixes.length} entr${fixes.length === 1 ? 'y' : 'ies'}:\n`);
+  for (const f of fixes) {
+    console.log(`  ${f.name}: ${f.oldAts} -> ${f.newAts}`);
+    console.log(`    - ${f.careersUrlOld}`);
+    console.log(`    + ${f.careersUrlNew}`);
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const fix = args.includes('--fix') || args.includes('--apply');
+  const dryRun = !fix; // default is always safe — writing requires an explicit flag
+
+  const fileFlag = args.indexOf('--file');
+  const filePath = resolve(fileFlag === -1 ? DEFAULT_PORTALS_PATH : args[fileFlag + 1] || '');
+
+  if (!existsSync(filePath)) {
+    console.log(`fix-slugs: no portals file at ${filePath} — nothing to fix.`);
+    return;
+  }
+
+  const { results } = await verifyPortalsFile(filePath);
+  const rawText = readFileSync(filePath, 'utf-8');
+  const { text, fixes } = computeFixes(rawText, results);
+
+  printDiff(fixes, { dryRun });
+
+  if (!dryRun && fixes.length > 0) {
+    writeFileSync(filePath, text, 'utf-8');
+    console.log(`\nportals.yml updated (${fixes.length} fixed).`);
+  } else if (dryRun && fixes.length > 0) {
+    console.log('\nRun with --fix to write these changes to portals.yml.');
+  }
+}
+
+// Only run main() when invoked directly, not when imported by tests.
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((err) => {
+    console.error(`fix-slugs failed: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/fix-slugs.mjs
+++ b/fix-slugs.mjs
@@ -102,6 +102,80 @@ function findFieldLine(lines, startLine, endLine, fieldIndent, field) {
   return -1;
 }
 
+/** Escape a plain-scalar string so it's safe to wrap in a double-quoted YAML scalar. */
+function escapeForDoubleQuoted(str) {
+  return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Append a migration note to an existing `notes:` field, without corrupting
+ * the surrounding YAML — handles three shapes:
+ *
+ *   1. Block scalar (`notes: |` / `notes: >`, with optional chomping
+ *      indicator and explicit indentation digit): the header must NOT be
+ *      rewritten as a plain scalar (that would silently truncate/garble any
+ *      multi-line content). Instead, the note is appended as a new
+ *      continuation line at the scalar's own content indentation.
+ *   2. Double-quoted plain scalar (`notes: "..."`): the existing escaped
+ *      content is reused as-is (already valid inside a `"..."` scalar) and
+ *      the note is appended before the closing quote.
+ *   3. Single-quoted or unquoted plain scalar: any embedded quote/backslash
+ *      characters are escaped before the value is re-wrapped in double
+ *      quotes, so an embedded `"` (or a single-quoted `''` YAML escape)
+ *      can't break the rewritten line.
+ *
+ * @param {string[]} lines - Full file, split by line (mutated).
+ * @param {{indent: string, startLine: number, endLine: number}} block - Mutated in place (endLine grows on insert).
+ * @param {number} notesLine - Line index of the existing `notes:` field.
+ * @param {string} fieldIndent - Indentation of fields inside this block.
+ * @param {string} note - The migration note text to append (no quoting needed — built from ats/slug/date).
+ */
+function appendNote(lines, block, notesLine, fieldIndent, note) {
+  const keyIdx = lines[notesLine].indexOf('notes:');
+  const afterKey = lines[notesLine].slice(keyIdx + 'notes:'.length).trim();
+
+  const blockScalarMatch = afterKey.match(/^([|>])[-+]?\d*\s*(#.*)?$/);
+  if (blockScalarMatch) {
+    // Walk the scalar's continuation lines to find their indentation and the
+    // insertion point (first line at/under the field's own indent, or the
+    // end of the block, ends the scalar).
+    let contentIndent = null;
+    let insertAt = notesLine + 1;
+    for (let i = notesLine + 1; i < block.endLine; i++) {
+      const line = lines[i];
+      if (line.trim() === '') {
+        insertAt = i + 1;
+        continue;
+      }
+      const lineIndent = line.match(/^[ \t]*/)[0];
+      if (lineIndent.length <= fieldIndent.length) break; // dedent — scalar ended
+      contentIndent = lineIndent;
+      insertAt = i + 1;
+    }
+    const noteIndent = contentIndent || `${fieldIndent}  `;
+    lines.splice(insertAt, 0, `${noteIndent}${note}`);
+    block.endLine += 1;
+    return;
+  }
+
+  let inner;
+  if (afterKey.length >= 2 && afterKey.startsWith('"') && afterKey.endsWith('"')) {
+    // Already double-quoted: the content between the quotes is already valid
+    // double-quoted-scalar text (any embedded `"`/`\` is already escaped) —
+    // reuse it verbatim rather than re-escaping already-escaped sequences.
+    inner = afterKey.slice(1, -1);
+  } else if (afterKey.length >= 2 && afterKey.startsWith("'") && afterKey.endsWith("'")) {
+    // Single-quoted YAML escapes a literal `'` as `''` — undo that, then
+    // escape for the double-quoted scalar we're about to produce.
+    inner = escapeForDoubleQuoted(afterKey.slice(1, -1).replace(/''/g, "'"));
+  } else {
+    // Unquoted plain scalar — may itself contain unescaped `"` or `\`
+    // characters that would break a naive re-wrap.
+    inner = escapeForDoubleQuoted(afterKey);
+  }
+  lines[notesLine] = `${fieldIndent}notes: "${inner} ${note}"`;
+}
+
 /**
  * Apply one resolved suggestion to a company's block in-place (mutates `lines`).
  *
@@ -146,10 +220,7 @@ function applyFix(lines, block, suggested, oldAts, dateStr) {
   const note = `(slug migrated ${oldAts}->${suggested.ats} ${dateStr}, verify-portals)`;
   const notesLine = findFieldLine(lines, block.startLine, block.endLine, fieldIndent, 'notes');
   if (notesLine !== -1) {
-    const raw = lines[notesLine].slice(lines[notesLine].indexOf('notes:') + 'notes:'.length).trim();
-    const quoted = raw.startsWith('"') && raw.endsWith('"');
-    const inner = quoted ? raw.slice(1, -1) : raw;
-    lines[notesLine] = `${fieldIndent}notes: "${inner} ${note}"`;
+    appendNote(lines, block, notesLine, fieldIndent, note);
   } else {
     lines.splice(insertAfter + 1, 0, `${fieldIndent}notes: "${note}"`);
     block.endLine += 1;
@@ -170,14 +241,30 @@ function applyFix(lines, block, suggested, oldAts, dateStr) {
 export function computeFixes(rawText, results, { dateStr = new Date().toISOString().slice(0, 10) } = {}) {
   const { lines, blocks } = splitCompanyBlocks(rawText);
   const blocksByName = new Map(blocks.map((b) => [b.name, b]));
-  const fixes = [];
 
+  // Pair each resolvable result with its block first, WITHOUT applying any
+  // edits yet. Line insertions/removals inside one block shift the absolute
+  // line numbers of every block further down the file — if we applied fixes
+  // in `results` order (which has no relation to file position), fixing an
+  // earlier-in-file company first could invalidate the startLine/endLine of
+  // a later-in-file company still waiting to be processed (or vice versa).
+  // Processing strictly bottom-to-top (highest startLine first) guarantees
+  // every edit only ever shifts lines that are BELOW it, so a block still
+  // pending above the current edit point never has its recorded position
+  // invalidated by a fix applied further down.
+  const pending = [];
   for (const r of results) {
     if (r.status !== 'missing' || !r.suggested) continue;
     const block = blocksByName.get(r.name);
     if (!block) continue; // name mismatch — leave untouched rather than guess
+    pending.push({ r, block });
+  }
+  pending.sort((a, b) => b.block.startLine - a.block.startLine);
+
+  const fixesByName = new Map();
+  for (const { r, block } of pending) {
     const { careersUrlOld, careersUrlNew } = applyFix(lines, block, r.suggested, r.ats || 'unknown', dateStr);
-    fixes.push({
+    fixesByName.set(r.name, {
       name: r.name,
       oldAts: r.ats || 'unknown',
       newAts: r.suggested.ats,
@@ -185,6 +272,10 @@ export function computeFixes(rawText, results, { dateStr = new Date().toISOStrin
       careersUrlNew,
     });
   }
+
+  // Report fixes back in the caller's original `results` order (diff output
+  // should read like the verify-portals run, not our bottom-to-top processing order).
+  const fixes = results.map((r) => fixesByName.get(r.name)).filter(Boolean);
 
   return { text: lines.join('\n'), fixes };
 }

--- a/fix-slugs.mjs
+++ b/fix-slugs.mjs
@@ -158,22 +158,46 @@ function appendNote(lines, block, notesLine, fieldIndent, note) {
     return;
   }
 
+  // A trailing inline comment must be split off BEFORE the quote-type check —
+  // otherwise a quoted value followed by `# comment` doesn't end with the
+  // closing quote character and falls through to the unquoted branch, which
+  // escapes the comment text itself into the value instead of leaving it as
+  // a real YAML comment.
+  const doubleQuotedRe = /^"((?:[^"\\]|\\.)*)"[ \t]*(#.*)?$/;
+  const singleQuotedRe = /^'((?:[^']|'')*)'[ \t]*(#.*)?$/;
+
   let inner;
-  if (afterKey.length >= 2 && afterKey.startsWith('"') && afterKey.endsWith('"')) {
+  let comment = '';
+  const dq = afterKey.match(doubleQuotedRe);
+  const sq = !dq && afterKey.match(singleQuotedRe);
+  if (dq) {
     // Already double-quoted: the content between the quotes is already valid
     // double-quoted-scalar text (any embedded `"`/`\` is already escaped) —
     // reuse it verbatim rather than re-escaping already-escaped sequences.
-    inner = afterKey.slice(1, -1);
-  } else if (afterKey.length >= 2 && afterKey.startsWith("'") && afterKey.endsWith("'")) {
+    inner = dq[1];
+    comment = dq[2] || '';
+  } else if (sq) {
     // Single-quoted YAML escapes a literal `'` as `''` — undo that, then
     // escape for the double-quoted scalar we're about to produce.
-    inner = escapeForDoubleQuoted(afterKey.slice(1, -1).replace(/''/g, "'"));
+    inner = escapeForDoubleQuoted(sq[1].replace(/''/g, "'"));
+    comment = sq[2] || '';
   } else {
     // Unquoted plain scalar — may itself contain unescaped `"` or `\`
-    // characters that would break a naive re-wrap.
-    inner = escapeForDoubleQuoted(afterKey);
+    // characters that would break a naive re-wrap, and may carry its own
+    // trailing `# comment` (a YAML comment must start at the line or be
+    // preceded by whitespace, so scan for the first such `#`).
+    let hashIdx = -1;
+    for (let i = 0; i < afterKey.length; i++) {
+      if (afterKey[i] === '#' && (i === 0 || /\s/.test(afterKey[i - 1]))) {
+        hashIdx = i;
+        break;
+      }
+    }
+    const value = hashIdx === -1 ? afterKey : afterKey.slice(0, hashIdx).trimEnd();
+    comment = hashIdx === -1 ? '' : afterKey.slice(hashIdx);
+    inner = escapeForDoubleQuoted(value);
   }
-  lines[notesLine] = `${fieldIndent}notes: "${inner} ${note}"`;
+  lines[notesLine] = `${fieldIndent}notes: "${inner} ${note}"${comment ? ` ${comment}` : ''}`;
 }
 
 /**
@@ -205,6 +229,7 @@ function applyFix(lines, block, suggested, oldAts, dateStr) {
   if (api) {
     if (apiLine !== -1) {
       lines[apiLine] = `${fieldIndent}api: ${api}`;
+      insertAfter = Math.max(insertAfter, apiLine);
     } else {
       lines.splice(insertAfter + 1, 0, `${fieldIndent}api: ${api}`);
       block.endLine += 1;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4052,16 +4052,103 @@ try {
     fail('fix-slugs modified an unresolved entry it should have left alone');
   }
 
+  // Bottom-to-top processing: fixing an earlier-in-file company must not
+  // corrupt the line ranges of a later-in-file company still pending, even
+  // when the earlier fix inserts new lines (new `api:` field, new `notes:`
+  // field) that shift every line number below it.
+  const orderFixture = [
+    'tracked_companies:',
+    '',
+    '  - name: First Co',
+    '    careers_url: https://jobs.lever.co/firstco',
+    '    enabled: true',
+    '',
+    '  - name: Second Co',
+    '    careers_url: https://jobs.lever.co/secondco',
+    '    enabled: true',
+    '',
+    '  - name: Third Co',
+    '    careers_url: https://jobs.lever.co/thirdco',
+    '    enabled: true',
+    '',
+  ].join('\n');
+  const orderResults = [
+    { name: 'First Co', status: 'missing', ats: 'lever', slug: 'firstco', suggested: { ats: 'greenhouse', slug: 'first-gh' } },
+    { name: 'Second Co', status: 'missing', ats: 'lever', slug: 'secondco', suggested: { ats: 'greenhouse', slug: 'second-gh' } },
+    { name: 'Third Co', status: 'missing', ats: 'lever', slug: 'thirdco', suggested: { ats: 'ashby', slug: 'third-ashby' } },
+  ];
+  const { text: orderedText } = computeFixes(orderFixture, orderResults, { dateStr: '2026-07-09' });
+  const orderedParsed = yaml.load(orderedText);
+  const orderedByName = Object.fromEntries(orderedParsed.tracked_companies.map((c) => [c.name, c]));
+  if (
+    orderedByName['First Co'].careers_url === 'https://job-boards.greenhouse.io/first-gh' &&
+    orderedByName['First Co'].api === 'https://boards-api.greenhouse.io/v1/boards/first-gh/jobs' &&
+    orderedByName['Second Co'].careers_url === 'https://job-boards.greenhouse.io/second-gh' &&
+    orderedByName['Second Co'].api === 'https://boards-api.greenhouse.io/v1/boards/second-gh/jobs' &&
+    orderedByName['Third Co'].careers_url === 'https://jobs.ashbyhq.com/third-ashby' &&
+    !('api' in orderedByName['Third Co'])
+  ) {
+    pass('fix-slugs applies fixes bottom-to-top so earlier line-count shifts never corrupt a later block');
+  } else {
+    fail(`fix-slugs multi-company ordering wrong: ${JSON.stringify(orderedByName)}`);
+  }
+
+  // notes: edge cases — block scalar and embedded/single quotes must not
+  // corrupt the surrounding YAML.
+  const notesFixture = [
+    'tracked_companies:',
+    '',
+    '  - name: Block Co',
+    '    careers_url: https://jobs.lever.co/blockco',
+    '    notes: |',
+    '      Line one of notes.',
+    '      Line two of notes.',
+    '    enabled: true',
+    '',
+    '  - name: Quote Co',
+    '    careers_url: https://jobs.lever.co/quoteco',
+    '    notes: Some "quoted" unquoted text',
+    '    enabled: true',
+    '',
+    "  - name: Single Co",
+    '    careers_url: https://jobs.lever.co/singleco',
+    "    notes: 'It''s a single-quoted note'",
+    '    enabled: true',
+    '',
+  ].join('\n');
+  const notesResults = [
+    { name: 'Block Co', status: 'missing', ats: 'lever', slug: 'blockco', suggested: { ats: 'ashby', slug: 'block-ashby' } },
+    { name: 'Quote Co', status: 'missing', ats: 'lever', slug: 'quoteco', suggested: { ats: 'ashby', slug: 'quote-ashby' } },
+    { name: 'Single Co', status: 'missing', ats: 'lever', slug: 'singleco', suggested: { ats: 'ashby', slug: 'single-ashby' } },
+  ];
+  const { text: notesText } = computeFixes(notesFixture, notesResults, { dateStr: '2026-07-09' });
+  const notesParsed = yaml.load(notesText);
+  const notesByName = Object.fromEntries(notesParsed.tracked_companies.map((c) => [c.name, c]));
+  if (
+    notesByName['Block Co'].notes.includes('Line one of notes.') &&
+    notesByName['Block Co'].notes.includes('Line two of notes.') &&
+    notesByName['Block Co'].notes.includes('slug migrated lever->ashby 2026-07-09, verify-portals') &&
+    notesByName['Quote Co'].notes === 'Some "quoted" unquoted text (slug migrated lever->ashby 2026-07-09, verify-portals)' &&
+    notesByName['Single Co'].notes === "It's a single-quoted note (slug migrated lever->ashby 2026-07-09, verify-portals)"
+  ) {
+    pass('fix-slugs safely appends notes to block-scalar and quote-embedded values');
+  } else {
+    fail(`fix-slugs notes edge cases produced invalid/wrong content: ${JSON.stringify(notesByName)}`);
+  }
+
   // --dry-run must never mutate the file: computeFixes is pure (it only
   // returns text), so a caller doing dry-run simply never calls writeFileSync.
-  // Verify that guarantee holds by running computeFixes twice and confirming
-  // the ORIGINAL fixture string used as the base for a second run is untouched.
-  const fixtureBefore = fixture;
-  computeFixes(fixture, mockResults, { dateStr: '2026-07-08' });
-  if (fixture === fixtureBefore) {
+  // Verify that guarantee holds by calling computeFixes twice on the SAME base
+  // input and deep-equality-checking the two independently-returned outputs —
+  // comparing the input string to itself would prove nothing (strings are
+  // immutable in JS; that reference can never change no matter what the
+  // function does internally).
+  const runA = computeFixes(fixture, mockResults, { dateStr: '2026-07-08' });
+  const runB = computeFixes(fixture, mockResults, { dateStr: '2026-07-08' });
+  if (runA.text === runB.text && JSON.stringify(runA.fixes) === JSON.stringify(runB.fixes)) {
     pass('fix-slugs computeFixes does not mutate its input text (dry-run safe)');
   } else {
-    fail('fix-slugs computeFixes mutated its input text');
+    fail('fix-slugs computeFixes produced different output across two calls on the same input');
   }
 
   // End-to-end CLI --dry-run must not write to disk.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4115,11 +4115,17 @@ try {
     "    notes: 'It''s a single-quoted note'",
     '    enabled: true',
     '',
+    '  - name: Commented Co',
+    '    careers_url: https://jobs.lever.co/commentedco',
+    '    notes: "Existing note" # do not remove this line',
+    '    enabled: true',
+    '',
   ].join('\n');
   const notesResults = [
     { name: 'Block Co', status: 'missing', ats: 'lever', slug: 'blockco', suggested: { ats: 'ashby', slug: 'block-ashby' } },
     { name: 'Quote Co', status: 'missing', ats: 'lever', slug: 'quoteco', suggested: { ats: 'ashby', slug: 'quote-ashby' } },
     { name: 'Single Co', status: 'missing', ats: 'lever', slug: 'singleco', suggested: { ats: 'ashby', slug: 'single-ashby' } },
+    { name: 'Commented Co', status: 'missing', ats: 'lever', slug: 'commentedco', suggested: { ats: 'ashby', slug: 'commented-ashby' } },
   ];
   const { text: notesText } = computeFixes(notesFixture, notesResults, { dateStr: '2026-07-09' });
   const notesParsed = yaml.load(notesText);
@@ -4129,11 +4135,47 @@ try {
     notesByName['Block Co'].notes.includes('Line two of notes.') &&
     notesByName['Block Co'].notes.includes('slug migrated lever->ashby 2026-07-09, verify-portals') &&
     notesByName['Quote Co'].notes === 'Some "quoted" unquoted text (slug migrated lever->ashby 2026-07-09, verify-portals)' &&
-    notesByName['Single Co'].notes === "It's a single-quoted note (slug migrated lever->ashby 2026-07-09, verify-portals)"
+    notesByName['Single Co'].notes === "It's a single-quoted note (slug migrated lever->ashby 2026-07-09, verify-portals)" &&
+    notesByName['Commented Co'].notes === 'Existing note (slug migrated lever->ashby 2026-07-09, verify-portals)'
   ) {
     pass('fix-slugs safely appends notes to block-scalar and quote-embedded values');
   } else {
     fail(`fix-slugs notes edge cases produced invalid/wrong content: ${JSON.stringify(notesByName)}`);
+  }
+
+  // A quoted notes value followed by a trailing `# comment` must keep that
+  // comment as a real YAML comment (outside the rewritten quoted scalar),
+  // not swallow it into the value — regression guard for the quote-type
+  // check running before the comment was split off.
+  if (notesText.includes('# do not remove this line')) {
+    pass('fix-slugs preserves a trailing inline comment on a quoted notes value');
+  } else {
+    fail(`fix-slugs lost the trailing comment on Commented Co's notes line: ${JSON.stringify(notesText)}`);
+  }
+
+  // Regression guard: when `api:` already exists and is rewritten in place
+  // (not newly inserted), a subsequently-inserted `notes:` field must land
+  // AFTER it, not before it — `insertAfter` has to advance to the existing
+  // api line's position, not stay pinned at careers_url.
+  const apiOrderFixture = [
+    'tracked_companies:',
+    '',
+    '  - name: Renamed GH Co',
+    '    careers_url: https://job-boards.greenhouse.io/oldslug',
+    '    api: https://boards-api.greenhouse.io/v1/boards/oldslug/jobs',
+    '    enabled: true',
+    '',
+  ].join('\n');
+  const apiOrderResults = [
+    { name: 'Renamed GH Co', status: 'missing', ats: 'greenhouse', slug: 'oldslug', suggested: { ats: 'greenhouse', slug: 'newslug' } },
+  ];
+  const { text: apiOrderText } = computeFixes(apiOrderFixture, apiOrderResults, { dateStr: '2026-07-09' });
+  const apiLineIdx = apiOrderText.split('\n').findIndex((l) => l.trim().startsWith('api:'));
+  const notesLineIdx = apiOrderText.split('\n').findIndex((l) => l.trim().startsWith('notes:'));
+  if (apiLineIdx !== -1 && notesLineIdx !== -1 && notesLineIdx > apiLineIdx) {
+    pass('fix-slugs inserts a new notes field after an existing rewritten-in-place api field');
+  } else {
+    fail(`fix-slugs inserted notes before the existing api field: ${JSON.stringify(apiOrderText)}`);
   }
 
   // --dry-run must never mutate the file: computeFixes is pure (it only

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -29,6 +29,7 @@ import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFil
 import { join, dirname, basename, delimiter } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
+import yaml from 'js-yaml';
 import { pass, fail, warn, run, fileExists, finish, ROOT, QUICK, NODE, getBash, toBashPath } from './tests/helpers.mjs';
 
 /**
@@ -3929,6 +3930,162 @@ try {
   }
 } catch (e) {
   fail(`portal slug validator tests crashed: ${e.message}`);
+}
+
+// ── 10c. SLUG AUTO-FIXER (fix-slugs.mjs) ─────────────────────────
+
+console.log('\n10c. Slug auto-fixer');
+
+try {
+  const { splitCompanyBlocks, computeFixes } = await import(
+    pathToFileURL(join(ROOT, 'fix-slugs.mjs')).href
+  );
+
+  const fixture = [
+    'tracked_companies:',
+    '',
+    '  # A live company — must stay untouched',
+    '  - name: Live Co',
+    '    careers_url: https://job-boards.greenhouse.io/livewco',
+    '    api: https://boards-api.greenhouse.io/v1/boards/livewco/jobs',
+    '    notes: "Some notes here."',
+    '    enabled: true',
+    '',
+    '  - name: Migrated Co',
+    '    careers_url: https://jobs.lever.co/migratedco',
+    '    notes: "Old lever board."',
+    '    enabled: true',
+    '',
+    '  - name: Unresolved Co',
+    '    careers_url: https://job-boards.greenhouse.io/typo-slug',
+    '    enabled: true',
+    '',
+    '  - name: No Notes Co',
+    '    careers_url: https://jobs.ashbyhq.com/nonotesco',
+    '    enabled: true',
+    '',
+  ].join('\n');
+
+  const { blocks } = splitCompanyBlocks(fixture);
+  const blockNames = blocks.map((b) => b.name);
+  if (
+    blockNames.length === 4 &&
+    blockNames.includes('Live Co') &&
+    blockNames.includes('Migrated Co') &&
+    blockNames.includes('Unresolved Co') &&
+    blockNames.includes('No Notes Co')
+  ) {
+    pass('fix-slugs splits portals.yml text into per-company blocks (comments excluded)');
+  } else {
+    fail(`fix-slugs splitCompanyBlocks wrong: ${JSON.stringify(blockNames)}`);
+  }
+
+  // Mock verify-portals results: one resolvable ATS migration (lever->ashby),
+  // one resolvable migration into Greenhouse for an entry with no api/notes
+  // fields yet, one genuinely unresolved slug, and one already-live entry.
+  const mockResults = [
+    { name: 'Live Co', status: 'live', ats: 'greenhouse', slug: 'livewco' },
+    {
+      name: 'Migrated Co',
+      status: 'missing',
+      ats: 'lever',
+      slug: 'migratedco',
+      errorKind: 'slug_gone',
+      suggested: { ats: 'ashby', slug: 'top-hat' },
+    },
+    {
+      name: 'Unresolved Co',
+      status: 'missing',
+      ats: 'greenhouse',
+      slug: 'typo-slug',
+      errorKind: 'slug_gone',
+      // no `suggested` — nothing resolved
+    },
+    {
+      name: 'No Notes Co',
+      status: 'missing',
+      ats: 'ashby',
+      slug: 'nonotesco',
+      errorKind: 'slug_gone',
+      suggested: { ats: 'greenhouse', slug: 'nonotesnew' },
+    },
+  ];
+
+  const { text: fixedText, fixes } = computeFixes(fixture, mockResults, { dateStr: '2026-07-08' });
+  const fixedByName = Object.fromEntries(fixes.map((f) => [f.name, f]));
+
+  if (
+    fixes.length === 2 &&
+    fixedByName['Migrated Co']?.newAts === 'ashby' &&
+    fixedByName['Migrated Co']?.careersUrlNew === 'https://jobs.ashbyhq.com/top-hat' &&
+    fixedByName['No Notes Co']?.newAts === 'greenhouse' &&
+    fixedByName['No Notes Co']?.careersUrlNew === 'https://job-boards.greenhouse.io/nonotesnew'
+  ) {
+    pass('fix-slugs computeFixes resolves only entries with a suggested alternate');
+  } else {
+    fail(`fix-slugs computeFixes wrong fix set: ${JSON.stringify(fixedByName)}`);
+  }
+
+  const parsedFixed = yaml.load(fixedText);
+  const byNameFixed = Object.fromEntries(parsedFixed.tracked_companies.map((c) => [c.name, c]));
+  if (
+    byNameFixed['Live Co'].careers_url === 'https://job-boards.greenhouse.io/livewco' &&
+    byNameFixed['Live Co'].notes === 'Some notes here.' &&
+    byNameFixed['Migrated Co'].careers_url === 'https://jobs.ashbyhq.com/top-hat' &&
+    !('api' in byNameFixed['Migrated Co']) &&
+    byNameFixed['Migrated Co'].notes.includes('slug migrated lever->ashby 2026-07-08, verify-portals') &&
+    byNameFixed['Unresolved Co'].careers_url === 'https://job-boards.greenhouse.io/typo-slug' &&
+    byNameFixed['No Notes Co'].careers_url === 'https://job-boards.greenhouse.io/nonotesnew' &&
+    byNameFixed['No Notes Co'].api === 'https://boards-api.greenhouse.io/v1/boards/nonotesnew/jobs' &&
+    byNameFixed['No Notes Co'].notes.includes('slug migrated ashby->greenhouse 2026-07-08, verify-portals')
+  ) {
+    pass('fix-slugs writes resolved careers_url/api/notes and re-parses as valid YAML');
+  } else {
+    fail(`fix-slugs fixed-text YAML wrong: ${JSON.stringify(byNameFixed)}`);
+  }
+
+  // A resolvable-but-untouched control: an unresolved entry (no `suggested`)
+  // must come out of computeFixes byte-for-byte identical to its input block.
+  if (fixedText.includes('  - name: Unresolved Co\n    careers_url: https://job-boards.greenhouse.io/typo-slug\n    enabled: true')) {
+    pass('fix-slugs leaves an unresolved entry (no suggestion) completely untouched');
+  } else {
+    fail('fix-slugs modified an unresolved entry it should have left alone');
+  }
+
+  // --dry-run must never mutate the file: computeFixes is pure (it only
+  // returns text), so a caller doing dry-run simply never calls writeFileSync.
+  // Verify that guarantee holds by running computeFixes twice and confirming
+  // the ORIGINAL fixture string used as the base for a second run is untouched.
+  const fixtureBefore = fixture;
+  computeFixes(fixture, mockResults, { dateStr: '2026-07-08' });
+  if (fixture === fixtureBefore) {
+    pass('fix-slugs computeFixes does not mutate its input text (dry-run safe)');
+  } else {
+    fail('fix-slugs computeFixes mutated its input text');
+  }
+
+  // End-to-end CLI --dry-run must not write to disk.
+  const dryRunTmp = mkdtempSync(join(tmpdir(), 'career-ops-fix-slugs-dryrun-'));
+  const dryRunPortals = join(dryRunTmp, 'portals.yml');
+  writeFileSync(dryRunPortals, fixture);
+  const beforeDryRun = readFileSync(dryRunPortals, 'utf-8');
+  try {
+    execFileSync(NODE, [join(ROOT, 'fix-slugs.mjs'), '--file', dryRunPortals, '--dry-run'], {
+      cwd: ROOT,
+      timeout: 15000,
+    });
+  } catch {
+    // Network is reachable-or-not in CI; either way, no write should occur.
+  }
+  const afterDryRun = readFileSync(dryRunPortals, 'utf-8');
+  if (afterDryRun === beforeDryRun) {
+    pass('fix-slugs.mjs --dry-run (default) never writes to portals.yml');
+  } else {
+    fail('fix-slugs.mjs --dry-run wrote to portals.yml — must require --fix/--apply');
+  }
+  rmSync(dryRunTmp, { recursive: true, force: true });
+} catch (e) {
+  fail(`slug auto-fixer tests crashed: ${e.message}`);
 }
 
 // ── 11. AGENTS.md INTEGRITY ─────────────────────────────────────

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -223,6 +223,7 @@ const SYSTEM_PATHS = [
   'agent-inbox-tests.mjs',
   'validate-portals.mjs',
   'verify-portals.mjs',
+  'fix-slugs.mjs',
   'updater-migration-tests.mjs',
   'validate-system-paths-coverage.mjs',
   'reply-matcher.mjs',


### PR DESCRIPTION
## What does this PR do?

Adds `fix-slugs.mjs`, the write side of `verify-portals.mjs` (#1016, extended in #1455). `verify-portals.mjs` already probes every tracked company's ATS slug and, for a failing entry, cross-probes slug variants across Greenhouse/Ashby/Lever via `discoverAlternates()`, attaching `suggested: { ats, slug }` when one resolves — but it's read-only. This script writes that suggestion back into the matching `portals.yml` entry.

### Which option, and why

The issue offered two shapes: a `--fix`/`--dry-run` flag on `verify-portals.mjs` directly, or a standalone `fix-slugs.mjs`. I went with **the standalone script** (matching the issue title and the original #1612 proposal) because `verify-portals.mjs` is explicitly documented as read-only / network-probe-only in its own header comment, and its `main()` is deliberately simple (probe, print, exit code for `--strict`). Keeping the write path in its own file avoids growing that responsibility into a script whose whole design point is "never mutates state," and keeps the write logic (YAML-safe text editing) testable in isolation.

### How it differs from the closed #1612 version

Per the maintainer's note that #1612's approach shouldn't be copied wholesale:

- **No hardcoded company list.** Reads `tracked_companies` straight from `portals.yml` (or `--file <path>`), so it works for any user's tracked companies, not a fixed personal set.
- **No HTML scraping / redirect-following.** Reuses `verify-portals.mjs`'s existing `verifyPortalsFile()` → `probeSlug()`/`discoverAlternates()` pipeline (imported, not reimplemented) — the same Greenhouse/Ashby/Lever JSON API probes verify-portals already does.
- **Comments survive.** #1612 used `yaml.load()` + `yaml.dump()`, which would silently strip every one of the many hand-written comment blocks in `portals.yml` (provider docs, filter examples, etc.). This version edits the file as text — it locates each company's block by its `- name:` line and only rewrites the `careers_url`/`api`/`notes` lines inside that block, leaving everything else byte-for-byte identical. Verified the output still round-trips through `yaml.load()` correctly.
- **Only touches resolvable fixes.** Only entries verify-portals classifies `missing` **and** attaches a `suggested` alternate to are touched. Already-live/working entries and genuinely unresolved slugs (no suggestion found) are left completely alone — no disabling or `_note` fields for unsupported ATSes, since that wasn't the reported problem.

### Usage

```bash
node fix-slugs.mjs               # dry run (default, safe) — prints the diff, writes nothing
node fix-slugs.mjs --dry-run     # same as above, explicit
node fix-slugs.mjs --fix         # write the resolved slugs back to portals.yml
node fix-slugs.mjs --apply       # alias for --fix
node fix-slugs.mjs --file <path> # use a specific portals file
```

Each fix appends an inline note to the entry, e.g.:
```
notes: "Old lever board. (slug migrated lever->ashby 2026-07-08, verify-portals)"
```

## Related issue

Closes #1702

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] This is a new feature — issue #1702 was opened first
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs --quick` and all tests pass (1542 passed, 0 failed)
- [x] My changes respect the Data Contract (`fix-slugs.mjs` is a system-layer script; registered in `update-system.mjs` SYSTEM_PATHS, `node validate-system-paths-coverage.mjs` passes)
- [x] My changes align with the project roadmap

## Test plan

- Added a new `test-all.mjs` section ("10c. Slug auto-fixer") covering:
  - `splitCompanyBlocks()` correctly splits a portals.yml fixture into per-company blocks, ignoring commented-out example entries.
  - `computeFixes()` resolves only entries with a `suggested` alternate (a lever→ashby migration and an ashby→greenhouse migration), leaving an unresolved entry (no suggestion) and a live entry untouched.
  - The rewritten text re-parses as valid YAML with the expected `careers_url`/`api`/`notes` values.
  - `computeFixes()` doesn't mutate its input text (dry-run safety at the function level).
  - End-to-end: `node fix-slugs.mjs --file <tmp> --dry-run` never writes to the file.
- `node test-all.mjs --quick`: 1542 passed, 0 failed.
- `node validate-system-paths-coverage.mjs`: OK, 665 tracked files covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `fix-slugs` CLI to review `portals.yml` tracked company entries, generate suggested ATS slug updates, and optionally apply them.
  * Supports `--file <path>`, and defaults to dry-run output; `--fix/--apply` writes changes.
  * Updates `careers_url` and manages `api` plus migration `notes` when a resolvable suggested ATS is missing.
* **Bug Fixes**
  * Ensures edits are applied in a way that preserves later company blocks correctly.
* **Tests**
  * Added unit and end-to-end tests covering block splitting, YAML-validated output, note formatting edge cases, non-mutation, and confirming dry-run doesn’t modify disk.
* **Chores**
  * Included `fix-slugs` in system-only update allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->