### PR TITLE
fix(scan): seed the company+role dedupe key from all three sources

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -935,34 +935,119 @@ export function companyRoleDedupKey(company, role, canonicalize = defaultCompany
 }
 
 /**
- * Load company+role keys already present in the applications tracker.
+ * Build the seen-role set from the same three sources as `loadSeenUrls`.
  *
- * Existing tracker rows are canonicalized with the same company aliasing and
- * role-title normalization used for freshly scanned jobs. That lets URL-new
- * duplicates match older tracker entries instead of being evaluated again.
+ * Existing rows are canonicalized with the same company aliasing and role-title
+ * normalization used for freshly scanned jobs. That lets URL-new duplicates match
+ * older entries instead of being evaluated again.
  *
- * @param {string} [appsPath=APPLICATIONS_PATH] - Applications tracker path.
+ * Seeding from applications.md alone made the key effectively intra-run: a role
+ * added by a prior scan lives in scan-history and pipeline, and does not reach
+ * applications.md until the user evaluates and applies. Companies that open one req
+ * per city therefore leaked one city variant per scan — run 1 added the SF req
+ * (marking the key in memory only), run 2 re-seeded from applications.md, found the
+ * key absent, and the NY req cleared both the URL check and the role check.
+ *
+ * Two deliberate semantics on the scan-history source:
+ *
+ * - Only `added` rows seed a key. `skipped_expired` / `skipped_invalid_url` /
+ *   `skipped_blocked_host` are URL-level failures, not evidence the role was
+ *   surfaced; seeding from them would let a dead SF URL bury a live NY req. Because
+ *   an expired posting is recorded as `skipped_expired` rather than `added`, this
+ *   self-heals: when the canonical posting dies, its city variants become eligible
+ *   again on the next scan.
+ * - Seeding honours `scan_history.recheck_after_days` via the existing
+ *   `shouldDedupScanHistoryRow` predicate, so the role key cannot outlive the URL
+ *   key it mirrors.
+ *
+ * @param {{applicationsText?: string, scanHistoryText?: string, pipelineText?: string}} sources
+ *   Raw text of each dedupe source; absent sources default to empty.
+ * @param {{recheckAfterDays?: number|null, today?: string}} [policy] - Scan-history
+ *   recheck policy, shared with `loadSeenUrls`.
  * @param {(name: unknown) => string} [canonicalize=defaultCompanyNormalizer] -
  *   Company canonicalizer shared with scan-side dedupe.
  * @returns {Set<string>} Existing company+role dedupe keys.
  */
-export function loadSeenCompanyRoles(appsPath = APPLICATIONS_PATH, canonicalize = defaultCompanyNormalizer) {
+export function collectSeenCompanyRoles(sources = {}, policy = {}, canonicalize = defaultCompanyNormalizer) {
+  const { applicationsText = '', scanHistoryText = '', pipelineText = '' } = sources;
   const seen = new Set();
-  if (existsSync(appsPath)) {
-    // Header-aware parse (tracker-parse.mjs, #954) — the old positional regex
-    // captured the wrong cells on customized layouts (e.g. with a Location
-    // column), so the seen-set keyed on garbage and dedup misfired.
-    const lines = readFileSync(appsPath, 'utf-8').split('\n');
+  const add = (company, role) => {
+    const c = String(company ?? '').trim();
+    const r = String(role ?? '').trim();
+    if (!c || !r) return;
+    // Header and markdown-separator cells are not roles.
+    if (c.toLowerCase() === 'company') return;
+    if (/^[-:]+$/.test(c) || /^[-:]+$/.test(r)) return;
+    seen.add(companyRoleDedupKey(c, r, canonicalize));
+  };
+
+  // applications.md — header-aware parse (tracker-parse.mjs, #954). The old
+  // positional regex captured the wrong cells on customized layouts (e.g. with a
+  // Location column), so the seen-set keyed on garbage and dedup misfired.
+  if (applicationsText) {
+    const lines = applicationsText.split('\n');
     const colmap = resolveColumns(lines);
     for (const line of lines) {
       const row = parseTrackerRow(line, colmap);
       if (!row) continue;
-      const company = row.company.trim();
-      const role = row.role.trim();
-      if (company && role) seen.add(companyRoleDedupKey(company, role, canonicalize));
+      add(row.company, row.role);
     }
   }
+
+  // scan-history.tsv — url, first_seen, portal, title, company, status, location
+  for (const line of scanHistoryText.split('\n').slice(1)) { // skip header
+    const [url, firstSeen, , title, company, status = 'added'] = line.split('\t');
+    if (!url) continue;
+    if (status !== 'added') continue;
+    if (!shouldDedupScanHistoryRow({ firstSeen, status }, policy)) continue;
+    add(company, title);
+  }
+
+  // pipeline.md — "- [ ] {url} | {company} | {title}" plus optional trailing
+  // columns (location, compensation, posted:/trust:/note: segments).
+  for (const match of pipelineText.matchAll(/^- \[[ x]\]\s+\S+\s*\|\s*([^|\n]+?)\s*\|\s*([^|\n]+?)\s*(?:\|[^\n]*)?$/gm)) {
+    add(match[1], match[2]);
+  }
+
   return seen;
+}
+
+function readIfExists(filePath) {
+  return existsSync(filePath) ? readFileSync(filePath, 'utf-8') : '';
+}
+
+/**
+ * Load company+role keys already surfaced by a prior scan or tracked by the user.
+ *
+ * Thin filesystem wrapper over {@link collectSeenCompanyRoles}, mirroring the
+ * source list `loadSeenUrls` already reads.
+ *
+ * The two leading positional parameters are unchanged, so existing callers keep
+ * working. The extra sources are injectable via the trailing options object: the
+ * module-level paths are relative to `process.cwd()`, so a test that passes only a
+ * sandbox tracker would otherwise pick up the developer's real scan-history and
+ * pipeline (CI only avoids this because those files are gitignored).
+ *
+ * @param {string} [appsPath=APPLICATIONS_PATH] - Applications tracker path.
+ * @param {(name: unknown) => string} [canonicalize=defaultCompanyNormalizer] -
+ *   Company canonicalizer shared with scan-side dedupe.
+ * @param {object} [options] - Additional sources and policy.
+ * @param {{recheckAfterDays?: number|null, today?: string}} [options.policy] -
+ *   Scan-history recheck policy, shared with `loadSeenUrls`.
+ * @param {string} [options.scanHistoryPath=SCAN_HISTORY_PATH] - Scan-history path.
+ * @param {string} [options.pipelinePath=PIPELINE_PATH] - Pipeline inbox path.
+ * @returns {Set<string>} Existing company+role dedupe keys.
+ */
+export function loadSeenCompanyRoles(
+  appsPath = APPLICATIONS_PATH,
+  canonicalize = defaultCompanyNormalizer,
+  { policy = {}, scanHistoryPath = SCAN_HISTORY_PATH, pipelinePath = PIPELINE_PATH } = {},
+) {
+  return collectSeenCompanyRoles({
+    applicationsText: readIfExists(appsPath),
+    scanHistoryText: readIfExists(scanHistoryPath),
+    pipelineText: readIfExists(pipelinePath),
+  }, policy, canonicalize);
 }
 
 // ── Pipeline writer ─────────────────────────────────────────────────
@@ -1616,7 +1701,7 @@ async function main() {
   const seenUrlState = loadSeenUrls(historyPolicy);
   const seenUrls = seenUrlState.seen;
   const canonicalizeCompany = buildCompanyCanonicalizer(config.company_aliases);
-  const seenCompanyRoles = loadSeenCompanyRoles(APPLICATIONS_PATH, canonicalizeCompany);
+  const seenCompanyRoles = loadSeenCompanyRoles(APPLICATIONS_PATH, canonicalizeCompany, { policy: historyPolicy });
 
   // 5. Fetch from each target
   const date = new Date().toISOString().slice(0, 10);

--- a/tests/fixtures/three-city-board.mjs
+++ b/tests/fixtures/three-city-board.mjs
@@ -1,0 +1,16 @@
+// tests/fixtures/three-city-board.mjs — a local-parser fixture board.
+//
+// Emits ONE role posted at THREE URLs, one per city — the shape that leaked a
+// city variant per scan before the company+role key was seeded across runs.
+// Used by tests/scan-company-role-dedup.test.mjs; no network involved.
+//
+// local-parser requires the script to live inside the project root and to be
+// the interpreter's first argument, and runs it with cwd pinned to the repo
+// root. It reads a JSON array (or {jobs:[]}) off stdout.
+const ROLE = 'Strategic Finance Manager';
+
+console.log(JSON.stringify([
+  { title: ROLE, url: 'https://boards.example.com/fixture/1001', company: 'Fixture Defense', location: 'Costa Mesa, CA' },
+  { title: ROLE, url: 'https://boards.example.com/fixture/1002', company: 'Fixture Defense', location: 'Washington, DC' },
+  { title: ROLE, url: 'https://boards.example.com/fixture/1003', company: 'Fixture Defense', location: 'Huntsville, AL' },
+]));

--- a/tests/scan-company-role-dedup.test.mjs
+++ b/tests/scan-company-role-dedup.test.mjs
@@ -1,0 +1,175 @@
+// tests/scan-company-role-dedup.test.mjs — the company+role dedupe key must
+// survive between scan runs.
+//
+// `loadSeenUrls` reads all three dedupe sources (scan-history.tsv, pipeline.md,
+// applications.md). Its company+role counterpart read applications.md alone, so
+// the role key was effectively intra-run: a role surfaced by a prior scan lives
+// in scan-history and pipeline, and does not reach applications.md until the
+// user evaluates and applies it. Companies that open one req per city therefore
+// leaked one city variant per scan — run 1 added the Costa Mesa req (marking the
+// key in memory only), run 2 re-seeded from applications.md, found the key
+// absent, and the DC req cleared both the URL check and the role check.
+//
+// These exercise `loadSeenCompanyRoles` (the filesystem wrapper) rather than the
+// pure collector, because the defect was in which sources get wired in, not in
+// how any one source is parsed.
+import { pass, fail } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadSeenCompanyRoles, companyRoleDedupKey } from '../scan.mjs';
+
+console.log('\nscan.mjs — company+role dedupe survives between runs');
+
+const EMPTY_TRACKER = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+`;
+
+const HISTORY_HEADER = 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation';
+
+// Build a sandbox and return the paths, so nothing reads the developer's real
+// data/ (the module-level paths are relative to process.cwd()).
+function sandbox({ tracker = EMPTY_TRACKER, history = '', pipeline = '' } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'co-roledash-'));
+  mkdirSync(dir, { recursive: true });
+  const paths = {
+    dir,
+    appsPath: join(dir, 'applications.md'),
+    scanHistoryPath: join(dir, 'scan-history.tsv'),
+    pipelinePath: join(dir, 'pipeline.md'),
+  };
+  writeFileSync(paths.appsPath, tracker);
+  if (history) writeFileSync(paths.scanHistoryPath, history);
+  if (pipeline) writeFileSync(paths.pipelinePath, pipeline);
+  return paths;
+}
+
+function seenFor(paths, policy = {}) {
+  return loadSeenCompanyRoles(paths.appsPath, undefined, {
+    policy,
+    scanHistoryPath: paths.scanHistoryPath,
+    pipelinePath: paths.pipelinePath,
+  });
+}
+
+const KEY = companyRoleDedupKey('Anduril', 'Strategic Finance');
+
+// ── 1. The cross-run leak ───────────────────────────────────────────────────
+// The regression itself: a role recorded as `added` in scan-history seeds the
+// key even though it has not reached the tracker yet.
+{
+  const sb = sandbox({
+    history: `${HISTORY_HEADER}\nhttps://ex.com/a/1\t2026-07-18\tgreenhouse\tStrategic Finance\tAnduril\tadded\tCosta Mesa\n`,
+  });
+  const seen = seenFor(sb);
+  if (seen.has(KEY)) pass('scan-history `added` row seeds the role key (cross-run leak closed)');
+  else fail(`scan-history \`added\` row did not seed the role key — got [${[...seen].join(', ')}]`);
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 2. pipeline.md seeds the key ────────────────────────────────────────────
+// Both the pending form and the processed strikethrough form, with and without
+// the optional trailing columns.
+{
+  const sb = sandbox({
+    pipeline: [
+      '- [ ] https://ex.com/a/1 | Anduril | Strategic Finance | Costa Mesa',
+      '- [ ] https://ex.com/b/2 | Brex | BizOps Manager',
+      '- [x] https://ex.com/c/3 | Harvey | GTM Finance Lead | NY | $200k | posted: 2026-07-01',
+    ].join('\n') + '\n',
+  });
+  const seen = seenFor(sb);
+  const want = [
+    ['Anduril', 'Strategic Finance', 'with location column'],
+    ['Brex', 'BizOps Manager', 'bare 3-column form'],
+    ['Harvey', 'GTM Finance Lead', 'checked row with trailing segments'],
+  ];
+  let ok = true;
+  for (const [co, role, label] of want) {
+    if (!seen.has(companyRoleDedupKey(co, role))) { ok = false; fail(`pipeline.md ${label} did not seed the key`); }
+  }
+  if (ok) pass('pipeline.md seeds the role key (3-col, location column, trailing segments)');
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 3. URL-level failures must NOT seed ─────────────────────────────────────
+// skipped_expired is not evidence the role was surfaced. Seeding from it would
+// let a dead Costa Mesa URL permanently bury a live DC req; because an expired
+// posting is recorded as skipped_expired rather than added, this self-heals.
+{
+  for (const status of ['skipped_expired', 'skipped_invalid_url', 'skipped_blocked_host']) {
+    const sb = sandbox({
+      history: `${HISTORY_HEADER}\nhttps://ex.com/a/1\t2026-07-18\tgreenhouse\tStrategic Finance\tAnduril\t${status}\tCosta Mesa\n`,
+    });
+    const seen = seenFor(sb);
+    if (!seen.has(KEY)) pass(`\`${status}\` does not seed the role key (variant can resurface)`);
+    else fail(`\`${status}\` seeded the role key — a dead URL would bury a live req`);
+    rmSync(sb.dir, { recursive: true, force: true });
+  }
+}
+
+// ── 4. Seeding honours the recheck TTL ──────────────────────────────────────
+// The role key mirrors the URL key, so it must not outlive it.
+{
+  const sb = sandbox({
+    history: `${HISTORY_HEADER}\nhttps://ex.com/a/1\t2026-01-01\tgreenhouse\tStrategic Finance\tAnduril\tadded\tCosta Mesa\n`,
+  });
+  const fresh = seenFor(sb, { recheckAfterDays: 30, today: '2026-01-10' });
+  const stale = seenFor(sb, { recheckAfterDays: 30, today: '2026-06-01' });
+  if (fresh.has(KEY) && !stale.has(KEY)) {
+    pass('role key honours scan_history.recheck_after_days (cannot outlive the URL key)');
+  } else {
+    fail(`recheck TTL not honoured — inside window: ${fresh.has(KEY)}, past window: ${stale.has(KEY)}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 5. applications.md still seeds (no regression) ──────────────────────────
+// Header-aware parse (#954) must keep working, including a customized layout
+// with an extra column that no consumer recognizes.
+{
+  const sb = sandbox({
+    tracker: `# Applications Tracker
+
+| # | Date | Company | Priority | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|----------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-01-01 | Anduril | high | Strategic Finance | 4.0/5 | Applied | ✅ | — | seed row |
+`,
+  });
+  const seen = seenFor(sb);
+  if (seen.has(KEY) && seen.size === 1) {
+    pass('applications.md still seeds the key, unknown extra column skipped');
+  } else {
+    fail(`applications.md seeding regressed — [${[...seen].join(', ')}]`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 6. Header and separator cells are not roles ─────────────────────────────
+{
+  const sb = sandbox({
+    history: `${HISTORY_HEADER}\nhttps://ex.com/a/1\t2026-07-18\tgreenhouse\tStrategic Finance\tAnduril\tadded\tCosta Mesa\n`,
+    pipeline: '- [ ] https://ex.com/z/9 | --- | :---:\n',
+  });
+  const seen = seenFor(sb);
+  const garbage = [...seen].filter(k => /^[-:]+::|::[-:]+$|^company::/.test(k));
+  if (garbage.length === 0) pass('header and markdown-separator cells never become keys');
+  else fail(`garbage keys seeded: [${garbage.join(', ')}]`);
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 7. Absent sources are not an error ──────────────────────────────────────
+// A fresh install has no scan-history or pipeline yet.
+{
+  const sb = sandbox();
+  try {
+    const seen = seenFor(sb);
+    if (seen.size === 0) pass('absent scan-history/pipeline degrade to an empty set');
+    else fail(`expected an empty set on a fresh install — got [${[...seen].join(', ')}]`);
+  } catch (err) {
+    fail(`absent sources threw: ${err.message}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}

--- a/tests/scan-company-role-dedup.test.mjs
+++ b/tests/scan-company-role-dedup.test.mjs
@@ -10,13 +10,16 @@
 // key in memory only), run 2 re-seeded from applications.md, found the key
 // absent, and the DC req cleared both the URL check and the role check.
 //
-// These exercise `loadSeenCompanyRoles` (the filesystem wrapper) rather than the
-// pure collector, because the defect was in which sources get wired in, not in
-// how any one source is parsed.
-import { pass, fail } from './helpers.mjs';
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
+// The unit checks exercise `loadSeenCompanyRoles` (the filesystem wrapper)
+// rather than the pure collector, because the defect was in which sources get
+// wired in, not in how any one source is parsed. The last check is end-to-end —
+// two real `scan.mjs` runs over a fixture board — because the defect is in the
+// wiring between the loader and main(), which no unit test observes.
+import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { execFileSync } from 'child_process';
 import { loadSeenCompanyRoles, companyRoleDedupKey } from '../scan.mjs';
 
 console.log('\nscan.mjs — company+role dedupe survives between runs');
@@ -172,4 +175,66 @@ const KEY = companyRoleDedupKey('Anduril', 'Strategic Finance');
     fail(`absent sources threw: ${err.message}`);
   }
   rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 8. END-TO-END: two real scan runs over a three-city board ───────────────
+// The only check here that would have caught the original bug. Every unit above
+// passes against a build where main() simply never passes the extra sources —
+// the defect lived in the wiring, so it has to be observed through the CLI.
+//
+// scan.mjs resolves data/ relative to process.cwd(), so the child runs with cwd
+// pinned to a sandbox. The fixture board is reached through local-parser, which
+// requires an in-repo script (realpath-guarded) and runs it with cwd at the repo
+// root — hence the repo-relative `script:` against an absolute portals path.
+// No network is involved.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'scan-e2e-'));
+  try {
+    mkdirSync(join(dir, 'data'), { recursive: true });
+    writeFileSync(join(dir, 'data', 'applications.md'), `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+`);
+    writeFileSync(join(dir, 'data', 'pipeline.md'), '# Pipeline\n\n');
+
+    const portals = join(dir, 'portals.yml');
+    writeFileSync(portals, `title_filter:
+  positive:
+    - "Strategic Finance"
+tracked_companies:
+  - name: Fixture Defense
+    careers_url: https://boards.example.com/fixture
+    parser:
+      command: node
+      script: tests/fixtures/three-city-board.mjs
+`);
+
+    const scan = () => execFileSync(NODE, [join(ROOT, 'scan.mjs')], {
+      cwd: dir,
+      env: { ...process.env, CAREER_OPS_PORTALS: portals },
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const entries = () => {
+      const p = join(dir, 'data', 'pipeline.md');
+      if (!existsSync(p)) return [];
+      return readFileSync(p, 'utf-8').split('\n').filter(l => /^- \[[ x]\]\s+https?:\/\//.test(l));
+    };
+
+    scan();
+    const afterFirst = entries().length;
+    scan();
+    const afterSecond = entries().length;
+
+    if (afterFirst === 1 && afterSecond === 1) {
+      pass('two scan runs over a one-role/three-city board yield exactly 1 pipeline entry');
+    } else {
+      fail(`same-role/different-city leak: ${afterFirst} entr(y/ies) after run 1, ${afterSecond} after run 2 (want 1 and 1)`);
+    }
+  } catch (err) {
+    fail(`e2e scan run failed: ${err.message}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }

--- a/tracker-columns-tests.mjs
+++ b/tracker-columns-tests.mjs
@@ -83,6 +83,17 @@ function makeSandbox(trackerContent, additions = {}) {
   return { dir, tracker, additions: additionsDir, lock };
 }
 
+// Pin scan.mjs's extra dedupe sources inside the sandbox. The module-level
+// paths are relative to process.cwd(), so an in-process call would otherwise
+// read the developer's real data/scan-history.tsv and data/pipeline.md — CI
+// only escapes that because both files are gitignored.
+function sandboxSources(sb) {
+  return {
+    scanHistoryPath: join(sb.dir, 'scan-history.tsv'),
+    pipelinePath: join(sb.dir, 'pipeline.md'),
+  };
+}
+
 // Return the data rows of a tracker (pipe lines that aren't header/separator).
 function dataRows(trackerPath) {
   return readFileSync(trackerPath, 'utf-8')
@@ -201,7 +212,7 @@ const TSV_NO_LOCATION = '2\t2026-02-02\tGlobex\tManager\tApplied\tN/A\t✅\t—\
 {
   const { loadSeenCompanyRoles } = await import('./scan.mjs');
   const sb = makeSandbox(HEADER_10);
-  const seen = loadSeenCompanyRoles(sb.tracker);
+  const seen = loadSeenCompanyRoles(sb.tracker, undefined, sandboxSources(sb));
   if (seen.has('acme::engineer')) pass('scan.mjs: seen-set keys company::role on 10-col tracker');
   else fail(`scan.mjs: seen-set on 10-col tracker — got [${[...seen].join(', ')}]`);
   if (![...seen].some(k => k.includes('remote') || k.includes('4.0/5'))) {
@@ -242,7 +253,7 @@ const TSV_NO_LOCATION = '2\t2026-02-02\tGlobex\tManager\tApplied\tN/A\t✅\t—\
   }
 
   const { loadSeenCompanyRoles } = await import('./scan.mjs');
-  const seen = loadSeenCompanyRoles(sb.tracker);
+  const seen = loadSeenCompanyRoles(sb.tracker, undefined, sandboxSources(sb));
   if (seen.has('acme::engineer') && seen.size === 1) {
     pass('contract: scan.mjs seen-set skips an unknown extra column');
   } else {


### PR DESCRIPTION
## Summary

`loadSeenUrls` reads all three dedupe sources (`scan-history.tsv`, `pipeline.md`, `applications.md`). Its company+role counterpart, `loadSeenCompanyRoles`, reads `applications.md` alone — which makes the role key effectively **intra-run**. A role surfaced by a prior scan lives in scan-history and pipeline, and does not reach `applications.md` until the user evaluates and applies it.

Companies that open one req per city therefore leak one city variant into `pipeline.md` per scan, indefinitely.

## Reproduction

A board posting one role in three cities (Costa Mesa / DC / Huntsville), scanned repeatedly:

| run | what happens | pipeline entries |
|-----|--------------|------------------|
| 1 | Costa Mesa added; key marked in memory; DC + Huntsville skipped intra-run | 1 |
| 2 | key re-seeded from applications.md (absent); Costa Mesa blocked by `seenUrls`; DC passes both checks | 2 |
| 3 | same, Huntsville passes | 3 |

Observed on Anduril (Strategic Finance; Director BD — Costa Mesa/DC/Huntsville/Remote), Brex (BizOps Sr Manager — SF/NY/Seattle) and Harvey (GTM Strategic Finance Lead — SF/NY).

Direct A/B against current `main`, with a role recorded as `added` in scan-history but not yet in the tracker:

```
BEFORE  seen set: []                            → NO  — next scan leaks another city
AFTER   seen set: [anduril::strategic finance]  → YES — variants blocked
```

## What this does not change

An earlier version of this fix also replaced the positional regex in `loadSeenCompanyRoles`. #954 already fixed that with the header-aware `tracker-parse.mjs` parse, which handles customized layouts a regex cannot — so that parse is kept as-is. Company aliasing (`buildCompanyCanonicalizer`) and `normalizeRoleForDedup` are likewise untouched; this PR only changes **which sources seed the set**.

## Semantics

Two deliberate choices on the scan-history source:

- **Only `added` rows seed a key.** `skipped_expired` / `skipped_invalid_url` / `skipped_blocked_host` are URL-level failures, not evidence the role was surfaced — seeding from them would let a dead Costa Mesa URL permanently bury a live DC req. Because an expired posting is recorded as `skipped_expired` rather than `added`, this self-heals: when the canonical posting dies, its city variants become eligible again on the next scan.
- **Seeding honours `scan_history.recheck_after_days`** via the existing `shouldDedupScanHistoryRow` predicate, so the role key cannot outlive the URL key it mirrors.

## A latent test-hermeticity issue this surfaced

`SCAN_HISTORY_PATH` and `PIPELINE_PATH` are relative strings resolved against `process.cwd()`. The existing `loadSeenCompanyRoles` tests in `tracker-columns-tests.mjs` pass only a sandbox tracker, so once the function reads the other two sources it would pick up the developer's **real** `data/scan-history.tsv` and `data/pipeline.md`. CI does not catch this because both files are gitignored — but Test 7 asserts `seen.size === 1`, so it fails on any working checkout that has scanned.

`loadSeenCompanyRoles` therefore keeps its two leading positional parameters (existing callers unaffected) and takes the extra sources through a trailing options object; the two existing call sites are pinned to sandbox paths.

## Tests

New discovered suite `tests/scan-company-role-dedup.test.mjs`, 9 assertions:

- the cross-run leak — a scan-history `added` row seeds the key
- `pipeline.md` seeding across the bare 3-column, location-column, and checked-with-trailing-segments forms
- `skipped_expired` / `skipped_invalid_url` / `skipped_blocked_host` do **not** seed (variant can resurface)
- seeding honours the recheck TTL
- no regression on `applications.md` seeding, including an unrecognized extra column
- header and markdown-separator cells never become keys
- absent scan-history/pipeline degrade to an empty set

**Six of the nine fail against current `main`.** Full suite: 2009 → 2018 passed, 0 failed, same 1 pre-existing warning.

## Known gap

This does not include an end-to-end test driving two real `scan.mjs` runs over a fixture board. `local-parser` realpath-guards `parser.script` to inside `PROJECT_ROOT`, so such a fixture has to live in-repo. The assertions here exercise `loadSeenCompanyRoles` (the filesystem wrapper) rather than the pure collector, so the source-wiring is covered; what remains uncovered is whether `main()` invokes it correctly. Happy to add the e2e in a follow-up if you'd like it in-tree.

## Note for the maintainer

Same-role/different-city stays a dedup side effect: the first city req wins, the rest count as dupes. Making it first-class (collapsing to one canonical posting and recording alternate locations) is a reasonable follow-up but is out of scope here — the self-healing property above means nothing is permanently lost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened company+role deduplication by considering applications, scan history, and pipeline entries.
  * Enforced recheck eligibility consistently across runs and tracker status types.
  * Improved handling of customized tracker layouts while ignoring headers/separators and non-qualifying statuses.
* **Tests**
  * Added end-to-end and unit coverage for cross-run dedupe, recheck windows, missing optional files, and varied tracker formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->