### PR TITLE
fix(tracker-utils, followup-seed): floor the ownerless stale-lock check so a just-created lock can't be stolen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `generate-latex.mjs` | LaTeX CV validator + pdflatex compiler |
 | `scan.mjs` | Zero-token portal scanner (Greenhouse/Ashby/Lever APIs, zero LLM cost) |
 | `scan-ats-full.mjs` | Reverse-ATS keyword-first scanner over full public ATS datasets (Greenhouse/Lever/Ashby/Workday/iCIMS), filtered by portals.yml `title_filter`/`location_filter` — no company list needed; checkpoints every 500 companies, `--resume` continues an interrupted sweep |
+| `scan-interamt.mjs` | Playwright browser scanner for Interamt.de (German public sector portal — Apache Wicket, no REST API) |
 | `check-liveness.mjs` / `liveness-core.mjs` | Job posting liveness checker + shared logic (expired signals win over generic Apply text) |
 | `set-status.mjs` | Canonical tracker-row update: `node set-status.mjs <report#\|company> <State> [--note] [--force]` — strict states.yml validation, report-link mismatch guard, shared lock, atomic write |
 | `invite-match.mjs` | Fuzzy-match a pasted interview invite (company, date, req ID) against the tracker, ranking candidates when a company has multiple entries (JSON or `--summary`) |

--- a/followup-seed-tests.mjs
+++ b/followup-seed-tests.mjs
@@ -13,7 +13,7 @@
  */
 
 import { execFileSync } from 'child_process';
-import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, existsSync, utimesSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -366,6 +366,66 @@ function cleanup(sandbox) {
   else fail(`13. --backfill --date → exit 1 — got ${res.code}\n${res.stdout}${res.stderr}`);
   if (res.stderr.includes('--date cannot be combined with --backfill')) pass('13. usage error explains the rejection');
   else fail(`13. usage error explains the rejection — got\n${res.stderr}`);
+  cleanup(sb);
+}
+
+// ── Test 14: an orphaned recover guard does not block stale-lock recovery ───
+// A process killed between creating `<lock>.recover` and cleaning it up leaves
+// the guard behind forever. Because the guard is the ticket required to run
+// stale-lock recovery at all, an abandoned one permanently disables recovery:
+// every later seed run times out at exit 4 until someone deletes the directory
+// under tmpdir by hand. tracker-utils.mjs and pipeline-lock.mjs both age the
+// guard out for exactly this reason; followup-seed.mjs was the outlier.
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  const guard = `${sb.lock}.recover`;
+  mkdirSync(sb.lock, { recursive: true });   // ownerless: no owner.json
+  mkdirSync(guard, { recursive: true });     // the SIGKILLed predecessor's leftover
+  // Both an hour old. Backdating explicitly keeps the test off the wall clock:
+  // an age of 3_600_000ms clears the configured staleMs of 10 by five orders of
+  // magnitude, so the outcome cannot hinge on how long the retry loop happens
+  // to take.
+  const anHourAgo = new Date(Date.now() - 3_600_000);
+  utimesSync(sb.lock, anHourAgo, anHourAgo);
+  utimesSync(guard, anHourAgo, anHourAgo);
+  const res = run(['1'], sb, {
+    CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS: '10',
+    CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS: '3000',
+  });
+  if (res.code === 0) pass('14. orphaned recover guard does not block stale-lock recovery');
+  else fail(`14. orphaned recover guard does not block stale-lock recovery — got ${res.code}\n${res.stdout}${res.stderr}`);
+  if (existsSync(sb.followups)) pass('14. the seed actually ran after recovery');
+  else fail('14. the seed actually ran after recovery — follow-ups.md was never written');
+  cleanup(sb);
+}
+
+// ── Test 15: a guard still inside its age window is respected ───────────────
+// Guards the fix against the vacuous implementation. Removing the guard
+// unconditionally would also pass test 14 while destroying the mutual
+// exclusion the guard exists to provide — two processes would run recovery on
+// the same lock at once. A fresh guard means a sibling is inside its recovery
+// window right now, so the lock must be left alone even though it is old
+// enough to reclaim.
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  const guard = `${sb.lock}.recover`;
+  mkdirSync(sb.lock, { recursive: true });
+  const twoHoursAgo = new Date(Date.now() - 7_200_000);
+  utimesSync(sb.lock, twoHoursAgo, twoHoursAgo);   // reclaimable, if the guard were free
+  mkdirSync(guard, { recursive: true });           // deliberately left at "now"
+  // staleMs 60_000 against a 400ms timeout pins the boundary: the guard cannot
+  // reach 60s of age inside this run no matter how the retry loop is scheduled,
+  // so "fresh" stays true for the whole window rather than expiring mid-test.
+  const res = run(['1'], sb, {
+    CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS: '60000',
+    CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS: '400',
+  });
+  if (res.code === 4) pass('15. a guard inside its age window is respected → exit 4');
+  else fail(`15. a guard inside its age window is respected → exit 4 — got ${res.code}\n${res.stdout}${res.stderr}`);
+  if (existsSync(guard)) pass('15. the live guard survives');
+  else fail('15. the live guard survives — it was removed');
   cleanup(sb);
 }
 

--- a/followup-seed-tests.mjs
+++ b/followup-seed-tests.mjs
@@ -369,7 +369,7 @@ function cleanup(sandbox) {
   cleanup(sb);
 }
 
-// ── Test 14: a freshly created ownerless lock is not stolen (#2306) ─────────
+// ── Test 14: an ownerless lock inside the grace period is not stolen (#2306) ─
 // The follow-ups lock is ownerless for the instant between its `mkdirSync` and
 // its `owner.json` write. Judging it on `age > staleMs` alone lets a caller
 // with a small staleMs delete a lock created microseconds earlier and walk
@@ -377,13 +377,20 @@ function cleanup(sandbox) {
 {
   const sb = makeSandbox();
   writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
-  mkdirSync(sb.lock, { recursive: true });          // ownerless, created just now
+  // Ownerless for 100ms: past the caller's staleMs (so the unfloored code
+  // reclaims it immediately) but far inside the 1s floor. Pinning both sides
+  // of the relation keeps the test off the wall clock — against a directory
+  // created "just now" this would instead depend on whether a sub-millisecond
+  // age drifts past a 1ms threshold before the retry loop looks again.
+  mkdirSync(sb.lock, { recursive: true });
+  const heldSince = new Date(Date.now() - 100);
+  utimesSync(sb.lock, heldSince, heldSince);
   const res = run(['1'], sb, {
-    CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS: '1',
+    CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS: '10',
     CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS: '300',
   });
-  if (res.code === 4) pass('14. ownerless lock created microseconds ago is not stolen → exit 4');
-  else fail(`14. ownerless lock created microseconds ago is not stolen → exit 4 — got ${res.code}\n${res.stdout}${res.stderr}`);
+  if (res.code === 4) pass('14. ownerless lock inside the grace period is not stolen → exit 4');
+  else fail(`14. ownerless lock inside the grace period is not stolen → exit 4 — got ${res.code}\n${res.stdout}${res.stderr}`);
   if (existsSync(sb.lock)) pass('14. the untouched lock directory survives');
   else fail('14. the untouched lock directory survives — it was removed');
   cleanup(sb);
@@ -399,7 +406,7 @@ function cleanup(sandbox) {
   const when = new Date(Date.now() - 60_000);
   utimesSync(sb.lock, when, when);                  // a real orphan, not a new lock
   const res = run(['1'], sb, {
-    CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS: '1',
+    CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS: '10',
     CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS: '2000',
   });
   if (res.code === 0) pass('15. ownerless lock older than the grace period is still recovered');

--- a/followup-seed-tests.mjs
+++ b/followup-seed-tests.mjs
@@ -13,7 +13,7 @@
  */
 
 import { execFileSync } from 'child_process';
-import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, existsSync, utimesSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -366,6 +366,44 @@ function cleanup(sandbox) {
   else fail(`13. --backfill --date → exit 1 — got ${res.code}\n${res.stdout}${res.stderr}`);
   if (res.stderr.includes('--date cannot be combined with --backfill')) pass('13. usage error explains the rejection');
   else fail(`13. usage error explains the rejection — got\n${res.stderr}`);
+  cleanup(sb);
+}
+
+// ── Test 14: a freshly created ownerless lock is not stolen (#2306) ─────────
+// The follow-ups lock is ownerless for the instant between its `mkdirSync` and
+// its `owner.json` write. Judging it on `age > staleMs` alone lets a caller
+// with a small staleMs delete a lock created microseconds earlier and walk
+// straight into the read-check-append critical section beside its owner.
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  mkdirSync(sb.lock, { recursive: true });          // ownerless, created just now
+  const res = run(['1'], sb, {
+    CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS: '1',
+    CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS: '300',
+  });
+  if (res.code === 4) pass('14. ownerless lock created microseconds ago is not stolen → exit 4');
+  else fail(`14. ownerless lock created microseconds ago is not stolen → exit 4 — got ${res.code}\n${res.stdout}${res.stderr}`);
+  if (existsSync(sb.lock)) pass('14. the untouched lock directory survives');
+  else fail('14. the untouched lock directory survives — it was removed');
+  cleanup(sb);
+}
+
+// ── Test 15: an ownerless lock older than the grace period still recovers ───
+// Guards the fix against the vacuous implementation: a floor that never lets
+// an ownerless lock age out would deadlock every writer behind a real orphan.
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  mkdirSync(sb.lock, { recursive: true });
+  const when = new Date(Date.now() - 60_000);
+  utimesSync(sb.lock, when, when);                  // a real orphan, not a new lock
+  const res = run(['1'], sb, {
+    CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS: '1',
+    CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS: '2000',
+  });
+  if (res.code === 0) pass('15. ownerless lock older than the grace period is still recovered');
+  else fail(`15. ownerless lock older than the grace period is still recovered — got ${res.code}\n${res.stdout}${res.stderr}`);
   cleanup(sb);
 }
 

--- a/followup-seed.mjs
+++ b/followup-seed.mjs
@@ -75,6 +75,12 @@ export const FOLLOWUPS_HEADER = [
 
 const FOLLOWUPS_LOCK_PREFIX = 'career-ops-followups-';
 
+/**
+ * Minimum age before directory age alone may condemn an ownerless lock.
+ * See `lockCanRecover` for why the age check needs a floor.
+ */
+export const OWNERLESS_GRACE_MS = 1_000;
+
 /** Structured error carrying an exit-code-mapping `code`. */
 export class SeedError extends Error {
   constructor(code, message) {
@@ -253,11 +259,28 @@ function readLockOwner(lockDir) {
   }
 }
 
+/**
+ * Decide whether an existing lock can be safely recovered. Owner-PID liveness
+ * wins; directory age is only consulted when the metadata is missing.
+ *
+ * That age fallback needs a floor. A lock is ownerless by construction — not
+ * by accident — for the instant between its `mkdirSync` and its `owner.json`
+ * write. Judging it on `age > staleMs` alone lets a caller with an aggressive
+ * staleMs delete a lock created microseconds ago, stealing it from a winner
+ * still inside its acquisition window and putting two writers into the
+ * read-check-append critical section. OWNERLESS_GRACE_MS is a lower bound on
+ * that patience, never a cap: a larger caller staleMs still wins, and a
+ * genuinely abandoned lock still ages out.
+ *
+ * @param {string} lockDir - Directory that represents the active lock.
+ * @param {number} staleMs - Age threshold for metadata-free lock recovery, floored at OWNERLESS_GRACE_MS.
+ * @returns {boolean} True when the caller may remove and recreate the lock.
+ */
 function lockCanRecover(lockDir, staleMs) {
   const owner = readLockOwner(lockDir);
   if (owner?.pid) return !processIsAlive(owner.pid);
   try {
-    return Date.now() - statSync(lockDir).mtimeMs > staleMs;
+    return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
   } catch {
     return true;
   }
@@ -271,7 +294,7 @@ function lockCanRecover(lockDir, staleMs) {
  *
  * @param {string} lockDir
  * @param {string} followupsPath - Recorded in owner.json for diagnostics.
- * @param {{timeoutMs?: number, retryMs?: number, staleMs?: number}} [options]
+ * @param {{timeoutMs?: number, retryMs?: number, staleMs?: number}} [options] - `staleMs` is floored at OWNERLESS_GRACE_MS.
  * @returns {Promise<{release: Function}>}
  */
 async function acquireFollowupsLock(lockDir, followupsPath, options = {}) {

--- a/followup-seed.mjs
+++ b/followup-seed.mjs
@@ -312,6 +312,17 @@ async function acquireFollowupsLock(lockDir, followupsPath, options = {}) {
         hasRecoverGuard = true;
       } catch (guardErr) {
         if (guardErr?.code !== 'EEXIST') throw guardErr;
+        // A process killed between creating the guard and its cleanup leaves
+        // the guard behind forever, permanently disabling stale-lock recovery
+        // for every future writer. The guard normally lives for milliseconds,
+        // so an old one is judged stale by the same age rule as a
+        // metadata-free lock and removed; the next loop iteration can then
+        // take the guard and run recovery. Removing it unconditionally would
+        // instead let two writers recover the same lock at once, which is
+        // exactly what the guard exists to prevent.
+        if (lockCanRecover(recoverGuardDir, staleMs)) {
+          rmSync(recoverGuardDir, { recursive: true, force: true });
+        }
       }
 
       if (hasRecoverGuard) {

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -7,12 +7,13 @@
  * title or req number. Finding which `data/applications.md` row an invite
  * belongs to otherwise means a manual grep every time.
  *
- * This script extracts a company name (and, if present, a date and a
- * req/job-ID-looking token) from pasted invite text, fuzzy-matches it
- * against the tracker's Company column, and ranks candidates when the same
- * company has multiple applications — which is common. A silent wrong guess
- * is worse than showing a short ranked list, so ambiguous input always
- * returns all plausible candidates rather than picking one.
+ * This script extracts a company name (and, if present, a date, a
+ * req/job-ID-looking token, and a call platform/medium) from pasted invite
+ * text, fuzzy-matches it against the tracker's Company column, and ranks
+ * candidates when the same company has multiple applications — which is
+ * common. A silent wrong guess is worse than showing a short ranked list,
+ * so ambiguous input always returns all plausible candidates rather than
+ * picking one.
  *
  * Run: node invite-match.mjs < invite.txt          (JSON to stdout)
  *      node invite-match.mjs --file invite.txt
@@ -243,6 +244,67 @@ export function extractReqId(text) {
   return m ? m[1] : null;
 }
 
+// A meeting-platform URL is unambiguous, so these are checked in a fixed
+// order and the first hit wins — no scoring needed, unlike company-name
+// matching where several candidates can plausibly overlap.
+//
+// Each pattern requires a proper URL/host boundary, not just a substring
+// match: an optional scheme + single subdomain label ahead of the host, a
+// real host-boundary character (or start-of-string) before that, and a
+// path/query/fragment/whitespace delimiter (or end-of-string) after the
+// host. This rejects lookalike hosts (`notzoom.us`, `teams.microsoft.com.evil.
+// example`) and email addresses (`support@zoom.us`) that merely contain the
+// host string as a substring — "silence stays silence" per this file's
+// extractDate/extractReqId convention, so a lookalike is never reported as
+// a real meeting platform.
+//
+// The prefix boundary also excludes URL-structure characters (`/ ? = & #`)
+// so a platform host is only recognized at the true start of a URL
+// authority, not when it's actually a path segment or query value on a
+// *different* host: `https://example.com/zoom.us` (path segment) and
+// `https://example.com?next=zoom.us` (query value) must NOT match, since
+// `zoom.us` is not the URL's actual host in either case.
+//
+// An optional explicit port (`:443`, `:8443`, etc.) is permitted between
+// the host and the following delimiter, since a URL authority may legally
+// include one (`https://zoom.us:443/j/123456789`) and rejecting it would
+// silently drop otherwise-legitimate invite links.
+const PLATFORM_URL_PATTERNS = [
+  { name: 'Zoom', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?zoom\.us(?::\d{1,5})?(?:[/?#\s]|$)/i },
+  { name: 'Microsoft Teams', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com(?::\d{1,5})?(?:[/?#\s]|$)/i },
+  { name: 'Google Meet', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?meet\.google\.com(?::\d{1,5})?(?:[/?#\s]|$)/i },
+];
+
+// A plain phone number, used only when no meeting-platform URL was found —
+// deliberately simple (not a full E.164/i18n validator), since this is a
+// "does this look like a call-in number" heuristic, not a phone-format
+// validator. Requires a separator between digit groups so it doesn't fire
+// on unrelated long digit runs (req IDs, zip+4, order numbers, etc.).
+const PHONE_PATTERN = /(?:\+?\d{1,3}[\s.-])?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}\b/;
+
+/**
+ * Best-effort extraction of the call platform/medium from raw invite or
+ * scheduling text — distinct from the round *type* (recruiter screen vs.
+ * onsite, etc.), this is specifically about whether the candidate will be
+ * on a video call and which one, or on a plain phone call. A meeting-
+ * platform URL is checked first (Zoom / Microsoft Teams / Google Meet); if
+ * none is present, falls back to a phone-number pattern. Returns null when
+ * nothing plausible is found — never guessed, consistent with this
+ * project's "silence stays silence" convention (see extractDate/extractReqId
+ * above and the title/location filters in scan.mjs).
+ *
+ * @param {string} text - Raw pasted invite/scheduling text.
+ * @returns {'Zoom'|'Microsoft Teams'|'Google Meet'|'Phone'|null}
+ */
+export function extractPlatform(text) {
+  if (!text) return null;
+  for (const { name, pattern } of PLATFORM_URL_PATTERNS) {
+    if (pattern.test(text)) return name;
+  }
+  if (PHONE_PATTERN.test(text)) return 'Phone';
+  return null;
+}
+
 // --- Tracker loading ---
 function loadTracker(appsFile = APPS_FILE) {
   if (!existsSync(appsFile)) return [];
@@ -324,6 +386,7 @@ export function analyzeInvite(text, trackerRows = null) {
     company: extractCompany(text),
     date: extractDate(text),
     reqId: extractReqId(text),
+    platform: extractPlatform(text),
   };
   const rows = trackerRows ?? loadTracker();
   const candidates = matchInvite(signals, rows);
@@ -336,9 +399,10 @@ function printSummary(result) {
   console.log('  Interview Invite Matcher — career-ops');
   console.log(`${'='.repeat(70)}\n`);
 
-  console.log(`  Extracted company: ${result.signals.company || '(not found)'}`);
-  console.log(`  Extracted date:    ${result.signals.date || '(not found)'}`);
-  console.log(`  Extracted req ID:  ${result.signals.reqId || '(not found)'}\n`);
+  console.log(`  Extracted company:  ${result.signals.company || '(not found)'}`);
+  console.log(`  Extracted date:     ${result.signals.date || '(not found)'}`);
+  console.log(`  Extracted req ID:   ${result.signals.reqId || '(not found)'}`);
+  console.log(`  Extracted platform: ${result.signals.platform || '(not found)'}\n`);
 
   if (!result.signals.company) {
     console.log('  Could not find a company name in the invite text — paste more context or check manually.\n');
@@ -402,6 +466,27 @@ function runSelfTest() {
   check(extractReqId('Job ID: 43683') === '43683', 'extracts "Job ID:" token');
   check(extractReqId('no id here') === null, 'returns null when no req-like token is present');
 
+  // --- extractPlatform ---
+  check(extractPlatform('Join via Zoom: https://us02web.zoom.us/j/1234567890') === 'Zoom', 'detects Zoom from a zoom.us URL');
+  check(extractPlatform('Join Microsoft Teams Meeting: https://teams.microsoft.com/l/meetup-join/xyz') === 'Microsoft Teams', 'detects Microsoft Teams from a teams.microsoft.com URL');
+  check(extractPlatform('Meeting link: https://teams.live.com/meet/abc') === 'Microsoft Teams', 'detects Microsoft Teams from a teams.live.com URL');
+  check(extractPlatform('Google Meet: https://meet.google.com/abc-defg-hij') === 'Google Meet', 'detects Google Meet from a meet.google.com URL');
+  check(extractPlatform('We will call you at (416) 555-0199 for the screen.') === 'Phone', 'detects a phone call from a phone-number pattern with no meeting URL');
+  check(extractPlatform('Please confirm your availability for the interview.') === null, 'returns null when no platform or phone signal is present');
+  check(extractPlatform('') === null, 'returns null for empty text');
+  check(extractPlatform('Please visit https://notzoom.us for details.') === null, 'does not report Zoom for a lookalike host (notzoom.us)');
+  check(extractPlatform('Contact support@zoom.us with questions.') === null, 'does not report Zoom for an email address containing zoom.us');
+  check(extractPlatform('See https://teams.microsoft.com.evil.example for the link.') === null, 'does not report Microsoft Teams for a lookalike domain (teams.microsoft.com.evil.example)');
+  check(extractPlatform('See https://example.com/zoom.us for details.') === null, 'does not detect Zoom as a URL path segment on an unrelated host');
+  check(extractPlatform('See https://example.com?next=zoom.us for details.') === null, 'does not detect Zoom as a URL query value on an unrelated host');
+  check(extractPlatform('See https://example.com/teams.microsoft.com for details.') === null, 'does not detect Microsoft Teams as a URL path segment on an unrelated host');
+  check(extractPlatform('See https://example.com?next=teams.microsoft.com for details.') === null, 'does not detect Microsoft Teams as a URL query value on an unrelated host');
+  check(extractPlatform('See https://example.com/meet.google.com for details.') === null, 'does not detect Google Meet as a URL path segment on an unrelated host');
+  check(extractPlatform('See https://example.com?next=meet.google.com for details.') === null, 'does not detect Google Meet as a URL query value on an unrelated host');
+  check(extractPlatform('Join via Zoom: https://zoom.us:443/j/123456789') === 'Zoom', 'detects Zoom from a zoom.us URL with an explicit port');
+  check(extractPlatform('Join Microsoft Teams Meeting: https://teams.microsoft.com:8443/l/meetup-join/xyz') === 'Microsoft Teams', 'detects Microsoft Teams from a teams.microsoft.com URL with an explicit port');
+  check(extractPlatform('Google Meet: https://meet.google.com:443/abc-defg-hij') === 'Google Meet', 'detects Google Meet from a meet.google.com URL with an explicit port');
+
   // --- matchInvite (fixture rows, no real tracker data) ---
   const fixtureRows = [
     { num: 101, company: 'Example Industries', role: 'Training Coordinator', status: 'Applied', date: '2026-06-01', notes: 'Req EX9001' },
@@ -427,10 +512,11 @@ function runSelfTest() {
   check(noMatch.length === 0, 'unrelated company name returns no candidates');
 
   // --- analyzeInvite (end-to-end with injected rows, no file I/O) ---
-  const fullText = 'Schedule Your Phone Screen – Acme Opportunity\nInterview scheduled for 2026-07-09.';
+  const fullText = 'Schedule Your Phone Screen – Acme Opportunity\nInterview scheduled for 2026-07-09.\nJoin via Zoom: https://zoom.us/j/1234567890';
   const result = analyzeInvite(fullText, fixtureRows);
   check(result.signals.company === 'Acme', 'analyzeInvite extracts company end-to-end');
   check(result.signals.date === '2026-07-09', 'analyzeInvite extracts date end-to-end');
+  check(result.signals.platform === 'Zoom', 'analyzeInvite extracts platform end-to-end');
   check(result.candidates.length === 1 && result.candidates[0].appNumber === 103, 'analyzeInvite returns the matched candidate end-to-end');
 
   console.log(`\n  invite-match self-test: ${pass} passed, ${fail} failed\n`);

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -6,7 +6,7 @@
  * Run: node invite-match.test.mjs
  */
 
-import { matchInvite, normalizeCompanyName } from './invite-match.mjs';
+import { matchInvite, normalizeCompanyName, extractPlatform } from './invite-match.mjs';
 
 let passed = 0;
 let failed = 0;
@@ -86,6 +86,37 @@ eq(
   normalizeCompanyName('Northwind Solutions Group') === normalizeCompanyName('Northwind Technologies Holdings'),
   false
 );
+
+// extractPlatform — deterministic call-platform detection (issue #2126).
+// A meeting-platform URL always wins over a phone-number pattern that might
+// also be present in the same text (e.g. a dial-in fallback line under a
+// Zoom link) — the video link is the actual call medium in that case.
+eq('Zoom URL detected as Zoom', extractPlatform('Join: https://us05web.zoom.us/j/9998887777'), 'Zoom');
+eq('Teams (microsoft.com) URL detected as Microsoft Teams', extractPlatform('https://teams.microsoft.com/l/meetup-join/abc'), 'Microsoft Teams');
+eq('Teams (live.com) URL detected as Microsoft Teams', extractPlatform('https://teams.live.com/meet/abc'), 'Microsoft Teams');
+eq('Meet URL detected as Google Meet', extractPlatform('https://meet.google.com/xyz-abcd-efg'), 'Google Meet');
+eq('phone number with no meeting URL detected as Phone', extractPlatform('We will call you at 416-555-0199 for the screen.'), 'Phone');
+eq('meeting URL outranks a phone-number fallback line in the same text', extractPlatform('Zoom: https://zoom.us/j/1234567890\nDial-in: 416-555-0199'), 'Zoom');
+eq('no platform or phone signal returns null', extractPlatform('Please confirm your availability for the interview.'), null);
+// Lookalike hosts / email addresses must never be reported as a real
+// meeting platform — "silence stays silence" (issue #2128 review finding).
+eq('lookalike host (notzoom.us) is not detected as Zoom', extractPlatform('Please visit https://notzoom.us for details.'), null);
+eq('email address containing zoom.us is not detected as Zoom', extractPlatform('Contact support@zoom.us with questions.'), null);
+eq('lookalike domain (teams.microsoft.com.evil.example) is not detected as Microsoft Teams', extractPlatform('See https://teams.microsoft.com.evil.example for the link.'), null);
+// A platform-looking host must only be recognized at a true URL authority
+// boundary — not as a path segment or query value on an unrelated host
+// (issue #2128 review finding).
+eq('does not detect a platform-looking URL path (Zoom)', extractPlatform('See https://example.com/zoom.us for details.'), null);
+eq('does not detect a platform-looking query value (Zoom)', extractPlatform('See https://example.com?next=zoom.us for details.'), null);
+eq('does not detect a platform-looking URL path (Microsoft Teams)', extractPlatform('See https://example.com/teams.microsoft.com for details.'), null);
+eq('does not detect a platform-looking query value (Microsoft Teams)', extractPlatform('See https://example.com?next=teams.microsoft.com for details.'), null);
+eq('does not detect a platform-looking URL path (Google Meet)', extractPlatform('See https://example.com/meet.google.com for details.'), null);
+eq('does not detect a platform-looking query value (Google Meet)', extractPlatform('See https://example.com?next=meet.google.com for details.'), null);
+// An explicit port in the URL authority must not block detection (issue
+// #2128 review finding).
+eq('Zoom URL with explicit port detected as Zoom', extractPlatform('Join: https://zoom.us:443/j/123456789'), 'Zoom');
+eq('Microsoft Teams URL with explicit port detected as Microsoft Teams', extractPlatform('https://teams.microsoft.com:8443/l/meetup-join/abc'), 'Microsoft Teams');
+eq('Google Meet URL with explicit port detected as Google Meet', extractPlatform('https://meet.google.com:443/xyz-abcd-efg'), 'Google Meet');
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) {

--- a/modes/interview-prep.md
+++ b/modes/interview-prep.md
@@ -108,6 +108,7 @@ If the company is small or obscure and yields few results, broaden: search for t
 ## Process Overview
 - **Rounds:** {N} rounds, ~{X} days end-to-end
 - **Format:** {e.g., recruiter screen → technical phone → take-home → onsite (4 rounds) → hiring manager}
+- **Platform:** {e.g., Zoom / Microsoft Teams / Google Meet / Phone — the call medium, distinct from Format above. Extract from invite/scheduling text using the same platform-detection approach `invite-match.mjs`'s `extractPlatform` uses (meeting-platform URL first, phone-number pattern as fallback). If not detectable, write "not stated in the invite, confirm before the call" rather than guessing; this field-specific fallback overrides the generic unknown rule below}
 - **Difficulty:** {X}/5 (Glassdoor avg, N reviews)
 - **Positive experience rate:** {X}%
 - **Known quirks:** {e.g., "pair programming instead of whiteboard", "no LeetCode, all practical", "take-home is 4 hours"}
@@ -155,6 +156,7 @@ For each round discovered in research:
 ### Round {N}: {Type} — audience: `{audience}`
 - **Duration:** {X} min
 - **Conducted by:** {peer / manager / skip-level / recruiter — if known}
+- **Platform:** {Zoom / Microsoft Teams / Google Meet / Phone for this specific round — extract from that round's invite/scheduling text the same way as Step 2's Platform field above. If not stated in the invite, write "not stated in the invite, confirm before the call"}
 - **What they evaluate:** {specific skills or traits}
 - **Reported questions:**
   - {question} — [source: Glassdoor (URL/date)]
@@ -163,6 +165,8 @@ For each round discovered in research:
 ```
 
 If round structure is unknown, state that and provide the best available intel on what types of rounds to expect based on company size, stage, and role level.
+
+When a round's Platform is known, add one logistics line to "How to prepare": for a video platform (Zoom / Microsoft Teams / Google Meet), a reminder to check camera, lighting, and background in advance; for Phone, a reminder to confirm a quiet space and good signal. Skip this line when Platform is not stated.
 
 ## Step 4 — Likely Questions (per audience)
 

--- a/modes/interview/debrief.md
+++ b/modes/interview/debrief.md
@@ -22,7 +22,7 @@ After a real interview, capture what was asked, assess what landed and what didn
 6. **Story bank** at `interview-prep/story-bank.md` — add new stories if surfaced
 7. **CV** at `cv.md` + `article-digest.md` (if present) — to ground suggested answers in real experience
 8. **Retracted claims** at `interview-prep/retracted-claims.md` (if present) — hard gate; never use a retracted claim in a suggested answer even if the candidate said it in the interview
-9. **Role-specific prep file** — append debrief notes
+9. **Role-specific prep file** — append debrief notes; correct in place any existing fact the interview directly contradicts (see Step 1b)
 
 ---
 
@@ -54,6 +54,27 @@ If memory is incomplete, ask targeted prompts:
 Set the explicit source marker: **`input_source: recall`**.
 
 Whichever path produced the question/answer data, Steps 2 onward operate on it identically — honest assessment, gap-closing, and question-bank/story-bank updates don't distinguish between an `input_source: transcript` and an `input_source: recall` debrief. The marker itself is still carried through unchanged so Step 9 can read it.
+
+---
+
+## Step 1b — Check for Contradicted Facts
+
+While capturing what was said, also check it against the role-specific prep file's existing factual claims — this runs alongside Step 1, not after it.
+
+**The distinction that matters:** most of what an interview surfaces is *new information* — a new gap, a new story, a new detail that wasn't in the prep file before. That's append-only, and Steps 4/5/8 below handle it exactly as they always have. But sometimes what the interview surfaces isn't new — it's a **direct contradiction of a specific fact the prep file already asserts** (location, comp range, team size, reporting structure, tech/system stack, etc.). That's not a gap to close or a story to add; it's an existing claim that is now known to be wrong.
+
+- **"This is new information" → appends.** Use the existing Step 4 / Step 5 / Step 8 flows unchanged.
+- **"This directly contradicts something the prep file already asserts as fact" → correct in place.** Edit the original line in the role-specific prep file itself, rather than leaving the wrong claim untouched and only noting the discrepancy in a new section below it.
+
+When correcting in place, use a strikethrough-plus-correction format so the history of what was believed vs. confirmed stays visible in the diff:
+
+```markdown
+~~Metro Hall, on-site~~ **Metro Hall — hybrid** (confirmed on the {date} call)
+```
+
+**Resolve inference tags on contradiction or confirmation.** If the original line carried an inference marker — `[inferred from JD]`, or prose noting the source was an expired/inaccessible posting — and the interview either confirms or corrects it, resolve the tag rather than leaving a now-settled fact permanently marked as uncertain: replace the marker with the confirmed fact and its real source (the interview/call itself), using the same strikethrough-plus-correction shape when the value changed, or a plain edit to drop the marker and cite the new source when the value was merely confirmed as-is.
+
+This step never touches `interview-prep/retracted-claims.md` or the story bank — those stay reserved for the candidate's own claims, not for facts about the role. It also never rewrites Step 4's "Gaps to Close" additions; a contradicted fact is corrected at its original location, not logged as a gap.
 
 ---
 
@@ -217,3 +238,4 @@ Rules for the transcript:
 - **Extract vocabulary gaps explicitly.** If the candidate used an imprecise term where a precise one exists, add it to `interview-prep/interview-prep-guide.md` under the vocabulary section (if the candidate maintains one).
 - **One gap = one fix.** Don't overwhelm with a full study plan for every gap. Prioritize the 1–2 most likely to be tested in the next round.
 - **Celebrate what worked.** Debrief isn't only about gaps. Name what was strong — it reinforces the right behaviour and builds confidence for the next round.
+- **Contradicted facts get corrected in place, not appended around.** If the interview directly contradicts a specific fact the prep file already states (location, comp, team size, stack, reporting line), edit that line — strikethrough the old value, bold the confirmed one, note when/how it was confirmed (see Step 1b). Don't leave a wrong claim standing untouched with a caveat bolted on below it.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "scan:full": "node scan-ats-full.mjs",
     "scan:seeds": "node scan-ats-full.mjs --seeds yc,a16z",
     "scan:yc": "node scan-ats-full.mjs --seeds yc",
+    "scan:interamt": "node scan-interamt.mjs",
     "validate:portals": "node validate-portals.mjs",
     "verify:portals": "node verify-portals.mjs",
     "tracker": "node tracker.mjs",

--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -16,7 +16,10 @@
 //     before deleting anything.
 //   - staleness is judged by owner-PID liveness first, falling back to
 //     directory age only when the metadata is missing or unreadable. An old
-//     lock whose owner is still running is NOT stale.
+//     lock whose owner is still running is NOT stale, and an ownerless
+//     directory gets a fixed grace period (OWNERLESS_GRACE_MS) before age
+//     alone can condemn it, so a directory created microseconds ago is never
+//     reclaimable no matter how aggressive the caller's staleMs.
 //   - stale reclamation is serialized behind a second atomic guard directory
 //     ("<path>.lock.recover"). Without it, reclamation is itself a TOCTOU
 //     race: two callers that both judge the same lock stale can have the
@@ -32,6 +35,7 @@ import { join, dirname } from 'path';
 import { randomUUID } from 'crypto';
 
 const DEFAULT_STALE_MS = 30_000;
+export const OWNERLESS_GRACE_MS = 1_000;
 const DEFAULT_RETRY_MS = 80;
 const DEFAULT_TIMEOUT_MS = 8_000;
 
@@ -77,11 +81,22 @@ function processIsAlive(pid) {
 
 // Conservative: a lock whose recorded owner is still running is never stale,
 // however old it is. Age is the fallback only when there's no readable owner.
+//
+// That fallback needs a floor. Two directories are ownerless by construction,
+// not by accident: a lock between its mkdir and its owner.json write, and the
+// recover guard, which never carries owner.json at all. Judging those on
+// `age > staleMs` alone lets a caller with an aggressive staleMs delete a
+// directory created microseconds ago — either stealing a winner's lock inside
+// its acquisition window, or evicting a live guard and putting two callers
+// inside the decide-then-delete window the guard exists to serialize.
+// OWNERLESS_GRACE_MS is a lower bound on that patience, never a cap: a larger
+// caller staleMs still wins, and a genuinely abandoned directory still ages
+// out, so a crash while holding the guard cannot disable recovery for good.
 function lockCanRecover(lockDir, staleMs) {
   const owner = readLockOwner(lockDir);
   if (owner?.pid) return !processIsAlive(owner.pid);
   try {
-    return Date.now() - statSync(lockDir).mtimeMs > staleMs;
+    return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
   } catch {
     return true; // vanished — nothing to recover, retry acquisition
   }
@@ -95,7 +110,7 @@ function lockCanRecover(lockDir, staleMs) {
  * @param {object} [options]
  * @param {number} [options.timeoutMs=8000] - Max time to wait for the lock.
  * @param {number} [options.retryMs=80] - Delay between acquisition attempts.
- * @param {number} [options.staleMs=30000] - Age threshold for a lock with no readable owner.
+ * @param {number} [options.staleMs=30000] - Age threshold for a lock with no readable owner, floored at OWNERLESS_GRACE_MS.
  */
 export async function acquirePipelineLock(pipelinePath, options = {}) {
   // Env overrides let a caller several frames up the stack (a test driving

--- a/scan-interamt.mjs
+++ b/scan-interamt.mjs
@@ -1,0 +1,366 @@
+#!/usr/bin/env node
+
+/**
+ * scan-interamt.mjs — Interamt.de scanner via Playwright
+ *
+ * Interamt uses Apache Wicket (stateful Java framework) — no REST API exists.
+ * Playwright maintains a browser session so the wicket-crypt token and cookies
+ * are handled transparently.
+ *
+ * Reads `interamt_searches` from portals.yml. Falls back to a generic set of
+ * German IT keywords if the section is absent.
+ *
+ * Usage:
+ *   node scan-interamt.mjs
+ *   node scan-interamt.mjs --dry-run
+ *   node scan-interamt.mjs --all            # skip date filter (use for first scan)
+ *   node scan-interamt.mjs --keyword "Softwareentwickler"
+ */
+
+import { chromium } from 'playwright';
+import { readFileSync, existsSync, mkdirSync } from 'fs';
+import yaml from 'js-yaml';
+import { appendToPipeline, appendToScanHistory, loadSeenUrls } from './scan.mjs';
+
+// ── Config ───────────────────────────────────────────────────────────
+
+const PORTALS_PATH    = 'portals.yml';
+const SCAN_HISTORY    = 'data/scan-history.tsv';
+const INTERAMT_HOME   = 'https://interamt.de/koop/app/';
+// Direct offer URL — constructed from StellenangebotId.
+// Wicket adds a session version number (?28&id=...) during live navigation,
+// but the bookmarkable form (?id=...) works without a session.
+// If a specific offer fails to load from pipeline, open Interamt manually
+// and navigate to it — Wicket will assign a valid version for that session.
+const OFFER_BASE_URL  = 'https://interamt.de/koop/app/stelle?id=';
+
+// Generic fallback — configure interamt_searches in portals.yml for your target roles
+const DEFAULT_KEYWORDS = [
+  'Informatiker',
+  'Softwareentwickler',
+  'IT-Spezialist',
+  'Datenwissenschaftler',
+  'Systemadministrator',
+  'Datenanalyst',
+];
+
+// ── Args ─────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const DRY_RUN    = args.includes('--dry-run');
+const DEBUG      = args.includes('--debug');
+const NO_DATE_FILTER = args.includes('--all');
+const kwIdx = args.indexOf('--keyword');
+if (kwIdx !== -1 && (args[kwIdx + 1] === undefined || args[kwIdx + 1].startsWith('--'))) {
+  console.error('Error: --keyword requires a value, e.g. --keyword "Softwareentwickler"');
+  process.exit(1);
+}
+const SINGLE_KEYWORD = kwIdx !== -1 ? args[kwIdx + 1] : null;
+
+// ── Load portals.yml ─────────────────────────────────────────────────
+
+let config = {};
+if (existsSync(PORTALS_PATH)) {
+  config = yaml.load(readFileSync(PORTALS_PATH, 'utf-8')) || {};
+}
+
+const interamtSearches = config.interamt_searches || DEFAULT_KEYWORDS.map(k => ({ was: k }));
+const keywords = SINGLE_KEYWORD
+  ? [SINGLE_KEYWORD]
+  : interamtSearches.map(s => s.was).filter(Boolean);
+
+// ── Filters ──────────────────────────────────────────────────────────
+
+const titleFilter = config.title_filter || {};
+const positiveKw = (titleFilter.positive || []).map(k => k.toLowerCase());
+const negativeKw = (titleFilter.negative || []).map(k => k.toLowerCase());
+
+function matchesTitle(title) {
+  const lower = title.toLowerCase();
+  if (negativeKw.some(k => lower.includes(k))) return false;
+  if (positiveKw.length === 0) return true;
+  return positiveKw.some(k => lower.includes(k));
+}
+
+const locFilter = config.location_filter || {};
+const locAllow = (locFilter.allow || []).map(k => k.toLowerCase());
+const locBlock = (locFilter.block || []).map(k => k.toLowerCase());
+
+function matchesLocation(loc) {
+  if (!loc) return true;
+  const lower = loc.toLowerCase();
+  if (locBlock.some(k => lower.includes(k))) return false;
+  if (locAllow.length === 0) return true;
+  return locAllow.some(k => lower.includes(k));
+}
+
+// ── Date helpers ─────────────────────────────────────────────────────
+
+// Parse Interamt date format DD.MM.YYYY → Date (midnight UTC)
+function parseDE(str) {
+  if (!str) return null;
+  const [d, m, y] = str.trim().split('.');
+  if (!d || !m || !y) return null;
+  return new Date(`${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}T00:00:00Z`);
+}
+
+// Returns the most recent first_seen date for 'interamt' portal entries, or null
+function loadLastScanDate() {
+  if (!existsSync(SCAN_HISTORY)) return null;
+  let latest = null;
+  readFileSync(SCAN_HISTORY, 'utf-8').split('\n').slice(1).forEach(line => {
+    const parts = line.split('\t');
+    if (parts[2] !== 'interamt') return;
+    const d = new Date((parts[1] || '') + 'T00:00:00Z');
+    if (!isNaN(d) && (!latest || d > latest)) latest = d;
+  });
+  return latest;
+}
+
+// ── Stable selectors (Wicket name attributes don't change between sessions) ──
+
+const SEL_EDIT_BTN    = 'a.ia-e-link--icon:has-text("Suchkriterien ändern"), a:has-text("Suchkriterien ändern")';
+const SEL_NEXT_INPUT  = 'input[name="stellensucheFilterAttributes.suchtextContainer:stellensucheFilterAttributes.suchText"]';
+const SEL_NEXT_SUBMIT = 'button.ia-e-button--primary:has-text("Detailsuche")';
+
+// ── Scraper ──────────────────────────────────────────────────────────
+
+async function extractRows(page) {
+  return page.$$eval('tr.ia-e-table__row', rows =>
+    rows.map(row => {
+      const cell = field => row.querySelector(`td[data-field="${field}"]`)?.textContent?.trim() || '';
+
+      const title        = cell('Stellenbezeichnung');
+      const id           = row.querySelector('td[data-field="StellenangebotId"] span')?.textContent?.trim() || '';
+      const company      = cell('Behoerde') || 'Interamt';
+      const modality     = cell('Dienstort');
+      const city         = cell('PLZOrte');
+      const publishedDate = cell('Von');
+      const deadline     = cell('Bewerbungsfrist');
+
+      return { title, id, company, modality, city, publishedDate, deadline };
+    }).filter(r => r.title && r.id)
+  );
+}
+
+async function searchInteramt(page, keyword, isFirst) {
+  const found = [];
+
+  if (isFirst) {
+    // Initial search: navigate to homepage and use the landing form
+    await page.goto(INTERAMT_HOME, { waitUntil: 'networkidle', timeout: 30000 });
+
+    // Dismiss cookie modal — it has a backdrop overlay that blocks all clicks
+    const cookieModal = page.locator('#ia-m-cookie-modal');
+    const isModalVisible = await cookieModal.isVisible().catch(() => false);
+    if (isModalVisible) {
+      await page.locator('#ia-m-cookie-modal .ia-m-modal__close').click();
+      await cookieModal.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => null);
+    }
+
+    await page.waitForSelector('#idOrSuchtext', { state: 'visible', timeout: 15000 });
+    await page.fill('#idOrSuchtext', keyword);
+
+    // #ida is Wicket auto-generated; fallback to class selector if ID changes
+    const submitBtn = page.locator('#ida, button.ia-e-button--primary.ia-e-button--icon').first();
+    await submitBtn.waitFor({ state: 'visible', timeout: 10000 });
+    await submitBtn.click();
+  } else {
+    // Subsequent search: use "Suchkriterien ändern" to reuse the Wicket session.
+    // Fall back to a fresh homepage load if the button isn't found (e.g. after an error).
+    const editBtn = page.locator(SEL_EDIT_BTN).first();
+    const editVisible = await editBtn.isVisible({ timeout: 5000 }).catch(() => false);
+
+    if (editVisible) {
+      // Dismiss any modal/backdrop that Wicket may have raised during the previous search
+      const anyModal = page.locator('.ia-m-modal__close').first();
+      if (await anyModal.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await anyModal.evaluate(el => el.click());
+        await page.locator('.ia-m-modal__container').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => null);
+      }
+      await page.locator('.ia-e-backdrop').waitFor({ state: 'hidden', timeout: 10000 }).catch(() => null);
+      await editBtn.evaluate(el => el.click());
+      await page.waitForSelector(SEL_NEXT_INPUT, { state: 'visible', timeout: 15000 });
+      await page.fill(SEL_NEXT_INPUT, keyword);
+      const submitBtn = page.locator(SEL_NEXT_SUBMIT);
+      await submitBtn.waitFor({ state: 'visible', timeout: 10000 });
+      await submitBtn.click();
+    } else {
+      // Fallback: reload homepage (no cookie modal on subsequent loads)
+      await page.goto(INTERAMT_HOME, { waitUntil: 'networkidle', timeout: 30000 });
+      await page.waitForSelector('#idOrSuchtext', { state: 'visible', timeout: 15000 });
+      await page.fill('#idOrSuchtext', keyword);
+      const submitBtn = page.locator('#ida, button.ia-e-button--primary.ia-e-button--icon').first();
+      await submitBtn.waitFor({ state: 'visible', timeout: 10000 });
+      await submitBtn.click();
+    }
+  }
+
+  // Wait for results table or "no results" message
+  await Promise.race([
+    page.waitForSelector('tr.ia-e-table__row', { timeout: 20000 }),
+    page.waitForSelector('.ia-e-no-results, .ia-no-results, [class*="no-result"]', { timeout: 20000 }),
+  ]).catch(() => null);
+
+  if (DEBUG) {
+    mkdirSync('output', { recursive: true });
+    await page.screenshot({ path: 'output/debug-interamt.png', fullPage: true });
+    const { writeFileSync: wf } = await import('fs');
+    wf('output/debug-interamt.html', await page.content());
+    console.log('  [debug] screenshot → output/debug-interamt.png');
+    console.log('  [debug] html       → output/debug-interamt.html');
+    console.log('  [debug] url:', page.url());
+    const rowCount = await page.$$eval('tr', rows => rows.length);
+    console.log(`  [debug] total <tr> on page: ${rowCount}`);
+  }
+
+  // Wait for Wicket AJAX to fully settle — networkidle ensures no pending requests
+  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => null);
+
+  // "mehr laden" appends rows to the same page — click until gone, then extract all at once
+  const loadMoreBtn = page.locator('button.ia-m-searchresults__btn-load').first();
+  let pageNum = 1;
+  while (pageNum <= 50) {
+    const visible = await loadMoreBtn.isVisible().catch(() => false);
+    if (!visible) break;
+    const beforeCount = await page.$$eval('tr.ia-e-table__row', rows => rows.length);
+    await loadMoreBtn.evaluate(el => el.click());
+    // Wait for backdrop to clear, then for new rows to appear
+    await page.locator('.ia-e-backdrop').waitFor({ state: 'hidden', timeout: 10000 }).catch(() => null);
+    await page.waitForFunction(
+      n => document.querySelectorAll('tr.ia-e-table__row').length > n,
+      beforeCount,
+      { timeout: 15000 }
+    ).catch(() => null);
+    pageNum++;
+  }
+
+  const rows = await extractRows(page);
+  for (const row of rows) {
+    found.push({
+      title:         row.title,
+      url:           `${OFFER_BASE_URL}${row.id}`,
+      company:       row.company,
+      modality:      row.modality,
+      city:          row.city,
+      publishedDate: row.publishedDate,
+      deadline:      row.deadline,
+    });
+  }
+
+  return found;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  mkdirSync('data', { recursive: true });
+
+  const { seen } = loadSeenUrls();
+  const date = new Date().toISOString().slice(0, 10);
+
+  const lastScanDate = NO_DATE_FILTER ? null : loadLastScanDate();
+  if (NO_DATE_FILTER) {
+    console.log(`  --all: date filter disabled — fetching all available offers`);
+  } else if (lastScanDate) {
+    console.log(`  Last Interamt scan: ${lastScanDate.toISOString().slice(0,10)} — skipping older offers`);
+  }
+
+  let totalFound = 0;
+  const newOffers = [];
+  const titleSkipped = [];
+  const locationSkipped = [];
+  const dateSkipped = [];
+  const dupeSkipped = [];
+  const errors = [];
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ locale: 'de-DE', timezoneId: 'Europe/Berlin' });
+  const page = await context.newPage();
+
+  try {
+    for (let i = 0; i < keywords.length; i++) {
+      const kw = keywords[i];
+      process.stdout.write(`  Searching "${kw}"... `);
+      try {
+        const found = await searchInteramt(page, kw, i === 0);
+        totalFound += found.length;
+        process.stdout.write(`${found.length} found\n`);
+
+        for (const offer of found) {
+          const location = [offer.modality, offer.city].filter(Boolean).join(' ')
+            + (offer.deadline ? ` (Frist: ${offer.deadline})` : '');
+          const pubDate = parseDE(offer.publishedDate);
+          const canonical = {
+            url: offer.url,
+            company: offer.company,
+            title: offer.title,
+            location,
+            source: 'interamt',
+            postedAt: pubDate ? pubDate.getTime() : undefined,
+          };
+
+          if (!matchesTitle(offer.title)) { seen.add(canonical.url); titleSkipped.push(canonical); continue; }
+          if (!matchesLocation(location)) { seen.add(canonical.url); locationSkipped.push(canonical); continue; }
+          // Same-day offers pass: lastScanDate is the day of the last run, and an
+          // offer published later that same day should not be treated as stale.
+          if (lastScanDate && pubDate && pubDate < lastScanDate) { seen.add(canonical.url); dateSkipped.push(canonical); continue; }
+          if (seen.has(canonical.url)) { dupeSkipped.push(canonical); continue; }
+          seen.add(canonical.url);
+          newOffers.push(canonical);
+        }
+      } catch (err) {
+        process.stdout.write(`ERROR\n`);
+        errors.push({ keyword: kw, error: err.message });
+      }
+    }
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+
+  if (!DRY_RUN) {
+    if (newOffers.length > 0) await appendToPipeline(newOffers);
+    if (newOffers.length > 0) appendToScanHistory(newOffers, date, 'added');
+    if (titleSkipped.length > 0) appendToScanHistory(titleSkipped, date, 'skipped_title');
+    if (locationSkipped.length > 0) appendToScanHistory(locationSkipped, date, 'skipped_location');
+    if (dateSkipped.length > 0) appendToScanHistory(dateSkipped, date, 'skipped_date');
+    if (dupeSkipped.length > 0) appendToScanHistory(dupeSkipped, date, 'skipped_dup');
+  }
+
+  // Summary
+  console.log(`\n${'━'.repeat(45)}`);
+  console.log(`Interamt Scan — ${date}`);
+  console.log(`${'━'.repeat(45)}`);
+  console.log(`Keywords searched:  ${keywords.length}`);
+  console.log(`Total found:        ${totalFound}`);
+  console.log(`Filtered by title:  ${titleSkipped.length}`);
+  console.log(`Filtered location:  ${locationSkipped.length}`);
+  console.log(`Filtered by date:   ${dateSkipped.length}`);
+  console.log(`Duplicates:         ${dupeSkipped.length}`);
+  console.log(`New offers:         ${newOffers.length}`);
+
+  if (errors.length > 0) {
+    console.log(`\nErrors (${errors.length}):`);
+    for (const e of errors) console.log(`  ✗ "${e.keyword}": ${e.error}`);
+  }
+
+  if (newOffers.length > 0) {
+    console.log('\nNew offers:');
+    for (const o of newOffers) {
+      console.log(`  + ${o.company} | ${o.title} | ${o.location || 'N/A'}`);
+    }
+    if (DRY_RUN) {
+      console.log('\n(dry run — not saved)');
+    } else {
+      console.log(`\nSaved to data/pipeline.md`);
+    }
+  }
+
+  console.log('\n→ Run /career-ops pipeline to evaluate new offers.');
+}
+
+main().catch(err => {
+  console.error('Fatal:', err.message);
+  process.exit(1);
+});

--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -21,7 +21,7 @@
  */
 
 import { execFileSync } from 'child_process';
-import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, chmodSync } from 'fs';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, chmodSync, utimesSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
@@ -618,8 +618,14 @@ const TRACKER_REPORT_MISMATCH = `# Applications Tracker
   mkdirSync(lockDir, { recursive: true });
   writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({ pid: 999999999, token: 'dead', tracker: 'x' }));
   // Orphaned guard left behind by a killed process (no owner.json → judged by age).
+  // Backdate it rather than sleeping: the guard has to read as genuinely
+  // abandoned, not merely as older than a small staleMs. Age alone is floored
+  // at OWNERLESS_GRACE_MS (#2306) so that a guard a live caller is holding is
+  // never evicted, and sleeping past that floor would make this test both
+  // slower and vaguer about which condition it is exercising.
   mkdirSync(`${lockDir}.recover`, { recursive: true });
-  await new Promise(r => setTimeout(r, 150));
+  const abandonedAt = new Date(Date.now() - 60_000);
+  utimesSync(`${lockDir}.recover`, abandonedAt, abandonedAt);
   try {
     const lock = await acquireTrackerLock(lockDir, { timeoutMs: 3000, retryMs: 25, staleMs: 50, tracker: 'x' });
     if (lock.staleRecovered) {

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -31,6 +31,24 @@
 # scan_history:
 #   recheck_after_days: 30
 
+# -- Interamt.de searches (optional, German public sector) --
+# Read by scan-interamt.mjs (`npm run scan:interamt`), a separate Playwright
+# scanner for Interamt.de, a portal for German federal, state, and municipal
+# government job postings. Interamt has no REST API (Apache Wicket, stateful),
+# so it isn't reachable through the tracked_companies providers above;
+# scan-interamt.mjs drives a real browser session instead.
+#
+# Each `was:` entry is a search keyword submitted to Interamt's search form.
+# If this block is absent, scan-interamt.mjs falls back to a generic set of
+# German IT keywords (Informatiker, Softwareentwickler, IT-Spezialist, ...).
+# Results are still filtered by title_filter/location_filter below.
+#
+# interamt_searches:
+#   - was: "Softwareentwickler"
+#   - was: "Informatiker"
+#   - was: "Datenanalyst"
+#   - was: "Systemadministrator"
+
 # -- Location filter (optional) --
 # Filter scanned jobs by location. Applied AFTER title filter, BEFORE dedup.
 # If this entire block is absent, all locations pass (current default behavior).

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10933,6 +10933,67 @@ try {
   fail(`transcript-input debrief check: ${e.message}`);
 }
 
+// ── CONTRADICTED-FACTS CORRECTION (#2125) ────────────────────────
+// interview/debrief was append-only against the role-specific prep file —
+// no path existed for correcting an existing fact the interview directly
+// contradicts (as opposed to appending a new gap/story/retraction). This
+// section pins that the mode now documents an in-place correction step,
+// the strikethrough-plus-correction example format, and inference-tag
+// resolution, without touching the pre-existing append-only steps.
+
+console.log('\n64. Contradicted-facts correction step (#2125)');
+
+try {
+  const debriefMode = readFile('modes/interview/debrief.md');
+
+  if (debriefMode.includes('Check for Contradicted Facts')) {
+    pass('interview/debrief has a dedicated contradicted-facts step');
+  } else {
+    fail('interview/debrief missing a dedicated contradicted-facts step');
+  }
+
+  // Scoped regex: both bullets must appear, in order, within the same
+  // decision-list paragraph — not just "appends" and "correct in place"
+  // occurring anywhere independently in the file.
+  if (
+    /"This is new information"\s*→\s*appends\.[\s\S]{0,200}"This directly contradicts something the prep file already asserts as fact"\s*→\s*correct in place\./.test(
+      debriefMode
+    )
+  ) {
+    pass('interview/debrief distinguishes new-information-appends from contradiction-corrects-in-place');
+  } else {
+    fail('interview/debrief missing the append-vs-correct distinction');
+  }
+
+  // Scoped regex: the strikethrough, the bolded correction, and the
+  // confirmation-date parenthetical must all appear together on the same
+  // example line — not merely present somewhere in the file independently.
+  if (
+    /~~Metro Hall, on-site~~\s+\*\*Metro Hall — hybrid\*\*\s*\(confirmed on the \{date\} call\)/.test(
+      debriefMode
+    )
+  ) {
+    pass('interview/debrief includes a concrete strikethrough-plus-correction example with the confirmation detail');
+  } else {
+    fail('interview/debrief missing the strikethrough-plus-correction example format with its confirmation detail');
+  }
+
+  // Scoped regex: the resolve-inference-tags instruction, the literal tag,
+  // and the actual resolution behavior must appear tied together in the
+  // same instruction — not as three unrelated substrings anywhere in the file.
+  if (
+    /\*\*Resolve inference tags on contradiction or confirmation\.\*\*[\s\S]{0,200}`\[inferred from JD\]`[\s\S]{0,400}resolve the tag/.test(
+      debriefMode
+    )
+  ) {
+    pass('interview/debrief instructs resolving inference tags once confirmed or corrected');
+  } else {
+    fail('interview/debrief missing the inference-tag resolution instruction tied to its own guidance');
+  }
+} catch (e) {
+  fail(`contradicted-facts correction check: ${e.message}`);
+}
+
 await runDiscovered();
 
 finish();

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10994,6 +10994,74 @@ try {
   fail(`contradicted-facts correction check: ${e.message}`);
 }
 
+// ── CALL-PLATFORM DETECTION (#2126) ─────────────────────────────
+// Pins the new **Platform:** field in interview-prep.md's Step 2 (Process
+// Overview) and Step 3 (Round-by-Round Breakdown) — distinct from the
+// existing round-type **Format:** field, cross-referencing invite-match.mjs's
+// extractPlatform without duplicating its detection logic in prose, and
+// falling back to "not stated in the invite, confirm before the call"
+// rather than guessing when the invite text doesn't say.
+
+console.log('\n65. Call-platform detection wired into interview-prep (#2126)');
+
+try {
+  const prepModeDoc = readFile('modes/interview-prep.md');
+
+  // Scope assertions to the actual sections they're supposed to be in,
+  // rather than whole-document .includes() checks that could pass even if
+  // Platform only exists in the wrong section (#2128 review finding).
+  const processOverview = prepModeDoc.match(
+    /## Step 2 — Process Overview[\s\S]*?## Step 2\.5 — Audience Map/
+  )?.[0] ?? '';
+  const roundBreakdown = prepModeDoc.match(
+    /## Step 3 — Round-by-Round Breakdown[\s\S]*?(?=\n## |$)/
+  )?.[0] ?? '';
+  const processOverviewFlat = processOverview.replace(/\s+/g, ' ');
+
+  if (processOverview.includes('- **Format:**') && processOverview.includes('- **Platform:**')) {
+    pass('interview-prep Process Overview has both Format (round type) and Platform (call medium) as distinct fields');
+  } else {
+    fail('interview-prep Process Overview missing the distinct Platform field alongside Format');
+  }
+
+  if (processOverviewFlat.includes("extractPlatform") && processOverviewFlat.includes('invite-match.mjs')) {
+    pass('interview-prep Platform field cross-references invite-match.mjs\'s extractPlatform instead of restating the detection logic');
+  } else {
+    fail('interview-prep Platform field missing the cross-reference to invite-match.mjs\'s extractPlatform');
+  }
+
+  if (processOverviewFlat.includes('not stated in the invite, confirm before the call')) {
+    pass('interview-prep Platform field falls back to "not stated in the invite, confirm before the call" instead of guessing');
+  } else {
+    fail('interview-prep Platform field missing the "not stated in the invite, confirm before the call" fallback');
+  }
+
+  if (/### Round \{N\}:[\s\S]*?- \*\*Platform:\*\*/.test(roundBreakdown)) {
+    pass('interview-prep Round-by-Round Breakdown (Step 3) also carries a per-round Platform field');
+  } else {
+    fail('interview-prep Round-by-Round Breakdown missing a per-round Platform field');
+  }
+
+  // The fallback instruction must independently exist in the Round {N}
+  // template itself, not just in Step 2 — otherwise a future edit that
+  // drops it from Step 3 only would go unnoticed (#2128 review finding).
+  // Scoped to the Round {N} template specifically (not just anywhere in
+  // Step 3's surrounding prose) so a future edit that drops the fallback
+  // from the round template but leaves it elsewhere in Step 3 would still
+  // be caught (#2128 review finding, round 2).
+  const roundTemplate = roundBreakdown.match(
+    /### Round \{N\}:[\s\S]*?(?=\n### |\n## |$)/
+  )?.[0] ?? '';
+  const roundTemplateFlat = roundTemplate.replace(/\s+/g, ' ');
+  if (roundTemplateFlat.includes('not stated in the invite, confirm before the call')) {
+    pass('interview-prep Round-by-Round Breakdown (Step 3) also carries the "not stated in the invite, confirm before the call" fallback');
+  } else {
+    fail('interview-prep Round-by-Round Breakdown missing the "not stated in the invite, confirm before the call" fallback');
+  }
+} catch (e) {
+  fail(`call-platform detection wiring check: ${e.message}`);
+}
+
 await runDiscovered();
 
 finish();

--- a/test/pipeline-lock.test.mjs
+++ b/test/pipeline-lock.test.mjs
@@ -19,15 +19,33 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
-import { acquirePipelineLock, LockTimeoutError } from '../pipeline-lock.mjs';
+import { acquirePipelineLock, LockTimeoutError, OWNERLESS_GRACE_MS } from '../pipeline-lock.mjs';
 
 function fixtureRoot() {
   const root = mkdtempSync(join(tmpdir(), 'career-ops-pipeline-lock-'));
   mkdirSync(join(root, 'data'), { recursive: true });
   return root;
+}
+
+// Ages a directory by rewriting its mtime, so the age-based branch can be
+// exercised at any point on either side of the grace floor without sleeping.
+function backdate(dir, ms) {
+  const when = new Date(Date.now() - ms);
+  utimesSync(dir, when, when);
+}
+
+// A lock directory left behind by a holder that died — stale by the owner-PID
+// rule, so reclamation is genuinely on the table.
+function writeCrashedHolder(lockDir) {
+  mkdirSync(lockDir, { recursive: true });
+  writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
+    pid: 2147483000, // not a live pid
+    token: 'crashed-holder-token',
+    started_at: new Date(Date.now() - 60 * 60_000).toISOString(),
+  }), 'utf-8');
 }
 
 test('acquirePipelineLock: a live holder blocks a second acquirer, which times out', async () => {
@@ -55,8 +73,14 @@ test('acquirePipelineLock: configurable timing — the contention timeout is not
     const held = await acquirePipelineLock(p, { timeoutMs: 150, retryMs: 20 });
     try {
       const startedAt = Date.now();
-      await assert.rejects(() => acquirePipelineLock(p, { timeoutMs: 150, retryMs: 20 }));
+      // The failure must be the *timeout*, not an unrelated instant throw —
+      // otherwise a lock broken in some other way still passes this test.
+      await assert.rejects(
+        () => acquirePipelineLock(p, { timeoutMs: 150, retryMs: 20 }),
+        (err) => err instanceof LockTimeoutError,
+      );
       const elapsed = Date.now() - startedAt;
+      assert.ok(elapsed >= 100, `timeout returned too early after ${elapsed}ms — the caller timeout was not actually awaited`);
       // Must honor the caller's timeout, not the module default (seconds).
       assert.ok(elapsed < 2000, `expected the caller timeout to be honored, waited ${elapsed}ms`);
     } finally {
@@ -88,12 +112,7 @@ test('acquirePipelineLock: stale-reclaim is serialized — a second reclaimer ca
 
     // Simulate a crashed holder: a lock directory owned by a PID that is not
     // alive, old enough to be judged stale by any age rule.
-    mkdirSync(lockDir, { recursive: true });
-    writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
-      pid: 2147483000, // not a live pid
-      token: 'crashed-holder-token',
-      started_at: new Date(Date.now() - 60 * 60_000).toISOString(),
-    }), 'utf-8');
+    writeCrashedHolder(lockDir);
 
     // Two concurrent acquirers both see the same stale lock. Exactly one must
     // win; the loser must NOT end up holding a lock at the same time.
@@ -104,7 +123,120 @@ test('acquirePipelineLock: stale-reclaim is serialized — a second reclaimer ca
 
     const winners = [a, b].filter((r) => r.status === 'fulfilled');
     assert.equal(winners.length, 1, 'exactly one acquirer may hold the reclaimed lock at a time');
+    // ...and the loser must have lost by *waiting out the lock*, not by
+    // crashing on something unrelated, which would make the count above lie.
+    const failures = [a, b].filter((r) => r.status === 'rejected');
+    assert.ok(
+      failures[0].reason instanceof LockTimeoutError,
+      `the losing acquirer must fail with LockTimeoutError, got: ${failures[0].reason}`,
+    );
     winners.forEach((w) => w.value.release());
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: a just-created ownerless lock is never judged stale, however small the caller staleMs (#2304)', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+
+    // The acquisition window: a holder has mkdir'd the lock but has not
+    // written owner.json yet. Age alone must not make this reclaimable, or a
+    // contender deletes the winner's lock and both end up "holding" it.
+    mkdirSync(lockDir, { recursive: true });
+
+    await assert.rejects(
+      () => acquirePipelineLock(p, { timeoutMs: 200, retryMs: 20, staleMs: 0 }),
+      (err) => err instanceof LockTimeoutError,
+    );
+    assert.ok(existsSync(lockDir), 'a contender destroyed a lock created microseconds ago');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: an ownerless lock older than the grace floor is still reclaimable (#2304)', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+
+    // The floor must not become "ownerless locks are never reclaimable" — a
+    // truly abandoned lock with no owner metadata has to age out.
+    mkdirSync(lockDir, { recursive: true });
+    backdate(lockDir, OWNERLESS_GRACE_MS * 3);
+
+    const lock = await acquirePipelineLock(p, { timeoutMs: 500, retryMs: 20, staleMs: 1 });
+    lock.release();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: the grace floor never shortens a larger caller-supplied staleMs (#2304)', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+
+    // Past the floor, but nowhere near the caller's staleMs. The floor is a
+    // lower bound on patience, not a replacement for the caller's value.
+    mkdirSync(lockDir, { recursive: true });
+    backdate(lockDir, OWNERLESS_GRACE_MS * 2);
+
+    await assert.rejects(
+      () => acquirePipelineLock(p, { timeoutMs: 200, retryMs: 20, staleMs: 60 * 60_000 }),
+      (err) => err instanceof LockTimeoutError,
+    );
+    assert.ok(existsSync(lockDir), 'the caller asked for an hour of patience and got the floor instead');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: a live recover guard is not deleted out from under the caller inside it (#2304)', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+    const guardDir = `${lockDir}.recover`;
+
+    // A stale lock is available to reclaim...
+    writeCrashedHolder(lockDir);
+    // ...but another caller is already inside the guarded decide-then-delete
+    // window. The guard never carries owner.json, so it is judged by age
+    // alone — and a fresh one must not be reclaimable, or two callers end up
+    // inside that window at once and each rmSync's the other's guard.
+    mkdirSync(guardDir);
+
+    await assert.rejects(
+      () => acquirePipelineLock(p, { timeoutMs: 200, retryMs: 20, staleMs: 1 }),
+      (err) => err instanceof LockTimeoutError,
+    );
+    assert.ok(existsSync(guardDir), 'a contender deleted a live recover guard, defeating reclaim serialization');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: a recover guard abandoned by a crashed process still ages out (#2304)', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const lockDir = `${p}.lock`;
+    const guardDir = `${lockDir}.recover`;
+
+    // A process killed between taking the guard and cleaning it up must not
+    // disable stale recovery forever — the floor delays reclaim, never blocks it.
+    writeCrashedHolder(lockDir);
+    mkdirSync(guardDir);
+    backdate(guardDir, OWNERLESS_GRACE_MS * 3);
+
+    const lock = await acquirePipelineLock(p, { timeoutMs: 1000, retryMs: 20, staleMs: 1 });
+    lock.release();
+    assert.equal(existsSync(guardDir), false, 'the abandoned recover guard should have been cleaned up');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -15,6 +15,12 @@ import { tmpdir } from 'os';
 import yaml from 'js-yaml';
 
 /**
+ * Minimum age before directory age alone may condemn an ownerless lock or
+ * recover guard. See `lockCanRecover` for why the age check needs a floor.
+ */
+export const OWNERLESS_GRACE_MS = 1_000;
+
+/**
  * Rebuild a markdown table row from the cells produced by `line.split('|')`.
  *
  * `split('|')` yields a leading empty element (before the opening `|`) and,
@@ -217,8 +223,20 @@ function sameLockDirectory(left, right) {
  * directory itself is older than the stale threshold, the waiting process may
  * remove the lock and retry acquisition.
  *
+ * That age fallback needs a floor. Two directories are ownerless by
+ * construction, not by accident: a lock between its `mkdirSync` and its
+ * `owner.json` write, and the recover guard, which never carries `owner.json`
+ * at all. Judging those on `age > staleMs` alone lets a caller with an
+ * aggressive staleMs delete a directory created microseconds ago — either
+ * stealing a winner's lock inside its acquisition window, or evicting a live
+ * guard and putting two callers inside the decide-then-delete window the guard
+ * exists to serialize. OWNERLESS_GRACE_MS is a lower bound on that patience,
+ * never a cap: a larger caller staleMs still wins, and a genuinely abandoned
+ * directory still ages out, so a crash while holding the guard cannot disable
+ * recovery for good.
+ *
  * @param {string} lockDir - Directory that represents the active lock.
- * @param {number} staleMs - Age threshold for metadata-free lock recovery.
+ * @param {number} staleMs - Age threshold for metadata-free lock recovery, floored at OWNERLESS_GRACE_MS.
  * @returns {boolean} True when the caller may remove and recreate the lock.
  */
 function lockCanRecover(lockDir, staleMs) {
@@ -226,7 +244,7 @@ function lockCanRecover(lockDir, staleMs) {
   if (owner?.pid) return !processIsAlive(owner.pid);
 
   try {
-    return Date.now() - statSync(lockDir).mtimeMs > staleMs;
+    return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
   } catch {
     return true;
   }
@@ -246,7 +264,7 @@ function lockCanRecover(lockDir, staleMs) {
  * @param {object} [options] - Lock timing options.
  * @param {number} [options.timeoutMs=60000] - Maximum time to wait for the lock.
  * @param {number} [options.retryMs=75] - Delay between acquisition attempts.
- * @param {number} [options.staleMs=600000] - Metadata-free stale-lock threshold.
+ * @param {number} [options.staleMs=600000] - Metadata-free stale-lock threshold, floored at OWNERLESS_GRACE_MS.
  * @param {string} [options.tracker] - Tracker path recorded in owner metadata.
  * @param {Function} [options.removeLock] - Release hook for deterministic fault tests.
  * @returns {Promise<{attempts:number,waitMs:number,staleRecovered:boolean,release:Function}>}

--- a/tracker-writer-lock-tests.mjs
+++ b/tracker-writer-lock-tests.mjs
@@ -4,7 +4,7 @@
 
 import { spawn } from 'child_process';
 import {
-  existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync,
+  existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, utimesSync, writeFileSync,
 } from 'fs';
 import { dirname, join } from 'path';
 import { tmpdir } from 'os';
@@ -448,6 +448,108 @@ async function testReplyWatchConflictingRecommendations() {
 }
 
 await testReplyWatchConflictingRecommendations();
+
+// --- Ownerless-directory grace period (#2306) -------------------------------
+//
+// A lock is ownerless for the instant between its `mkdirSync` and its
+// `owner.json` write, and the recover guard is ownerless for its whole life.
+// Judging either on `age > staleMs` alone lets a caller with a small staleMs
+// delete a directory created microseconds ago. These tests pin the floor that
+// keeps a brand-new ownerless directory off-limits, and — just as importantly —
+// pin that a genuinely old one is still reclaimed, so the floor cannot be
+// satisfied by disabling recovery outright.
+
+// Backdate a directory's mtime so the age check sees it as genuinely old.
+function backdate(path, ms) {
+  const when = new Date(Date.now() - ms);
+  utimesSync(path, when, when);
+}
+
+async function testFreshOwnerlessLockIsNotStolen() {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-ownerless-'));
+  const lockDir = join(dir, 'tracker.lock');
+  try {
+    // Stands in for a winner that has run mkdirSync but not yet written owner.json.
+    mkdirSync(lockDir);
+    let acquired = null;
+    let err = null;
+    try {
+      acquired = await acquireTrackerLock(lockDir, {
+        timeoutMs: 300, retryMs: 20, staleMs: 1, tracker: join(dir, 'applications.md'),
+      });
+    } catch (e) {
+      err = e;
+    }
+    if (err?.code === 'LOCK_TIMEOUT' && existsSync(lockDir)) {
+      pass('ownerless lock created microseconds ago is not stolen by a small staleMs');
+    } else {
+      fail(`fresh ownerless lock was stolen (staleRecovered=${acquired?.staleRecovered}, err=${err?.code})`);
+    }
+    acquired?.release();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function testAgedOwnerlessLockStillRecovers() {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-ownerless-aged-'));
+  const lockDir = join(dir, 'tracker.lock');
+  try {
+    // A real orphan: ownerless *and* older than any grace period.
+    mkdirSync(lockDir);
+    backdate(lockDir, 60_000);
+    const lock = await acquireTrackerLock(lockDir, {
+      timeoutMs: 1_000, retryMs: 20, staleMs: 1, tracker: join(dir, 'applications.md'),
+    });
+    if (lock.staleRecovered) {
+      pass('ownerless lock older than the grace period is still recovered');
+    } else {
+      fail('aged ownerless lock was not recovered — the grace period must not disable recovery');
+    }
+    lock.release();
+  } catch (e) {
+    fail(`aged ownerless lock was not recovered (${e.code ?? e.message})`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function testLiveRecoverGuardIsNotEvicted() {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-guard-live-'));
+  const lockDir = join(dir, 'tracker.lock');
+  const guardDir = `${lockDir}.recover`;
+  try {
+    // The lock itself is recoverable (dead owner PID), so the only thing that
+    // can hold recovery back is the guard — which another caller is holding
+    // right now. Evicting it puts two callers inside the decide-then-delete
+    // window the guard exists to serialize.
+    mkdirSync(lockDir);
+    writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({ pid: 999999999, token: 'dead', tracker: 'x' }));
+    mkdirSync(guardDir);
+
+    let acquired = null;
+    let err = null;
+    try {
+      acquired = await acquireTrackerLock(lockDir, {
+        timeoutMs: 300, retryMs: 20, staleMs: 1, tracker: join(dir, 'applications.md'),
+      });
+    } catch (e) {
+      err = e;
+    }
+    if (err?.code === 'LOCK_TIMEOUT' && existsSync(guardDir)) {
+      pass('recover guard held by a live caller is not evicted by a small staleMs');
+    } else {
+      fail(`live recover guard was evicted (staleRecovered=${acquired?.staleRecovered}, err=${err?.code}, guard=${existsSync(guardDir)})`);
+    }
+    acquired?.release();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+await testFreshOwnerlessLockIsNotStolen();
+await testAgedOwnerlessLockStillRecovers();
+await testLiveRecoverGuardIsNotEvicted();
 
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tracker-writer-lock-tests.mjs
+++ b/tracker-writer-lock-tests.mjs
@@ -465,25 +465,45 @@ function backdate(path, ms) {
   utimesSync(path, when, when);
 }
 
+// The two "must not reclaim" tests describe the boundary the floor creates by
+// backdating the ownerless directory into it: older than the caller's staleMs
+// (so the unfloored code reclaims on its very first pass) but far younger than
+// OWNERLESS_GRACE_MS (so the floored code must not). Stating both sides
+// explicitly keeps the tests off the wall clock — asserting against a
+// directory created "just now" would instead depend on whether a sub-
+// millisecond age drifts past a 1 ms threshold before the loop looks again,
+// which is a race, not an assertion.
+//
+// With the age relation pinned, one pass is enough in both directions, so
+// retryMs is set above timeoutMs. That also stops the loop from creating and
+// deleting the guard directory a dozen times: Windows defers a directory's
+// real removal until the last handle closes, so a tight mkdir/rmdir cycle on
+// one path can surface EPERM instead of the timeout under test.
+const ONE_PASS = { timeoutMs: 150, retryMs: 200 };
+const INSIDE_GRACE_MS = 100;   // ownerless for 100ms: past staleMs, well inside the 1s floor
+const SMALL_STALE_MS = 10;
+
 async function testFreshOwnerlessLockIsNotStolen() {
   const dir = mkdtempSync(join(tmpdir(), 'career-ops-ownerless-'));
   const lockDir = join(dir, 'tracker.lock');
   try {
-    // Stands in for a winner that has run mkdirSync but not yet written owner.json.
+    // Stands in for a winner that has run mkdirSync but not yet written
+    // owner.json — live, real, and unlabelled inside its acquisition window.
     mkdirSync(lockDir);
+    backdate(lockDir, INSIDE_GRACE_MS);
     let acquired = null;
     let err = null;
     try {
       acquired = await acquireTrackerLock(lockDir, {
-        timeoutMs: 300, retryMs: 20, staleMs: 1, tracker: join(dir, 'applications.md'),
+        ...ONE_PASS, staleMs: SMALL_STALE_MS, tracker: join(dir, 'applications.md'),
       });
     } catch (e) {
       err = e;
     }
     if (err?.code === 'LOCK_TIMEOUT' && existsSync(lockDir)) {
-      pass('ownerless lock created microseconds ago is not stolen by a small staleMs');
+      pass('ownerless lock inside the grace period is not stolen by a small staleMs');
     } else {
-      fail(`fresh ownerless lock was stolen (staleRecovered=${acquired?.staleRecovered}, err=${err?.code})`);
+      fail(`ownerless lock inside the grace period was stolen (staleRecovered=${acquired?.staleRecovered}, err=${err?.code})`);
     }
     acquired?.release();
   } finally {
@@ -526,12 +546,13 @@ async function testLiveRecoverGuardIsNotEvicted() {
     mkdirSync(lockDir);
     writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({ pid: 999999999, token: 'dead', tracker: 'x' }));
     mkdirSync(guardDir);
+    backdate(guardDir, INSIDE_GRACE_MS);
 
     let acquired = null;
     let err = null;
     try {
       acquired = await acquireTrackerLock(lockDir, {
-        timeoutMs: 300, retryMs: 20, staleMs: 1, tracker: join(dir, 'applications.md'),
+        ...ONE_PASS, staleMs: SMALL_STALE_MS, tracker: join(dir, 'applications.md'),
       });
     } catch (e) {
       err = e;

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -170,6 +170,7 @@ const SYSTEM_PATHS = [
   'pipeline-lock.mjs',
   'classify-tier.mjs',
   'scan-ats-full.mjs',
+  'scan-interamt.mjs',
   'match-star.mjs',
   'jd-skill-gap.mjs',
   'prepare-application.mjs',


### PR DESCRIPTION
## What does this PR do?

Floors the ownerless stale-lock check in `tracker-utils.mjs` and `followup-seed.mjs` at a 1-second grace period, so a lock or recover guard created microseconds ago can no longer be condemned by a caller passing a small `staleMs`. This is the same defect #2305 fixed in `pipeline-lock.mjs`, applied to the two sibling lock implementations that PR deliberately left alone.

## Related issue

Closes #2306

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

### The defect

`lockCanRecover()` prefers owner-PID liveness and falls back to directory age only when `owner.json` is missing or unreadable. The age fallback had no lower bound:

```js
return Date.now() - statSync(lockDir).mtimeMs > staleMs;
```

The fallback is written for a lock whose owner metadata is missing *by accident* — a process killed hard enough to leave the directory behind. But two directories are ownerless **by construction**, and the age rule cannot tell them apart from a corpse:

1. **A lock inside its own acquisition window.** Acquisition is `mkdirSync(lockDir)` followed by `writeFileSync(owner.json)`. Between those two calls the winner's lock is live, real, and unlabelled.
2. **The recover guard.** `${lockDir}.recover` never carries an `owner.json` at all — it is a bare `mkdirSync` whose entire job is to serialize the decide-then-delete sequence around stale-lock recovery. Every live guard is ownerless for its whole lifetime.

With no floor, a directory created microseconds ago is already "older than 1ms", which produces two failures:

- **Lock theft inside the acquisition window.** A wins `mkdirSync`; before A's `writeFileSync` lands, B hits `EEXIST`, reads no owner, computes `age > staleMs` → true, and removes A's lock. Both then believe they hold it — two writers inside the `applications.md` read/modify/write critical section, which is the lost-update race the lock exists to prevent.
- **Eviction of a live recover guard.** `tracker-utils.mjs` ages out guards orphaned by a killed process (L365). Without a floor that same check also evicts a guard another caller is *actively holding*, putting two callers inside the window the guard was added to serialize — after which both can judge the same lock stale and both remove it.

Neither copy is dead code: the tracker lock is the shared write path for `applications.md` (`set-status.mjs`, `merge-tracker.mjs`, `reserve-report-num.mjs`, `openTrackerTransaction`), and the follow-ups lock guards the read-check-append on `data/follow-ups.md`. Both expose `staleMs` to operators through `CAREER_OPS_TRACKER_LOCK_STALE_MS` and `CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS`, so small values are reachable in production, not only from tests.

### The fix

```js
export const OWNERLESS_GRACE_MS = 1_000;

// ...
return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
```

Identical in shape and value to #2305, and a lower bound rather than a cap — a larger caller `staleMs` still wins, and a genuinely abandoned directory still ages out, so a crash while holding the guard cannot disable recovery permanently. The constant is defined per-module rather than imported from `pipeline-lock.mjs`, so this PR stays independent of #2305's merge order and a tracker module gains no dependency on a pipeline module.

### Tests (written first, watched fail)

Five new assertions across the two suites. Each test backdates the ownerless directory into the boundary the floor creates — **older than the caller's `staleMs`, so the unfloored code reclaims it on its first pass, but far younger than `OWNERLESS_GRACE_MS`, so the floored code must not.** Pinning both sides of that relation keeps the tests off the wall clock; asserting against a directory created "just now" under `staleMs: 1` would instead depend on whether a sub-millisecond age drifts past a 1 ms threshold before the retry loop looks again, which is a race rather than an assertion. With the relation pinned, one pass settles it in both directions, so `retryMs` sits above `timeoutMs`.

Reverting the floor in both modules fails exactly the three positive tests, with the symptom under discussion:

```
FAIL ownerless lock inside the grace period was stolen (staleRecovered=true, err=undefined)
FAIL live recover guard was evicted (staleRecovered=undefined, err=LOCK_TIMEOUT, guard=false)
FAIL 14. ownerless lock inside the grace period is not stolen → exit 4 — got 0
FAIL 14. the untouched lock directory survives — it was removed
```

`tracker-writer-lock-tests.mjs`:
- an ownerless lock inside the grace period is not stolen → `LOCK_TIMEOUT`, lock survives
- a recover guard held by a live caller is not evicted → `LOCK_TIMEOUT`, guard survives
- **an ownerless lock backdated 60 s is still recovered** — this one passes both before and after, deliberately: it is the guard against a vacuous fix, since a floor that never let anything age out would deadlock every writer behind a real orphan

`followup-seed-tests.mjs` (driven through the CLI, so the fix is proven to reach real callers rather than just the helper):
- test 14 — ownerless lock inside the grace period → exit 4, lock directory survives
- test 15 — lock backdated 60 s → still recovered, exit 0

One note in case it is useful beyond this PR: the first revision of these tests did churn the guard directory through a dozen `mkdir`/`rmdir` cycles, and that failed **only on `windows-latest`** — Windows defers a directory's real removal until its last handle closes, so the tight cycle surfaced `EPERM` out of the acquisition loop instead of the timeout under test. The rewrite above removes the churn as a side effect of removing the race. Worth knowing that `test-all.mjs` reports any non-zero exit from a suite as `<name> crashed` and discards its stdout/stderr, so on CI this was indistinguishable from a genuine crash and took a round trip to attribute.

### One existing test adjusted, and a correction to the issue

`set-status-tests.mjs` L624 ages an orphaned guard with a real 150 ms `setTimeout` under `staleMs: 50`. I predicted in #2306 that the floor would break it. **It doesn't** — it still passes, because `timeoutMs: 3000` lets the acquisition loop spin until the guard crosses 1 s. But it then passes for a vaguer reason (the guard aged past the floor, not past the threshold the test names) and costs ~0.9 s of spinning.

So this is a clarity and speed change rather than a required fix: the guard's mtime is backdated with `utimesSync` instead, which makes the test assert what it claims — *this guard is reclaimable because it is abandoned* — and brings the suite from 3.05 s back to 1.96 s, slightly under its 2.12 s pre-change baseline.

I verified the adjusted test is still non-vacuous by disabling the guard-aging branch in `tracker-utils.mjs` and confirming it fails for the original reason:

```
FAIL recover-guard: acquisition failed — orphaned guard blocked recovery (Timed out waiting for tracker lock ...)
```

The other three `staleMs` call sites — `tracker-writer-lock-tests.mjs` L110, L272, L316 — pass `5_000`. `Math.max(5_000, 1_000)` is `5_000`, so those see no behavior change at all.

### Verification

```
node test-all.mjs                      → 2451 passed, 0 failed, 1 warning
node validate-system-paths-coverage.mjs → OK: 886 tracked files covered
```

The single warning is `cv-sync-check.mjs exited with error (expected without user data)` — pre-existing on a clean checkout with no `cv.md`, unrelated to this change. CI is green on all three runners (ubuntu, macos, windows).

### Noted, not fixed here

`followup-seed.mjs` has no equivalent of `tracker-utils.mjs`'s L365 guard-aging branch, so a recover guard orphaned by a killed process permanently disables stale-lock recovery for the follow-ups lock. That is a separate defect from this one and I left it alone rather than widen this PR; happy to file it if useful.

Relatedly, three near-identical lock implementations now carry three copies of this same reasoning. Consolidating them behind one module looks worthwhile, but is a refactor rather than a bug fix — I'd rather do it as its own change, once #2305 and this one have landed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Interamt job scanning with keyword searches, filtering, duplicate detection, pagination, dry-run, and debug options.
  - Invite analysis now identifies Zoom, Microsoft Teams, Google Meet, or phone calls.
- **Bug Fixes**
  - Improved lock recovery to protect newly created or active locks while recovering genuinely stale locks safely.
  - Prevented abandoned recovery guards from blocking valid recovery indefinitely.
- **Documentation**
  - Updated interview preparation and debrief guidance for call platforms and correcting contradicted facts.
  - Added Interamt configuration examples and usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->