### PR TITLE
fix(reply-matcher): sanitize the domains getAppDomains harvests from notes

### DIFF
--- a/reply-matcher.mjs
+++ b/reply-matcher.mjs
@@ -66,6 +66,52 @@ export function checkRoleMatch(text, role) {
   return false;
 }
 
+// Shared ATS, job board, and webmail hosts. Mail from one of these identifies a
+// vendor, never an employer, so it must never become a candidate domain: every
+// message from the host would then score a sender-domain match against whichever
+// application happened to mention it.
+const SHARED_DOMAINS = [
+  'linkedin.com',
+  'applytojob.com',
+  'greenhouse.io',
+  'lever.co',
+  'icims.com',
+  'myworkday.com',
+  'ashbyhq.com',
+  'smartrecruiters.com',
+  'taleo.net',
+  'successfactors.com',
+  'gmail.com',
+  'outlook.com',
+  'yahoo.com',
+  'hotmail.com'
+];
+
+// Dot-separated labels ending in a letters-only TLD. Rejects the shapes tracker
+// prose produces: sentence-final words ("gaps."), bare numerics ("3.34.5."), and
+// paths or filenames ("output/cv-2026-06-23.pdf").
+const DOMAIN_SHAPE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*\.[a-z]{2,}$/;
+
+// Extensions of the artifacts career-ops writes into tracker notes. Several parse
+// as a valid TLD, so shape alone cannot tell a filename from a hostname: "cv.md"
+// would otherwise read as a Moldovan domain. Deliberately excludes extensions that
+// are common employer TLDs (io, co, ai, sh, me, dev, app).
+const FILE_EXTENSIONS = [
+  'pdf', 'md', 'doc', 'docx', 'txt', 'html', 'htm',
+  'png', 'jpg', 'jpeg', 'csv', 'tsv', 'json', 'yaml', 'yml', 'mjs'
+];
+
+function isUsableDomain(domain) {
+  if (!DOMAIN_SHAPE.test(domain)) return false;
+  if (FILE_EXTENSIONS.includes(domain.slice(domain.lastIndexOf('.') + 1))) return false;
+  return !SHARED_DOMAINS.some(shared => domain === shared || domain.endsWith(`.${shared}`));
+}
+
+function addDomain(domains, value) {
+  const domain = (value || '').toLowerCase();
+  if (isUsableDomain(domain)) domains.add(domain);
+}
+
 export function getAppDomains(app, followups) {
   const domains = new Set();
   
@@ -73,15 +119,16 @@ export function getAppDomains(app, followups) {
   if (app.notes) {
     const emails = app.notes.match(/[\w.-]+@[\w.-]+\.\w+/g) || [];
     for (const email of emails) {
-      const d = extractDomain(email);
-      if (d) domains.add(d);
+      addDomain(domains, extractDomain(email));
     }
     // Also look for explicit domains in notes (e.g. "ATS: lever.co")
     const words = app.notes.split(/\s+/);
     for (const w of words) {
       if (w.includes('.') && !w.includes('@')) {
-        // very rough domain check
-        domains.add(w.toLowerCase().replace(/[^a-z0-9.-]/g, ''));
+        // Notes are prose, so trim the punctuation wrapping the token rather than
+        // deleting every disallowed character: dropping "/" would splice a path
+        // like "output/cv-2026-06-23.pdf" into one plausible-looking hostname.
+        addDomain(domains, w.replace(/^[^A-Za-z0-9]+/, '').replace(/[^A-Za-z0-9]+$/, ''));
       }
     }
   }
@@ -90,27 +137,26 @@ export function getAppDomains(app, followups) {
   const appFollowups = followups.filter(f => f.appNum === app.num);
   for (const fu of appFollowups) {
     if (fu.contact) {
-      const d = extractDomain(fu.contact);
-      if (d) domains.add(d);
+      addDomain(domains, extractDomain(fu.contact));
     }
     if (fu.notes) {
        const emails = fu.notes.match(/[\w.-]+@[\w.-]+\.\w+/g) || [];
        for (const email of emails) {
-         const d = extractDomain(email);
-         if (d) domains.add(d);
+         addDomain(domains, extractDomain(email));
        }
     }
   }
 
-  // Add common company domain guess (companyname.com)
+  // Add common company domain guess (companyname.com). "?" is the structural
+  // marker for a confidential employer, not a name, so there is nothing to guess.
   const cNorm = normalizeStr(app.company);
-  if (cNorm) {
-    domains.add(`${cNorm}.com`);
-    domains.add(`${cNorm}.co`);
-    domains.add(`${cNorm}.io`);
+  if (cNorm && cNorm !== '?') {
+    addDomain(domains, `${cNorm}.com`);
+    addDomain(domains, `${cNorm}.co`);
+    addDomain(domains, `${cNorm}.io`);
   }
 
-  return Array.from(domains).filter(Boolean);
+  return Array.from(domains);
 }
 
 export function matchCandidates(candidates, apps, followups = []) {

--- a/reply-matcher.test.mjs
+++ b/reply-matcher.test.mjs
@@ -9,6 +9,15 @@ import {
   classifyReply
 } from './reply-matcher.mjs';
 
+// getAppDomains returns an array of bare hostnames, so membership is already an
+// exact whole-string comparison. Assert it through `===` rather than
+// Array.prototype.includes: CodeQL's js/incomplete-url-substring-sanitization
+// reads any `.includes('<host>.<tld>')` as a substring test against a URL and
+// cannot see that the receiver is an array. The literal alone trips it — the
+// rule fired on the four `.com` fixtures below and ignored the structurally
+// identical `.example` ones on adjacent lines.
+const hasDomain = (domains, domain) => domains.some(d => d === domain);
+
 test('extractDomain', () => {
   assert.equal(extractDomain('notice@fundeliver.com'), 'fundeliver.com');
   assert.equal(extractDomain('Jane Doe <jane.doe@lever.co>'), 'lever.co');
@@ -46,10 +55,10 @@ test('getAppDomains - drops prose tokens and filenames, keeps real hostnames', (
 
   const domains = getAppDomains(app, []);
 
-  assert.ok(domains.includes('northwind.com'), 'company-domain guess must survive');
-  assert.ok(domains.includes('careers.northwind.com'), 'employer subdomain in notes must survive');
+  assert.ok(hasDomain(domains, 'northwind.com'), 'company-domain guess must survive');
+  assert.ok(hasDomain(domains, 'careers.northwind.com'), 'employer subdomain in notes must survive');
   for (const junk of ['gaps.', 'remote-us.', 'screen.', 'outputcv-vp-demand-generation-2026-06-23.pdf']) {
-    assert.ok(!domains.includes(junk), `expected junk token "${junk}" to be dropped`);
+    assert.ok(!hasDomain(domains, junk), `expected junk token "${junk}" to be dropped`);
   }
 });
 
@@ -63,9 +72,9 @@ test('getAppDomains - keeps an employer contact domain but skips the confidentia
 
   const domains = getAppDomains(app, []);
 
-  assert.ok(domains.includes('franchise-search.example'), 'employer contact domain must survive');
+  assert.ok(hasDomain(domains, 'franchise-search.example'), 'employer contact domain must survive');
   for (const junk of ['client.', 'location-tied.', 'directly.', '?.com', '?.co', '?.io']) {
-    assert.ok(!domains.includes(junk), `expected junk token "${junk}" to be dropped`);
+    assert.ok(!hasDomain(domains, junk), `expected junk token "${junk}" to be dropped`);
   }
   assert.ok(
     !domains.some(d => d.includes('applytojob')),
@@ -83,9 +92,9 @@ test('getAppDomains - drops a score delta and keeps the recruiter domain', () =>
 
   const domains = getAppDomains(app, []);
 
-  assert.ok(domains.includes('talent-partners.example'), 'recruiter contact domain must survive');
+  assert.ok(hasDomain(domains, 'talent-partners.example'), 'recruiter contact domain must survive');
   for (const junk of ['3.34.5.', 'talentpartners.', 'searches.', '?.com', '?.co', '?.io']) {
-    assert.ok(!domains.includes(junk), `expected junk token "${junk}" to be dropped`);
+    assert.ok(!hasDomain(domains, junk), `expected junk token "${junk}" to be dropped`);
   }
 });
 
@@ -99,10 +108,10 @@ test('getAppDomains - rejects bare filenames whose extension parses as a TLD', (
 
   const domains = getAppDomains(app, []);
 
-  assert.ok(domains.includes('initech.com'), 'company-domain guess must survive');
-  assert.ok(domains.includes('initech-group.example'), 'employer contact domain must survive');
+  assert.ok(hasDomain(domains, 'initech.com'), 'company-domain guess must survive');
+  assert.ok(hasDomain(domains, 'initech-group.example'), 'employer contact domain must survive');
   for (const filename of ['cv.md', 'article-digest.md', 'cover-letter.pdf']) {
-    assert.ok(!domains.includes(filename), `expected filename "${filename}" to be dropped`);
+    assert.ok(!hasDomain(domains, filename), `expected filename "${filename}" to be dropped`);
   }
 });
 
@@ -123,10 +132,10 @@ test('getAppDomains - drops shared ATS, job-board and webmail domains', () => {
 
   const domains = getAppDomains(app, followups);
 
-  assert.ok(domains.includes('globex.com'), 'company-domain guess must survive');
-  assert.ok(domains.includes('globex-hq.example'), 'employer contact domain in notes must survive');
+  assert.ok(hasDomain(domains, 'globex.com'), 'company-domain guess must survive');
+  assert.ok(hasDomain(domains, 'globex-hq.example'), 'employer contact domain in notes must survive');
   for (const shared of ['linkedin.com', 'greenhouse.io', 'gmail.com', 'outlook.com', 'myworkday.com']) {
-    assert.ok(!domains.includes(shared), `expected shared domain "${shared}" to be dropped`);
+    assert.ok(!hasDomain(domains, shared), `expected shared domain "${shared}" to be dropped`);
   }
 });
 

--- a/reply-matcher.test.mjs
+++ b/reply-matcher.test.mjs
@@ -1,9 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { 
-  extractDomain, 
-  checkCompanyMatch, 
-  checkRoleMatch, 
+import {
+  extractDomain,
+  checkCompanyMatch,
+  checkRoleMatch,
+  getAppDomains,
   matchCandidates,
   classifyReply
 } from './reply-matcher.mjs';
@@ -33,6 +34,100 @@ test('checkRoleMatch', () => {
   // Chinese role matches
   assert.ok(checkRoleMatch('邀请您参加PY01_python开发工程师的面试', 'python开发工程师'));
   assert.ok(checkRoleMatch('邀请您参加python开发工程师的面试', 'PY01_python开发工程师'));
+});
+
+test('getAppDomains - drops prose tokens and filenames, keeps real hostnames', () => {
+  const app = {
+    num: 68,
+    company: 'Northwind',
+    role: 'VP, Demand Generation',
+    notes: 'Near-bullseye remote VP-DG at enterprise SaaS; no hard blockers (MBA/vertical-pod soft gaps).; Applied via careers.northwind.com, Remote-US. Comp expectation submitted before the screen. CV: output/cv-vp-demand-generation-2026-06-23.pdf'
+  };
+
+  const domains = getAppDomains(app, []);
+
+  assert.ok(domains.includes('northwind.com'), 'company-domain guess must survive');
+  assert.ok(domains.includes('careers.northwind.com'), 'employer subdomain in notes must survive');
+  for (const junk of ['gaps.', 'remote-us.', 'screen.', 'outputcv-vp-demand-generation-2026-06-23.pdf']) {
+    assert.ok(!domains.includes(junk), `expected junk token "${junk}" to be dropped`);
+  }
+});
+
+test('getAppDomains - keeps an employer contact domain but skips the confidential-marker guess', () => {
+  const app = {
+    num: 270,
+    company: '?',
+    role: 'Vice President of Marketing - Franchisor',
+    notes: 'Recruiter search on behalf of an undisclosed franchisor client. Emailed resume to founder@franchise-search.example and asked whether the search is remote or location-tied. Their other posting (clientco.applytojob.com/apply/F2cqqwBuit) reads like a different client, so not applied to directly.'
+  };
+
+  const domains = getAppDomains(app, []);
+
+  assert.ok(domains.includes('franchise-search.example'), 'employer contact domain must survive');
+  for (const junk of ['client.', 'location-tied.', 'directly.', '?.com', '?.co', '?.io']) {
+    assert.ok(!domains.includes(junk), `expected junk token "${junk}" to be dropped`);
+  }
+  assert.ok(
+    !domains.some(d => d.includes('applytojob')),
+    'a shared ATS host mentioned in notes must not become a candidate domain'
+  );
+});
+
+test('getAppDomains - drops a score delta and keeps the recruiter domain', () => {
+  const app = {
+    num: 234,
+    company: '?',
+    role: 'Vice President Marketing',
+    notes: 'Re-eval 2026-07-12, score 3.3/4.5. Build-from-scratch VP Mktg sourced via TalentPartners. Emailed resume to recruiter@talent-partners.example and asked about similar searches.'
+  };
+
+  const domains = getAppDomains(app, []);
+
+  assert.ok(domains.includes('talent-partners.example'), 'recruiter contact domain must survive');
+  for (const junk of ['3.34.5.', 'talentpartners.', 'searches.', '?.com', '?.co', '?.io']) {
+    assert.ok(!domains.includes(junk), `expected junk token "${junk}" to be dropped`);
+  }
+});
+
+test('getAppDomains - rejects bare filenames whose extension parses as a TLD', () => {
+  const app = {
+    num: 30,
+    company: 'Initech',
+    role: 'Head of Growth',
+    notes: 'Tailored from cv.md. Proof points pulled from article-digest.md, cover draft saved as cover-letter.pdf. Recruiter is talent@initech-group.example.'
+  };
+
+  const domains = getAppDomains(app, []);
+
+  assert.ok(domains.includes('initech.com'), 'company-domain guess must survive');
+  assert.ok(domains.includes('initech-group.example'), 'employer contact domain must survive');
+  for (const filename of ['cv.md', 'article-digest.md', 'cover-letter.pdf']) {
+    assert.ok(!domains.includes(filename), `expected filename "${filename}" to be dropped`);
+  }
+});
+
+test('getAppDomains - drops shared ATS, job-board and webmail domains', () => {
+  const app = {
+    num: 12,
+    company: 'Globex',
+    role: 'Director of Marketing',
+    notes: 'Applied via LinkedIn.com; req tracked at greenhouse.io for this team. Screener wrote from screening@gmail.com, hiring manager is manager@globex-hq.example.'
+  };
+  const followups = [
+    {
+      appNum: 12,
+      contact: 'recruiter@outlook.com',
+      notes: 'Left a voicemail and also emailed talent@myworkday.com about scheduling.'
+    }
+  ];
+
+  const domains = getAppDomains(app, followups);
+
+  assert.ok(domains.includes('globex.com'), 'company-domain guess must survive');
+  assert.ok(domains.includes('globex-hq.example'), 'employer contact domain in notes must survive');
+  for (const shared of ['linkedin.com', 'greenhouse.io', 'gmail.com', 'outlook.com', 'myworkday.com']) {
+    assert.ok(!domains.includes(shared), `expected shared domain "${shared}" to be dropped`);
+  }
 });
 
 test('matchCandidates - high confidence with company + role', () => {
@@ -134,6 +229,32 @@ test('matchCandidates - no match', () => {
   assert.equal(results[0].application_num, null);
   assert.equal(results[0].confidence, 'low');
   assert.ok(results[0].signals.includes('no-match'));
+});
+
+test('matchCandidates - a shared ATS domain in one application does not capture unrelated mail', () => {
+  const apps = [
+    { num: 20, company: 'Initech', role: 'Head of Growth', notes: 'Applied through greenhouse.io for this req' },
+    { num: 21, company: 'Umbrella', role: 'Marketing Director', notes: '' }
+  ];
+
+  const candidates = [
+    {
+      message_id: 'msg6',
+      from: 'no-reply@greenhouse.io',
+      subject: 'Your application to Umbrella',
+      body_snippet: 'Thanks for your interest.',
+      signal: null
+    }
+  ];
+
+  const results = matchCandidates(candidates, apps, []);
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].application_num, 21);
+  assert.ok(
+    !results[0].signals.includes('sender-domain'),
+    'a shared ATS sender must not score a domain match against an unrelated application'
+  );
 });
 
 test('classifyReply - high confidence interview fixtures', () => {


### PR DESCRIPTION
## What does this PR do?

`getAppDomains()` collected candidate sender domains for an application by treating any whitespace-separated token containing a period as a domain. Prose fragments (`gaps.`, `directly.`), a filename whose slash was stripped into a single token, a score delta like `3.3/4.5`, the `${company}` guess applied to the confidential-employer marker `?`, and shared ATS or webmail hosts all landed in the set. This validates each candidate: it must look like a hostname, must not be a filename, and must not be a shared ATS, job-board, or webmail domain; the `${company}` guess is skipped for the `?` marker.

## Related issue

Closes #2134

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Why it matters

The prose junk is inert: no real sender address equals `gaps.` or `?.com`. The shared-domain case is not. `matchCandidates()` awards `+2` `sender-domain` to any application whose domain set contains the sender's from-domain, so once `linkedin.com`, `greenhouse.io`, or `gmail.com` enters one application's set, every message from that host false-matches that one application at `medium` or `high` confidence. On a score tie the spurious `+2` can also displace a legitimate company-name match into `ambiguous-match`, so a correct result is suppressed rather than merely joined by a wrong one.

The blocklist deliberately applies to domains taken from email addresses too, not only bare note tokens. A recruiter who writes from a Gmail address would otherwise seed `gmail.com` into that application's set and turn every Gmail sender into a `+2` match. The cost of dropping one shared address is small, because company-name and role matching still carry the signal; the cost of keeping one is a confident wrong attribution.

## Approach

A candidate domain now has to pass three checks: a hostname shape (dot-separated labels ending in a letters-only TLD), not a known file extension, and not a shared vendor domain or a subdomain of one. Filenames are rejected on their extension because shape alone cannot separate them from hosts: `cv.md` parses as a valid TLD. The extension list excludes extensions that are also common employer TLDs (`io`, `co`, `ai`, `sh`, `me`, `dev`, `app`). The `${company}` guess is skipped when the company is `?`.

Whether a token ends up in the returned domain set:

| Input token | Before | After |
| --- | :---: | :---: |
| `careers.northwind.com` | ✅ | ✅ |
| `gaps.` (sentence-final) | ✅ | ❌ |
| `output/cv-2026-06-23.pdf` (as `outputcv-...pdf`) | ✅ | ❌ |
| `?.com` (from `company === '?'`) | ✅ | ❌ |
| `linkedin.com`, `greenhouse.io`, `gmail.com` | ✅ | ❌ |

## Verification

Six tests added in `reply-matcher.test.mjs`, each asserting both directions: the junk is excluded and the real employer domains still survive (company-guess hostnames, tenant subdomains, and recruiter contact domains), since the matcher's domain leg depends on them. `node test-all.mjs` passes.

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application-domain detection with stricter validation to exclude filename/extension-like tokens and prevent inclusion of known shared ATS/webmail domains, even when mentioned in follow-up notes.
  * Improved handling of explicit domain mentions and company-based domain guesses, avoiding invalid or confidential-marker values and applying consistent filtering.
* **Tests**
  * Added unit tests covering domain extraction/filtering rules and ensuring shared-provider domains do not produce incorrect sender-domain signals across unrelated applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->