### PR TITLE
fix(envrc): only load the Nix flake when Nix is installed

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,13 @@
 export DIRENV_WARN_TIMEOUT=2m
-if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
-    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
-fi
+
+# Load .env for everyone. Only bring up the Nix flake dev shell when Nix is
+# actually installed, so direnv users without Nix are not hit with a
+# `nix: command not found` error on every cd into the repo.
 dotenv
-use flake
+
+if has nix; then
+    if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
+        source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
+    fi
+    use flake
+fi


### PR DESCRIPTION
`.envrc` runs `use flake` unconditionally, which requires the `nix` binary.

direnv is a general-purpose tool. Plenty of people install it only to auto-load `.env` files or set per-project PATH, with no Nix on the machine. For all of them the committed `.envrc` prints this on every `cd` into the repo:

```
direnv: using flake
direnv: nix-direnv: command not found: nix
```

The README installs the project with npm and never mentions Nix, so someone who follows it and also happens to use direnv (a common pairing) runs into the error with no hint that Nix was expected. It is non-fatal, npm still works, but it is noise aimed at users who followed the setup guide.

## Change

Wrap the nix-direnv bootstrap and `use flake` in `if has nix; then ... fi`, and move `dotenv` outside the guard so `.env` still loads regardless of Nix.

- With Nix installed: same behavior as today, the flake dev shell comes up.
- Without Nix: `.env` loads, the flake is skipped, no error.

`has` is direnv's own builtin, so the guard adds no dependency.

## Testing

This only touches `.envrc` (direnv config), which `test-all.mjs` does not exercise, so I verified it by hand:

- Nix present: `direnv allow` brings up the flake dev shell as before.
- Nix absent (direnv installed, no `nix` on PATH): `cd` into the repo is quiet and `.env` still loads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development environment setup for systems without Nix installed.
  * Environment variables now load consistently, while Nix-specific activation runs only when Nix is available.
  * Prevented Nix-related setup errors on non-Nix systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->