### PR TITLE
docs(faq): add a FAQ entry for custom CV templates

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -40,6 +40,10 @@ it means the job description text of two listings from **different companies** i
 
 **Technical note:** the scanner computes a 64-bit SimHash fingerprint of each JD body and stores it in the 8th column of `data/scan-history.tsv` (`jd_fingerprint`). Fingerprints are computed locally from text already returned by the ATS API — no extra network request is made. Postings without a usable description never receive a fingerprint and are never flagged. See [docs/SCRIPTS.md](SCRIPTS.md#cross-listing-detection) for the full column reference.
 
+## 6. Can I use my own CV template?
+
+Yes. Set `cv.template` (and/or `cover_letter.template`) in `config/profile.yml` to the kebab-case name of a template file in `templates/` — a value of `modern` resolves to `templates/cv-template.modern.html` (cover letters use `templates/cover-letter-template.<name>.html`). Leave the field unset and career-ops falls back to the built-in default template (`templates/cv-template.html`). You can also pick a template per generation just by asking (e.g. "use the modern template"). See the commented `cv.template` / `cover_letter.template` fields in `config/profile.example.yml` for the full reference.
+
 ## How do I stop a company from showing up in scans?
 
 Copy `templates/blacklist.example.md` to `data/blacklist.md`, then list one company per line.


### PR DESCRIPTION
Closes #1773.

## What

Adds one FAQ entry ("Can I use my own CV template?") to `docs/FAQ.md`, covering the config-selectable templates that shipped in #1691. Follows the format of the existing entries (question as heading, short answer, link out for detail).

The entry covers:
- the two `config/profile.yml` fields (`cv.template`, `cover_letter.template`)
- the naming convention (`templates/cv-template.<name>.html` / `cover-letter-template.<name>.html`)
- where the default templates live (`templates/`)
- the fallback to the built-in default when the field is unset

## Sources of truth

- `config/profile.example.yml` comments for the two fields
- `cv-templates.mjs` resolver — confirmed the unset → `templates/cv-template.html` ("standard") fallback in `resolveTemplate`/`loadProfileDefault`.

Acceptance: one FAQ entry, neighbor voice/structure, behavior matches the resolver, no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ guidance for using custom CV and cover letter templates.
  * Documented template configuration, presets, fallback behavior, and per-generation template requests.
  * Added a reference to the example profile configuration for available fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->