### PR TITLE
feat(providers): Oracle Recruiting Cloud (ORC) zero-auth provider

### DIFF
--- a/providers/oraclecloud.mjs
+++ b/providers/oraclecloud.mjs
@@ -1,0 +1,297 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// Oracle Recruiting Cloud (ORC) / Fusion Candidate Experience provider — hits
+// the public recruitingCEJobRequisitions REST API (zero-auth, GET). Large
+// employers (JPMorgan Chase, Oracle, BNY Mellon, American Express, Honeywell, …)
+// run their careers site on ORC.
+//
+// Host patterns (per-tenant, dynamic):
+//   <tenant>.fa.oraclecloud.com
+//   <tenant>.fa.<region>.oraclecloud.com   (e.g. us2)
+//   <tenant>.fa.ocs.oraclecloud.com
+//
+// Career page URL:
+//   https://<host>/hcmUI/CandidateExperience/<lang>/sites/<siteNumber>/jobs
+//   siteNumber is the segment after `sites/` (usually CX_1, CX_1002, …; default CX_1).
+//
+// JSON API (GET, zero-auth, no token/cookie):
+//   https://<host>/hcmRestApi/resources/latest/recruitingCEJobRequisitions
+//   ?onlyData=true
+//   &expand=requisitionList.workLocation,requisitionList.secondaryLocations
+//   &finder=findReqs;siteNumber=<site>,facetsList=...,limit=<n>,sortBy=POSTING_DATES_DESC,offset=<n>
+//   &limit=<n>&offset=<n>   (set in BOTH finder and top-level — some tenants only honor one)
+//   Optional: locationId=<numericId> (some tenants, e.g. BNY/Amex, need it to scope results).
+//   The `expand` is REQUIRED: without it the API returns TotalJobsCount but an
+//   empty/absent requisitionList (verified live against JPMC).
+//   Response: items[0].requisitionList[] (jobs), items[0].TotalJobsCount (total),
+//   top-level hasMore. Per item: Id, Title, PostedDate, PrimaryLocation,
+//   WorkplaceTypeCode, ShortDescriptionStr, and (sometimes) ExternalURL.
+//
+// Known limitation: some tenants front the API with a WAF (e.g. Imperva) that
+// 403s datacenter/cloud egress IPs. That's an environment/IP issue, not a
+// provider bug — the same request succeeds from a residential IP. A browser-like
+// User-Agent is sent to reduce (not eliminate) WAF friction.
+
+import { decodeEntities } from './_html-entities.mjs';
+
+const ORACLE_HOST_RE = /^[a-z0-9-]+\.fa\.(?:[a-z0-9-]+\.)?(?:ocs\.)?oraclecloud\.com$/i;
+
+const PAGE_SIZE = 200;
+const MAX_PAGES = 25;             // safety cap (~5000 jobs); hard ceiling like workday
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 500;
+const RETRY_MAX_DELAY_MS = 8_000;
+const INTER_PAGE_DELAY_MS = 150;  // WAF-aware spacing between same-host pages
+
+// Browser-like UA reduces WAF friction; ORC's requisitions API needs no auth.
+const BROWSER_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36';
+
+// facetsList is a fixed constant on the finder; %3B is the encoded ';' separator.
+const FACETS_LIST = 'LOCATIONS%3BWORK_LOCATIONS%3BWORKPLACE_TYPES%3BTITLES%3BCATEGORIES%3BORGANIZATIONS%3BPOSTING_DATES%3BFLEX_FIELDS';
+
+/** @param {string} url */
+function assertOracleUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`oraclecloud: invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`oraclecloud: URL must use HTTPS: ${url}`);
+  if (!ORACLE_HOST_RE.test(parsed.hostname)) {
+    throw new Error(`oraclecloud: untrusted hostname "${parsed.hostname}" — must match *.fa[.<region>][.ocs].oraclecloud.com`);
+  }
+  return url;
+}
+
+// NaN-safe Date.parse — `|| undefined` would also coerce a valid epoch 0.
+// (copied from greenhouse.mjs)
+function toEpochMs(value) {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function sleep(ms, ctx) {
+  if (typeof ctx?.sleep === 'function') return ctx.sleep(ms);
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Parses a `Retry-After` header value (seconds, or an HTTP-date) to ms, or null. */
+function parseRetryAfterMs(value) {
+  if (!value) return null;
+  const secs = Number(value);
+  if (Number.isFinite(secs) && secs >= 0) return secs * 1000;
+  const dateMs = Date.parse(value);
+  return Number.isFinite(dateMs) ? Math.max(0, dateMs - Date.now()) : null;
+}
+
+function isRetryableError(err) {
+  const status = err?.status;
+  if (status === 429) return true;
+  if (typeof status === 'number' && status >= 500) return true;
+  return status === undefined; // network error / timeout / abort — no status set
+}
+
+/** Fetches a single page, retrying transient failures with backoff + jitter. */
+async function fetchPageWithRetry(ctx, api, opts) {
+  let lastErr;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return await ctx.fetchJson(api, opts);
+    } catch (err) {
+      lastErr = err;
+      if (attempt === MAX_RETRIES || !isRetryableError(err)) throw err;
+      const backoff = Math.min(RETRY_BASE_DELAY_MS * 2 ** attempt, RETRY_MAX_DELAY_MS);
+      const retryAfterMs = parseRetryAfterMs(err?.retryAfter);
+      const delayMs = retryAfterMs !== null ? Math.min(retryAfterMs, RETRY_MAX_DELAY_MS * 4) : (backoff + Math.random() * 250);
+      await sleep(delayMs, ctx);
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Resolve ORC coordinates from a portal entry. `entry.api` takes precedence
+ * over `entry.careers_url` (mirrors greenhouse/ashby/smartrecruiters) so a
+ * branded careers page can stay as careers_url while the ORC host/site is
+ * pinned via api:. Honors optional `entry.siteNumber` / `entry.locationId`.
+ *
+ * @param {import('./_types.js').PortalEntry & {siteNumber?:string, locationId?:string|number}} entry
+ * @returns {{host:string, lang:string, siteNumber:string, locationId:(string|null)}|null}
+ */
+export function resolveSite(entry) {
+  for (const raw of [entry.api, entry.careers_url]) {
+    if (typeof raw !== 'string' || !raw) continue;
+    let parsed;
+    try {
+      parsed = new URL(raw);
+    } catch {
+      continue;
+    }
+    if (parsed.protocol !== 'https:') continue;
+    if (!ORACLE_HOST_RE.test(parsed.hostname)) continue;
+
+    const segs = parsed.pathname.split('/').filter(Boolean);
+    // Path shape: /hcmUI/CandidateExperience/<lang>/sites/<siteNumber>/...
+    const ceIdx = segs.findIndex((s) => s === 'CandidateExperience');
+    const lang = ceIdx !== -1 && segs[ceIdx + 1] ? segs[ceIdx + 1] : 'en';
+    const sitesIdx = segs.indexOf('sites');
+    const siteFromUrl = sitesIdx !== -1 && segs[sitesIdx + 1] ? segs[sitesIdx + 1] : null;
+
+    const overrideSite = typeof entry.siteNumber === 'string' && entry.siteNumber ? entry.siteNumber : null;
+    const siteNumber = overrideSite || siteFromUrl || 'CX_1';
+    const locationId = entry.locationId != null && `${entry.locationId}` !== ''
+      ? `${entry.locationId}`
+      : null;
+
+    return { host: parsed.hostname, lang, siteNumber, locationId };
+  }
+  return null;
+}
+
+/**
+ * Build the requisitions API URL. Params are set in BOTH the finder segment
+ * and top-level (some tenants only honor one). facetsList uses %3B-encoded ';'.
+ *
+ * @param {{host:string, siteNumber:string, locationId?:(string|null)}} site
+ * @param {number} offset
+ * @param {number} limit
+ */
+export function buildApiUrl(site, offset = 0, limit = PAGE_SIZE) {
+  // Finder grammar: `findReqs;key=val,key=val,...` — a ';' after the finder
+  // name, then comma-separated key/value pairs. (A comma after findReqs 400s.)
+  const finderParams = [
+    `siteNumber=${site.siteNumber}`,
+    `facetsList=${FACETS_LIST}`,
+    `limit=${limit}`,
+    'sortBy=POSTING_DATES_DESC',
+    `offset=${offset}`,
+  ];
+  if (site.locationId) finderParams.push(`locationId=${site.locationId}`);
+  const finder = `findReqs;${finderParams.join(',')}`;
+  const expand = 'requisitionList.workLocation,requisitionList.secondaryLocations';
+  return `https://${site.host}/hcmRestApi/resources/latest/recruitingCEJobRequisitions`
+    + `?onlyData=true`
+    + `&expand=${encodeURIComponent(expand)}`
+    + `&finder=${finder}`
+    + `&limit=${limit}&offset=${offset}`;
+}
+
+/**
+ * Build the public posting URL for a requisition Id.
+ * @param {{host:string, lang:string, siteNumber:string}} site
+ * @param {string} id
+ */
+export function buildJobUrl(site, id) {
+  return `https://${site.host}/hcmUI/CandidateExperience/${site.lang}/sites/${site.siteNumber}/job/${id}`;
+}
+
+/**
+ * Assemble a location string for a requisition. Prefers PrimaryLocation; else
+ * builds from the expanded workLocation object; appends a remote/hybrid hint
+ * from WorkplaceTypeCode. Returns "" when nothing is available.
+ * @param {any} req
+ */
+function assembleLocation(req) {
+  let base = typeof req.PrimaryLocation === 'string' ? req.PrimaryLocation.trim() : '';
+  if (!base && Array.isArray(req.workLocation) && req.workLocation.length) {
+    const wl = req.workLocation[0] || {};
+    base = [wl.TownOrCity, wl.Region, wl.Country].filter((v) => typeof v === 'string' && v.trim()).join(', ');
+  }
+  const wt = req.WorkplaceTypeCode;
+  const remoteHint = wt === 'ORA_REMOTE' ? 'Remote' : wt === 'ORA_HYBRID' ? 'Hybrid' : '';
+  return [base, remoteHint].filter(Boolean).join(' · ');
+}
+
+/**
+ * Pure normalizer for an ORC requisitions response. Exported for unit tests.
+ * Reads items[0].requisitionList[], maps each to the Job shape, drops rows with
+ * no resolvable URL. Returns [] for null / {} / non-array / {items:null}.
+ *
+ * @param {any} json
+ * @param {{host:string, lang:string, siteNumber:string}} site
+ * @param {string} companyName
+ * @returns {Array<{title:string, url:string, company:string, location:string, description?:string, postedAt?:number}>}
+ */
+export function parseOracleResponse(json, site, companyName) {
+  const item = Array.isArray(json?.items) ? json.items[0] : null;
+  const list = item && Array.isArray(item.requisitionList) ? item.requisitionList : null;
+  if (!list) return [];
+  const out = [];
+  for (const req of list) {
+    if (!req || typeof req !== 'object') continue;
+    const id = req.Id != null ? String(req.Id) : (req.RequisitionNumber != null ? String(req.RequisitionNumber) : '');
+    const externalUrl = typeof req.ExternalURL === 'string' && req.ExternalURL.trim() ? req.ExternalURL.trim() : '';
+    const url = externalUrl || (id ? buildJobUrl(site, id) : '');
+    if (!url) continue; // dedup key — drop rows we can't link to
+    const job = {
+      title: typeof req.Title === 'string' ? req.Title : '',
+      url,
+      company: companyName,
+      location: assembleLocation(req),
+    };
+    if (typeof req.ShortDescriptionStr === 'string' && req.ShortDescriptionStr.trim()) {
+      job.description = decodeEntities(req.ShortDescriptionStr);
+    }
+    const postedAt = toEpochMs(req.PostedDate);
+    if (postedAt !== undefined) job.postedAt = postedAt;
+    out.push(job);
+  }
+  return out;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'oraclecloud',
+
+  detect(entry) {
+    try {
+      const site = resolveSite(entry);
+      return site ? { url: buildApiUrl(site, 0, PAGE_SIZE) } : null;
+    } catch {
+      return null;
+    }
+  },
+
+  async fetch(entry, ctx) {
+    const site = resolveSite(entry);
+    if (!site) throw new Error(`oraclecloud: cannot derive API URL for ${entry.name}`);
+
+    const maxPages = Number.isInteger(entry.max_pages) && entry.max_pages > 0
+      ? Math.min(entry.max_pages, MAX_PAGES)
+      : MAX_PAGES;
+
+    const all = [];
+    let total = null;
+    for (let page = 0; page < maxPages; page++) {
+      const offset = page * PAGE_SIZE;
+      const apiUrl = buildApiUrl(site, offset, PAGE_SIZE);
+      assertOracleUrl(apiUrl); // SSRF guard before every fetch
+      if (page > 0) await sleep(INTER_PAGE_DELAY_MS, ctx);
+
+      const json = await fetchPageWithRetry(ctx, apiUrl, {
+        redirect: 'error',
+        headers: { 'User-Agent': BROWSER_UA, Accept: 'application/json' },
+      });
+
+      const parsed = parseOracleResponse(json, site, entry.name);
+      all.push(...parsed);
+
+      const item = Array.isArray(json?.items) ? json.items[0] : null;
+      if (total === null && item && typeof item.TotalJobsCount === 'number') total = item.TotalJobsCount;
+      const listLen = item && Array.isArray(item.requisitionList) ? item.requisitionList.length : 0;
+
+      // Stop conditions. NOTE: `hasMore` is unreliable on some tenants (e.g.
+      // JPMC returns hasMore:false on EVERY page even with 7000+ jobs), so it's
+      // NOT used to stop — trusting it caps the scan at one page. The
+      // authoritative signals are the returned list length and TotalJobsCount:
+      //   - an empty or short page means we've reached the end;
+      //   - once we've paged past TotalJobsCount there's nothing left to fetch.
+      if (listLen === 0 || listLen < PAGE_SIZE) break;
+      if (total !== null && offset + PAGE_SIZE >= total) break;
+    }
+    return all;
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -525,6 +525,9 @@ search_queries:
 #   amazon          amazon.jobs           (global board; provider: amazon + an amazon: filter block, see below)
 #   successfactors  *.successfactors.(eu|com) / *.jobs2web.com  (SAP SF Recruiting Marketing / RMK boards;
 #                   branded hosts like jobs.<company>.com need provider: successfactors + api: <board origin>)
+#   oraclecloud     <tenant>.fa[.<region>][.ocs].oraclecloud.com/hcmUI/CandidateExperience/.../sites/<siteNumber>/jobs
+#                   (Oracle Recruiting Cloud / Fusion CX — JPMorgan, Oracle, BNY, Amex, Honeywell; siteNumber
+#                   auto-derived from the URL, override with provider: oraclecloud + siteNumber: / optional locationId:)
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
@@ -585,6 +588,24 @@ search_queries:
 #   max_pages: 100         # optional page cap (20 jobs/page, default 100, max 1500) —
 #                          # raise it for a tenant with 2000+ open postings (a warning
 #                          # is logged if the cap truncates real results)
+#   enabled: true
+#
+# - name: Example Oracle Recruiting Cloud Co
+#   # Oracle Recruiting Cloud / Fusion Candidate Experience. Auto-detects any
+#   # <tenant>.fa[.<region>][.ocs].oraclecloud.com host and derives siteNumber
+#   # from the /sites/<siteNumber>/ path segment (default CX_1).
+#   careers_url: https://exampleco.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/jobs
+#   max_pages: 25          # optional page cap (200 jobs/page, default 25 ≈ 5000 jobs, max 25)
+#   enabled: true
+#
+# - name: JPMorgan Chase                    # worked override example
+#   # Override form: pin the host + siteNumber explicitly (useful when the public
+#   # careers link is branded or the /sites/<n>/ segment isn't in the URL you have).
+#   careers_url: https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1002/jobs
+#   provider: oraclecloud
+#   siteNumber: CX_1002    # the site number after /sites/ (JPMC's external site)
+#   # locationId: 300000000123456   # optional — some tenants (BNY, Amex) need it to scope results
+#   max_pages: 25
 #   enabled: true
 #
 # - name: Example Avature Co

--- a/tests/providers/oraclecloud.test.mjs
+++ b/tests/providers/oraclecloud.test.mjs
@@ -11,6 +11,12 @@ try {
   const oc = mod.default;
   const { parseOracleResponse, resolveSite, buildApiUrl, buildJobUrl } = mod;
 
+  // Validate a derived URL by its parsed hostname, never by substring-matching
+  // the whole URL string — a trusted host fragment can appear in a hostile
+  // URL's path/query/userinfo (CodeQL js/incomplete-url-substring-sanitization).
+  // Mirrors the provider's own assertOracleUrl discipline.
+  const hostOf = (u) => { try { return new URL(u).hostname; } catch { return null; } };
+
   // ── id ──────────────────────────────────────────────────────────────
   if (oc.id === 'oraclecloud') pass('oraclecloud.id is "oraclecloud"');
   else fail(`oraclecloud.id is ${JSON.stringify(oc.id)}`);
@@ -18,7 +24,8 @@ try {
   // ── detect ──────────────────────────────────────────────────────────
   const careers = 'https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1002/jobs';
   const hit = oc.detect({ name: 'JPMC', careers_url: careers });
-  if (hit && hit.url.includes('jpmc.fa.oraclecloud.com/hcmRestApi/resources/latest/recruitingCEJobRequisitions')
+  if (hit && hostOf(hit.url) === 'jpmc.fa.oraclecloud.com'
+      && new URL(hit.url).pathname === '/hcmRestApi/resources/latest/recruitingCEJobRequisitions'
       && hit.url.includes('findReqs;siteNumber=CX_1002')) {
     pass('oraclecloud.detect() derives the requisitions API URL with siteNumber from careers_url');
   } else {
@@ -34,7 +41,7 @@ try {
 
   // region host variant (<tenant>.fa.<region>.oraclecloud.com)
   const regionHit = oc.detect({ name: 'Oracle', careers_url: 'https://oracle.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/jobs' });
-  if (regionHit && regionHit.url.startsWith('https://oracle.fa.us2.oraclecloud.com/hcmRestApi')) {
+  if (regionHit && hostOf(regionHit.url) === 'oracle.fa.us2.oraclecloud.com') {
     pass('oraclecloud.detect() handles the <region> host variant (us2)');
   } else {
     fail(`region variant returned ${JSON.stringify(regionHit)}`);
@@ -42,7 +49,7 @@ try {
 
   // ocs host variant
   const ocsHit = oc.detect({ name: 'X', careers_url: 'https://acme.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/jobs' });
-  if (ocsHit && ocsHit.url.startsWith('https://acme.fa.ocs.oraclecloud.com/')) {
+  if (ocsHit && hostOf(ocsHit.url) === 'acme.fa.ocs.oraclecloud.com') {
     pass('oraclecloud.detect() handles the .ocs. host variant');
   } else {
     fail(`ocs variant returned ${JSON.stringify(ocsHit)}`);
@@ -78,7 +85,7 @@ try {
     careers_url: 'https://careers.branded.com',
     api: 'https://tenant.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1005/jobs',
   });
-  if (apiPinned && apiPinned.url.includes('tenant.fa.oraclecloud.com') && apiPinned.url.includes('siteNumber=CX_1005')) {
+  if (apiPinned && hostOf(apiPinned.url) === 'tenant.fa.oraclecloud.com' && apiPinned.url.includes('siteNumber=CX_1005')) {
     pass('oraclecloud.detect() honors api: over a branded careers_url');
   } else {
     fail(`api-pinned returned ${JSON.stringify(apiPinned)}`);
@@ -238,7 +245,8 @@ try {
     fail(`fetch headers = ${JSON.stringify(capturedOpts?.headers)}`);
   }
 
-  if (capturedUrl && capturedUrl.startsWith('https://jpmc.fa.oraclecloud.com/hcmRestApi/')) {
+  if (capturedUrl && hostOf(capturedUrl) === 'jpmc.fa.oraclecloud.com'
+      && new URL(capturedUrl).pathname.startsWith('/hcmRestApi/')) {
     pass('oraclecloud.fetch() requests the trusted Oracle host');
   } else {
     fail(`fetch url = ${JSON.stringify(capturedUrl)}`);

--- a/tests/providers/oraclecloud.test.mjs
+++ b/tests/providers/oraclecloud.test.mjs
@@ -1,0 +1,351 @@
+// tests/providers/oraclecloud.test.mjs — contract test for the Oracle Recruiting
+// Cloud (ORC) provider. Auto-discovered by test-all.mjs under tests/**.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — oraclecloud');
+
+try {
+  const mod = await import(pathToFileURL(join(ROOT, 'providers/oraclecloud.mjs')).href);
+  const oc = mod.default;
+  const { parseOracleResponse, resolveSite, buildApiUrl, buildJobUrl } = mod;
+
+  // ── id ──────────────────────────────────────────────────────────────
+  if (oc.id === 'oraclecloud') pass('oraclecloud.id is "oraclecloud"');
+  else fail(`oraclecloud.id is ${JSON.stringify(oc.id)}`);
+
+  // ── detect ──────────────────────────────────────────────────────────
+  const careers = 'https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1002/jobs';
+  const hit = oc.detect({ name: 'JPMC', careers_url: careers });
+  if (hit && hit.url.includes('jpmc.fa.oraclecloud.com/hcmRestApi/resources/latest/recruitingCEJobRequisitions')
+      && hit.url.includes('findReqs;siteNumber=CX_1002')) {
+    pass('oraclecloud.detect() derives the requisitions API URL with siteNumber from careers_url');
+  } else {
+    fail(`oraclecloud.detect(careers) returned ${JSON.stringify(hit)}`);
+  }
+
+  // finder grammar: `findReqs;` (semicolon) then comma-separated pairs
+  if (hit && hit.url.includes('finder=findReqs;siteNumber=CX_1002,') && !hit.url.includes('findReqs,siteNumber')) {
+    pass('oraclecloud.detect() uses findReqs; (semicolon) finder grammar');
+  } else {
+    fail(`finder grammar wrong in ${JSON.stringify(hit?.url)}`);
+  }
+
+  // region host variant (<tenant>.fa.<region>.oraclecloud.com)
+  const regionHit = oc.detect({ name: 'Oracle', careers_url: 'https://oracle.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1001/jobs' });
+  if (regionHit && regionHit.url.startsWith('https://oracle.fa.us2.oraclecloud.com/hcmRestApi')) {
+    pass('oraclecloud.detect() handles the <region> host variant (us2)');
+  } else {
+    fail(`region variant returned ${JSON.stringify(regionHit)}`);
+  }
+
+  // ocs host variant
+  const ocsHit = oc.detect({ name: 'X', careers_url: 'https://acme.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/jobs' });
+  if (ocsHit && ocsHit.url.startsWith('https://acme.fa.ocs.oraclecloud.com/')) {
+    pass('oraclecloud.detect() handles the .ocs. host variant');
+  } else {
+    fail(`ocs variant returned ${JSON.stringify(ocsHit)}`);
+  }
+
+  // default siteNumber CX_1 when no /sites/<n>/ in the path
+  const noSite = oc.detect({ name: 'X', careers_url: 'https://acme.fa.oraclecloud.com/hcmUI/CandidateExperience/en/' });
+  if (noSite && noSite.url.includes('siteNumber=CX_1,')) {
+    pass('oraclecloud.detect() falls back to siteNumber CX_1');
+  } else {
+    fail(`default site returned ${JSON.stringify(noSite?.url)}`);
+  }
+
+  // siteNumber override on the entry
+  const override = oc.detect({ name: 'X', careers_url: careers, siteNumber: 'CX_2001' });
+  if (override && override.url.includes('siteNumber=CX_2001,')) {
+    pass('oraclecloud.detect() honors an explicit siteNumber override');
+  } else {
+    fail(`siteNumber override returned ${JSON.stringify(override?.url)}`);
+  }
+
+  // locationId override surfaces in the finder
+  const locId = oc.detect({ name: 'X', careers_url: careers, locationId: 300000000123456 });
+  if (locId && locId.url.includes('locationId=300000000123456')) {
+    pass('oraclecloud.detect() includes locationId when provided');
+  } else {
+    fail(`locationId override returned ${JSON.stringify(locId?.url)}`);
+  }
+
+  // entry.api precedence over a branded careers_url
+  const apiPinned = oc.detect({
+    name: 'Branded',
+    careers_url: 'https://careers.branded.com',
+    api: 'https://tenant.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1005/jobs',
+  });
+  if (apiPinned && apiPinned.url.includes('tenant.fa.oraclecloud.com') && apiPinned.url.includes('siteNumber=CX_1005')) {
+    pass('oraclecloud.detect() honors api: over a branded careers_url');
+  } else {
+    fail(`api-pinned returned ${JSON.stringify(apiPinned)}`);
+  }
+
+  // non-Oracle URL → null
+  if (oc.detect({ name: 'X', careers_url: 'https://example.com/careers' }) === null) {
+    pass('oraclecloud.detect() returns null for non-Oracle URLs');
+  } else {
+    fail('oraclecloud.detect() should return null for non-Oracle URLs');
+  }
+
+  // missing / null / non-string careers_url → null
+  if (oc.detect({ name: 'X' }) === null
+      && oc.detect({ name: 'X', careers_url: null }) === null
+      && oc.detect({ name: 'X', careers_url: { foo: 'bar' } }) === null) {
+    pass('oraclecloud.detect() returns null for missing/null/non-string careers_url');
+  } else {
+    fail('oraclecloud.detect() should treat missing/null/non-string careers_url as no-match');
+  }
+
+  // host-suffix spoof (oraclecloud.com in a longer evil host) → null
+  if (oc.detect({ name: 'Spoof', careers_url: 'https://x.fa.oraclecloud.com.evil.example/hcmUI/CandidateExperience/en/sites/CX_1/jobs' }) === null) {
+    pass('oraclecloud.detect() rejects host-suffix spoofing');
+  } else {
+    fail('oraclecloud.detect() must reject host-suffix spoofing');
+  }
+
+  // path-spoof (oracle host in the path, not the host) → null
+  if (oc.detect({ name: 'Spoof2', careers_url: 'https://evil.example/x.fa.oraclecloud.com/sites/CX_1/jobs' }) === null) {
+    pass('oraclecloud.detect() rejects path-spoofed URLs');
+  } else {
+    fail('oraclecloud.detect() must reject path-spoofed URLs');
+  }
+
+  // non-HTTPS → null
+  if (oc.detect({ name: 'X', careers_url: 'http://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/jobs' }) === null) {
+    pass('oraclecloud.detect() rejects non-HTTPS URLs');
+  } else {
+    fail('oraclecloud.detect() must reject non-HTTPS URLs');
+  }
+
+  // ── parseOracleResponse (pure) ──────────────────────────────────────
+  const site = { host: 'jpmc.fa.oraclecloud.com', lang: 'en', siteNumber: 'CX_1002' };
+  const sample = {
+    items: [{
+      TotalJobsCount: 2,
+      requisitionList: [
+        {
+          Id: '210577366',
+          Title: 'Client Service Associate',
+          PrimaryLocation: 'Newark, DE, United States',
+          PostedDate: '2026-07-15',
+          WorkplaceTypeCode: 'ORA_ON_SITE',
+          ShortDescriptionStr: 'Support the Private Bank &amp; clients',
+        },
+        {
+          Id: '999',
+          Title: 'Remote Engineer',
+          WorkplaceTypeCode: 'ORA_REMOTE',
+          workLocation: [{ TownOrCity: 'Austin', Region: 'TX', Country: 'United States' }],
+          ExternalURL: 'https://jpmc.fa.oraclecloud.com/some/external/link',
+        },
+      ],
+    }],
+  };
+  const jobs = parseOracleResponse(sample, site, 'JPMorgan Chase');
+  if (jobs.length === 2) pass('parseOracleResponse extracts 2 jobs');
+  else fail(`parseOracleResponse returned ${jobs.length} jobs`);
+
+  if (jobs[0]?.url === 'https://jpmc.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1002/job/210577366') {
+    pass('parseOracleResponse builds the /sites/<site>/job/<Id> URL when ExternalURL is absent');
+  } else {
+    fail(`row 0 url = ${JSON.stringify(jobs[0]?.url)}`);
+  }
+
+  if (jobs[1]?.url === 'https://jpmc.fa.oraclecloud.com/some/external/link') {
+    pass('parseOracleResponse prefers ExternalURL when present');
+  } else {
+    fail(`row 1 url = ${JSON.stringify(jobs[1]?.url)}`);
+  }
+
+  if (jobs[0]?.location === 'Newark, DE, United States') {
+    pass('parseOracleResponse uses PrimaryLocation');
+  } else {
+    fail(`row 0 location = ${JSON.stringify(jobs[0]?.location)}`);
+  }
+
+  if (jobs[1]?.location === 'Austin, TX, United States · Remote') {
+    pass('parseOracleResponse assembles location from workLocation + remote hint');
+  } else {
+    fail(`row 1 location = ${JSON.stringify(jobs[1]?.location)}`);
+  }
+
+  if (jobs[0]?.description === 'Support the Private Bank & clients') {
+    pass('parseOracleResponse decodes HTML entities in the description');
+  } else {
+    fail(`row 0 description = ${JSON.stringify(jobs[0]?.description)}`);
+  }
+
+  if (typeof jobs[0]?.postedAt === 'number' && !Number.isNaN(jobs[0].postedAt)) {
+    pass('parseOracleResponse parses PostedDate to an epoch number');
+  } else {
+    fail(`row 0 postedAt = ${JSON.stringify(jobs[0]?.postedAt)}`);
+  }
+
+  // row without Id AND without ExternalURL → dropped (no linkable URL)
+  const dropped = parseOracleResponse(
+    { items: [{ requisitionList: [{ Title: 'No Id No URL' }, { Id: '1', Title: 'Keep' }] }] },
+    site, 'X',
+  );
+  if (dropped.length === 1 && dropped[0].title === 'Keep') {
+    pass('parseOracleResponse drops rows with no resolvable URL');
+  } else {
+    fail(`expected 1 kept row, got ${JSON.stringify(dropped)}`);
+  }
+
+  // RequisitionNumber fallback when Id is absent
+  const reqNum = parseOracleResponse(
+    { items: [{ requisitionList: [{ RequisitionNumber: 'R-42', Title: 'Fallback' }] }] },
+    site, 'X',
+  );
+  if (reqNum.length === 1 && reqNum[0].url.endsWith('/job/R-42')) {
+    pass('parseOracleResponse falls back to RequisitionNumber for the URL');
+  } else {
+    fail(`RequisitionNumber fallback = ${JSON.stringify(reqNum[0]?.url)}`);
+  }
+
+  // malformed / empty bodies → [] (no crash)
+  const safe = [null, {}, { items: null }, { items: [] }, { items: [{ requisitionList: 'nope' }] }, 'string'];
+  if (safe.every((b) => parseOracleResponse(b, site, 'X').length === 0)) {
+    pass('parseOracleResponse returns [] for null/{}/{items:null}/non-array (no crash)');
+  } else {
+    fail('parseOracleResponse should be empty-safe on malformed bodies');
+  }
+
+  // ── fetch: normalization + redirect:error + trusted host ────────────
+  let capturedUrl = null;
+  let capturedOpts = null;
+  const okJobs = await oc.fetch(
+    { name: 'JPMC', careers_url: careers, max_pages: 1 },
+    {
+      transport: 'http',
+      fetchText: async () => { throw new Error('fetchText should not be called'); },
+      fetchJson: async (url, opts) => {
+        capturedUrl = url; capturedOpts = opts;
+        return { items: [{ TotalJobsCount: 1, requisitionList: [{ Id: '5', Title: 'Solo' }] }], hasMore: false };
+      },
+    },
+  );
+  if (capturedOpts?.redirect === 'error') pass('oraclecloud.fetch() passes redirect:"error"');
+  else fail(`fetch opts.redirect = ${JSON.stringify(capturedOpts?.redirect)}`);
+
+  if (capturedOpts?.headers?.['User-Agent'] && capturedOpts.headers.Accept === 'application/json') {
+    pass('oraclecloud.fetch() sends browser UA + Accept: application/json');
+  } else {
+    fail(`fetch headers = ${JSON.stringify(capturedOpts?.headers)}`);
+  }
+
+  if (capturedUrl && capturedUrl.startsWith('https://jpmc.fa.oraclecloud.com/hcmRestApi/')) {
+    pass('oraclecloud.fetch() requests the trusted Oracle host');
+  } else {
+    fail(`fetch url = ${JSON.stringify(capturedUrl)}`);
+  }
+
+  if (okJobs.length === 1 && okJobs[0].title === 'Solo' && okJobs[0].url.endsWith('/job/5')) {
+    pass('oraclecloud.fetch() normalizes to the Job shape');
+  } else {
+    fail(`fetch normalized = ${JSON.stringify(okJobs)}`);
+  }
+
+  // ── fetch: untrusted host throws BEFORE any network call ────────────
+  // The provider derives its own URL from careers_url, so to exercise the
+  // assertOracleUrl guard we can't easily inject a bad host through resolveSite
+  // (it already rejects non-Oracle hosts). Instead assert the derive-failure
+  // path: an undetectable entry throws the documented message.
+  let fetchCalled = false;
+  try {
+    await oc.fetch(
+      { name: 'BadCo', careers_url: 'https://example.com/careers' },
+      { transport: 'http', fetchJson: async () => { fetchCalled = true; return {}; }, fetchText: async () => {} },
+    );
+    fail('oraclecloud.fetch() should throw for an undetectable entry');
+  } catch (e) {
+    if (/cannot derive API URL for BadCo/.test(e.message) && !fetchCalled) {
+      pass('oraclecloud.fetch() throws "cannot derive API URL" before any fetch');
+    } else {
+      fail(`unexpected fetch error / fetchCalled=${fetchCalled}: ${e.message}`);
+    }
+  }
+
+  // ── fetch: pagination (2 full pages then a short page) ──────────────
+  let pageReqs = 0;
+  const paged = await oc.fetch(
+    { name: 'PagedCo', careers_url: careers },
+    {
+      transport: 'http',
+      fetchText: async () => {},
+      fetchJson: async (url) => {
+        pageReqs++;
+        const offset = parseInt(new URL(url).searchParams.get('offset') || '0', 10);
+        if (offset === 0) {
+          return { items: [{ TotalJobsCount: 450, requisitionList: Array.from({ length: 200 }, (_, i) => ({ Id: `A${i}`, Title: `Role ${i}` })) }], hasMore: true };
+        }
+        if (offset === 200) {
+          return { items: [{ TotalJobsCount: 450, requisitionList: Array.from({ length: 200 }, (_, i) => ({ Id: `B${i}`, Title: `Role ${i}` })) }], hasMore: true };
+        }
+        // offset 400: short page (50) → stop
+        return { items: [{ TotalJobsCount: 450, requisitionList: Array.from({ length: 50 }, (_, i) => ({ Id: `C${i}`, Title: `Role ${i}` })) }], hasMore: true };
+      },
+    },
+  );
+  if (pageReqs === 3 && paged.length === 450) {
+    pass('oraclecloud.fetch() paginates by offset and aggregates (3 pages → 450)');
+  } else {
+    fail(`pagination: pageReqs=${pageReqs}, total=${paged.length} (expected 3 / 450)`);
+  }
+
+  // ── fetch: hasMore:false is IGNORED (unreliable on JPMC — false on every
+  //    page despite 7000+ jobs). Pagination is driven by list length + total,
+  //    so a full page with hasMore:false must still advance. ────────────────
+  let hasMoreReqs = 0;
+  const keepGoing = await oc.fetch(
+    { name: 'HasMoreCo', careers_url: careers },
+    {
+      transport: 'http',
+      fetchText: async () => {},
+      fetchJson: async (url) => {
+        hasMoreReqs++;
+        const offset = parseInt(new URL(url).searchParams.get('offset') || '0', 10);
+        // total 350: page 0 full (200), page 1 short (150) → stop after 2 pages,
+        // even though every response says hasMore:false.
+        const len = offset === 0 ? 200 : 150;
+        return { items: [{ TotalJobsCount: 350, requisitionList: Array.from({ length: len }, (_, i) => ({ Id: `H${offset}-${i}`, Title: `R${i}` })) }], hasMore: false };
+      },
+    },
+  );
+  if (hasMoreReqs === 2 && keepGoing.length === 350) {
+    pass('oraclecloud.fetch() ignores unreliable hasMore:false and paginates by list length/total');
+  } else {
+    fail(`hasMore-ignored: reqs=${hasMoreReqs}, total=${keepGoing.length} (expected 2 / 350)`);
+  }
+
+  // ── fetch: retry on a 429 then success (via injected ctx.sleep) ─────
+  let attempts = 0;
+  let slept = 0;
+  const retried = await oc.fetch(
+    { name: 'RetryCo', careers_url: careers, max_pages: 1 },
+    {
+      transport: 'http',
+      sleep: async () => { slept++; },
+      fetchText: async () => {},
+      fetchJson: async () => {
+        attempts++;
+        if (attempts === 1) {
+          const err = new Error('HTTP 429'); err.status = 429; throw err;
+        }
+        return { items: [{ TotalJobsCount: 1, requisitionList: [{ Id: '7', Title: 'Recovered' }] }], hasMore: false };
+      },
+    },
+  );
+  if (attempts === 2 && slept === 1 && retried.length === 1 && retried[0].title === 'Recovered') {
+    pass('oraclecloud.fetch() retries a 429 and recovers (via injected ctx.sleep)');
+  } else {
+    fail(`retry: attempts=${attempts}, slept=${slept}, jobs=${JSON.stringify(retried)}`);
+  }
+
+} catch (e) {
+  fail(`oraclecloud provider tests crashed: ${e.message}`);
+}


### PR DESCRIPTION
## What does this PR do?

Adds an `oraclecloud` scanner provider so Oracle Recruiting Cloud / Fusion Candidate Experience career sites (`*.fa[.<region>][.ocs].oraclecloud.com`) become first-class, zero-token scan targets. Large employers — JPMorgan Chase, Oracle, BNY Mellon, American Express, Honeywell — run their careers site on ORC, and those roles previously couldn't be auto-scanned.

## Related issue

Part of #230 (scanner-providers umbrella).

No dedicated issue — new zero-auth scanner provider (CONTRIBUTING exempts providers from issue-first).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

### How it works

- Hits the public `recruitingCEJobRequisitions` REST API (GET, no auth/token/cookie). `siteNumber` is auto-derived from the `/sites/<siteNumber>/` segment of `careers_url` (default `CX_1`), overridable via `provider: oraclecloud` + `siteNumber:` and an optional `locationId:` some tenants (BNY, Amex) need to scope results.
- Mirrors the existing provider pattern: SSRF-hardened host allowlist (`assertOracleUrl` — `https:` + `*.oraclecloud.com` host-shape match) called before every fetch with `redirect: 'error'`; offset pagination with a page cap; 429/5xx retry with exponential backoff + jitter and a `ctx.sleep` fallback (mirrors `workday.mjs`).
- Exports `parseOracleResponse` for unit testing; reuses `decodeEntities` from `_html-entities.mjs` and a NaN-safe date parse. Emits the standard `{ title, url, company, location, description?, postedAt? }` Job shape.

### Two ORC quirks handled (documented in code)

1. **Finder grammar** is `findReqs;key=val,key=val` — a semicolon after `findReqs`, then comma-separated pairs. A comma there returns HTTP 400.
2. **`hasMore` is unreliable** — JPMC returns `hasMore: false` on *every* page despite 7000+ jobs, so trusting it caps a scan at one page. Pagination is instead driven by the returned list length and `TotalJobsCount`.

### Tests & docs

- `tests/providers/oraclecloud.test.mjs` — 32 checks, auto-discovered under `tests/**` (no `test-all.mjs` edit needed). Covers `detect` (host variants, siteNumber override, `api:` precedence, host-suffix/path spoof rejection, non-HTTPS), `parseOracleResponse` (URL/location/description/date normalization, empty-safety), and `fetch` (`redirect:'error'`, browser UA, trusted host, pagination, `hasMore`-ignored, 429 retry).
- `templates/portals.example.yml` — auto-detection table row + auto-detected and override example stanzas (JPMorgan `CX_1002`).

### Verification

- `node test-all.mjs` passes (the only failure on my machine is the pre-existing `tracker-columns-tests` `node:sqlite` requirement on Node < 22.5, unrelated to this change).
- Verified live against JPMorgan Chase (`CX_1001`/`CX_1002`): correct titles, locations, `/sites/<site>/job/<Id>` URLs, and pagination across thousands of jobs.

### Known limitation

Some tenants front the API with a WAF (e.g. Imperva) that may 403 datacenter/cloud egress IPs. That's an environment/IP issue, not a provider bug — the same request succeeds from a residential IP. Noted in the provider header.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Oracle Recruiting Cloud (ORC) provider support to discover site/region details from portal URLs.
  * Automatically builds the correct requisitions API, paginates through results, and outputs normalized job listings (links, descriptions, locations, remote hints, and posting dates).
  * Improved resilience with retry/backoff for transient failures and rate limiting.

* **Documentation**
  * Expanded Oracle ORC configuration examples, including expected URL patterns and optional site/location overrides.

* **Tests**
  * Added a comprehensive contract-style test suite covering detection, parsing, pagination, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
