### PR TITLE
feat(cover-letter): support --format and --report CLI arguments

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -167,6 +167,8 @@ async function main() {
     options: {
       payload: { type: "string" },
       out:     { type: "string" },
+      format:  { type: "string" },
+      report:  { type: "string" },
       help:    { type: "boolean", short: "h" },
     },
     strict: false,
@@ -175,10 +177,12 @@ async function main() {
   if (args.help || !args.payload) {
     console.log(`
 Usage:
-  node generate-cover-letter.mjs --payload payload.json [--out output/path.pdf]
+  node generate-cover-letter.mjs --payload payload.json [--out output/path.pdf] [--format letter|a4] [--report NNN]
 
   --payload   Path to the JSON payload file (required)
   --out       Override output path from payload (optional)
+  --format    Override output PDF page format (letter|a4, default: a4)
+  --report    Link the PDF to a tracker report number in data/pdf-index.tsv
 `);
     process.exit(args.help ? 0 : 1);
   }
@@ -211,7 +215,11 @@ Usage:
   try {
     const html = buildHtml(payload);
     const outputPath = resolve(payload.output_path);
-    await renderHtmlToPdf(html, outputPath, { format: "a4" });
+    await renderHtmlToPdf(html, outputPath, {
+      format: args.format || "a4",
+      reportNum: args.report,
+      inputPath: payloadPath,
+    });
     console.log(`\nCover letter PDF: ${payload.output_path}`);
   } catch (err) {
     console.error("ERROR generating cover letter PDF:");

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6136,6 +6136,14 @@ try {
   } else {
     fail('Single-pass substitution left a known token unreplaced');
   }
+
+  // CLI arguments: --help prints custom --format and --report usage guidelines
+  const usageOut = execFileSync(process.execPath, [join(ROOT, 'generate-cover-letter.mjs'), '--help'], { encoding: 'utf-8' });
+  if (usageOut.includes('--format') && usageOut.includes('--report') && usageOut.includes('[--format letter|a4]')) {
+    pass('Cover letter CLI --help documents format and report options');
+  } else {
+    fail('Cover letter CLI --help does not document format and report options');
+  }
 } catch (e) {
   fail(`Cover letter single-pass substitution test crashed: ${e.message}`);
 }


### PR DESCRIPTION
Resolves #1828 

### Description
This pull request adds support for the `--format` and `--report` command-line arguments to `generate-cover-letter.mjs`, aligning it with the options already supported by `generate-pdf.mjs`.

### Changes:
1. **CLI Support**: Updated `parseArgs` in `generate-cover-letter.mjs` to accept `--format` (string, default `"a4"`) and `--report` (string) options, and updated help usage text.
2. **Manifest Integration**: Passed `format`, `reportNum` (`args.report`), and `inputPath` (`payloadPath`) to `renderHtmlToPdf` so cover letters can be registered in `data/pdf-index.tsv`.
3. **Tests**: Added a unit test in `test-all.mjs` verifying that the `--help` output of `generate-cover-letter.mjs` documents the new options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--format` support for choosing Letter or A4 PDF output.
  * Added `--report` support for associating generated cover letters with a report number.
  * Updated help text to document the new command-line options.

* **Tests**
  * Added coverage verifying that the help output lists the expected options and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->