### PR TITLE
ci: keep the career-ops release marked as Latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,26 @@ jobs:
         if: ${{ steps.release.outputs.release_created || github.event_name == 'workflow_dispatch' }}
         run: npm publish --provenance --access public
         working-directory: scaffolder
+
+      # GitHub marks whichever release was created LAST as "Latest", and in this
+      # manifest the `web` component is created after `career-ops`. Result: the
+      # repository's releases page has never once pointed at the main package —
+      # every career-ops release since the web component was added showed
+      # `web-vX.Y.Z` as the latest version to anyone landing there. Verified
+      # 28-jul: 0 of 20 career-ops releases carried the flag.
+      #
+      # Re-assert it explicitly so ordering stops deciding. Reads the version
+      # from the manifest rather than an action output, so it cannot drift from
+      # what was actually released.
+      - name: Keep the career-ops release marked as Latest
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ver=$(jq -r '."."' .release-please-manifest.json)
+          if [ -z "$ver" ] || [ "$ver" = "null" ]; then
+            echo "::error::could not read the career-ops version from .release-please-manifest.json"
+            exit 1
+          fi
+          echo "marking career-ops-v${ver} as Latest"
+          gh release edit "career-ops-v${ver}" --repo "$GITHUB_REPOSITORY" --latest


### PR DESCRIPTION
## The problem

GitHub marks whichever release was created **last** as "Latest". This manifest releases two components, and `web` is created after `career-ops`, so the flag has been landing on the wrong one.

Verified today: **0 of the last 20 `career-ops` releases carried the flag**, while `web-v0.4.0` did. Anyone opening the releases page to check the current version saw the web component's number instead of career-ops'.

## The fix

One step after release-please re-asserts the flag, so creation order stops deciding it:

```yaml
- name: Keep the career-ops release marked as Latest
  if: ${{ steps.release.outputs.release_created }}
  run: |
    ver=$(jq -r '."."' .release-please-manifest.json)
    gh release edit "career-ops-v${ver}" --repo "$GITHUB_REPOSITORY" --latest
```

The version comes from `.release-please-manifest.json` rather than an action output, so it cannot drift from what was actually released, and the step fails loudly if the manifest can't be read.

## Verification

Ran the step's logic against the live repo: the manifest resolves to `career-ops-v1.23.0`, that tag exists, and `gh release edit --latest` is what I just used by hand to correct today's release. No new permissions needed — the workflow already has `contents: write`.

## Scope

`.github/workflows/release.yml` only. Trigger unchanged (`push` to main + `workflow_dispatch`), no `permissions:` change, no new actions, and the single `run:` step calls `jq` and `gh` against this repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release management by ensuring the intended `career-ops` release is consistently marked as the latest release.
  * Added validation to prevent release workflows from continuing when the required version information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->