### PR TITLE
fix(web): detect OpenCode default install path

### DIFF
--- a/web/src/lib/clis.ts
+++ b/web/src/lib/clis.ts
@@ -28,6 +28,7 @@ function searchDirs(): string[] {
   const home = os.homedir();
   const extra = [
     path.join(home, ".local/bin"),
+    path.join(home, ".opencode", "bin"),
     path.join(home, ".npm-global/bin"),
     path.join(home, ".bun/bin"),
     path.join(home, ".deno/bin"),


### PR DESCRIPTION
## Summary

Add the default OpenCode installation directory (`~/.opencode/bin`) to the web UI's CLI search paths.

Fixes #1793

## Validation

- Web tests: 19 passed, 0 failed
- TypeScript typecheck passed
- Next.js production build passed
- Full test suite: 2045 passed, 0 failed
- Verified with OpenCode 1.18.4 installed at `/root/.opencode/bin/opencode` in a Linux Docker container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI detection now also checks the user’s `~/.opencode/bin` directory, improving discovery of installed command-line tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->