### PR TITLE
fix(pdf): clean temporary HTML when browser launch fails

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -417,7 +417,13 @@ export async function inlineLocalFonts(html) {
  *
  * @param {string} html - Full HTML document to render.
  * @param {string} outputPath - Absolute path to write the PDF to.
- * @param {{format?: 'a4'|'letter', baseDir?: string, reportNum?: string, inputPath?: string}} [opts]
+ * @param {{
+ *   format?: 'a4'|'letter',
+ *   baseDir?: string,
+ *   reportNum?: string,
+ *   inputPath?: string,
+ *   launchBrowser?: (options: {headless: boolean}) => Promise<import('playwright').Browser>
+ * }} [opts]
  * @returns {Promise<{outputPath: string, pageCount: number, size: number}>}
  */
 export async function renderHtmlToPdf(html, outputPath, opts = {}) {
@@ -437,8 +443,10 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
   const { writeFile, unlink } = await import('fs/promises');
   await writeFile(tmpHtmlPath, html, 'utf-8');
 
-  const browser = await chromium.launch({ headless: true });
+  const launchBrowser = opts.launchBrowser || ((options) => chromium.launch(options));
+  let browser = null;
   try {
+    browser = await launchBrowser({ headless: true });
     const page = await browser.newPage();
 
     // Load from file:// so the page origin allows local subresources
@@ -482,9 +490,17 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
 
     return { outputPath, pageCount, size: pdfBuffer.length };
   } finally {
-    await browser.close();
+    if (browser) {
+      await browser.close().catch((err) => {
+        console.warn(`⚠️  Browser cleanup failed: ${err.message}`);
+      });
+    }
     // Clean up temp file
-    await unlink(tmpHtmlPath).catch(() => {});
+    await unlink(tmpHtmlPath).catch((err) => {
+      if (err?.code !== 'ENOENT') {
+        console.warn(`⚠️  Temporary HTML cleanup failed: ${err.message}`);
+      }
+    });
   }
 }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -974,6 +974,62 @@ try {
   fail(`PDF manifest path helper test crashed: ${e.message}`);
 }
 
+console.log('\n7b2. PDF renderer temporary-file cleanup');
+
+try {
+  const { renderHtmlToPdf } = await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-pdf-cleanup-launch-'));
+  const launchError = new Error('injected browser launch failure');
+  let caught;
+  try {
+    await renderHtmlToPdf('<html><body>PII_MARKER@example.com</body></html>', join(fixtureRoot, 'cv.pdf'), {
+      baseDir: fixtureRoot,
+      launchBrowser: async () => { throw launchError; },
+    });
+  } catch (error) {
+    caught = error;
+  }
+  const leftovers = readdirSync(fixtureRoot)
+    .filter((name) => name.startsWith('.career-ops-render-'));
+  if (caught === launchError && leftovers.length === 0) {
+    pass('PDF renderer removes temporary HTML when Chromium launch fails');
+  } else {
+    fail(`PDF renderer leaked temporary HTML after launch failure: ${leftovers.join(', ')}`);
+  }
+  rmSync(fixtureRoot, { recursive: true, force: true });
+} catch (error) {
+  fail(`PDF renderer launch-cleanup test crashed: ${error.message}`);
+}
+
+try {
+  const { renderHtmlToPdf } = await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-pdf-cleanup-page-'));
+  const pageError = new Error('injected newPage failure');
+  let closeCalls = 0;
+  let caught;
+  try {
+    await renderHtmlToPdf('<html><body>PRIVATE_CV_MARKER</body></html>', join(fixtureRoot, 'cv.pdf'), {
+      baseDir: fixtureRoot,
+      launchBrowser: async () => ({
+        newPage: async () => { throw pageError; },
+        close: async () => { closeCalls += 1; },
+      }),
+    });
+  } catch (error) {
+    caught = error;
+  }
+  const leftovers = readdirSync(fixtureRoot)
+    .filter((name) => name.startsWith('.career-ops-render-'));
+  if (caught === pageError && closeCalls === 1 && leftovers.length === 0) {
+    pass('PDF renderer closes Chromium and removes temporary HTML after launch');
+  } else {
+    fail(`PDF renderer post-launch cleanup mismatch: close=${closeCalls}, temp=${leftovers.join(', ')}`);
+  }
+  rmSync(fixtureRoot, { recursive: true, force: true });
+} catch (error) {
+  fail(`PDF renderer post-launch cleanup test crashed: ${error.message}`);
+}
+
 // ── 7c. UPDATER DASHBOARD REBUILD ─────────────────────────────────
 
 console.log('\n7c. Updater dashboard rebuild');


### PR DESCRIPTION
## Problem

In `renderHtmlToPdf` (`generate-pdf.mjs`), the full CV HTML is written to a temporary file (`.career-ops-render-<uuid>.html`) in `baseDir` **before** `chromium.launch()` is called, and the launch happens **outside** the `try/finally` that owns cleanup:

```js
const tmpHtmlPath = resolve(baseDir, `.career-ops-render-${randomUUID()}.html`);
await writeFile(tmpHtmlPath, html, 'utf-8');

const browser = await chromium.launch({ headless: true }); // outside try
try {
  ...
} finally {
  await browser.close();
  await unlink(tmpHtmlPath).catch(() => {});
}
```

If `chromium.launch()` rejects — a missing/broken Playwright browser, a sandbox denial, or a launch timeout — the `finally` is never reached, so the temporary HTML is **never deleted**. That file contains the rendered résumé: name, email, phone, and full work history. It persists in the output/input directory and accumulates one leaked copy per failed run.

## Fix

- Route the launch through an optional `opts.launchBrowser` (defaults to `chromium.launch`) purely so the failure path is testable; the public `renderHtmlToPdf(html, outputPath, opts)` signature is unchanged.
- Initialize `browser = null` and move the launch **inside** the `try`, so the single `try/finally` now owns the entire browser + temp-file lifecycle.
- In `finally`: best-effort `browser.close()` (guarded by `if (browser)`, so a launch failure never NPEs), then **unconditionally** attempt `unlink(tmpHtmlPath)`. Both are `.catch()`-wrapped and only log a warning — a cleanup error never replaces the original rendering error.

No change to the success path: manifest update, page-count, console output, and the `{ outputPath, pageCount, size }` return value are byte-for-byte identical.

## Tests (`test-all.mjs`)

Two new cases in a `7b2. PDF renderer temporary-file cleanup` section:

1. **Regression (red before this fix, green after):** injects a browser launcher that rejects, asserts the original launch error is re-thrown *and* no `.career-ops-render-*` file is left behind. Confirmed to fail on the pre-fix code (leaks the temp HTML).
2. **Preservation guard:** injects a browser whose `newPage()` rejects, asserts `browser.close()` is called exactly once, the temp HTML is removed, and the original error is preserved — proving post-launch failures also clean up.

Each test uses an isolated `mkdtempSync` fixture and cleans up with `rmSync`.

## Validation

- `node test-all.mjs` (the CI gate — full suite, not `--quick`): **1691 passed, 0 failed**.
- Change is scoped to the renderer lifecycle + JSDoc and the two tests. No path-resolution, PDF-option, manifest, or dependency changes.

No linked issue (per CONTRIBUTING, bug fixes may go straight to a PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional browser-launch configuration for PDF generation, enabling greater flexibility in how rendering is started.

* **Bug Fixes**
  * Improved PDF rendering cleanup when browser startup or page creation fails.
  * Temporary files are now reliably removed, with cleanup issues logged as warnings instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->