### PR TITLE
feat(img-to-pdf): convert a screenshot into a PDF for ATS uploads

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -12,6 +12,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run dedup` | `dedup-tracker.mjs` | Remove duplicate tracker entries |
 | `npm run merge` | `merge-tracker.mjs` | Merge batch TSVs into applications.md |
 | `npm run pdf` | `generate-pdf.mjs` | Convert HTML to ATS-optimized PDF |
+| `npm run img-to-pdf` | `img-to-pdf.mjs` | Convert a single screenshot/image into a single-page PDF |
 | `npm run build:latex` | `build-cv-latex.mjs` | Build .tex from structured JSON payload |
 | `npm run sync-check` | `cv-sync-check.mjs` | Validate CV/profile consistency |
 | `npm run patterns` | `analyze-patterns.mjs` | Analyze tracker outcomes and report patterns |
@@ -128,6 +129,22 @@ npm run pdf -- input.html output.pdf --format=a4        # A4 (default)
 ```
 
 **Exit codes:** `0` PDF generated, `1` missing arguments or generation failure.
+
+---
+
+## img-to-pdf
+
+Converts a single screenshot or image (PNG, JPEG, GIF, WEBP, BMP, SVG) into a single-page PDF via headless Chromium — for ATS upload fields that require a PDF specifically and reject images. Embeds the image as a base64 `data:` URI in a minimal HTML page and renders it with `page.pdf()`, sized to the image's own pixel dimensions so the page is neither cropped nor padded. Zero new dependencies — reuses the `playwright` dependency `generate-pdf.mjs` already uses, and is a deliberately standalone script: it does not go through `generate-pdf.mjs`, so it is never subject to that script's cv.md section-order validation.
+
+```bash
+npm run img-to-pdf -- screenshot.png output.pdf
+npm run img-to-pdf -- screenshot.png output.pdf --force   # overwrite an existing output file
+node img-to-pdf.mjs --self-test
+```
+
+MVP scope: one image in, one PDF page out. Multi-image/multi-page conversion is not implemented.
+
+**Exit codes:** `0` PDF generated, `1` missing arguments, unsupported image type, missing input file, existing output without `--force`, or generation failure.
 
 ---
 

--- a/img-to-pdf.mjs
+++ b/img-to-pdf.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+/**
+ * img-to-pdf.mjs — Screenshot/image -> single-page PDF via Playwright
+ *
+ * Some ATS upload fields demand a PDF specifically and reject images
+ * (screenshots of an offer, a portal error, a badge, etc). This wraps
+ * the image in a minimal HTML page and renders it with the same
+ * Playwright/Chromium engine generate-pdf.mjs already uses for CVs —
+ * zero new npm dependencies.
+ *
+ * Deliberately standalone: it does NOT go through generate-pdf.mjs, so
+ * it is never subject to that script's cv.md section-order validation
+ * (which only makes sense for the CV HTML template).
+ *
+ * MVP scope: one image -> one PDF page. Multi-image/multi-page is an
+ * explicit non-goal for v1 (see issue #1730).
+ *
+ * Usage:
+ *   node img-to-pdf.mjs <image-path> <output-path> [--force]
+ *   node img-to-pdf.mjs --self-test
+ *
+ * --force is required to overwrite an existing output file; without it
+ * the script errors out rather than silently clobbering a PDF.
+ */
+
+import { chromium } from 'playwright';
+import { resolve, dirname, extname } from 'path';
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const MIME_TYPES = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.svg': 'image/svg+xml',
+};
+
+/**
+ * @param {string} imagePath
+ * @returns {string|null} MIME type, or null if the extension is unsupported.
+ */
+export function detectMimeType(imagePath) {
+  const ext = extname(imagePath).toLowerCase();
+  return MIME_TYPES[ext] || null;
+}
+
+/**
+ * Parse CLI args into { inputPath, outputPath, force, help, error }.
+ * Pure and side-effect free so it's testable without touching the filesystem.
+ *
+ * @param {string[]} args
+ */
+export function parseArgs(args) {
+  let inputPath = '';
+  let outputPath = '';
+  let force = false;
+  let help = false;
+
+  for (const arg of args) {
+    if (arg === '--force') {
+      force = true;
+    } else if (arg === '--help' || arg === '-h') {
+      help = true;
+    } else if (!inputPath) {
+      inputPath = arg;
+    } else if (!outputPath) {
+      outputPath = arg;
+    }
+  }
+
+  if (help) return { inputPath, outputPath, force, help, error: null };
+  if (!inputPath || !outputPath) {
+    return { inputPath, outputPath, force, help, error: 'Missing <image-path> and/or <output-path>.' };
+  }
+  return { inputPath, outputPath, force, help, error: null };
+}
+
+function usage() {
+  console.log('Usage: node img-to-pdf.mjs <image-path> <output-path> [--force]');
+  console.log('');
+  console.log('Converts a single screenshot/image into a single-page PDF (Playwright/Chromium),');
+  console.log('for ATS upload fields that require a PDF specifically. Zero new dependencies —');
+  console.log('reuses the playwright dependency already used by generate-pdf.mjs.');
+  console.log('');
+  console.log('  --force   overwrite <output-path> if it already exists');
+  console.log('');
+  console.log('MVP scope: one image in, one PDF page out. Multi-image/multi-page is not supported.');
+}
+
+/**
+ * Render a single image file to a single-page PDF matching the image's own
+ * pixel dimensions (at 96 CSS px/inch), so the output is neither cropped
+ * nor padded with blank margins.
+ *
+ * @param {string} inputPath - Absolute path to the source image.
+ * @param {string} outputPath - Absolute path to write the PDF to.
+ * @returns {Promise<{outputPath: string, size: number, width: number, height: number}>}
+ */
+export async function convertImageToPdf(inputPath, outputPath) {
+  const mimeType = detectMimeType(inputPath);
+  if (!mimeType) {
+    throw new Error(`Unsupported image type: ${extname(inputPath) || '(no extension)'}. Supported: ${Object.keys(MIME_TYPES).join(', ')}`);
+  }
+
+  const buffer = await readFile(inputPath);
+  const base64 = buffer.toString('base64');
+  const html = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; }
+  html, body { margin: 0; padding: 0; }
+  img { display: block; }
+</style>
+</head>
+<body>
+<img id="career-ops-img" src="data:${mimeType};base64,${base64}">
+</body>
+</html>`;
+
+  await mkdir(dirname(outputPath), { recursive: true });
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'load' });
+
+    await page.waitForFunction(() => {
+      const img = document.getElementById('career-ops-img');
+      return !!img && img.complete && img.naturalWidth > 0;
+    });
+
+    const { width, height } = await page.evaluate(() => {
+      const img = document.getElementById('career-ops-img');
+      return { width: img.naturalWidth, height: img.naturalHeight };
+    });
+
+    // 96 CSS px per inch is the standard browser/Playwright conversion —
+    // sizing the PDF page to the image's own dimensions means the image
+    // fills the page exactly: no cropping, no blank margins.
+    const widthIn = width / 96;
+    const heightIn = height / 96;
+
+    const pdfBuffer = await page.pdf({
+      width: `${widthIn}in`,
+      height: `${heightIn}in`,
+      margin: { top: '0', right: '0', bottom: '0', left: '0' },
+      printBackground: true,
+    });
+
+    await writeFile(outputPath, pdfBuffer);
+
+    return { outputPath, size: pdfBuffer.length, width, height };
+  } finally {
+    await browser.close();
+  }
+}
+
+function selfTest() {
+  const assert = (cond, msg) => {
+    if (!cond) { console.error(`SELF-TEST FAIL: ${msg}`); process.exit(1); }
+  };
+
+  // detectMimeType
+  assert(detectMimeType('screenshot.png') === 'image/png', 'png detected');
+  assert(detectMimeType('a/b/c.JPG') === 'image/jpeg', 'uppercase JPG detected');
+  assert(detectMimeType('x.jpeg') === 'image/jpeg', 'jpeg detected');
+  assert(detectMimeType('x.gif') === 'image/gif', 'gif detected');
+  assert(detectMimeType('x.webp') === 'image/webp', 'webp detected');
+  assert(detectMimeType('x.bmp') === 'image/bmp', 'bmp detected');
+  assert(detectMimeType('x.svg') === 'image/svg+xml', 'svg detected');
+  assert(detectMimeType('x.pdf') === null, 'unsupported extension -> null');
+  assert(detectMimeType('noext') === null, 'no extension -> null');
+
+  // parseArgs
+  const a1 = parseArgs(['in.png', 'out.pdf']);
+  assert(a1.inputPath === 'in.png' && a1.outputPath === 'out.pdf' && a1.force === false && a1.error === null, 'basic positional args');
+
+  const a2 = parseArgs(['in.png', 'out.pdf', '--force']);
+  assert(a2.force === true && a2.error === null, '--force flag parsed');
+
+  const a3 = parseArgs(['--force', 'in.png', 'out.pdf']);
+  assert(a3.inputPath === 'in.png' && a3.outputPath === 'out.pdf' && a3.force === true, '--force before positionals still parses correctly');
+
+  const a4 = parseArgs(['in.png']);
+  assert(a4.error !== null, 'missing output-path -> error');
+
+  const a5 = parseArgs([]);
+  assert(a5.error !== null, 'no args -> error');
+
+  const a6 = parseArgs(['--help']);
+  assert(a6.help === true && a6.error === null, '--help short-circuits missing-arg validation');
+
+  console.log('img-to-pdf self-test OK (mime detection + arg parsing)');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--self-test')) {
+    selfTest();
+    return;
+  }
+
+  const parsed = parseArgs(args);
+
+  if (parsed.help) {
+    usage();
+    return;
+  }
+
+  if (parsed.error) {
+    console.error(`❌ ${parsed.error}`);
+    usage();
+    process.exit(1);
+  }
+
+  const inputPath = resolve(parsed.inputPath);
+  const outputPath = resolve(parsed.outputPath);
+
+  if (!existsSync(inputPath)) {
+    console.error(`❌ Image not found: ${inputPath}`);
+    process.exit(1);
+  }
+
+  if (existsSync(outputPath) && !parsed.force) {
+    console.error(`❌ Output already exists: ${outputPath}`);
+    console.error('   Pass --force to overwrite it.');
+    process.exit(1);
+  }
+
+  console.log(`🖼️  Input:  ${inputPath}`);
+  console.log(`📁 Output: ${outputPath}`);
+
+  try {
+    const result = await convertImageToPdf(inputPath, outputPath);
+    console.log(`✅ PDF generated: ${result.outputPath}`);
+    console.log(`📐 Page size: ${result.width}x${result.height}px`);
+    console.log(`📦 Size: ${(result.size / 1024).toFixed(1)} KB`);
+  } catch (err) {
+    console.error(`❌ Conversion failed: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (isMain) {
+  main();
+}

--- a/img-to-pdf.mjs
+++ b/img-to-pdf.mjs
@@ -131,10 +131,14 @@ export async function convertImageToPdf(inputPath, outputPath) {
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: 'load' });
 
-    await page.waitForFunction(() => {
-      const img = document.getElementById('career-ops-img');
-      return !!img && img.complete && img.naturalWidth > 0;
-    });
+    try {
+      await page.waitForFunction(() => {
+        const img = document.getElementById('career-ops-img');
+        return !!img && img.complete && img.naturalWidth > 0 && img.naturalHeight > 0;
+      }, { timeout: 10000 });
+    } catch (err) {
+      throw new Error(`Image failed to decode within 10s (unreadable or corrupt file?): ${inputPath}`);
+    }
 
     const { width, height } = await page.evaluate(() => {
       const img = document.getElementById('career-ops-img');

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "merge": "node merge-tracker.mjs",
     "reconcile": "node reconcile-pipeline.mjs",
     "pdf": "node generate-pdf.mjs",
+    "img-to-pdf": "node img-to-pdf.mjs",
     "cover-letter": "node generate-cover-letter.mjs --payload",
     "cv:verify-facts": "node verify-cv-facts.mjs",
     "sync-check": "node cv-sync-check.mjs",

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -131,6 +131,7 @@ const scripts = [
   { name: 'process-quality.mjs --self-test', expectExit: 0 },
   { name: 'salary-gap.mjs --self-test', expectExit: 0 },
   { name: 'funnel-velocity.mjs --self-test', expectExit: 0 },
+  { name: 'img-to-pdf.mjs --self-test', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
   { name: 'agent-inbox-tests.mjs', expectExit: 0 },

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -129,6 +129,7 @@ const SYSTEM_PATHS = [
   'patch-latex-content.mjs',
   'lib/latex-escape.mjs',
   'lib/latex-content.mjs',
+  'img-to-pdf.mjs',
   'archive-posting.mjs',
   'application-answers.mjs',
   'generate-cover-letter.mjs',


### PR DESCRIPTION
## Summary
- Adds `img-to-pdf.mjs <image-path> <output-path> [--force]` — converts a single image (PNG/JPEG/GIF/WEBP/BMP/SVG) into a single-page PDF, for ATS upload fields that require a PDF specifically and reject images.
- Zero new npm dependencies — reuses the `playwright` dependency `generate-pdf.mjs` already uses. Embeds the image as a base64 `<img>` in a minimal HTML page and calls `page.pdf()`, sized to the image's own pixel dimensions so the page is neither cropped nor padded.
- Deliberately standalone from `generate-pdf.mjs`: it does not go through that script's cv.md section-order validation, which only makes sense for the CV HTML template.
- MVP scope only: single image → single-page PDF. Multi-image/multi-page support is out of scope for v1 (mentioned in the issue only as a stretch goal).
- Never silently overwrites an existing output file — requires an explicit `--force` flag.
- Registered per the existing conventions: `update-system.mjs` `SYSTEM_PATHS`, `package.json` (`npm run img-to-pdf`), `docs/SCRIPTS.md`, and `test-all.mjs` (`--self-test`), matching how `salary-gap.mjs`/`detect-reposts.mjs` are wired up.

Closes #1730

## Test plan
- [x] `node img-to-pdf.mjs --self-test` (mime detection + arg parsing)
- [x] `node validate-system-paths-coverage.mjs` — new file covered
- [x] End-to-end manual run: converted a 1x1 PNG to a PDF, confirmed the overwrite guard rejects a re-run without `--force` and succeeds with `--force`
- [x] `node test-all.mjs --quick` — full suite green (1554 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `img-to-pdf` command-line tool to convert a single image (PNG, JPEG, GIF, WEBP, BMP, SVG) into a one-page PDF sized to match the image.
  * Added overwrite control (`--force`) and a `--self-test` mode.
* **Documentation**
  * Updated the scripts guide with usage details, supported formats, and documented exit-code behavior.
* **Tests**
  * Extended the automated script runner to execute `img-to-pdf --self-test`.
* **Chores**
  * Added the `img-to-pdf` npm script and included it in the system update allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->