### PR TITLE
fix(successfactors): preserve brand path for multi-brand RMK tenants (#2010)

### DIFF
--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -68,7 +68,7 @@ const CSB_DEFAULT_LOCALES = ['de_DE', 'en_US'];
 const CSB_LOCALE_PRIORITY = ['de_DE', 'en_US', 'en_GB', 'en_EN'];
 
 /** @param {import('./_types.js').PortalEntry} entry */
-function resolveConfig(entry) {
+export function resolveConfig(entry) {
   const raw = entry.api || entry.careers_url || '';
   let u;
   try {

--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -262,7 +262,7 @@ export function cleanCsbLocation(raw) {
 // Map one CSB jobs-API response to raw {id, title, url, location, postedAt}.
 // Records nest the useful fields under `.response`; a record without an id or a
 // title is skipped (can't build a stable dedup key or a meaningful listing).
-/** @param {any} json @param {{origin:string}} cfg @param {string} locale */
+/** @param {any} json @param {{origin:string, base?:string}} cfg @param {string} locale */
 export function parseCsbJobs(json, cfg, locale) {
   const list = Array.isArray(json?.jobSearchResult) ? json.jobSearchResult : [];
   const out = [];
@@ -282,7 +282,7 @@ export function parseCsbJobs(json, cfg, locale) {
     const slug = decodeEntities(String(r.unifiedUrlTitle || r.urlTitle || 'job'))
       .replace(/[?#&]+/g, '-')
       .replace(/-{2,}/g, '-');
-    const url = `${cfg.origin}/job/${slug}/${id}-${locale}`;
+    const url = `${cfg.base || cfg.origin}/job/${slug}/${id}-${locale}`;
     out.push({
       id,
       title,

--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -77,12 +77,27 @@ export function resolveConfig(entry) {
     return null;
   }
   if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  // Preserve a brand/tenant path prefix when the configured URL carries one —
+  // some holding companies run several acquired brands off one shared RMK
+  // instance, disambiguated by a path segment instead of a separate domain
+  // (e.g. careers.nemetschek.com/Bluebeam/ vs. .../Vectorworks/). Strip a
+  // trailing /search/ (the page tenants commonly configure as careers_url)
+  // and any trailing slash, so a bare-origin config and a brand-scoped
+  // /search/ config both collapse to the same base. Single-domain tenants
+  // (the common case) have an empty pathname, so base === origin unchanged.
+  const path = u.pathname.replace(/\/search\/?$/i, '').replace(/\/+$/, '');
+  const base = u.origin + path;
   return {
     origin: u.origin,
-    tileApi: `${u.origin}/tile-search-results/`,
+    base,
+    tileApi: `${base}/tile-search-results/`,
+    // jobBase stays origin-only: RMK tile data-url paths for a brand-scoped
+    // tenant already carry the brand segment (confirmed against Nemetschek's
+    // /Bluebeam/tile-search-results/ output), so prefixing base here would
+    // double it up.
     jobBase: u.origin,
-    jobsApi: `${u.origin}/services/recruiting/v1/jobs`,
-    searchPage: `${u.origin}/search/`,
+    jobsApi: `${base}/services/recruiting/v1/jobs`,
+    searchPage: `${base}/search/`,
   };
 }
 

--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -81,11 +81,16 @@ export function resolveConfig(entry) {
   // some holding companies run several acquired brands off one shared RMK
   // instance, disambiguated by a path segment instead of a separate domain
   // (e.g. careers.nemetschek.com/Bluebeam/ vs. .../Vectorworks/). Strip a
-  // trailing /search/ (the page tenants commonly configure as careers_url)
-  // and any trailing slash, so a bare-origin config and a brand-scoped
-  // /search/ config both collapse to the same base. Single-domain tenants
-  // (the common case) have an empty pathname, so base === origin unchanged.
-  const path = u.pathname.replace(/\/search\/?$/i, '').replace(/\/+$/, '');
+  // trailing known-endpoint segment — /search/ (the page tenants commonly
+  // configure as careers_url), or one of the API paths this module itself
+  // builds below (/tile-search-results/, /services/recruiting/v1/jobs), in
+  // case an `api:` override points straight at one — plus any trailing
+  // slash, so all of those collapse to the same brand-scoped base instead of
+  // doubling the endpoint segment onto itself. Single-domain tenants (the
+  // common case) have an empty pathname, so base === origin unchanged.
+  const path = u.pathname
+    .replace(/\/(?:search|tile-search-results|services\/recruiting\/v1\/jobs)\/?$/i, '')
+    .replace(/\/+$/, '');
   const base = u.origin + path;
   return {
     origin: u.origin,

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -59,6 +59,23 @@ try {
     fail('resolveConfig should return null for an unparseable URL');
   }
 
+  // An `api:` override pointing straight at one of the endpoints this module
+  // itself builds (rather than at the brand root or /search/) must not
+  // double the segment onto the derived base (e.g. …/tile-search-results/
+  // tile-search-results/).
+  const brandTileEndpoint = resolveConfig({ name: 'Bluebeam', api: 'https://careers.nemetschek.com/Bluebeam/tile-search-results/' });
+  if (brandTileEndpoint.base === 'https://careers.nemetschek.com/Bluebeam' && brandTileEndpoint.tileApi === 'https://careers.nemetschek.com/Bluebeam/tile-search-results/') {
+    pass('resolveConfig: api: pointing at tile-search-results/ directly does not double the segment (#2010)');
+  } else {
+    fail(`resolveConfig tile-endpoint-as-api wrong: base=${brandTileEndpoint.base} tileApi=${brandTileEndpoint.tileApi}`);
+  }
+  const brandJobsEndpoint = resolveConfig({ name: 'Bluebeam', api: 'https://careers.nemetschek.com/Bluebeam/services/recruiting/v1/jobs' });
+  if (brandJobsEndpoint.base === 'https://careers.nemetschek.com/Bluebeam' && brandJobsEndpoint.jobsApi === 'https://careers.nemetschek.com/Bluebeam/services/recruiting/v1/jobs') {
+    pass('resolveConfig: api: pointing at services/recruiting/v1/jobs directly does not double the segment (#2010)');
+  } else {
+    fail(`resolveConfig jobs-endpoint-as-api wrong: base=${brandJobsEndpoint.base} jobsApi=${brandJobsEndpoint.jobsApi}`);
+  }
+
   // detect() — literal SF hosts auto-claim; branded RMK hosts (jobs.zf.com) do
   // NOT (they carry no "successfactors" string and rely on explicit provider:).
   if (sf.detect({ name: 'X', careers_url: 'https://acme.successfactors.eu/careers' })) {

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -207,6 +207,16 @@ try {
   const c2 = csbJobs[1];
   if (c2 && !/[?#&]|&amp;/.test(new URL(c2.url).pathname)) pass('parseCsbJobs sanitizes &amp; / URL-structural chars out of the slug');
   else fail(`parseCsbJobs slug not sanitized: ${JSON.stringify(c2 && c2.url)}`);
+
+  // parseCsbJobs (#2010): a brand-scoped cfg.base (from resolveConfig) must
+  // flow into the built job URL, for a hypothetical multi-brand CSB tenant.
+  const csbBrandCfg = { origin: 'https://careers.example.com', base: 'https://careers.example.com/Acme' };
+  const csbBrandJobs = parseCsbJobs(csbJson, csbBrandCfg, 'en_US');
+  if (csbBrandJobs[0]?.url === 'https://careers.example.com/Acme/job/Analytical-Lab-Technician/31099-en_US') {
+    pass('parseCsbJobs uses cfg.base (brand-scoped) when present (#2010)');
+  } else {
+    fail(`parseCsbJobs did not honor cfg.base: ${JSON.stringify(csbBrandJobs[0]?.url)}`);
+  }
 } catch (err) {
   fail(`successfactors provider test threw: ${err.message}`);
 }

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -25,6 +25,18 @@ try {
     fail(`resolveConfig single-domain wrong: base=${single.base} tileApi=${single.tileApi}`);
   }
 
+  const brandSearch = resolveConfig({ name: 'Bluebeam', api: 'https://careers.nemetschek.com/Bluebeam/search/' });
+  if (
+    brandSearch.base === 'https://careers.nemetschek.com/Bluebeam' &&
+    brandSearch.tileApi === 'https://careers.nemetschek.com/Bluebeam/tile-search-results/' &&
+    brandSearch.jobsApi === 'https://careers.nemetschek.com/Bluebeam/services/recruiting/v1/jobs' &&
+    brandSearch.searchPage === 'https://careers.nemetschek.com/Bluebeam/search/'
+  ) {
+    pass('resolveConfig: multi-brand tenant keeps the brand path in tileApi/jobsApi/searchPage (#2010)');
+  } else {
+    fail(`resolveConfig multi-brand wrong: ${JSON.stringify(brandSearch)}`);
+  }
+
   // detect() — literal SF hosts auto-claim; branded RMK hosts (jobs.zf.com) do
   // NOT (they carry no "successfactors" string and rely on explicit provider:).
   if (sf.detect({ name: 'X', careers_url: 'https://acme.successfactors.eu/careers' })) {

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -9,10 +9,21 @@ console.log('\nProvider — successfactors (SAP RMK tile parser)');
 try {
   const successfactorsModule = await import(pathToFileURL(join(ROOT, 'providers/successfactors.mjs')).href);
   const sf = successfactorsModule.default;
-  const { parseTiles, cityFromSlug } = successfactorsModule;
+  const { parseTiles, cityFromSlug, resolveConfig } = successfactorsModule;
 
   if (sf.id === 'successfactors') pass('successfactors.id is "successfactors"');
   else fail(`successfactors.id is ${JSON.stringify(sf.id)}`);
+
+  // resolveConfig — multi-brand RMK tenants (#2010): a brand/tenant path
+  // segment in the configured URL (careers.nemetschek.com/Bluebeam/) must
+  // survive into tileApi/jobsApi/searchPage, not collapse to the shared
+  // origin (which would silently return the parent brand's postings).
+  const single = resolveConfig({ name: 'ZF', careers_url: 'https://jobs.zf.com' });
+  if (single.base === 'https://jobs.zf.com' && single.tileApi === 'https://jobs.zf.com/tile-search-results/') {
+    pass('resolveConfig: single-domain tenant is unaffected (base === origin, #2010)');
+  } else {
+    fail(`resolveConfig single-domain wrong: base=${single.base} tileApi=${single.tileApi}`);
+  }
 
   // detect() — literal SF hosts auto-claim; branded RMK hosts (jobs.zf.com) do
   // NOT (they carry no "successfactors" string and rely on explicit provider:).

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -53,6 +53,12 @@ try {
     fail(`resolveConfig brand-no-search wrong: base=${brandNoSearch.base}`);
   }
 
+  if (resolveConfig({ name: 'X', careers_url: 'not a url' }) === null) {
+    pass('resolveConfig: returns null for an unparseable URL');
+  } else {
+    fail('resolveConfig should return null for an unparseable URL');
+  }
+
   // detect() — literal SF hosts auto-claim; branded RMK hosts (jobs.zf.com) do
   // NOT (they carry no "successfactors" string and rely on explicit provider:).
   if (sf.detect({ name: 'X', careers_url: 'https://acme.successfactors.eu/careers' })) {

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -46,6 +46,13 @@ try {
     fail(`resolveConfig jobBase wrong: ${brandSearch.jobBase}`);
   }
 
+  const brandNoSearch = resolveConfig({ name: 'Bluebeam', careers_url: 'https://careers.nemetschek.com/Bluebeam/' });
+  if (brandNoSearch.base === 'https://careers.nemetschek.com/Bluebeam') {
+    pass('resolveConfig: a brand path without a trailing /search/ segment still resolves correctly (#2010)');
+  } else {
+    fail(`resolveConfig brand-no-search wrong: base=${brandNoSearch.base}`);
+  }
+
   // detect() — literal SF hosts auto-claim; branded RMK hosts (jobs.zf.com) do
   // NOT (they carry no "successfactors" string and rely on explicit provider:).
   if (sf.detect({ name: 'X', careers_url: 'https://acme.successfactors.eu/careers' })) {

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -36,6 +36,15 @@ try {
   } else {
     fail(`resolveConfig multi-brand wrong: ${JSON.stringify(brandSearch)}`);
   }
+  // jobBase deliberately stays origin-only: live RMK data-url paths for a
+  // brand-scoped tenant already carry the brand segment (confirmed against
+  // Nemetschek's own /Bluebeam/tile-search-results/ output), so prefixing
+  // base there would double it up.
+  if (brandSearch.jobBase === 'https://careers.nemetschek.com') {
+    pass('resolveConfig: jobBase stays origin-only for a brand-scoped tenant (#2010)');
+  } else {
+    fail(`resolveConfig jobBase wrong: ${brandSearch.jobBase}`);
+  }
 
   // detect() — literal SF hosts auto-claim; branded RMK hosts (jobs.zf.com) do
   // NOT (they carry no "successfactors" string and rely on explicit provider:).


### PR DESCRIPTION
## What does this PR do?

`providers/successfactors.mjs`'s `resolveConfig()` built every API URL from `new URL(raw).origin` alone, discarding any path segment in the configured `api`/`careers_url`. This works for single-domain tenants (`jobs.zf.com`, `jobs.schaeffler.com`, …) but silently breaks for holding companies that run several acquired brands off one shared SAP SuccessFactors RMK instance, disambiguated by a path prefix instead of a separate domain — e.g. Nemetschek Group runs Bluebeam, Vectorworks, Graphisoft, Allplan, and Maxon all on `careers.nemetschek.com`, brand-selected by a `/{Brand}/` path segment.

Configuring `api: https://careers.nemetschek.com/Bluebeam/search/` to track Bluebeam specifically silently queried the parent/default brand's postings instead — a wrong-data bug, not a missing-data or error case, with nothing signaling the mismatch to the user.

Fix: derive a brand-scoped `base` (`origin + pathname`, with a trailing `/search/` and trailing slash stripped) and use it for `tileApi`/`jobsApi`/`searchPage`. `jobBase` deliberately stays origin-only — confirmed against Nemetschek's live `/Bluebeam/tile-search-results/` output that RMK tile `data-url` paths for a brand-scoped tenant already carry the brand segment, so prefixing `base` there would double it up. Also threaded `cfg.base` (falling back to `cfg.origin`) into `parseCsbJobs`'s URL building, per the issue's own note that the CSB strategy derives its API URLs from the same `cfg` object and would need the same handling for a hypothetical multi-brand CSB tenant.

Single-domain tenants are unaffected: an unscoped URL has an empty pathname, so `base` collapses back to `origin` exactly as before.

## Related issue

Fixes #2010

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Bug fix — no issue-first requirement
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (2037 passed, 0 failed, 4 pre-existing unrelated warnings)
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SuccessFactors integration for tenant- and brand-scoped career URLs, including proper handling of URLs with or without the `/search/` segment.
  * Corrected tile, jobs, and search page links to avoid duplicating brand path segments.
  * Fixed job detail links for multi-brand career sites.

* **Tests**
  * Expanded SuccessFactors provider test coverage for multi-brand tenant scenarios and CSB job URL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->