### PR TITLE
Keep the checkpoint when a resolver outage stops a sweep

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -866,8 +866,9 @@ async function main() {
       // it can be up to 500 boards behind where the breaker actually stopped —
       // and --resume would replay all of them against the resolver that just
       // refused.
+      let checkpointWritten = false;
       if (!opts.dryRun) {
-        writeCheckpoint({
+        checkpointWritten = writeCheckpoint({
           ...checkpointBase(),
           current: { name, resumeAt: startAt + lastResumeAt, datasetLen: list.length, datasetHash },
           counters: snapshotCounters(),
@@ -878,8 +879,9 @@ async function main() {
       log(`     Lower CONCURRENCY, raise the resolver's per-client limit, or set`);
       log(`     CAREER_OPS_NO_DNS_CACHE=1 only if you know the cache is at fault.`);
       // Only claim resumability when a checkpoint actually exists: --dry-run
-      // writes none, and a failed write already said so on its own.
-      if (!opts.dryRun) log(`     Rerun with --resume once the resolver recovers — checkpointed at company ${startAt + lastResumeAt} of ${name}.`);
+      // writes none, and a failed write (ENOSPC, read-only volume) leaves at
+      // best the last periodic checkpoint — nothing at the offset named here.
+      if (checkpointWritten) log(`     Rerun with --resume once the resolver recovers — checkpointed at company ${startAt + lastResumeAt} of ${name}.`);
       break;
     }
     completedSources.add(name);
@@ -999,6 +1001,11 @@ async function main() {
       companiesAvailable: totalCompaniesAvailable,
       companiesScanned: totalCompaniesScanned,
       capHit,
+      // The most degraded outcome this payload can report: the sweep did not
+      // finish its sources, and a checkpoint is waiting for --resume. Without
+      // it a caller can't tell a stopped run from a complete one except by
+      // stat'ing the checkpoint file itself.
+      stoppedByOutage,
       datasetStatus,
       postingsKept: offers.length,
       postingsDroppedNoDate: droppedNoDate,

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -757,6 +757,10 @@ async function main() {
     let errors = 0;
     let consecutiveResolverFailures = 0;
     let resolverOutage = false;
+    // The board whose failure tripped the breaker. `name` is only the ATS
+    // vendor, and the resume offset is only a position — neither tells the user
+    // which board to try by hand once the resolver is back.
+    let resolverOutageCompany = null;
     // Latest progress reported by parallelEach. It computes both on every item
     // but keeps neither, and a run stopped mid-source needs them after the
     // call returns to checkpoint where it actually stopped (#2283).
@@ -787,7 +791,13 @@ async function main() {
         // the *consecutive* run tells them apart, so any non-resolver outcome
         // resets the count (#2229).
         if (isResolverFailure(err)) {
-          if (++consecutiveResolverFailures >= RESOLVER_FAILURE_LIMIT) resolverOutage = true;
+          // Record only the first board past the limit: in-flight boards keep
+          // failing after the flag is set, and the last of them is not the one
+          // that tripped it.
+          if (++consecutiveResolverFailures >= RESOLVER_FAILURE_LIMIT && !resolverOutage) {
+            resolverOutage = true;
+            resolverOutageCompany = entry.name;
+          }
         } else {
           consecutiveResolverFailures = 0;
         }
@@ -843,24 +853,27 @@ async function main() {
       // Deliberately before completedSources/checkpoint: this source did NOT
       // finish, and marking it done would make --resume skip the rest of it.
       stoppedByOutage = true;
+      // The counter was bumped by the FULL entries.length up front, but the
+      // breaker left entries.length - lastDone boards unattempted. Correct the
+      // live counter, not just the checkpoint payload: this run's own summary
+      // and --json would otherwise report companies nobody ever contacted as
+      // scanned. Correcting it here also gives the checkpoint the right figure
+      // for free — a resumed run re-adds its own slice, so a checkpoint holding
+      // the full slice makes the completed portion count twice.
+      totalCompaniesScanned -= entries.length - lastDone;
       // Pin the resume point here rather than leaving the last periodic write
       // to stand for it. That one fires every CHECKPOINT_EVERY companies, so
       // it can be up to 500 boards behind where the breaker actually stopped —
       // and --resume would replay all of them against the resolver that just
-      // refused. The counter correction mirrors the periodic write's: on
-      // resume the run re-adds its own slice, so a checkpoint must record only
-      // the work actually attempted or the completed portion is counted twice.
+      // refused.
       if (!opts.dryRun) {
         writeCheckpoint({
           ...checkpointBase(),
           current: { name, resumeAt: startAt + lastResumeAt, datasetLen: list.length, datasetHash },
-          counters: {
-            ...snapshotCounters(),
-            totalCompaniesScanned: totalCompaniesScanned - (entries.length - lastDone),
-          },
+          counters: snapshotCounters(),
         });
       }
-      log(`\n  ⛔ stopped ${name}: ${RESOLVER_FAILURE_LIMIT} consecutive DNS failures.`);
+      log(`\n  ⛔ stopped ${name}/${resolverOutageCompany}: ${RESOLVER_FAILURE_LIMIT} consecutive DNS failures.`);
       log(`     Your resolver is refusing queries — it may be rate-limiting this host.`);
       log(`     Lower CONCURRENCY, raise the resolver's per-client limit, or set`);
       log(`     CAREER_OPS_NO_DNS_CACHE=1 only if you know the cache is at fault.`);

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -717,6 +717,10 @@ async function main() {
     }
   };
 
+  // Run-level, because resolverOutage below is per-source and long out of
+  // scope by the time the checkpoint's fate is decided at the end of main().
+  let stoppedByOutage = false;
+
   for (const name of opts.ats) {
     const source = SOURCES[name];
     // Stats are accumulated BEFORE the completed-source skip: on --resume a
@@ -753,6 +757,11 @@ async function main() {
     let errors = 0;
     let consecutiveResolverFailures = 0;
     let resolverOutage = false;
+    // Latest progress reported by parallelEach. It computes both on every item
+    // but keeps neither, and a run stopped mid-source needs them after the
+    // call returns to checkpoint where it actually stopped (#2283).
+    let lastDone = 0;
+    let lastResumeAt = 0;
     const truncated = [];
     await parallelEach(entries, CONCURRENCY, async (entry) => {
       try {
@@ -785,6 +794,8 @@ async function main() {
         if (opts.verbose) console.error(`  ✗ ${name}/${entry.name}: ${err.message}`);
       }
     }, ({ done, resumeAt }) => {
+      lastDone = done;
+      lastResumeAt = resumeAt;
       if (done % 200 === 0 || done === entries.length) {
         progress(`  ${done}/${entries.length} scanned, ${newOffers.length} total matches\r`);
       }
@@ -831,10 +842,31 @@ async function main() {
     if (resolverOutage) {
       // Deliberately before completedSources/checkpoint: this source did NOT
       // finish, and marking it done would make --resume skip the rest of it.
+      stoppedByOutage = true;
+      // Pin the resume point here rather than leaving the last periodic write
+      // to stand for it. That one fires every CHECKPOINT_EVERY companies, so
+      // it can be up to 500 boards behind where the breaker actually stopped —
+      // and --resume would replay all of them against the resolver that just
+      // refused. The counter correction mirrors the periodic write's: on
+      // resume the run re-adds its own slice, so a checkpoint must record only
+      // the work actually attempted or the completed portion is counted twice.
+      if (!opts.dryRun) {
+        writeCheckpoint({
+          ...checkpointBase(),
+          current: { name, resumeAt: startAt + lastResumeAt, datasetLen: list.length, datasetHash },
+          counters: {
+            ...snapshotCounters(),
+            totalCompaniesScanned: totalCompaniesScanned - (entries.length - lastDone),
+          },
+        });
+      }
       log(`\n  ⛔ stopped ${name}: ${RESOLVER_FAILURE_LIMIT} consecutive DNS failures.`);
       log(`     Your resolver is refusing queries — it may be rate-limiting this host.`);
       log(`     Lower CONCURRENCY, raise the resolver's per-client limit, or set`);
       log(`     CAREER_OPS_NO_DNS_CACHE=1 only if you know the cache is at fault.`);
+      // Only claim resumability when a checkpoint actually exists: --dry-run
+      // writes none, and a failed write already said so on its own.
+      if (!opts.dryRun) log(`     Rerun with --resume once the resolver recovers — checkpointed at company ${startAt + lastResumeAt} of ${name}.`);
       break;
     }
     completedSources.add(name);
@@ -937,8 +969,10 @@ async function main() {
     }
   }
 
-  // Sweep completed — the checkpoint's job is done.
-  if (!opts.dryRun && existsSync(CHECKPOINT_PATH)) unlinkSync(CHECKPOINT_PATH);
+  // Sweep completed — the checkpoint's job is done. A run the breaker stopped
+  // did NOT complete: deleting here would destroy the resume point the outage
+  // branch just wrote, which is the one case --resume exists for (#2283).
+  if (!opts.dryRun && !stoppedByOutage && existsSync(CHECKPOINT_PATH)) unlinkSync(CHECKPOINT_PATH);
 
   // The authoritative machine-readable result: lets a caller (e.g. the web)
   // tell a *degraded* scan (capped / stale dataset / undated dropped) apart

--- a/tests/scan-ats-full-outage-checkpoint.test.mjs
+++ b/tests/scan-ats-full-outage-checkpoint.test.mjs
@@ -123,6 +123,20 @@ function sweep(dir, dnsCode, extraArgs = []) {
       } else {
         fail(`outage checkpoint unusable: incomplete=${incomplete} current=${JSON.stringify(cp.current)}`);
       }
+
+      // The interrupted run's own report must agree with what it checkpointed.
+      // greenhouse starts at offset 0 here, so every board below resumeAt was
+      // attempted and none above it was: the count it reports, the count it
+      // stored, and the resume point are all the same number. A counter left at
+      // the full slice shows up as companiesScanned > resumeAt — unattempted
+      // boards reported as scanned, and double-counted again on resume.
+      const reported = JSON.parse(out).companiesScanned;
+      const stored = cp.counters?.totalCompaniesScanned;
+      if (reported === at && stored === at) {
+        pass(`interrupted run counts only what it attempted (${reported} = checkpoint ${stored} = resumeAt ${at})`);
+      } else {
+        fail(`interrupted counters disagree: companiesScanned=${reported} checkpoint=${stored} resumeAt=${at}`);
+      }
     }
 
     // The point of keeping the file: --resume finishes the source, and the
@@ -135,10 +149,14 @@ function sweep(dir, dnsCode, extraArgs = []) {
         fail(`--resume after an outage stop failed${formatRunFailure()}`);
       } else {
         const { companiesScanned, resumed: wasResumed } = JSON.parse(resumed);
-        if (wasResumed && companiesScanned === COMPANIES) {
-          pass(`--resume continues the stopped source (${companiesScanned} scanned across both runs, no double count)`);
-        } else {
+        if (!wasResumed || companiesScanned !== COMPANIES) {
           fail(`resumed run miscounted: resumed=${wasResumed} companiesScanned=${companiesScanned}, expected ${COMPANIES}`);
+        } else if (existsSync(cpPath)) {
+          // The clean-sweep case below never reads a checkpoint, so it cannot
+          // catch a cleanup that only fails on the --resume path.
+          fail('a completed resumed sweep left its checkpoint behind');
+        } else {
+          pass(`--resume continues the stopped source (${companiesScanned} scanned across both runs, no double count)`);
         }
       }
     }

--- a/tests/scan-ats-full-outage-checkpoint.test.mjs
+++ b/tests/scan-ats-full-outage-checkpoint.test.mjs
@@ -130,12 +130,21 @@ function sweep(dir, dnsCode, extraArgs = []) {
       // stored, and the resume point are all the same number. A counter left at
       // the full slice shows up as companiesScanned > resumeAt — unattempted
       // boards reported as scanned, and double-counted again on resume.
-      const reported = JSON.parse(out).companiesScanned;
+      const result = JSON.parse(out);
       const stored = cp.counters?.totalCompaniesScanned;
-      if (reported === at && stored === at) {
-        pass(`interrupted run counts only what it attempted (${reported} = checkpoint ${stored} = resumeAt ${at})`);
+      if (result.companiesScanned === at && stored === at) {
+        pass(`interrupted run counts only what it attempted (${result.companiesScanned} = checkpoint ${stored} = resumeAt ${at})`);
       } else {
-        fail(`interrupted counters disagree: companiesScanned=${reported} checkpoint=${stored} resumeAt=${at}`);
+        fail(`interrupted counters disagree: companiesScanned=${result.companiesScanned} checkpoint=${stored} resumeAt=${at}`);
+      }
+
+      // A caller that reads only the JSON (the web UI does) must be able to
+      // tell a resumable stop from a finished sweep without stat'ing the
+      // checkpoint file itself.
+      if (result.stoppedByOutage === true) {
+        pass('--json reports the run as stopped by the resolver breaker');
+      } else {
+        fail(`--json hides the outage stop: stoppedByOutage=${result.stoppedByOutage}`);
       }
     }
 
@@ -175,8 +184,10 @@ function sweep(dir, dnsCode, extraArgs = []) {
       fail(`clean sweep did not complete${formatRunFailure()}`);
     } else if (existsSync(cpPath)) {
       fail('a completed sweep left its checkpoint behind — the next run will demand --resume');
+    } else if (JSON.parse(out).stoppedByOutage !== false) {
+      fail(`a completed sweep reported stoppedByOutage=${JSON.parse(out).stoppedByOutage}`);
     } else {
-      pass('a completed sweep still deletes its checkpoint');
+      pass('a completed sweep still deletes its checkpoint and reports no outage stop');
     }
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/tests/scan-ats-full-outage-checkpoint.test.mjs
+++ b/tests/scan-ats-full-outage-checkpoint.test.mjs
@@ -1,0 +1,166 @@
+// tests/scan-ats-full-outage-checkpoint.test.mjs — a sweep stopped by the
+// resolver circuit breaker must LEAVE its checkpoint on disk, and leave it
+// pointing at where the sweep actually stopped (#2283).
+//
+// The end of main() deletes the checkpoint unconditionally ("sweep completed —
+// the checkpoint's job is done"), and the outage `break` falls straight into
+// that exit path, so the stop deliberately designed to be resumable destroyed
+// the only file `--resume` reads.
+//
+// Driven end-to-end in a child process rather than against an exported helper:
+// the bug is not in any single function but in the interaction between the
+// breaker, the checkpoint writer, and the exit path, and only a whole run
+// exercises all three. The child runs in a sandbox cwd (every path
+// scan-ats-full.mjs touches is relative) with a stubbed `dns.lookup`, so no
+// network is involved and the resolver's behaviour is exact:
+//
+//   EAI_AGAIN  — a resolver-level failure; trips the breaker  → checkpoint kept
+//   ENOTFOUND  — NXDOMAIN, an ordinary dead board; no outage  → checkpoint deleted
+//
+// The ENOTFOUND arm is load-bearing. Without it a fix that simply never
+// deleted the checkpoint would pass, and every clean sweep would leave a stale
+// file behind that makes the next run warn and demand --resume.
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { pass, fail, run, formatRunFailure, NODE, ROOT } from './helpers.mjs';
+
+console.log('\nscan-ats-full — a resolver-outage stop keeps its checkpoint (#2283)');
+
+// Comfortably above RESOLVER_FAILURE_LIMIT (50) so the breaker trips with
+// companies still unscanned, and comfortably below CHECKPOINT_EVERY (500) so
+// the periodic checkpoint writer never fires. Any checkpoint on disk at the
+// end of the outage arm therefore came from the outage path itself.
+const COMPANIES = 120;
+const CHECKPOINT_REL = join('data', 'cache', 'ats-full-checkpoint.json');
+
+/**
+ * Build a sandbox cwd holding everything a greenhouse-only sweep reads, plus
+ * the launcher that stubs DNS before scan-ats-full.mjs loads.
+ *
+ * @returns {string} Sandbox directory.
+ */
+function makeSandbox() {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-outage-'));
+  // Minimal portals.yml: main() exits early without one. The filters never
+  // matter here — no board is reachable, so no posting reaches them.
+  writeFileSync(join(dir, 'portals.yml'), 'title_filter:\n  positive:\n    - director\n', 'utf-8');
+
+  // A fresh dataset cache means loadCompanyList() returns these slugs instead
+  // of downloading the real 8k-company directory.
+  mkdirSync(join(dir, 'data', 'cache', 'ats-companies'), { recursive: true });
+  writeFileSync(
+    join(dir, 'data', 'cache', 'ats-companies', 'greenhouse.json'),
+    JSON.stringify(Array.from({ length: COMPANIES }, (_, i) => `sandbox-co-${i}`)),
+    'utf-8',
+  );
+
+  // Launcher: patch dns.lookup, then import the scanner. providers/_dns-cache.mjs
+  // captures the real lookup at ITS import time and net.connect reads
+  // dns.lookup at call time, so patching first makes the stub the resolver for
+  // the whole run. Overwriting argv[1] is what makes scan-ats-full.mjs's
+  // "invoked directly?" guard fire under an importing parent — preferred over
+  // a --import preload so the test runs on any Node the project supports.
+  const scanUrl = pathToFileURL(join(ROOT, 'scan-ats-full.mjs')).href;
+  writeFileSync(join(dir, 'launch.mjs'), `
+import dns from 'node:dns';
+const code = process.env.STUB_DNS_CODE;
+dns.lookup = (hostname, options, callback) => {
+  const cb = typeof options === 'function' ? options : callback;
+  const err = new Error('getaddrinfo ' + code + ' ' + hostname);
+  err.code = code;
+  err.syscall = 'getaddrinfo';
+  err.hostname = hostname;
+  process.nextTick(cb, err);
+};
+process.argv[1] = ${JSON.stringify(join(ROOT, 'scan-ats-full.mjs'))};
+await import(${JSON.stringify(scanUrl)});
+`, 'utf-8');
+  return dir;
+}
+
+/**
+ * Run one sandboxed sweep to completion.
+ *
+ * @param {string} dir - Sandbox directory.
+ * @param {string} dnsCode - Error code every dns.lookup call fails with.
+ * @param {string[]} [extraArgs=[]] - Additional scanner flags.
+ * @returns {string|null} Trimmed stdout, or null when the child failed.
+ */
+function sweep(dir, dnsCode, extraArgs = []) {
+  return run(NODE, [join(dir, 'launch.mjs'), '--ats', 'greenhouse', '--json', ...extraArgs], {
+    cwd: dir,
+    // Pacing would only add wall-clock time to a run whose every lookup fails.
+    env: { ...process.env, STUB_DNS_CODE: dnsCode, CAREER_OPS_DNS_LOOKUPS_PER_MIN: '0' },
+    timeout: 120_000,
+  });
+}
+
+// --- a resolver outage leaves a resumable checkpoint, and --resume uses it ---
+{
+  const dir = makeSandbox();
+  try {
+    const out = sweep(dir, 'EAI_AGAIN');
+    const cpPath = join(dir, CHECKPOINT_REL);
+    let resumeAt = null;
+    if (out === null) {
+      fail(`outage sweep did not complete${formatRunFailure()}`);
+    } else if (!existsSync(cpPath)) {
+      fail('a resolver-outage stop deleted its own checkpoint — --resume has nothing to read');
+    } else {
+      const cp = JSON.parse(readFileSync(cpPath, 'utf-8'));
+      // The source must NOT be marked complete, or --resume skips the rest of it.
+      const incomplete = !(cp.completedSources || []).includes('greenhouse');
+      // resumeAt is parallelEach's lowest unfinished index: everything below it
+      // is done, so a resumed run neither skips nor redoes completed boards.
+      const at = cp.current?.resumeAt;
+      const usable = cp.current?.name === 'greenhouse'
+        && Number.isInteger(at) && at > 0 && at < COMPANIES;
+      if (incomplete && usable) {
+        resumeAt = at;
+        pass(`outage checkpoint survives and resumes at ${at}/${COMPANIES} with greenhouse still open`);
+      } else {
+        fail(`outage checkpoint unusable: incomplete=${incomplete} current=${JSON.stringify(cp.current)}`);
+      }
+    }
+
+    // The point of keeping the file: --resume finishes the source, and the
+    // company count comes out at COMPANIES rather than COMPANIES + resumeAt.
+    // A checkpoint that stored the full slice instead of the attempted part
+    // would double-count the portion the first run completed.
+    if (resumeAt !== null) {
+      const resumed = sweep(dir, 'ENOTFOUND', ['--resume']);
+      if (resumed === null) {
+        fail(`--resume after an outage stop failed${formatRunFailure()}`);
+      } else {
+        const { companiesScanned, resumed: wasResumed } = JSON.parse(resumed);
+        if (wasResumed && companiesScanned === COMPANIES) {
+          pass(`--resume continues the stopped source (${companiesScanned} scanned across both runs, no double count)`);
+        } else {
+          fail(`resumed run miscounted: resumed=${wasResumed} companiesScanned=${companiesScanned}, expected ${COMPANIES}`);
+        }
+      }
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// --- a sweep that merely hit dead boards still cleans up after itself ---
+{
+  const dir = makeSandbox();
+  try {
+    const out = sweep(dir, 'ENOTFOUND');
+    const cpPath = join(dir, CHECKPOINT_REL);
+    if (out === null) {
+      fail(`clean sweep did not complete${formatRunFailure()}`);
+    } else if (existsSync(cpPath)) {
+      fail('a completed sweep left its checkpoint behind — the next run will demand --resume');
+    } else {
+      pass('a completed sweep still deletes its checkpoint');
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
# Keep the checkpoint when a resolver outage stops a sweep

Closes #2283.

The breaker added in #2266 stops a sweep mid-source and deliberately does *not* mark the source complete, so `--resume` can finish it. Then the exit path at the end of `main()` deletes the checkpoint unconditionally — the outage `break` falls straight into it, so the stop designed to be resumable destroys the only file `--resume` reads. On a 12k-tenant sweep that is hours of work discarded by the recovery mechanism itself.

## What changed

**1. The unlink is now conditional.** `resolverOutage` is per-source and out of scope by the time the checkpoint's fate is decided, so a run-level `stoppedByOutage` carries the signal to the exit path.

**2. The outage branch writes a final checkpoint before breaking.** Without it the surviving file is whatever the periodic writer last produced — up to `CHECKPOINT_EVERY` = 500 boards behind where the breaker actually stopped, and `--resume` would replay all of them against the resolver that just refused. Below 500 companies the periodic writer never fires at all, so there was nothing to survive in the first place.

The resume point is `parallelEach`'s last reported `resumeAt` — the lowest unfinished index, which the callback already computes but nobody retained after the call returned.

**3. Counters are corrected the same way the periodic write corrects them.** `totalCompaniesScanned` is bumped by the full `entries.length` up front; a checkpoint must store only work actually attempted, or the resumed run re-adds its own slice on top and double-counts the completed portion. Verified by mutation: dropping the correction makes the resumed run report 180 companies scanned for a 120-company dataset.

**4. One line added to the outage message** pointing at `--resume` and naming the company it stopped at, gated on `!--dry-run` so it can't promise a checkpoint that was never written.

## Test

`tests/scan-ats-full-outage-checkpoint.test.mjs`, driven end-to-end in a child process. The bug lives in the interaction between the breaker, the checkpoint writer and the exit path, so no single exported helper can show it.

The child runs in a sandbox cwd (every path `scan-ats-full.mjs` touches is relative) with `dns.lookup` stubbed before `providers/_dns-cache.mjs` captures it, which makes the resolver's behaviour exact and the test fully offline:

- `EAI_AGAIN` — a resolver-level failure; trips the breaker → checkpoint must survive
- `ENOTFOUND` — NXDOMAIN, an ordinary dead board; no outage → checkpoint must still be deleted

120 companies: above `RESOLVER_FAILURE_LIMIT` (50) so the breaker trips with work left, below `CHECKPOINT_EVERY` (500) so the periodic writer never fires and any surviving file provably came from the new path.

Three assertions: the checkpoint survives with `greenhouse` still open and a usable `resumeAt`; a following `--resume` finishes the source at exactly 120 companies scanned across both runs; and a clean sweep still deletes its checkpoint. That last arm is load-bearing — without it, a "fix" that simply never deleted the checkpoint would pass, and every clean sweep would leave a stale file behind that makes the next run warn and demand `--resume`.

Instead of a `--import` preload the launcher patches `dns.lookup` and then overwrites `process.argv[1]` before importing the scanner, so the direct-invocation guard still fires and the test needs no flag that constrains the Node version.

## Deliberately not included

After the outage `break`, the in-run summary still reports the full `entries.length` for the stopped source even though only part of it was attempted (the test's own run prints `Companies scanned: 120` after stopping at 60). That is the report, not the resume point, and it predates this change — it looks like its own issue rather than scope creep here. Happy to fold it in if you'd rather.

Likewise `--json` still carries no "this run was cut short" flag; a machine consumer can only infer it from the counts. Say the word if that belongs here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan recovery when a resolver outage interrupts a sweep.
  * Checkpoints now preserve the exact interruption point and accurate progress counts.
  * Resume instructions are shown only when recovery is available.
  * Completed scans clean up checkpoints while interrupted scans retain them.
  * Added validation to ensure interrupted scans can resume without duplicate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->