### PR TITLE
fix(merge-tracker): four silent data-loss paths in the merge loop

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -225,6 +225,29 @@ function extractReqNumber(notes) {
 }
 
 /**
+ * Company equality for duplicate detection.
+ *
+ * normalizeCompany() strips everything outside [a-z0-9], so a company name
+ * written entirely in a non-Latin script (CJK, Cyrillic, Arabic, …) normalizes
+ * to the empty string — and every such name would compare equal to every other
+ * one. That collapses DIFFERENT companies into one row as soon as their roles
+ * fuzzy-match (six Japanese companies posting データエンジニア → one row).
+ * When the normalized key carries no signal, fall back to raw trimmed
+ * equality so distinct non-Latin companies stay distinct; the unknown-employer
+ * `?` marker still matches itself, so the #1596 cross-channel guard keeps its
+ * existing behavior.
+ *
+ * @param {string} a - Company cell from one side of the comparison.
+ * @param {string} b - Company cell from the other side.
+ * @returns {boolean} True when the two cells name the same company.
+ */
+function companiesMatch(a, b) {
+  const key = normalizeCompany(String(a));
+  if (key !== normalizeCompany(String(b))) return false;
+  return key !== '' || String(a).trim() === String(b).trim();
+}
+
+/**
  * Combine an existing row's Notes with a re-evaluation's Notes.
  *
  * The update path used to overwrite Notes with
@@ -257,8 +280,17 @@ function mergeNotes(existingNotes, addition, oldScore, newScore) {
   const incoming = String(addition.notes ?? '').trim();
   const marker = `Re-eval ${addition.date} (${oldScore}→${newScore})`;
   // Re-running the same evaluation would otherwise repeat its own text; the
-  // marker still records that the re-evaluation happened.
-  const tail = incoming && !prev.includes(incoming) ? `${marker}: ${incoming}` : marker;
+  // marker still records that the re-evaluation happened. Repeats are detected
+  // per CLAUSE — the same '. ' separator this function joins with — not by raw
+  // substring: `prev.includes(incoming)` dropped any new note that happened to
+  // appear INSIDE an existing clause ("Remote" vanished against "Remote OK").
+  // A clause equals the incoming text either bare or in the marker-prefixed
+  // form a previous run of this function appended (`{marker}: {incoming}`).
+  const clause = (s) => s.replace(/\.+$/, '').trim();
+  const incomingClause = clause(incoming);
+  const isRepeat = incoming !== '' && prev.split(/\.\s+/).map(clause)
+    .some(c => c === incomingClause || c.endsWith(`: ${incomingClause}`));
+  const tail = incoming && !isRepeat ? `${marker}: ${incoming}` : marker;
   return prev ? `${prev}. ${tail}` : tail;
 }
 
@@ -756,10 +788,9 @@ for (const file of tsvFiles) {
     // appearing for two different companies is sequence drift, not a duplicate.
     // Without the company guard, a NewCo TSV with report [1] silently overwrites
     // the existing tracker row [1] belonging to an unrelated company.
-    const normCompany = normalizeCompany(addition.company);
     duplicate = existingApps.find(app => {
       const existingReportNum = extractReportNum(app.report);
-      return existingReportNum === reportNum && normalizeCompany(app.company) === normCompany;
+      return existingReportNum === reportNum && companiesMatch(app.company, addition.company);
     });
     if (duplicate) reportNumMatched = true;
   }
@@ -771,18 +802,25 @@ for (const file of tsvFiles) {
     // 067 while the tracker was already at #69). A bare num collision across
     // *different* companies is that drift, not a duplicate — matching on num
     // alone silently merges a brand-new role into an unrelated existing row.
-    const normCompany = normalizeCompany(addition.company);
     duplicate = existingApps.find(app =>
-      app.num === addition.num && normalizeCompany(app.company) === normCompany
+      app.num === addition.num && companiesMatch(app.company, addition.company)
+      // Same-run num collisions are reservation races, not row-id references:
+      // two TSVs that both claimed num=5 for DIFFERENT roles at one company
+      // are two distinct evaluations, and folding them keeps the first title
+      // with the second score (main renumbers and keeps both via the
+      // #1704/#1733 path). For a row queued THIS run, only accept the num
+      // match when the roles also fuzzy-match — consistent with tier-3's
+      // cross-run semantics. For rows already on disk, num remains the
+      // tracker row id and behavior is unchanged.
+      && (!app.addedThisRun || roleFuzzyMatch(addition.role, app.role))
     );
   }
 
   if (!duplicate) {
     // Company + role fuzzy match
-    const normCompany = normalizeCompany(addition.company);
     const additionReqNum = extractReqNumber(addition.notes);
     duplicate = existingApps.find(app => {
-      if (normalizeCompany(app.company) !== normCompany) return false;
+      if (!companiesMatch(app.company, addition.company)) return false;
       if (!roleFuzzyMatch(addition.role, app.role)) return false;
       // Cross-channel guard (#1596): unknown-employer rows (`?`) all normalize
       // to the same empty company key, but the same role via two DIFFERENT
@@ -892,7 +930,14 @@ for (const file of tsvFiles) {
     // higher-scored addition updates it in place just like a row already on
     // disk.
     const parsedNew = parseAppLine(newLine);
-    if (parsedNew) existingApps.push(parsedNew);
+    if (parsedNew) {
+      // Mark the row as queued this run: tier-2 treats a num collision with a
+      // same-run row as a reservation race unless the roles also fuzzy-match
+      // (see the tier-2 guard above). Object.assign() in the update path never
+      // deletes the flag, so it survives in-place refreshes within the run.
+      parsedNew.addedThisRun = true;
+      existingApps.push(parsedNew);
+    }
     added++;
     console.log(`➕ Add #${entryNum}: ${addition.company} — ${addition.role} (${addition.score})`);
   }

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -893,9 +893,29 @@ if (newLines.length > 0) {
       break;
     }
   }
-  if (insertIdx >= 0) {
-    appLines.splice(insertIdx, 0, ...newLines);
+  if (insertIdx < 0) {
+    // #2394: no separator row means no insert point. The old code left
+    // insertIdx at -1, skipped the splice with no else, then carried on to
+    // write the file, archive every TSV into merged/ and print "+N added" —
+    // so a tracker whose table header had been damaged (or a fresh file that
+    // only ever got its `# Applications Tracker` line) swallowed a whole batch
+    // of evaluations while reporting success. Nothing survived: the tracker is
+    // gitignored and merge-tracker keeps no .bak.
+    //
+    // Abort before writing anything. Leaving the tracker and the additions dir
+    // exactly as they were makes the run a no-op that replays cleanly once the
+    // table is repaired.
+    console.error(`❌ Aborting merge: ${basename(APPS_FILE)} has no table separator row ("|---|------|...").`);
+    console.error(`   There is no insert point for ${newLines.length} new row(s), so NOTHING was written and no TSV was archived.`);
+    console.error('   Repair the tracker table header, then re-run — the pending additions in');
+    console.error(`   ${ADDITIONS_DIR} will merge then. Expected header:`);
+    console.error('     | # | Date | Company | Role | Score | Status | PDF | Report | Notes |');
+    console.error('     |---|------|---------|------|-------|--------|-----|--------|-------|');
+    for (const line of newLines) console.error(`   not merged: ${line}`);
+    trackerLock.release();
+    process.exit(1);
   }
+  appLines.splice(insertIdx, 0, ...newLines);
 }
 
 // Write back

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -625,6 +625,10 @@ tsvFiles.sort((a, b) => {
 console.log(`📥 Found ${tsvFiles.length} pending additions`);
 
 const newLines = [];
+// TSVs whose evaluation could not be applied to the tracker. They are kept out
+// of merged/ so a re-run picks them up, and they make the process exit non-zero
+// instead of reporting a success that did not happen.
+const failedAdditions = [];
 
 for (const file of tsvFiles) {
   const content = readFileSync(join(ADDITIONS_DIR, file), 'utf-8').trim();
@@ -740,7 +744,31 @@ for (const file of tsvFiles) {
           notes: `Re-eval ${addition.date} (${oldScore}→${newScore}). ${addition.notes}`,
         });
         appLines[lineIdx] = updatedLine;
+        // Refresh the cached row from the line just written (#2392). `raw` was
+        // captured when applications.md was parsed and used to be left stale
+        // after the write, so a SECOND addition matching this same row found
+        // nothing at indexOf(), fell through a branch with no else, and was
+        // archived as merged — the evaluation was gone with no warning and no
+        // recoverable copy (the tracker is gitignored and no .bak is written).
+        // The stale `score` was just as damaging: the second comparison read
+        // the pre-update score, so which of several re-evaluations survived
+        // depended on TSV filename sort order. Re-parsing the written line is
+        // the faithful refresh — the cached row then holds exactly what a fresh
+        // read of the tracker would produce. syncPdfFlags() has always kept its
+        // cache in step this way; the update path did not.
+        const refreshed = parseAppLine(updatedLine);
+        if (refreshed) Object.assign(duplicate, refreshed);
+        else duplicate.raw = updatedLine;
         updated++;
+      } else {
+        // Unreachable once `raw` is refreshed above, but never silent again: a
+        // row we cannot locate means the addition was NOT applied, so say so,
+        // keep the TSV out of merged/, and fail the run.
+        console.error(
+          `❌ ${file}: could not locate tracker row #${duplicate.num} ` +
+          `(${duplicate.company} — ${duplicate.role}) to update; this evaluation was NOT merged.`,
+        );
+        failedAdditions.push(file);
       }
     } else {
       console.log(`⏭️  Skip: ${addition.company} — ${addition.role} (existing #${duplicate.num} ${oldScore} >= new ${newScore})`);
@@ -801,15 +829,19 @@ if (newLines.length > 0) {
 if (!DRY_RUN) {
   writeFileAtomic(APPS_FILE, appLines.join('\n'));
 
-  // Move processed files to merged/
+  // Move processed files to merged/ — but only the ones actually applied.
+  // Archiving a TSV whose row never reached the tracker is what turns a bug
+  // into permanent data loss, since applications.md is gitignored and no backup
+  // is written.
   if (!existsSync(MERGED_DIR)) mkdirSync(MERGED_DIR, { recursive: true });
-  for (const file of tsvFiles) {
+  const archivable = tsvFiles.filter(f => !failedAdditions.includes(f));
+  for (const file of archivable) {
     renameSync(join(ADDITIONS_DIR, file), join(MERGED_DIR, file));
   }
-  console.log(`\n✅ Moved ${tsvFiles.length} TSVs to merged/`);
+  console.log(`\n✅ Moved ${archivable.length} TSVs to merged/`);
 }
 
-console.log(`\n📊 Summary: +${added} added, 🔄${updated} updated, ⏭️${skipped} skipped`);
+console.log(`\n📊 Summary: +${added} added, 🔄${updated} updated, ⏭️${skipped} skipped${failedAdditions.length ? `, ❌${failedAdditions.length} NOT merged` : ''}`);
 if (DRY_RUN) console.log('(dry-run — no changes written)');
 trackerLock.release();
 
@@ -830,4 +862,14 @@ if (VERIFY && !DRY_RUN) {
   } catch (e) {
     process.exit(1);
   }
+}
+
+// Any addition that could not be applied fails the run. The TSVs stay in the
+// additions dir, so re-running after the tracker is repaired merges them once.
+if (failedAdditions.length > 0) {
+  console.error(
+    `\n❌ ${failedAdditions.length} addition(s) were NOT merged and were left in ${ADDITIONS_DIR}: ` +
+    failedAdditions.join(', '),
+  );
+  process.exit(1);
 }

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -630,6 +630,32 @@ const newLines = [];
 // instead of reporting a success that did not happen.
 const failedAdditions = [];
 
+/**
+ * Replace one tracker row line wherever it currently lives.
+ *
+ * A row added earlier in THIS run is still queued in `newLines` and has not
+ * been spliced into `appLines` yet, so an update targeting it would not be
+ * found by an appLines-only lookup (#2392 gap 3). Searching both keeps the
+ * intra-run dedup below able to update a row it just created.
+ *
+ * @param {string} oldLine - The row line as it currently stands.
+ * @param {string} updatedLine - Replacement row line.
+ * @returns {boolean} True when the line was found and replaced.
+ */
+function replaceTrackerLine(oldLine, updatedLine) {
+  const idx = appLines.indexOf(oldLine);
+  if (idx >= 0) {
+    appLines[idx] = updatedLine;
+    return true;
+  }
+  const pendingIdx = newLines.indexOf(oldLine);
+  if (pendingIdx >= 0) {
+    newLines[pendingIdx] = updatedLine;
+    return true;
+  }
+  return false;
+}
+
 for (const file of tsvFiles) {
   const content = readFileSync(join(ADDITIONS_DIR, file), 'utf-8').trim();
   const addition = parseTsvContent(content, file);
@@ -731,19 +757,17 @@ for (const file of tsvFiles) {
 
     if (newScore > oldScore) {
       console.log(`🔄 Update: #${duplicate.num} ${addition.company} — ${addition.role} (${oldScore}→${newScore})`);
-      const lineIdx = appLines.indexOf(duplicate.raw);
-      if (lineIdx >= 0) {
-        const pdf = reportNum && pdfIndex.has(String(reportNum)) ? '✅' : duplicate.pdf;
-        const updatedLine = buildRow({
-          num: duplicate.num, date: addition.date, company: addition.company,
-          role: reportNumMatched ? addition.role : duplicate.role,
-          via: addition.via || duplicate.via || '—',
-          location: addition.location || duplicate.location || '—',
-          score: addition.score, status: duplicate.status, pdf,
-          report: addition.report,
-          notes: `Re-eval ${addition.date} (${oldScore}→${newScore}). ${addition.notes}`,
-        });
-        appLines[lineIdx] = updatedLine;
+      const pdf = reportNum && pdfIndex.has(String(reportNum)) ? '✅' : duplicate.pdf;
+      const updatedLine = buildRow({
+        num: duplicate.num, date: addition.date, company: addition.company,
+        role: reportNumMatched ? addition.role : duplicate.role,
+        via: addition.via || duplicate.via || '—',
+        location: addition.location || duplicate.location || '—',
+        score: addition.score, status: duplicate.status, pdf,
+        report: addition.report,
+        notes: `Re-eval ${addition.date} (${oldScore}→${newScore}). ${addition.notes}`,
+      });
+      if (replaceTrackerLine(duplicate.raw, updatedLine)) {
         // Refresh the cached row from the line just written (#2392). `raw` was
         // captured when applications.md was parsed and used to be left stale
         // after the write, so a SECOND addition matching this same row found
@@ -803,6 +827,17 @@ for (const file of tsvFiles) {
       report: addition.report, notes: addition.notes,
     });
     newLines.push(newLine);
+    // Register the row with the dedup index right away (#2392 gap 3). All
+    // three dedup tiers search `existingApps`, which only ever held rows read
+    // from the file, so two TSVs for the same company+role in ONE run both
+    // appended and the tracker gained duplicate rows — the exact outcome
+    // CLAUDE.md's "NEVER create new entries if company+role already exists"
+    // rule forbids. The parsed row's `raw` is the queued line, and
+    // replaceTrackerLine() knows how to find it in `newLines`, so a later
+    // higher-scored addition updates it in place just like a row already on
+    // disk.
+    const parsedNew = parseAppLine(newLine);
+    if (parsedNew) existingApps.push(parsedNew);
     added++;
     console.log(`➕ Add #${entryNum}: ${addition.company} — ${addition.role} (${addition.score})`);
   }

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -349,6 +349,23 @@ function buildRow(o) {
   return `| ${cells.join(' | ')} |`;
 }
 
+// Header + separator for the DETECTED layout, mirroring buildRow's column
+// order. The abort path below prints these as repair guidance, so hard-coding
+// the nine-column form would hand a user with a Via or Location column a
+// header that silently drops it — repair instructions that reintroduce the
+// drift they exist to fix.
+function buildHeaderRows() {
+  const labels = ['#', 'Date', 'Company'];
+  if (COLMAP.via != null) labels.push('Via');
+  labels.push('Role');
+  if (COLMAP.location != null) labels.push('Location');
+  labels.push('Score', 'Status', 'PDF', 'Report', 'Notes');
+  return {
+    header: `| ${labels.join(' | ')} |`,
+    separator: `|${labels.map((l) => '-'.repeat(Math.max(3, l.length + 2))).join('|')}|`,
+  };
+}
+
 /**
  * Parse one Markdown applications.md table row into a tracker object.
  *
@@ -909,8 +926,9 @@ if (newLines.length > 0) {
     console.error(`   There is no insert point for ${newLines.length} new row(s), so NOTHING was written and no TSV was archived.`);
     console.error('   Repair the tracker table header, then re-run — the pending additions in');
     console.error(`   ${ADDITIONS_DIR} will merge then. Expected header:`);
-    console.error('     | # | Date | Company | Role | Score | Status | PDF | Report | Notes |');
-    console.error('     |---|------|---------|------|-------|--------|-----|--------|-------|');
+    const { header, separator } = buildHeaderRows();
+    console.error(`     ${header}`);
+    console.error(`     ${separator}`);
     for (const line of newLines) console.error(`   not merged: ${line}`);
     trackerLock.release();
     process.exit(1);

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -225,6 +225,44 @@ function extractReqNumber(notes) {
 }
 
 /**
+ * Combine an existing row's Notes with a re-evaluation's Notes.
+ *
+ * The update path used to overwrite Notes with
+ * `Re-eval {date} ({old}→{new}). {new notes}`, discarding the existing cell
+ * outright (#2392 gap 2). The Notes column is not decoration: it carries the
+ * `Applied YYYY-MM-DD` marker that followup-cadence.mjs prefers over the Date
+ * column (dropping it silently resets the follow-up clock to the evaluation
+ * date), the req/job number that this script's OWN sibling-req guard reads back
+ * via extractReqNumber(), contact addresses, and whatever the user wrote with
+ * `set-status --note`. None of it is recoverable: applications.md is gitignored
+ * and no .bak is written.
+ *
+ * Format: the existing notes are kept verbatim and FIRST, with the re-eval
+ * marker and any new notes appended after them. Order is deliberate, not
+ * cosmetic — parseAppliedDate() and extractReqNumber() both return their FIRST
+ * match, so leading with the established text keeps a row's apply date and req
+ * number stable across re-evaluations instead of letting each new evaluation's
+ * text take over. The cost is that Notes grows by one clause per re-evaluation.
+ *
+ * @param {string} existingNotes - Notes cell currently on the tracker row.
+ * @param {object} addition - Parsed TSV addition (uses `notes` and `date`).
+ * @param {number} oldScore - Score currently on the row.
+ * @param {number} newScore - Score from the addition.
+ * @returns {string} Combined Notes cell.
+ */
+function mergeNotes(existingNotes, addition, oldScore, newScore) {
+  // Trailing period trimmed only so the '. ' join does not produce '..'; no
+  // other character of the existing text is touched.
+  const prev = String(existingNotes ?? '').trim().replace(/\s*\.\s*$/, '');
+  const incoming = String(addition.notes ?? '').trim();
+  const marker = `Re-eval ${addition.date} (${oldScore}→${newScore})`;
+  // Re-running the same evaluation would otherwise repeat its own text; the
+  // marker still records that the re-evaluation happened.
+  const tail = incoming && !prev.includes(incoming) ? `${marker}: ${incoming}` : marker;
+  return prev ? `${prev}. ${tail}` : tail;
+}
+
+/**
  * Parse a score cell into a numeric value for score-upgrade decisions.
  *
  * The merge path compares old and new scores to decide whether to update an
@@ -765,7 +803,7 @@ for (const file of tsvFiles) {
         location: addition.location || duplicate.location || '—',
         score: addition.score, status: duplicate.status, pdf,
         report: addition.report,
-        notes: `Re-eval ${addition.date} (${oldScore}→${newScore}). ${addition.notes}`,
+        notes: mergeNotes(duplicate.notes, addition, oldScore, newScore),
       });
       if (replaceTrackerLine(duplicate.raw, updatedLine)) {
         // Refresh the cached row from the line just written (#2392). `raw` was

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -32,23 +32,31 @@ function runMerge(additions) {
  * and exit code, and which TSVs the run archived into merged/.
  *
  * @param {Record<string,string>} additions - TSV filename → file content.
- * @param {{rows?: string, header?: string}} [opts] - Seed rows appended to the
- *   tracker header, or a replacement header (used to build a tracker whose
- *   table separator row is missing).
- * @returns {{tracker: string, output: string, exitCode: number, archived: string[], pending: string[]}}
+ * @param {{rows?: string, header?: string, keepWorkspace?: boolean, reuse?: object}} [opts] -
+ *   Seed rows appended to the tracker header, or a replacement header (used to
+ *   build a tracker whose table separator row is missing). `keepWorkspace`
+ *   leaves the temp dir on disk and returns it, and `reuse` runs against a
+ *   workspace a previous call kept, so a test can genuinely re-run the SAME
+ *   pending TSVs after repairing the tracker rather than starting fresh.
+ * @returns {{tracker: string, output: string, exitCode: number, archived: string[], pending: string[], work?: string}}
  */
 function runMergeDetailed(additions, opts = {}) {
-  const work = mkdtempSync(join(tmpdir(), 'cops-merge-'));
+  const work = opts.reuse?.work ?? mkdtempSync(join(tmpdir(), 'cops-merge-'));
   try {
     const tracker = join(work, 'applications.md');
     const addsDir = join(work, 'adds');
     mkdirSync(addsDir, { recursive: true });
     writeFileSync(tracker, (opts.header ?? TRACKER_HEADER) + (opts.rows ?? ''));
-    for (const [name, line] of Object.entries(additions)) {
-      writeFileSync(join(addsDir, name), line);
+    // On a reused workspace the pending TSVs are already on disk from the
+    // aborted run; rewriting them would defeat the point of replaying them.
+    if (!opts.reuse) {
+      for (const [name, line] of Object.entries(additions)) {
+        writeFileSync(join(addsDir, name), line);
+      }
     }
     let output = '';
     let exitCode = 0;
+    let killedBy = null;
     try {
       output = execFileSync(NODE, [join(ROOT, 'merge-tracker.mjs')], {
         encoding: 'utf-8',
@@ -61,18 +69,31 @@ function runMergeDetailed(additions, opts = {}) {
       });
     } catch (e) {
       output = String(e.stdout ?? '') + String(e.stderr ?? '');
-      exitCode = e.status ?? -1;
+      // A normal non-zero exit carries `status`; a kill (the 30s timeout, or
+      // any other signal) carries `signal` with a null status. Collapsing both
+      // to -1 would let a HUNG merge-tracker satisfy an `exitCode !== 0`
+      // assertion, so the separator test would pass on a hang — the opposite
+      // of what it checks. Surface the signal separately and let the caller
+      // fail on it.
+      if (typeof e.status === 'number') {
+        exitCode = e.status;
+      } else {
+        killedBy = e.signal ?? 'unknown';
+        exitCode = null;
+      }
     }
     const mergedDir = join(addsDir, 'merged');
     return {
       tracker: readFileSync(tracker, 'utf-8'),
       output,
       exitCode,
+      killedBy,
       archived: existsSync(mergedDir) ? readdirSync(mergedDir) : [],
       pending: readdirSync(addsDir).filter(f => f.endsWith('.tsv')),
+      work: opts.keepWorkspace ? work : undefined,
     };
   } finally {
-    rmSync(work, { recursive: true, force: true });
+    if (!opts.keepWorkspace) rmSync(work, { recursive: true, force: true });
   }
 }
 
@@ -268,11 +289,17 @@ try {
 // evaluations existed only in merged/ afterwards.
 console.log('\nmerge-tracker.mjs — tracker with no table separator row (#2394)');
 try {
-  const broken = runMergeDetailed({
-    '001-acme.tsv': '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-03-01.md)\tonly evaluation\n',
-  }, { header: '# Applications Tracker\n\n' });
+  const ADDITION = '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-03-01.md)\tonly evaluation\n';
+  const broken = runMergeDetailed(
+    { '001-acme.tsv': ADDITION },
+    { header: '# Applications Tracker\n\n', keepWorkspace: true },
+  );
 
-  if (broken.exitCode !== 0) {
+  // exitCode is null when the child was killed rather than exiting, so a hung
+  // merge cannot masquerade as the loud failure this asserts.
+  if (broken.killedBy) {
+    fail(`merge-tracker was killed by ${broken.killedBy} instead of exiting`);
+  } else if (broken.exitCode !== 0) {
     pass('merge fails loudly when the tracker table has no separator row');
   } else {
     fail(`merge reported success against a separator-less tracker (exit ${broken.exitCode})`);
@@ -292,14 +319,26 @@ try {
     fail(`merge misreported the outcome: ${broken.output.split('\n').filter(l => /added|Summary/.test(l)).join(' // ') || '(no summary line)'}`);
   }
 
-  // Re-running after the header is repaired must merge the addition once.
-  const repaired = runMergeDetailed({
-    '001-acme.tsv': '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-03-01.md)\tonly evaluation\n',
-  });
-  if (dataRows(repaired.tracker).length === 1 && repaired.exitCode === 0) {
-    pass('the same addition merges normally once the table header is intact');
-  } else {
-    fail(`addition did not merge against a well-formed tracker (exit ${repaired.exitCode})`);
+  // The abort promises the run "replays cleanly once the table is repaired", so
+  // replay it literally: same workspace, same TSV left on disk by the aborted
+  // run, only the tracker header repaired. Merging a fresh copy into a fresh
+  // workspace would prove nothing about the pending file the user still has.
+  try {
+    const repaired = runMergeDetailed({}, { reuse: broken, keepWorkspace: true });
+    if (repaired.killedBy) {
+      fail(`replay was killed by ${repaired.killedBy} instead of exiting`);
+    } else if (dataRows(repaired.tracker).length === 1 && repaired.exitCode === 0) {
+      pass('the TSV left pending by the abort merges on replay once the header is repaired');
+    } else {
+      fail(`pending addition did not merge after header repair (exit ${repaired.exitCode}, rows ${dataRows(repaired.tracker).length})`);
+    }
+    if (repaired.archived.includes('001-acme.tsv') && repaired.pending.length === 0) {
+      pass('the replayed TSV is archived once it has actually landed in the tracker');
+    } else {
+      fail(`replay left the TSV unarchived: archived=[${repaired.archived.join(', ')}] pending=[${repaired.pending.join(', ')}]`);
+    }
+  } finally {
+    rmSync(broken.work, { recursive: true, force: true });
   }
 } catch (e) {
   fail(`merge-tracker separator-row tests crashed: ${e.message}`);

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -53,6 +53,10 @@ function runMergeDetailed(additions, opts = {}) {
       output = execFileSync(NODE, [join(ROOT, 'merge-tracker.mjs')], {
         encoding: 'utf-8',
         timeout: 30000,
+        // Capture stderr instead of letting execFileSync echo it: the
+        // separator-row fixture below deliberately triggers a loud failure,
+        // and its error text would otherwise land in the suite's own log.
+        stdio: ['ignore', 'pipe', 'pipe'],
         env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: addsDir },
       });
     } catch (e) {
@@ -255,4 +259,48 @@ try {
   }
 } catch (e) {
   fail(`merge-tracker Notes-preservation tests crashed: ${e.message}`);
+}
+
+// ── #2394: a tracker with no separator row dropped everything, silently ─────
+// The insert point comes from SEPARATOR_ROW_RE. With no match, insertIdx
+// stayed -1, the splice was skipped with no else, and the run went on to write
+// the file, archive every TSV into merged/ and print "+N added". The
+// evaluations existed only in merged/ afterwards.
+console.log('\nmerge-tracker.mjs — tracker with no table separator row (#2394)');
+try {
+  const broken = runMergeDetailed({
+    '001-acme.tsv': '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-03-01.md)\tonly evaluation\n',
+  }, { header: '# Applications Tracker\n\n' });
+
+  if (broken.exitCode !== 0) {
+    pass('merge fails loudly when the tracker table has no separator row');
+  } else {
+    fail(`merge reported success against a separator-less tracker (exit ${broken.exitCode})`);
+  }
+
+  // The consequence that actually costs data: an archived TSV whose row never
+  // reached the tracker is unrecoverable, because the tracker is gitignored.
+  if (broken.archived.length === 0 && broken.pending.includes('001-acme.tsv')) {
+    pass('the unmerged TSV stays in the additions dir instead of being archived');
+  } else {
+    fail(`TSV archived despite never reaching the tracker: archived=[${broken.archived.join(', ')}] pending=[${broken.pending.join(', ')}]`);
+  }
+
+  if (!/\+1 added/.test(broken.output) && /separator row/.test(broken.output)) {
+    pass('the failure names the missing separator row rather than reporting rows added');
+  } else {
+    fail(`merge misreported the outcome: ${broken.output.split('\n').filter(l => /added|Summary/.test(l)).join(' // ') || '(no summary line)'}`);
+  }
+
+  // Re-running after the header is repaired must merge the addition once.
+  const repaired = runMergeDetailed({
+    '001-acme.tsv': '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-03-01.md)\tonly evaluation\n',
+  });
+  if (dataRows(repaired.tracker).length === 1 && repaired.exitCode === 0) {
+    pass('the same addition merges normally once the table header is intact');
+  } else {
+    fail(`addition did not merge against a well-formed tracker (exit ${repaired.exitCode})`);
+  }
+} catch (e) {
+  fail(`merge-tracker separator-row tests crashed: ${e.message}`);
 }

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -7,7 +7,7 @@
 import { pass, fail, NODE, ROOT } from './helpers.mjs';
 import { join } from 'path';
 import { execFileSync } from 'child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, existsSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 
 console.log('\nmerge-tracker.mjs — status validation');
@@ -22,24 +22,58 @@ const TRACKER_HEADER = [
 
 // One merge run in an isolated workspace. Returns the merged tracker text.
 function runMerge(additions) {
+  return runMergeDetailed(additions).tracker;
+}
+
+/**
+ * Merge run in an isolated workspace, exposing everything the data-loss
+ * regressions need to assert on: the merged tracker text, the process output
+ * and exit code, and which TSVs the run archived into merged/.
+ *
+ * @param {Record<string,string>} additions - TSV filename → file content.
+ * @param {{rows?: string, header?: string}} [opts] - Seed rows appended to the
+ *   tracker header, or a replacement header (used to build a tracker whose
+ *   table separator row is missing).
+ * @returns {{tracker: string, output: string, exitCode: number, archived: string[], pending: string[]}}
+ */
+function runMergeDetailed(additions, opts = {}) {
   const work = mkdtempSync(join(tmpdir(), 'cops-merge-'));
   try {
     const tracker = join(work, 'applications.md');
     const addsDir = join(work, 'adds');
     mkdirSync(addsDir, { recursive: true });
-    writeFileSync(tracker, TRACKER_HEADER);
+    writeFileSync(tracker, (opts.header ?? TRACKER_HEADER) + (opts.rows ?? ''));
     for (const [name, line] of Object.entries(additions)) {
       writeFileSync(join(addsDir, name), line);
     }
-    execFileSync(NODE, [join(ROOT, 'merge-tracker.mjs')], {
-      encoding: 'utf-8',
-      timeout: 30000,
-      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: addsDir },
-    });
-    return readFileSync(tracker, 'utf-8');
+    let output = '';
+    let exitCode = 0;
+    try {
+      output = execFileSync(NODE, [join(ROOT, 'merge-tracker.mjs')], {
+        encoding: 'utf-8',
+        timeout: 30000,
+        env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: addsDir },
+      });
+    } catch (e) {
+      output = String(e.stdout ?? '') + String(e.stderr ?? '');
+      exitCode = e.status ?? -1;
+    }
+    const mergedDir = join(addsDir, 'merged');
+    return {
+      tracker: readFileSync(tracker, 'utf-8'),
+      output,
+      exitCode,
+      archived: existsSync(mergedDir) ? readdirSync(mergedDir) : [],
+      pending: readdirSync(addsDir).filter(f => f.endsWith('.tsv')),
+    };
   } finally {
     rmSync(work, { recursive: true, force: true });
   }
+}
+
+/** Data rows of a merged tracker, in file order. */
+function dataRows(trackerText) {
+  return trackerText.split('\n').filter(l => /^\|\s*\d+\s*\|/.test(l));
 }
 
 try {
@@ -68,4 +102,59 @@ try {
   }
 } catch (e) {
   fail(`merge-tracker.mjs tests crashed: ${e.message}`);
+}
+
+// ── #2392 gap 1: a SECOND update to the same row was silently dropped ───────
+// The update path located the row with appLines.indexOf(duplicate.raw), where
+// `raw` was the snapshot taken when the tracker was parsed. After the first
+// write the snapshot no longer matched any line, so the second addition hit
+// indexOf() === -1, fell through a branch with no else, and was archived into
+// merged/ anyway. The tracker is gitignored and no .bak is written, so the
+// higher-scored evaluation was gone for good.
+console.log('\nmerge-tracker.mjs — repeated updates to one row (#2392)');
+try {
+  const seeded =
+    '| 1 | 2026-01-01 | Acme | Staff Data Platform Engineer | 4.0/5 | Evaluated | ❌ | ' +
+    '[1](reports/001-acme-2026-01-01.md) | original eval |\n';
+  const res = runMergeDetailed({
+    // Filenames sort a → b, so 4.2 is applied first and 4.7 second: the second,
+    // BETTER evaluation is exactly the one the old code dropped.
+    'a-001-acme.tsv': '1\t2026-02-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.2/5\t❌\t[1](reports/001-acme-2026-01-01.md)\tsecond look\n',
+    'b-001-acme.tsv': '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-01-01.md)\tthird look\n',
+  }, { rows: seeded });
+
+  const rows = dataRows(res.tracker);
+  if (rows.length === 1 && /4\.7\/5/.test(rows[0])) {
+    pass('second update to the same row lands (4.0 → 4.2 → 4.7, one row)');
+  } else {
+    fail(`second update to the same row was dropped: ${rows.length} row(s): ${rows.join(' // ')}`);
+  }
+
+  // The summary must count both updates. Reporting "1 updated" for two applied
+  // updates is how the loss stayed invisible.
+  if (/🔄2 updated/.test(res.output)) {
+    pass('summary counts both in-place updates');
+  } else {
+    fail(`summary undercounted the updates: ${res.output.split('\n').find(l => l.includes('Summary:')) || '(no summary)'}`);
+  }
+
+  // The score comparison must read the CURRENT row, not the parse-time
+  // snapshot: a lower-scored addition arriving after a higher-scored one must
+  // be skipped rather than overwriting it.
+  const downgrade = runMergeDetailed({
+    'a-001-acme.tsv': '1\t2026-02-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-01-01.md)\thigh\n',
+    'b-001-acme.tsv': '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.2/5\t❌\t[1](reports/001-acme-2026-01-01.md)\tlow\n',
+  }, { rows: seeded });
+  const downgradeRows = dataRows(downgrade.tracker);
+  // Both the surviving row AND the accounting have to be right: against the
+  // stale-snapshot code the 4.2 addition compared against the parse-time 4.0,
+  // was announced as an update, and only failed to overwrite because its
+  // indexOf() lookup silently missed. Same file on disk, opposite reason.
+  if (downgradeRows.length === 1 && /4\.7\/5/.test(downgradeRows[0]) && /⏭️1 skipped/.test(downgrade.output)) {
+    pass('a later lower-scored addition is skipped against the CURRENT score, not the parse-time one');
+  } else {
+    fail(`stale score comparison mishandled the downgrade: ${downgradeRows.join(' // ')} | ${downgrade.output.split('\n').find(l => l.includes('Summary:')) || '(no summary)'}`);
+  }
+} catch (e) {
+  fail(`merge-tracker repeated-update tests crashed: ${e.message}`);
 }

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -6,6 +6,7 @@
 // overrides the script already supports for test isolation.
 import { pass, fail, NODE, ROOT } from './helpers.mjs';
 import { join } from 'path';
+import { pathToFileURL } from 'url';
 import { execFileSync } from 'child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, existsSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
@@ -197,4 +198,61 @@ try {
   }
 } catch (e) {
   fail(`merge-tracker intra-run dedup tests crashed: ${e.message}`);
+}
+
+// ── #2392 gap 2: Notes overwritten on a score upgrade ───────────────────────
+// The update path rebuilt Notes as `Re-eval {date} ({old}→{new}). {new notes}`,
+// throwing the existing cell away. The assertions below are on consequences,
+// not text: followup-cadence.mjs must still read the notes-sourced apply date,
+// and merge-tracker's own sibling-req guard must still find the req number.
+console.log('\nmerge-tracker.mjs — Notes preserved across a score upgrade (#2392)');
+try {
+  const APPLIED_ROW =
+    '| 1 | 2026-01-01 | Acme | Staff Data Platform Engineer | 4.0/5 | Applied | ❌ | ' +
+    '[1](reports/001-acme-2026-01-01.md) | Applied 2026-01-15. Req R_1488728. recruiter jane@acme.example |\n';
+  const upgraded = runMergeDetailed({
+    '001-acme.tsv': '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-01-01.md)\tre-scored after JD refresh\n',
+  }, { rows: APPLIED_ROW });
+  const upgradedRow = dataRows(upgraded.tracker)[0] || '';
+
+  if (/4\.7\/5/.test(upgradedRow) && /re-scored after JD refresh/.test(upgradedRow) && /Re-eval 2026-03-01/.test(upgradedRow)) {
+    pass('score upgrade still records the new score, new notes and the re-eval marker');
+  } else {
+    fail(`score upgrade lost the new evaluation's own content: ${upgradedRow}`);
+  }
+
+  if (/Applied 2026-01-15/.test(upgradedRow) && /R_1488728/.test(upgradedRow) && /jane@acme\.example/.test(upgradedRow)) {
+    pass('score upgrade preserves the existing Notes (apply marker, req number, contact)');
+  } else {
+    fail(`score upgrade destroyed the existing Notes: ${upgradedRow}`);
+  }
+
+  // Consequence 1: the follow-up clock. followup-cadence prefers the
+  // "Applied YYYY-MM-DD" marker in Notes over the Date column, so losing it
+  // silently re-dates the application to the evaluation date.
+  const { analyzeFromContent } = await import(pathToFileURL(join(ROOT, 'followup-cadence.mjs')).href);
+  const cadence = analyzeFromContent(upgraded.tracker, '');
+  const entry = (cadence.entries || []).find(e => e.num === 1);
+  if (entry && entry.appliedDate === '2026-01-15' && entry.appDateSource === 'notes') {
+    pass('followup-cadence still measures from the notes apply date after a merge upgrade');
+  } else {
+    fail(`follow-up clock reset by the merge: ${JSON.stringify(entry && { appliedDate: entry.appliedDate, appDateSource: entry.appDateSource })}`);
+  }
+
+  // Consequence 2: merge-tracker's own #1524 sibling-req guard reads the req
+  // number back out of Notes. With the req number erased, a genuinely distinct
+  // posting with a similar title folds into the row instead of being added.
+  // "Senior Staff Data Platform Engineer" fuzzy-matches the row's title, so
+  // only the req-number mismatch can keep the two rows apart.
+  const sibling = runMergeDetailed({
+    '002-acme.tsv': '2\t2026-04-01\tAcme\tSenior Staff Data Platform Engineer\tEvaluated\t4.9/5\t❌\t[2](reports/002-acme-2026-04-01.md)\tReq R_1499999 separate posting\n',
+  }, { rows: `${upgradedRow}\n` });
+  const siblingRows = dataRows(sibling.tracker);
+  if (siblingRows.length === 2) {
+    pass('sibling-req guard still fires after a merge upgrade (req number survived in Notes)');
+  } else {
+    fail(`sibling req folded into the upgraded row — req number was lost: ${siblingRows.join(' // ')}`);
+  }
+} catch (e) {
+  fail(`merge-tracker Notes-preservation tests crashed: ${e.message}`);
 }

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -343,3 +343,122 @@ try {
 } catch (e) {
   fail(`merge-tracker separator-row tests crashed: ${e.message}`);
 }
+
+// ── Non-Latin company names must not collapse into one row ──────────────────
+// normalizeCompany() strips everything outside [a-z0-9], so every CJK /
+// Cyrillic / Arabic company name normalizes to '' and all of them compared
+// equal. With same-run rows registered in existingApps, tier-3 (empty company
+// key + fuzzy role) folded DIFFERENT companies posting the same role in one
+// batch into a single row. companiesMatch() falls back to raw equality when
+// the normalized key is empty.
+console.log('\nmerge-tracker.mjs — non-Latin company names stay distinct');
+try {
+  const twoCompanies = runMergeDetailed({
+    '030-zeta.tsv': '30\t2026-02-01\t株式会社ゼータ\tデータエンジニア\tEvaluated\t4.2/5\t❌\t[30](reports/030-zeta-2026-02-01.md)\tzeta eval\n',
+    '031-omega.tsv': '31\t2026-02-02\t合同会社オメガ\tデータエンジニア\tEvaluated\t4.6/5\t❌\t[31](reports/031-omega-2026-02-02.md)\tomega eval\n',
+  });
+  const twoCompanyRows = dataRows(twoCompanies.tracker);
+  if (twoCompanyRows.length === 2 && /株式会社ゼータ/.test(twoCompanies.tracker) && /合同会社オメガ/.test(twoCompanies.tracker)) {
+    pass('two distinct Japanese companies with the same role produce two rows');
+  } else {
+    fail(`non-Latin companies collapsed: ${twoCompanyRows.length} row(s): ${twoCompanyRows.join(' // ')}`);
+  }
+
+  // Control: dedup must still fire for the SAME non-Latin company — raw
+  // equality replaces the empty key, it does not disable duplicate detection.
+  const sameCompany = runMergeDetailed({
+    '040-zeta.tsv': '40\t2026-02-01\t株式会社ゼータ\tデータエンジニア\tEvaluated\t4.2/5\t❌\t[40](reports/040-zeta-2026-02-01.md)\tfirst pass\n',
+    '041-zeta.tsv': '41\t2026-02-02\t株式会社ゼータ\tデータエンジニア\tEvaluated\t4.6/5\t❌\t[41](reports/041-zeta-2026-02-02.md)\tsecond pass\n',
+  });
+  const sameCompanyRows = dataRows(sameCompany.tracker);
+  if (sameCompanyRows.length === 1 && /4\.6\/5/.test(sameCompanyRows[0])) {
+    pass('the same Japanese company twice still dedups to one row (higher score kept)');
+  } else {
+    fail(`same non-Latin company did not dedup: ${sameCompanyRows.join(' // ')}`);
+  }
+} catch (e) {
+  fail(`merge-tracker non-Latin company tests crashed: ${e.message}`);
+}
+
+// ── mergeNotes: a new note that is a substring of an old clause must land ───
+// The repeat check was a raw prev.includes(incoming): existing
+// "Applied 2026-01-15. Remote OK" swallowed an incoming "Remote" outright.
+// Repeats are now judged per '. '-separated clause.
+console.log('\nmerge-tracker.mjs — substring notes survive a score upgrade');
+try {
+  const REMOTE_ROW =
+    '| 1 | 2026-01-01 | Acme | Staff Data Platform Engineer | 4.0/5 | Applied | ❌ | ' +
+    '[1](reports/001-acme-2026-01-01.md) | Applied 2026-01-15. Remote OK |\n';
+  const substringNote = runMergeDetailed({
+    '001-acme.tsv': '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-01-01.md)\tRemote\n',
+  }, { rows: REMOTE_ROW });
+  const substringRow = dataRows(substringNote.tracker)[0] || '';
+  if (/Remote OK/.test(substringRow) && /\(4→4\.7\): Remote\s*\|/.test(substringRow)) {
+    pass('an incoming note that is a substring of an existing clause is still appended');
+  } else {
+    fail(`substring note was dropped: ${substringRow}`);
+  }
+
+  // Control: an incoming note IDENTICAL to an existing clause is a genuine
+  // repeat — the marker is recorded, the text is not duplicated.
+  const repeatNote = runMergeDetailed({
+    '001-acme.tsv': '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-01-01.md)\tRemote OK\n',
+  }, { rows: REMOTE_ROW });
+  const repeatRow = dataRows(repeatNote.tracker)[0] || '';
+  const remoteOkCount = (repeatRow.match(/Remote OK/g) || []).length;
+  if (remoteOkCount === 1 && /Re-eval 2026-03-01/.test(repeatRow)) {
+    pass('an incoming note identical to an existing clause is not duplicated');
+  } else {
+    fail(`clause-level repeat detection failed (${remoteOkCount} copies): ${repeatRow}`);
+  }
+} catch (e) {
+  fail(`merge-tracker substring-note tests crashed: ${e.message}`);
+}
+
+// ── Same-run num collisions: distinct roles must not fold into one row ──────
+// Two TSVs that both claimed the same reserved num for DIFFERENT roles at one
+// company are a reservation race, not a re-evaluation. Tier-2 (num + company)
+// has no role check, so with same-run rows in existingApps the second TSV
+// became an update candidate for the first — one row, first title, second
+// score. Main renumbered and kept both (#1704/#1733); same-run tier-2 now
+// requires a fuzzy role match too.
+console.log('\nmerge-tracker.mjs — same-run num collision with distinct roles');
+try {
+  const collision = runMergeDetailed({
+    '050-acme-a.tsv': '5\t2026-02-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.2/5\t❌\t[5](reports/005-acme-2026-02-01.md)\tplatform\n',
+    '051-acme-b.tsv': '5\t2026-02-02\tAcme\tDirector of Product Marketing\tEvaluated\t4.6/5\t❌\t[6](reports/006-acme-2026-02-02.md)\tmarketing\n',
+  });
+  const collisionRows = dataRows(collision.tracker);
+  if (collisionRows.length === 2
+      && /Staff Data Platform Engineer/.test(collision.tracker)
+      && /Director of Product Marketing/.test(collision.tracker)) {
+    pass('two same-run TSVs sharing one num but distinct roles stay two rows');
+  } else {
+    fail(`same-run num collision folded distinct roles: ${collisionRows.join(' // ')}`);
+  }
+  // The renumber itself is the observable contract (#1704/#1733): the first
+  // TSV keeps the contested num, the second gets the next free one. (The
+  // accompanying "already used" warning goes to stderr, which the success-path
+  // capture here does not see.)
+  const marketingRow = collisionRows.find(r => /Director of Product Marketing/.test(r)) || '';
+  if (/^\|\s*6\s*\|/.test(marketingRow) && collisionRows.some(r => /^\|\s*5\s*\|/.test(r))) {
+    pass('the losing TSV of a same-run num collision is renumbered to the next free id');
+  } else {
+    fail(`same-run num collision was not renumbered: ${collisionRows.join(' // ')}`);
+  }
+
+  // Control: the same num AND the same role in one run is still one evaluation
+  // re-emitted — it must keep deduping to a single row.
+  const sameRoleCollision = runMergeDetailed({
+    '060-acme-a.tsv': '7\t2026-02-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.2/5\t❌\t[7](reports/007-acme-2026-02-01.md)\tfirst pass\n',
+    '061-acme-b.tsv': '7\t2026-02-02\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.6/5\t❌\t[8](reports/008-acme-2026-02-02.md)\tsecond pass\n',
+  });
+  const sameRoleRows = dataRows(sameRoleCollision.tracker);
+  if (sameRoleRows.length === 1 && /4\.6\/5/.test(sameRoleRows[0])) {
+    pass('the same num with the same role in one run still dedups to one row');
+  } else {
+    fail(`same-run same-role collision mishandled: ${sameRoleRows.join(' // ')}`);
+  }
+} catch (e) {
+  fail(`merge-tracker same-run num collision tests crashed: ${e.message}`);
+}

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -158,3 +158,43 @@ try {
 } catch (e) {
   fail(`merge-tracker repeated-update tests crashed: ${e.message}`);
 }
+
+// ── #2392 gap 3: no dedup between rows added in the same run ────────────────
+// All three dedup tiers search `existingApps`, which only ever held rows read
+// from the file. Rows appended during the run went to `newLines` and were
+// invisible, so two TSVs for one company+role in a single batch both appended.
+console.log('\nmerge-tracker.mjs — intra-run dedup (#2392)');
+try {
+  const sameRole = runMergeDetailed({
+    '010-acme.tsv': '10\t2026-02-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.2/5\t❌\t[10](reports/010-acme-2026-02-01.md)\tfirst pass\n',
+    '011-acme.tsv': '11\t2026-02-02\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.6/5\t❌\t[11](reports/011-acme-2026-02-02.md)\tsecond pass\n',
+  });
+  const sameRows = dataRows(sameRole.tracker);
+  if (sameRows.length === 1) {
+    pass('two TSVs for one company+role in one run produce a single tracker row');
+  } else {
+    fail(`intra-run duplicate rows appended: ${sameRows.length} rows: ${sameRows.join(' // ')}`);
+  }
+  // Dedup is only worth having if the better evaluation is the one kept — a
+  // dedup that drops the higher score is the same data loss by another route.
+  if (sameRows.length === 1 && /4\.6\/5/.test(sameRows[0])) {
+    pass('the higher-scored of two same-run evaluations wins the merged row');
+  } else {
+    fail(`same-run dedup kept the wrong evaluation: ${sameRows.join(' // ')}`);
+  }
+
+  // Control: dedup must not become greedy. Distinct roles at the same company
+  // arriving in one run are two real applications and must both survive.
+  const distinct = runMergeDetailed({
+    '020-acme.tsv': '20\t2026-02-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.2/5\t❌\t[20](reports/020-acme-2026-02-01.md)\tplatform\n',
+    '021-acme.tsv': '21\t2026-02-02\tAcme\tDirector of Product Marketing\tEvaluated\t4.6/5\t❌\t[21](reports/021-acme-2026-02-02.md)\tmarketing\n',
+  });
+  const distinctRows = dataRows(distinct.tracker);
+  if (distinctRows.length === 2) {
+    pass('distinct roles at one company in the same run stay separate rows');
+  } else {
+    fail(`same-run dedup collapsed two distinct roles: ${distinctRows.join(' // ')}`);
+  }
+} catch (e) {
+  fail(`merge-tracker intra-run dedup tests crashed: ${e.message}`);
+}


### PR DESCRIPTION
Closes #2392
Closes #2394

These are four ways `merge-tracker.mjs` could throw an evaluation away and still report success. They share a branch because all four live in the same merge loop and the fixes interact: refreshing the cached row (gap 1) changes what the new intra-run dedup (gap 3) can find, and both feed the row-lookup helper. Reviewing them separately would mean reviewing the same forty lines three times. There is one commit per concern.

None of these losses are recoverable. `data/applications.md` is gitignored, so there is no VCS copy, and merge-tracker writes no `.bak`.

## Gap 1: a second update to the same row was dropped (commit 1)

`appLines.indexOf(duplicate.raw)` looked the row up by the snapshot taken when the tracker was parsed. Nothing refreshed it after `appLines[lineIdx] = updatedLine`, so the next TSV matching that row searched for a line that no longer existed, got `-1`, and fell through an `if (lineIdx >= 0)` block with no else. Nothing incremented a counter or printed a warning, and the TSV was archived into `merged/` anyway. The stale snapshot also fed the score comparison, so with several re-evaluations of one row the survivor was decided by TSV filename sort order rather than by score.

Before, tracker row #1 at 4.0 plus TSVs at 4.2 and 4.7:

```
🔄 Update: #1 Acme — Staff Data Platform Engineer (4→4.2)
🔄 Update: #1 Acme — Staff Data Platform Engineer (4→4.7)
📊 Summary: +0 added, 🔄1 updated, ⏭️0 skipped
| 1 | 2026-02-01 | Acme | Staff Data Platform Engineer | 4.2/5 | ...
```

Both updates were announced, only one was counted, and the 4.7 evaluation no longer exists anywhere.

The fix re-parses the written line back into the cached row, which is what `syncPdfFlags` has always done. The now unreachable "row not found" branch is no longer silent: it keeps the TSV out of `merged/`, reports it in the summary, and exits non-zero.

## Gap 3: no dedup between rows added in the same run (commit 2)

All three dedup tiers search `existingApps`, which was only ever populated from rows read out of the file. A row appended during the run went to `newLines` and was invisible, so two TSVs for the same company and role in one batch both appended. That is the case `CLAUDE.md`'s Pipeline Integrity rule forbids, and it happens on an ordinary path: two evaluations of one role in a single batch.

Before, an empty tracker plus two Acme / Staff Data Platform Engineer TSVs gave `+2 added` and two rows.

New rows now go into `existingApps` as they are created. Updating a row created earlier in the same run needs the line lookup to search the queued rows too, so `appLines.indexOf()` moved into a `replaceTrackerLine()` helper that checks `appLines` first, then `newLines`.

## Gap 2: Notes overwritten on a score upgrade (commit 3)

The update path rebuilt Notes as `Re-eval {date} ({old}->{new}). {new notes}` and discarded the existing cell. That cell carries the `Applied YYYY-MM-DD` marker `followup-cadence.mjs` prefers over the Date column, the req number this same script reads back through `extractReqNumber()` for the #1524 sibling-req guard, contacts, and anything the user wrote with `set-status --note`.

**Format choice for the reviewer.** Preserving the old notes is not optional, but where the re-eval marker goes is a judgement call, so please push back if you want it the other way. I kept the existing text verbatim and first, then appended the marker and the new notes:

```
Applied 2026-01-15. Req R_1488728. recruiter jane@acme.example. Re-eval 2026-03-01 (4→4.7): re-scored after JD refresh
```

The reason for that order rather than leading with the marker: `parseAppliedDate()` and `extractReqNumber()` both return their *first* match, so leading with the established text keeps a row's apply date and req number stable across re-evaluations instead of letting each new evaluation's text take over. Two trade-offs come with it. Notes grows by one clause per re-evaluation, and the join trims a single trailing period off the existing text so it does not read as `..`. Re-running an identical evaluation does not repeat its own text, only the marker.

## #2394: no separator row dropped everything and reported success (commit 4)

`insertIdx` stayed `-1` when `SEPARATOR_ROW_RE` matched nothing, the splice was skipped with no else, and the run went on to write the file, archive every TSV and print `+N added`. Against a tracker holding only `# Applications Tracker`, one addition produced `+1 added`, an unchanged tracker, and the evaluation living only in `merged/`.

It now aborts before writing anything, so the tracker and the additions directory are left as they were and the run replays cleanly once the header is repaired. The error names the missing separator, prints the expected header, lists the rows that were not merged, and exits non-zero.

## Tests

`tests/merge-tracker.test.mjs` grows a `runMergeDetailed` helper (seeded tracker rows, custom header, process output, exit code, and which TSVs were archived versus left pending) and 14 assertions across the four defects. Where it matters the assertion is on the consequence rather than on the text: gap 2 imports `analyzeFromContent` from `followup-cadence.mjs` and checks the merged row still reports `appliedDate: 2026-01-15` with `appDateSource: notes`, then runs a second merge to confirm the sibling-req guard still fires.

Each test was checked against the unfixed code by reverting its own fix and re-running:

| Defect | Mutation | Result |
|---|---|---|
| Gap 1 | `git stash` of `merge-tracker.mjs` | 3 of 3 fail. Row ends at 4.2 not 4.7; summary reads `🔄1 updated`; the downgrade case is announced as an update and reports `⏭️0 skipped` |
| Gap 3 | `git stash` of `merge-tracker.mjs`, gap 1 fix in HEAD | 2 of 2 fail with two identical Acme rows. The third assertion in that block is a control: distinct roles must stay separate, and it passes either way by design |
| Gap 2 | `mergeNotes(...)` call swapped back to the old template literal | 3 of 3 fail. Notes reduced to the re-eval marker; cadence falls back to `appDateSource: evaluation-date-fallback`; the sibling req folds into the row |
| #2394 | `git stash` of `merge-tracker.mjs` | 3 of 3 fail with `exit 0`, `+1 added`, and the TSV archived into `merged/`. The fourth assertion is a control: the same TSV must still merge against a healthy tracker |

## Validation

`node test-all.mjs`: 2761 passed, 1 failed, 2 warnings. The single failure is the pre-existing `analyze() appDateSource end-to-end check crashed: EPERM: operation not permitted, symlink`, a Windows symlink permission issue in my environment that is unrelated to this change.


## Behavior changes

Two contract changes callers should know about.

**merge-tracker can now exit 1.** The separator-row abort and the "addition not applied" path both exit non-zero, where the script previously always exited 0 after printing a summary. That is caller-visible: `batch/batch-runner.sh` runs under `set -euo pipefail` and calls merge-tracker unguarded, so a damaged tracker header now hard-stops the batch at the merge step instead of letting it continue past a merge that silently dropped rows. Stopping is the point (the alternative was archiving evaluations that never landed), but any wrapper that relied on merge-tracker never failing needs a guard if it wants to carry on.

**Same-run num collisions (review round 2).** Registering same-run rows in `existingApps` had a side effect: two TSVs that both claimed one reserved num at the same company for different roles hit the tier-2 num+company match, and the second folded into the first row (first title, second score). On main both rows survived through the #1704/#1733 renumbering path. Tier-2 now also requires a fuzzy role match before accepting a same-run row as an update candidate, so a reservation race renumbers the second row and keeps both evaluations, matching main. For rows already on disk, num keeps its meaning as the tracker row id and nothing changes there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved company matching across Unicode and non-Latin names.
  * Enhanced duplicate detection for existing and same-run entries.
  * Preserved notes and follow-up dates while merging updates.
  * Prevented incomplete tracker files from being written or archived.
  * Improved failed-addition reporting and retry handling.

* **Tests**
  * Added coverage for score updates, note merging, duplicate detection, missing separators, replay scenarios, and related requirement checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
