### PR TITLE
fix(liveness): classify transient 5xx as uncertain, not expired

### DIFF
--- a/liveness-core.mjs
+++ b/liveness-core.mjs
@@ -132,6 +132,14 @@ export function classifyLiveness({ status = 0, requestedUrl = '', finalUrl = '',
   if (status === 403 || status === 503) {
     return { result: 'uncertain', code: 'access_blocked', reason: `HTTP ${status} (access blocked, likely anti-bot)` };
   }
+  // Any other 5xx is a transient origin error (502/504 gateway hiccups, 500s
+  // during deploys), not evidence the posting is gone. Without this guard the
+  // short error body ("502 Bad Gateway / nginx") falls through to the
+  // insufficient-content heuristic and reads as expired — and a false
+  // "expired" permanently dedup-filters a real job out of future scans.
+  if (status >= 500) {
+    return { result: 'uncertain', code: 'server_error', reason: `HTTP ${status} (transient server error)` };
+  }
 
   const expiredUrl = firstMatch(EXPIRED_URL_PATTERNS, finalUrl);
   if (expiredUrl) {

--- a/tests/liveness-core.test.mjs
+++ b/tests/liveness-core.test.mjs
@@ -59,3 +59,31 @@ classifyLiveness({
 }).result !== 'expired'
   ? pass('"job application form has been filled" (no "out") is NOT expired')
   : fail('false positive: "application form has been filled" read as an expired req');
+
+console.log('\nliveness-core — transient 5xx must not classify as expired');
+
+// Regression: a 502 with a typical short gateway body used to fall through to
+// the insufficient-content heuristic and read as expired, which dedup-blocks
+// the posting from every future scan. Any 5xx is transient, never "gone".
+for (const status of [500, 502, 504]) {
+  const verdict = classifyLiveness({
+    status,
+    requestedUrl: 'https://careers.example.com/job/123',
+    finalUrl: 'https://careers.example.com/job/123',
+    bodyText: `${status} Bad Gateway\nnginx`,
+    applyControls: [],
+  });
+  verdict.result === 'uncertain' && verdict.code === 'server_error'
+    ? pass(`HTTP ${status} -> uncertain/server_error (was: expired via insufficient_content)`)
+    : fail(`HTTP ${status} classified ${verdict.result}/${verdict.code}, expected uncertain/server_error`);
+}
+
+// 503 keeps its more specific access-blocked classification.
+classifyLiveness({ status: 503, finalUrl: 'https://careers.example.com/job/123', bodyText: 'checking your browser', applyControls: [] }).code === 'access_blocked'
+  ? pass('HTTP 503 still classifies as access_blocked, not server_error')
+  : fail('HTTP 503 lost its access_blocked classification');
+
+// A real 404/410 is still authoritative expiry.
+classifyLiveness({ status: 404, finalUrl: 'https://careers.example.com/job/123', bodyText: 'Not found', applyControls: [] }).result === 'expired'
+  ? pass('HTTP 404 still -> expired')
+  : fail('HTTP 404 regressed');

--- a/tests/liveness-core.test.mjs
+++ b/tests/liveness-core.test.mjs
@@ -78,12 +78,22 @@ for (const status of [500, 502, 504]) {
     : fail(`HTTP ${status} classified ${verdict.result}/${verdict.code}, expected uncertain/server_error`);
 }
 
-// 503 keeps its more specific access-blocked classification.
-classifyLiveness({ status: 503, finalUrl: 'https://careers.example.com/job/123', bodyText: 'checking your browser', applyControls: [] }).code === 'access_blocked'
-  ? pass('HTTP 503 still classifies as access_blocked, not server_error')
-  : fail('HTTP 503 lost its access_blocked classification');
+// 503 keeps its more specific access-blocked classification: the 5xx guard
+// sits below it, so both halves of the verdict must hold, not just the code.
+const blocked = classifyLiveness({ status: 503, finalUrl: 'https://careers.example.com/job/123', bodyText: 'checking your browser', applyControls: [] });
+blocked.result === 'uncertain' && blocked.code === 'access_blocked'
+  ? pass('HTTP 503 still classifies as uncertain/access_blocked, not server_error')
+  : fail(`HTTP 503 classified ${blocked.result}/${blocked.code}, expected uncertain/access_blocked`);
 
-// A real 404/410 is still authoritative expiry.
-classifyLiveness({ status: 404, finalUrl: 'https://careers.example.com/job/123', bodyText: 'Not found', applyControls: [] }).result === 'expired'
-  ? pass('HTTP 404 still -> expired')
-  : fail('HTTP 404 regressed');
+// A real 404/410 is still authoritative expiry — both statuses, both halves.
+for (const status of [404, 410]) {
+  const gone = classifyLiveness({
+    status,
+    finalUrl: 'https://careers.example.com/job/123',
+    bodyText: 'Not found',
+    applyControls: [],
+  });
+  gone.result === 'expired' && gone.code === 'http_gone'
+    ? pass(`HTTP ${status} still -> expired/http_gone`)
+    : fail(`HTTP ${status} classified ${gone.result}/${gone.code}, expected expired/http_gone`);
+}


### PR DESCRIPTION
Closes #2371.

`classifyLiveness()` guarded 403 and 503 as `access_blocked`, but any other 5xx fell through to the body heuristics, where a short gateway-error body ("502 Bad Gateway / nginx") lands in the `insufficient_content` branch and reads as **expired**. `scan --verify` then writes the offer to scan-history as `skipped_expired`, and `shouldDedupScanHistoryRow` filters it from every future scan, so a single origin hiccup permanently hides a live job.

The change: `status >= 500` returns `uncertain` with a new `server_error` code. 503 keeps its more specific `access_blocked` classification (checked first), and 404/410 stay authoritative expiry. No caller switches on the code string, so the new value is additive.

Tests: three transient statuses (500/502/504) assert `uncertain`/`server_error`, plus regression coverage that 503 keeps `access_blocked` and 404 still expires. `node tests/liveness-core.test.mjs` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of server-side HTTP errors by classifying status codes 500 and above as uncertain rather than expired.
  * Preserved existing classifications for blocked-access responses, including HTTP 503, and expired responses for HTTP 404 and 410.

* **Tests**
  * Added regression coverage for HTTP 500, 502, 503, 504, 404, and 410 responses to ensure classifications remain accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->