### PR TITLE
Negative-cache resolver refusals and stop a sweep when DNS starts failing

### DIFF
--- a/providers/_dns-cache.mjs
+++ b/providers/_dns-cache.mjs
@@ -83,6 +83,10 @@ export function isResolverFailure(err) {
 
 const DEFAULT_TTL_MS = 5 * 60_000;
 const DEFAULT_MAX_ENTRIES = 512;
+// Short by design: long enough to break the retry storm that a refusing
+// resolver otherwise feeds (see #2229), short enough that a resolver coming
+// back is picked up almost immediately.
+const DEFAULT_NEGATIVE_TTL_MS = 30_000;
 
 /**
  * Build a caching wrapper around a callback-style `dns.lookup`.
@@ -99,6 +103,7 @@ const DEFAULT_MAX_ENTRIES = 512;
  */
 export function createCachedLookup(realLookup, options = {}) {
   const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const negativeTtlMs = options.negativeTtlMs ?? DEFAULT_NEGATIVE_TTL_MS;
   const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
   const now = options.now ?? Date.now;
 
@@ -139,13 +144,18 @@ export function createCachedLookup(realLookup, options = {}) {
       const callbacks = inflight.get(key) ?? [];
       inflight.delete(key);
 
-      // Never cache failures — a transient resolver blip must not be pinned
-      // in for the whole TTL window.
-      if (!err) {
+      // Successes cache for the full TTL. Resolver-level refusals cache for a
+      // much shorter one: not caching them at all is what turns a rate-limited
+      // resolver into a self-sustaining flood, because every worker retries a
+      // refusal that costs the resolver another query to reject (#2229).
+      // Everything else — NXDOMAIN above all — stays uncached as before, so a
+      // transient blip is never pinned in for the whole TTL window.
+      const ttl = err ? (isResolverFailure(err) ? negativeTtlMs : 0) : ttlMs;
+      if (ttl > 0) {
         // Oldest-first eviction; insertion order is good enough for a cap
         // this size, and avoids tracking per-entry access times.
         if (cache.size >= maxEntries) cache.delete(cache.keys().next().value);
-        cache.set(key, { expires: now() + ttlMs, args: [null, ...rest] });
+        cache.set(key, { expires: now() + ttl, args: err ? [err] : [null, ...rest] });
       }
 
       for (const cb of callbacks) cb(err, ...rest);

--- a/providers/_dns-cache.mjs
+++ b/providers/_dns-cache.mjs
@@ -47,6 +47,40 @@
 
 import dns from 'node:dns';
 
+/**
+ * DNS failures that mean *the resolver itself refused or failed*, as opposed
+ * to answering "no such host". Only these are safe to negative-cache and to
+ * treat as a resolver-health signal.
+ *
+ * ENOTFOUND is deliberately absent: it is NXDOMAIN, a legitimate per-host
+ * answer that must stay uncached so a tenant appearing later is picked up.
+ * ETIMEOUT is also absent: a query timeout is ambiguous between a slow
+ * resolver and a refusing one, and #2229 scoped this to refusals.
+ */
+export const RESOLVER_FAILURE_CODES = new Set([
+  'ENOTIMP',    // dns.NOTIMP   — what a rate-limiting Pi-hole replies with
+  'EREFUSED',   // dns.REFUSED  — resolver refused the query outright
+  'ESERVFAIL',  // dns.SERVFAIL — resolver failed to produce an answer
+  'EAI_AGAIN',  // getaddrinfo temporary failure
+]);
+
+/**
+ * Is this error (or anything it wraps) a resolver-level failure?
+ *
+ * Walks the `cause` chain because Node's `fetch()` reports every transport
+ * error as `TypeError: fetch failed` and hangs the real error off `.cause`.
+ * The walk is depth-bounded so a self-referential cause can't spin.
+ *
+ * @param {unknown} err - Error to inspect.
+ * @returns {boolean} True when a resolver refusal/failure code is present.
+ */
+export function isResolverFailure(err) {
+  for (let e = err, depth = 0; e && typeof e === 'object' && depth < 5; e = e.cause, depth++) {
+    if (RESOLVER_FAILURE_CODES.has(/** @type {any} */ (e).code)) return true;
+  }
+  return false;
+}
+
 const DEFAULT_TTL_MS = 5 * 60_000;
 const DEFAULT_MAX_ENTRIES = 512;
 

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -37,6 +37,7 @@ import path from 'path';
 import yaml from 'js-yaml';
 
 import { makeHttpCtx, fetchJson } from './providers/_http.mjs';
+import { isResolverFailure } from './providers/_dns-cache.mjs';
 import greenhouse from './providers/greenhouse.mjs';
 import lever from './providers/lever.mjs';
 import ashby from './providers/ashby.mjs';
@@ -60,6 +61,11 @@ const CACHE_TTL_HOURS = 24;
 // so a tampered dataset can at worst name boards that don't exist.
 const DATASET_BASE = 'https://raw.githubusercontent.com/Feashliaa/job-board-aggregator/main/data';
 const CONCURRENCY = 20;
+// A refusing resolver fails every lookup in milliseconds, so a sweep that
+// keeps going just feeds it (#2229). Stop after this many consecutive
+// resolver-level failures — high enough that a handful of unlucky boards
+// can't trip it, low enough to stop within seconds of a real outage.
+const RESOLVER_FAILURE_LIMIT = 50;
 
 // Crash insurance for multi-hour directory sweeps: progress + matches are
 // checkpointed every CHECKPOINT_EVERY companies so --resume can continue a
@@ -503,12 +509,15 @@ export function withTimeout(promise, ms, label) {
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
-export async function parallelEach(items, limit, fn, onItemDone = null) {
+export async function parallelEach(items, limit, fn, onItemDone = null, shouldStop = null) {
   let next = 0;
   let done = 0;
   const inFlight = new Set();
   async function worker() {
     while (next < items.length) {
+      // Checked before claiming an index, so a stopped run leaves `next` where
+      // the unclaimed work starts and onItemDone's resumeAt stays truthful.
+      if (shouldStop && shouldStop()) return;
       const idx = next++;
       inFlight.add(idx);
       try {
@@ -740,6 +749,8 @@ async function main() {
     log(`\n⚙  ${name} — ${entriesAll.length} companies${status !== 'ok' ? ` (dataset: ${status})` : ''}${startAt ? ` — resuming at ${startAt}` : ''}`);
 
     let errors = 0;
+    let consecutiveResolverFailures = 0;
+    let resolverOutage = false;
     const truncated = [];
     await parallelEach(entries, CONCURRENCY, async (entry) => {
       try {
@@ -748,6 +759,7 @@ async function main() {
         // one watchdog, so enrichment latency can't blow past COMPANY_TIMEOUT_MS.
         await withTimeout((async () => {
           const jobs = await source.provider.fetch(entry, ctx);
+          consecutiveResolverFailures = 0;
           if (jobs.workdayTruncated) truncated.push(entry);
           if (jobs.icimsTruncated) {
             cappedBoards++;
@@ -760,6 +772,14 @@ async function main() {
         // Mostly defunct boards in the public dataset — expected noise, so the
         // default stays quiet; --verbose surfaces per-board failures.
         errors++;
+        // A dead board and a dead resolver look identical one at a time; only
+        // the *consecutive* run tells them apart, so any non-resolver outcome
+        // resets the count (#2229).
+        if (isResolverFailure(err)) {
+          if (++consecutiveResolverFailures >= RESOLVER_FAILURE_LIMIT) resolverOutage = true;
+        } else {
+          consecutiveResolverFailures = 0;
+        }
         if (opts.verbose) console.error(`  ✗ ${name}/${entry.name}: ${err.message}`);
       }
     }, ({ done, resumeAt }) => {
@@ -781,11 +801,13 @@ async function main() {
           },
         });
       }
-    });
+    }, () => resolverOutage);
     // Second chance for boards the parallel sweep truncated: retry alone on a
     // quiet line. Re-processing the full board is safe — seenUrls already
     // holds every match from the partial first pass.
-    if (truncated.length) {
+    // Skipped entirely under a resolver outage: retrying boards one by one is
+    // more of exactly the traffic the breaker just stopped.
+    if (truncated.length && !resolverOutage) {
       log(`\n  ↻ retrying ${truncated.length} truncated board(s) sequentially...`);
       for (const entry of truncated) {
         try {
@@ -804,6 +826,15 @@ async function main() {
       }
     }
     totalErrors += errors;
+    if (resolverOutage) {
+      // Deliberately before completedSources/checkpoint: this source did NOT
+      // finish, and marking it done would make --resume skip the rest of it.
+      log(`\n  ⛔ stopped ${name}: ${RESOLVER_FAILURE_LIMIT} consecutive DNS failures.`);
+      log(`     Your resolver is refusing queries — it may be rate-limiting this host.`);
+      log(`     Lower CONCURRENCY, raise the resolver's per-client limit, or set`);
+      log(`     CAREER_OPS_NO_DNS_CACHE=1 only if you know the cache is at fault.`);
+      break;
+    }
     completedSources.add(name);
     if (!opts.dryRun) {
       writeCheckpoint({ ...checkpointBase(), current: null, counters: snapshotCounters() });

--- a/tests/providers/dns-cache.test.mjs
+++ b/tests/providers/dns-cache.test.mjs
@@ -7,7 +7,7 @@ import { pathToFileURL } from 'url';
 console.log('\nProvider — DNS cache');
 
 try {
-  const { createCachedLookup } = await import(
+  const { createCachedLookup, isResolverFailure } = await import(
     pathToFileURL(join(ROOT, 'providers/_dns-cache.mjs')).href
   );
 
@@ -145,6 +145,28 @@ try {
       fail(`option variants collapsed into ${resolver.calls.length} key(s), expected 3`);
     }
     resolver.flush();
+  }
+
+  // --- resolver-level failures are told apart from NXDOMAIN ---
+  {
+    const refused = Object.assign(new Error('queryA EREFUSED'), { code: 'EREFUSED' });
+    const nxdomain = Object.assign(new Error('getaddrinfo ENOTFOUND x'), { code: 'ENOTFOUND' });
+    // Node's fetch() wraps the real error: TypeError('fetch failed') with .cause.
+    const wrapped = Object.assign(new TypeError('fetch failed'), { cause: refused });
+
+    const results = [
+      isResolverFailure(refused),
+      isResolverFailure(wrapped),
+      isResolverFailure(nxdomain),
+      isResolverFailure(new Error('plain')),
+      isResolverFailure(null),
+    ];
+
+    if (JSON.stringify(results) === JSON.stringify([true, true, false, false, false])) {
+      pass('isResolverFailure detects refusals through a cause chain, ignores NXDOMAIN');
+    } else {
+      fail(`isResolverFailure wrong: got ${JSON.stringify(results)}`);
+    }
   }
 
   // --- the module-level patch is opt-out-able ---

--- a/tests/providers/dns-cache.test.mjs
+++ b/tests/providers/dns-cache.test.mjs
@@ -169,6 +169,37 @@ try {
     }
   }
 
+  // --- a resolver refusal is cached briefly, then retried ---
+  {
+    const refused = Object.assign(new Error('queryA EREFUSED'), { code: 'EREFUSED' });
+    const resolver = mkResolver([refused]);
+    let clock = 1_000;
+    const lookup = createCachedLookup(resolver, { negativeTtlMs: 30_000, now: () => clock });
+
+    const first = lookupOnce(lookup, 'refused.example.com');
+    resolver.flush();
+    const [firstErr] = await first;
+
+    // Check the resolver was skipped BEFORE awaiting: a miss would queue on the
+    // stub and never settle, hanging the suite instead of failing it.
+    const secondCall = lookupOnce(lookup, 'refused.example.com');
+    const skippedResolver = resolver.calls.length === 0;
+    if (!skippedResolver) resolver.flush();          // don't strand the promise
+    const second = await secondCall;
+    const servedFromCache = skippedResolver && second[0] && second[0].code === 'EREFUSED';
+
+    clock += 30_001;                       // past the negative window
+    lookupOnce(lookup, 'refused.example.com');
+    const retried = resolver.calls.length === 1;
+    resolver.flush();
+
+    if (firstErr && firstErr.code === 'EREFUSED' && servedFromCache && retried) {
+      pass('a resolver refusal is served from the negative cache, then retried past its TTL');
+    } else {
+      fail(`negative cache wrong: served=${servedFromCache} retried=${retried}`);
+    }
+  }
+
   // --- the module-level patch is opt-out-able ---
   {
     const probe = [

--- a/tests/providers/scan-resolver-breaker.test.mjs
+++ b/tests/providers/scan-resolver-breaker.test.mjs
@@ -1,0 +1,86 @@
+// tests/providers/scan-resolver-breaker.test.mjs — parallelEach honors an
+// abort predicate, so a resolver outage can stop a sweep instead of feeding it.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nScan — resolver circuit breaker');
+
+try {
+  const { parallelEach } = await import(
+    pathToFileURL(join(ROOT, 'scan-ats-full.mjs')).href
+  );
+
+  // --- parallelEach stops pulling work once shouldStop flips ---
+  {
+    const items = Array.from({ length: 500 }, (_, i) => i);
+    const processed = [];
+    let stop = false;
+
+    await parallelEach(items, 20, async (item) => {
+      processed.push(item);
+      if (processed.length >= 40) stop = true;
+    }, null, () => stop);
+
+    // Workers already in flight may finish their current item, so allow the
+    // in-flight batch to land — but nothing like the full 500.
+    if (processed.length >= 40 && processed.length < 100) {
+      pass(`parallelEach stopped early on shouldStop (${processed.length}/500 processed)`);
+    } else {
+      fail(`parallelEach processed ${processed.length}/500 — expected an early stop`);
+    }
+  }
+
+  // --- absent predicate keeps the old behaviour ---
+  {
+    const items = Array.from({ length: 50 }, (_, i) => i);
+    let count = 0;
+    await parallelEach(items, 5, async () => { count++; });
+
+    if (count === 50) {
+      pass('parallelEach without a predicate still processes every item');
+    } else {
+      fail(`parallelEach processed ${count}/50 without a predicate`);
+    }
+  }
+
+  // --- the checkpoint callback still fires, and still reports resumeAt ---
+  // parallelEach already carried a 4th argument (onItemDone) driving
+  // checkpoint/--resume. shouldStop is a 5th, so that contract is unchanged.
+  {
+    const items = Array.from({ length: 30 }, (_, i) => i);
+    const seen = [];
+    await parallelEach(items, 4, async () => {}, ({ done, resumeAt }) => {
+      seen.push({ done, resumeAt });
+    });
+
+    const monotonic = seen.every((s, i) => i === 0 || s.done === seen[i - 1].done + 1);
+    if (seen.length === 30 && monotonic && seen[29].resumeAt === 30) {
+      pass('onItemDone still fires once per item with a monotonic done count and final resumeAt');
+    } else {
+      fail(`onItemDone contract broken: n=${seen.length} monotonic=${monotonic} last=${JSON.stringify(seen[seen.length - 1])}`);
+    }
+  }
+
+  // --- a stopped run still reports progress, so --resume stays correct ---
+  {
+    const items = Array.from({ length: 200 }, (_, i) => i);
+    let processed = 0;
+    let stop = false;
+    let lastResumeAt = -1;
+
+    await parallelEach(items, 10, async () => {
+      processed++;
+      if (processed >= 25) stop = true;
+    }, ({ resumeAt }) => { lastResumeAt = resumeAt; }, () => stop);
+
+    // Everything below resumeAt finished, so resuming there loses no work.
+    if (lastResumeAt > 0 && lastResumeAt <= processed) {
+      pass(`a stopped sweep still reports a usable resumeAt (${lastResumeAt} <= ${processed} processed)`);
+    } else {
+      fail(`resumeAt unusable after stop: resumeAt=${lastResumeAt} processed=${processed}`);
+    }
+  }
+} catch (e) {
+  fail(`resolver breaker tests threw: ${e.message}`);
+}


### PR DESCRIPTION
# Stop a rate-limited resolver from being amplified into a self-sustaining DNS flood

Implements #2229, **proposed fixes 1 and 3**. Fix 2 (token-bucket pacing) is #2264 — separate, as offered in the issue, and neither depends on the other.

## The failure this fixes

A refusing resolver fails a lookup in about a millisecond. The in-process cache from #2155 deliberately never caches failures, so under a *sustained* refusal that inverts: 20 workers retry a refusal that costs the resolver another query to reject, forever. Measured during the incident behind #2229 — a Pi-hole logged 4,637–6,152 attempted queries/minute for 39 minutes against a universe of 3,784 hostnames, of which only 1,362 ever got through.

The sweep meanwhile reports thousands of `fetch failed` lines that look like dead boards. The diagnosis is wrong in the most expensive direction: the boards are fine, the resolver is refusing.

Two changes, sharing one definition:

1. **Negative-cache resolver refusals** for 30s, which breaks the retry loop.
2. **Circuit-break the sweep** after 50 consecutive resolver-level failures, so it stops and says what's actually wrong.

## One predicate, two consumers

`isResolverFailure` is exported from `providers/_dns-cache.mjs` and used by both the cache and the sweep, so the two can't drift on what counts as a resolver failure. It walks the `cause` chain, because Node's `fetch()` reports every transport error as `TypeError: fetch failed` with the real error hung off `.cause`. The walk is depth-bounded so a self-referential cause can't spin.

**Naming correction vs. the issue text:** #2229 says "REFUSED / SERVFAIL". The actual runtime values are `E`-prefixed — `dns.REFUSED === 'EREFUSED'`. The code uses the runtime values; flagging it so the mismatch with the issue doesn't read as a bug.

Covered: `ENOTIMP` (what a rate-limiting Pi-hole actually replies with), `EREFUSED`, `ESERVFAIL`, `EAI_AGAIN`.

**`ENOTFOUND` is deliberately excluded.** It is NXDOMAIN — "this tenant does not exist" — a legitimate per-host answer, not a resolver refusal. Caching it would pin a tenant as nonexistent for the window even after it appears. The pre-existing assertion `a failed resolution is not cached` uses `ENOTFOUND` and is **unmodified** by this PR; it is the guardrail against ever conflating the two categories, and it still passes.

**`ETIMEOUT` is also excluded.** A query timeout is ambiguous between a slow resolver and a refusing one, and #2229 scoped this to refusals. Noted in a code comment so it reads as a decision rather than an oversight.

## The breaker

`parallelEach` gains an optional `shouldStop` predicate, checked before a worker claims its next index. When it flips, workers stop pulling work and the call resolves.

**This is a 5th parameter, not a 4th.** `parallelEach` already carries `onItemDone` in position 4, driving checkpoint/`--resume`. Appending `shouldStop` after it leaves that contract untouched, and two of the new tests pin it down: `onItemDone` still fires once per item with a monotonic `done`, and a *stopped* run still reports a usable `resumeAt` — everything below it finished, so resuming there loses no work. Checking the predicate before claiming an index is what keeps `resumeAt` truthful.

Two things the breaker deliberately does **not** do when it trips:

- It does not run the sequential retry pass for truncated boards. Retrying them one at a time is more of exactly the traffic the breaker just stopped.
- It does not add the source to `completedSources` or write a "finished" checkpoint. The source did not finish; marking it done would make `--resume` skip the rest of it.

Output on trip:

```
  ⛔ stopped workday: 50 consecutive DNS failures.
     Your resolver is refusing queries — it may be rate-limiting this host.
     Lower CONCURRENCY, raise the resolver's per-client limit, or set
     CAREER_OPS_NO_DNS_CACHE=1 only if you know the cache is at fault.
```

A dead board and a dead resolver look identical one at a time — only the *consecutive* run tells them apart, so any non-resolver outcome (including a successful fetch) resets the counter. 50 is high enough that a handful of unlucky boards can't trip it and low enough to stop within seconds of a real outage.

## Verification

`node test-all.mjs --quick`:

- Baseline at `06da05c6` before any change: **2343 passed, 0 failed, 2 warnings**
- After: **2349 passed, 0 failed, 2 warnings** (6 new assertions)

The 2 warnings are pre-existing and unrelated (`workday: InvalidCo truncated at max_pages=100`).

Beyond the unit tests, the wiring was exercised against a real sweep:

- `--ats workday --limit 40 --since 1 --dry-run` completes normally, 40/40 scanned with 3 unreachable boards — non-resolver failures correctly do **not** trip the breaker.
- With `RESOLVER_FAILURE_LIMIT` temporarily lowered and the predicate forced true, the same sweep aborts early and prints the diagnosis above. That patch was reverted; it exists only as evidence the wired path fires, since the counting lives inside `main()` and isn't unit-reachable.

No new dependencies; `package.json` untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of DNS resolver failures by temporarily caching eligible failures and retrying after the configured interval.
  * Prevented unnecessary repeated DNS requests during resolver outages.
  * Reverse ATS scans now stop early when widespread resolver failures are detected, avoiding extended unsuccessful scans.

* **Reliability**
  * Scans preserve progress and can resume consistently after an outage-related interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->