### PR TITLE
fix(tracker): set SQLite busy_timeout to avoid SQLITE_BUSY under concurrent access

### DIFF
--- a/tests/tracker-busy-timeout.test.mjs
+++ b/tests/tracker-busy-timeout.test.mjs
@@ -1,0 +1,39 @@
+// tests/tracker-busy-timeout.test.mjs — regression coverage for #1957.
+//
+// openDb() must set a non-zero SQLite busy_timeout. Without it the default is
+// 0, so a CLI query, a `set-status` write and the Go TUI dashboard touching
+// the derived index at the same time throw SQLITE_BUSY on the first contention
+// instead of waiting for the lock to clear.
+//
+// The check is deterministic: open a fresh connection and read the pragma back
+// with `PRAGMA busy_timeout`. No timing, no second connection — nothing flaky.
+import { pass, fail } from './helpers.mjs';
+import { join } from 'path';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+
+console.log('\ntracker.mjs — SQLite busy_timeout (#1957)');
+
+// openDb reads DB_PATH once at import time, so point it at a throwaway file
+// before importing tracker.mjs — the test never touches a real applications.db.
+const work = mkdtempSync(join(tmpdir(), 'cops-busy-'));
+process.env.CAREER_OPS_TRACKER_DB = join(work, 'applications.db');
+
+try {
+  const { DatabaseSync } = await import('node:sqlite');
+  const { openDb } = await import(new URL('../tracker.mjs', import.meta.url).href);
+
+  const db = openDb(DatabaseSync);
+  const { timeout } = db.prepare('PRAGMA busy_timeout').get();
+  db.close();
+
+  if (timeout === 5000) {
+    pass(`openDb() sets busy_timeout to ${timeout}ms`);
+  } else {
+    fail(`openDb() busy_timeout is ${timeout}, expected 5000 (SQLITE_BUSY would fire instantly under concurrent access)`);
+  }
+} catch (e) {
+  fail(`tracker busy_timeout test crashed: ${e.message}`);
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}

--- a/tracker.mjs
+++ b/tracker.mjs
@@ -81,9 +81,14 @@ async function loadSqlite() {
   }
 }
 
-function openDb(DatabaseSync) {
+export function openDb(DatabaseSync) {
   mkdirSync(dirname(DB_PATH) || '.', { recursive: true });
   const db = new DatabaseSync(DB_PATH);
+  // Wait up to 5s for a lock instead of throwing SQLITE_BUSY on the first
+  // contention. The index is read by concurrent callers — a CLI query, a
+  // `set-status` write and the Go TUI dashboard can all hit the same db at
+  // once — and the default busy_timeout of 0 makes any overlap fail instantly.
+  db.exec('PRAGMA busy_timeout = 5000');
   db.exec('PRAGMA foreign_keys = ON'); // SQLite ignores REFERENCES without this
   db.exec(`
     CREATE TABLE IF NOT EXISTS applications (


### PR DESCRIPTION
Opening the index with the default `busy_timeout = 0` means the moment two callers touch `applications.db` at once (a `query`, a `set-status` write, the Go TUI dashboard), one throws `SQLITE_BUSY` instead of waiting for the lock. This sets `busy_timeout = 5000` in `openDb`, so callers wait up to 5s for the lock to clear.

Added `tests/tracker-busy-timeout.test.mjs`, which reads the pragma back off a fresh connection (`PRAGMA busy_timeout` == 5000). Deterministic, no timing. `openDb` is exported so the test can reach it.

Kept it to the one pragma. WAL mode would also help here, but it creates `-wal`/`-shm` sidecar files, which is a behavior change I did not want to slip in. Happy to do it as a follow-up if you would like.

Closes #1957


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database reliability by waiting up to five seconds when the database is temporarily locked, reducing failures during concurrent access.
* **Tests**
  * Added regression coverage to verify the database lock-wait behavior is configured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->