### PR TITLE
feat(oferta): Block G signal — benefits/employment terminology country mismatch

### DIFF
--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -281,12 +281,12 @@ This signal does not change the High Confidence / Proceed with Caution / Suspici
 
 Some JDs are copy-pasted from a template built for a different country's postings, leaving behind benefits or employment-law terminology that belongs to the wrong jurisdiction — e.g. a Canada-located posting that lists "401(k)" or "W-2 employment," which are US-only terms. The posting can be entirely live and real and still describe the wrong country's benefits; this is a template-error detector, not a ghost-job signal. Check the JD's benefits/employment section against the jurisdiction-specific term list below (add a new row to extend to another country — this table is a data reference, not instruction logic, so extending it never requires touching the rule text):
 
-| Jurisdiction | Terms exclusive to that jurisdiction |
-|---|---|
-| US only | "401(k)", "W-2 employment", "PTO" (used alone, without "vacation," is a weaker signal) |
-| Canada only | "RRSP", "T4", "ESA" (Employment Standards Act) |
+| Jurisdiction | Strong markers (unconditional) | Corroborating-only markers |
+|---|---|---|
+| US only | "401(k)", "W-2 employment" | "PTO" — used in Canada and other jurisdictions too, so it never triggers this signal on its own; count it only when it appears alongside "401(k)" or "W-2 employment" in the same posting |
+| Canada only | "RRSP", "T4" | "Employment Standards Act" spelled out — the bare acronym "ESA" is ambiguous (collides with other jurisdictions' usage) and must never be matched on its own |
 
-Only flag when the JD's stated location is in jurisdiction A, but the benefits/employment section uses terms exclusive to jurisdiction B. Generic terms ("health benefits," "retirement plan") should never trigger this on their own.
+Only flag when the JD's stated location is in jurisdiction A, but the benefits/employment section uses a strong marker exclusive to jurisdiction B, or a corroborating-only marker that co-occurs with a strong marker from jurisdiction B. A corroborating-only marker appearing by itself (e.g. "PTO" with no "401(k)"/"W-2," or a bare "ESA" with no expanded "Employment Standards Act") must never trigger this signal on its own. Generic terms ("health benefits," "retirement plan") should never trigger this on their own.
 
 If this mismatch is present, append a short, non-alarmist note to the report:
 

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -277,6 +277,23 @@ Check the JD for these three signal classes:
 
 This signal does not change the High Confidence / Proceed with Caution / Suspicious tier below — the posting can be entirely real and still oversell its AI maturity. It is orthogonal to ghost-job detection and is reported separately.
 
+**8. Benefits/Employment Terminology Country Mismatch** (from JD text; cross-check stated location against jurisdiction-specific benefits/employment terms):
+
+Some JDs are copy-pasted from a template built for a different country's postings, leaving behind benefits or employment-law terminology that belongs to the wrong jurisdiction — e.g. a Canada-located posting that lists "401(k)" or "W-2 employment," which are US-only terms. The posting can be entirely live and real and still describe the wrong country's benefits; this is a template-error detector, not a ghost-job signal. Check the JD's benefits/employment section against the jurisdiction-specific term list below (add a new row to extend to another country — this table is a data reference, not instruction logic, so extending it never requires touching the rule text):
+
+| Jurisdiction | Terms exclusive to that jurisdiction |
+|---|---|
+| US only | "401(k)", "W-2 employment", "PTO" (used alone, without "vacation," is a weaker signal) |
+| Canada only | "RRSP", "T4", "ESA" (Employment Standards Act) |
+
+Only flag when the JD's stated location is in jurisdiction A, but the benefits/employment section uses terms exclusive to jurisdiction B. Generic terms ("health benefits," "retirement plan") should never trigger this on their own.
+
+If this mismatch is present, append a short, non-alarmist note to the report:
+
+> ⚠️ **Benefits terminology mismatch signal:** This posting is listed in {location}, but its benefits section uses {jurisdiction B}-specific terms ("{specific phrase found}"). This is often a copy-paste artifact from a template used for a different country's postings, and doesn't necessarily mean the posting is fake — but worth confirming with the employer/recruiter which country's employment terms actually apply before assuming the listed benefits package is accurate.
+
+This signal does not change the High Confidence / Proceed with Caution / Suspicious tier below — it is orthogonal to ghost-job detection and is reported separately.
+
 ### Output format:
 
 **Assessment:** One of three tiers:


### PR DESCRIPTION
## Summary

Adds an 8th signal to Block G — Posting Legitimacy (`modes/oferta.md`): **Benefits/Employment Terminology Country Mismatch**. Cross-checks the JD's stated location against jurisdiction-specific benefits/employment terms found in the JD text — e.g. a Canada-located posting listing "401(k)" or "W-2 employment," which are US-only terms.

This is a copy-paste-template-error detector, not a ghost-job signal — the posting can be entirely live and real and still describe the wrong country's benefits. A candidate deciding whether a comp/benefits package is competitive needs accurate terms for the country they'd actually work in.

Follows the exact pattern of signals 6 (Employment Classification Risk) and 7 (AI-Buzzword vs. Infrastructure Mismatch): prompt-instruction only (no new script), a jurisdiction table that's a data reference (extensible without touching rule text), non-alarmist descriptive tone, and explicitly orthogonal to the High Confidence / Proceed with Caution / Suspicious tier — reported separately from ghost-job detection.

Closes #1935

## Motivation (from #1935)

Two real, same-day postings surfaced this gap:
1. A posting located in Ontario, Canada listed "401(k) match" — a US-specific retirement plan term; Canadian employers use RRSP.
2. A separate agency-sourced posting, also located in Ontario, listed "W2 employment" and "401(k) retirement plan" — both US employment-classification/benefits terms not used in Canada.

Both look like a US-market JD template reused for a Canada-listed posting, rather than a genuinely Canada-based role with accurate terms.

## Changes

- `modes/oferta.md`: inserted signal 8 into Block G, right after signal 7 and before the `### Output format:` heading. Signals 1-7 are unchanged/unrenumbered.

## Test plan

- [x] `node test-all.mjs --quick` — 1739 passed, 0 failed (1 pre-existing warning unrelated to this change)
- [x] Docs/prompt-only change — no script touched, no User Layer files touched (`AGENTS.md`/`DATA_CONTRACT.md` boundary respected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a posting legitimacy signal that detects mismatches between a job’s stated location and region-specific benefits/employment-law terminology.
  - When detected, reports include a clear, non-alarmist note referencing the location and the specific phrase found.
  - This check is explicitly independent of existing confidence/tiering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->