### PR TITLE
fix(web): let the pipeline table scroll horizontally instead of clipping on narrow screens

### DIFF
--- a/web/src/components/pipeline-view.tsx
+++ b/web/src/components/pipeline-view.tsx
@@ -117,7 +117,7 @@ export function PipelineView({
   }, [applications, tab, q, sort, minFilter]);
 
   return (
-    <div className="mx-auto max-w-6xl px-6 py-8 max-sm:pb-24">
+    <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 sm:py-8 max-sm:pb-24">
       <div className="flex items-end justify-between gap-4">
         <div>
           <h1 className="font-display text-2xl tracking-tight text-landing">Pipeline</h1>
@@ -189,15 +189,19 @@ export function PipelineView({
           <InboxEmpty count={0} filtered={false} />
         )
       ) : filtered.length > 0 ? (
-        /* ── Tracker table ── */
-        <div className="mt-4 overflow-hidden rounded-2xl border border-border">
-          <table className="w-full text-sm">
+        /* ── Tracker table ──
+           overflow-x-auto, not overflow-hidden: the rounded corners still clip,
+           but a table too wide for the viewport can now be scrolled to instead
+           of being silently cut off. min-w keeps the columns readable rather
+           than letting w-full crush them on a phone. */
+        <div className="mt-4 overflow-x-auto rounded-2xl border border-border">
+          <table className="w-full min-w-[44rem] text-sm">
             <thead className="bg-surface/60 text-left text-xs uppercase tracking-wide text-faint">
               <tr>
                 {SORT_KEYS.map((k) => (
                   <th
                     key={k}
-                    className="cursor-pointer select-none px-4 py-2.5 font-medium hover:text-foreground"
+                    className="cursor-pointer select-none whitespace-nowrap px-4 py-2.5 font-medium hover:text-foreground"
                     onClick={() => setParams({ sort: k, dir: sort.key === k ? sort.dir * -1 : -1 })}
                   >
                     <span className="inline-flex items-center gap-1">
@@ -223,13 +227,13 @@ export function PipelineView({
                   <td className="px-4 py-3">
                     <Badge tone={scoreTone(r.score)}>{r.score || "—"}</Badge>
                   </td>
-                  <td className="px-4 py-3 text-muted">
+                  <td className="whitespace-nowrap px-4 py-3 text-muted">
                     <span className="inline-flex items-center gap-1.5">
                       <span className={cn("size-1.5 shrink-0 rounded-full", statusDot(r.status))} />
                       {r.status}
                     </span>
                   </td>
-                  <td className="px-4 py-3 text-faint tabular-nums">{r.date}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-faint tabular-nums">{r.date}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## What breaks

On a narrow viewport the tracker table on `/pipeline` is partly unreachable. Reported from an Android phone: the right-hand columns "can't even be clicked through", and the page padding eats a lot of the screen.

Measured at a 360px viewport on `main`, with the tracker table rendered:

| | `main` | this PR |
|---|---|---|
| wrapper `overflow-x` | `hidden` | `auto` |
| table content width | 508px | 704px |
| visible width | 295px | 311px |
| unreachable | **213px, no way to scroll to it** | 0 — scrolls |
| Role cell width | 97px (3-line wrap) | readable |
| row height | 85px | 65px |
| container padding | 48px (13% of the screen) | 32px |

## Why

The table wrapper carries `overflow-hidden`. That class is there to clip the `rounded-2xl` corners, but it also clips horizontally, so anything wider than the viewport is cut off with no scrollbar and no gesture to reach it. Combined with `w-full` on the table, the browser's only remaining option is to crush the columns — Role collapses to 97px and wraps over three lines rather than overflowing.

`overflow-x-auto` keeps the corner clipping (per CSS, when one axis is not `visible` the other computes to `auto`, so the wrapper is still a clipping context — verified: `border-radius` stays 16px and the corners render identically), while making the overflow reachable.

## What changed

`web/src/components/pipeline-view.tsx` only, CSS classes only:

- wrapper `overflow-hidden` → `overflow-x-auto`
- table `w-full` → `w-full min-w-[44rem]`, so columns keep a readable width and overflow instead of being crushed
- page container `px-6 py-8` → `px-4 py-6 sm:px-6 sm:py-8`
- `whitespace-nowrap` on the sort headers and the status/date cells, so rows stay one line now that horizontal scrolling exists

## Verification

- `npx tsc --noEmit` clean
- `npm test` in `web/` — 31/31 pass
- Measured in a real `next dev` render at 360px and 1280px (numbers above)
- Desktop unregressed at 1280px: no scrollbar appears (content 975px = container 975px), padding returns to 24px/32px at the `sm:` breakpoint, row height and corner radius unchanged

## Scope

I grepped `web/src` for the same `overflow-hidden` + scrollable-content pattern (19 hits for `overflow-hidden rounded`). The rest are legitimate: progress bars and meters, and gradient/`dot-bg` cards where clipping to the radius is the point. The `<ul>` lists in `jobs/page.tsx` and `portals-view.tsx` use `truncate`/`min-w-0`, so they shrink rather than overflow. The `<details>` blocks in `report-view.tsx` render markdown, but `.report-prose pre` already sets its own `overflow-x: auto` and `.report-prose td` sets `word-break: break-word`, so nothing is trapped there. This PR is the one file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved pipeline layout responsiveness on smaller screens.
  * Added horizontal scrolling for the tracker table when needed.
  * Prevented headers, status, and date fields from wrapping for clearer display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->