### PR TITLE
feat(cv): add optional Awards / Honors section to HTML + LaTeX CV templates

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -55,6 +55,7 @@ const DEFAULT_SECTION_TITLES = {
   projects: 'Projects',
   education: 'Education',
   certifications: 'Certifications',
+  awards: 'Awards & Honors',
   skills: 'Skills',
 };
 
@@ -275,7 +276,7 @@ function loadSectionPartials(templatePath) {
   if (!existsSync(sectionsDir)) return partials;
 
   const sectionNames = [
-    'competencies', 'experience', 'projects', 'education', 'certifications', 'skills',
+    'competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'skills',
   ];
   for (const name of sectionNames) {
     const partialPath = join(sectionsDir, `${name}.html`);
@@ -457,6 +458,40 @@ function buildCertifications(entries, partial) {
   }).join('\n    ');
 }
 
+// Awards mirror certifications: a title with an optional issuing body and year,
+// laid out on one baseline. Kept as its own builder rather than an alias so the
+// two can diverge (and so awards.html can be authored independently of
+// certifications.html) without one section's markup leaking into the other.
+function buildAwards(entries, partial) {
+  if (!Array.isArray(entries) || entries.length === 0) return '';
+  if (!partial) {
+    return entries.filter(Boolean).map(e => {
+      const org = e.org ? `<span class="award-org">${escapeHtml(e.org)}</span>` : '<span class="award-org"></span>';
+      const year = e.year ? `<span class="award-year">${escapeHtml(e.year)}</span>` : '<span class="award-year"></span>';
+      return `<div class="award-item">
+      <span class="award-title">${escapeHtml(e.title)}</span>
+      ${org}
+      ${year}
+    </div>`;
+    }).join('\n    ');
+  }
+
+  const { entryTemplate, blocks } = partial;
+  return entries.filter(Boolean).map(e => {
+    const blockValues = new Map([
+      // As with certifications, absent fields still emit an empty <span> so the
+      // table cells stay aligned across rows.
+      ['ORG_BLOCK',  { value: escapeHtml(e.org || ''),  present: Boolean(e.org) }],
+      ['YEAR_BLOCK', { value: escapeHtml(e.year || ''), present: Boolean(e.year) }],
+    ]);
+    return fillEntry(entryTemplate, blocks, {
+      TITLE: escapeHtml(e.title || ''),
+      ORG:   escapeHtml(e.org || ''),
+      YEAR:  escapeHtml(e.year || ''),
+    }, blockValues);
+  }).join('\n    ');
+}
+
 function buildSkills(categories, partial) {
   if (!Array.isArray(categories) || categories.length === 0) return '';
   if (!partial) {
@@ -545,6 +580,8 @@ function renderReport(payload, partials) {
     EDUCATION: buildEducation(payload.education, partials.get('education')),
     SECTION_CERTIFICATIONS: escapeHtml(sectionTitles.certifications),
     CERTIFICATIONS: buildCertifications(payload.certifications, partials.get('certifications')),
+    SECTION_AWARDS: escapeHtml(sectionTitles.awards),
+    AWARDS: buildAwards(payload.awards, partials.get('awards')),
     SECTION_SKILLS: escapeHtml(sectionTitles.skills),
     SKILLS: buildSkills(payload.skills, partials.get('skills')),
   };
@@ -604,6 +641,7 @@ async function writeAndReport(html, absOutput, payload, extra = {}) {
       projectEntries: (payload.projects || []).length,
       educationEntries: (payload.education || []).length,
       certificationEntries: (payload.certifications || []).length,
+      awardEntries: (payload.awards || []).length,
       skillCategories: (payload.skills || []).length,
       totalBullets: countBullets(payload),
     },
@@ -721,6 +759,7 @@ async function runSelfTest() {
       description: 'Coursework: Data Structures, Algorithms, Machine Learning.',
     }],
     certifications: [{ title: 'Certified Kubernetes Administrator', org: 'CNCF', year: '2025' }],
+    awards: [{ title: 'Gold Medal, International Olympiad in Informatics', org: 'IOI', year: '2023' }],
     skills: [
       { category: 'Languages', items: 'Python, JavaScript, TypeScript' },
       { category: 'Frameworks', items: ['FastAPI', 'React', 'PyTorch'] },
@@ -810,6 +849,10 @@ async function runSelfTest() {
   }
   if (!html.includes('class="cert-item"')) {
     console.error('Self-test failed: certifications section is missing .cert-item class');
+    process.exit(1);
+  }
+  if (!html.includes('class="award-item"')) {
+    console.error('Self-test failed: awards section is missing .award-item class');
     process.exit(1);
   }
 

--- a/build-cv-latex.mjs
+++ b/build-cv-latex.mjs
@@ -51,6 +51,21 @@ function buildProjects(entries) {
   return blocks.join('\n\n');
 }
 
+// Awards are one line each — no bullet list — so they reuse
+// \resumeProjectHeading (bold left column, year right) rather than
+// \resumeSubheading, which would leave an empty second row. The issuing body
+// follows the title in the same $|$ style buildProjects() uses for context.
+function buildAwards(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return '';
+  const blocks = [];
+  for (const e of entries) {
+    if (!e) continue;
+    const org = e.org ? ` \\emph{$|$ ${escapeLatex(e.org)}}` : '';
+    blocks.push(`    \\resumeProjectHeading\n      {\\textbf{${escapeLatex(e.title)}}${org}}{${escapeLatex(e.year)}}`);
+  }
+  return blocks.join('\n\n');
+}
+
 function buildSkills(categories) {
   if (!Array.isArray(categories) || categories.length === 0) return '';
   return categories.map(c => {
@@ -140,6 +155,7 @@ async function main() {
     EDUCATION: buildEducation(payload.education),
     EXPERIENCE: buildExperience(payload.experience),
     PROJECTS: buildProjects(payload.projects),
+    AWARDS: buildAwards(payload.awards),
     SKILLS: buildSkills(payload.skills),
   };
 
@@ -171,6 +187,7 @@ async function main() {
       educationEntries: (payload.education || []).length,
       experienceEntries: (payload.experience || []).length,
       projectEntries: (payload.projects || []).length,
+      awardEntries: (payload.awards || []).length,
       skillCategories: (payload.skills || []).length,
       totalBullets: (() => {
         const ex = Array.isArray(payload.experience) ? payload.experience.flatMap(e => Array.isArray(e?.bullets) ? e.bullets : []) : [];
@@ -217,6 +234,10 @@ async function runSelfTest() {
         'Built a REST API with automated test coverage exceeding 90%',
       ],
     }],
+    awards: [
+      { title: 'Gold Medal, International Olympiad in Informatics', org: 'IOI', year: '2023' },
+      { title: "Dean's List", org: 'Test University', year: '2022' },
+    ],
     skills: [
       { category: 'Languages', items: 'Python, JavaScript, TypeScript' },
       { category: 'Frameworks', items: 'FastAPI, React, PyTorch' },
@@ -257,6 +278,7 @@ async function runSelfTest() {
     EDUCATION: buildEducation(sample.education),
     EXPERIENCE: buildExperience(sample.experience),
     PROJECTS: buildProjects(sample.projects),
+    AWARDS: buildAwards(sample.awards),
     SKILLS: buildSkills(sample.skills),
   };
 
@@ -290,6 +312,7 @@ async function runSelfTest() {
       educationEntries: sample.education.length,
       experienceEntries: sample.experience.length,
       projectEntries: sample.projects.length,
+      awardEntries: sample.awards.length,
       skillCategories: sample.skills.length,
       totalBullets: (() => {
         const ex = Array.isArray(sample.experience) ? sample.experience.flatMap(e => Array.isArray(e?.bullets) ? e.bullets : []) : [];

--- a/cv-sections-core.mjs
+++ b/cv-sections-core.mjs
@@ -1,19 +1,21 @@
 // Shared optional-section stripping for the CV builders (build-cv-html.mjs,
 // build-cv-latex.mjs).
 //
-// Projects, education, and certifications are the genuinely optional CV
-// sections: a candidate's projects are often already covered under Work
-// Experience, not every candidate has a degree, and not every application
-// carries a certification worth listing. The templates wrap all three
-// unconditionally, so a payload with no entries renders a bare section header
-// with nothing under it. The builders' buildProjects()/buildEducation()/
-// buildCertifications() correctly return '' — nothing removes the surrounding
-// wrapper, which is what this module does.
+// Projects, education, certifications, and awards are the genuinely optional
+// CV sections: a candidate's projects are often already covered under Work
+// Experience, not every candidate has a degree, not every application carries a
+// certification worth listing, and most candidates have no award to name. The
+// templates wrap all four unconditionally, so a payload with no entries renders
+// a bare section header with nothing under it. The builders'
+// buildProjects()/buildEducation()/buildCertifications()/buildAwards()
+// correctly return '' — nothing removes the surrounding wrapper, which is what
+// this module does.
 //
 // Certifications has no marker in the LaTeX template (cv-template.tex has no
 // Certifications section at all), so PATTERNS.tex has no `certifications` key
 // — stripEmptySections skips a section silently when the active format has no
-// pattern for it, rather than trying to match against `undefined`.
+// pattern for it, rather than trying to match against `undefined`. Awards, by
+// contrast, is defined for both formats.
 //
 // The section body is delimited by markers rather than parsed, so the boundary
 // pattern carries the whole correctness burden and is easy to get subtly wrong:
@@ -41,14 +43,16 @@ const PATTERNS = {
     projects: new RegExp(String.raw`<!--\s+PROJECTS\s+-->[\s\S]*?` + HTML_BOUNDARY),
     education: new RegExp(String.raw`<!--\s+EDUCATION\s+-->[\s\S]*?` + HTML_BOUNDARY),
     certifications: new RegExp(String.raw`<!--\s+CERTIFICATIONS\s+-->[\s\S]*?` + HTML_BOUNDARY),
+    awards: new RegExp(String.raw`<!--\s+AWARDS\s+-->[\s\S]*?` + HTML_BOUNDARY),
   },
   tex: {
     projects: new RegExp(String.raw`%{4,}\s+PROJECTS\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
     education: new RegExp(String.raw`%{4,}\s+Education\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
+    awards: new RegExp(String.raw`%{4,}\s+AWARDS\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
   },
 };
 
-export const OPTIONAL_SECTIONS = ['projects', 'education', 'certifications'];
+export const OPTIONAL_SECTIONS = ['projects', 'education', 'certifications', 'awards'];
 
 export function isEmptySection(payload, section) {
   const entries = payload?.[section];

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -154,6 +154,13 @@ const SECTION_ALIASES = new Map([
   ['education', 'education'],
   ['education & certifications', 'education'],
   ['certifications', 'certifications'],
+  ['awards', 'awards'],
+  ['honors', 'awards'],
+  ['honours', 'awards'],
+  ['awards & honors', 'awards'],
+  ['awards and honors', 'awards'],
+  ['honors & awards', 'awards'],
+  ['awards & honours', 'awards'],
   ['skills', 'skills'],
   ['technical skills', 'skills'],
   // Polish — the vocabulary documented in modes/pl/README.md, plus the word-order
@@ -177,6 +184,9 @@ const SECTION_ALIASES = new Map([
   ['certyfikaty', 'certifications'],
   ['certyfikaty i szkolenia', 'certifications'],
   ['szkolenia i certyfikaty', 'certifications'],
+  ['nagrody', 'awards'],
+  ['wyróżnienia', 'awards'],
+  ['nagrody i wyróżnienia', 'awards'],
   ['umiejętności', 'skills'],
   ['umiejętności techniczne', 'skills'],
 ].map(([alias, key]) => [foldDiacritics(alias), key]));

--- a/modes/latex.md
+++ b/modes/latex.md
@@ -11,7 +11,7 @@ Export a tailored, ATS-optimized CV as a `.tex` file and compile it to PDF via `
 5. Detect JD language → CV language (EN default)
 6. Detect role archetype → adapt framing
 7. Rewrite Professional Summary injecting JD keywords (same rules as `pdf` mode — NEVER invent skills)
-8. Select top 3-4 most relevant projects for the offer
+8. Select top 3-4 most relevant projects for the offer, and populate `awards[]` from `cv.md`'s Awards / Honors section when it has entries that support the role (omit the key otherwise — the section is dropped, header included; never invent an award)
 9. Reorder experience bullets by JD relevance
 10. Inject keywords naturally into existing achievements
 11. Build a JSON payload (see schema below) and write to `/tmp/cv-{candidate}-{company}.json`
@@ -69,6 +69,9 @@ Write a JSON file with this structure. `build-cv-latex.mjs` handles template mer
       ]
     }
   ],
+  "awards": [
+    { "title": "Gold Medal, International Olympiad in Informatics", "org": "IOI", "year": "2021" }
+  ],
   "skills": [
     { "category": "Languages", "items": "Python, JavaScript, C++" },
     { "category": "Frameworks", "items": "FastAPI, React, PyTorch" }
@@ -102,6 +105,9 @@ Write a JSON file with this structure. `build-cv-latex.mjs` handles template mer
 | `projects[].context` | string | Tech stack — appears next to project name |
 | `projects[].dates` | string | Date range (or empty) |
 | `projects[].bullets` | string[] | Selected project achievements |
+| `awards[].title` | string | Award name, from cv.md Awards / Honors |
+| `awards[].org` | string | Optional — issuing body, rendered after the title |
+| `awards[].year` | string | Optional — year, right-aligned |
 | `skills[].category` | string | Skill category name (e.g. "Languages", "Frameworks") |
 | `skills[].items` | string | Comma-separated skills in that category |
 
@@ -129,7 +135,8 @@ Write a JSON file with this structure. `build-cv-latex.mjs` handles template mer
 ## ATS Rules (same as pdf mode)
 
 - Single-column layout (enforced by template)
-- Standard section headers: Education, Work Experience, Personal Projects, Technical Skills
+- Standard section headers: Education, Work Experience, Personal Projects, Awards & Honors, Technical Skills
+- Optional sections (Personal Projects, Education, Awards & Honors) are dropped entirely — header included — when their array is empty or absent
 - UTF-8, machine-readable via `\pdfgentounicode=1`
 - Keywords distributed: first bullet of each role, skills section
 - No images, no graphics, no color in body text

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -30,7 +30,7 @@ Run `npm run jd:similarity -- {bundle-root}/jd/current.md {bundle-root}/jd/previ
 8. Before tailoring, optionally compare the new JD with the latest tailored CV or JD. Resolve the application/report first with `node find.mjs {report-or-tracker-number}`. Use the resolved report/JD snapshot as `{new-jd.txt}` and the referenced prior CV or prior JD as `{previous-jd-or-cv.txt}`; if either source cannot be located, do not silently reuse a CV. Run `npm run jd:similarity -- {new-jd.txt} {previous-jd-or-cv.txt}` and display the `decision` and `score`. Reuse is allowed only when the recommendation is `reuse` or the user explicitly overrides it; `reuse-with-edits` still requires the listed edits, and `regenerate` requires the normal tailoring flow.
 9. Build an internal recruiter-side risk map from the JD using `modes/heuristics/recruiter-side.md`: likely doubts, matching evidence, and which document section should address each doubt
 10. Rewrite Professional Summary by injecting JD keywords + exit narrative bridge ("Built and sold a business. Now applying systems thinking to [JD domain].")
-11. Select top 3-4 most relevant projects for the job
+11. Select top 3-4 most relevant projects for the job. If `cv.md` carries an Awards / Honors section, populate `awards[]` with the entries that support this role — for an early-career candidate a contest medal or dean's list often outranks a thin project. Omit the key when there is nothing to list and the section disappears entirely; never invent an award to fill it
 12. Reorder experience bullets by JD relevance and by the risk map: strongest matching evidence first
 13. Build competency grid from JD requirements (6-8 keyword phrases), prioritizing `existing` and `supportedByResume` skills from Step 4 — never a `gap` skill
 14. Inject keywords naturally into existing achievements (NEVER invent)
@@ -140,6 +140,7 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
     "projects": "Projects",
     "education": "Education",
     "certifications": "Certifications",
+    "awards": "Awards & Honors",
     "skills": "Skills"
   },
   "summary": "Personalized summary with JD keywords injected (honest vs cv.md).",
@@ -161,6 +162,9 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
   ],
   "certifications": [
     { "title": "Certified Kubernetes Administrator", "org": "CNCF", "year": "2024" }
+  ],
+  "awards": [
+    { "title": "Gold Medal, International Olympiad in Informatics", "org": "IOI", "year": "2021" }
   ],
   "skills": [
     { "category": "Languages", "items": "Python, JavaScript, C++" },
@@ -191,6 +195,7 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `projects[]` | object | `name`, `badge` (optional), `tech` (optional), `description` (a `bullets` array is also accepted and joined into the description line). |
 | `education[]` | object | `title` (degree), `org` (institution), `year`, `description` (optional). |
 | `certifications[]` | object | `title`, `org`, `year`. |
+| `awards[]` | object | `title` (award name), `org` (issuing body, optional), `year` (optional). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Use it for competitive or academic distinctions (olympiad medals, hackathon wins, dean's list) that carry more signal than a thin experience section. |
 | `skills[]` | object | `category` + `items` (comma-separated string or string array). |
 
 `build-cv-html.mjs` errors out (non-zero exit) if any template placeholder is left unresolved, so a malformed payload fails loudly instead of shipping a broken CV. Run `node build-cv-html.mjs --test` for a self-test render.

--- a/templates/README.md
+++ b/templates/README.md
@@ -7,7 +7,7 @@ System-layer template files used by career-ops scripts and modes. These files ar
 | File | Used By | Purpose |
 |------|---------|---------|
 | `cv-template.html` | `generate-pdf.mjs` | HTML/CSS template for ATS-optimized CV PDFs |
-| `resume-template.html` | `generate-pdf.mjs` (via `--template`) | Resume-branded variant of `cv-template.html`. Same layout and placeholder tokens; differs in: `<title>` reads "Resume" instead of "CV", omits Certifications section, targets 1–2 page US/industry format. See detailed section below. |
+| `resume-template.html` | `generate-pdf.mjs` (via `--template`) | Resume-branded variant of `cv-template.html`. Same layout and placeholder tokens; differs in: `<title>` reads "Resume" instead of "CV", omits Certifications section (but keeps Awards & Honors), targets 1–2 page US/industry format. See detailed section below. |
 | `cv-template.tex` | `generate-latex.mjs` | LaTeX/Overleaf template for ATS-optimized CV PDFs |
 | `portals.example.yml` | Onboarding | Example portal scanner configuration (copy to `portals.yml` to activate) |
 | `states.yml` | `verify-pipeline.mjs`, `normalize-statuses.mjs`, `merge-tracker.mjs` | Canonical application states and their aliases |
@@ -26,6 +26,8 @@ The HTML template rendered by Playwright into PDF. Uses placeholder tokens (`{{N
 
 **Customization:** Edit this file to change colors, spacing, or section order. The placeholder tokens are documented in `batch/batch-prompt.md` under "Template placeholders."
 
+**Optional sections:** Projects, Education, Certifications, and Awards & Honors are dropped in full — section header included — when the payload carries no entries for them (see `cv-sections-core.mjs`). Their markers (`<!-- PROJECTS -->`, `<!-- AWARDS -->`, …) are what the strip matches on, so renaming or removing a marker disables the strip for that section.
+
 ### resume-template.html
 
 Resume-branded variant of `cv-template.html` for US/industry job applications. Key differences from the CV template:
@@ -33,6 +35,7 @@ Resume-branded variant of `cv-template.html` for US/industry job applications. K
 - **Title** reads "Resume" instead of "CV"
 - **No Certifications section** — resumes focus on recent, relevant experience
 - **Designed for 1–2 pages** — omits academic-style sections
+- **Awards & Honors is kept** — unlike Certifications. A contest medal or dean's list is a competitive signal rather than academic filler, and it is the strongest line an early-career candidate has when the experience section is thin. It costs nothing when unused: no entries means no section.
 
 Otherwise uses the same placeholder tokens (`{{NAME}}`, `{{SUMMARY_TEXT}}`, etc.) and is fully compatible with the existing PDF pipeline.
 

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -342,6 +342,44 @@
     width: 44px;
   }
 
+  /* === AWARDS === */
+  /* Same table model as certifications (title / issuer / year on one baseline),
+     under its own class names so a template pack can restyle awards without
+     dragging certifications along. */
+  .award-table {
+    display: table;
+    width: 100%;
+  }
+
+  .award-item {
+    display: table-row;
+  }
+
+  .award-item > * {
+    display: table-cell;
+    vertical-align: baseline;
+    padding-bottom: 6px;
+  }
+
+  .award-title {
+    font-size: 10.5px;
+    font-weight: 500;
+    color: #333;
+  }
+
+  .award-org {
+    color: hsl(270, 70%, 45%);
+    white-space: nowrap;
+  }
+
+  .award-year {
+    font-size: 10px;
+    color: #777;
+    white-space: nowrap;
+    text-align: right;
+    width: 44px;
+  }
+
   /* === SKILLS === */
   .skills-grid {
     display: flex;
@@ -575,6 +613,12 @@
   <div class="section">
     <div class="section-title">{{SECTION_CERTIFICATIONS}}</div>
     <div class="cert-table">{{CERTIFICATIONS}}</div>
+  </div>
+
+  <!-- AWARDS -->
+  <div class="section">
+    <div class="section-title">{{SECTION_AWARDS}}</div>
+    <div class="award-table">{{AWARDS}}</div>
   </div>
 
   <!-- SKILLS -->

--- a/templates/cv-template.tex
+++ b/templates/cv-template.tex
@@ -111,6 +111,12 @@
 {{PROJECTS}}
 \resumeSubHeadingListEnd
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%  AWARDS  %%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\section{Awards \& Honors}
+\resumeSubHeadingListStart
+{{AWARDS}}
+\resumeSubHeadingListEnd
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%  Technical Skills  %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Technical Skills}
 \vspace{-7pt}

--- a/templates/cv-template.zh-minimal.html
+++ b/templates/cv-template.zh-minimal.html
@@ -329,6 +329,41 @@ version: 1.0.0
     width: 44px;
   }
 
+  /* === AWARDS === */
+  .award-table {
+    display: table;
+    width: 100%;
+  }
+
+  .award-item {
+    display: table-row;
+  }
+
+  .award-item > * {
+    display: table-cell;
+    vertical-align: baseline;
+    padding-bottom: 6px;
+  }
+
+  .award-title {
+    font-size: 10.5px;
+    font-weight: 500;
+    color: #333;
+  }
+
+  .award-org {
+    color: hsl(270, 70%, 45%);
+    white-space: nowrap;
+  }
+
+  .award-year {
+    font-size: 10px;
+    color: #777;
+    white-space: nowrap;
+    text-align: right;
+    width: 44px;
+  }
+
   /* === SKILLS === */
   .skills-grid {
     display: flex;
@@ -683,6 +718,12 @@ version: 1.0.0
   <div class="section">
     <div class="section-title">{{SECTION_CERTIFICATIONS}}</div>
     <div class="cert-table">{{CERTIFICATIONS}}</div>
+  </div>
+
+  <!-- AWARDS -->
+  <div class="section">
+    <div class="section-title">{{SECTION_AWARDS}}</div>
+    <div class="award-table">{{AWARDS}}</div>
   </div>
 
   <!-- SKILLS -->

--- a/templates/resume-template.html
+++ b/templates/resume-template.html
@@ -329,6 +329,45 @@
     line-height: 1.5;
   }
 
+  /* === AWARDS === */
+  /* Kept here even though Certifications is not: an award is a recent,
+     competitive signal (contest medal, dean's list) rather than the academic
+     filler the resume variant drops, and the section is hidden entirely when
+     the payload carries no entries. */
+  .award-table {
+    display: table;
+    width: 100%;
+  }
+
+  .award-item {
+    display: table-row;
+  }
+
+  .award-item > * {
+    display: table-cell;
+    vertical-align: baseline;
+    padding-bottom: 6px;
+  }
+
+  .award-title {
+    font-size: 10.5px;
+    font-weight: 500;
+    color: #333;
+  }
+
+  .award-org {
+    color: hsl(270, 70%, 45%);
+    white-space: nowrap;
+  }
+
+  .award-year {
+    font-size: 10px;
+    color: #777;
+    white-space: nowrap;
+    text-align: right;
+    width: 44px;
+  }
+
   /* === SKILLS === */
   .skills-grid {
     display: flex;
@@ -527,6 +566,12 @@
   <div class="section avoid-break">
     <div class="section-title">{{SECTION_EDUCATION}}</div>
     {{EDUCATION}}
+  </div>
+
+  <!-- AWARDS -->
+  <div class="section avoid-break">
+    <div class="section-title">{{SECTION_AWARDS}}</div>
+    <div class="award-table">{{AWARDS}}</div>
   </div>
 
   <!-- SKILLS -->

--- a/templates/sections/awards.html
+++ b/templates/sections/awards.html
@@ -1,0 +1,23 @@
+<!--
+  awards.html — section partial for Awards & Honors (#2220).
+
+  Field placeholders filled per entry:
+    TITLE      — award name (e.g. "Gold Medal, International Olympiad in Informatics")
+    ORG_BLOCK  — conditional: award-org span with the issuing body when present;
+                 falls back to empty award-org span (ORG_EMPTY) for table-cell alignment
+    YEAR_BLOCK — conditional: award-year span with year text when present;
+                 falls back to empty award-year span (YEAR_EMPTY) for alignment
+
+  Template packs: edit tag names, class names, and field order freely inside the ENTRY zone.
+-->
+<!--ENTRY-->
+<div class="award-item">
+  <span class="award-title">{{TITLE}}</span>
+  {{ORG_BLOCK}}
+  {{YEAR_BLOCK}}
+</div>
+<!--ORG_BLOCK--><span class="award-org">{{ORG}}</span><!--/ORG_BLOCK-->
+<!--ORG_EMPTY--><span class="award-org"></span><!--/ORG_EMPTY-->
+<!--YEAR_BLOCK--><span class="award-year">{{YEAR}}</span><!--/YEAR_BLOCK-->
+<!--YEAR_EMPTY--><span class="award-year"></span><!--/YEAR_EMPTY-->
+<!--/ENTRY-->

--- a/tests/cv-optional-sections.test.mjs
+++ b/tests/cv-optional-sections.test.mjs
@@ -1,12 +1,14 @@
 // tests/cv-optional-sections.test.mjs — the optional CV sections (projects,
-// education, certifications) must vanish entirely when they have no entries,
-// rather than rendering a bare section header with nothing under it.
+// education, certifications, awards) must vanish entirely when they have no
+// entries, rather than rendering a bare section header with nothing under it.
 //
 // #1879 fixed this for projects; education is the same bug (not every
 // candidate has a degree). Certifications was fixed once directly in
 // build-cv-html.mjs, then lost when that logic was generalized into this
 // shared module (only projects/education made the cut) — the v1.22.0
-// auto-update shipped that regression. All three are delimited by marker
+// auto-update shipped that regression. Awards (#2220) is optional by
+// construction: most candidates have none, so it ships hidden-when-empty from
+// the start rather than being retrofitted. All four are delimited by marker
 // matching rather than parsed, so the boundary pattern is the whole
 // correctness story — see the header comment in cv-sections-core.mjs for the
 // failure modes exercised here.
@@ -17,8 +19,13 @@ import { stripEmptySections } from '../cv-sections-core.mjs';
 
 console.log('\ncv-sections-core.mjs — optional sections leave no bare header');
 
-const EMPTY = { projects: [], education: [], certifications: [] };
-const FULL = { projects: [{ name: 'P' }], education: [{ degree: 'D' }], certifications: [{ title: 'C' }] };
+const EMPTY = { projects: [], education: [], certifications: [], awards: [] };
+const FULL = {
+  projects: [{ name: 'P' }],
+  education: [{ degree: 'D' }],
+  certifications: [{ title: 'C' }],
+  awards: [{ title: 'A' }],
+};
 
 function check(label, actual, expected) {
   if (actual === expected) pass(label);
@@ -42,13 +49,15 @@ for (const { file, format, after, hasCertifications } of TEMPLATES) {
   const projectsMarker = format === 'html' ? '<!-- PROJECTS -->' : 'PROJECTS  %';
   const educationMarker = format === 'html' ? '<!-- EDUCATION -->' : 'Education  %';
   const certificationsMarker = '<!-- CERTIFICATIONS -->'; // html-only; no LaTeX Certifications section exists
+  const awardsMarker = format === 'html' ? '<!-- AWARDS -->' : 'AWARDS  %';
 
   check(`${name}: empty payload removes the projects block`, stripped.includes(projectsMarker), false);
   check(`${name}: empty payload removes the education block`, stripped.includes(educationMarker), false);
   if (hasCertifications) {
     check(`${name}: empty payload removes the certifications block`, stripped.includes(certificationsMarker), false);
   }
-  check(`${name}: the section after certifications survives`, stripped.includes(after), true);
+  check(`${name}: empty payload removes the awards block`, stripped.includes(awardsMarker), false);
+  check(`${name}: the section after awards survives`, stripped.includes(after), true);
   check(`${name}: {{EXPERIENCE}} is untouched`, stripped.includes('{{EXPERIENCE}}'), true);
 
   // Populated payload must be a no-op — the strip only ever removes.
@@ -56,17 +65,30 @@ for (const { file, format, after, hasCertifications } of TEMPLATES) {
     stripEmptySections(template, FULL, format) === template, true);
 
   // One empty, one populated: only the empty one goes.
-  const onlyEdu = stripEmptySections(template, { projects: [{ name: 'P' }], education: [], certifications: [{ title: 'C' }] }, format);
+  const onlyEdu = stripEmptySections(template, { ...FULL, education: [] }, format);
   check(`${name}: empty education alone keeps projects`, onlyEdu.includes(projectsMarker), true);
   check(`${name}: empty education alone drops education`, onlyEdu.includes(educationMarker), false);
+  check(`${name}: empty education alone keeps awards`, onlyEdu.includes(awardsMarker), true);
   if (hasCertifications) {
     check(`${name}: empty education alone keeps certifications`, onlyEdu.includes(certificationsMarker), true);
 
     // Certifications empty on its own: projects/education (both populated) survive, only certifications goes.
-    const onlyCert = stripEmptySections(template, { projects: [{ name: 'P' }], education: [{ degree: 'D' }], certifications: [] }, format);
+    const onlyCert = stripEmptySections(template, { ...FULL, certifications: [] }, format);
     check(`${name}: empty certifications alone keeps projects`, onlyCert.includes(projectsMarker), true);
     check(`${name}: empty certifications alone keeps education`, onlyCert.includes(educationMarker), true);
     check(`${name}: empty certifications alone drops certifications`, onlyCert.includes(certificationsMarker), false);
+    check(`${name}: empty certifications alone keeps awards`, onlyCert.includes(awardsMarker), true);
+  }
+
+  // Awards empty on its own: it is last among the optional sections in the HTML
+  // templates, so an end-of-block boundary slip here would swallow Skills.
+  const onlyAwards = stripEmptySections(template, { ...FULL, awards: [] }, format);
+  check(`${name}: empty awards alone keeps projects`, onlyAwards.includes(projectsMarker), true);
+  check(`${name}: empty awards alone keeps education`, onlyAwards.includes(educationMarker), true);
+  check(`${name}: empty awards alone drops awards`, onlyAwards.includes(awardsMarker), false);
+  check(`${name}: empty awards alone keeps the section after it`, onlyAwards.includes(after), true);
+  if (hasCertifications) {
+    check(`${name}: empty awards alone keeps certifications`, onlyAwards.includes(certificationsMarker), true);
   }
 }
 


### PR DESCRIPTION
## Description

Adds an optional Awards / Honors section to the HTML and LaTeX CV templates,
following the existing optional-section pattern — no entries means the whole
block is removed, header included, rather than rendering a bare title.

Entries are `{title, org?, year?}`, mirroring certifications.

Two placements the issue left open:

- `cv-template.tex` has no Certifications section, so "below certifications"
  has no meaning there. Awards sits after Personal Projects, registered in
  `PATTERNS.tex` so the empty-section strip covers both formats.
- `resume-template.html` keeps Awards even though it omits Certifications.
  A contest medal is a competitive signal rather than academic filler, and
  it costs nothing when unused.

Closes #2220

## Motivation

For an early-career candidate a contest medal or dean's list often carries
more signal than a thin experience section, and until now it had to be added
by hand on every tailoring pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Awards & Honors sections to HTML, PDF, and LaTeX CVs.
  * Awards support titles, organizations, and years with responsive formatting.
  * Added English and Polish heading recognition for awards and honors.
  * Awards sections are included only when populated.

* **Documentation**
  * Documented award fields, optional-section behavior, and template support.

* **Tests**
  * Added coverage for populated, empty, and omitted awards sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->