### PR TITLE
docs(scripts): document the set-status --row/--report selectors

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -896,7 +896,7 @@ A bare number or company name is convenient, but becomes ambiguous when multiple
 
 `--row` and `--report` are mutually exclusive. Because an explicit selector answers the report-mismatch guard rather than overriding it, `--row` bypasses that guard without needing `--force` (which silences the check while the ambiguity is still real).
 
-This is worth preferring in practice, not just in principle: on a diverged tracker the guard fires on nearly every bare numeric call, and a guard that always fires trains callers to reach for `--force` by reflex — which disables it everywhere, including the cases it was written to catch. Reach for a selector (or the company name) instead.
+This is worth preferring in practice, not just in principle. Once the counters have diverged, a bare number trips the guard whenever the row it matches links a report number other than its own `#`, or links no report at all while a different row claims that number as its report — so on a tracker with a wide gap the check keeps firing, and a check that keeps firing teaches callers to pass `--force` by reflex, which disables it everywhere including the cases it was written to catch. Reach for a selector (or the company name) instead.
 
 ### Bare numbers vs. explicit selectors
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -886,7 +886,7 @@ node set-status.mjs --row 12 Applied
 node set-status.mjs --report 345 Applied --on 2026-08-01
 ```
 
-A bare number or company name is convenient, but becomes ambiguous when multiple tracker rows exist for a company or when tracker row IDs and report IDs diverge. Base selectors resolve the main target, while explicit selectors and filters disambiguate the target row:
+A bare number or company name is convenient, but becomes ambiguous when multiple tracker rows exist for a company or when tracker row IDs and report IDs diverge. That divergence is permanent once it starts: `reserve-report-num.mjs` treats tracker row IDs as occupied when it allocates a report number, so a row that never got a report still consumes a number the report sequence then skips — the two counters leapfrog each other and never realign. On a diverged tracker "5" may mean tracker row #5 or report #5, which are different applications. Base selectors resolve the main target, while explicit selectors and filters disambiguate the target row:
 
 - `--row N`: Selects the row whose `#` cell is `N`.
 - `--report N`: Selects the row whose `Report` cell links report `N`.
@@ -896,16 +896,24 @@ A bare number or company name is convenient, but becomes ambiguous when multiple
 
 `--row` and `--report` are mutually exclusive. Because an explicit selector answers the report-mismatch guard rather than overriding it, `--row` bypasses that guard without needing `--force` (which silences the check while the ambiguity is still real).
 
+This is worth preferring in practice, not just in principle: on a diverged tracker the guard fires on nearly every bare numeric call, and a guard that always fires trains callers to reach for `--force` by reflex — which disables it everywhere, including the cases it was written to catch. Reach for a selector (or the company name) instead.
+
 ### Bare numbers vs. explicit selectors
 
 - **Use a bare number** when tracker row IDs and report IDs are identical or when querying interactively.
 - **Use `--row N` or `--report N`** in automated scripts, modes, or whenever row IDs and report IDs have diverged to avoid triggering report-number mismatch guards or ambiguous updates. Use `--role` alongside a base selector to narrow down multiple matching roles for a company.
 
-Exit codes:
+Exit codes (the shared `CLI_EXIT` contract in `tracker-utils.mjs`, so these values are stable across every canonical tracker writer):
 
+- `0` success, including an idempotent no-op re-run that changed nothing.
 - `1` for an invalid or conflicting selector, or a non-canonical state.
 - `2` when the selector matches no tracker row.
-- `3` when a bare numeric selector triggers the report-number mismatch guard (`report-number-mismatch`).
+- `3` when a bare numeric selector triggers the report-number mismatch guard (`report-number-mismatch`), or a company matches several rows.
+- `4` when the shared tracker lock is busy — retryable, unlike the others.
+
+Nothing is written on any non-zero exit.
+
+To identify a row before writing to it, [find](#find) resolves a number, company, or role fragment to its full identity and surfaces collisions between the two numbering schemes rather than picking one silently.
 
 ## mark-pdf-ready.mjs
 


### PR DESCRIPTION
Closes #2355.

Adds a `## set-status` section to `docs/SCRIPTS.md` documenting the `--row` and `--report` selectors from #2347, and names them in the agent-invoked utilities table so they are discoverable from there too.

## Where it went

`set-status.mjs` had no prose section — only a row in the `## Agent-invoked utilities` table. Same situation as `verify-portals.mjs` when I documented `fix-slugs` in #2329. I put the new section immediately after that table, before `## stats.mjs`, since `stats.mjs` is also listed in the table and already has its own top-level section there. The table row now links to it.

## What the entry states

The two selectors, one example each, and the fact that on a diverged tracker the same number through the two flags writes to two different companies. Then the parts a reader would otherwise have to open the source for:

- They are mutually exclusive, and each **replaces** the positional selector rather than narrowing it, so a selector flag plus a positional company is rejected too.
- `--row`/`--report` skip the report-link mismatch guard without `--force`, and why that is not the same thing: they answer the ambiguity, `--force` suppresses the check while the ambiguity is still real. The script's header makes this point well and it seemed worth carrying into the docs, since it is the reason the flags exist rather than an implementation detail.
- When a bare number is still enough: counters that have not diverged, or a row whose report link agrees with its `#`.
- `--report` does not fall back to matching a report-less row by its tracker number.
- A pointer to `find`, which exists for this exact ambiguity.

## One correction to the issue text

The issue asks for "1 = invalid or conflicting selector, 2 = not found". Both are right, but the case the flags exist *for* — a bare ambiguous number — exits **3**, not 1. So the entry documents the full set rather than the two, since a reader hitting the guard would otherwise look up the wrong code.

## Verification

Semantics checked against the running script on a sandboxed tracker (`CAREER_OPS_TRACKER`) built to be diverged: row #5 Globex links report #4, row #6 Initech has no report, row #7 Acme links report #5.

```
bare 5 (ambiguous: row 5 vs report 5)          exit=3 written=no
--row 5 (tracker row -> Globex)                exit=0 written=YES
--report 5 (row linking report 5 -> Acme)      exit=0 written=YES
--row 7 (mismatched link, no --force)          exit=0 written=YES
--row 5 --report 5 (conflicting)               exit=1 written=no
--report 999 (nothing links it)                exit=2 written=no
--report 6 (row 6 has no report link)          exit=2 written=no
--row abc (non-numeric)                        exit=1 written=no
```

Every claim in the entry corresponds to a line above. The `--row 5` / `--report 5` pair landing on Globex and Acme respectively is the example used in the docs.

`node test-all.mjs --quick`: **2713 passed, 0 failed, 1 warning.** Identical to the same run on a clean checkout, and the warning is the pre-existing `cv-sync-check.mjs exited with error (expected without user data)`, which needs the user-layer `cv.md` a fresh clone does not have.

## Note, not part of this PR

`AGENTS.md` still tells agents to use `node set-status.mjs <report#|company> <State>` in the Pipeline Integrity rules and the main-files table. On a tracker whose counters have diverged, that bare-number form is the one the guard rejects with exit 3, so agents following the rule literally will hit it. Mentioning `--row`/`--report` there would close that gap, but AGENTS.md is outside what this issue asked for and is a behaviour-guidance file rather than documentation. Happy to open a separate issue or PR if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded status utility guidance for permanent tracker and report-number differences.
  * Clarified selector disambiguation and row lookup using `find`.
  * Documented automated-use recommendations, stable exit codes `0`–`4`, lock retry behavior, and non-zero write results.
  * Added details on validation, mismatch protection, ambiguity handling, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->