### PR TITLE
fix(sync-pdf): reject unknown options

### DIFF
--- a/sync-pdf-flags.mjs
+++ b/sync-pdf-flags.mjs
@@ -24,9 +24,18 @@ const APPS_FILE = resolveTrackerPath(CAREER_OPS);
 const PDF_MANIFEST = process.env.CAREER_OPS_PDF_INDEX || join(CAREER_OPS, 'data', 'pdf-index.tsv');
 
 const flags = { dryRun: false, json: false };
+const unknownOptions = [];
 for (const arg of process.argv.slice(2)) {
   if (arg === '--dry-run') flags.dryRun = true;
   else if (arg === '--json') flags.json = true;
+  else unknownOptions.push(arg);
+}
+
+if (unknownOptions.length > 0) {
+  const error = `unknown option(s): ${unknownOptions.join(', ')}`;
+  if (flags.json) console.error(JSON.stringify({ error, code: 'unknown-option' }));
+  else console.error(`Error: ${error}\nUsage: node sync-pdf-flags.mjs [--dry-run] [--json]`);
+  process.exit(1);
 }
 
 if (!existsSync(APPS_FILE)) {

--- a/tests/sync-pdf-flags.test.mjs
+++ b/tests/sync-pdf-flags.test.mjs
@@ -2,7 +2,7 @@
 
 import { pass, fail, NODE, ROOT } from './helpers.mjs';
 import { join } from 'path';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 
@@ -81,4 +81,29 @@ try {
   }
 } catch (e) {
   fail(`sync-pdf-flags.mjs tests crashed: ${e.message}`);
+}
+
+{
+  const work = mkdtempSync(join(tmpdir(), 'cops-sync-unknown-flag-'));
+  try {
+    const tracker = join(work, 'applications.md');
+    const pdfIndex = join(work, 'pdf-index.tsv');
+    writeFileSync(tracker, TRACKER_HEADER);
+    writeFileSync(pdfIndex, PDF_MANIFEST);
+
+    const result = spawnSync(NODE, [join(ROOT, 'sync-pdf-flags.mjs'), '--dry-rn', '--json'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_PDF_INDEX: pdfIndex },
+    });
+    const unchanged = readFileSync(tracker, 'utf-8') === TRACKER_HEADER;
+
+    if (result.status === 1 && /unknown option.*--dry-rn/i.test(result.stderr) && unchanged) {
+      pass('sync-pdf-flags rejects unknown options before changing the tracker');
+    } else {
+      fail(`unknown option changed the tracker or returned the wrong result: status=${result.status}, stderr=${JSON.stringify(result.stderr)}, unchanged=${unchanged}`);
+    }
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
 }


### PR DESCRIPTION
## Summary

Reject unknown sync-pdf-flags options before opening the tracker transaction. A typo such as --dry-rn can no longer continue in live write mode.

## Root cause

Argument parsing recognized supported flags but silently ignored every other token, then ran with default write behavior.

## Validation

- node tests/sync-pdf-flags.test.mjs
- node test-all.mjs — 2754 passed, 0 failed; 2 expected environment warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line validation by detecting unrecognized options before processing begins.
  * Added clear error reporting in both human-readable and JSON formats.
  * The command now exits with status 1 when an unknown option is provided, preventing unintended tracker changes.

* **Tests**
  * Added regression coverage for invalid command-line options and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->