### PR TITLE
fix(scaffolder): materialize the Kimi skill entrypoint on symlink-less filesystems

### DIFF
--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -67,6 +67,8 @@ To configure OpenCode with a custom provider:
    ```
 ### Kimi K2.5 via OpenCode (Verified)
 
+> **Kimi the model, not Kimi the CLI.** This recipe runs the Kimi K2.5 *model* through the **OpenCode** CLI. That is a different thing from using the standalone **Kimi CLI** as your host (see [Supported CLIs](SUPPORTED_CLIS.md)). The names collide; the setups don't. Follow the steps below inside OpenCode.
+
 The following configuration was verified with Career-Ops using OpenCode and Moonshot AI's OpenAI-compatible API.
 
 #### opencode.json

--- a/docs/SUPPORTED_CLIS.md
+++ b/docs/SUPPORTED_CLIS.md
@@ -5,6 +5,7 @@ Career-ops is AI-agnostic and runs on several command-line agent tools. The core
 | CLI | Entry File | How to Invoke |
 | --- | --- | --- |
 | Claude Code | `CLAUDE.md` | Interactive: `claude` (then `/career-ops`). Headless/Batch: `claude -p "prompt"` |
+| Cursor | `AGENTS.md` | Interactive: open the project in Cursor and ask for `career-ops` (skill entrypoint at `.cursor/skills/career-ops/SKILL.md`) |
 | Codex | `CODEX.md` (see [`docs/CODEX.md`](CODEX.md)) | Interactive: `codex` (then use plain text). Headless/Batch: `codex exec "prompt"` |
 | OpenCode | `OPENCODE.md` | Interactive: `opencode` (then `/career-ops`). Headless/Batch: `opencode run "prompt"` |
 | Antigravity CLI | `AGENTS.md` | Interactive: `agy` (then `/career-ops`). Headless/Batch: `agy -p "prompt"` |

--- a/scaffolder/bin/skill-entrypoints.mjs
+++ b/scaffolder/bin/skill-entrypoints.mjs
@@ -32,6 +32,10 @@ export const SKILL_ENTRYPOINTS = [
     path: '.grok/skills/career-ops/SKILL.md',
     pointer: '../../../.agents/skills/career-ops/SKILL.md',
   },
+  {
+    path: '.kimi/skills/career-ops/SKILL.md',
+    pointer: '../../../.agents/skills/career-ops/SKILL.md',
+  },
 ];
 
 function repoPath(root, path) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3947,6 +3947,45 @@ console.log('\n12a. Skill entrypoint materialization');
   }
 }
 
+// Every CLI skill entrypoint tracked in git MUST also be listed in
+// SKILL_ENTRYPOINTS, because that array is the only thing that materializes
+// these files on filesystems without symlink support. A tracked-but-unlisted
+// entrypoint checks out as a pointer text file on Windows and stays that way:
+// the user opens their CLI and the skill is the literal string
+// "../../../.agents/skills/career-ops/SKILL.md". That is bug #1051, and it hit
+// a second time because Kimi shipped after the list was written and nobody
+// compared the two. Adding a CLI touches five wiring points; this asserts the
+// sixth instead of trusting a reviewer to remember it.
+console.log('\n12a-bis. Every tracked skill entrypoint is materializable');
+
+{
+  try {
+    const tracked = execSync('git ls-files', { cwd: ROOT, encoding: 'utf-8' })
+      .split('\n')
+      .filter((p) => /^\.[^/]+\/skills\/career-ops\/SKILL\.md$/.test(p))
+      .filter((p) => !p.startsWith('.agents/')) // the canonical target, not an entrypoint
+      .sort();
+
+    // An empty list means git could not see the tree, not that there is nothing
+    // to check (#2240): a guard that cannot look must never pass.
+    if (tracked.length === 0) {
+      fail('git ls-files returned no skill entrypoints — this check could not inspect anything');
+    } else {
+      const skills = await import(pathToFileURL(join(ROOT, 'scaffolder/bin/skill-entrypoints.mjs')).href);
+      const listed = new Set(skills.SKILL_ENTRYPOINTS.map((e) => e.path));
+      const unlisted = tracked.filter((p) => !listed.has(p));
+
+      if (unlisted.length === 0) {
+        pass(`all ${tracked.length} tracked skill entrypoints are in SKILL_ENTRYPOINTS`);
+      } else {
+        fail(`skill entrypoint(s) tracked in git but missing from SKILL_ENTRYPOINTS — broken on filesystems without symlinks: ${unlisted.join(', ')}`);
+      }
+    }
+  } catch (e) {
+    fail(`skill entrypoint coverage check crashed: ${e.message}`);
+  }
+}
+
 console.log('\n12b. Skill entrypoint bootstrap (npx / old releases)');
 
 {
@@ -3964,14 +4003,13 @@ console.log('\n12b. Skill entrypoint bootstrap (npx / old releases)');
 
     const skills = await import(pathToFileURL(join(ROOT, 'scaffolder/bin/skill-entrypoints.mjs')).href);
     const touched = skills.ensureSkillEntrypoints(fixtureRoot).sort();
-    const expectedTouched = [
-      '.antigravitycli/skills/career-ops/SKILL.md',
-      '.claude/skills/career-ops/SKILL.md',
-      '.cursor/skills/career-ops/SKILL.md',
-      '.grok/skills/career-ops/SKILL.md',
-      '.opencode/skills/career-ops/SKILL.md',
-      '.qwen/skills/career-ops/SKILL.md',
-    ];
+    // Derived from SKILL_ENTRYPOINTS, never hand-listed. A literal array here is
+    // a second copy of the same list, and a second copy goes stale: adding Kimi
+    // to the registry turned this assertion red for the correct behaviour, which
+    // teaches whoever hits it to edit the expectation without reading it. The
+    // assertion that matters is "bootstraps everything in the registry", and
+    // that one holds whatever the registry contains.
+    const expectedTouched = skills.SKILL_ENTRYPOINTS.map((e) => e.path).sort();
 
     if (JSON.stringify(touched) === JSON.stringify(expectedTouched)) {
       pass('ensureSkillEntrypoints bootstraps all CLI skill entrypoints');


### PR DESCRIPTION
Found while auditing which core facts have a machine-readable source. `.kimi/skills/career-ops/SKILL.md` is tracked as a real symlink, asserted by `test-all.mjs`, and listed in `SYSTEM_PATHS` — but it was **not** in `SKILL_ENTRYPOINTS`.

That array is the only thing that materializes these files on filesystems without symlink support. So on Windows, a Kimi user's `SKILL.md` checks out as a text file whose entire contents are `../../../.agents/skills/career-ops/SKILL.md`, and nothing ever repairs it. They open Kimi and the skill is a file path.

This is the same failure as #1051, which was fixed for the CLIs that existed at the time. Kimi shipped afterwards and was never added to the list. Nobody noticed because every other signal says it's fine: the symlink is correct in git, the file exists, the tests pass, and it works on macOS and Linux.

## What stops the third occurrence

A check that cross-references every skill entrypoint tracked in git against `SKILL_ENTRYPOINTS`, failing with the specific path that's missing.

**Verified in both directions**, because a guard that has never been seen to fail is not known to work:

- with Kimi listed → `all 7 tracked skill entrypoints are in SKILL_ENTRYPOINTS`
- with Kimi removed → `skill entrypoint(s) tracked in git but missing from SKILL_ENTRYPOINTS — broken on filesystems without symlinks: .kimi/skills/career-ops/SKILL.md`

It also fails when `git ls-files` returns nothing, so it can't pass by being unable to look — that's the failure mode #2240 fixed this morning in the SYSTEM_PATHS validator.

## Two smaller things in the same change

- The bootstrap test's expected list was a hand-written copy of `SKILL_ENTRYPOINTS`. Adding Kimi turned it red for correct behaviour, which is how people learn to edit an expectation without reading it. It now derives from the registry.
- `docs/SUPPORTED_CLIS.md` was missing Cursor, added in #2115 this morning. That PR wired five places correctly; the docs table was a sixth nobody checked.

Suite: 2346 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cursor to the list of supported CLI integrations.
  * Added Kimi CLI skill entrypoint support for career operations.
  * Added validation to ensure tracked CLI skill entrypoints are registered correctly.

* **Documentation**
  * Clarified that the Kimi K2.5 model is used through the OpenCode CLI, not the standalone Kimi CLI.
  * Added setup guidance for the Cursor integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->