### PR TITLE
feat(interview/debrief): correct contradicted facts in the prep file in place

### DIFF
--- a/modes/interview/debrief.md
+++ b/modes/interview/debrief.md
@@ -22,7 +22,7 @@ After a real interview, capture what was asked, assess what landed and what didn
 6. **Story bank** at `interview-prep/story-bank.md` — add new stories if surfaced
 7. **CV** at `cv.md` + `article-digest.md` (if present) — to ground suggested answers in real experience
 8. **Retracted claims** at `interview-prep/retracted-claims.md` (if present) — hard gate; never use a retracted claim in a suggested answer even if the candidate said it in the interview
-9. **Role-specific prep file** — append debrief notes
+9. **Role-specific prep file** — append debrief notes; correct in place any existing fact the interview directly contradicts (see Step 1b)
 
 ---
 
@@ -54,6 +54,27 @@ If memory is incomplete, ask targeted prompts:
 Set the explicit source marker: **`input_source: recall`**.
 
 Whichever path produced the question/answer data, Steps 2 onward operate on it identically — honest assessment, gap-closing, and question-bank/story-bank updates don't distinguish between an `input_source: transcript` and an `input_source: recall` debrief. The marker itself is still carried through unchanged so Step 9 can read it.
+
+---
+
+## Step 1b — Check for Contradicted Facts
+
+While capturing what was said, also check it against the role-specific prep file's existing factual claims — this runs alongside Step 1, not after it.
+
+**The distinction that matters:** most of what an interview surfaces is *new information* — a new gap, a new story, a new detail that wasn't in the prep file before. That's append-only, and Steps 4/5/8 below handle it exactly as they always have. But sometimes what the interview surfaces isn't new — it's a **direct contradiction of a specific fact the prep file already asserts** (location, comp range, team size, reporting structure, tech/system stack, etc.). That's not a gap to close or a story to add; it's an existing claim that is now known to be wrong.
+
+- **"This is new information" → appends.** Use the existing Step 4 / Step 5 / Step 8 flows unchanged.
+- **"This directly contradicts something the prep file already asserts as fact" → correct in place.** Edit the original line in the role-specific prep file itself, rather than leaving the wrong claim untouched and only noting the discrepancy in a new section below it.
+
+When correcting in place, use a strikethrough-plus-correction format so the history of what was believed vs. confirmed stays visible in the diff:
+
+```markdown
+~~Metro Hall, on-site~~ **Metro Hall — hybrid** (confirmed on the {date} call)
+```
+
+**Resolve inference tags on contradiction or confirmation.** If the original line carried an inference marker — `[inferred from JD]`, or prose noting the source was an expired/inaccessible posting — and the interview either confirms or corrects it, resolve the tag rather than leaving a now-settled fact permanently marked as uncertain: replace the marker with the confirmed fact and its real source (the interview/call itself), using the same strikethrough-plus-correction shape when the value changed, or a plain edit to drop the marker and cite the new source when the value was merely confirmed as-is.
+
+This step never touches `interview-prep/retracted-claims.md` or the story bank — those stay reserved for the candidate's own claims, not for facts about the role. It also never rewrites Step 4's "Gaps to Close" additions; a contradicted fact is corrected at its original location, not logged as a gap.
 
 ---
 
@@ -217,3 +238,4 @@ Rules for the transcript:
 - **Extract vocabulary gaps explicitly.** If the candidate used an imprecise term where a precise one exists, add it to `interview-prep/interview-prep-guide.md` under the vocabulary section (if the candidate maintains one).
 - **One gap = one fix.** Don't overwhelm with a full study plan for every gap. Prioritize the 1–2 most likely to be tested in the next round.
 - **Celebrate what worked.** Debrief isn't only about gaps. Name what was strong — it reinforces the right behaviour and builds confidence for the next round.
+- **Contradicted facts get corrected in place, not appended around.** If the interview directly contradicts a specific fact the prep file already states (location, comp, team size, stack, reporting line), edit that line — strikethrough the old value, bold the confirmed one, note when/how it was confirmed (see Step 1b). Don't leave a wrong claim standing untouched with a caveat bolted on below it.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10952,28 +10952,43 @@ try {
     fail('interview/debrief missing a dedicated contradicted-facts step');
   }
 
+  // Scoped regex: both bullets must appear, in order, within the same
+  // decision-list paragraph — not just "appends" and "correct in place"
+  // occurring anywhere independently in the file.
   if (
-    debriefMode.includes('corrects in place') ||
-    (debriefMode.includes('correct in place') && debriefMode.includes('appends'))
+    /"This is new information"\s*→\s*appends\.[\s\S]{0,200}"This directly contradicts something the prep file already asserts as fact"\s*→\s*correct in place\./.test(
+      debriefMode
+    )
   ) {
     pass('interview/debrief distinguishes new-information-appends from contradiction-corrects-in-place');
   } else {
     fail('interview/debrief missing the append-vs-correct distinction');
   }
 
+  // Scoped regex: the strikethrough, the bolded correction, and the
+  // confirmation-date parenthetical must all appear together on the same
+  // example line — not merely present somewhere in the file independently.
   if (
-    debriefMode.includes('~~Metro Hall, on-site~~') &&
-    debriefMode.includes('**Metro Hall — hybrid**')
+    /~~Metro Hall, on-site~~\s+\*\*Metro Hall — hybrid\*\*\s*\(confirmed on the \{date\} call\)/.test(
+      debriefMode
+    )
   ) {
-    pass('interview/debrief includes a concrete strikethrough-plus-correction example');
+    pass('interview/debrief includes a concrete strikethrough-plus-correction example with the confirmation detail');
   } else {
-    fail('interview/debrief missing the strikethrough-plus-correction example format');
+    fail('interview/debrief missing the strikethrough-plus-correction example format with its confirmation detail');
   }
 
-  if (debriefMode.includes('[inferred from JD]') && debriefMode.includes('resolve')) {
+  // Scoped regex: the resolve-inference-tags instruction, the literal tag,
+  // and the actual resolution behavior must appear tied together in the
+  // same instruction — not as three unrelated substrings anywhere in the file.
+  if (
+    /\*\*Resolve inference tags on contradiction or confirmation\.\*\*[\s\S]{0,200}`\[inferred from JD\]`[\s\S]{0,400}resolve the tag/.test(
+      debriefMode
+    )
+  ) {
     pass('interview/debrief instructs resolving inference tags once confirmed or corrected');
   } else {
-    fail('interview/debrief missing the inference-tag resolution instruction');
+    fail('interview/debrief missing the inference-tag resolution instruction tied to its own guidance');
   }
 } catch (e) {
   fail(`contradicted-facts correction check: ${e.message}`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10933,6 +10933,52 @@ try {
   fail(`transcript-input debrief check: ${e.message}`);
 }
 
+// ── CONTRADICTED-FACTS CORRECTION (#2125) ────────────────────────
+// interview/debrief was append-only against the role-specific prep file —
+// no path existed for correcting an existing fact the interview directly
+// contradicts (as opposed to appending a new gap/story/retraction). This
+// section pins that the mode now documents an in-place correction step,
+// the strikethrough-plus-correction example format, and inference-tag
+// resolution, without touching the pre-existing append-only steps.
+
+console.log('\n64. Contradicted-facts correction step (#2125)');
+
+try {
+  const debriefMode = readFile('modes/interview/debrief.md');
+
+  if (debriefMode.includes('Check for Contradicted Facts')) {
+    pass('interview/debrief has a dedicated contradicted-facts step');
+  } else {
+    fail('interview/debrief missing a dedicated contradicted-facts step');
+  }
+
+  if (
+    debriefMode.includes('corrects in place') ||
+    (debriefMode.includes('correct in place') && debriefMode.includes('appends'))
+  ) {
+    pass('interview/debrief distinguishes new-information-appends from contradiction-corrects-in-place');
+  } else {
+    fail('interview/debrief missing the append-vs-correct distinction');
+  }
+
+  if (
+    debriefMode.includes('~~Metro Hall, on-site~~') &&
+    debriefMode.includes('**Metro Hall — hybrid**')
+  ) {
+    pass('interview/debrief includes a concrete strikethrough-plus-correction example');
+  } else {
+    fail('interview/debrief missing the strikethrough-plus-correction example format');
+  }
+
+  if (debriefMode.includes('[inferred from JD]') && debriefMode.includes('resolve')) {
+    pass('interview/debrief instructs resolving inference tags once confirmed or corrected');
+  } else {
+    fail('interview/debrief missing the inference-tag resolution instruction');
+  }
+} catch (e) {
+  fail(`contradicted-facts correction check: ${e.message}`);
+}
+
 await runDiscovered();
 
 finish();


### PR DESCRIPTION
## Problem

`modes/interview/debrief.md` is append-only against the role-specific prep file — its own Inputs section says "append debrief notes." Every concrete instruction in the mode follows that shape: add a "Gaps to Close Before Round N" section, add stories to `interview-prep/story-bank.md`, log retractions to `interview-prep/retracted-claims.md`. Nothing handles the case where a live interview reveals that a **specific fact already stated in the prep file is simply wrong** — not a new gap, a correction to something already asserted (location, comp range, team size, reporting structure, tech/system stack).

Concrete example: a prep file's header said a role was "Metro Hall, on-site" (inferred from an expired posting, tagged as such). The actual recruiter call revealed it's hybrid. The correct fix was editing that header line in place, not appending a new note under an unchanged, now-wrong claim.

## Solution

Adds a new **Step 1b — Check for Contradicted Facts** to `modes/interview/debrief.md`, running alongside Step 1's capture phase:

- Flags when the interview directly contradicts a specific existing fact in the role-specific prep file (as opposed to surfacing new information, which still appends via the existing Steps 4/5/8, unchanged).
- Instructs correcting the original line in place with a strikethrough-plus-correction format:
  ```
  ~~Metro Hall, on-site~~ **Metro Hall — hybrid** (confirmed on the {date} call)
  ```
- Instructs resolving any inference tag (`[inferred from JD]`, or prose noting an expired/inaccessible source) once the interview confirms or corrects it — replacing the marker with the confirmed fact and its real source, rather than leaving a settled fact permanently marked uncertain.

The Inputs section (item 9) and the Rules section both get a one-line pointer to this new step for reinforcement. No existing step's behavior changes — this is additive only.

Added `test-all.mjs` section 63 (following the same mode-doc pinning convention as section 62's stated-comp wiring check) asserting: the new step exists, the append-vs-correct distinction is documented, the strikethrough-correction example format is present verbatim, and the inference-tag resolution instruction is present.

`node test-all.mjs`: 2048 passed, 0 failed, 2 pre-existing warnings (unrelated to this change).

## Coordination note

Overlaps file-wise with #2122 (also touches `modes/interview/debrief.md`, different section — that PR adds a transcript-input path to Step 1/Step 9, this PR adds a fact-correction step elsewhere in the mode). No content conflict expected; a mechanical rebase may be needed on whichever of the two merges second.

Closes #2125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the interview debrief workflow with a new **Contradicted Facts** sub-step to correct existing role prep-file claims when interviews directly contradict them.
  * Added clear guidance to distinguish **new information (append)** from **contradictions (correct in place)**.
  * Documented the required in-place correction format and added instructions for resolving inference tags after contradiction/confirmation.
  * Clarified boundaries to avoid touching retracted-claims, and not updating the story bank or rewriting gap additions.

* **Tests**
  * Added an end-of-suite check to enforce the contradicted-facts workflow requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->