### PR TITLE
fix(dashboard): the progress funnel dropped Hired from every stage

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -933,7 +933,9 @@ func ComputeProgressMetrics(apps []model.CareerApplication) model.ProgressMetric
 			}
 		}
 
-		if norm == "offer" {
+		// A hire proves an offer was received and accepted, so it counts here
+		// too — same reasoning as everOffer in stats.mjs's computeFunnel().
+		if norm == "offer" || norm == "hired" {
 			pm.TotalOffers++
 		}
 		if norm != "skip" && norm != "rejected" && norm != "discarded" {
@@ -947,11 +949,16 @@ func ComputeProgressMetrics(apps []model.CareerApplication) model.ProgressMetric
 
 	// Funnel: each stage counts all apps that reached at least that stage.
 	// An app in "interview" has passed through evaluated -> applied -> responded -> interview.
+	// "hired" is terminal success and proves every earlier stage (a landed job
+	// proves the offer, the interviews, the response, and the submission), so it
+	// counts into all four tiers — matching computeFunnel() in stats.mjs, the
+	// canonical funnel definition, whose docstring already describes this exact
+	// math as mirroring this function.
 	total := len(apps)
-	applied := statusCounts["applied"] + statusCounts["responded"] + statusCounts["interview"] + statusCounts["offer"] + statusCounts["rejected"]
-	responded := statusCounts["responded"] + statusCounts["interview"] + statusCounts["offer"]
-	interview := statusCounts["interview"] + statusCounts["offer"]
-	offer := statusCounts["offer"]
+	applied := statusCounts["applied"] + statusCounts["responded"] + statusCounts["interview"] + statusCounts["offer"] + statusCounts["hired"] + statusCounts["rejected"]
+	responded := statusCounts["responded"] + statusCounts["interview"] + statusCounts["offer"] + statusCounts["hired"]
+	interview := statusCounts["interview"] + statusCounts["offer"] + statusCounts["hired"]
+	offer := statusCounts["offer"] + statusCounts["hired"]
 
 	pm.FunnelStages = []model.FunnelStage{
 		{Label: "Evaluated", Count: total, Pct: 100.0},

--- a/dashboard/internal/data/progress_metrics_test.go
+++ b/dashboard/internal/data/progress_metrics_test.go
@@ -1,0 +1,102 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/santifer/career-ops/dashboard/internal/model"
+)
+
+// apps builds a slice of applications from a status -> count map-ish list.
+func appsWithStatuses(statuses ...string) []model.CareerApplication {
+	out := make([]model.CareerApplication, 0, len(statuses))
+	for i, s := range statuses {
+		out = append(out, model.CareerApplication{Number: i + 1, Status: s})
+	}
+	return out
+}
+
+func stageCount(pm model.ProgressMetrics, label string) int {
+	for _, s := range pm.FunnelStages {
+		if s.Label == label {
+			return s.Count
+		}
+	}
+	return -1
+}
+
+// A hire is terminal success and proves every earlier stage. It must count into
+// Applied, Responded, Interview and Offer — the same cumulative math stats.mjs's
+// computeFunnel() documents as mirroring this function. Before the fix "hired"
+// appeared in no tier, so a landed job rendered as an entirely empty funnel.
+func TestComputeProgressMetricsCountsHiredInEveryStage(t *testing.T) {
+	pm := ComputeProgressMetrics(appsWithStatuses("Hired"))
+
+	for _, tc := range []struct {
+		label string
+		want  int
+	}{
+		{"Evaluated", 1},
+		{"Applied", 1},
+		{"Responded", 1},
+		{"Interview", 1},
+		{"Offer", 1},
+	} {
+		if got := stageCount(pm, tc.label); got != tc.want {
+			t.Errorf("funnel stage %q = %d, want %d (a hire proves every earlier stage)", tc.label, got, tc.want)
+		}
+	}
+
+	if pm.TotalOffers != 1 {
+		t.Errorf("TotalOffers = %d, want 1 (a hire proves an offer was received)", pm.TotalOffers)
+	}
+}
+
+// With a hire in the denominator and numerator, the rates must be real numbers
+// rather than the 0%% the missing tiers produced.
+func TestComputeProgressMetricsRatesIncludeHired(t *testing.T) {
+	// 1 hired + 1 rejected: everApplied = 2, everResponded/Interview/Offer = 1.
+	pm := ComputeProgressMetrics(appsWithStatuses("Hired", "Rejected"))
+
+	if pm.ResponseRate != 50 {
+		t.Errorf("ResponseRate = %v, want 50", pm.ResponseRate)
+	}
+	if pm.InterviewRate != 50 {
+		t.Errorf("InterviewRate = %v, want 50", pm.InterviewRate)
+	}
+	if pm.OfferRate != 50 {
+		t.Errorf("OfferRate = %v, want 50", pm.OfferRate)
+	}
+}
+
+// The cumulative tiers must stay ordered: each stage is a superset of the next.
+func TestComputeProgressMetricsFunnelIsMonotonic(t *testing.T) {
+	pm := ComputeProgressMetrics(appsWithStatuses(
+		"Evaluated", "Applied", "Responded", "Interview", "Offer", "Hired", "Rejected", "Discarded", "SKIP",
+	))
+
+	applied := stageCount(pm, "Applied")
+	responded := stageCount(pm, "Responded")
+	interview := stageCount(pm, "Interview")
+	offer := stageCount(pm, "Offer")
+
+	if !(applied >= responded && responded >= interview && interview >= offer) {
+		t.Errorf("funnel not monotonic: applied=%d responded=%d interview=%d offer=%d",
+			applied, responded, interview, offer)
+	}
+	// applied = applied+responded+interview+offer+hired+rejected = 6
+	if applied != 6 {
+		t.Errorf("Applied = %d, want 6", applied)
+	}
+	// responded = responded+interview+offer+hired = 4
+	if responded != 4 {
+		t.Errorf("Responded = %d, want 4", responded)
+	}
+	// interview = interview+offer+hired = 3
+	if interview != 3 {
+		t.Errorf("Interview = %d, want 3", interview)
+	}
+	// offer = offer+hired = 2
+	if offer != 2 {
+		t.Errorf("Offer = %d, want 2", offer)
+	}
+}


### PR DESCRIPTION
Closes #2405.

`ComputeProgressMetrics` builds a cumulative funnel — its own comment says *"each stage counts all apps that reached at least that stage"* — but `hired` was in **none** of the tiers. A hire definitionally passed through all four, so a landed job was invisible at Applied, Responded, Interview and Offer, and (since `applied` is the denominator for all three rates) missing from the denominator as well.

A pipeline whose only row is `Hired`:

| Stage | Before | After |
|---|---|---|
| Evaluated | 1 | 1 |
| Applied | **0** | 1 |
| Responded | **0** | 1 |
| Interview | **0** | 1 |
| Offer | **0** | 1 |
| rates | 0% / 0% / 0% | real values |

The single best outcome the tool can represent rendered as though nothing ever happened.

## Why this is a broken mirror, not a judgment call

`computeFunnel()` in `stats.mjs` is the *"canonical funnel definition for career-ops going forward"*, and its docstring describes its math as mirroring **this exact function**:

> Rejected counts into everApplied (a rejection proves a submission), **Hired counts into every stage through everOffer** (a landed job proves the offer and everything before it)

The Go side already matched on `Rejected` — it just never got `Hired`. Same incomplete-`Hired`-propagation family as #2289, #2295, #2297.

## Changes

- `hired` added to all four cumulative tiers, matching `computeFunnel()` exactly.
- `TotalOffers` counts a hire too (a hire proves an offer was received).
- Comment updated to state the rule explicitly and point at the canonical definition.

## Tests

`ComputeProgressMetrics` had **no test coverage at all** — that's why this slipped through. Added `progress_metrics_test.go` with three tests: a lone `Hired` row counting into all four stages + `TotalOffers`; the rates including it in numerator and denominator; and a monotonicity check (`applied ≥ responded ≥ interview ≥ offer`) across all nine canonical states with exact expected counts.

Go isn't installed on my machine, so these are verified by CI's `go test ./...` rather than locally — the assertions are derived from `NormalizeStatus`'s mapping for each literal used.

## Not changed (flagged in the issue)

`pm.ActiveApps` still counts a `Hired` row as *active* even though it's terminal. There's no canonical SSOT for "active", so I didn't guess — happy to follow up if you want it excluded.

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hired applications are now included across all relevant application funnel stages.
  * Offer totals and downstream funnel rates now accurately reflect hired applications.
  * Funnel counts remain cumulative and consistent across application statuses.

* **Tests**
  * Added coverage for funnel counts, offer totals, rates, and funnel consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->