### PR TITLE
fix(templates): allowlist the template format to prevent path traversal

### DIFF
--- a/cv-templates.mjs
+++ b/cv-templates.mjs
@@ -43,6 +43,16 @@ export function kebab(display) {
     .replace(/^-+|-+$/g, '');
 }
 
+// The only template formats the resolver recognizes. `format` reaches path
+// construction (fileFor) unmodified, so it must be allowlisted or a value like
+// `--format=../../etc/passwd` would traverse out of the templates dir.
+const VALID_FORMATS = new Set(['html', 'tex']);
+function assertFormat(format) {
+  if (!VALID_FORMATS.has(format)) {
+    throw new Error(`Unsupported template format: ${format} (expected html or tex)`);
+  }
+}
+
 // filename → {name, format} | null. Base "cv-template.html" → name "standard";
 // "cv-template.<name>.html" → that name. Only html/tex are recognized.
 function parseFilename(prefix, file) {
@@ -71,6 +81,7 @@ export function parseMeta(path) {
 export function listTemplates(kind, { dir = DEFAULT_TEMPLATES_DIR, format = 'html' } = {}) {
   const cfg = KINDS[kind];
   if (!cfg) throw new Error(`Unknown template kind: ${kind}`);
+  assertFormat(format);
   if (!existsSync(dir)) return [];
   const out = [];
   for (const file of readdirSync(dir)) {
@@ -121,6 +132,7 @@ export function resolveTemplate(kind, name, opts = {}) {
     profilePath = DEFAULT_PROFILE_PATH,
     fallback = false,
   } = opts;
+  assertFormat(format);
 
   const explicit = Boolean(name && String(name).trim());
   let chosen = kebab(explicit ? name : loadProfileDefault(kind, { profilePath }) || 'standard');

--- a/test/cv-templates.test.mjs
+++ b/test/cv-templates.test.mjs
@@ -155,6 +155,19 @@ test('resolveTemplate: fallback=true drops missing name to standard', () => {
   assert.ok(p.endsWith('cv-template.tex'));
 });
 
+test('resolveTemplate: rejects a path-traversal format (allowlist guard)', () => {
+  const { dir, profile } = fixtureWithProfile(null);
+  assert.throws(
+    () => resolveTemplate('cv', undefined, { dir, profilePath: profile, format: '../../../../etc/passwd' }),
+    /Unsupported template format/
+  );
+});
+
+test('listTemplates: rejects a path-traversal format (allowlist guard)', () => {
+  const dir = fixtureDir();
+  assert.throws(() => listTemplates('cv', { dir, format: '../../etc' }), /Unsupported template format/);
+});
+
 test('resolveTemplate: html validation failure throws', () => {
   const { dir, profile } = fixtureWithProfile(null);
   writeFileSync(join(dir, 'cv-template.broken.html'), '{{NAME}} only');


### PR DESCRIPTION
## What does this PR do?

Guards `resolveTemplate` and `listTemplates` with a strict `html`/`tex` format allowlist. `format` was concatenated straight into the resolved filename (`fileFor` → `resolve(dir, ...)`), so a value like `--format=../../../../etc/passwd` produced `/../` segments that `resolve()` honors, escaping the templates directory — and any non-`html` format skipped `validateTemplate` entirely. This is a follow-up to the resolver added in #1691.

## Related issue

None — bug fix (path traversal), sent straight in per CONTRIBUTING.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template operations now reject unsupported formats before processing, improving safety and preventing invalid path resolution.
  * Supported template formats remain limited to HTML and TeX.

* **Tests**
  * Added coverage for invalid and path-traversal-style format values in template listing and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->