### PR TITLE
docs: mention NVIDIA NIM in the openai-eval provider list

### DIFF
--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -105,7 +105,7 @@ When choosing a budget-friendly model, you need strong reasoning capabilities to
 > ```
 > Run `node openai-eval.mjs --help` for per-provider examples. For 100% local/private use, point `--url` at a local server (LM Studio / llama.cpp / vLLM) or use `node ollama-eval.mjs`.
 
----
+> NVIDIA NIM also works (hosted `https://integrate.api.nvidia.com/v1` or a self-hosted container's `/v1`), e.g. `--model meta/llama-3.3-70b-instruct`. The hosted free tier can queue for minutes, so raise `OPENAI_TIMEOUT_MS` above the 300s default.
 
 ## 5. Local LLM Tradeoffs (Ollama / Llama.cpp)
 
@@ -228,7 +228,7 @@ npm run or:eval        # Evaluate a single offer (paste URL or text)
 npm run or:apply       # Generate draft application answers for a report
 ```
 
-**Usage** 
+**Usage**
 
 ```bash
 node openrouter-runner.mjs scan              # Scan Greenhouse API companies for new listings


### PR DESCRIPTION
I use NVIDIA's hosted NIM API for job scoring in another project and wanted to point career-ops evaluation at it. Turns out `openai-eval.mjs` already handles it fine since NIM speaks the OpenAI API, but NIM isn't mentioned in `RUNNING_ON_A_BUDGET.md` so I didn't know until I tried.

Tested against the hosted API with `meta/llama-3.3-70b-instruct`, got a full report and the score summary parsed fine. One thing that bit me: the hosted free tier queues hard (a tiny test request took ~90s), so the default 300s timeout kept failing on full evals. 600s worked. Added that to the line too.

One line, docs only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an NVIDIA NIM compatibility note for standalone evaluator usage, including hosted vs. self-hosted `--url` expectations.
  * Provided an example `--model` value and guidance to increase `OPENAI_TIMEOUT_MS` above the 300s default to reduce queue delays.
  * Updated the OpenRouter free-models section by adding a bold **Usage** label before the command list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->