### PR TITLE
fix(providers): build public SmartRecruiters URLs without /postings/ (#2046)

### DIFF
--- a/providers/smartrecruiters.mjs
+++ b/providers/smartrecruiters.mjs
@@ -133,7 +133,7 @@ export function parseSmartRecruitersResponse(json, companyName) {
     if (!url && j.id) {
       const companySlug = (companyName || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
       if (companySlug) {
-        url = `https://jobs.smartrecruiters.com/${companySlug}/${j.id}-${slugified}`;
+        url = `https://jobs.smartrecruiters.com/${companySlug}/${j.id}${slugified ? `-${slugified}` : ''}`;
       }
     }
     return { title: j.name || '', url, location, company: companyName };

--- a/providers/smartrecruiters.mjs
+++ b/providers/smartrecruiters.mjs
@@ -92,8 +92,12 @@ export default {
  * - location: prefer `fullLocation`; else assemble from city/region/country
  *   parts (skipping empties); append "Remote" when `location.remote` is true.
  * - url: `j.ref` is an `api.smartrecruiters.com/v1/companies/<slug>/postings/<id>`
- *   URL — rewrite to the public `jobs.smartrecruiters.com/<slug>/postings/<id>`.
- *   If `ref` is missing, synthesise a URL from the company slug + posting id.
+ *   URL — rewrite to the public `jobs.smartrecruiters.com/<slug>/<id>-<title-slug>`.
+ *   The public site has no `/postings/` segment; carrying it over yields a 404,
+ *   which the liveness checker then reports as an expired posting (#1612).
+ *   SmartRecruiters resolves the page by id alone, so the trailing title slug is
+ *   cosmetic. If `ref` is missing or untrusted, synthesise the same shape from
+ *   the company slug + posting id.
  *
  * @param {any} json
  * @param {string} companyName
@@ -116,8 +120,14 @@ export function parseSmartRecruitersResponse(json, companyName) {
           && parsedRef.protocol === 'https:'
           && parsedRef.hostname === 'api.smartrecruiters.com'
           && parsedRef.pathname.startsWith('/v1/companies/')) {
-        const restOfPath = parsedRef.pathname.slice('/v1/companies/'.length);
-        url = `https://jobs.smartrecruiters.com/${restOfPath}`;
+        // /v1/companies/<slug>/postings/<id> → <slug>, <id>
+        const [refSlug, postings, refId] = parsedRef.pathname
+          .slice('/v1/companies/'.length)
+          .split('/')
+          .filter(Boolean);
+        if (refSlug && postings === 'postings' && refId) {
+          url = `https://jobs.smartrecruiters.com/${refSlug}/${refId}${slugified ? `-${slugified}` : ''}`;
+        }
       }
     }
     if (!url && j.id) {

--- a/tests/providers/smartrecruiters.test.mjs
+++ b/tests/providers/smartrecruiters.test.mjs
@@ -84,10 +84,31 @@ try {
     fail(`row 1 location = ${JSON.stringify(jobs[1]?.location)}, expected "Paris, France, Remote"`);
   }
 
-  if (jobs[0]?.url === 'https://jobs.smartrecruiters.com/sgs/postings/abc-123') {
-    pass('parseSmartRecruitersResponse rewrites api.smartrecruiters.com → jobs.smartrecruiters.com');
+  // The public site is /<slug>/<id>-<title-slug> — NOT /<slug>/postings/<id>.
+  // Carrying the API's /postings/ segment over produces a 404 that the liveness
+  // checker misreports as an expired posting (#1612).
+  if (jobs[0]?.url === 'https://jobs.smartrecruiters.com/sgs/abc-123-senior-pm') {
+    pass('parseSmartRecruitersResponse rewrites api ref → public /<slug>/<id>-<title> URL');
   } else {
     fail(`row 0 url = ${JSON.stringify(jobs[0]?.url)}`);
+  }
+
+  if (!jobs.some(j => j.url.includes('/postings/'))) {
+    pass('parseSmartRecruitersResponse never emits a /postings/ segment (404 on the public site)');
+  } else {
+    fail(`a /postings/ URL leaked: ${JSON.stringify(jobs.map(j => j.url))}`);
+  }
+
+  // Malformed ref (no /postings/<id> tail) must fall through to the id fallback,
+  // not emit a truncated URL.
+  const malformedRef = parseSmartRecruitersResponse(
+    { content: [{ id: 'zz-9', name: 'Odd Role', ref: 'https://api.smartrecruiters.com/v1/companies/sgs' }] },
+    'SGS',
+  );
+  if (malformedRef[0]?.url === 'https://jobs.smartrecruiters.com/sgs/zz-9-odd-role') {
+    pass('parseSmartRecruitersResponse falls back when ref lacks a /postings/<id> tail');
+  } else {
+    fail(`malformed ref url = ${JSON.stringify(malformedRef[0]?.url)}`);
   }
 
   if (jobs[2]?.url && jobs[2].url.startsWith('https://jobs.smartrecruiters.com/sgs/ghi-789')) {

--- a/tests/providers/smartrecruiters.test.mjs
+++ b/tests/providers/smartrecruiters.test.mjs
@@ -174,6 +174,22 @@ try {
     fail(`fallback URL not properly slugified: ${JSON.stringify(slugifiedCompany[0]?.url)}`);
   }
 
+  // A posting with no usable name must not leave a dangling hyphen on either
+  // URL-building path (the id alone resolves fine).
+  const noName = parseSmartRecruitersResponse(
+    { content: [
+      { id: 'N1', ref: 'https://api.smartrecruiters.com/v1/companies/sgs/postings/N1' },
+      { id: 'N2' },
+    ] },
+    'SGS',
+  );
+  if (noName[0]?.url === 'https://jobs.smartrecruiters.com/sgs/N1'
+      && noName[1]?.url === 'https://jobs.smartrecruiters.com/sgs/N2') {
+    pass('parseSmartRecruitersResponse omits the trailing hyphen when the title slug is empty');
+  } else {
+    fail(`empty-title urls = ${JSON.stringify(noName.map(j => j.url))}`);
+  }
+
   // Pagination: fetch() loops until an empty page (or short page) is returned
   let pageRequests = 0;
   const pagedJobs = await sr.fetch(


### PR DESCRIPTION
Ref #2046 (closed as redundant — CONTRIBUTING notes bug fixes can go straight to a PR; the full reproduction is below).

## Problem

`parseSmartRecruitersResponse` rewrote the API `ref` by swapping only the hostname, carrying the API-only `/postings/` segment into the public URL:

```js
const restOfPath = parsedRef.pathname.slice('/v1/companies/'.length);
url = `https://jobs.smartrecruiters.com/${restOfPath}`;   // .../<slug>/postings/<id>
```

`jobs.smartrecruiters.com` has no `/postings/` segment, so every URL 404s. Because `check-liveness.mjs` treats a 404 as an expired posting, the scan finds the jobs and then silently discards them as dead.

## Fix

Split `<slug>` and `<id>` out of the ref and rebuild the public shape `/<slug>/<id>-<title-slug>`. SmartRecruiters resolves by id alone, so the title slug is cosmetic — it is included for readability only.

The new structural check (`postings === 'postings'`) means a ref in an unexpected shape now falls through to the existing id-based fallback below, instead of emitting a truncated URL. The old code did no validation and concatenated whatever the path happened to be.

The doc comment, which documented the broken URL as correct, is updated.

## Verification

Same parser, same live API response, before and after:

```
API ref: https://api.smartrecruiters.com/v1/companies/ScalableGmbH/postings/744000138372259

v1.21.0:  404  https://jobs.smartrecruiters.com/ScalableGmbH/postings/744000138372259
          404  https://jobs.smartrecruiters.com/ScalableGmbH/postings/744000138369100
          404  https://jobs.smartrecruiters.com/ScalableGmbH/postings/744000138332736

patched:  200  https://jobs.smartrecruiters.com/ScalableGmbH/744000138372259-quality-assurance-manager-m-w-d
          200  https://jobs.smartrecruiters.com/ScalableGmbH/744000138369100-quality-assurance-manager-m-w-d
          200  https://jobs.smartrecruiters.com/ScalableGmbH/744000138332736-working-student-executive-office-m-f-x-from-january-2027
```

## Tests

One existing case asserted the broken URL, so it was pinning the bug in place — replaced. Added:

- a blanket assertion that no emitted URL ever contains `/postings/`
- a malformed-ref case covering the fallback path

`node test-all.mjs`: 1552 passed, 0 failed.

## Note for maintainers

Existing users have dead URLs recorded in `data/scan-history.tsv` and `data/pipeline.md` from previous scans. Those are user-layer data files, so this PR does not touch them, but a one-line migration note in the changelog may be worth it — rewriting `smartrecruiters.com/<slug>/postings/<id>` to `smartrecruiters.com/<slug>/<id>` restores them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SmartRecruiters job links to use the public, canonical URL format (removing the `/postings/` segment).
  * Updated link rewriting to extract the correct company slug and posting id, and to append the title-based slug only when available.
  * Improved handling for malformed or missing references to generate valid, non-truncated job URLs.
  * Added coverage to ensure URLs omit the trailing hyphen when the title slug is empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
