### PR TITLE
docs: add NVIDIA NIM to openai-eval.mjs compatible providers (RUNNING_ON_A_BUDGET)

### DIFF
--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -104,6 +104,7 @@ When choosing a budget-friendly model, you need strong reasoning capabilities to
 > node openai-eval.mjs --file ./jds/job.txt
 > ```
 > Run `node openai-eval.mjs --help` for per-provider examples. For 100% local/private use, point `--url` at a local server (LM Studio / llama.cpp / vLLM) or use `node ollama-eval.mjs`.
+> NVIDIA NIM works too (hosted `https://integrate.api.nvidia.com/v1` or a self-hosted NIM container's `/v1`) — e.g. `--model meta/llama-3.3-70b-instruct`; on the hosted free tier raise `OPENAI_TIMEOUT_MS` (queue latency regularly exceeds the 300s default).
 
 ---
 


### PR DESCRIPTION
## Summary

One-line docs addition: NVIDIA NIM endpoints (hosted `integrate.api.nvidia.com/v1` or self-hosted NIM containers) are OpenAI-compatible and work with `openai-eval.mjs` (#1278) unchanged — plus the one operational gotcha a NIM user will hit.

## Verified

Ran `openai-eval.mjs` end-to-end against the hosted NIM API with `meta/llama-3.3-70b-instruct`: full A–F + G report generated, `---SCORE_SUMMARY---` machine block parsed correctly, score/archetype/legitimacy all present.

## The gotcha documented

NVIDIA's hosted free tier queues requests aggressively — a 2-token probe took 92s wall-clock. The default `OPENAI_TIMEOUT_MS` (300s) regularly times out on a full evaluation; 600s succeeds. The added line points users at raising `OPENAI_TIMEOUT_MS`.

## Prior art

- #1278 shipped `openai-eval.mjs` (any OpenAI-compatible endpoint)
- #1522 / #1355 — local/cheap-model paths discussion; NIM wasn't named anywhere in docs
- Originally drafted as a feature request for pluggable evaluate backends (2026-06-21, pre-#1278) — the feature landed since, so this is the remaining docs gap.

Docs-only, no behavior change. Opening as draft per issue-first convention — happy to file an issue instead if preferred.