### PR TITLE
fix(dashboard): don't parse funding/valuation figures as Pay

### DIFF
--- a/dashboard/internal/data/derive.go
+++ b/dashboard/internal/data/derive.go
@@ -18,7 +18,11 @@ var (
 	// Pay amounts in user-written Notes. Currencies are listed in currencyTokens
 	// below — the regex is assembled from that slice in three positions
 	// (prefix, optional range-prefix, suffix) so adding a new currency is a
-	// one-line append. payCeiling is currency-naive; PayMax sorts numerically.
+	// one-line append. The B suffix is matched too (not for pay itself, but so
+	// a billion-scale valuation like "$7.6B" is captured as one token and can
+	// be excluded by reFundingContext below — otherwise the "B" would be left
+	// dangling after the match and the trailing "valuation" check would never
+	// see it). payCeiling is currency-naive; PayMax sorts numerically.
 	reMoneySpan = buildMoneySpanRegex(currencyTokens)
 	// ISO dates embedded in notes ("Rejected 2026-06-04", "viewed 2026-06-04")
 	reISODate = regexp.MustCompile(`\b20\d{2}-\d{2}-\d{2}\b`)
@@ -31,7 +35,7 @@ var (
 	// "remote in Germany", which describe eligibility, not the job's location.
 	reCityIntl = regexp.MustCompile(`(?i)\b(Porto|Lisbon|London|Berlin|Munich|Hamburg|Frankfurt|Cologne|D(?:ü|u)sseldorf|Stuttgart|Z(?:ü|u)rich|Geneva|Lausanne|Basel|Dublin|Cork|Amsterdam|Rotterdam|Eindhoven|Utrecht|Paris|Lyon|Madrid|Barcelona|Valencia|Stockholm|Gothenburg|Malm(?:ö|o)|Copenhagen|Oslo|Helsinki|Milan|Rome|Turin|Vienna|Brussels|Ghent|Antwerp|Luxembourg|Warsaw|Krak(?:ó|o)w|Wroc(?:ł|l)aw|Tallinn|Riga|Vilnius|Prague|Brno|Budapest|Bucharest|Sofia|Athens|Bengaluru|Bangalore|Singapore|Sydney|Toronto|Vancouver|Tel Aviv|S(?:ã|a)o Paulo)\b`)
 	// Individual amounts inside an already-matched span: "140", "210K", "209,983"
-	reMoneyPart = regexp.MustCompile(`(\d[\d,]*(?:\.\d+)?)\s*([KkMm]?)`)
+	reMoneyPart = regexp.MustCompile(`(\d[\d,]*(?:\.\d+)?)\s*([KkMmBb]?)`)
 	// Estimate markers: "(est)", "(est;", "market est)" or "market" as its own
 	// word — but not "(EST/CST" timezones, "interest)" or "marketing".
 	reEstHint = regexp.MustCompile(`\(est[),;. ]|\best\)|\bmarket\b`)
@@ -74,10 +78,10 @@ func buildMoneySpanRegex(currencies []string) *regexp.Regexp {
 		}
 	}
 	pattern := fmt.Sprintf(
-		`~?(?:(?:%s)\s*\d[\d,]*(?:\.\d+)?[KkMm]?`+
-			`(?:\s*[-–]\s*(?:%s)?\d[\d,]*(?:\.\d+)?[KkMm]?)?`+
-			`|\d[\d,]*(?:\.\d+)?[KkMm]?`+
-			`(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMm]?)?`+
+		`~?(?:(?:%s)\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?`+
+			`(?:\s*[-–]\s*(?:%s)?\d[\d,]*(?:\.\d+)?[KkMmBb]?)?`+
+			`|\d[\d,]*(?:\.\d+)?[KkMmBb]?`+
+			`(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?)?`+
 			`\s+(?:%s))`,
 		strings.Join(prefixParts, "|"),
 		strings.Join(rangePrefixParts, "|"),
@@ -112,6 +116,8 @@ func payCeiling(span string) float64 {
 			v *= 1_000
 		case "m":
 			v *= 1_000_000
+		case "b":
+			v *= 1_000_000_000
 		}
 		if v > top {
 			top = v

--- a/dashboard/internal/data/derive.go
+++ b/dashboard/internal/data/derive.go
@@ -35,6 +35,10 @@ var (
 	// Estimate markers: "(est)", "(est;", "market est)" or "market" as its own
 	// word — but not "(EST/CST" timezones, "interest)" or "marketing".
 	reEstHint = regexp.MustCompile(`\(est[),;. ]|\best\)|\bmarket\b`)
+	// Funding/valuation context immediately after a money match: "$600M
+	// valuation", "$124M total raised", "$70M Series C" describe the company,
+	// not pay, and must not be picked up as the Pay column's figure.
+	reFundingContext = regexp.MustCompile(`(?i)^\s*(valuation|(total\s+)?raised|series\s|round\b)`)
 )
 
 // currencyTokens is the single source of truth for currencies the dashboard
@@ -155,8 +159,16 @@ func deriveNoteFields(app *model.CareerApplication) {
 	}
 
 	// Pay: prefer the first $-range; fall back to the first lone $-amount
-	// (e.g. "$170K min floor") only when no range exists.
-	matches := reMoneySpan.FindAllString(app.Notes, -1)
+	// (e.g. "$170K min floor") only when no range exists. Skip money spans
+	// that are actually funding/valuation figures ("$600M valuation", "$70M
+	// Series C") — they describe the company, not compensation.
+	var matches []string
+	for _, idx := range reMoneySpan.FindAllStringIndex(app.Notes, -1) {
+		if reFundingContext.MatchString(app.Notes[idx[1]:]) {
+			continue
+		}
+		matches = append(matches, app.Notes[idx[0]:idx[1]])
+	}
 	for _, mm := range matches {
 		if strings.ContainsAny(mm, "-–") {
 			app.PayRange = mm

--- a/dashboard/internal/data/derive_test.go
+++ b/dashboard/internal/data/derive_test.go
@@ -227,6 +227,26 @@ func TestDeriveNoteFields(t *testing.T) {
 			paySrc:   "est",
 			last:     "2026-06-16",
 		},
+		{
+			name: "valuation and funding figures are not pay",
+			app: model.CareerApplication{
+				Date:  "2026-07-16",
+				Notes: "Series C, $600M valuation (not pay) — real hiring signal; $70M Series C closed 8mo ago; $124M total raised; advertised comp range is broken data, confirm real number",
+			},
+			payRange: "",
+			last:     "2026-07-16",
+		},
+		{
+			name: "pay range still wins over an adjacent valuation figure",
+			app: model.CareerApplication{
+				Date:  "2026-06-08",
+				Notes: "$7.6B valuation, Remote. $122-149K (POSTED)",
+			},
+			workMode: "Remote",
+			payRange: "$122-149K",
+			paySrc:   "POSTED",
+			last:     "2026-06-08",
+		},
 	}
 
 	for _, tc := range cases {
@@ -368,7 +388,7 @@ func TestIsBareSymbol(t *testing.T) {
 		{"JPY", false}, {"INR", false}, {"SEK", false}, {"BRL", false},
 		// Edge cases
 		{"", true},
-		{"A.B", false}, 
+		{"A.B", false},
 		{"Chf", false},
 		{"123", true},
 	}

--- a/dashboard/internal/data/derive_test.go
+++ b/dashboard/internal/data/derive_test.go
@@ -247,6 +247,16 @@ func TestDeriveNoteFields(t *testing.T) {
 			paySrc:   "POSTED",
 			last:     "2026-06-08",
 		},
+		{
+			name: "billion-scale valuation alone is not pay",
+			app: model.CareerApplication{
+				Date:  "2026-04-11",
+				Notes: "Series H drone logistics, $7.6B valuation, Remote Canada",
+			},
+			workMode: "Remote",
+			payRange: "",
+			last:     "2026-04-11",
+		},
 	}
 
 	for _, tc := range cases {
@@ -309,27 +319,27 @@ func TestBuildMoneySpanRegex(t *testing.T) {
 		{
 			name:    "single bare symbol ($)",
 			input:   []string{"$"},
-			wantPat: `~?(?:(?:\$)\s*\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*(?:\$)?\d[\d,]*(?:\.\d+)?[KkMm]?)?|\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMm]?)?\s+(?:\$))`,
+			wantPat: `~?(?:(?:\$)\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?(?:\s*[-–]\s*(?:\$)?\d[\d,]*(?:\.\d+)?[KkMmBb]?)?|\d[\d,]*(?:\.\d+)?[KkMmBb]?(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?)?\s+(?:\$))`,
 		},
 		{
 			name:    "single ISO code (PLN)",
 			input:   []string{"PLN"},
-			wantPat: `~?(?:(?:PLN ?)\s*\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*(?:PLN ?)?\d[\d,]*(?:\.\d+)?[KkMm]?)?|\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMm]?)?\s+(?:PLN))`,
+			wantPat: `~?(?:(?:PLN ?)\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?(?:\s*[-–]\s*(?:PLN ?)?\d[\d,]*(?:\.\d+)?[KkMmBb]?)?|\d[\d,]*(?:\.\d+)?[KkMmBb]?(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?)?\s+(?:PLN))`,
 		},
 		{
 			name:    "two ISO codes (PLN, UAH)",
 			input:   []string{"PLN", "UAH"},
-			wantPat: `~?(?:(?:PLN ?|UAH ?)\s*\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*(?:PLN ?|UAH ?)?\d[\d,]*(?:\.\d+)?[KkMm]?)?|\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMm]?)?\s+(?:PLN|UAH))`,
+			wantPat: `~?(?:(?:PLN ?|UAH ?)\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?(?:\s*[-–]\s*(?:PLN ?|UAH ?)?\d[\d,]*(?:\.\d+)?[KkMmBb]?)?|\d[\d,]*(?:\.\d+)?[KkMmBb]?(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?)?\s+(?:PLN|UAH))`,
 		},
 		{
 			name:    "mixed bare + ISO ($ bare, PLN ISO)",
 			input:   []string{"$", "PLN"},
-			wantPat: `~?(?:(?:\$|PLN ?)\s*\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*(?:\$|PLN ?)?\d[\d,]*(?:\.\d+)?[KkMm]?)?|\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMm]?)?\s+(?:\$|PLN))`,
+			wantPat: `~?(?:(?:\$|PLN ?)\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?(?:\s*[-–]\s*(?:\$|PLN ?)?\d[\d,]*(?:\.\d+)?[KkMmBb]?)?|\d[\d,]*(?:\.\d+)?[KkMmBb]?(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?)?\s+(?:\$|PLN))`,
 		},
 		{
 			name:    "metachar token (escaped via QuoteMeta)",
 			input:   []string{"A.B"},
-			wantPat: `~?(?:(?:A\.B ?)\s*\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*(?:A\.B ?)?\d[\d,]*(?:\.\d+)?[KkMm]?)?|\d[\d,]*(?:\.\d+)?[KkMm]?(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMm]?)?\s+(?:A\.B))`,
+			wantPat: `~?(?:(?:A\.B ?)\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?(?:\s*[-–]\s*(?:A\.B ?)?\d[\d,]*(?:\.\d+)?[KkMmBb]?)?|\d[\d,]*(?:\.\d+)?[KkMmBb]?(?:\s*[-–]\s*\d[\d,]*(?:\.\d+)?[KkMmBb]?)?\s+(?:A\.B))`,
 		},
 	}
 	for _, tc := range cases {

--- a/dashboard/internal/data/derive_test.go
+++ b/dashboard/internal/data/derive_test.go
@@ -300,6 +300,7 @@ func TestPayCeiling(t *testing.T) {
 		"165-185K CHF":     185_000,
 		"120K €":           120_000,
 		"80-120K UAH":      120_000,
+		"$7.6B":            7_600_000_000,
 		"":                 0,
 	}
 	for span, want := range cases {


### PR DESCRIPTION
## Summary
- The tracker Notes column sometimes mentions company funding/valuation ("$600M valuation", "$70M Series C", "$124M total raised") alongside the actual compensation range. The dashboard's Pay-column parser (`dashboard/internal/data/derive.go`) grabbed the *first* dollar figure in Notes with no way to tell these apart, so a valuation figure could end up displayed as if it were the offered pay.
- Adds a `reFundingContext` check that skips a money match when it's immediately followed by "valuation", "(total) raised", "Series", or "round" — so those get excluded from the Pay column while a real pay range/floor elsewhere in the same note still wins.

## Test plan
- [x] `go test ./...` in `dashboard/` passes
- [x] Added regression cases: valuation-only notes produce no Pay value; a pay range still parses correctly when a valuation figure appears nearby in the same note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note pay extraction so billion-scale amounts (e.g., “$7.6B”) are captured correctly as complete money tokens.
  * Prevented valuation, funding, and round figures from being misclassified as compensation, ensuring only genuine pay ranges populate pay fields.

* **Tests**
  * Added coverage for valuation/funding scenarios to verify `PayRange`/`PayMax` behavior, including cases where valuation-only notes should clear pay values.
  * Updated regex-related expectations and added additional edge-case assertions for symbol detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->