### PR TITLE
fix(followup): recognise name-only outreach so an empty contact list means no contact

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -219,9 +219,21 @@ function parseOverrides() {
 }
 
 // --- Extract contacts from notes ---
-function extractContacts(notes) {
+// Outreach recorded in notes is usually a NAME, not an email — LinkedIn, the
+// most common channel, never produces one. An email-only parser therefore
+// reports `contacts: []` for rows that do have a human attached, and "no
+// contact" becomes indistinguishable from "contact with no email on file".
+// That inverts the meaning of the field: an empty list reads as "outreach is
+// untried here" when outreach has in fact been tried and has not converted.
+//
+// Emitted shape is `{ name, email, channel }`. `email` stays first-class (and
+// remains non-null for email contacts) so existing consumers keep working;
+// `channel` is additive.
+export function extractContacts(notes) {
   if (!notes) return [];
   const contacts = [];
+  const seen = new Set();
+
   const emailRegex = /[\w.-]+@[\w.-]+\.\w+/g;
   const emails = notes.match(emailRegex) || [];
   for (const email of emails) {
@@ -230,9 +242,38 @@ function extractContacts(notes) {
     const beforeEmail = notes.substring(0, notes.indexOf(email));
     const nameMatch = beforeEmail.match(/(?:Emailed|emailed|contact[:\s]+|to\s+)([A-Z][a-z]+ ?[A-Z]?[a-z]*)\s*(?:at|@|$)/i);
     if (nameMatch) name = nameMatch[1].trim();
-    contacts.push({ email, name });
+    contacts.push({ name, email, channel: 'email' });
+    if (name) seen.add(name.toLowerCase());
   }
+
+  // Name-shaped contacts. Gated on an explicit outreach verb or role word so a
+  // capitalized company name ("Acme Corp") can never be mistaken for a person.
+  const nameRegex = /\b(?:recruiter|hiring manager|messaged|contacted|reached out to|spoke with|outreach)\b[\s(]*([A-Z][a-z]+(?:\s+[A-Z][a-z'’-]+)+)/g;
+  for (const m of notes.matchAll(nameRegex)) {
+    const name = m[1].trim();
+    if (seen.has(name.toLowerCase())) continue; // already captured with its email
+    seen.add(name.toLowerCase());
+    contacts.push({ name, email: null, channel: detectChannel(notes) });
+  }
+
   return contacts;
+}
+
+// The channel the notes name, when they name one. Null rather than a guess:
+// an unspecified channel is not evidence of any particular one.
+function detectChannel(notes) {
+  if (/\blinkedin\b/i.test(notes)) return 'linkedin';
+  if (/\bemail(ed)?\b/i.test(notes)) return 'email';
+  if (/\bphone|\bcalled\b/i.test(notes)) return 'phone';
+  return null;
+}
+
+// Display label for a contact: the email when there is one, otherwise the name.
+// The summary table reads this instead of `.email` directly, so a name-only
+// contact shows the person rather than a literal "null".
+export function contactLabel(contact) {
+  if (!contact) return '-';
+  return contact.email || contact.name || '-';
 }
 
 // --- Resolve report path ---
@@ -428,7 +469,7 @@ function printSummary(result) {
   for (const e of entries) {
     const urgLabel = urgencyIcon[e.urgency] || e.urgency;
     const nextStr = e.nextFollowupDate || '-';
-    const contactStr = e.contacts.length > 0 ? e.contacts[0].email : '-';
+    const contactStr = e.contacts.length > 0 ? contactLabel(e.contacts[0]) : '-';
     console.log(
       '  ' +
       String(e.num).padEnd(5) +

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -229,42 +229,90 @@ function parseOverrides() {
 // Emitted shape is `{ name, email, channel }`. `email` stays first-class (and
 // remains non-null for email contacts) so existing consumers keep working;
 // `channel` is additive.
+const EMAIL_RE = /[\w.-]+@[\w.-]+\.\w+/g;
+
+// Name-shaped contacts are gated on an explicit outreach verb or role word, so
+// a capitalized company name ("Acme Corp") can never be mistaken for a person.
+// Both name parts allow an internal hyphen or apostrophe ("Mary-Jane
+// O'Brien") — dropping such a name would report "no contact" for a row that
+// plainly names a person, the very silence this parser exists to remove.
+const OUTREACH_NAME_RE = /\b(?:recruiter|hiring manager|messaged|contacted|emailed|called|reached out to|spoke with|outreach)\b[\s(]*([A-Z][a-z]*(?:[-'’][A-Z]?[a-z]+)*(?:\s+[A-Z][a-z]*(?:[-'’][A-Z]?[a-z]+)*)+)/g;
+
+// One note can record several separate outreach events ("Messaged X on
+// LinkedIn; called Y"). Resolving a contact against the WHOLE note attributes
+// the first channel word it finds to every contact, so the second person is
+// silently credited to the wrong channel. Split into statements and resolve
+// each independently.
+//
+// The sentence split only fires on a period followed by whitespace and a
+// capital, so it cannot break an address like `jane.doe@acme.com`.
+function splitStatements(notes) {
+  return String(notes).split(/[;\n]+|\.\s+(?=[A-Z])/).filter(s => s.trim());
+}
+
 export function extractContacts(notes) {
   if (!notes) return [];
+  const byEmail = new Map();  // normalized email -> contact
+  const byName = new Map();   // normalized name  -> contact
   const contacts = [];
-  const seen = new Set();
 
-  const emailRegex = /[\w.-]+@[\w.-]+\.\w+/g;
-  const emails = notes.match(emailRegex) || [];
-  for (const email of emails) {
-    // Try to extract name before email: "Emailed Name at" or "contact: Name"
-    let name = null;
-    const beforeEmail = notes.substring(0, notes.indexOf(email));
-    const nameMatch = beforeEmail.match(/(?:Emailed|emailed|contact[:\s]+|to\s+)([A-Z][a-z]+ ?[A-Z]?[a-z]*)\s*(?:at|@|$)/i);
-    if (nameMatch) name = nameMatch[1].trim();
-    contacts.push({ name, email, channel: 'email' });
-    if (name) seen.add(name.toLowerCase());
-  }
+  const add = ({ name, email, channel }) => {
+    const emailKey = email ? email.toLowerCase() : null;
+    const nameKey = name ? name.toLowerCase() : null;
 
-  // Name-shaped contacts. Gated on an explicit outreach verb or role word so a
-  // capitalized company name ("Acme Corp") can never be mistaken for a person.
-  const nameRegex = /\b(?:recruiter|hiring manager|messaged|contacted|reached out to|spoke with|outreach)\b[\s(]*([A-Z][a-z]+(?:\s+[A-Z][a-z'’-]+)+)/g;
-  for (const m of notes.matchAll(nameRegex)) {
-    const name = m[1].trim();
-    if (seen.has(name.toLowerCase())) continue; // already captured with its email
-    seen.add(name.toLowerCase());
-    contacts.push({ name, email: null, channel: detectChannel(notes) });
+    // Same address recorded twice is one contact; fill in a name/channel the
+    // earlier mention lacked rather than emitting a duplicate.
+    const existing = (emailKey && byEmail.get(emailKey)) || (nameKey && byName.get(nameKey)) || null;
+    if (existing) {
+      if (!existing.name && name) existing.name = name;
+      if (!existing.email && email) existing.email = email;
+      if (!existing.channel && channel) existing.channel = channel;
+      if (existing.email) byEmail.set(existing.email.toLowerCase(), existing);
+      if (existing.name) byName.set(existing.name.toLowerCase(), existing);
+      return;
+    }
+
+    const contact = { name: name ?? null, email: email ?? null, channel: channel ?? null };
+    contacts.push(contact);
+    if (emailKey) byEmail.set(emailKey, contact);
+    if (nameKey) byName.set(nameKey, contact);
+  };
+
+  for (const span of splitStatements(notes)) {
+    const emails = span.match(EMAIL_RE) || [];
+    const names = [...span.matchAll(OUTREACH_NAME_RE)].map(m => m[1].trim());
+    if (!emails.length && !names.length) continue;
+    const channel = detectChannel(span, emails.length > 0);
+
+    // One person and one address in the same statement is one contact, not an
+    // email-only entry plus a separate name-only duplicate.
+    if (names.length === 1 && emails.length === 1) {
+      add({ name: names[0], email: emails[0], channel });
+      continue;
+    }
+
+    for (const email of emails) {
+      // Fall back to the older "Emailed Name at <addr>" shape for a name that
+      // sits next to the address without a listed outreach verb.
+      let name = null;
+      const beforeEmail = span.substring(0, span.indexOf(email));
+      const nameMatch = beforeEmail.match(/(?:emailed|contact[:\s]+|to\s+)([A-Z][a-z]+ ?[A-Z]?[a-z]*)\s*(?:at|@|$)/i);
+      if (nameMatch) name = nameMatch[1].trim();
+      add({ name, email, channel });
+    }
+    for (const name of names) add({ name, email: null, channel });
   }
 
   return contacts;
 }
 
-// The channel the notes name, when they name one. Null rather than a guess:
-// an unspecified channel is not evidence of any particular one.
-function detectChannel(notes) {
-  if (/\blinkedin\b/i.test(notes)) return 'linkedin';
-  if (/\bemail(ed)?\b/i.test(notes)) return 'email';
-  if (/\bphone|\bcalled\b/i.test(notes)) return 'phone';
+// The channel a single statement names, when it names one. Null rather than a
+// guess: an unspecified channel is not evidence of any particular one. An
+// address in the statement implies email only when no channel word says otherwise.
+function detectChannel(span, hasEmail = false) {
+  if (/\blinkedin\b/i.test(span)) return 'linkedin';
+  if (/\bphone\b|\bcalled\b/i.test(span)) return 'phone';
+  if (/\bemail(ed)?\b/i.test(span) || hasEmail) return 'email';
   return null;
 }
 

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -262,7 +262,25 @@ export function extractContacts(notes) {
 
     // Same address recorded twice is one contact; fill in a name/channel the
     // earlier mention lacked rather than emitting a duplicate.
-    const existing = (emailKey && byEmail.get(emailKey)) || (nameKey && byName.get(nameKey)) || null;
+    const byEmailHit = emailKey ? byEmail.get(emailKey) : null;
+    const byNameHit = nameKey ? byName.get(nameKey) : null;
+
+    // A name-only and an email-only record can be created separately, then a
+    // later statement names BOTH and proves they are the same person. Fold the
+    // two records into one and drop the redundant entry, or the result reports
+    // two contacts where the note itself says there is one.
+    if (byEmailHit && byNameHit && byEmailHit !== byNameHit) {
+      byEmailHit.name = byEmailHit.name || byNameHit.name;
+      byEmailHit.email = byEmailHit.email || byNameHit.email;
+      byEmailHit.channel = byEmailHit.channel || byNameHit.channel;
+      const idx = contacts.indexOf(byNameHit);
+      if (idx !== -1) contacts.splice(idx, 1);
+      // Repoint every key that pointed at the discarded record.
+      for (const [k, v] of byEmail) if (v === byNameHit) byEmail.set(k, byEmailHit);
+      for (const [k, v] of byName) if (v === byNameHit) byName.set(k, byEmailHit);
+    }
+
+    const existing = byEmailHit || byNameHit || null;
     if (existing) {
       if (!existing.name && name) existing.name = name;
       if (!existing.email && email) existing.email = email;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5438,6 +5438,19 @@ try {
       }
     }
 
+    // LATE BRIDGE: a name-only and an email-only record can be recorded
+    // separately, then a later statement names BOTH and proves they are one
+    // person. Leaving two records behind reports two contacts where the note
+    // itself says there is one.
+    {
+      const bridged = cadence.extractContacts('recruiter Ann Lee; emailed ann.lee@acme.com; contacted Ann Lee at ann.lee@acme.com');
+      if (bridged.length === 1 && bridged[0].name === 'Ann Lee' && bridged[0].email === 'ann.lee@acme.com') {
+        pass('extractContacts coalesces name-only and email-only records once a later statement bridges them');
+      } else {
+        fail(`extractContacts late-bridge got ${JSON.stringify(bridged)}`);
+      }
+    }
+
     // A hyphenated or apostrophed name is still a name. Dropping it reports
     // "no contact" for a row that names a person, which is the exact silence
     // this parser exists to remove.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5343,6 +5343,54 @@ try {
     fail('parseDate validation wrong');
   }
 
+  // extractContacts — recorded outreach is usually a NAME (LinkedIn produces no
+  // email), so an email-only parser reports contacts: [] for rows that do have a
+  // human attached. "no contact" then reads identically to "contact with no
+  // email on file", which inverts the meaning of the field.
+  {
+    const nameOnly = cadence.extractContacts('reached out to recruiter Julia Masera (LinkedIn)');
+    if (nameOnly.length === 1 && nameOnly[0].name === 'Julia Masera' && nameOnly[0].email === null) {
+      pass('extractContacts finds a name-only contact with no email on file');
+    } else {
+      fail(`extractContacts name-only got ${JSON.stringify(nameOnly)}`);
+    }
+    if (nameOnly[0] && nameOnly[0].channel === 'linkedin') {
+      pass('extractContacts carries the channel through when the notes name one');
+    } else {
+      fail(`extractContacts should report channel 'linkedin', got ${JSON.stringify(nameOnly[0])}`);
+    }
+
+    const emailed = cadence.extractContacts('Emailed Jane Doe at jane.doe@acme.com');
+    if (emailed.length === 1 && emailed[0].email === 'jane.doe@acme.com' && emailed[0].channel === 'email') {
+      pass('extractContacts still resolves an email contact (regression)');
+    } else {
+      fail(`extractContacts email-case got ${JSON.stringify(emailed)}`);
+    }
+
+    if (cadence.extractContacts('On-archetype fit; no submission yet').length === 0) {
+      pass('extractContacts reports no contact when the notes carry none');
+    } else {
+      fail('extractContacts should find nothing in notes with no outreach');
+    }
+
+    // A bare capitalized word pair must not be mistaken for a contact — only a
+    // named outreach verb qualifies, or the field fills with company names.
+    if (cadence.extractContacts('Strong fit for Acme Corp; Series B').length === 0) {
+      pass('extractContacts does not treat a capitalized company name as a contact');
+    } else {
+      fail(`extractContacts false-positived on a company name: ${JSON.stringify(cadence.extractContacts('Strong fit for Acme Corp; Series B'))}`);
+    }
+
+    // The summary printer reads contacts[0].email directly; a name-only contact
+    // must not surface as a literal "null" in that column.
+    const label = cadence.contactLabel(cadence.extractContacts('messaged recruiter Asha Beirne')[0]);
+    if (label === 'Asha Beirne') {
+      pass('contactLabel shows the name when the contact has no email');
+    } else {
+      fail(`contactLabel should fall back to the name, got ${JSON.stringify(label)}`);
+    }
+  }
+
   // parseAppliedDate — extracts the real submission date from notes (the
   // tracker `date` column is the evaluation date), case-insensitive.
   if (cadence.parseAppliedDate('Applied 2026-06-09 via Personio; raised part-time') === '2026-06-09') {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5381,6 +5381,85 @@ try {
       fail(`extractContacts false-positived on a company name: ${JSON.stringify(cadence.extractContacts('Strong fit for Acme Corp; Series B'))}`);
     }
 
+    // MULTIPLICITY: two contacts in one note, reached on DIFFERENT channels.
+    // A whole-note channel scan tags both with whichever channel word appears
+    // first, so the second contact is silently attributed to the wrong channel.
+    {
+      const two = cadence.extractContacts('Messaged recruiter Asha Beirne on LinkedIn; called hiring manager Bob Smith');
+      const asha = two.find(c => c.name === 'Asha Beirne');
+      const bob = two.find(c => c.name === 'Bob Smith');
+      if (two.length === 2 && asha && bob) {
+        pass('extractContacts finds both contacts when one note names two people');
+      } else {
+        fail(`extractContacts two-contact case got ${JSON.stringify(two)}`);
+      }
+      if (asha?.channel === 'linkedin' && bob?.channel === 'phone') {
+        pass('extractContacts derives each contact channel from its own statement, not the whole note');
+      } else {
+        fail(`per-contact channel wrong: asha=${JSON.stringify(asha?.channel)} bob=${JSON.stringify(bob?.channel)}`);
+      }
+    }
+
+    // MERGE: one outreach statement naming a person AND their email is ONE
+    // contact, not an email-only contact plus a separate name-only duplicate.
+    {
+      const merged = cadence.extractContacts('contacted Jane Doe at jane.doe@acme.com');
+      if (merged.length === 1 && merged[0].name === 'Jane Doe' && merged[0].email === 'jane.doe@acme.com') {
+        pass('extractContacts merges a name and email from the same outreach statement');
+      } else {
+        fail(`extractContacts merge-case got ${JSON.stringify(merged)}`);
+      }
+    }
+
+    // DEDUP: the same address repeated in a note is one contact, not two.
+    {
+      const repeated = cadence.extractContacts('emailed jane.doe@acme.com; followed up jane.doe@acme.com');
+      if (repeated.length === 1) {
+        pass('extractContacts deduplicates a repeated email address');
+      } else {
+        fail(`extractContacts repeated-email got ${JSON.stringify(repeated)}`);
+      }
+      // Address case must not defeat the dedup.
+      const cased = cadence.extractContacts('emailed Jane.Doe@Acme.com; then jane.doe@acme.com again');
+      if (cased.length === 1) {
+        pass('extractContacts deduplicates emails case-insensitively');
+      } else {
+        fail(`extractContacts case-variant email got ${JSON.stringify(cased)}`);
+      }
+    }
+
+    // The same person named twice across statements stays one contact.
+    {
+      const dup = cadence.extractContacts('messaged recruiter Ryan Hill; recruiter Ryan Hill replied');
+      if (dup.length === 1 && dup[0].name === 'Ryan Hill') {
+        pass('extractContacts does not double-count a person named in two statements');
+      } else {
+        fail(`extractContacts repeated-name got ${JSON.stringify(dup)}`);
+      }
+    }
+
+    // A hyphenated or apostrophed name is still a name. Dropping it reports
+    // "no contact" for a row that names a person, which is the exact silence
+    // this parser exists to remove.
+    {
+      const punct = cadence.extractContacts('reached out to recruiter Mary-Jane O’Brien (LinkedIn)');
+      if (punct.length === 1 && punct[0].name === 'Mary-Jane O’Brien') {
+        pass('extractContacts handles hyphenated and apostrophed names');
+      } else {
+        fail(`extractContacts punctuated-name got ${JSON.stringify(punct)}`);
+      }
+    }
+
+    // An email with no name attached still yields a contact (name null).
+    {
+      const bare = cadence.extractContacts('sent CV to careers@acme.com');
+      if (bare.length === 1 && bare[0].email === 'careers@acme.com' && bare[0].name === null) {
+        pass('extractContacts keeps a bare email contact with no name');
+      } else {
+        fail(`extractContacts bare-email got ${JSON.stringify(bare)}`);
+      }
+    }
+
     // The summary printer reads contacts[0].email directly; a name-only contact
     // must not surface as a literal "null" in that column.
     const label = cadence.contactLabel(cadence.extractContacts('messaged recruiter Asha Beirne')[0]);


### PR DESCRIPTION
## Summary

`extractContacts()` only matched an **email address**, but most recorded outreach is a **name** — LinkedIn, the most common channel, never produces an email. Rows like `reached out to recruiter Julia Masera (LinkedIn)` reported `contacts: []`.

That inverts the meaning of the field. An empty list reads as *"outreach is untried here"* when outreach has in fact been tried and has not converted, and any analysis built on it concludes the wrong thing about someone's job search.

All four real-world examples from the issue now resolve:

| Notes fragment | Before | After |
|---|---|---|
| `contacting recruiter Ryan Hill` | `[]` | `Ryan Hill` |
| `messaged recruiter Asha Beirne` | `[]` | `Asha Beirne` |
| `reached out to recruiter Julia Masera (LinkedIn)` | `[]` | `Julia Masera` (channel `linkedin`) |
| `Recruiter outreach (Joey Martinez, #LI-JM1) sent` | `[]` | `Joey Martinez` |

Closes #2299 — split out of #2288 at @jamin84's suggestion, since it is a separate parser with its own failure mode.

## Design notes

- **Name matching is gated on an explicit outreach verb or role word** (`recruiter`, `hiring manager`, `messaged`, `contacted`, `reached out to`, `spoke with`, `outreach`). A bare capitalized pair is *not* enough — otherwise the field fills with company names. There's a test asserting `Strong fit for Acme Corp; Series B` yields no contact.
- **Emitted shape is `{ name, email, channel }`.** `email` stays first-class and remains non-null for email contacts, so existing consumers keep working; `channel` is additive.
- **`channel` is `null` rather than a guess** when the notes don't name one — an unspecified channel isn't evidence of any particular one.
- **A contact captured with its email is not re-emitted** as a name-only duplicate.
- **Adds `contactLabel()`**, used by the summary table in place of a direct `.email` read. Without it a name-only contact would have rendered as a literal `null` in that column — a consumer break the tests now cover.

## Test plan
- [x] `node test-all.mjs` — 2457 passed, 0 failed
- [x] Test written first and confirmed failing (`cadence.extractContacts is not a function`)
- [x] Email-contact regression case still passes
- [x] Explicit false-positive guard for a capitalized company name
- [x] `contactLabel()` covered for the no-email case


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced contact extraction from outreach notes, including channel attribution per outreach statement and support for name-only contacts.
  * Added a new `contactLabel` helper to render contacts by email (when present) or otherwise by name, including in summary output.

* **Bug Fixes**
  * Improved parsing to avoid cross-attributing channel data across multiple outreach statements.
  * More reliable merging and deduplication of contacts across name/email variations and repeated mentions.

* **Tests**
  * Expanded coverage for channel detection, deduplication (including case-insensitive emails), hyphenated/apostrophed names, and label fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->