### PR TITLE
feat(scan): dedup company reposts via aliases

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -565,7 +565,68 @@ export function loadSeenUrls(policy = {}) {
   return { seen, recheckEligible };
 }
 
-export function loadSeenCompanyRoles(appsPath = APPLICATIONS_PATH) {
+// The default company normalizer, used when no alias map is configured: just
+// lowercase and trim. buildCompanyCanonicalizer wraps this with the alias map.
+function defaultCompanyNormalizer(name) {
+  return String(name ?? '').trim().toLowerCase();
+}
+
+// Build a company-name canonicalizer from an alias map (config.company_aliases).
+// The map is `{ CanonicalName: [alias, ...] }`; every alias AND the canonical
+// name itself resolve to the lowercased canonical name. This closes the gap
+// where an ATS org name (e.g. "Intercom") differs from the tracker/brand label
+// (e.g. "Fin"): without it, the company::role dedup key never matches the
+// tracker and the same role is re-scanned and re-evaluated on every run.
+// Unknown names pass through as plain lowercased text, so behavior is unchanged
+// for companies with no alias entry.
+export function buildCompanyCanonicalizer(aliases) {
+  const map = new Map();
+  if (aliases && typeof aliases === 'object' && !Array.isArray(aliases)) {
+    for (const [canonical, list] of Object.entries(aliases)) {
+      const canon = defaultCompanyNormalizer(canonical);
+      if (!canon) continue;
+      map.set(canon, canon);
+      const arr = Array.isArray(list) ? list : [list];
+      for (const a of arr) {
+        const alias = defaultCompanyNormalizer(a);
+        if (alias) map.set(alias, canon);
+      }
+    }
+  }
+  return name => {
+    const key = defaultCompanyNormalizer(name);
+    return map.get(key) ?? key;
+  };
+}
+
+// Normalize a role/title for repost-tolerant dedup. Two postings of the same
+// role should collapse to one key even when the company re-lists it under a new
+// requisition ID (a new URL, so URL dedup misses it) or splits it per location
+// with a trailing tag like "(Berlin)". We therefore:
+//   1. lowercase
+//   2. strip trailing parenthetical/bracketed tags — "(Berlin)", "[Remote]",
+//      "(Berlin, Germany)", and stacked "(Senior) (Berlin)" — since these are
+//      the location/qualifier suffixes that create false distinct roles
+//   3. collapse all remaining punctuation/whitespace to single spaces so
+//      em-dash vs hyphen and double spaces don't split a key
+// The requisition ID lives in the URL, never the title, so keying on the
+// normalized title is inherently requisition-ID-agnostic.
+export function normalizeRoleForDedup(role) {
+  return String(role ?? '')
+    .toLowerCase()
+    .replace(/(?:\s*[([][^)\]]*[)\]])+\s*$/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+// The canonical company::role dedup key shared by both the tracker-side load and
+// the scan-side check, so the two can never drift. `canonicalize` defaults to
+// plain lowercase/trim (no alias map).
+export function companyRoleDedupKey(company, role, canonicalize = defaultCompanyNormalizer) {
+  return `${canonicalize(company)}::${normalizeRoleForDedup(role)}`;
+}
+
+export function loadSeenCompanyRoles(appsPath = APPLICATIONS_PATH, canonicalize = defaultCompanyNormalizer) {
   const seen = new Set();
   if (existsSync(appsPath)) {
     // Header-aware parse (tracker-parse.mjs, #954) — the old positional regex
@@ -576,9 +637,9 @@ export function loadSeenCompanyRoles(appsPath = APPLICATIONS_PATH) {
     for (const line of lines) {
       const row = parseTrackerRow(line, colmap);
       if (!row) continue;
-      const company = row.company.trim().toLowerCase();
-      const role = row.role.trim().toLowerCase();
-      if (company && role) seen.add(`${company}::${role}`);
+      const company = row.company.trim();
+      const role = row.role.trim();
+      if (company && role) seen.add(companyRoleDedupKey(company, role, canonicalize));
     }
   }
   return seen;
@@ -1056,7 +1117,8 @@ async function main() {
   const historyPolicy = scanHistoryPolicy(config);
   const seenUrlState = loadSeenUrls(historyPolicy);
   const seenUrls = seenUrlState.seen;
-  const seenCompanyRoles = loadSeenCompanyRoles();
+  const canonicalizeCompany = buildCompanyCanonicalizer(config.company_aliases);
+  const seenCompanyRoles = loadSeenCompanyRoles(APPLICATIONS_PATH, canonicalizeCompany);
 
   // 5. Fetch from each target
   const date = new Date().toISOString().slice(0, 10);
@@ -1134,7 +1196,7 @@ async function main() {
           totalDupes++;
           continue;
         }
-        const key = `${job.company.toLowerCase()}::${job.title.toLowerCase()}`;
+        const key = companyRoleDedupKey(job.company, job.title, canonicalizeCompany);
         if (seenCompanyRoles.has(key)) {
           totalDupes++;
           continue;

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -780,6 +780,23 @@ search_queries:
 #     provider: jibeapply
 #     enabled: true
 
+# -- Company aliases (optional) --
+# Map alternate company names to a single canonical label so the scanner's
+# company+role dedup matches your tracker. The scanner keys dedup on the name a
+# provider returns — usually the ATS org (e.g. Greenhouse "Intercom") — which
+# may differ from the brand you track (e.g. "Fin"). Without an alias, the same
+# role is re-scanned and re-evaluated every run because "intercom::role" never
+# matches "fin::role" in data/applications.md.
+#
+# Format: `CanonicalName: [alias, ...]`. Every alias AND the canonical name
+# resolve to the canonical label (case-insensitive). Companies with no entry are
+# unaffected. Combined with title normalization, this also collapses reposts
+# (same role re-listed under a new requisition ID / URL) and per-location splits
+# ("Engineer (Berlin)" vs "Engineer") onto one dedup key.
+#
+# company_aliases:
+#   Fin: [Intercom]
+
 tracked_companies:
 
   # -- AI Labs & LLM providers --

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5574,6 +5574,90 @@ try {
 }
 
 
+// ── 45b. SCAN COMPANY+ROLE DEDUP (alias + repost normalization) ──────
+// Guards the fix for ATS repost churn: the scanner keys company+role dedup on
+// the provider's company name (often the ATS org, e.g. "Intercom") which may
+// differ from the tracker brand ("Fin"), and on a title that a company mutates
+// per requisition/location ("Engineer (Berlin)"). buildCompanyCanonicalizer +
+// normalizeRoleForDedup collapse both so the same role is not re-evaluated.
+
+console.log('\n45b. Scan company+role dedup (alias + repost)');
+try {
+  const {
+    buildCompanyCanonicalizer,
+    normalizeRoleForDedup,
+    companyRoleDedupKey,
+  } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+
+  // -- Company alias canonicalization --
+  const canon = buildCompanyCanonicalizer({ Fin: ['Intercom', 'Intercom Inc'] });
+  if (canon('Intercom') === 'fin' && canon('intercom inc') === 'fin' && canon('Fin') === 'fin') {
+    pass('buildCompanyCanonicalizer maps every alias and the canonical name to the canonical label');
+  } else {
+    fail(`alias canonicalization wrong: Intercom=${canon('Intercom')} "Intercom Inc"=${canon('intercom inc')} Fin=${canon('Fin')}`);
+  }
+  if (canon('Acme Corp') === 'acme corp') pass('unknown company passes through as lowercased text (unchanged behavior)');
+  else fail(`unknown company should pass through: got ${canon('Acme Corp')}`);
+
+  // Malformed / empty alias maps must not crash and must degrade to plain lowercase.
+  const emptyCanon = buildCompanyCanonicalizer(undefined);
+  const arrayCanon = buildCompanyCanonicalizer(['not', 'a', 'map']);
+  const messyCanon = buildCompanyCanonicalizer({ '': ['x'], Fin: [null, 'Intercom', 42] });
+  if (emptyCanon('Intercom') === 'intercom' && arrayCanon('Intercom') === 'intercom' && messyCanon('Intercom') === 'fin') {
+    pass('canonicalizer tolerates undefined/array/messy alias config without crashing');
+  } else {
+    fail(`canonicalizer robustness wrong: empty=${emptyCanon('Intercom')} array=${arrayCanon('Intercom')} messy=${messyCanon('Intercom')}`);
+  }
+
+  // -- Title normalization (location suffix + punctuation + requisition-agnostic) --
+  if (normalizeRoleForDedup('AI Infrastructure Engineer (Berlin)') === normalizeRoleForDedup('AI Infrastructure Engineer')) {
+    pass('normalizeRoleForDedup strips a trailing location tag "(Berlin)"');
+  } else {
+    fail(`trailing location tag not stripped: "${normalizeRoleForDedup('AI Infrastructure Engineer (Berlin)')}"`);
+  }
+  if (normalizeRoleForDedup('Senior Engineer (Senior) (Berlin, Germany)') === 'senior engineer') {
+    pass('normalizeRoleForDedup strips stacked trailing tags');
+  } else {
+    fail(`stacked tags not stripped: "${normalizeRoleForDedup('Senior Engineer (Senior) (Berlin, Germany)')}"`);
+  }
+  if (normalizeRoleForDedup('Engineering Manager, AI Models  Infrastructure') === normalizeRoleForDedup('Engineering Manager — AI Models Infrastructure')) {
+    pass('normalizeRoleForDedup collapses punctuation/whitespace (comma vs em-dash, double space)');
+  } else {
+    fail('punctuation/whitespace not normalized');
+  }
+  // A mid-title parenthetical is NOT a trailing tag; its words are kept so two
+  // genuinely different disciplines don't collapse.
+  if (normalizeRoleForDedup('Engineer (Backend), Platform') !== normalizeRoleForDedup('Engineer (Frontend), Platform')) {
+    pass('normalizeRoleForDedup keeps mid-title parentheticals distinct (no over-merge)');
+  } else {
+    fail('mid-title parentheticals over-merged distinct roles');
+  }
+
+  // -- End-to-end: the exact real-world repost pairs that leaked before --
+  const cases = [
+    ['Intercom', 'AI Infrastructure Engineer (Berlin)', 'Fin', 'AI Infrastructure Engineer'],
+    ['Intercom', 'Engineering Manager, AI Models Infrastructure', 'Fin', 'Engineering Manager, AI Models Infrastructure'],
+    ['Intercom', 'Senior Product Engineer', 'Fin', 'Senior Product Engineer'],
+  ];
+  let allMatch = true;
+  for (const [scanCo, scanTitle, trackCo, trackTitle] of cases) {
+    const scanKey = companyRoleDedupKey(scanCo, scanTitle, canon);
+    const trackKey = companyRoleDedupKey(trackCo, trackTitle, canon);
+    if (scanKey !== trackKey) { allMatch = false; break; }
+  }
+  if (allMatch) pass('companyRoleDedupKey matches scan-side (Intercom + churned title) to tracker-side (Fin) across repost pairs');
+  else fail('companyRoleDedupKey failed to unify a real-world repost pair');
+
+  // Without an alias, distinct companies must still stay distinct.
+  if (companyRoleDedupKey('Acme', 'Engineer', canon) !== companyRoleDedupKey('Globex', 'Engineer', canon)) {
+    pass('companyRoleDedupKey keeps unrelated companies distinct');
+  } else {
+    fail('companyRoleDedupKey collapsed two unrelated companies');
+  }
+} catch (e) {
+  fail(`scan company+role dedup tests crashed: ${e.message}`);
+}
+
 // ── Plugin engine (contract + sandbox + firewall) ────────────────
 console.log('\n49. Plugin engine (contract + sandbox + firewall)');
 


### PR DESCRIPTION
## Summary
- Add company alias canonicalization to scanner company/role dedupe.
- Normalize role titles so reposts with new req URLs, trailing location tags, or punctuation drift collapse to the same dedupe key.
- Document optional company_aliases in the portals template and add regression coverage.

## Validation
- node test-all.mjs --quick (1561 passed, 0 failed, 1 expected no-user-data warning)
- node validate-system-paths-coverage.mjs
- node validate-portals.mjs --file templates/portals.example.yml