### PR TITLE
feat(browser-extract): configurable jd-mode text cap via --max-chars (avoid silently truncating long JDs)

### DIFF
--- a/browser-extract.mjs
+++ b/browser-extract.mjs
@@ -12,7 +12,10 @@
  * fills — that boundary is exactly what keeps this separate from `apply`.
  *
  * Usage:
- *   node browser-extract.mjs <url> [--mode jd|listing] [--max N] [--timeout MS]
+ *   node browser-extract.mjs <url> [--mode jd|listing] [--max N] [--max-chars N] [--timeout MS]
+ *
+ * `--max-chars` overrides the jd-mode text cap (default 12000) — raise it when a
+ * long JD would otherwise be truncated at the tail, at the cost of more tokens.
  *
  * Modes:
  *   jd (default) — one posting page → { url, title, text }. `text` is the main
@@ -80,11 +83,11 @@ export function compactText(s, cap = JD_TEXT_CAP) {
  * @param {{ title?: string, text?: string }} raw
  * @param {string} finalUrl
  */
-export function normalizeJd(raw, finalUrl) {
+export function normalizeJd(raw, finalUrl, textCap = JD_TEXT_CAP) {
   return {
     url: finalUrl,
     title: compactText(raw?.title || '', 300),
-    text: compactText(raw?.text || ''),
+    text: compactText(raw?.text || '', textCap),
   };
 }
 
@@ -127,10 +130,11 @@ export function normalizeListing(anchors, finalUrl, max = DEFAULT_LISTING_MAX) {
  * @param {string[]} argv - process.argv.slice(2)
  */
 export function parseArgs(argv) {
-  const FLAGS = new Set(['--mode', '--max', '--timeout']);
+  const FLAGS = new Set(['--mode', '--max', '--max-chars', '--timeout']);
   let url;
   let mode = 'jd';
   let max = DEFAULT_LISTING_MAX;
+  let maxChars = JD_TEXT_CAP;
   let timeout = DEFAULT_TIMEOUT_MS;
   for (let i = 0; i < argv.length; i++) {
     const tok = argv[i];
@@ -139,12 +143,13 @@ export function parseArgs(argv) {
       const n = Number(val);
       if (tok === '--mode' && val != null) mode = val;
       else if (tok === '--max' && Number.isInteger(n) && n >= 0) max = n;
+      else if (tok === '--max-chars' && Number.isInteger(n) && n > 0) maxChars = n;
       else if (tok === '--timeout' && Number.isInteger(n) && n > 0) timeout = n;
     } else if (!tok.startsWith('--') && url === undefined) {
       url = tok;
     }
   }
-  return { url, mode, max, timeout };
+  return { url, mode, max, maxChars, timeout };
 }
 
 // Read the raw DOM inside the page: title, main visible text, and visible
@@ -177,10 +182,10 @@ async function readDom(page) {
 }
 
 async function main() {
-  const { url, mode, max, timeout } = parseArgs(process.argv.slice(2));
+  const { url, mode, max, maxChars, timeout } = parseArgs(process.argv.slice(2));
 
   if (!url) {
-    console.error(JSON.stringify({ error: 'usage: browser-extract.mjs <url> [--mode jd|listing] [--max N]', code: 'no_url' }));
+    console.error(JSON.stringify({ error: 'usage: browser-extract.mjs <url> [--mode jd|listing] [--max N] [--max-chars N]', code: 'no_url' }));
     process.exit(1);
   }
   if (mode !== 'jd' && mode !== 'listing') {
@@ -230,7 +235,7 @@ async function main() {
 
     const result = mode === 'listing'
       ? normalizeListing(raw.anchors, finalUrl, max)
-      : normalizeJd(raw, finalUrl);
+      : normalizeJd(raw, finalUrl, maxChars);
     process.stdout.write(JSON.stringify(result));
   } catch (err) {
     console.error(JSON.stringify({ error: `navigation error: ${String(err.message).split('\n')[0]}`, code: 'navigation_error' }));

--- a/tests/browser-extract.test.mjs
+++ b/tests/browser-extract.test.mjs
@@ -47,6 +47,17 @@ try {
   if (badMax.max === 200) pass('parseArgs falls back to the default for a non-integer --max');
   else fail(`parseArgs --max abc => ${badMax.max}`);
 
+  // parseArgs --max-chars (#configurable JD cap): overrides the jd text cap,
+  // defaults to 12000, and rejects non-positive/non-integer values.
+  if (parseArgs(['https://x/1']).maxChars === 12000) pass('parseArgs defaults maxChars to the 12000 JD cap');
+  else fail(`parseArgs default maxChars => ${parseArgs(['https://x/1']).maxChars}`);
+  const bigChars = parseArgs(['https://x/1', '--max-chars', '40000']);
+  if (bigChars.maxChars === 40000) pass('parseArgs honors an explicit --max-chars');
+  else fail(`parseArgs --max-chars 40000 => ${bigChars.maxChars}`);
+  const badChars = parseArgs(['https://x/1', '--max-chars', '0']);
+  if (badChars.maxChars === 12000) pass('parseArgs ignores a non-positive --max-chars (keeps the default cap)');
+  else fail(`parseArgs --max-chars 0 => ${badChars.maxChars}`);
+
   // compactText — collapse whitespace + cap length
   if (compactText('a   b\t\tc') === 'a b c') pass('compactText collapses runs of whitespace');
   else fail(`compactText => ${JSON.stringify(compactText('a   b\t\tc'))}`);
@@ -60,6 +71,18 @@ try {
     pass('normalizeJd shapes { url, title, text } and compacts both');
   } else {
     fail(`normalizeJd => ${JSON.stringify(jd)}`);
+  }
+
+  // normalizeJd honors a custom text cap (a long JD is truncated at the cap, not
+  // silently at the 12000 default) while leaving the default behavior unchanged.
+  const longText = 'y'.repeat(20000);
+  const raised = normalizeJd({ title: 'Role', text: longText }, 'https://x/1', 15000);
+  const defaulted = normalizeJd({ title: 'Role', text: longText }, 'https://x/1');
+  if (raised.text.length === 15001 && raised.text.endsWith('…') &&
+      defaulted.text.length === 12001 && defaulted.text.endsWith('…')) {
+    pass('normalizeJd applies a custom textCap and defaults to the 12000 JD cap');
+  } else {
+    fail(`normalizeJd textCap => raised=${raised.text.length} default=${defaulted.text.length}`);
   }
 
   // normalizeListing — resolve relatives, drop nav/short labels, dedup, cap

--- a/tests/browser-extract.test.mjs
+++ b/tests/browser-extract.test.mjs
@@ -57,6 +57,9 @@ try {
   const badChars = parseArgs(['https://x/1', '--max-chars', '0']);
   if (badChars.maxChars === 12000) pass('parseArgs ignores a non-positive --max-chars (keeps the default cap)');
   else fail(`parseArgs --max-chars 0 => ${badChars.maxChars}`);
+  const nonIntChars = parseArgs(['https://x/1', '--max-chars', '1.5']);
+  if (nonIntChars.maxChars === 12000) pass('parseArgs ignores a non-integer --max-chars (keeps the default cap)');
+  else fail(`parseArgs --max-chars 1.5 => ${nonIntChars.maxChars}`);
 
   // compactText — collapse whitespace + cap length
   if (compactText('a   b\t\tc') === 'a b c') pass('compactText collapses runs of whitespace');


### PR DESCRIPTION
## Problem
`browser-extract.mjs` (jd mode) hard-caps the extracted JD text at 12000 chars (~3K tokens). That's a sensible default for token economy, but a long posting is **silently truncated at the tail** — and I hit this for real while measuring #1449 Phase 2: a live Anthropic Greenhouse JD extracts to 12198 chars, i.e. clipped right at the cap. With #1449 Phase 2 routing `oferta`/`auto-pipeline` JD extraction through this helper, a clipped tail can drop genuine requirements before the A–G evaluation ever sees them.

## Change
Add an opt-in `--max-chars N` flag to override the jd text cap:
- threaded `parseArgs` → `normalizeJd(raw, finalUrl, textCap)` → `compactText(text, cap)`
- **default stays 12000** — no behavior change unless a user opts in to trade tokens for a complete long JD
- non-positive / non-integer values fall back to the default (same guard style as `--max`)

Listing mode and the token-economy default are untouched; this is purely an escape hatch for the occasional long JD.

## Tests
`node test-all.mjs --quick` → **1695 passed, 0 failed**. New coverage: `--max-chars` parsing (explicit, default, invalid→default) and `normalizeJd` honoring a custom cap while the default remains 12000.

2 commits: impl · tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--max-chars` option to customize the maximum job description text length.
  * Job description output now uses the specified character cap (with the existing default retained when not provided).
  * Updated command-line usage and error messages to include the new option.
* **Bug Fixes**
  * Improved validation so `--max-chars` accepts only positive integers; invalid values fall back to the default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->