### PR TITLE
docs: stop CLAUDE.md double-loading AGENTS.md (~8K tokens/session)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,7 @@ Verify a posting is still live before applying — using the cheapest check that
 - JDs in `jds/` (referenced as `local:jds/{file}` in pipeline.md)
 - Batch in `batch/` (gitignored except scripts and prompt)
 - Report numbering: sequential 3-digit zero-padded, max existing + 1
+- **Parallel fan-outs — reserve report numbers first.** When orchestrating N parallel evaluators (headless workers, subagents, or multiple agent windows), reserve the report-number range before spawning: `node reserve-report-num.mjs --count N` prints e.g. `042-049`; hand each worker its own number. Each slot claim is individually atomic; the contiguous range is an ergonomic allocation, not an all-or-nothing transaction — on collision the partially claimed slots are released and the reservation restarts past the collision. Release with `node reserve-report-num.mjs --release 042-049` when done (stale sentinels are GC'd after 4h, so reserve right before spawning; collision restarts leave permanent — harmless — gaps in the sequence). Never let parallel workers compute `max+1` themselves — that is the #749 race.
 - **RULE: After each batch of evaluations, run `node merge-tracker.mjs`** to merge tracker additions and avoid duplications.
 - **RULE: NEVER create new entries in applications.md if company+role already exists.** Update the existing entry.
 
@@ -387,5 +388,11 @@ Write one TSV file per evaluation to `batch/tracker-additions/{num}-{company-slu
 **Source of truth (full descriptions + aliases):** `templates/states.yml`. The 8 canonical states (use exactly one): `Evaluated` · `Applied` · `Responded` · `Interview` · `Offer` · `Rejected` · `Discarded` · `SKIP`.
 
 **RULES:** no markdown bold (`**`), no dates (those go in the date column), no extra text (use the notes column) in the status field.
-@AGENTS.md
+
+<!-- CLAUDE.md is a complete, standalone spec for Claude Code. It intentionally does NOT
+     `@AGENTS.md`: that transclude double-loaded every shared rule into each Claude Code
+     session (~8K tokens, ~77% duplicated). AGENTS.md remains the entrypoint for other CLIs.
+     Claude-Code-relevant rules that previously lived only in AGENTS.md (e.g. parallel
+     report-number reservation) have been ported into the body above. Add anything
+     Claude-Code-specific here. -->
 <!-- Add anything Claude Code specific that other agents don't need -->


### PR DESCRIPTION
# docs: stop CLAUDE.md double-loading AGENTS.md (~8K tokens/session)

## Problem

`CLAUDE.md` ends with an `@AGENTS.md` transclude, so Claude Code loads the entire `AGENTS.md` on top of `CLAUDE.md` at the start of every session. But `CLAUDE.md` already contains a full, standalone copy of the shared ruleset (Data Contract, Source-of-Truth Boundary, canonical states, TSV format, Pipeline Integrity, Ethical Use, Offer Verification). The result is that the shared rules are loaded **twice**.

Measured on the current `main` (v1.18.0):

| File | Lines | Bytes | ~Tokens |
|------|-------|-------|---------|
| `CLAUDE.md` | 391 | 25.9 KB | ~6.5K |
| `AGENTS.md` | 431 | 31.8 KB | ~8.0K |

- **77% of `CLAUDE.md`'s non-blank lines appear verbatim in `AGENTS.md`.**
- Effective always-on context for a Claude Code user: **~14.4K tokens**, of which ~8K is a duplicate.

The two copies have also **drifted**: several `CLAUDE.md` rules are newer, tightened variants of the `AGENTS.md` wording (e.g. the condensed canonical-states line, the `claude -p` batch exception, the `check-liveness.mjs` liveness rule). So maintaining both is a correctness hazard, not just a token cost — a rule fixed in one file can silently stay stale in the other.

## Fix

Remove the redundant `@AGENTS.md` transclude and keep `CLAUDE.md` as the complete standalone entrypoint for Claude Code. `AGENTS.md` is unchanged and remains the entrypoint for the other CLIs (Codex, OpenCode, Gemini, etc.), which never read `CLAUDE.md`.

Nothing regresses: the only Claude-Code-relevant rule that lived **only** in `AGENTS.md` was the parallel report-number reservation (`reserve-report-num.mjs`, the #749 race). It is ported into `CLAUDE.md`'s report-numbering rules in this PR. The remaining `AGENTS.md`-only content is either other-CLI invocation or non-English language modes, both out of scope for the Claude Code entrypoint.

**Net effect for Claude Code:** ~14.4K → ~6.5K tokens of always-on context, no loss of rules.

Diff: `CLAUDE.md`, +8 / -1.

## Alternative considered

The inverse refactor — slim `CLAUDE.md` down to a thin Claude-specific header that keeps `@AGENTS.md` for the shared body — also removes the duplication and would make `AGENTS.md` the single source of truth. It was not chosen here because (a) it's a much larger diff that requires reconciling the drifted wording back into `AGENTS.md`, and (b) a Claude Code user still pays for `AGENTS.md`'s other-CLI and multi-language content they don't need. Happy to switch to that shape if you'd prefer a single shared source over a standalone `CLAUDE.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational guidance for parallel evaluation workflows.
  * Added instructions for reserving and releasing report-number ranges safely.
  * Clarified collision handling and the risks of independently assigning report numbers.
  * Improved guidance on standalone Claude Code rules and shared documentation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->