### PR TITLE
test(update-system): behavioral rollback tests + git-runner seam (follow-up to #2110)

### DIFF
--- a/tests/updater-rollback-behavior.test.mjs
+++ b/tests/updater-rollback-behavior.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * updater-rollback-behavior.test.mjs — BEHAVIORAL rollback tests (#2015 follow-up).
+ *
+ * The rest of updater-migration-tests.mjs verifies the updater by source-pattern
+ * assertions (the file's convention, because apply()/revertPaths are ROOT-bound
+ * with heavy side effects). This file drives the real `removeAdditionsNotInHead`
+ * export against a throwaway git repo via the git-runner seam, so it verifies the
+ * rollback *behaves* right — the property that actually protects user data — not
+ * just that the code reads right (@FReptar0 + CodeRabbit review of #2110).
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail } from './helpers.mjs';
+import { gitIn, removeAdditionsNotInHead } from '../update-system.mjs';
+
+// A throwaway git repo plus a ctx that binds the rollback helper's git runner
+// and filesystem root to it, so nothing touches the real working tree.
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-rollback-'));
+  const g = (...args) => gitIn(dir, ...args);
+  g('init', '-q', '-b', 'main', '.');
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  return { dir, g, ctx: { git: g, root: dir } };
+}
+
+// Paths currently staged as changes vs HEAD — the snapshot apply() takes as
+// `initialStatusPaths` before it mutates anything.
+function stagedPaths(g) {
+  return new Set(g('diff', '--cached', '--name-only', 'HEAD').split('\n').filter(Boolean));
+}
+
+console.log('\n🧪 Testing updater rollback behavior (#2015)...');
+
+// ── 1. protectedPaths: a user's pre-staged work survives a rollback ──
+{
+  const { dir, g, ctx } = makeRepo();
+  mkdirSync(join(dir, 'docs'));
+  writeFileSync(join(dir, 'docs/OLD.md'), 'v1');
+  g('add', '-A');
+  g('commit', '-qm', 'base');
+
+  // Before any update: the user has their own staged addition AND a staged
+  // modification under the docs/ system pathspec.
+  writeFileSync(join(dir, 'docs/USER.md'), 'user work');
+  writeFileSync(join(dir, 'docs/OLD.md'), 'user edit');
+  g('add', 'docs/USER.md', 'docs/OLD.md');
+  const protectedPaths = stagedPaths(g);
+
+  // The update then stages a brand-new file under the same directory pathspec.
+  writeFileSync(join(dir, 'docs/NEW.md'), 'from update');
+  g('add', 'docs/NEW.md');
+
+  // Roll back the docs/ pathspec.
+  removeAdditionsNotInHead('docs/', protectedPaths, ctx);
+
+  if (!existsSync(join(dir, 'docs/NEW.md'))) {
+    pass('rollback removes the addition the update introduced (docs/NEW.md)');
+  } else {
+    fail('rollback left the update addition docs/NEW.md behind');
+  }
+  if (existsSync(join(dir, 'docs/USER.md'))) {
+    pass('rollback preserves the user\'s pre-staged addition (protectedPaths)');
+  } else {
+    fail('rollback DESTROYED the user\'s pre-staged docs/USER.md — data loss');
+  }
+  if (existsSync(join(dir, 'docs/OLD.md'))) {
+    pass('rollback preserves the user\'s pre-staged modification');
+  } else {
+    fail('rollback destroyed the user\'s staged modification docs/OLD.md');
+  }
+  // The index no longer carries the update's addition, but still carries the
+  // user's staged work.
+  const staged = stagedPaths(g);
+  if (!staged.has('docs/NEW.md') && staged.has('docs/USER.md') && staged.has('docs/OLD.md')) {
+    pass('index reflects only the update addition being unstaged');
+  } else {
+    fail(`index wrong after rollback: ${[...staged].join(', ')}`);
+  }
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 2. --diff-filter=A: a merely modified file is never removed ──
+{
+  const { dir, g, ctx } = makeRepo();
+  mkdirSync(join(dir, 'modes'));
+  writeFileSync(join(dir, 'modes/a.md'), 'v1');
+  g('add', '-A');
+  g('commit', '-qm', 'base');
+
+  // A staged MODIFICATION (not an addition) and a staged ADDITION, no protection.
+  writeFileSync(join(dir, 'modes/a.md'), 'v2');
+  writeFileSync(join(dir, 'modes/b.md'), 'new');
+  g('add', '-A');
+
+  removeAdditionsNotInHead('modes/', new Set(), ctx);
+
+  if (existsSync(join(dir, 'modes/a.md'))) {
+    pass('rollback never deletes a modified file (only additions are targeted)');
+  } else {
+    fail('rollback deleted a modified file — --diff-filter=A guard failed');
+  }
+  if (!existsSync(join(dir, 'modes/b.md'))) {
+    pass('rollback removes an unprotected addition');
+  } else {
+    fail('rollback left an unprotected addition behind');
+  }
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 3. a single-file pathspec is handled like a directory one ──
+{
+  const { dir, g, ctx } = makeRepo();
+  writeFileSync(join(dir, 'seed.txt'), 'x');
+  g('add', '-A');
+  g('commit', '-qm', 'base');
+
+  writeFileSync(join(dir, 'browser-extract.mjs'), 'added by update');
+  g('add', 'browser-extract.mjs');
+
+  removeAdditionsNotInHead('browser-extract.mjs', new Set(), ctx);
+
+  if (!existsSync(join(dir, 'browser-extract.mjs'))) {
+    pass('rollback removes an added file for a file pathspec');
+  } else {
+    fail('rollback left an added file for a file pathspec');
+  }
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -435,7 +435,7 @@ function gitTimeoutEnvVar(args) {
   return args[0] === 'fetch' ? 'CAREER_OPS_GIT_FETCH_TIMEOUT_MS' : 'CAREER_OPS_GIT_TIMEOUT_MS';
 }
 
-function gitIn(root, ...args) {
+export function gitIn(root, ...args) {
   const timeout = gitTimeoutMs(args);
   try {
     return execFileSync('git', args, { cwd: root, encoding: 'utf-8', timeout }).trim();
@@ -630,7 +630,9 @@ export function prepareMaterializedSkillEntrypointsForStage(paths, root = ROOT) 
   return prepared;
 }
 
-function revertPaths(paths, protectedPaths = new Set()) {
+export function revertPaths(paths, protectedPaths = new Set(), ctx = {}) {
+  const runGit = ctx.git || git;
+  const root = ctx.root || ROOT;
   if (paths.length === 0) return;
   // Must restore from HEAD, not from the index (#915 bug 1). After
   // `git checkout FETCH_HEAD -- <path>` the index already holds the new
@@ -639,25 +641,25 @@ function revertPaths(paths, protectedPaths = new Set()) {
   // to the pre-update commit, which is the correct rollback target.
   for (const p of paths) {
     try {
-      git('checkout', 'HEAD', '--', p);
+      runGit('checkout', 'HEAD', '--', p);
     } catch (err) {
       const pathspec = p.endsWith('/') ? p.slice(0, -1) : p;
       // Only remove if the path genuinely doesn't exist in HEAD.
       // Other errors (permissions, corrupt refs) should re-throw.
       let existsInHead = true;
-      try { git('cat-file', '-e', `HEAD:${pathspec}`); } catch { existsInHead = false; }
+      try { runGit('cat-file', '-e', `HEAD:${pathspec}`); } catch { existsInHead = false; }
       if (existsInHead) throw err;
       // Path was newly introduced by the update — remove it so the
       // working tree is consistent with HEAD.
-      try { git('rm', '-r', '-f', '--ignore-unmatch', '--', pathspec); } catch { /* ignore */ }
-      try { rmSync(join(ROOT, pathspec), { recursive: true, force: true }); } catch { /* already gone */ }
+      try { runGit('rm', '-r', '-f', '--ignore-unmatch', '--', pathspec); } catch { /* ignore */ }
+      try { rmSync(join(root, pathspec), { recursive: true, force: true }); } catch { /* already gone */ }
     }
     // A directory pathspec that exists in HEAD checks out cleanly above, so the
     // catch never runs — but `git checkout HEAD -- docs/` only restores files
     // HEAD already knows about. Files the update introduced *under* that
     // directory are not in HEAD, so they survive the rollback as staged
     // additions and the tree is left dirtier than before the update (#2015).
-    removeAdditionsNotInHead(p, protectedPaths);
+    removeAdditionsNotInHead(p, protectedPaths, ctx);
   }
 }
 
@@ -672,14 +674,20 @@ function revertPaths(paths, protectedPaths = new Set()) {
  * @param {Set<string>} protectedPaths - Paths already dirty/staged BEFORE the
  *   update ran; never deleted, so a rollback cannot destroy the user's own
  *   pre-existing staged work under a system pathspec (#2015).
+ * @param {{git?: typeof git, root?: string}} [ctx] - Testability seam: the git
+ *   runner (defaults to the module `git`, bound to ROOT) and the working-tree
+ *   root used for filesystem deletes. Production always uses the defaults; only
+ *   the behavioral rollback test overrides them to drive a throwaway repo.
  */
-function removeAdditionsNotInHead(pathspec, protectedPaths = new Set()) {
+export function removeAdditionsNotInHead(pathspec, protectedPaths = new Set(), ctx = {}) {
+  const runGit = ctx.git || git;
+  const root = ctx.root || ROOT;
   const spec = pathspec.endsWith('/') ? pathspec.slice(0, -1) : pathspec;
   let added = '';
   try {
     // -z: NUL-delimited, unquoted output, so paths containing spaces or even
     // newlines survive intact — `split('\n').trim()` would mangle them.
-    added = git('diff', '--cached', '-z', '--name-only', '--diff-filter=A', 'HEAD', '--', spec);
+    added = runGit('diff', '--cached', '-z', '--name-only', '--diff-filter=A', 'HEAD', '--', spec);
   } catch {
     // No HEAD yet, or an unreadable pathspec — nothing safe to clean up.
     return;
@@ -690,7 +698,7 @@ function removeAdditionsNotInHead(pathspec, protectedPaths = new Set()) {
     if (protectedPaths.has(file)) continue;
     let removed = false;
     try {
-      git('rm', '-f', '--ignore-unmatch', '--', file);
+      runGit('rm', '-f', '--ignore-unmatch', '--', file);
       removed = true;
     } catch {
       // Index removal failed (lock/permission). Leave both the index entry AND
@@ -699,7 +707,7 @@ function removeAdditionsNotInHead(pathspec, protectedPaths = new Set()) {
       console.error(`Rollback: could not unstage ${file}; leaving it untouched.`);
     }
     if (removed) {
-      try { rmSync(join(ROOT, file), { force: true }); } catch { /* already gone */ }
+      try { rmSync(join(root, file), { force: true }); } catch { /* already gone */ }
     }
   }
 }

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -146,7 +146,7 @@ const twoPassManifestChecks = [
   },
   {
     name: 'revertPaths uses git checkout HEAD (not just --) to reset index+worktree (#915)',
-    pattern: /git\('checkout',\s*'HEAD',\s*'--'/,
+    pattern: /\b(?:git|runGit)\('checkout',\s*'HEAD',\s*'--'/,
   },
   {
     name: 'apply commit is scoped to update paths, not bare commit (#915)',
@@ -200,7 +200,7 @@ const twoPassManifestChecks = [
     // paths HEAD lacks, so files the update introduced under a directory
     // pathspec survived the rollback as staged additions (#2015).
     name: 'revertPaths clears additions HEAD lacks under a directory pathspec (#2015)',
-    pattern: /removeAdditionsNotInHead\(p, protectedPaths\)/,
+    pattern: /removeAdditionsNotInHead\(p, protectedPaths, ctx\)/,
   },
   {
     name: 'removeAdditionsNotInHead only targets additions, never modifications (#2015)',


### PR DESCRIPTION
**Draft, stacked on #2110** — do not merge until #2110 lands. The diff currently shows #2110's commits too (main doesn't have them yet); I'll rebase to a clean two-commit diff the moment #2110 merges. **Only the last two commits are this PR** (`715d3a9` seam, `84f03fd` behavioral test).

Follows up on the review of #2110, where both @FReptar0 and CodeRabbit made the same point: for a rollback path this safety-critical, a *behavioral* test is worth more than source-pattern assertions. @FReptar0's exact recipe — "stage an addition under a directory `SYSTEM_PATHS` entry, run the revert, assert the addition is gone **and** a `protectedPaths` file survives" — is what this implements.

## Why it needed a small refactor first

As I noted on #2110, `revertPaths` / `removeAdditionsNotInHead` called the module-bound `git()` (hardcoded to `ROOT`) and deleted via `join(ROOT, …)`, so they could only run against the real working tree — which is why that whole suite is source-pattern today. Rather than test a *copy* of the logic (which drifts), this adds a minimal git-runner seam.

### Commit 1 — the seam (`update-system.mjs`)
- `revertPaths(paths, protectedPaths, ctx)` and `removeAdditionsNotInHead(pathspec, protectedPaths, ctx)` take an optional `ctx = { git, root }`.
- Defaults to the module `git` and `ROOT`, so **production behavior is byte-identical** — `apply()` still calls with two args.
- Exports `revertPaths`, `removeAdditionsNotInHead`, `gitIn` (module has a proper entry guard at `update-system.mjs:1117`, so importing runs no updater logic — confirmed).

### Commit 2 — the behavioral test (`tests/updater-rollback-behavior.test.mjs`)
Drives the **real exported** `removeAdditionsNotInHead` against a throwaway git repo via the seam:
- an addition the update introduced is removed (index **and** worktree);
- a file the user staged *before* the update (`protectedPaths`) **survives** — the no-data-loss guarantee, tested for real;
- a merely *modified* file is never deleted (`--diff-filter=A`);
- a single-file pathspec behaves like a directory one.

Auto-discovered under `tests/`. The rest of `updater-migration-tests.mjs` stays source-pattern per the file's convention.

## Tests
`node tests/updater-rollback-behavior.test.mjs` → 7/7 · `node test-all.mjs --quick` → **2051 passed, 0 failed**.

2 commits (seam + test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update rollback to better preserve pre-existing staged changes and modified files.
  * Ensured rollback removes update-introduced added files both from the git index and from the working tree when they no longer exist in `HEAD`.
  * Improved handling so directory and single-file rollback pathspecs behave consistently.
* **Tests**
  * Added dedicated rollback behavior tests using an isolated temporary git repository.
  * Updated rollback-related test expectations to match the new rollback helper behavior and command invocation patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->