### PR TITLE
fix(role-matcher): stop collapsing leveled variants into the bare title (#2009)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,6 +367,8 @@ One TSV file per evaluation at `batch/tracker-additions/{num}-{company-slug}.tsv
 
 **Report link normalization:** the TSV always carries a root-relative `[num](reports/...)` link; `merge-tracker.mjs` rewrites it relative to the tracker's own directory (`../reports/...` at `data/applications.md`, `reports/...` at root) so links stay clickable. Idempotent; fix an existing tracker with `node merge-tracker.mjs --migrate` (#760).
 
+**Req/posting ID in notes disambiguates same-title postings (#1524, #2009):** when a company posts two genuinely different requisitions whose titles fuzzy-match (e.g. a leveled variant and its bare title, or two sibling team roles), put the req/job/posting ID in the **notes** column on both rows. `merge-tracker.mjs` reads it (`REQ_NUMBER_RE`) and treats rows carrying *different* recognizable IDs as distinct openings, overriding fuzzy title matching. Recognized forms are a `job id` / `posting id` / `requisition` / `req` / `jr` / `job` / `posting` / `ref` / `r_` label followed by an alphanumeric ID containing at least one digit — e.g. `req JR-10423`, `job id 88214`, `ref R_2291`. Prefer this whenever the JD exposes an ID; it is the only signal that survives near-identical titles.
+
 ### Pipeline Integrity
 
 1. **NEVER edit applications.md to ADD new entries** -- write TSV in `batch/tracker-additions/` and let `merge-tracker.mjs` merge.

--- a/role-matcher.mjs
+++ b/role-matcher.mjs
@@ -12,6 +12,17 @@ export const SENIORITY_TOKENS = new Set([
   'chief', 'associate', 'intern', 'entry'
 ]);
 
+// Seniority tokens that place a requisition BELOW the bare baseline title.
+// "senior"/"principal" modify an ambiguous baseline and are routinely added or
+// dropped when the same opening is re-posted, so seeing one on a single side is
+// not evidence of a different job. These words are different in kind: they mean
+// the req sits at a lower level than the unqualified title, with its own scope,
+// comp band, and req ID. "Associate X" and a bare "X" at one company are two
+// real openings, so a lone sub-baseline qualifier is a disagreement (#2009).
+export const SUB_BASELINE_SENIORITY = new Set([
+  'associate', 'junior', 'entry', 'intern',
+]);
+
 // Tokens that almost every role shares must not count as strong matching
 // signal. This set covers seniority, work mode, contract shape, locations, and
 // other words that frequently appear in titles without identifying the opening.
@@ -111,6 +122,14 @@ export function roleFuzzyMatch(a, b) {
   if (senA.size > 0 && senB.size > 0) {
     const hasOverlap = [...senA].some(s => senB.has(s));
     if (!hasOverlap) return false;
+  } else if (senA.size > 0 || senB.size > 0) {
+    // Exactly one side states a seniority. The tokenizer drops seniority words
+    // as stopwords, so "Associate Product Manager, Team" and "Product Manager,
+    // Team" otherwise tokenize identically and score a perfect Jaccard ratio —
+    // silently collapsing two real requisitions. A sub-baseline qualifier on
+    // the lone side is a level disagreement, not a loose rewrite (#2009).
+    const lone = senA.size > 0 ? senA : senB;
+    if ([...lone].some(s => SUB_BASELINE_SENIORITY.has(s))) return false;
   }
 
   const wordsA = [...new Set(roleTokens(a))];

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5150,6 +5150,36 @@ try {
     fail('role matcher rejected a repost that only adds a seniority word');
   }
 
+  // A sub-baseline qualifier on ONE side is a level disagreement, not a loose
+  // rewrite: the tokenizer drops seniority words as stopwords, so these pairs
+  // otherwise tokenize identically and scored a perfect Jaccard ratio, silently
+  // collapsing two genuinely different requisitions (#2009).
+  for (const [lower, bare] of [
+    ['Associate Product Manager, TeamName', 'Product Manager, TeamName'],
+    ['Junior Product Manager, TeamName', 'Product Manager, TeamName'],
+    ['Entry Level Data Engineer', 'Data Engineer'],
+  ]) {
+    if (!roleFuzzyMatch(lower, bare)) {
+      pass(`role matcher keeps "${lower}" distinct from the bare title (#2009)`);
+    } else {
+      fail(`role matcher collapsed "${lower}" into the bare title "${bare}"`);
+    }
+  }
+
+  // Direction must not matter — the lone qualifier can be on either side.
+  if (!roleFuzzyMatch('Product Manager, TeamName', 'Associate Product Manager, TeamName')) {
+    pass('role matcher applies the sub-baseline gate in both argument orders (#2009)');
+  } else {
+    fail('role matcher only applied the sub-baseline gate in one argument order');
+  }
+
+  // Both sides sub-baseline at the same level is still the same opening.
+  if (roleFuzzyMatch('Associate Product Manager, TeamName', 'Associate Product Manager, TeamName')) {
+    pass('role matcher still matches two same-level Associate reposts (#2009)');
+  } else {
+    fail('role matcher rejected a genuine Associate-level repost');
+  }
+
   // A repost annotation is tracking metadata, not a specialization — must still match.
   if (roleFuzzyMatch('Learning Development Designer III', 'Learning Development Designer III (Repost)')) {
     pass('role matcher does not treat a "(Repost)" annotation as a specialization marker');


### PR DESCRIPTION
Closes #2009 (items 1 and 2; item 3 — the `set-status.mjs` company-only fallback guard — follows as its own PR, per the issue framing it as "Separately").

Thanks @clede for an unusually precise report — the repro and the root-cause analysis distinguishing this from #793 were exactly right.

## The bug

`roleFuzzyMatch`'s seniority gate only fires when **both** titles carry a seniority token:

```js
if (senA.size > 0 && senB.size > 0) { /* require overlap */ }
```

`"Associate Product Manager, TeamName"` vs `"Product Manager, TeamName"` skips it — only one side has a token. And because `roleTokens` drops seniority words as **stopwords**, the two then tokenize *identically*:

```
['product','manager','teamname']   ===   ['product','manager','teamname']
```

Jaccard = 1.0 → dedupe. `merge-tracker.mjs` silently drops the second requisition even though it has its own req ID, URL, and score. As @clede notes, this sits upstream of #793's Jaccard fix — the ratio is computed correctly here; the titles genuinely are identical strings *after* tokenization.

## The fix

A **sub-baseline** qualifier on the lone side is treated as a level disagreement:

```js
export const SUB_BASELINE_SENIORITY = new Set(['associate', 'junior', 'entry', 'intern']);
```

The distinction the issue draws is the one implemented: `associate`/`junior`/`entry`/`intern` mean the req sits *below* the unqualified title (own scope, comp band, req ID), whereas `senior`/`principal` modify an ambiguous baseline and are routinely added or dropped when the same opening is re-posted. So:

| Pair | Before | After |
|---|---|---|
| `Associate Product Manager, Team` vs `Product Manager, Team` | ✅ dedupe | ❌ distinct |
| `Junior Product Manager, Team` vs `Product Manager, Team` | ✅ dedupe | ❌ distinct |
| `Data Engineer` vs `Senior Data Engineer` | ✅ dedupe | ✅ **unchanged** |
| `Associate PM, Team` vs `Associate PM, Team` | ✅ dedupe | ✅ **unchanged** |

The existing `'role matcher still matches when seniority is only stated on one side'` assertion (`Data Engineer` / `Senior Data Engineer`) is deliberately preserved — this narrows only the sub-baseline case, exactly as the issue scopes it.

## Docs (item 2)

`merge-tracker.mjs` has honored a req/job/posting-ID override since #1524 (`REQ_NUMBER_RE`) — different IDs keep rows distinct regardless of title similarity — but that convention lived only in the source, so the TSV spec agents actually follow never mentioned it. Now documented alongside the other tracker-addition rules, with the recognized label forms and examples **verified against the regex** (`req JR-10423`, `job id 88214`, `ref R_2291`).

## Tests

5 new assertions in the existing role-matcher block: all three leveled variants stay distinct, the gate is order-independent, and a same-level `Associate` repost still matches.

`node test-all.mjs --quick` → **2048 passed, 0 failed**.

2 commits (fix + docs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job title matching to keep Associate, Junior, Entry Level, and Intern roles distinct from higher-level roles.
  * Prevented postings with different recognizable requisition or job IDs from being incorrectly merged when titles are similar.

* **Tests**
  * Added coverage for seniority-specific matching, including symmetric comparisons and same-level reposts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->