### PR TITLE
fix(upskill): --url-text URL path destroyed the fetched JD via misused normalizeJd (#1894)

### DIFF
--- a/upskill.mjs
+++ b/upskill.mjs
@@ -514,6 +514,27 @@ soft_gaps:
     }
   }
 
+  // Targeted --url-text path (#1894): the fetched page text must reach
+  // computeTargetedGaps as a plain STRING. It used to be run through normalizeJd
+  // (which wants the { title, text } DOM object), yielding { text: '' } and then
+  // a `text.matchAll is not a function` crash. Guard both halves: a realistic
+  // multi-line JD string produces the right gaps, and the source no longer feeds
+  // the raw string to normalizeJd.
+  {
+    const jdText = 'Requirements:\n- Kubernetes and Go\n- 5+ years experience';
+    const { gaps } = computeTargetedGaps(jdText, 'Python, AWS'); // must not throw on a string
+    if (!gaps.includes('Kubernetes') || !gaps.includes('Go')) {
+      failures.push(`url-text: multi-line JD string should yield Kubernetes+Go gaps (got ${gaps.join(',')})`);
+    }
+    const selfSrc = readFileSync(fileURLToPath(import.meta.url), 'utf-8');
+    if (/normalizeJd\(\s*targetText/.test(selfSrc)) {
+      failures.push('url-text: upskill.mjs still passes the raw fetched string to normalizeJd (regression, #1894)');
+    }
+    if (!/compactText\(targetText\)/.test(selfSrc)) {
+      failures.push('url-text: fetched text should be normalized with compactText (string->string), #1894');
+    }
+  }
+
   if (failures.length > 0) {
     console.error(`upskill self-test failed: ${failures.join('; ')}`);
     process.exit(1);

--- a/upskill.mjs
+++ b/upskill.mjs
@@ -604,9 +604,15 @@ if (urlTextIdx !== -1 || directUrl) {
         if (browser) await browser.close();
       }
 
+      // Whitespace-collapse + length-cap the fetched page text. Use compactText
+      // (string -> string), NOT normalizeJd: normalizeJd expects the { title,
+      // text } DOM-read object and returns { url, title, text }, so feeding it
+      // the innerText/fetch STRING silently produced { text: '' } — destroying
+      // the JD and then throwing `text.matchAll is not a function` downstream
+      // (#1894). compactText is the string-in/string-out helper this wants.
       try {
-        const { normalizeJd } = await import('./browser-extract.mjs');
-        targetText = normalizeJd(targetText, inputSource);
+        const { compactText } = await import('./browser-extract.mjs');
+        targetText = compactText(targetText);
       } catch (e) {}
     } else {
       if (existsSync(inputSource)) {


### PR DESCRIPTION
Fixes #1894.

## Bug
The targeted-mode URL path passed the fetched page **string** (`page.innerText("body")` / `res.text()`) to `normalizeJd`, which is browser-extract's shaper for the `{ title, text }` **DOM-read object** (it returns `{ url, title, text }`). Feeding it a string gives `{ url, title: "", text: "" }`, so (1) the fetched JD is **silently replaced by empty text**, and (2) `targetText` is now an object → `extractSkills(text)` → `text.matchAll(...)` throws **`TypeError`**. Any real `--url-text <url>` run: fetch → destroyed text → crash. The file path was unaffected, hiding it since #1796.

## Fix
One-line swap to `compactText` (also exported by browser-extract) — the string→string helper (whitespace collapse + length cap) matching what `normalizeJd` would have applied to its `text` field.

## Test
`runSelfTest()` guard: a multi-line JD string yields the right gaps, plus a source-level check the raw string is never passed to `normalizeJd` again. `node test-all.mjs --quick` → **1739/0**.

2 commits: fix · regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved targeted mode when processing job descriptions from URLs.
  * Prevented crashes caused by incorrectly processed fetched text.
  * Ensured multi-line job descriptions are preserved and cleaned up before analysis.
  * Added regression coverage for URL-based job description extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->