### PR TITLE
docs(architecture): batch-runner.sh has no --cli flag

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,7 +68,7 @@ batch-input.tsv    →  batch-runner.sh  →  N × headless CLI workers
                     (tracks progress)
 ```
 
-Each worker is a headless AI CLI instance — the bundled `batch-runner.sh` supports multiple CLIs via the `--cli` flag (`--cli claude` or `--cli opencode`). See the Headless / Batch Mode table in `AGENTS.md`. Workers produce:
+Each worker is a headless AI CLI instance — the bundled `batch-runner.sh` currently runs `claude -p` workers only. See the Headless / Batch Mode table in `AGENTS.md`. Workers produce:
 - Report .md
 - PDF
 - Tracker TSV line


### PR DESCRIPTION
## What does this PR do?

`docs/ARCHITECTURE.md` credits the bundled `batch-runner.sh` with a `--cli` flag that the script does not implement and its own header explicitly disclaims. This corrects that one sentence to describe what the runner actually does, keeping the pointer to the Headless / Batch Mode table in `AGENTS.md`. One line, one file.

The doc, at `docs/ARCHITECTURE.md:71`:

> Each worker is a headless AI CLI instance — the bundled batch-runner.sh supports multiple CLIs via the --cli flag (--cli claude or --cli opencode). 

`batch-runner.sh` doesn't have that flag. Its argument loop matches `--parallel`, `--model`, `--min-score` and friends, and the catch-all rejects anything else, so following the doc fails immediately:

    $ ./batch/batch-runner.sh --cli opencode
    Unknown option: --cli

The note at the top of the script says the opposite of the doc:

> NOTE: This script is Claude Code-specific. It uses claude -p with --dangerously-skip-permissions and --append-system-prompt-file flags that are not available in other CLIs. Multi-CLI support is out of scope for now — contributions welcome.

The sentence looks like it came in with #707, which added the OpenCode docs without touching `batch/`. `--cli` does exist on `doctor.mjs` (per OPENCODE.md), which may be where the wire got crossed. #738 would add `--cli` to the batch runner too, so this line becomes accurate again the day multi-CLI batch lands — until then it sends anyone following the doc into `Unknown option`.

## Related issue

None. Documentation fix, exempt from issue-first per the instruction.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.
