### PR TITLE
fix(update-system): rollback leaves new files behind under a directory pathspec (#2015)

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -630,7 +630,7 @@ export function prepareMaterializedSkillEntrypointsForStage(paths, root = ROOT) 
   return prepared;
 }
 
-function revertPaths(paths) {
+function revertPaths(paths, protectedPaths = new Set()) {
   if (paths.length === 0) return;
   // Must restore from HEAD, not from the index (#915 bug 1). After
   // `git checkout FETCH_HEAD -- <path>` the index already holds the new
@@ -657,7 +657,7 @@ function revertPaths(paths) {
     // HEAD already knows about. Files the update introduced *under* that
     // directory are not in HEAD, so they survive the rollback as staged
     // additions and the tree is left dirtier than before the update (#2015).
-    removeAdditionsNotInHead(p);
+    removeAdditionsNotInHead(p, protectedPaths);
   }
 }
 
@@ -669,19 +669,38 @@ function revertPaths(paths) {
  * a user file that merely changed is untouched.
  *
  * @param {string} pathspec - SYSTEM_PATHS entry (file or directory).
+ * @param {Set<string>} protectedPaths - Paths already dirty/staged BEFORE the
+ *   update ran; never deleted, so a rollback cannot destroy the user's own
+ *   pre-existing staged work under a system pathspec (#2015).
  */
-function removeAdditionsNotInHead(pathspec) {
+function removeAdditionsNotInHead(pathspec, protectedPaths = new Set()) {
   const spec = pathspec.endsWith('/') ? pathspec.slice(0, -1) : pathspec;
   let added = '';
   try {
-    added = git('diff', '--cached', '--name-only', '--diff-filter=A', 'HEAD', '--', spec);
+    // -z: NUL-delimited, unquoted output, so paths containing spaces or even
+    // newlines survive intact — `split('\n').trim()` would mangle them.
+    added = git('diff', '--cached', '-z', '--name-only', '--diff-filter=A', 'HEAD', '--', spec);
   } catch {
     // No HEAD yet, or an unreadable pathspec — nothing safe to clean up.
     return;
   }
-  for (const file of added.split('\n').map(s => s.trim()).filter(Boolean)) {
-    try { git('rm', '-f', '--ignore-unmatch', '--', file); } catch { /* ignore */ }
-    try { rmSync(join(ROOT, file), { force: true }); } catch { /* already gone */ }
+  for (const file of added.split('\0').filter(Boolean)) {
+    // Never touch something the user already had staged before the update —
+    // only additions THIS update introduced (#2015 review: no data loss).
+    if (protectedPaths.has(file)) continue;
+    let removed = false;
+    try {
+      git('rm', '-f', '--ignore-unmatch', '--', file);
+      removed = true;
+    } catch {
+      // Index removal failed (lock/permission). Leave both the index entry AND
+      // the worktree file in place and keep rolling back the rest — deleting
+      // the worktree copy now would strand a staged addition with no file.
+      console.error(`Rollback: could not unstage ${file}; leaving it untouched.`);
+    }
+    if (removed) {
+      try { rmSync(join(ROOT, file), { force: true }); } catch { /* already gone */ }
+    }
   }
 }
 
@@ -1019,7 +1038,7 @@ async function apply() {
       // through. Revert what we already applied and abort.
       console.error(`Aborting: could not validate user-layer safety (${err.message}).`);
       try {
-        revertPaths(updated);
+        revertPaths(updated, initialStatusPaths);
       } catch (revertErr) {
         // If the revert itself fails (likely whatever broke `git
         // status` also broke `git checkout --`), don't lose the
@@ -1043,7 +1062,7 @@ async function apply() {
       // what to do with them.
       const violation = new Error('Update aborted: user files were touched.');
       try {
-        revertPaths([...updated]);
+        revertPaths([...updated], initialStatusPaths);
       } catch (revertErr) {
         // If the revert itself fails, don't lose the safety-violation
         // diagnostic — chain it via `cause` so the user sees both.

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -652,6 +652,36 @@ function revertPaths(paths) {
       try { git('rm', '-r', '-f', '--ignore-unmatch', '--', pathspec); } catch { /* ignore */ }
       try { rmSync(join(ROOT, pathspec), { recursive: true, force: true }); } catch { /* already gone */ }
     }
+    // A directory pathspec that exists in HEAD checks out cleanly above, so the
+    // catch never runs — but `git checkout HEAD -- docs/` only restores files
+    // HEAD already knows about. Files the update introduced *under* that
+    // directory are not in HEAD, so they survive the rollback as staged
+    // additions and the tree is left dirtier than before the update (#2015).
+    removeAdditionsNotInHead(p);
+  }
+}
+
+/**
+ * Delete files staged as additions relative to HEAD under a pathspec.
+ *
+ * Complements `git checkout HEAD -- <path>`, which restores tracked content but
+ * never removes paths HEAD does not contain. Only additions are considered, so
+ * a user file that merely changed is untouched.
+ *
+ * @param {string} pathspec - SYSTEM_PATHS entry (file or directory).
+ */
+function removeAdditionsNotInHead(pathspec) {
+  const spec = pathspec.endsWith('/') ? pathspec.slice(0, -1) : pathspec;
+  let added = '';
+  try {
+    added = git('diff', '--cached', '--name-only', '--diff-filter=A', 'HEAD', '--', spec);
+  } catch {
+    // No HEAD yet, or an unreadable pathspec — nothing safe to clean up.
+    return;
+  }
+  for (const file of added.split('\n').map(s => s.trim()).filter(Boolean)) {
+    try { git('rm', '-f', '--ignore-unmatch', '--', file); } catch { /* ignore */ }
+    try { rmSync(join(ROOT, file), { force: true }); } catch { /* already gone */ }
   }
 }
 

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -195,6 +195,17 @@ const twoPassManifestChecks = [
     name: 'a checkout failure only skips when the path is absent upstream, else rethrows (#1998)',
     pattern: /catch \{ absentUpstream = true; \}\s*if \(!absentUpstream\) throw err;/,
   },
+  {
+    // `git checkout HEAD -- docs/` restores tracked content but never removes
+    // paths HEAD lacks, so files the update introduced under a directory
+    // pathspec survived the rollback as staged additions (#2015).
+    name: 'revertPaths clears additions HEAD lacks under a directory pathspec (#2015)',
+    pattern: /removeAdditionsNotInHead\(p\)/,
+  },
+  {
+    name: 'removeAdditionsNotInHead only targets additions, never modifications (#2015)',
+    pattern: /'--diff-filter=A'/,
+  },
 ];
 
 for (const check of twoPassManifestChecks) {

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -200,11 +200,33 @@ const twoPassManifestChecks = [
     // paths HEAD lacks, so files the update introduced under a directory
     // pathspec survived the rollback as staged additions (#2015).
     name: 'revertPaths clears additions HEAD lacks under a directory pathspec (#2015)',
-    pattern: /removeAdditionsNotInHead\(p\)/,
+    pattern: /removeAdditionsNotInHead\(p, protectedPaths\)/,
   },
   {
     name: 'removeAdditionsNotInHead only targets additions, never modifications (#2015)',
     pattern: /'--diff-filter=A'/,
+  },
+  {
+    // The cleanup must not delete a file the user already had staged before the
+    // update ran, only additions the update itself introduced (#2015 review).
+    name: 'rollback cleanup skips pre-update staged paths (protectedPaths) (#2015)',
+    pattern: /if \(protectedPaths\.has\(file\)\) continue;/,
+  },
+  {
+    name: 'revertPaths receives the pre-update snapshot at its call sites (#2015)',
+    pattern: /revertPaths\(updated, initialStatusPaths\)/,
+  },
+  {
+    // -z output is NUL-delimited/unquoted, so a path with spaces or newlines is
+    // not mangled by split('\n').trim() (#2015 review).
+    name: 'rollback cleanup parses NUL-delimited git output (#2015)',
+    pattern: /'--cached', '-z', '--name-only', '--diff-filter=A'[\s\S]*?added\.split\('\\0'\)\.filter/,
+  },
+  {
+    // The worktree file is deleted only after git rm succeeds, so a failed
+    // index removal never strands a staged addition with no file (#2015).
+    name: 'rollback deletes the worktree copy only after a successful git rm (#2015)',
+    pattern: /removed = true;[\s\S]{0,400}?if \(removed\) \{[\s\S]{0,80}?rmSync/,
   },
 ];
 


### PR DESCRIPTION
Addresses the **incomplete directory rollback** in #2015 (secondary problem 1). Scoping note on the primary false-positive at the bottom — I could not reproduce that half on current `main` and would rather say so than claim a fix I can't demonstrate.

Thanks @clede — the diagnosis in the report was exactly right, down to naming the four leftover files.

## The bug

`revertPaths` restores each `SYSTEM_PATHS` entry with `git checkout HEAD -- <path>`. That resets tracked content, but it **never removes paths HEAD doesn't contain**. The existing `catch` only fires when the *whole* pathspec is missing from HEAD — so a directory entry that already exists (`docs/`) checks out cleanly, the catch never runs, and files the update introduced *beneath* it survive the "rollback" as staged additions.

Demonstrated in a scratch repo, mirroring v1.20.0 → v1.21.0:

```console
$ git status --porcelain              # after `git checkout FETCH_HEAD -- docs/`
M  docs/EXISTING.md
A  docs/REVIEWING.md
A  docs/logo.png

$ git checkout HEAD -- docs/          # the rollback as it exists today
$ git status --porcelain              # ← the two new files survived
A  docs/REVIEWING.md
A  docs/logo.png
```

Which is precisely what @clede observed: after `Aborting: user files were touched. Rolling back system files...`, `docs/logo.png`, `docs/wordmark-dark.svg`, `docs/wordmark-light.svg` and `docs/REVIEWING.md` were still staged.

## The fix

After each checkout, delete the entries staged as **additions** relative to HEAD under that pathspec:

```js
git('diff', '--cached', '--name-only', '--diff-filter=A', 'HEAD', '--', spec)
```

Same scratch repo, with the fix applied → `git status --porcelain` is empty.

`--diff-filter=A` is the important constraint: only additions are considered, so a file that merely *changed* is never deleted. The helper also returns early when `git diff` fails (no HEAD yet, unreadable pathspec) rather than guessing.

## On the primary complaint (the false-positive SAFETY VIOLATION)

I deliberately did **not** touch that here. `apply()` already snapshots `initialStatusPaths` before doing anything and skips those files in the safety loop (`update-system.mjs:725` / `:885`), and that guard dates back to #119 — so a pre-existing dirty `interview-prep/story-bank.md` should already be exempt, and I couldn't construct a repro against current `main`.

That leaves @clede's own point 2 as the likely live mechanism: on installs predating #944, `story-bank.md` is still **git-tracked**, `.gitignore` isn't in `SYSTEM_PATHS` so `apply` never syncs the new ignore rule, and adding an ignore rule doesn't untrack an already-tracked file. That's a migration problem (something has to run `git rm --cached`), not a bug in the safety check — and it deserves its own decision rather than being smuggled into this PR. Happy to take it if you want to scope it.

## Tests

2 source-level invariants in the existing two-pass-manifest style: revert calls the cleanup for every pathspec, and the cleanup stays scoped to additions.

`node updater-migration-tests.mjs` → **70 passed, 0 failed**
`node test-all.mjs --quick` → **2043 passed, 0 failed**

2 commits (fix + tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety-abort rollback cleanup so directory-scoped staged additions are removed only when they’re missing from the current `HEAD`.
  * Cleanup now targets additions only (not modifications) to reduce unintended changes.
  * Rollback cleanup is constrained to exclude any pre-update staged/dirty paths within the update area.

* **Tests**
  * Expanded migration/rollback coverage to confirm protected-path handling, additions-only filtering, correct NUL-delimited parsing, and that worktree deletions occur only after successful unstaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->