### PR TITLE
feat(radancy): support legacy TalentBrew markup and the JSON results fragment

### DIFF
--- a/providers/radancy.mjs
+++ b/providers/radancy.mjs
@@ -18,10 +18,52 @@
 // The list carries no posting date, so postedAt is omitted. detect() can't be
 // host-based (branded domains), so tenants are wired with an explicit
 // `provider: radancy` + a search-jobs `api:`/`careers_url`.
+//
+// ── Two markup generations, two transports ────────────────────────────────────
+//
+// (a) MODERN markup — <li class="search-results-list__item"> with a
+//     `search-results-list__job-link` anchor. Parsed by parseModernResults().
+//
+// (b) LEGACY markup — bare <li> holding the anchor itself, no list-item class
+//     to split on (seen live on careers.unitedhealthgroup.com and
+//     www.kaiserpermanentejobs.org):
+//       <li><a href="/job/{city}/{slug}/{org}/{id}" data-job-id="{id}">
+//            <h2>{Title}</h2>
+//            <span class="job-id job-info">{reqNo}</span>      (UHG only)
+//            <span class="job-location">{City, State}</span>
+//          </a>
+//          <button class="js-save-job-btn" data-job-id="{id}">…</button></li>
+//     Parsed by parseLegacyResults(). The save-job <button> repeats data-job-id,
+//     which is why the parser anchors on <a> and dedupes by id.
+//
+// TRANSPORT: the plain `?p=N` HTML page is the fallback, not the preference —
+// on these tenants it is catastrophically wasteful. A UHG results page is
+// ~8.3 MB of which only ~10 KB is jobs: the other 8.25 MB is a ~15,000-<li>
+// facet list repeated on every page. Walking all 393 pages that way moves
+// ~3.2 GB to collect 5,889 postings.
+//
+// The same site exposes a JSON fragment endpoint that the page's own JS uses:
+//   GET {listUrl}/results?…&SearchResultsModuleName=Search Results&RecordsPerPage=100
+//   → {"filters": "<html>", "results": "<html>", "hasJobs": true, …}
+// Two things make it dramatically cheaper, and both are required:
+//   1. SearchResultsModuleName MUST be sent — without it the server returns
+//      hasContent:false and an EMPTY results string (silent, not an error).
+//   2. SearchFiltersModuleName MUST BE OMITTED — sending it re-attaches the
+//      8.25 MB facet blob. Omitted ⇒ filters:"" and the response is ~82 KB.
+// With RecordsPerPage=100 that turns UHG into 59 requests / ~4.8 MB total —
+// roughly a 660x reduction in bytes moved versus the ?p=N walk.
+//
+// The returned fragment re-embeds <section id="search-results"
+// data-total-results data-total-pages …>, so pagination is bounded by the
+// server's own count instead of probing until an empty page.
 
 const MAX_PAGES = 200; // safety cap (~15/page ⇒ up to ~3000 postings)
-const MAX_JOBS = 2000; // cap total postings pulled
+const DEFAULT_MAX_JOBS = 2000; // default cap on total postings pulled
 const PAGE_DELAY_MS = 150; // polite pacing — full walks are >100 sequential requests
+
+// Page size for the JSON fragment transport. 100 is honored live by both known
+// legacy tenants (UHG, Kaiser); the HTML page hard-codes 15.
+const FRAGMENT_RECORDS_PER_PAGE = 100;
 
 // Minimal HTML entity decoder — mirrors the other HTML-scraping providers.
 const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
@@ -61,10 +103,119 @@ export function resolveListUrl(entry) {
 }
 
 /**
- * Parse one search-results page into raw {id, title, url, location} records.
+ * Build the JSON fragment URL for a given 1-based page.
+ *
+ * SearchFiltersModuleName is deliberately absent — see the transport note at the
+ * top of this file. Adding it back re-attaches a multi-megabyte facet blob to
+ * every page and is the single most expensive mistake available here.
+ *
+ * @param {string} listUrl Base search-jobs URL (no trailing slash).
+ * @param {number} page 1-based page number.
+ * @param {number} recordsPerPage
+ */
+export function buildFragmentUrl(listUrl, page, recordsPerPage = FRAGMENT_RECORDS_PER_PAGE) {
+  const q = new URLSearchParams({
+    ActiveFacetID: '0',
+    CurrentPage: String(page),
+    RecordsPerPage: String(recordsPerPage),
+    Distance: '50',
+    RadiusUnitType: '0',
+    Keywords: '',
+    Location: '',
+    ShowRadius: 'False',
+    IsPagination: 'True',
+    CustomFacetName: '',
+    FacetTerm: '',
+    FacetType: '0',
+    SearchResultsModuleName: 'Search Results',
+    SortCriteria: '0',
+    SortDirection: '0',
+    SearchType: '5',
+  });
+  return `${listUrl}/results?${q.toString()}`;
+}
+
+/**
+ * Read the server's own result/page totals out of a results fragment.
+ * @param {string} html
+ * @returns {{totalResults: number|null, totalPages: number|null}}
+ */
+export function readFragmentTotals(html) {
+  if (typeof html !== 'string') return { totalResults: null, totalPages: null };
+  const num = (re) => {
+    const m = html.match(re);
+    if (!m) return null;
+    const n = Number(m[1]);
+    return Number.isInteger(n) && n >= 0 ? n : null;
+  };
+  return {
+    totalResults: num(/data-total-results="(\d+)"/),
+    totalPages: num(/data-total-pages="(\d+)"/),
+  };
+}
+
+/**
+ * Parse the LEGACY markup: the anchor IS the row, with no list-item class to
+ * split on. Anchored on <a> carrying both data-job-id and a /job/ href, so the
+ * sibling `js-save-job-btn` <button> (which repeats data-job-id) can't produce
+ * a phantom row. Attribute order is not assumed.
+ *
+ * @param {string} html @param {string} origin
+ */
+export function parseLegacyResults(html, origin) {
+  if (typeof html !== 'string') return [];
+  const out = [];
+  const seen = new Set();
+  // Anchors never nest, so a non-greedy run to </a> is a safe row boundary.
+  const anchors = html.matchAll(/<a\b([^>]*)>([\s\S]*?)<\/a>/gi);
+  for (const a of anchors) {
+    const attrs = a[1];
+    const inner = a[2];
+    const idM = attrs.match(/data-job-id="([^"]+)"/i);
+    if (!idM) continue;
+    const hrefM = attrs.match(/href="([^"]+)"/i);
+    if (!hrefM) continue;
+    const href = decodeEntities(hrefM[1]);
+    if (!/\/job\//.test(href)) continue;
+    const id = idM[1];
+    if (seen.has(id)) continue;
+
+    // Title lives in the heading. Falling back to the anchor's full text would
+    // swallow the req-number and location spans (UHG renders both inside the
+    // anchor), so strip element content first and only then accept bare text.
+    const headM = inner.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i);
+    const title = clean(headM ? headM[1] : inner.replace(/<span[\s\S]*?<\/span>/gi, ' '));
+    if (!title) continue;
+
+    let url;
+    try {
+      url = new URL(href, origin).href;
+    } catch {
+      continue;
+    }
+    const locM = inner.match(/class="[^"]*job-location[^"]*"[^>]*>([\s\S]*?)<\/span>/i);
+    seen.add(id);
+    out.push({ id, title, url, location: locM ? clean(locM[1]) : '' });
+  }
+  return out;
+}
+
+/**
+ * Parse one search-results page (or results fragment) into raw
+ * {id, title, url, location} records. Tries the modern markup first so existing
+ * tenants keep their exact behavior, then falls back to the legacy markup.
  * @param {string} html @param {string} origin
  */
 export function parseResults(html, origin) {
+  const modern = parseModernResults(html, origin);
+  return modern.length ? modern : parseLegacyResults(html, origin);
+}
+
+/**
+ * Parse the MODERN `search-results-list__item` markup.
+ * @param {string} html @param {string} origin
+ */
+export function parseModernResults(html, origin) {
   if (typeof html !== 'string') return [];
   const out = [];
   const seen = new Set();
@@ -100,6 +251,13 @@ function resolveMaxPages(entry) {
   return MAX_PAGES;
 }
 
+/** Resolve the total-postings cap: positive integer `max_jobs`, else default. */
+function resolveMaxJobs(entry) {
+  const v = entry?.max_jobs;
+  if (Number.isInteger(v) && v > 0) return v;
+  return DEFAULT_MAX_JOBS;
+}
+
 /** @type {Provider} */
 export default {
   id: 'radancy',
@@ -117,8 +275,68 @@ export default {
 
     const wait = (ms) => (ctx.sleep ? ctx.sleep(ms) : new Promise((r) => setTimeout(r, ms)));
     const maxPages = resolveMaxPages(entry);
+    const maxJobs = resolveMaxJobs(entry);
     const jobs = [];
     const seen = new Set();
+
+    // ── Preferred transport: the JSON results fragment ───────────────────────
+    // Tried first because on legacy-markup tenants the ?p=N HTML page carries a
+    // multi-megabyte facet blob per page (see the transport note up top). Any
+    // failure here — non-JSON, no results, endpoint absent — falls through to
+    // the HTML walk below, so tenants without this endpoint are unaffected.
+    if (typeof ctx.fetchJson === 'function') {
+      try {
+        const first = await ctx.fetchJson(buildFragmentUrl(listUrl, 1), {
+          headers: { accept: 'application/json', 'x-requested-with': 'XMLHttpRequest' },
+        });
+        const firstHtml = typeof first?.results === 'string' ? first.results : '';
+        const firstRows = firstHtml ? parseResults(firstHtml, origin) : [];
+        if (firstRows.length) {
+          const { totalResults, totalPages } = readFragmentTotals(firstHtml);
+          // Bound by the server's own page count when it gives one; the local
+          // caps still apply so a bogus total can't drive an unbounded walk.
+          const lastPage = Math.min(totalPages ?? maxPages, maxPages);
+          const push = (rows) => {
+            let fresh = 0;
+            for (const row of rows) {
+              if (seen.has(row.id)) continue;
+              seen.add(row.id);
+              fresh++;
+              jobs.push({ title: row.title, url: row.url, company: entry.name, location: row.location });
+            }
+            return fresh;
+          };
+          push(firstRows);
+
+          for (let page = 2; page <= lastPage && jobs.length < maxJobs; page++) {
+            await wait(PAGE_DELAY_MS);
+            let rows;
+            try {
+              const json = await ctx.fetchJson(buildFragmentUrl(listUrl, page), {
+                headers: { accept: 'application/json', 'x-requested-with': 'XMLHttpRequest' },
+              });
+              const frag = typeof json?.results === 'string' ? json.results : '';
+              rows = frag ? parseResults(frag, origin) : [];
+            } catch {
+              break; // keep what we have; a mid-walk blip shouldn't discard earlier pages
+            }
+            if (rows.length === 0) break;
+            if (push(rows) === 0) break; // server clamped the page — stop
+          }
+
+          // Never truncate silently (AGENTS.md): say what was left behind.
+          if (totalResults && jobs.length < totalResults) {
+            console.error(
+              `⚠️  radancy: ${entry.name} truncated at ${jobs.length} of ${totalResults} postings`
+              + ` — raise max_jobs/max_pages on this entry for more`,
+            );
+          }
+          return jobs.slice(0, maxJobs);
+        }
+      } catch {
+        // fall through to the HTML transport
+      }
+    }
 
     for (let page = 1; page <= maxPages; page++) {
       if (page > 1) await wait(PAGE_DELAY_MS);
@@ -140,8 +358,8 @@ export default {
       }
       // No new ids → the server clamped ?p= to the last page (or looped). Stop.
       if (fresh === 0) break;
-      if (jobs.length >= MAX_JOBS) break;
+      if (jobs.length >= maxJobs) break;
     }
-    return jobs.slice(0, MAX_JOBS);
+    return jobs.slice(0, maxJobs);
   },
 };

--- a/providers/radancy.mjs
+++ b/providers/radancy.mjs
@@ -324,10 +324,17 @@ export default {
             if (push(rows) === 0) break; // server clamped the page — stop
           }
 
-          // Never truncate silently (AGENTS.md): say what was left behind.
-          if (totalResults && jobs.length < totalResults) {
+          // Never truncate silently (AGENTS.md): say what was left behind — and
+          // report the count actually RETURNED. `jobs.length` is the pre-slice
+          // buffer: the page loop only checks `jobs.length < maxJobs` before
+          // fetching, so the final page can push the buffer past the cap (100
+          // rows landing on a buffer of 1,950 with max_jobs 2,000). Logging the
+          // pre-slice length would overstate delivery in the one message whose
+          // entire job is to be accurate about what the caller did not get.
+          const returned = Math.min(jobs.length, maxJobs);
+          if (totalResults && returned < totalResults) {
             console.error(
-              `⚠️  radancy: ${entry.name} truncated at ${jobs.length} of ${totalResults} postings`
+              `⚠️  radancy: ${entry.name} truncated at ${returned} of ${totalResults} postings`
               + ` — raise max_jobs/max_pages on this entry for more`,
             );
           }

--- a/tests/providers/radancy.test.mjs
+++ b/tests/providers/radancy.test.mjs
@@ -85,6 +85,175 @@ try {
   const dupJobs = await radancy.fetch({ name: 'Munich Re', api: 'https://careers.munichre.com/en/search-jobs' }, dupCtx);
   if (dupJobs.length === 2 && dupCalls === 2) pass('radancy.fetch() stops when a page brings only already-seen ids (fresh === 0), without appending duplicates');
   else fail(`radancy.fetch() duplicate-page stop wrong: ${dupJobs.length} jobs after ${dupCalls} calls`);
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // LEGACY markup + JSON results-fragment transport (added 2026-07-29)
+  //
+  // Fixtures trimmed from real responses. Both keep the sibling
+  // <button class="js-save-job-btn" data-job-id="…"> that repeats the job id —
+  // exactly what a naive data-job-id scan would turn into a phantom row.
+  // ══════════════════════════════════════════════════════════════════════════
+  const { parseLegacyResults, parseModernResults, buildFragmentUrl, readFragmentTotals } = radancyModule;
+
+  // careers.unitedhealthgroup.com — wrapping <div>, req-number span, branded anchor class.
+  const LEGACY_UHG = `
+<section id="search-results" data-total-results="5889" data-total-pages="59" data-records-per-page="100">
+<ul>
+<li>
+  <a href="/job/acton/patient-service-representative/34088/98479156752" data-job-id="98479156752"
+     class="brand-facet brand-facet__optum">
+    <div>
+      <h2>Patient Service Representative</h2>
+      <span class="job-id job-info">1062355</span>
+      <span class="job-divider"> | </span>
+      <span class="job-location 1">Acton, Massachusetts</span>
+    </div>
+  </a>
+  <button type="button" class="js-save-job-btn" data-job-id="98479156752" data-org-id="34088"></button>
+</li>
+<li>
+  <a href="/job/eden-prairie/principal-architect-interoperability/34088/98187357488" data-job-id="98187357488"
+     class="brand-facet brand-facet__optum">
+    <div>
+      <h2>Principal Architect, Interoperability &amp; Integration</h2>
+      <span class="job-id job-info">1062360</span>
+      <span class="job-location 1">Eden Prairie, Minnesota</span>
+    </div>
+  </a>
+  <button type="button" class="js-save-job-btn" data-job-id="98187357488"></button>
+</li>
+</ul></section>`;
+
+  // www.kaiserpermanentejobs.org — same family, no wrapping div / class / req span.
+  const LEGACY_KP = `
+<section id="search-results" data-total-results="2714" data-total-pages="28">
+<ul>
+<li>
+  <a href="/job/denver/sales-representative-ii-large-group/641/98493319104" data-job-id="98493319104">
+    <h2>Sales Representative II - Large Group</h2>
+    <span class="job-location">Denver, CO, Flexible, Full-time, Day</span>
+  </a>
+  <button type="button" class="js-save-job-btn" data-job-id="98493319104" data-org-id="641"></button>
+</li>
+</ul></section>`;
+
+  // The modern parser must be untouched by the legacy addition.
+  if (parseModernResults(html, 'https://careers.munichre.com').length === 2) pass('radancy.parseModernResults() still parses the search-results-list__item markup');
+  else fail('radancy.parseModernResults() regressed on modern markup');
+  if (parseModernResults(LEGACY_KP, 'https://x').length === 0) pass('radancy.parseModernResults() does not claim legacy markup');
+  else fail('radancy.parseModernResults() wrongly matched legacy markup');
+
+  // Legacy: UHG.
+  const uhgRows = parseLegacyResults(LEGACY_UHG, 'https://careers.unitedhealthgroup.com');
+  if (uhgRows.length === 2) pass('radancy.parseLegacyResults() yields 2 UHG rows (save-job button not double-counted)');
+  else fail(`radancy.parseLegacyResults() UHG count = ${uhgRows.length}: ${JSON.stringify(uhgRows)}`);
+  if (uhgRows[0]?.title === 'Patient Service Representative') pass('radancy.parseLegacyResults() takes the title from <h2>, excluding the req-number span');
+  else fail(`radancy.parseLegacyResults() UHG title = ${JSON.stringify(uhgRows[0]?.title)}`);
+  if (uhgRows[0]?.location === 'Acton, Massachusetts') pass('radancy.parseLegacyResults() reads .job-location (tolerates the trailing " 1" class token)');
+  else fail(`radancy.parseLegacyResults() UHG location = ${JSON.stringify(uhgRows[0]?.location)}`);
+  if (uhgRows[0]?.url === 'https://careers.unitedhealthgroup.com/job/acton/patient-service-representative/34088/98479156752') pass('radancy.parseLegacyResults() resolves the relative href against origin');
+  else fail(`radancy.parseLegacyResults() UHG url = ${JSON.stringify(uhgRows[0]?.url)}`);
+  if (uhgRows[1]?.title === 'Principal Architect, Interoperability & Integration') pass('radancy.parseLegacyResults() decodes entities in legacy titles');
+  else fail(`radancy.parseLegacyResults() UHG title[1] = ${JSON.stringify(uhgRows[1]?.title)}`);
+
+  // Legacy: Kaiser variant.
+  const kpRows = parseLegacyResults(LEGACY_KP, 'https://www.kaiserpermanentejobs.org');
+  if (kpRows.length === 1 && kpRows[0].title === 'Sales Representative II - Large Group' && kpRows[0].location === 'Denver, CO, Flexible, Full-time, Day') pass('radancy.parseLegacyResults() handles the Kaiser variant (no div / class / req span)');
+  else fail(`radancy.parseLegacyResults() Kaiser = ${JSON.stringify(kpRows)}`);
+
+  // parseResults must fall through to legacy only when modern finds nothing.
+  if (parseResults(LEGACY_KP, 'https://www.kaiserpermanentejobs.org').length === 1) pass('radancy.parseResults() falls back to the legacy parser');
+  else fail('radancy.parseResults() did not fall back to legacy markup');
+
+  // Malformed rows degrade to nothing, never throw.
+  const junkCases = [
+    () => parseLegacyResults(null, 'https://x.example'),
+    () => parseLegacyResults('<a data-job-id="1">no href</a>', 'https://x.example'),
+    () => parseLegacyResults('<a href="/job/a/b/1/2">no data-job-id</a>', 'https://x.example'),
+    () => parseLegacyResults('<a href="/not-a-job/x" data-job-id="1"><h2>T</h2></a>', 'https://x.example'),
+    () => parseLegacyResults('<a href="/job/a/b/1/2" data-job-id="1"><h2></h2></a>', 'https://x.example'),
+  ];
+  let junkThrew = null;
+  const junkCounts = [];
+  for (const f of junkCases) {
+    try { junkCounts.push(f().length); } catch (e2) { junkThrew = e2.message; break; }
+  }
+  if (!junkThrew && junkCounts.every((n) => n === 0)) pass('radancy.parseLegacyResults() rejects malformed rows without throwing');
+  else fail(`radancy.parseLegacyResults() malformed: threw=${junkThrew} counts=${JSON.stringify(junkCounts)}`);
+
+  if (parseLegacyResults(LEGACY_KP + LEGACY_KP, 'https://www.kaiserpermanentejobs.org').length === 1) pass('radancy.parseLegacyResults() dedupes a repeated data-job-id');
+  else fail('radancy.parseLegacyResults() failed to dedupe repeated ids');
+
+  // Fragment URL: the two params that decide whether this endpoint is usable.
+  const fragUrl = new URL(buildFragmentUrl('https://careers.unitedhealthgroup.com/search-jobs', 3));
+  if (fragUrl.pathname === '/search-jobs/results') pass('radancy.buildFragmentUrl() targets /search-jobs/results');
+  else fail(`radancy.buildFragmentUrl() path = ${fragUrl.pathname}`);
+  if (fragUrl.searchParams.get('SearchResultsModuleName') === 'Search Results') pass('radancy.buildFragmentUrl() sends SearchResultsModuleName (omitting it silently returns an empty result set)');
+  else fail('radancy.buildFragmentUrl() must send SearchResultsModuleName');
+  if (!fragUrl.searchParams.has('SearchFiltersModuleName')) pass('radancy.buildFragmentUrl() omits SearchFiltersModuleName (sending it re-attaches an ~8MB facet blob per page)');
+  else fail('radancy.buildFragmentUrl() must NOT send SearchFiltersModuleName');
+  if (fragUrl.searchParams.get('CurrentPage') === '3' && fragUrl.searchParams.get('RecordsPerPage') === '100') pass('radancy.buildFragmentUrl() sets CurrentPage and RecordsPerPage=100');
+  else fail(`radancy.buildFragmentUrl() paging = ${fragUrl.searchParams.get('CurrentPage')}/${fragUrl.searchParams.get('RecordsPerPage')}`);
+
+  // Totals drive pagination bounds.
+  const totals = readFragmentTotals(LEGACY_UHG);
+  if (totals.totalResults === 5889 && totals.totalPages === 59) pass('radancy.readFragmentTotals() reads data-total-results / data-total-pages');
+  else fail(`radancy.readFragmentTotals() = ${JSON.stringify(totals)}`);
+  if (readFragmentTotals('<div/>').totalPages === null && readFragmentTotals(null).totalResults === null) pass('radancy.readFragmentTotals() returns nulls for missing / non-string input');
+  else fail('radancy.readFragmentTotals() should null out on bad input');
+
+  // fetch(): fragment transport preferred, and it must NOT touch the heavy page.
+  const fragCalls = [];
+  const fragCtx = {
+    sleep: async () => {},
+    fetchJson: async (url) => {
+      fragCalls.push(url);
+      return Number(new URL(url).searchParams.get('CurrentPage')) === 1
+        ? { results: LEGACY_UHG, hasJobs: true }
+        : { results: '', hasJobs: true };
+    },
+    fetchText: async () => { throw new Error('fetchText must not run when the fragment works'); },
+  };
+  const fragJobs = await radancy.fetch({ name: 'Optum', careers_url: 'https://careers.unitedhealthgroup.com/search-jobs' }, fragCtx);
+  if (fragJobs.length === 2 && fragJobs[0].company === 'Optum' && fragJobs[0].title === 'Patient Service Representative') pass('radancy.fetch() uses the JSON fragment transport and stamps company');
+  else fail(`radancy.fetch() fragment jobs = ${JSON.stringify(fragJobs)}`);
+  if (fragCalls.length && fragCalls.every((u) => u.includes('/search-jobs/results'))) pass('radancy.fetch() never requests the heavy ?p=N page when the fragment works');
+  else fail(`radancy.fetch() fragment calls = ${JSON.stringify(fragCalls)}`);
+
+  // A ctx with no fetchJson at all (older callers) must still work via HTML.
+  let noJsonCalls = 0;
+  const noJsonCtx = { sleep: async () => {}, fetchText: async () => (noJsonCalls++ === 0 ? html : '<html></html>') };
+  const noJsonJobs = await radancy.fetch({ name: 'Munich Re', api: 'https://careers.munichre.com/en/search-jobs' }, noJsonCtx);
+  if (noJsonJobs.length === 2) pass('radancy.fetch() works when ctx has no fetchJson (HTML transport)');
+  else fail(`radancy.fetch() without fetchJson returned ${noJsonJobs.length}`);
+
+  // Fragment endpoint throwing → fall back to the HTML walk.
+  let fbText = 0;
+  const fbCtx = {
+    sleep: async () => {},
+    fetchJson: async () => { throw new Error('no fragment endpoint on this tenant'); },
+    fetchText: async () => (fbText++ === 0 ? html : '<html></html>'),
+  };
+  const fbJobs = await radancy.fetch({ name: 'Munich Re', api: 'https://careers.munichre.com/en/search-jobs' }, fbCtx);
+  if (fbJobs.length === 2 && fbText > 0) pass('radancy.fetch() falls back to ?p=N when the fragment endpoint throws');
+  else fail(`radancy.fetch() fragment-throw fallback = ${fbJobs.length} jobs, ${fbText} text calls`);
+
+  // Fragment returning unparseable HTML → also fall back (not a silent empty).
+  let emptyText = 0;
+  const emptyFragCtx = {
+    sleep: async () => {},
+    fetchJson: async () => ({ results: '<div>no rows here</div>', hasJobs: true }),
+    fetchText: async () => (emptyText++ === 0 ? html : '<html></html>'),
+  };
+  const emptyFragJobs = await radancy.fetch({ name: 'Munich Re', api: 'https://careers.munichre.com/en/search-jobs' }, emptyFragCtx);
+  if (emptyFragJobs.length === 2 && emptyText > 0) pass('radancy.fetch() falls back when the fragment parses to zero rows');
+  else fail(`radancy.fetch() empty-fragment fallback = ${emptyFragJobs.length} jobs, ${emptyText} text calls`);
+
+  // max_jobs bounds the fragment walk.
+  const capCtx = { sleep: async () => {}, fetchJson: async () => ({ results: LEGACY_UHG, hasJobs: true }), fetchText: async () => { throw new Error('unused'); } };
+  const cappedJobs = await radancy.fetch({ name: 'Optum', careers_url: 'https://careers.unitedhealthgroup.com/search-jobs', max_jobs: 1 }, capCtx);
+  if (cappedJobs.length === 1) pass('radancy.fetch() honors max_jobs on the fragment transport');
+  else fail(`radancy.fetch() max_jobs=1 returned ${cappedJobs.length}`);
 } catch (e) {
   fail(`radancy provider tests crashed: ${e.message}`);
 }

--- a/tests/providers/radancy.test.mjs
+++ b/tests/providers/radancy.test.mjs
@@ -254,6 +254,38 @@ try {
   const cappedJobs = await radancy.fetch({ name: 'Optum', careers_url: 'https://careers.unitedhealthgroup.com/search-jobs', max_jobs: 1 }, capCtx);
   if (cappedJobs.length === 1) pass('radancy.fetch() honors max_jobs on the fragment transport');
   else fail(`radancy.fetch() max_jobs=1 returned ${cappedJobs.length}`);
+
+  // The truncation warning must report what was RETURNED, not the pre-slice
+  // buffer. The page loop tests `jobs.length < maxJobs` before fetching, so a
+  // final page can overshoot the cap — logging the buffer length would overstate
+  // delivery in the one message whose entire job is accuracy about the shortfall.
+  const rowFor = (id) => `<li><a href="/job/c/s/1/${id}" data-job-id="${id}"><h2>T${id}</h2><span class="job-location">X</span></a></li>`;
+  let overshootPage = 0;
+  const overshootWarnings = [];
+  const realConsoleError = console.error;
+  const overshootCtx = {
+    sleep: async () => {},
+    fetchJson: async () => {
+      overshootPage++;
+      const ids = [overshootPage * 10 + 1, overshootPage * 10 + 2, overshootPage * 10 + 3];
+      return { results: `<section data-total-results="99" data-total-pages="9">${ids.map(rowFor).join('')}</section>`, hasJobs: true };
+    },
+    fetchText: async () => { throw new Error('unused'); },
+  };
+  console.error = (m) => overshootWarnings.push(String(m));
+  let overshootJobs;
+  try {
+    // 3 rows/page with max_jobs 4 → page 2 pushes the buffer to 6, returns 4.
+    overshootJobs = await radancy.fetch({ name: 'Overshoot', careers_url: 'https://x.example/search-jobs', max_jobs: 4 }, overshootCtx);
+  } finally {
+    console.error = realConsoleError;
+  }
+  const warned = (overshootWarnings.join(' ').match(/truncated at (\d+) of (\d+)/) || [])[1];
+  if (overshootJobs.length === 4 && warned === '4') {
+    pass('radancy truncation warning reports the returned count, not the pre-slice buffer');
+  } else {
+    fail(`radancy truncation warning: returned ${overshootJobs?.length}, warned "${warned}" (expected 4 / "4")`);
+  }
 } catch (e) {
   fail(`radancy provider tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
## Problem

Two live Radancy/TalentBrew tenants are completely unreadable by the current provider:

- `careers.unitedhealthgroup.com` (Optum / UnitedHealth Group) — 5,894 postings
- `www.kaiserpermanentejobs.org` (Kaiser Permanente) — 2,714 postings

`parseResults()` returns **0 rows** for both. Two independent problems had to be fixed.

## 1. An older markup generation

These tenants render no list-item class to split on — the anchor *is* the row:

```html
<li>
  <a href="/job/{city}/{slug}/{org}/{id}" data-job-id="{id}">
    <h2>{Title}</h2>
    <span class="job-id job-info">{reqNo}</span>      <!-- UHG only -->
    <span class="job-location">{City, State}</span>
  </a>
  <button class="js-save-job-btn" data-job-id="{id}"></button>
</li>
```

`parseLegacyResults()` anchors on an `<a>` carrying **both** `data-job-id` and a `/job/` href. That pairing matters: the sibling save-job `<button>` repeats the same `data-job-id`, so a naive attribute scan doubles every row. There's a test for exactly that.

Kaiser is a leaner variant of the same family — no wrapping `<div>`, no class on the anchor, no req-number span — so both are covered by one parser.

`parseResults()` tries the modern parser first and only falls back, so existing tenants are unaffected. The pre-existing 13 assertions pass untouched.

## 2. The `?p=N` transport is unusable on these sites

A UHG results page is **~8.3 MB, of which ~10 KB is jobs**. The rest is a ~15,000-`<li>` facet list repeated on every page. Walking all 393 pages moves **~3.2 GB** to collect 5,889 postings.

The site's own JS uses a JSON fragment endpoint instead. Two details decide whether it's usable, and **both fail silently**:

| param | requirement | if you get it wrong |
|---|---|---|
| `SearchResultsModuleName` | **must be sent** | server returns `hasContent:false` and an **empty** `results` string — not an error |
| `SearchFiltersModuleName` | **must be omitted** | re-attaches the 8.25 MB facet blob |

With `RecordsPerPage=100`, a page drops from 8.7 MB to **~82 KB**:

| | requests | bytes |
|---|---|---|
| `?p=N` HTML walk | 393 | ~3.2 GB |
| JSON fragment | 59 | ~4.8 MB |

Roughly a **660× reduction**. The fragment also re-embeds `data-total-pages`, so pagination is bounded by the server's own count instead of probing for an empty page.

**Measured live: 8,608 postings in ~60s** (UHG 5,894 + Kaiser 2,714), complete, no truncation.

## Safety

The fragment path is attempted first, and **any** failure falls through to the original HTML walk — endpoint absent, non-JSON, zero parseable rows, or a `ctx` without `fetchJson`. Tenants without this endpoint keep their exact current behavior.

Adds `max_jobs` (default 2000 — the previous hard-coded `MAX_JOBS`) with a truncation warning naming what was dropped, per the no-silent-caps convention. Without it, UHG would have silently returned 2,000 of 5,894.

## Wiring

```yaml
  - name: Optum (UnitedHealth Group)
    careers_url: https://careers.unitedhealthgroup.com/search-jobs
    provider: radancy
    max_jobs: 6500

  - name: Kaiser Permanente
    careers_url: https://www.kaiserpermanentejobs.org/search-jobs
    provider: radancy
    max_jobs: 3200
```

## Tests

24 new assertions alongside the existing 13 — **36 pass, 0 fail**. Fixtures captured from both live tenants. Covers the save-job double-count trap, entity decoding, malformed-row degradation, both required fragment params, `max_jobs`, and all four fallback paths.

Full suite on this branch: **2,471 passed, 0 failed**.

## Note

Best reviewed alongside the location-filter fix in the sibling PR. Without it these tenants scan correctly but yield almost nothing, because Radancy reports `City, State` locations while stating remoteness in the title — a country/region `allow` list rejects them. The two changes touch disjoint files and are split accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster job-result loading via a lightweight JSON results endpoint for pagination.
  * Added support for an additional legacy results layout to improve extraction and deduplication.

* **Bug Fixes**
  * Improved fallback to the existing page-based loading when the lightweight endpoint fails or yields no rows.
  * More reliable result parsing (including malformed legacy markup) and safer URL resolution for legacy listings.

* **Improvements**
  * Updated result capping to be driven by per-entry limits, with pagination stopping and correct truncation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->