### PR TITLE
fix: 3-digit report-number regex breaks past report 999

### DIFF
--- a/reserve-report-num.mjs
+++ b/reserve-report-num.mjs
@@ -76,7 +76,7 @@ function maxSlot() {
   const entries = readdirSync(REPORTS_DIR);
   let max = 0;
   for (const name of entries) {
-    const m = name.match(/^(\d{3})-/);
+    const m = name.match(/^(\d+)-/);
     if (m) max = Math.max(max, parseInt(m[1], 10));
   }
   return max;
@@ -193,7 +193,7 @@ function gc() {
 const [,, cmd, arg] = process.argv;
 
 if (cmd === '--release') {
-  const m = (arg || '').match(/^(\d{1,3})(?:-(\d{1,3}))?$/);
+  const m = (arg || '').match(/^(\d+)(?:-(\d+))?$/);
   if (!m) {
     process.stderr.write('Usage: node reserve-report-num.mjs --release <NNN>[-<MMM>]\n');
     process.exit(1);


### PR DESCRIPTION
## Summary
`reserve-report-num.mjs`'s `maxSlot()` used `/^(\d{3})-/` to find the highest existing report number — 4+ digit report files (e.g. `1004-...md`) don't match, so it silently ignores them and returns a stale, too-low max every time report numbers cross 1000. `--release` had the same problem: `/^(\d{1,3})(?:-(\d{1,3}))?$/` outright rejects a 4-digit argument like `--release 1004` with a usage error instead of releasing the sentinel.

Both spots fixed by widening the digit-count assumption (`\d{3}` → `\d+`, `\d{1,3}` → `\d+`).

Note: `analyze-patterns.mjs` had a related report-link resolution bug, but it's already fixed upstream (`main`) with a more robust path-safety check — no change needed there, so this PR is scoped to `reserve-report-num.mjs` only.

## Test plan
- [x] `node -c reserve-report-num.mjs` — syntax OK
- [x] 4-digit filename (e.g. `1004-....md`) now matches `maxSlot()`'s regex, so it correctly returns the next slot past an existing 4-digit report instead of restarting from a stale low base
- [x] `--release 1004` (and other 4-digit numbers) now matches the `--release` regex and cleanly removes the sentinel instead of failing with a usage error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slot number handling to support values with any number of digits.
  * Release ranges can now include larger slot numbers beyond 999.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->