### PR TITLE
fix(update-system): correctly surface commit failures instead of sile…

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -949,13 +949,14 @@ async function apply() {
 
     // 7. Commit the update
     const remote = localVersion(); // Re-read after checkout updated VERSION
+    const pathsToStage = [...updated];
+    const dismissFile = join(ROOT, '.update-dismissed');
+    if (existsSync(dismissFile)) {
+      unlinkSync(dismissFile);
+      pathsToStage.push('.update-dismissed');
+    }
+
     try {
-      const pathsToStage = [...updated];
-      const dismissFile = join(ROOT, '.update-dismissed');
-      if (existsSync(dismissFile)) {
-        unlinkSync(dismissFile);
-        pathsToStage.push('.update-dismissed');
-      }
       prepareMaterializedSkillEntrypointsForStage(materializedSkillEntrypoints);
       addPaths(pathsToStage);
       // Scope the commit to only the staged update paths (#915 bug 2).
@@ -963,8 +964,24 @@ async function apply() {
       // the update commit. Passing the explicit pathspec list constrains the
       // commit to exactly the files this update touched.
       git('commit', '-m', `chore: auto-update system files to v${remote}`, '--', ...pathsToStage);
-    } catch {
-      // Nothing to commit (already up to date)
+    } catch (e) {
+      let commitFailed = false;
+      try {
+        const entries = gitStatusEntries();
+        const changedPaths = new Set(entries.map(entry => entry.path));
+        const allTargetPaths = [...pathsToStage, ...materializedSkillEntrypoints];
+        commitFailed = allTargetPaths.some(p => changedPaths.has(p));
+      } catch (err) {
+        commitFailed = true;
+      }
+
+      if (commitFailed) {
+        console.error(`\n[!] Update commit failed (files may be staged but not committed).`);
+        console.error(`    Error: ${e.message.split('\\n')[0]}`);
+        console.error(`    Please run 'git commit -m "chore: auto-update system files to v${remote}"' manually to finish the update.\n`);
+        process.exit(1);
+      }
+      // Otherwise, genuinely nothing to commit (already up to date)
     }
 
     console.log(`\nUpdate complete: v${local} → v${remote}`);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -976,10 +976,14 @@ async function apply() {
       }
 
       if (commitFailed) {
-        console.error(`\n[!] Update commit failed (files may be staged but not committed).`);
-        console.error(`    Error: ${e.message.split('\\n')[0]}`);
-        console.error(`    Please run 'git commit -m "chore: auto-update system files to v${remote}"' manually to finish the update.\n`);
-        process.exit(1);
+        const allTargetPaths = [...pathsToStage, ...materializedSkillEntrypoints];
+        const pathspec = allTargetPaths.map(p => `"${p}"`).join(' ');
+        throw new Error(
+          `Update commit failed (files may be staged but not committed).\n` +
+          `    Error: ${e.message.split('\n')[0]}\n` +
+          `    Please run manually to finish the update:\n` +
+          `    git commit -m "chore: auto-update system files to v${remote}" -- ${pathspec}`
+        );
       }
       // Otherwise, genuinely nothing to commit (already up to date)
     }


### PR DESCRIPTION
This PR resolves #1844 by ensuring that commit failures during system updates are not silently ignored.

### Context & Changes
Currently, `update-system.mjs` wraps the final stage-and-commit step in a generic `try/catch` block that assumes any error is a no-op (i.e. "Nothing to commit"). This silently swallows legitimate issues like:
- GPG signing failures (`commit.gpgsign = true` causing agent failures inside re-execs)
- Errors inside `prepareMaterializedSkillEntrypointsForStage`

To fix this, we:
1. Hoisted the update paths configuration out of the `try` block.
2. Updated the `catch` block to inspect `gitStatusEntries()`.
3. If any target update paths (including materialized skill entrypoints) still appear in `git status` as staged or modified after a failed commit, we treat it as a real failure.
4. When a failure is detected, the script prints the exact error message, alerts the user that their updates are staged but require a manual `git commit`, and exits with a non-zero exit code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of system update commit failures by validating whether the expected update outputs are still pending.
  * If changes remain, the update now provides clear instructions to complete the commit manually with the correct message and paths.
  * If the update is already complete (nothing left to commit), it no longer surfaces an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->