### PR TITLE
refactor(set-status): extract shared candidate resolution

### DIFF
--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -1017,5 +1017,109 @@ const TRACKER_REPORT_MISMATCH = `# Applications Tracker
   });
 }
 
+// ── shared candidate resolution (#2348) ──────────────────────────
+//
+// The three selector paths delegate their match → narrow → refuse-to-guess
+// flow to resolveCandidates(). These pin the properties that must survive any
+// future edit to that helper: every path fails CLOSED on 2+ survivors (the
+// #1704 property, previously enforced in three separate copies), and --role
+// narrowing works from every path rather than only the two that had tests.
+{
+  // Two rows link the SAME report — reachable when a re-evaluation is filed
+  // against an existing report, or a report link is copied between rows.
+  const TRACKER_DUP_REPORT = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-01 | Acme | Backend Engineer | 4.2/5 | Evaluated | ✅ | [9](../reports/009-acme-2026-06-01.md) | — |
+| 2 | 2026-06-02 | Globex | Data Engineer | 4.0/5 | Evaluated | ✅ | [9](../reports/009-globex-2026-06-02.md) | — |
+`;
+
+  const withDupReport = fn => {
+    const sandbox = makeSandbox(TRACKER_DUP_REPORT);
+    try { fn(sandbox); } finally { rmSync(sandbox.dir, { recursive: true, force: true }); }
+  };
+
+  // Previously untested: the --report path had no 2+ coverage at all, so a
+  // regression to first-match-wins there would have gone unnoticed.
+  withDupReport(sandbox => {
+    const before = readTracker(sandbox);
+    const r = runSetStatus(['--report', '9', 'Applied', '--json'], sandbox);
+    let parsed = null;
+    try { parsed = JSON.parse(r.stdout); } catch {}
+    if (r.code === 3 && parsed?.code === 'ambiguous' && parsed.candidates?.length === 2
+        && readTracker(sandbox) === before) {
+      pass('#2348: --report fails closed on 2+ linking rows, with candidates');
+    } else {
+      fail(`#2348: --report dup → code=${r.code} json=${JSON.stringify(parsed)}`);
+    }
+  });
+
+  // --role narrowing must serve the --report path too, not just the numeric
+  // and company paths that already had coverage.
+  withDupReport(sandbox => {
+    const r = runSetStatus(['--report', '9', 'Applied', '--role', 'Data Engineer', '--json'], sandbox);
+    let parsed = null;
+    try { parsed = JSON.parse(r.stdout); } catch {}
+    if (r.code === 0 && parsed?.company === 'Globex') {
+      pass('#2348: --role narrows a --report match to the intended row');
+    } else {
+      fail(`#2348: --report + --role → code=${r.code} company=${parsed?.company}`);
+    }
+  });
+
+  // A --role that matches NEITHER candidate must not silently pick one; the
+  // helper falls through with the original list so both stay visible.
+  withDupReport(sandbox => {
+    const before = readTracker(sandbox);
+    const r = runSetStatus(['--report', '9', 'Applied', '--role', 'Site Reliability Engineer', '--json'], sandbox);
+    let parsed = null;
+    try { parsed = JSON.parse(r.stdout); } catch {}
+    if (r.code === 3 && parsed?.candidates?.length === 2 && readTracker(sandbox) === before) {
+      pass('#2348: a --role matching neither candidate still fails closed with both listed');
+    } else {
+      fail(`#2348: --report + unmatched --role → code=${r.code} json=${JSON.stringify(parsed)}`);
+    }
+  });
+
+  // Parity: the fail-closed contract is now enforced in ONE place, so assert
+  // it holds identically from every entry point. This is the test that would
+  // catch a future edit to resolveCandidates() that regressed one path.
+  {
+    const TRACKER_ALL_AMBIGUOUS = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 7 | 2026-06-01 | Initech | Backend Engineer | 4.2/5 | Evaluated | ✅ | [3](../reports/003-initech-2026-06-01.md) | — |
+| 7 | 2026-06-02 | Initech | Data Engineer | 4.0/5 | Evaluated | ✅ | [3](../reports/003-initech-2026-06-02.md) | — |
+`;
+    const paths = [
+      ['bare numeric', ['7', 'Applied', '--json']],
+      ['--row', ['--row', '7', 'Applied', '--json']],
+      ['--report', ['--report', '3', 'Applied', '--json']],
+      ['company', ['Initech', 'Applied', '--json']],
+    ];
+    const failures = [];
+    for (const [label, args] of paths) {
+      const sandbox = makeSandbox(TRACKER_ALL_AMBIGUOUS);
+      try {
+        const before = readTracker(sandbox);
+        const r = runSetStatus(args, sandbox);
+        let parsed = null;
+        try { parsed = JSON.parse(r.stdout); } catch {}
+        const ok = r.code === 3 && parsed?.candidates?.length === 2 && readTracker(sandbox) === before;
+        if (!ok) failures.push(`${label} (code=${r.code}, candidates=${parsed?.candidates?.length})`);
+      } finally {
+        rmSync(sandbox.dir, { recursive: true, force: true });
+      }
+    }
+    if (failures.length === 0) {
+      pass('#2348: all four selector paths fail closed on 2+ candidates, none written');
+    } else {
+      fail(`#2348: paths that did not fail closed: ${failures.join('; ')}`);
+    }
+  }
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -221,6 +221,49 @@ if (!existsSync(APPS_FILE)) {
 }
 
 /**
+ * Reduce a selector's candidate list to exactly one row, or exit.
+ *
+ * Every selector path shares one shape: match, optionally narrow by --role,
+ * refuse to guess between survivors, return the unique row. Only the predicate
+ * and the two messages differ.
+ *
+ * Centralising it matters more than the duplication it removes. **Failing
+ * closed on 2+ candidates is the #1704 fix** — a stale tracker # reused across
+ * two rows makes "the first match" a silent coin flip on which company gets
+ * edited. While that behaviour lived in three copies, a future change that
+ * reintroduced first-match-wins in one branch would have been invisible in the
+ * other two. There is now one place to get it wrong, and one place to test.
+ *
+ * Note --role only ever *narrows* here; it never validates a lone match. That
+ * is deliberate and load-bearing: the #2009 check downstream compares the
+ * resolved row against --role precisely because a selector matching exactly
+ * one row never reaches the narrowing branch. Do not "fix" that by validating
+ * here — the two checks answer different questions.
+ *
+ * @param {object[]} matches - Rows matching the selector, before --role narrowing.
+ * @param {object} messages - Selector-specific failure text.
+ * @param {string} messages.notFound - Message when nothing matched.
+ * @param {(count: number, listing: string) => string} messages.ambiguous - Message when 2+ survive.
+ * @returns {object} The single matched row. Exits the process on 0 or 2+ matches.
+ */
+function resolveCandidates(matches, { notFound, ambiguous }) {
+  if (matches.length === 0) {
+    failWith(EXIT_NOT_FOUND, 'not-found', notFound);
+  }
+  if (matches.length > 1 && flags.role) {
+    const narrowed = matches.filter(r => roleFuzzyMatch(r.role, flags.role));
+    if (narrowed.length === 1) return narrowed[0];
+    // Fall through with the original list so the candidates stay visible.
+  }
+  if (matches.length > 1) {
+    const candidates = matches.map(r => ({ num: r.num, company: r.company, role: r.role }));
+    const listing = candidates.map(c => `#${c.num}\t${c.company}\t${c.role}`).join('\n');
+    failWith(EXIT_AMBIGUOUS, 'ambiguous', ambiguous(matches.length, listing), { candidates });
+  }
+  return matches[0];
+}
+
+/**
  * Find the tracker row matching the CLI selector.
  *
  * @param {object[]} rows - Parsed data rows (parseTrackerRow output + lineIdx).
@@ -231,74 +274,45 @@ function resolveRow(rows) {
   // caller reading a report filename actually has in hand.
   if (flags.report !== null) {
     const num = parseInt(flags.report, 10);
-    const matches = rows.filter(r => extractTrackerReportNumbers(r.report).includes(num));
-    if (matches.length === 0) {
-      failWith(EXIT_NOT_FOUND, 'not-found',
-        `No tracker row links report #${num}. (Report IDs and tracker row IDs differ — ` +
-        'use --row N to select by tracker #.)');
-    }
-    if (matches.length > 1 && flags.role) {
-      const narrowed = matches.filter(r => roleFuzzyMatch(r.role, flags.role));
-      if (narrowed.length === 1) return narrowed[0];
-    }
-    if (matches.length > 1) {
-      const candidates = matches.map(r => ({ num: r.num, company: r.company, role: r.role }));
-      const listing = candidates.map(c => `#${c.num}\t${c.company}\t${c.role}`).join('\n');
-      failWith(EXIT_AMBIGUOUS, 'ambiguous',
-        `Report #${num} is linked by ${matches.length} tracker rows — pass --role to disambiguate:\n${listing}`,
-        { candidates });
-    }
-    return matches[0];
+    return resolveCandidates(
+      rows.filter(r => extractTrackerReportNumbers(r.report).includes(num)),
+      {
+        notFound: `No tracker row links report #${num}. (Report IDs and tracker row IDs differ — ` +
+          'use --row N to select by tracker #.)',
+        ambiguous: (count, listing) =>
+          `Report #${num} is linked by ${count} tracker rows — pass --role to disambiguate:\n${listing}`,
+      },
+    );
   }
 
   // --row N and a bare numeric selector both match the # column; they differ
   // only in whether the mismatch guard below treats the number as ambiguous.
   if (flags.row !== null || isBareNumericSelector) {
     const num = parseInt(flags.row !== null ? flags.row : selector, 10);
-    let matches = rows.filter(r => r.num === num);
-    if (matches.length === 0) {
-      failWith(EXIT_NOT_FOUND, 'not-found', `No tracker row with #${num}`);
-    }
-    if (matches.length > 1 && flags.role) {
-      const narrowed = matches.filter(r => roleFuzzyMatch(r.role, flags.role));
-      if (narrowed.length === 1) return narrowed[0];
-      // Fall through with the original list so the candidates stay visible.
-    }
-    if (matches.length > 1) {
-      // A bare report number should never match more than one row — this is
-      // exactly the failure mode from #1704: a stale tracker # reused across
-      // 2+ rows means "the first match" is a silent coin flip on which
-      // company gets edited. Refuse to guess; require --role or the company
-      // selector instead.
-      const candidates = matches.map(r => ({ num: r.num, company: r.company, role: r.role }));
-      const listing = candidates.map(c => `#${c.num}\t${c.company}\t${c.role}`).join('\n');
-      failWith(EXIT_AMBIGUOUS, 'ambiguous',
-        `#${num} is a duplicate tracker number shared by ${matches.length} rows (see #1704) — pass --role to disambiguate, or use the company name instead:\n${listing}`,
-        { candidates });
-    }
-    return matches[0];
+    return resolveCandidates(
+      rows.filter(r => r.num === num),
+      {
+        notFound: `No tracker row with #${num}`,
+        // #1704: a stale tracker # reused across 2+ rows means "the first
+        // match" is a silent coin flip on which company gets edited. Refuse to
+        // guess; require --role or the company selector instead.
+        ambiguous: (count, listing) =>
+          `#${num} is a duplicate tracker number shared by ${count} rows (see #1704) — ` +
+          `pass --role to disambiguate, or use the company name instead:\n${listing}`,
+      },
+    );
   }
 
   const key = normalizeCompany(selector);
   if (!key) failUsage(`Selector "${selector}" is empty after normalization`);
-  let matches = rows.filter(r => normalizeCompany(r.company) === key);
-
-  if (matches.length === 0) {
-    failWith(EXIT_NOT_FOUND, 'not-found', `No tracker row with company matching "${selector}"`);
-  }
-  if (matches.length > 1 && flags.role) {
-    const narrowed = matches.filter(r => roleFuzzyMatch(r.role, flags.role));
-    if (narrowed.length === 1) return narrowed[0];
-    // Fall through with the original list so the candidates stay visible.
-  }
-  if (matches.length > 1) {
-    const candidates = matches.map(r => ({ num: r.num, company: r.company, role: r.role }));
-    const listing = candidates.map(c => `#${c.num}\t${c.company}\t${c.role}`).join('\n');
-    failWith(EXIT_AMBIGUOUS, 'ambiguous',
-      `Company "${selector}" matches ${matches.length} rows — pass the # or narrow with --role:\n${listing}`,
-      { candidates });
-  }
-  return matches[0];
+  return resolveCandidates(
+    rows.filter(r => normalizeCompany(r.company) === key),
+    {
+      notFound: `No tracker row with company matching "${selector}"`,
+      ambiguous: (count, listing) =>
+        `Company "${selector}" matches ${count} rows — pass the # or narrow with --role:\n${listing}`,
+    },
+  );
 }
 
 // ── locked read-modify-write ─────────────────────────────────────


### PR DESCRIPTION
Closes #2348

## Summary

The `--report`, `--row`/bare-numeric and company selector paths each carried their own copy of the same flow: match → optionally narrow by `--role` → refuse to guess between survivors → return the unique row. Only the predicate and the two messages ever differed. All four entry points now delegate to one `resolveCandidates(matches, { notFound, ambiguous })`.

## Why this is worth doing

Centralising it matters more than the duplication it removes.

**Failing closed on 2+ candidates *is* the #1704 fix.** A stale tracker `#` reused across two rows makes "the first match" a silent coin flip on which company gets edited. While that behaviour lived in three copies, a change that reintroduced first-match-wins in one branch would have been invisible in the other two. There is now one place to get it wrong, and one place to test it.

## Behaviour is unchanged

Every message, exit code and candidate payload is byte-identical. **The existing tests pass unedited** — that was the acceptance bar I held myself to: if a behaviour-preserving refactor requires touching the tests that pin the behaviour, it isn't behaviour-preserving.

## #2009 is deliberately untouched

`--role` only *narrows* inside the helper and never validates a lone match. That is load-bearing, not an oversight: the post-resolution role-mismatch check exists precisely because a selector matching exactly one row never reaches the narrowing branch. Validating `--role` inside `resolveCandidates()` would look like a tidy-up and would quietly duplicate — then eventually replace — the #2009 guard.

The helper's doc comment says so explicitly, because "validate `--role` here too" is the obvious wrong fix for whoever reads this next.

## Tests

Four new cases, pinning what the helper now owns centrally:

- **`--report` fails closed on 2+ linking rows.** Previously untested — that path had no 2+ coverage at all, so a regression there would have gone unnoticed.
- **`--role` narrows from the `--report` path**, not just the two paths that already had coverage.
- **A `--role` matching neither candidate still fails closed** with both candidates listed, rather than silently picking one.
- **Parity:** all four entry points (bare numeric, `--row`, `--report`, company) fail closed on 2+ candidates with a candidate list, and none of them writes. This is the test that catches a future edit to `resolveCandidates()` regressing a single path.

Fixtures are synthetic (Acme / Globex / Initech).

## Verification

- `set-status-tests.mjs`: **75 passed, 0 failed** — the 71 pre-existing cases unmodified, plus the 4 above.
- **Negative control:** disabling the fail-closed branch in `resolveCandidates()` produces **8 failures**, including the parity test naming all four paths by name. Restored and hash-verified byte-identical to the commit before running anything else. A refactor test that cannot fail proves nothing, so this seemed worth doing explicitly.
- `node test-all.mjs`: **2747 passed, 1 failed.** The single failure is `analyze() appDateSource end-to-end` with `EPERM: symlink`, a Windows symlink-permission issue in the harness; an unmodified `origin/main` in the same environment produces the identical result.
- No documentation change is owed: `docs/SCRIPTS.md` documents `set-status` behaviour, not `resolveRow()` internals, and behaviour is unchanged.

## Acceptance criteria from #2348

- [x] The three selector branches delegate their common candidate-resolution work to one shared helper — four, counting bare-numeric and `--row` separately.
- [x] Existing #1704 duplicate-tracker-number behaviour remains covered and passes.
- [x] Existing #2009 unique-target `--role` mismatch protection remains covered and passes.
- [x] `--report` matching, role narrowing, not-found handling and ambiguity reporting retain their current behaviour.
- [x] Focused regression tests cover the preserved safeguards and the refactored resolution paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved status selection across numeric, row, report, and company selectors.
  - Prevented changes when a selector matches multiple candidates.
  - Added consistent no-write behavior for ambiguous selections.
  - Improved role-based narrowing for report selections while preserving candidates when no role matches.

- **Tests**
  - Added regression coverage for candidate resolution and ambiguity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->