### PR TITLE
feat(test): seed-fixture.mjs + era-appropriate install fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,8 @@ plan/
 
 # Web — runtime cache/history the dashboard writes locally; nothing here is tracked.
 .career-ops-web/
+
+# Upgrade-test fixtures are fictional system-layer data, never user data
+# (see DATA_CONTRACT.md). Re-include them past the unanchored user-layer
+# patterns above (cv.md, portals.yml).
+!test-fixtures/**

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -104,6 +104,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `VERSION` | Current version number |
 | `DATA_CONTRACT.md` | This file |
 | `writing-samples/README.md` | System-owned onboarding documentation for the writing-samples directory |
+| `seed-fixture.mjs` / `test-fixtures/*` | Upgrade-test fixtures and seeder (system layer; fictional data, never user data) |
 
 ## The Rule
 

--- a/seed-fixture.mjs
+++ b/seed-fixture.mjs
@@ -69,7 +69,12 @@ export function loadExpectations(state = DEFAULT_STATE) {
 function selfTest() {
   let failed = 0;
   const check = (ok, msg) => { console.log(`${ok ? 'PASS' : 'FAIL'} ${msg}`); if (!ok) failed++; };
-  for (const state of listStates()) {
+  const states = listStates();
+  // Guard against a vacuous pass: zero fixture states would run zero checks and
+  // still print "green". listStates() legitimately returns [] for discovery, so
+  // the assertion lives here in the test, not in listStates() itself.
+  check(states.length > 0, `discovered at least one fixture state (found ${states.length})`);
+  for (const state of states) {
     const dir = mkdtempSync(join(tmpdir(), 'seed-fixture-'));
     try {
       const { files, manifest } = seedFixture(dir, { state });

--- a/seed-fixture.mjs
+++ b/seed-fixture.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * seed-fixture.mjs — materialize a realistic user-data fixture into an install.
+ *
+ * Fixture states live in test-fixtures/upgrade/<state>/ and mirror the
+ * user-layer files a real install of that era contains. Returns a SHA-256
+ * manifest so callers can assert byte-identity later.
+ *
+ * Usage:
+ *   node seed-fixture.mjs <targetDir> [--state state-v1.18]
+ *   node seed-fixture.mjs --self-test
+ */
+import { createHash } from 'crypto';
+import { cpSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, existsSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname, relative, sep } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(ROOT, 'test-fixtures', 'upgrade');
+export const DEFAULT_STATE = 'state-v1.18';
+
+function walk(dir, base = dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, base, out);
+    else out.push(relative(base, p).split(sep).join('/'));
+  }
+  return out;
+}
+
+export function listStates() {
+  return readdirSync(FIXTURES).filter((n) => statSync(join(FIXTURES, n)).isDirectory());
+}
+
+export function seedFixture(targetDir, { state = DEFAULT_STATE } = {}) {
+  if (!existsSync(targetDir) || !statSync(targetDir).isDirectory()) throw new Error(`targetDir is not an existing directory: ${targetDir}`);
+  const src = join(FIXTURES, state);
+  if (!existsSync(src)) throw new Error(`Unknown fixture state: ${state} (have: ${listStates().join(', ')})`);
+  // expected.json is harness metadata, not user data — never seed it.
+  const files = walk(src).filter((f) => f !== 'expected.json');
+  const manifest = {};
+  for (const f of files) {
+    const dest = join(targetDir, f);
+    mkdirSync(dirname(dest), { recursive: true });
+    cpSync(join(src, f), dest);
+    manifest[f] = createHash('sha256').update(readFileSync(dest)).digest('hex');
+  }
+  return { state, files, manifest };
+}
+
+export function loadExpectations(state = DEFAULT_STATE) {
+  return JSON.parse(readFileSync(join(FIXTURES, state, 'expected.json'), 'utf-8'));
+}
+
+function selfTest() {
+  let failed = 0;
+  const check = (ok, msg) => { console.log(`${ok ? 'PASS' : 'FAIL'} ${msg}`); if (!ok) failed++; };
+  for (const state of listStates()) {
+    const dir = mkdtempSync(join(tmpdir(), 'seed-fixture-'));
+    try {
+      const { files, manifest } = seedFixture(dir, { state });
+      check(files.length >= 8, `${state}: seeds ${files.length} files (>=8)`);
+      check(!files.includes('expected.json'), `${state}: expected.json not seeded`);
+      const REQUIRED = ['cv.md', 'config/profile.yml', 'modes/_profile.md', 'portals.yml', 'data/applications.md'];
+      for (const r of REQUIRED) check(files.includes(r), `${state}: required file seeded: ${r}`);
+      const again = seedFixture(dir, { state });
+      check(JSON.stringify(again.manifest) === JSON.stringify(manifest), `${state}: manifest is deterministic`);
+      const exp = loadExpectations(state);
+      check(Number.isInteger(exp.tracker_rows) && exp.tracker_rows > 0, `${state}: expected.json parses with tracker_rows`);
+      const tracker = readFileSync(join(dir, 'data/applications.md'), 'utf-8');
+      const rows = tracker.split('\n').filter((l) => /^\|\s*\d+\s*\|/.test(l)).length;
+      check(rows === exp.tracker_rows, `${state}: tracker has ${rows} rows == expected ${exp.tracker_rows}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  console.log(failed ? `${failed} check(s) failed` : 'seed-fixture self-test green');
+  process.exit(failed ? 1 : 0);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = process.argv.slice(2);
+  if (args[0] === '--self-test') selfTest();
+  else if (args[0] && !args[0].startsWith('--')) {
+    const stateIdx = args.indexOf('--state');
+    if (stateIdx > -1 && (args[stateIdx + 1] === undefined || args[stateIdx + 1].startsWith('--'))) {
+      console.error('Missing value for --state');
+      process.exit(1);
+    }
+    const res = seedFixture(args[0], stateIdx > -1 ? { state: args[stateIdx + 1] } : {});
+    console.log(JSON.stringify(res, null, 2));
+  } else {
+    console.error('Usage: node seed-fixture.mjs <targetDir> [--state name] | --self-test');
+    process.exit(1);
+  }
+}

--- a/seed-fixture.mjs
+++ b/seed-fixture.mjs
@@ -30,13 +30,25 @@ function walk(dir, base = dir, out = []) {
 }
 
 export function listStates() {
+  if (!existsSync(FIXTURES)) return [];
   return readdirSync(FIXTURES).filter((n) => statSync(join(FIXTURES, n)).isDirectory());
+}
+
+// Strict allowlist: a state must be one of the real fixture subdirectories.
+// Membership in listStates() (basenames only) inherently rejects both unknown
+// states and traversal strings ('../x', 'state/../..'), so no join() ever
+// escapes FIXTURES.
+function assertKnownState(state) {
+  const states = listStates();
+  if (!states.includes(state)) {
+    throw new Error(`Unknown fixture state: ${state} (have: ${states.join(', ') || 'none'})`);
+  }
 }
 
 export function seedFixture(targetDir, { state = DEFAULT_STATE } = {}) {
   if (!existsSync(targetDir) || !statSync(targetDir).isDirectory()) throw new Error(`targetDir is not an existing directory: ${targetDir}`);
+  assertKnownState(state);
   const src = join(FIXTURES, state);
-  if (!existsSync(src)) throw new Error(`Unknown fixture state: ${state} (have: ${listStates().join(', ')})`);
   // expected.json is harness metadata, not user data — never seed it.
   const files = walk(src).filter((f) => f !== 'expected.json');
   const manifest = {};
@@ -50,6 +62,7 @@ export function seedFixture(targetDir, { state = DEFAULT_STATE } = {}) {
 }
 
 export function loadExpectations(state = DEFAULT_STATE) {
+  assertKnownState(state);
   return JSON.parse(readFileSync(join(FIXTURES, state, 'expected.json'), 'utf-8'));
 }
 

--- a/seed-fixture.mjs
+++ b/seed-fixture.mjs
@@ -21,7 +21,9 @@ const FIXTURES = join(ROOT, 'test-fixtures', 'upgrade');
 export const DEFAULT_STATE = 'state-v1.18';
 
 function walk(dir, base = dir, out = []) {
-  for (const name of readdirSync(dir)) {
+  // Sort so files[] and the manifest key order are deterministic across
+  // platforms (readdirSync returns filesystem order, which varies).
+  for (const name of readdirSync(dir).sort()) {
     const p = join(dir, name);
     if (statSync(p).isDirectory()) walk(p, base, out);
     else out.push(relative(base, p).split(sep).join('/'));
@@ -31,7 +33,9 @@ function walk(dir, base = dir, out = []) {
 
 export function listStates() {
   if (!existsSync(FIXTURES)) return [];
-  return readdirSync(FIXTURES).filter((n) => statSync(join(FIXTURES, n)).isDirectory());
+  // Sort for deterministic state ordering across platforms (readdirSync
+  // returns filesystem order, which varies).
+  return readdirSync(FIXTURES).sort().filter((n) => statSync(join(FIXTURES, n)).isDirectory());
 }
 
 // Strict allowlist: a state must be one of the real fixture subdirectories.

--- a/seed-fixture.mjs
+++ b/seed-fixture.mjs
@@ -110,8 +110,14 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
       console.error('Missing value for --state');
       process.exit(1);
     }
-    const res = seedFixture(args[0], stateIdx > -1 ? { state: args[stateIdx + 1] } : {});
-    console.log(JSON.stringify(res, null, 2));
+    try {
+      const res = seedFixture(args[0], stateIdx > -1 ? { state: args[stateIdx + 1] } : {});
+      console.log(JSON.stringify(res, null, 2));
+    } catch (err) {
+      // Concise, actionable message — never leak a raw stack trace to the CLI.
+      console.error(`seed-fixture: ${err.message}`);
+      process.exit(1);
+    }
   } else {
     console.error('Usage: node seed-fixture.mjs <targetDir> [--state name] | --self-test');
     process.exit(1);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -209,7 +209,10 @@ const scriptTmp = mkdtempSync(join(ROOT, '.tmp-script-test-'));
 try {
   const copyDirSync = (src, dest, exclude = []) => {
     const name = src.split(/[\\/]/).pop();
-    if (exclude.includes(name)) return;
+    // Exclude only top-level workspace dirs (data/, reports/, node_modules, …).
+    // Match by basename ONLY at the repo root so nested fixture subdirs such as
+    // test-fixtures/upgrade/state-*/data and .../reports still get copied.
+    if (dirname(src) === ROOT && exclude.includes(name)) return;
     const stat = statSync(src);
     if (stat.isDirectory()) {
       mkdirSync(dest, { recursive: true });

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -201,6 +201,7 @@ const scripts = [
   // portals file that would trigger a live remote sweep during tests.
   { name: 'verify-portals.mjs --file .tmp-test-missing-portals.yml', expectExit: 0 },
   { name: 'update-system.mjs check', expectExit: 0 },
+  { name: 'seed-fixture.mjs --self-test', expectExit: 0 },
   { name: 'archive-posting.mjs --help', expectExit: 0 },
 ];
 

--- a/test-fixtures/upgrade/state-v1.16/config/profile.yml
+++ b/test-fixtures/upgrade/state-v1.16/config/profile.yml
@@ -1,0 +1,15 @@
+name: Jordan Reyes
+email: jordan.reyes@example.test
+location: Manchester, UK
+timezone: Europe/London
+target_roles:
+  - Senior Platform Engineer
+  - Staff DevOps Engineer
+salary_target:
+  min: 85000
+  max: 105000
+  currency: GBP
+spend_tier: standard
+narrative: >
+  Platform engineer who treats developer experience as a product.
+  Looking for remote-first teams with real CI/CD investment.

--- a/test-fixtures/upgrade/state-v1.16/cv.md
+++ b/test-fixtures/upgrade/state-v1.16/cv.md
@@ -1,0 +1,24 @@
+# Jordan Reyes — Platform Engineer
+
+## Summary
+Platform engineer with 7 years building CI/CD and internal tooling for mid-size SaaS teams. Cut deploy lead time 68% at Acme by replacing hand-rolled shell pipelines with a reusable workflow library used by 14 teams.
+
+## Experience
+
+### Senior Platform Engineer — Acme Corp (2022–2026)
+- Designed workflow library (Node/TypeScript) adopted by 14 product teams; deploy lead time 45m → 14m.
+- Led migration of 200+ repos to trunk-based development; change-failure rate down 31%.
+- On-call rotation lead; wrote the incident-review template now used org-wide.
+
+### DevOps Engineer — Globex GmbH (2019–2022)
+- Built Kubernetes platform (EKS) serving 40 microservices; 99.95% availability over 3 years.
+- Automated compliance evidence collection, saving ~6 engineer-days per audit.
+
+## Projects
+- **shipcheck** — open-source pre-deploy sanity checker (1.2k stars).
+
+## Education
+B.Sc. Computer Science, University of Leeds, 2019.
+
+## Skills
+Node.js, TypeScript, Go, Kubernetes, Terraform, GitHub Actions, Postgres, Grafana.

--- a/test-fixtures/upgrade/state-v1.16/data/applications.md
+++ b/test-fixtures/upgrade/state-v1.16/data/applications.md
@@ -1,0 +1,10 @@
+# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-20 | Acme | Senior Platform Engineer | 4.2/5 | Applied | ✅ | [1](../reports/001-acme-2026-06-20.md) | Strong platform fit |
+| 2 | 2026-06-25 | Globex | Staff DevOps Engineer | 4.5/5 | Interview | ✅ | [2](../reports/002-globex-2026-06-25.md) | Referral via ex-colleague |
+| 3 | 2026-06-26 | Initech | SRE | 3.1/5 | SKIP | ❌ | — | Below 4.0 bar |
+| 4 | 2026-06-27 | Umbrella Cloud | Platform Engineer | 4.0/5 | Evaluated | ❌ | — | Awaiting decision |
+| 5 | 2026-06-28 | Hooli | DevOps Lead | 3.8/5 | Rejected | ✅ | — | Auto-rejection day 2 |
+| 6 | 2026-06-30 | Stark Industries | Infrastructure Engineer | 4.1/5 | Applied | ✅ | — | Follow-up due 2026-07-07 |

--- a/test-fixtures/upgrade/state-v1.16/data/follow-ups.md
+++ b/test-fixtures/upgrade/state-v1.16/data/follow-ups.md
@@ -1,0 +1,6 @@
+# Follow-ups
+
+| # | Company | Applied | Follow-up 1 | Follow-up 2 | Status |
+|---|---------|---------|-------------|-------------|--------|
+| 1 | Acme | 2026-06-20 | 2026-06-27 ✅ | 2026-07-04 | Awaiting reply |
+| 6 | Stark Industries | 2026-06-30 | 2026-07-07 | — | Scheduled |

--- a/test-fixtures/upgrade/state-v1.16/data/scan-history.tsv
+++ b/test-fixtures/upgrade/state-v1.16/data/scan-history.tsv
@@ -1,0 +1,3 @@
+https://boards.example.test/acme/jobs/12345	2026-06-19	Senior Platform Engineer
+https://boards.example.test/globex/jobs/67890	2026-06-24	Staff DevOps Engineer
+https://boards.example.test/initech/jobs/11111	2026-06-25	Site Reliability Engineer

--- a/test-fixtures/upgrade/state-v1.16/expected.json
+++ b/test-fixtures/upgrade/state-v1.16/expected.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "tracker_rows": 6,
+  "status_counts": { "Applied": 2, "Interview": 1, "SKIP": 1, "Evaluated": 1, "Rejected": 1 },
+  "report_files": 2,
+  "has_via_column": false,
+  "salary_observations": null
+}

--- a/test-fixtures/upgrade/state-v1.16/modes/_profile.md
+++ b/test-fixtures/upgrade/state-v1.16/modes/_profile.md
@@ -1,0 +1,15 @@
+# Profile — Jordan Reyes
+
+## Archetypes
+1. **Platform builder** — internal tooling, CI/CD, golden paths.
+2. **Reliability engineer** — SLOs, on-call maturity, incident process.
+
+## Proof points
+- Deploy lead time 45m → 14m across 14 teams (Acme).
+- 99.95% availability over 3 years on EKS (Globex).
+
+## Location policy
+Remote UK/EU; no relocation; on-site max 1 week/quarter.
+
+## Comp targets
+£85–105k base; pension ≥ 6%; no equity-for-salary trades.

--- a/test-fixtures/upgrade/state-v1.16/portals.yml
+++ b/test-fixtures/upgrade/state-v1.16/portals.yml
@@ -1,0 +1,13 @@
+title_filter:
+  positive: ["platform engineer", "devops", "sre", "infrastructure"]
+  negative: ["intern", "junior"]
+companies:
+  - name: ExampleSoft
+    ats: greenhouse
+    slug: examplesoft
+  - name: Initech
+    ats: lever
+    slug: initech
+  - name: Umbrella Cloud
+    ats: ashby
+    slug: umbrella-cloud

--- a/test-fixtures/upgrade/state-v1.16/reports/001-acme-2026-06-20.md
+++ b/test-fixtures/upgrade/state-v1.16/reports/001-acme-2026-06-20.md
@@ -1,0 +1,28 @@
+# 001 — Acme Corp — Senior Platform Engineer
+
+**Date:** 2026-06-20
+**Score:** 4.2/5
+**URL:** https://boards.example.test/acme/jobs/12345
+**PDF:** ✅
+**Legitimacy:** High Confidence
+
+## A. Role Summary
+Senior platform engineer owning CI/CD golden paths for ~200 repos.
+
+## B. Fit Analysis
+Direct overlap with workflow-library experience; scale matches.
+
+## C. Compensation
+Advertised £90-100k GBP; inside target band.
+
+## D. Risks
+Platform team is new (formed Q1); charter may shift.
+
+## E. Verdict
+Apply. Lead with the 45m→14m deploy-lead-time proof point.
+
+## F. Next Steps
+Tailored CV generated; application submitted 2026-06-20.
+
+## G. Posting Legitimacy
+Company site cross-links the ATS posting; recruiter verified on LinkedIn. Tier: High Confidence.

--- a/test-fixtures/upgrade/state-v1.16/reports/002-globex-2026-06-25.md
+++ b/test-fixtures/upgrade/state-v1.16/reports/002-globex-2026-06-25.md
@@ -1,0 +1,28 @@
+# 002 — Globex GmbH — Staff DevOps Engineer
+
+**Date:** 2026-06-25
+**Score:** 4.5/5
+**URL:** https://boards.example.test/globex/jobs/67890
+**PDF:** ✅
+**Legitimacy:** High Confidence
+
+## A. Role Summary
+Staff DevOps engineer owning the Kubernetes platform for 40+ microservices.
+
+## B. Fit Analysis
+Near-identical to Globex-era EKS platform work; availability track record matches the SLO bar.
+
+## C. Compensation
+Advertised £95-110k GBP; upper half of target band.
+
+## D. Risks
+Platform and SRE orgs recently merged; reporting line may change.
+
+## E. Verdict
+Apply — referral in play. Lead with the 99.95% availability proof point.
+
+## F. Next Steps
+Phone screen booked 2026-07-02.
+
+## G. Posting Legitimacy
+Company site cross-links the ATS posting; hiring manager confirmed the req via referral. Tier: High Confidence.

--- a/test-fixtures/upgrade/state-v1.18/config/profile.yml
+++ b/test-fixtures/upgrade/state-v1.18/config/profile.yml
@@ -1,0 +1,15 @@
+name: Jordan Reyes
+email: jordan.reyes@example.test
+location: Manchester, UK
+timezone: Europe/London
+target_roles:
+  - Senior Platform Engineer
+  - Staff DevOps Engineer
+salary_target:
+  min: 85000
+  max: 105000
+  currency: GBP
+spend_tier: standard
+narrative: >
+  Platform engineer who treats developer experience as a product.
+  Looking for remote-first teams with real CI/CD investment.

--- a/test-fixtures/upgrade/state-v1.18/cv.md
+++ b/test-fixtures/upgrade/state-v1.18/cv.md
@@ -1,0 +1,24 @@
+# Jordan Reyes — Platform Engineer
+
+## Summary
+Platform engineer with 7 years building CI/CD and internal tooling for mid-size SaaS teams. Cut deploy lead time 68% at Acme by replacing hand-rolled shell pipelines with a reusable workflow library used by 14 teams.
+
+## Experience
+
+### Senior Platform Engineer — Acme Corp (2022–2026)
+- Designed workflow library (Node/TypeScript) adopted by 14 product teams; deploy lead time 45m → 14m.
+- Led migration of 200+ repos to trunk-based development; change-failure rate down 31%.
+- On-call rotation lead; wrote the incident-review template now used org-wide.
+
+### DevOps Engineer — Globex GmbH (2019–2022)
+- Built Kubernetes platform (EKS) serving 40 microservices; 99.95% availability over 3 years.
+- Automated compliance evidence collection, saving ~6 engineer-days per audit.
+
+## Projects
+- **shipcheck** — open-source pre-deploy sanity checker (1.2k stars).
+
+## Education
+B.Sc. Computer Science, University of Leeds, 2019.
+
+## Skills
+Node.js, TypeScript, Go, Kubernetes, Terraform, GitHub Actions, Postgres, Grafana.

--- a/test-fixtures/upgrade/state-v1.18/data/applications.md
+++ b/test-fixtures/upgrade/state-v1.18/data/applications.md
@@ -1,0 +1,10 @@
+# Applications Tracker
+
+| # | Date | Company | Via | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|-----|------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-20 | Acme | — | Senior Platform Engineer | 4.2/5 | Applied | ✅ | [1](../reports/001-acme-2026-06-20.md) | Strong platform fit |
+| 2 | 2026-06-25 | Globex | Hays | Staff DevOps Engineer | 4.5/5 | Interview | ✅ | [2](../reports/002-globex-2026-06-25.md) | Referral via ex-colleague |
+| 3 | 2026-06-26 | Initech | — | SRE | 3.1/5 | SKIP | ❌ | — | Below 4.0 bar |
+| 4 | 2026-06-27 | Umbrella Cloud | — | Platform Engineer | 4.0/5 | Evaluated | ❌ | — | Awaiting decision |
+| 5 | 2026-06-28 | Hooli | — | DevOps Lead | 3.8/5 | Rejected | ✅ | — | Auto-rejection day 2 |
+| 6 | 2026-06-30 | Stark Industries | — | Infrastructure Engineer | 4.1/5 | Applied | ✅ | — | Follow-up due 2026-07-07 |

--- a/test-fixtures/upgrade/state-v1.18/data/follow-ups.md
+++ b/test-fixtures/upgrade/state-v1.18/data/follow-ups.md
@@ -1,0 +1,6 @@
+# Follow-ups
+
+| # | Company | Applied | Follow-up 1 | Follow-up 2 | Status |
+|---|---------|---------|-------------|-------------|--------|
+| 1 | Acme | 2026-06-20 | 2026-06-27 ✅ | 2026-07-04 | Awaiting reply |
+| 6 | Stark Industries | 2026-06-30 | 2026-07-07 | — | Scheduled |

--- a/test-fixtures/upgrade/state-v1.18/data/salary-observations.tsv
+++ b/test-fixtures/upgrade/state-v1.18/data/salary-observations.tsv
@@ -1,0 +1,2 @@
+1	2026-06-20	desired	85000-105000	GBP	user	target band going in
+2	2026-07-02	actual	98000	GBP	recruiter-verbal	range floated in phone screen

--- a/test-fixtures/upgrade/state-v1.18/data/scan-history.tsv
+++ b/test-fixtures/upgrade/state-v1.18/data/scan-history.tsv
@@ -1,0 +1,3 @@
+https://boards.example.test/acme/jobs/12345	2026-06-19	Senior Platform Engineer
+https://boards.example.test/globex/jobs/67890	2026-06-24	Staff DevOps Engineer
+https://boards.example.test/initech/jobs/11111	2026-06-25	Site Reliability Engineer

--- a/test-fixtures/upgrade/state-v1.18/expected.json
+++ b/test-fixtures/upgrade/state-v1.18/expected.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "tracker_rows": 6,
+  "status_counts": { "Applied": 2, "Interview": 1, "SKIP": 1, "Evaluated": 1, "Rejected": 1 },
+  "report_files": 2,
+  "has_via_column": true,
+  "salary_observations": 2
+}

--- a/test-fixtures/upgrade/state-v1.18/modes/_profile.md
+++ b/test-fixtures/upgrade/state-v1.18/modes/_profile.md
@@ -1,0 +1,15 @@
+# Profile — Jordan Reyes
+
+## Archetypes
+1. **Platform builder** — internal tooling, CI/CD, golden paths.
+2. **Reliability engineer** — SLOs, on-call maturity, incident process.
+
+## Proof points
+- Deploy lead time 45m → 14m across 14 teams (Acme).
+- 99.95% availability over 3 years on EKS (Globex).
+
+## Location policy
+Remote UK/EU; no relocation; on-site max 1 week/quarter.
+
+## Comp targets
+£85–105k base; pension ≥ 6%; no equity-for-salary trades.

--- a/test-fixtures/upgrade/state-v1.18/portals.yml
+++ b/test-fixtures/upgrade/state-v1.18/portals.yml
@@ -1,0 +1,13 @@
+title_filter:
+  positive: ["platform engineer", "devops", "sre", "infrastructure"]
+  negative: ["intern", "junior"]
+companies:
+  - name: ExampleSoft
+    ats: greenhouse
+    slug: examplesoft
+  - name: Initech
+    ats: lever
+    slug: initech
+  - name: Umbrella Cloud
+    ats: ashby
+    slug: umbrella-cloud

--- a/test-fixtures/upgrade/state-v1.18/reports/001-acme-2026-06-20.md
+++ b/test-fixtures/upgrade/state-v1.18/reports/001-acme-2026-06-20.md
@@ -1,0 +1,50 @@
+# 001 — Acme Corp — Senior Platform Engineer
+
+**Date:** 2026-06-20
+**Score:** 4.2/5
+**URL:** https://boards.example.test/acme/jobs/12345
+**PDF:** ✅
+**Legitimacy:** High Confidence
+
+## Machine Summary
+
+```yaml
+company: "Acme"
+role: "Senior Platform Engineer"
+score: 4.2
+legitimacy_tier: "High Confidence"
+archetype: "Platform builder"
+final_decision: "Apply"
+hard_stops: []
+soft_gaps:
+  - "New platform team; charter may shift"
+top_strengths:
+  - "Deploy lead time 45m → 14m across 14 teams"
+risk_level: "Low"
+confidence: "High"
+next_action: "Follow up on application submitted 2026-06-20"
+via: null
+company_confidential: false
+advertised_comp: "£90-100k GBP"
+```
+
+## A. Role Summary
+Senior platform engineer owning CI/CD golden paths for ~200 repos.
+
+## B. Fit Analysis
+Direct overlap with workflow-library experience; scale matches.
+
+## C. Compensation
+Advertised £90-100k GBP; inside target band.
+
+## D. Risks
+Platform team is new (formed Q1); charter may shift.
+
+## E. Verdict
+Apply. Lead with the 45m→14m deploy-lead-time proof point.
+
+## F. Next Steps
+Tailored CV generated; application submitted 2026-06-20.
+
+## G. Posting Legitimacy
+Company site cross-links the ATS posting; recruiter verified on LinkedIn. Tier: High Confidence.

--- a/test-fixtures/upgrade/state-v1.18/reports/002-globex-2026-06-25.md
+++ b/test-fixtures/upgrade/state-v1.18/reports/002-globex-2026-06-25.md
@@ -1,0 +1,50 @@
+# 002 — Globex GmbH — Staff DevOps Engineer
+
+**Date:** 2026-06-25
+**Score:** 4.5/5
+**URL:** https://boards.example.test/globex/jobs/67890
+**PDF:** ✅
+**Legitimacy:** High Confidence
+
+## Machine Summary
+
+```yaml
+company: "Globex"
+role: "Staff DevOps Engineer"
+score: 4.5
+legitimacy_tier: "High Confidence"
+archetype: "Reliability engineer"
+final_decision: "Apply"
+hard_stops: []
+soft_gaps:
+  - "Platform and SRE orgs recently merged; reporting line may change"
+top_strengths:
+  - "99.95% availability over 3 years on EKS"
+risk_level: "Low"
+confidence: "High"
+next_action: "Prepare for phone screen booked 2026-07-02"
+via: "Hays"
+company_confidential: false
+advertised_comp: "£95-110k GBP"
+```
+
+## A. Role Summary
+Staff DevOps engineer owning the Kubernetes platform for 40+ microservices.
+
+## B. Fit Analysis
+Near-identical to Globex-era EKS platform work; availability track record matches the SLO bar.
+
+## C. Compensation
+Advertised £95-110k GBP; upper half of target band.
+
+## D. Risks
+Platform and SRE orgs recently merged; reporting line may change.
+
+## E. Verdict
+Apply — referral in play. Lead with the 99.95% availability proof point.
+
+## F. Next Steps
+Phone screen booked 2026-07-02.
+
+## G. Posting Legitimacy
+Company site cross-links the ATS posting; hiring manager confirmed the req via referral. Tier: High Confidence.

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -986,49 +986,56 @@ async function apply() {
       console.log(`Skipped ${skippedPaths.length} path(s) absent upstream: ${skippedPaths.join(', ')}`);
     }
 
-    // tests/ is auto-discovered and EXECUTED (tests/**/*.test.mjs), so stale
-    // files left behind by upstream renames would run twice or crash the
-    // suite. `git checkout` never deletes upstream-removed files (see the
-    // limitation note in rollback below) — prune tracked extras against
-    // FETCH_HEAD. Only git-tracked files are removed: a user's untracked
-    // local experiments in tests/ are never touched.
-    try {
-      let remoteTests = new Set();
+    // tests/ and test-fixtures/ are both auto-discovered and EXECUTED
+    // (tests/**/*.test.mjs run directly; test-fixtures/upgrade/<state>/ dirs are
+    // enumerated by seed-fixture.mjs's listStates() and exercised by its
+    // --self-test, which fails if a stale state lacks expected.json/required
+    // files). Stale files left behind by upstream renames would run twice,
+    // crash the suite, or make the self-test iterate a state that no longer
+    // ships upstream. `git checkout` never deletes upstream-removed files (see
+    // the limitation note in rollback below) — prune tracked extras against
+    // FETCH_HEAD. Only git-tracked files are removed: a user's untracked local
+    // experiments in these dirs are never touched.
+    for (const prunePrefix of ['tests/', 'test-fixtures/']) {
       try {
-        remoteTests = new Set(
-          git('ls-tree', '-r', '--name-only', 'FETCH_HEAD', '--', 'tests/')
-            .split('\n').filter(Boolean).map((p) => p.replace(/\\/g, '/'))
-        );
-      } catch {
-        // tests/ may not exist in older targets (ls-tree throws) — nothing to
-        // prune. This is the only expected-and-silent failure in this block.
-      }
-      // An empty set means FETCH_HEAD has no tests/ at all (older target, or
-      // ls-tree quietly returning nothing) — pruning against it would delete
-      // every local test file. Only prune when the remote actually ships tests/.
-      if (remoteTests.size > 0) {
-        const localTests = git('ls-files', '--', 'tests/').split('\n').filter(Boolean);
-        for (const f of localTests) {
-          if (!remoteTests.has(f.replace(/\\/g, '/'))) {
-            // Per-file isolation: one failed unlink (locked file, permissions)
-            // must not abort pruning the rest.
-            try {
-              unlinkSync(join(ROOT, f));
-              // Raw path only: `updated` entries are reused as git pathspecs by
-              // revertPaths() and the scoped commit below. Pushed only after a
-              // successful unlink so failed deletions never enter `updated`.
-              updated.push(f);
-              console.log(`Pruned stale test file: ${f}`);
-            } catch (err) {
-              console.error(`Failed to prune stale test file ${f}: ${err.message}`);
+        let remoteFiles = new Set();
+        try {
+          remoteFiles = new Set(
+            git('ls-tree', '-r', '--name-only', 'FETCH_HEAD', '--', prunePrefix)
+              .split('\n').filter(Boolean).map((p) => p.replace(/\\/g, '/'))
+          );
+        } catch {
+          // The dir may not exist in older targets (ls-tree throws) — nothing
+          // to prune. This is the only expected-and-silent failure here.
+        }
+        // An empty set means FETCH_HEAD has no such dir at all (older target, or
+        // ls-tree quietly returning nothing) — pruning against it would delete
+        // every local file under the prefix. Only prune when the remote actually
+        // ships the directory.
+        if (remoteFiles.size > 0) {
+          const localFiles = git('ls-files', '--', prunePrefix).split('\n').filter(Boolean);
+          for (const f of localFiles) {
+            if (!remoteFiles.has(f.replace(/\\/g, '/'))) {
+              // Per-file isolation: one failed unlink (locked file, permissions)
+              // must not abort pruning the rest.
+              try {
+                unlinkSync(join(ROOT, f));
+                // Raw path only: `updated` entries are reused as git pathspecs by
+                // revertPaths() and the scoped commit below. Pushed only after a
+                // successful unlink so failed deletions never enter `updated`.
+                updated.push(f);
+                console.log(`Pruned stale file: ${f}`);
+              } catch (err) {
+                console.error(`Failed to prune stale file ${f}: ${err.message}`);
+              }
             }
           }
         }
+      } catch (err) {
+        // Unexpected failure (e.g. ls-files threw) — surface it instead of
+        // silently skipping the prune step.
+        console.error(`Stale-file prune step failed for ${prunePrefix}: ${err.message}`);
       }
-    } catch (err) {
-      // Unexpected failure (e.g. ls-files threw) — surface it instead of
-      // silently skipping the prune step.
-      console.error(`Stale-test prune step failed: ${err.message}`);
     }
 
     // Lazy import: keep update-system.mjs self-loading (see the top-of-file

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -312,6 +312,8 @@ const SYSTEM_PATHS = [
   'plugin-audit.mjs',
   'validate-plugin-registry.mjs',
   'config/plugins.example.yml',
+  'seed-fixture.mjs',
+  'test-fixtures/',
 ];
 
 const BOOTSTRAP_PATHS = [


### PR DESCRIPTION
First slice of #2007 (upgrade regression testing).

Adds a standalone fixture seeder plus two era-appropriate install states — the groundwork the upgrade harness builds on, and immediately useful on its own: any script test can now materialize a realistic install in one call.

**`seed-fixture.mjs`** — copies a fixture state into a target dir, returns a SHA-256 manifest for later byte-identity assertions. Exports `seedFixture`/`listStates`/`loadExpectations`; `--self-test` wired into `test-all.mjs`.

**`test-fixtures/upgrade/state-v1.16` & `state-v1.18`** — fictional but structurally real installs (CV, profile, 6-row tracker, reports, follow-ups, scan history). The v1.18.0 boundary is where the Via column, Machine Summary, and salary observations land, so each state carries only what its era supported — verified by running that era's own `verify-pipeline.mjs` over the seeded install (both exit 0). Machine Summary uses the real 15-field `batch/batch-prompt.md` schema; Via placement and salary-observations columns mirror the v1.18.0 sources exactly.

**Registrations:** `seed-fixture.mjs` + `test-fixtures/` appended to SYSTEM_PATHS (end of array), DATA_CONTRACT system-layer row, and a `!test-fixtures/**` negation in .gitignore (the unanchored `cv.md`/`portals.yml` ignore patterns were silently excluding fixture copies).

**Verification:** `seed-fixture.mjs --self-test` green (both states, deterministic manifest, required-files check); `test-all.mjs --quick` 1798/0.

Open design questions (oracle shape, support-version window, nightly routing) are in #2007 — the harness PR that consumes these fixtures follows once those settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added upgrade-test fixtures for multiple application-tracking states.
  * Introduced a fixture seeding CLI with `--self-test` and deterministic manifest output.
* **Documentation**
  * Documented upgrade-test fixtures as fictional, non-user system-layer data in the data contract.
  * Clarified repository ignore behavior to ensure fixture assets are included.
* **Tests**
  * Extended the test suite to execute the fixture seeding CLI self-test.
* **Chores**
  * Updated system-layer update/rollback allowlist and improved fixture pruning/copy behavior to better handle fixture directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->