### PR TITLE
feat(scan): add exclude_companies filter to block re-listed employers

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -156,6 +156,23 @@ export function buildTitleFilter(titleFilter) {
   };
 }
 
+// ── Company exclusion filter ────────────────────────────────────────
+// Blocks specific employers the user has evaluated and decided against, so
+// re-listings (even under a fresh URL that bypasses URL/company::role dedup)
+// never re-enter the pipeline. Case-insensitive substring match on company name.
+// Configured via `exclude_companies:` (list of strings) in portals.yml.
+export function buildCompanyExcludeFilter(excludeCompanies) {
+  const blocked = (Array.isArray(excludeCompanies) ? excludeCompanies : [])
+    .filter(c => typeof c === 'string')
+    .map(c => c.trim().toLowerCase())
+    .filter(c => c.length > 0);
+  return (company) => {
+    const lower = (company || '').toLowerCase();
+    // returns true if the company should be KEPT (not excluded)
+    return !blocked.some(b => lower.includes(b));
+  };
+}
+
 // ── Location filter ─────────────────────────────────────────────────
 // Optional. If `location_filter` is absent from portals.yml, all locations pass.
 // Semantics (case-insensitive substring, in this order):
@@ -907,6 +924,7 @@ async function main() {
   const companies = Array.isArray(config.tracked_companies) ? config.tracked_companies : [];
   const boards = Array.isArray(config.job_boards) ? config.job_boards : [];
   const titleFilter = buildTitleFilter(config.title_filter);
+  const companyExcludeFilter = buildCompanyExcludeFilter(config.exclude_companies);
 
   // Seniority tier classifier integration
   let classifyTier = null;
@@ -1036,6 +1054,10 @@ async function main() {
         job.trustLevel = trustResult.level;
 
         if (!titleFilter(job.title)) {
+          totalFilteredTitle++;
+          continue;
+        }
+        if (!companyExcludeFilter(job.company)) {
           totalFilteredTitle++;
           continue;
         }


### PR DESCRIPTION
## What

Adds `buildCompanyExcludeFilter()` to `scan.mjs` and wires it into the scan pipeline. Blocks specific employers — configured via a new `exclude_companies:` list in `portals.yml` — so a role re-listed under a fresh URL (which bypasses the URL and `company::role` dedup) never re-enters the pipeline.

## How

- New exported `buildCompanyExcludeFilter(excludeCompanies)` — case-insensitive substring match on company name; returns a keep-predicate, following the same shape as the existing `buildTitleFilter`.
- Applied in `main()` right after the title filter, incrementing the existing `totalFilteredTitle` counter when a company is excluded.
- No config = no-op (empty/absent `exclude_companies` keeps all companies).

## Test plan

- [ ] `node test-all.mjs` passes
- [ ] Add a company to `exclude_companies:` in `portals.yml` and confirm its roles are dropped from a scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional company exclusion filter for job scanning, allowing specific employers to be skipped based on your configuration.
  * Jobs from excluded companies are now filtered out earlier in the scan process, helping reduce unwanted results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->