### PR TITLE
fix(web): skip {n}-RESERVED.md sentinels when locating a report file

### DIFF
--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -222,7 +222,19 @@ export type ReportData = { content: string; file: string };
  *  resolving only by leading filename number misses those. Links are
  *  normalized relative to the tracker file's directory (see #760). Falls back
  *  to the filename scan (reports/{n}-{slug}-{date}.md, possibly zero-padded)
- *  for rows without a parseable link. */
+ *  for rows without a parseable link.
+ *
+ *  The fallback scan skips `{n}-RESERVED.md` placeholder files.
+ *  `reserve-report-num.mjs` writes an empty `NNN-RESERVED.md` sentinel to
+ *  claim a report number before a worker has actually written the report;
+ *  it's normally deleted once the real report lands (or GC'd after 4h if
+ *  abandoned). But "RESERVED" sorts alphabetically before nearly every real
+ *  slug (company names start with lowercase/uppercase letters after the
+ *  number-dash, "R" often lands mid-alphabet or earlier), so if a sentinel
+ *  outlives its report — e.g. a worker was driven directly instead of
+ *  through the orchestrator that owns cleanup — `.find()` could return the
+ *  empty sentinel instead of the real report, making the report body and the
+ *  Apply/PDF-ready checks disappear. */
 export function findReportFile(n: string): string | null {
   const target = parseInt(n, 10);
   if (Number.isNaN(target)) return null;
@@ -240,7 +252,9 @@ export function findReportFile(n: string): string | null {
   } catch {
     return null;
   }
-  const match = files.find((f) => f.endsWith(".md") && parseInt(f, 10) === target);
+  const match = files.find(
+    (f) => f.endsWith(".md") && !/^\d+-RESERVED\.md$/.test(f) && parseInt(f, 10) === target,
+  );
   if (!match) return null;
   const p = path.join(root, "reports", match);
   return containedRealpath(p, root) ? p : null;

--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -224,7 +224,8 @@ export type ReportData = { content: string; file: string };
  *  to the filename scan (reports/{n}-{slug}-{date}.md, possibly zero-padded)
  *  for rows without a parseable link.
  *
- *  The fallback scan skips `{n}-RESERVED.md` placeholder files.
+ *  Both the linked lookup and the fallback scan skip `{n}-RESERVED.md`
+ *  placeholder files.
  *  `reserve-report-num.mjs` writes an empty `NNN-RESERVED.md` sentinel to
  *  claim a report number before a worker has actually written the report;
  *  it's normally deleted once the real report lands (or GC'd after 4h if
@@ -235,6 +236,12 @@ export type ReportData = { content: string; file: string };
  *  through the orchestrator that owns cleanup — `.find()` could return the
  *  empty sentinel instead of the real report, making the report body and the
  *  Apply/PDF-ready checks disappear. */
+/** True for a `{n}-RESERVED.md` placeholder sentinel — never a real report,
+ *  whichever branch below found it. */
+function isReservedReportFile(file: string): boolean {
+  return /^\d+-RESERVED\.md$/.test(path.basename(file));
+}
+
 export function findReportFile(n: string): string | null {
   const target = parseInt(n, 10);
   if (Number.isNaN(target)) return null;
@@ -244,7 +251,7 @@ export function findReportFile(n: string): string | null {
   if (linked) {
     const p = path.resolve(root, "data", linked);
     // Containment: a hand-edited link must not resolve outside the project.
-    if (p.endsWith(".md") && containedRealpath(p, root)) return p;
+    if (p.endsWith(".md") && !isReservedReportFile(p) && containedRealpath(p, root)) return p;
   }
   let files: string[];
   try {
@@ -253,7 +260,7 @@ export function findReportFile(n: string): string | null {
     return null;
   }
   const match = files.find(
-    (f) => f.endsWith(".md") && !/^\d+-RESERVED\.md$/.test(f) && parseInt(f, 10) === target,
+    (f) => f.endsWith(".md") && !isReservedReportFile(f) && parseInt(f, 10) === target,
   );
   if (!match) return null;
   const p = path.join(root, "reports", match);


### PR DESCRIPTION
## What does this PR do?

`findReportFile()` in `web/src/lib/career-ops.ts` locates a report by
scanning `reports/*.md` for a filename whose leading number matches the
requested id (`parseInt(f, 10) === target`). `reserve-report-num.mjs`
writes an empty `{n}-RESERVED.md` sentinel to claim a report number before
a worker has actually written the report, normally deleting it once the
real report lands.

If a sentinel outlives its report — e.g. a worker is driven directly
(`claude -p`) instead of through the orchestrator (`batch-runner.sh`) that
owns cleanup — both files parse to the same leading number, and
`"RESERVED"` sorts alphabetically before almost every real company slug.
`.find()` picked the empty sentinel over the real report. Downstream
effects observed on a live instance:

- The report page (`/pipeline/{id}`) rendered no body — `readReport()`
  returned the sentinel's empty content.
- The **Apply button locked** with "No application URL on this report" —
  `parseReport()` found no `**URL:**` field in the empty content, so
  `ReportView`'s `url` stayed undefined regardless of the tracker/PDF
  state.

The fix excludes `{n}-RESERVED.md` from the match so a real report always
wins over a lingering sentinel for the same number.

## Related issue

None filed — found via a live repro while debugging a locked Apply button,
fixed directly per the bug-fix exemption.

## Type of change

- [x] Bug fix

## Testing

- [x] `node test-all.mjs` — 1740 passed, 0 failed
- [x] `web` `npx tsc --noEmit` — clean
- [x] `web` `npm run build` — clean
- [x] Manual: reproduced against a live instance — an empty `026-RESERVED.md`
      left behind after a report was written for #26 caused exactly this
      symptom (empty report body, locked Apply button); deleting the
      sentinel fixed it, confirming the mechanism, then the code fix
      applied here makes the sentinel harmless even if left behind.
- [x] Fixture: built an isolated `reports/` dir with a real report +
      a same-numbered stale sentinel and confirmed `.find()` picks the
      sentinel pre-fix and the real report post-fix (4/4 assertions,
      including that a number with *only* a sentinel — report not yet
      written — still correctly resolves to nothing).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] This is a bug fix (issue-first requirement exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected report selection to skip reserved placeholder files.
  * Ensured report reads return the actual report content when a reserved placeholder exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->