### PR TITLE
fix(scan-ats-full): wire content_filter (incl. by_title_keyword scoping) into reverse scans

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -39,7 +39,7 @@ import greenhouse from './providers/greenhouse.mjs';
 import lever from './providers/lever.mjs';
 import ashby from './providers/ashby.mjs';
 import workday from './providers/workday.mjs';
-import { buildTitleFilter, buildLocationFilter, loadSeenUrls, appendToPipeline, appendToScanHistory, loadBlacklist } from './scan.mjs';
+import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, loadSeenUrls, appendToPipeline, appendToScanHistory, loadBlacklist } from './scan.mjs';
 import { SEED_SOURCES, toPortalEntry } from './seeds/vc-portfolios.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
 
@@ -292,6 +292,19 @@ export function filterBlacklistedOffers(offers, blacklist, { includeBlacklisted 
   return { offers: kept, filteredBlacklist, annotatedBlacklisted };
 }
 
+// Title/location/content filter chain for one posting, used by runSeedScan().
+// The main ATS-directory loop below inlines the same three checks (it tracks
+// a droppedContent counter per stage for the run summary), but this shared,
+// pure, exported helper keeps the content_filter.by_title_keyword wiring
+// (#1846) unit-testable without mocking providers or duplicating the rule
+// order in two places for the caller that doesn't need per-stage counts.
+export function passesFilters(job, { titleFilter, locationFilter, contentFilter, titleFilterConfig }) {
+  if (!titleFilter(job.title)) return false;
+  if (!locationFilter(job.location)) return false;
+  if (contentFilter && !contentFilter(job.description, matchedTitleKeywords(job.title, titleFilterConfig))) return false;
+  return true;
+}
+
 // Cap-aware company sampling. Default: the dataset's natural (alphabetical)
 // prefix. With --shuffle: a random sample of `limit` companies, so a capped
 // scan isn't always biased to the same alphabetical-first slice. Pure; returns
@@ -378,8 +391,12 @@ export async function runSeedScan(seedId, opts, ctx, seenUrls, label) {
       const dateClass = classifyPostingDate(job, cutoff);
       if (dateClass === 'stale') continue;
       if (dateClass === 'undated' && !opts.includeUndated) continue;
-      if (!opts.titleFilter(job.title)) continue;
-      if (!opts.locationFilter(job.location)) continue;
+      if (!passesFilters(job, {
+        titleFilter: opts.titleFilter,
+        locationFilter: opts.locationFilter,
+        contentFilter: opts.contentFilter,
+        titleFilterConfig: opts.titleFilterConfig,
+      })) continue;
       if (seenUrls.has(job.url)) continue;
       seenUrls.add(job.url);
       offers.push({ ...job, source: sourceName, dateStatus: job.postedAt ? 'dated' : 'unknown' });
@@ -451,12 +468,19 @@ async function main() {
   const config = yaml.load(readFileSync(PORTALS_PATH, 'utf-8'));
   const titleFilter = buildTitleFilter(config?.title_filter);
   const locationFilter = buildLocationFilter(config?.location_filter);
+  // Same content_filter (incl. by_title_keyword scoping) scan.mjs applies —
+  // see #1846. Built once here from the same portals.yml config.
+  const contentFilter = buildContentFilter(config?.content_filter);
   if (!config?.title_filter?.positive?.length) {
     console.error('⚠️  portals.yml has no title_filter.positive — every fresh posting on every board will match. Consider adding keywords.');
   }
   // Attach filters to opts so runSeedScan can use them without extra parameters.
   opts.titleFilter = titleFilter;
   opts.locationFilter = locationFilter;
+  opts.contentFilter = contentFilter;
+  // Raw title_filter config, needed by matchedTitleKeywords() to scope
+  // content_filter.by_title_keyword the same way scan.mjs does.
+  opts.titleFilterConfig = config?.title_filter;
 
   const atsSummary = opts.ats.length ? `ats: ${opts.ats.join(', ')}` : '';
   const seedsSummary = opts.seeds.length ? `seeds: ${opts.seeds.join(', ')}` : '';
@@ -478,6 +502,7 @@ async function main() {
   let totalCompaniesAvailable = 0;
   let totalErrors = 0;
   let droppedNoDate = 0;
+  let droppedContent = 0;
   let capHit = false;
   // Aggregated from providers/workday.mjs's jobs.workdayNoDateSkip tag — see
   // there for why this is a counter instead of a per-company console.error
@@ -513,6 +538,7 @@ async function main() {
           if (dateClass === 'undated' && !opts.includeUndated) { droppedNoDate++; continue; }
           if (!titleFilter(job.title)) continue;
           if (!locationFilter(job.location)) continue;
+          if (!contentFilter(job.description, matchedTitleKeywords(job.title, config?.title_filter))) { droppedContent++; continue; }
           if (seenUrls.has(job.url)) continue;
           seenUrls.add(job.url); // intra-scan dedup
           newOffers.push({ ...job, source: `${name}-full`, dateStatus: job.postedAt ? 'dated' : 'unknown' });
@@ -572,6 +598,7 @@ async function main() {
       log(`Blacklisted:      ${blacklistResult.filteredBlacklist} skipped (blacklist)`);
     }
   }
+  if (droppedContent) log(`Content-filtered:   ${droppedContent}`);
   log(`New matches:        ${offers.length}`);
 
   if (offers.length) {
@@ -633,6 +660,7 @@ async function main() {
       postingsDroppedNoDate: droppedNoDate,
       postingsFilteredBlacklist: blacklistResult.filteredBlacklist,
       postingsAnnotatedBlacklisted: blacklistResult.annotatedBlacklisted,
+      postingsDroppedContent: droppedContent,
       unreachableBoards: totalErrors,
       saved,
       offers: offers.map(o => ({

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2306,6 +2306,73 @@ try {
   fail(`scan-ats-full blacklist test crashed: ${e.message}`);
 }
 
+// Reverse-scan content_filter wiring (#1846) — scan-ats-full.mjs previously
+// imported only buildTitleFilter/buildLocationFilter, so portals.yml's
+// content_filter (incl. #1638's per-title-keyword scoping) had zero effect
+// on reverse scans. passesFilters() is the shared gate runSeedScan() uses;
+// exercise it directly with buildContentFilter/matchedTitleKeywords from
+// scan.mjs the same way scan-ats-full.mjs wires them.
+try {
+  const { passesFilters } = await import(pathToFileURL(join(ROOT, 'scan-ats-full.mjs')).href);
+  const { buildTitleFilter, buildLocationFilter, buildContentFilter } =
+    await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+
+  const titleFilterConfig = { positive: ['AI Engineer', 'Instructional Designer'] };
+  const titleFilter = buildTitleFilter(titleFilterConfig);
+  const locationFilter = buildLocationFilter(null);
+
+  // (a) A posting that fails the GLOBAL content_filter is rejected.
+  const globalCf = buildContentFilter({ positive: ['gpt', 'llm'] });
+  const failsGlobal = passesFilters(
+    { title: 'AI Engineer', location: '', description: 'Kubernetes and Terraform all day' },
+    { titleFilter, locationFilter, contentFilter: globalCf, titleFilterConfig },
+  );
+  if (failsGlobal === false) {
+    pass('scan-ats-full passesFilters rejects a posting failing the global content_filter');
+  } else {
+    fail('scan-ats-full passesFilters should reject postings failing the global content_filter');
+  }
+
+  // (b) A posting that fails a PER-TITLE-KEYWORD content_filter override is rejected.
+  const scopedCf = buildContentFilter({
+    by_title_keyword: { 'AI Engineer': { positive: ['gpt', 'llm', 'claude'] } },
+  });
+  const failsScoped = passesFilters(
+    { title: 'Senior AI Engineer', location: '', description: 'Build internal tools, no ML involved' },
+    { titleFilter, locationFilter, contentFilter: scopedCf, titleFilterConfig },
+  );
+  if (failsScoped === false) {
+    pass('scan-ats-full passesFilters rejects a posting failing its by_title_keyword override');
+  } else {
+    fail('scan-ats-full passesFilters should reject postings failing a by_title_keyword override');
+  }
+
+  // (c) Regression for #1636: a posting matched via a DIFFERENT title keyword
+  // with no content_filter override for it must NOT be wrongly rejected.
+  const passesUnrelated = passesFilters(
+    { title: 'Instructional Designer II', location: '', description: 'Designs onboarding curricula' },
+    { titleFilter, locationFilter, contentFilter: scopedCf, titleFilterConfig },
+  );
+  if (passesUnrelated === true) {
+    pass('scan-ats-full passesFilters does not leak an unrelated by_title_keyword override onto a different title match');
+  } else {
+    fail('scan-ats-full passesFilters wrongly rejected a posting whose matched keyword has no override (#1636 regression)');
+  }
+
+  // No content_filter configured at all → behaves exactly as before (title/location only).
+  const noCf = passesFilters(
+    { title: 'AI Engineer', location: '', description: 'Kubernetes and Terraform all day' },
+    { titleFilter, locationFilter, contentFilter: null, titleFilterConfig },
+  );
+  if (noCf === true) {
+    pass('scan-ats-full passesFilters passes everything through when content_filter is absent');
+  } else {
+    fail('scan-ats-full passesFilters should pass all postings when content_filter is absent');
+  }
+} catch (e) {
+  fail(`scan-ats-full content_filter wiring test crashed: ${e.message}`);
+}
+
 // ── VC Portfolio Seed Fetcher ────────────────────────────────────────
 // Tests the pure (no-network) parseSeedEntries(), parseYCPayload(),
 // parseA16zPayload(), toPortalEntry(), and the SEED_SOURCES registry.


### PR DESCRIPTION
## Problem

`scan-ats-full.mjs` only imported `buildTitleFilter`/`buildLocationFilter` from `scan.mjs`. `buildContentFilter` was never imported or called, so `portals.yml`'s `content_filter` — including #1638's per-title-keyword scoping (`content_filter.by_title_keyword`) — had **zero effect** on reverse ATS-directory scans. It only ever applied to the company-list-bounded `scan.mjs` path.

Real-world impact: a broad `title_filter.positive` keyword like `"AI"` (needed to catch AI-adjacent roles) pulls in a large volume of irrelevant postings via `scan-ats-full.mjs`, because there's no description-level relevance check at all in that scanner — the exact false-positive pattern #1636 documented and #1638 fixed, just not wired into this second scanner.

## Fix

- Import `buildContentFilter` and `matchedTitleKeywords` from `scan.mjs`.
- Build the content filter once from `config.content_filter`, same pattern `scan.mjs` uses at its own filter-setup site.
- Apply it at the same point `titleFilter`/`locationFilter` are already applied, in **both** scan paths this file has:
  - the main ATS-directory loop (`for (const name of opts.ats) …`)
  - the `--seeds` VC-portfolio path (`runSeedScan()`)
- Threaded the per-title-keyword scoping through properly: `content_filter.by_title_keyword` needs to know *which* `title_filter.positive` keyword matched a posting's title before it can pick the right override. I reused `matchedTitleKeywords(title, title_filter)` (already exported from `scan.mjs`, added in #1638) rather than reimplementing keyword-match tracking — this is the full fix, not a global-content_filter-only bolt-on that would silently ignore the scoping feature.
- Extracted the shared title/location/content decision into a small exported pure function, `passesFilters()`, mirroring the existing pattern of exported pure helpers in this file (`classifyPostingDate`, `sampleCompanies`) that exist specifically so scan logic is unit-testable without mocking providers/network. `runSeedScan()` calls it directly; the main loop keeps its inline per-stage checks since it tracks a `droppedContent` counter for the run summary (now surfaced in both the human log output and the `--json` result as `postingsDroppedContent`).

## Validation

Added a new test block in `test-all.mjs` covering the scenario from the issue and the by_title_keyword feature's original regression case:

- (a) a posting failing the **global** `content_filter` is rejected
- (b) a posting failing a **per-title-keyword** `content_filter.by_title_keyword` override is rejected
- (c) regression case from #1636/#1638: a posting matched via a **different** title keyword that has no override must **not** be wrongly rejected (the override must not leak across keyword categories)
- bonus: with no `content_filter` configured at all, behavior is unchanged (title/location only)

`node test-all.mjs`: 1741 passed, 0 failed (4 new assertions, all passing).

## File scope

Only `scan-ats-full.mjs` and `test-all.mjs` touched — no doc files reference `content_filter` today so none needed updating.

Closes #1846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reverse ATS scans now apply configured content filters to job descriptions, including title-scoped filtering.
  * Seeded and full directory scan pipelines consistently honor title, location, and content filtering.
  * JSON output now reports how many postings were removed by content filtering.
  * End-of-run summaries report content-filtered postings when applicable.

* **Bug Fixes**
  * Fixed title-specific content filter logic so unrelated keyword rules no longer affect results.

* **Tests**
  * Added regression coverage for global filters, title-scoped overrides, keyword-regression behavior, and the `null` (disabled) case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->