### PR TITLE
docs(fr): remove stale gemini auth step from README.fr.md

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -147,15 +147,13 @@ career-ops prend en charge [Gemini CLI](https://github.com/google-gemini/gemini-
 # 1. Installez Gemini CLI
 npm install -g @google/gemini-cli
 # ou : npx @google/gemini-cli --version
+#    L'authentification se fait via votre compte Google (gratuit) au premier lancement
 
-# 2. Authentifiez-vous (gratuit, utilise votre compte Google)
-gemini auth
-
-# 3. Exécutez dans le dossier career-ops
+# 2. Exécutez dans le dossier career-ops
 cd career-ops
 gemini
 
-# 4. Utilisez la commande unifiée /career-ops avec ses sous-commandes :
+# 3. Utilisez la commande unifiée /career-ops avec ses sous-commandes :
 /career-ops "Senior AI Engineer at Anthropic..."
 /career-ops pipeline
 /career-ops scan


### PR DESCRIPTION
Closes #2215

README.fr.md still documented a `gemini auth` step that doesn't exist — Gemini CLI authenticates via Google account automatically on first run. Mirrors the fix already applied to README.md (#936) and README.ar.md (#2205): dropped the step, folded a one-line note into the install step, and renumbered the remaining steps.

Verified: `grep -n "gemini auth" README*.md` returns nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Gemini CLI quick-start instructions to clarify that Google authentication occurs on first launch.
  * Removed the separate authentication command and renumbered the setup steps.
  * Preserved the unified `/career-ops ...` usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->