### PR TITLE
feat(liveness): add Workday to the zero-token ATS liveness API rung

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -322,7 +322,9 @@ npm run rollback
 
 ## liveness
 
-Tests whether job posting URLs are still live using headless Chromium. Detects expired patterns (e.g. "job no longer available"), HTTP 404/410, ATS redirect patterns, and apply-button presence. Supports multi-language expired patterns (English, German, French).
+Tests whether job posting URLs are still live. Two rungs: a zero-token ATS API check first (`liveness-api.mjs` — Greenhouse, Lever, Ashby, Workday), falling back to headless Chromium (`liveness-browser.mjs`) for non-ATS pages or when the API is inconclusive. The browser rung detects expired patterns (e.g. "job no longer available"), HTTP 404/410, ATS redirect patterns, and apply-button presence, and supports multi-language expired patterns (English, German, French).
+
+Per-job ATS endpoints (Greenhouse, Lever, Workday) treat a 200 as proof the posting is live; Ashby's public API is org-level (the whole job board), so that rung parses the board and confirms the specific job id is still listed. A definitive 404/410 from any ATS API is authoritative and short-circuits the browser check entirely — zero tokens, no browser launch.
 
 ```bash
 npm run liveness -- https://example.com/job/123

--- a/liveness-api.mjs
+++ b/liveness-api.mjs
@@ -2,10 +2,10 @@
 /**
  * liveness-api.mjs — zero-token liveness check for ATS-hosted job postings.
  *
- * Many postings live on ATS platforms (Greenhouse, Lever, Ashby, ...) that expose
- * a public JSON endpoint. We can confirm whether a posting is still live by hitting
- * that endpoint directly — no browser, no LLM tokens — and only fall back to the
- * Playwright check (liveness-browser.mjs) for non-ATS pages or when the API is
+ * Many postings live on ATS platforms (Greenhouse, Lever, Ashby, Workday, ...) that
+ * expose a public JSON endpoint. We can confirm whether a posting is still live by
+ * hitting that endpoint directly — no browser, no LLM tokens — and only fall back to
+ * the Playwright check (liveness-browser.mjs) for non-ATS pages or when the API is
  * inconclusive. This is the cheap first rung of the liveness ladder.
  *
  * CONSERVATIVE BY DESIGN: a false "expired" is worse than the status quo (the user
@@ -14,8 +14,8 @@
  * `null` (→ caller falls back to Playwright).
  *
  * Two endpoint shapes:
- *   - Per-job (Greenhouse, Lever): the URL maps to a single-job endpoint, so a 200
- *     is itself proof the posting is live.
+ *   - Per-job (Greenhouse, Lever, Workday): the URL maps to a single-job endpoint,
+ *     so a 200 is itself proof the posting is live.
  *   - Org-level (Ashby): the URL maps to the org's whole job board. A 200 only
  *     proves the board exists, so the provider's `interpret` step parses the board
  *     and confirms THIS posting is still listed before returning active/expired.
@@ -31,6 +31,22 @@ const TIMEOUT_MS = 8_000;
 // Strict path-segment charset. Anything with a slash, dot-dot, or other char is
 // rejected before it can reach the fixed-host API URL template.
 const SAFE_SEGMENT = /^[A-Za-z0-9._-]+$/;
+
+// Most providers extract single path segments (SAFE_SEGMENT covers those directly).
+// Workday's job path is genuinely multi-segment (a location slug + a title slug,
+// e.g. "Toronto-ON-CAN/Agentic-AI-Engineer_R260010125"), so a `parts` value may
+// itself contain slashes. This still validates every individual segment against
+// the same strict charset (and rejects ".." in any of them) — it only relaxes
+// "no slash at all" to "no *unsafe* content between slashes", so the traversal/
+// injection guarantee is unchanged.
+function isSafeValue(v) {
+  if (typeof v !== 'string' || v.length === 0) return false;
+  // SAFE_SEGMENT's charset includes "." (some real segments use dots), so ".."
+  // alone passes that regex — same as the single-segment guard in
+  // resolveAtsApi below, the explicit `!includes('..')` check per segment is
+  // load-bearing, not redundant with the regex test.
+  return v.split('/').every((seg) => seg.length > 0 && SAFE_SEGMENT.test(seg) && !seg.includes('..'));
+}
 
 // Each ATS: detect its posting URL, then map to a public JSON API URL.
 // `match` returns the extracted path params (or null); `api` builds the FIXED-host URL.
@@ -87,6 +103,32 @@ const ATS_PROVIDERS = [
       return classifyAshbyBoard(json, jobId);
     },
   },
+  {
+    id: 'workday',
+    // {tenant}.{shard}.myworkdayjobs.com[/{xx-XX}]/{site}/job/{jobPath...}
+    // Mirrors the tenant/shard/site detection in providers/workday.mjs, but for a
+    // single posting rather than the board-wide CXS search endpoint. Workday's
+    // per-job CXS endpoint (`/wday/cxs/{tenant}/{site}/job/{jobPath}`) is a
+    // genuinely PER-JOB API like Greenhouse/Lever — a 200 is itself proof the
+    // posting is live, confirmed against real tenants (BMO, TD, Manulife, CIBC):
+    // an existing posting returns 200, a garbage job id returns 404.
+    //
+    // jobPath is intentionally multi-segment (Workday encodes a location slug and
+    // a title slug as separate path parts, e.g.
+    // "Toronto-ON-CAN/Agentic-AI-Engineer_R260010125") — isSafeValue (not the
+    // single-segment SAFE_SEGMENT check other providers use directly) validates
+    // it component-by-component.
+    match(u) {
+      const m = `${u.hostname}${u.pathname}`.match(
+        /^([\w-]+)\.(wd[\w-]*)\.myworkdayjobs\.com\/(?:[a-z]{2}-[A-Z]{2}\/)?([^/?#]+)\/job\/(.+?)\/?$/
+      );
+      if (!m) return null;
+      const [, tenant, shard, site, jobPath] = m;
+      return { tenant, shard, site, jobPath };
+    },
+    api: ({ tenant, shard, site, jobPath }) =>
+      `https://${tenant}.${shard}.myworkdayjobs.com/wday/cxs/${tenant}/${site}/job/${jobPath}`,
+  },
 ];
 
 /**
@@ -130,8 +172,10 @@ export function resolveAtsApi(rawUrl) {
   for (const provider of ATS_PROVIDERS) {
     const parts = provider.match(u);
     if (!parts) continue;
-    // SSRF guard: every derived segment must be a single safe path segment.
-    if (!Object.values(parts).every((v) => SAFE_SEGMENT.test(v) && !v.includes('..'))) return null;
+    // SSRF guard: every derived value must be safe — a single path segment for
+    // most providers, or (Workday) a slash-separated sequence of safe segments.
+    // isSafeValue enforces the same charset + no-".." rule either way.
+    if (!Object.values(parts).every(isSafeValue)) return null;
     return { ats: provider.id, apiUrl: provider.api(parts), parts, timeoutMs: provider.timeoutMs, interpret: provider.interpret };
   }
   return null;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -378,6 +378,39 @@ try {
   } else {
     fail('resolveAtsApi guard failed (bad id or http accepted)');
   }
+  // Workday: per-job CXS endpoint. Job path is genuinely multi-segment (a location
+  // slug + a title slug), which is why resolveAtsApi's SSRF guard uses isSafeValue
+  // (component-by-component) instead of the single-segment SAFE_SEGMENT check.
+  const wdApi = resolveAtsApi('https://acme.wd1.myworkdayjobs.com/en-US/External/job/Toronto-ON-CAN/Agentic-AI-Engineer_R260010125');
+  if (wdApi?.ats === 'workday'
+      && wdApi.apiUrl === 'https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/External/job/Toronto-ON-CAN/Agentic-AI-Engineer_R260010125'
+      && wdApi.parts?.jobPath === 'Toronto-ON-CAN/Agentic-AI-Engineer_R260010125') {
+    pass('resolveAtsApi maps a Workday posting (with locale prefix) to its per-job CXS API URL');
+  } else {
+    fail(`Workday API URL wrong: ${JSON.stringify(wdApi)}`);
+  }
+  // Same tenant, no locale prefix in the URL.
+  const wdApiNoLocale = resolveAtsApi('https://acme.wd5.myworkdayjobs.com/External/job/Toronto-ON-CAN/Agentic-AI-Engineer_R260010125');
+  if (wdApiNoLocale?.ats === 'workday'
+      && wdApiNoLocale.apiUrl === 'https://acme.wd5.myworkdayjobs.com/wday/cxs/acme/External/job/Toronto-ON-CAN/Agentic-AI-Engineer_R260010125') {
+    pass('resolveAtsApi maps a Workday posting without a locale prefix');
+  } else {
+    fail(`Workday (no locale) API URL wrong: ${JSON.stringify(wdApiNoLocale)}`);
+  }
+  // Directory traversal embedded inside one segment (not a bare ".." dot-segment,
+  // which the URL parser itself would normalize away before we ever see it) must
+  // still be rejected by isSafeValue's per-segment "..": ownership check.
+  if (resolveAtsApi('https://acme.wd1.myworkdayjobs.com/External/job/Toronto-ON-CAN/Role..R1') === null) {
+    pass('resolveAtsApi rejects ".." embedded in a Workday jobPath segment (SSRF guard)');
+  } else {
+    fail('resolveAtsApi should reject ".." embedded in a Workday jobPath segment');
+  }
+  if (resolveAtsApi('https://acme.notworkdayjobs.com/External/job/Toronto-ON-CAN/Role_R1') === null) {
+    pass('resolveAtsApi returns null for a myworkdayjobs.com lookalike host');
+  } else {
+    fail('resolveAtsApi should not match a lookalike Workday host');
+  }
+
   // Ashby: org-level board endpoint. Ashby pages are JS-rendered, so the browser/
   // static rung sees only nav/footer and false-reports live postings as expired —
   // the API rung must resolve the org board and confirm the specific job id.
@@ -438,15 +471,22 @@ try {
     const cvGone = await checkLivenessViaApi('https://boards.greenhouse.io/acme/jobs/4567890');
     globalThis.fetch = async () => { throw new Error('network down'); };
     const cvErr = await checkLivenessViaApi('https://boards.greenhouse.io/acme/jobs/4567890');
+    const wdUrl = 'https://acme.wd1.myworkdayjobs.com/External/job/Toronto-ON-CAN/Agentic-AI-Engineer_R260010125';
+    globalThis.fetch = async () => ({ status: 200 });
+    const cvWdLive = await checkLivenessViaApi(wdUrl);
+    globalThis.fetch = async () => ({ status: 404 });
+    const cvWdGone = await checkLivenessViaApi(wdUrl);
     if (cvAshbyLive?.result === 'active' && cvAshbyLive?.code === 'ashby_api_ok'
         && cvAshbyGone?.result === 'expired' && cvAshbyGone?.code === 'ashby_api_unlisted'
         && cvAshbyMalformed === null
         && cvGhLive?.result === 'active'
         && cvGone?.result === 'expired'
-        && cvErr === null) {
-      pass('checkLivenessViaApi: 200→interpret (Ashby), malformed→null, greenhouse 200→active, 404→expired, fetch error→null');
+        && cvErr === null
+        && cvWdLive?.result === 'active' && cvWdLive?.code === 'workday_api_ok'
+        && cvWdGone?.result === 'expired' && cvWdGone?.code === 'workday_api_gone') {
+      pass('checkLivenessViaApi: 200→interpret (Ashby), malformed→null, greenhouse/workday 200→active, 404→expired, fetch error→null');
     } else {
-      fail(`checkLivenessViaApi wrong: ashbyLive=${JSON.stringify(cvAshbyLive)} ashbyGone=${JSON.stringify(cvAshbyGone)} malformed=${JSON.stringify(cvAshbyMalformed)} ghLive=${JSON.stringify(cvGhLive)} gone=${JSON.stringify(cvGone)} err=${JSON.stringify(cvErr)}`);
+      fail(`checkLivenessViaApi wrong: ashbyLive=${JSON.stringify(cvAshbyLive)} ashbyGone=${JSON.stringify(cvAshbyGone)} malformed=${JSON.stringify(cvAshbyMalformed)} ghLive=${JSON.stringify(cvGhLive)} gone=${JSON.stringify(cvGone)} err=${JSON.stringify(cvErr)} wdLive=${JSON.stringify(cvWdLive)} wdGone=${JSON.stringify(cvWdGone)}`);
     }
   } finally {
     globalThis.fetch = origFetch;


### PR DESCRIPTION
## What does this PR do?

Adds Workday to the zero-token ATS liveness rung (`liveness-api.mjs`) so `check-liveness.mjs` can confirm Workday postings are live/expired via a direct API hit — no Playwright launch needed.

Workday's per-job CXS endpoint (`/wday/cxs/{tenant}/{site}/job/{jobPath}`) is a genuine per-job API like Greenhouse/Lever — a 200 is proof the posting is live, a 404 means it's gone. Verified against real tenants (BMO, TD, Manulife, CIBC) before implementing.

Workday's `jobPath` is multi-segment (location slug + title slug), so the existing single-segment `SAFE_SEGMENT` guard in `resolveAtsApi` couldn't be used directly. Added `isSafeValue()`, which validates a slash-separated value segment-by-segment against the same charset and `".."` exclusion, and switched `resolveAtsApi`'s guard to use it for all providers (behavior for existing single-segment providers is unchanged).

`check-liveness.mjs` now resolves Workday postings via this rung with zero browser launches, only falling back to Playwright when the API is inconclusive.

## Related issue

None — this mirrors the existing `ATS_PROVIDERS` pattern (Greenhouse/Lever/Ashby) one-for-one and adds support for an ATS (`providers/workday.mjs`) already integrated elsewhere in the project, rather than introducing new architecture. Happy to open a discussion first if a maintainer prefers that for this size of change.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added liveness verification support for Workday job postings.
  * Workday checks now use per-job API endpoints when available, with browser verification as a fallback.
  * Improved detection of expired postings across HTTP responses, redirects, apply-button states, and English, German, and French patterns.

* **Documentation**
  * Updated liveness script documentation to explain the API-first verification flow and outcome semantics.

* **Bug Fixes**
  * Strengthened URL validation while supporting legitimate multi-segment Workday job paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->