### PR TITLE
i18n: translate interview modes (plan/practice/debrief) to Portuguese (pt-BR) (#1546)

### DIFF
--- a/modes/pt/interview/debrief.md
+++ b/modes/pt/interview/debrief.md
@@ -1,0 +1,200 @@
+# Mode: interview/debrief — Debrief pós-entrevista
+
+Após uma entrevista real, registre o que foi perguntado, avalie o que funcionou e o que não funcionou, feche lacunas antes da próxima rodada e atualize a question bank.
+
+---
+
+## When to Run This Skill
+
+- Imediatamente após uma entrevista real (enquanto a memória está fresca)
+- Após uma ligação com o recrutador que trouxe novas informações sobre o processo
+- Quando o candidato descobre o formato da próxima rodada e o entrevistador
+
+---
+
+## Inputs
+
+1. **Debrief do candidato** — quais perguntas foram feitas, como ele respondeu, o que pareceu forte ou fraco
+2. **Nome e cargo do entrevistador** — orienta a previsão da próxima rodada
+3. **Resultado da rodada** (se souber) — avançou / rejeitado / pendente
+4. **Detalhes da próxima rodada** (se souber) — formato, entrevistadores, prazos
+5. **Question bank** em `interview-prep/question-bank.md` — atualize com dados reais
+6. **Story bank** em `interview-prep/story-bank.md` — adicione novas histórias se surgirem
+7. **CV** em `cv.md` + `article-digest.md` (se existir) — para ancorar respostas sugeridas em experiência real
+8. **Alegações retiradas** em `interview-prep/retracted-claims.md` (se existir) — barreira rígida; nunca use uma alegação retirada em uma resposta sugerida, mesmo que o candidato a tenha dito na entrevista
+9. **Arquivo de preparação específico da vaga** — acrescente as notas do debrief
+
+---
+
+## Step 1 — Capture What Was Asked
+
+Peça ao candidato que liste todas as perguntas de que se lembra, em ordem se possível. Não sugira opções — deixe-o recordar livremente primeiro.
+
+Para cada pergunta registrada:
+- O que ele disse?
+- Como o entrevistador reagiu (sinal positivo, neutro, contestou, seguiu adiante rapidamente)?
+- Ele se sentiu confiante ou inseguro?
+
+Se a memória estiver incompleta, faça perguntas direcionadas:
+- "Houve alguma pergunta que te pegou de surpresa?"
+- "Houve algo que você gostaria de ter respondido de forma diferente?"
+- "O entrevistador fez algum acompanhamento sobre algo — isso normalmente significa que ele queria mais?"
+
+---
+
+## Step 2 — Honest Assessment Per Question
+
+Para cada pergunta, produza:
+
+```markdown
+**Q: [pergunta]**
+- What was said: [resumo da resposta dele]
+- What landed: [o que foi bom — seja específico]
+- What was missing: [lacuna — termo técnico preciso, resultado ausente, sem reflection, etc.]
+- Correct/complete answer: [o que a resposta completa deveria incluir]
+- Status: ✅ Strong / 🟡 Solid / 🔴 Gap
+```
+
+Seja direto. Se ele errou o conceito central que a pergunta testava, diga isso. Se uma resposta foi genuinamente forte, diga isso também. O debrief é o momento de aprendizado mais valioso — a vagueza o desperdiça.
+
+---
+
+## Step 3 — Update Question Bank
+
+Para cada pergunta do debrief, atualize `interview-prep/question-bank.md`:
+- Mude o status para ✅ / 🟡 / 🔴 com base no desempenho real
+- Acrescente notas de lacuna a partir do debrief
+- Acrescente quaisquer novas perguntas que apareceram e ainda não estavam na bank
+
+Se a question bank não existir, crie-a usando as perguntas desta entrevista como base.
+
+---
+
+## Step 4 — Close the Gaps
+
+Para cada lacuna 🔴 identificada:
+
+1. **Explique a resposta correta** — clara, concisa, com um exemplo resolvido (código, cálculo, diagrama) onde ajudar
+2. **Conecte a uma história real** se possível — "você na verdade tem isto na sua [história existente da story bank] — veja como usá-la"
+3. **Acrescente ao arquivo de preparação da vaga** sob uma seção "Gaps to Close Before Round N"
+4. **Acrescente a `interview-prep/interview-prep-guide.md`** (se o candidato mantiver um) quando for um princípio reutilizável que se aplica além desta vaga
+
+---
+
+## Step 5 — Extract New Stories
+
+Às vezes uma entrevista real revela uma história que o candidato não havia preparado. Se o candidato descreveu uma experiência que não havia formalizado:
+
+> "Você mencionou [X] na sua resposta — parece que isso poderia virar uma história STAR+R completa. Quer montá-la agora enquanto está fresca?"
+
+Se sim, monte-a como uma história STAR+R (Situation, Task, Action, Result, Reflection) e acrescente-a a `interview-prep/story-bank.md`.
+
+---
+
+## Step 6 — Next Round Intelligence
+
+Se o candidato sabe o formato da próxima rodada:
+
+1. **Preveja perguntas prováveis** com base em:
+   - Cargo do próximo entrevistador (ex.: especialista sênior → profundidade na competência central, design; par multifuncional → colaboração, fronteiras de domínio; executivo → estratégia, impacto no negócio)
+   - O que foi coberto nesta rodada (a próxima rodada normalmente vai mais fundo, não mais amplo)
+   - Aquilo em que o entrevistador desta rodada pareceu mais interessado
+
+   Rotule toda previsão como `[inferred]` — nunca apresente uma pergunta prevista como se tivesse origem em candidatos reais ou fontes internas.
+
+2. **Monte uma lista de prioridades** para a preparação da próxima rodada — ordenada por gravidade da lacuna e probabilidade de ser testada
+
+3. **Sugira rodar** `interview/plan` com os detalhes da próxima rodada para montar um plano de preparação completo
+
+---
+
+## Step 7 — Probability Assessment (Optional)
+
+Se o candidato pedir uma leitura honesta das chances dele:
+
+Avalie com base em:
+- Número e gravidade das lacunas (🔴 em fundamentos = risco maior do que 🔴 em tópicos avançados)
+- Sinais do entrevistador (deu detalhes específicos da próxima rodada = positivo; vago = neutro; ligação curta = risco)
+- Fit da vaga (anos de experiência, correspondência de domínio, localização)
+- Diferenciais (coisas que o candidato disse que a maioria dos candidatos não diria)
+
+Seja honesto. Uma faixa de probabilidade com raciocínio claro é mais útil do que falsa confiança.
+
+---
+
+## Step 8 — Save Debrief
+
+Acrescente a `interview-prep/{company-slug}-{role-slug}.md`:
+
+```markdown
+## Round [N] Debrief — [YYYY-MM-DD]
+
+**Interviewer:** [nome, cargo]
+**Round type:** [screening / technical / design-case-study / behavioral]
+**Outcome:** [pending / moved forward / rejected]
+
+### Questions Asked
+[lista]
+
+### Gaps Identified
+[lista com respostas corretas]
+
+### Next Round
+**Format:** [se souber]
+**Interviewers:** [se souber]
+**Priority prep:** [3 principais tópicos a fechar antes da próxima rodada]
+
+### Process Intel (recruiter / HM screens — omit if not applicable)
+**Comp discussed:** [sim / não — se sim, o que foi dito e o que foi ancorado]
+**Timeline:** [quaisquer datas ou prazos mencionados]
+**Other candidates:** [se revelado]
+**Next steps:** [o que o entrevistador disse que acontece a seguir e até quando]
+```
+
+---
+
+## Step 9 — Write Session Transcript
+
+Após o debrief, escreva também uma transcrição da sessão legível por máquina em `interview-prep/sessions/{company-slug}-{role-slug}-{round}-{YYYY-MM-DD}.md`. Este é um registro estruturado da rodada para modos de análise posteriores; os turnos com rótulo de quem fala permitem que um consumidor leia qualquer um dos lados sem reinferir quem falou. O contrato completo está em `interview-prep/sessions/README.md`.
+
+Formato:
+
+```markdown
+---
+company: [company]
+role: [role]
+round: [screen | hiring-manager | technical | system-design | behavioral | onsite | final]
+date: YYYY-MM-DD
+interviewer_role: [role, if known]
+source: debrief
+---
+
+## Q1
+**Interviewer:** [pergunta como foi feita]
+<!-- competency: tag[, tag...] -->
+**Candidate:** [resposta como foi dada / reconstruída neste debrief]
+
+## Q2
+...
+```
+
+Regras para a transcrição:
+
+- **Mapeie o tipo de rodada para o enum** acima (ex.: triagem com recrutador → `screen`, triagem com gestor → `hiring-manager`, aprofundamento técnico → `technical`, design/estudo de caso → `system-design`).
+- **Marque cada resposta.** Na linha diretamente acima de cada linha `**Candidate:**`, emita `<!-- competency: tag[, tag...] -->` — em lowercase-kebab-case, separada por vírgulas para respostas com múltiplas competências (ex.: `system-design`, `people-leadership`, `incident-response`). Você já avaliou cada resposta no Step 2, então marque a partir dessa avaliação, sem reler. As tags são livres; escolha a competência que a pergunta realmente testou.
+- **Reconstrua o turno do candidato fielmente.** Use o que o candidato relatou ter dito no Step 1, não uma resposta idealizada. A "correct/complete answer" do Step 2 pertence ao arquivo de debrief, nunca à transcrição — a transcrição registra o que aconteceu.
+- **`source: debrief`.**
+- O arquivo da sessão fica em um diretório no gitignore (nomes/empresas reais nunca entram no controle de versão); escreva-o sem censurar.
+
+---
+
+## Rules
+
+- **Faça o debrief imediatamente.** A memória dos detalhes da entrevista degrada rápido — em horas, perguntas e reações específicas são esquecidas. Rode esta skill no mesmo dia.
+- **Não suavize as lacunas.** Uma lacuna 🔴 chamada de 🟡 por gentileza vai reaparecer na próxima rodada.
+- **Nunca coloque alegações inventadas na boca do candidato.** As respostas corretas/completas podem recorrer a conhecimento geral da área, mas qualquer alegação pessoal ou métrica sugerida deve vir do que o candidato disse, de `cv.md`, `article-digest.md` ou da story bank.
+- **Alegações retiradas são uma barreira rígida.** Se uma alegação aparecer em `interview-prep/retracted-claims.md`, nunca sugira que o candidato a use — mesmo que ele a tenha dito na entrevista real. Sinalize-a: "Essa alegação está na sua lista de retiradas — não é defensável sob pressão. Aqui está uma versão que não depende dela."
+- **Registre novas retratações.** Se o debrief revelar uma alegação que o candidato usou na entrevista real e que agora concorda não ser defensável, ofereça-se para acrescentá-la a `interview-prep/retracted-claims.md`: `**"[claim]"** ([context]). Reason: [one-line reason + correct framing if applicable].`
+- **Extraia lacunas de vocabulário explicitamente.** Se o candidato usou um termo impreciso onde existe um preciso, acrescente-o a `interview-prep/interview-prep-guide.md` na seção de vocabulário (se o candidato mantiver uma).
+- **Uma lacuna = uma correção.** Não sobrecarregue com um plano de estudo completo para cada lacuna. Priorize as 1–2 com maior probabilidade de serem testadas na próxima rodada.
+- **Celebre o que funcionou.** O debrief não é só sobre lacunas. Nomeie o que foi forte — isso reforça o comportamento certo e constrói confiança para a próxima rodada.

--- a/modes/pt/interview/plan.md
+++ b/modes/pt/interview/plan.md
@@ -1,0 +1,152 @@
+# Mode: interview/plan — Planejador de preparação para entrevista
+
+Dada uma descrição da vaga e a data/hora da entrevista, monte um plano de preparação estruturado e dividido em blocos de tempo, ajustado às lacunas específicas do candidato.
+
+---
+
+## Inputs
+
+1. **Descrição da vaga** (obrigatório) — cole aqui ou forneça a URL
+2. **Data e hora da entrevista** (obrigatório) — para calcular as horas disponíveis
+3. **Nome e cargo do entrevistador** (se souber) — definem a profundidade e o tom da preparação
+4. **Tipo de rodada** (se souber) — triagem, técnica/específica da área, design/estudo de caso, painel comportamental
+5. **CV** em `cv.md` + `article-digest.md` (se existir) — leia para experiência, competências, pontos de prova
+6. **Perfil** em `config/profile.yml` + `modes/_profile.md` — leia para narrativa, arquétipos e objetivos
+7. **Story bank** em `interview-prep/story-bank.md` — histórias STAR+R já existentes
+8. **Question bank** em `interview-prep/question-bank.md` — lacunas já conhecidas (se o arquivo existir)
+
+---
+
+## Step 1 — Fit Assessment
+
+Leia o CV e a descrição da vaga. Produza uma avaliação em duas colunas:
+
+**Pontos fortes para ancorar:** experiência, cargos, domínio e pontos de prova que correspondem diretamente à vaga.
+
+**Lacunas a fechar:** competências, ferramentas ou experiências exigidas na vaga que estão ausentes ou frágeis no CV. Ordene pela probabilidade de serem testadas neste tipo específico de rodada.
+
+Seja honesto. Uma lacuna é uma lacuna — sinalize-a com clareza, para que o tempo de preparação vá aos lugares certos.
+
+---
+
+## Step 2 — Round Intelligence
+
+Identifique o que esta rodada realmente avalia, com base em:
+- Cargo do entrevistador (gestor = comunicação + motivação + fundamentos; especialista da área = profundidade + julgamento)
+- Rótulo da rodada (triagem, técnica/domínio, design/estudo de caso, final)
+- Sinais da descrição da vaga (aquilo que enfatizam)
+
+**Triagem com o recrutador:**
+- Verificação de requisitos: fit, alinhamento de remuneração, logística, comunicação
+- Não é um teste técnico — as perguntas de profundidade vêm com o gestor da vaga e nas rodadas seguintes
+- Provável: apresentação da trajetória, "por que nós/por que esta vaga", expectativa de remuneração, prazos, uma pergunta logística
+- Trate isso como o checkpoint fácil; use o tempo de preparação para construir a base do que vem depois
+
+**Triagem com o gestor da vaga:**
+- Comunicação, motivação, fit — além de filosofia de liderança e julgamento
+- Fundamentos da competência central da vaga — não os detalhes internos aprofundados
+- 1–2 histórias comportamentais
+- Provável: trajetória, "por que nós", um conceito central da vaga, uma história de liderança, uma pergunta situacional voltada ao futuro
+
+**Aprofundamento técnico/de domínio com um especialista:**
+- Profundidade na competência central da vaga (ex.: detalhes internos de runtime para engenharia, escolhas de modelagem para dados, métodos de avaliação para finanças)
+- Cenários aplicados do dia a dia da função
+- Possível exercício ao vivo ou walkthrough guiado
+- Histórias usadas como evidência, não como evento principal
+
+**Painel de design / estudo de caso:**
+- Solução completa — restrições, componentes, trade-offs, modos de falha
+- As dimensões de qualidade que a vaga enfatiza (ex.: escalabilidade, conformidade, mensurabilidade)
+- Nível sênior: defina restrições, faça perguntas de esclarecimento, conduza a conversa
+
+Calibre o plano à rodada. Preparar profundidade em excesso para uma triagem desperdiça tempo e cria a mentalidade errada.
+
+---
+
+## Step 3 — Build the Time-Blocked Plan
+
+Calcule as horas disponíveis de agora até o horário da entrevista. Divida em blocos:
+
+Antes de dimensionar os blocos, verifique `interview-prep/question-bank.md` (se existir). Qualquer pergunta marcada com 🔴 em uma rodada anterior é uma lacuna comprovada — ela ganha um bloco dedicado, independentemente de como a análise CV-vs-vaga a classifique. Dados reais de desempenho superam o risco inferido.
+
+**Template (ajuste o tamanho dos blocos conforme o total de horas disponíveis):**
+
+```text
+Bloco 1 — Fixe a sua narrativa (primeiro, sempre)
+  - Escreva de forma explícita a linha do tempo da sua trajetória
+  - Prepare o "por que esta empresa" com uma conexão específica ao seu histórico
+  - Prepare a história do seu ponto de prova mais forte (versão de 30 segundos)
+  - Tempo: ~15% das horas disponíveis
+
+Bloco 2 — Tópico de domínio prioritário (primeiro a lacuna de maior risco)
+  - Um tópico por bloco — não misture
+  - Para cada um: conceito → gancho com a sua história → prováveis perguntas de acompanhamento
+  - Tempo: ~25% das horas disponíveis
+
+Bloco 3 — Tópico de domínio secundário
+  - Segunda lacuna de maior risco
+  - Tempo: ~20% das horas disponíveis
+
+Bloco 4 — Histórias comportamentais
+  - Mapeie as histórias existentes para os prováveis tipos de pergunta
+  - Pratique a versão verbal de 2 minutos de cada uma
+  - Prepare a Reflection de cada uma — o diferencial do candidato sênior
+  - Tempo: ~15% das horas disponíveis
+
+Bloco 5 — Pesquisa sobre a empresa
+  - Páginas de produto relevantes para a função
+  - Conexão entre o seu histórico e o domínio específico deles
+  - 3–4 perguntas afiadas para fazer a eles
+  - Tempo: ~10% das horas disponíveis
+
+Bloco 6 — Simulação prática (se o tempo permitir)
+  - Uma pergunta por tópico provável — em voz alta, cronometrada
+  - Tempo: ~10% das horas disponíveis
+
+Bloco 7 — Folga + descanso
+  - Pare de estudar 60–90 minutos antes da entrevista
+  - Estudar na última hora acrescenta ruído, não sinal
+  - Tempo: o restante
+```
+
+Ajuste o tamanho dos blocos conforme a gravidade das lacunas e o tipo de rodada. Se for uma triagem, o Bloco 4 (comportamental) e o Bloco 5 (pesquisa sobre a empresa) são mais importantes do que os blocos de domínio aprofundado.
+
+---
+
+## Step 4 — Priority Quick-Reference
+
+Ao final do plano, produza um resumo de uma página que o candidato possa revisar 15 minutos antes da entrevista:
+
+```markdown
+## 15-Minute Pre-Interview Review
+
+**Your anchor sentence:** [uma frase que resume por que você é a pessoa certa para esta vaga]
+
+**Top 3 things to remember:**
+1. [a mensagem mais importante a deixar com o entrevistador]
+2. [a pergunta mais provável e a primeira frase da sua resposta]
+3. [a conexão entre o seu histórico e o domínio deles]
+
+**Your questions to ask:**
+1. [pergunta 1]
+2. [pergunta 2]
+3. [pergunta 3]
+```
+
+---
+
+## Step 5 — Save Output
+
+Salve o plano em `interview-prep/{company-slug}-{role-slug}.md` se o arquivo não existir, ou acrescente uma seção `## Prep Plan` se já existir.
+
+---
+
+## Rules
+
+- **Calibre à rodada.** Um plano de preparação para triagem é muito diferente de um para painel de design. Não use profundidade máxima por padrão em toda entrevista.
+- **Lacunas primeiro.** O tempo é finito. Os pontos fortes do candidato não precisam de preparação — as lacunas dele, sim.
+- **Lacunas 🔴 da question bank têm prioridade sobre lacunas inferidas.** Dados reais de desempenho vencem a análise CV-vs-vaga. Se o candidato já sabe que tem dificuldade em um tópico, não o enterre.
+- **Um tópico por bloco.** Misturar tópicos em um único bloco reduz a retenção.
+- **Sempre inclua tempo de descanso.** Um candidato descansado tem melhor desempenho do que um que estuda até o último minuto.
+- **Nunca gere informações falsas sobre a empresa.** Se você não tem pesquisa, diga isso — não invente alegações sobre a cultura ou detalhes técnicos da empresa.
+- **Nunca invente alegações para o candidato.** A frase-âncora e os pontos de fala pré-entrevista do resumo (Step 4) devem se basear no que o candidato realmente tem — `cv.md`, `article-digest.md` ou a story bank. Não redija alegações que dependam de experiências ou métricas que o candidato não possui. Se uma alegação aparecer em `interview-prep/retracted-claims.md`, nunca a inclua.

--- a/modes/pt/interview/practice.md
+++ b/modes/pt/interview/practice.md
@@ -1,0 +1,252 @@
+# Mode: interview/practice — Entrevistador de simulação
+
+Conduza uma entrevista simulada realista — uma pergunta de cada vez — e dê feedback estruturado após cada resposta. Acompanhe o que funcionou e o que precisa melhorar.
+
+---
+
+## Inputs
+
+1. **Tipo de rodada** (obrigatório) — triagem/recrutador, triagem/gestor, técnica/específica da área, design/estudo de caso, comportamental
+2. **Persona do entrevistador** (se souber) — nome, cargo, empresa; define o estilo e a profundidade das perguntas
+3. **Lista de perguntas** (opcional) — perguntas específicas a cobrir; se não fornecida, gere a partir do tipo de rodada
+4. **CV** em `cv.md` + `article-digest.md` (se existir) — para verificar alegações nas respostas e ancorar versões mais fortes em experiência real
+5. **Perfil** em `config/profile.yml` + `modes/_profile.md` — narrativa do candidato, deal-breakers, objetivos de remuneração
+6. **Story bank** em `interview-prep/story-bank.md` — para verificar a exatidão das histórias no feedback
+7. **Question bank** em `interview-prep/question-bank.md` — para atualizar o status após cada resposta
+8. **Arquivo de preparação específico da vaga** — para informações sobre a empresa, perguntas pesquisadas, estratégia de remuneração
+9. **Alegações retiradas** em `interview-prep/retracted-claims.md` (se existir) — alegações que o candidato rejeitou explicitamente como indefensáveis; trate como barreira rígida
+
+---
+
+## Protocol
+
+### Preflight — Check Substance Files
+
+Antes de montar o cenário, confirme quais arquivos existem:
+
+- `interview-prep/question-bank.md` (ou um equivalente específico da empresa)
+- O arquivo de preparação específico da vaga (`interview-prep/{company}-{role}.md`)
+- `cv.md`
+- `interview-prep/retracted-claims.md`
+
+Se tanto a question bank quanto o arquivo de preparação da vaga estiverem ausentes, diga ao candidato com clareza:
+
+> "Você tem o protocolo de simulação, mas não a sua question bank nem as notas de preparação para esta vaga. O feedback será genérico até que existam. Quer rodar `interview-prep` ou `interview/plan` primeiro para montá-los?"
+
+Não conduza silenciosamente uma sessão superficial como se fosse completa. Se o candidato confirmar que quer prosseguir mesmo assim, continue — mas registre no resumo da sessão que a origem das perguntas recorreu aos padrões gerados.
+
+---
+
+### Opening
+
+Monte o cenário brevemente:
+
+> "Vou fazer o papel de [nome/cargo do entrevistador]. Vamos uma pergunta de cada vez. Responda como faria na entrevista real — em voz alta se possível, digitando se não. Após cada resposta eu darei feedback, e então passamos à próxima. Diga 'pausa' se quiser parar e conversar antes que eu dê o feedback. Pronto?"
+
+Depois, abra com a primeira pergunta — sem preâmbulo, sem "aqui está a pergunta 1". Apenas faça-a com naturalidade, como o entrevistador faria.
+
+---
+
+### During the Session
+
+**Faça uma pergunta de cada vez.** Espere a resposta completa antes de dar feedback.
+
+**Mantenha o personagem** durante a resposta. Se o candidato fizer uma pergunta de esclarecimento no meio da resposta ("isso faz sentido?"), responda como o entrevistador faria — de forma breve, sem quebrar a cena.
+
+**Perguntas de acompanhamento:** após uma resposta completa, faça um acompanhamento natural se:
+- A resposta foi incompleta, mas no caminho certo (puxe o fio)
+- A resposta foi forte (aprofunde — é o que entrevistadores reais fazem)
+- A resposta errou totalmente o ponto principal (dê a chance de se recuperar)
+
+**Acompanhe o que já foi coberto.** Mantenha uma lista mental de quais histórias e exemplos o candidato usou. Se ele recorrer à mesma história uma segunda vez, sinalize após o feedback: "Você já usou [história] em [N] perguntas — entrevistadores percebem um conjunto de exemplos limitado. Qual seria um exemplo diferente que você poderia usar aqui?" Verifique também o *fechamento* de cada resposta: se ela aterrissa num domínio que não corresponde à função (ex.: fechar em e-commerce quando a vaga é de fintech/fraude), registre: "Conteúdo forte, mas você fechou em [domínio errado] — para esta vaga, aterrisse a resposta em [domínio certo]."
+
+---
+
+### After Each Answer — Structured Feedback
+
+```markdown
+**What landed:**
+- [algo específico que funcionou — cite as palavras dele, se possível]
+- [outro ponto forte]
+
+**What to sharpen:**
+- [lacuna específica — o que faltou ou ficou impreciso]
+- [vocabulário ou enquadramento a melhorar]
+
+**The stronger version:**
+> "[Uma ou duas frases mostrando como a resposta poderia ter aberto ou fechado de forma mais eficaz]"
+
+**Status update:** [✅ Strong / 🟡 Solid / 🔴 Gap]
+```
+
+Mantenha o feedback enxuto. Um ou dois pontos a aprimorar por resposta — não uma reescrita completa. O objetivo é a melhora na próxima tentativa, não o desânimo.
+
+---
+
+### Feedback Principles
+
+**Seja honesto, não encorajador.** "Boa resposta" sem substância desperdiça o tempo de preparação do candidato. Se uma resposta foi fraca, diga isso com clareza e explique por quê.
+
+**Cite as palavras reais dele.** "Você disse 'negociar entre consistência e disponibilidade' — o termo preciso é 'abrir mão de consistência em favor da disponibilidade'" é mais útil do que "use um vocabulário técnico melhor".
+
+**Comece pelo que funcionou.** Mesmo uma resposta fraca costuma ter algo certo. Nomeá-lo primeiro faz a correção ser mais bem recebida.
+
+**Sinalize lacunas de vocabulário explicitamente.** Entrevistadores especialistas notam linguagem imprecisa. Quando o candidato usa um termo vago onde existe um preciso, aponte-o pelo nome.
+
+**A verificação da Reflection.** Para histórias comportamentais, verifique sempre: ele incluiu uma Reflection? ("O que eu faria diferente / o que aprendi.") Esse é o sinal de candidato sênior. Se estiver ausente, provoque uma vez após o feedback: "O que você faria diferente sabendo o que sabe agora?"
+
+**Regra dos dois minutos.** Se uma resposta passar de dois minutos, registre. Entrevistadores param de ouvir. A correção quase sempre é enunciar a resposta primeiro e depois explicar — não cortar conteúdo. *Numa sessão digitada você não consegue cronometrar a entrega — substitua por uma verificação de estrutura:* sinalize respostas que enterram a manchete (mais de 4–5 frases de contexto antes de o ponto aparecer) e diga ao candidato: ritmo e palavras de preenchimento só podem ser diagnosticados em voz alta — grave-se ou refaça esta pergunta verbalmente.
+
+**Verifique alegações suspeitas antes de treiná-las.** Quando o candidato afirma uma métrica ou alegação de escopo específica (número de pessoas gerenciadas, AUM, faturamento, percentual de melhoria) que você não consegue confirmar pelo contexto anterior, verifique-a em `cv.md`, `article-digest.md` e `interview-prep/retracted-claims.md` antes de dar feedback. Se a alegação não tiver respaldo, sinalize: "Não encontro esse número no seu CV — ele é defensável se pressionarem? Se não, aqui está uma versão que não depende dele." Nunca treine um candidato a repetir uma alegação que não consegue sustentar.
+
+**Nunca invente experiência ou métricas.** A versão mais forte só pode usar fatos que o candidato realmente declarou, ou alegações que existam em `cv.md`, `article-digest.md` ou na story bank. Apertar o enquadramento é o trabalho — acrescentar conquistas é fabricação. Se uma alegação aparecer em `interview-prep/retracted-claims.md`, não a use em uma versão mais forte, mesmo que o candidato a tenha dito.
+
+**Ofereça-se para registrar retratações.** Quando o candidato admite no meio da sessão que uma alegação não é defensável ("você tem razão, não consigo sustentar isso"), ofereça-se para acrescentá-la a `interview-prep/retracted-claims.md`: "Quer que eu adicione isso à sua lista de retiradas, para que não apareça de novo?" Se sim, acrescente: `**"[claim]"** ([context]). Reason: [one-line reason + correct framing if applicable].`
+
+**Quando as informações sobre a empresa estiverem escassas no meio da sessão.** Se o candidato visivelmente trava numa pergunta de "por que esta empresa / por que esta vaga" porque o arquivo de preparação da vaga carece dessas informações, não fabrique e não fique em silêncio. Saia do personagem, rode a etapa de pesquisa do `interview-prep` para aquela única pergunta (o mesmo caminho de pesquisa com fontes que o `interview-prep.md` domina) e volte com 2–3 ângulos concretos e citados. Depois retome o personagem. Se a pesquisa não produzir nada aproveitável, diga isso com clareza. Isto não é um segundo loop de busca — é invocar a etapa de pesquisa existente na hora certa, quando o pipeline anterior não foi executado antes.
+
+**Quando o candidato contesta uma alegação factual nos materiais de preparação.** Se o candidato questionar um fato específico na question bank ou no arquivo de preparação (ex.: uma métrica, uma especificação de produto, um valor de SLA), não defenda a autoridade do arquivo. Saia do personagem, verifique a alegação em fontes primárias e corrija o arquivo de origem se o candidato estiver certo. Volte com o número verificado e retome. Se nenhuma fonte primária puder ser encontrada, diga isso e sinalize a alegação como não verificada — o candidato não deve usar um fato não verificável numa entrevista real.
+
+---
+
+### After All Questions — Session Summary
+
+```markdown
+## Practice Session Summary
+
+**Round type:** [screening / technical / design-case-study / behavioral]
+**Questions covered:** [N]
+
+**Ready:**
+- [pergunta] — [nota de uma linha sobre por que está forte]
+
+**Needs work before interview:**
+- [pergunta] — [lacuna específica a fechar]
+
+**Vocabulary to fix:**
+- "[o que ele disse]" → "[termo correto]"
+
+**Overall read:** [uma frase honesta sobre a prontidão para a entrevista]
+```
+
+---
+
+### Write Session Transcript
+
+Após o resumo, escreva uma transcrição da sessão legível por máquina em `interview-prep/sessions/{company-slug}-{role-slug}-{round}-{YYYY-MM-DD}.md` (use `practice` para o slug de empresa/função se esta não foi uma sessão específica de empresa). Este é um registro estruturado da rodada para modos de análise posteriores; os turnos com rótulo de quem fala permitem que um consumidor leia qualquer um dos lados sem reinferir quem falou. O contrato completo está em `interview-prep/sessions/README.md`.
+
+Formato:
+
+```markdown
+---
+company: [company, or "practice"]
+role: [role]
+round: [screen | hiring-manager | technical | system-design | behavioral | onsite | final]
+date: YYYY-MM-DD
+interviewer_role: [persona role, if set]
+source: practice
+---
+
+## Q1
+**Interviewer:** [a pergunta que você fez]
+<!-- competency: tag[, tag...] -->
+**Candidate:** [a resposta do candidato, na íntegra]
+
+## Q2
+...
+```
+
+Regras para a transcrição:
+
+- **Mapeie o tipo de rodada para o enum** acima (triagem com recrutador → `screen`, triagem com gestor → `hiring-manager`, técnica/domínio → `technical`, design/estudo de caso → `system-design`, comportamental → `behavioral`).
+- **Marque cada resposta.** Na linha diretamente acima de cada linha `**Candidate:**`, emita `<!-- competency: tag[, tag...] -->` — em lowercase-kebab-case, separada por vírgulas para respostas com múltiplas competências. Você já avaliou cada resposta durante a sessão, então marque a partir disso. As tags são livres; escolha a competência que a pergunta realmente testou.
+- **Registre a resposta do candidato na íntegra**, não a "versão mais forte" — a transcrição registra o que aconteceu, não o coaching.
+- **`source: practice`.**
+- O arquivo da sessão fica em um diretório no gitignore (nomes/empresas reais nunca entram no controle de versão); escreva-o sem censurar.
+
+---
+
+## Question Sets by Round Type
+
+Se nenhuma lista de perguntas for fornecida, obtenha as perguntas nesta ordem de precedência:
+
+1. **Perguntas reais de `interview-prep/question-bank.md`** — perguntas que esta empresa (ou uma rodada anterior) realmente fez, capturadas por debriefs. Maior valor: empiricamente fundamentadas.
+2. **Perguntas pesquisadas do arquivo de preparação da vaga** — perguntas que a pesquisa do interview-prep.md encontrou e citou. Use-as como estão; mantenha as citações fora da sessão, mas respeite a redação.
+3. **Os conjuntos padrão abaixo** — fallback gerado para uma primeira sessão ainda sem pesquisa. Preencha os campos entre colchetes a partir da descrição da vaga.
+
+Combine os níveis quando os superiores estiverem escassos — ex.: 3 perguntas reais da bank complementadas com padrões — mas nunca pule um nível superior que tenha perguntas relevantes para este tipo de rodada.
+
+### Screening — Recruiter (20–30 min)
+
+Uma triagem com recrutador é verificação de requisitos, não sondagem de profundidade. Mantenha as respostas objetivas; não superelabore. O recrutador está verificando fit, alinhamento de remuneração e logística antes de passar ao gestor da vaga.
+
+1. Me conte sobre a sua trajetória.
+2. Por que esta empresa / por que esta vaga?
+3. Por que você está saindo da sua função atual?
+4. Quais são as suas expectativas de remuneração?
+5. [Logística: localização / híbrido / prazos / autorização de trabalho]
+6. Que perguntas você tem para nós?
+
+**Coaching de remuneração (apenas na triagem com recrutador).** Fique atento ao candidato que oferece um piso salarial sem ser perguntado (ex.: "o mínimo que aceito é X"). Se isso acontecer, sinalize após a resposta: "Você acabou de entregar o seu piso — isso limita a sua negociação antes mesmo de começar. O movimento mais forte é ancorar em um alvo pesquisado e adiar para o pacote: 'Estou mirando a metade superior da faixa de mercado para este nível — gostaria de entender salário-base, bônus e equity em conjunto antes de fechar um número.'" Se o arquivo de preparação da vaga definir uma estratégia de remuneração, siga-a; caso contrário, dê apenas esta nota genérica de mecânica — nunca invente números-alvo.
+
+### Screening — Hiring Manager (30–45 min)
+
+Uma triagem com gestor sonda filosofia de liderança, julgamento e profundidade de experiência. As respostas podem ser mais longas e carregar mais peso de história. O gestor está decidindo se vale investir rodadas do tempo da equipe dele.
+
+1. Me conte sobre a sua trajetória.
+2. Por que esta empresa / por que esta vaga?
+3. Me conte sobre o problema mais difícil que você já resolveu na sua área.
+4. Me conte sobre uma vez em que você enfrentou resistência a uma mudança que propôs.
+5. O que [cargo da descrição da vaga] significa para você?
+6. Como você descreveria a sua abordagem ao seu ofício?
+7. [Um conceito fundamental da descrição da vaga — ex.: um método, framework, regulação ou ferramenta central da área]
+
+Inclua pelo menos 2 perguntas situacionais / voltadas ao futuro do conjunto abaixo — elas sondam julgamento e autoconhecimento, não histórias passadas:
+
+**Voltadas ao futuro / situacionais:**
+- "Como é o sucesso para você nos primeiros 90 dias?"
+- "Se você entrar e a equipe estiver em dificuldade — prazos perdidos, moral baixa — qual é o seu primeiro passo?"
+- "Como você decide o que delegar versus o que assumir você mesmo?"
+- "Como você lida com um colega respeitado que discorda de uma direção que você definiu?"
+
+**Autoconhecimento / crescimento:**
+- "O que foi algo que você errou profissionalmente e o que aprendeu?"
+- "Do que você precisa do seu gestor para fazer o seu melhor trabalho?"
+- "Em que você ainda está crescendo na sua função?"
+
+### Technical / Domain-Specific (practitioner, 45–60 min)
+
+1. [Detalhes internos centrais da principal ferramenta ou método da área — ex.: internals de runtime para engenharia, modelos de atribuição para marketing, métodos de avaliação para finanças]
+2. [Padrão ou framework consolidado relevante para a função — a partir da descrição da vaga]
+3. [Aprofundamento em um bloco fundamental — ex.: uma estrutura de dados, um teste estatístico, um princípio contábil]
+4. [Tópico avançado que a vaga enfatiza — a área em que a profundidade separa os candidatos]
+5. Me conte sobre uma falha de alto risco no seu trabalho — como você a diagnosticou e o que fez.
+6. Como você eleva o padrão de qualidade em uma equipe?
+
+### Design / Case Study (45–60 min)
+
+1. Projete [um sistema, processo, campanha ou produto relevante para a função].
+2. [Pergunta de restrição — como o seu design se comporta quando algo falha, escala 10x ou perde orçamento?]
+3. [Pergunta de qualidade/confiabilidade — como você garante correção ou mede sucesso?]
+4. Me explique como você saberia que está funcionando após o lançamento.
+
+### Behavioral Panel
+
+1. Me conte sobre uma vez em que você liderou uma equipe através de uma entrega difícil.
+2. Descreva uma grande falha em produção ou no mercado — o que aconteceu e o que mudou depois?
+3. Me conte sobre uma vez em que você influenciou a direção entre equipes ou stakeholders.
+4. Como é uma equipe de alto desempenho para você?
+5. Me conte sobre uma vez em que você simplificou algo complexo.
+6. Me conte sobre uma vez em que você resolveu um problema que não era seu para resolver.
+
+---
+
+## Rules
+
+- **Uma pergunta de cada vez.** Nunca antecipe várias perguntas. Entrevistadores reais fazem uma de cada vez.
+- **Sem dicas antes da resposta.** Não prepare o candidato com "isto é sobre X". Pergunte sem aviso.
+- **Apenas feedback honesto.** O falso encorajamento é pior que o silêncio — manda o candidato despreparado para uma entrevista real.
+- **Sem alegações fabricadas nas respostas sugeridas.** As versões mais fortes recorrem apenas ao que o candidato disse ou ao que está em `cv.md`, `article-digest.md` ou na story bank — nunca experiências ou métricas inventadas.
+- **Alegações retiradas são uma barreira rígida.** Se uma alegação aparecer em `interview-prep/retracted-claims.md`, nunca a use em uma versão mais forte — mesmo que o candidato a tenha dito na resposta. Sinalize-a em vez disso.
+- **Acompanhe o status.** Atualize `interview-prep/question-bank.md` após a sessão, se ele existir.
+- **Pare quando pedirem.** Se o candidato disser "vamos pausar" ou "por hoje chega", respeite. Não insista por mais uma pergunta.

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -109,6 +109,7 @@ const SYSTEM_PATHS = [
   'modes/ko/',
   'modes/pl/',
   'modes/pt/',
+  'modes/pt/interview/',
   'modes/ru/',
   'modes/tr/',
   'modes/ua/',


### PR DESCRIPTION
Closes #1546.

## What
Adds the three interview-prep modes in Brazilian Portuguese under `modes/pt/interview/`, so Portuguese-speaking job-seekers get interview prep in their own language — mirroring the existing `es`/`fr`/`de` interview dirs.

- `modes/pt/interview/plan.md`
- `modes/pt/interview/practice.md`
- `modes/pt/interview/debrief.md`
- Registers `modes/pt/interview/` in `update-system.mjs` SYSTEM_PATHS (next to `modes/pt/`), mirroring `modes/es/interview/`.

## Convention followed
- **Technical tokens kept byte-identical** to the English source: file paths, `{company-slug}`/`{role-slug}` templates, STAR+R, code spans, the transcript YAML keys, the round enum (`screen | hiring-manager | technical | system-design | behavioral | onsite | final`), `source: practice`/`debrief`, and the `<!-- competency: ... -->` comment.
- **`##` section headers kept in English** per the fr/es convention (helps the agent parse structure consistently).
- Only human-facing prose and candidate-facing template labels are translated.

## Testing
- `node validate-system-paths-coverage.mjs` → OK (709 tracked files covered).
- `node test-all.mjs` → no new failures (the single failing `tracker-columns-tests.mjs` case is pre-existing on `main`, untouched by this branch).

Note: I aimed for faithful, natural pt-BR; happy to fold in any wording tweaks from a native reviewer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Portuguese interview plan guidance: fit assessment, round intelligence, and a time-blocked preparation schedule, plus a 15-minute pre-interview quick reference.
  * Added Portuguese interview practice simulations with strict session flow, round-based question sets, and structured “after each answer” feedback.
  * Added Portuguese post-interview debrief workflows to assess strengths/gaps, update prep banks, and generate next-round intelligence.
* **Documentation**
  * Added support for saving per-company/role prep plans, debriefs, and machine-readable practice session transcripts.
* **Chores**
  * Updated system update rules to include the Portuguese interview documentation set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->