### PR TITLE
Pace DNS lookups so a full sweep can't trip a resolver's rate limit

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -481,6 +481,20 @@ and probes those companies via the ATS providers instead of (or in addition
 to) the directory walk. Other flags: `--verbose`, `--json`, `--include-undated`,
 `--shuffle`.
 
+### DNS pacing
+
+A full sweep resolves one hostname per Workday and iCIMS tenant — 13,892 distinct hostnames across the current datasets, against 3 for Greenhouse, Lever and Ashby combined. Those lookups are irreducible (nothing to cache: every hostname is distinct), and issued unpaced they trip the per-client rate limit on a resolver like Pi-hole, which then refuses queries for the whole machine — the scan reports thousands of misleading `fetch failed` lines while the boards themselves are fine (#2229).
+
+Lookups that reach the resolver are therefore rate-limited to **400 per minute** by default. Node ≥ 20 resolves A and AAAA per lookup, so that is roughly 800 upstream queries/minute — under a stock Pi-hole's 1,000/minute, with headroom for the rest of the machine. Cache hits and lookups that coalesce onto an in-flight one are free, so only *new* hostnames count against the ceiling.
+
+```bash
+CAREER_OPS_DNS_LOOKUPS_PER_MIN=800 npm run scan:full   # raise the ceiling
+CAREER_OPS_DNS_LOOKUPS_PER_MIN=0 npm run scan:full     # no pacing (pre-#2229 behaviour)
+CAREER_OPS_NO_DNS_CACHE=1 npm run scan:full            # no DNS cache AND no pacing
+```
+
+The cost is real: a full Workday + iCIMS sweep becomes DNS-bound at roughly 35 minutes. Raise the ceiling if your resolver has the budget — but if you see `fetch failed` in bulk from one ATS section, suspect the resolver before the boards.
+
 **Exit codes:** `0` scan completed, `1` configuration error (no portals.yml, unknown `--ats` source) or fatal scan error.
 
 ---

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -485,9 +485,11 @@ to) the directory walk. Other flags: `--verbose`, `--json`, `--include-undated`,
 
 A full sweep resolves one hostname per Workday and iCIMS tenant — 13,889 distinct hostnames across the current datasets (3,781 Workday + 10,108 iCIMS), against 3 for Greenhouse, Lever and Ashby combined. Those lookups are irreducible (nothing to cache: every hostname is distinct), and issued unpaced they trip the per-client rate limit on a resolver like Pi-hole, which then refuses queries for the whole machine — the scan reports thousands of misleading `fetch failed` lines while the boards themselves are fine (#2229).
 
-Lookups that reach the resolver are therefore rate-limited to **400 per minute** by default. How many upstream queries that becomes depends on the OS resolver: `dns.lookup()` delegates to `getaddrinfo`, which may answer from `/etc/hosts` without any query at all, but on a typical glibc host with `autoSelectFamily` it emits an A **and** an AAAA query — roughly 800 queries/minute, measured against a Pi-hole. That is under a stock Pi-hole's 1,000/minute with headroom for the rest of the machine; size it against your own resolver's limit.
+Uncached, non-coalesced lookups are therefore paced at **400 per minute** by default. The token is spent *before* `dns.lookup()` runs, so a name answered locally — from `/etc/hosts`, say — still costs one; the ceiling meters what the process asks to resolve, not what leaves the machine.
 
-Cache hits and lookups that coalesce onto an in-flight one are free, so only lookups that actually reach the resolver count against the ceiling — a hostname not in the cache, or a cached one requested with different resolver options (the cache key is hostname plus `family`/`all`/`hints`/`verbatim`).
+How many upstream queries that becomes depends on the OS resolver: `dns.lookup()` delegates to `getaddrinfo`, which may answer without any query at all, but on a typical glibc host with `autoSelectFamily` it emits an A **and** an AAAA query — roughly 800 queries/minute, measured against a Pi-hole. That is under a stock Pi-hole's 1,000/minute with headroom for the rest of the machine; size it against your own resolver's limit.
+
+Cache hits and lookups that coalesce onto an in-flight one are free, so only uncached, non-coalesced lookup keys count against the ceiling — a hostname not in the cache, or a cached one requested with different resolver options (the cache key is hostname plus `family`/`all`/`hints`/`verbatim`).
 
 ```bash
 CAREER_OPS_DNS_LOOKUPS_PER_MIN=800 npm run scan:full   # raise the ceiling

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -483,9 +483,11 @@ to) the directory walk. Other flags: `--verbose`, `--json`, `--include-undated`,
 
 ### DNS pacing
 
-A full sweep resolves one hostname per Workday and iCIMS tenant — 13,892 distinct hostnames across the current datasets, against 3 for Greenhouse, Lever and Ashby combined. Those lookups are irreducible (nothing to cache: every hostname is distinct), and issued unpaced they trip the per-client rate limit on a resolver like Pi-hole, which then refuses queries for the whole machine — the scan reports thousands of misleading `fetch failed` lines while the boards themselves are fine (#2229).
+A full sweep resolves one hostname per Workday and iCIMS tenant — 13,889 distinct hostnames across the current datasets (3,781 Workday + 10,108 iCIMS), against 3 for Greenhouse, Lever and Ashby combined. Those lookups are irreducible (nothing to cache: every hostname is distinct), and issued unpaced they trip the per-client rate limit on a resolver like Pi-hole, which then refuses queries for the whole machine — the scan reports thousands of misleading `fetch failed` lines while the boards themselves are fine (#2229).
 
-Lookups that reach the resolver are therefore rate-limited to **400 per minute** by default. Node ≥ 20 resolves A and AAAA per lookup, so that is roughly 800 upstream queries/minute — under a stock Pi-hole's 1,000/minute, with headroom for the rest of the machine. Cache hits and lookups that coalesce onto an in-flight one are free, so only *new* hostnames count against the ceiling.
+Lookups that reach the resolver are therefore rate-limited to **400 per minute** by default. How many upstream queries that becomes depends on the OS resolver: `dns.lookup()` delegates to `getaddrinfo`, which may answer from `/etc/hosts` without any query at all, but on a typical glibc host with `autoSelectFamily` it emits an A **and** an AAAA query — roughly 800 queries/minute, measured against a Pi-hole. That is under a stock Pi-hole's 1,000/minute with headroom for the rest of the machine; size it against your own resolver's limit.
+
+Cache hits and lookups that coalesce onto an in-flight one are free, so only lookups that actually reach the resolver count against the ceiling — a hostname not in the cache, or a cached one requested with different resolver options (the cache key is hostname plus `family`/`all`/`hints`/`verbatim`).
 
 ```bash
 CAREER_OPS_DNS_LOOKUPS_PER_MIN=800 npm run scan:full   # raise the ceiling

--- a/providers/_dns-cache.mjs
+++ b/providers/_dns-cache.mjs
@@ -337,6 +337,21 @@ export function lookupsPerMinFromEnv(env = process.env) {
   return n;
 }
 
+/** @type {{ pacingStats: () => { delayed: number, waitedMs: number } } | null} */
+let patched = null;
+
+/**
+ * Pacing counters for the process-wide patched lookup.
+ *
+ * Zeroes when the patch is opted out, so callers never need to branch.
+ *
+ * @returns {{ delayed: number, waitedMs: number }} Delayed lookup count and total wait.
+ */
+export function dnsPacingStats() {
+  return patched ? patched.pacingStats() : { delayed: 0, waitedMs: 0 };
+}
+
 if (process.env.CAREER_OPS_NO_DNS_CACHE !== '1') {
-  dns.lookup = createCachedLookup(dns.lookup, { lookupsPerMin: lookupsPerMinFromEnv() });
+  patched = createCachedLookup(dns.lookup, { lookupsPerMin: lookupsPerMinFromEnv() });
+  dns.lookup = patched;
 }

--- a/providers/_dns-cache.mjs
+++ b/providers/_dns-cache.mjs
@@ -87,6 +87,113 @@ const DEFAULT_MAX_ENTRIES = 512;
 // resolver otherwise feeds (see #2229), short enough that a resolver coming
 // back is picked up almost immediately.
 const DEFAULT_NEGATIVE_TTL_MS = 30_000;
+// Pacing defaults. The ceiling counts *lookups*; Node ≥20's autoSelectFamily
+// turns each one into an A and an AAAA query, so 400 lookups/min is ~800
+// upstream queries/min — comfortably under a stock Pi-hole's 1000/min, with
+// headroom left for the rest of the machine (#2229).
+const DEFAULT_LOOKUPS_PER_MIN = 400;
+// One sweep worker per token, so a cold start of CONCURRENCY=20 workers
+// (scan-ats-full.mjs) is admitted at once and pacing only bites afterwards.
+// Small runs against a handful of hostnames are therefore never slowed.
+const DEFAULT_BURST = 20;
+
+/**
+ * A token bucket: `capacity` calls may run at once, refilling at `ratePerMin`.
+ *
+ * The cache in this file collapses *repeat* lookups of one hostname, which is
+ * total for greenhouse/lever/ashby (1 host each) and structurally inert for
+ * workday and icims, where every tenant has its own hostname. Those lookups
+ * are all genuinely distinct — nothing to deduplicate — so the only remaining
+ * lever is how fast they are issued (#2229).
+ *
+ * Clock and timer are injectable so the tests are deterministic and offline.
+ *
+ * @param {object} [options] - Bucket tuning.
+ * @param {number} [options.ratePerMin] - Sustained calls per minute. Must be > 0.
+ * @param {number} [options.capacity] - Burst size, in tokens.
+ * @param {() => number} [options.now] - Clock source, injectable for tests.
+ * @param {(fn: Function, ms: number) => void} [options.setTimer] - Timer, injectable for tests.
+ * @returns {{ take: (fn: Function) => void, pending: number, stats: () => { delayed: number, waitedMs: number } }}
+ */
+export function createTokenBucket(options = {}) {
+  const ratePerMin = options.ratePerMin ?? DEFAULT_LOOKUPS_PER_MIN;
+  const capacity = options.capacity ?? DEFAULT_BURST;
+  const now = options.now ?? Date.now;
+  const setTimer = options.setTimer ?? setTimeout;
+
+  // Caller-supplied, so validate rather than assert: a zero or negative rate
+  // would make the refill interval Infinity and hang every queued lookup.
+  if (!Number.isFinite(ratePerMin) || ratePerMin <= 0) {
+    throw new RangeError(`ratePerMin must be a finite number > 0, got ${ratePerMin}`);
+  }
+  if (!Number.isFinite(capacity) || capacity < 1) {
+    throw new RangeError(`capacity must be a finite number >= 1, got ${capacity}`);
+  }
+
+  const tokensPerMs = ratePerMin / 60_000;
+  let tokens = capacity;
+  let lastRefill = now();
+  /** @type {{ fn: Function, queuedAt: number }[]} */
+  const queue = [];
+  let timerPending = false;
+  let delayed = 0;
+  let waitedMs = 0;
+
+  function refill() {
+    const t = now();
+    tokens = Math.min(capacity, tokens + (t - lastRefill) * tokensPerMs);
+    lastRefill = t;
+  }
+
+  function schedule() {
+    if (timerPending || queue.length === 0) return;
+    timerPending = true;
+    // At least 1ms: a fractional token left over must not schedule a 0ms spin.
+    setTimer(pump, Math.max(1, Math.ceil((1 - tokens) / tokensPerMs)));
+  }
+
+  function pump() {
+    timerPending = false;
+    refill();
+    // Bounded by queue length and by the tokens available this tick — both
+    // finite, so this cannot spin.
+    while (queue.length > 0 && tokens >= 1) {
+      tokens -= 1;
+      const { fn, queuedAt } = /** @type {{ fn: Function, queuedAt: number }} */ (queue.shift());
+      delayed++;
+      waitedMs += now() - queuedAt;
+      fn();
+    }
+    schedule();
+  }
+
+  return {
+    /**
+     * Run `fn` as soon as a token allows. FIFO: a queued call is never
+     * overtaken by a later one, so no hostname can be starved.
+     *
+     * The queue needs no cap of its own — it holds at most one entry per
+     * in-flight connection, and the sweep's own CONCURRENCY bounds that.
+     *
+     * @param {Function} fn - Work to admit.
+     * @returns {void}
+     */
+    take(fn) {
+      refill();
+      if (queue.length === 0 && tokens >= 1) {
+        tokens -= 1;
+        fn();
+        return;
+      }
+      queue.push({ fn, queuedAt: now() });
+      schedule();
+    },
+    /** @returns {number} Calls queued but not yet run. */
+    get pending() { return queue.length; },
+    /** @returns {{ delayed: number, waitedMs: number }} Counters for operator reporting. */
+    stats() { return { delayed, waitedMs }; },
+  };
+}
 
 /**
  * Build a caching wrapper around a callback-style `dns.lookup`.

--- a/providers/_dns-cache.mjs
+++ b/providers/_dns-cache.mjs
@@ -209,6 +209,9 @@ export function createTokenBucket(options = {}) {
  * @param {number} [options.ttlMs] - How long a successful result stays fresh.
  * @param {number} [options.maxEntries] - Cap on distinct cached keys.
  * @param {() => number} [options.now] - Clock source, injectable for tests.
+ * @param {number} [options.lookupsPerMin] - Ceiling on resolver-bound lookups; 0 disables pacing.
+ * @param {number} [options.burst] - Tokens available at once before pacing bites.
+ * @param {(fn: Function, ms: number) => void} [options.setTimer] - Timer, injectable for tests.
  * @returns {Function} A drop-in replacement for `dns.lookup`.
  */
 export function createCachedLookup(realLookup, options = {}) {
@@ -216,6 +219,16 @@ export function createCachedLookup(realLookup, options = {}) {
   const negativeTtlMs = options.negativeTtlMs ?? DEFAULT_NEGATIVE_TTL_MS;
   const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
   const now = options.now ?? Date.now;
+  const lookupsPerMin = options.lookupsPerMin ?? DEFAULT_LOOKUPS_PER_MIN;
+  // No bucket at all when pacing is off, so the disabled path costs nothing.
+  const bucket = lookupsPerMin > 0
+    ? createTokenBucket({
+      ratePerMin: lookupsPerMin,
+      capacity: options.burst ?? DEFAULT_BURST,
+      now,
+      setTimer: options.setTimer,
+    })
+    : null;
 
   /** @type {Map<string, { expires: number, args: any[] }>} */
   const cache = new Map();
@@ -250,7 +263,16 @@ export function createCachedLookup(realLookup, options = {}) {
     }
     inflight.set(key, [callback]);
 
-    realLookup(hostname, opts, (err, ...rest) => {
+    // Only the leader of a coalesced group reaches the resolver, so only the
+    // leader spends a token: cache hits and queued waiters are free. That is
+    // what keeps pacing proportional to *distinct hostnames* rather than to
+    // request volume — greenhouse's 8,333 boards still cost one lookup, while
+    // workday's 3,781 tenants and icims's 10,108 are metered (#2229).
+    //
+    // The key stays in `inflight` while the thunk waits for a token, so a
+    // later caller for the same hostname coalesces onto it instead of queueing
+    // a second one.
+    const resolve = () => realLookup(hostname, opts, (err, ...rest) => {
       const callbacks = inflight.get(key) ?? [];
       inflight.delete(key);
 
@@ -270,6 +292,8 @@ export function createCachedLookup(realLookup, options = {}) {
 
       for (const cb of callbacks) cb(err, ...rest);
     });
+
+    if (bucket) bucket.take(resolve); else resolve();
   }
 
   // dns.lookup carries an internal symbol telling util.promisify which
@@ -278,6 +302,9 @@ export function createCachedLookup(realLookup, options = {}) {
   for (const sym of Object.getOwnPropertySymbols(realLookup)) {
     cachedLookup[sym] = realLookup[sym];
   }
+
+  /** @returns {{ delayed: number, waitedMs: number }} How much pacing cost this process. */
+  cachedLookup.pacingStats = () => (bucket ? bucket.stats() : { delayed: 0, waitedMs: 0 });
 
   return cachedLookup;
 }

--- a/providers/_dns-cache.mjs
+++ b/providers/_dns-cache.mjs
@@ -100,6 +100,10 @@ const DEFAULT_LOOKUPS_PER_MIN = 400;
 // (scan-ats-full.mjs) is admitted at once and pacing only bites afterwards.
 // Small runs against a handful of hostnames are therefore never slowed.
 const DEFAULT_BURST = 20;
+// setTimeout clamps anything larger to 1ms (and warns), which would turn a
+// long refill wait into a 1ms spin that never gains a token. Cap instead and
+// re-arm: a rate that slow simply wakes, finds no token, and waits again.
+const MAX_TIMER_MS = 2_147_483_647;
 
 /**
  * A token bucket: `capacity` calls may run at once, refilling at `ratePerMin`.
@@ -153,7 +157,8 @@ export function createTokenBucket(options = {}) {
     if (timerPending || queue.length === 0) return;
     timerPending = true;
     // At least 1ms: a fractional token left over must not schedule a 0ms spin.
-    setTimer(pump, Math.max(1, Math.ceil((1 - tokens) / tokensPerMs)));
+    // At most MAX_TIMER_MS: past that setTimeout clamps to 1ms and spins.
+    setTimer(pump, Math.min(MAX_TIMER_MS, Math.max(1, Math.ceil((1 - tokens) / tokensPerMs))));
   }
 
   function pump() {
@@ -325,7 +330,10 @@ export function createCachedLookup(realLookup, options = {}) {
  */
 export function lookupsPerMinFromEnv(env = process.env) {
   const raw = env.CAREER_OPS_DNS_LOOKUPS_PER_MIN;
-  if (raw === undefined || raw === '') return DEFAULT_LOOKUPS_PER_MIN;
+  // Trim before the blank check: Number(' ') is 0, and 0 is the documented
+  // "pacing off" value, so a whitespace-only setting would silently disable
+  // the limiter rather than fall back like any other unusable value.
+  if (raw === undefined || String(raw).trim() === '') return DEFAULT_LOOKUPS_PER_MIN;
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) {
     console.error(

--- a/providers/_dns-cache.mjs
+++ b/providers/_dns-cache.mjs
@@ -42,7 +42,11 @@
  *         p.lookup('example.com').then(()=>console.log('promises hit patch:',n>0))"
  *   - Failed resolutions are never cached, so an outage cannot be pinned in.
  *
- * Opt out entirely with `CAREER_OPS_NO_DNS_CACHE=1`.
+ * Two env knobs, both read at import time:
+ *   - `CAREER_OPS_NO_DNS_CACHE=1` opts out entirely — no memoization AND no
+ *     pacing, since both live inside this patched lookup.
+ *   - `CAREER_OPS_DNS_LOOKUPS_PER_MIN` caps resolver-bound lookups
+ *     (default 400; `0` disables pacing but keeps the cache).
  */
 
 import dns from 'node:dns';
@@ -309,6 +313,30 @@ export function createCachedLookup(realLookup, options = {}) {
   return cachedLookup;
 }
 
+/**
+ * Read the pacing ceiling from the environment.
+ *
+ * Unparseable values warn and fall back rather than throwing: this runs at
+ * import time inside every scanner, and a typo in an env var must not take
+ * the whole run down.
+ *
+ * @param {Record<string, string | undefined>} [env] - Environment to read.
+ * @returns {number} Lookups per minute; 0 disables pacing.
+ */
+export function lookupsPerMinFromEnv(env = process.env) {
+  const raw = env.CAREER_OPS_DNS_LOOKUPS_PER_MIN;
+  if (raw === undefined || raw === '') return DEFAULT_LOOKUPS_PER_MIN;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    console.error(
+      `⚠ CAREER_OPS_DNS_LOOKUPS_PER_MIN=${raw} is not a non-negative number — `
+      + `using the default ${DEFAULT_LOOKUPS_PER_MIN} lookups/min`,
+    );
+    return DEFAULT_LOOKUPS_PER_MIN;
+  }
+  return n;
+}
+
 if (process.env.CAREER_OPS_NO_DNS_CACHE !== '1') {
-  dns.lookup = createCachedLookup(dns.lookup);
+  dns.lookup = createCachedLookup(dns.lookup, { lookupsPerMin: lookupsPerMinFromEnv() });
 }

--- a/providers/_dns-cache.mjs
+++ b/providers/_dns-cache.mjs
@@ -155,16 +155,19 @@ export function createTokenBucket(options = {}) {
   function pump() {
     timerPending = false;
     refill();
-    // Bounded by queue length and by the tokens available this tick — both
-    // finite, so this cannot spin.
-    while (queue.length > 0 && tokens >= 1) {
-      tokens -= 1;
-      const { fn, queuedAt } = /** @type {{ fn: Function, queuedAt: number }} */ (queue.shift());
-      delayed++;
-      waitedMs += now() - queuedAt;
-      fn();
+    try {
+      // Bounded by queue length and by the tokens available this tick — both
+      // finite, so this cannot spin.
+      while (queue.length > 0 && tokens >= 1) {
+        tokens -= 1;
+        const { fn, queuedAt } = /** @type {{ fn: Function, queuedAt: number }} */ (queue.shift());
+        delayed++;
+        waitedMs += now() - queuedAt;
+        fn();
+      }
+    } finally {
+      schedule();
     }
-    schedule();
   }
 
   return {

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -37,7 +37,7 @@ import path from 'path';
 import yaml from 'js-yaml';
 
 import { makeHttpCtx, fetchJson } from './providers/_http.mjs';
-import { isResolverFailure } from './providers/_dns-cache.mjs';
+import { isResolverFailure, dnsPacingStats } from './providers/_dns-cache.mjs';
 import greenhouse from './providers/greenhouse.mjs';
 import lever from './providers/lever.mjs';
 import ashby from './providers/ashby.mjs';
@@ -866,6 +866,12 @@ async function main() {
   log(`Companies scanned:  ${totalCompaniesScanned}${capHit ? ` of ${totalCompaniesAvailable} (capped)` : ''}`);
   log(`Unreachable boards: ${totalErrors}`);
   if (cappedBoards) log(`Page-capped boards: ${cappedBoards} (partial coverage — later postings not scanned)`);
+  // A paced sweep is slower on purpose. Say so, or the operator reads the
+  // wall-clock time as a hang (#2229).
+  const pacing = dnsPacingStats();
+  if (pacing.delayed > 0) {
+    log(`DNS pacing:         ${pacing.delayed} lookup${pacing.delayed === 1 ? '' : 's'} delayed, ${Math.round(pacing.waitedMs / 1000)}s total wait (CAREER_OPS_DNS_LOOKUPS_PER_MIN to tune, 0 disables)`);
+  }
   // noDateSkipJobs is a subset of droppedNoDate, not a separate pool: every
   // no-postedOn workday posting counted here also hits the per-job undated
   // filter in the scan loop above and gets dropped there too. Report it as
@@ -952,6 +958,7 @@ async function main() {
       postingsDroppedContent: droppedContent,
       unreachableBoards: totalErrors,
       cappedBoards,
+      dnsPacing: { delayed: pacing.delayed, waitedMs: Math.round(pacing.waitedMs) },
       saved,
       offers: offers.map(o => ({
         company: o.company,

--- a/tests/providers/dns-pacing.test.mjs
+++ b/tests/providers/dns-pacing.test.mjs
@@ -102,6 +102,31 @@ try {
     }
   }
 
+  // --- a refill delay never exceeds Node's maximum timeout ---
+  // setTimeout clamps anything above 2^31-1 ms to 1ms, so an unbounded delay
+  // does not wait — it fires pump() immediately, gains no token, and re-arms,
+  // spinning at 1ms forever. A rate low enough to overflow must still schedule
+  // a real wait.
+  {
+    const MAX_TIMER_MS = 2_147_483_647;
+    let clock = 0;
+    const delays = [];
+    const setTimer = (fn, ms) => { delays.push(ms); };
+    const bucket = createTokenBucket({
+      ratePerMin: 1e-5, capacity: 1, now: () => clock, setTimer,
+    });
+
+    bucket.take(() => {});   // spends the only token, runs inline, schedules nothing
+    bucket.take(() => {});   // queues, so this one arms the refill timer
+
+    const armed = delays.length === 1 && delays[0] <= MAX_TIMER_MS && delays[0] >= 1;
+    if (armed) {
+      pass('a tiny rate still schedules within the maximum timeout instead of clamping to 1ms');
+    } else {
+      fail(`refill delay out of range: ${JSON.stringify(delays)} (max ${MAX_TIMER_MS})`);
+    }
+  }
+
   // --- a throwing callback does not strand the queue ---
   {
     let clock = 0;
@@ -274,6 +299,25 @@ try {
       pass('CAREER_OPS_DNS_LOOKUPS_PER_MIN parses, defaults to 400, and 0 disables');
     } else {
       fail(`env parsing wrong: ${JSON.stringify(seen)}`);
+    }
+  }
+
+  // --- whitespace must not read as 0 ---
+  // `Number(' ')` is 0, and 0 is the documented "pacing off" value, so a
+  // whitespace-only setting would silently disable the rate limiter instead of
+  // being rejected like any other junk. Silent-off is the one failure this knob
+  // must never have.
+  {
+    const seen = {
+      space: lookupsPerMinFromEnv({ CAREER_OPS_DNS_LOOKUPS_PER_MIN: ' ' }),
+      tab: lookupsPerMinFromEnv({ CAREER_OPS_DNS_LOOKUPS_PER_MIN: '\t' }),
+      padded: lookupsPerMinFromEnv({ CAREER_OPS_DNS_LOOKUPS_PER_MIN: ' 120 ' }),
+    };
+
+    if (seen.space === 400 && seen.tab === 400 && seen.padded === 120) {
+      pass('whitespace falls back to the default instead of silently disabling pacing');
+    } else {
+      fail(`whitespace handling wrong: ${JSON.stringify(seen)}`);
     }
   }
 

--- a/tests/providers/dns-pacing.test.mjs
+++ b/tests/providers/dns-pacing.test.mjs
@@ -1,0 +1,106 @@
+// tests/providers/dns-pacing.test.mjs — token-bucket pacing for providers/_dns-cache.mjs.
+// Fake clock + manual timer: no real waiting, no network, deterministic ordering.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — DNS lookup pacing');
+
+try {
+  const { createTokenBucket } = await import(
+    pathToFileURL(join(ROOT, 'providers/_dns-cache.mjs')).href
+  );
+
+  /**
+   * Manual timer: records what the bucket scheduled instead of waiting for it.
+   * `fireAll()` runs everything currently pending — anything the callback
+   * schedules in turn lands in the next batch, so a test advances the clock
+   * one refill at a time and sees exactly one release per step.
+   */
+  const mkTimer = () => {
+    const timers = [];
+    const setTimer = (fn, ms) => { timers.push({ fn, ms }); };
+    setTimer.fireAll = () => { for (const t of timers.splice(0)) t.fn(); };
+    setTimer.pending = () => timers.length;
+    return setTimer;
+  };
+
+  // --- a burst up to capacity runs immediately, the rest queues ---
+  {
+    let clock = 0;
+    const setTimer = mkTimer();
+    const bucket = createTokenBucket({ ratePerMin: 60, capacity: 3, now: () => clock, setTimer });
+
+    const ran = [];
+    for (let i = 0; i < 5; i++) bucket.take(() => ran.push(i));
+    const immediate = ran.join(',');
+
+    clock += 1_000;                       // 60/min = one token per second
+    setTimer.fireAll();
+    const afterOne = ran.join(',');
+
+    clock += 1_000;
+    setTimer.fireAll();
+    const afterTwo = ran.join(',');
+
+    if (immediate === '0,1,2' && afterOne === '0,1,2,3' && afterTwo === '0,1,2,3,4') {
+      pass('token bucket admits the burst, then releases one per refill in FIFO order');
+    } else {
+      fail(`pacing wrong: immediate=[${immediate}] afterOne=[${afterOne}] afterTwo=[${afterTwo}]`);
+    }
+  }
+
+  // --- an idle bucket refills back to capacity, and no further ---
+  {
+    let clock = 0;
+    const setTimer = mkTimer();
+    const bucket = createTokenBucket({ ratePerMin: 60, capacity: 3, now: () => clock, setTimer });
+
+    for (let i = 0; i < 3; i++) bucket.take(() => {});   // drain
+    clock += 60_000;                                      // idle a full minute
+    const ran = [];
+    for (let i = 0; i < 5; i++) bucket.take(() => ran.push(i));
+
+    if (ran.join(',') === '0,1,2' && bucket.pending === 2) {
+      pass('an idle bucket refills to capacity and is capped there');
+    } else {
+      fail(`refill cap wrong: ran=[${ran.join(',')}] pending=${bucket.pending}`);
+    }
+  }
+
+  // --- stats count only the delayed calls, and how long they waited ---
+  {
+    let clock = 0;
+    const setTimer = mkTimer();
+    const bucket = createTokenBucket({ ratePerMin: 60, capacity: 1, now: () => clock, setTimer });
+
+    bucket.take(() => {});                // immediate — not delayed
+    bucket.take(() => {});                // queued
+    clock += 1_000;
+    setTimer.fireAll();
+
+    const s = bucket.stats();
+    if (s.delayed === 1 && s.waitedMs === 1_000) {
+      pass('stats report 1 delayed lookup waiting 1000ms');
+    } else {
+      fail(`stats wrong: delayed=${s.delayed} waitedMs=${s.waitedMs}`);
+    }
+  }
+
+  // --- a nonsense rate is a caller error, not a silent Infinity ---
+  {
+    const bad = [];
+    for (const rate of [0, -5, Number.NaN]) {
+      try { createTokenBucket({ ratePerMin: rate }); bad.push(rate); } catch (e) {
+        if (!(e instanceof RangeError)) bad.push(`${rate}:${e.constructor.name}`);
+      }
+    }
+    if (bad.length === 0) {
+      pass('createTokenBucket rejects a non-positive or non-finite rate with RangeError');
+    } else {
+      fail(`bad rates accepted or wrongly typed: ${bad.join(', ')}`);
+    }
+  }
+} catch (e) {
+  fail(`DNS pacing tests threw: ${e.message}`);
+}

--- a/tests/providers/dns-pacing.test.mjs
+++ b/tests/providers/dns-pacing.test.mjs
@@ -7,7 +7,7 @@ import { pathToFileURL } from 'url';
 console.log('\nProvider — DNS lookup pacing');
 
 try {
-  const { createTokenBucket } = await import(
+  const { createTokenBucket, createCachedLookup } = await import(
     pathToFileURL(join(ROOT, 'providers/_dns-cache.mjs')).href
   );
 
@@ -135,6 +135,88 @@ try {
       pass('a throwing callback does not strand the queue');
     } else {
       fail(`queue stranded: ran=[${ran.join(',')}]`);
+    }
+  }
+
+  const mkResolver = (result = [null, '93.184.216.34', 4]) => {
+    const calls = [];
+    const resolver = (hostname, opts, cb) => { calls.push({ hostname, opts, cb }); };
+    resolver.calls = calls;
+    resolver.flush = () => { for (const c of calls.splice(0)) c.cb(...result); };
+    return resolver;
+  };
+
+  const lookupOnce = (fn, hostname, opts = {}) =>
+    new Promise((resolve) => fn(hostname, opts, (...args) => resolve(args)));
+
+  // --- distinct hostnames are metered ---
+  {
+    let clock = 0;
+    const setTimer = mkTimer();
+    const resolver = mkResolver();
+    const lookup = createCachedLookup(resolver, {
+      lookupsPerMin: 60, burst: 2, now: () => clock, setTimer,
+    });
+
+    for (let i = 0; i < 5; i++) lookupOnce(lookup, `h${i}.example.com`);
+    const duringBurst = resolver.calls.length;
+
+    clock += 1_000;
+    setTimer.fireAll();
+    const afterRefill = resolver.calls.length;
+    resolver.flush();
+
+    if (duringBurst === 2 && afterRefill === 3) {
+      pass('5 distinct hostnames: 2 resolved on the burst, 1 more per refill');
+    } else {
+      fail(`hostname pacing wrong: duringBurst=${duringBurst} afterRefill=${afterRefill}`);
+    }
+  }
+
+  // --- coalesced waiters and cache hits are free ---
+  {
+    let clock = 0;
+    const setTimer = mkTimer();
+    const resolver = mkResolver();
+    const lookup = createCachedLookup(resolver, {
+      lookupsPerMin: 60, burst: 1, now: () => clock, setTimer,
+    });
+
+    // 20 concurrent callers, one hostname: only the leader reaches the
+    // resolver, so only the leader may spend the single available token.
+    const pending = Array.from({ length: 20 }, () => lookupOnce(lookup, 'one.example.com'));
+    const leaderOnly = resolver.calls.length === 1 && setTimer.pending() === 0;
+    resolver.flush();
+    await Promise.all(pending);
+
+    // And a warm cache hit must not queue behind the (now empty) bucket.
+    await lookupOnce(lookup, 'one.example.com');
+    const hitWasFree = resolver.calls.length === 0 && setTimer.pending() === 0;
+
+    if (leaderOnly && hitWasFree) {
+      pass('coalesced waiters and cache hits take no tokens — pacing tracks distinct hostnames');
+    } else {
+      fail(`token accounting wrong: leaderOnly=${leaderOnly} hitWasFree=${hitWasFree}`);
+    }
+  }
+
+  // --- pacing can be switched off entirely ---
+  {
+    let clock = 0;
+    const setTimer = mkTimer();
+    const resolver = mkResolver();
+    const lookup = createCachedLookup(resolver, {
+      lookupsPerMin: 0, now: () => clock, setTimer,
+    });
+
+    for (let i = 0; i < 50; i++) lookupOnce(lookup, `off${i}.example.com`);
+    const all = resolver.calls.length === 50 && setTimer.pending() === 0;
+    resolver.flush();
+
+    if (all) {
+      pass('lookupsPerMin: 0 disables pacing — every miss goes straight to the resolver');
+    } else {
+      fail(`disable wrong: calls=${resolver.calls.length} timers=${setTimer.pending()}`);
     }
   }
 } catch (e) {

--- a/tests/providers/dns-pacing.test.mjs
+++ b/tests/providers/dns-pacing.test.mjs
@@ -7,7 +7,7 @@ import { pathToFileURL } from 'url';
 console.log('\nProvider — DNS lookup pacing');
 
 try {
-  const { createTokenBucket, createCachedLookup } = await import(
+  const { createTokenBucket, createCachedLookup, lookupsPerMinFromEnv } = await import(
     pathToFileURL(join(ROOT, 'providers/_dns-cache.mjs')).href
   );
 
@@ -217,6 +217,45 @@ try {
       pass('lookupsPerMin: 0 disables pacing — every miss goes straight to the resolver');
     } else {
       fail(`disable wrong: calls=${resolver.calls.length} timers=${setTimer.pending()}`);
+    }
+  }
+
+  // --- env parsing: unset means the default, junk means the default, 0 means off ---
+  {
+    const seen = {
+      unset: lookupsPerMinFromEnv({}),
+      empty: lookupsPerMinFromEnv({ CAREER_OPS_DNS_LOOKUPS_PER_MIN: '' }),
+      set: lookupsPerMinFromEnv({ CAREER_OPS_DNS_LOOKUPS_PER_MIN: '120' }),
+      off: lookupsPerMinFromEnv({ CAREER_OPS_DNS_LOOKUPS_PER_MIN: '0' }),
+      junk: lookupsPerMinFromEnv({ CAREER_OPS_DNS_LOOKUPS_PER_MIN: 'fast' }),
+      negative: lookupsPerMinFromEnv({ CAREER_OPS_DNS_LOOKUPS_PER_MIN: '-1' }),
+    };
+
+    if (seen.unset === 400 && seen.empty === 400 && seen.set === 120
+        && seen.off === 0 && seen.junk === 400 && seen.negative === 400) {
+      pass('CAREER_OPS_DNS_LOOKUPS_PER_MIN parses, defaults to 400, and 0 disables');
+    } else {
+      fail(`env parsing wrong: ${JSON.stringify(seen)}`);
+    }
+  }
+
+  // --- pacing is on by default, with no options passed ---
+  {
+    let clock = 0;
+    const setTimer = mkTimer();
+    const resolver = mkResolver();
+    // Only the clock and timer are injected: rate and burst take their defaults.
+    const lookup = createCachedLookup(resolver, { now: () => clock, setTimer });
+
+    for (let i = 0; i < 25; i++) lookupOnce(lookup, `d${i}.example.com`);
+    const admitted = resolver.calls.length;
+    const queued = setTimer.pending() > 0;
+    resolver.flush();
+
+    if (admitted === 20 && queued) {
+      pass('pacing defaults to on — 25 hostnames admit the 20-token burst and queue the rest');
+    } else {
+      fail(`default pacing wrong: admitted=${admitted} queued=${queued}`);
     }
   }
 } catch (e) {

--- a/tests/providers/dns-pacing.test.mjs
+++ b/tests/providers/dns-pacing.test.mjs
@@ -101,6 +101,42 @@ try {
       fail(`bad rates accepted or wrongly typed: ${bad.join(', ')}`);
     }
   }
+
+  // --- a throwing callback does not strand the queue ---
+  {
+    let clock = 0;
+    const setTimer = mkTimer();
+    const bucket = createTokenBucket({ ratePerMin: 60, capacity: 1, now: () => clock, setTimer });
+
+    // Drain the bucket so the next calls queue.
+    bucket.take(() => {});
+    const ran = [];
+    const thrower = () => { throw new Error('test error'); };
+    bucket.take(thrower);         // First queued: will throw
+    bucket.take(() => ran.push(1)); // Second queued
+    bucket.take(() => ran.push(2)); // Third queued
+
+    // Advance clock and fire timers. The first callback throws, but schedule()
+    // must still be called (via finally block) to arm the next timer. We wrap
+    // fireAll in try/catch so the error is contained and doesn't break the test.
+    clock += 1_000;
+    try { setTimer.fireAll(); } catch (e) { /* Expected: thrower throws. */ }
+
+    // Second callback should have run during the first pump(). Advance again
+    // for the third callback.
+    clock += 1_000;
+    try { setTimer.fireAll(); } catch (e) { /* Expected: should not throw again. */ }
+
+    // Third callback runs in this pump.
+    clock += 1_000;
+    try { setTimer.fireAll(); } catch (e) { /* should not happen */ }
+
+    if (ran.join(',') === '1,2') {
+      pass('a throwing callback does not strand the queue');
+    } else {
+      fail(`queue stranded: ran=[${ran.join(',')}]`);
+    }
+  }
 } catch (e) {
   fail(`DNS pacing tests threw: ${e.message}`);
 }

--- a/tests/providers/dns-pacing.test.mjs
+++ b/tests/providers/dns-pacing.test.mjs
@@ -200,6 +200,44 @@ try {
     }
   }
 
+  // --- a negative-cached refusal is free too ---
+  // Guards the seam between negative caching (#2229 resolver refusals) and
+  // pacing: both landed separately, so nothing covered them together. A
+  // refusal held in the negative cache is answered from memory and never
+  // reaches the resolver, so it must not wait on a token either — otherwise a
+  // drained bucket would stall the very retry storm the negative cache exists
+  // to absorb.
+  {
+    let clock = 0;
+    const setTimer = mkTimer();
+    const refusal = Object.assign(new Error('refused'), { code: 'EREFUSED' });
+    const resolver = mkResolver([refusal]);
+    const lookup = createCachedLookup(resolver, {
+      lookupsPerMin: 60, burst: 1, now: () => clock, setTimer,
+    });
+
+    // The leader spends the only token and is refused; the refusal is cached.
+    const first = lookupOnce(lookup, 'refused.example.com');
+    resolver.flush();
+    const [firstErr] = await first;
+
+    // Bucket is now empty. Deliver via callback rather than await: if the hit
+    // wrongly queued for a token it would never settle, and this must fail
+    // rather than hang.
+    let settled = false;
+    let secondErr = null;
+    lookup('refused.example.com', {}, (e) => { settled = true; secondErr = e; });
+    await new Promise((r) => setImmediate(r));
+
+    const free = settled && resolver.calls.length === 0 && setTimer.pending() === 0;
+    if (free && firstErr?.code === 'EREFUSED' && secondErr?.code === 'EREFUSED') {
+      pass('a negative-cached refusal is served without spending a pacing token');
+    } else {
+      fail(`negative-cache hit not free: settled=${settled} calls=${resolver.calls.length} `
+        + `pending=${setTimer.pending()} first=${firstErr?.code} second=${secondErr?.code}`);
+    }
+  }
+
   // --- pacing can be switched off entirely ---
   {
     let clock = 0;

--- a/tests/providers/dns-pacing.test.mjs
+++ b/tests/providers/dns-pacing.test.mjs
@@ -122,8 +122,8 @@ try {
     clock += 1_000;
     try { setTimer.fireAll(); } catch (e) { /* Expected: thrower throws. */ }
 
-    // Second callback should have run during the first pump(). Advance again
-    // for the third callback.
+    // The thrower spent that token, so nothing else ran in the first pump.
+    // Each later refill releases exactly one queued callback.
     clock += 1_000;
     try { setTimer.fireAll(); } catch (e) { /* Expected: should not throw again. */ }
 


### PR DESCRIPTION
# Pace DNS lookups so a full sweep can't trip a resolver's rate limit

Implements #2229, **proposed fix 2 only**. Fixes 1 (negative-caching resolver refusals) and 3 (circuit breaker) ship as their own PR, as offered in the issue — the pacing default deserves its own discussion, and this is that discussion.

## The tradeoff, up front

**Pacing is on by default, and it costs roughly 35 minutes on a full Workday + iCIMS sweep.**

That is the part worth rejecting if you disagree, so it is easy to reject:

- `CAREER_OPS_DNS_LOOKUPS_PER_MIN=0` restores today's behaviour exactly (cache still on).
- Changing the default is a one-line edit to `DEFAULT_LOOKUPS_PER_MIN` in `providers/_dns-cache.mjs`.

I defaulted it **on** because an opt-in knob leaves every user behind a rate-limiting resolver with the same failure they can't diagnose: the sweep reports thousands of `fetch failed` lines that look like dead boards, while the actual cause is the local resolver refusing queries for the whole machine.

## Why the gate sits on the miss path, after coalescing

The merged in-process cache (#2155) collapses *repeat* lookups of one hostname. That is total for the single-host providers and structurally inert for the per-tenant-host ones:

| Provider | Boards | Distinct hostnames |
|---|---:|---:|
| greenhouse + lever + ashby | 15,862 | **3** |
| workday | 12,884 | **3,781** |
| icims | 10,108 | **10,108** |

Those 13,892 Workday + iCIMS lookups are irreducible — every hostname is genuinely distinct, so there is nothing left to deduplicate. The only remaining lever is *how fast they are issued*.

So the token bucket gates exactly one path: a cache miss that is not already coalesced onto an in-flight lookup. Cache hits and coalesced waiters never spend a token. Pacing is therefore proportional to **distinct hostnames**, not request volume — Greenhouse's 8,333 boards still cost one lookup and are never slowed.

## Lookups vs. upstream queries

The ceiling counts **lookups**, not upstream queries. Node ≥ 20 defaults `autoSelectFamily` to true, so undici calls `dns.lookup(host, { all: true })` and the resolver answers A **and** AAAA — one lookup costs the resolver two queries.

Default **400 lookups/min ≈ 800 upstream queries/min**, under a stock Pi-hole's 1,000/min with headroom for the rest of the machine. The env var, the docs and the summary line all say "lookups" so 400 is never misread as 400 queries.

## Details

- **Burst = 20 = `CONCURRENCY`** in `scan-ats-full.mjs`, so a cold start of 20 workers is admitted at once and small runs against a handful of hostnames are never slowed. Pacing only bites on a sustained sweep.
- **`CAREER_OPS_NO_DNS_CACHE=1` now disables pacing too**, since both live inside the patched `dns.lookup`. That is a foot-gun otherwise — an operator disabling the "cache" to debug would silently drop the rate limit — so it is called out in both the module header and `docs/SCRIPTS.md`.
- **The pacing timer is never `unref()`d.** A queued lookup is work a caller is awaiting; an unref'd timer would let the process exit with the callback unfired. Same reasoning `dns-cache.test.mjs` already carries for its own timer.
- **Unparseable env values warn and fall back** rather than throwing — this runs at import time inside every scanner, and a typo must not take the whole run down.
- **No new dependencies.** `package.json` is untouched.
- Clock and timer are injectable, so every pacing test is deterministic and offline — no real waiting, no network.

## Tests

`node test-all.mjs --quick`:

- Baseline at `06da05c6` before any change: **2343 passed, 0 failed, 2 warnings**
- After: **2353 passed, 0 failed, 2 warnings** (10 new assertions in `tests/providers/dns-pacing.test.mjs`)

The 2 warnings are pre-existing and unrelated (`workday: InvalidCo truncated at max_pages=100` from the provider suite).

New coverage: burst-then-FIFO release, idle refill capped at capacity, `stats()` accounting, `RangeError` on a non-positive rate, a throwing callback not stranding the queue, distinct hostnames metered, coalesced waiters and cache hits taking no tokens, `lookupsPerMin: 0` disabling, env parsing, and the on-by-default behaviour (so the default can't drift silently).

## Sweep reporting

`scan-ats-full.mjs` now reports what pacing cost, on **both** surfaces — the text summary and the `--json` payload:

```
Companies scanned:  70 of 12884 (capped)
DNS pacing:         1 lookup delayed, 59s total wait (CAREER_OPS_DNS_LOOKUPS_PER_MIN to tune, 0 disables)
```

```json
"dnsPacing": { "delayed": 1, "waitedMs": 58548 }
```

Both, deliberately: on #2141 CodeRabbit caught `cappedBoards` being logged to the text summary but missing from `--json`. The line is suppressed entirely when nothing was delayed, so an unpaced or small run stays quiet.

This was verified live, not just in unit tests: `CAREER_OPS_DNS_LOOKUPS_PER_MIN=1 node scan-ats-full.mjs --ats workday --limit 70 --since 1 --dry-run --json`. Worth noting for anyone reproducing it — at `--limit 30` the sweep only issues **11** distinct lookups (the rest of the companies are filtered before any fetch), which is under the burst of 20, so pacing correctly does nothing and `delayed` stays 0. You need enough companies to clear the burst before the ceiling is observable.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced DNS pacing for high-volume full scans to reduce resolver rate-limit noise (default: 400 DNS lookups/min) with burst control.
  * Added end-of-run DNS pacing diagnostics and a new `dnsPacing: { delayed, waitedMs }` field in `--json` output.
  * DNS caching remains active unless explicitly disabled, and pacing can be turned off via configuration.
* **Documentation**
  * Documented DNS pacing behavior, expected DNS-bound timing, and environment tuning options (including how pacing interacts with caching).
* **Tests**
  * Added deterministic coverage for pacing, caching/coalescing behavior, environment parsing, and pacing statistics reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->