### PR TITLE
fix(dashboard): pin the row's own status to the top of the status picker

### DIFF
--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -194,8 +194,13 @@ type StatusPair struct {
 	Canonical string
 }
 
-func getStatusPairs() []StatusPair {
-	return []StatusPair{
+// getStatusPairs returns the status-change picker's options in their static
+// display order. When currentNormalized is non-empty and matches one of the
+// entries (compared via data.NormalizeStatus), that entry is pulled to the
+// front so the row's own current status always leads the list, with the
+// remaining options kept in their original relative order behind it.
+func getStatusPairs(currentNormalized string) []StatusPair {
+	base := []StatusPair{
 		{i18n.Current.StatusEvaluated, "Evaluated"},
 		{i18n.Current.StatusApplied, "Applied"},
 		{i18n.Current.StatusResponded, "Responded"},
@@ -206,6 +211,41 @@ func getStatusPairs() []StatusPair {
 		{i18n.Current.StatusDiscarded, "Discarded"},
 		{i18n.Current.StatusSkip, "Skip"},
 	}
+
+	if currentNormalized == "" {
+		return base
+	}
+
+	var current *StatusPair
+	rest := make([]StatusPair, 0, len(base))
+	for _, pair := range base {
+		if current == nil && data.NormalizeStatus(pair.Canonical) == currentNormalized {
+			p := pair
+			current = &p
+			continue
+		}
+		rest = append(rest, pair)
+	}
+
+	if current == nil {
+		// Unrecognized/unmapped status -- fall back to the static order.
+		return base
+	}
+
+	ordered := make([]StatusPair, 0, len(base))
+	ordered = append(ordered, *current)
+	ordered = append(ordered, rest...)
+	return ordered
+}
+
+// currentStatusPairs resolves the status-change picker options for whichever
+// application is currently selected in the main list, so the picker reflects
+// that row's own status rather than always assuming "Evaluated".
+func (m PipelineModel) currentStatusPairs() []StatusPair {
+	if app, ok := m.CurrentApp(); ok {
+		return getStatusPairs(data.NormalizeStatus(app.Status))
+	}
+	return getStatusPairs("")
 }
 
 // statusGroupOrder defines display order for grouped view.
@@ -746,8 +786,8 @@ func (m PipelineModel) handleStatusPicker(msg tea.KeyMsg) (PipelineModel, tea.Cm
 
 	case "down", "j":
 		m.statusCursor++
-		if m.statusCursor >= len(getStatusPairs()) {
-			m.statusCursor = len(getStatusPairs()) - 1
+		if m.statusCursor >= len(m.currentStatusPairs()) {
+			m.statusCursor = len(m.currentStatusPairs()) - 1
 		}
 
 	case "up", "k":
@@ -759,7 +799,7 @@ func (m PipelineModel) handleStatusPicker(msg tea.KeyMsg) (PipelineModel, tea.Cm
 	case "enter":
 		m.statusPicker = false
 		if app, ok := m.CurrentApp(); ok {
-			newStatus := getStatusPairs()[m.statusCursor].Canonical
+			newStatus := m.currentStatusPairs()[m.statusCursor].Canonical
 			norm := data.NormalizeStatus(newStatus)
 			if norm == "hired" {
 				m.hiredApp = app
@@ -1899,7 +1939,7 @@ func (m PipelineModel) overlayStatusPicker(body string) string {
 	var picker []string
 	picker = append(picker, padStyle.Render(borderStyle.Render(i18n.Current.PickerChangeStatus)))
 
-	for i, pair := range getStatusPairs() {
+	for i, pair := range m.currentStatusPairs() {
 		style := lipgloss.NewStyle().Foreground(m.theme.Text).Width(pickerWidth)
 		if i == m.statusCursor {
 			style = style.Background(m.theme.Overlay).Bold(true)

--- a/dashboard/internal/ui/screens/pipeline_test.go
+++ b/dashboard/internal/ui/screens/pipeline_test.go
@@ -689,3 +689,41 @@ func TestWithReloadedDataPreservesDiscardAndHiredFlow(t *testing.T) {
 		t.Fatalf("hired flow lost: step=%d app=%+v", reloaded.hiredStep, reloaded.hiredApp)
 	}
 }
+
+func TestGetStatusPairsPinsCurrentStatusToFront(t *testing.T) {
+	base := getStatusPairs("")
+
+	ordered := getStatusPairs("applied")
+	if ordered[0].Canonical != "Applied" {
+		t.Fatalf("ordered[0].Canonical = %q, want Applied", ordered[0].Canonical)
+	}
+	if len(ordered) != len(base) {
+		t.Fatalf("len(ordered) = %d, want %d (no entries added or dropped)", len(ordered), len(base))
+	}
+
+	// The rest of the list keeps its original relative order.
+	var restGotWithoutApplied []string
+	for _, pair := range ordered[1:] {
+		restGotWithoutApplied = append(restGotWithoutApplied, pair.Canonical)
+	}
+	var restWant []string
+	for _, pair := range base {
+		if pair.Canonical != "Applied" {
+			restWant = append(restWant, pair.Canonical)
+		}
+	}
+	if strings.Join(restGotWithoutApplied, ",") != strings.Join(restWant, ",") {
+		t.Fatalf("rest of list reordered: got %v, want %v", restGotWithoutApplied, restWant)
+	}
+}
+
+func TestGetStatusPairsUnrecognizedStatusFallsBackToStaticOrder(t *testing.T) {
+	base := getStatusPairs("")
+	got := getStatusPairs("some-unmapped-status")
+
+	for i := range base {
+		if got[i].Canonical != base[i].Canonical {
+			t.Fatalf("got[%d].Canonical = %q, want %q (static order)", i, got[i].Canonical, base[i].Canonical)
+		}
+	}
+}

--- a/dashboard/internal/ui/screens/viewer.go
+++ b/dashboard/internal/ui/screens/viewer.go
@@ -138,14 +138,9 @@ func (m ViewerModel) Update(msg tea.Msg) (ViewerModel, tea.Cmd) {
 
 		case "c":
 			m.statusPicker = true
+			// The picker's own current-status-first reordering (see
+			// getStatusPairs) always places this row's status at index 0.
 			m.statusCursor = 0
-			currentNorm := data.NormalizeStatus(m.app.Status)
-			for idx, pair := range getStatusPairs() {
-				if pair.Canonical == currentNorm {
-					m.statusCursor = idx
-					break
-				}
-			}
 			m.clampScrollOffset()
 			return m, nil
 
@@ -210,7 +205,7 @@ func (m ViewerModel) Update(msg tea.Msg) (ViewerModel, tea.Cmd) {
 func (m ViewerModel) bodyHeight() int {
 	h := m.height - 4 // header + footer + padding
 	if m.statusPicker {
-		h -= (len(getStatusPairs()) + 1)
+		h -= (len(m.currentStatusPairs()) + 1)
 	}
 	if h < 3 {
 		h = 3
@@ -746,8 +741,8 @@ func (m ViewerModel) handleStatusPicker(msg tea.KeyMsg) (ViewerModel, tea.Cmd) {
 
 	case "down", "j":
 		m.statusCursor++
-		if m.statusCursor >= len(getStatusPairs()) {
-			m.statusCursor = len(getStatusPairs()) - 1
+		if m.statusCursor >= len(m.currentStatusPairs()) {
+			m.statusCursor = len(m.currentStatusPairs()) - 1
 		}
 
 	case "up", "k":
@@ -759,7 +754,7 @@ func (m ViewerModel) handleStatusPicker(msg tea.KeyMsg) (ViewerModel, tea.Cmd) {
 	case "enter":
 		m.statusPicker = false
 		m.clampScrollOffset()
-		newStatus := getStatusPairs()[m.statusCursor].Canonical
+		newStatus := m.currentStatusPairs()[m.statusCursor].Canonical
 		return m, func() tea.Msg {
 			return ViewerUpdateStatusMsg{
 				App:       m.app,
@@ -782,7 +777,7 @@ func (m ViewerModel) overlayStatusPicker(body string) string {
 	var picker []string
 	picker = append(picker, padStyle.Render(borderStyle.Render(i18n.Current.PickerChangeStatus)))
 
-	for i, pair := range getStatusPairs() {
+	for i, pair := range m.currentStatusPairs() {
 		style := lipgloss.NewStyle().Foreground(m.theme.Text).Width(pickerWidth)
 		if i == m.statusCursor {
 			style = style.Background(m.theme.Overlay).Bold(true)
@@ -796,6 +791,13 @@ func (m ViewerModel) overlayStatusPicker(body string) string {
 
 	bodyLines = append(bodyLines, picker...)
 	return strings.Join(bodyLines, "\n")
+}
+
+// currentStatusPairs resolves the status-change picker options for the
+// application currently open in the viewer, so the picker leads with this
+// row's own status (see getStatusPairs).
+func (m ViewerModel) currentStatusPairs() []StatusPair {
+	return getStatusPairs(data.NormalizeStatus(m.app.Status))
 }
 
 // UpdateAppStatus updates the status of the current application inside the viewer model.

--- a/dashboard/internal/ui/screens/viewer_test.go
+++ b/dashboard/internal/ui/screens/viewer_test.go
@@ -6,8 +6,18 @@ import (
 
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/santifer/career-ops/dashboard/internal/model"
 	"github.com/santifer/career-ops/dashboard/internal/theme"
 )
+
+func TestViewerCurrentStatusPairsLeadsWithRowStatus(t *testing.T) {
+	m := ViewerModel{app: model.CareerApplication{Status: "Interview"}}
+
+	pairs := m.currentStatusPairs()
+	if len(pairs) == 0 || pairs[0].Canonical != "Interview" {
+		t.Fatalf("currentStatusPairs()[0] = %+v, want Interview leading", pairs[0])
+	}
+}
 
 func TestViewerRebuildRenderClampsScrollOffset(t *testing.T) {
 	m := ViewerModel{


### PR DESCRIPTION
## What
The status-change picker (`c` on a pipeline row, or in the report viewer) always opened with **Evaluated** highlighted at position 0, regardless of the row's actual current status. `getStatusPairs()` now takes the row's normalized current status and moves that entry to the front of the list; every other status keeps its existing relative order behind it.

## Why
Pressing `c` on a row already marked `Applied`/`Interview`/etc. opened the picker on `Evaluated`, so the row's real status was buried further down the list — you'd scroll past several options just to find where you already were. The single-item viewer had a similar cursor-jump path that was supposed to fix this but silently never worked: it compared the raw `Canonical` string (`"Applied"`) against `data.NormalizeStatus`'s lowercase output (`"applied"`), so the comparison never matched and the cursor always fell back to index 0. The reordering approach here makes that fallback unnecessary — index 0 is always correct by construction — so the dead code was removed rather than fixed in place.

## Scope
This only changes *which entry leads the list*. It does not reorder, rename, or add to the remaining status options — `Skip` stays in its existing last position, and no new statuses are introduced.

## Test plan
- Added `TestGetStatusPairsPinsCurrentStatusToFront` / `TestGetStatusPairsUnrecognizedStatusFallsBackToStaticOrder` (pipeline_test.go)
- Added `TestViewerCurrentStatusPairsLeadsWithRowStatus` (viewer_test.go)
- `go build ./...`, `go vet ./...`, `gofmt -l .` clean; full existing suite passes unmodified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Status pickers now place the application’s current status at the top of the list for faster selection.
  * Picker navigation, selection, and displayed options remain synchronized with the reordered list.
  * Unknown or unavailable statuses continue to use the default option order.

* **Tests**
  * Added coverage for current-status ordering and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->