### PR TITLE
fix(scan-ats-full): respect company blacklist

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -374,6 +374,8 @@ Reverse ATS discovery scanner. Where `scan.mjs` scans the companies you track in
 
 Postings without a usable publish date are skipped — a reverse scan is only useful for fresh postings. New matches are appended to `data/pipeline.md` and `data/scan-history.tsv` in the same format as `scan.mjs`.
 
+`data/blacklist.md` is respected here too: blacklisted companies are skipped by default and reported in the summary. Pass `--include-blacklisted` to audit them instead; matching postings flow through annotated (`note: blacklisted: {reason}` in `data/pipeline.md`).
+
 ### Cross-listing detection
 
 `data/scan-history.tsv` carries a **SimHash fingerprint** of the JD text in its 8th column (`jd_fingerprint`), and the original posting date in its 9th column (`postedAt`). The fingerprint column exists to catch a specific double-submission hazard: the same role posted by the direct employer **and** by a recruitment agency, often with the employer name stripped from the agency listing. URL dedup and company+role dedup both miss this pair because the URLs and company names are different — but agencies rarely rewrite the requirements text, so a near-identical JD body is a reliable signal.
@@ -395,6 +397,7 @@ node scan-ats-full.mjs --ats greenhouse,workday # subset of sources
 node scan-ats-full.mjs --limit 200             # max companies per ATS
 node scan-ats-full.mjs --dry-run               # preview without writing
 node scan-ats-full.mjs --liveness              # Playwright-verify matches first
+node scan-ats-full.mjs --include-blacklisted   # audit blacklist matches instead of skipping
 node scan-ats-full.mjs --md-out notes/scans    # also write a dated markdown digest
 ```
 

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -23,6 +23,7 @@
  *   node scan-ats-full.mjs --limit 200          # max companies per ATS (default: all)
  *   node scan-ats-full.mjs --dry-run            # preview without writing files
  *   node scan-ats-full.mjs --liveness           # Playwright-verify matches before writing
+ *   node scan-ats-full.mjs --include-blacklisted # audit: let data/blacklist.md matches through, annotated
  *   node scan-ats-full.mjs --verbose            # log per-board fetch failures
  *   node scan-ats-full.mjs --md-out <dir>       # also write a dated markdown digest to <dir>
  *   node scan-ats-full.mjs --help               # print this usage block and exit
@@ -38,8 +39,9 @@ import greenhouse from './providers/greenhouse.mjs';
 import lever from './providers/lever.mjs';
 import ashby from './providers/ashby.mjs';
 import workday from './providers/workday.mjs';
-import { buildTitleFilter, buildLocationFilter, loadSeenUrls, appendToPipeline, appendToScanHistory } from './scan.mjs';
+import { buildTitleFilter, buildLocationFilter, loadSeenUrls, appendToPipeline, appendToScanHistory, loadBlacklist } from './scan.mjs';
 import { SEED_SOURCES, toPortalEntry } from './seeds/vc-portfolios.mjs';
+import { normalizeCompany } from './tracker-utils.mjs';
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -117,8 +119,8 @@ const SOURCES = {
 
 const KNOWN_FLAGS = [
   '--since', '--limit', '--ats', '--seeds', '--dry-run', '--liveness',
-  '--verbose', '--md-out', '--json', '--include-undated', '--shuffle',
-  '--help', '-h',
+  '--verbose', '--md-out', '--json', '--include-undated', '--include-blacklisted',
+  '--shuffle', '--help', '-h',
 ];
 
 // Flags that consume the next argv token as a value (space-separated form —
@@ -132,6 +134,7 @@ const USAGE = `Usage:
   node scan-ats-full.mjs --limit 200          # max companies per ATS (default: all)
   node scan-ats-full.mjs --dry-run            # preview without writing files
   node scan-ats-full.mjs --liveness           # Playwright-verify matches before writing
+  node scan-ats-full.mjs --include-blacklisted # audit: let data/blacklist.md matches through, annotated
   node scan-ats-full.mjs --verbose            # log per-board fetch failures
   node scan-ats-full.mjs --md-out <dir>       # also write a dated markdown digest to <dir>
   node scan-ats-full.mjs --help               # print this usage block and exit`;
@@ -204,6 +207,7 @@ function parseArgs(argv) {
     mdOut: valueOf('--md-out'),
     json: args.includes('--json'),
     includeUndated: args.includes('--include-undated'),
+    includeBlacklisted: args.includes('--include-blacklisted'),
     shuffle: args.includes('--shuffle'),
   };
 }
@@ -250,11 +254,49 @@ export function classifyPostingDate(job, cutoff) {
   return 'keep';
 }
 
+// Apply the same user-owned do-not-apply gate as scan.mjs to reverse-scan
+// results. Absent/empty blacklist is a no-op. Default skips are counted and
+// never silent; --include-blacklisted keeps matches but marks them for audit.
+export function filterBlacklistedOffers(offers, blacklist, { includeBlacklisted = false } = {}) {
+  if (!blacklist || blacklist.size === 0) {
+    return { offers, filteredBlacklist: 0, annotatedBlacklisted: 0 };
+  }
+
+  const kept = [];
+  let filteredBlacklist = 0;
+  let annotatedBlacklisted = 0;
+
+  for (const offer of offers) {
+    const entry = blacklist.get(normalizeCompany(offer.company || ''));
+    if (!entry) {
+      kept.push(offer);
+      continue;
+    }
+
+    if (!includeBlacklisted) {
+      filteredBlacklist++;
+      continue;
+    }
+
+    annotatedBlacklisted++;
+    const label = `blacklisted${entry.reason ? `: ${entry.reason}` : ''}`;
+    kept.push({
+      ...offer,
+      blacklisted: true,
+      note: typeof offer.note === 'string' && offer.note.trim()
+        ? `${label} — ${offer.note}`
+        : label,
+    });
+  }
+
+  return { offers: kept, filteredBlacklist, annotatedBlacklisted };
+}
+
 // Cap-aware company sampling. Default: the dataset's natural (alphabetical)
 // prefix. With --shuffle: a random sample of `limit` companies, so a capped
 // scan isn't always biased to the same alphabetical-first slice. Pure; returns
 // a new array and never mutates `list`.
-export function sampleCompanies(list, limit, shuffle) {
+export function sampleCompanies(list, limit, shuffle = false) {
   if (!shuffle || limit >= list.length) return list.slice(0, limit);
   const copy = list.slice();
   for (let i = copy.length - 1; i > 0; i--) {
@@ -422,6 +464,7 @@ async function main() {
   log(`Reverse ATS scan — ${sourcesSummary} | since ${opts.sinceDays}d${opts.limit < Infinity ? ` | limit ${opts.limit}/ats` : ''}${opts.shuffle ? ' | shuffled' : ''}${opts.includeUndated ? ' | +undated' : ''}${opts.liveness ? ' | liveness' : ''}${opts.dryRun ? ' | DRY RUN' : ''}`);
 
   const { seen: seenUrls } = loadSeenUrls();
+  const blacklist = loadBlacklist();
   // sinceMs and includeUndated let providers (currently only workday.mjs)
   // stop paginating a tenant early instead of always walking to max_pages:
   // sinceMs once postings are confidently past the --since window, and
@@ -502,8 +545,9 @@ async function main() {
     }
   }
 
-  let offers = newOffers;
-  if (offers.length && opts.liveness) offers = await filterLive(newOffers);
+  const blacklistResult = filterBlacklistedOffers(newOffers, blacklist, { includeBlacklisted: opts.includeBlacklisted });
+  let offers = blacklistResult.offers;
+  if (offers.length && opts.liveness) offers = await filterLive(offers);
   offers.sort((a, b) => (b.postedAt || 0) - (a.postedAt || 0));
 
   log(`\n${'━'.repeat(45)}`);
@@ -521,13 +565,21 @@ async function main() {
       : '';
     log(`Undated dropped: ${droppedNoDate}${breakdown}${opts.includeUndated ? '' : '. Use --include-undated to keep'}`);
   }
+  if (blacklist.size > 0) {
+    if (opts.includeBlacklisted) {
+      log(`Blacklisted:      ${blacklistResult.annotatedBlacklisted} let through annotated (--include-blacklisted)`);
+    } else {
+      log(`Blacklisted:      ${blacklistResult.filteredBlacklist} skipped (blacklist)`);
+    }
+  }
   log(`New matches:        ${offers.length}`);
 
   if (offers.length) {
     log('\nNew offers:');
     for (const o of offers) {
       const posted = o.postedAt ? new Date(o.postedAt).toISOString().slice(0, 10) : 'n/a';
-      log(`  + [${o.source}] ${posted} | ${o.company} | ${o.title} | ${o.location || 'N/A'}\n    ${o.url}`);
+      const blacklistSuffix = o.blacklisted ? ' [BLACKLISTED — on your do-not-apply list]' : '';
+      log(`  + [${o.source}] ${posted} | ${o.company} | ${o.title} | ${o.location || 'N/A'}${blacklistSuffix}\n    ${o.url}`);
     }
   }
 
@@ -579,6 +631,8 @@ async function main() {
       datasetStatus,
       postingsKept: offers.length,
       postingsDroppedNoDate: droppedNoDate,
+      postingsFilteredBlacklist: blacklistResult.filteredBlacklist,
+      postingsAnnotatedBlacklisted: blacklistResult.annotatedBlacklisted,
       unreachableBoards: totalErrors,
       saved,
       offers: offers.map(o => ({
@@ -588,6 +642,8 @@ async function main() {
         location: o.location || null,
         postedAt: o.postedAt ? new Date(o.postedAt).toISOString().slice(0, 10) : null,
         dateStatus: o.dateStatus || (o.postedAt ? 'dated' : 'unknown'),
+        blacklisted: Boolean(o.blacklisted),
+        note: o.note || null,
         source: o.source,
       })),
     }) + '\n');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2218,6 +2218,38 @@ try {
   fail(`scan-ats-full date-gate/sampling test crashed: ${e.message}`);
 }
 
+// Reverse-scan blacklist gate: scan-ats-full must share scan.mjs's
+// user-owned do-not-apply semantics, including audit mode annotation.
+try {
+  const { filterBlacklistedOffers } = await import(pathToFileURL(join(ROOT, 'scan-ats-full.mjs')).href);
+  const blacklist = new Map([
+    ['acmecorp', { company: 'Acme Corp', reason: 'example reason' }],
+  ]);
+  const offers = [
+    { company: 'Acme Corp.', title: 'Software Engineer', url: 'https://example.com/acme' },
+    { company: 'Globex', title: 'Software Engineer', url: 'https://example.com/globex' },
+  ];
+  const skipped = typeof filterBlacklistedOffers === 'function'
+    ? filterBlacklistedOffers(offers, blacklist, { includeBlacklisted: false })
+    : null;
+  const audited = typeof filterBlacklistedOffers === 'function'
+    ? filterBlacklistedOffers(offers, blacklist, { includeBlacklisted: true })
+    : null;
+  const ok =
+    skipped?.filteredBlacklist === 1 &&
+    skipped.offers.length === 1 &&
+    skipped.offers[0].company === 'Globex' &&
+    audited?.annotatedBlacklisted === 1 &&
+    audited.offers.length === 2 &&
+    audited.offers[0].blacklisted === true &&
+    audited.offers[0].note.includes('blacklisted: example reason') &&
+    offers[0].blacklisted === undefined;
+  if (ok) pass('scan-ats-full filters data/blacklist.md matches by default and annotates them under --include-blacklisted (#1911)');
+  else fail('scan-ats-full missing blacklist filter/audit semantics (#1911)');
+} catch (e) {
+  fail(`scan-ats-full blacklist test crashed: ${e.message}`);
+}
+
 // ── VC Portfolio Seed Fetcher ────────────────────────────────────────
 // Tests the pure (no-network) parseSeedEntries(), parseYCPayload(),
 // parseA16zPayload(), toPortalEntry(), and the SEED_SOURCES registry.


### PR DESCRIPTION
## Summary

- Wire `data/blacklist.md` into `scan-ats-full.mjs` using the existing `scan.mjs` blacklist parser and shared company normalization.
- Add `--include-blacklisted` audit mode for reverse scans, with annotated postings instead of skips.
- Surface blacklist skip/audit counters in the human summary and JSON output.
- Document the reverse-scan blacklist behavior and add regression coverage.

Closes #1911

## Test Plan

- `node --check scan-ats-full.mjs && node --check test-all.mjs`
- Focused helper check via `node --input-type=module` for default skip + audit annotation semantics.
- `node scan-ats-full.mjs --help | grep -F -- '--include-blacklisted'`
- `node scan-ats-full.mjs --dry-run --include-blacklisted --limit 1 --ats greenhouse`
- `node test-all.mjs` now passes the new `scan-ats-full` blacklist regression; local full-suite run still has two unrelated pre-existing failures from this checkout's personal-data symlink layout:
  - `verify-pipeline.mjs` cannot resolve local workspace report links from the app repo checkout.
  - `reconcile-pipeline.mjs --dry-run` rejects the symlinked `data/pipeline.md` because it points outside the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blacklist-aware filtering to reverse scans, skipping matching companies by default.
  * Added an auditing option to include blacklisted postings with clear annotations and reasons.
  * Enhanced console and JSON results with blacklist status and summary counts.

* **Documentation**
  * Updated command-line usage guidance and examples for blacklist auditing.

* **Tests**
  * Added coverage verifying default filtering and annotated audit results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->