### PR TITLE
fix: materialize career-ops SKILL.md symlinks into real files

### DIFF
--- a/.antigravitycli/skills/career-ops/SKILL.md
+++ b/.antigravitycli/skills/career-ops/SKILL.md
@@ -1,1 +1,182 @@
-../../../.agents/skills/career-ops/SKILL.md
+---
+name: career-ops
+description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
+arguments: mode
+user_invocable: true
+user-invocable: true
+argument-hint: "[scan | deep | pdf | latex | latex-tex | cover | email | add | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | offer-prep | titles | upskill | followup | update]"
+license: MIT
+---
+
+# career-ops -- Router
+
+career-ops is a multi-CLI job-search command center. The routing below is shared across supported agent CLIs even when the invocation surface differs.
+
+## Invocation Notes
+
+- CLIs with slash-command registration can expose this router as `/career-ops`.
+- Interactive Codex sessions use `codex` in the repo root. Slash commands are not guaranteed in Codex, so ask Codex to run the same mode by name if `/career-ops` is unavailable.
+- Headless Codex workers use `codex exec "prompt"`.
+- The routing semantics below stay the same regardless of whether the entrypoint is a slash command or a natural-language prompt.
+
+Codex prompt examples that map to the same router semantics:
+
+```text
+Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123
+Run the career-ops scan mode and summarize new matches.
+Run the career-ops pipeline mode for data/pipeline.md.
+Run the career-ops pdf mode for the latest evaluated role.
+Run the career-ops tracker mode and summarize the current statuses.
+```
+
+## Mode Routing
+
+Determine the mode from `$mode`:
+
+| Input | Mode |
+|-------|------|
+| (empty / no args) | `discovery` -- Show command menu |
+| JD text or URL (no sub-command) | **`auto-pipeline`** |
+| `oferta` | `oferta` |
+| `ofertas` | `ofertas` |
+| `contacto` | `contacto` |
+| `deep` | `deep` |
+| `interview-prep` | `interview-prep` |
+| `interview` | `interview` |
+| `eu-swe` | `regional/eu-swe` |
+| `interview/plan` | `interview/plan` |
+| `interview/practice` | `interview/practice` |
+| `interview/debrief` | `interview/debrief` |
+| `pdf` | `pdf` |
+| `latex` | `latex` |
+| `latex-tex` | `latex-tex` |
+| `email` | `email` |
+| `training` | `training` |
+| `project` | `project` |
+| `tracker` | `tracker` |
+| `agent-inbox` | `agent-inbox` |
+| `inbox` | `agent-inbox` |
+| `pipeline` | `pipeline` |
+| `apply` | `apply` |
+| `scan` | `scan` |
+| `batch` | `batch` |
+| `patterns` | `patterns` |
+| `offer-prep` | `offer-prep` |
+| `titles` | `titles` |
+| `upskill` | `upskill` |
+| `followup` | `followup` |
+| `update` | `update` |
+| `cover` | `cover` |
+| `add` | `add` |
+
+**Auto-pipeline detection:** If `$mode` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
+
+If `$mode` is not a sub-command AND doesn't look like a JD, show discovery.
+
+---
+
+## Output Language Directive
+
+Before executing any mode, read `config/profile.yml` if it exists and resolve:
+
+- `language.output` → ISO language code for human-facing output. Default: `en`.
+- `language.modes_dir` → optional market-mode directory. This controls market vocabulary and local evaluation rules only.
+
+Inject this directive after loading the mode instructions and before producing any user-visible content:
+
+> Write all human-facing output in `{language.output}` regardless of the language of these instructions or of the job description. This includes reports, tracker notes, PDFs, cover letters, outreach, interview prep, form answers, and summaries. If `language.modes_dir` supplies market-specific vocabulary, keep the market logic but explain terms in `{language.output}` when needed.
+
+`language.output` is authoritative for prose. `modes_dir` is market context; it must not force the prose language.
+
+---
+
+## Discovery Mode (no arguments)
+
+If your CLI supports `/career-ops`, show this menu. In Codex, surface the same options in plain text and map the requested mode the same way.
+
+Concrete equivalents for Codex prompt-driven sessions:
+
+```text
+/career-ops {JD}           ↔ "Evaluate this JD with career-ops auto-pipeline: {JD or URL}"
+/career-ops scan           ↔ "Run the career-ops scan mode and summarize new matches."
+/career-ops pipeline       ↔ "Run the career-ops pipeline mode for data/pipeline.md."
+/career-ops pdf            ↔ "Run the career-ops pdf mode for the latest evaluated role."
+/career-ops email          ↔ "Run the career-ops email mode for the latest evaluated role."
+/career-ops tracker        ↔ "Run the career-ops tracker mode and summarize the current statuses."
+```
+
+Show this menu:
+
+```
+career-ops -- Command Center
+
+Available commands:
+  /career-ops {JD}      → AUTO-PIPELINE: evaluate + report + PDF + tracker (paste text or URL)
+  /career-ops pipeline  → Process pending URLs from inbox (data/pipeline.md)
+  /career-ops oferta    → Evaluation only A-F (no auto PDF)
+  /career-ops ofertas   → Compare and rank multiple offers
+  /career-ops contacto  → LinkedIn power move: find contacts + draft message
+  /career-ops deep      → Deep research prompt about company
+  /career-ops interview-prep → Generate company-specific interview prep doc
+  /career-ops interview    → Interactive profile/CV onboarding interview
+  /career-ops eu-swe    → Calibrate a European SWE application before CV/apply/interview
+  /career-ops interview/plan → Time-blocked prep plan for an upcoming interview
+  /career-ops interview/practice → Practice interview, one question at a time with feedback
+  /career-ops interview/debrief → Post-interview debrief: close gaps, predict next round
+  /career-ops pdf       → PDF only, ATS-optimized CV
+  /career-ops latex     → Export CV as LaTeX/Overleaf .tex
+  /career-ops latex-tex → Tailor your own resume.tex in place (opt-in; cv.md stays default)
+  /career-ops cover     → Cover letter: standalone JD paste or /career-ops cover {slug}
+  /career-ops email     → Formal application email draft (draft-only; never sends, submits, or clicks)
+  /career-ops add       → Add a project/paper/role to your CV (fetch + preview + confirm)
+  /career-ops training  → Evaluate course/cert against North Star
+  /career-ops project   → Evaluate portfolio project idea
+  /career-ops tracker   → Application status overview
+  /career-ops agent-inbox → Queue/drain requests for the next session (data/agent-inbox.md)
+  /career-ops apply     → Live application assistant (reads form + generates answers)
+  /career-ops scan      → Scan portals and discover new offers
+  /career-ops batch     → Batch processing with parallel workers
+  /career-ops patterns  → Analyze rejection patterns and improve targeting
+  /career-ops offer-prep → Read a received offer/contract with the candidate: clause walk + lawyer questions (not legal advice)
+  /career-ops titles    → Suggest adjacent job titles from your CV to broaden the search
+  /career-ops upskill   → Aggregate skill-gap analysis from your evaluated reports
+  /career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
+  /career-ops update    → Update career-ops system files with diff preview + compat check
+
+Inbox: add URLs to data/pipeline.md → /career-ops pipeline
+Or paste a JD directly to run the full pipeline.
+```
+
+---
+
+## Context Loading by Mode
+
+After determining the mode, load the necessary files before executing:
+
+If `modes/_custom.md` exists, read it after `modes/_profile.md` and before the selected mode file. It contains user house rules and procedural preferences. It may override workflow/style defaults, but it never adds factual claims about the candidate.
+
+### Modes that require `_shared.md` + their mode file
+
+Read `modes/_shared.md` + `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
+
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+
+### Standalone modes with profile and custom context
+
+Read `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
+
+Applies to: `tracker`, `agent-inbox`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `latex-tex`, `training`, `project`, `patterns`, `titles`, `upskill`, `followup`, `cover`, `email`, `add`, `offer-prep`
+
+### Modes delegated to subagent
+
+For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `_profile.md` (if exists) + `_custom.md` (if exists) + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:
+
+```python
+Agent(
+  subagent_type="general-purpose",
+  prompt="[output language directive]\n\n[content of modes/_shared.md]\n\n[content of modes/_profile.md if exists]\n\n[content of modes/_custom.md if exists]\n\n[content of modes/{mode}.md]\n\n[invocation-specific data]",
+  description="career-ops {mode}"
+)
+```
+
+Execute the instructions from the loaded mode file.

--- a/.claude/skills/career-ops/SKILL.md
+++ b/.claude/skills/career-ops/SKILL.md
@@ -1,1 +1,182 @@
-../../../.agents/skills/career-ops/SKILL.md
+---
+name: career-ops
+description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
+arguments: mode
+user_invocable: true
+user-invocable: true
+argument-hint: "[scan | deep | pdf | latex | latex-tex | cover | email | add | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | offer-prep | titles | upskill | followup | update]"
+license: MIT
+---
+
+# career-ops -- Router
+
+career-ops is a multi-CLI job-search command center. The routing below is shared across supported agent CLIs even when the invocation surface differs.
+
+## Invocation Notes
+
+- CLIs with slash-command registration can expose this router as `/career-ops`.
+- Interactive Codex sessions use `codex` in the repo root. Slash commands are not guaranteed in Codex, so ask Codex to run the same mode by name if `/career-ops` is unavailable.
+- Headless Codex workers use `codex exec "prompt"`.
+- The routing semantics below stay the same regardless of whether the entrypoint is a slash command or a natural-language prompt.
+
+Codex prompt examples that map to the same router semantics:
+
+```text
+Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123
+Run the career-ops scan mode and summarize new matches.
+Run the career-ops pipeline mode for data/pipeline.md.
+Run the career-ops pdf mode for the latest evaluated role.
+Run the career-ops tracker mode and summarize the current statuses.
+```
+
+## Mode Routing
+
+Determine the mode from `$mode`:
+
+| Input | Mode |
+|-------|------|
+| (empty / no args) | `discovery` -- Show command menu |
+| JD text or URL (no sub-command) | **`auto-pipeline`** |
+| `oferta` | `oferta` |
+| `ofertas` | `ofertas` |
+| `contacto` | `contacto` |
+| `deep` | `deep` |
+| `interview-prep` | `interview-prep` |
+| `interview` | `interview` |
+| `eu-swe` | `regional/eu-swe` |
+| `interview/plan` | `interview/plan` |
+| `interview/practice` | `interview/practice` |
+| `interview/debrief` | `interview/debrief` |
+| `pdf` | `pdf` |
+| `latex` | `latex` |
+| `latex-tex` | `latex-tex` |
+| `email` | `email` |
+| `training` | `training` |
+| `project` | `project` |
+| `tracker` | `tracker` |
+| `agent-inbox` | `agent-inbox` |
+| `inbox` | `agent-inbox` |
+| `pipeline` | `pipeline` |
+| `apply` | `apply` |
+| `scan` | `scan` |
+| `batch` | `batch` |
+| `patterns` | `patterns` |
+| `offer-prep` | `offer-prep` |
+| `titles` | `titles` |
+| `upskill` | `upskill` |
+| `followup` | `followup` |
+| `update` | `update` |
+| `cover` | `cover` |
+| `add` | `add` |
+
+**Auto-pipeline detection:** If `$mode` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
+
+If `$mode` is not a sub-command AND doesn't look like a JD, show discovery.
+
+---
+
+## Output Language Directive
+
+Before executing any mode, read `config/profile.yml` if it exists and resolve:
+
+- `language.output` → ISO language code for human-facing output. Default: `en`.
+- `language.modes_dir` → optional market-mode directory. This controls market vocabulary and local evaluation rules only.
+
+Inject this directive after loading the mode instructions and before producing any user-visible content:
+
+> Write all human-facing output in `{language.output}` regardless of the language of these instructions or of the job description. This includes reports, tracker notes, PDFs, cover letters, outreach, interview prep, form answers, and summaries. If `language.modes_dir` supplies market-specific vocabulary, keep the market logic but explain terms in `{language.output}` when needed.
+
+`language.output` is authoritative for prose. `modes_dir` is market context; it must not force the prose language.
+
+---
+
+## Discovery Mode (no arguments)
+
+If your CLI supports `/career-ops`, show this menu. In Codex, surface the same options in plain text and map the requested mode the same way.
+
+Concrete equivalents for Codex prompt-driven sessions:
+
+```text
+/career-ops {JD}           ↔ "Evaluate this JD with career-ops auto-pipeline: {JD or URL}"
+/career-ops scan           ↔ "Run the career-ops scan mode and summarize new matches."
+/career-ops pipeline       ↔ "Run the career-ops pipeline mode for data/pipeline.md."
+/career-ops pdf            ↔ "Run the career-ops pdf mode for the latest evaluated role."
+/career-ops email          ↔ "Run the career-ops email mode for the latest evaluated role."
+/career-ops tracker        ↔ "Run the career-ops tracker mode and summarize the current statuses."
+```
+
+Show this menu:
+
+```
+career-ops -- Command Center
+
+Available commands:
+  /career-ops {JD}      → AUTO-PIPELINE: evaluate + report + PDF + tracker (paste text or URL)
+  /career-ops pipeline  → Process pending URLs from inbox (data/pipeline.md)
+  /career-ops oferta    → Evaluation only A-F (no auto PDF)
+  /career-ops ofertas   → Compare and rank multiple offers
+  /career-ops contacto  → LinkedIn power move: find contacts + draft message
+  /career-ops deep      → Deep research prompt about company
+  /career-ops interview-prep → Generate company-specific interview prep doc
+  /career-ops interview    → Interactive profile/CV onboarding interview
+  /career-ops eu-swe    → Calibrate a European SWE application before CV/apply/interview
+  /career-ops interview/plan → Time-blocked prep plan for an upcoming interview
+  /career-ops interview/practice → Practice interview, one question at a time with feedback
+  /career-ops interview/debrief → Post-interview debrief: close gaps, predict next round
+  /career-ops pdf       → PDF only, ATS-optimized CV
+  /career-ops latex     → Export CV as LaTeX/Overleaf .tex
+  /career-ops latex-tex → Tailor your own resume.tex in place (opt-in; cv.md stays default)
+  /career-ops cover     → Cover letter: standalone JD paste or /career-ops cover {slug}
+  /career-ops email     → Formal application email draft (draft-only; never sends, submits, or clicks)
+  /career-ops add       → Add a project/paper/role to your CV (fetch + preview + confirm)
+  /career-ops training  → Evaluate course/cert against North Star
+  /career-ops project   → Evaluate portfolio project idea
+  /career-ops tracker   → Application status overview
+  /career-ops agent-inbox → Queue/drain requests for the next session (data/agent-inbox.md)
+  /career-ops apply     → Live application assistant (reads form + generates answers)
+  /career-ops scan      → Scan portals and discover new offers
+  /career-ops batch     → Batch processing with parallel workers
+  /career-ops patterns  → Analyze rejection patterns and improve targeting
+  /career-ops offer-prep → Read a received offer/contract with the candidate: clause walk + lawyer questions (not legal advice)
+  /career-ops titles    → Suggest adjacent job titles from your CV to broaden the search
+  /career-ops upskill   → Aggregate skill-gap analysis from your evaluated reports
+  /career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
+  /career-ops update    → Update career-ops system files with diff preview + compat check
+
+Inbox: add URLs to data/pipeline.md → /career-ops pipeline
+Or paste a JD directly to run the full pipeline.
+```
+
+---
+
+## Context Loading by Mode
+
+After determining the mode, load the necessary files before executing:
+
+If `modes/_custom.md` exists, read it after `modes/_profile.md` and before the selected mode file. It contains user house rules and procedural preferences. It may override workflow/style defaults, but it never adds factual claims about the candidate.
+
+### Modes that require `_shared.md` + their mode file
+
+Read `modes/_shared.md` + `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
+
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+
+### Standalone modes with profile and custom context
+
+Read `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
+
+Applies to: `tracker`, `agent-inbox`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `latex-tex`, `training`, `project`, `patterns`, `titles`, `upskill`, `followup`, `cover`, `email`, `add`, `offer-prep`
+
+### Modes delegated to subagent
+
+For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `_profile.md` (if exists) + `_custom.md` (if exists) + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:
+
+```python
+Agent(
+  subagent_type="general-purpose",
+  prompt="[output language directive]\n\n[content of modes/_shared.md]\n\n[content of modes/_profile.md if exists]\n\n[content of modes/_custom.md if exists]\n\n[content of modes/{mode}.md]\n\n[invocation-specific data]",
+  description="career-ops {mode}"
+)
+```
+
+Execute the instructions from the loaded mode file.

--- a/.grok/skills/career-ops/SKILL.md
+++ b/.grok/skills/career-ops/SKILL.md
@@ -1,1 +1,182 @@
-../../../.agents/skills/career-ops/SKILL.md
+---
+name: career-ops
+description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
+arguments: mode
+user_invocable: true
+user-invocable: true
+argument-hint: "[scan | deep | pdf | latex | latex-tex | cover | email | add | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | offer-prep | titles | upskill | followup | update]"
+license: MIT
+---
+
+# career-ops -- Router
+
+career-ops is a multi-CLI job-search command center. The routing below is shared across supported agent CLIs even when the invocation surface differs.
+
+## Invocation Notes
+
+- CLIs with slash-command registration can expose this router as `/career-ops`.
+- Interactive Codex sessions use `codex` in the repo root. Slash commands are not guaranteed in Codex, so ask Codex to run the same mode by name if `/career-ops` is unavailable.
+- Headless Codex workers use `codex exec "prompt"`.
+- The routing semantics below stay the same regardless of whether the entrypoint is a slash command or a natural-language prompt.
+
+Codex prompt examples that map to the same router semantics:
+
+```text
+Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123
+Run the career-ops scan mode and summarize new matches.
+Run the career-ops pipeline mode for data/pipeline.md.
+Run the career-ops pdf mode for the latest evaluated role.
+Run the career-ops tracker mode and summarize the current statuses.
+```
+
+## Mode Routing
+
+Determine the mode from `$mode`:
+
+| Input | Mode |
+|-------|------|
+| (empty / no args) | `discovery` -- Show command menu |
+| JD text or URL (no sub-command) | **`auto-pipeline`** |
+| `oferta` | `oferta` |
+| `ofertas` | `ofertas` |
+| `contacto` | `contacto` |
+| `deep` | `deep` |
+| `interview-prep` | `interview-prep` |
+| `interview` | `interview` |
+| `eu-swe` | `regional/eu-swe` |
+| `interview/plan` | `interview/plan` |
+| `interview/practice` | `interview/practice` |
+| `interview/debrief` | `interview/debrief` |
+| `pdf` | `pdf` |
+| `latex` | `latex` |
+| `latex-tex` | `latex-tex` |
+| `email` | `email` |
+| `training` | `training` |
+| `project` | `project` |
+| `tracker` | `tracker` |
+| `agent-inbox` | `agent-inbox` |
+| `inbox` | `agent-inbox` |
+| `pipeline` | `pipeline` |
+| `apply` | `apply` |
+| `scan` | `scan` |
+| `batch` | `batch` |
+| `patterns` | `patterns` |
+| `offer-prep` | `offer-prep` |
+| `titles` | `titles` |
+| `upskill` | `upskill` |
+| `followup` | `followup` |
+| `update` | `update` |
+| `cover` | `cover` |
+| `add` | `add` |
+
+**Auto-pipeline detection:** If `$mode` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
+
+If `$mode` is not a sub-command AND doesn't look like a JD, show discovery.
+
+---
+
+## Output Language Directive
+
+Before executing any mode, read `config/profile.yml` if it exists and resolve:
+
+- `language.output` → ISO language code for human-facing output. Default: `en`.
+- `language.modes_dir` → optional market-mode directory. This controls market vocabulary and local evaluation rules only.
+
+Inject this directive after loading the mode instructions and before producing any user-visible content:
+
+> Write all human-facing output in `{language.output}` regardless of the language of these instructions or of the job description. This includes reports, tracker notes, PDFs, cover letters, outreach, interview prep, form answers, and summaries. If `language.modes_dir` supplies market-specific vocabulary, keep the market logic but explain terms in `{language.output}` when needed.
+
+`language.output` is authoritative for prose. `modes_dir` is market context; it must not force the prose language.
+
+---
+
+## Discovery Mode (no arguments)
+
+If your CLI supports `/career-ops`, show this menu. In Codex, surface the same options in plain text and map the requested mode the same way.
+
+Concrete equivalents for Codex prompt-driven sessions:
+
+```text
+/career-ops {JD}           ↔ "Evaluate this JD with career-ops auto-pipeline: {JD or URL}"
+/career-ops scan           ↔ "Run the career-ops scan mode and summarize new matches."
+/career-ops pipeline       ↔ "Run the career-ops pipeline mode for data/pipeline.md."
+/career-ops pdf            ↔ "Run the career-ops pdf mode for the latest evaluated role."
+/career-ops email          ↔ "Run the career-ops email mode for the latest evaluated role."
+/career-ops tracker        ↔ "Run the career-ops tracker mode and summarize the current statuses."
+```
+
+Show this menu:
+
+```
+career-ops -- Command Center
+
+Available commands:
+  /career-ops {JD}      → AUTO-PIPELINE: evaluate + report + PDF + tracker (paste text or URL)
+  /career-ops pipeline  → Process pending URLs from inbox (data/pipeline.md)
+  /career-ops oferta    → Evaluation only A-F (no auto PDF)
+  /career-ops ofertas   → Compare and rank multiple offers
+  /career-ops contacto  → LinkedIn power move: find contacts + draft message
+  /career-ops deep      → Deep research prompt about company
+  /career-ops interview-prep → Generate company-specific interview prep doc
+  /career-ops interview    → Interactive profile/CV onboarding interview
+  /career-ops eu-swe    → Calibrate a European SWE application before CV/apply/interview
+  /career-ops interview/plan → Time-blocked prep plan for an upcoming interview
+  /career-ops interview/practice → Practice interview, one question at a time with feedback
+  /career-ops interview/debrief → Post-interview debrief: close gaps, predict next round
+  /career-ops pdf       → PDF only, ATS-optimized CV
+  /career-ops latex     → Export CV as LaTeX/Overleaf .tex
+  /career-ops latex-tex → Tailor your own resume.tex in place (opt-in; cv.md stays default)
+  /career-ops cover     → Cover letter: standalone JD paste or /career-ops cover {slug}
+  /career-ops email     → Formal application email draft (draft-only; never sends, submits, or clicks)
+  /career-ops add       → Add a project/paper/role to your CV (fetch + preview + confirm)
+  /career-ops training  → Evaluate course/cert against North Star
+  /career-ops project   → Evaluate portfolio project idea
+  /career-ops tracker   → Application status overview
+  /career-ops agent-inbox → Queue/drain requests for the next session (data/agent-inbox.md)
+  /career-ops apply     → Live application assistant (reads form + generates answers)
+  /career-ops scan      → Scan portals and discover new offers
+  /career-ops batch     → Batch processing with parallel workers
+  /career-ops patterns  → Analyze rejection patterns and improve targeting
+  /career-ops offer-prep → Read a received offer/contract with the candidate: clause walk + lawyer questions (not legal advice)
+  /career-ops titles    → Suggest adjacent job titles from your CV to broaden the search
+  /career-ops upskill   → Aggregate skill-gap analysis from your evaluated reports
+  /career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
+  /career-ops update    → Update career-ops system files with diff preview + compat check
+
+Inbox: add URLs to data/pipeline.md → /career-ops pipeline
+Or paste a JD directly to run the full pipeline.
+```
+
+---
+
+## Context Loading by Mode
+
+After determining the mode, load the necessary files before executing:
+
+If `modes/_custom.md` exists, read it after `modes/_profile.md` and before the selected mode file. It contains user house rules and procedural preferences. It may override workflow/style defaults, but it never adds factual claims about the candidate.
+
+### Modes that require `_shared.md` + their mode file
+
+Read `modes/_shared.md` + `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
+
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+
+### Standalone modes with profile and custom context
+
+Read `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
+
+Applies to: `tracker`, `agent-inbox`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `latex-tex`, `training`, `project`, `patterns`, `titles`, `upskill`, `followup`, `cover`, `email`, `add`, `offer-prep`
+
+### Modes delegated to subagent
+
+For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `_profile.md` (if exists) + `_custom.md` (if exists) + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:
+
+```python
+Agent(
+  subagent_type="general-purpose",
+  prompt="[output language directive]\n\n[content of modes/_shared.md]\n\n[content of modes/_profile.md if exists]\n\n[content of modes/_custom.md if exists]\n\n[content of modes/{mode}.md]\n\n[invocation-specific data]",
+  description="career-ops {mode}"
+)
+```
+
+Execute the instructions from the loaded mode file.

--- a/.opencode/skills/career-ops/SKILL.md
+++ b/.opencode/skills/career-ops/SKILL.md
@@ -1,1 +1,182 @@
-../../../.agents/skills/career-ops/SKILL.md
+---
+name: career-ops
+description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
+arguments: mode
+user_invocable: true
+user-invocable: true
+argument-hint: "[scan | deep | pdf | latex | latex-tex | cover | email | add | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | offer-prep | titles | upskill | followup | update]"
+license: MIT
+---
+
+# career-ops -- Router
+
+career-ops is a multi-CLI job-search command center. The routing below is shared across supported agent CLIs even when the invocation surface differs.
+
+## Invocation Notes
+
+- CLIs with slash-command registration can expose this router as `/career-ops`.
+- Interactive Codex sessions use `codex` in the repo root. Slash commands are not guaranteed in Codex, so ask Codex to run the same mode by name if `/career-ops` is unavailable.
+- Headless Codex workers use `codex exec "prompt"`.
+- The routing semantics below stay the same regardless of whether the entrypoint is a slash command or a natural-language prompt.
+
+Codex prompt examples that map to the same router semantics:
+
+```text
+Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123
+Run the career-ops scan mode and summarize new matches.
+Run the career-ops pipeline mode for data/pipeline.md.
+Run the career-ops pdf mode for the latest evaluated role.
+Run the career-ops tracker mode and summarize the current statuses.
+```
+
+## Mode Routing
+
+Determine the mode from `$mode`:
+
+| Input | Mode |
+|-------|------|
+| (empty / no args) | `discovery` -- Show command menu |
+| JD text or URL (no sub-command) | **`auto-pipeline`** |
+| `oferta` | `oferta` |
+| `ofertas` | `ofertas` |
+| `contacto` | `contacto` |
+| `deep` | `deep` |
+| `interview-prep` | `interview-prep` |
+| `interview` | `interview` |
+| `eu-swe` | `regional/eu-swe` |
+| `interview/plan` | `interview/plan` |
+| `interview/practice` | `interview/practice` |
+| `interview/debrief` | `interview/debrief` |
+| `pdf` | `pdf` |
+| `latex` | `latex` |
+| `latex-tex` | `latex-tex` |
+| `email` | `email` |
+| `training` | `training` |
+| `project` | `project` |
+| `tracker` | `tracker` |
+| `agent-inbox` | `agent-inbox` |
+| `inbox` | `agent-inbox` |
+| `pipeline` | `pipeline` |
+| `apply` | `apply` |
+| `scan` | `scan` |
+| `batch` | `batch` |
+| `patterns` | `patterns` |
+| `offer-prep` | `offer-prep` |
+| `titles` | `titles` |
+| `upskill` | `upskill` |
+| `followup` | `followup` |
+| `update` | `update` |
+| `cover` | `cover` |
+| `add` | `add` |
+
+**Auto-pipeline detection:** If `$mode` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
+
+If `$mode` is not a sub-command AND doesn't look like a JD, show discovery.
+
+---
+
+## Output Language Directive
+
+Before executing any mode, read `config/profile.yml` if it exists and resolve:
+
+- `language.output` → ISO language code for human-facing output. Default: `en`.
+- `language.modes_dir` → optional market-mode directory. This controls market vocabulary and local evaluation rules only.
+
+Inject this directive after loading the mode instructions and before producing any user-visible content:
+
+> Write all human-facing output in `{language.output}` regardless of the language of these instructions or of the job description. This includes reports, tracker notes, PDFs, cover letters, outreach, interview prep, form answers, and summaries. If `language.modes_dir` supplies market-specific vocabulary, keep the market logic but explain terms in `{language.output}` when needed.
+
+`language.output` is authoritative for prose. `modes_dir` is market context; it must not force the prose language.
+
+---
+
+## Discovery Mode (no arguments)
+
+If your CLI supports `/career-ops`, show this menu. In Codex, surface the same options in plain text and map the requested mode the same way.
+
+Concrete equivalents for Codex prompt-driven sessions:
+
+```text
+/career-ops {JD}           ↔ "Evaluate this JD with career-ops auto-pipeline: {JD or URL}"
+/career-ops scan           ↔ "Run the career-ops scan mode and summarize new matches."
+/career-ops pipeline       ↔ "Run the career-ops pipeline mode for data/pipeline.md."
+/career-ops pdf            ↔ "Run the career-ops pdf mode for the latest evaluated role."
+/career-ops email          ↔ "Run the career-ops email mode for the latest evaluated role."
+/career-ops tracker        ↔ "Run the career-ops tracker mode and summarize the current statuses."
+```
+
+Show this menu:
+
+```
+career-ops -- Command Center
+
+Available commands:
+  /career-ops {JD}      → AUTO-PIPELINE: evaluate + report + PDF + tracker (paste text or URL)
+  /career-ops pipeline  → Process pending URLs from inbox (data/pipeline.md)
+  /career-ops oferta    → Evaluation only A-F (no auto PDF)
+  /career-ops ofertas   → Compare and rank multiple offers
+  /career-ops contacto  → LinkedIn power move: find contacts + draft message
+  /career-ops deep      → Deep research prompt about company
+  /career-ops interview-prep → Generate company-specific interview prep doc
+  /career-ops interview    → Interactive profile/CV onboarding interview
+  /career-ops eu-swe    → Calibrate a European SWE application before CV/apply/interview
+  /career-ops interview/plan → Time-blocked prep plan for an upcoming interview
+  /career-ops interview/practice → Practice interview, one question at a time with feedback
+  /career-ops interview/debrief → Post-interview debrief: close gaps, predict next round
+  /career-ops pdf       → PDF only, ATS-optimized CV
+  /career-ops latex     → Export CV as LaTeX/Overleaf .tex
+  /career-ops latex-tex → Tailor your own resume.tex in place (opt-in; cv.md stays default)
+  /career-ops cover     → Cover letter: standalone JD paste or /career-ops cover {slug}
+  /career-ops email     → Formal application email draft (draft-only; never sends, submits, or clicks)
+  /career-ops add       → Add a project/paper/role to your CV (fetch + preview + confirm)
+  /career-ops training  → Evaluate course/cert against North Star
+  /career-ops project   → Evaluate portfolio project idea
+  /career-ops tracker   → Application status overview
+  /career-ops agent-inbox → Queue/drain requests for the next session (data/agent-inbox.md)
+  /career-ops apply     → Live application assistant (reads form + generates answers)
+  /career-ops scan      → Scan portals and discover new offers
+  /career-ops batch     → Batch processing with parallel workers
+  /career-ops patterns  → Analyze rejection patterns and improve targeting
+  /career-ops offer-prep → Read a received offer/contract with the candidate: clause walk + lawyer questions (not legal advice)
+  /career-ops titles    → Suggest adjacent job titles from your CV to broaden the search
+  /career-ops upskill   → Aggregate skill-gap analysis from your evaluated reports
+  /career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
+  /career-ops update    → Update career-ops system files with diff preview + compat check
+
+Inbox: add URLs to data/pipeline.md → /career-ops pipeline
+Or paste a JD directly to run the full pipeline.
+```
+
+---
+
+## Context Loading by Mode
+
+After determining the mode, load the necessary files before executing:
+
+If `modes/_custom.md` exists, read it after `modes/_profile.md` and before the selected mode file. It contains user house rules and procedural preferences. It may override workflow/style defaults, but it never adds factual claims about the candidate.
+
+### Modes that require `_shared.md` + their mode file
+
+Read `modes/_shared.md` + `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
+
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+
+### Standalone modes with profile and custom context
+
+Read `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
+
+Applies to: `tracker`, `agent-inbox`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `latex-tex`, `training`, `project`, `patterns`, `titles`, `upskill`, `followup`, `cover`, `email`, `add`, `offer-prep`
+
+### Modes delegated to subagent
+
+For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `_profile.md` (if exists) + `_custom.md` (if exists) + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:
+
+```python
+Agent(
+  subagent_type="general-purpose",
+  prompt="[output language directive]\n\n[content of modes/_shared.md]\n\n[content of modes/_profile.md if exists]\n\n[content of modes/_custom.md if exists]\n\n[content of modes/{mode}.md]\n\n[invocation-specific data]",
+  description="career-ops {mode}"
+)
+```
+
+Execute the instructions from the loaded mode file.

--- a/.qwen/skills/career-ops/SKILL.md
+++ b/.qwen/skills/career-ops/SKILL.md
@@ -1,1 +1,182 @@
-../../../.agents/skills/career-ops/SKILL.md
+---
+name: career-ops
+description: AI job search command center -- evaluate offers, generate CVs, scan portals, track applications
+arguments: mode
+user_invocable: true
+user-invocable: true
+argument-hint: "[scan | deep | pdf | latex | latex-tex | cover | email | add | eu-swe | oferta | ofertas | apply | batch | tracker | agent-inbox | pipeline | contacto | training | project | interview-prep | interview | interview/plan | interview/practice | interview/debrief | patterns | offer-prep | titles | upskill | followup | update]"
+license: MIT
+---
+
+# career-ops -- Router
+
+career-ops is a multi-CLI job-search command center. The routing below is shared across supported agent CLIs even when the invocation surface differs.
+
+## Invocation Notes
+
+- CLIs with slash-command registration can expose this router as `/career-ops`.
+- Interactive Codex sessions use `codex` in the repo root. Slash commands are not guaranteed in Codex, so ask Codex to run the same mode by name if `/career-ops` is unavailable.
+- Headless Codex workers use `codex exec "prompt"`.
+- The routing semantics below stay the same regardless of whether the entrypoint is a slash command or a natural-language prompt.
+
+Codex prompt examples that map to the same router semantics:
+
+```text
+Evaluate this JD with career-ops auto-pipeline: https://company.com/jobs/123
+Run the career-ops scan mode and summarize new matches.
+Run the career-ops pipeline mode for data/pipeline.md.
+Run the career-ops pdf mode for the latest evaluated role.
+Run the career-ops tracker mode and summarize the current statuses.
+```
+
+## Mode Routing
+
+Determine the mode from `$mode`:
+
+| Input | Mode |
+|-------|------|
+| (empty / no args) | `discovery` -- Show command menu |
+| JD text or URL (no sub-command) | **`auto-pipeline`** |
+| `oferta` | `oferta` |
+| `ofertas` | `ofertas` |
+| `contacto` | `contacto` |
+| `deep` | `deep` |
+| `interview-prep` | `interview-prep` |
+| `interview` | `interview` |
+| `eu-swe` | `regional/eu-swe` |
+| `interview/plan` | `interview/plan` |
+| `interview/practice` | `interview/practice` |
+| `interview/debrief` | `interview/debrief` |
+| `pdf` | `pdf` |
+| `latex` | `latex` |
+| `latex-tex` | `latex-tex` |
+| `email` | `email` |
+| `training` | `training` |
+| `project` | `project` |
+| `tracker` | `tracker` |
+| `agent-inbox` | `agent-inbox` |
+| `inbox` | `agent-inbox` |
+| `pipeline` | `pipeline` |
+| `apply` | `apply` |
+| `scan` | `scan` |
+| `batch` | `batch` |
+| `patterns` | `patterns` |
+| `offer-prep` | `offer-prep` |
+| `titles` | `titles` |
+| `upskill` | `upskill` |
+| `followup` | `followup` |
+| `update` | `update` |
+| `cover` | `cover` |
+| `add` | `add` |
+
+**Auto-pipeline detection:** If `$mode` is not a known sub-command AND contains JD text (keywords: "responsibilities", "requirements", "qualifications", "about the role", "we're looking for", company name + role) or a URL to a JD, execute `auto-pipeline`.
+
+If `$mode` is not a sub-command AND doesn't look like a JD, show discovery.
+
+---
+
+## Output Language Directive
+
+Before executing any mode, read `config/profile.yml` if it exists and resolve:
+
+- `language.output` → ISO language code for human-facing output. Default: `en`.
+- `language.modes_dir` → optional market-mode directory. This controls market vocabulary and local evaluation rules only.
+
+Inject this directive after loading the mode instructions and before producing any user-visible content:
+
+> Write all human-facing output in `{language.output}` regardless of the language of these instructions or of the job description. This includes reports, tracker notes, PDFs, cover letters, outreach, interview prep, form answers, and summaries. If `language.modes_dir` supplies market-specific vocabulary, keep the market logic but explain terms in `{language.output}` when needed.
+
+`language.output` is authoritative for prose. `modes_dir` is market context; it must not force the prose language.
+
+---
+
+## Discovery Mode (no arguments)
+
+If your CLI supports `/career-ops`, show this menu. In Codex, surface the same options in plain text and map the requested mode the same way.
+
+Concrete equivalents for Codex prompt-driven sessions:
+
+```text
+/career-ops {JD}           ↔ "Evaluate this JD with career-ops auto-pipeline: {JD or URL}"
+/career-ops scan           ↔ "Run the career-ops scan mode and summarize new matches."
+/career-ops pipeline       ↔ "Run the career-ops pipeline mode for data/pipeline.md."
+/career-ops pdf            ↔ "Run the career-ops pdf mode for the latest evaluated role."
+/career-ops email          ↔ "Run the career-ops email mode for the latest evaluated role."
+/career-ops tracker        ↔ "Run the career-ops tracker mode and summarize the current statuses."
+```
+
+Show this menu:
+
+```
+career-ops -- Command Center
+
+Available commands:
+  /career-ops {JD}      → AUTO-PIPELINE: evaluate + report + PDF + tracker (paste text or URL)
+  /career-ops pipeline  → Process pending URLs from inbox (data/pipeline.md)
+  /career-ops oferta    → Evaluation only A-F (no auto PDF)
+  /career-ops ofertas   → Compare and rank multiple offers
+  /career-ops contacto  → LinkedIn power move: find contacts + draft message
+  /career-ops deep      → Deep research prompt about company
+  /career-ops interview-prep → Generate company-specific interview prep doc
+  /career-ops interview    → Interactive profile/CV onboarding interview
+  /career-ops eu-swe    → Calibrate a European SWE application before CV/apply/interview
+  /career-ops interview/plan → Time-blocked prep plan for an upcoming interview
+  /career-ops interview/practice → Practice interview, one question at a time with feedback
+  /career-ops interview/debrief → Post-interview debrief: close gaps, predict next round
+  /career-ops pdf       → PDF only, ATS-optimized CV
+  /career-ops latex     → Export CV as LaTeX/Overleaf .tex
+  /career-ops latex-tex → Tailor your own resume.tex in place (opt-in; cv.md stays default)
+  /career-ops cover     → Cover letter: standalone JD paste or /career-ops cover {slug}
+  /career-ops email     → Formal application email draft (draft-only; never sends, submits, or clicks)
+  /career-ops add       → Add a project/paper/role to your CV (fetch + preview + confirm)
+  /career-ops training  → Evaluate course/cert against North Star
+  /career-ops project   → Evaluate portfolio project idea
+  /career-ops tracker   → Application status overview
+  /career-ops agent-inbox → Queue/drain requests for the next session (data/agent-inbox.md)
+  /career-ops apply     → Live application assistant (reads form + generates answers)
+  /career-ops scan      → Scan portals and discover new offers
+  /career-ops batch     → Batch processing with parallel workers
+  /career-ops patterns  → Analyze rejection patterns and improve targeting
+  /career-ops offer-prep → Read a received offer/contract with the candidate: clause walk + lawyer questions (not legal advice)
+  /career-ops titles    → Suggest adjacent job titles from your CV to broaden the search
+  /career-ops upskill   → Aggregate skill-gap analysis from your evaluated reports
+  /career-ops followup  → Follow-up cadence tracker: flag overdue, generate drafts
+  /career-ops update    → Update career-ops system files with diff preview + compat check
+
+Inbox: add URLs to data/pipeline.md → /career-ops pipeline
+Or paste a JD directly to run the full pipeline.
+```
+
+---
+
+## Context Loading by Mode
+
+After determining the mode, load the necessary files before executing:
+
+If `modes/_custom.md` exists, read it after `modes/_profile.md` and before the selected mode file. It contains user house rules and procedural preferences. It may override workflow/style defaults, but it never adds factual claims about the candidate.
+
+### Modes that require `_shared.md` + their mode file
+
+Read `modes/_shared.md` + `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
+
+Applies to: `auto-pipeline`, `oferta`, `ofertas`, `pdf`, `contacto`, `apply`, `pipeline`, `scan`, `batch`
+
+### Standalone modes with profile and custom context
+
+Read `modes/_profile.md` (if exists) + `modes/_custom.md` (if exists) + `modes/{mode}.md`
+
+Applies to: `tracker`, `agent-inbox`, `deep`, `interview-prep`, `interview`, `regional/eu-swe`, `interview/plan`, `interview/practice`, `interview/debrief`, `latex`, `latex-tex`, `training`, `project`, `patterns`, `titles`, `upskill`, `followup`, `cover`, `email`, `add`, `offer-prep`
+
+### Modes delegated to subagent
+
+For `scan`, `apply` (with Playwright), and `pipeline` (3+ URLs): launch as a worker/subagent with the content of `_shared.md` + `_profile.md` (if exists) + `_custom.md` (if exists) + `modes/{mode}.md` injected into the worker prompt. If your CLI exposes an `Agent(...)` primitive, the call looks like this:
+
+```python
+Agent(
+  subagent_type="general-purpose",
+  prompt="[output language directive]\n\n[content of modes/_shared.md]\n\n[content of modes/_profile.md if exists]\n\n[content of modes/_custom.md if exists]\n\n[content of modes/{mode}.md]\n\n[invocation-specific data]",
+  description="career-ops {mode}"
+)
+```
+
+Execute the instructions from the loaded mode file.


### PR DESCRIPTION
## Summary
- `core.symlinks=false` checkouts (e.g. Windows without symlink support) check out symlinked `SKILL.md` files as a literal one-line path instead of resolving them, so `.antigravitycli`, `.claude`, `.grok`, `.opencode`, and `.qwen` were loading a useless pointer instead of the router content.
- Materializes the full router content into those 5 files directly, matching the pattern already used by `.kimi/skills/career-ops/SKILL.md`.

## Test plan
- [x] Diffed all 5 materialized files against `.agents/skills/career-ops/SKILL.md` (canonical source) - byte-identical
- [x] Confirmed line endings (CRLF) match source


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent career-operations routing across supported assistant environments.
  * Added automatic detection for job descriptions and job URLs, enabling streamlined pipeline workflows.
  * Added a discovery menu for exploring available career modes and commands.
  * Added configurable output-language support based on the user’s profile settings.
  * Added clearer workflows for resume scanning, applications, interviews, PDFs, and regional career operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->