### PR TITLE
fix(test-all): the states.yml freeze guarded 6 of 9 ids — `hired`/`responded`/`skip` were unprotected

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -11179,7 +11179,14 @@ try {
 
   // 55.3 canonical statuses (templates/states.yml → web status pills/actions)
   const statesSrc = readFileSync(join(ROOT, 'templates', 'states.yml'), 'utf-8');
-  const CANONICAL_STATE_IDS = ['evaluated', 'applied', 'interview', 'offer', 'rejected', 'discarded'];
+  // Every id in states.yml, hardcoded ON PURPOSE — deriving this list from the
+  // file it guards would make the check vacuous. It protected only 6 of the 9,
+  // so `responded`, `skip` and `hired` could be deleted from states.yml and this
+  // check still passed while claiming it "keeps every canonical status id".
+  // 55.3b below reads states.yml dynamically, so it inherits any such loss
+  // instead of catching it: with `hired` removed both checks went green while
+  // set-status.mjs would reject the terminal-success state as invalid.
+  const CANONICAL_STATE_IDS = ['evaluated', 'applied', 'responded', 'interview', 'offer', 'hired', 'rejected', 'discarded', 'skip'];
   const missingStates = CANONICAL_STATE_IDS.filter((s) => !new RegExp(`^  - id: ${s}$`, 'm').test(statesSrc));
   if (missingStates.length === 0) {
     pass('templates/states.yml keeps every canonical status id (new ids may be appended)');


### PR DESCRIPTION
Closes #2407.

Check **55.3** is the hardcoded floor that keeps `templates/states.yml` from losing a canonical status id. Hardcoding is right — deriving the list from the file it guards would make it vacuous — but the list only had 6 of the 9 ids:

```js
const CANONICAL_STATE_IDS = ['evaluated', 'applied', 'interview', 'offer', 'rejected', 'discarded'];
```

states.yml defines nine. `responded`, `skip` and `hired` were unprotected, while the check still printed *"keeps every canonical status id"*.

## Verified before the fix

Deleting the `hired` block from `templates/states.yml` and running `node test-all.mjs --quick`:

```
55. Core↔web contract freeze
  ✅ templates/states.yml keeps every canonical status id (new ids may be appended)
```

Green — with the terminal-success state removed from the source of truth.

## Why 55.3b doesn't cover it

55.3b (the six-web-list drift guard I added in #2250) derives `stateLabels` **dynamically** from states.yml, so it *inherits* the loss instead of catching it: with `hired` gone, `stateLabels` no longer contains it, every web list trivially satisfies the check, and both guards go green — while `set-status.mjs` validates against states.yml and would start rejecting `Hired` as invalid, reproducing the "landed a job, can't record it" failure #2249/#2250 fixed.

The two are complementary by design (55.3 = hardcoded floor, 55.3b = dynamic cross-layer sweep). The floor just had three holes.

## Fix

Complete the list to all nine ids, with a comment explaining why it stays hardcoded and why 55.3b can't substitute for it.

Verified after the change:

```
real file                → passes
remove 'hired'           → ❌ lost canonical status id(s): hired
remove 'responded'       → ❌ lost canonical status id(s): responded
remove 'skip'            → ❌ lost canonical status id(s): skip
```

`node test-all.mjs --quick` → **2754 passed, 0 failed**.

One commit — the change is a single list plus its rationale; splitting it would separate the fix from the comment that explains it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded state validation coverage to include responded, hired, and skipped states.
  * Ensured all supported states are checked against the canonical state definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->