### PR TITLE
fix(web): link inbox triage rows to the job posting

### DIFF
--- a/web/src/components/inbox/triage-row.tsx
+++ b/web/src/components/inbox/triage-row.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Bookmark, BookmarkCheck, Loader2, X } from "lucide-react";
+import { Bookmark, BookmarkCheck, ExternalLink, Loader2, X } from "lucide-react";
 import type { InboxJob } from "@/lib/career-ops";
 import type { AtsSource } from "@/lib/explore";
 import { ATS_LABEL } from "@/lib/explore";
@@ -68,8 +68,19 @@ export function TriageRow({
 
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm">
-          <span className="font-medium text-foreground">{job.company}</span>
-          <span className="text-muted"> · {job.role}</span>
+          <a
+            href={job.url}
+            target="_blank"
+            rel="noreferrer"
+            title="Open job posting"
+            className="group/link inline-flex max-w-full items-center gap-1 align-bottom"
+          >
+            <span className="truncate">
+              <span className="font-medium text-foreground group-hover/link:text-brand group-hover/link:underline">{job.company}</span>
+              <span className="text-muted"> · {job.role}</span>
+            </span>
+            <ExternalLink className="size-3 shrink-0 text-faint opacity-0 transition-opacity group-hover/link:opacity-100" />
+          </a>
         </p>
         <p className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-faint">
           {job.location && <span className="truncate">{job.location}</span>}


### PR DESCRIPTION
## What does this PR do?

Makes each pipeline-inbox triage row's title an external link to the actual job posting (opens in a new tab, hover shows an external-link icon). Previously the inbox rendered company/role/location but never the job URL, so the only place in the web UI to open a posting was the Today page's capped what's-new list.

## Related issue

None — bug fix, sent straight in per the template.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (1537 passed, 0 failed)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

Reviewer notes: Save/Skip buttons and the multi-select checkbox are untouched; only the title text became an anchor. The Explore discovery cards already linked out (`discovery-card.tsx`) — this brings the inbox to parity. `npx tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)