### PR TITLE
feat(dashboard): add Spanish (es) locale to the i18n catalog

### DIFF
--- a/dashboard/internal/i18n/catalog.go
+++ b/dashboard/internal/i18n/catalog.go
@@ -469,14 +469,145 @@ var Tr = Catalog{
 	ViewFlat:     "düz",
 }
 
+// Es is the static Spanish translation catalog.
+var Es = Catalog{
+	// Screen banners & general
+	AppTitle:       "FLUJO DE CARRERA",
+	OffersSummary:  "%d ofertas | Prom %s/5",
+	NoOffersMatch:  "Ninguna oferta coincide con este filtro",
+	LoadingPreview: "Cargando vista previa...",
+
+	// Tabs & filters
+	TabAll:       "TODAS",
+	TabEvaluated: "EVALUADAS",
+	TabApplied:   "APLICADAS",
+	TabInterview: "ENTREVISTA",
+	TabTop:       "TOP ≥4",
+	TabSkip:      "OMITIR",
+	TabRejected:  "RECHAZADAS",
+	TabDiscarded: "DESCARTADAS",
+
+	// Table column headers
+	ColFit:      "AJUSTE",
+	ColApplied:  "APLICADA",
+	ColCompany:  "EMPRESA",
+	ColRole:     "PUESTO",
+	ColStatus:   "ESTADO",
+	ColLocation: "UBICACIÓN",
+	ColPay:      "SALARIO",
+	ColLast:     "ÚLTIMO",
+
+	// Preview labels
+	LabelLoc:     "Ubic: ",
+	LabelPay:     "Salario: ",
+	LabelLast:    "Último contacto: ",
+	LabelRemote:  "Remoto: ",
+	LabelOutcome: "Resultado: ",
+
+	// Work modes
+	ModeRemote:     "Remoto",
+	ModeRemoteFlex: "Remoto (Flex)",
+	ModeHybrid:     "Híbrido",
+	ModeFull:       "Presencial",
+
+	// Progress screen
+	ProgressTitle:   "PROGRESO DE BÚSQUEDA",
+	ProgressSummary: "%d evaluadas | %.1f puntuación media",
+	FunnelTitle:     "Embudo del proceso",
+	ScoresTitle:     "Distribución de puntuaciones",
+	RatesTitle:      "Tasas de conversión",
+	WeeklyTitle:     "Actividad semanal",
+	ActiveInfo:      "%d solicitudes activas | %d ofertas totales",
+
+	// Relative dates
+	TimeToday:     "hoy",
+	TimeYesterday: "ayer",
+	TimeDaysAgo:   "hace %dd",
+
+	// Status display names
+	StatusEvaluated: "Evaluada",
+	StatusApplied:   "Aplicada",
+	StatusResponded: "Respondida",
+	StatusInterview: "Entrevista",
+	StatusOffer:     "Oferta",
+	StatusRejected:  "Rechazada",
+	StatusDiscarded: "Descartada",
+	StatusSkip:      "OMITIR",
+	StatusHired:     "Contratada",
+
+	// Additional UI strings
+	NoData:        "Sin datos",
+	EmptyFile:     "(archivo vacío)",
+	RateResponse:  "Tasa de respuesta: ",
+	RateInterview: "Tasa de entrevistas: ",
+	RateOffer:     "Tasa de ofertas: ",
+
+	// Footer descriptions & hints
+	HelpNav:        " navegar  ",
+	HelpTabs:       " pestañas  ",
+	HelpSearch:     " buscar  ",
+	HelpSort:       " ordenar  ",
+	HelpRefresh:    " actualizar  ",
+	HelpReport:     " informe  ",
+	HelpOpenURL:    " abrir URL  ",
+	HelpOpenPDF:    " abrir PDF  ",
+	HelpRegenPDF:   " regenerar PDF  ",
+	HelpChange:     " cambiar  ",
+	HelpColumns:    " columnas  ",
+	HelpView:       " vista  ",
+	HelpProgress:   " progreso  ",
+	HelpQuit:       " salir",
+	HelpScroll:     " desplazar  ",
+	HelpPage:       " página  ",
+	HelpTopEnd:     " inicio/fin  ",
+	HelpLanguage:   " idioma  ",
+	HelpBack:       " atrás",
+	HelpNavigate:   " navegar  ",
+	HelpToggle:     " alternar  ",
+	HelpClose:      " cerrar",
+	HelpConfirm:    " confirmar  ",
+	HelpCancel:     " cancelar",
+	HelpFilterLive: " filtrar en vivo  ",
+	HelpKeep:       " guardar  ",
+	HelpClear:      " limpiar  ",
+
+	// Picker overlay titles & bar hints
+	PickerChangeStatus: "Cambiar estado:",
+	PickerColumnsTitle: "─── Columnas (SPACE alternar · ESC cerrar) ───",
+	SearchHintInput:    "   Enter: guardar   Esc: cancelar   Ctrl+U: limpiar",
+	SearchHintNormal:   "   Esc: limpiar   /: editar",
+	SearchMatching:     "  %d/%d coincidencias",
+	SortLabel:          "[Orden: %s]",
+	ViewLabel:          "[Vista: %s]",
+	ShownCount:         "%d mostradas",
+	ColReport:          "INF",
+	ColPDF:             "PDF",
+
+	// Sort & view modes
+	SortScore:    "puntuación",
+	SortDate:     "fecha",
+	SortCompany:  "empresa",
+	SortStatus:   "estado",
+	SortLocation: "ubicación",
+	SortPay:      "salario",
+	SortLast:     "último",
+	ViewGrouped:  "agrupado",
+	ViewFlat:     "plano",
+}
+
 // Current points to the active language catalog. Defaults to English (&En).
 var Current = &En
 
-// SetLang sets the active catalog based on language code prefix (e.g., "tr", "tr_TR" -> &Tr).
+// SetLang sets the active catalog based on language code prefix
+// (e.g., "tr", "tr_TR" -> &Tr; "es", "es_ES" -> &Es; anything else -> &En).
 func SetLang(lang string) {
-	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(lang)), "tr") {
+	l := strings.ToLower(strings.TrimSpace(lang))
+	switch {
+	case strings.HasPrefix(l, "tr"):
 		Current = &Tr
-	} else {
+	case strings.HasPrefix(l, "es"):
+		Current = &Es
+	default:
 		Current = &En
 	}
 }
@@ -490,10 +621,14 @@ func ToggleLang() {
 	}
 }
 
-// GetLang returns the active language code ("tr" if Current == &Tr, else "en").
+// GetLang returns the active language code ("tr" if Current == &Tr, "es" if
+// Current == &Es, else "en").
 func GetLang() string {
 	if Current == &Tr {
 		return "tr"
+	}
+	if Current == &Es {
+		return "es"
 	}
 	return "en"
 }

--- a/dashboard/internal/i18n/i18n_test.go
+++ b/dashboard/internal/i18n/i18n_test.go
@@ -10,16 +10,17 @@ func TestStatusLabel(t *testing.T) {
 		norm string
 		en   string
 		tr   string
+		es   string
 	}{
-		{"interview", "Interview", "Mülakat"},
-		{"offer", "Offer", "Teklif"},
-		{"responded", "Responded", "Yanıt Verildi"},
-		{"applied", "Applied", "Başvuruldu"},
-		{"evaluated", "Evaluated", "Değerlendirildi"},
-		{"skip", "SKIP", "Uygun Değil"},
-		{"rejected", "Rejected", "Reddedildi"},
-		{"discarded", "Discarded", "İptal Edildi"},
-		{"unknown", "unknown", "unknown"},
+		{"interview", "Interview", "Mülakat", "Entrevista"},
+		{"offer", "Offer", "Teklif", "Oferta"},
+		{"responded", "Responded", "Yanıt Verildi", "Respondida"},
+		{"applied", "Applied", "Başvuruldu", "Aplicada"},
+		{"evaluated", "Evaluated", "Değerlendirildi", "Evaluada"},
+		{"skip", "SKIP", "Uygun Değil", "OMITIR"},
+		{"rejected", "Rejected", "Reddedildi", "Rechazada"},
+		{"discarded", "Discarded", "İptal Edildi", "Descartada"},
+		{"unknown", "unknown", "unknown", "unknown"},
 	}
 
 	for _, tt := range tests {
@@ -31,6 +32,9 @@ func TestStatusLabel(t *testing.T) {
 			}
 			if got := Tr.StatusLabel(tt.norm); got != tt.tr {
 				t.Fatalf("Tr.StatusLabel(%q) = %q, expected %q", tt.norm, got, tt.tr)
+			}
+			if got := Es.StatusLabel(tt.norm); got != tt.es {
+				t.Fatalf("Es.StatusLabel(%q) = %q, expected %q", tt.norm, got, tt.es)
 			}
 		})
 	}
@@ -81,6 +85,23 @@ func TestFormatTimeAgo(t *testing.T) {
 	if got := Tr.FormatTimeAgo("not-a-date"); got != "not-a-date" {
 		t.Errorf("Tr.FormatTimeAgo(invalid) = %q; want \"not-a-date\"", got)
 	}
+
+	// Spanish tests
+	if got := Es.FormatTimeAgo(today); got != "hoy" {
+		t.Errorf("Es.FormatTimeAgo(today) = %q; want \"hoy\"", got)
+	}
+	if got := Es.FormatTimeAgo(yesterday); got != "ayer" {
+		t.Errorf("Es.FormatTimeAgo(yesterday) = %q; want \"ayer\"", got)
+	}
+	if got := Es.FormatTimeAgo(threeDaysAgo); got != "hace 3d" {
+		t.Errorf("Es.FormatTimeAgo(3d ago) = %q; want \"hace 3d\"", got)
+	}
+	if got := Es.FormatTimeAgo(tomorrow); got != "hoy" {
+		t.Errorf("Es.FormatTimeAgo(tomorrow) = %q; want \"hoy\"", got)
+	}
+	if got := Es.FormatTimeAgo("not-a-date"); got != "not-a-date" {
+		t.Errorf("Es.FormatTimeAgo(invalid) = %q; want \"not-a-date\"", got)
+	}
 }
 
 func TestRuntimeLanguageManagement(t *testing.T) {
@@ -99,6 +120,16 @@ func TestRuntimeLanguageManagement(t *testing.T) {
 	SetLang("tr_TR")
 	if Current != &Tr || GetLang() != "tr" {
 		t.Errorf("after SetLang(\"tr_TR\"), GetLang() = %q; want \"tr\"", GetLang())
+	}
+
+	SetLang("es")
+	if Current != &Es || GetLang() != "es" {
+		t.Errorf("after SetLang(\"es\"), GetLang() = %q; want \"es\"", GetLang())
+	}
+
+	SetLang("es_ES")
+	if Current != &Es || GetLang() != "es" {
+		t.Errorf("after SetLang(\"es_ES\"), GetLang() = %q; want \"es\"", GetLang())
 	}
 
 	SetLang("en")
@@ -167,6 +198,25 @@ func TestSortModeLabel(t *testing.T) {
 			}
 		})
 	}
+
+	esCases := []sortTestCase{
+		{name: "score", mode: "score", want: "puntuación"},
+		{name: "date", mode: "date", want: "fecha"},
+		{name: "company", mode: "company", want: "empresa"},
+		{name: "status", mode: "status", want: "estado"},
+		{name: "location", mode: "location", want: "ubicación"},
+		{name: "pay", mode: "pay", want: "salario"},
+		{name: "last", mode: "last", want: "último"},
+		{name: "unknown", mode: "unknown", want: "unknown"},
+	}
+
+	for _, tc := range esCases {
+		t.Run("Es/"+tc.name, func(t *testing.T) {
+			if got := Es.SortModeLabel(tc.mode); got != tc.want {
+				t.Errorf("Es.SortModeLabel(%q) = %q; want %q", tc.mode, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestViewModeLabel(t *testing.T) {
@@ -200,6 +250,20 @@ func TestViewModeLabel(t *testing.T) {
 		t.Run("Tr/"+tc.name, func(t *testing.T) {
 			if got := Tr.ViewModeLabel(tc.mode); got != tc.want {
 				t.Errorf("Tr.ViewModeLabel(%q) = %q; want %q", tc.mode, got, tc.want)
+			}
+		})
+	}
+
+	esCases := []viewTestCase{
+		{name: "grouped", mode: "grouped", want: "agrupado"},
+		{name: "flat", mode: "flat", want: "plano"},
+		{name: "unknown", mode: "unknown", want: "unknown"},
+	}
+
+	for _, tc := range esCases {
+		t.Run("Es/"+tc.name, func(t *testing.T) {
+			if got := Es.ViewModeLabel(tc.mode); got != tc.want {
+				t.Errorf("Es.ViewModeLabel(%q) = %q; want %q", tc.mode, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## What does this PR do

Adds a Spanish (`es`) translation catalog to the Go TUI dashboard, mirroring the existing `tr` block key-for-key (all 99 `Catalog` fields), and wires it into language selection.

- **`catalog.go`**: new `var Es = Catalog{...}` + `SetLang` now resolves an `es`/`es_ES` prefix to `&Es`, and `GetLang` returns `"es"`. Both stay inside `internal/i18n/`.
- **`i18n_test.go`**: added `es` assertions to `TestStatusLabel`, `TestFormatTimeAgo`, `TestRuntimeLanguageManagement`, `TestSortModeLabel`, `TestViewModeLabel`, mirroring how `tr` is asserted.

Terminology follows the existing `modes/es/` (entrevista, oferta, empresa, salario, puesto, híbrido, remoto, presencial), neutral Latin-American-friendly Spanish.

## Scope note

The issue scopes this to files inside `dashboard/internal/i18n/`. To make the locale actually selectable rather than dead data, `SetLang`/`GetLang` are wired for `es` — both live in `catalog.go`, so nothing outside `internal/i18n/` is touched. Spanish is reachable via `--lang es` or `LANG=es`. I deliberately left the `t`-key `ToggleLang` as a binary `en`↔`tr` toggle (turning it into a 3-way cycle would touch `main.go`'s flag help + change existing UX/tests). Happy to extend it to a 3-way toggle in a follow-up if you'd prefer.

## Related issue

Fixes #1764

## Type of change

- [x] New feature (non-breaking)

## Checklist

- [x] I've read CONTRIBUTING.md
- [x] Linked to a related issue
- [x] No personal data
- [x] Ran `node test-all.mjs` (1688 passed, 0 failed; the 1 warning is the pre-existing `cv-sync-check.mjs` no-user-data warning) and `cd dashboard && go test ./...` (153 passed)
- [x] Changes respect the Data Contract (no user-layer files touched)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spanish language support throughout the dashboard.
  * Spanish can now be selected using language codes beginning with `es`, including regional variants such as `es_ES`.
  * Status labels, time references, sorting options, and view modes are now available in Spanish.
* **Tests**
  * Expanded language coverage to verify Spanish translations and runtime language switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->