### PR TITLE
fix(pdf): render markdown bold in CV summary as <strong>

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -97,6 +97,11 @@ function normalizeTextForATS(html) {
     // wrong for half of users \u2014 better to leave the glyph than emit bad data.
     t = t.replace(/\u20AC/g, () => { bump('euro', 1); return 'EUR '; });
     t = t.replace(/\u00A3/g, () => { bump('pound', 1); return 'GBP '; });
+    // Markdown bold from tailored CV builders (SUMMARY_TEXT uses **…**).
+    t = t.replace(/\*\*([^*]+?)\*\*/g, (_, inner) => {
+      bump('markdown-bold', 1);
+      return `<strong>${inner}</strong>`;
+    });
     return t;
   }
 }

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -136,6 +136,11 @@
     color: #2f2f2f;
   }
 
+  .summary-text strong {
+    font-weight: 700;
+    color: #1a1a1a;
+  }
+
   /* Links must never break across lines */
   a {
     white-space: nowrap;


### PR DESCRIPTION
## Summary
- Convert markdown bold (`**text**`) in CV HTML to `<strong>` tags during ATS normalization in `generate-pdf.mjs`
- Add `.summary-text strong` CSS so tailored summary emphasis renders correctly in PDF output instead of literal asterisks

## Test plan
- [ ] Run `node generate-pdf.mjs` on HTML with `**bold**` in the summary section
- [ ] Confirm the generated PDF shows bold text, not literal `**` asterisks


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bold text in CV content is now preserved and displayed more consistently in generated PDFs.
  * Markup-style bold formatting is converted into proper bold styling, improving readability in the final document.
  * Text normalization continues to work as before, with an added count for this formatting conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->