### PR TITLE
fix(cv-template): keep role header with its bullets when a location line is present

### DIFF
--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -380,6 +380,7 @@
   .section-title,
   .job-company,
   .job-role,
+  .job-location,
   .project-title {
     break-after: avoid;
     page-break-after: avoid;


### PR DESCRIPTION
## What

`templates/cv-template.html` print CSS keeps a role header attached to the content that follows it via a `break-after: avoid` group, but the group only listed `.section-title`, `.job-company`, `.job-role`, and `.project-title` — not `.job-location`.

`build-cv-html.mjs` renders each experience entry as:

```
.job-header (.job-company + .job-period)
.job-role
.job-location        <-- only present when the entry has a location
<ul> … bullets …
```

When an entry has a location, `.job-location` is the **last element before the bullet list**. Since it was not in the `break-after: avoid` group, a page break could land right after it, orphaning the role header (company + title + location) at the bottom of one page while its bullets flowed onto the next.

## Fix

Add `.job-location` to the existing `break-after: avoid` group (one line). The header, location line, and first bullet now stay together. Multi-bullet roles can still split across a page boundary, preserving the existing design intent noted in the surrounding comment ("multi-bullet roles are allowed to flow across a page boundary so content packs tight").

## Reproduce

Generate a two-page CV where an experience entry that has a `location` falls across the page-1/page-2 boundary: before this change the company/role header renders at the bottom of page 1 with its bullets on page 2.

## Testing

`node test-all.mjs` → 1730 passed. The only failing item is `tracker-columns-tests.mjs`, which fails solely because the local runtime is Node 18 and `tracker.mjs`'s sqlite path needs Node ≥ 22.5 (`node:sqlite is not available`). That is environmental and pre-existing on `main`, unrelated to this CSS-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved printed and PDF resume pagination by keeping job location text together and preventing awkward page breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->