### PR TITLE
fix(portals): accept provider-plugin ids

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2114,6 +2114,7 @@ console.log('\n10. Portals config validator');
 try {
   const tmp = mkdtempSync(join(tmpdir(), 'career-ops-portals-validator-'));
   const validPath = join(tmp, 'valid.yml');
+  const validProviderPluginPath = join(tmp, 'valid-provider-plugin.yml');
   const invalidProviderPath = join(tmp, 'invalid-provider.yml');
   const emptyKeywordPath = join(tmp, 'empty-keyword.yml');
   const duplicateCompanyPath = join(tmp, 'duplicate-company.yml');
@@ -2127,6 +2128,14 @@ title_filter:
 tracked_companies:
   - name: "Acme"
     careers_url: "https://jobs.lever.co/acme"
+`, 'utf-8');
+
+  writeFileSync(validProviderPluginPath, `
+title_filter:
+  positive: ["AI"]
+tracked_companies:
+  - name: "Apify Source"
+    provider: "apify"
 `, 'utf-8');
 
   writeFileSync(invalidProviderPath, `
@@ -2188,6 +2197,13 @@ tracked_companies:
     pass('validate-portals accepts a minimal valid portals file');
   } else {
     fail('validate-portals should accept a minimal valid portals file');
+  }
+
+  const validProviderPluginResult = run(NODE, ['validate-portals.mjs', '--file', validProviderPluginPath]);
+  if (validProviderPluginResult !== null && validProviderPluginResult.includes('0 errors')) {
+    pass('validate-portals accepts bundled provider-plugin ids');
+  } else {
+    fail('validate-portals should accept bundled provider-plugin ids');
   }
 
   const exampleResult = run(NODE, ['validate-portals.mjs', '--file', 'templates/portals.example.yml']);

--- a/validate-portals.mjs
+++ b/validate-portals.mjs
@@ -107,9 +107,10 @@ async function loadProviderIds() {
     for (const manifest of manifests) {
       if (manifest.hooks.includes('provider')) ids.add(manifest.id);
     }
-  } catch {
+  } catch (err) {
     // A stripped-down checkout may not include plugin infrastructure. Core
     // provider validation should continue to work in that environment.
+    if (err?.code !== 'ERR_MODULE_NOT_FOUND') throw err;
   }
   return ids;
 }

--- a/validate-portals.mjs
+++ b/validate-portals.mjs
@@ -88,13 +88,28 @@ function validateParser(parser, path, errors) {
 
 async function loadProviderIds() {
   const ids = new Set();
-  if (!existsSync(PROVIDERS_DIR)) return ids;
-  const files = readdirSync(PROVIDERS_DIR)
-    .filter(f => f.endsWith('.mjs') && !f.startsWith('_'))
-    .sort();
-  for (const file of files) {
-    const mod = await import(pathToFileURL(join(PROVIDERS_DIR, file)).href);
-    if (mod.default?.id) ids.add(mod.default.id);
+  if (existsSync(PROVIDERS_DIR)) {
+    const files = readdirSync(PROVIDERS_DIR)
+      .filter(f => f.endsWith('.mjs') && !f.startsWith('_'))
+      .sort();
+    for (const file of files) {
+      const mod = await import(pathToFileURL(join(PROVIDERS_DIR, file)).href);
+      if (mod.default?.id) ids.add(mod.default.id);
+    }
+  }
+
+  // scan.mjs accepts explicit provider-plugin ids even when a plugin is
+  // disabled or missing credentials (the runtime installs an actionable
+  // inactive-provider stub). Keep validation aligned with that contract.
+  try {
+    const { discoverPlugins, pluginRoots, resolveSuccessorIds } = await import('./plugins/_engine.mjs');
+    const manifests = discoverPlugins(pluginRoots(ROOT), resolveSuccessorIds(ROOT));
+    for (const manifest of manifests) {
+      if (manifest.hooks.includes('provider')) ids.add(manifest.id);
+    }
+  } catch {
+    // A stripped-down checkout may not include plugin infrastructure. Core
+    // provider validation should continue to work in that environment.
   }
   return ids;
 }


### PR DESCRIPTION
## What does this PR do?

Aligns `validate-portals.mjs` with the scanner's provider-plugin contract.

The scanner accepts an explicit provider-plugin ID from `portals.yml`, including known plugins that are disabled or missing credentials (those receive an actionable inactive-provider stub). The validator previously loaded IDs only from core `providers/*.mjs`, so the same valid configuration failed validation as `unknown provider`.

This change:

- keeps loading core provider IDs as before;
- discovers bundled and locally installed provider plugins through the existing plugin engine;
- uses the same approved-successor selection rules as runtime provider loading;
- lazily imports plugin infrastructure so core-only or stripped-down checkouts continue to validate safely;
- adds regression coverage using the bundled `apify` provider plugin while preserving rejection of invented providers.

## Related issue

Related to the plugin ecosystem umbrella #1321. This is a validator/runtime consistency bug fix.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Validation

- `node test-all.mjs` — 1665 passed, 0 failed; one expected warning because Go is not available in the local environment
- `node test-all.mjs --quick` — 1665 passed, 0 failed; one expected no-user-data warning
- `node validate-portals.mjs --self-test`
- `node validate-portals.mjs --file templates/portals.example.yml` — 0 errors, 0 warnings
- `node --check validate-portals.mjs`
- `git diff --check`

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] My changes contain no personal data
- [x] My changes respect the Data Contract
- [x] The full test suite passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portal validation now recognizes provider IDs coming from bundled provider plugins (in addition to providers available in the standard providers directory).
  * Validation is more resilient in setups where optional provider-plugin infrastructure is missing.

* **Tests**
  * Added a temporary portals fixture and assertions to confirm that tracked company entries using a bundled provider-plugin provider ID pass validation with zero errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->