### PR TITLE
fix(set-status): don't silently update a lone row that contradicts --role (#2009)

### DIFF
--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -147,6 +147,59 @@ const TRACKER_REPORT_MISMATCH = `# Applications Tracker
   rmSync(sb.dir, { recursive: true, force: true });
 }
 
+// ── 1c. A single match must still be checked against --role (#2009) ─
+// resolveRow only consults --role to break ties between 2+ candidates, so a
+// company matching exactly one row was updated without ever comparing it to
+// the role the caller explicitly asked for. The intended requisition may not
+// be in the tracker at all (fuzzy-deduped away), and the lone survivor for
+// that company silently absorbed the status change.
+{
+  const sb = makeSandbox(TRACKER_9);
+  const before = readTracker(sb);
+  const r = runSetStatus(['globex', 'SKIP', '--role', 'Data Engineer', '--json'], sb);
+  let parsed = null;
+  try { parsed = JSON.parse(r.stdout); } catch {}
+  if (r.code === 3 && parsed?.code === 'role-mismatch'
+      && parsed.rowRole === 'Platform Engineer' && parsed.requestedRole === 'Data Engineer'
+      && readTracker(sb) === before) {
+    pass('role-mismatch: single company match fails closed without writing (#2009)');
+  } else {
+    fail(`role-mismatch: code=${r.code} json=${JSON.stringify(parsed)}\n${r.stdout}${r.stderr}`);
+  }
+
+  const forced = runSetStatus(['globex', 'SKIP', '--role', 'Data Engineer', '--force'], sb);
+  if (forced.code === 0 && /\| 2 \|[^\n]*\| SKIP \|/.test(readTracker(sb))) {
+    pass('role-mismatch: --force records an explicit decision to proceed');
+  } else {
+    fail(`role-mismatch force: code=${forced.code}\n${forced.stdout}${forced.stderr}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
+// ── 1d. An exact --role must NOT be rejected by the new guard (#2009) ─
+// roleFuzzyMatch is a dedup predicate: it returns false when the overlap is
+// entirely baseline vocabulary (["platform","engineer"]) so same-titled
+// sibling reqs never auto-merge. Using it alone as the guard's equality test
+// would reject --role "Platform Engineer" against a row that is exactly that.
+{
+  const sb = makeSandbox(TRACKER_9);
+  const r = runSetStatus(['globex', 'Applied', '--role', 'Platform Engineer'], sb);
+  if (r.code === 0 && /\| 2 \|[^\n]*\| Applied \|/.test(readTracker(sb))) {
+    pass('role-mismatch: an exact all-baseline role title still proceeds (#2009)');
+  } else {
+    fail(`role-mismatch exact: code=${r.code}\n${r.stdout}${r.stderr}`);
+  }
+
+  // Case and punctuation must not matter for the equality path.
+  const r2 = runSetStatus(['globex', 'Evaluated', '--role', 'platform  engineer'], sb);
+  if (r2.code === 0 && /\| 2 \|[^\n]*\| Evaluated \|/.test(readTracker(sb))) {
+    pass('role-mismatch: role equality is case/punctuation insensitive (#2009)');
+  } else {
+    fail(`role-mismatch normalize: code=${r2.code}\n${r2.stdout}${r2.stderr}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
 // ── 2. Update by company name (single match) ────────────────────
 {
   const sb = makeSandbox(TRACKER_9);

--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -200,6 +200,39 @@ const TRACKER_REPORT_MISMATCH = `# Applications Tracker
   rmSync(sb.dir, { recursive: true, force: true });
 }
 
+// ── 1e. Symbol-bearing titles must not collapse to the same role (#2009) ─
+// The equality normalizer strips generic punctuation, so it must preserve the
+// symbols that actually distinguish a title first — otherwise "C# Engineer" and
+// "C++ Engineer" both fold to "c engineer" and the guard silently updates the
+// wrong row for exactly the kind of title it exists to protect.
+{
+  const TRACKER_SYMBOL = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-01 | Contoso | C++ Engineer | 4.0/5 | Evaluated | ✅ | [1](../reports/001-contoso-2026-06-01.md) | — |
+`;
+  const sb = makeSandbox(TRACKER_SYMBOL);
+  const before = readTracker(sb);
+  const r = runSetStatus(['contoso', 'SKIP', '--role', 'C# Engineer', '--json'], sb);
+  let parsed = null;
+  try { parsed = JSON.parse(r.stdout); } catch {}
+  if (r.code === 3 && parsed?.code === 'role-mismatch' && readTracker(sb) === before) {
+    pass('role-mismatch: "C# Engineer" does not match a "C++ Engineer" row (#2009)');
+  } else {
+    fail(`role-mismatch symbol: code=${r.code} json=${JSON.stringify(parsed)}\n${r.stdout}${r.stderr}`);
+  }
+
+  // The genuine same-symbol title still matches (guard does not over-fire).
+  const r2 = runSetStatus(['contoso', 'Applied', '--role', 'c++ engineer'], sb);
+  if (r2.code === 0 && /\| 1 \|[^\n]*\| Applied \|/.test(readTracker(sb))) {
+    pass('role-mismatch: "c++ engineer" still matches a "C++ Engineer" row (#2009)');
+  } else {
+    fail(`role-mismatch symbol-equal: code=${r2.code}\n${r2.stdout}${r2.stderr}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
 // ── 2. Update by company name (single match) ────────────────────
 {
   const sb = makeSandbox(TRACKER_9);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -300,7 +300,15 @@ if (/^\d+$/.test(selector) && !flags.force) {
 // entirely baseline vocabulary (["platform","engineer"]) so that same-titled
 // sibling reqs never auto-merge. That makes it unusable on its own here — it
 // would reject --role "Platform Engineer" against a row that IS exactly that.
-const normalizeRoleText = s => String(s ?? '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+const normalizeRoleText = s => String(s ?? '')
+  .toLowerCase()
+  // Preserve symbols that distinguish real titles before collapsing generic
+  // punctuation — otherwise "C# Engineer" and "C++ Engineer" both fold to
+  // "c engineer" and the exact-equality path treats them as the same row.
+  .replace(/\+\+/g, ' plusplus ')
+  .replace(/#/g, ' sharp ')
+  .replace(/[^a-z0-9]+/g, ' ')
+  .trim();
 const roleMatchesTarget = normalizeRoleText(target.role) === normalizeRoleText(flags.role)
   || roleFuzzyMatch(target.role, flags.role);
 

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -286,6 +286,33 @@ if (/^\d+$/.test(selector) && !flags.force) {
     );
   }
 }
+
+// --role is an explicit statement of which opening the caller means, but
+// resolveRow only consults it to break ties between 2+ candidates. A selector
+// matching exactly one row therefore returned that row without ever checking
+// it against --role, silently rewriting a status the caller never asked for.
+// That is the wrong-row mutation in #2009: the intended requisition may not be
+// in the tracker at all (fuzzy-deduped away, or never merged), so the lone
+// survivor for that company absorbs the update instead. Fail closed and let
+// --force record an explicit decision, matching the report-mismatch guard.
+// Exact-title equality must be checked separately: roleFuzzyMatch is a DEDUP
+// predicate, and it deliberately returns false for two titles whose overlap is
+// entirely baseline vocabulary (["platform","engineer"]) so that same-titled
+// sibling reqs never auto-merge. That makes it unusable on its own here — it
+// would reject --role "Platform Engineer" against a row that IS exactly that.
+const normalizeRoleText = s => String(s ?? '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+const roleMatchesTarget = normalizeRoleText(target.role) === normalizeRoleText(flags.role)
+  || roleFuzzyMatch(target.role, flags.role);
+
+if (flags.role && !flags.force && !roleMatchesTarget) {
+  failWith(
+    EXIT_AMBIGUOUS,
+    'role-mismatch',
+    `Tracker #${target.num} (${target.company}) is "${target.role}", which does not match --role "${flags.role}". ` +
+      'The row you meant may not be in the tracker. Re-run with --force to update this row anyway.',
+    { trackerNum: target.num, rowRole: target.role, requestedRole: flags.role },
+  );
+}
 const oldStatus = target.status;
 const note = flags.note != null ? cell(flags.note) : null;
 


### PR DESCRIPTION
Closes #2009 (item 3 — the "separately" item). The matcher half is #2107.

## The bug

@clede reported nearly overwriting the status of a live, unrelated application. Tracing it, the mechanism is narrower than the report assumed — and still real.

The numeric path does **not** fall back to company matching (it exits `not-found`, `set-status.mjs:177`). The actual hole is `--role`:

```js
if (matches.length > 1 && flags.role) { /* narrow */ }   // lines 180, 207
```

`--role` is consulted **only to break ties**. When a selector matches exactly one row, that row is returned without ever being compared to the role the caller explicitly named. Reproduced on current `main`:

```console
$ node set-status.mjs globex SKIP --role "Data Engineer"
✅ #2 Globex — Platform Engineer: set Evaluated → SKIP
```

I asked for *Data Engineer*; it silently marked *Platform Engineer*. That is exactly @clede's scenario: when a requisition gets fuzzy-deduped away (or never merged), it is **absent** from the tracker, so the lone survivor for that company absorbs the update.

## The fix

Fail closed when an explicit `--role` doesn't correspond to the resolved row, with `--force` as the escape — mirroring the existing `report-number-mismatch` guard right above it:

```console
$ node set-status.mjs globex SKIP --role "Data Engineer"
❌ Tracker #2 (Globex) is "Platform Engineer", which does not match --role "Data Engineer".
   The row you meant may not be in the tracker. Re-run with --force to update this row anyway.
```

Exit 3, structured `role-mismatch` payload under `--json`, nothing written.

### One subtlety worth flagging in review

`roleFuzzyMatch` alone is **not** usable as the equality test here. It's a *dedup* predicate and deliberately returns `false` when the overlap is entirely baseline vocabulary — so `roleFuzzyMatch('Platform Engineer', 'Platform Engineer')` is `false` (both tokens are in `BASELINE_TOKENS`, leaving `discriminating` empty). Using it directly would reject `--role "Platform Engineer"` against a row that *is* exactly that. I caught this in testing; the guard checks normalized exact equality first, then falls back to the fuzzy predicate.

## Scope

Callers passing no `--role` are completely unaffected (the common path). The multi-match path already narrowed via fuzzy match, so a narrowed row passes the guard trivially — the new friction is confined to the single-match case, which is the one this issue is about.

## Tests

4 new cases in `set-status-tests.mjs`: mismatch fails closed with no write · `--force` proceeds · exact all-baseline title still proceeds · equality ignores case/punctuation.

`node set-status-tests.mjs` → **42 passed, 0 failed**
`node test-all.mjs --quick` → **2043 passed, 0 failed**

2 commits (fix + tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `set-status` behavior with `--role` by verifying the resolved tracker row’s role matches the requested one before applying updates.
  - Added clear `role-mismatch` failure behavior when roles don’t match (and no update occurs), including structured details in the result.
  - Kept valid updates working for exact role matches, while avoiding incorrect matches when roles contain symbols.
  - Continued support for bypassing mismatches using `--force`.
- **Tests**
  - Expanded regression coverage for `--role` handling during tracker row resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->