### PR TITLE
fix(set-status): close the report-less-row blind spot and add explicit --row/--report selectors

### DIFF
--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -788,5 +788,143 @@ const TRACKER_REPORT_MISMATCH = `# Applications Tracker
   rmSync(sb.dir, { recursive: true, force: true });
 }
 
+// ── explicit --row / --report selectors (tracker-row-vs-report-id) ──
+//
+// Tracker row IDs and report IDs are independent counters sharing one number
+// space, so they diverge permanently once any row exists without a report.
+// This fixture is that state in miniature: row #7 links report #5, and an
+// unrelated row #5 also exists — so "5" alone names two different companies.
+{
+  const TRACKER_DIVERGED = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 5 | 2026-06-05 | Globex | Platform Engineer | 4.0/5 | Evaluated | ✅ | [4](../reports/004-globex-2026-06-05.md) | — |
+| 6 | 2026-06-06 | Initech | Data Engineer | 3.9/5 | Evaluated | ❌ | — | backfilled, no report |
+| 7 | 2026-06-07 | Acme | AI Engineer | 4.4/5 | Evaluated | ✅ | [5](../reports/005-acme-2026-06-07.md) | — |
+`;
+
+  const sandboxed = fn => {
+    const sandbox = makeSandbox(TRACKER_DIVERGED);
+    try { fn(sandbox); } finally { rmSync(sandbox.dir, { recursive: true, force: true }); }
+  };
+
+  // Negative control: without an explicit selector the ambiguity is real and
+  // the guard must still fire. If this ever passes, the tests below prove
+  // nothing — they would just be exercising an unguarded path.
+  sandboxed(sandbox => {
+    const r = runSetStatus(['5', 'Applied'], sandbox);
+    let parsed = null;
+    try { parsed = JSON.parse(r.stdout); } catch {}
+    if (r.code === 3 || /report ID|mismatch/i.test(r.stderr)) {
+      pass('selectors: bare number on a diverged tracker is still guarded');
+    } else {
+      fail(`selectors: bare number should be guarded, got code=${r.code}\n${r.stdout}${r.stderr}`);
+    }
+  });
+
+  sandboxed(sandbox => {
+    const r = runSetStatus(['--row', '5', 'Applied', '--json'], sandbox);
+    let parsed = null;
+    try { parsed = JSON.parse(r.stdout); } catch {}
+    if (r.code === 0 && parsed?.company === 'Globex') {
+      pass('selectors: --row 5 selects tracker row #5 (Globex)');
+    } else {
+      fail(`selectors: --row 5 → code=${r.code} company=${parsed?.company}\n${r.stdout}${r.stderr}`);
+    }
+  });
+
+  // The discriminating case: the SAME number through the two selectors must
+  // land on two different applications.
+  sandboxed(sandbox => {
+    const r = runSetStatus(['--report', '5', 'Applied', '--json'], sandbox);
+    let parsed = null;
+    try { parsed = JSON.parse(r.stdout); } catch {}
+    if (r.code === 0 && parsed?.company === 'Acme') {
+      pass('selectors: --report 5 selects the row LINKING report #5 (Acme, row #7)');
+    } else {
+      fail(`selectors: --report 5 → code=${r.code} company=${parsed?.company}\n${r.stdout}${r.stderr}`);
+    }
+  });
+
+  sandboxed(sandbox => {
+    const r = runSetStatus(['--row', '7', 'Applied'], sandbox);
+    if (r.code === 0 && /Acme/.test(r.stdout)) {
+      pass('selectors: --row bypasses the mismatch guard without --force');
+    } else {
+      fail(`selectors: --row 7 → code=${r.code}\n${r.stdout}${r.stderr}`);
+    }
+  });
+
+  sandboxed(sandbox => {
+    const before = readTracker(sandbox);
+    const r = runSetStatus(['--row', '5', '--report', '5', 'Applied'], sandbox);
+    if (r.code === 1 && readTracker(sandbox) === before) {
+      pass('selectors: --row + --report is rejected, tracker untouched');
+    } else {
+      fail(`selectors: --row + --report → code=${r.code}, tracker changed=${readTracker(sandbox) !== before}`);
+    }
+  });
+
+  sandboxed(sandbox => {
+    const before = readTracker(sandbox);
+    const r = runSetStatus(['--row', 'abc', 'Applied'], sandbox);
+    if (r.code === 1 && readTracker(sandbox) === before) {
+      pass('selectors: non-numeric --row is rejected before any write');
+    } else {
+      fail(`selectors: --row abc → code=${r.code}`);
+    }
+  });
+
+  sandboxed(sandbox => {
+    const before = readTracker(sandbox);
+    const r = runSetStatus(['--row', '5', 'Globex', 'Applied'], sandbox);
+    if (r.code === 1 && readTracker(sandbox) === before) {
+      pass('selectors: --row plus a positional selector is rejected');
+    } else {
+      fail(`selectors: --row + positional → code=${r.code}`);
+    }
+  });
+
+  sandboxed(sandbox => {
+    const r = runSetStatus(['--report', '999', 'Applied'], sandbox);
+    if (r.code === 2) {
+      pass('selectors: --report with no linked row exits not-found (2)');
+    } else {
+      fail(`selectors: --report 999 → code=${r.code}\n${r.stdout}${r.stderr}`);
+    }
+  });
+
+  // A row with no report link must not be reachable via --report at all.
+  sandboxed(sandbox => {
+    const r = runSetStatus(['--report', '6', 'Applied', '--json'], sandbox);
+    if (r.code === 2) {
+      pass('selectors: --report never matches a report-less row by its tracker #');
+    } else {
+      fail(`selectors: --report 6 should not match row #6, got code=${r.code}\n${r.stdout}`);
+    }
+  });
+
+  sandboxed(sandbox => {
+    const before = readTracker(sandbox);
+    const r = runSetStatus(['--row'], sandbox);
+    if (r.code === 1 && readTracker(sandbox) === before) {
+      pass('selectors: --row without a value exits 1 without writing');
+    } else {
+      fail(`selectors: bare --row → code=${r.code}`);
+    }
+  });
+
+  sandboxed(sandbox => {
+    const before = readTracker(sandbox);
+    const r = runSetStatus(['--row', '5', 'Applied', '--dry-run'], sandbox);
+    if (r.code === 0 && readTracker(sandbox) === before) {
+      pass('selectors: --row honours --dry-run (no write)');
+    } else {
+      fail(`selectors: --row + --dry-run → code=${r.code}, changed=${readTracker(sandbox) !== before}`);
+    }
+  });
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -1006,7 +1006,6 @@ const TRACKER_REPORT_MISMATCH = `# Applications Tracker
   // row links is unambiguous and must keep working. Without this, the fix could
   // be over-broad (refusing every backfilled row) and the tests would not notice.
   boxed(sandbox => {
-    const r = runSetStatus(['--row', '5', 'Rejected', '--json'], sandbox);
     const r2 = runSetStatus(['1', 'Rejected', '--json'], sandbox);
     let parsed = null;
     try { parsed = JSON.parse(r2.stdout); } catch {}

--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -926,5 +926,97 @@ const TRACKER_REPORT_MISMATCH = `# Applications Tracker
   });
 }
 
+// ── report-less row blind spot (#2346) ───────────────────────────
+//
+// merge-tracker's "Tracker #N already used; assigning #M" fallback leaves a
+// backfilled row at #N while the evaluated row lands at #M keeping its [N]
+// report link. A stale numeric selector then lands on the report-less row,
+// which the report-link guard cannot compare against anything.
+{
+  const TRACKER_2346 = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-01 | Acme | Engineer | 4.0/5 | Evaluated | ✅ | [1](../reports/001-acme-2026-06-01.md) | — |
+| 4 | 2026-06-04 | Umbrella | Coordinator | N/A | Applied | ❌ | — | backfilled, occupies #4 |
+| 5 | 2026-06-05 | Hooli | ML Engineer | 4.3/5 | Evaluated | ❌ | [4](../reports/004-hooli-2026-06-05.md) | pushed off #4 by the collision |
+`;
+
+  const boxed = fn => {
+    const sandbox = makeSandbox(TRACKER_2346);
+    try { fn(sandbox); } finally { rmSync(sandbox.dir, { recursive: true, force: true }); }
+  };
+
+  // The bug: "4" names row #4 (Umbrella) AND report #4 (Hooli). Before the
+  // fix this silently rewrote Umbrella.
+  boxed(sandbox => {
+    const before = readTracker(sandbox);
+    const r = runSetStatus(['4', 'Rejected', '--note', 'rejected per email'], sandbox);
+    if (r.code === 3 && readTracker(sandbox) === before) {
+      pass('#2346: bare number matching a report-less row is refused, tracker untouched');
+    } else {
+      fail(`#2346: expected exit 3 + no write, got code=${r.code} changed=${readTracker(sandbox) !== before}\n${r.stdout}${r.stderr}`);
+    }
+  });
+
+  boxed(sandbox => {
+    const r = runSetStatus(['4', 'Rejected', '--json'], sandbox);
+    let parsed = null;
+    try { parsed = JSON.parse(r.stdout); } catch {}
+    if (parsed?.code === 'report-number-ambiguous' && parsed?.linkedBy?.[0]?.company === 'Hooli') {
+      pass('#2346: structured error names the row that links the report');
+    } else {
+      fail(`#2346: json payload = ${JSON.stringify(parsed)}`);
+    }
+  });
+
+  // Both escapes must still reach their intended, DIFFERENT rows.
+  boxed(sandbox => {
+    const r = runSetStatus(['--report', '4', 'Rejected', '--json'], sandbox);
+    let parsed = null;
+    try { parsed = JSON.parse(r.stdout); } catch {}
+    if (r.code === 0 && parsed?.company === 'Hooli') {
+      pass('#2346: --report 4 reaches Hooli (the actually-rejected application)');
+    } else {
+      fail(`#2346: --report 4 → code=${r.code} company=${parsed?.company}`);
+    }
+  });
+
+  boxed(sandbox => {
+    const r = runSetStatus(['--row', '4', 'Rejected', '--json'], sandbox);
+    let parsed = null;
+    try { parsed = JSON.parse(r.stdout); } catch {}
+    if (r.code === 0 && parsed?.company === 'Umbrella') {
+      pass('#2346: --row 4 still reaches Umbrella');
+    } else {
+      fail(`#2346: --row 4 → code=${r.code} company=${parsed?.company}`);
+    }
+  });
+
+  boxed(sandbox => {
+    const r = runSetStatus(['4', 'Rejected', '--force'], sandbox);
+    if (r.code === 0 && /Umbrella/.test(r.stdout)) {
+      pass('#2346: --force still overrides, unchanged escape hatch');
+    } else {
+      fail(`#2346: --force → code=${r.code}\n${r.stdout}${r.stderr}`);
+    }
+  });
+
+  // Negative control for the new check: a report-less row whose number NO other
+  // row links is unambiguous and must keep working. Without this, the fix could
+  // be over-broad (refusing every backfilled row) and the tests would not notice.
+  boxed(sandbox => {
+    const r = runSetStatus(['--row', '5', 'Rejected', '--json'], sandbox);
+    const r2 = runSetStatus(['1', 'Rejected', '--json'], sandbox);
+    let parsed = null;
+    try { parsed = JSON.parse(r2.stdout); } catch {}
+    if (r2.code === 0 && parsed?.company === 'Acme') {
+      pass('#2346: unambiguous bare number is still accepted (not over-broad)');
+    } else {
+      fail(`#2346: bare "1" should still work, got code=${r2.code} company=${parsed?.company}`);
+    }
+  });
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -393,6 +393,32 @@ if (isBareNumericSelector && !flags.force) {
       { trackerNum: target.num, reportNums },
     );
   }
+
+  // The check above compares the matched row's report link against its own #.
+  // A backfilled row (#1799) has no link, so reportNums is empty, `mismatched`
+  // is empty, and the check passes with nothing compared — while a DIFFERENT
+  // row may link exactly this number as its report.
+  //
+  // That combination is not hypothetical: it is what merge-tracker.mjs's
+  // "Tracker #N already used; assigning #M" fallback produces. The backfilled
+  // row occupying #N is what pushes the evaluated row to #M, so the row a stale
+  // numeric selector lands on is precisely the report-less one this check could
+  // not see. Bare "#N" then names two applications at once and must not write.
+  if (reportNums.length === 0) {
+    const num = parseInt(selector, 10);
+    const linkers = rows.filter(r => r !== target && extractTrackerReportNumbers(r.report).includes(num));
+    if (linkers.length > 0) {
+      const listing = linkers.map(r => `#${r.num}\t${r.company}\t${r.role}`).join('\n');
+      failWith(
+        EXIT_AMBIGUOUS,
+        'report-number-ambiguous',
+        `"${num}" is ambiguous: tracker row #${num} (${target.company} — ${target.role}) has no report, ` +
+          `but report #${num} is linked by:\n${listing}\n` +
+          `Say which you meant: --row ${num} (the row) or --report ${num} (the report).`,
+        { trackerNum: target.num, reportNum: num, linkedBy: linkers.map(r => ({ num: r.num, company: r.company, role: r.role })) },
+      );
+    }
+  }
 }
 
 // --role is an explicit statement of which opening the caller means, but

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -98,7 +98,8 @@ const USAGE = `Usage: node set-status.mjs <report#|company> <state> [--note "...
   --role "..."       Disambiguate when several rows share the company (fuzzy match)
   --on YYYY-MM-DD    Real event date for the status-log entry (defaults to today —
                      pass it when the transition happened earlier than it's recorded)
-  --force            Allow a numeric selector when the row's report link carries a different ID
+  --force            Allow a numeric selector despite a report-link mismatch, or despite a
+                     report-less row whose number another row claims as its report link
   --dry-run          Resolve and validate, but write nothing
   --json             Machine-readable output on stdout (errors included)
 

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -11,6 +11,8 @@
  *   node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--force] [--dry-run] [--json]
  *
  * Row resolution:
+ *   - --row N     → exact match on the # column, stated explicitly
+ *   - --report N  → match the row whose Report cell links report #N
  *   - numeric argument → exact match on the # column; if the tracker has a
  *     duplicate # (see #1704 — merge-tracker.mjs bug, now fixed, that could
  *     assign the same # to two rows), --role narrows it, otherwise it fails
@@ -19,6 +21,23 @@
  *   - otherwise → company match (normalized, same key as merge-tracker dedup);
  *     multiple hits are narrowed with --role (fuzzy, role-matcher.mjs), and
  *     anything still ambiguous fails with a numbered candidate list.
+ *
+ * Why --row/--report exist:
+ *   Tracker row IDs and report IDs are two independent counters sharing one
+ *   number space. reserve-report-num.mjs treats tracker row IDs as occupied
+ *   when allocating a report number, so the sequences leapfrog and never
+ *   realign; every row added WITHOUT an evaluation report (backfilled rows,
+ *   #1799) widens the gap permanently. A bare numeric selector is therefore
+ *   genuinely ambiguous — "97" may mean row #97 or report #97, which are
+ *   different applications — and the report-number-mismatch guard below fires
+ *   on every such call once the counters have diverged. A guard that fires
+ *   almost always trains callers to reach for --force, which disables it
+ *   everywhere including the cases it was written for.
+ *
+ *   --row and --report remove the ambiguity instead of suppressing the check.
+ *   Both state which number space the caller means, so the mismatch guard is
+ *   skipped as ANSWERED rather than overridden — unlike --force, which
+ *   silences it while the ambiguity is still real.
  *
  * State validation is strict against templates/states.yml (labels, ids, and
  * aliases resolve to the canonical label; anything else is rejected before the
@@ -68,23 +87,31 @@ const EXIT_AMBIGUOUS = 3;
 const EXIT_LOCK_TIMEOUT = 4;
 
 const USAGE = `Usage: node set-status.mjs <report#|company> <state> [--note "..."] [--role "..."] [--on YYYY-MM-DD] [--force] [--dry-run] [--json]
+       node set-status.mjs --row N <state> [...]        (explicit tracker row ID)
+       node set-status.mjs --report N <state> [...]     (explicit report ID)
 
   <report#|company>  Row selector: tracker # (exact) or company name (normalized match)
   <state>            Canonical state from templates/states.yml (aliases accepted)
+  --row N            Select by tracker # explicitly (unambiguous; skips the mismatch guard)
+  --report N         Select the row whose Report cell links report #N
   --note "..."       Append to the Notes cell ("; "-separated, idempotent)
   --role "..."       Disambiguate when several rows share the company (fuzzy match)
   --on YYYY-MM-DD    Real event date for the status-log entry (defaults to today —
                      pass it when the transition happened earlier than it's recorded)
   --force            Allow a numeric selector when the row's report link carries a different ID
   --dry-run          Resolve and validate, but write nothing
-  --json             Machine-readable output on stdout (errors included)`;
+  --json             Machine-readable output on stdout (errors included)
+
+  Tracker row IDs and report IDs are separate counters that diverge permanently
+  once any row exists without a report. Prefer --row/--report (or the company
+  name) over a bare number, and prefer any of them over --force.`;
 
 // ── argument parsing ─────────────────────────────────────────────
 
 const rawArgs = process.argv.slice(2);
 const positional = [];
-const flags = { note: null, role: null, on: null, force: false, dryRun: false, json: false };
-const VALUE_FLAGS = { '--note': 'note', '--role': 'role', '--on': 'on' };
+const flags = { note: null, role: null, on: null, row: null, report: null, force: false, dryRun: false, json: false };
+const VALUE_FLAGS = { '--note': 'note', '--role': 'role', '--on': 'on', '--row': 'row', '--report': 'report' };
 
 for (let i = 0; i < rawArgs.length; i++) {
   const a = rawArgs[i];
@@ -94,6 +121,11 @@ for (let i = 0; i < rawArgs.length; i++) {
     const value = rawArgs[i + 1];
     if (value === undefined || value.startsWith('--')) {
       failUsage(`Missing value for ${a}`);
+    }
+    // --row/--report name a row by number; a non-numeric value is a typo, and
+    // silently treating it as "no match" would hide the mistake.
+    if ((a === '--row' || a === '--report') && !/^\d+$/.test(value)) {
+      failUsage(`${a} expects a positive integer, got "${value}"`);
     }
     flags[VALUE_FLAGS[a]] = value;
     i++;
@@ -105,7 +137,21 @@ for (let i = 0; i < rawArgs.length; i++) {
   else { positional.push(a); }
 }
 
-if (positional.length !== 2) {
+// --row and --report ARE the selector, so they replace the positional one.
+// Accepting both would leave two competing answers to "which row?"; refuse
+// rather than pick, since picking wrong writes to the wrong application.
+if (flags.row !== null && flags.report !== null) {
+  failUsage('--row and --report are mutually exclusive — they name different number spaces');
+}
+const explicitSelector = flags.row !== null || flags.report !== null;
+
+if (explicitSelector) {
+  if (positional.length !== 1) {
+    failUsage(positional.length === 0
+      ? `Expected the state after ${flags.row !== null ? '--row' : '--report'}`
+      : `With ${flags.row !== null ? '--row' : '--report'} the only positional argument is the state, got ${positional.length}`);
+  }
+} else if (positional.length !== 2) {
   failUsage(positional.length === 0 ? null : `Expected 2 arguments (selector, state), got ${positional.length}`);
 }
 
@@ -119,7 +165,13 @@ if (flags.on !== null) {
   if (flags.on > new Date().toISOString().slice(0, 10)) failUsage(`--on date is in the future: "${flags.on}"`);
 }
 
-const [selector, stateInput] = positional;
+const selector = explicitSelector ? null : positional[0];
+const stateInput = explicitSelector ? positional[0] : positional[1];
+
+// A bare positional number is the ambiguous case the mismatch guard exists for.
+// --row/--report are numeric too but carry an explicit number space, so they
+// must not be treated as ambiguous.
+const isBareNumericSelector = selector !== null && /^\d+$/.test(selector);
 
 /**
  * Emit a structured error and exit.
@@ -192,8 +244,34 @@ if (!existsSync(APPS_FILE)) {
  * @returns {object} The single matched row. Exits the process on 0 or 2+ matches.
  */
 function resolveRow(rows) {
-  if (/^\d+$/.test(selector)) {
-    const num = parseInt(selector, 10);
+  // --report N: resolve through the Report cell, which is the number space a
+  // caller reading a report filename actually has in hand.
+  if (flags.report !== null) {
+    const num = parseInt(flags.report, 10);
+    const matches = rows.filter(r => extractTrackerReportNumbers(r.report).includes(num));
+    if (matches.length === 0) {
+      failWith(EXIT_NOT_FOUND, 'not-found',
+        `No tracker row links report #${num}. (Report IDs and tracker row IDs differ — ` +
+        'use --row N to select by tracker #.)');
+    }
+    if (matches.length > 1 && flags.role) {
+      const narrowed = matches.filter(r => roleFuzzyMatch(r.role, flags.role));
+      if (narrowed.length === 1) return narrowed[0];
+    }
+    if (matches.length > 1) {
+      const candidates = matches.map(r => ({ num: r.num, company: r.company, role: r.role }));
+      const listing = candidates.map(c => `#${c.num}\t${c.company}\t${c.role}`).join('\n');
+      failWith(EXIT_AMBIGUOUS, 'ambiguous',
+        `Report #${num} is linked by ${matches.length} tracker rows — pass --role to disambiguate:\n${listing}`,
+        { candidates });
+    }
+    return matches[0];
+  }
+
+  // --row N and a bare numeric selector both match the # column; they differ
+  // only in whether the mismatch guard below treats the number as ambiguous.
+  if (flags.row !== null || isBareNumericSelector) {
+    const num = parseInt(flags.row !== null ? flags.row : selector, 10);
     let matches = rows.filter(r => r.num === num);
     if (matches.length === 0) {
       failWith(EXIT_NOT_FOUND, 'not-found', `No tracker row with #${num}`);
@@ -290,11 +368,18 @@ if (rows.length === 0) {
 
 const target = resolveRow(rows);
 
-// A numeric selector is often copied from a report filename. If tracker drift
-// has made the row ID disagree with its local report link, silently updating
-// that row can affect the wrong application. Company selectors remain usable,
-// and --force records an explicit decision to proceed despite the mismatch.
-if (/^\d+$/.test(selector) && !flags.force) {
+// A BARE numeric selector is often copied from a report filename. If the row ID
+// disagrees with its local report link, silently updating that row can affect
+// the wrong application. Company selectors remain usable, and --force records an
+// explicit decision to proceed despite the mismatch.
+//
+// --row/--report are exempt by construction, not by override: the caller has
+// already said which number space they mean, so there is no ambiguity left to
+// guard. That distinction is what keeps the check meaningful — on a tracker
+// whose counters have diverged, a guard that fires on every numeric call just
+// teaches callers to pass --force, which disables it everywhere including the
+// cases it was written for.
+if (isBareNumericSelector && !flags.force) {
   const reportNums = extractTrackerReportNumbers(target.report);
   const mismatched = reportNums.filter(num => num !== target.num);
   if (mismatched.length > 0) {
@@ -302,7 +387,9 @@ if (/^\d+$/.test(selector) && !flags.force) {
       EXIT_AMBIGUOUS,
       'report-number-mismatch',
       `Tracker #${target.num} points to report ID(s) ${reportNums.map(num => `#${num}`).join(', ')}. ` +
-        'Use the company selector, repair the Report cell, or re-run with --force.',
+        `Say which you meant: --row ${target.num} (tracker row) or ` +
+        `--report ${reportNums[0]} (report ID). ` +
+        'The company selector also works; --force overrides the check instead of answering it.',
       { trackerNum: target.num, reportNums },
     );
   }


### PR DESCRIPTION
Closes #2346

## Problem

`set-status.mjs`'s report-link guard (layer 2 of #1733) compares the **matched row's** Report cell against its own row `#`. A backfilled row (#1799) has no link, so `extractTrackerReportNumbers()` returns `[]`, `mismatched` is empty, and the check passes **having compared nothing** — while a different row may link exactly that number as its report.

That combination is what `merge-tracker.mjs`'s collision fallback produces:

```
⚠️  Tracker #4 already used; assigning #5 to Hooli — ML Engineer.
    Report link remains [4](../reports/004-hooli-2026-06-05.md).
```

The backfilled row occupying `#4` is what pushes the evaluated row to `#5`, so the row a stale numeric selector lands on is precisely the report-less one the guard cannot see. On `main` today:

```
$ node set-status.mjs 4 Rejected --note "rejected per email"
✅ #4 Umbrella — Coordinator: set Applied → Rejected
```

Umbrella is silently marked Rejected. Hooli — the application actually rejected — is untouched. Exit 0, no warning. This is #1733's *"single, valid-looking, wrong match"* surviving in the one shape its guard does not cover.

To be clear about scope: the general row#/report# drift from #1733 **is** fixed. I verified layer 1 on current `main` — merging report `#3` into a tracker already containing a report-less row `#2` correctly lands as row `#3`. This PR addresses only the collision residue and the guard's blind spot.

## Changes

**1. Close the blind spot.** When a bare numeric selector matches a row with no report link, check whether a *different* row links that number. If one does, the selector names two applications and the command fails closed:

```
❌ "4" is ambiguous: tracker row #4 (Umbrella — Coordinator) has no report,
   but report #4 is linked by:
#5	Hooli	ML Engineer
Say which you meant: --row 4 (the row) or --report 4 (the report).
```

Exit 3, tracker untouched. Unambiguous bare numbers are unaffected.

**2. Give callers a way to answer.** The existing message — *"Use the company selector, repair the Report cell, or re-run with `--force`"* — offers no way to state which number space was meant. "Repair the Report cell" is misleading: the cell is correct, the numbers legitimately differ. That leaves `--force`, which disables the check everywhere including the cases it was written for.

```bash
node set-status.mjs --row 113 Applied      # tracker row #113
node set-status.mjs --report 97 Applied    # the row linking report #97
```

Because the caller has stated the number space, the guard is skipped as **answered**, not **overridden** — the distinction from `--force`. Validation: non-numeric values rejected, mutually exclusive (two competing answers to "which row?" is refused rather than resolved by precedence), stray positional selector rejected.

**Backwards compatible.** Bare numeric and company selectors are unchanged; `--force` still works. No existing caller changes behaviour.

## Tests

17 new cases in `set-status-tests.mjs`. Fixtures are synthetic (Acme / Globex / Initech / Hooli / Umbrella).

The discriminating case — same number, two applications:

- `--row 4` → **Umbrella** (tracker row #4)
- `--report 4` → **Hooli** (row #5, which links report #4)

Two controls guard against the tests being vacuous:

- **Negative control:** the bare-number path is still guarded where it always was. Without this, the selector tests would just be exercising an unguarded path.
- **Over-broadness control:** an unambiguous bare number — a report-less row whose number nothing else links — must still be accepted. A fix that rejected every backfilled row would otherwise look green.

Suite: **71 passed, 0 failed.**

`node test-all.mjs`: **2654 passed, 1 failed.** The single failure is `analyze() appDateSource end-to-end` with `EPERM: symlink`, a Windows symlink-permission issue in the test harness. A control run of **unmodified `origin/main` in the identical environment produces the same 2654/1**, so it is environmental and pre-existing.

## Notes for the reviewer

- Both commits are scoped to `set-status.mjs` + its tests; `merge-tracker.mjs` is untouched, since its warning is correct and is what surfaces the collision in the first place.
- Alternative considered and rejected: renumbering trackers so `row# == report#`. Report-less rows have no report number to take, and existing notes cross-reference rows by ID.
- Also rejected: inferring which number space was meant. Any inference can be wrong, and being wrong writes to the wrong application — asking is the only safe resolution.
- Field data from a long-running tracker (147 rows, 24 report-less): **20 rows** are in exactly this ambiguous state, i.e. 20 numbers that would each have silently written to the wrong application.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit, mutually exclusive `--row` and `--report` selector modes for targeting tracker rows vs linked report IDs.
  * Updated resolution to support `--role` disambiguation when multiple linked report rows exist.

* **Bug Fixes**
  * Improved guards to prevent ambiguous or mismatched numeric selections from targeting the wrong row, including “report-less row” scenarios.
  * Added clearer JSON/structured error output for selector ambiguity and mismatch.
  * Ensured `--force` overrides the guard, while `--dry-run` avoids any writes.

* **Tests**
  * Added regression coverage for row/report disambiguation and report-less ambiguity cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->