### PR TITLE
fix(merge-tracker): preserve empty interior cells in tracker-row parsing

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -312,7 +312,9 @@ function parseTsvContent(content, filename) {
 
   // Detect pipe-delimited (markdown table row)
   if (content.startsWith('|')) {
-    parts = content.split('|').map(s => s.trim()).filter(Boolean);
+    parts = content.split('|').map(s => s.trim());
+    if (parts[0] === '') parts.shift();
+    if (parts[parts.length - 1] === '') parts.pop();
     if (parts.length < 8) {
       console.warn(`⚠️  Skipping malformed pipe-delimited ${filename}: ${parts.length} fields`);
       return null;

--- a/tracker-columns-tests.mjs
+++ b/tracker-columns-tests.mjs
@@ -546,5 +546,28 @@ if (!HAS_WEB) {
   rmSync(dir, { recursive: true, force: true });
 }
 
+// ── Test 17: pipe rows preserve empty interior cells ──────────────────────
+{
+  const EMPTY_PDF = '| 42 | 2026-01-01 | Foo | Bar Engineer | 4.0/5 | Evaluated |  | [42](reports/042-foo-2026-01-01.md) | some note |';
+  const EMPTY_NOTES = '| 43 | 2026-01-02 | Baz | Platform Engineer | 4.1/5 | Evaluated | ✅ | [43](reports/043-baz-2026-01-02.md) |  | Singapore';
+  const sb = makeSandbox(HEADER_10, { '42-foo.tsv': EMPTY_PDF, '43-baz.tsv': EMPTY_NOTES });
+  const res = runScript('merge-tracker.mjs', [], sb);
+  const foo = dataRows(sb.tracker).find(l => l.includes('Foo'));
+  const baz = dataRows(sb.tracker).find(l => l.includes('Baz'));
+  const fooCells = foo ? foo.split('|').map(s => s.trim()) : [];
+  const bazCells = baz ? baz.split('|').map(s => s.trim()) : [];
+  if (res.code === 0 && fooCells[8] === '' && fooCells[9] === '[42](reports/042-foo-2026-01-01.md)' && fooCells[10] === 'some note') {
+    pass('merge: empty PDF cell does not shift Report or Notes');
+  } else {
+    fail(`merge: empty PDF cell shifted columns (code ${res.code}) row: ${foo}\n${res.stdout}`);
+  }
+  if (bazCells[5] === 'Singapore' && bazCells[10] === '') {
+    pass('merge: empty Notes cell does not shift a later Location');
+  } else {
+    fail(`merge: empty Notes cell shifted Location — row: ${baz}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tracker-columns-tests.mjs
+++ b/tracker-columns-tests.mjs
@@ -561,10 +561,10 @@ if (!HAS_WEB) {
   } else {
     fail(`merge: empty PDF cell shifted columns (code ${res.code}) row: ${foo}\n${res.stdout}`);
   }
-  if (bazCells[5] === 'Singapore' && bazCells[10] === '') {
+  if (res.code === 0 && bazCells[5] === 'Singapore' && bazCells[10] === '') {
     pass('merge: empty Notes cell does not shift a later Location');
   } else {
-    fail(`merge: empty Notes cell shifted Location — row: ${baz}`);
+    fail(`merge: empty Notes cell shifted Location (code ${res.code}) row: ${baz}\n${res.stdout}`);
   }
   rmSync(sb.dir, { recursive: true, force: true });
 }


### PR DESCRIPTION
### Problem
`parseTsvContent` in merge-tracker.mjs parses pipe-delimited tracker rows with
`.split('|').filter(Boolean)`. That drops empty interior cells too, so a row with
an empty column (e.g. no PDF or empty notes) has all following columns shifted
one place left and merges into the tracker misaligned — silently, with no error.

### Fix
Strip only the empty leading token and an empty trailing token when present,
preserving interior empties and rows without a closing pipe. Adds regression
coverage for an empty PDF cell and an empty notes cell.

### Testing
`node test-all.mjs` under Node 24.18.0: 1699 passed, 0 failed. The new regression
test fails on the previous behavior and passes with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Markdown table parsing to preserve empty interior cells in pipe-delimited rows, keeping column indexes stable.
  * Prevented subsequent fields (e.g., report, notes, and location) from shifting into incorrect columns.
* **Tests**
  * Added a regression test to verify merged TSV rows retain correct cell alignment when empty table cells are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->