### PR TITLE
feat(latex-tex): support resumeItemWithoutTitle bullets and resumeSubItem skills

### DIFF
--- a/examples/latex-tex/resume-subheading-withouttitle.tex
+++ b/examples/latex-tex/resume-subheading-withouttitle.tex
@@ -1,0 +1,60 @@
+% Fictional example CV for latex-tex tests (resumeSubheading family,
+% \resumeItemWithoutTitle{}{...} bullet variant + \resumeSubItem skills).
+% The preamble macro definitions below intentionally contain \resumeItem{#1}{#2}
+% and \textbf{#1}{: #2} — regression guards: extraction must skip the preamble.
+\documentclass[letterpaper,10pt]{article}
+\usepackage{enumitem}
+\usepackage[hidelinks]{hyperref}
+\pdfgentounicode=1
+
+\newcommand{\resumeItem}[2]{
+  \item\small{
+    \textbf{#1}{: #2 \vspace{-2pt}}
+  }
+}
+\newcommand{\resumeItemWithoutTitle}[1]{
+  \item\small{
+    {#1 \vspace{-1pt}}
+  }
+}
+\newcommand{\resumeSubItem}[2]{\resumeItem{#1}{#2}\vspace{-4pt}}
+\newcommand{\resumeSubheading}[4]{%
+  \item
+  \textbf{#1} \hfill #2 \\
+  \textit{#3} \hfill \textit{#4}%
+}
+\newcommand{\resumeSubHeadingListStart}{\begin{itemize}[label={}, leftmargin=*]}
+\newcommand{\resumeSubHeadingListEnd}{\end{itemize}}
+\newcommand{\resumeItemListStart}{\begin{itemize}}
+\newcommand{\resumeItemListEnd}{\end{itemize}\vspace{-5pt}}
+
+\begin{document}
+
+\begin{center}
+  {\LARGE\bfseries Alex Example}\\[2pt]
+  \small alex@example.dev $|$ Example City, EX
+\end{center}
+
+\section{Skills}
+\resumeSubHeadingListStart
+  \resumeSubItem{Languages}{Python, Go, SQL}
+  \resumeSubItem{Tools}{Docker, PostgreSQL, Redis}
+\resumeSubHeadingListEnd
+
+\section{Experience}
+\resumeSubHeadingListStart
+  \resumeSubheading{Example Corp}{2022 -- Present}{Backend Engineer}{Remote}
+  \resumeItemListStart
+    \resumeItemWithoutTitle{}{Built REST APIs in Python serving 20k daily active users.}
+    % Old bullet kept for reference — commented calls must NOT become slots:
+    %\resumeItemWithoutTitle{}{Stale commented bullet that must never be extracted.}
+    \resumeItemWithoutTitle{}{Reduced batch job runtime by 35 percent with parallel workers.}
+  \resumeItemListEnd
+\resumeSubHeadingListEnd
+
+\section{Leadership}
+\resumeSubHeadingListStart
+  \resumeSubItem{President, Example Club}{Led a 10-person officer team and shipped two internal tools.}
+\resumeSubHeadingListEnd
+
+\end{document}

--- a/lib/latex-content.mjs
+++ b/lib/latex-content.mjs
@@ -44,7 +44,7 @@ export function findMatchingBrace(tex, openIdx) {
  */
 export function detectFamily(tex) {
   if (typeof tex !== 'string' || !tex.trim()) return null;
-  if (/\\resumeSubheading\b/.test(tex) && /\\resumeItem\b/.test(tex)) {
+  if (/\\resumeSubheading\b/.test(tex) && /\\(resumeItem|resumeItemWithoutTitle|resumeSubItem)\b/.test(tex)) {
     return 'resumeSubheading';
   }
   const hasTabularx = /\\usepackage\{[^}]*tabularx[^}]*\}/.test(tex) || /\\begin\{tabularx\}/.test(tex);
@@ -56,30 +56,132 @@ export function detectFamily(tex) {
 }
 
 /**
+ * Index where the document body starts, so extraction can skip macro
+ * definitions in the preamble (e.g. `\newcommand{\resumeSubItem}[2]{\resumeItem{#1}{#2}}`
+ * would otherwise be captured as a `#1` slot).
+ *
+ * @param {string} tex
+ * @returns {number}
+ */
+function bodyStart(tex) {
+  const docStart = tex.indexOf('\\begin{document}');
+  return docStart === -1 ? 0 : docStart;
+}
+
+/**
+ * True when `idx` sits on a line that is commented out at that position —
+ * i.e. an unescaped `%` appears earlier on the same line. Commented macro
+ * calls are inert LaTeX (often old bullets kept for reference) and must not
+ * become editable slots.
+ *
+ * @param {string} tex
+ * @param {number} idx
+ * @returns {boolean}
+ */
+function isCommentedAt(tex, idx) {
+  const lineStart = tex.lastIndexOf('\n', idx - 1) + 1;
+  for (let i = lineStart; i < idx; i++) {
+    if (tex[i] === '\\') {
+      i++; // skip escaped char (\% is a literal percent)
+      continue;
+    }
+    if (tex[i] === '%') return true;
+  }
+  return false;
+}
+
+/**
+ * Extract macro argument bodies as editable slots. Spans are absolute
+ * offsets into `tex`; scanning starts at the document body.
+ *
+ * `useNextGroupIfEmpty` handles the common `\resumeItemWithoutTitle{}{Text}`
+ * pattern (one-parameter macro called with an empty first group followed by a
+ * plain braced group): when the captured group is empty/whitespace, the slot
+ * points at the immediately following braced group instead.
+ *
  * @param {string} tex
  * @param {string} macroName
  * @param {string} kind
+ * @param {{useNextGroupIfEmpty?: boolean}} [opts]
  * @returns {Array<{id: string, kind: string, text: string, span: {start: number, end: number}}>}
  */
-function extractMacroBodies(tex, macroName, kind) {
+function extractMacroBodies(tex, macroName, kind, { useNextGroupIfEmpty = false } = {}) {
   const slots = [];
   const needle = `\\${macroName}{`;
-  let searchFrom = 0;
+  let searchFrom = bodyStart(tex);
   while (searchFrom < tex.length) {
     const idx = tex.indexOf(needle, searchFrom);
     if (idx === -1) break;
+    if (isCommentedAt(tex, idx)) {
+      searchFrom = idx + needle.length;
+      continue;
+    }
     const openBrace = idx + needle.length - 1;
     const closeBrace = findMatchingBrace(tex, openBrace);
     if (closeBrace === -1) break;
-    const innerStart = openBrace + 1;
-    const innerEnd = closeBrace;
+    let innerStart = openBrace + 1;
+    let innerEnd = closeBrace;
+    searchFrom = closeBrace + 1;
+
+    if (useNextGroupIfEmpty && !tex.slice(innerStart, innerEnd).trim()) {
+      let cursor = closeBrace + 1;
+      while (cursor < tex.length && /\s/.test(tex[cursor])) cursor++;
+      if (tex[cursor] !== '{') continue; // empty group with no follow-up group — nothing editable
+      const openNext = cursor;
+      const closeNext = findMatchingBrace(tex, openNext);
+      if (closeNext === -1) break;
+      innerStart = openNext + 1;
+      innerEnd = closeNext;
+      searchFrom = closeNext + 1;
+    }
+
     slots.push({
       id: `${kind}-${slots.length}`,
       kind,
       text: tex.slice(innerStart, innerEnd),
       span: { start: innerStart, end: innerEnd },
     });
-    searchFrom = closeBrace + 1;
+  }
+  return slots;
+}
+
+/**
+ * Extract the value argument of `\resumeSubItem{Category}{Items}` calls as
+ * skill slots. The category (first group) is left untouched; only the second
+ * group is editable.
+ *
+ * @param {string} tex
+ * @returns {Array<{kind: string, text: string, span: {start: number, end: number}}>}
+ */
+function extractSubItemValues(tex) {
+  const slots = [];
+  const needle = '\\resumeSubItem{';
+  let searchFrom = bodyStart(tex);
+  while (searchFrom < tex.length) {
+    const idx = tex.indexOf(needle, searchFrom);
+    if (idx === -1) break;
+    if (isCommentedAt(tex, idx)) {
+      searchFrom = idx + needle.length;
+      continue;
+    }
+    const openCat = idx + needle.length - 1;
+    const closeCat = findMatchingBrace(tex, openCat);
+    if (closeCat === -1) break;
+    searchFrom = closeCat + 1;
+
+    let cursor = closeCat + 1;
+    while (cursor < tex.length && /\s/.test(tex[cursor])) cursor++;
+    if (tex[cursor] !== '{') continue;
+    const openVal = cursor;
+    const closeVal = findMatchingBrace(tex, openVal);
+    if (closeVal === -1) break;
+
+    slots.push({
+      kind: 'skill',
+      text: tex.slice(openVal + 1, closeVal),
+      span: { start: openVal + 1, end: closeVal },
+    });
+    searchFrom = closeVal + 1;
   }
   return slots;
 }
@@ -90,10 +192,14 @@ function extractMacroBodies(tex, macroName, kind) {
  */
 function extractSkillValues(tex) {
   const slots = [];
-  let searchFrom = 0;
+  let searchFrom = bodyStart(tex);
   while (searchFrom < tex.length) {
     const idx = tex.indexOf('\\textbf{', searchFrom);
     if (idx === -1) break;
+    if (isCommentedAt(tex, idx)) {
+      searchFrom = idx + 8;
+      continue;
+    }
     const openCat = tex.indexOf('{', idx);
     const closeCat = findMatchingBrace(tex, openCat);
     if (closeCat === -1) break;
@@ -119,7 +225,6 @@ function extractSkillValues(tex) {
     const itemsStart = openVal + 1 + colon[0].length;
     const itemsText = tex.slice(itemsStart, closeVal);
     slots.push({
-      id: `skill-${slots.length}`,
       kind: 'skill',
       text: itemsText,
       span: { start: itemsStart, end: closeVal },
@@ -141,6 +246,7 @@ function extractItemizeItems(tex) {
   const itemRe = /\\item\b/g;
   let match;
   while ((match = itemRe.exec(body)) !== null) {
+    if (isCommentedAt(body, match.index)) continue;
     let i = match.index + match[0].length;
     while (i < body.length && /\s/.test(body[i])) i++;
 
@@ -178,10 +284,25 @@ function extractItemizeItems(tex) {
  */
 export function extractSlots(tex, family) {
   if (family === 'resumeSubheading') {
-    return [
+    const byPosition = (a, b) => a.span.start - b.span.start;
+    const dedupe = (list) => {
+      const seen = new Set();
+      return list.filter(s => {
+        const key = `${s.span.start}-${s.span.end}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+    };
+    const bullets = dedupe([
       ...extractMacroBodies(tex, 'resumeItem', 'bullet'),
+      ...extractMacroBodies(tex, 'resumeItemWithoutTitle', 'bullet', { useNextGroupIfEmpty: true }),
+    ].sort(byPosition)).map((s, i) => ({ ...s, id: `bullet-${i}` }));
+    const skills = dedupe([
       ...extractSkillValues(tex),
-    ];
+      ...extractSubItemValues(tex),
+    ].sort(byPosition)).map((s, i) => ({ ...s, id: `skill-${i}` }));
+    return [...bullets, ...skills];
   }
   if (family === 'tabularx-itemize') {
     return extractItemizeItems(tex);

--- a/modes/latex-tex.md
+++ b/modes/latex-tex.md
@@ -11,8 +11,10 @@ Opt-in mode for candidates who already maintain a hand-tuned `.tex` CV. **Does n
 
 | Family | Detection | Editable prose |
 |--------|-----------|----------------|
-| `resumeSubheading` | `\resumeSubheading` + `\resumeItem` | `\resumeItem{...}` bullets; `\textbf{Category}{: items}` skill values |
+| `resumeSubheading` | `\resumeSubheading` + `\resumeItem`/`\resumeItemWithoutTitle`/`\resumeSubItem` | `\resumeItem{...}` and `\resumeItemWithoutTitle{}{...}` bullets; `\textbf{Category}{: items}` and `\resumeSubItem{Category}{items}` skill values |
 | `tabularx-itemize` | `tabularx` + `itemize`, no resume macros | `\item` body text in the document body |
+
+Extraction only reads the document body (preamble macro definitions are skipped) and ignores commented-out macro calls — old bullets kept as `%` comments never become editable slots.
 
 Any other layout → stop with the script error and suggest `/career-ops latex` (cv.md → career-ops template).
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7039,6 +7039,60 @@ try {
     fail('resume-subheading manifest has no bullet slot to patch');
   }
 
+  // resumeItemWithoutTitle variant: `\resumeItemWithoutTitle{}{...}` bullets,
+  // `\resumeSubItem{Cat}{items}` skills, and preamble macro defs that must NOT
+  // leak into slots (the defs contain \resumeItem{#1}{#2} / \textbf{#1}{: #2}).
+  const withoutTitleFixture = readFileSync(join(ROOT, 'examples/latex-tex/resume-subheading-withouttitle.tex'), 'utf-8');
+
+  if (detectFamily(withoutTitleFixture) === 'resumeSubheading') {
+    pass('resumeItemWithoutTitle fixture detected as resumeSubheading family');
+  } else {
+    fail('resumeItemWithoutTitle fixture family detection failed');
+  }
+
+  const wtManifest = buildManifest('resume-subheading-withouttitle.tex', withoutTitleFixture);
+  const wtBullets = wtManifest.slots.filter(s => s.kind === 'bullet');
+  const wtSkills = wtManifest.slots.filter(s => s.kind === 'skill');
+  if (wtBullets.length === 2 && wtSkills.length === 3) {
+    pass('resumeItemWithoutTitle manifest extracts 2 bullets + 3 skill values');
+  } else {
+    fail(`resumeItemWithoutTitle slot mismatch (want 2 bullets/3 skills): ${JSON.stringify(wtManifest.slots.map(s => ({ id: s.id, text: s.text.slice(0, 40) })))}`);
+  }
+
+  if (wtManifest.slots.every(s => !s.text.includes('#1') && !s.text.includes('#2'))) {
+    pass('preamble macro definitions are not extracted as slots');
+  } else {
+    fail('extraction leaked preamble macro definitions (#1/#2) into slots');
+  }
+
+  if (wtManifest.slots.every(s => !s.text.includes('Stale commented bullet'))) {
+    pass('commented-out macro calls are not extracted as slots');
+  } else {
+    fail('extraction leaked a commented-out bullet into slots');
+  }
+
+  // Slot spans must point at the prose group: patching every slot with its own
+  // extracted text must reproduce the input byte-for-byte.
+  const wtRoundTrip = applyPatches(
+    withoutTitleFixture,
+    wtManifest.slots.map(s => ({ id: s.id, text: s.text })),
+    wtManifest.slots,
+    { escape: false },
+  );
+  if (wtRoundTrip === withoutTitleFixture) {
+    pass('no-op patch round-trip is byte-identical (spans point at prose groups)');
+  } else {
+    fail('no-op patch round-trip altered the document — slot spans are misaligned');
+  }
+
+  const wtBullet = wtBullets[0];
+  const wtPatched = applyPatches(withoutTitleFixture, [{ id: wtBullet.id, text: 'Tailored withouttitle bullet.' }], wtManifest.slots);
+  if (wtPatched.includes('\\resumeItemWithoutTitle{}{Tailored withouttitle bullet.}')) {
+    pass('applyPatches rewrites a resumeItemWithoutTitle bullet in place');
+  } else {
+    fail('applyPatches did not rewrite the resumeItemWithoutTitle prose group');
+  }
+
   const compileOnlyTex = `\\documentclass{article}\\begin{document}Minimal user CV\\end{document}`;
   const compileOnlyValidation = validateLatexContent(compileOnlyTex, true);
   if (compileOnlyValidation.issues.length === 0) {


### PR DESCRIPTION
## What

Extends the `resumeSubheading` extractor family in `lib/latex-content.mjs` to cover a widespread template variant (Jake's-resume derivatives) that writes bullets as `\resumeItemWithoutTitle{}{Text}` and skills as `\resumeSubItem{Category}{items}`. Previously these files were *detected* as supported but produced junk slots: the only matches were the macro definitions in the preamble (`#1`, `#2 \vspace{-2pt}`), so `latex-tex` mode had nothing real to tailor — and patching would have written into the preamble.

## Changes

- Extract `\resumeItemWithoutTitle` bullets, resolving the common empty-first-group calling pattern (`{}{Text}`) to the following prose group — slot `span` and `text` both point at the prose group, verified by a byte-identical no-op round-trip test
- Extract `\resumeSubItem{Cat}{items}` second arguments as skill slots
- Scan only the document body, so preamble `\newcommand` definitions no longer leak in as slots
- Skip commented-out macro calls — old bullets kept as `%` comments are inert LaTeX and must not become editable slots (they often contain stale facts, e.g. an outdated GPA)
- Merge bullet/skill slots in document order with stable ids, deduped by span
- `detectFamily` also accepts files using only the WithoutTitle/SubItem macros
- Docs: supported-layout table in `modes/latex-tex.md` updated

## Tests

New fixture `examples/latex-tex/resume-subheading-withouttitle.tex` (fictional content) whose preamble intentionally reproduces the false-positive patterns. Seven new checks in `test-all.mjs` §20b: family detection, slot counts, preamble exclusion, comment exclusion, byte-identical no-op patch round-trip, and in-place patching. Full suite: **2049 passed, 0 failed**.

Also verified end-to-end against a real-world resume of this shape: 12 live bullets + 4 skill values extracted, zero stale/commented leaks, no-op round-trip byte-identical, patched output compiles with pdflatex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional LaTeX resume formats, including untitled resume items and sub-items.
  - Improved editable content extraction for bullets, skills, and subheadings.

- **Bug Fixes**
  - Commented-out content and preamble definitions are no longer incorrectly treated as editable resume content.
  - Prevented duplicate extracted entries and preserved reliable slot ordering.

- **Documentation**
  - Updated supported-layout guidance to describe the expanded macro support and extraction behavior.

- **Tests**
  - Added coverage for detection, extraction, and applying edits to the new resume format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->