### PR TITLE
feat(scan): suppress duplicate roles via company aliases

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -581,20 +581,38 @@ export function loadSeenUrls(policy = {}) {
   return { seen, recheckEligible };
 }
 
-// The default company normalizer, used when no alias map is configured: just
-// lowercase and trim. buildCompanyCanonicalizer wraps this with the alias map.
+/**
+ * Normalize a company label when no alias map is configured.
+ *
+ * This deliberately does only the pre-existing behavior: trim and lowercase the
+ * raw company name. `buildCompanyCanonicalizer` wraps this with the optional
+ * alias map so installs without `company_aliases` keep byte-for-byte dedupe
+ * semantics.
+ *
+ * @param {unknown} name - Raw company value from a tracker row or provider job.
+ * @returns {string} Lowercased, trimmed company key.
+ */
 function defaultCompanyNormalizer(name) {
   return String(name ?? '').trim().toLowerCase();
 }
 
-// Build a company-name canonicalizer from an alias map (config.company_aliases).
-// The map is `{ CanonicalName: [alias, ...] }`; every alias AND the canonical
-// name itself resolve to the lowercased canonical name. This closes the gap
-// where an ATS org name (e.g. "Intercom") differs from the tracker/brand label
-// (e.g. "Fin"): without it, the company::role dedup key never matches the
-// tracker and the same role is re-scanned and re-evaluated on every run.
-// Unknown names pass through as plain lowercased text, so behavior is unchanged
-// for companies with no alias entry.
+/**
+ * Build a company-name canonicalizer from `config.company_aliases`.
+ *
+ * The map is `{ CanonicalName: [alias, ...] }`; every alias and the canonical
+ * name itself resolve to the lowercased canonical name. This closes the gap
+ * where an ATS org name, for example Greenhouse "Intercom", differs from the
+ * tracker/brand label, for example "Fin". Without it, the company+role dedupe
+ * key never matches the tracker and the same role is re-scanned every run.
+ *
+ * Unknown names pass through as plain lowercased text, so behavior is unchanged
+ * for companies with no alias entry.
+ *
+ * @param {Record<string, unknown>|undefined|null} aliases - Optional canonical
+ *   company name to alias list map.
+ * @returns {(name: unknown) => string} Canonicalizer for tracker and scan-side
+ *   company labels.
+ */
 export function buildCompanyCanonicalizer(aliases) {
   const map = new Map();
   if (aliases && typeof aliases === 'object' && !Array.isArray(aliases)) {
@@ -609,24 +627,34 @@ export function buildCompanyCanonicalizer(aliases) {
       }
     }
   }
-  return name => {
+
+  /**
+   * Canonicalize one raw company label through the alias map.
+   *
+   * @param {unknown} name - Raw company value from a tracker row or provider job.
+   * @returns {string} Canonical lowercased company key.
+   */
+  return function canonicalizeCompany(name) {
     const key = defaultCompanyNormalizer(name);
     return map.get(key) ?? key;
   };
 }
 
-// Normalize a role/title for repost-tolerant dedup. Two postings of the same
-// role should collapse to one key even when the company re-lists it under a new
-// requisition ID (a new URL, so URL dedup misses it) or splits it per location
-// with a trailing tag like "(Berlin)". We therefore:
-//   1. lowercase
-//   2. strip trailing parenthetical/bracketed tags — "(Berlin)", "[Remote]",
-//      "(Berlin, Germany)", and stacked "(Senior) (Berlin)" — since these are
-//      the location/qualifier suffixes that create false distinct roles
-//   3. collapse all remaining punctuation/whitespace to single spaces so
-//      em-dash vs hyphen and double spaces don't split a key
-// The requisition ID lives in the URL, never the title, so keying on the
-// normalized title is inherently requisition-ID-agnostic.
+/**
+ * Normalize a role title for repost-tolerant dedupe.
+ *
+ * Two postings of the same role should collapse to one key even when the
+ * company re-lists it under a new requisition ID or splits it per location with
+ * a trailing tag like "(Berlin)". The requisition ID lives in the URL, never the
+ * title, so keying on the normalized title is requisition-ID agnostic.
+ *
+ * The normalizer lowercases the title, strips trailing parenthetical/bracketed
+ * tags such as "(Berlin)" and "[Remote]", then collapses punctuation and
+ * whitespace so em dash vs hyphen or double spaces do not split a key.
+ *
+ * @param {unknown} role - Raw role title from a tracker row or provider job.
+ * @returns {string} Normalized role key.
+ */
 export function normalizeRoleForDedup(role) {
   return String(role ?? '')
     .toLowerCase()
@@ -635,13 +663,34 @@ export function normalizeRoleForDedup(role) {
     .trim();
 }
 
-// The canonical company::role dedup key shared by both the tracker-side load and
-// the scan-side check, so the two can never drift. `canonicalize` defaults to
-// plain lowercase/trim (no alias map).
+/**
+ * Build the canonical company+role dedupe key.
+ *
+ * This shared helper is used by both the tracker-side load and the scan-side
+ * check so those two code paths cannot drift. `canonicalize` defaults to plain
+ * lowercase/trim behavior when no alias map is configured.
+ *
+ * @param {unknown} company - Raw company label.
+ * @param {unknown} role - Raw role title.
+ * @param {(name: unknown) => string} [canonicalize] - Company canonicalizer.
+ * @returns {string} Stable dedupe key in `company::role` form.
+ */
 export function companyRoleDedupKey(company, role, canonicalize = defaultCompanyNormalizer) {
   return `${canonicalize(company)}::${normalizeRoleForDedup(role)}`;
 }
 
+/**
+ * Load company+role keys already present in the applications tracker.
+ *
+ * Existing tracker rows are canonicalized with the same company aliasing and
+ * role-title normalization used for freshly scanned jobs. That lets URL-new
+ * reposts match older tracker entries instead of being evaluated again.
+ *
+ * @param {string} [appsPath=APPLICATIONS_PATH] - Applications tracker path.
+ * @param {(name: unknown) => string} [canonicalize=defaultCompanyNormalizer] -
+ *   Company canonicalizer shared with scan-side dedupe.
+ * @returns {Set<string>} Existing company+role dedupe keys.
+ */
 export function loadSeenCompanyRoles(appsPath = APPLICATIONS_PATH, canonicalize = defaultCompanyNormalizer) {
   const seen = new Set();
   if (existsSync(appsPath)) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -608,6 +608,10 @@ function defaultCompanyNormalizer(name) {
  * Unknown names pass through as plain lowercased text, so behavior is unchanged
  * for companies with no alias entry.
  *
+ * Canonical names always keep their own identity when an alias collides with
+ * one. An alias claimed by multiple canonical companies also passes through
+ * unchanged so malformed config cannot silently merge unrelated companies.
+ *
  * @param {Record<string, unknown>|undefined|null} aliases - Optional canonical
  *   company name to alias list map.
  * @returns {(name: unknown) => string} Canonicalizer for tracker and scan-side
@@ -616,15 +620,34 @@ function defaultCompanyNormalizer(name) {
 export function buildCompanyCanonicalizer(aliases) {
   const map = new Map();
   if (aliases && typeof aliases === 'object' && !Array.isArray(aliases)) {
-    for (const [canonical, list] of Object.entries(aliases)) {
+    const entries = Object.entries(aliases);
+    const canonicalKeys = new Set();
+
+    // Canonical names always own their identity, independent of YAML key order.
+    for (const [canonical] of entries) {
       const canon = defaultCompanyNormalizer(canonical);
       if (!canon) continue;
       map.set(canon, canon);
+      canonicalKeys.add(canon);
+    }
+
+    const aliasTargets = new Map();
+    for (const [canonical, list] of entries) {
+      const canon = defaultCompanyNormalizer(canonical);
+      if (!canon) continue;
       const arr = Array.isArray(list) ? list : [list];
       for (const a of arr) {
         const alias = defaultCompanyNormalizer(a);
-        if (alias) map.set(alias, canon);
+        if (!alias || canonicalKeys.has(alias)) continue;
+        if (!aliasTargets.has(alias)) aliasTargets.set(alias, new Set());
+        aliasTargets.get(alias).add(canon);
       }
+    }
+
+    // Ambiguous aliases fail open as their raw normalized label. This may allow
+    // a duplicate through, but it cannot silently suppress another company.
+    for (const [alias, targets] of aliasTargets) {
+      if (targets.size === 1) map.set(alias, targets.values().next().value);
     }
   }
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -581,7 +581,68 @@ export function loadSeenUrls(policy = {}) {
   return { seen, recheckEligible };
 }
 
-export function loadSeenCompanyRoles(appsPath = APPLICATIONS_PATH) {
+// The default company normalizer, used when no alias map is configured: just
+// lowercase and trim. buildCompanyCanonicalizer wraps this with the alias map.
+function defaultCompanyNormalizer(name) {
+  return String(name ?? '').trim().toLowerCase();
+}
+
+// Build a company-name canonicalizer from an alias map (config.company_aliases).
+// The map is `{ CanonicalName: [alias, ...] }`; every alias AND the canonical
+// name itself resolve to the lowercased canonical name. This closes the gap
+// where an ATS org name (e.g. "Intercom") differs from the tracker/brand label
+// (e.g. "Fin"): without it, the company::role dedup key never matches the
+// tracker and the same role is re-scanned and re-evaluated on every run.
+// Unknown names pass through as plain lowercased text, so behavior is unchanged
+// for companies with no alias entry.
+export function buildCompanyCanonicalizer(aliases) {
+  const map = new Map();
+  if (aliases && typeof aliases === 'object' && !Array.isArray(aliases)) {
+    for (const [canonical, list] of Object.entries(aliases)) {
+      const canon = defaultCompanyNormalizer(canonical);
+      if (!canon) continue;
+      map.set(canon, canon);
+      const arr = Array.isArray(list) ? list : [list];
+      for (const a of arr) {
+        const alias = defaultCompanyNormalizer(a);
+        if (alias) map.set(alias, canon);
+      }
+    }
+  }
+  return name => {
+    const key = defaultCompanyNormalizer(name);
+    return map.get(key) ?? key;
+  };
+}
+
+// Normalize a role/title for repost-tolerant dedup. Two postings of the same
+// role should collapse to one key even when the company re-lists it under a new
+// requisition ID (a new URL, so URL dedup misses it) or splits it per location
+// with a trailing tag like "(Berlin)". We therefore:
+//   1. lowercase
+//   2. strip trailing parenthetical/bracketed tags — "(Berlin)", "[Remote]",
+//      "(Berlin, Germany)", and stacked "(Senior) (Berlin)" — since these are
+//      the location/qualifier suffixes that create false distinct roles
+//   3. collapse all remaining punctuation/whitespace to single spaces so
+//      em-dash vs hyphen and double spaces don't split a key
+// The requisition ID lives in the URL, never the title, so keying on the
+// normalized title is inherently requisition-ID-agnostic.
+export function normalizeRoleForDedup(role) {
+  return String(role ?? '')
+    .toLowerCase()
+    .replace(/(?:\s*[([][^)\]]*[)\]])+\s*$/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+// The canonical company::role dedup key shared by both the tracker-side load and
+// the scan-side check, so the two can never drift. `canonicalize` defaults to
+// plain lowercase/trim (no alias map).
+export function companyRoleDedupKey(company, role, canonicalize = defaultCompanyNormalizer) {
+  return `${canonicalize(company)}::${normalizeRoleForDedup(role)}`;
+}
+
+export function loadSeenCompanyRoles(appsPath = APPLICATIONS_PATH, canonicalize = defaultCompanyNormalizer) {
   const seen = new Set();
   if (existsSync(appsPath)) {
     // Header-aware parse (tracker-parse.mjs, #954) — the old positional regex
@@ -592,9 +653,9 @@ export function loadSeenCompanyRoles(appsPath = APPLICATIONS_PATH) {
     for (const line of lines) {
       const row = parseTrackerRow(line, colmap);
       if (!row) continue;
-      const company = row.company.trim().toLowerCase();
-      const role = row.role.trim().toLowerCase();
-      if (company && role) seen.add(`${company}::${role}`);
+      const company = row.company.trim();
+      const role = row.role.trim();
+      if (company && role) seen.add(companyRoleDedupKey(company, role, canonicalize));
     }
   }
   return seen;
@@ -1085,7 +1146,8 @@ async function main() {
   const historyPolicy = scanHistoryPolicy(config);
   const seenUrlState = loadSeenUrls(historyPolicy);
   const seenUrls = seenUrlState.seen;
-  const seenCompanyRoles = loadSeenCompanyRoles();
+  const canonicalizeCompany = buildCompanyCanonicalizer(config.company_aliases);
+  const seenCompanyRoles = loadSeenCompanyRoles(APPLICATIONS_PATH, canonicalizeCompany);
 
   // 5. Fetch from each target
   const date = new Date().toISOString().slice(0, 10);
@@ -1168,7 +1230,7 @@ async function main() {
           totalDupes++;
           continue;
         }
-        const key = `${job.company.toLowerCase()}::${job.title.toLowerCase()}`;
+        const key = companyRoleDedupKey(job.company, job.title, canonicalizeCompany);
         if (seenCompanyRoles.has(key)) {
           totalDupes++;
           continue;

--- a/scan.mjs
+++ b/scan.mjs
@@ -640,6 +640,133 @@ export function buildCompanyCanonicalizer(aliases) {
   };
 }
 
+const ROLE_LOCATION_SUFFIXES = new Set([
+  'amer',
+  'americas',
+  'amsterdam',
+  'apac',
+  'austin',
+  'barcelona',
+  'bay area',
+  'belgium',
+  'berlin',
+  'boston',
+  'brussels',
+  'budapest',
+  'canada',
+  'chicago',
+  'copenhagen',
+  'dublin',
+  'emea',
+  'eu',
+  'europe',
+  'finland',
+  'france',
+  'frankfurt',
+  'germany',
+  'hamburg',
+  'helsinki',
+  'india',
+  'ireland',
+  'italy',
+  'la',
+  'latin america',
+  'lisbon',
+  'london',
+  'los angeles',
+  'madrid',
+  'melbourne',
+  'milan',
+  'montreal',
+  'munich',
+  'netherlands',
+  'new york',
+  'north america',
+  'nyc',
+  'on site',
+  'onsite',
+  'oslo',
+  'paris',
+  'poland',
+  'porto',
+  'prague',
+  'remote',
+  'rome',
+  'san francisco',
+  'seattle',
+  'sf',
+  'singapore',
+  'spain',
+  'stockholm',
+  'sydney',
+  'tokyo',
+  'toronto',
+  'uk',
+  'united kingdom',
+  'united states',
+  'us',
+  'usa',
+  'vancouver',
+  'vienna',
+  'warsaw',
+  'zurich',
+]);
+
+const ROLE_REMOTE_SUFFIXES = new Set([
+  'distributed',
+  'hybrid',
+  'on site',
+  'onsite',
+  'remote',
+  'wfh',
+  'work from home',
+]);
+
+/**
+ * Normalize bracket text before checking whether it is a location suffix.
+ *
+ * @param {unknown} tag - Text from a trailing parenthetical or bracket suffix.
+ * @returns {string} Lowercased, punctuation-normalized suffix text.
+ */
+function normalizeRoleSuffixTag(tag) {
+  return String(tag ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+/**
+ * Decide whether a trailing role-title suffix is a location/remote tag.
+ *
+ * Only known remote/location suffixes are stripped. Seniority, discipline, team,
+ * and product qualifiers are intentionally preserved so distinct role variants
+ * do not collapse to the same scanner dedupe key.
+ *
+ * @param {unknown} tag - Text from a trailing parenthetical or bracket suffix.
+ * @returns {boolean} True when the suffix is safe to remove for dedupe.
+ */
+function isRoleLocationSuffix(tag) {
+  const normalized = normalizeRoleSuffixTag(tag);
+  if (!normalized) return false;
+  if (ROLE_LOCATION_SUFFIXES.has(normalized)) return true;
+
+  const raw = String(tag ?? '').toLowerCase();
+  const parts = raw
+    .split(/[,/|;]+|\s+(?:and|or)\s+/g)
+    .map(normalizeRoleSuffixTag)
+    .filter(Boolean);
+  if (parts.length > 1 && parts.every(part => ROLE_LOCATION_SUFFIXES.has(part))) return true;
+
+  for (const remote of ROLE_REMOTE_SUFFIXES) {
+    const prefix = `${remote} `;
+    if (normalized.startsWith(prefix) && ROLE_LOCATION_SUFFIXES.has(normalized.slice(prefix.length))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Normalize a role title for repost-tolerant dedupe.
  *
@@ -648,19 +775,22 @@ export function buildCompanyCanonicalizer(aliases) {
  * a trailing tag like "(Berlin)". The requisition ID lives in the URL, never the
  * title, so keying on the normalized title is requisition-ID agnostic.
  *
- * The normalizer lowercases the title, strips trailing parenthetical/bracketed
- * tags such as "(Berlin)" and "[Remote]", then collapses punctuation and
- * whitespace so em dash vs hyphen or double spaces do not split a key.
+ * The normalizer lowercases the title, strips trailing location/remote
+ * parenthetical/bracketed tags such as "(Berlin)" and "[Remote]", then
+ * collapses punctuation and whitespace so em dash vs hyphen or double spaces do
+ * not split a key.
  *
  * @param {unknown} role - Raw role title from a tracker row or provider job.
  * @returns {string} Normalized role key.
  */
 export function normalizeRoleForDedup(role) {
-  return String(role ?? '')
-    .toLowerCase()
-    .replace(/(?:\s*[([][^)\]]*[)\]])+\s*$/g, '')
-    .replace(/[^a-z0-9]+/g, ' ')
-    .trim();
+  let title = String(role ?? '').toLowerCase();
+  while (true) {
+    const match = title.match(/\s*[\[(]([^[\]()]+)[\])]\s*$/);
+    if (!match || !isRoleLocationSuffix(match[1])) break;
+    title = title.slice(0, match.index).trimEnd();
+  }
+  return title.replace(/[^a-z0-9]+/g, ' ').trim();
 }
 
 /**

--- a/scan.mjs
+++ b/scan.mjs
@@ -768,17 +768,20 @@ function isRoleLocationSuffix(tag) {
 }
 
 /**
- * Normalize a role title for repost-tolerant dedupe.
+ * Normalize a role title for stable scan-time duplicate identity.
  *
- * Two postings of the same role should collapse to one key even when the
- * company re-lists it under a new requisition ID or splits it per location with
- * a trailing tag like "(Berlin)". The requisition ID lives in the URL, never the
- * title, so keying on the normalized title is requisition-ID agnostic.
+ * Equivalent tracker/provider titles should collapse to one key when a company
+ * splits a role per location with a trailing tag like "(Berlin)". Requisition
+ * IDs live in URLs rather than titles, so this identity remains URL-agnostic.
  *
  * The normalizer lowercases the title, strips trailing location/remote
  * parenthetical/bracketed tags such as "(Berlin)" and "[Remote]", then
  * collapses punctuation and whitespace so em dash vs hyphen or double spaces do
  * not split a key.
+ *
+ * This helper does not infer posting churn or detect repost clusters. Those
+ * post-tracking facts remain the responsibility of detect-reposts.mjs and the
+ * company-history `postingChurn` axis.
  *
  * @param {unknown} role - Raw role title from a tracker row or provider job.
  * @returns {string} Normalized role key.
@@ -814,7 +817,7 @@ export function companyRoleDedupKey(company, role, canonicalize = defaultCompany
  *
  * Existing tracker rows are canonicalized with the same company aliasing and
  * role-title normalization used for freshly scanned jobs. That lets URL-new
- * reposts match older tracker entries instead of being evaluated again.
+ * duplicates match older tracker entries instead of being evaluated again.
  *
  * @param {string} [appsPath=APPLICATIONS_PATH] - Applications tracker path.
  * @param {(name: unknown) => string} [canonicalize=defaultCompanyNormalizer] -

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -806,9 +806,11 @@ search_queries:
 #
 # Format: `CanonicalName: [alias, ...]`. Every alias AND the canonical name
 # resolve to the canonical label (case-insensitive). Companies with no entry are
-# unaffected. Combined with title normalization, this also collapses reposts
-# (same role re-listed under a new requisition ID / URL) and per-location splits
-# ("Engineer (Berlin)" vs "Engineer") onto one dedup key.
+# unaffected. Combined with title normalization, this suppresses URL-new
+# duplicates caused by requisition URL changes and per-location title splits
+# ("Engineer (Berlin)" vs "Engineer"). It does not classify repost patterns or
+# produce `postingChurn` evidence; detect-reposts.mjs and company-history.mjs own
+# that post-tracking layer.
 #
 # company_aliases:
 #   Fin: [Intercom]

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -796,6 +796,23 @@ search_queries:
 #     provider: jibeapply
 #     enabled: true
 
+# -- Company aliases (optional) --
+# Map alternate company names to a single canonical label so the scanner's
+# company+role dedup matches your tracker. The scanner keys dedup on the name a
+# provider returns — usually the ATS org (e.g. Greenhouse "Intercom") — which
+# may differ from the brand you track (e.g. "Fin"). Without an alias, the same
+# role is re-scanned and re-evaluated every run because "intercom::role" never
+# matches "fin::role" in data/applications.md.
+#
+# Format: `CanonicalName: [alias, ...]`. Every alias AND the canonical name
+# resolve to the canonical label (case-insensitive). Companies with no entry are
+# unaffected. Combined with title normalization, this also collapses reposts
+# (same role re-listed under a new requisition ID / URL) and per-location splits
+# ("Engineer (Berlin)" vs "Engineer") onto one dedup key.
+#
+# company_aliases:
+#   Fin: [Intercom]
+
 tracked_companies:
 
   # -- AI Labs & LLM providers --

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6100,6 +6100,90 @@ try {
 }
 
 
+// ── 45b. SCAN COMPANY+ROLE DEDUP (alias + repost normalization) ──────
+// Guards the fix for ATS repost churn: the scanner keys company+role dedup on
+// the provider's company name (often the ATS org, e.g. "Intercom") which may
+// differ from the tracker brand ("Fin"), and on a title that a company mutates
+// per requisition/location ("Engineer (Berlin)"). buildCompanyCanonicalizer +
+// normalizeRoleForDedup collapse both so the same role is not re-evaluated.
+
+console.log('\n45b. Scan company+role dedup (alias + repost)');
+try {
+  const {
+    buildCompanyCanonicalizer,
+    normalizeRoleForDedup,
+    companyRoleDedupKey,
+  } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+
+  // -- Company alias canonicalization --
+  const canon = buildCompanyCanonicalizer({ Fin: ['Intercom', 'Intercom Inc'] });
+  if (canon('Intercom') === 'fin' && canon('intercom inc') === 'fin' && canon('Fin') === 'fin') {
+    pass('buildCompanyCanonicalizer maps every alias and the canonical name to the canonical label');
+  } else {
+    fail(`alias canonicalization wrong: Intercom=${canon('Intercom')} "Intercom Inc"=${canon('intercom inc')} Fin=${canon('Fin')}`);
+  }
+  if (canon('Acme Corp') === 'acme corp') pass('unknown company passes through as lowercased text (unchanged behavior)');
+  else fail(`unknown company should pass through: got ${canon('Acme Corp')}`);
+
+  // Malformed / empty alias maps must not crash and must degrade to plain lowercase.
+  const emptyCanon = buildCompanyCanonicalizer(undefined);
+  const arrayCanon = buildCompanyCanonicalizer(['not', 'a', 'map']);
+  const messyCanon = buildCompanyCanonicalizer({ '': ['x'], Fin: [null, 'Intercom', 42] });
+  if (emptyCanon('Intercom') === 'intercom' && arrayCanon('Intercom') === 'intercom' && messyCanon('Intercom') === 'fin') {
+    pass('canonicalizer tolerates undefined/array/messy alias config without crashing');
+  } else {
+    fail(`canonicalizer robustness wrong: empty=${emptyCanon('Intercom')} array=${arrayCanon('Intercom')} messy=${messyCanon('Intercom')}`);
+  }
+
+  // -- Title normalization (location suffix + punctuation + requisition-agnostic) --
+  if (normalizeRoleForDedup('AI Infrastructure Engineer (Berlin)') === normalizeRoleForDedup('AI Infrastructure Engineer')) {
+    pass('normalizeRoleForDedup strips a trailing location tag "(Berlin)"');
+  } else {
+    fail(`trailing location tag not stripped: "${normalizeRoleForDedup('AI Infrastructure Engineer (Berlin)')}"`);
+  }
+  if (normalizeRoleForDedup('Senior Engineer (Senior) (Berlin, Germany)') === 'senior engineer') {
+    pass('normalizeRoleForDedup strips stacked trailing tags');
+  } else {
+    fail(`stacked tags not stripped: "${normalizeRoleForDedup('Senior Engineer (Senior) (Berlin, Germany)')}"`);
+  }
+  if (normalizeRoleForDedup('Engineering Manager, AI Models  Infrastructure') === normalizeRoleForDedup('Engineering Manager — AI Models Infrastructure')) {
+    pass('normalizeRoleForDedup collapses punctuation/whitespace (comma vs em-dash, double space)');
+  } else {
+    fail('punctuation/whitespace not normalized');
+  }
+  // A mid-title parenthetical is NOT a trailing tag; its words are kept so two
+  // genuinely different disciplines don't collapse.
+  if (normalizeRoleForDedup('Engineer (Backend), Platform') !== normalizeRoleForDedup('Engineer (Frontend), Platform')) {
+    pass('normalizeRoleForDedup keeps mid-title parentheticals distinct (no over-merge)');
+  } else {
+    fail('mid-title parentheticals over-merged distinct roles');
+  }
+
+  // -- End-to-end: the exact real-world repost pairs that leaked before --
+  const cases = [
+    ['Intercom', 'AI Infrastructure Engineer (Berlin)', 'Fin', 'AI Infrastructure Engineer'],
+    ['Intercom', 'Engineering Manager, AI Models Infrastructure', 'Fin', 'Engineering Manager, AI Models Infrastructure'],
+    ['Intercom', 'Senior Product Engineer', 'Fin', 'Senior Product Engineer'],
+  ];
+  let allMatch = true;
+  for (const [scanCo, scanTitle, trackCo, trackTitle] of cases) {
+    const scanKey = companyRoleDedupKey(scanCo, scanTitle, canon);
+    const trackKey = companyRoleDedupKey(trackCo, trackTitle, canon);
+    if (scanKey !== trackKey) { allMatch = false; break; }
+  }
+  if (allMatch) pass('companyRoleDedupKey matches scan-side (Intercom + churned title) to tracker-side (Fin) across repost pairs');
+  else fail('companyRoleDedupKey failed to unify a real-world repost pair');
+
+  // Without an alias, distinct companies must still stay distinct.
+  if (companyRoleDedupKey('Acme', 'Engineer', canon) !== companyRoleDedupKey('Globex', 'Engineer', canon)) {
+    pass('companyRoleDedupKey keeps unrelated companies distinct');
+  } else {
+    fail('companyRoleDedupKey collapsed two unrelated companies');
+  }
+} catch (e) {
+  fail(`scan company+role dedup tests crashed: ${e.message}`);
+}
+
 // ── Plugin engine (contract + sandbox + firewall) ────────────────
 console.log('\n49. Plugin engine (contract + sandbox + firewall)');
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6141,10 +6141,20 @@ try {
   } else {
     fail(`trailing location tag not stripped: "${normalizeRoleForDedup('AI Infrastructure Engineer (Berlin)')}"`);
   }
-  if (normalizeRoleForDedup('Senior Engineer (Senior) (Berlin, Germany)') === 'senior engineer') {
-    pass('normalizeRoleForDedup strips stacked trailing tags');
+  if (normalizeRoleForDedup('Platform Engineer [Remote]') === normalizeRoleForDedup('Platform Engineer')) {
+    pass('normalizeRoleForDedup strips a trailing remote tag "[Remote]"');
   } else {
-    fail(`stacked tags not stripped: "${normalizeRoleForDedup('Senior Engineer (Senior) (Berlin, Germany)')}"`);
+    fail(`trailing remote tag not stripped: "${normalizeRoleForDedup('Platform Engineer [Remote]')}"`);
+  }
+  if (normalizeRoleForDedup('Senior Engineer (Senior) (Berlin, Germany)') === 'senior engineer senior') {
+    pass('normalizeRoleForDedup strips location suffixes while preserving level qualifiers');
+  } else {
+    fail(`location suffix/level qualifier handling wrong: "${normalizeRoleForDedup('Senior Engineer (Senior) (Berlin, Germany)')}"`);
+  }
+  if (normalizeRoleForDedup('Engineer (Senior)') !== normalizeRoleForDedup('Engineer (Junior)')) {
+    pass('normalizeRoleForDedup keeps trailing seniority variants distinct');
+  } else {
+    fail('trailing seniority variants over-merged distinct roles');
   }
   if (normalizeRoleForDedup('Engineering Manager, AI Models  Infrastructure') === normalizeRoleForDedup('Engineering Manager — AI Models Infrastructure')) {
     pass('normalizeRoleForDedup collapses punctuation/whitespace (comma vs em-dash, double space)');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6100,14 +6100,14 @@ try {
 }
 
 
-// ── 45b. SCAN COMPANY+ROLE DEDUP (alias + repost normalization) ──────
-// Guards the fix for ATS repost churn: the scanner keys company+role dedup on
+// ── 45b. SCAN COMPANY+ROLE DEDUP (alias + title normalization) ───────
+// Guards scan-time duplicate identity: the scanner keys company+role dedup on
 // the provider's company name (often the ATS org, e.g. "Intercom") which may
 // differ from the tracker brand ("Fin"), and on a title that a company mutates
 // per requisition/location ("Engineer (Berlin)"). buildCompanyCanonicalizer +
 // normalizeRoleForDedup collapse both so the same role is not re-evaluated.
 
-console.log('\n45b. Scan company+role dedup (alias + repost)');
+console.log('\n45b. Scan company+role dedup (alias + title normalization)');
 try {
   const {
     buildCompanyCanonicalizer,
@@ -6169,7 +6169,7 @@ try {
     fail('mid-title parentheticals over-merged distinct roles');
   }
 
-  // -- End-to-end: the exact real-world repost pairs that leaked before --
+  // -- End-to-end: the exact URL-new duplicate pairs that leaked before --
   const cases = [
     ['Intercom', 'AI Infrastructure Engineer (Berlin)', 'Fin', 'AI Infrastructure Engineer'],
     ['Intercom', 'Engineering Manager, AI Models Infrastructure', 'Fin', 'Engineering Manager, AI Models Infrastructure'],
@@ -6181,8 +6181,8 @@ try {
     const trackKey = companyRoleDedupKey(trackCo, trackTitle, canon);
     if (scanKey !== trackKey) { allMatch = false; break; }
   }
-  if (allMatch) pass('companyRoleDedupKey matches scan-side (Intercom + churned title) to tracker-side (Fin) across repost pairs');
-  else fail('companyRoleDedupKey failed to unify a real-world repost pair');
+  if (allMatch) pass('companyRoleDedupKey matches scan-side (Intercom + location-suffixed title) to tracker-side (Fin) across URL-new duplicate pairs');
+  else fail('companyRoleDedupKey failed to unify a real-world URL-new duplicate pair');
 
   // Without an alias, distinct companies must still stay distinct.
   if (companyRoleDedupKey('Acme', 'Engineer', canon) !== companyRoleDedupKey('Globex', 'Engineer', canon)) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6135,6 +6135,22 @@ try {
     fail(`canonicalizer robustness wrong: empty=${emptyCanon('Intercom')} array=${arrayCanon('Intercom')} messy=${messyCanon('Intercom')}`);
   }
 
+  const canonicalCollisionA = buildCompanyCanonicalizer({ Fin: ['Intercom'], Intercom: [] });
+  const canonicalCollisionB = buildCompanyCanonicalizer({ Intercom: [], Fin: ['Intercom'] });
+  if (canonicalCollisionA('Intercom') === 'intercom' && canonicalCollisionB('Intercom') === 'intercom') {
+    pass('canonical company identities win alias collisions regardless of config order');
+  } else {
+    fail(`canonical alias collision is order-dependent: first=${canonicalCollisionA('Intercom')} second=${canonicalCollisionB('Intercom')}`);
+  }
+
+  const ambiguousAliasA = buildCompanyCanonicalizer({ Fin: ['Shared ATS'], Acme: ['Shared ATS'] });
+  const ambiguousAliasB = buildCompanyCanonicalizer({ Acme: ['Shared ATS'], Fin: ['Shared ATS'] });
+  if (ambiguousAliasA('Shared ATS') === 'shared ats' && ambiguousAliasB('Shared ATS') === 'shared ats') {
+    pass('ambiguous aliases fail open instead of merging companies by config order');
+  } else {
+    fail(`ambiguous alias should pass through: first=${ambiguousAliasA('Shared ATS')} second=${ambiguousAliasB('Shared ATS')}`);
+  }
+
   // -- Title normalization (location suffix + punctuation + requisition-agnostic) --
   if (normalizeRoleForDedup('AI Infrastructure Engineer (Berlin)') === normalizeRoleForDedup('AI Infrastructure Engineer')) {
     pass('normalizeRoleForDedup strips a trailing location tag "(Berlin)"');


### PR DESCRIPTION
## What does this PR do?

Adds a stable scan-time company-role identity for duplicate suppression. The scanner can now canonicalize configured company aliases and normalize role titles before comparing newly scanned jobs with existing tracker rows, preventing URL-new duplicates when an ATS organization name differs from the tracked brand or a role is split into per-location titles.

The same key builder is used on both sides of the comparison. Role normalization strips only known trailing location or remote tags and preserves meaningful qualifiers such as seniority.

This PR does not infer reposts, count posting churn, or produce legitimacy evidence. #1711 and #1712 own that post-tracking `postingChurn` layer through `detect-reposts.mjs`. Issue #1750 records the boundary and the open question of whether suppressed observations eventually need a dedicated scan-history status.

The branch is rebased onto current `main` and preserves the `postedAt` persistence from #1725 and the opt-in freshness gate from #1726.

Supersedes #1720, which closed automatically when the fork branch was renamed to `feat/repost-aware-scanner-dedupe`.

## Related issue

Closes #1750

Related: #1711, #1712

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Validation notes

- `node test-all.mjs` — 1635 passed, 0 failed; warnings were expected for absent user data and the Go compiler not being available on local `PATH`.
- `node test-all.mjs --quick` — 1635 passed, 0 failed, 1 expected no-user-data warning.
- `node validate-portals.mjs --file templates/portals.example.yml` — 0 errors, 0 warnings.
- `node --check scan.mjs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced duplicate detection by deduplicating on a canonical company label combined with a normalized company/role title, improving consistency across provider naming variations.
  * Added optional `company_aliases` support to map alternate company names to a canonical label for deduplication.
* **Bug Fixes**
  * More accurate role-title normalization, including punctuation/spacing cleanup and removal of recognized trailing location/remote-style qualifiers to reduce false “new” entries.
* **Documentation**
  * Added commented guidance on `company_aliases` configuration format and intent.
* **Tests**
  * Added new coverage for company canonicalization, role normalization, and scan-to-tracker dedup matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->