### PR TITLE
test: assert the Dockerfile's Playwright pin matches package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # career-ops container
-# Base: Playwright image with Chromium preinstalled (matches playwright@1.58.1 in package.json).
+# Base: Playwright image with Chromium preinstalled (matches playwright@1.62.0 in package.json).
 # Host kernels that block Playwright's chromium installer (e.g. Ubuntu 26.04) work fine here
 # because the browser ships in the image and runs under the image's userland.
 
-FROM mcr.microsoft.com/playwright:v1.61.1-jammy
+FROM mcr.microsoft.com/playwright:v1.62.0-jammy
 
 ENV DEBIAN_FRONTEND=noninteractive \
     NODE_ENV=development \
@@ -35,7 +35,7 @@ WORKDIR /app
 # Pin playwright to the version that matches the base image's bundled chromium.
 COPY package.json package-lock.json* ./
 RUN npm install --no-audit --no-fund \
- && npm install --no-audit --no-fund --save-exact playwright@1.58.1
+ && npm install --no-audit --no-fund --save-exact playwright@1.62.0
 
 # The rest of the project is bind-mounted at runtime via docker compose,
 # so we don't COPY sources here — keeps the image generic and lets local

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -943,29 +943,40 @@ for (const f of skillEntrypoints) {
   }
 }
 
-// The Dockerfile pins playwright to the exact version baked into its base
-// image so the npm-installed package matches the bundled Chromium. Nothing
-// enforced that pin against package.json's own playwright version, so it
-// silently drifted for months (#2221) — this keeps the two in sync going
-// forward instead of relying on whoever next reads the Dockerfile noticing.
+// The Dockerfile pins playwright twice — the FROM base image tag (bundled
+// Chromium) and the --save-exact npm install — so the npm package matches
+// the browser the container ships. Nothing enforced either pin against
+// package.json's own playwright version, so this keeps all three in sync
+// going forward instead of relying on whoever next reads the Dockerfile.
 {
   const pkgPlaywright = JSON.parse(readFile('package.json')).dependencies?.playwright;
   const dockerfile = readFile('Dockerfile');
+  const dockerfileLine2 = dockerfile.split(/\r?\n/, 3)[1] ?? '';
+  const fromPinMatch = dockerfile.match(/^FROM mcr\.microsoft\.com\/playwright:v([\d.]+)-/m);
   const runPinMatch = dockerfile.match(/--save-exact playwright@([\d.]+)/);
-  const commentPinMatch = dockerfile.match(/matches playwright@([\d.]+) in package\.json/);
+  const commentPinMatch = dockerfileLine2.match(/matches playwright@([\d.]+) in package\.json/);
   if (!pkgPlaywright) {
-    fail('package.json missing dependencies.playwright — cannot check Dockerfile pin against it');
-  } else if (!runPinMatch) {
-    fail('Dockerfile missing the expected "--save-exact playwright@X" RUN line');
-  } else if (runPinMatch[1] !== pkgPlaywright) {
-    fail(`Dockerfile pins playwright@${runPinMatch[1]} but package.json depends on playwright@${pkgPlaywright} — bump the Dockerfile's --save-exact pin`);
+    fail('package.json missing dependencies.playwright — cannot check Dockerfile pins against it');
   } else {
-    pass(`Dockerfile's playwright pin (${runPinMatch[1]}) matches package.json`);
-  }
-  if (commentPinMatch && pkgPlaywright && commentPinMatch[1] !== pkgPlaywright) {
-    fail(`Dockerfile's line-2 comment claims playwright@${commentPinMatch[1]} but package.json depends on playwright@${pkgPlaywright} — update the comment`);
-  } else if (commentPinMatch) {
-    pass('Dockerfile\'s line-2 comment version matches package.json');
+    if (!fromPinMatch) {
+      fail('Dockerfile missing the expected "FROM mcr.microsoft.com/playwright:vX-<distro>" base image line');
+    } else if (fromPinMatch[1] !== pkgPlaywright) {
+      fail(`Dockerfile's FROM base image is playwright@${fromPinMatch[1]} but package.json depends on playwright@${pkgPlaywright} — bump the base image tag`);
+    } else {
+      pass(`Dockerfile's FROM base image (${fromPinMatch[1]}) matches package.json`);
+    }
+    if (!runPinMatch) {
+      fail('Dockerfile missing the expected "--save-exact playwright@X" RUN line');
+    } else if (runPinMatch[1] !== pkgPlaywright) {
+      fail(`Dockerfile pins playwright@${runPinMatch[1]} but package.json depends on playwright@${pkgPlaywright} — bump the Dockerfile's --save-exact pin`);
+    } else {
+      pass(`Dockerfile's playwright pin (${runPinMatch[1]}) matches package.json`);
+    }
+    if (commentPinMatch && commentPinMatch[1] !== pkgPlaywright) {
+      fail(`Dockerfile's line-2 comment claims playwright@${commentPinMatch[1]} but package.json depends on playwright@${pkgPlaywright} — update the comment`);
+    } else if (commentPinMatch) {
+      pass('Dockerfile\'s line-2 comment version matches package.json');
+    }
   }
 }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -943,6 +943,32 @@ for (const f of skillEntrypoints) {
   }
 }
 
+// The Dockerfile pins playwright to the exact version baked into its base
+// image so the npm-installed package matches the bundled Chromium. Nothing
+// enforced that pin against package.json's own playwright version, so it
+// silently drifted for months (#2221) — this keeps the two in sync going
+// forward instead of relying on whoever next reads the Dockerfile noticing.
+{
+  const pkgPlaywright = JSON.parse(readFile('package.json')).dependencies?.playwright;
+  const dockerfile = readFile('Dockerfile');
+  const runPinMatch = dockerfile.match(/--save-exact playwright@([\d.]+)/);
+  const commentPinMatch = dockerfile.match(/matches playwright@([\d.]+) in package\.json/);
+  if (!pkgPlaywright) {
+    fail('package.json missing dependencies.playwright — cannot check Dockerfile pin against it');
+  } else if (!runPinMatch) {
+    fail('Dockerfile missing the expected "--save-exact playwright@X" RUN line');
+  } else if (runPinMatch[1] !== pkgPlaywright) {
+    fail(`Dockerfile pins playwright@${runPinMatch[1]} but package.json depends on playwright@${pkgPlaywright} — bump the Dockerfile's --save-exact pin`);
+  } else {
+    pass(`Dockerfile's playwright pin (${runPinMatch[1]}) matches package.json`);
+  }
+  if (commentPinMatch && pkgPlaywright && commentPinMatch[1] !== pkgPlaywright) {
+    fail(`Dockerfile's line-2 comment claims playwright@${commentPinMatch[1]} but package.json depends on playwright@${pkgPlaywright} — update the comment`);
+  } else if (commentPinMatch) {
+    pass('Dockerfile\'s line-2 comment version matches package.json');
+  }
+}
+
 // Check user files are NOT tracked (gitignored)
 const userFiles = [
   'config/profile.yml', 'modes/_profile.md', 'portals.yml',


### PR DESCRIPTION
## Summary
- Adds an assertion to `test-all.mjs` (same shape as the existing `.claude-plugin/plugin.json` mirror check) that reads the Playwright version out of the Dockerfile's `--save-exact playwright@X` RUN line and its line-2 comment, and fails when either disagrees with `package.json`'s `dependencies.playwright`.
- Fixes the current drift: the Dockerfile's base image tag, RUN pin, and comment were all still at `1.58.1`/`1.61.1` while `package.json` is at `1.62.0`. Brought all three back in sync at `1.62.0` (confirmed the `v1.62.0-jammy` base image tag exists on `mcr.microsoft.com`).

## Test plan
- [x] `node test-all.mjs` passes (2165 passed, 0 failed)
- [x] Verified the new assertion actually fails when the pin disagrees (checked before fixing the Dockerfile)

Fixes #2221.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgraded Playwright to version 1.62.0 to improve browser automation compatibility.

* **Tests**
  * Added a CI guard that verifies Playwright version consistency across package configuration and container setup, including checks for the base image tag and the installed Playwright pin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->