### PR TITLE
fix(followup-seed): age out an orphaned recover guard so it can't permanently disable stale-lock recovery

### DIFF
--- a/followup-seed-tests.mjs
+++ b/followup-seed-tests.mjs
@@ -383,9 +383,9 @@ function cleanup(sandbox) {
   mkdirSync(sb.lock, { recursive: true });   // ownerless: no owner.json
   mkdirSync(guard, { recursive: true });     // the SIGKILLed predecessor's leftover
   // Both an hour old. Backdating explicitly keeps the test off the wall clock:
-  // an age of 3_600_000ms clears any threshold the run could apply (staleMs 10,
-  // floored to 1_000 by OWNERLESS_GRACE_MS) by three orders of magnitude, so
-  // the outcome cannot hinge on how long the retry loop happens to take.
+  // an age of 3_600_000ms clears the configured staleMs of 10 by five orders of
+  // magnitude, so the outcome cannot hinge on how long the retry loop happens
+  // to take.
   const anHourAgo = new Date(Date.now() - 3_600_000);
   utimesSync(sb.lock, anHourAgo, anHourAgo);
   utimesSync(guard, anHourAgo, anHourAgo);

--- a/followup-seed-tests.mjs
+++ b/followup-seed-tests.mjs
@@ -13,7 +13,7 @@
  */
 
 import { execFileSync } from 'child_process';
-import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, existsSync, utimesSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -366,6 +366,66 @@ function cleanup(sandbox) {
   else fail(`13. --backfill --date → exit 1 — got ${res.code}\n${res.stdout}${res.stderr}`);
   if (res.stderr.includes('--date cannot be combined with --backfill')) pass('13. usage error explains the rejection');
   else fail(`13. usage error explains the rejection — got\n${res.stderr}`);
+  cleanup(sb);
+}
+
+// ── Test 14: an orphaned recover guard does not block stale-lock recovery ───
+// A process killed between creating `<lock>.recover` and cleaning it up leaves
+// the guard behind forever. Because the guard is the ticket required to run
+// stale-lock recovery at all, an abandoned one permanently disables recovery:
+// every later seed run times out at exit 4 until someone deletes the directory
+// under tmpdir by hand. tracker-utils.mjs and pipeline-lock.mjs both age the
+// guard out for exactly this reason; followup-seed.mjs was the outlier.
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  const guard = `${sb.lock}.recover`;
+  mkdirSync(sb.lock, { recursive: true });   // ownerless: no owner.json
+  mkdirSync(guard, { recursive: true });     // the SIGKILLed predecessor's leftover
+  // Both an hour old. Backdating explicitly keeps the test off the wall clock:
+  // an age of 3_600_000ms clears any threshold the run could apply (staleMs 10,
+  // floored to 1_000 by OWNERLESS_GRACE_MS) by three orders of magnitude, so
+  // the outcome cannot hinge on how long the retry loop happens to take.
+  const anHourAgo = new Date(Date.now() - 3_600_000);
+  utimesSync(sb.lock, anHourAgo, anHourAgo);
+  utimesSync(guard, anHourAgo, anHourAgo);
+  const res = run(['1'], sb, {
+    CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS: '10',
+    CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS: '3000',
+  });
+  if (res.code === 0) pass('14. orphaned recover guard does not block stale-lock recovery');
+  else fail(`14. orphaned recover guard does not block stale-lock recovery — got ${res.code}\n${res.stdout}${res.stderr}`);
+  if (existsSync(sb.followups)) pass('14. the seed actually ran after recovery');
+  else fail('14. the seed actually ran after recovery — follow-ups.md was never written');
+  cleanup(sb);
+}
+
+// ── Test 15: a guard still inside its age window is respected ───────────────
+// Guards the fix against the vacuous implementation. Removing the guard
+// unconditionally would also pass test 14 while destroying the mutual
+// exclusion the guard exists to provide — two processes would run recovery on
+// the same lock at once. A fresh guard means a sibling is inside its recovery
+// window right now, so the lock must be left alone even though it is old
+// enough to reclaim.
+{
+  const sb = makeSandbox();
+  writeTracker(sb, [trackerRow(1, '2026-05-01', 'Acme', 'Engineer', '4.0/5', 'Applied', 'Applied 2026-06-20.')]);
+  const guard = `${sb.lock}.recover`;
+  mkdirSync(sb.lock, { recursive: true });
+  const twoHoursAgo = new Date(Date.now() - 7_200_000);
+  utimesSync(sb.lock, twoHoursAgo, twoHoursAgo);   // reclaimable, if the guard were free
+  mkdirSync(guard, { recursive: true });           // deliberately left at "now"
+  // staleMs 60_000 against a 400ms timeout pins the boundary: the guard cannot
+  // reach 60s of age inside this run no matter how the retry loop is scheduled,
+  // so "fresh" stays true for the whole window rather than expiring mid-test.
+  const res = run(['1'], sb, {
+    CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS: '60000',
+    CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS: '400',
+  });
+  if (res.code === 4) pass('15. a guard inside its age window is respected → exit 4');
+  else fail(`15. a guard inside its age window is respected → exit 4 — got ${res.code}\n${res.stdout}${res.stderr}`);
+  if (existsSync(guard)) pass('15. the live guard survives');
+  else fail('15. the live guard survives — it was removed');
   cleanup(sb);
 }
 

--- a/followup-seed.mjs
+++ b/followup-seed.mjs
@@ -312,6 +312,17 @@ async function acquireFollowupsLock(lockDir, followupsPath, options = {}) {
         hasRecoverGuard = true;
       } catch (guardErr) {
         if (guardErr?.code !== 'EEXIST') throw guardErr;
+        // A process killed between creating the guard and its cleanup leaves
+        // the guard behind forever, permanently disabling stale-lock recovery
+        // for every future writer. The guard normally lives for milliseconds,
+        // so an old one is judged stale by the same age rule as a
+        // metadata-free lock and removed; the next loop iteration can then
+        // take the guard and run recovery. Removing it unconditionally would
+        // instead let two writers recover the same lock at once, which is
+        // exactly what the guard exists to prevent.
+        if (lockCanRecover(recoverGuardDir, staleMs)) {
+          rmSync(recoverGuardDir, { recursive: true, force: true });
+        }
       }
 
       if (hasRecoverGuard) {


### PR DESCRIPTION
## What does this PR do?

Ages out an orphaned `<lock>.recover` guard in `acquireFollowupsLock`. The guard is the ticket a waiting writer must hold to run stale-lock recovery at all, so one left behind by a killed process disabled recovery permanently — every later `followup-seed` run timed out at exit 4 until someone deleted the directory under `tmpdir()` by hand. `tracker-utils.mjs` and `pipeline-lock.mjs` both already have this branch; `followup-seed.mjs` was the only outlier.

## Related issue

Closes #2313

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

## The defect

On `EEXIST` from the guard `mkdirSync`, the old code did nothing but rethrow non-`EEXIST` errors:

```js
      } catch (guardErr) {
        if (guardErr?.code !== 'EEXIST') throw guardErr;
      }
```

`hasRecoverGuard` stays `false`, the recovery block is skipped, the loop sleeps and retries until `LOCK_TIMEOUT`. Nothing ever removes the stale guard, so that outcome is permanent across invocations.

The guard normally lives for milliseconds, so a `SIGKILL`, an OOM kill, or a CI runner teardown between `mkdirSync(recoverGuardDir)` and the `finally { rmSync(...) }` is enough to orphan one. `followup-seed.mjs` runs automatically on every transition into `Applied` (`set-status.mjs` calls it, as does the web status control), so the user-visible effect is that no application gets a first follow-up pinned — silently.

## Why aged out rather than removed unconditionally

An unconditional `rmSync` would also make the orphan case pass, while destroying the mutual exclusion the guard exists to provide: a guard still inside its window means a sibling process is inside its recovery window *right now*, and dropping it puts two writers into recovery on the same lock. The fix judges the guard by the same age rule already used for a metadata-free lock, matching both siblings.

## Verification

Reproduced before fixing, with two controls isolating the guard as the cause (full scripts in #2313):

| Scenario | Before | After |
|---|---|---|
| stale ownerless lock **+ orphaned guard** | exit 4, lock never removed, nothing seeded | exit 0, recovered, seeded |
| same stale lock, **no guard** (control) | exit 0, recovered | exit 0, recovered |
| `acquireTrackerLock`, identical scenario (control) | acquired, `staleRecovered=true` | unchanged |

Two tests, both with every age comparison pinned explicitly via `utimesSync` rather than raced against the wall clock — `staleMs` is compared against directory age *inside the retry loop*, so a directory that is "fresh" against a 10 ms threshold stops being fresh 10 ms later and the assertion inverts mid-run:

- **Test 14** — orphaned guard (backdated 1h) no longer blocks recovery of a stale ownerless lock. Fails on `main` with exit 4; passes after.
- **Test 15** — a guard still inside its age window is respected (`staleMs` 60 s against a 400 ms timeout, so "fresh" cannot expire mid-run). This is the anti-vacuous twin: I confirmed it fails against an unconditional `rmSync` variant that test 14 alone accepts.

`node test-all.mjs` → **2451 passed, 0 failed**. `node validate-system-paths-coverage.mjs` → OK, 886 tracked files covered. The one warning (`cv-sync-check.mjs exited with error`) is the expected no-user-data warning in a clean checkout, present on `main` too.

## Note on overlap with #2308

#2308 also touches `followup-seed.mjs` and `followup-seed-tests.mjs`, so whichever of the two merges second will need a small rebase — the test numbering (14/15) and the `existsSync, utimesSync` import line collide. This PR is branched off `main` rather than stacked on #2308 so that CI actually runs, since `test.yml` triggers only on PRs targeting `main`, and `windows-latest` is the runner that catches exactly this class of lock-timing and directory-removal bug.

The two changes are independent: the fix here does not depend on #2308's `OWNERLESS_GRACE_MS` floor, and the tests backdate mtimes far enough (1 h and 2 h) that they behave identically with or without it. Happy to rebase in whichever order suits you.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved follow-up seed lock recovery after unexpected interruptions.
  * Stale locks can now be recovered when an orphaned recovery guard directory is detected.
  * Recovery guards are no longer removed unless it’s safe, preventing premature or conflicting recovery.
* **Tests**
  * Added end-to-end regression coverage for stale-lock recovery and for preserving active recovery guards during contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->