### PR TITLE
Sync tracker PDF column from data/pdf-index.tsv (#1429)

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -20,6 +20,7 @@ import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
 import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
+import { parsePdfIndex } from './find.mjs';
 import { LEGACY_COLMAP, detectColumns, resolveScoreStatus, normalizeVia } from './tracker-parse.mjs';
 import { resolveTrackerPath, trackerLockDirFor, acquireTrackerLock, writeFileAtomic, normalizeCompany, cell } from './tracker-utils.mjs';
 
@@ -47,6 +48,7 @@ const TRACKER_LOCK_DIR = trackerLockDirFor(APPS_FILE);
 // The reports/ dir sits at the repo root, which is the tracker's parent in the
 // data/ layout (data/applications.md) and the tracker's own dir at root layout.
 const REPORTS_ROOT = basename(TRACKER_DIR) === 'data' ? dirname(TRACKER_DIR) : TRACKER_DIR;
+const PDF_INDEX_FILE = join(REPORTS_ROOT, 'data', 'pdf-index.tsv');
 
 /**
  * Normalize report links before writing them into the tracker file.
@@ -203,6 +205,53 @@ function extractReqNumber(notes) {
 function parseScore(s) {
   const m = s.replace(/\*\*/g, '').match(/([\d.]+)/);
   return m ? parseFloat(m[1]) : 0;
+}
+
+/**
+ * Load the optional generated-PDF manifest.
+ *
+ * data/pdf-index.tsv is gitignored and only exists after generate-pdf.mjs has
+ * written at least one PDF. Missing manifest = nothing to sync.
+ *
+ * @returns {Map<string,string>} Normalized report# → PDF path.
+ */
+function loadPdfIndex() {
+  return existsSync(PDF_INDEX_FILE)
+    ? parsePdfIndex(readFileSync(PDF_INDEX_FILE, 'utf-8'))
+    : new Map();
+}
+
+/**
+ * Flip stale PDF cells to ✅ when the generated-PDF manifest has the row's
+ * report number.
+ *
+ * @param {Array<object>} existingApps - Parsed tracker rows.
+ * @param {string[]} appLines - Mutable tracker file lines.
+ * @param {Map<string,string>} pdfIndex - Normalized report# → PDF path.
+ * @returns {number} Number of tracker rows updated.
+ */
+function syncPdfFlags(existingApps, appLines, pdfIndex) {
+  let changed = 0;
+  if (pdfIndex.size === 0) return changed;
+
+  for (const app of existingApps) {
+    const reportNum = extractReportNum(app.report);
+    if (!reportNum || !pdfIndex.has(String(reportNum)) || app.pdf !== '❌') continue;
+
+    const lineIdx = appLines.indexOf(app.raw);
+    if (lineIdx < 0) continue;
+
+    console.log(`${DRY_RUN ? '🔄 PDF sync (dry-run)' : '🔄 PDF sync'}: #${app.num} ${app.company} — report ${reportNum} now has a generated PDF`);
+    if (!DRY_RUN) {
+      const updatedLine = buildRow({ ...app, pdf: '✅' });
+      appLines[lineIdx] = updatedLine;
+      app.pdf = '✅';
+      app.raw = updatedLine;
+    }
+    changed++;
+  }
+
+  return changed;
 }
 
 // Column layout for the applications.md table. The tracker may use the original
@@ -503,16 +552,27 @@ for (const line of appLines) {
 }
 
 console.log(`📊 Existing: ${existingApps.length} entries, max #${maxNum}`);
+let added = 0;
+let updated = 0;
+let skipped = 0;
+const pdfSynced = syncPdfFlags(existingApps, appLines, loadPdfIndex());
+updated += pdfSynced;
 
 // Read tracker additions
 if (!existsSync(ADDITIONS_DIR)) {
   console.log('No tracker-additions directory found.');
+  if (pdfSynced > 0 && !DRY_RUN) writeFileAtomic(APPS_FILE, appLines.join('\n'));
+  if (DRY_RUN) console.log('(dry-run — no changes written)');
+  trackerLock.release();
   process.exit(0);
 }
 
 const tsvFiles = readdirSync(ADDITIONS_DIR).filter(f => f.endsWith('.tsv'));
 if (tsvFiles.length === 0) {
   console.log('✅ No pending additions to merge.');
+  if (pdfSynced > 0 && !DRY_RUN) writeFileAtomic(APPS_FILE, appLines.join('\n'));
+  if (DRY_RUN) console.log('(dry-run — no changes written)');
+  trackerLock.release();
   process.exit(0);
 }
 
@@ -525,9 +585,6 @@ tsvFiles.sort((a, b) => {
 
 console.log(`📥 Found ${tsvFiles.length} pending additions`);
 
-let added = 0;
-let updated = 0;
-let skipped = 0;
 const newLines = [];
 
 for (const file of tsvFiles) {

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -555,7 +555,8 @@ console.log(`📊 Existing: ${existingApps.length} entries, max #${maxNum}`);
 let added = 0;
 let updated = 0;
 let skipped = 0;
-const pdfSynced = syncPdfFlags(existingApps, appLines, loadPdfIndex());
+const pdfIndex = loadPdfIndex();
+const pdfSynced = syncPdfFlags(existingApps, appLines, pdfIndex);
 updated += pdfSynced;
 
 // Read tracker additions
@@ -676,11 +677,12 @@ for (const file of tsvFiles) {
       console.log(`🔄 Update: #${duplicate.num} ${addition.company} — ${addition.role} (${oldScore}→${newScore})`);
       const lineIdx = appLines.indexOf(duplicate.raw);
       if (lineIdx >= 0) {
+        const pdf = reportNum && pdfIndex.has(String(reportNum)) ? '✅' : duplicate.pdf;
         const updatedLine = buildRow({
           num: duplicate.num, date: addition.date, company: addition.company, role: addition.role,
           via: addition.via || duplicate.via || '—',
           location: addition.location || duplicate.location || '—',
-          score: addition.score, status: duplicate.status, pdf: duplicate.pdf,
+          score: addition.score, status: duplicate.status, pdf,
           report: addition.report,
           notes: `Re-eval ${addition.date} (${oldScore}→${newScore}). ${addition.notes}`,
         });
@@ -711,11 +713,12 @@ for (const file of tsvFiles) {
     usedNumbers.add(entryNum);
     if (entryNum > maxNum) maxNum = entryNum;
 
+    const pdf = reportNum && pdfIndex.has(String(reportNum)) ? '✅' : addition.pdf;
     const newLine = buildRow({
       num: entryNum, date: addition.date, company: addition.company, role: addition.role,
       via: addition.via || '—',
       location: addition.location || '—',
-      score: addition.score, status: addition.status, pdf: addition.pdf,
+      score: addition.score, status: addition.status, pdf,
       report: addition.report, notes: addition.notes,
     });
     newLines.push(newLine);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5312,6 +5312,69 @@ try {
   fail(`merge-tracker column-order tests crashed: ${e.message}`);
 }
 
+// ── MERGE-TRACKER PDF FLAG SYNC (#1429) ─────────────────────────
+// generate-pdf.mjs can run after the tracker row already exists. The
+// gitignored data/pdf-index.tsv manifest is the source of truth that the row's
+// PDF was generated, so merge-tracker should flip only matching ❌ cells to ✅.
+console.log('\n🧪 Testing merge-tracker PDF flag sync from data/pdf-index.tsv (#1429)...');
+try {
+  const runPdfSyncFixture = (name, trackerRow, pdfIndex = null) => {
+    const tmp = mkdtempSync(join(tmpdir(), `career-ops-merge-pdf-${name}-`));
+    mkdirSync(join(tmp, 'data'), { recursive: true });
+    const additionsDir = join(tmp, 'additions');
+    const tracker = join(tmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      trackerRow + '\n');
+    if (pdfIndex !== null) writeFileSync(join(tmp, 'data', 'pdf-index.tsv'), pdfIndex);
+
+    const result = run(NODE, ['merge-tracker.mjs'], {
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: additionsDir },
+    });
+    const merged = readFileSync(tracker, 'utf-8');
+    rmSync(tmp, { recursive: true, force: true });
+    return { result, merged };
+  };
+
+  const matching = runPdfSyncFixture(
+    'match',
+    '| 7 | 2026-01-04 | Acme | Engineer | 4.2/5 | Evaluated | ❌ | [12](../reports/012-acme-2026-01-04.md) | ok |',
+    '# report\tpdf\thtml\tformat\tdate\n' +
+      '012\toutput/cv-acme.pdf\toutput/cv-acme.html\tletter\t2026-01-04\n',
+  );
+  if (matching.result !== null && matching.merged.includes('| ✅ | [12](../reports/012-acme-2026-01-04.md) |')) {
+    pass('merge-tracker flips a stale ❌ PDF cell when pdf-index.tsv has the row report number');
+  } else {
+    fail('merge-tracker did not flip the matching PDF cell from ❌ to ✅');
+  }
+
+  const nonMatching = runPdfSyncFixture(
+    'miss',
+    '| 8 | 2026-01-05 | Globex | Analyst | 3.8/5 | Evaluated | ❌ | [22](../reports/022-globex-2026-01-05.md) | ok |',
+    '# report\tpdf\thtml\tformat\tdate\n' +
+      '023\toutput/cv-other.pdf\toutput/cv-other.html\tletter\t2026-01-05\n',
+  );
+  if (nonMatching.result !== null && nonMatching.merged.includes('| ❌ | [22](../reports/022-globex-2026-01-05.md) |')) {
+    pass('merge-tracker leaves PDF ❌ when the report number is absent from pdf-index.tsv');
+  } else {
+    fail('merge-tracker produced a false-positive PDF sync for a missing report number');
+  }
+
+  const missingManifest = runPdfSyncFixture(
+    'missing',
+    '| 9 | 2026-01-06 | Initech | Manager | 3.9/5 | Evaluated | ❌ | [31](../reports/031-initech-2026-01-06.md) | ok |',
+  );
+  if (missingManifest.result !== null && missingManifest.merged.includes('| ❌ | [31](../reports/031-initech-2026-01-06.md) |')) {
+    pass('merge-tracker runs successfully when data/pdf-index.tsv does not exist');
+  } else {
+    fail('merge-tracker crashed or changed the PDF cell when pdf-index.tsv was missing');
+  }
+} catch (e) {
+  fail(`merge-tracker PDF flag sync test crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER REPORT-NUMBER COLLISION (#912) ─────────────────
 // The report-number dedup check was not company-guarded: a TSV for NewCo
 // with report [1] would find the existing tracker row [1] for OtherCo and

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5318,7 +5318,7 @@ try {
 // PDF was generated, so merge-tracker should flip only matching ❌ cells to ✅.
 console.log('\n🧪 Testing merge-tracker PDF flag sync from data/pdf-index.tsv (#1429)...');
 try {
-  const runPdfSyncFixture = (name, trackerRow, pdfIndex = null) => {
+  const runPdfSyncFixture = (name, trackerRow, pdfIndex = null, additions = []) => {
     const tmp = mkdtempSync(join(tmpdir(), `career-ops-merge-pdf-${name}-`));
     mkdirSync(join(tmp, 'data'), { recursive: true });
     const additionsDir = join(tmp, 'additions');
@@ -5329,13 +5329,22 @@ try {
       '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
       trackerRow + '\n');
     if (pdfIndex !== null) writeFileSync(join(tmp, 'data', 'pdf-index.tsv'), pdfIndex);
+    if (additions.length > 0) {
+      mkdirSync(additionsDir, { recursive: true });
+      for (const addition of additions) {
+        writeFileSync(join(additionsDir, addition.name), addition.content);
+      }
+    }
 
+    try {
     const result = run(NODE, ['merge-tracker.mjs'], {
       env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: additionsDir },
     });
     const merged = readFileSync(tracker, 'utf-8');
-    rmSync(tmp, { recursive: true, force: true });
     return { result, merged };
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   };
 
   const matching = runPdfSyncFixture(
@@ -5370,6 +5379,22 @@ try {
     pass('merge-tracker runs successfully when data/pdf-index.tsv does not exist');
   } else {
     fail('merge-tracker crashed or changed the PDF cell when pdf-index.tsv was missing');
+  }
+
+  const newAddition = runPdfSyncFixture(
+    'new-addition',
+    '',
+    '# report\tpdf\thtml\tformat\tdate\n' +
+      '041\toutput/cv-umbrella.pdf\toutput/cv-umbrella.html\tletter\t2026-01-07\n',
+    [{
+      name: '001-umbrella.tsv',
+      content: '1\t2026-01-07\tUmbrella\tEngineer\t4.1/5\tEvaluated\t❌\t[41](../reports/041-umbrella-2026-01-07.md)\tok\n',
+    }],
+  );
+  if (newAddition.result !== null && newAddition.merged.includes('| 1 | 2026-01-07 | Umbrella | Engineer | 4.1/5 | Evaluated | ✅ | [41](../reports/041-umbrella-2026-01-07.md) | ok |')) {
+    pass('merge-tracker applies pdf-index.tsv to a newly merged tracker row in the same run');
+  } else {
+    fail('merge-tracker left a newly merged row at ❌ despite a matching pdf-index.tsv entry');
   }
 } catch (e) {
   fail(`merge-tracker PDF flag sync test crashed: ${e.message}`);


### PR DESCRIPTION
Fixes #1429.

Syncs stale tracker PDF flags from `data/pdf-index.tsv` during `merge-tracker.mjs`.
When a PDF is generated after a tracker row already exists, the tracker's PDF
column could remain `❌` indefinitely.

`merge-tracker.mjs` now reuses the existing `parsePdfIndex()` logic from
`find.mjs`, reads the optional generated PDF manifest, and flips matching
tracker rows from `❌` to `✅` based on the row's report number.

**Note:   the manifest parser actually lives in `find.mjs` — the original
issue comment pointed at `merge-tracker.mjs`, but I found the reusable
`parsePdfIndex()` function in `find.mjs` instead and imported it here.
- Adds 3 regression tests in `test-all.mjs`: matching report, non-matching
  report, and missing manifest.

<img width="1452" height="864" alt="contri" src="https://github.com/user-attachments/assets/3c2edf83-4457-4ae6-8e69-fd903029a3b8" />




 happy to address any feedback!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tracker PDF statuses now automatically update when matching generated reports are listed in the PDF manifest.
  * PDF status synchronization works even when there are no pending tracker additions.
  * Dry-run mode reports synchronization changes without modifying files.

* **Bug Fixes**
  * Tracker processing now safely handles missing or incomplete PDF manifests.

* **Tests**
  * Added coverage for matching, non-matching, and missing PDF manifest scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->