### PR TITLE
ci(web): run web/'s node tests in web-ci.yml (#2092)

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -31,5 +31,6 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: npm ci
+      - run: npm test
       - run: npx tsc --noEmit
       - run: npm run build


### PR DESCRIPTION
## What does this PR do?

No workflow runs web/'s Node test files. `.github/workflows/web-ci.yml` runs `npm ci`, `npx tsc --noEmit`, and `npm run build` — no test step. `.github/workflows/test.yml` runs `node test-all.mjs --quick` plus `go test ./...` for the dashboard, but neither reaches web/ (it only reads `web/src/lib/career-ops.ts` for the tracker column contract freeze — a file read, not a test run). `web/test-clean-chips.mjs` has been green by assumption since it landed; a contributor could add a test under web/, watch it pass locally, and have it never run in CI again.

Adds one step to `web-ci.yml`, right after `npm ci`:

```yaml
- run: npm test
```

`web-ci.yml` is the right home for it: it already runs inside `web/` with dependencies installed (`test.yml` deliberately avoids web/ since web/ can be absent on core-only installs per #1677), and the workflow documents itself as informative-only — not a required check — so this surfaces the tests without adding a merge gate on the core.

Verified locally: `cd web && npm ci && npm test` → 19/19 passing.

## Related issue

Fixes #2092

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Bug fix — no issue-first requirement
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (2031 passed, 0 failed, 4 pre-existing unrelated warnings)
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated test execution to the web application’s continuous integration checks.
  * Web builds and type validation now run alongside the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->