### PR TITLE
fix(liveness): normalize typographic punctuation and accents before matching

### DIFF
--- a/liveness-core.mjs
+++ b/liveness-core.mjs
@@ -1,3 +1,19 @@
+// Portals write closure banners with typographic punctuation and accents:
+// WTTJ renders "Cette offre n’est plus disponible." with U+2019, not ASCII "'".
+// A pattern spelled with a plain apostrophe silently never matches, so a clearly
+// expired posting fell through to `no_apply_control` → uncertain → never filtered.
+// Normalize once at the entry point and spell every pattern below in the
+// normalized alphabet: ASCII quotes, no diacritics, collapsed whitespace.
+function normalizeForMatch(text = '') {
+  if (typeof text !== 'string') return '';
+  return text
+    .replace(/[‘’ʼ′´`]/g, "'")
+    .replace(/[“”″]/g, '"')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/\s+/g, ' ');
+}
+
 const HARD_EXPIRED_PATTERNS = [
   /job (is )?no longer available/i,
   /job.*no longer open/i,
@@ -13,7 +29,15 @@ const HARD_EXPIRED_PATTERNS = [
   /closed on \d{1,2}\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)/i,
   /closed on (?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*\s+\d{1,2}/i,
   /diese stelle (ist )?(nicht mehr|bereits) besetzt/i,
-  /offre (expirée|n'est plus disponible)/i,
+  // French closure banners. Spelled accent-free on purpose: normalizeForMatch
+  // strips diacritics, so "expiree" here matches "expirée" on the page.
+  /offre (expiree|n'est plus disponible)/i,
+  /(cette )?offre n'est plus (disponible|en ligne|active)/i,
+  /(offre|poste|annonce) (deja )?pourvu(e)?/i,
+  /offre (cloturee|desactivee|terminee)/i,
+  /ce poste n'est plus (disponible|a pourvoir|ouvert)/i,
+  /recrutement (termine|cloture)/i,
+  /candidatures (closes|cloturees)/i,
 ];
 
 const LISTING_PAGE_PATTERNS = [
@@ -57,7 +81,8 @@ const APPLY_PATTERNS = [
   // Polish posting has no recognized apply control and falls to no_apply_control.
   /\baplikuj\b/i,
   /panelu aplikowania/i,
-  /wyślij (cv|aplikacj)/i,
+  // Accent-free: apply controls go through normalizeForMatch too ("wyślij" → "wyslij").
+  /wyslij (cv|aplikacj)/i,
 ];
 
 const MIN_CONTENT_CHARS = 300;
@@ -80,7 +105,10 @@ function hasApplyControl(controls = []) {
   return controls.some((control) => APPLY_PATTERNS.some((pattern) => pattern.test(control)));
 }
 
-export function classifyLiveness({ status = 0, requestedUrl = '', finalUrl = '', bodyText = '', applyControls = [] } = {}) {
+export function classifyLiveness({ status = 0, requestedUrl = '', finalUrl = '', bodyText: rawBodyText = '', applyControls: rawApplyControls = [] } = {}) {
+  const bodyText = normalizeForMatch(rawBodyText);
+  const applyControls = (Array.isArray(rawApplyControls) ? rawApplyControls : []).map(normalizeForMatch);
+
   if (status === 404 || status === 410) {
     return { result: 'expired', code: 'http_gone', reason: `HTTP ${status}` };
   }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -294,6 +294,47 @@ try {
     fail(`Closed mycareersfuture posting misclassified as ${closedMycareersfuture.result}`);
   }
 
+  // Welcome to the Jungle renders its closure banner with a typographic
+  // apostrophe (U+2019), not the ASCII one the pattern was spelled with, so the
+  // banner never matched and a closed posting came back "uncertain".
+  const closedWttjTypographicApostrophe = classifyLiveness({
+    status: 200,
+    finalUrl: 'https://www.welcometothejungle.com/fr/companies/acme/jobs/graphiste_paris',
+    bodyText: [
+      'Cette offre n’est plus disponible.',
+      'ACME',
+      'Graphiste & Motion Designer',
+      'CDI    Paris    Télétravail fréquent',
+      'Descriptif du poste : conception d’identités visuelles et d’animations pour les campagnes de la marque.',
+      'Profil recherché : 3 ans d’expérience minimum, maîtrise de la suite Adobe et d’After Effects.',
+    ].join('\n'),
+    applyControls: [],
+  });
+  if (closedWttjTypographicApostrophe.result === 'expired') {
+    pass('Closure banners written with a typographic apostrophe are detected');
+  } else {
+    fail(`WTTJ closed posting misclassified as ${closedWttjTypographicApostrophe.result}`);
+  }
+
+  // Same normalization, accent side: the pattern is spelled "pourvu" but the
+  // page says "pourvue"/"déjà" with diacritics.
+  const closedAccentedBanner = classifyLiveness({
+    status: 200,
+    finalUrl: 'https://example.fr/offres/directeur-artistique',
+    bodyText: [
+      'Offre déjà pourvue',
+      'Directeur artistique',
+      'Cette annonce est conservée à titre d’archive.',
+      'Missions : direction de création, suivi de production, relation client sur les campagnes annuelles.',
+    ].join('\n'),
+    applyControls: [],
+  });
+  if (closedAccentedBanner.result === 'expired') {
+    pass('Accented French closure banners are detected');
+  } else {
+    fail(`Accented French banner misclassified as ${closedAccentedBanner.result}`);
+  }
+
   const cloudflareChallenge = classifyLiveness({
     status: 403,
     finalUrl: 'https://www.pracuj.pl/praca/sap-consultant,oferta,1004870954',


### PR DESCRIPTION
Fixes #2162.

## Problem

`HARD_EXPIRED_PATTERNS` spells the French closure banner with an ASCII apostrophe, but portals print U+2019 (`Cette offre n’est plus disponible.`). The pattern never matches, the page falls through to `no_apply_control` → `uncertain`, and no caller filters `uncertain`, so closed postings stay in the pipeline forever.

## Approach

Adding `[’]` to each pattern would fix today’s banner and miss tomorrow’s. Instead, `classifyLiveness` normalizes its inputs once at the entry point — typographic quotes to ASCII, diacritics stripped, whitespace collapsed — and every pattern is spelled in that normalized alphabet. `expiree` then matches `expirée`, `pourvu` matches `pourvue`.

Also adds the closure formulas French portals actually print: `offre pourvue`, `offre clôturée`, `offre désactivée`, `recrutement terminé`, `candidatures closes`.

## Compatibility

- Branch order and every existing classification are unchanged (404/410, bot challenge, access blocked, expired URL, expired body, redirected off posting, apply control, listing page, insufficient content).
- Apply-control labels go through the same normalization, so the Polish pattern is respelled `wyslij` instead of `wyślij`. English and German banners are unaffected — they carry no diacritics.
- `applyControls` is defensively coerced to an array before mapping.

## Tests

Two regression cases added to `test-all.mjs`, covering the typographic apostrophe and the accented banner. Both **fail on current `main`** and pass with this change; I verified the baseline failure by stashing the patch and re-running.

Verified against the live site: a closed WTTJ posting serves HTTP 200 with the full description and the banner, and its only "postuler" occurrences are FAQ question titles, not apply controls — so the banner is the sole reliable signal, which is exactly the one that was being missed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved liveness classification for text containing accents, typographic apostrophes, inconsistent spacing, or varied quotation marks.
  * Better detects expired job postings, including French closure notices and Polish application controls.

* **Tests**
  * Added coverage for accented French expiration banners and typographic apostrophes in expiration messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->