### PR TITLE
Add Cursor CLI support

### DIFF
--- a/.agents/skills/career-ops/SKILL.md
+++ b/.agents/skills/career-ops/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: career-ops
-description: AI job search command center -- evaluate offers, tailor CVs, scan portals, track applications. Use when the user pastes a job description or URL, asks to evaluate an offer, tailor a resume or cover letter, scan job boards, prepare for an interview, or track/update their applications.
+description: >-
+  AI job search command center -- evaluate offers, generate CVs, scan portals,
+  track applications. Use when the user pastes a job URL or JD, asks to scan
+  portals, generate a CV/PDF, track applications, prepare for interviews, draft
+  outreach/emails, or run any career-ops mode.
 arguments: mode
 user_invocable: true
 user-invocable: true
@@ -15,6 +19,7 @@ career-ops is a multi-CLI job-search command center. The routing below is shared
 ## Invocation Notes
 
 - CLIs with slash-command registration can expose this router as `/career-ops`.
+- In Cursor, this skill lives at `.cursor/skills/career-ops/` and is auto-discovered; ask for a mode by name, or paste a JD/URL to trigger auto-pipeline.
 - Interactive Codex sessions use `codex` in the repo root. Slash commands are not guaranteed in Codex, so ask Codex to run the same mode by name if `/career-ops` is unavailable.
 - Headless Codex workers use `codex exec "prompt"`.
 - The routing semantics below stay the same regardless of whether the entrypoint is a slash command or a natural-language prompt.

--- a/.cursor/skills/career-ops/SKILL.md
+++ b/.cursor/skills/career-ops/SKILL.md
@@ -1,0 +1,1 @@
+../../../.agents/skills/career-ops/SKILL.md

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,7 @@
           - modes/*.md
           - modes/**/*.md
           - .claude/skills/**
+          - .cursor/skills/**
           - .opencode/skills/**
           - .qwen/skills/**
           - .antigravitycli/skills/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ If yes → `node update-system.mjs apply`. If no → `node update-system.mjs dis
 
 ## What is career-ops
 
-AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluation, CV generation, portal scanning, batch processing. Runs on any AI coding CLI following the [open agent skill standard](https://agentskills.io) (Claude Code, Codex, OpenCode, Qwen, Copilot, Kimi, Antigravity CLI, Grok Build CLI). Legacy Gemini API evaluation remains via `gemini-eval.mjs`.
+AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluation, CV generation, portal scanning, batch processing. Runs on any AI coding CLI following the [open agent skill standard](https://agentskills.io) (Claude Code, Cursor, Codex, OpenCode, Qwen, Copilot, Kimi, Antigravity CLI, Grok Build CLI). Legacy Gemini API evaluation remains via `gemini-eval.mjs`.
 
 ### Codex invocation
 

--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -94,6 +94,7 @@ These files contain system logic, scripts, templates, and instructions that impr
 | `templates/*` | Base templates |
 | `fonts/*` | Self-hosted fonts |
 | `.claude/skills/*` | Skill definitions (Claude Code) |
+| `.cursor/skills/*` | Skill definitions (Cursor) |
 | `.opencode/skills/*` | Skill definitions (OpenCode) |
 | `.qwen/skills/*` | Skill definitions (Qwen Code) |
 | `.antigravitycli/skills/*` | Skill definitions (Antigravity CLI) |

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ agy
 /career-ops tracker
 ```
 
-The skill is defined using the open standard in `.agents/skills/career-ops/SKILL.md` and symlinked/referenced for each supported CLI (e.g. `.claude/`, `.qwen/`, `.antigravitycli/`, `.grok/`).
+The skill is defined using the open standard in `.agents/skills/career-ops/SKILL.md` and symlinked/referenced for each supported CLI (e.g. `.claude/`, `.cursor/`, `.qwen/`, `.antigravitycli/`, `.grok/`).
 
 ## Codex Integration
 

--- a/scaffolder/bin/skill-entrypoints.mjs
+++ b/scaffolder/bin/skill-entrypoints.mjs
@@ -13,6 +13,10 @@ export const SKILL_ENTRYPOINTS = [
     pointer: '../../../.agents/skills/career-ops/SKILL.md',
   },
   {
+    path: '.cursor/skills/career-ops/SKILL.md',
+    pointer: '../../../.agents/skills/career-ops/SKILL.md',
+  },
+  {
     path: '.opencode/skills/career-ops/SKILL.md',
     pointer: '../../../.agents/skills/career-ops/SKILL.md',
   },

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -698,6 +698,7 @@ const systemFiles = [
   'modes/heuristics/recruiter-side.md',
   'templates/states.yml', 'templates/cv-template.html',
   '.claude/skills/career-ops/SKILL.md',
+  '.cursor/skills/career-ops/SKILL.md',
   '.opencode/skills/career-ops/SKILL.md',
   '.qwen/skills/career-ops/SKILL.md',
   '.antigravitycli/skills/career-ops/SKILL.md',
@@ -3183,6 +3184,7 @@ console.log('\n12. Skill symlink integrity');
 const canonicalSkill = '.agents/skills/career-ops/SKILL.md';
 const symlinks = [
   '.claude/skills/career-ops/SKILL.md',
+  '.cursor/skills/career-ops/SKILL.md',
   '.opencode/skills/career-ops/SKILL.md',
   '.qwen/skills/career-ops/SKILL.md',
   '.antigravitycli/skills/career-ops/SKILL.md',
@@ -3339,6 +3341,7 @@ console.log('\n12b. Skill entrypoint bootstrap (npx / old releases)');
     const expectedTouched = [
       '.antigravitycli/skills/career-ops/SKILL.md',
       '.claude/skills/career-ops/SKILL.md',
+      '.cursor/skills/career-ops/SKILL.md',
       '.grok/skills/career-ops/SKILL.md',
       '.opencode/skills/career-ops/SKILL.md',
       '.qwen/skills/career-ops/SKILL.md',

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -225,6 +225,7 @@ const SYSTEM_PATHS = [
   '.editorconfig',
   '.agents/',
   '.claude/skills/',
+  '.cursor/skills/',
   '.opencode/skills/',
   '.opencode/commands/',
   '.claude-plugin/',
@@ -296,6 +297,7 @@ const SYSTEM_PATHS = [
 
 const BOOTSTRAP_PATHS = [
   '.agents/',
+  '.cursor/skills/',
   '.opencode/skills/',
   '.antigravitycli/skills/',
   '.grok/skills/',

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -64,6 +64,7 @@ const requiredSystemPaths = [
   '.qwen/',
   '.antigravitycli/skills/',
   '.grok/skills/',
+  '.cursor/skills/',
   'tracker-columns-tests.mjs',
   'updater-migration-tests.mjs',
   'README.ar.md',
@@ -81,6 +82,7 @@ const requiredSystemPaths = [
 
 const requiredBootstrapPaths = [
   '.agents/',
+  '.cursor/skills/',
   '.opencode/skills/',
   '.antigravitycli/skills/',
   '.grok/skills/',


### PR DESCRIPTION
## What does this PR do?

Adds Cursor as a supported CLI host for career-ops. It introduces a .cursor/skills/career-ops/SKILL.md entrypoint (symlinked to the canonical .agents/skills/career-ops/SKILL.md), wires it into the skill bootstrap/update paths, and updates docs and tests so the shared router is auto-discovered in Cursor IDE and Cursor CLI (agent).

## Related issue

None — happy to open one if maintainers prefer issue-first for new CLI hosts.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cursor CLI support for the career-ops skill.
  * Users can trigger career-ops modes by name or provide a job URL or description to start the appropriate workflow.
  * Cursor skill setup and updates are now handled automatically alongside supported integrations.

* **Documentation**
  * Updated career-ops guidance to describe its AI job search command center capabilities and Cursor invocation options.

* **Tests**
  * Expanded validation to cover Cursor skill installation, updates, and integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->