### PR TITLE
fix(liveness): treat off-posting redirects as uncertain, not active

### DIFF
--- a/liveness-browser.mjs
+++ b/liveness-browser.mjs
@@ -173,7 +173,7 @@ export async function checkUrlLiveness(page, url, { extraSettleMs = 0 } = {}) {
         .filter(Boolean);
     });
 
-    return classifyLiveness({ status, finalUrl, bodyText, applyControls });
+    return classifyLiveness({ status, requestedUrl: url, finalUrl, bodyText, applyControls });
   } catch (err) {
     // Transient failures (timeout, DNS, TLS, 5xx) shouldn't be treated as expired —
     // doing so would cause scan --verify to drop the URL and write it to scan-history,

--- a/liveness-core.mjs
+++ b/liveness-core.mjs
@@ -62,6 +62,16 @@ const APPLY_PATTERNS = [
 
 const MIN_CONTENT_CHARS = 300;
 
+// A job-detail URL almost always carries the posting's identity: a numeric req id
+// (Greenhouse, Workday pid, Microsoft) or a UUID (Lever, Ashby). If the requested
+// URL had one and the final URL lost it, the browser landed somewhere else.
+const JOB_ID_TOKEN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|\d{5,}/gi;
+
+function jobIdToken(url = '') {
+  const matches = url.match(JOB_ID_TOKEN);
+  return matches ? matches[matches.length - 1].toLowerCase() : null;
+}
+
 function firstMatch(patterns, text = '') {
   return patterns.find((pattern) => pattern.test(text));
 }
@@ -70,7 +80,7 @@ function hasApplyControl(controls = []) {
   return controls.some((control) => APPLY_PATTERNS.some((pattern) => pattern.test(control)));
 }
 
-export function classifyLiveness({ status = 0, finalUrl = '', bodyText = '', applyControls = [] } = {}) {
+export function classifyLiveness({ status = 0, requestedUrl = '', finalUrl = '', bodyText = '', applyControls = [] } = {}) {
   if (status === 404 || status === 410) {
     return { result: 'expired', code: 'http_gone', reason: `HTTP ${status}` };
   }
@@ -95,6 +105,22 @@ export function classifyLiveness({ status = 0, finalUrl = '', bodyText = '', app
   const expiredBody = firstMatch(HARD_EXPIRED_PATTERNS, bodyText);
   if (expiredBody) {
     return { result: 'expired', code: 'expired_body', reason: `pattern matched: ${expiredBody.source}` };
+  }
+
+  // A dead permalink that 301s to a generic search/listing page still shows
+  // "Apply" buttons — on OTHER jobs' cards (seen when jobs.careers.microsoft.com
+  // permalinks migrated to apply.careers.microsoft.com). When the requested URL
+  // carried a job identifier and the final URL lost it, the page being read is
+  // not the posting, so apply controls are not evidence of liveness. Uncertain,
+  // not expired: a portal migration can 301 live postings too, and a false
+  // "expired" permanently filters a real job out of scans.
+  const jobId = jobIdToken(requestedUrl);
+  if (jobId && finalUrl && !finalUrl.toLowerCase().includes(jobId)) {
+    return {
+      result: 'uncertain',
+      code: 'redirected_off_posting',
+      reason: `redirected to ${finalUrl} — job id "${jobId}" missing from final URL`,
+    };
   }
 
   if (hasApplyControl(applyControls)) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -253,6 +253,32 @@ try {
     fail(`Polish apply control not recognized: ${activePolishPosting.result} (${activePolishPosting.code})`);
   }
 
+  const redirectedOffPosting = classifyLiveness({
+    status: 200,
+    requestedUrl: 'https://jobs.careers.microsoft.com/professionals/us/en/job/1399802/Intune-Support-Engineer',
+    finalUrl: 'https://apply.careers.microsoft.com/careers?start=0&sort_by=timestamp',
+    bodyText: 'Search jobs. Partner Marketing Manager. Software Engineer II. Browse all open positions at Microsoft. '.repeat(6),
+    applyControls: ['Apply now', 'Apply now', 'Apply now'],
+  });
+  if (redirectedOffPosting.result === 'uncertain' && redirectedOffPosting.code === 'redirected_off_posting') {
+    pass('Dead permalink 301 to a generic listing is uncertain, not revived by other jobs\' Apply buttons');
+  } else {
+    fail(`Off-posting redirect misclassified as ${redirectedOffPosting.result} (${redirectedOffPosting.code})`);
+  }
+
+  const redirectKeepingJobId = classifyLiveness({
+    status: 200,
+    requestedUrl: 'https://boards.greenhouse.io/acme/jobs/4567890',
+    finalUrl: 'https://job-boards.greenhouse.io/acme/jobs/4567890',
+    bodyText: 'Senior AI Engineer. Own delivery across evaluation, deployment, and reliability at Acme. '.repeat(6),
+    applyControls: ['Apply for this Job'],
+  });
+  if (redirectKeepingJobId.result === 'active') {
+    pass('Redirect that keeps the job id (board migration) still classifies active');
+  } else {
+    fail(`Same-job redirect misclassified as ${redirectKeepingJobId.result} (${redirectKeepingJobId.code})`);
+  }
+
   // Liveness API rung (liveness-api.mjs) — the zero-token ATS first rung. We test the
   // pure URL→API resolution + SSRF guard; the network fetch is conservative by
   // construction (only 404/410→expired, 200→active, else null→Playwright fallback).


### PR DESCRIPTION
## Bug

`classifyLiveness()` checks `hasApplyControl()` before considering where a redirect landed. A dead job permalink that 301s to a generic search/listing page still renders "Apply" buttons — on **other jobs' cards** — so the dead posting classifies as `active` (`apply_control_visible`).

## Real-world reproduction

Microsoft migrated its careers portal: every legacy `jobs.careers.microsoft.com/.../job/{id}/...` permalink now 301s to `apply.careers.microsoft.com/careers?...`, a generic "latest jobs" listing. Example:

```
node check-liveness.mjs "https://jobs.careers.microsoft.com/professionals/us/en/job/1399802/Intune-Support-Engineer"
→ ✅ active   (false positive — the Apply buttons belong to unrelated postings on the landing page)
```

Same result for sibling reqs 1663687 and 1733321. Downstream, the pipeline treats a dead posting as verified-active and a worker starts evaluating phantom content.

## Fix

Pass the requested URL into `classifyLiveness()`. When it carried a job identifier (numeric req id or UUID) that is **missing from the final URL**, the page being read is not the posting, so apply controls are not evidence. New verdict: `uncertain` / `redirected_off_posting`.

Design choices, matching the existing philosophy that a false "expired" is worse than a slow check:

- **`uncertain`, not `expired`** — a portal migration can 301 live postings too; `uncertain` defers to per-URL extraction instead of permanently filtering the job out of scans via scan-history.
- **Guard sits after the hard-expired checks** — `?error=true` redirects and "no longer available" banners still win as definitive `expired`.
- **Conservative scope** — redirects that keep the job id (e.g. `boards.greenhouse.io` → `job-boards.greenhouse.io`) are unaffected; URLs with no extractable id (short Workday R-numbers like `R-2026-3722`) skip the guard entirely, behavior unchanged.

## Tests

Two new cases in `test-all.mjs` §3 (Liveness classification):
- dead permalink 301 → generic listing with other jobs' Apply buttons ⇒ `uncertain` / `redirected_off_posting`
- redirect that keeps the job id + visible apply control ⇒ still `active`

Full suite: 1555 passed, 0 failed.

Note: filed as PR-direct rather than issue-first — happy to open a tracking issue if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved liveness checks to better detect when a link redirects away from the original posting.
  * URLs that land on a different page now return a more cautious status instead of being misclassified.
  * Redirects that keep the original job identifier continue to be treated normally.
* **Tests**
  * Added coverage for redirect scenarios to verify both off-posting redirects and valid job-page redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->