### PR TITLE
fix(scan): resolve PORTAL_HEALTH_PATH from cwd, not script dir

### DIFF
--- a/portal-health-lock.mjs
+++ b/portal-health-lock.mjs
@@ -32,6 +32,19 @@ const DEFAULT_STALE_MS = 30_000;
 const DEFAULT_RETRY_MS = 80;
 const DEFAULT_TIMEOUT_MS = 8_000;
 
+// Two directories are ownerless by construction, not by accident: a lock
+// between its mkdir and its owner.json write, and the recover guard, which
+// never carries owner.json at all. Judging those on `age > staleMs` alone lets
+// a caller with an aggressive staleMs delete a directory created microseconds
+// ago — either stealing a winner's lock inside its acquisition window, or
+// evicting a live guard and putting two callers inside the decide-then-delete
+// window the guard exists to serialize.
+//
+// This is a lower bound on patience, never a cap: a larger caller staleMs
+// still wins, and a genuinely abandoned directory still ages out, so a crash
+// while holding the guard cannot disable recovery for good.
+export const OWNERLESS_GRACE_MS = 1_000;
+
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 export class LockTimeoutError extends Error {
@@ -78,7 +91,7 @@ function lockCanRecover(lockDir, staleMs) {
   const owner = readLockOwner(lockDir);
   if (owner?.pid) return !processIsAlive(owner.pid);
   try {
-    return Date.now() - statSync(lockDir).mtimeMs > staleMs;
+    return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
   } catch {
     return true; // vanished — nothing to recover, retry acquisition
   }

--- a/portal-health-lock.mjs
+++ b/portal-health-lock.mjs
@@ -1,0 +1,90 @@
+// portal-health-lock.mjs — a tiny cross-process advisory lock for
+// data/portal-health.tsv, so appendPortalHealth() (scan.mjs) and any
+// read-modify-write cleanup of the same file (tests/portal-health-guard.mjs)
+// can never interleave. A concurrent appender that lands between a cleanup's
+// read and write would otherwise be silently discarded.
+//
+// Same mkdir-is-atomic protocol used elsewhere in this codebase for
+// single-file locks: the lock is a directory ("<path>.lock"); a holder older
+// than STALE_MS is presumed crashed and reclaimed; acquisition retries with
+// backoff until MAX_WAIT_MS, then throws LockTimeoutError. Deliberately
+// self-contained (no re-entrancy tracking) — neither caller ever nests a
+// second acquisition of this same lock, so that machinery isn't needed here.
+
+import { mkdirSync, rmSync, statSync, writeFileSync } from 'fs';
+
+const STALE_MS = 30_000;
+const RETRY_MS = 80;
+const MAX_WAIT_MS = 8_000;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export class LockTimeoutError extends Error {
+  constructor(lockDir) {
+    super(`portal-health lock timeout: ${lockDir} held > ${MAX_WAIT_MS}ms`);
+    this.name = 'LockTimeoutError';
+    this.lockDir = lockDir;
+  }
+}
+
+function lockDirFor(filePath) {
+  return `${filePath}.lock`;
+}
+
+/** Blocks until the lock on `filePath` is held, then returns a handle whose release() frees it. */
+export async function acquirePortalHealthLock(filePath) {
+  const lockDir = lockDirFor(filePath);
+  const deadline = Date.now() + MAX_WAIT_MS;
+
+  for (;;) {
+    try {
+      mkdirSync(lockDir);
+      break; // acquired
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+      let ageMs = Infinity;
+      try {
+        ageMs = Date.now() - statSync(lockDir).mtimeMs;
+      } catch {
+        ageMs = Infinity; // vanished between mkdir and stat — retry
+      }
+      if (ageMs > STALE_MS) {
+        try {
+          rmSync(lockDir, { recursive: true, force: true });
+        } catch {
+          /* another process may have reclaimed it first */
+        }
+        continue;
+      }
+      if (Date.now() > deadline) throw new LockTimeoutError(lockDir);
+      await sleep(RETRY_MS);
+    }
+  }
+
+  try {
+    writeFileSync(`${lockDir}/owner`, `${process.pid} ${new Date().toISOString()}\n`);
+  } catch {
+    /* owner stamp is diagnostic only */
+  }
+
+  return {
+    lockDir,
+    release() {
+      try {
+        rmSync(lockDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort release; a stale-reclaim will recover it */
+      }
+    },
+  };
+}
+
+/** Acquires the lock on `filePath`, runs fn, and always releases it. */
+export async function withPortalHealthLock(filePath, fn) {
+  const lock = await acquirePortalHealthLock(filePath);
+  try {
+    return await fn();
+  } finally {
+    lock.release();
+  }
+}

--- a/portal-health-lock.mjs
+++ b/portal-health-lock.mjs
@@ -1,27 +1,42 @@
-// portal-health-lock.mjs — a tiny cross-process advisory lock for
+// portal-health-lock.mjs — a cross-process advisory lock for
 // data/portal-health.tsv, so appendPortalHealth() (scan.mjs) and any
 // read-modify-write cleanup of the same file (tests/portal-health-guard.mjs)
 // can never interleave. A concurrent appender that lands between a cleanup's
 // read and write would otherwise be silently discarded.
 //
-// Same mkdir-is-atomic protocol used elsewhere in this codebase for
-// single-file locks: the lock is a directory ("<path>.lock"); a holder older
-// than STALE_MS is presumed crashed and reclaimed; acquisition retries with
-// backoff until MAX_WAIT_MS, then throws LockTimeoutError. Deliberately
-// self-contained (no re-entrancy tracking) — neither caller ever nests a
-// second acquisition of this same lock, so that machinery isn't needed here.
+// Protocol — deliberately the same shape as the tracker lock in
+// tracker-utils.mjs, so there is one lock idiom in the codebase:
+//   - the lock is a directory ("<path>.lock"); a mkdir is atomic.
+//   - the holder records owner.json — pid, a unique token, started_at — so
+//     both stale-reclaim and release can verify who actually owns the lock
+//     before deleting anything.
+//   - staleness is judged by owner-PID liveness first, falling back to
+//     directory age only when the metadata is missing or unreadable. An old
+//     lock whose owner is still running is NOT stale.
+//   - stale reclamation is serialized behind a second atomic guard directory
+//     ("<path>.lock.recover"). Without it, reclamation is itself a TOCTOU
+//     race: two callers that both judge the same lock stale can have the
+//     second one's rmSync delete the first one's freshly created lock, after
+//     which both believe they hold it — reintroducing the very interleaving
+//     this module exists to prevent, just gated behind a crash + contention
+//     window.
+//
+// Timing is caller-configurable (with these defaults) so tests can exercise
+// contention in milliseconds instead of waiting out a multi-second constant.
 
-import { mkdirSync, rmSync, statSync, writeFileSync } from 'fs';
+import { mkdirSync, rmSync, statSync, writeFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { randomUUID } from 'crypto';
 
-const STALE_MS = 30_000;
-const RETRY_MS = 80;
-const MAX_WAIT_MS = 8_000;
+const DEFAULT_STALE_MS = 30_000;
+const DEFAULT_RETRY_MS = 80;
+const DEFAULT_TIMEOUT_MS = 8_000;
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 export class LockTimeoutError extends Error {
-  constructor(lockDir) {
-    super(`portal-health lock timeout: ${lockDir} held > ${MAX_WAIT_MS}ms`);
+  constructor(lockDir, timeoutMs) {
+    super(`portal-health lock timeout: ${lockDir} held > ${timeoutMs}ms`);
     this.name = 'LockTimeoutError';
     this.lockDir = lockDir;
   }
@@ -31,57 +46,161 @@ function lockDirFor(filePath) {
   return `${filePath}.lock`;
 }
 
-/** Blocks until the lock on `filePath` is held, then returns a handle whose release() frees it. */
-export async function acquirePortalHealthLock(filePath) {
+/** Owner metadata for a lock directory, or null when missing/unreadable. */
+function readLockOwner(lockDir) {
+  try {
+    return JSON.parse(readFileSync(join(lockDir, 'owner.json'), 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+// Identity of a directory, so a lock that was removed and recreated by another
+// process is never mistaken for the one this caller created.
+function sameLockDirectory(left, right) {
+  return left.dev === right.dev && left.ino === right.ino
+    && (left.ino !== 0 || left.birthtimeMs === right.birthtimeMs);
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === 'EPERM'; // exists, just not signalable by this user
+  }
+}
+
+// Conservative: a lock whose recorded owner is still running is never stale,
+// however old it is. Age is the fallback only when there's no readable owner.
+function lockCanRecover(lockDir, staleMs) {
+  const owner = readLockOwner(lockDir);
+  if (owner?.pid) return !processIsAlive(owner.pid);
+  try {
+    return Date.now() - statSync(lockDir).mtimeMs > staleMs;
+  } catch {
+    return true; // vanished — nothing to recover, retry acquisition
+  }
+}
+
+/**
+ * Blocks until the lock on `filePath` is held, then returns a handle whose
+ * release() frees it. Throws LockTimeoutError if the lock stays busy.
+ *
+ * @param {string} filePath - File the lock guards.
+ * @param {object} [options]
+ * @param {number} [options.timeoutMs=8000] - Max time to wait for the lock.
+ * @param {number} [options.retryMs=80] - Delay between acquisition attempts.
+ * @param {number} [options.staleMs=30000] - Age threshold for a lock with no readable owner.
+ */
+export async function acquirePortalHealthLock(filePath, options = {}) {
+  // Env overrides let a caller several frames up the stack tune contention
+  // timing without threading options through every signature — the same
+  // escape hatch the tracker lock provides.
+  const timeoutMs = options.timeoutMs ?? (Number(process.env.CAREER_OPS_PORTAL_HEALTH_LOCK_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS);
+  const retryMs = options.retryMs ?? (Number(process.env.CAREER_OPS_PORTAL_HEALTH_LOCK_RETRY_MS) || DEFAULT_RETRY_MS);
+  const staleMs = options.staleMs ?? (Number(process.env.CAREER_OPS_PORTAL_HEALTH_LOCK_STALE_MS) || DEFAULT_STALE_MS);
   const lockDir = lockDirFor(filePath);
-  const deadline = Date.now() + MAX_WAIT_MS;
+  const recoverGuardDir = `${lockDir}.recover`;
+  const token = randomUUID();
+  const deadline = Date.now() + timeoutMs;
+
+  // A fresh install may not have data/ yet, and appendPortalHealth() creates
+  // it only after this lock is taken — create it here so mkdirSync(lockDir)
+  // cannot throw a raw ENOENT.
+  mkdirSync(dirname(lockDir), { recursive: true });
 
   for (;;) {
     try {
       mkdirSync(lockDir);
-      break; // acquired
     } catch (err) {
-      if (err.code !== 'EEXIST') throw err;
-      let ageMs = Infinity;
+      if (err?.code !== 'EEXIST') throw err;
+
+      // Serialize stale-reclaim behind a second atomic guard so only one
+      // caller can be inside the decide-then-delete window at a time.
+      let hasRecoverGuard = false;
       try {
-        ageMs = Date.now() - statSync(lockDir).mtimeMs;
-      } catch {
-        ageMs = Infinity; // vanished between mkdir and stat — retry
+        mkdirSync(recoverGuardDir);
+        hasRecoverGuard = true;
+      } catch (guardErr) {
+        if (guardErr?.code !== 'EEXIST') throw guardErr;
+        // A process killed between taking the guard and cleaning it up would
+        // otherwise disable stale recovery forever. The guard normally lives
+        // for milliseconds, so an old one is judged by the same age rule.
+        if (lockCanRecover(recoverGuardDir, staleMs)) {
+          rmSync(recoverGuardDir, { recursive: true, force: true });
+        }
       }
-      if (ageMs > STALE_MS) {
+
+      if (hasRecoverGuard) {
+        try {
+          if (lockCanRecover(lockDir, staleMs)) {
+            rmSync(lockDir, { recursive: true, force: true });
+            continue; // retry acquisition immediately
+          }
+        } finally {
+          rmSync(recoverGuardDir, { recursive: true, force: true });
+        }
+      }
+
+      if (Date.now() > deadline) throw new LockTimeoutError(lockDir, timeoutMs);
+      await sleep(retryMs);
+      continue;
+    }
+
+    // Acquired. Record ownership; an owner-less lock would block every future
+    // acquirer until the age-out, so clean up if the stamp can't be written.
+    try {
+      writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
+        pid: process.pid,
+        token,
+        started_at: new Date().toISOString(),
+        file: filePath,
+      }, null, 2));
+    } catch (ownerErr) {
+      rmSync(lockDir, { recursive: true, force: true });
+      throw ownerErr;
+    }
+
+    let released = false;
+    return {
+      lockDir,
+      release() {
+        if (released) return;
+        released = true;
+        // Verify this caller still owns the lock before removing anything: if
+        // our operation outlived staleMs and another process legitimately
+        // reclaimed the lock, deleting it here would free someone else's
+        // critical section.
+        let before;
+        try {
+          before = statSync(lockDir);
+        } catch {
+          return; // already gone
+        }
+        const owner = readLockOwner(lockDir);
+        if (owner?.token !== token) return; // reclaimed by someone else — leave it alone
+        let after;
+        try {
+          after = statSync(lockDir);
+        } catch {
+          return;
+        }
+        if (!sameLockDirectory(before, after)) return; // swapped underneath us
         try {
           rmSync(lockDir, { recursive: true, force: true });
         } catch {
-          /* another process may have reclaimed it first */
+          /* best-effort; a stale-reclaim will recover it */
         }
-        continue;
-      }
-      if (Date.now() > deadline) throw new LockTimeoutError(lockDir);
-      await sleep(RETRY_MS);
-    }
+      },
+    };
   }
-
-  try {
-    writeFileSync(`${lockDir}/owner`, `${process.pid} ${new Date().toISOString()}\n`);
-  } catch {
-    /* owner stamp is diagnostic only */
-  }
-
-  return {
-    lockDir,
-    release() {
-      try {
-        rmSync(lockDir, { recursive: true, force: true });
-      } catch {
-        /* best-effort release; a stale-reclaim will recover it */
-      }
-    },
-  };
 }
 
 /** Acquires the lock on `filePath`, runs fn, and always releases it. */
-export async function withPortalHealthLock(filePath, fn) {
-  const lock = await acquirePortalHealthLock(filePath);
+export async function withPortalHealthLock(filePath, fn, options = {}) {
+  const lock = await acquirePortalHealthLock(filePath, options);
   try {
     return await fn();
   } finally {

--- a/scan.mjs
+++ b/scan.mjs
@@ -1610,7 +1610,7 @@ export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
 
 // ── Portal health persistence (#1744) ───────────────────────────────
 
-const PORTAL_HEALTH_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), 'data', 'portal-health.tsv');
+const PORTAL_HEALTH_PATH = 'data/portal-health.tsv';
 export const PORTAL_HEALTH_HEADER = 'timestamp\tcompany\tstatus\n';
 
 export function appendPortalHealth(healthRecords, filePath = PORTAL_HEALTH_PATH) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -46,6 +46,7 @@ import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
 import { normalizeCompanyName } from './invite-match.mjs';
 import { withPipelineLock } from './pipeline-lock.mjs';
+import { withPortalHealthLock } from './portal-health-lock.mjs';
 
 try {
   const { config } = await import('dotenv');
@@ -1613,14 +1614,19 @@ export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
 const PORTAL_HEALTH_PATH = 'data/portal-health.tsv';
 export const PORTAL_HEALTH_HEADER = 'timestamp\tcompany\tstatus\n';
 
-export function appendPortalHealth(healthRecords, filePath = PORTAL_HEALTH_PATH) {
-  mkdirSync(path.dirname(filePath), { recursive: true });
-  if (!existsSync(filePath)) writeFileSync(filePath, PORTAL_HEALTH_HEADER, 'utf-8');
-  let lines = '';
-  for (const r of healthRecords) {
-    lines += [r.timestamp, r.company, r.status].join('\t') + '\n';
-  }
-  if (lines) appendFileSync(filePath, lines, 'utf-8');
+// Locked (portal-health-lock.mjs) so a concurrent read-modify-write of this
+// same file — e.g. tests/portal-health-guard.mjs's regression-cleanup path —
+// can never interleave with this append and silently discard one side.
+export async function appendPortalHealth(healthRecords, filePath = PORTAL_HEALTH_PATH) {
+  await withPortalHealthLock(filePath, async () => {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    if (!existsSync(filePath)) writeFileSync(filePath, PORTAL_HEALTH_HEADER, 'utf-8');
+    let lines = '';
+    for (const r of healthRecords) {
+      lines += [r.timestamp, r.company, r.status].join('\t') + '\n';
+    }
+    if (lines) appendFileSync(filePath, lines, 'utf-8');
+  });
 }
 
 export function loadPortalHealth(filePath = PORTAL_HEALTH_PATH) {
@@ -2382,7 +2388,7 @@ async function main() {
   // Persist this run's counters (#1604) — guarded exactly like the other
   // writes; a --dry-run must leave no trace.
   if (!dryRun) {
-    appendPortalHealth(healthRecords);
+    await appendPortalHealth(healthRecords);
     appendScanRunSummary({
       timestamp: new Date().toISOString(), status: 'completed',
       companies: summaryCompanies, boards: summaryBoards, found: totalFound,

--- a/tests/portal-health-cleanup-guard.test.mjs
+++ b/tests/portal-health-cleanup-guard.test.mjs
@@ -1,0 +1,55 @@
+// tests/portal-health-cleanup-guard.test.mjs — applyScriptDirGuard() must never
+// clobber content another process wrote into the script-dir data file during a
+// test run. Unlike a blind backup/restore, it removes only the marker row the
+// test's own child process may have written (regression case), leaving any
+// concurrent legitimate row intact, and deletes the file only if the marker
+// row was the sole content and the file did not exist before the run.
+import { pass, fail } from './helpers.mjs';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { applyScriptDirGuard } from './portal-health-guard.mjs';
+
+console.log('\napplyScriptDirGuard() — safe cleanup of a possibly-regressed script-dir write');
+
+const dir = mkdtempSync(join(tmpdir(), 'career-ops-guard-'));
+const marker = 'Portal Health CWD Fixture TEST-MARKER';
+
+try {
+  // 1. Marker absent (the expected/fixed case) -> file left completely untouched.
+  {
+    const p = join(dir, 'untouched.tsv');
+    const original = 'timestamp\tcompany\tstatus\n2026-01-01\tRealCo\treachable\n';
+    writeFileSync(p, original, 'utf-8');
+    applyScriptDirGuard({ path: p, existedBefore: true, marker });
+    if (readFileSync(p, 'utf-8') === original) pass('marker absent: file left byte-for-byte untouched');
+    else fail('marker absent: file was modified when it should not have been');
+  }
+
+  // 2. Marker present alongside a concurrent legitimate row -> only the marker
+  //    row is stripped; the concurrent row survives (this is the CodeRabbit finding).
+  {
+    const p = join(dir, 'concurrent.tsv');
+    const concurrentRow = '2026-01-01\tConcurrentRealCo\treachable\n';
+    writeFileSync(p, concurrentRow + '2026-01-01\t' + marker + '\treachable\n', 'utf-8');
+    applyScriptDirGuard({ path: p, existedBefore: true, marker });
+    const after = readFileSync(p, 'utf-8');
+    if (after.includes('ConcurrentRealCo') && !after.includes(marker)) {
+      pass('marker present: only the marker row removed, concurrent row preserved');
+    } else {
+      fail(`marker present: expected concurrent row preserved and marker stripped, got: ${JSON.stringify(after)}`);
+    }
+  }
+
+  // 3. File did not exist before, and marker was the only content -> the file
+  //    is removed entirely rather than left as an empty artifact.
+  {
+    const p = join(dir, 'new-file.tsv');
+    writeFileSync(p, '2026-01-01\t' + marker + '\treachable\n', 'utf-8');
+    applyScriptDirGuard({ path: p, existedBefore: false, marker });
+    if (!existsSync(p)) pass('marker-only new file: removed entirely rather than left empty');
+    else fail('marker-only new file: expected file to be removed, it still exists');
+  }
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/tests/portal-health-cleanup-guard.test.mjs
+++ b/tests/portal-health-cleanup-guard.test.mjs
@@ -3,25 +3,30 @@
 // test run. Unlike a blind backup/restore, it removes only the marker row the
 // test's own child process may have written (regression case), leaving any
 // concurrent legitimate row intact, and deletes the file only if the marker
-// row was the sole content and the file did not exist before the run.
+// row was the sole content (allowing for a leading header) and the file did
+// not exist before the run. Its read-modify-write shares portal-health-lock.mjs's
+// cross-process lock with appendPortalHealth() (scan.mjs), so the two can
+// never interleave.
 import { pass, fail } from './helpers.mjs';
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { applyScriptDirGuard } from './portal-health-guard.mjs';
+import { acquirePortalHealthLock, LockTimeoutError } from '../portal-health-lock.mjs';
 
 console.log('\napplyScriptDirGuard() — safe cleanup of a possibly-regressed script-dir write');
 
 const dir = mkdtempSync(join(tmpdir(), 'career-ops-guard-'));
 const marker = 'Portal Health CWD Fixture TEST-MARKER';
+const HEADER = 'timestamp\tcompany\tstatus\n';
 
 try {
   // 1. Marker absent (the expected/fixed case) -> file left completely untouched.
   {
     const p = join(dir, 'untouched.tsv');
-    const original = 'timestamp\tcompany\tstatus\n2026-01-01\tRealCo\treachable\n';
+    const original = HEADER + '2026-01-01\tRealCo\treachable\n';
     writeFileSync(p, original, 'utf-8');
-    applyScriptDirGuard({ path: p, existedBefore: true, marker });
+    await applyScriptDirGuard({ path: p, existedBefore: true, marker });
     if (readFileSync(p, 'utf-8') === original) pass('marker absent: file left byte-for-byte untouched');
     else fail('marker absent: file was modified when it should not have been');
   }
@@ -31,8 +36,8 @@ try {
   {
     const p = join(dir, 'concurrent.tsv');
     const concurrentRow = '2026-01-01\tConcurrentRealCo\treachable\n';
-    writeFileSync(p, concurrentRow + '2026-01-01\t' + marker + '\treachable\n', 'utf-8');
-    applyScriptDirGuard({ path: p, existedBefore: true, marker });
+    writeFileSync(p, HEADER + concurrentRow + '2026-01-01\t' + marker + '\treachable\n', 'utf-8');
+    await applyScriptDirGuard({ path: p, existedBefore: true, marker, headerOnlyContent: HEADER });
     const after = readFileSync(p, 'utf-8');
     if (after.includes('ConcurrentRealCo') && !after.includes(marker)) {
       pass('marker present: only the marker row removed, concurrent row preserved');
@@ -46,9 +51,40 @@ try {
   {
     const p = join(dir, 'new-file.tsv');
     writeFileSync(p, '2026-01-01\t' + marker + '\treachable\n', 'utf-8');
-    applyScriptDirGuard({ path: p, existedBefore: false, marker });
+    await applyScriptDirGuard({ path: p, existedBefore: false, marker });
     if (!existsSync(p)) pass('marker-only new file: removed entirely rather than left empty');
     else fail('marker-only new file: expected file to be removed, it still exists');
+  }
+
+  // 4. appendPortalHealth() always writes the header line before the marker
+  //    row, so a plain "is the remainder empty?" check never fires in the real
+  //    regression it exists to clean up. Header-only remainder must also be
+  //    treated as empty and the new file removed entirely.
+  {
+    const p = join(dir, 'header-only.tsv');
+    writeFileSync(p, HEADER + '2026-01-01\t' + marker + '\treachable\n', 'utf-8');
+    await applyScriptDirGuard({ path: p, existedBefore: false, marker, headerOnlyContent: HEADER });
+    if (!existsSync(p)) pass('header-only remainder on a new file: removed entirely, not left as a bare header');
+    else fail(`header-only remainder: expected file removed, it still exists with: ${JSON.stringify(readFileSync(p, 'utf-8'))}`);
+  }
+
+  // 5. The guard's read-modify-write must share the SAME lock appendPortalHealth()
+  //    takes (pipeline-lock.mjs, keyed by the file path) — proven here by holding
+  //    that exact lock manually and confirming the guard genuinely blocks on it
+  //    (times out) rather than racing straight through to a read/write.
+  {
+    const p = join(dir, 'locked.tsv');
+    writeFileSync(p, HEADER + '2026-01-01\t' + marker + '\treachable\n', 'utf-8');
+    const held = await acquirePortalHealthLock(p);
+    try {
+      await applyScriptDirGuard({ path: p, existedBefore: false, marker });
+      fail('lock sharing: applyScriptDirGuard() proceeded while another holder had the lock — no shared exclusion');
+    } catch (e) {
+      if (e instanceof LockTimeoutError) pass('lock sharing: applyScriptDirGuard() correctly blocked on a lock held elsewhere (LockTimeoutError)');
+      else fail(`lock sharing: expected LockTimeoutError, got: ${e?.constructor?.name}: ${e?.message}`);
+    } finally {
+      held.release();
+    }
   }
 } finally {
   rmSync(dir, { recursive: true, force: true });

--- a/tests/portal-health-cleanup-guard.test.mjs
+++ b/tests/portal-health-cleanup-guard.test.mjs
@@ -69,12 +69,18 @@ try {
   }
 
   // 5. The guard's read-modify-write must share the SAME lock appendPortalHealth()
-  //    takes (pipeline-lock.mjs, keyed by the file path) — proven here by holding
-  //    that exact lock manually and confirming the guard genuinely blocks on it
-  //    (times out) rather than racing straight through to a read/write.
+  //    takes (portal-health-lock.mjs, keyed by the file path) — proven here by
+  //    holding that exact lock manually and confirming the guard genuinely
+  //    blocks on it (times out) rather than racing straight through to a
+  //    read/write. The env overrides keep this assertion in the milliseconds
+  //    range instead of waiting out the lock's real default timeout.
   {
     const p = join(dir, 'locked.tsv');
     writeFileSync(p, HEADER + '2026-01-01\t' + marker + '\treachable\n', 'utf-8');
+    const prevTimeout = process.env.CAREER_OPS_PORTAL_HEALTH_LOCK_TIMEOUT_MS;
+    const prevRetry = process.env.CAREER_OPS_PORTAL_HEALTH_LOCK_RETRY_MS;
+    process.env.CAREER_OPS_PORTAL_HEALTH_LOCK_TIMEOUT_MS = '200';
+    process.env.CAREER_OPS_PORTAL_HEALTH_LOCK_RETRY_MS = '20';
     const held = await acquirePortalHealthLock(p);
     try {
       await applyScriptDirGuard({ path: p, existedBefore: false, marker });
@@ -84,6 +90,10 @@ try {
       else fail(`lock sharing: expected LockTimeoutError, got: ${e?.constructor?.name}: ${e?.message}`);
     } finally {
       held.release();
+      if (prevTimeout === undefined) delete process.env.CAREER_OPS_PORTAL_HEALTH_LOCK_TIMEOUT_MS;
+      else process.env.CAREER_OPS_PORTAL_HEALTH_LOCK_TIMEOUT_MS = prevTimeout;
+      if (prevRetry === undefined) delete process.env.CAREER_OPS_PORTAL_HEALTH_LOCK_RETRY_MS;
+      else process.env.CAREER_OPS_PORTAL_HEALTH_LOCK_RETRY_MS = prevRetry;
     }
   }
 } finally {

--- a/tests/portal-health-guard.mjs
+++ b/tests/portal-health-guard.mjs
@@ -1,0 +1,32 @@
+// tests/portal-health-guard.mjs — safe cleanup for a test-run write that may
+// have landed in the wrong (script-directory) location under a cwd-resolution
+// regression. A blind backup/restore of the whole file would silently discard
+// any row a concurrent real process (e.g. a scheduled scan) appended to that
+// same live file while the test's child process ran. This instead removes
+// only the marker row the test itself may have written, leaving everything
+// else in the file exactly as it was found.
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
+
+/**
+ * Remove a fixture marker row from `path` without disturbing any other content.
+ *
+ * @param {object} opts
+ * @param {string} opts.path - File to guard (the script directory's data path).
+ * @param {boolean} opts.existedBefore - Whether the file existed before the test ran.
+ * @param {string} opts.marker - Substring unique to the fixture row the test wrote.
+ * @returns {void}
+ */
+export function applyScriptDirGuard({ path, existedBefore, marker }) {
+  if (!existsSync(path)) return; // never touched -- the expected, fixed case
+  const current = readFileSync(path, 'utf-8');
+  if (!current.includes(marker)) return; // no marker row -- leave untouched
+
+  const remainingLines = current.split('\n').filter((line) => !line.includes(marker));
+  const remaining = remainingLines.join('\n');
+
+  if (!existedBefore && remaining.trim() === '') {
+    rmSync(path, { force: true });
+    return;
+  }
+  writeFileSync(path, remaining, 'utf-8');
+}

--- a/tests/portal-health-guard.mjs
+++ b/tests/portal-health-guard.mjs
@@ -4,8 +4,12 @@
 // any row a concurrent real process (e.g. a scheduled scan) appended to that
 // same live file while the test's child process ran. This instead removes
 // only the marker row the test itself may have written, leaving everything
-// else in the file exactly as it was found.
+// else in the file exactly as it was found. The read-modify-write shares
+// portal-health-lock.mjs's cross-process lock with appendPortalHealth()
+// (scan.mjs), so a concurrent appender can never land between this guard's
+// read and write.
 import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { withPortalHealthLock } from '../portal-health-lock.mjs';
 
 /**
  * Remove a fixture marker row from `path` without disturbing any other content.
@@ -14,19 +18,29 @@ import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
  * @param {string} opts.path - File to guard (the script directory's data path).
  * @param {boolean} opts.existedBefore - Whether the file existed before the test ran.
  * @param {string} opts.marker - Substring unique to the fixture row the test wrote.
- * @returns {void}
+ * @param {string} [opts.headerOnlyContent] - The writer's leading header line(s)
+ *   (e.g. PORTAL_HEALTH_HEADER). appendPortalHealth() always writes this before
+ *   the marker row on a new file, so "the remainder is empty" alone never fires
+ *   in the real regression this guard exists for; a remainder that is exactly
+ *   this header must also count as empty.
+ * @returns {Promise<void>}
  */
-export function applyScriptDirGuard({ path, existedBefore, marker }) {
-  if (!existsSync(path)) return; // never touched -- the expected, fixed case
-  const current = readFileSync(path, 'utf-8');
-  if (!current.includes(marker)) return; // no marker row -- leave untouched
+export async function applyScriptDirGuard({ path, existedBefore, marker, headerOnlyContent }) {
+  await withPortalHealthLock(path, async () => {
+    if (!existsSync(path)) return; // never touched -- the expected, fixed case
+    const current = readFileSync(path, 'utf-8');
+    if (!current.includes(marker)) return; // no marker row -- leave untouched
 
-  const remainingLines = current.split('\n').filter((line) => !line.includes(marker));
-  const remaining = remainingLines.join('\n');
+    const remainingLines = current.split('\n').filter((line) => !line.includes(marker));
+    const remaining = remainingLines.join('\n');
+    const remainingTrimmed = remaining.trim();
+    const isEffectivelyEmpty =
+      remainingTrimmed === '' || (headerOnlyContent !== undefined && remainingTrimmed === headerOnlyContent.trim());
 
-  if (!existedBefore && remaining.trim() === '') {
-    rmSync(path, { force: true });
-    return;
-  }
-  writeFileSync(path, remaining, 'utf-8');
+    if (!existedBefore && isEffectivelyEmpty) {
+      rmSync(path, { force: true });
+      return;
+    }
+    writeFileSync(path, remaining, 'utf-8');
+  });
 }

--- a/tests/portal-health-lock.test.mjs
+++ b/tests/portal-health-lock.test.mjs
@@ -1,0 +1,116 @@
+// tests/portal-health-lock.test.mjs — portal-health-lock.mjs must provide real
+// mutual exclusion for data/portal-health.tsv, including under the crash +
+// contention window that stale-lock reclamation opens.
+//
+// A naive stat-then-rmSync-then-mkdirSync reclaim is itself a TOCTOU race:
+// two callers that both judge the same lock stale can have the second one's
+// rmSync delete the first one's freshly created lock, after which both
+// believe they hold it -- reintroducing the very interleaving this lock
+// exists to prevent. release() has the mirror-image gap: a holder whose
+// operation outlived the stale window would delete whichever lock directory
+// happened to be present, including another process's legitimate one.
+import { pass, fail } from './helpers.mjs';
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { acquirePortalHealthLock, LockTimeoutError } from '../portal-health-lock.mjs';
+
+console.log('\nportal-health-lock.mjs — ownership-verified locking');
+
+const root = mkdtempSync(join(tmpdir(), 'career-ops-ph-lock-'));
+
+try {
+  // 1. A live holder blocks a second acquirer, which times out.
+  {
+    const p = join(root, 'data', 'portal-health.tsv');
+    mkdirSync(dirname(p), { recursive: true });
+    const held = await acquirePortalHealthLock(p, { timeoutMs: 200, retryMs: 20 });
+    try {
+      const startedAt = Date.now();
+      let threw = null;
+      try {
+        await acquirePortalHealthLock(p, { timeoutMs: 200, retryMs: 20 });
+      } catch (e) {
+        threw = e;
+      }
+      const elapsed = Date.now() - startedAt;
+      if (threw instanceof LockTimeoutError && elapsed < 2000) {
+        pass(`a live holder blocks a second acquirer, honoring the caller timeout (${elapsed}ms)`);
+      } else if (!(threw instanceof LockTimeoutError)) {
+        fail(`expected LockTimeoutError, got: ${threw?.constructor?.name}: ${threw?.message}`);
+      } else {
+        fail(`caller timeout not honored — waited ${elapsed}ms for a 200ms timeout`);
+      }
+    } finally {
+      held.release();
+    }
+  }
+
+  // 2. Fresh install: the parent data/ directory may not exist yet.
+  {
+    const fresh = mkdtempSync(join(tmpdir(), 'career-ops-ph-fresh-'));
+    const p = join(fresh, 'data', 'portal-health.tsv');
+    try {
+      const lock = await acquirePortalHealthLock(p, { timeoutMs: 200, retryMs: 20 });
+      lock.release();
+      pass('creates a missing parent data/ directory instead of throwing ENOENT');
+    } catch (e) {
+      fail(`fresh install threw instead of creating data/: ${e.message}`);
+    } finally {
+      rmSync(fresh, { recursive: true, force: true });
+    }
+  }
+
+  // 3. Stale reclamation is serialized: exactly one of two concurrent
+  //    reclaimers may end up holding the lock.
+  {
+    const p = join(root, 'data', 'concurrent.tsv');
+    const lockDir = `${p}.lock`;
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
+      pid: 2147483000, // not a live pid
+      token: 'crashed-holder-token',
+      started_at: new Date(Date.now() - 60 * 60_000).toISOString(),
+    }), 'utf-8');
+
+    const results = await Promise.allSettled([
+      acquirePortalHealthLock(p, { timeoutMs: 1000, retryMs: 15, staleMs: 1 }),
+      acquirePortalHealthLock(p, { timeoutMs: 1000, retryMs: 15, staleMs: 1 }),
+    ]);
+    const winners = results.filter((r) => r.status === 'fulfilled');
+    if (winners.length === 1) {
+      pass('stale reclamation is serialized — exactly one concurrent reclaimer holds the lock');
+    } else {
+      fail(`expected exactly 1 winner, got ${winners.length} (both believe they hold the lock)`);
+    }
+    winners.forEach((w) => w.value.release());
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+
+  // 4. release() must not delete a lock another process legitimately reclaimed.
+  {
+    const p = join(root, 'data', 'reclaimed.tsv');
+    const lockDir = `${p}.lock`;
+    const first = await acquirePortalHealthLock(p, { timeoutMs: 200, retryMs: 20 });
+    rmSync(lockDir, { recursive: true, force: true });
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
+      pid: process.pid,
+      token: 'a-different-owners-token',
+      started_at: new Date().toISOString(),
+    }), 'utf-8');
+
+    first.release(); // must be a no-op
+
+    const stillThere = existsSync(lockDir);
+    const owner = stillThere ? JSON.parse(readFileSync(join(lockDir, 'owner.json'), 'utf-8')) : null;
+    if (stillThere && owner?.token === 'a-different-owners-token') {
+      pass("release() leaves another holder's reclaimed lock intact");
+    } else {
+      fail("release() deleted a lock owned by a different holder");
+    }
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/tests/portal-health-lock.test.mjs
+++ b/tests/portal-health-lock.test.mjs
@@ -10,7 +10,7 @@
 // operation outlived the stale window would delete whichever lock directory
 // happened to be present, including another process's legitimate one.
 import { pass, fail } from './helpers.mjs';
-import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync, utimesSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { acquirePortalHealthLock, LockTimeoutError } from '../portal-health-lock.mjs';
@@ -108,6 +108,51 @@ try {
       pass("release() leaves another holder's reclaimed lock intact");
     } else {
       fail("release() deleted a lock owned by a different holder");
+    }
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+
+  // 5. A lock directory is ownerless for a moment by construction: between its
+  //    mkdir and its owner.json write. The recover guard is ownerless for its
+  //    whole life. Judging those on age alone lets a caller with an aggressive
+  //    staleMs delete a directory created microseconds ago — stealing a
+  //    winner's lock inside its acquisition window, or evicting a live guard
+  //    and putting two callers inside the window the guard exists to serialize.
+  {
+    const p = join(root, 'data', 'ownerless.tsv');
+    const lockDir = `${p}.lock`;
+    mkdirSync(lockDir, { recursive: true });   // ownerless, just created
+    let stolen = false;
+    try {
+      const l = await acquirePortalHealthLock(p, { timeoutMs: 400, retryMs: 20, staleMs: 1 });
+      stolen = true;
+      l.release();
+    } catch (e) {
+      if (!(e instanceof LockTimeoutError)) fail(`ownerless-floor: expected LockTimeoutError, got ${e?.constructor?.name}`);
+    }
+    if (stolen) {
+      fail('ownerless-floor: reclaimed a just-created ownerless lock despite an aggressive staleMs');
+    } else {
+      pass('a just-created ownerless lock is not reclaimable, however aggressive the caller staleMs');
+    }
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+
+  // 6. The floor is a lower bound on patience, never a cap: a genuinely
+  //    abandoned ownerless directory must still age out, or a crash while
+  //    holding the guard would disable recovery permanently.
+  {
+    const p = join(root, 'data', 'aged.tsv');
+    const lockDir = `${p}.lock`;
+    mkdirSync(lockDir, { recursive: true });
+    const old = (Date.now() - 60 * 60_000) / 1000;   // an hour old
+    utimesSync(lockDir, old, old);
+    try {
+      const l = await acquirePortalHealthLock(p, { timeoutMs: 800, retryMs: 20, staleMs: 1 });
+      pass('a genuinely aged ownerless lock still ages out and is reclaimable');
+      l.release();
+    } catch (e) {
+      fail(`aged ownerless lock should be reclaimable, got ${e?.constructor?.name}: ${e?.message}`);
     }
     rmSync(lockDir, { recursive: true, force: true });
   }

--- a/tests/portal-health-path.test.mjs
+++ b/tests/portal-health-path.test.mjs
@@ -1,0 +1,86 @@
+// tests/portal-health-path.test.mjs — appendPortalHealth()/loadPortalHealth()
+// must resolve their default path against process.cwd(), not the directory
+// scan.mjs lives in.
+//
+// Every sibling data path in scan.mjs (SCAN_HISTORY_PATH, PIPELINE_PATH,
+// APPLICATIONS_PATH, BLACKLIST_PATH, SCAN_RUNS_PATH) is a bare cwd-relative
+// string. PORTAL_HEALTH_PATH used to be the one exception, resolved via
+// path.dirname(fileURLToPath(import.meta.url)) -- the script's own directory.
+// Any invocation with a sandboxed cwd (a test run, a temp dir, a CI checkout)
+// still wrote fixture rows straight into the real data/portal-health.tsv of
+// whatever checkout happens to own scan.mjs, polluting real pipeline data with
+// test fixtures.
+//
+// This spawns a real child process with cwd pinned to a temp dir that is NOT
+// the directory scan.mjs lives in, then calls appendPortalHealth() with no
+// filePath argument -- the exact call scan.mjs's own production code path
+// makes. The row must land under the given cwd, and the script's own
+// directory must be provably untouched.
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pathToFileURL } from 'url';
+
+console.log('\nscan.mjs — portal-health.tsv resolves against cwd, not script dir');
+
+const scanUrl = JSON.stringify(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+const sandboxCwd = mkdtempSync(join(tmpdir(), 'career-ops-portal-health-'));
+
+// The script's own directory is ROOT in this checkout -- the same directory
+// the pre-fix bug always resolved to regardless of the cwd it was given.
+const scriptDirHealthPath = join(ROOT, 'data', 'portal-health.tsv');
+const scriptDirHealthExisted = existsSync(scriptDirHealthPath);
+const scriptDirHealthBackup = scriptDirHealthExisted ? readFileSync(scriptDirHealthPath, 'utf-8') : null;
+
+try {
+  const marker = 'Portal Health CWD Fixture';
+  const script = `
+    const mod = await import(${scanUrl});
+    mod.appendPortalHealth([{ timestamp: '2026-01-01T00:00:00.000Z', company: ${JSON.stringify(marker)}, status: 'reachable' }]);
+  `;
+
+  const res = spawnSync(NODE, ['-e', script], {
+    cwd: sandboxCwd,
+    encoding: 'utf-8',
+    timeout: 30000,
+  });
+
+  if (res.error || res.status !== 0) {
+    fail(`appendPortalHealth() child process failed: ${res.error?.message || res.stderr}`);
+  } else {
+    pass('appendPortalHealth() runs cleanly with a sandbox cwd');
+  }
+
+  // 1. The row lands under the cwd the process was given, not the script dir.
+  const sandboxHealthPath = join(sandboxCwd, 'data', 'portal-health.tsv');
+  if (existsSync(sandboxHealthPath) && readFileSync(sandboxHealthPath, 'utf-8').includes(marker)) {
+    pass('the fixture row is written under the sandbox cwd');
+  } else {
+    fail(`expected ${sandboxHealthPath} to contain the fixture row, it does not`);
+  }
+
+  // 2. The script's own directory -- the real user-layer data dir in a normal
+  //    checkout -- is left completely alone. This is the assertion this test
+  //    exists to make: without it, this exact test would silently regress by
+  //    resurrecting the bug it was written to catch.
+  const scriptDirHealthContentNow = existsSync(scriptDirHealthPath) ? readFileSync(scriptDirHealthPath, 'utf-8') : null;
+  if (!scriptDirHealthExisted && scriptDirHealthContentNow === null) {
+    pass("the script directory's data/portal-health.tsv was never created");
+  } else if (scriptDirHealthExisted && scriptDirHealthContentNow === scriptDirHealthBackup) {
+    pass("the pre-existing script directory data/portal-health.tsv is untouched");
+  } else {
+    fail(`the sandboxed run wrote into the script's own directory (${scriptDirHealthPath}) -- this is the cwd-resolution regression`);
+  }
+} finally {
+  rmSync(sandboxCwd, { recursive: true, force: true });
+  // Defensive restore, matching the pattern in tests/scan-no-targets.test.mjs
+  // and tests/intake-mutex.test.mjs -- never observed to trigger once the path
+  // is fixed, but leaves the tree exactly as found if it somehow still does.
+  if (scriptDirHealthExisted) {
+    writeFileSync(scriptDirHealthPath, scriptDirHealthBackup, 'utf-8');
+  } else if (existsSync(scriptDirHealthPath)) {
+    rmSync(scriptDirHealthPath, { force: true });
+  }
+}

--- a/tests/portal-health-path.test.mjs
+++ b/tests/portal-health-path.test.mjs
@@ -41,7 +41,7 @@ try {
     mod.appendPortalHealth([{ timestamp: '2026-01-01T00:00:00.000Z', company: ${JSON.stringify(marker)}, status: 'reachable' }]);
   `;
 
-  const res = spawnSync(NODE, ['-e', script], {
+  const res = spawnSync(NODE, ['--input-type=module', '-e', script], {
     cwd: sandboxCwd,
     encoding: 'utf-8',
     timeout: 30000,

--- a/tests/portal-health-path.test.mjs
+++ b/tests/portal-health-path.test.mjs
@@ -18,10 +18,11 @@
 // directory must be provably untouched.
 import { pass, fail, NODE, ROOT } from './helpers.mjs';
 import { spawnSync } from 'child_process';
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { pathToFileURL } from 'url';
+import { applyScriptDirGuard } from './portal-health-guard.mjs';
 
 console.log('\nscan.mjs — portal-health.tsv resolves against cwd, not script dir');
 
@@ -33,9 +34,9 @@ const sandboxCwd = mkdtempSync(join(tmpdir(), 'career-ops-portal-health-'));
 const scriptDirHealthPath = join(ROOT, 'data', 'portal-health.tsv');
 const scriptDirHealthExisted = existsSync(scriptDirHealthPath);
 const scriptDirHealthBackup = scriptDirHealthExisted ? readFileSync(scriptDirHealthPath, 'utf-8') : null;
+const marker = 'Portal Health CWD Fixture';
 
 try {
-  const marker = 'Portal Health CWD Fixture';
   const script = `
     const mod = await import(${scanUrl});
     mod.appendPortalHealth([{ timestamp: '2026-01-01T00:00:00.000Z', company: ${JSON.stringify(marker)}, status: 'reachable' }]);
@@ -75,12 +76,13 @@ try {
   }
 } finally {
   rmSync(sandboxCwd, { recursive: true, force: true });
-  // Defensive restore, matching the pattern in tests/scan-no-targets.test.mjs
+  // Defensive cleanup, matching the pattern in tests/scan-no-targets.test.mjs
   // and tests/intake-mutex.test.mjs -- never observed to trigger once the path
   // is fixed, but leaves the tree exactly as found if it somehow still does.
-  if (scriptDirHealthExisted) {
-    writeFileSync(scriptDirHealthPath, scriptDirHealthBackup, 'utf-8');
-  } else if (existsSync(scriptDirHealthPath)) {
-    rmSync(scriptDirHealthPath, { force: true });
-  }
+  // Uses applyScriptDirGuard() rather than a blind restore-from-backup: a
+  // straight write of scriptDirHealthBackup would silently discard any row a
+  // concurrent real process (e.g. a scheduled scan) appended to this same
+  // live file while the sandboxed child process ran. The guard instead
+  // removes only this test's own marker row and leaves everything else alone.
+  applyScriptDirGuard({ path: scriptDirHealthPath, existedBefore: scriptDirHealthExisted, marker });
 }

--- a/tests/portal-health-path.test.mjs
+++ b/tests/portal-health-path.test.mjs
@@ -22,6 +22,7 @@ import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { pathToFileURL } from 'url';
+import { randomUUID } from 'crypto';
 import { applyScriptDirGuard } from './portal-health-guard.mjs';
 
 console.log('\nscan.mjs — portal-health.tsv resolves against cwd, not script dir');
@@ -34,12 +35,19 @@ const sandboxCwd = mkdtempSync(join(tmpdir(), 'career-ops-portal-health-'));
 const scriptDirHealthPath = join(ROOT, 'data', 'portal-health.tsv');
 const scriptDirHealthExisted = existsSync(scriptDirHealthPath);
 const scriptDirHealthBackup = scriptDirHealthExisted ? readFileSync(scriptDirHealthPath, 'utf-8') : null;
-const marker = 'Portal Health CWD Fixture';
+// Keep in sync with PORTAL_HEALTH_HEADER in scan.mjs -- passed to the guard so
+// a header-only remainder (appendPortalHealth always writes the header before
+// the marker row) still counts as empty and the cleanup fully removes a
+// script-dir file it created rather than leaving a bare header behind.
+const PORTAL_HEALTH_HEADER = 'timestamp\tcompany\tstatus\n';
+// Unique per test run so two concurrent CI/test runs can never remove each
+// other's fixture row from this shared fallback path.
+const marker = 'Portal Health CWD Fixture ' + randomUUID();
 
 try {
   const script = `
     const mod = await import(${scanUrl});
-    mod.appendPortalHealth([{ timestamp: '2026-01-01T00:00:00.000Z', company: ${JSON.stringify(marker)}, status: 'reachable' }]);
+    await mod.appendPortalHealth([{ timestamp: '2026-01-01T00:00:00.000Z', company: ${JSON.stringify(marker)}, status: 'reachable' }]);
   `;
 
   const res = spawnSync(NODE, ['--input-type=module', '-e', script], {
@@ -84,5 +92,10 @@ try {
   // concurrent real process (e.g. a scheduled scan) appended to this same
   // live file while the sandboxed child process ran. The guard instead
   // removes only this test's own marker row and leaves everything else alone.
-  applyScriptDirGuard({ path: scriptDirHealthPath, existedBefore: scriptDirHealthExisted, marker });
+  await applyScriptDirGuard({
+    path: scriptDirHealthPath,
+    existedBefore: scriptDirHealthExisted,
+    marker,
+    headerOnlyContent: PORTAL_HEALTH_HEADER,
+  });
 }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -168,6 +168,7 @@ const SYSTEM_PATHS = [
   'reserve-report-num.mjs',
   'scan.mjs',
   'pipeline-lock.mjs',
+  'portal-health-lock.mjs',
   'classify-tier.mjs',
   'scan-ats-full.mjs',
   'match-star.mjs',


### PR DESCRIPTION
## What does this PR do?

`PORTAL_HEALTH_PATH` resolved its default against the directory `scan.mjs` lives in (`path.dirname(fileURLToPath(import.meta.url))`), while every sibling data path in the same file — `SCAN_HISTORY_PATH`, `PIPELINE_PATH`, `APPLICATIONS_PATH`, `BLACKLIST_PATH`, `SCAN_RUNS_PATH` — is a bare cwd-relative string. This makes it a bare `'data/portal-health.tsv'` like its siblings, and adds a regression test.

## Related issue

None — bug fix (sending straight in per the template).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (2048 passed, 0 failed; the single warning is the pre-existing `cv-sync-check.mjs exited with error (expected without user data)`)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Why it matters

Any invocation with a sandboxed cwd — a test run, a temp dir, a CI checkout — still wrote portal-health rows into the real `data/portal-health.tsv` of whatever checkout happens to own `scan.mjs`, instead of the cwd's own data dir. That silently pollutes real pipeline data with fixtures.

The regression test spawns a real child process with cwd pinned to a temp dir (not the script's directory), calls `appendPortalHealth()` with no path argument — the exact call the production code path makes — and asserts the row lands under that cwd while the script's own directory is left provably untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Portal health persistence now defaults to `data/portal-health.tsv` relative to the current working directory, preventing writes to an unexpected location.

* **Tests**
  * Added an integration test that runs the process from a temporary sandbox to verify default path resolution and confirm existing portal health data remains unchanged.
  * Added coverage for safe, regression-resistant cleanup behavior when removing test marker rows from the portal health TSV.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->