### PR TITLE
Cache DNS lookups in-process to stop scanner resolver floods

### DIFF
--- a/providers/_dns-cache.mjs
+++ b/providers/_dns-cache.mjs
@@ -1,0 +1,133 @@
+// @ts-check
+/**
+ * _dns-cache.mjs — in-process DNS memoization for the scanners.
+ *
+ * Node's `fetch()` resolves the hostname once per *connection* it opens, and
+ * keeps no DNS cache of its own. Sequential requests are cheap — undici's
+ * keep-alive reuses the socket — but the sweeps run their requests in
+ * parallel, and every concurrent connection resolves independently. Measured
+ * against a local server (30 requests to one hostname):
+ *
+ *     sequential           2 lookups
+ *     30 in parallel      29 lookups   <-- one per connection
+ *
+ * Scaled across a full directory sweep that reached ~37k lookups for a single
+ * hostname in one run. On a host whose resolver rate-limits per client (a
+ * Pi-hole's default is 1000/min) that trips the limit and breaks DNS for the
+ * whole machine, not just the scan.
+ *
+ * Because the driver is concurrency rather than request count, coalescing
+ * in-flight misses is the load-bearing part of this file — a plain TTL cache
+ * would still let a cold parallel burst through. With both, the 29 above
+ * becomes 1.
+ *
+ * Why patch `dns.lookup` rather than configure the HTTP client: career-ops
+ * depends on no HTTP library — providers call the global `fetch()`. Node
+ * exposes no supported way to give `fetch()` a custom resolver without
+ * taking on `undici` as a direct dependency to build an `Agent` with a
+ * `connect.lookup` option. Patching the `node:dns` module object keeps the
+ * dependency list untouched: `net.connect` reads `dns.lookup` at call time,
+ * so importing this file once (`_http.mjs` does) covers every provider and
+ * every direct `fetch()` in the process.
+ *
+ * Scope of the patch — deliberately narrow:
+ *   - Only the callback-style `dns.lookup` on the `node:dns` module object.
+ *   - `dns/promises` has its own independent `lookup` and is NOT affected.
+ *     That matters: the SSRF egress guard in `upskill.mjs` resolves through
+ *     `dns/promises` (`dns.resolve` + `dns.promises.lookup`), so its
+ *     validation still hits the resolver every time and cannot be poisoned
+ *     by this cache. Verify with:
+ *       node -e "const d=require('dns'),p=require('dns/promises');let n=0; \
+ *         const r=d.lookup; d.lookup=(...a)=>{n++;return r(...a)}; \
+ *         p.lookup('example.com').then(()=>console.log('promises hit patch:',n>0))"
+ *   - Failed resolutions are never cached, so an outage cannot be pinned in.
+ *
+ * Opt out entirely with `CAREER_OPS_NO_DNS_CACHE=1`.
+ */
+
+import dns from 'node:dns';
+
+const DEFAULT_TTL_MS = 5 * 60_000;
+const DEFAULT_MAX_ENTRIES = 512;
+
+/**
+ * Build a caching wrapper around a callback-style `dns.lookup`.
+ *
+ * Exported for the test suite, which drives it with a stub resolver so the
+ * cache semantics can be asserted without touching the network.
+ *
+ * @param {Function} realLookup - The underlying `dns.lookup` to memoize.
+ * @param {object} [options] - Cache tuning.
+ * @param {number} [options.ttlMs] - How long a successful result stays fresh.
+ * @param {number} [options.maxEntries] - Cap on distinct cached keys.
+ * @param {() => number} [options.now] - Clock source, injectable for tests.
+ * @returns {Function} A drop-in replacement for `dns.lookup`.
+ */
+export function createCachedLookup(realLookup, options = {}) {
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  const now = options.now ?? Date.now;
+
+  /** @type {Map<string, { expires: number, args: any[] }>} */
+  const cache = new Map();
+  /** @type {Map<string, Function[]>} */
+  const inflight = new Map();
+
+  function cachedLookup(hostname, options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+    // dns.lookup accepts a bare family number in place of an options object.
+    const opts = typeof options === 'number' ? { family: options } : (options ?? {});
+    const key = `${hostname}|${opts.family ?? 0}|${opts.all ? 1 : 0}|${opts.hints ?? 0}|${opts.verbatim ?? ''}`;
+
+    const hit = cache.get(key);
+    if (hit && hit.expires > now()) {
+      // Stay asynchronous on a hit: callers (net.connect among them) assume
+      // the callback never fires before lookup() returns.
+      process.nextTick(callback, ...hit.args);
+      return;
+    }
+
+    // Coalesce concurrent misses. Without this the cache is useless against
+    // the burst it exists to stop: a sweep opens its workers in parallel, so
+    // on a cold key every one of them would miss and hit the resolver before
+    // the first result lands.
+    const waiting = inflight.get(key);
+    if (waiting) {
+      waiting.push(callback);
+      return;
+    }
+    inflight.set(key, [callback]);
+
+    realLookup(hostname, opts, (err, ...rest) => {
+      const callbacks = inflight.get(key) ?? [];
+      inflight.delete(key);
+
+      // Never cache failures — a transient resolver blip must not be pinned
+      // in for the whole TTL window.
+      if (!err) {
+        // Oldest-first eviction; insertion order is good enough for a cap
+        // this size, and avoids tracking per-entry access times.
+        if (cache.size >= maxEntries) cache.delete(cache.keys().next().value);
+        cache.set(key, { expires: now() + ttlMs, args: [null, ...rest] });
+      }
+
+      for (const cb of callbacks) cb(err, ...rest);
+    });
+  }
+
+  // dns.lookup carries an internal symbol telling util.promisify which
+  // callback arguments to collect. Copy it across or promisify(dns.lookup)
+  // silently starts yielding only the address, dropping the family.
+  for (const sym of Object.getOwnPropertySymbols(realLookup)) {
+    cachedLookup[sym] = realLookup[sym];
+  }
+
+  return cachedLookup;
+}
+
+if (process.env.CAREER_OPS_NO_DNS_CACHE !== '1') {
+  dns.lookup = createCachedLookup(dns.lookup);
+}

--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -1,6 +1,8 @@
 // HTTP transport helpers shared across providers.
 // Files prefixed with _ are never loaded as providers by scan.mjs.
 
+import './_dns-cache.mjs'; // memoize dns.lookup process-wide (see that file)
+
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_USER_AGENT = 'Mozilla/5.0 (compatible; career-ops/1.3)';
 

--- a/tests/providers/dns-cache.test.mjs
+++ b/tests/providers/dns-cache.test.mjs
@@ -1,0 +1,172 @@
+// tests/providers/dns-cache.test.mjs — cache semantics for providers/_dns-cache.mjs.
+// Driven with a stub resolver: no network, no real DNS, deterministic clock.
+import { pass, fail, run, NODE, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — DNS cache');
+
+try {
+  const { createCachedLookup } = await import(
+    pathToFileURL(join(ROOT, 'providers/_dns-cache.mjs')).href
+  );
+
+  /**
+   * Stub resolver that records calls and resolves on demand, so a test can
+   * hold several lookups open at once and observe coalescing.
+   */
+  const mkResolver = (result = [null, '93.184.216.34', 4]) => {
+    const calls = [];
+    const resolver = (hostname, opts, cb) => {
+      calls.push({ hostname, opts, cb });
+    };
+    resolver.calls = calls;
+    resolver.flush = () => { for (const c of calls.splice(0)) c.cb(...result); };
+    return resolver;
+  };
+
+  const lookupOnce = (fn, hostname, opts = {}) =>
+    new Promise((resolve) => fn(hostname, opts, (...args) => resolve(args)));
+
+  /**
+   * Bound a wait so a dropped callback fails the assertion instead of hanging
+   * the suite: an implementation that loses queued callbacks would otherwise
+   * leave the process waiting forever with no output at all.
+   */
+  const within = (ms, promise) => {
+    let timer;
+    // The timer must NOT be unref'd: dropped callbacks leave nothing else
+    // holding the event loop open, and an unref'd timer would let the process
+    // exit silently instead of reporting the failure. Cleared on the winning
+    // path so a passing run doesn't sit here for the full timeout.
+    return Promise.race([
+      promise.finally(() => clearTimeout(timer)),
+      new Promise((resolve) => { timer = setTimeout(() => resolve('TIMED_OUT'), ms); }),
+    ]);
+  };
+
+  // --- a repeat lookup is served from cache ---
+  {
+    const resolver = mkResolver();
+    const lookup = createCachedLookup(resolver);
+
+    const first = lookupOnce(lookup, 'example.com');
+    resolver.flush();
+    await first;
+
+    const second = await lookupOnce(lookup, 'example.com');
+    if (resolver.calls.length === 0 && second[1] === '93.184.216.34') {
+      pass('repeat lookup is served from cache without a second resolver call');
+    } else {
+      fail(`repeat lookup hit the resolver ${resolver.calls.length} extra time(s)`);
+    }
+  }
+
+  // --- concurrent misses coalesce into one resolver call ---
+  {
+    const resolver = mkResolver();
+    const lookup = createCachedLookup(resolver);
+
+    const pending = Array.from({ length: 20 }, () => lookupOnce(lookup, 'burst.example.com'));
+    const callsDuringBurst = resolver.calls.length;
+    resolver.flush();
+    const settled = await within(2_000, Promise.all(pending));
+
+    if (settled === 'TIMED_OUT') {
+      fail('20 concurrent misses: not every queued callback fired (waiters dropped)');
+    } else if (callsDuringBurst === 1 && settled.every((r) => r[1] === '93.184.216.34')) {
+      pass('20 concurrent misses coalesce into 1 resolver call, all callbacks fire');
+    } else {
+      fail(`20 concurrent misses produced ${callsDuringBurst} resolver call(s)`);
+    }
+  }
+
+  // --- failures are never cached ---
+  {
+    const err = Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' });
+    const resolver = mkResolver([err]);
+    const lookup = createCachedLookup(resolver);
+
+    const first = lookupOnce(lookup, 'broken.example.com');
+    resolver.flush();
+    const [firstErr] = await first;
+
+    const second = lookupOnce(lookup, 'broken.example.com');
+    const retried = resolver.calls.length === 1;
+    resolver.flush();
+    await second;
+
+    if (firstErr && firstErr.code === 'ENOTFOUND' && retried) {
+      pass('a failed resolution is not cached — the next call retries the resolver');
+    } else {
+      fail(`failure caching wrong: err=${firstErr && firstErr.code} retried=${retried}`);
+    }
+  }
+
+  // --- entries expire at the TTL boundary ---
+  {
+    const resolver = mkResolver();
+    let clock = 1_000;
+    const lookup = createCachedLookup(resolver, { ttlMs: 5_000, now: () => clock });
+
+    const first = lookupOnce(lookup, 'ttl.example.com');
+    resolver.flush();
+    await first;
+
+    clock += 4_999;                       // still inside the window
+    const fresh = lookupOnce(lookup, 'ttl.example.com');
+    const servedFromCache = resolver.calls.length === 0;
+    await fresh;
+
+    clock += 2;                           // now past expiry
+    lookupOnce(lookup, 'ttl.example.com');
+    const refetched = resolver.calls.length === 1;
+    resolver.flush();
+
+    if (servedFromCache && refetched) {
+      pass('cache honors the TTL boundary — fresh inside it, re-resolves past it');
+    } else {
+      fail(`TTL wrong: servedFromCache=${servedFromCache} refetched=${refetched}`);
+    }
+  }
+
+  // --- distinct option shapes do not collide ---
+  {
+    const resolver = mkResolver();
+    const lookup = createCachedLookup(resolver);
+
+    lookupOnce(lookup, 'opts.example.com', { family: 4 });
+    lookupOnce(lookup, 'opts.example.com', { family: 6 });
+    lookupOnce(lookup, 'opts.example.com', { all: true });
+
+    if (resolver.calls.length === 3) {
+      pass('family/all variants are cached under distinct keys');
+    } else {
+      fail(`option variants collapsed into ${resolver.calls.length} key(s), expected 3`);
+    }
+    resolver.flush();
+  }
+
+  // --- the module-level patch is opt-out-able ---
+  {
+    const probe = [
+      'import dns from "node:dns";',
+      'const before = dns.lookup;',
+      'await import("./providers/_dns-cache.mjs");',
+      'console.log(dns.lookup === before ? "UNPATCHED" : "PATCHED");',
+    ].join('');
+
+    const patched = run(NODE, ['--input-type=module', '-e', probe]);
+    const optedOut = run(NODE, ['--input-type=module', '-e', probe], {
+      env: { ...process.env, CAREER_OPS_NO_DNS_CACHE: '1' },
+    });
+
+    if (patched === 'PATCHED' && optedOut === 'UNPATCHED') {
+      pass('importing the module patches dns.lookup; CAREER_OPS_NO_DNS_CACHE=1 opts out');
+    } else {
+      fail(`patch toggle wrong: default=${patched} optedOut=${optedOut}`);
+    }
+  }
+} catch (e) {
+  fail(`DNS cache tests threw: ${e.message}`);
+}


### PR DESCRIPTION
# PR: Cache DNS lookups in-process to stop scanner resolver floods

Implements #2154. Independent of #2138 / #2141 — this branch is cut from `main` and touches a different part of `_http.mjs` (the import block, not `fetchWithTimeout`), so it merges cleanly in any order.

## The problem

Node's `fetch()` resolves a hostname once per **connection**, not per request, and keeps no DNS cache of its own. Sequential traffic is therefore already fine — undici's keep-alive reuses the socket. The sweeps, though, open their connections in parallel, and every concurrent connection resolves independently.

Measured against a local server, 30 requests to one hostname on current `main`:

```
30 sequential ->  2 lookups
30 parallel   -> 29 lookups   <-- one per connection
```

Scaled across a full `scan-ats-full.mjs` run that reached **~37k identical lookups for a single hostname**. On a host whose resolver rate-limits per client (a Pi-hole's default is 1000/min) it trips the limit and breaks DNS for the whole machine — which then surfaces as a wave of `ENOTFOUND`/`EAI_AGAIN` errors that look like the boards failing rather than a local problem. The exact repro script is in #2154.

## The fix

`providers/_dns-cache.mjs` memoizes `dns.lookup` with a 5-minute TTL, imported once from `_http.mjs` so every provider and every direct `fetch()` in the process is covered. The 30-parallel case drops from **29 lookups to 1**.

**Coalescing concurrent misses is the load-bearing part, not the TTL.** Since the driver is concurrency rather than request count, a plain TTL cache would still let a cold parallel burst straight through to the resolver — exactly the traffic shape that trips the limiter. The first miss on a key registers; the rest queue behind it and are served the single result.

Other behaviour:
- **Failures are never cached** — a transient resolver blip can't be pinned in for the TTL window.
- **`CAREER_OPS_NO_DNS_CACHE=1`** disables the patch entirely.
- Cache hits still call back on `process.nextTick`, so the async contract `net.connect` relies on is preserved.
- `realLookup`'s own symbols are copied across, or `promisify(dns.lookup)` would silently start dropping the `family` argument.
- Oldest-first eviction at 512 entries.

## Two things you'll want to check first

**1. Why patch `node:dns` instead of configuring the HTTP client.** career-ops depends on no HTTP library — providers call the global `fetch()`. Node exposes no supported way to hand `fetch()` a custom resolver without adding `undici` as a direct dependency to build an `Agent` with a `connect.lookup` option. Patching the `node:dns` module object keeps `package.json` untouched, since `net.connect` reads `dns.lookup` at call time. If you'd rather take the `undici` dependency and do it through a dispatcher, say so and I'll rewrite it that way.

**2. It does not weaken the SSRF egress guard.** `upskill.mjs`'s `validateUrlSecurity()` resolves through `dns/promises` (`dns.resolve` + `dns.promises.lookup`). `dns/promises` has its own independent `lookup` that does **not** route through the patched `dns.lookup`, so that guard still hits the resolver on every check and cannot be poisoned by this cache:

```bash
node -e "const d=require('dns'),p=require('dns/promises');let n=0;
  const r=d.lookup; d.lookup=(...a)=>{n++;return r(...a)};
  p.lookup('example.com').then(()=>console.log('promises hit patch:', n>0))"
# -> promises hit patch: false
```

The patch is also confined to the callback-style `dns.lookup` — nothing else on the module object is touched.

## Tests

`tests/providers/dns-cache.test.mjs`, 6 assertions, driven by a stub resolver with an injected clock — no network, no real DNS, deterministic:

- repeat lookup served from cache
- 20 concurrent misses coalesce into 1 resolver call, all 20 callbacks fire
- failed resolution is not cached, next call retries
- TTL boundary honored (fresh at `ttl-1`, re-resolves at `ttl+1`)
- `family`/`all` variants cached under distinct keys
- import patches `dns.lookup`; `CAREER_OPS_NO_DNS_CACHE=1` opts out

Each was mutation-checked — coalescing disabled, failure-caching inverted, TTL pinned open — and each mutation fails the corresponding assertion. The concurrency test carries a bounded outer timeout (not `unref`'d, cleared on the winning path) so an implementation that drops queued callbacks fails loudly instead of hanging the suite with no output.

`node test-all.mjs --quick`: **2041 passed, 2 failed**. Both failures (`tracker-columns-tests.mjs`, `tracker-writer-lock-tests.mjs`) reproduce identically on a clean `main` worktree at the same commit — they're pre-existing here and unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced repeated DNS lookups during concurrent operations through in-process caching.
  * Reuses ongoing lookups for identical requests and automatically expires cached results.
  * Failed lookups are retried instead of being stored.

* **Reliability**
  * Preserves expected callback behavior for cached responses.
  * Supports disabling DNS caching when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->