### PR TITLE
feat(reports): add unified Risk Summary block joining the five company-risk signals (#1737)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner — walks the full public job-board-aggregator dataset per ATS provider (Greenhouse/Lever/Ashby/Workday), filtered by portals.yml's title_filter/location_filter. No company-list curation needed; complements scan.mjs's company-first model. |
 | `check-liveness.mjs` | Job posting liveness checker |
 | `liveness-core.mjs` | Shared liveness logic (expired signals win over generic Apply text) |
-| `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`). Blocks A-F + G (Posting Legitimacy). Header includes `**Legitimacy:** {tier}`. |
+| `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`). Blocks A-F + G (Posting Legitimacy) + Risk Summary. Header includes `**Legitimacy:** {tier}`. |
 
 ### Plugins (optional)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner — walks the full public job-board-aggregator dataset per ATS provider (Greenhouse/Lever/Ashby/Workday), filtered by portals.yml's title_filter/location_filter. No company-list curation needed; complements scan.mjs's company-first model. |
 | `check-liveness.mjs` | Job posting liveness checker |
 | `liveness-core.mjs` | Shared liveness logic (expired signals win over generic Apply text) |
-| `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`). Blocks A-F + G (Posting Legitimacy) + Risk Summary. Header includes `**Legitimacy:** {tier}`. |
+| `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`). Blocks A-F + G (Posting Legitimacy) + Risk Summary, plus `## Machine Summary` YAML for downstream scripts. Header includes `**Legitimacy:** {tier}`. |
 
 ### Plugins (optional)
 

--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -218,6 +218,38 @@ company_confidential: true
   if (summary?.via !== 'Hays') failures.push('via was not preserved from Machine Summary');
   if (summary?.company_confidential !== true) failures.push('company_confidential boolean was not preserved from Machine Summary');
 
+  // Backward compat (#1737): summaries without risk_summary parse as before, key simply absent.
+  if ('risk_summary' in (summary ?? {})) failures.push('summary without risk_summary must not gain the key');
+
+  // risk_summary preservation (#1737): the nested map must survive the
+  // MACHINE_SUMMARY_FIELDS allowlist intact — nested keys preserved, not
+  // flattened or dropped.
+  const riskSummary = parseMachineSummary(`
+## Machine Summary
+
+\`\`\`yaml
+company: "Acme"
+role: "Staff AI Engineer"
+score: 4.4
+legitimacy_tier: "High Confidence"
+risk_summary:
+  legitimacy: high_confidence
+  classification: clear
+  culture: caution
+  interview_redflags: not_evaluated
+  ai_infra: not_evaluated
+\`\`\`
+`)?.risk_summary;
+  if (!riskSummary || typeof riskSummary !== 'object' || Array.isArray(riskSummary)) {
+    failures.push('risk_summary nested map was dropped or not parsed as a map');
+  } else {
+    if (riskSummary.legitimacy !== 'high_confidence') failures.push('risk_summary.legitimacy was not preserved');
+    if (riskSummary.classification !== 'clear') failures.push('risk_summary.classification was not preserved');
+    if (riskSummary.culture !== 'caution') failures.push('risk_summary.culture was not preserved');
+    if (riskSummary.interview_redflags !== 'not_evaluated') failures.push('risk_summary.interview_redflags was not preserved');
+    if (riskSummary.ai_infra !== 'not_evaluated') failures.push('risk_summary.ai_infra was not preserved');
+  }
+
   // Vendor detection (community ATS only; white-labeled → null)
   const vendorCases = [
     ['https://boards.greenhouse.io/acme/jobs/12345', 'greenhouse'],

--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -48,6 +48,7 @@ const MACHINE_SUMMARY_FIELDS = new Set([
   'advertised_comp',
   'via',
   'company_confidential',
+  'risk_summary',
 ]);
 
 // --- CLI args ---

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -209,6 +209,36 @@ Assess whether the posting appears real and worth pursuing.
 
 Batch mode limitation: Playwright is not available, so exact apply-button state and freshness cannot be directly verified. Mark those signals as `unverified (batch mode)`.
 
+#### Risk Summary (después del Bloque G)
+
+Cierra el cuerpo del report con un bloque `## Risk Summary` justo después de la sección del Bloque G — una fila por señal de riesgo, orden fijo, tres estados por fila: `✅ {clear verdict}` / `⚠️ {finding}` / `— not evaluated`. **Aggregation only, zero new judgment:** cada fila cita el veredicto ya producido por su señal fuente; nunca re-puntúa ni sobrescribe.
+
+**`— not evaluated` es un estado de primera clase:** una señal que este worker no puede evaluar se declara explícitamente — NUNCA se omite la fila — para que un summary todo-✅ sea fiable.
+
+Reglas batch por fila:
+
+| Signal | Batch rendering |
+|--------|-----------------|
+| Posting legitimacy | Espejo del tier del Bloque G: `✅ High Confidence`, o `⚠️ {tier} — {one-line reason}` |
+| Employment classification | `— not evaluated` (el check de clasificación no forma parte del Bloque G batch) |
+| Culture screen | `— not evaluated` (el Bloque A batch no produce el campo Culture screen pass/caution/fail) |
+| Interview red flags | Si existe `interview-prep/{company-slug}-redflags.md`, espejo de su warning level + link relativo `[{level}](../interview-prep/{company-slug}-redflags.md)`; si no, `— no interview sessions yet` |
+| AI claims vs. infrastructure | Si este prompt/report contiene el check de mismatch AI/infraestructura, espejo de su veredicto (`✅ consistent` / `⚠️ {finding}`); si no, `— not evaluated` |
+
+Formato del bloque:
+
+```markdown
+## Risk Summary
+
+| Signal | Status |
+|--------|--------|
+| Posting legitimacy | ✅ High Confidence |
+| Employment classification | — not evaluated |
+| Culture screen | — not evaluated |
+| Interview red flags | — no interview sessions yet |
+| AI claims vs. infrastructure | — not evaluated |
+```
+
 #### Score Global
 Read `modes/_custom.md` → Scoring Rules, if it exists, and apply its override here. Default (if absent or silent): calculate global score based on dimension scores below.
 
@@ -267,6 +297,12 @@ discard_reasons:
 via: {agency/recruiter firm as a quoted string, or null for direct applications}
 company_confidential: {true when the end employer is unknown (company is "?"), else false}
 advertised_comp: {verbatim JD salary/range as a quoted string (e.g. "80-90k EUR"), or null when the JD states nothing}
+risk_summary:
+  legitimacy: {high_confidence | proceed_with_caution | suspicious}
+  classification: {clear | flagged | not_evaluated}
+  culture: {pass | caution | fail | not_evaluated}
+  interview_redflags: {none | caution | warning | not_evaluated}
+  ai_infra: {consistent | mismatch | not_evaluated}
 ```
 
 Rules:
@@ -275,6 +311,7 @@ Rules:
 - `final_decision` must reflect the full evaluation, not only the CV match.
 - `advertised_comp` is the JD's **own** figure, verbatim; `null` when the JD states nothing — never estimate it and never substitute researched market data (Block D research stays in Block D). Batch workers never write `data/salary-observations.tsv` — the report itself is the advertised observation (`salary-gap.mjs` reads it).
 - Do not invent missing data. If confidence is limited, set `confidence: "Low"` and explain the limitation in the human-readable sections.
+- `risk_summary` mirrors the `## Risk Summary` block row by row — same source verdicts, snake_cased: `legitimacy` from the Block G tier (`high_confidence` / `proceed_with_caution` / `suspicious`), `culture` from the Block A Culture screen (`pass` / `caution` / `fail`), `interview_redflags` from the red-flag file's warning level (`none` / `caution` / `warning`). Any row rendered `— not evaluated` (or `— no interview sessions yet`) is `not_evaluated` here. Never invent a value the block does not show.
 
 ### Step 3 — Save the Report
 
@@ -325,6 +362,12 @@ discard_reasons:
 via: {agency/recruiter firm as a quoted string, or null for direct applications}
 company_confidential: {true when the end employer is unknown (company is "?"), else false}
 advertised_comp: {verbatim JD salary/range as a quoted string (e.g. "80-90k EUR"), or null when the JD states nothing}
+risk_summary:
+  legitimacy: {high_confidence | proceed_with_caution | suspicious}
+  classification: {clear | flagged | not_evaluated}
+  culture: {pass | caution | fail | not_evaluated}
+  interview_redflags: {none | caution | warning | not_evaluated}
+  ai_infra: {consistent | mismatch | not_evaluated}
 ```
 ```
 
@@ -338,6 +381,7 @@ Then include:
 - `## E) Personalization Plan`
 - `## F) Interview Plan`
 - `## G) Posting Legitimacy`
+- `## Risk Summary`
 - `## Extracted Keywords`
 
 Translate these human-facing headings according to `language.output` when it is not English. Keep `## Machine Summary` and YAML keys exact for downstream parsers.

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -298,11 +298,11 @@ via: {agency/recruiter firm as a quoted string, or null for direct applications}
 company_confidential: {true when the end employer is unknown (company is "?"), else false}
 advertised_comp: {verbatim JD salary/range as a quoted string (e.g. "80-90k EUR"), or null when the JD states nothing}
 risk_summary:
-  legitimacy: {high_confidence | proceed_with_caution | suspicious}
-  classification: {clear | flagged | not_evaluated}
-  culture: {pass | caution | fail | not_evaluated}
-  interview_redflags: {none | caution | warning | not_evaluated}
-  ai_infra: {consistent | mismatch | not_evaluated}
+  legitimacy: "{high_confidence | proceed_with_caution | suspicious}"
+  classification: "{clear | flagged | not_evaluated}"
+  culture: "{pass | caution | fail | not_evaluated}"
+  interview_redflags: "{none | caution | warning | not_evaluated}"
+  ai_infra: "{consistent | mismatch | not_evaluated}"
 ```
 
 Rules:
@@ -363,11 +363,11 @@ via: {agency/recruiter firm as a quoted string, or null for direct applications}
 company_confidential: {true when the end employer is unknown (company is "?"), else false}
 advertised_comp: {verbatim JD salary/range as a quoted string (e.g. "80-90k EUR"), or null when the JD states nothing}
 risk_summary:
-  legitimacy: {high_confidence | proceed_with_caution | suspicious}
-  classification: {clear | flagged | not_evaluated}
-  culture: {pass | caution | fail | not_evaluated}
-  interview_redflags: {none | caution | warning | not_evaluated}
-  ai_infra: {consistent | mismatch | not_evaluated}
+  legitimacy: "{high_confidence | proceed_with_caution | suspicious}"
+  classification: "{clear | flagged | not_evaluated}"
+  culture: "{pass | caution | fail | not_evaluated}"
+  interview_redflags: "{none | caution | warning | not_evaluated}"
+  ai_infra: "{consistent | mismatch | not_evaluated}"
 ```
 ```
 

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -213,7 +213,7 @@ Batch mode limitation: Playwright is not available, so exact apply-button state 
 
 Close the report body with a `## Risk Summary` block directly after Block G's section — one row per risk signal, fixed order, three states per row: `✅ {clear verdict}` / `⚠️ {finding}` / `— not evaluated`. **Aggregation only, zero new judgment:** each row quotes the verdict already produced by its source signal; it never re-scores or overrides.
 
-**`— not evaluated` is a first-class state:** a signal that this worker cannot evaluate is explicitly declared — NEVER omit the row — so an all-✅ summary can be trusted.
+**`— not evaluated` is a first-class state:** a signal that this worker cannot evaluate is explicitly declared — NEVER omit the row — so an all-✅ summary can be trusted. **Named exception:** the Interview red flags row renders its not-evaluated case as `— no interview sessions yet` — a documented, more specific phrasing of the same "not evaluated" concept for that one row (the cross-reference check did run; it just found no redflags file), not a fourth free-floating state.
 
 Batch rendering rules per row:
 

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -209,23 +209,23 @@ Assess whether the posting appears real and worth pursuing.
 
 Batch mode limitation: Playwright is not available, so exact apply-button state and freshness cannot be directly verified. Mark those signals as `unverified (batch mode)`.
 
-#### Risk Summary (después del Bloque G)
+#### Risk Summary (after Block G)
 
-Cierra el cuerpo del report con un bloque `## Risk Summary` justo después de la sección del Bloque G — una fila por señal de riesgo, orden fijo, tres estados por fila: `✅ {clear verdict}` / `⚠️ {finding}` / `— not evaluated`. **Aggregation only, zero new judgment:** cada fila cita el veredicto ya producido por su señal fuente; nunca re-puntúa ni sobrescribe.
+Close the report body with a `## Risk Summary` block directly after Block G's section — one row per risk signal, fixed order, three states per row: `✅ {clear verdict}` / `⚠️ {finding}` / `— not evaluated`. **Aggregation only, zero new judgment:** each row quotes the verdict already produced by its source signal; it never re-scores or overrides.
 
-**`— not evaluated` es un estado de primera clase:** una señal que este worker no puede evaluar se declara explícitamente — NUNCA se omite la fila — para que un summary todo-✅ sea fiable.
+**`— not evaluated` is a first-class state:** a signal that this worker cannot evaluate is explicitly declared — NEVER omit the row — so an all-✅ summary can be trusted.
 
-Reglas batch por fila:
+Batch rendering rules per row:
 
 | Signal | Batch rendering |
 |--------|-----------------|
-| Posting legitimacy | Espejo del tier del Bloque G: `✅ High Confidence`, o `⚠️ {tier} — {one-line reason}` |
-| Employment classification | `— not evaluated` (el check de clasificación no forma parte del Bloque G batch) |
-| Culture screen | `— not evaluated` (el Bloque A batch no produce el campo Culture screen pass/caution/fail) |
-| Interview red flags | Si existe `interview-prep/{company-slug}-redflags.md`, espejo de su warning level + link relativo `[{level}](../interview-prep/{company-slug}-redflags.md)`; si no, `— no interview sessions yet` |
-| AI claims vs. infrastructure | Si este prompt/report contiene el check de mismatch AI/infraestructura, espejo de su veredicto (`✅ consistent` / `⚠️ {finding}`); si no, `— not evaluated` |
+| Posting legitimacy | Mirror the Block G tier: `✅ High Confidence`, or `⚠️ {tier} — {one-line reason}` |
+| Employment classification | `— not evaluated` (classification check is not part of batch Block G) |
+| Culture screen | `— not evaluated` (batch Block A does not produce the Culture screen pass/caution/fail field) |
+| Interview red flags | If `interview-prep/{company-slug}-redflags.md` exists, mirror its warning level + relative link `[{level}](../interview-prep/{company-slug}-redflags.md)`; if not, `— no interview sessions yet` |
+| AI claims vs. infrastructure | If this prompt/report contains the AI/infrastructure mismatch check, mirror its verdict (`✅ consistent` / `⚠️ {finding}`); if not, `— not evaluated` |
 
-Formato del bloque:
+Block format:
 
 ```markdown
 ## Risk Summary

--- a/modes/interview-redflag.md
+++ b/modes/interview-redflag.md
@@ -109,7 +109,7 @@ Compute a **red-flag score**:
 
 ## Step 5 — Generate Output
 
-**Output routing:** Red-flag analysis is company-wide (signals aggregate across rounds regardless of role). Write to a single company-level file: `interview-prep/{company-slug}-redflags.md`. Create it if absent. If sessions span multiple role slugs, note all roles in the header. Do not append to per-role intel files — those are role-specific, this is company-specific.
+**Output routing:** Red-flag analysis is company-wide (signals aggregate across rounds regardless of role). Write to a single company-level file: `interview-prep/{company-slug}-redflags.md`. Create it if absent. If sessions span multiple role slugs, note all roles in the header. Do not append to per-role intel files — those are role-specific, this is company-specific. This file is cross-referenced by the evaluation report's `## Risk Summary` block (see `modes/oferta.md`), which surfaces its warning level plus a relative link — keep the `**Warning level:**` line intact.
 
 Write the following structure:
 

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -321,7 +321,7 @@ Close the report body with a `## Risk Summary` block directly after Block G's se
 
 **Aggregation only, zero new judgment.** Each row quotes or links the verdict already produced by its source signal. The summary never re-scores, re-weights, or overrides — if a row looks wrong, the fix belongs in the source signal, not here.
 
-Three states per row: `✅ {clear verdict}` / `⚠️ {finding}` / `— not evaluated`. **`— not evaluated` is a first-class state:** when a signal could not run, say so explicitly rather than omitting the row, so an all-✅ summary can be trusted.
+Three states per row: `✅ {clear verdict}` / `⚠️ {finding}` / `— not evaluated`. **`— not evaluated` is a first-class state:** when a signal could not run, say so explicitly rather than omitting the row, so an all-✅ summary can be trusted. **Named exception:** the Interview red flags row renders its not-evaluated case as `— no interview sessions yet` — a documented, more specific phrasing of the same "not evaluated" concept for that one row (the cross-reference check did run; it found no redflags file), not a fourth free-floating state.
 
 | Signal | Source | Row rendering |
 |--------|--------|---------------|

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -315,6 +315,40 @@ This signal does not change the High Confidence / Proceed with Caution / Suspici
 
 ---
 
+## Risk Summary (after Block G)
+
+Close the report body with a `## Risk Summary` block directly after Block G's section — one row per risk signal, fixed order — so the question the candidate actually asks ("is this company safe to join?") is answered on one screen instead of by mentally joining Block A, Block G, and a sidecar file.
+
+**Aggregation only, zero new judgment.** Each row quotes or links the verdict already produced by its source signal. The summary never re-scores, re-weights, or overrides — if a row looks wrong, the fix belongs in the source signal, not here.
+
+Three states per row: `✅ {clear verdict}` / `⚠️ {finding}` / `— not evaluated`. **`— not evaluated` is a first-class state:** when a signal could not run, say so explicitly rather than omitting the row, so an all-✅ summary can be trusted.
+
+| Signal | Source | Row rendering |
+|--------|--------|---------------|
+| Posting legitimacy | Block G assessment tier | `✅ High Confidence`, or `⚠️ {tier} — {one-line reason}` for Proceed with Caution / Suspicious |
+| Employment classification | Employment classification signal inside Block G | `✅ clear` when the check ran and found nothing; `⚠️ contractor-style language: "{quoted phrase}"` when the flag fired; `— not evaluated` when the check could not run |
+| Culture screen | Culture screen field in Block A | `✅ pass`, or `⚠️ caution — {evidence}` / `⚠️ fail — {evidence}`; `— not evaluated` when no screen was run |
+| Interview red flags | `interview-prep/{company-slug}-redflags.md` (from `interview-redflag` mode) | **Cross-reference, not a copy:** if the file exists, surface its current warning level plus a relative link — `[{level}](../interview-prep/{company-slug}-redflags.md)` (relative to `reports/`); otherwise `— no interview sessions yet` |
+| AI claims vs. infrastructure | AI/infrastructure mismatch check in Block G, when present | If this report contains that check, mirror its verdict (`✅ consistent` / `⚠️ {finding}`); otherwise `— not evaluated`. The row activates automatically once the check exists — no ordering dependency |
+
+Block format:
+
+```markdown
+## Risk Summary
+
+| Signal | Status |
+|--------|--------|
+| Posting legitimacy | ✅ High Confidence |
+| Employment classification | ⚠️ contractor-style language: "{quoted phrase}" |
+| Culture screen | ⚠️ caution — {evidence} |
+| Interview red flags | — no interview sessions yet |
+| AI claims vs. infrastructure | — not evaluated |
+```
+
+Mirror the block into `## Machine Summary` as a `risk_summary:` map (exact key names and enum values in `batch/batch-prompt.md`, the Machine Summary source of truth) so downstream scripts consume it without re-parsing prose.
+
+---
+
 ## Cover Letter Draft (auto-generated after Block G)
 
 After saving the report and recording in the tracker, append a cover letter draft to the report file under `## Cover Letter Draft`. This is a starting point — not the final letter. The user completes it via `/career-ops cover {slug}`.
@@ -424,6 +458,9 @@ Save full evaluation in `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 ## G) Posting Legitimacy
 (full content of block G)
 
+## Risk Summary
+(one row per risk signal, fixed order — see the Risk Summary section above)
+
 ## H) Draft Application Answers
 (only if score >= 4.5 — draft answers for the application form)
 
@@ -433,7 +470,7 @@ Save full evaluation in `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 (list of 15-20 keywords from the JD for ATS optimization)
 ```
 
-**Machine Summary (required):** every report carries a `## Machine Summary` YAML fence directly after the header — same schema, exact field names, and rules as the "Machine Summary" block in `batch/batch-prompt.md` (do not duplicate the schema here; that file is the source of truth). It includes `advertised_comp`: the JD's own salary figure **verbatim** (e.g. `"80-90k EUR"`), or `null` when the JD states nothing — never estimated, never replaced with researched market data. This key seeds the advertised salary observation read by `node salary-gap.mjs`.
+**Machine Summary (required):** every report carries a `## Machine Summary` YAML fence directly after the header — same schema, exact field names, and rules as the "Machine Summary" block in `batch/batch-prompt.md` (do not duplicate the schema here; that file is the source of truth). It includes `advertised_comp`: the JD's own salary figure **verbatim** (e.g. `"80-90k EUR"`), or `null` when the JD states nothing — never estimated, never replaced with researched market data. This key seeds the advertised salary observation read by `node salary-gap.mjs`. It also includes `risk_summary`: the Risk Summary block mirrored as a map (schema and enum values in `batch/batch-prompt.md`).
 
 ### 2. Record in tracker
 


### PR DESCRIPTION
## Summary

Implements the unified **`## Risk Summary`** block from #1737: every evaluation report now closes its body (directly after Block G) with one fixed-order checklist joining the five existing company-risk signals, so "is this company safe to join?" is answered on one screen instead of by mentally joining Block A, Block G, and a sidecar file.

Prompt-level only — no new scripts, no new mode files.

Closes #1737

## Rendered example

```markdown
## Risk Summary

| Signal | Status |
|--------|--------|
| Posting legitimacy | ✅ High Confidence |
| Employment classification | ⚠️ contractor-style language: "invoice for services" |
| Culture screen | ⚠️ caution — no team-size or org-structure evidence found |
| Interview red flags | — no interview sessions yet |
| AI claims vs. infrastructure | — not evaluated |
```

## Design rules (as specified in the issue)

- **Aggregation only, zero new judgment.** Each row quotes/links the verdict already produced by its source: Block G tier, the #1631 classification flag line, the #1641 Culture screen field, the #1233 red-flag file, the #1685 AI-infra check. If a row is wrong, the fix belongs in the source signal.
- **Interview red flags is a cross-reference, not a copy:** if `interview-prep/{company-slug}-redflags.md` exists, the row surfaces its warning level plus a relative link (`../interview-prep/...` from `reports/`); otherwise `— no interview sessions yet`. This gives #1233 its first consumer inside the report.
- **`— not evaluated` is a first-class state.** Batch workers declare rows they cannot evaluate (classification, culture screen, AI-infra) explicitly instead of omitting them, so an all-✅ summary can be trusted.
- **The AI-infra row ships dormant:** #1685 is still open, so `modes/oferta.md` has no AI/infrastructure mismatch check yet. The template rule is conditional — "if the report contains that check, mirror its verdict; otherwise `— not evaluated`" — so the row activates automatically when #1685 merges, with no ordering dependency between the two PRs.
- **Machine Summary mirror:** the block is mirrored as a `risk_summary:` map, with enums snake_cased from the existing tier vocabularies (no new tier names invented):

  ```yaml
  risk_summary:
    legitimacy: high_confidence   # High Confidence | Proceed with Caution | Suspicious
    classification: clear          # clear | flagged | not_evaluated
    culture: caution               # pass | caution | fail | not_evaluated
    interview_redflags: not_evaluated  # none | caution | warning | not_evaluated
    ai_infra: not_evaluated        # consistent | mismatch | not_evaluated
  ```

  `batch/batch-prompt.md` stays the Machine Summary schema source of truth (both fences updated); `modes/oferta.md` points at it, matching the existing `advertised_comp` pattern.

## Files changed

- `modes/oferta.md` — Risk Summary section (rendering rules + block format) + report skeleton + Machine Summary pointer
- `batch/batch-prompt.md` — batch rendering rules, both Machine Summary fences, report skeleton
- `modes/interview-redflag.md` — one line noting its output file is cross-referenced by the report's Risk Summary
- `AGENTS.md` / `CLAUDE.md` — `reports/` row: "Blocks A-F + G (Posting Legitimacy) + Risk Summary" (minimal diff, hot collision files)
- No `modes/{lang}/` translations touched (can follow up if wanted)

## Testing

- `node test-all.mjs` — 1553 passed, 0 failed (1 pre-existing warning: `cv-sync-check.mjs` without user data)
- `node validate-system-paths-coverage.mjs` — OK, 675 tracked files covered (no new files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a standardized **Risk Summary (after Block G)** to evaluation reports, presenting a fixed table that aggregates existing verdicts and clearly marks signals as ✅ / ⚠️ / — not evaluated.
  - Added matching **Machine Summary** support via a new `risk_summary` section for automated downstream use.

- **Documentation**
  - Updated report and mode guidance/templates to require the new Risk Summary block and to include the relevant warning level and red-flags presence when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->