### PR TITLE
fix(opencode): add missing /career-ops command router

### DIFF
--- a/.opencode/commands/career-ops.md
+++ b/.opencode/commands/career-ops.md
@@ -1,0 +1,13 @@
+---
+description: career-ops command center — evaluate offers, scan portals, track applications
+---
+
+# career-ops
+
+$ARGUMENTS
+
+Load the career-ops skill:
+
+```javascript
+skill({ name: "career-ops" })
+```


### PR DESCRIPTION
## Summary
- Adds the missing `.opencode/commands/career-ops.md` router file so OpenCode registers `/career-ops` as a slash command
- Follows the same pattern as the existing sub-commands (`career-ops-interview-prep.md`, `career-ops-interview-intel.md`)

Fixes #2191

## Test plan
- [ ] Run `node test-all.mjs` — all OpenCode-related checks pass
- [ ] Verify `/career-ops` is available in OpenCode after the change
- [ ] Verify `/career-ops scan`, `/career-ops pdf`, etc. route correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the new `career-ops` command.
  * Included command argument handling and initialization instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->