### PR TITLE
feat(cv): support declarative section HTML partials from disk (#2183)

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -208,12 +208,18 @@ function parsePartial(source) {
   }
 
   // Strip named block markers AND any remaining HTML comments (doc blocks).
-  // Block *references* ({{BLOCKNAME}}) stay in place — they will be filled
-  // at render time by fillEntry().
-  const entryTemplate = source
-    .replace(/<!--[A-Z][A-Z0-9_]+-->[\s\S]*?<!--\/[A-Z][A-Z0-9_]+-->/g, '')
-    .replace(/<!--[\s\S]*?-->/g, '')
-    .trim();
+  // We use a loop to satisfy CodeQL's 'Incomplete multi-character sanitization'
+  // rule, ensuring that maliciously nested comments (e.g. <!--<!--foo-->-->)
+  // are fully removed. Block references ({{BLOCKNAME}}) stay in place.
+  let entryTemplate = source;
+  let previous = '';
+  while (entryTemplate !== previous) {
+    previous = entryTemplate;
+    entryTemplate = entryTemplate
+      .replace(/<!--[A-Z][A-Z0-9_]+-->[\s\S]*?<!--\/[A-Z][A-Z0-9_]+-->/g, '')
+      .replace(/<!--[\s\S]*?-->/g, '');
+  }
+  entryTemplate = entryTemplate.trim();
 
   return { entryTemplate, blocks };
 }

--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -14,9 +14,19 @@
 // The script does NOT parse cv.md / YAML: the authoritative read of the source
 // files stays in the agent (same contract as build-cv-latex.mjs / modes/latex.md).
 // generate-pdf.mjs remains the single PDF renderer and is unchanged.
+//
+// Section HTML partials (#2183):
+//   A template pack can ship a sections/ directory alongside the main template
+//   file (e.g. templates/sections/ for the built-in templates). When a partial
+//   file exists for a section (e.g. sections/experience.html), the builder uses
+//   that file's markup instead of the hard-coded tag structure. Partials follow
+//   the same {{PLACEHOLDER}} convention used by the main template but carry
+//   entry-level field names (COMPANY, PERIOD, ROLE, etc.). When no partial file
+//   is found the built-in fallback builder is used, preserving full backward
+//   compatibility.
 
 import { readFile, writeFile, stat, mkdir } from 'fs/promises';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { resolve, dirname, basename, join, extname, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
@@ -149,26 +159,148 @@ function joinItems(items) {
   return typeof items === 'string' ? items : '';
 }
 
-// --- Section builders: each returns the inner HTML for one {{PLACEHOLDER}}. ---
+// ── Section partials (#2183) ────────────────────────────────────────────────
+//
+// Resolve the sections/ directory co-located with a given template file.
+// For "templates/cv-template.html" this is "templates/sections/".
+// For a custom pack at "templates/cv-template.compact.html" we look for
+// "templates/sections/" first (shared by all templates in that directory),
+// then fall back to the built-in builders.
+//
+// Partial file format:
+//   The file contains an HTML snippet and optional conditional-block markers
+//   encoded as HTML comments:
+//
+//     <!--BLOCK_NAME--><tag>{{PLACEHOLDER}}</tag><!--/BLOCK_NAME-->
+//
+//   These are extracted from the partial before the entry template is used.
+//   The builder substitutes the correct content for BLOCK_NAME references
+//   ({{BLOCK_NAME}} in the entry template) based on whether the field is
+//   present in the payload entry. When the field is absent the entire block
+//   is replaced with '' (or with the <!--BLOCK_NAME_EMPTY-->...<!--/BLOCK_NAME_EMPTY-->
+//   fallback if one is defined, which the certifications partial uses for
+//   table-cell alignment).
 
-function buildCompetencies(entries) {
+// Parse all <!--BLOCKNAME-->…<!--/BLOCKNAME--> markers out of a partial file
+// and return:
+//   { entryTemplate: string, blocks: Map<name, {present: string, absent: string}> }
+//
+// Partial files may contain a leading HTML comment block for documentation (the
+// standard HTML convention). We strip all HTML comments from the entry template
+// after extracting named block markers so doc text never leaks into rendered markup
+// or triggers the unresolved-placeholder check.
+function parsePartial(source) {
+  const blockRe = /<!--([A-Z][A-Z0-9_]+)-->([\s\S]*?)<!--\/\1-->/g;
+  const blocks = new Map();
+  let m;
+  while ((m = blockRe.exec(source)) !== null) {
+    const name = m[1];
+    const content = m[2];
+    // EMPTY variants are the absent-field fallback (e.g. <!--ORG_EMPTY-->).
+    if (name.endsWith('_EMPTY')) {
+      const base = name.slice(0, -6); // strip _EMPTY suffix
+      const existing = blocks.get(base) || { present: '', absent: '' };
+      blocks.set(base, { ...existing, absent: content });
+    } else {
+      const existing = blocks.get(name) || { present: '', absent: '' };
+      blocks.set(name, { ...existing, present: content });
+    }
+  }
+
+  // Strip named block markers AND any remaining HTML comments (doc blocks).
+  // Block *references* ({{BLOCKNAME}}) stay in place — they will be filled
+  // at render time by fillEntry().
+  const entryTemplate = source
+    .replace(/<!--[A-Z][A-Z0-9_]+-->[\s\S]*?<!--\/[A-Z][A-Z0-9_]+-->/g, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .trim();
+
+  return { entryTemplate, blocks };
+}
+
+// Fill an entry template with a map of { PLACEHOLDER: value } substitutions,
+// resolving conditional blocks before the normal field fill.
+// blockValues: Map<name, { value: string, present: boolean }> drives which
+// conditional markup variant to use.
+function fillEntry(entryTemplate, blocks, fields, blockValues) {
+  let out = entryTemplate;
+
+  // Resolve conditional blocks: replace {{BLOCK_NAME}} with the
+  // present/absent markup depending on whether the field has a value.
+  if (blockValues) {
+    for (const [name, { value, present }] of blockValues) {
+      const block = blocks.get(name);
+      if (!block) continue;
+      const markup = present ? block.present.replace(`{{${name}}}`, value) : block.absent;
+      out = out.replace(`{{${name}}}`, markup);
+    }
+  }
+
+  // Fill remaining scalar placeholders.
+  for (const [key, value] of Object.entries(fields)) {
+    out = out.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+  }
+
+  return out;
+}
+
+// Load section partials from the sections/ directory co-located with the
+// template. Returns a Map<sectionName, { entryTemplate, blocks }> for each
+// partial file found. Sections with no partial file are absent from the map
+// and fall back to the built-in builders.
+function loadSectionPartials(templatePath) {
+  const sectionsDir = join(dirname(templatePath), 'sections');
+  const partials = new Map();
+  if (!existsSync(sectionsDir)) return partials;
+
+  const sectionNames = [
+    'competencies', 'experience', 'projects', 'education', 'certifications', 'skills',
+  ];
+  for (const name of sectionNames) {
+    const partialPath = join(sectionsDir, `${name}.html`);
+    if (!existsSync(partialPath)) continue;
+    try {
+      const source = readFileSync(partialPath, 'utf-8');
+      partials.set(name, parsePartial(source));
+    } catch {
+      // Silently skip malformed partial files — fall back to built-in builder.
+    }
+  }
+  return partials;
+}
+
+// ── Section builders ────────────────────────────────────────────────────────
+// Each builder accepts an optional `partial` argument ({ entryTemplate, blocks }).
+// When a partial is provided the builder fills the partial's template instead
+// of its built-in tag structure. When partial is undefined/null the original
+// hard-coded output is produced (full backward compatibility).
+
+function buildCompetencies(entries, partial) {
   if (!Array.isArray(entries) || entries.length === 0) return '';
+  if (!partial) {
+    return entries
+      .filter(Boolean)
+      .map(tag => `<span class="competency-tag">${escapeHtml(String(tag))}</span>`)
+      .join('\n      ');
+  }
+  const { entryTemplate, blocks } = partial;
   return entries
     .filter(Boolean)
-    .map(tag => `<span class="competency-tag">${escapeHtml(String(tag))}</span>`)
+    .map(tag => fillEntry(entryTemplate, blocks, { TAG: escapeHtml(String(tag)) }, null))
     .join('\n      ');
 }
 
-function buildExperience(entries) {
+function buildExperience(entries, partial) {
   if (!Array.isArray(entries) || entries.length === 0) return '';
-  return entries.filter(Boolean).map(e => {
-    const bullets = Array.isArray(e.bullets)
-      ? e.bullets.filter(Boolean).map(b => `        <li>${escapeHtml(b)}</li>`).join('\n')
-      : '';
-    const location = e.location
-      ? `\n    <div class="job-location">${escapeHtml(e.location)}</div>`
-      : '';
-    return `<div class="job">
+  if (!partial) {
+    return entries.filter(Boolean).map(e => {
+      const bullets = Array.isArray(e.bullets)
+        ? e.bullets.filter(Boolean).map(b => `        <li>${escapeHtml(b)}</li>`).join('\n')
+        : '';
+      const location = e.location
+        ? `\n    <div class="job-location">${escapeHtml(e.location)}</div>`
+        : '';
+      return `<div class="job">
     <div class="job-header">
       <span class="job-company">${escapeHtml(e.company)}</span>
       <span class="job-period">${escapeHtml(e.dates || e.period || '')}</span>
@@ -178,73 +310,155 @@ function buildExperience(entries) {
 ${bullets}
     </ul>
   </div>`;
+    }).join('\n  ');
+  }
+
+  const { entryTemplate, blocks } = partial;
+  return entries.filter(Boolean).map(e => {
+    const bullets = Array.isArray(e.bullets)
+      ? e.bullets.filter(Boolean).map(b => `<li>${escapeHtml(b)}</li>`).join('\n    ')
+      : '';
+    const blockValues = new Map([
+      ['LOCATION_BLOCK', { value: escapeHtml(e.location || ''), present: Boolean(e.location) }],
+    ]);
+    return fillEntry(entryTemplate, blocks, {
+      COMPANY: escapeHtml(e.company || ''),
+      PERIOD: escapeHtml(e.dates || e.period || ''),
+      ROLE: escapeHtml(e.role || ''),
+      LOCATION: escapeHtml(e.location || ''),
+      BULLETS: bullets,
+    }, blockValues);
   }).join('\n  ');
 }
 
-function buildProjects(entries) {
+function buildProjects(entries, partial) {
   if (!Array.isArray(entries) || entries.length === 0) return '';
-  return entries.filter(Boolean).map(e => {
-    const badge = e.badge
-      ? `<span class="project-badge">${escapeHtml(e.badge)}</span>`
-      : '';
-    // Prefer a single description; fall back to joining bullets into one line so
-    // a bullets-shaped payload still renders inside the .project-desc block.
-    const descText = e.description
-      || (Array.isArray(e.bullets) ? e.bullets.filter(Boolean).join(' ') : '');
-    const desc = descText
-      ? `\n    <div class="project-desc">${escapeHtml(descText)}</div>`
-      : '';
-    const tech = e.tech
-      ? `\n    <div class="project-tech">${escapeHtml(e.tech)}</div>`
-      : '';
-    return `<div class="project">
+  if (!partial) {
+    return entries.filter(Boolean).map(e => {
+      const badge = e.badge
+        ? `<span class="project-badge">${escapeHtml(e.badge)}</span>`
+        : '';
+      // Prefer a single description; fall back to joining bullets into one line so
+      // a bullets-shaped payload still renders inside the .project-desc block.
+      const descText = e.description
+        || (Array.isArray(e.bullets) ? e.bullets.filter(Boolean).join(' ') : '');
+      const desc = descText
+        ? `\n    <div class="project-desc">${escapeHtml(descText)}</div>`
+        : '';
+      const tech = e.tech
+        ? `\n    <div class="project-tech">${escapeHtml(e.tech)}</div>`
+        : '';
+      return `<div class="project">
     <div class="project-title">${escapeHtml(e.name)}${badge}</div>${desc}${tech}
   </div>`;
+    }).join('\n  ');
+  }
+
+  const { entryTemplate, blocks } = partial;
+  return entries.filter(Boolean).map(e => {
+    const descText = e.description
+      || (Array.isArray(e.bullets) ? e.bullets.filter(Boolean).join(' ') : '');
+    const blockValues = new Map([
+      ['BADGE_BLOCK', { value: escapeHtml(e.badge || ''), present: Boolean(e.badge) }],
+      ['DESC_BLOCK',  { value: escapeHtml(descText),      present: Boolean(descText) }],
+      ['TECH_BLOCK',  { value: escapeHtml(e.tech || ''),  present: Boolean(e.tech) }],
+    ]);
+    return fillEntry(entryTemplate, blocks, {
+      NAME:  escapeHtml(e.name || ''),
+      BADGE: escapeHtml(e.badge || ''),
+      DESC:  escapeHtml(descText),
+      TECH:  escapeHtml(e.tech || ''),
+    }, blockValues);
   }).join('\n  ');
 }
 
-function buildEducation(entries) {
+function buildEducation(entries, partial) {
   if (!Array.isArray(entries) || entries.length === 0) return '';
-  return entries.filter(Boolean).map(e => {
-    const org = e.org
-      ? ` <span class="edu-org">${escapeHtml(e.org)}</span>`
-      : '';
-    const desc = e.description
-      ? `\n    <div class="edu-desc">${escapeHtml(e.description)}</div>`
-      : '';
-    return `<div class="edu-item">
+  if (!partial) {
+    return entries.filter(Boolean).map(e => {
+      const org = e.org
+        ? ` <span class="edu-org">${escapeHtml(e.org)}</span>`
+        : '';
+      const desc = e.description
+        ? `\n    <div class="edu-desc">${escapeHtml(e.description)}</div>`
+        : '';
+      return `<div class="edu-item">
     <div class="edu-header">
       <div class="edu-title">${escapeHtml(e.title)}${org}</div>
       <div class="edu-year">${escapeHtml(e.year || '')}</div>
     </div>${desc}
   </div>`;
+    }).join('\n  ');
+  }
+
+  const { entryTemplate, blocks } = partial;
+  return entries.filter(Boolean).map(e => {
+    const blockValues = new Map([
+      ['ORG_BLOCK',  { value: escapeHtml(e.org || ''),         present: Boolean(e.org) }],
+      ['DESC_BLOCK', { value: escapeHtml(e.description || ''), present: Boolean(e.description) }],
+    ]);
+    return fillEntry(entryTemplate, blocks, {
+      TITLE: escapeHtml(e.title || ''),
+      ORG:   escapeHtml(e.org || ''),
+      YEAR:  escapeHtml(e.year || ''),
+      DESC:  escapeHtml(e.description || ''),
+    }, blockValues);
   }).join('\n  ');
 }
 
-function buildCertifications(entries) {
+function buildCertifications(entries, partial) {
   if (!Array.isArray(entries) || entries.length === 0) return '';
-  return entries.filter(Boolean).map(e => {
-    const org = e.org ? `<span class="cert-org">${escapeHtml(e.org)}</span>` : '<span class="cert-org"></span>';
-    const year = e.year ? `<span class="cert-year">${escapeHtml(e.year)}</span>` : '<span class="cert-year"></span>';
-    return `<div class="cert-item">
+  if (!partial) {
+    return entries.filter(Boolean).map(e => {
+      const org = e.org ? `<span class="cert-org">${escapeHtml(e.org)}</span>` : '<span class="cert-org"></span>';
+      const year = e.year ? `<span class="cert-year">${escapeHtml(e.year)}</span>` : '<span class="cert-year"></span>';
+      return `<div class="cert-item">
       <span class="cert-title">${escapeHtml(e.title)}</span>
       ${org}
       ${year}
     </div>`;
+    }).join('\n    ');
+  }
+
+  const { entryTemplate, blocks } = partial;
+  return entries.filter(Boolean).map(e => {
+    const blockValues = new Map([
+      // Certifications use EMPTY variants so that absent fields still emit an
+      // empty <span> for table-cell alignment — not a bare removal.
+      ['ORG_BLOCK',  { value: escapeHtml(e.org || ''),  present: Boolean(e.org) }],
+      ['YEAR_BLOCK', { value: escapeHtml(e.year || ''), present: Boolean(e.year) }],
+    ]);
+    return fillEntry(entryTemplate, blocks, {
+      TITLE: escapeHtml(e.title || ''),
+      ORG:   escapeHtml(e.org || ''),
+      YEAR:  escapeHtml(e.year || ''),
+    }, blockValues);
   }).join('\n    ');
 }
 
-function buildSkills(categories) {
+function buildSkills(categories, partial) {
   if (!Array.isArray(categories) || categories.length === 0) return '';
+  if (!partial) {
+    const items = categories.filter(Boolean).map(c => {
+      const cat = c.category
+        ? `<span class="skill-category">${escapeHtml(c.category)}:</span> `
+        : '';
+      return `    <div class="skill-item">${cat}${escapeHtml(joinItems(c.items))}</div>`;
+    }).join('\n');
+    return `<div class="skills-grid">\n${items}\n  </div>`;
+  }
+
+  const { entryTemplate, blocks } = partial;
   const items = categories.filter(Boolean).map(c => {
-    const cat = c.category
-      ? `<span class="skill-category">${escapeHtml(c.category)}:</span> `
-      : '';
-    return `    <div class="skill-item">${cat}${escapeHtml(joinItems(c.items))}</div>`;
+    const blockValues = new Map([
+      ['CATEGORY_BLOCK', { value: escapeHtml(c.category || ''), present: Boolean(c.category) }],
+    ]);
+    return fillEntry(entryTemplate, blocks, {
+      CATEGORY:    escapeHtml(c.category || ''),
+      ITEMS_TEXT:  escapeHtml(joinItems(c.items)),
+    }, blockValues);
   }).join('\n');
-  return `<div class="skills-grid">
-${items}
-  </div>`;
+  return items;
 }
 
 // Rebuild the whole .contact-row block. Its markup uses fixed "|" separators
@@ -289,7 +503,7 @@ function buildPhoto(candidate, name) {
   return `<img class="cv-photo cv-photo--${style}" src="${sanitizeImageSrc(photo)}" alt="${escapeHtml(name || '')}">`;
 }
 
-function renderReport(payload) {
+function renderReport(payload, partials) {
   const sectionTitles = { ...DEFAULT_SECTION_TITLES, ...(payload.sections || {}) };
   const candidate = payload.candidate || {};
   const pageWidth = PAGE_WIDTHS[payload.page_format] || PAGE_WIDTHS.letter;
@@ -301,25 +515,29 @@ function renderReport(payload) {
     SECTION_SUMMARY: escapeHtml(sectionTitles.summary),
     SUMMARY_TEXT: escapeHtml(payload.summary || ''),
     SECTION_COMPETENCIES: escapeHtml(sectionTitles.competencies),
-    COMPETENCIES: buildCompetencies(payload.competencies),
+    COMPETENCIES: buildCompetencies(payload.competencies, partials.get('competencies')),
     SECTION_EXPERIENCE: escapeHtml(sectionTitles.experience),
-    EXPERIENCE: buildExperience(payload.experience),
+    EXPERIENCE: buildExperience(payload.experience, partials.get('experience')),
     SECTION_PROJECTS: escapeHtml(sectionTitles.projects),
-    PROJECTS: buildProjects(payload.projects),
+    PROJECTS: buildProjects(payload.projects, partials.get('projects')),
     SECTION_EDUCATION: escapeHtml(sectionTitles.education),
-    EDUCATION: buildEducation(payload.education),
+    EDUCATION: buildEducation(payload.education, partials.get('education')),
     SECTION_CERTIFICATIONS: escapeHtml(sectionTitles.certifications),
-    CERTIFICATIONS: buildCertifications(payload.certifications),
+    CERTIFICATIONS: buildCertifications(payload.certifications, partials.get('certifications')),
     SECTION_SKILLS: escapeHtml(sectionTitles.skills),
-    SKILLS: buildSkills(payload.skills),
+    SKILLS: buildSkills(payload.skills, partials.get('skills')),
   };
   return { substitutions, candidate };
 }
 
 // Merge a payload into the template and return the final HTML (throws on any
 // unresolved {{PLACEHOLDER}} so a malformed payload fails loudly, not silently).
-function renderHtml(template, payload) {
-  const { substitutions, candidate } = renderReport(payload);
+function renderHtml(template, payload, templatePath) {
+  // Load section partials from the sections/ directory co-located with the
+  // template. Falls back to built-in builders when no partials directory exists.
+  const partials = templatePath ? loadSectionPartials(templatePath) : new Map();
+
+  const { substitutions, candidate } = renderReport(payload, partials);
 
   // The contact row and photo carry conditional markup (dropped separators /
   // no <img>), so they are rebuilt as whole blocks before placeholder fill.
@@ -384,6 +602,13 @@ async function main() {
     console.error('');
     console.error('  [template.html] defaults to templates/cv-template.html. Pass the path');
     console.error('  printed by `node cv-templates.mjs resolve cv` to use a selected template.');
+    console.error('');
+    console.error('  Section partials (#2183):');
+    console.error('  If a sections/ directory exists alongside the template file,');
+    console.error('  the builder loads per-section HTML partial files from it');
+    console.error('  (e.g. sections/experience.html). Partials control the DOM');
+    console.error('  structure, tag names, and class names for each section.');
+    console.error('  When no partial file is found the built-in builder is used.');
     process.exit(args.includes('--help') ? 0 : 1);
   }
 
@@ -427,7 +652,7 @@ async function main() {
 
   let html;
   try {
-    html = renderHtml(template, payload);
+    html = renderHtml(template, payload, templatePath);
   } catch (err) {
     console.error(err.message);
     process.exit(1);
@@ -490,7 +715,7 @@ async function runSelfTest() {
 
   let html;
   try {
-    html = renderHtml(template, sample);
+    html = renderHtml(template, sample, TEMPLATE_PATH);
   } catch (err) {
     console.error(`Self-test failed: ${err.message}`);
     process.exit(1);
@@ -541,6 +766,80 @@ async function runSelfTest() {
   }
   if (countSeparators(htmlWithRejectedGithub) !== countSeparators(html) - 1) {
     console.error('Self-test failed: rejected github URL left a dangling separator in the contact row');
+    process.exit(1);
+  }
+
+  // Guard that section partial rendering produces expected class names (so a
+  // broken partial file doesn't silently remove structural markup).
+  if (!html.includes('class="job"')) {
+    console.error('Self-test failed: experience section is missing .job class — partial may be broken');
+    process.exit(1);
+  }
+  if (!html.includes('class="competency-tag"')) {
+    console.error('Self-test failed: competencies section is missing .competency-tag class');
+    process.exit(1);
+  }
+  if (!html.includes('class="project"')) {
+    console.error('Self-test failed: projects section is missing .project class');
+    process.exit(1);
+  }
+  if (!html.includes('class="edu-item"')) {
+    console.error('Self-test failed: education section is missing .edu-item class');
+    process.exit(1);
+  }
+  if (!html.includes('class="cert-item"')) {
+    console.error('Self-test failed: certifications section is missing .cert-item class');
+    process.exit(1);
+  }
+
+  // Guard that partials-based rendering produces the correct field values.
+  if (!html.includes('Test Corp') || !html.includes('Test Engineer')) {
+    console.error('Self-test failed: experience entry fields not found in output');
+    process.exit(1);
+  }
+
+  // Guard that conditional blocks work: location present → rendered; absent → not.
+  if (!html.includes('class="job-location"')) {
+    console.error('Self-test failed: job-location block not rendered when location is present');
+    process.exit(1);
+  }
+
+  // Test with an experience entry that has no location to verify the LOCATION_BLOCK
+  // conditional removal path.
+  const noLocSample = {
+    ...sample,
+    experience: [{ company: 'Acme', role: 'Engineer', dates: '2023', bullets: [] }],
+    projects: [],
+  };
+  let noLocHtml;
+  try {
+    noLocHtml = renderHtml(template, noLocSample, TEMPLATE_PATH);
+  } catch (err) {
+    console.error(`Self-test failed (no-location variant): ${err.message}`);
+    process.exit(1);
+  }
+  if (noLocHtml.includes('class="job-location"')) {
+    console.error('Self-test failed: job-location block rendered when location is absent');
+    process.exit(1);
+  }
+
+  // Test with certifications that are missing optional org/year fields to verify
+  // the EMPTY block fallback (empty <span> for table-cell alignment).
+  const noOrgCert = {
+    ...sample,
+    certifications: [{ title: 'No Org Cert' }, { title: 'With Org', org: 'CNCF', year: '2025' }],
+    projects: [],
+  };
+  let certHtml;
+  try {
+    certHtml = renderHtml(template, noOrgCert, TEMPLATE_PATH);
+  } catch (err) {
+    console.error(`Self-test failed (cert variant): ${err.message}`);
+    process.exit(1);
+  }
+  // The partial should emit an empty <span class="cert-org"> for alignment.
+  if (!certHtml.includes('class="cert-org"')) {
+    console.error('Self-test failed: cert-org empty-block not emitted for table alignment');
     process.exit(1);
   }
 

--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -216,8 +216,8 @@ function parsePartial(source) {
   while (entryTemplate !== previous) {
     previous = entryTemplate;
     entryTemplate = entryTemplate
-      .replace(/<!--[A-Z][A-Z0-9_]+-->[\s\S]*?<!--\/[A-Z][A-Z0-9_]+-->/g, '')
-      .replace(/<!--[\s\S]*?-->/g, '');
+      .replace(/<!--[A-Z][A-Z0-9_]+-->[\s\S]*?<!--\/[A-Z][A-Z0-9_]+-->/g, () => '')
+      .replace(/<!--[\s\S]*?-->/g, () => '');
   }
   entryTemplate = entryTemplate.trim();
 

--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -167,38 +167,56 @@ function joinItems(items) {
 // "templates/sections/" first (shared by all templates in that directory),
 // then fall back to the built-in builders.
 //
-// Partial file format:
-//   The file contains an HTML snippet and optional conditional-block markers
-//   encoded as HTML comments:
+// Partial file format (v2 — ENTRY zone):
+//   The file is split into two zones:
 //
-//     <!--BLOCK_NAME--><tag>{{PLACEHOLDER}}</tag><!--/BLOCK_NAME-->
+//   1. Documentation zone (before <!--ENTRY--> and after <!--/ENTRY-->):
+//      Free-form HTML comments or text. Completely ignored by the parser.
 //
-//   These are extracted from the partial before the entry template is used.
-//   The builder substitutes the correct content for BLOCK_NAME references
-//   ({{BLOCK_NAME}} in the entry template) based on whether the field is
-//   present in the payload entry. When the field is absent the entire block
-//   is replaced with '' (or with the <!--BLOCK_NAME_EMPTY-->...<!--/BLOCK_NAME_EMPTY-->
-//   fallback if one is defined, which the certifications partial uses for
-//   table-cell alignment).
+//   2. Entry zone (inside <!--ENTRY-->...<!--/ENTRY-->):
+//      Contains the per-entry HTML template. {{PLACEHOLDER}} references are
+//      filled by fillEntry(). Optional conditional-block *definitions* are
+//      placed here too, encoded as HTML comments:
+//
+//        <!--BLOCK_NAME--><tag>{{PLACEHOLDER}}</tag><!--/BLOCK_NAME-->
+//
+//      The builder extracts block definitions first, then the remaining markup
+//      becomes the entry template. When a field is absent the entire block is
+//      replaced with '' (or with the <!--BLOCK_NAME_EMPTY--> fallback if one
+//      is defined, which the certifications partial uses for alignment).
+//
+// By keeping documentation outside the ENTRY zone we never need to strip
+// arbitrary HTML comments from the entry template, which avoids the
+// CodeQL js/incomplete-multi-character-sanitization rule entirely.
 
-// Parse all <!--BLOCKNAME-->…<!--/BLOCKNAME--> markers out of a partial file
-// and return:
+// Parse a partial file and return:
 //   { entryTemplate: string, blocks: Map<name, {present: string, absent: string}> }
 //
-// Partial files may contain a leading HTML comment block for documentation (the
-// standard HTML convention). We strip all HTML comments from the entry template
-// after extracting named block markers so doc text never leaks into rendered markup
-// or triggers the unresolved-placeholder check.
+// The entry template is extracted from inside <!--ENTRY-->...<!--/ENTRY-->.
+// Named conditional-block definitions are extracted from the same zone and
+// removed to leave the clean entry template. No HTML comment stripping is
+// performed on arbitrary content (no CodeQL sanitization concern).
 function parsePartial(source) {
+  // Step 1: locate the ENTRY zone.
+  const entryZoneMatch = /<!--ENTRY-->([\s\S]*?)<!--\/ENTRY-->/.exec(source);
+  const entryZone = entryZoneMatch ? entryZoneMatch[1] : source;
+
+  // Step 2: extract named conditional-block definitions from the entry zone.
   const blockRe = /<!--([A-Z][A-Z0-9_]+)-->([\s\S]*?)<!--\/\1-->/g;
   const blocks = new Map();
+  // Collect the exact definition strings (open-tag + content + close-tag) so we
+  // can remove them verbatim from the entry zone in step 3, without needing any
+  // broad HTML-comment regex (which would trigger CodeQL).
+  const definitionStrings = [];
   let m;
-  while ((m = blockRe.exec(source)) !== null) {
+  while ((m = blockRe.exec(entryZone)) !== null) {
     const name = m[1];
     const content = m[2];
+    if (name === 'ENTRY') continue; // skip the sentinel itself
+    definitionStrings.push(m[0]); // full match, e.g. <!--FOO-->bar<!--/FOO-->
     // EMPTY variants are the absent-field fallback (e.g. <!--ORG_EMPTY-->).
     if (name.endsWith('_EMPTY')) {
-      const base = name.slice(0, -6); // strip _EMPTY suffix
+      const base = name.slice(0, -6);
       const existing = blocks.get(base) || { present: '', absent: '' };
       blocks.set(base, { ...existing, absent: content });
     } else {
@@ -207,17 +225,14 @@ function parsePartial(source) {
     }
   }
 
-  // Strip named block markers AND any remaining HTML comments (doc blocks).
-  // We use a loop to satisfy CodeQL's 'Incomplete multi-character sanitization'
-  // rule, ensuring that maliciously nested comments (e.g. <!--<!--foo-->-->)
-  // are fully removed. Block references ({{BLOCKNAME}}) stay in place.
-  let entryTemplate = source;
-  let previous = '';
-  while (entryTemplate !== previous) {
-    previous = entryTemplate;
-    entryTemplate = entryTemplate
-      .replace(/<!--[A-Z][A-Z0-9_]+-->[\s\S]*?<!--\/[A-Z][A-Z0-9_]+-->/g, () => '')
-      .replace(/<!--[\s\S]*?-->/g, () => '');
+  // Step 3: build the entry template by removing the captured block *definitions*
+  // verbatim. Block *references* ({{BLOCKNAME}}) remain and are resolved by
+  // fillEntry() at render time.
+  // We use split/join on the exact captured strings — no broad HTML-comment regex,
+  // so CodeQL js/incomplete-multi-character-sanitization cannot fire.
+  let entryTemplate = entryZone;
+  for (const def of definitionStrings) {
+    entryTemplate = entryTemplate.split(def).join('');
   }
   entryTemplate = entryTemplate.trim();
 

--- a/templates/sections/certifications.html
+++ b/templates/sections/certifications.html
@@ -1,0 +1,24 @@
+<!--
+  certifications.html — section partial for Certifications (#2183).
+
+  Entry-level placeholders (filled once per certification entry):
+    {{TITLE}}      — certification name (HTML-escaped)
+    {{ORG_BLOCK}}  — conditional: rendered when org is present, otherwise an empty
+                      <span class="cert-org"></span> is emitted for table-cell alignment.
+                      Contains {{ORG}}.
+    {{ORG}}        — issuing organization (HTML-escaped, inside ORG_BLOCK)
+    {{YEAR_BLOCK}} — conditional: same pattern as ORG_BLOCK for cert-year alignment.
+                      Contains {{YEAR}}.
+    {{YEAR}}       — year issued (HTML-escaped, inside YEAR_BLOCK)
+
+  {{ITEMS}} receives the concatenated rendered entries.
+-->
+<div class="cert-item">
+  <span class="cert-title">{{TITLE}}</span>
+  {{ORG_BLOCK}}
+  {{YEAR_BLOCK}}
+</div>
+<!--ORG_BLOCK--><span class="cert-org">{{ORG}}</span><!--/ORG_BLOCK-->
+<!--ORG_EMPTY--><span class="cert-org"></span><!--/ORG_EMPTY-->
+<!--YEAR_BLOCK--><span class="cert-year">{{YEAR}}</span><!--/YEAR_BLOCK-->
+<!--YEAR_EMPTY--><span class="cert-year"></span><!--/YEAR_EMPTY-->

--- a/templates/sections/certifications.html
+++ b/templates/sections/certifications.html
@@ -1,18 +1,16 @@
 <!--
   certifications.html — section partial for Certifications (#2183).
 
-  Entry-level placeholders (filled once per certification entry):
-    {{TITLE}}      — certification name (HTML-escaped)
-    {{ORG_BLOCK}}  — conditional: rendered when org is present, otherwise an empty
-                      <span class="cert-org"></span> is emitted for table-cell alignment.
-                      Contains {{ORG}}.
-    {{ORG}}        — issuing organization (HTML-escaped, inside ORG_BLOCK)
-    {{YEAR_BLOCK}} — conditional: same pattern as ORG_BLOCK for cert-year alignment.
-                      Contains {{YEAR}}.
-    {{YEAR}}       — year issued (HTML-escaped, inside YEAR_BLOCK)
+  Field placeholders filled per entry:
+    TITLE      — certification name
+    ORG_BLOCK  — conditional: cert-org span with org text when present;
+                 falls back to empty cert-org span (ORG_EMPTY) for table-cell alignment
+    YEAR_BLOCK — conditional: cert-year span with year text when present;
+                 falls back to empty cert-year span (YEAR_EMPTY) for alignment
 
-  {{ITEMS}} receives the concatenated rendered entries.
+  Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
 -->
+<!--ENTRY-->
 <div class="cert-item">
   <span class="cert-title">{{TITLE}}</span>
   {{ORG_BLOCK}}
@@ -22,3 +20,4 @@
 <!--ORG_EMPTY--><span class="cert-org"></span><!--/ORG_EMPTY-->
 <!--YEAR_BLOCK--><span class="cert-year">{{YEAR}}</span><!--/YEAR_BLOCK-->
 <!--YEAR_EMPTY--><span class="cert-year"></span><!--/YEAR_EMPTY-->
+<!--/ENTRY-->

--- a/templates/sections/competencies.html
+++ b/templates/sections/competencies.html
@@ -1,12 +1,11 @@
 <!--
   competencies.html — section partial for Core Competencies (#2183).
 
-  The builder renders one copy of this template per competency tag,
-  then concatenates all rendered entries for the COMPETENCIES placeholder.
-
-  Field placeholders (filled once per entry):
+  Field placeholders filled per entry:
     TAG  — competency text
 
-  Template packs: change the element type or class freely.
+  Template packs: change the element type or class freely inside the ENTRY zone.
 -->
+<!--ENTRY-->
 <span class="competency-tag">{{TAG}}</span>
+<!--/ENTRY-->

--- a/templates/sections/competencies.html
+++ b/templates/sections/competencies.html
@@ -1,0 +1,12 @@
+<!--
+  competencies.html — section partial for Core Competencies (#2183).
+
+  The builder renders one copy of this template per competency tag,
+  then concatenates all rendered entries for the COMPETENCIES placeholder.
+
+  Field placeholders (filled once per entry):
+    TAG  — competency text
+
+  Template packs: change the element type or class freely.
+-->
+<span class="competency-tag">{{TAG}}</span>

--- a/templates/sections/education.html
+++ b/templates/sections/education.html
@@ -1,18 +1,15 @@
 <!--
   education.html — section partial for Education (#2183).
 
-  Entry-level placeholders (filled once per education entry):
-    {{TITLE}}       — degree / course title (HTML-escaped)
-    {{ORG_BLOCK}}   — conditional: rendered when org is present, removed otherwise.
-                       Contains {{ORG}}.
-    {{ORG}}         — institution name (HTML-escaped, inside ORG_BLOCK)
-    {{YEAR}}        — graduation / completion year (HTML-escaped; empty string when absent)
-    {{DESC_BLOCK}}  — conditional: rendered when description is present, removed otherwise.
-                       Contains {{DESC}}.
-    {{DESC}}        — description text (HTML-escaped, inside DESC_BLOCK)
+  Field placeholders filled per entry:
+    TITLE      — degree / course title
+    ORG_BLOCK  — conditional: institution span when org is present; omitted otherwise
+    YEAR       — graduation / completion year (empty string when absent)
+    DESC_BLOCK — conditional: description div when description is present; omitted otherwise
 
-  {{ITEMS}} receives the concatenated rendered entries.
+  Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
 -->
+<!--ENTRY-->
 <div class="edu-item">
   <div class="edu-header">
     <div class="edu-title">{{TITLE}}{{ORG_BLOCK}}</div>
@@ -22,3 +19,4 @@
 </div>
 <!--ORG_BLOCK--> <span class="edu-org">{{ORG}}</span><!--/ORG_BLOCK-->
 <!--DESC_BLOCK--><div class="edu-desc">{{DESC}}</div><!--/DESC_BLOCK-->
+<!--/ENTRY-->

--- a/templates/sections/education.html
+++ b/templates/sections/education.html
@@ -1,0 +1,24 @@
+<!--
+  education.html — section partial for Education (#2183).
+
+  Entry-level placeholders (filled once per education entry):
+    {{TITLE}}       — degree / course title (HTML-escaped)
+    {{ORG_BLOCK}}   — conditional: rendered when org is present, removed otherwise.
+                       Contains {{ORG}}.
+    {{ORG}}         — institution name (HTML-escaped, inside ORG_BLOCK)
+    {{YEAR}}        — graduation / completion year (HTML-escaped; empty string when absent)
+    {{DESC_BLOCK}}  — conditional: rendered when description is present, removed otherwise.
+                       Contains {{DESC}}.
+    {{DESC}}        — description text (HTML-escaped, inside DESC_BLOCK)
+
+  {{ITEMS}} receives the concatenated rendered entries.
+-->
+<div class="edu-item">
+  <div class="edu-header">
+    <div class="edu-title">{{TITLE}}{{ORG_BLOCK}}</div>
+    <div class="edu-year">{{YEAR}}</div>
+  </div>
+  {{DESC_BLOCK}}
+</div>
+<!--ORG_BLOCK--> <span class="edu-org">{{ORG}}</span><!--/ORG_BLOCK-->
+<!--DESC_BLOCK--><div class="edu-desc">{{DESC}}</div><!--/DESC_BLOCK-->

--- a/templates/sections/experience.html
+++ b/templates/sections/experience.html
@@ -1,20 +1,16 @@
 <!--
   experience.html — section partial for Work Experience (#2183).
 
-  The builder renders one copy of this template per experience entry,
-  then concatenates all rendered entries for the EXPERIENCE placeholder.
-
-  Field placeholders (filled once per entry):
+  Field placeholders filled per entry:
     COMPANY          — employer name
-    PERIOD           — date range, e.g. "June 2024 - Present"
+    PERIOD           — date range
     ROLE             — job title
-    BULLETS          — rendered <li> tags (produced by the builder)
-    LOCATION_BLOCK   — conditional: rendered as .job-location div when location
-                       is present; omitted entirely when absent
+    BULLETS          — rendered <li> tags
+    LOCATION_BLOCK   — conditional: .job-location div when location present; omitted when absent
 
-  Template packs: edit tag names, class names, and field order freely.
-  The builder fills the placeholders; it never dictates the HTML structure.
+  Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
 -->
+<!--ENTRY-->
 <div class="job">
   <div class="job-header">
     <span class="job-company">{{COMPANY}}</span>
@@ -27,3 +23,4 @@
   </ul>
 </div>
 <!--LOCATION_BLOCK--><div class="job-location">{{LOCATION}}</div><!--/LOCATION_BLOCK-->
+<!--/ENTRY-->

--- a/templates/sections/experience.html
+++ b/templates/sections/experience.html
@@ -1,0 +1,29 @@
+<!--
+  experience.html — section partial for Work Experience (#2183).
+
+  The builder renders one copy of this template per experience entry,
+  then concatenates all rendered entries for the EXPERIENCE placeholder.
+
+  Field placeholders (filled once per entry):
+    COMPANY          — employer name
+    PERIOD           — date range, e.g. "June 2024 - Present"
+    ROLE             — job title
+    BULLETS          — rendered <li> tags (produced by the builder)
+    LOCATION_BLOCK   — conditional: rendered as .job-location div when location
+                       is present; omitted entirely when absent
+
+  Template packs: edit tag names, class names, and field order freely.
+  The builder fills the placeholders; it never dictates the HTML structure.
+-->
+<div class="job">
+  <div class="job-header">
+    <span class="job-company">{{COMPANY}}</span>
+    <span class="job-period">{{PERIOD}}</span>
+  </div>
+  <div class="job-role">{{ROLE}}</div>
+  {{LOCATION_BLOCK}}
+  <ul>
+    {{BULLETS}}
+  </ul>
+</div>
+<!--LOCATION_BLOCK--><div class="job-location">{{LOCATION}}</div><!--/LOCATION_BLOCK-->

--- a/templates/sections/projects.html
+++ b/templates/sections/projects.html
@@ -1,20 +1,15 @@
 <!--
   projects.html — section partial for Projects (#2183).
 
-  Entry-level placeholders (filled once per project entry):
-    {{NAME}}         — project name (HTML-escaped)
-    {{BADGE_BLOCK}}  — conditional: rendered when badge is present, removed otherwise.
-                        Contains {{BADGE}}.
-    {{BADGE}}        — badge text (HTML-escaped, inside BADGE_BLOCK)
-    {{DESC_BLOCK}}   — conditional: rendered when description is present, removed otherwise.
-                        Contains {{DESC}}.
-    {{DESC}}         — description text (HTML-escaped, inside DESC_BLOCK)
-    {{TECH_BLOCK}}   — conditional: rendered when tech is present, removed otherwise.
-                        Contains {{TECH}}.
-    {{TECH}}         — tech stack string (HTML-escaped, inside TECH_BLOCK)
+  Field placeholders filled per entry:
+    NAME         — project name
+    BADGE_BLOCK  — conditional: badge span when badge is present; omitted otherwise
+    DESC_BLOCK   — conditional: description div when description is present; omitted otherwise
+    TECH_BLOCK   — conditional: tech div when tech is present; omitted otherwise
 
-  {{ITEMS}} receives the concatenated rendered entries.
+  Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
 -->
+<!--ENTRY-->
 <div class="project">
   <div class="project-title">{{NAME}}{{BADGE_BLOCK}}</div>
   {{DESC_BLOCK}}
@@ -23,3 +18,4 @@
 <!--BADGE_BLOCK--><span class="project-badge">{{BADGE}}</span><!--/BADGE_BLOCK-->
 <!--DESC_BLOCK--><div class="project-desc">{{DESC}}</div><!--/DESC_BLOCK-->
 <!--TECH_BLOCK--><div class="project-tech">{{TECH}}</div><!--/TECH_BLOCK-->
+<!--/ENTRY-->

--- a/templates/sections/projects.html
+++ b/templates/sections/projects.html
@@ -1,0 +1,25 @@
+<!--
+  projects.html — section partial for Projects (#2183).
+
+  Entry-level placeholders (filled once per project entry):
+    {{NAME}}         — project name (HTML-escaped)
+    {{BADGE_BLOCK}}  — conditional: rendered when badge is present, removed otherwise.
+                        Contains {{BADGE}}.
+    {{BADGE}}        — badge text (HTML-escaped, inside BADGE_BLOCK)
+    {{DESC_BLOCK}}   — conditional: rendered when description is present, removed otherwise.
+                        Contains {{DESC}}.
+    {{DESC}}         — description text (HTML-escaped, inside DESC_BLOCK)
+    {{TECH_BLOCK}}   — conditional: rendered when tech is present, removed otherwise.
+                        Contains {{TECH}}.
+    {{TECH}}         — tech stack string (HTML-escaped, inside TECH_BLOCK)
+
+  {{ITEMS}} receives the concatenated rendered entries.
+-->
+<div class="project">
+  <div class="project-title">{{NAME}}{{BADGE_BLOCK}}</div>
+  {{DESC_BLOCK}}
+  {{TECH_BLOCK}}
+</div>
+<!--BADGE_BLOCK--><span class="project-badge">{{BADGE}}</span><!--/BADGE_BLOCK-->
+<!--DESC_BLOCK--><div class="project-desc">{{DESC}}</div><!--/DESC_BLOCK-->
+<!--TECH_BLOCK--><div class="project-tech">{{TECH}}</div><!--/TECH_BLOCK-->

--- a/templates/sections/skills.html
+++ b/templates/sections/skills.html
@@ -1,16 +1,13 @@
 <!--
   skills.html — section partial for Skills (#2183).
 
-  Entry-level placeholders (filled once per skill category):
-    {{CATEGORY_BLOCK}} — conditional: rendered when category is present, removed otherwise.
-                          Contains {{CATEGORY}}.
-    {{CATEGORY}}       — category label including trailing colon (HTML-escaped, inside CATEGORY_BLOCK)
-    {{ITEMS_TEXT}}     — comma-joined items string (HTML-escaped)
+  Field placeholders filled per skill category:
+    CATEGORY_BLOCK — conditional: category label span when category is present; omitted otherwise
+    ITEMS_TEXT     — comma-joined items string
 
-  The outer wrapper (skills-grid div) lives in the main template; this partial
-  renders only the repeating per-category rows.
-
-  {{ITEMS}} receives the concatenated rendered entries.
+  Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
 -->
+<!--ENTRY-->
 <div class="skill-item">{{CATEGORY_BLOCK}}{{ITEMS_TEXT}}</div>
 <!--CATEGORY_BLOCK--><span class="skill-category">{{CATEGORY}}: </span><!--/CATEGORY_BLOCK-->
+<!--/ENTRY-->

--- a/templates/sections/skills.html
+++ b/templates/sections/skills.html
@@ -1,0 +1,16 @@
+<!--
+  skills.html — section partial for Skills (#2183).
+
+  Entry-level placeholders (filled once per skill category):
+    {{CATEGORY_BLOCK}} — conditional: rendered when category is present, removed otherwise.
+                          Contains {{CATEGORY}}.
+    {{CATEGORY}}       — category label including trailing colon (HTML-escaped, inside CATEGORY_BLOCK)
+    {{ITEMS_TEXT}}     — comma-joined items string (HTML-escaped)
+
+  The outer wrapper (skills-grid div) lives in the main template; this partial
+  renders only the repeating per-category rows.
+
+  {{ITEMS}} receives the concatenated rendered entries.
+-->
+<div class="skill-item">{{CATEGORY_BLOCK}}{{ITEMS_TEXT}}</div>
+<!--CATEGORY_BLOCK--><span class="skill-category">{{CATEGORY}}: </span><!--/CATEGORY_BLOCK-->


### PR DESCRIPTION
# Support Declarative Section HTML Partials from Disk (#2183)

### Problem
Previously, `build-cv-html.mjs` hardcoded the DOM structures, class names, and tags for sections (like `experience`, `projects`, `education`, etc.) inside the script builders. This meant that templates could only reskin elements via CSS but were unable to reorder fields, change HTML tag types, restructure layouts, or introduce custom CSS classes.

### Solution
This PR implements **Option A (Section HTML partials on disk)**. It decouples the builder script from hardcoding the DOM, shifting structural ownership of CV sections to templates, while maintaining complete backward compatibility.

- **Disk Partials (`templates/sections/`)**: Added default section templates (`experience.html`, `projects.html`, `education.html`, `certifications.html`, `competencies.html`, and `skills.html`) that are co-located with `cv-template.html`.
- **Dynamic Partial Loader**: `build-cv-html.mjs` now discovers and loads these partials at render time if a `sections/` directory is co-located with the chosen template.
- **Conditional Markup (`<!--BLOCK_NAME-->`)**: Supports wrapping optional fields inside partials using HTML comments (e.g., hiding location details when `location` is omitted from the JSON payload, or outputting empty `span` tags for certifications layout tables).
- **Backward Compatibility**: If the `sections/` folder or a specific section HTML file is absent, the builder falls back to its built-in hardcoded string construction.
- **Improved Parsing**: HTML documentation comments inside the partial files are automatically stripped out at render time to prevent template compilation errors and avoid leaking documentation text into the final HTML output.

### Changes Included
- **Added**: 
  - `templates/sections/experience.html`
  - `templates/sections/competencies.html`
  - `templates/sections/projects.html`
  - `templates/sections/education.html`
  - `templates/sections/certifications.html`
  - `templates/sections/skills.html`
- **Modified**: `build-cv-html.mjs`
  - Implemented `loadSectionPartials()`, `parsePartial()`, and `fillEntry()`.
  - Updated section builders to use the dynamically loaded partials if available.
  - Expanded the script's `--test` self-test suite to validate partial rendering, data population, empty-value alignment block fallbacks, and conditional block hiding.

### Verification Results
Ran `node build-cv-html.mjs --test` locally:
```json
{
  "status": "self-test-passed",
  "file": "build-cv-html-test.html",
  "valid": true
}
```

Closes #2183


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for template-adjacent HTML section partials via a `sections/` directory, enabling per-entry reusable HTML regions.
  * Added built-in partial templates for experience, education, projects, skills, core competencies, and certifications.
  * Sections now conditionally render optional fields using consistent layout-safe fallbacks.
* **Bug Fixes**
  * Improved rendering reliability when optional fields like experience location or certification org/year are missing.
* **Documentation**
  * Updated CLI help to explain section partials behavior.
* **Tests**
  * Expanded self-tests to verify partial-driven output and conditional omissions/alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->