### PR TITLE
feat(interview/plan): wire in the existing Panel Intel table when later-round panelists are named

### DIFF
--- a/modes/interview/plan.md
+++ b/modes/interview/plan.md
@@ -8,7 +8,7 @@ Given a job description and interview date/time, build a structured, time-blocke
 
 1. **Job description** (required) — paste inline or provide URL
 2. **Interview date and time** (required) — to calculate hours available
-3. **Interviewer name and role** (if known) — shapes depth and tone of prep
+3. **Interviewer name and role** (if known) — shapes depth and tone of prep. Later rounds (panel / onsite loop) often name several interviewers at once — from the user directly, a pasted calendar invite, or a pasted scheduling email. When more than one panelist is named, see the Panel Intel note in Step 2.
 4. **Round type** (if known) — screening, technical/domain-specific, design/case study, behavioral panel
 5. **CV** at `cv.md` + `article-digest.md` (if present) — read for experience, skills, proof points
 6. **Profile** at `config/profile.yml` + `modes/_profile.md` — read for narrative, archetypes, and targets
@@ -60,6 +60,8 @@ Identify what this round is actually evaluating based on:
 - Senior-level: set constraints, ask clarifying questions, drive the conversation
 
 Calibrate the plan to the round. Over-preparing depth for a screening wastes time and creates the wrong mindset.
+
+**Panel Intel (when panelists are named).** If two or more interviewers are named for this round — from the user directly, a pasted calendar invite, or a pasted scheduling email — build the Panel Intel table before moving to Step 3. See `modes/interview-prep.md` § "Panel Intel table" (under Step 4 → `panel-mixed`) for the full table format and the three sub-behaviors (decision-maker weighting against the JD's reporting line, career-trajectory signal reading, per-panelist tailored closing question) — apply that same logic here, then use the resulting audience tags to size Step 3's blocks per panelist instead of prepping one generic pack. A single named interviewer doesn't need the table; go straight to Step 3 calibrated to that person's round type above.
 
 ---
 


### PR DESCRIPTION
## Problem

\`modes/interview-prep.md\` already has a fully-designed Panel Intel table (decision-maker weighting against the JD's reporting line, career-trajectory signal reading, per-panelist tailored closing questions), built from pasted-in profile text or a screenshot description — no scraping or automation.

\`modes/interview/plan.md\` — the mode used for later-round, time-blocked prep, exactly when new panelists most often get named — had zero reference to this feature.

## Fix

Add a short cross-reference in \`interview/plan.md\` Step 2 ("Round Intelligence"): when two or more interviewers are named for the round (from the user directly, a pasted calendar invite, or a pasted scheduling email), build the Panel Intel table per \`interview-prep.md\` § "Panel Intel table" before sizing Step 3's blocks. Also noted the same in the Inputs section's interviewer-name entry, pointing to the Step 2 note.

Chose a pointer over duplicating the spec, per the issue's own suggestion — keeps the two mode files from drifting out of sync. Both mode files live in the same repo/`modes/` directory, so an agent following \`interview/plan.md\` has read access to \`interview-prep.md\` the same way it already reads other cross-referenced files like \`_shared.md\` and \`voice-dna.md\` (existing convention in this codebase).

## Scope

Docs/prompt-instruction change only — \`modes/interview/plan.md\`. No scripts, no automation, no other files touched.

Closes #1857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded interview planning guidance for identifying multiple panelists.
  * Added instructions for creating Panel Intel during multi-interviewer rounds and using audience tags to tailor preparation time.
  * Clarified that Panel Intel is unnecessary for single-interviewer sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->