### PR TITLE
feat(modes): wire the opt-in CLI extractor into the oferta + auto-pipeline JD paths (#1449 Phase 2)

### DIFF
--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -9,6 +9,7 @@ If the input is a **URL** (not pasted JD text), follow this strategy to extract 
 **Priority order:**
 
 1. **Playwright (preferred):** Most job portals (Lever, Ashby, Greenhouse, Workday) are SPAs. Use `browser_navigate` + `browser_snapshot` to render and read the JD.
+   - **Opt-in — CLI extractor (`scan.extractor: cli` in `config/profile.yml`):** run `node browser-extract.mjs <url>` (default `--mode jd`) instead; it returns compact `{ "url", "title", "text" }` — just the distilled JD main text rather than the full page a11y tree, so the model processes fewer tokens (board-dependent — modest on clean boards, larger on chrome-heavy SPAs). Use its `text` as the JD. **Fall back silently** to `browser_navigate` + `browser_snapshot` if it errors or is missing. Read-only (navigate + read, no clicks/fills), so it never applies to the apply-form step below.
 2. **WebFetch (fallback):** For static pages (ZipRecruiter, WeLoveProduct, company career pages).
 3. **WebSearch (last resort):** Search for the role title + company in secondary portals that index the JD in static HTML.
 

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -6,7 +6,7 @@ When the candidate pastes a job (text or URL), ALWAYS deliver the 7 blocks (A-F 
 
 When the candidate pastes a **URL** (not JD text), confirm the posting is still live before doing any evaluation. A dead link must never reach Block A — a 404/expired page wastes a full A-G evaluation, report, and PDF on phantom content.
 
-1. Get the page content: if you arrived here from `auto-pipeline` (its Step 0.5 already navigated and cleared the link), reuse that snapshot — do not navigate again. On a direct URL entry, navigate with Playwright (`browser_navigate` + `browser_snapshot`) and read the title, URL, and visible content.
+1. Get the page content: if you arrived here from `auto-pipeline` (its Step 0.5 already navigated and cleared the link), reuse that snapshot — do not navigate again. On a direct URL entry, navigate with Playwright (`browser_navigate` + `browser_snapshot`) and read the title, URL, and visible content. **Opt-in:** if `scan.extractor: cli` is set in `config/profile.yml`, run `node browser-extract.mjs <url>` (default `--mode jd`) instead and use its compact `{ "url", "title", "text" }` (the distilled JD main text rather than the full page a11y tree — fewer tokens for the model, board-dependent), **falling back silently** to `browser_navigate` + `browser_snapshot` if it errors or is missing.
 2. Classify the posting:
    - **active posting evidence:** title/role + a real job description or an application/apply path
    - **closed posting evidence:** expired/closed/"no longer accepting applications", missing JD with only nav/footer, hard redirect to a generic careers/search page, or 404/410

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1980,6 +1980,28 @@ if (
   }
 }
 
+// Opt-in CLI extractor wiring (#1449 Phase 2): every read-only JD-extraction
+// path must offer `browser-extract.mjs` behind `scan.extractor`, with a silent
+// MCP fallback — so the flag actually reaches the JD paths, not just scan/pipeline.
+{
+  const jdPathModes = ['modes/oferta.md', 'modes/auto-pipeline.md', 'modes/pipeline.md', 'modes/scan.md'];
+  const missing = jdPathModes.filter((m) => {
+    const src = readFile(m);
+    return !(src.includes('browser-extract.mjs') && src.includes('scan.extractor'));
+  });
+  if (missing.length === 0) {
+    pass('read-only JD paths wire the opt-in CLI extractor behind scan.extractor (#1449)');
+  } else {
+    fail(`JD paths missing browser-extract/scan.extractor wiring: ${missing.join(', ')}`);
+  }
+  // apply must stay on the MCP — the extractor is read-only and never fills forms.
+  if (!readFile('modes/apply.md').includes('browser-extract.mjs')) {
+    pass('apply mode does not route through the read-only extractor (#1449)');
+  } else {
+    fail('apply mode references browser-extract.mjs — the extractor must not touch the apply/form path');
+  }
+}
+
 if (readFile('DATA_CONTRACT.md').includes('data/blacklist.md')) {
   pass('DATA_CONTRACT.md registers data/blacklist.md as user layer (#1742)');
 } else {


### PR DESCRIPTION
Phase 2 of #1449 (scope approved above). Pure wiring of the already-merged `browser-extract.mjs` into the remaining read-only JD paths — no new script, same flag, same silent fallback.

## What
Phase 1 (#1667) shipped `browser-extract.mjs` and wired it into `scan.md` (listing) + `pipeline.md` (JD). Its `jd` mode was built for "pipeline / oferta / auto-pipeline," but only the first was wired. This routes the other two read-only JD paths through the same helper:
- **`auto-pipeline.md` Step 0** (URL → JD extraction)
- **`oferta.md`** direct-URL navigation

Same contract as Phase 1: opt-in behind `scan.extractor: cli`, **silent fallback** to `browser_navigate` + `browser_snapshot`, MCP stays the default. Strictly read-only — the apply/form-fill step (`auto-pipeline` "Extract form questions") stays on the MCP, untouched. A `test-all` guard asserts all four JD paths wire the extractor and `apply.md` does not.

## At-scale numbers (measured, and honest about it)
I measured `browser-extract --mode jd` against the page's a11y snapshot on live postings today:

| Board | full `body.ariaSnapshot()` | `browser-extract` (jd) | ratio |
|---|---|---|---|
| Greenhouse (Anthropic, AE ASEAN) | ~3.4K tok | ~3.05K tok (at 12K-char cap) | ~1.1× |
| Greenhouse (Anthropic, AE Nonprofits) | ~4.3K tok | ~3.07K tok | ~1.4× |
| Ashby (Ramp) | ~2.7K tok | ~1.9K tok | ~1.45× |

**Caveat I want to be upfront about:** this compares against `body.ariaSnapshot()`, which is a *conservative floor* — the actual MCP `browser_snapshot` the agent receives is the fuller interactive tree (every element + `[ref_N]` annotations, nav/footer/consent chrome), which is larger, so the real agent-path saving is higher than these numbers (Phase 1 measured up to ~5.6× on heavier boards). I couldn't capture a fresh live MCP-path figure this session. So: on clean boards the per-offer win is modest (~1.1–1.5× floor), larger on chrome-heavy SPAs (Workday/consent-walled) where the snapshot balloons while the distilled extract stays capped at 12K chars. Across an N-offer pipeline/auto-pipeline run it compounds, and the structural win holds regardless — the extract is bounded, deterministic, and JD-only.

Given that, I softened the mode prose to describe the saving as board-dependent rather than repeating a hard "~4–5×" (happy to reconcile the existing `pipeline.md`/`scan.md` wording to match in a follow-up if you'd like consistency).

## Follow-up (Phase 2b)
The ~15 `modes/{lang}/pipeline.md` mirrors are the same mechanical wiring but need translated opt-in notes — I kept them out to keep this review focused (mirrors the engine-by-engine split on #1709). Happy to do them next, or fold them in here if you'd prefer.

## Tests
`node test-all.mjs --quick` → **1693 passed, 0 failed**.

2 commits: mode wiring · test guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional command-line extractor for obtaining job description content from URLs.
  * Automatically falls back to the existing browser-based extraction when the optional extractor is unavailable or fails.
  * Extraction is limited to read-only job description workflows and is not used for application submission flows.

* **Tests**
  * Added validation to ensure extractor configuration is consistently applied across supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->