### PR TITLE
fix(web): label-aware pipeline.md reader — posted:/trust:/note: never misread as columns

### DIFF
--- a/web/src/lib/career-ops.ts
+++ b/web/src/lib/career-ops.ts
@@ -47,10 +47,20 @@ function read(rel: string): string | null {
 
 export type InboxJob = { url: string; company: string; role: string; location?: string; compensation?: string; done: boolean; postedAt?: string };
 
-/** Parse data/pipeline.md — `- [ ] URL | Company | Role [| Location [| Compensation]]`.
- *  Positional split (NOT a greedy trailing group): the optional 4th `location`
- *  (#1015) and 5th `compensation` (#1017) columns must NOT bleed into `role`;
- *  any further trailing columns are ignored gracefully. */
+/** A pipeline-row segment like `posted: 2026-07-14`, `trust: 62 stale` or
+ *  `note: …` — the core appends these LABELED segments after whatever
+ *  positional shape a row has (3/4/5 columns), so a naive positional reader
+ *  would misread them as location/compensation on short rows. Any
+ *  `word:`-prefixed segment is treated as labeled (forward-compatible with
+ *  labels the core hasn't invented yet). */
+const LABELED_SEGMENT = /^([a-z][a-z_-]*):\s*(.*)$/i;
+
+/** Parse data/pipeline.md — `- [ ] URL | Company | Role [| Location [| Compensation]] [| label: …]*`.
+ *  Positional split for the first columns (the optional 4th `location` #1015
+ *  and 5th `compensation` #1017 must NOT bleed into `role`); labeled segments
+ *  (posted:/trust:/note:/…) are filtered out of positional assignment wherever
+ *  they appear and surfaced when useful (posted: → postedAt). Unknown labels
+ *  and further trailing columns are ignored gracefully. */
 export function readInbox(): InboxJob[] {
   const md = read("data/pipeline.md");
   if (!md) return [];
@@ -58,8 +68,17 @@ export function readInbox(): InboxJob[] {
   for (const line of md.split("\n")) {
     const m = line.match(/^\s*-\s*\[([ xX])\]\s*(.+)$/);
     if (!m) continue;
-    const parts = m[2].split("|").map((s) => s.trim());
+    const all = m[2].split("|").map((s) => s.trim());
+    const labels = new Map<string, string>();
+    const parts: string[] = [];
+    for (const [i, seg] of all.entries()) {
+      // the URL cell can contain a colon-y value but is always position 0
+      const lm = i >= 3 ? seg.match(LABELED_SEGMENT) : null;
+      if (lm) labels.set(lm[1].toLowerCase(), lm[2].trim());
+      else parts.push(seg);
+    }
     if (parts.length < 3 || !parts[0]) continue; // need at least url | company | role
+    const posted = labels.get("posted");
     jobs.push({
       done: m[1].toLowerCase() === "x",
       url: parts[0],
@@ -67,6 +86,9 @@ export function readInbox(): InboxJob[] {
       role: parts[2],
       location: parts[3] || undefined, // optional 4th column (#1015)
       compensation: parts[4] || undefined, // optional 5th column (#1017); 6th+ ignored
+      // the row's own posting date (scan.mjs `posted:` label) — a more direct
+      // freshness signal than the scan-history join, which stays as fallback
+      postedAt: posted && /^\d{4}-\d{2}-\d{2}$/.test(posted) ? posted : undefined,
     });
   }
   return jobs;
@@ -187,7 +209,7 @@ export function pipelineSummary(): PipelineSummary {
     rootExists: fs.existsSync(root),
     // join the freshness date (first_seen) onto each raw posting — the inbox's
     // triage view orders/faceted-filters on it entirely client-side.
-    inbox: readInbox().map((j) => ({ ...j, postedAt: scanDates.get(j.url) })),
+    inbox: readInbox().map((j) => ({ ...j, postedAt: j.postedAt ?? scanDates.get(j.url) })),
     applications: readApplications(),
   };
 }


### PR DESCRIPTION
## What

`readInbox` was purely positional (`parts[3]`=location, `parts[4]`=compensation), but the core appends **labeled segments** (`posted:`, `note:`, and `trust:` with #1765) after whatever positional shape a row has. On a 3-column row the inbox UI displayed *"posted: 2026-07-14"* as the **location** — a pre-existing web bug that #1765's `trust:` would have amplified. Surfaced while verifying the maintainer's additive-contract FYI for #1765.

## How

Any `word:`-prefixed segment at index ≥3 (URL cell exempt) is filtered out of positional assignment — **forward-compatible with labels the core hasn't invented yet**. Bonus: `posted:` now feeds the row's own `postedAt` (a more direct freshness signal for the inbox triage than the scan-history join, which stays as fallback).

## Verification

5 row shapes tested (3/4/5-col × posted/trust/note): all parse correctly, including the two that misrender today. typecheck + `next build` green.

Unblocks the ACK for #1765 (trust-segment) — with this, the web tolerates the new segment by construction.

Scope: `web/` only, 1 file, +28/−6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbox parsing for entries with labeled details such as location, compensation, and posting date.
  * Posting dates are now displayed when provided in a valid date format.
  * Preserved explicitly provided posting dates, using scan history only when no date is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->