### PR TITLE
feat(offer-prep): jurisdiction-aware restrictive-covenant notes — table + statutory context + lawyer questions

### DIFF
--- a/modes/offer-prep.md
+++ b/modes/offer-prep.md
@@ -30,7 +30,11 @@ It is NOT:
   figures must never appear in an outbound query of any kind.
 - **Never state law from memory.** Jurisdiction-dependent legal questions
   become entries in the Questions-for-your-lawyer list — never answered
-  inline, never guessed.
+  inline, never guessed. The single sanctioned source of statutory facts is
+  `templates/restrictive-covenants.yml` (a verified, cited, local data
+  table — see the statutory-context subsection in Step 2); reading it is a
+  local file lookup, not online research and not memory. Anything not in
+  the table stays a lawyer question.
 - **Never headless.** This mode must not run in batch/headless mode
   (`claude -p`, batch workers, subagents). It requires an attending human.
   The repo's batch conventions explicitly do not apply here.
@@ -109,7 +113,11 @@ jurisdiction and route it to the lawyer list as a question; it may never
 assert what any law requires, permits, or prohibits. Content-level
 statements ("{state} requires X", "this is unenforceable") are banned. The
 `[commonly negotiated]` tag is a negotiation-norms meta-statement and is
-fine.
+fine. One narrow, table-backed carve-out exists: statutory facts drawn
+verbatim-close from `templates/restrictive-covenants.yml` may be relayed
+with their citation as statutory-context notes (rules in Step 2) — but
+statements about what the law means for **this** clause remain banned
+everywhere.
 
 ## Step 2 — Clause walk (describe, don't judge)
 
@@ -172,6 +180,72 @@ described as an absence, anchored to where it would belong, and tagged
     clause erases the rest); unilateral-amendment clauses; contingencies
     (background check, references, visa); offer-expiry terms.
 
+### Statutory-context notes for restrictive covenants (#2028)
+
+Whether a restrictive covenant is enforceable **at all** is one of the
+sharpest jurisdiction-dependent facts in employment law — the same clause is
+largely a dead letter in one jurisdiction and the most negotiable line in the
+document in another. This subsection adds jurisdiction-aware **statutory
+context** to the clause walk without changing the mode's posture: it states
+facts about statutes, and it never judges the candidate's clause.
+
+**Lookup:** when the Step 2 walk reaches a restrictive-covenant clause
+(taxonomy category 4), check `templates/restrictive-covenants.yml` for a row
+matching (a) the jurisdiction derived in Step 1 (candidate's location from
+`config/profile.yml`; a named work location in the contract wins if it
+contradicts) and (b) the clause's **covenant type**. The table is a data
+reference, not instruction logic — adding a jurisdiction or covenant-type row
+there never requires touching this rule text; every row carries a legal
+basis, an effective date, statutory exceptions, sources, and an `as_of`
+verification date. Reading it is a local file lookup — it is **not** online
+research, and the no-online-research hard guard is unchanged: no WebSearch,
+no WebFetch, no URL visits, ever.
+
+**Covenant-type discipline (mandatory):** non-compete and non-solicitation
+are never conflated. Ontario's ESA s.67.2 ban, for example, covers
+non-compete agreements only — a non-solicitation clause in the same contract
+gets no statutory-context note from that row. If the table has no row for
+the clause's exact covenant type in the jurisdiction, this subsection is
+skipped entirely for that clause and the standard Step 1 meta-statement
+boundary applies (topic → lawyer list, no law stated).
+
+**On a match, two things happen — both inside existing output shapes:**
+
+1. The clause's neutral tags (which always include `[ask your lawyer]` for a
+   matched covenant) gain a **statutory-context note** — a fact about the
+   statute, never a verdict about this clause. Template:
+
+   > **Statutory context:** [Render in {language.output}: state what the
+   > statute says, with citation, effective date, and its exceptions, from
+   > the table row only — e.g. for a fictional Acme Corp offer in Ontario:
+   > "Ontario's ESA s.67.2 has prohibited non-compete agreements in
+   > employment contracts entered into since 2021-10-25, with executive
+   > (defined C-suite list) and sale-of-business exceptions." If the row's
+   > `as_of` date is not recent, add: "this table row was last verified
+   > {as_of}; the law may have changed since." Close with: whether this
+   > statute applies to this specific clause depends on facts a contract
+   > cannot self-certify — that question is in the lawyer list below. This
+   > is statutory context, not legal advice.]
+
+2. The **Questions for your lawyer** list gains a targeted, clause-anchored
+   entry — e.g. for the fictional Acme Corp offer above: "Does ESA s.67.2
+   apply to this clause given my role, or does the executive exception cover
+   it?" or, for a California-governed contract: "Given B&P §16600/§16600.5,
+   what is the practical status of this clause, and does the choice-of-law
+   provision change anything?" The conclusion belongs to the lawyer; this
+   mode's job is making sure the question gets asked.
+
+**Never assert application (HARD RULE):** the statutory exceptions —
+executive status, sale-of-business context, choice-of-law wrinkles — are
+exactly the things a contract document cannot self-certify. So this mode
+never asserts that the candidate's clause is void, unenforceable, or
+illegal, and never says the statute "applies here". A statute's existence,
+scope, effective dates, and exceptions are facts and may be stated with
+citation; whether it governs **this** clause is always a lawyer question.
+No enforceability opinions, no negotiation-leverage claims, no verdicts —
+the describes-never-judges posture is unchanged. Statutory-context notes
+are context, not legal advice.
+
 ## Step 3 — Consistency check
 
 Compare contract terms against:
@@ -195,8 +269,11 @@ nothing more; it implies no view on the number.
 **Questions for your lawyer** — jurisdiction-scoped and clause-anchored: at
 least one entry per `[ask your lawyer]` tag (one tag may generate several
 sub-questions, and cross-clause questions spanning multiple sections are
-encouraged), plus one per unprovided referenced document, plus anything the
-candidate raised. Written to make a single paid hour efficient.
+encouraged), plus one per unprovided referenced document, plus one targeted
+question per statutory-context note from the restrictive-covenants
+subsection (does the statute apply to this clause, or does an exception
+cover it?), plus anything the candidate raised. Written to make a single
+paid hour efficient.
 
 **Items to raise with the employer** — from `[differs from what you were
 told]` deltas and `[commonly negotiated]` tags. Phrased exclusively as

--- a/templates/README.md
+++ b/templates/README.md
@@ -11,6 +11,7 @@ System-layer template files used by career-ops scripts and modes. These files ar
 | `cv-template.tex` | `generate-latex.mjs` | LaTeX/Overleaf template for ATS-optimized CV PDFs |
 | `portals.example.yml` | Onboarding | Example portal scanner configuration (copy to `portals.yml` to activate) |
 | `states.yml` | `verify-pipeline.mjs`, `normalize-statuses.mjs`, `merge-tracker.mjs` | Canonical application states and their aliases |
+| `restrictive-covenants.yml` | `modes/offer-prep.md` (statutory-context notes) | Jurisdiction-keyed table of restrictive-covenant statutory rules, per covenant type (v1: non-compete only — seeds US-CA B&P §16600/§16600.5 and Ontario ESA s.67.2). Status spectrum: `prohibited` / `allowed_with_mandatory_compensation` / `allowed_with_limits` / `common_law_reasonableness`. Prompt-level data reference — no script reads it; local lookup, never online research. Feeds statutory-context notes and targeted lawyer questions; never a verdict about the candidate's clause. Contribution rule: no entry without a citable legal source, an effective date, and an `as_of` verification date; covenant types are never conflated. |
 
 ### cv-template.html
 

--- a/templates/restrictive-covenants.yml
+++ b/templates/restrictive-covenants.yml
@@ -1,0 +1,118 @@
+# Career-Ops — Restrictive-Covenant Statutory Context (jurisdiction table) (#2028)
+#
+# Consumed prompt-level by modes/offer-prep.md ("Statutory-context notes for
+# restrictive covenants"). This file is a DATA REFERENCE, not instruction
+# logic: extending it to a new jurisdiction or covenant type never requires
+# touching the rule text in modes/offer-prep.md. No script reads it — the
+# agent does, as a LOCAL file lookup (which is not online research and does
+# not touch offer-prep's no-research guard).
+#
+# CONTRIBUTION RULE (mandatory): no entry lands in this table without
+#   1. a citable legal source (statute text, official government page, or a
+#      reputable law-firm bulletin summarizing it), AND
+#   2. an explicit effective date for the rule described, AND
+#   3. an `as_of` date recording when the row was last verified.
+# Unverified or "I heard that..." rows will be rejected in review. Seed
+# narrow and verified; extend via community PRs — same discipline as the
+# jurisdiction tables introduced for #2013/#2018/#2019/#2025.
+#
+# COVENANT-TYPE DISCIPLINE (mandatory): rows are keyed per covenant_type and
+# covenant types are NEVER conflated. A non-compete rule says nothing about
+# non-solicitation — Ontario's ESA s.67.2 ban, for example, does NOT cover
+# non-solicitation clauses, and a note implying otherwise would misinform the
+# candidate in the more dangerous direction. If a jurisdiction regulates
+# non-solicits, that is a SEPARATE row with covenant_type: non_solicit and
+# its own sources. v1 seeds cover covenant_type: non_compete only.
+#
+# NOT LEGAL ADVICE: these rows describe what published statutes say — their
+# existence, scope, effective dates, and statutory exceptions. They are never
+# a basis for asserting that any specific contract clause is void,
+# unenforceable, or illegal: exceptions (executive status, sale-of-business
+# context, choice-of-law wrinkles) are exactly the things a contract document
+# cannot self-certify. Application to a specific clause is always a lawyer
+# question.
+#
+# status enum (the real-world spectrum, not a ban/no-ban binary):
+#   prohibited                            — statute voids/bans the covenant in
+#                                           the employment context (subject to
+#                                           listed exceptions)
+#   allowed_with_mandatory_compensation   — enforceable only if the employer
+#                                           pays for the restricted period
+#                                           (e.g. Germany's Karenzentschädigung)
+#   allowed_with_limits                   — statutory caps on duration, scope,
+#                                           income thresholds, etc.
+#   common_law_reasonableness             — no statute; courts apply a
+#                                           reasonableness test case by case
+#                                           (e.g. UK)
+#
+# Schema per entry (list under `covenants`):
+#   jurisdiction: string       — code, e.g. US-CA, CA-ON, DE, UK
+#   jurisdiction_name: string  — human-readable name for report output
+#   covenant_type: enum        — non_compete | non_solicit | non_dealing
+#   status: enum               — see above
+#   exceptions: list           — statutory exceptions, verbatim-close summaries
+#   effective: YYYY-MM-DD      — date the current rule came into force
+#                                (quoted string — keep dates as strings)
+#   legal_basis: string        — statute/regulation citation + key case law
+#   sources: list              — citable texts/bulletins backing the row
+#   as_of: YYYY-MM-DD          — date this row was last verified against sources
+#
+# CANDIDATE ROWS FOR CONTRIBUTORS (suggestions only — do NOT add without the
+# source + effective-date + as_of discipline above):
+#   - US-MN : Minnesota banned employment non-competes for agreements entered
+#             into on or after 2023-07-01 (Minn. Stat. §181.988)
+#   - US-ND / US-OK : long-standing statutory bans (N.D.C.C. §9-08-06;
+#             Okla. Stat. tit. 15 §219A) — verify current text before adding
+#   - DE    : allowed_with_mandatory_compensation — §74 HGB requires
+#             Karenzentschädigung (≥50% of last compensation) for the
+#             restricted period, max 2 years
+#   - UK    : common_law_reasonableness — no statute; restraint-of-trade
+#             doctrine, enforceable only if no wider than necessary to protect
+#             a legitimate business interest
+#   - US-WA / US-CO / US-IL : allowed_with_limits — income thresholds and
+#             notice requirements vary; key at the state level with sources
+
+covenants:
+  - jurisdiction: US-CA
+    jurisdiction_name: "California, USA"
+    covenant_type: non_compete
+    status: prohibited
+    exceptions:
+      - "Statutory sale-of-business context (B&P Code §16601 family — seller of a business's goodwill or ownership interest may agree not to compete in the sold business's area)"
+    effective: "2024-01-01"   # §16600.5 (SB 699) and §16600.1 (AB 1076) in force; §16600 itself is long-standing
+    legal_basis: >-
+      California Business & Professions Code §16600 — voids non-compete
+      clauses in the employment context "no matter how narrowly tailored"
+      (codifying Edwards v. Arthur Andersen, 2008); §16600.5 (SB 699,
+      effective 2024-01-01) — unenforceable regardless of where and when the
+      contract was signed; §16600.1 (AB 1076) — inclusion of such a clause is
+      itself unlawful, and employers were placed under an individualized
+      notice duty to affected employees.
+    sources:
+      - "Quinn Emanuel client alert — California non-compete legislation (SB 699 / AB 1076)"
+      - "Holland & Knight alert — New California laws further restrict non-competes"
+      - "Jackson Lewis — California non-compete notice requirement analysis"
+      - "CalChamber alert — AB 1076 / SB 699 employer obligations"
+    as_of: "2026-07-18"
+
+  - jurisdiction: CA-ON
+    jurisdiction_name: "Ontario, Canada"
+    covenant_type: non_compete
+    status: prohibited
+    exceptions:
+      - "Executive exception — applies only to a defined C-suite list: CEO, President, CAO, COO, CFO, CIO, CLO, CHRO, Chief Corporate Development Officer, or any other chief executive position"
+      - "Sale-of-business exception — the seller becomes the purchaser's employee immediately after the sale; 'sale' includes a lease"
+    effective: "2021-10-25"
+    legal_basis: >-
+      Ontario Employment Standards Act, 2000, s.67.2 (added by the Working
+      for Workers Act, 2021 / Bill 27) — prohibits employers from entering
+      into employment contracts or other agreements with an employee that
+      include a non-compete agreement; non-compete agreements in contracts
+      entered into on or after 2021-10-25 are void. NOTE: the ban does not
+      cover non-solicitation clauses — covenant types are never conflated.
+    sources:
+      - "Bill 27, Working for Workers Act, 2021 — official text (ola.org)"
+      - "Littler insight — Ontario's ban on non-compete agreements"
+      - "Torys LLP bulletin — Working for Workers Act non-compete prohibition"
+      - "Bennett Jones bulletin — Ontario ESA non-compete amendments"
+    as_of: "2026-07-18"

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1685,6 +1685,100 @@ if (
   fail('offer-prep reply-draft step missing (or lost its prep-report gate, reply-draft path, traceability rule, never-send guard, questions-not-demands framing, no-legal-claims rule, checklist, or prep-report+conversation-only source boundary) (#1663)');
 }
 
+// --- offer-prep statutory-context notes for restrictive covenants (#2028) ---
+{
+  // 1. Jurisdiction table exists, parses as YAML, and both seeds are complete
+  const rcPath = join(ROOT, 'templates', 'restrictive-covenants.yml');
+  const RC_STATUS_ENUM = ['prohibited', 'allowed_with_mandatory_compensation', 'allowed_with_limits', 'common_law_reasonableness'];
+  if (!existsSync(rcPath)) {
+    fail('templates/restrictive-covenants.yml missing (#2028)');
+  } else {
+    try {
+      const { load } = await import('js-yaml');
+      const rcRaw = readFileSync(rcPath, 'utf-8');
+      const rc = load(rcRaw);
+      const rows = Array.isArray(rc?.covenants) ? rc.covenants : [];
+      const completeRow = (r) =>
+        r &&
+        typeof r.jurisdiction === 'string' &&
+        typeof r.jurisdiction_name === 'string' &&
+        r.covenant_type === 'non_compete' &&
+        RC_STATUS_ENUM.includes(r.status) &&
+        Array.isArray(r.exceptions) && r.exceptions.length > 0 &&
+        typeof r.effective === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(r.effective) &&
+        typeof r.legal_basis === 'string' && r.legal_basis.length > 0 &&
+        Array.isArray(r.sources) && r.sources.length > 0 &&
+        typeof r.as_of === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(r.as_of);
+      const usCa = rows.find((r) => r?.jurisdiction === 'US-CA');
+      const caOn = rows.find((r) => r?.jurisdiction === 'CA-ON');
+      if (
+        completeRow(usCa) && usCa.status === 'prohibited' &&
+        usCa.legal_basis.includes('16600') && usCa.legal_basis.includes('16600.5') &&
+        completeRow(caOn) && caOn.status === 'prohibited' &&
+        caOn.legal_basis.includes('67.2') && caOn.effective === '2021-10-25' &&
+        caOn.exceptions.some((e) => /executive/i.test(e)) &&
+        caOn.exceptions.some((e) => /sale/i.test(e))
+      ) {
+        pass('restrictive-covenants.yml parses; US-CA (§16600/§16600.5) and CA-ON (ESA s.67.2, 2021-10-25) non-compete seeds complete — status enum, exceptions, string dates, legal_basis, sources, as_of (#2028)');
+      } else {
+        fail('restrictive-covenants.yml seed rows incomplete — need US-CA and CA-ON non_compete rows with prohibited status, exceptions, quoted-string effective/as_of dates, legal_basis, sources (#2028)');
+      }
+      if (
+        rcRaw.includes('CONTRIBUTION RULE') &&
+        rcRaw.includes('COVENANT-TYPE DISCIPLINE') &&
+        rcRaw.includes('NEVER conflated') &&
+        rcRaw.includes('NOT LEGAL ADVICE')
+      ) {
+        pass('restrictive-covenants.yml header documents the contribution rule, covenant-type discipline, and not-legal-advice boundary (#2028)');
+      } else {
+        fail('restrictive-covenants.yml header missing the contribution rule, covenant-type (never-conflate) discipline, and/or not-legal-advice note (#2028)');
+      }
+    } catch (e) {
+      fail(`templates/restrictive-covenants.yml does not parse as YAML: ${e.message} (#2028)`);
+    }
+  }
+
+  // 2. offer-prep carries the statutory-context subsection with both output
+  //    integrations (clause-tag note + lawyer question), the covenant-type
+  //    discipline, and the never-assert-application hard rule
+  const rcStart = offerPrepMode.indexOf('Statutory-context notes for restrictive covenants');
+  const rcEnd = offerPrepMode.indexOf('## Step 3', Math.max(rcStart, 0));
+  const rcSection = rcStart >= 0 && rcEnd > rcStart ? offerPrepMode.slice(rcStart, rcEnd) : '';
+  if (
+    rcSection.includes('templates/restrictive-covenants.yml') &&
+    rcSection.includes('statutory-context note') &&
+    rcSection.includes('Questions for your lawyer') &&
+    rcSection.includes('Covenant-type discipline (mandatory)') &&
+    rcSection.includes('never conflated') &&
+    rcSection.includes('Never assert application (HARD RULE)') &&
+    rcSection.includes('cannot self-certify') &&
+    rcSection.includes('always a lawyer question') &&
+    rcSection.includes('not legal advice') &&
+    rcSection.includes('not** online') &&
+    rcSection.includes('Render in {language.output}')
+  ) {
+    pass('offer-prep statutory-context subsection pins table lookup, tag-note + lawyer-question integration, covenant-type discipline, never-assert-application rule, not-legal-advice, no-research reaffirmation, i18n rendering (#2028)');
+  } else {
+    fail('offer-prep statutory-context subsection missing/incomplete — needs table reference, statutory-context note + lawyer-question integration, covenant-type never-conflate discipline, never-assert-application hard rule, not-legal-advice note, local-lookup-is-not-research clarification, {language.output} rendering (#2028)');
+  }
+
+  // 3. Phrasing discipline holds in the report-facing text: the blockquote
+  //    template the agent renders may state what a STATUTE says (which
+  //    legitimately includes words like "prohibited" or "void" describing
+  //    the statute), but must never assert those verdicts about the
+  //    candidate's own clause. Only '>' lines (rendered output templates)
+  //    are scanned, and only for clause-directed assertions.
+  const rcQuoteLines = rcSection.split('\n').filter((l) => l.trimStart().startsWith('>'));
+  const rcAssertive = rcQuoteLines.filter((l) =>
+    /(this|your|the candidate'?s?) (specific )?(clause|covenant|non-compete) (is|would be|will be) (void|illegal|unenforceable|invalid|prohibited)/i.test(l)
+  );
+  if (rcSection && rcQuoteLines.length >= 1 && rcAssertive.length === 0) {
+    pass('restrictive-covenant statutory-context template states statute facts only — no void/illegal/unenforceable assertions about the candidate\'s clause (#2028)');
+  } else {
+    fail(`restrictive-covenant phrasing discipline broken: ${rcAssertive.length ? `clause-directed verdict in blockquote: ${rcAssertive[0].trim().slice(0, 80)}` : 'expected a blockquote output template in the section'} (#2028)`);
+  }
+}
+
 const routerSkill = readFile('.agents/skills/career-ops/SKILL.md');
 if (
   /argument-hint:.*offer-prep/.test(routerSkill) &&


### PR DESCRIPTION
Closes #2028. Fifth member of the jurisdiction-compliance umbrella (#2026) — and the **first offer-document-surface member**: unlike siblings #2014/#2020/#2021/#2027, this lives in `modes/offer-prep.md`, not oferta's Block G, so it does **not** touch the Signal-9 coordination queue at all.

## What this adds

**Prompt/instruction + data-template PR — no new executable script.**

1. **`templates/restrictive-covenants.yml`** — jurisdiction-keyed table of restrictive-covenant statutory rules, keyed **per covenant type** with a spectrum `status` enum (`prohibited | allowed_with_mandatory_compensation | allowed_with_limits | common_law_reasonableness`). Seeded with exactly two verified `non_compete` rows:
   - **US-CA** (`prohibited`): B&P §16600 (void "no matter how narrowly tailored", codifying *Edwards v. Arthur Andersen*, 2008), §16600.5 (SB 699, effective 2024-01-01 — unenforceable regardless of where/when signed), §16600.1 (AB 1076 — inclusion unlawful + individualized notice duty). Exception: sale-of-business (§16601 family). Sources: Quinn Emanuel, Holland & Knight, Jackson Lewis, CalChamber alerts.
   - **CA-ON** (`prohibited`): ESA, 2000 s.67.2 (Working for Workers Act, 2021 / Bill 27), effective 2021-10-25. Exceptions: defined C-suite executive list; sale-of-business (seller becomes purchaser's employee; "sale" includes lease). Sources: Bill 27 text (ola.org), Littler, Torys, Bennett Jones.
   
   Header carries the series contribution rule (no row without citable legal source + effective date + `as_of`) **plus a covenant-type discipline rule: non-compete and non-solicitation are never conflated** — Ontario's ban notably does NOT cover non-solicits, which is why `covenant_type` is a key field. Candidate rows in comments only (Minnesota 2023, ND/OK, Germany §74 HGB Karenzentschädigung, UK common-law reasonableness, WA/CO/IL thresholds). All dates are quoted YAML strings (the #2027 timezone lesson).

2. **`modes/offer-prep.md`** — a "Statutory-context notes for restrictive covenants" subsection inside Step 2's clause walk, integrating at the mode's **two existing output surfaces** only:
   - the matched clause's neutral tags gain a **statutory-context note** (blockquote template, `[Render in {language.output}: ...]`, fictional Acme Corp example, `as_of` staleness disclosure) — a fact about the statute, never a verdict about this clause;
   - the **Questions for your lawyer** list gains a targeted, clause-anchored entry ("Does ESA s.67.2 apply to this clause given my role, or does the executive exception cover it?"). Step 4's lawyer-list spec references it.

## Describes-never-judges is preserved, not overridden

This was the design constraint. offer-prep's contract — describes clauses with neutral tags, builds a lawyer-question list, never judges, never researches online — stays intact:

- **Never assert application (HARD RULE)** in the new subsection: the statutory exceptions (executive status, sale-of-business context, choice-of-law) are exactly the things a contract document cannot self-certify, so the mode never says a clause is void/unenforceable/illegal and never says a statute "applies here". Statute existence, scope, dates, exceptions = facts stated with citation; application = always a lawyer question.
- The **"Never state law from memory"** hard guard and Step 1's **meta-statement boundary** each gain one narrow, explicit carve-out: verified, cited rows in the local table are the *single* sanctioned source of statutory facts. Statements about what the law means for *this* clause remain banned everywhere.
- The **no-online-research guard is explicitly reaffirmed**: table lookup is a local file read, not research — no WebSearch, no WebFetch, no URLs, unchanged.
- No new judgment machinery, no enforceability scoring, no negotiation-leverage claims, not-legal-advice notes throughout.

## Seed-source discipline

Both rows follow the umbrella #2026 contract: narrow, verified, citable legal basis + effective date + `as_of: 2026-07-18`. Broad coverage is deliberately left to comment-listed candidate rows requiring the same discipline.

## Tests (mirrors the #2027 pin approach)

Three doc-structure pins added to `test-all.mjs` (1799 → **1802 passed, 0 failed** on `--quick`):
1. table exists + YAML-parses + both seeds complete (status enum membership, non-empty exceptions/sources, quoted-string `effective`/`as_of`, §16600/§16600.5 and s.67.2/2021-10-25 anchors) + header contribution & covenant-type rules;
2. offer-prep subsection structure — table reference, tag-note + lawyer-question integration, covenant-type discipline, never-assert-application hard rule, not-legal-advice, local-lookup-is-not-research, `{language.output}` rendering;
3. phrasing scan scoped to blockquote (`>`) lines only, and only for **clause-directed** verdict patterns (`this/your clause is void|illegal|unenforceable|...`) — so the statute descriptions, which legitimately contain "prohibited"/"void" *about the statute*, can never false-positive (same scoping move as #2021/#2027).

The existing offer-prep posture-freeze suite (55b, #1634) and all five hard-guard pins still pass untouched.

## Housekeeping

- `templates/README.md` gains the table's row (the #2020/#2027 precedent); no AGENTS.md row, matching the sibling tables.
- SYSTEM_PATHS: covered by the existing `templates/` directory prefix in `update-system.mjs` — `node validate-system-paths-coverage.mjs` passes ("OK: 751 tracked files covered"); no per-file entry needed.
- **Consolidation offer (same as siblings):** if a single consolidated `templates/jurisdiction-*.yml` is preferred over per-feature tables, happy to fold this one in — flagging per the umbrella's coordination note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a local reference for restrictive-covenant statutory context, including jurisdiction-specific rules, exceptions, effective dates, and sources.
  - Updated offer-preparation guidance to provide table-backed statutory context and targeted questions for legal counsel without making clause-specific legal conclusions.

- **Documentation**
  - Documented the new restrictive-covenant reference file, its data fields, and contribution requirements.

- **Tests**
  - Added validation for reference data completeness, workflow integration, required wording, and legal-safety phrasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->