### PR TITLE
fix(pipeline): recognize the #1799 score sentinels in verify-pipeline.mjs

### DIFF
--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -22,6 +22,7 @@
 import { readFileSync, readdirSync, existsSync, mkdirSync, unlinkSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { looksLikeScoreCell } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original).
@@ -188,8 +189,7 @@ if (brokenReports === 0) ok('All report links valid');
 // --- Check 4: Score format ---
 let badScores = 0;
 for (const e of entries) {
-  const s = e.score.replace(/\*\*/g, '').trim();
-  if (!/^\d+\.?\d*\/5$/.test(s) && s !== 'N/A' && s !== 'DUP') {
+  if (!looksLikeScoreCell(e.score)) {
     error(`#${e.num}: Invalid score format: "${e.score}"`);
     badScores++;
   }


### PR DESCRIPTION
Ran a pipeline batch that produced a few hard-blocker rows scored `—` (no eval, per #1799). They merged in fine. Then `verify-pipeline.mjs` flagged them as errors on the very next health check.

Turns out `verify-pipeline.mjs` never got the #1799 fix. It has its own hardcoded regex for the score column instead of using `tracker-parse.mjs`'s `looksLikeScoreCell()` — so `—`/`-` merge in fine but fail validation right after. Two copies of the same rule, one of them stale.

Fix is small: import `looksLikeScoreCell()` instead of duplicating the pattern. One source of truth now.

Closes #2068
