### PR TITLE
fix(scan): normalize cosmetic URL variants for dedup (#2065)

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -540,7 +540,7 @@ async function main() {
           if (!locationFilter(job.location)) continue;
           if (!contentFilter(job.description, matchedTitleKeywords(job.title, config?.title_filter))) { droppedContent++; continue; }
           if (seenUrls.has(normalizeUrlForDedup(job.url))) continue;
-          seenUrls.add(job.url); // intra-scan dedup
+          seenUrls.add(normalizeUrlForDedup(job.url)); // intra-scan dedup
           newOffers.push({ ...job, source: `${name}-full`, dateStatus: job.postedAt ? 'dated' : 'unknown' });
         }
       } catch (err) {

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -398,7 +398,7 @@ export async function runSeedScan(seedId, opts, ctx, seenUrls, label) {
         titleFilterConfig: opts.titleFilterConfig,
       })) continue;
       if (seenUrls.has(normalizeUrlForDedup(job.url))) continue;
-      seenUrls.add(job.url);
+      seenUrls.add(normalizeUrlForDedup(job.url));
       offers.push({ ...job, source: sourceName, dateStatus: job.postedAt ? 'dated' : 'unknown' });
     }
   });

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -539,7 +539,7 @@ async function main() {
           if (!titleFilter(job.title)) continue;
           if (!locationFilter(job.location)) continue;
           if (!contentFilter(job.description, matchedTitleKeywords(job.title, config?.title_filter))) { droppedContent++; continue; }
-          if (seenUrls.has(job.url)) continue;
+          if (seenUrls.has(normalizeUrlForDedup(job.url))) continue;
           seenUrls.add(job.url); // intra-scan dedup
           newOffers.push({ ...job, source: `${name}-full`, dateStatus: job.postedAt ? 'dated' : 'unknown' });
         }

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -397,8 +397,9 @@ export async function runSeedScan(seedId, opts, ctx, seenUrls, label) {
         contentFilter: opts.contentFilter,
         titleFilterConfig: opts.titleFilterConfig,
       })) continue;
-      if (seenUrls.has(normalizeUrlForDedup(job.url))) continue;
-      seenUrls.add(normalizeUrlForDedup(job.url));
+      const dedupUrl = normalizeUrlForDedup(job.url);
+      if (seenUrls.has(dedupUrl)) continue;
+      seenUrls.add(dedupUrl);
       offers.push({ ...job, source: sourceName, dateStatus: job.postedAt ? 'dated' : 'unknown' });
     }
   });
@@ -539,8 +540,9 @@ async function main() {
           if (!titleFilter(job.title)) continue;
           if (!locationFilter(job.location)) continue;
           if (!contentFilter(job.description, matchedTitleKeywords(job.title, config?.title_filter))) { droppedContent++; continue; }
-          if (seenUrls.has(normalizeUrlForDedup(job.url))) continue;
-          seenUrls.add(normalizeUrlForDedup(job.url)); // intra-scan dedup
+          const dedupUrl = normalizeUrlForDedup(job.url);
+          if (seenUrls.has(dedupUrl)) continue;
+          seenUrls.add(dedupUrl); // intra-scan dedup
           newOffers.push({ ...job, source: `${name}-full`, dateStatus: job.postedAt ? 'dated' : 'unknown' });
         }
       } catch (err) {

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -39,7 +39,7 @@ import greenhouse from './providers/greenhouse.mjs';
 import lever from './providers/lever.mjs';
 import ashby from './providers/ashby.mjs';
 import workday from './providers/workday.mjs';
-import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, loadSeenUrls, appendToPipeline, appendToScanHistory, loadBlacklist } from './scan.mjs';
+import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, loadSeenUrls, normalizeUrlForDedup, appendToPipeline, appendToScanHistory, loadBlacklist } from './scan.mjs';
 import { SEED_SOURCES, toPortalEntry } from './seeds/vc-portfolios.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
 

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -397,7 +397,7 @@ export async function runSeedScan(seedId, opts, ctx, seenUrls, label) {
         contentFilter: opts.contentFilter,
         titleFilterConfig: opts.titleFilterConfig,
       })) continue;
-      if (seenUrls.has(job.url)) continue;
+      if (seenUrls.has(normalizeUrlForDedup(job.url))) continue;
       seenUrls.add(job.url);
       offers.push({ ...job, source: sourceName, dateStatus: job.postedAt ? 'dated' : 'unknown' });
     }

--- a/scan.mjs
+++ b/scan.mjs
@@ -1769,7 +1769,8 @@ async function main() {
           totalFilteredVisa++;
           continue;
         }
-        if (seenUrls.has(normalizeUrlForDedup(job.url))) {
+        const dedupUrl = normalizeUrlForDedup(job.url);
+        if (seenUrls.has(dedupUrl)) {
           totalDupes++;
           continue;
         }
@@ -1788,7 +1789,7 @@ async function main() {
           continue;
         }
         // Mark as seen to avoid intra-scan dupes
-        seenUrls.add(normalizeUrlForDedup(job.url));
+        seenUrls.add(dedupUrl);
         seenCompanyRoles.add(key);
         // Tag with the company's careers domain so verify can offer a 404/410
         // rediscovery fallback. A null domain (no careers_url) marks the offer

--- a/scan.mjs
+++ b/scan.mjs
@@ -715,7 +715,7 @@ export function loadSeenUrls(policy = {}) {
   if (existsSync(APPLICATIONS_PATH)) {
     const text = readFileSync(APPLICATIONS_PATH, 'utf-8');
     for (const match of text.matchAll(/https?:\/\/[^\s|)]+/g)) {
-      seen.add(match[0]);
+      seen.add(normalizeUrlForDedup(match[0]));
     }
   }
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -646,6 +646,48 @@ function scanHistoryPolicy(config = {}) {
   };
 }
 
+// Query params that carry no identity information for a job posting — safe to
+// strip when computing the dedup key. Deliberately an allowlist rather than
+// "strip everything": several ATSes key the posting off a query param (e.g.
+// Greenhouse's `gh_jid`), so a blanket strip would collapse distinct roles.
+const DEDUP_STRIP_PARAMS = new Set([
+  'language', 'lang', 'locale',
+  'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content',
+  'ref', 'src', 'source', 'gh_src', 'lever-origin', 'lever-source',
+]);
+
+/**
+ * Normalize a job posting URL into a stable dedup key.
+ *
+ * Strips cosmetic query params (locale/tracking), drops a trailing slash,
+ * and lowercases scheme + host. Only used to compute the *comparison* key —
+ * callers keep writing/displaying the original URL so links stay clickable
+ * and scan-history/pipeline.md stay faithful to what the provider returned.
+ *
+ * Falls back to the raw string when the URL is malformed, preserving the
+ * old byte-for-byte behavior for unparsable history rows.
+ *
+ * @param {string} url
+ * @returns {string}
+ */
+export function normalizeUrlForDedup(url) {
+  if (typeof url !== 'string' || !url) return url;
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  for (const param of Array.from(parsed.searchParams.keys())) {
+    if (DEDUP_STRIP_PARAMS.has(param.toLowerCase())) {
+      parsed.searchParams.delete(param);
+    }
+  }
+  parsed.hash = '';
+  parsed.pathname = parsed.pathname.replace(/\/+$/, '') || '/';
+  return parsed.toString();
+}
+
 export function loadSeenUrls(policy = {}) {
   const seen = new Set();
   let recheckEligible = 0;

--- a/scan.mjs
+++ b/scan.mjs
@@ -698,7 +698,7 @@ export function loadSeenUrls(policy = {}) {
     for (const line of lines.slice(1)) { // skip header
       const [url, firstSeen, , , , status = 'added'] = line.split('\t');
       if (!url) continue;
-      if (shouldDedupScanHistoryRow({ firstSeen, status }, policy)) seen.add(url);
+      if (shouldDedupScanHistoryRow({ firstSeen, status }, policy)) seen.add(normalizeUrlForDedup(url));
       else recheckEligible++;
     }
   }

--- a/scan.mjs
+++ b/scan.mjs
@@ -707,7 +707,7 @@ export function loadSeenUrls(policy = {}) {
   if (existsSync(PIPELINE_PATH)) {
     const text = readFileSync(PIPELINE_PATH, 'utf-8');
     for (const match of text.matchAll(/- \[[ x]\] (https?:\/\/\S+)/g)) {
-      seen.add(match[1]);
+      seen.add(normalizeUrlForDedup(match[1]));
     }
   }
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -1769,7 +1769,7 @@ async function main() {
           totalFilteredVisa++;
           continue;
         }
-        if (seenUrls.has(job.url)) {
+        if (seenUrls.has(normalizeUrlForDedup(job.url))) {
           totalDupes++;
           continue;
         }

--- a/scan.mjs
+++ b/scan.mjs
@@ -1788,7 +1788,7 @@ async function main() {
           continue;
         }
         // Mark as seen to avoid intra-scan dupes
-        seenUrls.add(job.url);
+        seenUrls.add(normalizeUrlForDedup(job.url));
         seenCompanyRoles.add(key);
         // Tag with the company's careers domain so verify can offer a 404/410
         // rediscovery fallback. A null domain (no careers_url) marks the offer

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2061,6 +2061,26 @@ try {
     } else {
       fail(`scan.mjs loadSeenUrls did not dedup query-suffix variant: has(bare)=${seen.has(normalizeUrlForDedup(bare))} has(withLang)=${seen.has(normalizeUrlForDedup(withLang))}`);
     }
+
+    // Same dedupUrl-once pattern the main-loop and runSeedScan/scan-ats-full
+    // loops use: a job re-fetched under either URL variant of an already-seen
+    // history row must be counted as a dupe (never re-added to seenUrls).
+    let dupeCount = 0;
+    let newCount = 0;
+    for (const jobUrl of [bare, withLang, withTrailingSlash]) {
+      const dedupUrl = normalizeUrlForDedup(jobUrl);
+      if (seen.has(dedupUrl)) {
+        dupeCount++;
+      } else {
+        seen.add(dedupUrl);
+        newCount++;
+      }
+    }
+    if (dupeCount === 3 && newCount === 0) {
+      pass('scan.mjs main-loop dedup pattern treats every cosmetic URL variant of a seen row as a duplicate, never re-adds (#2065)');
+    } else {
+      fail(`scan.mjs main-loop dedup pattern wrong: dupeCount=${dupeCount} newCount=${newCount} (expected 3/0)`);
+    }
   } finally {
     process.chdir(originalCwd);
     rmSync(fixtureRoot, { recursive: true, force: true });

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2018,6 +2018,35 @@ try {
   fail(`scan.mjs fresh-install pipeline test crashed: ${err.message}`);
 }
 
+// URL dedup normalization (#2065): a cosmetic query-suffix variant of an
+// already-processed URL (locale/tracking params, trailing slash, case) must
+// still dedup against the bare form, while an identity-bearing param (e.g.
+// Greenhouse's gh_jid) must NOT be stripped.
+try {
+  const { normalizeUrlForDedup } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+
+  const bare = 'https://acme.jobs.personio.com/job/2670127';
+  const withLang = `${bare}?language=en`;
+  const withTrailingSlash = `${bare}/`;
+  const withUtm = `${bare}?utm_source=newsletter`;
+  const ghJid = 'https://boards.greenhouse.io/acme/jobs/123?gh_jid=123';
+  const malformed = 'not a url';
+
+  if (
+    normalizeUrlForDedup(withLang) === normalizeUrlForDedup(bare) &&
+    normalizeUrlForDedup(withTrailingSlash) === normalizeUrlForDedup(bare) &&
+    normalizeUrlForDedup(withUtm) === normalizeUrlForDedup(bare) &&
+    normalizeUrlForDedup(ghJid).includes('gh_jid=123') &&
+    normalizeUrlForDedup(malformed) === malformed
+  ) {
+    pass('scan.mjs normalizeUrlForDedup strips cosmetic params/trailing slash but preserves identity params and malformed input (#2065)');
+  } else {
+    fail(`scan.mjs normalizeUrlForDedup wrong: withLang=${normalizeUrlForDedup(withLang)} withTrailingSlash=${normalizeUrlForDedup(withTrailingSlash)} withUtm=${normalizeUrlForDedup(withUtm)} ghJid=${normalizeUrlForDedup(ghJid)} malformed=${normalizeUrlForDedup(malformed)}`);
+  }
+} catch (err) {
+  fail(`scan.mjs normalizeUrlForDedup test crashed: ${err.message}`);
+}
+
 // Company blacklist (#1742): data/blacklist.md is the user's do-not-apply
 // list. parseBlacklist keys rows by the shared normalizeCompany() so matching
 // is case- and punctuation-insensitive; loadBlacklist on an absent file is a

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2043,6 +2043,28 @@ try {
   } else {
     fail(`scan.mjs normalizeUrlForDedup wrong: withLang=${normalizeUrlForDedup(withLang)} withTrailingSlash=${normalizeUrlForDedup(withTrailingSlash)} withUtm=${normalizeUrlForDedup(withUtm)} ghJid=${normalizeUrlForDedup(ghJid)} malformed=${normalizeUrlForDedup(malformed)}`);
   }
+
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-seen-urls-'));
+  const originalCwd = process.cwd();
+  try {
+    mkdirSync(join(fixtureRoot, 'data'), { recursive: true });
+    writeFileSync(
+      join(fixtureRoot, 'data', 'scan-history.tsv'),
+      `url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\n${withLang}\t2026-07-06\tpersonio-feed\tPM\tAcme\tadded\tRemote\n`,
+      'utf-8',
+    );
+    process.chdir(fixtureRoot);
+    const { loadSeenUrls } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+    const { seen } = loadSeenUrls();
+    if (seen.has(normalizeUrlForDedup(bare)) && seen.has(normalizeUrlForDedup(withLang))) {
+      pass('scan.mjs loadSeenUrls dedups a history row against a cosmetic query-suffix variant (#2065)');
+    } else {
+      fail(`scan.mjs loadSeenUrls did not dedup query-suffix variant: has(bare)=${seen.has(normalizeUrlForDedup(bare))} has(withLang)=${seen.has(normalizeUrlForDedup(withLang))}`);
+    }
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
 } catch (err) {
   fail(`scan.mjs normalizeUrlForDedup test crashed: ${err.message}`);
 }


### PR DESCRIPTION
## What does this PR do?

`scan.mjs` / `scan-ats-full.mjs` dedup job URLs by exact string equality, so a cosmetic variation (locale query suffix like `?language=en`, tracking params, trailing slash) defeats dedup and re-emits already-processed roles into `data/pipeline.md`. This adds a `normalizeUrlForDedup()` helper applied on both the insert side (`loadSeenUrls`, intra-scan adds) and the lookup side (every `seenUrls.has(...)` check in both scripts), so all variants of the same posting collapse to one dedup key while the original URL is still what gets written to scan-history/pipeline (links stay clickable).

Only a denylist of known-cosmetic params is stripped (`language`, `lang`, `locale`, `utm_*`, `ref`, `src`, `source`, `gh_src`, `lever-origin`, `lever-source`) — identity-bearing params like Greenhouse's `gh_jid` are preserved. Malformed URLs fall back to the raw string, keeping old byte-for-byte behavior for unparsable history rows.

## Related issue

Fixes #2065

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Bug fix — no issue-first requirement
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (2006 passed, 0 failed, 4 pre-existing unrelated warnings)
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job posting deduplication by normalizing URLs (ignoring tracking/cosmetic parameters, fragments, and trailing slashes) before comparing.
  * Ensured deduplication is consistent across the main ATS scan and the portfolio seed scan, and respects previously recorded scan history.
  * Preserved identity-bearing parameters so truly distinct postings aren’t incorrectly merged.
* **Tests**
  * Added regression coverage for URL normalization behavior and verified deduplication against stored scan history and repeated URL variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->