### PR TITLE
fix(test): make the SYSTEM_PATHS coverage guard actually run in CI

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -189,7 +189,11 @@ const scripts = [
   { name: 'reply-matcher.test.mjs', expectExit: 0 },
   { name: 'validate-portals.mjs --file templates/portals.example.yml', expectExit: 0 },
   { name: 'validate-system-paths-coverage.mjs --self-test', expectExit: 0 },
-  { name: 'validate-system-paths-coverage.mjs', expectExit: 0 },
+  // The bare coverage run is NOT here on purpose: this section executes each
+  // script from a throwaway copy of the repo, and the coverage check needs
+  // `git ls-files` on the REAL tree. Running it here validated nothing and
+  // exited 0 no matter what, which is how five unregistered files shipped.
+  // It now runs from ROOT in section 5.
   // Missing-file run: must exit 0 gracefully and hit no network. Do not use the
   // default portals.yml because end-user workspaces often have a real user-layer
   // portals file that would trigger a live remote sweep during tests.
@@ -923,6 +927,56 @@ for (const f of skillEntrypoints) {
     pass(`Entrypoint is a real symlink in git: ${f}`);
   } else {
     fail(`Entrypoint committed as a REGULAR file (mode ${staged.split(' ')[0]}) — users of this CLI get a broken skill: ${f}`);
+  }
+}
+
+// The SYSTEM_PATHS coverage guard must FAIL when it cannot inspect the tree,
+// not report success.
+//
+// For as long as that guard existed it was a no-op in CI. The script-execution
+// section above runs each script from a throwaway copy created inside the repo,
+// and `git ls-files` from an untracked directory returns zero paths — so the
+// guard printed "OK: 0 tracked files covered" and exited 0 while the real tree
+// had an unregistered top-level file. `update-system` never ships an
+// unregistered file, so every user who updates silently loses it. That class has
+// landed five times with this check green throughout.
+//
+// This asserts the opposite behaviour directly: invoked where git sees nothing,
+// the guard must exit non-zero.
+{
+  const probeDir = join(ROOT, '.tmp-coverage-guard-probe');
+  try {
+    mkdirSync(probeDir, { recursive: true });
+    copyFileSync(join(ROOT, 'validate-system-paths-coverage.mjs'), join(probeDir, 'validate-system-paths-coverage.mjs'));
+    copyFileSync(join(ROOT, 'update-system.mjs'), join(probeDir, 'update-system.mjs'));
+    const probe = spawnSync(process.execPath, [join(probeDir, 'validate-system-paths-coverage.mjs')], {
+      cwd: probeDir,
+      encoding: 'utf-8',
+    });
+    if (probe.status !== 0) {
+      pass('SYSTEM_PATHS coverage guard fails when it cannot inspect the tree (not a silent pass)');
+    } else {
+      fail('SYSTEM_PATHS coverage guard exited 0 from an untracked dir — it is a no-op in CI again');
+    }
+  } catch (err) {
+    fail(`could not probe the SYSTEM_PATHS coverage guard: ${err.message} (a failed probe is not a pass)`);
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true });
+  }
+}
+
+// And the check itself, run where it can actually see the tree. This is the
+// assertion that was missing: every tracked file must be claimed by SYSTEM_PATHS
+// or USER_PATHS, or `update-system` silently stops shipping it.
+{
+  const cov = spawnSync(process.execPath, [join(ROOT, 'validate-system-paths-coverage.mjs')], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+  });
+  if (cov.status === 0) {
+    pass('every tracked file is covered by SYSTEM_PATHS or USER_PATHS');
+  } else {
+    fail(`SYSTEM_PATHS coverage gap — a new file is unregistered and update-system will not ship it:\n${(cov.stderr || cov.stdout || '').trim()}`);
   }
 }
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -143,6 +143,7 @@ const SYSTEM_PATHS = [
   'application-answers.mjs',
   'generate-cover-letter.mjs',
   'merge-tracker.mjs',
+  'sync-pdf-flags.mjs',
   'tracker-links.mjs',
   'tracker.mjs',
   'find.mjs',

--- a/validate-system-paths-coverage.mjs
+++ b/validate-system-paths-coverage.mjs
@@ -121,6 +121,28 @@ try {
   process.exit(1);
 }
 
+// An empty file list is NOT "nothing to check" — it means this run could not
+// inspect anything, and reporting success would make the guard a no-op.
+//
+// That is exactly what happened for as long as this check has existed. test-all
+// runs the scripts from a throwaway copy created *inside* the repo, and
+// `git ls-files` from an untracked subdirectory returns zero paths. So CI printed
+// "OK: 0 tracked files covered" and exited 0 while the real tree had an
+// unregistered top-level file. A file missing from SYSTEM_PATHS is not cosmetic:
+// `update-system` never ships it, so every user who updates silently loses it.
+// This bug class has landed five times (#649, #704, .editorconfig, and twice
+// since) and the guard meant to stop it was green throughout.
+//
+// A check that cannot look must fail, not pass.
+if (tracked.length === 0) {
+  console.error('FAIL: git ls-files returned no paths — this run could not inspect anything.');
+  console.error('');
+  console.error('Run this from the repository root. An empty listing usually means the');
+  console.error('script was invoked from an untracked directory (a temp copy, a fixture');
+  console.error('dir), where git reports nothing and the coverage check is meaningless.');
+  process.exit(1);
+}
+
 const orphans = tracked.filter((f) => !covered(f));
 
 if (orphans.length > 0) {


### PR DESCRIPTION
## The problem

`validate-system-paths-coverage.mjs` exists to stop a new system file from shipping unregistered — the bug class that has landed **five times** (#649, #704, `.editorconfig`, and twice since). It has been a no-op in CI for its entire life.

`test-all.mjs` runs each script from a throwaway copy created *inside* the repo. The check calls `git ls-files`, which from an untracked subdirectory returns **zero paths**. Zero paths means zero orphans, so it printed `OK: 0 tracked files covered` and exited 0 no matter what the real tree looked like.

Reproduced:

```
$ node validate-system-paths-coverage.mjs        # from the repo root
Coverage gap: sync-pdf-flags.mjs                 → exit 1   correct
$ node .tmp/validate-system-paths-coverage.mjs   # as CI ran it
OK: 0 tracked files covered                      → exit 0   green, and wrong
```

An unregistered file is not cosmetic: `update-system` never ships it, so every user who updates silently loses it.

## The fix

- **`validate-system-paths-coverage.mjs`** — an empty file list now fails. A check that cannot look must not pass.
- **`test-all.mjs`** — the bare coverage run leaves the script section, where it could never be meaningful, and runs from `ROOT` instead.
- **`test-all.mjs`** — a probe asserts the guard exits non-zero when invoked where git sees nothing, so it cannot silently become a no-op again.
- **`update-system.mjs`** — registers `sync-pdf-flags.mjs`, which the blind guard let through when #2213 landed.

## Verification

Both directions, not just the happy one:

- Remove the registration → suite goes **red** and names the gap
- Restore it → **2284 passed, 0 failed**

## Note

The unregistered file got in through a merge of mine earlier today, and the reason I caught it at all is that `co-gate --deep` runs this check from the repo root. CI never would have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation reliability by detecting when repository files cannot be inspected, preventing false-positive coverage results.
  - Added coverage tracking for an additional system-level file so automated updates and restoration remain consistent.

- **Tests**
  - Expanded validation checks to confirm failures are reported in incomplete environments and successful checks pass against the actual repository.
  - Improved diagnostic output when coverage validation detects an issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->