### PR TITLE
ci: matrix the test suite across ubuntu, macOS, and Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,20 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      # One OS failing must not cancel the evidence from the others —
+      # a platform-specific failure is exactly what this matrix exists to isolate.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
+      # The repo is committed with LF; Windows runners default to autocrlf,
+      # which would rewrite every text file on checkout and make regexes that
+      # rely on `.` (no \r) fail in ways the other platforms never see.
+      - name: Force LF checkout on Windows
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 # A force-push supersedes the running matrix; cancel it instead of letting
 # stale legs occupy runners (3 jobs per push at this repo's PR volume).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [main]
 
+# A force-push supersedes the running matrix; cancel it instead of letting
+# stale legs occupy runners (3 jobs per push at this repo's PR volume).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Closes #1761

## Why

The #1719 review caught a deterministic macOS-only crash (`tmpdir()` symlink defeating the copied-script main-guard) that `ubuntu-latest` CI structurally cannot see — it survived to a maintainer laptop because CI runs one OS. Six scripts share that main-guard convention; the class recurs. Full reasoning in #1761.

## What

One file, `.github/workflows/test.yml`:
- `strategy.matrix.os: [ubuntu-latest, macos-latest, windows-latest]`, `fail-fast: false` (a platform-specific failure should be isolated, not cancel the other legs)
- Windows leg sets `core.autocrlf false` before checkout. This is load-bearing, not cosmetic: with autocrlf rewriting, at least two current upstream checks fail on Windows purely from `\r` — JS regexes using `.` (which excludes `\r`) against CRLF-checked-out files (reproduced today against test-all.mjs:1028's `language.output` check; the same regex passes against the LF blob).
- Everything else unchanged (same Node/Go setup, same `--ignore-scripts`, same `--quick`).

## Evidence it goes green

- **Windows**: full suite 1620–1662 passed / 0 failed locally across several branches today (LF checkouts; symlink checks degrade to warnings by design)
- **macOS**: #1719's 1557/1 becomes /0 with the realpath fix already on that branch; nothing else in the suite touches symlinked tmp paths without realpath
- **ubuntu**: status quo

## ⚠️ Deployment — needs a settings change in the same window as merge

Branch protection required checks rename: `test` → `test (ubuntu-latest)` / `test (macos-latest)` / `test (windows-latest)`. Without the settings update every subsequent PR blocks on a phantom check.

Sequencing per the block-order note in #1761: happy for this to sit until the current review block (#1694→#1695→#1712→#1719→#1714) clears, so the required-check migration doesn't land mid-block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the CI test suite to run across Ubuntu, macOS, and Windows.
  * Enabled parallel cross-platform runs without stopping other environments when one fails.
  * Improved Windows test consistency by preventing automatic line-ending rewriting.
* **Chores**
  * Added workflow run concurrency to cancel superseded in-progress runs for the same branch/version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->