### PR TITLE
feat(oferta): work-authorization signal — flag explicit no-sponsorship as a hard blocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ career-ops is the first reference implementation of [the CareerOps Manifesto](ht
 | Feature                  | Description                                                                                                                              |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | **Auto-Pipeline**        | Paste a URL, get a full evaluation + PDF + tracker entry                                                                                 |
-| **6-Block Evaluation**   | Role summary, CV match, level strategy, comp research, personalization, interview prep (STAR+R) -- plus a Block G posting-legitimacy check that flags scams and ghost jobs |
+| **6-Block Evaluation**   | Role summary, CV match, level strategy, comp research, personalization, interview prep (STAR+R) -- plus a Block G posting-legitimacy check that flags scams and ghost jobs, and a Work-Auth signal that flags an explicit no-sponsorship JD as a hard blocker |
 | **Interview Story Bank** | Accumulates STAR+Reflection stories across evaluations -- 5-10 master stories that answer any behavioral question                        |
 | **Negotiation Scripts**  | Salary negotiation frameworks, geographic discount pushback, competing offer leverage                                                    |
 | **ATS PDF Generation**   | Keyword-injected CVs with Space Grotesk + DM Sans design                                                                                 |

--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -49,6 +49,9 @@ const MACHINE_SUMMARY_FIELDS = new Set([
   'via',
   'company_confidential',
   'risk_summary',
+  // Work-authorization / visa-sponsorship tier from Block A (report + Machine
+  // Summary only). Allowlisted so it round-trips; no consumer logic yet.
+  'work_auth',
 ]);
 
 // --- CLI args ---
@@ -204,6 +207,7 @@ top_strengths:
 risk_level: "Medium"
 confidence: "High"
 next_action: "Follow up on ticket #42 with tailored CV"
+work_auth: "unstated"
 via: "Hays"
 company_confidential: true
 \`\`\`
@@ -217,6 +221,7 @@ company_confidential: true
   if (summary?.next_action !== 'Follow up on ticket #42 with tailored CV') failures.push('hash-containing scalar field was not parsed');
   if (summary?.via !== 'Hays') failures.push('via was not preserved from Machine Summary');
   if (summary?.company_confidential !== true) failures.push('company_confidential boolean was not preserved from Machine Summary');
+  if (summary?.work_auth !== 'unstated') failures.push('work_auth field was not preserved from Machine Summary');
 
   // Backward compat (#1737): summaries without risk_summary parse as before, key simply absent.
   if ('risk_summary' in (summary ?? {})) failures.push('summary without risk_summary must not gain the key');

--- a/batch/batch-prompt.md
+++ b/batch/batch-prompt.md
@@ -292,6 +292,7 @@ top_strengths:
 risk_level: "{Low | Medium | High}"
 confidence: "{Low | Medium | High}"
 next_action: "{one concrete next step}"
+work_auth: "{sponsors | not_needed | unstated | no_sponsorship}"
 discard_reasons:
   - "{predicted reason if final_decision is Skip/Consider, e.g. salary_too_low, hybrid_required, tech_stack_mismatch, seniority_mismatch, geo_restriction, size_mismatch, company_culture, or other specific reason}"
 via: {agency/recruiter firm as a quoted string, or null for direct applications}
@@ -311,6 +312,7 @@ Rules:
 - `final_decision` must reflect the full evaluation, not only the CV match.
 - `advertised_comp` is the JD's **own** figure, verbatim; `null` when the JD states nothing — never estimate it and never substitute researched market data (Block D research stays in Block D). Batch workers never write `data/salary-observations.tsv` — the report itself is the advertised observation (`salary-gap.mjs` reads it).
 - Do not invent missing data. If confidence is limited, set `confidence: "Low"` and explain the limitation in the human-readable sections.
+- `work_auth` reflects the Block A work-authorization tier: `no_sponsorship` only when the JD **explicitly** refuses sponsorship for a role outside the candidate's `authorized_in`; `unstated` when the JD is silent (neutral, not a blocker); `not_needed` when the role is within `authorized_in` or sponsorship isn't required; `sponsors` when the JD explicitly offers it.
 - `risk_summary` mirrors the `## Risk Summary` block row by row — same source verdicts, snake_cased: `legitimacy` from the Block G tier (`high_confidence` / `proceed_with_caution` / `suspicious`), `culture` from the Block A Culture screen (`pass` / `caution` / `fail`), `interview_redflags` from the red-flag file's warning level (`none` / `caution` / `warning`). Any row rendered `— not evaluated` (or `— no interview sessions yet`) is `not_evaluated` here. Never invent a value the block does not show.
 
 ### Step 3 — Save the Report
@@ -332,6 +334,7 @@ Report header:
 **Archetype:** {detected}
 **Score:** {X.X/5}
 **Legitimacy:** {High Confidence | Proceed with Caution | Suspicious}
+**Work Auth:** {✅ Sponsors | ➖ Not needed | ⚠️ Unstated | ⛔ No sponsorship}
 **URL:** {{URL}}
 **PDF:** {output/cv-candidate-{company-slug}-{{DATE}}.pdf if score >= resolved auto_pdf_score_threshold, otherwise a localized equivalent of `not generated — run /career-ops pdf {company-slug} to create on demand` in `language.output`}
 **Batch ID:** {{ID}}
@@ -357,6 +360,7 @@ top_strengths:
 risk_level: "{Low | Medium | High}"
 confidence: "{Low | Medium | High}"
 next_action: "{one concrete next step}"
+work_auth: "{sponsors | not_needed | unstated | no_sponsorship}"
 discard_reasons:
   - "{predicted reason if final_decision is Skip/Consider, e.g. salary_too_low, hybrid_required, tech_stack_mismatch, seniority_mismatch, geo_restriction, size_mismatch, company_culture, or other specific reason}"
 via: {agency/recruiter firm as a quoted string, or null for direct applications}

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -72,6 +72,15 @@ location:
   city: "San Francisco"
   timezone: "PST"
   visa_status: "No sponsorship needed"
+  # Countries/regions where you ALREADY hold work authorization (no sponsorship
+  # needed there). Drives the Work-Authorization signal in job evaluation
+  # (modes/oferta.md → Block A "Work-authorization check"). Optional — omit or
+  # leave [] if not applicable; the free-text visa_status above still applies.
+  authorized_in: ["United States"]
+  # true if you need visa sponsorship for roles OUTSIDE authorized_in. When a JD
+  # explicitly states it will not sponsor, that is a hard blocker (see
+  # modes/_profile.md "Your Location Policy"). Omit → treated as false.
+  needs_sponsorship: false
   # For remote roles outside your country:
   # onsite_availability: "1 week/month in any city"
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -9,7 +9,7 @@ Key sections:
 - **target_roles**: Your North Star roles and archetypes
 - **narrative**: Your headline, exit story, superpowers, proof points
 - **compensation**: Target range, minimum, currency
-- **location**: Country, timezone, visa status, on-site availability
+- **location**: Country, timezone, visa status, on-site availability, and structured work authorization (`authorized_in`, `needs_sponsorship`) that drives the Work-Auth signal in job evaluation (flags an explicit no-sponsorship JD as a hard blocker)
 - **culture_screen**: Structural criteria for team culture (the `deprioritize_if_absent` strict flag caps the culture score at 2/5 if evidence is entirely missing)
 
 ## Target Roles (modes/_profile.md)

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -71,6 +71,27 @@ On contradiction, add exactly one flag line at the top of Block B in the report,
 
 The flag is an additive line only — Block B's existing content stays unchanged below it, and no flag line appears when there is no contradiction.
 
+### Work-authorization check
+
+After the Role Summary table, compare the candidate's work authorization against what the JD says about sponsorship and work eligibility. Read the candidate's work rights from `config/profile.yml` → `location.authorized_in` (list of countries/regions where they already hold authorization) and `location.needs_sponsorship`, falling back to the free-text `location.visa_status` when those structured keys are absent. Classify into exactly one tier:
+
+- ✅ **Sponsors** — the JD explicitly offers visa sponsorship or relocation, and the role is in a country **not** in `authorized_in`.
+- ➖ **Not needed** — the role is in a country listed in `authorized_in` (or is genuinely location-agnostic remote the candidate can work from an authorized country), **or** `needs_sponsorship` is false.
+- ⚠️ **Unstated** — the role is outside `authorized_in` and the JD says nothing about sponsorship. Silence is absence of signal, not a refusal — this tier is **NEUTRAL**.
+- ⛔ **No sponsorship** — the JD explicitly states it will **not** sponsor (e.g. "no visa sponsorship", "must have existing work authorization", "we are unable to sponsor"), **and** the role is outside `authorized_in`.
+
+Rules (mirror the Geo-mismatch discipline):
+- Quote the JD **verbatim** — never paraphrase the sponsorship language.
+- A generic "must be authorized to work in {country}" where {country} **is** in `authorized_in` is ➖ Not needed, not ⛔.
+- If the profile has no `authorized_in`/`needs_sponsorship` keys and only the free-text `visa_status`, infer conservatively and default to ⚠️ Unstated rather than guessing a blocker.
+- **Scoring (aligns with `modes/_profile.md` "Your Location Policy"):** ✅ / ➖ / ⚠️ are score-neutral — do **not** apply a location or relocation penalty. Only ⛔ **No sponsorship** for a role the candidate cannot take from an authorized country is a genuine hard blocker: score location low and record it as a `hard_stop`.
+
+On a ⛔ determination, add exactly one flag line at the top of Block B in the report, quoting the evidence **verbatim**:
+
+`⛔ **No sponsorship:** JD states "{verbatim JD line}" and role is outside your authorized_in`
+
+The flag is additive only; ✅ / ➖ / ⚠️ emit no flag line.
+
 ## Block B — Match with CV
 
 Read `cv.md`. Create a table with each JD requirement mapped to exact lines in the CV.
@@ -430,6 +451,7 @@ Save full evaluation in `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 **Archetype:** {detected}
 **Score:** {X/5}
 **Legitimacy:** {High Confidence | Proceed with Caution | Suspicious}
+**Work Auth:** {✅ Sponsors | ➖ Not needed | ⚠️ Unstated | ⛔ No sponsorship}
 **PDF:** {path or pending}
 
 ---

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1609,6 +1609,17 @@ if (
   fail('oferta missing geo-mismatch cross-check of location field vs JD body (#1433)');
 }
 
+if (
+  ofertaMode.includes('### Work-authorization check') &&
+  ofertaMode.includes('⛔ **No sponsorship:** JD states "{verbatim JD line}" and role is outside your authorized_in') &&
+  ofertaMode.includes('**Work Auth:**') &&
+  ofertaMode.includes('this tier is **NEUTRAL**')
+) {
+  pass('oferta cross-checks visa sponsorship against candidate work authorization');
+} else {
+  fail('oferta missing work-authorization / visa-sponsorship signal in Block A');
+}
+
 // --- offer-prep mode: contract reading companion (describes, never judges) ---
 const offerPrepMode = fileExists('modes/offer-prep.md') ? readFile('modes/offer-prep.md') : '';
 if (


### PR DESCRIPTION
Closes #2016.

Adds a **Work-Authorization / visa-sponsorship signal** to the A–G evaluation — one of the biggest silent filters in an international search, previously invisible to the scorer. Zero extra tokens (folds into the existing eval pass).

## What it does

When evaluating a role, a new **Block A sub-check** cross-references the candidate's work rights against what the JD says about sponsorship and classifies into one tier:

| Tier | Meaning |
|------|---------|
| ✅ Sponsors | JD explicitly offers sponsorship/relocation; role outside `authorized_in` |
| ➖ Not needed | Role within `authorized_in`, or `needs_sponsorship` false |
| ⚠️ Unstated | Outside `authorized_in`, JD silent — **NEUTRAL** (silence ≠ refusal) |
| ⛔ No sponsorship | JD **explicitly** refuses, and role outside `authorized_in` |

It surfaces as a `**Work Auth:**` header line and a `work_auth` field in the batch Machine Summary.

## Scoring alignment

Aligns with `modes/_profile.md` "Your Location Policy": ✅/➖/⚠️ are **score-neutral** (no location/relocation penalty); only an explicit ⛔ for a role the candidate can't take from an authorized country is a hard blocker → scored low + recorded as a `hard_stop`. Mirrors the Geo-mismatch discipline verbatim (read structured field → cross-check JD body → verbatim evidence → silence = no signal).

## Changes (7 files, +53/-2, all additive)

- `config/profile.example.yml` — optional `location.authorized_in` + `needs_sponsorship` (free-text `visa_status` preserved as fallback)
- `modes/oferta.md` — `### Work-authorization check` in Block A + `**Work Auth:**` header line
- `batch/batch-prompt.md` — `work_auth` in both Machine Summary fences + a rule
- `analyze-patterns.mjs` — allowlist `work_auth` (no consumer logic yet, like `domain`/`seniority`) + `--self-test` coverage
- `test-all.mjs` — assert the new mode-doc contract (mirrors the #1433 geo-mismatch check)
- `docs/CUSTOMIZATION.md` + `README.md`

## Notes for review

- **Data contract:** `config/profile.yml` is gitignored/user-layer and is **not** touched — only the schema + `config/profile.example.yml`. Mode instructions read the new keys defensively, so an un-migrated profile keeps today's behavior (falls back to `visa_status` → ⚠️ Unstated).
- **`work_auth` is allowlist-only** in the parser (round-trips, no consumer logic) — matching the `domain`/`seniority` precedent; avoids scope creep.
- **English-only.** Mirroring into the ~17 localized oferta modes is a separate follow-up (precedent #1963).
- **No tracker column** — report + Machine Summary only.

## Verification

```
node analyze-patterns.mjs --self-test   # OK — work_auth survives the allowlist
node test-all.mjs --quick               # new "oferta cross-checks visa sponsorship…" assertion PASSES;
                                        # geo-mismatch + A-G structure intact
```
The only failing check locally is the pre-existing `node:sqlite` tracker-columns test (needs Node ≥ 22.5; I'm on v20), unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Work Authorization signal to job evaluations, with statuses for sponsorship, no sponsorship, not needed, or unstated.
  * Added work-authorization details to evaluation report headers and machine-readable summaries.
  * Explicit no-sponsorship requirements are now treated as hard blockers.

* **Documentation**
  * Updated profile configuration and customization guidance for work-authorization settings.
  * Expanded feature documentation to include scam and work-authorization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->