### PR TITLE
Add Node engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.23.0",
   "description": "AI-powered job search pipeline — works with any AI coding CLI (Claude Code, Codex, OpenCode, Antigravity, Grok, Qwen, Kimi, Copilot)",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "doctor": "node doctor.mjs",
     "or": "node openrouter-runner.mjs",


### PR DESCRIPTION
## What does this PR do?

Adds an `engines` field to `package.json`:

```json
"engines": {
  "node": ">=18"
}
```

## Verification

- Read `checkNodeVersion()` in `doctor.mjs` and confirmed that Node.js 18 is the minimum supported version.
- Checked `web/package.json` and confirmed it does not currently define an `engines` field.
- This change provides an npm warning for unsupported Node.js versions while leaving the existing compatibility policy unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a requirement for Node.js version 18 or later.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->