### PR TITLE
Bump gemini-eval default model to gemini-3.6-flash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,13 +6,13 @@
 # ── Gemini Integration ────────────────────────────────────────────────────────
 # Required for: node gemini-eval.mjs "JD text here"
 # Free API key: https://aistudio.google.com/apikey
-# Free tier: 15 RPM / 1M tokens/day with gemini-2.5-flash (no billing needed)
+# Free tier: rate-limited usage with gemini-3.6-flash (no billing needed)
 GEMINI_API_KEY=your_gemini_api_key_here
 
 # ── Optional: Override default Gemini model ───────────────────────────────────
-# Default: gemini-2.5-flash (free-tier, fast)
-# Alternatives: gemini-1.5-flash, gemini-1.5-pro, gemini-2.5-flash-thinking-exp
-# GEMINI_MODEL=gemini-2.5-flash
+# Default: gemini-3.6-flash (stable Flash)
+# Alternatives: gemini-3.5-flash, gemini-3.1-flash-lite, gemini-2.5-pro
+# GEMINI_MODEL=gemini-3.6-flash
 
 # ── OpenRouter Integration (openrouter-runner.mjs — no-CLI, $0 free tier) ─────
 # Required for: node openrouter-runner.mjs

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ GEMINI_API_KEY=your_gemini_api_key_here
 
 # ── Optional: Override default Gemini model ───────────────────────────────────
 # Default: gemini-3.6-flash (stable Flash)
-# Alternatives: gemini-3.5-flash, gemini-3.1-flash-lite, gemini-2.5-pro
+# Alternatives: gemini-3.5-flash, gemini-2.5-pro
 # GEMINI_MODEL=gemini-3.6-flash
 
 # ── OpenRouter Integration (openrouter-runner.mjs — no-CLI, $0 free tier) ─────

--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -21,7 +21,7 @@
  *   - gemini-2.0-flash-lite  deprecated 2026-03-31
  *   - gemini-2.5-flash       deprecated 2026-06-17
  *   - gemini-2.5-flash-lite  deprecated 2026-07-22
- *   - gemini-3.5-flash       superseded by 3.6-flash
+ *   - gemini-3.5-flash       prior Flash generation (still available)
  *   - gemini-3.6-flash       current default (stable)
  * Stable Gemini models follow a 12-month lifecycle from their release date.
  * Source: https://ai.google.dev/gemini-api/docs/models

--- a/gemini-eval.mjs
+++ b/gemini-eval.mjs
@@ -14,13 +14,15 @@
  * Requires:
  *   GEMINI_API_KEY in .env (or environment variable)
  *
- * Free-tier model: gemini-2.5-flash (generous quota, no billing required)
+ * Default model: gemini-3.6-flash (GA July 2026)
  *
  * Model deprecation reference (per Google AI for Developers, May 2026):
- *   - gemini-2.0-flash       deprecated 2026-03-31  (do not use)
+ *   - gemini-2.0-flash       deprecated 2026-03-31  (do not use — generateContent 404)
  *   - gemini-2.0-flash-lite  deprecated 2026-03-31
- *   - gemini-2.5-flash       deprecated 2026-06-17  (current default)
+ *   - gemini-2.5-flash       deprecated 2026-06-17
  *   - gemini-2.5-flash-lite  deprecated 2026-07-22
+ *   - gemini-3.5-flash       superseded by 3.6-flash
+ *   - gemini-3.6-flash       current default (stable)
  * Stable Gemini models follow a 12-month lifecycle from their release date.
  * Source: https://ai.google.dev/gemini-api/docs/models
  *
@@ -89,11 +91,11 @@ if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
   USAGE
     node gemini-eval.mjs "<JD text>"
     node gemini-eval.mjs --file ./jds/my-job.txt
-    node gemini-eval.mjs --model gemini-2.5-flash "<JD text>"
+    node gemini-eval.mjs --model gemini-3.6-flash "<JD text>"
 
   OPTIONS
     --file <path>    Read JD from a file instead of inline text
-    --model <name>   Gemini model to use (default: gemini-2.5-flash)
+    --model <name>   Gemini model to use (default: gemini-3.6-flash)
     --no-save        Do not save report to reports/ directory
     --help           Show this help
 
@@ -111,7 +113,7 @@ if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
 
 // Parse flags
 let jdText = '';
-let modelName = process.env.GEMINI_MODEL || 'gemini-2.5-flash';
+let modelName = process.env.GEMINI_MODEL || 'gemini-3.6-flash';
 let saveReport = true;
 
 for (let i = 0; i < args.length; i++) {

--- a/utils/token-tracker.mjs
+++ b/utils/token-tracker.mjs
@@ -7,7 +7,9 @@ export const RATES = {
   'gpt-4o-mini': { input: 0.150 / 1000000, output: 0.600 / 1000000 },
   'gpt-4o': { input: 2.50 / 1000000, output: 10.00 / 1000000 },
 
-  // Gemini models
+  // Gemini models (Developer API paid tier, USD per token; free tier is $0)
+  'gemini-3.6-flash': { input: 1.50 / 1000000, output: 7.50 / 1000000, cachedInput: 0.15 / 1000000 },
+  'gemini-3.5-flash': { input: 1.50 / 1000000, output: 9.00 / 1000000, cachedInput: 0.15 / 1000000 },
   'gemini-2.5-flash': { input: 0.075 / 1000000, output: 0.300 / 1000000, cachedInput: 0.0375 / 1000000 },
   'gemini-2.5-pro': { input: 1.25 / 1000000, output: 5.00 / 1000000, cachedInput: 0.625 / 1000000 },
 
@@ -66,7 +68,7 @@ export function estimateCost(model, usage, provider) {
     if (provider === 'openai') {
       rate = RATES['gpt-4o-mini'];
     } else if (provider === 'gemini') {
-      rate = RATES['gemini-2.5-flash'];
+      rate = RATES['gemini-3.6-flash'];
     } else if (provider === 'claude' || provider === 'anthropic') {
       rate = RATES['claude-3-5-sonnet'];
     } else {


### PR DESCRIPTION
Cherry-pick model default/docs/help only. Preserve prompt-cache and token-tracker.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the default Gemini model to `gemini-3.6-flash`.
  * Refreshed CLI help text and examples to match the new default.
  * Kept model selection customizable via the `GEMINI_MODEL` environment variable or `--model` option.
* **Documentation**
  * Updated `.env.example` with revised Gemini model guidance and default recommendations.
  * Added an `OPENROUTER_API_KEY` placeholder to `.env.example`.
* **Bug Fixes**
  * Updated Gemini cost estimates and rate tables to reflect `gemini-3.6-flash` and `gemini-3.5-flash` pricing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->