### PR TITLE
docs(scripts): document openai-tailor.mjs in SCRIPTS.md

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -29,6 +29,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run tracker` | `tracker.mjs` | SQLite derived index over applications.md — sync/query/history/export |
 | `npm run find` | `find.mjs` | Resolve a report#/tracker#/company query to its full pipeline identity |
 | `npm run invite-match` | `invite-match.mjs` | Fuzzy-match a pasted interview-invite email against `data/applications.md` |
+| `npm run openai:tailor` | `openai-tailor.mjs` | Tailor a CV via any OpenAI-compatible endpoint (headless companion to `openai-eval.mjs`) |
 
 ---
 


### PR DESCRIPTION
Closes #1763.

## What

Adds one row to the Quick Reference table in `docs/SCRIPTS.md` for `openai-tailor.mjs`, which shipped in #1671 but had no entry (`grep openai-tailor docs/SCRIPTS.md` returned nothing).

```
| `npm run openai:tailor` | `openai-tailor.mjs` | Tailor a CV via any OpenAI-compatible endpoint (headless companion to `openai-eval.mjs`) |
```

## Sources of truth

- npm alias `openai:tailor` → `node openai-tailor.mjs` (`package.json`)
- Purpose one-liner taken from the script's header comment ("headless companion to openai-eval.mjs … tailor your CV with any OpenAI-compatible chat endpoint"), not invented.

## Note for the maintainer

The issue suggested mirroring an existing `openai-eval.mjs` row, but SCRIPTS.md currently has no `openai-eval` row (openai-eval/tailor are documented in `docs/RUNNING_ON_A_BUDGET.md`). So this follows the format/voice of the table's existing neighbor rows instead. Happy to also add sibling rows (openai-eval, gemini-eval, ollama-eval) or a detailed `## openai-tailor` section if you'd prefer — kept it to the single row per the acceptance criteria.

Acceptance: one table row, neighbor voice/format, usage matches the script, no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a quick-reference entry for the CV tailoring command.
  * Documented support for OpenAI-compatible endpoints in headless workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->