### PR TITLE
feat(providers): add Meituan careers provider

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -33,6 +33,7 @@ are shared helpers and are not loaded as providers.
 | LaraJobs | RSS | Reads the board-wide `https://larajobs.com/feed` RSS feed (Laravel / PHP jobs) and parses it in-process. Configure with `provider: larajobs`; company and location come from the feed's `job:` namespace. |
 | Lever | API | Auto-detects `https://jobs.(eu.)?lever.co/<slug>` boards and uses Lever's public postings endpoint. |
 | Local parser | Parser | Runs an in-repo parser command from `portals.yml`. Use this for stable SSR or HTML pages that need a custom extractor. |
+| Meituan Careers | API | Auto-detects `https://zhaopin.meituan.com` URLs (host-matched, HTTPS-only) and posts to the public zero-auth getJobList JSON API (zh-CN social-hiring listings with title, department, city, JD text, refresh date). Each `keywords:` entry is queried server-side separately and results are deduped; omit `keywords:` to pull the whole board. Paginates up to `max_pages` per keyword (default 30, 100 posts/page), retrying empty mid-pagination pages (the board rate-limits sporadically). |
 | No Fluff Jobs | API | Auto-detects `nofluffjobs.com` and reads its public `/api/search/posting` API (Polish/EU tech board); paginates up to `max_pages` (default 5). |
 | NoDesk | RSS | Reads the public `https://nodesk.co/remote-jobs/index.xml` feed and parses it in-process. Configure with `provider: nodesk`. |
 | Personio | RSS | Auto-detects `<slug>.jobs.personio.de` or `.com` hosts and parses the public XML jobs feed. |

--- a/providers/meituan.mjs
+++ b/providers/meituan.mjs
@@ -1,0 +1,177 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Meituan careers provider — posts to the public zhaopin.meituan.com JSON API
+// (no auth, no browser, no special headers). Verified 2026-07 by capturing the
+// site's own XHR:
+//   POST /api/official/job/getJobList
+//   { "page": {"pageNo": N, "pageSize": 100},   ← nested pagination (a flat
+//     "keywords": "大模型",                        {pageNo} is silently ignored
+//     "jobShareType": "1",                         and always returns page 1)
+//     "jobType": [{"code": "3", "subCode": []}], ← 3 = social hiring (社招)
+//     "cityList": [], "department": [], "jfJgList": [], "typeCode": [], "specialCode": [] }
+//
+// portals.yml entry example:
+//   - name: 美团
+//     careers_url: https://zhaopin.meituan.com/web/social   # auto-detected
+//     keywords: ["AI", "大模型"]   # each keyword is a separate server-side query, results deduped;
+//                                  # omit to pull the whole board (~2300 postings)
+//     max_pages: 30                # per keyword, pageSize 100
+
+const API_HOST = 'zhaopin.meituan.com';
+const API = `https://${API_HOST}/api/official/job/getJobList`;
+const DETAIL = `https://${API_HOST}/web/position/detail?jobUnionId=`;
+const PAGE_SIZE = 100;
+const DEFAULT_KEYWORDS = [''];  // empty keyword = the whole board, no topical bias
+const DEFAULT_MAX_PAGES = 30;
+// Every request after the first pays it — across pages and keyword switches
+// (same idiom as avature/workday); 400ms instead of their 150 because this
+// board rate-limits harder (see EMPTY_RETRIES below).
+const INTER_PAGE_DELAY_MS = 400;
+// The board sporadically answers a mid-pagination request with an empty list
+// (observed live; reads as rate-limiting) — retry with backoff before
+// concluding a keyword is exhausted.
+const EMPTY_RETRIES = 2;
+const RETRY_BACKOFF_MS = 1500;
+
+function toEpochMs(v) {
+  if (v == null) return undefined;
+  if (typeof v === 'number') return v > 1e12 ? v : v * 1000;
+  const parsed = Date.parse(v);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/** cityList/department items are objects like {name: "北京市"} */
+function names(arr) {
+  if (!Array.isArray(arr)) return '';
+  return arr.map(x => (typeof x === 'string' ? x : x?.name)).filter(Boolean).join('/');
+}
+
+function buildBody(keywords, pageNo) {
+  return JSON.stringify({
+    page: { pageNo, pageSize: PAGE_SIZE },
+    keywords,
+    jobShareType: '1',
+    jobType: [{ code: '3', subCode: [] }],
+    cityList: [], department: [], jfJgList: [], typeCode: [], specialCode: [],
+  });
+}
+
+/**
+ * Parse one page of the getJobList payload.
+ * Exported for tests.
+ * @param {any} json
+ * @param {string} companyName
+ * @returns {{ jobs: import('./_types.js').Job[], total: number }}
+ */
+export function parseMeituanResponse(json, companyName) {
+  const list = json?.data?.list;
+  const total = Number(json?.data?.page?.totalCount) || 0;
+  if (!Array.isArray(list)) return { jobs: [], total };
+
+  const jobs = [];
+  for (const p of list) {
+    const title = p.name || '';
+    const id = p.jobUnionId;
+    if (!title || !id) continue;
+    jobs.push({
+      title,
+      url: DETAIL + encodeURIComponent(id),
+      company: companyName,
+      location: names(p.cityList),
+      // Meituan posts carry full-text JDs (duty + requirements), much longer
+      // than other boards' summaries — cap to keep scan payloads sane.
+      description: [
+        names(p.department) && `部门: ${names(p.department)}`,
+        p.jobFamily && `序列: ${p.jobFamily}`,
+        p.workYear && `经验: ${p.workYear}`,
+        p.jobDuty,
+        p.jobRequirement,
+      ].filter(Boolean).join('\n').slice(0, 4000),
+      postedAt: toEpochMs(p.refreshTime ?? p.firstPostTime),
+    });
+  }
+  return { jobs, total };
+}
+
+/** @type {Provider} */
+export default {
+  id: 'meituan',
+
+  detect(entry) {
+    // Match the host, not a path segment, to avoid spoofed URLs.
+    const url = entry.careers_url;
+    if (typeof url !== 'string') return null;
+    let u;
+    try { u = new URL(url); } catch { return null; }
+    if (u.protocol !== 'https:' || u.hostname !== API_HOST) return null;
+    return { url };
+  },
+
+  async fetch(entry, ctx) {
+    const keywords = Array.isArray(entry.keywords) && entry.keywords.length
+      ? entry.keywords
+      : DEFAULT_KEYWORDS;
+    const entryMaxPages = Number(entry.max_pages) > 0 ? Number(entry.max_pages) : DEFAULT_MAX_PAGES;
+    // Honor the ctx.maxPages pagination hint (verify-portals' health probe passes 1).
+    const maxPages = Math.min(entryMaxPages, Number(ctx?.maxPages) > 0 ? Number(ctx.maxPages) : Infinity);
+
+    /** @type {Map<string, import('./_types.js').Job>} */
+    const seen = new Map();
+    const sleep = (ms) => (typeof ctx?.sleep === 'function' ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
+    let firstRequest = true;
+    let succeededOnce = false;
+
+    for (const keyword of keywords) {
+      let total = 0;
+
+      for (let pageNo = 1; pageNo <= maxPages; pageNo++) {
+        /** @type {import('./_types.js').Job[]|null} */
+        let jobs = null;
+
+        for (let attempt = 0; attempt <= EMPTY_RETRIES; attempt++) {
+          if (firstRequest) firstRequest = false;
+          else await sleep(attempt > 0 ? RETRY_BACKOFF_MS * attempt : INTER_PAGE_DELAY_MS);
+
+          let json;
+          try {
+            json = await ctx.fetchJson(API, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: buildBody(keyword, pageNo),
+              redirect: 'error',
+            });
+          } catch (err) {
+            // A dead board should still read as a failure, but a mid-run blip
+            // must not discard what's already collected (same idiom as
+            // workday/jobstreet/glints). Track successes directly — a keyword
+            // can legitimately match 0 jobs, so seen.size is not the signal.
+            if (!succeededOnce) throw err;
+            console.error(`  ⚠ meituan: keyword "${keyword}" page ${pageNo} failed (${err.message}) — keeping the ${seen.size} jobs collected so far`);
+            return [...seen.values()];
+          }
+          const parsed = parseMeituanResponse(json, entry.name || '美团');
+          succeededOnce = true;
+          if (parsed.total) total = parsed.total;
+          if (parsed.jobs.length > 0) { jobs = parsed.jobs; break; }
+          if (total && (pageNo - 1) * PAGE_SIZE >= total) break; // legitimately past the end
+        }
+
+        if (!jobs) {
+          if (total && (pageNo - 1) * PAGE_SIZE < total) {
+            console.error(`  ⚠ meituan: keyword "${keyword}" page ${pageNo} still empty after ${EMPTY_RETRIES} retries — keeping the ${seen.size} jobs collected so far`);
+          }
+          break;
+        }
+
+        for (const job of jobs) {
+          if (!seen.has(job.url)) seen.set(job.url, job);
+        }
+
+        if (total && pageNo * PAGE_SIZE >= total) break;
+      }
+    }
+
+    return [...seen.values()];
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -519,6 +519,7 @@ search_queries:
 #   rippling        ats.rippling.com/<slug>/jobs
 #   jibeapply       <slug>.jibeapply.com/jobs  (or provider: jibeapply + api: for a branded host's own /jobs path)
 #   tencent         careers.tencent.com  (zh-CN board; each keywords: entry queried server-side, results deduped)
+#   meituan         zhaopin.meituan.com  (zh-CN board; each keywords: entry queried server-side, results deduped)
 #   workday         <tenant>.wd<N>.myworkdayjobs.com[/<locale>]/<board>
 #   avature         <tenant>.avature.net  (branded host → provider: avature + api: the /careers/SearchJobs URL)
 #   amazon          amazon.jobs           (global board; provider: amazon + an amazon: filter block, see below)
@@ -570,6 +571,13 @@ search_queries:
 #   keywords: ["AI", "大模型"]   # each keyword is a separate server-side query, results deduped;
 #                                # omit keywords to pull the whole board
 #   max_pages: 20          # optional per-keyword page cap (100 posts/page, default 20)
+#   enabled: true
+#
+# - name: 美团 (Meituan)
+#   careers_url: https://zhaopin.meituan.com/web/social   # any https://zhaopin.meituan.com URL
+#   keywords: ["AI", "大模型"]   # each keyword is a separate server-side query, results deduped;
+#                                # omit keywords to pull the whole board
+#   max_pages: 30          # optional per-keyword page cap (100 posts/page, default 30)
 #   enabled: true
 #
 # - name: Example Workday Co

--- a/tests/providers/meituan.test.mjs
+++ b/tests/providers/meituan.test.mjs
@@ -1,0 +1,243 @@
+// tests/providers/meituan.test.mjs — Meituan careers provider (zhaopin.meituan.com
+// public JSON API). Added with the provider in the same PR; follows the
+// discovered-test layout from #1440.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — meituan (zhaopin.meituan.com JSON API)');
+try {
+  const meituan = (await import(pathToFileURL(join(ROOT, 'providers/meituan.mjs')).href)).default;
+  const { parseMeituanResponse } = await import(pathToFileURL(join(ROOT, 'providers/meituan.mjs')).href);
+
+  if (meituan.id === 'meituan') pass('meituan.id is "meituan"');
+  else fail(`meituan.id is ${JSON.stringify(meituan.id)}`);
+
+  const hit = meituan.detect({ name: '美团', careers_url: 'https://zhaopin.meituan.com/web/social' });
+  if (hit && hit.url === 'https://zhaopin.meituan.com/web/social') {
+    pass('meituan.detect() claims zhaopin.meituan.com URLs');
+  } else {
+    fail(`meituan.detect() returned ${JSON.stringify(hit)}`);
+  }
+
+  if (meituan.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('meituan.detect() returns null for non-Meituan URLs');
+  } else {
+    fail('meituan.detect() should return null for non-Meituan URLs');
+  }
+
+  if (meituan.detect({ name: 'X', careers_url: 'https://evil.example/zhaopin.meituan.com' }) === null) {
+    pass('meituan.detect() rejects path-spoofed hosts');
+  } else {
+    fail('meituan.detect() should reject path-spoofed hosts');
+  }
+
+  if (meituan.detect({ name: 'X', careers_url: 'http://zhaopin.meituan.com/web/social' }) === null) {
+    pass('meituan.detect() is HTTPS-only');
+  } else {
+    fail('meituan.detect() should reject http:// URLs');
+  }
+
+  if (meituan.detect({ name: 'X', careers_url: 12345 }) === null) {
+    pass('meituan.detect() returns null for a non-string careers_url');
+  } else {
+    fail('meituan.detect() should return null for a non-string careers_url');
+  }
+
+  // parseMeituanResponse
+  const sample = {
+    data: {
+      page: { pageNo: 1, pageSize: 100, totalCount: 42 },
+      list: [
+        {
+          jobUnionId: 'abc-123',
+          name: '大模型算法工程师',
+          cityList: [{ name: '北京市' }, { name: '上海市' }],
+          department: [{ name: '核心本地商业-测试部' }],
+          jobFamily: '技术类',
+          workYear: '3-5年',
+          jobDuty: '负责大模型训练。',
+          jobRequirement: '熟悉深度学习框架。',
+          refreshTime: 1751500800000,
+        },
+        {
+          jobUnionId: 'def-456',
+          name: 'AI产品经理',
+          cityList: [{ name: '深圳市' }],
+          firstPostTime: '2026-06-20T00:00:00.000Z',
+        },
+        { jobUnionId: 'ghi-789' },
+        { name: '无ID岗位' },
+      ],
+    },
+  };
+  const { jobs, total } = parseMeituanResponse(sample, '美团');
+
+  if (total === 42) pass('parseMeituanResponse() reads data.page.totalCount as total');
+  else fail(`parseMeituanResponse() total = ${total}`);
+
+  if (jobs.length === 2) pass('parseMeituanResponse() keeps titled+ID posts, drops incomplete ones');
+  else fail(`parseMeituanResponse() returned ${jobs.length} jobs, expected 2`);
+
+  const j1 = jobs[0];
+  if (j1 && j1.url === 'https://zhaopin.meituan.com/web/position/detail?jobUnionId=abc-123' && j1.location === '北京市/上海市') {
+    pass('parseMeituanResponse() builds detail URL from jobUnionId and joins cityList names');
+  } else {
+    fail(`parseMeituanResponse() job[0] = ${JSON.stringify(j1)}`);
+  }
+
+  if (j1 && j1.description.includes('部门: 核心本地商业-测试部') && j1.description.includes('负责大模型训练。')) {
+    pass('parseMeituanResponse() packs department/family/duty/requirement into description');
+  } else {
+    fail(`parseMeituanResponse() description = ${JSON.stringify(j1 && j1.description)}`);
+  }
+
+  if (j1 && j1.postedAt === 1751500800000) {
+    pass('parseMeituanResponse() passes epoch-ms refreshTime through');
+  } else {
+    fail(`parseMeituanResponse() postedAt = ${j1 && j1.postedAt}`);
+  }
+
+  const j2 = jobs[1];
+  if (j2 && j2.postedAt === Date.parse('2026-06-20T00:00:00.000Z')) {
+    pass('parseMeituanResponse() falls back to firstPostTime when refreshTime is absent');
+  } else {
+    fail(`parseMeituanResponse() job[1].postedAt = ${j2 && j2.postedAt}`);
+  }
+
+  const empty = parseMeituanResponse({ data: { page: { totalCount: 0 }, list: null } }, '美团');
+  if (empty.jobs.length === 0 && empty.total === 0) {
+    pass('parseMeituanResponse() handles a missing list array');
+  } else {
+    fail(`parseMeituanResponse() empty payload → ${JSON.stringify(empty)}`);
+  }
+
+  // fetch() — pagination, retry-on-empty, cross-keyword dedup, page caps (mocked ctx)
+  const MEITUAN_URL = 'https://zhaopin.meituan.com/web/social';
+  const mkJob = (id, title) => ({ jobUnionId: String(id), name: title, cityList: [{ name: '北京市' }] });
+  const mkCtx = (impl) => {
+    const calls = [];
+    const sleeps = [];
+    return {
+      calls,
+      sleeps,
+      ctx: {
+        sleep: async (ms) => { sleeps.push(ms); },
+        fetchJson: async (_url, opts) => {
+          const body = JSON.parse(opts.body);
+          const call = { keywords: body.keywords, pageNo: body.page.pageNo };
+          calls.push(call);
+          return impl(call, calls.length);
+        },
+      },
+    };
+  };
+
+  const paged = mkCtx(({ pageNo }) => ({
+    data: {
+      page: { totalCount: 150 },
+      list: pageNo === 1
+        ? Array.from({ length: 100 }, (_, i) => mkJob(1000 + i, `岗位A${i}`))
+        : Array.from({ length: 50 }, (_, i) => mkJob(2000 + i, `岗位B${i}`)),
+    },
+  }));
+  const pagedJobs = await meituan.fetch({ name: '美团', careers_url: MEITUAN_URL, keywords: ['AI'] }, paged.ctx);
+  if (pagedJobs.length === 150 && paged.calls.length === 2) {
+    pass('meituan.fetch() paginates until totalCount is exhausted (150 posts → 2 requests)');
+  } else {
+    fail(`meituan.fetch() pagination: ${pagedJobs.length} jobs, ${paged.calls.length} requests`);
+  }
+
+  if (paged.sleeps.length === 1 && paged.sleeps[0] > 0) {
+    pass('meituan.fetch() paces follow-up requests via ctx.sleep (no delay before the first request)');
+  } else {
+    fail(`meituan.fetch() ctx.sleep calls: ${JSON.stringify(paged.sleeps)}`);
+  }
+
+  const flaky = mkCtx((_call, n) => (n === 2
+    ? { data: { page: { totalCount: 120 }, list: [] } }   // page 2, attempt 1: rate-limit flake
+    : {
+        data: {
+          page: { totalCount: 120 },
+          list: n === 1
+            ? Array.from({ length: 100 }, (_, i) => mkJob(3000 + i, `岗位C${i}`))
+            : Array.from({ length: 20 }, (_, i) => mkJob(4000 + i, `岗位D${i}`)),
+        },
+      }));
+  const flakyJobs = await meituan.fetch({ name: '美团', careers_url: MEITUAN_URL, keywords: ['AI'] }, flaky.ctx);
+  if (flakyJobs.length === 120 && flaky.calls.length === 3) {
+    pass('meituan.fetch() retries an empty mid-pagination page instead of truncating (flake → retry → 120 jobs)');
+  } else {
+    fail(`meituan.fetch() retry-on-empty: ${flakyJobs.length} jobs, ${flaky.calls.length} requests`);
+  }
+
+  const overlap = mkCtx(() => ({
+    data: { page: { totalCount: 1 }, list: [mkJob(42, '重复岗位')] },
+  }));
+  const overlapJobs = await meituan.fetch({ name: '美团', careers_url: MEITUAN_URL, keywords: ['AI', '大模型'] }, overlap.ctx);
+  if (overlapJobs.length === 1 && overlap.calls.length === 2 && overlap.sleeps.length === 1) {
+    pass('meituan.fetch() dedupes across keywords and paces the keyword switch');
+  } else {
+    fail(`meituan.fetch() cross-keyword: ${overlapJobs.length} jobs, ${overlap.calls.length} requests, sleeps ${JSON.stringify(overlap.sleeps)}`);
+  }
+
+  const capped = mkCtx(() => ({
+    data: { page: { totalCount: 500 }, list: Array.from({ length: 100 }, (_, i) => mkJob(5000 + i, `岗位E${i}`)) },
+  }));
+  await meituan.fetch({ name: '美团', careers_url: MEITUAN_URL, keywords: ['AI'], max_pages: 1 }, capped.ctx);
+  if (capped.calls.length === 1) {
+    pass('meituan.fetch() honors entry.max_pages');
+  } else {
+    fail(`meituan.fetch() entry.max_pages=1 made ${capped.calls.length} requests`);
+  }
+
+  const probe = mkCtx(() => ({
+    data: { page: { totalCount: 500 }, list: Array.from({ length: 100 }, (_, i) => mkJob(6000 + i, `岗位F${i}`)) },
+  }));
+  probe.ctx.maxPages = 1;
+  const probeJobs = await meituan.fetch({ name: '美团', careers_url: MEITUAN_URL }, probe.ctx);
+  if (probe.calls.length === 1 && probe.calls[0].keywords === '' && probeJobs.length === 100) {
+    pass('meituan.fetch() honors the ctx.maxPages probe hint and defaults to a whole-board (empty keyword) query');
+  } else {
+    fail(`meituan.fetch() ctx.maxPages=1: ${probe.calls.length} requests, keywords=${JSON.stringify(probe.calls[0] && probe.calls[0].keywords)}`);
+  }
+
+  const blip = mkCtx(({ keywords }) => {
+    if (keywords === '大模型') throw new Error('HTTP 503');
+    return { data: { page: { totalCount: 1 }, list: [mkJob(7, '幸存岗位')] } };
+  });
+  const blipJobs = await meituan.fetch({ name: '美团', careers_url: MEITUAN_URL, keywords: ['AI', '大模型'] }, blip.ctx);
+  if (blipJobs.length === 1 && blipJobs[0].title === '幸存岗位') {
+    pass('meituan.fetch() keeps already-collected jobs when a later request fails');
+  } else {
+    fail(`meituan.fetch() partial results on failure: ${JSON.stringify(blipJobs.map(j => j.title))}`);
+  }
+
+  const zeroThenBlip = mkCtx(({ keywords }) => {
+    if (keywords === '大模型') throw new Error('HTTP 503');
+    return { data: { page: { totalCount: 0 }, list: [] } };
+  });
+  let zeroThenBlipJobs;
+  let zeroThenBlipThrew = false;
+  try {
+    zeroThenBlipJobs = await meituan.fetch({ name: '美团', careers_url: MEITUAN_URL, keywords: ['AI', '大模型'] }, zeroThenBlip.ctx);
+  } catch { zeroThenBlipThrew = true; }
+  if (!zeroThenBlipThrew && Array.isArray(zeroThenBlipJobs) && zeroThenBlipJobs.length === 0) {
+    pass('meituan.fetch() treats a later failure as a blip even when earlier keywords matched 0 jobs (board is alive)');
+  } else {
+    fail(`meituan.fetch() 0-result keyword then 503: ${zeroThenBlipThrew ? 'threw' : JSON.stringify(zeroThenBlipJobs)}`);
+  }
+
+  let firstFailThrew = false;
+  const dead = mkCtx(() => { throw new Error('HTTP 500'); });
+  try {
+    await meituan.fetch({ name: '美团', careers_url: MEITUAN_URL, keywords: ['AI'] }, dead.ctx);
+  } catch { firstFailThrew = true; }
+  if (firstFailThrew) {
+    pass('meituan.fetch() still throws when the very first request fails (dead board reads as failure)');
+  } else {
+    fail('meituan.fetch() swallowed a first-request failure');
+  }
+} catch (e) {
+  fail(`meituan provider tests crashed: ${e.message}`);
+}


### PR DESCRIPTION
## What does this PR do?

Adds a zero-token Meituan careers provider that posts to the public
`zhaopin.meituan.com/api/official/job/getJobList` JSON API (no auth, no
browser, no special headers). Auto-detects `https://zhaopin.meituan.com`
careers URLs (host-matched, HTTPS-only). Like the Tencent board (#1619) it is
one company-wide endpoint, so each `keywords:` entry is queried server-side
separately and results are deduped by job URL; omitting `keywords:` pulls the
whole board (~2300 postings). Paginates up to `max_pages` per keyword
(default 30, 100 posts/page) and honors the `ctx.maxPages` probe hint.
Verified live 2026-07.

Two board-specific behaviors worth calling out:

- The board sporadically answers a mid-pagination request with an empty list
  (observed live; reads as rate-limiting), so empty pages are retried with
  backoff before a keyword is considered exhausted, and follow-up requests are
  paced at 400ms (the avature/workday idiom, slower because this board
  rate-limits harder).
- A mid-run request failure keeps the jobs already collected instead of
  discarding the run; success is tracked with an explicit flag rather than
  the collected count, so a keyword that legitimately matches 0 jobs doesn't
  turn a later blip into a hard failure. The very first request failing still
  throws (a dead board should read as a failure). Same semantics the Tencent
  provider settled on in review.

## Related issue

N/A — new zero-auth scanner provider, exempt from the issue-first requirement per CONTRIBUTING.md.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Changes

- `providers/meituan.mjs`: `detect()` matches the `zhaopin.meituan.com` host
  (HTTPS-only, rejects path-spoofed URLs and non-string input); `fetch()`
  POSTs the site's own getJobList XHR shape (nested `page` pagination — a flat
  `pageNo` is silently ignored by the API), queries each keyword, paginates
  until `totalCount` is exhausted with retry-on-empty, and dedupes by job URL
  across keywords; `parseMeituanResponse()` maps
  name/jobUnionId/cityList/department/JD text into the normalized shape and
  passes `refreshTime` (epoch ms) through, falling back to `firstPostTime`
- `tests/providers/meituan.test.mjs`: detect() incl. spoofed-host / http:// /
  non-string negatives, parseMeituanResponse() field mapping / dates / empty
  payload, and fetch() pagination + retry-on-empty + cross-keyword dedup +
  pacing + `max_pages` + `ctx.maxPages` + partial-results-on-blip +
  first-request-failure via a mocked ctx (22 checks)
- `docs/SUPPORTED_JOB_BOARDS.md`: add Meituan Careers row (alphabetical)
- `templates/portals.example.yml`: auto-detect pattern comment + example stanza

Open question: a totalCount-0 page is indistinguishable from the board's
rate-limit flake (both answer with an empty list), so a keyword that
legitimately matches nothing still pays the retry ladder before the provider
moves on. Happy to skip retries when totalCount is 0 if you'd rather save the
requests, at the risk of truncating on a flake that also reports 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Meituan Careers job listings.
  - Automatically detects Meituan career pages and retrieves public job postings without authentication.
  - Supports keyword searches, pagination, duplicate removal, retries, rate-limit handling, and configurable page limits.
  - Added an example configuration for tracking Meituan roles, including AI and large-language-model keywords.

- **Documentation**
  - Documented Meituan Careers as a supported job board and described its search and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->