### PR TITLE
fix(upskill): canonical known-skill suppression in targeted mode (fixes inverted gaps) (#1851)

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -16,7 +16,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run build:latex` | `build-cv-latex.mjs` | Build .tex from structured JSON payload |
 | `npm run sync-check` | `cv-sync-check.mjs` | Validate CV/profile consistency |
 | `npm run patterns` | `analyze-patterns.mjs` | Analyze tracker outcomes and report patterns |
-| `npm run upskill` | `upskill.mjs` | Aggregate skill-gap map from tracked reports |
+| `npm run upskill` | `upskill.mjs` | Aggregate skill-gap map from tracked reports (or `--url-text <url\|file>` for a single-JD targeted gap analysis) |
 | `npm run add` | `add-entry.mjs` | Dedup + insert a `/career-ops add` entry into cv.md / article-digest.md |
 | `npm run update:check` | `update-system.mjs check` | Check for upstream updates |
 | `npm run update` | `update-system.mjs apply` | Apply upstream update |
@@ -198,6 +198,8 @@ Aggregates skill gaps across every tracked report (#1520, phase 1). Extracts ski
 npm run upskill
 npm run upskill -- --summary
 npm run upskill -- --min-reports 3
+node upskill.mjs --url-text https://boards.greenhouse.io/acme/jobs/123   # targeted: gaps for one JD
+node upskill.mjs --url-text ./jds/my-job.txt                            # targeted: --url-text also takes a local file
 node upskill.mjs --self-test
 ```
 

--- a/modes/upskill.md
+++ b/modes/upskill.md
@@ -4,7 +4,9 @@
 
 After dozens of evaluations, the tracker holds dozens of verdicts — and no aggregate reading. Every low-scoring evaluation names the skills the candidate was missing. This mode turns that discard history into an answer to the question every job seeker asks: **what should I learn, in what order?**
 
-Phase 1 (this mode): aggregate gap map from tracked reports, with an optional LLM synthesis pass and a diff against the previous run. The web-searched learning plan and targeted `<URL>` mode are phase 2 (see #1520).
+Phase 1 (this mode): aggregate gap map from tracked reports, with an optional LLM synthesis pass and a diff against the previous run.
+
+**Targeted mode** (`node upskill.mjs --url-text <url-or-file>`, #1739) analyses a *single* JD instead of the tracked history: it extracts the JD's required skills, suppresses the ones already in `cv.md`/`config/profile.yml`, and prints the remaining gaps as JSON (`{ mode: "targeted", gaps, excludedAsKnown, knownSkills }`). Known-skill suppression uses the same canonical extraction as the aggregate path, so a CV skill is never reported as a gap and a real gap is never hidden. `--url-text` accepts either an `http(s)` URL (Playwright, then a redirect-refusing fetch fallback) or a local file path. The web-searched learning plan is still phase 2 (see #1520).
 
 Pattern credit: [MadsLorentzen/ai-job-search](https://github.com/MadsLorentzen/ai-job-search)'s `/upskill`, adapted to career-ops' tracker and A–F scoring model.
 

--- a/upskill.mjs
+++ b/upskill.mjs
@@ -589,7 +589,11 @@ if (urlTextIdx !== -1 || directUrl) {
         console.warn('Playwright extraction failed or blocked, trying fallback WebFetch...', err.message);
         try {
           const secureUrl = await validateUrlSecurity(inputSource);
-          const res = await fetch(secureUrl, { signal: AbortSignal.timeout(30000) });
+          // validateUrlSecurity only vets the initial URL; a redirect could still
+          // steer the fetch at an internal host (SSRF). The Playwright path
+          // re-validates per hop, but this plain fetch must refuse redirects
+          // outright — fail closed rather than follow an unvetted Location (#1851).
+          const res = await fetch(secureUrl, { signal: AbortSignal.timeout(30000), redirect: 'error' });
           if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
           targetText = await res.text();
         } catch (fetchErr) {

--- a/upskill.mjs
+++ b/upskill.mjs
@@ -263,6 +263,32 @@ export function aggregateGaps(reports, knownSkills) {
   return { gaps, excludedAsKnown, totalLowFit };
 }
 
+/**
+ * Targeted-mode gap analysis for a single JD (#1739): which JD skills are gaps
+ * vs. already known from the CV/profile.
+ *
+ * Uses the SAME canonicalization as the aggregate path (extractSkills on both
+ * sides, canonical-to-canonical comparison) so a known CV skill is suppressed
+ * and a real gap surfaces. The previous inline implementation matched raw
+ * lowercased regex tokens with substring `.includes()`, which (a) never matched
+ * symbol skills like `c\+\+`/`\.net` and (b) over-suppressed via substrings
+ * (`go` ⊂ `mongodb`, `sql` ⊂ `postgresql`, `java` ⊂ `javascript`) — inverting the
+ * result on every skill (#1851). Emits canonical names, matching aggregate mode.
+ *
+ * @param {string} jdText - the target job description text
+ * @param {string} knownText - cv + profile text (already-known skills)
+ * @returns {{ gaps: string[], excludedAsKnown: string[], knownSkills: string[] }}
+ */
+export function computeTargetedGaps(jdText, knownText) {
+  const known = extractSkills(knownText);
+  const gaps = [];
+  const excludedAsKnown = [];
+  for (const skill of extractSkills(jdText)) {
+    (known.has(skill) ? excludedAsKnown : gaps).push(skill);
+  }
+  return { gaps, excludedAsKnown, knownSkills: [...known].sort() };
+}
+
 // --- Main ---
 function analyze(minReports) {
   if (!existsSync(APPS_FILE)) {
@@ -566,58 +592,30 @@ if (urlTextIdx !== -1 || directUrl) {
       }
     }
 
-    const rawJdSkills = extractSkills(targetText);
-    const jdSkills = Array.isArray(rawJdSkills) ? rawJdSkills : Array.from(rawJdSkills || []);
-
-    let knownTextChunks = [];
+    // Assemble the known-skills text (cv + profile), matching aggregate mode.
+    // Targeted mode additionally falls back to cv-example.md when cv.md is absent
+    // so a fresh checkout still produces a meaningful comparison.
+    const knownTextChunks = [];
     if (existsSync(PROFILE_FILE)) {
-      try { knownTextChunks.push(readFileSync(PROFILE_FILE, 'utf-8').toLowerCase()); } catch (e) {}
+      try { knownTextChunks.push(readFileSync(PROFILE_FILE, 'utf-8')); } catch (e) {}
     }
-
     let activeCvFile = CV_FILE;
     if (!existsSync(activeCvFile)) {
       activeCvFile = join(CAREER_OPS, 'cv-example.md');
     }
     if (existsSync(activeCvFile)) {
-      try { knownTextChunks.push(readFileSync(activeCvFile, 'utf-8').toLowerCase()); } catch (e) {}
+      try { knownTextChunks.push(readFileSync(activeCvFile, 'utf-8')); } catch (e) {}
     }
 
-    const combinedKnownText = knownTextChunks.join('\n');
-    const knownSkillsSet = new Set();
-
-    if (typeof SKILL_TOKENS !== 'undefined' && Array.isArray(SKILL_TOKENS)) {
-      SKILL_TOKENS.forEach(token => {
-        if (combinedKnownText.includes(token.toLowerCase())) {
-          knownSkillsSet.add(token.toLowerCase());
-        }
-      });
-    }
-
-    const essentialSuppression = ['python', 'kubernetes', 'kafka', 'pytorch', 'tensorflow', 'aws', 'redis', 'postgresql', 'go', 'typescript', 'sql'];
-    essentialSuppression.forEach(token => {
-      if (combinedKnownText.includes(token)) {
-        knownSkillsSet.add(token);
-      }
-    });
-
-    const gapList = [];
-    const excludedAsKnown = [];
-
-    jdSkills.forEach(skill => {
-      if (!skill) return;
-      if (knownSkillsSet.has(skill.toLowerCase())) {
-        excludedAsKnown.push(skill);
-      } else {
-        gapList.push(skill);
-      }
-    });
+    const { gaps: gapList, excludedAsKnown, knownSkills } =
+      computeTargetedGaps(targetText, knownTextChunks.join('\n'));
 
     console.log(JSON.stringify({
       mode: 'targeted',
       source: inputSource,
       gaps: gapList.map(skill => ({ skill })),
       excludedAsKnown: excludedAsKnown.map(skill => ({ skill })),
-      knownSkills: Array.from(knownSkillsSet).sort()
+      knownSkills,
     }, null, 2));
 
     process.exit(0);

--- a/upskill.mjs
+++ b/upskill.mjs
@@ -493,6 +493,27 @@ soft_gaps:
   if (!/Kafka/.test(parsed.gapText)) failures.push('Gap table row not captured');
   if (!/Airflow/.test(parsed.gapText)) failures.push('soft_gaps not captured');
 
+  // Targeted mode (#1851): known-skill suppression must be canonical-to-canonical,
+  // never raw-token substring matching. The old inline path inverted every skill —
+  // CV skills shown as gaps, real gaps hidden. This is the exact reproduction from
+  // the bug report.
+  {
+    const { gaps, excludedAsKnown } = computeTargetedGaps(
+      'Kubernetes, C++, .NET, Java, SQL, Go, LLMs',        // JD asks for
+      'k8s, C++, .NET, JavaScript, PostgreSQL, MongoDB, LLMs' // CV already has
+    );
+    const gapSet = new Set(gaps);
+    const exSet = new Set(excludedAsKnown);
+    for (const g of ['Java', 'SQL', 'Go']) {
+      if (!gapSet.has(g)) failures.push(`targeted: ${g} should be a gap (got ${gaps.join(',')})`);
+      if (exSet.has(g)) failures.push(`targeted: real gap ${g} wrongly suppressed as known`);
+    }
+    for (const k of ['Kubernetes', 'C++', '.NET', 'LLMs']) {
+      if (!exSet.has(k)) failures.push(`targeted: ${k} should be excluded as known (got ${excludedAsKnown.join(',')})`);
+      if (gapSet.has(k)) failures.push(`targeted: known skill ${k} wrongly reported as gap`);
+    }
+  }
+
   if (failures.length > 0) {
     console.error(`upskill self-test failed: ${failures.join('; ')}`);
     process.exit(1);


### PR DESCRIPTION
Fixes #1851. Thanks @Scott-Emberson for the root-cause + recipe.

## The bug
Targeted mode (`--url-text`, #1739/#1796) re-implemented known-skill suppression instead of reusing the aggregate path's canonicalization, and the two vocabularies disagreed badly enough to **invert the result on every skill**:

- `SKILL_TOKENS` matching did substring `.includes()` over **raw lowercased regex tokens** (`c\+\+`, `\.net`, `llms?`) — the literal backslashes never match real CV text, so those CV skills were reported as gaps.
- a hardcoded `essentialSuppression` list did bare substring matching, so `go` ⊂ mongo**db**, `sql` ⊂ postgre**sql**, `java` ⊂ **java**script hid real gaps.

Reproduction (CV `k8s, C++, .NET, JavaScript, PostgreSQL, MongoDB, LLMs` / JD `Kubernetes, C++, .NET, Java, SQL, Go, LLMs`) came out wrong on all 7 skills, both directions.

## The fix (as scoped in the issue)
- **New exported `computeTargetedGaps(jdText, knownText)`** — runs `extractSkills()` on both sides and compares **canonical-to-canonical** (same as the aggregate path ~311–315). `essentialSuppression` + the raw-token matching are deleted; output emits canonical names. Result now matches the "correct" column exactly: gaps = `Java, SQL, Go`, excluded = `Kubernetes, C++, .NET, LLMs`.
- **Regression test**: the exact 7-skill fixture added to `runSelfTest()` (the targeted path had zero coverage), asserting both directions — real gaps surface *and* known skills don't leak in.

## Same-PR items you flagged
- **Docs**: `docs/SCRIPTS.md` and `modes/upskill.md` now document the targeted `--url-text` mode (previously described as aggregate-only / "phase 2"), including that `--url-text` also accepts a local file path.
- **SSRF**: the fetch fallback now uses `redirect: 'error'` — `validateUrlSecurity()` only vets the initial URL, so the fallback fails closed rather than following an unvetted redirect (the Playwright path already re-validates per hop).

## Tests
`node test-all.mjs --quick` → **1736 passed, 0 failed** (includes the new targeted self-test).

4 commits: canonical-suppression fix · regression fixture · SSRF redirect guard · docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added targeted job-description analysis using a URL or local file.
  * Reports missing skills, recognized skills, and skills excluded because they are already known.
  * Supports secure processing of remote job-description URLs.

* **Bug Fixes**
  * Improved skill matching for terms such as C++, .NET, JavaScript, SQL, and PostgreSQL.
  * Prevented known skills from being incorrectly classified as gaps.

* **Documentation**
  * Added targeted-mode usage instructions and examples for remote URLs and local files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->