### PR TITLE
fix(scan): lowercase path in normalizeUrlForDedup to catch cross-scanner duplicates

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -660,9 +660,22 @@ const DEDUP_STRIP_PARAMS = new Set([
  * Normalize a job posting URL into a stable dedup key.
  *
  * Strips cosmetic query params (locale/tracking), drops a trailing slash,
- * and lowercases scheme + host. Only used to compute the *comparison* key —
- * callers keep writing/displaying the original URL so links stay clickable
- * and scan-history/pipeline.md stay faithful to what the provider returned.
+ * and lowercases scheme, host, and path. Only used to compute the
+ * *comparison* key — callers keep writing/displaying the original URL so
+ * links stay clickable and scan-history/pipeline.md stay faithful to what
+ * the provider returned.
+ *
+ * The path is lowercased because scan.mjs and scan-ats-full.mjs run as
+ * separate processes and can independently produce different casing for the
+ * identical posting — a Workday tenant/site path segment reached via the
+ * curated portals.yml entry vs. the reverse-ATS dataset, for instance. A
+ * case-sensitive key silently treats those as two distinct URLs, so the same
+ * role lands in pipeline.md twice. Path casing is not meaningfully distinct
+ * for any provider these scanners target.
+ *
+ * Query *values* keep their original casing — those can be identity-bearing
+ * (Greenhouse's `gh_jid`), which is also why DEDUP_STRIP_PARAMS is an
+ * allowlist rather than a blanket strip.
  *
  * Falls back to the raw string when the URL is malformed, preserving the
  * old byte-for-byte behavior for unparsable history rows.
@@ -684,7 +697,7 @@ export function normalizeUrlForDedup(url) {
     }
   }
   parsed.hash = '';
-  parsed.pathname = parsed.pathname.replace(/\/+$/, '') || '/';
+  parsed.pathname = parsed.pathname.replace(/\/+$/, '').toLowerCase() || '/';
   return parsed.toString();
 }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2044,6 +2044,25 @@ try {
     fail(`scan.mjs normalizeUrlForDedup wrong: withLang=${normalizeUrlForDedup(withLang)} withTrailingSlash=${normalizeUrlForDedup(withTrailingSlash)} withUtm=${normalizeUrlForDedup(withUtm)} ghJid=${normalizeUrlForDedup(ghJid)} malformed=${normalizeUrlForDedup(malformed)}`);
   }
 
+  // Path casing: scan.mjs and scan-ats-full.mjs can reach the identical Workday
+  // posting via different path casing (curated portals.yml entry vs. reverse-ATS
+  // dataset). A case-sensitive key files them as two roles and pipeline.md gets
+  // a duplicate, so the path is lowercased.
+  const wdMixed = 'https://Kyndryl.wd5.myworkdayjobs.com/KyndrylProfessionalCareers/job/Network-Engineer_R-64949';
+  const wdLower = 'https://kyndryl.wd5.myworkdayjobs.com/kyndrylprofessionalcareers/job/network-engineer_r-64949';
+  if (normalizeUrlForDedup(wdMixed) === normalizeUrlForDedup(wdLower)) {
+    pass('normalizeUrlForDedup collapses a case-only path difference (same posting via two scanners)');
+  } else {
+    fail(`normalizeUrlForDedup left a case-only duplicate: ${normalizeUrlForDedup(wdMixed)} vs ${normalizeUrlForDedup(wdLower)}`);
+  }
+
+  // ...but query values stay case-sensitive: they can be identity-bearing.
+  if (normalizeUrlForDedup('https://boards.greenhouse.io/acme/jobs/9?gh_jid=AbC').includes('gh_jid=AbC')) {
+    pass('normalizeUrlForDedup preserves query-value casing (identity-bearing params)');
+  } else {
+    fail('normalizeUrlForDedup must not lowercase query values — gh_jid is identity-bearing');
+  }
+
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-seen-urls-'));
   const originalCwd = process.cwd();
   try {


### PR DESCRIPTION
## What does this PR do?

`normalizeUrlForDedup()` lowercases scheme and host (a side effect of `new URL()`) but leaves the **path** untouched, so the same posting reached with different path casing produces two different dedup keys and gets appended to `pipeline.md` twice.

## Related issue

None — bug fix, sent straight in per CONTRIBUTING. Follow-up to #2065, which introduced the function.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

---

### How it happens

`scan.mjs` and `scan-ats-full.mjs` run as separate processes and reach the same board by different routes — a curated `portals.yml` entry vs. the reverse-ATS dataset. Workday tenant/site path segments come back with different casing depending on the route:

```
https://Kyndryl.wd5.myworkdayjobs.com/KyndrylProfessionalCareers/job/Network-Engineer_R-64949
https://kyndryl.wd5.myworkdayjobs.com/kyndrylprofessionalcareers/job/network-engineer_r-64949
```

Both are the same posting. Host casing is normalized away, but the path isn't, so `seenUrls` holds two entries and the role is written to `pipeline.md` twice. I hit this on a live scan — the duplicates survive into the pipeline and then have to be culled by hand.

### The fix

Lowercase the path as part of the dedup key. Path casing is not meaningfully distinct for any provider these scanners target (Greenhouse, Lever, Ashby, Workday).

**Query values deliberately keep their casing.** They can be identity-bearing — Greenhouse's `gh_jid` is the motivating example, and it's the same reason `DEDUP_STRIP_PARAMS` is an allowlist rather than a blanket strip. Lowercasing them could collapse genuinely distinct roles, which is the failure mode worth avoiding here.

Only the *comparison* key changes. Callers still write and display the original URL, so links stay clickable and `scan-history.tsv` / `pipeline.md` stay faithful to what the provider returned.

### Compatibility note for reviewers

Existing `scan-history.tsv` rows were keyed with mixed-case paths. After this change a previously-seen posting whose stored path had uppercase characters can be re-added once, since the new key won't match the old row. It self-corrects on the following scan. Worth a release-note line; happy to add a one-time migration instead if you'd prefer that.

## Testing

2 new cases next to the existing `normalizeUrlForDedup` block: a case-only path difference collapses to one key, and query-value casing survives.

```
node test-all.mjs → 2028 passed, 0 failed
```

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection for URLs that differ only in hostname or path capitalization.
  * Preserved case sensitivity for identity-bearing query parameters, preventing distinct postings from being incorrectly merged.

* **Tests**
  * Added coverage for case-insensitive URL deduplication and case-sensitive query parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->