### PR TITLE
docs: add verified OpenCode recipe for Kimi K2.5

### DIFF
--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -95,6 +95,84 @@ When choosing a budget-friendly model, you need strong reasoning capabilities to
 | **Qwen-2.5-Coder (32B / 72B)** | OpenRouter / DeepInfra | ~$0.07 - ~$0.30 | Strong coding and structured reasoning, highly cost-effective. |
 | **GLM-4-Air / GLM-4** | Zhipu AI / OpenRouter | Very Cheap | Reliable multi-turn reasoning and JSON/Markdown generation. |
 | **Gemini 2.5 Flash** | Google AI Studio | Free Tier (15 RPM) | Available via the standalone script `node gemini-eval.mjs`. Excellent for zero-cost low-volume runs, but subject to rate limits. |
+| **Kimi K2.5** | Moonshot AI | API pricing applies | Verified with OpenCode using the Moonshot OpenAI-compatible endpoint. Produces structured Markdown suitable for Career-Ops evaluations. See the verified OpenCode recipe below. |
+
+## 5. Verified OpenCode Recipe: Kimi K2.5 (Moonshot AI)
+
+The following configuration was verified with Career-Ops using OpenCode and Moonshot AI's OpenAI-compatible API.
+
+### opencode.json
+
+```json
+{
+  "$schema": "[https://opencode.ai/config.json](https://opencode.ai/config.json)",
+  "provider": {
+    "moonshot": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Moonshot Kimi",
+      "options": {
+        "baseURL": "[https://api.moonshot.ai/v1](https://api.moonshot.ai/v1)",
+        "apiKey": "{env:MOONSHOT_API_KEY}"
+      },
+      "models": {
+        "kimi-k2.5": {
+          "name": "Kimi K2.5"
+        }
+      }
+    }
+  },
+  "model": "moonshot/kimi-k2.5"
+}
+
+```
+
+### Environment Variable
+
+**Linux / macOS**
+
+```bash
+export MOONSHOT_API_KEY="your_api_key"
+
+```
+
+**Windows PowerShell**
+
+```powershell
+$env:MOONSHOT_API_KEY="your_api_key"
+
+```
+
+**Windows CMD**
+
+```cmd
+set MOONSHOT_API_KEY=your_api_key
+
+```
+
+### Verification
+
+The configuration was verified by running a complete Career-Ops evaluation pipeline.
+
+Observed during verification:
+
+* Evaluation completed successfully.
+* Markdown evaluation report was generated successfully.
+* Applications tracker was updated successfully.
+* No malformed structured output was observed during this verification run.
+* PDF generation was skipped because Playwright MCP was not configured in the local environment.
+
+**Notes:**
+
+* The measured runtime reflects the complete Career-Ops pipeline (job retrieval, prompt loading, report generation, and tracker updates) rather than raw model inference latency.
+* Kimi K2.5 worked correctly with the OpenAI-compatible Moonshot endpoint during verification.
+
+### Comparison
+
+| Option | Cost | Notes |
+| --- | --- | --- |
+| **OpenRouter `:free**` | Free tier | Easy setup. Subject to model availability and rate limits. |
+| **Kimi K2.5** | Moonshot API | Verified working with OpenCode using the OpenAI-compatible endpoint. |
+| **Ollama** | Local | No API cost, but requires suitable local hardware and recommended larger models for reliable evaluations. |
 
 > **Standalone evaluator (no CLI config needed):** every OpenAI-compatible provider above (DeepSeek, Qwen, GLM, Together, Groq, OpenRouter, …) works directly through `node openai-eval.mjs` — just set a base URL, model, and key:
 > ```bash
@@ -107,7 +185,7 @@ When choosing a budget-friendly model, you need strong reasoning capabilities to
 
 > NVIDIA NIM also works (hosted `https://integrate.api.nvidia.com/v1` or a self-hosted container's `/v1`), e.g. `--model meta/llama-3.3-70b-instruct`. The hosted free tier can queue for minutes, so raise `OPENAI_TIMEOUT_MS` above the 300s default.
 
-## 5. Local LLM Tradeoffs (Ollama / Llama.cpp)
+## 6. Local LLM Tradeoffs (Ollama / Llama.cpp)
 
 Running a model 100% locally via Ollama is completely free, but it comes with significant tradeoffs:
 
@@ -124,7 +202,7 @@ Running 32B or 70B models locally requires substantial system resources:
 
 ---
 
-## 6. Token-Saving Best Practices
+## 7. Token-Saving Best Practices
 
 To prevent unnecessary API costs or hitting rate limits, implement the following practices:
 
@@ -151,7 +229,7 @@ To prevent unnecessary API costs or hitting rate limits, implement the following
 
 ---
 
-## 7. Worked Example: Running the Pipeline Cheaply
+## 8. Worked Example: Running the Pipeline Cheaply
 
 Here is a concrete, end-to-end walkthrough of scanning for jobs and evaluating a single posting using **DeepSeek V3 via OpenRouter** and the standalone `openai-eval.mjs` evaluator. This bypasses the need for an expensive CLI agent for the heavy evaluation block.
 
@@ -211,7 +289,7 @@ By routing the heaviest step (Evaluation) to a cheap OpenAI-compatible endpoint,
 
 ---
 
-## 8. Zero-Cost Paths (No Claude / Paid CLI Required)
+## 9. Zero-Cost Paths (No Claude / Paid CLI Required)
 
 Career-ops ships a full pipeline that runs **entirely on free models** — no Claude Code, no Anthropic API key, no paid CLI subscription. Everything below works out of the box after a one-time `.env` setup.
 

--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -65,6 +65,78 @@ To configure OpenCode with a custom provider:
    $env:OPENAI_API_BASE="https://openrouter.ai/api/v1"
    $env:OPENAI_API_KEY="your_openrouter_api_key_here"
    ```
+### Kimi K2.5 via OpenCode (Verified)
+
+The following configuration was verified with Career-Ops using OpenCode and Moonshot AI's OpenAI-compatible API.
+
+#### opencode.json
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "moonshot": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Moonshot Kimi",
+      "options": {
+        "baseURL": "https://api.moonshot.ai/v1",
+        "apiKey": "{env:MOONSHOT_API_KEY}"
+      },
+      "models": {
+        "kimi-k2.5": {
+          "name": "Kimi K2.5"
+        }
+      }
+    }
+  },
+  "model": "moonshot/kimi-k2.5"
+}
+```
+
+#### Environment variable
+
+Linux/macOS
+
+```bash
+export MOONSHOT_API_KEY="your_api_key"
+```
+
+Windows PowerShell
+
+```powershell
+$env:MOONSHOT_API_KEY="your_api_key"
+```
+
+Windows CMD
+
+```cmd
+set MOONSHOT_API_KEY=your_api_key
+```
+
+#### Verification
+
+This configuration was verified locally by running a complete Career-Ops evaluation.
+
+Observed during verification:
+
+- Evaluation completed successfully.
+- Markdown evaluation report was generated successfully.
+- Applications tracker was updated successfully.
+- No malformed structured output was observed during this verification run.
+- PDF generation was skipped because Playwright MCP was not configured in the local environment.
+
+#### Notes
+
+- The measured runtime reflects the complete Career-Ops pipeline (job retrieval, prompt loading, report generation, and tracker updates), not raw model inference latency.
+- Kimi K2.5 worked correctly with the Moonshot OpenAI-compatible endpoint during verification.
+
+#### Comparison
+
+| Option | Cost | Notes |
+|---------|------|------|
+| OpenRouter `:free` | Free tier | Easy setup. Subject to model availability and rate limits. |
+| Kimi K2.5 | Moonshot API | Verified working with OpenCode using the Moonshot OpenAI-compatible endpoint. |
+| Ollama | Local | No API cost, but requires suitable local hardware and larger recommended models for reliable evaluations. |
 
 ### Qwen CLI
 Qwen CLI natively supports Qwen models but can be configured to point to any custom OpenAI-compatible API base URL:
@@ -97,82 +169,6 @@ When choosing a budget-friendly model, you need strong reasoning capabilities to
 | **Gemini 2.5 Flash** | Google AI Studio | Free Tier (15 RPM) | Available via the standalone script `node gemini-eval.mjs`. Excellent for zero-cost low-volume runs, but subject to rate limits. |
 | **Kimi K2.5** | Moonshot AI | API pricing applies | Verified with OpenCode using the Moonshot OpenAI-compatible endpoint. Produces structured Markdown suitable for Career-Ops evaluations. See the verified OpenCode recipe below. |
 
-## 5. Verified OpenCode Recipe: Kimi K2.5 (Moonshot AI)
-
-The following configuration was verified with Career-Ops using OpenCode and Moonshot AI's OpenAI-compatible API.
-
-### opencode.json
-
-```json
-{
-  "$schema": "[https://opencode.ai/config.json](https://opencode.ai/config.json)",
-  "provider": {
-    "moonshot": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "Moonshot Kimi",
-      "options": {
-        "baseURL": "[https://api.moonshot.ai/v1](https://api.moonshot.ai/v1)",
-        "apiKey": "{env:MOONSHOT_API_KEY}"
-      },
-      "models": {
-        "kimi-k2.5": {
-          "name": "Kimi K2.5"
-        }
-      }
-    }
-  },
-  "model": "moonshot/kimi-k2.5"
-}
-
-```
-
-### Environment Variable
-
-**Linux / macOS**
-
-```bash
-export MOONSHOT_API_KEY="your_api_key"
-
-```
-
-**Windows PowerShell**
-
-```powershell
-$env:MOONSHOT_API_KEY="your_api_key"
-
-```
-
-**Windows CMD**
-
-```cmd
-set MOONSHOT_API_KEY=your_api_key
-
-```
-
-### Verification
-
-The configuration was verified by running a complete Career-Ops evaluation pipeline.
-
-Observed during verification:
-
-* Evaluation completed successfully.
-* Markdown evaluation report was generated successfully.
-* Applications tracker was updated successfully.
-* No malformed structured output was observed during this verification run.
-* PDF generation was skipped because Playwright MCP was not configured in the local environment.
-
-**Notes:**
-
-* The measured runtime reflects the complete Career-Ops pipeline (job retrieval, prompt loading, report generation, and tracker updates) rather than raw model inference latency.
-* Kimi K2.5 worked correctly with the OpenAI-compatible Moonshot endpoint during verification.
-
-### Comparison
-
-| Option | Cost | Notes |
-| --- | --- | --- |
-| **OpenRouter `:free**` | Free tier | Easy setup. Subject to model availability and rate limits. |
-| **Kimi K2.5** | Moonshot API | Verified working with OpenCode using the OpenAI-compatible endpoint. |
-| **Ollama** | Local | No API cost, but requires suitable local hardware and recommended larger models for reliable evaluations. |
 
 > **Standalone evaluator (no CLI config needed):** every OpenAI-compatible provider above (DeepSeek, Qwen, GLM, Together, Groq, OpenRouter, …) works directly through `node openai-eval.mjs` — just set a base URL, model, and key:
 > ```bash
@@ -185,7 +181,7 @@ Observed during verification:
 
 > NVIDIA NIM also works (hosted `https://integrate.api.nvidia.com/v1` or a self-hosted container's `/v1`), e.g. `--model meta/llama-3.3-70b-instruct`. The hosted free tier can queue for minutes, so raise `OPENAI_TIMEOUT_MS` above the 300s default.
 
-## 6. Local LLM Tradeoffs (Ollama / Llama.cpp)
+## 5. Local LLM Tradeoffs (Ollama / Llama.cpp)
 
 Running a model 100% locally via Ollama is completely free, but it comes with significant tradeoffs:
 
@@ -202,7 +198,7 @@ Running 32B or 70B models locally requires substantial system resources:
 
 ---
 
-## 7. Token-Saving Best Practices
+## 6. Token-Saving Best Practices
 
 To prevent unnecessary API costs or hitting rate limits, implement the following practices:
 
@@ -229,7 +225,7 @@ To prevent unnecessary API costs or hitting rate limits, implement the following
 
 ---
 
-## 8. Worked Example: Running the Pipeline Cheaply
+## 7. Worked Example: Running the Pipeline Cheaply
 
 Here is a concrete, end-to-end walkthrough of scanning for jobs and evaluating a single posting using **DeepSeek V3 via OpenRouter** and the standalone `openai-eval.mjs` evaluator. This bypasses the need for an expensive CLI agent for the heavy evaluation block.
 
@@ -289,7 +285,7 @@ By routing the heaviest step (Evaluation) to a cheap OpenAI-compatible endpoint,
 
 ---
 
-## 9. Zero-Cost Paths (No Claude / Paid CLI Required)
+## 8. Zero-Cost Paths (No Claude / Paid CLI Required)
 
 Career-ops ships a full pipeline that runs **entirely on free models** — no Claude Code, no Anthropic API key, no paid CLI subscription. Everything below works out of the box after a one-time `.env` setup.
 


### PR DESCRIPTION
## Summary

This PR adds a verified OpenCode configuration recipe for Moonshot AI Kimi K2.5 to the budget guide.

### Changes

- Added a verified OpenCode configuration example for Moonshot AI Kimi K2.5
- Documented required environment variables
- Added a verified pipeline section
- Added observations from a successful verification run
- Added a qualitative comparison with OpenRouter `:free` and Ollama
- Added a cross-reference from the recommended models table

## Verification

I verified the configuration locally by running an end-to-end Career-Ops evaluation using OpenCode configured with Kimi K2.5.

Verification completed successfully:

- ✅ Evaluation completed
- ✅ Report generated
- ✅ Applications tracker updated
- ✅ No malformed structured output observed during this verification run

## Screenshots
<img width="710" height="611" alt="image" src="https://github.com/user-attachments/assets/19c8d7a2-f05c-4f7e-b8ed-890e7bca728c" />
<img width="722" height="341" alt="image" src="https://github.com/user-attachments/assets/d4ab74a3-f962-4ae5-bc86-a6bb57c29471" />
<img width="599" height="657" alt="image" src="https://github.com/user-attachments/assets/6c22c4c9-4fd9-4095-a8e9-1ad08c9e81ac" />
<img width="721" height="218" alt="image" src="https://github.com/user-attachments/assets/b15c41b6-8691-4d8a-a665-f309a79a7cbc" />



## Notes

The measured runtime reflects the complete Career-Ops pipeline (job retrieval, prompt loading, report generation, and tracker updates) rather than raw model inference latency.

Fixes #1980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Kimi K2.5 to the recommended cost-efficient models, including notes about Moonshot API pricing.
  * Added a verified OpenCode setup guide for Moonshot access, with an `opencode.json` example, OS-specific environment variable instructions, and a success checklist.
  * Included a comparison table for cost/usage options and updated section numbering across the budget guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->