### PR TITLE
docs(i18n): translate FAQ into Simplified Chinese

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -295,6 +295,26 @@ career-ops/
 
 - **[cv-santiago](https://github.com/santifer/cv-santiago)**：作者的作品集网站（santifer.io），包含 AI 聊天机器人、LLMOps Dashboard 和案例研究。如果你也需要一个能在求职时展示的作品集，可以 fork 它然后改成自己的版本。
 
+## 常见问题（FAQ）
+
+**career-ops 是什么？**
+career-ops 是一个开源且不受特定 CLI 限制的求职命令中心。它能把任意 AI 编程 CLI 变成一套求职流程：根据你的 CV 评估职位，生成适配 ATS 的 PDF，查找合适的联系人，并在一个地方记录所有进展，最终决定仍由你作出。它是 CareerOps Manifesto 的首个参考实现，详情见 [career-ops.org](https://career-ops.org)。
+
+**我可以免费运行 career-ops，或使用更便宜的本地模型吗？**
+可以。career-ops 不受特定 CLI 限制，可通过 OpenRouter 免费模型、Ollama 或任何兼容 OpenAI 的端点使用免费或本地模型，因此无需依赖付费订阅。完整设置方法见 [docs/RUNNING_ON_A_BUDGET.md](docs/RUNNING_ON_A_BUDGET.md)。
+
+**career-ops 支持哪些 AI CLI？**
+career-ops 支持主流 AI 编程 CLI，包括 Claude Code、Codex、Gemini / Antigravity、OpenCode、Grok、Qwen 等。它通过开放的 Agent Skill Standard 运行，不受单一厂商限制，你可以继续使用现有 CLI。
+
+**如何在 Windows 上安装 career-ops？**
+career-ops 可以在 Windows 上运行。如果安装时因符号链接（symlink）错误导致 skills 无法加载，请按 [docs/FAQ.md](docs/FAQ.md) 中的方法处理；完整安装步骤见 [docs/SETUP.md](docs/SETUP.md)。
+
+**career-ops 会替我自动申请职位吗？**
+不会。career-ops 用来筛选职位，而不是盲目批量申请；AI 负责评估、排序和起草，你负责审阅与决定。它不会自行提交、发送或点击任何内容，最终决定始终在你手中。这正是保留人工审核的意义。
+
+**career-ops 是免费开源软件吗？**
+是。career-ops 是免费开源软件，而且对求职者会一直免费；它是 [CareerOps Manifesto](https://career-ops.org/manifesto) 的首个参考实现。欢迎阅读这份宣言，如果认同其内容，也可以签名支持。
+
 ## 关于作者
 
 我是 [Santiago Fernández de Valderrama Aparicio](https://santifer.io/about)（santifer），现任 Head of Applied AI，也曾是一名创业者（创建并出售过一家公司，那家公司至今仍以我的名字运营）。我构建 career-ops 是为了管理我自己的求职流程，而它确实奏效了：我用它拿到了现在这份工作。


### PR DESCRIPTION
## What does this PR do?

Adds the Simplified Chinese translation of the six FAQ entries to `README.cn.md`. The translation mirrors the English source while preserving brand names and documentation links.

## Related issue

Part of #2051

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Chinese FAQ section answering common questions about career-ops, supported AI tools, free and budget-friendly usage, Windows installation troubleshooting, automatic applications, and open-source availability.
  * Included links to setup guidance and the CareerOps Manifesto for additional context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->