### PR TITLE
fix: prevent double comma in cover letter achievement bullets

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -81,7 +81,10 @@ function buildDateline(letter) {
 function buildAchievementsBlock(achievements) {
   if (!achievements || !achievements.length) return "";
   const items = achievements.map(ach => {
-    const lead = escapeHtml(ach.lead || "");
+    // Trim a caller-supplied trailing comma (cover.md's own bullet-format
+    // example shows the lead ending in a comma) so it never doubles up with
+    // the comma this function always appends.
+    const lead = escapeHtml((ach.lead || "").replace(/,\s*$/, ""));
     const impact = escapeHtml(ach.impact || "");
     return `    <li><b>${lead},</b> ${impact}</li>`;
   }).join("\n");

--- a/modes/cover.md
+++ b/modes/cover.md
@@ -199,7 +199,7 @@ Select 4-5 achievement bullets from `cv.md` only (`article-digest.md` may be rea
 4. Use the exact wording and metrics from cv.md — never paraphrase or invent
 5. Apply keyword mirroring from Step 4 to the vocabulary around each bullet (not the metrics)
 
-Format: `**Bold lead phrase,** one sentence of impact with metric.`
+Format: `**Bold lead phrase,** one sentence of impact with metric.` This describes the *rendered* bullet only — the `lead` value in the JSON payload (Step 9) must be a bare phrase with no trailing punctuation; `generate-cover-letter.mjs` appends the comma automatically when building the bullet.
 
 ---
 
@@ -299,6 +299,8 @@ Assemble the JSON payload:
     "profile_intro": "{approved profile intro}",
     "achievements": [
       {"lead": "...", "impact": "..."}
+      // "lead" is a bare phrase, no trailing comma or other punctuation —
+      // generate-cover-letter.mjs appends the comma when rendering
     ],
     "problems_section": "{approved problems paragraph}",
     "closing": "{approved closing}",

--- a/modes/cover.md
+++ b/modes/cover.md
@@ -299,8 +299,6 @@ Assemble the JSON payload:
     "profile_intro": "{approved profile intro}",
     "achievements": [
       {"lead": "...", "impact": "..."}
-      // "lead" is a bare phrase, no trailing comma or other punctuation —
-      // generate-cover-letter.mjs appends the comma when rendering
     ],
     "problems_section": "{approved problems paragraph}",
     "closing": "{approved closing}",
@@ -309,6 +307,8 @@ Assemble the JSON payload:
   "output_path": "output/{company-slug}-{role-slug}-cover.pdf"
 }
 ```
+
+Each `achievements[].lead` must be a bare phrase with no trailing comma or other punctuation — `generate-cover-letter.mjs` appends the comma when rendering (see Step 7).
 
 Write payload to `/tmp/cover-payload-{company-slug}.json`.
 


### PR DESCRIPTION
## Summary
- Fixes #2253 — cover letter achievement bullets rendered with a double comma after the bold lead phrase (e.g. "Built and maintained automated and manual test suites,,")
- `generate-cover-letter.mjs` unconditionally appended a comma after `lead`; `modes/cover.md`'s own bullet-format example shows `lead` ending in a comma, so following the documented convention produced a collision
- Strips any trailing comma from `lead` before appending the script's own comma, so it's correct regardless of what the caller supplies
- Clarifies `modes/cover.md` in two places so `lead` is documented as a bare phrase with no trailing punctuation, closing the root ambiguity rather than relying solely on defensive stripping in the script

## Test plan
- [x] Reproduced the bug with a payload matching `cover.md`'s documented `lead` convention (trailing comma) before the fix
- [x] Confirmed single comma renders correctly after the fix, using the same payload
- [x] Confirmed a `lead` with no trailing punctuation still renders correctly (no regression for payloads that were already correct)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed achievement bullet rendering in generated cover letters to prevent duplicated commas by properly sanitizing the “lead” text.
  * Improved handling of achievement descriptions with trailing punctuation.

* **Documentation**
  * Clarified the required punctuation-free formatting for achievement “lead” text in cover-letter generation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->