### PR TITLE
Add iCIMS provider to the reverse-ATS full sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `generate-pdf.mjs` | Playwright: HTML to PDF |
 | `generate-latex.mjs` | LaTeX CV validator + pdflatex compiler |
 | `scan.mjs` | Zero-token portal scanner (Greenhouse/Ashby/Lever APIs, zero LLM cost) |
-| `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner over full public ATS datasets (Greenhouse/Lever/Ashby/Workday), filtered by portals.yml `title_filter`/`location_filter` — no company list needed; checkpoints every 500 companies, `--resume` continues an interrupted sweep |
+| `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner over full public ATS datasets (Greenhouse/Lever/Ashby/Workday/iCIMS), filtered by portals.yml `title_filter`/`location_filter` — no company list needed; checkpoints every 500 companies, `--resume` continues an interrupted sweep |
 | `check-liveness.mjs` / `liveness-core.mjs` | Job posting liveness checker + shared logic (expired signals win over generic Apply text) |
 | `set-status.mjs` | Canonical tracker-row update: `node set-status.mjs <report#\|company> <State> [--note] [--force]` — strict states.yml validation, report-link mismatch guard, shared lock, atomic write |
 | `invite-match.mjs` | Fuzzy-match a pasted interview invite (company, date, req ID) against the tracker, ranking candidates when a company has multiple entries (JSON or `--summary`) |

--- a/providers/icims.mjs
+++ b/providers/icims.mjs
@@ -76,9 +76,12 @@ export function parseIcimsSearchPage(html, origin, companyName) {
     // The origin check below still rejects any link that resolves off-host.
     try { parsed = new URL(decodeEntities(href[1]), origin); } catch { continue; }
     if (parsed.origin !== origin) continue;
-    const title = card.match(/<h3\s*>\s*([\s\S]*?)<\/h3>/);
+    // Match the tags with attributes allowed: tenants theme their portals, and a
+    // themed <h3 class="..."> under a bare-tag-only regex would drop the card
+    // silently — zero jobs, no error, indistinguishable from an empty board.
+    const title = card.match(/<h3\b[^>]*>\s*([\s\S]*?)<\/h3>/);
     if (!title || !title[1].trim()) continue;
-    const location = card.match(/field-label">Location<\/span>\s*<span\s*>\s*([\s\S]*?)<\/span>/);
+    const location = card.match(/field-label">Location<\/span>\s*<span\b[^>]*>\s*([\s\S]*?)<\/span>/);
     jobs.push({
       title: decodeEntities(title[1].replace(/\s+/g, ' ').trim()),
       url: `${parsed.origin}${parsed.pathname}`,

--- a/providers/icims.mjs
+++ b/providers/icims.mjs
@@ -96,10 +96,37 @@ export default {
   },
 
   async fetch(entry, ctx) {
-    throw new Error('icims: not implemented yet');
+    const origin = resolveOrigin(entry);
+    if (!origin) throw new Error(`icims: cannot derive portal origin for ${entry.name}`);
+    const all = [];
+    let prevFirstUrl = null;
+    for (let pageNum = 0; pageNum < ICIMS_MAX_PAGES; pageNum++) {
+      if (pageNum > 0) await sleep(INTER_PAGE_DELAY_MS, ctx);
+      const html = await ctx.fetchText(searchUrl(origin, pageNum), { headers: HEADERS, redirect: 'error' });
+      const pageJobs = parseIcimsSearchPage(html, origin, entry.name);
+      if (pageJobs.length === 0) break; // past the last page
+      // Some tenants serve the last real page again for an out-of-range pr
+      // instead of an empty one — a repeated first URL means we're looping.
+      if (pageJobs[0].url === prevFirstUrl) break;
+      prevFirstUrl = pageJobs[0].url;
+      all.push(...pageJobs);
+    }
+    return all;
   },
 
+  /**
+   * Fill in job.postedAt from the posting's detail page (JSON-LD JobPosting
+   * `datePosted`) — the list pages carry no date at all. Any failure leaves
+   * the job undated; the caller's undated policy then applies as usual.
+   */
   async enrichDate(job, ctx) {
-    throw new Error('icims: not implemented yet');
+    const sep = job.url.includes('?') ? '&' : '?';
+    const html = await ctx.fetchText(`${job.url}${sep}in_iframe=1`, { headers: HEADERS, redirect: 'error' });
+    const block = String(html).match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+    if (!block) return;
+    let data;
+    try { data = JSON.parse(block[1]); } catch { return; }
+    const ts = Date.parse(data?.datePosted || '');
+    if (!Number.isNaN(ts)) job.postedAt = ts;
   },
 };

--- a/providers/icims.mjs
+++ b/providers/icims.mjs
@@ -1,0 +1,105 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// iCIMS provider — scrapes the public hosted-portal search pages.
+// Auto-detects from careers_url on any `*.icims.com` https host
+// (canonical form: `https://careers-<tenant>.icims.com/jobs/search?ss=1`).
+//
+// iCIMS list pages carry title/location/URL but NO posted date; dates live
+// only on the job detail page's JSON-LD (schema.org JobPosting `datePosted`).
+// The provider therefore returns undated jobs plus an `enrichDate(job, ctx)`
+// hook — scan-ats-full.mjs calls it only for jobs that already passed the
+// cheap title/location filters, so a 10k-tenant sweep pays detail-page
+// requests for real candidates only, never for noise.
+
+import { BROWSER_LIKE_USER_AGENT } from './_http.mjs';
+import { decodeEntities } from './_html-entities.mjs';
+
+// ~20 postings/page → 30 pages covers 600 postings; tenants bigger than that
+// are rare on iCIMS and a reverse scan only needs the fresh slice anyway.
+const ICIMS_MAX_PAGES = 30;
+// Same per-tenant courtesy delay as workday.mjs — only multi-page tenants pay it.
+const INTER_PAGE_DELAY_MS = 150;
+
+// iCIMS serves 200 directly to a browser-like UA (verified live); the default
+// career-ops UA risks WAF interstitials, same as workday/glints.
+const HEADERS = {
+  'user-agent': BROWSER_LIKE_USER_AGENT,
+  'accept-language': 'en-US,en;q=0.9',
+};
+
+function sleep(ms, ctx) {
+  if (typeof ctx?.sleep === 'function') return ctx.sleep(ms);
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveOrigin(entry) {
+  // entry.api takes precedence over careers_url (mirrors greenhouse/ashby).
+  for (const raw of [entry.api, entry.careers_url]) {
+    if (typeof raw !== 'string' || !raw) continue;
+    let parsed;
+    try { parsed = new URL(raw); } catch { continue; }
+    if (parsed.protocol !== 'https:') continue;
+    if (!parsed.hostname.endsWith('.icims.com')) continue;
+    return parsed.origin;
+  }
+  return null;
+}
+
+// in_iframe=1 selects the lighter portal-only markup; pr is the 0-based page.
+const searchUrl = (origin, page) => `${origin}/jobs/search?ss=1&pr=${page}&in_iframe=1`;
+
+/**
+ * Parse one iCIMS search-results page. Exported for unit tests.
+ *
+ * Postings are `<li class="iCIMS_JobCardItem">` cards: posting URL in an
+ * `iCIMS_Anchor` href (`/jobs/{id}/{title-slug}/job`, query stripped), title
+ * in the anchor's `<h3>`, location in the card's `field-label">Location`
+ * span. Cards whose href resolves off-origin are dropped (defense in depth —
+ * a portal page should never link a posting on another host).
+ *
+ * @param {string} html
+ * @param {string} origin   e.g. "https://careers-acme.icims.com"
+ * @param {string} companyName
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parseIcimsSearchPage(html, origin, companyName) {
+  const jobs = [];
+  const cards = String(html).split('iCIMS_JobCardItem').slice(1);
+  for (const card of cards) {
+    const href = card.match(/href="(https:\/\/[^"]+\/jobs\/\d+\/[^"/]+\/job)[^"]*"/);
+    if (!href) continue;
+    let parsed;
+    try { parsed = new URL(href[1]); } catch { continue; }
+    if (parsed.origin !== origin) continue;
+    const title = card.match(/<h3\s*>\s*([\s\S]*?)<\/h3>/);
+    if (!title || !title[1].trim()) continue;
+    const location = card.match(/field-label">Location<\/span>\s*<span\s*>\s*([\s\S]*?)<\/span>/);
+    jobs.push({
+      title: decodeEntities(title[1].replace(/\s+/g, ' ').trim()),
+      url: href[1],
+      company: companyName,
+      location: location ? decodeEntities(location[1].replace(/\s+/g, ' ').trim()) : '',
+      // no postedAt — iCIMS list pages have no date; see enrichDate.
+    });
+  }
+  return jobs;
+}
+
+/** @type {Provider} */
+export default {
+  id: 'icims',
+
+  detect(entry) {
+    const origin = resolveOrigin(entry);
+    return origin ? { url: searchUrl(origin, 0) } : null;
+  },
+
+  async fetch(entry, ctx) {
+    throw new Error('icims: not implemented yet');
+  },
+
+  async enrichDate(job, ctx) {
+    throw new Error('icims: not implemented yet');
+  },
+};

--- a/providers/icims.mjs
+++ b/providers/icims.mjs
@@ -67,17 +67,21 @@ export function parseIcimsSearchPage(html, origin, companyName) {
   const jobs = [];
   const cards = String(html).split('iCIMS_JobCardItem').slice(1);
   for (const card of cards) {
-    const href = card.match(/href="(https:\/\/[^"]+\/jobs\/\d+\/[^"/]+\/job)[^"]*"/);
+    const href = card.match(/href="([^"]*\/jobs\/\d+\/[^"/]+\/job[^"]*)"/);
     if (!href) continue;
     let parsed;
-    try { parsed = new URL(href[1]); } catch { continue; }
+    // Resolve against the portal origin so a documented *relative* posting href
+    // (/jobs/{id}/{slug}/job) isn't silently dropped — some tenants emit those,
+    // and dropping them all would make fetch() return zero jobs with no error.
+    // The origin check below still rejects any link that resolves off-host.
+    try { parsed = new URL(decodeEntities(href[1]), origin); } catch { continue; }
     if (parsed.origin !== origin) continue;
     const title = card.match(/<h3\s*>\s*([\s\S]*?)<\/h3>/);
     if (!title || !title[1].trim()) continue;
     const location = card.match(/field-label">Location<\/span>\s*<span\s*>\s*([\s\S]*?)<\/span>/);
     jobs.push({
       title: decodeEntities(title[1].replace(/\s+/g, ' ').trim()),
-      url: href[1],
+      url: `${parsed.origin}${parsed.pathname}`,
       company: companyName,
       location: location ? decodeEntities(location[1].replace(/\s+/g, ' ').trim()) : '',
       // no postedAt — iCIMS list pages have no date; see enrichDate.
@@ -122,11 +126,31 @@ export default {
   async enrichDate(job, ctx) {
     const sep = job.url.includes('?') ? '&' : '?';
     const html = await ctx.fetchText(`${job.url}${sep}in_iframe=1`, { headers: HEADERS, redirect: 'error' });
-    const block = String(html).match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
-    if (!block) return;
-    let data;
-    try { data = JSON.parse(block[1]); } catch { return; }
-    const ts = Date.parse(data?.datePosted || '');
+    const nodes = [];
+    for (const [, raw] of String(html).matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+      let data;
+      try { data = JSON.parse(raw); } catch { continue; }
+      // Flatten the JSON-LD shapes iCIMS / schema.org emit: a bare JobPosting
+      // object, an array of nodes, or a graph document ({"@graph":[...]}).
+      if (Array.isArray(data)) nodes.push(...data);
+      else if (Array.isArray(data?.['@graph'])) nodes.push(...data['@graph']);
+      else nodes.push(data);
+    }
+    const ts = Date.parse(pickDatePosted(nodes) || '');
     if (!Number.isNaN(ts)) job.postedAt = ts;
   },
 };
+
+// From flattened JSON-LD nodes, return the datePosted of the first JobPosting
+// node; if none carries a @type, fall back to the first node that has a
+// datePosted at all (preserves the original lenient single-object behavior).
+function pickDatePosted(nodes) {
+  let fallback = null;
+  for (const node of nodes) {
+    if (!node || typeof node !== 'object' || !node.datePosted) continue;
+    const type = node['@type'];
+    if (type === 'JobPosting' || (Array.isArray(type) && type.includes('JobPosting'))) return node.datePosted;
+    if (fallback == null) fallback = node.datePosted;
+  }
+  return fallback;
+}

--- a/providers/icims.mjs
+++ b/providers/icims.mjs
@@ -107,17 +107,23 @@ export default {
     if (!origin) throw new Error(`icims: cannot derive portal origin for ${entry.name}`);
     const all = [];
     let prevFirstUrl = null;
+    // Distinguishes "walked the whole board" from "stopped at the page cap".
+    // Exhausting the cap silently would drop every later posting and look
+    // identical to a complete board — the same failure mode the Workday
+    // truncation tag exists to prevent.
+    let reachedEnd = false;
     for (let pageNum = 0; pageNum < ICIMS_MAX_PAGES; pageNum++) {
       if (pageNum > 0) await sleep(INTER_PAGE_DELAY_MS, ctx);
       const html = await ctx.fetchText(searchUrl(origin, pageNum), { headers: HEADERS, redirect: 'error' });
       const pageJobs = parseIcimsSearchPage(html, origin, entry.name);
-      if (pageJobs.length === 0) break; // past the last page
+      if (pageJobs.length === 0) { reachedEnd = true; break; } // past the last page
       // Some tenants serve the last real page again for an out-of-range pr
       // instead of an empty one — a repeated first URL means we're looping.
-      if (pageJobs[0].url === prevFirstUrl) break;
+      if (pageJobs[0].url === prevFirstUrl) { reachedEnd = true; break; }
       prevFirstUrl = pageJobs[0].url;
       all.push(...pageJobs);
     }
+    if (!reachedEnd) all.icimsTruncated = true;
     return all;
   },
 

--- a/providers/icims.mjs
+++ b/providers/icims.mjs
@@ -54,8 +54,9 @@ const searchUrl = (origin, page) => `${origin}/jobs/search?ss=1&pr=${page}&in_if
  *
  * Postings are `<li class="iCIMS_JobCardItem">` cards: posting URL in an
  * `iCIMS_Anchor` href (`/jobs/{id}/{title-slug}/job`, query stripped), title
- * in the anchor's `<h3>`, location in the card's `field-label">Location`
- * span. Cards whose href resolves off-origin are dropped (defense in depth —
+ * in the anchor's `<h3>`, location in the span following the card's
+ * `field-label` "Location" label. Cards whose href resolves off-origin are
+ * dropped (defense in depth —
  * a portal page should never link a posting on another host).
  *
  * @param {string} html
@@ -81,7 +82,13 @@ export function parseIcimsSearchPage(html, origin, companyName) {
     // silently — zero jobs, no error, indistinguishable from an empty board.
     const title = card.match(/<h3\b[^>]*>\s*([\s\S]*?)<\/h3>/);
     if (!title || !title[1].trim()) continue;
-    const location = card.match(/field-label">Location<\/span>\s*<span\b[^>]*>\s*([\s\S]*?)<\/span>/);
+    // `field-label` is one token in a themed class list, not reliably the last
+    // one, so anchoring on the literal `field-label">` read an empty location
+    // off any tenant that appended a class. An empty location then fails
+    // location_filter and the posting is dropped with nothing to explain it.
+    // The lookarounds keep `field-label` a whole token, so a longer hyphenated
+    // class like `field-label-inline` still doesn't count as a match.
+    const location = card.match(/<span\b[^>]*class=["'][^"']*(?<![\w-])field-label(?![\w-])[^"']*["'][^>]*>\s*Location\s*<\/span>\s*<span\b[^>]*>\s*([\s\S]*?)<\/span>/);
     jobs.push({
       title: decodeEntities(title[1].replace(/\s+/g, ' ').trim()),
       url: `${parsed.origin}${parsed.pathname}`,
@@ -136,7 +143,11 @@ export default {
     const sep = job.url.includes('?') ? '&' : '?';
     const html = await ctx.fetchText(`${job.url}${sep}in_iframe=1`, { headers: HEADERS, redirect: 'error' });
     const nodes = [];
-    for (const [, raw] of String(html).matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    // `type` is not reliably the first attribute: a tenant running CSP emits a
+    // nonce on every inline script. Requiring it first found no date at all,
+    // leaving every posting on that board undated — the undated policy then
+    // drops them and a working board looks identical to an empty one.
+    for (const [, raw] of String(html).matchAll(/<script\b[^>]*(?<![\w-])type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)) {
       let data;
       try { data = JSON.parse(raw); } catch { continue; }
       // Flatten the JSON-LD shapes iCIMS / schema.org emit: a bare JobPosting

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -5,7 +5,7 @@
  *
  * Where scan.mjs scans the companies you track in portals.yml, this script
  * inverts the direction: it walks public directories of companies per ATS
- * (Greenhouse, Lever, Ashby, Workday) and surfaces fresh postings that match
+ * (Greenhouse, Lever, Ashby, Workday, iCIMS) and surfaces fresh postings that match
  * your portals.yml `title_filter` / `location_filter` — no manual company
  * curation needed.
  *
@@ -41,6 +41,7 @@ import greenhouse from './providers/greenhouse.mjs';
 import lever from './providers/lever.mjs';
 import ashby from './providers/ashby.mjs';
 import workday from './providers/workday.mjs';
+import icims from './providers/icims.mjs';
 import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, loadSeenUrls, normalizeUrlForDedup, appendToPipeline, appendToScanHistory, loadBlacklist } from './scan.mjs';
 import { SEED_SOURCES, toPortalEntry } from './seeds/vc-portfolios.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
@@ -146,7 +147,7 @@ export function entryOnHost(name, careersUrl, isCanonicalHost) {
 
 // Each source: the provider module that does the fetching, plus how to turn a
 // dataset entry into a synthetic PortalEntry the provider can detect/fetch.
-const SOURCES = {
+export const SOURCES = {
   greenhouse: {
     provider: greenhouse,
     dataset: `${DATASET_BASE}/greenhouse_companies.json`,
@@ -181,6 +182,13 @@ const SOURCES = {
         h => h === `${tenant}.${instance}.myworkdayjobs.com` && h.endsWith('.myworkdayjobs.com'),
       );
     },
+  },
+  icims: {
+    provider: icims,
+    dataset: `${DATASET_BASE}/icims_companies.json`,
+    toEntry: (slug) => SLUG_RE.test(String(slug))
+      ? entryOnHost(String(slug), `https://careers-${slug}.icims.com/jobs/search?ss=1&in_iframe=1`, h => h === `careers-${String(slug).toLowerCase()}.icims.com`)
+      : null,
   },
 };
 
@@ -660,9 +668,20 @@ async function main() {
       // Confirmed-stale postings are always dropped. Undated postings are
       // dropped by default (a reverse scan targets *fresh* roles) but
       // COUNTED so callers see the gap; --include-undated keeps them, marked.
-      const dateClass = classifyPostingDate(job, cutoff);
+      let dateClass = classifyPostingDate(job, cutoff);
       if (dateClass === 'stale') continue;
-      if (dateClass === 'undated' && !opts.includeUndated) { droppedNoDate++; continue; }
+      if (dateClass === 'undated' && !opts.includeUndated) {
+        // Providers whose list pages carry no date (icims) get one shot at
+        // dating the posting from its detail page — but only after the cheap
+        // title/location filters pass, so a 10k-tenant sweep never pays a
+        // detail-page request for noise.
+        if (provider.enrichDate && titleFilter(job.title) && locationFilter(job.location)) {
+          try { await provider.enrichDate(job, ctx); } catch { /* stays undated */ }
+          dateClass = classifyPostingDate(job, cutoff);
+        }
+        if (dateClass === 'stale') continue;
+        if (dateClass === 'undated') { droppedNoDate++; continue; }
+      }
       if (!titleFilter(job.title)) continue;
       // job.url is passed so the location filter can fall back to the URL's own
       // location segment when the provider reports a rolled-up "N Locations" string.

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -675,7 +675,9 @@ async function main() {
         // dating the posting from its detail page — but only after the cheap
         // title/location filters pass, so a 10k-tenant sweep never pays a
         // detail-page request for noise.
-        if (provider.enrichDate && titleFilter(job.title) && locationFilter(job.location)) {
+        // Same (location, url) pair as the real filter below — a stricter gate
+        // here would deny enrichment to jobs the final check would have kept.
+        if (provider.enrichDate && titleFilter(job.title) && locationFilter(job.location, job.url)) {
           try { await provider.enrichDate(job, ctx); } catch { /* stays undated */ }
           dateClass = classifyPostingDate(job, cutoff);
         }

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -920,6 +920,7 @@ async function main() {
       postingsAnnotatedBlacklisted: blacklistResult.annotatedBlacklisted,
       postingsDroppedContent: droppedContent,
       unreachableBoards: totalErrors,
+      cappedBoards,
       saved,
       offers: offers.map(o => ({
         company: o.company,

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -642,11 +642,16 @@ async function main() {
   // would just be the same message repeated thousands of times).
   let noDateSkipCompanies = cc.noDateSkipCompanies || 0;
   let noDateSkipJobs = cc.noDateSkipJobs || 0;
+  // Boards that hit a provider's hard page cap (icims). Unlike a Workday
+  // truncation this isn't a network hiccup, so a sequential retry would just
+  // re-hit the cap — it's reported, not retried, so capped coverage is visible
+  // instead of passing for a fully-walked board.
+  let cappedBoards = cc.cappedBoards || 0;
   const datasetStatus = {};
 
   const snapshotCounters = () => ({
     totalCompaniesScanned, totalErrors, droppedNoDate, droppedContent,
-    noDateSkipCompanies, noDateSkipJobs,
+    noDateSkipCompanies, noDateSkipJobs, cappedBoards,
   });
   const checkpointBase = () => ({
     version: 1,
@@ -670,20 +675,25 @@ async function main() {
       // COUNTED so callers see the gap; --include-undated keeps them, marked.
       let dateClass = classifyPostingDate(job, cutoff);
       if (dateClass === 'stale') continue;
-      if (dateClass === 'undated' && !opts.includeUndated) {
-        // Providers whose list pages carry no date (icims) get one shot at
-        // dating the posting from its detail page — but only after the cheap
-        // title/location filters pass, so a 10k-tenant sweep never pays a
-        // detail-page request for noise.
-        // Same (location, url) pair as the real filter below — a stricter gate
-        // here would deny enrichment to jobs the final check would have kept.
-        if (provider.enrichDate && titleFilter(job.title) && locationFilter(job.location, job.url)) {
-          try { await provider.enrichDate(job, ctx); } catch { /* stays undated */ }
-          dateClass = classifyPostingDate(job, cutoff);
-        }
-        if (dateClass === 'stale') continue;
-        if (dateClass === 'undated') { droppedNoDate++; continue; }
+      // Providers whose list pages carry no date (icims) get one shot at dating
+      // the posting from its detail page — but only after the cheap title and
+      // location filters pass, so a 10k-tenant sweep never pays a detail-page
+      // request for noise. The same (location, url) pair as the real filter
+      // below: a stricter gate here would deny enrichment to jobs the final
+      // check would have kept.
+      //
+      // Deliberately OUTSIDE the includeUndated branch. Gating enrichment on
+      // !includeUndated meant --include-undated left every icims posting
+      // undated, and since classifyPostingDate can never call an undated
+      // posting stale, --since was silently ignored for the entire source.
+      // Enrich first, then let the undated policy decide.
+      if (dateClass === 'undated' && provider.enrichDate
+          && titleFilter(job.title) && locationFilter(job.location, job.url)) {
+        try { await provider.enrichDate(job, ctx); } catch { /* stays undated */ }
+        dateClass = classifyPostingDate(job, cutoff);
       }
+      if (dateClass === 'stale') continue;
+      if (dateClass === 'undated' && !opts.includeUndated) { droppedNoDate++; continue; }
       if (!titleFilter(job.title)) continue;
       // job.url is passed so the location filter can fall back to the URL's own
       // location segment when the provider reports a rolled-up "N Locations" string.
@@ -739,6 +749,10 @@ async function main() {
         await withTimeout((async () => {
           const jobs = await source.provider.fetch(entry, ctx);
           if (jobs.workdayTruncated) truncated.push(entry);
+          if (jobs.icimsTruncated) {
+            cappedBoards++;
+            if (opts.verbose) console.error(`  ⚠ ${name}/${entry.name}: hit the page cap — later postings not scanned`);
+          }
           if (jobs.workdayNoDateSkip) { noDateSkipCompanies++; noDateSkipJobs += jobs.length; }
           await processJobs(jobs, name, source.provider);
         })(), COMPANY_TIMEOUT_MS, `${name}/${entry.name}`);
@@ -820,6 +834,7 @@ async function main() {
   log(`${'━'.repeat(45)}`);
   log(`Companies scanned:  ${totalCompaniesScanned}${capHit ? ` of ${totalCompaniesAvailable} (capped)` : ''}`);
   log(`Unreachable boards: ${totalErrors}`);
+  if (cappedBoards) log(`Page-capped boards: ${cappedBoards} (partial coverage — later postings not scanned)`);
   // noDateSkipJobs is a subset of droppedNoDate, not a separate pool: every
   // no-postedOn workday posting counted here also hits the per-job undated
   // filter in the scan loop above and gets dropped there too. Report it as

--- a/tests/fixtures/icims-search-page.html
+++ b/tests/fixtures/icims-search-page.html
@@ -29,7 +29,7 @@ Own quota setting, territory design and incentive compensation.</div>
 <div class="row">
 <div class="col-xs-6 header left">
 <span class="sr-only field-label">Location</span>
-<span >
+<span class="iCIMS_JobHeaderField" data-test="location">
 US-CA-Fontana</span>
 </div>
 <div class="col-xs-6 header right">
@@ -40,7 +40,7 @@ US-CA-Fontana</span>
 <div class="col-xs-12 title">
 <a href="https://careers-acmefreight.icims.com/jobs/5678/forklift-operator/job?in_iframe=1" class="iCIMS_Anchor" title="5678 - Forklift Operator">
 <span class="sr-only field-label">Title</span>
-<h3 >
+<h3 class="iCIMS_Header" id="jobtitle-5678">
 Forklift Operator</h3>
 </a>
 </div>

--- a/tests/fixtures/icims-search-page.html
+++ b/tests/fixtures/icims-search-page.html
@@ -1,0 +1,65 @@
+<div class="iCIMS_MainWrapper iCIMS_ListingsPage">
+<ul class="container-fluid iCIMS_JobsTable">
+
+<li class="iCIMS_JobCardItem">
+<div class="row">
+<div class="col-xs-6 header left">
+<span class="sr-only field-label">Location</span>
+<span >
+US-NJ-Edison</span>
+</div>
+<div class="col-xs-6 header right">
+<span class="sr-only field-label">ID</span>
+<span >
+2026-1234</span>
+</div>
+<div class="col-xs-12 title">
+<a href="https://careers-acmefreight.icims.com/jobs/1234/director%2c-revenue-operations/job?in_iframe=1&amp;hashed=-33555" class="iCIMS_Anchor" title="1234 - Director, Revenue Operations">
+<span class="sr-only field-label">Title</span>
+<h3 >
+Director, Revenue Operations &amp; Strategy</h3>
+</a>
+</div>
+<div class="col-xs-12 description">
+Own quota setting, territory design and incentive compensation.</div>
+</div>
+</li>
+
+<li class="iCIMS_JobCardItem">
+<div class="row">
+<div class="col-xs-6 header left">
+<span class="sr-only field-label">Location</span>
+<span >
+US-CA-Fontana</span>
+</div>
+<div class="col-xs-6 header right">
+<span class="sr-only field-label">ID</span>
+<span >
+2026-5678</span>
+</div>
+<div class="col-xs-12 title">
+<a href="https://careers-acmefreight.icims.com/jobs/5678/forklift-operator/job?in_iframe=1" class="iCIMS_Anchor" title="5678 - Forklift Operator">
+<span class="sr-only field-label">Title</span>
+<h3 >
+Forklift Operator</h3>
+</a>
+</div>
+</div>
+</li>
+
+<li class="iCIMS_JobCardItem">
+<div class="row">
+<div class="col-xs-12 title">
+<a href="https://evil.example.com/jobs/9999/phish/job" class="iCIMS_Anchor" title="9999 - Phish">
+<h3 >
+Foreign Host Card</h3>
+</a>
+</div>
+</div>
+</li>
+
+</ul>
+<div class="iCIMS_Paging">
+<a href="https://careers-acmefreight.icims.com/jobs/search?pr=1&amp;in_iframe=1&amp;searchRelation=keyword_all">2</a>
+</div>
+</div>

--- a/tests/providers/icims.test.mjs
+++ b/tests/providers/icims.test.mjs
@@ -58,3 +58,62 @@ else fail(`icims.id is ${JSON.stringify(icims.id)}`);
     fail('garbage HTML did not parse to []');
   }
 }
+
+// ── fetch(): pagination ─────────────────────────────────────────────
+const mkCard = (id, title) => `
+<li class="iCIMS_JobCardItem"><div class="row">
+<div class="col-xs-6 header left"><span class="sr-only field-label">Location</span><span >US-TX-Austin</span></div>
+<div class="col-xs-12 title"><a href="${ORIGIN}/jobs/${id}/${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}/job?in_iframe=1" class="iCIMS_Anchor"><h3 >${title}</h3></a></div>
+</div></li>`;
+const page = (...cards) => `<ul class="iCIMS_JobsTable">${cards.join('')}</ul>`;
+
+const mkCtx = (pages) => ({
+  transport: 'http',
+  sleep: async () => {},
+  fetchJson: async () => { throw new Error('fetchJson should not be called'); },
+  fetchText: async (url) => {
+    const pr = Number(new URL(url).searchParams.get('pr'));
+    mkCtx.calls.push(pr);
+    return pages[pr] ?? page(); // out-of-range → empty page
+  },
+});
+
+// Multi-page tenant: stops on the first empty page.
+{
+  mkCtx.calls = [];
+  const ctx = mkCtx([page(mkCard(1, 'Role A'), mkCard(2, 'Role B')), page(mkCard(3, 'Role C'))]);
+  const jobs = await icims.fetch({ name: 'acmefreight', careers_url: `${ORIGIN}/jobs/search?ss=1` }, ctx);
+  if (jobs.length === 3 && mkCtx.calls.join(',') === '0,1,2') pass('fetch paginates and stops on empty page');
+  else fail(`jobs=${jobs.length} calls=${mkCtx.calls.join(',')}`);
+}
+
+// Tenant that repeats the last page for out-of-range pr: repeat-content stop.
+{
+  mkCtx.calls = [];
+  const repeating = page(mkCard(9, 'Sticky Role'));
+  const ctx = mkCtx({ 0: page(mkCard(1, 'First')), 1: repeating, 2: repeating, 3: repeating });
+  const jobs = await icims.fetch({ name: 'acmefreight', careers_url: `${ORIGIN}/jobs/search?ss=1` }, ctx);
+  if (jobs.length === 2 && mkCtx.calls.length === 3) pass('fetch stops when a page repeats the previous first URL');
+  else fail(`jobs=${jobs.length} calls=${mkCtx.calls.length}`);
+}
+
+// ── enrichDate(): detail-page JSON-LD ───────────────────────────────
+{
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: 'US' };
+  const detail = `<html><script type="application/ld+json">{"@type":"JobPosting","datePosted":"2026-07-20","title":"X"}</script></html>`;
+  await icims.enrichDate(job, { fetchText: async () => detail });
+  if (job.postedAt === Date.parse('2026-07-20')) pass('enrichDate sets postedAt from JSON-LD datePosted');
+  else fail(`postedAt: ${job.postedAt}`);
+}
+{
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: 'US' };
+  await icims.enrichDate(job, { fetchText: async () => '<html>no ldjson</html>' });
+  if (job.postedAt === undefined) pass('enrichDate leaves job undated when JSON-LD missing');
+  else fail(`postedAt unexpectedly set: ${job.postedAt}`);
+}
+{
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: 'US' };
+  await icims.enrichDate(job, { fetchText: async () => '<script type="application/ld+json">{broken json</script>' });
+  if (job.postedAt === undefined) pass('enrichDate tolerates malformed JSON-LD without throwing');
+  else fail(`postedAt unexpectedly set: ${job.postedAt}`);
+}

--- a/tests/providers/icims.test.mjs
+++ b/tests/providers/icims.test.mjs
@@ -1,0 +1,60 @@
+// tests/providers/icims.test.mjs
+import { readFileSync } from 'node:fs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { pass, fail, ROOT } from '../helpers.mjs';
+
+console.log('\nProvider — icims');
+
+const mod = await import(pathToFileURL(join(ROOT, 'providers/icims.mjs')).href);
+const icims = mod.default;
+const { parseIcimsSearchPage } = mod;
+
+const ORIGIN = 'https://careers-acmefreight.icims.com';
+const fixture = readFileSync(join(ROOT, 'tests/fixtures/icims-search-page.html'), 'utf-8');
+
+if (icims.id === 'icims') pass('icims.id is "icims"');
+else fail(`icims.id is ${JSON.stringify(icims.id)}`);
+
+// detect(): any *.icims.com https careers_url resolves to the search URL.
+{
+  const hit = icims.detect({ name: 'Acme', careers_url: `${ORIGIN}/jobs/search?ss=1&in_iframe=1` });
+  if (hit && hit.url === `${ORIGIN}/jobs/search?ss=1&pr=0&in_iframe=1`) pass('icims.detect() resolves portal search URL');
+  else fail(`icims.detect() returned ${JSON.stringify(hit)}`);
+
+  if (icims.detect({ name: 'X', careers_url: 'https://example.com/jobs' }) === null) pass('icims.detect() null for non-icims URL');
+  else fail('icims.detect() accepted a non-icims URL');
+
+  if (icims.detect({ name: 'X', careers_url: 'http://careers-a.icims.com/jobs' }) === null) pass('icims.detect() rejects plain http');
+  else fail('icims.detect() accepted http URL');
+}
+
+// parseIcimsSearchPage(): two same-origin cards parsed; foreign-host card dropped.
+{
+  const jobs = parseIcimsSearchPage(fixture, ORIGIN, 'acmefreight');
+  if (jobs.length === 2) pass('parses 2 same-origin job cards (foreign-host card dropped)');
+  else fail(`expected 2 jobs, got ${jobs.length}: ${JSON.stringify(jobs.map(j => j.url))}`);
+
+  const [dir, fork] = jobs;
+  if (dir.title === 'Director, Revenue Operations & Strategy') pass('title extracted with entities decoded');
+  else fail(`title: ${JSON.stringify(dir.title)}`);
+  if (dir.url === `${ORIGIN}/jobs/1234/director%2c-revenue-operations/job`) pass('url extracted with query stripped');
+  else fail(`url: ${dir.url}`);
+  if (dir.location === 'US-NJ-Edison') pass('location extracted');
+  else fail(`location: ${JSON.stringify(dir.location)}`);
+  if (dir.company === 'acmefreight') pass('company passed through');
+  else fail(`company: ${dir.company}`);
+  if (dir.postedAt === undefined) pass('no postedAt on list-page jobs (enrichDate supplies it later)');
+  else fail(`unexpected postedAt: ${dir.postedAt}`);
+  if (fork.location === 'US-CA-Fontana' && fork.title === 'Forklift Operator') pass('second card parsed');
+  else fail(`second card: ${JSON.stringify(fork)}`);
+}
+
+// Empty/garbage input → [] not a throw.
+{
+  if (parseIcimsSearchPage('', ORIGIN, 'x').length === 0 && parseIcimsSearchPage('<html>no cards</html>', ORIGIN, 'x').length === 0) {
+    pass('empty/garbage HTML parses to []');
+  } else {
+    fail('garbage HTML did not parse to []');
+  }
+}

--- a/tests/providers/icims.test.mjs
+++ b/tests/providers/icims.test.mjs
@@ -50,6 +50,22 @@ else fail(`icims.id is ${JSON.stringify(icims.id)}`);
   else fail(`second card: ${JSON.stringify(fork)}`);
 }
 
+// Relative posting hrefs must resolve against the origin, not be dropped.
+{
+  const relCard = `<li class="iCIMS_JobCardItem"><div class="col-xs-12 title">
+    <a href="/jobs/7777/relative-role/job?in_iframe=1" class="iCIMS_Anchor"><h3 >Relative Role</h3></a></div></li>`;
+  const jobs = parseIcimsSearchPage(`<ul>${relCard}</ul>`, ORIGIN, 'acmefreight');
+  if (jobs.length === 1 && jobs[0].url === `${ORIGIN}/jobs/7777/relative-role/job`) pass('relative href resolved against origin');
+  else fail(`relative href: ${JSON.stringify(jobs.map(j => j.url))}`);
+
+  // A relative href is still origin-checked once resolved — a protocol-relative
+  // link to another host must not sneak past.
+  const offHost = `<li class="iCIMS_JobCardItem"><div class="col-xs-12 title">
+    <a href="//evil.example.com/jobs/8888/x/job" class="iCIMS_Anchor"><h3 >Off Host</h3></a></div></li>`;
+  if (parseIcimsSearchPage(`<ul>${offHost}</ul>`, ORIGIN, 'acmefreight').length === 0) pass('resolved off-host href still dropped');
+  else fail('off-host protocol-relative href was not dropped');
+}
+
 // Empty/garbage input → [] not a throw.
 {
   if (parseIcimsSearchPage('', ORIGIN, 'x').length === 0 && parseIcimsSearchPage('<html>no cards</html>', ORIGIN, 'x').length === 0) {
@@ -110,6 +126,22 @@ const mkCtx = (pages) => ({
   await icims.enrichDate(job, { fetchText: async () => '<html>no ldjson</html>' });
   if (job.postedAt === undefined) pass('enrichDate leaves job undated when JSON-LD missing');
   else fail(`postedAt unexpectedly set: ${job.postedAt}`);
+}
+// @graph document: JobPosting node nested under @graph is still found.
+{
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: 'US' };
+  const detail = `<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"WebPage"},{"@type":"JobPosting","datePosted":"2026-07-18"}]}</script>`;
+  await icims.enrichDate(job, { fetchText: async () => detail });
+  if (job.postedAt === Date.parse('2026-07-18')) pass('enrichDate reads datePosted from an @graph JobPosting node');
+  else fail(`@graph postedAt: ${job.postedAt}`);
+}
+// Array-form JSON-LD: pick the JobPosting element, skip the non-JobPosting one.
+{
+  const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: 'US' };
+  const detail = `<script type="application/ld+json">[{"@type":"Organization","datePosted":"2026-01-01"},{"@type":"JobPosting","datePosted":"2026-07-19"}]</script>`;
+  await icims.enrichDate(job, { fetchText: async () => detail });
+  if (job.postedAt === Date.parse('2026-07-19')) pass('enrichDate picks the JobPosting node from an array');
+  else fail(`array postedAt: ${job.postedAt}`);
 }
 {
   const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: 'US' };

--- a/tests/providers/icims.test.mjs
+++ b/tests/providers/icims.test.mjs
@@ -174,3 +174,41 @@ const mkCtx = (pages) => ({
   if (job.postedAt === undefined) pass('enrichDate tolerates malformed JSON-LD without throwing');
   else fail(`postedAt unexpectedly set: ${job.postedAt}`);
 }
+
+// ── attribute ordering must not change what we extract ──────────────
+// Tenants theme their portals, so `field-label` is one token in a class list,
+// not reliably the last one. A matcher anchored on `field-label">` reads an
+// empty location off a card that plainly has one, and an empty location fails
+// location_filter — the posting is dropped with no error to explain it.
+{
+  const locCard = (cls) => `<li class="iCIMS_JobCardItem"><div class="row">
+    <div class="col-xs-6 header left"><span class="${cls}">Location</span><span >US-TX-Austin</span></div>
+    <div class="col-xs-12 title"><a href="${ORIGIN}/jobs/4242/themed-role/job" class="iCIMS_Anchor"><h3 >Themed Role</h3></a></div>
+  </div></li>`;
+  for (const cls of ['field-label', 'sr-only field-label', 'field-label sr-only', 'a field-label b']) {
+    const [j] = parseIcimsSearchPage(locCard(cls), ORIGIN, 'acmefreight');
+    if (j && j.location === 'US-TX-Austin') pass(`location extracted with class="${cls}"`);
+    else fail(`class="${cls}" → location ${JSON.stringify(j?.location)}`);
+  }
+}
+
+// Same failure mode on the detail page. A tenant running Content-Security-
+// Policy emits a nonce on every inline script, which pushes `type` off the
+// front of the tag. If the matcher requires `type` first, enrichment finds no
+// date, every posting on that board stays undated, the undated policy drops
+// them, and a working board is indistinguishable from an empty one.
+{
+  const ld = '{"@type":"JobPosting","datePosted":"2026-07-17"}';
+  const variants = {
+    'a nonce before type': `<script nonce="r4nd0m" type="application/ld+json">${ld}</script>`,
+    'an attribute after type': `<script type="application/ld+json" id="jobposting">${ld}</script>`,
+    'a single-quoted type': `<script type='application/ld+json'>${ld}</script>`,
+    'extra whitespace': `<script  type="application/ld+json" >${ld}</script>`,
+  };
+  for (const [label, detail] of Object.entries(variants)) {
+    const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: 'US' };
+    await icims.enrichDate(job, { fetchText: async () => detail });
+    if (job.postedAt === Date.parse('2026-07-17')) pass(`enrichDate reads JSON-LD with ${label}`);
+    else fail(`JSON-LD with ${label}: postedAt ${job.postedAt}`);
+  }
+}

--- a/tests/providers/icims.test.mjs
+++ b/tests/providers/icims.test.mjs
@@ -113,6 +113,31 @@ const mkCtx = (pages) => ({
   else fail(`jobs=${jobs.length} calls=${mkCtx.calls.length}`);
 }
 
+// A board that ends naturally is NOT flagged — the flag must mean "capped",
+// not "finished", or the run summary cries wolf on every healthy tenant.
+{
+  mkCtx.calls = [];
+  const ctx = mkCtx([page(mkCard(1, 'Role A')), page(mkCard(2, 'Role B'))]);
+  const jobs = await icims.fetch({ name: 'acmefreight', careers_url: `${ORIGIN}/jobs/search?ss=1` }, ctx);
+  if (jobs.icimsTruncated === undefined) pass('complete board carries no truncation flag');
+  else fail(`complete board flagged truncated (${jobs.length} jobs)`);
+}
+
+// A board deeper than the page cap is flagged instead of silently truncated:
+// every page holds distinct jobs, so neither natural stop condition fires.
+{
+  mkCtx.calls = [];
+  const deep = {};
+  for (let i = 0; i < 60; i++) deep[i] = page(mkCard(100 + i, `Role ${i}`));
+  const ctx = mkCtx(deep);
+  const jobs = await icims.fetch({ name: 'bigtenant', careers_url: `${ORIGIN}/jobs/search?ss=1` }, ctx);
+  if (jobs.icimsTruncated === true && jobs.length === mkCtx.calls.length) {
+    pass(`fetch flags truncation at the page cap (${mkCtx.calls.length} pages)`);
+  } else {
+    fail(`icimsTruncated=${jobs.icimsTruncated} jobs=${jobs.length} pages=${mkCtx.calls.length}`);
+  }
+}
+
 // ── enrichDate(): detail-page JSON-LD ───────────────────────────────
 {
   const job = { title: 'X', url: `${ORIGIN}/jobs/1234/x/job`, company: 'acmefreight', location: 'US' };

--- a/tests/scan-ats-full-resume.test.mjs
+++ b/tests/scan-ats-full-resume.test.mjs
@@ -174,3 +174,24 @@ const { loadCheckpoint, checkpointCompatible } = mod;
   if (datasetFingerprint(a) !== datasetFingerprint(['globex', 'acme', 'initech'])) pass('datasetFingerprint detects reordering');
   else fail('datasetFingerprint missed reordering');
 }
+
+// ── icims SOURCES wiring (Task 8) ───────────────────────────────────
+{
+  const { SOURCES } = mod;
+  if (!SOURCES) {
+    fail('SOURCES not exported from scan-ats-full.mjs');
+  } else if (!SOURCES.icims) {
+    fail('SOURCES.icims missing');
+  } else {
+    const good = SOURCES.icims.toEntry('acmefreight');
+    if (good && good.careers_url === 'https://careers-acmefreight.icims.com/jobs/search?ss=1&in_iframe=1' && good.name === 'acmefreight') {
+      pass('icims toEntry builds canonical portal URL');
+    } else {
+      fail(`icims toEntry: ${JSON.stringify(good)}`);
+    }
+    if (SOURCES.icims.toEntry('evil/..%2f') === null) pass('icims toEntry rejects non-slug input');
+    else fail('icims toEntry accepted a hostile slug');
+    if (SOURCES.icims.provider?.id === 'icims') pass('icims source wired to icims provider');
+    else fail('icims source provider mismatch');
+  }
+}

--- a/tests/scan-ats-full-resume.test.mjs
+++ b/tests/scan-ats-full-resume.test.mjs
@@ -1,5 +1,6 @@
 // tests/scan-ats-full-resume.test.mjs — parallelEach resume-index tracking,
 // withTimeout watchdog, and (Task 3) checkpoint compatibility rules.
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
 import { pass, fail, ROOT } from './helpers.mjs';
@@ -193,5 +194,31 @@ const { loadCheckpoint, checkpointCompatible } = mod;
     else fail('icims toEntry accepted a hostile slug');
     if (SOURCES.icims.provider?.id === 'icims') pass('icims source wired to icims provider');
     else fail('icims source provider mismatch');
+  }
+}
+
+// ── cappedBoards reaches the --json payload ─────────────────────────
+// The --json object exists so a caller can tell a *degraded* sweep apart from
+// an empty one. A page-capped board is exactly that: coverage is partial, so a
+// consumer reading postingsKept alone would mistake it for a fully-walked
+// board that simply had nothing fresh. The counter is a local in main(), so
+// this asserts on the source of the payload literal rather than a run.
+{
+  const src = readFileSync(join(ROOT, 'scan-ats-full.mjs'), 'utf-8');
+  const start = src.indexOf('if (opts.json) {');
+  const end = src.indexOf('offers: offers.map(', start);
+
+  if (start === -1 || end === -1 || end <= start) {
+    fail('could not locate the --json payload literal in scan-ats-full.mjs');
+  } else {
+    const payload = src.slice(start, end);
+    // Control arm: if the slice ever stops covering the payload, this sibling
+    // counter goes missing too and the real assertion below can't pass vacuously.
+    if (/\bunreachableBoards\b/.test(payload)) {
+      if (/\bcappedBoards\b/.test(payload)) pass('--json payload reports cappedBoards');
+      else fail('--json payload omits cappedBoards — capped coverage is invisible to consumers');
+    } else {
+      fail('--json payload slice missed unreachableBoards — the control arm broke, assertion would be vacuous');
+    }
   }
 }


### PR DESCRIPTION
# PR: Add iCIMS provider to the reverse-ATS full sweep

Implements #2137. **Stacked on #2136 / PR #2138** — split out of that PR per the
"keep the Workday freeze fix focused" review note.

> **Review order:** this branch builds on `contrib/ats-sweep-upstream` (PR #2138),
> so until #2138 merges this PR's diff also shows the five reliability commits.
> Review the **four iCIMS commits** here; the rest belong to #2138. Once #2138
> merges into `main`, this diff collapses to iCIMS only.

## What this does

Adds iCIMS as a fifth reverse-ATS source (`scan-ats-full.mjs` already handles
Greenhouse / Lever / Ashby / Workday).

- **`providers/icims.mjs`** — detect any `*.icims.com` careers URL, scrape the
  public hosted-portal search pages (title / location / posting URL), and
  paginate with two stop conditions (empty page, or a page that repeats the
  previous first URL — some tenants re-serve the last page for out-of-range
  `pr`).
- **Lazy date enrichment** — iCIMS list pages carry no posting date; the date
  lives only on the detail page's schema.org JSON-LD (`datePosted`). The
  provider exposes an `enrichDate(job, ctx)` hook that the sweep calls **only**
  for jobs that already passed the cheap title/location filters, so a
  10k-tenant sweep never pays a detail-page request for noise.
- Wired into the sweep's source list; documented in `AGENTS.md`.

## Review fixes included (from the CodeRabbit pass on #2138)

- **Relative posting hrefs** are now resolved against the portal origin before
  the same-origin check, so a tenant emitting relative `/jobs/{id}/…/job` links
  yields jobs instead of a silent empty result. Off-host links are still dropped.
- **JSON-LD `@graph` / array documents** are handled: `enrichDate` iterates all
  `ld+json` blocks and flattens array and `{"@graph":[…]}` shapes, selecting the
  `JobPosting` node's `datePosted`.
- **Per-company watchdog now covers `processJobs`** (the enrichment path):
  `fetch` **and** `processJobs` run inside one `withTimeout`, in both the
  parallel pass and the sequential retry, so per-job `enrichDate` requests can't
  accumulate latency past `COMPANY_TIMEOUT_MS`.

## Compatibility

- No new dependencies.
- Behavior change worth noting: a bare `scan-ats-full.mjs` (no `--ats`) now also
  walks the iCIMS directory, so the default sweep covers one more source.

## Testing

`tests/providers/icims.test.mjs` (fixture-driven parse, pagination stop
conditions, relative-href resolution, off-host rejection, JSON-LD
object/`@graph`/array enrichment) plus the `SOURCES.icims` wiring assertions in
`tests/scan-ats-full-resume.test.mjs`. Full suite green (the two failing tests
are a pre-existing `node:sqlite` requirement — Node ≥ 22.5 — unrelated to this
change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added iCIMS hosted-portal reverse ATS discovery, including detail-page JSON-LD date enrichment.
  - Added resumable full ATS scans with periodic checkpointing, compatibility checks, and `--resume` restart behavior (including `--json` reporting when resumed).
- **Bug Fixes**
  - Improved HTTP timeout handling so stalled response-body reads abort reliably.
  - Added clearer Workday truncation labeling for retry-exhausted pagination.
- **Documentation**
  - Updated ATS documentation to include iCIMS and clarify checkpoint cadence/resume behavior.
- **Tests**
  - Added fixtures and suites for iCIMS, resume/checkpoint logic, HTTP timeout regression, and Workday truncation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->