### PR TITLE
feat(cv): add a polished Chinese minimal CV template

### DIFF
--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -112,6 +112,7 @@ cv:
   # templates/cv-template.html. You can also pick per-generation just by asking
   # (e.g. "use the modern template").
   # template: modern
+  # For a restrained Chinese technical CV, use: template: zh-minimal
 
 # ── Culture Screen ───────────────────────────────────────────────────────────
 #

--- a/templates/cv-template.zh-minimal.html
+++ b/templates/cv-template.zh-minimal.html
@@ -1,0 +1,695 @@
+<!DOCTYPE html>
+<!-- career-ops-template
+name: Chinese Minimal
+version: 1.0.0
+-->
+<html lang="{{LANG}}">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{NAME}} — CV</title>
+<style>
+  /* ATS-safe typography (#font-extraction fix):
+     The bundled variable woff2 fonts (Space Grotesk / DM Sans) render with
+     glyph advances that make PDF text extractors inject spurious spaces inside
+     words (e.g. "SUM M ARY", "Germ any") — which corrupts ATS keyword parsing.
+     This template's job is clean machine-readable parsing, so we use a standard
+     static system sans stack instead. Verified clean via pypdf text extraction.
+     The lang="ja" rules reuse this Latin base stack (with a CJK fallback added);
+     the lang="ar" rules below intentionally define their own Arabic stack. */
+
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    /* Disable fi/fl/ffi ligatures. Headless Chromium substitutes these letter
+       pairs with the Unicode glyphs U+FB01/FB02/FB03 at PDF layout time, and PDF
+       text extractors (what ATS systems read) decode them back to those
+       codepoints, so "verification" becomes "veriﬁcation" and a literal keyword
+       search misses it. Setting this on every element covers headings and
+       competency tags too. Required ligatures (rlig) stay on, so Arabic shaping
+       is unaffected. */
+    font-variant-ligatures: none;
+    font-feature-settings: "liga" 0, "clig" 0, "dlig" 0;
+  }
+
+  html {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  body {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-size: 11px;
+    line-height: 1.5;
+    color: #1a1a2e;
+    background: #ffffff;
+    padding: 0;
+    margin: 0;
+    /* Disable ligatures here as well; see the * rule above. */
+    font-variant-ligatures: none;
+    font-feature-settings: "liga" 0, "clig" 0, "dlig" 0;
+  }
+
+  .page {
+    width: 100%;
+    max-width: {{PAGE_WIDTH}};
+    margin: 0 auto;
+    padding: 2px 0;
+  }
+
+  /* === HEADER === */
+  .header {
+    margin-bottom: 20px;
+  }
+
+  .header h1 {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-size: 28px;
+    font-weight: 700;
+    color: #1a1a2e;
+    letter-spacing: -0.02em;
+    margin-bottom: 6px;
+    line-height: 1.1;
+  }
+
+  .header-gradient {
+    height: 2px;
+    background: linear-gradient(to right, hsl(187, 74%, 32%), hsl(270, 70%, 45%));
+    border-radius: 1px;
+    margin-bottom: 10px;
+  }
+
+  .contact-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 14px;
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-size: 10.5px;
+    line-height: 1.4;
+    color: #555;
+  }
+
+  .contact-row a {
+    color: #555;
+    text-decoration: none;
+  }
+
+  .contact-row .separator {
+    color: #ccc;
+  }
+
+  /* === OPTIONAL PROFILE PHOTO (opt-in, DACH/European markets — #264) ===
+     Off by default: with no candidate.photo the {{PHOTO}} slot is empty, no
+     <img> is emitted, and the layout is byte-identical to a photoless CV.
+     When opted in (candidate.photo in config/profile.yml) the photo floats into
+     the top corner and the header/summary text wraps beside it. Photos are
+     penalized by US/UK/many-market ATS, so this is never on by default. */
+  .cv-photo {
+    float: right;
+    width: 80px;
+    height: 100px;
+    object-fit: cover;
+    margin: 0 0 8px 14px;
+    border-radius: 3px;
+    border: 1px solid #e2e2e2;
+  }
+
+  /* === SECTIONS === */
+  .section {
+    margin-bottom: 18px;
+  }
+
+  .section-title {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: hsl(187, 74%, 32%);
+    border-bottom: 1.5px solid #e2e2e2;
+    padding-bottom: 4px;
+    margin-bottom: 10px;
+    line-height: 1.2;
+  }
+
+  /* === PROFESSIONAL SUMMARY === */
+  .summary-text {
+    font-size: 11px;
+    line-height: 1.7;
+    color: #2f2f2f;
+  }
+
+  .summary-text strong {
+    font-weight: 700;
+    color: #1a1a1a;
+  }
+
+  /* Links must never break across lines */
+  a {
+    white-space: nowrap;
+  }
+
+  /* === CORE COMPETENCIES === */
+  .competencies-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .competency-tag {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-size: 10px;
+    font-weight: 500;
+    color: hsl(187, 74%, 28%);
+    background: hsl(187, 40%, 95%);
+    padding: 4px 10px;
+    border-radius: 3px;
+    border: 1px solid hsl(187, 40%, 88%);
+  }
+
+  /* === WORK EXPERIENCE === */
+  .job {
+    margin-bottom: 14px;
+  }
+
+  .job-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 4px;
+  }
+
+  .job-company {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: hsl(270, 70%, 45%);
+  }
+
+  .job-period {
+    font-size: 10.5px;
+    color: #777;
+    white-space: nowrap;
+  }
+
+  .job-role {
+    font-size: 11px;
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 6px;
+  }
+
+  .job-location {
+    font-size: 10px;
+    color: #888;
+  }
+
+  .job ul {
+    padding-left: 18px;
+    margin-top: 6px;
+  }
+
+  .job li {
+    font-size: 10.5px;
+    line-height: 1.6;
+    color: #333;
+    margin-bottom: 4px;
+  }
+
+  .job li strong {
+    font-weight: 600;
+  }
+
+  /* === PROJECTS === */
+  .project {
+    margin-bottom: 12px;
+  }
+
+  .project-title {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'DejaVu Sans', sans-serif;
+    font-size: 11.5px;
+    font-weight: 600;
+    color: hsl(270, 70%, 45%);
+  }
+
+  .project-badge {
+    font-size: 9px;
+    font-weight: 500;
+    color: hsl(187, 74%, 32%);
+    background: hsl(187, 40%, 95%);
+    padding: 1px 6px;
+    border-radius: 2px;
+    margin-left: 6px;
+  }
+
+  .project-desc {
+    font-size: 10.5px;
+    color: #444;
+    margin-top: 3px;
+    line-height: 1.55;
+  }
+
+  .project-tech {
+    font-size: 9.5px;
+    color: #888;
+    margin-top: 3px;
+  }
+
+  /* === EDUCATION === */
+  .edu-item {
+    margin-bottom: 8px;
+  }
+
+  .edu-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+  }
+
+  .edu-title {
+    font-weight: 600;
+    font-size: 11px;
+    color: #333;
+  }
+
+  .edu-org {
+    color: hsl(270, 70%, 45%);
+    font-weight: 500;
+  }
+
+  .edu-year {
+    font-size: 10px;
+    color: #777;
+    white-space: nowrap;
+  }
+
+  .edu-desc {
+    font-size: 10px;
+    color: #666;
+    margin-top: 2px;
+    line-height: 1.5;
+  }
+
+  /* === CERTIFICATIONS === */
+  .cert-table {
+    display: table;
+    width: 100%;
+  }
+
+  .cert-item {
+    display: table-row;
+  }
+
+  .cert-item > * {
+    display: table-cell;
+    vertical-align: baseline;
+    padding-bottom: 6px;
+  }
+
+  .cert-title {
+    font-size: 10.5px;
+    font-weight: 500;
+    color: #333;
+  }
+
+  .cert-org {
+    color: hsl(270, 70%, 45%);
+    white-space: nowrap;
+  }
+
+  .cert-year {
+    font-size: 10px;
+    color: #777;
+    white-space: nowrap;
+    text-align: right;
+    width: 44px;
+  }
+
+  /* === SKILLS === */
+  .skills-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+  }
+
+  .skill-item {
+    font-size: 10.5px;
+    color: #444;
+  }
+
+  .skill-category {
+    font-weight: 600;
+    color: #333;
+    font-size: 10.5px;
+  }
+
+  /* === PRINT === */
+  @media print {
+    body {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
+
+    /* Keep a small right gutter for the print box. Right-aligned content
+       (job periods, education years) right-aligns to the content-box edge,
+       and the rightmost glyph's side bearing can spill ~1px past it and get
+       clipped by Chromium's print clip. A plain `.page` padding is reset to 0
+       here for print, which is why padding set outside @media print has no
+       effect; restoring a right gutter inside the print rule fixes it without
+       re-centering the page or hard-coding a per-format max-width. See #1341. */
+    .page {
+      padding: 0 0.18in 0 0;
+    }
+  }
+
+  /* === PAGE BREAK CONTROL === */
+  /* Only avoid breaking small atomic units (a cert row, an education line, the
+     header, a single competency or skill).  Sections and multi-bullet roles are
+     allowed to flow across a page boundary so content packs tight instead of
+     jumping wholesale and leaving large bottom gaps. */
+  .header,
+  .edu-item,
+  .cert-item,
+  .competency-tag,
+  .skill-item {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Keep a heading attached to the content that follows it, so headings are not
+     orphaned at the bottom of a page. */
+  .section-title,
+  .job-company,
+  .job-role,
+  .job-location,
+  .project-title {
+    break-after: avoid;
+    page-break-after: avoid;
+  }
+
+  /* === RTL (Arabic) Support === */
+  html[lang="ar"] body {
+    direction: rtl;
+    text-align: right;
+    font-family: 'Segoe UI', Tahoma, Arial, sans-serif;
+  }
+
+  html[lang="ar"] .header h1,
+  html[lang="ar"] .section-title,
+  html[lang="ar"] .job-company,
+  html[lang="ar"] .project-title,
+  html[lang="ar"] .competency-tag,
+  html[lang="ar"] .skill-category {
+    font-family: 'Segoe UI', Tahoma, Arial, sans-serif;
+  }
+
+  html[lang="ar"] .header-gradient {
+    background: linear-gradient(to left, hsl(187, 74%, 32%), hsl(270, 70%, 45%));
+  }
+
+  html[lang="ar"] .job ul {
+    padding-right: 18px;
+    padding-left: 0;
+  }
+
+  html[lang="ar"] .project-badge {
+    margin-right: 6px;
+    margin-left: 0;
+  }
+
+  html[lang="ar"] .cert-year {
+    text-align: left;
+  }
+
+  html[lang="ar"] .cert-table {
+    direction: rtl;
+  }
+
+  html[lang="ar"] .cv-photo {
+    float: left;
+    margin: 0 14px 8px 0;
+  }
+
+  /* === CJK (Japanese) font fallback === */
+  /* The bundled webfonts are Latin-only (see #951). Without a CJK fallback,
+     Japanese text renders as tofu (□) in headless Chromium on any system
+     without a CJK system font (Linux/CI, minimal containers). The Latin brand
+     fonts are kept first so ASCII still uses Space Grotesk / DM Sans, then the
+     browser's per-glyph fallback picks the first installed CJK face for kana
+     and kanji. Mirrors the lang="ar" precedent above. */
+  html[lang="ja"] body {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+      'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
+      Meiryo, 'MS PGothic', sans-serif;
+  }
+
+  html[lang="ja"] .header h1,
+  html[lang="ja"] .section-title,
+  html[lang="ja"] .job-company,
+  html[lang="ja"] .project-title,
+  html[lang="ja"] .competency-tag,
+  html[lang="ja"] .skill-category {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+      'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
+      Meiryo, 'MS PGothic', sans-serif;
+  }
+
+  /* === CHINESE MINIMAL DESIGN ===
+     An opt-in, restrained visual system for Chinese and mixed-language
+     technical CVs. The document stays single-column and ATS-readable. */
+  :root {
+    --zhm-ink: #172033;
+    --zhm-text: #2f3747;
+    --zhm-muted: #667085;
+    --zhm-rule: #d9dee8;
+    --zhm-accent: #174a7e;
+  }
+
+  body,
+  html[lang="zh-CN"] body,
+  html[lang="zh"] body {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang SC',
+      'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC',
+      'Noto Sans SC', 'Source Han Sans SC', sans-serif;
+    color: var(--zhm-text);
+    line-break: strict;
+    word-break: normal;
+    overflow-wrap: break-word;
+  }
+
+  .header {
+    margin-bottom: 18px;
+  }
+
+  .header h1 {
+    font-family: inherit;
+    font-size: 27px;
+    color: var(--zhm-ink);
+    letter-spacing: 0.02em;
+    margin-bottom: 8px;
+  }
+
+  .header-gradient {
+    height: 1px;
+    margin-bottom: 9px;
+    border-radius: 0;
+    background: var(--zhm-ink);
+  }
+
+  .contact-row,
+  .contact-row a {
+    color: var(--zhm-muted);
+  }
+
+  .section {
+    margin-bottom: 17px;
+  }
+
+  .section-title {
+    font-family: inherit;
+    font-size: 12px;
+    color: var(--zhm-ink);
+    text-transform: none;
+    letter-spacing: 0.08em;
+    border-bottom: 1px solid var(--zhm-rule);
+    padding-bottom: 5px;
+    margin-bottom: 10px;
+  }
+
+  .summary-text {
+    color: var(--zhm-text);
+    line-height: 1.72;
+  }
+
+  .competencies-grid {
+    display: block;
+    line-height: 1.7;
+  }
+
+  .competency-tag {
+    display: inline;
+    font-family: inherit;
+    font-size: 10.5px;
+    font-weight: 500;
+    color: var(--zhm-text);
+    background: none;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+  }
+
+  .competency-tag:not(:last-child)::after {
+    content: '  ·  ';
+    color: #98a2b3;
+  }
+
+  .job {
+    margin-bottom: 15px;
+  }
+
+  .job-header {
+    margin-bottom: 3px;
+  }
+
+  .job-company {
+    font-family: inherit;
+    font-size: 12.5px;
+    font-weight: 700;
+    color: var(--zhm-ink);
+  }
+
+  .job-period,
+  .job-location {
+    color: var(--zhm-muted);
+  }
+
+  .job-role {
+    color: var(--zhm-accent);
+    font-weight: 600;
+    margin-bottom: 5px;
+  }
+
+  .job li {
+    color: var(--zhm-text);
+    line-height: 1.65;
+  }
+
+  .project {
+    margin-bottom: 13px;
+  }
+
+  .project-title {
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--zhm-ink);
+  }
+
+  .project-badge {
+    color: var(--zhm-accent);
+    background: none;
+    border: 1px solid var(--zhm-rule);
+    border-radius: 2px;
+  }
+
+  .project-desc {
+    color: var(--zhm-text);
+    line-height: 1.62;
+  }
+
+  .project-tech {
+    color: var(--zhm-muted);
+  }
+
+  .edu-org,
+  .cert-org {
+    color: var(--zhm-accent);
+  }
+
+  .skills-grid {
+    display: block;
+  }
+
+  .skill-item {
+    color: var(--zhm-text);
+    margin-bottom: 4px;
+    line-height: 1.55;
+  }
+
+  .skill-category {
+    font-family: inherit;
+    color: var(--zhm-ink);
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  {{PHOTO}}
+  <!-- HEADER -->
+  <div class="header">
+    <h1>{{NAME}}</h1>
+    <div class="header-gradient"></div>
+    <div class="contact-row">
+      <a href="tel:{{PHONE}}">{{PHONE}}</a>
+      <span class="separator">|</span>
+      <a href="mailto:{{EMAIL}}">{{EMAIL}}</a>
+      <span class="separator">|</span>
+      <a href="{{LINKEDIN_URL}}">{{LINKEDIN_DISPLAY}}</a>
+      <span class="separator">|</span>
+      <a href="{{PORTFOLIO_URL}}">{{PORTFOLIO_DISPLAY}}</a>
+      <span class="separator">|</span>
+      <span>{{LOCATION}}</span>
+    </div>
+  </div>
+
+  <!-- PROFESSIONAL SUMMARY -->
+  <div class="section">
+    <div class="section-title">{{SECTION_SUMMARY}}</div>
+    <div class="summary-text">{{SUMMARY_TEXT}}</div>
+  </div>
+
+  <!-- CORE COMPETENCIES -->
+  <div class="section">
+    <div class="section-title">{{SECTION_COMPETENCIES}}</div>
+    <div class="competencies-grid">
+      {{COMPETENCIES}}
+    </div>
+  </div>
+
+  <!-- WORK EXPERIENCE -->
+  <div class="section">
+    <div class="section-title">{{SECTION_EXPERIENCE}}</div>
+    {{EXPERIENCE}}
+  </div>
+
+  <!-- PROJECTS -->
+  <div class="section">
+    <div class="section-title">{{SECTION_PROJECTS}}</div>
+    {{PROJECTS}}
+  </div>
+
+  <!-- EDUCATION -->
+  <div class="section">
+    <div class="section-title">{{SECTION_EDUCATION}}</div>
+    {{EDUCATION}}
+  </div>
+
+  <!-- CERTIFICATIONS -->
+  <div class="section">
+    <div class="section-title">{{SECTION_CERTIFICATIONS}}</div>
+    <div class="cert-table">{{CERTIFICATIONS}}</div>
+  </div>
+
+  <!-- SKILLS -->
+  <div class="section">
+    <div class="section-title">{{SECTION_SKILLS}}</div>
+    {{SKILLS}}
+  </div>
+
+</div>
+</body>
+</html>

--- a/templates/cv-template.zh-minimal.html
+++ b/templates/cv-template.zh-minimal.html
@@ -145,9 +145,10 @@ version: 1.0.0
     color: #1a1a1a;
   }
 
-  /* Links must never break across lines */
+  /* Keep long contact values inside the printable A4 box. */
   a {
-    white-space: nowrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   /* === CORE COMPETENCIES === */

--- a/test/zh-minimal-template.test.mjs
+++ b/test/zh-minimal-template.test.mjs
@@ -1,0 +1,59 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { listTemplates, resolveTemplate, validateTemplate } from '../cv-templates.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const TEMPLATE = join(ROOT, 'templates', 'cv-template.zh-minimal.html');
+
+test('Chinese Minimal template is discoverable and valid', () => {
+  const listed = listTemplates('cv');
+  const entry = listed.find((item) => item.name === 'zh-minimal');
+  assert.equal(entry?.displayName, 'Chinese Minimal');
+  assert.equal(resolveTemplate('cv', 'zh-minimal'), TEMPLATE);
+  assert.deepEqual(validateTemplate(TEMPLATE, 'cv'), { ok: true, missing: [] });
+});
+
+test('Chinese Minimal uses one restrained accent and removes chip styling', () => {
+  const html = readFileSync(TEMPLATE, 'utf8');
+  assert.match(html, /--zhm-accent:\s*#174a7e/);
+  assert.match(html, /\.header-gradient\s*\{[^}]*height:\s*1px[^}]*background:\s*var\(--zhm-ink\)/s);
+  assert.match(html, /\.competency-tag\s*\{[^}]*background:\s*none[^}]*border:\s*0/s);
+  assert.doesNotMatch(html.slice(html.indexOf('CHINESE MINIMAL DESIGN')), /hsl\(270/);
+});
+
+test('Chinese Minimal renders a complete mixed-language payload', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'zh-minimal-'));
+  const input = join(dir, 'cv.json');
+  const output = join(dir, 'cv.html');
+  writeFileSync(input, JSON.stringify({
+    lang: 'zh-CN',
+    page_format: 'a4',
+    candidate: { name: '测试候选人', email: 'candidate@example.com', location: '中国｜杭州' },
+    sections: {
+      summary: '个人简介', competencies: '核心能力', experience: '工作经历',
+      projects: '精选项目', education: '教育经历', certifications: '认证', skills: '技术栈',
+    },
+    summary: '全栈工程师，负责 AI Agent 工作流与生产部署。',
+    competencies: ['AI Agent 工作流', '后端 API 工程', '生产部署'],
+    experience: [{
+      company: '示例科技有限公司', role: '全栈开发工程师', dates: '2025.01 至今',
+      bullets: ['交付 React、FastAPI 与数据库组成的生产系统。'],
+    }],
+    projects: [{ name: '开源自动化项目', badge: '开源', tech: 'Node.js · Playwright', description: '构建可验证的自动化流程。' }],
+    education: [{ title: '计算机科学与技术', org: '示例大学', year: '2025' }],
+    certifications: [],
+    skills: [{ category: '工程能力', items: ['TypeScript', 'FastAPI', 'Docker'] }],
+  }));
+
+  execFileSync(process.execPath, ['build-cv-html.mjs', input, output, TEMPLATE], { cwd: ROOT });
+  const rendered = readFileSync(output, 'utf8');
+  assert.match(rendered, /<html lang="zh-CN">/);
+  assert.match(rendered, /测试候选人/);
+  assert.match(rendered, /AI Agent 工作流/);
+  assert.doesNotMatch(rendered, /\{\{[A-Z_]+\}\}/);
+});

--- a/test/zh-minimal-template.test.mjs
+++ b/test/zh-minimal-template.test.mjs
@@ -4,7 +4,7 @@ import { existsSync, readFileSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { listTemplates, resolveTemplate, validateTemplate } from '../cv-templates.mjs';
 import { chromium } from 'playwright';
 
@@ -84,7 +84,7 @@ test('Chinese Minimal keeps long mixed-language contacts inside the A4 page', {
   try {
     const page = await browser.newPage({ viewport: { width: 794, height: 1123 } });
     await page.emulateMedia({ media: 'print' });
-    await page.goto(`file://${output}`);
+    await page.goto(pathToFileURL(output).href);
     const layout = await page.evaluate(() => {
       const printable = document.querySelector('.page');
       const right = printable.getBoundingClientRect().right;

--- a/test/zh-minimal-template.test.mjs
+++ b/test/zh-minimal-template.test.mjs
@@ -1,11 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { listTemplates, resolveTemplate, validateTemplate } from '../cv-templates.mjs';
+import { chromium } from 'playwright';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const TEMPLATE = join(ROOT, 'templates', 'cv-template.zh-minimal.html');
@@ -56,4 +57,45 @@ test('Chinese Minimal renders a complete mixed-language payload', () => {
   assert.match(rendered, /测试候选人/);
   assert.match(rendered, /AI Agent 工作流/);
   assert.doesNotMatch(rendered, /\{\{[A-Z_]+\}\}/);
+});
+
+test('Chinese Minimal keeps long mixed-language contacts inside the A4 page', {
+  skip: !existsSync(chromium.executablePath()) && 'Chromium is not installed',
+}, async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'zh-minimal-layout-'));
+  const input = join(dir, 'cv.json');
+  const output = join(dir, 'cv.html');
+  writeFileSync(input, JSON.stringify({
+    lang: 'zh-CN', page_format: 'a4',
+    candidate: {
+      name: '测试候选人',
+      email: 'candidate-with-an-intentionally-long-address-for-print-regression@example-company.cn',
+      location: '中国｜杭州',
+      portfolio: 'https://example.com/一个很长的中英文混合项目地址/remote-agent-production-delivery',
+    },
+    summary: '全栈工程师，负责 AI Agent 工作流与生产部署。',
+    competencies: ['AI Agent 工作流'],
+    experience: [{ company: '示例科技有限公司', role: '工程师', dates: '2025 至今', bullets: ['交付生产系统。'] }],
+    projects: [], education: [], certifications: [], skills: [],
+  }));
+  execFileSync(process.execPath, ['build-cv-html.mjs', input, output, TEMPLATE], { cwd: ROOT });
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage({ viewport: { width: 794, height: 1123 } });
+    await page.emulateMedia({ media: 'print' });
+    await page.goto(`file://${output}`);
+    const layout = await page.evaluate(() => {
+      const printable = document.querySelector('.page');
+      const right = printable.getBoundingClientRect().right;
+      const overflow = [...printable.querySelectorAll('*')]
+        .filter((element) => element.getBoundingClientRect().right > right + 0.5)
+        .map((element) => element.className || element.tagName);
+      return { documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth, overflow };
+    });
+    assert.equal(layout.documentOverflow, false);
+    assert.deepEqual(layout.overflow, []);
+  } finally {
+    await browser.close();
+  }
 });

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -269,6 +269,7 @@ const SYSTEM_PATHS = [
   'cv-templates.mjs',
   'test/cv-templates.test.mjs',
   'test/cover-resolver.test.mjs',
+  'test/zh-minimal-template.test.mjs',
   'scaffolder/',
   'Dockerfile',
   'docker-compose.yml',

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -269,6 +269,7 @@ const SYSTEM_PATHS = [
   'cv-templates.mjs',
   'test/cv-templates.test.mjs',
   'test/cover-resolver.test.mjs',
+  'templates/cv-template.zh-minimal.html',
   'test/zh-minimal-template.test.mjs',
   'scaffolder/',
   'Dockerfile',


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `zh-minimal` HTML CV template with restrained typography, a single accent color, text-based competencies, and clearer project/experience hierarchy for Chinese technical resumes. The existing Standard template remains unchanged.

## Related issue

Closes #1985

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] The feature has an issue first
- [x] No personal data is included
- [x] `node test-all.mjs` passes
- [x] The Data Contract is respected
- [x] The change aligns with the local-first project direction

## Validation

- `node --test test/zh-minimal-template.test.mjs test/cv-templates.test.mjs`
- `node cv-templates.mjs list cv`
- `node build-cv-html.mjs --test`
- `node test-all.mjs` — 1797 passed, 0 failed, 1 expected warning
- visually inspected a rendered zh-CN A4 preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a restrained, single-column “Chinese Minimal” résumé template with ATS-safe typography, optional photo placement, and refined Chinese/Japanese/Arabic layout styling.
  * Updated the example profile configuration to point to the new template.
* **Tests**
  * Added automated template discovery/validation checks, HTML rendering end-to-end verification (no unresolved placeholders), and a print/A4 layout overflow regression test.  
* **Chores**
  * Included the new template and its test in the system update manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->