### PR TITLE
feat(i18n): add Simplified Chinese interview modes (plan/practice/debrief)

### DIFF
--- a/modes/zh/interview/debrief.md
+++ b/modes/zh/interview/debrief.md
@@ -1,0 +1,202 @@
+# Mode: interview/debrief — 面试后复盘
+
+真实面试结束后，记录问了什么，评估哪些答到位、哪些没有，在下一轮前补齐短板，并更新题库。
+
+---
+
+## When to Run This Skill
+
+- 真实面试刚结束（记忆还新鲜时）
+- 招聘电话挖出了流程相关的新信息之后
+- 候选人得知下一轮形式与面试官时
+
+---
+
+## Inputs
+
+1. **候选人的面试复盘** — 问了哪些题、怎么答的、感觉哪里强/弱
+2. **面试官姓名与角色** — 用于预测下一轮
+3. **本轮结果**（如已知）— moved forward / rejected / pending
+4. **下一轮细节**（如已知）— 形式、面试官、时间线
+5. **题库**，位于 `interview-prep/question-bank.md` — 用真实数据更新
+6. **故事库**，位于 `interview-prep/story-bank.md` — 若挖出新故事则追加
+7. **简历**，位于 `cv.md` + `article-digest.md`（如存在）— 把建议答案锚定在真实经历上
+8. **已撤回主张**，位于 `interview-prep/retracted-claims.md`（如存在）— 硬门禁；即使候选人在面试里说了，也绝不把已撤回主张写进建议答案
+9. **岗位专属准备文件** — 追加复盘笔记
+
+---
+
+## Step 1 — Capture What Was Asked
+
+请候选人按记忆列出每一道题，尽量按顺序。不要给选项提示——先让他们自由回忆。
+
+对每道已捕获的题：
+- 他们说了什么？
+- 面试官反应如何（正向信号、中性、顶回来、很快跳过）？
+- 他们感觉自信还是不确定？
+
+若记忆不完整，用定向追问：
+- "有没有哪题让你措手不及？"
+- "有没有哪题你事后希望换一种答法？"
+- "面试官有没有追问什么——那通常意味着他们想听更多？"
+
+---
+
+## Step 2 — Honest Assessment Per Question
+
+对每道题产出：
+
+```markdown
+**Q: [question]**
+- What was said: [summary of their answer]
+- What landed: [what was good — be specific]
+- What was missing: [gap — precise technical term, missing result, no reflection, etc.]
+- Correct/complete answer: [what the full answer should include]
+- Status: ✅ Strong / 🟡 Solid / 🔴 Gap
+```
+
+要直接。若错过了该题考察的核心概念，就说出来。若回答确实很强，也要说。复盘是最有价值的学习时刻——含糊其辞等于浪费。
+
+---
+
+## Step 3 — Update Question Bank
+
+对每道已复盘的题，更新 `interview-prep/question-bank.md`：
+- 按真实表现把状态改为 ✅ / 🟡 / 🔴
+- 从复盘加入短板笔记
+- 加入题库里还没有、但本轮出现的新题
+
+若题库不存在，用本轮面试的题目作为种子创建它。
+
+---
+
+## Step 4 — Close the Gaps
+
+对每个识别出的 🔴 短板：
+
+1. **讲清正确答案** — 清晰、简洁；有帮助时配上可操作示例（代码、计算、图示）
+2. **尽量连到真实故事** — "你其实在 [故事库里已有故事] 里有这个——可以这样用"
+3. **写入岗位专属准备文件**，放在 "Gaps to Close Before Round N" 小节下
+4. **写入 `interview-prep/interview-prep-guide.md`**（若候选人维护该文件）——当它是可复用、超出本岗位的原则时
+
+---
+
+## Step 5 — Extract New Stories
+
+真实面试有时会挖出候选人尚未准备好的故事。若候选人描述了一段尚未形式化的经历：
+
+> "你在回答里提到了 [X]——这听起来可以做成一条正式的 STAR+R 故事。趁还新鲜，要不要现在一起拆出来？"
+
+若同意，按 STAR+R（Situation, Task, Action, Result, Reflection）拆好，并追加到 `interview-prep/story-bank.md`。
+
+---
+
+## Step 6 — Next Round Intelligence
+
+若候选人已知下一轮形式：
+
+1. **预测可能的问题**，依据：
+   - 下一位面试官的角色（例如资深 practitioner → 核心技能深度、设计；跨职能同伴 → 协作、领域边界；高管 → 战略、业务影响）
+   - 本轮已覆盖内容（下一轮通常更深，而不是更广）
+   - 本轮面试官显得最感兴趣的点
+
+   每条预测都标 `[inferred]` — 绝不把预测题说成来自真实候选人或内部人士。
+
+2. **为下一轮准备建优先级清单** — 按短板严重程度与被考到的可能性排序
+
+3. **建议运行** `interview/plan`，带上下一轮细节，生成完整准备计划
+
+---
+
+## Step 7 — Probability Assessment (Optional)
+
+若候选人要求对机会做诚实判断：
+
+基于以下评估：
+- 短板数量与严重程度（基本功上的 🔴 风险高于进阶题上的 🔴）
+- 面试官信号（给出具体下一轮细节 = 正向；含糊 = 中性；通话很短 = 风险）
+- 岗位匹配（年限、领域、地点）
+- 差异化点（候选人说了大多数人不会说的东西）
+
+要诚实。带清晰理由的概率区间，比虚假自信更有用。
+
+---
+
+## Step 8 — Save Debrief
+
+追加到 `interview-prep/{company-slug}-{role-slug}.md`：
+
+```markdown
+## Round [N] Debrief — [YYYY-MM-DD]
+
+**Interviewer:** [name, role]
+**Round type:** [screening / technical / design-case-study / behavioral]
+**Outcome:** [pending / moved forward / rejected]
+
+### Questions Asked
+[list]
+
+### Gaps Identified
+[list with correct answers]
+
+### Next Round
+**Format:** [if known]
+**Interviewers:** [if known]
+**Priority prep:** [top 3 topics to close before next round]
+
+### Process Intel (recruiter / HM screens — omit if not applicable)
+**Comp discussed:** [yes / no — if yes, what was said and what was anchored]
+**Timeline:** [any dates or deadlines mentioned]
+**Other candidates:** [if disclosed]
+**Next steps:** [what the interviewer said happens next and by when]
+```
+
+**若本轮口头报出了薪酬数字**（候选人给了具体数字，而不只是"提到了薪酬"），向 `data/salary-observations.tsv` 追加一行 `stated`（文件不存在则创建；格式见 `docs/SCRIPTS.md` → salary-gap），写入 tracker#、本轮日期、金额/币种、来源 `user`、简短备注、轮次标签与面试官姓名。这能让 `interview/plan` 在下一轮前提醒候选人——见该模式 Inputs #9。
+
+---
+
+## Step 9 — Write Session Transcript
+
+复盘之后，再把机器可读的场次记录写到 `interview-prep/sessions/{company-slug}-{role-slug}-{round}-{YYYY-MM-DD}.md`。这是给下游分析模式用的结构化记录；带说话人标签的回合让消费者不必再推断谁在说。完整约定见 `interview-prep/sessions/README.md`。
+
+格式：
+
+```markdown
+---
+company: [company]
+role: [role]
+round: [screen | hiring-manager | technical | system-design | behavioral | onsite | final]
+date: YYYY-MM-DD
+interviewer_role: [role, if known]
+source: debrief
+---
+
+## Q1
+**Interviewer:** [question as asked]
+<!-- competency: tag[, tag...] -->
+**Candidate:** [answer as delivered / reconstructed in this debrief]
+
+## Q2
+...
+```
+
+记录规则：
+
+- **把轮次类型映射到上面的 enum**（例如 recruiter screen → `screen`，HM screen → `hiring-manager`，technical deep-dive → `technical`，design/case-study → `system-design`）。
+- **给每次作答打标签。** 在每行 `**Candidate:**` 正上方输出 `<!-- competency: tag[, tag...] -->` — lowercase-kebab-case，多能力用逗号分隔（例如 `system-design`、`people-leadership`、`incident-response`）。你在 Step 2 已评估过每次作答，按那次评估打标签，而不是重读。标签是自由形式；选该题实际考察的能力。
+- **忠实重建候选人回合。** 用候选人在 Step 1 报告说过的内容，而不是理想化答案。Step 2 的"correct/complete answer"属于复盘文件，绝不要进记录——记录记的是发生了什么。
+- **`source: debrief`。**
+- 场次文件落在 gitignore 目录（真实姓名/公司永不进版本库）；写入时不要脱敏。
+
+---
+
+## Rules
+
+- **立刻复盘。** 面试细节遗忘很快——几小时内，具体题目与反应就会忘掉。当天就跑这个 skill。
+- **不要淡化短板。** 出于善意把 🔴 叫成 🟡，下一轮还会再撞上。
+- **绝不把编造的主张塞进候选人口中。** Correct/complete answers 可以借用通用领域知识，但任何个人主张或指标必须来自候选人说过的内容、`cv.md`、`article-digest.md` 或故事库。
+- **已撤回主张是硬门禁。** 若某主张出现在 `interview-prep/retracted-claims.md`，即使候选人在真实面试里说了，也绝不建议再用——改为标出："该主张在你的撤回清单里——压力下撑不住。这里有一个不依赖它的版本。"
+- **记录新的撤回。** 若复盘发现候选人在真实面试用过、现在也同意撑不住的主张，提议追加到 `interview-prep/retracted-claims.md`：`**"[claim]"** ([context]). Reason: [one-line reason + correct framing if applicable].`
+- **明确抽出词汇缺口。** 若候选人用了不精确术语而精确术语存在，把它加到 `interview-prep/interview-prep-guide.md` 的词汇小节（若候选人维护该文件）。
+- **一个短板 = 一个修复。** 不要为每个短板塞一整套学习计划。优先下一轮最可能被考到的 1–2 个。
+- **也要点名答得好的地方。** 复盘不只是找短板。说出哪些强——能强化正确行为，并为下一轮建立信心。

--- a/modes/zh/interview/debrief.md
+++ b/modes/zh/interview/debrief.md
@@ -151,7 +151,7 @@
 **Next steps:** [what the interviewer said happens next and by when]
 ```
 
-**若本轮口头报出了薪酬数字**（候选人给了具体数字，而不只是"提到了薪酬"），向 `data/salary-observations.tsv` 追加一行 `stated`（文件不存在则创建；格式见 `docs/SCRIPTS.md` → salary-gap），写入 tracker#、本轮日期、金额/币种、来源 `user`、简短备注、轮次标签与面试官姓名。这能让 `interview/plan` 在下一轮前提醒候选人——见该模式 Inputs #9。
+**若本轮口头报出了薪酬数字**（候选人给了具体数字，而不只是"提到了薪酬"），且本轮对应的 tracker# **已知**：向 `data/salary-observations.tsv` 追加一行 `stated`（文件不存在则创建；格式见 `docs/SCRIPTS.md` → salary-gap），写入该 tracker#、本轮日期、金额/币种、来源 `user`、简短备注、轮次标签与面试官姓名。这能让 `interview/plan` 在下一轮前提醒候选人——见该模式 Inputs #9。若 tracker# 尚不可用，**跳过追加**——不要写入不完整或可能错绑的行；等 tracker# 明确后再补记。
 
 ---
 

--- a/modes/zh/interview/debrief.md
+++ b/modes/zh/interview/debrief.md
@@ -129,26 +129,26 @@
 ```markdown
 ## Round [N] Debrief — [YYYY-MM-DD]
 
-**Interviewer:** [name, role]
+**Interviewer:** [姓名, 角色]
 **Round type:** [screening / technical / design-case-study / behavioral]
 **Outcome:** [pending / moved forward / rejected]
 
 ### Questions Asked
-[list]
+[题目列表]
 
 ### Gaps Identified
-[list with correct answers]
+[短板列表，附正确答案]
 
 ### Next Round
-**Format:** [if known]
-**Interviewers:** [if known]
-**Priority prep:** [top 3 topics to close before next round]
+**Format:** [如已知]
+**Interviewers:** [如已知]
+**Priority prep:** [下一轮前优先补齐的 top 3 主题]
 
 ### Process Intel (recruiter / HM screens — omit if not applicable)
-**Comp discussed:** [yes / no — if yes, what was said and what was anchored]
-**Timeline:** [any dates or deadlines mentioned]
-**Other candidates:** [if disclosed]
-**Next steps:** [what the interviewer said happens next and by when]
+**Comp discussed:** [是 / 否 — 若是，说了什么、锚定在什么]
+**Timeline:** [提到的任何日期或截止日期]
+**Other candidates:** [若有披露]
+**Next steps:** [面试官说的下一步是什么、何时完成]
 ```
 
 **若本轮口头报出了薪酬数字**（候选人给了具体数字，而不只是"提到了薪酬"），且本轮对应的 tracker# **已知**：向 `data/salary-observations.tsv` 追加一行 `stated`（文件不存在则创建；格式见 `docs/SCRIPTS.md` → salary-gap），写入该 tracker#、本轮日期、金额/币种、来源 `user`、简短备注、轮次标签与面试官姓名。这能让 `interview/plan` 在下一轮前提醒候选人——见该模式 Inputs #9。若 tracker# 尚不可用，**跳过追加**——不要写入不完整或可能错绑的行；等 tracker# 明确后再补记。

--- a/modes/zh/interview/plan.md
+++ b/modes/zh/interview/plan.md
@@ -74,7 +74,7 @@
 
 **模板（按可用总时长调整各块大小）：**
 
-```
+```text
 Block 1 — Lock your narrative (first, always)
   - Write out your background timeline explicitly
   - Prepare "why this company" with a specific connection to your history

--- a/modes/zh/interview/plan.md
+++ b/modes/zh/interview/plan.md
@@ -72,44 +72,47 @@
 
 在确定块大小之前，先检查 `interview-prep/question-bank.md`（如存在）。任何来自先前轮次、标为 🔴 的题都是已被证实的短板——无论 CV-vs-JD 分析如何排序，都要给它单独一块。真实表现数据优先于推断风险。
 
-**模板（按可用总时长调整各块大小）：**
+**模板（先预留休息，再按剩余可学习时长调整各块大小）：**
 
 ```text
-Block 1 — Lock your narrative (first, always)
-  - Write out your background timeline explicitly
-  - Prepare "why this company" with a specific connection to your history
-  - Prepare your strongest proof point story (30-second version)
-  - Time: ~15% of available hours
+先从「现在 → 面试时刻」的总可用时间中，强制预留面试前 60–90 分钟休息（Block 7）。
+Blocks 1–6 的百分比只作用于扣掉该休息窗口后的剩余学习时间。
 
-Block 2 — Priority domain topic (highest-risk gap first)
-  - One topic per block — don't mix
-  - For each: concept → your story hook → likely follow-up questions
-  - Time: ~25% of available hours
+Block 1 — 锁定叙事（始终最先）
+  - 把背景时间线写清楚
+  - 准备「为什么这家公司」，并与你的经历做具体连接
+  - 准备最强证明点故事（30 秒版）
+  - 时间：剩余学习时间的 ~15%
 
-Block 3 — Secondary domain topic
-  - Second-highest-risk gap
-  - Time: ~20% of available hours
+Block 2 — 优先领域主题（最高风险短板优先）
+  - 一块一个主题 — 不要混
+  - 每个主题：概念 → 你的故事钩子 → 可能的追问
+  - 时间：剩余学习时间的 ~25%
 
-Block 4 — Behavioral stories
-  - Map existing stories to likely question types
-  - Practice the 2-minute verbal version of each
-  - Prepare the Reflection for each — the senior-candidate differentiator
-  - Time: ~15% of available hours
+Block 3 — 次优先领域主题
+  - 第二高风险短板
+  - 时间：剩余学习时间的 ~20%
 
-Block 5 — Company research
-  - Product pages relevant to the role
-  - Connection between your history and their specific domain
-  - 3–4 sharp questions to ask them
-  - Time: ~10% of available hours
+Block 4 — 行为故事
+  - 把已有故事映射到可能的题型
+  - 练习每条故事的 2 分钟口述版
+  - 为每条准备 Reflection — 高级候选人的差异化信号
+  - 时间：剩余学习时间的 ~15%
 
-Block 6 — Practice run (if time permits)
-  - One question per likely topic — out loud, timed
-  - Time: ~10% of available hours
+Block 5 — 公司调研
+  - 与岗位相关的产品页
+  - 你的经历与他们具体领域的连接
+  - 准备 3–4 个尖锐问题问对方
+  - 时间：剩余学习时间的 ~10%
 
-Block 7 — Buffer + rest
-  - Stop studying 60–90 minutes before the interview
-  - Cramming in the last hour adds noise, not signal
-  - Time: remaining
+Block 6 — 演练（有时间才做）
+  - 每个可能主题一题 — 出声、计时
+  - 时间：剩余学习时间的 ~10%
+
+Block 7 — 缓冲 + 休息
+  - 面试前 60–90 分钟停止学习（强制预留，不是「剩下多少算多少」）
+  - 最后一小时临时抱佛脚只增加噪声，不增加信号
+  - 时间：固定预留 60–90 分钟；Blocks 1–6 仅分配扣掉该窗口后的剩余小时数
 ```
 
 按短板严重程度与轮次类型调整块大小。若是 screening，Block 4（行为）与 Block 5（公司调研）比深层领域块更重要。
@@ -123,19 +126,19 @@ Block 7 — Buffer + rest
 ```markdown
 ## 15-Minute Pre-Interview Review
 
-**Your anchor sentence:** [one sentence that captures why you're right for this role]
+**你的锚定句：** [一句话概括你为什么适合这个岗位]
 
-**Top 3 things to remember:**
-1. [most important message to leave the interviewer with]
-2. [most likely question and your first sentence of the answer]
-3. [the connection between your history and their domain]
+**最重要的 3 件事：**
+1. [最想留给面试官的信息]
+2. [最可能被问到的题，以及你回答的第一句]
+3. [你的经历与他们领域之间的连接]
 
-**Compensation — already discussed:** [only if `--stated-for` returned prior observations] "You stated {amount} {currency} to {interviewer} on {date} in {round}. Stay consistent unless something material changed." Omit this block entirely if there are no prior `stated` observations for this tracker# — don't invent a number that was never said.
+**薪酬 — 此前已谈过：** [仅当 `--stated-for` 返回过先前观察时] "你曾在 {date} 的 {round} 对 {interviewer} 表态 {amount} {currency}。除非出现实质性变化，否则保持口径一致。" 若该 tracker# 没有任何先前 `stated` 观察，整块省略 — 不要编造从未说过的数字。
 
-**Your questions to ask:**
-1. [question 1]
-2. [question 2]
-3. [question 3]
+**你要问对方的问题：**
+1. [问题 1]
+2. [问题 2]
+3. [问题 3]
 ```
 
 ---
@@ -152,6 +155,6 @@ Block 7 — Buffer + rest
 - **短板优先。** 时间有限。候选人的优势不需要准备——短板才需要。
 - **题库里的 🔴 短板优先于推断短板。** 真实表现数据胜过 CV-vs-JD 分析。若候选人已知自己某题吃力，不要把它埋掉。
 - **一块一个主题。** 单块混多个主题会降低记忆留存。
-- **始终留出休息时间。** 休息好的候选人比临时抱佛脚的表现更好。
+- **始终留出休息时间。** 先固定预留面试前 60–90 分钟休息，再用剩余时间分配学习块。休息好的候选人比临时抱佛脚的表现更好。
 - **绝不编造公司情报。** 若没有调研，就直说——不要捏造公司文化或技术细节。
-- **绝不替候选人编造主张。** 速查页（Step 4）中的锚定句与面试前话术，必须 grounded 在候选人实际拥有的材料上——`cv.md`、`article-digest.md` 或故事库。不要起草依赖候选人没有的经验或指标的主张。若某主张出现在 `interview-prep/retracted-claims.md` 中，永远不要纳入。
+- **绝不替候选人编造主张。** 速查页（Step 4）中的锚定句与面试前话术，必须基于候选人实际拥有的材料——`cv.md`、`article-digest.md` 或故事库。不要起草依赖候选人没有的经验或指标的主张。若某主张出现在 `interview-prep/retracted-claims.md` 中，永远不要纳入。

--- a/modes/zh/interview/plan.md
+++ b/modes/zh/interview/plan.md
@@ -1,0 +1,157 @@
+# Mode: interview/plan — 面试准备计划器
+
+给定职位描述（JD）和面试日期/时间，构建一份结构化、按时间分块的准备计划，针对候选人的具体短板量身定制。
+
+---
+
+## Inputs
+
+1. **职位描述**（必填）— 内联粘贴或提供 URL
+2. **面试日期与时间**（必填）— 用于计算可用小时数
+3. **面试官姓名与角色**（如已知）— 影响准备的深度与语气。后续轮次（panel / onsite loop）常会一次点名多位面试官——来自用户直接告知、粘贴的日历邀请，或粘贴的排期邮件。当点名超过一位小组成员时，见 Step 2 中的 Panel Intel 说明。
+4. **轮次类型**（如已知）— screening、technical/domain-specific、design/case study、behavioral panel
+5. **简历**，位于 `cv.md` + `article-digest.md`（如存在）— 读取经验、技能与证明点
+6. **画像**，位于 `config/profile.yml` + `modes/_profile.md` — 读取叙事、原型与目标
+7. **故事库**，位于 `interview-prep/story-bank.md` — 已有的 STAR+R 故事
+8. **题库**，位于 `interview-prep/question-bank.md` — 已有短板（如文件存在）
+9. **此前已表态的薪酬** — 若已知 tracker#，运行 `node salary-gap.mjs --stated-for <tracker#>`（零 token）。任何先前的 `stated` 观察值，都是候选人在更早一轮、对某位具体面试官已经承诺过的数字——把它写入 Step 4 的速查页，让候选人保持口径一致，避免无意中重新谈价。
+
+---
+
+## Step 1 — Fit Assessment
+
+阅读简历与 JD。产出两列评估：
+
+**可锚定的优势：** 与 JD 直接匹配的经验、头衔、领域与证明点。
+
+**需补齐的短板：** JD 点名但简历中缺失或偏弱的技能、工具或经验。按在本轮类型中被考察的可能性排序。
+
+要诚实。短板就是短板——标清楚，好把准备时间花在刀刃上。
+
+---
+
+## Step 2 — Round Intelligence
+
+根据以下信号判断本轮真正在评估什么：
+- 面试官角色（manager = 沟通 + 热情 + 基本功；practitioner = 深度 + 判断力）
+- 轮次标签（screening、technical/domain、design/case study、final）
+- JD 信号（他们强调什么）
+
+**Recruiter screen：**
+- 勾选式核对：匹配度、薪酬对齐、后勤、沟通
+- 不是技术测试——深度问题在 HM 及后续轮次才会出现
+- 常见：背景介绍、"为什么选我们/为什么这个岗位"、薪酬预期、时间线、一个后勤问题
+- 把它当作轻松的检查点；把准备时间用来打好后续轮次的基础
+
+**Hiring-manager screen：**
+- 沟通、热情、匹配——外加领导力哲学与判断力
+- JD 核心技能的基本面——不是深层内部细节
+- 1–2 个行为故事
+- 常见：背景、"为什么选我们"、一个来自 JD 的核心概念、一个领导力故事、面向未来的情境题
+
+**Technical / domain deep-dive with a practitioner：**
+- 对 JD 核心技能的深度（例如工程的 runtime internals、数据的建模选择、金融的估值方法）
+- 来自岗位日常的应用场景
+- 可能有现场练习或带练走读
+- 故事用作证据，不是主菜
+
+**Design / case study panel：**
+- 完整方案——约束、组件、权衡、失效模式
+- JD 强调的质量维度（例如可扩展性、合规、可度量性）
+- 高级别：设定约束、提出澄清问题、主导对话
+
+按轮次校准计划。为 screening 过度准备深度既浪费时间，也会带错心态。
+
+**Panel Intel（当点名了小组成员时）。** 若本轮点名了两位及以上面试官——来自用户直接告知、粘贴的日历邀请，或粘贴的排期邮件——在进入 Step 3 之前先建好 Panel Intel 表。完整表格格式与三个子行为（按 JD 汇报线做决策者加权、读职业轨迹信号、为每位小组成员定制收尾问题）见 `modes/interview-prep.md` § "Panel Intel table"（在 Step 4 → `panel-mixed` 下）——此处沿用同一逻辑，再用得到的受众标签按面试官拆分 Step 3 的时间块，而不是准备一份通吃的材料。只点名一位面试官时不需要该表；直接按上文该人的轮次类型进入 Step 3。
+
+---
+
+## Step 3 — Build the Time-Blocked Plan
+
+从现在到面试时间计算可用小时数，并划分成时间块：
+
+在确定块大小之前，先检查 `interview-prep/question-bank.md`（如存在）。任何来自先前轮次、标为 🔴 的题都是已被证实的短板——无论 CV-vs-JD 分析如何排序，都要给它单独一块。真实表现数据优先于推断风险。
+
+**模板（按可用总时长调整各块大小）：**
+
+```
+Block 1 — Lock your narrative (first, always)
+  - Write out your background timeline explicitly
+  - Prepare "why this company" with a specific connection to your history
+  - Prepare your strongest proof point story (30-second version)
+  - Time: ~15% of available hours
+
+Block 2 — Priority domain topic (highest-risk gap first)
+  - One topic per block — don't mix
+  - For each: concept → your story hook → likely follow-up questions
+  - Time: ~25% of available hours
+
+Block 3 — Secondary domain topic
+  - Second-highest-risk gap
+  - Time: ~20% of available hours
+
+Block 4 — Behavioral stories
+  - Map existing stories to likely question types
+  - Practice the 2-minute verbal version of each
+  - Prepare the Reflection for each — the senior-candidate differentiator
+  - Time: ~15% of available hours
+
+Block 5 — Company research
+  - Product pages relevant to the role
+  - Connection between your history and their specific domain
+  - 3–4 sharp questions to ask them
+  - Time: ~10% of available hours
+
+Block 6 — Practice run (if time permits)
+  - One question per likely topic — out loud, timed
+  - Time: ~10% of available hours
+
+Block 7 — Buffer + rest
+  - Stop studying 60–90 minutes before the interview
+  - Cramming in the last hour adds noise, not signal
+  - Time: remaining
+```
+
+按短板严重程度与轮次类型调整块大小。若是 screening，Block 4（行为）与 Block 5（公司调研）比深层领域块更重要。
+
+---
+
+## Step 4 — Priority Quick-Reference
+
+在计划末尾产出一页速查，供候选人在面试前 15 分钟快速浏览：
+
+```markdown
+## 15-Minute Pre-Interview Review
+
+**Your anchor sentence:** [one sentence that captures why you're right for this role]
+
+**Top 3 things to remember:**
+1. [most important message to leave the interviewer with]
+2. [most likely question and your first sentence of the answer]
+3. [the connection between your history and their domain]
+
+**Compensation — already discussed:** [only if `--stated-for` returned prior observations] "You stated {amount} {currency} to {interviewer} on {date} in {round}. Stay consistent unless something material changed." Omit this block entirely if there are no prior `stated` observations for this tracker# — don't invent a number that was never said.
+
+**Your questions to ask:**
+1. [question 1]
+2. [question 2]
+3. [question 3]
+```
+
+---
+
+## Step 5 — Save Output
+
+若文件不存在，将计划保存到 `interview-prep/{company-slug}-{role-slug}.md`；若已存在，则追加一个 `## Prep Plan` 小节。
+
+---
+
+## Rules
+
+- **按轮次校准。** screening 准备计划与 design-panel 准备计划差异很大。不要默认每场面试都上最大深度。
+- **短板优先。** 时间有限。候选人的优势不需要准备——短板才需要。
+- **题库里的 🔴 短板优先于推断短板。** 真实表现数据胜过 CV-vs-JD 分析。若候选人已知自己某题吃力，不要把它埋掉。
+- **一块一个主题。** 单块混多个主题会降低记忆留存。
+- **始终留出休息时间。** 休息好的候选人比临时抱佛脚的表现更好。
+- **绝不编造公司情报。** 若没有调研，就直说——不要捏造公司文化或技术细节。
+- **绝不替候选人编造主张。** 速查页（Step 4）中的锚定句与面试前话术，必须 grounded 在候选人实际拥有的材料上——`cv.md`、`article-digest.md` 或故事库。不要起草依赖候选人没有的经验或指标的主张。若某主张出现在 `interview-prep/retracted-claims.md` 中，永远不要纳入。

--- a/modes/zh/interview/practice.md
+++ b/modes/zh/interview/practice.md
@@ -215,6 +215,7 @@ HM screen 探的是领导力哲学、判断力与经验深度。回答可以更�
 - "Where are you still growing in your role?"
 
 ### Technical / Domain-Specific (practitioner, 45–60 min)
+
 1. [Core internals of the discipline's main tool or method — e.g., runtime internals for engineering, attribution models for marketing, valuation methods for finance]
 2. [Established pattern or framework relevant to the role — from the JD]
 3. [Fundamental building block deep-dive — e.g., a data structure, a statistical test, an accounting principle]
@@ -223,12 +224,14 @@ HM screen 探的是领导力哲学、判断力与经验深度。回答可以更�
 6. How do you raise the quality bar on a team?
 
 ### Design / Case Study (45–60 min)
+
 1. Design [a system, process, campaign, or product relevant to the role].
 2. [Constraint question — how does your design behave when something fails, scales 10x, or loses budget?]
 3. [Quality/reliability question — how do you guarantee correctness or measure success?]
 4. Walk me through how you'd know it's working after launch.
 
 ### Behavioral Panel
+
 1. Tell me about a time you led a team through a difficult delivery.
 2. Describe a major failure in production or in market — what happened and what changed after?
 3. Tell me about a time you influenced direction across teams or stakeholders.

--- a/modes/zh/interview/practice.md
+++ b/modes/zh/interview/practice.md
@@ -180,12 +180,12 @@ source: practice
 
 Recruiter screen 是勾选核对，不是深度探查。回答要干脆；不要过度工程化。招聘方在核实匹配度、薪酬对齐与后勤，再交给 hiring manager。
 
-1. Walk me through your background.
-2. Why this company / why this role?
-3. Why are you leaving your current role?
-4. What are your comp expectations?
-5. [Logistics: location / hybrid / timeline / work authorization]
-6. What questions do you have for us?
+1. 请介绍一下你的背景经历。
+2. 为什么选这家公司 / 为什么这个岗位？
+3. 你为什么要离开现在的工作？
+4. 你的薪酬预期是什么？
+5. [后勤：地点 / 混合办公 / 时间线 / 工作许可]
+6. 你有什么问题想问我们？
 
 **Comp coaching（仅 recruiter screen）。** 留意候选人是否主动报出薪酬底线（例如"最低我只能到 X"）。若发生，作答后点明："你刚把底线交出去了——谈判还没开始就被封顶。更强的做法是锚定调研后的目标区间，并把口径推到整包：'我盯的是这个级别市场区间的上半段——在定数字前，我想一起看清 base、bonus 和 equity。'" 若岗位专属准备文件定义了薪酬策略，就跟它走；否则只给这条通用机制说明——绝不编造目标数字。
 
@@ -193,51 +193,51 @@ Recruiter screen 是勾选核对，不是深度探查。回答要干脆；不要
 
 HM screen 探的是领导力哲学、判断力与经验深度。回答可以更长、更有故事分量。HM 在决定是否投入团队后续轮次的时间。
 
-1. Walk me through your background.
-2. Why this company / why this role?
-3. Tell me about the hardest problem you've solved in your field.
-4. Tell me about a time you faced resistance to a change you proposed.
-5. What does [title from JD] mean to you?
-6. How would you describe your approach to your craft?
-7. [One fundamental concept from the JD — e.g., a core method, framework, regulation, or tool of the discipline]
+1. 请介绍一下你的背景经历。
+2. 为什么选这家公司 / 为什么这个岗位？
+3. 讲讲你在本领域解决过的最难问题。
+4. 讲讲一次你推动变革却遇到阻力的经历。
+5. 对你来说，[title from JD] 意味着什么？
+6. 你会如何描述自己做这件事的方法论？
+7. [来自 JD 的一个基本概念 — 例如该学科的核心方法、框架、法规或工具]
 
 至少混入 2 道下方情境 / 前瞻题——这些探的是判断力与自我认知，不是过往故事：
 
-**Forward-looking / situational：**
-- "What does success look like for you in the first 90 days?"
-- "If you join and the team is struggling — missed deadlines, low morale — what's your first move?"
-- "How do you decide what to delegate vs. what to own yourself?"
-- "How do you handle a respected colleague who disagrees with a direction you've set?"
+**前瞻 / 情境：**
+- "对你来说，入职前 90 天的成功长什么样？"
+- "如果你入职后团队状态不好——交期延误、士气低落——你的第一步会做什么？"
+- "你如何决定什么该授权、什么该自己扛？"
+- "如果一位你尊重的同事不同意你定的方向，你会怎么处理？"
 
-**Self-awareness / growth：**
-- "What's something you got wrong professionally and what did you learn?"
-- "What do you need from your manager to do your best work?"
-- "Where are you still growing in your role?"
+**自我认知 / 成长：**
+- "职业上你曾做错过什么，学到了什么？"
+- "你需要管理者怎样支持，才能发挥最好水平？"
+- "在当前角色里，你还在哪些方面持续成长？"
 
 ### Technical / Domain-Specific (practitioner, 45–60 min)
 
-1. [Core internals of the discipline's main tool or method — e.g., runtime internals for engineering, attribution models for marketing, valuation methods for finance]
-2. [Established pattern or framework relevant to the role — from the JD]
-3. [Fundamental building block deep-dive — e.g., a data structure, a statistical test, an accounting principle]
-4. [Advanced topic the JD emphasizes — the area where depth separates candidates]
-5. Tell me about a high-stakes failure in your work — how you diagnosed it and what you did.
-6. How do you raise the quality bar on a team?
+1. [该学科主工具或方法的核心内部机制 — 例如工程的 runtime internals、营销的归因模型、金融的估值方法]
+2. [与岗位相关的成熟模式或框架 — 来自 JD]
+3. [基础构件深挖 — 例如某数据结构、某统计检验、某会计原则]
+4. [JD 强调的进阶主题 — 深度拉开候选人差距的区域]
+5. 讲讲工作中一次高风险失败——你如何诊断、又做了什么。
+6. 你如何在团队里拉高质量标准？
 
 ### Design / Case Study (45–60 min)
 
-1. Design [a system, process, campaign, or product relevant to the role].
-2. [Constraint question — how does your design behave when something fails, scales 10x, or loses budget?]
-3. [Quality/reliability question — how do you guarantee correctness or measure success?]
-4. Walk me through how you'd know it's working after launch.
+1. 设计 [与岗位相关的系统、流程、活动或产品]。
+2. [约束题 — 当某环节失败、放大 10 倍或预算砍掉时，你的设计如何表现？]
+3. [质量/可靠性题 — 你如何保证正确性或度量成功？]
+4. 上线后，你如何判断它在正常工作？
 
 ### Behavioral Panel
 
-1. Tell me about a time you led a team through a difficult delivery.
-2. Describe a major failure in production or in market — what happened and what changed after?
-3. Tell me about a time you influenced direction across teams or stakeholders.
-4. What does a high-performing team look like to you?
-5. Tell me about a time you simplified something complex.
-6. Tell me about a time you solved a problem that wasn't yours to solve.
+1. 讲讲一次你带领团队完成艰难交付的经历。
+2. 描述一次生产或市场上的重大失败——发生了什么，之后改了什么？
+3. 讲讲一次你跨团队或跨利益相关方影响方向的经历。
+4. 对你来说，高绩效团队是什么样的？
+5. 讲讲一次你把复杂事物简化的经历。
+6. 讲讲一次你解决了本不属于你职责范围的问题。
 
 ---
 

--- a/modes/zh/interview/practice.md
+++ b/modes/zh/interview/practice.md
@@ -1,0 +1,249 @@
+# Mode: interview/practice — 模拟面试官
+
+按真实面试节奏跑一场练习——一次一题——并在每次作答后给出结构化反馈。跟踪哪些答到位了、哪些还需要练。
+
+---
+
+## Inputs
+
+1. **轮次类型**（必填）— screening/recruiter、screening/HM、technical/domain-specific、design/case study、behavioral
+2. **面试官人设**（如已知）— 姓名、角色、公司；影响提问风格与深度
+3. **问题列表**（可选）— 要覆盖的具体问题；若未提供，则按轮次类型生成
+4. **简历**，位于 `cv.md` + `article-digest.md`（如存在）— 用于核验回答中的主张，并把更强版本锚定在真实经历上
+5. **画像**，位于 `config/profile.yml` + `modes/_profile.md` — 候选人叙事、底线、薪酬目标
+6. **故事库**，位于 `interview-prep/story-bank.md` — 在反馈中核验故事准确性
+7. **题库**，位于 `interview-prep/question-bank.md` — 每次作答后更新状态
+8. **岗位专属准备文件** — 公司情报、有来源的题目、薪酬策略
+9. **已撤回主张**，位于 `interview-prep/retracted-claims.md`（如存在）— 候选人已明确认定站不住脚的主张；视为硬门禁
+
+---
+
+## Protocol
+
+### Preflight — Check Substance Files
+
+开场设景之前，确认哪些文件存在：
+
+- `interview-prep/question-bank.md`（或公司专属等价文件）
+- 岗位专属准备文件（`interview-prep/{company}-{role}.md`）
+- `cv.md`
+- `interview-prep/retracted-claims.md`
+
+若题库与岗位专属准备文件都不存在，就直白告诉候选人：
+
+> "你有练习协议，但没有本题库或本岗位的准备笔记。在这些材料齐备之前，反馈会比较泛。要不要先跑 `interview-prep` 或 `interview/plan` 把它们建起来？"
+
+不要悄悄跑一场单薄的练习，却装作是完整场次。若候选人确认仍要继续，可以继续——但要在场次总结里注明：题目来源回退到了生成默认集。
+
+---
+
+### Opening
+
+简短设景：
+
+> "我将扮演 [面试官姓名/角色]。我们一次一题。请按真实面试作答——能出声最好，不能就打字。每次作答后我会给反馈，然后进入下一题。若想在反馈前先停下来讨论，说 'pause'。准备好了吗？"
+
+然后直接抛出第一题——不要开场白，不要说"这是第 1 题"。就像面试官自然开问那样。
+
+---
+
+### During the Session
+
+**一次只问一题。** 等完整作答后再给反馈。
+
+**作答期间保持角色。** 若候选人在作答中途问澄清问题（"这样说得通吗？"），按面试官会怎么回——简短回应，不破戏。
+
+**追问：** 在完整作答后，若符合以下情况，再问一个自然追问：
+- 回答不完整但方向对（把线往下拉）
+- 回答很强（往深处挖——真实面试官就会这样）
+- 完全没打到关键点（给他们一次回正的机会）
+
+**跟踪已覆盖内容。** 在脑子里维护一份候选人已用过的故事与例子清单。若同一故事第二次被拿出来，在反馈后点明："你已经用 [story] 答了 [N] 道题——面试官会注意到例子池偏薄。这里能换一个不同例子吗？" 也要检查每次作答的*收尾*：若落在与岗位不匹配的领域（例如岗位是 fintech/fraud，却收在电商），注明："内容不错，但你收在了 [wrong domain]——对本岗位，要把答案落在 [right domain]。"
+
+---
+
+### After Each Answer — Structured Feedback
+
+```markdown
+**What landed:**
+- [specific thing that worked — quote their words if possible]
+- [another strength]
+
+**What to sharpen:**
+- [specific gap — what was missing or imprecise]
+- [vocabulary or framing to improve]
+
+**The stronger version:**
+> "[One or two sentences showing how the answer could have opened or closed more effectively]"
+
+**Status update:** [✅ Strong / 🟡 Solid / 🔴 Gap]
+```
+
+反馈要短。每次作答只挑一两处 sharpen——不是整段重写。目标是下一轮答得更好，而不是打击信心。
+
+---
+
+### Feedback Principles
+
+**要诚实，不要空鼓励。** 没有实质的"答得好"会浪费准备时间。若答得弱，就说清楚为什么。
+
+**引用他们的原话。** "你说 'negotiate between consistency and availability'——精确说法是 'trade off consistency for availability'"，比"用更好的技术词汇"有用得多。
+
+**先说什么答到位了。** 即使偏弱的回答通常也有对的部分。先点名它，纠正更容易被听进去。
+
+**明确标出词汇缺口。** 资深面试官会注意不精确的表述。候选人用了含糊词、而精确术语存在时，要点名说出来。
+
+**Reflection 检查。** 对行为故事，始终检查：有没有 Reflection？（"换作现在我会怎么做 / 我学到了什么。"）这是高级候选人的信号。若缺失，反馈后提示一次："以你现在知道的，换作重来你会怎么做不同？"
+
+**两分钟规则。** 若回答超过两分钟，要注明。面试官会听不下去。修复几乎总是：先给答案，再解释——而不是砍内容。*打字场次无法计时——改做结构检查：* 标记那些把 headline 埋在后面的回答（落点前超过 4–5 句铺垫），并告诉候选人：节奏与口头禅只能靠出声诊断——自己录音，或再口头跑一遍这题。
+
+**可疑主张先核验再教练。** 当候选人说出具体指标或范围主张（管理人数、AUM、营收数字、提升百分比）而你无法从既有上下文确认时，在给反馈前对照 `cv.md`、`article-digest.md` 与 `interview-prep/retracted-claims.md`。若主张没有支撑，就标出来："我在简历里找不到这个数字——若对方追问，它站得住吗？站不住的话，这里有一个不依赖该数字的版本。" 永远不要教练候选人重复他们撑不住的主张。
+
+**绝不编造经历或指标。** 更强版本只能使用候选人实际说过的事实，或存在于 `cv.md`、`article-digest.md`、故事库中的主张。收紧表述是本职——添加成就就是编造。若某主张出现在 `interview-prep/retracted-claims.md`，即使候选人说了，也不要写进更强版本。
+
+**主动提议记录撤回。** 当候选人在场次中承认某个主张在压力下撑不住（"你说得对，我撑不住"）时，提议追加到 `interview-prep/retracted-claims.md`："要不要我把它加进你的撤回清单，免得下次再冒出来？" 若同意，追加：`**"[claim]"** ([context]). Reason: [one-line reason + correct framing if applicable].`
+
+**场中公司情报偏薄时。** 若候选人在"为什么这家公司 / 为什么这个岗位"上明显卡壳，是因为岗位专属准备文件缺情报，不要编造，也不要装聋。跳出角色，为这一题跑 `interview-prep` 的调研步骤（与 `interview-prep.md` 拥有的同源调研路径相同），带着 2–3 个具体、有引用的角度回来，再回到角色。若调研得不到可用结果，就直说。这不是第二轮搜索循环——只是在上游流水线没先跑时，即时调用既有调研阶段。
+
+**候选人质疑准备材料中的事实主张时。** 若候选人挑战题库或准备文件中的具体事实（例如某指标、产品规格、SLA 数字），不要维护文件权威。跳出角色，对照一手来源核验；若候选人正确，就修正源文件。带着已核验数字回来再入戏。若找不到一手来源，就直说并把该主张标为未核验——候选人不应在真实面试里使用无法核验的事实。
+
+---
+
+### After All Questions — Session Summary
+
+```markdown
+## Practice Session Summary
+
+**Round type:** [screening / technical / design-case-study / behavioral]
+**Questions covered:** [N]
+
+**Ready:**
+- [question] — [one-line note on why it's strong]
+
+**Needs work before interview:**
+- [question] — [specific gap to close]
+
+**Vocabulary to fix:**
+- "[what they said]" → "[correct term]"
+
+**Overall read:** [one honest sentence on interview readiness]
+```
+
+---
+
+### Write Session Transcript
+
+总结之后，把机器可读的场次记录写到 `interview-prep/sessions/{company-slug}-{role-slug}-{round}-{YYYY-MM-DD}.md`（若不是公司专属场次，company/role slug 用 `practice`）。这是给下游分析模式用的结构化记录；带说话人标签的回合让消费者不必再推断谁在说。完整约定见 `interview-prep/sessions/README.md`。
+
+格式：
+
+```markdown
+---
+company: [company, or "practice"]
+role: [role]
+round: [screen | hiring-manager | technical | system-design | behavioral | onsite | final]
+date: YYYY-MM-DD
+interviewer_role: [persona role, if set]
+source: practice
+---
+
+## Q1
+**Interviewer:** [the question you asked]
+<!-- competency: tag[, tag...] -->
+**Candidate:** [the candidate's answer, verbatim]
+
+## Q2
+...
+```
+
+记录规则：
+
+- **把轮次类型映射到上面的 enum**（recruiter screen → `screen`，HM screen → `hiring-manager`，technical/domain → `technical`，design/case study → `system-design`，behavioral → `behavioral`）。
+- **给每次作答打标签。** 在每行 `**Candidate:**` 正上方输出 `<!-- competency: tag[, tag...] -->` — lowercase-kebab-case，多能力用逗号分隔。你在场次中已评估过每次作答，按那次评估打标签。标签是自由形式；选该题实际考察的能力。
+- **原样记录候选人作答**，不要写成"更强版本"——记录记的是发生了什么，不是教练稿。
+- **`source: practice`。**
+- 场次文件落在 gitignore 目录（真实姓名/公司永不进版本库）；写入时不要脱敏。
+
+---
+
+## Question Sets by Round Type
+
+若未提供问题列表，按以下优先级取材：
+
+1. **来自 `interview-prep/question-bank.md` 的真题** — 该公司（或先前轮次）实际问过、由 debrief 捕获的题。价值最高：有实证依据。
+2. **来自岗位专属准备文件的有来源题目** — interview-prep.md 调研找到并引用的题。按原文使用；场次中不必带引用，但尊重其措辞。
+3. **下方默认集** — 尚无调研时的首次场次回退。方括号槽位用 JD 填充。
+
+更高层偏薄时可以混层——例如题库 3 道真题再垫默认题——但绝不要跳过对本轮类型仍有相关题目的更高层。
+
+### Screening — Recruiter (20–30 min)
+
+Recruiter screen 是勾选核对，不是深度探查。回答要干脆；不要过度工程化。招聘方在核实匹配度、薪酬对齐与后勤，再交给 hiring manager。
+
+1. Walk me through your background.
+2. Why this company / why this role?
+3. Why are you leaving your current role?
+4. What are your comp expectations?
+5. [Logistics: location / hybrid / timeline / work authorization]
+6. What questions do you have for us?
+
+**Comp coaching（仅 recruiter screen）。** 留意候选人是否主动报出薪酬底线（例如"最低我只能到 X"）。若发生，作答后点明："你刚把底线交出去了——谈判还没开始就被封顶。更强的做法是锚定调研后的目标区间，并把口径推到整包：'我盯的是这个级别市场区间的上半段——在定数字前，我想一起看清 base、bonus 和 equity。'" 若岗位专属准备文件定义了薪酬策略，就跟它走；否则只给这条通用机制说明——绝不编造目标数字。
+
+### Screening — Hiring Manager (30–45 min)
+
+HM screen 探的是领导力哲学、判断力与经验深度。回答可以更长、更有故事分量。HM 在决定是否投入团队后续轮次的时间。
+
+1. Walk me through your background.
+2. Why this company / why this role?
+3. Tell me about the hardest problem you've solved in your field.
+4. Tell me about a time you faced resistance to a change you proposed.
+5. What does [title from JD] mean to you?
+6. How would you describe your approach to your craft?
+7. [One fundamental concept from the JD — e.g., a core method, framework, regulation, or tool of the discipline]
+
+至少混入 2 道下方情境 / 前瞻题——这些探的是判断力与自我认知，不是过往故事：
+
+**Forward-looking / situational：**
+- "What does success look like for you in the first 90 days?"
+- "If you join and the team is struggling — missed deadlines, low morale — what's your first move?"
+- "How do you decide what to delegate vs. what to own yourself?"
+- "How do you handle a respected colleague who disagrees with a direction you've set?"
+
+**Self-awareness / growth：**
+- "What's something you got wrong professionally and what did you learn?"
+- "What do you need from your manager to do your best work?"
+- "Where are you still growing in your role?"
+
+### Technical / Domain-Specific (practitioner, 45–60 min)
+1. [Core internals of the discipline's main tool or method — e.g., runtime internals for engineering, attribution models for marketing, valuation methods for finance]
+2. [Established pattern or framework relevant to the role — from the JD]
+3. [Fundamental building block deep-dive — e.g., a data structure, a statistical test, an accounting principle]
+4. [Advanced topic the JD emphasizes — the area where depth separates candidates]
+5. Tell me about a high-stakes failure in your work — how you diagnosed it and what you did.
+6. How do you raise the quality bar on a team?
+
+### Design / Case Study (45–60 min)
+1. Design [a system, process, campaign, or product relevant to the role].
+2. [Constraint question — how does your design behave when something fails, scales 10x, or loses budget?]
+3. [Quality/reliability question — how do you guarantee correctness or measure success?]
+4. Walk me through how you'd know it's working after launch.
+
+### Behavioral Panel
+1. Tell me about a time you led a team through a difficult delivery.
+2. Describe a major failure in production or in market — what happened and what changed after?
+3. Tell me about a time you influenced direction across teams or stakeholders.
+4. What does a high-performing team look like to you?
+5. Tell me about a time you simplified something complex.
+6. Tell me about a time you solved a problem that wasn't yours to solve.
+
+---
+
+## Rules
+
+- **一次一题。** 绝不一次抛出多题。真实面试官一次只问一题。
+- **作答前不给提示。** 不要用"这题考的是 X"给候选人预热。冷开场。
+- **只给诚实反馈。** 虚假鼓励比沉默更糟——会把准备不足的候选人送进真实面试。
+- **建议答案里不编造主张。** 更强版本只能来自候选人说过的内容，或 `cv.md`、`article-digest.md`、故事库——绝不编造经历或指标。
+- **已撤回主张是硬门禁。** 若某主张出现在 `interview-prep/retracted-claims.md`，即使候选人在作答里说了，也绝不写进更强版本——改为标出。
+- **跟踪状态。** 场次结束后，若 `interview-prep/question-bank.md` 存在则更新它。
+- **被要求就停。** 若候选人说"let's pause"或"that's enough for today"，尊重它。不要硬推再来一题。

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -115,6 +115,7 @@ const SYSTEM_PATHS = [
   'modes/heuristics/',
   'modes/regional/',
   'modes/zh/',
+  'modes/zh/interview/',
   'modes/zh-TW/',
   'CLAUDE.md',
   'CODEX.md',


### PR DESCRIPTION
## Summary
- Add `modes/zh/interview/{plan,practice,debrief}.md` — Simplified Chinese translations of the English interview modes
- Keep `##` section headers in English and leave technical tokens (paths, `{slug}` templates, STAR+R, code spans, enums) unchanged
- Register `modes/zh/interview/` in `SYSTEM_PATHS` (`update-system.mjs`)

Closes #1545

## Test plan
- [x] `node validate-system-paths-coverage.mjs` — OK (751 tracked files covered)
- [ ] Spot-check that `##` headers and path/template tokens match the English sources
- [ ] Optional: `node test-all.mjs --quick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chinese-language interview workflows for planning, one-question practice, and post-interview debrief.
  * Planning includes round-specific intelligence, prioritized gap-based study blocks, and a concise pre-interview review.
  * Practice delivers standardized feedback with strict verification and machine-readable session transcript recording.
  * Debriefs assess each question, update story/question banks, optionally capture probabilities, and generate next-round prep; salary notes are saved only when fully specified.
* **Documentation**
  * Expanded guidance for evidence-based recording, retracted-claim handling, vocabulary-gap extraction, competency tagging, and strict Q/A reconstruction rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->