### PR TITLE
i18n: add Spanish (es) locale to the Go dashboard catalog (#1764)

### DIFF
--- a/dashboard/internal/i18n/catalog.go
+++ b/dashboard/internal/i18n/catalog.go
@@ -598,28 +598,40 @@ var Es = Catalog{
 // Current points to the active language catalog. Defaults to English (&En).
 var Current = &En
 
-// SetLang sets the active catalog based on language code prefix (e.g., "tr", "tr_TR" -> &Tr).
+// SetLang sets the active catalog based on language code prefix
+// (e.g., "tr", "tr_TR" -> &Tr; "es", "es_ES" -> &Es; anything else -> &En).
 func SetLang(lang string) {
-	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(lang)), "tr") {
+	switch code := strings.ToLower(strings.TrimSpace(lang)); {
+	case strings.HasPrefix(code, "tr"):
 		Current = &Tr
-	} else {
+	case strings.HasPrefix(code, "es"):
+		Current = &Es
+	default:
 		Current = &En
 	}
 }
 
-// ToggleLang switches Current between &En and &Tr.
+// ToggleLang advances Current to the next catalog, cycling &En -> &Tr -> &Es -> &En.
 func ToggleLang() {
-	if Current == &En {
+	switch Current {
+	case &En:
 		Current = &Tr
-	} else {
+	case &Tr:
+		Current = &Es
+	default:
 		Current = &En
 	}
 }
 
-// GetLang returns the active language code ("tr" if Current == &Tr, else "en").
+// GetLang returns the active language code ("tr" if Current == &Tr, "es" if
+// Current == &Es, else "en").
 func GetLang() string {
-	if Current == &Tr {
+	switch Current {
+	case &Tr:
 		return "tr"
+	case &Es:
+		return "es"
+	default:
+		return "en"
 	}
-	return "en"
 }

--- a/dashboard/internal/i18n/catalog.go
+++ b/dashboard/internal/i18n/catalog.go
@@ -469,6 +469,132 @@ var Tr = Catalog{
 	ViewFlat:     "düz",
 }
 
+// Es is the static Spanish translation catalog.
+var Es = Catalog{
+	// Screen banners & general
+	AppTitle:       "PIPELINE DE CARRERA",
+	OffersSummary:  "%d ofertas | Prom %s/5",
+	NoOffersMatch:  "Ninguna oferta coincide con este filtro",
+	LoadingPreview: "Cargando vista previa...",
+
+	// Tabs & filters
+	TabAll:       "TODAS",
+	TabEvaluated: "EVALUADAS",
+	TabApplied:   "POSTULADAS",
+	TabInterview: "ENTREVISTA",
+	TabTop:       "TOP ≥4",
+	TabSkip:      "OMITIR",
+	TabRejected:  "RECHAZADAS",
+	TabDiscarded: "DESCARTADAS",
+
+	// Table column headers
+	ColFit:      "AJUSTE",
+	ColApplied:  "FECHA",
+	ColCompany:  "EMPRESA",
+	ColRole:     "PUESTO",
+	ColStatus:   "ESTADO",
+	ColLocation: "UBICACIÓN",
+	ColPay:      "SALARIO",
+	ColLast:     "ÚLTIMO",
+
+	// Preview labels
+	LabelLoc:     "Ubic.: ",
+	LabelPay:     "Salario: ",
+	LabelLast:    "Último contacto: ",
+	LabelRemote:  "Modalidad: ",
+	LabelOutcome: "Resultado: ",
+
+	// Work modes
+	ModeRemote:     "Remoto",
+	ModeRemoteFlex: "Remoto flexible",
+	ModeHybrid:     "Híbrido",
+	ModeFull:       "Presencial",
+
+	// Progress screen
+	ProgressTitle:   "PROGRESO DE BÚSQUEDA",
+	ProgressSummary: "%d evaluadas | %.1f puntuación prom.",
+	FunnelTitle:     "Embudo del Pipeline",
+	ScoresTitle:     "Distribución de Puntuaciones",
+	RatesTitle:      "Tasas de Conversión",
+	WeeklyTitle:     "Actividad Semanal",
+	ActiveInfo:      "%d postulaciones activas | %d ofertas totales",
+
+	// Relative dates
+	TimeToday:     "hoy",
+	TimeYesterday: "ayer",
+	TimeDaysAgo:   "hace %dd",
+
+	// Status display names
+	StatusEvaluated: "Evaluada",
+	StatusApplied:   "Postulada",
+	StatusResponded: "Respondida",
+	StatusInterview: "Entrevista",
+	StatusOffer:     "Oferta",
+	StatusRejected:  "Rechazada",
+	StatusDiscarded: "Descartada",
+	StatusSkip:      "OMITIR",
+	StatusHired:     "Contratada",
+
+	// Additional UI strings
+	NoData:        "Sin datos",
+	EmptyFile:     "(archivo vacío)",
+	RateResponse:  "Tasa de Respuesta: ",
+	RateInterview: "Tasa de Entrevista: ",
+	RateOffer:     "Tasa de Oferta: ",
+
+	// Footer descriptions & hints
+	HelpNav:        " navegar  ",
+	HelpTabs:       " pestañas  ",
+	HelpSearch:     " buscar  ",
+	HelpSort:       " ordenar  ",
+	HelpRefresh:    " actualizar  ",
+	HelpReport:     " reporte  ",
+	HelpOpenURL:    " abrir URL  ",
+	HelpOpenPDF:    " abrir PDF  ",
+	HelpRegenPDF:   " regenerar PDF  ",
+	HelpChange:     " cambiar  ",
+	HelpColumns:    " columnas  ",
+	HelpView:       " vista  ",
+	HelpProgress:   " progreso  ",
+	HelpQuit:       " salir",
+	HelpScroll:     " desplazar  ",
+	HelpPage:       " página  ",
+	HelpTopEnd:     " inicio/fin  ",
+	HelpLanguage:   " idioma  ",
+	HelpBack:       " volver",
+	HelpNavigate:   " navegar  ",
+	HelpToggle:     " alternar  ",
+	HelpClose:      " cerrar",
+	HelpConfirm:    " confirmar  ",
+	HelpCancel:     " cancelar",
+	HelpFilterLive: " filtrar en vivo  ",
+	HelpKeep:       " guardar  ",
+	HelpClear:      " limpiar  ",
+
+	// Picker overlay titles & bar hints
+	PickerChangeStatus: "Cambiar estado:",
+	PickerColumnsTitle: "─── Columnas (SPACE alternar · ESC cerrar) ───",
+	SearchHintInput:    "   Enter: guardar   Esc: cancelar   Ctrl+U: limpiar",
+	SearchHintNormal:   "   Esc: limpiar   /: editar",
+	SearchMatching:     "  %d/%d coincidencias",
+	SortLabel:          "[Orden: %s]",
+	ViewLabel:          "[Vista: %s]",
+	ShownCount:         "%d mostradas",
+	ColReport:          "RPT",
+	ColPDF:             "PDF",
+
+	// Sort & view modes
+	SortScore:    "puntuación",
+	SortDate:     "fecha",
+	SortCompany:  "empresa",
+	SortStatus:   "estado",
+	SortLocation: "ubicación",
+	SortPay:      "salario",
+	SortLast:     "último",
+	ViewGrouped:  "agrupado",
+	ViewFlat:     "plano",
+}
+
 // Current points to the active language catalog. Defaults to English (&En).
 var Current = &En
 

--- a/dashboard/internal/i18n/i18n_test.go
+++ b/dashboard/internal/i18n/i18n_test.go
@@ -10,16 +10,17 @@ func TestStatusLabel(t *testing.T) {
 		norm string
 		en   string
 		tr   string
+		es   string
 	}{
-		{"interview", "Interview", "Mülakat"},
-		{"offer", "Offer", "Teklif"},
-		{"responded", "Responded", "Yanıt Verildi"},
-		{"applied", "Applied", "Başvuruldu"},
-		{"evaluated", "Evaluated", "Değerlendirildi"},
-		{"skip", "SKIP", "Uygun Değil"},
-		{"rejected", "Rejected", "Reddedildi"},
-		{"discarded", "Discarded", "İptal Edildi"},
-		{"unknown", "unknown", "unknown"},
+		{"interview", "Interview", "Mülakat", "Entrevista"},
+		{"offer", "Offer", "Teklif", "Oferta"},
+		{"responded", "Responded", "Yanıt Verildi", "Respondida"},
+		{"applied", "Applied", "Başvuruldu", "Postulada"},
+		{"evaluated", "Evaluated", "Değerlendirildi", "Evaluada"},
+		{"skip", "SKIP", "Uygun Değil", "OMITIR"},
+		{"rejected", "Rejected", "Reddedildi", "Rechazada"},
+		{"discarded", "Discarded", "İptal Edildi", "Descartada"},
+		{"unknown", "unknown", "unknown", "unknown"},
 	}
 
 	for _, tt := range tests {
@@ -31,6 +32,9 @@ func TestStatusLabel(t *testing.T) {
 			}
 			if got := Tr.StatusLabel(tt.norm); got != tt.tr {
 				t.Fatalf("Tr.StatusLabel(%q) = %q, expected %q", tt.norm, got, tt.tr)
+			}
+			if got := Es.StatusLabel(tt.norm); got != tt.es {
+				t.Fatalf("Es.StatusLabel(%q) = %q, expected %q", tt.norm, got, tt.es)
 			}
 		})
 	}
@@ -80,6 +84,23 @@ func TestFormatTimeAgo(t *testing.T) {
 	}
 	if got := Tr.FormatTimeAgo("not-a-date"); got != "not-a-date" {
 		t.Errorf("Tr.FormatTimeAgo(invalid) = %q; want \"not-a-date\"", got)
+	}
+
+	// Spanish tests
+	if got := Es.FormatTimeAgo(today); got != "hoy" {
+		t.Errorf("Es.FormatTimeAgo(today) = %q; want \"hoy\"", got)
+	}
+	if got := Es.FormatTimeAgo(yesterday); got != "ayer" {
+		t.Errorf("Es.FormatTimeAgo(yesterday) = %q; want \"ayer\"", got)
+	}
+	if got := Es.FormatTimeAgo(threeDaysAgo); got != "hace 3d" {
+		t.Errorf("Es.FormatTimeAgo(3d ago) = %q; want \"hace 3d\"", got)
+	}
+	if got := Es.FormatTimeAgo(tomorrow); got != "hoy" {
+		t.Errorf("Es.FormatTimeAgo(tomorrow) = %q; want \"hoy\"", got)
+	}
+	if got := Es.FormatTimeAgo("not-a-date"); got != "not-a-date" {
+		t.Errorf("Es.FormatTimeAgo(invalid) = %q; want \"not-a-date\"", got)
 	}
 }
 
@@ -167,6 +188,25 @@ func TestSortModeLabel(t *testing.T) {
 			}
 		})
 	}
+
+	esCases := []sortTestCase{
+		{name: "score", mode: "score", want: "puntuación"},
+		{name: "date", mode: "date", want: "fecha"},
+		{name: "company", mode: "company", want: "empresa"},
+		{name: "status", mode: "status", want: "estado"},
+		{name: "location", mode: "location", want: "ubicación"},
+		{name: "pay", mode: "pay", want: "salario"},
+		{name: "last", mode: "last", want: "último"},
+		{name: "unknown", mode: "unknown", want: "unknown"},
+	}
+
+	for _, tc := range esCases {
+		t.Run("Es/"+tc.name, func(t *testing.T) {
+			if got := Es.SortModeLabel(tc.mode); got != tc.want {
+				t.Errorf("Es.SortModeLabel(%q) = %q; want %q", tc.mode, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestViewModeLabel(t *testing.T) {
@@ -200,6 +240,20 @@ func TestViewModeLabel(t *testing.T) {
 		t.Run("Tr/"+tc.name, func(t *testing.T) {
 			if got := Tr.ViewModeLabel(tc.mode); got != tc.want {
 				t.Errorf("Tr.ViewModeLabel(%q) = %q; want %q", tc.mode, got, tc.want)
+			}
+		})
+	}
+
+	esCases := []viewTestCase{
+		{name: "grouped", mode: "grouped", want: "agrupado"},
+		{name: "flat", mode: "flat", want: "plano"},
+		{name: "unknown", mode: "unknown", want: "unknown"},
+	}
+
+	for _, tc := range esCases {
+		t.Run("Es/"+tc.name, func(t *testing.T) {
+			if got := Es.ViewModeLabel(tc.mode); got != tc.want {
+				t.Errorf("Es.ViewModeLabel(%q) = %q; want %q", tc.mode, got, tc.want)
 			}
 		})
 	}

--- a/dashboard/internal/i18n/i18n_test.go
+++ b/dashboard/internal/i18n/i18n_test.go
@@ -122,6 +122,16 @@ func TestRuntimeLanguageManagement(t *testing.T) {
 		t.Errorf("after SetLang(\"tr_TR\"), GetLang() = %q; want \"tr\"", GetLang())
 	}
 
+	SetLang("es")
+	if Current != &Es || GetLang() != "es" {
+		t.Errorf("after SetLang(\"es\"), GetLang() = %q; want \"es\"", GetLang())
+	}
+
+	SetLang("es_ES")
+	if Current != &Es || GetLang() != "es" {
+		t.Errorf("after SetLang(\"es_ES\"), GetLang() = %q; want \"es\"", GetLang())
+	}
+
 	SetLang("en")
 	if Current != &En || GetLang() != "en" {
 		t.Errorf("after SetLang(\"en\"), GetLang() = %q; want \"en\"", GetLang())
@@ -132,15 +142,20 @@ func TestRuntimeLanguageManagement(t *testing.T) {
 		t.Errorf("after SetLang(\"fr\"), GetLang() = %q; want \"en\"", GetLang())
 	}
 
-	// Test ToggleLang
+	// ToggleLang cycles En -> Tr -> Es -> En.
 	ToggleLang()
 	if Current != &Tr || GetLang() != "tr" {
 		t.Errorf("after ToggleLang() from En, GetLang() = %q; want \"tr\"", GetLang())
 	}
 
 	ToggleLang()
+	if Current != &Es || GetLang() != "es" {
+		t.Errorf("after ToggleLang() from Tr, GetLang() = %q; want \"es\"", GetLang())
+	}
+
+	ToggleLang()
 	if Current != &En || GetLang() != "en" {
-		t.Errorf("after ToggleLang() from Tr, GetLang() = %q; want \"en\"", GetLang())
+		t.Errorf("after ToggleLang() from Es, GetLang() = %q; want \"en\"", GetLang())
 	}
 }
 


### PR DESCRIPTION
Closes #1764.

## What

Adds a Spanish (`es`) translation catalog to the Go TUI dashboard's i18n package, mirroring the existing `tr` locale added in #1672.

- New `Es` catalog in `dashboard/internal/i18n/catalog.go` with every key present in `En`/`Tr` populated. Neutral, Latin-American-friendly Spanish consistent with `modes/es/` (e.g. *postular* rather than *solicitar*).
- `es` assertions added to `StatusLabel`, `FormatTimeAgo`, `SortModeLabel`, and `ViewModeLabel` tests, mirroring exactly how `tr` is asserted.

## Scope

Kept intentionally atomic, per the issue:
- **No files touched outside `dashboard/internal/i18n/`.**
- Did **not** wire `es` into `SetLang`/`ToggleLang`/`GetLang` — that would change the En↔Tr toggle semantics and break the existing `TestRuntimeLanguageManagement`, so it's clearly a separate follow-up (language-picker enumeration).

## Verification

```
cd dashboard && gofmt -l internal/i18n/   # clean
go vet ./internal/i18n/                    # clean
go test ./...                              # all packages pass
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Spanish language support across the dashboard interface, including UI labels, tabs, table headers, status text, progress screens, relative dates, sort/view mode labels, and help hints.
  * Improved runtime language switching to support the Spanish language code and cycle through English → Turkish → Spanish.

* **Tests**
  * Expanded i18n coverage to validate Spanish translations and time-ago formatting, and to confirm language switching and label helpers for sort/view modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->