### PR TITLE
fix(providers): dead boards must throw, not read as "live but empty"

### DIFF
--- a/providers/cryptocurrencyjobs.mjs
+++ b/providers/cryptocurrencyjobs.mjs
@@ -105,14 +105,12 @@ export default {
   id: 'cryptocurrencyjobs',
 
   async fetch(_entry, ctx) {
-    let xml;
-    try {
-      // redirect:'error' — refuse server-side redirects (SSRF hardening, matches
-      // the other HTTP providers); the feed host is fixed so a redirect is a flag.
-      xml = await ctx.fetchText(FEED, { redirect: 'error' });
-    } catch {
-      return [];
-    }
+    // redirect:'error' — refuse server-side redirects (SSRF hardening, matches
+    // the other HTTP providers); the feed host is fixed so a redirect is a flag.
+    // A failed fetch must THROW, not return []: swallowing it makes a dead
+    // board read as "live but empty", so portal-health never escalates and
+    // coverage decays silently (same contract as meituan/tencent).
+    const xml = await ctx.fetchText(FEED, { redirect: 'error' });
     return parseCryptocurrencyJobsRss(xml);
   },
 };

--- a/providers/phenom.mjs
+++ b/providers/phenom.mjs
@@ -150,6 +150,10 @@ export default {
     const jobs = [];
     const seen = new Set();
     let total = null;
+    // A page-1 failure means the board is unreachable, not empty — it must
+    // THROW so scan/portal-health record a failure instead of "live but
+    // empty" (meituan/tencent idiom). Only a mid-scan failure keeps partials.
+    let succeededOnce = false;
 
     for (let page = 0; page < maxPages; page++) {
       if (page > 0) await wait(PAGE_DELAY_MS);
@@ -183,9 +187,11 @@ export default {
             locationData: {},
           }),
         });
-      } catch {
+      } catch (err) {
+        if (!succeededOnce) throw err;
         break; // keep jobs collected so far — a transient mid-scan failure shouldn't discard earlier pages
       }
+      succeededOnce = true;
       const { total: pageTotal, rows } = parseRefineSearch(json, cfg);
       if (total === null) total = pageTotal;
       if (rows.length === 0) break;

--- a/providers/radancy.mjs
+++ b/providers/radancy.mjs
@@ -293,9 +293,13 @@ export default {
         const first = await ctx.fetchJson(buildFragmentUrl(listUrl, 1), {
           headers: { accept: 'application/json', 'x-requested-with': 'XMLHttpRequest' },
         });
-        succeededOnce = true;
         const firstHtml = typeof first?.results === 'string' ? first.results : '';
         const firstRows = firstHtml ? parseResults(firstHtml, origin) : [];
+        // Proof of life only once the response also PARSED: a valid fragment
+        // with zero rows counts, but a response that crashes parsing leaves
+        // this false so a failing HTML fallback still reports the malformed
+        // initial response instead of returning [].
+        succeededOnce = true;
         if (firstRows.length) {
           const { totalResults, totalPages } = readFragmentTotals(firstHtml);
           // Bound by the server's own page count when it gives one; the local

--- a/providers/radancy.mjs
+++ b/providers/radancy.mjs
@@ -345,15 +345,22 @@ export default {
       }
     }
 
+    // A page-1 failure on the fallback transport (after the JSON transport also
+    // produced nothing) means the board is unreachable, not empty — THROW so
+    // scan/portal-health record a failure instead of "live but empty"
+    // (meituan/tencent idiom). Only a mid-scan failure keeps partials.
+    let succeededOnce = false;
     for (let page = 1; page <= maxPages; page++) {
       if (page > 1) await wait(PAGE_DELAY_MS);
       let rows;
       try {
         const html = await ctx.fetchText(`${listUrl}?p=${page}`, { headers: { accept: 'text/html' } });
         rows = parseResults(html, origin);
-      } catch {
+      } catch (err) {
+        if (!succeededOnce) throw err;
         break; // keep jobs collected so far — a transient mid-scan failure shouldn't discard earlier pages
       }
+      succeededOnce = true;
       if (rows.length === 0) break; // past the last page
 
       let fresh = 0;

--- a/providers/radancy.mjs
+++ b/providers/radancy.mjs
@@ -278,6 +278,10 @@ export default {
     const maxJobs = resolveMaxJobs(entry);
     const jobs = [];
     const seen = new Set();
+    // Proof of life across BOTH transports: any resolved request — including a
+    // fragment 200 that parses to zero rows — proves the tenant is reachable,
+    // so a later HTML page-1 failure must not read as "unreachable".
+    let succeededOnce = false;
 
     // ── Preferred transport: the JSON results fragment ───────────────────────
     // Tried first because on legacy-markup tenants the ?p=N HTML page carries a
@@ -289,6 +293,7 @@ export default {
         const first = await ctx.fetchJson(buildFragmentUrl(listUrl, 1), {
           headers: { accept: 'application/json', 'x-requested-with': 'XMLHttpRequest' },
         });
+        succeededOnce = true;
         const firstHtml = typeof first?.results === 'string' ? first.results : '';
         const firstRows = firstHtml ? parseResults(firstHtml, origin) : [];
         if (firstRows.length) {
@@ -345,11 +350,11 @@ export default {
       }
     }
 
-    // A page-1 failure on the fallback transport (after the JSON transport also
-    // produced nothing) means the board is unreachable, not empty — THROW so
-    // scan/portal-health record a failure instead of "live but empty"
-    // (meituan/tencent idiom). Only a mid-scan failure keeps partials.
-    let succeededOnce = false;
+    // A page-1 failure on the fallback transport — when NO request on either
+    // transport ever resolved — means the board is unreachable, not empty:
+    // THROW so scan/portal-health record a failure instead of "live but empty"
+    // (meituan/tencent idiom). A resolved fragment request above, or a mid-scan
+    // failure here, keeps partials instead.
     for (let page = 1; page <= maxPages; page++) {
       if (page > 1) await wait(PAGE_DELAY_MS);
       let rows;

--- a/providers/radancy.mjs
+++ b/providers/radancy.mjs
@@ -293,13 +293,15 @@ export default {
         const first = await ctx.fetchJson(buildFragmentUrl(listUrl, 1), {
           headers: { accept: 'application/json', 'x-requested-with': 'XMLHttpRequest' },
         });
-        const firstHtml = typeof first?.results === 'string' ? first.results : '';
+        const firstIsString = typeof first?.results === 'string';
+        const firstHtml = firstIsString ? first.results : '';
         const firstRows = firstHtml ? parseResults(firstHtml, origin) : [];
-        // Proof of life only once the response also PARSED: a valid fragment
-        // with zero rows counts, but a response that crashes parsing leaves
-        // this false so a failing HTML fallback still reports the malformed
-        // initial response instead of returning [].
-        succeededOnce = true;
+        // Proof of life only for a WELL-FORMED fragment response: a string
+        // `results` — even "" (zero rows) — counts, but a missing/non-string
+        // `results` or a response that crashes parsing leaves this false, so
+        // a failing HTML fallback still surfaces the malformed initial
+        // response instead of returning [].
+        if (firstIsString) succeededOnce = true;
         if (firstRows.length) {
           const { totalResults, totalPages } = readFragmentTotals(firstHtml);
           // Bound by the server's own page count when it gives one; the local

--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -295,8 +295,12 @@ function resolveCsbMaxPages(entry) {
 // CSB strategy: discover locales, paginate the JSON jobs API per locale, dedup
 // by id across locales+pages. `total` from the first page bounds pagination;
 // an empty/short page also stops the loop.
-/** @param {import('./_types.js').PortalEntry} entry @param {any} cfg @param {import('./_types.js').Context} ctx */
-async function fetchCsb(entry, cfg, ctx) {
+//
+// `probe: true` marks the post-RMK fallback probe: RMK already answered (the
+// board is reachable, just empty of tiles), so an all-locales CSB failure must
+// NOT read as a dead board — return [] instead of throwing.
+/** @param {import('./_types.js').PortalEntry} entry @param {any} cfg @param {import('./_types.js').Context} ctx @param {{probe?: boolean}} [opts] */
+async function fetchCsb(entry, cfg, ctx, { probe = false } = {}) {
   let locales = CSB_DEFAULT_LOCALES;
   try {
     const html = await ctx.fetchText(cfg.searchPage, { redirect: 'error', headers: { accept: 'text/html' } });
@@ -357,7 +361,7 @@ async function fetchCsb(entry, cfg, ctx) {
       if (rawCount < CSB_PAGE_SIZE) break;
     }
   }
-  if (!succeededOnce && lastErr) throw lastErr;
+  if (!probe && !succeededOnce && lastErr) throw lastErr;
   return jobs;
 }
 
@@ -419,6 +423,9 @@ export default {
     }
     const rmkJobs = await fetchRmk(entry, cfg, ctx);
     if (rmkJobs.length > 0) return rmkJobs;
-    return fetchCsb(entry, cfg, ctx);
+    // RMK answered (healthy, possibly legitimately empty) — the CSB call here
+    // is only a probe for the empty-shell signature, so it must not turn a
+    // failing/absent CSB endpoint into a dead-board throw.
+    return fetchCsb(entry, cfg, ctx, { probe: true });
   },
 };

--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -315,9 +315,11 @@ async function fetchCsb(entry, cfg, ctx, { probe = false } = {}) {
   const seen = new Set();
   // When EVERY locale fails without a single successful request the board is
   // unreachable, not empty — THROW so scan/portal-health record a failure
-  // instead of "live but empty" (meituan/tencent idiom).
+  // instead of "live but empty" (meituan/tencent idiom). The FIRST failure is
+  // retained and surfaced: later locales usually fail for the same root cause,
+  // and keeping the first makes the thrown error deterministic.
   let succeededOnce = false;
-  let lastErr = null;
+  let firstErr = null;
 
   for (const locale of locales) {
     if (jobs.length >= MAX_JOBS) break;
@@ -332,7 +334,7 @@ async function fetchCsb(entry, cfg, ctx, { probe = false } = {}) {
           body: JSON.stringify({ keywords: '', locale, location: '', pageNumber: page, sortBy: 'recent' }),
         });
       } catch (err) {
-        lastErr = err;
+        firstErr ??= err;
         break; // this locale failed (e.g. 307 legacy redirect) — try the next
       }
       succeededOnce = true;
@@ -361,7 +363,7 @@ async function fetchCsb(entry, cfg, ctx, { probe = false } = {}) {
       if (rawCount < CSB_PAGE_SIZE) break;
     }
   }
-  if (!probe && !succeededOnce && lastErr) throw lastErr;
+  if (!probe && !succeededOnce && firstErr) throw firstErr;
   return jobs;
 }
 

--- a/providers/successfactors.mjs
+++ b/providers/successfactors.mjs
@@ -309,6 +309,11 @@ async function fetchCsb(entry, cfg, ctx) {
   const maxPages = resolveCsbMaxPages(entry);
   const jobs = [];
   const seen = new Set();
+  // When EVERY locale fails without a single successful request the board is
+  // unreachable, not empty — THROW so scan/portal-health record a failure
+  // instead of "live but empty" (meituan/tencent idiom).
+  let succeededOnce = false;
+  let lastErr = null;
 
   for (const locale of locales) {
     if (jobs.length >= MAX_JOBS) break;
@@ -322,9 +327,11 @@ async function fetchCsb(entry, cfg, ctx) {
           headers: { 'content-type': 'application/json', accept: 'application/json' },
           body: JSON.stringify({ keywords: '', locale, location: '', pageNumber: page, sortBy: 'recent' }),
         });
-      } catch {
+      } catch (err) {
+        lastErr = err;
         break; // this locale failed (e.g. 307 legacy redirect) — try the next
       }
+      succeededOnce = true;
       if (total === null) {
         total = typeof json?.totalJobs === 'number' ? json.totalJobs : null;
       }
@@ -350,6 +357,7 @@ async function fetchCsb(entry, cfg, ctx) {
       if (rawCount < CSB_PAGE_SIZE) break;
     }
   }
+  if (!succeededOnce && lastErr) throw lastErr;
   return jobs;
 }
 

--- a/tests/providers/cryptocurrencyjobs.test.mjs
+++ b/tests/providers/cryptocurrencyjobs.test.mjs
@@ -79,13 +79,20 @@ try {
   if (capturedOpts && capturedOpts.redirect === 'error') pass('cryptocurrencyjobs.fetch() passes redirect:"error" (SSRF hardening)');
   else fail(`cryptocurrencyjobs.fetch() should pass redirect:"error", got ${JSON.stringify(capturedOpts)}`);
 
-  // fetch() swallows transport errors and returns [] (zero-token scan must not abort)
-  const errored = await ccj.fetch(
-    { name: 'CryptocurrencyJobs', provider: 'cryptocurrencyjobs' },
-    { transport: 'http', fetchText: async () => { throw new Error('network down'); }, fetchJson: async () => ({}) },
-  );
-  if (errored.length === 0) pass('cryptocurrencyjobs.fetch() returns [] when the feed fetch fails');
-  else fail('cryptocurrencyjobs.fetch() should return [] on fetch failure');
+  // A failed feed fetch must THROW, not return []: scan.mjs catches per-target
+  // throws and records a failure, while [] reads as "live but empty" — so a
+  // dead board never trips portal-health escalation (meituan/tencent contract).
+  let threw = null;
+  try {
+    await ccj.fetch(
+      { name: 'CryptocurrencyJobs', provider: 'cryptocurrencyjobs' },
+      { transport: 'http', fetchText: async () => { throw new Error('network down'); }, fetchJson: async () => ({}) },
+    );
+  } catch (err) {
+    threw = err;
+  }
+  if (threw?.message === 'network down') pass('cryptocurrencyjobs.fetch() throws when the feed fetch fails (dead board ≠ empty board)');
+  else fail('cryptocurrencyjobs.fetch() swallowed a feed-fetch failure into []');
 } catch (e) {
   fail(`cryptocurrencyjobs provider tests crashed: ${e.message}`);
 }

--- a/tests/providers/phenom.test.mjs
+++ b/tests/providers/phenom.test.mjs
@@ -98,6 +98,20 @@ try {
   const partialJobs = await phenom.fetch({ name: 'Allianz', api: 'https://careers.allianz.com' }, partialCtx);
   if (partialJobs.length === 100 && partialCalls === 2) pass('phenom.fetch() preserves jobs from earlier pages when a later page fetch throws');
   else fail(`phenom.fetch() partial-failure handling wrong: ${partialJobs.length} jobs after ${partialCalls} calls`);
+
+  // A FIRST-page failure means the board is unreachable, not empty. It must
+  // throw so scan/portal-health record a failure instead of "live but empty".
+  let firstPageErr = null;
+  try {
+    await phenom.fetch(
+      { name: 'Allianz', api: 'https://careers.allianz.com' },
+      { sleep: async () => {}, fetchJson: async () => { throw new Error('endpoint down'); } },
+    );
+  } catch (err) {
+    firstPageErr = err;
+  }
+  if (firstPageErr?.message === 'endpoint down') pass('phenom.fetch() throws when the first page fetch fails (dead board ≠ empty board)');
+  else fail('phenom.fetch() swallowed a first-page failure into []');
 } catch (e) {
   fail(`phenom provider tests crashed: ${e.message}`);
 }

--- a/tests/providers/radancy.test.mjs
+++ b/tests/providers/radancy.test.mjs
@@ -263,6 +263,31 @@ try {
   if (emptyFragJobs.length === 2 && emptyText > 0) pass('radancy.fetch() falls back when the fragment parses to zero rows');
   else fail(`radancy.fetch() empty-fragment fallback = ${emptyFragJobs.length} jobs, ${emptyText} text calls`);
 
+  // A resolved fragment request is proof of life even with zero rows: when the
+  // HTML fallback then fails (e.g. 403 on ?p=1), fetch() must NOT throw
+  // "unreachable" for a tenant it just talked to — it returns what it has.
+  {
+    let zeroErr = null;
+    let zeroJobs = null;
+    try {
+      zeroJobs = await radancy.fetch(
+        { name: 'Munich Re', api: 'https://careers.munichre.com/en/search-jobs' },
+        {
+          sleep: async () => {},
+          fetchJson: async () => ({ results: '', hasJobs: false }),
+          fetchText: async () => { throw new Error('403 on the HTML page'); },
+        },
+      );
+    } catch (err) {
+      zeroErr = err;
+    }
+    if (!zeroErr && Array.isArray(zeroJobs) && zeroJobs.length === 0) {
+      pass('radancy.fetch() does not throw when the fragment resolved (zero rows) and the HTML fallback fails (fragment success = proof of life)');
+    } else {
+      fail(`radancy.fetch() fragment proof-of-life wrong: ${zeroErr ? `threw "${zeroErr.message}"` : JSON.stringify(zeroJobs)}`);
+    }
+  }
+
   // max_jobs bounds the fragment walk.
   const capCtx = { sleep: async () => {}, fetchJson: async () => ({ results: LEGACY_UHG, hasJobs: true }), fetchText: async () => { throw new Error('unused'); } };
   const cappedJobs = await radancy.fetch({ name: 'Optum', careers_url: 'https://careers.unitedhealthgroup.com/search-jobs', max_jobs: 1 }, capCtx);

--- a/tests/providers/radancy.test.mjs
+++ b/tests/providers/radancy.test.mjs
@@ -75,6 +75,20 @@ try {
   if (partialJobs.length === 2 && partialCalls === 2) pass('radancy.fetch() preserves jobs from earlier pages when a later page fetch throws');
   else fail(`radancy.fetch() partial-failure handling wrong: ${partialJobs.length} jobs after ${partialCalls} calls`);
 
+  // A FIRST-page failure means the board is unreachable, not empty. It must
+  // throw so scan/portal-health record a failure instead of "live but empty".
+  let radFirstErr = null;
+  try {
+    await radancy.fetch(
+      { name: 'Munich Re', api: 'https://careers.munichre.com/en/search-jobs' },
+      { sleep: async () => {}, fetchText: async () => { throw new Error('tenant down'); } },
+    );
+  } catch (err) {
+    radFirstErr = err;
+  }
+  if (radFirstErr?.message === 'tenant down') pass('radancy.fetch() throws when the first page fetch fails (dead board ≠ empty board)');
+  else fail('radancy.fetch() swallowed a first-page failure into []');
+
   // fetch — stops on a page whose ids are all already-seen (server clamped
   // ?p= to the last page, or looped), NOT just on a literally empty page.
   // fresh === 0 must halt pagination without appending duplicate jobs.

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -275,6 +275,33 @@ try {
     if (csbErr?.message === 'jobs api down') pass('successfactors CSB fetch() throws when every locale fails (dead board ≠ empty board)');
     else fail(`successfactors CSB fetch() swallowed an all-locales failure${csbErr ? ` (threw ${csbErr.message})` : ' into []'}`);
   }
+  // Dispatcher default path (NO sfVariant): a healthy RMK tenant with zero
+  // postings triggers the post-RMK CSB probe. The probe failing on every
+  // locale must NOT throw — RMK already answered, so the board is reachable
+  // and legitimately empty, not a dead slug.
+  {
+    let probeErr = null;
+    let probeJobs = null;
+    try {
+      probeJobs = await sf.fetch(
+        { name: 'EmptyCo', careers_url: 'https://jobs.emptyco.example' },
+        {
+          sleep: async () => {},
+          // Serves both the RMK tile endpoint (healthy 200, zero tiles) and
+          // the best-effort /search/ locale discovery.
+          fetchText: async () => '<!DOCTYPE html>',
+          fetchJson: async () => { throw new Error('no CSB endpoint on this tenant'); },
+        },
+      );
+    } catch (err) {
+      probeErr = err;
+    }
+    if (!probeErr && Array.isArray(probeJobs) && probeJobs.length === 0) {
+      pass('successfactors fetch() without sfVariant: empty RMK + failing CSB probe returns [] (healthy empty board ≠ dead slug)');
+    } else {
+      fail(`successfactors fetch() empty-RMK CSB-probe wrong: ${probeErr ? `threw "${probeErr.message}"` : JSON.stringify(probeJobs)}`);
+    }
+  }
 } catch (err) {
   fail(`successfactors provider test threw: ${err.message}`);
 }

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -267,14 +267,22 @@ try {
         {
           sleep: async () => {},
           fetchText: async () => { throw new Error('discovery down'); }, // locale discovery is best-effort
-          fetchJson: async () => { csbCalls++; throw new Error('jobs api down'); },
+          // Each locale fails with a DISTINCT message so the assertion below
+          // pins WHICH failure fetch() surfaces, not merely THAT it throws.
+          fetchJson: async () => { csbCalls++; throw new Error(`jobs api down (call ${csbCalls})`); },
         },
       );
     } catch (err) {
       csbErr = err;
     }
-    if (csbErr?.message === 'jobs api down' && csbCalls >= 1) pass('successfactors CSB fetch() throws when every locale fails (dead board ≠ empty board)');
-    else fail(`successfactors CSB fetch() wrong: ${csbErr ? `threw "${csbErr.message}"` : 'swallowed an all-locales failure into []'} after ${csbCalls} jobs-API calls`);
+    // Discovery is down, so both default locales (de_DE, en_US) are tried and
+    // fail → 2+ calls; the surfaced error must be the FIRST locale's, pinning
+    // the deterministic firstErr retention.
+    if (csbErr?.message === 'jobs api down (call 1)' && csbCalls >= 2) {
+      pass('successfactors CSB fetch() throws the FIRST locale failure when every locale fails (dead board ≠ empty board, deterministic error)');
+    } else {
+      fail(`successfactors CSB fetch() wrong: ${csbErr ? `threw "${csbErr.message}"` : 'swallowed an all-locales failure into []'} after ${csbCalls} jobs-API calls`);
+    }
   }
   // Dispatcher default path (NO sfVariant): a healthy RMK tenant with zero
   // postings triggers the post-RMK CSB probe. The probe failing on every

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -260,20 +260,21 @@ try {
   // record a failure instead of "live but empty".
   {
     let csbErr = null;
+    let csbCalls = 0;
     try {
       await sf.fetch(
         { name: 'DeadCo', careers_url: 'https://careers.deadco.example', sfVariant: 'csb' },
         {
           sleep: async () => {},
           fetchText: async () => { throw new Error('discovery down'); }, // locale discovery is best-effort
-          fetchJson: async () => { throw new Error('jobs api down'); },
+          fetchJson: async () => { csbCalls++; throw new Error('jobs api down'); },
         },
       );
     } catch (err) {
       csbErr = err;
     }
-    if (csbErr?.message === 'jobs api down') pass('successfactors CSB fetch() throws when every locale fails (dead board ≠ empty board)');
-    else fail(`successfactors CSB fetch() swallowed an all-locales failure${csbErr ? ` (threw ${csbErr.message})` : ' into []'}`);
+    if (csbErr?.message === 'jobs api down' && csbCalls >= 1) pass('successfactors CSB fetch() throws when every locale fails (dead board ≠ empty board)');
+    else fail(`successfactors CSB fetch() wrong: ${csbErr ? `threw "${csbErr.message}"` : 'swallowed an all-locales failure into []'} after ${csbCalls} jobs-API calls`);
   }
   // Dispatcher default path (NO sfVariant): a healthy RMK tenant with zero
   // postings triggers the post-RMK CSB probe. The probe failing on every
@@ -282,6 +283,7 @@ try {
   {
     let probeErr = null;
     let probeJobs = null;
+    let probeCalls = 0;
     try {
       probeJobs = await sf.fetch(
         { name: 'EmptyCo', careers_url: 'https://jobs.emptyco.example' },
@@ -290,16 +292,18 @@ try {
           // Serves both the RMK tile endpoint (healthy 200, zero tiles) and
           // the best-effort /search/ locale discovery.
           fetchText: async () => '<!DOCTYPE html>',
-          fetchJson: async () => { throw new Error('no CSB endpoint on this tenant'); },
+          fetchJson: async () => { probeCalls++; throw new Error('no CSB endpoint on this tenant'); },
         },
       );
     } catch (err) {
       probeErr = err;
     }
-    if (!probeErr && Array.isArray(probeJobs) && probeJobs.length === 0) {
+    // probeCalls >= 1 pins that the CSB probe actually RAN — an empty array
+    // straight off the RMK path would otherwise pass this test vacuously.
+    if (!probeErr && Array.isArray(probeJobs) && probeJobs.length === 0 && probeCalls >= 1) {
       pass('successfactors fetch() without sfVariant: empty RMK + failing CSB probe returns [] (healthy empty board ≠ dead slug)');
     } else {
-      fail(`successfactors fetch() empty-RMK CSB-probe wrong: ${probeErr ? `threw "${probeErr.message}"` : JSON.stringify(probeJobs)}`);
+      fail(`successfactors fetch() empty-RMK CSB-probe wrong: ${probeErr ? `threw "${probeErr.message}"` : JSON.stringify(probeJobs)} after ${probeCalls} jobs-API calls`);
     }
   }
 } catch (err) {

--- a/tests/providers/successfactors.test.mjs
+++ b/tests/providers/successfactors.test.mjs
@@ -255,6 +255,26 @@ try {
     else if (badTiles.length === 1 && badTiles[0].title === 'Overflow &#99999999; & Hex &#xFFFFFFFF; Surrogate &#xD800;') pass('successfactors.parseTiles() tolerates out-of-range / surrogate entities, degrading them to literal text while still decoding &amp; (no RangeError crash)');
     else fail(`successfactors.parseTiles() out-of-range entity wrong: ${JSON.stringify(badTiles)}`);
   }
+  // CSB: when every locale fails without one successful jobs-API request, the
+  // board is unreachable, not empty. fetch() must throw so scan/portal-health
+  // record a failure instead of "live but empty".
+  {
+    let csbErr = null;
+    try {
+      await sf.fetch(
+        { name: 'DeadCo', careers_url: 'https://careers.deadco.example', sfVariant: 'csb' },
+        {
+          sleep: async () => {},
+          fetchText: async () => { throw new Error('discovery down'); }, // locale discovery is best-effort
+          fetchJson: async () => { throw new Error('jobs api down'); },
+        },
+      );
+    } catch (err) {
+      csbErr = err;
+    }
+    if (csbErr?.message === 'jobs api down') pass('successfactors CSB fetch() throws when every locale fails (dead board ≠ empty board)');
+    else fail(`successfactors CSB fetch() swallowed an all-locales failure${csbErr ? ` (threw ${csbErr.message})` : ' into []'}`);
+  }
 } catch (err) {
   fail(`successfactors provider test threw: ${err.message}`);
 }


### PR DESCRIPTION
Closes #2374.

cryptocurrencyjobs, phenom, radancy and successfactors (CSB) each swallowed a first-request failure into `[]`. scan.mjs reads that as "live but empty" and files the target under `emptyTargets`, so a dead endpoint never reaches the error path, portal-health keeps reporting it healthy, and the consecutive-failure escalation never fires.

All four now follow the `succeededOnce` idiom meituan and tencent already implement: a failure before any successful request throws, so scan records a real failure; a mid-scan failure still keeps the pages already collected. scan.mjs catches per-target, so the throw never aborts a run.

One existing assertion changes meaning: the cryptocurrencyjobs test that expected `[]` on a failed feed fetch now expects the throw. Each of the other three gains a first-request-failure case, and the meituan test that already encodes this contract still passes unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fetch failures are now reported instead of being incorrectly shown as empty job results.
  * Initial page and complete request failures are surfaced clearly, while partial results remain available when later pages fail.
  * Improved error handling across multiple job board integrations.

* **Tests**
  * Added regression coverage for network and API failures across supported job sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->