### PR TITLE
fix(tracker): a data row containing `---` is invisible to merge-tracker dedup

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -21,7 +21,7 @@ import { execFileSync } from 'child_process';
 import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
 import { parsePdfIndex } from './find.mjs';
-import { LEGACY_COLMAP, detectColumns, resolveScoreStatus, normalizeVia } from './tracker-parse.mjs';
+import { LEGACY_COLMAP, detectColumns, resolveScoreStatus, normalizeVia, SEPARATOR_ROW_RE } from './tracker-parse.mjs';
 import { resolveTrackerPath, trackerLockDirFor, acquireTrackerLock, writeFileAtomic, normalizeCompany, cell } from './tracker-utils.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
@@ -520,25 +520,31 @@ const existingApps = [];
 let maxNum = 0;
 
 for (const line of appLines) {
-  if (line.startsWith('|') && !line.includes('---') && !line.includes('Empresa')) {
-    const app = parseAppLine(line);
-    if (app) {
-      existingApps.push(app);
-      if (app.num > maxNum) maxNum = app.num;
-    }
+  // Skip only on the NaN check inside parseAppLine, which already rejects the
+  // header and separator rows because neither has a numeric `#` cell. The old
+  // `.includes('---') / .includes('Empresa')` heuristic was redundant for those
+  // two rows and wrong for data rows: any row whose free text contained three
+  // hyphens (a URL slug such as `Senior-Engineer---Platform-Team`, an em
+  // dash typed as `---`) or the word "Empresa" (a Spanish-market company name)
+  // never reached existingApps, so duplicate detection could not see it and a
+  // re-evaluation of that role appended a second row instead of updating it in
+  // place. #1704 fixed the numbering half of this with the usedNumbers pass
+  // below; this is the dedup half (#2265).
+  if (!line.startsWith('|')) continue;
+  const app = parseAppLine(line);
+  if (app) {
+    existingApps.push(app);
+    if (app.num > maxNum) maxNum = app.num;
   }
 }
 
-// Full set of numbers already on the tracker (#1704). This is a separate,
-// deliberately narrower pass than the existingApps loop above: it reads only
-// the numeric # cell and skips a row via the same NaN check verify-pipeline.mjs
-// uses, instead of the `.includes('---') / .includes('Empresa')` heuristic —
-// so a company or role field that happens to CONTAIN "Empresa" or "---" (e.g.
-// a Spanish-market company name, or an em-dash-style separator in a title)
-// can't hide that row's number the way it can hide the row from existingApps
-// (which stays as-is; it drives duplicate detection, not numbering). Used
-// below so a new entry's number is checked against every number actually on
-// the tracker, not just the largest one the existingApps loop happened to see.
+// Full set of numbers already on the tracker (#1704). Deliberately broader than
+// the existingApps loop above: it reserves the number from any row with a
+// numeric # cell, including a row too malformed for parseAppLine to return.
+// Such a row can't participate in duplicate detection, but its number is still
+// taken and must never be handed out again. Used below so a new entry's number
+// is checked against every number actually on the tracker, not just the largest
+// one the existingApps loop saw.
 const usedNumbers = new Set();
 const MAX_COL_IDX = Math.max(...Object.values(COLMAP));
 for (const line of appLines) {
@@ -730,10 +736,12 @@ for (const file of tsvFiles) {
 
 // Insert new lines after the header (line index of first data row)
 if (newLines.length > 0) {
-  // Find header separator (|---|...) and insert after it
+  // Find header separator (|---|...) and insert after it. Match the row's
+  // structure rather than a bare `---` substring, so a data row carrying three
+  // hyphens in its free text can never be mistaken for the separator.
   let insertIdx = -1;
   for (let i = 0; i < appLines.length; i++) {
-    if (appLines[i].includes('---') && appLines[i].startsWith('|')) {
+    if (SEPARATOR_ROW_RE.test(appLines[i])) {
       insertIdx = i + 1;
       break;
     }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6967,6 +6967,121 @@ try {
   fail(`merge-tracker reserved-number fidelity test crashed: ${e.message}`);
 }
 
+// ── DEDUP BLINDNESS FROM `---` / "Empresa" IN A DATA ROW (#2265) ─────────
+// Readers recognized the markdown separator row with `line.includes('---')`,
+// which also matched any DATA row whose free text contained three hyphens — a
+// URL slug like `Senior-Engineer---Platform-Team`, an em dash typed as
+// `---` — or, via the sibling `.includes('Empresa')` guard, a Spanish-market
+// company name. Such a row never reached `existingApps`, so it was invisible to
+// duplicate detection: re-evaluating that exact role appended a second row
+// instead of updating the first in place.
+//
+// #1704 fixed the NUMBERING half of this (the separate usedNumbers pass, so the
+// hidden row's number is never reissued) and deliberately left `existingApps`
+// alone. This covers the dedup half, and pins the row-format check that shares
+// the same heuristic.
+console.log('\n🧪 Testing dedup blindness from `---` / "Empresa" in a data row...');
+try {
+  const hyphenTmp = mkdtempSync(join(tmpdir(), 'career-ops-dedup-hyphen-'));
+  try {
+    const hData = join(hyphenTmp, 'data');
+    const hReports = join(hyphenTmp, 'reports');
+    const hAdditions = join(hyphenTmp, 'additions');
+    mkdirSync(hData);
+    mkdirSync(hReports);
+    mkdirSync(hAdditions);
+
+    const hTracker = join(hData, 'applications.md');
+    const hHeader =
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n';
+    // Row #2 hides behind `---` (URL slug); row #1 hides behind "Empresa"
+    // (a Spanish company name). Both must be visible to dedup.
+    const hRows =
+      '| 2 | 2026-01-05 | Acme Corp | Director, Data Platform | 4.3/5 | Evaluated | ❌ | ' +
+      '[2](../reports/002-acme-corp-2026-01-05.md) | URL slug says Senior-Engineer---Platform-Team. |\n' +
+      '| 1 | 2026-01-05 | Empresa Ejemplo | Data Lead | 3.9/5 | Evaluated | ❌ | ' +
+      '[1](../reports/001-empresa-ejemplo-2026-01-05.md) | Madrid hybrid. |\n';
+    writeFileSync(hTracker, hHeader + hRows);
+    for (const r of ['002-acme-corp-2026-01-05.md', '001-empresa-ejemplo-2026-01-05.md']) {
+      writeFileSync(join(hReports, r), '# fixture\n');
+    }
+
+    // Re-evaluation of BOTH existing roles at a higher score. Correct behavior
+    // is two in-place updates and zero new rows.
+    writeFileSync(join(hAdditions, '002-acme-corp.tsv'),
+      '2\t2026-01-06\tAcme Corp\tDirector, Data Platform\tEvaluated\t4.8/5\t❌\t' +
+      '[2](reports/002-acme-corp-2026-01-05.md)\tre-evaluated after JD update\n');
+    writeFileSync(join(hAdditions, '001-empresa-ejemplo.tsv'),
+      '1\t2026-01-06\tEmpresa Ejemplo\tData Lead\tEvaluated\t4.1/5\t❌\t' +
+      '[1](reports/001-empresa-ejemplo-2026-01-05.md)\tre-evaluated after JD update\n');
+
+    const hOut = run(NODE, ['merge-tracker.mjs'], {
+      env: { ...process.env, CAREER_OPS_TRACKER: hTracker, CAREER_OPS_ADDITIONS: hAdditions },
+    });
+
+    if (hOut === null) {
+      fail('merge-tracker crashed on the `---`/"Empresa" fixture');
+    } else {
+      if (/Existing: 2 entries/.test(hOut)) {
+        pass('rows containing `---` and "Empresa" are both visible to merge-tracker');
+      } else {
+        fail(`merge-tracker did not see both rows — expected "Existing: 2 entries", got: ${hOut.split('\n').find(l => l.includes('Existing:')) || '(none)'}`);
+      }
+
+      const hMerged = readFileSync(hTracker, 'utf-8');
+      const hDataRows = hMerged.split('\n').filter(l => /^\|\s*\d+\s*\|/.test(l));
+
+      if (hDataRows.length === 2) {
+        pass('re-evaluating a `---`/"Empresa" row updates in place, no duplicate row appended');
+      } else {
+        fail(`expected 2 rows after two in-place updates, got ${hDataRows.length}`);
+      }
+
+      if (/4\.8\/5/.test(hMerged) && /4\.1\/5/.test(hMerged)) {
+        pass('both re-evaluated scores landed on the existing rows');
+      } else {
+        fail('re-evaluated scores did not reach the existing rows');
+      }
+
+      // The separator row must still be found, or new rows land in the wrong
+      // place (or nowhere) — the structural match has to keep working.
+      if (hMerged.includes('|---|------|')) {
+        pass('table separator row survives the merge intact');
+      } else {
+        fail('table separator row was consumed or rewritten');
+      }
+    }
+
+    // verify-pipeline's row-format check shares the heuristic: a malformed row
+    // carrying `---` used to skip the column-count check entirely.
+    const hBadRow = join(hData, 'applications-badrow.md');
+    writeFileSync(hBadRow, hHeader +
+      '| 3 | 2026-01-05 | Acme | Truncated Row --- with hyphens |\n' + hRows);
+    let badOut = '';
+    let badCode = 0;
+    try {
+      badOut = execFileSync(NODE, ['verify-pipeline.mjs'], {
+        cwd: ROOT, encoding: 'utf-8', timeout: 30000,
+        env: { ...process.env, CAREER_OPS_TRACKER: hBadRow, CAREER_OPS_REPORTS: hReports },
+      });
+    } catch (e) {
+      badOut = String(e.stdout ?? '');
+      badCode = e.status ?? -1;
+    }
+    if (/Row with too few columns/.test(badOut) && badCode === 1) {
+      pass('verify-pipeline flags a malformed row even when it contains `---`');
+    } else {
+      fail(`verify-pipeline did not flag a short row containing \`---\` (exit ${badCode})`);
+    }
+  } finally {
+    rmSync(hyphenTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`dedup blindness test crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER REQ/JOB-NUMBER DEDUP GUARD (#1524) ─────────────────────
 // Tier-3 dedup (company + fuzzy role match) had no req/job-number awareness:
 // two distinct postings at the same company with similarly-worded titles were

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7075,6 +7075,40 @@ try {
     } else {
       fail(`verify-pipeline did not flag a short row containing \`---\` (exit ${badCode})`);
     }
+
+    // Header detection must key on the whole header SCHEMA, not one telltale
+    // cell: a malformed row carrying an exact `Empresa`/`Company` cell (a
+    // company genuinely named that, a one-word note) must not be mistaken for
+    // the header and skip the column-count check.
+    const hHeaderish = join(hData, 'applications-headerish.md');
+    writeFileSync(hHeaderish, hHeader +
+      '| 4 | 2026-01-05 | Empresa | Short Row |\n' +
+      '| 5 | 2026-01-05 | Company | Also Short |\n' + hRows);
+    let hdrOut = '';
+    let hdrCode = 0;
+    try {
+      hdrOut = execFileSync(NODE, ['verify-pipeline.mjs'], {
+        cwd: ROOT, encoding: 'utf-8', timeout: 30000,
+        env: { ...process.env, CAREER_OPS_TRACKER: hHeaderish, CAREER_OPS_REPORTS: hReports },
+      });
+    } catch (e) {
+      hdrOut = String(e.stdout ?? '');
+      hdrCode = e.status ?? -1;
+    }
+    const shortRowErrors = (hdrOut.match(/Row with too few columns/g) || []).length;
+    if (shortRowErrors === 2 && hdrCode === 1) {
+      pass('a malformed row with an exact Empresa/Company cell is not mistaken for the header');
+    } else {
+      fail(`expected 2 short-row errors for header-like malformed rows, got ${shortRowErrors} (exit ${hdrCode})`);
+    }
+
+    // …and the real header row must still be recognized, or every tracker
+    // reports its own header as a malformed row.
+    if (!/Row with too few columns[^\n]*# \| Date \| Company/.test(hdrOut)) {
+      pass('the genuine header row is still recognized as header furniture');
+    } else {
+      fail('the genuine header row was flagged as a malformed data row');
+    }
   } finally {
     rmSync(hyphenTmp, { recursive: true, force: true });
   }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7109,6 +7109,42 @@ try {
     } else {
       fail('the genuine header row was flagged as a malformed data row');
     }
+
+    // A FULLY localized header must map through the alias table, not fall back
+    // to LEGACY_COLMAP (#2274). On a plain 9-column table the fallback happens
+    // to line up and hides the bug; with a Location column inserted, the Score
+    // cell is read from Location instead — an ES tracker scored "Remote".
+    const trackerParse = await import(pathToFileURL(join(ROOT, 'tracker-parse.mjs')).href);
+    const esHeader = '| # | Fecha | Empresa | Puesto | Location | Score | Status | PDF | Report | Notes |';
+    const esMap = trackerParse.detectColumns([esHeader]);
+    if (esMap && esMap.score === 6 && esMap.company === 3 && esMap.role === 4 && esMap.location === 5) {
+      pass('a fully localized header maps through the alias table (#2274)');
+    } else {
+      fail(`localized header did not map: ${JSON.stringify(esMap)}`);
+    }
+
+    // The two readers must agree on every shape, or validation skips as
+    // furniture what column detection cannot parse.
+    const headerShapes = [
+      ['| # | Date | Company | Role | Score | Status | PDF | Report | Notes |', true],
+      ['| # | Date | Company | Role | Location | Score | Status | PDF | Report | Notes |', true],
+      ['| # | Fecha | Empresa | Puesto | Score | Status | PDF | Report | Notes |', true],
+      [esHeader, true],
+      ['| 4 | 2026-01-05 | Company | Short Row |', false],
+      ['| 5 | 2026-01-05 | Empresa | Also Short |', false],
+      ['| 6 | 2026-01-05 | Acme Corp | Director | 4.0/5 | Evaluated | ❌ | — | note |', false],
+      ['|---|------|---------|------|-------|--------|-----|--------|-------|', false],
+    ];
+    const disagreements = headerShapes.filter(([line, expected]) => {
+      const isHeader = trackerParse.isHeaderRow(line);
+      const detects = trackerParse.detectColumns([line]) !== null;
+      return isHeader !== detects || isHeader !== expected;
+    });
+    if (disagreements.length === 0) {
+      pass('isHeaderRow and detectColumns agree on every header shape');
+    } else {
+      fail(`isHeaderRow/detectColumns disagree on: ${disagreements.map(d => d[0].slice(0, 40)).join(' | ')}`);
+    }
   } finally {
     rmSync(hyphenTmp, { recursive: true, force: true });
   }

--- a/tracker-parse.mjs
+++ b/tracker-parse.mjs
@@ -83,27 +83,46 @@ export function isSeparatorRow(line) {
 const REQUIRED_HEADER_FIELDS = ['num', 'company', 'role', 'score', 'status'];
 
 /**
+ * The ONE definition of "this row is the tracker header", shared by
+ * `isHeaderRow` and `detectColumns`.
+ *
+ * A row qualifies only by labelling the whole schema — every field in
+ * REQUIRED_HEADER_FIELDS. One telltale cell is not enough: a company genuinely
+ * named "Company", or a note consisting of that single word, would otherwise be
+ * read as table furniture and skip row-format validation, which is the same
+ * class of false positive this module exists to stop.
+ *
+ * Extracted rather than duplicated (PR #2267 review): the two callers had
+ * drifted, and a header they disagree about is one that validation skips as
+ * furniture while column detection cannot parse — silently falling back to the
+ * fixed legacy layout.
+ *
+ * @param {string[]} cells - Lowercased, trimmed cells from `line.split('|')`.
+ * @returns {Object<string,number>|null} Field → column index, or null.
+ */
+function headerSchemaMap(cells) {
+  // NOTE: the literal `company`/`role` pre-filter is kept deliberately, to hold
+  // `detectColumns` behavior identical while removing the drift. It does mean a
+  // FULLY localized header (`| # | Fecha | Empresa | Puesto | … |`) is rejected
+  // here even though HEADER_ALIASES defines `empresa`/`puesto` for exactly that
+  // case, so such a tracker silently falls back to LEGACY_COLMAP. That is a
+  // pre-existing gap, not one this PR introduces, and widening it touches every
+  // detectColumns consumer — so it belongs in its own change.
+  if (!cells.includes('company') || !cells.includes('role')) return null;
+  const map = {};
+  cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
+  return REQUIRED_HEADER_FIELDS.every(k => map[k] != null) ? map : null;
+}
+
+/**
  * Whether a table row is the tracker's header row.
- *
- * Recognized by the whole header SCHEMA, not by one telltale cell: a row has to
- * label every column in REQUIRED_HEADER_FIELDS. One exact `Company` cell is not
- * enough — a company genuinely named "Company", or a note consisting of that one
- * word, would otherwise be read as table furniture and skip row-format
- * validation, which is the same substring-ish false positive this module exists
- * to stop.
- *
- * This is deliberately the acceptance test `detectColumns` already applies, so
- * the two cannot disagree about what a header is.
  *
  * @param {string} line - One line from applications.md.
  * @returns {boolean}
  */
 export function isHeaderRow(line) {
   if (typeof line !== 'string' || !line.startsWith('|')) return false;
-  const cells = line.split('|').map(s => s.trim().toLowerCase());
-  const map = {};
-  cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
-  return REQUIRED_HEADER_FIELDS.every(k => map[k] != null);
+  return headerSchemaMap(line.split('|').map(s => s.trim().toLowerCase())) !== null;
 }
 
 /**
@@ -139,11 +158,8 @@ export function resolveScoreStatus(a, b) {
 export function detectColumns(lines) {
   for (const line of lines) {
     if (!line.startsWith('|')) continue;
-    const cells = line.split('|').map(s => s.trim().toLowerCase());
-    if (!cells.includes('company') || !cells.includes('role')) continue;
-    const map = {};
-    cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
-    if (['num', 'company', 'role', 'score', 'status'].every(k => map[k] != null)) return map;
+    const map = headerSchemaMap(line.split('|').map(s => s.trim().toLowerCase()));
+    if (map) return map;
   }
   return null;
 }

--- a/tracker-parse.mjs
+++ b/tracker-parse.mjs
@@ -64,6 +64,37 @@ export function looksLikeScoreCell(v) {
 }
 
 /**
+ * A markdown table separator row: `|---|------|...|`, optionally with alignment
+ * colons.
+ *
+ * Readers used to recognize this row with `line.includes('---')`, which also
+ * matched any DATA row whose free text happened to contain three hyphens — a
+ * URL slug such as `Senior-Engineer---Platform-Team`, or an em dash typed
+ * as `---`. Matching the row's structure instead cannot false-positive that way.
+ */
+export const SEPARATOR_ROW_RE = /^\|(?:\s*:?-+:?\s*\|)+\s*$/;
+
+/** @param {string} line @returns {boolean} whether the line is the `|---|` separator row. */
+export function isSeparatorRow(line) {
+  return typeof line === 'string' && SEPARATOR_ROW_RE.test(line);
+}
+
+/**
+ * Whether a table row is the header row, detected by a whole cell reading
+ * "company" (or its Spanish alias) rather than by substring. A data row can
+ * legitimately contain the word inside a longer company name or note; only an
+ * exact cell match identifies the header.
+ *
+ * @param {string} line - One line from applications.md.
+ * @returns {boolean}
+ */
+export function isHeaderRow(line) {
+  if (typeof line !== 'string' || !line.startsWith('|')) return false;
+  const cells = line.split('|').map(s => s.trim().toLowerCase());
+  return cells.includes('company') || cells.includes('empresa');
+}
+
+/**
  * Given the two adjacent cells that carry score and status in EITHER order,
  * identify which is which by content — the score cell is recognizable by
  * pattern (`looksLikeScoreCell`), statuses never are. This lets TSV ingestion

--- a/tracker-parse.mjs
+++ b/tracker-parse.mjs
@@ -101,14 +101,17 @@ const REQUIRED_HEADER_FIELDS = ['num', 'company', 'role', 'score', 'status'];
  * @returns {Object<string,number>|null} Field → column index, or null.
  */
 function headerSchemaMap(cells) {
-  // NOTE: the literal `company`/`role` pre-filter is kept deliberately, to hold
-  // `detectColumns` behavior identical while removing the drift. It does mean a
-  // FULLY localized header (`| # | Fecha | Empresa | Puesto | … |`) is rejected
-  // here even though HEADER_ALIASES defines `empresa`/`puesto` for exactly that
-  // case, so such a tracker silently falls back to LEGACY_COLMAP. That is a
-  // pre-existing gap, not one this PR introduces, and widening it touches every
-  // detectColumns consumer — so it belongs in its own change.
-  if (!cells.includes('company') || !cells.includes('role')) return null;
+  // The alias table is the whole contract — no literal `company`/`role`
+  // pre-filter. There used to be one, which meant a FULLY localized header
+  // (`| # | Fecha | Empresa | Puesto | … |`) never reached the aliases that
+  // exist for exactly that case, and the tracker silently fell back to
+  // LEGACY_COLMAP. On a plain 9-column table the fallback lines up and nothing
+  // looks wrong; insert the Location column from #946's own use case and the
+  // Score cell is read from Location instead (#2274).
+  //
+  // Requiring the full schema is what makes the pre-filter unnecessary: a data
+  // row would have to carry five different header labels in five different
+  // cells to qualify, which no real row does.
   const map = {};
   cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
   return REQUIRED_HEADER_FIELDS.every(k => map[k] != null) ? map : null;

--- a/tracker-parse.mjs
+++ b/tracker-parse.mjs
@@ -79,11 +79,21 @@ export function isSeparatorRow(line) {
   return typeof line === 'string' && SEPARATOR_ROW_RE.test(line);
 }
 
+/** The columns a row must label before it counts as the tracker header. */
+const REQUIRED_HEADER_FIELDS = ['num', 'company', 'role', 'score', 'status'];
+
 /**
- * Whether a table row is the header row, detected by a whole cell reading
- * "company" (or its Spanish alias) rather than by substring. A data row can
- * legitimately contain the word inside a longer company name or note; only an
- * exact cell match identifies the header.
+ * Whether a table row is the tracker's header row.
+ *
+ * Recognized by the whole header SCHEMA, not by one telltale cell: a row has to
+ * label every column in REQUIRED_HEADER_FIELDS. One exact `Company` cell is not
+ * enough — a company genuinely named "Company", or a note consisting of that one
+ * word, would otherwise be read as table furniture and skip row-format
+ * validation, which is the same substring-ish false positive this module exists
+ * to stop.
+ *
+ * This is deliberately the acceptance test `detectColumns` already applies, so
+ * the two cannot disagree about what a header is.
  *
  * @param {string} line - One line from applications.md.
  * @returns {boolean}
@@ -91,7 +101,9 @@ export function isSeparatorRow(line) {
 export function isHeaderRow(line) {
   if (typeof line !== 'string' || !line.startsWith('|')) return false;
   const cells = line.split('|').map(s => s.trim().toLowerCase());
-  return cells.includes('company') || cells.includes('empresa');
+  const map = {};
+  cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
+  return REQUIRED_HEADER_FIELDS.every(k => map[k] != null);
 }
 
 /**

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -22,7 +22,7 @@
 import { readFileSync, readdirSync, existsSync, mkdirSync, unlinkSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { looksLikeScoreCell } from './tracker-parse.mjs';
+import { looksLikeScoreCell, isSeparatorRow, isHeaderRow } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original).
@@ -200,7 +200,7 @@ if (badScores === 0) ok('All scores valid');
 let badRows = 0;
 for (const line of lines) {
   if (!line.startsWith('|')) continue;
-  if (line.includes('---') || line.includes('Empresa')) continue;
+  if (isSeparatorRow(line) || isHeaderRow(line)) continue;
   const parts = line.split('|');
   if (parts.length <= MAX_IDX) {
     error(`Row with too few columns (need ${MAX_IDX} data cols): ${line.substring(0, 80)}...`);

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -22,7 +22,7 @@
 import { readFileSync, readdirSync, existsSync, mkdirSync, unlinkSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { looksLikeScoreCell, isSeparatorRow, isHeaderRow } from './tracker-parse.mjs';
+import { looksLikeScoreCell, isSeparatorRow, isHeaderRow, resolveColumns } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original).
@@ -81,24 +81,13 @@ const lines = content.split('\n');
 // Location column after Role). Fixed-position indexing would otherwise read
 // Location where Score is expected and flag false errors. Falls back to the
 // legacy fixed layout when no recognizable header row is found.
-const LEGACY_COLMAP = { num: 1, date: 2, company: 3, role: 4, score: 5, status: 6, pdf: 7, report: 8, notes: 9 };
-const HEADER_ALIASES = {
-  '#': 'num', 'num': 'num', 'date': 'date', 'company': 'company', 'empresa': 'company',
-  'via': 'via', 'role': 'role', 'puesto': 'role', 'location': 'location', 'score': 'score',
-  'status': 'status', 'pdf': 'pdf', 'report': 'report', 'notes': 'notes',
-};
-function detectColumns(allLines) {
-  for (const line of allLines) {
-    if (!line.startsWith('|')) continue;
-    const cells = line.split('|').map(s => s.trim().toLowerCase());
-    if (!cells.includes('company') || !cells.includes('role')) continue;
-    const map = {};
-    cells.forEach((c, i) => { if (HEADER_ALIASES[c] != null) map[HEADER_ALIASES[c]] = i; });
-    if (['num', 'company', 'role', 'score', 'status'].every(k => map[k] != null)) return map;
-  }
-  return null;
-}
-const COLMAP = detectColumns(lines) || LEGACY_COLMAP;
+//
+// Sourced from tracker-parse.mjs rather than re-declared here: this file used
+// to carry its own copy of LEGACY_COLMAP, HEADER_ALIASES and detectColumns, so
+// a fix to the shared module left verify-pipeline reading a different layout
+// than merge-tracker wrote — the drift tracker-parse.mjs exists to prevent, and
+// the same half-application #1291 was filed for.
+const COLMAP = resolveColumns(lines);
 const MAX_IDX = Math.max(...Object.values(COLMAP));
 
 const entries = [];


### PR DESCRIPTION
## What does this PR do?

`merge-tracker.mjs` and `verify-pipeline.mjs` recognized the markdown separator row with `line.includes('---')`, which also matches any **data** row whose free text contains three hyphens (a URL slug like `Senior-Engineer---Platform-Team`, an em dash typed as `---`) — and the sibling `.includes('Empresa')` guard matches a Spanish-market company name. Such a row never reached `existingApps`, so duplicate detection could not see it: re-evaluating that exact company+role appended a second row instead of updating the first in place.

This is the half #1704 deliberately left open. #1704 fixed the *numbering* side via its separate `usedNumbers` pass; its comment is explicit that `existingApps` "stays as-is; it drives duplicate detection, not numbering." Numbering is safe today, dedup is not.

## Related issue

Fixes #2265

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

### Before / after

Tracker row #2 has a `---` URL slug in its Notes; a TSV re-evaluates that same role at a higher score.

**Before** — appended a duplicate instead of updating:

```
📊 Existing: 1 entries, max #2
➕ Add #3: Acme Corp — Director, Data Platform (4.8/5)
```

**After** — updates in place:

```
📊 Existing: 2 entries, max #2
🔄 Update: #2 Acme Corp — Director, Data Platform (4.3→4.8)
```

### What changed

- **`merge-tracker.mjs`** — drop the heuristic from the `existingApps` loop. `parseAppLine` already rejects the header and separator rows (neither has a numeric `#` cell), so the guard was redundant for its intended targets and wrong for data rows. Also match the separator structurally when locating the insert point.
- **`verify-pipeline.mjs`** — the row-format check skipped any line containing `---`, so a genuinely malformed row carrying three hyphens escaped the column-count check.
- **`tracker-parse.mjs`** — `SEPARATOR_ROW_RE`, `isSeparatorRow`, `isHeaderRow` live here so both readers share one definition and cannot drift, per the module's stated purpose. `isHeaderRow` matches a whole cell reading "company"/"empresa" rather than a substring — matching by substring is what caused this class of bug in the first place.
- **`test-all.mjs`** — 5 assertions: a tracker with one row hidden by `---` and one by "Empresa", both re-evaluated at higher scores, expecting two in-place updates and zero appended rows; plus the `verify-pipeline` short-row case. Fails on `main`, passes here.

### Two deliberate restraints

1. **#1704's `usedNumbers` pass is kept, not merged into the fixed loop.** The two now look redundant, but that pass is deliberately *broader*: it reserves numbers from rows too malformed for `parseAppLine` to return. Collapsing them would silently weaken #1704's guarantee. I updated its comment, since the old wording described a premise this change removes.
2. **No change to dedup semantics** — only to which rows dedup can see. The report-number, exact-num, and fuzzy company+role tiers (including the #1524 req-number guard) are untouched.

`node test-all.mjs`: **2348 passed, 0 failed.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tracker merge deduplication and in-place role/score updates when markdown table separator tokens (`---`) appear in tracker data (e.g., URL slugs).
  * Prevented incorrect handling of company names containing “Empresa” during header/separator detection.
  * Improved detection of the true markdown table header and separator rows and preserved them during merges/validation.
* **Tests**
  * Added regression coverage for the separator/header edge cases, dedup/update behavior, and malformed-row validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->