### PR TITLE
fix(update-system): verify the target manifest materialized instead of reporting success (#1998)

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -489,6 +489,25 @@ function missingFromTargetManifest(targetPaths) {
   const missing = [];
   for (const path of targetPaths) {
     const spec = path.endsWith('/') ? path.slice(0, -1) : path;
+
+    // Directory entries need a RECURSIVE check: a pre-existing directory
+    // (`.gemini/commands/`, `docs/`) can still be missing files the target
+    // added under it, and `existsSync` on the directory would wrongly call it
+    // materialized — masking the very partial update this verification exists
+    // to catch. Compare the target tree's files beneath the entry against disk.
+    if (path.endsWith('/')) {
+      let treeFiles = [];
+      try {
+        treeFiles = gitQuiet('ls-tree', '-r', '--name-only', 'FETCH_HEAD', '--', spec)
+          .split('\n').map(s => s.trim()).filter(Boolean);
+      } catch {
+        continue; // FETCH_HEAD unreadable for this spec — treat as stale, not missing
+      }
+      // Empty tree ⇒ the target ships nothing here (stale manifest entry).
+      if (treeFiles.some(f => !existsSync(join(ROOT, f)))) missing.push(path);
+      continue;
+    }
+
     if (existsSync(join(ROOT, spec))) continue;
     // Only count it as missing when the target actually ships it — a manifest
     // entry the target no longer carries is a stale entry, not a failed update.
@@ -869,8 +888,17 @@ async function apply() {
         // update and sends people chasing the wrong root cause (#1998).
         gitQuiet('checkout', 'FETCH_HEAD', '--', path);
         updated.push(path);
-      } catch {
-        // File may not exist in remote (new additions), skip
+      } catch (err) {
+        // A path genuinely absent upstream is the expected skip. But the catch
+        // also caught timeouts, permission errors, and repo corruption and
+        // reported them as skips too — letting a partial update reach the
+        // success banner (#1998). Confirm the path is actually absent from
+        // FETCH_HEAD before treating the failure as benign; otherwise rethrow.
+        const spec = path.endsWith('/') ? path.slice(0, -1) : path;
+        let absentUpstream = false;
+        try { gitQuiet('cat-file', '-e', `FETCH_HEAD:${spec}`); }
+        catch { absentUpstream = true; }
+        if (!absentUpstream) throw err;
         skippedPaths.push(path);
       }
     }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -450,6 +450,56 @@ function git(...args) {
   return gitIn(ROOT, ...args);
 }
 
+/**
+ * git(), but with the child's stderr piped instead of inherited.
+ *
+ * execFileSync inherits stderr by default, so a command whose failure is
+ * expected and handled still prints git's raw error to the console. Use this
+ * where a non-zero exit is a normal outcome the caller reports itself.
+ *
+ * @param {...string} args - git arguments.
+ * @returns {string} Trimmed stdout.
+ */
+function gitQuiet(...args) {
+  const timeout = gitTimeoutMs(args);
+  try {
+    return execFileSync('git', args, {
+      cwd: ROOT, encoding: 'utf-8', timeout, stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch (err) {
+    if (isTimeoutLikeError(err)) {
+      throw new Error(`${describeGitCommand(args)} timed out after ${timeoutSeconds(timeout)}s. If your network is slow, retry or set ${gitTimeoutEnvVar(args)} to a larger value.`);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Paths the target manifest ships that did not materialize on disk.
+ *
+ * apply() reports success without checking that the checkout loop actually
+ * produced a coherent install, so a client whose local manifest predates the
+ * target's silently ends up missing every path added since — and only finds
+ * out when the next script crashes with ERR_MODULE_NOT_FOUND (#1998).
+ *
+ * @param {string[]} targetPaths - SYSTEM_PATHS read from the target updater.
+ * @returns {string[]} Entries present in FETCH_HEAD but absent locally.
+ */
+function missingFromTargetManifest(targetPaths) {
+  const missing = [];
+  for (const path of targetPaths) {
+    const spec = path.endsWith('/') ? path.slice(0, -1) : path;
+    if (existsSync(join(ROOT, spec))) continue;
+    // Only count it as missing when the target actually ships it — a manifest
+    // entry the target no longer carries is a stale entry, not a failed update.
+    try {
+      gitQuiet('cat-file', '-e', `FETCH_HEAD:${spec}`);
+      missing.push(path);
+    } catch { /* absent upstream too — nothing to materialize */ }
+  }
+  return missing;
+}
+
 function gitStatusEntries() {
   const status = git('status', '--porcelain');
   if (!status) return [];
@@ -808,13 +858,24 @@ async function apply() {
     // target updater's SYSTEM_PATHS is now the source of truth for new files.
     const updatePaths = mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS);
 
+    const skippedPaths = [];
     for (const path of updatePaths) {
       try {
-        git('checkout', 'FETCH_HEAD', '--', path);
+        // stderr is piped rather than inherited here. A path absent upstream is
+        // an EXPECTED skip (a stale manifest entry such as `.gemini/commands/`),
+        // but execFileSync inherits stderr by default, so git printed
+        // `error: pathspec '...' did not match any file(s) known to git`
+        // immediately before the success banner — which reads as a failed
+        // update and sends people chasing the wrong root cause (#1998).
+        gitQuiet('checkout', 'FETCH_HEAD', '--', path);
         updated.push(path);
       } catch {
         // File may not exist in remote (new additions), skip
+        skippedPaths.push(path);
       }
+    }
+    if (skippedPaths.length > 0) {
+      console.log(`Skipped ${skippedPaths.length} path(s) absent upstream: ${skippedPaths.join(', ')}`);
     }
 
     // tests/ is auto-discovered and EXECUTED (tests/**/*.test.mjs), so stale
@@ -997,6 +1058,24 @@ async function apply() {
         );
       }
       // Otherwise, genuinely nothing to commit (already up to date)
+    }
+
+    // Verify the update actually produced a coherent install before claiming
+    // success. A client whose local manifest predates the target checks out
+    // only the paths ITS OWN manifest lists, so everything added upstream since
+    // is silently absent and the next script dies with ERR_MODULE_NOT_FOUND.
+    // Re-running apply fixes it (the first pass did update update-system.mjs
+    // itself, so the second pass uses the target manifest) — but only if the
+    // user is told, instead of being shown "Update complete" (#1998).
+    const unmaterialized = missingFromTargetManifest(remoteSystemPaths);
+    if (unmaterialized.length > 0) {
+      console.error(`\nUpdate incomplete: v${local} → v${remote}`);
+      console.error(`${unmaterialized.length} path(s) from the target manifest were not checked out:`);
+      for (const path of unmaterialized) console.error(`  ${path}`);
+      console.error('\nThis happens when the installed updater predates the paths the target adds.');
+      console.error('Run `node update-system.mjs apply` again — the updater itself is now current,');
+      console.error('so the second pass uses the target manifest and picks up what this one missed.');
+      process.exit(1);
     }
 
     console.log(`\nUpdate complete: v${local} → v${remote}`);

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -160,6 +160,27 @@ const twoPassManifestChecks = [
     name: 'apply captures uncommitted work via git stash create before branching (#915)',
     pattern: /git\('stash',\s*'create'\)/,
   },
+  {
+    // A client whose manifest predates the target checks out only its own
+    // paths, so everything added upstream since is silently absent and apply
+    // still printed "Update complete" (#1998).
+    name: 'apply verifies the target manifest materialized before claiming success (#1998)',
+    pattern: /missingFromTargetManifest\(remoteSystemPaths\)/,
+  },
+  {
+    name: 'an incomplete apply exits non-zero instead of reporting success (#1998)',
+    pattern: /Update incomplete[\s\S]{0,600}?process\.exit\(1\)/,
+  },
+  {
+    // execFileSync inherits stderr, so an expected per-path skip printed git's
+    // raw pathspec error right before the success banner (#1998).
+    name: 'per-path checkout pipes stderr so expected skips stay quiet (#1998)',
+    pattern: /gitQuiet\('checkout',\s*'FETCH_HEAD',\s*'--',\s*path\)/,
+  },
+  {
+    name: 'skipped upstream-absent paths are summarized explicitly (#1998)',
+    pattern: /Skipped \$\{skippedPaths\.length\} path\(s\) absent upstream/,
+  },
 ];
 
 for (const check of twoPassManifestChecks) {

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -181,6 +181,20 @@ const twoPassManifestChecks = [
     name: 'skipped upstream-absent paths are summarized explicitly (#1998)',
     pattern: /Skipped \$\{skippedPaths\.length\} path\(s\) absent upstream/,
   },
+  {
+    // existsSync on a pre-existing directory (docs/) would call it materialized
+    // even when the target added files under it — the verification must recurse
+    // into directory entries against FETCH_HEAD (#1998 CodeRabbit review).
+    name: 'manifest verification recurses into directory entries via ls-tree (#1998)',
+    pattern: /ls-tree', '-r', '--name-only', 'FETCH_HEAD'[\s\S]{0,400}?treeFiles\.some\(f => !existsSync/,
+  },
+  {
+    // A checkout failure is only an expected skip when the path is truly absent
+    // from FETCH_HEAD; timeouts/permission errors must rethrow, not report
+    // success (#1998 CodeRabbit review).
+    name: 'a checkout failure only skips when the path is absent upstream, else rethrows (#1998)',
+    pattern: /catch \{ absentUpstream = true; \}\s*if \(!absentUpstream\) throw err;/,
+  },
 ];
 
 for (const check of twoPassManifestChecks) {


### PR DESCRIPTION
Closes #1998 (suggested fixes 1 and 3). Fix 2 is a docs/release-note item — happy to add it here if you'd rather it ship together.

Thanks @Dreamkeeper — the report already contained the correct root cause *and* the right fix; this is mostly implementing what you specified.

## What breaks today

A client on ≤1.10.0 runs its **own** `SYSTEM_PATHS` through the checkout loop. It has no knowledge of paths added upstream since, so it never attempts them — then prints:

```
Updated 104 system paths.
Update complete: v1.10.0 → v1.20.0
```

…on an install that is missing `plugins/`, `lib/`, `browser-extract.mjs` and ~380 other files, and the next command dies with `ERR_MODULE_NOT_FOUND`. Two things made it hard to diagnose, both addressed here.

## 1. Post-apply verification (fix 1)

`apply()` never checked that the checkout loop produced a coherent install. It now compares the **target** manifest (already read from `FETCH_HEAD:update-system.mjs` into `remoteSystemPaths`) against what is actually on disk, and refuses to claim success:

```
Update incomplete: v1.10.0 → v1.20.0
3 path(s) from the target manifest were not checked out:
  plugins/
  lib/
  browser-extract.mjs

This happens when the installed updater predates the paths the target adds.
Run `node update-system.mjs apply` again — the updater itself is now current,
so the second pass uses the target manifest and picks up what this one missed.
```

…and exits non-zero. This surfaces your own recovery (`apply` twice) at the exact moment it's needed, and it also catches any future manifest-merge regression, not just the ≤1.10.0 population.

An entry is only counted as missing when the target genuinely ships it (`git cat-file -e FETCH_HEAD:<spec>`), so a **stale** manifest entry the target no longer carries is never mistaken for a failed update.

## 2. Quiet the expected skips (fix 3)

`execFileSync` inherits stderr by default, so a deliberately-tolerated per-path failure still printed git's raw error immediately before the success banner — which is what sent you chasing a batched-checkout theory. The loop now goes through a `gitQuiet` helper that pipes stderr, and expected skips are summarized once:

```
Skipped 1 path(s) absent upstream: .gemini/commands/
```

`gitQuiet` is a narrow addition rather than a change to `git()` — only calls whose non-zero exit is a normal, self-reported outcome should hide stderr.

## Scope

Nothing changes for a healthy update: when everything materializes, `unmaterialized` is empty and output is byte-identical apart from the skip summary when one applies.

## Tests

4 source-level invariants in the existing two-pass-manifest style (verification runs, incomplete exits non-zero, checkout uses the quiet helper, skips are summarized). Also smoke-tested `update-system.mjs check` and confirmed the piped-stderr behavior directly.

`node updater-migration-tests.mjs` → **72 passed, 0 failed**
`node test-all.mjs --quick` → **2043 passed, 0 failed**

2 commits (fix + tests).

> Note: this and #2110 both touch `update-system.mjs` but different functions (`apply()` here, `revertPaths` there) — they should merge independently in either order. Happy to rebase whichever lands second.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system update behavior when upstream paths are missing.
  * Checkout failures now suppress unnecessary raw Git noise and instead summarize truly skipped paths.
  * Added a post-update completeness check; incomplete updates now fail with a non-zero exit and direct you to rerun the update.

* **Tests**
  * Expanded updater migration test coverage for incomplete updates, quiet checkout handling, skipped-path summaries, and manifest verification (including recursive directory entries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->