### PR TITLE
fix(echojobs): keep hybrid roles distinguishable from remote (#2258)

### DIFF
--- a/providers/echojobs.mjs
+++ b/providers/echojobs.mjs
@@ -93,9 +93,13 @@ export function normalizeEchojobsJob(j, fallbackCompany) {
       .map((l) => l.trim())
       .join(', ');
   }
+  // The feed is a third-party aggregate, so `remote_type` is compared
+  // case/whitespace-insensitively: a "Hybrid" variant must not fall through
+  // silently and become an unmarked, unfilterable role.
+  const remoteType = typeof j.remote_type === 'string' ? j.remote_type.trim().toLowerCase() : '';
   if (!location) {
-    if (j.remote_type === 'remote') location = 'Remote';
-    else if (j.remote_type === 'hybrid') location = 'Hybrid';
+    if (remoteType === 'remote') location = 'Remote';
+    else if (remoteType === 'hybrid') location = 'Hybrid';
   }
 
   /** @type {{ title: string, url: string, company: string, location: string, postedAt?: number }} */

--- a/providers/echojobs.mjs
+++ b/providers/echojobs.mjs
@@ -54,11 +54,22 @@ const HYBRID_MARKER = /\bhybrid\b/i;
  *               host (NOT echojobs.io), used as the dedup key. Non-https/malformed
  *               URLs drop the item.
  *   - company:  `company_name`, falling back to the portal entry name, then "EchoJobs".
- *   - location: the joined `locations` array; falls back to "Remote" for a
- *               placeless remote posting, "Hybrid" for a placeless hybrid one
- *               (kept distinguishable so a `location_filter.block: ["Hybrid"]`
- *               rule — or a user's own — can still act on it; collapsing both
- *               to "Remote" would make that block unmatchable, #2258).
+ *   - location: the joined `locations` array, with " · Hybrid" appended when
+ *               `remote_type` is hybrid ("Berlin · Hybrid"), and falling back
+ *               to a bare "Hybrid" / "Remote" when the posting lists no place
+ *               at all. Hybrid is never collapsed into "Remote": the emitted
+ *               string is what `location_filter` matches on, so collapsing it
+ *               would make a `block: ["Hybrid"]` rule unmatchable and let
+ *               hybrid roles pass a remote-only filter (#2258). A placeless
+ *               on_site posting keeps "" — only remote/hybrid are
+ *               placeless-tolerant, and "" passes the filter under the
+ *               scanner's "don't penalize missing data" convention.
+ *
+ *               Note this diverges from greenhouse.mjs, which treats a
+ *               work-model-only location as damage to repair via /offices
+ *               enrichment. That provider can recover a real city; this feed
+ *               exposes none, so the work model is the only signal there is
+ *               and is better surfaced than dropped.
  *   - postedAt: `posted_at` (already epoch ms) when a positive finite number.
  *
  * @param {any} j

--- a/providers/echojobs.mjs
+++ b/providers/echojobs.mjs
@@ -50,8 +50,11 @@ function resolveMaxPages(entry) {
  *               host (NOT echojobs.io), used as the dedup key. Non-https/malformed
  *               URLs drop the item.
  *   - company:  `company_name`, falling back to the portal entry name, then "EchoJobs".
- *   - location: the joined `locations` array; falls back to "Remote" when the
- *               posting has no listed place but `remote_type` is remote/hybrid.
+ *   - location: the joined `locations` array; falls back to "Remote" for a
+ *               placeless remote posting, "Hybrid" for a placeless hybrid one
+ *               (kept distinguishable so a `location_filter.block: ["Hybrid"]`
+ *               rule — or a user's own — can still act on it; collapsing both
+ *               to "Remote" would make that block unmatchable, #2258).
  *   - postedAt: `posted_at` (already epoch ms) when a positive finite number.
  *
  * @param {any} j
@@ -90,7 +93,10 @@ export function normalizeEchojobsJob(j, fallbackCompany) {
       .map((l) => l.trim())
       .join(', ');
   }
-  if (!location && (j.remote_type === 'remote' || j.remote_type === 'hybrid')) location = 'Remote';
+  if (!location) {
+    if (j.remote_type === 'remote') location = 'Remote';
+    else if (j.remote_type === 'hybrid') location = 'Hybrid';
+  }
 
   /** @type {{ title: string, url: string, company: string, location: string, postedAt?: number }} */
   const job = { title, url, company, location };

--- a/providers/echojobs.mjs
+++ b/providers/echojobs.mjs
@@ -41,6 +41,10 @@ function resolveMaxPages(entry) {
   return DEFAULT_MAX_PAGES;
 }
 
+// Guards against a doubled marker when the board already spells the work model
+// into the location itself ("Berlin (Hybrid)", "Hybrid - London").
+const HYBRID_MARKER = /\bhybrid\b/i;
+
 /**
  * Normalize a single EchoJobs feed item. Exported for tests.
  *
@@ -97,9 +101,15 @@ export function normalizeEchojobsJob(j, fallbackCompany) {
   // case/whitespace-insensitively: a "Hybrid" variant must not fall through
   // silently and become an unmarked, unfilterable role.
   const remoteType = typeof j.remote_type === 'string' ? j.remote_type.trim().toLowerCase() : '';
-  if (!location) {
-    if (remoteType === 'remote') location = 'Remote';
-    else if (remoteType === 'hybrid') location = 'Hybrid';
+  if (remoteType === 'hybrid') {
+    // A hybrid role keeps its city AND gains the marker ("Berlin · Hybrid"),
+    // same shape as oraclecloud's WorkplaceTypeCode hint. Marking only the
+    // placeless ones would leave `block: ["Hybrid"]` half-working: it would
+    // catch the placeless roles and silently pass every hybrid that happens
+    // to list a city (#2258).
+    if (!HYBRID_MARKER.test(location)) location = [location, 'Hybrid'].filter(Boolean).join(' · ');
+  } else if (!location && remoteType === 'remote') {
+    location = 'Remote';
   }
 
   /** @type {{ title: string, url: string, company: string, location: string, postedAt?: number }} */

--- a/tests/providers/echojobs.test.mjs
+++ b/tests/providers/echojobs.test.mjs
@@ -39,13 +39,24 @@ try {
     fail(`normalizeEchojobsJob => ${JSON.stringify(n)}`);
   }
 
-  // remote fallback when no listed place
+  // remote/hybrid fallback when no listed place — kept distinguishable (#2258)
+  // so a location_filter.block: ["Hybrid"] rule can still catch a hybrid role;
+  // collapsing both to "Remote" would make that block unmatchable.
   const remote = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/1', locations: [], remote_type: 'remote' });
   const hybrid = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/2', remote_type: 'hybrid' });
-  if (remote?.location === 'Remote' && hybrid?.location === 'Remote') {
-    pass('normalizeEchojobsJob falls back to "Remote" for a placeless remote OR hybrid role');
+  if (remote?.location === 'Remote' && hybrid?.location === 'Hybrid') {
+    pass('normalizeEchojobsJob falls back to "Remote" for a placeless remote role, "Hybrid" for a placeless hybrid one (#2258)');
   } else {
     fail(`remote/hybrid fallback => ${JSON.stringify([remote?.location, hybrid?.location])}`);
+  }
+
+  // on_site with no listed place gets no location fallback at all — only
+  // remote/hybrid roles are placeless-tolerant.
+  const onSiteNoPlace = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/3', remote_type: 'on_site' });
+  if (onSiteNoPlace?.location === '') {
+    pass('normalizeEchojobsJob leaves location empty for a placeless on_site role (no false Remote/Hybrid)');
+  } else {
+    fail(`on_site placeless fallback => ${JSON.stringify(onSiteNoPlace?.location)}`);
   }
 
   // company fallback to the entry name

--- a/tests/providers/echojobs.test.mjs
+++ b/tests/providers/echojobs.test.mjs
@@ -59,6 +59,40 @@ try {
     fail(`on_site placeless fallback => ${JSON.stringify(onSiteNoPlace?.location)}`);
   }
 
+  // a hybrid role that DOES list a city keeps the city and gains the marker,
+  // so block: ["Hybrid"] is not half-working (#2258).
+  const hybridWithCity = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/4', locations: ['Berlin'], remote_type: 'hybrid' });
+  if (hybridWithCity?.location === 'Berlin · Hybrid') {
+    pass('normalizeEchojobsJob appends the Hybrid marker to a hybrid role that lists a city (#2258)');
+  } else {
+    fail(`hybrid with city => ${JSON.stringify(hybridWithCity?.location)}`);
+  }
+
+  // the marker is never doubled when the board already spells it out
+  const hybridSpelledOut = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/5', locations: ['Berlin (Hybrid)'], remote_type: 'hybrid' });
+  if (hybridSpelledOut?.location === 'Berlin (Hybrid)') {
+    pass('normalizeEchojobsJob does not double the marker when the location already says Hybrid');
+  } else {
+    fail(`hybrid already spelled out => ${JSON.stringify(hybridSpelledOut?.location)}`);
+  }
+
+  // a placed remote role is left alone — only hybrid gets a marker appended
+  const remoteWithCity = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/6', locations: ['Berlin'], remote_type: 'remote' });
+  if (remoteWithCity?.location === 'Berlin') {
+    pass('normalizeEchojobsJob leaves a placed remote role untouched (no marker beyond the #2258 scope)');
+  } else {
+    fail(`remote with city => ${JSON.stringify(remoteWithCity?.location)}`);
+  }
+
+  // remote_type is a third-party field: casing/whitespace must not smuggle an
+  // unmarked hybrid through.
+  const hybridOddCasing = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/7', locations: ['Berlin'], remote_type: ' Hybrid ' });
+  if (hybridOddCasing?.location === 'Berlin · Hybrid') {
+    pass('normalizeEchojobsJob matches remote_type case/whitespace-insensitively');
+  } else {
+    fail(`hybrid odd casing => ${JSON.stringify(hybridOddCasing?.location)}`);
+  }
+
   // company fallback to the entry name
   const bare = normalizeEchojobsJob({ title: 'X', url: 'https://jobs.lever.co/x/1' }, 'EntryName');
   if (bare?.company === 'EntryName') pass('normalizeEchojobsJob falls back to the entry name for company');


### PR DESCRIPTION
Fixes #2258

## Problem

In `normalizeEchojobsJob`, a placeless posting with `remote_type: 'hybrid'` was mapped to the same location string as a genuinely remote one:

```js
if (!location && (j.remote_type === 'remote' || j.remote_type === 'hybrid')) location = 'Remote';
```

The emitted location string is what `location_filter` matches on, so a remote-only `block: ["Hybrid"]` rule could never match and hybrid roles silently passed it.

## Fix

Hybrid is never collapsed into `Remote`. The work model is surfaced so the existing block-token mechanism can act on it — no new filter machinery:

```js
if (remoteType === 'hybrid') {
  if (!HYBRID_MARKER.test(location)) location = [location, 'Hybrid'].filter(Boolean).join(' · ');
} else if (!location && remoteType === 'remote') {
  location = 'Remote';
}
```

- **Placeless hybrid** → `"Hybrid"`.
- **Hybrid that lists a city** → `"Berlin · Hybrid"` — the city is kept, the marker appended, same shape as `oraclecloud.mjs`'s `WorkplaceTypeCode` hint. Marking only the placeless ones would leave the fix half-working: `block: ["Hybrid"]` would catch them but still pass every hybrid that happens to list a city. `allow: ["berlin"]` keeps matching (substring), `block: ["Hybrid"]` now rejects.
- **Marker never doubled** when the board already spells it out (`"Berlin (Hybrid)"`).
- **`remote_type` compared case/whitespace-insensitively** — third-party aggregate feed; a `"Hybrid"` variant must not fall through and produce an unmarked, unfilterable role.
- **Placed remote roles are untouched** (`"Berlin"` stays `"Berlin"`) — out of scope for this issue.
- **Placeless `on_site`** keeps `""` and passes, per the scanner's "don't penalize missing data" convention.

This diverges from `greenhouse.mjs`, which treats a work-model-only location as damage to repair via `/offices` enrichment. That provider can recover a real city; this feed exposes none, so the work model is the only signal there is and is better surfaced than dropped. Documented in the JSDoc.

### Behaviour change worth calling out

Users with an `allow`-list such as `allow: ["remote"]` previously received placeless hybrid roles (they were labelled `"Remote"`). They will now be filtered out. That is the point of the issue, but it is a visible drop in volume for those configs.

## Test plan

- [x] `node tests/providers/echojobs.test.mjs` — placeless remote/hybrid split, placeless `on_site` (no false `Remote`/`Hybrid`), placed hybrid marker, no-double-marker guard, placed remote untouched, case/whitespace-insensitive `remote_type`
- [x] Verified end-to-end against `buildLocationFilter`: `block: ["Hybrid"]` rejects both `"Hybrid"` and `"Berlin · Hybrid"` while passing `"Berlin"` and `"Remote"`; `allow: ["berlin"]` still accepts `"Berlin · Hybrid"`
- [x] `node test-all.mjs` — 2455 passed, 0 failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected location labels for job postings without listed locations.
  * Placeless remote roles now display as “Remote,” while placeless hybrid roles display as “Hybrid.”
  * On-site roles without a location no longer receive an incorrect remote or hybrid label.
  * Hybrid postings now consistently include the “· Hybrid” marker for filtering, without duplicating it when already present.
  * Improved normalization to handle remote-type text with extra whitespace/casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->