### PR TITLE
Add structured HTML CV builder

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { basename, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = resolve(ROOT, 'templates', 'cv-template.html');
+const PLACEHOLDER_RE = /\{\{[^{}]+\}\}/g;
+const PAGE_WIDTHS = new Set(['210mm', '8.5in']);
+
+export function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+    .replaceAll('{', '&#123;')
+    .replaceAll('}', '&#125;');
+}
+
+function safeUrl(value, protocols = ['https:', 'http:']) {
+  const raw = String(value ?? '').trim();
+  if (!raw) return '';
+
+  try {
+    const parsed = new URL(raw);
+    return protocols.includes(parsed.protocol) ? escapeHtml(raw) : '';
+  } catch {
+    return '';
+  }
+}
+
+function renderContact(candidate = {}) {
+  const items = [];
+  const phone = String(candidate.phone ?? '').trim();
+  const email = String(candidate.email ?? '').trim();
+  const linkedinUrl = safeUrl(candidate.linkedin?.url);
+  const portfolioUrl = safeUrl(candidate.portfolio?.url);
+  const location = String(candidate.location ?? '').trim();
+
+  if (phone) items.push(`<a href="tel:${escapeHtml(phone)}">${escapeHtml(phone)}</a>`);
+  if (email) items.push(`<a href="mailto:${escapeHtml(email)}">${escapeHtml(email)}</a>`);
+  if (linkedinUrl) {
+    items.push(`<a href="${linkedinUrl}">${escapeHtml(candidate.linkedin?.display || candidate.linkedin.url)}</a>`);
+  }
+  if (portfolioUrl) {
+    items.push(`<a href="${portfolioUrl}">${escapeHtml(candidate.portfolio?.display || candidate.portfolio.url)}</a>`);
+  }
+  if (location) items.push(`<span>${escapeHtml(location)}</span>`);
+
+  return items.join('\n      <span class="separator">|</span>\n      ');
+}
+
+function renderCompetencies(entries) {
+  return Array.isArray(entries)
+    ? entries.map(entry => `<span class="competency-tag">${escapeHtml(entry)}</span>`).join('\n      ')
+    : '';
+}
+
+function renderExperience(entries) {
+  if (!Array.isArray(entries)) return '';
+  return entries.filter(Boolean).map(entry => {
+    const bullets = Array.isArray(entry.bullets)
+      ? entry.bullets.map(bullet => `      <li>${escapeHtml(bullet)}</li>`).join('\n')
+      : '';
+    return `<div class="job">
+    <div class="job-header">
+      <div class="job-company">${escapeHtml(entry.company)}</div>
+      <div class="job-period">${escapeHtml(entry.dates)}</div>
+    </div>
+    <div class="job-role">${escapeHtml(entry.role)}</div>
+    <div class="job-location">${escapeHtml(entry.location)}</div>
+    <ul>
+${bullets}
+    </ul>
+  </div>`;
+  }).join('\n  ');
+}
+
+function renderProjects(entries) {
+  if (!Array.isArray(entries)) return '';
+  return entries.filter(Boolean).map(entry => {
+    const badge = entry.badge ? `<span class="project-badge">${escapeHtml(entry.badge)}</span>` : '';
+    const description = entry.description ? `<div class="project-desc">${escapeHtml(entry.description)}</div>` : '';
+    const tech = entry.tech ? `<div class="project-tech">${escapeHtml(entry.tech)}</div>` : '';
+    return `<div class="project">
+    <div><span class="project-title">${escapeHtml(entry.name)}</span>${badge}</div>
+    ${description}
+    ${tech}
+  </div>`;
+  }).join('\n  ');
+}
+
+function renderEducation(entries) {
+  if (!Array.isArray(entries)) return '';
+  return entries.filter(Boolean).map(entry => `<div class="edu-item">
+    <div><strong>${escapeHtml(entry.degree)}</strong>${entry.year ? ` <span class="edu-year">${escapeHtml(entry.year)}</span>` : ''}</div>
+    <div>${escapeHtml(entry.institution)}${entry.location ? ` — ${escapeHtml(entry.location)}` : ''}</div>
+  </div>`).join('\n  ');
+}
+
+function renderCertifications(entries) {
+  if (!Array.isArray(entries)) return '';
+  return entries.filter(Boolean).map(entry => `<div class="cert-item">
+    <span class="cert-title">${escapeHtml(entry.title)}</span>
+    <span class="cert-org">${escapeHtml(entry.organization)}</span>
+    <span class="cert-year">${escapeHtml(entry.year)}</span>
+  </div>`).join('\n  ');
+}
+
+function renderSkills(entries) {
+  if (!Array.isArray(entries)) return '';
+  const items = entries.filter(Boolean).map(entry => {
+    const values = Array.isArray(entry.items) ? entry.items.join(', ') : entry.items;
+    return `<div class="skill-item"><span class="skill-category">${escapeHtml(entry.category)}:</span> ${escapeHtml(values)}</div>`;
+  }).join('\n    ');
+  return `<div class="skills-grid">\n    ${items}\n  </div>`;
+}
+
+function renderPhoto(candidate = {}) {
+  const raw = String(candidate.photo ?? '').trim();
+  if (!raw) return '';
+  const isDataImage = /^data:image\/(?:png|jpe?g|webp);base64,[a-z0-9+/=\s]+$/i.test(raw);
+  const isLocalPath = !/^[a-z][a-z0-9+.-]*:/i.test(raw);
+  if (!isDataImage && !isLocalPath) {
+    throw new Error('candidate.photo must be a local path or base64 image data URL');
+  }
+  return `<img class="cv-photo" src="${escapeHtml(raw)}" alt="${escapeHtml(candidate.name)}">`;
+}
+
+export function buildCvHtml(template, payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('input JSON must be an object');
+  }
+  const pageWidth = payload.page_width || '210mm';
+  if (!PAGE_WIDTHS.has(pageWidth)) {
+    throw new Error('page_width must be 210mm or 8.5in');
+  }
+
+  const candidate = payload.candidate || {};
+  const labels = {
+    summary: 'Professional Summary',
+    competencies: 'Core Competencies',
+    experience: 'Work Experience',
+    projects: 'Projects',
+    education: 'Education',
+    certifications: 'Certifications',
+    skills: 'Skills',
+    ...(payload.section_labels || {}),
+  };
+  const substitutions = {
+    LANG: escapeHtml(payload.lang || 'en'),
+    PAGE_WIDTH: pageWidth,
+    PHOTO: renderPhoto(candidate),
+    NAME: escapeHtml(candidate.name),
+    PHONE: '',
+    EMAIL: '',
+    LINKEDIN_URL: '',
+    LINKEDIN_DISPLAY: '',
+    PORTFOLIO_URL: '',
+    PORTFOLIO_DISPLAY: '',
+    LOCATION: '',
+    SECTION_SUMMARY: escapeHtml(labels.summary),
+    SUMMARY_TEXT: escapeHtml(payload.summary),
+    SECTION_COMPETENCIES: escapeHtml(labels.competencies),
+    COMPETENCIES: renderCompetencies(payload.competencies),
+    SECTION_EXPERIENCE: escapeHtml(labels.experience),
+    EXPERIENCE: renderExperience(payload.experience),
+    SECTION_PROJECTS: escapeHtml(labels.projects),
+    PROJECTS: renderProjects(payload.projects),
+    SECTION_EDUCATION: escapeHtml(labels.education),
+    EDUCATION: renderEducation(payload.education),
+    SECTION_CERTIFICATIONS: escapeHtml(labels.certifications),
+    CERTIFICATIONS: renderCertifications(payload.certifications),
+    SECTION_SKILLS: escapeHtml(labels.skills),
+    SKILLS: renderSkills(payload.skills),
+  };
+
+  let output = template.replace(
+    /<div class="contact-row">[\s\S]*?<\/div>/,
+    `<div class="contact-row">\n      ${renderContact(candidate)}\n    </div>`,
+  );
+  output = output.replace(PLACEHOLDER_RE, token => {
+    const key = token.slice(2, -2);
+    return Object.hasOwn(substitutions, key) ? substitutions[key] : token;
+  });
+
+  const unresolved = [...new Set(output.match(PLACEHOLDER_RE) || [])];
+  if (unresolved.length) throw new Error(`Unresolved placeholders: ${unresolved.join(', ')}`);
+  return output;
+}
+
+async function main() {
+  const [inputPath, outputPath] = process.argv.slice(2);
+  if (!inputPath || !outputPath || inputPath === '--help') {
+    console.error('Usage: node build-cv-html.mjs <input.json> <output.html>');
+    process.exitCode = inputPath === '--help' ? 0 : 1;
+    return;
+  }
+
+  try {
+    if (!existsSync(inputPath)) throw new Error(`Input file not found: ${resolve(inputPath)}`);
+    const payload = JSON.parse(await readFile(inputPath, 'utf8'));
+    const template = await readFile(TEMPLATE_PATH, 'utf8');
+    const html = buildCvHtml(template, payload);
+    const absoluteOutput = resolve(outputPath);
+    await mkdir(dirname(absoluteOutput), { recursive: true });
+    await writeFile(absoluteOutput, html, 'utf8');
+    const info = await stat(absoluteOutput);
+    console.log(JSON.stringify({
+      file: basename(absoluteOutput),
+      path: absoluteOutput,
+      sizeKB: Number((info.size / 1024).toFixed(1)),
+      valid: true,
+    }, null, 2));
+  } catch (error) {
+    console.error(`Failed to build CV HTML: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -12,6 +12,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run dedup` | `dedup-tracker.mjs` | Remove duplicate tracker entries |
 | `npm run merge` | `merge-tracker.mjs` | Merge batch TSVs into applications.md |
 | `npm run pdf` | `generate-pdf.mjs` | Convert HTML to ATS-optimized PDF |
+| `npm run build:html` | `build-cv-html.mjs` | Build HTML from a structured JSON payload |
 | `npm run build:latex` | `build-cv-latex.mjs` | Build .tex from structured JSON payload |
 | `npm run sync-check` | `cv-sync-check.mjs` | Validate CV/profile consistency |
 | `npm run patterns` | `analyze-patterns.mjs` | Analyze tracker outcomes and report patterns |
@@ -141,6 +142,26 @@ node build-cv-latex.mjs --test
 ```
 
 **Exit codes:** `0` file generated, `1` missing inputs, invalid JSON, unresolved placeholders, or template not found.
+
+---
+
+## build:html
+
+Builds an ATS-safe HTML CV from a structured JSON payload and
+`templates/cv-template.html`. The agent reads the approved source-of-truth files,
+selects and reformulates only supported content, then writes the compact payload;
+the script owns HTML structure, escaping, and template substitution.
+
+```bash
+npm run build:html -- examples/cv-html/candidate.json output/cv-example.html
+node generate-pdf.mjs output/cv-example.html output/cv-example.pdf --format=a4
+```
+
+`page_width` accepts only `210mm` or `8.5in`. Candidate text is HTML-escaped,
+contact links reject unsafe URL schemes, and profile photos remain opt-in.
+
+**Exit codes:** `0` HTML generated, `1` missing inputs, invalid JSON, unsafe
+values, unresolved placeholders, or a missing template.
 
 ---
 

--- a/examples/cv-html/candidate.json
+++ b/examples/cv-html/candidate.json
@@ -1,0 +1,56 @@
+{
+  "lang": "en",
+  "page_width": "210mm",
+  "candidate": {
+    "name": "Alex Example",
+    "email": "alex@example.com",
+    "linkedin": {
+      "url": "https://linkedin.com/in/alex-example",
+      "display": "linkedin.com/in/alex-example"
+    },
+    "portfolio": {
+      "url": "https://example.com",
+      "display": "example.com"
+    },
+    "location": "Example City"
+  },
+  "summary": "Engineer who turns <unsafe> input into reliable products.",
+  "competencies": ["Workflow automation", "HTML & PDF"],
+  "experience": [
+    {
+      "company": "Example Labs",
+      "role": "Software Engineer",
+      "location": "Remote",
+      "dates": "2024 — Present",
+      "bullets": ["Built a deterministic renderer with 100% escaped input."]
+    }
+  ],
+  "projects": [
+    {
+      "name": "Safe Renderer",
+      "badge": "Open source",
+      "description": "Converted structured data into ATS-safe output.",
+      "tech": "Node.js, HTML"
+    }
+  ],
+  "education": [
+    {
+      "degree": "BSc Computer Science",
+      "institution": "Example University",
+      "year": "2024"
+    }
+  ],
+  "certifications": [
+    {
+      "title": "Example Certification",
+      "organization": "Example Institute",
+      "year": "2025"
+    }
+  ],
+  "skills": [
+    {
+      "category": "Languages",
+      "items": ["JavaScript", "HTML"]
+    }
+  ]
+}

--- a/examples/cv-html/unsafe-page-width.json
+++ b/examples/cv-html/unsafe-page-width.json
@@ -1,0 +1,4 @@
+{
+  "page_width": "210mm; } body { display: none",
+  "candidate": { "name": "Unsafe Example" }
+}

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -75,7 +75,13 @@ Examples of legitimate reformulation:
 
 **Before generating: read `modes/_custom.md` (if it exists) and apply its formatting/content house rules to every CV in this session — including every item of a batch.** Rules recorded there (date formats, section-order preferences, content to always/never include) are persistent user instructions, not suggestions; if the user corrects the same thing twice in conversation, write it into `modes/_custom.md` so it stops drifting.
 
-Use the template in `cv-template.html`. Replace the `{{...}}` placeholders with personalized content:
+Build a compact structured payload from the approved source-of-truth files, then run
+`node build-cv-html.mjs <payload.json> <output.html>`. The deterministic builder
+escapes candidate-controlled text and replaces the `cv-template.html` placeholders;
+do not spend model output reproducing the template's HTML/CSS. Review the generated
+HTML before passing it to `generate-pdf.mjs` in Step 17.
+
+The payload maps to these template placeholders:
 
 | Placeholder | Content |
 |-------------|-----------|

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "merge": "node merge-tracker.mjs",
     "reconcile": "node reconcile-pipeline.mjs",
     "pdf": "node generate-pdf.mjs",
+    "build:html": "node build-cv-html.mjs",
     "cover-letter": "node generate-cover-letter.mjs --payload",
     "sync-check": "node cv-sync-check.mjs",
     "update:check": "node update-system.mjs check",

--- a/tests/build-cv-html.test.mjs
+++ b/tests/build-cv-html.test.mjs
@@ -1,0 +1,114 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fail, pass, ROOT } from './helpers.mjs';
+import { buildCvHtml } from '../build-cv-html.mjs';
+
+console.log('\nCV HTML builder');
+
+const dir = await mkdtemp(join(tmpdir(), 'career-ops-html-'));
+const output = join(dir, 'cv.html');
+
+try {
+  const result = spawnSync(process.execPath, [
+    join(ROOT, 'build-cv-html.mjs'),
+    join(ROOT, 'examples/cv-html/candidate.json'),
+    output,
+  ], { encoding: 'utf8' });
+
+  if (result.status !== 0) {
+    fail(`structured fixture failed to build: ${result.stderr}`);
+  } else {
+    const html = await readFile(output, 'utf8');
+    const checks = [
+      [/<html lang="en">/, 'sets the payload language'],
+      [/Alex Example/, 'renders the candidate name'],
+      [/Engineer who turns &lt;unsafe&gt; input/, 'escapes candidate-controlled text'],
+      [/<span class="competency-tag">Workflow automation<\/span>/, 'renders competencies'],
+      [/<div class="job-company">Example Labs<\/div>/, 'renders experience'],
+      [/<span class="skill-category">Languages:<\/span>/, 'renders skills'],
+    ];
+    for (const [pattern, label] of checks) {
+      if (pattern.test(html)) pass(`build-cv-html ${label}`);
+      else fail(`build-cv-html does not ${label}`);
+    }
+    if (!/\{\{[A-Z_]+\}\}/.test(html)) pass('build-cv-html resolves every template placeholder');
+    else fail('build-cv-html leaves unresolved template placeholders');
+    if (!/<img\s+[^>]*class=/.test(html)) pass('build-cv-html keeps profile photos opt-in');
+    else fail('build-cv-html emits a profile photo without candidate.photo');
+  }
+
+  const unsafe = spawnSync(process.execPath, [
+    join(ROOT, 'build-cv-html.mjs'),
+    join(ROOT, 'examples/cv-html/unsafe-page-width.json'),
+    join(dir, 'unsafe.html'),
+  ], { encoding: 'utf8' });
+  if (unsafe.status !== 0 && /page_width must be 210mm or 8\.5in/.test(unsafe.stderr)) {
+    pass('build-cv-html rejects CSS injection through page_width');
+  } else {
+    fail('build-cv-html accepts an unsupported page_width');
+  }
+
+  const hostileInput = join(dir, 'hostile.json');
+  const hostileOutput = join(dir, 'hostile.html');
+  await writeFile(hostileInput, JSON.stringify({
+    candidate: {
+      name: 'Literal {{SKILLS}}',
+      phone: '123" onmouseover="alert(1)',
+      email: 'alex"@example.com',
+      linkedin: { url: 'javascript:alert(1)', display: 'unsafe' },
+      portfolio: { url: 'data:text/html,unsafe', display: 'unsafe' },
+      photo: 'images/profile" onerror="alert(1).png',
+    },
+    summary: 'Keep literal {{SKILLS}} text',
+    skills: [{ category: 'Safe', items: ['Rendered once'] }],
+  }));
+  const hostile = spawnSync(process.execPath, [join(ROOT, 'build-cv-html.mjs'), hostileInput, hostileOutput], { encoding: 'utf8' });
+  if (hostile.status !== 0) {
+    fail(`hostile-but-valid payload failed to build: ${hostile.stderr}`);
+  } else {
+    const html = await readFile(hostileOutput, 'utf8');
+    const summary = html.match(/<div class="summary-text">([\s\S]*?)<\/div>/)?.[1] || '';
+    if (/&#123;&#123;SKILLS&#125;&#125;/.test(summary) && !/skills-grid/.test(summary)) {
+      pass('candidate placeholder-like text is escaped and never reprocessed');
+    } else {
+      fail('candidate placeholder-like text is reprocessed as template markup');
+    }
+    if (!/javascript:|data:text\/html/.test(html)) pass('unsafe contact URL schemes are dropped');
+    else fail('unsafe contact URL schemes reach generated HTML');
+    if (!/["']\s+(?:onmouseover|onerror)=/i.test(html)) pass('contact and photo attributes escape injected markup');
+    else fail('candidate-controlled attributes permit markup injection');
+    if (/<img class="cv-photo" src="images\/profile&quot; onerror=&quot;alert\(1\)\.png"/.test(html)) {
+      pass('safe local profile photos remain opt-in and attribute-escaped');
+    } else {
+      fail('safe local profile photo is missing or not attribute-escaped');
+    }
+  }
+
+  try {
+    buildCvHtml('<html>{{lowercase_token}}</html>', {});
+    fail('build-cv-html permits generic unresolved template tokens');
+  } catch (error) {
+    if (/Unresolved placeholders: \{\{lowercase_token\}\}/.test(error.message)) {
+      pass('build-cv-html rejects generic unresolved template tokens');
+    } else {
+      fail(`generic unresolved token raised the wrong error: ${error.message}`);
+    }
+  }
+
+  const packageJson = JSON.parse(await readFile(join(ROOT, 'package.json'), 'utf8'));
+  const docs = await readFile(join(ROOT, 'docs/SCRIPTS.md'), 'utf8');
+  const pdfMode = await readFile(join(ROOT, 'modes/pdf.md'), 'utf8');
+  const updater = await readFile(join(ROOT, 'update-system.mjs'), 'utf8');
+  if (packageJson.scripts['build:html'] === 'node build-cv-html.mjs') pass('package.json exposes build:html');
+  else fail('package.json does not expose build:html');
+  if (/build:html/.test(docs)) pass('script docs cover build:html');
+  else fail('script docs omit build:html');
+  if (/build-cv-html\.mjs/.test(pdfMode)) pass('PDF mode uses the deterministic HTML builder');
+  else fail('PDF mode still requires handwritten template HTML');
+  if (/'build-cv-html\.mjs'/.test(updater)) pass('updater ships build-cv-html.mjs');
+  else fail('updater omits build-cv-html.mjs');
+} finally {
+  await rm(dir, { recursive: true, force: true });
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -245,6 +245,7 @@ const SYSTEM_PATHS = [
   '.github/',
   'package.json',
   'build-cv-latex.mjs',
+  'build-cv-html.mjs',
   'scaffolder/',
   'Dockerfile',
   'docker-compose.yml',


### PR DESCRIPTION
## Summary

- add a deterministic `build-cv-html.mjs` renderer for structured CV payloads
- escape candidate-controlled text and attributes, reject unsafe URL/CSS inputs, and keep profile photos opt-in
- update the PDF mode to emit compact JSON instead of reproducing template HTML/CSS
- add fictional fixtures, focused regression coverage, npm/docs wiring, and updater registration

Closes #557.

## Validation

- `node test-all.mjs --only build-cv-html` → 18 passed, 0 failed
- `node test-all.mjs` → exit 0, dashboard build included
- generated fixture HTML and rendered it through `generate-pdf.mjs` → 1-page A4 PDF
- `git diff --check origin/main...HEAD`
