### PR TITLE
feat(scan-history): additive normalized-company column for reliable repost keying

### DIFF
--- a/DATA_CONTRACT.md
+++ b/DATA_CONTRACT.md
@@ -26,7 +26,7 @@ These files contain your personal data, customizations, and work product. Update
 | `data/applications.md` | Your application tracker (source of truth) |
 | `data/applications.db` | Derived query index over `applications.md` (SQLite, rebuilt by `node tracker.mjs sync` — safe to delete) |
 | `data/pipeline.md` | Your URL inbox |
-| `data/scan-history.tsv` | Your scan history (9 tab-separated columns; col 8: local SimHash JD fingerprint for cross-listing detection, col 9: posting date) |
+| `data/scan-history.tsv` | Your scan history (tab-separated, append-only trailing columns; col 8: local SimHash JD fingerprint for cross-listing detection, col 9: posting date, cols 10-11: trust score/flags, col 12: normalized company key for repost/name matching). Older rows may have fewer columns — readers index by position and tolerate the absence. |
 | `data/scan-runs.tsv` | Your per-run scan counters (appended by `scan.mjs`, read by `stats.mjs`) |
 | `data/portal-health.tsv` | Consecutive reachability status for scanned portals (appended by `scan.mjs`) |
 | `data/follow-ups.md` | Your follow-up history |

--- a/detect-reposts.mjs
+++ b/detect-reposts.mjs
@@ -26,6 +26,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 import { roleFuzzyMatch } from './role-matcher.mjs';
+import { normalizeCompanyName } from './invite-match.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const SCAN_HISTORY_PATH = join(CAREER_OPS, 'data/scan-history.tsv');
@@ -54,7 +55,11 @@ function daysBetween(d1, d2) {
 }
 
 // --- Parse scan-history.tsv ---
-// Format: url, first_seen, portal, title, company, status, location
+// Format: url, first_seen, portal, title, company, status, location, ...,
+//         normalized_company (trailing col 12, additive — see scan.mjs).
+// The normalized_company column is preferred as the clustering key when
+// present; rows written before it existed (fewer columns) simply lack it and
+// carry `normCompany: ''`, so a consumer normalizes the raw company on the fly.
 export function parseScanHistory(content) {
   const lines = content.split('\n').filter(line => line.trim());
   if (lines.length === 0) return [];
@@ -78,9 +83,26 @@ export function parseScanHistory(content) {
       company: company.trim(),
       status: (status || 'added').trim(),
       location: (location || '').trim(),
+      // Trailing normalized-company key (col 12, 0-indexed 11). '' for older
+      // rows that predate the column — companyKey() falls back to normalizing
+      // the raw name so old and new rows still cluster on the same key.
+      normCompany: (cols[11] || '').trim(),
     });
   }
   return rows;
+}
+
+// Canonical clustering key for a row. Prefers the stored normalized-company
+// column (written by scan.mjs via normalizeCompanyName) so "Acme Inc." and
+// "Acme" cluster without re-deriving anything; falls back to normalizing the
+// raw company on the fly for pre-column rows and for row objects built directly
+// (e.g. tests). A final fallback to the raw lowercased name preserves the
+// pre-normalization behavior for names that fold to empty (e.g. all-CJK or
+// all-Cyrillic company names), so those never over-cluster under one '' key.
+export function companyKey(row) {
+  const stored = typeof row.normCompany === 'string' ? row.normCompany.trim() : '';
+  const raw = typeof row.company === 'string' ? row.company.trim() : '';
+  return stored || normalizeCompanyName(raw) || raw.toLowerCase();
 }
 
 function loadScanHistory(path = SCAN_HISTORY_PATH) {
@@ -118,10 +140,12 @@ export function detectReposts(rows, windowDays = DEFAULT_WINDOW_DAYS) {
     }));
   if (valid.length < 2) return [];
 
-  // Group by company (case-insensitive).
+  // Group by normalized company key (prefers the stored normalized-company
+  // column, falls back to normalizing the raw name — see companyKey). This is
+  // what makes "Acme Inc." and "Acme" a single repost cluster instead of two.
   const byCompany = new Map();
   for (const row of valid) {
-    const key = row.company.toLowerCase();
+    const key = companyKey(row);
     if (!byCompany.has(key)) byCompany.set(key, []);
     byCompany.get(key).push(row);
   }

--- a/detect-reposts.test.mjs
+++ b/detect-reposts.test.mjs
@@ -17,7 +17,7 @@
  * Run: node detect-reposts.test.mjs
  */
 
-import { detectReposts, parseScanHistory } from './detect-reposts.mjs';
+import { detectReposts, parseScanHistory, companyKey } from './detect-reposts.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
 import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdtempSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
@@ -281,6 +281,42 @@ eq('company with trailing whitespace trimmed', detectReposts([
   row({ url: 'https://a.com/1', company: 'Acme ', title: 'Backend Engineer Platform' }),
   row({ url: 'https://a.com/2', company: ' Acme', date: d('2026-02-01'), dateStr: '2026-02-01' }),
 ]).length, 1);
+
+// ============================================================================
+// 4.5 companyKey + normalized-company clustering (#2093)
+// ============================================================================
+console.log('\n--- 4.5 companyKey / normalized-company (#2093) ---');
+
+// companyKey unit behavior
+eq('companyKey prefers the stored normCompany column', companyKey({ company: 'Ignored LLC', normCompany: 'acme' }), 'acme');
+eq('companyKey falls back to normalizing the raw company', companyKey({ company: 'Acme Inc.' }), 'acme');
+eq('companyKey "Acme, Inc." == "ACME Inc" (punctuation/case folded)', companyKey({ company: 'Acme, Inc.' }), companyKey({ company: 'ACME Inc' }));
+eq('companyKey "Acme Inc." == "Acme" (legal-suffix stripped)', companyKey({ company: 'Acme Inc.' }), companyKey({ company: 'Acme' }));
+eq('companyKey unicode-only name falls back to raw lowercase', companyKey({ company: 'Тинькофф' }), 'тинькофф');
+ok('companyKey keeps two distinct unicode-only names apart (no empty over-merge)', companyKey({ company: 'Тинькофф' }) !== companyKey({ company: 'Сбербанк' }));
+
+// (a) stored normalized column clusters "Acme Inc." + "Acme"
+eq('stored normCompany clusters "Acme Inc." + "Acme"', detectReposts([
+  row({ url: 'https://a.com/1', company: 'Acme Inc.', normCompany: 'acme', title: 'Backend Engineer Platform' }),
+  row({ url: 'https://a.com/2', company: 'Acme', normCompany: 'acme', date: d('2026-02-01'), dateStr: '2026-02-01' }),
+]).length, 1);
+
+// (b) backward compat: rows without the column cluster via raw-normalize fallback
+eq('fallback clusters "Acme Inc." + "Acme" with no stored column', detectReposts([
+  row({ url: 'https://a.com/1', company: 'Acme Inc.', title: 'Backend Engineer Platform' }),
+  row({ url: 'https://a.com/2', company: 'Acme', date: d('2026-02-01'), dateStr: '2026-02-01' }),
+]).length, 1);
+
+eq('fallback clusters "Acme, Inc." + "ACME Inc" (punctuation/case)', detectReposts([
+  row({ url: 'https://a.com/1', company: 'Acme, Inc.', title: 'Backend Engineer Platform' }),
+  row({ url: 'https://a.com/2', company: 'ACME Inc', date: d('2026-02-01'), dateStr: '2026-02-01' }),
+]).length, 1);
+
+// Distinct companies must NOT merge under normalization
+eq('distinct companies not merged by normalization', detectReposts([
+  row({ url: 'https://a.com/1', company: 'Acme Inc.', title: 'Backend Engineer Platform' }),
+  row({ url: 'https://b.com/2', company: 'Beta Corp', date: d('2026-02-01'), dateStr: '2026-02-01' }),
+]).length, 0);
 
 // ============================================================================
 // 5. detectReposts — title matching
@@ -645,6 +681,29 @@ try {
   // parseScanHistory produces rows with empty company, but detectReposts filters them out
   eq('TSV with empty company: rows parsed (2)', emptyCoParsed.length, 2);
   eq('TSV with empty company: no clusters (filtered by detectReposts)', detectReposts(emptyCoParsed, 90).length, 0);
+
+  // #2093 — normalized-company column: writer stores it (trailing col 12),
+  // parser prefers it as the clustering key so "Acme Inc." and "Acme" cluster.
+  const normTsv = [
+    'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\tfingerprint\tposted_at\ttrust_score\ttrust_flags\tnormalized_company',
+    'https://a.com/1\t2026-01-01\tgreenhouse\tBackend Engineer Platform\tAcme Inc.\tadded\tRemote\t\t\t\t\tacme',
+    'https://a.com/2\t2026-02-01\tgreenhouse\tBackend Engineer Platform\tAcme\tadded\tRemote\t\t\t\t\tacme',
+  ].join('\n');
+  const normParsed = parseScanHistory(normTsv);
+  eq('#2093: normalized_company (col 12) parsed into normCompany', normParsed[0]?.normCompany, 'acme');
+  eq('#2093: "Acme Inc." + "Acme" cluster via stored normalized column', detectReposts(normParsed, 90).length, 1);
+
+  // Backward compat: legacy 7-column rows lack the column. Clustering falls back
+  // to normalizing the raw company on the fly, so old and new rows still key the
+  // same and cluster together — nothing depends on the writer having run.
+  const legacyTsv = [
+    'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation',
+    'https://a.com/1\t2026-01-01\tgreenhouse\tBackend Engineer Platform\tAcme Inc.\tadded\tRemote',
+    'https://a.com/2\t2026-02-01\tgreenhouse\tBackend Engineer Platform\tAcme\tadded\tRemote',
+  ].join('\n');
+  const legacyParsed = parseScanHistory(legacyTsv);
+  eq('#2093 backward-compat: legacy rows carry empty normCompany', legacyParsed[0]?.normCompany, '');
+  eq('#2093 backward-compat: legacy "Acme Inc." + "Acme" still cluster (raw fallback)', detectReposts(legacyParsed, 90).length, 1);
 
   // Headerless 5-column TSV parsing test (Older scan-history and seed file backward compat)
   const headerlessTsv = [

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -411,6 +411,8 @@ Postings without a usable publish date are skipped — a reverse scan is only us
 
 `data/scan-history.tsv` carries a **SimHash fingerprint** of the JD text in its 8th column (`jd_fingerprint`), and the original posting date in its 9th column (`postedAt`). The fingerprint column exists to catch a specific double-submission hazard: the same role posted by the direct employer **and** by a recruitment agency, often with the employer name stripped from the agency listing. URL dedup and company+role dedup both miss this pair because the URLs and company names are different — but agencies rarely rewrite the requirements text, so a near-identical JD body is a reliable signal.
 
+The 12th column (`normalized_company`) stores the **canonical company key** — the raw company (col 5) run through the shared `normalizeCompanyName` (lowercased, punctuation/whitespace folded, trailing legal-entity suffixes stripped), so `Acme Inc.`, `Acme, Inc.` and `ACME  Inc` all resolve to `acme`. It is written at scan time so repost/name matching (`detect-reposts.mjs`) keys on a stable value instead of re-deriving it or routing a legitimacy signal through script execution. The column is **additive and trailing**: rows written before it existed simply omit it, and consumers normalize the raw company on the fly for those rows (backward-compatible). All columns beyond col 7 are append-only — index-based readers (including the web parser, which reads only cols 0-6) are unaffected.
+
 How it works:
 
 - When the ATS provider's list API returns a description field (e.g. Lever's `descriptionPlain`), the scanner computes a **64-bit SimHash** of the normalized text and stores it as the 8th column.

--- a/scan.mjs
+++ b/scan.mjs
@@ -1428,6 +1428,7 @@ export function appendToScanHistory(offers, date, status = 'added') {
   // backward-compatible. `status` is parameterized so callers can record verify
   // outcomes (`skipped_expired`, etc.) without the legacy `(expired)` suffix.
   if (!existsSync(SCAN_HISTORY_PATH)) {
+    mkdirSync(path.dirname(SCAN_HISTORY_PATH), { recursive: true });
     writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\tfingerprint\tposted_at\ttrust_score\ttrust_flags\tnormalized_company\n', 'utf-8');
   }
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -44,6 +44,7 @@ import { classifyFetchError } from './verify-portals.mjs';
 import { fingerprintText, findCrossListings } from './fingerprint-core.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
+import { normalizeCompanyName } from './invite-match.mjs';
 import { withPipelineLock } from './pipeline-lock.mjs';
 
 try {
@@ -1316,6 +1317,17 @@ export function formatScanHistoryRow(offer, date, status = 'added') {
     // posting or a scan without trust_filter leaves both empty.
     trustIsFlagged(offer) ? String(offer.trustScore) : '',
     trustIsFlagged(offer) ? trustFlagList(offer).join(',') : '',
+    // Normalized company key (#2093): the canonical company form shared across
+    // the tracker (normalizeCompanyName — lowercased, punctuation/whitespace
+    // folded, trailing legal-entity suffixes stripped) so "Acme Inc.",
+    // "Acme, Inc." and "ACME  Inc" all key to `acme`. Stored at write time so
+    // repost/name-matching never has to route through executing a script, and
+    // the raw display company in col 5 stays faithful to what the provider
+    // returned. Trailing col 12 — purely additive: index-based readers
+    // (fingerprint@7, postedAt@8, trust@9-10, and the web parser's first 7
+    // cols) are unaffected, and older rows that lack it are tolerated by
+    // consumers normalizing the raw name on the fly.
+    normalizeCompanyName(offer.company || ''),
   ].map(sanitizeTsvField).join('\t');
 }
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -1343,6 +1343,11 @@ export function loadFingerprintHistory(historyPath = SCAN_HISTORY_PATH) {
   const rows = [];
   for (const line of readFileSync(historyPath, 'utf-8').split('\n')) {
     const cols = line.split('\t');
+    // Skip the header row. Older 7-col headers fall out of the `cols.length < 8`
+    // guard below on their own, but the 12-col header names col 7 `fingerprint`
+    // (non-empty), so it would otherwise pass that guard and be read as data.
+    // Real rows always carry a URL in col 0, never the literal `url`.
+    if (cols[0] === 'url') continue;
     if (cols.length < 8 || !cols[7].trim()) continue;
     rows.push({
       url: (cols[0] || '').trim(),
@@ -1412,13 +1417,18 @@ export async function appendToPipeline(offers) {
 }
 
 export function appendToScanHistory(offers, date, status = 'added') {
-  // Ensure file + header exist. Location appended as 7th column for non-breaking
-  // backward compat — older scan-history.tsv files with 6 columns still parse fine
-  // since loadSeenUrls only reads column 0. `status` is parameterized so callers
-  // can record verify outcomes (`skipped_expired`, etc.) without the legacy
-  // `(expired)` suffix in `source`.
+  // Ensure file + header exist. The header names every column the row writer
+  // (formatScanHistoryRow) emits, in the same order: the original 7 positional
+  // cols (url…location) plus the append-only trailing cols added since —
+  // fingerprint (7), posted_at (8), trust_score (9), trust_flags (10),
+  // normalized_company (11). Written ONLY on fresh-file creation; existing files
+  // (including headerless legacy files and older 7-col-header files) are never
+  // rewritten. All readers either skip line 0 unconditionally, detect the header
+  // by its `url\t` prefix, or skip non-URL col-0 rows, so widening it stays
+  // backward-compatible. `status` is parameterized so callers can record verify
+  // outcomes (`skipped_expired`, etc.) without the legacy `(expired)` suffix.
   if (!existsSync(SCAN_HISTORY_PATH)) {
-    writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\n', 'utf-8');
+    writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\tfingerprint\tposted_at\ttrust_score\ttrust_flags\tnormalized_company\n', 'utf-8');
   }
 
   const lines = offers.map(o => formatScanHistoryRow(o, date, status)).join('\n') + '\n';

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4628,7 +4628,7 @@ try {
   const historyRow = formatScanHistoryRow(hostileOffer, '2026-06-18');
   const historyColumns = historyRow.split('\t');
   if (
-    historyColumns.length === 11 && // 7 metadata + fingerprint (#1597) + postedAt + trust score/flags (#1743)
+    historyColumns.length === 12 && // 7 metadata + fingerprint (#1597) + postedAt + trust score/flags (#1743) + normalized_company (#2093)
     historyColumns[8] === '' && // no postedAt on hostileOffer → empty trailing col
     historyColumns[9] === '' && historyColumns[10] === '' && // no trust signal → empty trailing cols
     !historyColumns.some(col => /[\r\n\t]/.test(col)) &&
@@ -4659,10 +4659,12 @@ try {
   const datedHistory = formatScanHistoryRow(datedOffer, '2026-07-09').split('\t');
   const noDateHistory = formatScanHistoryRow({ ...datedOffer, postedAt: undefined }, '2026-07-09').split('\t');
   if (
-    datedHistory.length === 11 &&
+    datedHistory.length === 12 &&
     datedHistory[8] === '2026-06-18' && // epoch ms → YYYY-MM-DD in the trailing column
-    noDateHistory.length === 11 &&
-    noDateHistory[8] === '' // missing postedAt → empty trailing column, never a bogus date
+    datedHistory[11] === 'acme' && // normalized company key (#2093), trailing col 12
+    noDateHistory.length === 12 &&
+    noDateHistory[8] === '' && // missing postedAt → empty trailing column, never a bogus date
+    noDateHistory[11] === 'acme'
   ) {
     pass('scan-history writer appends postedAt as an ISO trailing column (empty when absent)');
   } else {
@@ -4696,9 +4698,10 @@ try {
   const flaggedHist = formatScanHistoryRow(flaggedOffer, '2026-07-09').split('\t');
   const cleanHist = formatScanHistoryRow(cleanOffer, '2026-07-09').split('\t');
   if (
-    flaggedHist.length === 11 &&
+    flaggedHist.length === 12 &&
     flaggedHist[9] === '60' && flaggedHist[10] === 'missing_apply_url,suspicious_domain' &&
-    cleanHist.length === 11 && cleanHist[9] === '' && cleanHist[10] === '' // score 100 → not flagged → empty
+    flaggedHist[11] === 'acme' && // normalized company key (#2093), after the trust cols
+    cleanHist.length === 12 && cleanHist[9] === '' && cleanHist[10] === '' // score 100 → not flagged → empty
   ) {
     pass('scan-history writer appends trust score + flags trailing columns when flagged, empty otherwise (#1743)');
   } else {
@@ -9672,7 +9675,7 @@ try {
     '2026-07-06',
   );
   const cols = withBody.split('\t');
-  if (cols.length === 11 && /^[0-9a-f]{16}$/.test(cols[7])) {
+  if (cols.length === 12 && /^[0-9a-f]{16}$/.test(cols[7]) && cols[11] === 'acme') {
     pass('formatScanHistoryRow appends a fingerprint column for described offers');
   } else {
     fail(`formatScanHistoryRow columns: ${cols.length}, fingerprint=${JSON.stringify(cols[7])}`);
@@ -9682,7 +9685,7 @@ try {
     '2026-07-06',
   );
   const cols2 = withoutBody.split('\t');
-  if (cols2.length === 11 && cols2[7] === '') {
+  if (cols2.length === 12 && cols2[7] === '' && cols2[11] === 'acme') {
     pass('formatScanHistoryRow leaves the fingerprint empty when no description is available');
   } else {
     fail(`formatScanHistoryRow (no body) columns: ${cols2.length}, last=${JSON.stringify(cols2[7])}`);


### PR DESCRIPTION
## Agreed follow-up to #1712

This is the agreed follow-up from #1712. In that PR the maintainer held back the hunk that routed the "Reposting pattern" legitimacy signal through **executing** `company-history.mjs`, because execution fails to silent-absence. The diagnosis: the real problem isn't a *source* gap, it's a **data** gap — `scan-history.tsv` stores the raw company string with no normalized key, so `Acme Inc.` and `Acme` are treated as two companies. Fix it **in the file** with an additive column, and the mode, web, and `detect-reposts` all benefit with nothing depending on a script having run.

> "A normalized company column is additive, so it doesn't break the scan-history contract the web parses."

## What changes

- **Writer (`scan.mjs`)** — `formatScanHistoryRow` appends a trailing **`normalized_company`** column (col 12), populated at write time via the existing exported `normalizeCompanyName` (lowercase, punctuation/whitespace folded, trailing legal-entity suffixes stripped) so `Acme Inc.`, `Acme, Inc.` and `ACME  Inc` all key to `acme`. The raw display company (col 5) stays faithful to what the provider returned. No new normalizer was written — this reuses the one already shared across the tracker.
- **Consumer (`detect-reposts.mjs`)** — clustering now keys on a new `companyKey(row)` that **prefers the stored column** and **falls back to normalizing the raw company on the fly** for pre-existing rows that lack it (and for row objects built directly in tests). A final fallback to the raw lowercased name preserves today's behavior for names that fold to empty (all-CJK / all-Cyrillic), so those never over-cluster under a single empty key. This is what makes `Acme Inc.` and `Acme` a single repost cluster instead of two.
- **Docs** — `DATA_CONTRACT.md` and `docs/SCRIPTS.md` describe the new trailing column and the append-only column contract.

The `modes/*` legitimacy tables are intentionally untouched — this PR is purely the data-layer fix. The mode keeps reading the file as before, now with a better key available.

## Backward compatibility

- **Additive / trailing.** The column is appended after the existing fingerprint (col 8), postedAt (col 9) and trust (cols 10-11) columns. No existing column is reordered.
- **Web parser unaffected.** Every `scan-history.tsv` reader in `web/` (`readScanDates`, `discover`, `whats-new`, explore/add) splits by `\t` and indexes only cols 0-6, so a trailing column is invisible to them (verified). The core readers (`loadSeenUrls`, `loadFingerprintHistory`, `parseScanHistory`) are likewise index-based.
- **Old rows tolerated.** Rows written before this column simply have fewer fields; `companyKey` normalizes their raw company on the fly, so old and new rows key identically and cluster together — nothing depends on the writer having run.

## Notes for review

- Two normalizers exist: `normalizeCompany` (tracker-utils, alphanumeric-only — would leave `acmeinc` ≠ `acme`) and `normalizeCompanyName` (`invite-match.mjs`, legal-suffix aware). Only the latter delivers the maintainer's stated example (`Acme Inc.` == `Acme`), so it is the correct canonical reuse. If you'd prefer that function to live in a neutral shared module rather than `invite-match.mjs`, that's a trivial relocation follow-up.

## Validation

- `node detect-reposts.mjs --self-test` → 8 passed, 0 failed
- `node detect-reposts.test.mjs` → 213 passed, 0 failed (new: `companyKey` unit cases, stored-column clustering, raw-normalize fallback, backward-compat legacy rows)
- `node test-all.mjs` → **2281 passed, 0 failed**, 2 warnings (benign env: cv-sync-check without user data / CV section order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a trailing `normalized_company` field to scan history records for more consistent company matching and repost clustering, including support for older files missing it.
  - When creating a new scan history file, the widened header now includes the new column.
- **Bug Fixes**
  - Improved fingerprint history loading by ignoring the header row when present.
- **Documentation**
  - Updated the scan-history data contract and script documentation to describe the append-only, trailing-column format.
- **Tests**
  - Expanded scan-history and repost-detection tests to cover the 12-column format and normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->