### PR TITLE
feat(interview-redflag): flag scope/compensation mismatch when interview probes off-JD skills at entry-level pay

### DIFF
--- a/modes/interview-redflag.md
+++ b/modes/interview-redflag.md
@@ -154,7 +154,7 @@ Write the following structure:
 #### {round} ({date})
 
 **Off-JD topic asked about:** {specific skill/topic}, absent from the posted JD text for {role}.
-**JD context:** posted as {the actual seniority label captured in Step 2b — junior / associate / coordinator-tier / entry-level / etc.} at {stated pay band, with the explicit benchmark that qualified it as low-end}.
+**JD context:** posted as {the actual seniority label captured in Step 2b — junior / associate / coordinator-tier / entry-level / etc.}; compensation evidence: {exact JD pay figure/band if the JD stated one, otherwise the exact user-notes below-market benchmark or classification that qualified condition 2 — never invent or estimate a pay band}.
 
 {1–2 sentences, descriptive not accusatory: what was asked, and how it sits outside the JD's stated scope and pay level. E.g. "The interviewer asked directly about workflow automation experience — a skill not mentioned anywhere in the JD, which is posted as a coordinator-tier, non-technical role at the low end of its stated band."}
 
@@ -179,7 +179,7 @@ Signals:
   • {signal}: {n}/{total} sessions {(pattern) if 2+}
   ...
 {If Step 2b flagged one or more sessions, list all of them here, most recent first — one bullet per qualifying session, do not collapse into a single line:
-  • Scope/Compensation Mismatch: {round} — {off-JD topic} asked at {the actual seniority label captured in Step 2b, e.g. junior/associate/coordinator-tier/entry-level} pay {(corroborated) if a coffee chat or other source confirms it}
+  • Scope/Compensation Mismatch: {round} ({date}) — {off-JD topic} asked at {the actual seniority label captured in Step 2b, e.g. junior/associate/coordinator-tier/entry-level} pay [{exact JD pay figure/band, or exact user-notes below-market benchmark/classification that qualified condition 2}] — {"single-instance observation" OR "corroborated by [coffee chat note / other source, e.g. see #1940 / PR #1941]"}
   ...}
 
 → Full analysis written to interview-prep/{company-slug}-redflags.md

--- a/modes/interview-redflag.md
+++ b/modes/interview-redflag.md
@@ -15,6 +15,7 @@ Requires transcripts produced by `modes/interview/debrief.md` or `modes/intervie
 - `interview-prep/sessions/` — Session transcripts (debrief + practice outputs). One file per round.
 - `interview-prep/{company}-{role}.md` — Company intel file (for context + output target).
 - `config/profile.yml` — User profile (for role/archetype context).
+- **Original JD text (user-provided, for Step 2b only)** — the posted job description for the role under analysis. Same "user-provided input, not automated scraping" pattern used elsewhere in this codebase (e.g. `jd-skill-gap.mjs`): paste it, or point at `local:jds/{file}` if it's already saved under `jds/`. Without it, Step 2b is skipped — every other step runs as normal.
 
 Expected transcript filename convention (from #956):
 ```
@@ -70,6 +71,19 @@ Mark each of the four signal types as **present** or **absent** for the session.
 
 Record which signals are present per session. Do not infer — only flag what is explicitly observable in the transcript text.
 
+## Step 2b — Detect Scope/Compensation Mismatch (requires JD text)
+
+This is a **separate, fifth dimension** — distinct from the four interviewer-behaviour signals above. It doesn't measure how the interviewer conducted the session; it measures whether what they *asked about* matches what the company *posted and priced* the role at. It only runs if the user has supplied the original JD text (see Inputs). If not supplied, skip this step entirely — it does not block or degrade Steps 2–6.
+
+Check, per session:
+
+1. **Off-JD topic** — did the interviewer ask about a specific skill, tool, or scope of responsibility that has **zero textual grounding anywhere in the JD** (not a rephrasing, not an adjacent/implied skill — genuinely absent from the posted text)? Quote the JD and the transcript question side by side to confirm before flagging; do not infer an absence you haven't checked.
+2. **Entry-level/junior framing** — does the JD title or body label the role entry-level, junior, associate, coordinator-tier, or similar, **and** does the posted pay band sit at the low end for that title/market (use whatever pay information the JD or the user's notes provide — don't estimate market rate yourself)?
+
+Flag **Scope/Compensation Mismatch** only when both conditions hold in the same session: an off-JD topic surfaced during a JD-labeled entry-level, low-band role.
+
+**This signal is corroboration-sensitive, not a count-and-threshold signal like the four above.** A single instance is a data point, not a pattern — say so plainly in the output. If the user has a coffee chat note or other independent source for the same company (see #1940 / PR #1941, the coffee-chat cross-reference feature — a sibling to this one), check whether it corroborates that the off-JD topic is something the company consistently screens for. Corroboration changes the framing from "isolated tangent" to "observed pattern" — reflect that distinction explicitly rather than folding it into a score.
+
 ## Step 3 — Aggregate Per Company
 
 For each company, count how many sessions triggered each signal type.
@@ -78,6 +92,8 @@ Compute a **red-flag score**:
 - Each signal type present in **1 session**: +1
 - Each signal type present in **2+ sessions** (pattern, not noise): +2
 - Maximum possible: 8 (4 signal types × 2)
+
+**Scope/Compensation Mismatch (Step 2b) is reported separately and does not feed the red-flag score above.** It's a different category of finding — JD-completeness and pay fairness, not interviewer conduct — and, unlike the four signals above, it's discovered *after* the fact rather than protecting the candidate in the process that produced it. Mixing it into the same 0–8 scale would overstate or understate it depending on session count for reasons unrelated to what it actually measures. Report it in its own output section (Step 5) instead.
 
 ## Step 4 — Assign Warning Level
 
@@ -124,6 +140,22 @@ Write the following structure:
 *Analysis based on interviewer behaviour only. Candidate decides.*
 ```
 
+**If Step 2b flagged a Scope/Compensation Mismatch**, append this section (omit entirely if Step 2b was skipped or found nothing):
+
+```markdown
+### Scope/Compensation Mismatch
+
+**Round:** {round} ({date})
+**Off-JD topic asked about:** {specific skill/topic}, absent from the posted JD text for {role}.
+**JD context:** posted as {entry-level/junior/associate/etc.} at {stated pay band, if given}.
+
+{1–2 sentences, descriptive not accusatory: what was asked, and how it sits outside the JD's stated scope and pay level. E.g. "The interviewer asked directly about workflow automation experience — a skill not mentioned anywhere in the JD, which is posted as an entry-level, non-technical role at the low end of its stated band."}
+
+**Evidence strength:** {"Single instance — one data point, not yet a pattern. Treat as an open question, not a conclusion." OR, if a coffee chat or other independent source corroborates it: "Corroborated by [coffee chat note / other source] (see #1940 / PR #1941) — this reads as something the company consistently screens for, not an isolated tangent."}
+
+*This does not feed the red-flag score above — it's a separate JD-completeness/pay-fairness observation, not a measure of interviewer conduct.*
+```
+
 ## Step 6 — Present Summary
 
 After writing the file, show the user:
@@ -137,6 +169,7 @@ Warning level:   {emoji} {label}
 Signals:
   • {signal}: {n}/{total} sessions {(pattern) if 2+}
   ...
+{If Step 2b flagged: "  • Scope/Compensation Mismatch: {round} — {off-JD topic} asked at entry-level pay {(corroborated) if a coffee chat or other source confirms it}"}
 
 → Full analysis written to interview-prep/{company-slug}-redflags.md
 ```
@@ -158,3 +191,4 @@ Company          Rounds   Level
 - **Privacy** — reads only local, gitignored session files. Nothing leaves the machine.
 - **Not a Glassdoor replacement** — analyses this candidate's live experience in this process, not crowd-sourced opinion.
 - **Candidate-side analysis is out of scope** — use `realign-targeting` (#960) for that.
+- **Scope/Compensation Mismatch (Step 2b) is descriptive, not actionable-in-the-moment** — by the time it's detected, the interview that produced it is already over, so it can't protect the candidate in that specific round. It's written to the company-level file as a record: if a later round with the same company happens, or the candidate considers re-applying, this is the place to check first. It is not fed automatically into `interview-prep/{company}-{role}.md` or any future prep step — the candidate re-reads it manually, the same way every other output of this mode is advisory-only.

--- a/modes/interview-redflag.md
+++ b/modes/interview-redflag.md
@@ -77,12 +77,16 @@ This is a **separate, fifth dimension** — distinct from the four interviewer-b
 
 Check, per session:
 
-1. **Off-JD topic** — did the interviewer ask about a specific skill, tool, or scope of responsibility that has **zero textual grounding anywhere in the JD** (not a rephrasing, not an adjacent/implied skill — genuinely absent from the posted text)? Quote the JD and the transcript question side by side to confirm before flagging; do not infer an absence you haven't checked.
-2. **Entry-level/junior framing** — does the JD title or body label the role entry-level, junior, associate, coordinator-tier, or similar, **and** does the posted pay band sit at the low end for that title/market (use whatever pay information the JD or the user's notes provide — don't estimate market rate yourself)?
+0. **Role match (gate, run first)** — confirm the session's role slug (from the filename pattern in Step 1) matches the role the supplied JD is for. The mode can analyze multiple role slugs for one company, but the supplied JD is for a single role — a session for a different role must never be compared against it. If the match can't be confirmed explicitly (ambiguous slug, JD role unclear, or the user hasn't stated which role the JD is for), **skip this session for Step 2b entirely** — do not run conditions 1–2 below on it, and do not guess.
 
-Flag **Scope/Compensation Mismatch** only when both conditions hold in the same session: an off-JD topic surfaced during a JD-labeled entry-level, low-band role.
+1. **Off-JD topic** — did the interviewer ask about a specific skill, tool, or scope of responsibility that has **zero textual grounding anywhere in the JD** (not a rephrasing, not an adjacent/implied skill — genuinely absent from the posted text)? Quote the JD and the transcript question side by side to confirm before flagging; do not infer an absence you haven't checked.
+2. **Entry-level/junior framing** — does the JD title or body label the role entry-level, junior, associate, coordinator-tier, or similar, **and** is there an **explicit** benchmark establishing the posted pay band as low-end for that title/market — either the JD itself states a specific pay figure alongside the entry-level/junior/associate/coordinator-tier label, or the user's own notes explicitly classify it as below market for that title (e.g. "this is below market for a coordinator role")? **Never estimate or infer market compensation yourself.** If no such explicit benchmark or classification is present in the JD text or the user's notes, treat this condition as unmet — do not flag the mismatch on the basis of an inferred or assumed market rate.
+
+Flag **Scope/Compensation Mismatch** only when all conditions hold for the same session: the session's role is confirmed to match the supplied JD (condition 0), an off-JD topic surfaced (condition 1), during a JD-labeled entry-level/junior/associate/coordinator-tier role with an explicit low-band pay benchmark (condition 2).
 
 **This signal is corroboration-sensitive, not a count-and-threshold signal like the four above.** A single instance is a data point, not a pattern — say so plainly in the output. If the user has a coffee chat note or other independent source for the same company (see #1940 / PR #1941, the coffee-chat cross-reference feature — a sibling to this one), check whether it corroborates that the off-JD topic is something the company consistently screens for. Corroboration changes the framing from "isolated tangent" to "observed pattern" — reflect that distinction explicitly rather than folding it into a score.
+
+**Multiple sessions may qualify.** Evaluate every session independently against conditions 0–2; do not stop at the first match. Carry forward every qualifying session (round, date, off-JD topic, JD context including the seniority label actually captured, evidence strength) into Step 5/6 — see the aggregation rule there.
 
 ## Step 3 — Aggregate Per Company
 
@@ -140,18 +144,23 @@ Write the following structure:
 *Analysis based on interviewer behaviour only. Candidate decides.*
 ```
 
-**If Step 2b flagged a Scope/Compensation Mismatch**, append this section (omit entirely if Step 2b was skipped or found nothing):
+**If Step 2b flagged one or more Scope/Compensation Mismatches**, append this section (omit entirely if Step 2b was skipped or found nothing across all sessions):
 
 ```markdown
 ### Scope/Compensation Mismatch
 
-**Round:** {round} ({date})
-**Off-JD topic asked about:** {specific skill/topic}, absent from the posted JD text for {role}.
-**JD context:** posted as {entry-level/junior/associate/etc.} at {stated pay band, if given}.
+{One entry per qualifying session, most recent first. Do not collapse multiple sessions into a single entry — each qualifying session gets its own full entry below.}
 
-{1–2 sentences, descriptive not accusatory: what was asked, and how it sits outside the JD's stated scope and pay level. E.g. "The interviewer asked directly about workflow automation experience — a skill not mentioned anywhere in the JD, which is posted as an entry-level, non-technical role at the low end of its stated band."}
+#### {round} ({date})
+
+**Off-JD topic asked about:** {specific skill/topic}, absent from the posted JD text for {role}.
+**JD context:** posted as {the actual seniority label captured in Step 2b — junior / associate / coordinator-tier / entry-level / etc.} at {stated pay band, with the explicit benchmark that qualified it as low-end}.
+
+{1–2 sentences, descriptive not accusatory: what was asked, and how it sits outside the JD's stated scope and pay level. E.g. "The interviewer asked directly about workflow automation experience — a skill not mentioned anywhere in the JD, which is posted as a coordinator-tier, non-technical role at the low end of its stated band."}
 
 **Evidence strength:** {"Single instance — one data point, not yet a pattern. Treat as an open question, not a conclusion." OR, if a coffee chat or other independent source corroborates it: "Corroborated by [coffee chat note / other source] (see #1940 / PR #1941) — this reads as something the company consistently screens for, not an isolated tangent."}
+
+{repeat the #### block above for each additional qualifying session}
 
 *This does not feed the red-flag score above — it's a separate JD-completeness/pay-fairness observation, not a measure of interviewer conduct.*
 ```
@@ -169,7 +178,9 @@ Warning level:   {emoji} {label}
 Signals:
   • {signal}: {n}/{total} sessions {(pattern) if 2+}
   ...
-{If Step 2b flagged: "  • Scope/Compensation Mismatch: {round} — {off-JD topic} asked at entry-level pay {(corroborated) if a coffee chat or other source confirms it}"}
+{If Step 2b flagged one or more sessions, list all of them here, most recent first — one bullet per qualifying session, do not collapse into a single line:
+  • Scope/Compensation Mismatch: {round} — {off-JD topic} asked at {the actual seniority label captured in Step 2b, e.g. junior/associate/coordinator-tier/entry-level} pay {(corroborated) if a coffee chat or other source confirms it}
+  ...}
 
 → Full analysis written to interview-prep/{company-slug}-redflags.md
 ```


### PR DESCRIPTION
## Scoping decision

Issue #1942 left the actionable shape open with three options: a watchlist-style note, feeding into `interview-prep` for a future round, or a structured field on `interview-redflag`'s existing output. I went with **option 3** (structured field/section on `interview-redflag`'s output) after reading `modes/interview-redflag.md` (#1233) in full.

Reasoning:
- `interview-redflag` already ingests interview transcripts — the only place this signal (interviewer asking about something off-JD) is observable from.
- It's already the established pattern for "something surfaced during an interview that's worth flagging," matching #1854/PR #1856's precedent (blacklist suggestion added to this same mode's existing signal breakdown).
- A watchlist-style file or a hook into `interview-prep.md` would be a second output path for the same underlying observation this mode already owns, and would require touching or creating additional user-layer surface for a signal that's really a *variant* of "what did the interviewer's behavior reveal about this company" — which is squarely `interview-redflag`'s job.

## What changed

`modes/interview-redflag.md`:

- New input: the original JD text (user-provided — same "paste it or point at `local:jds/{file}`" pattern used by `jd-skill-gap.mjs`). Optional; only needed for the new step.
- New **Step 2b — Detect Scope/Compensation Mismatch**: checks, per session, whether (1) the interviewer asked about a skill/topic with zero textual grounding anywhere in the JD, and (2) the JD labels the role entry-level/junior with a correspondingly low pay band. Both conditions must hold in the same session to flag.
- Kept **out of the existing 4-signal red-flag score** (Step 3) on purpose — it's a different category of finding (JD-completeness / pay fairness, discovered only *after* the interview) from the four interviewer-conduct signals, which are about how the interviewer behaved and are discoverable pre-decision. Mixing it into the 0–8 scale would distort both.
- New output section in Step 5, and a summary line in Step 6, when the signal fires.
- Output language is descriptive/corroborating, matching the mode's existing non-alarmist tone — not accusatory.
- Explicitly notes a single instance is a data point, not a pattern, and points at the sibling coffee-chat cross-reference feature (**#1940 / PR #1941**, not yet merged) as the corroboration path when the user has an independent source for the same company.
- Added a line to the Scope/Non-Goals section clarifying this is descriptive/retrospective (can't protect the candidate in the round that produced it) and isn't auto-fed into any future prep file — same advisory-only posture as the rest of the mode.

No new script — this whole feature family (#1233, #1854/#1856) has been prompt-instruction-only, and a fifth transcript-classification dimension didn't need to break that pattern.

## Test plan

- [x] `node test-all.mjs --quick` — 1739 passed, 0 failed (1 pre-existing CRLF warning unrelated to this change)
- [x] Only `modes/interview-redflag.md` touched — no `data/`, `cv.md`, `config/profile.yml`, or other user-layer files modified

Closes #1942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Step 2b check for potential scope/compensation mismatch between the interview and the original job description (runs only when original JD text is provided and the role explicitly matches).
  * Included a dedicated advisory section that lists qualifying sessions with the off-JD topic, captured JD seniority/pay context, and corroboration-sensitive evidence wording.
  * Reported the mismatch findings separately (not included in the existing 0–8 red-flag score) and surfaced them in the Step 5/Step 6 outputs for later manual re-checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->