### PR TITLE
fix(scan): restore browser-like headers on Workday CXS requests

### DIFF
--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -4,6 +4,13 @@
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_USER_AGENT = 'Mozilla/5.0 (compatible; career-ops/1.3)';
 
+// Some providers sit behind WAF/CDN bot management (seen live: Glints,
+// Geico's Workday tenant) that blocks the default career-ops UA outright.
+// Shared so every provider working around such a block bumps one constant
+// instead of drifting Chrome versions independently per file.
+export const BROWSER_LIKE_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+
 async function fetchWithTimeout(url, { timeoutMs = DEFAULT_TIMEOUT_MS, headers = {}, method = 'GET', body = null, redirect = 'follow' } = {}) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);

--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -4,10 +4,13 @@
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_USER_AGENT = 'Mozilla/5.0 (compatible; career-ops/1.3)';
 
-// Some providers sit behind WAF/CDN bot management (seen live: Glints,
-// Geico's Workday tenant) that blocks the default career-ops UA outright.
-// Shared so every provider working around such a block bumps one constant
-// instead of drifting Chrome versions independently per file.
+/**
+ * Browser-like User-Agent for providers that must clear WAF/CDN bot
+ * management blocking the default career-ops UA outright (seen live:
+ * Glints' firewall, Geico's Cloudflare-gated Workday tenant). Shared so
+ * every provider working around such a block bumps one constant instead
+ * of drifting Chrome versions independently per file.
+ */
 export const BROWSER_LIKE_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
 

--- a/providers/glints.mjs
+++ b/providers/glints.mjs
@@ -20,6 +20,8 @@
 //   graphqlQuery    — Custom GraphQL query string. If not provided, the
 //                     built-in default query is used.
 
+import { BROWSER_LIKE_USER_AGENT } from './_http.mjs';
+
 const DEFAULT_API = 'https://glints.com/api/v2-alc/graphql';
 const DEFAULT_COUNTRY = 'ID';
 const DEFAULT_PAGE_SIZE = 30;
@@ -153,7 +155,7 @@ async function graphqlPage(apiUrl, query, variables, ctx) {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+        'user-agent': BROWSER_LIKE_USER_AGENT,
         'origin': 'https://glints.com',
         'referer': 'https://glints.com/id/opportunities/jobs/explore',
       },

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -132,6 +132,7 @@ function resolveEndpoint(entry) {
       // externalPath is relative to the site, not the host root — without the
       // site segment the URL 404s.
       jobBase: `${origin}/${site}`,
+      origin,
     };
   }
   return null;
@@ -188,7 +189,24 @@ export default {
     const ep = resolveEndpoint(entry);
     if (!ep) throw new Error(`workday: cannot derive CXS endpoint for ${entry.name}`);
 
-    const postOpts = { method: 'POST', redirect: 'error', headers: { 'content-type': 'application/json', accept: 'application/json' } };
+    // Some tenants front their CXS API with Cloudflare bot management (seen
+    // live: geico) that 500s requests missing ordinary browser headers —
+    // the default UA/accept-language-less request trips it even over plain
+    // HTTPS with no other red flags. A real Chrome UA + accept-language +
+    // matching origin/referer clears it without needing per-tenant config
+    // (same fix as providers/glints.mjs's firewall).
+    const postOpts = {
+      method: 'POST',
+      redirect: 'error',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+        'accept-language': 'en-US,en;q=0.9',
+        origin: ep.origin,
+        referer: `${ep.jobBase}/`,
+      },
+    };
     const makeBody = (offset) => JSON.stringify({ limit: PAGE_SIZE, offset, searchText: '', appliedFacets: {} });
     const sinceMs = typeof ctx?.sinceMs === 'number' ? ctx.sinceMs : null;
 

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -11,6 +11,8 @@
 // "Posted 5 Days Ago", "Posted 30+ Days Ago"); postedAt is derived from it
 // and omitted for the unbounded "30+ Days Ago" form.
 
+import { BROWSER_LIKE_USER_AGENT } from './_http.mjs';
+
 const PAGE_SIZE = 20;
 
 // Safety cap on pagination — applied regardless of what the upstream reports
@@ -201,7 +203,7 @@ export default {
       headers: {
         'content-type': 'application/json',
         accept: 'application/json',
-        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+        'user-agent': BROWSER_LIKE_USER_AGENT,
         'accept-language': 'en-US,en;q=0.9',
         origin: ep.origin,
         referer: `${ep.jobBase}/`,

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -187,16 +187,25 @@ export default {
     return ep ? { url: ep.api } : null;
   },
 
+  /**
+   * Fetch all job postings for a Workday-backed entry, paginating through
+   * the tenant's CXS API.
+   *
+   * Some tenants front their CXS API with Cloudflare bot management (seen
+   * live: geico) that 500s requests missing ordinary browser headers — the
+   * default UA/accept-language-less request trips it even over plain HTTPS
+   * with no other red flags. A real Chrome UA + accept-language + matching
+   * origin/referer clears it without needing per-tenant config (same fix
+   * as providers/glints.mjs's firewall).
+   *
+   * @param {{ name?: string, api?: string, careers_url?: string, max_pages?: number }} entry
+   * @param {{ fetchJson: (url: string, opts?: object) => Promise<any>, sinceMs?: number, maxPages?: number }} ctx
+   * @returns {Promise<Array<{title: string, url: string, company: string, location: string, postedAt?: number}>>}
+   */
   async fetch(entry, ctx) {
     const ep = resolveEndpoint(entry);
     if (!ep) throw new Error(`workday: cannot derive CXS endpoint for ${entry.name}`);
 
-    // Some tenants front their CXS API with Cloudflare bot management (seen
-    // live: geico) that 500s requests missing ordinary browser headers —
-    // the default UA/accept-language-less request trips it even over plain
-    // HTTPS with no other red flags. A real Chrome UA + accept-language +
-    // matching origin/referer clears it without needing per-tenant config
-    // (same fix as providers/glints.mjs's firewall).
     const postOpts = {
       method: 'POST',
       redirect: 'error',


### PR DESCRIPTION
Fixes #1811

## Problem

`providers/workday.mjs` sends a bare POST (no User-Agent/Accept-Language/
Origin/Referer) to the Workday CXS API. Some tenants — observed live:
Geico — front their CXS endpoint with Cloudflare bot management that 500s
requests missing ordinary browser headers, even though curl and a
browser-shaped request succeed.

## Fix

Add a real Chrome UA plus Accept-Language/Origin/Referer to the CXS POST,
mirroring the same fix already used in `providers/glints.mjs` for its
firewall. No per-tenant config needed — this clears the block for any
Workday tenant behind similar bot management.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job fetching reliability for Workday by adding accurate request `origin` and referrer details and sending more browser-like headers.
  * Applied the same improved request header setup consistently to both the first page and subsequent paginated Workday requests.
  * Updated Glints job search requests to use a shared browser-like user-agent value to help reduce bot-blocking issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->