### PR TITLE
fix(providers): correct Jobstreet job URL format

### DIFF
--- a/providers/jobstreet.mjs
+++ b/providers/jobstreet.mjs
@@ -119,7 +119,7 @@ export function parseJobstreetItem(item, origin, fallbackCompany) {
   // Build job URL from the job ID
   const jobId = (item.id || '').trim();
   if (!jobId) return null;
-  const url = `${origin}/id/job/${jobId}`;
+  const url = `${origin}/job/${jobId}`;
 
   // Validate URL hostname belongs to allowed set
   try {

--- a/tests/providers/jobstreet.test.mjs
+++ b/tests/providers/jobstreet.test.mjs
@@ -33,7 +33,7 @@ try {
   };
   const parsed = parseJobstreetItem(sampleItem, 'https://id.jobstreet.com', 'FallbackCo');
   if (parsed && parsed.title === 'Facility Engineer'
-      && parsed.url === 'https://id.jobstreet.com/id/job/92996157'
+      && parsed.url === 'https://id.jobstreet.com/job/92996157'
       && parsed.company === 'PT YOFC International Indonesia'
       && parsed.location === 'Karawang, West Java'
       && parsed.postedAt != null) {


### PR DESCRIPTION
## Summary
- `parseJobstreetItem` built job detail URLs as `{origin}/id/job/{id}`, but live scan results (`data/scan-history.tsv`) show the real Jobstreet/SEEK path is `{origin}/job/{id}` — no `/id/` segment.
- Fixed the URL builder and updated the corresponding unit test assertion to match.

## Test plan
- [x] `node tests/providers/jobstreet.test.mjs` — all 15 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Jobstreet job links to use the current URL format.
  * Job listings now open the intended job detail pages reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->