### PR TITLE
refactor(web): adopt the Button primitive where parity is exact (4 icon-ghosts)

### DIFF
--- a/web/src/components/assistant-console.tsx
+++ b/web/src/components/assistant-console.tsx
@@ -12,6 +12,7 @@ import { usePipeline } from "@/components/pipeline/pipeline-provider";
 import { useApply } from "@/components/apply/apply-provider";
 import { useExplore } from "@/components/explore/explore-provider";
 import { WorkerCard } from "@/components/jobs/worker-card";
+import { Button } from "@/components/ui/button";
 import { dispatch, type ActionCtx, type DoneInfo } from "@/app/actions/registry";
 import { scoreNum } from "@/lib/format";
 import { cn } from "@/lib/cn";
@@ -490,12 +491,12 @@ export function AssistantConsole() {
               <div className="text-sm font-semibold tracking-tight">Assistant</div>
               <div className="text-xs text-faint">{cliId ? `via ${cliId}` : "no CLI configured"}</div>
             </div>
-            <button onClick={resetChat} className="rounded-md p-1.5 text-muted transition-colors hover:bg-surface-hover hover:text-foreground" aria-label="New chat" title="New chat">
+            <Button variant="ghost" size="icon" onClick={resetChat} className="text-muted" aria-label="New chat" title="New chat">
               <RotateCcw className="size-4" />
-            </button>
-            <button onClick={() => setOpen(false)} className="rounded-md p-1.5 text-muted transition-colors hover:bg-surface-hover hover:text-foreground" aria-label="Close assistant">
+            </Button>
+            <Button variant="ghost" size="icon" onClick={() => setOpen(false)} className="text-muted" aria-label="Close assistant">
               <X className="size-4" />
-            </button>
+            </Button>
           </header>
 
           <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto px-4 py-4">

--- a/web/src/components/copyable-command.tsx
+++ b/web/src/components/copyable-command.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/cn";
 
 // Single-line monospace command + copy-to-clipboard — ported from the
@@ -44,19 +45,21 @@ export function CopyableCommand({
       >
         Copied
       </span>
-      <button
+      <Button
+        variant="ghost"
+        size="icon"
         type="button"
         onClick={handleCopy}
         aria-label={copied ? "Copied to clipboard" : "Copy command"}
         title={copied ? "Copied" : "Copy"}
-        className="inline-flex shrink-0 items-center justify-center rounded-md p-1.5 text-muted transition-colors hover:bg-surface-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+        className="shrink-0 text-muted"
       >
         {copied ? (
           <CheckIcon className="size-4 text-brand" aria-hidden="true" />
         ) : (
           <CopyIcon className="size-4" aria-hidden="true" />
         )}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/web/src/components/theme-toggle.tsx
+++ b/web/src/components/theme-toggle.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Sun, Moon } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/cn";
 
 const KEY = "career-ops:theme";
@@ -29,17 +30,16 @@ export function ThemeToggle({ className }: { className?: string }) {
   }
 
   return (
-    <button
+    <Button
+      variant="ghost"
+      size="icon"
       type="button"
       onClick={toggle}
       aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
       title={dark ? "Light mode" : "Dark mode"}
-      className={cn(
-        "inline-flex items-center justify-center rounded-md p-1.5 text-muted transition-colors hover:bg-surface-hover hover:text-foreground max-sm:min-h-[44px] max-sm:min-w-[44px]",
-        className,
-      )}
+      className={cn("text-muted", className)}
     >
       {dark ? <Sun className="size-4" /> : <Moon className="size-4" />}
-    </button>
+    </Button>
   );
 }


### PR DESCRIPTION
## What

First real call-sites for `ui/button.tsx` (it had **zero**): the 4 `p-1.5` icon-buttons that match `ghost`/`icon` exactly — assistant new-chat + close, copy-command, theme-toggle. They now inherit the primitive's 44px mobile defaults, focus ring and disabled handling from one place.

## The honest finding (why only 4 of 90)

A full sweep classified all 90 hand-rolled `<button>`s. The other 86 are **deliberate bespoke language**, where migration would change look or behavior:

| Not migrated | ~N |
|---|---|
| `rounded-full` pills (CTAs/hero/chips) | 26 |
| Bespoke `brightness-110`/shadow CTAs | 15 |
| Chips / tabs / segmented (own pattern) | 12 |
| Text/link-style (no bg) | 14 |
| `brand-soft` bespoke | 6 |
| Config selector cards | 5 |
| Destructive red | 3 |
| Padding/always-44 mismatches | 5 |

Sharpest edge: mobile-nav's open/close is **always-44** (no `max-sm:`) because the nav is visible up to 767px — migrating to the `max-sm`-only default would *regress* tablets.

**Design-system question raised to career-ops-ux:** should `buttonVariants` grow `pill` / `soft` variants matching the app's real vocabulary, so future adoption is meaningful? Their call (DESIGN_SYSTEM.md is arbiter).

## Verification

typecheck + `next build` green. Visual parity exact on the 4 migrated (same classes the variant emits).

Scope: `web/` only, 3 files, +17/−13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated assistant controls, command copying, and theme switching to use consistent shared button styling.
  - Preserved existing actions, labels, tooltips, icons, and visual states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->