### PR TITLE
chore(eval): update default Gemini model to gemini-3.5-flash

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -166,7 +166,7 @@ node gemini-eval.mjs --file ./jds/my-job.txt
 npm run gemini:eval -- "职位描述文本"
 ```
 
-> **免费层：** 两种选项都无需付费。原生 CLI 使用 Google OAuth；API 脚本使用 `gemini-2.0-flash`（15 RPM，每天 1M token 免费）。
+> **免费层：** 两种选项都无需付费。原生 CLI 使用 Google OAuth；API 脚本使用 `gemini-3.6-flash`（速率限制取决于模型和层级；请参阅 Google AI 文档了解当前配额）。
 
 
 ## 用法

--- a/README.fr.md
+++ b/README.fr.md
@@ -173,7 +173,7 @@ node gemini-eval.mjs --file ./jds/my-job.txt
 npm run gemini:eval -- "Texte de la description de poste ici"
 ```
 
-> **Offre gratuite :** Les deux options fonctionnent sans facturation. Le CLI natif utilise l'authentification OAuth Google ; le script d'API utilise `gemini-2.5-flash` (15 requêtes/min, 1M de jetons/jour gratuits).
+> **Offre gratuite :** Les deux options fonctionnent sans facturation. Le CLI natif utilise l'authentification OAuth Google ; le script d'API utilise `gemini-3.6-flash` (les limites de requêtes dépendent du modèle et du niveau d'accès ; voir la documentation Google AI pour les quotas actuels).
 
 ## Utilisation
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ node gemini-eval.mjs --file ./jds/my-job.txt
 npm run gemini:eval -- "JD text here"
 ```
 
-> **Free tier:** Both options work without billing. Native CLI uses Google OAuth; the API script uses `gemini-2.5-flash` (15 RPM, 1M tokens/day free).
+> **Free tier:** Both options work without billing. Native CLI uses Google OAuth; the API script uses `gemini-3.6-flash` (rate limits are model- and tier-dependent; see Google AI docs for current quotas).
 
 ## Usage
 


### PR DESCRIPTION
## What does this PR do?

This PR updates the default Gemini model used in `gemini-eval.mjs` and mentioned in the README docs from `gemini-2.5-flash` to `gemini-3.5-flash`. The previous default `gemini-2.5-flash` reached its deprecation in June 2026 and was deactivated by Google in July 2026, causing evaluations to fail.

## Related issue

Fixes #1958

## Type of change

- [x] Documentation / translation
- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] I linked a related issue above (required for features and architecture changes)
- [x] My PR does not include personal data (CV, email, real names)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the default Gemini model to `gemini-3.5-flash`.
  * Preserved support for overriding the model via command-line options or environment settings.

* **Documentation**
  * Updated English, French, and Chinese documentation to reflect the new default model.
  * Clarified that free-tier limits are model- and tier-dependent, and that billing is not required for the standalone API script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->