### PR TITLE
Fix silent freeze in the reverse-ATS full sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `generate-pdf.mjs` | Playwright: HTML to PDF |
 | `generate-latex.mjs` | LaTeX CV validator + pdflatex compiler |
 | `scan.mjs` | Zero-token portal scanner (Greenhouse/Ashby/Lever APIs, zero LLM cost) |
-| `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner over full public ATS datasets (Greenhouse/Lever/Ashby/Workday), filtered by portals.yml `title_filter`/`location_filter` — no company list needed |
+| `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner over full public ATS datasets (Greenhouse/Lever/Ashby/Workday), filtered by portals.yml `title_filter`/`location_filter` — no company list needed; checkpoints every 500 companies, `--resume` continues an interrupted sweep |
 | `check-liveness.mjs` / `liveness-core.mjs` | Job posting liveness checker + shared logic (expired signals win over generic Apply text) |
 | `set-status.mjs` | Canonical tracker-row update: `node set-status.mjs <report#\|company> <State> [--note] [--force]` — strict states.yml validation, report-link mismatch guard, shared lock, atomic write |
 | `invite-match.mjs` | Fuzzy-match a pasted interview invite (company, date, req ID) against the tracker, ranking candidates when a company has multiple entries (JSON or `--summary`) |

--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -16,7 +16,7 @@ const DEFAULT_USER_AGENT = 'Mozilla/5.0 (compatible; career-ops/1.3)';
 export const BROWSER_LIKE_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
 
-async function fetchWithTimeout(url, { timeoutMs = DEFAULT_TIMEOUT_MS, headers = {}, method = 'GET', body = null, redirect = 'follow' } = {}) {
+async function fetchWithTimeout(url, { timeoutMs = DEFAULT_TIMEOUT_MS, headers = {}, method = 'GET', body = null, redirect = 'follow' } = {}, consume) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -40,20 +40,22 @@ async function fetchWithTimeout(url, { timeoutMs = DEFAULT_TIMEOUT_MS, headers =
       err.retryAfter = res.headers.get('retry-after');
       throw err;
     }
-    return res;
+    // Body consumption must stay inside the timer window: a server that sends
+    // headers and then stalls the body otherwise hangs the caller forever
+    // (this froze full-directory sweeps silently — 20 workers all stuck on
+    // stalled reads with the abort timer already cleared).
+    return await consume(res);
   } finally {
     clearTimeout(timer);
   }
 }
 
 export async function fetchJson(url, opts = {}) {
-  const res = await fetchWithTimeout(url, opts);
-  return await res.json();
+  return fetchWithTimeout(url, opts, (res) => res.json());
 }
 
 export async function fetchText(url, opts = {}) {
-  const res = await fetchWithTimeout(url, opts);
-  return await res.text();
+  return fetchWithTimeout(url, opts, (res) => res.text());
 }
 
 export function makeHttpCtx() {

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -330,6 +330,12 @@ export default {
     // times, so tag the array instead; scan-ats-full.mjs aggregates it into
     // one summary line.
     if (stopReason === 'no-date-skip') jobs.workdayNoDateSkip = true;
+    // 'fetch-error' means retries were exhausted mid-pagination while 19
+    // other tenants were hammering the same uplink. scan-ats-full.mjs
+    // collects tagged tenants and retries them sequentially after the
+    // parallel sweep, when the line is quiet — same array-tag pattern as
+    // workdayNoDateSkip (no extra per-tenant logging here).
+    if (stopReason === 'fetch-error') jobs.workdayTruncated = true;
 
     return jobs;
   },

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -663,9 +663,11 @@ async function main() {
     log(`\n⚙  ${name} — ${entriesAll.length} companies${status !== 'ok' ? ` (dataset: ${status})` : ''}${startAt ? ` — resuming at ${startAt}` : ''}`);
 
     let errors = 0;
+    const truncated = [];
     await parallelEach(entries, CONCURRENCY, async (entry) => {
       try {
         const jobs = await withTimeout(source.provider.fetch(entry, ctx), COMPANY_TIMEOUT_MS, `${name}/${entry.name}`);
+        if (jobs.workdayTruncated) truncated.push(entry);
         if (jobs.workdayNoDateSkip) { noDateSkipCompanies++; noDateSkipJobs += jobs.length; }
         await processJobs(jobs, name, source.provider);
       } catch (err) {
@@ -694,6 +696,25 @@ async function main() {
         });
       }
     });
+    // Second chance for boards the parallel sweep truncated: retry alone on a
+    // quiet line. Re-processing the full board is safe — seenUrls already
+    // holds every match from the partial first pass.
+    if (truncated.length) {
+      log(`\n  ↻ retrying ${truncated.length} truncated board(s) sequentially...`);
+      for (const entry of truncated) {
+        try {
+          const jobs = await withTimeout(source.provider.fetch(entry, ctx), COMPANY_TIMEOUT_MS, `${name}/${entry.name} (retry)`);
+          await processJobs(jobs, name, source.provider);
+          if (jobs.workdayTruncated) {
+            errors++; // still truncated on a quiet line — genuine board problem, move on
+            if (opts.verbose) console.error(`  ✗ ${name}/${entry.name}: still truncated after sequential retry`);
+          }
+        } catch (err) {
+          errors++;
+          if (opts.verbose) console.error(`  ✗ ${name}/${entry.name} (retry): ${err.message}`);
+        }
+      }
+    }
     totalErrors += errors;
     completedSources.add(name);
     if (!opts.dryRun) {

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -613,7 +613,10 @@ async function main() {
   const ctx = { ...makeHttpCtx(), sinceMs: cutoff, includeUndated: opts.includeUndated };
   const date = new Date().toISOString().slice(0, 10);
 
-  const newOffers = checkpoint ? checkpoint.offers : [];
+  // Same defensive default as completedSources/counters below: a version-1
+  // checkpoint that lost its offers array would otherwise set this to undefined
+  // and throw on the next line, instead of degrading to an empty resume.
+  const newOffers = checkpoint?.offers || [];
   // Checkpointed matches were already deduped once — without re-seeding, a
   // resumed run re-scanning the in-flight overlap would duplicate them.
   for (const o of newOffers) seenUrls.add(normalizeUrlForDedup(o.url));

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -26,10 +26,11 @@
  *   node scan-ats-full.mjs --include-blacklisted # audit: let data/blacklist.md matches through, annotated
  *   node scan-ats-full.mjs --verbose            # log per-board fetch failures
  *   node scan-ats-full.mjs --md-out <dir>       # also write a dated markdown digest to <dir>
+ *   node scan-ats-full.mjs --resume             # continue an interrupted sweep from its checkpoint
  *   node scan-ats-full.mjs --help               # print this usage block and exit
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync, renameSync, unlinkSync } from 'fs';
 import { pathToFileURL } from 'url';
 import path from 'path';
 import yaml from 'js-yaml';
@@ -57,6 +58,40 @@ const CACHE_TTL_HOURS = 24;
 // so a tampered dataset can at worst name boards that don't exist.
 const DATASET_BASE = 'https://raw.githubusercontent.com/Feashliaa/job-board-aggregator/main/data';
 const CONCURRENCY = 20;
+
+// Crash insurance for multi-hour directory sweeps: progress + matches are
+// checkpointed every CHECKPOINT_EVERY companies so --resume can continue a
+// dead run (with its ORIGINAL date window) instead of restarting from zero.
+const CHECKPOINT_PATH = 'data/cache/ats-full-checkpoint.json';
+const CHECKPOINT_EVERY = 500;
+
+export function loadCheckpoint(file = CHECKPOINT_PATH) {
+  if (!existsSync(file)) return null;
+  try {
+    const cp = JSON.parse(readFileSync(file, 'utf-8'));
+    return cp?.version === 1 ? cp : null;
+  } catch {
+    return null;
+  }
+}
+
+// A checkpoint written under different scan settings must not be resumed —
+// silently mixing sources, caps, or undated policy would corrupt the run's
+// semantics. --shuffle is never resumable: the sampled order isn't reproducible.
+export function checkpointCompatible(cp, opts) {
+  return Boolean(cp)
+    && !opts.shuffle
+    && JSON.stringify(cp.ats) === JSON.stringify(opts.ats)
+    && (cp.limit ?? null) === (opts.limit === Infinity ? null : opts.limit)
+    && cp.includeUndated === opts.includeUndated;
+}
+
+function writeCheckpoint(cp) {
+  mkdirSync(CACHE_DIR, { recursive: true });
+  const tmp = `${CHECKPOINT_PATH}.tmp`;
+  writeFileSync(tmp, JSON.stringify(cp), 'utf-8');
+  renameSync(tmp, CHECKPOINT_PATH); // atomic: a crash mid-write can't corrupt the checkpoint
+}
 
 // Dataset entries are external input destined for URL interpolation — reject
 // anything outside a conservative slug charset.
@@ -120,7 +155,7 @@ const SOURCES = {
 const KNOWN_FLAGS = [
   '--since', '--limit', '--ats', '--seeds', '--dry-run', '--liveness',
   '--verbose', '--md-out', '--json', '--include-undated', '--include-blacklisted',
-  '--shuffle', '--help', '-h',
+  '--shuffle', '--resume', '--help', '-h',
 ];
 
 // Flags that consume the next argv token as a value (space-separated form —
@@ -137,6 +172,7 @@ const USAGE = `Usage:
   node scan-ats-full.mjs --include-blacklisted # audit: let data/blacklist.md matches through, annotated
   node scan-ats-full.mjs --verbose            # log per-board fetch failures
   node scan-ats-full.mjs --md-out <dir>       # also write a dated markdown digest to <dir>
+  node scan-ats-full.mjs --resume             # continue an interrupted sweep from its checkpoint
   node scan-ats-full.mjs --help               # print this usage block and exit`;
 
 function parseArgs(argv) {
@@ -209,6 +245,7 @@ function parseArgs(argv) {
     includeUndated: args.includes('--include-undated'),
     includeBlacklisted: args.includes('--include-blacklisted'),
     shuffle: args.includes('--shuffle'),
+    resume: args.includes('--resume'),
   };
 }
 
@@ -483,7 +520,24 @@ async function filterLive(offers) {
 
 async function main() {
   const opts = parseArgs(process.argv);
-  const cutoff = Date.now() - opts.sinceDays * 86_400_000;
+  let checkpoint = null;
+  if (opts.resume) {
+    const cp = loadCheckpoint();
+    if (!cp) {
+      console.error(`Error: --resume passed but no checkpoint found at ${CHECKPOINT_PATH}.`);
+      process.exit(1);
+    }
+    if (!checkpointCompatible(cp, opts)) {
+      console.error('Error: checkpoint was written with different settings (--ats/--limit/--include-undated, or --shuffle is set) — rerun with the original flags, or delete the checkpoint to start fresh.');
+      process.exit(1);
+    }
+    checkpoint = cp;
+  } else if (loadCheckpoint() && !opts.dryRun) {
+    console.error(`⚠️  Unfinished sweep checkpoint found at ${CHECKPOINT_PATH} — pass --resume to continue it; this fresh run will overwrite it.`);
+  }
+  // Resume reuses the ORIGINAL cutoff so the date window stays consistent
+  // across the interruption instead of silently sliding forward.
+  const cutoff = checkpoint ? checkpoint.cutoffMs : Date.now() - opts.sinceDays * 86_400_000;
   // In --json mode, stdout is reserved for the single machine-readable result,
   // so every human-facing line goes to stderr instead.
   const log = opts.json ? (...a) => console.error(...a) : (...a) => console.log(...a);
@@ -525,32 +579,65 @@ async function main() {
   const ctx = { ...makeHttpCtx(), sinceMs: cutoff, includeUndated: opts.includeUndated };
   const date = new Date().toISOString().slice(0, 10);
 
-  const newOffers = [];
-  let totalCompaniesScanned = 0;
+  const newOffers = checkpoint ? checkpoint.offers : [];
+  // Checkpointed matches were already deduped once — without re-seeding, a
+  // resumed run re-scanning the in-flight overlap would duplicate them.
+  for (const o of newOffers) seenUrls.add(normalizeUrlForDedup(o.url));
+  const completedSources = new Set(checkpoint?.completedSources || []);
+  const cc = checkpoint?.counters || {};
+  let totalCompaniesScanned = cc.totalCompaniesScanned || 0;
   let totalCompaniesAvailable = 0;
-  let totalErrors = 0;
-  let droppedNoDate = 0;
-  let droppedContent = 0;
+  let totalErrors = cc.totalErrors || 0;
+  let droppedNoDate = cc.droppedNoDate || 0;
+  let droppedContent = cc.droppedContent || 0;
   let capHit = false;
   // Aggregated from providers/workday.mjs's jobs.workdayNoDateSkip tag — see
   // there for why this is a counter instead of a per-company console.error
   // (thousands of tenants hit this on a full directory scan; one line each
   // would just be the same message repeated thousands of times).
-  let noDateSkipCompanies = 0;
-  let noDateSkipJobs = 0;
+  let noDateSkipCompanies = cc.noDateSkipCompanies || 0;
+  let noDateSkipJobs = cc.noDateSkipJobs || 0;
   const datasetStatus = {};
+
+  const snapshotCounters = () => ({
+    totalCompaniesScanned, totalErrors, droppedNoDate, droppedContent,
+    noDateSkipCompanies, noDateSkipJobs,
+  });
+  const checkpointBase = () => ({
+    version: 1,
+    cutoffMs: cutoff,
+    ats: opts.ats,
+    limit: opts.limit === Infinity ? null : opts.limit,
+    includeUndated: opts.includeUndated,
+    completedSources: [...completedSources],
+    offers: newOffers,
+    savedAt: new Date().toISOString(),
+  });
 
   for (const name of opts.ats) {
     const source = SOURCES[name];
+    if (completedSources.has(name)) {
+      log(`\n⚙  ${name} — already complete in resumed checkpoint, skipping`);
+      continue;
+    }
     const { list, status } = await loadCompanyList(name, source.dataset);
     datasetStatus[name] = status;
     totalCompaniesAvailable += list.length;
     if (opts.limit < list.length) capHit = true;
-    const entries = sampleCompanies(list, opts.limit, opts.shuffle).map(source.toEntry).filter(Boolean);
-    totalCompaniesScanned += entries.length;
-    log(`\n⚙  ${name} — ${entries.length} companies${status !== 'ok' ? ` (dataset: ${status})` : ''}`);
+    const entriesAll = sampleCompanies(list, opts.limit, opts.shuffle).map(source.toEntry).filter(Boolean);
 
-    let done = 0;
+    let startAt = 0;
+    if (checkpoint && checkpoint.current?.name === name) {
+      if (checkpoint.current.datasetLen !== list.length) {
+        console.error(`Error: ${name} company dataset changed since the checkpoint (${checkpoint.current.datasetLen} → ${list.length} entries) — resume order is no longer valid. Delete ${CHECKPOINT_PATH} and rerun.`);
+        process.exit(1);
+      }
+      startAt = checkpoint.current.resumeAt;
+    }
+    const entries = entriesAll.slice(startAt);
+    totalCompaniesScanned += entries.length;
+    log(`\n⚙  ${name} — ${entriesAll.length} companies${status !== 'ok' ? ` (dataset: ${status})` : ''}${startAt ? ` — resuming at ${startAt}` : ''}`);
+
     let errors = 0;
     await parallelEach(entries, CONCURRENCY, async (entry) => {
       try {
@@ -578,12 +665,31 @@ async function main() {
         errors++;
         if (opts.verbose) console.error(`  ✗ ${name}/${entry.name}: ${err.message}`);
       }
-      done++;
+    }, ({ done, resumeAt }) => {
       if (done % 200 === 0 || done === entries.length) {
         progress(`  ${done}/${entries.length} scanned, ${newOffers.length} total matches\r`);
       }
+      if (done % CHECKPOINT_EVERY === 0 && !opts.dryRun) {
+        writeCheckpoint({
+          ...checkpointBase(),
+          current: { name, resumeAt: startAt + resumeAt, datasetLen: list.length },
+          counters: {
+            ...snapshotCounters(),
+            // totalCompaniesScanned was bumped by the FULL entries.length up
+            // front; a checkpoint must store only work actually attempted, or
+            // a resumed run (which re-adds its own slice) double-counts the
+            // completed portion in the final summary.
+            totalCompaniesScanned: totalCompaniesScanned - (entries.length - done),
+            totalErrors: totalErrors + errors,
+          },
+        });
+      }
     });
     totalErrors += errors;
+    completedSources.add(name);
+    if (!opts.dryRun) {
+      writeCheckpoint({ ...checkpointBase(), current: null, counters: snapshotCounters() });
+    }
     log(`\n  done (${errors} unreachable boards skipped)`);
   }
 
@@ -673,6 +779,9 @@ async function main() {
     }
   }
 
+  // Sweep completed — the checkpoint's job is done.
+  if (!opts.dryRun && existsSync(CHECKPOINT_PATH)) unlinkSync(CHECKPOINT_PATH);
+
   // The authoritative machine-readable result: lets a caller (e.g. the web)
   // tell a *degraded* scan (capped / stale dataset / undated dropped) apart
   // from a genuinely *empty* one. In --json mode stdout carries ONLY this.
@@ -680,6 +789,7 @@ async function main() {
     process.stdout.write(JSON.stringify({
       date,
       sources: opts.ats,
+      resumed: Boolean(checkpoint),
       sinceDays: opts.sinceDays,
       companiesAvailable: totalCompaniesAvailable,
       companiesScanned: totalCompaniesScanned,

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -32,6 +32,7 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync, renameSync, unlinkSync } from 'fs';
 import { pathToFileURL } from 'url';
+import { createHash } from 'crypto';
 import path from 'path';
 import yaml from 'js-yaml';
 
@@ -91,6 +92,15 @@ function writeCheckpoint(cp) {
   const tmp = `${CHECKPOINT_PATH}.tmp`;
   writeFileSync(tmp, JSON.stringify(cp), 'utf-8');
   renameSync(tmp, CHECKPOINT_PATH); // atomic: a crash mid-write can't corrupt the checkpoint
+}
+
+// Cheap content fingerprint of a source's company list. --resume relies on the
+// dataset order being byte-for-byte reproducible; a same-length regeneration
+// with different members would pass a bare length check and silently resume at
+// the wrong offset (companies skipped or re-scanned). Hashing the list detects
+// that drift so we can fail loudly instead.
+export function datasetFingerprint(list) {
+  return createHash('sha1').update(JSON.stringify(list)).digest('hex').slice(0, 16);
 }
 
 // Dataset entries are external input destined for URL interpolation — reject
@@ -640,20 +650,29 @@ async function main() {
 
   for (const name of opts.ats) {
     const source = SOURCES[name];
-    if (completedSources.has(name)) {
-      log(`\n⚙  ${name} — already complete in resumed checkpoint, skipping`);
-      continue;
-    }
+    // Stats are accumulated BEFORE the completed-source skip: on --resume a
+    // source finished before the checkpoint was written still contributed its
+    // companies to the sweep, so it must still count toward the availability /
+    // cap figures the final report and --json output show.
     const { list, status } = await loadCompanyList(name, source.dataset);
     datasetStatus[name] = status;
     totalCompaniesAvailable += list.length;
     if (opts.limit < list.length) capHit = true;
+    if (completedSources.has(name)) {
+      log(`\n⚙  ${name} — already complete in resumed checkpoint, skipping`);
+      continue;
+    }
+    const datasetHash = datasetFingerprint(list);
     const entriesAll = sampleCompanies(list, opts.limit, opts.shuffle).map(source.toEntry).filter(Boolean);
 
     let startAt = 0;
     if (checkpoint && checkpoint.current?.name === name) {
-      if (checkpoint.current.datasetLen !== list.length) {
-        console.error(`Error: ${name} company dataset changed since the checkpoint (${checkpoint.current.datasetLen} → ${list.length} entries) — resume order is no longer valid. Delete ${CHECKPOINT_PATH} and rerun.`);
+      // datasetHash is absent in checkpoints written before this guard existed;
+      // fall back to the length-only check for those rather than hard-failing.
+      const hashMismatch = checkpoint.current.datasetHash != null
+        && checkpoint.current.datasetHash !== datasetHash;
+      if (checkpoint.current.datasetLen !== list.length || hashMismatch) {
+        console.error(`Error: ${name} company dataset changed since the checkpoint — resume order is no longer valid. Delete ${CHECKPOINT_PATH} and rerun.`);
         process.exit(1);
       }
       startAt = checkpoint.current.resumeAt;
@@ -666,10 +685,15 @@ async function main() {
     const truncated = [];
     await parallelEach(entries, CONCURRENCY, async (entry) => {
       try {
-        const jobs = await withTimeout(source.provider.fetch(entry, ctx), COMPANY_TIMEOUT_MS, `${name}/${entry.name}`);
-        if (jobs.workdayTruncated) truncated.push(entry);
-        if (jobs.workdayNoDateSkip) { noDateSkipCompanies++; noDateSkipJobs += jobs.length; }
-        await processJobs(jobs, name, source.provider);
+        // The whole per-company unit — fetch AND processJobs (which may issue
+        // per-job detail-page requests via provider.enrichDate) — runs inside
+        // one watchdog, so enrichment latency can't blow past COMPANY_TIMEOUT_MS.
+        await withTimeout((async () => {
+          const jobs = await source.provider.fetch(entry, ctx);
+          if (jobs.workdayTruncated) truncated.push(entry);
+          if (jobs.workdayNoDateSkip) { noDateSkipCompanies++; noDateSkipJobs += jobs.length; }
+          await processJobs(jobs, name, source.provider);
+        })(), COMPANY_TIMEOUT_MS, `${name}/${entry.name}`);
       } catch (err) {
         // Mostly defunct boards in the public dataset — expected noise, so the
         // default stays quiet; --verbose surfaces per-board failures.
@@ -683,7 +707,7 @@ async function main() {
       if (done % CHECKPOINT_EVERY === 0 && !opts.dryRun) {
         writeCheckpoint({
           ...checkpointBase(),
-          current: { name, resumeAt: startAt + resumeAt, datasetLen: list.length },
+          current: { name, resumeAt: startAt + resumeAt, datasetLen: list.length, datasetHash },
           counters: {
             ...snapshotCounters(),
             // totalCompaniesScanned was bumped by the FULL entries.length up
@@ -703,12 +727,14 @@ async function main() {
       log(`\n  ↻ retrying ${truncated.length} truncated board(s) sequentially...`);
       for (const entry of truncated) {
         try {
-          const jobs = await withTimeout(source.provider.fetch(entry, ctx), COMPANY_TIMEOUT_MS, `${name}/${entry.name} (retry)`);
-          await processJobs(jobs, name, source.provider);
-          if (jobs.workdayTruncated) {
-            errors++; // still truncated on a quiet line — genuine board problem, move on
-            if (opts.verbose) console.error(`  ✗ ${name}/${entry.name}: still truncated after sequential retry`);
-          }
+          await withTimeout((async () => {
+            const jobs = await source.provider.fetch(entry, ctx);
+            await processJobs(jobs, name, source.provider);
+            if (jobs.workdayTruncated) {
+              errors++; // still truncated on a quiet line — genuine board problem, move on
+              if (opts.verbose) console.error(`  ✗ ${name}/${entry.name}: still truncated after sequential retry`);
+            }
+          })(), COMPANY_TIMEOUT_MS, `${name}/${entry.name} (retry)`);
         } catch (err) {
           errors++;
           if (opts.verbose) console.error(`  ✗ ${name}/${entry.name} (retry): ${err.message}`);

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -411,12 +411,37 @@ export async function runSeedScan(seedId, opts, ctx, seenUrls, label) {
 
 // ── Parallel fetch with concurrency limit ───────────────────────────
 
-async function parallelEach(items, limit, fn) {
-  let i = 0;
+// One company's whole fetch may not exceed this — even with per-request
+// timeouts in _http.mjs, an unforeseen hang (DNS, a provider bug) must cost
+// one company, not freeze a worker slot for the rest of a 12k-company sweep.
+const COMPANY_TIMEOUT_MS = 5 * 60_000;
+
+export function withTimeout(promise, ms, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label}: timed out after ${Math.round(ms / 1000)}s`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+export async function parallelEach(items, limit, fn, onItemDone = null) {
+  let next = 0;
+  let done = 0;
+  const inFlight = new Set();
   async function worker() {
-    while (i < items.length) {
-      const item = items[i++];
-      await fn(item);
+    while (next < items.length) {
+      const idx = next++;
+      inFlight.add(idx);
+      try {
+        await fn(items[idx], idx);
+      } finally {
+        inFlight.delete(idx);
+        done++;
+        // Lowest not-yet-finished index: everything below it is complete, so
+        // a resumed run can restart exactly here without skipping work.
+        const resumeAt = inFlight.size ? Math.min(...inFlight) : next;
+        if (onItemDone) onItemDone({ done, resumeAt });
+      }
     }
   }
   await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
@@ -529,7 +554,7 @@ async function main() {
     let errors = 0;
     await parallelEach(entries, CONCURRENCY, async (entry) => {
       try {
-        const jobs = await source.provider.fetch(entry, ctx);
+        const jobs = await withTimeout(source.provider.fetch(entry, ctx), COMPANY_TIMEOUT_MS, `${name}/${entry.name}`);
         if (jobs.workdayNoDateSkip) { noDateSkipCompanies++; noDateSkipJobs += jobs.length; }
         for (const job of jobs) {
           if (!job.url || !job.title) continue;

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -70,10 +70,24 @@ export function loadCheckpoint(file = CHECKPOINT_PATH) {
   if (!existsSync(file)) return null;
   try {
     const cp = JSON.parse(readFileSync(file, 'utf-8'));
-    return cp?.version === 1 ? cp : null;
+    if (cp?.version !== 1) return null;
+    // A version tag alone isn't enough: `current` is consumed unchecked below
+    // (`entriesAll.slice(resumeAt)`), so a truncated or hand-edited record with
+    // a missing/non-numeric resumeAt would silently rescan from zero and then
+    // persist `startAt + resumeAt === NaN` into every later checkpoint — a state
+    // no subsequent resume can recover from. Reject the malformed record instead.
+    if (cp.current !== null && cp.current !== undefined && !validCheckpointCurrent(cp.current)) return null;
+    return cp;
   } catch {
     return null;
   }
+}
+
+function validCheckpointCurrent(cur) {
+  return typeof cur === 'object'
+    && typeof cur.name === 'string'
+    && Number.isInteger(cur.resumeAt) && cur.resumeAt >= 0
+    && Number.isInteger(cur.datasetLen) && cur.datasetLen >= 0;
 }
 
 // A checkpoint written under different scan settings must not be resumed —
@@ -87,11 +101,21 @@ export function checkpointCompatible(cp, opts) {
     && cp.includeUndated === opts.includeUndated;
 }
 
+// Never throws: this runs from parallelEach's `finally`, so an escaping error
+// (ENOSPC, EACCES, read-only volume) would reject the whole sweep and discard
+// every in-memory match from a multi-hour run — the checkpoint killing the work
+// it exists to protect. A failed write costs resumability, not the results.
 function writeCheckpoint(cp) {
-  mkdirSync(CACHE_DIR, { recursive: true });
-  const tmp = `${CHECKPOINT_PATH}.tmp`;
-  writeFileSync(tmp, JSON.stringify(cp), 'utf-8');
-  renameSync(tmp, CHECKPOINT_PATH); // atomic: a crash mid-write can't corrupt the checkpoint
+  try {
+    mkdirSync(CACHE_DIR, { recursive: true });
+    const tmp = `${CHECKPOINT_PATH}.tmp`;
+    writeFileSync(tmp, JSON.stringify(cp), 'utf-8');
+    renameSync(tmp, CHECKPOINT_PATH); // atomic: a crash mid-write can't corrupt the checkpoint
+    return true;
+  } catch (err) {
+    console.error(`\n⚠ checkpoint write failed (${err.message}) — sweep continues, --resume unavailable`);
+    return false;
+  }
 }
 
 // Cheap content fingerprint of a source's company list. --resume relies on the

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -614,6 +614,30 @@ async function main() {
     savedAt: new Date().toISOString(),
   });
 
+  // Per-job filter chain, shared by the parallel sweep, the truncation retry
+  // pass (workday), and date enrichment (icims). Closure over the filters and
+  // counters so both passes update the same run totals.
+  const processJobs = async (jobs, sourceName, provider) => {
+    for (const job of jobs) {
+      if (!job.url || !job.title) continue;
+      // Confirmed-stale postings are always dropped. Undated postings are
+      // dropped by default (a reverse scan targets *fresh* roles) but
+      // COUNTED so callers see the gap; --include-undated keeps them, marked.
+      const dateClass = classifyPostingDate(job, cutoff);
+      if (dateClass === 'stale') continue;
+      if (dateClass === 'undated' && !opts.includeUndated) { droppedNoDate++; continue; }
+      if (!titleFilter(job.title)) continue;
+      // job.url is passed so the location filter can fall back to the URL's own
+      // location segment when the provider reports a rolled-up "N Locations" string.
+      if (!locationFilter(job.location, job.url)) continue;
+      if (!contentFilter(job.description, matchedTitleKeywords(job.title, config?.title_filter))) { droppedContent++; continue; }
+      const dedupUrl = normalizeUrlForDedup(job.url);
+      if (seenUrls.has(dedupUrl)) continue;
+      seenUrls.add(dedupUrl); // intra-scan dedup
+      newOffers.push({ ...job, source: `${sourceName}-full`, dateStatus: job.postedAt ? 'dated' : 'unknown' });
+    }
+  };
+
   for (const name of opts.ats) {
     const source = SOURCES[name];
     if (completedSources.has(name)) {
@@ -643,22 +667,7 @@ async function main() {
       try {
         const jobs = await withTimeout(source.provider.fetch(entry, ctx), COMPANY_TIMEOUT_MS, `${name}/${entry.name}`);
         if (jobs.workdayNoDateSkip) { noDateSkipCompanies++; noDateSkipJobs += jobs.length; }
-        for (const job of jobs) {
-          if (!job.url || !job.title) continue;
-          // Confirmed-stale postings are always dropped. Undated postings are
-          // dropped by default (a reverse scan targets *fresh* roles) but
-          // COUNTED so callers see the gap; --include-undated keeps them, marked.
-          const dateClass = classifyPostingDate(job, cutoff);
-          if (dateClass === 'stale') continue;
-          if (dateClass === 'undated' && !opts.includeUndated) { droppedNoDate++; continue; }
-          if (!titleFilter(job.title)) continue;
-          if (!locationFilter(job.location, job.url)) continue;
-          if (!contentFilter(job.description, matchedTitleKeywords(job.title, config?.title_filter))) { droppedContent++; continue; }
-          const dedupUrl = normalizeUrlForDedup(job.url);
-          if (seenUrls.has(dedupUrl)) continue;
-          seenUrls.add(dedupUrl); // intra-scan dedup
-          newOffers.push({ ...job, source: `${name}-full`, dateStatus: job.postedAt ? 'dated' : 'unknown' });
-        }
+        await processJobs(jobs, name, source.provider);
       } catch (err) {
         // Mostly defunct boards in the public dataset — expected noise, so the
         // default stays quiet; --verbose surfaces per-board failures.

--- a/tests/providers/http-timeout.test.mjs
+++ b/tests/providers/http-timeout.test.mjs
@@ -16,11 +16,18 @@ const { fetchJson, fetchText } = await import(pathToFileURL(join(ROOT, 'provider
 // instead of reintroducing the very silent hang this suite guards against.
 // Set well above the 300ms request timeout but bounded far below a real hang.
 function hardTimeout(promise, ms, label) {
+  let timer;
   return Promise.race([
     promise,
-    new Promise((_, reject) => setTimeout(() => reject(new Error(`${label}: hard test timeout after ${ms}ms — regression suspected`)), ms)),
-  ]);
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label}: hard test timeout after ${ms}ms — regression suspected`)), ms);
+    }),
+  ]).finally(() => clearTimeout(timer));  // else the loser keeps the loop alive to `ms`
 }
+
+// Bounded allowance over the 300ms request timeout: loose enough for a slow CI
+// runner, tight enough that a multi-second stalled-body regression still fails.
+const MAX_ABORT_MS = 1_500;
 
 const sockets = new Set();
 const server = createServer((req, res) => {
@@ -44,7 +51,7 @@ const base = `http://127.0.0.1:${server.address().port}`;
     fail('fetchJson resolved on a stalled body');
   } catch {
     const elapsed = Date.now() - t0;
-    if (elapsed < 5_000) pass(`fetchJson aborted stalled body read in ${elapsed}ms`);
+    if (elapsed < MAX_ABORT_MS) pass(`fetchJson aborted stalled body read in ${elapsed}ms`);
     else fail(`fetchJson took ${elapsed}ms to abort a stalled body (timeout not covering body read)`);
   }
 }
@@ -57,7 +64,7 @@ const base = `http://127.0.0.1:${server.address().port}`;
     fail('fetchText resolved on a stalled body');
   } catch {
     const elapsed = Date.now() - t0;
-    if (elapsed < 5_000) pass(`fetchText aborted stalled body read in ${elapsed}ms`);
+    if (elapsed < MAX_ABORT_MS) pass(`fetchText aborted stalled body read in ${elapsed}ms`);
     else fail(`fetchText took ${elapsed}ms to abort a stalled body`);
   }
 }

--- a/tests/providers/http-timeout.test.mjs
+++ b/tests/providers/http-timeout.test.mjs
@@ -11,6 +11,17 @@ console.log('\nProvider — _http timeout');
 
 const { fetchJson, fetchText } = await import(pathToFileURL(join(ROOT, 'providers/_http.mjs')).href);
 
+// Independent upper bound: if the mechanism under test regresses and the call
+// never settles, this makes the test fail fast (hitting the elapsed assertion)
+// instead of reintroducing the very silent hang this suite guards against.
+// Set well above the 300ms request timeout but bounded far below a real hang.
+function hardTimeout(promise, ms, label) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error(`${label}: hard test timeout after ${ms}ms — regression suspected`)), ms)),
+  ]);
+}
+
 const sockets = new Set();
 const server = createServer((req, res) => {
   if (req.url === '/stall') {
@@ -29,7 +40,7 @@ const base = `http://127.0.0.1:${server.address().port}`;
 {
   const t0 = Date.now();
   try {
-    await fetchJson(`${base}/stall`, { timeoutMs: 300 });
+    await hardTimeout(fetchJson(`${base}/stall`, { timeoutMs: 300 }), 8_000, 'fetchJson /stall');
     fail('fetchJson resolved on a stalled body');
   } catch {
     const elapsed = Date.now() - t0;
@@ -42,7 +53,7 @@ const base = `http://127.0.0.1:${server.address().port}`;
 {
   const t0 = Date.now();
   try {
-    await fetchText(`${base}/stall`, { timeoutMs: 300 });
+    await hardTimeout(fetchText(`${base}/stall`, { timeoutMs: 300 }), 8_000, 'fetchText /stall');
     fail('fetchText resolved on a stalled body');
   } catch {
     const elapsed = Date.now() - t0;

--- a/tests/providers/http-timeout.test.mjs
+++ b/tests/providers/http-timeout.test.mjs
@@ -1,0 +1,62 @@
+// tests/providers/http-timeout.test.mjs — the abort timeout must cover the
+// BODY read, not just the header phase. A server that sends headers and then
+// stalls the body used to hang fetchJson forever, which could silently freeze
+// a full-directory sweep partway through with no error output.
+import { createServer } from 'node:http';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { pass, fail, ROOT } from '../helpers.mjs';
+
+console.log('\nProvider — _http timeout');
+
+const { fetchJson, fetchText } = await import(pathToFileURL(join(ROOT, 'providers/_http.mjs')).href);
+
+const sockets = new Set();
+const server = createServer((req, res) => {
+  if (req.url === '/stall') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.write('{"jobs": [');   // headers + partial body, then silence forever
+    return;
+  }
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end('{"ok":true}');
+});
+server.on('connection', (s) => { sockets.add(s); s.on('close', () => sockets.delete(s)); });
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const base = `http://127.0.0.1:${server.address().port}`;
+
+// 1. Stalled body must abort within the timeout window, not hang.
+{
+  const t0 = Date.now();
+  try {
+    await fetchJson(`${base}/stall`, { timeoutMs: 300 });
+    fail('fetchJson resolved on a stalled body');
+  } catch {
+    const elapsed = Date.now() - t0;
+    if (elapsed < 5_000) pass(`fetchJson aborted stalled body read in ${elapsed}ms`);
+    else fail(`fetchJson took ${elapsed}ms to abort a stalled body (timeout not covering body read)`);
+  }
+}
+
+// 2. Same for fetchText.
+{
+  const t0 = Date.now();
+  try {
+    await fetchText(`${base}/stall`, { timeoutMs: 300 });
+    fail('fetchText resolved on a stalled body');
+  } catch {
+    const elapsed = Date.now() - t0;
+    if (elapsed < 5_000) pass(`fetchText aborted stalled body read in ${elapsed}ms`);
+    else fail(`fetchText took ${elapsed}ms to abort a stalled body`);
+  }
+}
+
+// 3. Happy path still works after the refactor.
+{
+  const ok = await fetchJson(`${base}/ok`, { timeoutMs: 2_000 });
+  if (ok && ok.ok === true) pass('fetchJson still parses a completed body');
+  else fail(`fetchJson happy path broken: ${JSON.stringify(ok)}`);
+}
+
+for (const s of sockets) s.destroy();
+server.close();

--- a/tests/providers/workday.test.mjs
+++ b/tests/providers/workday.test.mjs
@@ -312,6 +312,46 @@ try {
     fail(`workday fetch-error stop should not also warn about max_pages: ${JSON.stringify(flakyWarnings)}`);
   }
 
+  // fetch-error truncation must TAG the returned array so scan-ats-full.mjs
+  // can queue the tenant for a calm sequential retry (the workdayNoDateSkip
+  // pattern — no per-tenant logging beyond the existing truncation warning).
+  {
+    const entry = { name: 'TagCo', careers_url: 'https://tagco.wd1.myworkdayjobs.com/jobs' };
+    const page0 = {
+      total: 60,
+      jobPostings: Array.from({ length: 20 }, (_, i) => ({
+        title: `Role ${i}`, externalPath: `/job/City/role-${i}`, postedOn: 'Posted Today',
+      })),
+    };
+    let calls = 0;
+    const ctx = mkWorkdayCtx(async () => {
+      calls++;
+      if (calls === 1) return page0;
+      throw new Error('fetch failed'); // every page-2 attempt dies
+    });
+    const { result: jobs } = await captureConsoleErrors(() => workday.fetch(entry, ctx));
+    if (jobs.workdayTruncated === true && jobs.length === 20) {
+      pass('fetch-error truncation tags jobs.workdayTruncated');
+    } else {
+      fail(`expected workdayTruncated tag on 20 partial jobs, got tag=${jobs.workdayTruncated} len=${jobs.length}`);
+    }
+  }
+
+  // A clean complete fetch must NOT carry the tag.
+  {
+    const entry = { name: 'CleanCo', careers_url: 'https://cleanco.wd1.myworkdayjobs.com/jobs' };
+    const ctx = mkWorkdayCtx(async () => ({
+      total: 2,
+      jobPostings: [
+        { title: 'A', externalPath: '/job/X/a', postedOn: 'Posted Today' },
+        { title: 'B', externalPath: '/job/X/b', postedOn: 'Posted Today' },
+      ],
+    }));
+    const jobs = await workday.fetch(entry, ctx);
+    if (jobs.workdayTruncated === undefined) pass('complete fetch carries no workdayTruncated tag');
+    else fail('workdayTruncated set on a complete fetch');
+  }
+
   // fetch() retry — a 429 that succeeds on a later attempt is transparent to
   // the caller (no jobs lost, no error surfaced) and respects Retry-After.
   let retrySleepCalls = [];

--- a/tests/scan-ats-full-resume.test.mjs
+++ b/tests/scan-ats-full-resume.test.mjs
@@ -7,7 +7,7 @@ import { pass, fail, ROOT } from './helpers.mjs';
 console.log('\nscan-ats-full — resume machinery');
 
 const mod = await import(pathToFileURL(join(ROOT, 'scan-ats-full.mjs')).href);
-const { parallelEach, withTimeout } = mod;
+const { parallelEach, withTimeout, datasetFingerprint } = mod;
 
 // withTimeout: passes a fast promise through untouched.
 {
@@ -91,4 +91,21 @@ const { loadCheckpoint, checkpointCompatible } = mod;
   if (loadCheckpoint(p)?.cutoffMs === 5) pass('loadCheckpoint reads a valid checkpoint');
   else fail('valid checkpoint not read');
   rmSync(dir, { recursive: true, force: true });
+}
+
+// datasetFingerprint: same content → same hash; any drift → different hash.
+// Guards --resume against a same-length dataset regenerated with different
+// members (which a bare length check would miss and silently mis-resume).
+{
+  const a = ['acme', 'globex', 'initech'];
+  if (datasetFingerprint(a) === datasetFingerprint(['acme', 'globex', 'initech'])) pass('datasetFingerprint stable for identical lists');
+  else fail('datasetFingerprint not stable for identical content');
+
+  // Same length, swapped member — the case a length-only check misses.
+  if (datasetFingerprint(a) !== datasetFingerprint(['acme', 'globex', 'umbrella'])) pass('datasetFingerprint detects same-length content drift');
+  else fail('datasetFingerprint missed same-length content drift');
+
+  // Reordering is drift too — resume offsets are order-dependent.
+  if (datasetFingerprint(a) !== datasetFingerprint(['globex', 'acme', 'initech'])) pass('datasetFingerprint detects reordering');
+  else fail('datasetFingerprint missed reordering');
 }

--- a/tests/scan-ats-full-resume.test.mjs
+++ b/tests/scan-ats-full-resume.test.mjs
@@ -1,0 +1,54 @@
+// tests/scan-ats-full-resume.test.mjs — parallelEach resume-index tracking,
+// withTimeout watchdog, and (Task 3) checkpoint compatibility rules.
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { pass, fail, ROOT } from './helpers.mjs';
+
+console.log('\nscan-ats-full — resume machinery');
+
+const mod = await import(pathToFileURL(join(ROOT, 'scan-ats-full.mjs')).href);
+const { parallelEach, withTimeout } = mod;
+
+// withTimeout: passes a fast promise through untouched.
+{
+  const v = await withTimeout(Promise.resolve(42), 1_000, 'fast');
+  if (v === 42) pass('withTimeout passes fast resolution through');
+  else fail(`withTimeout returned ${v}`);
+}
+
+// withTimeout: rejects a hung promise with a labeled error.
+{
+  try {
+    await withTimeout(new Promise(() => {}), 100, 'acme/board');
+    fail('withTimeout resolved a never-settling promise');
+  } catch (err) {
+    if (/acme\/board: timed out after/.test(err.message)) pass('withTimeout rejects with labeled timeout');
+    else fail(`withTimeout error message: ${err.message}`);
+  }
+}
+
+// parallelEach: resumeAt is the lowest UNFINISHED index — a slow early item
+// holds resumeAt down even while later items complete (resuming at plain
+// `done` count would skip the slow item's work).
+{
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  const events = [];
+  const p = parallelEach(
+    [...Array(10).keys()], 2,
+    async (item) => { if (item === 2) await gate; },
+    (e) => events.push({ ...e }),
+  );
+  await new Promise((r) => setTimeout(r, 100)); // let everything except item 2 finish
+  const held = events[events.length - 1];
+  if (held && held.done === 9 && held.resumeAt === 2) {
+    pass('resumeAt pinned to slow in-flight index 2 while 9 others finished');
+  } else {
+    fail(`expected {done:9, resumeAt:2}, got ${JSON.stringify(held)}`);
+  }
+  release();
+  await p;
+  const last = events[events.length - 1];
+  if (last.done === 10 && last.resumeAt === 10) pass('resumeAt reaches items.length on completion');
+  else fail(`final event ${JSON.stringify(last)}`);
+}

--- a/tests/scan-ats-full-resume.test.mjs
+++ b/tests/scan-ats-full-resume.test.mjs
@@ -52,3 +52,43 @@ const { parallelEach, withTimeout } = mod;
   if (last.done === 10 && last.resumeAt === 10) pass('resumeAt reaches items.length on completion');
   else fail(`final event ${JSON.stringify(last)}`);
 }
+
+// ── Checkpoint compatibility rules (Task 3) ─────────────────────────
+const { loadCheckpoint, checkpointCompatible } = mod;
+
+{
+  const cp = { version: 1, cutoffMs: 1, ats: ['workday'], limit: null, includeUndated: false };
+  const opts = { ats: ['workday'], limit: Infinity, includeUndated: false, shuffle: false };
+  if (checkpointCompatible(cp, opts)) pass('checkpoint compatible with identical settings');
+  else fail('identical settings judged incompatible');
+
+  if (!checkpointCompatible(cp, { ...opts, ats: ['greenhouse'] })) pass('ats mismatch rejected');
+  else fail('ats mismatch accepted');
+
+  if (!checkpointCompatible(cp, { ...opts, shuffle: true })) pass('--shuffle rejected for resume (order not reproducible)');
+  else fail('shuffle accepted');
+
+  if (!checkpointCompatible(cp, { ...opts, limit: 200 })) pass('limit mismatch rejected');
+  else fail('limit mismatch accepted');
+
+  if (!checkpointCompatible(null, opts)) pass('null checkpoint rejected');
+  else fail('null checkpoint accepted');
+}
+
+// loadCheckpoint: garbage and wrong-version files → null, never a throw.
+{
+  const { writeFileSync, mkdirSync, rmSync } = await import('node:fs');
+  const dir = 'data/cache/.test-checkpoint';
+  mkdirSync(dir, { recursive: true });
+  const p = `${dir}/cp.json`;
+  writeFileSync(p, 'not json', 'utf-8');
+  if (loadCheckpoint(p) === null) pass('loadCheckpoint returns null on garbage JSON');
+  else fail('garbage JSON not rejected');
+  writeFileSync(p, JSON.stringify({ version: 99 }), 'utf-8');
+  if (loadCheckpoint(p) === null) pass('loadCheckpoint returns null on unknown version');
+  else fail('unknown version not rejected');
+  writeFileSync(p, JSON.stringify({ version: 1, cutoffMs: 5 }), 'utf-8');
+  if (loadCheckpoint(p)?.cutoffMs === 5) pass('loadCheckpoint reads a valid checkpoint');
+  else fail('valid checkpoint not read');
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/tests/scan-ats-full-resume.test.mjs
+++ b/tests/scan-ats-full-resume.test.mjs
@@ -78,7 +78,9 @@ const { loadCheckpoint, checkpointCompatible } = mod;
 // loadCheckpoint: garbage and wrong-version files → null, never a throw.
 {
   const { writeFileSync, mkdirSync, rmSync } = await import('node:fs');
-  const dir = 'data/cache/.test-checkpoint';
+  // Anchored to ROOT, not CWD: run from anywhere else and a relative path would
+  // create — and then rmSync — a directory outside the project.
+  const dir = join(ROOT, 'data/cache/.test-checkpoint');
   mkdirSync(dir, { recursive: true });
   const p = `${dir}/cp.json`;
   writeFileSync(p, 'not json', 'utf-8');
@@ -90,6 +92,29 @@ const { loadCheckpoint, checkpointCompatible } = mod;
   writeFileSync(p, JSON.stringify({ version: 1, cutoffMs: 5 }), 'utf-8');
   if (loadCheckpoint(p)?.cutoffMs === 5) pass('loadCheckpoint reads a valid checkpoint');
   else fail('valid checkpoint not read');
+
+  // A malformed `current` is worse than no checkpoint: resumeAt is consumed
+  // unchecked, so it rescans from zero and then writes NaN offsets forever.
+  for (const [label, current] of [
+    ['missing resumeAt', { name: 'workday', datasetLen: 10 }],
+    ['non-numeric resumeAt', { name: 'workday', resumeAt: 'x', datasetLen: 10 }],
+    ['negative resumeAt', { name: 'workday', resumeAt: -1, datasetLen: 10 }],
+    ['missing name', { resumeAt: 5, datasetLen: 10 }],
+  ]) {
+    writeFileSync(p, JSON.stringify({ version: 1, current }), 'utf-8');
+    if (loadCheckpoint(p) === null) pass(`loadCheckpoint rejects malformed current (${label})`);
+    else fail(`malformed current accepted (${label})`);
+  }
+
+  writeFileSync(p, JSON.stringify({ version: 1, current: { name: 'workday', resumeAt: 500, datasetLen: 12884 } }), 'utf-8');
+  if (loadCheckpoint(p)?.current?.resumeAt === 500) pass('loadCheckpoint accepts a well-formed current');
+  else fail('well-formed current rejected');
+
+  // current: null is the legitimate "source finished" marker, not malformed.
+  writeFileSync(p, JSON.stringify({ version: 1, current: null }), 'utf-8');
+  if (loadCheckpoint(p)?.version === 1) pass('loadCheckpoint accepts current: null');
+  else fail('current: null rejected');
+
   rmSync(dir, { recursive: true, force: true });
 }
 

--- a/tests/scan-ats-full-resume.test.mjs
+++ b/tests/scan-ats-full-resume.test.mjs
@@ -27,6 +27,46 @@ const { parallelEach, withTimeout, datasetFingerprint } = mod;
   }
 }
 
+// withTimeout: a loser that rejects AFTER the race is over must not surface as
+// an unhandled rejection — Node terminates the process on those, so the
+// watchdog meant to cost one company would take down the whole sweep.
+//
+// This passes against the current implementation and is meant to: Promise.race
+// attaches a rejection handler to every participant (ECMA-262 PerformPromiseRace),
+// so the losers cannot leak. It is a regression guard for a future refactor that
+// replaces the race with a hand-rolled then-chain, where they could.
+//
+// The control arm is load-bearing. Without it, a listener that silently stopped
+// working would make the real assertion pass vacuously — the failure mode that
+// makes "no event fired" a weak signal on its own.
+{
+  const seen = [];
+  const onUnhandled = (err) => seen.push(err.message);
+  process.on('unhandledRejection', onUnhandled);
+  const settle = () => new Promise((r) => setTimeout(r, 160));
+
+  // CONTROL: a genuinely orphaned rejection. Detection must see this one.
+  { new Promise((_, reject) => setTimeout(() => reject(new Error('ORPHAN')), 20)); }
+  await settle();
+  const controlFired = seen.includes('ORPHAN');
+
+  // SUBJECT: the timeout wins, then the loser rejects well afterwards.
+  seen.length = 0;
+  const late = new Promise((_, reject) => setTimeout(() => reject(new Error('LATE_LOSER')), 40));
+  try {
+    await withTimeout(late, 15, 'acme/board');
+    fail('withTimeout resolved when the timeout should have won');
+  } catch (err) {
+    if (!/acme\/board: timed out after/.test(err.message)) fail(`unexpected error: ${err.message}`);
+  }
+  await settle();
+  process.off('unhandledRejection', onUnhandled);
+
+  if (!controlFired) fail('unhandledRejection listener never fired on the control — test is vacuous');
+  else if (seen.length === 0) pass('withTimeout: late rejection from the losing promise stays handled');
+  else fail(`losing promise leaked an unhandled rejection: ${seen.join(', ')}`);
+}
+
 // parallelEach: resumeAt is the lowest UNFINISHED index — a slow early item
 // holds resumeAt down even while later items complete (resuming at plain
 // `done` count would skip the slow item's work).


### PR DESCRIPTION
# PR: Fix silent freeze in the reverse-ATS full sweep

Fixes #2136.

> **Scope update:** the iCIMS provider that was originally bundled here has been
> split into **#2141** (implements #2137), per the review note to keep this PR
> focused on the Workday freeze fix. This PR is now reliability-only.

## What this does

Fixes a silent hang in the reverse-ATS full sweep (`scan-ats-full.mjs`) and adds
the crash-recovery + fairness machinery a multi-hour directory sweep needs.

- **The freeze:** `providers/_http.mjs` cleared its abort timer before reading
  the response body, so a server that sent headers then stalled the body hung
  the request forever — eventually wedging a full directory sweep with no error
  output. The timeout now covers the body read.
- **Per-company watchdog:** one company's whole unit (fetch + `processJobs`)
  runs inside a `COMPANY_TIMEOUT_MS` guard, so an unforeseen hang costs one
  company, not a worker slot.
- **Checkpoint + `--resume`:** progress and matches are checkpointed every 500
  companies so an interrupted multi-hour sweep continues instead of restarting.
- **Sequential retry** for Workday boards rate-limited into a partial fetch
  during the parallel pass — retried alone on a quiet line.

## Review fixes (from the CodeRabbit pass)

- **Resume stats:** `datasetStatus` / `totalCompaniesAvailable` / `capHit` are
  now accumulated **before** the completed-source skip, so a `--resume` run no
  longer under-reports availability/cap for sources that finished before the
  checkpoint was written.
- **Resume integrity:** the checkpoint now stores a content fingerprint of the
  company list and compares it on resume, so a same-length dataset regenerated
  with different members fails loudly instead of silently resuming at the wrong
  offset (falls back to the length-only check for pre-fingerprint checkpoints).
- **Watchdog scope:** `processJobs` runs inside the per-company `withTimeout` in
  both the parallel and sequential-retry passes, so a provider that issues
  follow-up per-job requests can't blow past `COMPANY_TIMEOUT_MS`.
- **Test hardening:** the stalled-body timeout tests get a bounded outer
  timeout so a regression fails fast instead of re-introducing the silent hang
  inside the suite itself.

## Compatibility

- No new dependencies.
- `fetchJson` / `fetchText` public signatures and error shape unchanged.

## Testing

`tests/providers/http-timeout.test.mjs` (live local stall server),
`tests/scan-ats-full-resume.test.mjs` (resume-index gating, checkpoint
compatibility, dataset fingerprint), and additions to
`tests/providers/workday.test.mjs`. Full suite green (the two failing tests are
a pre-existing `node:sqlite` requirement — Node ≥ 22.5 — unrelated to this
change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resumable full ATS directory scans with periodic checkpointing via a new `--resume` option.
  * `--json` output now includes a `resumed` flag when a checkpoint is loaded and the run continues.
* **Bug Fixes**
  * Improved HTTP timeouts to abort during stalled response body reads (not just after headers).
  * Workday scans now correctly mark job results as truncated when pagination stops after exhausted retries.
* **Documentation**
  * Updated scanner documentation to describe resume/checkpoint behavior and existing filtering rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->