### PR TITLE
fix(merge-tracker): write a lower-scored re-evaluation through instead of discarding it

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -273,9 +273,15 @@ function companiesMatch(a, b) {
  * @param {object} addition - Parsed TSV addition (uses `notes` and `date`).
  * @param {number} oldScore - Score currently on the row.
  * @param {number} newScore - Score from the addition.
+ * @param {string} [extraMarker] - Appended to the re-eval marker, before any
+ *   incoming notes. Used by the downgrade path to record the superseded report
+ *   (#2411). It rides on the marker rather than on `addition.notes` so that the
+ *   repeat detection below keeps comparing the user's own text against the
+ *   user's own text — a generated fragment in that comparison would make every
+ *   downgrade look like a new note and defeat it.
  * @returns {string} Combined Notes cell.
  */
-function mergeNotes(existingNotes, addition, oldScore, newScore) {
+function mergeNotes(existingNotes, addition, oldScore, newScore, extraMarker = '') {
   // Trailing period trimmed only so the '. ' join does not produce '..'; no
   // other character of the existing text is touched. The tracker's "no data"
   // sentinels (the looksLikeScoreCell set minus the score-only DUP) count as
@@ -286,7 +292,9 @@ function mergeNotes(existingNotes, addition, oldScore, newScore) {
     ? ''
     : prevRaw.replace(/\s*\.\s*$/, '');
   const incoming = String(addition.notes ?? '').trim();
-  const marker = `Re-eval ${addition.date} (${oldScore}→${newScore})`;
+  const marker = extraMarker
+    ? `Re-eval ${addition.date} (${oldScore}→${newScore}) — ${extraMarker}`
+    : `Re-eval ${addition.date} (${oldScore}→${newScore})`;
   // Re-running the same evaluation would otherwise repeat its own text; the
   // marker still records that the re-evaluation happened. Repeats are detected
   // per CLAUSE — the same '. ' separator this function joins with — not by raw
@@ -856,48 +864,68 @@ for (const file of tsvFiles) {
     const newScore = parseScore(addition.score);
     const oldScore = parseScore(duplicate.score);
 
-    if (newScore > oldScore) {
-      console.log(`🔄 Update: #${duplicate.num} ${addition.company} — ${addition.role} (${oldScore}→${newScore})`);
-      const pdf = reportNum && pdfIndex.has(String(reportNum)) ? '✅' : duplicate.pdf;
-      const updatedLine = buildRow({
-        num: duplicate.num, date: addition.date, company: addition.company,
-        role: reportNumMatched ? addition.role : duplicate.role,
-        via: addition.via || duplicate.via || '—',
-        location: addition.location || duplicate.location || '—',
-        score: addition.score, status: duplicate.status, pdf,
-        report: addition.report,
-        notes: mergeNotes(duplicate.notes, addition, oldScore, newScore),
-      });
-      if (replaceTrackerLine(duplicate.raw, updatedLine)) {
-        // Refresh the cached row from the line just written (#2392). `raw` was
-        // captured when applications.md was parsed and used to be left stale
-        // after the write, so a SECOND addition matching this same row found
-        // nothing at indexOf(), fell through a branch with no else, and was
-        // archived as merged — the evaluation was gone with no warning and no
-        // recoverable copy (the tracker is gitignored and no .bak is written).
-        // The stale `score` was just as damaging: the second comparison read
-        // the pre-update score, so which of several re-evaluations survived
-        // depended on TSV filename sort order. Re-parsing the written line is
-        // the faithful refresh — the cached row then holds exactly what a fresh
-        // read of the tracker would produce. syncPdfFlags() has always kept its
-        // cache in step this way; the update path did not.
-        const refreshed = parseAppLine(updatedLine);
-        if (refreshed) Object.assign(duplicate, refreshed);
-        else duplicate.raw = updatedLine;
-        updated++;
-      } else {
-        // Unreachable once `raw` is refreshed above, but never silent again: a
-        // row we cannot locate means the addition was NOT applied, so say so,
-        // keep the TSV out of merged/, and fail the run.
-        console.error(
-          `❌ ${file}: could not locate tracker row #${duplicate.num} ` +
-          `(${duplicate.company} — ${duplicate.role}) to update; this evaluation was NOT merged.`,
-        );
-        failedAdditions.push(file);
-      }
+    // A re-evaluation writes through in BOTH directions. A lower score is not
+    // noise to discard — it is newer information, and often the most valuable
+    // kind: a targeting/policy change, a freshly-discovered staleness signal (a
+    // requisition turning out to be a year old), or a gap re-weighted from
+    // "ramp-up item" to "decisive gate". The former `newScore > oldScore` gate
+    // sent all of those to a bare `else`, so the tracker kept asserting a stale
+    // optimistic score, the new report was orphaned, and the TSV was archived to
+    // merged/ as if it had landed (#2411). Equal scores write through too, since
+    // the notes and report link are still fresher than what the row holds.
+    //
+    // Because the fuzzy matcher can mis-pair genuinely different roles (see
+    // role-matcher.mjs — "Senior" is a stopword and short tokens are dropped), a
+    // downgrade records the superseded report number so a bad match stays
+    // recoverable from the tracker alone. mergeNotes() keeps the existing cell
+    // verbatim and first, so a second downgrade preserves the earlier marker
+    // rather than overwriting it.
+    const downgrade = newScore < oldScore;
+    const oldReportNum = extractReportNum(duplicate.report);
+    const supersededNote = downgrade && oldReportNum && oldReportNum !== reportNum
+      ? `Superseded report [${oldReportNum}] (was ${oldScore}/5)`
+      : '';
+
+    console.log(
+      `${downgrade ? '🔽' : '🔄'} Update: #${duplicate.num} ${addition.company} — ${addition.role} (${oldScore}→${newScore})`
+      + (downgrade ? ' — DOWNGRADE, re-eval scored lower' : ''),
+    );
+    const pdf = reportNum && pdfIndex.has(String(reportNum)) ? '✅' : duplicate.pdf;
+    const updatedLine = buildRow({
+      num: duplicate.num, date: addition.date, company: addition.company,
+      role: reportNumMatched ? addition.role : duplicate.role,
+      via: addition.via || duplicate.via || '—',
+      location: addition.location || duplicate.location || '—',
+      score: addition.score, status: duplicate.status, pdf,
+      report: addition.report,
+      notes: mergeNotes(duplicate.notes, addition, oldScore, newScore, supersededNote),
+    });
+    if (replaceTrackerLine(duplicate.raw, updatedLine)) {
+      // Refresh the cached row from the line just written (#2392). `raw` was
+      // captured when applications.md was parsed and used to be left stale
+      // after the write, so a SECOND addition matching this same row found
+      // nothing at indexOf(), fell through a branch with no else, and was
+      // archived as merged — the evaluation was gone with no warning and no
+      // recoverable copy (the tracker is gitignored and no .bak is written).
+      // The stale `score` was just as damaging: the second comparison read
+      // the pre-update score, so which of several re-evaluations survived
+      // depended on TSV filename sort order. Re-parsing the written line is
+      // the faithful refresh — the cached row then holds exactly what a fresh
+      // read of the tracker would produce. syncPdfFlags() has always kept its
+      // cache in step this way; the update path did not.
+      const refreshed = parseAppLine(updatedLine);
+      if (refreshed) Object.assign(duplicate, refreshed);
+      else duplicate.raw = updatedLine;
+      updated++;
     } else {
-      console.log(`⏭️  Skip: ${addition.company} — ${addition.role} (existing #${duplicate.num} ${oldScore} >= new ${newScore})`);
-      skipped++;
+      // Unreachable once `raw` is refreshed above, but never silent again: a
+      // row we cannot locate means the addition was NOT applied, so say so,
+      // keep the TSV out of merged/, and fail the run.
+      console.error(
+        `❌ ${file}: could not locate tracker row #${duplicate.num} ` +
+        `(${duplicate.company} — ${duplicate.role}) to update; this evaluation was NOT merged.`,
+      );
+      failedAdditions.push(file);
     }
   } else {
     // New entry - preserve the TSV's reserved ID whenever it is actually

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -126,6 +126,91 @@ try {
   } else {
     fail(`merge-tracker did not resolve accepted -> Hired: ${acceptedRow.trim()}`);
   }
+
+  // --- Re-evaluation write-through, both directions -----------------------
+  // A re-evaluation that scores LOWER used to hit a bare `else`: the row kept
+  // its stale optimistic score, the new report was orphaned, and the TSV was
+  // archived to merged/ as though it had landed.
+  const SEED = '| 7 | 2026-02-01 | Initech | Payments PM | 3.8/5 | Evaluated | ✅ | '
+    + '[7](../reports/7-initech-2026-02-01.md) | Req R5639. stretch apply |\n';
+
+  const down = runMergeDetailed({
+    '8-initech.tsv': '8\t2026-03-01\tInitech\tPayments PM\tEvaluated\t3.0/5\t✅\t[8](reports/8-initech-2026-03-01.md)\tre-scored: req is 12 months old, rails gap is a gate\n',
+  }, { rows: SEED });
+  const downRow = down.tracker.split('\n').find(l => /\bInitech\b/.test(l)) || '';
+
+  if (/\|\s*3\.0\/5\s*\|/.test(downRow) && !/\|\s*3\.8\/5\s*\|/.test(downRow)) {
+    pass('re-evaluation with a LOWER score writes through (no silent skip)');
+  } else {
+    fail(`lower-scored re-eval did not write through: ${downRow.trim()}`);
+  }
+
+  if (/\[8\]/.test(downRow) && !/\[7\]\(/.test(downRow)) {
+    pass('downgrade re-points the Report link at the newer report');
+  } else {
+    fail(`downgrade left a stale report link: ${downRow.trim()}`);
+  }
+
+  // The fuzzy matcher can mis-pair genuinely different roles (role-matcher.mjs
+  // drops "Senior" and short tokens), so a downgrade must stay recoverable.
+  if (/Superseded report \[7\] \(was 3\.8\/5\)/.test(downRow)) {
+    pass('downgrade records the superseded report number in Notes');
+  } else {
+    fail(`downgrade did not record the superseded report: ${downRow.trim()}`);
+  }
+
+  // mergeNotes() keeps the existing cell verbatim and FIRST (#2483), so the
+  // seeded Req number — which this script's own sibling-req guard reads back —
+  // must survive the downgrade rather than being overwritten by it.
+  if (/Req R5639/.test(downRow)) {
+    pass('downgrade preserves the existing Notes (req number still readable)');
+  } else {
+    fail(`downgrade discarded the existing Notes: ${downRow.trim()}`);
+  }
+
+  if (/DOWNGRADE/.test(down.output) && /🔽/.test(down.output)) {
+    pass('downgrade is announced on stdout, not merged silently');
+  } else {
+    fail(`downgrade was not announced: ${down.output.trim()}`);
+  }
+
+  if (/🔄1 updated/.test(down.output) && /⏭️0 skipped/.test(down.output)) {
+    pass('downgrade counts as an update, not a skip');
+  } else {
+    fail(`downgrade counters wrong: ${down.output.trim()}`);
+  }
+
+  // An upgrade must keep behaving exactly as before this change.
+  const up = runMergeDetailed({
+    '9-initech.tsv': '9\t2026-03-01\tInitech\tPayments PM\tEvaluated\t4.5/5\t✅\t[9](reports/9-initech-2026-03-01.md)\tre-scored up after JD refresh\n',
+  }, { rows: SEED });
+  const upRow = up.tracker.split('\n').find(l => /\bInitech\b/.test(l)) || '';
+
+  if (/\|\s*4\.5\/5\s*\|/.test(upRow) && /Re-eval 2026-03-01 \(3\.8→4\.5\)/.test(upRow)) {
+    pass('re-evaluation with a HIGHER score still writes through unchanged');
+  } else {
+    fail(`upgrade path regressed: ${upRow.trim()}`);
+  }
+
+  if (!/Superseded report/.test(upRow) && !/DOWNGRADE/.test(up.output)) {
+    pass('upgrade does not add the superseded-report marker');
+  } else {
+    fail(`upgrade wrongly marked as a downgrade: ${upRow.trim()}`);
+  }
+
+  // Equal scores write through too: the notes and report link are still fresher
+  // than what the row holds, and no superseded marker is warranted.
+  const same = runMergeDetailed({
+    '10-initech.tsv': '10\t2026-03-02\tInitech\tPayments PM\tEvaluated\t3.8/5\t✅\t[10](reports/10-initech-2026-03-02.md)\tsame score, fresher read\n',
+  }, { rows: SEED });
+  const sameRow = same.tracker.split('\n').find(l => /\bInitech\b/.test(l)) || '';
+
+  if (/\[10\]/.test(sameRow) && /Re-eval 2026-03-02 \(3\.8→3\.8\)/.test(sameRow)
+      && !/Superseded report/.test(sameRow) && /🔄1 updated/.test(same.output)) {
+    pass('equal-scored re-evaluation writes through without a superseded marker');
+  } else {
+    fail(`equal-score re-eval mishandled: ${sameRow.trim()} | ${same.output.trim()}`);
+  }
 } catch (e) {
   fail(`merge-tracker.mjs tests crashed: ${e.message}`);
 }
@@ -165,19 +250,22 @@ try {
   }
 
   // The score comparison must read the CURRENT row, not the parse-time
-  // snapshot: a lower-scored addition arriving after a higher-scored one must
-  // be skipped rather than overwriting it.
+  // snapshot. Since #2411 a lower-scored addition writes through rather than
+  // being skipped, so what the stale snapshot would corrupt is no longer *which*
+  // row survives but what the re-eval marker claims: against the parse-time
+  // score this renders `(4.0→4.2)` and silently mis-states the history the row
+  // is supposed to preserve. Asserting the marker keeps the original invariant
+  // under test, on the behaviour that replaced the skip.
   const downgrade = runMergeDetailed({
     'a-001-acme.tsv': '1\t2026-02-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-01-01.md)\thigh\n',
     'b-001-acme.tsv': '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.2/5\t❌\t[1](reports/001-acme-2026-01-01.md)\tlow\n',
   }, { rows: seeded });
   const downgradeRows = dataRows(downgrade.tracker);
-  // Both the surviving row AND the accounting have to be right: against the
-  // stale-snapshot code the 4.2 addition compared against the parse-time 4.0,
-  // was announced as an update, and only failed to overwrite because its
-  // indexOf() lookup silently missed. Same file on disk, opposite reason.
-  if (downgradeRows.length === 1 && /4\.7\/5/.test(downgradeRows[0]) && /⏭️1 skipped/.test(downgrade.output)) {
-    pass('a later lower-scored addition is skipped against the CURRENT score, not the parse-time one');
+  if (downgradeRows.length === 1
+      && /4\.2\/5/.test(downgradeRows[0])
+      && /Re-eval 2026-03-01 \(4\.7→4\.2\)/.test(downgradeRows[0])
+      && /🔄2 updated/.test(downgrade.output)) {
+    pass('a later lower-scored addition writes through against the CURRENT score, not the parse-time one');
   } else {
     fail(`stale score comparison mishandled the downgrade: ${downgradeRows.join(' // ')} | ${downgrade.output.split('\n').find(l => l.includes('Summary:')) || '(no summary)'}`);
   }


### PR DESCRIPTION
Closes #2411

A re-evaluation whose score is **lower** than the row it matches was silently discarded. The row kept its stale optimistic score, the newer report was orphaned, no counter moved, and the TSV was archived into `merged/` as though it had landed.

`data/applications.md` is gitignored user-layer data that is never regenerated, so the loss was unrecoverable.

## The path

merge-tracker.mjs:728

```js
if (newScore > oldScore) {
  // ... rewrite the row, updated++
} else {
  console.log(`⏭️  Skip: ${addition.company} — ${addition.role} (existing #${duplicate.num} ${oldScore} >= new ${newScore})`);
  skipped++;
}
```

The dedup tiers above this had already established the row is the same opening. The only remaining question is which evaluation is *newer*, and that is always the incoming one — but a lower score routed it to `else`.

## Why the downgrade case is the one that matters

A lower score is rarely noise. In practice it means:

- **targeting changed** — a role that was on-strategy no longer is, so the same JD honestly scores lower;
- **a staleness signal surfaced late** — e.g. reading `first_published` for the first time and finding the requisition is ~12 months old;
- **a gap was re-weighted** — something previously judged a "ramp-up item" turns out to be a hard gate.

All three are strictly better information than the number already in the row. Discarding them leaves the tracker asserting a stale optimistic score, which is worse than no row at all: it actively misleads the next prioritisation pass.

## What changed

A re-evaluation now writes through in both directions:

- **downgrades log with their own marker** (`🔽 ... — DOWNGRADE, re-eval scored lower`) so they cannot be mistaken for an upgrade when skimming a batch log;
- **they count as an update, not a skip**;
- **Notes records `Superseded report [N] (was X.X/5)`**.

That last point is deliberate rather than decorative. `role-matcher.mjs` treats "Senior" as a stopword and drops tokens of ≤3 characters, so near-identical titles can pair when they shouldn't. Writing through unconditionally with no breadcrumb would convert a bad match into data loss of a different kind — the Notes pointer keeps the superseded evaluation reachable from the tracker alone.

Equal scores also write through, since the notes and report link are still fresher than what the row holds. `skipped` keeps its meaning: it still counts malformed and genuinely rejected rows.

The upgrade arm is otherwise untouched — `pdfIndex` lookup, `reportNumMatched` role handling, and the existing `Re-eval` notes format all behave exactly as before.

## Tests

`tests/merge-tracker.test.mjs` gains nine cases: seven on the downgrade path (write-through, report re-pointing, superseded marker, stdout announcement, update-vs-skip counters) and two guarding the upgrade path against regression.

Two small harness changes: `runMerge()` takes an optional `seedRows` argument so a pre-existing row can be matched against, and returns `{ text, stdout }` so the summary line can be asserted. Both existing callers updated.

Verified failing against unpatched `main`, where they reproduce the exact defect:

```
⏭️  Skip: Initech — Payments PM (existing #7 3.8 >= new 3)
📊 Summary: +0 added, 🔄0 updated, ⏭️1 skipped
```

```
$ node tests/merge-tracker.test.mjs
  ✅ merge-tracker preserves the canonical Hired status (no silent downgrade)
  ✅ merge-tracker resolves the "accepted" alias to Hired
  ✅ re-evaluation with a LOWER score writes through (no silent skip)
  ✅ downgrade re-points the Report link at the newer report
  ✅ downgrade records the superseded report number in Notes
  ✅ downgrade is announced on stdout, not merged silently
  ✅ downgrade counts as an update, not a skip
  ✅ re-evaluation with a HIGHER score still writes through unchanged
  ✅ upgrade does not add the superseded-report marker
```

Full suite: 2740 passed. The failures on my machine are pre-existing and reproduce identically on unpatched `main` — two need Node ≥ 22.5 for `node:sqlite` (I'm on v20.18.1), one is an `EPERM` symlink issue on Windows, one is a 10-column/Location shift in `tracker-columns-tests.mjs`, and two are the `#912` report-number collision cases. I confirmed each against a stashed baseline rather than assuming; none are touched by this change.

## Relationship to #2399

PR #2399 fixes four other data-loss paths in this same merge loop (stale row snapshot, no intra-run dedup, Notes overwritten on upgrade, missing separator row). It only changes what happens *inside* the `newScore > oldScore` arm and never revisits the `else`, so there is no overlap in intent — this is a fifth, independent gap.

The two do touch adjacent lines, so whichever lands second needs a small rebase. **Happy to sequence behind #2399** if that's easier for review; say the word and I'll rebase on it.

## How this surfaced

Found while re-evaluating a requisition I'd scored 3.8/5 three weeks earlier. The re-run scored it 3.0 — the posting turned out to be ~12 months old, and a gap I'd called a ramp-up item was really a hard gate. The merge printed `⏭️ Skip`, archived the TSV, and left the tracker claiming 3.8. I only noticed because `verify-pipeline.mjs` flagged the new report as an orphan; without that I'd have kept prioritising a role I'd already decided against.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-evaluations now update tracker entries for higher, equal, and lower scores.
  * Downgrades are clearly identified and retain superseded report details and previous scores.
  * Updates consistently refresh dates, scores, report links, and re-evaluation notes while preserving existing status.
  * Generated-PDF indicators are applied when available.
* **Tests**
  * Added regression coverage for score changes, report updates, downgrade notices, note preservation, and update counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->