### PR TITLE
fix(patterns): recognize the Hired canonical status in analyze-patterns

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -80,6 +80,7 @@ const ALIASES = {
   'entrevista': 'interview',
   'oferta': 'offer',
   'rechazado': 'rejected', 'rechazada': 'rejected',
+  'contratado': 'hired', 'contratada': 'hired', 'accepted': 'hired', 'accept': 'hired',
   'descartado': 'discarded', 'descartada': 'discarded',
   'cerrada': 'discarded', 'cancelada': 'discarded',
   'no aplicar': 'skip', 'no_aplicar': 'skip', 'monitor': 'skip', 'geo blocker': 'skip',
@@ -93,11 +94,28 @@ function normalizeStatus(raw) {
 
 function classifyOutcome(status) {
   const s = normalizeStatus(status);
-  if (['interview', 'offer', 'responded', 'applied'].includes(s)) return 'positive';
+  // 'hired' is the strongest positive outcome — a landed job. It must not fall
+  // through to the 'pending' default, which would drag conversion rates down.
+  if (['hired', 'interview', 'offer', 'responded', 'applied'].includes(s)) return 'positive';
   if (['rejected', 'discarded'].includes(s)) return 'negative';
   if (['skip'].includes(s)) return 'self_filtered';
   return 'pending'; // evaluated
 }
+
+// Statuses that count as a submitted application for channel-yield analysis
+// (drop 'evaluated' = never applied, 'skip' = self-filtered). 'hired' counts —
+// a landed job was, by definition, submitted. Module-scoped so the self-test
+// can assert membership and the channel-yield pass and self-test share one set.
+const SUBMITTED_STATUSES = new Set(['applied', 'responded', 'interview', 'offer', 'hired', 'rejected', 'discarded']);
+
+// Statuses that count as "advanced past screening" — STRICTER than
+// outcome=='positive': a bare 'applied' (submitted, no reply yet) does NOT
+// count. 'hired' is the furthest advance of all.
+const ADVANCED_STATUSES = new Set(['responded', 'interview', 'offer', 'hired']);
+
+// Print order for the CONVERSION FUNNEL summary. A status absent here is
+// silently omitted from the printed funnel, so this must track states.yml.
+const FUNNEL_ORDER = ['evaluated', 'applied', 'responded', 'interview', 'offer', 'hired', 'rejected', 'discarded', 'skip'];
 
 function normalizeList(value) {
   if (Array.isArray(value)) return value.map(v => String(v).trim()).filter(Boolean);
@@ -269,7 +287,6 @@ risk_summary:
   }
 
   // Via channel analysis (#1596): agency vs direct yield, normalized buckets.
-  const advanced = new Set(['responded', 'interview', 'offer']);
   const viaRows = [
     { via: 'Hays', normalizedStatus: 'interview' },
     { via: 'HAYS ', normalizedStatus: 'rejected' },   // same bucket as Hays
@@ -281,7 +298,7 @@ risk_summary:
     { via: '—', normalizedStatus: 'rejected' },        // direct
     { via: '', normalizedStatus: 'applied' },          // no Via column → unknownVia, neither bucket
   ];
-  const viaResult = buildViaChannelAnalysis(viaRows, (e) => advanced.has(e.normalizedStatus), 2);
+  const viaResult = buildViaChannelAnalysis(viaRows, (e) => ADVANCED_STATUSES.has(e.normalizedStatus), 2);
   if (viaResult.agencySubmitted !== 6) failures.push(`via: agencySubmitted → ${viaResult.agencySubmitted}, expected 6`);
   if (viaResult.directSubmitted !== 2) failures.push(`via: directSubmitted → ${viaResult.directSubmitted}, expected 2`);
   if (viaResult.unknownVia !== 1) failures.push(`via: unknownVia → ${viaResult.unknownVia}, expected 1 (submitted row with empty Via must be counted, not silently dropped)`);
@@ -300,6 +317,22 @@ risk_summary:
   if (randstad?.sufficientSample) failures.push('via: Randstad (n=1) must be flagged as too small for a claim');
   if (buildViaChannelAnalysis([], () => false).breakdown.length !== 0) {
     failures.push('via: empty input must produce an empty breakdown');
+  }
+
+  // Hired status (canonical per states.yml; follow-up to PR #2050). A landed job
+  // is the strongest positive outcome and the furthest advance — it must not be
+  // mis-bucketed as 'pending' or dropped from channel yield / the funnel.
+  if (classifyOutcome('Hired') !== 'positive') failures.push(`hired: classifyOutcome('Hired') → ${classifyOutcome('Hired')}, expected 'positive'`);
+  if (normalizeStatus('contratado') !== 'hired') failures.push(`hired: normalizeStatus('contratado') → ${normalizeStatus('contratado')}, expected 'hired'`);
+  if (!ADVANCED_STATUSES.has('hired')) failures.push('hired: ADVANCED_STATUSES must include hired (a hire advanced past screening)');
+  if (!SUBMITTED_STATUSES.has('hired')) failures.push('hired: SUBMITTED_STATUSES must include hired (a hire was submitted)');
+  if (!FUNNEL_ORDER.includes('hired')) failures.push('hired: FUNNEL_ORDER must include hired so it prints in the funnel');
+  const hiredVia = buildViaChannelAnalysis(
+    [{ via: 'Hays', normalizedStatus: 'hired' }, { via: 'Hays', normalizedStatus: 'rejected' }],
+    (e) => ADVANCED_STATUSES.has(e.normalizedStatus), 1);
+  const hiredHays = hiredVia.breakdown.find(a => a.agency === 'Hays');
+  if (!hiredHays || hiredHays.advanced !== 1 || hiredHays.advanceRate !== 50) {
+    failures.push(`hired: must count as advanced in channel yield (1/2 = 50%) → ${JSON.stringify(hiredHays)}`);
   }
 
   if (failures.length > 0) {
@@ -702,8 +735,6 @@ function analyze() {
   //
   // "Advanced" here is STRICTER than the outcome=='positive' bucket: a bare
   // 'applied' (submitted, no reply yet) does NOT count as passing screening.
-  const ADVANCED_STATUSES = new Set(['responded', 'interview', 'offer']);
-  const SUBMITTED_STATUSES = new Set(['applied', 'responded', 'interview', 'offer', 'rejected', 'discarded']);
   const isAdvanced = (e) => ADVANCED_STATUSES.has(e.normalizedStatus);
 
   // Only applications we actually submitted count toward channel yield (drop
@@ -976,8 +1007,7 @@ function printSummary(result) {
   // Funnel
   console.log('CONVERSION FUNNEL');
   console.log('-'.repeat(40));
-  const funnelOrder = ['evaluated', 'applied', 'responded', 'interview', 'offer', 'rejected', 'discarded', 'skip'];
-  for (const status of funnelOrder) {
+  for (const status of FUNNEL_ORDER) {
     if (funnel[status]) {
       const pct = Math.round((funnel[status] / metadata.total) * 100);
       console.log(`  ${status.padEnd(15)} ${String(funnel[status]).padStart(3)} (${pct}%)`);

--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -323,7 +323,10 @@ risk_summary:
   // is the strongest positive outcome and the furthest advance — it must not be
   // mis-bucketed as 'pending' or dropped from channel yield / the funnel.
   if (classifyOutcome('Hired') !== 'positive') failures.push(`hired: classifyOutcome('Hired') → ${classifyOutcome('Hired')}, expected 'positive'`);
-  if (normalizeStatus('contratado') !== 'hired') failures.push(`hired: normalizeStatus('contratado') → ${normalizeStatus('contratado')}, expected 'hired'`);
+  // Every hired alias must resolve to 'hired' — testing only one lets the others regress silently.
+  for (const alias of ['contratado', 'contratada', 'accepted', 'accept']) {
+    if (normalizeStatus(alias) !== 'hired') failures.push(`hired: normalizeStatus('${alias}') → ${normalizeStatus(alias)}, expected 'hired'`);
+  }
   if (!ADVANCED_STATUSES.has('hired')) failures.push('hired: ADVANCED_STATUSES must include hired (a hire advanced past screening)');
   if (!SUBMITTED_STATUSES.has('hired')) failures.push('hired: SUBMITTED_STATUSES must include hired (a hire was submitted)');
   if (!FUNNEL_ORDER.includes('hired')) failures.push('hired: FUNNEL_ORDER must include hired so it prints in the funnel');


### PR DESCRIPTION
## What does this PR do?

Follow-up to #2050. That PR fixed the `Hired` status drift in `merge-tracker.mjs`
and `stats.mjs`; `analyze-patterns.mjs` had the same drift in four spots it never
touched. A `hired` row — the strongest possible outcome — was mis-bucketed
everywhere:

- **`classifyOutcome`** had no case for `hired`, so it fell to the `'pending'`
  default. Conversion rate is `positive / total`, so a hired row landed in `total`
  but not `positive` — **dragging down the conversion rate of the very
  archetype / remote-policy / company-size that landed the job.**
- **`SUBMITTED_STATUSES`** omitted `hired`, dropping a hire from channel-yield
  analysis entirely (neither numerator nor denominator).
- **`ADVANCED_STATUSES`** omitted `hired`, so the channel/agency that produced a
  hire showed a *lower* advance rate (skewing the dead-channel warning and the
  best-converting-agency pick).
- The **funnel print order** omitted `hired`, so hired rows were silently absent
  from the `--summary` conversion funnel.

Fix: treat `hired` (and its `states.yml` aliases `contratado`/`contratada`/
`accepted`/`accept`) as a positive, submitted, advanced status, and add it to the
funnel order. `ADVANCED_STATUSES` / `SUBMITTED_STATUSES` / `FUNNEL_ORDER` are
hoisted to module scope so the in-file `--self-test` can assert on them (this also
removes a duplicate `advanced` set the self-test kept). The self-test is extended
with `hired` regression assertions.

Before this fix, a tracker with a hired row printed a funnel with the hired row
missing entirely; after, it appears:
before: applied 1 · interview 1 · rejected 2 
after: applied 1 · interview 1 · hired 1 · rejected 2



## Related issue

None — bug fix, which `CONTRIBUTING.md` exempts from issue-first.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of the “hired” outcome across English and Spanish variants.
  * Updated funnel reporting and channel-yield calculations so “hired” is treated as a completed positive outcome.
  * Ensured “hired” is included in submitted/advanced status groupings and appears in the summary funnel ordering.
  * Expanded self-validation to confirm consistent hired handling end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->