### PR TITLE
fix(verify-cv-facts): stop a bare `<` from swallowing source evidence

### DIFF
--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -65,7 +65,12 @@ function stripMarkup(text) {
   return text
     .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, ' ')
     .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
+    // Only strip things that actually look like tags: `<name …>` or `</name>`.
+    // A bare `<` is ordinary prose in these sources (`p<0.001`, `ρ < 0.3`, `<30 min`),
+    // and `[^>]` matches newlines — so the old `/<[^>]+>/g` let one stray `<` swallow
+    // everything up to the next `>`, deleting real evidence from the allow-list and
+    // failing truthful CVs (article-digest.md lost 1,327 chars, incl. two metrics).
+    .replace(/<\/?[a-zA-Z][^>\n]*>/g, ' ')
     .replace(/\\[a-zA-Z]+\*?(?:\[[^\]]*\])?(?:\{([^}]*)\})?/g, ' $1 ')
     .replace(/&nbsp;/g, ' ')
     .replace(/&amp;/g, '&')


### PR DESCRIPTION
`stripMarkup()` strips HTML with `/<[^>]+>/g`. `[^>]` matches newlines, so a **bare `<` swallows everything up to the next `>`** — deleting real evidence before the allow-list is built.

A bare `<` is ordinary prose in exactly the files this gate reads: `p<0.001`, `ρ < 0.3`, `<30 min`, `5<10`.

## Reproduction

With a stats-bearing `article-digest.md`:

```
raw 12525 chars  ->  stripped 11198     (1327 chars deleted)
```

The consumed span starts at `p<0.001` and runs to the next `>`:

```
"<0.001 stacking-backfire effect\n\n**Architecture:** `.eval` log ingestion ->"
```

Two documented metrics (`0%`, `23%`) lived inside that span, so they never reached the allow-list — and the gate then reported them as invented:

```
CV fact check failed: cv-….html

Metric-like claims absent from sources:
  - 0%
  - 23%
```

## Why this matters more than a cosmetic false positive

It **inverts the guard's purpose**. The metrics were true and sourced, the CV was honest, and the gate failed it anyway. The two paths it pushes you toward are:

1. delete a true metric from the CV, or
2. widen `config/cv-facts.json`

…i.e. **weaken the anti-fabrication guard to work around a regex bug**. Option 2 is the dangerous one: a permanent allow-list entry added for a transient parsing fault.

And it fails open in the other direction too — any genuine metric that happens to sit inside a swallowed span is silently dropped from the allow-list, so the gate quietly checks against less evidence than it thinks it has. The failure is invisible: nothing warns that 1,327 characters of the source never got read.

## Fix

Only strip things that actually look like tags — `<name …>` or `</name>` — and never span newlines:

```js
.replace(/<\/?[a-zA-Z][^>\n]*>/g, " ")
```

Verified both directions:

| input | result |
|---|---|
| `<p class="x">hi</p>\n<div>\n<span>y</span></div>` | `hi y` (still stripped) |
| `p<0.001 and 5<10` | preserved |
| `article-digest.md` | 12525 chars in, 12525 out (0 lost) |

## Tests

`node test-all.mjs` → **1787 passed**. One unrelated pre-existing failure (`tracker-columns-tests.mjs` crashes with `MODULE_NOT_FOUND` on Node 18.20.8, reproduces on clean `main`).

Found while generating a real CV: the gate blocked a truthful A4 render whose METEOR figures were verbatim from `article-digest.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text processing to preserve ordinary prose containing symbols such as `<`, inequalities, brackets, or regex-like text.
  * Enhanced extraction of metric evidence and matching of restricted phrases by producing more accurate normalized text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->