### PR TITLE
fix(cover): resolve the cover-letter template through the shared resolver

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -17,6 +17,7 @@ import { readFileSync, existsSync, mkdirSync } from "fs";
 import { dirname, resolve, basename, join } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 import { parseArgs } from "util";
+import { resolveTemplate } from "./cv-templates.mjs";
 
 const OUTPUT_ROOT = resolve("output");
 
@@ -103,16 +104,30 @@ function buildFootnotesBlock(footnotes) {
   return `<div class="footnotes">\n${lines}\n  </div>`;
 }
 
-export function buildHtml(payload) {
+// Resolve the cover-letter template through the shared resolver so a
+// `cover_letter.template` profile default, an explicit `payload.template`, and
+// installed template packs are all honored. Any resolver failure (no profile,
+// no templates dir, bad config) falls back to the base template, preserving the
+// original hardcoded behavior.
+export function resolveCoverTemplatePath(payload = {}, opts = {}) {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const base = resolve(scriptDir, "templates", "cover-letter-template.html");
+  try {
+    return resolveTemplate("cover", payload.template, { format: "html", fallback: true, ...opts });
+  } catch {
+    return base;
+  }
+}
+
+export function buildHtml(payload, templatePath) {
   _require(payload, ["candidate", "letter"], "payload");
   const candidate = payload.candidate;
   const letter = payload.letter;
   _require(candidate, ["name"], "candidate");
   _require(letter, ["role_title", "opening", "profile_intro"], "letter");
 
-  const scriptDir = dirname(fileURLToPath(import.meta.url));
-  const templatePath = resolve(scriptDir, "templates", "cover-letter-template.html");
-  let html = readFileSync(templatePath, "utf-8");
+  const resolvedPath = templatePath || resolveCoverTemplatePath(payload);
+  let html = readFileSync(resolvedPath, "utf-8");
 
   // Optional salutation (e.g. "Dear Jane Smith,"). Omitted -> no salutation,
   // preserving the original behavior for payloads that don't set it.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7832,6 +7832,13 @@ console.log('\n59. CV template resolver (cv-templates.mjs)');
   else fail(`CLI: resolve cv (unset) unexpected: ${resolved}`);
 }
 
+console.log('\n60. Cover-letter template resolver (generate-cover-letter.mjs)');
+{
+  const unit = run(NODE, ['--test', 'test/cover-resolver.test.mjs']);
+  if (unit !== null) pass('cover-resolver unit tests pass');
+  else fail('cover-resolver unit tests failed (run: node --test test/cover-resolver.test.mjs)');
+}
+
 console.log('\nTest layout guard (provider tests live in tests/providers/)');
 try {
   const src = readFileSync(join(ROOT, 'test-all.mjs'), 'utf-8');

--- a/test/cover-resolver.test.mjs
+++ b/test/cover-resolver.test.mjs
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, basename } from 'node:path';
+import { resolveCoverTemplatePath } from '../generate-cover-letter.mjs';
+
+function coverFixture(templateValue) {
+  const dir = mkdtempSync(join(tmpdir(), 'cover-'));
+  writeFileSync(join(dir, 'cover-letter-template.html'), '{{NAME}}{{ROLE_TITLE}}{{OPENING}}');
+  writeFileSync(
+    join(dir, 'cover-letter-template.formal.html'),
+    '<!-- career-ops-template\nname: Formal\nversion: 1.0.0\n-->\n{{NAME}}{{ROLE_TITLE}}{{OPENING}}'
+  );
+  const profile = join(dir, 'profile.yml');
+  writeFileSync(
+    profile,
+    templateValue == null ? 'cover_letter: {}\n' : `cover_letter:\n  template: ${templateValue}\n`
+  );
+  return { dir, profile };
+}
+
+test('resolveCoverTemplatePath: honors the cover_letter.template profile default', () => {
+  const { dir, profile } = coverFixture('formal');
+  const p = resolveCoverTemplatePath({}, { dir, profilePath: profile });
+  assert.equal(basename(p), 'cover-letter-template.formal.html');
+});
+
+test('resolveCoverTemplatePath: explicit payload.template wins, kebab-normalized', () => {
+  const { dir, profile } = coverFixture(null);
+  const p = resolveCoverTemplatePath({ template: 'Formal' }, { dir, profilePath: profile });
+  assert.equal(basename(p), 'cover-letter-template.formal.html');
+});
+
+test('resolveCoverTemplatePath: base template when nothing configured (backward-compatible)', () => {
+  const { dir, profile } = coverFixture(null);
+  const p = resolveCoverTemplatePath({}, { dir, profilePath: profile });
+  assert.equal(basename(p), 'cover-letter-template.html');
+});
+
+test('resolveCoverTemplatePath: falls back to base when the configured template is missing', () => {
+  const { dir, profile } = coverFixture('nonexistent');
+  const p = resolveCoverTemplatePath({}, { dir, profilePath: profile });
+  assert.equal(basename(p), 'cover-letter-template.html');
+});

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -259,6 +259,7 @@ const SYSTEM_PATHS = [
   'build-cv-latex.mjs',
   'cv-templates.mjs',
   'test/cv-templates.test.mjs',
+  'test/cover-resolver.test.mjs',
   'scaffolder/',
   'Dockerfile',
   'docker-compose.yml',


### PR DESCRIPTION
## What does this PR do?

Routes `generate-cover-letter.mjs` through the shared `cv-templates.mjs` resolver (added in #1691) instead of reading the hardcoded `templates/cover-letter-template.html`, so the config-selectable cover templates that #1691 introduced are actually reachable from the cover-letter path: a `cover_letter.template` profile default, an explicit template name, and installed template packs are now honored. Adds `resolveCoverTemplatePath()` (falls back to the base template on any resolver error, so the default path is byte-identical to before) and an optional `buildHtml(payload, templatePath)` override to keep `buildHtml` hermetically testable.

## Related issue

None — bug fix (the #1691 resolver was unreachable from the cover-letter script), sent straight in per CONTRIBUTING.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable cover-letter template selection using profile or payload settings.
  * Added fallback to the default template when a configured template cannot be found.

* **Bug Fixes**
  * Improved template resolution while preserving backward compatibility.

* **Tests**
  * Added coverage for profile defaults, payload overrides, normalization, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->