### PR TITLE
fix(liveness): treat Phenom/SPA "job ... has been filled" as expired

### DIFF
--- a/liveness-core.mjs
+++ b/liveness-core.mjs
@@ -5,9 +5,11 @@ const HARD_EXPIRED_PATTERNS = [
   // phrasing SPA ATSs (Phenom, e.g. careers.icf.com) inject on a filled req —
   // "the job you are trying to apply for has been filled" — so those pages
   // returned HTTP 200 with a generic Apply control and were classified active.
-  // Requires a job noun within 60 chars, and the negative lookahead rejects
-  // "has been filled out" (a candidate completing a form, not a closed req).
-  /\b(?:job|jobs|position|role|posting|opening|vacancy|requisition|req|listing)\b[\s\S]{0,60}?\bhas been filled\b(?!\s+out)/i,
+  // A job noun within 60 chars, then "has been filled" — but NOT when the thing
+  // filled is an application/form (the lookbehind) or "filled out" (the
+  // lookahead). Both guards avoid the worse error: reading a LIVE posting whose
+  // copy says "once the application form has been filled…" as expired.
+  /\b(?:job|jobs|position|role|posting|opening|vacancy|requisition|req|listing)\b[\s\S]{0,60}?(?<!\b(?:application|form)\s)has been filled\b(?!\s+out)/i,
   /this job has expired/i,
   /job posting has expired/i,
   /no longer accepting applications/i,

--- a/liveness-core.mjs
+++ b/liveness-core.mjs
@@ -1,7 +1,13 @@
 const HARD_EXPIRED_PATTERNS = [
   /job (is )?no longer available/i,
   /job.*no longer open/i,
-  /position has been filled/i,
+  // Generalized "filled" signal. The old /position has been filled/ missed the
+  // phrasing SPA ATSs (Phenom, e.g. careers.icf.com) inject on a filled req —
+  // "the job you are trying to apply for has been filled" — so those pages
+  // returned HTTP 200 with a generic Apply control and were classified active.
+  // Requires a job noun within 60 chars, and the negative lookahead rejects
+  // "has been filled out" (a candidate completing a form, not a closed req).
+  /\b(?:job|jobs|position|role|posting|opening|vacancy|requisition|req|listing)\b[\s\S]{0,60}?\bhas been filled\b(?!\s+out)/i,
   /this job has expired/i,
   /job posting has expired/i,
   /no longer accepting applications/i,

--- a/tests/liveness-core.test.mjs
+++ b/tests/liveness-core.test.mjs
@@ -1,0 +1,49 @@
+// tests/liveness-core.test.mjs — classifyLiveness must treat the "filled"
+// phrasing SPA ATSs inject (Phenom, e.g. careers.icf.com) as expired.
+//
+// Regression for the false-active reported on careers.icf.com: Phenom-hosted
+// career pages return HTTP 200 with a generic "Apply" control in the shell,
+// while the true status — "the job you are trying to apply for has been
+// filled" — is rendered into the main content. The old HARD_EXPIRED pattern
+// was /position has been filled/, which does not match that phrasing, so the
+// generic apply control won and the posting was classified active. The
+// generalized pattern requires any job noun within 60 chars of "has been
+// filled" and rejects "filled out" (a candidate completing a form).
+import { pass, fail } from './helpers.mjs';
+import { classifyLiveness } from '../liveness-core.mjs';
+
+console.log('\nliveness-core — "filled" reqs (incl. Phenom/ICF phrasing) classify as expired');
+
+const expired = (bodyText, applyControls = ['Apply']) =>
+  classifyLiveness({ status: 200, finalUrl: 'https://careers.example.com/job/123', bodyText, applyControls }).result;
+
+// The reported bug: Phenom/ICF phrasing, HTTP 200, with a generic Apply control.
+expired('We’re sorry… the job you are trying to apply for has been filled. Apply')
+  === 'expired'
+  ? pass('Phenom/ICF "the job ... has been filled" -> expired (was: active)')
+  : fail('Phenom/ICF "the job ... has been filled" NOT classified expired');
+
+// Regression: the original phrasing still classifies as expired.
+expired('This position has been filled. Apply') === 'expired'
+  ? pass('"position has been filled" still -> expired')
+  : fail('"position has been filled" regressed');
+
+// Regression: a genuinely active posting is NOT swept up by the new pattern.
+classifyLiveness({
+  status: 200,
+  finalUrl: 'https://boards.greenhouse.io/acme/jobs/123',
+  bodyText: 'Senior Program Manager. You will own the enterprise AI roadmap and lead delivery across teams. Apply now.',
+  applyControls: ['Apply now'],
+}).result === 'active'
+  ? pass('active posting with an apply control stays active')
+  : fail('new pattern over-triggered on an active posting');
+
+// False-positive guard: "has been filled out" (a form) must NOT read as expired.
+classifyLiveness({
+  status: 200,
+  finalUrl: 'https://careers.example.com/job/123',
+  bodyText: 'Once the job application form has been filled out, submit it below. Apply',
+  applyControls: ['Apply'],
+}).result !== 'expired'
+  ? pass('"job application form has been filled out" is NOT expired (form, not req)')
+  : fail('false positive: "filled out" (a form) read as an expired req');

--- a/tests/liveness-core.test.mjs
+++ b/tests/liveness-core.test.mjs
@@ -47,3 +47,15 @@ classifyLiveness({
 }).result !== 'expired'
   ? pass('"job application form has been filled out" is NOT expired (form, not req)')
   : fail('false positive: "filled out" (a form) read as an expired req');
+
+// False-positive guard (no "out"): "application form has been filled" must NOT
+// read as expired — "job" satisfies the noun but the thing filled is the form,
+// not the req. Reading a live posting as expired is the worse error.
+classifyLiveness({
+  status: 200,
+  finalUrl: 'https://careers.example.com/job/123',
+  bodyText: 'Please confirm the job application form has been filled and accurate before submitting. Apply',
+  applyControls: ['Apply'],
+}).result !== 'expired'
+  ? pass('"job application form has been filled" (no "out") is NOT expired')
+  : fail('false positive: "application form has been filled" read as an expired req');


### PR DESCRIPTION
Fixes #2211.

## Problem
Phenom-hosted career pages (e.g. `careers.icf.com`) return **HTTP 200** on a filled req with a generic **Apply** control in the shell, while the real status — *"the job you are trying to apply for has been filled"* — is rendered into the main content. `HARD_EXPIRED_PATTERNS` only had `/position has been filled/`, which misses that phrasing, so `apply_control_visible` won and the dead posting was classified `active`. This breaks the "expired signals win over generic Apply text" invariant on SPA ATSs.

## Change
- **`liveness-core.mjs`** — replace `/position has been filled/` with:
  ```js
  /\b(?:job|jobs|position|role|posting|opening|vacancy|requisition|req|listing)\b[\s\S]{0,60}?\bhas been filled\b(?!\s+out)/i
  ```
  A job noun within 60 chars of "has been filled"; the negative lookahead rejects "has been filled **out**" (form completion, not a closed req).
- **`tests/liveness-core.test.mjs`** (new) — Phenom/ICF phrasing → `expired`; the original "position has been filled" still → `expired`; an active posting with an apply control stays `active`; and "application form has been filled out" is **not** a false positive.

## Testing
```
node test-all.mjs --only liveness
# 4 passed, 0 failed
```

## Notes / possible follow-up
This fixes the pattern gap, which resolves the reported case once the page content is read. A deeper hardening — treating a bare apply-control on a known SPA/Phenom shell as `uncertain` (force a render) rather than `active` — could be a follow-up, but is more invasive; this PR is the minimal, well-tested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “filled” expiration detection to cover more common job-status wording variants.
  * Prevented false positives from application-form phrasing like “has been filled out” (and similar text) being misclassified as expired.
  * Added regression tests to confirm correct classification for both expired and active postings, including key guard cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->