### PR TITLE
fix(batch): update Claude tier mapping to the current model lineup

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -346,8 +346,8 @@ read_spend_tier() {
 spend_tier_to_model() {
   case "$1" in
     economy) echo "claude-haiku-4-5" ;;
-    premium) echo "claude-opus-4-8" ;;
-    standard|*) echo "claude-sonnet-4-6" ;;
+    premium) echo "claude-opus-5" ;;
+    standard|*) echo "claude-sonnet-5" ;;
   esac
 }
 

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -42,7 +42,7 @@ The files below are the **ONLY** sources for user-facing content (CV, cover lett
 
 | CLI | economy | standard | premium | Extended thinking |
 |-----|---------|----------|---------|--------------------|
-| Claude Code | Haiku 4.5 | Sonnet 4.6 | Opus 4.8 | off / off / adaptive |
+| Claude Code | Haiku 4.5 | Sonnet 5 | Opus 5 | off / off / adaptive |
 | OpenCode | your CLI's cheapest/fastest available model | balanced model | most capable model | off / off / adaptive |
 | Gemini CLI | your CLI's cheapest/fastest available model | balanced model | most capable model | off / off / adaptive |
 | Copilot CLI | your CLI's cheapest/fastest available model | balanced model | most capable model | off / off / adaptive |

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6615,8 +6615,8 @@ try {
   const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, BATCH_ARG_FILE: argFile };
   const premiumOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
   const premiumArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
-  if (premiumArgv.includes('--model') && premiumArgv.includes('claude-opus-4-8') && premiumOut.includes('spend_tier=premium')) {
-    pass('premium spend_tier resolves to claude-opus-4-8');
+  if (premiumArgv.includes('--model') && premiumArgv.includes('claude-opus-5') && premiumOut.includes('spend_tier=premium')) {
+    pass('premium spend_tier resolves to claude-opus-5');
   } else {
     fail(`premium spend_tier did not route to opus: argv=${JSON.stringify(premiumArgv)}, out=${JSON.stringify(premiumOut.slice(-240))}`);
   }
@@ -6628,9 +6628,9 @@ try {
   const { tmp, batchDir, fakeBin } = makeTierFixture('spend_tier: premium\n');
   const argFile = join(tmp, 'claude-argv.txt');
   const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, BATCH_ARG_FILE: argFile };
-  const overrideOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1', '--model', 'claude-sonnet-4-6'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
+  const overrideOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1', '--model', 'claude-sonnet-5'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
   const overrideArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
-  if (overrideArgv.includes('--model') && overrideArgv.includes('claude-sonnet-4-6') && !overrideArgv.includes('claude-opus-4-8') && overrideOut.includes('explicit --model override')) {
+  if (overrideArgv.includes('--model') && overrideArgv.includes('claude-sonnet-5') && !overrideArgv.includes('claude-opus-5') && overrideOut.includes('explicit --model override')) {
     pass('--model override takes precedence over spend_tier');
   } else {
     fail(`--model override did not win: argv=${JSON.stringify(overrideArgv)}, out=${JSON.stringify(overrideOut.slice(-240))}`);
@@ -6645,8 +6645,8 @@ try {
   const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, BATCH_ARG_FILE: argFile };
   const standardDefaultOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
   const standardDefaultArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
-  if (standardDefaultArgv.includes('--model') && standardDefaultArgv.includes('claude-sonnet-4-6') && standardDefaultOut.includes('spend_tier=standard')) {
-    pass('missing spend_tier key defaults to standard tier (claude-sonnet-4-6)');
+  if (standardDefaultArgv.includes('--model') && standardDefaultArgv.includes('claude-sonnet-5') && standardDefaultOut.includes('spend_tier=standard')) {
+    pass('missing spend_tier key defaults to standard tier (claude-sonnet-5)');
   } else {
     fail(`missing spend_tier did not default to standard: argv=${JSON.stringify(standardDefaultArgv)}, out=${JSON.stringify(standardDefaultOut.slice(-240))}`);
   }
@@ -6660,8 +6660,8 @@ try {
   const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}`, BATCH_ARG_FILE: argFile };
   const invalidTierOut = run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1'], { cwd: tmp, env, stdio: ['pipe', 'pipe', 'pipe'] }) || '';
   const invalidTierArgv = existsSync(argFile) ? readFileSync(argFile, 'utf-8') : '';
-  if (invalidTierArgv.includes('--model') && invalidTierArgv.includes('claude-sonnet-4-6') && invalidTierOut.includes('spend_tier=standard')) {
-    pass('invalid spend_tier value falls back to standard tier (claude-sonnet-4-6)');
+  if (invalidTierArgv.includes('--model') && invalidTierArgv.includes('claude-sonnet-5') && invalidTierOut.includes('spend_tier=standard')) {
+    pass('invalid spend_tier value falls back to standard tier (claude-sonnet-5)');
   } else {
     fail(`invalid spend_tier did not fall back to standard: argv=${JSON.stringify(invalidTierArgv)}, out=${JSON.stringify(invalidTierOut.slice(-240))}`);
   }


### PR DESCRIPTION
## What

The `spend_tier` → model table still maps to the 4.x line. `batch/batch-runner.sh` passes those IDs straight to `claude -p --model`, so a batch run resolves to a previous generation on both the `standard` and `premium` tiers.

| tier | before | after |
|---|---|---|
| `economy` | `claude-haiku-4-5` | unchanged — still the current cheapest tier |
| `standard` | `claude-sonnet-4-6` | `claude-sonnet-5` |
| `premium` | `claude-opus-4-8` | `claude-opus-5` |

## Why this is a refresh, not a breakage fix

I probed every ID before touching anything, because "this model is gone" is exactly the kind of claim that is cheap to assert and expensive to get wrong:

```
claude -p --model <id> "reply exactly: OK"
```

`claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-8`, `claude-sonnet-5` and `claude-opus-5` all answer today. Nothing is currently broken — batch runs work, they just land a generation behind what the tier names promise. That also means this can land without a migration note or a version gate.

## Why three files

The mapping is duplicated on purpose, and the comment at `batch/batch-runner.sh:344` asks for the copies to be kept in sync:

- **`modes/_shared.md`** — the documented table. Per the note under it, this is the only place model names are allowed to appear in mode logic, so every other mode referring to "the tier's model" inherits the change for free.
- **`batch/batch-runner.sh`** — the only real enforcement point in the repo. Every other path (interactive, subagent, workflow) is prose that a running model cannot act on about itself.
- **`test-all.mjs`** — five assertions pin the resolved IDs.

The `--model` override test keeps its shape: it still passes a non-premium model against `spend_tier: premium` and asserts the explicit flag wins, just with the refreshed pair.

## Out of scope, flagged rather than fixed

`utils/token-tracker.mjs:22-24` prices only `claude-3-haiku` and `claude-3-5-haiku`. Any cost figure derived from it is already wrong for every model this table can route to. Fixing it needs verified per-token pricing for the current lineup, which is a different change with a different review — happy to open it separately if useful.

## Testing

`node test-all.mjs` on this branch: **2044 passed, 0 failed, 2 warnings** (the two warnings are pre-existing and unrelated).

Follows the precedent of #1958, which refreshed the Gemini default the same way. No issue opened first — `CONTRIBUTING.md` lists bug fixes and docs as go-straight-to-PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated model routing to use Claude Opus 5 for premium workloads.
  * Updated standard and fallback routing to use Claude Sonnet 5.
  * Explicit model selections continue to take precedence over spend-tier routing.
* **Documentation**
  * Updated the spend-tier model reference to reflect Claude Sonnet 5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->