### PR TITLE
fix: preserve fetched text in targeted upskill mode

### DIFF
--- a/upskill.mjs
+++ b/upskill.mjs
@@ -27,6 +27,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { load as yamlLoad } from 'js-yaml';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { compactText } from './browser-extract.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -289,6 +290,12 @@ export function computeTargetedGaps(jdText, knownText) {
   return { gaps, excludedAsKnown, knownSkills: [...known].sort() };
 }
 
+// Both Playwright's innerText() and fetch().text() produce strings. Keep that
+// contract while applying the same whitespace cap as browser extraction.
+export function compactTargetText(rawText) {
+  return compactText(rawText);
+}
+
 // --- Main ---
 function analyze(minReports) {
   if (!existsSync(APPS_FILE)) {
@@ -514,6 +521,21 @@ soft_gaps:
     }
   }
 
+  // URL extraction returns body text as a string. The targeted pipeline must
+  // keep that shape while compacting it; passing the string through normalizeJd
+  // turns it into an empty object and crashes extractSkills (#1894).
+  {
+    const targetText = compactTargetText('  Senior Engineer\n\n\nRequires Kubernetes and Go.  ');
+    if (typeof targetText !== 'string' || !targetText.includes('Requires Kubernetes')) {
+      failures.push(`targeted URL text was not preserved as a compact string (${JSON.stringify(targetText)})`);
+    } else {
+      const { gaps } = computeTargetedGaps(targetText, 'Python');
+      if (!gaps.includes('Kubernetes') || !gaps.includes('Go')) {
+        failures.push(`targeted URL text did not reach gap extraction (got ${gaps.join(',')})`);
+      }
+    }
+  }
+
   if (failures.length > 0) {
     console.error(`upskill self-test failed: ${failures.join('; ')}`);
     process.exit(1);
@@ -604,10 +626,7 @@ if (urlTextIdx !== -1 || directUrl) {
         if (browser) await browser.close();
       }
 
-      try {
-        const { normalizeJd } = await import('./browser-extract.mjs');
-        targetText = normalizeJd(targetText, inputSource);
-      } catch (e) {}
+      targetText = compactTargetText(targetText);
     } else {
       if (existsSync(inputSource)) {
         targetText = readFileSync(inputSource, 'utf-8');


### PR DESCRIPTION
Closes #1894

## Summary
- compact URL-fetched JD text with the string-to-string browser extraction helper
- remove the normalizeJd call that converted body text into an empty object
- cover the URL text shape and downstream targeted gap extraction in the built-in self-test

## Tests
- `node upskill.mjs --self-test`
- `node test-all.mjs` (1738 passed, 0 failed; one expected missing-user-CV warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill extraction from job descriptions fetched through URLs.
  * Preserved the expected text format during processing, helping ensure extracted job description content remains usable.
  * Added validation to confirm URL-based extraction returns meaningful text and identifies expected skills reliably.

* **Tests**
  * Expanded automated checks for URL-fetched job description processing and skill extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->