### PR TITLE
fix: prevent role-matcher from collapsing base titles into specialized siblings

### DIFF
--- a/role-matcher.mjs
+++ b/role-matcher.mjs
@@ -24,6 +24,8 @@ export const ROLE_STOPWORDS = new Set([
   'fulltime', 'parttime', 'permanent', 'temporary', 'intern', 'internship',
   // generic job words
   'role', 'position', 'opportunity', 'team', 'based',
+  // reposting/tracking annotations — meta noise, never part of the job itself
+  'repost', 'reposted', 'relisted',
   // very common locations
   'bangalore', 'bengaluru', 'mumbai', 'delhi', 'hyderabad', 'pune', 'chennai',
   'london', 'berlin', 'paris', 'madrid', 'barcelona', 'amsterdam', 'dublin',
@@ -124,6 +126,23 @@ export function roleFuzzyMatch(a, b) {
   // engineer] are not the same opening.
   const discriminating = overlap.filter(w => !BASELINE_TOKENS.has(w));
   if (discriminating.length === 0) return false;
+
+  // A generic base title carries no suffix of its own to counterbalance a
+  // specialized sibling's extra word, so the shared tokens alone can cross the
+  // Jaccard threshold even though that extra word is exactly the signal that
+  // these are two different, separately-postable openings (e.g. "Senior
+  // Analytics Engineer" vs "Senior Analytics Engineer, People Analytics").
+  // When one title's token set is a strict subset of the other's, and the
+  // superset's extra tokens contain a non-baseline word, treat that word as a
+  // specialization marker and keep the titles distinct.
+  const smaller = wordsA.length <= wordsB.length ? wordsA : wordsB;
+  const larger = wordsA.length <= wordsB.length ? wordsB : wordsA;
+  const isProperSubset = larger.length > smaller.length && overlap.length === smaller.length;
+  if (isProperSubset) {
+    const smallerSet = new Set(smaller);
+    const extraTokens = larger.filter(w => !smallerSet.has(w));
+    if (extraTokens.some(w => !BASELINE_TOKENS.has(w))) return false;
+  }
 
   // Use a true set-based Jaccard ratio. Dividing by the smaller title inflates
   // matches for roles that share a long generic prefix but differ in specialty.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4494,6 +4494,37 @@ try {
     fail('role matcher ignored a real short-acronym overlap');
   }
 
+  // A generic base title (no suffix of its own) shares every one of its tokens
+  // with a specialized sibling, so the shared tokens alone used to cross the
+  // Jaccard threshold — even though the sibling's extra word is exactly the
+  // signal that these are two different, separately-postable openings.
+  if (!roleFuzzyMatch('Senior Analytics Engineer', 'Senior Analytics Engineer, People Analytics')) {
+    pass('role matcher keeps a base title distinct from its specialized-suffix sibling (#1881)');
+  } else {
+    fail('role matcher collapsed a base title into its specialized-suffix sibling');
+  }
+
+  // A true repost of the same base title must still match.
+  if (roleFuzzyMatch('Senior Analytics Engineer', 'Senior Analytics Engineer')) {
+    pass('role matcher still matches an exact-title repost');
+  } else {
+    fail('role matcher rejected an exact-title repost');
+  }
+
+  // Seniority omitted on one side is not a specialization suffix — still a repost.
+  if (roleFuzzyMatch('Data Engineer', 'Senior Data Engineer')) {
+    pass('role matcher still matches when seniority is only stated on one side');
+  } else {
+    fail('role matcher rejected a repost that only adds a seniority word');
+  }
+
+  // A repost annotation is tracking metadata, not a specialization — must still match.
+  if (roleFuzzyMatch('Learning Development Designer III', 'Learning Development Designer III (Repost)')) {
+    pass('role matcher does not treat a "(Repost)" annotation as a specialization marker');
+  } else {
+    fail('role matcher wrongly treated a "(Repost)" annotation as a distinct sibling role');
+  }
+
   const dedupTmp = mkdtempSync(join(tmpdir(), 'career-ops-dedup-'));
   try {
     mkdirSync(join(dedupTmp, 'data'));


### PR DESCRIPTION
## What does this PR do?

Fixes #1881. `roleFuzzyMatch()` treated a generic base title with no suffix of its own as a duplicate of its specialized-suffix sibling at the same company — e.g. `"Senior Analytics Engineer"` vs `"Senior Analytics Engineer, People Analytics"` — because the base title's tokens are a full subset of the specialized title's, so the shared tokens alone crossed the 0.6 Jaccard threshold. `merge-tracker.mjs` then silently skipped or overwrote one of the two distinct tracker rows.

Same failure class as #1616 → #1622 (which fixed the seniority-token case, e.g. Senior vs Principal), different shape: this one has no seniority mismatch to fall back on, since the difference is a specialization word, not a level.

## Root cause / fix

When one title's token set is a strict subset of the other's, and the superset's extra tokens contain at least one non-baseline word, treat that word as a specialization marker and return `false` before the Jaccard check — mirroring how #1622's seniority gate already short-circuits on a mismatch.

One regression surfaced while verifying against the existing fixtures: test `#1524b` ("Learning Development Designer III" vs "...III (Repost)", same req number, expected to still dedupe) broke, because `"repost"` was picked up as a false specialization marker. Root-caused to tokenization, not the new subset check: a `(Repost)` annotation is tracking metadata, not part of the job itself, so `repost`/`reposted`/`relisted` now live in `ROLE_STOPWORDS` alongside the other non-identifying words already filtered there (`role`, `position`, `opportunity`, ...). That fixes it at the source for every caller of `roleTokens()`, not just this one check.

## Test plan

- [x] Verified against all pre-existing `role-matcher` fixtures used across `test-all.mjs` — sibling teams (#947), acronym siblings, the true short-acronym overlap case, the #1616/#1622 seniority case — all unchanged.
- [x] Added 4 new cases to the existing role-matcher test block: the #1881 base-vs-specialized-sibling case, an exact-title repost, a repost where seniority is only stated on one side, and the `(Repost)`-annotation case that the fix's first draft regressed.
- [x] `node test-all.mjs`: 1744 passed, 0 failed (1 pre-existing environment-only warning: dashboard build skipped, no Go compiler in this env — unrelated).

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Bug fix — no issue required (issue #1881 already exists with intent-to-PR declared)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` — 0 failed
- [x] My changes respect the Data Contract (only touches system-layer `role-matcher.mjs` / `test-all.mjs`, no user-layer files)
- [x] My changes align with the project roadmap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role-title matching to prevent distinct specialized roles from being incorrectly merged.
  * Reposted and relisted annotations are now ignored when comparing role titles.
  * Improved handling of seniority differences and reposted listings for more accurate deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->