### PR TITLE
fix(cover-letter): strip github URL scheme case-insensitively

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -61,7 +61,7 @@ function buildContactLine(candidate) {
     parts.push(`<a href="${escapeHtml(asUrl(candidate.linkedin))}">LinkedIn</a>`);
   }
   if (candidate.github) {
-    const display = candidate.github.replace(/^https?:\/\//, "");
+    const display = candidate.github.replace(/^https?:\/\//i, "");
     parts.push(`<a href="${escapeHtml(asUrl(candidate.github))}">${escapeHtml(display)}</a>`);
   }
   return parts.join(" &nbsp;|&nbsp; ");


### PR DESCRIPTION
## Summary

The display-strip regex in buildContactLine() only matched lowercase http:// / https://, so a mixed-case input like HTTPS://github.com/yourhandle left the scheme visible in the anchor text.

Add the /i flag to match asUrl()'s own case-insensitive scheme test.

Same class of bug as #2336 (linkedin, fixed in #2338).

## Testing

before: 'HTTPS://github.com/foo'.replace(/^https?:\/\//, '') => 'HTTPS://github.com/foo'
after:  'HTTPS://github.com/foo'.replace(/^https?:\/\//i, '') => 'github.com/foo'

Closes #2339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub link display text by consistently removing `http://` and `https://` prefixes, regardless of capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->