### PR TITLE
fix(i18n): headless eval engines honor language.output; gemini-eval drops the hardcoded English policy (#1897)

### DIFF
--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -47,6 +47,7 @@ try {
 }
 
 import { GoogleGenerativeAI } from '@google/generative-ai';
+import { resolveOutputLanguage, outputLanguageDirective } from './profile-utils.mjs';
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -224,6 +225,7 @@ const ofertaLogic    = readFile(PATHS.oferta,      'modes/oferta.md');
 const cvContent      = readFile(PATHS.cv,          'cv.md');
 const profileContent = readFile(PATHS.profile,     'modes/_profile.md');
 const profileYml     = readFile(PATHS.profileYml,  'config/profile.yml');
+const outputLang     = resolveOutputLanguage(PATHS.profileYml);
 
 // ---------------------------------------------------------------------------
 // Build the system prompt (mirrors the Claude skill router logic)
@@ -265,7 +267,7 @@ IMPORTANT OPERATING RULES FOR THIS CLI SESSION
    - For Block D (Comp research): provide salary estimates based on your training data, clearly noted as estimates.
    - For Block G (Legitimacy): analyze the JD text only; skip URL/page freshness checks.
    - Post-evaluation file saving is handled by the script, not by you.
-2. Generate Blocks A through G in full, in English, unless the JD is in another language.
+2. Generate Blocks A through G in full. ${outputLanguageDirective(outputLang)}
 3. At the very end, output a machine-readable summary block in this exact format:
 
 ---SCORE_SUMMARY---

--- a/ollama-eval.mjs
+++ b/ollama-eval.mjs
@@ -28,6 +28,7 @@ import { fileURLToPath } from 'url';
 import {
   formatReportNumber, releaseReportNumbers, reserveReportNumbers,
 } from './reserve-report-num.mjs';
+import { resolveOutputLanguage, outputLanguageDirective } from './profile-utils.mjs';
 
 try {
   const { config } = await import('dotenv');
@@ -192,6 +193,7 @@ console.log('\n📂  Loading context files...');
 const sharedContext = readFile(PATHS.shared, 'modes/_shared.md');
 const ofertaLogic   = readFile(PATHS.oferta, 'modes/oferta.md');
 const cvContent     = readFile(PATHS.cv,     'cv.md');
+const outputLang    = resolveOutputLanguage(join(ROOT, 'config', 'profile.yml'));
 
 // ---------------------------------------------------------------------------
 // Build system prompt
@@ -223,7 +225,7 @@ IMPORTANT OPERATING RULES FOR THIS SESSION
    - Block D (Comp research): use training-data salary estimates; note them as estimates.
    - Block G (Legitimacy): analyze JD text only; skip URL/page freshness checks.
    - Post-evaluation file saving is handled by the script, not by you.
-2. Generate Blocks A through G in full.
+2. Generate Blocks A through G in full. ${outputLanguageDirective(outputLang)}
 3. At the very end, output this exact machine-readable block:
 
 ---SCORE_SUMMARY---

--- a/openai-eval.mjs
+++ b/openai-eval.mjs
@@ -33,6 +33,7 @@ import { fileURLToPath } from 'url';
 import {
   formatReportNumber, releaseReportNumbers, reserveReportNumbers,
 } from './reserve-report-num.mjs';
+import { resolveOutputLanguage, outputLanguageDirective } from './profile-utils.mjs';
 
 try {
   const { config } = await import('dotenv');
@@ -205,6 +206,7 @@ console.log('\n📂  Loading context files...');
 const sharedContext = readFile(PATHS.shared, 'modes/_shared.md');
 const ofertaLogic   = readFile(PATHS.oferta, 'modes/oferta.md');
 const cvContent     = readFile(PATHS.cv,     'cv.md');
+const outputLang    = resolveOutputLanguage(join(ROOT, 'config', 'profile.yml'));
 
 // ---------------------------------------------------------------------------
 // Build system prompt
@@ -236,7 +238,7 @@ IMPORTANT OPERATING RULES FOR THIS SESSION
    - Block D (Comp research): use training-data salary estimates; note them as estimates.
    - Block G (Legitimacy): analyze JD text only; skip URL/page freshness checks.
    - Post-evaluation file saving is handled by the script, not by you.
-2. Generate Blocks A through G in full.
+2. Generate Blocks A through G in full. ${outputLanguageDirective(outputLang)}
 3. At the very end, output this exact machine-readable block:
 
 ---SCORE_SUMMARY---

--- a/openrouter-runner.mjs
+++ b/openrouter-runner.mjs
@@ -26,6 +26,7 @@ import yaml from 'js-yaml';
 import {
   formatReportNumber, releaseReportNumbers, reserveReportNumbers,
 } from './reserve-report-num.mjs';
+import { resolveOutputLanguage, outputLanguageDirective } from './profile-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -344,6 +345,7 @@ function loadContext() {
     profile:     readFile('config/profile.yml')  ?? '',
     shared:      readFile('modes/_shared.md')    ?? '',
     profileMode: readFile('modes/_profile.md')   ?? '',
+    outputLang:  resolveOutputLanguage('config/profile.yml'),
   };
 }
 
@@ -352,6 +354,8 @@ function buildSystemPrompt(modeContent, ctx) {
     ctx.shared,
     ctx.profileMode,
     modeContent,
+    '---',
+    outputLanguageDirective(ctx.outputLang || 'en'),
     '---',
     'CANDIDATE PROFILE (YAML):',
     ctx.profile,

--- a/profile-utils.mjs
+++ b/profile-utils.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * profile-utils.mjs — small shared readers for config/profile.yml (#1897)
+ *
+ * The headless eval engines (gemini/openai/ollama/openrouter) each assemble a
+ * system prompt from the same modes but never honored `language.output`, so a
+ * user with `language: { output: de }` still got English reports from the budget
+ * path (and gemini-eval hardcoded "in English, unless the JD is in another
+ * language" — the JD-language detection AGENTS.md says must NEVER override the
+ * explicit user preference). This centralizes the language resolution + the
+ * canonical directive so all four engines agree and can't drift.
+ *
+ * Pure + js-yaml only, so it's unit-testable without any model/network.
+ */
+import { readFileSync, existsSync } from 'fs';
+import yaml from 'js-yaml';
+
+/**
+ * Resolve the human-facing output language from a profile file. Missing file,
+ * absent `language.output`, non-string value, or bad YAML → 'en' (the documented
+ * default). Never throws.
+ * @param {string} [profilePath]
+ * @returns {string} an ISO-ish language code, e.g. 'en', 'de', 'ja'
+ */
+export function resolveOutputLanguage(profilePath = 'config/profile.yml') {
+  try {
+    if (!existsSync(profilePath)) return 'en';
+    const raw = yaml.load(readFileSync(profilePath, 'utf-8')) || {};
+    const v = raw?.language?.output;
+    return typeof v === 'string' && v.trim() ? v.trim() : 'en';
+  } catch {
+    return 'en';
+  }
+}
+
+/**
+ * The canonical output-language directive (mirrors AGENTS.md's "Agent rule").
+ * Injected into every headless engine's system prompt so human-facing output
+ * follows `language.output`, not the JD's language.
+ * @param {string} [lang]
+ * @returns {string}
+ */
+export function outputLanguageDirective(lang = 'en') {
+  return [
+    `OUTPUT LANGUAGE: Write all human-facing output — the full A–G evaluation and`,
+    `the machine-readable summary's free-text fields — in ${lang}, regardless of the`,
+    `language of these instructions or of the job description. Keep market-specific`,
+    `terms where relevant, but explain them in ${lang} when needed. The candidate's`,
+    `configured language.output always wins over the JD's language.`,
+  ].join(' ');
+}

--- a/tests/profile-utils.test.mjs
+++ b/tests/profile-utils.test.mjs
@@ -1,0 +1,54 @@
+// tests/profile-utils.test.mjs — the shared language.output resolver (#1897) and
+// a guard that all four headless eval engines actually use it (and gemini-eval
+// no longer hardcodes the JD-language-detection policy AGENTS.md forbids).
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+
+console.log('\nprofile-utils.mjs (language.output, #1897)');
+
+try {
+  const { resolveOutputLanguage, outputLanguageDirective } = await import(pathToFileURL(join(ROOT, 'profile-utils.mjs')).href);
+
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-lang-'));
+  try {
+    const write = (name, body) => { const p = join(dir, name); writeFileSync(p, body); return p; };
+    if (resolveOutputLanguage(write('de.yml', 'language:\n  output: de\n')) === 'de') pass('resolveOutputLanguage reads language.output');
+    else fail('resolveOutputLanguage should read de');
+    if (resolveOutputLanguage(write('none.yml', 'candidate:\n  full_name: X\n')) === 'en') pass('resolveOutputLanguage defaults to en when language.output is absent');
+    else fail('resolveOutputLanguage should default to en');
+    if (resolveOutputLanguage(join(dir, 'missing.yml')) === 'en') pass('resolveOutputLanguage returns en for a missing profile');
+    else fail('resolveOutputLanguage should return en for a missing file');
+    if (resolveOutputLanguage(write('bad.yml', 'language:\n  output: [de\n')) === 'en') pass('resolveOutputLanguage falls back to en on malformed YAML');
+    else fail('resolveOutputLanguage should fall back to en on bad YAML');
+    if (resolveOutputLanguage(write('num.yml', 'language:\n  output: 42\n')) === 'en') pass('resolveOutputLanguage ignores a non-string language.output');
+    else fail('resolveOutputLanguage should ignore a non-string value');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  // directive embeds the language and states the precedence rule
+  const d = outputLanguageDirective('ja');
+  if (d.includes('ja') && /language\.output always wins/i.test(d)) pass('outputLanguageDirective embeds the language and the precedence rule');
+  else fail(`outputLanguageDirective => ${d}`);
+
+  // Guard: every headless engine resolves + injects the directive, and gemini
+  // no longer hardcodes "in English, unless the JD is in another language".
+  const engines = ['gemini-eval.mjs', 'openai-eval.mjs', 'ollama-eval.mjs', 'openrouter-runner.mjs'];
+  const missing = engines.filter((e) => {
+    const src = readFileSync(join(ROOT, e), 'utf-8');
+    return !(src.includes('resolveOutputLanguage') && src.includes('outputLanguageDirective'));
+  });
+  if (missing.length === 0) pass('all four headless engines resolve and inject language.output (#1897)');
+  else fail(`engines missing language.output wiring: ${missing.join(', ')}`);
+
+  if (!/in English, unless the JD is in another language/i.test(readFileSync(join(ROOT, 'gemini-eval.mjs'), 'utf-8'))) {
+    pass('gemini-eval no longer hardcodes the JD-language-detection policy (#1897)');
+  } else {
+    fail('gemini-eval still hardcodes "in English, unless the JD is in another language"');
+  }
+} catch (e) {
+  fail(`profile-utils tests crashed: ${e.message}`);
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -184,6 +184,7 @@ const SYSTEM_PATHS = [
   'agent-inbox.mjs',
   'followup-seed.mjs',
   'followup-seed-tests.mjs',
+  'profile-utils.mjs',
   'gemini-eval.mjs',
   'ollama-eval.mjs',
   'openai-eval.mjs',


### PR DESCRIPTION
Fixes #1897. Starting with the gemini-eval hardcode you flagged as "the first thing to fix", and taking the other three in the same pass since the gap is uniform.

## Problem
The four headless engines build prompts from the same modes but never read `language.output`:
- `ollama-eval` / `openai-eval` / `openrouter-runner` — no language handling at all → a user with `language.output: de` gets **English** reports from the budget path.
- `gemini-eval:275` hardcoded *"Generate Blocks A through G in full, in English, unless the JD is in another language"* — the exact JD-language detection AGENTS.md says must **never** override the explicit `language.output` preference (so a French JD produced a French report even when the user asked for English).

## Fix
- **`profile-utils.mjs`** (new, shared): `resolveOutputLanguage(profilePath)` (default `en`, never throws) + `outputLanguageDirective(lang)` (the canonical AGENTS.md directive). One home, no 4× duplication (the drift that produced #1851/#1896).
- All four engines resolve the language and inject the directive into their system prompt; the gemini hardcode is removed.

## Tests
`tests/profile-utils.test.mjs`: resolution (present / absent / missing-file / bad-YAML / non-string → `en`), the directive contents, a guard that **all four** engines wire it, and that gemini-eval no longer contains the hardcoded policy string. `node test-all.mjs --quick` → **1748 passed, 0 failed**.

4 commits: shared helper · gemini hardcode · other 3 engines · tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profile-driven output-language support for evaluation reports, applying the configured `language.output` consistently across supported engines.
  * Injected a dynamic output-language directive into generated evaluation instructions, with English as the default fallback.
* **Bug Fixes**
  * Improved robustness when profile language settings are missing, malformed, or non-string, preventing prompt/output inconsistencies.
* **Tests**
  * Added a dedicated test suite covering language resolution, fallbacks, precedence rules, and cross-engine prompt updates.
* **Chores**
  * Updated the system update manifest to include the shared profile utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->