### PR TITLE
fix(verify-pipeline): orphan check masks and invents orphans (#1425)

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6979,6 +6979,89 @@ try {
   fail(`verify-pipeline report checks crashed: ${e.message}`);
 }
 
+// ── VERIFY-PIPELINE ORPHAN REFERENCE RESOLUTION (#1425 follow-up) ────────────
+// Check 10 resolves "is this report referenced?" three ways. Two of them were
+// wrong:
+//   (a) a cell may carry SEVERAL links ("[901](…) / [902](…)" — a re-evaluation
+//       keeping both reports on record). A single .match() sees only the first,
+//       so every later link false-positives as an orphan.
+//   (b) the row's own number was credited UNCONDITIONALLY. Row and report
+//       numbers are independent counters that diverge in normal operation
+//       (#1733), so a row that links elsewhere silently "references" an
+//       unrelated report sharing its number, masking a real orphan.
+console.log('\n🧪 Testing verify-pipeline orphan reference resolution (#1425 follow-up)');
+try {
+  const orTmp = mkdtempSync(join(tmpdir(), 'career-ops-verify-orphan-'));
+  try {
+    const orReports = join(orTmp, 'reports');
+    mkdirSync(orReports, { recursive: true });
+    const orTracker = join(orTmp, 'applications.md');
+    const orEnv = { ...process.env, CAREER_OPS_TRACKER: orTracker, CAREER_OPS_REPORTS: orReports };
+    const rpt = (company, role) =>
+      `# Evaluación: ${company} — ${role}\n\n## Machine Summary\n\n\`\`\`yaml\ncompany: "${company}"\nrole: "${role}"\nscore: 3.1\n\`\`\`\n`;
+
+    // 901 + 902: one posting evaluated twice; row 900 keeps BOTH on record.
+    // 950: a genuine orphan whose number collides with row 950, which links 955.
+    // 955: the report row 950 actually points at.
+    // 970: referenced ONLY by the row-number fallback (its row carries no link).
+    writeFileSync(join(orReports, '901-acme-2026-02-01.md'), rpt('Acme', 'Director of Platform'));
+    writeFileSync(join(orReports, '902-acme-2026-02-09.md'), rpt('Acme', 'Director of Platform'));
+    writeFileSync(join(orReports, '950-globex-2026-03-02.md'), rpt('Globex', 'QA Manager'));
+    writeFileSync(join(orReports, '955-initech-2026-03-05.md'), rpt('Initech', 'Test Lead'));
+    writeFileSync(join(orReports, '970-hooli-2026-03-06.md'), rpt('Hooli', 'Release Manager'));
+
+    writeFileSync(orTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 900 | 2026-02-01 | Acme | Director of Platform | 3.1/5 | Evaluated | ❌ | ' +
+        '[901](reports/901-acme-2026-02-01.md) / [902](reports/902-acme-2026-02-09.md) | re-eval |\n' +
+      '| 950 | 2026-03-05 | Initech | Test Lead | 3.1/5 | Evaluated | ❌ | ' +
+        '[955](reports/955-initech-2026-03-05.md) | row number collides with orphan report 950 |\n' +
+      '| 970 | 2026-03-06 | Hooli | Release Manager | 3.1/5 | Evaluated | ❌ | — | legacy row, no markdown link |\n');
+
+    const orOut = run(NODE, ['verify-pipeline.mjs'], { env: orEnv, stdio: ['pipe', 'pipe', 'pipe'] });
+    if (orOut === null) {
+      fail('verify-pipeline crashed on the orphan-reference fixture');
+    } else {
+      // (a) second link of a dual-link cell must NOT be an orphan.
+      if (/Orphan report[^\n]*902-acme/.test(orOut)) {
+        fail('dual-link cell: second link (902) falsely flagged as orphan — .match() sees only the first');
+      } else {
+        pass('dual-link report cell resolves BOTH links, not just the first (#1425 follow-up)');
+      }
+      if (/Orphan report[^\n]*901-acme/.test(orOut)) {
+        fail('dual-link cell: first link (901) falsely flagged as orphan');
+      } else {
+        pass('dual-link report cell resolves its first link');
+      }
+      // (b) a row's own number must not mask an unrelated orphan sharing it.
+      if (/Orphan report[^\n]*#950[^\n]*950-globex/.test(orOut)) {
+        pass('row number does not mask an unrelated orphan sharing it (#1733 divergence)');
+      } else {
+        fail('orphan 950 masked by row 950, which links report 955 — row number credited unconditionally');
+      }
+      if (/Orphan report[^\n]*955-initech/.test(orOut)) {
+        fail('linked report 955 falsely flagged as orphan');
+      } else {
+        pass('report referenced by a linking row is not flagged');
+      }
+      // A link-less row is the ONE case where the row number is still the only
+      // signal. Report 970 exists on disk, so this assertion can genuinely fail
+      // if the fallback is dropped.
+      if (/Orphan report[^\n]*970-hooli/.test(orOut)) {
+        fail('link-less legacy row lost its row-number fallback — report 970 flagged');
+      } else {
+        pass('link-less row still falls back to its own number');
+      }
+    }
+  } finally {
+    rmSync(orTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`verify-pipeline orphan reference resolution crashed: ${e.message}`);
+}
+
 // ── VERIFY-PIPELINE DUPLICATE TRACKER NUMBER (#1704) ────────────
 // A tracker # must be a unique row id. Two rows sharing a # is never
 // legitimate (unlike Check 2's company+role dedup, which can false-positive

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -300,17 +300,35 @@ for (const group of reportsByRole.values()) {
 if (dupReports === 0) ok('No duplicate reports for the same company+role');
 
 // --- Check 10: Orphan reports with no tracker row (#1425) ---
-// Every reports/NNN-*.md should be referenced by a tracker row — by the row's
-// own number, the [NNN] link text, or the NNN- prefix of the linked filename.
-// A report none of them reference is usually the loser of a tracker dedup.
+// Every reports/NNN-*.md should be referenced by a tracker row — by the
+// [NNN] link text(s), the NNN- prefix of the linked filename(s), or (only when
+// the cell carries no markdown link at all) the row's own number.
+//
+// The row's own number is a LAST RESORT, not a standing signal. Tracker row
+// numbers and report numbers are independent counters that diverge in normal
+// operation — #1733 established that a reserved report number is discarded
+// when it is <= the tracker max, permanently desynchronising the two. Treating
+// a row's number as a reference whenever it merely coexists with an unrelated
+// link therefore masks real orphans: a row numbered 950 that legitimately
+// links to report 955 also silently "references" an unrelated orphaned
+// report 950. Only when the cell has no link is the row number the only signal
+// available, and only then is it used.
+//
+// Links are matched GLOBALLY. A cell can carry more than one — "[901](…) /
+// [902](…)" is the documented form for a re-evaluation that keeps both reports
+// on record — and a single .match() sees only the first, so every later link
+// in the cell false-positives as an orphan.
 const referencedNums = new Set();
 for (const e of entries) {
-  referencedNums.add(e.num);
-  const linkText = e.report.match(/\[(\d+)\]/);
-  if (linkText) referencedNums.add(parseInt(linkText[1], 10));
-  const linkTarget = e.report.match(/\]\(([^)]+)\)/);
-  if (linkTarget) {
-    const m = linkTarget[1].split('/').pop().match(/^(\d+)-/);
+  const linkTexts = [...e.report.matchAll(/\[(\d+)\]/g)];
+  const linkTargets = [...e.report.matchAll(/\]\(([^)]+)\)/g)];
+  if (linkTexts.length === 0 && linkTargets.length === 0) {
+    referencedNums.add(e.num);
+    continue;
+  }
+  for (const lt of linkTexts) referencedNums.add(parseInt(lt[1], 10));
+  for (const lt of linkTargets) {
+    const m = lt[1].split('/').pop().match(/^(\d+)-/);
     if (m) referencedNums.add(parseInt(m[1], 10));
   }
 }


### PR DESCRIPTION
…real orphans (#1425)

Check 10 resolves "is this report referenced by a tracker row?" three ways. Two of them are wrong, and they fail in opposite directions — one hides real orphans, the other invents them.

1. The row's own number is credited UNCONDITIONALLY.

   Row and report numbers are independent counters that diverge in normal operation: #1733 established that a reserved report number is discarded when it is <= the tracker max, permanently desynchronising the two. Check 10 nonetheless treats a row's own number as a reference even when the cell links somewhere else, so a row numbered 306 that legitimately links report 311 also silently "references" an unrelated orphaned report 306 — and the orphan is never reported.

   The row number is now a last resort, used only when the cell carries no markdown link at all. Link-less legacy rows keep the old behaviour.

2. Only the FIRST link in a cell is read.

   `e.report.match(/\[(\d+)\]/)` returns one match. A cell may carry several — "[019](...) / [111](...)" is the documented form for a re-evaluation that keeps both reports on record — so every link after the first false-positives as an orphan. Now matched globally with matchAll, for both the [NNN] link text and the NNN- filename prefix.

Tests: five assertions added alongside the existing #1425 fixture, covering a dual-link cell, a row number colliding with an unrelated orphan, and a link-less row that must keep the fallback. Each was run against unpatched main first and observed failing on exactly the two defects above (2 failed), then against this change (0 failed) — a fixture that cannot fail proves nothing. Full node test-all.mjs passes: 2722 passed, 0 failed.

Refs #1425, #1733.

## What does this PR do?

Fixes two defects in verify-pipeline.mjs's orphan-report check (#1425). The row's own number was credited unconditionally, masking real orphans; and only the first link in a report cell was read, so dual-link cells false-positived. Adds five fixture assertions, each observed failing before being trusted.

## Related issue

<!-- No issue needed, send the PR straight in: bug fixes, new zero-auth scanner providers, docs, and translations. We don't want to slow these down. -->

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [X] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [X] I ran `node test-all.mjs` and all tests pass
- [X] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [X] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved orphan report detection when tracker cells contain multiple report links.
  - Prevented unrelated row numbers from incorrectly matching reports when explicit links are present.
  - Preserved row-number fallback behavior for rows without report links.
  - Correctly recognizes linked reports so they are not flagged as orphaned.

- **Tests**
  - Added regression coverage for report-link resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->