### PR TITLE
fix(dashboard): localize the `hired` status label (StatusLabel dropped it)

### DIFF
--- a/dashboard/internal/i18n/catalog.go
+++ b/dashboard/internal/i18n/catalog.go
@@ -171,13 +171,16 @@ func (c *Catalog) ViewModeLabel(mode string) string {
 }
 
 // StatusLabel returns the localized display label for a canonical status ID
-// (interview, offer, responded, applied, evaluated, skip, rejected, discarded).
+// (interview, offer, hired, responded, applied, evaluated, skip, rejected,
+// discarded).
 func (c *Catalog) StatusLabel(norm string) string {
 	switch strings.ToLower(strings.TrimSpace(norm)) {
 	case "interview":
 		return c.StatusInterview
 	case "offer":
 		return c.StatusOffer
+	case "hired":
+		return c.StatusHired
 	case "responded":
 		return c.StatusResponded
 	case "applied":

--- a/dashboard/internal/i18n/i18n_test.go
+++ b/dashboard/internal/i18n/i18n_test.go
@@ -14,6 +14,7 @@ func TestStatusLabel(t *testing.T) {
 	}{
 		{"interview", "Interview", "Mülakat", "Entrevista"},
 		{"offer", "Offer", "Teklif", "Oferta"},
+		{"hired", "Hired", "İşe Alındı", "Contratada"},
 		{"responded", "Responded", "Yanıt Verildi", "Respondida"},
 		{"applied", "Applied", "Başvuruldu", "Aplicada"},
 		{"evaluated", "Evaluated", "Değerlendirildi", "Evaluada"},

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test": "node --test test-clean-chips.mjs"
+    "test": "node --test test-clean-chips.mjs test-stream-parse.mjs"
   },
   "dependencies": {
     "@paper-design/shaders-react": "^0.0.78",

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test": "node --test test-clean-chips.mjs test-stream-parse.mjs"
+    "test": "node --test test-clean-chips.mjs test-stream-parse.mjs test-act-envelope.mjs"
   },
   "dependencies": {
     "@paper-design/shaders-react": "^0.0.78",

--- a/web/src/components/assistant-console.tsx
+++ b/web/src/components/assistant-console.tsx
@@ -15,6 +15,7 @@ import { WorkerCard } from "@/components/jobs/worker-card";
 import { Button } from "@/components/ui/button";
 import { dispatch, type ActionCtx, type DoneInfo } from "@/app/actions/registry";
 import { scoreNum } from "@/lib/format";
+import { pendingActOpenerStart } from "@/lib/act-envelope.mjs";
 import { cn } from "@/lib/cn";
 
 // ── message model: messages are PART arrays so a live worker card can render
@@ -72,6 +73,11 @@ function parseEnvelopes(acc: string): { complete: Env[]; hidePartialFrom: number
     }
     complete.push({ start, end: close + 2, id: m[1], argsJson: acc.slice(argsStart, close).trim() });
   }
+  // The regex above only sees an opener once its id letters AND trailing space
+  // have streamed in. Also hide a shorter trailing partial (`<<`, `<<act:sav`)
+  // so it doesn't flicker into the bubble before the space arrives (#2290-class).
+  const pending = pendingActOpenerStart(acc);
+  if (pending >= 0 && (hidePartialFrom === -1 || pending < hidePartialFrom)) hidePartialFrom = pending;
   return { complete, hidePartialFrom };
 }
 function removeRanges(s: string, cuts: [number, number][]): string {

--- a/web/src/lib/act-envelope.mjs
+++ b/web/src/lib/act-envelope.mjs
@@ -1,0 +1,35 @@
+// Pure JS helper for the assistant console's <<act:ID {json}>> envelope parser
+// (assistant-console.tsx). No TypeScript types so it can be imported by both the
+// component and test-act-envelope.mjs (which can't import .tsx without a runner).
+//
+// parseEnvelopes only hides an incomplete envelope once the opener regex
+// `<<act:([a-zA-Z]+)[ \t]+` fully matches — i.e. `<<act:`, the id letters, AND
+// the trailing space are all present. While a chunk boundary leaves the opener
+// short of that (`<<`, `<<act`, `<<act:save` with no space yet), nothing hides
+// it, so the half-written marker flickers into the rendered chat bubble on every
+// action the assistant takes. This finds where such a trailing partial opener
+// begins so the caller can hide it too — the same "buffer a split opener, never
+// render garbage" invariant the AI-search parser holds (stream-parse.mjs).
+
+const OPEN = "<<act:";
+
+/**
+ * Start index of a trailing partial `<<act:` opener in `acc` that the main
+ * `<<act:([a-zA-Z]+)[ \t]+` regex can't match yet, or -1 if none.
+ *
+ * Anchored to the end of `acc`, so a completed envelope earlier in the string
+ * (which is followed by its `>>`, not by end-of-buffer) is never matched.
+ *
+ * @param {string} acc - Accumulated assistant text so far.
+ * @returns {number} Index where the trailing partial opener starts, else -1.
+ */
+export function pendingActOpenerStart(acc) {
+  // `<<act:` plus any id letters, but no trailing space yet → regex can't fire.
+  const withColon = /<<act:[a-zA-Z]*$/.exec(acc);
+  if (withColon) return withColon.index;
+  // A proper prefix of the literal `<<act:` at the very end (`<` … `<<act`).
+  for (let k = Math.min(acc.length, OPEN.length - 1); k > 0; k--) {
+    if (acc.endsWith(OPEN.slice(0, k))) return acc.length - k;
+  }
+  return -1;
+}

--- a/web/src/lib/explore-ai.ts
+++ b/web/src/lib/explore-ai.ts
@@ -5,6 +5,7 @@
 // across stream chunk boundaries must BUFFER, never flush as garbage or drop.
 
 import type { DiscoveredOffer } from "./explore";
+import { pendingOpenerLen } from "./stream-parse.mjs";
 
 const OPEN = "<<offer:";
 const CLOSE = ">>";
@@ -58,20 +59,15 @@ export function makeAiStreamParser(opts?: { knownUrls?: Set<string> }) {
       for (;;) {
         const open = buf.indexOf(OPEN);
         if (open === -1) {
-          // No opener in view. Flush as narration — but hold back a short tail
-          // that could be the start of a split opener ("<<offe…").
-          const keep = OPEN.length - 1;
-          if (buf.length > keep) {
-            const tail = buf.slice(buf.length - keep);
-            if (OPEN.startsWith(tail)) {
-              const text = buf.slice(0, buf.length - keep);
-              if (text.trim()) out.push({ kind: "narration", text });
-              buf = tail;
-            } else {
-              if (buf.trim()) out.push({ kind: "narration", text: buf });
-              buf = "";
-            }
-          }
+          // No opener in view. Flush as narration — but hold back the longest
+          // trailing run that could be the start of a split opener ("<<offe…"),
+          // so an offer whose marker straddles a chunk boundary is never dropped
+          // as garbage (#2290). A fixed-length tail check missed the shorter
+          // partial openers ("<<", "<<off") preceded by other text.
+          const hold = pendingOpenerLen(buf, OPEN);
+          const text = hold ? buf.slice(0, buf.length - hold) : buf;
+          if (text.trim()) out.push({ kind: "narration", text });
+          buf = hold ? buf.slice(buf.length - hold) : "";
           break;
         }
         const before = buf.slice(0, open);

--- a/web/src/lib/stream-parse.mjs
+++ b/web/src/lib/stream-parse.mjs
@@ -1,0 +1,27 @@
+// Pure JS helper for the AI-search <<offer:>> stream parser — no TypeScript
+// types so it can be imported directly by both explore-ai.ts (which uses it)
+// and test-stream-parse.mjs (which can't import .ts without a runner). This is
+// the single source of truth for the "how much of a possibly-split opener do we
+// hold back?" logic — the load-bearing part of never dropping an offer whose
+// `<<offer:` marker straddles a stream chunk boundary (#2290).
+
+/**
+ * Length of the trailing run of `buf` that is a proper prefix of `opener` —
+ * i.e. a possibly-split opener to buffer rather than flush as narration.
+ *
+ * Returns the LONGEST such suffix length (0 if none). The previous code checked
+ * only whether the fixed last `opener.length - 1` characters formed a prefix,
+ * which missed shorter partial openers (`<<`, `<<off`) preceded by other text
+ * and dropped the offer once the rest of the marker arrived (#2290).
+ *
+ * @param {string} buf - Current parse buffer with no full `opener` in view.
+ * @param {string} opener - The envelope opener, e.g. "<<offer:".
+ * @returns {number} Number of trailing chars to keep buffered (0 = flush all).
+ */
+export function pendingOpenerLen(buf, opener) {
+  const max = Math.min(buf.length, opener.length - 1);
+  for (let k = max; k > 0; k--) {
+    if (buf.endsWith(opener.slice(0, k))) return k;
+  }
+  return 0;
+}

--- a/web/test-act-envelope.mjs
+++ b/web/test-act-envelope.mjs
@@ -1,0 +1,49 @@
+// Tests for the assistant console's partial <<act:> opener hiding (#2290-class).
+// Imports directly from act-envelope.mjs (the single source of truth) so the
+// test and production code can never drift.
+//
+// Run:  node --test test-act-envelope.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pendingActOpenerStart } from "./src/lib/act-envelope.mjs";
+
+test("every trailing partial opener is caught as the stream builds `<<act:navigate `", () => {
+  // Char-by-char up to (but not including) the space the regex requires: each
+  // trailing partial must report a hide-start so it never renders.
+  const prefix = "Here you go. ";
+  const opener = "<<act:navigate"; // no trailing space yet
+  for (let i = 1; i <= opener.length; i++) {
+    const acc = prefix + opener.slice(0, i);
+    assert.equal(
+      pendingActOpenerStart(acc),
+      prefix.length,
+      `partial "${opener.slice(0, i)}" should hide from index ${prefix.length}`,
+    );
+  }
+});
+
+test("a lone '<' and the bare '<<act:' are both hidden", () => {
+  assert.equal(pendingActOpenerStart("text <"), 5);
+  assert.equal(pendingActOpenerStart("text <<act:"), 5);
+});
+
+test("no trailing opener → -1", () => {
+  assert.equal(pendingActOpenerStart("plain assistant prose"), -1);
+  assert.equal(pendingActOpenerStart(""), -1);
+});
+
+test("a completed envelope earlier in the buffer is not matched", () => {
+  // Followed by `>>` and more text — the tail isn't a partial opener.
+  const acc = 'Done <<act:navigate {"path":"/"}>> and more prose';
+  assert.equal(pendingActOpenerStart(acc), -1);
+});
+
+test("once the trailing space arrives, this helper defers to the main regex", () => {
+  // `<<act:save ` (space, no `>>`) is the main regex's job, not ours.
+  assert.equal(pendingActOpenerStart("x <<act:save "), -1);
+});
+
+test("a mid-buffer '<<act:' with later prose is not mistaken for a trailing one", () => {
+  assert.equal(pendingActOpenerStart("<<act:nav then the space came and text"), -1);
+});

--- a/web/test-stream-parse.mjs
+++ b/web/test-stream-parse.mjs
@@ -1,0 +1,46 @@
+// Tests for the AI-search stream parser's split-opener handling (#2290).
+// Imports directly from stream-parse.mjs (the single source of truth) so the
+// test and production code can never drift out of sync.
+//
+// Run:  node --test test-stream-parse.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pendingOpenerLen } from "./src/lib/stream-parse.mjs";
+
+const OPEN = "<<offer:";
+
+test("holds back the longest trailing prefix of the opener (every split offset)", () => {
+  // A buffer ending in each partial opener must hold exactly that many chars, so
+  // the rest of the marker arriving next chunk still forms a whole `<<offer:`.
+  for (let k = 1; k < OPEN.length; k++) {
+    const partial = OPEN.slice(0, k);
+    assert.equal(
+      pendingOpenerLen("Found a great role " + partial, OPEN),
+      k,
+      `should hold ${k} chars for trailing "${partial}"`,
+    );
+  }
+});
+
+test("the reported case: a trailing '<<off' is held, not flushed", () => {
+  // The old fixed-7-char tail check returned 0 here → the offer was dropped.
+  assert.equal(pendingOpenerLen("Found a great role <<off", OPEN), 5);
+});
+
+test("holds nothing when the tail can't begin the opener", () => {
+  assert.equal(pendingOpenerLen("plain narration text", OPEN), 0);
+  assert.equal(pendingOpenerLen("", OPEN), 0);
+});
+
+test("a lone '<' is held (it can begin the opener)", () => {
+  assert.equal(pendingOpenerLen("ends with a single <", OPEN), 1);
+});
+
+test("caps at opener.length - 1 (a complete opener is the found-opener path, not held)", () => {
+  assert.ok(pendingOpenerLen("x" + OPEN, OPEN) <= OPEN.length - 1);
+});
+
+test("a mid-buffer opener prefix is not mistaken for a trailing one", () => {
+  assert.equal(pendingOpenerLen("<<of appeared then more plain text", OPEN), 0);
+});


### PR DESCRIPTION
Closes #2294.

`StatusLabel(norm)` in `dashboard/internal/i18n/catalog.go` maps a canonical status ID to its localized label, but its `switch` had no `case "hired"`. The catalog already carries a `StatusHired` field translated in every locale:

| Locale | `StatusHired` |
|--------|---------------|
| En | `Hired` |
| Tr | `İşe Alındı` |
| Es | `Contratada` |

Without the case, a `hired` row fell through to `default: return norm` and rendered the raw lowercase English `"hired"` in the TUI — untranslated, uncapitalized — while the correct label sat unused two structs away.

Same incomplete-`Hired`-propagation class as #2289 (the pipeline colour map): `Hired` was added to `states.yml` (#2050) and translated, but a consuming `switch` was missed.

## Fix
- Add `case "hired": return c.StatusHired` (placed after `offer`, matching the canonical order).
- Update the doc comment's status list to include `hired`.

## Test
`TestStatusLabel` covered the other 8 statuses but omitted `hired` — which is why this slipped through. Added the row:

```go
{"hired", "Hired", "İşe Alındı", "Contratada"},
```

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized “Hired” status labels in Turkish, Spanish, and English.

* **Bug Fixes**
  * Improved streaming message rendering by preventing incomplete action and offer markers from briefly appearing.
  * Preserved text correctly when markers are split across incoming stream chunks.

* **Tests**
  * Expanded coverage for localized status labels and streaming marker handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->