### PR TITLE
feat: paste-reply.mjs — manual/no-Gmail input path into the existing reply-watch classification pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON output) |
 | `set-status.mjs` | Canonical CLI to update a tracker row: `node set-status.mjs <report#\|company> <State> [--note]` — strict states.yml validation, shared tracker lock, atomic write |
 | `invite-match.mjs` | Fuzzy-matches a pasted interview-invite email (company name, date, req ID) against `data/applications.md`, ranking candidates when a company has multiple tracker entries (JSON or `--summary` table output) |
+| `paste-reply.mjs` | Manual/no-Gmail input path into `reply-watch.mjs`'s classification pipeline — normalizes a pasted or file-provided email's subject/from/body into a candidate object and appends it to `data/reply-candidates.json` (never overwrites existing entries; never classifies or touches the tracker itself) |
 | `detect-reposts.mjs` | Repost detector — flags roles re-listed 2+ times in 90 days from scan-history.tsv (JSON or `--summary` table output) |
 | `process-quality.mjs` | Recruiting-process friction aggregator — parses `[process-friction]` tags candidates add to `data/active-interviews.md` Notes and reports per-company friction rate (JSON or `--summary` table output) |
 | `salary-gap.mjs` | Desired/advertised/actual compensation gap analyzer — folds report `advertised_comp` + `data/salary-observations.tsv` (JSON or `--summary`) |

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -29,6 +29,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run tracker` | `tracker.mjs` | SQLite derived index over applications.md — sync/query/history/export |
 | `npm run find` | `find.mjs` | Resolve a report#/tracker#/company query to its full pipeline identity |
 | `npm run invite-match` | `invite-match.mjs` | Fuzzy-match a pasted interview-invite email against `data/applications.md` |
+| `npm run paste-reply` | `paste-reply.mjs` | Manual/no-Gmail input into the `reply-watch.mjs` classification pipeline |
 | `npm run openai:tailor` | `openai-tailor.mjs` | Tailor a CV via any OpenAI-compatible endpoint (headless companion to `openai-eval.mjs`) |
 
 ---
@@ -443,6 +444,30 @@ node find.mjs acme --json       # machine-readable output
 Multiple matches print as a table; zero matches print a clean message.
 
 **Exit codes:** `0` at least one match, `1` no match, missing query, or no `applications.md`.
+
+---
+
+## paste-reply
+
+Manual, no-Gmail input path into `reply-watch.mjs`'s classification pipeline (#1802). `reply-watch.mjs` already classifies employer replies and matches them to tracker rows, but its only input is `data/reply-candidates.json`, and the only planned way to populate that file is a Gmail scanner (#1583, unbuilt, requires OAuth inbox-read access). `paste-reply.mjs` normalizes a pasted (or file-provided) email's subject/from/body into the exact candidate shape `reply-watch.mjs` expects and appends it — existing candidates are never overwritten. It does not classify the reply itself (that stays `reply-watch.mjs`'s job) and never runs `reply-watch.mjs` or touches `data/applications.md`.
+
+```bash
+npm run paste-reply                    # interactive: prompts for subject, from, body
+node paste-reply.mjs --file email.txt  # read subject/from/body from a file
+```
+
+`--file` format (header lines optional, blank line separates headers from body):
+
+```text
+Subject: <subject line>
+From: <sender>
+
+<body text...>
+```
+
+If no `Subject:`/`From:` header lines are found, the whole file is treated as the body. After appending, run `node reply-watch.mjs` to classify the new candidate and review suggested tracker updates.
+
+**Exit codes:** `0` candidate appended, `1` missing `--file` argument, input file not found, or no subject/body text found.
 
 ---
 

--- a/modes/reply-watch.md
+++ b/modes/reply-watch.md
@@ -17,6 +17,8 @@ Local-first, human-in-the-loop: **nothing here auto-updates without user confirm
 - `data/applications.md` — Application tracker (source of truth)
 - `data/follow-ups.md` — Follow-up history (for contact matching)
 
+**Populating `data/reply-candidates.json` manually:** if you don't want to grant any tool mailbox access, run `node paste-reply.mjs` and paste (or point `--file` at) the raw text of a reply email. It normalizes the subject/from/body into the exact candidate shape above and appends it — it never classifies the reply itself and never runs `reply-watch.mjs` or touches the tracker.
+
 ## Invocation
 
 Run the reply-watch command:

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "add": "node add-entry.mjs",
     "reposts": "node detect-reposts.mjs",
     "invite-match": "node invite-match.mjs",
+    "paste-reply": "node paste-reply.mjs",
     "gemini:eval": "node gemini-eval.mjs",
     "ollama:eval": "node ollama-eval.mjs",
     "openai:eval": "node openai-eval.mjs",

--- a/paste-reply-tests.mjs
+++ b/paste-reply-tests.mjs
@@ -178,5 +178,32 @@ console.log('7. parseFileInput / normalizeCandidate as direct unit imports');
   check('normalizeCandidate: missing from defaults to empty string, not undefined', candNoFrom.from === '');
 }
 
+// ---------------------------------------------------------------------------
+console.log('8. interactive (stdin) mode — no --file flag');
+{
+  const dir = tmp('paste-reply-');
+  const candidates = join(dir, 'reply-candidates.json');
+  // collectInteractive() prompts Subject → From → multiline body (EOF-terminated).
+  // Piped stdin supplies all three in order; execFileSync closes stdin after
+  // writing `input`, which readMultilineStdin() reads as EOF.
+  const stdin = 'Interview invite from Acme\nrecruiter@acme.com\nWe would like to schedule a call.\nPlease pick a time.\n';
+  const out = execFileSync(NODE, [CLI], {
+    cwd: ROOT,
+    env: { ...process.env, CAREER_OPS_REPLY_CANDIDATES: candidates },
+    input: stdin,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const arr = JSON.parse(readFileSync(candidates, 'utf8'));
+  check('interactive mode created exactly one candidate', arr.length === 1, `got ${arr.length}`);
+  const cand = arr[0];
+  check('interactive: subject parsed', cand.subject === 'Interview invite from Acme', cand.subject);
+  check('interactive: from parsed', cand.from === 'recruiter@acme.com', cand.from);
+  check('interactive: multiline body joined', cand.body_snippet === 'We would like to schedule a call.\nPlease pick a time.', JSON.stringify(cand.body_snippet));
+  check('interactive: signal is null', cand.signal === null);
+  check('interactive: CLI reports success', out.includes('Appended a new reply candidate'), out);
+}
+
 console.log(`\nResults: ${passed} passed, ${failed} failed`);
 process.exit(failed ? 1 : 0);

--- a/paste-reply-tests.mjs
+++ b/paste-reply-tests.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+/**
+ * paste-reply-tests.mjs — regression tests for paste-reply.mjs (#1802).
+ *
+ * Locks in the manual/no-Gmail input path into reply-watch.mjs's classification
+ * pipeline:
+ *   1. --file mode normalizes subject/from/body into the exact candidate shape
+ *      reply-watch.mjs expects, with signal left null (classification stays
+ *      reply-watch.mjs's job).
+ *   2. Appending is additive — existing candidates are never clobbered.
+ *   3. A missing candidates file is created (with the array wrapper) on first append.
+ *   4. --file input with no Subject:/From: headers falls back to whole-file-as-body.
+ *   5. --file pointing at a nonexistent path fails loudly (exit 1).
+ *   6. message_id values are unique across appends.
+ *   7. parseFileInput / normalizeCandidate work correctly as direct unit imports.
+ *
+ * Provisions a throwaway candidates file via CAREER_OPS_REPLY_CANDIDATES and a
+ * temp dir; never touches the repo's real data/reply-candidates.json.
+ */
+
+import { execFileSync } from 'child_process';
+import { readFileSync, writeFileSync, mkdtempSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const NODE = process.execPath;
+const CLI = join(ROOT, 'paste-reply.mjs');
+
+let passed = 0;
+let failed = 0;
+function check(name, cond, detail = '') {
+  if (cond) { passed++; console.log(`  ✅ ${name}`); }
+  else { failed++; console.log(`  ❌ ${name}${detail ? ` — ${detail}` : ''}`); }
+}
+
+function tmp(prefix) {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function runFile(candidatesPath, filePath, extraEnv = {}) {
+  return execFileSync(NODE, [CLI, '--file', filePath], {
+    cwd: ROOT,
+    env: { ...process.env, CAREER_OPS_REPLY_CANDIDATES: candidatesPath, ...extraEnv },
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+// ---------------------------------------------------------------------------
+console.log('1. --file mode normalizes into the exact candidate shape');
+{
+  const dir = tmp('paste-reply-');
+  const candidates = join(dir, 'reply-candidates.json');
+  const emailFile = join(dir, 'email.txt');
+  writeFileSync(emailFile, [
+    'Subject: 恭喜简历通过，杭州赢云贸易有限公司邀您面试',
+    'From: recruiter@wingyun.com',
+    '',
+    '您的首轮面试是AI微信小程序面试。',
+    '面试形式：AI微信小程序面试，面试时长：约15~30分钟',
+  ].join('\n'));
+
+  runFile(candidates, emailFile);
+  const arr = JSON.parse(readFileSync(candidates, 'utf8'));
+  check('exactly one candidate written', arr.length === 1, `got ${arr.length}`);
+  const cand = arr[0];
+  check('has message_id', typeof cand.message_id === 'string' && cand.message_id.length > 0);
+  check('from parsed', cand.from === 'recruiter@wingyun.com', cand.from);
+  check('subject parsed', cand.subject === '恭喜简历通过，杭州赢云贸易有限公司邀您面试', cand.subject);
+  check('body_snippet contains multi-line body', cand.body_snippet.includes('AI微信小程序面试') && cand.body_snippet.includes('15~30分钟'), cand.body_snippet);
+  check('signal is null (classification stays reply-watch.mjs job)', cand.signal === null, JSON.stringify(cand.signal));
+  check('exactly 5 shape keys', Object.keys(cand).sort().join(',') === 'body_snippet,from,message_id,signal,subject', Object.keys(cand).sort().join(','));
+}
+
+// ---------------------------------------------------------------------------
+console.log('2. appending is additive — existing candidates are never clobbered');
+{
+  const dir = tmp('paste-reply-');
+  const candidates = join(dir, 'reply-candidates.json');
+  const existing = [
+    { message_id: 'msg1', from: 'hr@existing.com', subject: 'Existing candidate', body_snippet: 'do not touch me', signal: 'rejection' },
+  ];
+  writeFileSync(candidates, JSON.stringify(existing, null, 2));
+
+  const emailFile = join(dir, 'email.txt');
+  writeFileSync(emailFile, 'Subject: New reply\nFrom: hr@newco.com\n\nThanks for applying.');
+  runFile(candidates, emailFile);
+
+  const arr = JSON.parse(readFileSync(candidates, 'utf8'));
+  check('two candidates now present', arr.length === 2, `got ${arr.length}`);
+  check('original candidate untouched', arr[0].message_id === 'msg1' && arr[0].body_snippet === 'do not touch me');
+  check('new candidate appended second', arr[1].subject === 'New reply');
+}
+
+// ---------------------------------------------------------------------------
+console.log('3. missing candidates file is created (array wrapper) on first append');
+{
+  const dir = tmp('paste-reply-');
+  const candidates = join(dir, 'reply-candidates.json');
+  check('candidates file does not exist yet', !existsSync(candidates));
+
+  const emailFile = join(dir, 'email.txt');
+  writeFileSync(emailFile, 'Subject: First ever\n\nHello world.');
+  runFile(candidates, emailFile);
+
+  check('candidates file created', existsSync(candidates));
+  const arr = JSON.parse(readFileSync(candidates, 'utf8'));
+  check('is a JSON array with one entry', Array.isArray(arr) && arr.length === 1, JSON.stringify(arr));
+}
+
+// ---------------------------------------------------------------------------
+console.log('4. --file input with no headers falls back to whole-file-as-body');
+{
+  const dir = tmp('paste-reply-');
+  const candidates = join(dir, 'reply-candidates.json');
+  const emailFile = join(dir, 'email.txt');
+  writeFileSync(emailFile, 'Just some pasted text with no headers at all.');
+  runFile(candidates, emailFile);
+
+  const arr = JSON.parse(readFileSync(candidates, 'utf8'));
+  check('subject left blank', arr[0].subject === '', JSON.stringify(arr[0].subject));
+  check('whole content becomes body_snippet', arr[0].body_snippet === 'Just some pasted text with no headers at all.', arr[0].body_snippet);
+}
+
+// ---------------------------------------------------------------------------
+console.log('5. --file pointing at a nonexistent path fails loudly (exit 1)');
+{
+  const dir = tmp('paste-reply-');
+  const candidates = join(dir, 'reply-candidates.json');
+  let exit = 0;
+  try {
+    runFile(candidates, join(dir, 'does-not-exist.txt'));
+  } catch (e) {
+    exit = e.status;
+  }
+  check('non-zero exit on missing input file', exit === 1, `exit=${exit}`);
+  check('no candidates file created on failure', !existsSync(candidates));
+}
+
+// ---------------------------------------------------------------------------
+console.log('6. message_id values are unique across appends');
+{
+  const dir = tmp('paste-reply-');
+  const candidates = join(dir, 'reply-candidates.json');
+  const emailFile = join(dir, 'email.txt');
+  writeFileSync(emailFile, 'Subject: Repeat\n\nSame content each time.');
+  runFile(candidates, emailFile);
+  runFile(candidates, emailFile);
+  runFile(candidates, emailFile);
+
+  const arr = JSON.parse(readFileSync(candidates, 'utf8'));
+  const ids = new Set(arr.map((c) => c.message_id));
+  check('3 candidates appended', arr.length === 3, `got ${arr.length}`);
+  check('all message_ids unique', ids.size === 3, `got ${ids.size} unique of ${arr.length}`);
+}
+
+// ---------------------------------------------------------------------------
+console.log('7. parseFileInput / normalizeCandidate as direct unit imports');
+{
+  const mod = await import(pathToFileURL(CLI).href);
+  const parsed = mod.parseFileInput('Subject: Hi\nFrom: a@b.com\n\nline one\nline two');
+  check('parseFileInput: subject', parsed.subject === 'Hi', parsed.subject);
+  check('parseFileInput: from', parsed.from === 'a@b.com', parsed.from);
+  check('parseFileInput: body preserves multiple lines', parsed.body === 'line one\nline two', JSON.stringify(parsed.body));
+
+  const noHeaders = mod.parseFileInput('just body text');
+  check('parseFileInput: no-header fallback subject blank', noHeaders.subject === '');
+  check('parseFileInput: no-header fallback body is full text', noHeaders.body === 'just body text');
+
+  const cand = mod.normalizeCandidate({ subject: 'S', from: 'F', body: 'B' });
+  check('normalizeCandidate: signal is null', cand.signal === null);
+  check('normalizeCandidate: fields map through', cand.subject === 'S' && cand.from === 'F' && cand.body_snippet === 'B');
+
+  const candNoFrom = mod.normalizeCandidate({ subject: 'S', from: '', body: 'B' });
+  check('normalizeCandidate: missing from defaults to empty string, not undefined', candNoFrom.from === '');
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/paste-reply.mjs
+++ b/paste-reply.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+
+/**
+ * paste-reply.mjs — manual, no-Gmail input path into the reply-watch.mjs
+ * classification pipeline (#1802).
+ *
+ * reply-watch.mjs already classifies employer replies (Interview / Responded /
+ * Need Action / Rejected / Offer / Auto-confirmation / Noise / Unknown), matches
+ * them to tracker rows, and prompts before touching data/applications.md — but
+ * its only input is data/reply-candidates.json, and the only planned way to
+ * populate that file is a Gmail scanner (#1583, unbuilt, requires OAuth
+ * inbox-read access). This script is the alternative for anyone who doesn't
+ * want to grant any tool mailbox access but is willing to paste an email's
+ * text themselves.
+ *
+ * This script does ONE job: normalize raw pasted (or file-provided) email text
+ * into the exact candidate object shape reply-watch.mjs expects, and append it
+ * to data/reply-candidates.json. It does NOT classify the reply — classification
+ * stays reply-watch.mjs's job. reply-matcher.mjs's classifyReply() derives its
+ * verdict from `subject` + `body_snippet` text directly; `signal` is only ever
+ * used as a supplementary confidence boost (`cand.signal || ''`), never a hard
+ * dependency — so leaving `signal: null` here is safe. This script never runs
+ * reply-watch.mjs itself and never touches data/applications.md.
+ *
+ * Usage:
+ *   node paste-reply.mjs                  # interactive: prompts for subject, from, body
+ *   node paste-reply.mjs --file email.txt # read subject/from/body from a file
+ *   node paste-reply.mjs --help
+ *
+ * --file format (header lines optional, blank line separates headers from body):
+ *   Subject: <subject line>
+ *   From: <sender email or name>
+ *
+ *   <body text, any number of lines>
+ *
+ * If no "Subject:"/"From:" header lines are found, the entire file content is
+ * treated as the body and the subject is left blank.
+ *
+ * Env:
+ *   CAREER_OPS_REPLY_CANDIDATES  override the output JSON path (used by tests;
+ *                                 defaults to data/reply-candidates.json next to
+ *                                 this script, matching reply-watch.mjs's default)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CANDIDATES_PATH = process.env.CAREER_OPS_REPLY_CANDIDATES
+  || path.join(__dirname, 'data', 'reply-candidates.json');
+
+function askQuestion(query) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => rl.question(query, (ans) => {
+    rl.close();
+    resolve(ans);
+  }));
+}
+
+// Read the rest of stdin as a multi-line body, ending at EOF (Ctrl+D / Ctrl+Z+Enter).
+function readMultilineStdin() {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin });
+    const lines = [];
+    rl.on('line', (line) => lines.push(line));
+    rl.on('close', () => resolve(lines.join('\n').trim()));
+  });
+}
+
+/**
+ * Parse the --file input format: optional "Subject:"/"From:" header lines,
+ * an optional blank separator line, then the body (everything else).
+ * Exported for direct unit testing.
+ */
+export function parseFileInput(raw) {
+  const lines = raw.replace(/\r\n/g, '\n').split('\n');
+  let subject = '';
+  let from = '';
+  let i = 0;
+  while (i < lines.length) {
+    const subjMatch = /^Subject:\s*(.*)$/i.exec(lines[i]);
+    const fromMatch = /^From:\s*(.*)$/i.exec(lines[i]);
+    if (subjMatch) {
+      subject = subjMatch[1].trim();
+      i++;
+      continue;
+    }
+    if (fromMatch) {
+      from = fromMatch[1].trim();
+      i++;
+      continue;
+    }
+    break;
+  }
+  if (lines[i] === '') i++; // skip a single blank header/body separator
+  const body = lines.slice(i).join('\n').trim();
+  return { subject, from, body };
+}
+
+// No real email message ID exists on the manual path — synthesize a unique one
+// from a timestamp + short random suffix so two pastes in the same millisecond
+// can never collide.
+function nextMessageId() {
+  return `pasted-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Normalize raw {subject, from, body} into the exact candidate shape
+ * reply-watch.mjs expects. Exported for direct unit testing.
+ */
+export function normalizeCandidate({ subject, from, body }) {
+  return {
+    message_id: nextMessageId(),
+    from: from || '',
+    subject: subject || '',
+    body_snippet: body || '',
+    // Classification is reply-watch.mjs's job, not this script's — leaving
+    // signal unset is safe (see file header comment for why).
+    signal: null,
+  };
+}
+
+/**
+ * Append a candidate to the candidates JSON file, creating the file/array if
+ * missing, without disturbing any existing entries. Exported for direct unit
+ * testing. Returns the total candidate count after the append.
+ */
+export function appendCandidate(candidate, candidatesPath = CANDIDATES_PATH) {
+  let candidates = [];
+  if (fs.existsSync(candidatesPath)) {
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(candidatesPath, 'utf-8'));
+    } catch (e) {
+      throw new Error(`Could not parse existing candidates file at ${candidatesPath}: ${e.message}`);
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error(`Existing candidates file at ${candidatesPath} is not a JSON array`);
+    }
+    candidates = parsed;
+  } else {
+    fs.mkdirSync(path.dirname(candidatesPath), { recursive: true });
+  }
+  candidates.push(candidate);
+  fs.writeFileSync(candidatesPath, JSON.stringify(candidates, null, 2), 'utf-8');
+  return candidates.length;
+}
+
+async function collectInteractive() {
+  const subject = (await askQuestion('Subject: ')).trim();
+  const from = (await askQuestion('From (optional, press Enter to skip): ')).trim();
+  console.log('Paste the email body. Finish with EOF (Ctrl+D, or Ctrl+Z then Enter on Windows):');
+  const body = await readMultilineStdin();
+  return { subject, from, body };
+}
+
+function printHelp() {
+  console.log(`paste-reply.mjs — manual/no-Gmail input into the reply-watch.mjs pipeline (#1802)
+
+Usage:
+  node paste-reply.mjs                  interactive: prompts for subject, from, body
+  node paste-reply.mjs --file <path>    read subject/from/body from a file
+  node paste-reply.mjs --help
+
+--file format:
+  Subject: <subject line>
+  From: <sender>            (optional)
+
+  <body text...>
+
+If no Subject:/From: header lines are found, the whole file is treated as the body.
+
+Appends one normalized candidate to data/reply-candidates.json (creates it if
+missing; never overwrites or removes existing entries). Run
+\`node reply-watch.mjs\` afterward to classify it and review tracker updates —
+this script never runs reply-watch.mjs or touches data/applications.md itself.`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp();
+    return;
+  }
+
+  const fileIdx = args.indexOf('--file');
+  let input;
+  if (fileIdx !== -1) {
+    const filePath = args[fileIdx + 1];
+    if (!filePath) {
+      console.error('Error: --file requires a path argument.');
+      process.exit(1);
+    }
+    if (!fs.existsSync(filePath)) {
+      console.error(`Error: file not found: ${filePath}`);
+      process.exit(1);
+    }
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    input = parseFileInput(raw);
+  } else {
+    input = await collectInteractive();
+  }
+
+  if (!input.subject && !input.body) {
+    console.error('Error: no subject or body text found — nothing to add.');
+    process.exit(1);
+  }
+
+  const candidate = normalizeCandidate(input);
+  const total = appendCandidate(candidate);
+
+  const preview = candidate.body_snippet.length > 80
+    ? `${candidate.body_snippet.slice(0, 80)}…`
+    : candidate.body_snippet;
+
+  console.log('\nAppended a new reply candidate:');
+  console.log(`  message_id:   ${candidate.message_id}`);
+  console.log(`  from:         ${candidate.from || '(none)'}`);
+  console.log(`  subject:      ${candidate.subject || '(none)'}`);
+  console.log(`  body_snippet: ${preview || '(none)'}`);
+  console.log(`\ndata/reply-candidates.json now has ${total} candidate(s).`);
+  console.log('Next: run `node reply-watch.mjs` to classify and review this reply.');
+}
+
+// Only run when executed directly (`node paste-reply.mjs`), not when imported
+// for unit testing (e.g. `import(pathToFileURL(SCRIPT).href)` in tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error('Fatal:', err);
+    process.exit(1);
+  });
+}

--- a/paste-reply.mjs
+++ b/paste-reply.mjs
@@ -51,23 +51,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CANDIDATES_PATH = process.env.CAREER_OPS_REPLY_CANDIDATES
   || path.join(__dirname, 'data', 'reply-candidates.json');
 
-function askQuestion(query) {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => rl.question(query, (ans) => {
-    rl.close();
-    resolve(ans);
-  }));
-}
-
-// Read the rest of stdin as a multi-line body, ending at EOF (Ctrl+D / Ctrl+Z+Enter).
-function readMultilineStdin() {
-  return new Promise((resolve) => {
-    const rl = readline.createInterface({ input: process.stdin });
-    const lines = [];
-    rl.on('line', (line) => lines.push(line));
-    rl.on('close', () => resolve(lines.join('\n').trim()));
-  });
-}
 
 /**
  * Parse the --file input format: optional "Subject:"/"From:" header lines,
@@ -144,16 +127,52 @@ export function appendCandidate(candidate, candidatesPath = CANDIDATES_PATH) {
     fs.mkdirSync(path.dirname(candidatesPath), { recursive: true });
   }
   candidates.push(candidate);
-  fs.writeFileSync(candidatesPath, JSON.stringify(candidates, null, 2), 'utf-8');
+  // Write-then-rename so an interrupted write (crash, signal, disk full)
+  // can never leave the real candidates file truncated/corrupted.
+  const tmpPath = `${candidatesPath}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(candidates, null, 2), 'utf-8');
+  fs.renameSync(tmpPath, candidatesPath);
   return candidates.length;
 }
 
-async function collectInteractive() {
-  const subject = (await askQuestion('Subject: ')).trim();
-  const from = (await askQuestion('From (optional, press Enter to skip): ')).trim();
-  console.log('Paste the email body. Finish with EOF (Ctrl+D, or Ctrl+Z then Enter on Windows):');
-  const body = await readMultilineStdin();
-  return { subject, from, body };
+// Collect subject/from/body from stdin via a single readline.Interface and a
+// tiny manual state machine driven off its 'line' event.
+//
+// Earlier drafts chained `rl.question()` calls (one interface per prompt, or
+// repeated `.question()` on one interface). Both are unreliable on piped
+// (non-TTY) stdin: Node's readline resolves the FIRST `.question()` call
+// correctly, but a SECOND `.question()` on the same interface never fires its
+// callback when the input isn't a real TTY — confirmed directly against this
+// Node build, not assumed. A single 'line' listener with manual state
+// tracking works identically on both TTY and piped/non-interactive stdin.
+function collectInteractive() {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  let stage = 'subject';
+  let subject = '';
+  let from = '';
+  const bodyLines = [];
+
+  rl.setPrompt('Subject: ');
+  rl.prompt();
+
+  return new Promise((resolve) => {
+    rl.on('line', (line) => {
+      if (stage === 'subject') {
+        subject = line.trim();
+        stage = 'from';
+        rl.setPrompt('From (optional, press Enter to skip): ');
+        rl.prompt();
+      } else if (stage === 'from') {
+        from = line.trim();
+        stage = 'body';
+        console.log('Paste the email body. Finish with EOF (Ctrl+D, or Ctrl+Z then Enter on Windows):');
+        rl.setPrompt('');
+      } else {
+        bodyLines.push(line);
+      }
+    });
+    rl.on('close', () => resolve({ subject, from, body: bodyLines.join('\n').trim() }));
+  });
 }
 
 function printHelp() {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -161,6 +161,7 @@ const scripts = [
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
   { name: 'agent-inbox-tests.mjs', expectExit: 0 },
   { name: 'followup-seed-tests.mjs', expectExit: 0 },
+  { name: 'paste-reply-tests.mjs', expectExit: 0 },
   { name: 'set-status-tests.mjs', expectExit: 0 },
   // Root-level standalone suites shipped in SYSTEM_PATHS but previously never
   // executed by CI (issue #1624). All are fast (<0.5s each), so they run in

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -201,6 +201,8 @@ const SYSTEM_PATHS = [
   'reply-matcher.mjs',
   'reply-matcher.test.mjs',
   'reply-watch.mjs',
+  'paste-reply.mjs',
+  'paste-reply-tests.mjs',
   'batch/batch-prompt.md',
   'batch/batch-runner.sh',
   'batch/README.md',


### PR DESCRIPTION
## Summary

`reply-watch.mjs` already classifies employer replies (Interview / Responded / Need Action / Rejected / Offer / Auto-confirmation / Noise / Unknown) and matches them to tracker rows — but its only input is `data/reply-candidates.json`, and the only planned way to populate that file is a Gmail scanner (#1583, still open/unbuilt, labeled `plugin-candidate`, requires OAuth inbox-read access). This closes the gap for anyone who doesn't want to grant any tool mailbox access but is willing to paste an email's text themselves.

This is a **manual companion** to the existing `reply-watch.mjs` pipeline. It does **not** touch, block, or duplicate #1582/#1583's Gmail-scanner path — both input paths write to the same `data/reply-candidates.json` shape and can coexist.

- **`paste-reply.mjs`** (repo root, next to `reply-watch.mjs`): normalizes raw email text into the exact candidate object shape (`message_id`, `from`, `subject`, `body_snippet`, `signal`) `reply-watch.mjs` expects, then appends it to `data/reply-candidates.json` (creates the file/array if missing; never overwrites existing candidates).
  - Interactive mode: prompts for subject, from, and multi-line body via stdin.
  - `--file <path>` mode: reads a simple `Subject:`/`From:` header + blank line + body format; falls back to whole-file-as-body if no headers are present.
  - `signal` is left `null` — classification stays `reply-watch.mjs`'s job. Verified `reply-matcher.mjs`'s `classifyReply()` derives its verdict from `subject`+`body_snippet` directly and only ever treats `signal` as a supplementary confidence boost (`cand.signal || ''`), never a hard dependency, so this is safe.
  - Zero new dependencies, zero network access — local file I/O + stdin/file reading only.
  - Local-first, human-in-the-loop: never auto-runs `reply-watch.mjs`, never touches `data/applications.md`. Prints a confirmation and reminds the user to run `node reply-watch.mjs` next.
- **`paste-reply-tests.mjs`**: regression tests (shape correctness, additive append behavior, missing-file bootstrap, header-less fallback, missing-input-file error path, unique `message_id`s, direct unit tests of `parseFileInput`/`normalizeCandidate`), registered in `test-all.mjs` following the `agent-inbox-tests.mjs`/`followup-seed-tests.mjs` pattern.
- Docs: added to `docs/SCRIPTS.md` (quick-reference row + dedicated section), `AGENTS.md`'s Main Files table, and a short pointer in `modes/reply-watch.md`'s Inputs section. Also added `npm run paste-reply` and registered the new files in `update-system.mjs`'s `SYSTEM_PATHS`.

## Test plan

- [x] `node test-all.mjs --quick` — full suite green: **1694 passed, 0 failed** (1 pre-existing/unrelated warning from the Workday provider tests)
- [x] `node paste-reply-tests.mjs` standalone — 27/27 assertions pass
- [x] `node validate-system-paths-coverage.mjs` — OK, all tracked files covered
- [x] Manual `--help` and `--file` smoke test

Closes #1802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `npm run paste-reply` CLI command to manually import pasted reply content or load it from a file.
  * Imported replies are normalized and appended additively to the reply candidates list (no overwrites).
  * Shows a preview and updated candidate count after a successful import.

* **Documentation**
  * Updated script and reply-watch guidance with usage, input format (`Subject:`/`From:` optional), and manual workflow details.

* **Tests**
  * Added end-to-end regression tests for interactive and `--file` modes, including validation and append behavior.
  * Included the new tests in the standard CI run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->