### PR TITLE
fix(cv): add GitHub contact link to the HTML CV pipeline (#2170)

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -267,7 +267,10 @@ function buildContactRow(candidate) {
     items.push(`<a href="${sanitizeUrl(c.linkedin.url)}">${escapeHtml(c.linkedin.display || c.linkedin.url)}</a>`);
   }
   if (c.github && c.github.url) {
-    items.push(`<a href="${sanitizeUrl(c.github.url)}">${escapeHtml(c.github.display || c.github.url)}</a>`);
+    const githubHref = sanitizeUrl(c.github.url);
+    if (githubHref) {
+      items.push(`<a href="${githubHref}">${escapeHtml(c.github.display || c.github.url)}</a>`);
+    }
   }
   if (c.portfolio && c.portfolio.url) {
     items.push(`<a href="${sanitizeUrl(c.portfolio.url)}">${escapeHtml(c.portfolio.display || c.portfolio.url)}</a>`);
@@ -443,6 +446,7 @@ async function runSelfTest() {
       phone: '+1 234 567 8900',
       email: 'test@example.com',
       linkedin: { url: 'https://linkedin.com/in/test', display: 'linkedin.com/in/test' },
+      github: { url: 'https://github.com/test', display: 'github.com/test' },
       portfolio: { url: 'https://test.example.com', display: 'test.example.com' },
       location: 'City, State',
     },
@@ -500,6 +504,43 @@ async function runSelfTest() {
   }
   if (/Kubernetes & Docker/.test(html)) {
     console.error('Self-test failed: found an unescaped ampersand in output');
+    process.exit(1);
+  }
+
+  // Guard the github contact-row case added for #2170: the link must render
+  // with the sanitized href from the sample.
+  if (!html.includes('href="https://github.com/test"')) {
+    console.error('Self-test failed: github contact link missing from output');
+    process.exit(1);
+  }
+
+  // Guard the absent-field side of the same case: omitting candidate.github
+  // must drop both its anchor and its separator, leaving no dangling item.
+  const { github, ...candidateWithoutGithub } = sample.candidate;
+  const htmlWithoutGithub = renderHtml(template, { ...sample, candidate: candidateWithoutGithub });
+  const countSeparators = (h) => (h.match(/class="separator"/g) || []).length;
+  if (htmlWithoutGithub.includes('github.com/test')) {
+    console.error('Self-test failed: github contact link rendered when candidate.github is absent');
+    process.exit(1);
+  }
+  if (countSeparators(htmlWithoutGithub) !== countSeparators(html) - 1) {
+    console.error('Self-test failed: omitting candidate.github left a dangling separator in the contact row');
+    process.exit(1);
+  }
+
+  // Guard the rejected-scheme side: sanitizeUrl() must reject javascript:/data:
+  // github URLs, which must drop the item and separator exactly like an
+  // absent field, never fall through to an empty href="".
+  const htmlWithRejectedGithub = renderHtml(template, {
+    ...sample,
+    candidate: { ...sample.candidate, github: { url: 'javascript:alert(1)', display: 'github.com/test' } },
+  });
+  if (htmlWithRejectedGithub.includes('href=""') || htmlWithRejectedGithub.includes('github.com/test')) {
+    console.error('Self-test failed: rejected github URL still rendered a contact item');
+    process.exit(1);
+  }
+  if (countSeparators(htmlWithRejectedGithub) !== countSeparators(html) - 1) {
+    console.error('Self-test failed: rejected github URL left a dangling separator in the contact row');
     process.exit(1);
   }
 

--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -248,10 +248,11 @@ ${items}
 }
 
 // Rebuild the whole .contact-row block. Its markup uses fixed "|" separators
-// between phone / email / linkedin / portfolio / location, so an absent optional
-// field (phone, linkedin, portfolio) must drop BOTH its <a> and one separator.
-// Building the present items and joining them is more robust than excising
-// separators from the template one placeholder at a time.
+// between phone / email / linkedin / github / portfolio / location, so an
+// absent optional field (phone, linkedin, github, portfolio) must drop BOTH
+// its <a> and one separator. Building the present items and joining them is
+// more robust than excising separators from the template one placeholder at
+// a time.
 function buildContactRow(candidate) {
   const c = candidate || {};
   const items = [];
@@ -264,6 +265,9 @@ function buildContactRow(candidate) {
   }
   if (c.linkedin && c.linkedin.url) {
     items.push(`<a href="${sanitizeUrl(c.linkedin.url)}">${escapeHtml(c.linkedin.display || c.linkedin.url)}</a>`);
+  }
+  if (c.github && c.github.url) {
+    items.push(`<a href="${sanitizeUrl(c.github.url)}">${escapeHtml(c.github.display || c.github.url)}</a>`);
   }
   if (c.portfolio && c.portfolio.url) {
     items.push(`<a href="${sanitizeUrl(c.portfolio.url)}">${escapeHtml(c.portfolio.display || c.portfolio.url)}</a>`);

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -166,7 +166,7 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `candidate.phone` | string | Optional — **omit or leave empty** to drop the `tel:` link and its separator (no empty cell). |
 | `candidate.email` | string | From `profile.yml`. |
 | `candidate.linkedin` | `{url, display}` | Optional — omit to drop the item and its separator. |
-| `candidate.github` | `{url, display}` | Optional — from `config/profile.yml`'s `github:` field. Omit to drop the item and its separator. |
+| `candidate.github` | `{url, display}` | Optional — omit to drop the item and its separator. |
 | `candidate.portfolio` | `{url, display}` | Optional — omit to drop the item and its separator. |
 | `candidate.location` | string | From `profile.yml`. |
 | `candidate.photo` | string | Opt-in profile photo (#264): a local path or `data:` URL. Empty/absent emits **no `<img>`**, rendering pixel-for-pixel identical to the photoless layout (US/UK/many-market ATS penalize photos; opt in for DACH/European markets). |

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -114,6 +114,7 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
     "phone": "+1 415 555 0100",
     "email": "jane@example.com",
     "linkedin": { "url": "https://linkedin.com/in/janesmith", "display": "linkedin.com/in/janesmith" },
+    "github": { "url": "https://github.com/janesmith", "display": "github.com/janesmith" },
     "portfolio": { "url": "https://janesmith.dev", "display": "janesmith.dev" },
     "location": "San Francisco, CA",
     "photo": "",
@@ -165,6 +166,7 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `candidate.phone` | string | Optional — **omit or leave empty** to drop the `tel:` link and its separator (no empty cell). |
 | `candidate.email` | string | From `profile.yml`. |
 | `candidate.linkedin` | `{url, display}` | Optional — omit to drop the item and its separator. |
+| `candidate.github` | `{url, display}` | Optional — from `config/profile.yml`'s `github:` field. Omit to drop the item and its separator. |
 | `candidate.portfolio` | `{url, display}` | Optional — omit to drop the item and its separator. |
 | `candidate.location` | string | From `profile.yml`. |
 | `candidate.photo` | string | Opt-in profile photo (#264): a local path or `data:` URL. Empty/absent emits **no `<img>`**, rendering pixel-for-pixel identical to the photoless layout (US/UK/many-market ATS penalize photos; opt in for DACH/European markets). |


### PR DESCRIPTION
## Summary
- `build-cv-html.mjs`'s `buildContactRow()` handled phone/email/linkedin/portfolio/location but had no `github` case, even though `config/profile.yml` documents `github` as a distinct, first-class field (separate from `portfolio`, which is a personal site, not GitHub).
- The LaTeX/Overleaf template (`cv-template.tex`) already renders GitHub correctly — this was specifically a gap in the HTML pipeline.
- Adds a `github` case to `buildContactRow()` mirroring the existing `linkedin`/`portfolio` optional-field pattern (renders the link + separator when present, drops both cleanly when absent).
- Documents `candidate.github: {url, display}` in `modes/pdf.md`'s JSON Input Schema and Field reference table.
- Extends `build-cv-html.mjs --test`'s self-test fixture/assertions to cover the new `github` branch.

Closes #2170.

## Test plan
- [x] `node build-cv-html.mjs --test` — self-test passes, including a dedicated assertion for the new `github` contact link
- [x] `node test-all.mjs` — 2045 passed, 0 failed (1 pre-existing, unrelated warning: dashboard build skipped, no Go compiler in this environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional GitHub contact support to generated CVs.
  * GitHub links are rendered only when a valid, scheme-safe GitHub URL is provided, with safe HTML-escaped display text.

* **Bug Fixes**
  * Improved contact-row separator handling so omitted optional fields (including GitHub) don’t leave dangling or extra separators.

* **Documentation**
  * Updated PDF mode input documentation and example/schema to include optional `candidate.github { url, display }`.
  * Documented that the GitHub contact item and separator are omitted when the field is not supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->