### PR TITLE
fix(providers): guard decodeEntities against out-of-range code points in 4 ATS decoders

### DIFF
--- a/providers/avature.mjs
+++ b/providers/avature.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
+import { decodeEntities } from './_html-entities.mjs';
 
 // Avature provider — parses the public Avature career-site job list.
 // Auto-detects from a careers_url on `*.avature.net`; a branded custom domain
@@ -54,18 +55,6 @@ function resolveConfig(entry) {
   // e.g. /en_US/searchjobs/SearchJobs); otherwise default to the classic path.
   const searchPath = /\/SearchJobs\b/i.test(u.pathname) ? u.pathname.replace(/\/+$/, '') : '/careers/SearchJobs';
   return { searchUrl: `${u.origin}${searchPath}`, origin: u.origin };
-}
-
-const NAMED = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ', '#8226': '•' };
-/** @param {string} s */
-function decodeEntities(s) {
-  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z0-9]+);/g, (m, body) => {
-    if (body[0] === '#') {
-      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
-      return Number.isFinite(code) ? String.fromCodePoint(code) : m;
-    }
-    return NAMED[body.toLowerCase()] ?? m;
-  });
 }
 
 /** @param {string} s */

--- a/providers/dassault.mjs
+++ b/providers/dassault.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
+import { decodeEntities } from './_html-entities.mjs';
 
 // Dassault Systèmes provider — hits the public Exalead "card search" API that
 // powers www.3ds.com/careers/jobs. Single-company provider (like ibm.mjs): the
@@ -42,20 +43,6 @@ export function buildUrl(start) {
   for (const r of REFINES) p.append('r', r);
   p.set('start', String(start));
   return `${BASE}?${p.toString()}`;
-}
-
-// Minimal HTML entity decoder — titles/URLs/locations carry named (&amp;, &apos;)
-// and numeric (&#252; / &#xfc;) entities. Mirrors successfactors.mjs.
-const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
-/** @param {string} s */
-function decodeEntities(s) {
-  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
-    if (body[0] === '#') {
-      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
-      return Number.isFinite(code) ? String.fromCodePoint(code) : m;
-    }
-    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
-  });
 }
 
 // Pull every <Meta name="X"><MetaString name="value">V</MetaString> pair from one

--- a/providers/rheinmetall.mjs
+++ b/providers/rheinmetall.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
+import { decodeEntities } from './_html-entities.mjs';
 
 // Rheinmetall provider — single-company (like ibm.mjs / dassault.mjs). The
 // public vacancy list at https://www.rheinmetall.com/{lang}/career/vacancies is
@@ -27,20 +28,6 @@
 const MAX_PAGES = 150; // safety cap (~1350 postings at 10/page); tune via entry.max_pages
 const MAX_JOBS = 1500; // cap total postings pulled
 const PAGE_DELAY_MS = 150; // polite pacing — full walks are >100 sequential requests
-
-// Minimal HTML entity decoder — titles carry named (&amp;) and numeric
-// (&#252; / &#xfc;) entities. Mirrors successfactors.mjs / dassault.mjs.
-const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
-/** @param {string} s */
-function decodeEntities(s) {
-  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
-    if (body[0] === '#') {
-      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
-      return Number.isFinite(code) ? String.fromCodePoint(code) : m;
-    }
-    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
-  });
-}
 
 /** @param {string} s */
 function clean(s) {

--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
+import { decodeEntities } from './_html-entities.mjs';
 
 // SAP SuccessFactors provider — Recruiting Marketing (RMK, ex-jobs2web) career
 // sites (Career Site Builder's branded job boards). These are the portals big
@@ -104,21 +105,6 @@ export function resolveConfig(entry) {
     jobsApi: `${base}/services/recruiting/v1/jobs`,
     searchPage: `${base}/search/`,
   };
-}
-
-// Minimal HTML entity decoder — titles carry named (&amp;) and numeric
-// (&#252; / &#xfc;) entities. We only need the handful that show up in job
-// titles; anything else is left as-is.
-const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
-/** @param {string} s */
-function decodeEntities(s) {
-  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
-    if (body[0] === '#') {
-      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
-      return Number.isFinite(code) ? String.fromCodePoint(code) : m;
-    }
-    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
-  });
 }
 
 /** @param {string} s */

--- a/tests/providers/avature.test.mjs
+++ b/tests/providers/avature.test.mjs
@@ -166,6 +166,26 @@ try {
   const emptyHealed = await avature.fetch({ name: 'X', api: base }, emptyP1Ctx);
   if (emptyHealed.length === 14 && emptyP1Ctx.calls.some((u) => /[?&]offset=/.test(u))) pass('avature.fetch() self-heals when the inert key returns an empty page 1');
   else fail(`avature.fetch() failed to heal empty page 1: ${emptyHealed.length} jobs`);
+
+  // Regression (#1639 lineage) — a numeric entity above U+10FFFF must not throw
+  // RangeError out of the whole parse. The local decodeEntities copy guarded
+  // only with Number.isFinite (no `<= 0x10FFFF` / surrogate check), so ONE
+  // adversarial/malformed entity (&#99999999;, &#xFFFFFFFF;) crashed the entire
+  // provider parse and scan.mjs's per-company catch dropped EVERY posting for
+  // that run. parseArticles now routes through the shared guarded decoder, which
+  // degrades an out-of-range or lone-surrogate entity to literal text while
+  // still decoding valid ones (&amp;).
+  {
+    const badFrag = `
+    <article class="article article--result" id="article--bad">
+      <h3 class="title"><a class="link" href="https://acme.avature.net/careers/JobDetail/Bad-Entity-Role/778899">Overflow &#99999999; &amp; Hex &#xFFFFFFFF; Surrogate &#xD800;</a></h3>
+    </article>`;
+    let badArts, badThrew = null;
+    try { badArts = parseArticles(badFrag, origin); } catch (e) { badThrew = e; }
+    if (badThrew) fail(`avature.parseArticles() threw ${badThrew.name} on an out-of-range numeric entity (unguarded String.fromCodePoint): ${badThrew.message}`);
+    else if (badArts.length === 1 && badArts[0].title === 'Overflow &#99999999; & Hex &#xFFFFFFFF; Surrogate &#xD800;') pass('avature.parseArticles() tolerates out-of-range / surrogate entities, degrading them to literal text while still decoding &amp; (no RangeError crash)');
+    else fail(`avature.parseArticles() out-of-range entity wrong: ${JSON.stringify(badArts)}`);
+  }
 } catch (e) {
   fail(`avature provider tests crashed: ${e.message}`);
 }

--- a/tests/providers/dassault.test.mjs
+++ b/tests/providers/dassault.test.mjs
@@ -124,6 +124,29 @@ try {
   if (fetched.every(j => !('_id' in j))) pass('dassault.fetch() strips the internal _id from returned jobs');
   else fail('dassault.fetch() leaked _id into returned jobs');
 
+  // Regression (#1639 lineage) — a numeric entity above U+10FFFF must not throw
+  // RangeError out of the whole parse. The local decodeEntities copy guarded
+  // only with Number.isFinite (no `<= 0x10FFFF` / surrogate check), so ONE
+  // adversarial/malformed entity (&#99999999;, &#xFFFFFFFF;) crashed the entire
+  // provider parse and scan.mjs's per-company catch dropped EVERY posting for
+  // that run. parseHits now routes through the shared guarded decoder, which
+  // degrades an out-of-range or lone-surrogate entity to literal text while
+  // still decoding valid ones (&amp;).
+  {
+    const xmlBad = `<Answer><hits>` +
+      mkHit({ id: 'bad1', title: 'Overflow &#99999999; &amp; Hex &#xFFFFFFFF; Surrogate &#xD800;', cta1: 'https://www.3ds.com/careers/jobs/bad-1' }) +
+      mkHit({ id: 'ok1', title: 'Normal Role', cta1: 'https://www.3ds.com/careers/jobs/ok-1' }) +
+      `</hits></Answer>`;
+    let bad, badThrew = null;
+    try { bad = parseHits(xmlBad, 'Dassault Systèmes'); } catch (e) { badThrew = e; }
+    if (badThrew) fail(`dassault.parseHits() threw ${badThrew.name} on an out-of-range numeric entity (unguarded String.fromCodePoint): ${badThrew.message}`);
+    else if (bad.length === 2) pass('dassault.parseHits() tolerates out-of-range / surrogate numeric entities (no RangeError crash)');
+    else fail(`dassault.parseHits() out-of-range entity: expected 2 jobs, got ${bad.length}`);
+    const bj = badThrew ? null : bad.find((j) => j.url.endsWith('/bad-1'));
+    if (bj && bj.title === 'Overflow &#99999999; & Hex &#xFFFFFFFF; Surrogate &#xD800;') pass('dassault.parseHits() degrades bad entities to literal text while still decoding &amp;');
+    else if (!badThrew) fail(`dassault.parseHits() degraded title wrong: ${JSON.stringify(bj && bj.title)}`);
+  }
+
 } catch (e) {
   fail(`dassault provider tests crashed: ${e.message}`);
 }

--- a/tests/providers/rheinmetall.test.mjs
+++ b/tests/providers/rheinmetall.test.mjs
@@ -57,6 +57,23 @@ try {
   else fail(`rheinmetall.fetch() returned ${rhmJobs.length} jobs after ${rhmCalls} calls`);
   if (rhmSeen[0]?.endsWith('?page=1') && rhmSeen[1]?.endsWith('?page=2')) pass('rheinmetall.fetch() pages via ?page=N (1-based)');
   else fail(`rheinmetall.fetch() paged wrong: ${JSON.stringify(rhmSeen)}`);
+
+  // Regression (#1639 lineage) — a numeric entity above U+10FFFF must not throw
+  // RangeError out of the whole parse. The local decodeEntities copy guarded
+  // only with Number.isFinite (no `<= 0x10FFFF` / surrogate check), so ONE
+  // adversarial/malformed entity (&#99999999;, &#xFFFFFFFF;) crashed the entire
+  // provider parse and scan.mjs's per-company catch dropped EVERY posting for
+  // that run. parseVacancies now routes through the shared guarded decoder, which
+  // degrades an out-of-range or lone-surrogate entity to literal text while
+  // still decoding valid ones (&amp;).
+  {
+    const badPage = '<html>' + card('9001', 'Overflow &#99999999; &amp; Hex &#xFFFFFFFF; Surrogate &#xD800;', 'Rheinmetall AG | Kassel') + '</html>';
+    let badRows, badThrew = null;
+    try { badRows = parseVacancies(badPage, 'https://www.rheinmetall.com'); } catch (e) { badThrew = e; }
+    if (badThrew) fail(`rheinmetall.parseVacancies() threw ${badThrew.name} on an out-of-range numeric entity (unguarded String.fromCodePoint): ${badThrew.message}`);
+    else if (badRows.length === 1 && badRows[0].title === 'Overflow &#99999999; & Hex &#xFFFFFFFF; Surrogate &#xD800;') pass('rheinmetall.parseVacancies() tolerates out-of-range / surrogate entities, degrading them to literal text while still decoding &amp; (no RangeError crash)');
+    else fail(`rheinmetall.parseVacancies() out-of-range entity wrong: ${JSON.stringify(badRows)}`);
+  }
 } catch (e) {
   fail(`rheinmetall provider tests crashed: ${e.message}`);
 }

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -234,6 +234,27 @@ try {
   } else {
     fail(`parseCsbJobs did not honor cfg.base: ${JSON.stringify(csbBrandJobs[0]?.url)}`);
   }
+
+  // Regression (#1639 lineage) — a numeric entity above U+10FFFF must not throw
+  // RangeError out of the whole parse. The local decodeEntities copy guarded
+  // only with Number.isFinite (no `<= 0x10FFFF` / surrogate check), so ONE
+  // adversarial/malformed entity (&#99999999;, &#xFFFFFFFF;) crashed the entire
+  // provider parse and scan.mjs's per-company catch dropped EVERY posting for
+  // that run. parseTiles now routes through the shared guarded decoder, which
+  // degrades an out-of-range or lone-surrogate entity to literal text while
+  // still decoding valid ones (&amp;).
+  {
+    const badFrag2 = `<ul>
+      <li class="job-tile job-id-9001" data-url="/job/City-Bad-Entity/9001/">
+        <a class="jobTitle-link fontcolorx" href="/x">Overflow &#99999999; &amp; Hex &#xFFFFFFFF; Surrogate &#xD800;</a>
+      </li>
+    </ul>`;
+    let badTiles, badThrew = null;
+    try { badTiles = parseTiles(badFrag2, 'https://jobs.example.com'); } catch (e) { badThrew = e; }
+    if (badThrew) fail(`successfactors.parseTiles() threw ${badThrew.name} on an out-of-range numeric entity (unguarded String.fromCodePoint): ${badThrew.message}`);
+    else if (badTiles.length === 1 && badTiles[0].title === 'Overflow &#99999999; & Hex &#xFFFFFFFF; Surrogate &#xD800;') pass('successfactors.parseTiles() tolerates out-of-range / surrogate entities, degrading them to literal text while still decoding &amp; (no RangeError crash)');
+    else fail(`successfactors.parseTiles() out-of-range entity wrong: ${JSON.stringify(badTiles)}`);
+  }
 } catch (err) {
   fail(`successfactors provider test threw: ${err.message}`);
 }


### PR DESCRIPTION
Fixes #2146.

`dassault`, `avature`, `rheinmetall`, and `successfactors` each carried a local `decodeEntities` whose numeric path was `Number.isFinite(code) ? String.fromCodePoint(code) : m`. `String.fromCodePoint` throws `RangeError` for a code point above `0x10FFFF` (e.g. `&#99999999;`), and because the decode runs in a bare parse loop, one malformed entity throws out of the whole provider parse — `scan.mjs`'s per-company `catch` then drops every posting for that company in the run.

This swaps the four local copies for the already-correct shared `decodeEntities` from `providers/_html-entities.mjs` (which guards `code >= 0 && code <= 0x10ffff` and lone surrogates), matching the five providers that already import it.

- Verified real-entity equivalence across a 23-input battery — no well-formed entity the old code decoded correctly changes.
- Bonus: the shared helper additionally decodes valid uppercase-`X` hex refs (`&#XFC;` → `ü`) that the old copies left literal — a strict improvement, not a regression.
- Per-provider regression tests feed `&#99999999;` / `&#xFFFFFFFF;` / `&#xD800;` and assert the decoder returns without throwing (entity degraded to literal), plus a control that a normal entity still decodes.

`node test-all.mjs --quick`: 2049 passed, 0 failed.

Same bug class as the central fix behind #1639, which never landed in these four.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job and vacancy parsing when malformed HTML character references are encountered.
  * Prevented crashes caused by invalid, oversized, or unsupported numeric entities.
  * Preserved valid entity decoding while displaying invalid entities as literal text.

* **Tests**
  * Added regression coverage across multiple job-provider parsers for malformed character references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->