### PR TITLE
fix: git-ignore article-digest.md and guard the user-layer list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Personal data (user fills these)
 cv.md
+article-digest.md
 local/
 # Everything under data/ is generated or personal at runtime — only .gitkeep
 # placeholders are tracked (verify with `git ls-files data/`). A blanket rule

--- a/tests/user-layer-gitignored.test.mjs
+++ b/tests/user-layer-gitignored.test.mjs
@@ -1,0 +1,49 @@
+// tests/user-layer-gitignored.test.mjs
+//
+// AGENTS.md declares a User Layer: the files a candidate fills with their own
+// personal data. Every one of those paths must be git-ignored, or a contributor
+// working in a fork can stage their own CV, proof points or tracker into a public
+// repository with a reflexive `git add .`.
+//
+// article-digest.md drifted off .gitignore while remaining on the AGENTS.md list.
+// This test compares the two lists directly so they cannot diverge again.
+
+import { execFileSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { pass, fail, finish, ROOT } from './helpers.mjs';
+
+console.log('\n🔒 user-layer files are git-ignored');
+
+// Pull the declared user-layer paths straight out of AGENTS.md so the test tracks
+// the document rather than a hand-copied duplicate of it.
+const agents = readFileSync(join(ROOT, 'AGENTS.md'), 'utf-8');
+const line = agents.split(/\r?\n/).find(l => l.includes('**User Layer'));
+
+if (!line) {
+  fail('AGENTS.md no longer contains a "**User Layer" line — update this test');
+} else {
+  // Backtick-quoted paths, minus the glob suffix: `data/*` -> data/
+  const paths = [...line.matchAll(/`([^`]+)`/g)]
+    .map(m => m[1])
+    .map(p => (p.endsWith('/*') ? `${p.slice(0, -1)}` : p));
+
+  if (paths.length === 0) fail('parsed no paths from the AGENTS.md user-layer line');
+  else pass(`parsed ${paths.length} user-layer paths from AGENTS.md`);
+
+  for (const p of paths) {
+    // A directory glob is satisfied by a probe file inside it; a bare filename
+    // is checked directly. check-ignore exits 1 when the path is NOT ignored.
+    const probe = p.endsWith('/') ? `${p}__gitignore_probe__.md` : p;
+    let ignored = true;
+    try {
+      execFileSync('git', ['check-ignore', '-q', '--no-index', probe], { cwd: ROOT });
+    } catch {
+      ignored = false;
+    }
+    if (ignored) pass(`${p} is git-ignored`);
+    else fail(`${p} is declared user-layer in AGENTS.md but is NOT git-ignored — personal data could be committed`);
+  }
+}
+
+finish();


### PR DESCRIPTION
Closes #2364

## What

Adds `article-digest.md` to `.gitignore`, plus a test that keeps the user-layer list and `.gitignore` from drifting apart again.

## Why

`AGENTS.md` declares `article-digest.md` part of the **User Layer** — the files a candidate fills with their own personal data. It was the only entry on that list missing from `.gitignore`, so it sat untracked in the working tree where `git add .` would stage it.

| User-layer file (per `AGENTS.md`) | In `.gitignore` before this PR |
|---|---|
| `cv.md` | yes |
| `config/profile.yml` | yes |
| `modes/_profile.md` | yes |
| `modes/_custom.md` | yes |
| `portals.yml` | yes |
| `data/*`, `reports/*`, `output/*`, `interview-prep/*` | yes |
| **`article-digest.md`** | **no** |

The exposure lands hardest on contributors. Anyone who forks career-ops to send a PR is working in a repo pointed at a public remote, with their own proof points, metrics and employer details stageable. The failure is silent, and the file is one of the most personal in the layout after `cv.md` — the modes are explicitly told to put detailed proof points there.

I hit this while preparing #2343. My own `article-digest.md` was the sole untracked file in the tree.

## How

**`.gitignore`** — one line, placed next to `cv.md` under the existing `# Personal data (user fills these)` heading.

**`tests/user-layer-gitignored.test.mjs`** — parses the backtick-quoted paths straight out of the `**User Layer` line in `AGENTS.md` and asserts each is git-ignored. It tracks the document rather than duplicating the list, so adding a future user-layer file to `AGENTS.md` without a matching `.gitignore` entry fails the suite.

Directory globs (`data/*`) are checked with a probe path inside the directory; bare filenames are checked directly. `--no-index` so the check works whether or not a file exists yet on a given machine.

## Verification

The test genuinely detects the bug rather than passing vacuously. With the `.gitignore` line removed:

```
❌ article-digest.md is declared user-layer in AGENTS.md but is NOT git-ignored — personal data could be committed
📊 Results: 10 passed, 1 failed, 0 warnings
```

Restored:

```
✅ article-digest.md is git-ignored
📊 Results: 11 passed, 0 failed, 0 warnings
```

Full suite:

```
node test-all.mjs
📊 Results: 2728 passed, 0 failed, 0 warnings
```

## Note for existing users

This only stops *future* commits. Anyone who already committed an `article-digest.md` will need `git rm --cached article-digest.md` to untrack it. Worth a line in release notes if you think it is warranted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure declared User Layer paths are properly excluded from version control.
  * Improved reporting for missing, invalid, ignored, and unignored paths.

* **Chores**
  * Excluded the generated article digest file from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->