### PR TITLE
fix: unify atomic report number allocation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `data/scan-runs.tsv` | Per-run scan counters (appended by `scan.mjs`, read by `stats.mjs`) |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON output) |
 | `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON output) |
-| `set-status.mjs` | Canonical CLI to update a tracker row: `node set-status.mjs <report#\|company> <State> [--note]` — strict states.yml validation, shared tracker lock, atomic write |
+| `set-status.mjs` | Canonical CLI to update a tracker row: `node set-status.mjs <report#\|company> <State> [--note] [--force]` — strict states.yml validation, report-link mismatch guard, shared tracker lock, atomic write |
 | `invite-match.mjs` | Fuzzy-matches a pasted interview-invite email (company name, date, req ID) against `data/applications.md`, ranking candidates when a company has multiple tracker entries (JSON or `--summary` table output) |
 | `paste-reply.mjs` | Manual/no-Gmail input path into `reply-watch.mjs`'s classification pipeline — normalizes a pasted or file-provided email's subject/from/body into a candidate object and appends it to `data/reply-candidates.json` (never overwrites existing entries; never classifies or touches the tracker itself) |
 | `detect-reposts.mjs` | Repost detector — flags roles re-listed 2+ times in 90 days from scan-history.tsv (JSON or `--summary` table output) |
@@ -401,7 +401,7 @@ When spawning headless workers for batch processing, use the appropriate command
 | Antigravity CLI | `agy -p "prompt"` |
 | Grok Build CLI | `grok -p "prompt"` |
 
-**Parallel fan-outs — reserve report numbers first.** When orchestrating N parallel evaluators (headless workers, subagents, or multiple agent windows), reserve the report-number range before spawning: `node reserve-report-num.mjs --count N` prints e.g. `042-049`; hand each worker its own number. Each slot claim is individually atomic; the contiguous range is an ergonomic allocation, not an all-or-nothing transaction — on collision the partially claimed slots are released and the reservation restarts past the collision. Release with `node reserve-report-num.mjs --release 042-049` when done (stale sentinels are GC'd after 4h, so reserve right before spawning; collision restarts leave permanent — harmless — gaps in the sequence). Never let parallel workers compute `max+1` themselves — that is the #749 race.
+**Parallel fan-outs — reserve report numbers first.** When orchestrating N parallel evaluators (headless workers, subagents, or multiple agent windows), reserve the report-number range before spawning: `node reserve-report-num.mjs --count N` prints e.g. `042-049`; hand each worker its own number. The allocator treats report files, sentinels, tracker row IDs, and tracker report links as occupied. Each slot claim is individually atomic; the contiguous range is an ergonomic allocation, not an all-or-nothing transaction — on collision the partially claimed slots are released and the reservation restarts past the collision. Release with `node reserve-report-num.mjs --release 042-049` when done (stale sentinels are GC'd after 4h, so reserve right before spawning; collision restarts leave permanent — harmless — gaps in the sequence). Never let parallel workers compute `max+1` themselves — that is the #749 race.
 
 ## Stack and Conventions
 

--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -430,7 +430,7 @@ ${evaluationText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').tri
 
   if (reservedNumbers.length > 0) {
     try {
-      releaseReportNumbers(reservedNumbers, { reportsDir: PATHS.reports });
+      await releaseReportNumbers(reservedNumbers, { reportsDir: PATHS.reports });
     } catch (err) {
       console.warn(`⚠️   Could not release report reservation: ${err.message}`);
     }

--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -28,10 +28,13 @@
  * `modelName` below and the `--model` examples accordingly.
  */
 
-import { readFileSync, existsSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
+import {
+  formatReportNumber, releaseReportNumbers, reserveReportNumbers,
+} from './reserve-report-num.mjs';
 
 // ---------------------------------------------------------------------------
 // Bootstrap: load .env before anything else
@@ -151,16 +154,6 @@ function readFile(path, label) {
     return `[${label} not found — skipping]`;
   }
   return readFileSync(path, 'utf-8').trim();
-}
-
-function nextReportNumber() {
-  if (!existsSync(PATHS.reports)) return '001';
-  const files = readdirSync(PATHS.reports)
-    .filter(f => /^\d{3}-/.test(f))
-    .map(f => parseInt(f.slice(0, 3)))
-    .filter(n => !isNaN(n));
-  if (files.length === 0) return '001';
-  return String(Math.max(...files) + 1).padStart(3, '0');
 }
 
 function validateEvaluationShape(text) {
@@ -370,12 +363,14 @@ if (summaryMatch) {
 // ---------------------------------------------------------------------------
 if (saveReport) {
   let reportSaved = false;
+  let reservedNumbers = [];
   try {
     if (!existsSync(PATHS.reports)) {
       mkdirSync(PATHS.reports, { recursive: true });
     }
 
-    const num         = nextReportNumber();
+    reservedNumbers   = await reserveReportNumbers(1, { rootDir: ROOT, reportsDir: PATHS.reports });
+    const num         = formatReportNumber(reservedNumbers[0]);
     const today       = new Date().toISOString().split('T')[0];
     const companySlug = slugifyCompany(company);
     const filename    = `${num}-${companySlug}-${today}.md`;
@@ -430,6 +425,14 @@ ${evaluationText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').tri
     } catch (err) {
       console.warn(`⚠️   Report saved, but could not merge tracker addition into data/applications.md: ${err.message}`);
       process.exitCode = 1;
+    }
+  }
+
+  if (reservedNumbers.length > 0) {
+    try {
+      releaseReportNumbers(reservedNumbers, { reportsDir: PATHS.reports });
+    } catch (err) {
+      console.warn(`⚠️   Could not release report reservation: ${err.message}`);
     }
   }
 }

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -635,21 +635,21 @@ for (const file of tsvFiles) {
       skipped++;
     }
   } else {
-    // New entry — trust the TSV's own number only when it is BOTH ahead of
-    // this run's max AND not already claimed by any row on the tracker.
-    // `addition.num > maxNum` alone is not proof the number is free: a stale,
-    // precomputed number (e.g. carried by a batch worker's TSV that sat
-    // unmerged while other unrelated evaluations were merged in the
-    // meantime) can still collide with a row already on the tracker even
-    // though it's numerically ahead of a naive maxNum snapshot (#1704).
-    // usedNumbers already includes every number this run has assigned so
-    // far (added below), so same-run collisions are covered too.
+    // New entry - preserve the TSV's reserved ID whenever it is actually
+    // free. Parallel workers can finish out of order, so a valid reservation
+    // may be lower than the current tracker maximum (#1733). Renumber only on
+    // a real collision, using the next free ID above the current maximum and
+    // warning loudly so report/tracker drift is visible (#1704).
     let entryNum;
-    if (addition.num > maxNum && !usedNumbers.has(addition.num)) {
+    if (!usedNumbers.has(addition.num)) {
       entryNum = addition.num;
     } else {
       entryNum = maxNum + 1;
       while (usedNumbers.has(entryNum)) entryNum++;
+      console.warn(
+        `⚠️  Tracker #${addition.num} already used; assigning #${entryNum} to ` +
+        `${addition.company} — ${addition.role}. Report link remains ${addition.report}.`,
+      );
     }
     usedNumbers.add(entryNum);
     if (entryNum > maxNum) maxNum = entryNum;

--- a/ollama-eval.mjs
+++ b/ollama-eval.mjs
@@ -360,7 +360,7 @@ ${evaluationText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').tri
   } finally {
     if (reservedNumbers.length > 0) {
       try {
-        releaseReportNumbers(reservedNumbers, { reportsDir: PATHS.reports });
+        await releaseReportNumbers(reservedNumbers, { reportsDir: PATHS.reports });
       } catch (err) {
         console.warn(`⚠️   Could not release report reservation: ${err.message}`);
       }

--- a/ollama-eval.mjs
+++ b/ollama-eval.mjs
@@ -22,9 +22,12 @@
  *   Smaller models (llama3.2:3b, phi3) may produce incomplete evaluations.
  */
 
-import { readFileSync, existsSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import {
+  formatReportNumber, releaseReportNumbers, reserveReportNumbers,
+} from './reserve-report-num.mjs';
 
 try {
   const { config } = await import('dotenv');
@@ -134,22 +137,6 @@ function readFile(path, label) {
     return `[${label} not found — skipping]`;
   }
   return readFileSync(path, 'utf-8').trim();
-}
-
-/**
- * Determine the next zero-padded report number based on existing files in reports/.
- * Scans for files whose name starts with one or more digits followed by a hyphen,
- * then returns max + 1 padded to at least 3 digits. Supports report counts above 999
- * without resetting or colliding (avoids the fixed-3-digit slice assumption).
- * @returns {string} Zero-padded report number string, e.g. "042" or "1001".
- */
-function nextReportNumber() {
-  if (!existsSync(PATHS.reports)) return '001';
-  const files = readdirSync(PATHS.reports)
-    .map(f => { const m = f.match(/^(\d+)-/); return m ? parseInt(m[1], 10) : NaN; })
-    .filter(n => !isNaN(n));
-  if (files.length === 0) return '001';
-  return String(Math.max(...files) + 1).padStart(3, '0');
 }
 
 // ---------------------------------------------------------------------------
@@ -336,12 +323,14 @@ if (summaryMatch) {
 // Save report
 // ---------------------------------------------------------------------------
 if (saveReport) {
+  let reservedNumbers = [];
   try {
     if (!existsSync(PATHS.reports)) {
       mkdirSync(PATHS.reports, { recursive: true });
     }
 
-    const num         = nextReportNumber();
+    reservedNumbers   = await reserveReportNumbers(1, { rootDir: ROOT, reportsDir: PATHS.reports });
+    const num         = formatReportNumber(reservedNumbers[0]);
     const today       = new Date().toISOString().split('T')[0];
     const companySlug = company.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
     const filename    = `${num}-${companySlug}-${today}.md`;
@@ -368,6 +357,14 @@ ${evaluationText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').tri
     console.log(`    | ${num} | ${today} | ${company} | ${role} | ${score}/5 | Evaluated | ❌ | [${num}](reports/${filename}) |`);
   } catch (err) {
     console.warn(`⚠️   Could not save report: ${err.message}`);
+  } finally {
+    if (reservedNumbers.length > 0) {
+      try {
+        releaseReportNumbers(reservedNumbers, { reportsDir: PATHS.reports });
+      } catch (err) {
+        console.warn(`⚠️   Could not release report reservation: ${err.message}`);
+      }
+    }
   }
 }
 

--- a/openai-eval.mjs
+++ b/openai-eval.mjs
@@ -380,7 +380,7 @@ ${evaluationText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').tri
   } finally {
     if (reservedNumbers.length > 0) {
       try {
-        releaseReportNumbers(reservedNumbers, { reportsDir: PATHS.reports });
+        await releaseReportNumbers(reservedNumbers, { reportsDir: PATHS.reports });
       } catch (err) {
         console.warn(`⚠️   Could not release report reservation: ${err.message}`);
       }

--- a/openai-eval.mjs
+++ b/openai-eval.mjs
@@ -27,9 +27,12 @@
  * --url at http://localhost:... (or use ollama-eval.mjs).
  */
 
-import { readFileSync, existsSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import {
+  formatReportNumber, releaseReportNumbers, reserveReportNumbers,
+} from './reserve-report-num.mjs';
 
 try {
   const { config } = await import('dotenv');
@@ -194,19 +197,6 @@ function readFile(path, label) {
   return readFileSync(path, 'utf-8').trim();
 }
 
-/**
- * Determine the next zero-padded report number based on existing files in reports/.
- * @returns {string} Zero-padded report number string, e.g. "042" or "1001".
- */
-function nextReportNumber() {
-  if (!existsSync(PATHS.reports)) return '001';
-  const files = readdirSync(PATHS.reports)
-    .map(f => { const m = f.match(/^(\d+)-/); return m ? parseInt(m[1], 10) : NaN; })
-    .filter(n => !isNaN(n));
-  if (files.length === 0) return '001';
-  return String(Math.max(...files) + 1).padStart(3, '0');
-}
-
 // ---------------------------------------------------------------------------
 // Load context files
 // ---------------------------------------------------------------------------
@@ -353,12 +343,14 @@ if (summaryMatch) {
 // Save report
 // ---------------------------------------------------------------------------
 if (saveReport) {
+  let reservedNumbers = [];
   try {
     if (!existsSync(PATHS.reports)) {
       mkdirSync(PATHS.reports, { recursive: true });
     }
 
-    const num         = nextReportNumber();
+    reservedNumbers   = await reserveReportNumbers(1, { rootDir: ROOT, reportsDir: PATHS.reports });
+    const num         = formatReportNumber(reservedNumbers[0]);
     const today       = new Date().toISOString().split('T')[0];
     const companySlug = company.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
     const filename    = `${num}-${companySlug}-${today}.md`;
@@ -385,6 +377,14 @@ ${evaluationText.replace(/---SCORE_SUMMARY---[\s\S]*?---END_SUMMARY---/, '').tri
     console.log(`    | ${num} | ${today} | ${company} | ${role} | ${score}/5 | Evaluated | ❌ | [${num}](reports/${filename}) |`);
   } catch (err) {
     console.warn(`⚠️   Could not save report: ${err.message}`);
+  } finally {
+    if (reservedNumbers.length > 0) {
+      try {
+        releaseReportNumbers(reservedNumbers, { reportsDir: PATHS.reports });
+      } catch (err) {
+        console.warn(`⚠️   Could not release report reservation: ${err.message}`);
+      }
+    }
   }
 }
 

--- a/openrouter-runner.mjs
+++ b/openrouter-runner.mjs
@@ -667,7 +667,7 @@ async function cmdEvaluate(input, ctx) {
     return relPath;
   } finally {
     try {
-      releaseReportNumbers(reservedNumbers, { reportsDir: path.join(__dirname, 'reports') });
+      await releaseReportNumbers(reservedNumbers, { reportsDir: path.join(__dirname, 'reports') });
     } catch (e) {
       console.warn(`Could not release report reservation: ${e.message}`);
     }

--- a/openrouter-runner.mjs
+++ b/openrouter-runner.mjs
@@ -23,6 +23,9 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import readline from 'node:readline';
 import yaml from 'js-yaml';
+import {
+  formatReportNumber, releaseReportNumbers, reserveReportNumbers,
+} from './reserve-report-num.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -521,18 +524,6 @@ function addToPipeline(entries) {
   return newEntries.length;
 }
 
-// ---------------------------------------------------------------------------
-// Report numbering
-// ---------------------------------------------------------------------------
-function nextReportNum() {
-  try {
-    const nums = fs.readdirSync(path.join(__dirname, 'reports'))
-      .map(f => parseInt(f.match(/^(\d+)/)?.[1] ?? '0', 10))
-      .filter(n => n > 0);
-    return nums.length ? Math.max(...nums) + 1 : 1;
-  } catch { return 1; }
-}
-
 function extractCompanySlug(text, url) {
   // Try to extract from text (e.g. "Senior Engineer at Acme" or "Company: Acme")
   const m = text.match(/(?:at|@|company[:\s]+)\s*([A-Z][A-Za-z0-9]{2,25})/);
@@ -635,33 +626,52 @@ async function cmdEvaluate(input, ctx) {
     return null;
   }
 
-  // Save report
-  const today   = new Date().toISOString().split('T')[0];
-  const num     = nextReportNum();
-  const slug    = extractCompanySlug(jdText, typeof input === 'string' ? input : null);
-  const numStr  = String(num).padStart(3, '0');
-  const relPath = `reports/${numStr}-${slug}-${today}.md`;
+  let reservedNumbers;
+  try {
+    reservedNumbers = await reserveReportNumbers(1, {
+      rootDir: __dirname,
+      reportsDir: path.join(__dirname, 'reports'),
+    });
+  } catch (e) {
+    console.error(`Could not reserve a report number: ${e.message}`);
+    return null;
+  }
 
-  // Extract Legitimacy from LLM output or fall back to placeholder
-  const legitMatch = result.match(/\*\*Legitimacy:\*\*\s*([^\n]+)/);
-  const legitLine  = legitMatch ? `**Legitimacy:** ${legitMatch[1].trim()}` : '**Legitimacy:** unconfirmed';
-  writeFile(relPath, `**URL:** ${input || '(pasted)'}\n${legitLine}\n\n${result}`);
+  try {
+    // Save report
+    const today   = new Date().toISOString().split('T')[0];
+    const num     = reservedNumbers[0];
+    const slug    = extractCompanySlug(jdText, typeof input === 'string' ? input : null);
+    const numStr  = formatReportNumber(num);
+    const relPath = `reports/${numStr}-${slug}-${today}.md`;
+
+    // Extract Legitimacy from LLM output or fall back to placeholder
+    const legitMatch = result.match(/\*\*Legitimacy:\*\*\s*([^\n]+)/);
+    const legitLine  = legitMatch ? `**Legitimacy:** ${legitMatch[1].trim()}` : '**Legitimacy:** unconfirmed';
+    writeFile(relPath, `**URL:** ${input || '(pasted)'}\n${legitLine}\n\n${result}`);
 
     const scoreMatch  = result.match(/(?:score|puntuaci[oó]n)[^\d]*(\d+\.?\d*)/i);
-  const scoreValue  = scoreMatch ? parseFloat(scoreMatch[1]) : NaN;
-  const scoreStr    = isFinite(scoreValue) ? `${scoreValue.toFixed(1)}/5` : '';
-  const companyName = slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-  const reportLink  = `[${numStr}](reports/${numStr}-${slug}-${today}.md)`;
-  const tsvLine     = `${num}\t${today}\t${companyName}\t(see report)\tEvaluated\t${scoreStr}\t❌\t${reportLink}\t\n`;
-  const tsvFile     = `batch/tracker-additions/or-${numStr}-${slug}.tsv`;
-  writeFile(tsvFile, `num\tdate\tcompany\trole\tstatus\tscore\tpdf\treport\tnotes\n${tsvLine}`);
+    const scoreValue  = scoreMatch ? parseFloat(scoreMatch[1]) : NaN;
+    const scoreStr    = isFinite(scoreValue) ? `${scoreValue.toFixed(1)}/5` : '';
+    const companyName = slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+    const reportLink  = `[${numStr}](reports/${numStr}-${slug}-${today}.md)`;
+    const tsvLine     = `${num}\t${today}\t${companyName}\t(see report)\tEvaluated\t${scoreStr}\t❌\t${reportLink}\t\n`;
+    const tsvFile     = `batch/tracker-additions/or-${numStr}-${slug}.tsv`;
+    writeFile(tsvFile, `num\tdate\tcompany\trole\tstatus\tscore\tpdf\treport\tnotes\n${tsvLine}`);
 
-  console.log(`\n✅ Report saved: ${relPath}`);
-  console.log('\n─── EVALUATION ──────────────────────────────────────\n');
-  console.log(result);
-  console.log('\n─────────────────────────────────────────────────────\n');
+    console.log(`\n✅ Report saved: ${relPath}`);
+    console.log('\n─── EVALUATION ──────────────────────────────────────\n');
+    console.log(result);
+    console.log('\n─────────────────────────────────────────────────────\n');
 
-  return relPath;
+    return relPath;
+  } finally {
+    try {
+      releaseReportNumbers(reservedNumbers, { reportsDir: path.join(__dirname, 'reports') });
+    } catch (e) {
+      console.warn(`Could not release report reservation: ${e.message}`);
+    }
+  }
 }
 
 // -- PIPELINE --

--- a/reserve-report-num.mjs
+++ b/reserve-report-num.mjs
@@ -38,7 +38,7 @@ const RESERVATION_TOKEN = Symbol('career-ops-report-reservation-token');
 
 /** Format a report ID with a minimum width of three digits. */
 export function formatReportNumber(num) {
-  if (!Number.isInteger(num) || num < 1) {
+  if (!Number.isSafeInteger(num) || num < 1) {
     throw new TypeError(`Report number must be a positive integer, got ${num}`);
   }
   return String(num).padStart(3, '0');
@@ -176,9 +176,13 @@ export async function reserveReportNumbers(count = 1, options = {}) {
     const token = randomUUID();
 
     for (let tries = 0; tries < MAX_RETRIES; tries++) {
+      const end = base + (count - 1);
+      if (!Number.isSafeInteger(base) || !Number.isSafeInteger(end)) {
+        throw new RangeError('No safe report-number range remains');
+      }
       const claimed = [];
       let failedAt = null;
-      for (let num = base; num < base + count; num++) {
+      for (let num = base; num <= end; num++) {
         if (claimSlot(reportsDir, num, occupied, token)) {
           claimed.push(num);
         } else {
@@ -211,7 +215,7 @@ export async function releaseReportNumbers(numbers, options = {}) {
   const reportsDir = reportsDirFor(options);
   const values = Array.isArray(numbers) ? numbers : [numbers];
   for (const num of values) {
-    if (!Number.isInteger(num) || num < 1) {
+    if (!Number.isSafeInteger(num) || num < 1) {
       throw new TypeError(`Report number must be a positive integer, got ${num}`);
     }
   }

--- a/reserve-report-num.mjs
+++ b/reserve-report-num.mjs
@@ -1,245 +1,274 @@
 #!/usr/bin/env node
 
 /**
- * reserve-report-num.mjs — Atomically reserve the next report number.
+ * reserve-report-num.mjs - shared atomic report-number allocator.
  *
- * Fixes the race condition described in #749: when two Claude Code windows
- * (or batch workers) run simultaneously they each compute `max(existing)+1`
- * independently and collide on the same report-number slot.
+ * The CLI and every evaluator use the exported API below. Reservations account
+ * for report files, reservation sentinels, tracker row IDs, and report links in
+ * the tracker. The tracker scan and sentinel creation run under the same lock
+ * as tracker writers, while O_CREAT|O_EXCL keeps claims atomic across processes.
  *
- * ## How it works
- *
- * Uses `fs.writeFileSync(path, data, { flag: 'wx' })` — which maps to
- * `open(O_CREAT|O_EXCL)` on POSIX and `CreateFile(CREATE_NEW)` on Windows —
- * to create a sentinel file atomically.  If two processes try to claim the
- * same number simultaneously only one succeeds; the loser increments and
- * retries.  No external lock daemon or advisory file is needed.
- *
- * The sentinel is a zero-byte marker named `NNN-RESERVED.md` inside
- * `reports/`.  The caller (mode file or agent) must:
- *   1. Run this script to get a number.
- *   2. Write the real report file `NNN-{slug}-{date}.md`.
- *   3. Delete the sentinel (or let verify-pipeline.mjs GC it on next run).
- *
- * ## Usage
- *
+ * Usage:
  *   node reserve-report-num.mjs
- *   # stdout: 035           (zero-padded, 3 digits)
- *
  *   node reserve-report-num.mjs --count 8
- *   # stdout: 042-049       (reserves a contiguous range — for multi-agent
- *   #                        fan-outs: reserve first, hand each parallel
- *   #                        worker its own number. On collision the whole
- *   #                        range restarts past the taken slot, so skipped
- *   #                        numbers become permanent gaps — expected, not
- *   #                        corruption. Range protection follows the normal
- *   #                        sentinel TTL: reserve right before spawning.)
- *
  *   node reserve-report-num.mjs --release 035
  *   node reserve-report-num.mjs --release 042-049
- *   # Deletes the sentinel(s) (call after writing the real report(s)).
- *
  *   node reserve-report-num.mjs --gc
- *   # Removes all stale sentinels older than MAX_SENTINEL_AGE_MS.
- *   # Called automatically by verify-pipeline.mjs.
- *
- * The script exits with code 0 on success, non-zero on fatal error.
  */
 
-import { readdirSync, writeFileSync, unlinkSync, statSync, existsSync, mkdirSync } from 'fs';
-import { join, dirname } from 'path';
+import {
+  existsSync, mkdirSync, readFileSync, readdirSync, realpathSync,
+  statSync, unlinkSync, writeFileSync,
+} from 'fs';
+import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
+import {
+  extractTrackerReportNumbers, parseTrackerRow, resolveColumns,
+} from './tracker-parse.mjs';
+import {
+  acquireTrackerLock, canonicalizeTrackerPath, resolveTrackerPath, trackerLockDirFor,
+} from './tracker-utils.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const REPORTS_DIR = process.env.CAREER_OPS_REPORTS_DIR || join(__dirname, 'reports');
-
-// Sentinels older than this are considered stale and may be GC'd.
-// 4 hours covers any reasonable interactive or batch session.
+const ROOT = dirname(fileURLToPath(import.meta.url));
 const MAX_SENTINEL_AGE_MS = 4 * 60 * 60 * 1000;
-
-// Maximum number of retries before giving up (guards against pathological
-// contention — in practice 2-3 parallel windows will resolve in < 5 tries).
 const MAX_RETRIES = 50;
-
-// Maximum range size for --count (guards typos like --count 800).
 const MAX_COUNT = 50;
 
-// ── helpers ─────────────────────────────────────────────────────────────────
-
-function pad(n) {
-  return String(n).padStart(3, '0');
+/** Format a report ID with a minimum width of three digits. */
+export function formatReportNumber(num) {
+  if (!Number.isInteger(num) || num < 1) {
+    throw new TypeError(`Report number must be a positive integer, got ${num}`);
+  }
+  return String(num).padStart(3, '0');
 }
 
-/** Return the highest numeric slot currently taken in reports/ (files + sentinels). */
-function maxSlot() {
-  if (!existsSync(REPORTS_DIR)) return 0;
-  const entries = readdirSync(REPORTS_DIR);
-  let max = 0;
-  for (const name of entries) {
-    const m = name.match(/^(\d+)-/);
-    if (m) max = Math.max(max, parseInt(m[1], 10));
+function reportsDirFor(options = {}) {
+  return resolve(options.reportsDir
+    || process.env.CAREER_OPS_REPORTS_DIR
+    || join(options.rootDir || ROOT, 'reports'));
+}
+
+function trackerPathFor(options = {}) {
+  return options.trackerPath
+    ? canonicalizeTrackerPath(options.trackerPath)
+    : resolveTrackerPath(options.rootDir || ROOT);
+}
+
+function occupiedFromReports(reportsDir) {
+  const occupied = new Set();
+  if (!existsSync(reportsDir)) return occupied;
+  for (const name of readdirSync(reportsDir)) {
+    const match = name.match(/^(\d+)-/);
+    if (!match) continue;
+    const num = parseInt(match[1], 10);
+    if (Number.isInteger(num) && num > 0) occupied.add(num);
   }
+  return occupied;
+}
+
+function occupiedFromTracker(trackerPath) {
+  const occupied = new Set();
+  if (!existsSync(trackerPath)) return occupied;
+
+  const lines = readFileSync(trackerPath, 'utf-8').split(/\r?\n/);
+  const colmap = resolveColumns(lines);
+  for (const line of lines) {
+    const row = parseTrackerRow(line, colmap);
+    if (!row) continue;
+    if (row.num > 0) occupied.add(row.num);
+    for (const reportNum of extractTrackerReportNumbers(row.report)) {
+      if (reportNum > 0) occupied.add(reportNum);
+    }
+  }
+  return occupied;
+}
+
+function collectOccupied(reportsDir, trackerPath) {
+  const occupied = occupiedFromReports(reportsDir);
+  for (const num of occupiedFromTracker(trackerPath)) occupied.add(num);
+  return occupied;
+}
+
+function highestNumber(numbers) {
+  let max = 0;
+  for (const num of numbers) max = Math.max(max, num);
   return max;
 }
 
-/**
- * One readdir pass → Set of numeric prefixes currently occupying slots
- * (e.g. "042" from "042-acme-2026-07-02.md" or "042-RESERVED.md").
- * Advisory only — real atomicity comes from claimSlot's O_CREAT|O_EXCL write.
- */
-function takenPrefixes() {
-  const taken = new Set();
-  if (!existsSync(REPORTS_DIR)) return taken;
-  for (const name of readdirSync(REPORTS_DIR)) {
-    const m = name.match(/^(\d+)-/);
-    if (m) taken.add(m[1]);
-  }
-  return taken;
+function sentinelPath(reportsDir, num) {
+  return join(reportsDir, `${formatReportNumber(num)}-RESERVED.md`);
 }
 
-/**
- * Attempt to atomically claim slot `n`. Returns true on success.
- * `taken` is an optional pre-scanned Set from takenPrefixes(); without it,
- * the occupancy pre-check scans REPORTS_DIR itself. Either way the check is
- * only advisory — the 'wx' write below is what guarantees atomicity.
- */
-function claimSlot(n, taken = null) {
-  // Check if any file (real report or sentinel) already occupies this slot
-  const occupied = taken
-    ? taken.has(pad(n))
-    : existsSync(REPORTS_DIR) && readdirSync(REPORTS_DIR).some(name => name.startsWith(`${pad(n)}-`));
-  if (occupied) return false;
-
-  const sentinel = join(REPORTS_DIR, `${pad(n)}-RESERVED.md`);
+function claimSlot(reportsDir, num, occupied) {
+  if (occupied.has(num)) return false;
   try {
-    // 'wx' = O_CREAT | O_EXCL — fails if file already exists.
-    writeFileSync(sentinel, '', { flag: 'wx' });
+    writeFileSync(sentinelPath(reportsDir, num), '', { flag: 'wx' });
     return true;
   } catch (err) {
-    if (err.code === 'EEXIST') return false; // another process beat us
-    throw err; // unexpected FS error
+    if (err?.code === 'EEXIST') return false;
+    throw err;
   }
 }
 
-/** Release (delete) the sentinel for slot `n`. */
-function releaseSlot(n) {
-  const sentinel = join(REPORTS_DIR, `${pad(n)}-RESERVED.md`);
-  if (existsSync(sentinel)) unlinkSync(sentinel);
+function releaseSlot(reportsDir, num) {
+  const sentinel = sentinelPath(reportsDir, num);
+  try {
+    unlinkSync(sentinel);
+  } catch (err) {
+    if (err?.code !== 'ENOENT') throw err;
+  }
 }
 
 /**
- * Reserve `count` contiguous slots. All-or-nothing per attempt: if any slot
- * in the candidate range is already taken, release the slots claimed so far
- * and restart past the collision. Each slot claim is individually atomic
- * (O_CREAT|O_EXCL), which is all the pipeline needs — contiguity is an
- * ergonomic property, not a correctness one. Skipped numbers become
- * permanent gaps; report numbers are opaque IDs, so gaps are harmless.
- * Returns the array of reserved numbers, or null if MAX_RETRIES attempts
- * were exhausted. Terminates under contention: `base` strictly advances
- * past every collision, so two racing ranges can never livelock.
+ * Reserve one or more contiguous report IDs.
+ *
+ * @param {number} [count=1] Number of IDs to reserve (1-50).
+ * @param {object} [options] Path and lock overrides.
+ * @returns {Promise<number[]>} Reserved numeric IDs.
  */
-function reserveRange(count) {
-  let base = maxSlot() + 1;
-  let tries = 0;
-  // One directory scan per attempt, shared by every per-slot check;
-  // refreshed only after a collision forces a retry.
-  let taken = takenPrefixes();
-  while (tries < MAX_RETRIES) {
-    const claimed = [];
-    let failedAt = -1;
-    for (let n = base; n < base + count; n++) {
-      if (claimSlot(n, taken)) {
-        claimed.push(n);
-      } else {
-        failedAt = n;
-        break;
-      }
-    }
-    if (failedAt === -1) return claimed;
-    for (const n of claimed) releaseSlot(n);
-    base = failedAt + 1;
-    tries++;
-    taken = takenPrefixes();
+export async function reserveReportNumbers(count = 1, options = {}) {
+  if (!Number.isInteger(count) || count < 1 || count > MAX_COUNT) {
+    throw new RangeError(`Reservation count must be an integer from 1 to ${MAX_COUNT}`);
   }
-  return null;
+
+  const reportsDir = reportsDirFor(options);
+  const trackerPath = trackerPathFor(options);
+  mkdirSync(reportsDir, { recursive: true });
+
+  const lock = await acquireTrackerLock(trackerLockDirFor(trackerPath), {
+    timeoutMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_TIMEOUT_MS) || 60_000,
+    retryMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_RETRY_MS) || 75,
+    staleMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_STALE_MS) || 10 * 60_000,
+    tracker: trackerPath,
+    ...options.lockOptions,
+  });
+
+  try {
+    let occupied = collectOccupied(reportsDir, trackerPath);
+    let base = highestNumber(occupied) + 1;
+
+    for (let tries = 0; tries < MAX_RETRIES; tries++) {
+      const claimed = [];
+      let failedAt = null;
+      for (let num = base; num < base + count; num++) {
+        if (claimSlot(reportsDir, num, occupied)) {
+          claimed.push(num);
+        } else {
+          failedAt = num;
+          break;
+        }
+      }
+      if (failedAt == null) return claimed;
+
+      for (const num of claimed) releaseSlot(reportsDir, num);
+      occupied = collectOccupied(reportsDir, trackerPath);
+      base = Math.max(failedAt + 1, highestNumber(occupied) + 1);
+    }
+  } finally {
+    lock.release();
+  }
+
+  throw new Error(`Could not claim ${count} report slot(s) after ${MAX_RETRIES} retries`);
 }
 
-/** GC stale sentinels (no real report was written within MAX_SENTINEL_AGE_MS). */
-function gc() {
-  if (!existsSync(REPORTS_DIR)) return;
+/** Release reservation sentinels after report creation or on failure. */
+export function releaseReportNumbers(numbers, options = {}) {
+  const reportsDir = reportsDirFor(options);
+  const values = Array.isArray(numbers) ? numbers : [numbers];
+  for (const num of values) {
+    if (!Number.isInteger(num) || num < 1) {
+      throw new TypeError(`Report number must be a positive integer, got ${num}`);
+    }
+    releaseSlot(reportsDir, num);
+  }
+}
+
+/** Remove reservation sentinels older than the configured TTL. */
+export function gcStaleReportReservations(options = {}) {
+  const reportsDir = reportsDirFor(options);
+  if (!existsSync(reportsDir)) return 0;
+
+  const maxAgeMs = options.maxAgeMs ?? MAX_SENTINEL_AGE_MS;
   const now = Date.now();
   let removed = 0;
-  for (const name of readdirSync(REPORTS_DIR)) {
-    if (!name.endsWith('-RESERVED.md')) continue;
-    const full = join(REPORTS_DIR, name);
+  for (const name of readdirSync(reportsDir)) {
+    if (!/^\d+-RESERVED\.md$/.test(name)) continue;
+    const fullPath = join(reportsDir, name);
     try {
-      const { mtimeMs } = statSync(full);
-      if (now - mtimeMs > MAX_SENTINEL_AGE_MS) {
-        unlinkSync(full);
+      if (now - statSync(fullPath).mtimeMs > maxAgeMs) {
+        unlinkSync(fullPath);
         removed++;
         process.stderr.write(`reserve-report-num: GC stale sentinel ${name}\n`);
       }
-    } catch {
-      // Already gone — fine.
+    } catch (err) {
+      if (err?.code !== 'ENOENT') throw err;
     }
   }
   if (removed > 0) {
     process.stderr.write(`reserve-report-num: removed ${removed} stale sentinel(s)\n`);
   }
+  return removed;
 }
 
-// ── CLI ──────────────────────────────────────────────────────────────────────
+async function runCli() {
+  const [,, cmd, arg] = process.argv;
+  const options = {};
 
-const [,, cmd, arg] = process.argv;
-
-if (cmd === '--release') {
-  const m = (arg || '').match(/^(\d+)(?:-(\d+))?$/);
-  if (!m) {
-    process.stderr.write('Usage: node reserve-report-num.mjs --release <NNN>[-<MMM>]\n');
-    process.exit(1);
+  if (cmd === '--release') {
+    const match = (arg || '').match(/^(\d+)(?:-(\d+))?$/);
+    if (!match) {
+      process.stderr.write('Usage: node reserve-report-num.mjs --release <NNN>[-<MMM>]\n');
+      return 1;
+    }
+    const start = parseInt(match[1], 10);
+    const end = match[2] ? parseInt(match[2], 10) : start;
+    if (start < 1 || end < start) {
+      process.stderr.write('reserve-report-num: --release range end must be >= start\n');
+      return 1;
+    }
+    releaseReportNumbers(Array.from({ length: end - start + 1 }, (_, index) => start + index), options);
+    return 0;
   }
-  const start = parseInt(m[1], 10);
-  const end = m[2] ? parseInt(m[2], 10) : start;
-  if (end < start) {
-    process.stderr.write('reserve-report-num: --release range end must be >= start\n');
-    process.exit(1);
+
+  if (cmd === '--gc') {
+    gcStaleReportReservations(options);
+    return 0;
   }
-  for (let n = start; n <= end; n++) releaseSlot(n);
-  process.exit(0);
-}
 
-if (cmd === '--gc') {
-  gc();
-  process.exit(0);
-}
-
-// Default (or --count N): reserve the next slot(s).
-let count = 1;
-if (cmd === '--count') {
-  if (!/^\d+$/.test(arg || '')) {
-    process.stderr.write(`Usage: node reserve-report-num.mjs --count <1-${MAX_COUNT}>\n`);
-    process.exit(1);
+  let count = 1;
+  if (cmd === '--count') {
+    if (!/^\d+$/.test(arg || '')) {
+      process.stderr.write(`Usage: node reserve-report-num.mjs --count <1-${MAX_COUNT}>\n`);
+      return 1;
+    }
+    count = parseInt(arg, 10);
+    if (count < 1 || count > MAX_COUNT) {
+      process.stderr.write(`Usage: node reserve-report-num.mjs --count <1-${MAX_COUNT}>\n`);
+      return 1;
+    }
   }
-  count = parseInt(arg, 10);
-  if (count < 1 || count > MAX_COUNT) {
-    process.stderr.write(`Usage: node reserve-report-num.mjs --count <1-${MAX_COUNT}>\n`);
-    process.exit(1);
+
+  try {
+    const numbers = await reserveReportNumbers(count, options);
+    process.stdout.write(count === 1
+      ? `${formatReportNumber(numbers[0])}\n`
+      : `${formatReportNumber(numbers[0])}-${formatReportNumber(numbers[numbers.length - 1])}\n`);
+    return 0;
+  } catch (err) {
+    process.stderr.write(`reserve-report-num: ${err.message}\n`);
+    return 1;
   }
 }
-// Any other/unknown cmd falls through to a single reserve — unchanged
-// legacy behavior.
 
-mkdirSync(REPORTS_DIR, { recursive: true });
-
-const nums = reserveRange(count);
-if (!nums) {
-  process.stderr.write(`reserve-report-num: could not claim ${count} slot(s) after ${MAX_RETRIES} retries\n`);
-  process.exit(1);
+function isDirectInvocation() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(resolve(process.argv[1])) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+  }
 }
 
-process.stdout.write(
-  count === 1
-    ? pad(nums[0]) + '\n'
-    : `${pad(nums[0])}-${pad(nums[nums.length - 1])}\n`
-);
-process.exit(0);
+if (isDirectInvocation()) {
+  process.exitCode = await runCli();
+}

--- a/reserve-report-num.mjs
+++ b/reserve-report-num.mjs
@@ -20,6 +20,7 @@ import {
   existsSync, mkdirSync, readFileSync, readdirSync, realpathSync,
   statSync, unlinkSync, writeFileSync,
 } from 'fs';
+import { randomUUID } from 'crypto';
 import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import {
@@ -33,6 +34,7 @@ const ROOT = dirname(fileURLToPath(import.meta.url));
 const MAX_SENTINEL_AGE_MS = 4 * 60 * 60 * 1000;
 const MAX_RETRIES = 50;
 const MAX_COUNT = 50;
+const RESERVATION_TOKEN = Symbol('career-ops-report-reservation-token');
 
 /** Format a report ID with a minimum width of three digits. */
 export function formatReportNumber(num) {
@@ -99,10 +101,14 @@ function sentinelPath(reportsDir, num) {
   return join(reportsDir, `${formatReportNumber(num)}-RESERVED.md`);
 }
 
-function claimSlot(reportsDir, num, occupied) {
+function claimSlot(reportsDir, num, occupied, token) {
   if (occupied.has(num)) return false;
   try {
-    writeFileSync(sentinelPath(reportsDir, num), '', { flag: 'wx' });
+    writeFileSync(sentinelPath(reportsDir, num), JSON.stringify({
+      pid: process.pid,
+      token,
+      created_at: new Date().toISOString(),
+    }), { flag: 'wx' });
     return true;
   } catch (err) {
     if (err?.code === 'EEXIST') return false;
@@ -110,12 +116,33 @@ function claimSlot(reportsDir, num, occupied) {
   }
 }
 
-function releaseSlot(reportsDir, num) {
+function readSentinelOwner(sentinel) {
+  try {
+    return JSON.parse(readFileSync(sentinel, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function releaseSlot(reportsDir, num, { token, force = false } = {}) {
   const sentinel = sentinelPath(reportsDir, num);
   try {
+    if (!force && readSentinelOwner(sentinel)?.token !== token) return false;
     unlinkSync(sentinel);
+    return true;
   } catch (err) {
-    if (err?.code !== 'ENOENT') throw err;
+    if (err?.code === 'ENOENT') return false;
+    throw err;
+  }
+}
+
+function processIsAlive(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === 'EPERM';
   }
 }
 
@@ -146,21 +173,25 @@ export async function reserveReportNumbers(count = 1, options = {}) {
   try {
     let occupied = collectOccupied(reportsDir, trackerPath);
     let base = highestNumber(occupied) + 1;
+    const token = randomUUID();
 
     for (let tries = 0; tries < MAX_RETRIES; tries++) {
       const claimed = [];
       let failedAt = null;
       for (let num = base; num < base + count; num++) {
-        if (claimSlot(reportsDir, num, occupied)) {
+        if (claimSlot(reportsDir, num, occupied, token)) {
           claimed.push(num);
         } else {
           failedAt = num;
           break;
         }
       }
-      if (failedAt == null) return claimed;
+      if (failedAt == null) {
+        Object.defineProperty(claimed, RESERVATION_TOKEN, { value: token });
+        return claimed;
+      }
 
-      for (const num of claimed) releaseSlot(reportsDir, num);
+      for (const num of claimed) releaseSlot(reportsDir, num, { token });
       occupied = collectOccupied(reportsDir, trackerPath);
       base = Math.max(failedAt + 1, highestNumber(occupied) + 1);
     }
@@ -171,38 +202,76 @@ export async function reserveReportNumbers(count = 1, options = {}) {
   throw new Error(`Could not claim ${count} report slot(s) after ${MAX_RETRIES} retries`);
 }
 
-/** Release reservation sentinels after report creation or on failure. */
-export function releaseReportNumbers(numbers, options = {}) {
+/**
+ * Release reservation sentinels after report creation or on failure.
+ * Only the array returned by reserveReportNumbers owns its sentinels. The CLI
+ * uses force mode as an explicit administrative cleanup path.
+ */
+export async function releaseReportNumbers(numbers, options = {}) {
   const reportsDir = reportsDirFor(options);
   const values = Array.isArray(numbers) ? numbers : [numbers];
   for (const num of values) {
     if (!Number.isInteger(num) || num < 1) {
       throw new TypeError(`Report number must be a positive integer, got ${num}`);
     }
-    releaseSlot(reportsDir, num);
+  }
+  const force = options.force === true;
+  const token = options.reservationToken || numbers?.[RESERVATION_TOKEN];
+  if (!force && !token) throw new Error('Reservation ownership token is required for release');
+  if (!existsSync(reportsDir)) return 0;
+
+  const trackerPath = trackerPathFor(options);
+  const lock = await acquireTrackerLock(trackerLockDirFor(trackerPath), {
+    timeoutMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_TIMEOUT_MS) || 60_000,
+    retryMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_RETRY_MS) || 75,
+    staleMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_STALE_MS) || 10 * 60_000,
+    tracker: trackerPath,
+    ...options.lockOptions,
+  });
+  try {
+    return values.reduce(
+      (removed, num) => removed + Number(releaseSlot(reportsDir, num, { token, force })),
+      0,
+    );
+  } finally {
+    lock.release();
   }
 }
 
 /** Remove reservation sentinels older than the configured TTL. */
-export function gcStaleReportReservations(options = {}) {
+export async function gcStaleReportReservations(options = {}) {
   const reportsDir = reportsDirFor(options);
   if (!existsSync(reportsDir)) return 0;
 
+  const trackerPath = trackerPathFor(options);
+  const lock = await acquireTrackerLock(trackerLockDirFor(trackerPath), {
+    timeoutMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_TIMEOUT_MS) || 60_000,
+    retryMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_RETRY_MS) || 75,
+    staleMs: Number(process.env.CAREER_OPS_TRACKER_LOCK_STALE_MS) || 10 * 60_000,
+    tracker: trackerPath,
+    ...options.lockOptions,
+  });
   const maxAgeMs = options.maxAgeMs ?? MAX_SENTINEL_AGE_MS;
   const now = Date.now();
   let removed = 0;
-  for (const name of readdirSync(reportsDir)) {
-    if (!/^\d+-RESERVED\.md$/.test(name)) continue;
-    const fullPath = join(reportsDir, name);
-    try {
-      if (now - statSync(fullPath).mtimeMs > maxAgeMs) {
-        unlinkSync(fullPath);
-        removed++;
-        process.stderr.write(`reserve-report-num: GC stale sentinel ${name}\n`);
+  try {
+    for (const name of readdirSync(reportsDir)) {
+      if (!/^\d+-RESERVED\.md$/.test(name)) continue;
+      const fullPath = join(reportsDir, name);
+      try {
+        if (now - statSync(fullPath).mtimeMs > maxAgeMs) {
+          const owner = readSentinelOwner(fullPath);
+          if (owner?.pid && processIsAlive(owner.pid)) continue;
+          unlinkSync(fullPath);
+          removed++;
+          process.stderr.write(`reserve-report-num: GC stale sentinel ${name}\n`);
+        }
+      } catch (err) {
+        if (err?.code !== 'ENOENT') throw err;
       }
-    } catch (err) {
-      if (err?.code !== 'ENOENT') throw err;
     }
+  } finally {
+    lock.release();
   }
   if (removed > 0) {
     process.stderr.write(`reserve-report-num: removed ${removed} stale sentinel(s)\n`);
@@ -222,16 +291,21 @@ async function runCli() {
     }
     const start = parseInt(match[1], 10);
     const end = match[2] ? parseInt(match[2], 10) : start;
-    if (start < 1 || end < start) {
-      process.stderr.write('reserve-report-num: --release range end must be >= start\n');
+    const rangeCount = end - start + 1;
+    if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)
+        || start < 1 || end < start || rangeCount > MAX_COUNT) {
+      process.stderr.write(`reserve-report-num: --release requires a safe ascending range of at most ${MAX_COUNT} slots\n`);
       return 1;
     }
-    releaseReportNumbers(Array.from({ length: end - start + 1 }, (_, index) => start + index), options);
+    await releaseReportNumbers(
+      Array.from({ length: rangeCount }, (_, index) => start + index),
+      { ...options, force: true },
+    );
     return 0;
   }
 
   if (cmd === '--gc') {
-    gcStaleReportReservations(options);
+    await gcStaleReportReservations(options);
     return 0;
   }
 

--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -17,7 +17,7 @@
  *   0 — success (including no-op re-runs)
  *   1 — usage error or non-canonical state
  *   2 — row not found (bad number, unknown company)
- *   3 — ambiguous company match (candidates listed on stderr / in JSON)
+ *   3 — ambiguous company match or numeric selector/report-link mismatch
  */
 
 import { execFileSync } from 'child_process';
@@ -98,6 +98,13 @@ const TRACKER_DUP_NUM = `# Applications Tracker
 | 5 | 2026-06-03 | Esri Canada | Manager Talent and Organizational Development | 4.1/5 | Evaluated | ❌ | — | — |
 `;
 
+const TRACKER_REPORT_MISMATCH = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 2 | 2026-06-02 | DriftCo | Platform Engineer | 4.0/5 | Evaluated | ✅ | [7](../reports/007-driftco-2026-06-02.md) | migrated badly |
+`;
+
 // ── 1. Update by report number ──────────────────────────────────
 {
   const sb = makeSandbox(TRACKER_9);
@@ -112,6 +119,30 @@ const TRACKER_DUP_NUM = `# Applications Tracker
     pass('by-num: other rows untouched');
   } else {
     fail('by-num: other rows were modified');
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 1b. Numeric selector refuses a tracker/report ID mismatch ───
+{
+  const sb = makeSandbox(TRACKER_REPORT_MISMATCH);
+  const before = readTracker(sb);
+  const r = runSetStatus(['2', 'Applied', '--json'], sb);
+  let parsed = null;
+  try { parsed = JSON.parse(r.stdout); } catch {}
+  if (r.code === 3 && parsed?.code === 'report-number-mismatch'
+      && parsed.trackerNum === 2 && parsed.reportNums?.includes(7)
+      && readTracker(sb) === before) {
+    pass('report-mismatch: numeric selector fails closed without writing');
+  } else {
+    fail(`report-mismatch: code=${r.code} json=${JSON.stringify(parsed)}\n${r.stdout}${r.stderr}`);
+  }
+
+  const forced = runSetStatus(['2', 'Applied', '--force'], sb);
+  if (forced.code === 0 && /\| 2 \|[^\n]*\| Applied \|/.test(readTracker(sb))) {
+    pass('report-mismatch: --force permits an intentional numeric update');
+  } else {
+    fail(`report-mismatch force: code=${forced.code}\n${forced.stdout}${forced.stderr}`);
   }
   rmSync(sb.dir, { recursive: true, force: true });
 }

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -8,7 +8,7 @@
  * modes (apply Step 9, followup, batch) call this instead of editing the table.
  *
  * Usage:
- *   node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--dry-run] [--json]
+ *   node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--force] [--dry-run] [--json]
  *
  * Row resolution:
  *   - numeric argument → exact match on the # column; if the tracker has a
@@ -43,7 +43,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { extractTrackerReportNumbers, resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
 import {
   rebuildRow, resolveTrackerPath, trackerLockDirFor, acquireTrackerLock,
@@ -59,12 +59,13 @@ const EXIT_NOT_FOUND = 2;
 const EXIT_AMBIGUOUS = 3;
 const EXIT_LOCK_TIMEOUT = 4;
 
-const USAGE = `Usage: node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--dry-run] [--json]
+const USAGE = `Usage: node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--force] [--dry-run] [--json]
 
   <report#|company>  Row selector: tracker # (exact) or company name (normalized match)
   <state>            Canonical state from templates/states.yml (aliases accepted)
   --note "..."       Append to the Notes cell ("; "-separated, idempotent)
   --role "..."       Disambiguate when several rows share the company (fuzzy match)
+  --force            Allow a numeric selector when the row's report link carries a different ID
   --dry-run          Resolve and validate, but write nothing
   --json             Machine-readable output on stdout (errors included)`;
 
@@ -72,7 +73,7 @@ const USAGE = `Usage: node set-status.mjs <report#|company> <state> [--note "...
 
 const rawArgs = process.argv.slice(2);
 const positional = [];
-const flags = { note: null, role: null, dryRun: false, json: false };
+const flags = { note: null, role: null, force: false, dryRun: false, json: false };
 
 for (let i = 0; i < rawArgs.length; i++) {
   const a = rawArgs[i];
@@ -86,6 +87,7 @@ for (let i = 0; i < rawArgs.length; i++) {
     flags[a === '--note' ? 'note' : 'role'] = value;
     i++;
   }
+  else if (a === '--force') { flags.force = true; }
   else if (a === '--dry-run') { flags.dryRun = true; }
   else if (a === '--json') { flags.json = true; }
   else if (a.startsWith('--')) { failUsage(`Unknown flag: ${a}`); }
@@ -266,6 +268,24 @@ if (rows.length === 0) {
 }
 
 const target = resolveRow(rows);
+
+// A numeric selector is often copied from a report filename. If tracker drift
+// has made the row ID disagree with its local report link, silently updating
+// that row can affect the wrong application. Company selectors remain usable,
+// and --force records an explicit decision to proceed despite the mismatch.
+if (/^\d+$/.test(selector) && !flags.force) {
+  const reportNums = extractTrackerReportNumbers(target.report);
+  const mismatched = reportNums.filter(num => num !== target.num);
+  if (mismatched.length > 0) {
+    failWith(
+      EXIT_AMBIGUOUS,
+      'report-number-mismatch',
+      `Tracker #${target.num} points to report ID(s) ${reportNums.map(num => `#${num}`).join(', ')}. ` +
+        'Use the company selector, repair the Report cell, or re-run with --force.',
+      { trackerNum: target.num, reportNums },
+    );
+  }
+}
 const oldStatus = target.status;
 const note = flags.note != null ? cell(flags.note) : null;
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4293,6 +4293,33 @@ try {
   }
   rmSync(fourDigitTmp, { recursive: true, force: true });
 
+  const unsafeRangeTmp = mkdtempSync(join(tmpdir(), 'career-ops-reserve-unsafe-range-'));
+  const unsafeRangeReports = join(unsafeRangeTmp, 'reports');
+  const unsafeRangeTracker = join(unsafeRangeTmp, 'applications.md');
+  mkdirSync(unsafeRangeReports);
+  writeFileSync(
+    join(unsafeRangeReports, `${Number.MAX_SAFE_INTEGER - 1}-existing.md`),
+    '# fixture',
+  );
+  const allocatorApi = await import(`${pathToFileURL(RESERVE).href}?unsafe-range=${Date.now()}`);
+  let unsafeRangeError = null;
+  try {
+    await allocatorApi.reserveReportNumbers(2, {
+      reportsDir: unsafeRangeReports,
+      trackerPath: unsafeRangeTracker,
+    });
+  } catch (err) {
+    unsafeRangeError = err;
+  }
+  const unsafeRangeLeaked = readdirSync(unsafeRangeReports)
+    .some(name => name.endsWith('-RESERVED.md'));
+  if (unsafeRangeError instanceof RangeError && !unsafeRangeLeaked) {
+    pass('unsafe report-number ranges fail before creating a partial sentinel');
+  } else {
+    fail(`unsafe range guard failed: error=${unsafeRangeError?.message}, leaked=${unsafeRangeLeaked}`);
+  }
+  rmSync(unsafeRangeTmp, { recursive: true, force: true });
+
   const evaluatorSources = ['ollama-eval.mjs', 'openai-eval.mjs', 'gemini-eval.mjs', 'openrouter-runner.mjs']
     .map(name => [name, readFile(name)]);
   const unmigratedEvaluators = evaluatorSources

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -24,7 +24,7 @@
  */
 
 
-import { execSync, execFileSync, spawn } from 'child_process';
+import { execSync, execFileSync, spawn, spawnSync } from 'child_process';
 import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, unlinkSync, realpathSync, symlinkSync } from 'fs';
 import { join, dirname, basename, delimiter } from 'path';
 import { tmpdir } from 'os';
@@ -4175,10 +4175,36 @@ try {
 console.log('\n🧪 Testing reserve-report-num env override and range reservation...');
 try {
   const RESERVE = join(ROOT, 'reserve-report-num.mjs');
-  const reserveRun = (args, dir) => execFileSync(NODE, [RESERVE, ...args], {
+  const reserveRun = (args, dir, tracker = join(dir, 'applications.md')) => execFileSync(NODE, [RESERVE, ...args], {
     encoding: 'utf-8',
-    env: { ...process.env, CAREER_OPS_REPORTS_DIR: dir },
+    env: { ...process.env, CAREER_OPS_REPORTS_DIR: dir, CAREER_OPS_TRACKER: tracker },
   }).trim();
+
+  // Importing the module must expose the same allocator used by the CLI,
+  // without running the CLI as an import side effect.
+  const apiTmp = mkdtempSync(join(tmpdir(), 'career-ops-reserve-api-'));
+  const apiTracker = join(apiTmp, 'applications.md');
+  const apiProbe = execFileSync(NODE, ['--input-type=module', '--eval', `
+    const api = await import(${JSON.stringify(pathToFileURL(RESERVE).href)});
+    const nums = await api.reserveReportNumbers(1, {
+      reportsDir: process.env.CAREER_OPS_REPORTS_DIR,
+      trackerPath: process.env.CAREER_OPS_TRACKER,
+    });
+    api.releaseReportNumbers(nums, { reportsDir: process.env.CAREER_OPS_REPORTS_DIR });
+    console.log(JSON.stringify({ nums, formatted: api.formatReportNumber(nums[0]) }));
+  `], {
+    encoding: 'utf-8',
+    env: { ...process.env, CAREER_OPS_REPORTS_DIR: apiTmp, CAREER_OPS_TRACKER: apiTracker },
+  }).trim();
+  let apiResult = null;
+  try { apiResult = JSON.parse(apiProbe); } catch {}
+  if (apiResult?.nums?.[0] === 1 && apiResult.formatted === '001'
+      && !existsSync(join(apiTmp, '001-RESERVED.md'))) {
+    pass('reserve-report-num is import-safe and exposes reserve/release/format APIs');
+  } else {
+    fail(`reserve-report-num import API failed: ${apiProbe}`);
+  }
+  rmSync(apiTmp, { recursive: true, force: true });
 
   const reserveTmp = mkdtempSync(join(tmpdir(), 'career-ops-reserve-'));
   const single = reserveRun([], reserveTmp);
@@ -4188,6 +4214,50 @@ try {
     fail(`env override failed: stdout=${single}, sentinel in tmp=${existsSync(join(reserveTmp, '001-RESERVED.md'))}`);
   }
   rmSync(reserveTmp, { recursive: true, force: true });
+
+  // Tracker IDs and linked report IDs are occupied even when their report
+  // files are missing (for example after a partial sync or manual archive).
+  const trackerTmp = mkdtempSync(join(tmpdir(), 'career-ops-reserve-tracker-'));
+  const trackerFile = join(trackerTmp, 'applications.md');
+  writeFileSync(trackerFile,
+    '# Applications Tracker\n\n' +
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+    '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+    '| 7 | 2026-01-01 | Acme | Engineer | 4.0/5 | Evaluated | ❌ | [12](../reports/012-acme-2026-01-01.md) | fixture |\n');
+  const afterTracker = reserveRun([], join(trackerTmp, 'reports'), trackerFile);
+  if (afterTracker === '013') {
+    pass('reservation accounts for tracker row IDs and linked report IDs');
+  } else {
+    fail(`tracker-aware reservation produced ${afterTracker}, expected 013`);
+  }
+  rmSync(trackerTmp, { recursive: true, force: true });
+
+  // Formatting is a minimum width, not a three-digit ceiling.
+  const fourDigitTmp = mkdtempSync(join(tmpdir(), 'career-ops-reserve-4digit-'));
+  const fourDigitTracker = join(fourDigitTmp, 'applications.md');
+  writeFileSync(fourDigitTracker,
+    '# Applications Tracker\n\n' +
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+    '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+    '| 1000 | 2026-01-01 | Acme | Engineer | 4.0/5 | Evaluated | ❌ | — | fixture |\n');
+  const fourDigit = reserveRun([], join(fourDigitTmp, 'reports'), fourDigitTracker);
+  if (fourDigit === '1001' && existsSync(join(fourDigitTmp, 'reports', '1001-RESERVED.md'))) {
+    pass('reservation continues beyond 999 without truncation or reset');
+  } else {
+    fail(`four-digit reservation produced ${fourDigit}, expected 1001`);
+  }
+  rmSync(fourDigitTmp, { recursive: true, force: true });
+
+  const evaluatorSources = ['ollama-eval.mjs', 'openai-eval.mjs', 'gemini-eval.mjs', 'openrouter-runner.mjs']
+    .map(name => [name, readFile(name)]);
+  const unmigratedEvaluators = evaluatorSources
+    .filter(([, source]) => !source.includes('reserveReportNumbers') || /function\s+nextReport(?:Number|Num)\s*\(/.test(source))
+    .map(([name]) => name);
+  if (unmigratedEvaluators.length === 0) {
+    pass('all headless evaluators use the shared atomic report allocator');
+  } else {
+    fail(`headless evaluators still carry private max+1 allocators: ${unmigratedEvaluators.join(', ')}`);
+  }
 
   // --count N: contiguous range from an empty dir.
   const rangeTmp = mkdtempSync(join(tmpdir(), 'career-ops-reserve-range-'));
@@ -4235,28 +4305,21 @@ try {
   }
   rmSync(collideTmp, { recursive: true, force: true });
 
-  // Mid-range collision → rollback. reserveRange must claim a partial range,
-  // fail on a later slot, release the partial claims, and restart past the
-  // collision. A blocker visible to maxSlot() can't trigger this (it bumps the
-  // base instead, as the previous test pins), so plant one maxSlot() can't
-  // see: its /^(\d{3})-/ regex skips 4-digit names, while claimSlot's
-  // occupancy check matches any numeric prefix. Seeding max=999 puts the base
-  // at 1000; "1001-taken.md" then collides mid-range exactly like a slot
-  // claimed by a racing process after the base was computed.
-  const rollbackTmp = mkdtempSync(join(tmpdir(), 'career-ops-reserve-rollback-'));
-  writeFileSync(join(rollbackTmp, '999-acme-2026-07-02.md'), '# stub');
-  writeFileSync(join(rollbackTmp, '1001-taken.md'), '# stub');
-  const rolledBack = reserveRun(['--count', '3'], rollbackTmp);
-  const released1000 = !existsSync(join(rollbackTmp, '1000-RESERVED.md'));
-  const blocker1001 = existsSync(join(rollbackTmp, '1001-taken.md'));
-  const restarted = ['1002', '1003', '1004']
-    .every(n => existsSync(join(rollbackTmp, `${n}-RESERVED.md`)));
-  if (rolledBack === '1002-1004' && released1000 && blocker1001 && restarted) {
-    pass('mid-range collision releases partially claimed slots and restarts past it');
+  // Existing four-digit report names participate in the same occupancy scan.
+  const highRangeTmp = mkdtempSync(join(tmpdir(), 'career-ops-reserve-high-range-'));
+  writeFileSync(join(highRangeTmp, '999-acme-2026-07-02.md'), '# stub');
+  writeFileSync(join(highRangeTmp, '1001-taken.md'), '# stub');
+  const highRange = reserveRun(['--count', '3'], highRangeTmp);
+  const skipped1000 = !existsSync(join(highRangeTmp, '1000-RESERVED.md'));
+  const blocker1001 = existsSync(join(highRangeTmp, '1001-taken.md'));
+  const reservedHighRange = ['1002', '1003', '1004']
+    .every(n => existsSync(join(highRangeTmp, `${n}-RESERVED.md`)));
+  if (highRange === '1002-1004' && skipped1000 && blocker1001 && reservedHighRange) {
+    pass('four-digit report files advance a contiguous range without truncation');
   } else {
-    fail(`rollback: stdout=${rolledBack} (want 1002-1004), 1000 released=${released1000}, blocker kept=${blocker1001}, restarted sentinels=${restarted}`);
+    fail(`four-digit range: stdout=${highRange} (want 1002-1004), 1000 skipped=${skipped1000}, blocker kept=${blocker1001}, sentinels=${reservedHighRange}`);
   }
-  rmSync(rollbackTmp, { recursive: true, force: true });
+  rmSync(highRangeTmp, { recursive: true, force: true });
 
   // Range-vs-range: two concurrent --count 4 reservations must not overlap.
   // Terminates by construction: each restart strictly advances the base.
@@ -4288,7 +4351,7 @@ try {
       execFileSync(NODE, [RESERVE, ...args], {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env, CAREER_OPS_REPORTS_DIR: dir },
+        env: { ...process.env, CAREER_OPS_REPORTS_DIR: dir, CAREER_OPS_TRACKER: join(dir, 'applications.md') },
       });
       return null;
     } catch (err) {
@@ -5190,6 +5253,60 @@ try {
   }
 } catch (e) {
   fail(`merge-tracker stale-number collision test crashed: ${e.message}`);
+}
+
+// ── MERGE-TRACKER RESERVED-NUMBER FIDELITY (#1733) ──────────────
+// Parallel workers may reserve numbers in order but finish out of order. A
+// free reserved number remains valid even when a later number has already
+// reached the tracker; merge-tracker must preserve it, and only renumber on a
+// real collision (with a visible warning).
+console.log('\n🧪 Testing merge-tracker reserved-number fidelity (#1733)...');
+try {
+  const reservedTmp = mkdtempSync(join(tmpdir(), 'career-ops-merge-reserved-'));
+  try {
+    mkdirSync(join(reservedTmp, 'data'));
+    const reservedAdditions = join(reservedTmp, 'additions');
+    mkdirSync(reservedAdditions);
+    const reservedTracker = join(reservedTmp, 'data', 'applications.md');
+    writeFileSync(reservedTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 10 | 2026-01-10 | LaterCo | Engineer | 4.0/5 | Evaluated | ❌ | — | finished first |\n');
+
+    writeFileSync(join(reservedAdditions, '005-early.tsv'),
+      '5\t2026-01-05\tEarlyCo\tEngineer\tEvaluated\t4.1/5\t❌\t[5](reports/005-early-2026-01-05.md)\treserved first\n');
+    const preserveResult = run(NODE, ['merge-tracker.mjs'], {
+      env: { ...process.env, CAREER_OPS_TRACKER: reservedTracker, CAREER_OPS_ADDITIONS: reservedAdditions },
+    });
+    const afterPreserve = readFileSync(reservedTracker, 'utf-8');
+    if (preserveResult !== null && /^\| 5 \|[^\n]*\| EarlyCo \|/m.test(afterPreserve)) {
+      pass('merge-tracker preserves a free reserved ID below the current maximum');
+    } else {
+      fail(`merge-tracker renumbered a free reserved ID\n${afterPreserve}`);
+    }
+
+    writeFileSync(join(reservedAdditions, '005-collision.tsv'),
+      '5\t2026-01-11\tCollisionCo\tAnalyst\tEvaluated\t3.8/5\t❌\t—\tstale reservation\n');
+    const collisionResult = spawnSync(NODE, [join(ROOT, 'merge-tracker.mjs')], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      env: { ...process.env, CAREER_OPS_TRACKER: reservedTracker, CAREER_OPS_ADDITIONS: reservedAdditions },
+    });
+    const afterCollision = readFileSync(reservedTracker, 'utf-8');
+    const collisionOutput = `${collisionResult.stdout || ''}\n${collisionResult.stderr || ''}`;
+    if (collisionResult.status === 0
+        && /^\| 11 \|[^\n]*\| CollisionCo \|/m.test(afterCollision)
+        && /#5[^\n]*(?:already|collision)[^\n]*#11/i.test(collisionOutput)) {
+      pass('merge-tracker renumbers only a real collision and warns with both IDs');
+    } else {
+      fail(`merge-tracker collision fallback was not loud and deterministic\n${collisionOutput}\n${afterCollision}`);
+    }
+  } finally {
+    rmSync(reservedTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`merge-tracker reserved-number fidelity test crashed: ${e.message}`);
 }
 
 // ── MERGE-TRACKER REQ/JOB-NUMBER DEDUP GUARD (#1524) ─────────────────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4186,12 +4186,42 @@ try {
   const apiTracker = join(apiTmp, 'applications.md');
   const apiProbe = execFileSync(NODE, ['--input-type=module', '--eval', `
     const api = await import(${JSON.stringify(pathToFileURL(RESERVE).href)});
+    const { existsSync, readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
     const nums = await api.reserveReportNumbers(1, {
       reportsDir: process.env.CAREER_OPS_REPORTS_DIR,
       trackerPath: process.env.CAREER_OPS_TRACKER,
     });
-    api.releaseReportNumbers(nums, { reportsDir: process.env.CAREER_OPS_REPORTS_DIR });
-    console.log(JSON.stringify({ nums, formatted: api.formatReportNumber(nums[0]) }));
+    const sentinel = join(process.env.CAREER_OPS_REPORTS_DIR, '001-RESERVED.md');
+    let firstToken = null;
+    try { firstToken = JSON.parse(readFileSync(sentinel, 'utf-8')).token; } catch {}
+    await api.releaseReportNumbers(nums, {
+      reportsDir: process.env.CAREER_OPS_REPORTS_DIR,
+      trackerPath: process.env.CAREER_OPS_TRACKER,
+    });
+    const replacement = await api.reserveReportNumbers(1, {
+      reportsDir: process.env.CAREER_OPS_REPORTS_DIR,
+      trackerPath: process.env.CAREER_OPS_TRACKER,
+    });
+    let replacementToken = null;
+    try { replacementToken = JSON.parse(readFileSync(sentinel, 'utf-8')).token; } catch {}
+    await api.releaseReportNumbers(nums, {
+      reportsDir: process.env.CAREER_OPS_REPORTS_DIR,
+      trackerPath: process.env.CAREER_OPS_TRACKER,
+    });
+    const replacementPreserved = existsSync(sentinel);
+    await api.releaseReportNumbers(replacement, {
+      reportsDir: process.env.CAREER_OPS_REPORTS_DIR,
+      trackerPath: process.env.CAREER_OPS_TRACKER,
+    });
+    console.log(JSON.stringify({
+      nums,
+      formatted: api.formatReportNumber(nums[0]),
+      firstToken,
+      replacementToken,
+      replacementPreserved,
+      replacementCleaned: !existsSync(sentinel),
+    }));
   `], {
     encoding: 'utf-8',
     env: { ...process.env, CAREER_OPS_REPORTS_DIR: apiTmp, CAREER_OPS_TRACKER: apiTracker },
@@ -4199,12 +4229,27 @@ try {
   let apiResult = null;
   try { apiResult = JSON.parse(apiProbe); } catch {}
   if (apiResult?.nums?.[0] === 1 && apiResult.formatted === '001'
-      && !existsSync(join(apiTmp, '001-RESERVED.md'))) {
-    pass('reserve-report-num is import-safe and exposes reserve/release/format APIs');
+      && apiResult.firstToken && apiResult.replacementToken
+      && apiResult.firstToken !== apiResult.replacementToken
+      && apiResult.replacementPreserved && apiResult.replacementCleaned) {
+    pass('reserve-report-num token ownership prevents stale cleanup from deleting a replacement claim');
   } else {
     fail(`reserve-report-num import API failed: ${apiProbe}`);
   }
   rmSync(apiTmp, { recursive: true, force: true });
+
+  const trackerParseApi = await import(pathToFileURL(join(ROOT, 'tracker-parse.mjs')).href);
+  const complexLinkNums = trackerParseApi.extractTrackerReportNumbers(
+    '[22](../reports/021-acme_(us)-2026-07-15.md "US role")',
+  );
+  const angleLinkNums = trackerParseApi.extractTrackerReportNumbers(
+    '[23](<../reports/023-acme role-(eu)-2026-07-15.md> \'EU role\')',
+  );
+  if (complexLinkNums.join(',') === '22,21' && angleLinkNums.join(',') === '23') {
+    pass('tracker report-link parsing supports balanced parentheses, spaces, and optional titles');
+  } else {
+    fail(`complex tracker report links parsed incorrectly: ${complexLinkNums} / ${angleLinkNums}`);
+  }
 
   const reserveTmp = mkdtempSync(join(tmpdir(), 'career-ops-reserve-'));
   const single = reserveRun([], reserveTmp);
@@ -4251,7 +4296,9 @@ try {
   const evaluatorSources = ['ollama-eval.mjs', 'openai-eval.mjs', 'gemini-eval.mjs', 'openrouter-runner.mjs']
     .map(name => [name, readFile(name)]);
   const unmigratedEvaluators = evaluatorSources
-    .filter(([, source]) => !source.includes('reserveReportNumbers') || /function\s+nextReport(?:Number|Num)\s*\(/.test(source))
+    .filter(([, source]) => !/reservedNumbers\s*=\s*await\s+reserveReportNumbers\s*\(/.test(source)
+      || !/await\s+releaseReportNumbers\s*\(\s*reservedNumbers\b/.test(source)
+      || /function\s+nextReport(?:Number|Num)\s*\(/.test(source))
     .map(([name]) => name);
   if (unmigratedEvaluators.length === 0) {
     pass('all headless evaluators use the shared atomic report allocator');
@@ -4373,10 +4420,13 @@ try {
   const badCount = reserveRunFail(['--count', '0'], relTmp);
   const hugeCount = reserveRunFail(['--count', '999'], relTmp);
   const badRelease = reserveRunFail(['--release', '009-004'], relTmp);
-  if (badCount === 1 && hugeCount === 1 && badRelease === 1) {
-    pass('invalid --count and inverted --release range exit 1');
+  const hugeRelease = reserveRunFail(['--release', '1-9007199254740992'], relTmp);
+  const wideRelease = reserveRunFail(['--release', '1-51'], relTmp);
+  if (badCount === 1 && hugeCount === 1 && badRelease === 1
+      && hugeRelease === 1 && wideRelease === 1) {
+    pass('invalid counts and unsafe, inverted, or oversized release ranges exit 1');
   } else {
-    fail(`validation exits: count0=${badCount}, count999=${hugeCount}, inverted=${badRelease}`);
+    fail(`validation exits: count0=${badCount}, count999=${hugeCount}, inverted=${badRelease}, unsafe=${hugeRelease}, wide=${wideRelease}`);
   }
   rmSync(relTmp, { recursive: true, force: true });
 } catch (e) {

--- a/tracker-parse.mjs
+++ b/tracker-parse.mjs
@@ -167,6 +167,81 @@ export function parseTrackerRow(line, colmap = LEGACY_COLMAP) {
  * @param {string} reportCell - Raw Report cell value.
  * @returns {number[]} Unique positive report IDs in encounter order.
  */
+function markdownLinkDestination(raw) {
+  const value = String(raw).trimStart();
+  if (value.startsWith('<')) {
+    for (let i = 1; i < value.length; i++) {
+      if (value[i] === '\\') {
+        i++;
+      } else if (value[i] === '>') {
+        return value.slice(1, i).replace(/\\([\\()<> ])/g, '$1');
+      }
+    }
+    return null;
+  }
+
+  let depth = 0;
+  let end = value.length;
+  for (let i = 0; i < value.length; i++) {
+    if (value[i] === '\\') {
+      i++;
+      continue;
+    }
+    if (value[i] === '(') depth++;
+    else if (value[i] === ')' && depth > 0) depth--;
+    else if (/\s/.test(value[i]) && depth === 0) {
+      end = i;
+      break;
+    }
+  }
+  const destination = value.slice(0, end).trim();
+  return destination ? destination.replace(/\\([\\()<> ])/g, '$1') : null;
+}
+
+function parseMarkdownLinks(value) {
+  const links = [];
+  let cursor = 0;
+  while (cursor < value.length) {
+    const labelStart = value.indexOf('[', cursor);
+    if (labelStart === -1) break;
+
+    let labelEnd = -1;
+    for (let i = labelStart + 1; i < value.length; i++) {
+      if (value[i] === '\\') i++;
+      else if (value[i] === ']') {
+        labelEnd = i;
+        break;
+      }
+    }
+    if (labelEnd === -1 || value[labelEnd + 1] !== '(') {
+      cursor = labelStart + 1;
+      continue;
+    }
+
+    let depth = 1;
+    let linkEnd = -1;
+    for (let i = labelEnd + 2; i < value.length; i++) {
+      if (value[i] === '\\') {
+        i++;
+      } else if (value[i] === '(') {
+        depth++;
+      } else if (value[i] === ')' && --depth === 0) {
+        linkEnd = i;
+        break;
+      }
+    }
+    if (linkEnd === -1) {
+      cursor = labelStart + 1;
+      continue;
+    }
+
+    const target = markdownLinkDestination(value.slice(labelEnd + 2, linkEnd));
+    if (target != null) links.push({ label: value.slice(labelStart + 1, labelEnd), target });
+    cursor = linkEnd + 1;
+  }
+  return links;
+}
+
 export function extractTrackerReportNumbers(reportCell) {
   const value = String(reportCell ?? '').trim();
   if (!value || value === '-' || value === '—') return [];
@@ -183,12 +258,11 @@ export function extractTrackerReportNumbers(reportCell) {
     return Number.isInteger(num) && num > 0 ? num : null;
   };
 
-  let sawMarkdownLink = false;
-  for (const match of value.matchAll(/\[([^\]]*)\]\(([^)]+)\)/g)) {
-    sawMarkdownLink = true;
-    const pathNum = numberFromTarget(match[2]);
+  const markdownLinks = parseMarkdownLinks(value);
+  for (const link of markdownLinks) {
+    const pathNum = numberFromTarget(link.target);
     if (pathNum == null) continue;
-    const label = match[1].trim();
+    const label = link.label.trim();
     if (/^\d+$/.test(label)) {
       const labelNum = parseInt(label, 10);
       if (labelNum > 0) numbers.add(labelNum);
@@ -196,7 +270,7 @@ export function extractTrackerReportNumbers(reportCell) {
     numbers.add(pathNum);
   }
 
-  if (!sawMarkdownLink) {
+  if (markdownLinks.length === 0) {
     const pathNum = numberFromTarget(value);
     if (pathNum != null) numbers.add(pathNum);
   }

--- a/tracker-parse.mjs
+++ b/tracker-parse.mjs
@@ -157,6 +157,53 @@ export function parseTrackerRow(line, colmap = LEGACY_COLMAP) {
 }
 
 /**
+ * Extract report IDs referenced by one tracker Report cell.
+ *
+ * Both the numeric markdown label and the local report filename are returned.
+ * Keeping both makes tracker drift visible instead of silently trusting one
+ * side of a malformed link. External URLs are ignored even when their path
+ * happens to contain a reports/ segment.
+ *
+ * @param {string} reportCell - Raw Report cell value.
+ * @returns {number[]} Unique positive report IDs in encounter order.
+ */
+export function extractTrackerReportNumbers(reportCell) {
+  const value = String(reportCell ?? '').trim();
+  if (!value || value === '-' || value === '—') return [];
+
+  const numbers = new Set();
+  const numberFromTarget = (rawTarget) => {
+    const target = String(rawTarget).trim().replace(/^<|>$/g, '');
+    if (!target || /^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(target)) return null;
+    const pathname = target.split(/[?#]/, 1)[0];
+    const match = pathname.match(/(?:^|[\\/])reports[\\/]0*(\d+)-/i)
+      || pathname.match(/(?:^|[\\/])0*(\d+)-[^\\/]*\.md$/i);
+    if (!match) return null;
+    const num = parseInt(match[1], 10);
+    return Number.isInteger(num) && num > 0 ? num : null;
+  };
+
+  let sawMarkdownLink = false;
+  for (const match of value.matchAll(/\[([^\]]*)\]\(([^)]+)\)/g)) {
+    sawMarkdownLink = true;
+    const pathNum = numberFromTarget(match[2]);
+    if (pathNum == null) continue;
+    const label = match[1].trim();
+    if (/^\d+$/.test(label)) {
+      const labelNum = parseInt(label, 10);
+      if (labelNum > 0) numbers.add(labelNum);
+    }
+    numbers.add(pathNum);
+  }
+
+  if (!sawMarkdownLink) {
+    const pathNum = numberFromTarget(value);
+    if (pathNum != null) numbers.add(pathNum);
+  }
+  return [...numbers];
+}
+
+/**
  * Unicode-aware key for Via (agency) comparison.
  *
  * normalizeCompany()-style keys strip everything outside [a-z0-9], so


### PR DESCRIPTION
## Summary

- make `reserve-report-num.mjs` an import-safe shared allocator used by every headless evaluator
- reserve against report files, sentinels, tracker row IDs, and tracker report links under the shared tracker lock
- preserve free reserved IDs during tracker merge and warn only on real collisions
- block numeric `set-status` updates when the tracker row and report link disagree unless `--force` is explicit
- keep report numbering correct beyond 999

This carries forward the two-layer safeguard proposed in #1734 and consolidates the related allocator fixes in one non-conflicting change.

Closes #1733
Closes #1801
Closes #1835
Closes #1895
Supersedes #1734

## Root cause

Report files, tracker rows, and the four headless evaluators maintained independent counters. Out-of-order completion or an incomplete local `reports/` directory could therefore reuse or silently rewrite a reserved ID.

## Verification

- `node set-status-tests.mjs` (38 passed)
- `node test-all.mjs` (1742 passed, 0 failed; 2 expected environment warnings)
- dashboard compile included in the full suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Report numbering now uses a shared, atomic reservation workflow across evaluators for safer parallel runs.
  - Report numbers are formatted consistently, including four-digit values.
  - Added `--force` to the status CLI, enabling override behavior when tracker/report numbers don’t align.

- **Bug Fixes**
  - Detects tracker/report-number mismatches and returns a structured error unless `--force` is used.
  - Improved collision handling and cleanup of stale reservations.

- **Documentation**
  - Updated CLI usage and headless/batch guidance for reservation behavior.

- **Tests**
  - Added regression coverage for mismatches and reservation fidelity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->