### PR TITLE
docs(scripts): document fix-slugs.mjs in SCRIPTS.md

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -38,6 +38,7 @@ All scripts live in the project root as `.mjs` modules. Most are exposed via
 | `npm run reconcile` | `reconcile-pipeline.mjs` | Remove batch-evaluated offers from pipeline.md "Pendientes" |
 | `npm run cover-letter` | `generate-cover-letter.mjs` | Render a cover-letter JSON payload to PDF |
 | `npm run verify:portals` | `verify-portals.mjs` | Probe ATS endpoints to confirm portals.yml slugs resolve (network) |
+| `node fix-slugs.mjs` | `fix-slugs.mjs` | Write `verify-portals.mjs`'s suggested ATS slug fixes back to portals.yml (dry run by default, `--fix` to write) |
 | `npm run reposts` | `detect-reposts.mjs` | Flag re-listed (ghost) postings from scan history |
 | `npm run gemini:eval` | `gemini-eval.mjs` | Evaluate a JD with Google Gemini (free-tier alternative) |
 | `npm run ollama:eval` | `ollama-eval.mjs` | Evaluate a JD with a local Ollama model |
@@ -132,6 +133,30 @@ node validate-portals.mjs --self-test
 ```
 
 **Exit codes:** `0` no errors (warnings allowed), `1` one or more errors found.
+
+---
+
+## fix-slugs
+
+Write-side twin of `verify-portals.mjs` (#1703). `verify-portals` already probes every tracked company's ATS slug and, for a failing Greenhouse/Ashby/Lever entry, cross-probes slug variants across all three ATSes and attaches `suggested: { ats, slug }` when one resolves. That tool is read-only; this one patches the matching `tracked_companies` entry in `portals.yml`. It imports the same probe and suggestion logic rather than re-implementing it, so the two can never disagree about what a broken slug is (network, like `verify-portals`).
+
+**It is a dry run by default: writing requires an explicit `--fix` (or its alias `--apply`).** A bare `node fix-slugs.mjs` prints the diff it *would* apply and changes nothing, so the safe invocation is also the shortest one. `--dry-run` exists only to say that out loud.
+
+Only entries `verify-portals` classifies as `missing` **and** for which it found a `suggested` alternate are touched. Live entries, empty entries, and entries whose slug genuinely could not be resolved are left completely alone.
+
+The file is edited as text — line-level surgery inside the matching company's block — rather than through a YAML parse-and-dump round trip, because `portals.yml` carries hand-written comments and documentation blocks that `yaml.dump()` would silently discard.
+
+```bash
+node fix-slugs.mjs                            # dry run (default, safe): print the diff, write nothing
+node fix-slugs.mjs --dry-run                  # same as above, explicit
+node fix-slugs.mjs --fix                      # write the resolved slugs back to portals.yml
+node fix-slugs.mjs --apply                    # alias for --fix
+node fix-slugs.mjs --file templates/portals.example.yml
+```
+
+The default path is `portals.yml`, overridable with `--file` or the `CAREER_OPS_PORTALS` environment variable. A missing portals file is reported and treated as nothing to do, not as an error.
+
+**Exit codes:** `0` on every normal run, `1` only if the run itself fails. Unlike `check-table-freshness`, pending fixes in a dry run do **not** fail the run, so this is a maintenance tool rather than a CI gate.
 
 ---
 


### PR DESCRIPTION
Closes #2326.

Adds a `fix-slugs.mjs` entry to `docs/SCRIPTS.md`, mirroring the `check-table-freshness` entry as the issue suggested: what it does, its relationship to `verify-portals.mjs`, the dry-run default, and the flags.

Two additions:

- **Quick Reference row**, placed directly under `verify:portals` since they are twins. It uses `node fix-slugs.mjs` in the Command column rather than an `npm run` alias, because there is no npm script for it. That follows the existing `node build-cv-latex.mjs` row.
- **A `## fix-slugs` section**, placed after `## validate:portals` so the portals tooling reads as a cluster: validate (offline) then verify (network, read-only) then fix (network, write). Worth noting `verify-portals.mjs` itself has no prose section, only a table row, so there was no verify entry to sit beside.

## What the entry states

The dry-run default is called out in bold as its own paragraph, since the acceptance criteria name it as the safety property. Beyond the issue's list, the entry also documents the details a reader would otherwise have to open the source for:

- Only entries `verify-portals` classifies as `missing` **and** that carry a `suggested` alternate are touched. Live, empty, and genuinely unresolved entries are left alone.
- `--file <path>` and the `CAREER_OPS_PORTALS` environment variable, neither of which was in the issue text.
- A missing portals file is reported as nothing to do, not an error.
- Why the file is edited as text rather than through a YAML round trip: `portals.yml` carries hand-written comments that `yaml.dump()` would discard.
- Exit codes, with the contrast to `check-table-freshness` made explicit. Pending fixes in a dry run do **not** fail the run, so this is a maintenance tool rather than a CI gate. That difference seemed worth stating precisely because the entry I was asked to mirror is a CI gate, and a reader moving between the two could reasonably assume the same behaviour.

## Verification

The claims are checked against the running script, not just its header comment, since a docs PR whose only failure mode is being wrong deserves that:

```
$ node fix-slugs.mjs --file /tmp/does-not-exist.yml
fix-slugs: no portals file at /tmp/does-not-exist.yml — nothing to fix.
EXIT=0
```

Dry-run-writes-nothing, checked by hashing a copy of `templates/portals.example.yml` either side of a real run:

```
$ shasum -a 256 portals-copy.yml    # before
0b293c6472edcd8cb5a332f9d56fac57a6555e632bec90ea20db7659c23053a0

$ node fix-slugs.mjs --file portals-copy.yml
  ... Forto: lever -> ashby, Runway: greenhouse -> ashby ...
Run with --fix to write these changes to portals.yml.
EXIT=0

$ shasum -a 256 portals-copy.yml    # after — identical
0b293c6472edcd8cb5a332f9d56fac57a6555e632bec90ea20db7659c23053a0
```

I read `--dry-run` off `main()` rather than assuming: `dryRun` is derived as `!fix`, so the flag is not separately parsed and the default is what makes a run safe. The entry says `--dry-run` "exists only to say that out loud" rather than implying it is a distinct code path.

`node test-all.mjs --quick` (the CI gate): **2587 passed, 0 failed, 1 warning.** The warning is `cv-sync-check.mjs exited with error (expected without user data)`, which needs the user-layer `cv.md` that a fresh clone does not have. Unrelated to this change, and docs-only besides.

## Note, not part of this PR

`fix-slugs.mjs` has no `npm run` alias while its read-side twin has `npm run verify:portals`. Adding a `fix:slugs` script would make the pair symmetric, but that is a `package.json` change rather than documentation, so I left it out. Happy to open a separate issue or PR if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `fix-slugs.mjs` to the Scripts Reference.
  * Documented dry-run behavior, including diff output without writing changes.
  * Documented `--fix`/`--apply` options for applying updates.
  * Clarified that only eligible missing entries with suggested alternatives are updated.
  * Added details on preserving comments, missing-file handling, and exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->