### PR TITLE
fix(web): AI-search drops offers when the <<offer: opener splits across a stream chunk

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test": "node --test test-clean-chips.mjs"
+    "test": "node --test test-clean-chips.mjs test-stream-parse.mjs"
   },
   "dependencies": {
     "@paper-design/shaders-react": "^0.0.78",

--- a/web/src/lib/explore-ai.ts
+++ b/web/src/lib/explore-ai.ts
@@ -5,6 +5,7 @@
 // across stream chunk boundaries must BUFFER, never flush as garbage or drop.
 
 import type { DiscoveredOffer } from "./explore";
+import { pendingOpenerLen } from "./stream-parse.mjs";
 
 const OPEN = "<<offer:";
 const CLOSE = ">>";
@@ -58,20 +59,15 @@ export function makeAiStreamParser(opts?: { knownUrls?: Set<string> }) {
       for (;;) {
         const open = buf.indexOf(OPEN);
         if (open === -1) {
-          // No opener in view. Flush as narration — but hold back a short tail
-          // that could be the start of a split opener ("<<offe…").
-          const keep = OPEN.length - 1;
-          if (buf.length > keep) {
-            const tail = buf.slice(buf.length - keep);
-            if (OPEN.startsWith(tail)) {
-              const text = buf.slice(0, buf.length - keep);
-              if (text.trim()) out.push({ kind: "narration", text });
-              buf = tail;
-            } else {
-              if (buf.trim()) out.push({ kind: "narration", text: buf });
-              buf = "";
-            }
-          }
+          // No opener in view. Flush as narration — but hold back the longest
+          // trailing run that could be the start of a split opener ("<<offe…"),
+          // so an offer whose marker straddles a chunk boundary is never dropped
+          // as garbage (#2290). A fixed-length tail check missed the shorter
+          // partial openers ("<<", "<<off") preceded by other text.
+          const hold = pendingOpenerLen(buf, OPEN);
+          const text = hold ? buf.slice(0, buf.length - hold) : buf;
+          if (text.trim()) out.push({ kind: "narration", text });
+          buf = hold ? buf.slice(buf.length - hold) : "";
           break;
         }
         const before = buf.slice(0, open);

--- a/web/src/lib/stream-parse.mjs
+++ b/web/src/lib/stream-parse.mjs
@@ -1,0 +1,27 @@
+// Pure JS helper for the AI-search <<offer:>> stream parser — no TypeScript
+// types so it can be imported directly by both explore-ai.ts (which uses it)
+// and test-stream-parse.mjs (which can't import .ts without a runner). This is
+// the single source of truth for the "how much of a possibly-split opener do we
+// hold back?" logic — the load-bearing part of never dropping an offer whose
+// `<<offer:` marker straddles a stream chunk boundary (#2290).
+
+/**
+ * Length of the trailing run of `buf` that is a proper prefix of `opener` —
+ * i.e. a possibly-split opener to buffer rather than flush as narration.
+ *
+ * Returns the LONGEST such suffix length (0 if none). The previous code checked
+ * only whether the fixed last `opener.length - 1` characters formed a prefix,
+ * which missed shorter partial openers (`<<`, `<<off`) preceded by other text
+ * and dropped the offer once the rest of the marker arrived (#2290).
+ *
+ * @param {string} buf - Current parse buffer with no full `opener` in view.
+ * @param {string} opener - The envelope opener, e.g. "<<offer:".
+ * @returns {number} Number of trailing chars to keep buffered (0 = flush all).
+ */
+export function pendingOpenerLen(buf, opener) {
+  const max = Math.min(buf.length, opener.length - 1);
+  for (let k = max; k > 0; k--) {
+    if (buf.endsWith(opener.slice(0, k))) return k;
+  }
+  return 0;
+}

--- a/web/test-stream-parse.mjs
+++ b/web/test-stream-parse.mjs
@@ -1,0 +1,46 @@
+// Tests for the AI-search stream parser's split-opener handling (#2290).
+// Imports directly from stream-parse.mjs (the single source of truth) so the
+// test and production code can never drift out of sync.
+//
+// Run:  node --test test-stream-parse.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pendingOpenerLen } from "./src/lib/stream-parse.mjs";
+
+const OPEN = "<<offer:";
+
+test("holds back the longest trailing prefix of the opener (every split offset)", () => {
+  // A buffer ending in each partial opener must hold exactly that many chars, so
+  // the rest of the marker arriving next chunk still forms a whole `<<offer:`.
+  for (let k = 1; k < OPEN.length; k++) {
+    const partial = OPEN.slice(0, k);
+    assert.equal(
+      pendingOpenerLen("Found a great role " + partial, OPEN),
+      k,
+      `should hold ${k} chars for trailing "${partial}"`,
+    );
+  }
+});
+
+test("the reported case: a trailing '<<off' is held, not flushed", () => {
+  // The old fixed-7-char tail check returned 0 here → the offer was dropped.
+  assert.equal(pendingOpenerLen("Found a great role <<off", OPEN), 5);
+});
+
+test("holds nothing when the tail can't begin the opener", () => {
+  assert.equal(pendingOpenerLen("plain narration text", OPEN), 0);
+  assert.equal(pendingOpenerLen("", OPEN), 0);
+});
+
+test("a lone '<' is held (it can begin the opener)", () => {
+  assert.equal(pendingOpenerLen("ends with a single <", OPEN), 1);
+});
+
+test("caps at opener.length - 1 (a complete opener is the found-opener path, not held)", () => {
+  assert.ok(pendingOpenerLen("x" + OPEN, OPEN) <= OPEN.length - 1);
+});
+
+test("a mid-buffer opener prefix is not mistaken for a trailing one", () => {
+  assert.equal(pendingOpenerLen("<<of appeared then more plain text", OPEN), 0);
+});


### PR DESCRIPTION
Closes #2290.

`makeAiStreamParser` (`web/src/lib/explore-ai.ts`) is the tolerant parser for the AI-search `<<offer:{…}>>` envelopes. Its header states the invariant:

> an envelope (or its opener) split across stream chunk boundaries must BUFFER, never flush as garbage or drop.

It broke that. The no-opener branch held the buffer back only when the **fixed last `OPEN.length - 1` (7) characters** formed a prefix of the opener:

```ts
const tail = buf.slice(buf.length - keep);   // exactly 7 chars
if (OPEN.startsWith(tail)) { …hold… } else { …flush everything… }
```

`OPEN.startsWith(tail)` is true only when the tail is *exactly* `"<<offer"`. A shorter partial opener at the end (`<<`, `<<off`, `<<offe`) preceded by narration makes `tail` a non-prefix, so the whole buffer — partial opener included — is flushed. When `er:{…}>>` arrives next chunk there's no opener to match, and the offer is dropped (and leaks as malformed narration). Token streaming chunks at arbitrary offsets, so this fires often.

Ported the exact `feed()` loop to confirm:

```
split "<<offer:" after 2 chars → offers: 0   (opener leaked to narration)
split "<<offer:" after 5 chars → offers: 0
split "<<offer:" after 6 chars → offers: 0
split "<<offer:" after 7 chars → offers: 1   ← the only one that worked
```

## Fix

Hold back the **longest suffix of `buf` that is a prefix of `OPEN`** instead of a fixed-length tail. Extracted as a pure `pendingOpenerLen()` helper into `stream-parse.mjs` — mirroring the existing `clean-chips.mjs` pattern — so it's unit-testable under `node --test` without a TS runner, and `explore-ai.ts` stays fully typed (it just imports the helper).

After the fix, every split offset (and a byte-by-byte stream) recovers the offer with clean narration:

```
split after 1..7 → offers: 1   (all)
```

## Tests

`web/test-stream-parse.mjs` covers every split offset, the reported `<<off` case, the no-hold cases, a lone `<`, the length cap, and the mid-buffer false-positive guard. Wired into the web `test` script.

`npm test` (web) → **25 passed, 0 failed** (19 clean-chips + 6 new).

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI search streaming to correctly handle offer markers split across incoming data chunks.
  - Prevented partial markers, such as `<<off`, from appearing as unwanted narration or being discarded.
  - Preserved complete offer parsing and existing narration behavior while making streamed results more reliable.

- **Tests**
  - Added coverage for split-marker handling across chunk boundaries and related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->