### PR TITLE
fix(web): stop the assistant console flickering a half-written `<<act:` opener into the bubble

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test": "node --test test-clean-chips.mjs"
+    "test": "node --test test-clean-chips.mjs test-stream-parse.mjs"
   },
   "dependencies": {
     "@paper-design/shaders-react": "^0.0.78",

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test": "node --test test-clean-chips.mjs test-stream-parse.mjs"
+    "test": "node --test test-clean-chips.mjs test-stream-parse.mjs test-act-envelope.mjs"
   },
   "dependencies": {
     "@paper-design/shaders-react": "^0.0.78",

--- a/web/src/components/assistant-console.tsx
+++ b/web/src/components/assistant-console.tsx
@@ -15,6 +15,7 @@ import { WorkerCard } from "@/components/jobs/worker-card";
 import { Button } from "@/components/ui/button";
 import { dispatch, type ActionCtx, type DoneInfo } from "@/app/actions/registry";
 import { scoreNum } from "@/lib/format";
+import { pendingActOpenerStart } from "@/lib/act-envelope.mjs";
 import { cn } from "@/lib/cn";
 
 // ── message model: messages are PART arrays so a live worker card can render
@@ -72,6 +73,11 @@ function parseEnvelopes(acc: string): { complete: Env[]; hidePartialFrom: number
     }
     complete.push({ start, end: close + 2, id: m[1], argsJson: acc.slice(argsStart, close).trim() });
   }
+  // The regex above only sees an opener once its id letters AND trailing space
+  // have streamed in. Also hide a shorter trailing partial (`<<`, `<<act:sav`)
+  // so it doesn't flicker into the bubble before the space arrives (#2290-class).
+  const pending = pendingActOpenerStart(acc);
+  if (pending >= 0 && (hidePartialFrom === -1 || pending < hidePartialFrom)) hidePartialFrom = pending;
   return { complete, hidePartialFrom };
 }
 function removeRanges(s: string, cuts: [number, number][]): string {

--- a/web/src/lib/act-envelope.mjs
+++ b/web/src/lib/act-envelope.mjs
@@ -1,0 +1,35 @@
+// Pure JS helper for the assistant console's <<act:ID {json}>> envelope parser
+// (assistant-console.tsx). No TypeScript types so it can be imported by both the
+// component and test-act-envelope.mjs (which can't import .tsx without a runner).
+//
+// parseEnvelopes only hides an incomplete envelope once the opener regex
+// `<<act:([a-zA-Z]+)[ \t]+` fully matches — i.e. `<<act:`, the id letters, AND
+// the trailing space are all present. While a chunk boundary leaves the opener
+// short of that (`<<`, `<<act`, `<<act:save` with no space yet), nothing hides
+// it, so the half-written marker flickers into the rendered chat bubble on every
+// action the assistant takes. This finds where such a trailing partial opener
+// begins so the caller can hide it too — the same "buffer a split opener, never
+// render garbage" invariant the AI-search parser holds (stream-parse.mjs).
+
+const OPEN = "<<act:";
+
+/**
+ * Start index of a trailing partial `<<act:` opener in `acc` that the main
+ * `<<act:([a-zA-Z]+)[ \t]+` regex can't match yet, or -1 if none.
+ *
+ * Anchored to the end of `acc`, so a completed envelope earlier in the string
+ * (which is followed by its `>>`, not by end-of-buffer) is never matched.
+ *
+ * @param {string} acc - Accumulated assistant text so far.
+ * @returns {number} Index where the trailing partial opener starts, else -1.
+ */
+export function pendingActOpenerStart(acc) {
+  // `<<act:` plus any id letters, but no trailing space yet → regex can't fire.
+  const withColon = /<<act:[a-zA-Z]*$/.exec(acc);
+  if (withColon) return withColon.index;
+  // A proper prefix of the literal `<<act:` at the very end (`<` … `<<act`).
+  for (let k = Math.min(acc.length, OPEN.length - 1); k > 0; k--) {
+    if (acc.endsWith(OPEN.slice(0, k))) return acc.length - k;
+  }
+  return -1;
+}

--- a/web/src/lib/explore-ai.ts
+++ b/web/src/lib/explore-ai.ts
@@ -5,6 +5,7 @@
 // across stream chunk boundaries must BUFFER, never flush as garbage or drop.
 
 import type { DiscoveredOffer } from "./explore";
+import { pendingOpenerLen } from "./stream-parse.mjs";
 
 const OPEN = "<<offer:";
 const CLOSE = ">>";
@@ -58,20 +59,15 @@ export function makeAiStreamParser(opts?: { knownUrls?: Set<string> }) {
       for (;;) {
         const open = buf.indexOf(OPEN);
         if (open === -1) {
-          // No opener in view. Flush as narration — but hold back a short tail
-          // that could be the start of a split opener ("<<offe…").
-          const keep = OPEN.length - 1;
-          if (buf.length > keep) {
-            const tail = buf.slice(buf.length - keep);
-            if (OPEN.startsWith(tail)) {
-              const text = buf.slice(0, buf.length - keep);
-              if (text.trim()) out.push({ kind: "narration", text });
-              buf = tail;
-            } else {
-              if (buf.trim()) out.push({ kind: "narration", text: buf });
-              buf = "";
-            }
-          }
+          // No opener in view. Flush as narration — but hold back the longest
+          // trailing run that could be the start of a split opener ("<<offe…"),
+          // so an offer whose marker straddles a chunk boundary is never dropped
+          // as garbage (#2290). A fixed-length tail check missed the shorter
+          // partial openers ("<<", "<<off") preceded by other text.
+          const hold = pendingOpenerLen(buf, OPEN);
+          const text = hold ? buf.slice(0, buf.length - hold) : buf;
+          if (text.trim()) out.push({ kind: "narration", text });
+          buf = hold ? buf.slice(buf.length - hold) : "";
           break;
         }
         const before = buf.slice(0, open);

--- a/web/src/lib/stream-parse.mjs
+++ b/web/src/lib/stream-parse.mjs
@@ -1,0 +1,27 @@
+// Pure JS helper for the AI-search <<offer:>> stream parser — no TypeScript
+// types so it can be imported directly by both explore-ai.ts (which uses it)
+// and test-stream-parse.mjs (which can't import .ts without a runner). This is
+// the single source of truth for the "how much of a possibly-split opener do we
+// hold back?" logic — the load-bearing part of never dropping an offer whose
+// `<<offer:` marker straddles a stream chunk boundary (#2290).
+
+/**
+ * Length of the trailing run of `buf` that is a proper prefix of `opener` —
+ * i.e. a possibly-split opener to buffer rather than flush as narration.
+ *
+ * Returns the LONGEST such suffix length (0 if none). The previous code checked
+ * only whether the fixed last `opener.length - 1` characters formed a prefix,
+ * which missed shorter partial openers (`<<`, `<<off`) preceded by other text
+ * and dropped the offer once the rest of the marker arrived (#2290).
+ *
+ * @param {string} buf - Current parse buffer with no full `opener` in view.
+ * @param {string} opener - The envelope opener, e.g. "<<offer:".
+ * @returns {number} Number of trailing chars to keep buffered (0 = flush all).
+ */
+export function pendingOpenerLen(buf, opener) {
+  const max = Math.min(buf.length, opener.length - 1);
+  for (let k = max; k > 0; k--) {
+    if (buf.endsWith(opener.slice(0, k))) return k;
+  }
+  return 0;
+}

--- a/web/test-act-envelope.mjs
+++ b/web/test-act-envelope.mjs
@@ -1,0 +1,49 @@
+// Tests for the assistant console's partial <<act:> opener hiding (#2290-class).
+// Imports directly from act-envelope.mjs (the single source of truth) so the
+// test and production code can never drift.
+//
+// Run:  node --test test-act-envelope.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pendingActOpenerStart } from "./src/lib/act-envelope.mjs";
+
+test("every trailing partial opener is caught as the stream builds `<<act:navigate `", () => {
+  // Char-by-char up to (but not including) the space the regex requires: each
+  // trailing partial must report a hide-start so it never renders.
+  const prefix = "Here you go. ";
+  const opener = "<<act:navigate"; // no trailing space yet
+  for (let i = 1; i <= opener.length; i++) {
+    const acc = prefix + opener.slice(0, i);
+    assert.equal(
+      pendingActOpenerStart(acc),
+      prefix.length,
+      `partial "${opener.slice(0, i)}" should hide from index ${prefix.length}`,
+    );
+  }
+});
+
+test("a lone '<' and the bare '<<act:' are both hidden", () => {
+  assert.equal(pendingActOpenerStart("text <"), 5);
+  assert.equal(pendingActOpenerStart("text <<act:"), 5);
+});
+
+test("no trailing opener → -1", () => {
+  assert.equal(pendingActOpenerStart("plain assistant prose"), -1);
+  assert.equal(pendingActOpenerStart(""), -1);
+});
+
+test("a completed envelope earlier in the buffer is not matched", () => {
+  // Followed by `>>` and more text — the tail isn't a partial opener.
+  const acc = 'Done <<act:navigate {"path":"/"}>> and more prose';
+  assert.equal(pendingActOpenerStart(acc), -1);
+});
+
+test("once the trailing space arrives, this helper defers to the main regex", () => {
+  // `<<act:save ` (space, no `>>`) is the main regex's job, not ours.
+  assert.equal(pendingActOpenerStart("x <<act:save "), -1);
+});
+
+test("a mid-buffer '<<act:' with later prose is not mistaken for a trailing one", () => {
+  assert.equal(pendingActOpenerStart("<<act:nav then the space came and text"), -1);
+});

--- a/web/test-stream-parse.mjs
+++ b/web/test-stream-parse.mjs
@@ -1,0 +1,46 @@
+// Tests for the AI-search stream parser's split-opener handling (#2290).
+// Imports directly from stream-parse.mjs (the single source of truth) so the
+// test and production code can never drift out of sync.
+//
+// Run:  node --test test-stream-parse.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pendingOpenerLen } from "./src/lib/stream-parse.mjs";
+
+const OPEN = "<<offer:";
+
+test("holds back the longest trailing prefix of the opener (every split offset)", () => {
+  // A buffer ending in each partial opener must hold exactly that many chars, so
+  // the rest of the marker arriving next chunk still forms a whole `<<offer:`.
+  for (let k = 1; k < OPEN.length; k++) {
+    const partial = OPEN.slice(0, k);
+    assert.equal(
+      pendingOpenerLen("Found a great role " + partial, OPEN),
+      k,
+      `should hold ${k} chars for trailing "${partial}"`,
+    );
+  }
+});
+
+test("the reported case: a trailing '<<off' is held, not flushed", () => {
+  // The old fixed-7-char tail check returned 0 here → the offer was dropped.
+  assert.equal(pendingOpenerLen("Found a great role <<off", OPEN), 5);
+});
+
+test("holds nothing when the tail can't begin the opener", () => {
+  assert.equal(pendingOpenerLen("plain narration text", OPEN), 0);
+  assert.equal(pendingOpenerLen("", OPEN), 0);
+});
+
+test("a lone '<' is held (it can begin the opener)", () => {
+  assert.equal(pendingOpenerLen("ends with a single <", OPEN), 1);
+});
+
+test("caps at opener.length - 1 (a complete opener is the found-opener path, not held)", () => {
+  assert.ok(pendingOpenerLen("x" + OPEN, OPEN) <= OPEN.length - 1);
+});
+
+test("a mid-buffer opener prefix is not mistaken for a trailing one", () => {
+  assert.equal(pendingOpenerLen("<<of appeared then more plain text", OPEN), 0);
+});


### PR DESCRIPTION
Closes #2292.

`parseEnvelopes` in `web/src/components/assistant-console.tsx` hides an in-flight `<<act:ID {json}>>` envelope via `hidePartialFrom` — but only after the opener regex `/<<act:([a-zA-Z]+)[ \t]+/` has *fully* matched, which needs `<<act:`, the id letters, **and** the trailing space. Streaming delivers those a few chars at a time, so on every chunk between `<<` and the space, nothing hides the partial opener and it renders into the chat bubble.

Ported the component's parse + display path and streamed a navigate action char-by-char — 11 frames leak before the space arrives:

```
"Here you go. <<ac"
"Here you go. <<act:"
"Here you go. <<act:navigate"
…
```

Since every assistant action (navigate, remember, setStatus, setApplyField) opens with `<<act:`, the user sees this flicker constantly.

## Fix

Fold a **trailing** partial opener's start index into `hidePartialFrom`. Extracted the detection into a pure `pendingActOpenerStart()` helper in `web/src/lib/act-envelope.mjs` — mirroring `stream-parse.mjs` / `clean-chips.mjs` — so it's unit-testable under `node --test` and the component change stays a two-line fold. It's anchored to end-of-buffer, so a completed envelope earlier in the string (followed by `>>`) is never matched, and once the trailing space arrives it defers to the existing regex.

Re-running the same simulation with the helper applied: **0 leak frames**, final display `"Here you go.  Done."`.

## Tests

`web/test-act-envelope.mjs` covers every trailing partial as the opener streams in, the bare-prefix cases, the completed-envelope / post-space cases (deferred to the main regex), and the mid-buffer false-positive guard.

`npm test` (web) → **31 passed, 0 failed** (19 clean-chips + 6 stream-parse + 6 act-envelope).

Sibling to #2291 (same invariant, the AI-search `<<offer:` parser). 2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming message parsing to prevent partial action and offer markers from appearing prematurely or flickering.
  * Preserved narration correctly when streamed content splits marker text across chunks.

* **Tests**
  * Expanded automated coverage for split-stream markers and incomplete action envelopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->