### PR TITLE
feat(scan): track portal-health over time and surface coverage decay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ data/status-log.tsv
 data/pipeline.md
 data/scan-history.tsv
 data/scan-runs.tsv
+data/portal-health.tsv
 data/blacklist.md
 data/pdf-index.tsv
 data/agent-inbox.md

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -28,6 +28,7 @@ These files contain your personal data, customizations, and work product. Update
 | `data/pipeline.md` | Your URL inbox |
 | `data/scan-history.tsv` | Your scan history (9 tab-separated columns; col 8: local SimHash JD fingerprint for cross-listing detection, col 9: posting date) |
 | `data/scan-runs.tsv` | Your per-run scan counters (appended by `scan.mjs`, read by `stats.mjs`) |
+| `data/portal-health.tsv` | Consecutive reachability status for scanned portals (appended by `scan.mjs`) |
 | `data/follow-ups.md` | Your follow-up history |
 | `data/offers/*` | Your received offers/contracts, promise notes, prep reports, and reply drafts (PII — gitignored, written by the `offer-prep` mode) |
 | `data/salary-observations.tsv` | Your append-only compensation observation log: `{tracker#}\t{date}\t{desired\|advertised\|actual}\t{amount}\t{currency}\t{source}\t{note}`. Written by interactive modes when a figure is stated/confirmed; never edited in place. Advertised figures come from reports' `advertised_comp` instead — reports are themselves observation sources. Read by `salary-gap.mjs` |

--- a/scan.mjs
+++ b/scan.mjs
@@ -1141,7 +1141,7 @@ export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
 
 // ── Portal health persistence (#1744) ───────────────────────────────
 
-const PORTAL_HEALTH_PATH = 'data/portal-health.tsv';
+const PORTAL_HEALTH_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), 'data', 'portal-health.tsv');
 export const PORTAL_HEALTH_HEADER = 'timestamp\tcompany\tstatus\n';
 
 export function appendPortalHealth(healthRecords, filePath = PORTAL_HEALTH_PATH) {
@@ -1761,8 +1761,8 @@ async function main() {
   const unreachableTargets = errors.filter((e) => e.kind === 'slug_gone');
   const networkTargets = errors.filter((e) => e.kind === 'network');
   const otherErrors = errors.filter((e) => e.kind !== 'slug_gone' && e.kind !== 'network');
-
-  const STREAK_THRESHOLD = 3;
+  
+  const STREAK_THRESHOLD = config.portal_health_threshold || 3;
   const nowStr = new Date().toISOString();
   const healthRecords = [];
   
@@ -1800,7 +1800,7 @@ async function main() {
       if (!persistentlyDead.includes(e.company)) persistentlyDead.push(e.company);
     } else {
       if (e.kind === 'slug_gone') {
-        if (!newlyDeadSlug.includes(e.company)) newlyDeadSlug.push(e.company);
+        if (!newlyDeadSlug.some(x => x.company === e.company)) newlyDeadSlug.push(e);
       } else {
         newlyDeadNetwork.push(e);
       }
@@ -1813,7 +1813,8 @@ async function main() {
     console.log(`   Run: node verify-portals.mjs to check if the ATS migrated, or update their board slugs.`);
   }
   if (newlyDeadSlug.length > 0) {
-    console.log(`\n⚠️  ${newlyDeadSlug.length} target(s) unreachable (slug?): ${newlyDeadSlug.join(', ')} — run: node verify-portals.mjs`);
+    const names = newlyDeadSlug.map(x => x.company).join(', ');
+    console.log(`\n⚠️  ${newlyDeadSlug.length} target(s) unreachable (slug?): ${names} — run: node verify-portals.mjs`);
   }
   if (emptyTargets.length > 0) {
     console.log(`🟡 ${emptyTargets.length} target(s) live but empty: ${emptyTargets.join(', ')}`);

--- a/scan.mjs
+++ b/scan.mjs
@@ -1139,6 +1139,47 @@ export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
   appendFileSync(filePath, row, 'utf-8');
 }
 
+// ── Portal health persistence (#1744) ───────────────────────────────
+
+const PORTAL_HEALTH_PATH = 'data/portal-health.tsv';
+export const PORTAL_HEALTH_HEADER = 'timestamp\tcompany\tstatus\n';
+
+export function appendPortalHealth(healthRecords, filePath = PORTAL_HEALTH_PATH) {
+  if (!existsSync(filePath)) writeFileSync(filePath, PORTAL_HEALTH_HEADER, 'utf-8');
+  let lines = '';
+  for (const r of healthRecords) {
+    lines += [r.timestamp, r.company, r.status].join('\t') + '\n';
+  }
+  if (lines) appendFileSync(filePath, lines, 'utf-8');
+}
+
+export function loadPortalHealth(filePath = PORTAL_HEALTH_PATH) {
+  if (!existsSync(filePath)) return [];
+  const lines = readFileSync(filePath, 'utf-8').split('\n');
+  const records = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    const parts = line.split('\t');
+    if (parts.length >= 3) {
+      records.push({ timestamp: parts[0], company: parts[1], status: parts[2] });
+    }
+  }
+  return records;
+}
+
+export function computeConsecutiveFailures(healthRecords) {
+  const streaks = new Map();
+  for (const r of healthRecords) {
+    if (r.status === 'slug_gone' || r.status === 'network') {
+      streaks.set(r.company, (streaks.get(r.company) || 0) + 1);
+    } else if (r.status === 'reachable' || r.status === 'empty') {
+      streaks.set(r.company, 0);
+    }
+  }
+  return streaks;
+}
+
 // ── Parallel fetch with concurrency limit ───────────────────────────
 
 async function parallelFetch(tasks, limit) {
@@ -1721,16 +1762,65 @@ async function main() {
   const networkTargets = errors.filter((e) => e.kind === 'network');
   const otherErrors = errors.filter((e) => e.kind !== 'slug_gone' && e.kind !== 'network');
 
-  if (unreachableTargets.length > 0) {
-    const names = unreachableTargets.map((e) => e.company).join(', ');
-    console.log(`\n⚠️  ${unreachableTargets.length} target(s) unreachable (slug?): ${names} — run: node verify-portals.mjs`);
+  const STREAK_THRESHOLD = 3;
+  const nowStr = new Date().toISOString();
+  const healthRecords = [];
+  
+  for (const t of targets) {
+    const isUnreachable = unreachableTargets.some(e => e.company === t.name);
+    const isNetwork = networkTargets.some(e => e.company === t.name);
+    const isEmpty = emptyTargets.includes(t.name);
+    
+    let status = 'reachable';
+    if (isUnreachable) status = 'slug_gone';
+    else if (isNetwork) status = 'network';
+    else if (isEmpty) status = 'empty';
+    
+    healthRecords.push({ timestamp: nowStr, company: t.name, status });
+  }
+
+  const pastHealth = loadPortalHealth();
+  const currentStreaks = computeConsecutiveFailures(pastHealth);
+  
+  for (const r of healthRecords) {
+    if (r.status === 'slug_gone' || r.status === 'network') {
+      currentStreaks.set(r.company, (currentStreaks.get(r.company) || 0) + 1);
+    } else if (r.status === 'reachable' || r.status === 'empty') {
+      currentStreaks.set(r.company, 0);
+    }
+  }
+
+  const persistentlyDead = [];
+  const newlyDeadSlug = [];
+  const newlyDeadNetwork = [];
+  
+  for (const e of [...unreachableTargets, ...networkTargets]) {
+    const streak = currentStreaks.get(e.company) || 1;
+    if (streak >= STREAK_THRESHOLD) {
+      if (!persistentlyDead.includes(e.company)) persistentlyDead.push(e.company);
+    } else {
+      if (e.kind === 'slug_gone') {
+        if (!newlyDeadSlug.includes(e.company)) newlyDeadSlug.push(e.company);
+      } else {
+        newlyDeadNetwork.push(e);
+      }
+    }
+  }
+
+  if (persistentlyDead.length > 0) {
+    console.log(`\n🚨 FIX NEEDED: ${persistentlyDead.length} target(s) have been unreachable for ${STREAK_THRESHOLD}+ runs:`);
+    console.log(`   ${persistentlyDead.join(', ')}`);
+    console.log(`   Run: node verify-portals.mjs to check if the ATS migrated, or update their board slugs.`);
+  }
+  if (newlyDeadSlug.length > 0) {
+    console.log(`\n⚠️  ${newlyDeadSlug.length} target(s) unreachable (slug?): ${newlyDeadSlug.join(', ')} — run: node verify-portals.mjs`);
   }
   if (emptyTargets.length > 0) {
     console.log(`🟡 ${emptyTargets.length} target(s) live but empty: ${emptyTargets.join(', ')}`);
   }
-  if (networkTargets.length > 0) {
-    console.log(`\nNetwork errors (${networkTargets.length}):`);
-    for (const e of networkTargets) {
+  if (newlyDeadNetwork.length > 0) {
+    console.log(`\nNetwork errors (${newlyDeadNetwork.length}):`);
+    for (const e of newlyDeadNetwork) {
       console.log(`  ✗ ${e.company}: ${e.error}`);
     }
   }
@@ -1760,6 +1850,7 @@ async function main() {
   // Persist this run's counters (#1604) — guarded exactly like the other
   // writes; a --dry-run must leave no trace.
   if (!dryRun) {
+    appendPortalHealth(healthRecords);
     appendScanRunSummary({
       timestamp: new Date().toISOString(), status: 'completed',
       companies: summaryCompanies, boards: summaryBoards, found: totalFound,

--- a/stats.mjs
+++ b/stats.mjs
@@ -251,23 +251,28 @@ export function computePortalStats(portalsYmlContent, scanStats, producingCompan
   let persistentlyDead = 0;
   if (portalHealthContent) {
     const lines = portalHealthContent.split('\n');
-    const streaks = new Map();
+    const healthRecords = [];
     for (let i = 1; i < lines.length; i++) {
       const line = lines[i].trim();
       if (!line) continue;
       const parts = line.split('\t');
       if (parts.length >= 3) {
-        const company = parts[1];
-        const status = parts[2];
-        if (status === 'slug_gone' || status === 'network') {
-          streaks.set(company, (streaks.get(company) || 0) + 1);
-        } else if (status === 'reachable' || status === 'empty') {
-          streaks.set(company, 0);
-        }
+        healthRecords.push({ company: parts[1], status: parts[2] });
       }
     }
-    for (const streak of streaks.values()) {
-      if (streak >= 3) persistentlyDead++;
+    const streaks = new Map();
+    for (const r of healthRecords) {
+      if (r.status === 'slug_gone' || r.status === 'network') {
+        streaks.set(r.company, (streaks.get(r.company) || 0) + 1);
+      } else if (r.status === 'reachable' || r.status === 'empty') {
+        streaks.set(r.company, 0);
+      }
+    }
+    const threshold = cfg.portal_health_threshold || 3;
+    for (const [company, streak] of streaks.entries()) {
+      if (streak >= threshold && configuredNames.has(String(company).toLowerCase())) {
+        persistentlyDead++;
+      }
     }
   }
 

--- a/stats.mjs
+++ b/stats.mjs
@@ -31,6 +31,7 @@ const SCAN_HISTORY_FILE = join(ROOT, 'data', 'scan-history.tsv');
 const FOLLOWUPS_FILE = join(ROOT, 'data', 'follow-ups.md');
 const SCAN_RUNS_FILE = join(ROOT, 'data', 'scan-runs.tsv');
 const PORTALS_FILE = join(ROOT, 'portals.yml');
+const PORTAL_HEALTH_FILE = join(ROOT, 'data', 'portal-health.tsv');
 
 const CANONICAL_STATUSES = ['Evaluated', 'Applied', 'Responded', 'Interview', 'Offer', 'Rejected', 'Discarded', 'SKIP'];
 
@@ -231,7 +232,7 @@ export function scanCompanyNames(content) {
  * @param {object|null} scanStats - Result of computeScanStats (for activePortals).
  * @param {string[]} [producingCompanyNames] - From scanCompanyNames().
  */
-export function computePortalStats(portalsYmlContent, scanStats, producingCompanyNames = []) {
+export function computePortalStats(portalsYmlContent, scanStats, producingCompanyNames = [], portalHealthContent = null) {
   let cfg;
   try {
     cfg = yaml.load(String(portalsYmlContent ?? '')) || {};
@@ -246,12 +247,37 @@ export function computePortalStats(portalsYmlContent, scanStats, producingCompan
   const producing = new Set(producingCompanyNames.map((n) => String(n).toLowerCase()));
   let producingCompanies = 0;
   for (const name of configuredNames) if (producing.has(name)) producingCompanies++;
+
+  let persistentlyDead = 0;
+  if (portalHealthContent) {
+    const lines = portalHealthContent.split('\n');
+    const streaks = new Map();
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line) continue;
+      const parts = line.split('\t');
+      if (parts.length >= 3) {
+        const company = parts[1];
+        const status = parts[2];
+        if (status === 'slug_gone' || status === 'network') {
+          streaks.set(company, (streaks.get(company) || 0) + 1);
+        } else if (status === 'reachable' || status === 'empty') {
+          streaks.set(company, 0);
+        }
+      }
+    }
+    for (const streak of streaks.values()) {
+      if (streak >= 3) persistentlyDead++;
+    }
+  }
+
   return {
     configuredCompanies: companies.length,
     configuredBoards: boards.length,
     activePortals: Object.keys(scanStats?.byPortal || {}).length,
     producingCompanies,
     producingPct: pct(producingCompanies, configuredNames.size),
+    persistentlyDead,
   };
 }
 
@@ -351,6 +377,7 @@ export function computeAllStats({
   followupsFile = FOLLOWUPS_FILE,
   scanRunsFile = SCAN_RUNS_FILE,
   portalsFile = PORTALS_FILE,
+  portalHealthFile = PORTAL_HEALTH_FILE,
 } = {}) {
   const read = (f) => (existsSync(f) ? readFileSync(f, 'utf-8') : null);
   const apps = read(appsFile);
@@ -358,6 +385,7 @@ export function computeAllStats({
   const fups = read(followupsFile);
   const portals = read(portalsFile);
   const runs = read(scanRunsFile);
+  const portalHealth = read(portalHealthFile);
   const tracker = apps ? computeTrackerStats(apps) : null;
   const scan = scanHist ? computeScanStats(scanHist) : null;
   return {
@@ -369,12 +397,13 @@ export function computeAllStats({
         followups: !!fups,
         portals: !!portals,
         scanRuns: !!runs,
+        portalHealth: !!portalHealth,
       },
     },
     tracker,
     funnel: tracker ? computeFunnel(tracker.byStatus) : null,
     scan,
-    portals: portals ? computePortalStats(portals, scan, scanHist ? scanCompanyNames(scanHist) : []) : null,
+    portals: portals ? computePortalStats(portals, scan, scanHist ? scanCompanyNames(scanHist) : [], portalHealth) : null,
     followups: fups && apps ? computeFollowupStats(fups, trackerStatusByNum(apps)) : null,
     runs: runs ? computeRunStats(runs) : null,
   };
@@ -411,7 +440,8 @@ function printSummary(stats) {
   }
   const p = stats.portals;
   if (p) {
-    console.log(`Portals:    ${p.configuredCompanies} companies + ${p.configuredBoards} boards configured | ${p.producingCompanies} have produced a match (${p.producingPct}%) — low ≠ broken, may just be no openings`);
+    const deadPart = p.persistentlyDead > 0 ? ` | 🚨 ${p.persistentlyDead} persistently dead (run verify-portals.mjs)` : '';
+    console.log(`Portals:    ${p.configuredCompanies} companies + ${p.configuredBoards} boards configured | ${p.producingCompanies} have produced a match (${p.producingPct}%)${deadPart} — low ≠ broken, may just be no openings`);
   } else {
     console.log('Portals:    — no data (portals.yml missing)');
   }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7745,6 +7745,20 @@ try {
   } else {
     fail('computeRunStats should return null for empty/unknown-schema input');
   }
+
+  const portalsYml = 'tracked_companies:\n  - name: Acme\n  - name: GlobalCorp\n  - name: DeadInc\njob_boards: []';
+  const portalHealthTsv = 'timestamp\tcompany\tstatus\n' +
+    '2026-07-01\tDeadInc\tslug_gone\n' +
+    '2026-07-02\tDeadInc\tslug_gone\n' +
+    '2026-07-03\tDeadInc\tslug_gone\n' +
+    '2026-07-01\tGlobalCorp\tnetwork\n' +
+    '2026-07-02\tGlobalCorp\treachable\n';
+  const p = stats.computePortalStats(portalsYml, null, [], portalHealthTsv);
+  if (p && p.persistentlyDead === 1) {
+    pass('computePortalStats tracks persistentlyDead count from portal-health.tsv streaks');
+  } else {
+    fail('computePortalStats failed to compute persistentlyDead streaks');
+  }
 } catch (e) {
   fail(`test layout guard: ${e.message}`);
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7746,18 +7746,30 @@ try {
     fail('computeRunStats should return null for empty/unknown-schema input');
   }
 
-  const portalsYml = 'tracked_companies:\n  - name: Acme\n  - name: GlobalCorp\n  - name: DeadInc\njob_boards: []';
+  const portalsYml = 'tracked_companies:\n  - name: Acme\n  - name: GlobalCorp\n  - name: DeadInc\n  - name: NetworkDead\njob_boards: []';
   const portalHealthTsv = 'timestamp\tcompany\tstatus\n' +
     '2026-07-01\tDeadInc\tslug_gone\n' +
     '2026-07-02\tDeadInc\tslug_gone\n' +
     '2026-07-03\tDeadInc\tslug_gone\n' +
+    '2026-07-01\tNetworkDead\tnetwork\n' +
+    '2026-07-02\tNetworkDead\tnetwork\n' +
+    '2026-07-03\tNetworkDead\tnetwork\n' +
     '2026-07-01\tGlobalCorp\tnetwork\n' +
-    '2026-07-02\tGlobalCorp\treachable\n';
+    '2026-07-02\tGlobalCorp\treachable\n' +
+    '2026-07-01\tUnconfiguredDead\tnetwork\n' +
+    '2026-07-02\tUnconfiguredDead\tnetwork\n' +
+    '2026-07-03\tUnconfiguredDead\tnetwork\n';
   const p = stats.computePortalStats(portalsYml, null, [], portalHealthTsv);
-  if (p && p.persistentlyDead === 1) {
+  if (p && p.persistentlyDead === 2) {
     pass('computePortalStats tracks persistentlyDead count from portal-health.tsv streaks');
   } else {
     fail('computePortalStats failed to compute persistentlyDead streaks');
+  }
+  const pNull = stats.computePortalStats(portalsYml, null, [], null);
+  if (pNull && pNull.persistentlyDead === 0) {
+    pass('computePortalStats gracefully handles null portalHealthTsv');
+  } else {
+    fail('computePortalStats failed on null portalHealthTsv');
   }
 } catch (e) {
   fail(`test layout guard: ${e.message}`);


### PR DESCRIPTION
This PR resolves #1744 by tracking portal reachability over time to prevent silent coverage decay. 

**Changes:**
- **Data Layer**: Introduced `data/portal-health.tsv` (tracked in `.gitignore` and `DATA_CONTRACT.md`) to record per-target reachability (`reachable`, `slug_gone`, `network`, `empty`) append-only at the end of each non-dry scan.
- **Scanner Escalation (`scan.mjs`)**: Replaced stateless per-run warnings with streak tracking. Portals failing for 3+ consecutive runs trigger an escalated `🚨 FIX NEEDED` alert.
- **Analytics Surface (`stats.mjs`)**: Extended the `Portals:` summary output to include the count of persistently dead portals, providing visibility directly in the lifetime pipeline stats.
- **Validation**: Added a self-test in `test-all.mjs` verifying streak computation logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persistent portal “health” history across scans, tracking consecutive failures to distinguish newly unavailable vs persistently unavailable portals (configurable threshold, defaulting to 3).
  - Extended coverage statistics with a `persistentlyDead` metric and surfaced a warning in the scan summary when any persistently unavailable portals are detected.
- **Documentation**
  - Documented the new portal health history file as user-layer content (never auto-updated) and updated ignore rules for the generated TSV.
- **Tests**
  - Added unit/regression coverage for consecutive-failure detection, persistent-dead counting, and successful operation when portal health data is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->