### PR TITLE
fix(test): accept a materialized skill entrypoint, not just a symlink

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -914,21 +914,50 @@ for (const f of systemFiles) {
   }
 }
 
-// Per-CLI SKILL.md entrypoints must be SYMLINKS in the git index (mode 120000).
-// A regular-file blob whose content is the link path as text ships a broken,
-// empty skill to every user of that CLI — exactly what happened to .kimi/ when
-// a symlink was created under core.symlinks=false and committed as-is. Checking
-// the INDEX mode (not the filesystem) keeps this assertion true on Windows
-// checkouts too.
+// Per-CLI SKILL.md entrypoints must resolve to the canonical skill content.
+//
+// The defect this guards is a regular-file blob whose content is the LINK PATH
+// AS TEXT — exactly what happened to .kimi/ when a symlink was created under
+// core.symlinks=false and committed as-is (#1051). That ships a broken, empty
+// skill to every user of that CLI.
+//
+// Index mode was a faithful proxy for that until #2259 added
+// materializeSkillEntrypoints(), which writes the real content as a regular
+// file on filesystems without symlink support. That is a second, CORRECT
+// mode-100644 state, so mode alone can no longer tell the two apart:
+//
+//   120000                          → symlink                        (correct)
+//   100644 + canonical blob         → materialized entrypoint        (correct)
+//   100644 + any other blob         → link-path text or stale copy   (BROKEN)
+//
+// Comparing the blob to the canonical entrypoint asserts the invariant the
+// defect is actually about, and still catches #1051: a link-path blob never
+// equals the canonical blob. Reading the INDEX (not the filesystem) keeps this
+// true on Windows checkouts, where a symlink entry materializes as a text file.
+const CANONICAL_ENTRYPOINT = '.agents/skills/career-ops/SKILL.md';
+const stagedBlob = (path) => {
+  const entry = run('git', ['ls-files', '-s', path]);
+  if (entry === null || entry === '') return null;
+  const [mode, sha] = entry.split(/\s+/);
+  return { mode, sha };
+};
+
+const canonicalEntry = stagedBlob(CANONICAL_ENTRYPOINT);
+if (!canonicalEntry) {
+  fail(`Could not read git index entry for the canonical entrypoint ${CANONICAL_ENTRYPOINT}`);
+}
+
 const skillEntrypoints = systemFiles.filter((f) => f.endsWith('/skills/career-ops/SKILL.md'));
 for (const f of skillEntrypoints) {
-  const staged = run('git', ['ls-files', '-s', f]);
-  if (staged === null || staged === '') {
+  const staged = stagedBlob(f);
+  if (!staged) {
     fail(`Could not read git index entry for ${f} (lookup failed — not evidence of absence)`);
-  } else if (staged.startsWith('120000')) {
+  } else if (staged.mode === '120000') {
     pass(`Entrypoint is a real symlink in git: ${f}`);
+  } else if (canonicalEntry && staged.sha === canonicalEntry.sha) {
+    pass(`Entrypoint is a materialized regular file with canonical content: ${f}`);
   } else {
-    fail(`Entrypoint committed as a REGULAR file (mode ${staged.split(' ')[0]}) — users of this CLI get a broken skill: ${f}`);
+    fail(`Entrypoint committed as a REGULAR file (mode ${staged.mode}) whose content is not the canonical skill — users of this CLI get a broken skill: ${f}`);
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

The per-CLI `SKILL.md` entrypoint check asserts index mode `120000`. On a filesystem without symlink support, `update-system.mjs apply` materializes those entrypoints as regular files — by design; #2259 added exactly that so these users get a working skill instead of a pointer file (#1051) — and commits them at `100644`. **The documented fallback produces the state the test rejects: 7 permanent failures after any successful update, no user error involved.** CI never sees it, running only on ubuntu where symlinks work.

This compares the blob against the canonical entrypoint instead of asserting the mode.

## Related issue

Fixes #2272

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

### The suite already contradicts itself

Section `12c. Materialized skill index mode` passes in the same run that produces the 7 failures:

```
✅ materialized skill entrypoints stage as regular files, not symlink blobs
✅ materialized skill blobs contain canonical skill content
```

12c blesses mode `100644` + canonical content; the entrypoint check rejects `100644` unconditionally.

### Why mode is the wrong proxy now

The check's own comment states the real invariant — *"a regular-file blob whose content is the link path as text ships a broken, empty skill"*. That is a **content** condition. Mode was faithful to it until #2259 introduced a second, correct `100644` state:

| Mode | Blob | Reality |
|---|---|---|
| `120000` | symlink | correct |
| `100644` | canonical | materialized entrypoint — correct (#2259) |
| `100644` | anything else | link-path text or stale copy — **broken** (#1051) |

Comparing against the canonical blob separates them and still catches #1051: a link-path blob never equals the canonical blob.

### Verified in all four states

| State | Before | After |
|---|---|---|
| symlink checkout (ubuntu-equivalent) | 7 pass | 7 pass |
| materialized checkout after a real Windows `apply` | **7 fail** | 7 pass |
| #1051 link-path-as-text blob | fail | fail |
| stale non-canonical copy | *pass* ⚠️ | fail |

The last row is a small bonus: once a stale copy had the right mode, the old check waved it through. Content comparison does not.

Fixture used for rows 3–4 — a link-path blob and a stale copy, both at `100644`:

```
FAIL  regular, non-canon  .grok/skills/career-ops/SKILL.md (mode 100644)
FAIL  regular, non-canon  .kimi/skills/career-ops/SKILL.md (mode 100644)
```

`node test-all.mjs` on this branch: **2343 passed, 0 failed.**

### Note on the alternative

If you would rather the updater restore `120000` on these filesystems and leave the test alone, this PR is the wrong shape and I will close it. Worth weighing first: with `core.symlinks=false` a `120000` entry checks out as a text file containing the target path, and Claude Code then reads that path as the skill description — the skill silently becomes `career-ops: ../../../.agents/skills/career-ops/SKILL.md`. I hit that firsthand checking out an unmaterialized branch on Windows, which is why I think the fallback is right and the assertion is what needs to move.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of skill entrypoints to detect broken links and incorrect copied content.
  * Tests now confirm that each CLI entrypoint resolves to the canonical skill content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->