### PR TITLE
bug(doctor): warn when Node version is less than 22.5.0

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -30,14 +30,29 @@ const yellow = (s) => isTTY ? `\x1b[33m${s}\x1b[0m` : s;
 const dim = (s) => isTTY ? `\x1b[2m${s}\x1b[0m` : s;
 
 function checkNodeVersion() {
-  const major = parseInt(process.versions.node.split('.')[0]);
-  if (major >= 18) {
-    return { pass: true, label: `Node.js >= 18 (v${process.versions.node})` };
+  const versionStr = process.versions.node;
+  const [major, minor] = versionStr.split('.').map(Number);
+  const hasSqlite = major > 22 || (major === 22 && minor >= 5);
+
+  if (hasSqlite) {
+    return { pass: true, label: `Node.js >= 22.5 (v${versionStr})` };
   }
+
+  if (major >= 18) {
+    return {
+      warn: true,
+      label: `Node.js v${versionStr} detected. Node >= 22.5.0 is highly recommended because tracker.mjs (SQLite database indexing) requires node:sqlite.`,
+      fix: [
+        'Upgrade Node.js to v22.5.0 or later to enable full tracker database support.',
+        'The markdown tracker keeps working without it — the index is optional.',
+      ],
+    };
+  }
+
   return {
     pass: false,
-    label: `Node.js >= 18 (found v${process.versions.node})`,
-    fix: 'Install Node.js 18 or later from https://nodejs.org',
+    label: `Node.js >= 18 (found v${versionStr})`,
+    fix: 'Install Node.js 22.5.0 or later from https://nodejs.org',
   };
 }
 


### PR DESCRIPTION
Resolves #1829 

### Description
This pull request updates the Node.js version check in `doctor.mjs`.

### Changes:
* Checks if the active Node.js version is `>= 22.5.0` (which is when `node:sqlite` became available as a stable/standard built-in module).
* If Node.js is between `v18.0.0` and `v22.5.0` (such as Node v18 or v20), the check emits a warning instead of passing cleanly, reminding the user that SQLite database indexing via `tracker.mjs` requires Node `>= 22.5.0`.
* If Node.js is `< 18.0.0`, the check fails as before, but the error message advises installing Node.js 22.5.0 or later.

This alerts users early on during the `npm run doctor` phase if their environment will encounter errors when running database-dependent features of the workspace (like the dashboard, web app tracker APIs, or `reply-watch.mjs`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Node.js version checks with clearer pass, warning, and failure outcomes.
  * Added specific guidance for upgrading older Node.js versions.
  * Clarified when tracker indexing may be unavailable on supported but older versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->