### PR TITLE
feat(providers): add Welcome to the Jungle and Agentic Engineering Jobs providers

### DIFF
--- a/providers/agentic-jobs.mjs
+++ b/providers/agentic-jobs.mjs
@@ -34,6 +34,8 @@ function assertAgenticUrl(url) {
   return url;
 }
 
+const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
+
 /**
  * Convert a two-letter regional-indicator flag emoji (e.g. 🇩🇪) into an
  * English country name ("Germany"). Returns '' when the input isn't a flag or
@@ -49,7 +51,7 @@ export function flagToCountry(s) {
   });
   if (codes.some((c) => !c)) return '';
   try {
-    const name = new Intl.DisplayNames(['en'], { type: 'region' }).of(codes.join(''));
+    const name = regionNames.of(codes.join(''));
     return name && name !== codes.join('') ? name : '';
   } catch {
     return '';

--- a/providers/agentic-jobs.mjs
+++ b/providers/agentic-jobs.mjs
@@ -85,7 +85,10 @@ export function normalizeAgenticCard(slug, lines) {
   const [title, company, maybeLocation] = fields;
   if (!title || !company) return null;
 
-  let location = maybeLocation && !/^\d{4}-\d{2}-\d{2}$/.test(maybeLocation) ? maybeLocation : '';
+  // A card without a location line slides the flag-emoji line into this slot —
+  // a bare flag is never a location (it resolves to the country name below).
+  let location =
+    maybeLocation && !/^\d{4}-\d{2}-\d{2}$/.test(maybeLocation) && !flagToCountry(maybeLocation) ? maybeLocation : '';
   const flag = fields.map(flagToCountry).find(Boolean);
   if (flag) location = location ? `${location}, ${flag}` : flag;
 

--- a/providers/agentic-jobs.mjs
+++ b/providers/agentic-jobs.mjs
@@ -1,0 +1,143 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+import { decodeEntities } from './_html-entities.mjs';
+
+// Agentic Engineering Jobs provider — scrapes the server-rendered listing at
+// https://agentic-engineering-jobs.com/. The site has no public API, but every
+// job card is plain HTML wrapped in a `data-impression-slug` container, so the
+// full list is parseable from one page fetch (zero tokens, no browser).
+//
+// Card text lines after tag-stripping follow a stable order:
+//   [Featured?] → title → company → location → tech tags… → 🇺🇸 flag → [date]
+// The country flag emoji is decoded to a country name and appended to the
+// location so scan.mjs's location_filter can gate non-US postings that only
+// say "Remote".
+//
+// Wire in via a `job_boards:` entry with `provider: agentic-jobs`.
+
+const SITE_ORIGIN = 'https://agentic-engineering-jobs.com';
+const TRUSTED_HOST = 'agentic-engineering-jobs.com';
+
+/** @param {string} url */
+function assertAgenticUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`agentic-jobs: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`agentic-jobs: URL must use HTTPS: ${url}`);
+  if (parsed.hostname !== TRUSTED_HOST) {
+    throw new Error(`agentic-jobs: untrusted hostname "${parsed.hostname}" — must be ${TRUSTED_HOST}`);
+  }
+  return url;
+}
+
+/**
+ * Convert a two-letter regional-indicator flag emoji (e.g. 🇩🇪) into an
+ * English country name ("Germany"). Returns '' when the input isn't a flag or
+ * the region code can't be resolved.
+ * @param {string} s
+ */
+export function flagToCountry(s) {
+  const cps = [...s];
+  if (cps.length !== 2) return '';
+  const codes = cps.map((c) => {
+    const cp = c.codePointAt(0) ?? 0;
+    return cp >= 0x1f1e6 && cp <= 0x1f1ff ? String.fromCharCode(cp - 0x1f1e6 + 65) : '';
+  });
+  if (codes.some((c) => !c)) return '';
+  try {
+    const name = new Intl.DisplayNames(['en'], { type: 'region' }).of(codes.join(''));
+    return name && name !== codes.join('') ? name : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Parse one job card's HTML segment into text lines (tags stripped, entities
+ * decoded, blanks removed). Exported for tests.
+ * @param {string} segment
+ */
+export function cardLines(segment) {
+  const noMedia = segment.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ').replace(/<img[^>]*>/gi, ' ');
+  return noMedia
+    .split(/<[^>]+>/)
+    .map((t) => decodeEntities(t).trim())
+    .filter(Boolean);
+}
+
+/**
+ * Normalize one card. Exported for tests.
+ * @param {string} slug
+ * @param {string[]} lines
+ * @returns {{ title: string, url: string, company: string, location: string, postedAt?: number } | null}
+ */
+export function normalizeAgenticCard(slug, lines) {
+  if (!slug || !/^[a-z0-9_-]+$/i.test(slug)) return null;
+  // Drop the leftover `slug">` artifact of the split plus any Featured badge.
+  const fields = lines.filter((l) => !l.includes('">') && l !== 'Featured');
+  if (fields.length < 2) return null;
+  const [title, company, maybeLocation] = fields;
+  if (!title || !company) return null;
+
+  let location = maybeLocation && !/^\d{4}-\d{2}-\d{2}$/.test(maybeLocation) ? maybeLocation : '';
+  const flag = fields.map(flagToCountry).find(Boolean);
+  if (flag) location = location ? `${location}, ${flag}` : flag;
+
+  /** @type {{ title: string, url: string, company: string, location: string, postedAt?: number }} */
+  const job = { title, url: `${SITE_ORIGIN}/jobs/${slug}`, company, location };
+
+  const dateLine = fields.find((l) => /^\d{4}-\d{2}-\d{2}$/.test(l));
+  if (dateLine) {
+    const parsed = Date.parse(`${dateLine}T00:00:00Z`);
+    if (!Number.isNaN(parsed)) job.postedAt = parsed;
+  }
+  return job;
+}
+
+/**
+ * Parse the full listing page. Exported for tests.
+ * @param {string} html
+ */
+export function parseAgenticListing(html) {
+  const out = [];
+  const seen = new Set();
+  const segments = html.split(/<div[^>]*\bdata-impression-slug="/).slice(1);
+  for (const seg of segments) {
+    const slug = seg.slice(0, seg.indexOf('"'));
+    // Cards can nest other markup; stop this card at the next card boundary.
+    const nextCard = seg.indexOf('data-impression-slug', slug.length + 2);
+    const body = nextCard > 0 ? seg.slice(0, nextCard) : seg;
+    const job = normalizeAgenticCard(slug, cardLines(body));
+    if (job && !seen.has(job.url)) {
+      seen.add(job.url);
+      out.push(job);
+    }
+  }
+  return out;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'agentic-jobs',
+
+  detect(entry) {
+    return entry?.provider === 'agentic-jobs' ? { url: SITE_ORIGIN } : null;
+  },
+
+  async fetch(_entry, ctx) {
+    const url = assertAgenticUrl(`${SITE_ORIGIN}/`);
+    // redirect:'error' prevents SSRF via server-side redirects
+    const html = await ctx.fetchText(url, { redirect: 'error' });
+    const jobs = parseAgenticListing(html);
+    if (jobs.length === 0) {
+      throw new Error(
+        'agentic-jobs: parsed 0 job cards — the site markup likely changed (expected data-impression-slug containers)',
+      );
+    }
+    return jobs;
+  },
+};

--- a/providers/wttj.mjs
+++ b/providers/wttj.mjs
@@ -65,7 +65,12 @@ export function parseEnvPayload(text) {
   // App ids are short alphanumerics; validating keeps the derived Algolia
   // hostname from being attacker-shaped if the env payload ever changes.
   if (!/^[A-Z0-9]{6,16}$/i.test(appId)) throw new Error(`wttj: unexpected Algolia app id "${appId}"`);
-  if (!/^[a-f0-9]{16,64}$/i.test(apiKey)) throw new Error('wttj: unexpected Algolia api key shape');
+  // The key is only ever sent as a request header (never used to build a
+  // host), so don't over-constrain its format — WTTJ may rotate to a longer
+  // or non-hex (e.g. secured/base64) client key. Length bounds only.
+  if (!apiKey || apiKey.length < 16 || apiKey.length > 500) {
+    throw new Error('wttj: unexpected Algolia api key shape');
+  }
   return { appId, apiKey };
 }
 

--- a/providers/wttj.mjs
+++ b/providers/wttj.mjs
@@ -1,0 +1,206 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Welcome to the Jungle provider — queries WTTJ's public Algolia search index
+// (the same one the welcometothejungle.com jobs UI calls). The Algolia app id
+// and client search key are public but rotate, so they are fetched fresh from
+// https://www.welcometothejungle.com/api/env on every run instead of being
+// hardcoded. The key is referer-locked, so every Algolia request sends a
+// welcometothejungle.com Referer header.
+//
+// The board is global and enormous, so a `wttj:` config block with explicit
+// search queries is REQUIRED — without one the provider throws rather than
+// silently scanning an arbitrary slice:
+//
+//   - name: Welcome to the Jungle
+//     provider: wttj
+//     wttj:
+//       queries: ["finops", "data platform engineer", "snowflake"]
+//       max_hits: 100        # optional, per query, capped at 200
+//     enabled: true
+//
+// Each hit maps to the normalized Job shape; salary_yearly_minimum (when
+// present) is attached as `salary: {min, max, currency}` so scan.mjs's
+// salary_filter can gate on it.
+
+const ENV_URL = 'https://www.welcometothejungle.com/api/env';
+const SITE_ORIGIN = 'https://www.welcometothejungle.com';
+const INDEX = 'wttj_jobs_production_en';
+const DEFAULT_MAX_HITS = 100;
+const MAX_HITS_CAP = 200;
+
+/** Pin a URL to an expected https host. */
+function assertHost(url, host, label) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`wttj: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`wttj: URL must use HTTPS: ${url}`);
+  if (parsed.hostname !== host.toLowerCase()) {
+    throw new Error(`wttj: untrusted ${label} hostname "${parsed.hostname}" — must be ${host}`);
+  }
+  return url;
+}
+
+/**
+ * Parse the `window.env = {...}` payload served by /api/env and extract the
+ * Algolia application id + client search key.
+ * @param {string} text
+ * @returns {{ appId: string, apiKey: string }}
+ */
+export function parseEnvPayload(text) {
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end <= start) throw new Error('wttj: /api/env payload has no JSON object');
+  let env;
+  try {
+    env = JSON.parse(text.slice(start, end + 1));
+  } catch {
+    throw new Error('wttj: /api/env payload is not valid JSON');
+  }
+  const appId = typeof env.PUBLIC_ALGOLIA_APPLICATION_ID === 'string' ? env.PUBLIC_ALGOLIA_APPLICATION_ID.trim() : '';
+  const apiKey = typeof env.PUBLIC_ALGOLIA_API_KEY_CLIENT === 'string' ? env.PUBLIC_ALGOLIA_API_KEY_CLIENT.trim() : '';
+  // App ids are short alphanumerics; validating keeps the derived Algolia
+  // hostname from being attacker-shaped if the env payload ever changes.
+  if (!/^[A-Z0-9]{6,16}$/i.test(appId)) throw new Error(`wttj: unexpected Algolia app id "${appId}"`);
+  if (!/^[a-f0-9]{16,64}$/i.test(apiKey)) throw new Error('wttj: unexpected Algolia api key shape');
+  return { appId, apiKey };
+}
+
+/**
+ * Normalize a single Algolia hit. Exported for tests.
+ *
+ * Field mapping → normalized Job shape:
+ *   - title:    `name`
+ *   - url:      /en/companies/{organization.slug}/jobs/{slug} on the WTTJ site
+ *   - company:  `organization.name`
+ *   - location: offices[0] city+country, with ", Remote" appended when the
+ *               posting allows fulltime remote
+ *   - postedAt: `published_at_timestamp` (epoch seconds → ms)
+ *   - salary:   {min, max, currency} from salary_yearly_minimum/salary_maximum
+ *
+ * @param {any} h
+ * @returns {{ title: string, url: string, company: string, location: string, postedAt?: number, salary?: {min: number, max: number, currency: string} } | null}
+ */
+export function normalizeWttjHit(h) {
+  if (!h || typeof h !== 'object') return null;
+  const title = typeof h.name === 'string' ? h.name.trim() : '';
+  const slug = typeof h.slug === 'string' ? h.slug.trim() : '';
+  const orgSlug = typeof h.organization?.slug === 'string' ? h.organization.slug.trim() : '';
+  if (!title || !slug || !orgSlug) return null;
+  // Slugs feed straight into a URL path — keep them to safe path characters.
+  if (!/^[a-z0-9_-]+$/i.test(slug) || !/^[a-z0-9_-]+$/i.test(orgSlug)) return null;
+
+  const url = `${SITE_ORIGIN}/en/companies/${orgSlug}/jobs/${slug}`;
+  const company =
+    typeof h.organization?.name === 'string' && h.organization.name.trim()
+      ? h.organization.name.trim()
+      : 'Welcome to the Jungle';
+
+  const office = Array.isArray(h.offices) && h.offices.length > 0 ? h.offices[0] : null;
+  const parts = [];
+  if (office && typeof office.city === 'string' && office.city.trim()) parts.push(office.city.trim());
+  if (office && typeof office.country === 'string' && office.country.trim()) parts.push(office.country.trim());
+  if (h.remote === 'fulltime') parts.push('Remote');
+  const location = parts.join(', ');
+
+  /** @type {{ title: string, url: string, company: string, location: string, postedAt?: number, salary?: {min: number, max: number, currency: string} }} */
+  const job = { title, url, company, location };
+
+  const ts = h.published_at_timestamp;
+  if (Number.isFinite(ts) && ts > 0) job.postedAt = ts * 1000;
+
+  const min = Number.isFinite(h.salary_yearly_minimum) && h.salary_yearly_minimum > 0 ? h.salary_yearly_minimum : 0;
+  // salary_maximum is per salary_period; only trust it as an annual bound when
+  // the period is yearly — otherwise keep just the annualized minimum.
+  const max =
+    h.salary_period === 'yearly' && Number.isFinite(h.salary_maximum) && h.salary_maximum > 0
+      ? h.salary_maximum
+      : 0;
+  if (min || max) {
+    job.salary = {
+      min: min || max,
+      max: max || min,
+      currency: typeof h.salary_currency === 'string' ? h.salary_currency.trim().toUpperCase() : '',
+    };
+  }
+  return job;
+}
+
+/** Resolve config: required queries list + optional per-query hit cap. */
+function resolveConfig(entry) {
+  const cfg = entry?.wttj && typeof entry.wttj === 'object' ? entry.wttj : {};
+  const queries = Array.isArray(cfg.queries)
+    ? cfg.queries.filter((q) => typeof q === 'string' && q.trim()).map((q) => q.trim())
+    : [];
+  if (queries.length === 0) {
+    throw new Error(
+      'wttj: the WTTJ board is global — configure explicit searches via `wttj: { queries: ["…"] }`',
+    );
+  }
+  const maxHits =
+    Number.isInteger(cfg.max_hits) && cfg.max_hits > 0 ? Math.min(cfg.max_hits, MAX_HITS_CAP) : DEFAULT_MAX_HITS;
+  return { queries, maxHits };
+}
+
+/** @type {Provider} */
+export default {
+  id: 'wttj',
+
+  detect(entry) {
+    return entry?.provider === 'wttj' ? { url: SITE_ORIGIN } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const { queries, maxHits } = resolveConfig(entry);
+
+    // 1. Fresh Algolia credentials from the site's public env endpoint.
+    const envText = await ctx.fetchText(assertHost(ENV_URL, 'www.welcometothejungle.com', 'env'), {
+      redirect: 'error',
+    });
+    const { appId, apiKey } = parseEnvPayload(envText);
+    const algoliaHost = `${appId}-dsn.algolia.net`;
+
+    // 2. One Algolia query per configured search term; dedup across queries.
+    const byUrl = new Map();
+    for (const query of queries) {
+      const url = assertHost(
+        `https://${algoliaHost}/1/indexes/${INDEX}/query`,
+        algoliaHost,
+        'algolia',
+      );
+      const params = new URLSearchParams({
+        query,
+        hitsPerPage: String(maxHits),
+        attributesToRetrieve:
+          'name,slug,organization,offices,remote,published_at_timestamp,salary_yearly_minimum,salary_maximum,salary_period,salary_currency',
+      });
+      const json = /** @type {any} */ (
+        await ctx.fetchJson(url, {
+          method: 'POST',
+          redirect: 'error',
+          headers: {
+            'x-algolia-application-id': appId,
+            'x-algolia-api-key': apiKey,
+            // The client search key is referer-locked to the WTTJ site.
+            referer: `${SITE_ORIGIN}/`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ params: params.toString() }),
+        })
+      );
+      if (!json || !Array.isArray(json.hits)) {
+        throw new Error(
+          `wttj: unexpected Algolia response for query "${query}" — expected { hits: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`,
+        );
+      }
+      for (const h of json.hits) {
+        const job = normalizeWttjHit(h);
+        if (job && !byUrl.has(job.url)) byUrl.set(job.url, job);
+      }
+    }
+    return [...byUrl.values()];
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -531,9 +531,9 @@ search_queries:
 #
 # Some providers are job boards / aggregators with no per-company careers
 # URL to detect, so they must be selected with an explicit `provider:`
-# field: 4dayweek, arbeitnow, arbeitsagentur, getonbrd, glints, himalayas, ibm, jobicy,
-# jobstreet, justjoin, landingjobs, nofluffjobs, remoteok, remotive, thehub,
-# weworkremotely, workingnomads. Examples for every built-in provider are below.
+# field: 4dayweek, agentic-jobs, arbeitnow, arbeitsagentur, getonbrd, glints, himalayas,
+# ibm, jobicy, jobstreet, justjoin, landingjobs, nofluffjobs, remoteok, remotive, thehub,
+# weworkremotely, workingnomads, wttj. Examples for every built-in provider are below.
 
 # ── Built-in provider examples ────────────────────────────────────
 # Commented config for each provider in providers/. Copy a stanza into
@@ -751,6 +751,19 @@ search_queries:
 #
 # - name: LaraJobs                        # Laravel / PHP jobs (public RSS feed)
 #   provider: larajobs
+#   enabled: true
+#
+# - name: Welcome to the Jungle           # global board via WTTJ's public Algolia index
+#   provider: wttj
+#   wttj:
+#     queries: ["ai engineer", "data platform engineer"]  # REQUIRED — the board is global,
+#                                 # so explicit searches must be configured; each query is a
+#                                 # separate Algolia search, results deduped across queries
+#     max_hits: 100        # optional per-query hit cap (default 100, max 200)
+#   enabled: true
+#
+# - name: Agentic Engineering Jobs        # AI-agent engineering roles (SSR HTML, one fetch)
+#   provider: agentic-jobs
 #   enabled: true
 #
 # Comeet needs the full careers-api URL (it carries a per-tenant token that a

--- a/tests/providers/agentic-jobs.test.mjs
+++ b/tests/providers/agentic-jobs.test.mjs
@@ -1,0 +1,191 @@
+// tests/providers/agentic-jobs.test.mjs — Agentic Engineering Jobs provider
+// (server-rendered listing at agentic-engineering-jobs.com, parsed from
+// data-impression-slug card containers). Follows the discovered-test layout
+// from #1440.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — agentic-jobs (agentic-engineering-jobs.com SSR listing)');
+try {
+  const mod = await import(pathToFileURL(join(ROOT, 'providers/agentic-jobs.mjs')).href);
+  const agentic = mod.default;
+  const { flagToCountry, cardLines, normalizeAgenticCard, parseAgenticListing } = mod;
+
+  if (agentic.id === 'agentic-jobs') pass('agentic-jobs.id is "agentic-jobs"');
+  else fail(`agentic-jobs.id is ${JSON.stringify(agentic.id)}`);
+
+  const hit = agentic.detect({ name: 'Agentic Engineering Jobs', provider: 'agentic-jobs' });
+  if (hit && hit.url === 'https://agentic-engineering-jobs.com') {
+    pass('agentic-jobs.detect() claims entries with provider: agentic-jobs');
+  } else {
+    fail(`agentic-jobs.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  if (agentic.detect({ name: 'X', provider: 'remoteok' }) === null) {
+    pass('agentic-jobs.detect() returns null for other providers');
+  } else {
+    fail('agentic-jobs.detect() should return null for other providers');
+  }
+
+  if (agentic.detect({ name: 'X', careers_url: 'https://agentic-engineering-jobs.com/' }) === null) {
+    pass('agentic-jobs.detect() does not URL-autodetect (explicit provider: only)');
+  } else {
+    fail('agentic-jobs.detect() should not claim entries by careers_url');
+  }
+
+  // flagToCountry — regional-indicator flag emoji → English country name
+  if (flagToCountry('🇺🇸') === 'United States') pass('flagToCountry() decodes 🇺🇸 to United States');
+  else fail(`flagToCountry('🇺🇸') = ${JSON.stringify(flagToCountry('🇺🇸'))}`);
+
+  if (flagToCountry('🇩🇪') === 'Germany') pass('flagToCountry() decodes 🇩🇪 to Germany');
+  else fail(`flagToCountry('🇩🇪') = ${JSON.stringify(flagToCountry('🇩🇪'))}`);
+
+  if (flagToCountry('DE') === '' && flagToCountry('🇺') === '' && flagToCountry('LangGraph') === '') {
+    pass('flagToCountry() returns "" for plain text and non-flag input');
+  } else {
+    fail('flagToCountry() should return "" for non-flag input');
+  }
+
+  // cardLines — tag-stripped, entity-decoded text lines
+  const lines = cardLines(
+    '<script>var x = "<b>ignore</b>";</script><style>.a{}</style><img src="/logo.png">' +
+    '<h2>Agent Engineer</h2> <p>Acme &amp; Co</p><span>  </span><span>Berlin</span>',
+  );
+  if (JSON.stringify(lines) === JSON.stringify(['Agent Engineer', 'Acme & Co', 'Berlin'])) {
+    pass('cardLines() strips script/style/img, decodes entities, and drops blank lines');
+  } else {
+    fail(`cardLines() = ${JSON.stringify(lines)}`);
+  }
+
+  // normalizeAgenticCard — text lines → normalized Job
+  const card = normalizeAgenticCard('senior-agent-engineer-acme', [
+    'senior-agent-engineer-acme" class="card">',
+    'Featured',
+    'Senior Agent Engineer',
+    'Acme AI',
+    'San Francisco',
+    'LangGraph',
+    '🇺🇸',
+    '2026-07-01',
+  ]);
+  if (
+    card &&
+    card.title === 'Senior Agent Engineer' &&
+    card.company === 'Acme AI' &&
+    card.url === 'https://agentic-engineering-jobs.com/jobs/senior-agent-engineer-acme'
+  ) {
+    pass('normalizeAgenticCard() drops the slug artifact + Featured badge and maps title/company/url');
+  } else {
+    fail(`normalizeAgenticCard() = ${JSON.stringify(card)}`);
+  }
+
+  if (card && card.location === 'San Francisco, United States') {
+    pass('normalizeAgenticCard() appends the decoded flag country to the location');
+  } else {
+    fail(`normalizeAgenticCard() location = ${JSON.stringify(card && card.location)}`);
+  }
+
+  if (card && card.postedAt === Date.parse('2026-07-01T00:00:00Z')) {
+    pass('normalizeAgenticCard() parses the YYYY-MM-DD date line as UTC postedAt');
+  } else {
+    fail(`normalizeAgenticCard() postedAt = ${card && card.postedAt}`);
+  }
+
+  const noLocation = normalizeAgenticCard('agent-eng', ['Agent Engineer', 'Globex', '2026-06-15', '🇫🇷']);
+  if (noLocation && noLocation.location === 'France' && noLocation.postedAt === Date.parse('2026-06-15T00:00:00Z')) {
+    pass('normalizeAgenticCard() treats a date-shaped third field as no location (flag country only)');
+  } else {
+    fail(`normalizeAgenticCard() no-location card = ${JSON.stringify(noLocation)}`);
+  }
+
+  if (normalizeAgenticCard('bad slug!', ['Title', 'Company']) === null) {
+    pass('normalizeAgenticCard() rejects path-unsafe slugs (they feed straight into a URL path)');
+  } else {
+    fail('normalizeAgenticCard() should reject path-unsafe slugs');
+  }
+
+  if (normalizeAgenticCard('', ['Title', 'Company']) === null && normalizeAgenticCard('ok-slug', ['Title only']) === null) {
+    pass('normalizeAgenticCard() returns null for a missing slug or fewer than title+company');
+  } else {
+    fail('normalizeAgenticCard() should return null for incomplete cards');
+  }
+
+  // parseAgenticListing — full page → deduped job list
+  const LISTING = `
+<html><body><main>
+  <div class="cards">
+    <div data-impression-slug="senior-agent-engineer-acme" class="card">
+      <img src="/acme.png">
+      <h2>Senior Agent Engineer</h2>
+      <p class="company">Acme AI</p>
+      <p class="location">San Francisco</p>
+      <span class="tag">LangGraph</span>
+      <span class="flag">🇺🇸</span>
+      <time>2026-07-01</time>
+    </div>
+    <div data-impression-slug="agent-platform-engineer-globex" class="card">
+      <span class="badge">Featured</span>
+      <h2>Agent Platform Engineer</h2>
+      <p class="company">Globex &amp; Co</p>
+      <p class="location">Remote</p>
+      <span class="flag">🇩🇪</span>
+      <time>2026-06-15</time>
+    </div>
+    <div data-impression-slug="senior-agent-engineer-acme" class="card">
+      <h2>Senior Agent Engineer</h2>
+      <p class="company">Acme AI</p>
+    </div>
+  </div>
+</main></body></html>`;
+
+  const jobs = parseAgenticListing(LISTING);
+  if (jobs.length === 2) {
+    pass('parseAgenticListing() parses every card and dedupes repeated slugs');
+  } else {
+    fail(`parseAgenticListing() returned ${jobs.length} jobs, expected 2`);
+  }
+
+  const g = jobs[1];
+  if (
+    g &&
+    g.company === 'Globex & Co' &&
+    g.location === 'Remote, Germany' &&
+    g.url === 'https://agentic-engineering-jobs.com/jobs/agent-platform-engineer-globex'
+  ) {
+    pass('parseAgenticListing() decodes entities and appends the flag country per card');
+  } else {
+    fail(`parseAgenticListing() job[1] = ${JSON.stringify(g)}`);
+  }
+
+  // fetch() — single page fetch, hard failure on zero cards (mocked ctx)
+  const mkCtx = (html) => {
+    const calls = [];
+    return { calls, ctx: { fetchText: async (url, opts) => { calls.push({ url, opts }); return html; } } };
+  };
+
+  const ok = mkCtx(LISTING);
+  const fetched = await agentic.fetch({ name: 'Agentic Engineering Jobs', provider: 'agentic-jobs' }, ok.ctx);
+  if (
+    fetched.length === 2 &&
+    ok.calls.length === 1 &&
+    ok.calls[0].url === 'https://agentic-engineering-jobs.com/' &&
+    ok.calls[0].opts.redirect === 'error'
+  ) {
+    pass('agentic-jobs.fetch() fetches the listing once with redirect: error and returns the parsed jobs');
+  } else {
+    fail(`agentic-jobs.fetch(): ${fetched.length} jobs, calls = ${JSON.stringify(ok.calls.map((c) => c.url))}`);
+  }
+
+  let zeroCardsThrew = false;
+  try {
+    await agentic.fetch({ name: 'X', provider: 'agentic-jobs' }, mkCtx('<html><body>no cards here</body></html>').ctx);
+  } catch { zeroCardsThrew = true; }
+  if (zeroCardsThrew) {
+    pass('agentic-jobs.fetch() throws when the page yields zero cards (markup-change canary)');
+  } else {
+    fail('agentic-jobs.fetch() should throw when no cards parse');
+  }
+} catch (e) {
+  fail(`agentic-jobs provider tests crashed: ${e.message}`);
+}

--- a/tests/providers/agentic-jobs.test.mjs
+++ b/tests/providers/agentic-jobs.test.mjs
@@ -99,6 +99,13 @@ try {
     fail(`normalizeAgenticCard() no-location card = ${JSON.stringify(noLocation)}`);
   }
 
+  const flagSlot = normalizeAgenticCard('agent-eng-2', ['Agent Engineer', 'Globex', '🇺🇸', '2026-06-15']);
+  if (flagSlot && flagSlot.location === 'United States') {
+    pass('normalizeAgenticCard() never reads a bare flag line as the location (no-location card)');
+  } else {
+    fail(`normalizeAgenticCard() flag-in-location-slot card = ${JSON.stringify(flagSlot)}`);
+  }
+
   if (normalizeAgenticCard('bad slug!', ['Title', 'Company']) === null) {
     pass('normalizeAgenticCard() rejects path-unsafe slugs (they feed straight into a URL path)');
   } else {

--- a/tests/providers/wttj.test.mjs
+++ b/tests/providers/wttj.test.mjs
@@ -1,0 +1,271 @@
+// tests/providers/wttj.test.mjs — Welcome to the Jungle provider (public
+// Algolia search index behind welcometothejungle.com; credentials fetched
+// fresh from /api/env). Follows the discovered-test layout from #1440.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — wttj (Welcome to the Jungle Algolia index)');
+try {
+  const mod = await import(pathToFileURL(join(ROOT, 'providers/wttj.mjs')).href);
+  const wttj = mod.default;
+  const { parseEnvPayload, normalizeWttjHit } = mod;
+
+  if (wttj.id === 'wttj') pass('wttj.id is "wttj"');
+  else fail(`wttj.id is ${JSON.stringify(wttj.id)}`);
+
+  const hit = wttj.detect({ name: 'Welcome to the Jungle', provider: 'wttj' });
+  if (hit && hit.url === 'https://www.welcometothejungle.com') {
+    pass('wttj.detect() claims entries with provider: wttj');
+  } else {
+    fail(`wttj.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  if (wttj.detect({ name: 'X', provider: 'greenhouse' }) === null) {
+    pass('wttj.detect() returns null for other providers');
+  } else {
+    fail('wttj.detect() should return null for other providers');
+  }
+
+  if (wttj.detect({ name: 'X', careers_url: 'https://www.welcometothejungle.com/en/jobs' }) === null) {
+    pass('wttj.detect() does not URL-autodetect (explicit provider: wttj only — the board is global)');
+  } else {
+    fail('wttj.detect() should not claim entries by careers_url');
+  }
+
+  // parseEnvPayload — the /api/env `window.env = {...}` payload
+  const HEX_KEY = '0123456789abcdef0123456789abcdef';
+  const envText = (appId, apiKey) =>
+    `window.env = ${JSON.stringify({ PUBLIC_ALGOLIA_APPLICATION_ID: appId, PUBLIC_ALGOLIA_API_KEY_CLIENT: apiKey, OTHER: 'noise' })};`;
+
+  const creds = parseEnvPayload(envText(' AB12CD34 ', HEX_KEY));
+  if (creds.appId === 'AB12CD34' && creds.apiKey === HEX_KEY) {
+    pass('parseEnvPayload() extracts and trims the Algolia app id + client key');
+  } else {
+    fail(`parseEnvPayload() returned ${JSON.stringify(creds)}`);
+  }
+
+  // The client key is only ever sent as a header, so its format is not
+  // over-constrained — a rotated long/base64 (secured) key must still parse.
+  const securedKey = 'QWxnb2xpYSBzZWN1cmVkIGtleQ==' + 'x'.repeat(100);
+  const secured = parseEnvPayload(envText('AB12CD34', securedKey));
+  if (secured.apiKey === securedKey) {
+    pass('parseEnvPayload() accepts a long non-hex (secured/base64) client key — length bounds only');
+  } else {
+    fail(`parseEnvPayload() secured key → ${JSON.stringify(secured.apiKey)}`);
+  }
+
+  const throws = (fn) => { try { fn(); return false; } catch { return true; } };
+
+  if (throws(() => parseEnvPayload(envText('AB12CD34', 'short')))) {
+    pass('parseEnvPayload() rejects an implausibly short api key');
+  } else {
+    fail('parseEnvPayload() should reject an implausibly short api key');
+  }
+
+  if (throws(() => parseEnvPayload(envText('bad app id!', HEX_KEY)))) {
+    pass('parseEnvPayload() rejects a non-alphanumeric app id (it becomes a hostname)');
+  } else {
+    fail('parseEnvPayload() should reject a non-alphanumeric app id');
+  }
+
+  if (throws(() => parseEnvPayload('window.env = undefined;'))) {
+    pass('parseEnvPayload() rejects a payload with no JSON object');
+  } else {
+    fail('parseEnvPayload() should reject a payload with no JSON object');
+  }
+
+  if (throws(() => parseEnvPayload('window.env = {not json};'))) {
+    pass('parseEnvPayload() rejects invalid JSON');
+  } else {
+    fail('parseEnvPayload() should reject invalid JSON');
+  }
+
+  // normalizeWttjHit — Algolia hit → normalized Job
+  const fullHit = {
+    name: '  Senior Data Engineer  ',
+    slug: 'senior-data-engineer_abc123',
+    organization: { name: 'Example SAS', slug: 'example-sas' },
+    offices: [{ city: 'Paris', country: 'France' }, { city: 'Lyon', country: 'France' }],
+    remote: 'fulltime',
+    published_at_timestamp: 1751500800,
+    salary_yearly_minimum: 60000,
+    salary_maximum: 80000,
+    salary_period: 'yearly',
+    salary_currency: 'eur',
+  };
+  const j1 = normalizeWttjHit(fullHit);
+  if (
+    j1 &&
+    j1.title === 'Senior Data Engineer' &&
+    j1.url === 'https://www.welcometothejungle.com/en/companies/example-sas/jobs/senior-data-engineer_abc123' &&
+    j1.company === 'Example SAS'
+  ) {
+    pass('normalizeWttjHit() maps name/slug/organization to title/url/company');
+  } else {
+    fail(`normalizeWttjHit() job = ${JSON.stringify(j1)}`);
+  }
+
+  if (j1 && j1.location === 'Paris, France, Remote') {
+    pass('normalizeWttjHit() joins first-office city+country and appends Remote for fulltime-remote posts');
+  } else {
+    fail(`normalizeWttjHit() location = ${JSON.stringify(j1 && j1.location)}`);
+  }
+
+  if (j1 && j1.postedAt === 1751500800000) {
+    pass('normalizeWttjHit() converts published_at_timestamp epoch-seconds to ms');
+  } else {
+    fail(`normalizeWttjHit() postedAt = ${j1 && j1.postedAt}`);
+  }
+
+  if (j1 && j1.salary && j1.salary.min === 60000 && j1.salary.max === 80000 && j1.salary.currency === 'EUR') {
+    pass('normalizeWttjHit() attaches a yearly salary range with uppercased currency');
+  } else {
+    fail(`normalizeWttjHit() salary = ${JSON.stringify(j1 && j1.salary)}`);
+  }
+
+  const monthly = normalizeWttjHit({
+    ...fullHit,
+    salary_yearly_minimum: 50000,
+    salary_maximum: 5000,
+    salary_period: 'monthly',
+  });
+  if (monthly && monthly.salary && monthly.salary.min === 50000 && monthly.salary.max === 50000) {
+    pass('normalizeWttjHit() ignores a non-yearly salary_maximum (keeps only the annualized minimum)');
+  } else {
+    fail(`normalizeWttjHit() monthly-period salary = ${JSON.stringify(monthly && monthly.salary)}`);
+  }
+
+  const bare = normalizeWttjHit({ name: 'Job', slug: 'job-1', organization: { slug: 'acme' } });
+  if (bare && bare.company === 'Welcome to the Jungle' && bare.location === '' && bare.salary === undefined && bare.postedAt === undefined) {
+    pass('normalizeWttjHit() falls back to the board name and omits absent salary/postedAt');
+  } else {
+    fail(`normalizeWttjHit() bare hit = ${JSON.stringify(bare)}`);
+  }
+
+  if (normalizeWttjHit({ name: 'Job', slug: 'job-1', organization: {} }) === null) {
+    pass('normalizeWttjHit() returns null when the organization slug is missing');
+  } else {
+    fail('normalizeWttjHit() should return null without an organization slug');
+  }
+
+  if (normalizeWttjHit({ name: 'Job', slug: '../evil', organization: { slug: 'acme' } }) === null) {
+    pass('normalizeWttjHit() rejects path-unsafe slugs (they feed straight into a URL path)');
+  } else {
+    fail('normalizeWttjHit() should reject path-unsafe slugs');
+  }
+
+  if (normalizeWttjHit(null) === null && normalizeWttjHit('nope') === null) {
+    pass('normalizeWttjHit() returns null for non-object hits');
+  } else {
+    fail('normalizeWttjHit() should return null for non-object hits');
+  }
+
+  // fetch() — env bootstrap, per-query Algolia calls, headers, dedup (mocked ctx)
+  const ENV_OK = envText('AB12CD34', HEX_KEY);
+  const mkHit = (slug, title) => ({
+    name: title,
+    slug,
+    organization: { name: 'Acme', slug: 'acme' },
+    offices: [{ city: 'Paris', country: 'France' }],
+  });
+  const mkCtx = (env, hitsFor) => {
+    const textCalls = [];
+    const jsonCalls = [];
+    return {
+      textCalls,
+      jsonCalls,
+      ctx: {
+        fetchText: async (url, opts) => { textCalls.push({ url, opts }); return env; },
+        fetchJson: async (url, opts) => {
+          const params = new URLSearchParams(JSON.parse(opts.body).params);
+          const call = { url, opts, query: params.get('query'), hitsPerPage: params.get('hitsPerPage') };
+          jsonCalls.push(call);
+          return hitsFor(call);
+        },
+      },
+    };
+  };
+
+  const happy = mkCtx(ENV_OK, ({ query }) => ({
+    hits: query === 'finops'
+      ? [mkHit('job-a', 'FinOps Lead'), mkHit('job-b', 'FinOps Analyst')]
+      : [mkHit('job-b', 'FinOps Analyst'), mkHit('job-c', 'Snowflake Engineer')],
+  }));
+  const happyJobs = await wttj.fetch(
+    { name: 'WTTJ', provider: 'wttj', wttj: { queries: ['finops', 'snowflake'] } },
+    happy.ctx,
+  );
+  if (happyJobs.length === 3 && happy.jsonCalls.length === 2) {
+    pass('wttj.fetch() runs one Algolia query per configured search and dedupes across queries');
+  } else {
+    fail(`wttj.fetch(): ${happyJobs.length} jobs from ${happy.jsonCalls.length} queries`);
+  }
+
+  if (
+    happy.textCalls.length === 1 &&
+    happy.textCalls[0].url === 'https://www.welcometothejungle.com/api/env' &&
+    happy.textCalls[0].opts.redirect === 'error'
+  ) {
+    pass('wttj.fetch() bootstraps credentials from /api/env with redirect: error');
+  } else {
+    fail(`wttj.fetch() env calls = ${JSON.stringify(happy.textCalls.map((c) => c.url))}`);
+  }
+
+  const q1 = happy.jsonCalls[0];
+  if (q1.url === 'https://AB12CD34-dsn.algolia.net/1/indexes/wttj_jobs_production_en/query') {
+    pass('wttj.fetch() derives the Algolia host from the fetched app id');
+  } else {
+    fail(`wttj.fetch() Algolia URL = ${q1.url}`);
+  }
+
+  if (
+    q1.opts.headers['x-algolia-application-id'] === 'AB12CD34' &&
+    q1.opts.headers['x-algolia-api-key'] === HEX_KEY &&
+    q1.opts.headers.referer === 'https://www.welcometothejungle.com/' &&
+    q1.opts.redirect === 'error'
+  ) {
+    pass('wttj.fetch() sends the app id, api key, and the referer the key is locked to');
+  } else {
+    fail(`wttj.fetch() Algolia headers = ${JSON.stringify(q1.opts.headers)}`);
+  }
+
+  if (q1.hitsPerPage === '100' && happy.jsonCalls.map((c) => c.query).join(',') === 'finops,snowflake') {
+    pass('wttj.fetch() defaults to 100 hits per query and passes each search term through');
+  } else {
+    fail(`wttj.fetch() hitsPerPage=${q1.hitsPerPage}, queries=${happy.jsonCalls.map((c) => c.query).join(',')}`);
+  }
+
+  const capped = mkCtx(ENV_OK, () => ({ hits: [] }));
+  await wttj.fetch({ name: 'WTTJ', provider: 'wttj', wttj: { queries: ['x'], max_hits: 500 } }, capped.ctx);
+  if (capped.jsonCalls[0].hitsPerPage === '200') {
+    pass('wttj.fetch() caps max_hits at 200 per query');
+  } else {
+    fail(`wttj.fetch() max_hits=500 → hitsPerPage=${capped.jsonCalls[0].hitsPerPage}`);
+  }
+
+  let noQueriesThrew = false;
+  try {
+    await wttj.fetch({ name: 'WTTJ', provider: 'wttj' }, mkCtx(ENV_OK, () => ({ hits: [] })).ctx);
+  } catch { noQueriesThrew = true; }
+  if (noQueriesThrew) {
+    pass('wttj.fetch() throws without an explicit wttj.queries config (never scans the whole board)');
+  } else {
+    fail('wttj.fetch() should throw when wttj.queries is missing');
+  }
+
+  let badShapeThrew = false;
+  try {
+    await wttj.fetch(
+      { name: 'WTTJ', provider: 'wttj', wttj: { queries: ['x'] } },
+      mkCtx(ENV_OK, () => ({ error: 'nope' })).ctx,
+    );
+  } catch { badShapeThrew = true; }
+  if (badShapeThrew) {
+    pass('wttj.fetch() throws on an Algolia response without a hits array');
+  } else {
+    fail('wttj.fetch() should throw on a malformed Algolia response');
+  }
+} catch (e) {
+  fail(`wttj provider tests crashed: ${e.message}`);
+}

--- a/tests/providers/wttj.test.mjs
+++ b/tests/providers/wttj.test.mjs
@@ -244,27 +244,28 @@ try {
     fail(`wttj.fetch() max_hits=500 → hitsPerPage=${capped.jsonCalls[0].hitsPerPage}`);
   }
 
-  let noQueriesThrew = false;
+  let noQueriesErr = '';
   try {
     await wttj.fetch({ name: 'WTTJ', provider: 'wttj' }, mkCtx(ENV_OK, () => ({ hits: [] })).ctx);
-  } catch { noQueriesThrew = true; }
-  if (noQueriesThrew) {
+  } catch (err) { noQueriesErr = err.message; }
+  // Assert the message, not just that something threw — an unrelated crash must not pass.
+  if (noQueriesErr.includes('wttj: the WTTJ board is global')) {
     pass('wttj.fetch() throws without an explicit wttj.queries config (never scans the whole board)');
   } else {
-    fail('wttj.fetch() should throw when wttj.queries is missing');
+    fail(`wttj.fetch() missing-queries error = ${JSON.stringify(noQueriesErr) || 'did not throw'}`);
   }
 
-  let badShapeThrew = false;
+  let badShapeErr = '';
   try {
     await wttj.fetch(
       { name: 'WTTJ', provider: 'wttj', wttj: { queries: ['x'] } },
       mkCtx(ENV_OK, () => ({ error: 'nope' })).ctx,
     );
-  } catch { badShapeThrew = true; }
-  if (badShapeThrew) {
+  } catch (err) { badShapeErr = err.message; }
+  if (badShapeErr.includes('wttj: unexpected Algolia response') && badShapeErr.includes('expected { hits: [...] }')) {
     pass('wttj.fetch() throws on an Algolia response without a hits array');
   } else {
-    fail('wttj.fetch() should throw on a malformed Algolia response');
+    fail(`wttj.fetch() malformed-response error = ${JSON.stringify(badShapeErr) || 'did not throw'}`);
   }
 } catch (e) {
   fail(`wttj provider tests crashed: ${e.message}`);


### PR DESCRIPTION
## What does this PR do?

Adds two zero-auth scanner providers:

- **`providers/wttj.mjs` — Welcome to the Jungle.** Queries WTTJ's public Algolia jobs index (the same one the site UI calls). The Algolia app id and referer-locked client search key rotate, so they are fetched fresh from `https://www.welcometothejungle.com/api/env` on every run instead of being hardcoded. The board is global and enormous, so an explicit `wttj: { queries: [...] }` config block is required — the provider throws a clear error rather than silently scanning an arbitrary slice. Hits carry salary data, attached as `{min, max, currency}` so `salary_filter` can gate on it. Both request hosts are pinned (env endpoint + derived `*.algolia.net` host validated against the app id shape) with `redirect: 'error'`, matching the SSRF conventions of the other providers.

- **`providers/agentic-jobs.mjs` — agentic-engineering-jobs.com.** The site has no API, but every job card is server-rendered inside a `data-impression-slug` container, so the full listing parses from one page fetch — zero tokens, no browser. Country flag emoji on the cards are decoded to English country names (`Intl.DisplayNames`) and appended to the location, so `location_filter` correctly gates non-US postings that otherwise just say "Remote". Parsing 0 cards throws (markup-change canary) instead of returning an empty success.

Both wire in via `job_boards:` entries (`provider: wttj` / `provider: agentic-jobs`) and export their normalizers for unit tests.

Verified live 2026-07-11: wttj returned 191 jobs across 2 test queries (with correct salary + location mapping); agentic-jobs returned 50. A full `scan.mjs --dry-run` with both enabled completed with zero provider errors.

## Related issue

None — new zero-auth scanner providers are exempt per the template.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (1537 passed, 0 failed)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new job-board providers: Agentic Engineering Jobs (SSR HTML parsing, country decoding, URL-based deduplication) and Welcome to the Jungle (per-term search, remote location handling, optional salary normalization).
  * Expanded the sample portals configuration to include both providers.
* **Bug Fixes**
  * Added stricter validation of trusted HTTPS endpoints/credentials and safer hit/card normalization, with clear errors when expected markup/response shapes change.
* **Tests**
  * Added comprehensive provider-specific test suites for both integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->