### PR TITLE
fix(scan): a title-stated remote role survives a city-only location

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -386,8 +386,9 @@ export function filterBlacklistedOffers(offers, blacklist, { includeBlacklisted 
 export function passesFilters(job, { titleFilter, locationFilter, contentFilter, titleFilterConfig }) {
   if (!titleFilter(job.title)) return false;
   // job.url is passed so the location filter can fall back to the URL's own
-  // location segment when the provider reports a rolled-up "N Locations" string.
-  if (!locationFilter(job.location, job.url)) return false;
+  // location segment when the provider reports a rolled-up "N Locations" string;
+  // job.title so a title-stated remote role survives a city-only location.
+  if (!locationFilter(job.location, job.url, job.title)) return false;
   if (contentFilter && !contentFilter(job.description, matchedTitleKeywords(job.title, titleFilterConfig))) return false;
   return true;
 }
@@ -697,7 +698,7 @@ async function main() {
       // posting stale, --since was silently ignored for the entire source.
       // Enrich first, then let the undated policy decide.
       if (dateClass === 'undated' && provider.enrichDate
-          && titleFilter(job.title) && locationFilter(job.location, job.url)) {
+          && titleFilter(job.title) && locationFilter(job.location, job.url, job.title)) {
         try { await provider.enrichDate(job, ctx); } catch { /* stays undated */ }
         dateClass = classifyPostingDate(job, cutoff);
       }
@@ -705,8 +706,9 @@ async function main() {
       if (dateClass === 'undated' && !opts.includeUndated) { droppedNoDate++; continue; }
       if (!titleFilter(job.title)) continue;
       // job.url is passed so the location filter can fall back to the URL's own
-      // location segment when the provider reports a rolled-up "N Locations" string.
-      if (!locationFilter(job.location, job.url)) continue;
+      // location segment when the provider reports a rolled-up "N Locations" string;
+      // job.title so a title-stated remote role survives a city-only location.
+      if (!locationFilter(job.location, job.url, job.title)) continue;
       if (!contentFilter(job.description, matchedTitleKeywords(job.title, config?.title_filter))) { droppedContent++; continue; }
       const dedupUrl = normalizeUrlForDedup(job.url);
       if (seenUrls.has(dedupUrl)) continue;

--- a/scan.mjs
+++ b/scan.mjs
@@ -146,7 +146,8 @@ export function matchedTitleKeywords(title, titleFilter) {
 //     the home region is an option, even though "france" is blocked)
 //   - `block` matches → reject
 //   - `allow` empty → pass (already cleared block)
-//   - `allow` non-empty → must match at least one keyword
+//   - `allow` non-empty → must match at least one keyword, OR the TITLE carries
+//     an explicit remote marker (see titleSignalsRemote below)
 
 // Normalize a keyword list from portals.yml: tolerates a bare string
 // (wrapped to a 1-item array), null/undefined (→ []), and non-string
@@ -225,15 +226,38 @@ export function locationHintFromUrl(url) {
   return segment.replace(/[-_+]+/g, ' ').replace(/\s+/g, ' ').trim().toLowerCase();
 }
 
-// `url` is optional. Callers that omit it get the original location-only
-// semantics, which is what the existing unit tests exercise.
+// Some ATSs report the hiring office as the location even when the role is
+// remote, and state the remoteness in the TITLE instead: Radancy/TalentBrew
+// tenants return bare "City, State" strings, so
+//   "Program Manager - Remote"  ->  location "Las Vegas, Nevada"
+// An `allow` list written in country/region terms ("united states", "remote")
+// then rejects a genuinely remote US role. Live measurement on
+// careers.unitedhealthgroup.com: 14 PM-family postings, 0 passed `allow`,
+// 5 of them said "Remote" outright in the title.
+//
+// Only an unambiguous work-arrangement marker counts. A bare /remote/ test
+// would admit domain compounds — "Remote Sensing Program Manager" is an
+// on-site GIS role, and Esri (a tracked company) posts exactly those. So
+// "remote" must be followed by end-of-string, a non-letter (")", ",", "-"),
+// or " in …" as in "Remote in MO" — never by another word, which is what makes
+// "remote sensing" / "remote monitoring" compounds.
+export const REMOTE_TITLE_RE = /(?<![a-z])remote(?=$|\s*[^a-z\s]|\s+in\b)/;
+
+/** @param {unknown} title @returns {boolean} whether the title marks the role remote. */
+export function titleSignalsRemote(title) {
+  if (typeof title !== 'string' || title.trim() === '') return false;
+  return REMOTE_TITLE_RE.test(title.toLowerCase());
+}
+
+// `url` and `title` are optional. Callers that omit them get the original
+// location-only semantics, which is what the existing unit tests exercise.
 export function buildLocationFilter(locationFilter) {
   if (!locationFilter) return () => true;
   const alwaysAllow = compileLocationKeywordList(locationFilter.always_allow);
   const allow = compileLocationKeywordList(locationFilter.allow);
   const block = compileLocationKeywordList(locationFilter.block);
 
-  return (location, url) => {
+  return (location, url, title) => {
     const lower = typeof location === 'string' ? location.trim().toLowerCase() : '';
     const hint = locationHintFromUrl(url);
     // Nothing to judge on either field → pass (don't penalize missing data).
@@ -245,7 +269,11 @@ export function buildLocationFilter(locationFilter) {
     if (alwaysAllow.length > 0 && alwaysAllow.some(matches)) return true;
     if (block.length > 0 && block.some(matches)) return false;
     if (allow.length === 0) return true;
-    return allow.some(matches);
+    if (allow.some(matches)) return true;
+    // Last resort only. Deliberately placed AFTER `block` so a remote title can
+    // never rescue a blocked location — "Program Manager - Remote" in Bengaluru
+    // stays rejected. This widens `allow`, never `block`.
+    return titleSignalsRemote(title);
   };
 }
 
@@ -2042,7 +2070,9 @@ async function main() {
           totalFilteredTier++;
           continue;
         }
-        if (!locationFilter(job.location, job.url)) {
+        // job.title is passed so a role whose remoteness is stated in the title
+        // ("Program Manager - Remote") isn't rejected for a city-only location.
+        if (!locationFilter(job.location, job.url, job.title)) {
           totalFilteredLocation++;
           continue;
         }

--- a/scan.mjs
+++ b/scan.mjs
@@ -247,13 +247,21 @@ export const REMOTE_TITLE_RE = /(?<![a-z])remote(?=$|\s*[^a-z\s]|\s+in\b)/;
 // cannot see: in "Non-Remote" / "Not Remote" the delimiter clears the lookbehind
 // and the trailing position clears the lookahead, so an explicitly on-site role
 // would bypass a non-empty `allow` list — the exact opposite of the intent.
-// `[\s-]*` only spans spaces/hyphens, so word-initial "non"/"not" in an
-// unrelated token cannot reach across ("Nonprofit Program Manager - Remote" and
-// "Not-for-Profit … - Remote" both stay remote).
+// The separator class must be at least as broad as the marker's own delimiter
+// lookahead, or the guard is trivially sidestepped. An ASCII-only `[\s-]*` let
+// every non-ASCII dash through — "Non–Remote" (en dash), "Non‑Remote"
+// (non-breaking hyphen), em dash, figure dash and minus all still read as
+// remote. `[^a-z]*` matches the marker's breadth: it spans any run of
+// non-letters, so no punctuation variant can slip between the negation and the
+// word.
+// It cannot over-reach, because it never crosses a letter: in "Nonprofit
+// Program Manager - Remote" the run after "non" starts with "profit", so the
+// negation cannot reach "remote". Same for "Not-for-Profit … - Remote",
+// "Nordic … - Remote", "Notary … - Remote".
 // A negation anywhere in the title disqualifies it. Over-rejecting here is the
 // safe direction: this tier only ever *rescues* a posting, so a false negative
 // restores the previous behavior while a false positive admits an on-site role.
-export const REMOTE_NEGATED_RE = /\b(?:non|not|no)[\s-]*remote/;
+export const REMOTE_NEGATED_RE = /\b(?:non|not|no)[^a-z]*remote/;
 
 /** @param {unknown} title @returns {boolean} whether the title marks the role remote. */
 export function titleSignalsRemote(title) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -243,10 +243,24 @@ export function locationHintFromUrl(url) {
 // "remote sensing" / "remote monitoring" compounds.
 export const REMOTE_TITLE_RE = /(?<![a-z])remote(?=$|\s*[^a-z\s]|\s+in\b)/;
 
+// …and a negation before the word has to lose, which the marker regex alone
+// cannot see: in "Non-Remote" / "Not Remote" the delimiter clears the lookbehind
+// and the trailing position clears the lookahead, so an explicitly on-site role
+// would bypass a non-empty `allow` list — the exact opposite of the intent.
+// `[\s-]*` only spans spaces/hyphens, so word-initial "non"/"not" in an
+// unrelated token cannot reach across ("Nonprofit Program Manager - Remote" and
+// "Not-for-Profit … - Remote" both stay remote).
+// A negation anywhere in the title disqualifies it. Over-rejecting here is the
+// safe direction: this tier only ever *rescues* a posting, so a false negative
+// restores the previous behavior while a false positive admits an on-site role.
+export const REMOTE_NEGATED_RE = /\b(?:non|not|no)[\s-]*remote/;
+
 /** @param {unknown} title @returns {boolean} whether the title marks the role remote. */
 export function titleSignalsRemote(title) {
   if (typeof title !== 'string' || title.trim() === '') return false;
-  return REMOTE_TITLE_RE.test(title.toLowerCase());
+  const lower = title.toLowerCase();
+  if (REMOTE_NEGATED_RE.test(lower)) return false;
+  return REMOTE_TITLE_RE.test(lower);
 }
 
 // `url` and `title` are optional. Callers that omit them get the original

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4578,6 +4578,7 @@ try {
   const {
     buildLocationFilter,
     locationHintFromUrl,
+    titleSignalsRemote,
     buildContentFilter,
     buildPostingAgeFilter,
     buildPostedDateFilter,
@@ -4846,6 +4847,68 @@ try {
     pass('URL hint is boundary-matched as well (Indianapolis URL survives, India URL does not)');
   } else {
     fail('URL hint must use the same word-boundary matching as the location string');
+  }
+
+  // Case 24: a remote marker in the TITLE satisfies `allow` when the location
+  // names only a city/state. Radancy/TalentBrew tenants (Optum, Kaiser) report
+  // the hiring office as the location and state remoteness in the title, so a
+  // country/region `allow` list rejected genuinely remote US roles. Measured
+  // live on careers.unitedhealthgroup.com: 14 PM-family postings, 0 passed.
+  const remoteTitleFilter = buildLocationFilter({
+    allow: ['remote', 'united states', 'usa', 'us', 'new york'],
+    block: ['india', 'united kingdom', 'london'],
+  });
+  if (
+    remoteTitleFilter('Costa Mesa, California', undefined, 'Sr. PBM Client Implementation Project Manager - Remote') === true &&
+    remoteTitleFilter('Las Vegas, Nevada', undefined, 'Program Manager - Remote') === true &&
+    remoteTitleFilter('St Louis, Missouri', undefined, 'Clinical Program Manager (Case Management) - Remote in MO') === true &&
+    remoteTitleFilter('Phoenix, Arizona', undefined, 'Project Manager (Remote)') === true &&
+    remoteTitleFilter('Dallas, Texas', undefined, 'IT Program Manager, Remote - US') === true
+  ) {
+    pass('a remote marker in the title satisfies allow when the location is city-only');
+  } else {
+    fail('title-stated remote roles are still being rejected for a city-only location');
+  }
+
+  // Case 25: the rescue must NOT widen `block`. It runs after the block tier, so
+  // a remote title can never pull in an excluded country.
+  if (
+    remoteTitleFilter('Bengaluru, Karnataka, India', undefined, 'Program Manager - Remote') === false &&
+    remoteTitleFilter('London, United Kingdom', undefined, 'Project Manager - Remote') === false &&
+    remoteTitleFilter('5 Locations', 'https://x.wd1.myworkdayjobs.com/c/job/Hyderabad-Telangana-India/PM_R1', 'Program Manager - Remote') === false
+  ) {
+    pass('a remote title never rescues a blocked location (block still wins, URL hint included)');
+  } else {
+    fail('remote-title rescue must not override the block tier');
+  }
+
+  // Case 26: only a work-arrangement marker counts. "Remote Sensing" is a GIS
+  // domain compound — Esri, a tracked company, posts on-site roles with exactly
+  // that phrase, so a bare /remote/ test would silently admit them.
+  if (
+    remoteTitleFilter('Redlands, California', undefined, 'Remote Sensing Program Manager') === false &&
+    remoteTitleFilter('Austin, Texas', undefined, 'Remote Monitoring Project Manager') === false &&
+    titleSignalsRemote('Remote Sensing Analyst') === false &&
+    titleSignalsRemote('Program Manager - Remote') === true &&
+    titleSignalsRemote('Telremote Engineer') === false
+  ) {
+    pass('remote-title detection ignores domain compounds (Remote Sensing/Monitoring) and mid-word hits');
+  } else {
+    fail('remote-title detection must not fire on "Remote Sensing"-style compounds');
+  }
+
+  // Case 27: unchanged behavior — on-site city-only roles with no remote marker
+  // stay rejected, and malformed/absent titles are inert.
+  if (
+    remoteTitleFilter('Eden Prairie, Minnesota', undefined, 'Senior Project Manager I') === false &&
+    remoteTitleFilter('Eden Prairie, Minnesota', undefined, undefined) === false &&
+    remoteTitleFilter('Eden Prairie, Minnesota', undefined, 42) === false &&
+    remoteTitleFilter('Eden Prairie, Minnesota', undefined, '   ') === false &&
+    remoteTitleFilter('United States', undefined, 'Program Manager') === true
+  ) {
+    pass('on-site city-only roles stay rejected; non-string/blank titles are inert');
+  } else {
+    fail('remote-title rescue changed behavior for non-remote or malformed titles');
   }
 
   if (

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4929,6 +4929,18 @@ try {
     fail('negation guard is over-rejecting legitimate remote titles');
   }
 
+  // Case 27c: the negation separator must be at least as broad as the marker's
+  // own delimiter lookahead. An ASCII-only [\s-] let every non-ASCII dash through
+  // — en dash, em dash, non-breaking hyphen, figure dash and minus all still read
+  // as remote, trivially sidestepping the guard.
+  const negatedDashes = ['-', '–', '—', '‑', '‒', '−', '', ' ', '/'];
+  if (negatedDashes.every((d) => titleSignalsRemote(`Project Manager - Non${d}Remote`) === false)) {
+    pass('the negation guard survives Unicode dash variants (en/em/non-breaking/figure/minus)');
+  } else {
+    const leak = negatedDashes.filter((d) => titleSignalsRemote(`Project Manager - Non${d}Remote`) !== false);
+    fail(`negated titles leak through with separator(s): ${JSON.stringify(leak)}`);
+  }
+
   // Case 27: unchanged behavior — on-site city-only roles with no remote marker
   // stay rejected, and malformed/absent titles are inert.
   if (

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4897,6 +4897,38 @@ try {
     fail('remote-title detection must not fire on "Remote Sensing"-style compounds');
   }
 
+  // Case 27a: an explicit negation must lose. "Non-Remote"/"Not Remote" satisfy
+  // REMOTE_TITLE_RE on their own — the delimiter clears the lookbehind and the
+  // trailing position clears the lookahead — so without a negation guard an
+  // explicitly on-site role would bypass a non-empty `allow` list.
+  if (
+    titleSignalsRemote('Project Manager - Non-Remote') === false &&
+    titleSignalsRemote('Project Manager - Not Remote') === false &&
+    titleSignalsRemote('Office Manager (Non-Remote)') === false &&
+    titleSignalsRemote('Program Manager - NonRemote') === false &&
+    titleSignalsRemote('Program Manager - No Remote') === false &&
+    remoteTitleFilter('Eden Prairie, Minnesota', undefined, 'Project Manager - Non-Remote') === false &&
+    remoteTitleFilter('Eden Prairie, Minnesota', undefined, 'Project Manager - Not Remote') === false
+  ) {
+    pass('an explicit negation ("Non-Remote"/"Not Remote") never counts as a remote marker');
+  } else {
+    fail('negated remote titles are being admitted — an on-site role can bypass allow');
+  }
+
+  // Case 27b: the negation guard must not over-reach. `[\s-]*` spans only spaces
+  // and hyphens, so a word-initial "non"/"not" in an unrelated token cannot
+  // reach across to "remote".
+  if (
+    titleSignalsRemote('Nonprofit Program Manager - Remote') === true &&
+    titleSignalsRemote('Not-for-Profit Program Manager - Remote') === true &&
+    titleSignalsRemote('Nordic Program Manager - Remote') === true &&
+    titleSignalsRemote('Notary Operations Manager - Remote') === true
+  ) {
+    pass('the negation guard does not misfire on Nonprofit/Not-for-Profit/Nordic/Notary titles');
+  } else {
+    fail('negation guard is over-rejecting legitimate remote titles');
+  }
+
   // Case 27: unchanged behavior — on-site city-only roles with no remote marker
   // stay rejected, and malformed/absent titles are inert.
   if (


### PR DESCRIPTION
## Problem

Some ATSs report the **hiring office** as the location even when the role is remote, and state the remoteness in the **title** instead. Radancy/TalentBrew tenants return bare `City, State` strings:

```
"Program Manager - Remote"   ->   location "Las Vegas, Nevada"
```

An `allow` list written in country/region terms — the natural way to express "US-remote only", and what `portals.example.yml` encourages — then rejects a genuinely remote US role.

**Measured live** on `careers.unitedhealthgroup.com`: 14 PM-family postings, **0 passed `allow`**, 5 of which said "Remote" outright in the title.

The failure is invisible in the counters. These are tallied under *"filtered by location"*, indistinguishable from correctly-rejected on-site roles — so a user sees a plausible-looking number and never learns they lost real leads.

## Fix

`buildLocationFilter()` takes an optional third `title` argument and, as a last resort, accepts an explicit remote marker in the title.

Placed **after** the `block` tier on purpose: a remote title widens `allow` and can **never** rescue an excluded location. `"Program Manager - Remote"` in Bengaluru stays rejected, including via the URL hint.

## Only a work-arrangement marker counts

```js
export const REMOTE_TITLE_RE = /(?<![a-z])remote(?=$|\s*[^a-z\s]|\s+in\b)/;
```

A bare `/remote/` test would admit domain compounds. **"Remote Sensing Program Manager" is an on-site GIS role** — and Esri, a company in the shipped `portals.example.yml`, posts exactly those. So `remote` must be followed by end-of-string, a non-letter (`)`, `,`, `-`), or `" in …"` as in "Remote in MO" — never by another word, which is what forms `remote sensing` / `remote monitoring`.

## Behavior

| title | location | before | after |
|---|---|---|---|
| `… Project Manager - Remote` | `Costa Mesa, California` | ❌ | ✅ |
| `Program Manager - Remote` | `Las Vegas, Nevada` | ❌ | ✅ |
| `… - Remote in MO` | `St Louis, Missouri` | ❌ | ✅ |
| `Project Manager (Remote)` | `Phoenix, Arizona` | ❌ | ✅ |
| `Program Manager - Remote` | `Bengaluru, …, India` | ❌ | ❌ |
| `Project Manager - Remote` | `London, United Kingdom` | ❌ | ❌ |
| `Program Manager - Remote` | Workday URL hint `…/job/Hyderabad-Telangana-India/…` | ❌ | ❌ |
| **`Remote Sensing Program Manager`** | `Redlands, California` | ❌ | ❌ |
| `Senior Project Manager I` (on-site) | `Eden Prairie, Minnesota` | ❌ | ❌ |
| `Program Manager` | `United States` | ✅ | ✅ |

## Compatibility

The new argument is optional, so any caller that omits it keeps the previous location-only semantics. Threaded through all four call sites — one in `scan.mjs`, three in `scan-ats-full.mjs`.

## Real-world effect

On a live scan of an Optum board wired via `provider: radancy`, new offers went from **0 → 15**, including:

- Release Train Engineer — Commercial Payments, Optum Financial — Remote
- Sr. PBM Client Implementation Project Manager — Remote
- Medicaid Pharmacy Network Program Manager — Remote
- IT Manager, Epic Professional Billing — Remote
- Product Capability Manager — AI Transformation, UMR — Remote

All are remote roles that the location filter had been discarding.

## Tests

4 new cases (24–27) in the existing `Location filter` block: the recovery, block-still-wins including the URL hint, the domain-compound guard, and inertness for absent/non-string/blank titles.

Full suite on this branch: **2,452 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Location filtering can now use job titles to treat roles as “remote” when location details are insufficient, including for undated/unenriched postings.
* **Bug Fixes**
  * Remote-title detection is conservative: it requires unambiguous “remote” markers, excludes negations like “non-remote”/“not remote,” and doesn’t widen regions blocked by earlier rules.
* **Tests**
  * Added assertions for remote-title positives, negation edge cases (including separator variations), and avoiding false matches for “remote”-like domain/compound words.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->