### PR TITLE
fix(update-system): keep the updater self-loading to survive old→new re-exec (#1706)

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2347,8 +2347,8 @@ console.log('\n12a. Skill entrypoint materialization');
     writeFileSync(join(claudeDir, 'SKILL.md'), pointer);
     writeFileSync(join(opencodeDir, 'SKILL.md'), pointer);
 
-    const updater = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
-    const materialized = updater.materializeSkillEntrypoints(fixtureRoot).sort();
+    const skills = await import(pathToFileURL(join(ROOT, 'scaffolder/bin/skill-entrypoints.mjs')).href);
+    const materialized = skills.materializeSkillEntrypoints(fixtureRoot).sort();
     const expected = [
       '.claude/skills/career-ops/SKILL.md',
       '.opencode/skills/career-ops/SKILL.md',
@@ -2446,14 +2446,44 @@ console.log('\n12b. Skill entrypoint bootstrap (npx / old releases)');
       fail(`relativeImportSpecifiers mismatch: got ${JSON.stringify(specs)}`);
     }
 
+    // #1706: update-system.mjs must be SELF-LOADING — no static (top-level)
+    // relative imports. A pre-#1245 client's apply() self-reexec checks out
+    // ONLY update-system.mjs before re-execing it, so a static top-level
+    // relative import crashes that re-exec with ERR_MODULE_NOT_FOUND on the
+    // old→new jump. Relative modules must be pulled in lazily instead. Matched
+    // line-anchored (not via relativeImportSpecifiers, whose loose regex also
+    // matches such specifiers inside prose/comments) so only real top-level
+    // import/export statements count.
     const liveSource = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
-    if (updater.relativeImportSpecifiers(liveSource).includes('./scaffolder/bin/skill-entrypoints.mjs')) {
-      pass('relativeImportSpecifiers picks up the live skill-entrypoints import (#1245)');
+    const staticRelativeImport = /^\s*(?:import|export)\b[^\n]*?\bfrom\s*['"]\.[^'"]*['"]|^\s*import\s*['"]\.[^'"]*['"]/m;
+    if (!staticRelativeImport.test(liveSource)) {
+      pass('update-system.mjs has no static relative imports — self-loading (#1706)');
     } else {
-      fail('relativeImportSpecifiers missed the live skill-entrypoints import');
+      fail('update-system.mjs has a static relative import that breaks old→new re-exec (#1706)');
     }
   } catch (e) {
     fail(`relativeImportSpecifiers test crashed: ${e.message}`);
+  }
+}
+
+{
+  // #1706 end-to-end regression: reproduce the old→new re-exec by checking out
+  // ONLY update-system.mjs into an otherwise-empty dir (no scaffolder/) and
+  // importing it. Before the lazy-import fix this threw ERR_MODULE_NOT_FOUND at
+  // module load; it must now load standalone.
+  const isolatedRoot = mkdtempSync(join(tmpdir(), 'career-ops-updater-standalone-'));
+  try {
+    const updaterSource = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
+    const isolatedUpdater = join(isolatedRoot, 'update-system.mjs');
+    writeFileSync(isolatedUpdater, updaterSource);
+    try {
+      await import(pathToFileURL(isolatedUpdater).href);
+      pass('update-system.mjs imports standalone without scaffolder/ present (#1706)');
+    } catch (err) {
+      fail(`update-system.mjs failed to import standalone (old→new re-exec crash, #1706): ${err.code || err.message}`);
+    }
+  } finally {
+    rmSync(isolatedRoot, { recursive: true, force: true });
   }
 }
 
@@ -2469,8 +2499,8 @@ console.log('\n12b. Skill entrypoint bootstrap (npx / old releases)');
     mkdirSync(join(canonicalDir, 'SKILL.md'));
     writeFileSync(join(claudeDir, 'SKILL.md'), pointer);
 
-    const updater = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
-    const materialized = updater.materializeSkillEntrypoints(fixtureRoot);
+    const skills = await import(pathToFileURL(join(ROOT, 'scaffolder/bin/skill-entrypoints.mjs')).href);
+    const materialized = skills.materializeSkillEntrypoints(fixtureRoot);
     const claudeSkill = readFileSync(join(claudeDir, 'SKILL.md'), 'utf-8');
     if (materialized.length === 0 && claudeSkill === pointer) {
       pass('update-system skips skill materialization when canonical entrypoint is unreadable');
@@ -2500,8 +2530,8 @@ console.log('\n12b. Skill entrypoint bootstrap (npx / old releases)');
     mkdirSync(join(claudeDir, 'SKILL.md'));
     writeFileSync(join(opencodeDir, 'SKILL.md'), pointer);
 
-    const updater = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
-    const materialized = updater.materializeSkillEntrypoints(fixtureRoot);
+    const skills = await import(pathToFileURL(join(ROOT, 'scaffolder/bin/skill-entrypoints.mjs')).href);
+    const materialized = skills.materializeSkillEntrypoints(fixtureRoot);
     const opencodeSkill = readFileSync(join(opencodeDir, 'SKILL.md'), 'utf-8');
     if (JSON.stringify(materialized) === JSON.stringify(['.opencode/skills/career-ops/SKILL.md']) && opencodeSkill === fixtureSkill) {
       pass('update-system skips non-file skill entrypoints while materializing valid pointers');
@@ -2557,7 +2587,8 @@ console.log('\n12c. Materialized skill index mode');
     gitRun(['update-index', '--add', '--cacheinfo', `120000,${pointerBlob},.opencode/skills/career-ops/SKILL.md`]);
 
     const updater = await import(pathToFileURL(join(ROOT, 'update-system.mjs')).href);
-    const materialized = updater.materializeSkillEntrypoints(fixtureRoot);
+    const skills = await import(pathToFileURL(join(ROOT, 'scaffolder/bin/skill-entrypoints.mjs')).href);
+    const materialized = skills.materializeSkillEntrypoints(fixtureRoot);
     updater.prepareMaterializedSkillEntrypointsForStage(materialized, fixtureRoot);
     gitRun(['add', '--', '.claude/skills/', '.opencode/skills/']);
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -19,12 +19,16 @@ import { execFile, execFileSync, execSync } from 'child_process';
 import { readFileSync, writeFileSync, existsSync, unlinkSync, rmSync } from 'fs';
 import { join, dirname, posix as pathPosix } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import {
-  ensureSkillEntrypoints,
-  materializeSkillEntrypoints,
-} from './scaffolder/bin/skill-entrypoints.mjs';
 
-export { materializeSkillEntrypoints, ensureSkillEntrypoints };
+// NOTE: this file must stay *self-loading* — no static (top-level) relative
+// imports. A pre-#1245 client's apply() self-reexec checks out ONLY
+// update-system.mjs before re-execing the target updater, so a static top-level
+// relative import here crashes that re-exec with ERR_MODULE_NOT_FOUND on the
+// old→new jump, before the fuller checkout that would materialize the imported
+// module ever runs (#1706). Local modules (e.g. the skill-entrypoints helper
+// under scaffolder/) are instead pulled in lazily at their point of use, by
+// which time the full update stage has already checked them out. The
+// updater-migration and test-all suites enforce this invariant.
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = __dirname;
@@ -823,6 +827,10 @@ async function apply() {
       console.error(`Stale-test prune step failed: ${err.message}`);
     }
 
+    // Lazy import: keep update-system.mjs self-loading (see the top-of-file
+    // note). scaffolder/ was just checked out by the update stage above, so the
+    // module resolves here even on a pre-#1245 old→new re-exec.
+    const { ensureSkillEntrypoints } = await import('./scaffolder/bin/skill-entrypoints.mjs');
     const materializedSkillEntrypoints = ensureSkillEntrypoints(ROOT);
     if (materializedSkillEntrypoints.length > 0) {
       for (const path of materializedSkillEntrypoints) {

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -167,6 +167,19 @@ for (const check of twoPassManifestChecks) {
   else fail(check.name);
 }
 
+// #1706: update-system.mjs must be self-loading — no static (top-level) relative
+// imports. A pre-#1245 client's apply() self-reexec checks out ONLY
+// update-system.mjs before re-execing it, so any top-level `import ... from
+// './...'` (or bare `import './...'`) crashes that re-exec with
+// ERR_MODULE_NOT_FOUND on the old→new jump. Relative modules must be lazily
+// `await import()`ed at their point of use instead.
+const staticRelativeImport = /^\s*(?:import|export)\b[^\n]*?\bfrom\s*['"]\.[^'"]*['"]|^\s*import\s*['"]\.[^'"]*['"]/m;
+if (staticRelativeImport.test(source)) {
+  fail('update-system.mjs is self-loading — no static relative imports (#1706)');
+} else {
+  pass('update-system.mjs is self-loading — no static relative imports (#1706)');
+}
+
 for (const userPath of ['cv.md', 'config/profile.yml', 'modes/_profile.md', 'portals.yml', 'data/', 'reports/']) {
   if (userPaths.includes(userPath)) pass(`USER_PATHS protects ${userPath}`);
   else fail(`USER_PATHS missing ${userPath}`);


### PR DESCRIPTION
Fixes #1706.

## The bug
Running `node update-system.mjs apply` on an old client (repro: 1.11.0 → 1.18.0) crashes every time with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../scaffolder/bin/skill-entrypoints.mjs'
  imported from .../update-system.mjs
Updater self-reexec failed
```

## Root cause
A pre-#1245 client's `apply()` self-reexec checks out **only** `update-system.mjs` from `FETCH_HEAD`, then re-execs it. The current `update-system.mjs` has a **static top-level import** of `./scaffolder/bin/skill-entrypoints.mjs`, so the re-exec'd target can't even *load* — it crashes at module resolution, before the fuller checkout stage that would materialize `scaffolder/` ever runs. Everyone below the #1245 boundary is stranded on that one jump.

The #1245 machinery (`resolveReexecCheckout` + `REEXEC_FALLBACK_FILES`) hardened *new* clients, but that logic lives in code old clients never reach.

## Fix
Make `update-system.mjs` **self-loading** — no static top-level relative imports:

- Drop the top-level `import { ensureSkillEntrypoints, materializeSkillEntrypoints } from './scaffolder/bin/skill-entrypoints.mjs'` and its unused re-export.
- Pull the helper in with a lazy `await import()` at its single use site inside `apply()`, by which point the update stage has already checked out `scaffolder/`.

The module now imports standalone even when checked out alone, so an old client's re-exec no longer crashes at load time. The #1245 belt-and-suspenders stays intact for new clients.

## Tests
- **Standalone-load regression** (`test-all.mjs`): copies *only* `update-system.mjs` into an empty dir (no `scaffolder/`) and imports it — reproducing exactly what the old self-reexec does. Fails on `main` with `ERR_MODULE_NOT_FOUND`; passes here.
- **Self-loading source invariant** (`test-all.mjs` + `updater-migration-tests.mjs`): line-anchored assertion that `update-system.mjs` has no static top-level relative import, so this can't silently regress. (Line-anchored rather than via `relativeImportSpecifiers`, whose loose regex also matches such specifiers in prose/comments.)
- The stale #1245 assertion requiring the *static* skill-entrypoints import is inverted accordingly; four skill-materialization tests that reached `materializeSkillEntrypoints` via the dropped re-export now import it from its canonical home.

`node test-all.mjs --quick` → **1553 passed, 0 failed** (1 pre-existing `cv-sync-check` warning, unrelated).

## Notes
- Behaviour-preserving for current installs; the only surface change is that `update-system.mjs` no longer re-exports the two skill-entrypoint helpers (nothing in-repo imported them from there — the canonical source is `scaffolder/bin/skill-entrypoints.mjs`).
- Splitting into two commits: the fix, then the regression guards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by making system updates load more safely in environments where related files are unavailable.
  * Added stronger checks to prevent regressions around self-loading behavior during updates.

* **Tests**
  * Expanded automated coverage for update flow stability and standalone loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->