### PR TITLE
perf(detect-reposts): bucket titles instead of comparing every pair

### DIFF
--- a/detect-reposts.mjs
+++ b/detect-reposts.mjs
@@ -25,7 +25,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
-import { roleFuzzyMatch } from './role-matcher.mjs';
+import { roleFuzzyMatch, roleTokens, BASELINE_TOKENS } from './role-matcher.mjs';
 import { normalizeCompanyName } from './invite-match.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
@@ -164,22 +164,7 @@ export function detectReposts(rows, windowDays = DEFAULT_WINDOW_DAYS) {
 // approach prevents non-matching roles (e.g. a Product Manager between two
 // Backend Engineer postings) from breaking a valid repost cluster.
 function detectRepostsInGroup(rows, windowDays) {
-  const titleGroups = [];
-  const used = new Set();
-
-  for (const row of rows) {
-    if (used.has(row)) continue;
-    const group = [row];
-    used.add(row);
-    for (const other of rows) {
-      if (used.has(other)) continue;
-      if (row.title.toLowerCase() === other.title.toLowerCase() || roleFuzzyMatch(row.title, other.title)) {
-        group.push(other);
-        used.add(other);
-      }
-    }
-    titleGroups.push(group);
-  }
+  const titleGroups = groupRowsByTitle(rows);
 
   const results = [];
   for (const group of titleGroups) {
@@ -216,6 +201,150 @@ function detectRepostsInGroup(rows, windowDays) {
     }
   }
   return results;
+}
+
+// Group one company's rows into title groups: a seed row plus every later row
+// whose title matches it (exact, case-insensitively, or via roleFuzzyMatch).
+//
+// The obvious implementation is a nested loop over rows, and that is what this
+// used to be. It degrades badly on the shape scan-history.tsv actually grows
+// into: the file is append-only with one row per scanned posting, so a large
+// employer accumulates thousands of DISTINCT titles. Nothing collapses, every
+// pair pays a full roleFuzzyMatch (which re-tokenizes both strings on every
+// call), and the run goes quadratic with a very expensive constant (#2383).
+//
+// Two structures replace the nested loop without changing what it computes:
+//
+//   1. Rows are bucketed by their lowercased title in one pass. Every row in a
+//      bucket matches every other by the exact-title arm of the old condition,
+//      so a bucket is atomic: a seed either takes the whole bucket or none of
+//      it. Exact reposts (the overwhelming majority of real ones) therefore
+//      collapse in O(N) with no fuzzy calls at all, and toLowerCase() runs once
+//      per row instead of once per comparison.
+//
+//   2. Fuzzy matching then runs over DISTINCT buckets only, and even there is
+//      gated by an inverted index over non-baseline tokens. roleFuzzyMatch can
+//      only return true for two non-identical titles when their deduped token
+//      sets share at least two tokens, at least one of which is not a
+//      BASELINE_TOKENS word, and their Jaccard ratio is >= 0.6. All three are
+//      necessary conditions and all three are checked exactly here, so any
+//      bucket pair the gate drops is one roleFuzzyMatch would have rejected
+//      anyway. The gate filters calls, never verdicts: every surviving pair is
+//      still decided by roleFuzzyMatch itself.
+//
+// Ordering is preserved exactly, because it is load-bearing downstream. The
+// date sort in detectRepostsInGroup uses a comparator that returns 1 (not 0)
+// for equal dates, so same-date rows keep their input order only if the group
+// arrives in input order; buildRepostCluster also reads clusterRows[0].company.
+// Groups are therefore emitted in seed order and their rows re-sorted by
+// original array position, which is what the nested loop produced: the seed is
+// always the first not-yet-used row, and the inner loop appended the rest in
+// array order.
+function groupRowsByTitle(rows) {
+  // Pass 1 — bucket by lowercased title, remembering each row's original
+  // position so groups can be rebuilt in input order later.
+  const buckets = [];
+  const bucketOfKey = new Map();
+  for (let i = 0; i < rows.length; i++) {
+    const key = rows[i].title.toLowerCase();
+    let idx = bucketOfKey.get(key);
+    if (idx === undefined) {
+      idx = buckets.length;
+      bucketOfKey.set(key, idx);
+      // The representative title is the FIRST row's raw title, which is also
+      // the row the nested loop would have used as the seed. Other rows in the
+      // bucket differ from it only in case, and every decision roleFuzzyMatch
+      // makes runs on lowercased text, so the choice cannot change a verdict.
+      buckets.push({ title: rows[i].title, rowIdx: [], tokens: null, tokenSet: null });
+    }
+    buckets[idx].rowIdx.push(i);
+  }
+
+  // Single distinct title: the nested loop would have made one group of
+  // everything. Skip the index entirely.
+  if (buckets.length === 1) return [buckets[0].rowIdx.map(i => rows[i])];
+
+  // Pass 2 — tokenize each distinct title once, then index DISCRIMINATING
+  // token -> buckets. Baseline tokens are deliberately left out of the index:
+  // words like "engineer" or "platform" appear in most titles at a company, so
+  // indexing them would build one enormous posting list that has to be walked
+  // for every seed and can never, on its own, justify a match.
+  const postings = new Map();
+  for (let b = 0; b < buckets.length; b++) {
+    const tokens = [...new Set(roleTokens(buckets[b].title))];
+    buckets[b].tokens = tokens;
+    buckets[b].tokenSet = new Set(tokens);
+    for (const token of tokens) {
+      if (BASELINE_TOKENS.has(token)) continue;
+      let list = postings.get(token);
+      if (!list) { list = []; postings.set(token, list); }
+      list.push(b);
+    }
+  }
+
+  // Pass 3 — seed buckets in first-appearance order, gathering matches.
+  const used = new Uint8Array(buckets.length);
+  const seen = new Uint8Array(buckets.length);
+  const candidates = [];
+  const groups = [];
+
+  for (let seed = 0; seed < buckets.length; seed++) {
+    if (used[seed]) continue;
+    used[seed] = 1;
+    const members = [seed];
+    const seedTokens = buckets[seed].tokens;
+
+    // Collect every bucket sharing at least one discriminating token with the
+    // seed. A bucket that shares none cannot match: roleFuzzyMatch requires a
+    // non-baseline word in the overlap, so it would return false without ever
+    // being asked.
+    for (const token of seedTokens) {
+      const list = postings.get(token);
+      if (!list) continue;
+      for (const b of list) {
+        if (b === seed || used[b] || seen[b]) continue;
+        seen[b] = 1;
+        candidates.push(b);
+      }
+    }
+
+    // Ascending bucket order keeps the candidate walk deterministic. It cannot
+    // change the outcome — each candidate is tested against the seed alone —
+    // but it makes the traversal reproducible run to run.
+    candidates.sort((a, b) => a - b);
+    for (const b of candidates) {
+      seen[b] = 0;
+      // Exact overlap over the deduped token sets, then the exact Jaccard
+      // ratio |A n B| / |A u B| with |A u B| = |A| + |B| - |A n B|. Both are
+      // the same numbers roleFuzzyMatch computes; failing either is a verdict
+      // it would have reached itself.
+      const candSet = buckets[b].tokenSet;
+      let overlap = 0;
+      for (const token of seedTokens) if (candSet.has(token)) overlap += 1;
+      if (overlap < 2) continue;
+      const union = seedTokens.length + buckets[b].tokens.length - overlap;
+      if (overlap / union < 0.6) continue;
+      if (roleFuzzyMatch(buckets[seed].title, buckets[b].title)) {
+        used[b] = 1;
+        members.push(b);
+      }
+    }
+    candidates.length = 0;
+
+    if (members.length === 1) {
+      groups.push(buckets[seed].rowIdx.map(i => rows[i]));
+      continue;
+    }
+    // Appended one index at a time rather than spread: a pathological history
+    // can put a very large number of rows into a single bucket, and a spread
+    // that wide overflows the argument stack.
+    const merged = [];
+    for (const b of members) for (const i of buckets[b].rowIdx) merged.push(i);
+    merged.sort((a, b) => a - b);
+    groups.push(merged.map(i => rows[i]));
+  }
+
+  return groups;
 }
 
 // A fuzzy-matched cluster becomes a repost cluster only when (a) at least two

--- a/detect-reposts.test.mjs
+++ b/detect-reposts.test.mjs
@@ -1045,8 +1045,17 @@ sameAsLegacy('equivalence: singleton companies and singleton titles', [
 // failure is reproducible rather than a one-off.
 let seed = 20260731;
 const rand = (n) => {
-  seed = (seed * 1103515245 + 12345) & 0x7fffffff;
-  return seed % n;
+  // Math.imul, not `*`: the product overflows 2^53, so plain multiplication
+  // rounds the low bits away and the generator degenerates. Measured over 3000
+  // draws mod 6 it returned {0:909, 1:1, 2:1022, 3:12, 4:1056} and never once
+  // returned 5, so the corpus never picked the last entry of a six-item list
+  // (the "Machine Learning" domain was unreachable).
+  seed = (Math.imul(seed, 1103515245) + 12345) & 0x7fffffff;
+  // Take the HIGH bits: an LCG's low bits have a very short period (these cycle
+  // 0,1,2,3 under `% 4`). Each row draws eight times and the company is the
+  // seventh draw, so it landed on the same phase every row and all 300 rows got
+  // a single company, despite the comment above promising several.
+  return (seed >>> 16) % n;
 };
 const levels = ['', 'Senior ', 'Staff ', 'Principal ', 'Associate '];
 const domains = ['Backend', 'Frontend', 'Platform', 'Security', 'Analytics', 'Machine Learning'];

--- a/detect-reposts.test.mjs
+++ b/detect-reposts.test.mjs
@@ -842,9 +842,268 @@ eq('SW: distinct roles not grouped', detectReposts([
 ], 90).length, 1);
 
 // ============================================================================
+// 10.6 Grouping equivalence with the pre-#2383 algorithm
+// ============================================================================
+console.log('\n--- 10.6 grouping equivalence (#2383) ---');
+
+// #2383 replaced the nested title loop in detectRepostsInGroup with a
+// bucket-by-lowercased-title Map plus an inverted token index. That was a pure
+// speed change, so the only thing worth testing is that it is in fact pure:
+// the clusters coming out must be byte-identical to what the old loop produced,
+// including their order and the order of appearances inside them.
+//
+// The reference below is the pre-#2383 file, copied verbatim. It is frozen on
+// purpose. If detect-reposts.mjs ever changes what it computes (window rules,
+// cluster shape, dedup policy) rather than how fast it computes it, this copy
+// must be updated in the same commit. A silent divergence failing here is the
+// intended behaviour, not a nuisance.
+function legacyBuildRepostCluster(clusterRows, windowDays) {
+  const byUrl = new Map();
+  for (const r of clusterRows) {
+    if (!byUrl.has(r.url) || r.date < byUrl.get(r.url).date) byUrl.set(r.url, r);
+  }
+  const deduped = [...byUrl.values()];
+  if (deduped.length < 2) return null;
+  const sorted = [...deduped].sort((a, b) => (a.date < b.date ? -1 : 1));
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  const span = daysBetween(first.date, last.date);
+  if (span > windowDays) return null;
+  return {
+    company: clusterRows[0].company,
+    role: last.title,
+    repostCount: sorted.length,
+    firstSeen: first.dateStr,
+    lastSeen: last.dateStr,
+    daysSpan: span,
+    appearances: sorted.map(r => ({ url: r.url, date: r.dateStr, title: r.title })),
+  };
+}
+
+function legacyDetectRepostsInGroup(rows, windowDays) {
+  // The quadratic loop this change removed: every row is compared against every
+  // other row with a fresh toLowerCase() and a fresh roleFuzzyMatch().
+  const titleGroups = [];
+  const used = new Set();
+  for (const r of rows) {
+    if (used.has(r)) continue;
+    const group = [r];
+    used.add(r);
+    for (const other of rows) {
+      if (used.has(other)) continue;
+      if (r.title.toLowerCase() === other.title.toLowerCase() || roleFuzzyMatch(r.title, other.title)) {
+        group.push(other);
+        used.add(other);
+      }
+    }
+    titleGroups.push(group);
+  }
+
+  const results = [];
+  for (const group of titleGroups) {
+    if (group.length < 2) continue;
+    const sorted = [...group].sort((a, b) => (a.date < b.date ? -1 : 1));
+    let cluster = [];
+    for (const r of sorted) {
+      if (cluster.length === 0) { cluster = [r]; continue; }
+      const span = daysBetween(cluster[0].date, r.date);
+      if (span <= windowDays) {
+        cluster.push(r);
+      } else {
+        if (cluster.length >= 2) {
+          const built = legacyBuildRepostCluster(cluster, windowDays);
+          if (built) results.push(built);
+        }
+        cluster = cluster.filter(cr => daysBetween(cr.date, r.date) <= windowDays);
+        cluster.push(r);
+      }
+    }
+    if (cluster.length >= 2) {
+      const built = legacyBuildRepostCluster(cluster, windowDays);
+      if (built) results.push(built);
+    }
+  }
+  return results;
+}
+
+function legacyDetectReposts(rows, windowDays = 90) {
+  if (!Array.isArray(rows)) return [];
+  const valid = rows
+    .filter(r =>
+      r && typeof r === 'object' && r.status === 'added' &&
+      typeof r.url === 'string' && r.url.trim() &&
+      r.date instanceof Date && !Number.isNaN(r.date.getTime()) &&
+      typeof r.company === 'string' && r.company.trim() &&
+      typeof r.title === 'string' && r.title.trim()
+    )
+    .map(r => ({ ...r, url: r.url.trim(), company: r.company.trim(), title: r.title.trim() }));
+  if (valid.length < 2) return [];
+
+  const byCompany = new Map();
+  for (const r of valid) {
+    const key = companyKey(r);
+    if (!byCompany.has(key)) byCompany.set(key, []);
+    byCompany.get(key).push(r);
+  }
+
+  const clusters = [];
+  for (const [, groupRows] of byCompany) {
+    if (groupRows.length < 2) continue;
+    clusters.push(...legacyDetectRepostsInGroup(groupRows, windowDays));
+  }
+  return clusters.sort((a, b) => (a.lastSeen < b.lastSeen ? 1 : -1));
+}
+
+// Compares full cluster output, not just cluster counts: eq() stringifies, so
+// this catches a changed cluster order, a changed appearance order inside a
+// cluster, or a different `role`/`company` representative being picked.
+function sameAsLegacy(label, rows, windowDays = 90) {
+  eq(label, detectReposts(rows, windowDays), legacyDetectReposts(rows, windowDays));
+}
+
+// Compact row builder for the corpora below.
+function eqRow(url, dateStr, title, company = 'Acme', status = 'added') {
+  return { url, date: d(dateStr), dateStr, title, company, status, portal: 'greenhouse', location: '' };
+}
+
+function dayStr(offset) {
+  // Walks forward from 2026-01-01 without needing a calendar in the caller.
+  const base = Date.UTC(2026, 0, 1) + offset * 86400000;
+  return new Date(base).toISOString().slice(0, 10);
+}
+
+// (a) Many DISTINCT titles at one company — the shape from the issue. Nothing
+// collapses, so this is the corpus where the old loop paid for every pair.
+const distinctCorpus = Array.from({ length: 120 }, (_, i) =>
+  eqRow(`https://x.com/d${i}`, dayStr(i % 200), `Backend Engineer, Squad ${'Zephyr'}${i}`)
+);
+sameAsLegacy('equivalence: 120 distinct titles, one company', distinctCorpus);
+
+// (b) Many EXACT duplicates — the case bucketing collapses in one pass. Dates
+// are spread so the sliding window produces several overlapping clusters.
+const exactCorpus = Array.from({ length: 60 }, (_, i) =>
+  eqRow(`https://x.com/e${i}`, dayStr(i * 7), 'Senior Backend Engineer, Payments')
+);
+sameAsLegacy('equivalence: 60 exact duplicates spread over a year', exactCorpus);
+
+// (c) Fuzzy-but-not-exact variants. These are the pairs that must still reach
+// roleFuzzyMatch through the token index rather than being filtered out.
+sameAsLegacy('equivalence: fuzzy word-order variants', [
+  eqRow('https://x.com/f1', dayStr(0), 'Senior Backend Engineer Payments'),
+  eqRow('https://x.com/f2', dayStr(20), 'Backend Engineer Payments Senior'),
+  eqRow('https://x.com/f3', dayStr(40), 'Senior Backend Engineer Payments Processing'),
+  eqRow('https://x.com/f4', dayStr(60), 'Backend Engineer Payments Processing Senior'),
+  eqRow('https://x.com/f5', dayStr(80), 'Engineering Manager Platform Infrastructure'),
+]);
+
+// (d) Near-misses that must NOT match: shared baseline vocabulary only, a
+// sub-baseline seniority on one side, and a specialization suffix. If the token
+// index ever let one of these through, the clusters would differ here.
+sameAsLegacy('equivalence: near-miss titles stay separate', [
+  eqRow('https://x.com/n1', dayStr(0), 'Software Engineer'),
+  eqRow('https://x.com/n2', dayStr(10), 'Software Developer'),
+  eqRow('https://x.com/n3', dayStr(20), 'Associate Product Manager, Marketplace'),
+  eqRow('https://x.com/n4', dayStr(30), 'Product Manager, Marketplace'),
+  eqRow('https://x.com/n5', dayStr(40), 'Senior Analytics Engineer'),
+  eqRow('https://x.com/n6', dayStr(50), 'Senior Analytics Engineer, People Analytics'),
+]);
+
+// (e) Case variants inside one title bucket. The new code compares the FIRST
+// row's raw title on behalf of the whole bucket, so this proves that choosing a
+// different-cased representative cannot change a verdict or the emitted `role`.
+sameAsLegacy('equivalence: mixed-case duplicates of one title', [
+  eqRow('https://x.com/c1', dayStr(0), 'Senior Backend Engineer, Payments'),
+  eqRow('https://x.com/c2', dayStr(10), 'SENIOR BACKEND ENGINEER, PAYMENTS'),
+  eqRow('https://x.com/c3', dayStr(20), 'senior backend engineer, payments'),
+  eqRow('https://x.com/c4', dayStr(30), 'Senior Backend Engineer Payments'),
+]);
+
+// (f) Same-date rows. The date sort in detectRepostsInGroup uses a comparator
+// that returns 1 rather than 0 for equal dates, so its result depends on the
+// order rows arrive in. This corpus fails loudly if grouping stops preserving
+// original array order.
+sameAsLegacy('equivalence: same-date rows keep input order', [
+  eqRow('https://x.com/s1', dayStr(0), 'Data Engineer, Ingestion'),
+  eqRow('https://x.com/s2', dayStr(0), 'Data Engineer, Ingestion'),
+  eqRow('https://x.com/s3', dayStr(0), 'data engineer, ingestion'),
+  eqRow('https://x.com/s4', dayStr(0), 'Data Engineer Ingestion'),
+  eqRow('https://x.com/s5', dayStr(0), 'Data Engineer, Ingestion'),
+]);
+
+// (g) Singletons: companies with one row, and titles that group alone. These
+// take the early-exit paths in the new grouping and must still be no-ops.
+sameAsLegacy('equivalence: singleton companies and singleton titles', [
+  eqRow('https://a.com/1', dayStr(0), 'Backend Engineer, Checkout', 'Alpha'),
+  eqRow('https://b.com/1', dayStr(5), 'Frontend Engineer, Checkout', 'Beta'),
+  eqRow('https://c.com/1', dayStr(10), 'Security Engineer, Identity', 'Gamma'),
+  eqRow('https://c.com/2', dayStr(15), 'Security Engineer, Identity', 'Gamma'),
+  eqRow('https://d.com/1', dayStr(20), 'Compiler Engineer, Toolchain', 'Delta'),
+]);
+
+// (h) Mixed corpus: several companies, duplicate URLs, non-added statuses,
+// out-of-order dates, shared vocabulary. Generated from a seeded LCG so a
+// failure is reproducible rather than a one-off.
+let seed = 20260731;
+const rand = (n) => {
+  seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+  return seed % n;
+};
+const levels = ['', 'Senior ', 'Staff ', 'Principal ', 'Associate '];
+const domains = ['Backend', 'Frontend', 'Platform', 'Security', 'Analytics', 'Machine Learning'];
+const kinds = ['Engineer', 'Developer', 'Manager'];
+const teams = ['Checkout', 'Marketplace', 'Billing', 'Ingestion', 'Trust'];
+const statuses = ['added', 'added', 'added', 'added', 'skipped_expired'];
+const mixedCorpus = Array.from({ length: 300 }, (_, i) => {
+  const title = `${levels[rand(levels.length)]}${domains[rand(domains.length)]} ${kinds[rand(kinds.length)]}, ${teams[rand(teams.length)]}`;
+  // Deliberate URL reuse (i % 7) so the URL-dedup path inside clusters runs.
+  return eqRow(
+    `https://mix.com/${i % 7 === 0 ? i - (i % 7) : i}`,
+    dayStr(rand(240)),
+    rand(9) === 0 ? title.toUpperCase() : title,
+    `Company${rand(4)}`,
+    statuses[rand(statuses.length)]
+  );
+});
+sameAsLegacy('equivalence: 300-row mixed corpus (seeded)', mixedCorpus);
+sameAsLegacy('equivalence: same mixed corpus at window=30', mixedCorpus, 30);
+sameAsLegacy('equivalence: same mixed corpus at window=0', mixedCorpus, 0);
+
+// The mixed corpus is only meaningful if it actually produces clusters — an
+// all-empty comparison would pass no matter what the grouping did.
+ok('equivalence corpus is non-trivial (mixed corpus yields clusters)', detectReposts(mixedCorpus, 90).length > 0);
+ok('equivalence corpus is non-trivial (exact-duplicate corpus yields clusters)', detectReposts(exactCorpus, 90).length > 0);
+
+// ============================================================================
 // 11. Performance
 // ============================================================================
 console.log('\n--- 11. performance ---');
+
+// #2383 regression guard. 4000 rows at ONE company with distinct titles is the
+// reachable worst case: scan-history.tsv is append-only with one row per
+// scanned posting, so a large employer accumulates thousands of distinct
+// titles and nothing collapses. The pre-#2383 nested loop took ~45s on this
+// machine for this shape; the bucketed version takes a fraction of a second.
+// The budget is deliberately loose (a whole order of magnitude of headroom
+// over the observed runtime) so it is not a wall-clock flake on a loaded CI
+// box, while still failing hard if the quadratic loop ever comes back.
+const bigDistinct = [];
+for (let i = 0; i < 4000; i++) {
+  // One unique discriminating token per title and otherwise only baseline
+  // vocabulary, so no two of these fuzzy-match (the overlap would be
+  // [backend, engineer], both baseline) and the expected cluster count is
+  // exactly the number of planted reposts below.
+  bigDistinct.push(eqRow(`https://big.com/u${i}`, dayStr(i % 200), `Backend Engineer, Zephyr${i}`, 'BigCo'));
+}
+// 25 planted exact reposts (distinct URL, same title, 10 days apart) so the
+// guard cannot pass by silently returning nothing.
+for (let i = 0; i < 25; i++) {
+  bigDistinct.push(eqRow(`https://big.com/r${i}`, dayStr((i % 200) + 10), `Backend Engineer, Zephyr${i}`, 'BigCo'));
+}
+const bigStart = Date.now();
+const bigClusters = detectReposts(bigDistinct, 90);
+const bigElapsed = Date.now() - bigStart;
+eq('4025 rows at one company: exactly the 25 planted reposts found', bigClusters.length, 25);
+ok(`4025 rows at one company completes under 10s (#2383 quadratic guard, took ${bigElapsed}ms)`, bigElapsed < 10000);
 
 // Smoke tests only — no wall-clock thresholds (flaky on CI)
 const perfRows = Array.from({ length: 100 }, (_, i) => row({


### PR DESCRIPTION
Closes #2383

## What was slow

`detectRepostsInGroup` grouped one company's rows with a nested loop over rows. Every pair paid a full `roleFuzzyMatch`, which re-tokenizes both strings on each call, and the seed's `row.title.toLowerCase()` was re-allocated inside the inner loop. The `used` set only prunes when titles collapse into groups, so a company with many distinct titles pruned nothing.

That shape is reachable rather than theoretical. `data/scan-history.tsv` is append-only with one row per scanned posting, so a large employer accumulates thousands of distinct titles over time.

## What changed

Grouping now runs in three passes instead of one nested loop.

Rows are bucketed by their lowercased title in a Map. Every row in a bucket matches every other row in it through the exact-title arm of the old condition, so a bucket is atomic: a seed takes all of it or none of it. Exact reposts, which are most real reposts, collapse in linear time with no fuzzy calls, and `toLowerCase()` runs once per row instead of once per comparison.

Fuzzy matching then runs over distinct buckets only, gated by an inverted index over non-baseline tokens. `roleFuzzyMatch` can only return true for two non-identical titles when their deduped token sets share at least two tokens, at least one of which is not in `BASELINE_TOKENS`, and their Jaccard ratio is 0.6 or higher. Those are necessary conditions, and all of them are computed exactly from the precomputed token sets, so any pair the gate drops is one `roleFuzzyMatch` would have rejected anyway. Every pair that survives the gate is still decided by `roleFuzzyMatch` itself. The gate filters calls, not verdicts.

Group order and row order within each group are preserved exactly. Both are load-bearing: the date sort in `detectRepostsInGroup` uses a comparator that returns 1 rather than 0 for equal dates, so same-date rows keep their order only if the group arrives in input order, and `buildRepostCluster` reads `clusterRows[0].company`. Groups are emitted in seed order, and their rows are re-sorted by original array position, which is what the nested loop produced: the seed was always the first not-yet-used row, and the inner loop appended the rest in array order.

## Measured on this machine

Synthetic 4k and 8k row scan histories for one company, titles drawn from a shared vocabulary of levels, domains, and teams so they are not artificially easy to bucket. Node 22.23.1, Windows 11.

| rows | before | after |
|------|--------|-------|
| 4000 (`--summary`) | 16,637 ms | 174 ms |
| 8000 (JSON) | 89,396 ms | 339 ms |

The JSON output of the old and new code is byte-identical on both corpora.

## Why the output is provably unchanged

`detect-reposts.test.mjs` now carries a frozen copy of the pre-change algorithm, nested loop and all, and compares full cluster output against it (not just cluster counts, so a changed cluster order or a changed appearance order inside a cluster fails too). The corpora cover 120 distinct titles at one company, 60 exact duplicates spread over a year, fuzzy word-order variants, near-miss titles that must stay separate, mixed-case duplicates of one title, same-date rows, singleton companies and singleton titles, and a seeded 300-row mixed corpus with duplicate URLs and non-added statuses run at three window sizes. Two assertions confirm the corpora actually produce clusters, so an all-empty comparison cannot pass by accident.

I checked the test has teeth by mutating the Jaccard gate from 0.6 to 0.9 in the implementation; the equivalence comparison failed as expected, then passed again once reverted.

Section 11 gains a 4025-row guard: 4000 distinct titles at one company plus 25 planted exact reposts, asserting both the exact cluster count and a 10s budget. The old code took tens of seconds on this shape and the new code takes a fraction of a second, so the budget has an order of magnitude of headroom and is not a wall-clock flake, while still failing if the quadratic loop returns.

If `detect-reposts.mjs` ever changes what it computes rather than how fast it computes it, the frozen copy has to be updated in the same commit. That is intentional. A silent divergence should fail there.

## Validation

`node test-all.mjs`: 2747 passed, 1 failed. The one failure is pre-existing on this branch point and unrelated, `analyze() appDateSource end-to-end check crashed: EPERM: operation not permitted, symlink`, which is a Windows symlink permission issue in a test that builds a temp worktree.

`node detect-reposts.mjs --self-test`: 8 passed, 0 failed.
`node detect-reposts.test.mjs`: 227 passed, 0 failed.
`node company-history.test.mjs`: 86 passed, 0 failed (it imports `detectReposts`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved repost detection efficiency, especially for larger datasets.
  * Potential matches are filtered more effectively while preserving grouping behavior and input order.

* **Bug Fixes**
  * Improved handling of duplicate, case-variant, fuzzy, near-match, same-date, and singleton entries.

* **Tests**
  * Added regression coverage across varied repost scenarios.
  * Added a large-scale benchmark covering 4,025 entries and 25 known repost clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->