### PR TITLE
fix(role-matcher): treat 'product' as a baseline token so PM sibling specialties stay distinct

### DIFF
--- a/role-matcher.mjs
+++ b/role-matcher.mjs
@@ -54,6 +54,10 @@ export const BASELINE_TOKENS = new Set([
   'analyst', 'designer', 'consultant', 'specialist',
   'platform', 'systems', 'services',
   'backend', 'frontend', 'full', 'stack', 'fullstack',
+  // 'product' alone cannot identify an opening: "Product Manager - Marketplace"
+  // and "Product Manager - AI" must stay separate applications ("ai" is dropped
+  // by the tokenizer, leaving only [product, manager] to match on).
+  'product',
 ]);
 
 /**

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5126,6 +5126,21 @@ try {
     fail('role matcher ignored a real short-acronym overlap');
   }
 
+  // 'product' is a baseline token: "ai" is dropped by the tokenizer (2-letter,
+  // not in SHORT_SPECIALTY), so without this these titles collapse to
+  // [product, manager] and merge-tracker skips one as a false duplicate.
+  if (!roleFuzzyMatch('Product Manager - Marketplace', 'Product Manager - AI')) {
+    pass('role matcher keeps Product Manager sibling specialties distinct');
+  } else {
+    fail('role matcher collapsed Product Manager - Marketplace into Product Manager - AI');
+  }
+
+  if (roleFuzzyMatch('Product Manager - Marketplace', 'Product Manager - Marketplace')) {
+    pass('role matcher still matches identical Product Manager titles');
+  } else {
+    fail('role matcher rejected an identical Product Manager title');
+  }
+
   // A generic base title (no suffix of its own) shares every one of its tokens
   // with a specialized sibling, so the shared tokens alone used to cross the
   // Jaccard threshold — even though the sibling's extra word is exactly the


### PR DESCRIPTION
## What does this PR do?

Adds `'product'` to `BASELINE_TOKENS` in `role-matcher.mjs` so two titles cannot fuzzy-match on `[product, manager]` alone, and adds two regression tests to the shared role-matcher section of `test-all.mjs`.

## The incident

`merge-tracker.mjs` skipped a new **"Product Manager - Marketplace"** tracker row as a false duplicate of an existing **"Product Manager - AI"** row at the same company. Mechanism:

1. The tokenizer drops `ai` (2-letter token, deliberately not in `SHORT_SPECIALTY` per the existing comment: broad AI/ML buckets appear across many unrelated roles).
2. Both titles reduce to `[product, manager]` (Marketplace side keeps `marketplace`, but the overlap is `[product, manager]`).
3. `product` was not a baseline token, so it counted as a discriminating overlap token.
4. Jaccard 2/3 >= 0.6 declared a match, and the new evaluation silently never reached the tracker.

`product` is exactly the kind of role-altitude descriptor `BASELINE_TOKENS` exists for: it identifies the discipline, not the opening, same as `engineer`, `manager`, or `platform`.

## Accepted trade-off

With this change, a repost that retitles "Product Manager - AI" to "PM, AI" (or similar) no longer fuzzy-matches its earlier row, so a retitled repost could produce two tracker rows. That is the safer failure: URL-level dedup in `scan-history.tsv` already covers true reposts at the same URL, and a duplicate row is visible and cheap to fix, while a silently skipped evaluation is not.

## Alternative rejected

Adding `ai` to `SHORT_SPECIALTY` would fix this pair but wrongly dedupe same-company sibling reqs like "Senior Product Manager, AI" vs "Staff Product Manager, AI" — seniority words are stopwords, so both would reduce to `[product, manager, ai]` and match on a real-looking specialty overlap. It would also contradict the existing rationale for excluding broad AI/ML buckets from `SHORT_SPECIALTY`.

## Related issue

None — bug fix, exempt per CONTRIBUTING.md.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (2043 passed, 0 failed; 3 pre-existing environment warnings: missing user data, no Go compiler)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role title matching to keep distinct Product Manager specialties separate, such as Marketplace and AI.
  * Preserved matching for identical Product Manager titles.

* **Tests**
  * Added regression coverage for specialized Product Manager title matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->