### PR TITLE
fix(pipeline-lock): floor the ownerless stale check, harden the timeout tests

### DIFF
--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -16,7 +16,10 @@
 //     before deleting anything.
 //   - staleness is judged by owner-PID liveness first, falling back to
 //     directory age only when the metadata is missing or unreadable. An old
-//     lock whose owner is still running is NOT stale.
+//     lock whose owner is still running is NOT stale, and an ownerless
+//     directory gets a fixed grace period (OWNERLESS_GRACE_MS) before age
+//     alone can condemn it, so a directory created microseconds ago is never
+//     reclaimable no matter how aggressive the caller's staleMs.
 //   - stale reclamation is serialized behind a second atomic guard directory
 //     ("<path>.lock.recover"). Without it, reclamation is itself a TOCTOU
 //     race: two callers that both judge the same lock stale can have the
@@ -32,6 +35,7 @@ import { join, dirname } from 'path';
 import { randomUUID } from 'crypto';
 
 const DEFAULT_STALE_MS = 30_000;
+export const OWNERLESS_GRACE_MS = 1_000;
 const DEFAULT_RETRY_MS = 80;
 const DEFAULT_TIMEOUT_MS = 8_000;
 
@@ -77,11 +81,22 @@ function processIsAlive(pid) {
 
 // Conservative: a lock whose recorded owner is still running is never stale,
 // however old it is. Age is the fallback only when there's no readable owner.
+//
+// That fallback needs a floor. Two directories are ownerless by construction,
+// not by accident: a lock between its mkdir and its owner.json write, and the
+// recover guard, which never carries owner.json at all. Judging those on
+// `age > staleMs` alone lets a caller with an aggressive staleMs delete a
+// directory created microseconds ago — either stealing a winner's lock inside
+// its acquisition window, or evicting a live guard and putting two callers
+// inside the decide-then-delete window the guard exists to serialize.
+// OWNERLESS_GRACE_MS is a lower bound on that patience, never a cap: a larger
+// caller staleMs still wins, and a genuinely abandoned directory still ages
+// out, so a crash while holding the guard cannot disable recovery for good.
 function lockCanRecover(lockDir, staleMs) {
   const owner = readLockOwner(lockDir);
   if (owner?.pid) return !processIsAlive(owner.pid);
   try {
-    return Date.now() - statSync(lockDir).mtimeMs > staleMs;
+    return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
   } catch {
     return true; // vanished — nothing to recover, retry acquisition
   }
@@ -95,7 +110,7 @@ function lockCanRecover(lockDir, staleMs) {
  * @param {object} [options]
  * @param {number} [options.timeoutMs=8000] - Max time to wait for the lock.
  * @param {number} [options.retryMs=80] - Delay between acquisition attempts.
- * @param {number} [options.staleMs=30000] - Age threshold for a lock with no readable owner.
+ * @param {number} [options.staleMs=30000] - Age threshold for a lock with no readable owner, floored at OWNERLESS_GRACE_MS.
  */
 export async function acquirePipelineLock(pipelinePath, options = {}) {
   // Env overrides let a caller several frames up the stack (a test driving

--- a/test/pipeline-lock.test.mjs
+++ b/test/pipeline-lock.test.mjs
@@ -19,15 +19,33 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
-import { acquirePipelineLock, LockTimeoutError } from '../pipeline-lock.mjs';
+import { acquirePipelineLock, LockTimeoutError, OWNERLESS_GRACE_MS } from '../pipeline-lock.mjs';
 
 function fixtureRoot() {
   const root = mkdtempSync(join(tmpdir(), 'career-ops-pipeline-lock-'));
   mkdirSync(join(root, 'data'), { recursive: true });
   return root;
+}
+
+// Ages a directory by rewriting its mtime, so the age-based branch can be
+// exercised at any point on either side of the grace floor without sleeping.
+function backdate(dir, ms) {
+  const when = new Date(Date.now() - ms);
+  utimesSync(dir, when, when);
+}
+
+// A lock directory left behind by a holder that died — stale by the owner-PID
+// rule, so reclamation is genuinely on the table.
+function writeCrashedHolder(lockDir) {
+  mkdirSync(lockDir, { recursive: true });
+  writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
+    pid: 2147483000, // not a live pid
+    token: 'crashed-holder-token',
+    started_at: new Date(Date.now() - 60 * 60_000).toISOString(),
+  }), 'utf-8');
 }
 
 test('acquirePipelineLock: a live holder blocks a second acquirer, which times out', async () => {
@@ -55,8 +73,14 @@ test('acquirePipelineLock: configurable timing — the contention timeout is not
     const held = await acquirePipelineLock(p, { timeoutMs: 150, retryMs: 20 });
     try {
       const startedAt = Date.now();
-      await assert.rejects(() => acquirePipelineLock(p, { timeoutMs: 150, retryMs: 20 }));
+      // The failure must be the *timeout*, not an unrelated instant throw —
+      // otherwise a lock broken in some other way still passes this test.
+      await assert.rejects(
+        () => acquirePipelineLock(p, { timeoutMs: 150, retryMs: 20 }),
+        (err) => err instanceof LockTimeoutError,
+      );
       const elapsed = Date.now() - startedAt;
+      assert.ok(elapsed >= 100, `timeout returned too early after ${elapsed}ms — the caller timeout was not actually awaited`);
       // Must honor the caller's timeout, not the module default (seconds).
       assert.ok(elapsed < 2000, `expected the caller timeout to be honored, waited ${elapsed}ms`);
     } finally {
@@ -88,12 +112,7 @@ test('acquirePipelineLock: stale-reclaim is serialized — a second reclaimer ca
 
     // Simulate a crashed holder: a lock directory owned by a PID that is not
     // alive, old enough to be judged stale by any age rule.
-    mkdirSync(lockDir, { recursive: true });
-    writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
-      pid: 2147483000, // not a live pid
-      token: 'crashed-holder-token',
-      started_at: new Date(Date.now() - 60 * 60_000).toISOString(),
-    }), 'utf-8');
+    writeCrashedHolder(lockDir);
 
     // Two concurrent acquirers both see the same stale lock. Exactly one must
     // win; the loser must NOT end up holding a lock at the same time.
@@ -104,7 +123,120 @@ test('acquirePipelineLock: stale-reclaim is serialized — a second reclaimer ca
 
     const winners = [a, b].filter((r) => r.status === 'fulfilled');
     assert.equal(winners.length, 1, 'exactly one acquirer may hold the reclaimed lock at a time');
+    // ...and the loser must have lost by *waiting out the lock*, not by
+    // crashing on something unrelated, which would make the count above lie.
+    const failures = [a, b].filter((r) => r.status === 'rejected');
+    assert.ok(
+      failures[0].reason instanceof LockTimeoutError,
+      `the losing acquirer must fail with LockTimeoutError, got: ${failures[0].reason}`,
+    );
     winners.forEach((w) => w.value.release());
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: a just-created ownerless lock is never judged stale, however small the caller staleMs (#2304)', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+
+    // The acquisition window: a holder has mkdir'd the lock but has not
+    // written owner.json yet. Age alone must not make this reclaimable, or a
+    // contender deletes the winner's lock and both end up "holding" it.
+    mkdirSync(lockDir, { recursive: true });
+
+    await assert.rejects(
+      () => acquirePipelineLock(p, { timeoutMs: 200, retryMs: 20, staleMs: 0 }),
+      (err) => err instanceof LockTimeoutError,
+    );
+    assert.ok(existsSync(lockDir), 'a contender destroyed a lock created microseconds ago');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: an ownerless lock older than the grace floor is still reclaimable (#2304)', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+
+    // The floor must not become "ownerless locks are never reclaimable" — a
+    // truly abandoned lock with no owner metadata has to age out.
+    mkdirSync(lockDir, { recursive: true });
+    backdate(lockDir, OWNERLESS_GRACE_MS * 3);
+
+    const lock = await acquirePipelineLock(p, { timeoutMs: 500, retryMs: 20, staleMs: 1 });
+    lock.release();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: the grace floor never shortens a larger caller-supplied staleMs (#2304)', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+
+    // Past the floor, but nowhere near the caller's staleMs. The floor is a
+    // lower bound on patience, not a replacement for the caller's value.
+    mkdirSync(lockDir, { recursive: true });
+    backdate(lockDir, OWNERLESS_GRACE_MS * 2);
+
+    await assert.rejects(
+      () => acquirePipelineLock(p, { timeoutMs: 200, retryMs: 20, staleMs: 60 * 60_000 }),
+      (err) => err instanceof LockTimeoutError,
+    );
+    assert.ok(existsSync(lockDir), 'the caller asked for an hour of patience and got the floor instead');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: a live recover guard is not deleted out from under the caller inside it (#2304)', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+    const guardDir = `${lockDir}.recover`;
+
+    // A stale lock is available to reclaim...
+    writeCrashedHolder(lockDir);
+    // ...but another caller is already inside the guarded decide-then-delete
+    // window. The guard never carries owner.json, so it is judged by age
+    // alone — and a fresh one must not be reclaimable, or two callers end up
+    // inside that window at once and each rmSync's the other's guard.
+    mkdirSync(guardDir);
+
+    await assert.rejects(
+      () => acquirePipelineLock(p, { timeoutMs: 200, retryMs: 20, staleMs: 1 }),
+      (err) => err instanceof LockTimeoutError,
+    );
+    assert.ok(existsSync(guardDir), 'a contender deleted a live recover guard, defeating reclaim serialization');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: a recover guard abandoned by a crashed process still ages out (#2304)', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+    const guardDir = `${lockDir}.recover`;
+
+    // A process killed between taking the guard and cleaning it up must not
+    // disable stale recovery forever — the floor delays reclaim, never blocks it.
+    writeCrashedHolder(lockDir);
+    mkdirSync(guardDir);
+    backdate(guardDir, OWNERLESS_GRACE_MS * 3);
+
+    const lock = await acquirePipelineLock(p, { timeoutMs: 1000, retryMs: 20, staleMs: 1 });
+    lock.release();
+    assert.equal(existsSync(guardDir), false, 'the abandoned recover guard should have been cleaned up');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What does this PR do?

Gives `lockCanRecover()` in `pipeline-lock.mjs` a fixed grace floor before an **ownerless** directory can be condemned on age alone, so a lock or recover guard created microseconds ago is never judged stale no matter how aggressive the caller's `staleMs`. Also hardens the two timeout assertions in `test/pipeline-lock.test.mjs` to require `LockTimeoutError` specifically instead of any rejection.

## Related issue

Closes #2304

Both points were raised by review on #2189 and were still open when it merged.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Details

`lockCanRecover()` fell back to a bare `age > staleMs` check whenever a directory had no readable `owner.json`. Two directories are ownerless **by construction**, not by accident:

1. **A lock inside its acquisition window** — `acquirePipelineLock()` does `mkdirSync(lockDir)` and only then `writeFileSync(owner.json)`. A contender that lands in between takes the age branch, deletes the winner's brand-new lock, and acquires it; the winner then writes its `owner.json` into the replacement directory and both callers believe they hold the lock — precisely the lost-update race #2188 closed.
2. **The recover guard, always** — `recoverGuardDir` never gets an `owner.json` written into it, so `lockCanRecover(recoverGuardDir, staleMs)` is *only ever* the age branch. A caller that finds the guard held just deletes it and takes it on the next pass, so two callers end up inside the decide-then-delete window simultaneously and the first one's `finally { rmSync(recoverGuardDir) }` removes the second one's guard. The serialization the guard exists to provide is defeated.

The fix floors the age branch with `Math.max(staleMs, OWNERLESS_GRACE_MS)` (1 s). It is a **lower bound on patience, never a cap**:

- a larger caller `staleMs` still wins outright (`staleMs: 60_000` still means 60 s),
- the 30 s default path is bit-for-bit unchanged (`Math.max(30_000, 1_000)`),
- a genuinely abandoned ownerless directory still ages out, so a process killed while holding the guard cannot disable stale recovery permanently.

This also removes a latent flake: the existing `stale-reclaim is serialized …` test runs with `staleMs: 1` and only passed because the `mkdir` → `writeFileSync` window is usually under 1 ms. On a loaded machine it could observe two winners.

### Related, deliberately not touched

`tracker-utils.mjs` and `followup-seed.mjs` carry the same unfloored `lockCanRecover()` shape. Fixing those means re-tuning existing callers that pass small `staleMs` values (e.g. `set-status-tests.mjs` uses `staleMs: 50`), so it belongs in its own issue rather than being smuggled into this one. Happy to open it if you want the family fixed.

## Test plan

- [X] **RED first.** Added the new tests against unmodified `main` and confirmed 2 of them fail, for the right reason — `Missing expected rejection`, i.e. the contender *successfully acquired* a lock it must not have been able to acquire:
  ```
  not ok 5 - acquirePipelineLock: a just-created ownerless lock is never judged stale …
    error: 'Missing expected rejection.'
  not ok 8 - acquirePipelineLock: a live recover guard is not deleted out from under the caller inside it …
    error: 'Missing expected rejection.'
  # tests 10 / pass 8 / fail 2
  ```
- [X] **GREEN after the fix** — `node --test test/pipeline-lock.test.mjs` → `# tests 10 / # pass 10 / # fail 0` in 2.2 s.
- [X] **Adversarial cases added** beyond the two findings:
  - *multiplicity* — a contender racing a lock inside its ownerless acquisition window (`staleMs: 0`);
  - *interaction* — a contender against a **live** recover guard; asserts the guard directory still exists afterwards, not just that acquisition failed;
  - *boundary, floor is a floor* — an ownerless lock aged past the floor but well within a large caller `staleMs` must stay protected (catches a fix that replaces `staleMs` instead of flooring it);
  - *boundary, liveness* — an ownerless lock older than the floor must still be reclaimable (catches an over-correction that never reclaims ownerless locks);
  - *boundary, no permanent deadlock* — a guard abandoned by a crashed process must still age out and be cleaned up.
- [X] Tests stay fast — no sleeps added. Ages are simulated with `utimesSync`, and contention uses the existing caller-configurable `timeoutMs`/`retryMs`/`staleMs`. Suite runtime 2.2 s.
- [X] Verified independently of the test file with a standalone repro script (in the issue): both cases print `BUG PRESENT` on `main` @ `dab8517` and `safe` after the fix.
- [X] `node test-all.mjs` → **2451 passed, 0 failed** (1 warning: the pre-existing `cv-sync-check.mjs exited with error (expected without user data)` on a checkout with no CV).
- [X] `node validate-system-paths-coverage.mjs` → `OK: 886 tracked files covered`.
- [X] Grepped every `acquirePipelineLock` caller: none passes a custom `staleMs`, so no production path changes behavior.

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [X] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [X] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [X] I ran `node test-all.mjs` and all tests pass
- [X] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [X] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stale lock recovery to prevent immediate reclamation of locks without owner information.
  - Added a minimum grace period before ownerless locks can be recovered.
  - Preserved longer, caller-defined stale timeouts.
  - Protected active recovery operations from being removed by competing processes.
  - Ensured abandoned recovery operations are eventually cleaned up.

- **Tests**
  - Expanded coverage for lock contention, timeout behavior, grace periods, and recovery safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->