### PR TITLE
fix(pdf): drop empty Education section instead of rendering a bare header

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -250,12 +250,22 @@ function renderHtml(template, payload) {
   let html = template.replace(CONTACT_ROW_RE, () => buildContactRow(candidate));
   html = html.replace(/\{\{PHOTO\}\}/g, () => buildPhoto(candidate, candidate.name));
 
-  // Projects is the one CV section that's genuinely optional (education,
-  // experience, and skills are effectively always present) — drop the whole
-  // <!-- PROJECTS --> block when there are no entries, instead of leaving a
-  // bare "Projects" header with nothing under it.
+  // Projects and education are the genuinely optional CV sections: a
+  // candidate's projects are often already covered under Work Experience, and
+  // not every candidate has a degree. Drop the whole block when there are no
+  // entries, instead of leaving a bare header with nothing under it.
+  //
+  // Both lookaheads match the *next* section marker generically rather than a
+  // named one. Education is followed by Certifications in cv-template.html but
+  // by Skills in resume-template.html, so no single name works there — and a
+  // named `<!-- EDUCATION -->` lookahead on the projects pattern would stop
+  // matching entirely once an empty education block had already been stripped,
+  // leaving the bare "Projects" header this is meant to remove.
   if (!Array.isArray(payload.projects) || payload.projects.length === 0) {
-    html = html.replace(/<!-- PROJECTS -->[\s\S]*?(?=<!-- EDUCATION -->)/, '');
+    html = html.replace(/<!-- PROJECTS -->[\s\S]*?(?=<!-- [A-Z])/, '');
+  }
+  if (!Array.isArray(payload.education) || payload.education.length === 0) {
+    html = html.replace(/<!-- EDUCATION -->[\s\S]*?(?=<!-- [A-Z])/, '');
   }
 
   for (const [key, value] of Object.entries(substitutions)) {

--- a/build-cv-latex.mjs
+++ b/build-cv-latex.mjs
@@ -116,12 +116,17 @@ async function main() {
 
   let template = await readFile(TEMPLATE_PATH_RESOLVED, 'utf-8');
 
-  // Projects is the one CV section that's genuinely optional (education,
-  // experience, and skills are effectively always present) — drop the whole
-  // Personal Projects \section when there are no entries, instead of leaving
-  // a bare section header with nothing under it.
+  // Projects and education are the genuinely optional CV sections: a
+  // candidate's projects are often already covered under Work Experience, and
+  // not every candidate has a degree. Drop the whole \section when there are
+  // no entries, instead of leaving a bare section header with nothing under
+  // it. Each pattern runs to the next banner comment, so the two are
+  // independent even when both sections are empty.
   if (!Array.isArray(payload.projects) || payload.projects.length === 0) {
-    template = template.replace(/%%%%%%%%%%%%%%%%%%%%%%%%%%%%  PROJECTS  %%%%%%%%%%%%%%%%%%%%%%%%%%%%[\s\S]*?(?=%%%%%%%%%%%%%%%%%%%%%%%%%%%%  Technical Skills)/, '');
+    template = template.replace(/%{4,}\s+PROJECTS\s+%{4,}[\s\S]*?(?=%{4,}\s)/, '');
+  }
+  if (!Array.isArray(payload.education) || payload.education.length === 0) {
+    template = template.replace(/%{4,}\s+Education\s+%{4,}[\s\S]*?(?=%{4,}\s)/, '');
   }
 
   const emailUrl = sanitizeUrl(payload.email?.url || '');


### PR DESCRIPTION
## What does this PR do?

`build-cv-html.mjs` and `build-cv-latex.mjs` always render the "Education" section title from the template, even when `payload.education` is empty or absent. Not every candidate has a degree, so any CV generated without an `education` array ships a blank "Education" heading with nothing underneath it in the rendered PDF/HTML/LaTeX output.

This is the direct analogue of #1879 (empty Projects section), applied to the other genuinely optional section.

## Related issue

No issue — bug fix, exempt per the checklist.

## Duplicate-check trail

- `gh search issues "empty Education section" --repo santifer/career-ops --include-prs` → no results
- `gh search issues "buildEducation" --repo santifer/career-ops --include-prs` → only #905 (the original `build-cv-latex.mjs` PR), not this bug
- #1879 fixed the same class of bug for Projects and explicitly scoped itself to Projects only, on the assumption that "education, experience, and skills are effectively always present". That assumption holds for experience and skills, but not for education.

## Root cause

Identical to #1879. `templates/cv-template.html` and `templates/resume-template.html` unconditionally wrap the Education placeholders:

```html
<!-- EDUCATION -->
<div class="section">
  <div class="section-title">{{SECTION_EDUCATION}}</div>
  {{EDUCATION}}
</div>
```

`buildEducation()` correctly returns `''` for an empty array, but nothing strips the surrounding `.section` wrapper, so the header renders with an empty body. Same pattern in `templates/cv-template.tex`'s `\section{Education}`.

## Steps to reproduce

```json
// payload.json — omit "education" entirely (or pass education: [])
{ "candidate": {"name": "Test"}, "summary": "...", "experience": [{"company":"Acme","role":"Eng","dates":"2024","bullets":["Did a thing"]}], "projects": [{"name":"Proj","bullets":["Built it"]}] }
```

```bash
node build-cv-html.mjs payload.json out.html
grep -A2 'section-title">Education' out.html
# <div class="section-title">Education</div>
# (nothing)
```

## The fix

Same shape as #1879 — strip the whole block before the placeholder-substitution loop when the array is empty.

**One deviation worth reviewing.** #1879 could use a literal lookahead (`(?=<!-- EDUCATION -->)`) because Projects is followed by Education in both HTML templates. Education has no such single successor: it is followed by Certifications in `cv-template.html` but by Skills in `resume-template.html`. So both patterns now match the *next* section marker generically (`(?=<!-- [A-Z])`).

This also makes the two strips order-independent. To be explicit: **the Projects lookahead is not broken on `main`** — I verified that a both-sections-empty payload renders correctly there, because `main` never strips Education, so the `<!-- EDUCATION -->` anchor is always present. But once Education stripping exists, a literal anchor makes Projects' correctness depend on strip order. Generalizing removes that coupling rather than fixing an existing bug.

I confirmed every HTML comment in both templates is an uppercase section marker, and that Education is never the last section, so a following marker always exists. On the LaTeX side all seven `%%%%` banners are section boundaries, so the same generalization applies.

## Test plan

Verified all four empty/present combinations against all three templates (`cv-template.html`, `resume-template.html`, `cv-template.tex`) — 12 cases, section headers counted in the rendered output:

| payload | Projects | Education | next section |
|---|---|---|---|
| both present | rendered | rendered | intact |
| projects empty | dropped | rendered | intact |
| education empty | rendered | dropped | intact |
| both empty | dropped | dropped | intact |

- [x] `node build-cv-html.mjs --test` passes
- [x] `node build-cv-latex.mjs --test` passes
- [x] `node test-all.mjs`: **1817 passed, 0 failed**
- [x] `resume-template.html` verified end-to-end with a real payload (noted as untested in #1879)

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Bug fix — no issue required
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (only touches system-layer `build-cv-html.mjs` / `build-cv-latex.mjs`)
- [x] My changes align with the project roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty Projects sections are now automatically removed from generated CVs.
  * Empty Education sections are now automatically removed from generated CVs.
  * Improved handling when both sections are missing, preventing leftover headings or template content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->