### PR TITLE
fix(arbeitsagentur): only tag nationwide-remote when homeofficetyp is VOLLSTAENDIG

### DIFF
--- a/providers/arbeitsagentur.mjs
+++ b/providers/arbeitsagentur.mjs
@@ -20,8 +20,9 @@
 //       size: 100               # results per keyword (1–100, default 100)
 //       remoteNationwide: true  # also run a nationwide pass keeping remote-eligible hits
 //       remoteMatch: filter     # how that pass detects remote (default 'title'):
-//                               #   'filter' — server-side `homeoffice=nv_true` query + pagination; every hit is
-//                               #              remote-eligible, cheap (no per-job calls). Recommended.
+//                               #   'filter' — server-side `homeoffice=nv_true` query + pagination, then one
+//                               #              detail call per hit to confirm `homeofficetyp: VOLLSTAENDIG`
+//                               #              (nv_true alone also returns hybrid roles). Recommended.
 //                               #   'title'  — regex on the job title only (cheap; misses body-level remote)
 //                               #   'off'    — skip the remote pass entirely
 //       remoteMaxPages: 10      # 'filter' mode: max pages to paginate (size each); default 1
@@ -30,6 +31,10 @@
 const API_URL = 'https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobs';
 const API_KEY = 'jobboerse-jobsuche'; // public client key the arbeitsagentur.de UI uses
 const DETAIL_BASE = 'https://www.arbeitsagentur.de/jobsuche/jobdetail/';
+const DETAIL_API = 'https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobdetails/';
+// Verify in small batches so a wide remote pass can't fire hundreds of detail
+// requests at once.
+const VERIFY_BATCH = 5;
 const REMOTE_RE = /(remote|homeoffice|home[-\s]?office|ortsunabh|deutschlandweit|bundesweit|100\s*%|full[-\s]?remote|fully remote)/i;
 
 // Clamp a runtime integer into [min, max], falling back to `def` for NaN, so a
@@ -95,6 +100,42 @@ export function normalizeJob(job) {
     location: buildLocation(job && job.arbeitsort),
     refnr: String(refnr),
   };
+}
+
+/**
+ * Confirms which of `jobs` are advertised as fully remote.
+ *
+ * The search response carries no home-office field, and the `homeoffice=nv_true`
+ * query only means "home office is possible" — it also matches
+ * `homeofficetyp: NACH_VEREINBARUNG` ("nach Absprache"), i.e. an office-anchored
+ * hybrid role. Only the detail endpoint exposes `homeofficetyp`, so each
+ * candidate is checked there before it may claim to be nationwide-remote.
+ *
+ * Fails closed: a posting whose lookup errors stays untagged, keeping its real
+ * city so the downstream location_filter still applies.
+ *
+ * @param {Array<{refnr: string}>} jobs
+ * @param {{ fetchJson: (url: string, opts?: object) => Promise<any> }} ctx
+ * @returns {Promise<Set<string>>} refnrs confirmed `VOLLSTAENDIG`
+ */
+export async function verifyFullyRemote(jobs, ctx) {
+  const confirmed = new Set();
+  for (let i = 0; i < jobs.length; i += VERIFY_BATCH) {
+    const batch = jobs.slice(i, i + VERIFY_BATCH);
+    await Promise.all(batch.map(async (job) => {
+      try {
+        const json = await ctx.fetchJson(DETAIL_API + Buffer.from(job.refnr).toString('base64'), {
+          headers: { 'X-API-Key': API_KEY, accept: 'application/json' },
+          redirect: 'error',
+          timeoutMs: 12_000,
+        });
+        if (String((json && json.homeofficetyp) || '') === 'VOLLSTAENDIG') confirmed.add(job.refnr);
+      } catch {
+        // Unverifiable → not confirmed. Never tag on optimism.
+      }
+    }));
+  }
+  return confirmed;
 }
 
 /** @type {Provider} */
@@ -172,18 +213,29 @@ export default {
           errors.push(`"${kw}" (remote pass): ${(err && err.message) || err}`);
         }
       }
-      // Pass A (commutable) keeps its city as-is. Pass B roles are remote, so we
-      // append a `Deutschlandweit (Homeoffice)` marker — remote ignores distance,
-      // and this lets scan.mjs's commute-based location_filter pass them via its
-      // always_allow rescue instead of dropping them on the far office city.
+      // Pass A (commutable) keeps its city as-is.
       for (const raw of primary) {
         const job = normalizeJob(raw);
         if (job && !byRef.has(job.refnr)) byRef.set(job.refnr, job);
       }
-      for (const raw of wide) {
-        const job = normalizeJob(raw);
-        if (!job) continue;
-        job.location = job.location ? `${job.location} · Deutschlandweit (Homeoffice)` : 'Deutschlandweit (Homeoffice)';
+      // Pass B roles get a `Deutschlandweit (Homeoffice)` marker, which makes
+      // scan.mjs's commute-based location_filter rescue them via always_allow
+      // instead of dropping them on a far office city. A wrong marker therefore
+      // smuggles an office-anchored hybrid past the distance check, so it may
+      // only be applied on evidence:
+      //   'title'  — the posting's own title claims remote; take it at face value.
+      //   'filter' — `homeoffice=nv_true` only means "home office possible" and
+      //              also returns NACH_VEREINBARUNG (hybrid) roles, so each
+      //              candidate's `homeofficetyp` is confirmed via the detail
+      //              endpoint. Unconfirmed ones keep their real city.
+      const wideJobs = wide.map(normalizeJob).filter(Boolean).filter(job => !byRef.has(job.refnr));
+      const fullyRemote = remoteMatch === 'filter' && wideJobs.length
+        ? await verifyFullyRemote(wideJobs, ctx)
+        : null; // null = mode needs no per-job proof
+      for (const job of wideJobs) {
+        if (!fullyRemote || fullyRemote.has(job.refnr)) {
+          job.location = job.location ? `${job.location} · Deutschlandweit (Homeoffice)` : 'Deutschlandweit (Homeoffice)';
+        }
         if (!byRef.has(job.refnr)) byRef.set(job.refnr, job);
       }
     }

--- a/providers/arbeitsagentur.mjs
+++ b/providers/arbeitsagentur.mjs
@@ -198,8 +198,9 @@ export default {
       if (wo && remoteNationwide && remoteMatch !== 'off') {
         try {
           if (remoteMatch === 'filter') {
-            // Server-side home-office filter: every hit is remote-eligible, so just
-            // paginate and keep them all — no per-job calls, no title regex.
+            // Server-side home-office filter: collect the candidates. `nv_true` only
+            // means "home office is possible", so these are not yet known to be
+            // remote — verifyFullyRemote() confirms each below before tagging.
             for (let page = 1; page <= remoteMaxPages; page++) {
               const res = await fetchKeyword(kw, { homeoffice: 'nv_true', page: String(page) });
               wide.push(...res);
@@ -228,7 +229,15 @@ export default {
       //              also returns NACH_VEREINBARUNG (hybrid) roles, so each
       //              candidate's `homeofficetyp` is confirmed via the detail
       //              endpoint. Unconfirmed ones keep their real city.
-      const wideJobs = wide.map(normalizeJob).filter(Boolean).filter(job => !byRef.has(job.refnr));
+      // Dedup by refnr before verifying: paginating a live index can return the same
+      // posting on two pages, and each duplicate would otherwise cost its own detail request.
+      const wideJobs = [...new Map(
+        wide
+          .map(normalizeJob)
+          .filter(Boolean)
+          .filter(job => !byRef.has(job.refnr))
+          .map(job => [job.refnr, job]),
+      ).values()];
       const fullyRemote = remoteMatch === 'filter' && wideJobs.length
         ? await verifyFullyRemote(wideJobs, ctx)
         : null; // null = mode needs no per-job proof

--- a/tests/providers/arbeitsagentur.test.mjs
+++ b/tests/providers/arbeitsagentur.test.mjs
@@ -127,13 +127,25 @@ try {
     fail(`parseArbeitsagenturConfig remote defaults = ${JSON.stringify({ m: rdef.remoteMatch, p: rdef.remoteMaxPages })}`);
   }
 
-  // fetch() — remoteMatch:'filter' uses server-side homeoffice filter, paginates, and tags remote roles
+  // fetch() — remoteMatch:'filter' uses server-side homeoffice filter, paginates, and tags
+  // only the candidates the detail endpoint confirms as homeofficetyp VOLLSTAENDIG.
+  // `homeoffice=nv_true` also returns NACH_VEREINBARUNG (office-anchored hybrid) roles,
+  // which must keep their real city so the commute location_filter still drops them.
   let usedHomeoffice = false;
   const pagesSeen = new Set();
+  const detailsSeen = [];
+  // R1 München = genuinely remote; R2 Stuttgart = hybrid "nach Absprache"; R3 Köln = lookup fails.
+  const HOMEOFFICETYP = { R1: 'VOLLSTAENDIG', R2: 'NACH_VEREINBARUNG' };
   const filterFetched = await aa.fetch(
     { name: 'AA', arbeitsagentur: { keywords: ['ML'], wo: 'Berlin', remoteNationwide: true, remoteMatch: 'filter', remoteMaxPages: 5, size: 2 } },
     {
       fetchJson: async (url) => {
+        if (url.includes('/jobdetails/')) {
+          const refnr = Buffer.from(url.split('/jobdetails/')[1], 'base64').toString();
+          detailsSeen.push(refnr);
+          if (!(refnr in HOMEOFFICETYP)) throw new Error('HTTP 404'); // unverifiable → must stay untagged
+          return { homeofficetyp: HOMEOFFICETYP[refnr] };
+        }
         const sp = new URL(url).searchParams;
         if (sp.has('wo')) {
           return { stellenangebote: [{ refnr: 'L', titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'Berlin' } }] };
@@ -150,10 +162,28 @@ try {
     },
   );
   const munich = filterFetched.find(j => j.url.endsWith('R1'));
-  if (usedHomeoffice && pagesSeen.has('1') && pagesSeen.has('2') && munich && /Deutschlandweit \(Homeoffice\)/.test(munich.location)) {
-    pass('aa.fetch() remoteMatch:filter sends homeoffice=nv_true, paginates, and tags far-city remote roles');
+  const stuttgart = filterFetched.find(j => j.url.endsWith('R2'));
+  const koeln = filterFetched.find(j => j.url.endsWith('R3'));
+  const TAG = /Deutschlandweit \(Homeoffice\)/;
+  if (usedHomeoffice && pagesSeen.has('1') && pagesSeen.has('2') && munich && TAG.test(munich.location)) {
+    pass('aa.fetch() remoteMatch:filter sends homeoffice=nv_true, paginates, and tags confirmed VOLLSTAENDIG roles');
   } else {
     fail(`aa.fetch() filter mode = ${JSON.stringify({ usedHomeoffice, pages: [...pagesSeen], munichLoc: munich?.location })}`);
+  }
+  if (stuttgart && !TAG.test(stuttgart.location) && stuttgart.location === 'Stuttgart') {
+    pass('aa.fetch() does not tag NACH_VEREINBARUNG (hybrid) roles as nationwide remote');
+  } else {
+    fail(`aa.fetch() NACH_VEREINBARUNG role = ${JSON.stringify({ loc: stuttgart?.location })}`);
+  }
+  if (koeln && !TAG.test(koeln.location) && koeln.location === 'Köln') {
+    pass('aa.fetch() leaves a posting untagged when the homeofficetyp lookup fails');
+  } else {
+    fail(`aa.fetch() unverifiable role = ${JSON.stringify({ loc: koeln?.location })}`);
+  }
+  if (detailsSeen.length === 3 && ['R1', 'R2', 'R3'].every(r => detailsSeen.includes(r))) {
+    pass('aa.fetch() verifies homeofficetyp once per remote candidate');
+  } else {
+    fail(`aa.fetch() detail lookups = ${JSON.stringify(detailsSeen)}`);
   }
 
   // fetch() — no keywords throws; total outage throws (not silent)

--- a/tests/providers/arbeitsagentur.test.mjs
+++ b/tests/providers/arbeitsagentur.test.mjs
@@ -186,6 +186,52 @@ try {
     fail(`aa.fetch() detail lookups = ${JSON.stringify(detailsSeen)}`);
   }
 
+  // fetch() — the detail lookups must stay batched (VERIFY_BATCH = 5). With more
+  // candidates than one batch, peak in-flight requests must never exceed the cap,
+  // and a duplicate refnr across pagination pages must not cost a second lookup.
+  // Both would pass silently under an unbounded Promise.all / an un-deduped list.
+  let inFlight = 0;
+  let peakInFlight = 0;
+  const detailCalls = [];
+  const wideRefs = ['W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'W7'];
+  const batchFetched = await aa.fetch(
+    { name: 'AA', arbeitsagentur: { keywords: ['ML'], wo: 'Berlin', remoteNationwide: true, remoteMatch: 'filter', remoteMaxPages: 5, size: 7 } },
+    {
+      fetchJson: async (url) => {
+        if (url.includes('/jobdetails/')) {
+          const refnr = Buffer.from(url.split('/jobdetails/')[1], 'base64').toString();
+          detailCalls.push(refnr);
+          inFlight++;
+          peakInFlight = Math.max(peakInFlight, inFlight);
+          await new Promise(r => setTimeout(r, 5)); // hold the slot so overlap is observable
+          inFlight--;
+          return { homeofficetyp: 'VOLLSTAENDIG' };
+        }
+        const sp = new URL(url).searchParams;
+        if (sp.has('wo')) return { stellenangebote: [] };
+        // Page 1 is full (== size) so pagination continues; W1 repeats on page 2.
+        return Number(sp.get('page')) === 1
+          ? { stellenangebote: wideRefs.map(r => ({ refnr: r, titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'München' } })) }
+          : { stellenangebote: [{ refnr: 'W1', titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'München' } }] };
+      },
+    },
+  );
+  if (peakInFlight > 0 && peakInFlight <= 5) {
+    pass(`aa.fetch() caps concurrent homeofficetyp lookups at VERIFY_BATCH (peak ${peakInFlight})`);
+  } else {
+    fail(`aa.fetch() peak in-flight detail requests = ${peakInFlight} (expected 1..5)`);
+  }
+  if (detailCalls.length === wideRefs.length && new Set(detailCalls).size === wideRefs.length) {
+    pass('aa.fetch() verifies each duplicated refnr only once');
+  } else {
+    fail(`aa.fetch() detail calls = ${detailCalls.length} (${JSON.stringify(detailCalls)}), expected ${wideRefs.length} unique`);
+  }
+  if (batchFetched.length === wideRefs.length && batchFetched.every(j => /Deutschlandweit \(Homeoffice\)/.test(j.location))) {
+    pass('aa.fetch() tags every confirmed VOLLSTAENDIG candidate across batches');
+  } else {
+    fail(`aa.fetch() batched tagging = ${JSON.stringify(batchFetched.map(j => j.location))}`);
+  }
+
   // fetch() — no keywords throws; total outage throws (not silent)
   let noKw = false;
   try { await aa.fetch({ name: 'AA', arbeitsagentur: {} }, mkCtx({})); } catch { noKw = true; }


### PR DESCRIPTION
The `remoteMatch: 'filter'` pass assumes every `homeoffice=nv_true` hit is remote (the code comment says *"every hit is remote-eligible"*) and stamps `Deutschlandweit (Homeoffice)` on all of them.

That query actually means **"home office is possible"**, so it also returns `homeofficetyp: NACH_VEREINBARUNG` — office-anchored hybrid roles advertised as *"Homeoffice nach Absprache"*.

The marker is not cosmetic: it makes `scan.mjs`'s commute-based `location_filter` rescue the role via `always_allow`, so a wrong one **smuggles a hybrid role at a far office past the distance check** and it reaches evaluation as if it were remote.

## Reproduction (public API, no auth)

```
GET /v4/jobs?was=Data%20Scientist&homeoffice=nv_true&size=5
```

Resolving each hit through `/v4/jobdetails/{base64(refnr)}`:

| arbeitsort | homeofficetyp | tagged `Deutschlandweit`? |
|---|---|---|
| Mülheim an der Ruhr | `NACH_VEREINBARUNG` | ✅ (wrong) |
| Frankfurt am Main | `NACH_VEREINBARUNG` | ✅ (wrong) |
| Kassel | `NACH_VEREINBARUNG` | ✅ (wrong) |
| Berlin | `NACH_VEREINBARUNG` | ✅ (wrong) |
| München | `NACH_VEREINBARUNG` | ✅ (wrong) |

**5 of 5 false.** Zero were `VOLLSTAENDIG`. I hit this in real use: four roles reached full evaluation labelled nationwide-remote whose own postings said München *Hybrid*, Essen *"tageweise mobiles Arbeiten"*, Frankfurt *"Hybrides Arbeitsmodell"*, and Mülheim *"Mobile-Working-Regelungen"*.

## Why a per-job call

The search response carries no home-office field (keys are `beruf, titel, refnr, arbeitsort, arbeitgeber, …`), and the API offers no server-side filter for it:

- `homeoffice=VOLLSTAENDIG` → HTTP 500
- `homeofficetyp=VOLLSTAENDIG` → silently ignored, returns the unfiltered set (356 vs 39)

So confirming via the detail endpoint is the only option. `'filter'` mode now costs **one detail call per remote hit**, batched 5 at a time. That loses the "no per-job calls" property — but the free version was wrong, and the pass exists precisely to bypass the distance check, which is the one place a false positive is expensive.

**Fails closed:** unconfirmed *and* unverifiable postings keep their real city and get filtered normally, rather than tagged on optimism.

## Scope

Deliberately limited to `'filter'` mode. `'title'` mode's tag rests on the posting's own explicit remote title — a narrower basis this query bug doesn't touch — so it stays free of per-job calls as documented. Happy to extend it if you'd rather the marker always require proof.

## Tests

`tests/providers/arbeitsagentur.test.mjs` — the existing `'filter'` test asserted the buggy behaviour, so it now encodes the rule, plus three new cases: hybrid stays untagged, lookup failure stays untagged, and one lookup per candidate.

`node test-all.mjs` → **1790 passed**. One unrelated pre-existing failure (`tracker-columns-tests.mjs` crashes with `MODULE_NOT_FOUND` on Node 18.20.8, on clean `main` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-demand verification step for nationwide “fully remote” tagging in remote filter mode using job details.
  * Applies nationwide remote designation only when job details confirm full home-office eligibility.

* **Bug Fixes**
  * Prevents hybrid roles and jobs with unverifiable home-office status from being incorrectly marked as fully remote.

* **Tests**
  * Extended provider tests to validate verification behavior, pagination handling, and batched/concurrency limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->