### PR TITLE
fix(scan): word-boundary location keywords + URL location fallback

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -300,7 +300,9 @@ export function filterBlacklistedOffers(offers, blacklist, { includeBlacklisted 
 // order in two places for the caller that doesn't need per-stage counts.
 export function passesFilters(job, { titleFilter, locationFilter, contentFilter, titleFilterConfig }) {
   if (!titleFilter(job.title)) return false;
-  if (!locationFilter(job.location)) return false;
+  // job.url is passed so the location filter can fall back to the URL's own
+  // location segment when the provider reports a rolled-up "N Locations" string.
+  if (!locationFilter(job.location, job.url)) return false;
   if (contentFilter && !contentFilter(job.description, matchedTitleKeywords(job.title, titleFilterConfig))) return false;
   return true;
 }
@@ -538,7 +540,7 @@ async function main() {
           if (dateClass === 'stale') continue;
           if (dateClass === 'undated' && !opts.includeUndated) { droppedNoDate++; continue; }
           if (!titleFilter(job.title)) continue;
-          if (!locationFilter(job.location)) continue;
+          if (!locationFilter(job.location, job.url)) continue;
           if (!contentFilter(job.description, matchedTitleKeywords(job.title, config?.title_filter))) { droppedContent++; continue; }
           const dedupUrl = normalizeUrlForDedup(job.url);
           if (seenUrls.has(dedupUrl)) continue;

--- a/scan.mjs
+++ b/scan.mjs
@@ -161,19 +161,89 @@ function normalizeKeywordList(value) {
     .filter(Boolean);
 }
 
+// Compile a location keyword into a word-boundary matcher.
+//
+// Plain String.includes() is wrong for location keywords because country and
+// city names are prefixes of unrelated US place names. The motivating bug:
+// blocking "india" also rejected "Indian Head, MD", "Indiana", and
+// "Indianapolis" — real US locations, silently dropped from every scan.
+// Likewise "china" would swallow "Chinatown" and "uk -" would swallow "Truck -".
+//
+// Lookarounds rather than \b so keywords that begin or end with punctuation
+// (", IND", "UK -") still anchor correctly — \b is defined relative to word
+// characters and behaves surprisingly at a punctuation edge.
+// Note: distinct from compileKeyword() above, which serves the *title* filter and
+// only boundary-anchors 2-3 letter acronyms. Location keywords need boundaries on
+// every keyword, so they get their own compiler rather than changing title-matching
+// behaviour. Returns a predicate, mirroring compileKeyword()'s shape.
+function compileLocationKeyword(keyword) {
+  const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const startsWord = /[a-z0-9]/.test(keyword[0]);
+  const endsWord = /[a-z0-9]/.test(keyword[keyword.length - 1]);
+  const prefix = startsWord ? '(?<![a-z0-9])' : '';
+  const suffix = endsWord ? '(?![a-z0-9])' : '';
+  const re = new RegExp(`${prefix}${escaped}${suffix}`);
+  return (lower) => re.test(lower);
+}
+
+function compileLocationKeywordList(value) {
+  return normalizeKeywordList(value).map(compileLocationKeyword);
+}
+
+// Some providers report a rolled-up display string ("5 Locations", "2 Locations")
+// while the canonical URL still names the real primary location. Workday is the
+// common case: .../job/Hyderabad-Telangana-India/Network-Engineer_R-65193-1 shows
+// up as "5 Locations", so no `block` keyword can ever match the location field.
+// Recover that signal by reading the path segment right after `/job/`.
+//
+// Deliberately narrow: only the post-`/job/` segment is inspected, never the whole
+// URL. Scanning the full URL would match company slugs and ATS subdomains by
+// accident (a "china" or "india" substring inside an unrelated path). Providers
+// without the `/job/{location}/` convention (Greenhouse, Lever, Ashby) yield no
+// hint and keep their previous behaviour exactly.
+export function locationHintFromUrl(url) {
+  if (typeof url !== 'string' || url.trim() === '') return '';
+  let pathname;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return '';
+  }
+  const segments = pathname.split('/').filter(Boolean);
+  const jobIdx = segments.lastIndexOf('job');
+  if (jobIdx === -1 || jobIdx === segments.length - 1) return '';
+  let segment = segments[jobIdx + 1];
+  try {
+    segment = decodeURIComponent(segment);
+  } catch {
+    // Malformed percent-encoding — fall back to the raw segment.
+  }
+  // "Hyderabad-Telangana-India" → "hyderabad telangana india" so multi-word
+  // block keywords like "united arab emirates" can still match.
+  return segment.replace(/[-_+]+/g, ' ').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+// `url` is optional. Callers that omit it get the original location-only
+// semantics, which is what the existing unit tests exercise.
 export function buildLocationFilter(locationFilter) {
   if (!locationFilter) return () => true;
-  const alwaysAllow = normalizeKeywordList(locationFilter.always_allow);
-  const allow = normalizeKeywordList(locationFilter.allow);
-  const block = normalizeKeywordList(locationFilter.block);
+  const alwaysAllow = compileLocationKeywordList(locationFilter.always_allow);
+  const allow = compileLocationKeywordList(locationFilter.allow);
+  const block = compileLocationKeywordList(locationFilter.block);
 
-  return (location) => {
-    if (typeof location !== 'string' || location.trim() === '') return true;
-    const lower = location.toLowerCase();
-    if (alwaysAllow.length > 0 && alwaysAllow.some(k => lower.includes(k))) return true;
-    if (block.length > 0 && block.some(k => lower.includes(k))) return false;
+  return (location, url) => {
+    const lower = typeof location === 'string' ? location.trim().toLowerCase() : '';
+    const hint = locationHintFromUrl(url);
+    // Nothing to judge on either field → pass (don't penalize missing data).
+    if (lower === '' && hint === '') return true;
+    const matches = (m) => (lower !== '' && m(lower)) || (hint !== '' && m(hint));
+    // always_allow still wins over block, and may be satisfied by either field:
+    // a genuinely US role whose display string says "United States" is never
+    // rejected because of what its URL happens to contain.
+    if (alwaysAllow.length > 0 && alwaysAllow.some(matches)) return true;
+    if (block.length > 0 && block.some(matches)) return false;
     if (allow.length === 0) return true;
-    return allow.some(k => lower.includes(k));
+    return allow.some(matches);
   };
 }
 
@@ -1830,7 +1900,7 @@ async function main() {
           totalFilteredTier++;
           continue;
         }
-        if (!locationFilter(job.location)) {
+        if (!locationFilter(job.location, job.url)) {
           totalFilteredLocation++;
           continue;
         }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3650,6 +3650,7 @@ console.log('\n13. Location filter — always_allow tier');
 try {
   const {
     buildLocationFilter,
+    locationHintFromUrl,
     buildContentFilter,
     buildPostingAgeFilter,
     buildPostedDateFilter,
@@ -3829,6 +3830,95 @@ try {
   // step rather than being silently dropped here.
   if (filter(42) === true) pass('non-string locations are passed through to downstream evaluation, not silently dropped');
   else fail('non-string locations should pass through');
+
+  // Case 16: URL location hint — rolled-up display strings ("5 Locations") hide the
+  // real location, which the Workday URL still names. Motivating real case: Kyndryl
+  // postings that render as "5 Locations" with a .../job/Hyderabad-Telangana-India/... URL.
+  const urlFilter = buildLocationFilter({
+    always_allow: ['united states'],
+    block: ['india', 'hyderabad', 'germany'],
+  });
+  if (urlFilter('5 Locations', 'https://kyndryl.wd5.myworkdayjobs.com/careers/job/Hyderabad-Telangana-India/Network-Engineer_R-65193-1') === false) {
+    pass('URL hint rejects a rolled-up "5 Locations" row whose canonical URL is India');
+  } else {
+    fail('"5 Locations" + Hyderabad URL should be rejected via the URL location hint');
+  }
+
+  // Case 17: always_allow still wins over a blocked URL hint — a genuinely US role is
+  // never dropped because of what its URL happens to contain.
+  if (urlFilter('New York, United States', 'https://x.wd5.myworkdayjobs.com/c/job/Hyderabad-Telangana-India/Eng_R1') === true) {
+    pass('always_allow on the display string beats a blocked URL hint');
+  } else {
+    fail('an explicit "United States" location must survive a blocked URL hint');
+  }
+
+  // Case 18: providers without the /job/{location}/ convention are unaffected
+  if (
+    locationHintFromUrl('https://jobs.ashbyhq.com/snowflake/4fe8d816') === '' &&
+    locationHintFromUrl('https://boards.greenhouse.io/acme/jobs/12345') === '' &&
+    locationHintFromUrl('not a url') === '' &&
+    locationHintFromUrl('') === '' &&
+    locationHintFromUrl(null) === ''
+  ) {
+    pass('locationHintFromUrl yields no hint for non-Workday, malformed, and empty URLs');
+  } else {
+    fail('locationHintFromUrl should return "" for URLs without a /job/{location}/ segment');
+  }
+
+  // Case 19: hint normalization — separators become spaces so multi-word keywords match
+  if (
+    locationHintFromUrl('https://x.wd1.myworkdayjobs.com/c/job/Hyderabad-Telangana-India/Eng_R1') === 'hyderabad telangana india' &&
+    locationHintFromUrl('https://x.wd1.myworkdayjobs.com/c/job/USA---El-Segundo-CA/Eng_R1') === 'usa el segundo ca'
+  ) {
+    pass('URL hint normalizes separators to spaces and lowercases');
+  } else {
+    fail(`URL hint normalization wrong: got "${locationHintFromUrl('https://x.wd1.myworkdayjobs.com/c/job/Hyderabad-Telangana-India/Eng_R1')}"`);
+  }
+
+  // Case 20: omitting the url argument preserves the original location-only behaviour
+  if (urlFilter('Bengaluru, India') === false && urlFilter('Austin, TX') === true) {
+    pass('calling the filter without a url keeps original location-only semantics');
+  } else {
+    fail('single-argument calls must behave exactly as before the url-hint change');
+  }
+
+  // Case 21: keywords match on word boundaries, not raw substrings. Blocking "india"
+  // must NOT reject the US locations Indian Head MD, Indiana, or Indianapolis — the
+  // substring bug that silently dropped real US roles from every scan.
+  const boundaryFilter = buildLocationFilter({ block: ['india', 'china', 'uk -'] });
+  if (
+    boundaryFilter('Indian Head, MD') === true &&
+    boundaryFilter('Indianapolis, IN') === true &&
+    boundaryFilter('West Lafayette, Indiana') === true &&
+    boundaryFilter('Chinatown, San Francisco') === true &&
+    boundaryFilter('Truck - Depot') === true
+  ) {
+    pass('block keywords honour word boundaries (Indiana/Indian Head/Indianapolis/Chinatown not rejected)');
+  } else {
+    fail('word-boundary matching failed — a substring match is silently dropping US locations');
+  }
+
+  // Case 22: ...while the genuine country matches still get blocked
+  if (
+    boundaryFilter('Hyderabad, India') === false &&
+    boundaryFilter('India') === false &&
+    boundaryFilter('Beijing, China') === false &&
+    boundaryFilter('UK - London') === false
+  ) {
+    pass('word-boundary matching still blocks the real country/region hits');
+  } else {
+    fail('word-boundary matching must not weaken genuine block hits');
+  }
+
+  // Case 23: boundary matching applies to the URL hint too
+  if (
+    boundaryFilter('5 Locations', 'https://x.wd1.myworkdayjobs.com/c/job/Hyderabad-Telangana-India/Eng_R1') === false &&
+    boundaryFilter('5 Locations', 'https://x.wd1.myworkdayjobs.com/c/job/Indianapolis-Indiana/Eng_R1') === true
+  ) {
+    pass('URL hint is boundary-matched as well (Indianapolis URL survives, India URL does not)');
+  } else {
+    fail('URL hint must use the same word-boundary matching as the location string');
+  }
 
   if (
     shouldDedupScanHistoryRow({ firstSeen: '2026-06-01', status: 'added' }, { recheckAfterDays: 30, today: '2026-06-10' }) === true &&


### PR DESCRIPTION
## What does this PR do?

Fixes two defects in the scan location filter. The first silently drops real US roles from every scan; the second lets blocked countries through when the ATS reports a rolled-up location string.

## Related issue

None — bug fix, sent straight in per CONTRIBUTING.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

---

### 1. Block keywords matched as raw substrings

`buildLocationFilter()` used `String.includes()`, so a keyword rejected any location that merely *contained* it. Country and city names are prefixes of unrelated US place names:

| Block keyword | Also rejected (all real US locations) |
|---|---|
| `india` | **Indian Head, MD** · **Indiana** · **Indianapolis** |
| `china` | Chinatown, San Francisco |
| `uk -` | Truck - Depot |

Nothing surfaces this to the user — the postings are counted as "filtered by location" and never seen. I hit it on a live scan: a `bah` posting in Indian Head, MD was dropped because of the `india` entry in my block list.

Location keywords are now compiled with word-boundary lookarounds. Lookarounds rather than `\b` so keywords that begin or end with punctuation (`", IND"`, `"UK -"`) still anchor correctly — `\b` is defined relative to word characters and behaves surprisingly at a punctuation edge.

This is deliberately a **separate compiler** from the existing `compileKeyword()`, which serves the title filter and intentionally boundary-anchors only 2–3 letter acronyms. Reusing it would have weakened location matching; changing it would have altered title matching everywhere.

**Config-visible behaviour change:** a keyword no longer matches longer words, so `"Milan"` no longer matches `"Milano"`. Configs relying on prefix matching need both listed. This only affects `location_filter`; `title_filter` is untouched. Worth a line in the release notes.

### 2. Rolled-up location strings hid the real location

Some providers report `"5 Locations"` / `"2 Locations"` as the location while the canonical URL still names the primary one. Workday is the common case:

```
display:  5 Locations
url:      .../job/Hyderabad-Telangana-India/Network-Engineer_R-65193-1
```

No `block` keyword can match `"5 Locations"`, so these always passed. On one scan of mine this put 13 India/Spain/Germany/Australia postings into the pipeline despite those countries being blocked.

`buildLocationFilter()` now takes an optional `url` and recovers a location hint from the path segment after `/job/`. Deliberately narrow:

- **Only that segment is read, never the whole URL.** Scanning the full URL would match company slugs and ATS subdomains by accident (a stray `china` or `india` substring in an unrelated path).
- Providers without the `/job/{location}/` convention (Greenhouse, Lever, Ashby) yield no hint and behave exactly as before.
- `always_allow` is still checked before `block` and may be satisfied by **either** field, so a role whose display string says "United States" is never rejected over what its URL happens to contain.
- The `url` argument is optional — single-argument calls keep the previous location-only semantics.

Call sites updated: `scan.mjs`, and `passesFilters()` + the seed-scan loop in `scan-ats-full.mjs`.

## Testing

8 new cases in `test-all.mjs` covering: the Indiana/Indian Head/Indianapolis/Chinatown regressions, that genuine country hits still block, hint extraction and normalization, non-Workday and malformed URLs, `always_allow` beating a blocked URL hint, boundary matching applied to the hint, and single-argument backward compatibility.

```
node test-all.mjs → 2034 passed, 0 failed
```

Verified against live scan data before and after: the Indian Head posting is retained, and the 13 rolled-up postings with blocked canonical URLs are now correctly rejected.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved location filtering to reduce false matches for similar place names.
  - Location checks now also consider relevant posting URL details, improving accuracy for listings with broad or rolled-up location labels.
  - Preserved location-only filtering behavior when URL information is unavailable.
  - Confirmed that approved locations can override blocked URL-derived hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->