### PR TITLE
docs(i18n): remove stale  step from README.fr.md

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -148,14 +148,11 @@ career-ops prend en charge [Gemini CLI](https://github.com/google-gemini/gemini-
 npm install -g @google/gemini-cli
 # ou : npx @google/gemini-cli --version
 
-# 2. Authentifiez-vous (gratuit, utilise votre compte Google)
-gemini auth
-
-# 3. Exécutez dans le dossier career-ops
+# 2. Exécutez dans le dossier career-ops
 cd career-ops
 gemini
 
-# 4. Utilisez la commande unifiée /career-ops avec ses sous-commandes :
+# 3. Utilisez la commande unifiée /career-ops avec ses sous-commandes :
 /career-ops "Senior AI Engineer at Anthropic..."
 /career-ops pipeline
 /career-ops scan


### PR DESCRIPTION
## What does this PR do?

Removes the stale `gemini auth` step from `README.fr.md` and renumbers the following steps. The native Gemini CLI signs you in on first run — there is no `auth` subcommand. #936 cleaned this up in `README.md` and #2205 fixed `README.ar.md`, but the French copy was missed.

## Related issue

Closes #2215

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] `grep -n "gemini auth" README*.md` returns nothing
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the French setup guide for the native Gemini CLI option.
  * Removed the separate authentication step and clarified the streamlined command sequence.
  * Renumbered the instructions and added the relevant commands inline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->