### PR TITLE
Add funded company discovery command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ career-ops is the first reference implementation of [the CareerOps Manifesto](ht
 | **Cover Letter Generator** | Research-backed cover letters with keyword mirroring, four interactive angle prompts (why/problems/approach/tone), draft-in-chat approval gate, and A4 PDF via the same HTML + Playwright pipeline as CVs. Auto-drafts on every evaluation; complete and generate on demand via `/career-ops cover` |
 | **Application Email Drafts** | Formal recruiter/referral/cold application emails from a report or pasted JD, with subject line, attachment checklist, source-backed fit points, and a profile-driven contact block. Draft-only -- career-ops never sends, submits, or clicks anything. |
 | **Portal Scanner**       | 100+ companies pre-configured (Anthropic, OpenAI, ElevenLabs, Retool, n8n...) + custom queries across Ashby, Greenhouse, Lever, Wellfound |
+| **Funded Company Discovery** | Review-first `company:funded` command surfaces recently funded companies, source diagnostics, and suggested `portals.yml` entries without editing your data |
 | **Batch Processing**     | Parallel evaluation with headless CLI workers (`claude -p` / `opencode run`)                                                             |
 | **Dashboard TUI**        | Terminal UI to browse, filter, and sort your pipeline                                                                                    |
 | **Human-in-the-Loop**    | AI evaluates and recommends, you decide and act. The system never submits an application -- you always have the final call               |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ career-ops is the first reference implementation of [the CareerOps Manifesto](ht
 | **Cover Letter Generator** | Research-backed cover letters with keyword mirroring, four interactive angle prompts (why/problems/approach/tone), draft-in-chat approval gate, and A4 PDF via the same HTML + Playwright pipeline as CVs. Auto-drafts on every evaluation; complete and generate on demand via `/career-ops cover` |
 | **Application Email Drafts** | Formal recruiter/referral/cold application emails from a report or pasted JD, with subject line, attachment checklist, source-backed fit points, and a profile-driven contact block. Draft-only -- career-ops never sends, submits, or clicks anything. |
 | **Portal Scanner**       | 100+ companies pre-configured (Anthropic, OpenAI, ElevenLabs, Retool, n8n...) + custom queries across Ashby, Greenhouse, Lever, Wellfound |
-| **Funded Company Discovery** | Review-first `company:funded` command surfaces recently funded companies, source diagnostics, and suggested `portals.yml` entries without editing your data |
+| **Funded Company Discovery** | Review-first `company:funded` command surfaces recently funded companies and source diagnostics from structured public feeds without editing your data |
 | **Batch Processing**     | Parallel evaluation with headless CLI workers (`claude -p` / `opencode run`)                                                             |
 | **Dashboard TUI**        | Terminal UI to browse, filter, and sort your pipeline                                                                                    |
 | **Human-in-the-Loop**    | AI evaluates and recommends, you decide and act. The system never submits an application -- you always have the final call               |

--- a/company-funded.mjs
+++ b/company-funded.mjs
@@ -1,0 +1,1380 @@
+#!/usr/bin/env node
+
+/**
+ * company-funded.mjs - discover recently funded companies for manual review.
+ *
+ * This is intentionally review-first: it writes a report/JSON candidate list,
+ * never portals.yml. Add approved entries manually after review.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import yaml from 'js-yaml';
+
+import { deriveSlugCandidates } from './verify-portals.mjs';
+import { loadProviders, resolveProvider } from './providers/_registry.mjs';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
+const PROVIDERS_DIR = resolve(ROOT, 'providers');
+const DEFAULT_LIMIT = 20;
+const DEFAULT_MONTHS = 3;
+const DEFAULT_SORT = 'date';
+const DEFAULT_SOURCES = ['techcrunch', 'prnewswire', 'guardian', 'hn'];
+const DEFAULT_ENRICH_CONCURRENCY = 3;
+const DEFAULT_ENRICH_TIMEOUT_MS = 20_000;
+const QUICK_FETCH_TIMEOUT_MS = 5_000;
+const BROWSER_UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+
+const SOURCE_RANK = {
+  techcrunch: 70,
+  prnewswire: 65,
+  guardian: 50,
+  hacker_news: 35,
+  duckduckgo: 10,
+  web: 5,
+};
+
+const RSS_SOURCES = {
+  techcrunch: [
+    'https://techcrunch.com/feed/',
+    'https://techcrunch.com/category/startups/feed/',
+    'https://techcrunch.com/tag/funding/feed/',
+  ],
+  prnewswire: [
+    'https://www.prnewswire.com/rss/news-releases-list.rss',
+    'https://www.prnewswire.com/rss/venture-capital-list.rss',
+  ],
+  guardian: ['https://www.theguardian.com/technology/rss'],
+};
+
+const GENERIC_NAMES = new Set([
+  'ai',
+  'startup',
+  'startups',
+  'company',
+  'companies',
+  'founder',
+  'founders',
+  'developer',
+  'developers',
+  'techcrunch',
+  'pr newswire',
+  'business wire',
+  'globenewswire',
+  'crunchbase',
+  'hacker news',
+  'valuation',
+  'valuations',
+  'bubble',
+  'fears',
+  'funding',
+  'fund',
+  'round',
+]);
+
+const BLOCKED_HOST_PARTS = [
+  'linkedin.',
+  'crunchbase.',
+  'wikipedia.',
+  'facebook.',
+  'instagram.',
+  'twitter.',
+  'x.com',
+  'youtube.',
+  'glassdoor.',
+  'indeed.',
+  'wellfound.',
+  'tracxn.',
+  'pitchbook.',
+  'bloomberg.',
+];
+
+const MONTH_INDEX = {
+  jan: 0,
+  january: 0,
+  feb: 1,
+  february: 1,
+  mar: 2,
+  march: 2,
+  apr: 3,
+  april: 3,
+  may: 4,
+  jun: 5,
+  june: 5,
+  jul: 6,
+  july: 6,
+  aug: 7,
+  august: 7,
+  sep: 8,
+  sept: 8,
+  september: 8,
+  oct: 9,
+  october: 9,
+  nov: 10,
+  november: 10,
+  dec: 11,
+  december: 11,
+};
+
+function usage() {
+  console.log(`Usage:
+  node company-funded.mjs --dry-run
+  node company-funded.mjs --limit 25 --months 6 --sort date
+  node company-funded.mjs --sources techcrunch,prnewswire,guardian,hn --dry-run
+  node company-funded.mjs --query "agentic AI Series A funding" --dry-run
+
+Options:
+  --limit <n>             Max companies in the review list. Default: 20.
+  --months <n>            Recent-funding window. Default: 3.
+  --sort <date|score>     Candidate ordering. Default: date.
+  --sources <csv>         Sources. Default: techcrunch,prnewswire,guardian,hn.
+                           Also accepts duckduckgo/search as opt-in fallback.
+  --query <text>          Add a DuckDuckGo fallback discovery query. Can be repeated.
+  --include-existing      Include companies already present in portals.yml.
+  --enrich                Resolve careers URLs/provider paths. This is the default.
+  --no-enrich             Fast mode: skip careers/scanner resolution.
+  --dry-run               Print only; do not write report/JSON files.
+  --json                  Print machine-readable JSON.
+  --portals <path>        portals.yml path. Default: portals.yml.
+  --self-test             Run offline self-test.
+`);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    limit: DEFAULT_LIMIT,
+    months: DEFAULT_MONTHS,
+    sort: DEFAULT_SORT,
+    sources: [...DEFAULT_SOURCES],
+    dryRun: false,
+    json: false,
+    includeExisting: false,
+    enrich: true,
+    queries: [],
+    portalsPath: DEFAULT_PORTALS_PATH,
+    selfTest: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--dry-run') opts.dryRun = true;
+    else if (arg === '--json') opts.json = true;
+    else if (arg === '--include-existing') opts.includeExisting = true;
+    else if (arg === '--enrich') opts.enrich = true;
+    else if (arg === '--no-enrich') opts.enrich = false;
+    else if (arg === '--self-test') opts.selfTest = true;
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+    else if (arg === '--limit') opts.limit = Number(argv[++i] || '');
+    else if (arg === '--months') opts.months = Number(argv[++i] || '');
+    else if (arg === '--sort') opts.sort = String(argv[++i] || '').trim().toLowerCase();
+    else if (arg === '--sources') opts.sources = parseSources(argv[++i] || '');
+    else if (arg === '--query') opts.queries.push(argv[++i] || '');
+    else if (arg === '--portals' || arg === '--file') opts.portalsPath = argv[++i] || '';
+    else throw new Error(`unknown option: ${arg}`);
+  }
+  if (!Number.isInteger(opts.limit) || opts.limit <= 0 || opts.limit > 100) {
+    throw new Error('--limit must be an integer from 1 to 100');
+  }
+  if (!Number.isInteger(opts.months) || opts.months <= 0 || opts.months > 120) {
+    throw new Error('--months must be an integer from 1 to 120');
+  }
+  if (!['date', 'score'].includes(opts.sort)) {
+    throw new Error('--sort must be date or score');
+  }
+  opts.queries = opts.queries.map((q) => q.trim()).filter(Boolean);
+  if (opts.queries.length && !opts.sources.includes('duckduckgo')) opts.sources.push('duckduckgo');
+  return opts;
+}
+
+function parseSources(value) {
+  const out = String(value || '')
+    .split(',')
+    .map((s) => normalizeSourceName(s.trim()))
+    .filter(Boolean);
+  const unique = [...new Set(out)];
+  const allowed = new Set(['techcrunch', 'prnewswire', 'guardian', 'hn', 'duckduckgo']);
+  for (const source of unique) {
+    if (!allowed.has(source)) throw new Error(`unknown source in --sources: ${source}`);
+  }
+  return unique.length ? unique : [...DEFAULT_SOURCES];
+}
+
+function normalizeSourceName(value) {
+  const s = String(value || '').toLowerCase().replace(/[_\s]+/g, '-');
+  if (s === 'hacker-news' || s === 'hackernews' || s === 'hn') return 'hn';
+  if (s === 'ddg' || s === 'duck-duck-go' || s === 'search') return 'duckduckgo';
+  return s.replace(/-/g, '');
+}
+
+function compact(text) {
+  return String(text || '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeName(name) {
+  return compact(name);
+}
+
+function companySlug(name) {
+  return compact(name)
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '')
+    .trim();
+}
+
+function decodeHtml(text) {
+  return String(text || '')
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(Number.parseInt(n, 16)))
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+function stripHtmlTags(text) {
+  return compact(decodeHtml(String(text || '').replace(/<script[\s\S]*?<\/script>/gi, ' ').replace(/<style[\s\S]*?<\/style>/gi, ' ').replace(/<[^>]+>/g, ' ')));
+}
+
+function isBlockedHost(url) {
+  let host;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return true;
+  }
+  return BLOCKED_HOST_PARTS.some((part) => host === part.replace(/\.$/, '') || host.includes(part));
+}
+
+export function parseDuckDuckGoResults(html, { allowBlockedHosts = false } = {}) {
+  const out = [];
+  const re = /<a\b[^>]*\bclass="[^"]*\bresult__a\b[^"]*"[^>]*>/gi;
+  for (const match of String(html || '').matchAll(re)) {
+    const hrefMatch = match[0].match(/\bhref="([^"]+)"/i);
+    if (!hrefMatch) continue;
+    let href = decodeHtml(hrefMatch[1]);
+    if (href.startsWith('//')) href = `https:${href}`;
+    try {
+      const parsed = new URL(href, 'https://duckduckgo.com');
+      if (parsed.hostname.includes('duckduckgo.com') && parsed.pathname === '/l/') {
+        const target = parsed.searchParams.get('uddg');
+        if (target) href = target;
+      } else {
+        href = parsed.href;
+      }
+      if (/^https?:\/\//i.test(href) && (allowBlockedHosts || !isBlockedHost(href))) {
+        out.push({ url: href, title: stripHtmlTags(match[0]) });
+      }
+    } catch {
+      // Ignore malformed search-result links.
+    }
+  }
+  const seen = new Set();
+  return out.filter((item) => {
+    const key = item.url.replace(/\/+$/, '');
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function stripPublisher(title) {
+  return compact(title)
+    .replace(/\s+\|\s+.*$/i, '')
+    .replace(/\s+-\s+(TechCrunch|Crunchbase|Forbes|Reuters|Bloomberg|BusinessWire|PR Newswire|SiliconANGLE|VentureBeat|The Guardian).*$/i, '')
+    .replace(/^Show HN:\s*/i, '')
+    .replace(/^Ask HN:\s*/i, '');
+}
+
+function cleanCompanyName(raw) {
+  let s = stripPublisher(decodeHtml(raw))
+    .replace(/^["'`]+|["'`]+$/g, '')
+    .replace(/'s$/i, '')
+    .replace(/’s$/i, '')
+    .replace(/\s*\([^)]*\)\s*$/g, '')
+    .replace(/\s*,.*$/g, '')
+    .trim();
+
+  const afterStartup = s.match(/\bstartup\s+(.+)$/i);
+  if (afterStartup?.[1]) s = afterStartup[1].trim();
+  if (/\bstartup$/i.test(s) && /['’]s\b/i.test(s)) return '';
+  if (/['’]s\b.*\b(company|startup)\b/i.test(s)) return '';
+  s = s.replace(/\s+in talks to$/i, '');
+  s = s.replace(/\s+reportedly$/i, '');
+  s = s.replace(/^[A-Z][A-Za-z0-9&.-]+-backed\s+/i, '');
+  s = s.replace(/\b(?:maker|creator)\s+of\s+.+$/i, '');
+  s = s.replace(/^(?:the\s+)?(?:(?:ai|genai|agentic|coding|developer tools|developer|data|security|fintech|startup|software|robotics|defense|healthcare|biotech|open-source|enterprise|infrastructure|crypto|climate)\s+)+(?:startup|company|platform)?\s+/i, '');
+  s = s.replace(/^.+\bmaker\s+/i, '');
+  s = s.replace(/^(?:startup|company|platform)\s+/i, '');
+  s = compact(s);
+
+  if (s.length < 2 || s.length > 70) return '';
+  if (GENERIC_NAMES.has(s.toLowerCase())) return '';
+  if (/\b(valuation|valuations|bubble|fears|earnings|fund)\b/i.test(s)) return '';
+  if (!/[a-z0-9]/i.test(s)) return '';
+  return s;
+}
+
+export function extractCompanyFromFundingTitle(title) {
+  const t = stripPublisher(title);
+  if (/^(ask hn|tell hn|who is hiring|launch hn)\b/i.test(t)) return '';
+
+  const patterns = [
+    /\b(?:raises?|raised|lands|landed|secures?|secured|closes?|closed|nabs?|nabbed|bags?|bagged)\s+(?:an?\s+|over\s+|more\s+than\s+|up\s+to\s+)?\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\s+for\s+(?:an?\s+)?(?:ai\s+)?startup\s+(.+?)$/i,
+    /(?:startup|company|agency|platform)\s+(.+?)\s+hits\s+unicorn\s+status\b.*\braises?\b/i,
+    /^(.+?)\s+(?:raises?|raised|lands|landed|secures?|secured|closes?|closed|nabs?|nabbed|bags?|bagged)\s+(?:an?\s+|over\s+|more\s+than\s+|up\s+to\s+)?\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\b/i,
+    /^(.+?)\s+(?:raises?|raised|lands|landed|secures?|secured|closes?|closed|nabs?|nabbed|bags?|bagged)\s+(?:an?\s+)?(?:\w+\s+){0,4}(?:funding|round|series\s+[a-h]|seed|pre-seed|investment|financing|valuation)\b/i,
+    /^(.+?)\s+(?:announces?|announced)\s+(?:\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\s+)?(?:\w+\s+){0,4}(?:funding|round|series\s+[a-h]|seed|pre-seed|financing)\b/i,
+    /^(.+?)\s+(?:gets|got|receives?|received)\s+(?:\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\s+)?(?:in\s+)?(?:funding|investment|financing)\b/i,
+    /^(.+?)\s+(?:hits?|hit|reaches?|reached)\s+(?:a\s+)?\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\s+valuation\b/i,
+    /^(.+?)\s+valued\s+at\s+\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\b/i,
+    /^(.+?)\s+emerges?\s+from\s+stealth\b/i,
+    /^(.+?)\s+in\s+talks\s+to\s+raise\b/i,
+  ];
+
+  for (const re of patterns) {
+    const m = t.match(re);
+    if (m?.[1]) return cleanCompanyName(m[1]);
+  }
+  return '';
+}
+
+export function extractFundingDetails(text) {
+  const raw = String(text || '');
+  const amount = raw.match(/\$[\d,.]+\s*(?:billion|million|bn|m|b|k)?/i)?.[0] || '';
+  const round = raw.match(/\b(?:pre-seed|seed|series\s+[a-h]|strategic|venture|growth)\b/i)?.[0] || '';
+  return {
+    amount: compact(amount),
+    round: round ? round.replace(/\s+/g, ' ').replace(/\bseries\b/i, 'Series') : '',
+  };
+}
+
+function sourceFromUrl(url, fallback = 'web') {
+  let host = '';
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return fallback;
+  }
+  if (host.includes('hn.algolia.com') || host.includes('news.ycombinator.com')) return 'hacker_news';
+  if (host.includes('techcrunch.com')) return 'techcrunch';
+  if (host.includes('prnewswire.com')) return 'prnewswire';
+  if (host.includes('theguardian.com')) return 'guardian';
+  if (host.includes('businesswire.com')) return 'businesswire';
+  if (host.includes('crunchbase.com')) return 'crunchbase';
+  if (host === 'x.com' || host.endsWith('.x.com') || host.includes('twitter.com')) return 'x_twitter';
+  if (host.includes('reddit.com')) return 'reddit';
+  return fallback;
+}
+
+function companyKey(name) {
+  return compact(name).toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+function loadExistingCompanies(filePath) {
+  if (!existsSync(filePath)) return new Set();
+  const parsed = yaml.load(readFileSync(filePath, 'utf-8'));
+  const companies = Array.isArray(parsed?.tracked_companies) ? parsed.tracked_companies : [];
+  return new Set(companies.map((c) => companyKey(c?.name || '')).filter(Boolean));
+}
+
+function diagnostic(source) {
+  return {
+    source,
+    status: 'ok',
+    fetched_items: 0,
+    funding_like_items: 0,
+    candidate_count: 0,
+    blocked: false,
+    errors: [],
+  };
+}
+
+function markDiagnosticError(diag, message, { blocked = false } = {}) {
+  if (!message) return;
+  diag.errors.push(message);
+  if (blocked) diag.blocked = true;
+  if (diag.status !== 'blocked') diag.status = blocked ? 'blocked' : 'error';
+}
+
+function detectBlockedContent(text, { status = 200, contentType = '' } = {}) {
+  const raw = String(text || '').slice(0, 20_000);
+  if ([401, 403, 429, 503].includes(Number(status))) return true;
+  if (/text\/html/i.test(contentType) || /<html/i.test(raw)) {
+    return /\b(access denied|captcha|cloudflare|attention required|verify you are human|enable javascript|unusual traffic|temporarily blocked|bot detection|ddos-guard|akamai|perimeterx)\b/i.test(raw);
+  }
+  return false;
+}
+
+async function fetchTextMeta(url, { timeoutMs = 12_000 } = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      headers: { 'user-agent': BROWSER_UA, accept: 'application/rss+xml,application/xml,text/xml,text/html,text/plain,*/*' },
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+    const text = await res.text().catch(() => '');
+    const contentType = res.headers.get('content-type') || '';
+    return {
+      url,
+      finalUrl: res.url || url,
+      status: res.status,
+      ok: res.ok,
+      contentType,
+      text,
+      blocked: detectBlockedContent(text, { status: res.status, contentType }),
+      error: res.ok ? '' : `HTTP ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      url,
+      finalUrl: url,
+      status: 0,
+      ok: false,
+      contentType: '',
+      text: '',
+      blocked: false,
+      error: err?.name === 'AbortError' ? 'timeout' : (err?.message || 'fetch failed'),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchJsonMeta(url, { timeoutMs = 12_000 } = {}) {
+  const meta = await fetchTextMeta(url, { timeoutMs });
+  if (!meta.ok) return { ...meta, json: null };
+  try {
+    return { ...meta, json: JSON.parse(meta.text) };
+  } catch (err) {
+    return { ...meta, ok: false, json: null, error: `invalid JSON: ${err.message}` };
+  }
+}
+
+function tagValue(xml, names) {
+  for (const name of names) {
+    const escaped = name.replace(':', '\\:');
+    const re = new RegExp(`<${escaped}\\b[^>]*>([\\s\\S]*?)<\\/${escaped}>`, 'i');
+    const m = String(xml || '').match(re);
+    if (m?.[1]) return decodeHtml(m[1]);
+  }
+  return '';
+}
+
+function attrValue(xml, tag, attr) {
+  const re = new RegExp(`<${tag}\\b[^>]*\\b${attr}=["']([^"']+)["'][^>]*>`, 'i');
+  return decodeHtml(String(xml || '').match(re)?.[1] || '');
+}
+
+function categoriesFromXml(xml) {
+  return [...String(xml || '').matchAll(/<category\b[^>]*>([\s\S]*?)<\/category>/gi)]
+    .map((m) => stripHtmlTags(m[1]))
+    .filter(Boolean);
+}
+
+function parsePublishedDate(value) {
+  const raw = compact(value);
+  if (!raw) return null;
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return null;
+  return {
+    value: date.toISOString().slice(0, 10),
+    precision: 'day',
+    date,
+  };
+}
+
+export function parseRssItems(xml, { source = 'web' } = {}) {
+  const out = [];
+  const raw = String(xml || '');
+  const blocks = [
+    ...raw.matchAll(/<item\b[^>]*>([\s\S]*?)<\/item>/gi),
+    ...raw.matchAll(/<entry\b[^>]*>([\s\S]*?)<\/entry>/gi),
+  ];
+  for (const blockMatch of blocks) {
+    const block = blockMatch[1];
+    const title = stripHtmlTags(tagValue(block, ['title']));
+    const description = stripHtmlTags(tagValue(block, ['description', 'summary', 'content:encoded', 'content']));
+    const link = compact(tagValue(block, ['link'])) || attrValue(block, 'link', 'href');
+    const publishedRaw = tagValue(block, ['pubDate', 'published', 'updated', 'dc:date']);
+    const observedDate = parsePublishedDate(publishedRaw);
+    const sourceCompany = stripHtmlTags(tagValue(block, ['dc:contributor', 'dc:creator', 'author', 'source']));
+    const itemSource = sourceFromUrl(link, source);
+    if (!title && !link) continue;
+    out.push({
+      source: itemSource === 'web' ? source : itemSource,
+      title,
+      url: link,
+      published_at: observedDate?.date?.toISOString() || '',
+      observedDate,
+      text: compact(`${title} ${description}`),
+      categories: categoriesFromXml(block),
+      source_company: sourceCompany,
+    });
+  }
+  return out;
+}
+
+function hasFundingLanguage(text) {
+  return /\b(funding|funded|raises?|raised|raise|series\s+[a-h]|seed\s+round|pre-seed|venture\s+round|investment|financing|valuation|valued\s+at|lands?|landed|secures?|secured|closes?|closed|nabs?|nabbed|bags?|bagged|emerges?\s+from\s+stealth|in\s+talks\s+to\s+raise)\b/i.test(String(text || ''));
+}
+
+function isExcludedFundingItem(item) {
+  const text = compact(`${item.title || ''} ${item.text || ''} ${(item.categories || []).join(' ')}`);
+  if (!hasFundingLanguage(text)) return true;
+  const negativePatterns = [
+    /\b(acquires?|acquired|acquisition|merger|merged|takeover|buyout|buys?|bought)\b/i,
+    /\b(earnings|quarterly results|financial results|fiscal year|revenue guidance|dividend|share repurchase|stock split|nasdaq|nyse|tsx:|lse:)\b/i,
+    /\b(scholarship|scholarships|grant|grants|donation|donates?|nonprofit grant)\b/i,
+    /\b(how to raise|tips for fundraising|fundraising advice|guide to fundraising|startup fundraising guide)\b/i,
+    /\b(public offering|registered direct offering|private placement|atm offering|offering of common stock)\b/i,
+    /\b(venture fund|vc fund|investment fund|private equity fund|capital fund|fund ii|fund iii|fund iv|new fund)\b/i,
+    /\b(?:raises?|raised|closes?|closed|launches?|launched)\s+(?:an?\s+|its\s+|new\s+)?\$[\d.,]+\s*(?:billion|million|bn|[bm])?\s+fund\b/i,
+    /\b(?:raises?|raised|closes?|closed|launches?|launched)\s+(?:an?\s+|its\s+|new\s+)?(?:first|second|third|fourth|latest)\s+fund\b/i,
+  ];
+  return negativePatterns.some((re) => re.test(text));
+}
+
+function fundingWindowStart(now = new Date(), months = DEFAULT_MONTHS) {
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  d.setUTCMonth(d.getUTCMonth() - months);
+  return d;
+}
+
+export function extractFundingDate(text, now = new Date()) {
+  const raw = String(text || '');
+  const iso = raw.match(/\b(20\d{2})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])\b/);
+  if (iso) return { value: iso[0], precision: 'day', date: new Date(`${iso[0]}T00:00:00Z`) };
+
+  const monthYear = raw.match(/\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?\s+(?:\d{1,2},?\s+)?(20\d{2})\b/i);
+  if (monthYear) {
+    const month = MONTH_INDEX[monthYear[1].toLowerCase().replace(/\.$/, '')];
+    const year = Number(monthYear[2]);
+    if (month != null) {
+      const date = new Date(Date.UTC(year, month, 1));
+      return { value: `${year}-${String(month + 1).padStart(2, '0')}`, precision: 'month', date };
+    }
+  }
+
+  const year = raw.match(/\b(20\d{2})\b/);
+  if (year) {
+    const y = Number(year[1]);
+    const date = new Date(Date.UTC(y, 0, 1));
+    return { value: String(y), precision: 'year', date };
+  }
+
+  const monthsAgo = raw.match(/\b(\d{1,2})\s+months?\s+ago\b/i);
+  if (monthsAgo) {
+    const date = fundingWindowStart(now, Number(monthsAgo[1]));
+    return { value: `${monthsAgo[1]} months ago`, precision: 'relative_month', date };
+  }
+  return null;
+}
+
+function dateValue(observedDate) {
+  return observedDate?.date instanceof Date && !Number.isNaN(observedDate.date.getTime())
+    ? observedDate.date.getTime()
+    : 0;
+}
+
+function candidateSourceName(hit) {
+  if (hit.source === 'prnewswire' && hit.source_company && hasFundingLanguage(`${hit.title || ''} ${hit.text || ''}`)) {
+    const clean = cleanCompanyName(hit.source_company);
+    if (clean) return clean;
+  }
+  return extractCompanyFromFundingTitle(hit.title);
+}
+
+function fundingEvidenceScore(hit, { now = new Date(), months = DEFAULT_MONTHS } = {}) {
+  const haystack = `${hit.title || ''} ${hit.text || ''} ${(hit.categories || []).join(' ')}`;
+  if (!hasFundingLanguage(haystack) || isExcludedFundingItem(hit)) return -100;
+  const observed = hit.observedDate || extractFundingDate(haystack, now);
+  const windowStart = fundingWindowStart(now, months);
+  let score = 25 + (SOURCE_RANK[hit.source] || SOURCE_RANK.web);
+  if (observed?.date && observed.date >= windowStart) score += 50;
+  else if (observed?.date) score -= 40;
+  if (/\$[\d,.]+\s*(?:billion|million|bn|m|b|k)?/i.test(haystack)) score += 15;
+  if (/\b(series\s+[a-h]|seed\s+round|pre-seed)\b/i.test(haystack)) score += 15;
+  if (/\braises?|raised|secures?|secured|lands?|landed|closes?|closed\b/i.test(haystack)) score += 10;
+  if (/\bemerges?\s+from\s+stealth|in\s+talks\s+to\s+raise|valuation|valued\s+at\b/i.test(haystack)) score += 5;
+  return score;
+}
+
+function buildFundingSignal(evidence, { now = new Date(), months = DEFAULT_MONTHS } = {}) {
+  const windowStart = fundingWindowStart(now, months);
+  const scored = evidence
+    .map((hit) => {
+      const haystack = `${hit.title || ''} ${hit.text || ''}`;
+      const observed = hit.observedDate || extractFundingDate(haystack, now);
+      return {
+        source: hit.source || sourceFromUrl(hit.url),
+        title: compact(hit.title || hit.url).slice(0, 180),
+        url: hit.url,
+        observed_date: observed?.value || '',
+        date_precision: observed?.precision || '',
+        recent: Boolean(observed?.date && observed.date >= windowStart),
+        categories: hit.categories || [],
+        score: fundingEvidenceScore({ ...hit, observedDate: observed }, { now, months }),
+        dateMs: dateValue(observed),
+      };
+    })
+    .filter((hit) => hit.score > 0)
+    .sort((a, b) => b.recent - a.recent || b.dateMs - a.dateMs || b.score - a.score || (SOURCE_RANK[b.source] || 0) - (SOURCE_RANK[a.source] || 0));
+
+  const recent = scored.filter((hit) => hit.recent);
+  const sources = scored.slice(0, 5).map(({ score, dateMs, ...rest }) => rest);
+  let status = 'no_signal';
+  let confidence = 'low';
+  if (recent.length > 0) {
+    status = 'recent_funding_signal';
+    const best = recent[0];
+    confidence = ['techcrunch', 'prnewswire', 'guardian'].includes(best.source) || /\$[\d,.]+|\bseries\s+[a-h]\b|\bseed\b/i.test(best.title)
+      ? 'medium'
+      : 'low';
+  } else if (scored.length > 0) {
+    status = 'funding_signal_unconfirmed_recency';
+  }
+
+  return {
+    status,
+    confidence,
+    checked_at: now.toISOString().slice(0, 10),
+    window_months: months,
+    sources,
+    note: 'Funding is a hiring-likelihood signal only; verify manually before prioritizing.',
+  };
+}
+
+export function buildCandidates(hits, {
+  months = DEFAULT_MONTHS,
+  includeExisting = false,
+  existingCompanies = new Set(),
+  now = new Date(),
+  sort = DEFAULT_SORT,
+  limit = DEFAULT_LIMIT,
+  diagnostics = [],
+} = {}) {
+  const grouped = new Map();
+  for (const hit of hits) {
+    if (isExcludedFundingItem(hit)) continue;
+    const name = candidateSourceName(hit);
+    if (!name) continue;
+    const key = companyKey(name);
+    if (!key) continue;
+    if (!includeExisting && existingCompanies.has(key)) continue;
+    if (!grouped.has(key)) grouped.set(key, { name, evidence: [], evidenceKeys: new Set() });
+    const evidenceKey = compact(`${hit.source || ''} ${hit.url || ''} ${hit.title || ''}`).toLowerCase();
+    if (grouped.get(key).evidenceKeys.has(evidenceKey)) continue;
+    grouped.get(key).evidenceKeys.add(evidenceKey);
+    grouped.get(key).evidence.push(hit);
+  }
+
+  let candidates = [];
+  for (const item of grouped.values()) {
+    const funding = buildFundingSignal(item.evidence, { months, now });
+    if (funding.status !== 'recent_funding_signal') continue;
+    const best = funding.sources[0] || {};
+    const details = extractFundingDetails(`${best.title || ''} ${item.evidence[0]?.title || ''} ${item.evidence[0]?.text || ''}`);
+    candidates.push({
+      company: item.name,
+      funding,
+      funding_date: best.observed_date || '',
+      amount: details.amount,
+      round: details.round,
+      existing: existingCompanies.has(companyKey(item.name)),
+      discovery_score: discoveryScore(funding),
+      best_source: best.source || '',
+      best_title: best.title || '',
+      best_url: best.url || '',
+      suggested_action: 'review',
+    });
+  }
+
+  annotateCandidateDiagnostics(candidates, diagnostics);
+  candidates = sortCandidates(candidates, sort);
+  return candidates.slice(0, limit);
+}
+
+function annotateCandidateDiagnostics(candidates, diagnostics) {
+  const bySource = new Map(diagnostics.map((d) => [d.source, d]));
+  for (const diag of diagnostics) diag.candidate_count = 0;
+  for (const candidate of candidates) {
+    const seen = new Set();
+    for (const src of candidate.funding.sources || []) {
+      if (!src.source || seen.has(src.source)) continue;
+      seen.add(src.source);
+      const key = src.source === 'hacker_news' ? 'hn' : src.source;
+      const diag = bySource.get(key) || bySource.get(src.source);
+      if (diag) diag.candidate_count += 1;
+    }
+  }
+}
+
+function sortCandidates(candidates, sort = DEFAULT_SORT) {
+  const sorted = [...candidates];
+  if (sort === 'score') {
+    return sorted.sort((a, b) => b.discovery_score - a.discovery_score || dateMs(b) - dateMs(a) || a.company.localeCompare(b.company));
+  }
+  return sorted.sort((a, b) =>
+    dateMs(b) - dateMs(a) ||
+    (SOURCE_RANK[b.best_source] || 0) - (SOURCE_RANK[a.best_source] || 0) ||
+    b.discovery_score - a.discovery_score ||
+    a.company.localeCompare(b.company)
+  );
+}
+
+function dateMs(candidate) {
+  const date = candidate.funding.sources?.[0]?.observed_date || candidate.funding_date || '';
+  const parsed = date ? new Date(`${date.length === 7 ? `${date}-01` : date}T00:00:00Z`) : null;
+  return parsed && !Number.isNaN(parsed.getTime()) ? parsed.getTime() : 0;
+}
+
+function discoveryScore(funding) {
+  let score = 0;
+  if (funding.status === 'recent_funding_signal') score += 70;
+  if (funding.confidence === 'medium') score += 20;
+  const source = funding.sources?.[0]?.source || '';
+  score += Math.floor((SOURCE_RANK[source] || 0) / 4);
+  score += Math.min((funding.sources || []).length, 5);
+  return score;
+}
+
+function websearchQuery(name, careersUrl) {
+  let site = '';
+  try {
+    site = `site:${new URL(careersUrl).hostname}`;
+  } catch {
+    site = `"${name}"`;
+  }
+  return `${site} "AI Engineer" OR "Applied AI" OR "LLMOps" OR "Agentic" OR "Principal Engineer" OR "Staff Engineer" OR "Software Architect" OR "Backend Engineer" India OR Singapore OR London OR remote`;
+}
+
+export async function buildCompanyEntry(name, careersUrl, { providers = null, providerHint = null } = {}) {
+  const entry = {
+    name: normalizeName(name),
+    careers_url: careersUrl,
+    enabled: true,
+  };
+  if (providerHint) entry.provider = providerHint;
+
+  const loadedProviders = providers || await loadProviders(PROVIDERS_DIR);
+  const resolved = resolveProvider(entry, loadedProviders, { skipIds: ['local-parser'] });
+  if (!resolved?.provider) {
+    entry.scan_method = 'websearch';
+    entry.scan_query = websearchQuery(entry.name, careersUrl);
+  }
+  return { entry, provider: resolved?.provider?.id || null };
+}
+
+function formatPortalsEntry(entry) {
+  if (!entry) return '';
+  return yaml.dump([entry], { lineWidth: 140, noRefs: true, sortKeys: false }).trimEnd();
+}
+
+async function enrichCandidate(candidate) {
+  try {
+    const resolved = await withTimeout(
+      quickResolveCareerUrl(candidate.company),
+      DEFAULT_ENRICH_TIMEOUT_MS,
+      `career resolution timed out after ${DEFAULT_ENRICH_TIMEOUT_MS}ms`,
+    );
+    if (!resolved?.url) return markEnrichmentNotFound(candidate, resolved?.website || '');
+    const { entry, provider } = await buildCompanyEntry(candidate.company, resolved.url, { providerHint: resolved.providerHint });
+    return {
+      ...candidate,
+      website: resolved.website || '',
+      careers_url: entry.careers_url,
+      scanner_path: provider ? `provider:${provider}` : 'websearch',
+      provider: provider || '',
+      enrichment_status: 'found',
+      enrichment_error: '',
+      portals_entry: entry,
+      portals_entry_yaml: formatPortalsEntry(entry),
+      suggested_action: 'review_portals_entry',
+    };
+  } catch (err) {
+    const timedOut = err?.code === 'ETIMEDOUT';
+    return {
+      ...candidate,
+      website: '',
+      careers_url: '',
+      scanner_path: timedOut ? 'resolution_timeout' : 'resolution_failed',
+      enrichment_status: timedOut ? 'timeout' : 'error',
+      enrichment_error: err?.message || 'career resolution failed',
+      suggested_action: 'research_manually',
+    };
+  }
+}
+
+function markEnrichmentNotFound(candidate, website = '') {
+  return {
+    ...candidate,
+    website,
+    careers_url: '',
+    scanner_path: 'resolution_failed',
+    enrichment_status: 'not_found',
+    enrichment_error: '',
+    suggested_action: 'research_manually',
+  };
+}
+
+async function withTimeout(promise, timeoutMs, message) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => {
+          const err = new Error(message);
+          err.code = 'ETIMEDOUT';
+          reject(err);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function ensureHttpsUrl(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  if (/^https?:\/\//i.test(raw)) return raw;
+  return `https://${raw}`;
+}
+
+function baseHostFromWebsite(website) {
+  try {
+    return new URL(ensureHttpsUrl(website)).hostname.replace(/^www\./i, '');
+  } catch {
+    return '';
+  }
+}
+
+function providerHintFromPage(meta) {
+  const text = `${meta.finalUrl || meta.url}\n${meta.text || ''}`.toLowerCase();
+  if (text.includes('teamtailor') && text.includes('jobs.rss')) return 'teamtailor';
+  return null;
+}
+
+function quickWebsiteUrls(name) {
+  const slug = companySlug(name);
+  if (!slug) return [];
+  return [`https://${slug}.com`, `https://${slug}.ai`, `https://${slug}.io`, `https://${slug}.co`];
+}
+
+function quickCareerUrlsFromWebsite(website) {
+  const baseHost = baseHostFromWebsite(website);
+  if (!baseHost) return [];
+  const roots = [`https://${baseHost}`, `https://www.${baseHost}`];
+  return [
+    `https://jobs.${baseHost}`,
+    `https://careers.${baseHost}`,
+    ...roots.map((root) => `${root}/careers`),
+    ...roots.map((root) => `${root}/jobs`),
+    ...roots.map((root) => `${root}/company/careers`),
+    ...roots.map((root) => `${root}/careers/jobs`),
+  ];
+}
+
+function quickAtsUrls(name) {
+  const slugs = deriveSlugCandidates(name).slice(0, 4);
+  const urls = [];
+  for (const slug of slugs) {
+    urls.push(`https://jobs.ashbyhq.com/${slug}`);
+    urls.push(`https://job-boards.greenhouse.io/${slug}`);
+    urls.push(`https://jobs.lever.co/${slug}`);
+  }
+  return urls;
+}
+
+function visibleText(meta) {
+  return stripHtmlTags(meta.text || '').toLowerCase();
+}
+
+function quickCareerProbeScore(meta, name, websiteUrl = '') {
+  let parsed;
+  try {
+    parsed = new URL(meta.finalUrl || meta.url);
+  } catch {
+    return -100;
+  }
+  const host = parsed.hostname.toLowerCase();
+  const path = parsed.pathname.toLowerCase();
+  const visible = visibleText(meta);
+  const baseHost = baseHostFromWebsite(websiteUrl);
+  const isKnownAts = /(^|\.)ashbyhq\.com$|(^|\.)greenhouse\.io$|(^|\.)lever\.co$/i.test(host);
+  let score = meta.ok ? 40 : 0;
+  if ([401, 403].includes(Number(meta.status))) score += 10;
+  if (baseHost && (host === baseHost || host.endsWith(`.${baseHost}`))) score += 25;
+  if (/^(jobs|careers)\./i.test(host)) score += 25;
+  if (isKnownAts) score += 45;
+  if (/\/(careers|jobs|work-with-us|open-roles)\b/i.test(path)) score += 20;
+  if (/(open roles|open positions|current openings|job openings|view jobs|apply now|greenhouse|ashby|lever|workday|smartrecruiters|teamtailor)/i.test(visible)) score += 25;
+  if (/(page not found|not found|no longer available|access denied|forbidden|no jobs found)/i.test(visible)) score -= 35;
+  if (companySlug(name) && `${host}${path}${visible.slice(0, 2000)}`.replace(/[^a-z0-9]+/g, '').includes(companySlug(name))) score += 5;
+  return score;
+}
+
+async function probeQuickUrl(url, name, website = '') {
+  const meta = await fetchTextMeta(url, { timeoutMs: QUICK_FETCH_TIMEOUT_MS });
+  const score = quickCareerProbeScore(meta, name, website);
+  if (score < 55) return null;
+  return {
+    url: meta.finalUrl || url,
+    score,
+    providerHint: providerHintFromPage(meta),
+  };
+}
+
+async function firstReachableWebsite(name) {
+  const probes = await Promise.allSettled(
+    quickWebsiteUrls(name).map(async (url) => {
+      const meta = await fetchTextMeta(url, { timeoutMs: QUICK_FETCH_TIMEOUT_MS });
+      if (!meta.ok) return null;
+      return { url: meta.finalUrl || url, status: meta.status };
+    }),
+  );
+  return probes.map((p) => p.status === 'fulfilled' ? p.value : null).find(Boolean)?.url || '';
+}
+
+export async function quickResolveCareerUrl(name) {
+  const website = await firstReachableWebsite(name);
+  const urls = [...quickCareerUrlsFromWebsite(website), ...quickAtsUrls(name)];
+  const seen = new Set();
+  const unique = urls.filter((url) => {
+    const key = url.replace(/\/+$/, '');
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  const probes = await Promise.allSettled(unique.map((url) => probeQuickUrl(url, name, website)));
+  const candidates = probes
+    .map((p) => p.status === 'fulfilled' ? p.value : null)
+    .filter(Boolean)
+    .sort((a, b) => b.score - a.score);
+  return { website, ...(candidates[0] || {}) };
+}
+
+function enrichmentFailure(candidate, err) {
+  const timedOut = err?.code === 'ETIMEDOUT';
+  return {
+    ...candidate,
+    website: '',
+    careers_url: '',
+    scanner_path: timedOut ? 'resolution_timeout' : 'resolution_failed',
+    enrichment_status: timedOut ? 'timeout' : 'error',
+    enrichment_error: err?.message || 'career resolution failed',
+    suggested_action: 'research_manually',
+  };
+}
+
+export async function enrichCandidates(candidates, {
+  enrichCandidateFn = enrichCandidate,
+  concurrency = DEFAULT_ENRICH_CONCURRENCY,
+  timeoutMs = DEFAULT_ENRICH_TIMEOUT_MS,
+} = {}) {
+  const out = new Array(candidates.length);
+  let next = 0;
+  const workerCount = Math.max(1, Math.min(concurrency, candidates.length || 1));
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (next < candidates.length) {
+      const idx = next++;
+      try {
+        out[idx] = await withTimeout(Promise.resolve().then(() => enrichCandidateFn(candidates[idx])), timeoutMs, `career resolution timed out after ${timeoutMs}ms`);
+      } catch (err) {
+        out[idx] = enrichmentFailure(candidates[idx], err);
+      }
+    }
+  }));
+  return out;
+}
+
+function isoDate(now = new Date()) {
+  return now.toISOString().slice(0, 10);
+}
+
+async function fetchRssDiscovery(source, diagnostics) {
+  const diag = diagnostics.find((d) => d.source === source) || diagnostic(source);
+  const out = [];
+  for (const url of RSS_SOURCES[source] || []) {
+    const meta = await fetchTextMeta(url);
+    if (!meta.ok || meta.blocked) {
+      markDiagnosticError(diag, `${url}: ${meta.error || (meta.blocked ? 'blocked/challenge page' : 'fetch failed')}`, { blocked: meta.blocked });
+      continue;
+    }
+    const items = parseRssItems(meta.text, { source });
+    diag.fetched_items += items.length;
+    for (const item of items) {
+      if (isExcludedFundingItem(item)) continue;
+      diag.funding_like_items += 1;
+      out.push(item);
+    }
+  }
+  if (diag.fetched_items === 0 && diag.errors.length === 0) {
+    markDiagnosticError(diag, 'no RSS items fetched');
+  }
+  return out;
+}
+
+function hnQueries(extra = []) {
+  return [
+    'AI startup raises funding',
+    'Series A AI startup',
+    'developer tools startup funding',
+    'infrastructure startup raises funding',
+    'agentic AI raises seed',
+    ...extra,
+  ];
+}
+
+async function fetchHnDiscovery({ months = DEFAULT_MONTHS, extraQueries = [], diagnostics = [] } = {}) {
+  const diag = diagnostics.find((d) => d.source === 'hn') || diagnostic('hn');
+  const cutoff = Math.floor(Date.now() / 1000) - months * 31 * 24 * 60 * 60;
+  const out = [];
+  for (const query of hnQueries(extraQueries)) {
+    const url =
+      `https://hn.algolia.com/api/v1/search?query=${encodeURIComponent(query)}` +
+      `&tags=story&hitsPerPage=50&numericFilters=created_at_i>${cutoff}`;
+    const meta = await fetchJsonMeta(url);
+    if (!meta.ok || meta.blocked || !meta.json) {
+      markDiagnosticError(diag, `${url}: ${meta.error || (meta.blocked ? 'blocked/challenge page' : 'fetch failed')}`, { blocked: meta.blocked });
+      continue;
+    }
+    const hits = Array.isArray(meta.json?.hits) ? meta.json.hits : [];
+    diag.fetched_items += hits.length;
+    for (const hit of hits) {
+      const title = compact(hit.title || hit.story_title || '');
+      if (!title) continue;
+      const item = {
+        source: 'hacker_news',
+        title,
+        url: hit.url || `https://news.ycombinator.com/item?id=${hit.objectID}`,
+        published_at: hit.created_at ? new Date(hit.created_at).toISOString() : '',
+        observedDate: hit.created_at ? { value: hit.created_at.slice(0, 10), precision: 'day', date: new Date(hit.created_at) } : null,
+        text: compact(hit.story_text || ''),
+        categories: [],
+        source_company: '',
+      };
+      if (isExcludedFundingItem(item)) continue;
+      diag.funding_like_items += 1;
+      out.push(item);
+    }
+  }
+  if (diag.fetched_items === 0 && diag.errors.length === 0) {
+    markDiagnosticError(diag, 'no HN items fetched');
+  }
+  return out;
+}
+
+function discoveryQueries(extra = []) {
+  const year = new Date().getUTCFullYear();
+  return [
+    ...extra,
+    `site:techcrunch.com raises funding AI startup Series A seed ${year}`,
+    `site:prnewswire.com raises funding AI startup ${year}`,
+  ];
+}
+
+async function fetchSearchDiscovery(extraQueries = [], diagnostics = []) {
+  const diag = diagnostics.find((d) => d.source === 'duckduckgo') || diagnostic('duckduckgo');
+  const out = [];
+  for (const query of discoveryQueries(extraQueries)) {
+    const url = `https://duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
+    const meta = await fetchTextMeta(url);
+    if (!meta.ok || meta.blocked) {
+      markDiagnosticError(diag, `${url}: ${meta.error || (meta.blocked ? 'blocked/challenge page' : 'fetch failed')}`, { blocked: meta.blocked });
+      continue;
+    }
+    const results = parseDuckDuckGoResults(meta.text, { allowBlockedHosts: true }).slice(0, 12);
+    diag.fetched_items += results.length;
+    for (const result of results) {
+      const item = {
+        source: sourceFromUrl(result.url, 'duckduckgo'),
+        title: result.title,
+        url: result.url,
+        published_at: '',
+        observedDate: null,
+        text: '',
+        categories: [],
+        source_company: '',
+      };
+      if (isExcludedFundingItem(item)) continue;
+      diag.funding_like_items += 1;
+      out.push(item);
+    }
+  }
+  if (diag.fetched_items === 0 && diag.errors.length === 0) {
+    markDiagnosticError(diag, 'no DuckDuckGo results parsed');
+  }
+  return out;
+}
+
+async function collectDiscoveryItems(opts, diagnostics) {
+  const requested = new Set(opts.sources || DEFAULT_SOURCES);
+  const hits = [];
+  for (const source of ['techcrunch', 'prnewswire', 'guardian']) {
+    if (requested.has(source)) hits.push(...await fetchRssDiscovery(source, diagnostics));
+  }
+  if (requested.has('hn')) {
+    hits.push(...await fetchHnDiscovery({ months: opts.months, extraQueries: opts.queries || [], diagnostics }));
+  }
+  if (requested.has('duckduckgo')) {
+    hits.push(...await fetchSearchDiscovery(opts.queries || [], diagnostics));
+  }
+  return hits;
+}
+
+function renderReport(result) {
+  const lines = [];
+  lines.push(`# Funded Company Discovery - ${result.generated_at}`);
+  lines.push('');
+  lines.push('Review-first output. No companies were added to portals.yml.');
+  lines.push('');
+  lines.push(`Window: ${result.window_months} months`);
+  lines.push(`Sort: ${result.sort}`);
+  lines.push(`Sources: ${result.sources.join(', ')}`);
+  lines.push(`Candidates: ${result.companies.length}`);
+  lines.push('');
+  lines.push('## Source Health');
+  lines.push('');
+  lines.push('| Source | Status | Fetched | Funding-like | Candidates | Notes |');
+  lines.push('|--------|--------|---------|--------------|------------|-------|');
+  for (const diag of result.diagnostics) {
+    lines.push(`| ${md(diag.source)} | ${md(diag.status)} | ${diag.fetched_items} | ${diag.funding_like_items} | ${diag.candidate_count} | ${md(diag.errors.join('; '))} |`);
+  }
+  lines.push('');
+  lines.push('| # | Company | Funding | Date | Source | Careers URL | Scanner | Action |');
+  lines.push('|---|---------|---------|------|--------|-------------|---------|--------|');
+  result.companies.forEach((c, idx) => {
+    const src = c.funding.sources?.[0] || {};
+    const funding = [c.round, c.amount, c.funding.status].filter(Boolean).join(' / ');
+    lines.push(`| ${idx + 1} | ${md(c.company)} | ${md(funding)} | ${md(src.observed_date || '')} | ${md(src.source || '')} | ${md(careerDisplay(c))} | ${md(scannerDisplay(c))} | ${md(c.suggested_action)} |`);
+  });
+  lines.push('');
+  for (const c of result.companies) {
+    lines.push(`## ${c.company}`);
+    lines.push('');
+    lines.push(`- Funding signal: ${c.funding.status} (${c.funding.confidence})`);
+    if (c.round || c.amount) lines.push(`- Round/amount: ${[c.round, c.amount].filter(Boolean).join(', ')}`);
+    lines.push(`- Careers URL: ${careerDisplay(c)}`);
+    lines.push(`- Scanner path: ${scannerDisplay(c)}`);
+    lines.push(`- Enrichment: ${c.enrichment_status || 'unknown'}${c.enrichment_error ? ` (${c.enrichment_error})` : ''}`);
+    lines.push(`- Existing in portals.yml: ${c.existing ? 'yes' : 'no'}`);
+    if (c.portals_entry_yaml) {
+      lines.push('- Suggested portals.yml entry:');
+      lines.push('```yaml');
+      lines.push(c.portals_entry_yaml);
+      lines.push('```');
+    } else {
+      lines.push('- Suggested action: research careers URL manually before adding to portals.yml');
+    }
+    lines.push('- Evidence:');
+    for (const src of c.funding.sources.slice(0, 3)) {
+      lines.push(`  - ${src.source}${src.observed_date ? `, ${src.observed_date}` : ''}: [${md(src.title)}](${src.url})`);
+    }
+    lines.push('');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function md(value) {
+  return String(value || '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function writeArtifacts(result) {
+  const outDir = join(ROOT, 'output');
+  const reportDir = join(ROOT, 'reports');
+  mkdirSync(outDir, { recursive: true });
+  mkdirSync(reportDir, { recursive: true });
+  const jsonPath = join(outDir, `funded-companies-${result.generated_at}.json`);
+  const reportPath = join(reportDir, `funded-companies-${result.generated_at}.md`);
+  writeFileSync(jsonPath, `${JSON.stringify(result, null, 2)}\n`, 'utf-8');
+  writeFileSync(reportPath, renderReport(result), 'utf-8');
+  return { jsonPath, reportPath };
+}
+
+function printHuman(result) {
+  console.log(`Funded company discovery - ${result.generated_at}`);
+  console.log(`Window: ${result.window_months} months`);
+  console.log(`Sort: ${result.sort}`);
+  console.log(`Sources: ${result.sources.join(', ')}`);
+  console.log(`Candidates: ${result.companies.length}`);
+  if (result.artifacts) {
+    console.log(`JSON: ${result.artifacts.jsonPath}`);
+    console.log(`Report: ${result.artifacts.reportPath}`);
+  }
+  const unhealthy = result.diagnostics.filter((d) => d.status !== 'ok' || d.blocked || d.fetched_items === 0);
+  if (unhealthy.length || result.companies.length === 0) {
+    console.log('');
+    console.log('Source health:');
+    for (const diag of result.diagnostics) {
+      const note = diag.errors.length ? ` - ${diag.errors.join('; ')}` : '';
+      console.log(`  ${diag.source}: ${diag.status}, fetched ${diag.fetched_items}, funding-like ${diag.funding_like_items}, candidates ${diag.candidate_count}${note}`);
+    }
+  }
+  console.log('');
+  for (const [idx, c] of result.companies.entries()) {
+    const src = c.funding.sources?.[0] || {};
+    console.log(`${idx + 1}. ${c.company}`);
+    console.log(`   Funding: ${[c.round, c.amount, c.funding.status].filter(Boolean).join(' / ')} (${c.funding.confidence})${src.observed_date ? `, ${src.observed_date}` : ''}`);
+    console.log(`   Source: ${src.source || 'n/a'} - ${src.title || 'n/a'}`);
+    console.log(`   Careers: ${careerDisplay(c)}`);
+    console.log(`   Scanner: ${scannerDisplay(c)}`);
+    if (c.enrichment_status && c.enrichment_status !== 'found') {
+      console.log(`   Enrichment: ${c.enrichment_status}${c.enrichment_error ? ` - ${c.enrichment_error}` : ''}`);
+    }
+    if (c.portals_entry_yaml) {
+      console.log('   Suggested portals.yml entry:');
+      for (const line of c.portals_entry_yaml.split('\n')) console.log(`     ${line}`);
+    } else {
+      console.log('   Suggested action: research careers URL manually before adding to portals.yml');
+    }
+  }
+}
+
+function careerDisplay(candidate) {
+  if (candidate.careers_url) return candidate.careers_url;
+  if (candidate.enrichment_status === 'skipped') return 'not checked (--no-enrich)';
+  return 'not found';
+}
+
+function scannerDisplay(candidate) {
+  if (candidate.scanner_path) return candidate.scanner_path;
+  if (candidate.enrichment_status === 'skipped') return 'not checked';
+  return 'resolution_failed';
+}
+
+export async function discoverFundedCompanies(opts = {}) {
+  const months = opts.months || DEFAULT_MONTHS;
+  const sources = (opts.sources || DEFAULT_SOURCES).map(normalizeSourceName);
+  const portalsPath = resolve(opts.portalsPath || DEFAULT_PORTALS_PATH);
+  const existingCompanies = loadExistingCompanies(portalsPath);
+  const diagnostics = [...new Set(sources)].map(diagnostic);
+  const hits = Array.isArray(opts.discoveryItems)
+    ? opts.discoveryItems
+    : await collectDiscoveryItems({ ...opts, months, sources }, diagnostics);
+  let companies = buildCandidates(hits, {
+    months,
+    includeExisting: opts.includeExisting,
+    existingCompanies,
+    sort: opts.sort || DEFAULT_SORT,
+    limit: opts.limit || DEFAULT_LIMIT,
+    diagnostics,
+  });
+
+  if (opts.enrich !== false) {
+    companies = await enrichCandidates(companies, {
+      enrichCandidateFn: opts.enrichCandidateFn || enrichCandidate,
+      concurrency: opts.enrichConcurrency || DEFAULT_ENRICH_CONCURRENCY,
+      timeoutMs: opts.enrichTimeoutMs || DEFAULT_ENRICH_TIMEOUT_MS,
+    });
+  } else {
+    companies = companies.map((c) => ({
+      ...c,
+      careers_url: '',
+      scanner_path: '',
+      enrichment_status: 'skipped',
+      enrichment_error: '',
+    }));
+  }
+
+  return {
+    generated_at: isoDate(),
+    window_months: months,
+    sort: opts.sort || DEFAULT_SORT,
+    dry_run: Boolean(opts.dryRun),
+    sources,
+    diagnostics,
+    companies,
+  };
+}
+
+async function selfTest() {
+  const examples = [
+    ['Prime Intellect raises $130M Series A', 'Prime Intellect'],
+    ['Norm raises $120M', 'Norm'],
+    ['Resolve AI raises $125M Series A', 'Resolve AI'],
+    ['Cascade raises $3.5M', 'Cascade'],
+    ['SambaNova raises $1B', 'SambaNova'],
+    ['Anysphere raises $900M in funding', 'Anysphere'],
+    ['AI coding startup Cursor maker Anysphere raises Series C funding', 'Anysphere'],
+    ['AI logistics startup Augment, from Deliverr founder, raises $85M Series A', 'Augment'],
+    ['Mira Murati’s AI startup Thinking Machines valued at $12B in early-stage funding', 'Thinking Machines'],
+    ['OpenAI in talks to raise funding that would value AI startup at up to $340B', 'OpenAI'],
+    ['AI-powered travel agency Fora hits unicorn status, raises $60M', 'Fora'],
+    ['Airbnb-backed WeRoad raises $58M to take its group travel platform to the US', 'WeRoad'],
+    ['Ex-DeepMind David Silver Raises $1.1B for AI Startup Ineffable', 'Ineffable'],
+    ['Travis Kalanick&#8217;s robotics company raises $1.7B, led by a16z', ''],
+    ['AI startup valuations raise bubble fears as funding surges', ''],
+    ["Yann LeCun's AI startup raises $1B seed round", ''],
+    ['Acme closes $25M Series A round', 'Acme'],
+    ['Ask HN: Who is hiring?', ''],
+  ];
+  for (const [title, expected] of examples) {
+    const got = extractCompanyFromFundingTitle(title);
+    if (got !== expected) throw new Error(`extractCompanyFromFundingTitle(${JSON.stringify(title)}) = ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`);
+  }
+
+  const details = extractFundingDetails('Acme closes $25M Series A round');
+  if (details.amount !== '$25M' || details.round !== 'Series A') {
+    throw new Error(`extractFundingDetails failed: ${JSON.stringify(details)}`);
+  }
+
+  const candidates = buildCandidates([
+    {
+      source: 'techcrunch',
+      title: 'Acme raises $25M Series B',
+      url: 'https://techcrunch.com/acme',
+      observedDate: { value: '2026-06-10', precision: 'day', date: new Date('2026-06-10T00:00:00Z') },
+      text: 'Acme raises $25M Series B funding.',
+      categories: ['Startups'],
+    },
+    {
+      source: 'hacker_news',
+      title: 'Startup raises seed funding in March 2026',
+      url: 'https://news.ycombinator.com/item?id=2',
+      observedDate: { value: '2026-03-10', precision: 'day', date: new Date('2026-03-10T00:00:00Z') },
+      text: '',
+      categories: [],
+    },
+  ], { months: 3, now: new Date('2026-07-20T00:00:00Z') });
+  if (candidates.length !== 1 || candidates[0].company !== 'Acme') {
+    throw new Error(`buildCandidates failed: ${JSON.stringify(candidates)}`);
+  }
+
+  console.log('company-funded self-test OK');
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    usage();
+    return;
+  }
+  if (opts.selfTest) {
+    await selfTest();
+    return;
+  }
+  const result = await discoverFundedCompanies(opts);
+  if (!opts.dryRun) result.artifacts = writeArtifacts(result);
+  if (opts.json) console.log(JSON.stringify(result, null, 2));
+  else printHuman(result);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((err) => {
+    console.error(`company-funded failed: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/company-funded.mjs
+++ b/company-funded.mjs
@@ -189,6 +189,44 @@ function trustedForSource(raw, source) {
   return domains.some((domain) => matchesDomain(url.hostname, domain));
 }
 
+function isPrivateOrInternalHostname(hostname) {
+  const host = String(hostname || '').toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (host.startsWith('fc') || host.startsWith('fd') || host.startsWith('fe80:')) return true;
+
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!ipv4) return false;
+  const parts = ipv4.slice(1).map(Number);
+  if (parts.some((part) => part < 0 || part > 255)) return true;
+  const [a, b] = parts;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224
+  );
+}
+
+function untrustedSourceMeta(url, finalUrl, message, status = 0, contentType = '') {
+  return {
+    url,
+    finalUrl,
+    status,
+    ok: false,
+    contentType,
+    text: '',
+    blocked: false,
+    error: message,
+  };
+}
+
 export function sourceFromUrl(raw, fallback = 'web') {
   const url = parseHttpUrl(raw);
   if (!url) return fallback;
@@ -324,56 +362,64 @@ function detectBlockedContent(text, { status = 200, contentType = '' } = {}) {
 }
 
 async function fetchTextMeta(url, { timeoutMs = 12_000, source = '' } = {}) {
-  if (!trustedForSource(url, source)) {
-    return {
-      url,
-      finalUrl: url,
-      status: 0,
-      ok: false,
-      contentType: '',
-      text: '',
-      blocked: false,
-      error: `untrusted source URL: ${url}`,
-    };
+  const startUrl = String(url || '');
+  if (!trustedForSource(startUrl, source)) return untrustedSourceMeta(startUrl, startUrl, `untrusted source URL: ${startUrl}`);
+  if (isPrivateOrInternalHostname(new URL(startUrl).hostname)) {
+    return untrustedSourceMeta(startUrl, startUrl, `internal source URL rejected: ${startUrl}`);
   }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await fetch(url, {
-      headers: { 'user-agent': BROWSER_UA, accept: 'application/rss+xml,application/xml,text/xml,text/plain,*/*' },
-      redirect: 'follow',
-      signal: controller.signal,
-    });
-    const finalUrl = res.url || url;
-    if (!trustedForSource(finalUrl, source)) {
+    let currentUrl = startUrl;
+    for (let hops = 0; hops <= 5; hops++) {
+      const res = await fetch(currentUrl, {
+        headers: { 'user-agent': BROWSER_UA, accept: 'application/rss+xml,application/xml,text/xml,text/plain,*/*' },
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+      const contentType = res.headers.get('content-type') || '';
+      if ([301, 302, 303, 307, 308].includes(Number(res.status))) {
+        const location = res.headers.get('location') || '';
+        if (!location) return untrustedSourceMeta(startUrl, currentUrl, `redirect without Location: ${currentUrl}`, res.status, contentType);
+        let nextUrl;
+        try {
+          nextUrl = new URL(location, currentUrl).href;
+        } catch {
+          return untrustedSourceMeta(startUrl, currentUrl, `invalid redirect Location: ${location}`, res.status, contentType);
+        }
+        const nextHost = new URL(nextUrl).hostname;
+        if (isPrivateOrInternalHostname(nextHost)) {
+          return untrustedSourceMeta(startUrl, nextUrl, `internal redirect target rejected: ${nextUrl}`, res.status, contentType);
+        }
+        if (!trustedForSource(nextUrl, source)) {
+          return untrustedSourceMeta(startUrl, nextUrl, `untrusted final source URL: ${nextUrl}`, res.status, contentType);
+        }
+        currentUrl = nextUrl;
+        continue;
+      }
+
+      const finalUrl = res.url || currentUrl;
+      if (!trustedForSource(finalUrl, source)) {
+        return untrustedSourceMeta(startUrl, finalUrl, `untrusted final source URL: ${finalUrl}`, res.status, contentType);
+      }
+      const text = await res.text().catch(() => '');
       return {
-        url,
+        url: startUrl,
         finalUrl,
         status: res.status,
-        ok: false,
-        contentType: res.headers.get('content-type') || '',
-        text: '',
-        blocked: false,
-        error: `untrusted final source URL: ${finalUrl}`,
+        ok: res.ok,
+        contentType,
+        text,
+        blocked: detectBlockedContent(text, { status: res.status, contentType }),
+        error: res.ok ? '' : `HTTP ${res.status}`,
       };
     }
-    const text = await res.text().catch(() => '');
-    const contentType = res.headers.get('content-type') || '';
-    return {
-      url,
-      finalUrl,
-      status: res.status,
-      ok: res.ok,
-      contentType,
-      text,
-      blocked: detectBlockedContent(text, { status: res.status, contentType }),
-      error: res.ok ? '' : `HTTP ${res.status}`,
-    };
+    return untrustedSourceMeta(startUrl, startUrl, 'too many redirects');
   } catch (err) {
     return {
-      url,
-      finalUrl: url,
+      url: startUrl,
+      finalUrl: startUrl,
       status: 0,
       ok: false,
       contentType: '',
@@ -524,7 +570,7 @@ function candidateFromItem(item, { now }) {
     round: details.round,
     source: item.source || sourceFromUrl(item.url),
     title: compact(item.title || ''),
-    url: trustedEvidenceUrl(item.url || '', item.source || ''),
+    url: trustedEvidenceUrl(item.url || '', ''),
     observedDate: observed,
     confidence: confidenceFor(item, details),
   };
@@ -653,7 +699,7 @@ async function fetchHnDiscovery({ months = DEFAULT_MONTHS, diagnostics = [] } = 
       const title = compact(hit.title || hit.story_title || '');
       if (!title) continue;
       const fallbackUrl = `https://news.ycombinator.com/item?id=${encodeURIComponent(String(hit.objectID || ''))}`;
-      const itemUrl = trustedEvidenceUrl(hit.url || '', 'hacker_news') || trustedEvidenceUrl(fallbackUrl, 'hacker_news');
+      const itemUrl = trustedEvidenceUrl(hit.url || '', '') || trustedEvidenceUrl(fallbackUrl, 'hacker_news');
       const item = {
         source: 'hacker_news',
         title: xmlText(title),

--- a/company-funded.mjs
+++ b/company-funded.mjs
@@ -342,14 +342,27 @@ async function fetchTextMeta(url, { timeoutMs = 12_000, source = '' } = {}) {
   try {
     const res = await fetch(url, {
       headers: { 'user-agent': BROWSER_UA, accept: 'application/rss+xml,application/xml,text/xml,text/plain,*/*' },
-      redirect: 'error',
+      redirect: 'follow',
       signal: controller.signal,
     });
+    const finalUrl = res.url || url;
+    if (!trustedForSource(finalUrl, source)) {
+      return {
+        url,
+        finalUrl,
+        status: res.status,
+        ok: false,
+        contentType: res.headers.get('content-type') || '',
+        text: '',
+        blocked: false,
+        error: `untrusted final source URL: ${finalUrl}`,
+      };
+    }
     const text = await res.text().catch(() => '');
     const contentType = res.headers.get('content-type') || '';
     return {
       url,
-      finalUrl: res.url || url,
+      finalUrl,
       status: res.status,
       ok: res.ok,
       contentType,
@@ -468,7 +481,8 @@ function inferredDateFromText(text, now = new Date()) {
   const raw = String(text || '');
   const year = raw.match(/\b(20\d{2})\b/)?.[1];
   if (year) {
-    const date = new Date(`${year}-01-01T00:00:00Z`);
+    const currentYear = now.getUTCFullYear();
+    const date = Number(year) === currentYear ? new Date(now.getTime()) : new Date(`${year}-01-01T00:00:00Z`);
     return { value: String(year), precision: 'year', date };
   }
   return { value: now.toISOString().slice(0, 10), precision: 'observed', date: now };
@@ -565,17 +579,19 @@ export function buildCandidates(items, {
     return candidate;
   });
 
-  for (const diag of diagnostics) {
-    diag.candidate_count = candidates.filter((c) => c.funding.sources.some((s) => s.source === sourceNameForDiagnostic(diag.source))).length;
-  }
-
   candidates.sort((a, b) => {
     if (sort === 'score') return b.discovery_score - a.discovery_score || a.company.localeCompare(b.company);
     const ad = a.funding.sources[0]?.observed_date || '';
     const bd = b.funding.sources[0]?.observed_date || '';
     return bd.localeCompare(ad) || b.discovery_score - a.discovery_score || a.company.localeCompare(b.company);
   });
-  return candidates.slice(0, limit);
+  const finalCandidates = candidates.slice(0, limit);
+
+  for (const diag of diagnostics) {
+    diag.candidate_count = finalCandidates.filter((c) => c.funding.sources.some((s) => s.source === sourceNameForDiagnostic(diag.source))).length;
+  }
+
+  return finalCandidates;
 }
 
 function sourceNameForDiagnostic(source) {
@@ -636,9 +652,10 @@ async function fetchHnDiscovery({ months = DEFAULT_MONTHS, diagnostics = [] } = 
     for (const hit of hits) {
       const title = compact(hit.title || hit.story_title || '');
       if (!title) continue;
-      const itemUrl = trustedEvidenceUrl(hit.url || '', '') || `https://news.ycombinator.com/item?id=${encodeURIComponent(String(hit.objectID || ''))}`;
+      const fallbackUrl = `https://news.ycombinator.com/item?id=${encodeURIComponent(String(hit.objectID || ''))}`;
+      const itemUrl = trustedEvidenceUrl(hit.url || '', 'hacker_news') || trustedEvidenceUrl(fallbackUrl, 'hacker_news');
       const item = {
-        source: sourceFromUrl(itemUrl, 'hacker_news'),
+        source: 'hacker_news',
         title: xmlText(title),
         url: itemUrl,
         published_at: hit.created_at ? new Date(hit.created_at).toISOString() : '',

--- a/company-funded.mjs
+++ b/company-funded.mjs
@@ -3,39 +3,24 @@
 /**
  * company-funded.mjs - discover recently funded companies for manual review.
  *
- * This is intentionally review-first: it writes a report/JSON candidate list,
- * never portals.yml. Add approved entries manually after review.
+ * V1 is intentionally narrow: it reads structured public feeds/APIs, writes a
+ * report/JSON candidate list, and never probes arbitrary company websites or
+ * edits portals.yml.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { dirname, join, resolve } from 'path';
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
 
-import { deriveSlugCandidates } from './verify-portals.mjs';
-import { loadProviders, resolveProvider } from './providers/_registry.mjs';
+import { decodeEntities } from './providers/_html-entities.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
-const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
-const PROVIDERS_DIR = resolve(ROOT, 'providers');
 const DEFAULT_LIMIT = 20;
 const DEFAULT_MONTHS = 3;
 const DEFAULT_SORT = 'date';
 const DEFAULT_SOURCES = ['techcrunch', 'prnewswire', 'guardian', 'hn'];
-const DEFAULT_ENRICH_CONCURRENCY = 3;
-const DEFAULT_ENRICH_TIMEOUT_MS = 20_000;
-const QUICK_FETCH_TIMEOUT_MS = 5_000;
 const BROWSER_UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
-
-const SOURCE_RANK = {
-  techcrunch: 70,
-  prnewswire: 65,
-  guardian: 50,
-  hacker_news: 35,
-  duckduckgo: 10,
-  web: 5,
-};
 
 const RSS_SOURCES = {
   techcrunch: [
@@ -50,6 +35,21 @@ const RSS_SOURCES = {
   guardian: ['https://www.theguardian.com/technology/rss'],
 };
 
+const SOURCE_HOSTS = {
+  techcrunch: ['techcrunch.com'],
+  prnewswire: ['prnewswire.com'],
+  guardian: ['theguardian.com'],
+  hacker_news: ['hn.algolia.com', 'news.ycombinator.com'],
+};
+
+const SOURCE_RANK = {
+  techcrunch: 70,
+  prnewswire: 65,
+  guardian: 50,
+  hacker_news: 35,
+  web: 5,
+};
+
 const GENERIC_NAMES = new Set([
   'ai',
   'startup',
@@ -60,6 +60,10 @@ const GENERIC_NAMES = new Set([
   'founders',
   'developer',
   'developers',
+  'edtech platform',
+  'fintech platform',
+  'healthcare platform',
+  'security platform',
   'techcrunch',
   'pr newswire',
   'business wire',
@@ -75,70 +79,19 @@ const GENERIC_NAMES = new Set([
   'round',
 ]);
 
-const BLOCKED_HOST_PARTS = [
-  'linkedin.',
-  'crunchbase.',
-  'wikipedia.',
-  'facebook.',
-  'instagram.',
-  'twitter.',
-  'x.com',
-  'youtube.',
-  'glassdoor.',
-  'indeed.',
-  'wellfound.',
-  'tracxn.',
-  'pitchbook.',
-  'bloomberg.',
-];
-
-const MONTH_INDEX = {
-  jan: 0,
-  january: 0,
-  feb: 1,
-  february: 1,
-  mar: 2,
-  march: 2,
-  apr: 3,
-  april: 3,
-  may: 4,
-  jun: 5,
-  june: 5,
-  jul: 6,
-  july: 6,
-  aug: 7,
-  august: 7,
-  sep: 8,
-  sept: 8,
-  september: 8,
-  oct: 9,
-  october: 9,
-  nov: 10,
-  november: 10,
-  dec: 11,
-  december: 11,
-};
-
 function usage() {
   console.log(`Usage:
   node company-funded.mjs --dry-run
   node company-funded.mjs --limit 25 --months 6 --sort date
   node company-funded.mjs --sources techcrunch,prnewswire,guardian,hn --dry-run
-  node company-funded.mjs --query "agentic AI Series A funding" --dry-run
 
 Options:
   --limit <n>             Max companies in the review list. Default: 20.
   --months <n>            Recent-funding window. Default: 3.
   --sort <date|score>     Candidate ordering. Default: date.
   --sources <csv>         Sources. Default: techcrunch,prnewswire,guardian,hn.
-                           Also accepts duckduckgo/search as opt-in fallback.
-  --query <text>          Add a DuckDuckGo fallback discovery query. Can be repeated.
-  --include-existing      Include companies already present in portals.yml.
-  --enrich                Resolve careers URLs/provider paths. This is the default.
-  --no-enrich             Fast mode: skip careers/scanner resolution.
   --dry-run               Print only; do not write report/JSON files.
   --json                  Print machine-readable JSON.
-  --portals <path>        portals.yml path. Default: portals.yml.
   --self-test             Run offline self-test.
 `);
 }
@@ -151,10 +104,6 @@ function parseArgs(argv) {
     sources: [...DEFAULT_SOURCES],
     dryRun: false,
     json: false,
-    includeExisting: false,
-    enrich: true,
-    queries: [],
-    portalsPath: DEFAULT_PORTALS_PATH,
     selfTest: false,
     help: false,
   };
@@ -162,17 +111,12 @@ function parseArgs(argv) {
     const arg = argv[i];
     if (arg === '--dry-run') opts.dryRun = true;
     else if (arg === '--json') opts.json = true;
-    else if (arg === '--include-existing') opts.includeExisting = true;
-    else if (arg === '--enrich') opts.enrich = true;
-    else if (arg === '--no-enrich') opts.enrich = false;
     else if (arg === '--self-test') opts.selfTest = true;
     else if (arg === '--help' || arg === '-h') opts.help = true;
     else if (arg === '--limit') opts.limit = Number(argv[++i] || '');
     else if (arg === '--months') opts.months = Number(argv[++i] || '');
     else if (arg === '--sort') opts.sort = String(argv[++i] || '').trim().toLowerCase();
     else if (arg === '--sources') opts.sources = parseSources(argv[++i] || '');
-    else if (arg === '--query') opts.queries.push(argv[++i] || '');
-    else if (arg === '--portals' || arg === '--file') opts.portalsPath = argv[++i] || '';
     else throw new Error(`unknown option: ${arg}`);
   }
   if (!Number.isInteger(opts.limit) || opts.limit <= 0 || opts.limit > 100) {
@@ -184,8 +128,6 @@ function parseArgs(argv) {
   if (!['date', 'score'].includes(opts.sort)) {
     throw new Error('--sort must be date or score');
   }
-  opts.queries = opts.queries.map((q) => q.trim()).filter(Boolean);
-  if (opts.queries.length && !opts.sources.includes('duckduckgo')) opts.sources.push('duckduckgo');
   return opts;
 }
 
@@ -195,7 +137,7 @@ function parseSources(value) {
     .map((s) => normalizeSourceName(s.trim()))
     .filter(Boolean);
   const unique = [...new Set(out)];
-  const allowed = new Set(['techcrunch', 'prnewswire', 'guardian', 'hn', 'duckduckgo']);
+  const allowed = new Set(['techcrunch', 'prnewswire', 'guardian', 'hn']);
   for (const source of unique) {
     if (!allowed.has(source)) throw new Error(`unknown source in --sources: ${source}`);
   }
@@ -205,16 +147,11 @@ function parseSources(value) {
 function normalizeSourceName(value) {
   const s = String(value || '').toLowerCase().replace(/[_\s]+/g, '-');
   if (s === 'hacker-news' || s === 'hackernews' || s === 'hn') return 'hn';
-  if (s === 'ddg' || s === 'duck-duck-go' || s === 'search') return 'duckduckgo';
   return s.replace(/-/g, '');
 }
 
 function compact(text) {
   return String(text || '').replace(/\s+/g, ' ').trim();
-}
-
-function normalizeName(name) {
-  return compact(name);
 }
 
 function companySlug(name) {
@@ -225,65 +162,58 @@ function companySlug(name) {
     .trim();
 }
 
-function decodeHtml(text) {
-  return String(text || '')
-    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#x27;/gi, "'")
-    .replace(/&apos;/g, "'")
-    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(Number.parseInt(n, 16)))
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>');
+export function matchesDomain(hostname, domain) {
+  const host = String(hostname || '').toLowerCase();
+  const d = String(domain || '').toLowerCase();
+  return Boolean(host && d && (host === d || host.endsWith(`.${d}`)));
 }
 
-function stripHtmlTags(text) {
-  return compact(decodeHtml(String(text || '').replace(/<script[\s\S]*?<\/script>/gi, ' ').replace(/<style[\s\S]*?<\/style>/gi, ' ').replace(/<[^>]+>/g, ' ')));
+function allowedSourceDomains(source) {
+  return SOURCE_HOSTS[source === 'hn' ? 'hacker_news' : source] || [];
 }
 
-function isBlockedHost(url) {
-  let host;
+function parseHttpUrl(raw) {
   try {
-    host = new URL(url).hostname.toLowerCase();
+    const url = new URL(String(raw || ''));
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+    return url;
   } catch {
-    return true;
+    return null;
   }
-  return BLOCKED_HOST_PARTS.some((part) => host === part.replace(/\.$/, '') || host.includes(part));
 }
 
-export function parseDuckDuckGoResults(html, { allowBlockedHosts = false } = {}) {
-  const out = [];
-  const re = /<a\b[^>]*\bclass="[^"]*\bresult__a\b[^"]*"[^>]*>/gi;
-  for (const match of String(html || '').matchAll(re)) {
-    const hrefMatch = match[0].match(/\bhref="([^"]+)"/i);
-    if (!hrefMatch) continue;
-    let href = decodeHtml(hrefMatch[1]);
-    if (href.startsWith('//')) href = `https:${href}`;
-    try {
-      const parsed = new URL(href, 'https://duckduckgo.com');
-      if (parsed.hostname.includes('duckduckgo.com') && parsed.pathname === '/l/') {
-        const target = parsed.searchParams.get('uddg');
-        if (target) href = target;
-      } else {
-        href = parsed.href;
-      }
-      if (/^https?:\/\//i.test(href) && (allowBlockedHosts || !isBlockedHost(href))) {
-        out.push({ url: href, title: stripHtmlTags(match[0]) });
-      }
-    } catch {
-      // Ignore malformed search-result links.
-    }
+function trustedForSource(raw, source) {
+  const url = parseHttpUrl(raw);
+  if (!url) return false;
+  const domains = allowedSourceDomains(source);
+  return domains.some((domain) => matchesDomain(url.hostname, domain));
+}
+
+export function sourceFromUrl(raw, fallback = 'web') {
+  const url = parseHttpUrl(raw);
+  if (!url) return fallback;
+  for (const [source, domains] of Object.entries(SOURCE_HOSTS)) {
+    if (domains.some((domain) => matchesDomain(url.hostname, domain))) return source;
   }
-  const seen = new Set();
-  return out.filter((item) => {
-    const key = item.url.replace(/\/+$/, '');
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
+  return fallback;
+}
+
+function trustedEvidenceUrl(raw, source) {
+  const url = parseHttpUrl(raw);
+  if (!url) return '';
+  const derived = sourceFromUrl(url.href, '');
+  if (!derived) return '';
+  if (source && source !== 'web' && derived !== source && !(source === 'hn' && derived === 'hacker_news')) return '';
+  return url.href;
+}
+
+function cdataValue(text) {
+  const match = String(text || '').match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
+  return match ? match[1] : text;
+}
+
+function xmlText(text) {
+  return compact(decodeEntities(cdataValue(String(text || ''))));
 }
 
 function stripPublisher(title) {
@@ -295,7 +225,7 @@ function stripPublisher(title) {
 }
 
 function cleanCompanyName(raw) {
-  let s = stripPublisher(decodeHtml(raw))
+  let s = stripPublisher(xmlText(raw))
     .replace(/^["'`]+|["'`]+$/g, '')
     .replace(/'s$/i, '')
     .replace(/’s$/i, '')
@@ -309,6 +239,7 @@ function cleanCompanyName(raw) {
   if (/['’]s\b.*\b(company|startup)\b/i.test(s)) return '';
   s = s.replace(/\s+in talks to$/i, '');
   s = s.replace(/\s+reportedly$/i, '');
+  s = s.replace(/\s+defies\s+.+$/i, '');
   s = s.replace(/^[A-Z][A-Za-z0-9&.-]+-backed\s+/i, '');
   s = s.replace(/\b(?:maker|creator)\s+of\s+.+$/i, '');
   s = s.replace(/^(?:the\s+)?(?:(?:ai|genai|agentic|coding|developer tools|developer|data|security|fintech|startup|software|robotics|defense|healthcare|biotech|open-source|enterprise|infrastructure|crypto|climate)\s+)+(?:startup|company|platform)?\s+/i, '');
@@ -317,39 +248,42 @@ function cleanCompanyName(raw) {
   s = compact(s);
 
   if (s.length < 2 || s.length > 70) return '';
+  if (/[<>]/.test(s)) return '';
   if (GENERIC_NAMES.has(s.toLowerCase())) return '';
+  if (/^(ai|genai|agentic|edtech|fintech|security|healthcare|biotech|robotics|climate|crypto|developer tools?)\s+(startup|company|platform)$/i.test(s)) return '';
   if (/\b(valuation|valuations|bubble|fears|earnings|fund)\b/i.test(s)) return '';
   if (!/[a-z0-9]/i.test(s)) return '';
   return s;
 }
 
 export function extractCompanyFromFundingTitle(title) {
-  const t = stripPublisher(title);
+  const t = stripPublisher(xmlText(title));
   if (/^(ask hn|tell hn|who is hiring|launch hn)\b/i.test(t)) return '';
 
   const patterns = [
     /\b(?:raises?|raised|lands|landed|secures?|secured|closes?|closed|nabs?|nabbed|bags?|bagged)\s+(?:an?\s+|over\s+|more\s+than\s+|up\s+to\s+)?\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\s+for\s+(?:an?\s+)?(?:ai\s+)?startup\s+(.+?)$/i,
+    /\bstartup\s+(.+?)\s+(?:reportedly\s+)?(?:raises?|raised|lands|landed|secures?|secured|closes?|closed|nabs?|nabbed|bags?|bagged)\b/i,
     /(?:startup|company|agency|platform)\s+(.+?)\s+hits\s+unicorn\s+status\b.*\braises?\b/i,
     /^(.+?)\s+(?:raises?|raised|lands|landed|secures?|secured|closes?|closed|nabs?|nabbed|bags?|bagged)\s+(?:an?\s+|over\s+|more\s+than\s+|up\s+to\s+)?\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\b/i,
     /^(.+?)\s+(?:raises?|raised|lands|landed|secures?|secured|closes?|closed|nabs?|nabbed|bags?|bagged)\s+(?:an?\s+)?(?:\w+\s+){0,4}(?:funding|round|series\s+[a-h]|seed|pre-seed|investment|financing|valuation)\b/i,
     /^(.+?)\s+(?:announces?|announced)\s+(?:\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\s+)?(?:\w+\s+){0,4}(?:funding|round|series\s+[a-h]|seed|pre-seed|financing)\b/i,
     /^(.+?)\s+(?:gets|got|receives?|received)\s+(?:\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\s+)?(?:in\s+)?(?:funding|investment|financing)\b/i,
-    /^(.+?)\s+(?:hits?|hit|reaches?|reached)\s+(?:a\s+)?\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\s+valuation\b/i,
-    /^(.+?)\s+valued\s+at\s+\$[\d.,]+\s*(?:billion|million|bn|[bkmt])?\b/i,
-    /^(.+?)\s+emerges?\s+from\s+stealth\b/i,
+    /^(.+?)\s+(?:hits?|hit|reaches?|reached)\s+(?:a\s+)?\$[\d.,]+(?:\.\d+)?\s*(?:billion|million|bn|[bkmt])?\s+valuation\b/i,
+    /^(.+?)\s+valued\s+at\s+\$[\d.,]+(?:\.\d+)?\s*(?:billion|million|bn|[bkmt])?\b/i,
+    /^(.+?)\s+emerges? from stealth\b/i,
     /^(.+?)\s+in\s+talks\s+to\s+raise\b/i,
   ];
 
   for (const re of patterns) {
-    const m = t.match(re);
-    if (m?.[1]) return cleanCompanyName(m[1]);
+    const match = t.match(re);
+    if (match?.[1]) return cleanCompanyName(match[1]);
   }
   return '';
 }
 
 export function extractFundingDetails(text) {
-  const raw = String(text || '');
-  const amount = raw.match(/\$[\d,.]+\s*(?:billion|million|bn|m|b|k)?/i)?.[0] || '';
+  const raw = xmlText(text);
+  const amount = raw.match(/\$[\d,.]+(?:\.\d+)?\s*(?:billion|million|bn|m|b|k)?/i)?.[0] || '';
   const round = raw.match(/\b(?:pre-seed|seed|series\s+[a-h]|strategic|venture|growth)\b/i)?.[0] || '';
   return {
     amount: compact(amount),
@@ -357,33 +291,8 @@ export function extractFundingDetails(text) {
   };
 }
 
-function sourceFromUrl(url, fallback = 'web') {
-  let host = '';
-  try {
-    host = new URL(url).hostname.toLowerCase();
-  } catch {
-    return fallback;
-  }
-  if (host.includes('hn.algolia.com') || host.includes('news.ycombinator.com')) return 'hacker_news';
-  if (host.includes('techcrunch.com')) return 'techcrunch';
-  if (host.includes('prnewswire.com')) return 'prnewswire';
-  if (host.includes('theguardian.com')) return 'guardian';
-  if (host.includes('businesswire.com')) return 'businesswire';
-  if (host.includes('crunchbase.com')) return 'crunchbase';
-  if (host === 'x.com' || host.endsWith('.x.com') || host.includes('twitter.com')) return 'x_twitter';
-  if (host.includes('reddit.com')) return 'reddit';
-  return fallback;
-}
-
 function companyKey(name) {
   return compact(name).toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
-}
-
-function loadExistingCompanies(filePath) {
-  if (!existsSync(filePath)) return new Set();
-  const parsed = yaml.load(readFileSync(filePath, 'utf-8'));
-  const companies = Array.isArray(parsed?.tracked_companies) ? parsed.tracked_companies : [];
-  return new Set(companies.map((c) => companyKey(c?.name || '')).filter(Boolean));
 }
 
 function diagnostic(source) {
@@ -414,13 +323,26 @@ function detectBlockedContent(text, { status = 200, contentType = '' } = {}) {
   return false;
 }
 
-async function fetchTextMeta(url, { timeoutMs = 12_000 } = {}) {
+async function fetchTextMeta(url, { timeoutMs = 12_000, source = '' } = {}) {
+  if (!trustedForSource(url, source)) {
+    return {
+      url,
+      finalUrl: url,
+      status: 0,
+      ok: false,
+      contentType: '',
+      text: '',
+      blocked: false,
+      error: `untrusted source URL: ${url}`,
+    };
+  }
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const res = await fetch(url, {
-      headers: { 'user-agent': BROWSER_UA, accept: 'application/rss+xml,application/xml,text/xml,text/html,text/plain,*/*' },
-      redirect: 'follow',
+      headers: { 'user-agent': BROWSER_UA, accept: 'application/rss+xml,application/xml,text/xml,text/plain,*/*' },
+      redirect: 'error',
       signal: controller.signal,
     });
     const text = await res.text().catch(() => '');
@@ -451,8 +373,8 @@ async function fetchTextMeta(url, { timeoutMs = 12_000 } = {}) {
   }
 }
 
-async function fetchJsonMeta(url, { timeoutMs = 12_000 } = {}) {
-  const meta = await fetchTextMeta(url, { timeoutMs });
+async function fetchJsonMeta(url, { timeoutMs = 12_000, source = '' } = {}) {
+  const meta = await fetchTextMeta(url, { timeoutMs, source });
   if (!meta.ok) return { ...meta, json: null };
   try {
     return { ...meta, json: JSON.parse(meta.text) };
@@ -465,20 +387,20 @@ function tagValue(xml, names) {
   for (const name of names) {
     const escaped = name.replace(':', '\\:');
     const re = new RegExp(`<${escaped}\\b[^>]*>([\\s\\S]*?)<\\/${escaped}>`, 'i');
-    const m = String(xml || '').match(re);
-    if (m?.[1]) return decodeHtml(m[1]);
+    const match = String(xml || '').match(re);
+    if (match?.[1]) return xmlText(match[1]);
   }
   return '';
 }
 
 function attrValue(xml, tag, attr) {
   const re = new RegExp(`<${tag}\\b[^>]*\\b${attr}=["']([^"']+)["'][^>]*>`, 'i');
-  return decodeHtml(String(xml || '').match(re)?.[1] || '');
+  return xmlText(String(xml || '').match(re)?.[1] || '');
 }
 
 function categoriesFromXml(xml) {
   return [...String(xml || '').matchAll(/<category\b[^>]*>([\s\S]*?)<\/category>/gi)]
-    .map((m) => stripHtmlTags(m[1]))
+    .map((match) => xmlText(match[1]))
     .filter(Boolean);
 }
 
@@ -503,18 +425,17 @@ export function parseRssItems(xml, { source = 'web' } = {}) {
   ];
   for (const blockMatch of blocks) {
     const block = blockMatch[1];
-    const title = stripHtmlTags(tagValue(block, ['title']));
-    const description = stripHtmlTags(tagValue(block, ['description', 'summary', 'content:encoded', 'content']));
+    const title = tagValue(block, ['title']);
+    const description = tagValue(block, ['description', 'summary', 'content:encoded', 'content']);
     const link = compact(tagValue(block, ['link'])) || attrValue(block, 'link', 'href');
-    const publishedRaw = tagValue(block, ['pubDate', 'published', 'updated', 'dc:date']);
-    const observedDate = parsePublishedDate(publishedRaw);
-    const sourceCompany = stripHtmlTags(tagValue(block, ['dc:contributor', 'dc:creator', 'author', 'source']));
+    const observedDate = parsePublishedDate(tagValue(block, ['pubDate', 'published', 'updated', 'dc:date']));
+    const sourceCompany = tagValue(block, ['dc:contributor', 'dc:creator', 'author', 'source']);
     const itemSource = sourceFromUrl(link, source);
     if (!title && !link) continue;
     out.push({
       source: itemSource === 'web' ? source : itemSource,
       title,
-      url: link,
+      url: trustedEvidenceUrl(link, itemSource === 'web' ? source : itemSource),
       published_at: observedDate?.date?.toISOString() || '',
       observedDate,
       text: compact(`${title} ${description}`),
@@ -526,489 +447,151 @@ export function parseRssItems(xml, { source = 'web' } = {}) {
 }
 
 function hasFundingLanguage(text) {
-  return /\b(funding|funded|raises?|raised|raise|series\s+[a-h]|seed\s+round|pre-seed|venture\s+round|investment|financing|valuation|valued\s+at|lands?|landed|secures?|secured|closes?|closed|nabs?|nabbed|bags?|bagged|emerges?\s+from\s+stealth|in\s+talks\s+to\s+raise)\b/i.test(String(text || ''));
+  return /\b(funding|funded|raises?|raised|raise|series\s+[a-h]|seed\s+round|pre-seed|venture\s+round|investment|financing|valuation|valued\s+at|lands?|landed|secures?|secured|closes?|closed|nabs?|nabbed|bags?|bagged|emerges?\s+from\s+stealth|in\s+talks\s+to\s+raise)\b/i.test(text);
 }
 
 function isExcludedFundingItem(item) {
-  const text = compact(`${item.title || ''} ${item.text || ''} ${(item.categories || []).join(' ')}`);
-  if (!hasFundingLanguage(text)) return true;
-  const negativePatterns = [
-    /\b(acquires?|acquired|acquisition|merger|merged|takeover|buyout|buys?|bought)\b/i,
-    /\b(earnings|quarterly results|financial results|fiscal year|revenue guidance|dividend|share repurchase|stock split|nasdaq|nyse|tsx:|lse:)\b/i,
-    /\b(scholarship|scholarships|grant|grants|donation|donates?|nonprofit grant)\b/i,
-    /\b(how to raise|tips for fundraising|fundraising advice|guide to fundraising|startup fundraising guide)\b/i,
+  const text = `${item.title || ''} ${item.text || ''} ${item.categories?.join(' ') || ''}`;
+  const exclusions = [
+    /\b(acquires?|acquired|acquisition|merger|spac|ipo|bankruptcy|layoffs?|cuts?\s+\d+%|earnings|quarterly results)\b/i,
     /\b(public offering|registered direct offering|private placement|atm offering|offering of common stock)\b/i,
+    /\braises?\s+\$[\d,.]+(?:\.\d+)?\s*(?:billion|million|bn|m|b|k)?\s+fund\b/i,
     /\b(venture fund|vc fund|investment fund|private equity fund|capital fund|fund ii|fund iii|fund iv|new fund)\b/i,
-    /\b(?:raises?|raised|closes?|closed|launches?|launched)\s+(?:an?\s+|its\s+|new\s+)?\$[\d.,]+\s*(?:billion|million|bn|[bm])?\s+fund\b/i,
-    /\b(?:raises?|raised|closes?|closed|launches?|launched)\s+(?:an?\s+|its\s+|new\s+)?(?:first|second|third|fourth|latest)\s+fund\b/i,
+    /\b(grant|grants|scholarship|scholarships|award|awards|donation|donates?)\b/i,
+    /\b(how to raise|ways to raise|guide to fundraising|startup valuations|bubble fears)\b/i,
   ];
-  return negativePatterns.some((re) => re.test(text));
+  if (exclusions.some((re) => re.test(text))) return true;
+  return !hasFundingLanguage(text);
 }
 
-function fundingWindowStart(now = new Date(), months = DEFAULT_MONTHS) {
-  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  d.setUTCMonth(d.getUTCMonth() - months);
-  return d;
-}
-
-export function extractFundingDate(text, now = new Date()) {
+function inferredDateFromText(text, now = new Date()) {
   const raw = String(text || '');
-  const iso = raw.match(/\b(20\d{2})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])\b/);
-  if (iso) return { value: iso[0], precision: 'day', date: new Date(`${iso[0]}T00:00:00Z`) };
-
-  const monthYear = raw.match(/\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?\s+(?:\d{1,2},?\s+)?(20\d{2})\b/i);
-  if (monthYear) {
-    const month = MONTH_INDEX[monthYear[1].toLowerCase().replace(/\.$/, '')];
-    const year = Number(monthYear[2]);
-    if (month != null) {
-      const date = new Date(Date.UTC(year, month, 1));
-      return { value: `${year}-${String(month + 1).padStart(2, '0')}`, precision: 'month', date };
-    }
-  }
-
-  const year = raw.match(/\b(20\d{2})\b/);
+  const year = raw.match(/\b(20\d{2})\b/)?.[1];
   if (year) {
-    const y = Number(year[1]);
-    const date = new Date(Date.UTC(y, 0, 1));
-    return { value: String(y), precision: 'year', date };
+    const date = new Date(`${year}-01-01T00:00:00Z`);
+    return { value: String(year), precision: 'year', date };
   }
-
-  const monthsAgo = raw.match(/\b(\d{1,2})\s+months?\s+ago\b/i);
-  if (monthsAgo) {
-    const date = fundingWindowStart(now, Number(monthsAgo[1]));
-    return { value: `${monthsAgo[1]} months ago`, precision: 'relative_month', date };
-  }
-  return null;
+  return { value: now.toISOString().slice(0, 10), precision: 'observed', date: now };
 }
 
-function dateValue(observedDate) {
-  return observedDate?.date instanceof Date && !Number.isNaN(observedDate.date.getTime())
-    ? observedDate.date.getTime()
-    : 0;
-}
-
-function candidateSourceName(hit) {
-  if (hit.source === 'prnewswire' && hit.source_company && hasFundingLanguage(`${hit.title || ''} ${hit.text || ''}`)) {
-    const clean = cleanCompanyName(hit.source_company);
-    if (clean) return clean;
+function bestObservedDate(item, now) {
+  if (item.observedDate?.date instanceof Date && !Number.isNaN(item.observedDate.date.getTime())) return item.observedDate;
+  if (item.published_at) {
+    const parsed = parsePublishedDate(item.published_at);
+    if (parsed) return parsed;
   }
-  return extractCompanyFromFundingTitle(hit.title);
+  return inferredDateFromText(`${item.title || ''} ${item.text || ''}`, now);
 }
 
-function fundingEvidenceScore(hit, { now = new Date(), months = DEFAULT_MONTHS } = {}) {
-  const haystack = `${hit.title || ''} ${hit.text || ''} ${(hit.categories || []).join(' ')}`;
-  if (!hasFundingLanguage(haystack) || isExcludedFundingItem(hit)) return -100;
-  const observed = hit.observedDate || extractFundingDate(haystack, now);
-  const windowStart = fundingWindowStart(now, months);
-  let score = 25 + (SOURCE_RANK[hit.source] || SOURCE_RANK.web);
-  if (observed?.date && observed.date >= windowStart) score += 50;
-  else if (observed?.date) score -= 40;
-  if (/\$[\d,.]+\s*(?:billion|million|bn|m|b|k)?/i.test(haystack)) score += 15;
-  if (/\b(series\s+[a-h]|seed\s+round|pre-seed)\b/i.test(haystack)) score += 15;
-  if (/\braises?|raised|secures?|secured|lands?|landed|closes?|closed\b/i.test(haystack)) score += 10;
-  if (/\bemerges?\s+from\s+stealth|in\s+talks\s+to\s+raise|valuation|valued\s+at\b/i.test(haystack)) score += 5;
-  return score;
+function withinMonths(date, months, now) {
+  const cutoff = new Date(now.getTime());
+  cutoff.setUTCMonth(cutoff.getUTCMonth() - months);
+  return date >= cutoff && date <= now;
 }
 
-function buildFundingSignal(evidence, { now = new Date(), months = DEFAULT_MONTHS } = {}) {
-  const windowStart = fundingWindowStart(now, months);
-  const scored = evidence
-    .map((hit) => {
-      const haystack = `${hit.title || ''} ${hit.text || ''}`;
-      const observed = hit.observedDate || extractFundingDate(haystack, now);
-      return {
-        source: hit.source || sourceFromUrl(hit.url),
-        title: compact(hit.title || hit.url).slice(0, 180),
-        url: hit.url,
-        observed_date: observed?.value || '',
-        date_precision: observed?.precision || '',
-        recent: Boolean(observed?.date && observed.date >= windowStart),
-        categories: hit.categories || [],
-        score: fundingEvidenceScore({ ...hit, observedDate: observed }, { now, months }),
-        dateMs: dateValue(observed),
-      };
-    })
-    .filter((hit) => hit.score > 0)
-    .sort((a, b) => b.recent - a.recent || b.dateMs - a.dateMs || b.score - a.score || (SOURCE_RANK[b.source] || 0) - (SOURCE_RANK[a.source] || 0));
+function confidenceFor(item, details) {
+  const sourceStrong = ['techcrunch', 'prnewswire', 'guardian'].includes(item.source);
+  const detailStrong = Boolean(details.amount || details.round);
+  if (sourceStrong && detailStrong) return 'high';
+  if (sourceStrong || detailStrong) return 'medium';
+  return 'low';
+}
 
-  const recent = scored.filter((hit) => hit.recent);
-  const sources = scored.slice(0, 5).map(({ score, dateMs, ...rest }) => rest);
-  let status = 'no_signal';
-  let confidence = 'low';
-  if (recent.length > 0) {
-    status = 'recent_funding_signal';
-    const best = recent[0];
-    confidence = ['techcrunch', 'prnewswire', 'guardian'].includes(best.source) || /\$[\d,.]+|\bseries\s+[a-h]\b|\bseed\b/i.test(best.title)
-      ? 'medium'
-      : 'low';
-  } else if (scored.length > 0) {
-    status = 'funding_signal_unconfirmed_recency';
-  }
-
+function candidateFromItem(item, { now }) {
+  if (isExcludedFundingItem(item)) return null;
+  const observed = bestObservedDate(item, now);
+  const details = extractFundingDetails(`${item.title || ''} ${item.text || ''}`);
+  const sourceCompany = item.source === 'prnewswire' ? cleanCompanyName(item.source_company || '') : '';
+  const company = extractCompanyFromFundingTitle(item.title) || sourceCompany;
+  if (!company) return null;
   return {
-    status,
-    confidence,
-    checked_at: now.toISOString().slice(0, 10),
-    window_months: months,
-    sources,
-    note: 'Funding is a hiring-likelihood signal only; verify manually before prioritizing.',
+    company,
+    amount: details.amount,
+    round: details.round,
+    source: item.source || sourceFromUrl(item.url),
+    title: compact(item.title || ''),
+    url: trustedEvidenceUrl(item.url || '', item.source || ''),
+    observedDate: observed,
+    confidence: confidenceFor(item, details),
   };
 }
 
-export function buildCandidates(hits, {
+export function buildCandidates(items, {
   months = DEFAULT_MONTHS,
-  includeExisting = false,
-  existingCompanies = new Set(),
-  now = new Date(),
   sort = DEFAULT_SORT,
   limit = DEFAULT_LIMIT,
+  now = new Date(),
   diagnostics = [],
 } = {}) {
   const grouped = new Map();
-  for (const hit of hits) {
-    if (isExcludedFundingItem(hit)) continue;
-    const name = candidateSourceName(hit);
-    if (!name) continue;
-    const key = companyKey(name);
+  for (const item of items || []) {
+    const candidate = candidateFromItem(item, { now });
+    if (!candidate) continue;
+    if (!withinMonths(candidate.observedDate.date, months, now)) continue;
+    const key = companyKey(candidate.company);
     if (!key) continue;
-    if (!includeExisting && existingCompanies.has(key)) continue;
-    if (!grouped.has(key)) grouped.set(key, { name, evidence: [], evidenceKeys: new Set() });
-    const evidenceKey = compact(`${hit.source || ''} ${hit.url || ''} ${hit.title || ''}`).toLowerCase();
-    if (grouped.get(key).evidenceKeys.has(evidenceKey)) continue;
-    grouped.get(key).evidenceKeys.add(evidenceKey);
-    grouped.get(key).evidence.push(hit);
+    const current = grouped.get(key) || {
+      company: candidate.company,
+      amount: '',
+      round: '',
+      funding: { status: 'recent_funding', confidence: 'low', sources: [] },
+      discovery_score: 0,
+      suggested_action: 'review_company_manually',
+    };
+    if (!current.amount && candidate.amount) current.amount = candidate.amount;
+    if (!current.round && candidate.round) current.round = candidate.round;
+    const evidence = {
+      source: candidate.source,
+      title: candidate.title,
+      url: candidate.url,
+      observed_date: candidate.observedDate.value,
+      date_precision: candidate.observedDate.precision,
+    };
+    const evidenceKey = `${evidence.source}\n${evidence.title}\n${evidence.url}\n${evidence.observed_date}`;
+    const duplicateEvidence = current.funding.sources.some((src) => `${src.source}\n${src.title}\n${src.url}\n${src.observed_date}` === evidenceKey);
+    if (!duplicateEvidence) {
+      current.funding.sources.push(evidence);
+      const sourceRank = SOURCE_RANK[candidate.source] || SOURCE_RANK.web;
+      const detailBonus = (candidate.amount ? 10 : 0) + (candidate.round ? 8 : 0);
+      const confidenceBonus = candidate.confidence === 'high' ? 15 : candidate.confidence === 'medium' ? 8 : 0;
+      current.discovery_score += sourceRank + detailBonus + confidenceBonus;
+      current.funding.confidence = bestConfidence(current.funding.confidence, candidate.confidence);
+    }
+    grouped.set(key, current);
   }
 
-  let candidates = [];
-  for (const item of grouped.values()) {
-    const funding = buildFundingSignal(item.evidence, { months, now });
-    if (funding.status !== 'recent_funding_signal') continue;
-    const best = funding.sources[0] || {};
-    const details = extractFundingDetails(`${best.title || ''} ${item.evidence[0]?.title || ''} ${item.evidence[0]?.text || ''}`);
-    candidates.push({
-      company: item.name,
-      funding,
-      funding_date: best.observed_date || '',
-      amount: details.amount,
-      round: details.round,
-      existing: existingCompanies.has(companyKey(item.name)),
-      discovery_score: discoveryScore(funding),
-      best_source: best.source || '',
-      best_title: best.title || '',
-      best_url: best.url || '',
-      suggested_action: 'review',
-    });
+  const candidates = [...grouped.values()].map((candidate) => {
+    candidate.funding.sources.sort((a, b) => String(b.observed_date || '').localeCompare(String(a.observed_date || '')));
+    return candidate;
+  });
+
+  for (const diag of diagnostics) {
+    diag.candidate_count = candidates.filter((c) => c.funding.sources.some((s) => s.source === sourceNameForDiagnostic(diag.source))).length;
   }
 
-  annotateCandidateDiagnostics(candidates, diagnostics);
-  candidates = sortCandidates(candidates, sort);
+  candidates.sort((a, b) => {
+    if (sort === 'score') return b.discovery_score - a.discovery_score || a.company.localeCompare(b.company);
+    const ad = a.funding.sources[0]?.observed_date || '';
+    const bd = b.funding.sources[0]?.observed_date || '';
+    return bd.localeCompare(ad) || b.discovery_score - a.discovery_score || a.company.localeCompare(b.company);
+  });
   return candidates.slice(0, limit);
 }
 
-function annotateCandidateDiagnostics(candidates, diagnostics) {
-  const bySource = new Map(diagnostics.map((d) => [d.source, d]));
-  for (const diag of diagnostics) diag.candidate_count = 0;
-  for (const candidate of candidates) {
-    const seen = new Set();
-    for (const src of candidate.funding.sources || []) {
-      if (!src.source || seen.has(src.source)) continue;
-      seen.add(src.source);
-      const key = src.source === 'hacker_news' ? 'hn' : src.source;
-      const diag = bySource.get(key) || bySource.get(src.source);
-      if (diag) diag.candidate_count += 1;
-    }
-  }
+function sourceNameForDiagnostic(source) {
+  return source === 'hn' ? 'hacker_news' : source;
 }
 
-function sortCandidates(candidates, sort = DEFAULT_SORT) {
-  const sorted = [...candidates];
-  if (sort === 'score') {
-    return sorted.sort((a, b) => b.discovery_score - a.discovery_score || dateMs(b) - dateMs(a) || a.company.localeCompare(b.company));
-  }
-  return sorted.sort((a, b) =>
-    dateMs(b) - dateMs(a) ||
-    (SOURCE_RANK[b.best_source] || 0) - (SOURCE_RANK[a.best_source] || 0) ||
-    b.discovery_score - a.discovery_score ||
-    a.company.localeCompare(b.company)
-  );
-}
-
-function dateMs(candidate) {
-  const date = candidate.funding.sources?.[0]?.observed_date || candidate.funding_date || '';
-  const parsed = date ? new Date(`${date.length === 7 ? `${date}-01` : date}T00:00:00Z`) : null;
-  return parsed && !Number.isNaN(parsed.getTime()) ? parsed.getTime() : 0;
-}
-
-function discoveryScore(funding) {
-  let score = 0;
-  if (funding.status === 'recent_funding_signal') score += 70;
-  if (funding.confidence === 'medium') score += 20;
-  const source = funding.sources?.[0]?.source || '';
-  score += Math.floor((SOURCE_RANK[source] || 0) / 4);
-  score += Math.min((funding.sources || []).length, 5);
-  return score;
-}
-
-function websearchQuery(name, careersUrl) {
-  let site = '';
-  try {
-    site = `site:${new URL(careersUrl).hostname}`;
-  } catch {
-    site = `"${name}"`;
-  }
-  return `${site} "AI Engineer" OR "Applied AI" OR "LLMOps" OR "Agentic" OR "Principal Engineer" OR "Staff Engineer" OR "Software Architect" OR "Backend Engineer" India OR Singapore OR London OR remote`;
-}
-
-export async function buildCompanyEntry(name, careersUrl, { providers = null, providerHint = null } = {}) {
-  const entry = {
-    name: normalizeName(name),
-    careers_url: careersUrl,
-    enabled: true,
-  };
-  if (providerHint) entry.provider = providerHint;
-
-  const loadedProviders = providers || await loadProviders(PROVIDERS_DIR);
-  const resolved = resolveProvider(entry, loadedProviders, { skipIds: ['local-parser'] });
-  if (!resolved?.provider) {
-    entry.scan_method = 'websearch';
-    entry.scan_query = websearchQuery(entry.name, careersUrl);
-  }
-  return { entry, provider: resolved?.provider?.id || null };
-}
-
-function formatPortalsEntry(entry) {
-  if (!entry) return '';
-  return yaml.dump([entry], { lineWidth: 140, noRefs: true, sortKeys: false }).trimEnd();
-}
-
-async function enrichCandidate(candidate) {
-  try {
-    const resolved = await withTimeout(
-      quickResolveCareerUrl(candidate.company),
-      DEFAULT_ENRICH_TIMEOUT_MS,
-      `career resolution timed out after ${DEFAULT_ENRICH_TIMEOUT_MS}ms`,
-    );
-    if (!resolved?.url) return markEnrichmentNotFound(candidate, resolved?.website || '');
-    const { entry, provider } = await buildCompanyEntry(candidate.company, resolved.url, { providerHint: resolved.providerHint });
-    return {
-      ...candidate,
-      website: resolved.website || '',
-      careers_url: entry.careers_url,
-      scanner_path: provider ? `provider:${provider}` : 'websearch',
-      provider: provider || '',
-      enrichment_status: 'found',
-      enrichment_error: '',
-      portals_entry: entry,
-      portals_entry_yaml: formatPortalsEntry(entry),
-      suggested_action: 'review_portals_entry',
-    };
-  } catch (err) {
-    const timedOut = err?.code === 'ETIMEDOUT';
-    return {
-      ...candidate,
-      website: '',
-      careers_url: '',
-      scanner_path: timedOut ? 'resolution_timeout' : 'resolution_failed',
-      enrichment_status: timedOut ? 'timeout' : 'error',
-      enrichment_error: err?.message || 'career resolution failed',
-      suggested_action: 'research_manually',
-    };
-  }
-}
-
-function markEnrichmentNotFound(candidate, website = '') {
-  return {
-    ...candidate,
-    website,
-    careers_url: '',
-    scanner_path: 'resolution_failed',
-    enrichment_status: 'not_found',
-    enrichment_error: '',
-    suggested_action: 'research_manually',
-  };
-}
-
-async function withTimeout(promise, timeoutMs, message) {
-  let timer;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise((_, reject) => {
-        timer = setTimeout(() => {
-          const err = new Error(message);
-          err.code = 'ETIMEDOUT';
-          reject(err);
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-function ensureHttpsUrl(value) {
-  const raw = String(value || '').trim();
-  if (!raw) return '';
-  if (/^https?:\/\//i.test(raw)) return raw;
-  return `https://${raw}`;
-}
-
-function baseHostFromWebsite(website) {
-  try {
-    return new URL(ensureHttpsUrl(website)).hostname.replace(/^www\./i, '');
-  } catch {
-    return '';
-  }
-}
-
-function providerHintFromPage(meta) {
-  const text = `${meta.finalUrl || meta.url}\n${meta.text || ''}`.toLowerCase();
-  if (text.includes('teamtailor') && text.includes('jobs.rss')) return 'teamtailor';
-  return null;
-}
-
-function quickWebsiteUrls(name) {
-  const slug = companySlug(name);
-  if (!slug) return [];
-  return [`https://${slug}.com`, `https://${slug}.ai`, `https://${slug}.io`, `https://${slug}.co`];
-}
-
-function quickCareerUrlsFromWebsite(website) {
-  const baseHost = baseHostFromWebsite(website);
-  if (!baseHost) return [];
-  const roots = [`https://${baseHost}`, `https://www.${baseHost}`];
-  return [
-    `https://jobs.${baseHost}`,
-    `https://careers.${baseHost}`,
-    ...roots.map((root) => `${root}/careers`),
-    ...roots.map((root) => `${root}/jobs`),
-    ...roots.map((root) => `${root}/company/careers`),
-    ...roots.map((root) => `${root}/careers/jobs`),
-  ];
-}
-
-function quickAtsUrls(name) {
-  const slugs = deriveSlugCandidates(name).slice(0, 4);
-  const urls = [];
-  for (const slug of slugs) {
-    urls.push(`https://jobs.ashbyhq.com/${slug}`);
-    urls.push(`https://job-boards.greenhouse.io/${slug}`);
-    urls.push(`https://jobs.lever.co/${slug}`);
-  }
-  return urls;
-}
-
-function visibleText(meta) {
-  return stripHtmlTags(meta.text || '').toLowerCase();
-}
-
-function quickCareerProbeScore(meta, name, websiteUrl = '') {
-  let parsed;
-  try {
-    parsed = new URL(meta.finalUrl || meta.url);
-  } catch {
-    return -100;
-  }
-  const host = parsed.hostname.toLowerCase();
-  const path = parsed.pathname.toLowerCase();
-  const visible = visibleText(meta);
-  const baseHost = baseHostFromWebsite(websiteUrl);
-  const isKnownAts = /(^|\.)ashbyhq\.com$|(^|\.)greenhouse\.io$|(^|\.)lever\.co$/i.test(host);
-  let score = meta.ok ? 40 : 0;
-  if ([401, 403].includes(Number(meta.status))) score += 10;
-  if (baseHost && (host === baseHost || host.endsWith(`.${baseHost}`))) score += 25;
-  if (/^(jobs|careers)\./i.test(host)) score += 25;
-  if (isKnownAts) score += 45;
-  if (/\/(careers|jobs|work-with-us|open-roles)\b/i.test(path)) score += 20;
-  if (/(open roles|open positions|current openings|job openings|view jobs|apply now|greenhouse|ashby|lever|workday|smartrecruiters|teamtailor)/i.test(visible)) score += 25;
-  if (/(page not found|not found|no longer available|access denied|forbidden|no jobs found)/i.test(visible)) score -= 35;
-  if (companySlug(name) && `${host}${path}${visible.slice(0, 2000)}`.replace(/[^a-z0-9]+/g, '').includes(companySlug(name))) score += 5;
-  return score;
-}
-
-async function probeQuickUrl(url, name, website = '') {
-  const meta = await fetchTextMeta(url, { timeoutMs: QUICK_FETCH_TIMEOUT_MS });
-  const score = quickCareerProbeScore(meta, name, website);
-  if (score < 55) return null;
-  return {
-    url: meta.finalUrl || url,
-    score,
-    providerHint: providerHintFromPage(meta),
-  };
-}
-
-async function firstReachableWebsite(name) {
-  const probes = await Promise.allSettled(
-    quickWebsiteUrls(name).map(async (url) => {
-      const meta = await fetchTextMeta(url, { timeoutMs: QUICK_FETCH_TIMEOUT_MS });
-      if (!meta.ok) return null;
-      return { url: meta.finalUrl || url, status: meta.status };
-    }),
-  );
-  return probes.map((p) => p.status === 'fulfilled' ? p.value : null).find(Boolean)?.url || '';
-}
-
-export async function quickResolveCareerUrl(name) {
-  const website = await firstReachableWebsite(name);
-  const urls = [...quickCareerUrlsFromWebsite(website), ...quickAtsUrls(name)];
-  const seen = new Set();
-  const unique = urls.filter((url) => {
-    const key = url.replace(/\/+$/, '');
-    if (!key || seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
-  const probes = await Promise.allSettled(unique.map((url) => probeQuickUrl(url, name, website)));
-  const candidates = probes
-    .map((p) => p.status === 'fulfilled' ? p.value : null)
-    .filter(Boolean)
-    .sort((a, b) => b.score - a.score);
-  return { website, ...(candidates[0] || {}) };
-}
-
-function enrichmentFailure(candidate, err) {
-  const timedOut = err?.code === 'ETIMEDOUT';
-  return {
-    ...candidate,
-    website: '',
-    careers_url: '',
-    scanner_path: timedOut ? 'resolution_timeout' : 'resolution_failed',
-    enrichment_status: timedOut ? 'timeout' : 'error',
-    enrichment_error: err?.message || 'career resolution failed',
-    suggested_action: 'research_manually',
-  };
-}
-
-export async function enrichCandidates(candidates, {
-  enrichCandidateFn = enrichCandidate,
-  concurrency = DEFAULT_ENRICH_CONCURRENCY,
-  timeoutMs = DEFAULT_ENRICH_TIMEOUT_MS,
-} = {}) {
-  const out = new Array(candidates.length);
-  let next = 0;
-  const workerCount = Math.max(1, Math.min(concurrency, candidates.length || 1));
-  await Promise.all(Array.from({ length: workerCount }, async () => {
-    while (next < candidates.length) {
-      const idx = next++;
-      try {
-        out[idx] = await withTimeout(Promise.resolve().then(() => enrichCandidateFn(candidates[idx])), timeoutMs, `career resolution timed out after ${timeoutMs}ms`);
-      } catch (err) {
-        out[idx] = enrichmentFailure(candidates[idx], err);
-      }
-    }
-  }));
-  return out;
-}
-
-function isoDate(now = new Date()) {
-  return now.toISOString().slice(0, 10);
+function bestConfidence(a, b) {
+  const rank = { low: 1, medium: 2, high: 3 };
+  return rank[b] > rank[a] ? b : a;
 }
 
 async function fetchRssDiscovery(source, diagnostics) {
   const diag = diagnostics.find((d) => d.source === source) || diagnostic(source);
   const out = [];
   for (const url of RSS_SOURCES[source] || []) {
-    const meta = await fetchTextMeta(url);
+    const meta = await fetchTextMeta(url, { source });
     if (!meta.ok || meta.blocked) {
       markDiagnosticError(diag, `${url}: ${meta.error || (meta.blocked ? 'blocked/challenge page' : 'fetch failed')}`, { blocked: meta.blocked });
       continue;
@@ -1021,32 +604,29 @@ async function fetchRssDiscovery(source, diagnostics) {
       out.push(item);
     }
   }
-  if (diag.fetched_items === 0 && diag.errors.length === 0) {
-    markDiagnosticError(diag, 'no RSS items fetched');
-  }
+  if (diag.fetched_items === 0 && diag.errors.length === 0) markDiagnosticError(diag, 'no RSS items fetched');
   return out;
 }
 
-function hnQueries(extra = []) {
+function hnQueries() {
   return [
     'AI startup raises funding',
     'Series A AI startup',
     'developer tools startup funding',
     'infrastructure startup raises funding',
     'agentic AI raises seed',
-    ...extra,
   ];
 }
 
-async function fetchHnDiscovery({ months = DEFAULT_MONTHS, extraQueries = [], diagnostics = [] } = {}) {
+async function fetchHnDiscovery({ months = DEFAULT_MONTHS, diagnostics = [] } = {}) {
   const diag = diagnostics.find((d) => d.source === 'hn') || diagnostic('hn');
   const cutoff = Math.floor(Date.now() / 1000) - months * 31 * 24 * 60 * 60;
   const out = [];
-  for (const query of hnQueries(extraQueries)) {
+  for (const query of hnQueries()) {
     const url =
       `https://hn.algolia.com/api/v1/search?query=${encodeURIComponent(query)}` +
       `&tags=story&hitsPerPage=50&numericFilters=created_at_i>${cutoff}`;
-    const meta = await fetchJsonMeta(url);
+    const meta = await fetchJsonMeta(url, { source: 'hacker_news' });
     if (!meta.ok || meta.blocked || !meta.json) {
       markDiagnosticError(diag, `${url}: ${meta.error || (meta.blocked ? 'blocked/challenge page' : 'fetch failed')}`, { blocked: meta.blocked });
       continue;
@@ -1056,13 +636,14 @@ async function fetchHnDiscovery({ months = DEFAULT_MONTHS, extraQueries = [], di
     for (const hit of hits) {
       const title = compact(hit.title || hit.story_title || '');
       if (!title) continue;
+      const itemUrl = trustedEvidenceUrl(hit.url || '', '') || `https://news.ycombinator.com/item?id=${encodeURIComponent(String(hit.objectID || ''))}`;
       const item = {
-        source: 'hacker_news',
-        title,
-        url: hit.url || `https://news.ycombinator.com/item?id=${hit.objectID}`,
+        source: sourceFromUrl(itemUrl, 'hacker_news'),
+        title: xmlText(title),
+        url: itemUrl,
         published_at: hit.created_at ? new Date(hit.created_at).toISOString() : '',
         observedDate: hit.created_at ? { value: hit.created_at.slice(0, 10), precision: 'day', date: new Date(hit.created_at) } : null,
-        text: compact(hit.story_text || ''),
+        text: xmlText(hit.story_text || ''),
         categories: [],
         source_company: '',
       };
@@ -1071,52 +652,7 @@ async function fetchHnDiscovery({ months = DEFAULT_MONTHS, extraQueries = [], di
       out.push(item);
     }
   }
-  if (diag.fetched_items === 0 && diag.errors.length === 0) {
-    markDiagnosticError(diag, 'no HN items fetched');
-  }
-  return out;
-}
-
-function discoveryQueries(extra = []) {
-  const year = new Date().getUTCFullYear();
-  return [
-    ...extra,
-    `site:techcrunch.com raises funding AI startup Series A seed ${year}`,
-    `site:prnewswire.com raises funding AI startup ${year}`,
-  ];
-}
-
-async function fetchSearchDiscovery(extraQueries = [], diagnostics = []) {
-  const diag = diagnostics.find((d) => d.source === 'duckduckgo') || diagnostic('duckduckgo');
-  const out = [];
-  for (const query of discoveryQueries(extraQueries)) {
-    const url = `https://duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
-    const meta = await fetchTextMeta(url);
-    if (!meta.ok || meta.blocked) {
-      markDiagnosticError(diag, `${url}: ${meta.error || (meta.blocked ? 'blocked/challenge page' : 'fetch failed')}`, { blocked: meta.blocked });
-      continue;
-    }
-    const results = parseDuckDuckGoResults(meta.text, { allowBlockedHosts: true }).slice(0, 12);
-    diag.fetched_items += results.length;
-    for (const result of results) {
-      const item = {
-        source: sourceFromUrl(result.url, 'duckduckgo'),
-        title: result.title,
-        url: result.url,
-        published_at: '',
-        observedDate: null,
-        text: '',
-        categories: [],
-        source_company: '',
-      };
-      if (isExcludedFundingItem(item)) continue;
-      diag.funding_like_items += 1;
-      out.push(item);
-    }
-  }
-  if (diag.fetched_items === 0 && diag.errors.length === 0) {
-    markDiagnosticError(diag, 'no DuckDuckGo results parsed');
-  }
+  if (diag.fetched_items === 0 && diag.errors.length === 0) markDiagnosticError(diag, 'no HN items fetched');
   return out;
 }
 
@@ -1127,23 +663,38 @@ async function collectDiscoveryItems(opts, diagnostics) {
     if (requested.has(source)) hits.push(...await fetchRssDiscovery(source, diagnostics));
   }
   if (requested.has('hn')) {
-    hits.push(...await fetchHnDiscovery({ months: opts.months, extraQueries: opts.queries || [], diagnostics }));
-  }
-  if (requested.has('duckduckgo')) {
-    hits.push(...await fetchSearchDiscovery(opts.queries || [], diagnostics));
+    hits.push(...await fetchHnDiscovery({ months: opts.months, diagnostics }));
   }
   return hits;
 }
 
-function renderReport(result) {
+function markdownText(value) {
+  return String(value || '')
+    .replace(/\\/g, '\\\\')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\|/g, '\\|')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]')
+    .replace(/\r?\n/g, ' ');
+}
+
+function safeReportUrl(value) {
+  const url = parseHttpUrl(value);
+  if (!url) return '';
+  return url.href.replace(/[<>\s]/g, encodeURIComponent);
+}
+
+export function renderReport(result) {
   const lines = [];
-  lines.push(`# Funded Company Discovery - ${result.generated_at}`);
+  lines.push(`# Funded Company Discovery - ${markdownText(result.generated_at)}`);
   lines.push('');
-  lines.push('Review-first output. No companies were added to portals.yml.');
+  lines.push('Review-first output. No companies were added to portals.yml and no company websites were probed.');
   lines.push('');
   lines.push(`Window: ${result.window_months} months`);
-  lines.push(`Sort: ${result.sort}`);
-  lines.push(`Sources: ${result.sources.join(', ')}`);
+  lines.push(`Sort: ${markdownText(result.sort)}`);
+  lines.push(`Sources: ${result.sources.map(markdownText).join(', ')}`);
   lines.push(`Candidates: ${result.companies.length}`);
   lines.push('');
   lines.push('## Source Health');
@@ -1151,45 +702,32 @@ function renderReport(result) {
   lines.push('| Source | Status | Fetched | Funding-like | Candidates | Notes |');
   lines.push('|--------|--------|---------|--------------|------------|-------|');
   for (const diag of result.diagnostics) {
-    lines.push(`| ${md(diag.source)} | ${md(diag.status)} | ${diag.fetched_items} | ${diag.funding_like_items} | ${diag.candidate_count} | ${md(diag.errors.join('; '))} |`);
+    lines.push(`| ${markdownText(diag.source)} | ${markdownText(diag.status)} | ${diag.fetched_items} | ${diag.funding_like_items} | ${diag.candidate_count} | ${markdownText(diag.errors.join('; '))} |`);
   }
   lines.push('');
-  lines.push('| # | Company | Funding | Date | Source | Careers URL | Scanner | Action |');
-  lines.push('|---|---------|---------|------|--------|-------------|---------|--------|');
-  result.companies.forEach((c, idx) => {
-    const src = c.funding.sources?.[0] || {};
-    const funding = [c.round, c.amount, c.funding.status].filter(Boolean).join(' / ');
-    lines.push(`| ${idx + 1} | ${md(c.company)} | ${md(funding)} | ${md(src.observed_date || '')} | ${md(src.source || '')} | ${md(careerDisplay(c))} | ${md(scannerDisplay(c))} | ${md(c.suggested_action)} |`);
+  lines.push('| # | Company | Funding | Date | Source | Action |');
+  lines.push('|---|---------|---------|------|--------|--------|');
+  result.companies.forEach((candidate, idx) => {
+    const src = candidate.funding.sources?.[0] || {};
+    const funding = [candidate.round, candidate.amount, candidate.funding.status].filter(Boolean).join(' / ');
+    lines.push(`| ${idx + 1} | ${markdownText(candidate.company)} | ${markdownText(funding)} | ${markdownText(src.observed_date || '')} | ${markdownText(src.source || '')} | ${markdownText(candidate.suggested_action)} |`);
   });
   lines.push('');
-  for (const c of result.companies) {
-    lines.push(`## ${c.company}`);
+  for (const candidate of result.companies) {
+    lines.push(`## ${markdownText(candidate.company)}`);
     lines.push('');
-    lines.push(`- Funding signal: ${c.funding.status} (${c.funding.confidence})`);
-    if (c.round || c.amount) lines.push(`- Round/amount: ${[c.round, c.amount].filter(Boolean).join(', ')}`);
-    lines.push(`- Careers URL: ${careerDisplay(c)}`);
-    lines.push(`- Scanner path: ${scannerDisplay(c)}`);
-    lines.push(`- Enrichment: ${c.enrichment_status || 'unknown'}${c.enrichment_error ? ` (${c.enrichment_error})` : ''}`);
-    lines.push(`- Existing in portals.yml: ${c.existing ? 'yes' : 'no'}`);
-    if (c.portals_entry_yaml) {
-      lines.push('- Suggested portals.yml entry:');
-      lines.push('```yaml');
-      lines.push(c.portals_entry_yaml);
-      lines.push('```');
-    } else {
-      lines.push('- Suggested action: research careers URL manually before adding to portals.yml');
-    }
+    lines.push(`- Funding signal: ${markdownText(candidate.funding.status)} (${markdownText(candidate.funding.confidence)})`);
+    if (candidate.round || candidate.amount) lines.push(`- Round/amount: ${markdownText([candidate.round, candidate.amount].filter(Boolean).join(', '))}`);
+    lines.push(`- Suggested action: ${markdownText(candidate.suggested_action)}`);
     lines.push('- Evidence:');
-    for (const src of c.funding.sources.slice(0, 3)) {
-      lines.push(`  - ${src.source}${src.observed_date ? `, ${src.observed_date}` : ''}: [${md(src.title)}](${src.url})`);
+    for (const src of candidate.funding.sources.slice(0, 3)) {
+      const url = safeReportUrl(src.url);
+      const suffix = url ? ` - ${url}` : '';
+      lines.push(`  - ${markdownText(src.source)}${src.observed_date ? `, ${markdownText(src.observed_date)}` : ''}: ${markdownText(src.title)}${suffix}`);
     }
     lines.push('');
   }
   return `${lines.join('\n')}\n`;
-}
-
-function md(value) {
-  return String(value || '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
 function writeArtifacts(result) {
@@ -1224,70 +762,29 @@ function printHuman(result) {
     }
   }
   console.log('');
-  for (const [idx, c] of result.companies.entries()) {
-    const src = c.funding.sources?.[0] || {};
-    console.log(`${idx + 1}. ${c.company}`);
-    console.log(`   Funding: ${[c.round, c.amount, c.funding.status].filter(Boolean).join(' / ')} (${c.funding.confidence})${src.observed_date ? `, ${src.observed_date}` : ''}`);
+  for (const [idx, candidate] of result.companies.entries()) {
+    const src = candidate.funding.sources?.[0] || {};
+    console.log(`${idx + 1}. ${candidate.company}`);
+    console.log(`   Funding: ${[candidate.round, candidate.amount, candidate.funding.status].filter(Boolean).join(' / ')} (${candidate.funding.confidence})${src.observed_date ? `, ${src.observed_date}` : ''}`);
     console.log(`   Source: ${src.source || 'n/a'} - ${src.title || 'n/a'}`);
-    console.log(`   Careers: ${careerDisplay(c)}`);
-    console.log(`   Scanner: ${scannerDisplay(c)}`);
-    if (c.enrichment_status && c.enrichment_status !== 'found') {
-      console.log(`   Enrichment: ${c.enrichment_status}${c.enrichment_error ? ` - ${c.enrichment_error}` : ''}`);
-    }
-    if (c.portals_entry_yaml) {
-      console.log('   Suggested portals.yml entry:');
-      for (const line of c.portals_entry_yaml.split('\n')) console.log(`     ${line}`);
-    } else {
-      console.log('   Suggested action: research careers URL manually before adding to portals.yml');
-    }
+    console.log(`   Evidence: ${src.url || 'n/a'}`);
+    console.log(`   Action: ${candidate.suggested_action}`);
   }
-}
-
-function careerDisplay(candidate) {
-  if (candidate.careers_url) return candidate.careers_url;
-  if (candidate.enrichment_status === 'skipped') return 'not checked (--no-enrich)';
-  return 'not found';
-}
-
-function scannerDisplay(candidate) {
-  if (candidate.scanner_path) return candidate.scanner_path;
-  if (candidate.enrichment_status === 'skipped') return 'not checked';
-  return 'resolution_failed';
 }
 
 export async function discoverFundedCompanies(opts = {}) {
   const months = opts.months || DEFAULT_MONTHS;
   const sources = (opts.sources || DEFAULT_SOURCES).map(normalizeSourceName);
-  const portalsPath = resolve(opts.portalsPath || DEFAULT_PORTALS_PATH);
-  const existingCompanies = loadExistingCompanies(portalsPath);
   const diagnostics = [...new Set(sources)].map(diagnostic);
   const hits = Array.isArray(opts.discoveryItems)
     ? opts.discoveryItems
     : await collectDiscoveryItems({ ...opts, months, sources }, diagnostics);
-  let companies = buildCandidates(hits, {
+  const companies = buildCandidates(hits, {
     months,
-    includeExisting: opts.includeExisting,
-    existingCompanies,
     sort: opts.sort || DEFAULT_SORT,
     limit: opts.limit || DEFAULT_LIMIT,
     diagnostics,
   });
-
-  if (opts.enrich !== false) {
-    companies = await enrichCandidates(companies, {
-      enrichCandidateFn: opts.enrichCandidateFn || enrichCandidate,
-      concurrency: opts.enrichConcurrency || DEFAULT_ENRICH_CONCURRENCY,
-      timeoutMs: opts.enrichTimeoutMs || DEFAULT_ENRICH_TIMEOUT_MS,
-    });
-  } else {
-    companies = companies.map((c) => ({
-      ...c,
-      careers_url: '',
-      scanner_path: '',
-      enrichment_status: 'skipped',
-      enrichment_error: '',
-    }));
-  }
 
   return {
     generated_at: isoDate(),
@@ -1300,20 +797,14 @@ export async function discoverFundedCompanies(opts = {}) {
   };
 }
 
+function isoDate(now = new Date()) {
+  return now.toISOString().slice(0, 10);
+}
+
 async function selfTest() {
   const examples = [
     ['Prime Intellect raises $130M Series A', 'Prime Intellect'],
-    ['Norm raises $120M', 'Norm'],
-    ['Resolve AI raises $125M Series A', 'Resolve AI'],
-    ['Cascade raises $3.5M', 'Cascade'],
-    ['SambaNova raises $1B', 'SambaNova'],
-    ['Anysphere raises $900M in funding', 'Anysphere'],
     ['AI coding startup Cursor maker Anysphere raises Series C funding', 'Anysphere'],
-    ['AI logistics startup Augment, from Deliverr founder, raises $85M Series A', 'Augment'],
-    ['Mira Murati’s AI startup Thinking Machines valued at $12B in early-stage funding', 'Thinking Machines'],
-    ['OpenAI in talks to raise funding that would value AI startup at up to $340B', 'OpenAI'],
-    ['AI-powered travel agency Fora hits unicorn status, raises $60M', 'Fora'],
-    ['Airbnb-backed WeRoad raises $58M to take its group travel platform to the US', 'WeRoad'],
     ['Ex-DeepMind David Silver Raises $1.1B for AI Startup Ineffable', 'Ineffable'],
     ['Travis Kalanick&#8217;s robotics company raises $1.7B, led by a16z', ''],
     ['AI startup valuations raise bubble fears as funding surges', ''],
@@ -1374,7 +865,7 @@ async function main() {
 
 if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
   main().catch((err) => {
-    console.error(`company-funded failed: ${err.message}`);
+    console.error(`company-funded: ${err.message}`);
     process.exit(1);
   });
 }

--- a/company-funded.mjs
+++ b/company-funded.mjs
@@ -9,6 +9,7 @@
  */
 
 import { mkdirSync, writeFileSync } from 'fs';
+import { isIP } from 'net';
 import { dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -189,17 +190,7 @@ function trustedForSource(raw, source) {
   return domains.some((domain) => matchesDomain(url.hostname, domain));
 }
 
-function isPrivateOrInternalHostname(hostname) {
-  const host = String(hostname || '').toLowerCase().replace(/^\[|\]$/g, '');
-  if (!host) return true;
-  if (host === 'localhost' || host.endsWith('.localhost')) return true;
-  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
-  if (host.startsWith('fc') || host.startsWith('fd') || host.startsWith('fe80:')) return true;
-
-  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (!ipv4) return false;
-  const parts = ipv4.slice(1).map(Number);
-  if (parts.some((part) => part < 0 || part > 255)) return true;
+function isPrivateIpv4(parts) {
   const [a, b] = parts;
   return (
     a === 0 ||
@@ -214,6 +205,63 @@ function isPrivateOrInternalHostname(hostname) {
   );
 }
 
+function parseIpv4Part(part) {
+  if (/^0x[0-9a-f]+$/i.test(part)) return Number.parseInt(part.slice(2), 16);
+  if (/^0[0-7]+$/.test(part)) return Number.parseInt(part, 8);
+  if (/^\d+$/.test(part)) return Number.parseInt(part, 10);
+  return NaN;
+}
+
+function parseIpv4Hostname(host) {
+  const parts = String(host || '').split('.');
+  if (parts.length < 1 || parts.length > 4 || parts.some((part) => part === '')) return null;
+  if (!parts.every((part) => /^(?:0x[0-9a-f]+|0[0-7]+|\d+)$/i.test(part))) return null;
+  const nums = parts.map(parseIpv4Part);
+  if (nums.some((num) => !Number.isSafeInteger(num) || num < 0)) return null;
+  const prefix = nums.slice(0, -1);
+  if (prefix.some((num) => num > 255)) return null;
+  const last = nums.at(-1);
+  const remainingBytes = 5 - nums.length;
+  if (last > 256 ** remainingBytes - 1) return null;
+  if (nums.length === 1) return [(last >>> 24) & 255, (last >>> 16) & 255, (last >>> 8) & 255, last & 255];
+  if (nums.length === 2) return [nums[0], (last >>> 16) & 255, (last >>> 8) & 255, last & 255];
+  if (nums.length === 3) return [nums[0], nums[1], (last >>> 8) & 255, last & 255];
+  return nums;
+}
+
+function parseIpv4MappedIpv6(host) {
+  const normalized = String(host || '').toLowerCase();
+  const dotted = normalized.match(/^(?:0:0:0:0:0:ffff:|::ffff:)(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (dotted) return parseIpv4Hostname(dotted[1]);
+  const hex = normalized.match(/^(?:0:0:0:0:0:ffff:|::ffff:)([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (!hex) return null;
+  const high = Number.parseInt(hex[1], 16);
+  const low = Number.parseInt(hex[2], 16);
+  if (high > 0xffff || low > 0xffff) return null;
+  return [(high >>> 8) & 255, high & 255, (low >>> 8) & 255, low & 255];
+}
+
+function isPrivateOrInternalHostname(hostname) {
+  const host = String(hostname || '').toLowerCase().replace(/^\[|\]$/g, '');
+  if (!host) return true;
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+
+  const ipv4 = parseIpv4Hostname(host);
+  if (ipv4) return isPrivateIpv4(ipv4);
+
+  const version = isIP(host);
+  if (version !== 6) return false;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+
+  const mappedIpv4 = parseIpv4MappedIpv6(host);
+  if (mappedIpv4) return isPrivateIpv4(mappedIpv4);
+
+  const firstHextet = host.split(':')[0];
+  if (/^f[cd][0-9a-f]{0,2}$/i.test(firstHextet)) return true;
+  const first = Number.parseInt(firstHextet, 16);
+  return Number.isFinite(first) && first >= 0xfe80 && first <= 0xfebf;
+}
+
 function untrustedSourceMeta(url, finalUrl, message, status = 0, contentType = '') {
   return {
     url,
@@ -225,6 +273,15 @@ function untrustedSourceMeta(url, finalUrl, message, status = 0, contentType = '
     blocked: false,
     error: message,
   };
+}
+
+async function releaseResponseBody(res) {
+  try {
+    if (res?.bodyUsed) return;
+    await res?.arrayBuffer?.();
+  } catch {
+    // Best-effort cleanup for rejected responses.
+  }
 }
 
 export function sourceFromUrl(raw, fallback = 'web') {
@@ -381,26 +438,34 @@ async function fetchTextMeta(url, { timeoutMs = 12_000, source = '' } = {}) {
       const contentType = res.headers.get('content-type') || '';
       if ([301, 302, 303, 307, 308].includes(Number(res.status))) {
         const location = res.headers.get('location') || '';
-        if (!location) return untrustedSourceMeta(startUrl, currentUrl, `redirect without Location: ${currentUrl}`, res.status, contentType);
+        if (!location) {
+          await releaseResponseBody(res);
+          return untrustedSourceMeta(startUrl, currentUrl, `redirect without Location: ${currentUrl}`, res.status, contentType);
+        }
         let nextUrl;
         try {
           nextUrl = new URL(location, currentUrl).href;
         } catch {
+          await releaseResponseBody(res);
           return untrustedSourceMeta(startUrl, currentUrl, `invalid redirect Location: ${location}`, res.status, contentType);
         }
         const nextHost = new URL(nextUrl).hostname;
         if (isPrivateOrInternalHostname(nextHost)) {
+          await releaseResponseBody(res);
           return untrustedSourceMeta(startUrl, nextUrl, `internal redirect target rejected: ${nextUrl}`, res.status, contentType);
         }
         if (!trustedForSource(nextUrl, source)) {
+          await releaseResponseBody(res);
           return untrustedSourceMeta(startUrl, nextUrl, `untrusted final source URL: ${nextUrl}`, res.status, contentType);
         }
+        await releaseResponseBody(res);
         currentUrl = nextUrl;
         continue;
       }
 
       const finalUrl = res.url || currentUrl;
       if (!trustedForSource(finalUrl, source)) {
+        await releaseResponseBody(res);
         return untrustedSourceMeta(startUrl, finalUrl, `untrusted final source URL: ${finalUrl}`, res.status, contentType);
       }
       const text = await res.text().catch(() => '');

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -535,18 +535,17 @@ The cost is real: a full Workday + iCIMS sweep becomes DNS-bound at roughly 35 m
 
 ## company:funded
 
-Review-first discovery for companies that recently raised funding. It reads public RSS/API sources, enriches likely careers pages when possible, and prints candidates plus suggested `portals.yml` entries for manual review. It never edits `portals.yml`.
+Review-first discovery for companies that recently raised funding. It reads structured public RSS/API sources and prints a candidate report for manual review. It never edits `portals.yml` and does not probe company websites.
 
 ```bash
 npm run company:funded -- --dry-run --limit 20
 npm run company:funded -- --dry-run --limit 20 --months 3 --json
 npm run company:funded -- --sources techcrunch,prnewswire,guardian,hn
-npm run company:funded -- --sources duckduckgo --query "agentic AI Series A funding"
 ```
 
-Defaults: last 3 months, sorted by newest funding date, sources `techcrunch,prnewswire,guardian,hn`. DuckDuckGo search is opt-in via `--sources duckduckgo` or `--query`.
+Defaults: last 3 months, sorted by newest funding date, sources `techcrunch,prnewswire,guardian,hn`.
 
-Source diagnostics are included in JSON output and surfaced in human output when a source has errors, is blocked, returns no items, or when no candidates are found. Candidate enrichment is enabled by default; pass `--no-enrich` for a faster funding-only run.
+Source diagnostics are included in JSON output and surfaced in human output when a source has errors, is blocked, returns no items, or when no candidates are found.
 
 **Exit codes:** `0` discovery completed, `1` invalid arguments or fatal runtime error.
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -28,6 +28,7 @@ All scripts live in the project root as `.mjs` modules. Most are exposed via
 | `npm run extract` | `browser-extract.mjs` | Headless read-only page extractor (opt-in `scan.extractor: cli`) — compact JSON for scan/JD |
 | `npm run scan` | `scan.mjs` | Zero-token portal scanner |
 | `npm run scan:full` | `scan-ats-full.mjs` | Reverse ATS discovery scanner |
+| `npm run company:funded` | `company-funded.mjs` | Review-first discovery of recently funded companies |
 | `npm run validate:portals` | `validate-portals.mjs` | Validate portals.yml shape before scanning |
 | `npm run tracker` | `tracker.mjs` | SQLite derived index over applications.md — sync/query/history/export |
 | `npm run find` | `find.mjs` | Resolve a report#/tracker#/company query to its full pipeline identity |
@@ -529,6 +530,25 @@ CAREER_OPS_NO_DNS_CACHE=1 npm run scan:full            # no DNS cache AND no pac
 The cost is real: a full Workday + iCIMS sweep becomes DNS-bound at roughly 35 minutes. Raise the ceiling if your resolver has the budget — but if you see `fetch failed` in bulk from one ATS section, suspect the resolver before the boards.
 
 **Exit codes:** `0` scan completed, `1` configuration error (no portals.yml, unknown `--ats` source) or fatal scan error.
+
+---
+
+## company:funded
+
+Review-first discovery for companies that recently raised funding. It reads public RSS/API sources, enriches likely careers pages when possible, and prints candidates plus suggested `portals.yml` entries for manual review. It never edits `portals.yml`.
+
+```bash
+npm run company:funded -- --dry-run --limit 20
+npm run company:funded -- --dry-run --limit 20 --months 3 --json
+npm run company:funded -- --sources techcrunch,prnewswire,guardian,hn
+npm run company:funded -- --sources duckduckgo --query "agentic AI Series A funding"
+```
+
+Defaults: last 3 months, sorted by newest funding date, sources `techcrunch,prnewswire,guardian,hn`. DuckDuckGo search is opt-in via `--sources duckduckgo` or `--query`.
+
+Source diagnostics are included in JSON output and surfaced in human output when a source has errors, is blocked, returns no items, or when no candidates are found. Candidate enrichment is enabled by default; pass `--no-enrich` for a faster funding-only run.
+
+**Exit codes:** `0` discovery completed, `1` invalid arguments or fatal runtime error.
 
 ---
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -540,10 +540,14 @@ Review-first discovery for companies that recently raised funding. It reads stru
 ```bash
 npm run company:funded -- --dry-run --limit 20
 npm run company:funded -- --dry-run --limit 20 --months 3 --json
+npm run company:funded -- --dry-run --sort score --limit 20
 npm run company:funded -- --sources techcrunch,prnewswire,guardian,hn
+npm run company:funded -- --self-test
 ```
 
-Defaults: last 3 months, sorted by newest funding date, sources `techcrunch,prnewswire,guardian,hn`.
+Defaults: last 3 months, `--sort date`, sources `techcrunch,prnewswire,guardian,hn`. `--sort score` ranks by source and funding-detail confidence instead.
+
+Runs without `--dry-run` write JSON under `output/` and a Markdown report under `reports/`.
 
 Source diagnostics are included in JSON output and surfaced in human output when a source has errors, is blocked, returns no items, or when no candidates are found.
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "scan:seeds": "node scan-ats-full.mjs --seeds yc,a16z",
     "scan:yc": "node scan-ats-full.mjs --seeds yc",
     "scan:interamt": "node scan-interamt.mjs",
+    "company:funded": "node company-funded.mjs",
     "validate:portals": "node validate-portals.mjs",
     "verify:portals": "node verify-portals.mjs",
     "tracker": "node tracker.mjs",

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -174,6 +174,7 @@ const scripts = [
   { name: 'jd-skill-gap.mjs --self-test', expectExit: 0 },
   { name: 'verify-cv-facts.mjs --self-test', expectExit: 0 },
   { name: 'contacts.mjs --self-test', expectExit: 0 },
+  { name: 'company-funded.mjs --self-test', expectExit: 0 },
   { name: 'updater-migration-tests.mjs', expectExit: 0 },
   { name: 'tracker-columns-tests.mjs', expectExit: 0 },
   { name: 'agent-inbox-tests.mjs', expectExit: 0 },

--- a/tests/company-funded.test.mjs
+++ b/tests/company-funded.test.mjs
@@ -1,0 +1,237 @@
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nUtility - company-funded');
+
+try {
+  const mod = await import(pathToFileURL(join(ROOT, 'company-funded.mjs')).href);
+
+  const cases = [
+    ['Prime Intellect raises $130M Series A', 'Prime Intellect'],
+    ['Norm raises $120M', 'Norm'],
+    ['Resolve AI raises $125M Series A', 'Resolve AI'],
+    ['Cascade raises $3.5M', 'Cascade'],
+    ['SambaNova raises $1B', 'SambaNova'],
+    ['Anysphere raises $900M in funding', 'Anysphere'],
+    ['AI coding startup Cursor maker Anysphere raises Series C funding', 'Anysphere'],
+    ['AI logistics startup Augment, from Deliverr founder, raises $85M Series A', 'Augment'],
+    ['Mira Murati’s AI startup Thinking Machines valued at $12B in early-stage funding', 'Thinking Machines'],
+    ['OpenAI in talks to raise funding that would value AI startup at up to $340B', 'OpenAI'],
+    ['AI-powered travel agency Fora hits unicorn status, raises $60M', 'Fora'],
+    ['Airbnb-backed WeRoad raises $58M to take its group travel platform to the US', 'WeRoad'],
+    ['Ex-DeepMind David Silver Raises $1.1B for AI Startup Ineffable', 'Ineffable'],
+    ['Travis Kalanick&#8217;s robotics company raises $1.7B, led by a16z', ''],
+    ['AI startup valuations raise bubble fears as funding surges', ''],
+    ["Yann LeCun's AI startup raises $1B seed round", ''],
+    ['Acme closes $25M Series A round - TechCrunch', 'Acme'],
+    ['Ask HN: Who is hiring?', ''],
+  ];
+  for (const [title, expected] of cases) {
+    const got = mod.extractCompanyFromFundingTitle(title);
+    if (got === expected) pass(`extractCompanyFromFundingTitle: ${title}`);
+    else fail(`extractCompanyFromFundingTitle(${JSON.stringify(title)}) = ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`);
+  }
+
+  const details = mod.extractFundingDetails('Acme closes $25M Series A round - TechCrunch');
+  if (details.amount === '$25M' && details.round === 'Series A') {
+    pass('extractFundingDetails reads amount and round');
+  } else {
+    fail(`extractFundingDetails returned ${JSON.stringify(details)}`);
+  }
+
+  const techCrunchXml = `<?xml version="1.0"?><rss><channel>
+    <item>
+      <title><![CDATA[Prime Intellect raises $130M Series A]]></title>
+      <link>https://techcrunch.com/2026/07/15/prime-intellect</link>
+      <pubDate>Wed, 15 Jul 2026 12:00:00 +0000</pubDate>
+      <category>Startups</category>
+      <description><![CDATA[Prime Intellect raises new funding for distributed AI research.]]></description>
+    </item>
+  </channel></rss>`;
+  const prNewswireXml = `<?xml version="1.0"?><rss><channel>
+    <item>
+      <title>New $120M Funding Round Announced for AI Compliance Platform</title>
+      <link>https://www.prnewswire.com/news-releases/norm-funding</link>
+      <pubDate>Tue, 14 Jul 2026 09:00:00 +0000</pubDate>
+      <dc:contributor>Norm</dc:contributor>
+      <description>Norm announced Series B financing.</description>
+    </item>
+  </channel></rss>`;
+  const guardianXml = `<?xml version="1.0"?><rss><channel>
+    <item>
+      <title>Resolve AI raises $125M Series A as agentic tools boom</title>
+      <link>https://www.theguardian.com/technology/2026/jul/13/resolve-ai</link>
+      <pubDate>Mon, 13 Jul 2026 08:00:00 +0000</pubDate>
+      <description>Resolve AI has secured funding for its enterprise product.</description>
+    </item>
+  </channel></rss>`;
+
+  const rssItems = [
+    ...mod.parseRssItems(techCrunchXml, { source: 'techcrunch' }),
+    ...mod.parseRssItems(prNewswireXml, { source: 'prnewswire' }),
+    ...mod.parseRssItems(guardianXml, { source: 'guardian' }),
+  ];
+  if (rssItems.length === 3 && rssItems.every((item) => item.observedDate?.value?.startsWith('2026-07'))) {
+    pass('parseRssItems reads TechCrunch, PRNewswire, and Guardian-style XML');
+  } else {
+    fail(`parseRssItems returned ${JSON.stringify(rssItems)}`);
+  }
+
+  const rssCandidates = mod.buildCandidates(rssItems, { now: new Date('2026-07-20T00:00:00Z'), months: 3, limit: 10 });
+  const rssNames = rssCandidates.map((c) => c.company);
+  if (rssNames.includes('Prime Intellect') && rssNames.includes('Norm') && rssNames.includes('Resolve AI')) {
+    pass('buildCandidates turns RSS funding items into candidates, including PRNewswire contributor company');
+  } else {
+    fail(`buildCandidates missed RSS candidates: ${JSON.stringify(rssNames)}`);
+  }
+
+  const negativeItems = [
+    ['techcrunch', 'Alpha Ventures raises $500M fund for AI startups'],
+    ['guardian', 'Acme acquires Beta after earlier funding talks'],
+    ['prnewswire', 'MegaCorp announces quarterly earnings and financial results'],
+    ['prnewswire', 'Foundation awards $5M scholarships and grants'],
+    ['techcrunch', 'How to raise seed funding in a difficult market'],
+  ].map(([source, title], idx) => ({
+    source,
+    title,
+    url: `https://example.test/${idx}`,
+    observedDate: { value: '2026-07-10', precision: 'day', date: new Date('2026-07-10T00:00:00Z') },
+    text: title,
+    categories: [],
+  }));
+  const negativeCandidates = mod.buildCandidates(negativeItems, { now: new Date('2026-07-20T00:00:00Z'), months: 3, limit: 10 });
+  if (negativeCandidates.length === 0) {
+    pass('buildCandidates rejects funds, acquisitions, earnings, scholarships, grants, and generic fundraising advice');
+  } else {
+    fail(`buildCandidates accepted negative items: ${JSON.stringify(negativeCandidates)}`);
+  }
+
+  const mixedDates = [
+    ['techcrunch', 'OldCo raises $20M Series A', '2025-12-15'],
+    ['techcrunch', 'Cascade raises $3.5M', '2026-05-01'],
+    ['guardian', 'SambaNova raises $1B', '2026-07-18'],
+    ['prnewswire', 'Prime Intellect raises $130M Series A', '2026-07-20'],
+  ].map(([source, title, date]) => ({
+    source,
+    title,
+    url: `https://example.test/${title.split(' ')[0].toLowerCase()}`,
+    observedDate: { value: date, precision: 'day', date: new Date(`${date}T00:00:00Z`) },
+    text: title,
+    categories: [],
+  }));
+  const recentSorted = mod.buildCandidates(mixedDates, { now: new Date('2026-07-20T00:00:00Z'), months: 3, limit: 10 });
+  const recentNames = recentSorted.map((c) => c.company);
+  if (recentNames.join(',') === 'Prime Intellect,SambaNova,Cascade') {
+    pass('buildCandidates defaults to newest funding date first and excludes stale items');
+  } else {
+    fail(`date sort/window returned ${JSON.stringify(recentNames)}`);
+  }
+  const extendedWindow = mod.buildCandidates(mixedDates, { now: new Date('2026-07-20T00:00:00Z'), months: 8, limit: 10 });
+  if (extendedWindow.map((c) => c.company).includes('OldCo')) {
+    pass('buildCandidates includes older funding only when --months allows it');
+  } else {
+    fail(`extended window excluded OldCo: ${JSON.stringify(extendedWindow.map((c) => c.company))}`);
+  }
+
+  const enrichmentItems = [
+    {
+      source: 'techcrunch',
+      title: 'Acme raises $25M Series A',
+      url: 'https://techcrunch.com/acme',
+      observedDate: { value: '2026-07-19', precision: 'day', date: new Date('2026-07-19T00:00:00Z') },
+      text: 'Acme raises $25M Series A funding.',
+      categories: [],
+    },
+  ];
+  const enrichedDefault = await mod.discoverFundedCompanies({
+    discoveryItems: enrichmentItems,
+    sources: ['techcrunch'],
+    months: 3,
+    limit: 5,
+    portalsPath: '.tmp-missing-portals.yml',
+    enrichCandidateFn: async (candidate) => ({
+      ...candidate,
+      website: 'https://acme.ai',
+      careers_url: 'https://jobs.acme.ai',
+      scanner_path: 'provider:greenhouse',
+      provider: 'greenhouse',
+      enrichment_status: 'found',
+      enrichment_error: '',
+      portals_entry: {
+        name: 'Acme',
+        careers_url: 'https://jobs.acme.ai',
+        enabled: true,
+        provider: 'greenhouse',
+      },
+      portals_entry_yaml: '- name: Acme\n  careers_url: https://jobs.acme.ai\n  enabled: true\n  provider: greenhouse',
+      suggested_action: 'review_portals_entry',
+    }),
+  });
+  if (enrichedDefault.companies[0]?.enrichment_status === 'found' && enrichedDefault.companies[0]?.careers_url === 'https://jobs.acme.ai') {
+    pass('discoverFundedCompanies enriches careers/scanner by default');
+  } else {
+    fail(`default enrichment missing: ${JSON.stringify(enrichedDefault.companies[0])}`);
+  }
+
+  const skippedEnrichment = await mod.discoverFundedCompanies({
+    discoveryItems: enrichmentItems,
+    sources: ['techcrunch'],
+    months: 3,
+    limit: 5,
+    enrich: false,
+    portalsPath: '.tmp-missing-portals.yml',
+  });
+  if (skippedEnrichment.companies[0]?.enrichment_status === 'skipped' && skippedEnrichment.companies[0]?.scanner_path === '') {
+    pass('discoverFundedCompanies marks --no-enrich output as skipped, not not_found');
+  } else {
+    fail(`--no-enrich status wrong: ${JSON.stringify(skippedEnrichment.companies[0])}`);
+  }
+
+  const failingEnrichment = await mod.enrichCandidates(
+    [{ company: 'FailCo', funding: { sources: [] }, discovery_score: 1 }],
+    { enrichCandidateFn: async () => { throw new Error('resolver exploded'); }, timeoutMs: 100 },
+  );
+  if (failingEnrichment[0]?.enrichment_status === 'error' && failingEnrichment[0]?.scanner_path === 'resolution_failed') {
+    pass('enrichCandidates converts resolver errors into candidate diagnostics');
+  } else {
+    fail(`enrichCandidates error handling failed: ${JSON.stringify(failingEnrichment)}`);
+  }
+
+  const timeoutEnrichment = await mod.enrichCandidates(
+    [{ company: 'SlowCo', funding: { sources: [] }, discovery_score: 1 }],
+    { enrichCandidateFn: async () => new Promise(() => {}), timeoutMs: 10 },
+  );
+  if (timeoutEnrichment[0]?.enrichment_status === 'timeout' && timeoutEnrichment[0]?.scanner_path === 'resolution_timeout') {
+    pass('enrichCandidates converts resolver timeouts into candidate diagnostics');
+  } else {
+    fail(`enrichCandidates timeout handling failed: ${JSON.stringify(timeoutEnrichment)}`);
+  }
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response('<html><title>Access denied</title><body>Verify you are human</body></html>', {
+    status: 403,
+    headers: { 'content-type': 'text/html' },
+  });
+  try {
+    const result = await mod.discoverFundedCompanies({
+      dryRun: true,
+      enrich: false,
+      sources: ['duckduckgo'],
+      months: 3,
+      limit: 5,
+      queries: ['agentic AI Series A funding'],
+      portalsPath: '.tmp-missing-portals.yml',
+    });
+    const diag = result.diagnostics.find((d) => d.source === 'duckduckgo');
+    if (diag?.status === 'blocked' && diag.blocked && diag.errors.length > 0 && result.companies.length === 0) {
+      pass('discoverFundedCompanies reports blocked/challenge pages in diagnostics');
+    } else {
+      fail(`blocked diagnostics missing: ${JSON.stringify(result)}`);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+} catch (err) {
+  fail(`company-funded test crashed: ${err.stack || err.message}`);
+}

--- a/tests/company-funded.test.mjs
+++ b/tests/company-funded.test.mjs
@@ -191,6 +191,20 @@ try {
     fail(`extended window excluded OldCo: ${JSON.stringify(extendedWindow.map((c) => c.company))}`);
   }
 
+  const currentYearInferred = mod.buildCandidates([{
+    source: 'hacker_news',
+    title: 'Acme raises $25M Series A in 2026',
+    url: 'https://news.ycombinator.com/item?id=77',
+    observedDate: null,
+    text: 'Acme raises funding.',
+    categories: [],
+  }], { now: new Date('2026-07-20T00:00:00Z'), months: 3, limit: 10 });
+  if (currentYearInferred[0]?.company === 'Acme' && currentYearInferred[0]?.funding.sources[0]?.observed_date === '2026') {
+    pass('buildCandidates keeps current-year inferred dates inside the recent window');
+  } else {
+    fail(`current-year inferred date was treated as stale: ${JSON.stringify(currentYearInferred)}`);
+  }
+
   const duplicateEvidence = mod.buildCandidates([
     {
       source: 'techcrunch',
@@ -271,17 +285,19 @@ try {
   const seenFetchOptions = [];
   globalThis.fetch = async (url, options) => {
     seenFetchOptions.push({ url, options });
-    return new Response(`<?xml version="1.0"?><rss><channel>
-      <item>
-        <title>Acme raises $25M Series A</title>
-        <link>https://techcrunch.com/acme</link>
-        <pubDate>Wed, 15 Jul 2026 12:00:00 +0000</pubDate>
-        <description>Acme raises funding.</description>
-      </item>
-    </channel></rss>`, {
+    const res = new Response(`<?xml version="1.0"?><rss><channel>
+        <item>
+          <title>Acme raises $25M Series A</title>
+          <link>https://techcrunch.com/acme</link>
+          <pubDate>Wed, 15 Jul 2026 12:00:00 +0000</pubDate>
+          <description>Acme raises funding.</description>
+        </item>
+      </channel></rss>`, {
       status: 200,
       headers: { 'content-type': 'application/rss+xml' },
     });
+    Object.defineProperty(res, 'url', { value: String(url).replace('/feed/', '/final-feed/') });
+    return res;
   };
   try {
     const result = await mod.discoverFundedCompanies({
@@ -290,10 +306,75 @@ try {
       months: 3,
       limit: 5,
     });
-    if (result.companies[0]?.company === 'Acme' && seenFetchOptions.every((call) => call.options?.redirect === 'error')) {
-      pass('discoverFundedCompanies fetches structured sources with redirect:error');
+    if (result.companies[0]?.company === 'Acme' && seenFetchOptions.every((call) => call.options?.redirect === 'follow')) {
+      pass('discoverFundedCompanies follows structured-source redirects after source validation');
     } else {
       fail(`structured fetch behavior wrong: ${JSON.stringify({ result, seenFetchOptions })}`);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  globalThis.fetch = async (url, options) => {
+    const res = new Response('not used', {
+      status: 200,
+      headers: { 'content-type': 'application/rss+xml' },
+    });
+    Object.defineProperty(res, 'url', { value: 'https://techcrunch.com.attacker.net/feed/' });
+    return res;
+  };
+  try {
+    const result = await mod.discoverFundedCompanies({
+      dryRun: true,
+      sources: ['techcrunch'],
+      months: 3,
+      limit: 5,
+    });
+    const diag = result.diagnostics.find((d) => d.source === 'techcrunch');
+    if (diag?.status === 'error' && diag.errors.some((err) => err.includes('untrusted final source URL')) && result.companies.length === 0) {
+      pass('discoverFundedCompanies rejects redirects to untrusted final source hosts');
+    } else {
+      fail(`untrusted final redirect was accepted: ${JSON.stringify(result)}`);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  globalThis.fetch = async (url, options) => {
+    const res = new Response(JSON.stringify({
+      hits: [{
+        title: 'Acme raises $25M Series A',
+        url: '',
+        objectID: '123',
+        created_at: '2026-07-19T12:00:00Z',
+        story_text: 'Acme raises funding.',
+      }],
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+    Object.defineProperty(res, 'url', { value: String(url) });
+    return res;
+  };
+  try {
+    const result = await mod.discoverFundedCompanies({
+      dryRun: true,
+      sources: ['hn'],
+      months: 3,
+      limit: 5,
+    });
+    const candidate = result.companies[0];
+    const evidence = candidate?.funding.sources[0];
+    const diag = result.diagnostics.find((d) => d.source === 'hn');
+    if (
+      candidate?.company === 'Acme' &&
+      evidence?.source === 'hacker_news' &&
+      evidence?.url === 'https://news.ycombinator.com/item?id=123' &&
+      diag?.candidate_count === 1
+    ) {
+      pass('discoverFundedCompanies handles Hacker News JSON and falls back to trusted item URLs');
+    } else {
+      fail(`Hacker News discovery path regressed: ${JSON.stringify(result)}`);
     }
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/company-funded.test.mjs
+++ b/tests/company-funded.test.mjs
@@ -20,10 +20,13 @@ try {
     ['OpenAI in talks to raise funding that would value AI startup at up to $340B', 'OpenAI'],
     ['AI-powered travel agency Fora hits unicorn status, raises $60M', 'Fora'],
     ['Airbnb-backed WeRoad raises $58M to take its group travel platform to the US', 'WeRoad'],
+    ['Insurance startup Corgi reportedly raised more money at $4B — its third round in 8 weeks', 'Corgi'],
+    ['AI chip startup Etched defies skeptics, hits $10.3B valuation from big-name investors', 'Etched'],
     ['Ex-DeepMind David Silver Raises $1.1B for AI Startup Ineffable', 'Ineffable'],
     ['Travis Kalanick&#8217;s robotics company raises $1.7B, led by a16z', ''],
     ['AI startup valuations raise bubble fears as funding surges', ''],
     ["Yann LeCun's AI startup raises $1B seed round", ''],
+    ['Edtech platform raises $4.5M to help teach students how to vibe code', ''],
     ['Acme closes $25M Series A round - TechCrunch', 'Acme'],
     ['Ask HN: Who is hiring?', ''],
   ];
@@ -38,6 +41,27 @@ try {
     pass('extractFundingDetails reads amount and round');
   } else {
     fail(`extractFundingDetails returned ${JSON.stringify(details)}`);
+  }
+
+  if (
+    mod.matchesDomain('techcrunch.com', 'techcrunch.com') &&
+    mod.matchesDomain('www.techcrunch.com', 'techcrunch.com') &&
+    !mod.matchesDomain('techcrunch.com.attacker.net', 'techcrunch.com') &&
+    !mod.matchesDomain('eviltechcrunch.com', 'techcrunch.com')
+  ) {
+    pass('matchesDomain accepts exact/subdomain hosts and rejects suffix spoofs');
+  } else {
+    fail('matchesDomain hostname policy regressed');
+  }
+
+  if (
+    mod.sourceFromUrl('https://techcrunch.com/2026/acme') === 'techcrunch' &&
+    mod.sourceFromUrl('https://techcrunch.com.attacker.net/2026/acme') === 'web' &&
+    mod.sourceFromUrl('https://evil.example/path/techcrunch.com/story') === 'web'
+  ) {
+    pass('sourceFromUrl uses parsed hostnames, not URL substrings');
+  } else {
+    fail('sourceFromUrl accepted a spoofed hostname/path');
   }
 
   const techCrunchXml = `<?xml version="1.0"?><rss><channel>
@@ -78,12 +102,45 @@ try {
     fail(`parseRssItems returned ${JSON.stringify(rssItems)}`);
   }
 
+  const spoofedXml = `<?xml version="1.0"?><rss><channel>
+    <item>
+      <title>SpoofCo raises $50M Series A</title>
+      <link>https://techcrunch.com.attacker.net/spoof</link>
+      <pubDate>Wed, 15 Jul 2026 12:00:00 +0000</pubDate>
+      <description>SpoofCo raises funding.</description>
+    </item>
+  </channel></rss>`;
+  const spoofedItem = mod.parseRssItems(spoofedXml, { source: 'techcrunch' })[0];
+  if (spoofedItem?.source === 'techcrunch' && spoofedItem.url === '') {
+    pass('parseRssItems strips spoofed evidence URLs while preserving source context');
+  } else {
+    fail(`spoofed RSS URL was not stripped: ${JSON.stringify(spoofedItem)}`);
+  }
+
   const rssCandidates = mod.buildCandidates(rssItems, { now: new Date('2026-07-20T00:00:00Z'), months: 3, limit: 10 });
   const rssNames = rssCandidates.map((c) => c.company);
   if (rssNames.includes('Prime Intellect') && rssNames.includes('Norm') && rssNames.includes('Resolve AI')) {
     pass('buildCandidates turns RSS funding items into candidates, including PRNewswire contributor company');
   } else {
     fail(`buildCandidates missed RSS candidates: ${JSON.stringify(rssNames)}`);
+  }
+
+  const authorFallbackItems = [
+    {
+      source: 'techcrunch',
+      title: 'ServiceNow bets $40 million on Indian banking software specialist to expand its financial services push',
+      url: 'https://techcrunch.com/servicenow-businessnext',
+      observedDate: { value: '2026-07-22', precision: 'day', date: new Date('2026-07-22T00:00:00Z') },
+      text: 'Businessnext funding story.',
+      categories: [],
+      source_company: 'Jagmeet Singh',
+    },
+  ];
+  const authorFallbackCandidates = mod.buildCandidates(authorFallbackItems, { now: new Date('2026-07-23T00:00:00Z'), months: 3, limit: 10 });
+  if (authorFallbackCandidates.length === 0) {
+    pass('buildCandidates does not treat publisher authors as company fallback outside PRNewswire');
+  } else {
+    fail(`author fallback accepted as company: ${JSON.stringify(authorFallbackCandidates)}`);
   }
 
   const negativeItems = [
@@ -134,81 +191,114 @@ try {
     fail(`extended window excluded OldCo: ${JSON.stringify(extendedWindow.map((c) => c.company))}`);
   }
 
-  const enrichmentItems = [
+  const duplicateEvidence = mod.buildCandidates([
     {
       source: 'techcrunch',
       title: 'Acme raises $25M Series A',
       url: 'https://techcrunch.com/acme',
       observedDate: { value: '2026-07-19', precision: 'day', date: new Date('2026-07-19T00:00:00Z') },
-      text: 'Acme raises $25M Series A funding.',
+      text: 'Acme raises funding.',
       categories: [],
     },
-  ];
-  const enrichedDefault = await mod.discoverFundedCompanies({
-    discoveryItems: enrichmentItems,
-    sources: ['techcrunch'],
+    {
+      source: 'techcrunch',
+      title: 'Acme raises $25M Series A',
+      url: 'https://techcrunch.com/acme',
+      observedDate: { value: '2026-07-19', precision: 'day', date: new Date('2026-07-19T00:00:00Z') },
+      text: 'Acme raises funding.',
+      categories: [],
+    },
+  ], { now: new Date('2026-07-20T00:00:00Z'), months: 3, limit: 10 });
+  if (duplicateEvidence[0]?.funding.sources.length === 1 && duplicateEvidence[0]?.discovery_score === 103) {
+    pass('buildCandidates deduplicates repeated feed evidence without inflating score');
+  } else {
+    fail(`duplicate evidence handling regressed: ${JSON.stringify(duplicateEvidence)}`);
+  }
+
+  const encodedXml = `<?xml version="1.0"?><rss><channel>
+    <item>
+      <title>Acme raises $25M Series A &amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;</title>
+      <link>https://techcrunch.com/acme</link>
+      <pubDate>Wed, 15 Jul 2026 12:00:00 +0000</pubDate>
+      <description>Acme raises funding with &lt;/script &gt; text in the feed.</description>
+    </item>
+  </channel></rss>`;
+  const encodedCandidate = mod.buildCandidates(mod.parseRssItems(encodedXml, { source: 'techcrunch' }), {
+    now: new Date('2026-07-20T00:00:00Z'),
     months: 3,
-    limit: 5,
-    portalsPath: '.tmp-missing-portals.yml',
-    enrichCandidateFn: async (candidate) => ({
-      ...candidate,
-      website: 'https://acme.ai',
-      careers_url: 'https://jobs.acme.ai',
-      scanner_path: 'provider:greenhouse',
-      provider: 'greenhouse',
-      enrichment_status: 'found',
-      enrichment_error: '',
-      portals_entry: {
-        name: 'Acme',
-        careers_url: 'https://jobs.acme.ai',
-        enabled: true,
-        provider: 'greenhouse',
+    limit: 10,
+  })[0];
+  const encodedReport = mod.renderReport({
+    generated_at: '2026-07-20',
+    window_months: 3,
+    sort: 'date',
+    sources: ['techcrunch'],
+    diagnostics: [{ source: 'techcrunch', status: 'ok', fetched_items: 1, funding_like_items: 1, candidate_count: 1, errors: [] }],
+    companies: [encodedCandidate],
+  });
+  if (encodedReport.includes('&amp;lt;script&amp;gt;') && !encodedReport.includes('<script>') && !encodedReport.includes('</script >')) {
+    pass('renderReport does not double-decode or emit executable-looking feed markup');
+  } else {
+    fail(`unsafe report escaping: ${encodedReport}`);
+  }
+
+  const markdownReport = mod.renderReport({
+    generated_at: '2026-07-20',
+    window_months: 3,
+    sort: 'date',
+    sources: ['techcrunch'],
+    diagnostics: [{ source: 'techcrunch', status: 'ok', fetched_items: 1, funding_like_items: 1, candidate_count: 1, errors: ['bad | value \\ test [x]'] }],
+    companies: [{
+      company: 'Pipe | Co \\ [x]',
+      amount: '$25M',
+      round: 'Series A',
+      funding: {
+        status: 'recent_funding',
+        confidence: 'high',
+        sources: [{ source: 'techcrunch', title: 'Pipe | Co \\ [x] raises $25M', url: 'https://techcrunch.com/path', observed_date: '2026-07-20' }],
       },
-      portals_entry_yaml: '- name: Acme\n  careers_url: https://jobs.acme.ai\n  enabled: true\n  provider: greenhouse',
-      suggested_action: 'review_portals_entry',
-    }),
+      discovery_score: 1,
+      suggested_action: 'review_company_manually',
+    }],
   });
-  if (enrichedDefault.companies[0]?.enrichment_status === 'found' && enrichedDefault.companies[0]?.careers_url === 'https://jobs.acme.ai') {
-    pass('discoverFundedCompanies enriches careers/scanner by default');
+  if (markdownReport.includes('Pipe \\| Co \\\\ \\[x\\]') && markdownReport.includes('bad \\| value \\\\ test \\[x\\]')) {
+    pass('renderReport escapes Markdown table/control characters');
   } else {
-    fail(`default enrichment missing: ${JSON.stringify(enrichedDefault.companies[0])}`);
-  }
-
-  const skippedEnrichment = await mod.discoverFundedCompanies({
-    discoveryItems: enrichmentItems,
-    sources: ['techcrunch'],
-    months: 3,
-    limit: 5,
-    enrich: false,
-    portalsPath: '.tmp-missing-portals.yml',
-  });
-  if (skippedEnrichment.companies[0]?.enrichment_status === 'skipped' && skippedEnrichment.companies[0]?.scanner_path === '') {
-    pass('discoverFundedCompanies marks --no-enrich output as skipped, not not_found');
-  } else {
-    fail(`--no-enrich status wrong: ${JSON.stringify(skippedEnrichment.companies[0])}`);
-  }
-
-  const failingEnrichment = await mod.enrichCandidates(
-    [{ company: 'FailCo', funding: { sources: [] }, discovery_score: 1 }],
-    { enrichCandidateFn: async () => { throw new Error('resolver exploded'); }, timeoutMs: 100 },
-  );
-  if (failingEnrichment[0]?.enrichment_status === 'error' && failingEnrichment[0]?.scanner_path === 'resolution_failed') {
-    pass('enrichCandidates converts resolver errors into candidate diagnostics');
-  } else {
-    fail(`enrichCandidates error handling failed: ${JSON.stringify(failingEnrichment)}`);
-  }
-
-  const timeoutEnrichment = await mod.enrichCandidates(
-    [{ company: 'SlowCo', funding: { sources: [] }, discovery_score: 1 }],
-    { enrichCandidateFn: async () => new Promise(() => {}), timeoutMs: 10 },
-  );
-  if (timeoutEnrichment[0]?.enrichment_status === 'timeout' && timeoutEnrichment[0]?.scanner_path === 'resolution_timeout') {
-    pass('enrichCandidates converts resolver timeouts into candidate diagnostics');
-  } else {
-    fail(`enrichCandidates timeout handling failed: ${JSON.stringify(timeoutEnrichment)}`);
+    fail(`Markdown escaping regressed: ${markdownReport}`);
   }
 
   const originalFetch = globalThis.fetch;
+  const seenFetchOptions = [];
+  globalThis.fetch = async (url, options) => {
+    seenFetchOptions.push({ url, options });
+    return new Response(`<?xml version="1.0"?><rss><channel>
+      <item>
+        <title>Acme raises $25M Series A</title>
+        <link>https://techcrunch.com/acme</link>
+        <pubDate>Wed, 15 Jul 2026 12:00:00 +0000</pubDate>
+        <description>Acme raises funding.</description>
+      </item>
+    </channel></rss>`, {
+      status: 200,
+      headers: { 'content-type': 'application/rss+xml' },
+    });
+  };
+  try {
+    const result = await mod.discoverFundedCompanies({
+      dryRun: true,
+      sources: ['techcrunch'],
+      months: 3,
+      limit: 5,
+    });
+    if (result.companies[0]?.company === 'Acme' && seenFetchOptions.every((call) => call.options?.redirect === 'error')) {
+      pass('discoverFundedCompanies fetches structured sources with redirect:error');
+    } else {
+      fail(`structured fetch behavior wrong: ${JSON.stringify({ result, seenFetchOptions })}`);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
   globalThis.fetch = async () => new Response('<html><title>Access denied</title><body>Verify you are human</body></html>', {
     status: 403,
     headers: { 'content-type': 'text/html' },
@@ -216,14 +306,11 @@ try {
   try {
     const result = await mod.discoverFundedCompanies({
       dryRun: true,
-      enrich: false,
-      sources: ['duckduckgo'],
+      sources: ['techcrunch'],
       months: 3,
       limit: 5,
-      queries: ['agentic AI Series A funding'],
-      portalsPath: '.tmp-missing-portals.yml',
     });
-    const diag = result.diagnostics.find((d) => d.source === 'duckduckgo');
+    const diag = result.diagnostics.find((d) => d.source === 'techcrunch');
     if (diag?.status === 'blocked' && diag.blocked && diag.errors.length > 0 && result.companies.length === 0) {
       pass('discoverFundedCompanies reports blocked/challenge pages in diagnostics');
     } else {

--- a/tests/company-funded.test.mjs
+++ b/tests/company-funded.test.mjs
@@ -353,7 +353,9 @@ try {
     globalThis.fetch = originalFetch;
   }
 
+  const internalRedirectUrls = [];
   globalThis.fetch = async (url, options) => {
+    internalRedirectUrls.push(String(url));
     const res = new Response('', {
       status: 302,
       headers: { location: 'https://127.0.0.1/feed/' },
@@ -369,15 +371,22 @@ try {
       limit: 5,
     });
     const diag = result.diagnostics.find((d) => d.source === 'techcrunch');
-    if (diag?.status === 'error' && diag.errors.some((err) => err.includes('internal redirect target rejected')) && result.companies.length === 0) {
+    if (
+      diag?.status === 'error' &&
+      diag.errors.some((err) => err.includes('internal redirect target rejected')) &&
+      result.companies.length === 0 &&
+      !internalRedirectUrls.includes('https://127.0.0.1/feed/')
+    ) {
       pass('discoverFundedCompanies rejects redirects to internal targets before following');
     } else {
-      fail(`internal redirect was accepted: ${JSON.stringify(result)}`);
+      fail(`internal redirect was accepted: ${JSON.stringify({ result, internalRedirectUrls })}`);
     }
   } finally {
     globalThis.fetch = originalFetch;
   }
 
+  const recentAcme = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  const recentBeta = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
   globalThis.fetch = async (url, options) => {
     const res = new Response(JSON.stringify({
       hits: [
@@ -385,14 +394,14 @@ try {
           title: 'Acme raises $25M Series A',
           url: '',
           objectID: '123',
-          created_at: '2026-07-19T12:00:00Z',
+          created_at: recentAcme,
           story_text: 'Acme raises funding.',
         },
         {
           title: 'Beta raises $30M Series B',
           url: 'https://techcrunch.com/beta',
           objectID: '124',
-          created_at: '2026-07-19T13:00:00Z',
+          created_at: recentBeta,
           story_text: 'Beta raises funding.',
         },
       ],

--- a/tests/company-funded.test.mjs
+++ b/tests/company-funded.test.mjs
@@ -285,6 +285,14 @@ try {
   const seenFetchOptions = [];
   globalThis.fetch = async (url, options) => {
     seenFetchOptions.push({ url, options });
+    if (seenFetchOptions.length === 1) {
+      const redirect = new Response('', {
+        status: 302,
+        headers: { location: 'https://techcrunch.com/final-feed/' },
+      });
+      Object.defineProperty(redirect, 'url', { value: String(url) });
+      return redirect;
+    }
     const res = new Response(`<?xml version="1.0"?><rss><channel>
         <item>
           <title>Acme raises $25M Series A</title>
@@ -306,8 +314,13 @@ try {
       months: 3,
       limit: 5,
     });
-    if (result.companies[0]?.company === 'Acme' && seenFetchOptions.every((call) => call.options?.redirect === 'follow')) {
-      pass('discoverFundedCompanies follows structured-source redirects after source validation');
+    if (
+      result.companies[0]?.company === 'Acme' &&
+      seenFetchOptions.every((call) => call.options?.redirect === 'manual') &&
+      String(seenFetchOptions[0]?.url) === 'https://techcrunch.com/feed/' &&
+      seenFetchOptions.some((call) => String(call.url) === 'https://techcrunch.com/final-feed/')
+    ) {
+      pass('discoverFundedCompanies follows structured-source redirects after validating each hop');
     } else {
       fail(`structured fetch behavior wrong: ${JSON.stringify({ result, seenFetchOptions })}`);
     }
@@ -316,11 +329,11 @@ try {
   }
 
   globalThis.fetch = async (url, options) => {
-    const res = new Response('not used', {
-      status: 200,
-      headers: { 'content-type': 'application/rss+xml' },
+    const res = new Response('', {
+      status: 302,
+      headers: { location: 'https://techcrunch.com.attacker.net/feed/' },
     });
-    Object.defineProperty(res, 'url', { value: 'https://techcrunch.com.attacker.net/feed/' });
+    Object.defineProperty(res, 'url', { value: String(url) });
     return res;
   };
   try {
@@ -341,14 +354,48 @@ try {
   }
 
   globalThis.fetch = async (url, options) => {
+    const res = new Response('', {
+      status: 302,
+      headers: { location: 'https://127.0.0.1/feed/' },
+    });
+    Object.defineProperty(res, 'url', { value: String(url) });
+    return res;
+  };
+  try {
+    const result = await mod.discoverFundedCompanies({
+      dryRun: true,
+      sources: ['techcrunch'],
+      months: 3,
+      limit: 5,
+    });
+    const diag = result.diagnostics.find((d) => d.source === 'techcrunch');
+    if (diag?.status === 'error' && diag.errors.some((err) => err.includes('internal redirect target rejected')) && result.companies.length === 0) {
+      pass('discoverFundedCompanies rejects redirects to internal targets before following');
+    } else {
+      fail(`internal redirect was accepted: ${JSON.stringify(result)}`);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  globalThis.fetch = async (url, options) => {
     const res = new Response(JSON.stringify({
-      hits: [{
-        title: 'Acme raises $25M Series A',
-        url: '',
-        objectID: '123',
-        created_at: '2026-07-19T12:00:00Z',
-        story_text: 'Acme raises funding.',
-      }],
+      hits: [
+        {
+          title: 'Acme raises $25M Series A',
+          url: '',
+          objectID: '123',
+          created_at: '2026-07-19T12:00:00Z',
+          story_text: 'Acme raises funding.',
+        },
+        {
+          title: 'Beta raises $30M Series B',
+          url: 'https://techcrunch.com/beta',
+          objectID: '124',
+          created_at: '2026-07-19T13:00:00Z',
+          story_text: 'Beta raises funding.',
+        },
+      ],
     }), {
       status: 200,
       headers: { 'content-type': 'application/json' },
@@ -363,16 +410,19 @@ try {
       months: 3,
       limit: 5,
     });
-    const candidate = result.companies[0];
-    const evidence = candidate?.funding.sources[0];
+    const acme = result.companies.find((c) => c.company === 'Acme');
+    const beta = result.companies.find((c) => c.company === 'Beta');
+    const acmeEvidence = acme?.funding.sources[0];
+    const betaEvidence = beta?.funding.sources[0];
     const diag = result.diagnostics.find((d) => d.source === 'hn');
     if (
-      candidate?.company === 'Acme' &&
-      evidence?.source === 'hacker_news' &&
-      evidence?.url === 'https://news.ycombinator.com/item?id=123' &&
-      diag?.candidate_count === 1
+      acmeEvidence?.source === 'hacker_news' &&
+      acmeEvidence?.url === 'https://news.ycombinator.com/item?id=123' &&
+      betaEvidence?.source === 'hacker_news' &&
+      betaEvidence?.url === 'https://techcrunch.com/beta' &&
+      diag?.candidate_count === 2
     ) {
-      pass('discoverFundedCompanies handles Hacker News JSON and falls back to trusted item URLs');
+      pass('discoverFundedCompanies handles Hacker News JSON with fallback and direct article URLs');
     } else {
       fail(`Hacker News discovery path regressed: ${JSON.stringify(result)}`);
     }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -172,6 +172,7 @@ const SYSTEM_PATHS = [
   'classify-tier.mjs',
   'scan-ats-full.mjs',
   'scan-interamt.mjs',
+  'company-funded.mjs',
   'match-star.mjs',
   'jd-skill-gap.mjs',
   'prepare-application.mjs',


### PR DESCRIPTION
## What does this PR do?

Adds a narrowed, review-first `company:funded` command for discovering recently funded companies from structured public sources only. The command defaults to a 3-month window, sorts by newest funding date, reports source diagnostics, and writes a candidate report/JSON for manual review.

This v1 intentionally does not scrape search-result HTML, probe company/careers websites, resolve ATS providers, or write/suggest `portals.yml` entries. Those surfaces are deferred until their scope and safety model are agreed in the issue.

## Related issue

Closes #2116

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt - send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ ] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Verification

Passed:

- `node tests/company-funded.test.mjs`
- `node company-funded.mjs --self-test`
- `node test-all.mjs --only company-funded`
- `git diff --check`
- `node company-funded.mjs --dry-run --limit 5 --sources techcrunch --json`
- `node company-funded.mjs --sources duckduckgo --dry-run` exits with `unknown source in --sources: duckduckgo`, confirming the removed search-scraping interface fails closed

Not fully passed locally:

- `node test-all.mjs --quick` still fails in unrelated existing areas: `tracker-columns-tests.mjs`, cover tests requiring `util.parseArgs`, and `cv-templates.mjs` / `cover-resolver` node:test suites. The `company-funded` checks pass in that run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `company:funded`, a review-first command to discover recently funded companies from public sources.
  - Generates a Markdown discovery report (with funding details, evidence, ranking, and source health diagnostics).
  - Includes configurable time window, sorting/limits, JSON output, dry-run mode, and an offline self-test.

- **Documentation**
  - Updated README “Features” and expanded command quick reference/usage in SCRIPTS.

- **Tests**
  - Added end-to-end coverage for parsing, filtering, source/redirect handling, blocked feeds, ranking, and report escaping.
  - Wired `company-funded.mjs --self-test` into the full test runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->