### PR TITLE
feat(stats): wire followup-cadence's cold classification into activeApps

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -137,10 +137,11 @@ export function addDays(date, days) {
 }
 
 // --- Parse applications.md ---
-function parseTracker() {
-  if (!existsSync(APPS_FILE)) return [];
-  const content = readFileSync(APPS_FILE, 'utf-8');
-  const lines = content.split('\n');
+// Content-based core so any consumer (stats.mjs, tests) can classify rows
+// from in-memory strings without touching disk. The disk-backed wrapper
+// below is what the CLI path uses.
+function parseTrackerContent(content) {
+  const lines = String(content ?? '').split('\n');
   const colmap = resolveColumns(lines);
   const entries = [];
   for (const line of lines) {
@@ -157,7 +158,7 @@ function parseTracker() {
 // check below and never enter `entries`.
 export function parseFollowups(content) {
   const entries = [];
-  for (const line of content.split('\n')) {
+  for (const line of String(content ?? '').split('\n')) {
     if (!line.startsWith('|')) continue;
     const parts = line.split('|').map(s => s.trim());
     if (parts.length < 8) continue;
@@ -175,11 +176,6 @@ export function parseFollowups(content) {
     });
   }
   return entries;
-}
-
-function readFollowups() {
-  if (!existsSync(FOLLOWUPS_FILE)) return [];
-  return parseFollowups(readFileSync(FOLLOWUPS_FILE, 'utf-8'));
 }
 
 // --- Next-date overrides (pins) ---
@@ -211,11 +207,6 @@ export function resolveNextOverride(override, lastFollowupDate) {
   if (!override) return null;
   if (lastFollowupDate && lastFollowupDate > override.setDate) return null;
   return override.date;
-}
-
-function parseOverrides() {
-  if (!existsSync(FOLLOWUPS_FILE)) return new Map();
-  return parseNextOverrides(readFileSync(FOLLOWUPS_FILE, 'utf-8'));
 }
 
 // --- Extract contacts from notes ---
@@ -288,14 +279,22 @@ export function computeNextFollowupDate(status, appDate, lastFollowupDate, follo
 }
 
 // --- Main analysis ---
-function analyze() {
-  const apps = parseTracker();
+// Content-based core so consumers outside this CLI (stats.mjs, tests) can
+// reuse the exact same cadence/urgency math — including the 'cold'
+// classification — without duplicating it or touching disk. `followupsContent`
+// missing/empty (the common case when data/follow-ups.md doesn't exist yet)
+// degrades gracefully: every app gets followupCount 0, so 'cold' (which
+// requires followupCount >= applied_max_followups) simply never triggers —
+// no error, no guessing, matching the same "absent optional file = pass
+// through" convention used elsewhere in this project.
+export function analyzeFromContent(trackerContent, followupsContent = '') {
+  const apps = parseTrackerContent(trackerContent);
   if (apps.length === 0) {
     return { error: 'No applications found in tracker.' };
   }
 
-  const followups = readFollowups();
-  const overrides = parseOverrides();
+  const followups = parseFollowups(followupsContent);
+  const overrides = parseNextOverrides(String(followupsContent ?? ''));
 
   // Group follow-ups by app number
   const followupsByApp = new Map();
@@ -396,6 +395,13 @@ function analyze() {
     entries: filtered,
     cadenceConfig: CADENCE,
   };
+}
+
+// --- Main analysis (disk-backed CLI entry point) ---
+function analyze() {
+  const trackerContent = existsSync(APPS_FILE) ? readFileSync(APPS_FILE, 'utf-8') : '';
+  const followupsContent = existsSync(FOLLOWUPS_FILE) ? readFileSync(FOLLOWUPS_FILE, 'utf-8') : '';
+  return analyzeFromContent(trackerContent, followupsContent);
 }
 
 // --- Summary mode ---

--- a/followup-cadence.test.mjs
+++ b/followup-cadence.test.mjs
@@ -13,6 +13,7 @@ import {
   parseDate,
   DEFAULT_CADENCE,
   parseFollowups,
+  analyzeFromContent,
 } from './followup-cadence.mjs';
 
 let passed = 0;
@@ -123,6 +124,45 @@ eq(
   'parseFollowups returns empty array for empty content',
   parseFollowups(''),
   [],
+);
+
+// analyzeFromContent (#2123): the content-based core exported so stats.mjs
+// can reuse the exact same cadence math for its own cold-classification
+// wiring, instead of re-deriving applied_max_followups/cadence rules there.
+const trackerMd = [
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|------|---------|------|-------|--------|-----|--------|-------|',
+  '| 1 | 2026-05-01 | Acme | Eng | 4.5/5 | Applied | ✅ | ❌ | note |',
+  '| 2 | 2026-05-01 | Beta | Eng | 4.0/5 | Applied | ✅ | ❌ | note |',
+].join('\n');
+const followupsMd = [
+  '| # | App | Date | Company | Role | Channel | Contact | Notes |',
+  '|---|-----|------|---------|------|---------|---------|-------|',
+  '| 1 | 1 | 2026-05-10 | Acme | Eng | email | jane | f1 |',
+  '| 2 | 1 | 2026-05-20 | Acme | Eng | email | jane | f2 |',
+].join('\n');
+
+const withFollowups = analyzeFromContent(trackerMd, followupsMd);
+eq(
+  'analyzeFromContent classifies app #1 cold after applied_max_followups follow-ups, app #2 stays actionable',
+  withFollowups.entries.filter((e) => e.urgency === 'cold').map((e) => e.num),
+  [1],
+);
+
+// Missing/empty follow-ups content must degrade gracefully — no follow-up
+// log means followupCount stays 0 for every row, so nothing can reach the
+// 'cold' threshold. No error, no guessing.
+const noFollowups = analyzeFromContent(trackerMd, '');
+eq(
+  'analyzeFromContent with no follow-ups content classifies nothing as cold',
+  noFollowups.entries.some((e) => e.urgency === 'cold'),
+  false,
+);
+const missingFollowupsArg = analyzeFromContent(trackerMd);
+eq(
+  'analyzeFromContent defaults followupsContent to empty string when omitted',
+  missingFollowupsArg.entries.some((e) => e.urgency === 'cold'),
+  false,
 );
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/stats.mjs
+++ b/stats.mjs
@@ -23,7 +23,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import yaml from 'js-yaml';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
-import { normalizeStatus } from './followup-cadence.mjs';
+import { normalizeStatus, analyzeFromContent } from './followup-cadence.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = join(ROOT, 'data', 'applications.md');
@@ -111,6 +111,29 @@ export function trackerStatusByNum(content) {
     if (row) byNum.set(row.num, canonicalStatus(row.status));
   }
   return byNum;
+}
+
+/**
+ * Tracker numbers that followup-cadence.mjs's own cadence math already
+ * classifies 'cold' (Applied, zero response after applied_max_followups
+ * follow-ups). Reuses `analyzeFromContent` — the same function
+ * followup-cadence.mjs's CLI runs — instead of re-deriving the
+ * applied_max_followups/cadence rule here (#2123). A row can only be
+ * classified cold when its status is 'applied', so every number returned
+ * here is already a subset of ACTIVE_STATUSES.
+ *
+ * Missing follow-ups content (`null`/absent file, the common case) degrades
+ * gracefully: analyzeFromContent treats it as zero logged follow-ups for
+ * every row, so nothing can cross the follow-up-count threshold and this
+ * returns an empty set — never an error, never a guess.
+ *
+ * @param {string} trackerContent - Raw applications.md text.
+ * @param {string|null} followupsContent - Raw follow-ups.md text, or null when absent.
+ */
+export function computeColdAppNums(trackerContent, followupsContent) {
+  const result = analyzeFromContent(trackerContent, followupsContent || '');
+  if (result.error) return new Set();
+  return new Set(result.entries.filter((e) => e.urgency === 'cold').map((e) => e.num));
 }
 
 // ── Cumulative funnel ───────────────────────────────────────────────
@@ -397,8 +420,33 @@ export function computeAllStats({
   const portals = read(portalsFile);
   const runs = read(scanRunsFile);
   const portalHealth = read(portalHealthFile);
-  const tracker = apps ? computeTrackerStats(apps) : null;
+  const trackerBase = apps ? computeTrackerStats(apps) : null;
   const scan = scanHist ? computeScanStats(scanHist) : null;
+
+  // Cold-classification wiring (#2123): activeApps is purely status-based and
+  // stays untouched for backward compatibility. activeAppsLive subtracts rows
+  // followup-cadence.mjs's own cadence math independently classifies 'cold'
+  // (Applied, zero response after applied_max_followups follow-ups) — the more
+  // honest "still worth expecting a reply from" figure. No follow-up data
+  // (`fups` null) means no cold rows can be identified, so activeAppsLive
+  // simply equals activeApps.
+  let tracker = trackerBase;
+  if (trackerBase) {
+    const coldNums = computeColdAppNums(apps, fups);
+    let activeAppsCold = 0;
+    if (coldNums.size > 0) {
+      const byNum = trackerStatusByNum(apps);
+      for (const [num, status] of byNum) {
+        if (ACTIVE_STATUSES.has(status) && coldNums.has(num)) activeAppsCold++;
+      }
+    }
+    tracker = {
+      ...trackerBase,
+      activeAppsLive: trackerBase.activeApps - activeAppsCold,
+      activeAppsCold,
+    };
+  }
+
   return {
     metadata: {
       generatedAt: new Date().toISOString().slice(0, 10),
@@ -431,7 +479,11 @@ function printSummary(stats) {
     const fit = t.avgScore != null
       ? ` | avg fit ${t.avgScore}/5${t.avgScoreApplied != null ? ` (pursued roles ${t.avgScoreApplied}/5)` : ''} | top ${t.topScore}`
       : '';
-    console.log(`Tracker:    ${t.total} total | ${t.activeApps} active${fit}`);
+    // Only break out live/cold when there's a cold row to report — with no
+    // follow-up data (or genuinely zero cold rows) the plain count is exactly
+    // as accurate and the parenthetical would be noise.
+    const liveInfo = t.activeAppsCold > 0 ? ` (${t.activeAppsLive} live, ${t.activeAppsCold} cold)` : '';
+    console.log(`Tracker:    ${t.total} total | ${t.activeApps} active${liveInfo}${fit}`);
     const statusLine = Object.entries(t.byStatus).filter(([, c]) => c > 0).map(([s, c]) => `${s} ${c}`).join(' · ');
     if (statusLine) console.log(`Status:     ${statusLine}`);
   } else {

--- a/tests/stats.test.mjs
+++ b/tests/stats.test.mjs
@@ -2,6 +2,8 @@
 import { pass, fail, run, NODE, ROOT } from './helpers.mjs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 
 console.log('\nstats.mjs — lifetime pipeline stats aggregator (#1604)');
 try {
@@ -112,6 +114,82 @@ try {
     fail(`computePortalStats wrong output: ${JSON.stringify(p)}`);
   }
 
+  // Cold-classification wiring (#2123): activeApps stays purely status-based
+  // (backward compatible for existing consumers); activeAppsLive subtracts
+  // rows followup-cadence.mjs's own cadence math independently flags 'cold'
+  // (Applied, zero response after applied_max_followups follow-ups).
+  const coldTrackerMd = [
+    '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+    '|---|------|---------|------|-------|--------|-----|--------|-------|',
+    '| 1 | 2026-05-01 | Acme | Eng | 4.5/5 | Applied | ✅ | ❌ | note |',
+    '| 2 | 2026-05-01 | Beta | Eng | 4.0/5 | Applied | ✅ | ❌ | note |',
+    '| 3 | 2026-05-01 | Gama | Eng | 3.9/5 | Interview | ✅ | ❌ | note |',
+  ].join('\n');
+  const coldFollowupsMd = [
+    '| # | App | Date | Company | Role | Channel | Contact | Notes |',
+    '|---|-----|------|---------|------|---------|---------|-------|',
+    '| 1 | 1 | 2026-05-10 | Acme | Eng | email | jane | f1 |',
+    '| 2 | 1 | 2026-05-20 | Acme | Eng | email | jane | f2 |',
+  ].join('\n');
+  const coldNums = stats.computeColdAppNums(coldTrackerMd, coldFollowupsMd);
+  if (coldNums.size === 1 && coldNums.has(1)) {
+    pass('computeColdAppNums reuses followup-cadence.mjs cadence math to flag app #1 cold');
+  } else {
+    fail(`computeColdAppNums wrong output: ${JSON.stringify([...coldNums])}`);
+  }
+
+  const allStatsWithCold = stats.computeAllStats({
+    appsFile: '__missing_apps__.md',
+    scanHistoryFile: '__missing_scan__.tsv',
+    followupsFile: '__missing_fups__.md',
+    scanRunsFile: '__missing_runs__.tsv',
+    portalsFile: '__missing_portals__.yml',
+    portalHealthFile: '__missing_health__.tsv',
+  });
+  if (allStatsWithCold.tracker === null) {
+    pass('computeAllStats tolerates a fully missing data set (tracker null, no crash)');
+  } else {
+    fail(`computeAllStats should return tracker null on missing files: ${JSON.stringify(allStatsWithCold.tracker)}`);
+  }
+
+  // computeAllStats reading from real content via tmp files: a tracker with
+  // one independently cold-classified row must lower activeAppsLive below
+  // activeApps while leaving activeApps itself untouched.
+  const coldTmp = mkdtempSync(join(tmpdir(), 'stats-cold-'));
+  const coldAppsFile = join(coldTmp, 'applications.md');
+  const coldFupsFile = join(coldTmp, 'follow-ups.md');
+  writeFileSync(coldAppsFile, coldTrackerMd);
+  writeFileSync(coldFupsFile, coldFollowupsMd);
+  const allCold = stats.computeAllStats({
+    appsFile: coldAppsFile,
+    scanHistoryFile: '__missing_scan__.tsv',
+    followupsFile: coldFupsFile,
+    scanRunsFile: '__missing_runs__.tsv',
+    portalsFile: '__missing_portals__.yml',
+    portalHealthFile: '__missing_health__.tsv',
+  });
+  if (allCold.tracker.activeApps === 3 && allCold.tracker.activeAppsLive === 2 && allCold.tracker.activeAppsCold === 1) {
+    pass('computeAllStats: activeApps unchanged (3), activeAppsLive correctly excludes the 1 cold row (2)');
+  } else {
+    fail(`computeAllStats cold wiring wrong: ${JSON.stringify(allCold.tracker)}`);
+  }
+
+  // Graceful degradation: no follow-ups.md at all → activeAppsLive === activeApps exactly.
+  const allNoFups = stats.computeAllStats({
+    appsFile: coldAppsFile,
+    scanHistoryFile: '__missing_scan__.tsv',
+    followupsFile: '__missing_fups__.md',
+    scanRunsFile: '__missing_runs__.tsv',
+    portalsFile: '__missing_portals__.yml',
+    portalHealthFile: '__missing_health__.tsv',
+  });
+  if (allNoFups.tracker.activeApps === 3 && allNoFups.tracker.activeAppsLive === 3 && allNoFups.tracker.activeAppsCold === 0) {
+    pass('computeAllStats: missing follow-ups.md degrades gracefully, activeAppsLive === activeApps');
+  } else {
+    fail(`computeAllStats missing-followups degradation wrong: ${JSON.stringify(allNoFups.tracker)}`);
+  }
+  rmSync(coldTmp, { recursive: true, force: true });
+
   // Follow-up compliance.
   const followupsMd = [
     '# Follow-ups',
@@ -145,6 +223,32 @@ try {
     pass('stats.mjs --summary renders the human table');
   } else {
     fail('stats.mjs --summary missing header');
+  }
+
+  // --summary cold-classification integration (#2123): the CLI reads its
+  // fixed data/ paths, so exercise it against real (temporary) tracker +
+  // follow-ups files at those exact paths, then restore whatever was there.
+  const liveAppsFile = join(ROOT, 'data', 'applications.md');
+  const liveFupsFile = join(ROOT, 'data', 'follow-ups.md');
+  const { existsSync, readFileSync: readFileSyncNode, mkdirSync } = await import('fs');
+  const dataDirExisted = existsSync(join(ROOT, 'data'));
+  const appsExisted = existsSync(liveAppsFile);
+  const fupsExisted = existsSync(liveFupsFile);
+  const appsBackup = appsExisted ? readFileSyncNode(liveAppsFile, 'utf-8') : null;
+  const fupsBackup = fupsExisted ? readFileSyncNode(liveFupsFile, 'utf-8') : null;
+  try {
+    if (!dataDirExisted) mkdirSync(join(ROOT, 'data'), { recursive: true });
+    writeFileSync(liveAppsFile, coldTrackerMd);
+    writeFileSync(liveFupsFile, coldFollowupsMd);
+    const coldSummaryOut = run(NODE, [join(ROOT, 'stats.mjs'), '--summary']);
+    if (coldSummaryOut && coldSummaryOut.includes('3 active (2 live, 1 cold)')) {
+      pass('stats.mjs --summary integrates live/cold counts into the existing Tracker line');
+    } else {
+      fail(`stats.mjs --summary missing live/cold breakdown: ${coldSummaryOut}`);
+    }
+  } finally {
+    if (appsBackup !== null) writeFileSync(liveAppsFile, appsBackup); else if (!appsExisted) rmSync(liveAppsFile, { force: true });
+    if (fupsBackup !== null) writeFileSync(liveFupsFile, fupsBackup); else if (!fupsExisted) rmSync(liveFupsFile, { force: true });
   }
 } catch (e) {
   fail(`stats.mjs tests crashed: ${e.message}`);


### PR DESCRIPTION
## Problem

\`followup-cadence.mjs\` already classifies an \`Applied\`-status tracker row as \`cold\` once the candidate has sent the maximum number of follow-ups (\`applied_max_followups\`, default 2) with zero response. \`stats.mjs\`'s headline \`activeApps\` count (reported as "N active" in \`--summary\` and JSON) is purely status-based and has no awareness of this — so a row that's functionally dead by the tool's own existing logic still counts as active. At scale (heavy users with 1,000+ tracked applications) this meaningfully overstates the pipeline.

## Solution

Pure integration — no new classification logic:

1. **\`followup-cadence.mjs\`**: split the existing disk-reading \`analyze()\` into a content-based core, exported as \`analyzeFromContent(trackerContent, followupsContent = '')\`, plus a thin disk-reading wrapper that keeps the CLI's behavior byte-identical. This is the same function the CLI already runs — reused, not duplicated, and the cadence rule (\`applied_max_followups\`, the 7-day math, pin overrides, etc.) is untouched.
2. **\`stats.mjs\`**: adds \`computeColdAppNums(trackerContent, followupsContent)\`, which calls \`analyzeFromContent\` and returns the set of tracker numbers currently classified \`cold\`. \`computeAllStats()\` now reports:
   - \`activeApps\` — unchanged, status-based, backward compatible for existing consumers.
   - \`activeAppsLive\` — \`activeApps\` minus rows independently classified \`cold\`.
   - \`activeAppsCold\` — the delta, for convenience.
3. \`--summary\` folds the breakdown into the existing \`Tracker:\` line rather than adding a new one, e.g. \`Tracker: 3 total | 3 active (2 live, 1 cold)\`. The parenthetical only appears when there's an actual cold row to report, so the common case (no follow-up data, or genuinely zero cold rows) stays exactly as it reads today.
4. **Graceful degradation**: a missing \`data/follow-ups.md\` (common — many users don't have one yet) means every row's follow-up count is 0, so nothing can cross the cold threshold; \`activeAppsLive\` simply equals \`activeApps\`. No error, no guessing — mirrors the same "absent optional file = pass-through" convention already used elsewhere (e.g. \`location_filter\`, \`scan.mjs\`'s blacklist handling).

\`stats.mjs\` remains fully read-only.

## Tests

- \`followup-cadence.test.mjs\`: \`analyzeFromContent\` classifies a row cold after \`applied_max_followups\` follow-ups; missing/empty follow-ups content classifies nothing as cold.
- \`tests/stats.test.mjs\`: \`computeColdAppNums\` reuses the cadence math correctly; \`computeAllStats\` reports \`activeAppsLive\`/\`activeAppsCold\` correctly against a tracker with one cold row; missing \`follow-ups.md\` degrades \`activeAppsLive\` to equal \`activeApps\`; \`--summary\` CLI output includes the live/cold breakdown in the expected format.
- Full suite: \`node test-all.mjs\` — 2049 passed, 0 failed (2 pre-existing, unrelated warnings).

Closes #2123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live vs cold breakdown to tracker statistics, including `activeAppsLive` and `activeAppsCold`.
  * Added content-based cadence analysis (`analyzeFromContent`) and cold-app identification to power the breakdown.
* **Bug Fixes**
  * Improved resilience when tracker or follow-up content is missing, including safer parsing of optional follow-up content.
  * Updated summary display to show “active (live, cold)” only when cold apps are present.
* **Tests**
  * Expanded cadence and stats tests with fixtures and CLI coverage for cold classification and graceful degradation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->