### PR TITLE
fix(role-matcher): fold accented Latin letters before tokenizing role titles

### DIFF
--- a/role-matcher.mjs
+++ b/role-matcher.mjs
@@ -81,6 +81,33 @@ export const BASELINE_TOKENS = new Set([
 ]);
 
 /**
+ * Lowercase a title and fold accented Latin letters onto their ASCII base.
+ *
+ * Every rule below matches against ASCII vocabulary, so an accent used to act
+ * as a word separator rather than a letter: "Sênior" became ["s", "nior"],
+ * leaving a phantom "nior" token that no stopword list covers. Folding first
+ * keeps the accented spelling in the same vocabulary as the plain one.
+ *
+ * Only accents that NFD decomposes are folded. Letters with no canonical
+ * decomposition (ø, ł, ß, đ) still reach the ASCII filter unchanged, exactly
+ * as before.
+ *
+ * `\p{Mn}` (nonspacing mark), not `\p{Diacritic}`: the latter also matches
+ * standalone characters such as "·", "^" and "`", which are separators in a
+ * title. Deleting those would glue neighbouring words into one token.
+ *
+ * @param {unknown} value - Raw title, possibly not a string.
+ * @returns {string} Lowercased, accent-folded text.
+ */
+function normalizeTitle(value) {
+  const text = typeof value === 'string' ? value : String(value ?? '');
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Mn}/gu, '');
+}
+
+/**
  * Convert a role title into content tokens used for fuzzy matching.
  *
  * The tokenizer keeps long descriptive words and a narrow set of short
@@ -92,9 +119,7 @@ export const BASELINE_TOKENS = new Set([
  * @returns {string[]} Ordered role-title tokens.
  */
 export function roleTokens(role) {
-  const text = typeof role === 'string' ? role : String(role ?? '');
-  return text
-    .toLowerCase()
+  return normalizeTitle(role)
     // Replace with a generic baseline token, not empty space: a bare "Member
     // of Technical Staff" (no suffix) or a one-word-suffix MTS title (e.g.
     // "...Staff, Backend") would otherwise tokenize to 0 or 1 words, and
@@ -109,10 +134,8 @@ export function roleTokens(role) {
 }
 
 function extractSeniorities(title) {
-  const text = typeof title === 'string' ? title : String(title ?? '');
   return new Set(
-    text
-      .toLowerCase()
+    normalizeTitle(title)
       .replace(/[^a-z0-9\s]/g, ' ')
       .split(/\s+/)
       .filter(w => SENIORITY_TOKENS.has(w))

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5724,7 +5724,7 @@ try {
 // application states from fuzzy-only deletion.
 console.log('\n🧪 Testing shared role matcher and dedup-tracker safety...');
 try {
-  const { roleFuzzyMatch } = await import(pathToFileURL(join(ROOT, 'role-matcher.mjs')).href);
+  const { roleFuzzyMatch, roleTokens } = await import(pathToFileURL(join(ROOT, 'role-matcher.mjs')).href);
 
   if (!roleFuzzyMatch('Full Stack Engineer, Foundation', 'Full Stack Engineer, Guarded Releases')) {
     pass('role matcher keeps Full Stack Engineer sibling teams distinct (#947)');
@@ -5885,6 +5885,89 @@ try {
     fail('role matcher collapsed distinct one-word-suffix MTS roles via the "engineer" filler');
   } else {
     pass('role matcher keeps distinct one-word-suffix MTS roles apart despite the "engineer" filler');
+  }
+
+  // Accented Latin titles used to split at the accent instead of folding it, so
+  // "Sênior" tokenized to ["s", "nior"]: "s" fell to the length filter and
+  // "nior" survived as a phantom token that is in no stopword list. Every
+  // downstream rule then misfired at once (#2207).
+  // Assert the whole token list, not just the absence of "nior": a fix that
+  // merely deleted non-ASCII would still leave a phantom ("snior") and pass a
+  // negative check.
+  const accentTokens = roleTokens('Software Engineer Node.js Sênior');
+  const plainTokens = roleTokens('Software Engineer Node.js Senior');
+  if (JSON.stringify(accentTokens) === JSON.stringify(plainTokens)) {
+    pass('role tokenizer folds accents onto the plain-ASCII token list (#2207)');
+  } else {
+    fail(`accented title tokenized differently from its plain spelling: ${JSON.stringify(accentTokens)} vs ${JSON.stringify(plainTokens)}`);
+  }
+
+  // Folding must delete combining marks only. Standalone characters such as
+  // "·" are separators in a title; deleting them would glue two words into a
+  // single token and turn a real repost into a duplicate row.
+  const separatorTokens = roleTokens('Backend Engineer·Payments');
+  if (separatorTokens.includes('payments') && !separatorTokens.some(w => w.includes('engineerpayments'))) {
+    pass('accent folding leaves standalone separator characters splitting words (#2207)');
+  } else {
+    fail(`accent folding swallowed a separator character: ${JSON.stringify(separatorTokens)}`);
+  }
+
+  // The phantom token is shared by every accented title, so it acted as a
+  // discriminating overlap and pushed two unrelated roles past the Jaccard
+  // threshold — exactly what the baseline-token guard exists to prevent.
+  if (!roleFuzzyMatch('Software Engineer Node.js Sênior', 'Software Engineer Flutter Sênior')) {
+    pass('role matcher keeps accented sibling roles distinct (#2207)');
+  } else {
+    fail('role matcher collapsed two accented sibling roles via the phantom accent token');
+  }
+
+  // Worse than a generic collision: "Sênior" and "Júnior" both reduce to the
+  // same "nior" phantom, so opposite seniority levels matched each other while
+  // the seniority-disagreement gate saw no seniority token at all.
+  if (!roleFuzzyMatch('Engenheiro de Dados Sênior', 'Engenheiro de Dados Júnior')) {
+    pass('role matcher keeps accented Sênior and Júnior requisitions distinct (#2207)');
+  } else {
+    fail('role matcher merged an accented Sênior req into an accented Júnior req');
+  }
+
+  // The same defect also caused false negatives: a genuine repost written once
+  // with the accent and once without tokenized differently and never matched.
+  if (roleFuzzyMatch('Engenheiro de Software Sênior, Pagamentos', 'Engenheiro de Software Senior, Pagamentos')) {
+    pass('role matcher matches a repost across accented and unaccented spellings (#2207)');
+  } else {
+    fail('role matcher missed a repost that differs only by an accent');
+  }
+
+  // Folding must not over-merge: accented specialty words have to survive as
+  // their own distinct tokens, not collapse into one another.
+  if (!roleFuzzyMatch('Ingeniero de Software Sênior, Búsqueda', 'Ingeniero de Software Sênior, Pagos')) {
+    pass('role matcher keeps accented specialty suffixes distinct after folding (#2207)');
+  } else {
+    fail('accent folding collapsed two distinct accented specialty suffixes');
+  }
+
+  // Folding is what lets the seniority gate see an accented qualifier at all.
+  // Before it, "Sênior"/"Júnior" both reduced to the same "nior" phantom, which
+  // survived as a non-baseline token on the qualified side only — so the
+  // specialization-marker rule (strict subset + extra non-baseline word) fired
+  // and returned false for BOTH. The gate itself never ran: extractSeniorities
+  // saw no seniority token either way. That produced a right answer for the
+  // wrong reason on "Júnior" and a plain false negative on "Sênior".
+  //
+  // After folding, the two cases separate on their actual meaning (#2009's
+  // SUB_BASELINE_SENIORITY rule): "senior" is routinely added or dropped
+  // between reposts of one req, while "junior" marks a genuinely lower-level
+  // req with its own scope and req ID.
+  if (roleFuzzyMatch('Sênior Product Manager, Marketplace', 'Product Manager, Marketplace')) {
+    pass('accent folding lets a lone accented "Sênior" be read as the same req (#2207)');
+  } else {
+    fail('accented "Sênior" still blocked a repost of the same requisition');
+  }
+
+  if (!roleFuzzyMatch('Júnior Product Manager, Marketplace', 'Product Manager, Marketplace')) {
+    pass('accent folding routes a lone accented "Júnior" through the sub-baseline gate (#2207)');
+  } else {
+    fail('accented "Júnior" collapsed a sub-baseline req into the bare title');
   }
 
   const dedupTmp = mkdtempSync(join(tmpdir(), 'career-ops-dedup-'));


### PR DESCRIPTION
## What does this PR do?

Folds accented Latin letters onto their ASCII base before `role-matcher.mjs` tokenizes a role title, so an accent stops behaving as a word separator.

`roleTokens()` and `extractSeniorities()` both ran `.replace(/[^a-z0-9\s]/g, ' ')` on the lowercased title. Since that class does not cover accented letters, `"Sênior"` split into `"s"` (dropped by the length filter) and `"nior"` — a phantom token that appears in no stopword list and is therefore treated as real content.

Reproduced on `main` before the change:

```js
roleTokens('Software Engineer Node.js Sênior');   // ['software','engineer','node','nior']
roleTokens('Software Engineer Flutter Sênior');   // ['software','engineer','flutter','nior']
roleFuzzyMatch(...)                                // true   ← should be false
```

The plain-ASCII control returns `false` correctly, which isolates the accent as the cause.

### Three failures from one root cause

While confirming the report I found the phantom token defeats three separate rules, not just the one in the issue:

1. **False positive (the reported case).** `"nior"` counts as a discriminating overlap, so two unrelated roles at one company cross the 0.6 Jaccard threshold and the `discriminating.length === 0` baseline guard never fires.
2. **Opposite seniorities merging.** `"Sênior"` and `"Júnior"` *both* reduce to `"nior"`. `Engenheiro de Dados Sênior` and `Engenheiro de Dados Júnior` matched on `main` — and because `extractSeniorities()` shares the same stripping, it saw no seniority token on either side, so the seniority-disagreement gate stayed silent instead of catching it.
3. **False negative.** A genuine repost written once with the accent and once without tokenized differently and never matched: `Engenheiro de Software Sênior, Pagamentos` vs `… Senior, Pagamentos` returned `false` on `main`.

### The change

A small `normalizeTitle()` helper lowercases, applies NFD, and drops combining marks; both `roleTokens()` and `extractSeniorities()` call it before the existing ASCII filter. No rule, threshold, or vocabulary list changes — accented spellings simply land in the same vocabulary as plain ones.

The strip uses `\p{Mn}` (nonspacing mark) rather than the more obvious `\p{Diacritic}`. `\p{Diacritic}` also matches standalone characters — `·`, `^`, `` ` ``, `¨`, `´`, `¸` — which are *separators* in a title, not marks on a letter. Deleting them would glue neighbouring words together: `Backend Engineer·Payments` tokenizes to `['backend', 'engineerpayments']`, turning a real repost into a duplicate row. `\p{Mn}` matches none of those, and I verified against every decomposing codepoint in U+0041–U+24FF that it covers everything NFD emits for Latin. There is a regression test for this.

Scope note: NFD folding covers combining-mark accents (`ê é ã ç ñ ü`), which is what the tracker actually sees. Letters with no canonical decomposition (`ø`, `ł`, `ß`, `đ`) still strip as before and can still produce a phantom token — the docstring says so explicitly. I left that alone rather than start a transliteration table for cases that have not come up; happy to follow up if you would rather cover them now.

Two other `[^a-z0-9\s]` tokenizers exist — `normalizeCompanyName` (`invite-match.mjs`) and `deriveSlugCandidates` (`verify-portals.mjs`). I deliberately left them out of scope: both compare company names, which fold consistently on both sides, so the false-positive risk is much lower than for role titles. Worth a separate issue if you want them aligned.

## Related issue

Fixes #2207

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Added to the existing shared-role-matcher section in `test-all.mjs`:

- the reported pair (`Node.js Sênior` vs `Flutter Sênior`) — `true` on `main`, now `false`
- the `Sênior`/`Júnior` collision — `true` on `main`, now `false`
- the accented-vs-unaccented repost — `false` on `main`, now `true`
- a tokenizer-level assertion that the accented title produces **exactly** the plain-ASCII token list (asserting the whole array, not merely the absence of `"nior"`, so a fix that just deleted non-ASCII would still fail it)
- an over-merge control: two distinct accented specialty suffixes must stay distinct
- a separator control: `Backend Engineer·Payments` must still split into two tokens

`node test-all.mjs` → **2079 passed, 0 failed, 1 warning** (the warning is the pre-existing `cv-sync-check.mjs` no-user-data notice).

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My PR is linked to a related issue
- [x] My changes contain no personal data
- [x] I ran `node test-all.mjs` locally
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

Credit to @pedrobrasileiro for the report — the root-cause trace in the issue was precise down to the line, and the production `merge-tracker` skip it caused is what made the impact concrete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role matching for titles with accented characters by treating accented and unaccented spellings consistently.
  * Fixed cases where accent-related tokenization could wrongly merge or incorrectly keep roles distinct.
  * Preserved correct distinctions between seniority levels and specialty suffixes.
  * Improved repost detection across accented and unaccented title variations.
* **Tests**
  * Added coverage to verify accent folding behavior and prevent related regression scenarios in role matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->