### PR TITLE
fix(web): prevent Codex run jobs from waiting on stdin

### DIFF
--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -117,7 +117,12 @@ export async function POST(req: Request) {
   // (tracker.mjs delete doesn't yet share a lock with merge-tracker — see run-registry).
   const writeToken = kind === "evaluate" || kind === "pdf" ? acquireTrackerWrite() : null;
 
-  const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env });
+  // stdin = /dev/null so the CLI doesn't wait on piped input (the /api/apply/prefill
+  // route already does this; Codex's `exec` in particular blocks reading stdin for
+  // additional context otherwise — confirmed it hangs until the kill timer, then
+  // reports a generic "installed and authenticated?" error that reads as an auth
+  // failure even though the CLI is fully signed in).
+  const child = spawn(binPath, args, { cwd: careerOpsRoot(), env: process.env, stdio: ["ignore", "pipe", "pipe"] });
   // Decode once on the stream, not per chunk. Buffer#toString() decodes each chunk
   // independently, so a chunk boundary falling inside a multi-byte UTF-8 sequence
   // yields a replacement character and mis-decodes the bytes after it. Those bytes


### PR DESCRIPTION
## Summary
- spawn /api/run CLI children with stdin ignored, matching the apply prefill route
- prevents Codex exec jobs from hanging on an open stdin pipe until the kill timer
- avoids the misleading installed/authenticated error after timeout

## Verification
- npm test --prefix web
- npm run typecheck --prefix web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution reliability by preventing processes from waiting for input.
  * Ensured command output and error messages continue streaming correctly during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->