### PR TITLE
fix(pdf): apply CV section-order check to non-English CVs

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -111,7 +111,35 @@ function normalizeTextForATS(html) {
   }
 }
 
+/**
+ * Strip diacritics so a heading is recognized regardless of how it was typed.
+ *
+ * Rendered Polish headings are not always spelled with their diacritics —
+ * "Wykształcenie" and "Wyksztalcenie" both occur in already-generated CVs.
+ * NFD splits most Polish letters into a base plus a combining mark we drop;
+ * ł (U+0142) has no canonical decomposition, so it needs its own pass.
+ *
+ * Only used for alias lookup — display titles keep their diacritics.
+ */
+function foldDiacritics(text) {
+  return text
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/ł/g, 'l');
+}
+
+/**
+ * Heading spelling -> canonical section key.
+ *
+ * Polish (modes/pl) is here because without these aliases the rendered Polish
+ * titles match nothing derived from the English cv.md: validateCvSectionOrder()
+ * finds fewer than two comparable sections and silently returns, leaving the
+ * section-order guard disabled on every CV rendered in that mode.
+ *
+ * Keys are folded on construction so authored diacritics match stripped input.
+ */
 const SECTION_ALIASES = new Map([
+  // English — cv.md is the source of truth and is written in English.
   ['summary', 'summary'],
   ['professional summary', 'summary'],
   ['competencies', 'competencies'],
@@ -127,7 +155,30 @@ const SECTION_ALIASES = new Map([
   ['certifications', 'certifications'],
   ['skills', 'skills'],
   ['technical skills', 'skills'],
-]);
+  // Polish — the vocabulary documented in modes/pl/README.md, plus the word-order
+  // variants that turn up in practice (both "Kompetencje kluczowe" and
+  // "Kluczowe kompetencje" are used for the same section).
+  ['podsumowanie', 'summary'],
+  ['podsumowanie zawodowe', 'summary'],
+  ['profil zawodowy', 'summary'],
+  ['kompetencje', 'competencies'],
+  ['kompetencje kluczowe', 'competencies'],
+  ['kluczowe kompetencje', 'competencies'],
+  ['doświadczenie', 'experience'],
+  ['doświadczenie zawodowe', 'experience'],
+  ['przebieg kariery', 'experience'],
+  ['projekty', 'projects'],
+  ['kluczowe projekty', 'projects'],
+  ['wybrane projekty', 'projects'],
+  ['wykształcenie', 'education'],
+  ['edukacja', 'education'],
+  ['wykształcenie i certyfikaty', 'education'],
+  ['certyfikaty', 'certifications'],
+  ['certyfikaty i szkolenia', 'certifications'],
+  ['szkolenia i certyfikaty', 'certifications'],
+  ['umiejętności', 'skills'],
+  ['umiejętności techniczne', 'skills'],
+].map(([alias, key]) => [foldDiacritics(alias), key]));
 
 function normalizeSectionTitle(text) {
   return text
@@ -141,7 +192,7 @@ function normalizeSectionTitle(text) {
 }
 
 function sectionKey(text) {
-  const normalized = normalizeSectionTitle(text);
+  const normalized = foldDiacritics(normalizeSectionTitle(text));
   return SECTION_ALIASES.get(normalized) ?? normalized;
 }
 
@@ -611,4 +662,4 @@ if (isMain) {
   });
 }
 
-export { normalizeTextForATS };
+export { normalizeTextForATS, sectionKey };

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1307,6 +1307,114 @@ if (
   fail('batch Machine Summary and downstream parser fields are misaligned');
 }
 
+// ── 7e. CV SECTION ORDER CHECK IS LANGUAGE-AWARE ────────────────
+
+// SECTION_ALIASES held English titles only, so a CV rendered in one of the
+// shipped non-English modes produced zero sections comparable against the
+// English cv.md: validateCvSectionOrder() saw fewer than two comparable
+// sections and early-returned, and the guard silently did nothing. Polish
+// (modes/pl) is covered here — a Polish CV that hoisted Education above
+// Doświadczenie zawodowe used to render without complaint while the identical
+// English CV was correctly rejected.
+
+console.log('\n7e. CV section order check is language-aware');
+
+for (const header of ['podsumowanie zawodowe', 'doświadczenie zawodowe', 'wykształcenie', 'certyfikaty', 'umiejętności']) {
+  if (generatePdfScript.includes(`['${header}',`)) {
+    pass(`SECTION_ALIASES maps Polish header: ${header}`);
+  } else {
+    fail(`SECTION_ALIASES missing Polish header: ${header}`);
+  }
+}
+
+// generate-pdf.mjs imports playwright at module scope; degrade to a warning
+// rather than crashing the suite where it is not installed.
+let pdfModule = null;
+try {
+  pdfModule = await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
+} catch (e) {
+  warn(`Cannot import generate-pdf.mjs (${e.code || e.message}) — skipping behavioral section-order tests`);
+}
+
+if (pdfModule) {
+  const { sectionKey, validateCvSectionOrder } = pdfModule;
+
+  // Canonical keys are language-independent; only the spelling differs.
+  const keyCases = [
+    ['Podsumowanie zawodowe', 'summary'],
+    ['Kompetencje kluczowe', 'competencies'],
+    ['Kluczowe kompetencje', 'competencies'], // word-order variant
+    ['Doświadczenie zawodowe', 'experience'],
+    ['Przebieg kariery', 'experience'],
+    ['Wykształcenie', 'education'],
+    ['Certyfikaty', 'certifications'],
+    ['Umiejętności', 'skills'],
+    ['Wyksztalcenie', 'education'],  // diacritics stripped
+    ['Umiejetnosci', 'skills'],      // diacritics stripped
+    ['Work Experience', 'experience'], // English must be unchanged
+    ['Core Competencies', 'competencies'],
+  ];
+  let keysOk = true;
+  for (const [title, expected] of keyCases) {
+    const actual = sectionKey(title);
+    if (actual !== expected) {
+      fail(`sectionKey("${title}") = "${actual}", expected "${expected}"`);
+      keysOk = false;
+    }
+  }
+  if (keysOk) pass(`sectionKey resolves all ${keyCases.length} PL/EN heading spellings`);
+
+  // Hermetic cv.md stand-in: passed in directly, so the test does not depend on
+  // a cv.md existing in the checkout (it is gitignored).
+  const cvMd = [
+    '# CV', '## Professional Summary', '## Work Experience',
+    '## Education', '## Certifications', '## Skills',
+  ].join('\n');
+  const titlesToHtml = titles => titles.map(t => `<div class="section-title">${t}</div>`).join('\n');
+
+  const plCorrect = titlesToHtml([
+    'Podsumowanie zawodowe', 'Kompetencje kluczowe', 'Doświadczenie zawodowe',
+    'Wykształcenie', 'Certyfikaty', 'Umiejętności',
+  ]);
+  // Education hoisted above Work Experience — the divergence the guard exists to catch.
+  const plMisordered = titlesToHtml([
+    'Podsumowanie zawodowe', 'Wykształcenie', 'Doświadczenie zawodowe',
+  ]);
+  const enMisordered = titlesToHtml([
+    'Professional Summary', 'Education', 'Work Experience',
+  ]);
+
+  const throws = (html, opts) => {
+    try { validateCvSectionOrder(html, cvMd, opts); return false; } catch { return true; }
+  };
+
+  if (throws(plMisordered)) {
+    pass('Polish CV with Education before Work Experience is rejected');
+  } else {
+    fail('Polish CV with Education before Work Experience was NOT rejected (guard is a no-op)');
+  }
+
+  if (!throws(plCorrect)) {
+    pass('Polish CV in cv.md order is accepted');
+  } else {
+    fail('Polish CV in cv.md order was wrongly rejected');
+  }
+
+  if (throws(enMisordered)) {
+    pass('English CV order check still rejects divergence (no regression)');
+  } else {
+    fail('English CV order check regressed');
+  }
+
+  // --allow-reorder must keep downgrading the divergence to a warning now that
+  // Polish CVs actually reach this code path.
+  if (!throws(plMisordered, { allowReorder: true })) {
+    pass('allowReorder downgrades Polish divergence to a warning');
+  } else {
+    fail('allowReorder did not suppress Polish divergence');
+  }
+}
+
 // ── 8. MODE FILE INTEGRITY ──────────────────────────────────────
 
 console.log('\n8. Mode file integrity');


### PR DESCRIPTION
SECTION_ALIASES held English section titles only. A CV rendered in one of the shipped non-English modes therefore produced zero sections comparable against the English cv.md: validateCvSectionOrder() found fewer than two comparable sections and early-returned, so the guard silently did nothing.

Reproduction (Polish, modes/pl): render a CV from templates/cv-template.html with Education above Work Experience. The English version is correctly rejected with "CV section order diverges from cv.md"; the identical Polish version renders with no error at all.

This adds Polish aliases mapping onto the existing canonical keys, using the vocabulary already documented in modes/pl/README.md plus the word-order variants that occur in practice ("Kompetencje kluczowe" / "Kluczowe kompetencje"). Lookup now folds diacritics, because rendered headings are not reliably spelled with them; ł has no canonical NFD decomposition and needs its own pass. Display titles keep their diacritics, so error messages are unchanged.

English behaviour is unchanged — folding is the identity on ASCII, and the English alias entries are untouched.

Tests (7e) cover alias resolution, both diacritic spellings, the rejection that previously did not happen, an accepted in-order Polish CV, the English path as a regression guard, and that --allow-reorder still downgrades the divergence to a warning now that these CVs reach that code path. They pass cv.md content in directly, so they do not depend on a gitignored cv.md, and they degrade to a warning where playwright is not installed.

Only Polish is added here; the same mechanism extends to the other shipped language modes if wanted.

## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- Link the issue this PR addresses, if it has one. Format: Fixes #123 / Closes #123 -->
<!-- Issue-first is asked for NEW FEATURES, new modes/commands, and architecture changes — it saves you from building something we'd have to redirect. -->
<!-- No issue needed, send the PR straight in: bug fixes, new zero-auth scanner providers, docs, and translations. We don't want to slow these down. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [ ] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ ] I ran `node test-all.mjs` and all tests pass
- [ ] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CV section-order validation for Polish headings, including accented and unaccented spellings.
  * Ensured Polish and English CV templates are consistently checked against the expected section order.
  * Preserved the option to allow custom section ordering when enabled.

* **Tests**
  * Added coverage for language-aware section matching and validation across Polish and English CVs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->