### PR TITLE
fix(agentic-jobs): replace broken HTML scraper with the documented REST API (#2143)

### DIFF
--- a/providers/agentic-jobs.mjs
+++ b/providers/agentic-jobs.mjs
@@ -3,21 +3,38 @@
 
 import { decodeEntities } from './_html-entities.mjs';
 
-// Agentic Engineering Jobs provider — scrapes the server-rendered listing at
-// https://agentic-engineering-jobs.com/. The site has no public API, but every
-// job card is plain HTML wrapped in a `data-impression-slug` container, so the
-// full list is parseable from one page fetch (zero tokens, no browser).
+// Agentic Engineering Jobs provider — queries the site's public, documented
+// REST API instead of scraping HTML. The previous scraper parsed
+// `data-impression-slug` card containers out of the server-rendered listing;
+// the site markup changed and the containers no longer exist, breaking the
+// scraper outright (#2143). The API is the stable integration point going
+// forward — no auth, CORS-enabled, and it's what the site itself recommends
+// for programmatic access (OpenAPI spec at /api/v1/openapi.json).
 //
-// Card text lines after tag-stripping follow a stable order:
-//   [Featured?] → title → company → location → tech tags… → 🇺🇸 flag → [date]
-// The country flag emoji is decoded to a country name and appended to the
-// location so scan.mjs's location_filter can gate non-US postings that only
-// say "Remote".
+//   GET {API_BASE}/jobs?page={n}   — 1-based, PAGE_SIZE per page
+//   → { data: [{ title, companyName, slug, location, countries: string[],
+//                description (HTML), postedAt (ISO), salaryMin/Max/Currency,
+//                geoRegion, … }], meta: { total, page, per_page } }
+//
+// Detail URL the site itself builds: {SITE_ORIGIN}/jobs/{slug}.
+// `location` is already a human-readable string ("Remote (EU)", "Bangalore,
+// India") for the overwhelming majority of postings — used as-is for
+// scan.mjs's location_filter. The rare posting without one falls back to the
+// ISO `countries` array, decoded to country names.
+//
+// Rate limit: 30 requests/60s per IP (documented in the OpenAPI info block).
+// PAGE_DELAY_MS paces requests comfortably under that even for the largest
+// boards; MAX_PAGES is a hard stop regardless.
 //
 // Wire in via a `job_boards:` entry with `provider: agentic-jobs`.
 
 const SITE_ORIGIN = 'https://agentic-engineering-jobs.com';
+const API_BASE = `${SITE_ORIGIN}/api/v1`;
 const TRUSTED_HOST = 'agentic-engineering-jobs.com';
+const PAGE_SIZE = 50; // fixed by the API (meta.per_page)
+const MAX_PAGES = 40; // safety cap on request count (40*50 = 2000 postings)
+const MAX_JOBS = 2000;
+const PAGE_DELAY_MS = 2100; // stays under the documented 30 req/60s limit
 
 /** @param {string} url */
 function assertAgenticUrl(url) {
@@ -37,92 +54,96 @@ function assertAgenticUrl(url) {
 const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
 
 /**
- * Convert a two-letter regional-indicator flag emoji (e.g. 🇩🇪) into an
- * English country name ("Germany"). Returns '' when the input isn't a flag or
- * the region code can't be resolved.
- * @param {string} s
+ * Resolve a two-letter ISO country code to an English name. Returns '' for
+ * anything that isn't a resolvable two-letter code. Exported for tests.
+ * @param {unknown} code
  */
-export function flagToCountry(s) {
-  const cps = [...s];
-  if (cps.length !== 2) return '';
-  const codes = cps.map((c) => {
-    const cp = c.codePointAt(0) ?? 0;
-    return cp >= 0x1f1e6 && cp <= 0x1f1ff ? String.fromCharCode(cp - 0x1f1e6 + 65) : '';
-  });
-  if (codes.some((c) => !c)) return '';
+export function countryName(code) {
+  if (typeof code !== 'string' || !/^[A-Za-z]{2}$/.test(code)) return '';
   try {
-    const name = regionNames.of(codes.join(''));
-    return name && name !== codes.join('') ? name : '';
+    const name = regionNames.of(code.toUpperCase());
+    return name && name !== code.toUpperCase() ? name : '';
   } catch {
     return '';
   }
 }
 
 /**
- * Parse one job card's HTML segment into text lines (tags stripped, entities
- * decoded, blanks removed). Exported for tests.
- * @param {string} segment
- */
-export function cardLines(segment) {
-  const noMedia = segment.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ').replace(/<img[^>]*>/gi, ' ');
-  return noMedia
-    .split(/<[^>]+>/)
-    .map((t) => decodeEntities(t).trim())
-    .filter(Boolean);
-}
-
-/**
- * Normalize one card. Exported for tests.
- * @param {string} slug
- * @param {string[]} lines
- * @returns {{ title: string, url: string, company: string, location: string, postedAt?: number } | null}
- */
-export function normalizeAgenticCard(slug, lines) {
-  if (!slug || !/^[a-z0-9_-]+$/i.test(slug)) return null;
-  // Drop the leftover `slug">` artifact of the split plus any Featured badge.
-  const fields = lines.filter((l) => !l.includes('">') && l !== 'Featured');
-  if (fields.length < 2) return null;
-  const [title, company, maybeLocation] = fields;
-  if (!title || !company) return null;
-
-  // A card without a location line slides the flag-emoji line into this slot —
-  // a bare flag is never a location (it resolves to the country name below).
-  let location =
-    maybeLocation && !/^\d{4}-\d{2}-\d{2}$/.test(maybeLocation) && !flagToCountry(maybeLocation) ? maybeLocation : '';
-  const flag = fields.map(flagToCountry).find(Boolean);
-  if (flag) location = location ? `${location}, ${flag}` : flag;
-
-  /** @type {{ title: string, url: string, company: string, location: string, postedAt?: number }} */
-  const job = { title, url: `${SITE_ORIGIN}/jobs/${slug}`, company, location };
-
-  const dateLine = fields.find((l) => /^\d{4}-\d{2}-\d{2}$/.test(l));
-  if (dateLine) {
-    const parsed = Date.parse(`${dateLine}T00:00:00Z`);
-    if (!Number.isNaN(parsed)) job.postedAt = parsed;
-  }
-  return job;
-}
-
-/**
- * Parse the full listing page. Exported for tests.
+ * Strip tags (dropping script/style content entirely) and decode entities,
+ * collapsing whitespace. Descriptions arrive as HTML; content_filter/
+ * visa_filter match keywords by substring, so plain text avoids a tag
+ * fragment accidentally breaking up (or noisily padding) a match.
  * @param {string} html
  */
-export function parseAgenticListing(html) {
-  const out = [];
-  const seen = new Set();
-  const segments = html.split(/<div[^>]*\bdata-impression-slug="/).slice(1);
-  for (const seg of segments) {
-    const slug = seg.slice(0, seg.indexOf('"'));
-    // Cards can nest other markup; stop this card at the next card boundary.
-    const nextCard = seg.indexOf('data-impression-slug', slug.length + 2);
-    const body = nextCard > 0 ? seg.slice(0, nextCard) : seg;
-    const job = normalizeAgenticCard(slug, cardLines(body));
-    if (job && !seen.has(job.url)) {
-      seen.add(job.url);
-      out.push(job);
-    }
-  }
-  return out;
+export function stripHtml(html) {
+  if (typeof html !== 'string' || !html) return '';
+  const noMedia = html.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ');
+  return decodeEntities(noMedia.replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Derive a human-readable location string. Exported for tests.
+ * @param {any} j
+ */
+export function normalizeAgenticLocation(j) {
+  if (typeof j?.location === 'string' && j.location.trim()) return j.location.trim();
+  const countries = Array.isArray(j?.countries) ? j.countries : [];
+  const names = [...new Set(countries.map(countryName).filter(Boolean))];
+  if (names.length) return names.join(' / ');
+  return typeof j?.geoRegion === 'string' ? j.geoRegion.trim() : '';
+}
+
+/**
+ * Extract {min, max, currency} from the API's flat salaryMin/salaryMax/
+ * salaryCurrency fields, omitting a bound the API left null (never coerced
+ * to 0 — a 0 min/max would read as real comp data downstream). Returns null
+ * when neither bound is present. Exported for tests.
+ * @param {any} j
+ */
+export function normalizeAgenticSalary(j) {
+  const hasMin = typeof j?.salaryMin === 'number' && Number.isFinite(j.salaryMin);
+  const hasMax = typeof j?.salaryMax === 'number' && Number.isFinite(j.salaryMax);
+  if (!hasMin && !hasMax) return null;
+  /** @type {{min?: number, max?: number, currency?: string}} */
+  const salary = {};
+  if (hasMin) salary.min = j.salaryMin;
+  if (hasMax) salary.max = j.salaryMax;
+  const currency = typeof j?.salaryCurrency === 'string' ? j.salaryCurrency.trim().toUpperCase() : '';
+  if (currency) salary.currency = currency;
+  return salary;
+}
+
+/**
+ * Normalize one API job record into the shared Job shape, or null when a
+ * required field is missing/unsafe. Exported for tests.
+ * @param {any} j
+ */
+export function normalizeAgenticJob(j) {
+  if (!j || typeof j !== 'object') return null;
+  const title = typeof j.title === 'string' ? j.title.trim() : '';
+  const company = typeof j.companyName === 'string' ? j.companyName.trim() : '';
+  const slug = typeof j.slug === 'string' ? j.slug.trim() : '';
+  // Slug feeds straight into a URL path — keep it to safe path characters.
+  if (!title || !company || !slug || !/^[A-Za-z0-9_-]+$/.test(slug)) return null;
+
+  /** @type {{title: string, url: string, company: string, location: string, description?: string, postedAt?: number, salary?: {min?: number, max?: number, currency?: string}}} */
+  const job = {
+    title,
+    url: `${SITE_ORIGIN}/jobs/${slug}`,
+    company,
+    location: normalizeAgenticLocation(j),
+  };
+
+  const description = stripHtml(j.description);
+  if (description) job.description = description;
+
+  const posted = typeof j.postedAt === 'string' ? Date.parse(j.postedAt) : NaN;
+  if (Number.isFinite(posted)) job.postedAt = posted;
+
+  const salary = normalizeAgenticSalary(j);
+  if (salary) job.salary = salary;
+
+  return job;
 }
 
 /** @type {Provider} */
@@ -134,15 +155,34 @@ export default {
   },
 
   async fetch(_entry, ctx) {
-    const url = assertAgenticUrl(`${SITE_ORIGIN}/`);
-    // redirect:'error' prevents SSRF via server-side redirects
-    const html = await ctx.fetchText(url, { redirect: 'error' });
-    const jobs = parseAgenticListing(html);
-    if (jobs.length === 0) {
-      throw new Error(
-        'agentic-jobs: parsed 0 job cards — the site markup likely changed (expected data-impression-slug containers)',
-      );
+    const wait = (ms) => (ctx.sleep ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
+    const jobs = [];
+    const seen = new Set();
+    let total = null;
+
+    for (let page = 1; page <= MAX_PAGES; page++) {
+      if (page > 1) await wait(PAGE_DELAY_MS);
+      const url = assertAgenticUrl(`${API_BASE}/jobs?page=${page}`);
+      const json = await ctx.fetchJson(url, { redirect: 'error', headers: { accept: 'application/json' } });
+      const records = Array.isArray(json?.data) ? json.data : [];
+      if (total === null) total = typeof json?.meta?.total === 'number' ? json.meta.total : null;
+
+      for (const record of records) {
+        const job = normalizeAgenticJob(record);
+        if (job && !seen.has(job.url)) {
+          seen.add(job.url);
+          jobs.push(job);
+        }
+      }
+
+      if (jobs.length >= MAX_JOBS) break;
+      if (records.length < PAGE_SIZE) break; // short page — last one
+      if (total !== null && page * PAGE_SIZE >= total) break;
     }
-    return jobs;
+
+    if (jobs.length === 0) {
+      throw new Error('agentic-jobs: parsed 0 jobs from the API — the response shape likely changed');
+    }
+    return jobs.slice(0, MAX_JOBS);
   },
 };

--- a/providers/agentic-jobs.mjs
+++ b/providers/agentic-jobs.mjs
@@ -164,8 +164,17 @@ export default {
       if (page > 1) await wait(PAGE_DELAY_MS);
       const url = assertAgenticUrl(`${API_BASE}/jobs?page=${page}`);
       const json = await ctx.fetchJson(url, { redirect: 'error', headers: { accept: 'application/json' } });
-      const records = Array.isArray(json?.data) ? json.data : [];
-      if (total === null) total = typeof json?.meta?.total === 'number' ? json.meta.total : null;
+      // A missing/non-array `data` is a response-shape change, not a legitimate
+      // empty page (the API returns `data: []` for that) — fail loudly instead
+      // of silently truncating whatever pages were already collected.
+      if (!json || !Array.isArray(json.data)) {
+        throw new Error(`agentic-jobs: unexpected API response shape on page ${page} — "data" is missing or not an array`);
+      }
+      const records = json.data;
+      if (total === null) total = typeof json.meta?.total === 'number' ? json.meta.total : null;
+      // Trust the API's own reported page size over our constant, in case it
+      // ever differs from the documented default.
+      const effectivePageSize = typeof json.meta?.per_page === 'number' && json.meta.per_page > 0 ? json.meta.per_page : PAGE_SIZE;
 
       for (const record of records) {
         const job = normalizeAgenticJob(record);
@@ -176,8 +185,8 @@ export default {
       }
 
       if (jobs.length >= MAX_JOBS) break;
-      if (records.length < PAGE_SIZE) break; // short page — last one
-      if (total !== null && page * PAGE_SIZE >= total) break;
+      if (records.length < effectivePageSize) break; // short page — last one
+      if (total !== null && page * effectivePageSize >= total) break;
     }
 
     if (jobs.length === 0) {

--- a/tests/providers/agentic-jobs.test.mjs
+++ b/tests/providers/agentic-jobs.test.mjs
@@ -143,10 +143,11 @@ try {
     fail(`normalizeAgenticJob() salary wrong: ${JSON.stringify(job && job.salary)}`);
   }
 
-  if (normalizeAgenticJob({ title: 'X', companyName: 'Y', slug: 'bad slug!' }) === null) {
-    pass('normalizeAgenticJob() rejects a path-unsafe slug (feeds straight into a URL path)');
+  const unsafeSlugs = ['bad slug!', '../admin', 'a/b', 'x?y=1', 'x#frag'];
+  if (unsafeSlugs.every((slug) => normalizeAgenticJob({ title: 'X', companyName: 'Y', slug }) === null)) {
+    pass('normalizeAgenticJob() rejects path-unsafe / traversal / URL-injection slugs (feeds straight into a URL path)');
   } else {
-    fail('normalizeAgenticJob() should reject a path-unsafe slug');
+    fail(`normalizeAgenticJob() should reject every unsafe slug: ${JSON.stringify(unsafeSlugs.map((slug) => [slug, normalizeAgenticJob({ title: 'X', companyName: 'Y', slug })]))}`);
   }
   if (
     normalizeAgenticJob({ companyName: 'Y', slug: 'x' }) === null &&
@@ -215,10 +216,48 @@ try {
     fail(`agentic-jobs.fetch() dedup: expected 1 job, got ${dupeJobs.length}`);
   }
 
+  // Cross-page dedup: a job re-appearing on the next page (a live listing can
+  // shift rank between requests) must not be double-counted.
+  const crossPageDupe = mkCtx([
+    { data: [mkJob(1), mkJob(2)], meta: { total: 3, page: 1, per_page: 2 } },
+    { data: [mkJob(2), mkJob(3)], meta: { total: 3, page: 2, per_page: 2 } },
+  ]);
+  const crossPageJobs = await agentic.fetch({ name: 'X', provider: 'agentic-jobs' }, crossPageDupe.ctx);
+  if (crossPageJobs.length === 3 && new Set(crossPageJobs.map((j) => j.url)).size === 3) {
+    pass('agentic-jobs.fetch() dedups a job repeated across two different pages');
+  } else {
+    fail(`agentic-jobs.fetch() cross-page dedup: expected 3 unique jobs, got ${JSON.stringify(crossPageJobs.map((j) => j.url))}`);
+  }
+
+  // A malformed page (missing/non-array `data`) after already collecting real
+  // jobs must fail loudly, not silently truncate the run as if it were a
+  // legitimate short/last page.
+  const malformedMidPagination = mkCtx([
+    { data: [mkJob(1), mkJob(2)], meta: { total: 99, page: 1, per_page: 2 } },
+    { meta: { total: 99, page: 2, per_page: 2 } }, // "data" missing entirely
+  ]);
+  let malformedThrew = false;
+  try {
+    await agentic.fetch({ name: 'X', provider: 'agentic-jobs' }, malformedMidPagination.ctx);
+  } catch (e) {
+    if (e instanceof Error && e.message.includes('unexpected API response shape on page 2')) malformedThrew = true;
+    else throw e;
+  }
+  if (malformedThrew) {
+    pass('agentic-jobs.fetch() throws on a malformed mid-pagination page instead of silently truncating');
+  } else {
+    fail('agentic-jobs.fetch() should throw when a later page has a missing/non-array "data" field');
+  }
+
   let zeroJobsThrew = false;
   try {
     await agentic.fetch({ name: 'X', provider: 'agentic-jobs' }, mkCtx([{ data: [], meta: { total: 0, page: 1, per_page: 50 } }]).ctx);
-  } catch { zeroJobsThrew = true; }
+  } catch (e) {
+    // Match the specific canary message — an unrelated error (e.g. a bug
+    // elsewhere) must not make this assertion pass by accident.
+    if (e instanceof Error && e.message.includes('parsed 0 jobs from the API')) zeroJobsThrew = true;
+    else throw e;
+  }
   if (zeroJobsThrew) {
     pass('agentic-jobs.fetch() throws when the API yields zero jobs (response-shape-change canary)');
   } else {

--- a/tests/providers/agentic-jobs.test.mjs
+++ b/tests/providers/agentic-jobs.test.mjs
@@ -1,16 +1,16 @@
 // tests/providers/agentic-jobs.test.mjs — Agentic Engineering Jobs provider
-// (server-rendered listing at agentic-engineering-jobs.com, parsed from
-// data-impression-slug card containers). Follows the discovered-test layout
-// from #1440.
+// (public REST API at agentic-engineering-jobs.com/api/v1/jobs, #2143 —
+// the previous HTML scraper broke when the site's markup changed). Follows
+// the discovered-test layout from #1440.
 import { pass, fail, ROOT } from '../helpers.mjs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
 
-console.log('\nProvider — agentic-jobs (agentic-engineering-jobs.com SSR listing)');
+console.log('\nProvider — agentic-jobs (agentic-engineering-jobs.com REST API)');
 try {
   const mod = await import(pathToFileURL(join(ROOT, 'providers/agentic-jobs.mjs')).href);
   const agentic = mod.default;
-  const { flagToCountry, cardLines, normalizeAgenticCard, parseAgenticListing } = mod;
+  const { countryName, stripHtml, normalizeAgenticLocation, normalizeAgenticSalary, normalizeAgenticJob } = mod;
 
   if (agentic.id === 'agentic-jobs') pass('agentic-jobs.id is "agentic-jobs"');
   else fail(`agentic-jobs.id is ${JSON.stringify(agentic.id)}`);
@@ -34,164 +34,195 @@ try {
     fail('agentic-jobs.detect() should not claim entries by careers_url');
   }
 
-  // flagToCountry — regional-indicator flag emoji → English country name
-  if (flagToCountry('🇺🇸') === 'United States') pass('flagToCountry() decodes 🇺🇸 to United States');
-  else fail(`flagToCountry('🇺🇸') = ${JSON.stringify(flagToCountry('🇺🇸'))}`);
-
-  if (flagToCountry('🇩🇪') === 'Germany') pass('flagToCountry() decodes 🇩🇪 to Germany');
-  else fail(`flagToCountry('🇩🇪') = ${JSON.stringify(flagToCountry('🇩🇪'))}`);
-
-  if (flagToCountry('DE') === '' && flagToCountry('🇺') === '' && flagToCountry('LangGraph') === '') {
-    pass('flagToCountry() returns "" for plain text and non-flag input');
+  // countryName — ISO alpha-2 code → English name
+  if (countryName('US') === 'United States' && countryName('de') === 'Germany') {
+    pass('countryName() resolves ISO alpha-2 codes case-insensitively');
   } else {
-    fail('flagToCountry() should return "" for non-flag input');
+    fail(`countryName('US')=${JSON.stringify(countryName('US'))} countryName('de')=${JSON.stringify(countryName('de'))}`);
+  }
+  if (countryName('XX') === '' && countryName('USA') === '' && countryName(null) === '' && countryName(42) === '') {
+    pass('countryName() returns "" for unresolvable/non-two-letter/non-string input');
+  } else {
+    fail('countryName() should return "" for invalid input');
   }
 
-  // cardLines — tag-stripped, entity-decoded text lines
-  const lines = cardLines(
-    '<script>var x = "<b>ignore</b>";</script><style>.a{}</style><img src="/logo.png">' +
-    '<h2>Agent Engineer</h2> <p>Acme &amp; Co</p><span>  </span><span>Berlin</span>',
-  );
-  if (JSON.stringify(lines) === JSON.stringify(['Agent Engineer', 'Acme & Co', 'Berlin'])) {
-    pass('cardLines() strips script/style/img, decodes entities, and drops blank lines');
+  // stripHtml — tags dropped (script/style content removed entirely), entities decoded
+  const html = '<script>var x = 1;</script><style>.a{}</style><p>Ship &amp; iterate</p><ul><li>Node.js</li><li>Go</li></ul>';
+  if (stripHtml(html) === 'Ship & iterate Node.js Go') {
+    pass('stripHtml() drops tags/script/style content, decodes entities, collapses whitespace');
   } else {
-    fail(`cardLines() = ${JSON.stringify(lines)}`);
+    fail(`stripHtml() = ${JSON.stringify(stripHtml(html))}`);
+  }
+  if (stripHtml('') === '' && stripHtml(null) === '' && stripHtml(undefined) === '') {
+    pass('stripHtml() returns "" for empty/non-string input');
+  } else {
+    fail('stripHtml() should return "" for empty/non-string input');
   }
 
-  // normalizeAgenticCard — text lines → normalized Job
-  const card = normalizeAgenticCard('senior-agent-engineer-acme', [
-    'senior-agent-engineer-acme" class="card">',
-    'Featured',
-    'Senior Agent Engineer',
-    'Acme AI',
-    'San Francisco',
-    'LangGraph',
-    '🇺🇸',
-    '2026-07-01',
-  ]);
+  // normalizeAgenticLocation — prefers the API's own location string; falls
+  // back to decoded countries, then geoRegion, when it's absent.
+  if (normalizeAgenticLocation({ location: 'Remote (EU)', countries: ['DE'] }) === 'Remote (EU)') {
+    pass('normalizeAgenticLocation() uses the API location string when present');
+  } else {
+    fail(`normalizeAgenticLocation() with location wrong: ${JSON.stringify(normalizeAgenticLocation({ location: 'Remote (EU)', countries: ['DE'] }))}`);
+  }
+  if (normalizeAgenticLocation({ location: '', countries: ['CA', 'GB'] }) === 'Canada / United Kingdom') {
+    pass('normalizeAgenticLocation() falls back to deduped decoded countries when location is empty');
+  } else {
+    fail(`normalizeAgenticLocation() countries-fallback wrong: ${JSON.stringify(normalizeAgenticLocation({ location: '', countries: ['CA', 'GB'] }))}`);
+  }
+  if (normalizeAgenticLocation({ location: null, countries: [], geoRegion: 'global' }) === 'global') {
+    pass('normalizeAgenticLocation() falls back to geoRegion when countries is empty too');
+  } else {
+    fail(`normalizeAgenticLocation() geoRegion-fallback wrong: ${JSON.stringify(normalizeAgenticLocation({ location: null, countries: [], geoRegion: 'global' }))}`);
+  }
+  if (normalizeAgenticLocation({}) === '') {
+    pass('normalizeAgenticLocation() returns "" when nothing is usable');
+  } else {
+    fail('normalizeAgenticLocation() should return "" when nothing is usable');
+  }
+
+  // normalizeAgenticSalary — flat salaryMin/Max/Currency → {min, max, currency},
+  // never coercing a null bound to 0.
+  const bothBounds = normalizeAgenticSalary({ salaryMin: 196875, salaryMax: 246094, salaryCurrency: 'usd' });
+  if (bothBounds && bothBounds.min === 196875 && bothBounds.max === 246094 && bothBounds.currency === 'USD') {
+    pass('normalizeAgenticSalary() maps both bounds and uppercases currency');
+  } else {
+    fail(`normalizeAgenticSalary() both-bounds wrong: ${JSON.stringify(bothBounds)}`);
+  }
+  const minOnly = normalizeAgenticSalary({ salaryMin: 100000, salaryMax: null, salaryCurrency: 'USD' });
+  if (minOnly && minOnly.min === 100000 && !('max' in minOnly)) {
+    pass('normalizeAgenticSalary() omits a null bound instead of coercing it to 0');
+  } else {
+    fail(`normalizeAgenticSalary() min-only wrong: ${JSON.stringify(minOnly)}`);
+  }
+  if (normalizeAgenticSalary({ salaryMin: null, salaryMax: null, salaryCurrency: null }) === null) {
+    pass('normalizeAgenticSalary() returns null when neither bound is present');
+  } else {
+    fail('normalizeAgenticSalary() should return null when neither bound is present');
+  }
+
+  // normalizeAgenticJob — full API record → normalized Job
+  const record = {
+    title: 'Senior Backend Engineer (Ruby)',
+    companyName: 'Acme AI',
+    slug: 'senior-backend-engineer-ruby-acme',
+    location: 'Remote - Canada; Remote - United Kingdom',
+    countries: ['CA', 'GB'],
+    description: '<p>Ship &amp; iterate with <strong>Ruby on Rails</strong>.</p>',
+    postedAt: '2026-07-01T12:00:00.000Z',
+    salaryMin: 120000,
+    salaryMax: 160000,
+    salaryCurrency: 'usd',
+  };
+  const job = normalizeAgenticJob(record);
   if (
-    card &&
-    card.title === 'Senior Agent Engineer' &&
-    card.company === 'Acme AI' &&
-    card.url === 'https://agentic-engineering-jobs.com/jobs/senior-agent-engineer-acme'
+    job &&
+    job.title === 'Senior Backend Engineer (Ruby)' &&
+    job.company === 'Acme AI' &&
+    job.url === 'https://agentic-engineering-jobs.com/jobs/senior-backend-engineer-ruby-acme' &&
+    job.location === 'Remote - Canada; Remote - United Kingdom'
   ) {
-    pass('normalizeAgenticCard() drops the slug artifact + Featured badge and maps title/company/url');
+    pass('normalizeAgenticJob() maps title/company/url/location');
   } else {
-    fail(`normalizeAgenticCard() = ${JSON.stringify(card)}`);
+    fail(`normalizeAgenticJob() core fields wrong: ${JSON.stringify(job)}`);
+  }
+  if (job && job.description === 'Ship & iterate with Ruby on Rails .') {
+    pass('normalizeAgenticJob() strips HTML from the description');
+  } else {
+    fail(`normalizeAgenticJob() description wrong: ${JSON.stringify(job && job.description)}`);
+  }
+  if (job && job.postedAt === Date.parse('2026-07-01T12:00:00.000Z')) {
+    pass('normalizeAgenticJob() parses the ISO postedAt timestamp');
+  } else {
+    fail(`normalizeAgenticJob() postedAt wrong: ${job && job.postedAt}`);
+  }
+  if (job && job.salary && job.salary.min === 120000 && job.salary.max === 160000 && job.salary.currency === 'USD') {
+    pass('normalizeAgenticJob() attaches the normalized salary');
+  } else {
+    fail(`normalizeAgenticJob() salary wrong: ${JSON.stringify(job && job.salary)}`);
   }
 
-  if (card && card.location === 'San Francisco, United States') {
-    pass('normalizeAgenticCard() appends the decoded flag country to the location');
+  if (normalizeAgenticJob({ title: 'X', companyName: 'Y', slug: 'bad slug!' }) === null) {
+    pass('normalizeAgenticJob() rejects a path-unsafe slug (feeds straight into a URL path)');
   } else {
-    fail(`normalizeAgenticCard() location = ${JSON.stringify(card && card.location)}`);
+    fail('normalizeAgenticJob() should reject a path-unsafe slug');
   }
-
-  if (card && card.postedAt === Date.parse('2026-07-01T00:00:00Z')) {
-    pass('normalizeAgenticCard() parses the YYYY-MM-DD date line as UTC postedAt');
-  } else {
-    fail(`normalizeAgenticCard() postedAt = ${card && card.postedAt}`);
-  }
-
-  const noLocation = normalizeAgenticCard('agent-eng', ['Agent Engineer', 'Globex', '2026-06-15', '🇫🇷']);
-  if (noLocation && noLocation.location === 'France' && noLocation.postedAt === Date.parse('2026-06-15T00:00:00Z')) {
-    pass('normalizeAgenticCard() treats a date-shaped third field as no location (flag country only)');
-  } else {
-    fail(`normalizeAgenticCard() no-location card = ${JSON.stringify(noLocation)}`);
-  }
-
-  const flagSlot = normalizeAgenticCard('agent-eng-2', ['Agent Engineer', 'Globex', '🇺🇸', '2026-06-15']);
-  if (flagSlot && flagSlot.location === 'United States') {
-    pass('normalizeAgenticCard() never reads a bare flag line as the location (no-location card)');
-  } else {
-    fail(`normalizeAgenticCard() flag-in-location-slot card = ${JSON.stringify(flagSlot)}`);
-  }
-
-  if (normalizeAgenticCard('bad slug!', ['Title', 'Company']) === null) {
-    pass('normalizeAgenticCard() rejects path-unsafe slugs (they feed straight into a URL path)');
-  } else {
-    fail('normalizeAgenticCard() should reject path-unsafe slugs');
-  }
-
-  if (normalizeAgenticCard('', ['Title', 'Company']) === null && normalizeAgenticCard('ok-slug', ['Title only']) === null) {
-    pass('normalizeAgenticCard() returns null for a missing slug or fewer than title+company');
-  } else {
-    fail('normalizeAgenticCard() should return null for incomplete cards');
-  }
-
-  // parseAgenticListing — full page → deduped job list
-  const LISTING = `
-<html><body><main>
-  <div class="cards">
-    <div data-impression-slug="senior-agent-engineer-acme" class="card">
-      <img src="/acme.png">
-      <h2>Senior Agent Engineer</h2>
-      <p class="company">Acme AI</p>
-      <p class="location">San Francisco</p>
-      <span class="tag">LangGraph</span>
-      <span class="flag">🇺🇸</span>
-      <time>2026-07-01</time>
-    </div>
-    <div data-impression-slug="agent-platform-engineer-globex" class="card">
-      <span class="badge">Featured</span>
-      <h2>Agent Platform Engineer</h2>
-      <p class="company">Globex &amp; Co</p>
-      <p class="location">Remote</p>
-      <span class="flag">🇩🇪</span>
-      <time>2026-06-15</time>
-    </div>
-    <div data-impression-slug="senior-agent-engineer-acme" class="card">
-      <h2>Senior Agent Engineer</h2>
-      <p class="company">Acme AI</p>
-    </div>
-  </div>
-</main></body></html>`;
-
-  const jobs = parseAgenticListing(LISTING);
-  if (jobs.length === 2) {
-    pass('parseAgenticListing() parses every card and dedupes repeated slugs');
-  } else {
-    fail(`parseAgenticListing() returned ${jobs.length} jobs, expected 2`);
-  }
-
-  const g = jobs[1];
   if (
-    g &&
-    g.company === 'Globex & Co' &&
-    g.location === 'Remote, Germany' &&
-    g.url === 'https://agentic-engineering-jobs.com/jobs/agent-platform-engineer-globex'
+    normalizeAgenticJob({ companyName: 'Y', slug: 'x' }) === null &&
+    normalizeAgenticJob({ title: 'X', slug: 'x' }) === null &&
+    normalizeAgenticJob({ title: 'X', companyName: 'Y' }) === null &&
+    normalizeAgenticJob(null) === null
   ) {
-    pass('parseAgenticListing() decodes entities and appends the flag country per card');
+    pass('normalizeAgenticJob() returns null when title/companyName/slug is missing');
   } else {
-    fail(`parseAgenticListing() job[1] = ${JSON.stringify(g)}`);
+    fail('normalizeAgenticJob() should return null when a required field is missing');
+  }
+  const noExtras = normalizeAgenticJob({ title: 'X', companyName: 'Y', slug: 'x-y', location: 'Remote' });
+  if (noExtras && !('description' in noExtras) && !('postedAt' in noExtras) && !('salary' in noExtras)) {
+    pass('normalizeAgenticJob() omits description/postedAt/salary when the record carries none');
+  } else {
+    fail(`normalizeAgenticJob() should omit absent optional fields: ${JSON.stringify(noExtras)}`);
   }
 
-  // fetch() — single page fetch, hard failure on zero cards (mocked ctx)
-  const mkCtx = (html) => {
+  // fetch() — pagination, cross-page dedup, and the zero-jobs canary (mocked ctx)
+  const mkJob = (n) => ({ title: `Engineer ${n}`, companyName: `Company ${n}`, slug: `engineer-${n}`, location: 'Remote' });
+  const mkCtx = (pages, { sleep = true } = {}) => {
     const calls = [];
-    return { calls, ctx: { fetchText: async (url, opts) => { calls.push({ url, opts }); return html; } } };
+    return {
+      calls,
+      ctx: {
+        fetchJson: async (url, opts) => {
+          calls.push({ url, opts });
+          const pageNum = Number(new URL(url).searchParams.get('page'));
+          return pages[pageNum - 1] ?? { data: [], meta: { total: 0, page: pageNum, per_page: 50 } };
+        },
+        ...(sleep ? { sleep: async () => {} } : {}),
+      },
+    };
   };
 
-  const ok = mkCtx(LISTING);
-  const fetched = await agentic.fetch({ name: 'Agentic Engineering Jobs', provider: 'agentic-jobs' }, ok.ctx);
+  const onePage = mkCtx([{ data: [mkJob(1), mkJob(2)], meta: { total: 2, page: 1, per_page: 50 } }]);
+  const onePageJobs = await agentic.fetch({ name: 'Agentic Engineering Jobs', provider: 'agentic-jobs' }, onePage.ctx);
   if (
-    fetched.length === 2 &&
-    ok.calls.length === 1 &&
-    ok.calls[0].url === 'https://agentic-engineering-jobs.com/' &&
-    ok.calls[0].opts.redirect === 'error'
+    onePageJobs.length === 2 &&
+    onePage.calls.length === 1 &&
+    onePage.calls[0].url === 'https://agentic-engineering-jobs.com/api/v1/jobs?page=1' &&
+    onePage.calls[0].opts.redirect === 'error'
   ) {
-    pass('agentic-jobs.fetch() fetches the listing once with redirect: error and returns the parsed jobs');
+    pass('agentic-jobs.fetch() stops after a short (< PAGE_SIZE) page');
   } else {
-    fail(`agentic-jobs.fetch(): ${fetched.length} jobs, calls = ${JSON.stringify(ok.calls.map((c) => c.url))}`);
+    fail(`agentic-jobs.fetch() one-page: ${onePageJobs.length} jobs, calls=${JSON.stringify(onePage.calls.map((c) => c.url))}`);
   }
 
-  let zeroCardsThrew = false;
-  try {
-    await agentic.fetch({ name: 'X', provider: 'agentic-jobs' }, mkCtx('<html><body>no cards here</body></html>').ctx);
-  } catch { zeroCardsThrew = true; }
-  if (zeroCardsThrew) {
-    pass('agentic-jobs.fetch() throws when the page yields zero cards (markup-change canary)');
+  const fullPage = Array.from({ length: 50 }, (_, i) => mkJob(i + 1));
+  const twoPages = mkCtx([
+    { data: fullPage, meta: { total: 51, page: 1, per_page: 50 } },
+    { data: [mkJob(51)], meta: { total: 51, page: 2, per_page: 50 } },
+  ]);
+  const twoPageJobs = await agentic.fetch({ name: 'X', provider: 'agentic-jobs' }, twoPages.ctx);
+  if (twoPageJobs.length === 51 && twoPages.calls.length === 2) {
+    pass('agentic-jobs.fetch() pages until meta.total is covered');
   } else {
-    fail('agentic-jobs.fetch() should throw when no cards parse');
+    fail(`agentic-jobs.fetch() two-page: ${twoPageJobs.length} jobs, ${twoPages.calls.length} calls`);
+  }
+
+  const dupePage = mkCtx([{ data: [mkJob(1), mkJob(1)], meta: { total: 2, page: 1, per_page: 50 } }]);
+  const dupeJobs = await agentic.fetch({ name: 'X', provider: 'agentic-jobs' }, dupePage.ctx);
+  if (dupeJobs.length === 1) {
+    pass('agentic-jobs.fetch() dedups by URL within a page');
+  } else {
+    fail(`agentic-jobs.fetch() dedup: expected 1 job, got ${dupeJobs.length}`);
+  }
+
+  let zeroJobsThrew = false;
+  try {
+    await agentic.fetch({ name: 'X', provider: 'agentic-jobs' }, mkCtx([{ data: [], meta: { total: 0, page: 1, per_page: 50 } }]).ctx);
+  } catch { zeroJobsThrew = true; }
+  if (zeroJobsThrew) {
+    pass('agentic-jobs.fetch() throws when the API yields zero jobs (response-shape-change canary)');
+  } else {
+    fail('agentic-jobs.fetch() should throw when no jobs parse');
   }
 } catch (e) {
   fail(`agentic-jobs provider tests crashed: ${e.message}`);


### PR DESCRIPTION
## What does this PR do?

`providers/agentic-jobs.mjs`'s `parseAgenticListing()` scraped `data-impression-slug` card containers out of the server-rendered listing at `agentic-engineering-jobs.com`. The site's markup changed and those containers no longer exist, so every scan now throws `parsed 0 job cards — the site markup likely changed`.

The site exposes a documented, public, CORS-enabled REST API (OpenAPI 3.1 spec at `/api/v1/openapi.json`, no auth) as the stable integration point going forward:

```
GET /api/v1/jobs?page={n}   → { data: Job[], meta: { total, page, per_page } }
```

Replaces the scraper with a paginated API client:

- **location**: uses the API's own human-readable location string (present on the large majority of postings, e.g. `"Remote (EU)"`, `"Bangalore, India"`); falls back to ISO country codes (decoded via `Intl.DisplayNames`) then `geoRegion` when absent.
- **description**: HTML stripped to plain text so `content_filter`/`visa_filter` keyword matching isn't broken up by tag fragments.
- **salary**: `{min, max, currency}` from the flat `salaryMin`/`salaryMax`/`salaryCurrency` fields, never coercing a `null` bound to `0` (which would otherwise read as real comp data downstream).
- Paces requests at ~1 per 2.1s, comfortably under the API's documented 30 req/60s rate limit; `MAX_PAGES`/`MAX_JOBS` remain hard caps.
- `redirect: 'error'` kept on every request (SSRF guard, matching the rest of the codebase's provider convention).

Verified live against the real API: returns well-formed postings with real title/company/url/location/description/postedAt/salary data; the old scraper's 0-cards failure is gone.

The old HTML-scraping helpers (`flagToCountry`, `cardLines`, `normalizeAgenticCard`, `parseAgenticListing`) are gone — nothing else in the codebase referenced them (confirmed via grep). Test file rewritten to match: covers the new JSON-record helpers (`countryName`, `stripHtml`, `normalizeAgenticLocation`, `normalizeAgenticSalary`, `normalizeAgenticJob`) plus `fetch()` pagination, cross-page dedup, and the zero-jobs canary.

## Related issue

Fixes #2143

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Bug fix — no issue-first requirement
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (2046 passed, 0 failed, 5 pre-existing unrelated warnings)
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switched job listings to the provider’s documented REST API for more consistent results.
  * Added pagination with throttling controls, plus enhanced job enrichment (location, salary, description, and posted date).
  * Implemented deduplication of repeated jobs across and within pages.
* **Bug Fixes**
  * Improved resilience to unexpected/invalid API responses and incomplete job records.
  * Added clear handling when the API returns no usable jobs.
* **Tests**
  * Updated and expanded coverage to validate REST-based parsing, pagination behavior, deduplication, and normalization rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->