### PR TITLE
test(context-budget): enforce every _shared.md heading is classified in SECTION_PRIORITY

### DIFF
--- a/lib/context-budget.test.mjs
+++ b/lib/context-budget.test.mjs
@@ -305,6 +305,30 @@ if (!existsSync(sharedPath)) {
     console.log('  lib/context-budget.mjs to match, or restore the heading.');
     console.log(`\n  Headings found in _shared.md: ${[...fileHeadings].sort().join(', ')}`);
   }
+
+  // Reverse check: every _shared.md heading MUST have an explicit entry in
+  // SECTION_PRIORITY. DEFAULT_PRIORITY = 2 means an unlisted section silently
+  // becomes compressible — add a scoring-critical section next year, forget
+  // the map, and it gets trimmed under budget pressure with nobody noticing.
+  // This test makes that failure mode impossible.
+  const unclassified = [];
+  for (const heading of fileHeadings) {
+    if (!(heading in SECTION_PRIORITY)) {
+      unclassified.push(heading);
+    }
+  }
+
+  ok('all _shared.md headings classified in SECTION_PRIORITY', unclassified.length === 0);
+
+  if (unclassified.length > 0) {
+    console.log(`\n  ❌  ${unclassified.length} heading(s) in _shared.md are NOT in SECTION_PRIORITY:`);
+    for (const h of unclassified) {
+      console.log(`      - "${h}" → falls through to DEFAULT_PRIORITY (P2, compressible)`);
+    }
+    console.log('  Add each heading to SECTION_PRIORITY in lib/context-budget.mjs with');
+    console.log('  the correct priority (0 = never compress, 1 = compress when tight,');
+    console.log('  2 = prefer to compress).');
+  }
 }
 
 // ============================================================================


### PR DESCRIPTION
## What does this PR do?

Adds a reverse check in test #11 of context-budget.test.mjs: every ## heading in _shared.md must have an explicit entry in SECTION_PRIORITY. Prevents the quiet failure mode where a new section silently defaults to P2 (compressible) because no one remembered to classify it.

## Related issue

Closes #2230

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integrity checks to ensure all shared content sections have explicit priority settings.
  * Improved failure messages to identify sections that may otherwise receive the default compression priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->