### PR TITLE
perf(fingerprint): popcount table + hoisted loop state in findCrossListings (#2381)

### DIFF
--- a/fingerprint-core.mjs
+++ b/fingerprint-core.mjs
@@ -82,6 +82,52 @@ export function fingerprintText(text) {
   return hash.toString(16).padStart(16, '0');
 }
 
+/** A fingerprint is exactly 16 lowercase hex chars; anything else never
+ * matches. Hoisted to module scope so the hot path reuses one compiled regex
+ * rather than re-evaluating a literal on every call. */
+const FINGERPRINT_RE = /^[0-9a-f]{16}$/;
+
+/** Set-bit count for every 16-bit value, built once at module load (64 KB).
+ * A 64-bit Hamming distance then costs four table lookups instead of the 64
+ * BigInt shift/mask iterations this module used to run per comparison, and
+ * findCrossListings compares offers × history rows, so that per-pair cost is
+ * multiplied by the product of both list lengths (#2381). */
+const POPCOUNT16 = (() => {
+  const table = new Uint8Array(1 << 16);
+  for (let i = 1; i < table.length; i++) table[i] = table[i >> 1] + (i & 1);
+  return table;
+})();
+
+/**
+ * Number of set bits in a 32-bit word.
+ *
+ * Sign is irrelevant: both masks yield a non-negative 0..65535 index, so a
+ * negative int32 (which `^` produces whenever the top bit is set) indexes the
+ * table just as correctly as a positive one.
+ *
+ * @param {number} x - Any 32-bit integer.
+ * @returns {number} 0..32.
+ */
+function popcount32(x) {
+  return POPCOUNT16[x & 0xffff] + POPCOUNT16[(x >>> 16) & 0xffff];
+}
+
+/**
+ * Split a fingerprint that has already passed FINGERPRINT_RE into its two
+ * 32-bit halves.
+ *
+ * JS bitwise operators are 32-bit, so the 64-bit value is carried as a pair.
+ * A single Number would lose precision above 2^53, and a BigInt allocates on
+ * every operation — the exact cost this rewrite removes.
+ *
+ * @param {string} fp - Validated 16-hex-char fingerprint.
+ * @returns {{hi: number, lo: number}} Upper and lower 32 bits, as int32.
+ */
+function splitFingerprint(fp) {
+  const s = String(fp);
+  return { hi: parseInt(s.slice(0, 8), 16) | 0, lo: parseInt(s.slice(8, 16), 16) | 0 };
+}
+
 /**
  * Similarity of two fingerprints: 1 − hammingDistance/64. Empty or malformed
  * fingerprints never match (returns 0).
@@ -91,14 +137,33 @@ export function fingerprintText(text) {
  * @returns {number} 0..1.
  */
 export function similarity(a, b) {
-  if (!/^[0-9a-f]{16}$/.test(a || '') || !/^[0-9a-f]{16}$/.test(b || '')) return 0;
-  let x = BigInt('0x' + a) ^ BigInt('0x' + b);
-  let dist = 0;
-  while (x) {
-    dist += Number(x & 1n);
-    x >>= 1n;
+  if (!FINGERPRINT_RE.test(a || '') || !FINGERPRINT_RE.test(b || '')) return 0;
+  const x = splitFingerprint(a);
+  const y = splitFingerprint(b);
+  return 1 - (popcount32(x.hi ^ y.hi) + popcount32(x.lo ^ y.lo)) / 64;
+}
+
+/**
+ * Largest Hamming distance (0..64) that still scores at or above `threshold`,
+ * or -1 when no distance does.
+ *
+ * Derived by evaluating the SAME `1 - d / 64 >= threshold` comparison the
+ * per-pair path used to run, not by rounding `64 * (1 - threshold)`. For
+ * integer d, `d / 64` is exact in binary floating point, so the sequence is
+ * exactly monotonic and this search reproduces the old accept/reject decision
+ * at every threshold — including one landing exactly on a bit boundary, where a
+ * floor()/ceil() derivation is off by one in one direction. The negated
+ * comparison also makes a NaN threshold return -1 (reject everything), matching
+ * what `score >= NaN` did before.
+ *
+ * @param {number} threshold - Minimum similarity, normally 0..1.
+ * @returns {number} Maximum accepted bit distance, or -1 when none qualifies.
+ */
+function maxDistanceFor(threshold) {
+  for (let d = 0; d <= 64; d++) {
+    if (!(1 - d / 64 >= threshold)) return d - 1;
   }
-  return 1 - dist / 64;
+  return 64;
 }
 
 /** Company key for "different employer" checks — same normalization family as
@@ -114,6 +179,15 @@ function companyKey(name) {
  *
  * Pure function: pass the offers and pre-parsed history rows in.
  *
+ * This is O(offers × recentHistory), so everything that depends on only one
+ * side of a pair is hoisted out of the inner loop: each row's companyKey and
+ * fingerprint halves are computed once when `recent` is built, each offer's
+ * once per offer, and the threshold is converted once into a maximum bit
+ * distance. The inner loop is then two integer compares plus four table
+ * lookups. Results are byte-identical to the per-pair similarity() version —
+ * see tests/fingerprint-core.test.mjs, which differentially tests this against
+ * a reference copy of the old implementation.
+ *
  * @param {Array<{url: string, company: string, title: string, fingerprint?: string}>} offers
  * @param {Array<{url: string, dateStr: string, company: string, title: string, fingerprint?: string}>} historyRows
  * @param {{today?: Date, threshold?: number, windowDays?: number}} [opts]
@@ -124,22 +198,51 @@ export function findCrossListings(offers, historyRows, opts = {}) {
   const windowDays = opts.windowDays ?? CROSSLIST_WINDOW_DAYS;
   const today = opts.today ? new Date(opts.today) : new Date();
   const cutoff = today.getTime() - windowDays * 86400000;
+  const maxDist = maxDistanceFor(threshold);
+  // A malformed (or absent) fingerprint on either side scores 0, exactly as
+  // similarity()'s regex guard did. 0 is still a match for a caller passing
+  // threshold <= 0, so the zero-score branch is kept rather than dropped.
+  const zeroScores = 0 >= threshold;
 
-  const recent = historyRows.filter((r) => {
-    if (!r.fingerprint) return false;
-    const t = Date.parse(r.dateStr);
-    return !Number.isNaN(t) && t >= cutoff;
-  });
+  // One pass over history: the date filter, companyKey and fingerprint split
+  // all happen once per row instead of once per (offer, row) pair. Iteration
+  // order is preserved so the pre-sort match order is unchanged.
+  const recent = [];
+  for (const row of historyRows) {
+    if (!row.fingerprint) continue;
+    const t = Date.parse(row.dateStr);
+    if (Number.isNaN(t) || t < cutoff) continue;
+    const valid = FINGERPRINT_RE.test(row.fingerprint);
+    const half = valid ? splitFingerprint(row.fingerprint) : null;
+    recent.push({ row, key: companyKey(row.company), url: row.url, valid, hi: half ? half.hi : 0, lo: half ? half.lo : 0 });
+  }
 
   const matches = [];
   for (const offer of offers) {
     if (!offer.fingerprint) continue;
     const offerCompany = companyKey(offer.company);
-    for (const row of recent) {
-      if (companyKey(row.company) === offerCompany) continue; // re-post, not cross-listing
-      if (row.url === offer.url) continue;
-      const score = similarity(offer.fingerprint, row.fingerprint);
-      if (score >= threshold) matches.push({ offer, row, score });
+    const offerValid = FINGERPRINT_RE.test(offer.fingerprint);
+    // Nothing an invalid offer fingerprint is compared against can score above
+    // 0, so when 0 is below the threshold the whole inner loop is dead.
+    if (!offerValid && !zeroScores) continue;
+    const half = offerValid ? splitFingerprint(offer.fingerprint) : null;
+    const offerHi = half ? half.hi : 0;
+    const offerLo = half ? half.lo : 0;
+    for (const cand of recent) {
+      if (cand.key === offerCompany) continue; // re-post, not cross-listing
+      if (cand.url === offer.url) continue;
+      let score;
+      if (offerValid && cand.valid) {
+        const dist = popcount32(offerHi ^ cand.hi) + popcount32(offerLo ^ cand.lo);
+        // `dist > maxDist` is exactly `1 - dist / 64 < threshold` by the
+        // construction of maxDistanceFor() — no float compare in the hot path.
+        if (dist > maxDist) continue;
+        score = 1 - dist / 64;
+      } else {
+        if (!zeroScores) continue;
+        score = 0;
+      }
+      matches.push({ offer, row: cand.row, score });
     }
   }
   return matches.sort((a, b) => b.score - a.score);

--- a/tests/fingerprint-core.test.mjs
+++ b/tests/fingerprint-core.test.mjs
@@ -1,0 +1,277 @@
+// tests/fingerprint-core.test.mjs — the popcount rewrite of similarity() and
+// findCrossListings() (#2381) must be a pure speedup, never a re-scoring.
+//
+// The old implementation re-parsed both 16-hex fingerprints into BigInts on
+// every pair and counted bits one at a time, inside a loop over
+// offers × recent-history rows: 500 × 20k measured at 53.6 s. The rewrite
+// hoists the per-fingerprint work out of the inner loop and counts bits from a
+// preallocated table, which measured 484x faster — but a 484x speedup that
+// moves a single match across the threshold is a bug, not an optimization.
+//
+// So the assertions below are differential: a reference copy of the ORIGINAL
+// BigInt implementation is inlined here and both are run over the same inputs.
+// The reference is intentionally a verbatim transcription, not a refactor, and
+// must not be "cleaned up" — its whole value is being the code that shipped.
+//
+// The seams that actually break under this rewrite, and what covers each:
+//   - the 0..1 threshold → maximum-bit-distance conversion (off-by-one at a
+//     bit boundary): pinned exactly at every boundary, and differentially at
+//     all 65 of them;
+//   - hoisted per-row state going stale across offers (companyKey, fingerprint
+//     halves): multi-offer, multi-company differential corpus;
+//   - the malformed/empty-fingerprint guard being optimized away: fed rows and
+//     offers with junk fingerprints, including at threshold <= 0 where a score
+//     of 0 is a legitimate match;
+//   - match ORDER changing (callers read matches[0] as the best candidate):
+//     compared as an ordered sequence, never as a set.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+// ── Reference implementation (verbatim pre-#2381 behaviour) ────────────────
+
+/** The shipped similarity(): BigInt parse + one-bit-at-a-time popcount. */
+function refSimilarity(a, b) {
+  if (!/^[0-9a-f]{16}$/.test(a || '') || !/^[0-9a-f]{16}$/.test(b || '')) return 0;
+  let x = BigInt('0x' + a) ^ BigInt('0x' + b);
+  let dist = 0;
+  while (x) {
+    dist += Number(x & 1n);
+    x >>= 1n;
+  }
+  return 1 - dist / 64;
+}
+
+function refCompanyKey(name) {
+  return String(name ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/** The shipped findCrossListings(): companyKey and similarity recomputed per pair. */
+function refFindCrossListings(offers, historyRows, opts = {}) {
+  const threshold = opts.threshold ?? 0.92;
+  const windowDays = opts.windowDays ?? 90;
+  const today = opts.today ? new Date(opts.today) : new Date();
+  const cutoff = today.getTime() - windowDays * 86400000;
+
+  const recent = historyRows.filter((r) => {
+    if (!r.fingerprint) return false;
+    const t = Date.parse(r.dateStr);
+    return !Number.isNaN(t) && t >= cutoff;
+  });
+
+  const matches = [];
+  for (const offer of offers) {
+    if (!offer.fingerprint) continue;
+    const offerCompany = refCompanyKey(offer.company);
+    for (const row of recent) {
+      if (refCompanyKey(row.company) === offerCompany) continue;
+      if (row.url === offer.url) continue;
+      const score = refSimilarity(offer.fingerprint, row.fingerprint);
+      if (score >= threshold) matches.push({ offer, row, score });
+    }
+  }
+  return matches.sort((a, b) => b.score - a.score);
+}
+
+// ── Deterministic corpus ───────────────────────────────────────────────────
+
+/** mulberry32 — seeded so a differential failure reproduces from the log
+ * instead of vanishing on the next run. */
+function rng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const rand = rng(0x2381);
+
+/** A random well-formed fingerprint (16 lowercase hex chars). */
+function randomFingerprint() {
+  let s = '';
+  for (let i = 0; i < 16; i++) s += '0123456789abcdef'[Math.floor(rand() * 16)];
+  return s;
+}
+
+/** Flip `n` distinct bits of a fingerprint — the near-duplicate case that
+ * actually exercises the threshold, which uniform-random pairs (≈32 bits
+ * apart) never reach. */
+function flipBits(fp, n) {
+  const bits = new Set();
+  while (bits.size < n) bits.add(Math.floor(rand() * 64));
+  let v = BigInt('0x' + fp);
+  for (const b of bits) v ^= 1n << BigInt(b);
+  return v.toString(16).padStart(16, '0');
+}
+
+/** A fingerprint at exactly `d` bits of Hamming distance from `fp`. */
+const atDistance = (fp, d) => (d === 0 ? fp : flipBits(fp, d));
+
+console.log('\nfingerprint-core.mjs — popcount rewrite is score-for-score identical (#2381)');
+try {
+  const { similarity, findCrossListings, CROSSLIST_THRESHOLD } =
+    await import(pathToFileURL(join(ROOT, 'fingerprint-core.mjs')).href);
+
+  // ── 1. similarity(): identical scores over random + near-duplicate pairs ──
+  // Strict === , not an epsilon: both paths compute 1 - d/64 from an integer d,
+  // so any difference at all means the distances themselves diverged.
+  const pairs = [];
+  for (let i = 0; i < 2000; i++) {
+    const a = randomFingerprint();
+    pairs.push([a, randomFingerprint()]);           // far apart: ≈32 bits
+    pairs.push([a, atDistance(a, i % 13)]);         // near-duplicate: 0..12 bits
+  }
+  let simMismatch = null;
+  for (const [a, b] of pairs) {
+    if (similarity(a, b) !== refSimilarity(a, b)) { simMismatch = [a, b]; break; }
+  }
+  if (!simMismatch) {
+    pass(`similarity matches the BigInt reference on ${pairs.length} random + near-duplicate pairs`);
+  } else {
+    const [a, b] = simMismatch;
+    fail(`similarity diverged on ${a}/${b}: ${similarity(a, b)} vs reference ${refSimilarity(a, b)}`);
+  }
+
+  // Distance 0..64 in one hop each: covers both 32-bit halves and the sign bit
+  // of each half, which is where a popcount that forgets `>>>` goes wrong.
+  const base = 'ffffffffffffffff';
+  const zeros = '0000000000000000';
+  let sweepBad = null;
+  for (let d = 0; d <= 64; d++) {
+    const probe = atDistance(zeros, d);
+    if (similarity(zeros, probe) !== refSimilarity(zeros, probe)) { sweepBad = d; break; }
+    if (similarity(base, probe) !== refSimilarity(base, probe)) { sweepBad = d; break; }
+  }
+  if (sweepBad === null) pass('similarity matches the reference at every Hamming distance 0..64');
+  else fail(`similarity diverged at distance ${sweepBad}`);
+
+  // The top bit of either 32-bit half makes `^` produce a NEGATIVE int32, and
+  // a popcount table is only defined over 0..65535. Any index that is not
+  // masked back into that range (a raw shift, a divide, a sign-extended value)
+  // reads out of bounds, yields undefined, and turns the score into NaN — which
+  // compares false against every threshold, so the pair silently stops matching
+  // instead of failing loudly. One bit set in each half, checked separately.
+  if (similarity('8000000000000000', zeros) === 1 - 1 / 64 &&
+      similarity('0000000080000000', zeros) === 1 - 1 / 64) {
+    pass('similarity counts a set sign bit in either 32-bit half (table index stays in range)');
+  } else {
+    fail(`sign-bit halves scored ${similarity('8000000000000000', zeros)} / ${similarity('0000000080000000', zeros)}`);
+  }
+
+  // Malformed input must still be 0. The rewrite keeps the same regex guard;
+  // if it were dropped, parseInt would return NaN and score NaN, not 0.
+  const guards = [[zeros, ''], ['', ''], [zeros, 'zzzz'], [zeros, 'FFFFFFFFFFFFFFFF'], [zeros, '00000000000000000'], [null, zeros], [undefined, undefined]];
+  const guardBad = guards.find(([a, b]) => similarity(a, b) !== refSimilarity(a, b) || similarity(a, b) !== 0);
+  if (!guardBad) pass('similarity returns 0 for empty/short/uppercase/non-hex/nullish input, as before');
+  else fail(`guard diverged on ${JSON.stringify(guardBad)}: got ${similarity(guardBad[0], guardBad[1])}`);
+
+  // ── 2. threshold → maximum bit distance, the off-by-one seam ─────────────
+  // 0.92 is the shipped CROSSLIST_THRESHOLD, and 1 - 5/64 = 0.921875 while
+  // 1 - 6/64 = 0.90625. A max-distance derivation that rounds the wrong way
+  // admits 6-bit pairs (false cross-listings) or rejects 5-bit ones (the
+  // agency re-posts this feature exists to catch).
+  const anchor = '0f1e2d3c4b5a6978';
+  const mkPair = (d) => ({
+    offers: [{ url: 'https://agency.example/j/1', company: 'Hays', title: 't', fingerprint: anchor }],
+    history: [{ url: 'https://acme.example/j/9', dateStr: '2026-06-20', company: 'Acme', title: 't', fingerprint: atDistance(anchor, d) }],
+  });
+  const hit = (d, threshold) => {
+    const { offers, history } = mkPair(d);
+    return findCrossListings(offers, history, { today: '2026-07-06', threshold }).length;
+  };
+  if (hit(5, CROSSLIST_THRESHOLD) === 1 && hit(6, CROSSLIST_THRESHOLD) === 0) {
+    pass('at the shipped 0.92 threshold, 5 differing bits match and 6 do not');
+  } else {
+    fail(`0.92 threshold admitted the wrong distances: 5 bits → ${hit(5, CROSSLIST_THRESHOLD)}, 6 bits → ${hit(6, CROSSLIST_THRESHOLD)}`);
+  }
+
+  // Thresholds sitting exactly ON a bit boundary are where floor()/ceil()
+  // derivations break: the comparison is >=, so distance k must still match at
+  // threshold 1 - k/64, while k+1 must not.
+  let boundaryBad = null;
+  for (let k = 0; k <= 63; k++) {
+    const t = 1 - k / 64;
+    if (hit(k, t) !== 1 || hit(k + 1, t) !== 0) { boundaryBad = k; break; }
+  }
+  if (boundaryBad === null) {
+    pass('every exact bit-boundary threshold (1 - k/64) admits k bits and rejects k+1');
+  } else {
+    const t = 1 - boundaryBad / 64;
+    fail(`threshold ${t} (k=${boundaryBad}) gave ${hit(boundaryBad, t)}/${hit(boundaryBad + 1, t)}, expected 1/0`);
+  }
+
+  // ── 3. findCrossListings(): identical matches, identical order ────────────
+  // The corpus deliberately mixes everything the hoisting could get wrong:
+  // several offers (stale per-offer state), companies that collide only after
+  // normalization ("Acme Ltd." vs "acme-ltd"), same-URL pairs, rows outside the
+  // 90-day window, unparseable dates, empty and malformed fingerprints, and
+  // clusters of near-duplicates so many rows land near the threshold at once.
+  const seeds = Array.from({ length: 6 }, () => randomFingerprint());
+  const companies = ['Acme', 'Acme Ltd.', 'acme-ltd', 'Hays', 'Globex', 'Initech', 'Umbrella'];
+  const offers = [];
+  for (let i = 0; i < 40; i++) {
+    const seed = seeds[i % seeds.length];
+    offers.push({
+      url: `https://agency.example/j/${i}`,
+      company: companies[i % companies.length],
+      title: `Role ${i}`,
+      fingerprint: i % 11 === 0 ? '' : i % 17 === 0 ? 'not-a-fingerprint' : atDistance(seed, i % 9),
+    });
+  }
+  const history = [];
+  for (let i = 0; i < 400; i++) {
+    const seed = seeds[i % seeds.length];
+    history.push({
+      url: i % 23 === 0 ? `https://agency.example/j/${i % 40}` : `https://board.example/j/${i}`,
+      dateStr: i % 29 === 0 ? 'not-a-date' : i % 7 === 0 ? '2025-01-01' : `2026-0${(i % 6) + 1}-1${i % 10}`,
+      company: companies[(i + 3) % companies.length],
+      title: `Role ${i}`,
+      fingerprint: i % 13 === 0 ? '' : i % 19 === 0 ? 'zzzz' : atDistance(seed, i % 10),
+    });
+  }
+
+  // Identity of the matched objects matters too: callers reach through to
+  // match.offer/match.row, so compare the URLs actually referenced, not copies.
+  const shape = (ms) => ms.map((m) => `${m.offer.url}|${m.row.url}|${m.score}`).join('\n');
+  let corpusBad = null;
+  for (const threshold of [0.92, 1, 0.9375, 0.5, 0.984375, 0]) {
+    for (const windowDays of [90, 30]) {
+      const opts = { today: '2026-07-06', threshold, windowDays };
+      const got = shape(findCrossListings(offers, history, opts));
+      const want = shape(refFindCrossListings(offers, history, opts));
+      if (got !== want) { corpusBad = { threshold, windowDays, got, want }; break; }
+    }
+    if (corpusBad) break;
+  }
+  if (!corpusBad) {
+    pass('findCrossListings output is identical to the reference across 6 thresholds × 2 windows (same matches, same order)');
+  } else {
+    const g = corpusBad.got.split('\n');
+    const w = corpusBad.want.split('\n');
+    const at = g.findIndex((line, i) => line !== w[i]);
+    fail(`findCrossListings diverged at threshold=${corpusBad.threshold} windowDays=${corpusBad.windowDays}, row ${at}: got ${g[at]}, want ${w[at]} (${g.length} vs ${w.length} matches)`);
+  }
+
+  // The corpus is only meaningful if it actually produces matches — a filter
+  // bug that returned nothing would otherwise pass the comparison above.
+  const produced = findCrossListings(offers, history, { today: '2026-07-06' }).length;
+  if (produced > 0) pass(`differential corpus produces ${produced} real matches at the default threshold`);
+  else fail('differential corpus produced 0 matches — it proves nothing');
+
+  // threshold 0 is the one case where a score of 0 is a match, so the
+  // malformed-fingerprint pairs the fast path would rather skip must still be
+  // emitted. Covered in the sweep above; asserted separately because dropping
+  // that branch is the tempting simplification.
+  const zeroT = { today: '2026-07-06', threshold: 0 };
+  if (shape(findCrossListings(offers, history, zeroT)) === shape(refFindCrossListings(offers, history, zeroT))) {
+    pass('at threshold 0, malformed-fingerprint pairs still score 0 and still match, as before');
+  } else {
+    fail('threshold 0 dropped the zero-score matches the reference emits');
+  }
+} catch (e) {
+  fail(`fingerprint-core popcount equivalence tests crashed: ${e.stack || e.message}`);
+}


### PR DESCRIPTION
Closes #2381

## What was slow

`similarity()` parsed both 16-hex-char fingerprints into BigInts on every call and counted set bits one at a time (`while (x) { dist += Number(x & 1n); x >>= 1n; }`). `findCrossListings()` called it once per (offer, recent history row) pair, and recomputed `companyKey(row.company)` on every pair as well. At 500 offers against 5k history rows that works out to 2.5M BigInt allocations and 2.5M redundant string normalizations, none of which depend on the pair.

## What changed

Per-fingerprint work is hoisted out of the inner loop. Each fingerprint is split once into two 32-bit halves, and each history row's `companyKey` plus its halves are computed once while the recent-window list is built. Hamming distance now comes from a 64 KB `Uint8Array` popcount table indexed 16 bits at a time.

The 0..1 `threshold` is converted once into a maximum bit distance, so the inner loop compares integers and never touches floating point. That conversion is the part most likely to hide an off-by-one, so it is not derived by rounding `64 * (1 - threshold)`. Instead it searches for the largest `d` satisfying the same `1 - d / 64 >= threshold` expression the per-pair path used to evaluate. For integer `d`, `d / 64` is exact in binary floating point, so the search reproduces the old accept/reject decision at every threshold, including thresholds landing exactly on a bit boundary where a `floor()` or `ceil()` derivation is one off in one direction.

`similarity(a, b)` keeps its signature, its 0..1 return value and its regex guard, so malformed or empty input still yields 0. The malformed-fingerprint path inside `findCrossListings` still scores 0 rather than skipping, because a caller passing `threshold <= 0` legitimately matches on a score of 0.

## Measured on this machine (Windows 11, Node 22.23.1)

| workload | before | after | |
|---|---|---|---|
| 500 offers x 5k rows (2.5M pairs) | 4370.9 ms | 16.4 ms | 266x |
| 500 offers x 20k rows (10M pairs) | 18028.8 ms | 61.9 ms | 291x |

Both runs returned an identical match list (25 and 121 matches respectively), compared as an ordered sequence of offer URL, row URL and score.

## Equivalence, not approximation

The distances are unchanged, and the new tests establish that rather than assuming it. `tests/fingerprint-core.test.mjs` inlines a verbatim copy of the previous BigInt implementation of both `similarity()` and `findCrossListings()` and runs old against new over:

- 4000 pairs, half uniformly random and half near-duplicates 0 to 12 bits apart, asserting strict `===` on the score rather than an epsilon, since both paths derive `1 - d / 64` from an integer `d` and any difference at all means the distances diverged
- every Hamming distance from 0 to 64, from two different base fingerprints
- all 65 exact bit-boundary thresholds `1 - k/64`, each asserting that `k` differing bits still match and `k+1` does not
- a 40 offer by 400 row corpus across 6 thresholds and 2 window sizes, mixing empty and malformed fingerprints, companies that collide only after normalization (`Acme Ltd.` vs `acme-ltd`), same-URL pairs, unparseable dates and out-of-window rows

The corpus comparison covers order as well as content, because callers read `matches[0]` as the best candidate. A separate assertion checks the corpus actually produces matches (153 at the default threshold), so a filter bug returning nothing could not pass by comparing empty against empty.

I sanity-checked the tests by mutating the implementation: replacing the threshold conversion with `Math.ceil(64 * (1 - threshold))` fails 2 assertions, with `Math.floor(...) - 1` fails 3, dropping the zero-score branch fails 2, and removing the table index mask fails 3. The seeded PRNG means any failure reproduces from the log.

## Validation

`node test-all.mjs`: 2756 passed, 1 failed, 2 warnings. 9 of those passes are new.

The single failure is `analyze() appDateSource end-to-end check crashed: EPERM: operation not permitted, symlink`. It is environmental rather than a regression: the check calls `symlinkSync()` to stage a temp directory, which Windows refuses without elevation, and it exercises `followup-cadence.mjs` and `tracker-parse.mjs`, neither of which this branch touches. It is the known baseline failure on this box and should not appear on Linux CI.
