### PR TITLE
refactor(pdf): harden optional-section boundaries, extract cv-sections-core.mjs

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -20,6 +20,7 @@ import { existsSync } from 'fs';
 import { resolve, dirname, basename, join } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
+import { stripEmptySections } from './cv-sections-core.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_PATH = resolve(__dirname, 'templates', 'cv-template.html');
@@ -250,23 +251,9 @@ function renderHtml(template, payload) {
   let html = template.replace(CONTACT_ROW_RE, () => buildContactRow(candidate));
   html = html.replace(/\{\{PHOTO\}\}/g, () => buildPhoto(candidate, candidate.name));
 
-  // Projects and education are the genuinely optional CV sections: a
-  // candidate's projects are often already covered under Work Experience, and
-  // not every candidate has a degree. Drop the whole block when there are no
-  // entries, instead of leaving a bare header with nothing under it.
-  //
-  // Both lookaheads match the *next* section marker generically rather than a
-  // named one. Education is followed by Certifications in cv-template.html but
-  // by Skills in resume-template.html, so no single name works there — and a
-  // named `<!-- EDUCATION -->` lookahead on the projects pattern would stop
-  // matching entirely once an empty education block had already been stripped,
-  // leaving the bare "Projects" header this is meant to remove.
-  if (!Array.isArray(payload.projects) || payload.projects.length === 0) {
-    html = html.replace(/<!-- PROJECTS -->[\s\S]*?(?=<!-- [A-Z])/, '');
-  }
-  if (!Array.isArray(payload.education) || payload.education.length === 0) {
-    html = html.replace(/<!-- EDUCATION -->[\s\S]*?(?=<!-- [A-Z])/, '');
-  }
+  // Drop the optional sections (projects, education) that have no entries, so
+  // an absent one leaves no bare header behind. See cv-sections-core.mjs.
+  html = stripEmptySections(html, payload, 'html');
 
   for (const [key, value] of Object.entries(substitutions)) {
     html = html.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), () => value);

--- a/build-cv-latex.mjs
+++ b/build-cv-latex.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
 import { escapeLatex, sanitizeUrl } from './lib/latex-escape.mjs';
 import { resolveTemplate } from './cv-templates.mjs';
+import { stripEmptySections } from './cv-sections-core.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_PATH = resolve(__dirname, 'templates', 'cv-template.tex');
@@ -116,18 +117,9 @@ async function main() {
 
   let template = await readFile(TEMPLATE_PATH_RESOLVED, 'utf-8');
 
-  // Projects and education are the genuinely optional CV sections: a
-  // candidate's projects are often already covered under Work Experience, and
-  // not every candidate has a degree. Drop the whole \section when there are
-  // no entries, instead of leaving a bare section header with nothing under
-  // it. Each pattern runs to the next banner comment, so the two are
-  // independent even when both sections are empty.
-  if (!Array.isArray(payload.projects) || payload.projects.length === 0) {
-    template = template.replace(/%{4,}\s+PROJECTS\s+%{4,}[\s\S]*?(?=%{4,}\s)/, '');
-  }
-  if (!Array.isArray(payload.education) || payload.education.length === 0) {
-    template = template.replace(/%{4,}\s+Education\s+%{4,}[\s\S]*?(?=%{4,}\s)/, '');
-  }
+  // Drop the optional sections (projects, education) that have no entries, so
+  // an absent one leaves no bare header behind. See cv-sections-core.mjs.
+  template = stripEmptySections(template, payload, 'tex');
 
   const emailUrl = sanitizeUrl(payload.email?.url || '');
   const emailDisplay = payload.email?.display || emailUrl;

--- a/cv-sections-core.mjs
+++ b/cv-sections-core.mjs
@@ -1,0 +1,63 @@
+// Shared optional-section stripping for the CV builders (build-cv-html.mjs,
+// build-cv-latex.mjs).
+//
+// Projects and education are the genuinely optional CV sections: a candidate's
+// projects are often already covered under Work Experience, and not every
+// candidate has a degree. The templates wrap both unconditionally, so a payload
+// with no entries renders a bare section header with nothing under it. The
+// builders' buildProjects()/buildEducation() correctly return '' — nothing
+// removes the surrounding wrapper, which is what this module does.
+//
+// The section body is delimited by markers rather than parsed, so the boundary
+// pattern carries the whole correctness burden and is easy to get subtly wrong:
+//
+//   - Stopping at any capitalized comment would also stop at an ordinary
+//     comment inside a section body, truncating the strip and leaving markup
+//     behind. Markers are therefore matched as all-caps only.
+//   - Omitting the end-of-input branch would silently keep a section that
+//     happens to be last in the template.
+//   - Naming the expected successor ("projects is followed by education")
+//     couples the two strips to each other and to template ordering: once an
+//     empty education block is removed, a named lookahead for it stops matching
+//     and the projects header survives.
+//
+// Each of those failure modes reintroduces the bare header this module exists
+// to remove, and does it silently, so they are covered in
+// tests/cv-optional-sections.test.mjs.
+
+// HTML: `<!-- SECTION NAME -->`, all-caps. LaTeX: `%%%%  Name  %%%%` banners.
+const HTML_BOUNDARY = String.raw`(?=<!--\s+[A-Z][A-Z ]*-->|$)`;
+const TEX_BOUNDARY = String.raw`(?=%{4,}\s|$)`;
+
+const PATTERNS = {
+  html: {
+    projects: new RegExp(String.raw`<!--\s+PROJECTS\s+-->[\s\S]*?` + HTML_BOUNDARY),
+    education: new RegExp(String.raw`<!--\s+EDUCATION\s+-->[\s\S]*?` + HTML_BOUNDARY),
+  },
+  tex: {
+    projects: new RegExp(String.raw`%{4,}\s+PROJECTS\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
+    education: new RegExp(String.raw`%{4,}\s+Education\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
+  },
+};
+
+export const OPTIONAL_SECTIONS = ['projects', 'education'];
+
+export function isEmptySection(payload, section) {
+  const entries = payload?.[section];
+  return !Array.isArray(entries) || entries.length === 0;
+}
+
+// Remove every optional section that has no entries in `payload`. Returns the
+// template unchanged when both are populated.
+export function stripEmptySections(template, payload, format) {
+  const patterns = PATTERNS[format];
+  if (!patterns) throw new Error(`Unknown template format: ${format}`);
+
+  let out = template;
+  for (const section of OPTIONAL_SECTIONS) {
+    if (isEmptySection(payload, section)) {
+      out = out.replace(patterns[section], '');
+    }
+  }
+  return out;
+}

--- a/tests/cv-optional-sections.test.mjs
+++ b/tests/cv-optional-sections.test.mjs
@@ -1,0 +1,110 @@
+// tests/cv-optional-sections.test.mjs — the optional CV sections (projects,
+// education) must vanish entirely when they have no entries, rather than
+// rendering a bare section header with nothing under it.
+//
+// #1879 fixed this for projects; the education half is the same bug (not every
+// candidate has a degree). Both are delimited by marker matching rather than
+// parsed, so the boundary pattern is the whole correctness story — see the
+// header comment in cv-sections-core.mjs for the failure modes exercised here.
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { pass, fail, ROOT } from './helpers.mjs';
+import { stripEmptySections } from '../cv-sections-core.mjs';
+
+console.log('\ncv-sections-core.mjs — optional sections leave no bare header');
+
+const EMPTY = { projects: [], education: [] };
+const FULL = { projects: [{ name: 'P' }], education: [{ degree: 'D' }] };
+
+function check(label, actual, expected) {
+  if (actual === expected) pass(label);
+  else fail(`${label} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+// --- Real templates: the sections must actually disappear ------------------
+// Assert against the shipped templates so a template edit that renames or
+// reorders a marker fails here instead of silently reviving the bare header.
+const TEMPLATES = [
+  { file: 'templates/cv-template.html', format: 'html', after: 'CERTIFICATIONS' },
+  { file: 'templates/resume-template.html', format: 'html', after: 'SKILLS' },
+  { file: 'templates/cv-template.tex', format: 'tex', after: 'Technical Skills' },
+];
+
+for (const { file, format, after } of TEMPLATES) {
+  const template = readFileSync(join(ROOT, file), 'utf-8');
+  const name = file.split('/').pop();
+
+  const stripped = stripEmptySections(template, EMPTY, format);
+  const projectsMarker = format === 'html' ? '<!-- PROJECTS -->' : 'PROJECTS  %';
+  const educationMarker = format === 'html' ? '<!-- EDUCATION -->' : 'Education  %';
+
+  check(`${name}: empty payload removes the projects block`, stripped.includes(projectsMarker), false);
+  check(`${name}: empty payload removes the education block`, stripped.includes(educationMarker), false);
+  check(`${name}: the section after education survives`, stripped.includes(after), true);
+  check(`${name}: {{EXPERIENCE}} is untouched`, stripped.includes('{{EXPERIENCE}}'), true);
+
+  // Populated payload must be a no-op — the strip only ever removes.
+  check(`${name}: populated payload leaves the template unchanged`,
+    stripEmptySections(template, FULL, format) === template, true);
+
+  // One empty, one populated: only the empty one goes.
+  const onlyEdu = stripEmptySections(template, { projects: [{ name: 'P' }], education: [] }, format);
+  check(`${name}: empty education alone keeps projects`, onlyEdu.includes(projectsMarker), true);
+  check(`${name}: empty education alone drops education`, onlyEdu.includes(educationMarker), false);
+}
+
+// --- Boundary edge cases ---------------------------------------------------
+// Each of these silently reintroduces the bare header if the boundary pattern
+// is written loosely.
+
+// A non-marker comment inside a section body is not a boundary. A lookahead of
+// `(?=<!-- [A-Z])` stops here and strands the rest of the block.
+const internalComment = [
+  '<!-- PROJECTS -->',
+  '<div class="section">',
+  '  <!-- Main block -->',
+  '  <div class="section-title">Projects</div>',
+  '</div>',
+  '<!-- EDUCATION -->',
+  'keep me',
+].join('\n');
+// Only projects is empty here: with EMPTY, education would also be stripped to
+// end of input and the fixture could not distinguish a correct strip from an
+// over-broad one.
+check('an ordinary comment inside the body is not treated as a boundary',
+  stripEmptySections(internalComment, { projects: [], education: [{ degree: 'D' }] }, 'html'),
+  '<!-- EDUCATION -->\nkeep me');
+
+// A section that is last in the template still gets removed. Without an
+// end-of-input branch there is no boundary to stop at and the strip no-ops.
+check('html: a trailing optional section is removed at end of template',
+  stripEmptySections('<!-- HEADER -->\nkeep\n<!-- PROJECTS -->\n<div>drop</div>\n', EMPTY, 'html').trim(),
+  '<!-- HEADER -->\nkeep');
+
+check('tex: a trailing optional section is removed at end of document',
+  stripEmptySections('%%%%  Heading  %%%%\nkeep\n%%%%  PROJECTS  %%%%\ndrop\n', EMPTY, 'tex').trim(),
+  '%%%%  Heading  %%%%\nkeep');
+
+// Stripping one section must not depend on the other still being present: a
+// lookahead naming `<!-- EDUCATION -->` breaks once education is removed.
+const bothEmpty = [
+  '<!-- PROJECTS -->',
+  '<div>projects body</div>',
+  '<!-- EDUCATION -->',
+  '<div>education body</div>',
+  '<!-- SKILLS -->',
+  'skills',
+].join('\n');
+check('both sections empty: neither body survives',
+  stripEmptySections(bothEmpty, EMPTY, 'html'),
+  '<!-- SKILLS -->\nskills');
+
+// A missing key is as empty as an empty array — payloads routinely omit these.
+check('an absent projects key is treated as empty',
+  stripEmptySections(bothEmpty, {}, 'html'),
+  '<!-- SKILLS -->\nskills');
+
+// An unknown format is a programming error, not a silent pass-through.
+let threw = false;
+try { stripEmptySections('x', EMPTY, 'pdf'); } catch { threw = true; }
+check('an unknown template format throws', threw, true);

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -267,6 +267,7 @@ const SYSTEM_PATHS = [
   'package.json',
   'build-cv-latex.mjs',
   'build-cv-html.mjs',
+  'cv-sections-core.mjs',
   'cv-templates.mjs',
   'test/cv-templates.test.mjs',
   'test/cover-resolver.test.mjs',


### PR DESCRIPTION
## What does this PR do?

Follow-up to #2063, addressing the CodeRabbit review that landed on that PR shortly before it merged. The feedback was valid but arrived too late to be folded in, so it is here instead.

Both findings are about the boundary pattern used to delimit an optional section. Neither is reachable in the templates as they stand today, so **this is hardening against a silent failure mode, not a live bug fix** — but both failure modes end in exactly the bare section header #1879 and #2063 exist to remove, and both fail quietly.

## The two findings

**1. A loose marker match treats an ordinary comment as a section boundary.**

`(?=<!-- [A-Z])` matches any comment starting with a capital, including a body comment like `<!-- Main block -->`. The strip stops early and strands the rest of the block. Markers are now matched as all-caps only (`<!--\s+[A-Z][A-Z ]*-->`).

**2. Neither pattern had an end-of-input branch.**

An optional section that is *last* in a template has no following marker to stop at, so the strip silently no-ops and the section stays. Both patterns now accept end of input.

## Why a new module

The boundary pattern carries the entire correctness burden here, and until now it was only reachable through two CLIs — awkward to test, and duplicated across HTML and LaTeX with independently-drifting regexes. The logic moves into `cv-sections-core.mjs`, following the existing `liveness-core.mjs` precedent for shared core logic.

Net effect on the builders is a reduction: both call sites collapse to a single `stripEmptySections(...)` call.

## Test plan

New `tests/cv-optional-sections.test.mjs` (auto-discovered under `tests/`), covering:

- All three shipped templates (`cv-template.html`, `resume-template.html`, `cv-template.tex`) — each optional section disappears when empty, the following section survives, `{{EXPERIENCE}}` is untouched, and a populated payload is a strict no-op
- Each boundary failure mode above, plus: both-sections-empty (the strips must not depend on each other), an absent key treated as empty, and an unknown format throwing rather than silently passing through

The suite was **mutation-checked**: reverting the code to each of the two loose patterns makes it fail, so it is a real regression net rather than decoration.

```
node test-all.mjs → 1845 passed, 0 failed
```

Also registers `cv-sections-core.mjs` in `update-system.mjs` SYSTEM_PATHS — caught by the repo's own `validate-system-paths-coverage.mjs`. Without it the new module would not be delivered by `update-system.mjs apply`, so existing installs would update the builders to import a file they never receive.

## Note on scope

`OPTIONAL_SECTIONS` currently holds `projects` and `education`. Certifications appears to be a third instance of the same bug (`cv-template.html` wraps it unconditionally, and `buildCertifications()` returns empty markup for an empty payload), and is now a one-line addition. Deliberately left out to keep this PR strictly about the review feedback — happy to add it here or send it separately, whichever you prefer.

## Type of change

- [x] Refactor (no behavior change in the templates as they ship today)
- [x] Bug fix (hardening against silent failure on future template edits)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Follow-up to a merged bug-fix PR — no issue required
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (system-layer files only)
- [x] My changes align with the project roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty Projects and Education sections are now fully removed from generated CVs, preventing blank section headers in HTML and LaTeX output.
  * Optional sections are handled consistently when one or both sections have no entries.

* **Tests**
  * Added coverage for empty, populated, missing, and edge-case section data across supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->