### PR TITLE
fix(tracker): recognize the Hired canonical status in merge-tracker and stats

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -98,7 +98,7 @@ try {
 }
 
 // Canonical states and aliases
-const CANONICAL_STATES = ['Evaluated', 'Applied', 'Responded', 'Interview', 'Offer', 'Rejected', 'Discarded', 'SKIP'];
+const CANONICAL_STATES = ['Evaluated', 'Applied', 'Responded', 'Interview', 'Offer', 'Hired', 'Rejected', 'Discarded', 'SKIP'];
 
 /**
  * Convert raw addition status text into one canonical tracker state.
@@ -128,6 +128,7 @@ function validateStatus(status) {
     'entrevista': 'Interview',
     'oferta': 'Offer',
     'rechazado': 'Rejected', 'rechazada': 'Rejected',
+    'contratado': 'Hired', 'contratada': 'Hired', 'accepted': 'Hired', 'accept': 'Hired',
     'descartado': 'Discarded', 'descartada': 'Discarded', 'cerrada': 'Discarded', 'cancelada': 'Discarded',
     'no aplicar': 'SKIP', 'no_aplicar': 'SKIP', 'skip': 'SKIP', 'monitor': 'SKIP',
     'geo blocker': 'SKIP',

--- a/stats.mjs
+++ b/stats.mjs
@@ -32,16 +32,18 @@ const FOLLOWUPS_FILE = join(ROOT, 'data', 'follow-ups.md');
 const SCAN_RUNS_FILE = join(ROOT, 'data', 'scan-runs.tsv');
 const PORTALS_FILE = join(ROOT, 'portals.yml');
 
-const CANONICAL_STATUSES = ['Evaluated', 'Applied', 'Responded', 'Interview', 'Offer', 'Rejected', 'Discarded', 'SKIP'];
+const CANONICAL_STATUSES = ['Evaluated', 'Applied', 'Responded', 'Interview', 'Offer', 'Hired', 'Rejected', 'Discarded', 'SKIP'];
 
 // In-flight applications. Deliberately NARROWER than the dashboard's
 // ActiveApps (which also counts Evaluated): an evaluated-but-never-sent row is
-// a candidate, not an application in flight.
+// a candidate, not an application in flight. Hired is a terminal success, not
+// in flight, so it is intentionally excluded here (but see PURSUED/funnel).
 const ACTIVE_STATUSES = new Set(['Applied', 'Responded', 'Interview', 'Offer']);
 
 // Rows that count toward avgScoreApplied — jobs the user actually pursued.
-// Plain avgScore mixes in SKIP/Discarded and understates real fit.
-const PURSUED_STATUSES = new Set(['Applied', 'Responded', 'Interview', 'Offer', 'Rejected']);
+// Plain avgScore mixes in SKIP/Discarded and understates real fit. Hired is
+// the fullest pursuit of all, so it belongs here.
+const PURSUED_STATUSES = new Set(['Applied', 'Responded', 'Interview', 'Offer', 'Hired', 'Rejected']);
 
 const round1 = (n) => Math.round(n * 10) / 10;
 const pct = (part, total) => (total > 0 ? round1((part / total) * 100) : 0);
@@ -115,8 +117,10 @@ export function trackerStatusByNum(content) {
 /**
  * Cumulative funnel: everX = "reached stage X or beyond, ever". The math
  * mirrors the dashboard's ComputeProgressMetrics (career.go): Rejected counts
- * into everApplied (a rejection proves a submission), and each later stage
- * sums itself plus everything beyond it. Rates are relative to everApplied.
+ * into everApplied (a rejection proves a submission), Hired counts into every
+ * stage through everOffer (a landed job proves the offer and everything before
+ * it), and each later stage sums itself plus everything beyond it. Rates are
+ * relative to everApplied.
  *
  * Keys are deliberately NOT bare status names — `tracker.byStatus.Applied` is
  * "currently in Applied" while `everApplied` is "ever applied"; the same word
@@ -132,10 +136,10 @@ export function trackerStatusByNum(content) {
  */
 export function computeFunnel(byStatus) {
   const n = (k) => byStatus[k] || 0;
-  const everApplied = n('Applied') + n('Responded') + n('Interview') + n('Offer') + n('Rejected');
-  const everResponded = n('Responded') + n('Interview') + n('Offer');
-  const everInterview = n('Interview') + n('Offer');
-  const everOffer = n('Offer');
+  const everApplied = n('Applied') + n('Responded') + n('Interview') + n('Offer') + n('Hired') + n('Rejected');
+  const everResponded = n('Responded') + n('Interview') + n('Offer') + n('Hired');
+  const everInterview = n('Interview') + n('Offer') + n('Hired');
+  const everOffer = n('Offer') + n('Hired');
   return {
     everApplied,
     everResponded,

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -1,0 +1,71 @@
+// tests/merge-tracker.test.mjs — regression coverage for status validation.
+//
+// `validateStatus` is not exported and importing merge-tracker.mjs runs the CLI
+// (top-level lock + merge), so this exercises the real merge path as a CLI
+// integration test via the CAREER_OPS_TRACKER / CAREER_OPS_ADDITIONS env
+// overrides the script already supports for test isolation.
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+
+console.log('\nmerge-tracker.mjs — status validation');
+
+const TRACKER_HEADER = [
+  '# Applications Tracker',
+  '',
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|------|---------|------|-------|--------|-----|--------|-------|',
+  '',
+].join('\n');
+
+// One merge run in an isolated workspace. Returns the merged tracker text.
+function runMerge(additions) {
+  const work = mkdtempSync(join(tmpdir(), 'cops-merge-'));
+  try {
+    const tracker = join(work, 'applications.md');
+    const addsDir = join(work, 'adds');
+    mkdirSync(addsDir, { recursive: true });
+    writeFileSync(tracker, TRACKER_HEADER);
+    for (const [name, line] of Object.entries(additions)) {
+      writeFileSync(join(addsDir, name), line);
+    }
+    execFileSync(NODE, [join(ROOT, 'merge-tracker.mjs')], {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: addsDir },
+    });
+    return readFileSync(tracker, 'utf-8');
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+try {
+  // TSV column order is status-BEFORE-score (per the batch TSV contract).
+  // "Hired" is canonical (states.yml) — the merge must keep it, not downgrade
+  // it to "Evaluated" the way an unrecognized status would be.
+  const hired = runMerge({
+    '1-acme.tsv': '1\t2026-01-01\tAcme\tML Eng\tHired\t4.5/5\t✅\t[1](reports/1-acme-2026-01-01.md)\tlanded the job\n',
+  });
+  const hiredRow = hired.split('\n').find(l => /\bAcme\b/.test(l)) || '';
+  if (/\|\s*Hired\s*\|/.test(hiredRow) && !/\|\s*Evaluated\s*\|/.test(hiredRow)) {
+    pass('merge-tracker preserves the canonical Hired status (no silent downgrade)');
+  } else {
+    fail(`merge-tracker mishandled Hired: ${hiredRow.trim()}`);
+  }
+
+  // "accepted" is a states.yml alias of Hired — it must resolve to Hired.
+  const accepted = runMerge({
+    '2-globex.tsv': '2\t2026-01-02\tGlobex\tData Eng\taccepted\t4.0/5\t✅\t[2](reports/2-globex-2026-01-02.md)\toffer accepted\n',
+  });
+  const acceptedRow = accepted.split('\n').find(l => /\bGlobex\b/.test(l)) || '';
+  if (/\|\s*Hired\s*\|/.test(acceptedRow)) {
+    pass('merge-tracker resolves the "accepted" alias to Hired');
+  } else {
+    fail(`merge-tracker did not resolve accepted -> Hired: ${acceptedRow.trim()}`);
+  }
+} catch (e) {
+  fail(`merge-tracker.mjs tests crashed: ${e.message}`);
+}

--- a/tests/stats.test.mjs
+++ b/tests/stats.test.mjs
@@ -26,6 +26,22 @@ try {
     fail(`computeTrackerStats wrong output: ${JSON.stringify(t)}`);
   }
 
+  // Hired rows must classify as Hired (a canonical status per states.yml), not
+  // collapse into an "Unknown" bucket, and must feed avgScoreApplied — a landed
+  // job is the fullest pursuit, so its fit score belongs in that average.
+  const hiredMd = [
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|-------|--------|-----|--------|-------|',
+    '| 1 | 2026-06-01 | Acme | Eng | 4.5/5 | Hired | ✅ | ❌ | landed |',
+    '| 2 | 2026-06-02 | Beta | Eng | 3.5/5 | Applied | ✅ | ❌ | sent |',
+  ].join('\n');
+  const th = stats.computeTrackerStats(hiredMd);
+  if (th.byStatus.Hired === 1 && th.byStatus.Unknown === undefined && th.avgScoreApplied === 4) {
+    pass('computeTrackerStats recognizes Hired and folds it into avgScoreApplied');
+  } else {
+    fail(`computeTrackerStats mishandles Hired: ${JSON.stringify(th.byStatus)} avgScoreApplied=${th.avgScoreApplied}`);
+  }
+
   // Funnel — Rejected counts into everApplied (mirrors dashboard ComputeProgressMetrics).
   const f = stats.computeFunnel({ Applied: 4, Responded: 2, Interview: 1, Offer: 1, Rejected: 2, Evaluated: 9 });
   if (f.everApplied === 10 && f.everResponded === 4 && f.everInterview === 2 && f.everOffer === 1
@@ -33,6 +49,15 @@ try {
     pass('computeFunnel cumulative ever* stages match the dashboard math');
   } else {
     fail(`computeFunnel wrong output: ${JSON.stringify(f)}`);
+  }
+
+  // Hired is a canonical status (states.yml) and the fullest success — it must
+  // count through everOffer, not fall out of the funnel as "Unknown".
+  const fh = stats.computeFunnel({ Applied: 2, Interview: 1, Hired: 1 });
+  if (fh.everApplied === 4 && fh.everResponded === 2 && fh.everInterview === 2 && fh.everOffer === 1) {
+    pass('computeFunnel counts Hired into every stage through everOffer');
+  } else {
+    fail(`computeFunnel mishandles Hired: ${JSON.stringify(fh)}`);
   }
   if (stats.computeFunnel({ Applied: 3 }).smallSample === true) {
     pass('computeFunnel flags small samples (everApplied < 10)');


### PR DESCRIPTION
## What does this PR do?

Teaches two readers about the `Hired` canonical status. `Hired` was added to
`templates/states.yml` (and to the dashboard, `normalize-statuses.mjs`,
`verify-pipeline.mjs`, and `set-status.mjs`), but `merge-tracker.mjs` and
`stats.mjs` still hardcoded the pre-`Hired` 8-state list — so a landed-job row
was silently mishandled by both. This aligns them with the source of truth.

Concretely, before this fix:
- `merge-tracker.mjs` `validateStatus("Hired")` matched nothing and fell
  through to the default, **silently rewriting the row to `Evaluated`** (data
  loss on the best possible outcome).
- `stats.mjs` classified `Hired` as `Unknown`, **dropping it from the
  cumulative funnel** (`everApplied/Responded/Interview/Offer`) and from
  `avgScoreApplied`.

Changes:
- **`merge-tracker.mjs`**: add `Hired` to `CANONICAL_STATES` plus the
  `states.yml` aliases (`contratado`/`contratada`/`accepted`/`accept`).
- **`stats.mjs`**: add `Hired` to `CANONICAL_STATUSES` and `PURSUED_STATUSES`,
  and count it through `everApplied/Responded/Interview/Offer` in
  `computeFunnel` (a landed job proves the offer and every stage before it).
  `Hired` stays out of `ACTIVE_STATUSES` — it's a terminal success, not an
  in-flight application.
- **Tests**: extend `tests/stats.test.mjs` and add `tests/merge-tracker.test.mjs`
  (a CLI integration test using the existing `CAREER_OPS_TRACKER` /
  `CAREER_OPS_ADDITIONS` env overrides) so this can't silently regress.

## Related issue

None — this is a bug fix, which `CONTRIBUTING.md` exempts from issue-first.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Recognized **Hired** as a standard application status.
  * Added support for additional status labels, including “accepted,” “accept,” and Spanish equivalents.
  * Updated application statistics and funnel metrics to include hired applications in success-stage totals and average score calculations.
* **Tests**
  * Added coverage confirming hired statuses are preserved, normalized correctly, and included in funnel reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->