### PR TITLE
Verify final PDF provenance before manifest publication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Personal data (user fills these)
 cv.md
+article-digest.md
 data/applications.md
 data/applications.db
 data/follow-ups.md

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -12,6 +12,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run dedup` | `dedup-tracker.mjs` | Remove duplicate tracker entries |
 | `npm run merge` | `merge-tracker.mjs` | Merge batch TSVs into applications.md |
 | `npm run pdf` | `generate-pdf.mjs` | Convert HTML to ATS-optimized PDF |
+| `npm run pdf:verify` | `verify-ats-pdf.mjs` | Verify final PDF provenance and text extraction before delivery |
 | `npm run img-to-pdf` | `img-to-pdf.mjs` | Convert a single screenshot/image into a single-page PDF |
 | `npm run build:latex` | `build-cv-latex.mjs` | Build .tex from structured JSON payload |
 | `npm run sync-check` | `cv-sync-check.mjs` | Validate CV/profile consistency |
@@ -122,7 +123,7 @@ node validate-portals.mjs --self-test
 
 ## pdf
 
-Renders an HTML file to a print-quality, ATS-parseable PDF via headless Chromium. Resolves font paths from `fonts/`, normalizes Unicode for ATS compatibility (em-dashes, smart quotes, zero-width characters), and reports page count and file size.
+Renders an HTML file to a print-quality, ATS-parseable PDF via headless Chromium. Resolves font paths from `fonts/`, normalizes Unicode for ATS compatibility (em-dashes, smart quotes, zero-width characters), and reports page count and file size. Before it records the manifest, it verifies that the exact output has direct Chromium provenance, embedded Unicode fonts, and selectable text.
 
 ```bash
 npm run pdf -- input.html output.pdf
@@ -131,6 +132,18 @@ npm run pdf -- input.html output.pdf --format=a4        # A4 (default)
 ```
 
 **Exit codes:** `0` PDF generated, `1` missing arguments or generation failure.
+
+### pdf:verify
+
+Verifies the final PDF that will actually be uploaded or delivered. It requires Poppler's `pdfinfo`, `pdffonts`, and `pdftotext`, and rejects files that have been rewritten after Career-Ops generated them (for example by Ghostscript or Preview), even if basic text extraction still succeeds.
+
+```bash
+npm run pdf:verify -- output/cv-jane-smith-acme-2026-07-14.pdf --require "Jane Smith" --require "Professional Summary"
+```
+
+Run this after the last copy/rename whenever the file leaves `output/`. No PDF post-processing is supported between a successful verification and upload.
+
+**Exit codes:** `0` verified direct Chromium PDF, `1` missing tools, a malformed/rewritten PDF, missing selectable text, or a required marker that did not extract.
 
 ---
 

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -6,6 +6,7 @@
  */
 
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { spawnSync } from 'node:child_process';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import yaml from 'js-yaml';
@@ -81,6 +82,23 @@ async function checkPlaywright() {
   } finally {
     try { await browser?.close(); } catch { /* ignore */ }
   }
+}
+
+// Career-Ops' PDF command runs verify-ats-pdf.mjs before publishing a manifest
+// entry. Check the Poppler utilities here so missing system packages fail during
+// setup rather than after a tailored CV has been rendered.
+function checkAtsPdfUtilities() {
+  const tools = ['pdfinfo', 'pdffonts', 'pdftotext'];
+  const missing = tools.filter((tool) => {
+    const result = spawnSync(tool, ['-v'], { stdio: 'ignore' });
+    return result.error || result.status !== 0;
+  });
+  if (!missing.length) return { pass: true, label: 'ATS PDF utilities installed (Poppler)' };
+  return {
+    pass: false,
+    label: `ATS PDF utilities missing: ${missing.join(', ')}`,
+    fix: 'Install Poppler utilities (Ubuntu/Debian: sudo apt install poppler-utils).',
+  };
 }
 
 // The browser tools (`browser_navigate` / `browser_snapshot`) that scan / pipeline /
@@ -329,6 +347,7 @@ async function main() {
     checkNodeVersion(),
     checkDependencies(),
     await checkPlaywright(),
+    checkAtsPdfUtilities(),
     checkPlaywrightMcp(projectRoot),
     checkScanExtractor(projectRoot),
     ...USER_LAYER_PREREQS.map(checkPrereq),

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -27,6 +27,7 @@ import { readFile } from 'fs/promises';
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { randomUUID } from 'node:crypto';
+import { verifyAtsPdf } from './verify-ats-pdf.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PDF_PAGE_MARGIN = '0.6in';
@@ -361,7 +362,31 @@ async function generatePDF() {
     console.log(`🧹 ATS normalization: ${totalReplacements} replacements (${breakdown})`);
   }
 
-  return renderHtmlToPdf(html, outputPath, { format, baseDir: dirname(inputPath), reportNum, inputPath });
+  // Verify the exact final artifact before it becomes the canonical manifest
+  // target. A later Ghostscript/Preview rewrite can leave pdftotext readable
+  // while breaking the file shape an ATS receives, so the supported path is
+  // direct Chromium render -> verifier -> manifest/delivery with no mutation.
+  const result = await renderHtmlToPdf(html, outputPath, {
+    format,
+    baseDir: dirname(inputPath),
+    reportNum,
+    inputPath,
+    recordManifest: false,
+  });
+  const verification = verifyAtsPdf(outputPath);
+  if (!verification.ok) {
+    throw new Error(`Generated PDF failed ATS verification:\n${verification.errors.map((error) => `- ${error}`).join('\n')}`);
+  }
+  console.log(`🛡️  ATS PDF verified: ${verification.details.extractedCharacters} extracted characters; direct Chromium provenance`);
+
+  try {
+    updatePDFManifest(reportNum, outputPath, inputPath, format);
+    console.log(`🔗 Manifest: data/pdf-index.tsv updated${reportNum ? ` (report ${reportNum})` : ' (no --report given)'}`);
+  } catch (err) {
+    // The verified PDF itself succeeded — never fail the run over bookkeeping.
+    console.error(`⚠️  Manifest update failed: ${err.message}`);
+  }
+  return result;
 }
 
 /**
@@ -422,6 +447,7 @@ export async function inlineLocalFonts(html) {
  *   baseDir?: string,
  *   reportNum?: string,
  *   inputPath?: string,
+ *   recordManifest?: boolean,
  *   launchBrowser?: (options: {headless: boolean}) => Promise<import('playwright').Browser>
  * }} [opts]
  * @returns {Promise<{outputPath: string, pageCount: number, size: number}>}
@@ -431,6 +457,7 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
   const baseDir = opts.baseDir || process.cwd();
   const reportNum = opts.reportNum || '';
   const inputPath = opts.inputPath || '';
+  const recordManifest = opts.recordManifest !== false;
 
   mkdirSync(dirname(outputPath), { recursive: true });
 
@@ -480,12 +507,14 @@ export async function renderHtmlToPdf(html, outputPath, opts = {}) {
     console.log(`📊 Pages: ${pageCount}`);
     console.log(`📦 Size: ${(pdfBuffer.length / 1024).toFixed(1)} KB`);
 
-    try {
-      updatePDFManifest(reportNum, outputPath, inputPath, format);
-      console.log(`🔗 Manifest: data/pdf-index.tsv updated${reportNum ? ` (report ${reportNum})` : ' (no --report given)'}`);
-    } catch (err) {
-      // The PDF itself succeeded — never fail the run over manifest bookkeeping.
-      console.error(`⚠️  Manifest update failed: ${err.message}`);
+    if (recordManifest) {
+      try {
+        updatePDFManifest(reportNum, outputPath, inputPath, format);
+        console.log(`🔗 Manifest: data/pdf-index.tsv updated${reportNum ? ` (report ${reportNum})` : ' (no --report given)'}`);
+      } catch (err) {
+        // The PDF itself succeeded — never fail the run over manifest bookkeeping.
+        console.error(`⚠️  Manifest update failed: ${err.message}`);
+      }
     }
 
     return { outputPath, pageCount, size: pdfBuffer.length };

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -27,8 +27,9 @@
 18. Run the fact gate: `node verify-cv-facts.mjs output/cv-{candidate}-{company}.html`
     - This is a hard gate before PDF rendering.
     - If it fails, stop and fix the generated HTML by removing invented metrics or adding verified evidence to `cv.md`, `article-digest.md`, or `config/cv-facts.json`.
-19. Execute: `node generate-pdf.mjs output/cv-{candidate}-{company}.html output/cv-{candidate}-{company}-{YYYY-MM-DD}.pdf --format={letter|a4} --report={report number}` — `{report number}` is the NNN from the report filename/link (e.g. `008` for `reports/008-acme-….md`), not the tracker `#` column. Pass it whenever the application has (or will have) a report; it records the PDF↔report linkage in `data/pdf-index.tsv` so the dashboard can open and regenerate the exact PDF. Omit it only for one-off CVs with no tracker entry.
-20. Report: PDF path, number of pages, keyword coverage %, and any skill gaps from Step 4 still unaddressed
+19. Execute: `node generate-pdf.mjs output/cv-{candidate}-{company}.html output/cv-{candidate}-{company}-{YYYY-MM-DD}.pdf --format={letter|a4} --report={report number}` — `{report number}` is the NNN from the report filename/link (e.g. `008` for `reports/008-acme-….md`), not the tracker `#` column. Pass it whenever the application has (or will have) a report; it records the PDF↔report linkage in `data/pdf-index.tsv` so the dashboard can open and regenerate the exact PDF. Omit it only for one-off CVs with no tracker entry. The command itself runs the final ATS verifier before recording the manifest.
+20. Treat that direct Chromium output as immutable. Do **not** run Ghostscript, Preview, qpdf, a metadata stamper, an optimizer, or any other PDF rewrite after `generate-pdf.mjs`. If a delivery workflow copies or renames it, run `node verify-ats-pdf.mjs {final-upload-file}.pdf --require "{candidate name}" --require "Professional Summary"` on the exact final file after the last copy. A different `Producer` is a hard stop, even when `pdftotext` appears to work.
+21. Report: PDF path, number of pages, keyword coverage %, the final verifier result, and any skill gaps from Step 4 still unaddressed
 
 ## ATS Rules (clean parsing)
 
@@ -37,6 +38,7 @@
 - No text in images/SVGs
 - No critical info in PDF headers/footers (ATS ignores them)
 - UTF-8, selectable text (not rasterized)
+- Final output must retain direct Chromium provenance (`pdfinfo` Producer starts with `Skia/PDF`), embedded Unicode-mapped fonts, and extractable body text. `generate-pdf.mjs` enforces this; `verify-ats-pdf.mjs` verifies a copied delivery artifact.
 - No nested tables
 - Distributed JD keywords: Summary (top 5), first bullet of each role, Skills section
 - No hidden text, keyword stuffing, or white-font tricks. Optimize for parseability plus human review.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "merge": "node merge-tracker.mjs",
     "reconcile": "node reconcile-pipeline.mjs",
     "pdf": "node generate-pdf.mjs",
+    "pdf:verify": "node verify-ats-pdf.mjs",
     "img-to-pdf": "node img-to-pdf.mjs",
     "cover-letter": "node generate-cover-letter.mjs --payload",
     "cv:verify-facts": "node verify-cv-facts.mjs",

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -823,6 +823,26 @@ if (!/waitUntil:\s*['"]networkidle['"]/.test(generatePdfScript)) {
   fail('generate-pdf still waits for networkidle');
 }
 
+const atsPdfVerifierScript = readFile('verify-ats-pdf.mjs');
+if (
+  atsPdfVerifierScript.includes("const REQUIRED_TOOLS = ['pdfinfo', 'pdffonts', 'pdftotext']") &&
+  atsPdfVerifierScript.includes("details.producer.startsWith('Skia/PDF')") &&
+  atsPdfVerifierScript.includes('PDF fonts must be embedded with Unicode mappings')
+) {
+  pass('ATS PDF verifier requires direct Chromium provenance and Unicode text fonts');
+} else {
+  fail('ATS PDF verifier is missing provenance or Unicode font checks');
+}
+if (
+  generatePdfScript.includes("import { verifyAtsPdf } from './verify-ats-pdf.mjs'") &&
+  generatePdfScript.includes('recordManifest: false') &&
+  generatePdfScript.includes('Generated PDF failed ATS verification')
+) {
+  pass('generate-pdf verifies the artifact before publishing its manifest entry');
+} else {
+  fail('generate-pdf does not enforce final ATS PDF verification before manifest publication');
+}
+
 function extractRenderHtmlToPdfOptions(source) {
   const call = /renderHtmlToPdf\s*\(\s*html\s*,\s*outputPath\s*,/g.exec(source);
   if (!call) return '';

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -124,6 +124,7 @@ const SYSTEM_PATHS = [
   'KIMI.md',
   'build-dashboard.mjs',
   'generate-pdf.mjs',
+  'verify-ats-pdf.mjs',
   'generate-latex.mjs',
   'extract-latex-content.mjs',
   'patch-latex-content.mjs',

--- a/verify-ats-pdf.mjs
+++ b/verify-ats-pdf.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+/**
+ * verify-ats-pdf.mjs — verify the final, uploadable PDF was produced directly
+ * by Career-Ops' Chromium renderer and retains selectable, Unicode text.
+ *
+ * Usage:
+ *   node verify-ats-pdf.mjs <resume.pdf> [--require "Jane Smith"] [--json]
+ *
+ * This intentionally verifies the exact file being handed to an applicant.
+ * It rejects PDFs rewritten by Ghostscript, Preview, or other post-processors:
+ * those tools can preserve text for pdftotext while changing the PDF structure
+ * that an ATS sees. The supported CV path is generate-pdf.mjs -> this checker
+ * -> delivery, with no PDF mutation between the last two steps.
+ *
+ * Requires Poppler utilities: pdfinfo, pdffonts, and pdftotext.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REQUIRED_TOOLS = ['pdfinfo', 'pdffonts', 'pdftotext'];
+const MIN_EXTRACTED_CHARACTERS = 250;
+
+function runTool(tool, args) {
+  try {
+    return { ok: true, output: execFileSync(tool, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }) };
+  } catch (error) {
+    const details = String(error?.stderr || error?.message || '').trim();
+    return { ok: false, error: `${tool}: ${details || 'command failed'}` };
+  }
+}
+
+function parsePdfInfo(raw) {
+  const values = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const match = /^([^:]+):\s*(.*)$/.exec(line);
+    if (match) values[match[1].trim()] = match[2].trim();
+  }
+  return values;
+}
+
+function parseFontRows(raw) {
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('name ') && !line.startsWith('---'))
+    .map((line) => {
+      const tail = /\s+(yes|no)\s+(yes|no)\s+(yes|no)\s+\d+\s+\d+\s*$/.exec(line);
+      return tail ? {
+        row: line,
+        embedded: tail[1] === 'yes',
+        subset: tail[2] === 'yes',
+        unicode: tail[3] === 'yes',
+      } : { row: line, embedded: false, subset: false, unicode: false };
+    });
+}
+
+/**
+ * Inspect an already rendered Career-Ops CV.
+ *
+ * @param {string} inputPath absolute or relative PDF path
+ * @param {{required?: string[]}} [opts]
+ * @returns {{ok: boolean, errors: string[], warnings: string[], details: object}}
+ */
+export function verifyAtsPdf(inputPath, opts = {}) {
+  const required = (opts.required || []).filter(Boolean);
+  const outputPath = resolve(inputPath || '');
+  const errors = [];
+  const warnings = [];
+  const details = { path: outputPath, required, tools: {}, fonts: [], extractedCharacters: 0 };
+
+  if (!inputPath || !existsSync(outputPath)) {
+    return { ok: false, errors: [`PDF not found: ${outputPath}`], warnings, details };
+  }
+  if (!statSync(outputPath).isFile()) {
+    return { ok: false, errors: [`Not a regular file: ${outputPath}`], warnings, details };
+  }
+
+  for (const tool of REQUIRED_TOOLS) {
+    const check = runTool(tool, ['-v']);
+    details.tools[tool] = check.ok;
+    if (!check.ok) errors.push(`Required Poppler utility is unavailable: ${tool}`);
+  }
+  if (errors.length) return { ok: false, errors, warnings, details };
+
+  const infoResult = runTool('pdfinfo', [outputPath]);
+  if (!infoResult.ok) {
+    errors.push(infoResult.error);
+    return { ok: false, errors, warnings, details };
+  }
+  const info = parsePdfInfo(infoResult.output);
+  details.producer = info.Producer || '';
+  details.pages = Number(info.Pages || 0);
+  details.encrypted = info.Encrypted || '';
+
+  if (details.pages < 1) errors.push('PDF has no readable pages.');
+  if (!/^no\b/i.test(details.encrypted)) errors.push(`PDF must not be encrypted (pdfinfo: ${details.encrypted || 'missing'}).`);
+  if (!details.producer.startsWith('Skia/PDF')) {
+    errors.push(`PDF provenance failed: expected direct Chromium output (Producer: Skia/PDF), found "${details.producer || 'missing'}".`);
+  }
+
+  const fontsResult = runTool('pdffonts', [outputPath]);
+  if (!fontsResult.ok) {
+    errors.push(fontsResult.error);
+  } else {
+    details.fonts = parseFontRows(fontsResult.output);
+    if (!details.fonts.length) {
+      errors.push('PDF exposes no embedded text fonts.');
+    } else {
+      const badFonts = details.fonts.filter((font) => !font.embedded || !font.unicode);
+      if (badFonts.length) {
+        errors.push(`PDF fonts must be embedded with Unicode mappings: ${badFonts.map((font) => font.row).join(' | ')}`);
+      }
+    }
+  }
+
+  const textResult = runTool('pdftotext', ['-enc', 'UTF-8', outputPath, '-']);
+  if (!textResult.ok) {
+    errors.push(textResult.error);
+  } else {
+    details.extractedCharacters = textResult.output.replace(/\s/g, '').length;
+    if (details.extractedCharacters < MIN_EXTRACTED_CHARACTERS) {
+      errors.push(`PDF text extraction is too short (${details.extractedCharacters} non-whitespace characters; need at least ${MIN_EXTRACTED_CHARACTERS}).`);
+    }
+    for (const marker of required) {
+      if (!textResult.output.toLocaleLowerCase().includes(marker.toLocaleLowerCase())) {
+        errors.push(`Required ATS marker is missing from extracted text: ${marker}`);
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors, warnings, details };
+}
+
+function usage() {
+  console.error('Usage: node verify-ats-pdf.mjs <resume.pdf> [--require "text marker"] [--json]');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const required = [];
+  let inputPath = '';
+  let json = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') json = true;
+    else if (arg === '--require') required.push(args[++index] || '');
+    else if (arg.startsWith('--require=')) required.push(arg.slice('--require='.length));
+    else if (!inputPath) inputPath = arg;
+    else {
+      usage();
+      process.exit(1);
+    }
+  }
+
+  if (!inputPath) {
+    usage();
+    process.exit(1);
+  }
+
+  const result = verifyAtsPdf(inputPath, { required });
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.ok) {
+    console.log(`✓ ATS PDF verified: ${result.details.path}`);
+    console.log(`  ${result.details.pages} page(s), ${result.details.extractedCharacters} extracted characters, Producer: ${result.details.producer}`);
+  } else {
+    console.error(`✗ ATS PDF verification failed: ${result.details.path}`);
+    for (const error of result.errors) console.error(`  - ${error}`);
+  }
+  process.exit(result.ok ? 0 : 1);
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (isMain) main();


### PR DESCRIPTION
## Summary

- add a local Poppler-based verifier for PDF provenance, embedded Unicode fonts, encryption state, text extraction, and required markers
- verify the exact Chromium artifact before recording it in the PDF manifest
- expose the verifier through npm, document immutable delivery handling, and check required utilities during doctor runs
- ignore article-digest.md consistently with its user-layer data contract

## Why

A PDF can remain superficially readable after a post-processing rewrite while no longer matching the artifact Career-Ops originally rendered. The manifest should only point at an artifact that has passed final verification, and copied delivery files need a repeatable check.

## Validation

- node test-all.mjs: 1,743 passed, 0 failed; dashboard build skipped because Go is unavailable in the environment
- verifier passed against an existing two-page direct Chromium PDF with embedded Unicode fonts and selectable text
- git diff --check passed
- staged diff checked for personal names, application companies, job IDs, local paths, and user-tools references

Closes #1926.