### PR TITLE
feat(openrouter): prompt-cache the static system prefix (~12K tokens/offer) via cache_control (#1709)

### DIFF
--- a/openrouter-runner.mjs
+++ b/openrouter-runner.mjs
@@ -166,6 +166,25 @@ function fileExists(relPath) {
 }
 
 // ---------------------------------------------------------------------------
+// Prompt caching (#1709)
+// ---------------------------------------------------------------------------
+// The static system prefix (shared + profile + mode + cv, ~12K tokens) is
+// byte-identical across every offer in a run, yet it was re-sent and re-billed
+// on each call. Send it as a structured content block with an ephemeral
+// `cache_control` breakpoint — OpenRouter's documented prompt-caching mechanism.
+// Providers that support caching (Anthropic, Gemini, …) reuse the prefix across
+// back-to-back calls within the cache TTL; providers that don't simply ignore
+// the field, so this is a safe passthrough that never changes the prompt text.
+export function buildCachedSystemMessage(systemPrompt) {
+  return {
+    role: 'system',
+    content: [
+      { type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
 // OpenRouter API call — automatic model rotation with fallback
 // ---------------------------------------------------------------------------
 async function callOpenRouter(systemPrompt, userMessage) {
@@ -184,8 +203,8 @@ async function callOpenRouter(systemPrompt, userMessage) {
     const body = JSON.stringify({
       model: pinnedModel,
       messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user',   content: userMessage  },
+        buildCachedSystemMessage(systemPrompt),
+        { role: 'user', content: userMessage },
       ],
       max_tokens: MAX_TOKENS,
     });
@@ -241,8 +260,8 @@ async function callOpenRouter(systemPrompt, userMessage) {
       const body = JSON.stringify({
         model,
         messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user',   content: userMessage  }
+          buildCachedSystemMessage(systemPrompt),
+          { role: 'user', content: userMessage },
         ],
         max_tokens: MAX_TOKENS,
       });

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6402,6 +6402,30 @@ try {
   fail(`openrouter-runner portals drift guard crashed: ${e.message}`);
 }
 
+// ── 44b. openrouter-runner — prompt-cache breakpoint (#1709) ────
+console.log('\n44b. openrouter-runner — prompt-cache breakpoint (#1709)');
+try {
+  const { buildCachedSystemMessage } = await import(pathToFileURL(join(ROOT, 'openrouter-runner.mjs')).href);
+  const prefix = 'STATIC SYSTEM PREFIX — shared + profile + mode + cv';
+  const msg = buildCachedSystemMessage(prefix);
+  const block = msg?.content?.[0];
+  // The static prefix must ride as a structured content block carrying an
+  // ephemeral cache_control breakpoint, with the prompt text preserved verbatim
+  // (caching must never alter what the model reads).
+  if (
+    msg.role === 'system' &&
+    Array.isArray(msg.content) && msg.content.length === 1 &&
+    block.type === 'text' && block.text === prefix &&
+    block.cache_control && block.cache_control.type === 'ephemeral'
+  ) {
+    pass('buildCachedSystemMessage marks the static prefix with an ephemeral cache_control breakpoint, text unchanged (#1709)');
+  } else {
+    fail(`buildCachedSystemMessage shape wrong: ${JSON.stringify(msg)}`);
+  }
+} catch (e) {
+  fail(`openrouter-runner prompt-cache test crashed: ${e.message}`);
+}
+
 // ── 45. SCAN COOLDOWN FILTER ──────────────────────────────────
 
 console.log('\n45. Scan cooldown filter');


### PR DESCRIPTION
Fixes #1709 (OpenRouter engine — the rest follow in their own PRs, per your engine-by-engine ask).

## What
`openrouter-runner.mjs` rebuilds the static system prefix (shared + profile + mode + cv, ~12K tokens) and re-sends it on **every offer** in a run, byte-identical each time, with no caching (`grep cache_control` → 0 hits before this).

## How
Send the static prefix as a structured content block carrying an ephemeral `cache_control` breakpoint — OpenRouter's documented prompt-caching mechanism — at **both** call sites (pinned model + free-model rotation):

```js
{ role: 'system', content: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }] }
```

Providers that support caching (Anthropic, Gemini, …) reuse the prefix across back-to-back calls within the cache TTL — the win for a multi-offer run. Providers that don't support it **ignore the field**, so:
- the prompt **text the model reads is unchanged** (the test asserts `block.text === systemPrompt`), and
- unsupported free models are unaffected — this is a safe passthrough, not a behavior change.

## Scope
Deliberately **OpenRouter only** (the free-tier default), as you asked — kept small. openai / gemini / ollama each get their own PR.

## One thing worth your eye
This changes the system message from a plain string to the single-element content-array form. That's OpenRouter's standard/documented shape and it normalizes per-provider, but if you'd rather gate it behind a config/env flag for the free-rotation path, say the word and I'll add one.

## Tests
`node test-all.mjs --quick` → all green. New: `buildCachedSystemMessage` shape guard (ephemeral breakpoint present, prefix text preserved verbatim).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prompt caching for system instructions to improve request efficiency across supported model calls.

* **Tests**
  * Added coverage to verify the cached system message structure and ephemeral cache settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->