### PR TITLE
feat(email): add confirmed-time no-show follow-up scenario

### DIFF
--- a/modes/email.md
+++ b/modes/email.md
@@ -47,6 +47,17 @@ Supported inputs:
      can't submit the form", "the assessment link is dead", "the login loop
      won't let me back in". Confirm the variant before drafting if ambiguous.
 
+5. `/career-ops email noshow {report-number-or-slug}`
+   - Load the matching `reports/{NNN}-*.md` for company and role context.
+   - Draft a confirmed-time no-show follow-up (see the dedicated section
+     below).
+   - Also trigger this variant conversationally when the user describes a
+     missed call after a two-way scheduling confirmation, e.g. "my call with
+     {interviewer} at {time} didn't happen", "we confirmed 2pm and nobody
+     called", "the recruiter never dialed in". Confirm the variant before
+     drafting if ambiguous — this is distinct from the cadence-driven
+     follow-ups in `modes/followup.md` (see the scope note below).
+
 ---
 
 ## Step 1 — Load Context
@@ -102,19 +113,24 @@ Choose one of four variants from user wording or context:
 | `referral_request` | User asks for referral, internal contact, friend, alumni, or former colleague. | Warm, low-pressure, easy to forward |
 | `cold_application` | No posted role, speculative reach-out, "cold email". | Direct, value-first, no desperation |
 | `process_stuck` | The ATS or application flow broke mid-process and email is the fallback channel. | Factual, forwardable, one precise ask |
+| `confirmed_time_noshow` | A recruiter or interviewer confirmed a specific call time in a two-way exchange and did not call. | Professional, not annoyed; time-anchored, not apologetic |
 
 If unclear, default to `hr_application`.
 
 **Precedence:** any process-failure signal (a broken step, an error message, a
 dead link, failed scheduling) selects `process_stuck` over the other variants.
-If a failure is hinted at but the intent is ambiguous, ask for confirmation —
-do not fall through to `hr_application`. The `hr_application` default applies
-only when there is no failure indication at all.
+A missed call after an explicit two-way time confirmation selects
+`confirmed_time_noshow` instead — it is not a process failure (nothing broke;
+someone simply did not call), so do not route it through `process_stuck`. If
+a failure or a missed-call signal is hinted at but the intent is ambiguous,
+ask for confirmation — do not fall through to `hr_application`. The
+`hr_application` default applies only when there is no failure or no-show
+indication at all.
 
-For `process_stuck`, skip Step 3 (fit points) and Step 4 (attachment checklist)
-— the reader already has the application; this email exists to unblock a
-process, not to sell — and follow the dedicated section below instead of the
-Step 5 structures.
+For `process_stuck` and `confirmed_time_noshow`, skip Step 3 (fit points) and
+Step 4 (attachment checklist) — the reader already has the application; these
+emails exist to unblock a process or reopen a scheduling gap, not to sell —
+and follow the dedicated sections below instead of the Step 5 structures.
 
 ---
 
@@ -309,6 +325,84 @@ stall the process.
 Best regards,
 {Candidate Name}
 {email}
+```
+
+---
+
+## Confirmed-Time No-Show Follow-up (`confirmed_time_noshow`)
+
+**Scope note:** this variant is unrelated to the elapsed-time cadence in
+`modes/followup.md` / `followup-cadence.mjs` (applied: 7 days, responded: 3
+days, interview: 1 day). Those track "it's been N days since the status
+changed." This variant is same-day and commitment-specific: a recruiter or
+interviewer explicitly confirmed a call time in a two-way exchange (email,
+ATS scheduler, text) and the call did not happen. There is no day-elapsed
+scoring here and no `followup-cadence.mjs` output to read — the trigger is
+the user telling you the confirmed time passed with no call.
+
+### Intake
+
+Required, always ask for whatever is missing (do not invent any of these):
+
+1. **The confirmed date/time**, as agreed in the exchange (include timezone
+   if known).
+2. **The interviewer or recruiter's name**, exactly as given by the user —
+   do not scrape or guess it from a report.
+3. **Remaining same-day availability** the user wants to offer (a window,
+   e.g. "before 4pm today" or "any time after 2:30").
+4. Company and role, for the subject line (from the linked report if one was
+   given, otherwise ask).
+
+### Draft structure
+
+1. Greeting, addressed to the named interviewer/recruiter by name.
+2. One plain sentence stating the confirmed time and that the call did not
+   happen. State it as a fact, not an accusation — no "I was very
+   disappointed" or over-apologizing for pointing it out.
+3. One sentence offering the remaining same-day availability the user gave.
+4. One-line reaffirmation of interest — brief, not a resell of fit points
+   (Step 3 is skipped for this variant).
+5. Signature.
+
+Keep it short: under 120 words. Reference the specific confirmed time
+plainly once; do not restate it more than once or pad with general "just
+checking in" framing (same banned-phrase rule as `modes/followup.md`).
+
+### Guardrails
+
+- **Tone is professional, not annoyed.** No passive-aggressive phrasing
+  ("I waited...", "I understand things come up, but..."), no guilt framing,
+  no exclamation points.
+- Never fabricate the confirmed time, the interviewer's name, or the
+  availability window — all three are user-provided inputs, never inferred
+  or scraped from a report.
+- Never speculate about why the call was missed (traffic, forgot, double
+  booked). State the fact and move to the ask.
+- This is a single follow-up for a single missed commitment, not a
+  multi-touch cadence — do not suggest a second no-show follow-up; if a
+  second miss happens, treat that as its own new instance of this same
+  scenario.
+- All standing email-mode guardrails apply unchanged: draft only, never
+  send, never click, never submit.
+
+### Example (generic)
+
+All values are placeholders. Fill them only with details the user actually
+provides.
+
+```text
+Subject: {Role} — following up on our {time} call
+
+Hi {Interviewer Name},
+
+We'd confirmed a call today at {confirmed time, timezone} for the {Role}
+role, and I didn't receive it. I'm available {remaining availability window}
+if there's still time to connect today.
+
+Still very interested in the role and happy to work around your schedule.
+
+Best,
+{Candidate Name}
 ```
 
 ---

--- a/modes/email.md
+++ b/modes/email.md
@@ -105,7 +105,7 @@ If `candidate.wechat` is absent, omit WeChat. Do not invent one.
 
 ## Step 2 — Classify Email Type
 
-Choose one of four variants from user wording or context:
+Choose one of five variants from user wording or context:
 
 | Variant | When | Tone |
 |---|---|---|
@@ -346,6 +346,8 @@ Required, always ask for whatever is missing (do not invent any of these):
 
 1. **The confirmed date/time**, as agreed in the exchange (include timezone
    if known).
+   Before drafting, verify that this time has passed and is today in the
+   relevant timezone; otherwise clarify the scenario or use another variant.
 2. **The interviewer or recruiter's name**, exactly as given by the user —
    do not scrape or guess it from a report.
 3. **Remaining same-day availability** the user wants to offer (a window,
@@ -365,8 +367,9 @@ Required, always ask for whatever is missing (do not invent any of these):
 5. Signature.
 
 Keep it short: under 120 words. Reference the specific confirmed time
-plainly once; do not restate it more than once or pad with general "just
-checking in" framing (same banned-phrase rule as `modes/followup.md`).
+plainly once in the body (the subject line may also reference it); do not
+restate it more than once in the body or pad with general "just checking in"
+framing (same banned-phrase rule as `modes/followup.md`).
 
 ### Guardrails
 

--- a/modes/followup.md
+++ b/modes/followup.md
@@ -6,6 +6,11 @@
 
 Track follow-up cadence for active applications. Flag overdue follow-ups, extract contacts from notes, and generate tailored follow-up email/LinkedIn drafts using report context.
 
+**Not in scope here:** a same-day follow-up after a recruiter/interviewer
+confirmed a specific call time and then didn't call. That's not an
+elapsed-time cadence case — see `confirmed_time_noshow` in `modes/email.md`
+(`/career-ops email noshow`) instead.
+
 ## Inputs
 
 - `data/applications.md` — Application tracker


### PR DESCRIPTION
## Problem

Neither existing tool covers "a recruiter confirmed a specific call time in a two-way exchange, and then didn't call":
- `modes/followup.md` + `followup-cadence.mjs` are purely elapsed-time cadence (applied: 7 days, responded: 3 days, interview: 1 day) — keyed off days-since-status-change, not a same-day missed commitment.
- `modes/email.md` covers formal application emails and, since a prior fix, a `process_stuck` variant for broken application machinery — but a missed call isn't a process failure, it's a missed human commitment.

## Fix

Added a new `confirmed_time_noshow` variant to `modes/email.md`, following the same situational-scenario pattern already established by `process_stuck` (variant table entry, precedence rule, dedicated intake/draft/guardrails section, generic example):

- **Why `email.md` over `followup.md`:** `email.md` already states it covers "recruiter follow-up emails" and already has the infrastructure for one-off, non-cadence situational scenarios (the `process_stuck` precedent — intake checklist, dedicated draft structure, guardrails). `followup.md`'s Step 1-6 flow assumes `followup-cadence.mjs` JSON output and application-tracker context that doesn't apply to a same-day, user-reported no-show. Shoehorning it there would mean bypassing most of that mode's existing steps. Added a short scope-note cross-reference in `followup.md` pointing to the new variant so users land on the right mode either way.
- **Inputs are all user-provided, never scraped/inferred:** confirmed date/time, interviewer name, remaining same-day availability.
- **Draft structure:** states the confirmed time and the missed call plainly (no over-apologizing), offers the remaining availability window, brief reaffirmation of interest, short (<120 words).
- **Tone guardrail:** professional, not annoyed — no passive-aggressive phrasing, no guilt framing, no speculation about why the call was missed.
- No new script — this is a documented instructional scenario for the AI agent to follow, consistent with how most mode-file features in this project work (drafting one email from user-supplied facts doesn't need deterministic script logic).

## Testing

- `node test-all.mjs --quick` — 1736 passed, 0 failed (docs-only change, no-op as expected).
- `git diff --stat` — scope limited to `modes/email.md` and `modes/followup.md`.

Closes #1859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for drafting email follow-ups for confirmed-time no-shows via a dedicated email mode.
  * Enhanced scenario classification to route missed confirmed-time events to the correct no-show flow.
  * Added guided intake (confirmed date/time, interviewer/recruiter name, remaining same-day availability, and role context) plus a constrained, factual draft format.
* **Documentation**
  * Clarified that same-day follow-up cadence tracking excludes confirmed-time no-shows, which are handled by the new no-show email flow instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->