### PR TITLE
fix: strip GitHub URL scheme case-insensitively in cover letters

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -61,7 +61,7 @@ function buildContactLine(candidate) {
     parts.push(`<a href="${escapeHtml(asUrl(candidate.linkedin))}">LinkedIn</a>`);
   }
   if (candidate.github) {
-    const display = candidate.github.replace(/^https?:\/\//, "");
+    const display = candidate.github.replace(/^https?:\/\//i, "");
     parts.push(`<a href="${escapeHtml(asUrl(candidate.github))}">${escapeHtml(display)}</a>`);
   }
   return parts.join(" &nbsp;|&nbsp; ");


### PR DESCRIPTION
## Summary

`buildContactLine()`'s `github` display-strip regex only matched a lowercase `http(s)://` scheme, while `asUrl()` (used for the same field's `href`) already tests the scheme case-insensitively. A mixed-case input like `HTTPS://github.com/...` would keep the scheme visible in the rendered link text instead of the scheme-stripped display used elsewhere. Adds the `/i` flag to match `asUrl()`'s behavior.

Same bug class as #2336 / PR #2338 (`linkedin` field), caught there by automated review — filing this one separately since it's a different, pre-existing line not touched by that PR.

Fixes #2339

## Test plan
- [x] `node --check generate-cover-letter.mjs`
- [x] Manually confirmed a mixed-case scheme input (`HTTPS://github.com/...`) now renders scheme-stripped, matching the existing lowercase-scheme behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitHub link display text by consistently removing `http://` and `https://` prefixes, regardless of capitalization.
  - Link destinations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->