### PR TITLE
fix(tests): find Git Bash under Scoop, and name the fallback shell when it fails

### DIFF
--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -75,9 +75,41 @@ export function finish() {
 // to the OS), so a test can never be tricked into executing an arbitrary
 // binary — and CodeQL's uncontrolled-command-line finding is closed by
 // construction rather than dismissed (alerts #36/#41/#42).
+// Scoop installs Git for Windows under the user profile, not Program Files, so
+// a Program-Files-only list misses it entirely and getBash() falls through to
+// WSL bash. That fallback launches the script but not the environment: WSL has
+// its own PATH, so the Windows `node` (and any stub binary a test injects via
+// PATH) is invisible, and batch-runner.sh dies with `node: command not found`,
+// exit 127. run() converts that to null, the caller does `|| ''`, and the
+// assertion reports an empty argv -- which reads as a routing bug in the code
+// under test rather than a missing shell. That is what all five spend_tier
+// tests were doing on a machine where Git Bash was installed the whole time
+// (#2344).
+//
+// Kept as fixed-shape literals joined onto %USERPROFILE% / %SCOOP% rather than
+// a PATH search, so this stays an allowlist of trusted literals (see
+// resolveAllowedExecutable below and CodeQL alerts #36/#41/#42).
+const SCOOP_ROOTS = [
+  process.env.SCOOP,
+  process.env.USERPROFILE ? join(process.env.USERPROFILE, 'scoop') : null,
+].filter(Boolean);
+
 const WINDOWS_BASH_CANDIDATES = [
   'C:\\Program Files\\Git\\bin\\bash.exe',
   'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
+  ...SCOOP_ROOTS.flatMap((root) => [
+    join(root, 'apps', 'git', 'current', 'bin', 'bash.exe'),
+    join(root, 'apps', 'git', 'current', 'usr', 'bin', 'bash.exe'),
+  ]),
+];
+
+// Same discovery problem, same fix: cygpath must come from the SAME Git
+// install as the bash above. Mixing them is #1409 in reverse -- cygpath emits
+// /c/... while WSL bash expects /mnt/c/..., so the path silently fails to
+// resolve inside the shell that receives it.
+const WINDOWS_CYGPATH_CANDIDATES = [
+  'C:\\Program Files\\Git\\usr\\bin\\cygpath.exe',
+  ...SCOOP_ROOTS.map((root) => join(root, 'apps', 'git', 'current', 'usr', 'bin', 'cygpath.exe')),
 ];
 
 /**
@@ -239,7 +271,7 @@ export function toBashPath(wpath) {
   try {
     // execFileSync: the path is passed as an argv element, never interpolated
     // into a shell string, so quotes/spaces in it can't be re-parsed.
-    const cygpathCmd = existsSync('C:\\Program Files\\Git\\usr\\bin\\cygpath.exe') ? 'C:\\Program Files\\Git\\usr\\bin\\cygpath.exe' : 'cygpath';
+    const cygpathCmd = WINDOWS_CYGPATH_CANDIDATES.find((p) => existsSync(p)) || 'cygpath';
     const out = execFileSync(cygpathCmd, ['-u', forwardSlashed], { stdio: ['pipe', 'pipe', 'ignore'] }).toString().trim();
     if (out) return out;
   } catch {}

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -171,6 +171,7 @@ export function run(cmd, args = [], opts = {}) {
       stdout: e?.stdout == null ? '' : String(e.stdout),
       stderr: e?.stderr == null ? '' : String(e.stderr),
     };
+    warnFallbackShell(exe);
     return null;
   }
 }
@@ -222,6 +223,65 @@ export function formatRunFailure(maxChars = 2000) {
 export function fileExists(path) { return existsSync(join(ROOT, path)); }
 
 let bashCache = null;
+let bashSourceCache = null;
+
+/**
+ * Which probe in getBash() produced the current bash, or null before the first
+ * getBash() call.
+ *
+ * getBash() returns the bare string 'bash' from three different branches -- the
+ * WSL probe, the PATH probe, and the give-up path -- so its return value alone
+ * cannot tell a caller which shell it is about to run. On Windows those are not
+ * interchangeable: 'bash' via WSL is a different OS with a different PATH and a
+ * different mount scheme (/mnt/c/... vs /c/...). Recording the branch is what
+ * lets a failure name the shell instead of leaving the reader to infer it
+ * (#2344).
+ *
+ * @returns {'posix'|'git-bash'|'wsl'|'path'|'unresolved'|null} Resolution source.
+ */
+export function bashSource() { return bashSourceCache; }
+
+/** Sources whose shell is ambiguous or foreign, and worth naming on failure. */
+const FALLBACK_BASH_SOURCES = new Set(['wsl', 'path', 'unresolved']);
+
+let warnedFallbackShell = false;
+
+/**
+ * Say out loud, once per process, that a failing shell command ran in a
+ * fallback shell rather than Git Bash.
+ *
+ * Unconditional by design. formatRunFailure() already surfaces the child's
+ * stderr to callers that ask for it, but the shell that produced it is still
+ * invisible, and the whole failure mode of #2344 is that nobody suspects the
+ * shell: it is missing, the script dies at `node`, run() returns null, `|| ''`
+ * turns that into an empty string, and the assertion accuses the code under
+ * test of a routing bug it does not have.
+ *
+ * Two things keep this from becoming noise in the suites that provoke command
+ * failures on purpose. It fires only when getBash() landed on a fallback -- a
+ * Git Bash resolved by literal path is unambiguous and stays silent, which is
+ * every correctly provisioned machine -- and it fires at most once per process.
+ *
+ * @param {string} exe - Executable that just failed.
+ * @returns {void}
+ */
+function warnFallbackShell(exe) {
+  if (warnedFallbackShell) return;
+  if (bashCache === null || exe !== bashCache) return;
+  if (!FALLBACK_BASH_SOURCES.has(bashSourceCache)) return;
+  warnedFallbackShell = true;
+  const where = {
+    wsl: 'WSL bash (`wsl -e bash`) -- a different OS with its own PATH',
+    path: '`bash` from PATH, provenance unknown',
+    unresolved: '`bash`, which no probe could confirm exists',
+  }[bashSourceCache];
+  console.error(`    [shell] this command ran under ${where},`);
+  console.error('            because no Git Bash was found at any known location.');
+  console.error('            The Windows `node` and any PATH-injected stub binary may be invisible there,');
+  console.error('            so scripts calling node die with `node: command not found` (exit 127) and the');
+  console.error('            assertion sees an empty result. Suspect the shell before the code under test.');
+  console.error('            Install Git for Windows, or see formatRunFailure() for the raw stderr.');
+}
 
 /**
  * Resolve the bash executable to use for shell-script checks, lazily.
@@ -236,24 +296,28 @@ let bashCache = null;
  */
 export function getBash() {
   if (bashCache !== null) return bashCache;
-  if (process.platform !== 'win32') return (bashCache = 'bash');
+  if (process.platform !== 'win32') { bashSourceCache = 'posix'; return (bashCache = 'bash'); }
   for (const cmd of WINDOWS_BASH_CANDIDATES) {
     try {
       execFileSync(cmd, ['-c', 'true'], { stdio: 'ignore' });
+      bashSourceCache = 'git-bash';
       return (bashCache = cmd);
     } catch {}
   }
   try {
     // Probe via argv vector — no shell string, nothing to interpolate.
     execFileSync('wsl', ['-e', 'bash', '-c', 'true'], { stdio: 'ignore' });
+    bashSourceCache = 'wsl';
     return (bashCache = 'bash');
   } catch {}
   for (const cmd of ['bash']) {
     try {
       execFileSync(cmd, ['-c', 'true'], { stdio: 'ignore' });
+      bashSourceCache = 'path';
       return (bashCache = cmd);
     } catch {}
   }
+  bashSourceCache = 'unresolved';
   return (bashCache = 'bash');
 }
 

--- a/tests/shell-discovery.test.mjs
+++ b/tests/shell-discovery.test.mjs
@@ -1,0 +1,56 @@
+// Covers the shell-discovery half of #2344: getBash() returns the bare string
+// 'bash' from three different branches, so its return value alone cannot tell
+// a caller which shell is about to run. bashSource() records the branch, and
+// run() names a fallback shell out loud when a command under it fails.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'fs';
+import { getBash, bashSource, run, lastRunFailure } from './helpers.mjs';
+
+const SOURCES = ['posix', 'git-bash', 'wsl', 'path', 'unresolved'];
+
+test('bashSource() is null until getBash() has resolved', () => {
+  // Import order matters here: nothing above may call getBash() first.
+  assert.equal(bashSource(), null);
+  getBash();
+  assert.ok(SOURCES.includes(bashSource()), `unexpected source: ${bashSource()}`);
+});
+
+test('resolution is memoized and the source stays consistent with it', () => {
+  const first = getBash();
+  const source = bashSource();
+  assert.equal(getBash(), first);
+  assert.equal(bashSource(), source);
+});
+
+test('a literal-path bash is reported as git-bash and actually exists', () => {
+  const bash = getBash();
+  if (bash === 'bash') {
+    // Fallback shell — the branch this test is not about.
+    assert.notEqual(bashSource(), 'git-bash');
+    return;
+  }
+  assert.equal(bashSource(), 'git-bash');
+  assert.ok(existsSync(bash), `getBash() returned a path that does not exist: ${bash}`);
+});
+
+test('on posix the source says so, on win32 it never does', () => {
+  getBash();
+  if (process.platform === 'win32') assert.notEqual(bashSource(), 'posix');
+  else assert.equal(bashSource(), 'posix');
+});
+
+test('a failing shell command exposes its real exit status instead of a bare null', () => {
+  // The #2344 symptom was `run(...) || ''` turning exit 127 into an empty
+  // string that the assertion blamed on the code under test.
+  const out = run(getBash(), ['-c', 'exit 7']);
+  assert.equal(out, null);
+  const failure = lastRunFailure();
+  assert.ok(failure, 'lastRunFailure() lost the failure');
+  assert.equal(failure.status, 7);
+});
+
+test('lastRunFailure() clears after a command succeeds', () => {
+  assert.equal(run(getBash(), ['-c', 'echo ok']), 'ok');
+  assert.equal(lastRunFailure(), null);
+});


### PR DESCRIPTION
Fixes #2344. Both halves you asked for, in two commits.

## 1. Find the Git Bash that is actually installed

`WINDOWS_BASH_CANDIDATES` and the `cygpath` probe both hardcoded the Program Files layout. Scoop installs Git for Windows under the user profile, so on a Scoop machine both probes miss a Git Bash that is present and `getBash()` falls through to WSL.

Adds `%SCOOP%`, else `%USERPROFILE%\scoop`, as roots for both `bash` and `cygpath`. They stay fixed-shape literals joined onto those roots rather than a PATH search, so the list remains an allowlist of trusted literals for `resolveAllowedExecutable` (CodeQL #36/#41/#42).

`cygpath` is resolved from the same candidate set as `bash` on purpose: mixing a Program Files `cygpath` with a WSL `bash` is #1409 in reverse, since `/c/...` and `/mnt/c/...` are not interchangeable.

## 2. Say which shell it picked

`getBash()` returns the bare string `bash` from three branches — WSL, PATH, and give-up — so the return value alone cannot tell a caller which shell is about to run. It now records which probe won (`posix` / `git-bash` / `wsl` / `path` / `unresolved`), exported as `bashSource()`, and `run()` names the shell when a command fails under one of the fallbacks:

```
    [shell] this command ran under WSL bash (`wsl -e bash`) -- a different OS with its own PATH,
            because no Git Bash was found at any known location.
            The Windows `node` and any PATH-injected stub binary may be invisible there,
            so scripts calling node die with `node: command not found` (exit 127) and the
            assertion sees an empty result. Suspect the shell before the code under test.
            Install Git for Windows, or see formatRunFailure() for the raw stderr.
```

**Why unconditional rather than behind a flag.** `formatRunFailure()` already surfaces the child's stderr to callers that ask for it, but the shell that produced it stays invisible, and the entire failure mode of #2344 is that nobody suspects the shell. A flag only helps someone who already does.

Two constraints keep it out of the suites that provoke command failures deliberately:

- it fires only when `getBash()` landed on a **fallback** — a Git Bash resolved by literal path is unambiguous and stays silent, which is every correctly provisioned machine
- it fires at most **once per process**

## Tests

New `tests/shell-discovery.test.mjs` (6 tests): source is `null` before resolution and in the known set after; memoization stays coherent; a literal-path bash reports `git-bash` and exists on disk; the posix/win32 split holds; a failing command exposes its real exit status instead of a bare `null`; `lastRunFailure()` clears on success.

## Verification

Windows 11, Git installed via Scoop, Node v24.18.1:

- `node test-all.mjs` → **2716 passed, 0 failed, 1 warning** — the warning is the pre-existing `cv-sync-check.mjs exited with error (expected without user data)`, unrelated to this change. No stray `[shell]` output anywhere in the run.
- `node --test tests/shell-discovery.test.mjs` → 6/6
- Forced fallback (`SCOOP` and `USERPROFILE` pointed at a bogus root, so no Git Bash candidate exists) → `bashSource()` returns `wsl` and the block above prints exactly once; a second failure in the same process is silent.
- Before this branch, on the same machine, the five `spend_tier` tests failed with "did not route to haiku/opus/sonnet" while the captured stdout read `Model: claude-haiku-4-5 (spend_tier=economy)`.

I have no way to test the Program Files layout on this machine, but that path is untouched — the new entries are appended after the existing literals, so an existing install still wins the probe and reports `git-bash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThzrNt5WdcvomxMYgnT36i


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows shell discovery, including support for Bash installed through Scoop.
  - Improved path conversion by checking all trusted `cygpath` locations.
  - Added clearer diagnostics when commands fail or fallback shells are used.

- **Tests**
  - Expanded coverage for shell-source detection, fallback behavior, command failures, and recovery after successful commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->