### PR TITLE
fix(scan): quiet dotenv so --json stdout stays parseable

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -47,7 +47,9 @@ import { normalizeCompany } from './tracker-utils.mjs';
 
 try {
   const { config } = await import('dotenv');
-  config();
+  // quiet: dotenv's startup banner goes to stdout, which --json reserves for a
+  // single JSON object (#1906).
+  config({ quiet: true });
 } catch {
   // dotenv is optional — fall back to process.env if not installed
 }

--- a/tests/scan-json-stdout.test.mjs
+++ b/tests/scan-json-stdout.test.mjs
@@ -1,0 +1,65 @@
+// tests/scan-json-stdout.test.mjs — scan.mjs must keep stdout clean so that
+// --json output stays machine-parseable (issue #1906).
+//
+// scan.mjs loads dotenv at module top level. dotenv v17 prints a startup
+// banner to stdout, gated on the `quiet` option rather than on isTTY, so it
+// fires even when stdout is a pipe. scan-ats-full.mjs imports scan.mjs, which
+// means the import alone is enough to put that banner on the stdout channel
+// that --json reserves for a single JSON object. Consumers that accumulate
+// stdout and JSON.parse it then fail on the leading banner.
+//
+// Both checks run scan.mjs in a child process: stdout has to be measured on a
+// real pipe, and the parent's own stdout carries the suite log.
+import { pass, fail, warn, run, NODE, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nscan.mjs — --json stdout stays machine-parseable (#1906)');
+
+try {
+  const scanUrl = JSON.stringify(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+
+  // dotenv is an optional import in scan.mjs. If it is not installed the
+  // banner cannot fire and both checks below would pass without proving
+  // anything, so say so rather than reporting a green that means nothing.
+  const dotenvPresent = run(NODE, ['-e', 'await import("dotenv")']) !== null;
+
+  if (!dotenvPresent) {
+    warn('dotenv is not installed — cannot verify the stdout channel stays clean');
+  } else {
+    // Importing scan.mjs must be silent on stdout. scan.mjs guards its CLI
+    // entry point, so the import runs module top level only.
+    const importOut = run(NODE, ['-e', `await import(${scanUrl})`]);
+    if (importOut === '') {
+      pass('importing scan.mjs writes nothing to stdout');
+    } else if (importOut === null) {
+      fail('importing scan.mjs failed');
+    } else {
+      fail(`importing scan.mjs wrote to stdout: ${JSON.stringify(importOut.slice(0, 80))}`);
+    }
+
+    // The contract a --json consumer depends on: accumulate the child's stdout,
+    // JSON.parse it, get the object back. Emitting the JSON after the import
+    // reproduces the ordering that scan-ats-full.mjs --json produces.
+    const jsonOut = run(NODE, [
+      '-e',
+      `await import(${scanUrl}); process.stdout.write(JSON.stringify({ date: '2026-01-01', offers: [] }));`,
+    ]);
+    if (jsonOut === null) {
+      fail('child emitting JSON after importing scan.mjs failed');
+    } else {
+      try {
+        const parsed = JSON.parse(jsonOut);
+        if (parsed.date === '2026-01-01' && Array.isArray(parsed.offers)) {
+          pass('stdout of a --json run parses as a single JSON object');
+        } else {
+          fail(`parsed stdout is not the emitted object: ${JSON.stringify(parsed).slice(0, 80)}`);
+        }
+      } catch (e) {
+        fail(`stdout of a --json run does not parse as JSON: ${e.message}`);
+      }
+    }
+  }
+} catch (e) {
+  fail(`scan --json stdout tests crashed: ${e.message}`);
+}


### PR DESCRIPTION
## What does this PR do?

`scan.mjs` loads dotenv at module top level with a bare `config()`. dotenv v17 prints a startup banner to stdout, gated on the `quiet` option rather than on `isTTY`, so it fires even when stdout is a pipe, and `scan-ats-full.mjs` imports `scan.mjs`, so that import alone puts the banner on the stdout channel that `--json` reserves for a single JSON object. Passing `quiet: true` leaves env loading exactly as it was and keeps the banner off stdout.

Before, `node scan-ats-full.mjs --dry-run --since 7 --ats greenhouse --limit 3 --json` printed `◇ injected env (0) from .env // tip: ...` ahead of the JSON, and parsing that stdout threw `Unexpected token '◇'`. After, stdout is the JSON object alone and parses cleanly. Two consumers depend on this: `web/src/lib/core/scan.ts`, which reports "The scanner returned no readable output." with 0 offers when the parse throws, and `web/src/lib/core/pipeline.ts`, which spawns a module importing `scan.mjs` and falls back to `added: 0` when its stdout does not parse. Fixing it at the dotenv call clears both, so neither consumer needs parsing workarounds.

`tests/scan-json-stdout.test.mjs` pins the contract: importing `scan.mjs` writes nothing to stdout, and the stdout of a `--json` run parses as a single JSON object. It fails on the old code and passes on the new. dotenv is an optional import in `scan.mjs`, so the test warns rather than passing silently when dotenv is absent, since the banner cannot fire without it.

## Related issue

Closes #1906

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kept standard output clean when using JSON mode, ensuring results remain machine-readable.
  * Prevented environment-loading messages from being mixed into JSON output.

* **Tests**
  * Added coverage verifying imports produce no unexpected output.
  * Added validation that JSON results contain the expected date and offers data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->