### PR TITLE
feat: add role name to PDF filename for multi-role tracking

### DIFF
--- a/openai-tailor.mjs
+++ b/openai-tailor.mjs
@@ -118,6 +118,14 @@ const reportFilename = basename(reportPath);
 const match = reportFilename.match(/^\d+-([a-z0-9-]+)-\d{4}-\d{2}-\d{2}\.md$/);
 const companySlug = match ? match[1] : 'unknown-company';
 
+// Extract role from report header (e.g., "# Evaluation: Company - Role Title")
+let roleSlug = 'role';
+const roleMatch = reportText.match(/^#\s+Evaluation:\s+[^-]+\s+-\s+(.+?)$/m);
+if (roleMatch && roleMatch[1]) {
+  roleSlug = roleMatch[1]
+    .toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
 // ---------------------------------------------------------------------------
 // Endpoint + security guard.
 // ---------------------------------------------------------------------------
@@ -300,7 +308,7 @@ try {
   console.log(`\n✅  Tailored HTML saved: ${htmlPath}`);
 
   // Print next steps
-  const pdfFilename = `cv-${candidateName}-${companySlug}-${new Date().toISOString().split('T')[0]}.pdf`;
+  const pdfFilename = `cv-${companySlug}-${roleSlug}-${new Date().toISOString().split('T')[0]}.pdf`;
   const reportNumMatch = reportFilename.match(/^(\d+)-/);
   const reportNum = reportNumMatch ? reportNumMatch[1] : '001';
 

--- a/openai-tailor.mjs
+++ b/openai-tailor.mjs
@@ -308,7 +308,7 @@ try {
   console.log(`\n✅  Tailored HTML saved: ${htmlPath}`);
 
   // Print next steps
-  const pdfFilename = `cv-${companySlug}-${roleSlug}-${new Date().toISOString().split('T')[0]}.pdf`;
+  const pdfFilename = `cv-${candidateName}-${companySlug}-${roleSlug}-${new Date().toISOString().split('T')[0]}.pdf`;
   const reportNumMatch = reportFilename.match(/^(\d+)-/);
   const reportNum = reportNumMatch ? reportNumMatch[1] : '001';
 


### PR DESCRIPTION
## What does this PR do?

When applying to multiple roles at the same company, the generated CVs were overwriting each other in the output folder. This PR adds the role name to the PDF filename to prevent conflicts and enable better traceability.

**Before:** `cv-{company}-{date}.pdf`  
**After:** `cv-{company}-{role}-{date}.pdf`

**Example:** `cv-parloa-manager-forward-deployed-engineering-2026-07-15.pdf`

This allows referencing the correct tailored CV during interviews and keeps a clean audit trail of which CV version was generated for which role.

## Related issue

N/A (bug fix — no issue needed per CONTRIBUTING.md)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran \`node test-all.mjs\` (1 pre-existing test failure unrelated to these changes)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (only modified system-layer file openai-tailor.mjs)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated evaluation PDF filenames by automatically including the evaluated role alongside the company, making documents easier to identify and organize.
  * Tailored HTML filenames remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->