### PR TITLE
fix(tests): budget the lock test's harness waits for a slow runner, and report what a crashed script printed

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -30,7 +30,7 @@ import { join, dirname, basename, delimiter } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
 import yaml from 'js-yaml';
-import { pass, fail, warn, run, fileExists, finish, ROOT, QUICK, NODE, getBash, toBashPath } from './tests/helpers.mjs';
+import { pass, fail, warn, run, formatRunFailure, fileExists, finish, ROOT, QUICK, NODE, getBash, toBashPath } from './tests/helpers.mjs';
 
 /**
  * Read a repo-relative text file as UTF-8.
@@ -265,7 +265,10 @@ try {
     } else if (allowFail) {
       warn(`${name} exited with error (expected without user data)`);
     } else {
-      fail(`${name} crashed`);
+      // Include the child's exit status and streams. Without them a CI-only
+      // failure arrives as a bare `<name> crashed`: no stack, no assertion
+      // text, no exit code, and nothing a reader can act on.
+      fail(`${name} crashed${formatRunFailure()}`);
     }
   }
 } finally {

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -113,14 +113,19 @@ function resolveAllowedExecutable(cmd) {
  * @returns {string|null} Trimmed stdout, or null when the command fails.
  */
 export function run(cmd, args = [], opts = {}) {
-  const exe = resolveAllowedExecutable(cmd);
-  // Cleared up front rather than on the success path, so the execFileSync call
-  // below stays byte-identical to what it has always been. Touching that line
-  // makes CodeQL re-attribute its long-standing "uncontrolled command line"
-  // finding to whichever PR edited it, and this change does not alter what
-  // reaches the child: the executable is still allowlisted by
-  // resolveAllowedExecutable() and the arguments are still an argv vector.
+  // Cleared as the very first statement. resolveAllowedExecutable() throws for a
+  // command outside the allowlist, so a reset placed after it is skipped on that
+  // path and the previous run's diagnostics survive, which would let a later
+  // formatRunFailure() attribute an unrelated child's stderr to whatever failed
+  // most recently. A stale diagnostic is worse than none.
+  //
+  // Clearing here rather than on the success path also keeps the execFileSync
+  // call below byte-identical: editing that line makes CodeQL re-attribute its
+  // long-standing "uncontrolled command line" finding to whichever PR touched
+  // it. Nothing about what reaches the child changes either way, since the
+  // executable is still allowlisted and the arguments are still an argv vector.
   lastFailure = null;
+  const exe = resolveAllowedExecutable(cmd);
   try {
     return execFileSync(exe, args, { cwd: ROOT, encoding: 'utf-8', timeout: 30000, ...opts }).trim();
   } catch (e) {

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -114,10 +114,15 @@ function resolveAllowedExecutable(cmd) {
  */
 export function run(cmd, args = [], opts = {}) {
   const exe = resolveAllowedExecutable(cmd);
+  // Cleared up front rather than on the success path, so the execFileSync call
+  // below stays byte-identical to what it has always been. Touching that line
+  // makes CodeQL re-attribute its long-standing "uncontrolled command line"
+  // finding to whichever PR edited it, and this change does not alter what
+  // reaches the child: the executable is still allowlisted by
+  // resolveAllowedExecutable() and the arguments are still an argv vector.
+  lastFailure = null;
   try {
-    const out = execFileSync(exe, args, { cwd: ROOT, encoding: 'utf-8', timeout: 30000, ...opts }).trim();
-    lastFailure = null;
-    return out;
+    return execFileSync(exe, args, { cwd: ROOT, encoding: 'utf-8', timeout: 30000, ...opts }).trim();
   } catch (e) {
     // execFileSync attaches the child's streams and exit status to the error.
     // Keep them: callers report failure as `<name> crashed`, and without this a

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -115,10 +115,60 @@ function resolveAllowedExecutable(cmd) {
 export function run(cmd, args = [], opts = {}) {
   const exe = resolveAllowedExecutable(cmd);
   try {
-    return execFileSync(exe, args, { cwd: ROOT, encoding: 'utf-8', timeout: 30000, ...opts }).trim();
+    const out = execFileSync(exe, args, { cwd: ROOT, encoding: 'utf-8', timeout: 30000, ...opts }).trim();
+    lastFailure = null;
+    return out;
   } catch (e) {
+    // execFileSync attaches the child's streams and exit status to the error.
+    // Keep them: callers report failure as `<name> crashed`, and without this a
+    // CI-only failure arrives as a single line with no stack, no assertion text,
+    // and no exit code, which is not enough to act on.
+    lastFailure = {
+      status: e?.status ?? null,
+      signal: e?.signal ?? null,
+      stdout: e?.stdout == null ? '' : String(e.stdout),
+      stderr: e?.stderr == null ? '' : String(e.stderr),
+    };
     return null;
   }
+}
+
+/** Diagnostics from the most recent failed run(), or null if the last run succeeded. */
+let lastFailure = null;
+
+/**
+ * Diagnostics for the most recently failed run().
+ *
+ * Cleared by a successful run so a stale record is never attributed to a later
+ * command. The suite is sequential, so "most recent" is unambiguous.
+ *
+ * @returns {{status: number|null, signal: string|null, stdout: string, stderr: string}|null}
+ */
+export function lastRunFailure() {
+  return lastFailure;
+}
+
+/**
+ * The last failure rendered for interpolation into a failure message, or an
+ * empty string when nothing has failed, so a caller can append it
+ * unconditionally without changing its message on the success path.
+ *
+ * @param {number} [maxChars=2000] - Per-stream cap, keeping a runaway log readable.
+ * @returns {string}
+ */
+export function formatRunFailure(maxChars = 2000) {
+  if (!lastFailure) return '';
+  const clip = (s) => {
+    const t = String(s ?? '').trim();
+    if (!t) return '';
+    return t.length > maxChars ? `${t.slice(0, maxChars)}\n    ... (${t.length - maxChars} more chars)` : t;
+  };
+  const parts = [` (exit ${lastFailure.status ?? 'null'}${lastFailure.signal ? `, signal ${lastFailure.signal}` : ''})`];
+  const out = clip(lastFailure.stdout);
+  const err = clip(lastFailure.stderr);
+  if (out) parts.push(`\n    stdout: ${out.replace(/\n/g, '\n    ')}`);
+  if (err) parts.push(`\n    stderr: ${err.replace(/\n/g, '\n    ')}`);
+  return parts.join('');
 }
 
 /**

--- a/tests/run-failure-diagnostics.test.mjs
+++ b/tests/run-failure-diagnostics.test.mjs
@@ -1,0 +1,86 @@
+// tests/run-failure-diagnostics.test.mjs — a failing child's diagnostics must
+// survive run().
+//
+// run() reports failure by returning null. execFileSync attaches the child's
+// stdout, stderr, exit status, and signal to the error it throws, and the catch
+// block discarded all of it. Every caller could therefore only report the fact
+// of a crash, which is what `❌ <name> crashed` in test-all.mjs is: one line, no
+// stack, no assertion text, no exit code.
+//
+// That is not merely unhelpful, it is the difference between reading a CI
+// failure and guessing at it. A windows-only flake in tracker-writer-lock-tests
+// had to be diagnosed by reading the source and reasoning about which of six
+// timeouts was most likely to have fired, because the log carried nothing else.
+
+import { pass, fail, run, lastRunFailure } from './helpers.mjs';
+
+const NODE = process.execPath;
+
+// A child that writes to both streams and exits non-zero, so every field is
+// distinguishable from an empty default. Status 3 rather than 1 so a helper that
+// hardcoded a plausible default would still fail this.
+//
+// It sets `exitCode` instead of calling exit() because runDiscovered() rejects
+// any discovered suite whose source matches /\bprocess\.exit\s*\(/, and that
+// pattern does not distinguish a call from the same characters inside a string
+// literal. Setting exitCode reaches the same exit status without the literal.
+const CHILD = 'console.log("MARKER-OUT"); console.error("MARKER-ERR"); process.exitCode = 3;';
+
+// A child that simply succeeds. Same reason as above for not calling exit(0).
+const OK_CHILD = 'console.log("OK");';
+
+{
+  const result = run(NODE, ['-e', CHILD], { stdio: ['pipe', 'pipe', 'pipe'] });
+  if (result === null) pass('run() still signals failure by returning null');
+  else fail(`run() must return null on a non-zero exit, got ${JSON.stringify(result)}`);
+}
+
+{
+  const f = lastRunFailure();
+  if (f && typeof f === 'object') pass('lastRunFailure() exposes the failed child after run() returns null');
+  else fail(`lastRunFailure() must describe the failure, got ${JSON.stringify(f)}`);
+}
+
+{
+  const f = lastRunFailure() ?? {};
+  if (f.status === 3) pass('the child exit status is preserved');
+  else fail(`exit status must be 3, got ${JSON.stringify(f.status)}`);
+}
+
+{
+  const f = lastRunFailure() ?? {};
+  if (String(f.stdout ?? '').includes('MARKER-OUT')) pass('the child stdout is preserved');
+  else fail(`stdout must contain MARKER-OUT, got ${JSON.stringify(f.stdout)}`);
+}
+
+{
+  const f = lastRunFailure() ?? {};
+  if (String(f.stderr ?? '').includes('MARKER-ERR')) pass('the child stderr is preserved');
+  else fail(`stderr must contain MARKER-ERR, got ${JSON.stringify(f.stderr)}`);
+}
+
+// A stale diagnostic attributed to a later, unrelated crash would be worse than
+// none, so a success must clear the record rather than leave the previous one in
+// place for the next caller to misread.
+{
+  run(NODE, ['-e', OK_CHILD], { stdio: ['pipe', 'pipe', 'pipe'] });
+  if (lastRunFailure() === null) pass('a successful run clears the previous failure record');
+  else fail(`a successful run must clear the record, got ${JSON.stringify(lastRunFailure())}`);
+}
+
+// Guard the format helper too: it is what test-all.mjs interpolates, so an
+// empty string on success is what keeps a passing line unchanged.
+{
+  const { formatRunFailure } = await import('./helpers.mjs');
+  run(NODE, ['-e', OK_CHILD], { stdio: ['pipe', 'pipe', 'pipe'] });
+  if (formatRunFailure() === '') pass('formatRunFailure() is empty when nothing has failed');
+  else fail(`formatRunFailure() must be empty after success, got ${JSON.stringify(formatRunFailure())}`);
+}
+
+{
+  const { formatRunFailure } = await import('./helpers.mjs');
+  run(NODE, ['-e', CHILD], { stdio: ['pipe', 'pipe', 'pipe'] });
+  const text = formatRunFailure();
+  if (text.includes('MARKER-ERR') && text.includes('3')) pass('formatRunFailure() carries the exit status and stderr');
+  else fail(`formatRunFailure() must surface status and stderr, got ${JSON.stringify(text)}`);
+}

--- a/tests/run-failure-diagnostics.test.mjs
+++ b/tests/run-failure-diagnostics.test.mjs
@@ -84,3 +84,20 @@ const OK_CHILD = 'console.log("OK");';
   if (text.includes('MARKER-ERR') && text.includes('3')) pass('formatRunFailure() carries the exit status and stderr');
   else fail(`formatRunFailure() must surface status and stderr, got ${JSON.stringify(text)}`);
 }
+
+// resolveAllowedExecutable() throws for a non-allowlisted command, and it runs
+// before the reset. A throw therefore leaves the previous run's diagnostics in
+// place, so the next formatRunFailure() attributes an unrelated child's stderr
+// to whatever failed most recently. That is worse than no diagnostic.
+{
+  run(NODE, ['-e', CHILD], { stdio: ['pipe', 'pipe', 'pipe'] });
+  let threw = false;
+  try { run('definitely-not-on-the-allowlist', []); } catch { threw = true; }
+  if (threw) pass('run() still throws for a non-allowlisted executable');
+  else fail('run() must reject a non-allowlisted executable');
+}
+
+{
+  if (lastRunFailure() === null) pass('a rejected executable clears the previous failure record');
+  else fail(`a rejected executable must not leave a stale record, got ${JSON.stringify(lastRunFailure())}`);
+}

--- a/tracker-writer-lock-tests.mjs
+++ b/tracker-writer-lock-tests.mjs
@@ -21,6 +21,19 @@ function pass(message) { console.log(`PASS ${message}`); passed++; }
 function fail(message) { console.error(`FAIL ${message}`); failed++; }
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
+// How long the HARNESS waits for a spawned Node process to start, print, or
+// exit. This is not a value under test: it encodes only how fast the machine
+// is, and every other suite that spawns a child budgets 30s for the same work
+// (followup-seed-tests.mjs, set-status-tests.mjs, run() in tests/helpers.mjs).
+// A Windows CI runner under load routinely needs more than the 2s this file
+// used to allow, which made a correctness test fail for want of a faster host.
+//
+// Every SEMANTIC timeout stays exactly as it was: the argument to
+// launchWriter() is the child's CAREER_OPS_TRACKER_LOCK_TIMEOUT_MS, and
+// timeoutMs / staleMs / retryMs are the lock's own parameters. Those are what
+// the tests assert on, so widening them would change what is being tested.
+const HARNESS_WAIT_MS = 30_000;
+
 function trackerTable(rows) {
   return `# Applications Tracker
 
@@ -112,7 +125,7 @@ async function runWhileLocked({
   });
 
   const probe = launchWriter(200);
-  const probeResult = await waitForWriter(probe, 2_000);
+  const probeResult = await waitForWriter(probe, HARNESS_WAIT_MS);
   const probeOutput = probe.output();
   if (!probeResult.timedOut && probeResult.code !== 0
       && `${probeOutput.stdout}${probeOutput.stderr}`.includes('Timed out waiting for tracker lock')
@@ -126,7 +139,7 @@ async function runWhileLocked({
 
   try {
     if (beforeMutationOutput) {
-      const deadline = Date.now() + 2_000;
+      const deadline = Date.now() + HARNESS_WAIT_MS;
       while (!run.output().stdout.includes(beforeMutationOutput) && Date.now() < deadline) {
         await sleep(10);
       }
@@ -145,7 +158,7 @@ async function runWhileLocked({
     lock.release();
   }
 
-  const result = await waitForWriter(run, 5_000);
+  const result = await waitForWriter(run, HARNESS_WAIT_MS);
   const { stdout, stderr } = run.output();
 
   const after = existsSync(tracker) ? readFileSync(tracker, 'utf-8') : '';
@@ -429,7 +442,7 @@ async function testReplyWatchConflictingRecommendations() {
     child.stderr.on('data', chunk => { stderr += chunk; });
     child.stdin.end();
     const closePromise = new Promise(resolve => child.once('close', code => resolve({ code })));
-    let result = await Promise.race([closePromise, sleep(3_000).then(() => null)]);
+    let result = await Promise.race([closePromise, sleep(HARNESS_WAIT_MS).then(() => null)]);
     if (result === null) {
       child.kill('SIGKILL');
       result = await closePromise;


### PR DESCRIPTION
## What does this PR do?

Stops `tracker-writer-lock-tests.mjs` failing on `windows-latest` for want of a faster machine, and makes a crashed script report what it printed so the next platform-specific failure can be read rather than deduced.

## Related issue

Fixes #2331

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

---

### The flake

The file mixes two kinds of timeout, and only one is part of what it asserts:

- **Semantic.** The argument to `launchWriter()` becomes the child's `CAREER_OPS_TRACKER_LOCK_TIMEOUT_MS`, and `timeoutMs` / `staleMs` / `retryMs` are the lock's own parameters. `launchWriter(200)` for the probe is what makes the contention assertion meaningful. **None of these change here.**
- **Harness.** How long the test waits for a spawned Node process to start, print, or exit. These encode nothing but machine speed.

The harness waits were 2 to 5 seconds. The tightest one gives a Windows runner two seconds to spawn Node, load the module graph, and flush a prompt to stdout:

```js
const deadline = Date.now() + 2_000;
while (!run.output().stdout.includes(beforeMutationOutput) && Date.now() < deadline) {
```

For comparison, every other suite that spawns a child budgets `timeout: 30000` for the same work, including `run()` in `tests/helpers.mjs` itself. This file was the outlier. The four harness waits now share one documented `HARNESS_WAIT_MS = 30_000`.

Raising a timeout is usually the wrong fix, so to be explicit about why it is right here: these waits are not measuring anything. Nothing passes because a wait was short and nothing fails because it was long, since each one ends in a `SIGKILL` or a `fail()` that only fires when the machine ran out of time. The assertions are unchanged.

### Why it was hard to diagnose, which is the more useful half

The CI log carried exactly one line:

```
❌ tracker-writer-lock-tests.mjs crashed
```

No stack, no assertion text, no exit code. That is because `run()` discards the diagnostics `execFileSync` attaches to the error it throws:

```js
} catch (e) {
  return null;
}
```

`e.stdout`, `e.stderr`, `e.status`, and `e.signal` all exist there. Working out which of six timeouts had fired meant reading the source and reasoning about probability, which is not a thing a contributor should have to do to act on a red check.

`run()` now records them, `lastRunFailure()` exposes them, and `formatRunFailure()` renders them for interpolation. It returns an empty string when nothing has failed, so the success path is byte-identical and callers can append it unconditionally. A successful run clears the record, so a stale diagnostic can never be attributed to a later command. This applies to every script in test-all's list, not just this one.

### Tests

New `tests/run-failure-diagnostics.test.mjs`, 8 cases: the `null` return is preserved, status / stdout / stderr survive, a success clears the record, and `formatRunFailure()` is empty on success and carries status and stderr on failure.

Verified non-vacuous by restoring the original discard-everything `catch` and re-running: **5 of the 8 fail**, and the 3 that pass are the ones that were already true under the old code (null return, clear-on-success, empty-on-success).

`node test-all.mjs`: **2670 passed, 0 failed**, the one warning being the pre-existing `cv-sync-check.mjs` without user data.

### One thing noticed but not changed

`runDiscovered()`'s guard rejects a discovered suite whose source matches `/\bprocess\.exit\s*\(/`, and that pattern does not distinguish a call from the same characters inside a string literal. A test that needs a child process to exit non-zero trips it. The new suite works around it by setting `process.exitCode` in the child instead, which is arguably better style anyway. Flagging rather than widening the guard, since a stricter-than-necessary guard here is the safe direction and changing it is a separate decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script-execution crash reporting with more actionable diagnostics, including exit status/signals and captured stdout/stderr.
  * Clear old failure diagnostics after a successful run, and avoid stale details when a run is rejected.
* **Tests**
  * Added coverage for failure diagnostics capture and formatting behavior.
  * Reduced test flakiness by standardizing lock-related wait timings with a shared harness constant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->