### PR TITLE
fix(tracker): detect and prevent duplicate tracker # numbers

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -477,6 +477,29 @@ for (const line of appLines) {
   }
 }
 
+// Full set of numbers already on the tracker (#1704). This is a separate,
+// deliberately narrower pass than the existingApps loop above: it reads only
+// the numeric # cell and skips a row via the same NaN check verify-pipeline.mjs
+// uses, instead of the `.includes('---') / .includes('Empresa')` heuristic —
+// so a company or role field that happens to CONTAIN "Empresa" or "---" (e.g.
+// a Spanish-market company name, or an em-dash-style separator in a title)
+// can't hide that row's number the way it can hide the row from existingApps
+// (which stays as-is; it drives duplicate detection, not numbering). Used
+// below so a new entry's number is checked against every number actually on
+// the tracker, not just the largest one the existingApps loop happened to see.
+const usedNumbers = new Set();
+const MAX_COL_IDX = Math.max(...Object.values(COLMAP));
+for (const line of appLines) {
+  if (!line.startsWith('|')) continue;
+  const parts = line.split('|').map(s => s.trim());
+  if (parts.length <= MAX_COL_IDX) continue;
+  const n = parseInt(parts[COLMAP.num]);
+  if (!isNaN(n) && n !== 0) {
+    usedNumbers.add(n);
+    if (n > maxNum) maxNum = n;
+  }
+}
+
 console.log(`📊 Existing: ${existingApps.length} entries, max #${maxNum}`);
 
 // Read tracker additions
@@ -610,9 +633,24 @@ for (const file of tsvFiles) {
       skipped++;
     }
   } else {
-    // New entry — use the number from the TSV
-    const entryNum = addition.num > maxNum ? addition.num : ++maxNum;
-    if (addition.num > maxNum) maxNum = addition.num;
+    // New entry — trust the TSV's own number only when it is BOTH ahead of
+    // this run's max AND not already claimed by any row on the tracker.
+    // `addition.num > maxNum` alone is not proof the number is free: a stale,
+    // precomputed number (e.g. carried by a batch worker's TSV that sat
+    // unmerged while other unrelated evaluations were merged in the
+    // meantime) can still collide with a row already on the tracker even
+    // though it's numerically ahead of a naive maxNum snapshot (#1704).
+    // usedNumbers already includes every number this run has assigned so
+    // far (added below), so same-run collisions are covered too.
+    let entryNum;
+    if (addition.num > maxNum && !usedNumbers.has(addition.num)) {
+      entryNum = addition.num;
+    } else {
+      entryNum = maxNum + 1;
+      while (usedNumbers.has(entryNum)) entryNum++;
+    }
+    usedNumbers.add(entryNum);
+    if (entryNum > maxNum) maxNum = entryNum;
 
     const newLine = buildRow({
       num: entryNum, date: addition.date, company: addition.company, role: addition.role,

--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -86,6 +86,18 @@ const TRACKER_10 = `# Applications Tracker
 | 1 | 2026-06-01 | Initech | AI Engineer | Remote | 4.5/5 | Evaluated | ✅ | [1](../reports/001-initech-2026-06-01.md) | — |
 `;
 
+// Two unrelated rows share tracker number 5 (the #1704 bug: merge-tracker.mjs
+// once trusted a stale TSV number as-is when it was numerically ahead of that
+// run's max, even though the number was already used by an unrelated row
+// merged in a separate, earlier invocation).
+const TRACKER_DUP_NUM = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 5 | 2026-05-29 | University of Alberta | Curriculum Coordinator | 3.8/5 | Evaluated | ❌ | — | — |
+| 5 | 2026-06-03 | Esri Canada | Manager Talent and Organizational Development | 4.1/5 | Evaluated | ❌ | — | — |
+`;
+
 // ── 1. Update by report number ──────────────────────────────────
 {
   const sb = makeSandbox(TRACKER_9);
@@ -173,6 +185,49 @@ const TRACKER_10 = `# Applications Tracker
     pass('ambiguous: --role disambiguates to the right row');
   } else {
     fail(`ambiguous --role: code=${r2.code}\n${r2.stdout}${r2.stderr}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 6b. Duplicate tracker #: bare number refuses to guess (#1704) ─
+{
+  const sb = makeSandbox(TRACKER_DUP_NUM);
+  const before = readTracker(sb);
+  const r = runSetStatus(['5', 'Rejected'], sb);
+  if (r.code === 3 && readTracker(sb) === before
+      && r.stderr.includes('University of Alberta') && r.stderr.includes('Esri Canada')) {
+    pass('dup-num: bare #5 matching 2 rows exits 3, tracker untouched, both companies listed');
+  } else {
+    fail(`dup-num: code=${r.code} (want 3)\n${r.stdout}${r.stderr}`);
+  }
+  // --role disambiguates exactly like the company-selector ambiguous path.
+  const r2 = runSetStatus(['5', 'Rejected', '--role', 'Manager Talent and Organizational Development'], sb);
+  if (r2.code === 0 && /\| 5 \| 2026-06-03 \| Esri Canada \|.*\| Rejected \|/.test(readTracker(sb))) {
+    pass('dup-num: --role disambiguates to the right row');
+  } else {
+    fail(`dup-num --role: code=${r2.code}\n${r2.stdout}${r2.stderr}`);
+  }
+  // The OTHER row (University of Alberta) must stay untouched by the --role
+  // disambiguated write above.
+  if (readTracker(sb).includes('| 5 | 2026-05-29 | University of Alberta | Curriculum Coordinator | 3.8/5 | Evaluated |')) {
+    pass('dup-num: unrelated row with the same # untouched after disambiguation');
+  } else {
+    fail(`dup-num: unrelated row was modified\n${readTracker(sb)}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 6c. Duplicate tracker # + --json: structured candidates ─────
+{
+  const sb = makeSandbox(TRACKER_DUP_NUM);
+  const r = runSetStatus(['5', 'Rejected', '--json'], sb);
+  let parsed = null;
+  try { parsed = JSON.parse(r.stdout || r.stderr); } catch {}
+  if (r.code === 3 && parsed && parsed.code === 'ambiguous' && Array.isArray(parsed.candidates)
+      && parsed.candidates.length === 2) {
+    pass('dup-num json: structured ambiguous error with 2 candidates');
+  } else {
+    fail(`dup-num json: code=${r.code}\n${r.stdout}${r.stderr}`);
   }
   rmSync(sb.dir, { recursive: true, force: true });
 }

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -11,7 +11,11 @@
  *   node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--dry-run] [--json]
  *
  * Row resolution:
- *   - numeric argument → exact match on the # column
+ *   - numeric argument → exact match on the # column; if the tracker has a
+ *     duplicate # (see #1704 — merge-tracker.mjs bug, now fixed, that could
+ *     assign the same # to two rows), --role narrows it, otherwise it fails
+ *     ambiguous with a candidate list instead of silently editing whichever
+ *     row was found first
  *   - otherwise → company match (normalized, same key as merge-tracker dedup);
  *     multiple hits are narrowed with --role (fuzzy, role-matcher.mjs), and
  *     anything still ambiguous fails with a numbered candidate list.
@@ -167,11 +171,28 @@ if (!existsSync(APPS_FILE)) {
 function resolveRow(rows) {
   if (/^\d+$/.test(selector)) {
     const num = parseInt(selector, 10);
-    const row = rows.find(r => r.num === num);
-    if (!row) {
+    let matches = rows.filter(r => r.num === num);
+    if (matches.length === 0) {
       failWith(EXIT_NOT_FOUND, 'not-found', `No tracker row with #${num}`);
     }
-    return row;
+    if (matches.length > 1 && flags.role) {
+      const narrowed = matches.filter(r => roleFuzzyMatch(r.role, flags.role));
+      if (narrowed.length === 1) return narrowed[0];
+      // Fall through with the original list so the candidates stay visible.
+    }
+    if (matches.length > 1) {
+      // A bare report number should never match more than one row — this is
+      // exactly the failure mode from #1704: a stale tracker # reused across
+      // 2+ rows means "the first match" is a silent coin flip on which
+      // company gets edited. Refuse to guess; require --role or the company
+      // selector instead.
+      const candidates = matches.map(r => ({ num: r.num, company: r.company, role: r.role }));
+      const listing = candidates.map(c => `#${c.num}\t${c.company}\t${c.role}`).join('\n');
+      failWith(EXIT_AMBIGUOUS, 'ambiguous',
+        `#${num} is a duplicate tracker number shared by ${matches.length} rows (see #1704) — pass --role to disambiguate, or use the company name instead:\n${listing}`,
+        { candidates });
+    }
+    return matches[0];
   }
 
   const key = normalizeCompany(selector);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3706,6 +3706,75 @@ try {
   fail(`verify-pipeline report checks crashed: ${e.message}`);
 }
 
+// ── VERIFY-PIPELINE DUPLICATE TRACKER NUMBER (#1704) ────────────
+// A tracker # must be a unique row id. Two rows sharing a # is never
+// legitimate (unlike Check 2's company+role dedup, which can false-positive
+// on a genuine re-application) — verify-pipeline must flag it as an error.
+console.log('\n🧪 Testing verify-pipeline duplicate tracker # check (#1704)...');
+try {
+  const dupNumTmp = mkdtempSync(join(tmpdir(), 'career-ops-verify-dupnum-'));
+  try {
+    const dupNumTracker = join(dupNumTmp, 'applications.md');
+    const dupNumEnv = { ...process.env, CAREER_OPS_TRACKER: dupNumTracker };
+
+    writeFileSync(dupNumTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 698 | 2026-05-29 | University of Alberta | Curriculum Coordinator | 3.8/5 | Evaluated | ❌ | — | — |\n' +
+      '| 698 | 2026-06-03 | Esri Canada | Manager Talent and Organizational Development | 4.1/5 | Evaluated | ❌ | — | — |\n' +
+      '| 700 | 2026-06-10 | Shopify | Staff Engineer | 4.5/5 | Evaluated | ❌ | — | — |\n');
+
+    let dupNumOut;
+    try {
+      dupNumOut = execFileSync(NODE, ['verify-pipeline.mjs'], { cwd: ROOT, env: dupNumEnv, encoding: 'utf-8', timeout: 30000, stdio: ['pipe', 'pipe', 'pipe'] });
+      fail('verify-pipeline should exit non-zero on a duplicate tracker number');
+    } catch (e) {
+      dupNumOut = (e.stdout || '').toString();
+      if (e.status === 1) {
+        pass('verify-pipeline exits 1 on a duplicate tracker number');
+      } else {
+        fail(`verify-pipeline: expected exit 1, got ${e.status}`);
+      }
+    }
+    if (dupNumOut.includes('Duplicate tracker number #698')
+        && dupNumOut.includes('University of Alberta') && dupNumOut.includes('Esri Canada')) {
+      pass('duplicate tracker number #698 flagged with both colliding rows named');
+    } else {
+      fail(`duplicate tracker number not flagged with both rows\n${dupNumOut}`);
+    }
+    if (/Duplicate tracker number #700/.test(dupNumOut)) {
+      fail('unique #700 row falsely flagged as a duplicate tracker number');
+    } else {
+      pass('unique tracker number not falsely flagged');
+    }
+  } finally {
+    rmSync(dupNumTmp, { recursive: true, force: true });
+  }
+
+  // Clean fixture: no duplicate numbers — must pass green.
+  const cleanTmp = mkdtempSync(join(tmpdir(), 'career-ops-verify-dupnum-clean-'));
+  try {
+    const cleanTracker = join(cleanTmp, 'applications.md');
+    writeFileSync(cleanTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 1 | 2026-01-01 | Acme | Engineer | 4.0/5 | Evaluated | ❌ | — | — |\n' +
+      '| 2 | 2026-01-02 | Globex | Analyst | 3.9/5 | Evaluated | ❌ | — | — |\n');
+    const cleanOut = run(NODE, ['verify-pipeline.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: cleanTracker }, stdio: ['pipe', 'pipe', 'pipe'] });
+    if (cleanOut !== null && cleanOut.includes('No duplicate tracker numbers')) {
+      pass('clean tracker with unique numbers passes the duplicate-number check');
+    } else {
+      fail('clean fixture did not pass the duplicate tracker number check');
+    }
+  } finally {
+    rmSync(cleanTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`verify-pipeline duplicate tracker number test crashed: ${e.message}`);
+}
+
 // ── SHARED ROLE MATCHER + DEDUP-TRACKER SAFETY (#947) ───────────
 // dedup-tracker.mjs used to ship an older fuzzy role matcher than
 // merge-tracker.mjs. That weaker matcher collapsed sibling roles at the same
@@ -4329,6 +4398,83 @@ try {
   }
 } catch (e) {
   fail(`merge-tracker report-number collision test crashed: ${e.message}`);
+}
+
+// ── MERGE-TRACKER STALE-NUMBER COLLISION WITH AN EXISTING ROW (#1704) ────
+// Different from the #912 test above: that one is a same-run collision where
+// the incoming TSV's num equals an EXISTING row's num (addition.num <= maxNum,
+// already handled by the old ++maxNum fallback). This one exercises the actual
+// #1704 gap: an existing row's number is invisible to the plain maxNum scan
+// (merge-tracker's own header/separator-skip heuristic excludes any row whose
+// company/role text happens to contain "Empresa" or "---" — a real Spanish-
+// market company name is a realistic trigger), so the naive
+// `addition.num > maxNum` check trusted a colliding number as free. The fix
+// builds a Set of every number actually on the tracker (independent of that
+// heuristic) and refuses to trust a number already in it.
+console.log('\n🧪 Testing merge-tracker stale-number collision with a hidden existing row (#1704)...');
+try {
+  const staleNumTmp = mkdtempSync(join(tmpdir(), 'career-ops-merge-1704-'));
+  try {
+    mkdirSync(join(staleNumTmp, 'data'));
+    const staleNumAdditions = join(staleNumTmp, 'additions');
+    mkdirSync(staleNumAdditions);
+
+    const staleNumTracker = join(staleNumTmp, 'data', 'applications.md');
+    // Row #9's company text contains "Empresa" — merge-tracker's existingApps
+    // loop skips this line entirely (the same heuristic it uses to skip the
+    // Spanish-locale header row), so its number is NOT counted toward the old
+    // plain maxNum scan.
+    writeFileSync(staleNumTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 9 | 2026-01-02 | Empresa Digital SA | Analyst | 3.5/5 | Evaluated | ❌ | — | original |\n');
+
+    // Stale TSV for an unrelated company also embeds num=9 — numerically
+    // "ahead" of the naive maxNum(0) computed from the hidden row, but already
+    // used.
+    writeFileSync(join(staleNumAdditions, '001-newco.tsv'),
+      '9\t2026-01-10\tNewCo\tFresh Role\tEvaluated\t2.9/5\t❌\t—\tstale number\n');
+
+    const staleNumResult = run(NODE, ['merge-tracker.mjs'], {
+      env: { ...process.env, CAREER_OPS_TRACKER: staleNumTracker, CAREER_OPS_ADDITIONS: staleNumAdditions },
+    });
+    if (staleNumResult === null) {
+      fail('merge-tracker crashed during stale-number collision test (#1704)');
+    } else {
+      const staleNumMerged = readFileSync(staleNumTracker, 'utf-8');
+      const staleNumRows = staleNumMerged.split('\n').filter(l => l.startsWith('| ') && !l.startsWith('| #') && !l.startsWith('|---'));
+
+      if (staleNumRows.length === 2) {
+        pass('stale-number collision (#1704): merged tracker has exactly 2 rows');
+      } else {
+        fail(`stale-number collision (#1704): expected 2 rows, got ${staleNumRows.length}`);
+      }
+
+      const numsUsed = staleNumRows.map(r => parseInt(r.split('|')[1].trim(), 10));
+      if (new Set(numsUsed).size === numsUsed.length) {
+        pass('stale-number collision (#1704): no two rows share a tracker number');
+      } else {
+        fail(`stale-number collision (#1704): duplicate tracker number produced — ${numsUsed.join(', ')}`);
+      }
+
+      if (staleNumRows.some(r => r.includes('Empresa Digital SA') && /^\| 9 \|/.test(r))) {
+        pass('stale-number collision (#1704): hidden existing row #9 (Empresa Digital SA) untouched');
+      } else {
+        fail(`stale-number collision (#1704): existing #9 row was overwritten\n${staleNumMerged}`);
+      }
+
+      if (staleNumRows.some(r => r.includes('NewCo') && !/^\| 9 \|/.test(r))) {
+        pass('stale-number collision (#1704): NewCo bumped to a truly free number instead of reusing #9');
+      } else {
+        fail(`stale-number collision (#1704): NewCo was not bumped off the colliding number\n${staleNumMerged}`);
+      }
+    }
+  } finally {
+    rmSync(staleNumTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`merge-tracker stale-number collision test crashed: ${e.message}`);
 }
 
 // ── MERGE-TRACKER REQ/JOB-NUMBER DEDUP GUARD (#1524) ─────────────────────

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -13,6 +13,8 @@
  * 8. Stale report-number reservation sentinels are garbage-collected
  * 9. No two report files cover the same company+role (warning — see #1425)
  * 10. Every report file has a tracker row referencing it (warning — see #1425)
+ * 11. Via channel consistency (see #1596)
+ * 12. No # value reused across 2+ tracker rows (error — see #1704)
  *
  * Run: node career-ops/verify-pipeline.mjs
  */
@@ -382,6 +384,30 @@ for (const [key, vias] of channelsByRole) {
   }
 }
 if (viaIssues === 0) ok('Via channels consistent');
+
+// --- Check 12: Duplicate tracker numbers (#1704) ---
+// The # column is a row id and must be unique. Unlike Check 2 (company+role
+// dedup, which can false-positive on a legitimate re-application), the SAME
+// number appearing on 2+ rows is never legitimate: it means set-status.mjs
+// can't tell the rows apart, and any external reference to "application #N"
+// (interview-prep notes, memory, cross-links) becomes ambiguous. Pure
+// addition, no existing check covers this — see #1704 for the 124-row sweep
+// that found this in the wild (merge-tracker.mjs trusted a stale TSV number
+// as-is whenever it exceeded that run's max, without checking it wasn't
+// already used by an unrelated row merged in a separate, earlier invocation).
+const numGroups = new Map();
+for (const e of entries) {
+  if (!numGroups.has(e.num)) numGroups.set(e.num, []);
+  numGroups.get(e.num).push(e);
+}
+let dupeNums = 0;
+for (const [num, group] of numGroups) {
+  if (group.length > 1) {
+    error(`Duplicate tracker number #${num} used by ${group.length} rows: ${group.map(e => `${e.company} — ${e.role}`).join(' | ')}`);
+    dupeNums++;
+  }
+}
+if (dupeNums === 0) ok('No duplicate tracker numbers');
 
 // --- Summary ---
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## Summary

A full sweep of `data/applications.md` found 124 report numbers reused across 2+ distinct rows (see #1704 for the details, including the two rows that surfaced this: `#698` used by both Company A and B, and `#1167` used by both Company C and D). Root cause: `merge-tracker.mjs`'s new-entry number assignment trusted an incoming TSV's embedded row number as-is whenever it was numerically ahead of that run's `maxNum` snapshot, with no check that the number wasn't already used by some other row.

This PR implements pieces 1-3 from #1704's proposed fix:

1. **Detection (`verify-pipeline.mjs`)** — new check flags any `#` value shared by 2+ rows as an error, naming every colliding company/role so a human can immediately see what collided. Pure addition, no existing check touched.
2. **Prevention (`merge-tracker.mjs`)** — new-entry numbering now builds a full `Set` of every number already on the tracker (via a scan independent of the existing header/separator-skip heuristic, which can otherwise hide a row's number if its company/role text happens to contain `"Empresa"` or `"---"` — realistic for a Spanish-market company name) and only trusts an incoming TSV number when it's both ahead of the run's max **and** not already in that set. Otherwise it bumps to the next truly free number. The existing #912 regression (same-run collision when `addition.num <= maxNum`) is unaffected — verified by its existing test, which still passes unmodified.
3. **Guardrail (`set-status.mjs`)** — a bare `<report#>` selector that matches 2+ rows no longer silently edits whichever row is found first. It now exits ambiguous (exit 3) with the full candidate list, mirroring the existing company-name ambiguity path, and `--role` disambiguates it the same way.

**Out of scope:** piece 4 (renumbering the 124 rows already duplicated in the tracker) is a separate migration touching report links, cross-references in `reports/*.md`, and merged TSV history — deliberately left for a follow-up PR. This PR only detects and prevents future occurrences; it does not fix the existing duplicates.

Closes #1704 (pieces 1-3 only — see note above on piece 4).

## Test plan

- [x] `node test-all.mjs --quick` — 1560 passed, 0 failed
- [x] New `verify-pipeline.mjs` test: fixture tracker with two rows sharing `#698` triggers the new duplicate-number error; a clean fixture with unique numbers passes
- [x] New `merge-tracker.mjs` test: a fixture where an existing row's number is hidden from the naive `maxNum` scan (company text containing "Empresa") and a stale TSV embeds the same number for an unrelated company — the fix bumps the new entry to a free number instead of colliding; distinct from the existing #912 same-run collision test, which still passes unmodified
- [x] New `set-status-tests.mjs` tests: a fixture tracker with a duplicate `#5` shared by two unrelated companies — calling `set-status.mjs 5 Rejected` without `--role` exits 3 (ambiguous) with both companies listed and the tracker untouched; `--role` disambiguates to the correct row; `--json` returns a structured `candidates` array
- [x] `node validate-system-paths-coverage.mjs` — OK (no new files added, existing paths still covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate tracker numbers from being assigned or reused.
  * Improved handling when a tracker number matches multiple entries, including clearer failure messages and better disambiguation when role information is provided.
  * Added validation to catch duplicate tracker numbers during pipeline checks, helping avoid inconsistent tracker data.

* **Tests**
  * Expanded automated coverage for duplicate-number scenarios and collision handling to guard against regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->