### PR TITLE
fix(providers): support explicit api: override for ashby/lever

### DIFF
--- a/providers/ashby.mjs
+++ b/providers/ashby.mjs
@@ -75,8 +75,31 @@ export function parseCompensation(job) {
   };
 }
 
+const ALLOWED_ASHBY_HOSTS = new Set(['api.ashbyhq.com']);
+
+/** @param {string} url */
+function assertAshbyUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`ashby: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`ashby: URL must use HTTPS: ${url}`);
+  if (!ALLOWED_ASHBY_HOSTS.has(parsed.hostname))
+    throw new Error(`ashby: untrusted hostname "${parsed.hostname}" — must be one of: ${[...ALLOWED_ASHBY_HOSTS].join(', ')}`);
+  return url;
+}
+
 /** @param {import('./_types.js').PortalEntry} entry */
 function resolveApiUrl(entry) {
+  // Explicit api: wins — lets an entry keep a human-facing corporate
+  // careers_url (e.g. https://openai.com/careers) while still pinning the
+  // Ashby posting-api board (mirrors greenhouse's api: precedence).
+  if (entry.api) {
+    assertAshbyUrl(entry.api);
+    return entry.api;
+  }
   const url = entry.careers_url || '';
   const match = url.match(/jobs\.ashbyhq\.com\/([^/?#]+)/);
   if (!match) return null;
@@ -126,13 +149,18 @@ export default {
   id: 'ashby',
 
   detect(entry) {
-    const apiUrl = resolveApiUrl(entry);
-    return apiUrl ? { url: apiUrl } : null;
+    try {
+      const apiUrl = resolveApiUrl(entry);
+      return apiUrl ? { url: apiUrl } : null;
+    } catch {
+      return null;
+    }
   },
 
   async fetch(entry, ctx) {
     const apiUrl = resolveApiUrl(entry);
     if (!apiUrl) throw new Error(`ashby: cannot derive API URL for ${entry.name}`);
+    assertAshbyUrl(apiUrl);
     let lastErr;
     for (let attempt = 0; attempt <= ASHBY_RETRIES; attempt++) {
       if (attempt > 0) {

--- a/providers/lever.mjs
+++ b/providers/lever.mjs
@@ -3,9 +3,33 @@
 
 // Lever provider — hits the public postings endpoint.
 // Auto-detects from careers_url via jobs.(eu.)?lever.co/<slug>.
+// Handles both explicit `api:` URLs and auto-detection from `careers_url`.
+
+const ALLOWED_LEVER_HOSTS = new Set(['api.lever.co', 'api.eu.lever.co']);
+
+/** @param {string} url */
+function assertLeverUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`lever: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`lever: URL must use HTTPS: ${url}`);
+  if (!ALLOWED_LEVER_HOSTS.has(parsed.hostname))
+    throw new Error(`lever: untrusted hostname "${parsed.hostname}" — must be one of: ${[...ALLOWED_LEVER_HOSTS].join(', ')}`);
+  return url;
+}
 
 /** @param {import('./_types.js').PortalEntry} entry */
 function resolveApiUrl(entry) {
+  // Explicit api: wins — lets an entry keep a human-facing corporate
+  // careers_url (e.g. https://www.coalfire.com/careers) while still pinning
+  // the Lever postings board (mirrors greenhouse's api: precedence).
+  if (entry.api) {
+    assertLeverUrl(entry.api);
+    return entry.api;
+  }
   let url;
   try {
     url = new URL(entry.careers_url || '');
@@ -24,13 +48,18 @@ export default {
   id: 'lever',
 
   detect(entry) {
-    const apiUrl = resolveApiUrl(entry);
-    return apiUrl ? { url: apiUrl } : null;
+    try {
+      const apiUrl = resolveApiUrl(entry);
+      return apiUrl ? { url: apiUrl } : null;
+    } catch {
+      return null;
+    }
   },
 
   async fetch(entry, ctx) {
     const apiUrl = resolveApiUrl(entry);
     if (!apiUrl) throw new Error(`lever: cannot derive API URL for ${entry.name}`);
+    assertLeverUrl(apiUrl);
     const json = await ctx.fetchJson(apiUrl, { redirect: 'error' });
     if (!Array.isArray(json)) return [];
     return json.map(j => ({

--- a/tests/providers/ashby.test.mjs
+++ b/tests/providers/ashby.test.mjs
@@ -40,6 +40,42 @@ try {
     fail('ashby.detect() should return null when careers_url is absent');
   }
 
+  // detect() — api: takes precedence over careers_url and is used verbatim
+  // when its host is on the allowlist. Lets an entry keep a human-facing
+  // corporate careers_url (e.g. https://openai.com/careers) while pinning
+  // the Ashby board explicitly.
+  const hitApi = ashby.detect({
+    name: 'Pinned',
+    careers_url: 'https://openai.com/careers',
+    api: 'https://api.ashbyhq.com/posting-api/job-board/openai?includeCompensation=true',
+  });
+  if (hitApi && hitApi.url === 'https://api.ashbyhq.com/posting-api/job-board/openai?includeCompensation=true') {
+    pass('ashby.detect() honors an allowlisted api: over a branded careers_url');
+  } else {
+    fail(`ashby.detect(api-pinned) returned ${JSON.stringify(hitApi)}`);
+  }
+
+  // detect() — api: with an untrusted host must NOT be claimed (SSRF guard).
+  if (ashby.detect({ name: 'Evil', api: 'https://evil.example/posting-api/job-board/acme' }) === null) {
+    pass('ashby.detect() returns null for an api: on an untrusted host');
+  } else {
+    fail('ashby.detect() must reject an untrusted api: host');
+  }
+
+  // detect() — api: must be HTTPS.
+  if (ashby.detect({ name: 'Insecure', api: 'http://api.ashbyhq.com/posting-api/job-board/acme' }) === null) {
+    pass('ashby.detect() returns null for a non-HTTPS api:');
+  } else {
+    fail('ashby.detect() must reject an http:// api:');
+  }
+
+  // detect() — malformed api: URL → null, not a crash.
+  if (ashby.detect({ name: 'Broken', api: 'not a url' }) === null) {
+    pass('ashby.detect() returns null for a malformed api: URL');
+  } else {
+    fail('ashby.detect() must reject a malformed api: URL');
+  }
+
   // parseCompensation() — annualization, coercion, and rejection paths.
   const annual = parseCompensation({ compensation: { interval: '1 YEAR', minValue: 90000, maxValue: 120000, currency: 'usd' } });
   if (annual && annual.min === 90000 && annual.max === 120000 && annual.currency === 'USD') {
@@ -205,6 +241,34 @@ try {
       pass('ashby.fetch() exhausts 3 attempts (ASHBY_RETRIES=2) and rethrows the last error');
     } else {
       fail(`ashby.fetch() retry exhaustion: attempts=${exhaustAttempts}, error=${e.message}`);
+    }
+  }
+
+  // fetch() — a pinned api: is used verbatim, bypassing careers_url parsing entirely.
+  let pinnedUrl = null;
+  await ashby.fetch(
+    { name: 'OpenAI', careers_url: 'https://openai.com/careers', api: 'https://api.ashbyhq.com/posting-api/job-board/openai?includeCompensation=true' },
+    { fetchJson: async (url) => { pinnedUrl = url; return { jobs: [] }; } },
+  );
+  if (pinnedUrl === 'https://api.ashbyhq.com/posting-api/job-board/openai?includeCompensation=true') {
+    pass('ashby.fetch() honors a pinned api: over a non-ashby careers_url');
+  } else {
+    fail(`ashby.fetch() pinned api: requested ${JSON.stringify(pinnedUrl)}`);
+  }
+
+  // fetch() — an untrusted api: host throws before any request (SSRF guard).
+  let evilFetchCalled = false;
+  try {
+    await ashby.fetch(
+      { name: 'Evil', api: 'https://evil.example/posting-api/job-board/acme' },
+      { fetchJson: async () => { evilFetchCalled = true; return { jobs: [] }; } },
+    );
+    fail('ashby.fetch() should throw for an untrusted api: host');
+  } catch (e) {
+    if (!evilFetchCalled && /untrusted hostname/.test(e.message)) {
+      pass('ashby.fetch() rejects an untrusted api: host before fetching');
+    } else {
+      fail(`ashby.fetch() untrusted api: fetchCalled=${evilFetchCalled}, error=${e.message}`);
     }
   }
 

--- a/tests/providers/lever.test.mjs
+++ b/tests/providers/lever.test.mjs
@@ -67,6 +67,50 @@ try {
     fail('lever.detect() should treat non-string careers_url as missing');
   }
 
+  // detect() — api: takes precedence over careers_url and is used verbatim
+  // when its host is on the allowlist. Lets an entry keep a human-facing
+  // corporate careers_url (e.g. https://www.coalfire.com/careers) while
+  // pinning the Lever board explicitly.
+  const hitApi = lever.detect({
+    name: 'Pinned',
+    careers_url: 'https://www.coalfire.com/careers',
+    api: 'https://api.lever.co/v0/postings/coalfire',
+  });
+  if (hitApi && hitApi.url === 'https://api.lever.co/v0/postings/coalfire') {
+    pass('lever.detect() honors an allowlisted api: over a branded careers_url');
+  } else {
+    fail(`lever.detect(api-pinned) returned ${JSON.stringify(hitApi)}`);
+  }
+
+  // detect() — api: on the EU host is also allowlisted.
+  const hitApiEu = lever.detect({ name: 'PinnedEu', api: 'https://api.eu.lever.co/v0/postings/euco' });
+  if (hitApiEu && hitApiEu.url === 'https://api.eu.lever.co/v0/postings/euco') {
+    pass('lever.detect() honors an allowlisted api: on the EU host');
+  } else {
+    fail(`lever.detect(api-pinned-eu) returned ${JSON.stringify(hitApiEu)}`);
+  }
+
+  // detect() — api: with an untrusted host must NOT be claimed (SSRF guard).
+  if (lever.detect({ name: 'Evil', api: 'https://evil.example/v0/postings/acme' }) === null) {
+    pass('lever.detect() returns null for an api: on an untrusted host');
+  } else {
+    fail('lever.detect() must reject an untrusted api: host');
+  }
+
+  // detect() — api: must be HTTPS.
+  if (lever.detect({ name: 'Insecure', api: 'http://api.lever.co/v0/postings/acme' }) === null) {
+    pass('lever.detect() returns null for a non-HTTPS api:');
+  } else {
+    fail('lever.detect() must reject an http:// api:');
+  }
+
+  // detect() — malformed api: URL → null, not a crash.
+  if (lever.detect({ name: 'Broken', api: 'not a url' }) === null) {
+    pass('lever.detect() returns null for a malformed api: URL');
+  } else {
+    fail('lever.detect() must reject a malformed api: URL');
+  }
+
   // fetch() — request URL, SSRF guard, and normalization from the real v0
   // postings shape: [{ text, hostedUrl, categories: {location}, descriptionPlain, createdAt }].
   const sample = [
@@ -132,6 +176,34 @@ try {
     if (!Array.isArray(out) || out.length !== 0) { emptyOk = false; fail(`lever.fetch() body=${JSON.stringify(body)} → ${JSON.stringify(out)}`); break; }
   }
   if (emptyOk) pass('lever.fetch() returns [] for non-array response bodies (null / {} / string)');
+
+  // fetch() — a pinned api: is used verbatim, bypassing careers_url parsing entirely.
+  let pinnedUrl = null;
+  await lever.fetch(
+    { name: 'Coalfire', careers_url: 'https://www.coalfire.com/careers', api: 'https://api.lever.co/v0/postings/coalfire' },
+    { fetchJson: async (url) => { pinnedUrl = url; return []; } },
+  );
+  if (pinnedUrl === 'https://api.lever.co/v0/postings/coalfire') {
+    pass('lever.fetch() honors a pinned api: over a non-lever careers_url');
+  } else {
+    fail(`lever.fetch() pinned api: requested ${JSON.stringify(pinnedUrl)}`);
+  }
+
+  // fetch() — an untrusted api: host throws before any request (SSRF guard).
+  let evilFetchCalled = false;
+  try {
+    await lever.fetch(
+      { name: 'Evil', api: 'https://evil.example/v0/postings/acme' },
+      { fetchJson: async () => { evilFetchCalled = true; return []; } },
+    );
+    fail('lever.fetch() should throw for an untrusted api: host');
+  } catch (e) {
+    if (!evilFetchCalled && /untrusted hostname/.test(e.message)) {
+      pass('lever.fetch() rejects an untrusted api: host before fetching');
+    } else {
+      fail(`lever.fetch() untrusted api: fetchCalled=${evilFetchCalled}, error=${e.message}`);
+    }
+  }
 
   // Underivable entry → typed error before any request.
   try {


### PR DESCRIPTION
## Summary
- `providers/ashby.mjs` and `providers/lever.mjs` only derive their API endpoint by regex-matching the ATS's own domain out of `careers_url` (`jobs.ashbyhq.com/<slug>`, `jobs.lever.co/<slug>`). An entry that intentionally keeps a human-facing corporate `careers_url` (e.g. `openai.com/careers`, `coalfire.com/careers`) can never resolve — even though `providers/_types.js` already documents `api` as "used directly by greenhouse/ashby providers", which isn't true for ashby today.
- `greenhouse.mjs` and (as of #1676) `workday.mjs` already support an explicit `api:` override that takes precedence over `careers_url` parsing, guarded by an HTTPS + hostname-allowlist check against SSRF via a malicious `api:` value. This PR brings `ashby.mjs` and `lever.mjs` up to the same pattern, so `api:` behaves consistently across all four ATS providers.
- Adds `detect()`/`fetch()` tests to both provider test files mirroring `greenhouse.test.mjs`'s existing `api:` coverage: precedence over `careers_url`, untrusted-host rejection, non-HTTPS rejection, malformed-URL rejection.

## Test plan
- [x] `node tests/providers/ashby.test.mjs` — all pass, including new `api:` cases
- [x] `node tests/providers/lever.test.mjs` — all pass, including new `api:` cases
- [x] `node tests/providers/ats-ssrf-hardening.test.mjs` — still passes
- [x] `node test-all.mjs` — 1562 passed, 0 failed, 3 pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job source detection and fetching for two providers by safely handling custom API links.
  * Added stricter validation for API URLs so only secure, trusted endpoints are used.
  * Invalid or malformed links now fail gracefully during detection instead of causing crashes.
  * Fetching now stops before making a request if a link is untrusted, reducing unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->