### PR TITLE
fix(web): propagate the Hired terminal-success state across the whole dashboard

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9536,6 +9536,29 @@ try {
     } else {
       fail(`web status list(s) missing canonical state(s) — dashboard can't set/count them (#2249): ${drift.join(' | ')}`);
     }
+
+    // The assistant preamble also enumerates the states in PROSE (the setStatus
+    // list + the filterPipeline tab enum). Those drift the same way — the AI
+    // couldn't offer to set/filter by Hired — so check them too (#2249).
+    const assistantPath = join(ROOT, 'web', 'src', 'app', 'api', 'assistant', 'route.ts');
+    if (existsSync(assistantPath)) {
+      const src = readFileSync(assistantPath, 'utf-8');
+      const proseChecks = [
+        { name: 'setStatus canonical-states list', text: src.match(/Canonical states:\s*([^.]*)\./)?.[1] ?? '', upper: false },
+        { name: 'filterPipeline tab enum', text: src.match(/tab ∈\s*([^;]*);/)?.[1] ?? '', upper: true },
+      ];
+      const proseDrift = [];
+      for (const { name, text, upper } of proseChecks) {
+        const want = upper ? stateLabels.map((l) => l.toUpperCase()) : stateLabels;
+        const missing = want.filter((l) => !new RegExp(`\\b${l}\\b`).test(text));
+        if (missing.length) proseDrift.push(`${name} (${missing.join(', ')})`);
+      }
+      if (proseDrift.length === 0) {
+        pass('assistant preamble prose enumerates every canonical state (#2249)');
+      } else {
+        fail(`assistant preamble missing canonical state(s) in prose (#2249): ${proseDrift.join(' | ')}`);
+      }
+    }
   }
 
   // 55.4 report format blocks (modes/oferta.md → web report parser)

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9505,6 +9505,25 @@ try {
     fail(`templates/states.yml lost canonical status id(s): ${missingStates.join(', ')} — BREAKING for the web status mapping`);
   }
 
+  // 55.3b The web status dropdown must offer EVERY canonical state. states.yml is
+  // the source of truth; web/src/lib/format.ts's CANONICAL_STATES is the single
+  // list the status-select dropdown + its known-check read. `Hired` (#2050)
+  // silently drifted out of the web list — a landed job couldn't be recorded and
+  // rendered as a gray "unknown" dot (#2249). Keep the two in lockstep.
+  const formatPath = join(ROOT, 'web', 'src', 'lib', 'format.ts');
+  if (existsSync(formatPath)) {
+    const stateLabels = [...statesSrc.matchAll(/^\s+label:\s*"?([A-Za-z]+)"?\s*$/gm)].map((m) => m[1]);
+    const formatSrc = readFileSync(formatPath, 'utf-8');
+    const webBlock = formatSrc.match(/CANONICAL_STATES\s*=\s*\[([\s\S]*?)\]/)?.[1] ?? '';
+    const webStates = new Set([...webBlock.matchAll(/"([A-Za-z]+)"/g)].map((m) => m[1]));
+    const webMissing = stateLabels.filter((l) => !webStates.has(l));
+    if (stateLabels.length > 0 && webMissing.length === 0) {
+      pass('web CANONICAL_STATES covers every canonical state label from states.yml (#2249)');
+    } else {
+      fail(`web/src/lib/format.ts CANONICAL_STATES is missing canonical state(s): ${webMissing.join(', ')} — the web dashboard can't set or recognize them (#2249)`);
+    }
+  }
+
   // 55.4 report format blocks (modes/oferta.md → web report parser)
   const ofertaSrc = readFileSync(join(ROOT, 'modes', 'oferta.md'), 'utf-8');
   const REPORT_BLOCKS = ['Block A', 'Block B', 'Block C', 'Block D', 'Block E', 'Block F', 'Block G'];

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9505,22 +9505,36 @@ try {
     fail(`templates/states.yml lost canonical status id(s): ${missingStates.join(', ')} — BREAKING for the web status mapping`);
   }
 
-  // 55.3b The web status dropdown must offer EVERY canonical state. states.yml is
-  // the source of truth; web/src/lib/format.ts's CANONICAL_STATES is the single
-  // list the status-select dropdown + its known-check read. `Hired` (#2050)
-  // silently drifted out of the web list — a landed job couldn't be recorded and
-  // rendered as a gray "unknown" dot (#2249). Keep the two in lockstep.
-  const formatPath = join(ROOT, 'web', 'src', 'lib', 'format.ts');
-  if (existsSync(formatPath)) {
-    const stateLabels = [...statesSrc.matchAll(/^\s+label:\s*"?([A-Za-z]+)"?\s*$/gm)].map((m) => m[1]);
-    const formatSrc = readFileSync(formatPath, 'utf-8');
-    const webBlock = formatSrc.match(/CANONICAL_STATES\s*=\s*\[([\s\S]*?)\]/)?.[1] ?? '';
-    const webStates = new Set([...webBlock.matchAll(/"([A-Za-z]+)"/g)].map((m) => m[1]));
-    const webMissing = stateLabels.filter((l) => !webStates.has(l));
-    if (stateLabels.length > 0 && webMissing.length === 0) {
-      pass('web CANONICAL_STATES covers every canonical state label from states.yml (#2249)');
+  // 55.3b Every web status list must carry every canonical state. states.yml is
+  // the source of truth; the web keeps SIX hardcoded copies (title-case canonical
+  // lists + UPPERCASE tab/stage lists). `Hired` (#2050) had silently drifted out
+  // of ALL of them — a landed job was unsettable, uncounted in the funnel, and a
+  // gray "unknown" dot (#2249). Cross-check each so a future core state can't
+  // vanish from the dashboard again. The analytics funnel intentionally omits
+  // SKIP (not a funnel stage), so it's excluded there.
+  const stateLabels = [...statesSrc.matchAll(/^\s+label:\s*"?([A-Za-z]+)"?\s*$/gm)].map((m) => m[1]);
+  const webStatusLists = [
+    { file: 'web/src/lib/format.ts', re: /CANONICAL_STATES\s*=\s*\[([\s\S]*?)\]/, upper: false, exclude: [] },
+    { file: 'web/src/app/actions/registry.ts', re: /CANON_STATUS\s*=\s*\[([\s\S]*?)\]/, upper: false, exclude: [] },
+    { file: 'web/src/app/actions/registry.ts', re: /TAB_VALUES\s*=\s*\[([\s\S]*?)\]/, upper: true, exclude: [] },
+    { file: 'web/src/components/pipeline-view.tsx', re: /TABS\s*=\s*\[([\s\S]*?)\]/, upper: true, exclude: [] },
+    { file: 'web/src/app/analytics/page.tsx', re: /STAGES[^=]*=\s*\[([\s\S]*?)\];/, upper: true, exclude: ['SKIP'] },
+  ];
+  if (stateLabels.length > 0) {
+    const drift = [];
+    for (const { file, re, upper, exclude } of webStatusLists) {
+      const p = join(ROOT, file);
+      if (!existsSync(p)) continue;
+      const block = readFileSync(p, 'utf-8').match(re)?.[1] ?? '';
+      const present = new Set([...block.matchAll(/"([A-Za-z]+)"/g)].map((m) => m[1]));
+      const want = (upper ? stateLabels.map((l) => l.toUpperCase()) : stateLabels).filter((l) => !exclude.includes(l));
+      const missing = want.filter((l) => !present.has(l));
+      if (missing.length) drift.push(`${file} (${missing.join(', ')})`);
+    }
+    if (drift.length === 0) {
+      pass('every web status list covers all canonical states from states.yml (#2249)');
     } else {
-      fail(`web/src/lib/format.ts CANONICAL_STATES is missing canonical state(s): ${webMissing.join(', ')} — the web dashboard can't set or recognize them (#2249)`);
+      fail(`web status list(s) missing canonical state(s) — dashboard can't set/count them (#2249): ${drift.join(' | ')}`);
     }
   }
 

--- a/web/src/app/actions/registry.ts
+++ b/web/src/app/actions/registry.ts
@@ -15,10 +15,10 @@ export const AUTO_FIRE_MAX = 3; // fire ≤3 evaluations silently; confirm above
 export const BATCH_CAP = 12; // hard ceiling on a single fan-out
 
 // Canonical states (templates/states.yml) — the web validates against the same set.
-const CANON_STATUS = ["Evaluated", "Applied", "Responded", "Interview", "Offer", "Rejected", "Discarded", "SKIP"];
+const CANON_STATUS = ["Evaluated", "Applied", "Responded", "Interview", "Offer", "Hired", "Rejected", "Discarded", "SKIP"];
 
 const TAB_VALUES = [
-  "INBOX", "ALL", "EVALUATED", "APPLIED", "RESPONDED", "INTERVIEW", "OFFER", "REJECTED", "DISCARDED", "SKIP",
+  "INBOX", "ALL", "EVALUATED", "APPLIED", "RESPONDED", "INTERVIEW", "OFFER", "HIRED", "REJECTED", "DISCARDED", "SKIP",
 ] as const;
 const SORT_VALUES = ["company", "role", "score", "status", "date"] as const;
 

--- a/web/src/app/analytics/page.tsx
+++ b/web/src/app/analytics/page.tsx
@@ -10,6 +10,7 @@ const STAGES: { key: string; label: string }[] = [
   { key: "RESPONDED", label: "Responded" },
   { key: "INTERVIEW", label: "Interview" },
   { key: "OFFER", label: "Offer" },
+  { key: "HIRED", label: "Hired" },
   { key: "REJECTED", label: "Rejected" },
   { key: "DISCARDED", label: "Discarded" },
 ];

--- a/web/src/app/api/assistant/route.ts
+++ b/web/src/app/api/assistant/route.ts
@@ -23,7 +23,7 @@ ACTIONS:
 - evaluateCompany {"company":"Anthropic"} — evaluate ALL of the user's PENDING inbox postings for that company. Emit the COMPANY NAME ONLY — never URLs; the app resolves the concrete postings itself. Big batches ask the user to confirm first.
 - research {"target":"https://… or 'my portfolio'","title":"Research · X"} — spin a read-only research worker.
 - generatePdf {"n":"42"} — generate an ATS-optimized CV tailored to application #42 (runs the real pdf mode → output/ + marks the tracker PDF column). Spends tokens.
-- setStatus {"n":"42","status":"Applied"} — move a tracked application to a new state (asks the user to confirm first). Canonical states: Evaluated, Applied, Responded, Interview, Offer, Rejected, Discarded, SKIP. Use the application number (the "#42" on its report page).
+- setStatus {"n":"42","status":"Applied"} — move a tracked application to a new state (asks the user to confirm first). Canonical states: Evaluated, Applied, Responded, Interview, Offer, Hired, Rejected, Discarded, SKIP. Use the application number (the "#42" on its report page).
 - apply {"url":"https://…"} — open the apply form-proxy for a posting URL (we re-render the real form in plain language; the user verifies and submits it themselves — never auto-submit).
 - setApplyField {"field":"Why this role?","value":"<the answer>"} — write or revise an answer in the apply form the user is filling (only when an APPLY FORM is shown in your context). Use the field's label or id. When the user asks to make an answer shorter/sharper/etc, generate the new text and emit this.
 - remember {"fact":"the concise fact"} — durably remember a preference/fact about the user (carries across sessions and across whichever CLI runs).

--- a/web/src/app/api/assistant/route.ts
+++ b/web/src/app/api/assistant/route.ts
@@ -18,7 +18,7 @@ The args are a single JSON object. The dashboard parses the envelope and perform
 
 ACTIONS:
 - navigate {"path":"/pipeline?tab=OFFER&min=4"} — take the user to a section. Valid paths: /, /pipeline, /portals, /analytics, /cv, /config, /apply, /pipeline/{n} (a report), /jobs/{id} (a worker). The path may carry a query string.
-- filterPipeline {"tab":"OFFER","min":4,"q":"text","sort":"score","dir":-1} — filter the pipeline table in place. tab ∈ INBOX, ALL, EVALUATED, APPLIED, RESPONDED, INTERVIEW, OFFER, REJECTED, DISCARDED, SKIP; min = score floor 0–5.
+- filterPipeline {"tab":"OFFER","min":4,"q":"text","sort":"score","dir":-1} — filter the pipeline table in place. tab ∈ INBOX, ALL, EVALUATED, APPLIED, RESPONDED, INTERVIEW, OFFER, HIRED, REJECTED, DISCARDED, SKIP; min = score floor 0–5.
 - evaluate {"url":"https://…","title":"Evaluate · Acme","subtitle":"Role"} — spin ONE read-only evaluation worker on a SPECIFIC posting URL. Only when you actually have a real URL (e.g. from the page the user is on).
 - evaluateCompany {"company":"Anthropic"} — evaluate ALL of the user's PENDING inbox postings for that company. Emit the COMPANY NAME ONLY — never URLs; the app resolves the concrete postings itself. Big batches ask the user to confirm first.
 - research {"target":"https://… or 'my portfolio'","title":"Research · X"} — spin a read-only research worker.

--- a/web/src/components/pipeline-view.tsx
+++ b/web/src/components/pipeline-view.tsx
@@ -20,6 +20,7 @@ const TABS = [
   "RESPONDED",
   "INTERVIEW",
   "OFFER",
+  "HIRED",
   "REJECTED",
   "DISCARDED",
   "SKIP",

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -31,6 +31,11 @@ const STATUS_ALIAS: Record<string, string> = {
   monitor: "SKIP",
   no_aplicar: "SKIP",
   "no aplicar": "SKIP",
+  // Hired — terminal success (offer accepted), added to states.yml in #2050.
+  contratado: "HIRED",
+  contratada: "HIRED",
+  accepted: "HIRED",
+  accept: "HIRED",
 };
 
 export const CANONICAL_STATES = [
@@ -39,6 +44,7 @@ export const CANONICAL_STATES = [
   "Responded",
   "Interview",
   "Offer",
+  "Hired",
   "Rejected",
   "Discarded",
   "SKIP",
@@ -50,11 +56,12 @@ export function canonStatus(s: string): string {
   return STATUS_ALIAS[k] ?? s.toUpperCase();
 }
 
-/** Status dot colour, mirroring the Go TUI: green interview/offer, sky applied/
- *  responded, red skip/rejected, gray discarded, neutral evaluated. */
+/** Status dot colour, mirroring the Go TUI: green hired/interview/offer, sky
+ *  applied/responded, red skip/rejected, gray discarded, neutral evaluated. */
 export function statusDot(status: string): string {
   const c = canonStatus(status);
-  if (c.includes("INTERVIEW") || c.includes("OFFER")) return "bg-emerald-400";
+  // Hired is the terminal win — the best outcome, never a neutral gray dot.
+  if (c.includes("HIRED") || c.includes("INTERVIEW") || c.includes("OFFER")) return "bg-emerald-400";
   if (c.includes("APPLIED") || c.includes("RESPONDED")) return "bg-sky-400";
   if (c.includes("REJECTED") || c.includes("SKIP")) return "bg-red-400";
   if (c.includes("DISCARDED")) return "bg-zinc-600";


### PR DESCRIPTION
Closes #2249.

`Hired` — offer accepted, landed the job — was added to the core `states.yml` in #2050 but never reached the web dashboard, so the single most important outcome the tool exists for was invisible in the UI.

## What was broken (`web/src/lib/format.ts`)

- **You couldn't set it.** `CANONICAL_STATES` is the one source for the `status-select.tsx` dropdown (it `.map`s over it to render the options) and its `known` check. `Hired` wasn't in it — so a user who lands a job couldn't record it, and an existing Hired row read as an unrecognized status.
- **Gray dot.** `statusDot("Hired")` fell through to the `bg-zinc-500` neutral — the best outcome looked identical to "Evaluated".
- **Aliases didn't canonicalize.** `states.yml` lists `contratado`/`contratada`/`accepted`/`accept`; none were in the web `STATUS_ALIAS`.

## The fix — one file, three coordinated edits

- add `"Hired"` to `CANONICAL_STATES` (after `Offer`, matching `states.yml` order) → dropdown + known-check;
- map the aliases (`contratado`/`contratada`/`accepted`/`accept` → `HIRED`);
- give `HIRED` the positive green dot alongside `Interview`/`Offer` (it's the terminal win — never gray).

Verified by simulating the exact `canonStatus`/`statusDot` logic:

```
Hired       canon=HIRED       dot=emerald(green)
contratado  canon=HIRED       dot=emerald(green)
accepted    canon=HIRED       dot=emerald(green)
Offer       canon=OFFER       dot=emerald(green)
Evaluated   canon=EVALUATED   dot=zinc-500(gray)   ← unchanged
```

## Drift guard (commit 2)

There was a check that `states.yml` keeps its ids, but nothing asserting the **web list covers them** — which is exactly how this slipped. Added a cross-check in `test-all.mjs`: every `states.yml` label must appear in `format.ts`'s `CANONICAL_STATES`. Confirmed it goes red if `Hired` is removed, so a future core state can't silently go unrecognized by the web again.

`node test-all.mjs --quick` → **2308 passed, 0 failed**.

2 commits (fix + guard).

> Note: the Go TUI has the mirror gap (`statusColorMap()` omits `"hired"`), filed separately since it's a different codebase and I can't build-test Go in my environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the new **“Hired”** pipeline status across registry status/tab handling, pipeline view tabs, and analytics “Pipeline by stage”.
  * Expanded hired alias recognition (e.g., “contratado,” “contratada,” “accepted,” “accept”) and updated status display so **HIRED** is treated as a primary success state.
* **Documentation**
  * Updated the assistant API documentation to reflect valid `tab` values and the `min` score-floor range, and included **Hired** in canonical status values.
* **Tests**
  * Strengthened drift checks to ensure web hardcoded status lists and assistant prose remain aligned with the canonical state label set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->