### PR TITLE
perf(tests): fix the dead SSRF DNS stub and cut three fixed costs from test-all

### DIFF
--- a/liveness-browser.mjs
+++ b/liveness-browser.mjs
@@ -127,24 +127,58 @@ export function rejectPrivateOrInvalid(url) {
 
 const dnsCache = new Map();
 
+// Real DNS: resolve4 + resolve6 + lookup, each tolerant of its own failure, so a
+// host that only answers on one of the three still yields an address list.
+async function resolveViaDns(hostname) {
+  const dns = await import('dns/promises');
+  const [ipv4, ipv6, lookupList] = await Promise.all([
+    dns.resolve4(hostname).catch(() => []),
+    dns.resolve6(hostname).catch(() => []),
+    dns.lookup(hostname, { all: true }).catch(() => [])
+  ]);
+  return Array.from(new Set([
+    ...ipv4,
+    ...ipv6,
+    ...lookupList.map(item => item.address)
+  ]));
+}
+
+let hostResolver = resolveViaDns;
+
+/**
+ * Swap the resolver the egress guard uses, returning a restore function.
+ *
+ * `dns/promises` is imported dynamically and the guard calls the ESM namespace
+ * bindings, which are immutable — monkey-patching the module object has no
+ * effect on them (#2386). Without this seam a test can only ever reach the
+ * "host resolved to nothing" branch: the real resolver returns an empty list
+ * for the synthetic hostname, the guard blocks on that, and the loopback
+ * rejection the test exists to cover never runs. The memo cache is cleared on
+ * every swap, in both directions, so a verdict computed under one resolver can
+ * never be served to the next.
+ *
+ * @param {((hostname: string) => Promise<string[]>)|null} resolver - Resolver to
+ *   install, or null to restore the real DNS one.
+ * @returns {() => void} Restores the resolver in place before this call.
+ */
+export function setHostResolver(resolver) {
+  const previous = hostResolver;
+  hostResolver = resolver ?? resolveViaDns;
+  dnsCache.clear();
+  return () => {
+    hostResolver = previous;
+    dnsCache.clear();
+  };
+}
+
 async function resolveDnsCached(hostname) {
   if (dnsCache.has(hostname)) {
     const cached = dnsCache.get(hostname);
     if (cached instanceof Error) throw cached;
     return cached;
   }
-  const dns = await import('dns/promises');
   try {
-    const [ipv4, ipv6, lookupList] = await Promise.all([
-      dns.resolve4(hostname).catch(() => []),
-      dns.resolve6(hostname).catch(() => []),
-      dns.lookup(hostname, { all: true }).catch(() => [])
-    ]);
-    const addresses = Array.from(new Set([
-      ...ipv4,
-      ...ipv6,
-      ...lookupList.map(item => item.address)
-    ]));
+    const addresses = await hostResolver(hostname);
     if (addresses.length === 0) {
       throw new Error(`DNS resolution returned no addresses for ${hostname}`);
     }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -145,14 +145,32 @@ const mjsFiles = readdirSync(ROOT).filter(f => f.endsWith('.mjs'));
 const SYNTAX_POOL_SIZE = 8;
 const execFileAsync = promisify(execFile);
 const syntaxOk = new Array(mjsFiles.length);
+const syntaxDetail = new Array(mjsFiles.length);
 let nextSyntaxIdx = 0;
+
+// A bare catch reports a child killed on timeout, or one that never spawned, as
+// "has syntax errors" — sending the reader hunting for a parse error that does
+// not exist. Keep enough of the child's own diagnosis to tell those apart.
+const describeCheckFailure = (err) => {
+  if (err?.killed || err?.signal === 'SIGTERM' || err?.code === 'ETIMEDOUT') {
+    return `node --check timed out after 30000ms${err.signal ? ` (signal ${err.signal})` : ''}`;
+  }
+  const stderr = String(err?.stderr ?? '').trim();
+  if (!stderr) return `no stderr (exit ${err?.code ?? 'unknown'})`;
+  const clipped = stderr.length > 2000
+    ? `${stderr.slice(0, 2000)}\n    ... (${stderr.length - 2000} more chars)`
+    : stderr;
+  return clipped.replace(/\n/g, '\n    ');
+};
+
 const syntaxWorker = async () => {
   for (let i = nextSyntaxIdx++; i < mjsFiles.length; i = nextSyntaxIdx++) {
     try {
       await execFileAsync(NODE, ['--check', mjsFiles[i]], { cwd: ROOT, timeout: 30000 });
       syntaxOk[i] = true;
-    } catch {
+    } catch (err) {
       syntaxOk[i] = false;
+      syntaxDetail[i] = describeCheckFailure(err);
     }
   }
 };
@@ -163,7 +181,7 @@ mjsFiles.forEach((f, i) => {
   if (syntaxOk[i]) {
     pass(`${f} syntax OK`);
   } else {
-    fail(`${f} has syntax errors`);
+    fail(`${f} has syntax errors\n    ${syntaxDetail[i] ?? 'no diagnostic captured'}`);
   }
 });
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -24,10 +24,11 @@
  */
 
 
-import { execSync, execFileSync, spawn, spawnSync } from 'child_process';
+import { execSync, execFile, execFileSync, spawn, spawnSync } from 'child_process';
 import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, unlinkSync, realpathSync, symlinkSync, copyFileSync } from 'fs';
 import { join, dirname, basename, delimiter } from 'path';
 import { tmpdir } from 'os';
+import { promisify } from 'util';
 import { fileURLToPath, pathToFileURL } from 'url';
 import yaml from 'js-yaml';
 import { pass, fail, warn, run, formatRunFailure, fileExists, finish, ROOT, QUICK, NODE, getBash, toBashPath } from './tests/helpers.mjs';
@@ -134,14 +135,37 @@ console.log('\n🧪 career-ops test suite\n');
 console.log('1. Syntax checks');
 
 const mjsFiles = readdirSync(ROOT).filter(f => f.endsWith('.mjs'));
-for (const f of mjsFiles) {
-  const result = run(NODE, ['--check', f]);
-  if (result !== null) {
+
+// `node --check` parses a file and exits; it runs no user code, touches no
+// shared state, and its result depends on nothing but that one file. Spawning
+// the 100+ root scripts one at a time was pure process-startup latency, so they
+// go through a bounded pool instead (#2387). Results are collected by index and
+// reported afterwards in the original readdir order, so the log stays
+// byte-identical to the sequential version regardless of completion order.
+const SYNTAX_POOL_SIZE = 8;
+const execFileAsync = promisify(execFile);
+const syntaxOk = new Array(mjsFiles.length);
+let nextSyntaxIdx = 0;
+const syntaxWorker = async () => {
+  for (let i = nextSyntaxIdx++; i < mjsFiles.length; i = nextSyntaxIdx++) {
+    try {
+      await execFileAsync(NODE, ['--check', mjsFiles[i]], { cwd: ROOT, timeout: 30000 });
+      syntaxOk[i] = true;
+    } catch {
+      syntaxOk[i] = false;
+    }
+  }
+};
+await Promise.all(
+  Array.from({ length: Math.min(SYNTAX_POOL_SIZE, mjsFiles.length) }, syntaxWorker)
+);
+mjsFiles.forEach((f, i) => {
+  if (syntaxOk[i]) {
     pass(`${f} syntax OK`);
   } else {
     fail(`${f} has syntax errors`);
   }
-}
+});
 
 // ── 2. SCRIPT EXECUTION ─────────────────────────────────────────
 
@@ -213,11 +237,19 @@ const scripts = [
 
 const scriptTmp = mkdtempSync(join(ROOT, '.tmp-script-test-'));
 try {
+  // Never copied, at any depth: dependency trees and git metadata. Nothing run
+  // from the throwaway copy reads them (module resolution walks up into the
+  // real ROOT/node_modules, which is how the root-level exclusion already
+  // worked), and a nested web/node_modules is ~400 MB on a machine that has
+  // installed the web app's deps — copying it dominated this section (#2387).
+  const EXCLUDE_AT_ANY_DEPTH = new Set(['node_modules', '.git']);
+
   const copyDirSync = (src, dest, exclude = []) => {
     const name = src.split(/[\\/]/).pop();
-    // Exclude only top-level workspace dirs (data/, reports/, node_modules, …).
-    // Match by basename ONLY at the repo root so nested fixture subdirs such as
-    // test-fixtures/upgrade/state-*/data and .../reports still get copied.
+    if (EXCLUDE_AT_ANY_DEPTH.has(name)) return;
+    // Everything else is a top-level workspace dir (data/, reports/, …) and is
+    // matched by basename ONLY at the repo root, so nested fixture subdirs such
+    // as test-fixtures/upgrade/state-*/data and .../reports still get copied.
     if (dirname(src) === ROOT && exclude.includes(name)) return;
     const stat = statSync(src);
     if (stat.isDirectory()) {
@@ -231,8 +263,8 @@ try {
   };
 
   const excludeDirs = [
-    'node_modules',
-    '.git',
+    // node_modules and .git are not listed here — EXCLUDE_AT_ANY_DEPTH above
+    // drops them wherever they occur, root included.
     'data',
     'reports',
     '.career-ops-web',
@@ -4300,9 +4332,15 @@ try {
   writeFileSync(dryRunPortals, fixture);
   const beforeDryRun = readFileSync(dryRunPortals, 'utf-8');
   try {
+    // fix-slugs probes live Greenhouse/Ashby/Lever endpoints before it decides
+    // what to rewrite, so on a connected machine this child runs to the timeout
+    // and is killed. That is fine: the assertion below is about disk writes, not
+    // about network reachability, and a dry run must not write at any point in
+    // its life. The timeout is therefore kept short (#2387) - 15 s bought
+    // nothing but 15 s.
     execFileSync(NODE, [join(ROOT, 'fix-slugs.mjs'), '--file', dryRunPortals, '--dry-run'], {
       cwd: ROOT,
-      timeout: 15000,
+      timeout: 2000,
     });
   } catch {
     // Network is reachable-or-not in CI; either way, no write should occur.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -706,7 +706,7 @@ try {
   // matched literal IPv4 patterns and bracketless IPv6, so several Chromium-
   // routable bypasses (0.0.0.0, [::], [::1] (bracketed), [::ffff:127.0.0.1],
   // localhost.) slipped through. These cases keep that regression covered.
-  const { rejectPrivateOrInvalid } = await import(
+  const { rejectPrivateOrInvalid, setHostResolver } = await import(
     pathToFileURL(join(ROOT, 'liveness-browser.mjs')).href
   );
   const blockCases = [
@@ -755,105 +755,108 @@ try {
     fail(`SSRF guard let unsupported protocol through: ${protoCase?.code ?? 'allowed'}`);
   }
 
-  // SSRF redirect routing tests
-  const dnsModule = await import('dns/promises');
-  const { mock } = await import('node:test');
-
-  // Stub resolve4, resolve6, and lookup to test the DNS path
-  mock.method(dnsModule.default, 'resolve4', (hostname) => {
-    if (hostname === 'ssrf-blocked-host.local') {
-      return Promise.resolve(['127.0.0.1']);
-    }
-    return Promise.resolve([]);
-  });
-  mock.method(dnsModule.default, 'resolve6', (hostname) => {
-    return Promise.resolve([]);
-  });
-  mock.method(dnsModule.default, 'lookup', (hostname, options) => {
-    if (hostname === 'ssrf-blocked-host.local') {
-      const addr = { address: '127.0.0.1', family: 4 };
-      return Promise.resolve(options?.all ? [addr] : addr);
-    }
-    return Promise.reject(new Error('DNS lookup failure'));
+  // SSRF redirect routing tests.
+  //
+  // The resolver is injected rather than mocked on the dns module (#2386): the
+  // guard calls the ESM namespace bindings of `dns/promises`, which no mock can
+  // reach, so the previous `mock.method(dnsModule.default, …)` stub never
+  // applied. The test passed anyway — the real resolver found nothing for
+  // `ssrf-blocked-host.local` and the guard blocked on the empty address list,
+  // so the loopback-rejection branch under test was never executed, and each
+  // run spent ~12s waiting for mDNS/LLMNR to time out. The injected resolver
+  // hands back a loopback address, which is the case that matters, and keeps
+  // the whole section off the network.
+  const restoreHostResolver = setHostResolver(async (hostname) => {
+    if (hostname === 'ssrf-blocked-host.local') return ['127.0.0.1'];
+    // Every other host in this section is a stand-in for a normal public site.
+    return ['93.184.216.34'];
   });
 
-  let routeCallback = null;
-  const mockPageInstance = {
-    _blockedByGuard: null,
-    async route(pattern, callback) {
-      routeCallback = callback;
-    },
-    async goto() {
-      if (routeCallback) {
-        let aborted = false;
-        const mockRoute = {
-          request: () => ({ url: () => 'http://ssrf-blocked-host.local/sensitive-internal' }),
-          abort: async () => {
-            aborted = true;
-          },
-          continue: async () => {}
-        };
-        await routeCallback(mockRoute);
-        if (aborted) {
-          throw new Error('net::ERR_BLOCKED_BY_CLIENT');
-        }
-      }
-      return { status: () => 200 };
-    },
-    async waitForTimeout() {},
-    url() { return 'https://example.com/redirected'; },
-    async evaluate() { return 'body text'; }
-  };
-
-  const redirectResult = await checkUrlLiveness(mockPageInstance, 'https://example.com/public-landing');
-  if (redirectResult.result === 'uncertain' && redirectResult.code === 'blocked_host') {
-    pass('SSRF redirect guard blocks redirects/subresources to private IPs via routing');
-  } else {
-    fail(`SSRF redirect guard failed to block: ${JSON.stringify(redirectResult)}`);
-  }
-
-  // Restore DNS mocks
-  mock.reset();
-
-  let legitimateRouteCallback = null;
-  const mockPageLegitimate = {
-    _blockedByGuard: null,
-    async route(pattern, callback) {
-      legitimateRouteCallback = callback;
-    },
-    async goto() {
-      if (legitimateRouteCallback) {
-        let continued = false;
-        const mockRoute = {
-          request: () => ({ url: () => 'https://example.com/assets/logo.png' }),
-          abort: async () => {},
-          continue: async () => {
-            continued = true;
+  try {
+    let routeCallback = null;
+    const mockPageInstance = {
+      _blockedByGuard: null,
+      async route(pattern, callback) {
+        routeCallback = callback;
+      },
+      async goto() {
+        if (routeCallback) {
+          let aborted = false;
+          const mockRoute = {
+            request: () => ({ url: () => 'http://ssrf-blocked-host.local/sensitive-internal' }),
+            abort: async () => {
+              aborted = true;
+            },
+            continue: async () => {}
+          };
+          await routeCallback(mockRoute);
+          if (aborted) {
+            throw new Error('net::ERR_BLOCKED_BY_CLIENT');
           }
-        };
-        await legitimateRouteCallback(mockRoute);
-        if (!continued) {
-          throw new Error('Blocked legitimate request');
         }
-      }
-      return { status: () => 200 };
-    },
-    async waitForTimeout() {},
-    url() { return 'https://example.com'; },
-    async evaluate(fn) {
-      const fnStr = fn.toString();
-      if (fnStr.includes('body')) {
-        return 'legitimate page body';
-      }
-      return ['Apply'];
-    }
-  };
+        return { status: () => 200 };
+      },
+      async waitForTimeout() {},
+      url() { return 'https://example.com/redirected'; },
+      async evaluate() { return 'body text'; }
+    };
 
-  const legitimateResult = await checkUrlLiveness(mockPageLegitimate, 'https://example.com');
-  if (legitimateResult.result === 'active') {
-    pass('SSRF redirect guard allows legitimate subresource requests');
-  } else {
-    fail(`SSRF redirect guard blocked legitimate requests: ${JSON.stringify(legitimateResult)}`);
+    const redirectResult = await checkUrlLiveness(mockPageInstance, 'https://example.com/public-landing');
+    // The reason has to name the loopback address. `blocked_host` alone is also
+    // what an unresolvable host produces, so asserting on the code by itself
+    // cannot tell "guard rejected 127.0.0.1" from "host resolved to nothing" —
+    // that ambiguity is exactly what hid the broken mock (#2386).
+    if (redirectResult.result === 'uncertain' && redirectResult.code === 'blocked_host'
+        && /private target IP 127\.0\.0\.1/.test(redirectResult.reason ?? '')) {
+      pass('SSRF redirect guard blocks redirects/subresources to private IPs via routing');
+    } else {
+      fail(`SSRF redirect guard failed to block: ${JSON.stringify(redirectResult)}`);
+    }
+
+    let legitimateRouteCallback = null;
+    const mockPageLegitimate = {
+      _blockedByGuard: null,
+      async route(pattern, callback) {
+        legitimateRouteCallback = callback;
+      },
+      async goto() {
+        if (legitimateRouteCallback) {
+          let continued = false;
+          const mockRoute = {
+            request: () => ({ url: () => 'https://example.com/assets/logo.png' }),
+            abort: async () => {},
+            continue: async () => {
+              continued = true;
+            }
+          };
+          await legitimateRouteCallback(mockRoute);
+          if (!continued) {
+            throw new Error('Blocked legitimate request');
+          }
+        }
+        return { status: () => 200 };
+      },
+      async waitForTimeout() {},
+      url() { return 'https://example.com'; },
+      async evaluate(fn) {
+        const fnStr = fn.toString();
+        if (fnStr.includes('body')) {
+          return 'legitimate page body';
+        }
+        return ['Apply'];
+      }
+    };
+
+    const legitimateResult = await checkUrlLiveness(mockPageLegitimate, 'https://example.com');
+    if (legitimateResult.result === 'active') {
+      pass('SSRF redirect guard allows legitimate subresource requests');
+    } else {
+      fail(`SSRF redirect guard blocked legitimate requests: ${JSON.stringify(legitimateResult)}`);
+    }
+  } finally {
+    // Always put the real resolver back, even if an assertion above throws:
+    // a leaked stub would silently answer for every later suite in this process.
+    restoreHostResolver();
   }
 } catch (e) {
   fail(`Liveness classification tests crashed: ${e.message}`);


### PR DESCRIPTION
Closes #2386
Closes #2387

Both issues change `test-all.mjs`, so they share one branch as two separate commits. Splitting them across two PRs would guarantee a conflict on that file for no benefit.

## #2386: the SSRF DNS stub never applied

The test stubbed `resolve4`, `resolve6` and `lookup` on the `dns/promises` module object. `liveness-browser.mjs` imports that module dynamically and calls the namespace bindings, which are immutable, so the stub never took effect. The test passed by a route it was not written to take: real DNS returned nothing for `ssrf-blocked-host.local`, the resolver threw on the empty address list, and the guard reported `blocked_host` anyway. The loopback rejection the test exists to cover never ran. On Windows the doomed lookup also cost 12.3 s of mDNS and LLMNR timeouts on every suite run.

I checked whether the module object could be patched at all before touching production code:

```js
mock.method(dnsModule.default, 'resolve4', () => Promise.resolve(['127.0.0.1']));
await ns.resolve4('ssrf-blocked-host.local');   // still hits real DNS: ECONNREFUSED
```

So the fix is a seam. `setHostResolver(fn)` in `liveness-browser.mjs` swaps the resolver, returns a restore function, and clears the memo cache in both directions, since `dnsCache` would otherwise serve a verdict computed under one resolver to the next and mask the assertion. The test injects a resolver that answers `127.0.0.1` for the synthetic host and a public address for everything else, then restores it in a `finally` so a stub can never leak into a later suite in the same process.

Evidence that the loopback branch now runs, from the suite log:

```
before: ... - DNS resolution returned no addresses for ssrf-blocked-host.local
after:  ... - Access denied: Egress guard blocked private target IP 127.0.0.1
```

The assertion now requires the blocked reason to name `127.0.0.1`, not just `code === 'blocked_host'`. That code alone cannot tell "the guard rejected loopback" from "the host resolved to nothing", which is the ambiguity that let a dead stub sit there unnoticed.

## #2387: items a, b and c

**a. `fix-slugs` dry-run timeout, 15 s to 2 s.** The child probes live Greenhouse, Ashby and Lever endpoints, so on a connected machine it never finishes. An unbounded run of the same command takes 45.5 s here, so the 15 s timeout was always reached and the `catch` always swallowed the kill. The assertion is that a dry run wrote nothing to disk, which holds at any timeout, and it is unchanged.

**b. `node --check` through a bounded pool of 8.** `--check` parses one file and exits: no user code, no shared state, no dependency on any other file. Results are collected by index and printed afterwards in the original readdir order, so the log stays byte identical no matter which child finishes first. Over the same 111 files on this machine: 4252 ms sequential, 726 ms pooled.

**c. Section 2's throwaway repo copy now skips `node_modules` and `.git` at any depth.** The root-only rule is deliberate and stays for every other entry, because nested fixture dirs such as `test-fixtures/upgrade/state-*/data` and `.../reports` must still be copied (`seed-fixture.mjs --self-test` reads them from inside the copy). Only those two names move into an any-depth set. A checkout that has installed the web app's dependencies carries a `web/node_modules` of about 430 MB that was being copied in full on every run. Measured against such a checkout, warm cache, two rounds each: 5526 ms and 5743 ms before, 452 ms and 475 ms after.

## Measured on this machine

Windows 11, Node 22.23, worktree off `upstream/main` at 93b1cbb, full `node test-all.mjs` with no flags.

| run | wall clock | passed | failed | warnings |
|---|---|---|---|---|
| baseline | 100.8 s | 2747 | 1 | 2 |
| after #2386 | 84.4 s | 2747 | 1 | 2 |
| after #2387 | 60.1 s | 2747 | 1 | 2 |

The pass count is identical at every step, so nothing dropped out of discovery or ordering. Diffing the baseline log against the final one shows only the intended change to the SSRF reason string, plus per-run noise in temp dir names and a few timing values. Both logs are 3206 lines.

The single failure is pre-existing on all three runs and environmental, not something this PR introduces or fixes:

```
analyze() appDateSource end-to-end check crashed: EPERM: operation not permitted, symlink
```

That is an unprivileged Windows user without symlink rights.

One caveat on item c: this worktree has no `web/node_modules`, so its saving is not in the table above. It was measured separately against a checkout that does have one, as described.

## Deliberately not in this PR

Item 4 of #2387, the live Greenhouse archive-posting test, and the `--quick` flag question. Both are policy calls about what the suite may depend on and what a fast run should skip, so they are yours to decide rather than mine to assume.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS resolution handling for more reliable network protection.
  * Strengthened SSRF redirect checks, including detection of private resolved addresses.
  * Preserved legitimate subresource requests during security validation.

* **Tests**
  * Expanded syntax and security test coverage.
  * Improved test execution efficiency with bounded parallel processing.
  * Enhanced temporary test isolation by excluding dependency and version-control directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->