### PR TITLE
docs: fix incorrect npm script reference for build-cv-latex.mjs

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -13,7 +13,7 @@ All scripts live in the project root as `.mjs` modules and are exposed via `npm 
 | `npm run merge` | `merge-tracker.mjs` | Merge batch TSVs into applications.md |
 | `npm run pdf` | `generate-pdf.mjs` | Convert HTML to ATS-optimized PDF |
 | `npm run img-to-pdf` | `img-to-pdf.mjs` | Convert a single screenshot/image into a single-page PDF |
-| `npm run build:latex` | `build-cv-latex.mjs` | Build .tex from structured JSON payload |
+| `node build-cv-latex.mjs` | `build-cv-latex.mjs` | Build .tex from structured JSON payload |
 | `npm run sync-check` | `cv-sync-check.mjs` | Validate CV/profile consistency |
 | `npm run patterns` | `analyze-patterns.mjs` | Analyze tracker outcomes and report patterns |
 | `npm run upskill` | `upskill.mjs` | Aggregate skill-gap map from tracked reports (or `--url-text <url\|file>` for a single-JD targeted gap analysis) |
@@ -150,7 +150,7 @@ MVP scope: one image in, one PDF page out. Multi-image/multi-page conversion is 
 
 ---
 
-## build:latex
+## build-cv-latex.mjs
 
 Builds a `.tex` file from a structured JSON payload, handling template merge and LaTeX escaping automatically. The JSON is produced by the agent during evaluation — this script replaces the manual LaTeX generation step in `modes/latex.md`.
 


### PR DESCRIPTION
## Summary
- `docs/SCRIPTS.md` documented `build-cv-latex.mjs` as runnable via `npm run build:latex`, but no such script exists in `package.json`.
- The script's own usage example (a few lines below) and `modes/latex.md` both invoke it directly with `node build-cv-latex.mjs`.
- Updated the quick-reference table row and section header to match actual usage.

## Test plan
- [x] Confirmed no `build:latex` entry exists in `package.json`
- [x] Confirmed no other table row uses an `npm run` command that doesn't exist
- Docs-only change, no functional code affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the script reference to use the direct `node build-cv-latex.mjs` command.
  * Renamed the related documentation section to match the current script name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->