### PR TITLE
fix(analyze-patterns): symbol-edge \b bugs drop C++/C#/.NET from tech gaps and 70+ from remote classify

### DIFF
--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -390,6 +390,16 @@ risk_summary:
     failures.push('node.js case variants failed to canonicalize');
   }
 
+  // Remote classifier (regression): the "70+" signal ends in "+", so a
+  // trailing \b silently dropped it and "70+ countries" postings fell to the
+  // weaker 'regional remote' bucket instead of 'global remote'.
+  if (classifyRemote('Fully remote — hiring in 70+ countries') !== 'global remote') {
+    failures.push('classifyRemote did not read "70+ countries" as global remote');
+  }
+  if (classifyRemote('US-only remote') !== 'geo-restricted') {
+    failures.push('classifyRemote geo-restricted precedence regressed');
+  }
+
   if (failures.length > 0) {
     console.error(`analyze-patterns self-test failed: ${failures.join('; ')}`);
     process.exit(1);
@@ -564,7 +574,11 @@ function classifyRemote(raw) {
   if (/\b(us[- ]?only|canada[- ]?only|residents only|usa only|us residents|canada residents)\b/.test(lower)) return 'geo-restricted';
   if (/\bargentina\s+remote\s+only\b/.test(lower)) return 'geo-restricted';
   if (/\b(hybrid|on-?site|office|columbus|cape town|relocat)\b/.test(lower)) return 'hybrid/onsite';
-  if (/\b(global|anywhere|worldwide|no restrict|70\+|work from anywhere)\b/.test(lower)) return 'global remote';
+  // (?<!\w)/(?!\w) not \b: the "70+" signal ends in "+", and a trailing \b
+  // never matches after a symbol edge, so "remote in 70+ countries" fell
+  // through to the weaker 'regional remote' bucket. Word alternatives behave
+  // identically under either boundary, so this only rescues the "70+" case.
+  if (/(?<!\w)(global|anywhere|worldwide|no restrict|70\+|work from anywhere)(?!\w)/.test(lower)) return 'global remote';
   if (/\b(remote|latam|americas|brazil|fully remote)\b/.test(lower)) return 'regional remote';
   return 'unknown';
 }

--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -206,6 +206,38 @@ function buildViaChannelAnalysis(submitted, isAdvanced, minSample = MIN_VENDOR_N
   };
 }
 
+// --- Tech-stack-gap extraction (shared by the analysis pass and the self-test) ---
+// Canonical display spelling keyed by lowercased alias, so "react native" /
+// "NODEJS" collapse into one bucket rather than one per case variant.
+const TECH_CANONICAL = new Map([
+  'JavaScript', 'TypeScript', 'Python', 'Ruby', 'Java', 'Go', 'Rust',
+  'React Native', 'React', 'Angular', 'Django', 'Flask', 'Rails', 'PHP',
+  'Laravel', 'Symfony', 'Kotlin', 'Swift', 'C++', 'C#', '.NET', 'MongoDB',
+  'MySQL', 'PostgreSQL', 'Redis', 'GraphQL', 'REST', 'AWS', 'GCP', 'Azure',
+  'Docker', 'Kubernetes', 'Terraform', 'Supabase', 'Inngest',
+].map(t => [t.toLowerCase(), t]));
+TECH_CANONICAL.set('node.js', 'Node.js').set('nodejs', 'Node.js');
+TECH_CANONICAL.set('vue.js', 'Vue.js').set('vuejs', 'Vue.js');
+
+// (?<!\w) / (?!\w) lookarounds, NOT \b: a trailing \b never matches after a
+// symbol edge, so "C++", "C#" and ".NET" — three of the most common stacks —
+// were silently never extracted, vanishing from the tech-gap rollup and the
+// "filter out roles requiring X" recommendation. Same symbol-edge fix that
+// skill-extract.mjs and upskill.mjs already carry. Ordered longest-first
+// (React Native before React) so the specific alternative wins at a position.
+const TECH_MENTION_RE = /(?<!\w)(JavaScript|TypeScript|Python|Ruby|Java|Go|Rust|Node\.?js|React Native|React|Angular|Vue\.?js|Django|Flask|Rails|PHP|Laravel|Symfony|Kotlin|Swift|C\+\+|C#|\.NET|MongoDB|MySQL|PostgreSQL|Redis|GraphQL|REST|AWS|GCP|Azure|Docker|Kubernetes|Terraform|Supabase|Inngest)(?!\w)/gi;
+
+/**
+ * Canonical tech names mentioned in a gap description.
+ * @param {string} description
+ * @returns {string[]} Canonical tech names, one entry per mention (may repeat).
+ */
+function extractTechMentions(description) {
+  const matches = String(description ?? '').match(TECH_MENTION_RE);
+  if (!matches) return [];
+  return matches.map(m => TECH_CANONICAL.get(m.toLowerCase()) || m);
+}
+
 function runSelfTest() {
   const summary = parseMachineSummary(`
 ## Machine Summary
@@ -845,31 +877,13 @@ function analyze() {
   }
 
   // --- Tech stack gaps (from negative + self_filtered outcomes) ---
-  // Canonical spellings keyed by lowercased match — the /i regex below returns
-  // the source casing ("react native", "NODEJS"), and without this map each
-  // case variant of the same tech lands in its own techStackGaps bucket.
-  // Keys cover the optional-dot regex variants (node.js/nodejs, vue.js/vuejs).
-  const TECH_CANONICAL = new Map([
-    'JavaScript', 'TypeScript', 'Python', 'Ruby', 'Java', 'Go', 'Rust',
-    'React Native', 'React', 'Angular', 'Django', 'Flask', 'Rails', 'PHP',
-    'Laravel', 'Symfony', 'Kotlin', 'Swift', 'C++', 'C#', '.NET', 'MongoDB',
-    'MySQL', 'PostgreSQL', 'Redis', 'GraphQL', 'REST', 'AWS', 'GCP', 'Azure',
-    'Docker', 'Kubernetes', 'Terraform', 'Supabase', 'Inngest',
-  ].map(t => [t.toLowerCase(), t]));
-  TECH_CANONICAL.set('node.js', 'Node.js').set('nodejs', 'Node.js');
-  TECH_CANONICAL.set('vue.js', 'Vue.js').set('vuejs', 'Vue.js');
   const stackGapCounts = new Map();
   for (const e of enriched) {
     if (e.outcome !== 'negative' && e.outcome !== 'self_filtered') continue;
     if (!e.report?.gaps) continue;
     for (const gap of e.report.gaps) {
-      // Extract tech keywords from gap descriptions
-      const techs = gap.description.match(/\b(JavaScript|TypeScript|Python|Ruby|Java|Go|Rust|Node\.?js|React Native|React|Angular|Vue\.?js|Django|Flask|Rails|PHP|Laravel|Symfony|Kotlin|Swift|C\+\+|C#|\.NET|MongoDB|MySQL|PostgreSQL|Redis|GraphQL|REST|AWS|GCP|Azure|Docker|Kubernetes|Terraform|Supabase|Inngest)\b/gi);
-      if (techs) {
-        for (const tech of techs) {
-          const normalized = TECH_CANONICAL.get(tech.toLowerCase()) || tech;
-          stackGapCounts.set(normalized, (stackGapCounts.get(normalized) || 0) + 1);
-        }
+      for (const tech of extractTechMentions(gap.description)) {
+        stackGapCounts.set(tech, (stackGapCounts.get(tech) || 0) + 1);
       }
     }
   }

--- a/analyze-patterns.mjs
+++ b/analyze-patterns.mjs
@@ -375,6 +375,21 @@ risk_summary:
     failures.push(`hired: must count as advanced in channel yield (1/2 = 50%) → ${JSON.stringify(hiredHays)}`);
   }
 
+  // Tech-gap extraction (regression): symbol-edge stacks were silently dropped
+  // because a trailing \b never matches after "+"/"#" (C++, C#, .NET).
+  const techHits = extractTechMentions('Requires C++, C# and .NET, plus React Native and Go');
+  for (const expected of ['C++', 'C#', '.NET', 'React Native', 'Go']) {
+    if (!techHits.includes(expected)) failures.push(`tech extraction dropped "${expected}"`);
+  }
+  // No false positives from substrings ("Go" in "Google", "Java" in "JavaScripting").
+  if (extractTechMentions('Google Cloud and JavaScripting skills').length !== 0) {
+    failures.push('tech extraction false-positived on Google/JavaScripting');
+  }
+  // Case/punctuation variants collapse to one canonical bucket.
+  if (extractTechMentions('nodejs, Node.js, NODEJS').some(t => t !== 'Node.js')) {
+    failures.push('node.js case variants failed to canonicalize');
+  }
+
   if (failures.length > 0) {
     console.error(`analyze-patterns self-test failed: ${failures.join('; ')}`);
     process.exit(1);


### PR DESCRIPTION
## The bug

`analyze-patterns.mjs`'s tech-mention regex bounded each match with `\b`:

```js
gap.description.match(/\b(...|C\+\+|C#|\.NET|...)\b/gi)
```

A trailing `\b` requires a word char on one side of the boundary, so it **never matches after a symbol edge** — after the `+` in `C++`, the `#` in `C#`, or around the leading `.` in `.NET`. All three silently failed to match in *any* gap description:

```
"needs C++ experience"  -> null
"strong C# background"  -> null
"built on .NET"         -> null
```

So `C++`, `C#`, and `.NET` — three of the most common stacks — never reached the `techStackGaps` rollup or the *"Filter out roles requiring {top gaps} as primary stack"* recommendation, even when they were the actual blocker in negative/self-filtered outcomes. The analysis quietly under-reported them as zero.

## The fix

Switch the boundaries to `(?<!\w)` / `(?!\w)` lookarounds — the same symbol-edge fix `skill-extract.mjs` and `upskill.mjs` already carry — and lift the regex + canonical map into a module-level `extractTechMentions()` so it's unit-testable:

```
"needs C++ experience"  -> ["C++"]
"strong C# background"  -> ["C#"]
"built on .NET"         -> [".NET"]
"Google Cloud"          -> null      (no false positive)
"JavaScripting"         -> null
```

**No vocabulary change** — the same 37-tech scope and case-canonicalization are preserved; this only stops the three symbol-bearing entries from being invisible. (The eventual unification onto `skill-extract.mjs` — #1896's PR 3 — will supersede this inline regex; this is the interim correctness fix so the analysis is right in the meantime.)

## Tests

Regression added to the existing `--self-test`: the three dropped stacks now extract, substrings (`Go` in `Google`, `Java` in `JavaScripting`) don't false-positive, and `node.js` case variants collapse to one bucket.

`node analyze-patterns.mjs --self-test` → OK · `node test-all.mjs --quick` → **2252 passed, 0 failed**.

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved technology stack detection during gap analysis.
  * Correctly recognizes symbol-edge technologies such as C++, C#, and .NET.
  * Prevents false matches inside unrelated words (e.g., “Go” in “Google,” “Java” in “JavaScripting”).
  * Standardizes technology variants and casing (e.g., “nodejs” → “Node.js”).
  * Enhances “tech stack gaps” and stack mismatch recommendations using more accurate detection results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->