### PR TITLE
test: cover set-status and mark-pdf-ready in the tracker writer lock matrix

### DIFF
--- a/tracker-writer-lock-tests.mjs
+++ b/tracker-writer-lock-tests.mjs
@@ -4,9 +4,10 @@
 
 import { spawn } from 'child_process';
 import {
-  existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, utimesSync, writeFileSync,
+  existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync, utimesSync, watch,
+  writeFileSync,
 } from 'fs';
-import { dirname, join } from 'path';
+import { basename, dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 import { acquireTrackerLock, openTrackerTransaction } from './tracker-utils.mjs';
@@ -33,6 +34,64 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 // timeoutMs / staleMs / retryMs are the lock's own parameters. Those are what
 // the tests assert on, so widening them would change what is being tested.
 const HARNESS_WAIT_MS = 30_000;
+
+// How long to wait for evidence that the spawned writer has reached the lock
+// before committing the concurrent row. Bounded, and not a value under test:
+// see watchForContention() for why the wait exists and what happens when the
+// evidence never arrives.
+const CONTENTION_WAIT_MS = 2_000;
+
+/**
+ * Watch for evidence that a spawned writer has attempted the tracker lock and
+ * lost — i.e. that it is now sitting in the retry loop.
+ *
+ * WHY THIS EXISTS: the fixture mutation below is what a writer with a stale
+ * pre-lock snapshot erases, so it only discriminates if it lands AFTER that
+ * writer's read. Committing it immediately after spawn() does not: a fresh
+ * Node process needs tens of milliseconds just to boot, so the row is already
+ * on disk before a buggy writer reads, and the buggy writer then reads the
+ * post-mutation file and passes. That was verified, not assumed — hoisting
+ * set-status.mjs's readFileSync above its acquireTrackerLockForCli call left
+ * this suite fully green until this wait was added.
+ *
+ * The signal is the lock's recover-guard directory: acquireTrackerLock creates
+ * and removes `${lockDir}.recover` on every contended pass, so its first
+ * appearance means "this child has tried the lock and someone else holds it".
+ * That instant sits after a pre-lock read and before a post-lock one, which is
+ * exactly the discrimination the mutation needs. fs.watch queues events, so a
+ * guard directory that exists for a millisecond is still observed.
+ *
+ * It is a bounded wait, never a barrier. If no guard event arrives — a lock
+ * implementation that stops using the guard, a writer that legitimately does
+ * other work first, a platform where fs.watch cannot report directory children
+ * — the mutation proceeds anyway once CONTENTION_WAIT_MS elapses and the test
+ * degrades to its previous timing-dependent behaviour instead of hanging.
+ *
+ * @param {string} dir - Directory containing the lock (watched non-recursively).
+ * @param {string} lockDir - The lock directory whose recover guard signals contention.
+ * @returns {{wait: (timeoutMs: number) => Promise<boolean>, close: () => void}}
+ */
+function watchForContention(dir, lockDir) {
+  const guardPrefix = `${basename(lockDir)}.recover`;
+  let seen = false;
+  let watcher = null;
+  try {
+    watcher = watch(dir, (_event, name) => {
+      if (name && String(name).startsWith(guardPrefix)) seen = true;
+    });
+  } catch {
+    // fs.watch is unavailable or unsupported here — the timed fallback stands in.
+  }
+  return {
+    async wait(timeoutMs) {
+      const deadline = Date.now() + timeoutMs;
+      while (!seen && Date.now() < deadline) await sleep(5);
+      watcher?.close();
+      return seen;
+    },
+    close() { watcher?.close(); },
+  };
+}
 
 function trackerTable(rows) {
   return `# Applications Tracker
@@ -135,6 +194,9 @@ async function runWhileLocked({
     fail(`${name}: lock contention probe failed (exit=${probeResult.code}, timedOut=${probeResult.timedOut})\n${probeOutput.stdout}${probeOutput.stderr}`);
   }
 
+  // Watching starts before the real writer launches and after the probe has
+  // exited, so the only guard events it can see are the writer's own.
+  const contention = beforeMutationOutput ? null : watchForContention(dir, lockDir);
   const run = launchWriter(3_000);
 
   try {
@@ -147,6 +209,11 @@ async function runWhileLocked({
         fail(`${name}: did not reach the pre-lock review prompt before the fixture mutation`);
       }
     }
+    // Order the mutation after the writer's own read. beforeMutationOutput
+    // entries already have a stronger, script-specific ordering signal (their
+    // pre-lock review prompt), and a writer parked at that prompt has not
+    // reached the lock yet, so the guard wait is skipped for them.
+    await contention?.wait(CONTENTION_WAIT_MS);
     // Simulate the current lock owner committing another row. The waiting
     // writer must read this fresh version after acquiring the lock; a writer
     // that reads before locking will erase row #99 with its stale snapshot.
@@ -155,6 +222,7 @@ async function runWhileLocked({
       : `${content.trimEnd()}\n${CONCURRENT_ROW}\n`;
     writeFileSync(tracker, nextContent);
   } finally {
+    contention?.close();
     lock.release();
   }
 
@@ -219,6 +287,44 @@ await runWhileLocked({
   completion: 'exports the fresh locked snapshot without losing concurrent rows',
 });
 
+// set-status.mjs is the writer CLAUDE.md names as canonical — the one every
+// mode calls to move a row — so it is the single most important entry in this
+// matrix, and it was the one missing. set-status-tests.mjs already covers the
+// lock TIMEOUT (exit 4) and a non-retryable lock error, but both prove only
+// that it contends; neither can tell a writer that re-reads under the lock
+// apart from one that reads first and writes a stale snapshot back. Hoisting
+// the readFileSync above acquireTrackerLockForCli looks like a harmless
+// optimisation ("resolve the row before paying for the lock"), and the file
+// already does real pre-lock work validating the state against states.yml, so
+// the shape is inviting. This test is what makes that refactor fail.
+await runWhileLocked({
+  name: 'set-status',
+  script: 'set-status.mjs',
+  args: ['--row', '1', 'Applied', '--note', 'sent CV'],
+  content: trackerTable([
+    '| 1 | 2026-01-01 | Acme | Engineer | 4.0/5 | Evaluated | ❌ | [1](reports/001-acme.md) | seed |',
+  ]),
+  verify: content => content.includes('| 1 | 2026-01-01 | Acme | Engineer | 4.0/5 | Applied |')
+    && content.includes('| seed; sent CV |'),
+  verifyOutput: stdout => stdout.includes('set Evaluated → Applied'),
+});
+
+// mark-pdf-ready.mjs is the canonical writer for the PDF column and shares
+// set-status.mjs's locked read-modify-write path (acquireTrackerLockForCli in
+// tracker-utils.mjs). It rewrites one cell of one line and keeps the rest of
+// the file, so a pre-lock read costs the same concurrent rows here as anywhere
+// else in this matrix.
+await runWhileLocked({
+  name: 'mark-pdf-ready',
+  script: 'mark-pdf-ready.mjs',
+  args: ['1'],
+  content: trackerTable([
+    '| 1 | 2026-01-01 | Acme | Engineer | 4.0/5 | Evaluated | ❌ | [1](reports/001-acme.md) | seed |',
+  ]),
+  verify: content => content.includes('| 1 | 2026-01-01 | Acme | Engineer | 4.0/5 | Evaluated | ✅ |'),
+  verifyOutput: stdout => stdout.includes('marked PDF ready'),
+});
+
 await runWhileLocked({
   name: 'reply-watch',
   script: 'reply-watch.mjs',
@@ -273,6 +379,112 @@ await runWhileLocked({
   completion: 'preserves a status changed while the recommendation was under review',
   beforeMutationOutput: 'Apply recommended status updates',
 });
+
+// --- followup-seed.mjs: a separate lock namespace, deliberately -------------
+//
+// followup-seed.mjs is absent from the matrix above because it is not a
+// tracker writer. It READS applications.md to find the row and its apply date,
+// then writes only data/follow-ups.md, under its own lock keyed by the
+// FOLLOW-UPS path and prefixed `career-ops-followups-` (followup-seed.mjs's
+// FOLLOWUPS_LOCK_PREFIX and resolveLockDir) rather than the shared
+// `career-ops-merge-tracker-` lock every writer above contends on.
+//
+// That split is the safe arrangement, not an oversight:
+//   - The two locks guard two different files' critical sections. The tracker
+//     lock says nothing about follow-ups.md, so a seeder holding it would
+//     still race a second seeder; the follow-ups lock is what actually
+//     serializes the read-check-append on follow-ups.md, and
+//     followup-seed.mjs is the only writer of that file in the repo (every
+//     other consumer — followup-cadence, reply-watch, stats, company-history —
+//     only reads it).
+//   - The stale-snapshot invariant this suite exists for cannot apply. It bites
+//     when a writer writes a whole-file snapshot back; followup-seed writes no
+//     tracker bytes at all, so a row committed while it runs cannot be erased.
+//     Its pre-lock tracker read is therefore an observation that may go stale
+//     (a row could leave Applied before the pin lands), never a lost write.
+//   - Sharing the tracker lock would serialize every seed behind unrelated
+//     tracker writes and, worse, nest two locks, without buying any safety.
+//
+// The test states all of that as behaviour: it holds the TRACKER lock for the
+// whole run and asserts followup-seed (a) completes anyway rather than blocking
+// on a lock it has no reason to want, (b) seeds follow-ups.md, and (c) leaves
+// the tracker byte-for-byte as the tracker-lock holder left it, concurrent row
+// included. Give followup-seed the tracker lock and (a) fails; give it a
+// tracker write and (c) fails.
+async function testFollowupSeedUsesASeparateLockNamespace() {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-followup-seed-lock-'));
+  const tracker = join(dir, 'applications.md');
+  const followups = join(dir, 'follow-ups.md');
+  const trackerLockDir = join(dir, 'career-ops-merge-tracker-followup-seed.lock');
+  const followupsLockDir = join(dir, 'career-ops-followups-seed.lock');
+  const content = trackerTable([
+    '| 1 | 2026-01-01 | Acme | Engineer | 4.0/5 | Applied | ❌ | [1](reports/001-acme.md) | Applied 2026-01-01 |',
+  ]);
+  writeFileSync(tracker, content);
+
+  const lock = await acquireTrackerLock(trackerLockDir, {
+    timeoutMs: 2_000,
+    retryMs: 20,
+    staleMs: 5_000,
+    tracker,
+  });
+
+  // Stand in for the tracker-lock holder committing a row: if followup-seed
+  // ever wrote the tracker from a snapshot, this row is what it would erase.
+  const lockedContent = `${content.trimEnd()}\n${CONCURRENT_ROW}\n`;
+  writeFileSync(tracker, lockedContent);
+  // Content alone would miss a writer that replaces the tracker with bytes it
+  // happens to have read a moment earlier. writeFileAtomic renames a temp file
+  // over the target, so the mtime moves even when the bytes do not.
+  const lockedMtimeMs = statSync(tracker).mtimeMs;
+
+  let stdout = '';
+  let stderr = '';
+  const child = spawn(NODE, [join(ROOT, 'followup-seed.mjs'), '1', '--json'], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      CAREER_OPS_TRACKER: tracker,
+      CAREER_OPS_FOLLOWUPS: followups,
+      CAREER_OPS_FOLLOWUPS_LOCK: followupsLockDir,
+      CAREER_OPS_FOLLOWUPS_LOCK_RETRY_MS: '20',
+      CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS: '3000',
+      // Short enough that a followup-seed which DID reach for the shared
+      // tracker lock would time out and fail loudly inside the harness wait,
+      // instead of hanging until the suite's own timeout.
+      CAREER_OPS_TRACKER_LOCK: trackerLockDir,
+      CAREER_OPS_TRACKER_LOCK_TIMEOUT_MS: '500',
+      CAREER_OPS_TRACKER_LOCK_RETRY_MS: '20',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  child.stdout.on('data', chunk => { stdout += chunk; });
+  child.stderr.on('data', chunk => { stderr += chunk; });
+  child.stdin.end();
+  const closePromise = new Promise(resolve => child.once('close', code => resolve({ code })));
+  let result = await Promise.race([closePromise, sleep(HARNESS_WAIT_MS).then(() => null)]);
+  if (result === null) {
+    child.kill('SIGKILL');
+    result = await closePromise;
+  }
+
+  // Released only after the child is done, so "completed" means "completed
+  // while the tracker lock was held by someone else".
+  lock.release();
+
+  const after = readFileSync(tracker, 'utf-8');
+  const trackerUntouched = after === lockedContent && statSync(tracker).mtimeMs === lockedMtimeMs;
+  const seeded = existsSync(followups) ? readFileSync(followups, 'utf-8') : '';
+  if (result.code === 0 && trackerUntouched
+      && seeded.includes('- next #1 ')) {
+    pass('followup-seed: seeds follow-ups under its own lock while the tracker lock is held, and writes no tracker bytes');
+  } else {
+    fail(`followup-seed: separate-namespace contract broken (exit=${result.code})\n${stdout}${stderr}\n${after}`);
+  }
+  rmSync(dir, { recursive: true, force: true });
+}
+
+await testFollowupSeedUsesASeparateLockNamespace();
 
 async function testTrackerLockReleaseRetriesPartialCleanup() {
   const dir = mkdtempSync(join(tmpdir(), 'career-ops-lock-release-'));

--- a/tracker-writer-lock-tests.mjs
+++ b/tracker-writer-lock-tests.mjs
@@ -4,8 +4,8 @@
 
 import { spawn } from 'child_process';
 import {
-  existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync, utimesSync, watch,
-  writeFileSync,
+  existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, statSync,
+  utimesSync, writeFileSync,
 } from 'fs';
 import { basename, dirname, join } from 'path';
 import { tmpdir } from 'os';
@@ -58,38 +58,43 @@ const CONTENTION_WAIT_MS = 2_000;
  * and removes `${lockDir}.recover` on every contended pass, so its first
  * appearance means "this child has tried the lock and someone else holds it".
  * That instant sits after a pre-lock read and before a post-lock one, which is
- * exactly the discrimination the mutation needs. fs.watch queues events, so a
- * guard directory that exists for a millisecond is still observed.
+ * exactly the discrimination the mutation needs.
  *
- * It is a bounded wait, never a barrier. If no guard event arrives — a lock
- * implementation that stops using the guard, a writer that legitimately does
- * other work first, a platform where fs.watch cannot report directory children
- * — the mutation proceeds anyway once CONTENTION_WAIT_MS elapses and the test
- * degrades to its previous timing-dependent behaviour instead of hanging.
+ * This POLLS rather than using fs.watch. On Windows, fs.watch aborts the whole
+ * process with a libuv assertion (`!_wcsnicmp(filename, dir, dirlen)`,
+ * src\win\fs-event.c) when the watched directory is reached through an 8.3
+ * short path — which is exactly what CI runners use (C:\Users\RUNNER~1\...),
+ * so the watcher version killed this suite with exit 3221226505 on
+ * windows-latest while passing locally. The guard is created and removed on
+ * every contended retry, not once, so a poll gets many chances to observe it.
  *
- * @param {string} dir - Directory containing the lock (watched non-recursively).
+ * It is a bounded wait, never a barrier. If no guard ever appears — a lock
+ * implementation that stops using the guard, or a writer that legitimately
+ * does other work first — the mutation proceeds anyway once
+ * CONTENTION_WAIT_MS elapses and the test degrades to its previous
+ * timing-dependent behaviour instead of hanging.
+ *
+ * @param {string} dir - Directory containing the lock.
  * @param {string} lockDir - The lock directory whose recover guard signals contention.
  * @returns {{wait: (timeoutMs: number) => Promise<boolean>, close: () => void}}
  */
 function watchForContention(dir, lockDir) {
   const guardPrefix = `${basename(lockDir)}.recover`;
-  let seen = false;
-  let watcher = null;
-  try {
-    watcher = watch(dir, (_event, name) => {
-      if (name && String(name).startsWith(guardPrefix)) seen = true;
-    });
-  } catch {
-    // fs.watch is unavailable or unsupported here — the timed fallback stands in.
-  }
+  const guardPresent = () => {
+    try {
+      return readdirSync(dir).some((name) => name.startsWith(guardPrefix));
+    } catch {
+      return false; // directory vanished mid-run; the timed fallback stands in
+    }
+  };
   return {
     async wait(timeoutMs) {
       const deadline = Date.now() + timeoutMs;
-      while (!seen && Date.now() < deadline) await sleep(5);
-      watcher?.close();
+      let seen = false;
+      while (!(seen = guardPresent()) && Date.now() < deadline) await sleep(2);
       return seen;
     },
-    close() { watcher?.close(); },
+    close() {},
   };
 }
 


### PR DESCRIPTION
Closes #2396

Test-only. No production script changes.

## The gap

`runWhileLocked` in `tracker-writer-lock-tests.mjs` covered `normalize-statuses`, `dedup-tracker`, `tracker delete`, `tracker export` and three `reply-watch` variants. It did not cover `set-status.mjs`, which is the writer CLAUDE.md names as canonical and the one the modes actually call, and it did not cover `mark-pdf-ready.mjs`.

Both scripts are correct today: they acquire the lock and then read. Nothing held that order in place. `set-status-tests.mjs` covers the lock timeout (exit 4) at line 584 and a lock error at line 606, but those only prove the script contends for the lock. Neither can tell a writer that re-reads under the lock apart from one that reads first and writes its stale snapshot back. Since `set-status.mjs` already does real pre-lock work validating the requested state against `states.yml`, hoisting the `readFileSync` up there to "resolve the row before paying for the lock" is a plausible refactor, and it would have stayed green.

## Ordering the fixture mutation

Adding the two matrix entries was not enough on its own, which is worth recording because it is not obvious.

The harness holds the lock, spawns the writer, then commits a concurrent row before releasing. That row is what a stale snapshot erases, so it only discriminates if it lands after the writer's own read. Committing it immediately after `spawn()` does not: a fresh Node process needs tens of milliseconds to boot, so the row is already on disk before even a buggy writer reads it, and the buggy writer then reads the post-mutation file and passes.

The harness now waits for the lock's recover-guard directory to appear before mutating. `acquireTrackerLock` creates and removes `${lockDir}.recover` on every contended pass, so its first appearance marks the moment the child has tried the lock and lost. That instant sits after a pre-lock read and before a post-lock one, which is exactly the discrimination needed. `fs.watch` queues events, so a guard that exists for a millisecond is still observed (measured at 54ms to 65ms after spawn on this box).

The wait is bounded at 2s and is not a barrier. If the guard never appears, because a future lock implementation drops it or `fs.watch` cannot report directory children on some platform, the mutation proceeds anyway and the test degrades to its previous timing-dependent behaviour rather than hanging. Entries using `beforeMutationOutput` skip the wait, since their pre-lock review prompt is a stronger script-specific signal and a writer parked at that prompt has not reached the lock yet.

## Mutation evidence

Each new test was checked against a deliberately broken copy of the script it covers, then the script was restored and `git diff` confirmed clean.

`set-status.mjs`, `readFileSync` hoisted above `acquireTrackerLockForCli`:

```
PASS set-status: contends on the shared lock before reading or writing
FAIL set-status: update failed after lock release (exit=0)
#1 Acme, Engineer: set Evaluated to Applied (note: sent CV)

| 1 | 2026-01-01 | Acme | Engineer | 4.0/5 | Applied | ❌ | [1](reports/001-acme.md) | seed; sent CV |
```

Exit 0, its own edit applied, and the concurrent row #99 gone. That is the failure this test exists to catch. The contention probe still passes under the mutant, which confirms the probe alone was never sufficient.

`mark-pdf-ready.mjs`, same hoist: `FAIL mark-pdf-ready: update failed after lock release (exit=0)`.

Before the guard wait was added, both mutants left the suite fully green at 26 passed, 0 failed.

## followup-seed

Investigated rather than assumed. `followup-seed.mjs:76` uses a separate `career-ops-followups-` lock namespace, keyed by the follow-ups path. That is deliberate and safe, so this is a test, not a bug report.

It reads `applications.md` to find the row and its apply date, then writes only `data/follow-ups.md`. It never writes the tracker. The stale-snapshot invariant cannot apply to it: with no tracker write there is no snapshot to write back, so a row committed while it runs cannot be erased. Its pre-lock tracker read is an observation that can go stale (a row could leave Applied before the pin lands) but never a lost write.

The namespaces have to stay separate. The tracker lock says nothing about `follow-ups.md`, so a seeder holding it would still race a second seeder, and `followup-seed.mjs` is the only writer of that file in the repo. Every other consumer (`followup-cadence`, `reply-watch`, `stats`, `company-history`) only reads it. Sharing the tracker lock would serialize seeding behind unrelated tracker writes and nest two locks without buying any safety.

The new test states that as behaviour. It holds the tracker lock for the whole run and asserts followup-seed completes anyway, seeds the pin, and leaves the tracker byte-for-byte as the lock holder left it. It compares mtime as well as content, so a writer that replaces the tracker with bytes it read a moment earlier is still caught.

Both directions were mutation-checked. Making `seedFollowup` acquire the tracker lock produced `FAIL followup-seed: separate-namespace contract broken (exit=4)` with a tracker lock timeout. Adding a byte-identical `writeFileAtomic(trackerPath, ...)` after the pin write produced `FAIL ... (exit=0)`, caught by the mtime comparison.

## Validation

`node tracker-writer-lock-tests.mjs`: 26 passed, 0 failed. Run twice, same result both times.

`node test-all.mjs`: 2747 passed, 1 failed, 2 warnings. Run twice, identical results. The single failure is a pre-existing Windows-only one on this box, `analyze() appDateSource end-to-end check crashed: EPERM: operation not permitted, symlink`, which also fails on unmodified `upstream/main` here and is unrelated to this change.

These tests spawn real processes and wait on real locks, so the repeat runs were specifically to check for flakiness. None seen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when multiple tracker-related operations run at the same time.
  - Follow-up processing now completes independently without altering tracker data during concurrent activity.

- **Tests**
  - Expanded coverage for status updates, PDF readiness changes, lock contention, and follow-up data handling.
  - Added safeguards to detect and validate contention scenarios more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->