### PR TITLE
test(update-system): guard against stale manifest entries (#2002)

### DIFF
--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -7,7 +7,7 @@
  * newly introduced system paths without touching user data.
  */
 
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 
 let passed = 0;
 let failed = 0;
@@ -44,6 +44,26 @@ function extractArray(name) {
 const systemPaths = extractArray('SYSTEM_PATHS');
 const userPaths = extractArray('USER_PATHS');
 const bootstrapPaths = extractArray('BOOTSTRAP_PATHS');
+
+// Every concrete (non-directory) manifest entry (SYSTEM_PATHS or
+// BOOTSTRAP_PATHS) must exist in the working tree. A path deleted upstream
+// but left in the manifest survives as a permanent `error: pathspec ...` in
+// every user's upgrade output (#2002). Directory entries (trailing '/') are
+// exempt: git checkout of a directory pathspec tolerates content drift
+// inside it. Add an entry to ALLOWED_MISSING_ENTRIES only with a comment
+// justifying why it may legitimately be absent.
+const ALLOWED_MISSING_ENTRIES = new Set([]);
+for (const [listName, entries] of [['SYSTEM_PATHS', systemPaths], ['BOOTSTRAP_PATHS', bootstrapPaths]]) {
+  for (const entry of entries) {
+    if (entry.endsWith('/')) continue;
+    if (ALLOWED_MISSING_ENTRIES.has(entry)) continue;
+    if (existsSync(entry)) {
+      pass(`${listName} entry exists on disk: ${entry}`);
+    } else {
+      fail(`${listName} entry missing from tree (stale manifest entry, #2002): ${entry}`);
+    }
+  }
+}
 
 const requiredSystemPaths = [
   'modes/email.md',


### PR DESCRIPTION
Closes #2002 (regression coverage).

## What changed

Rebased onto current `main`. The `plugins-registry.json` manifest removal that originally motivated this PR **has since landed on `main`**, so that hunk is now a no-op and was dropped during rebase.

What remains — and is still unique to this PR — is the **regression guard** that prevents #2002 from recurring:

- Every concrete (non-directory) `SYSTEM_PATHS` and `BOOTSTRAP_PATHS` entry must exist in the working tree.
- A path deleted upstream but left in the manifest would otherwise survive as a permanent `error: pathspec ...` in every user's upgrade output.
- Directory entries (trailing `/`) are exempt — `git checkout` of a directory pathspec tolerates content drift.
- `ALLOWED_MISSING_ENTRIES` escape hatch for legitimately-absent entries, gated behind a justifying comment.

## Verification

`node updater-migration-tests.mjs` → **271 passed, 0 failed** against current `main`.

Diff is now test-only: `updater-migration-tests.mjs` (+21/-1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect stale or missing files referenced by migration manifests.
  * Improved error reporting by identifying the specific missing path.
  * Directory entries are now correctly excluded from file-existence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->