### PR TITLE
fix(pipeline): lock appendToPipeline() against concurrent read-modify-write

### DIFF
--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -1,4 +1,4 @@
-// pipeline-lock.mjs — a tiny cross-process advisory lock for data/pipeline.md.
+// pipeline-lock.mjs — a cross-process advisory lock for data/pipeline.md.
 //
 // appendToPipeline() (scan.mjs) is a plain read-modify-write: readFileSync,
 // mutate the string, writeFileSync. It's exported and called from three
@@ -8,24 +8,38 @@
 // silently drop one side's offers: whichever write lands second overwrites
 // the first's in-memory read, with no error and no trace anything was lost.
 //
-// Protocol: the lock is a directory ("<path>.lock") — a mkdir is atomic. A
-// holder older than STALE_MS is presumed crashed and reclaimed. Acquisition
-// retries with a short backoff until MAX_WAIT_MS, then throws
-// LockTimeoutError. Deliberately self-contained (no re-entrancy tracking):
-// nothing in this codebase nests a second acquisition of this same lock, so
-// that machinery isn't needed here.
+// Protocol — deliberately the same shape as the tracker lock in
+// tracker-utils.mjs, so there is one lock idiom in the codebase:
+//   - the lock is a directory ("<path>.lock"); a mkdir is atomic.
+//   - the holder records owner.json — pid, a unique token, started_at — so
+//     both stale-reclaim and release can verify who actually owns the lock
+//     before deleting anything.
+//   - staleness is judged by owner-PID liveness first, falling back to
+//     directory age only when the metadata is missing or unreadable. An old
+//     lock whose owner is still running is NOT stale.
+//   - stale reclamation is serialized behind a second atomic guard directory
+//     ("<path>.lock.recover"). Without it, reclamation is itself a TOCTOU
+//     race: two callers that both judge the same lock stale can have the
+//     second one's rmSync delete the first one's freshly created lock, after
+//     which both believe they hold it — reintroducing the very race this
+//     module exists to close, just gated behind a crash + contention window.
+//
+// Timing is caller-configurable (with these defaults) so tests can exercise
+// contention in milliseconds instead of waiting out a multi-second constant.
 
-import { mkdirSync, rmSync, statSync, writeFileSync } from 'fs';
+import { mkdirSync, rmSync, statSync, existsSync, writeFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { randomUUID } from 'crypto';
 
-const STALE_MS = 30_000;
-const RETRY_MS = 80;
-const MAX_WAIT_MS = 8_000;
+const DEFAULT_STALE_MS = 30_000;
+const DEFAULT_RETRY_MS = 80;
+const DEFAULT_TIMEOUT_MS = 8_000;
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 export class LockTimeoutError extends Error {
-  constructor(lockDir) {
-    super(`pipeline lock timeout: ${lockDir} held > ${MAX_WAIT_MS}ms`);
+  constructor(lockDir, timeoutMs) {
+    super(`pipeline lock timeout: ${lockDir} held > ${timeoutMs}ms`);
     this.name = 'LockTimeoutError';
     this.lockDir = lockDir;
   }
@@ -35,59 +49,161 @@ export function lockDirFor(pipelinePath) {
   return `${pipelinePath}.lock`;
 }
 
-/** Blocks until the lock on `pipelinePath` is held, then returns a handle whose release() frees it. */
-export async function acquirePipelineLock(pipelinePath) {
+/** Owner metadata for a lock directory, or null when missing/unreadable. */
+function readLockOwner(lockDir) {
+  try {
+    return JSON.parse(readFileSync(join(lockDir, 'owner.json'), 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+// Identity of a directory, so a lock that was removed and recreated by another
+// process is never mistaken for the one this caller created.
+function sameLockDirectory(left, right) {
+  return left.dev === right.dev && left.ino === right.ino
+    && (left.ino !== 0 || left.birthtimeMs === right.birthtimeMs);
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === 'EPERM'; // exists, just not signalable by this user
+  }
+}
+
+// Conservative: a lock whose recorded owner is still running is never stale,
+// however old it is. Age is the fallback only when there's no readable owner.
+function lockCanRecover(lockDir, staleMs) {
+  const owner = readLockOwner(lockDir);
+  if (owner?.pid) return !processIsAlive(owner.pid);
+  try {
+    return Date.now() - statSync(lockDir).mtimeMs > staleMs;
+  } catch {
+    return true; // vanished — nothing to recover, retry acquisition
+  }
+}
+
+/**
+ * Blocks until the lock on `pipelinePath` is held, then returns a handle whose
+ * release() frees it. Throws LockTimeoutError if the lock stays busy.
+ *
+ * @param {string} pipelinePath - File the lock guards.
+ * @param {object} [options]
+ * @param {number} [options.timeoutMs=8000] - Max time to wait for the lock.
+ * @param {number} [options.retryMs=80] - Delay between acquisition attempts.
+ * @param {number} [options.staleMs=30000] - Age threshold for a lock with no readable owner.
+ */
+export async function acquirePipelineLock(pipelinePath, options = {}) {
+  // Env overrides let a caller several frames up the stack (a test driving
+  // appendToPipeline, say) tune contention timing without threading options
+  // through every signature — same escape hatch the tracker lock provides.
+  const timeoutMs = options.timeoutMs ?? (Number(process.env.CAREER_OPS_PIPELINE_LOCK_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS);
+  const retryMs = options.retryMs ?? (Number(process.env.CAREER_OPS_PIPELINE_LOCK_RETRY_MS) || DEFAULT_RETRY_MS);
+  const staleMs = options.staleMs ?? (Number(process.env.CAREER_OPS_PIPELINE_LOCK_STALE_MS) || DEFAULT_STALE_MS);
   const lockDir = lockDirFor(pipelinePath);
-  const deadline = Date.now() + MAX_WAIT_MS;
+  const recoverGuardDir = `${lockDir}.recover`;
+  const token = randomUUID();
+  const deadline = Date.now() + timeoutMs;
+
+  // A fresh install may not have data/ yet — plugins.mjs's cmdRun calls
+  // appendToPipeline with no directory pre-creation, so create it here rather
+  // than letting mkdirSync(lockDir) throw a raw ENOENT.
+  mkdirSync(dirname(lockDir), { recursive: true });
 
   for (;;) {
     try {
       mkdirSync(lockDir);
-      break; // acquired
     } catch (err) {
-      if (err.code !== 'EEXIST') throw err;
-      let ageMs = Infinity;
+      if (err?.code !== 'EEXIST') throw err;
+
+      // Serialize stale-reclaim behind a second atomic guard so only one
+      // caller can be inside the decide-then-delete window at a time.
+      let hasRecoverGuard = false;
       try {
-        ageMs = Date.now() - statSync(lockDir).mtimeMs;
-      } catch {
-        ageMs = Infinity; // vanished between mkdir and stat — retry
+        mkdirSync(recoverGuardDir);
+        hasRecoverGuard = true;
+      } catch (guardErr) {
+        if (guardErr?.code !== 'EEXIST') throw guardErr;
+        // A process killed between taking the guard and cleaning it up would
+        // otherwise disable stale recovery forever. The guard normally lives
+        // for milliseconds, so an old one is judged by the same age rule.
+        if (lockCanRecover(recoverGuardDir, staleMs)) {
+          rmSync(recoverGuardDir, { recursive: true, force: true });
+        }
       }
-      if (ageMs > STALE_MS) {
+
+      if (hasRecoverGuard) {
+        try {
+          if (lockCanRecover(lockDir, staleMs)) {
+            rmSync(lockDir, { recursive: true, force: true });
+            continue; // retry acquisition immediately, still holding the guard's decision
+          }
+        } finally {
+          rmSync(recoverGuardDir, { recursive: true, force: true });
+        }
+      }
+
+      if (Date.now() > deadline) throw new LockTimeoutError(lockDir, timeoutMs);
+      await sleep(retryMs);
+      continue;
+    }
+
+    // Acquired. Record ownership; an owner-less lock would block every future
+    // acquirer until the age-out, so clean up if the stamp can't be written.
+    try {
+      writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
+        pid: process.pid,
+        token,
+        started_at: new Date().toISOString(),
+        pipeline: pipelinePath,
+      }, null, 2));
+    } catch (ownerErr) {
+      rmSync(lockDir, { recursive: true, force: true });
+      throw ownerErr;
+    }
+
+    let released = false;
+    return {
+      lockDir,
+      release() {
+        if (released) return;
+        released = true;
+        // Verify this caller still owns the lock before removing anything: if
+        // our operation outlived staleMs and another process legitimately
+        // reclaimed the lock, deleting it here would free someone else's
+        // critical section.
+        let before;
+        try {
+          before = statSync(lockDir);
+        } catch {
+          return; // already gone
+        }
+        const owner = readLockOwner(lockDir);
+        if (owner?.token !== token) return; // reclaimed by someone else — leave it alone
+        let after;
+        try {
+          after = statSync(lockDir);
+        } catch {
+          return;
+        }
+        if (!sameLockDirectory(before, after)) return; // swapped underneath us
         try {
           rmSync(lockDir, { recursive: true, force: true });
         } catch {
-          /* another process may have reclaimed it first */
+          /* best-effort; a stale-reclaim will recover it */
         }
-        continue; // retry immediately
-      }
-      if (Date.now() > deadline) {
-        throw new LockTimeoutError(lockDir);
-      }
-      await sleep(RETRY_MS);
-    }
+      },
+    };
   }
-
-  try {
-    writeFileSync(`${lockDir}/owner`, `${process.pid} ${new Date().toISOString()}\n`);
-  } catch {
-    /* owner stamp is diagnostic only */
-  }
-
-  return {
-    lockDir,
-    release() {
-      try {
-        rmSync(lockDir, { recursive: true, force: true });
-      } catch {
-        /* best-effort release; a stale-reclaim will recover it */
-      }
-    },
-  };
 }
 
 /** Acquires the lock on `pipelinePath`, runs fn, and always releases it. */
-export async function withPipelineLock(pipelinePath, fn) {
-  const lock = await acquirePipelineLock(pipelinePath);
+export async function withPipelineLock(pipelinePath, fn, options = {}) {
+  const lock = await acquirePipelineLock(pipelinePath, options);
   try {
     return await fn();
   } finally {

--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -1,0 +1,96 @@
+// pipeline-lock.mjs — a tiny cross-process advisory lock for data/pipeline.md.
+//
+// appendToPipeline() (scan.mjs) is a plain read-modify-write: readFileSync,
+// mutate the string, writeFileSync. It's exported and called from three
+// places — scan.mjs itself, scan-ats-full.mjs, and plugins.mjs (pipeline
+// mode) — so any two of them running concurrently (a scheduled scan
+// overlapping a manual `/career-ops pipeline` run, or two plugin jobs) can
+// silently drop one side's offers: whichever write lands second overwrites
+// the first's in-memory read, with no error and no trace anything was lost.
+//
+// Protocol: the lock is a directory ("<path>.lock") — a mkdir is atomic. A
+// holder older than STALE_MS is presumed crashed and reclaimed. Acquisition
+// retries with a short backoff until MAX_WAIT_MS, then throws
+// LockTimeoutError. Deliberately self-contained (no re-entrancy tracking):
+// nothing in this codebase nests a second acquisition of this same lock, so
+// that machinery isn't needed here.
+
+import { mkdirSync, rmSync, statSync, writeFileSync } from 'fs';
+
+const STALE_MS = 30_000;
+const RETRY_MS = 80;
+const MAX_WAIT_MS = 8_000;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export class LockTimeoutError extends Error {
+  constructor(lockDir) {
+    super(`pipeline lock timeout: ${lockDir} held > ${MAX_WAIT_MS}ms`);
+    this.name = 'LockTimeoutError';
+    this.lockDir = lockDir;
+  }
+}
+
+export function lockDirFor(pipelinePath) {
+  return `${pipelinePath}.lock`;
+}
+
+/** Blocks until the lock on `pipelinePath` is held, then returns a handle whose release() frees it. */
+export async function acquirePipelineLock(pipelinePath) {
+  const lockDir = lockDirFor(pipelinePath);
+  const deadline = Date.now() + MAX_WAIT_MS;
+
+  for (;;) {
+    try {
+      mkdirSync(lockDir);
+      break; // acquired
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+      let ageMs = Infinity;
+      try {
+        ageMs = Date.now() - statSync(lockDir).mtimeMs;
+      } catch {
+        ageMs = Infinity; // vanished between mkdir and stat — retry
+      }
+      if (ageMs > STALE_MS) {
+        try {
+          rmSync(lockDir, { recursive: true, force: true });
+        } catch {
+          /* another process may have reclaimed it first */
+        }
+        continue; // retry immediately
+      }
+      if (Date.now() > deadline) {
+        throw new LockTimeoutError(lockDir);
+      }
+      await sleep(RETRY_MS);
+    }
+  }
+
+  try {
+    writeFileSync(`${lockDir}/owner`, `${process.pid} ${new Date().toISOString()}\n`);
+  } catch {
+    /* owner stamp is diagnostic only */
+  }
+
+  return {
+    lockDir,
+    release() {
+      try {
+        rmSync(lockDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort release; a stale-reclaim will recover it */
+      }
+    },
+  };
+}
+
+/** Acquires the lock on `pipelinePath`, runs fn, and always releases it. */
+export async function withPipelineLock(pipelinePath, fn) {
+  const lock = await acquirePipelineLock(pipelinePath);
+  try {
+    return await fn();
+  } finally {
+    lock.release();
+  }
+}

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -162,7 +162,7 @@ async function cmdRun(args) {
     const jobs = found.filter(j => !known.has(j.url) && !seen.has(j.url) && seen.add(j.url));
     console.log(`${id} ${hook}: ${found.length} found, ${jobs.length} new.`);
     if (dryRun) { jobs.slice(0, 20).forEach(j => console.log(`  • ${j.title} — ${j.url}`)); console.log('(--dry-run: pipeline not written)'); return; }
-    if (jobs.length) { appendToPipeline(jobs); console.log(`→ Appended ${jobs.length} to data/pipeline.md. Run /career-ops pipeline to evaluate.`); }
+    if (jobs.length) { await appendToPipeline(jobs); console.log(`→ Appended ${jobs.length} to data/pipeline.md. Run /career-ops pipeline to evaluate.`); }
     return;
   }
 

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -620,7 +620,7 @@ async function main() {
       mkdirSync(path.dirname(PIPELINE_PATH), { recursive: true });
       writeFileSync(PIPELINE_PATH, '# Pipeline\n\n## Pendientes\n', 'utf-8');
     }
-    appendToPipeline(offers);
+    await appendToPipeline(offers);
     appendToScanHistory(offers, date);
     saved = true;
     log(`\nResults saved to ${PIPELINE_PATH} and data/scan-history.tsv`);

--- a/scan.mjs
+++ b/scan.mjs
@@ -44,6 +44,7 @@ import { classifyFetchError } from './verify-portals.mjs';
 import { fingerprintText, findCrossListings } from './fingerprint-core.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
+import { withPipelineLock } from './pipeline-lock.mjs';
 
 try {
   const { config } = await import('dotenv');
@@ -1274,39 +1275,44 @@ Paste job URLs below as \`- [ ] {url}\` then run \`/career-ops pipeline\`.
 const PENDING_MARKERS = ['## Pending', '## Pendientes'];
 const PROCESSED_MARKERS = ['## Processed', '## Procesadas'];
 
-export function appendToPipeline(offers) {
+// Locked (pipeline-lock.mjs) so scan.mjs, scan-ats-full.mjs, and plugins.mjs
+// (pipeline mode) — the three current callers — can never interleave their
+// read-modify-write and silently drop each other's offers.
+export async function appendToPipeline(offers) {
   if (offers.length === 0) return;
 
-  // Auto-create with standard skeleton if missing (fresh-install guard).
-  if (!existsSync(PIPELINE_PATH)) {
-    writeFileSync(PIPELINE_PATH, PIPELINE_SKELETON, 'utf-8');
-  }
+  await withPipelineLock(PIPELINE_PATH, async () => {
+    // Auto-create with standard skeleton if missing (fresh-install guard).
+    if (!existsSync(PIPELINE_PATH)) {
+      writeFileSync(PIPELINE_PATH, PIPELINE_SKELETON, 'utf-8');
+    }
 
-  let text = readFileSync(PIPELINE_PATH, 'utf-8');
+    let text = readFileSync(PIPELINE_PATH, 'utf-8');
 
-  const marker = PENDING_MARKERS.find(m => text.includes(m)) ?? null;
-  const idx = marker !== null ? text.indexOf(marker) : -1;
+    const marker = PENDING_MARKERS.find(m => text.includes(m)) ?? null;
+    const idx = marker !== null ? text.indexOf(marker) : -1;
 
-  if (idx === -1) {
-    // No Pending section found — insert one before Processed (or at end)
-    const procIdx = PROCESSED_MARKERS.reduce((found, m) => {
-      const i = text.indexOf(m);
-      return (found === -1 || (i !== -1 && i < found)) ? i : found;
-    }, -1);
-    const insertAt = procIdx === -1 ? text.length : procIdx;
-    const block = `\n## Pending\n\n` + offers.map(formatPipelineOffer).join('\n') + '\n\n';
-    text = text.slice(0, insertAt) + block + text.slice(insertAt);
-  } else {
-    // Find the end of existing Pending content (next ## or end)
-    const afterMarker = idx + marker.length;
-    const nextSection = text.indexOf('\n## ', afterMarker);
-    const insertAt = nextSection === -1 ? text.length : nextSection;
+    if (idx === -1) {
+      // No Pending section found — insert one before Processed (or at end)
+      const procIdx = PROCESSED_MARKERS.reduce((found, m) => {
+        const i = text.indexOf(m);
+        return (found === -1 || (i !== -1 && i < found)) ? i : found;
+      }, -1);
+      const insertAt = procIdx === -1 ? text.length : procIdx;
+      const block = `\n## Pending\n\n` + offers.map(formatPipelineOffer).join('\n') + '\n\n';
+      text = text.slice(0, insertAt) + block + text.slice(insertAt);
+    } else {
+      // Find the end of existing Pending content (next ## or end)
+      const afterMarker = idx + marker.length;
+      const nextSection = text.indexOf('\n## ', afterMarker);
+      const insertAt = nextSection === -1 ? text.length : nextSection;
 
-    const block = '\n' + offers.map(formatPipelineOffer).join('\n') + '\n';
-    text = text.slice(0, insertAt) + block + text.slice(insertAt);
-  }
+      const block = '\n' + offers.map(formatPipelineOffer).join('\n') + '\n';
+      text = text.slice(0, insertAt) + block + text.slice(insertAt);
+    }
 
-  writeFileSync(PIPELINE_PATH, text, 'utf-8');
+    writeFileSync(PIPELINE_PATH, text, 'utf-8');
+  });
 }
 
 export function appendToScanHistory(offers, date, status = 'added') {
@@ -1930,7 +1936,7 @@ async function main() {
 
   // 6. Write results
   if (!dryRun && verifiedOffers.length > 0) {
-    appendToPipeline(verifiedOffers);
+    await appendToPipeline(verifiedOffers);
     appendToScanHistory(verifiedOffers, date);
   }
   if (!dryRun && cooldownOffers.length > 0) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2060,13 +2060,20 @@ try {
   const { acquirePipelineLock, LockTimeoutError } = await import(pathToFileURL(join(ROOT, 'pipeline-lock.mjs')).href);
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-pipeline-lock-'));
   const originalCwd = process.cwd();
+  let prevTimeout;
+  let prevRetry;
   try {
     mkdirSync(join(fixtureRoot, 'data'), { recursive: true });
     process.chdir(fixtureRoot);
     const pipelinePath = join(fixtureRoot, 'data', 'pipeline.md');
     // Hold the exact lock appendToPipeline() takes, then confirm it genuinely
     // blocks on it (times out) rather than racing straight through to its
-    // read-modify-write.
+    // read-modify-write. The env overrides keep this assertion in the
+    // milliseconds range instead of waiting out the module's real default.
+    prevTimeout = process.env.CAREER_OPS_PIPELINE_LOCK_TIMEOUT_MS;
+    prevRetry = process.env.CAREER_OPS_PIPELINE_LOCK_RETRY_MS;
+    process.env.CAREER_OPS_PIPELINE_LOCK_TIMEOUT_MS = '200';
+    process.env.CAREER_OPS_PIPELINE_LOCK_RETRY_MS = '20';
     const held = await acquirePipelineLock(pipelinePath);
     try {
       await appendToPipeline([{ url: 'https://jobs.example.com/1', company: 'Acme', title: 'Engineer' }]);
@@ -2078,6 +2085,10 @@ try {
       held.release();
     }
   } finally {
+    if (prevTimeout === undefined) delete process.env.CAREER_OPS_PIPELINE_LOCK_TIMEOUT_MS;
+    else process.env.CAREER_OPS_PIPELINE_LOCK_TIMEOUT_MS = prevTimeout;
+    if (prevRetry === undefined) delete process.env.CAREER_OPS_PIPELINE_LOCK_RETRY_MS;
+    else process.env.CAREER_OPS_PIPELINE_LOCK_RETRY_MS = prevRetry;
     process.chdir(originalCwd);
     rmSync(fixtureRoot, { recursive: true, force: true });
   }
@@ -8813,6 +8824,13 @@ console.log('\n59. CV template resolver (cv-templates.mjs)');
   const resolved = run(NODE, ['cv-templates.mjs', 'resolve', 'cv'], noProfile);
   if (resolved && resolved.endsWith('cv-template.html')) pass('CLI: resolve cv (unset) -> base template');
   else fail(`CLI: resolve cv (unset) unexpected: ${resolved}`);
+}
+
+console.log('\n59b. Pipeline lock (pipeline-lock.mjs)');
+{
+  const unit = run(NODE, ['--test', 'test/pipeline-lock.test.mjs']);
+  if (unit !== null) pass('pipeline-lock unit tests pass');
+  else fail('pipeline-lock unit tests failed (run: node --test test/pipeline-lock.test.mjs)');
 }
 
 console.log('\n60. Cover-letter template resolver (generate-cover-letter.mjs)');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -2036,7 +2036,7 @@ try {
   try {
     mkdirSync(join(fixtureRoot, 'data'), { recursive: true });
     process.chdir(fixtureRoot);
-    appendToPipeline([{ url: 'https://jobs.example.com/1', company: 'Acme', title: 'Engineer' }]);
+    await appendToPipeline([{ url: 'https://jobs.example.com/1', company: 'Acme', title: 'Engineer' }]);
     const pipeline = readFileSync(join(fixtureRoot, 'data', 'pipeline.md'), 'utf-8');
     if (
       pipeline.includes('# Pipeline') &&
@@ -2053,6 +2053,36 @@ try {
   }
 } catch (err) {
   fail(`scan.mjs fresh-install pipeline test crashed: ${err.message}`);
+}
+
+try {
+  const { appendToPipeline } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+  const { acquirePipelineLock, LockTimeoutError } = await import(pathToFileURL(join(ROOT, 'pipeline-lock.mjs')).href);
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-pipeline-lock-'));
+  const originalCwd = process.cwd();
+  try {
+    mkdirSync(join(fixtureRoot, 'data'), { recursive: true });
+    process.chdir(fixtureRoot);
+    const pipelinePath = join(fixtureRoot, 'data', 'pipeline.md');
+    // Hold the exact lock appendToPipeline() takes, then confirm it genuinely
+    // blocks on it (times out) rather than racing straight through to its
+    // read-modify-write.
+    const held = await acquirePipelineLock(pipelinePath);
+    try {
+      await appendToPipeline([{ url: 'https://jobs.example.com/1', company: 'Acme', title: 'Engineer' }]);
+      fail('appendToPipeline() proceeded while another holder had the pipeline lock — no shared exclusion');
+    } catch (e) {
+      if (e instanceof LockTimeoutError) pass('appendToPipeline() shares pipeline-lock.mjs — correctly blocked on a lock held elsewhere (LockTimeoutError)');
+      else fail(`appendToPipeline() lock sharing: expected LockTimeoutError, got: ${e?.constructor?.name}: ${e?.message}`);
+    } finally {
+      held.release();
+    }
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+} catch (err) {
+  fail(`pipeline-lock.mjs sharing test crashed: ${err.message}`);
 }
 
 // URL dedup normalization (#2065): a cosmetic query-suffix variant of an

--- a/test/pipeline-lock.test.mjs
+++ b/test/pipeline-lock.test.mjs
@@ -1,0 +1,139 @@
+/**
+ * pipeline-lock.test.mjs — regression tests for pipeline-lock.mjs.
+ *
+ * The lock exists to serialize appendToPipeline()'s read-modify-write on
+ * data/pipeline.md (#2188). These tests pin the three properties that make
+ * that guarantee actually hold under contention and on fresh installs:
+ *
+ *   1. Mutual exclusion — a second acquirer cannot take a lock a live holder
+ *      still owns, and times out instead.
+ *   2. Stale-reclaim safety — reclaiming a crashed holder's lock must not let
+ *      two processes both end up "holding" it. A naive stat-then-rmSync-then-
+ *      mkdirSync reclaim is itself a TOCTOU race: two callers that both judge
+ *      the same lock stale can have the second one's rmSync delete the first
+ *      one's freshly created lock, after which both believe they hold it.
+ *   3. Fresh-install robustness — the lock must not throw ENOENT when the
+ *      parent data/ directory does not exist yet (plugins.mjs's cmdRun calls
+ *      appendToPipeline with no directory pre-creation).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { acquirePipelineLock, LockTimeoutError } from '../pipeline-lock.mjs';
+
+function fixtureRoot() {
+  const root = mkdtempSync(join(tmpdir(), 'career-ops-pipeline-lock-'));
+  mkdirSync(join(root, 'data'), { recursive: true });
+  return root;
+}
+
+test('acquirePipelineLock: a live holder blocks a second acquirer, which times out', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const held = await acquirePipelineLock(p, { timeoutMs: 300, retryMs: 20 });
+    try {
+      await assert.rejects(
+        () => acquirePipelineLock(p, { timeoutMs: 300, retryMs: 20 }),
+        (err) => err instanceof LockTimeoutError,
+      );
+    } finally {
+      held.release();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: configurable timing — the contention timeout is not a hard-coded multi-second wait', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const held = await acquirePipelineLock(p, { timeoutMs: 150, retryMs: 20 });
+    try {
+      const startedAt = Date.now();
+      await assert.rejects(() => acquirePipelineLock(p, { timeoutMs: 150, retryMs: 20 }));
+      const elapsed = Date.now() - startedAt;
+      // Must honor the caller's timeout, not the module default (seconds).
+      assert.ok(elapsed < 2000, `expected the caller timeout to be honored, waited ${elapsed}ms`);
+    } finally {
+      held.release();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: creates a missing parent data/ directory instead of throwing ENOENT (fresh install)', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'career-ops-pipeline-lock-fresh-'));
+  try {
+    // No data/ directory at all — the plugins.mjs cmdRun path.
+    const p = join(root, 'data', 'pipeline.md');
+    assert.equal(existsSync(dirname(p)), false);
+    const lock = await acquirePipelineLock(p, { timeoutMs: 300, retryMs: 20 });
+    lock.release();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: stale-reclaim is serialized — a second reclaimer cannot delete the winner\'s fresh lock and double-hold', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+
+    // Simulate a crashed holder: a lock directory owned by a PID that is not
+    // alive, old enough to be judged stale by any age rule.
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
+      pid: 2147483000, // not a live pid
+      token: 'crashed-holder-token',
+      started_at: new Date(Date.now() - 60 * 60_000).toISOString(),
+    }), 'utf-8');
+
+    // Two concurrent acquirers both see the same stale lock. Exactly one must
+    // win; the loser must NOT end up holding a lock at the same time.
+    const [a, b] = await Promise.allSettled([
+      acquirePipelineLock(p, { timeoutMs: 1000, retryMs: 15, staleMs: 1 }),
+      acquirePipelineLock(p, { timeoutMs: 1000, retryMs: 15, staleMs: 1 }),
+    ]);
+
+    const winners = [a, b].filter((r) => r.status === 'fulfilled');
+    assert.equal(winners.length, 1, 'exactly one acquirer may hold the reclaimed lock at a time');
+    winners.forEach((w) => w.value.release());
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('release(): a holder whose lock was reclaimed by another process must not delete the new owner\'s lock', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+
+    const first = await acquirePipelineLock(p, { timeoutMs: 300, retryMs: 20 });
+    // Simulate: first's operation outlived staleMs, another process reclaimed
+    // the lock and now legitimately owns it with a different token.
+    rmSync(lockDir, { recursive: true, force: true });
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
+      pid: process.pid,
+      token: 'a-different-owners-token',
+      started_at: new Date().toISOString(),
+    }), 'utf-8');
+
+    first.release(); // must be a no-op: first no longer owns this lock
+
+    assert.ok(existsSync(lockDir), 'release() deleted a lock owned by a different holder');
+    const owner = JSON.parse(readFileSync(join(lockDir, 'owner.json'), 'utf-8'));
+    assert.equal(owner.token, 'a-different-owners-token');
+    rmSync(lockDir, { recursive: true, force: true });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -155,6 +155,7 @@ const SYSTEM_PATHS = [
   'update-system.mjs',
   'reserve-report-num.mjs',
   'scan.mjs',
+  'pipeline-lock.mjs',
   'classify-tier.mjs',
   'scan-ats-full.mjs',
   'match-star.mjs',

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -278,6 +278,7 @@ const SYSTEM_PATHS = [
   'cv-templates.mjs',
   'test/cv-templates.test.mjs',
   'test/cover-resolver.test.mjs',
+  'test/pipeline-lock.test.mjs',
   'test/profile-photo.test.mjs',
   'templates/cv-template.zh-minimal.html',
   'test/zh-minimal-template.test.mjs',


### PR DESCRIPTION
## Summary
- `appendToPipeline()` (`scan.mjs`) did a plain read-modify-write on `data/pipeline.md` with no locking, and is shared by three current callers (`scan.mjs`, `scan-ats-full.mjs`, `plugins.mjs` pipeline mode) — any two running concurrently could silently drop one side's offers.
- Adds `pipeline-lock.mjs`, a small self-contained cross-process advisory lock scoped to this one file (mkdir-is-atomic, stale-holder reclaim, retry with backoff, throws on timeout). `appendToPipeline()` now acquires it for its read-modify-write, protecting all three callers with one change.
- Deliberately minimal: no re-entrancy tracking, since nothing here nests a second acquisition of the same lock.

Closes #2188

## Test plan
- [x] `node test-all.mjs` — full suite passes (2047 passed, 0 failed)
- [x] `node validate-system-paths-coverage.mjs` — passes (new `pipeline-lock.mjs` registered)
- [x] Existing fresh-install pipeline test updated for the new async signature
- [x] New regression test: holds the exact lock `appendToPipeline()` takes and confirms it genuinely blocks (times out with `LockTimeoutError`) rather than racing through — proves the shared exclusion actually works, not just that the code compiles


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Added robust cross-process protection for pipeline updates, preventing simultaneous write conflicts.
  * Pipeline writes now complete (or fail) before the CLI proceeds with later steps.
  * Improved handling of stale locks and ensured releases don’t interfere with a new owner.

* **Bug Fixes**
  * Async pipeline write errors are now reliably surfaced instead of being missed.

* **Maintenance**
  * Updated system update management to include the new lock module and its tests.
  * Added regression coverage for lock contention, stale recovery, and safe release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->