### PR TITLE
registry: add career-ops-plugin-a16z-speedrun-talent

### DIFF
--- a/plugins-registry/a16z-speedrun-talent.json
+++ b/plugins-registry/a16z-speedrun-talent.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "description": "Scan and search live roles across the a16z speedrun talent network — hundreds of a16z portfolio startups behind one zero-key public feed.",
   "repo": "https://github.com/justma16ze/career-ops-plugin-a16z-speedrun-talent",
-  "sha": "77b86df2cba9e3411c771088f1deada3cb734e17",
+  "sha": "04e2ab1360b7366c6eb5eb87ae598465fb3fc3de",
   "hooks": [
     "provider",
     "search"

--- a/plugins-registry/a16z-speedrun-talent.json
+++ b/plugins-registry/a16z-speedrun-talent.json
@@ -1,0 +1,19 @@
+{
+  "id": "a16z-speedrun-talent",
+  "name": "career-ops-plugin-a16z-speedrun-talent",
+  "version": "0.1.0",
+  "license": "MIT",
+  "description": "Scan and search live roles across the a16z speedrun talent network — hundreds of a16z portfolio startups behind one zero-key public feed.",
+  "repo": "https://github.com/justma16ze/career-ops-plugin-a16z-speedrun-talent",
+  "sha": "77b86df2cba9e3411c771088f1deada3cb734e17",
+  "hooks": [
+    "provider",
+    "search"
+  ],
+  "requiredEnv": [],
+  "allowedHosts": [
+    "speedrun-talent-network.com"
+  ],
+  "registrationIssue": "https://github.com/santifer/career-ops/issues/2232",
+  "addedAt": "2026-07-27"
+}


### PR DESCRIPTION
## Plugin registry change

Home issue: #2232

Paste the registry entry (one object), pinned to the exact reviewed commit:

```json
{
  "id": "a16z-speedrun-talent",
  "name": "career-ops-plugin-a16z-speedrun-talent",
  "version": "0.1.0",
  "license": "MIT",
  "description": "Scan and search live roles across the a16z speedrun talent network — hundreds of a16z portfolio startups behind one zero-key public feed.",
  "repo": "https://github.com/justma16ze/career-ops-plugin-a16z-speedrun-talent",
  "sha": "04e2ab1360b7366c6eb5eb87ae598465fb3fc3de",
  "hooks": [
    "provider",
    "search"
  ],
  "requiredEnv": [],
  "allowedHosts": [
    "speedrun-talent-network.com"
  ],
  "registrationIssue": "https://github.com/santifer/career-ops/issues/2232",
  "addedAt": "2026-07-27"
}
```

### Maintainer review checklist

- [ ] Naming `career-ops-plugin-<name>`; `id` == name minus the prefix
- [ ] Minimum files present (manifest.json, index.mjs, README.md, LICENSE)
- [ ] Manifest valid: apiVersion 1, `humanInTheLoop: true`, hooks ⊆ {provider, ingest, search, notify, export} — **no apply/submit**
- [ ] MIT-compatible LICENSE; no personal data in the repo
- [ ] Egress: `allowedHosts` are real public hosts; no IP literals / metadata / `*.internal`; no localhost
- [ ] Static audit clean: egress only via `ctx.fetch`
- [ ] No core-owned secrets in `requiredEnv`
- [ ] Reads PUBLIC data only — no centralized infrastructure, no auto-submit, no blind-apply
- [ ] No commercial / hosted-service / monetization wording
- [ ] Skill is domain-scoped
- [ ] `sha` is pinned to the exact reviewed commit
- [ ] CI (`plugin-registry-validate`) is green

---

Notes for reviewers: zero keys — the feed is public and unauthenticated. `node validate-plugin-registry.mjs` passes locally. **Disclosure** (same as #2231/#2232): I run the a16z speedrun talent network; this plugin reads a public feed my team operates. The plugin's `provider` hook overlaps with core provider PR #2231 — happy to resolve either direction, maintainers' call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the a16z Speedrun Talent plugin to the registry.
  * Enables searching and accessing live roles across the Speedrun talent network.
  * Includes network access controls and plugin registration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->