### PR TITLE
docs: remove deprecated gemini CLI and broken agy auth login references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ Output: `{"onboardingNeeded": <bool>, "missing": [...], "warnings": [...], "auto
 
 If the user mentions cost, pricing, budget, or asks about free alternatives during onboarding, proactively surface the free path:
 
-> "career-ops works fully on Antigravity CLI's free tier — no API key or paid subscription needed. See [FREE_TIER.md](docs/FREE_TIER.md) for setup (`agy auth login`, daily limits, and batch tips)."
+> "career-ops works fully on Antigravity CLI's free tier — no API key or paid subscription needed. See [FREE_TIER.md](docs/FREE_TIER.md) for setup, daily limits, and batch tips."
 
 If the user is already on a paid plan (Claude Max, Google AI, etc.) or does not mention cost, skip this step silently.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This clones the latest release into `./career-ops` and installs dependencies. Th
 
 ```bash
 cd career-ops
-claude   # or gemini / codex / qwen / opencode / agy / grok — open your AI CLI here
+claude   # or codex / qwen / opencode / agy / grok — open your AI CLI here
 ```
 
 **On first launch, career-ops walks you through setup — your CV, profile and target roles — just by chatting. Nothing to edit by hand.**
@@ -153,7 +153,7 @@ cp templates/portals.example.yml portals.yml       # Customize companies
 # Create cv.md in the project root with your CV in markdown
 
 # 5. Open your AI CLI in this directory
-claude   # or codex / opencode / gemini / qwen / agy / grok
+claude   # or codex / opencode / qwen / agy / grok
 
 # Then ask your CLI to adapt the system to you:
 # "Change the archetypes to backend engineering roles"

--- a/docs/FREE_TIER.md
+++ b/docs/FREE_TIER.md
@@ -27,9 +27,9 @@ subscription required. This guide covers setup, limits, and trade-offs.
 
 2. Authenticate with your Google account:
 
-   ```bash
-   agy auth login
-   ```
+   Just run `agy`. If not already signed in, it checks the system
+   keyring, then falls back to Google Sign-In (browser locally /
+   URL + code over SSH).
 
 3. Run career-ops as usual:
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -18,7 +18,7 @@ npx @santifer/career-ops init
 
 ```bash
 cd career-ops
-claude   # or gemini / codex / qwen / opencode / agy / grok
+claude   # or codex / qwen / opencode / agy / grok
 ```
 
 **On first launch, career-ops walks you through setup by chatting** — it asks for your CV, your details (name, target roles, salary), and sets up the job scanner with pre-configured companies. Nothing to edit by hand: just answer its questions. Then paste a job offer URL or description and it evaluates it, writes a report, generates a tailored PDF, and tracks it.


### PR DESCRIPTION
## Summary

Fixes #1717

### Changes

- **`README.md`** — Remove `gemini` from two quick-start CLI suggestion lists
- **`docs/SETUP.md`** — Remove `gemini` from quick-start CLI suggestion list
- **`docs/FREE_TIER.md`** — Replace broken `agy auth login` with the correct sign-in flow (just run `agy`; it handles sign-in via system keyring, then falls back to Google Sign-In)
- **`AGENTS.md`** — Remove ``agy auth login`` reference from the free-tier onboarding message

### Why

- `gemini` CLI is deprecated and returns an `IneligibleTierError` for consumer users — they must migrate to Antigravity CLI
- `agy auth login` is not a real subcommand (confirmed by `agy help` showing no `auth` subcommand)

### Verification

- Diff is focused: 4 files, +7/-7 lines
- No functional code changes; docs-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified free-tier setup guidance, clarifying that no API key or paid subscription is required.
  * Updated authentication instructions to use the CLI with automatic keyring or Google Sign-In fallback.
  * Refreshed Quick Start examples to reflect currently supported AI coding CLI options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->