### PR TITLE
fix(tracker): rank Hired in dedup, canonicalize its aliases, and stop a bare tracker-number match merging different roles

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -40,6 +40,11 @@ const STATUS_RANK = {
   'responded': 4,
   'interview': 5,
   'offer': 6,
+  // Hired outranks everything: the accepted-job record must never lose a
+  // dedup contest to a repost row (aliases from templates/states.yml).
+  'hired': 7,
+  'accepted': 7,
+  'accept': 7,
   // Spanish aliases — kept for backwards compat with existing tracker data
   'no_aplicar': 0,
   'no aplicar': 0,
@@ -52,6 +57,8 @@ const STATUS_RANK = {
   'respondido': 4,
   'entrevista': 5,
   'oferta': 6,
+  'contratado': 7,
+  'contratada': 7,
 };
 
 /**
@@ -138,19 +145,22 @@ function extractReportNum(reportStr) {
 /**
  * Determine whether two tracker rows point to the same exact report identity.
  *
- * Exact identity is stronger than fuzzy role matching. If two rows share the
- * same tracker number or bracketed report number, dedup may treat them as the
- * same record even when an advanced status is present.
+ * Exact identity is stronger than fuzzy role matching: it may cluster rows
+ * even when an advanced status is present. Matching bracketed report numbers
+ * are that evidence. A shared tracker number alone is NOT — duplicate tracker
+ * numbers are a known artifact of the old merge bug (verify-pipeline Check 12
+ * exists because they never mean the same application), so a bare number match
+ * only counts when the rows also carry the same exact role title.
  *
  * @param {object} a - First parsed applications.md row.
  * @param {object} b - Second parsed applications.md row.
  * @returns {boolean} True when both rows represent the same report identity.
  */
 function sameReportIdentity(a, b) {
-  if (a.num === b.num) return true;
   const reportA = extractReportNum(a.report);
   const reportB = extractReportNum(b.report);
-  return reportA !== null && reportA === reportB;
+  if (reportA !== null && reportA === reportB) return true;
+  return a.num === b.num && normalizeRole(a.role) === normalizeRole(b.role);
 }
 
 /**

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -91,6 +91,10 @@ const ALIASES = {
   'respondido': 'responded',
   'entrevista': 'interview',
   'oferta': 'offer',
+  // Hired aliases from templates/states.yml — without these, an "Accepted" or
+  // "Contratado" row normalizes to itself, so stats/funnel/company-history
+  // consumers looking for 'hired' silently drop the best outcome in the tracker.
+  'contratado': 'hired', 'contratada': 'hired', 'accepted': 'hired', 'accept': 'hired',
   'rechazado': 'rejected', 'rechazada': 'rejected',
   'descartado': 'discarded', 'descartada': 'discarded',
   'cerrada': 'discarded', 'cancelada': 'discarded',

--- a/followup-cadence.test.mjs
+++ b/followup-cadence.test.mjs
@@ -14,6 +14,7 @@ import {
   DEFAULT_CADENCE,
   parseFollowups,
   analyzeFromContent,
+  normalizeStatus,
 } from './followup-cadence.mjs';
 
 let passed = 0;
@@ -164,6 +165,13 @@ eq(
   missingFollowupsArg.entries.some((e) => e.urgency === 'cold'),
   false,
 );
+
+// Hired aliases from templates/states.yml must normalize to 'hired'. Before
+// this, 'Accepted'/'Contratado' normalized to themselves, so stats/funnel/
+// company-history consumers looking for 'hired' silently dropped those rows.
+for (const raw of ['Hired', 'Accepted', 'accept', 'Contratado', 'contratada']) {
+  eq(`normalizeStatus('${raw}') canonicalizes to hired`, normalizeStatus(raw), 'hired');
+}
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7461,7 +7461,17 @@ try {
       '| 32 | 2026-01-10 | Cohere | Senior Software Engineer, Agent Infrastructure | 4.0/5 | Evaluated | ❌ | [32](../reports/014-cohere-agent-infra.md) | distinct role — higher score |\n' +
       // Exact company+role duplicate of #32 (same title, both Evaluated) — must
       // collapse to one, keeping the higher score.
-      '| 33 | 2026-01-11 | Cohere | Senior Software Engineer, Agent Infrastructure | 3.7/5 | Evaluated | ❌ | [33](../reports/033-cohere-agent-dup.md) | exact-title duplicate |\n');
+      '| 33 | 2026-01-11 | Cohere | Senior Software Engineer, Agent Infrastructure | 3.7/5 | Evaluated | ❌ | [33](../reports/033-cohere-agent-dup.md) | exact-title duplicate |\n' +
+      // A Hired row vs a later exact-title repost. Hired must rank as an
+      // advanced status: the accepted-job record can never lose a dedup
+      // contest to a higher-scored repost.
+      '| 34 | 2026-01-05 | HiredCo | Platform Engineer | 3.8/5 | Hired | ❌ | [34](../reports/034-hiredco.md) | the accepted job |\n' +
+      '| 35 | 2026-01-12 | HiredCo | Platform Engineer | 4.2/5 | Evaluated | ❌ | [35](../reports/035-hiredco-repost.md) | repost of the accepted job |\n' +
+      // Two DIFFERENT roles sharing a stale duplicate tracker number (the
+      // known merge-bug artifact, verify-pipeline Check 12). A bare number
+      // match must not read as same-report identity.
+      '| 36 | 2026-01-06 | NumCo | Data Engineer | 3.9/5 | Applied | ❌ | [36](../reports/036-numco-data.md) | duplicate-number, applied |\n' +
+      '| 36 | 2026-01-12 | NumCo | ML Engineer | 4.5/5 | Evaluated | ❌ | [37](../reports/037-numco-ml.md) | duplicate-number, different role |\n');
 
     const dedupResult = run(NODE, ['dedup-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
     if (dedupResult === null) {
@@ -7518,6 +7528,26 @@ try {
         pass('dedup-tracker merges an exact company+role duplicate to one (keeps highest score)');
       } else {
         fail(`dedup-tracker exact-duplicate handling broken: ${cohereAgentInfra.length} Cohere Agent Infrastructure rows`);
+      }
+
+      // Regression: Hired was missing from STATUS_RANK, so it ranked 0 — the
+      // advanced-status guard never fired and a higher-scored repost deleted
+      // the accepted-job record.
+      const hiredRows = deduped.split('\n').filter(l => l.includes('HiredCo'));
+      if (hiredRows.length === 2 && hiredRows.some(l => l.includes('Hired'))) {
+        pass('dedup-tracker protects a Hired row from an exact-title repost');
+      } else {
+        fail(`dedup-tracker deleted the Hired row: ${hiredRows.length} HiredCo rows survive`);
+      }
+
+      // Regression: a bare tracker-number match short-circuited roleMatch, so
+      // two different roles sharing a stale duplicate # merged and the Applied
+      // row of a different opening was deleted.
+      const numcoRows = deduped.split('\n').filter(l => l.includes('NumCo'));
+      if (numcoRows.length === 2 && numcoRows.some(l => l.includes('Applied'))) {
+        pass('dedup-tracker keeps different roles that share a stale duplicate tracker number');
+      } else {
+        fail(`dedup-tracker merged different roles across a duplicate tracker number: ${numcoRows.length} NumCo rows survive`);
       }
     }
   } finally {


### PR DESCRIPTION
Closes #2372.

Three fixes in the tracker's dedup and status-normalization path.

**dedup-tracker `STATUS_RANK` had no `hired` entry**, so `statusRank('Hired')` was 0, `isAdvancedStatus()` was false, and the guard that protects Applied+ rows from exact-title siblings never fired for the accepted-job row. A higher-scored repost could delete it. Hired and its states.yml aliases now rank above Offer.

**followup-cadence `ALIASES` lacked the states.yml hired aliases** (contratado/contratada/accepted/accept), so those rows normalized to themselves and every consumer of `normalizeStatus` looking for `hired` dropped them: stats.mjs `canonicalStatus` returned `Unknown` (funnel undercounts `everApplied`/`everOffer`), and company-history labelled the company that hired you `no-history` — the #2296 regression, surviving for every spelling but the literal one.

**`sameReportIdentity` treated a bare tracker-number match as same-application evidence**, short-circuiting `roleMatch` ahead of both the exact-title check and the advanced-status guard. Duplicate tracker numbers are the merge-bug artifact verify-pipeline Check 12 flags, not a same-application signal, so two different roles sharing a stale `#45` merged and the Applied row of a different opening was deleted. A number match now also requires the same exact role title.

Tests: the existing dedup fixture gains a Hired-vs-repost pair and a duplicate-number pair with different roles; five hired-alias assertions added to followup-cadence.test.mjs. The pre-existing duplicate-number case (two `#29` rows, same role) still merges, which is the behaviour that test encodes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recognized additional English and Spanish variations of “hired” status, ensuring they are consistently displayed and prioritized.
  - Improved duplicate report matching by prioritizing report-link numbers and validating role titles when tracker numbers overlap.
  - Prevented unrelated roles with shared tracker numbers from being incorrectly merged.
  - Preserved hired records when duplicate postings have higher-scored matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->