### PR TITLE
fix(normalize-statuses): use header-mapped columns instead of fixed indices

### DIFF
--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'url';
 import {
   openTrackerTransaction, rebuildRow, resolveTrackerPath,
 } from './tracker-utils.mjs';
+import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = resolveTrackerPath(CAREER_OPS);
@@ -112,19 +113,21 @@ const lines = content.split('\n');
 let changes = 0;
 let unknowns = [];
 
+// Map columns by header name (tracker-parse.mjs, #954/#1596). Fixed indices
+// assumed the original 9-column layout, so a customized tracker — an inserted
+// Location or Via column — shifted every field one to the left: the Score cell
+// was normalized as if it were the status and overwritten, while the real
+// status was left alone and reported as unknown (#1955).
+const COLS = resolveColumns(lines);
+
 for (let i = 0; i < lines.length; i++) {
   const line = lines[i];
-  if (!line.startsWith('|')) continue;
+  const row = parseTrackerRow(line, COLS);
+  if (!row) continue; // header, separator, non-row, or a row missing cells
 
   const parts = line.split('|').map(s => s.trim());
-  // Format: ['', '#', 'fecha', 'empresa', 'rol', 'score', 'STATUS', 'pdf', 'report', 'notas', '']
-  if (parts.length < 9) continue;
-  if (parts[1] === '#' || parts[1] === '---' || parts[1] === '') continue;
-
-  const num = parseInt(parts[1]);
-  if (isNaN(num)) continue;
-
-  const rawStatus = parts[6];
+  const num = row.num;
+  const rawStatus = row.status;
   const result = normalizeStatus(rawStatus);
 
   if (result.unknown) {
@@ -136,21 +139,21 @@ for (let i = 0; i < lines.length; i++) {
 
   // Apply change
   const oldStatus = rawStatus;
-  parts[6] = result.status;
+  parts[COLS.status] = result.status;
 
-  // Move DUPLICADO info to notes if needed
-  if (result.moveToNotes && parts[9]) {
-    const existing = parts[9] || '';
+  // Move DUPLICADO info to notes if needed. A layout without a Notes column
+  // has nowhere to put it — dropping the provenance beats appending a cell the
+  // table has no header for.
+  if (result.moveToNotes && COLS.notes != null) {
+    const existing = parts[COLS.notes] || '';
     if (!existing.includes(result.moveToNotes)) {
-      parts[9] = result.moveToNotes + (existing ? '. ' + existing : '');
+      parts[COLS.notes] = result.moveToNotes + (existing ? '. ' + existing : '');
     }
-  } else if (result.moveToNotes && !parts[9]) {
-    parts[9] = result.moveToNotes;
   }
 
   // Also strip bold from score field
-  if (parts[5]) {
-    parts[5] = parts[5].replace(/\*\*/g, '');
+  if (parts[COLS.score]) {
+    parts[COLS.score] = parts[COLS.score].replace(/\*\*/g, '');
   }
 
   // Reconstruct line

--- a/tracker-columns-tests.mjs
+++ b/tracker-columns-tests.mjs
@@ -223,12 +223,48 @@ const TSV_NO_LOCATION = '2\t2026-02-02\tGlobex\tManager\tApplied\tN/A\t✅\t—\
   rmSync(sb.dir, { recursive: true, force: true });
 }
 
+// ── Test 6b: normalize-statuses maps Status/Score/Notes by header (#1955) ───
+// normalize-statuses.mjs read Status at parts[6], Score at parts[5] and Notes
+// at parts[9]. On a 10-column tracker every one of those lands a column early:
+// the Score cell was normalized as if it were a status — a `—` score (the
+// tracker's own "no evaluation" sentinel) mapped to Discarded and OVERWROTE
+// the Score column — while the real, non-canonical status was left untouched
+// and reported as an unknown status instead.
+{
+  const TEN_COL_MESSY = `# Applications Tracker
+
+| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|----------|-------|--------|-----|--------|-------|
+| 1 | 2026-01-01 | Acme | Engineer | Remote | — | Aplicado 2026-01-02 | ✅ | — | backfilled, no eval |
+| 2 | 2026-01-03 | Globex | Manager | Berlin | 4.5/5 | DUPLICADO de #1 | ❌ | — | keep me |
+`;
+  const sb = makeSandbox(TEN_COL_MESSY);
+  const res = runScript('normalize-statuses.mjs', [], sb);
+  const rows = dataRows(sb.tracker);
+  const rowOf = (company) => rows.find(l => l.includes(company)) || '';
+  const cellsOf = (company) => rowOf(company).split('|').map(s => s.trim());
+  // cells: ['', num, date, company, role, location, score, status, pdf, report, notes, '']
+  const acme = cellsOf('Acme');
+  if (res.code === 0 && acme[7] === 'Applied' && acme[6] === '—') {
+    pass('normalize-statuses: Status normalized in place on 10-col tracker, Score not clobbered');
+  } else {
+    fail(`normalize-statuses on 10-col tracker (code ${res.code}) row: ${rowOf('Acme')}\n${res.stdout}`);
+  }
+  const globex = cellsOf('Globex');
+  if (globex[7] === 'Discarded' && globex[6] === '4.5/5'
+      && globex[10].includes('DUPLICADO de #1') && globex[10].includes('keep me')) {
+    pass('normalize-statuses: DUPLICADO provenance lands in the Notes column on 10-col tracker');
+  } else {
+    fail(`normalize-statuses DUPLICADO row on 10-col tracker: ${rowOf('Globex')}\n${res.stdout}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
 // ── Test 7: schema contract — every consumer maps an UNKNOWN extra column ───
 // The header-name contract (#1596): a column no consumer recognizes must be
 // skipped by ALL of them, never silently shifted into a known field. This is
 // the guard that makes the next column insertion a one-place change instead of
-// a repo-wide incident. normalize-statuses.mjs is excluded until PR #1114
-// (which retrofits it) lands — add it here when that merges.
+// a repo-wide incident.
 {
   const HEADER_UNKNOWN = `# Applications Tracker
 
@@ -258,6 +294,18 @@ const TSV_NO_LOCATION = '2\t2026-02-02\tGlobex\tManager\tApplied\tN/A\t✅\t—\
     pass('contract: scan.mjs seen-set skips an unknown extra column');
   } else {
     fail(`contract: scan.mjs seen-set on unknown-column tracker — [${[...seen].join(', ')}]`);
+  }
+
+  // The seed status is already canonical, so a header-aware run is a strict
+  // no-op: the file must come back byte-identical and nothing may be reported
+  // as an unknown status.
+  const before = readFileSync(sb.tracker, 'utf-8');
+  const norm = runScript('normalize-statuses.mjs', [], sb);
+  const after = readFileSync(sb.tracker, 'utf-8');
+  if (norm.code === 0 && after === before && !/unknown statuses/.test(norm.stdout)) {
+    pass('contract: normalize-statuses skips an unknown extra column');
+  } else {
+    fail(`contract: normalize-statuses on unknown-column tracker (code ${norm.code})\n${norm.stdout}`);
   }
 
   rmSync(sb.dir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #1955. Credit to @SparshGarg999 for the report.

## Overlap with #1114 — your call, not mine

@nikitacometa's #1114 covers this ground as part of a larger change. I'm opening this anyway because that PR has been conflicted with no push since 2026-07-11, and @FReptar0's note there gave a ~1-week stale window that has now passed. If you'd rather revive #1114, close this — no hard feelings, and this PR does not try to replace it.

The scopes differ:

| | #1114 | this |
|---|---|---|
| Files | 9 | 1 (+1 test file) |
| Column mapping | introduces its own `column-map.mjs` | uses `tracker-parse.mjs`, already on `main` |
| Also does | i18n, integrity checks | nothing else |

`tracker-parse.mjs` landed on `main` after #1114 opened and does the job `column-map.mjs` was written for, so this rides the current abstraction rather than a competing one. @santifer's comment on #1114 — *"killing the parts[5]/parts[6] hardcoding is the right fix"* — is the direction I followed.

## The bug

`normalize-statuses.mjs:115-154` parsed and rewrote rows by fixed index (`parts[6]` status, `parts[5]` score, `parts[9]` notes, `parts[1]` num) while the rest of the toolchain resolves columns from the header. With the documented optional `Location` column present:

```
| 1 | 2026-02-01 | Acme | Data Engineer | Remote | — | Aplicado 2026-02-02 | ❌ | — | backfilled, no eval |
```

```
#1: "—" → "Discarded"
⚠️  1 unknown statuses:  #2 (line 6): "4.5/5"
→ | 1 | ... | Remote | Discarded | Aplicado 2026-02-02 | ...
```

The `—` no-evaluation sentinel in **Score** was read as a status and overwritten with `Discarded`; the real status was left non-canonical; row 2's genuine `Rechazada` was reported as unknown status `"4.5/5"`. This is a writer that also `.bak`s over the previous backup, so the last good copy goes with it.

## The fix

One logical change in `normalize-statuses.mjs` (+39/−20): resolve columns once with `resolveColumns(lines)`, read rows through `parseTrackerRow()`, write to `parts[COLS.status]` / `parts[COLS.notes]` / `parts[COLS.score]`. The `moveToNotes` branch is guarded on `COLS.notes != null` — a layout with no Notes column has nowhere to put DUPLICADO provenance, and the old `else` appended a headerless cell.

## Tests

Added to `tracker-columns-tests.mjs` (already wired into `test-all.mjs:172`), and removed the now-stale TODO at `:230` that said *"normalize-statuses.mjs is excluded until PR #1114 (which retrofits it) lands."*

- **6b** — 10-col tracker: status normalized in Status, Score untouched, DUPLICADO provenance lands in Notes preserving the existing note
- **7 contract** — `normalize-statuses` added to the unknown-extra-column contract alongside `verify-pipeline` / `tracker.mjs` / `scan.mjs`: file returns byte-identical, no unknown statuses

Regression proof — `git checkout -- normalize-statuses.mjs`, tests kept:

```
FAIL normalize-statuses on 10-col tracker (code 0)
FAIL normalize-statuses DUPLICADO row on 10-col tracker
FAIL contract: normalize-statuses on unknown-column tracker (code 0)
40 passed, 3 failed
```
Restored → `43 passed, 0 failed`.

Full suite: `node test-all.mjs --quick` → **2042 passed, 0 failed, 2 warnings**, byte-identical pass/fail set vs. baseline (the 2 warnings are pre-existing: no user data for `cv-sync-check`, no Playwright browser for archive render).

Back-compat spot-checks: legacy 9-col with no trailing pipe keeps its notes cell; bold stripped from score; headerless tracker still works via `LEGACY_COLMAP`.

## One behaviour change worth flagging

`parseTrackerRow` enforces a strict full-width guard where the old code accepted `parts.length >= 9`. A **ragged** row narrower than its own header is now silently skipped rather than normalized (verified: reports `0 statuses normalized`).

I think fail-closed is right for a writer — rewriting a short row by index is exactly how columns get shifted — and it matches every other reader. But it *is* silent. If you'd prefer it warn like the `unknown statuses` block does, say the word; I left that out since `verify-pipeline.mjs` is the designated integrity checker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status normalization for trackers with reordered or additional columns.
  * Prevented score values from being overwritten during normalization.
  * Ensured duplicate provenance is added to the Notes field when available.
  * Preserved tracker content when unknown extra columns are present.

* **Tests**
  * Added coverage for varied tracker layouts and unchanged-file behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->