### PR TITLE
feat(interview-prep): URL entry path — prep for a role that was never evaluated (#1816)

### DIFF
--- a/modes/interview-prep.md
+++ b/modes/interview-prep.md
@@ -11,6 +11,32 @@ When the user asks to prep for an interview at a specific company+role, or when 
 5. **Profile** at `config/profile.yml` + `modes/_profile.md` — read for candidate context
 6. **Recruiter-side risk map** from the evaluation/PDF/application flow if present — use `modes/heuristics/recruiter-side.md` for the risk categories the interview process must resolve
 
+## URL entry — prep for a role that was never evaluated
+
+The inputs above are report-first, but a common path skips evaluation entirely: a referral, a recruiter reaching out directly, or an interview booked for a posting that never ran through the pipeline. When there is no report, ingest the JD from the URL instead.
+
+**Trigger — both conditions required:**
+
+1. The user **explicitly asks to prep** and provides a JD URL (e.g. "prep me for this", "interview prep: <URL>", `/career-ops interview-prep <URL>`). A pasted URL alone is NOT enough — per AGENTS.md, a bare URL routes to `auto-pipeline`, not here.
+2. **No matching report exists** in `reports/` for that company+role. If a report DOES exist, ignore the URL fetch and use the report — the report stays authoritative.
+
+**Fetch ladder** — same as `modes/oferta.md` and the AGENTS.md Offer Verification rule; JD fetching follows the same ladder:
+
+1. For ATS-shaped URLs (Greenhouse / Lever / Ashby / Workday — the four `liveness-core.mjs` already recognizes), the structured API endpoint may serve the JD directly.
+2. Otherwise Playwright: `browser_navigate` → `browser_snapshot`, read title, URL, and visible content.
+3. WebFetch **only** as the headless/batch fallback. If the JD came from WebFetch, mark the prep output header `**JD source:** unconfirmed (fetched without browser)`.
+4. Closed/expired posting (footer/navbar only, "no longer accepting applications", 404) → tell the user and ask them to paste the JD text instead. **Never fabricate JD content.**
+
+**From the fetched JD, extract:** role title, seniority, key requirements, named team/stack. Feed the normal Step 1+ research flow with these instead of report-derived archetype/gaps — everything downstream is unchanged. Questions derived from the fetched JD keep the `[inferred from JD]` tag.
+
+**What this path does NOT do:**
+
+| Out of scope | Belongs to |
+|--------------|------------|
+| Tracker writes — prep from URL is read-only on the pipeline | normal apply flow owns the tracker |
+| CV generation | `pdf` mode |
+| Contact automation | `contacto` |
+
 ## Step 1 — Research
 
 Run these WebSearch queries. Extract structured data, not summaries. Cite sources for every claim.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7896,6 +7896,59 @@ console.log('\n60. Cover-letter template resolver (generate-cover-letter.mjs)');
   else fail('cover-resolver unit tests failed (run: node --test test/cover-resolver.test.mjs)');
 }
 
+// ── 61. INTERVIEW-PREP URL ENTRY (#1816) ────────────────────────
+// Prompt-level slice: prep for a role that was never evaluated. Pins the
+// disambiguation rule (bare URL still routes to auto-pipeline), the
+// report-stays-authoritative rule, the oferta fetch ladder, and the
+// read-only-on-the-pipeline scope guard.
+
+console.log('\n61. Interview-prep URL entry (#1816)');
+
+try {
+  const prepMode = readFile('modes/interview-prep.md');
+  // Whitespace-normalized view so pinned phrases survive markdown re-wrapping.
+  const prepFlat = prepMode.replace(/\s+/g, ' ');
+
+  if (prepMode.includes('## URL entry — prep for a role that was never evaluated')) {
+    pass('interview-prep mode has the URL entry section (#1816)');
+  } else {
+    fail('interview-prep mode missing the "URL entry — prep for a role that was never evaluated" section');
+  }
+
+  if (
+    prepFlat.includes('If a report DOES exist, ignore the URL fetch and use the report — the report stays authoritative') &&
+    prepFlat.includes('a bare URL routes to `auto-pipeline`, not here')
+  ) {
+    pass('interview-prep URL entry: report stays authoritative, bare URL still routes to auto-pipeline');
+  } else {
+    fail('interview-prep URL entry missing the report-stays-authoritative rule or the auto-pipeline disambiguation rule');
+  }
+
+  if (
+    prepMode.includes('browser_navigate') &&
+    prepMode.includes('browser_snapshot') &&
+    prepFlat.includes('WebFetch **only** as the headless/batch fallback') &&
+    prepMode.includes('**JD source:** unconfirmed (fetched without browser)') &&
+    prepMode.includes('Never fabricate JD content')
+  ) {
+    pass('interview-prep URL entry quotes the oferta fetch ladder (Playwright first, WebFetch fallback marks JD source unconfirmed)');
+  } else {
+    fail('interview-prep URL entry missing the canonical fetch ladder (browser_navigate/browser_snapshot first, marked WebFetch fallback, no fabricated JD)');
+  }
+
+  if (
+    prepFlat.includes('read-only on the pipeline') &&
+    prepMode.includes('`pdf` mode') &&
+    prepMode.includes('`contacto`')
+  ) {
+    pass('interview-prep URL entry scope guard: no tracker writes, CV generation stays in pdf, contact automation stays in contacto');
+  } else {
+    fail('interview-prep URL entry missing the out-of-scope guard (tracker read-only / pdf / contacto)');
+  }
+} catch (e) {
+  fail(`modes/interview-prep.md missing or unreadable: ${e.message}`);
+}
+
 console.log('\nTest layout guard (provider tests live in tests/providers/)');
 try {
   const src = readFileSync(join(ROOT, 'test-all.mjs'), 'utf-8');


### PR DESCRIPTION
## Problem

`modes/interview-prep.md` is report-first: its inputs assume an evaluation report already exists in `reports/`. That covers the happy path, but a very common real-world path skips evaluation entirely — a referral, a recruiter reaching out directly, or an interview invite for a posting that never ran through the pipeline. Today the prep chain just breaks there.

Closes #1816

## Shape

This is the interview-domain twin of #1739's targeted-`<URL>` slot for `/upskill` — its spec language applies verbatim: **"JD fetching follows the same ladder."** No new mode file: a "URL entry" section inside `modes/interview-prep.md`, mirroring how #1739 scopes its "Targeted mode" section in `modes/upskill.md`.

- **Trigger** requires explicit prep intent + a JD URL + no matching report. A bare pasted URL still routes to `auto-pipeline` per AGENTS.md. If a report DOES exist, the URL fetch is ignored — the report stays authoritative.
- **Fetch ladder** quotes the canonical one from `modes/oferta.md` / the AGENTS.md Offer Verification rule: ATS structured endpoints for Greenhouse/Lever/Ashby/Workday-shaped URLs (`liveness-core.mjs` already recognizes all four), then Playwright (`browser_navigate` → `browser_snapshot`), then WebFetch only as the headless/batch fallback — marked `**JD source:** unconfirmed (fetched without browser)`. Closed/expired posting → ask the user to paste the JD text; never fabricate JD content.
- **Downstream unchanged**: role title / seniority / key requirements / team+stack extracted from the JD feed the normal Step 1+ research flow; JD-derived questions keep the existing `[inferred from JD]` tag.
- **Out of scope** (per the issue): no tracker writes (read-only on the pipeline), no CV generation (`pdf` mode), no contact automation (`contacto`).

## What changed

- `modes/interview-prep.md` — new `## URL entry — prep for a role that was never evaluated` section between Inputs and Step 1.
- `test-all.mjs` — new section 61 pinning the section heading, the report-stays-authoritative + auto-pipeline disambiguation rules, the fetch ladder, and the out-of-scope guard (mirrors the section-58 titles-mode doc-assertion style).

No new files, no new dependencies. `modes/interview-prep.md` and `test-all.mjs` are already in `update-system.mjs` SYSTEM_PATHS.

## Verification

`node test-all.mjs`: **1704 passed, 0 failed** (1 pre-existing environment warning: `cv-sync-check.mjs` without user data).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a URL-based interview preparation path for job postings without an existing evaluation report.
  - Retrieves job description details through supported sources and incorporates them into the standard research and question workflow.
  - Questions derived from the posting are clearly marked as inferred.
  - Handles expired or inaccessible postings by requesting pasted job description text without fabricating details.
  - Clarifies that URL-based preparation does not update trackers, generate CVs, or automate contact actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->