### PR TITLE
feat(dashboard): add a RESPONDED filter tab to the pipeline screen

### DIFF
--- a/dashboard/internal/i18n/catalog.go
+++ b/dashboard/internal/i18n/catalog.go
@@ -21,6 +21,7 @@ type Catalog struct {
 	TabEvaluated string
 	TabApplied   string
 	TabInterview string
+	TabResponded string
 	TabTop       string
 	TabSkip      string
 	TabRejected  string
@@ -231,6 +232,7 @@ var En = Catalog{
 	TabEvaluated: "EVALUATED",
 	TabApplied:   "APPLIED",
 	TabInterview: "INTERVIEW",
+	TabResponded: "RESPONDED",
 	TabTop:       "TOP ≥4",
 	TabSkip:      "SKIP",
 	TabRejected:  "REJECTED",
@@ -358,6 +360,7 @@ var Tr = Catalog{
 	TabEvaluated: "DEĞERLENDİRİLDİ",
 	TabApplied:   "BAŞVURULDU",
 	TabInterview: "MÜLAKAT",
+	TabResponded: "YANIT VERİLDİ",
 	TabTop:       "EN İYİ ≥4",
 	TabSkip:      "UYGUN DEĞİL",
 	TabRejected:  "REDDEDİLDİ",
@@ -485,6 +488,7 @@ var Es = Catalog{
 	TabEvaluated: "EVALUADAS",
 	TabApplied:   "APLICADAS",
 	TabInterview: "ENTREVISTA",
+	TabResponded: "RESPONDIDAS",
 	TabTop:       "TOP ≥4",
 	TabSkip:      "OMITIR",
 	TabRejected:  "RECHAZADAS",

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -128,6 +128,7 @@ const (
 	filterEvaluated = "evaluated"
 	filterApplied   = "applied"
 	filterInterview = "interview"
+	filterResponded = "responded"
 	filterSkip      = "skip"
 	filterRejected  = "rejected"
 	filterDiscarded = "discarded"
@@ -145,6 +146,7 @@ func getPipelineTabs() []pipelineTab {
 		{filterEvaluated, i18n.Current.TabEvaluated},
 		{filterApplied, i18n.Current.TabApplied},
 		{filterInterview, i18n.Current.TabInterview},
+		{filterResponded, i18n.Current.TabResponded},
 		{filterTop, i18n.Current.TabTop},
 		{filterSkip, i18n.Current.TabSkip},
 		{filterRejected, i18n.Current.TabRejected},

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -144,9 +144,9 @@ func getPipelineTabs() []pipelineTab {
 	return []pipelineTab{
 		{filterAll, i18n.Current.TabAll},
 		{filterEvaluated, i18n.Current.TabEvaluated},
-		{filterApplied, i18n.Current.TabApplied},
 		{filterInterview, i18n.Current.TabInterview},
 		{filterResponded, i18n.Current.TabResponded},
+		{filterApplied, i18n.Current.TabApplied},
 		{filterTop, i18n.Current.TabTop},
 		{filterSkip, i18n.Current.TabSkip},
 		{filterRejected, i18n.Current.TabRejected},

--- a/dashboard/internal/ui/screens/pipeline_test.go
+++ b/dashboard/internal/ui/screens/pipeline_test.go
@@ -349,6 +349,47 @@ func TestRejectedAndDiscardedTabsFilterCorrectly(t *testing.T) {
 	}
 }
 
+func TestRespondedTabFiltersCorrectly(t *testing.T) {
+	apps := []model.CareerApplication{
+		{
+			Company:    "Acme",
+			Role:       "Backend Engineer",
+			Status:     "Responded",
+			Score:      4.2,
+			ReportPath: "reports/001-acme.md",
+		},
+		{
+			Company:    "Beta",
+			Role:       "Platform Engineer",
+			Status:     "Applied",
+			Score:      3.8,
+			ReportPath: "reports/002-beta.md",
+		},
+		{
+			Company:    "Gamma",
+			Role:       "AI Engineer",
+			Status:     "Interview",
+			Score:      4.6,
+			ReportPath: "reports/003-gamma.md",
+		},
+	}
+
+	pm := NewPipelineModel(
+		theme.NewTheme("catppuccin-mocha"),
+		apps,
+		model.PipelineMetrics{Total: len(apps)},
+		"..",
+		120,
+		40,
+	)
+
+	pm.activeTab = tabIndexForFilter(t, filterResponded)
+	pm.applyFilterAndSort()
+	if len(pm.filtered) != 1 || pm.filtered[0].Status != "Responded" {
+		t.Fatalf("expected responded tab to isolate responded rows, got %+v", pm.filtered)
+	}
+}
+
 // Regression: with no committed search query, Esc must NOT close the screen.
 // The help bar advertises only `q quit`, so Esc quitting silently was a bug
 // that surfaced as accidental exits when users hit Esc to "back out" of the UI.

--- a/dashboard/internal/ui/screens/pipeline_test.go
+++ b/dashboard/internal/ui/screens/pipeline_test.go
@@ -390,6 +390,21 @@ func TestRespondedTabFiltersCorrectly(t *testing.T) {
 	}
 }
 
+// The tab row follows the funnel order used by statusGroupOrder, where a
+// responded posting sits between interview and applied.
+func TestRespondedTabSitsBetweenInterviewAndApplied(t *testing.T) {
+	interview := tabIndexForFilter(t, filterInterview)
+	responded := tabIndexForFilter(t, filterResponded)
+	applied := tabIndexForFilter(t, filterApplied)
+
+	if !(interview < responded && responded < applied) {
+		t.Fatalf(
+			"expected tab order interview < responded < applied, got %d, %d, %d",
+			interview, responded, applied,
+		)
+	}
+}
+
 // Regression: with no committed search query, Esc must NOT close the screen.
 // The help bar advertises only `q quit`, so Esc quitting silently was a bug
 // that surfaced as accidental exits when users hit Esc to "back out" of the UI.

--- a/dashboard/internal/ui/screens/pipeline_test.go
+++ b/dashboard/internal/ui/screens/pipeline_test.go
@@ -378,7 +378,7 @@ func TestRespondedTabFiltersCorrectly(t *testing.T) {
 		theme.NewTheme("catppuccin-mocha"),
 		apps,
 		model.PipelineMetrics{Total: len(apps)},
-		"..",
+		t.TempDir(),
 		120,
 		40,
 	)


### PR DESCRIPTION
## What does this PR do?

Adds a **RESPONDED** tab to the pipeline filter row so you can isolate postings that replied to you. `responded` is already a first-class canonical status — its own group (`— RESPONDED (n) —`), color, i18n string, and summary entry — but the filter tab row (`ALL · EVALUATED · APPLIED · INTERVIEW · TOP ≥4 · SKIP · REJECTED · DISCARDED`) had no way to filter down to it.

The tab is placed after INTERVIEW, following the `statusGroupOrder` funnel (interview → responded → applied). The filter-match logic is unchanged: `NormalizeStatus("Responded")` already normalizes to `"responded"`, which the existing `default` filter case matches — so only the `filterResponded` const, the `getPipelineTabs()` entry, and the `TabResponded` catalog string (en/tr/es) were needed.

Scoped to just the `responded` tab as the issue asked — the tab row stays a hardcoded list (no `statusGroupOrder`-derived refactor).

## Related issue

Closes #1999

## Type of change

- [x] New feature

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first — #1999 (authored by the maintainer)
- [x] My PR does not include personal data (the added test uses fictional Acme/Beta/Gamma)
- [x] I ran `node test-all.mjs` and all tests pass (1798 passed, 0 failed; the single warning is the pre-existing `cv-sync-check` "no user data" warning, unrelated to this change)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (System Layer only — no user-layer files touched)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Verification

- `go test ./...` in `dashboard/` — **154 passed**
- New `TestRespondedTabFiltersCorrectly` mirrors the existing rejected/discarded filter test (red before the const existed, green after)
- `gofmt` / `go vet` clean
- `node test-all.mjs --quick` — **1798 passed, 0 failed**

## Notes for reviewers

The tr/es tab labels are the uppercased forms of the existing `StatusResponded` strings, matching how the other tabs relate to their status strings (`YANIT VERİLDİ` from "Yanıt Verildi"; `RESPONDIDAS` pluralized like `APLICADAS` / `DESCARTADAS`). Happy to adjust the casing/wording if you'd prefer something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **“Responded”** tab to the pipeline view between **“Interview”** and **“Applied”**.
  * Selecting **“Responded”** filters the pipeline to show only applications with a responded status.
  * Updated localized tab labels for English, Turkish, and Spanish.
* **Tests**
  * Added tests verifying the **“Responded”** tab filters correctly and is placed in the correct tab order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->