### PR TITLE
fix(test): normalize CRLF at read time for doc assertions in test-all.mjs

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -49,6 +49,29 @@ function readFile(path) {
   return content;
 }
 
+/**
+ * Normalize CRLF line endings to LF (#1771).
+ *
+ * On Windows checkouts with core.autocrlf=true, repo text files arrive with
+ * CRLF endings. Doc assertions that anchor on `\n` (JS `.` never matches `\r`)
+ * then fail on pristine main. Normalizing at read time keeps the assertions
+ * byte-ending agnostic without touching any regex.
+ *
+ * @param {string} text - Raw file contents.
+ * @returns {string} Contents with LF-only line endings.
+ */
+const normalizeEol = (text) => text.replace(/\r\n/g, '\n');
+
+/**
+ * Read a repo text file with line endings normalized to LF (#1771).
+ * Use for doc-content reads that feed `\n`-anchored regex assertions.
+ * Do NOT use where byte-exact content matters.
+ *
+ * @param {string} path - Path relative to the career-ops repository root.
+ * @returns {string} File contents with LF-only line endings.
+ */
+const readTextLF = (path) => normalizeEol(readFile(path));
+
 // ── Auto-discovered test files (issue #1440) ─────────────────────────────
 // Deterministic: recursive readdirSync with default lexicographic sort of
 // entry names — same order on every run and OS. No glob library, no
@@ -1020,16 +1043,29 @@ try {
 
 console.log('\n7d. Output language contract');
 
-const profileExample = readFile('config/profile.example.yml');
-const outputLanguageAgentsDoc = readFile('AGENTS.md');
-const outputLanguageClaudeDoc = readFile('CLAUDE.md');
-const careerOpsSkill = readFile('.agents/skills/career-ops/SKILL.md');
-const batchPrompt = readFile('batch/batch-prompt.md');
+const profileExample = readTextLF('config/profile.example.yml');
+const outputLanguageAgentsDoc = readTextLF('AGENTS.md');
+const outputLanguageClaudeDoc = readTextLF('CLAUDE.md');
+const careerOpsSkill = readTextLF('.agents/skills/career-ops/SKILL.md');
+const batchPrompt = readTextLF('batch/batch-prompt.md');
 
 if (/language:\s*\n(?:\s*#.*\n)*\s*output:\s*["']?en["']?/.test(profileExample)) {
   pass('profile.example.yml documents language.output default');
 } else {
   fail('profile.example.yml is missing language.output default');
+}
+
+// Regression guard (#1771): doc assertions must survive CRLF checkouts
+// (Windows core.autocrlf=true) once reads are normalized to LF.
+const crlfLanguageSnippet = normalizeEol('language:\r\n  # Output language for human-facing prose\r\n  output: en\r\n');
+const crlfBatchSnippet = normalizeEol('Write HTML to `output/cv-x.html`\r\n\r\n```bash\r\nnode generate-pdf.mjs \\\r\n  output/cv-x.html \\\r\n  output/cv-x.pdf\r\n```\r\n');
+if (
+  /language:\s*\n(?:\s*#.*\n)*\s*output:\s*["']?en["']?/.test(crlfLanguageSnippet) &&
+  crlfBatchSnippet.match(/node generate-pdf\.mjs \\\n\s+([^\s\\]+) \\/)?.[1] === 'output/cv-x.html'
+) {
+  pass('doc assertions tolerate CRLF checkouts via read-time normalization');
+} else {
+  fail('doc assertions break on CRLF checkouts — read-time normalization regressed');
 }
 
 if (

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -26,7 +26,7 @@
 
 import { execSync, execFileSync, spawn } from 'child_process';
 import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, unlinkSync, realpathSync, symlinkSync } from 'fs';
-import { join, dirname, delimiter } from 'path';
+import { join, dirname, basename, delimiter } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { pass, fail, warn, run, fileExists, finish, ROOT, QUICK, NODE, getBash, toBashPath } from './tests/helpers.mjs';
@@ -1056,16 +1056,32 @@ if (/language:\s*\n(?:\s*#.*\n)*\s*output:\s*["']?en["']?/.test(profileExample))
 }
 
 // Regression guard (#1771): doc assertions must survive CRLF checkouts
-// (Windows core.autocrlf=true) once reads are normalized to LF.
-const crlfLanguageSnippet = normalizeEol('language:\r\n  # Output language for human-facing prose\r\n  output: en\r\n');
-const crlfBatchSnippet = normalizeEol('Write HTML to `output/cv-x.html`\r\n\r\n```bash\r\nnode generate-pdf.mjs \\\r\n  output/cv-x.html \\\r\n  output/cv-x.pdf\r\n```\r\n');
-if (
-  /language:\s*\n(?:\s*#.*\n)*\s*output:\s*["']?en["']?/.test(crlfLanguageSnippet) &&
-  crlfBatchSnippet.match(/node generate-pdf\.mjs \\\n\s+([^\s\\]+) \\/)?.[1] === 'output/cv-x.html'
-) {
-  pass('doc assertions tolerate CRLF checkouts via read-time normalization');
-} else {
-  fail('doc assertions break on CRLF checkouts — read-time normalization regressed');
+// (Windows core.autocrlf=true). Exercises the real read path: a CRLF fixture
+// is written to disk and read back through readTextLF, so stripping the
+// normalization out of readTextLF fails this check on every platform. The
+// fixture lives under ROOT because readFile resolves ROOT-relative paths.
+try {
+  const crlfGuardTmp = mkdtempSync(join(ROOT, 'crlf-guard-'));
+  try {
+    writeFileSync(
+      join(crlfGuardTmp, 'crlf-fixture.md'),
+      'language:\r\n  # Output language for human-facing prose\r\n  output: en\r\n\r\nWrite HTML to `output/cv-x.html`\r\n\r\n```bash\r\nnode generate-pdf.mjs \\\r\n  output/cv-x.html \\\r\n  output/cv-x.pdf\r\n```\r\n'
+    );
+    const crlfGuardContent = readTextLF(`${basename(crlfGuardTmp)}/crlf-fixture.md`);
+    if (
+      !crlfGuardContent.includes('\r') &&
+      /language:\s*\n(?:\s*#.*\n)*\s*output:\s*["']?en["']?/.test(crlfGuardContent) &&
+      crlfGuardContent.match(/node generate-pdf\.mjs \\\n\s+([^\s\\]+) \\/)?.[1] === 'output/cv-x.html'
+    ) {
+      pass('doc assertions tolerate CRLF checkouts via readTextLF normalization');
+    } else {
+      fail('doc assertions break on CRLF checkouts — readTextLF normalization regressed');
+    }
+  } finally {
+    rmSync(crlfGuardTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`CRLF regression guard crashed: ${e.message}`);
 }
 
 if (


### PR DESCRIPTION
Closes #1771

## Problem

On a **pristine `main`** checkout under Windows with `core.autocrlf=true`, `node test-all.mjs` fails 2 doc assertions that pass everywhere else — phantom failures for Windows contributors:

1. `profile.example.yml is missing language.output default` — the regex `language:\s*\n(?:\s*#.*\n)*\s*output:` can never consume comment lines when they end in CRLF, because JS `.` does not match `\r`, so `#.*` stops before the `\r` and `\n` can't follow.
2. `batch prompt HTML path mismatch` — the literal `\\\n` in the `generate-pdf.mjs` invocation regex never matches `\\\r\n`.

Both assertions read repo doc files (`config/profile.example.yml`, `batch/batch-prompt.md`, etc.) via `readFileSync`, which returns whatever line endings the checkout has.

## Fix (option 1 from #1771 — read-path normalization only)

- Adds two tiny helpers next to the existing `readFile()`: `normalizeEol(text)` (CRLF→LF) and `readTextLF(path)` (= `normalizeEol(readFile(path))`).
- Switches the five doc-content reads in the section-7d output-language cluster (`config/profile.example.yml`, `AGENTS.md`, `CLAUDE.md`, `.agents/skills/career-ops/SKILL.md`, `batch/batch-prompt.md`) to `readTextLF`.
- **Zero regex or assertion-logic changes.** All other reads stay byte-exact (script-source checks, template checks, fixture round-trips), and the rest of the suite already passes on a CRLF checkout, so the change is deliberately scoped to the reads that actually break.
- Adds one regression guard in the file's existing self-test style: the two affected regexes are exercised against CRLF-simulated snippets after normalization.

## Verification (Windows 11, `core.autocrlf=true`, pristine upstream/main)

| | passed | failed |
|---|---|---|
| before | 1675 | 2 |
| after | 1678 | 0 |

(+2 formerly failing checks now pass, +1 new regression guard.)

## Deliberately NOT included

Option 3 from #1771 (a `.gitattributes` forcing LF for these files) is intentionally left out — that's a repo-policy call best left to maintainer preference on #1771. This PR is sufficient on its own and composes cleanly with `.gitattributes` if added later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when validating documentation and content that uses Windows-style line endings.
  - Prevented false failures in language output checks caused by differences between Windows and Unix line endings.
- **Tests**
  - Added regression coverage to ensure output validation remains reliable across supported line-ending formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->