### PR TITLE
fix(auto-pipeline): remove duplicated "Agency-mediated postings" paragraph

### DIFF
--- a/modes/auto-pipeline.md
+++ b/modes/auto-pipeline.md
@@ -40,8 +40,6 @@ Execute the same as the `oferta` mode (read `modes/oferta.md` for all A-F blocks
 
 **Agency-mediated postings (#1596):** if the JD smells like a recruiter/agency listing ("our client", agency domain, no employer named), ask the user which agency it came through BEFORE writing the tracker row. Record the end employer as `?` (never "Confidential"), the agency in the Via field / `via=` TSV tag, and a distinguishing descriptor in Notes — see `modes/oferta.md` and `modes/tracker.md` for the full convention and reveal workflow.
 
-**Agency-mediated postings (#1596):** if the JD smells like a recruiter/agency listing ("our client", agency domain, no employer named), ask the user which agency it came through BEFORE writing the tracker row. Record the end employer as `?` (never "Confidential"), the agency in the Via field / `via=` TSV tag, and a distinguishing descriptor in Notes — see `modes/oferta.md` and `modes/tracker.md` for the full convention and reveal workflow.
-
 The evaluation inherits `oferta`'s bounded research budget. Company, compensation, and hiring-signal lookup must not invoke `deep-research`, must not spawn subagents, and must stop at the shared query cap instead of escalating into open-ended research.
 
 ## Step 2 — Save Report .md


### PR DESCRIPTION
A copy-paste slip left the #1596 agency-mediated guidance duplicated verbatim, back-to-back, in `modes/auto-pipeline.md` Step 1 (two identical paragraphs). Removes the duplicate — the remaining copy is byte-for-byte unchanged, so no guidance is lost.

`node test-all.mjs --quick` → all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the agency-mediated postings instruction from the Step 1 evaluation guidance.
  * Simplified the evaluation flow by eliminating the intermediary prompting rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->