### PR TITLE
fix(weekly-digest): `--from=…` was silently ignored, digesting the wrong week

### DIFF
--- a/weekly-digest.mjs
+++ b/weekly-digest.mjs
@@ -412,6 +412,16 @@ async function runSelfTest() {
   const sun = computeDefaultRange(new Date('2026-07-26T23:00:00Z'));
   check(sun.from === '2026-07-20' && sun.to === '2026-07-26', 'computeDefaultRange handles Sunday itself as the range end');
 
+  // flagValue: both CLI spellings must reach the same value. The `=` form used
+  // to be invisible to indexOf(), so `--from=2020-01-01` silently produced the
+  // CURRENT week's digest instead of the requested one.
+  check(flagValue(['--from', '2020-01-01'], '--from') === '2020-01-01', 'flagValue reads the space-separated form');
+  check(flagValue(['--from=2020-01-01'], '--from') === '2020-01-01', 'flagValue reads the --flag=value form');
+  check(flagValue(['--summary'], '--from') === undefined, 'flagValue returns undefined for an absent flag');
+  check(flagValue(['--from='], '--from') === '', 'flagValue reports an explicitly empty value as empty, not absent');
+  check(flagValue(['--dir=/tmp/x=y'], '--dir') === '/tmp/x=y', 'flagValue keeps later "=" characters in the value');
+  check(flagValue(['--to=2020-01-07', '--from=2020-01-01'], '--from') === '2020-01-01', 'flagValue matches its own flag, not a similarly-shaped neighbour');
+
   // parseSessionFile: well-formed session with two competency tags.
   const goodSession = [
     '---',

--- a/weekly-digest.mjs
+++ b/weekly-digest.mjs
@@ -76,6 +76,29 @@ function inRange(dateStr, from, to) {
   return isValidDateStr(dateStr) && dateStr >= from && dateStr <= to;
 }
 
+/**
+ * Value of a value-taking flag, accepting BOTH `--flag value` and `--flag=value`.
+ *
+ * `args.indexOf('--from')` is -1 for the `=` form, so a space-separated-only
+ * lookup silently DISCARDS the bound the caller supplied and the digest then
+ * reports a different week than the one that was asked for — the same silent
+ * discard `computeWeeklyDigest` already refuses to perform for a half-supplied
+ * range. company-history.mjs carries this same note and the same fix.
+ *
+ * @param {string[]} args - argv slice.
+ * @param {string} flag - Flag name including leading dashes, e.g. '--from'.
+ * @returns {string|undefined} The value, or undefined when the flag is absent.
+ */
+export function flagValue(args, flag) {
+  // `--flag=value` first: indexOf() can't see it, so checking it second would
+  // let the space-separated lookup fall through and drop the value.
+  const eq = args.find((a) => a.startsWith(`${flag}=`));
+  if (eq) return eq.slice(flag.length + 1);
+  const idx = args.indexOf(flag);
+  if (idx === -1) return undefined;
+  return args[idx + 1];
+}
+
 // ── Session file parsing ────────────────────────────────────────────
 
 /**
@@ -624,14 +647,16 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   }
 
   const summaryMode = args.includes('--summary');
-  const fromIdx = args.indexOf('--from');
-  const toIdx = args.indexOf('--to');
-  const dirIdx = args.indexOf('--dir');
-  const from = fromIdx !== -1 ? args[fromIdx + 1] : undefined;
-  const to = toIdx !== -1 ? args[toIdx + 1] : undefined;
-  const sessionsDir = dirIdx !== -1 && args[dirIdx + 1] !== undefined ? args[dirIdx + 1] : DEFAULT_SESSIONS_DIR;
+  const from = flagValue(args, '--from');
+  const to = flagValue(args, '--to');
+  const dirValue = flagValue(args, '--dir');
+  const sessionsDir = dirValue ? dirValue : DEFAULT_SESSIONS_DIR;
 
-  if ((from && !isValidDateStr(from)) || (to && !isValidDateStr(to))) {
+  // `!== undefined`, not truthiness: an explicitly EMPTY bound (`--from=`) is a
+  // malformed date the caller typed, not an absent flag. Treating it as absent
+  // let '' through as a range bound, and `dateStr >= ''` is true for every
+  // session — silently widening the window instead of reporting the mistake.
+  if ((from !== undefined && !isValidDateStr(from)) || (to !== undefined && !isValidDateStr(to))) {
     console.error('  Invalid --from/--to date — expected YYYY-MM-DD');
     process.exit(1);
   }


### PR DESCRIPTION
Closes #2401.

`weekly-digest.mjs` read its value-taking flags with `args.indexOf()` alone, which is `-1` for the `--from=2020-01-01` spelling. The value was silently discarded, the flag treated as absent, and — because dropping *both* bounds lands in the "neither supplied" branch — the tool emitted **the current week's digest** while the caller asked for a different one:

```console
$ node weekly-digest.mjs --from 2020-01-01 --to 2020-01-07   # space form — correct
      "from": "2020-01-01",  "to": "2020-01-07"

$ node weekly-digest.mjs --from=2020-01-01 --to=2020-01-07   # BEFORE — silently wrong
      "from": "2026-07-27",  "to": "2026-08-02"
```

No error, no warning; the output is well-formed, just for the wrong period. `--dir=` was affected identically, which also made the documented test-isolation flag unreliable in that spelling.

This isn't a generic arg-parsing nit: `computeWeeklyDigest` already refuses exactly this failure mode for a half-supplied range, because it previously *"silently fell back to the default range, which quietly discarded the one bound the caller did supply."* The `=` form discarded **both** bounds and reached that same silent fallback anyway — the invariant was bypassed by a spelling.

## Fix

A pure exported `flagValue(args, flag)` accepting both spellings, checking the `=` form **first** (`indexOf` can't see it, so checking it second re-introduces the drop). This mirrors the fix — and the warning comment — `company-history.mjs` already carries:

> `--flag=value` form first: `args.indexOf(flag)` is -1 for it, so the space-separated lookup below would silently drop the value otherwise.

Also tightened the date guard from truthiness to `!== undefined`: `--from=` (explicitly empty) previously slipped through as a range bound, and `dateStr >= ''` is true for every session — silently widening the window instead of reporting the typo.

After:

```console
$ node weekly-digest.mjs --from=2020-01-01 --to=2020-01-07
      "from": "2020-01-01",  "to": "2020-01-07"     ✔
$ node weekly-digest.mjs --dir=/does/not/exist
      "sessionsDirFound": false                      ✔
$ node weekly-digest.mjs --from= --to=2020-01-07
  Invalid --from/--to date — expected YYYY-MM-DD     ✔
$ node weekly-digest.mjs                             # default unchanged ✔
```

## Deliberately out of scope

Unknown flags are still silently ignored (`--frm 2020-01-01` → current week). Rejecting them properly means also deciding on a `--help` handler, and I'd rather not bundle a UX decision into a bug fix — happy to follow up if you want it.

## Tests

6 `flagValue` regressions (both spellings, absent flag, explicitly-empty value, a value containing its own `=`, neighbouring-flag guard).

`node weekly-digest.mjs --self-test` → **52 passed, 0 failed**. `node test-all.mjs --quick` → **2754 passed, 0 failed**.

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for both `--flag value` and `--flag=value` command-line formats.
  * Improved handling of date and directory options, including explicitly empty values.

* **Bug Fixes**
  * Added validation for supplied dates to provide more reliable command-line behavior.

* **Tests**
  * Added coverage for supported flag formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->