### PR TITLE
fix(scan): record auth/server/unknown fetch errors in portal-health instead of 'reachable'

### DIFF
--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -28,7 +28,7 @@ These files contain your personal data, customizations, and work product. Update
 | `data/pipeline.md` | Your URL inbox |
 | `data/scan-history.tsv` | Your scan history (9 tab-separated columns; col 8: local SimHash JD fingerprint for cross-listing detection, col 9: posting date) |
 | `data/scan-runs.tsv` | Your per-run scan counters (appended by `scan.mjs`, read by `stats.mjs`) |
-| `data/portal-health.tsv` | Consecutive reachability status for scanned portals (appended by `scan.mjs`) |
+| `data/portal-health.tsv` | Consecutive reachability status for scanned portals (appended by `scan.mjs`; statuses: `reachable`, `empty`, `slug_gone`, `network`, `auth`, `server`, `unknown` — the last three joined the vocabulary later, so older files carry only the first four) |
 | `data/follow-ups.md` | Your follow-up history |
 | `data/offers/*` | Your received offers/contracts, promise notes, prep reports, and reply drafts (PII — gitignored, written by the `offer-prep` mode) |
 | `data/salary-observations.tsv` | Your append-only compensation observation log: `{tracker#}\t{date}\t{desired\|advertised\|actual}\t{amount}\t{currency}\t{source}\t{note}`. Written by interactive modes when a figure is stated/confirmed; never edited in place. Advertised figures come from reports' `advertised_comp` instead — reports are themselves observation sources. Read by `salary-gap.mjs` |

--- a/scan.mjs
+++ b/scan.mjs
@@ -1525,10 +1525,14 @@ export function loadPortalHealth(filePath = PORTAL_HEALTH_PATH) {
 export function computeConsecutiveFailures(healthRecords) {
   const streaks = new Map();
   for (const r of healthRecords) {
-    if (r.status === 'slug_gone' || r.status === 'network') {
-      streaks.set(r.company, (streaks.get(r.company) || 0) + 1);
-    } else if (r.status === 'reachable' || r.status === 'empty') {
+    // Healthy statuses reset the streak; every other status counts toward it.
+    // Inverted (vs. listing failure statuses) so the newer error kinds
+    // (auth/server/unknown) can't silently fall outside the streak again.
+    // 'empty' is deliberately healthy: a live board with 0 jobs is reachable.
+    if (r.status === 'reachable' || r.status === 'empty') {
       streaks.set(r.company, 0);
+    } else {
+      streaks.set(r.company, (streaks.get(r.company) || 0) + 1);
     }
   }
   return streaks;
@@ -2168,16 +2172,21 @@ async function main() {
   const nowStr = new Date().toISOString();
   const healthRecords = [];
   
+  // Record each errored target under its real classifyFetchError kind. Before
+  // this, only slug_gone/network were recorded and auth (401/403), server
+  // (5xx), and unknown fell through to 'reachable' — so a portal WAF-403ing
+  // every run was logged as healthy forever and never reached the 🚨 streak
+  // escalation. The TSV status vocabulary is additive: auth/server/unknown
+  // join the existing reachable|slug_gone|network|empty.
+  const errorKindByCompany = new Map(
+    errors.filter((e) => e.kind).map((e) => [e.company, e.kind])
+  );
   for (const t of targets) {
-    const isUnreachable = unreachableTargets.some(e => e.company === t.name);
-    const isNetwork = networkTargets.some(e => e.company === t.name);
     const isEmpty = emptyTargets.includes(t.name);
-    
-    let status = 'reachable';
-    if (isUnreachable) status = 'slug_gone';
-    else if (isNetwork) status = 'network';
-    else if (isEmpty) status = 'empty';
-    
+
+    let status = errorKindByCompany.get(t.name) || 'reachable';
+    if (status === 'reachable' && isEmpty) status = 'empty';
+
     healthRecords.push({ timestamp: nowStr, company: t.name, status });
   }
 
@@ -2188,16 +2197,18 @@ async function main() {
   const newlyDeadSlug = [];
   const newlyDeadNetwork = [];
   
-  for (const e of [...unreachableTargets, ...networkTargets]) {
+  // All error kinds can reach the 🚨 persistent list (auth/server/unknown
+  // included — a WAF that 403s the scanner every run is coverage decay too).
+  // Below threshold, only slug_gone/network keep their dedicated warnings;
+  // auth/server/unknown stay in the one-off `Errors (N):` print below.
+  for (const e of [...unreachableTargets, ...networkTargets, ...otherErrors.filter((x) => x.kind)]) {
     const streak = currentStreaks.get(e.company) || 1;
     if (streak >= STREAK_THRESHOLD) {
       if (!persistentlyDead.includes(e.company)) persistentlyDead.push(e.company);
-    } else {
-      if (e.kind === 'slug_gone') {
-        if (!newlyDeadSlug.some(x => x.company === e.company)) newlyDeadSlug.push(e);
-      } else {
-        newlyDeadNetwork.push(e);
-      }
+    } else if (e.kind === 'slug_gone') {
+      if (!newlyDeadSlug.some(x => x.company === e.company)) newlyDeadSlug.push(e);
+    } else if (e.kind === 'network') {
+      newlyDeadNetwork.push(e);
     }
   }
 

--- a/stats.mjs
+++ b/stats.mjs
@@ -266,10 +266,12 @@ export function computePortalStats(portalsYmlContent, scanStats, producingCompan
     }
     const streaks = new Map();
     for (const r of healthRecords) {
-      if (r.status === 'slug_gone' || r.status === 'network') {
-        streaks.set(r.company, (streaks.get(r.company) || 0) + 1);
-      } else if (r.status === 'reachable' || r.status === 'empty') {
+      // Mirrors scan.mjs computeConsecutiveFailures: healthy statuses reset,
+      // every other status (slug_gone/network/auth/server/unknown) counts.
+      if (r.status === 'reachable' || r.status === 'empty') {
         streaks.set(r.company, 0);
+      } else {
+        streaks.set(r.company, (streaks.get(r.company) || 0) + 1);
       }
     }
     const threshold = cfg.portal_health_threshold || 3;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9842,6 +9842,44 @@ try {
   } else {
     fail('computePortalStats failed on null portalHealthTsv');
   }
+
+  // auth/server/unknown statuses count toward the persistent-dead streak too
+  // (previously they were recorded as 'reachable' and never escalated): a WAF
+  // 403ing the scanner every run is coverage decay exactly like a dead slug.
+  const portalsYml2 = 'tracked_companies:\n  - name: WafBlocked\n  - name: FlakyServer\njob_boards: []';
+  const authHealthTsv = 'timestamp\tcompany\tstatus\n' +
+    '2026-07-01\tWafBlocked\tauth\n' +
+    '2026-07-02\tWafBlocked\tauth\n' +
+    '2026-07-03\tWafBlocked\tauth\n' +
+    '2026-07-01\tFlakyServer\tserver\n' +
+    '2026-07-02\tFlakyServer\treachable\n' + // recovery resets the streak
+    '2026-07-03\tFlakyServer\tserver\n';
+  const p2 = stats.computePortalStats(portalsYml2, null, [], authHealthTsv);
+  if (p2 && p2.persistentlyDead === 1) {
+    pass('computePortalStats counts auth/server streaks as persistently dead; recovery resets');
+  } else {
+    fail(`computePortalStats auth/server streaks wrong: ${JSON.stringify(p2?.persistentlyDead)}`);
+  }
+
+  // scan.mjs computeConsecutiveFailures — same inverted rule at the source:
+  // any non-healthy status increments, reachable/empty reset, and a legacy
+  // 4-status TSV computes identical streaks to before the change.
+  const { computeConsecutiveFailures } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+  const streaks = computeConsecutiveFailures([
+    { company: 'A', status: 'auth' },
+    { company: 'A', status: 'auth' },
+    { company: 'A', status: 'auth' },
+    { company: 'B', status: 'server' },
+    { company: 'B', status: 'empty' },     // empty is healthy → resets
+    { company: 'C', status: 'slug_gone' }, // legacy status still counts
+    { company: 'C', status: 'network' },
+    { company: 'D', status: 'reachable' },
+  ]);
+  if (streaks.get('A') === 3 && streaks.get('B') === 0 && streaks.get('C') === 2 && streaks.get('D') === 0) {
+    pass('computeConsecutiveFailures: auth/server/unknown count, reachable/empty reset, legacy statuses unchanged');
+  } else {
+    fail(`computeConsecutiveFailures wrong streaks: ${JSON.stringify([...streaks])}`);
+  }
 } catch (e) {
   fail(`test layout guard: ${e.message}`);
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a gap in the portal-health tracking from #1768: the status assignment in `scan.mjs` only recorded `slug_gone` / `network` / `empty` — error kinds **`auth` (401/403), `server` (5xx), and `unknown` fell through to the default `'reachable'`** in `data/portal-health.tsv`.

Consequence: a portal that 403s the scanner on every run (a real-world mode — e.g. some Oracle Cloud tenants WAF-403 datacenter IPs, noted back in #1929) was recorded as *healthy* forever. No failure streak, no `🚨 FIX NEEDED` escalation, and `stats.mjs`'s `persistentlyDead` counter missed it too. Silent coverage decay is exactly what #1768 was built to surface; this gap defeated it for 3 of the 5 `classifyFetchError` kinds.

### Changes

- **Status assignment (`scan.mjs`)**: each errored target is now recorded under its real `classifyFetchError` kind. The TSV vocabulary is additive — `auth`/`server`/`unknown` join the existing `reachable|slug_gone|network|empty`. Same 3 columns, no schema change.
- **Streak logic** (`computeConsecutiveFailures` + the `stats.mjs` mirror): condition inverted — healthy statuses (`reachable`/`empty`) reset the streak, **every other status counts**. On legacy 4-status TSVs this computes identical results (backward compatible), and the inversion means future error kinds can't silently fall outside the streak again.
- **Escalation loop**: all error kinds can now reach the `🚨` persistent list once their streak crosses the threshold. Below threshold, `auth`/`server`/`unknown` keep their existing one-off `Errors (N):` print — per-run output for transient errors is unchanged.
- **Tests**: streak assertions for auth/server counting + recovery reset + legacy-status backward-compat; a `computePortalStats` fixture where a WAF-blocked portal crosses the threshold.
- **`DATA_CONTRACT.md`**: documents the full status vocabulary (and that older files carry only the first four).

### Not in scope

- Persisting raw error messages/HTTP statuses to the TSV (schema change).
- `PORTAL_HEALTH_PATH` cwd resolution — that's #2161 (different lines, no conflict).
- Auto-remediation of dead slugs — that's #1702/#1703.

## Related issue

None — bug fix (straight to PR per CONTRIBUTING).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Verification

```
node --check scan.mjs stats.mjs test-all.mjs
node test-all.mjs --quick
```
New assertions pass:
- `computePortalStats counts auth/server streaks as persistently dead; recovery resets`
- `computeConsecutiveFailures: auth/server/unknown count, reachable/empty reset, legacy statuses unchanged`

The 5 failing checks locally are identical on clean `main` (verified by stashing the diff and re-running): the pre-existing `node:sqlite` Node-v20 tracker tests and the #912 collision test — unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added portal health tracking for authentication, server, network, unreachable, and other failure statuses.
  - Persistent failure detection now includes all non-healthy statuses, while healthy and empty results reset failure streaks.
  - Documented the new portal health data file and supported status values.

- **Bug Fixes**
  - Improved escalation accuracy for portals experiencing recurring non-standard failures.

- **Tests**
  - Added coverage for expanded failure statuses and streak-reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->