### PR TITLE
fix(web): add Hired to the states.ts fallback (the #2249 bug's degraded path)

### DIFF
--- a/web/src/lib/core/states.ts
+++ b/web/src/lib/core/states.ts
@@ -27,6 +27,7 @@ const FALLBACK: CanonicalState[] = [
   { id: "rejected", label: "Rejected", aliases: ["rechazado", "rechazada"], description: "Rejected by company", group: "rejected" },
   { id: "discarded", label: "Discarded", aliases: ["descartado", "descartada", "cerrada", "cancelada"], description: "Discarded by candidate or offer closed", group: "discarded" },
   { id: "skip", label: "SKIP", aliases: ["no_aplicar", "no aplicar", "skip", "monitor"], description: "Doesn't fit, don't apply", group: "skip" },
+  { id: "hired", label: "Hired", aliases: ["contratado", "contratada", "hired", "accepted", "accept"], description: "Offer accepted, job landed!", group: "hired" },
 ];
 
 let cache: CanonicalState[] | null = null;


### PR DESCRIPTION
Found while reviewing **#2250** (propagating `Hired` to the web). That PR is correct, but it leaves this hole — and the new CI check can't see it.

## The gap

`web/src/lib/core/states.ts` reads `templates/states.yml` **live**, so `Hired` (#2050) already resolves on the normal path. But its `FALLBACK` — used when `states.yml` is unreadable — still listed only **8** states. The file's own comment promises the fallback *"is kept identical to the file"*; that invariant broke silently when the core gained a ninth state.

## Why it matters

`canonicalizeStatus()` gates the status writeback in `api/status/route.ts`:

```ts
const canon = canonicalizeStatus(status);
if (!canon) return NextResponse.json({ error: `not a canonical status: ${status}` }, { status: 400 });
```

So on the degraded path, "mark as hired" fails with **HTTP 400 `not a canonical status: Hired`** — precisely the #2249 bug #2250 is closing, surviving where `states.yml` can't be read (an incomplete core checkout, or `CAREER_OPS_ROOT` pointed somewhere without `templates/`).

## CI blind spot (for the maintainer)

#2250's new **55.3b** check enumerates five hardcoded lists (`format.ts CANONICAL_STATES`, `registry.ts CANON_STATUS`/`TAB_VALUES`, `pipeline-view TABS`, `analytics STAGES`) plus the assistant prose — **not this fallback**. Worth extending it to cover `states.ts`, or this drifts again on state number ten.

## Verification

Replayed `canonicalizeStatus` against the fallback alone: `Hired`, all five aliases (`contratado`/`contratada`/`hired`/`accepted`/`accept`) and the bold-stripped `**Hired**` now resolve; unknown input still correctly returns null. typecheck + `next build` green.

One line. Independent of #2250 — merge in either order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Hired” as a recognized job/application status when fallback status definitions are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->