### PR TITLE
fix(match-star): tokenize tag matches so short tokens do not substring-collide

### DIFF
--- a/match-star.mjs
+++ b/match-star.mjs
@@ -117,10 +117,12 @@ function score(story, queryTokens, jdTokens) {
   const signal = queryTokens.filter(t => !STOPWORDS.has(t));
   let s = 0;
 
-  // Tag match: highest weight (tags are explicit "best for" labels)
-  const tagText = story.tags.join(' ');
+  // Tag match: highest weight (tags are explicit "best for" labels).
+  // Tokenized exact membership (mirrors the JD-boost path below) so short query
+  // tokens (ai, ml, go, qa…) can't spuriously collide inside longer tag words.
+  const tagTokens = new Set(story.tags.flatMap(tokenize));
   for (const token of signal) {
-    if (tagText.includes(token)) s += 3;
+    if (tagTokens.has(token)) s += 3;
   }
 
   // Title/theme match

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8203,6 +8203,25 @@ try {
     fail(`match-star scorer: tag-exact match score too low (got ${tagExactScores[1]})`);
   }
 
+  // Regression: tag scoring must use tokenized exact membership, not a substring
+  // test — otherwise short query tokens (ai, ml, go, qa…) spuriously collide
+  // inside longer tag WORDS (token "ai" inside "maintainability") for a false +3,
+  // inflating irrelevant stories above genuinely relevant ones.
+  // With empty title/theme/action/result and no JD, total score == the tag bonus.
+  const mkTagStory = (tags) => ({ tags, title: '', theme: '', action: '', result: '' });
+  const aiVsMaintainability = score(mkTagStory(['maintainability']), tokenize('ai'), []);
+  if (aiVsMaintainability === 0) {
+    pass('match-star scorer: short token "ai" does not substring-match tag "maintainability" (bonus 0)');
+  } else {
+    fail(`match-star scorer: token "ai" spuriously matched tag "maintainability" (expected 0, got ${aiVsMaintainability})`);
+  }
+  const leadershipExactTag = score(mkTagStory(['leadership']), tokenize('leadership'), []);
+  if (leadershipExactTag === 3) {
+    pass('match-star scorer: exact tag token "leadership" still scores +3 after tokenized fix');
+  } else {
+    fail(`match-star scorer: exact tag match regressed (expected 3, got ${leadershipExactTag})`);
+  }
+
   // match-star.mjs file must exist (existsSync-guarded in the script itself)
   if (existsSync(join(ROOT, 'match-star.mjs'))) {
     pass('match-star.mjs: file present in repo root');


### PR DESCRIPTION
Fixes #2149.

The tag-scoring path substring-matched query tokens against the space-joined tag string, so `ai` / `maintainability` and `go` / `algorithm` earned a false +3 — inflating irrelevant STAR stories above genuinely relevant ones. Switched to `new Set(story.tags.flatMap(tokenize))` + `.has(token)` — same weight, same loop, consistent with the title / body / JD-boost paths already in the file.

Regression test proves `ai` vs tag `maintainability` scores 0 (was 3) while exact `leadership` still scores 3. `node test-all.mjs --quick`: 2046 passed, 0 failed.

Note: this intentionally stops partial-word tag matches (e.g. token `learn` no longer matches tag `learning` via the tag path), making the tag path consistent with the already-exact title / body / JD scorers.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved STAR-story tag matching to recognize only complete, exact tag words.
  * Prevented partial matches from incorrectly increasing relevance scores.

* **Tests**
  * Added coverage confirming partial-token matches are excluded while exact tag matches continue to receive the correct score.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->