### PR TITLE
fix(pdf): drop empty Projects section instead of rendering a bare header

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -250,6 +250,14 @@ function renderHtml(template, payload) {
   let html = template.replace(CONTACT_ROW_RE, () => buildContactRow(candidate));
   html = html.replace(/\{\{PHOTO\}\}/g, () => buildPhoto(candidate, candidate.name));
 
+  // Projects is the one CV section that's genuinely optional (education,
+  // experience, and skills are effectively always present) — drop the whole
+  // <!-- PROJECTS --> block when there are no entries, instead of leaving a
+  // bare "Projects" header with nothing under it.
+  if (!Array.isArray(payload.projects) || payload.projects.length === 0) {
+    html = html.replace(/<!-- PROJECTS -->[\s\S]*?(?=<!-- EDUCATION -->)/, '');
+  }
+
   for (const [key, value] of Object.entries(substitutions)) {
     html = html.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), () => value);
   }

--- a/build-cv-latex.mjs
+++ b/build-cv-latex.mjs
@@ -116,6 +116,14 @@ async function main() {
 
   let template = await readFile(TEMPLATE_PATH_RESOLVED, 'utf-8');
 
+  // Projects is the one CV section that's genuinely optional (education,
+  // experience, and skills are effectively always present) — drop the whole
+  // Personal Projects \section when there are no entries, instead of leaving
+  // a bare section header with nothing under it.
+  if (!Array.isArray(payload.projects) || payload.projects.length === 0) {
+    template = template.replace(/%%%%%%%%%%%%%%%%%%%%%%%%%%%%  PROJECTS  %%%%%%%%%%%%%%%%%%%%%%%%%%%%[\s\S]*?(?=%%%%%%%%%%%%%%%%%%%%%%%%%%%%  Technical Skills)/, '');
+  }
+
   const emailUrl = sanitizeUrl(payload.email?.url || '');
   const emailDisplay = payload.email?.display || emailUrl;
   const linkedinUrl = sanitizeUrl(payload.linkedin?.url || '');


### PR DESCRIPTION
## What does this PR do?

`build-cv-html.mjs` and `build-cv-latex.mjs` always render the "Projects" section title from the template, even when `payload.projects` is empty or absent. Projects is the one CV section that's genuinely optional (a candidate's projects are often already covered under Work Experience), so any CV generated without a `projects` array in the JSON payload ships a blank "Projects" heading with nothing underneath it in the rendered PDF/HTML/LaTeX output.

## Duplicate-check trail

- `gh search issues "empty Projects section" --repo santifer/career-ops --include-prs` -> no results
- `gh search issues "buildProjects" --repo santifer/career-ops --include-prs` -> only #905 (the original `build-cv-latex.mjs` PR), not this bug
- `gh search prs "build-cv-html.mjs" --repo santifer/career-ops` -> no open PRs touching this file
- `build-cv-html.mjs` landed in #1681 (merged 2026-07-11), so this is likely just unnoticed since it's very recent, not a re-report of a known issue

## Root cause

`templates/cv-template.html` (and `templates/resume-template.html`) unconditionally wrap the Projects placeholders:

```html
<!-- PROJECTS -->
<div class="section">
  <div class="section-title">{{SECTION_PROJECTS}}</div>
  {{PROJECTS}}
</div>
```

`buildProjects()` in `build-cv-html.mjs` correctly returns `''` when `payload.projects` is empty (`build-cv-html.mjs:116-117`), but nothing strips the surrounding `.section` wrapper, so the header renders with an empty body underneath. Same pattern in `templates/cv-template.tex`'s `\section{Personal Projects}` and `build-cv-latex.mjs`.

## Steps to reproduce

```bash
node build-cv-html.mjs --test   # sample payload includes a project, won't reproduce
```

```json
// payload.json - omit "projects" entirely (or pass projects: [])
{ "candidate": {"name": "Test"}, "summary": "...", "experience": [{"company":"Acme","role":"Eng","dates":"2024","bullets":["Did a thing"]}], "education": [{"title":"BS","org":"U","year":"2024"}] }
```

```bash
node build-cv-html.mjs payload.json out.html
grep -A2 'section-title">Projects' out.html
# <div class="section-title">Projects</div>
# (nothing)
```

## Expected behavior

When `projects` has no entries, the whole Projects section (header + wrapper) should be omitted from the rendered CV, the same way an empty CV never shows a dangling section title for anything else.

## Suggested fix (already applied in this PR)

In `renderHtml()` (`build-cv-html.mjs`) and the equivalent spot in `build-cv-latex.mjs`, strip the whole Projects block before the placeholder-substitution loop when `payload.projects` is empty:

```js
if (!Array.isArray(payload.projects) || payload.projects.length === 0) {
  html = html.replace(/<!-- PROJECTS -->[\s\S]*?(?=<!-- EDUCATION -->)/, '');
}
```

(LaTeX side matches on the `%%%% PROJECTS %%%%` / `%%%% Technical Skills %%%%` comment markers instead.) Both templates place Projects immediately before Education, so the non-greedy match is safe for the base template and `resume-template.html`.

## Test plan

- [x] `node build-cv-html.mjs --test` passes (sample payload has a project entry, verifies no regression)
- [x] `node build-cv-latex.mjs --test` passes (same)
- [x] Manually verified: payload without `projects` now produces zero "Projects" markup in the output HTML (previously left an empty header)
- [x] `node verify-cv-facts.mjs` still passes on the regenerated HTML
- [x] `node test-all.mjs`: 1745 passed, 2 failed on this branch — confirmed both failures (`tracker-columns-tests.mjs`, `offer-prep` data-contract check) pre-exist on `main` without this change (checked out `main` directly and reran); unrelated to this fix
- [ ] Not tested: `resume-template.html` end-to-end (fix targets the same marker pattern, not independently verified with a real payload)

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Bug fix — no issue required
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` — 2 pre-existing failures unrelated to this change (see Test plan)
- [x] My changes respect the Data Contract (only touches system-layer `build-cv-html.mjs` / `build-cv-latex.mjs`, no user-layer files)
- [x] My changes align with the project roadmap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty project data no longer produces blank “Projects” or “Personal Projects” sections in generated CVs.
  * Generated HTML and LaTeX CVs now omit the entire projects section when no projects are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->