### PR TITLE
feat(scan): country-eligibility filter — detect US-only vs US+Canada remote postings from JD body text

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -278,6 +278,77 @@ export function buildContentFilter(contentFilter) {
   };
 }
 
+// ── Country-eligibility filter (#2093) ──────────────────────────────
+// Optional, opt-in. If `country_eligibility_filter` is absent from
+// portals.yml, all jobs pass — byte-identical to pre-#2093 behavior.
+//
+// Problem it solves: `location_filter` only reads the ATS provider's
+// STRUCTURED location field (e.g. "Remote"), which many US companies use
+// identically regardless of actual country eligibility. The real
+// restriction — "US-based candidates only" vs. "US or Canada eligible" —
+// often lives only in the JD DESCRIPTION body text, which this filter reads
+// (same field `content_filter` already reads — `job.description`).
+//
+// Semantics (case-insensitive substring), mirroring location_filter's
+// "don't penalize missing data" discipline exactly:
+//   - Candidate's own `location.country` (config/profile.yml) is "United
+//     States" → always pass, unconditionally. An exclusionary "US only"
+//     phrase can never legitimately block a US-based candidate, so the
+//     filter no-ops entirely rather than special-casing every keyword check.
+//   - Empty / whitespace-only / non-string description → pass (no signal).
+//   - No `exclusionary` phrase matched → pass (ambiguous stays ambiguous,
+//     never guessed — this also means an `inclusive`-only match with no
+//     exclusionary wording present is a no-op pass, same as having no
+//     signal at all).
+//   - `exclusionary` phrase matched AND an `inclusive` phrase is also
+//     present → pass (the posting explicitly widens eligibility).
+//   - `exclusionary` phrase matched AND the candidate's own country is
+//     literally named in the JD text (e.g. a Canadian candidate scanning a
+//     posting that separately mentions "Canada" elsewhere) → pass.
+//   - `exclusionary` phrase matched, no `inclusive` phrase, and the
+//     candidate's own country isn't named → reject.
+//
+// Config shape (portals.yml):
+//   country_eligibility_filter:
+//     exclusionary: ["must be located in the united states", ...]
+//     inclusive: ["united states or canada", "north america", ...]
+//
+// Kept as a sibling block to `content_filter` rather than folded into its
+// positive/negative shape: this filter cross-references
+// `config/profile.yml`'s `location.country` and has its own three-way
+// exclusionary/inclusive/candidate-country-named semantics, which doesn't
+// fit content_filter's simpler two-list reject/require shape.
+
+export function buildCountryEligibilityFilter(countryEligibilityFilter, candidateCountry) {
+  if (!countryEligibilityFilter) return () => true;
+
+  const candidateCountryLower = typeof candidateCountry === 'string'
+    ? candidateCountry.toLowerCase().trim()
+    : '';
+
+  // A "US-based candidates only" restriction can never legitimately exclude
+  // a candidate who is themselves US-based — no-op the whole filter rather
+  // than relying on the literal-country-name check below (which would miss
+  // phrasing like "US-based candidates only" that never spells out "united
+  // states").
+  if (candidateCountryLower === 'united states') return () => true;
+
+  const exclusionary = normalizeKeywordList(countryEligibilityFilter.exclusionary);
+  const inclusive = normalizeKeywordList(countryEligibilityFilter.inclusive);
+
+  return (description) => {
+    if (typeof description !== 'string' || description.trim() === '') return true;
+    const lower = description.toLowerCase();
+
+    if (exclusionary.length === 0) return true;
+    if (!exclusionary.some(k => lower.includes(k))) return true;
+    if (inclusive.length > 0 && inclusive.some(k => lower.includes(k))) return true;
+    if (candidateCountryLower && lower.includes(candidateCountryLower)) return true;
+
+    return false;
+  };
+}
+
 // ── Visa / work-authorization filter ────────────────────────────────
 // Optional. If `visa_filter` is absent (or `enabled: false`), all jobs pass.
 // Surfaces roles that sponsor a work visa (H-1B / H-1B1 / O-1 for the US, plus
@@ -435,6 +506,25 @@ export function addDays(dateStr, days) {
   const date = new Date(`${dateStr}T00:00:00Z`);
   date.setUTCDate(date.getUTCDate() + days);
   return date.toISOString().slice(0, 10);
+}
+
+// Reads config/profile.yml's `location.country` (already a documented
+// profile field — see config/profile.example.yml) for the country-
+// eligibility filter (#2093). Missing file, missing field, or a malformed
+// profile all resolve to '' — buildCountryEligibilityFilter treats an empty
+// candidate country the same as "not the candidate's own country's US
+// no-op" and simply skips the literal-country-name pass-through, which is
+// the same conservative "don't penalize missing data" default used
+// throughout this file.
+export function loadCandidateCountry(profilePath = PROFILE_PATH) {
+  if (!existsSync(profilePath)) return '';
+  try {
+    const raw = yaml.load(readFileSync(profilePath, 'utf-8')) || {};
+    const country = raw?.location?.country;
+    return typeof country === 'string' ? country.trim() : '';
+  } catch {
+    return '';
+  }
 }
 
 export function loadReApplyWindows(profilePath = PROFILE_PATH) {
@@ -1383,7 +1473,7 @@ const SCAN_RUNS_PATH = 'data/scan-runs.tsv';
 // 'completed' in v1; a follow-up wires failure-path writes so trend stats can
 // exclude survivorship bias. Consumers MUST parse by header name, never by
 // position — columns may be appended in later versions.
-export const SCAN_RUNS_HEADER = 'timestamp\tstatus\tcompanies\tboards\tfound\tfiltered_title\tfiltered_tier\tfiltered_location\tfiltered_posting_age\tfiltered_salary\tfiltered_content\tfiltered_cooldown\tdupes\tnew_added\terrors\tfiltered_blacklist\tfiltered_visa\tfiltered_posted_date\n';
+export const SCAN_RUNS_HEADER = 'timestamp\tstatus\tcompanies\tboards\tfound\tfiltered_title\tfiltered_tier\tfiltered_location\tfiltered_posting_age\tfiltered_salary\tfiltered_content\tfiltered_cooldown\tdupes\tnew_added\terrors\tfiltered_blacklist\tfiltered_visa\tfiltered_posted_date\tfiltered_country_eligibility\n';
 
 export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
   if (!existsSync(filePath)) writeFileSync(filePath, SCAN_RUNS_HEADER, 'utf-8');
@@ -1399,6 +1489,8 @@ export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
     c.filteredVisa ?? 0,
     // filtered_posted_date appended at the END for the same reason.
     c.filteredPostedDate ?? 0,
+    // filtered_country_eligibility (#2093) appended at the END for the same reason.
+    c.filteredCountryEligibility ?? 0,
   ].join('\t') + '\n';
   appendFileSync(filePath, row, 'utf-8');
 }
@@ -1673,6 +1765,8 @@ async function main() {
   const salaryFilter = buildSalaryFilter(config.salary_filter);
   const trustValidator = buildTrustValidator(config.trust_filter);
   const contentFilter = buildContentFilter(config.content_filter);
+  const candidateCountry = loadCandidateCountry();
+  const countryEligibilityFilter = buildCountryEligibilityFilter(config.country_eligibility_filter, candidateCountry);
   const visaFilter = buildVisaFilter(config.visa_filter);
   const visaEnabled = Boolean(config.visa_filter) && config.visa_filter.enabled !== false;
 
@@ -1759,6 +1853,7 @@ async function main() {
   let totalFilteredPostedDate = 0;
   let totalFilteredSalary = 0;
   let totalFilteredContent = 0;
+  let totalFilteredCountryEligibility = 0;
   let totalFilteredBlacklist = 0;
   let annotatedBlacklisted = 0;
   let totalFilteredVisa = 0;
@@ -1848,6 +1943,10 @@ async function main() {
         }
         if (!contentFilter(job.description, matchedTitleKeywords(job.title, config.title_filter))) {
           totalFilteredContent++;
+          continue;
+        }
+        if (!countryEligibilityFilter(job.description)) {
+          totalFilteredCountryEligibility++;
           continue;
         }
         if (!visaFilter(job.description)) {
@@ -2000,6 +2099,9 @@ async function main() {
   }
   if (config.content_filter || totalFilteredContent > 0) {
     console.log(`Filtered by content:   ${totalFilteredContent} removed`);
+  }
+  if (config.country_eligibility_filter || totalFilteredCountryEligibility > 0) {
+    console.log(`Filtered by country eligibility: ${totalFilteredCountryEligibility} removed`);
   }
   if (visaEnabled) {
     console.log(`Filtered by visa:      ${totalFilteredVisa} removed`);
@@ -2164,6 +2266,7 @@ async function main() {
       filteredBlacklist: totalFilteredBlacklist,
       filteredVisa: totalFilteredVisa,
       filteredPostedDate: totalFilteredPostedDate,
+      filteredCountryEligibility: totalFilteredCountryEligibility,
     });
   }
 

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -73,6 +73,40 @@
 #     - "Brazil"
 #     - "Australia"
 
+# -- Country-eligibility filter (optional, opt-in, #2093) --
+# location_filter only reads the ATS provider's STRUCTURED location field
+# (e.g. "Remote"). Many US companies tag every remote requisition "Remote"
+# regardless of which countries are actually eligible — the real
+# restriction ("US-based candidates only" vs. "US or Canada eligible")
+# often lives only in the job description BODY TEXT. This filter reads that
+# text (same field content_filter reads) and cross-references it against
+# your own country from `location.country` above.
+#
+# Semantics (case-insensitive substring), same "don't penalize missing
+# data" discipline as location_filter:
+#   - Your location.country is "United States" → filter no-ops entirely
+#     (a "US only" restriction can never exclude a US-based candidate)
+#   - No description text available → pass
+#   - No `exclusionary` phrase matched → pass (ambiguous stays ambiguous)
+#   - `exclusionary` phrase matched but an `inclusive` phrase is also
+#     present, or your own country is separately named in the text → pass
+#   - `exclusionary` phrase matched, no `inclusive` phrase, your country
+#     not named → rejected, counted in scan-runs.tsv's
+#     filtered_country_eligibility column
+#
+# If this entire block is absent, behavior is unchanged (no country
+# filtering — same as before this feature existed).
+
+# country_eligibility_filter:
+#   exclusionary:
+#     - "must be located in the united states"
+#     - "us-based candidates only"
+#     - "authorized to work in the us without sponsorship"
+#   inclusive:
+#     - "united states or canada"
+#     - "north america"
+#     - "canada eligible"
+
 # -- Salary filter (optional) --
 # Filter scanned jobs by annual compensation range. Applied AFTER location
 # filter, BEFORE dedup. Only applies when structured salary data exists.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3673,6 +3673,7 @@ try {
     buildPostingAgeFilter,
     buildPostedDateFilter,
     buildVisaFilter,
+    buildCountryEligibilityFilter,
     shouldDedupScanHistoryRow,
     formatPipelineOffer,
     formatScanHistoryRow,
@@ -4170,6 +4171,77 @@ try {
     pass('visa_filter honors custom positive keyword lists over defaults');
   } else {
     fail('visa_filter should honor custom positive keyword lists');
+  }
+
+  // ── country_eligibility_filter (#2093) ──
+  // Absent config → all jobs pass, regardless of candidate country.
+  const noCountryFilter = buildCountryEligibilityFilter(null, 'Canada');
+  if (
+    noCountryFilter('Must be located in the United States') === true &&
+    noCountryFilter('') === true
+  ) {
+    pass('country_eligibility_filter absent config → all jobs pass');
+  } else {
+    fail('country_eligibility_filter absent config should pass all jobs');
+  }
+
+  const countryCfg = {
+    exclusionary: ['must be located in the united states', 'us-based candidates only'],
+    inclusive: ['united states or canada', 'north america'],
+  };
+
+  // Missing / empty description → pass (no signal to act on).
+  const caFilter = buildCountryEligibilityFilter(countryCfg, 'Canada');
+  if (
+    caFilter('') === true &&
+    caFilter(undefined) === true &&
+    caFilter(null) === true
+  ) {
+    pass('country_eligibility_filter passes jobs with no description text');
+  } else {
+    fail('country_eligibility_filter should pass jobs with no description text');
+  }
+
+  // Ambiguous text (no exclusionary or inclusive phrase) → pass unchanged.
+  if (caFilter('A generic remote engineering role with a collaborative team') === true) {
+    pass('country_eligibility_filter passes ambiguous text with no matched phrases');
+  } else {
+    fail('country_eligibility_filter should pass ambiguous text unchanged');
+  }
+
+  // Exclusionary phrase matched, no inclusive phrase, candidate's own
+  // country ("Canada") not named anywhere → rejected.
+  if (caFilter('This role is open only to US-based candidates only.') === false) {
+    pass('country_eligibility_filter rejects an exclusionary-only US posting for a Canadian candidate');
+  } else {
+    fail('country_eligibility_filter should reject exclusionary-only postings for a non-US candidate');
+  }
+
+  // Exclusionary phrase matched, but an inclusive phrase widens eligibility → pass.
+  if (caFilter('Must be located in the United States or Canada to apply.') === true) {
+    pass('country_eligibility_filter passes when an inclusive phrase widens eligibility');
+  } else {
+    fail('country_eligibility_filter should pass when an inclusive phrase is also present');
+  }
+
+  // Exclusionary phrase matched, candidate's own country literally named
+  // elsewhere in the text (even without a configured "inclusive" phrase) → pass.
+  if (caFilter('US-based candidates only. Note: our Canada office handles onboarding.') === true) {
+    pass('country_eligibility_filter passes when the candidate\'s own country is literally named in the text');
+  } else {
+    fail('country_eligibility_filter should pass when the candidate\'s own country is named in the text');
+  }
+
+  // Candidate's own location.country is "United States" → filter no-ops
+  // entirely, even against an explicit US-only exclusionary phrase.
+  const usFilter = buildCountryEligibilityFilter(countryCfg, 'United States');
+  if (
+    usFilter('US-based candidates only, no exceptions.') === true &&
+    usFilter('Must be located in the United States') === true
+  ) {
+    pass('country_eligibility_filter no-ops for a candidate whose own country is United States');
+  } else {
+    fail('country_eligibility_filter should no-op entirely for a US-based candidate');
   }
 
 } catch (e) {
@@ -8854,8 +8926,9 @@ try {
   const runRows = readFileSync(runsFile, 'utf-8').trim().split('\n');
   if (runRows[0] === SCAN_RUNS_HEADER.trim() && runRows.length === 3
       && runRows[1].startsWith('2026-07-03T14:02:11Z\tcompleted\t45\t3\t120\t')
-      // filtered_blacklist + filtered_visa + filtered_posted_date land in the three trailing columns.
-      && runRows[1].endsWith('\t4\t7\t2')
+      // filtered_blacklist + filtered_visa + filtered_posted_date + filtered_country_eligibility
+      // land in the four trailing columns (last defaults to 0 — not supplied above).
+      && runRows[1].endsWith('\t4\t7\t2\t0')
       && runRows[2].startsWith('2026-07-04T09:00:00Z\t')) {
     pass('appendScanRunSummary writes the header once, appends one row per run');
   } else {


### PR DESCRIPTION
## Problem

`scan.mjs`'s `location_filter` only reads the ATS provider's **structured** `location` field (e.g. `"Remote"`). Many US companies tag every remote requisition identically regardless of actual country eligibility — the real restriction ("open to US-based candidates only" vs. "open to US or Canada") lives only in the **job description body text**, which `location_filter` never inspects. Two postings that both surface as `location: "Remote"` can be genuinely different in eligibility, and there was no deterministic way to tell them apart at scan time.

## Solution

A new, **opt-in**, zero-LLM `country_eligibility_filter`, following the same discipline as `location_filter`/`content_filter`:

- Reads the candidate's own country from `config/profile.yml`'s existing `location.country` field.
- Scans `job.description` — the same field `content_filter` already reads, so no new provider-specific extraction was added.
- Matches against two configurable phrase lists in `portals.yml`: `exclusionary` and `inclusive`.
- Semantics (mirrors `location_filter`'s "don't penalize missing data" rule exactly):
  - No description text → pass.
  - No exclusionary phrase matched → pass (ambiguous stays ambiguous).
  - Exclusionary phrase matched + an inclusive phrase present, or the candidate's own country literally named in the text → pass.
  - Exclusionary phrase matched, no inclusive phrase, candidate's country not named → reject.
  - Candidate's `location.country` is `"United States"` → the filter no-ops entirely (a "US only" restriction can never legitimately exclude a US-based candidate).
- **Off by default** — absent `country_eligibility_filter` config means scan behavior is byte-identical to before this PR.
- Adds a `filtered_country_eligibility` counter, appended at the **end** of `SCAN_RUNS_HEADER` (same trailing-column convention as `filtered_blacklist`/`filtered_visa`/`filtered_posted_date`), so older `scan-runs.tsv` files keep parsing.
- Documents the new config block in `templates/portals.example.yml`, right next to the existing `location_filter` docs.

Kept as a sibling config block (`exclusionary`/`inclusive`) rather than folded into `content_filter`'s `positive`/`negative` shape — this filter has its own three-way semantics (exclusionary vs. inclusive vs. candidate's-own-country-named) and cross-references `config/profile.yml`, which doesn't fit `content_filter`'s simpler two-list reject/require model.

## Test plan

- [x] `node test-all.mjs` — 2043 passed, 0 failed (7 new tests covering: absent-config passthrough, missing-description passthrough, ambiguous-text passthrough, exclusionary-only rejection, inclusive-phrase passthrough, candidate's-own-country-named passthrough, US-candidate no-op)
- [x] Updated the existing `appendScanRunSummary` fixture test for the new trailing header column

Closes #2093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional country-eligibility filter for job descriptions.
  * Jobs can now be evaluated against the candidate’s configured country using inclusive and exclusionary phrases.
  * Added configuration guidance for enabling and customizing the filter.

* **Improvements**
  * Scan summaries now report how many jobs were excluded by country eligibility.
  * Country-filter results are retained in scan history for later review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->