### PR TITLE
feat(scan): add Playwright scanner for Interamt.de

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `generate-latex.mjs` | LaTeX CV validator + pdflatex compiler |
 | `scan.mjs` | Zero-token portal scanner (Greenhouse/Ashby/Lever APIs, zero LLM cost) |
 | `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner over full public ATS datasets (Greenhouse/Lever/Ashby/Workday/iCIMS), filtered by portals.yml `title_filter`/`location_filter` — no company list needed; checkpoints every 500 companies, `--resume` continues an interrupted sweep |
+| `scan-interamt.mjs` | Playwright browser scanner for Interamt.de (German public sector portal — Apache Wicket, no REST API) |
 | `check-liveness.mjs` / `liveness-core.mjs` | Job posting liveness checker + shared logic (expired signals win over generic Apply text) |
 | `set-status.mjs` | Canonical tracker-row update: `node set-status.mjs <report#\|company> <State> [--note] [--force]` — strict states.yml validation, report-link mismatch guard, shared lock, atomic write |
 | `invite-match.mjs` | Fuzzy-match a pasted interview invite (company, date, req ID) against the tracker, ranking candidates when a company has multiple entries (JSON or `--summary`) |

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "scan:full": "node scan-ats-full.mjs",
     "scan:seeds": "node scan-ats-full.mjs --seeds yc,a16z",
     "scan:yc": "node scan-ats-full.mjs --seeds yc",
+    "scan:interamt": "node scan-interamt.mjs",
     "validate:portals": "node validate-portals.mjs",
     "verify:portals": "node verify-portals.mjs",
     "tracker": "node tracker.mjs",

--- a/scan-interamt.mjs
+++ b/scan-interamt.mjs
@@ -1,0 +1,412 @@
+#!/usr/bin/env node
+
+/**
+ * scan-interamt.mjs — Interamt.de scanner via Playwright
+ *
+ * Interamt uses Apache Wicket (stateful Java framework) — no REST API exists.
+ * Playwright maintains a browser session so the wicket-crypt token and cookies
+ * are handled transparently.
+ *
+ * Reads `interamt_searches` from portals.yml. Falls back to a default set of
+ * GIS/geospatial keywords if the section is absent.
+ *
+ * Usage:
+ *   node scan-interamt.mjs
+ *   node scan-interamt.mjs --dry-run
+ *   node scan-interamt.mjs --all            # skip date filter (use for first scan)
+ *   node scan-interamt.mjs --keyword "Geoinformatik"
+ */
+
+import { chromium } from 'playwright';
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
+import yaml from 'js-yaml';
+
+// ── Config ───────────────────────────────────────────────────────────
+
+const PORTALS_PATH    = 'portals.yml';
+const SCAN_HISTORY    = 'data/scan-history.tsv';
+const PIPELINE_PATH   = 'data/pipeline.md';
+const APPLICATIONS    = 'data/applications.md';
+const INTERAMT_HOME   = 'https://interamt.de/koop/app/';
+// Direct offer URL — constructed from StellenangebotId.
+// Wicket adds a session version number (?28&id=...) during live navigation,
+// but the bookmarkable form (?id=...) works without a session.
+// If a specific offer fails to load from pipeline, open Interamt manually
+// and navigate to it — Wicket will assign a valid version for that session.
+const OFFER_BASE_URL  = 'https://interamt.de/koop/app/stelle?id=';
+
+// Generic fallback — configure interamt_searches in portals.yml for your target roles
+const DEFAULT_KEYWORDS = [
+  'Informatiker',
+  'Softwareentwickler',
+  'IT-Spezialist',
+  'Datenwissenschaftler',
+  'Systemadministrator',
+  'Datenanalyst',
+];
+
+// ── Args ─────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const DRY_RUN    = args.includes('--dry-run');
+const DEBUG      = args.includes('--debug');
+const NO_DATE_FILTER = args.includes('--all');
+const kwIdx = args.indexOf('--keyword');
+const SINGLE_KEYWORD = kwIdx !== -1 ? args[kwIdx + 1] : null;
+
+// ── Load portals.yml ─────────────────────────────────────────────────
+
+let config = {};
+if (existsSync(PORTALS_PATH)) {
+  config = yaml.load(readFileSync(PORTALS_PATH, 'utf-8')) || {};
+}
+
+const interamtSearches = config.interamt_searches || DEFAULT_KEYWORDS.map(k => ({ was: k }));
+const keywords = SINGLE_KEYWORD
+  ? [SINGLE_KEYWORD]
+  : interamtSearches.map(s => s.was).filter(Boolean);
+
+// ── Filters ──────────────────────────────────────────────────────────
+
+const titleFilter = config.title_filter || {};
+const positiveKw = (titleFilter.positive || []).map(k => k.toLowerCase());
+const negativeKw = (titleFilter.negative || []).map(k => k.toLowerCase());
+
+function matchesTitle(title) {
+  const lower = title.toLowerCase();
+  if (negativeKw.some(k => lower.includes(k))) return false;
+  if (positiveKw.length === 0) return true;
+  return positiveKw.some(k => lower.includes(k));
+}
+
+const locFilter = config.location_filter || {};
+const locAllow = (locFilter.allow || []).map(k => k.toLowerCase());
+const locBlock = (locFilter.block || []).map(k => k.toLowerCase());
+
+function matchesLocation(loc) {
+  if (!loc) return true;
+  const lower = loc.toLowerCase();
+  if (locBlock.some(k => lower.includes(k))) return false;
+  if (locAllow.length === 0) return true;
+  return locAllow.some(k => lower.includes(k));
+}
+
+// ── Date helpers ─────────────────────────────────────────────────────
+
+// Parse Interamt date format DD.MM.YYYY → Date (midnight UTC)
+function parseDE(str) {
+  if (!str) return null;
+  const [d, m, y] = str.trim().split('.');
+  if (!d || !m || !y) return null;
+  return new Date(`${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}T00:00:00Z`);
+}
+
+// Returns the most recent first_seen date for 'interamt' portal entries, or null
+function loadLastScanDate() {
+  if (!existsSync(SCAN_HISTORY)) return null;
+  let latest = null;
+  readFileSync(SCAN_HISTORY, 'utf-8').split('\n').slice(1).forEach(line => {
+    const parts = line.split('\t');
+    if (parts[2] !== 'interamt') return;
+    const d = new Date((parts[1] || '') + 'T00:00:00Z');
+    if (!isNaN(d) && (!latest || d > latest)) latest = d;
+  });
+  return latest;
+}
+
+// ── Dedup ────────────────────────────────────────────────────────────
+
+function loadSeen() {
+  const seen = new Set();
+  if (existsSync(SCAN_HISTORY)) {
+    readFileSync(SCAN_HISTORY, 'utf-8').split('\n').slice(1).forEach(line => {
+      const url = line.split('\t')[0];
+      if (url) seen.add(url);
+    });
+  }
+  if (existsSync(PIPELINE_PATH)) {
+    for (const m of readFileSync(PIPELINE_PATH, 'utf-8').matchAll(/- \[[ x]\] (https?:\/\/\S+)/g)) {
+      seen.add(m[1]);
+    }
+  }
+  if (existsSync(APPLICATIONS)) {
+    for (const m of readFileSync(APPLICATIONS, 'utf-8').matchAll(/https?:\/\/[^\s|)]+/g)) {
+      seen.add(m[0]);
+    }
+  }
+  return seen;
+}
+
+// ── Writers ──────────────────────────────────────────────────────────
+
+function appendToPipeline(offers) {
+  if (offers.length === 0) return;
+  let text = existsSync(PIPELINE_PATH)
+    ? readFileSync(PIPELINE_PATH, 'utf-8')
+    : '# Pipeline\n\n## Pendientes\n\n';
+
+  const marker = '## Pendientes';
+  const idx = text.indexOf(marker);
+  const block = '\n' + offers.map(o => {
+    const parts = [o.url, o.company, o.title];
+    if (o.city)     parts.push(o.city);
+    if (o.modality) parts.push(o.modality);
+    if (o.deadline) parts.push(`Frist: ${o.deadline}`);
+    return `- [ ] ${parts.join(' | ')}`;
+  }).join('\n') + '\n';
+
+  if (idx === -1) {
+    text += `\n${marker}\n${block}`;
+  } else {
+    const after = idx + marker.length;
+    const next = text.indexOf('\n## ', after);
+    const insertAt = next === -1 ? text.length : next;
+    text = text.slice(0, insertAt) + block + text.slice(insertAt);
+  }
+  writeFileSync(PIPELINE_PATH, text, 'utf-8');
+}
+
+function appendToScanHistory(offers, date) {
+  if (!existsSync(SCAN_HISTORY)) {
+    writeFileSync(SCAN_HISTORY, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\tcity\tpublished_date\tdeadline\n', 'utf-8');
+  }
+  const lines = offers.map(o =>
+    [o.url, date, 'interamt', o.title, o.company, 'added',
+     `${o.modality || ''} ${o.city || ''}`.trim(),
+     o.city || '', o.publishedDate || '', o.deadline || ''].join('\t')
+  ).join('\n') + '\n';
+  appendFileSync(SCAN_HISTORY, lines, 'utf-8');
+}
+
+// ── Stable selectors (Wicket name attributes don't change between sessions) ──
+
+const SEL_EDIT_BTN    = 'a.ia-e-link--icon:has-text("Suchkriterien ändern"), a:has-text("Suchkriterien ändern")';
+const SEL_NEXT_INPUT  = 'input[name="stellensucheFilterAttributes.suchtextContainer:stellensucheFilterAttributes.suchText"]';
+const SEL_NEXT_SUBMIT = 'button.ia-e-button--primary:has-text("Detailsuche")';
+
+// ── Scraper ──────────────────────────────────────────────────────────
+
+async function extractRows(page) {
+  return page.$$eval('tr.ia-e-table__row', rows =>
+    rows.map(row => {
+      const cell = field => row.querySelector(`td[data-field="${field}"]`)?.textContent?.trim() || '';
+
+      const title        = cell('Stellenbezeichnung');
+      const id           = row.querySelector('td[data-field="StellenangebotId"] span')?.textContent?.trim() || '';
+      const company      = cell('Behoerde') || 'Interamt';
+      const modality     = cell('Dienstort');
+      const city         = cell('PLZOrte');
+      const publishedDate = cell('Von');
+      const deadline     = cell('Bewerbungsfrist');
+
+      return { title, id, company, modality, city, publishedDate, deadline };
+    }).filter(r => r.title && r.id)
+  );
+}
+
+async function searchInteramt(page, keyword, isFirst) {
+  const found = [];
+
+  if (isFirst) {
+    // Initial search: navigate to homepage and use the landing form
+    await page.goto(INTERAMT_HOME, { waitUntil: 'networkidle', timeout: 30000 });
+
+    // Dismiss cookie modal — it has a backdrop overlay that blocks all clicks
+    const cookieModal = page.locator('#ia-m-cookie-modal');
+    const isModalVisible = await cookieModal.isVisible().catch(() => false);
+    if (isModalVisible) {
+      await page.locator('#ia-m-cookie-modal .ia-m-modal__close').click();
+      await cookieModal.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => null);
+    }
+
+    await page.waitForSelector('#idOrSuchtext', { state: 'visible', timeout: 15000 });
+    await page.fill('#idOrSuchtext', keyword);
+
+    // #ida is Wicket auto-generated; fallback to class selector if ID changes
+    const submitBtn = page.locator('#ida, button.ia-e-button--primary.ia-e-button--icon').first();
+    await submitBtn.waitFor({ state: 'visible', timeout: 10000 });
+    await submitBtn.click();
+  } else {
+    // Subsequent search: use "Suchkriterien ändern" to reuse the Wicket session.
+    // Fall back to a fresh homepage load if the button isn't found (e.g. after an error).
+    const editBtn = page.locator(SEL_EDIT_BTN).first();
+    const editVisible = await editBtn.isVisible({ timeout: 5000 }).catch(() => false);
+
+    if (editVisible) {
+      // Dismiss any modal/backdrop that Wicket may have raised during the previous search
+      const anyModal = page.locator('.ia-m-modal__close').first();
+      if (await anyModal.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await anyModal.evaluate(el => el.click());
+        await page.locator('.ia-m-modal__container').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => null);
+      }
+      await page.locator('.ia-e-backdrop').waitFor({ state: 'hidden', timeout: 10000 }).catch(() => null);
+      await editBtn.evaluate(el => el.click());
+      await page.waitForSelector(SEL_NEXT_INPUT, { state: 'visible', timeout: 15000 });
+      await page.fill(SEL_NEXT_INPUT, keyword);
+      const submitBtn = page.locator(SEL_NEXT_SUBMIT);
+      await submitBtn.waitFor({ state: 'visible', timeout: 10000 });
+      await submitBtn.click();
+    } else {
+      // Fallback: reload homepage (no cookie modal on subsequent loads)
+      await page.goto(INTERAMT_HOME, { waitUntil: 'networkidle', timeout: 30000 });
+      await page.waitForSelector('#idOrSuchtext', { state: 'visible', timeout: 15000 });
+      await page.fill('#idOrSuchtext', keyword);
+      const submitBtn = page.locator('#ida, button.ia-e-button--primary.ia-e-button--icon').first();
+      await submitBtn.waitFor({ state: 'visible', timeout: 10000 });
+      await submitBtn.click();
+    }
+  }
+
+  // Wait for results table or "no results" message
+  await Promise.race([
+    page.waitForSelector('tr.ia-e-table__row', { timeout: 20000 }),
+    page.waitForSelector('.ia-e-no-results, .ia-no-results, [class*="no-result"]', { timeout: 20000 }),
+  ]).catch(() => null);
+
+  if (DEBUG) {
+    await page.screenshot({ path: 'output/debug-interamt.png', fullPage: true });
+    const { writeFileSync: wf } = await import('fs');
+    wf('output/debug-interamt.html', await page.content());
+    console.log('  [debug] screenshot → output/debug-interamt.png');
+    console.log('  [debug] html       → output/debug-interamt.html');
+    console.log('  [debug] url:', page.url());
+    const rowCount = await page.$$eval('tr', rows => rows.length);
+    console.log(`  [debug] total <tr> on page: ${rowCount}`);
+  }
+
+  // Wait for Wicket AJAX to fully settle — networkidle ensures no pending requests
+  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => null);
+
+  // "mehr laden" appends rows to the same page — click until gone, then extract all at once
+  const loadMoreBtn = page.locator('button.ia-m-searchresults__btn-load').first();
+  let pageNum = 1;
+  while (pageNum <= 50) {
+    const visible = await loadMoreBtn.isVisible().catch(() => false);
+    if (!visible) break;
+    const beforeCount = await page.$$eval('tr.ia-e-table__row', rows => rows.length);
+    await loadMoreBtn.evaluate(el => el.click());
+    // Wait for backdrop to clear, then for new rows to appear
+    await page.locator('.ia-e-backdrop').waitFor({ state: 'hidden', timeout: 10000 }).catch(() => null);
+    await page.waitForFunction(
+      n => document.querySelectorAll('tr.ia-e-table__row').length > n,
+      beforeCount,
+      { timeout: 15000 }
+    ).catch(() => null);
+    pageNum++;
+  }
+
+  const rows = await extractRows(page);
+  for (const row of rows) {
+    found.push({
+      title:         row.title,
+      url:           `${OFFER_BASE_URL}${row.id}`,
+      company:       row.company,
+      modality:      row.modality,
+      city:          row.city,
+      publishedDate: row.publishedDate,
+      deadline:      row.deadline,
+    });
+  }
+
+  return found;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  mkdirSync('data', { recursive: true });
+
+  const seen = loadSeen();
+  const date = new Date().toISOString().slice(0, 10);
+
+  const lastScanDate = NO_DATE_FILTER ? null : loadLastScanDate();
+  if (NO_DATE_FILTER) {
+    console.log(`  --all: date filter disabled — fetching all available offers`);
+  } else if (lastScanDate) {
+    console.log(`  Last Interamt scan: ${lastScanDate.toISOString().slice(0,10)} — skipping older offers`);
+  }
+
+  let totalFound = 0;
+  let filteredTitle = 0;
+  let filteredLocation = 0;
+  let filteredDate = 0;
+  let dupes = 0;
+  const newOffers = [];
+  const errors = [];
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ locale: 'de-DE', timezoneId: 'Europe/Berlin' });
+  const page = await context.newPage();
+
+  try {
+    for (let i = 0; i < keywords.length; i++) {
+      const kw = keywords[i];
+      process.stdout.write(`  Searching "${kw}"... `);
+      try {
+        const found = await searchInteramt(page, kw, i === 0);
+        totalFound += found.length;
+        process.stdout.write(`${found.length} found\n`);
+
+        for (const offer of found) {
+          if (!matchesTitle(offer.title)) { filteredTitle++; continue; }
+          const loc = `${offer.modality || ''} ${offer.city || ''}`.trim();
+          if (!matchesLocation(loc)) { filteredLocation++; continue; }
+          if (lastScanDate) {
+            const pub = parseDE(offer.publishedDate);
+            if (pub && pub <= lastScanDate) { filteredDate++; continue; }
+          }
+          if (seen.has(offer.url)) { dupes++; continue; }
+          seen.add(offer.url);
+          newOffers.push(offer);
+        }
+      } catch (err) {
+        process.stdout.write(`ERROR\n`);
+        errors.push({ keyword: kw, error: err.message });
+      }
+    }
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+
+  if (!DRY_RUN && newOffers.length > 0) {
+    appendToPipeline(newOffers);
+    appendToScanHistory(newOffers, date);
+  }
+
+  // Summary
+  console.log(`\n${'━'.repeat(45)}`);
+  console.log(`Interamt Scan — ${date}`);
+  console.log(`${'━'.repeat(45)}`);
+  console.log(`Keywords searched:  ${keywords.length}`);
+  console.log(`Total found:        ${totalFound}`);
+  console.log(`Filtered by title:  ${filteredTitle}`);
+  console.log(`Filtered location:  ${filteredLocation}`);
+  console.log(`Filtered by date:   ${filteredDate}`);
+  console.log(`Duplicates:         ${dupes}`);
+  console.log(`New offers:         ${newOffers.length}`);
+
+  if (errors.length > 0) {
+    console.log(`\nErrors (${errors.length}):`);
+    for (const e of errors) console.log(`  ✗ "${e.keyword}": ${e.error}`);
+  }
+
+  if (newOffers.length > 0) {
+    console.log('\nNew offers:');
+    for (const o of newOffers) {
+      console.log(`  + ${o.company} | ${o.title} | ${[o.city, o.modality].filter(Boolean).join(' ') || 'N/A'}`);
+    }
+    if (DRY_RUN) {
+      console.log('\n(dry run — not saved)');
+    } else {
+      console.log(`\nSaved to ${PIPELINE_PATH}`);
+    }
+  }
+
+  console.log('\n→ Run /career-ops pipeline to evaluate new offers.');
+}
+
+main().catch(err => {
+  console.error('Fatal:', err.message);
+  process.exit(1);
+});

--- a/scan-interamt.mjs
+++ b/scan-interamt.mjs
@@ -14,7 +14,7 @@
  *   node scan-interamt.mjs
  *   node scan-interamt.mjs --dry-run
  *   node scan-interamt.mjs --all            # skip date filter (use for first scan)
- *   node scan-interamt.mjs --keyword "Geoinformatik"
+ *   node scan-interamt.mjs --keyword "Softwareentwickler"
  */
 
 import { chromium } from 'playwright';

--- a/scan-interamt.mjs
+++ b/scan-interamt.mjs
@@ -7,8 +7,8 @@
  * Playwright maintains a browser session so the wicket-crypt token and cookies
  * are handled transparently.
  *
- * Reads `interamt_searches` from portals.yml. Falls back to a default set of
- * GIS/geospatial keywords if the section is absent.
+ * Reads `interamt_searches` from portals.yml. Falls back to a generic set of
+ * German IT keywords if the section is absent.
  *
  * Usage:
  *   node scan-interamt.mjs
@@ -18,15 +18,14 @@
  */
 
 import { chromium } from 'playwright';
-import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync } from 'fs';
 import yaml from 'js-yaml';
+import { appendToPipeline, appendToScanHistory, loadSeenUrls } from './scan.mjs';
 
 // ── Config ───────────────────────────────────────────────────────────
 
 const PORTALS_PATH    = 'portals.yml';
 const SCAN_HISTORY    = 'data/scan-history.tsv';
-const PIPELINE_PATH   = 'data/pipeline.md';
-const APPLICATIONS    = 'data/applications.md';
 const INTERAMT_HOME   = 'https://interamt.de/koop/app/';
 // Direct offer URL — constructed from StellenangebotId.
 // Wicket adds a session version number (?28&id=...) during live navigation,
@@ -52,6 +51,10 @@ const DRY_RUN    = args.includes('--dry-run');
 const DEBUG      = args.includes('--debug');
 const NO_DATE_FILTER = args.includes('--all');
 const kwIdx = args.indexOf('--keyword');
+if (kwIdx !== -1 && (args[kwIdx + 1] === undefined || args[kwIdx + 1].startsWith('--'))) {
+  console.error('Error: --keyword requires a value, e.g. --keyword "Softwareentwickler"');
+  process.exit(1);
+}
 const SINGLE_KEYWORD = kwIdx !== -1 ? args[kwIdx + 1] : null;
 
 // ── Load portals.yml ─────────────────────────────────────────────────
@@ -112,70 +115,6 @@ function loadLastScanDate() {
     if (!isNaN(d) && (!latest || d > latest)) latest = d;
   });
   return latest;
-}
-
-// ── Dedup ────────────────────────────────────────────────────────────
-
-function loadSeen() {
-  const seen = new Set();
-  if (existsSync(SCAN_HISTORY)) {
-    readFileSync(SCAN_HISTORY, 'utf-8').split('\n').slice(1).forEach(line => {
-      const url = line.split('\t')[0];
-      if (url) seen.add(url);
-    });
-  }
-  if (existsSync(PIPELINE_PATH)) {
-    for (const m of readFileSync(PIPELINE_PATH, 'utf-8').matchAll(/- \[[ x]\] (https?:\/\/\S+)/g)) {
-      seen.add(m[1]);
-    }
-  }
-  if (existsSync(APPLICATIONS)) {
-    for (const m of readFileSync(APPLICATIONS, 'utf-8').matchAll(/https?:\/\/[^\s|)]+/g)) {
-      seen.add(m[0]);
-    }
-  }
-  return seen;
-}
-
-// ── Writers ──────────────────────────────────────────────────────────
-
-function appendToPipeline(offers) {
-  if (offers.length === 0) return;
-  let text = existsSync(PIPELINE_PATH)
-    ? readFileSync(PIPELINE_PATH, 'utf-8')
-    : '# Pipeline\n\n## Pendientes\n\n';
-
-  const marker = '## Pendientes';
-  const idx = text.indexOf(marker);
-  const block = '\n' + offers.map(o => {
-    const parts = [o.url, o.company, o.title];
-    if (o.city)     parts.push(o.city);
-    if (o.modality) parts.push(o.modality);
-    if (o.deadline) parts.push(`Frist: ${o.deadline}`);
-    return `- [ ] ${parts.join(' | ')}`;
-  }).join('\n') + '\n';
-
-  if (idx === -1) {
-    text += `\n${marker}\n${block}`;
-  } else {
-    const after = idx + marker.length;
-    const next = text.indexOf('\n## ', after);
-    const insertAt = next === -1 ? text.length : next;
-    text = text.slice(0, insertAt) + block + text.slice(insertAt);
-  }
-  writeFileSync(PIPELINE_PATH, text, 'utf-8');
-}
-
-function appendToScanHistory(offers, date) {
-  if (!existsSync(SCAN_HISTORY)) {
-    writeFileSync(SCAN_HISTORY, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\tcity\tpublished_date\tdeadline\n', 'utf-8');
-  }
-  const lines = offers.map(o =>
-    [o.url, date, 'interamt', o.title, o.company, 'added',
-     `${o.modality || ''} ${o.city || ''}`.trim(),
-     o.city || '', o.publishedDate || '', o.deadline || ''].join('\t')
-  ).join('\n') + '\n';
-  appendFileSync(SCAN_HISTORY, lines, 'utf-8');
 }
 
 // ── Stable selectors (Wicket name attributes don't change between sessions) ──
@@ -316,7 +255,7 @@ async function searchInteramt(page, keyword, isFirst) {
 async function main() {
   mkdirSync('data', { recursive: true });
 
-  const seen = loadSeen();
+  const { seen } = loadSeenUrls();
   const date = new Date().toISOString().slice(0, 10);
 
   const lastScanDate = NO_DATE_FILTER ? null : loadLastScanDate();
@@ -327,11 +266,11 @@ async function main() {
   }
 
   let totalFound = 0;
-  let filteredTitle = 0;
-  let filteredLocation = 0;
-  let filteredDate = 0;
-  let dupes = 0;
   const newOffers = [];
+  const titleSkipped = [];
+  const locationSkipped = [];
+  const dateSkipped = [];
+  const dupeSkipped = [];
   const errors = [];
 
   const browser = await chromium.launch({ headless: true });
@@ -348,16 +287,26 @@ async function main() {
         process.stdout.write(`${found.length} found\n`);
 
         for (const offer of found) {
-          if (!matchesTitle(offer.title)) { filteredTitle++; continue; }
-          const loc = `${offer.modality || ''} ${offer.city || ''}`.trim();
-          if (!matchesLocation(loc)) { filteredLocation++; continue; }
-          if (lastScanDate) {
-            const pub = parseDE(offer.publishedDate);
-            if (pub && pub <= lastScanDate) { filteredDate++; continue; }
-          }
-          if (seen.has(offer.url)) { dupes++; continue; }
-          seen.add(offer.url);
-          newOffers.push(offer);
+          const location = [offer.modality, offer.city].filter(Boolean).join(' ')
+            + (offer.deadline ? ` (Frist: ${offer.deadline})` : '');
+          const pubDate = parseDE(offer.publishedDate);
+          const canonical = {
+            url: offer.url,
+            company: offer.company,
+            title: offer.title,
+            location,
+            source: 'interamt',
+            postedAt: pubDate ? pubDate.getTime() : undefined,
+          };
+
+          if (!matchesTitle(offer.title)) { titleSkipped.push(canonical); continue; }
+          if (!matchesLocation(location)) { locationSkipped.push(canonical); continue; }
+          // Same-day offers pass: lastScanDate is the day of the last run, and an
+          // offer published later that same day should not be treated as stale.
+          if (lastScanDate && pubDate && pubDate < lastScanDate) { dateSkipped.push(canonical); continue; }
+          if (seen.has(canonical.url)) { dupeSkipped.push(canonical); continue; }
+          seen.add(canonical.url);
+          newOffers.push(canonical);
         }
       } catch (err) {
         process.stdout.write(`ERROR\n`);
@@ -369,9 +318,13 @@ async function main() {
     await browser.close();
   }
 
-  if (!DRY_RUN && newOffers.length > 0) {
-    appendToPipeline(newOffers);
-    appendToScanHistory(newOffers, date);
+  if (!DRY_RUN) {
+    if (newOffers.length > 0) appendToPipeline(newOffers);
+    if (newOffers.length > 0) appendToScanHistory(newOffers, date, 'added');
+    if (titleSkipped.length > 0) appendToScanHistory(titleSkipped, date, 'skipped_title');
+    if (locationSkipped.length > 0) appendToScanHistory(locationSkipped, date, 'skipped_location');
+    if (dateSkipped.length > 0) appendToScanHistory(dateSkipped, date, 'skipped_date');
+    if (dupeSkipped.length > 0) appendToScanHistory(dupeSkipped, date, 'skipped_dup');
   }
 
   // Summary
@@ -380,10 +333,10 @@ async function main() {
   console.log(`${'━'.repeat(45)}`);
   console.log(`Keywords searched:  ${keywords.length}`);
   console.log(`Total found:        ${totalFound}`);
-  console.log(`Filtered by title:  ${filteredTitle}`);
-  console.log(`Filtered location:  ${filteredLocation}`);
-  console.log(`Filtered by date:   ${filteredDate}`);
-  console.log(`Duplicates:         ${dupes}`);
+  console.log(`Filtered by title:  ${titleSkipped.length}`);
+  console.log(`Filtered location:  ${locationSkipped.length}`);
+  console.log(`Filtered by date:   ${dateSkipped.length}`);
+  console.log(`Duplicates:         ${dupeSkipped.length}`);
   console.log(`New offers:         ${newOffers.length}`);
 
   if (errors.length > 0) {
@@ -394,12 +347,12 @@ async function main() {
   if (newOffers.length > 0) {
     console.log('\nNew offers:');
     for (const o of newOffers) {
-      console.log(`  + ${o.company} | ${o.title} | ${[o.city, o.modality].filter(Boolean).join(' ') || 'N/A'}`);
+      console.log(`  + ${o.company} | ${o.title} | ${o.location || 'N/A'}`);
     }
     if (DRY_RUN) {
       console.log('\n(dry run — not saved)');
     } else {
-      console.log(`\nSaved to ${PIPELINE_PATH}`);
+      console.log(`\nSaved to data/pipeline.md`);
     }
   }
 

--- a/scan-interamt.mjs
+++ b/scan-interamt.mjs
@@ -203,6 +203,7 @@ async function searchInteramt(page, keyword, isFirst) {
   ]).catch(() => null);
 
   if (DEBUG) {
+    mkdirSync('output', { recursive: true });
     await page.screenshot({ path: 'output/debug-interamt.png', fullPage: true });
     const { writeFileSync: wf } = await import('fs');
     wf('output/debug-interamt.html', await page.content());
@@ -299,11 +300,11 @@ async function main() {
             postedAt: pubDate ? pubDate.getTime() : undefined,
           };
 
-          if (!matchesTitle(offer.title)) { titleSkipped.push(canonical); continue; }
-          if (!matchesLocation(location)) { locationSkipped.push(canonical); continue; }
+          if (!matchesTitle(offer.title)) { seen.add(canonical.url); titleSkipped.push(canonical); continue; }
+          if (!matchesLocation(location)) { seen.add(canonical.url); locationSkipped.push(canonical); continue; }
           // Same-day offers pass: lastScanDate is the day of the last run, and an
           // offer published later that same day should not be treated as stale.
-          if (lastScanDate && pubDate && pubDate < lastScanDate) { dateSkipped.push(canonical); continue; }
+          if (lastScanDate && pubDate && pubDate < lastScanDate) { seen.add(canonical.url); dateSkipped.push(canonical); continue; }
           if (seen.has(canonical.url)) { dupeSkipped.push(canonical); continue; }
           seen.add(canonical.url);
           newOffers.push(canonical);
@@ -319,7 +320,7 @@ async function main() {
   }
 
   if (!DRY_RUN) {
-    if (newOffers.length > 0) appendToPipeline(newOffers);
+    if (newOffers.length > 0) await appendToPipeline(newOffers);
     if (newOffers.length > 0) appendToScanHistory(newOffers, date, 'added');
     if (titleSkipped.length > 0) appendToScanHistory(titleSkipped, date, 'skipped_title');
     if (locationSkipped.length > 0) appendToScanHistory(locationSkipped, date, 'skipped_location');

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -33,10 +33,10 @@
 
 # -- Interamt.de searches (optional, German public sector) --
 # Read by scan-interamt.mjs (`npm run scan:interamt`), a separate Playwright
-# scanner for Interamt.de — the primary portal for German federal, state, and
-# municipal government job postings. Interamt has no REST API (Apache Wicket,
-# stateful), so it isn't reachable through the tracked_companies providers
-# above; scan-interamt.mjs drives a real browser session instead.
+# scanner for Interamt.de, a portal for German federal, state, and municipal
+# government job postings. Interamt has no REST API (Apache Wicket, stateful),
+# so it isn't reachable through the tracked_companies providers above;
+# scan-interamt.mjs drives a real browser session instead.
 #
 # Each `was:` entry is a search keyword submitted to Interamt's search form.
 # If this block is absent, scan-interamt.mjs falls back to a generic set of

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -44,10 +44,10 @@
 # Results are still filtered by title_filter/location_filter below.
 #
 # interamt_searches:
-#   - was: "Geoinformatik"
-#   - was: "GIS"
 #   - was: "Softwareentwickler"
+#   - was: "Informatiker"
 #   - was: "Datenanalyst"
+#   - was: "Systemadministrator"
 
 # -- Location filter (optional) --
 # Filter scanned jobs by location. Applied AFTER title filter, BEFORE dedup.

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -31,6 +31,24 @@
 # scan_history:
 #   recheck_after_days: 30
 
+# -- Interamt.de searches (optional, German public sector) --
+# Read by scan-interamt.mjs (`npm run scan:interamt`), a separate Playwright
+# scanner for Interamt.de — the primary portal for German federal, state, and
+# municipal government job postings. Interamt has no REST API (Apache Wicket,
+# stateful), so it isn't reachable through the tracked_companies providers
+# above; scan-interamt.mjs drives a real browser session instead.
+#
+# Each `was:` entry is a search keyword submitted to Interamt's search form.
+# If this block is absent, scan-interamt.mjs falls back to a generic set of
+# German IT keywords (Informatiker, Softwareentwickler, IT-Spezialist, ...).
+# Results are still filtered by title_filter/location_filter below.
+#
+# interamt_searches:
+#   - was: "Geoinformatik"
+#   - was: "GIS"
+#   - was: "Softwareentwickler"
+#   - was: "Datenanalyst"
+
 # -- Location filter (optional) --
 # Filter scanned jobs by location. Applied AFTER title filter, BEFORE dedup.
 # If this entire block is absent, all locations pass (current default behavior).

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -166,6 +166,7 @@ const SYSTEM_PATHS = [
   'pipeline-lock.mjs',
   'classify-tier.mjs',
   'scan-ats-full.mjs',
+  'scan-interamt.mjs',
   'match-star.mjs',
   'jd-skill-gap.mjs',
   'prepare-application.mjs',


### PR DESCRIPTION
Closes #698.

## Summary
- Adds `scan-interamt.mjs`, a standalone Playwright-based scanner for Interamt.de — the primary portal for German federal, state, and municipal government job postings. It has no REST API and runs on Apache Wicket (stateful Java framework), so the existing HTTP-based providers can't reach it; a real browser session is required.
- Same shape as `scan-ats-full.mjs` per the design discussed in the issue: single browser session across all configured keywords (reuses the "Suchkriterien ändern" flow instead of reloading per keyword), paginates via "mehr laden", applies the existing `title_filter`/`location_filter` conventions, writes to `pipeline.md`/`scan-history.tsv` in the same format as `scan.mjs`.
- Registers `scan-interamt.mjs` in `update-system.mjs` `SYSTEM_PATHS` so it distributes on update — this was the one open item from the issue thread.
- Documents the new script in `AGENTS.md`, wires up `npm run scan:interamt`, and adds a commented `interamt_searches` example block (generic keywords) to `templates/portals.example.yml`.

## Test plan
- [x] `node -c scan-interamt.mjs` — syntax check
- [x] `node validate-system-paths-coverage.mjs` — passes, new file correctly classified
- [x] `node test-all.mjs` — 1741 passed, 0 failed (tested from a fresh clone per CONTRIBUTING.md)
- [x] `node scan-interamt.mjs --dry-run --keyword "Softwareentwickler"` — live smoke test against Interamt.de, results parsed correctly, no writes in dry-run mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Interamt.de job-listings scanner CLI with configurable keywords.
  - Includes dry-run and debug options, plus full-run mode (no date filtering) and single-keyword scanning.
  - Applies title/location filtering, avoids duplicate URLs from prior runs, and records accepted offers to the pipeline and scan history.
  - Added `scan:interamt` to project scripts.

- **Documentation**
  - Updated agents guidance to document the new Interamt scanner.
  - Expanded the example portals configuration with an optional `interamt_searches` section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->