### PR TITLE
fix(company-funded): the `cuts N%` layoff exclusion never matched

### DIFF
--- a/company-funded.mjs
+++ b/company-funded.mjs
@@ -577,7 +577,14 @@ function hasFundingLanguage(text) {
 function isExcludedFundingItem(item) {
   const text = `${item.title || ''} ${item.text || ''} ${item.categories?.join(' ') || ''}`;
   const exclusions = [
-    /\b(acquires?|acquired|acquisition|merger|spac|ipo|bankruptcy|layoffs?|cuts?\s+\d+%|earnings|quarterly results)\b/i,
+    // (?<!\w)/(?!\w), not \b: the `cuts N%` alternative ends in "%", and a
+    // trailing \b can never match after a non-word character — so that
+    // alternative was dead and layoff headlines that also mention a raise
+    // ("Acme raises $40M Series A, then cuts 30% of staff") were surfaced as
+    // funding leads. Same symbol-edge class as the fix in #2227. For every
+    // other alternative (all of which end in a word character) \b and the
+    // lookarounds are equivalent, so their behaviour is unchanged.
+    /(?<!\w)(acquires?|acquired|acquisition|merger|spac|ipo|bankruptcy|layoffs?|cuts?\s+\d+%|earnings|quarterly results)(?!\w)/i,
     /\b(public offering|registered direct offering|private placement|atm offering|offering of common stock)\b/i,
     /\braises?\s+\$[\d,.]+(?:\.\d+)?\s*(?:billion|million|bn|m|b|k)?\s+fund\b/i,
     /\b(venture fund|vc fund|investment fund|private equity fund|capital fund|fund ii|fund iii|fund iv|new fund)\b/i,

--- a/tests/company-funded.test.mjs
+++ b/tests/company-funded.test.mjs
@@ -149,6 +149,11 @@ try {
     ['prnewswire', 'MegaCorp announces quarterly earnings and financial results'],
     ['prnewswire', 'Foundation awards $5M scholarships and grants'],
     ['techcrunch', 'How to raise seed funding in a difficult market'],
+    // The `cuts N%` exclusion sits in a group that used to close with \b, which
+    // can never match after "%" — so layoff headlines that also mention a raise
+    // were surfaced as funding leads.
+    ['techcrunch', 'Acme raises $40M Series A, then cuts 30% of staff'],
+    ['techcrunch', 'Beta Corp raises $25M seed and cuts 15% of its workforce'],
   ].map(([source, title], idx) => ({
     source,
     title,


### PR DESCRIPTION
Closes #2403.

`isExcludedFundingItem()`'s noise filter contains a `cuts?\s+\d+%` alternative meant to drop layoff coverage:

```js
/\b(acquires?|…|layoffs?|cuts?\s+\d+%|earnings|quarterly results)\b/i
```

It can never match. The alternative ends in `%`, and the group closes with `\b` — a word boundary needs a word/non-word transition, so after a non-word character it always fails. Dead code since it was written.

## Impact

A layoff headline that also mentions a raise clears `hasFundingLanguage()`, escapes the filter, and is surfaced by `company:funded` as a lead — reproduced end-to-end through the public `buildCandidates()` path:

```
BEFORE — layoff-tainted headlines surfaced as funding leads: 3
  Acme       $40M / Series A / confidence "high" / review_company_manually / score 103
  Beta Corp  $25M / seed      / confidence "high" / review_company_manually / score 103
  Gamma Inc
```

A *review-first discovery* feature recommending companies that just announced layoffs, at high confidence, is exactly the noise the exclusion list exists to prevent.

## Fix

`(?<!\w)…(?!\w)` instead of `\b…\b` — the same symbol-edge fix as #2227 (`\bC\+\+\b`, `70\+`). Every other alternative in the group ends in a word character, where `\b` and the lookarounds are **exactly equivalent**, so only the intended case changes:

```
AFTER — layoff-tainted headlines surfaced: 0
       genuine funding still accepted:     [ 'Prime Intellect', 'Cascade' ]
```

## Tests

Two cases added to the existing `negativeItems` block in `tests/company-funded.test.mjs`. Confirmed they **fail without the regex fix** (both accepted, with the full high-confidence candidate payload) and pass with it.

`node tests/company-funded.test.mjs` → 40 assertions passing. `node company-funded.mjs --self-test` → OK. `node test-all.mjs --quick` → green.

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of headlines that mention both fundraising and staff cuts, preventing them from being incorrectly classified as funding announcements.

- **Tests**
  - Added coverage for headlines combining fundraising references with staff reductions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->