### PR TITLE
docs(SCRIPTS): document set-status --row/--report selectors

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -813,6 +813,27 @@ These have no `npm run` binding — modes and agents call them with
 
 ---
 
+## set-status.mjs
+
+Canonical tracker write path: strict `states.yml` validation, shared lock, atomic write. Modes and agents call this instead of hand-editing `applications.md`.
+
+```bash
+node set-status.mjs <report#|company> <state> [--note "..."] [--force] [--dry-run]
+node set-status.mjs --row N <state> [--note "..."]          # explicit tracker row ID
+node set-status.mjs --report N <state> [--note "..."]       # row whose Report cell links report #N
+```
+
+A bare number is ambiguous once tracker row IDs and report IDs diverge, so an explicit selector disambiguates which number space you mean:
+
+- `--row N` selects the row whose `#` cell is `N`.
+- `--report N` selects the row whose `Report` cell links report `N`.
+
+`--row` and `--report` are mutually exclusive. Because an explicit selector answers the report-mismatch guard rather than overriding it, `--row` bypasses that guard without needing `--force` (which silences the check while the ambiguity is still real).
+
+On bad input: exit `1` on an invalid or conflicting selector (or a non-canonical state), `2` when the selector matches no tracker row.
+
+---
+
 ## stats.mjs
 
 Aggregates lifetime pipeline stats into one JSON report. Stats include tracker, scanner, portals, follow-ups and runs. Reads from data/applications.md, data/scan-history.tsv, portals.yml, data/follow-ups.md and data/scan-runs.tsv. If a file doesn't exist yet, the section turns into null.

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -821,6 +821,8 @@ Canonical tracker write path: strict `states.yml` validation, shared lock, atomi
 node set-status.mjs <report#|company> <state> [--note "..."] [--force] [--dry-run]
 node set-status.mjs --row N <state> [--note "..."]          # explicit tracker row ID
 node set-status.mjs --report N <state> [--note "..."]       # row whose Report cell links report #N
+node set-status.mjs --row 12 Applied
+node set-status.mjs --report 345 Applied
 ```
 
 A bare number is ambiguous once tracker row IDs and report IDs diverge, so an explicit selector disambiguates which number space you mean:
@@ -830,7 +832,11 @@ A bare number is ambiguous once tracker row IDs and report IDs diverge, so an ex
 
 `--row` and `--report` are mutually exclusive. Because an explicit selector answers the report-mismatch guard rather than overriding it, `--row` bypasses that guard without needing `--force` (which silences the check while the ambiguity is still real).
 
-On bad input: exit `1` on an invalid or conflicting selector (or a non-canonical state), `2` when the selector matches no tracker row.
+Exit codes:
+
+- `1` for an invalid or conflicting selector, or a non-canonical state.
+- `2` when the selector matches no tracker row.
+- `3` when a bare numeric selector triggers the report-number mismatch guard (`report-number-mismatch`).
 
 ---
 


### PR DESCRIPTION
Fixes #2355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for using the status-setting script.
  - Documented supported row and report selectors, selector disambiguation rules, available options, and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->