### PR TITLE
feat(interview-redflag): suggest a data/blacklist.md entry at the Reconsider tier

### DIFF
--- a/modes/interview-redflag.md
+++ b/modes/interview-redflag.md
@@ -121,17 +121,17 @@ Write the following structure:
 - "Before accepting: ask [specific questions] to verify the concern."
 - "Reconsider: the pattern across {N} rounds suggests [specific risk]."}
 
-{If Warning level is 🚩 Reconsider (score 4+), append a blacklist suggestion sub-block. Synthesize the one-line reason from the signal table in Step 3/4 — name the specific pattern(s) at 2+ sessions, not a generic label. This is a suggestion only: present the row in `data/blacklist.md`'s table format so the user can copy it in themselves. Never write to `data/blacklist.md`.
+{If Warning level is 🚩 Reconsider (score 4+), append a blacklist suggestion sub-block. Synthesize the one-line reason from the signal table in Step 3/4 — name the specific pattern(s) at 2+ sessions, not a generic label. This is a suggestion only: present the row in `data/blacklist.md`'s table format so the user can copy it in themselves. Never write to `data/blacklist.md`. Render the heading and instructional sentences in `{language.output}` per the project's language-mode rules (see AGENTS.md § "Output Language vs Market Modes") — only the table's column headers (`Company | Since | Scope | Reason`) and the literal `company` scope value stay fixed, since they must match `data/blacklist.md`'s actual file format regardless of output language.
 
-#### Consider adding to blacklist
+#### Consider adding to blacklist [heading — render in {language.output}]
 
-If you agree with this assessment, copy the row below into `data/blacklist.md` (see `templates/blacklist.example.md` for the file's column format):
+[Render in {language.output}: an instruction telling the user that if they agree with this assessment, they should copy the row below into `data/blacklist.md` (see `templates/blacklist.example.md` for the file's column format).]
 
 | Company | Since | Scope | Reason |
 |---------|-------|-------|--------|
 | {Company} | {today's date, YYYY-MM-DD} | company | {1-line reason drawn from the Step 3/4 signal breakdown, e.g. "2+ rounds: defensive closure + evaluator competency gap"} |
 
-This is a suggestion only — nothing is written to `data/blacklist.md` automatically.}
+[Render in {language.output}: a note that this is a suggestion only — nothing is written to `data/blacklist.md` automatically.]}
 
 *Analysis based on interviewer behaviour only. Candidate decides.*
 ```
@@ -153,10 +153,10 @@ Signals:
 → Full analysis written to interview-prep/{company-slug}-redflags.md
 ```
 
-If the warning level is `🚩 Reconsider`, add one line noting the suggestion is in the file — do not repeat the full blacklist row in the console summary:
+If the warning level is `🚩 Reconsider`, add one line noting the suggestion is in the file — do not repeat the full blacklist row in the console summary. Render this line in `{language.output}` (see AGENTS.md § "Output Language vs Market Modes"); only the file path is a fixed literal:
 
 ```text
-→ Blacklist entry suggested — see interview-prep/{company-slug}-redflags.md
+→ [render in {language.output}, e.g. "Blacklist entry suggested — see"] interview-prep/{company-slug}-redflags.md
 ```
 
 If multiple companies were analysed in one run, show a summary table:

--- a/modes/interview-redflag.md
+++ b/modes/interview-redflag.md
@@ -155,7 +155,7 @@ Signals:
 
 If the warning level is `🚩 Reconsider`, add one line noting the suggestion is in the file — do not repeat the full blacklist row in the console summary:
 
-```
+```text
 → Blacklist entry suggested — see interview-prep/{company-slug}-redflags.md
 ```
 

--- a/modes/interview-redflag.md
+++ b/modes/interview-redflag.md
@@ -121,6 +121,18 @@ Write the following structure:
 - "Before accepting: ask [specific questions] to verify the concern."
 - "Reconsider: the pattern across {N} rounds suggests [specific risk]."}
 
+{If Warning level is 🚩 Reconsider (score 4+), append a blacklist suggestion sub-block. Synthesize the one-line reason from the signal table in Step 3/4 — name the specific pattern(s) at 2+ sessions, not a generic label. This is a suggestion only: present the row in `data/blacklist.md`'s table format so the user can copy it in themselves. Never write to `data/blacklist.md`.
+
+#### Consider adding to blacklist
+
+If you agree with this assessment, copy the row below into `data/blacklist.md` (see `templates/blacklist.example.md` for the file's column format):
+
+| Company | Since | Scope | Reason |
+|---------|-------|-------|--------|
+| {Company} | {today's date, YYYY-MM-DD} | company | {1-line reason drawn from the Step 3/4 signal breakdown, e.g. "2+ rounds: defensive closure + evaluator competency gap"} |
+
+This is a suggestion only — nothing is written to `data/blacklist.md` automatically.}
+
 *Analysis based on interviewer behaviour only. Candidate decides.*
 ```
 
@@ -141,6 +153,12 @@ Signals:
 → Full analysis written to interview-prep/{company-slug}-redflags.md
 ```
 
+If the warning level is `🚩 Reconsider`, add one line noting the suggestion is in the file — do not repeat the full blacklist row in the console summary:
+
+```
+→ Blacklist entry suggested — see interview-prep/{company-slug}-redflags.md
+```
+
 If multiple companies were analysed in one run, show a summary table:
 
 ```
@@ -153,7 +171,7 @@ Company          Rounds   Level
 
 ## Scope / Non-Goals
 
-- **No auto-action** — never edits `portals.yml`, `modes/_profile.md`, or `data/applications.md`. Advisory only.
+- **No auto-action** — never edits `portals.yml`, `modes/_profile.md`, `data/applications.md`, or `data/blacklist.md`. At `🚩 Reconsider`, the output suggests a ready-to-copy blacklist row; the user (or their agent, on explicit instruction) still has to add it themselves. Advisory only.
 - **No new dependencies** — prompt-level analysis over local files.
 - **Privacy** — reads only local, gitignored session files. Nothing leaves the machine.
 - **Not a Glassdoor replacement** — analyses this candidate's live experience in this process, not crowd-sourced opinion.


### PR DESCRIPTION
## Summary
- When `interview-redflag`'s computed warning level is `🚩 Reconsider` (score 4+), the generated `interview-prep/{company-slug}-redflags.md` output now includes a "Consider adding to blacklist" sub-block with a ready-to-copy `data/blacklist.md`-format row (Company / Since / Scope / Reason), where the reason is synthesized from the signal breakdown already computed in Step 3/4.
- The Step 6 console summary gets one added line pointing to the suggestion when it's present, without repeating the full row inline.
- The Scope/Non-Goals section is updated to explicitly list `data/blacklist.md` alongside the other files this mode never auto-edits.

This bridges two existing, independently-shipped features (`interview-redflag` from #1233, `data/blacklist.md` from #1748) that compute the same shape of judgment but previously didn't reference each other.

## Non-goals / guarantees preserved
- No new script and no new executable logic — this is a markdown mode/prompt-instruction change only, telling the agent what additional text to generate.
- `data/blacklist.md` remains **never auto-populated**. The suggestion is presentational (written into the generated markdown report and echoed in the console summary); the user still has to copy the row in themselves.

## Test plan
- [x] `node test-all.mjs --quick` — 1736 passed, 0 failed (pre-existing warning unrelated to this change)
- [x] `git diff` scoped to `modes/interview-redflag.md` only
- [x] No docs-index changes needed — `modes/README.md` and `DATA_CONTRACT.md` entries for this mode/file remain accurate as-is

Closes #1854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an advisory “Consider adding to blacklist” sub-block to company red-flag reports when the warning level is “Reconsider.”
  * Included a copy-ready blacklist entry template with a synthesized, pattern-based reason—without automatically applying changes.
  * Updated the console/output to add a concise note pointing to the generated red-flags file when the suggestion is present (without reprinting the blacklist row).

* **Documentation**
  * Expanded Scope/Non-Goals to explicitly state that `data/blacklist.md` is never edited automatically, and blacklist entries remain user-driven.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->