### PR TITLE
fix(dedup): use Unicode-aware Via key for blind-employer grouping

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -16,7 +16,7 @@ import { fileURLToPath } from 'url';
 import {
   openTrackerTransaction, rebuildRow, resolveTrackerPath,
 } from './tracker-utils.mjs';
-import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { resolveColumns, parseTrackerRow, normalizeVia } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md
@@ -302,11 +302,19 @@ console.log(`📊 ${entries.length} entries loaded`);
 // normalize to the same empty key, so they group by their Via channel instead:
 // the same agency re-blasting one listing IS a duplicate, while the same role
 // via two different agencies is two real submissions and must never merge.
+// The channel key is Unicode-aware (#1603/#2393): normalizeCompany() strips
+// everything outside [a-z0-9], so distinct non-Latin agency names (リクルート,
+// パーソル, …) all collapsed to the same empty key and one of two genuinely
+// separate submissions was DELETED. normalizeVia() is the same key that
+// merge-tracker.mjs uses for its cross-channel guard, so the two scripts
+// cannot drift on agency identity. An absent Via (empty or `—`) still keys to
+// '' and groups with other via-less blind rows, matching merge-tracker, whose
+// guard does not reject a pair whose Via cells are both blank.
 const BLIND_KEY = ' blind-via:';
 const groups = new Map();
 for (const entry of entries) {
   const key = String(entry.company).trim() === '?'
-    ? BLIND_KEY + normalizeCompany(entry.via || '')
+    ? BLIND_KEY + normalizeVia(entry.via || '')
     : normalizeCompany(entry.company);
   if (!groups.has(key)) groups.set(key, []);
   groups.get(key).push(entry);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7527,6 +7527,75 @@ try {
   fail(`shared role matcher / dedup safety tests crashed: ${e.message}`);
 }
 
+// ── DEDUP BLIND-VIA CHANNEL KEY: NON-LATIN AGENCIES (#2393) ──────────────
+// Unknown-employer rows (Company `?`) group by their Via channel. dedup-tracker
+// keyed that group with the file-local normalizeCompany(), which strips
+// [^a-z0-9] — so リクルート and パーソル both keyed to '' and two genuinely
+// separate agency submissions for one role landed in the same cluster, and the
+// lower-scored row was DELETED. merge-tracker already compares Via with the
+// Unicode-aware normalizeVia(); dedup must use the same key. A same-agency
+// re-blast must still collapse, otherwise the fix would just be "never merge".
+console.log('\n🧪 Testing dedup blind-via channel key with non-Latin agencies (#2393)...');
+try {
+  const viaDedupTmp = mkdtempSync(join(tmpdir(), 'career-ops-dedup-via-'));
+  try {
+    mkdirSync(join(viaDedupTmp, 'data'));
+    const tracker = join(viaDedupTmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Via | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|-----|------|-------|--------|-----|--------|-------|\n' +
+      // (a) Same role, unknown employer, two DIFFERENT non-Latin agencies —
+      // two real submissions, both must survive.
+      '| 61 | 2026-03-01 | ? | リクルート | Backend Engineer, Payments Platform | 4.0/5 | Evaluated | ❌ | [61](../reports/061-blind-a.md) | first agency |\n' +
+      '| 62 | 2026-03-02 | ? | パーソル | Backend Engineer, Payments Platform | 4.1/5 | Evaluated | ❌ | [62](../reports/062-blind-b.md) | second agency |\n' +
+      // (b) Symmetric case: a via-less blind row must not collide with a
+      // non-Latin agency just because both used to key to ''.
+      '| 63 | 2026-03-03 | ? | — | Frontend Engineer, Checkout | 3.8/5 | Evaluated | ❌ | [63](../reports/063-blind-c.md) | no agency named |\n' +
+      '| 64 | 2026-03-04 | ? | リクルート | Frontend Engineer, Checkout | 4.2/5 | Evaluated | ❌ | [64](../reports/064-blind-d.md) | agency listing |\n' +
+      // (c) Control: the SAME agency re-blasting one listing is a genuine
+      // duplicate and must still collapse to the higher-scored row.
+      '| 65 | 2026-03-05 | ? | Hays | Data Engineer, Warehouse | 3.5/5 | Evaluated | ❌ | [65](../reports/065-blind-e.md) | first sighting |\n' +
+      '| 66 | 2026-03-06 | ? | Hays | Data Engineer, Warehouse | 4.4/5 | Evaluated | ❌ | [66](../reports/066-blind-f.md) | same agency re-blast |\n');
+
+    const r = run(NODE, ['dedup-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
+    if (r === null) {
+      fail('dedup-tracker.mjs crashed during blind-via channel key test (#2393)');
+    } else {
+      const out = readFileSync(tracker, 'utf-8');
+
+      const paymentsRows = out.split('\n').filter(l => l.includes('Backend Engineer, Payments Platform'));
+      if (paymentsRows.length === 2
+          && paymentsRows.some(l => l.includes('リクルート'))
+          && paymentsRows.some(l => l.includes('パーソル'))) {
+        pass('dedup-tracker keeps two blind rows submitted via different non-Latin agencies (#2393)');
+      } else {
+        fail(`dedup-tracker collapsed distinct non-Latin agency channels: ${paymentsRows.length} Payments Platform rows`);
+      }
+
+      const checkoutRows = out.split('\n').filter(l => l.includes('Frontend Engineer, Checkout'));
+      if (checkoutRows.length === 2
+          && checkoutRows.some(l => l.includes('リクルート'))
+          && checkoutRows.some(l => l.includes('| — |'))) {
+        pass('dedup-tracker keeps a via-less blind row separate from a non-Latin agency row (#2393)');
+      } else {
+        fail(`dedup-tracker collapsed a via-less blind row into an agency channel: ${checkoutRows.length} Checkout rows`);
+      }
+
+      const warehouseRows = out.split('\n').filter(l => l.includes('Data Engineer, Warehouse'));
+      if (warehouseRows.length === 1 && warehouseRows[0].includes('4.4/5')) {
+        pass('dedup-tracker still collapses a same-agency re-blast of one blind listing (#2393)');
+      } else {
+        fail(`dedup-tracker same-agency blind dedup broken: ${warehouseRows.length} Warehouse rows`);
+      }
+    }
+  } finally {
+    rmSync(viaDedupTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`dedup blind-via channel key tests crashed (#2393): ${e.message}`);
+}
+
 // dedup-tracker / normalize-statuses rebuilt promoted rows with
 // `parts.slice(1, -1)`, which assumes the closing `|` produced a trailing empty
 // cell. A valid row written WITHOUT a trailing pipe keeps its real last cell


### PR DESCRIPTION
Closes #2393

## The bug

`dedup-tracker.mjs` groups unknown-employer rows (Company `?`, #1596) by their Via channel, and it built that key with the file-local `normalizeCompany()`, which strips everything outside `[a-z0-9]`. `merge-tracker.mjs:710` compares the same Via values with the Unicode-aware `normalizeVia()` from `tracker-parse.mjs` (added in #1603). dedup never imported it, so the two scripts disagreed about agency identity.

| Via | dedup key (before) | merge key (correct) |
|---|---|---|
| リクルート | `""` | `リクルート` |
| パーソル | `""` | `パーソル` |
| — | `""` | `""` |
| Hays | `hays` | `hays` |

Two distinct agencies submitting the same role therefore shared one blind-via group, clustered as duplicates, and the lower-scored row was deleted. An empty or `—` Via collided with every non-Latin agency in the same way. That is data loss on user-layer data: `data/applications.md` is gitignored, so there is no VCS recovery, and dedup's single `.bak` is overwritten on the next run.

## The fix

Import `normalizeVia` and use it for the blind-via grouping key. `normalizeCompany()` is unchanged and non-blind grouping is untouched.

## Empty Via

A row whose Via is empty or `—` still keys to `""` and groups with other via-less blind rows. This matches merge-tracker: its guard rejects a pair only when the two `normalizeVia` keys differ, and two blank cells both produce `""`, so merge-tracker treats them as the same channel. Matching that behaviour keeps the two scripts consistent rather than introducing a third rule. The change is still strictly safer than before, because a blank Via no longer collides with a named non-Latin agency.

## Tests

New fixture in the dedup block of `test-all.mjs`, using the existing `CAREER_OPS_TRACKER` env pattern:

1. Two `?` rows, same role, `リクルート` vs `パーソル`, both Evaluated. Both must survive.
2. Symmetric case: `—` vs `リクルート` on the same role. Both must survive.
3. Control: `Hays` vs `Hays`, same role, both Evaluated. Must still collapse to the higher-scored row.

Case 3 exists so the fix cannot pass by simply never merging anything.

### Mutation evidence

Stashing only the `dedup-tracker.mjs` change and running the new fixture against the unfixed code:

```
🧪 Testing dedup blind-via channel key with non-Latin agencies (#2393)...
  ❌ dedup-tracker collapsed distinct non-Latin agency channels: 1 Payments Platform rows
  ❌ dedup-tracker collapsed a via-less blind row into an agency channel: 1 Checkout rows
  ✅ dedup-tracker still collapses a same-agency re-blast of one blind listing (#2393)
```

Cases 1 and 2 bite. Case 3 passes both before and after, confirming the control is genuine.

With the fix restored, all three pass.

## Validation

`node test-all.mjs`: 2750 passed, 1 failed. The single failure is pre-existing on this Windows box and unrelated: `analyze() appDateSource end-to-end check crashed: EPERM: operation not permitted, symlink`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved duplicate listing detection for tracker entries associated with unknown companies.
  - Preserved separate listings from distinct agencies, including non-Latin agency names.
  - Prevented entries without agency information from being incorrectly merged.
  - Continued selecting the highest-scored listing when duplicates come from the same agency.

- **Tests**
  - Added regression coverage for agency-based deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->