### PR TITLE
fix(scan): hide unconfigured salary/content filter summaries

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -1695,8 +1695,12 @@ async function main() {
   if (config.max_posting_age_days != null || totalFilteredPostingAge > 0) {
     console.log(`Filtered by age:       ${totalFilteredPostingAge} removed`);
   }
-  console.log(`Filtered by salary:   ${totalFilteredSalary} removed`);
-  console.log(`Filtered by content:  ${totalFilteredContent} removed`);
+  if (config.salary_filter || totalFilteredSalary > 0) {
+    console.log(`Filtered by salary:    ${totalFilteredSalary} removed`);
+  }
+  if (config.content_filter || totalFilteredContent > 0) {
+    console.log(`Filtered by content:   ${totalFilteredContent} removed`);
+  }
   if (Object.keys(windows).length > 0 || totalFilteredCooldown > 0) {
     console.log(`Filtered by cooldown:  ${totalFilteredCooldown} removed`);
   }


### PR DESCRIPTION
## Summary
- Only print `Filtered by salary` / `Filtered by content` summary lines when the corresponding filter is configured in `portals.yml`, or when it actually removed jobs — matching the existing guard pattern used by tier/age/cooldown filters.
- Align those two summary columns with the rest of the block.

Closes #1924

## Test plan
- [ ] Run `node scan.mjs --dry-run` with a `portals.yml` that does **not** define `salary_filter` or `content_filter` — confirm those two summary lines are absent
- [ ] Add `salary_filter` / `content_filter` and re-run — confirm the lines appear and columns align with `Filtered by title` / `Filtered by location`
- [ ] Optional: `node test-all.mjs --quick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scan summaries now show salary and content filtering results only when those filters are configured or have removed jobs.
  * Reduced unnecessary zero-count filter messages in end-of-run output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->