### PR TITLE
feat: group application CV artifacts

### DIFF
--- a/application-artifacts.mjs
+++ b/application-artifacts.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+/**
+ * Resolve and initialize one application-scoped artifact directory.
+ *
+ * Generated CVs are intentionally kept under output/ because they are user
+ * artifacts. The directory key is stable for a report/company/role tuple so
+ * the JD, source CV, tailored CV, PDF, and reuse decision stay together.
+ */
+
+import { mkdirSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { parseArgs } from 'util';
+import { fileURLToPath } from 'url';
+
+const DEFAULT_OUTPUT_ROOT = resolve('output');
+const DECISIONS = new Set(['reuse', 'reuse-with-edits', 'regenerate']);
+
+/** Convert a user-facing label into a safe, readable path segment. */
+export function slugifySegment(value, fallback = 'application') {
+  const slug = String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || fallback;
+}
+
+/** Return all stable paths belonging to one application artifact bundle. */
+export function applicationArtifactPaths({ reportNum, company, role, root = DEFAULT_OUTPUT_ROOT }) {
+  if (!/^\d+$/.test(String(reportNum ?? ''))) {
+    throw new Error('reportNum must be a numeric report number');
+  }
+  const key = `${String(reportNum).padStart(3, '0')}-${slugifySegment(company)}-${slugifySegment(role, 'role')}`;
+  const applicationRoot = join(resolve(root), key);
+  return {
+    key,
+    root: applicationRoot,
+    jd: {
+      current: join(applicationRoot, 'jd', 'current.md'),
+      previous: join(applicationRoot, 'jd', 'previous.md'),
+    },
+    cv: {
+      source: join(applicationRoot, 'cv', 'source.html'),
+      tailored: join(applicationRoot, 'cv', 'tailored.html'),
+      pdf: join(applicationRoot, 'cv', 'tailored.pdf'),
+    },
+    reuseDecision: join(applicationRoot, 'reuse-decision.json'),
+  };
+}
+
+/** Create the JD and CV subdirectories for an application bundle. */
+export function ensureApplicationArtifactDirs(paths) {
+  mkdirSync(paths.jd.current.replace(/[/\\][^/\\]+$/, ''), { recursive: true });
+  mkdirSync(paths.cv.source.replace(/[/\\][^/\\]+$/, ''), { recursive: true });
+  return paths;
+}
+
+/** Write an auditable CV reuse decision beside the application artifacts. */
+export function writeReuseDecision(paths, {
+  decision,
+  score = null,
+  sourceCv = null,
+  currentJd = null,
+  previousSource = null,
+  changedSections = [],
+  userOverride = false,
+}) {
+  if (!DECISIONS.has(decision)) throw new Error(`decision must be one of: ${[...DECISIONS].join(', ')}`);
+  if (!Array.isArray(changedSections)) throw new Error('changedSections must be an array');
+  ensureApplicationArtifactDirs(paths);
+  const record = {
+    schema_version: 1,
+    decision,
+    score,
+    source_cv: sourceCv,
+    current_jd: currentJd,
+    previous_source: previousSource,
+    changed_sections: changedSections,
+    user_override: Boolean(userOverride),
+    recorded_at: new Date().toISOString(),
+  };
+  writeFileSync(paths.reuseDecision, `${JSON.stringify(record, null, 2)}\n`);
+  return record;
+}
+
+function usage() {
+  return 'Usage: node application-artifacts.mjs --report N --company NAME --role ROLE [--root output] [--init]';
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      report: { type: 'string' },
+      company: { type: 'string' },
+      role: { type: 'string' },
+      root: { type: 'string' },
+      init: { type: 'boolean' },
+    },
+    strict: true,
+  });
+  if (!values.report || !values.company || !values.role) {
+    console.error(usage());
+    process.exitCode = 1;
+    return;
+  }
+  const paths = applicationArtifactPaths({ reportNum: values.report, company: values.company, role: values.role, root: values.root });
+  if (values.init) ensureApplicationArtifactDirs(paths);
+  console.log(JSON.stringify(paths, null, 2));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) main();
+

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -29,6 +29,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run tracker` | `tracker.mjs` | SQLite derived index over applications.md — sync/query/history/export |
 | `npm run find` | `find.mjs` | Resolve a report#/tracker#/company query to its full pipeline identity |
 | `npm run invite-match` | `invite-match.mjs` | Fuzzy-match a pasted interview-invite email against `data/applications.md` |
+| `npm run application:init` | `application-artifacts.mjs` | Initialize one application-scoped JD/CV/PDF artifact bundle |
 
 ---
 

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -2,6 +2,12 @@
 
 ## Full pipeline
 
+## Application-scoped artifacts
+
+When a CV is reused or lightly tailored for an existing application, initialize a bundle with `npm run application:init -- --report {report-number} --company "{company}" --role "{role}"`. Keep the current JD at `jd/current.md`, the comparison JD at `jd/previous.md`, the source CV at `cv/source.html`, the tailored CV at `cv/tailored.html`, the PDF at `cv/tailored.pdf`, and the reuse decision at `reuse-decision.json` under the printed bundle root. Resolve the application/report first with `node find.mjs {report-or-tracker-number}` so the bundle uses the report number, not an ambiguous tracker row.
+
+Run `npm run jd:similarity -- {bundle-root}/jd/current.md {bundle-root}/jd/previous.md` when both comparison sources exist. Record the visible decision (`reuse`, `reuse-with-edits`, or `regenerate`), score, source CV/JD paths, and changed sections in `reuse-decision.json`. Reuse only after a visible `reuse` result or an explicit user override; never silently reuse when a source is missing. The PDF manifest supports these nested paths and continues to link them to the report. Flat `output/` paths remain valid for one-off PDFs.
+
 1. Read `cv.md` as the source of truth
 2. Ask the user for the JD if it is not in context (text or URL)
 3. Extract 15-20 keywords from the JD
@@ -19,8 +25,8 @@
 13. Apply the six-second clarity gate from `modes/heuristics/recruiter-side.md`: top third must make target role, strongest fit, and proof obvious
 14. Generate full HTML from template + personalized content
 15. Read `name` from `config/profile.yml` → normalize to kebab-case lowercase (e.g. "John Doe" → "john-doe") → `{candidate}`
-16. Write HTML to `output/cv-{candidate}-{company}.html` (NOT a temp dir — the recorded HTML is what the dashboard's `D` hotkey regenerates from, so it must survive temp cleanup)
-17. Run the fact gate: `node verify-cv-facts.mjs output/cv-{candidate}-{company}.html`
+16. Write HTML to the application bundle's `cv/tailored.html` when a bundle is active; otherwise use `output/cv-{candidate}-{company}.html` (NOT a temp dir — the recorded HTML is what the dashboard's `D` hotkey regenerates from, so it must survive temp cleanup)
+17. Run the fact gate against the generated tailored HTML: `node verify-cv-facts.mjs {bundle-root}/cv/tailored.html` or the flat output path
     - This is a hard gate before PDF rendering.
     - If it fails, stop and fix the generated HTML by removing invented metrics or adding verified evidence to `cv.md`, `article-digest.md`, or `config/cv-facts.json`.
 18. Execute: `node generate-pdf.mjs output/cv-{candidate}-{company}.html output/cv-{candidate}-{company}-{YYYY-MM-DD}.pdf --format={letter|a4} --report={report number}` — `{report number}` is the NNN from the report filename/link (e.g. `008` for `reports/008-acme-….md`), not the tracker `#` column. Pass it whenever the application has (or will have) a report; it records the PDF↔report linkage in `data/pdf-index.tsv` so the dashboard can open and regenerate the exact PDF. Omit it only for one-off CVs with no tracker entry.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "star": "node match-star.mjs",
     "archive": "node archive-posting.mjs",
     "prepare:application": "node prepare-application.mjs",
+    "application:init": "node application-artifacts.mjs --init",
     "build:dashboard": "node build-dashboard.mjs",
     "serve:dashboard": "cd dashboard && go run . --path ..",
     "postinstall": "npx playwright install chromium --with-deps || npx playwright install chromium --with-deps"

--- a/tests/application-artifacts.test.mjs
+++ b/tests/application-artifacts.test.mjs
@@ -1,0 +1,39 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { applicationArtifactPaths, ensureApplicationArtifactDirs, writeReuseDecision } from '../application-artifacts.mjs';
+
+const root = mkdtempSync(join(tmpdir(), 'career-ops-application-artifacts-'));
+try {
+  const paths = applicationArtifactPaths({ reportNum: 7, company: 'Acme AI', role: 'Senior AI Engineer', root });
+  if (paths.key === '007-acme-ai-senior-ai-engineer' && paths.cv.pdf.endsWith('/cv/tailored.pdf')) {
+    console.log('  ✅ application artifacts use a stable report/company/role bundle');
+  } else {
+    throw new Error(`unexpected artifact paths: ${JSON.stringify(paths)}`);
+  }
+
+  ensureApplicationArtifactDirs(paths);
+  if (existsSync(join(paths.root, 'jd')) && existsSync(join(paths.root, 'cv'))) {
+    console.log('  ✅ application artifact directories initialize together');
+  } else {
+    throw new Error('application artifact directories were not created');
+  }
+
+  writeReuseDecision(paths, {
+    decision: 'reuse-with-edits',
+    score: 0.81,
+    sourceCv: paths.cv.source,
+    currentJd: paths.jd.current,
+    previousSource: paths.jd.previous,
+    changedSections: ['Summary', 'Skills'],
+  });
+  const decision = JSON.parse(readFileSync(paths.reuseDecision, 'utf8'));
+  if (decision.decision === 'reuse-with-edits' && decision.changed_sections.length === 2) {
+    console.log('  ✅ reuse decisions are recorded beside the artifact bundle');
+  } else {
+    throw new Error(`unexpected reuse decision: ${JSON.stringify(decision)}`);
+  }
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -157,6 +157,7 @@ const SYSTEM_PATHS = [
   'scan-ats-full.mjs',
   'match-star.mjs',
   'prepare-application.mjs',
+  'application-artifacts.mjs',
   'providers/',
   'seeds/',
   'tests/',


### PR DESCRIPTION
## Summary

- Add a stable application-scoped artifact layout keyed by report number, company, and role.
- Keep current/previous JD snapshots, source/tailored CV HTML, PDF, and reuse decision together.
- Add `npm run application:init` and document the workflow in `modes/pdf.md` and `docs/SCRIPTS.md`.
- Register the new system-layer script with `update-system.mjs`.
- Preserve flat `output/` paths for one-off PDFs and existing nested PDF manifest support.

Closes #1779

## Artifact layout

```text
output/{report}-{company}-{role}/
  jd/current.md
  jd/previous.md
  cv/source.html
  cv/tailored.html
  cv/tailored.pdf
  reuse-decision.json
```

## Validation

- `node tests/application-artifacts.test.mjs`
- `node application-artifacts.mjs --report 7 --company "Acme AI" --role "Senior AI Engineer" --root /tmp/career-ops-artifacts-test --init`
- `node test-all.mjs` — 1688 passed, 0 failed, 2 existing warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added application-scoped artifact bundles for organizing job descriptions, CVs, PDFs, and reuse decisions.
  * Added `npm run application:init` to initialize an application artifact bundle.
  * Added stable, sanitized paths and auditable CV reuse records.

* **Documentation**
  * Updated pipeline guidance for application bundles, nested PDF paths, and reuse tracking.
  * Clarified column-based parsing for scan statistics.

* **Tests**
  * Added coverage for artifact paths, directory creation, and reuse decision records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->