### PR TITLE
fix(dashboard): the 'hired' status renders with no colour in the pipeline list

### DIFF
--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -2052,6 +2052,7 @@ func (m PipelineModel) scoreStyle(score float64) lipgloss.Style {
 
 func (m PipelineModel) statusColorMap() map[string]lipgloss.Color {
 	return map[string]lipgloss.Color{
+		"hired":     m.theme.Green, // terminal success — never uncoloured (default) like an unknown status
 		"interview": m.theme.Green,
 		"offer":     m.theme.Green,
 		"applied":   m.theme.Sky,


### PR DESCRIPTION
Closes #2251 (the Go sibling of the web #2249/#2250 fix).

`Hired` was added as a canonical status in #2050, and the Go dashboard recognizes it — `data.NormalizeStatus` folds `Hired`/`contratado`/`accepted`/… → `"hired"`, it's in the recognized set, and it *leads* `statusGroupOrder`. But `statusColorMap()` had no entry for it:

```go
statusColor := m.statusColorMap()[norm]   // pipeline.go:1664, norm == "hired"
statusStyle := lipgloss.NewStyle().Foreground(statusColor)...
```

With the key missing, the lookup returns the zero-value `lipgloss.Color("")`, so the terminal-success status renders with **no explicit foreground** (default/inherited) — the one status that doesn't get a semantic colour.

## Fix

```go
"hired": m.theme.Green, // matches the interview/offer positive convention
```

I used `Green` as the minimal, uncontroversial mirror of the existing positive states. If you'd rather Hired **stand out** as the terminal win (it's the best outcome, not an intermediate one), the theme also has `Mauve`/`Peach` available — happy to switch it to whichever you prefer; that's a palette call I didn't want to make unilaterally.

> Note: `go` isn't available in my environment, so I couldn't `go build`/`go test` locally — the change is a single map entry using an existing `m.theme.Green` field (same as `interview`/`offer`), and CI builds + tests the dashboard. Flag me if the format/build check catches anything and I'll fix immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hired statuses are now consistently displayed using the designated green color in metrics and application status views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->