### PR TITLE
ci: republish the required 'test' status context lost to the matrix (#2261)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,11 @@ jobs:
   # be dropped:
   #   - `name: test` IS the required context. Renaming the job is harmless;
   #     renaming this is what re-breaks the merge gate.
-  #   - `if: always()` — without it a failed matrix skips this job, and a
-  #     skipped required check never reports, which reopens the same stall on
-  #     exactly the PRs that should be blocked.
+  #   - `if: always()` — without it a failed matrix skips this job, and GitHub
+  #     reports a skipped required check as SUCCESSFUL. The merge gate would
+  #     then be bypassed on exactly the PRs that should be blocked: worse than
+  #     the stall above, because a green check hides it. It must stay a bare
+  #     `always()`; `always() && <cond>` can skip again.
   test-summary:
     name: test
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,29 @@ jobs:
       - name: Go dashboard tests
         run: go test ./...
         working-directory: dashboard
+
+  # Branch protection requires a status context named exactly `test`. Since the
+  # suite was matrixed (#1762) the legs report as `test (ubuntu-latest)` /
+  # `(macos-latest)` / `(windows-latest)` and nothing publishes a bare `test`,
+  # so the required context sat at "Expected — waiting for status to be
+  # reported" on every PR forever, 3/3 green included (#2261).
+  #
+  # This job republishes that one name. Two things keep it honest and must not
+  # be dropped:
+  #   - `name: test` IS the required context. Renaming the job is harmless;
+  #     renaming this is what re-breaks the merge gate.
+  #   - `if: always()` — without it a failed matrix skips this job, and a
+  #     skipped required check never reports, which reopens the same stall on
+  #     exactly the PRs that should be blocked.
+  test-summary:
+    name: test
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # `needs.test.result` is the matrix roll-up: success only when every leg
+      # succeeded, so this is red on failure, cancellation, or a skipped matrix.
+      - name: Assert every matrix leg passed
+        run: |
+          echo "Tests matrix result: ${{ needs.test.result }}"
+          [ "${{ needs.test.result }}" = "success" ] || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,12 @@ jobs:
       # `needs.test.result` is the matrix roll-up: success only when every leg
       # succeeded, so this is red on failure, cancellation, or a skipped matrix.
       - name: Assert every matrix leg passed
+        # The result is read through env rather than interpolated into the
+        # script. It is a GitHub-controlled enum here, so nothing is
+        # exploitable — but `${{ }}` inside `run:` is the shape that becomes an
+        # injection the day someone copies this step for a value that isn't.
+        env:
+          MATRIX_RESULT: ${{ needs.test.result }}
         run: |
-          echo "Tests matrix result: ${{ needs.test.result }}"
-          [ "${{ needs.test.result }}" = "success" ] || exit 1
+          echo "Tests matrix result: $MATRIX_RESULT"
+          [ "$MATRIX_RESULT" = "success" ] || exit 1

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12431,25 +12431,37 @@ try {
   }
 
   const summary = /** @type {any} */ (publisher ? publisher[1] : null);
-
-  // Gating on the matrix is what makes the context meaningful: without `needs`
-  // it would go green while the suite burns.
-  const needs = [summary?.needs].flat().filter(Boolean);
   const matrixJobIds = Object.keys(jobs).filter((id) => /** @type {any} */ (jobs[id])?.strategy?.matrix);
-  if (matrixJobIds.length > 0 && matrixJobIds.every((id) => needs.includes(id))) {
-    pass(`the "test" context waits on every matrixed job (${matrixJobIds.join(', ')})`);
-  } else {
-    fail(`the "test" context does not depend on the matrixed job(s) [${matrixJobIds.join(', ')}] — it would report green while the matrix fails`);
-  }
 
-  // Without always() a failed matrix SKIPS the summary, and a skipped required
-  // check never reports — the same indefinite stall, on the PRs that should be
-  // blocked. With it, the result must be asserted or the job is green regardless.
-  const assertsResult = JSON.stringify(summary?.steps || []).includes('needs.test.result');
-  if (String(summary?.if || '').includes('always()') && assertsResult) {
-    pass('the "test" context runs on always() AND asserts the matrix result (fails closed)');
+  // The invariant is "a job publishes `test` and it is red when the suite is
+  // red", NOT "the suite is matrixed". Un-matrixing is a legitimate revert of
+  // #1762 in which the publisher IS the suite job — asserting the aggregation
+  // wiring there would fail a perfectly satisfied merge gate, and a guard that
+  // cries wolf on a valid workflow gets deleted rather than understood.
+  if (matrixJobIds.length === 0) {
+    pass('the suite is not matrixed — the "test" job publishes the required context directly, nothing to aggregate');
   } else {
-    fail('the "test" context is missing always() or the matrix-result assertion — a failed matrix would skip it (#2261)');
+    // Gating on the matrix is what makes the context meaningful: without
+    // `needs` it would go green while the suite burns.
+    const needs = [summary?.needs].flat().filter(Boolean);
+    if (matrixJobIds.every((id) => needs.includes(id))) {
+      pass(`the "test" context waits on every matrixed job (${matrixJobIds.join(', ')})`);
+    } else {
+      fail(`the "test" context does not depend on the matrixed job(s) [${matrixJobIds.join(', ')}] — it would report green while the matrix fails`);
+    }
+
+    // Without always() a failed matrix SKIPS the summary, and a skipped
+    // required check never reports — the same indefinite stall, on the PRs
+    // that should be blocked. With it, the result must be asserted or the job
+    // is green regardless. The expected expressions are derived from the
+    // matrix job ids, so renaming those jobs consistently does not trip this.
+    const steps = JSON.stringify(summary?.steps || []);
+    const assertsResult = matrixJobIds.every((id) => steps.includes(`needs.${id}.result`));
+    if (String(summary?.if || '').includes('always()') && assertsResult) {
+      pass('the "test" context runs on always() AND asserts every matrix result (fails closed)');
+    } else {
+      fail(`the "test" context is missing always() or an assertion on ${matrixJobIds.map((id) => `needs.${id}.result`).join(' / ')} — a failed matrix would skip it (#2261)`);
+    }
   }
 } catch (e) {
   fail(`required 'test' status context check crashed: ${e.message}`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12450,17 +12450,36 @@ try {
       fail(`the "test" context does not depend on the matrixed job(s) [${matrixJobIds.join(', ')}] — it would report green while the matrix fails`);
     }
 
-    // Without always() a failed matrix SKIPS the summary, and a skipped
-    // required check never reports — the same indefinite stall, on the PRs
-    // that should be blocked. With it, the result must be asserted or the job
-    // is green regardless. The expected expressions are derived from the
-    // matrix job ids, so renaming those jobs consistently does not trip this.
-    const steps = JSON.stringify(summary?.steps || []);
-    const assertsResult = matrixJobIds.every((id) => steps.includes(`needs.${id}.result`));
-    if (String(summary?.if || '').includes('always()') && assertsResult) {
-      pass('the "test" context runs on always() AND asserts every matrix result (fails closed)');
+    // Without always() a failed matrix SKIPS the summary — and GitHub reports
+    // a skipped required check as SUCCESSFUL, so the merge gate is bypassed on
+    // exactly the PRs that should be blocked. That is worse than the #2261
+    // stall this job fixes: the stall is at least visible.
+    //
+    // `always()` must therefore be the WHOLE condition: `always() && <cond>`
+    // can still skip. And it only buys a job that runs — the run must also
+    // fail on a red matrix, or the context is green regardless.
+    if (String(summary?.if ?? '').trim() === 'always()') {
+      pass('the "test" context runs unconditionally (if: always(), not always() && …)');
     } else {
-      fail(`the "test" context is missing always() or an assertion on ${matrixJobIds.map((id) => `needs.${id}.result`).join(' / ')} — a failed matrix would skip it (#2261)`);
+      fail(`the "test" context has if: ${JSON.stringify(summary?.if ?? null)} — anything but a bare always() can skip, and a skipped required check reports as SUCCESS (#2261)`);
+    }
+
+    // A step asserts a leg when it (a) binds that leg's result, in env or
+    // inline, (b) compares it to success, and (c) exits non-zero otherwise.
+    // Merely mentioning the expression is not an assertion. The expected
+    // expressions are derived from the matrix job ids, so renaming those jobs
+    // consistently does not trip this.
+    const assertsLeg = (/** @type {any} */ step, /** @type {string} */ id) => {
+      const script = String(step?.run || '');
+      const binds = script.includes(`needs.${id}.result`) || JSON.stringify(step?.env || {}).includes(`needs.${id}.result`);
+      return binds && /=+\s*"?success"?/.test(script) && /exit\s+[1-9]/.test(script);
+    };
+    const steps = Array.isArray(summary?.steps) ? summary.steps : [];
+    const unasserted = matrixJobIds.filter((id) => !steps.some((/** @type {any} */ step) => assertsLeg(step, id)));
+    if (unasserted.length === 0) {
+      pass('the "test" context fails closed: every matrix result is compared to success with a non-zero exit');
+    } else {
+      fail(`the "test" context never asserts ${unasserted.map((id) => `needs.${id}.result`).join(' / ')} against success with a non-zero exit — a red matrix would report green (#2261)`);
     }
   }
 } catch (e) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12464,15 +12464,36 @@ try {
       fail(`the "test" context has if: ${JSON.stringify(summary?.if ?? null)} — anything but a bare always() can skip, and a skipped required check reports as SUCCESS (#2261)`);
     }
 
-    // A step asserts a leg when it (a) binds that leg's result, in env or
-    // inline, (b) compares it to success, and (c) exits non-zero otherwise.
-    // Merely mentioning the expression is not an assertion. The expected
-    // expressions are derived from the matrix job ids, so renaming those jobs
-    // consistently does not trip this.
+    // A step asserts a leg only when the comparison is tied to THAT leg's
+    // result. Checking that the expression, a `success` comparison and an
+    // `exit` each appear somewhere in the step is not enough: they can belong
+    // to unrelated commands, and a step carrying its own `if:` may never run
+    // at all. The expected expressions are derived from the matrix job ids, so
+    // renaming those jobs consistently does not trip this.
     const assertsLeg = (/** @type {any} */ step, /** @type {string} */ id) => {
+      // A conditional step is not a guarantee — `if: false` asserts nothing.
+      const stepIf = String(step?.if ?? '').trim();
+      if (stepIf !== '' && stepIf !== 'always()' && stepIf !== 'true') return false;
+
+      // The shell tokens that actually carry this leg's result: the inline
+      // expression, plus any env var bound to it.
+      const expression = `needs.${id}.result`;
       const script = String(step?.run || '');
-      const binds = script.includes(`needs.${id}.result`) || JSON.stringify(step?.env || {}).includes(`needs.${id}.result`);
-      return binds && /=+\s*"?success"?/.test(script) && /exit\s+[1-9]/.test(script);
+      const tokens = script.includes(expression) ? [expression] : [];
+      for (const [key, value] of Object.entries(step?.env || {})) {
+        if (String(value).includes(expression)) tokens.push(`$${key}`, `\${${key}}`);
+      }
+      if (tokens.length === 0) return false;
+
+      // The comparison must sit in the same command as the token, and the
+      // non-zero exit within reach of it — covering both `[ … ] || exit 1` and
+      // the `if [ … ]; then exit 1; fi` spelling, but not an `exit` that
+      // belongs to some other command further down the script.
+      const lines = script.split('\n');
+      return lines.some((line, i) => {
+        if (!tokens.some((token) => line.includes(token)) || !line.includes('success')) return false;
+        return lines.slice(i, i + 4).some((l) => /exit\s+[1-9]/.test(l));
+      });
     };
     const steps = Array.isArray(summary?.steps) ? summary.steps : [];
     const unasserted = matrixJobIds.filter((id) => !steps.some((/** @type {any} */ step) => assertsLeg(step, id)));

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12409,6 +12409,52 @@ try {
   fail(`table-freshness wiring check: ${e.message}`);
 }
 
+// ── 70. CI — the required 'test' status context is published (#2261) ──
+console.log("\n70. CI — required 'test' status context (#2261)");
+
+try {
+  const { load } = await import('js-yaml');
+  const workflow = /** @type {any} */ (load(readFile('.github/workflows/test.yml')));
+  const jobs = workflow?.jobs || {};
+
+  // Branch protection requires a context named exactly `test`. A matrixed job
+  // reports `test (<os>)` and never that bare name, so SOME job must publish
+  // it — otherwise every PR stalls at "Expected, waiting for status to be
+  // reported" even when the whole matrix is green (#2261, regression of #1762).
+  const publisher = Object.entries(jobs).find(
+    ([id, job]) => (/** @type {any} */ (job)?.name || id) === 'test' && !(/** @type {any} */ (job)?.strategy?.matrix),
+  );
+  if (publisher) {
+    pass(`a non-matrixed job publishes the required "test" context (jobs.${publisher[0]})`);
+  } else {
+    fail('no job reports a bare "test" check — branch protection can never be satisfied (#2261)');
+  }
+
+  const summary = /** @type {any} */ (publisher ? publisher[1] : null);
+
+  // Gating on the matrix is what makes the context meaningful: without `needs`
+  // it would go green while the suite burns.
+  const needs = [summary?.needs].flat().filter(Boolean);
+  const matrixJobIds = Object.keys(jobs).filter((id) => /** @type {any} */ (jobs[id])?.strategy?.matrix);
+  if (matrixJobIds.length > 0 && matrixJobIds.every((id) => needs.includes(id))) {
+    pass(`the "test" context waits on every matrixed job (${matrixJobIds.join(', ')})`);
+  } else {
+    fail(`the "test" context does not depend on the matrixed job(s) [${matrixJobIds.join(', ')}] — it would report green while the matrix fails`);
+  }
+
+  // Without always() a failed matrix SKIPS the summary, and a skipped required
+  // check never reports — the same indefinite stall, on the PRs that should be
+  // blocked. With it, the result must be asserted or the job is green regardless.
+  const assertsResult = JSON.stringify(summary?.steps || []).includes('needs.test.result');
+  if (String(summary?.if || '').includes('always()') && assertsResult) {
+    pass('the "test" context runs on always() AND asserts the matrix result (fails closed)');
+  } else {
+    fail('the "test" context is missing always() or the matrix-result assertion — a failed matrix would skip it (#2261)');
+  }
+} catch (e) {
+  fail(`required 'test' status context check crashed: ${e.message}`);
+}
+
 await runDiscovered();
 
 finish();


### PR DESCRIPTION
Fixes #2261

## Problem

Since #1762 matrixed the suite, `.github/workflows/test.yml`'s single `test` job reports check runs named `test (ubuntu-latest)` / `test (macos-latest)` / `test (windows-latest)`. Branch protection still requires a context named exactly `test`, which nothing publishes anymore — so every PR opened since 2026-07-27 sits at **"test — Expected, waiting for status to be reported"**, matrix 3/3 green included.

Reproduced independently on the 5 currently-open PRs (#2302, #2303, #2305, #2307, #2308): not one of them reports a bare `test` context, and all show `mergeStateStatus: BLOCKED` while every actual check is green.

## Fix

Option 1 from the issue — an aggregate job that republishes the required context:

```yaml
  test-summary:
    name: test
    needs: test
    if: always()
    steps:
      - name: Assert every matrix leg passed
        env:
          MATRIX_RESULT: ${{ needs.test.result }}
        run: |
          echo "Tests matrix result: $MATRIX_RESULT"
          [ "$MATRIX_RESULT" = "success" ] || exit 1
```

It fails closed on every axis that matters:

- `needs: test` — `needs.test.result` is the matrix roll-up, so the context is `success` only when all three legs pass. Without it the job would go green while the suite burns.
- `if: always()` — without it a failed matrix *skips* the summary, and GitHub reports a skipped required check as **successful**. Dropping it does not reproduce the stall; it silently bypasses the merge gate on exactly the PRs that should be blocked, which is worse because a green check hides it. It must stay a bare `always()` — `always() && <cond>` can skip again.
- The result is asserted explicitly; `always()` alone would make the job green regardless of the matrix.
- The result is read through `env` rather than interpolated into the script. It is a GitHub-controlled enum, so nothing here is exploitable — but `${{ }}` inside `run:` is the shape that becomes an injection the day someone copies the step for a value that isn't.

No change to the matrix legs, so the existing `test (<os>)` contexts keep reporting for anyone reading per-OS results. Option 2 (updating the required contexts in branch protection) is still available to a maintainer and is compatible with this — it just needs admin access this PR doesn't have.

## Regression guard

New section 62 in `test-all.mjs` parses the workflow and asserts:

1. a **non-matrixed** job publishes the bare `test` name (a matrixed one never can);
2. it `needs` every matrixed job in the file;
3. its condition is exactly `always()` (`always() && <cond>` can still skip);
4. some step **binds** each matrix result, compares it to `success`, and exits non-zero — mentioning the expression is not an assertion.

Checks 2-4 are skipped when no job is matrixed: un-matrixing is a legitimate revert of #1762 in which the `test` job publishes the context directly, and a guard that fails a valid workflow gets deleted rather than understood. The expected expressions in check 4 are derived from the matrix job ids, so renaming those jobs consistently does not trip it either.

Rematrixing this job, renaming it, or dropping `always()` now fails the suite loudly instead of silently disabling the merge gate for the whole repo — which is how #1762 slipped through.

## Test plan

- [x] `node test-all.mjs --quick` — 2453 passed, 0 failed (the workflow's own CI command)
- [x] Guard verified to fail closed against four mutated workflows: summary job deleted, `name:` renamed, `if: always()` removed, `needs:` removed
- [x] Guard verified to stay green on two valid variants it must not reject: an un-matrixed suite, and a matrix job renamed consistently
- [x] Guard verified to reject three ways a workflow could look wired but still mask a red matrix: `always() && <cond>`, `!cancelled()`, and an `env` binding whose `run` never checks the value (or checks it and exits 0)
- [x] Workflow parses as valid YAML; jobs resolve to `test` (matrix) + `test-summary` (`name: test`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI status reporting by ensuring the required `test` check reflects the overall result across all test environments.
  * Ensured the `test` roll-up check runs even when individual environments fail or are skipped.

* **Tests**
  * Added a CI workflow contract test that verifies the required `test` status context is published and correctly wired to aggregate results from matrix jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->