### PR TITLE
feat(interview-prep): detect call platform (phone/Zoom/Teams/Meet) from invite text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `generate-latex.mjs` | LaTeX CV validator + pdflatex compiler |
 | `scan.mjs` | Zero-token portal scanner (Greenhouse/Ashby/Lever APIs, zero LLM cost) |
 | `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner over full public ATS datasets (Greenhouse/Lever/Ashby/Workday/iCIMS), filtered by portals.yml `title_filter`/`location_filter` — no company list needed; checkpoints every 500 companies, `--resume` continues an interrupted sweep |
+| `scan-interamt.mjs` | Playwright browser scanner for Interamt.de (German public sector portal — Apache Wicket, no REST API) |
 | `check-liveness.mjs` / `liveness-core.mjs` | Job posting liveness checker + shared logic (expired signals win over generic Apply text) |
 | `set-status.mjs` | Canonical tracker-row update: `node set-status.mjs <report#\|company> <State> [--note] [--force]` — strict states.yml validation, report-link mismatch guard, shared lock, atomic write |
 | `invite-match.mjs` | Fuzzy-match a pasted interview invite (company, date, req ID) against the tracker, ranking candidates when a company has multiple entries (JSON or `--summary`) |

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -250,17 +250,24 @@ export function extractReqId(text) {
 //
 // Each pattern requires a proper URL/host boundary, not just a substring
 // match: an optional scheme + single subdomain label ahead of the host, a
-// non-word/@/./- character (or start-of-string) before that, and a path/
-// query/fragment/whitespace delimiter (or end-of-string) after the host.
-// This rejects lookalike hosts (`notzoom.us`, `teams.microsoft.com.evil.
+// real host-boundary character (or start-of-string) before that, and a
+// path/query/fragment/whitespace delimiter (or end-of-string) after the
+// host. This rejects lookalike hosts (`notzoom.us`, `teams.microsoft.com.evil.
 // example`) and email addresses (`support@zoom.us`) that merely contain the
 // host string as a substring — "silence stays silence" per this file's
 // extractDate/extractReqId convention, so a lookalike is never reported as
 // a real meeting platform.
+//
+// The prefix boundary also excludes URL-structure characters (`/ ? = & #`)
+// so a platform host is only recognized at the true start of a URL
+// authority, not when it's actually a path segment or query value on a
+// *different* host: `https://example.com/zoom.us` (path segment) and
+// `https://example.com?next=zoom.us` (query value) must NOT match, since
+// `zoom.us` is not the URL's actual host in either case.
 const PLATFORM_URL_PATTERNS = [
-  { name: 'Zoom', pattern: /(?:^|[^\w@.-])(?:https?:\/\/)?(?:[\w-]+\.)?zoom\.us(?:[/?#\s]|$)/i },
-  { name: 'Microsoft Teams', pattern: /(?:^|[^\w@.-])(?:https?:\/\/)?(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com(?:[/?#\s]|$)/i },
-  { name: 'Google Meet', pattern: /(?:^|[^\w@.-])(?:https?:\/\/)?(?:[\w-]+\.)?meet\.google\.com(?:[/?#\s]|$)/i },
+  { name: 'Zoom', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?zoom\.us(?:[/?#\s]|$)/i },
+  { name: 'Microsoft Teams', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com(?:[/?#\s]|$)/i },
+  { name: 'Google Meet', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?meet\.google\.com(?:[/?#\s]|$)/i },
 ];
 
 // A plain phone number, used only when no meeting-platform URL was found —
@@ -465,6 +472,12 @@ function runSelfTest() {
   check(extractPlatform('Please visit https://notzoom.us for details.') === null, 'does not report Zoom for a lookalike host (notzoom.us)');
   check(extractPlatform('Contact support@zoom.us with questions.') === null, 'does not report Zoom for an email address containing zoom.us');
   check(extractPlatform('See https://teams.microsoft.com.evil.example for the link.') === null, 'does not report Microsoft Teams for a lookalike domain (teams.microsoft.com.evil.example)');
+  check(extractPlatform('See https://example.com/zoom.us for details.') === null, 'does not detect Zoom as a URL path segment on an unrelated host');
+  check(extractPlatform('See https://example.com?next=zoom.us for details.') === null, 'does not detect Zoom as a URL query value on an unrelated host');
+  check(extractPlatform('See https://example.com/teams.microsoft.com for details.') === null, 'does not detect Microsoft Teams as a URL path segment on an unrelated host');
+  check(extractPlatform('See https://example.com?next=teams.microsoft.com for details.') === null, 'does not detect Microsoft Teams as a URL query value on an unrelated host');
+  check(extractPlatform('See https://example.com/meet.google.com for details.') === null, 'does not detect Google Meet as a URL path segment on an unrelated host');
+  check(extractPlatform('See https://example.com?next=meet.google.com for details.') === null, 'does not detect Google Meet as a URL query value on an unrelated host');
 
   // --- matchInvite (fixture rows, no real tracker data) ---
   const fixtureRows = [

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -247,10 +247,20 @@ export function extractReqId(text) {
 // A meeting-platform URL is unambiguous, so these are checked in a fixed
 // order and the first hit wins — no scoring needed, unlike company-name
 // matching where several candidates can plausibly overlap.
+//
+// Each pattern requires a proper URL/host boundary, not just a substring
+// match: an optional scheme + single subdomain label ahead of the host, a
+// non-word/@/./- character (or start-of-string) before that, and a path/
+// query/fragment/whitespace delimiter (or end-of-string) after the host.
+// This rejects lookalike hosts (`notzoom.us`, `teams.microsoft.com.evil.
+// example`) and email addresses (`support@zoom.us`) that merely contain the
+// host string as a substring — "silence stays silence" per this file's
+// extractDate/extractReqId convention, so a lookalike is never reported as
+// a real meeting platform.
 const PLATFORM_URL_PATTERNS = [
-  { name: 'Zoom', pattern: /zoom\.us/i },
-  { name: 'Microsoft Teams', pattern: /teams\.(?:microsoft|live)\.com/i },
-  { name: 'Google Meet', pattern: /meet\.google\.com/i },
+  { name: 'Zoom', pattern: /(?:^|[^\w@.-])(?:https?:\/\/)?(?:[\w-]+\.)?zoom\.us(?:[/?#\s]|$)/i },
+  { name: 'Microsoft Teams', pattern: /(?:^|[^\w@.-])(?:https?:\/\/)?(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com(?:[/?#\s]|$)/i },
+  { name: 'Google Meet', pattern: /(?:^|[^\w@.-])(?:https?:\/\/)?(?:[\w-]+\.)?meet\.google\.com(?:[/?#\s]|$)/i },
 ];
 
 // A plain phone number, used only when no meeting-platform URL was found —
@@ -452,6 +462,9 @@ function runSelfTest() {
   check(extractPlatform('We will call you at (416) 555-0199 for the screen.') === 'Phone', 'detects a phone call from a phone-number pattern with no meeting URL');
   check(extractPlatform('Please confirm your availability for the interview.') === null, 'returns null when no platform or phone signal is present');
   check(extractPlatform('') === null, 'returns null for empty text');
+  check(extractPlatform('Please visit https://notzoom.us for details.') === null, 'does not report Zoom for a lookalike host (notzoom.us)');
+  check(extractPlatform('Contact support@zoom.us with questions.') === null, 'does not report Zoom for an email address containing zoom.us');
+  check(extractPlatform('See https://teams.microsoft.com.evil.example for the link.') === null, 'does not report Microsoft Teams for a lookalike domain (teams.microsoft.com.evil.example)');
 
   // --- matchInvite (fixture rows, no real tracker data) ---
   const fixtureRows = [

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -264,10 +264,15 @@ export function extractReqId(text) {
 // *different* host: `https://example.com/zoom.us` (path segment) and
 // `https://example.com?next=zoom.us` (query value) must NOT match, since
 // `zoom.us` is not the URL's actual host in either case.
+//
+// An optional explicit port (`:443`, `:8443`, etc.) is permitted between
+// the host and the following delimiter, since a URL authority may legally
+// include one (`https://zoom.us:443/j/123456789`) and rejecting it would
+// silently drop otherwise-legitimate invite links.
 const PLATFORM_URL_PATTERNS = [
-  { name: 'Zoom', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?zoom\.us(?:[/?#\s]|$)/i },
-  { name: 'Microsoft Teams', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com(?:[/?#\s]|$)/i },
-  { name: 'Google Meet', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?meet\.google\.com(?:[/?#\s]|$)/i },
+  { name: 'Zoom', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?zoom\.us(?::\d{1,5})?(?:[/?#\s]|$)/i },
+  { name: 'Microsoft Teams', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com(?::\d{1,5})?(?:[/?#\s]|$)/i },
+  { name: 'Google Meet', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?meet\.google\.com(?::\d{1,5})?(?:[/?#\s]|$)/i },
 ];
 
 // A plain phone number, used only when no meeting-platform URL was found —
@@ -478,6 +483,9 @@ function runSelfTest() {
   check(extractPlatform('See https://example.com?next=teams.microsoft.com for details.') === null, 'does not detect Microsoft Teams as a URL query value on an unrelated host');
   check(extractPlatform('See https://example.com/meet.google.com for details.') === null, 'does not detect Google Meet as a URL path segment on an unrelated host');
   check(extractPlatform('See https://example.com?next=meet.google.com for details.') === null, 'does not detect Google Meet as a URL query value on an unrelated host');
+  check(extractPlatform('Join via Zoom: https://zoom.us:443/j/123456789') === 'Zoom', 'detects Zoom from a zoom.us URL with an explicit port');
+  check(extractPlatform('Join Microsoft Teams Meeting: https://teams.microsoft.com:8443/l/meetup-join/xyz') === 'Microsoft Teams', 'detects Microsoft Teams from a teams.microsoft.com URL with an explicit port');
+  check(extractPlatform('Google Meet: https://meet.google.com:443/abc-defg-hij') === 'Google Meet', 'detects Google Meet from a meet.google.com URL with an explicit port');
 
   // --- matchInvite (fixture rows, no real tracker data) ---
   const fixtureRows = [

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -7,12 +7,13 @@
  * title or req number. Finding which `data/applications.md` row an invite
  * belongs to otherwise means a manual grep every time.
  *
- * This script extracts a company name (and, if present, a date and a
- * req/job-ID-looking token) from pasted invite text, fuzzy-matches it
- * against the tracker's Company column, and ranks candidates when the same
- * company has multiple applications — which is common. A silent wrong guess
- * is worse than showing a short ranked list, so ambiguous input always
- * returns all plausible candidates rather than picking one.
+ * This script extracts a company name (and, if present, a date, a
+ * req/job-ID-looking token, and a call platform/medium) from pasted invite
+ * text, fuzzy-matches it against the tracker's Company column, and ranks
+ * candidates when the same company has multiple applications — which is
+ * common. A silent wrong guess is worse than showing a short ranked list,
+ * so ambiguous input always returns all plausible candidates rather than
+ * picking one.
  *
  * Run: node invite-match.mjs < invite.txt          (JSON to stdout)
  *      node invite-match.mjs --file invite.txt
@@ -243,6 +244,45 @@ export function extractReqId(text) {
   return m ? m[1] : null;
 }
 
+// A meeting-platform URL is unambiguous, so these are checked in a fixed
+// order and the first hit wins — no scoring needed, unlike company-name
+// matching where several candidates can plausibly overlap.
+const PLATFORM_URL_PATTERNS = [
+  { name: 'Zoom', pattern: /zoom\.us/i },
+  { name: 'Microsoft Teams', pattern: /teams\.(?:microsoft|live)\.com/i },
+  { name: 'Google Meet', pattern: /meet\.google\.com/i },
+];
+
+// A plain phone number, used only when no meeting-platform URL was found —
+// deliberately simple (not a full E.164/i18n validator), since this is a
+// "does this look like a call-in number" heuristic, not a phone-format
+// validator. Requires a separator between digit groups so it doesn't fire
+// on unrelated long digit runs (req IDs, zip+4, order numbers, etc.).
+const PHONE_PATTERN = /(?:\+?\d{1,3}[\s.-])?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}\b/;
+
+/**
+ * Best-effort extraction of the call platform/medium from raw invite or
+ * scheduling text — distinct from the round *type* (recruiter screen vs.
+ * onsite, etc.), this is specifically about whether the candidate will be
+ * on a video call and which one, or on a plain phone call. A meeting-
+ * platform URL is checked first (Zoom / Microsoft Teams / Google Meet); if
+ * none is present, falls back to a phone-number pattern. Returns null when
+ * nothing plausible is found — never guessed, consistent with this
+ * project's "silence stays silence" convention (see extractDate/extractReqId
+ * above and the title/location filters in scan.mjs).
+ *
+ * @param {string} text - Raw pasted invite/scheduling text.
+ * @returns {'Zoom'|'Microsoft Teams'|'Google Meet'|'Phone'|null}
+ */
+export function extractPlatform(text) {
+  if (!text) return null;
+  for (const { name, pattern } of PLATFORM_URL_PATTERNS) {
+    if (pattern.test(text)) return name;
+  }
+  if (PHONE_PATTERN.test(text)) return 'Phone';
+  return null;
+}
+
 // --- Tracker loading ---
 function loadTracker(appsFile = APPS_FILE) {
   if (!existsSync(appsFile)) return [];
@@ -324,6 +364,7 @@ export function analyzeInvite(text, trackerRows = null) {
     company: extractCompany(text),
     date: extractDate(text),
     reqId: extractReqId(text),
+    platform: extractPlatform(text),
   };
   const rows = trackerRows ?? loadTracker();
   const candidates = matchInvite(signals, rows);
@@ -336,9 +377,10 @@ function printSummary(result) {
   console.log('  Interview Invite Matcher — career-ops');
   console.log(`${'='.repeat(70)}\n`);
 
-  console.log(`  Extracted company: ${result.signals.company || '(not found)'}`);
-  console.log(`  Extracted date:    ${result.signals.date || '(not found)'}`);
-  console.log(`  Extracted req ID:  ${result.signals.reqId || '(not found)'}\n`);
+  console.log(`  Extracted company:  ${result.signals.company || '(not found)'}`);
+  console.log(`  Extracted date:     ${result.signals.date || '(not found)'}`);
+  console.log(`  Extracted req ID:   ${result.signals.reqId || '(not found)'}`);
+  console.log(`  Extracted platform: ${result.signals.platform || '(not found)'}\n`);
 
   if (!result.signals.company) {
     console.log('  Could not find a company name in the invite text — paste more context or check manually.\n');
@@ -402,6 +444,15 @@ function runSelfTest() {
   check(extractReqId('Job ID: 43683') === '43683', 'extracts "Job ID:" token');
   check(extractReqId('no id here') === null, 'returns null when no req-like token is present');
 
+  // --- extractPlatform ---
+  check(extractPlatform('Join via Zoom: https://us02web.zoom.us/j/1234567890') === 'Zoom', 'detects Zoom from a zoom.us URL');
+  check(extractPlatform('Join Microsoft Teams Meeting: https://teams.microsoft.com/l/meetup-join/xyz') === 'Microsoft Teams', 'detects Microsoft Teams from a teams.microsoft.com URL');
+  check(extractPlatform('Meeting link: https://teams.live.com/meet/abc') === 'Microsoft Teams', 'detects Microsoft Teams from a teams.live.com URL');
+  check(extractPlatform('Google Meet: https://meet.google.com/abc-defg-hij') === 'Google Meet', 'detects Google Meet from a meet.google.com URL');
+  check(extractPlatform('We will call you at (416) 555-0199 for the screen.') === 'Phone', 'detects a phone call from a phone-number pattern with no meeting URL');
+  check(extractPlatform('Please confirm your availability for the interview.') === null, 'returns null when no platform or phone signal is present');
+  check(extractPlatform('') === null, 'returns null for empty text');
+
   // --- matchInvite (fixture rows, no real tracker data) ---
   const fixtureRows = [
     { num: 101, company: 'Example Industries', role: 'Training Coordinator', status: 'Applied', date: '2026-06-01', notes: 'Req EX9001' },
@@ -427,10 +478,11 @@ function runSelfTest() {
   check(noMatch.length === 0, 'unrelated company name returns no candidates');
 
   // --- analyzeInvite (end-to-end with injected rows, no file I/O) ---
-  const fullText = 'Schedule Your Phone Screen – Acme Opportunity\nInterview scheduled for 2026-07-09.';
+  const fullText = 'Schedule Your Phone Screen – Acme Opportunity\nInterview scheduled for 2026-07-09.\nJoin via Zoom: https://zoom.us/j/1234567890';
   const result = analyzeInvite(fullText, fixtureRows);
   check(result.signals.company === 'Acme', 'analyzeInvite extracts company end-to-end');
   check(result.signals.date === '2026-07-09', 'analyzeInvite extracts date end-to-end');
+  check(result.signals.platform === 'Zoom', 'analyzeInvite extracts platform end-to-end');
   check(result.candidates.length === 1 && result.candidates[0].appNumber === 103, 'analyzeInvite returns the matched candidate end-to-end');
 
   console.log(`\n  invite-match self-test: ${pass} passed, ${fail} failed\n`);

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -98,6 +98,11 @@ eq('Meet URL detected as Google Meet', extractPlatform('https://meet.google.com/
 eq('phone number with no meeting URL detected as Phone', extractPlatform('We will call you at 416-555-0199 for the screen.'), 'Phone');
 eq('meeting URL outranks a phone-number fallback line in the same text', extractPlatform('Zoom: https://zoom.us/j/1234567890\nDial-in: 416-555-0199'), 'Zoom');
 eq('no platform or phone signal returns null', extractPlatform('Please confirm your availability for the interview.'), null);
+// Lookalike hosts / email addresses must never be reported as a real
+// meeting platform — "silence stays silence" (issue #2128 review finding).
+eq('lookalike host (notzoom.us) is not detected as Zoom', extractPlatform('Please visit https://notzoom.us for details.'), null);
+eq('email address containing zoom.us is not detected as Zoom', extractPlatform('Contact support@zoom.us with questions.'), null);
+eq('lookalike domain (teams.microsoft.com.evil.example) is not detected as Microsoft Teams', extractPlatform('See https://teams.microsoft.com.evil.example for the link.'), null);
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) {

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -112,6 +112,11 @@ eq('does not detect a platform-looking URL path (Microsoft Teams)', extractPlatf
 eq('does not detect a platform-looking query value (Microsoft Teams)', extractPlatform('See https://example.com?next=teams.microsoft.com for details.'), null);
 eq('does not detect a platform-looking URL path (Google Meet)', extractPlatform('See https://example.com/meet.google.com for details.'), null);
 eq('does not detect a platform-looking query value (Google Meet)', extractPlatform('See https://example.com?next=meet.google.com for details.'), null);
+// An explicit port in the URL authority must not block detection (issue
+// #2128 review finding).
+eq('Zoom URL with explicit port detected as Zoom', extractPlatform('Join: https://zoom.us:443/j/123456789'), 'Zoom');
+eq('Microsoft Teams URL with explicit port detected as Microsoft Teams', extractPlatform('https://teams.microsoft.com:8443/l/meetup-join/abc'), 'Microsoft Teams');
+eq('Google Meet URL with explicit port detected as Google Meet', extractPlatform('https://meet.google.com:443/xyz-abcd-efg'), 'Google Meet');
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) {

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -6,7 +6,7 @@
  * Run: node invite-match.test.mjs
  */
 
-import { matchInvite, normalizeCompanyName } from './invite-match.mjs';
+import { matchInvite, normalizeCompanyName, extractPlatform } from './invite-match.mjs';
 
 let passed = 0;
 let failed = 0;
@@ -86,6 +86,18 @@ eq(
   normalizeCompanyName('Northwind Solutions Group') === normalizeCompanyName('Northwind Technologies Holdings'),
   false
 );
+
+// extractPlatform — deterministic call-platform detection (issue #2126).
+// A meeting-platform URL always wins over a phone-number pattern that might
+// also be present in the same text (e.g. a dial-in fallback line under a
+// Zoom link) — the video link is the actual call medium in that case.
+eq('Zoom URL detected as Zoom', extractPlatform('Join: https://us05web.zoom.us/j/9998887777'), 'Zoom');
+eq('Teams (microsoft.com) URL detected as Microsoft Teams', extractPlatform('https://teams.microsoft.com/l/meetup-join/abc'), 'Microsoft Teams');
+eq('Teams (live.com) URL detected as Microsoft Teams', extractPlatform('https://teams.live.com/meet/abc'), 'Microsoft Teams');
+eq('Meet URL detected as Google Meet', extractPlatform('https://meet.google.com/xyz-abcd-efg'), 'Google Meet');
+eq('phone number with no meeting URL detected as Phone', extractPlatform('We will call you at 416-555-0199 for the screen.'), 'Phone');
+eq('meeting URL outranks a phone-number fallback line in the same text', extractPlatform('Zoom: https://zoom.us/j/1234567890\nDial-in: 416-555-0199'), 'Zoom');
+eq('no platform or phone signal returns null', extractPlatform('Please confirm your availability for the interview.'), null);
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) {

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -103,6 +103,15 @@ eq('no platform or phone signal returns null', extractPlatform('Please confirm y
 eq('lookalike host (notzoom.us) is not detected as Zoom', extractPlatform('Please visit https://notzoom.us for details.'), null);
 eq('email address containing zoom.us is not detected as Zoom', extractPlatform('Contact support@zoom.us with questions.'), null);
 eq('lookalike domain (teams.microsoft.com.evil.example) is not detected as Microsoft Teams', extractPlatform('See https://teams.microsoft.com.evil.example for the link.'), null);
+// A platform-looking host must only be recognized at a true URL authority
+// boundary — not as a path segment or query value on an unrelated host
+// (issue #2128 review finding).
+eq('does not detect a platform-looking URL path (Zoom)', extractPlatform('See https://example.com/zoom.us for details.'), null);
+eq('does not detect a platform-looking query value (Zoom)', extractPlatform('See https://example.com?next=zoom.us for details.'), null);
+eq('does not detect a platform-looking URL path (Microsoft Teams)', extractPlatform('See https://example.com/teams.microsoft.com for details.'), null);
+eq('does not detect a platform-looking query value (Microsoft Teams)', extractPlatform('See https://example.com?next=teams.microsoft.com for details.'), null);
+eq('does not detect a platform-looking URL path (Google Meet)', extractPlatform('See https://example.com/meet.google.com for details.'), null);
+eq('does not detect a platform-looking query value (Google Meet)', extractPlatform('See https://example.com?next=meet.google.com for details.'), null);
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) {

--- a/modes/interview-prep.md
+++ b/modes/interview-prep.md
@@ -108,6 +108,7 @@ If the company is small or obscure and yields few results, broaden: search for t
 ## Process Overview
 - **Rounds:** {N} rounds, ~{X} days end-to-end
 - **Format:** {e.g., recruiter screen → technical phone → take-home → onsite (4 rounds) → hiring manager}
+- **Platform:** {e.g., Zoom / Microsoft Teams / Google Meet / Phone — the call medium, distinct from Format above. Extract from invite/scheduling text using the same platform-detection approach `invite-match.mjs`'s `extractPlatform` uses (meeting-platform URL first, phone-number pattern as fallback). If not detectable, write "not stated in the invite, confirm before the call" rather than guessing}
 - **Difficulty:** {X}/5 (Glassdoor avg, N reviews)
 - **Positive experience rate:** {X}%
 - **Known quirks:** {e.g., "pair programming instead of whiteboard", "no LeetCode, all practical", "take-home is 4 hours"}
@@ -155,6 +156,7 @@ For each round discovered in research:
 ### Round {N}: {Type} — audience: `{audience}`
 - **Duration:** {X} min
 - **Conducted by:** {peer / manager / skip-level / recruiter — if known}
+- **Platform:** {Zoom / Microsoft Teams / Google Meet / Phone for this specific round — extract from that round's invite/scheduling text the same way as Step 2's Platform field above. If not stated in the invite, write "not stated in the invite, confirm before the call"}
 - **What they evaluate:** {specific skills or traits}
 - **Reported questions:**
   - {question} — [source: Glassdoor (URL/date)]
@@ -163,6 +165,8 @@ For each round discovered in research:
 ```
 
 If round structure is unknown, state that and provide the best available intel on what types of rounds to expect based on company size, stage, and role level.
+
+When a round's Platform is known, add one logistics line to "How to prepare": for a video platform (Zoom / Microsoft Teams / Google Meet), a reminder to check camera, lighting, and background in advance; for Phone, a reminder to confirm a quiet space and good signal. Skip this line when Platform is not stated.
 
 ## Step 4 — Likely Questions (per audience)
 

--- a/modes/interview-prep.md
+++ b/modes/interview-prep.md
@@ -108,7 +108,7 @@ If the company is small or obscure and yields few results, broaden: search for t
 ## Process Overview
 - **Rounds:** {N} rounds, ~{X} days end-to-end
 - **Format:** {e.g., recruiter screen → technical phone → take-home → onsite (4 rounds) → hiring manager}
-- **Platform:** {e.g., Zoom / Microsoft Teams / Google Meet / Phone — the call medium, distinct from Format above. Extract from invite/scheduling text using the same platform-detection approach `invite-match.mjs`'s `extractPlatform` uses (meeting-platform URL first, phone-number pattern as fallback). If not detectable, write "not stated in the invite, confirm before the call" rather than guessing}
+- **Platform:** {e.g., Zoom / Microsoft Teams / Google Meet / Phone — the call medium, distinct from Format above. Extract from invite/scheduling text using the same platform-detection approach `invite-match.mjs`'s `extractPlatform` uses (meeting-platform URL first, phone-number pattern as fallback). If not detectable, write "not stated in the invite, confirm before the call" rather than guessing; this field-specific fallback overrides the generic unknown rule below}
 - **Difficulty:** {X}/5 (Glassdoor avg, N reviews)
 - **Positive experience rate:** {X}%
 - **Known quirks:** {e.g., "pair programming instead of whiteboard", "no LeetCode, all practical", "take-home is 4 hours"}

--- a/modes/interview/debrief.md
+++ b/modes/interview/debrief.md
@@ -22,7 +22,7 @@ After a real interview, capture what was asked, assess what landed and what didn
 6. **Story bank** at `interview-prep/story-bank.md` — add new stories if surfaced
 7. **CV** at `cv.md` + `article-digest.md` (if present) — to ground suggested answers in real experience
 8. **Retracted claims** at `interview-prep/retracted-claims.md` (if present) — hard gate; never use a retracted claim in a suggested answer even if the candidate said it in the interview
-9. **Role-specific prep file** — append debrief notes
+9. **Role-specific prep file** — append debrief notes; correct in place any existing fact the interview directly contradicts (see Step 1b)
 
 ---
 
@@ -54,6 +54,27 @@ If memory is incomplete, ask targeted prompts:
 Set the explicit source marker: **`input_source: recall`**.
 
 Whichever path produced the question/answer data, Steps 2 onward operate on it identically — honest assessment, gap-closing, and question-bank/story-bank updates don't distinguish between an `input_source: transcript` and an `input_source: recall` debrief. The marker itself is still carried through unchanged so Step 9 can read it.
+
+---
+
+## Step 1b — Check for Contradicted Facts
+
+While capturing what was said, also check it against the role-specific prep file's existing factual claims — this runs alongside Step 1, not after it.
+
+**The distinction that matters:** most of what an interview surfaces is *new information* — a new gap, a new story, a new detail that wasn't in the prep file before. That's append-only, and Steps 4/5/8 below handle it exactly as they always have. But sometimes what the interview surfaces isn't new — it's a **direct contradiction of a specific fact the prep file already asserts** (location, comp range, team size, reporting structure, tech/system stack, etc.). That's not a gap to close or a story to add; it's an existing claim that is now known to be wrong.
+
+- **"This is new information" → appends.** Use the existing Step 4 / Step 5 / Step 8 flows unchanged.
+- **"This directly contradicts something the prep file already asserts as fact" → correct in place.** Edit the original line in the role-specific prep file itself, rather than leaving the wrong claim untouched and only noting the discrepancy in a new section below it.
+
+When correcting in place, use a strikethrough-plus-correction format so the history of what was believed vs. confirmed stays visible in the diff:
+
+```markdown
+~~Metro Hall, on-site~~ **Metro Hall — hybrid** (confirmed on the {date} call)
+```
+
+**Resolve inference tags on contradiction or confirmation.** If the original line carried an inference marker — `[inferred from JD]`, or prose noting the source was an expired/inaccessible posting — and the interview either confirms or corrects it, resolve the tag rather than leaving a now-settled fact permanently marked as uncertain: replace the marker with the confirmed fact and its real source (the interview/call itself), using the same strikethrough-plus-correction shape when the value changed, or a plain edit to drop the marker and cite the new source when the value was merely confirmed as-is.
+
+This step never touches `interview-prep/retracted-claims.md` or the story bank — those stay reserved for the candidate's own claims, not for facts about the role. It also never rewrites Step 4's "Gaps to Close" additions; a contradicted fact is corrected at its original location, not logged as a gap.
 
 ---
 
@@ -217,3 +238,4 @@ Rules for the transcript:
 - **Extract vocabulary gaps explicitly.** If the candidate used an imprecise term where a precise one exists, add it to `interview-prep/interview-prep-guide.md` under the vocabulary section (if the candidate maintains one).
 - **One gap = one fix.** Don't overwhelm with a full study plan for every gap. Prioritize the 1–2 most likely to be tested in the next round.
 - **Celebrate what worked.** Debrief isn't only about gaps. Name what was strong — it reinforces the right behaviour and builds confidence for the next round.
+- **Contradicted facts get corrected in place, not appended around.** If the interview directly contradicts a specific fact the prep file already states (location, comp, team size, stack, reporting line), edit that line — strikethrough the old value, bold the confirmed one, note when/how it was confirmed (see Step 1b). Don't leave a wrong claim standing untouched with a caveat bolted on below it.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "scan:full": "node scan-ats-full.mjs",
     "scan:seeds": "node scan-ats-full.mjs --seeds yc,a16z",
     "scan:yc": "node scan-ats-full.mjs --seeds yc",
+    "scan:interamt": "node scan-interamt.mjs",
     "validate:portals": "node validate-portals.mjs",
     "verify:portals": "node verify-portals.mjs",
     "tracker": "node tracker.mjs",

--- a/scan-interamt.mjs
+++ b/scan-interamt.mjs
@@ -1,0 +1,366 @@
+#!/usr/bin/env node
+
+/**
+ * scan-interamt.mjs — Interamt.de scanner via Playwright
+ *
+ * Interamt uses Apache Wicket (stateful Java framework) — no REST API exists.
+ * Playwright maintains a browser session so the wicket-crypt token and cookies
+ * are handled transparently.
+ *
+ * Reads `interamt_searches` from portals.yml. Falls back to a generic set of
+ * German IT keywords if the section is absent.
+ *
+ * Usage:
+ *   node scan-interamt.mjs
+ *   node scan-interamt.mjs --dry-run
+ *   node scan-interamt.mjs --all            # skip date filter (use for first scan)
+ *   node scan-interamt.mjs --keyword "Softwareentwickler"
+ */
+
+import { chromium } from 'playwright';
+import { readFileSync, existsSync, mkdirSync } from 'fs';
+import yaml from 'js-yaml';
+import { appendToPipeline, appendToScanHistory, loadSeenUrls } from './scan.mjs';
+
+// ── Config ───────────────────────────────────────────────────────────
+
+const PORTALS_PATH    = 'portals.yml';
+const SCAN_HISTORY    = 'data/scan-history.tsv';
+const INTERAMT_HOME   = 'https://interamt.de/koop/app/';
+// Direct offer URL — constructed from StellenangebotId.
+// Wicket adds a session version number (?28&id=...) during live navigation,
+// but the bookmarkable form (?id=...) works without a session.
+// If a specific offer fails to load from pipeline, open Interamt manually
+// and navigate to it — Wicket will assign a valid version for that session.
+const OFFER_BASE_URL  = 'https://interamt.de/koop/app/stelle?id=';
+
+// Generic fallback — configure interamt_searches in portals.yml for your target roles
+const DEFAULT_KEYWORDS = [
+  'Informatiker',
+  'Softwareentwickler',
+  'IT-Spezialist',
+  'Datenwissenschaftler',
+  'Systemadministrator',
+  'Datenanalyst',
+];
+
+// ── Args ─────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const DRY_RUN    = args.includes('--dry-run');
+const DEBUG      = args.includes('--debug');
+const NO_DATE_FILTER = args.includes('--all');
+const kwIdx = args.indexOf('--keyword');
+if (kwIdx !== -1 && (args[kwIdx + 1] === undefined || args[kwIdx + 1].startsWith('--'))) {
+  console.error('Error: --keyword requires a value, e.g. --keyword "Softwareentwickler"');
+  process.exit(1);
+}
+const SINGLE_KEYWORD = kwIdx !== -1 ? args[kwIdx + 1] : null;
+
+// ── Load portals.yml ─────────────────────────────────────────────────
+
+let config = {};
+if (existsSync(PORTALS_PATH)) {
+  config = yaml.load(readFileSync(PORTALS_PATH, 'utf-8')) || {};
+}
+
+const interamtSearches = config.interamt_searches || DEFAULT_KEYWORDS.map(k => ({ was: k }));
+const keywords = SINGLE_KEYWORD
+  ? [SINGLE_KEYWORD]
+  : interamtSearches.map(s => s.was).filter(Boolean);
+
+// ── Filters ──────────────────────────────────────────────────────────
+
+const titleFilter = config.title_filter || {};
+const positiveKw = (titleFilter.positive || []).map(k => k.toLowerCase());
+const negativeKw = (titleFilter.negative || []).map(k => k.toLowerCase());
+
+function matchesTitle(title) {
+  const lower = title.toLowerCase();
+  if (negativeKw.some(k => lower.includes(k))) return false;
+  if (positiveKw.length === 0) return true;
+  return positiveKw.some(k => lower.includes(k));
+}
+
+const locFilter = config.location_filter || {};
+const locAllow = (locFilter.allow || []).map(k => k.toLowerCase());
+const locBlock = (locFilter.block || []).map(k => k.toLowerCase());
+
+function matchesLocation(loc) {
+  if (!loc) return true;
+  const lower = loc.toLowerCase();
+  if (locBlock.some(k => lower.includes(k))) return false;
+  if (locAllow.length === 0) return true;
+  return locAllow.some(k => lower.includes(k));
+}
+
+// ── Date helpers ─────────────────────────────────────────────────────
+
+// Parse Interamt date format DD.MM.YYYY → Date (midnight UTC)
+function parseDE(str) {
+  if (!str) return null;
+  const [d, m, y] = str.trim().split('.');
+  if (!d || !m || !y) return null;
+  return new Date(`${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}T00:00:00Z`);
+}
+
+// Returns the most recent first_seen date for 'interamt' portal entries, or null
+function loadLastScanDate() {
+  if (!existsSync(SCAN_HISTORY)) return null;
+  let latest = null;
+  readFileSync(SCAN_HISTORY, 'utf-8').split('\n').slice(1).forEach(line => {
+    const parts = line.split('\t');
+    if (parts[2] !== 'interamt') return;
+    const d = new Date((parts[1] || '') + 'T00:00:00Z');
+    if (!isNaN(d) && (!latest || d > latest)) latest = d;
+  });
+  return latest;
+}
+
+// ── Stable selectors (Wicket name attributes don't change between sessions) ──
+
+const SEL_EDIT_BTN    = 'a.ia-e-link--icon:has-text("Suchkriterien ändern"), a:has-text("Suchkriterien ändern")';
+const SEL_NEXT_INPUT  = 'input[name="stellensucheFilterAttributes.suchtextContainer:stellensucheFilterAttributes.suchText"]';
+const SEL_NEXT_SUBMIT = 'button.ia-e-button--primary:has-text("Detailsuche")';
+
+// ── Scraper ──────────────────────────────────────────────────────────
+
+async function extractRows(page) {
+  return page.$$eval('tr.ia-e-table__row', rows =>
+    rows.map(row => {
+      const cell = field => row.querySelector(`td[data-field="${field}"]`)?.textContent?.trim() || '';
+
+      const title        = cell('Stellenbezeichnung');
+      const id           = row.querySelector('td[data-field="StellenangebotId"] span')?.textContent?.trim() || '';
+      const company      = cell('Behoerde') || 'Interamt';
+      const modality     = cell('Dienstort');
+      const city         = cell('PLZOrte');
+      const publishedDate = cell('Von');
+      const deadline     = cell('Bewerbungsfrist');
+
+      return { title, id, company, modality, city, publishedDate, deadline };
+    }).filter(r => r.title && r.id)
+  );
+}
+
+async function searchInteramt(page, keyword, isFirst) {
+  const found = [];
+
+  if (isFirst) {
+    // Initial search: navigate to homepage and use the landing form
+    await page.goto(INTERAMT_HOME, { waitUntil: 'networkidle', timeout: 30000 });
+
+    // Dismiss cookie modal — it has a backdrop overlay that blocks all clicks
+    const cookieModal = page.locator('#ia-m-cookie-modal');
+    const isModalVisible = await cookieModal.isVisible().catch(() => false);
+    if (isModalVisible) {
+      await page.locator('#ia-m-cookie-modal .ia-m-modal__close').click();
+      await cookieModal.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => null);
+    }
+
+    await page.waitForSelector('#idOrSuchtext', { state: 'visible', timeout: 15000 });
+    await page.fill('#idOrSuchtext', keyword);
+
+    // #ida is Wicket auto-generated; fallback to class selector if ID changes
+    const submitBtn = page.locator('#ida, button.ia-e-button--primary.ia-e-button--icon').first();
+    await submitBtn.waitFor({ state: 'visible', timeout: 10000 });
+    await submitBtn.click();
+  } else {
+    // Subsequent search: use "Suchkriterien ändern" to reuse the Wicket session.
+    // Fall back to a fresh homepage load if the button isn't found (e.g. after an error).
+    const editBtn = page.locator(SEL_EDIT_BTN).first();
+    const editVisible = await editBtn.isVisible({ timeout: 5000 }).catch(() => false);
+
+    if (editVisible) {
+      // Dismiss any modal/backdrop that Wicket may have raised during the previous search
+      const anyModal = page.locator('.ia-m-modal__close').first();
+      if (await anyModal.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await anyModal.evaluate(el => el.click());
+        await page.locator('.ia-m-modal__container').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => null);
+      }
+      await page.locator('.ia-e-backdrop').waitFor({ state: 'hidden', timeout: 10000 }).catch(() => null);
+      await editBtn.evaluate(el => el.click());
+      await page.waitForSelector(SEL_NEXT_INPUT, { state: 'visible', timeout: 15000 });
+      await page.fill(SEL_NEXT_INPUT, keyword);
+      const submitBtn = page.locator(SEL_NEXT_SUBMIT);
+      await submitBtn.waitFor({ state: 'visible', timeout: 10000 });
+      await submitBtn.click();
+    } else {
+      // Fallback: reload homepage (no cookie modal on subsequent loads)
+      await page.goto(INTERAMT_HOME, { waitUntil: 'networkidle', timeout: 30000 });
+      await page.waitForSelector('#idOrSuchtext', { state: 'visible', timeout: 15000 });
+      await page.fill('#idOrSuchtext', keyword);
+      const submitBtn = page.locator('#ida, button.ia-e-button--primary.ia-e-button--icon').first();
+      await submitBtn.waitFor({ state: 'visible', timeout: 10000 });
+      await submitBtn.click();
+    }
+  }
+
+  // Wait for results table or "no results" message
+  await Promise.race([
+    page.waitForSelector('tr.ia-e-table__row', { timeout: 20000 }),
+    page.waitForSelector('.ia-e-no-results, .ia-no-results, [class*="no-result"]', { timeout: 20000 }),
+  ]).catch(() => null);
+
+  if (DEBUG) {
+    mkdirSync('output', { recursive: true });
+    await page.screenshot({ path: 'output/debug-interamt.png', fullPage: true });
+    const { writeFileSync: wf } = await import('fs');
+    wf('output/debug-interamt.html', await page.content());
+    console.log('  [debug] screenshot → output/debug-interamt.png');
+    console.log('  [debug] html       → output/debug-interamt.html');
+    console.log('  [debug] url:', page.url());
+    const rowCount = await page.$$eval('tr', rows => rows.length);
+    console.log(`  [debug] total <tr> on page: ${rowCount}`);
+  }
+
+  // Wait for Wicket AJAX to fully settle — networkidle ensures no pending requests
+  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => null);
+
+  // "mehr laden" appends rows to the same page — click until gone, then extract all at once
+  const loadMoreBtn = page.locator('button.ia-m-searchresults__btn-load').first();
+  let pageNum = 1;
+  while (pageNum <= 50) {
+    const visible = await loadMoreBtn.isVisible().catch(() => false);
+    if (!visible) break;
+    const beforeCount = await page.$$eval('tr.ia-e-table__row', rows => rows.length);
+    await loadMoreBtn.evaluate(el => el.click());
+    // Wait for backdrop to clear, then for new rows to appear
+    await page.locator('.ia-e-backdrop').waitFor({ state: 'hidden', timeout: 10000 }).catch(() => null);
+    await page.waitForFunction(
+      n => document.querySelectorAll('tr.ia-e-table__row').length > n,
+      beforeCount,
+      { timeout: 15000 }
+    ).catch(() => null);
+    pageNum++;
+  }
+
+  const rows = await extractRows(page);
+  for (const row of rows) {
+    found.push({
+      title:         row.title,
+      url:           `${OFFER_BASE_URL}${row.id}`,
+      company:       row.company,
+      modality:      row.modality,
+      city:          row.city,
+      publishedDate: row.publishedDate,
+      deadline:      row.deadline,
+    });
+  }
+
+  return found;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  mkdirSync('data', { recursive: true });
+
+  const { seen } = loadSeenUrls();
+  const date = new Date().toISOString().slice(0, 10);
+
+  const lastScanDate = NO_DATE_FILTER ? null : loadLastScanDate();
+  if (NO_DATE_FILTER) {
+    console.log(`  --all: date filter disabled — fetching all available offers`);
+  } else if (lastScanDate) {
+    console.log(`  Last Interamt scan: ${lastScanDate.toISOString().slice(0,10)} — skipping older offers`);
+  }
+
+  let totalFound = 0;
+  const newOffers = [];
+  const titleSkipped = [];
+  const locationSkipped = [];
+  const dateSkipped = [];
+  const dupeSkipped = [];
+  const errors = [];
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ locale: 'de-DE', timezoneId: 'Europe/Berlin' });
+  const page = await context.newPage();
+
+  try {
+    for (let i = 0; i < keywords.length; i++) {
+      const kw = keywords[i];
+      process.stdout.write(`  Searching "${kw}"... `);
+      try {
+        const found = await searchInteramt(page, kw, i === 0);
+        totalFound += found.length;
+        process.stdout.write(`${found.length} found\n`);
+
+        for (const offer of found) {
+          const location = [offer.modality, offer.city].filter(Boolean).join(' ')
+            + (offer.deadline ? ` (Frist: ${offer.deadline})` : '');
+          const pubDate = parseDE(offer.publishedDate);
+          const canonical = {
+            url: offer.url,
+            company: offer.company,
+            title: offer.title,
+            location,
+            source: 'interamt',
+            postedAt: pubDate ? pubDate.getTime() : undefined,
+          };
+
+          if (!matchesTitle(offer.title)) { seen.add(canonical.url); titleSkipped.push(canonical); continue; }
+          if (!matchesLocation(location)) { seen.add(canonical.url); locationSkipped.push(canonical); continue; }
+          // Same-day offers pass: lastScanDate is the day of the last run, and an
+          // offer published later that same day should not be treated as stale.
+          if (lastScanDate && pubDate && pubDate < lastScanDate) { seen.add(canonical.url); dateSkipped.push(canonical); continue; }
+          if (seen.has(canonical.url)) { dupeSkipped.push(canonical); continue; }
+          seen.add(canonical.url);
+          newOffers.push(canonical);
+        }
+      } catch (err) {
+        process.stdout.write(`ERROR\n`);
+        errors.push({ keyword: kw, error: err.message });
+      }
+    }
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+
+  if (!DRY_RUN) {
+    if (newOffers.length > 0) await appendToPipeline(newOffers);
+    if (newOffers.length > 0) appendToScanHistory(newOffers, date, 'added');
+    if (titleSkipped.length > 0) appendToScanHistory(titleSkipped, date, 'skipped_title');
+    if (locationSkipped.length > 0) appendToScanHistory(locationSkipped, date, 'skipped_location');
+    if (dateSkipped.length > 0) appendToScanHistory(dateSkipped, date, 'skipped_date');
+    if (dupeSkipped.length > 0) appendToScanHistory(dupeSkipped, date, 'skipped_dup');
+  }
+
+  // Summary
+  console.log(`\n${'━'.repeat(45)}`);
+  console.log(`Interamt Scan — ${date}`);
+  console.log(`${'━'.repeat(45)}`);
+  console.log(`Keywords searched:  ${keywords.length}`);
+  console.log(`Total found:        ${totalFound}`);
+  console.log(`Filtered by title:  ${titleSkipped.length}`);
+  console.log(`Filtered location:  ${locationSkipped.length}`);
+  console.log(`Filtered by date:   ${dateSkipped.length}`);
+  console.log(`Duplicates:         ${dupeSkipped.length}`);
+  console.log(`New offers:         ${newOffers.length}`);
+
+  if (errors.length > 0) {
+    console.log(`\nErrors (${errors.length}):`);
+    for (const e of errors) console.log(`  ✗ "${e.keyword}": ${e.error}`);
+  }
+
+  if (newOffers.length > 0) {
+    console.log('\nNew offers:');
+    for (const o of newOffers) {
+      console.log(`  + ${o.company} | ${o.title} | ${o.location || 'N/A'}`);
+    }
+    if (DRY_RUN) {
+      console.log('\n(dry run — not saved)');
+    } else {
+      console.log(`\nSaved to data/pipeline.md`);
+    }
+  }
+
+  console.log('\n→ Run /career-ops pipeline to evaluate new offers.');
+}
+
+main().catch(err => {
+  console.error('Fatal:', err.message);
+  process.exit(1);
+});

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -31,6 +31,24 @@
 # scan_history:
 #   recheck_after_days: 30
 
+# -- Interamt.de searches (optional, German public sector) --
+# Read by scan-interamt.mjs (`npm run scan:interamt`), a separate Playwright
+# scanner for Interamt.de, a portal for German federal, state, and municipal
+# government job postings. Interamt has no REST API (Apache Wicket, stateful),
+# so it isn't reachable through the tracked_companies providers above;
+# scan-interamt.mjs drives a real browser session instead.
+#
+# Each `was:` entry is a search keyword submitted to Interamt's search form.
+# If this block is absent, scan-interamt.mjs falls back to a generic set of
+# German IT keywords (Informatiker, Softwareentwickler, IT-Spezialist, ...).
+# Results are still filtered by title_filter/location_filter below.
+#
+# interamt_searches:
+#   - was: "Softwareentwickler"
+#   - was: "Informatiker"
+#   - was: "Datenanalyst"
+#   - was: "Systemadministrator"
+
 # -- Location filter (optional) --
 # Filter scanned jobs by location. Applied AFTER title filter, BEFORE dedup.
 # If this entire block is absent, all locations pass (current default behavior).

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10933,6 +10933,67 @@ try {
   fail(`transcript-input debrief check: ${e.message}`);
 }
 
+// ── CONTRADICTED-FACTS CORRECTION (#2125) ────────────────────────
+// interview/debrief was append-only against the role-specific prep file —
+// no path existed for correcting an existing fact the interview directly
+// contradicts (as opposed to appending a new gap/story/retraction). This
+// section pins that the mode now documents an in-place correction step,
+// the strikethrough-plus-correction example format, and inference-tag
+// resolution, without touching the pre-existing append-only steps.
+
+console.log('\n64. Contradicted-facts correction step (#2125)');
+
+try {
+  const debriefMode = readFile('modes/interview/debrief.md');
+
+  if (debriefMode.includes('Check for Contradicted Facts')) {
+    pass('interview/debrief has a dedicated contradicted-facts step');
+  } else {
+    fail('interview/debrief missing a dedicated contradicted-facts step');
+  }
+
+  // Scoped regex: both bullets must appear, in order, within the same
+  // decision-list paragraph — not just "appends" and "correct in place"
+  // occurring anywhere independently in the file.
+  if (
+    /"This is new information"\s*→\s*appends\.[\s\S]{0,200}"This directly contradicts something the prep file already asserts as fact"\s*→\s*correct in place\./.test(
+      debriefMode
+    )
+  ) {
+    pass('interview/debrief distinguishes new-information-appends from contradiction-corrects-in-place');
+  } else {
+    fail('interview/debrief missing the append-vs-correct distinction');
+  }
+
+  // Scoped regex: the strikethrough, the bolded correction, and the
+  // confirmation-date parenthetical must all appear together on the same
+  // example line — not merely present somewhere in the file independently.
+  if (
+    /~~Metro Hall, on-site~~\s+\*\*Metro Hall — hybrid\*\*\s*\(confirmed on the \{date\} call\)/.test(
+      debriefMode
+    )
+  ) {
+    pass('interview/debrief includes a concrete strikethrough-plus-correction example with the confirmation detail');
+  } else {
+    fail('interview/debrief missing the strikethrough-plus-correction example format with its confirmation detail');
+  }
+
+  // Scoped regex: the resolve-inference-tags instruction, the literal tag,
+  // and the actual resolution behavior must appear tied together in the
+  // same instruction — not as three unrelated substrings anywhere in the file.
+  if (
+    /\*\*Resolve inference tags on contradiction or confirmation\.\*\*[\s\S]{0,200}`\[inferred from JD\]`[\s\S]{0,400}resolve the tag/.test(
+      debriefMode
+    )
+  ) {
+    pass('interview/debrief instructs resolving inference tags once confirmed or corrected');
+  } else {
+    fail('interview/debrief missing the inference-tag resolution instruction tied to its own guidance');
+  }
+} catch (e) {
+  fail(`contradicted-facts correction check: ${e.message}`);
+}
+
 await runDiscovered();
 
 finish();

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10933,6 +10933,47 @@ try {
   fail(`transcript-input debrief check: ${e.message}`);
 }
 
+// ── CALL-PLATFORM DETECTION (#2126) ─────────────────────────────
+// Pins the new **Platform:** field in interview-prep.md's Step 2 (Process
+// Overview) and Step 3 (Round-by-Round Breakdown) — distinct from the
+// existing round-type **Format:** field, cross-referencing invite-match.mjs's
+// extractPlatform without duplicating its detection logic in prose, and
+// falling back to "not stated in the invite, confirm before the call"
+// rather than guessing when the invite text doesn't say.
+
+console.log('\n64. Call-platform detection wired into interview-prep (#2126)');
+
+try {
+  const prepModeDoc = readFile('modes/interview-prep.md');
+  const prepFlat = prepModeDoc.replace(/\s+/g, ' ');
+
+  if (prepModeDoc.includes('- **Format:**') && prepModeDoc.includes('- **Platform:**')) {
+    pass('interview-prep Process Overview has both Format (round type) and Platform (call medium) as distinct fields');
+  } else {
+    fail('interview-prep Process Overview missing the distinct Platform field alongside Format');
+  }
+
+  if (prepFlat.includes("extractPlatform") && prepFlat.includes('invite-match.mjs')) {
+    pass('interview-prep Platform field cross-references invite-match.mjs\'s extractPlatform instead of restating the detection logic');
+  } else {
+    fail('interview-prep Platform field missing the cross-reference to invite-match.mjs\'s extractPlatform');
+  }
+
+  if (prepFlat.includes('not stated in the invite, confirm before the call')) {
+    pass('interview-prep Platform field falls back to "not stated in the invite, confirm before the call" instead of guessing');
+  } else {
+    fail('interview-prep Platform field missing the "not stated in the invite, confirm before the call" fallback');
+  }
+
+  if (prepModeDoc.includes('### Round {N}:') && prepModeDoc.includes('- **Platform:**')) {
+    pass('interview-prep Round-by-Round Breakdown (Step 3) also carries a per-round Platform field');
+  } else {
+    fail('interview-prep Round-by-Round Breakdown missing a per-round Platform field');
+  }
+} catch (e) {
+  fail(`call-platform detection wiring check: ${e.message}`);
+}
+
 await runDiscovered();
 
 finish();

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10984,8 +10984,15 @@ try {
   // The fallback instruction must independently exist in the Round {N}
   // template itself, not just in Step 2 — otherwise a future edit that
   // drops it from Step 3 only would go unnoticed (#2128 review finding).
-  const roundBreakdownFlat = roundBreakdown.replace(/\s+/g, ' ');
-  if (roundBreakdownFlat.includes('not stated in the invite, confirm before the call')) {
+  // Scoped to the Round {N} template specifically (not just anywhere in
+  // Step 3's surrounding prose) so a future edit that drops the fallback
+  // from the round template but leaves it elsewhere in Step 3 would still
+  // be caught (#2128 review finding, round 2).
+  const roundTemplate = roundBreakdown.match(
+    /### Round \{N\}:[\s\S]*?(?=\n### |\n## |$)/
+  )?.[0] ?? '';
+  const roundTemplateFlat = roundTemplate.replace(/\s+/g, ' ');
+  if (roundTemplateFlat.includes('not stated in the invite, confirm before the call')) {
     pass('interview-prep Round-by-Round Breakdown (Step 3) also carries the "not stated in the invite, confirm before the call" fallback');
   } else {
     fail('interview-prep Round-by-Round Breakdown missing the "not stated in the invite, confirm before the call" fallback');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10945,27 +10945,37 @@ console.log('\n64. Call-platform detection wired into interview-prep (#2126)');
 
 try {
   const prepModeDoc = readFile('modes/interview-prep.md');
-  const prepFlat = prepModeDoc.replace(/\s+/g, ' ');
 
-  if (prepModeDoc.includes('- **Format:**') && prepModeDoc.includes('- **Platform:**')) {
+  // Scope assertions to the actual sections they're supposed to be in,
+  // rather than whole-document .includes() checks that could pass even if
+  // Platform only exists in the wrong section (#2128 review finding).
+  const processOverview = prepModeDoc.match(
+    /## Step 2 — Process Overview[\s\S]*?## Step 2\.5 — Audience Map/
+  )?.[0] ?? '';
+  const roundBreakdown = prepModeDoc.match(
+    /## Step 3 — Round-by-Round Breakdown[\s\S]*?(?=\n## |$)/
+  )?.[0] ?? '';
+  const processOverviewFlat = processOverview.replace(/\s+/g, ' ');
+
+  if (processOverview.includes('- **Format:**') && processOverview.includes('- **Platform:**')) {
     pass('interview-prep Process Overview has both Format (round type) and Platform (call medium) as distinct fields');
   } else {
     fail('interview-prep Process Overview missing the distinct Platform field alongside Format');
   }
 
-  if (prepFlat.includes("extractPlatform") && prepFlat.includes('invite-match.mjs')) {
+  if (processOverviewFlat.includes("extractPlatform") && processOverviewFlat.includes('invite-match.mjs')) {
     pass('interview-prep Platform field cross-references invite-match.mjs\'s extractPlatform instead of restating the detection logic');
   } else {
     fail('interview-prep Platform field missing the cross-reference to invite-match.mjs\'s extractPlatform');
   }
 
-  if (prepFlat.includes('not stated in the invite, confirm before the call')) {
+  if (processOverviewFlat.includes('not stated in the invite, confirm before the call')) {
     pass('interview-prep Platform field falls back to "not stated in the invite, confirm before the call" instead of guessing');
   } else {
     fail('interview-prep Platform field missing the "not stated in the invite, confirm before the call" fallback');
   }
 
-  if (prepModeDoc.includes('### Round {N}:') && prepModeDoc.includes('- **Platform:**')) {
+  if (/### Round \{N\}:[\s\S]*?- \*\*Platform:\*\*/.test(roundBreakdown)) {
     pass('interview-prep Round-by-Round Breakdown (Step 3) also carries a per-round Platform field');
   } else {
     fail('interview-prep Round-by-Round Breakdown missing a per-round Platform field');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10980,6 +10980,16 @@ try {
   } else {
     fail('interview-prep Round-by-Round Breakdown missing a per-round Platform field');
   }
+
+  // The fallback instruction must independently exist in the Round {N}
+  // template itself, not just in Step 2 — otherwise a future edit that
+  // drops it from Step 3 only would go unnoticed (#2128 review finding).
+  const roundBreakdownFlat = roundBreakdown.replace(/\s+/g, ' ');
+  if (roundBreakdownFlat.includes('not stated in the invite, confirm before the call')) {
+    pass('interview-prep Round-by-Round Breakdown (Step 3) also carries the "not stated in the invite, confirm before the call" fallback');
+  } else {
+    fail('interview-prep Round-by-Round Breakdown missing the "not stated in the invite, confirm before the call" fallback');
+  }
 } catch (e) {
   fail(`call-platform detection wiring check: ${e.message}`);
 }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -170,6 +170,7 @@ const SYSTEM_PATHS = [
   'pipeline-lock.mjs',
   'classify-tier.mjs',
   'scan-ats-full.mjs',
+  'scan-interamt.mjs',
   'match-star.mjs',
   'jd-skill-gap.mjs',
   'prepare-application.mjs',


### PR DESCRIPTION
## Problem

`interview-prep.md`'s `**Format:**` field (Step 2, Process Overview) captures round *type* (recruiter screen → technical phone → onsite, etc.) but says nothing about the actual call *medium* — whether a given round is a plain phone call or a Zoom/Teams/Meet video call. That information is usually present in the invite/scheduling text itself but nothing extracts or surfaces it distinctly, so the candidate can be unsure right up until the round starts whether they're about to be on camera.

## Solution

**`invite-match.mjs`** — new `extractPlatform(text)` pure function, matching the existing `extractCompany`/`extractDate`/`extractReqId` style:
- `zoom.us` URL → `'Zoom'`
- `teams.microsoft.com` / `teams.live.com` URL → `'Microsoft Teams'`
- `meet.google.com` URL → `'Google Meet'`
- no meeting-platform URL, but a phone-number pattern present → `'Phone'`
- nothing matches → `null` (never guessed — same "silence stays silence" discipline as the other extractors)

Wired into `analyzeInvite()`'s `signals` object and into `--summary` output the same way `date`/`reqId` already are. Self-test (`--self-test`) and `invite-match.test.mjs` both extended with platform-detection cases, including a case verifying a meeting URL wins over a phone-number fallback line in the same text.

**`modes/interview-prep.md`** — adds a `**Platform:**` field distinct from `**Format:**` in Step 2 (Process Overview) and Step 3 (Round-by-Round Breakdown). Cross-references `invite-match.mjs`'s `extractPlatform` by name rather than restating the detection logic (this file is agent instructions, not code). Falls back to "not stated in the invite, confirm before the call" instead of guessing, mirroring the mode's existing "unknown — not enough data" convention. Also adds a short optional logistics note to "How to prepare" (camera/lighting/background for video, quiet space/signal for phone) per the issue's non-required nice-to-have.

**`test-all.mjs`** — new section pinning the `**Platform:**` field's presence in both steps, the `extractPlatform` cross-reference, and the "not stated" fallback text.

## Coordination note

Overlaps file-wise with #2100 (`feat(invite-match): recognize rejection emails, not just interview invites`, also touches `invite-match.mjs`) — that PR adds email-type classification (`classifyEmail`, `REJECTION_PHRASES`/`INVITE_PHRASES`) and an `--apply` CLI flag; this PR adds a new `extractPlatform`-style pure extractor alongside the existing `extractCompany`/`extractDate`/`extractReqId`. No functional conflict expected — different functions, same file; a mechanical rebase may be needed on whichever of the two merges second.

## Test plan

- [x] `node invite-match.mjs --self-test` — 36 passed, 0 failed
- [x] `node invite-match.test.mjs` — 15 passed, 0 failed
- [x] `node test-all.mjs` — 2048 passed, 0 failed, 2 pre-existing unrelated warnings

Closes #2126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added call-platform/medium detection (Zoom, Microsoft Teams, Google Meet, or phone) from invite/scheduling text, with summaries now exposing the detected platform.
  * Interview preparation mode now includes a required **Platform** field in Step 2 and per-round in Step 3, showing platform-specific call prep reminders when known.
* **Bug Fixes**
  * Improved detection accuracy with stricter host/URL matching and correct precedence (meeting links over phone), avoiding lookalikes and false positives.
  * When not detectable, guidance consistently uses “not stated in the invite, confirm before the call.”
* **Tests**
  * Expanded unit, end-to-end, and markdown-wiring verification coverage for positive, negative, and precedence cases (including ports, lookalikes, and email/path/query negatives).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->