### PR TITLE
fix(tracker): keep reserved report numbers when free + set-status report-link sanity check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `data/scan-runs.tsv` | Per-run scan counters (appended by `scan.mjs`, read by `stats.mjs`) |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON output) |
-| `set-status.mjs` | Canonical CLI to update a tracker row: `node set-status.mjs <report#\|company> <State> [--note]` — strict states.yml validation, shared tracker lock, atomic write |
+| `set-status.mjs` | Canonical CLI to update a tracker row: `node set-status.mjs <report#\|company> <State> [--note]` — strict states.yml validation, shared tracker lock, atomic write. A numeric selector is cross-checked against the row's Report link (drifted row numbers, #1733) and refuses to write on mismatch unless `--force` is passed |
 | `invite-match.mjs` | Fuzzy-matches a pasted interview-invite email (company name, date, req ID) against `data/applications.md`, ranking candidates when a company has multiple tracker entries (JSON or `--summary` table output) |
 | `detect-reposts.mjs` | Repost detector — flags roles re-listed 2+ times in 90 days from scan-history.tsv (JSON or `--summary` table output) |
 | `process-quality.mjs` | Recruiting-process friction aggregator — parses `[process-friction]` tags candidates add to `data/active-interviews.md` Notes and reports per-company friction rate (JSON or `--summary` table output) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ AI-powered job search automation built on Claude Code: pipeline tracking, offer 
 | `data/scan-runs.tsv` | Per-run scan counters (appended by `scan.mjs`, read by `stats.mjs`) |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON output) |
-| `set-status.mjs` | Canonical CLI to update a tracker row: `node set-status.mjs <report#\|company> <State> [--note]` — strict states.yml validation, shared tracker lock, atomic write |
+| `set-status.mjs` | Canonical CLI to update a tracker row: `node set-status.mjs <report#\|company> <State> [--note]` — strict states.yml validation, shared tracker lock, atomic write. A numeric selector is cross-checked against the row's Report link (drifted row numbers, #1733) and refuses to write on mismatch unless `--force` is passed |
 | `salary-gap.mjs` | Desired/advertised/actual compensation gap analyzer — folds report `advertised_comp` + `data/salary-observations.tsv` (JSON or `--summary`) |
 | `data/salary-observations.tsv` | Append-only salary observation log (user layer) |
 | `data/follow-ups.md` | Follow-up history tracker |

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -477,6 +477,29 @@ for (const line of appLines) {
   }
 }
 
+// Full set of numbers already on the tracker (#1704). This is a separate,
+// deliberately narrower pass than the existingApps loop above: it reads only
+// the numeric # cell and skips a row via the same NaN check verify-pipeline.mjs
+// uses, instead of the `.includes('---') / .includes('Empresa')` heuristic —
+// so a company or role field that happens to CONTAIN "Empresa" or "---" (e.g.
+// a Spanish-market company name, or an em-dash-style separator in a title)
+// can't hide that row's number the way it can hide the row from existingApps
+// (which stays as-is; it drives duplicate detection, not numbering). Used
+// below so a new entry's number is checked against every number actually on
+// the tracker, not just the largest one the existingApps loop happened to see.
+const usedNumbers = new Set();
+const MAX_COL_IDX = Math.max(...Object.values(COLMAP));
+for (const line of appLines) {
+  if (!line.startsWith('|')) continue;
+  const parts = line.split('|').map(s => s.trim());
+  if (parts.length <= MAX_COL_IDX) continue;
+  const n = parseInt(parts[COLMAP.num]);
+  if (!isNaN(n) && n !== 0) {
+    usedNumbers.add(n);
+    if (n > maxNum) maxNum = n;
+  }
+}
+
 console.log(`📊 Existing: ${existingApps.length} entries, max #${maxNum}`);
 
 // Read tracker additions
@@ -610,9 +633,24 @@ for (const file of tsvFiles) {
       skipped++;
     }
   } else {
-    // New entry — use the number from the TSV
-    const entryNum = addition.num > maxNum ? addition.num : ++maxNum;
-    if (addition.num > maxNum) maxNum = addition.num;
+    // New entry — trust the TSV's own number only when it is BOTH ahead of
+    // this run's max AND not already claimed by any row on the tracker.
+    // `addition.num > maxNum` alone is not proof the number is free: a stale,
+    // precomputed number (e.g. carried by a batch worker's TSV that sat
+    // unmerged while other unrelated evaluations were merged in the
+    // meantime) can still collide with a row already on the tracker even
+    // though it's numerically ahead of a naive maxNum snapshot (#1704).
+    // usedNumbers already includes every number this run has assigned so
+    // far (added below), so same-run collisions are covered too.
+    let entryNum;
+    if (addition.num > maxNum && !usedNumbers.has(addition.num)) {
+      entryNum = addition.num;
+    } else {
+      entryNum = maxNum + 1;
+      while (usedNumbers.has(entryNum)) entryNum++;
+    }
+    usedNumbers.add(entryNum);
+    if (entryNum > maxNum) maxNum = entryNum;
 
     const newLine = buildRow({
       num: entryNum, date: addition.date, company: addition.company, role: addition.role,

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -633,23 +633,36 @@ for (const file of tsvFiles) {
       skipped++;
     }
   } else {
-    // New entry — trust the TSV's own number only when it is BOTH ahead of
-    // this run's max AND not already claimed by any row on the tracker.
-    // `addition.num > maxNum` alone is not proof the number is free: a stale,
-    // precomputed number (e.g. carried by a batch worker's TSV that sat
-    // unmerged while other unrelated evaluations were merged in the
-    // meantime) can still collide with a row already on the tracker even
-    // though it's numerically ahead of a naive maxNum snapshot (#1704).
-    // usedNumbers already includes every number this run has assigned so
-    // far (added below), so same-run collisions are covered too.
+    // New entry — keep the TSV's own reserved number whenever it is free.
+    // Report numbers come from reserve-report-num.mjs (counts off reports/),
+    // while maxNum comes from the tracker's own rows — two independent
+    // counters. A reserved number <= maxNum is therefore the COMMON case,
+    // not an anomaly, and silently replacing it with ++maxNum permanently
+    // diverges the tracker row # from the number embedded in the report
+    // file (filename + Machine Summary), which then makes
+    // `set-status.mjs <report#>` edit the wrong row (#1733, field report
+    // in #1704). So: trust addition.num as long as it's a valid positive
+    // integer AND not already claimed by any tracker row or by an earlier
+    // addition in this same run (usedNumbers covers both, per #1704).
+    // Only fall back to fresh max-based assignment when the number is
+    // genuinely taken — and warn loudly, because from that point the row #
+    // no longer matches the report file's number.
+    const reservedNum = Number.isInteger(addition.num) && addition.num > 0
+      ? addition.num : null;
     let entryNum;
-    if (addition.num > maxNum && !usedNumbers.has(addition.num)) {
-      entryNum = addition.num;
+    if (reservedNum !== null && !usedNumbers.has(reservedNum)) {
+      entryNum = reservedNum;
     } else {
       entryNum = maxNum + 1;
       while (usedNumbers.has(entryNum)) entryNum++;
+      if (reservedNum !== null) {
+        console.warn(`⚠️  Reserved #${reservedNum} already used by another tracker row — assigned #${entryNum} to ${addition.company} — ${addition.role} instead. Tracker row # no longer matches the report file's number (reports/${String(reservedNum).padStart(3, '0')}-...); fix the report link/number manually if needed.`);
+      }
     }
     usedNumbers.add(entryNum);
+    // maxNum must never go backwards: keeping a low reserved number (e.g.
+    // #415 while max is #417) must not make a later number-less addition
+    // land on #416 twice.
     if (entryNum > maxNum) maxNum = entryNum;
 
     const newLine = buildRow({

--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -86,6 +86,18 @@ const TRACKER_10 = `# Applications Tracker
 | 1 | 2026-06-01 | Initech | AI Engineer | Remote | 4.5/5 | Evaluated | ✅ | [1](../reports/001-initech-2026-06-01.md) | — |
 `;
 
+// Two unrelated rows share tracker number 5 (the #1704 bug: merge-tracker.mjs
+// once trusted a stale TSV number as-is when it was numerically ahead of that
+// run's max, even though the number was already used by an unrelated row
+// merged in a separate, earlier invocation).
+const TRACKER_DUP_NUM = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 5 | 2026-05-29 | University of Alberta | Curriculum Coordinator | 3.8/5 | Evaluated | ❌ | — | — |
+| 5 | 2026-06-03 | Esri Canada | Manager Talent and Organizational Development | 4.1/5 | Evaluated | ❌ | — | — |
+`;
+
 // ── 1. Update by report number ──────────────────────────────────
 {
   const sb = makeSandbox(TRACKER_9);
@@ -173,6 +185,49 @@ const TRACKER_10 = `# Applications Tracker
     pass('ambiguous: --role disambiguates to the right row');
   } else {
     fail(`ambiguous --role: code=${r2.code}\n${r2.stdout}${r2.stderr}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 6b. Duplicate tracker #: bare number refuses to guess (#1704) ─
+{
+  const sb = makeSandbox(TRACKER_DUP_NUM);
+  const before = readTracker(sb);
+  const r = runSetStatus(['5', 'Rejected'], sb);
+  if (r.code === 3 && readTracker(sb) === before
+      && r.stderr.includes('University of Alberta') && r.stderr.includes('Esri Canada')) {
+    pass('dup-num: bare #5 matching 2 rows exits 3, tracker untouched, both companies listed');
+  } else {
+    fail(`dup-num: code=${r.code} (want 3)\n${r.stdout}${r.stderr}`);
+  }
+  // --role disambiguates exactly like the company-selector ambiguous path.
+  const r2 = runSetStatus(['5', 'Rejected', '--role', 'Manager Talent and Organizational Development'], sb);
+  if (r2.code === 0 && /\| 5 \| 2026-06-03 \| Esri Canada \|.*\| Rejected \|/.test(readTracker(sb))) {
+    pass('dup-num: --role disambiguates to the right row');
+  } else {
+    fail(`dup-num --role: code=${r2.code}\n${r2.stdout}${r2.stderr}`);
+  }
+  // The OTHER row (University of Alberta) must stay untouched by the --role
+  // disambiguated write above.
+  if (readTracker(sb).includes('| 5 | 2026-05-29 | University of Alberta | Curriculum Coordinator | 3.8/5 | Evaluated |')) {
+    pass('dup-num: unrelated row with the same # untouched after disambiguation');
+  } else {
+    fail(`dup-num: unrelated row was modified\n${readTracker(sb)}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 6c. Duplicate tracker # + --json: structured candidates ─────
+{
+  const sb = makeSandbox(TRACKER_DUP_NUM);
+  const r = runSetStatus(['5', 'Rejected', '--json'], sb);
+  let parsed = null;
+  try { parsed = JSON.parse(r.stdout || r.stderr); } catch {}
+  if (r.code === 3 && parsed && parsed.code === 'ambiguous' && Array.isArray(parsed.candidates)
+      && parsed.candidates.length === 2) {
+    pass('dup-num json: structured ambiguous error with 2 candidates');
+  } else {
+    fail(`dup-num json: code=${r.code}\n${r.stdout}${r.stderr}`);
   }
   rmSync(sb.dir, { recursive: true, force: true });
 }

--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -232,6 +232,58 @@ const TRACKER_DUP_NUM = `# Applications Tracker
   rmSync(sb.dir, { recursive: true, force: true });
 }
 
+// ── 6d. Report-link mismatch: numeric selector blocked without --force (#1733) ─
+// merge-tracker.mjs once silently renumbered additions whose reserved report
+// number was <= the tracker max, leaving rows whose # disagrees with the
+// number embedded in their own Report link. Row #5 below "looks" fine to a
+// bare-number selector — exactly one match — but its Report column points to
+// reports/415-..., so `set-status 5` may well be targeting the wrong row.
+const TRACKER_DRIFTED = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 5 | 2026-07-09 | HPE | CloudOps Engineer | 4.1/5 | Evaluated | ❌ | [415](../reports/415-hpe-cloudops-2026-07-09.md) | drifted row |
+`;
+{
+  const sb = makeSandbox(TRACKER_DRIFTED);
+  const before = readTracker(sb);
+  const r = runSetStatus(['5', 'Applied'], sb);
+  if (r.code === 3 && readTracker(sb) === before
+      && r.stderr.includes('reports/415-') && r.stderr.includes('--force')) {
+    pass('report-link mismatch: #5 vs reports/415-... blocked (exit 3), tracker untouched, --force suggested');
+  } else {
+    fail(`report-link mismatch: code=${r.code} (want 3)\n${r.stdout}${r.stderr}`);
+  }
+  // --json carries the structured drift payload.
+  const rj = runSetStatus(['5', 'Applied', '--json'], sb);
+  let parsedDrift = null;
+  try { parsedDrift = JSON.parse(rj.stdout || rj.stderr); } catch {}
+  if (rj.code === 3 && parsedDrift && parsedDrift.code === 'report-link-mismatch'
+      && parsedDrift.rowNum === 5 && parsedDrift.linkedReportNum === 415) {
+    pass('report-link mismatch json: structured error with rowNum/linkedReportNum');
+  } else {
+    fail(`report-link mismatch json: code=${rj.code}\n${rj.stdout}${rj.stderr}`);
+  }
+  // --force overrides the guard and writes.
+  const rf = runSetStatus(['5', 'Applied', '--force'], sb);
+  if (rf.code === 0 && /\| 5 \| 2026-07-09 \| HPE \| CloudOps Engineer \| 4.1\/5 \| Applied \|/.test(readTracker(sb))) {
+    pass('report-link mismatch: --force writes anyway');
+  } else {
+    fail(`report-link mismatch --force: code=${rf.code}\n${rf.stdout}${rf.stderr}`);
+  }
+  // Company selector is unaffected by the drift guard (no number to disagree
+  // with) — reset the row and update by company.
+  const sb2 = makeSandbox(TRACKER_DRIFTED);
+  const rc = runSetStatus(['HPE', 'Rejected'], sb2);
+  if (rc.code === 0 && readTracker(sb2).includes('| Rejected |')) {
+    pass('report-link mismatch: company selector bypasses the drift guard');
+  } else {
+    fail(`report-link mismatch company selector: code=${rc.code}\n${rc.stdout}${rc.stderr}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+  rmSync(sb2.dir, { recursive: true, force: true });
+}
+
 // ── 7. Note append: idempotent, separator, pipe-sanitized ───────
 {
   const sb = makeSandbox(TRACKER_9);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -11,7 +11,11 @@
  *   node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--dry-run] [--json]
  *
  * Row resolution:
- *   - numeric argument → exact match on the # column
+ *   - numeric argument → exact match on the # column; if the tracker has a
+ *     duplicate # (see #1704 — merge-tracker.mjs bug, now fixed, that could
+ *     assign the same # to two rows), --role narrows it, otherwise it fails
+ *     ambiguous with a candidate list instead of silently editing whichever
+ *     row was found first
  *   - otherwise → company match (normalized, same key as merge-tracker dedup);
  *     multiple hits are narrowed with --role (fuzzy, role-matcher.mjs), and
  *     anything still ambiguous fails with a numbered candidate list.
@@ -167,11 +171,28 @@ if (!existsSync(APPS_FILE)) {
 function resolveRow(rows) {
   if (/^\d+$/.test(selector)) {
     const num = parseInt(selector, 10);
-    const row = rows.find(r => r.num === num);
-    if (!row) {
+    let matches = rows.filter(r => r.num === num);
+    if (matches.length === 0) {
       failWith(EXIT_NOT_FOUND, 'not-found', `No tracker row with #${num}`);
     }
-    return row;
+    if (matches.length > 1 && flags.role) {
+      const narrowed = matches.filter(r => roleFuzzyMatch(r.role, flags.role));
+      if (narrowed.length === 1) return narrowed[0];
+      // Fall through with the original list so the candidates stay visible.
+    }
+    if (matches.length > 1) {
+      // A bare report number should never match more than one row — this is
+      // exactly the failure mode from #1704: a stale tracker # reused across
+      // 2+ rows means "the first match" is a silent coin flip on which
+      // company gets edited. Refuse to guess; require --role or the company
+      // selector instead.
+      const candidates = matches.map(r => ({ num: r.num, company: r.company, role: r.role }));
+      const listing = candidates.map(c => `#${c.num}\t${c.company}\t${c.role}`).join('\n');
+      failWith(EXIT_AMBIGUOUS, 'ambiguous',
+        `#${num} is a duplicate tracker number shared by ${matches.length} rows (see #1704) — pass --role to disambiguate, or use the company name instead:\n${listing}`,
+        { candidates });
+    }
+    return matches[0];
   }
 
   const key = normalizeCompany(selector);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -190,12 +190,19 @@ function checkReportLink(row, num) {
   const m = /(?:^|[(\/])reports\/0*(\d+)-/.exec(row.report ?? '');
   if (m) {
     const linkedNum = parseInt(m[1], 10);
-    if (linkedNum !== num && !flags.force) {
-      failWith(EXIT_AMBIGUOUS, 'report-link-mismatch',
-        `Row #${num}'s Report column points to reports/${m[1]}-... — the tracker row number has drifted from the report file's own number (#1733). ` +
-        `Selector "${num}" may be targeting the wrong row (${row.company} — ${row.role}). ` +
-        `Use the company name as selector, or pass --force to write anyway.`,
-        { rowNum: num, linkedReportNum: linkedNum, company: row.company, role: row.role });
+    if (linkedNum !== num) {
+      if (!flags.force) {
+        failWith(EXIT_AMBIGUOUS, 'report-link-mismatch',
+          `Row #${num}'s Report column points to reports/${m[1]}-... — the tracker row number has drifted from the report file's own number (#1733). ` +
+          `Selector "${num}" may be targeting the wrong row (${row.company} — ${row.role}). ` +
+          `Use the company name as selector, or pass --force to write anyway.`,
+          { rowNum: num, linkedReportNum: linkedNum, company: row.company, role: row.role });
+      }
+      // Forced past a known mismatch — leave an audit trail on stderr so the
+      // override is visible in logs rather than silent.
+      console.error(
+        `set-status: warning — --force overriding report-link mismatch: row #${num} links reports/${m[1]}-... (${row.company} — ${row.role})`
+      );
     }
   }
   return row;

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -8,14 +8,18 @@
  * modes (apply Step 9, followup, batch) call this instead of editing the table.
  *
  * Usage:
- *   node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--dry-run] [--json]
+ *   node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--force] [--dry-run] [--json]
  *
  * Row resolution:
  *   - numeric argument → exact match on the # column; if the tracker has a
  *     duplicate # (see #1704 — merge-tracker.mjs bug, now fixed, that could
  *     assign the same # to two rows), --role narrows it, otherwise it fails
  *     ambiguous with a candidate list instead of silently editing whichever
- *     row was found first
+ *     row was found first. If the single matched row's Report column links a
+ *     report file whose embedded 3-digit number differs from the selector
+ *     (row # drift, #1733), the write is refused unless --force is passed —
+ *     a valid-looking single match can still be the WRONG row when the
+ *     tracker numbering has diverged from the report files.
  *   - otherwise → company match (normalized, same key as merge-tracker dedup);
  *     multiple hits are narrowed with --role (fuzzy, role-matcher.mjs), and
  *     anything still ambiguous fails with a numbered candidate list.
@@ -32,7 +36,8 @@
  *
  * Exit codes: 0 success (including no-op re-runs) · 1 usage error,
  * non-canonical state, unreadable states.yml, or non-retryable lock/write failure ·
- * 2 row not found or unreadable tracker · 3 ambiguous company match ·
+ * 2 row not found or unreadable tracker · 3 ambiguous company match or
+ * report-link mismatch (override with --force) ·
  * 4 tracker lock timeout (busy — retry later).
  *
  * When the new status is Applied, the JSON output carries
@@ -59,12 +64,14 @@ const EXIT_NOT_FOUND = 2;
 const EXIT_AMBIGUOUS = 3;
 const EXIT_LOCK_TIMEOUT = 4;
 
-const USAGE = `Usage: node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--dry-run] [--json]
+const USAGE = `Usage: node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--force] [--dry-run] [--json]
 
   <report#|company>  Row selector: tracker # (exact) or company name (normalized match)
   <state>            Canonical state from templates/states.yml (aliases accepted)
   --note "..."       Append to the Notes cell ("; "-separated, idempotent)
   --role "..."       Disambiguate when several rows share the company (fuzzy match)
+  --force            Write even when the row's Report link embeds a different
+                     report number than the selector (row # drift, #1733)
   --dry-run          Resolve and validate, but write nothing
   --json             Machine-readable output on stdout (errors included)`;
 
@@ -72,7 +79,7 @@ const USAGE = `Usage: node set-status.mjs <report#|company> <state> [--note "...
 
 const rawArgs = process.argv.slice(2);
 const positional = [];
-const flags = { note: null, role: null, dryRun: false, json: false };
+const flags = { note: null, role: null, force: false, dryRun: false, json: false };
 
 for (let i = 0; i < rawArgs.length; i++) {
   const a = rawArgs[i];
@@ -86,6 +93,7 @@ for (let i = 0; i < rawArgs.length; i++) {
     flags[a === '--note' ? 'note' : 'role'] = value;
     i++;
   }
+  else if (a === '--force') { flags.force = true; }
   else if (a === '--dry-run') { flags.dryRun = true; }
   else if (a === '--json') { flags.json = true; }
   else if (a.startsWith('--')) { failUsage(`Unknown flag: ${a}`); }
@@ -163,6 +171,37 @@ if (!existsSync(APPS_FILE)) {
 }
 
 /**
+ * Report-link sanity check for the numeric selector (#1733).
+ *
+ * merge-tracker.mjs once silently renumbered additions whose reserved report
+ * number was <= the tracker max, so a tracker can carry rows whose # disagrees
+ * with the number embedded in their own Report link (filename + Machine
+ * Summary). For those rows a bare-number selector finds exactly ONE
+ * valid-looking match — and it's the wrong one. When the matched row's Report
+ * column links a report file whose embedded number differs from the selector,
+ * refuse to write unless --force is passed. Rows without a parseable report
+ * link (e.g. "—") pass through unchecked.
+ *
+ * @param {object} row - The single matched row.
+ * @param {number} num - The numeric selector.
+ * @returns {object} The same row, if the check passes. Exits on mismatch.
+ */
+function checkReportLink(row, num) {
+  const m = /(?:^|[(\/])reports\/0*(\d+)-/.exec(row.report ?? '');
+  if (m) {
+    const linkedNum = parseInt(m[1], 10);
+    if (linkedNum !== num && !flags.force) {
+      failWith(EXIT_AMBIGUOUS, 'report-link-mismatch',
+        `Row #${num}'s Report column points to reports/${m[1]}-... — the tracker row number has drifted from the report file's own number (#1733). ` +
+        `Selector "${num}" may be targeting the wrong row (${row.company} — ${row.role}). ` +
+        `Use the company name as selector, or pass --force to write anyway.`,
+        { rowNum: num, linkedReportNum: linkedNum, company: row.company, role: row.role });
+    }
+  }
+  return row;
+}
+
+/**
  * Find the tracker row matching the CLI selector.
  *
  * @param {object[]} rows - Parsed data rows (parseTrackerRow output + lineIdx).
@@ -177,7 +216,7 @@ function resolveRow(rows) {
     }
     if (matches.length > 1 && flags.role) {
       const narrowed = matches.filter(r => roleFuzzyMatch(r.role, flags.role));
-      if (narrowed.length === 1) return narrowed[0];
+      if (narrowed.length === 1) return checkReportLink(narrowed[0], num);
       // Fall through with the original list so the candidates stay visible.
     }
     if (matches.length > 1) {
@@ -192,7 +231,7 @@ function resolveRow(rows) {
         `#${num} is a duplicate tracker number shared by ${matches.length} rows (see #1704) — pass --role to disambiguate, or use the company name instead:\n${listing}`,
         { candidates });
     }
-    return matches[0];
+    return checkReportLink(matches[0], num);
   }
 
   const key = normalizeCompany(selector);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3706,6 +3706,75 @@ try {
   fail(`verify-pipeline report checks crashed: ${e.message}`);
 }
 
+// ── VERIFY-PIPELINE DUPLICATE TRACKER NUMBER (#1704) ────────────
+// A tracker # must be a unique row id. Two rows sharing a # is never
+// legitimate (unlike Check 2's company+role dedup, which can false-positive
+// on a genuine re-application) — verify-pipeline must flag it as an error.
+console.log('\n🧪 Testing verify-pipeline duplicate tracker # check (#1704)...');
+try {
+  const dupNumTmp = mkdtempSync(join(tmpdir(), 'career-ops-verify-dupnum-'));
+  try {
+    const dupNumTracker = join(dupNumTmp, 'applications.md');
+    const dupNumEnv = { ...process.env, CAREER_OPS_TRACKER: dupNumTracker };
+
+    writeFileSync(dupNumTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 698 | 2026-05-29 | University of Alberta | Curriculum Coordinator | 3.8/5 | Evaluated | ❌ | — | — |\n' +
+      '| 698 | 2026-06-03 | Esri Canada | Manager Talent and Organizational Development | 4.1/5 | Evaluated | ❌ | — | — |\n' +
+      '| 700 | 2026-06-10 | Shopify | Staff Engineer | 4.5/5 | Evaluated | ❌ | — | — |\n');
+
+    let dupNumOut;
+    try {
+      dupNumOut = execFileSync(NODE, ['verify-pipeline.mjs'], { cwd: ROOT, env: dupNumEnv, encoding: 'utf-8', timeout: 30000, stdio: ['pipe', 'pipe', 'pipe'] });
+      fail('verify-pipeline should exit non-zero on a duplicate tracker number');
+    } catch (e) {
+      dupNumOut = (e.stdout || '').toString();
+      if (e.status === 1) {
+        pass('verify-pipeline exits 1 on a duplicate tracker number');
+      } else {
+        fail(`verify-pipeline: expected exit 1, got ${e.status}`);
+      }
+    }
+    if (dupNumOut.includes('Duplicate tracker number #698')
+        && dupNumOut.includes('University of Alberta') && dupNumOut.includes('Esri Canada')) {
+      pass('duplicate tracker number #698 flagged with both colliding rows named');
+    } else {
+      fail(`duplicate tracker number not flagged with both rows\n${dupNumOut}`);
+    }
+    if (/Duplicate tracker number #700/.test(dupNumOut)) {
+      fail('unique #700 row falsely flagged as a duplicate tracker number');
+    } else {
+      pass('unique tracker number not falsely flagged');
+    }
+  } finally {
+    rmSync(dupNumTmp, { recursive: true, force: true });
+  }
+
+  // Clean fixture: no duplicate numbers — must pass green.
+  const cleanTmp = mkdtempSync(join(tmpdir(), 'career-ops-verify-dupnum-clean-'));
+  try {
+    const cleanTracker = join(cleanTmp, 'applications.md');
+    writeFileSync(cleanTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 1 | 2026-01-01 | Acme | Engineer | 4.0/5 | Evaluated | ❌ | — | — |\n' +
+      '| 2 | 2026-01-02 | Globex | Analyst | 3.9/5 | Evaluated | ❌ | — | — |\n');
+    const cleanOut = run(NODE, ['verify-pipeline.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: cleanTracker }, stdio: ['pipe', 'pipe', 'pipe'] });
+    if (cleanOut !== null && cleanOut.includes('No duplicate tracker numbers')) {
+      pass('clean tracker with unique numbers passes the duplicate-number check');
+    } else {
+      fail('clean fixture did not pass the duplicate tracker number check');
+    }
+  } finally {
+    rmSync(cleanTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`verify-pipeline duplicate tracker number test crashed: ${e.message}`);
+}
+
 // ── SHARED ROLE MATCHER + DEDUP-TRACKER SAFETY (#947) ───────────
 // dedup-tracker.mjs used to ship an older fuzzy role matcher than
 // merge-tracker.mjs. That weaker matcher collapsed sibling roles at the same
@@ -4329,6 +4398,83 @@ try {
   }
 } catch (e) {
   fail(`merge-tracker report-number collision test crashed: ${e.message}`);
+}
+
+// ── MERGE-TRACKER STALE-NUMBER COLLISION WITH AN EXISTING ROW (#1704) ────
+// Different from the #912 test above: that one is a same-run collision where
+// the incoming TSV's num equals an EXISTING row's num (addition.num <= maxNum,
+// already handled by the old ++maxNum fallback). This one exercises the actual
+// #1704 gap: an existing row's number is invisible to the plain maxNum scan
+// (merge-tracker's own header/separator-skip heuristic excludes any row whose
+// company/role text happens to contain "Empresa" or "---" — a real Spanish-
+// market company name is a realistic trigger), so the naive
+// `addition.num > maxNum` check trusted a colliding number as free. The fix
+// builds a Set of every number actually on the tracker (independent of that
+// heuristic) and refuses to trust a number already in it.
+console.log('\n🧪 Testing merge-tracker stale-number collision with a hidden existing row (#1704)...');
+try {
+  const staleNumTmp = mkdtempSync(join(tmpdir(), 'career-ops-merge-1704-'));
+  try {
+    mkdirSync(join(staleNumTmp, 'data'));
+    const staleNumAdditions = join(staleNumTmp, 'additions');
+    mkdirSync(staleNumAdditions);
+
+    const staleNumTracker = join(staleNumTmp, 'data', 'applications.md');
+    // Row #9's company text contains "Empresa" — merge-tracker's existingApps
+    // loop skips this line entirely (the same heuristic it uses to skip the
+    // Spanish-locale header row), so its number is NOT counted toward the old
+    // plain maxNum scan.
+    writeFileSync(staleNumTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 9 | 2026-01-02 | Empresa Digital SA | Analyst | 3.5/5 | Evaluated | ❌ | — | original |\n');
+
+    // Stale TSV for an unrelated company also embeds num=9 — numerically
+    // "ahead" of the naive maxNum(0) computed from the hidden row, but already
+    // used.
+    writeFileSync(join(staleNumAdditions, '001-newco.tsv'),
+      '9\t2026-01-10\tNewCo\tFresh Role\tEvaluated\t2.9/5\t❌\t—\tstale number\n');
+
+    const staleNumResult = run(NODE, ['merge-tracker.mjs'], {
+      env: { ...process.env, CAREER_OPS_TRACKER: staleNumTracker, CAREER_OPS_ADDITIONS: staleNumAdditions },
+    });
+    if (staleNumResult === null) {
+      fail('merge-tracker crashed during stale-number collision test (#1704)');
+    } else {
+      const staleNumMerged = readFileSync(staleNumTracker, 'utf-8');
+      const staleNumRows = staleNumMerged.split('\n').filter(l => l.startsWith('| ') && !l.startsWith('| #') && !l.startsWith('|---'));
+
+      if (staleNumRows.length === 2) {
+        pass('stale-number collision (#1704): merged tracker has exactly 2 rows');
+      } else {
+        fail(`stale-number collision (#1704): expected 2 rows, got ${staleNumRows.length}`);
+      }
+
+      const numsUsed = staleNumRows.map(r => parseInt(r.split('|')[1].trim(), 10));
+      if (new Set(numsUsed).size === numsUsed.length) {
+        pass('stale-number collision (#1704): no two rows share a tracker number');
+      } else {
+        fail(`stale-number collision (#1704): duplicate tracker number produced — ${numsUsed.join(', ')}`);
+      }
+
+      if (staleNumRows.some(r => r.includes('Empresa Digital SA') && /^\| 9 \|/.test(r))) {
+        pass('stale-number collision (#1704): hidden existing row #9 (Empresa Digital SA) untouched');
+      } else {
+        fail(`stale-number collision (#1704): existing #9 row was overwritten\n${staleNumMerged}`);
+      }
+
+      if (staleNumRows.some(r => r.includes('NewCo') && !/^\| 9 \|/.test(r))) {
+        pass('stale-number collision (#1704): NewCo bumped to a truly free number instead of reusing #9');
+      } else {
+        fail(`stale-number collision (#1704): NewCo was not bumped off the colliding number\n${staleNumMerged}`);
+      }
+    }
+  } finally {
+    rmSync(staleNumTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`merge-tracker stale-number collision test crashed: ${e.message}`);
 }
 
 // ── MERGE-TRACKER REQ/JOB-NUMBER DEDUP GUARD (#1524) ─────────────────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -24,7 +24,7 @@
  */
 
 
-import { execSync, execFileSync, spawn } from 'child_process';
+import { execSync, execFileSync, spawn, spawnSync } from 'child_process';
 import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, unlinkSync, realpathSync, symlinkSync } from 'fs';
 import { join, dirname, delimiter } from 'path';
 import { tmpdir } from 'os';
@@ -4475,6 +4475,93 @@ try {
   }
 } catch (e) {
   fail(`merge-tracker stale-number collision test crashed: ${e.message}`);
+}
+
+// ── MERGE-TRACKER RESERVED-NUMBER FIDELITY (#1733) ───────────────────────
+// Opposite branch of #1704: report numbers are reserved off reports/
+// (reserve-report-num.mjs) while maxNum comes from the tracker's own rows —
+// two independent counters — so a reserved number <= maxNum is the COMMON
+// case. The old `addition.num > maxNum ? addition.num : ++maxNum` silently
+// replaced the reserved number, permanently diverging the tracker row # from
+// the number embedded in the report file, which later made
+// `set-status.mjs <report#>` edit the wrong (single, valid-looking) row.
+// Pins: (a) a free reserved number <= maxNum is KEPT; (b) a genuinely taken
+// number falls back to a fresh unused number AND warns loudly; (c) keeping a
+// low number never drags maxNum backwards — the fallback still assigns past
+// the true max.
+console.log('\n🧪 Testing merge-tracker reserved-number fidelity (#1733)...');
+try {
+  const fidTmp = mkdtempSync(join(tmpdir(), 'career-ops-merge-1733-'));
+  try {
+    mkdirSync(join(fidTmp, 'data'));
+    const fidAdditions = join(fidTmp, 'additions');
+    mkdirSync(fidAdditions);
+
+    const fidTracker = join(fidTmp, 'data', 'applications.md');
+    // Tracker max is #417; #415 is NOT on the tracker (it was reserved off
+    // reports/ by a batch worker) and #416 IS taken by an unrelated row.
+    writeFileSync(fidTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 416 | 2026-07-01 | OldCo | Data Analyst | 3.2/5 | Evaluated | ❌ | — | — |\n' +
+      '| 417 | 2026-07-02 | OtherCo | ML Engineer | 4.0/5 | Applied | ✅ | — | — |\n');
+
+    // (a) reserved #415 is free → must be kept even though 415 <= max 417.
+    writeFileSync(join(fidAdditions, '001-lowco.tsv'),
+      '415\t2026-07-09\tLowCo\tCloudOps Engineer\tEvaluated\t4.1/5\t❌\t[415](reports/415-lowco-2026-07-09.md)\treserved low number\n');
+    // (b) reserved #416 is taken by OldCo → fallback + loud warning.
+    writeFileSync(join(fidAdditions, '002-clashco.tsv'),
+      '416\t2026-07-09\tClashCo\tPlatform Engineer\tEvaluated\t3.9/5\t❌\t[416](reports/416-clashco-2026-07-09.md)\tclashing number\n');
+
+    // spawnSync instead of run(): the fallback warning goes to stderr
+    // (console.warn) and run() only returns stdout.
+    const fidRes = spawnSync(NODE, ['merge-tracker.mjs'], {
+      cwd: ROOT, encoding: 'utf-8', timeout: 30000,
+      env: { ...process.env, CAREER_OPS_TRACKER: fidTracker, CAREER_OPS_ADDITIONS: fidAdditions },
+    });
+    if (fidRes.status !== 0) {
+      fail(`reserved-number fidelity (#1733): merge-tracker exited ${fidRes.status}\n${fidRes.stdout}${fidRes.stderr}`);
+    } else {
+      const fidMerged = readFileSync(fidTracker, 'utf-8');
+      const fidRows = fidMerged.split('\n').filter(l => l.startsWith('| ') && !l.startsWith('| #') && !l.startsWith('|---'));
+
+      if (fidRows.some(r => /^\| 415 \|/.test(r) && r.includes('LowCo'))) {
+        pass('reserved-number fidelity (#1733): free reserved #415 kept as tracker row # despite being <= max 417');
+      } else {
+        fail(`reserved-number fidelity (#1733): reserved #415 was not kept\n${fidMerged}`);
+      }
+
+      // (c) fallback for the taken #416 must land PAST the true max (418+),
+      // proving keeping #415 did not drag maxNum backwards onto #416/#417.
+      const clashRow = fidRows.find(r => r.includes('ClashCo'));
+      const clashNum = clashRow ? parseInt(clashRow.split('|')[1].trim(), 10) : NaN;
+      if (clashNum >= 418) {
+        pass(`reserved-number fidelity (#1733): taken #416 fell back to fresh #${clashNum} past the true max`);
+      } else {
+        fail(`reserved-number fidelity (#1733): fallback assigned #${clashNum} (want >= 418)\n${fidMerged}`);
+      }
+
+      if ((fidRes.stderr || '').includes('Reserved #416 already used')) {
+        pass('reserved-number fidelity (#1733): fallback warns loudly that row # no longer matches the report file');
+      } else {
+        fail(`reserved-number fidelity (#1733): expected loud fallback warning on stderr, got:\n${fidRes.stderr}`);
+      }
+
+      const fidNums = fidRows.map(r => parseInt(r.split('|')[1].trim(), 10));
+      if (new Set(fidNums).size === fidNums.length
+          && fidRows.some(r => /^\| 416 \|/.test(r) && r.includes('OldCo'))
+          && fidRows.some(r => /^\| 417 \|/.test(r) && r.includes('OtherCo'))) {
+        pass('reserved-number fidelity (#1733): no duplicate numbers, existing rows untouched');
+      } else {
+        fail(`reserved-number fidelity (#1733): duplicate numbers or existing rows disturbed — ${fidNums.join(', ')}\n${fidMerged}`);
+      }
+    }
+  } finally {
+    rmSync(fidTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`merge-tracker reserved-number fidelity test crashed: ${e.message}`);
 }
 
 // ── MERGE-TRACKER REQ/JOB-NUMBER DEDUP GUARD (#1524) ─────────────────────

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -13,6 +13,8 @@
  * 8. Stale report-number reservation sentinels are garbage-collected
  * 9. No two report files cover the same company+role (warning — see #1425)
  * 10. Every report file has a tracker row referencing it (warning — see #1425)
+ * 11. Via channel consistency (see #1596)
+ * 12. No # value reused across 2+ tracker rows (error — see #1704)
  *
  * Run: node career-ops/verify-pipeline.mjs
  */
@@ -382,6 +384,30 @@ for (const [key, vias] of channelsByRole) {
   }
 }
 if (viaIssues === 0) ok('Via channels consistent');
+
+// --- Check 12: Duplicate tracker numbers (#1704) ---
+// The # column is a row id and must be unique. Unlike Check 2 (company+role
+// dedup, which can false-positive on a legitimate re-application), the SAME
+// number appearing on 2+ rows is never legitimate: it means set-status.mjs
+// can't tell the rows apart, and any external reference to "application #N"
+// (interview-prep notes, memory, cross-links) becomes ambiguous. Pure
+// addition, no existing check covers this — see #1704 for the 124-row sweep
+// that found this in the wild (merge-tracker.mjs trusted a stale TSV number
+// as-is whenever it exceeded that run's max, without checking it wasn't
+// already used by an unrelated row merged in a separate, earlier invocation).
+const numGroups = new Map();
+for (const e of entries) {
+  if (!numGroups.has(e.num)) numGroups.set(e.num, []);
+  numGroups.get(e.num).push(e);
+}
+let dupeNums = 0;
+for (const [num, group] of numGroups) {
+  if (group.length > 1) {
+    error(`Duplicate tracker number #${num} used by ${group.length} rows: ${group.map(e => `${e.company} — ${e.role}`).join(' | ')}`);
+    dupeNums++;
+  }
+}
+if (dupeNums === 0) ok('No duplicate tracker numbers');
 
 // --- Summary ---
 console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## Problem

Field report by @kevind589 in [#1704 (comment)](https://github.com/santifer/career-ops/issues/1704#issuecomment-4929129288): during a real 11-URL parallel pipeline batch, 9 of 11 evaluations landed on tracker rows #418–#426 while their report files say 410–420. Root cause is the `else` branch of the same line #1704/#1705 fixed for the `>` case:

```js
const entryNum = addition.num > maxNum ? addition.num : ++maxNum;
```

Report numbers are reserved via `reserve-report-num.mjs` (counts off `reports/`) while `maxNum` comes from `applications.md`'s rows — two independent counters — so `addition.num <= maxNum` is the **common** case, not an anomaly. The reserved number was silently discarded and replaced with `++maxNum`, permanently diverging the tracker row `#` from the number embedded in the report file (filename + Machine Summary). Worse, `set-status.mjs 415` then silently edited a pre-existing, unrelated row #415 — a single, valid-looking, *wrong* match that #1705's duplicate-selector guard cannot catch (it guards 2+ matches, not exactly-one-wrong-match).

## Fix — two independent layers

**Layer 1 — `merge-tracker.mjs`, number fidelity (stops new drift):** when `addition.num` is a valid positive integer and not already claimed by any existing tracker row or an earlier addition in the same run (via the `usedNumbers` set introduced in #1705), the reserved number is **kept** as the tracker row number even when `<= maxNum`. Only when the number is genuinely taken does it fall back to a fresh unused number — and it now warns loudly on stderr that the row `#` no longer matches the report file's number. `maxNum` never goes backwards: keeping a low reserved number (e.g. #415 while max is #417) cannot make a later fallback land on an already-used number.

**Layer 2 — `set-status.mjs`, report-link sanity check (protects rows already drifted in the wild):** when the selector is a report number and the single matched row's Report column links a report file whose embedded 3-digit number differs from the selector, the write is refused (exit 3, code `report-link-mismatch`, structured `--json` payload with `rowNum`/`linkedReportNum`) unless `--force` is passed. `--force` is documented in the usage text and file header. Company-name selectors and rows without a parseable report link are unaffected. Layer 1 only prevents *future* drift — trackers that already contain drifted rows from the old behavior stay dangerous forever without this guard, which is why the two layers are deliberately independent.

## Stacked on #1705

This branch is stacked on #1705 (`fix/dup-tracker-number-detection`) because both PRs edit the same numbering block in `merge-tracker.mjs`; **#1705 should merge first**, after which this PR's diff reduces to the `<=`-branch fidelity fix + the set-status guard.

## Tests

- `test-all.mjs`: new "merge-tracker reserved-number fidelity (#1733)" section — pins (a) free reserved #415 kept while tracker max is #417, (b) taken #416 falls back to a fresh number **past the true max** (#418+) with a loud stderr warning, (c) no duplicate numbers / existing rows untouched (maxNum never dragged backwards).
- `set-status-tests.mjs`: new section 6d — numeric selector vs mismatched Report link blocked (exit 3, tracker untouched), structured `--json` payload, allowed with `--force`, and company selector bypasses the guard.
- Full `node test-all.mjs` run green locally (Windows); only the known benign `batch-state.tsv` ENOENT flake / cv-sync-check warning observed.

Closes #1733

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer tracker updates with validation to block duplicate tracker numbers and mismatches between row numbers and linked report numbers.
  * Added `--force` to override report-link mismatches when needed.
* **Bug Fixes**
  * Prevented accidental writes when numeric selectors are ambiguous or drift from the linked report number.
  * Improved merge numbering by honoring already-used tracker IDs and reserving candidate numbers safely.
* **Tests**
  * Expanded coverage for duplicate IDs, drift detection, structured `--json` ambiguity errors, and merge collision regression cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->