### PR TITLE
docs: add scan-ats-full.mjs to AGENTS.md Main Files table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `data/follow-ups.md` | Follow-up history tracker |
 | `data/blacklist.md` | Your do-not-apply company list (user layer, opt-in — never auto-populated; respected by `scan.mjs` and the `auto-pipeline`/`oferta`/`apply` gates) |
 | `scan.mjs` | Zero-token portal scanner — hits Greenhouse/Ashby/Lever APIs directly, zero LLM cost |
+| `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner — walks the full public job-board-aggregator dataset per ATS provider (Greenhouse/Lever/Ashby/Workday), filtered by portals.yml's title_filter/location_filter. No company-list curation needed; complements scan.mjs's company-first model. |
 | `check-liveness.mjs` | Job posting liveness checker |
 | `liveness-core.mjs` | Shared liveness logic (expired signals win over generic Apply text) |
 | `reports/` | Evaluation reports (format: `{###}-{company-slug}-{YYYY-MM-DD}.md`). Blocks A-F + G (Posting Legitimacy). Header includes `**Legitimacy:** {tier}`. |


### PR DESCRIPTION
## Summary
- `scan-ats-full.mjs` (the reverse-ATS keyword-first scanner) was never documented in AGENTS.md's Main Files table, even though `scan.mjs` (its company-first counterpart) is. A fresh agent/contributor has no way to discover it exists without grepping source.
- Adds one row immediately after the `scan.mjs` row describing what it does and how it complements `scan.mjs`.

## Test plan
- [x] `node test-all.mjs --quick` — 1736 passed, 0 failed (docs-only change, no-op as expected)
- [x] `git diff` confirms only `AGENTS.md` touched, single line added

Closes #1845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance to describe an additional job-search scanning approach.
  * Clarified that searches can cover a broader set of public listings across major job-board platforms.
  * Documented filtering by job title and location, alongside the existing company-focused search method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->