### PR TITLE
feat(scan): persist + surface the scanner trust/legitimacy signal to pipeline.md + scan-history.tsv (#1743)

### DIFF
--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -84,10 +84,13 @@ are defined:
   (`offer.postedAt`). The scanner writes it so freshness is visible at triage time
   without re-fetching the ATS. Rows from providers with no posting date simply omit
   the segment.
-- `| trust: {score} {flag,flag}` — the scanner's legitimacy signal, written **only
-  when a posting is flagged** (`offer.trustScore < 100`): the 0–100 trust score,
-  then a space, then the comma-separated reasons (e.g. `missing_apply_url`,
-  `invalid_url`, `suspicious_domain`). Example: `… | trust: 60 missing_apply_url,suspicious_domain`.
+- `| trust: {score}` — optionally `| trust: {score} {flag,flag}` — the scanner's
+  legitimacy signal, written **only when a posting is flagged** (`offer.trustScore
+  < 100`): the 0–100 trust score, followed (when the validator recorded any
+  reasons) by a space and the comma-separated flags (e.g. `missing_apply_url`,
+  `invalid_url`, `suspicious_domain`). The flag suffix is omitted when there are
+  none, so a score-only segment like `… | trust: 80` is valid. Example with flags:
+  `… | trust: 60 missing_apply_url,suspicious_domain`.
   A clean posting (or a scan with `trust_filter` disabled) omits the segment. Treat
   a low score as a ghost/scam-posting warning and weigh it in Block G legitimacy
   before spending an evaluation. The same score + flags are also written to the

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -85,9 +85,9 @@ are defined:
   without re-fetching the ATS. Rows from providers with no posting date simply omit
   the segment.
 - `| trust: {score} {flag,flag}` — the scanner's legitimacy signal, written **only
-  when a posting is flagged** (`offer.trustScore < 100`): the 0–100 trust score
-  followed by the space-separated reasons (e.g. `missing_apply_url`, `invalid_url`,
-  `suspicious_domain`). Example: `… | trust: 60 missing_apply_url,suspicious_domain`.
+  when a posting is flagged** (`offer.trustScore < 100`): the 0–100 trust score,
+  then a space, then the comma-separated reasons (e.g. `missing_apply_url`,
+  `invalid_url`, `suspicious_domain`). Example: `… | trust: 60 missing_apply_url,suspicious_domain`.
   A clean posting (or a scan with `trust_filter` disabled) omits the segment. Treat
   a low score as a ghost/scam-posting warning and weigh it in Block G legitimacy
   before spending an evaluation. The same score + flags are also written to the

--- a/modes/pipeline.md
+++ b/modes/pipeline.md
@@ -77,18 +77,27 @@ read as having empty values for the missing trailing columns.
 
 Beyond the positional cells, rows may carry optional **labeled** segments —
 `| {label}: {value}` — that ride on any row shape (bare URL, 3-, 4-, or 5-column),
-because the `{label}:` prefix identifies them regardless of column position. Two
+because the `{label}:` prefix identifies them regardless of column position. Three
 are defined:
 
 - `| posted: {YYYY-MM-DD}` — the posting date, when the provider's API exposed one
   (`offer.postedAt`). The scanner writes it so freshness is visible at triage time
   without re-fetching the ATS. Rows from providers with no posting date simply omit
   the segment.
+- `| trust: {score} {flag,flag}` — the scanner's legitimacy signal, written **only
+  when a posting is flagged** (`offer.trustScore < 100`): the 0–100 trust score
+  followed by the space-separated reasons (e.g. `missing_apply_url`, `invalid_url`,
+  `suspicious_domain`). Example: `… | trust: 60 missing_apply_url,suspicious_domain`.
+  A clean posting (or a scan with `trust_filter` disabled) omits the segment. Treat
+  a low score as a ghost/scam-posting warning and weigh it in Block G legitimacy
+  before spending an evaluation. The same score + flags are also written to the
+  trailing columns of `data/scan-history.tsv`.
 - `| note: {text}` — a free-text ranking signal an importer attached to the offer
   (`- [ ] {url} | {company} | {title} | note: curated shortlist` is valid). The
   deterministic scanner never sets it.
 
-Treat both as hints when triaging; neither changes how you process the URL.
+When more than one is present the order is `posted:` → `trust:` → `note:`. Treat
+them as hints when triaging; none changes how you process the URL.
 
 ## Intelligent JD detection from URL
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -965,6 +965,11 @@ export function formatPipelineOffer(offer) {
   // 1/3/4/5-column contract in modes/pipeline.md intact.
   const posted = postedAtIsoDate(offer.postedAt);
   if (posted) line = `${line} | posted: ${posted}`;
+  // Labeled trust/legitimacy segment (#1743) — rides like posted:/note:, emitted
+  // only when the scanner flagged the posting (score < 100). Ordered after
+  // posted:, before note:, for a stable serialization.
+  const trust = formatTrustSegment(offer);
+  if (trust) line = `${line} | ${trust}`;
   // Optional free-text ranking signal (e.g. a curated-list flag an importer
   // attaches). Labeled — not positional like location/compensation — so it can
   // ride on any row shape (bare URL, 3-, 4-, or 5-column) without a reader

--- a/scan.mjs
+++ b/scan.mjs
@@ -919,6 +919,31 @@ export function formatCompensation(salary) {
   return sanitizeMarkdownField(currency ? `${range} ${currency}` : range);
 }
 
+// Trust/legitimacy signal (#1743): the scanner sets offer.trustScore (0-100) +
+// offer.trustFlags on every job (see buildTrustValidator). Surface it only when
+// it's meaningful — a score below 100 means the validator penalized the posting
+// (e.g. missing_apply_url, invalid_url, suspicious_domain). A clean posting
+// (score 100) or a scan without trust_filter configured stays byte-identical
+// (empty), exactly like the posted:/note: segments.
+export function trustIsFlagged(offer) {
+  return typeof offer.trustScore === 'number' && Number.isFinite(offer.trustScore) && offer.trustScore < 100;
+}
+
+function trustFlagList(offer) {
+  return Array.isArray(offer.trustFlags)
+    ? offer.trustFlags.filter((f) => typeof f === 'string' && f.trim())
+    : [];
+}
+
+// Labeled pipeline segment, e.g. `trust: 60 missing_apply_url,suspicious_domain`.
+// '' when the posting isn't flagged, so an unflagged offer produces no segment.
+export function formatTrustSegment(offer) {
+  if (!trustIsFlagged(offer)) return '';
+  const flags = trustFlagList(offer);
+  const body = flags.length ? `${offer.trustScore} ${flags.join(',')}` : String(offer.trustScore);
+  return sanitizeMarkdownField(`trust: ${body}`);
+}
+
 export function formatPipelineOffer(offer) {
   const url = sanitizePipelineUrl(offer.url);
   const company = sanitizeMarkdownField(offer.company);
@@ -971,6 +996,12 @@ export function formatScanHistoryRow(offer, date, status = 'added') {
     // New trailing column: posting date. Existing readers index by position up to
     // col 7, so appending col 8 is backward-compatible.
     postedAtIsoDate(offer.postedAt),
+    // Trust/legitimacy signal (#1743): score (only when the scanner flagged the
+    // posting, i.e. < 100) + comma-joined flags. Trailing cols 9-10, so existing
+    // index-based readers (fingerprint@7, postedAt@8) are unaffected; a clean
+    // posting or a scan without trust_filter leaves both empty.
+    trustIsFlagged(offer) ? String(offer.trustScore) : '',
+    trustIsFlagged(offer) ? trustFlagList(offer).join(',') : '',
   ].map(sanitizeTsvField).join('\t');
 }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3333,8 +3333,9 @@ try {
   const historyRow = formatScanHistoryRow(hostileOffer, '2026-06-18');
   const historyColumns = historyRow.split('\t');
   if (
-    historyColumns.length === 9 && // 7 metadata + fingerprint (#1597) + postedAt
+    historyColumns.length === 11 && // 7 metadata + fingerprint (#1597) + postedAt + trust score/flags (#1743)
     historyColumns[8] === '' && // no postedAt on hostileOffer → empty trailing col
+    historyColumns[9] === '' && historyColumns[10] === '' && // no trust signal → empty trailing cols
     !historyColumns.some(col => /[\r\n\t]/.test(col)) &&
     historyColumns[0] === 'https://jobs.example.com/123|evil' &&
     historyColumns[3].includes('- [ ] https://evil.example/job') &&
@@ -3363,9 +3364,9 @@ try {
   const datedHistory = formatScanHistoryRow(datedOffer, '2026-07-09').split('\t');
   const noDateHistory = formatScanHistoryRow({ ...datedOffer, postedAt: undefined }, '2026-07-09').split('\t');
   if (
-    datedHistory.length === 9 &&
+    datedHistory.length === 11 &&
     datedHistory[8] === '2026-06-18' && // epoch ms → YYYY-MM-DD in the trailing column
-    noDateHistory.length === 9 &&
+    noDateHistory.length === 11 &&
     noDateHistory[8] === '' // missing postedAt → empty trailing column, never a bogus date
   ) {
     pass('scan-history writer appends postedAt as an ISO trailing column (empty when absent)');
@@ -7490,17 +7491,17 @@ try {
     '2026-07-06',
   );
   const cols = withBody.split('\t');
-  if (cols.length === 9 && /^[0-9a-f]{16}$/.test(cols[7])) {
+  if (cols.length === 11 && /^[0-9a-f]{16}$/.test(cols[7])) {
     pass('formatScanHistoryRow appends a fingerprint column for described offers');
   } else {
-    fail(`formatScanHistoryRow columns: ${cols.length}, last=${JSON.stringify(cols[7])}`);
+    fail(`formatScanHistoryRow columns: ${cols.length}, fingerprint=${JSON.stringify(cols[7])}`);
   }
   const withoutBody = formatScanHistoryRow(
     { url: 'https://x.example/j/2', source: 'greenhouse', title: 'Data Engineer', company: 'Acme', location: '' },
     '2026-07-06',
   );
   const cols2 = withoutBody.split('\t');
-  if (cols2.length === 9 && cols2[7] === '') {
+  if (cols2.length === 11 && cols2[7] === '') {
     pass('formatScanHistoryRow leaves the fingerprint empty when no description is available');
   } else {
     fail(`formatScanHistoryRow (no body) columns: ${cols2.length}, last=${JSON.stringify(cols2[7])}`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3389,6 +3389,44 @@ try {
     fail(`pipeline postedAt segment wrong: dated="${datedPipeline}" / noDate="${noDatePipeline}" / bad="${badDatePipeline}" / nan="${nanDatePipeline}"`);
   }
 
+  // ── trust/legitimacy signal persistence (#1743) ──
+  // The scanner computes offer.trustScore/trustFlags on every job; surface it only
+  // when flagged (score < 100). scan-history gets trailing score+flags columns
+  // (after postedAt); pipeline.md gets a labeled `trust:` segment. Clean/unset
+  // trust stays byte-identical (empty column / no segment).
+  const trustBase = { url: 'https://jobs.example.com/77', source: 'lever-api', title: 'SRE', company: 'Acme', location: 'Remote', description: '' };
+  const flaggedOffer = { ...trustBase, trustScore: 60, trustFlags: ['missing_apply_url', 'suspicious_domain'] };
+  const cleanOffer = { ...trustBase, trustScore: 100, trustFlags: [] };
+  const untrustedOffer = { ...trustBase }; // no trust fields (trust_filter disabled)
+  const flaggedHist = formatScanHistoryRow(flaggedOffer, '2026-07-09').split('\t');
+  const cleanHist = formatScanHistoryRow(cleanOffer, '2026-07-09').split('\t');
+  if (
+    flaggedHist.length === 11 &&
+    flaggedHist[9] === '60' && flaggedHist[10] === 'missing_apply_url,suspicious_domain' &&
+    cleanHist.length === 11 && cleanHist[9] === '' && cleanHist[10] === '' // score 100 → not flagged → empty
+  ) {
+    pass('scan-history writer appends trust score + flags trailing columns when flagged, empty otherwise (#1743)');
+  } else {
+    fail(`scan-history trust columns wrong: flagged=${JSON.stringify(flaggedHist)} / clean=${JSON.stringify(cleanHist)}`);
+  }
+
+  const flaggedPipeline = formatPipelineOffer(flaggedOffer);
+  const cleanPipeline = formatPipelineOffer(cleanOffer);
+  const untrustedPipeline = formatPipelineOffer(untrustedOffer);
+  const flaggedNoFlags = formatPipelineOffer({ ...trustBase, trustScore: 80, trustFlags: [] });
+  const withDateAndTrust = formatPipelineOffer({ ...trustBase, postedAt: Date.parse('2026-06-18T00:00:00Z'), trustScore: 70, trustFlags: ['invalid_url'], note: 'pick' });
+  if (
+    flaggedPipeline === '- [ ] https://jobs.example.com/77 | Acme | SRE | Remote | trust: 60 missing_apply_url,suspicious_domain' &&
+    cleanPipeline === '- [ ] https://jobs.example.com/77 | Acme | SRE | Remote' && // score 100 → no segment
+    untrustedPipeline === cleanPipeline && // no trust fields → byte-identical
+    flaggedNoFlags === '- [ ] https://jobs.example.com/77 | Acme | SRE | Remote | trust: 80' && // score-only when no flags
+    withDateAndTrust === '- [ ] https://jobs.example.com/77 | Acme | SRE | Remote | posted: 2026-06-18 | trust: 70 invalid_url | note: pick' // stable order posted→trust→note
+  ) {
+    pass('pipeline writer appends a labeled trust: segment ordered posted→trust→note, byte-identical when clean/unset (#1743)');
+  } else {
+    fail(`pipeline trust segment wrong: flagged="${flaggedPipeline}" / clean="${cleanPipeline}" / untrusted="${untrustedPipeline}" / noFlags="${flaggedNoFlags}" / combo="${withDateAndTrust}"`);
+  }
+
   // ── content_filter (#734) ──
   // Absent config → all jobs pass.
   const noContentFilter = buildContentFilter(null);


### PR DESCRIPTION
Fixes #1743 (persistence half — Block G wording deferred, per the issue).

## What
The scanner scores every job's legitimacy (`buildTrustValidator` → `offer.trustScore` 0–100 + `offer.trustFlags` like `missing_apply_url` / `invalid_url` / `suspicious_domain`), but it was only printed to the scan console summary and then dropped — never reaching `pipeline.md`, `scan-history.tsv`, or the evaluation. This surfaces it so a low-trust posting can be spotted at triage before it costs an evaluation (or a real application to a ghost posting).

## How (additive, per your constraint)
- **`scan-history.tsv`** — two new **trailing** columns (score + comma-joined flags), appended after the #1597 fingerprint and #1578 postedAt columns. Written only when a posting is flagged (`trustScore < 100`); empty otherwise. Existing index-based readers (`loadSeenUrls`, `loadFingerprintHistory`, `detect-reposts`) are untouched.
- **`pipeline.md`** — a labeled (non-positional) `trust: {score} {flags}` segment, e.g. `… | trust: 60 missing_apply_url,suspicious_domain`. Rides like `posted:`/`note:`; emitted only when flagged; ordered `posted:` → `trust:` → `note:`. A clean posting — or a scan with `trust_filter` disabled — is **byte-identical** to before.
- **The frozen format assertions are updated in the same diff** (the scan-history column-count checks go 9 → 11), so the surface change shouts in the diff exactly as intended.

New `trustIsFlagged()` / `formatTrustSegment()` helpers; docs updated in `modes/pipeline.md`.

## Not in scope
Block G consuming the flags touches `oferta.md` (shared, scoring-sensitive) — deferred to a follow-up per the issue, so this PR is pure additive plumbing.

## Tests
`node test-all.mjs --quick` → **1678 passed, 0 failed**. New coverage: scan-history trust columns (flagged vs clean vs unset), pipeline `trust:` segment (byte-identical when clean, score-only when no flags, and the `posted:`→`trust:`→`note:` ordering).

3 commits: scan-history persistence · pipeline segment · docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `trust:` (legitimacy/scam triage) pipeline segments for low-trust postings only (`trustScore < 100`), inserted after `posted:` and before `note:`.
  * Extended scan-history TSV with two new trailing columns (trust score and validator flags), populated only when the posting is flagged.
* **Documentation**
  * Updated pipeline documentation to include the new `trust:` labeled segment and revised ordering to `posted:` → `trust:` → `note:`, clarifying these are triage hints only.
* **Tests**
  * Updated scan-history and pipeline contract tests to verify the new column shape, conditional population, and segment ordering/byte-identical output for clean cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->