### PR TITLE
fix(batch): retry state updates and lock reservations to prevent worker silent drops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ output/*
 batch/logs/*
 !batch/logs/.gitkeep
 batch/batch-state.tsv
+batch/batch-state-recovery.d/
 batch/batch-input.tsv
 batch/tracker-additions/**/*.tsv
 !batch/tracker-additions/.gitkeep

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -490,6 +490,12 @@ RECOVERY_DIR="$BATCH_DIR/batch-state-recovery.d"
 
 append_recovery_record() {
   local id="$1" url="$2" status="$3" started="$4" completed="$5" report_num="$6" score="$7" error="$8" retries="$9"
+  # Same rationale as update_state_unlocked: a literal tab/newline/CR in
+  # $error would split this single-line record into extra fields or rows,
+  # corrupting the record and the state row it later reconciles into.
+  error=${error//$'\r'/ }
+  error=${error//$'\n'/ }
+  error=${error//$'\t'/ }
   mkdir -p "$RECOVERY_DIR" || return 1
   local rec
   rec=$(mktemp "$RECOVERY_DIR/rec-XXXXXX") || return 1

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -471,64 +471,76 @@ update_state() {
   run_with_state_lock update_state_unlocked "$@"
 }
 
-# Durable last-resort record of a state transition that could NOT be written
-# into $STATE_FILE (state-lock exhausted its retries). A plain `>>` append is
-# used deliberately instead of the mkdir-based lock: it's a single atomic
-# write syscall for one line, so it doesn't need mutual exclusion the way a
-# full-file read-modify-write does, and it must not itself depend on the
-# lock that just failed. This is the durability half of the fix — a failed
-# write here would mean genuinely losing the transition, so callers of
-# update_state_retrying can trust that once THIS returns success, the
-# transition is recorded somewhere on disk even if not yet merged into
-# $STATE_FILE. reconcile_recovery_records() (called once at the start of the
-# next run, before any lock contention exists) merges these back in.
-RECOVERY_FILE="$BATCH_DIR/batch-state-recovery.tsv"
+# Durable last-resort records of state transitions that could NOT be written
+# into $STATE_FILE (state-lock exhausted its retries). ONE FILE PER RECORD:
+# each failed transition gets its own uniquely-named file via mktemp
+# (O_CREAT|O_EXCL — atomic creation, guaranteed-unique name), so no two
+# workers ever write to the same file and no shared-file truncate/append
+# race can exist on any platform. That matters here because recovery writes
+# are CORRELATED, not independent: they fire exactly when the state lock is
+# jammed, which makes all parallel workers fail (and try to record) at the
+# same moment — a shared recovery file is racing precisely when it is
+# needed most (PR #2417 review). This mechanism must also never depend on
+# the state lock that just failed, and it doesn't: creation is the only
+# synchronization. reconcile_recovery_records() (start of the next run,
+# single-threaded, before any worker spawns) merges each record into
+# $STATE_FILE and deletes its file only on success — there is no
+# rewrite-and-rename step, so nothing here needs cross-filesystem atomicity.
+RECOVERY_DIR="$BATCH_DIR/batch-state-recovery.d"
 
 append_recovery_record() {
   local id="$1" url="$2" status="$3" started="$4" completed="$5" report_num="$6" score="$7" error="$8" retries="$9"
-  if [[ ! -f "$RECOVERY_FILE" ]]; then
-    printf 'id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries\n' > "$RECOVERY_FILE"
-  fi
+  mkdir -p "$RECOVERY_DIR" || return 1
+  local rec
+  rec=$(mktemp "$RECOVERY_DIR/rec-XXXXXX") || return 1
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-    "$id" "$url" "$status" "$started" "$completed" "$report_num" "$score" "$error" "$retries" >> "$RECOVERY_FILE"
+    "$id" "$url" "$status" "$started" "$completed" "$report_num" "$score" "$error" "$retries" > "$rec"
 }
 
 # Merge any recovery records left by a prior run into $STATE_FILE. Runs
 # single-threaded at the very start of main(), before any worker is spawned,
 # so there is no lock contention here — this is the one place these records
-# are guaranteed a clean shot at the lock.
+# are guaranteed a clean shot at the lock. Each record file is deleted only
+# after its transition lands in $STATE_FILE; failures leave the file in
+# place for the run after that.
 reconcile_recovery_records() {
-  [[ -f "$RECOVERY_FILE" ]] || return 0
+  [[ -d "$RECOVERY_DIR" ]] || return 0
 
-  local pending
-  pending=$(tail -n +2 "$RECOVERY_FILE" | grep -c '[^[:space:]]' 2>/dev/null || true)
-  pending="${pending:-0}"
-  (( pending == 0 )) && { rm -f "$RECOVERY_FILE"; return 0; }
+  local -a rec_files=()
+  local f
+  for f in "$RECOVERY_DIR"/rec-*; do
+    [[ -f "$f" ]] || continue
+    rec_files+=("$f")
+  done
+  if (( ${#rec_files[@]} == 0 )); then
+    rmdir "$RECOVERY_DIR" 2>/dev/null || true
+    return 0
+  fi
 
-  echo "=== Reconciling $pending recovery record(s) from a prior interrupted run ==="
+  echo "=== Reconciling ${#rec_files[@]} recovery record(s) from a prior interrupted run ==="
   local merged=0 still_failed=0
-  local still_failed_file
-  still_failed_file=$(mktemp "${TMPDIR:-/tmp}/batch-recovery-retry.XXXXXX")
-  printf 'id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries\n' > "$still_failed_file"
-
-  while IFS=$'\t' read -r rid rurl rstatus rstarted rcompleted rreport rscore rerror rretries; do
-    [[ "$rid" == "id" ]] && continue
-    [[ -z "$rid" ]] && continue
+  local rid rurl rstatus rstarted rcompleted rreport rscore rerror rretries
+  for f in "${rec_files[@]}"; do
+    rid=""
+    IFS=$'\t' read -r rid rurl rstatus rstarted rcompleted rreport rscore rerror rretries < "$f" || true
+    if [[ -z "$rid" ]]; then
+      echo "    WARN: discarding unreadable recovery record $f" >&2
+      rm -f "$f"
+      continue
+    fi
     if update_state "$rid" "$rurl" "$rstatus" "$rstarted" "$rcompleted" "$rreport" "$rscore" "$rerror" "$rretries"; then
+      rm -f "$f"
       merged=$((merged + 1))
     else
       still_failed=$((still_failed + 1))
-      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-        "$rid" "$rurl" "$rstatus" "$rstarted" "$rcompleted" "$rreport" "$rscore" "$rerror" "$rretries" >> "$still_failed_file"
     fi
-  done < "$RECOVERY_FILE"
+  done
 
   echo "    Merged: $merged | Still unrecovered: $still_failed"
   if (( still_failed > 0 )); then
-    echo "    WARN: $still_failed record(s) could not be merged even single-threaded — check $STATE_LOCK_DIR for a genuinely stuck lock." >&2
-    mv "$still_failed_file" "$RECOVERY_FILE"
+    echo "    WARN: $still_failed record(s) could not be merged even single-threaded — check $STATE_LOCK_DIR for a genuinely stuck lock. Unmerged records remain in $RECOVERY_DIR." >&2
   else
-    rm -f "$still_failed_file" "$RECOVERY_FILE"
+    rmdir "$RECOVERY_DIR" 2>/dev/null || true
   fi
 }
 
@@ -555,9 +567,9 @@ update_state_retrying() {
     fi
   done
   if append_recovery_record "$@"; then
-    echo "    ⚠️  State update failed after $max_attempts attempts — offer id=$1 status=$3 recorded to $RECOVERY_FILE for reconciliation on next run." >&2
+    echo "    ⚠️  State update failed after $max_attempts attempts — offer id=$1 status=$3 recorded to $RECOVERY_DIR for reconciliation on next run." >&2
   else
-    echo "    ❌ State update failed after $max_attempts attempts AND recovery-log append also failed — offer id=$1 status=$3 was NOT recorded anywhere. It will be retried as pending next run." >&2
+    echo "    ❌ State update failed after $max_attempts attempts AND recovery-record write also failed — offer id=$1 status=$3 was NOT recorded anywhere. It will be retried as pending next run." >&2
   fi
   return 1
 }

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -246,7 +246,10 @@ acquire_state_lock() {
       local stale=false
       local stale_reason=""
 
-      if [[ -n "$lock_pid" ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
+      if [[ -n "$lock_pid" ]] && kill -0 "$lock_pid" 2>/dev/null; then
+        # Lock owner PID is verifiably running — lock is active and MUST NOT be reclaimed.
+        stale=false
+      elif [[ -n "$lock_pid" ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
         stale=true
         stale_reason="PID $lock_pid not running"
       elif [[ "$lock_epoch" =~ ^[0-9]+$ ]]; then
@@ -255,7 +258,7 @@ acquire_state_lock() {
         age=$((now - lock_epoch))
         if (( age >= STATE_LOCK_STALE_AGE_SECONDS )); then
           stale=true
-          stale_reason="lock age ${age}s >= ${STATE_LOCK_STALE_AGE_SECONDS}s (age-based fallback — PID liveness checks are unreliable on Git Bash/Windows)"
+          stale_reason="unverifiable PID lock age ${age}s >= ${STATE_LOCK_STALE_AGE_SECONDS}s"
         fi
       fi
 
@@ -446,21 +449,10 @@ update_state_unlocked() {
 }
 
 update_state() {
-  run_with_state_lock update_state_unlocked "$@"
-}
-
-# Retry wrapper around update_state. Bare `update_state ...` calls under
-# `set -e` will silently kill the entire background worker subshell if a
-# single lock-timeout failure propagates — this wrapper retries a few times
-# and, if it still fails, logs a clear warning and returns non-zero so the
-# CALLER can decide what to do, instead of the process vanishing with no
-# trace (found under --parallel 5 on Git Bash/Windows: ~47 of 50 jobs
-# silently dropped in one run from exactly this).
-update_state_retrying() {
   local attempt=0
   local max_attempts=3
   while (( attempt < max_attempts )); do
-    if update_state "$@"; then
+    if run_with_state_lock update_state_unlocked "$@"; then
       return 0
     fi
     attempt=$((attempt + 1))
@@ -470,7 +462,7 @@ update_state_retrying() {
     fi
   done
   echo "    ❌ State update failed after $max_attempts attempts — offer id=$1 status=$3 was NOT recorded in $STATE_FILE. It will be retried as pending next run." >&2
-  return 1
+  return 0
 }
 
 is_rate_limit_log() {
@@ -489,7 +481,7 @@ mark_paused_rate_limit() {
   completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   local error_msg
   error_msg=$(tail -5 "$log_file" 2>/dev/null | tr '\n' ' ' | cut -c1-200 || echo "session/rate limit reached")
-  update_state_retrying "$id" "$url" "paused_rate_limit" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries" || true
+  update_state "$id" "$url" "paused_rate_limit" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries"
   printf '%s\t%s\t%s\n' "$id" "$report_num" "$error_msg" > "$PAUSE_FILE"
   BATCH_PAUSED=true
 }
@@ -526,18 +518,11 @@ release_report_num() {
 }
 
 reserve_report_num() {
-  run_with_state_lock reserve_report_num_unlocked "$@"
-}
-
-# Retry wrapper — same rationale as update_state_retrying above. A bare
-# `x=$(reserve_report_num ...)` under `set -e` kills the worker subshell
-# silently on a single lock-timeout; this retries and logs instead.
-reserve_report_num_retrying() {
   local attempt=0
   local max_attempts=3
   local result=""
   while (( attempt < max_attempts )); do
-    if result=$(reserve_report_num "$@"); then
+    if result=$(run_with_state_lock reserve_report_num_unlocked "$@"); then
       printf '%s\n' "$result"
       return 0
     fi
@@ -560,7 +545,7 @@ process_offer() {
   local retries
   retries=$(get_retries "$id")
   local report_num
-  if ! report_num=$(reserve_report_num_retrying "$id" "$url" "$started_at" "$retries"); then
+  if ! report_num=$(reserve_report_num "$id" "$url" "$started_at" "$retries"); then
     return 1
   fi
   local date
@@ -672,7 +657,7 @@ process_offer() {
       retries=$((retries + 1))
       local retry_completed_at
       retry_completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-      update_state_retrying "$id" "$url" "rate_limited" "$started_at" "$retry_completed_at" "$report_num" "-" "rate-limit; retrying after ${RATE_LIMIT_SLEEP}s" "$retries" || true
+      update_state "$id" "$url" "rate_limited" "$started_at" "$retry_completed_at" "$report_num" "-" "rate-limit; retrying after ${RATE_LIMIT_SLEEP}s" "$retries"
       echo "    ⏳ Rate limited (attempt $retries/$MAX_RETRIES). Waiting ${RATE_LIMIT_SLEEP}s before retry..."
       sleep "$RATE_LIMIT_SLEEP"
       continue
@@ -752,7 +737,7 @@ process_offer() {
       if (( retries < MAX_RETRIES )); then
         retries=$((retries + 1))
       fi
-      update_state_retrying "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$worker_error_match" "$retries" || true
+      update_state "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$worker_error_match" "$retries"
       release_report_num "$report_num"
       echo "    ❌ Failed (worker-reported, attempt $retries): $worker_error_match"
       return 0
@@ -769,7 +754,7 @@ process_offer() {
       if (( retries < MAX_RETRIES )); then
         retries=$((retries + 1))
       fi
-      update_state_retrying "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "worker exited cleanly but wrote no report file for this report number" "$retries" || true
+      update_state "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "worker exited cleanly but wrote no report file for this report number" "$retries"
       release_report_num "$report_num"
       echo "    ❌ Failed (no report file on disk, attempt $retries)"
       return 0
@@ -778,14 +763,14 @@ process_offer() {
     # Check min-score gate
     if is_decimal_number "$score" && awk -v min="$MIN_SCORE" 'BEGIN{exit !(min > 0)}'; then
       if awk -v score="$score" -v min="$MIN_SCORE" 'BEGIN{exit !(score < min)}'; then
-        update_state_retrying "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries" || true
+        update_state "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries"
         release_report_num "$report_num"
         echo "    ⏭️  Skipped (score: $score < min-score: $MIN_SCORE)"
         return 0
       fi
     fi
 
-    update_state_retrying "$id" "$url" "completed" "$started_at" "$completed_at" "$report_num" "$score" "-" "$retries" || true
+    update_state "$id" "$url" "completed" "$started_at" "$completed_at" "$report_num" "$score" "-" "$retries"
     release_report_num "$report_num"
     echo "    ✅ Completed (score: $score, report: $report_num)"
   elif [[ "$terminal_failure_recorded" == "false" ]]; then
@@ -794,7 +779,7 @@ process_offer() {
     fi
     local error_msg
     error_msg=$(tail -5 "$log_file" 2>/dev/null | tr '\n' ' ' | cut -c1-200 || echo "Unknown error (exit code $exit_code)")
-    update_state_retrying "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries" || true
+    update_state "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries"
     release_report_num "$report_num"
     echo "    ❌ Failed (attempt $retries, exit code $exit_code)"
   fi

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -496,6 +496,10 @@ append_recovery_record() {
   error=${error//$'\r'/ }
   error=${error//$'\n'/ }
   error=${error//$'\t'/ }
+  # \x1f is used as the in-memory delimiter when this record is read back
+  # (see reconcile_recovery_records); strip it here too so a stray unit
+  # separator in $error can't inject a field boundary on the read side.
+  error=${error//$'\x1f'/ }
   mkdir -p "$RECOVERY_DIR" || return 1
   local rec
   rec=$(mktemp "$RECOVERY_DIR/rec-XXXXXX") || return 1
@@ -569,10 +573,18 @@ reconcile_recovery_records() {
   echo "=== Reconciling ${#rec_files[@]} recovery record(s) from a prior interrupted run ==="
   local merged=0 superseded=0 still_failed=0
   local rid rurl rstatus rstarted rcompleted rreport rscore rerror rretries
+  local rline
   local rc
   for f in "${rec_files[@]}"; do
-    rid=""
-    IFS=$'\t' read -r rid rurl rstatus rstarted rcompleted rreport rscore rerror rretries < "$f" || true
+    rline=""
+    # Don't split with `IFS=$'\t' read`: tab is IFS *whitespace*, so a run of
+    # tabs around an empty interior field (e.g. an empty completed_at on a
+    # non-terminal record) collapses to one delimiter and every later field
+    # shifts left, corrupting the merge. Read the line raw, then split on \x1f
+    # (a non-whitespace unit separator that preserves empty fields) after
+    # translating the on-disk tabs to it. Same rationale as process_offer.
+    IFS= read -r rline < "$f" || true
+    IFS=$'\x1f' read -r rid rurl rstatus rstarted rcompleted rreport rscore rerror rretries <<< "${rline//$'\t'/$'\x1f'}"
     if [[ -z "$rid" ]]; then
       echo "    WARN: discarding unreadable recovery record $f" >&2
       rm -f "$f"

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -503,12 +503,55 @@ append_recovery_record() {
     "$id" "$url" "$status" "$started" "$completed" "$report_num" "$score" "$error" "$retries" > "$rec"
 }
 
+# A recovery record is ALWAYS older than whatever $STATE_FILE holds for the
+# same id: the record is only written when the lock was unreachable, so any
+# row present for that id now was written afterwards by a path that did reach
+# the lock. Merging it blindly therefore rolls a finished offer backwards --
+# the score and completed_at are overwritten, and since rate_limited and
+# failed are NOT terminal, the offer re-enters pending selection in main()
+# and gets evaluated a second time. Cost: one lost evaluation plus one
+# duplicate run, on a path that by construction only fires when something
+# already went wrong.
+#
+# Terminal set mirrors the pending-selection guard in main() exactly. Keep
+# the two in sync: adding a terminal status there without adding it here
+# reopens this rollback for that status.
+recovery_record_is_superseded() {
+  local current="$1"
+  [[ "$current" == "completed" || "$current" == "skipped" ]]
+}
+
+# Merge one recovery record, but only into a row that has not already reached
+# a terminal state. The status read happens INSIDE the lock deliberately: a
+# check-then-write gap would let a worker finish between the two and
+# reintroduce the same rollback. get_status is a lock-free reader (plain awk
+# over $STATE_FILE), so calling it here does not re-enter the non-reentrant
+# mkdir lock.
+#
+# Exit codes: 0 merged · 3 superseded (record is stale, caller should drop
+# it) · anything else is a real failure. 3 avoids colliding with the 1 that
+# acquire_state_lock returns when the lock itself is unreachable.
+reconcile_one_unlocked() {
+  local id="$1"
+  local current
+  current=$(get_status "$id")
+  if recovery_record_is_superseded "$current"; then
+    echo "    Superseded: offer id=$id already '$current' in state — discarding stale recovery record (would have rolled it back to '$3')."
+    return 3
+  fi
+  update_state_unlocked "$@"
+}
+
+reconcile_one() {
+  run_with_state_lock reconcile_one_unlocked "$@"
+}
+
 # Merge any recovery records left by a prior run into $STATE_FILE. Runs
 # single-threaded at the very start of main(), before any worker is spawned,
 # so there is no lock contention here — this is the one place these records
 # are guaranteed a clean shot at the lock. Each record file is deleted only
-# after its transition lands in $STATE_FILE; failures leave the file in
-# place for the run after that.
+# after its transition lands in $STATE_FILE (or is found to be superseded);
+# genuine failures leave the file in place for the run after that.
 reconcile_recovery_records() {
   [[ -d "$RECOVERY_DIR" ]] || return 0
 
@@ -524,8 +567,9 @@ reconcile_recovery_records() {
   fi
 
   echo "=== Reconciling ${#rec_files[@]} recovery record(s) from a prior interrupted run ==="
-  local merged=0 still_failed=0
+  local merged=0 superseded=0 still_failed=0
   local rid rurl rstatus rstarted rcompleted rreport rscore rerror rretries
+  local rc
   for f in "${rec_files[@]}"; do
     rid=""
     IFS=$'\t' read -r rid rurl rstatus rstarted rcompleted rreport rscore rerror rretries < "$f" || true
@@ -534,15 +578,23 @@ reconcile_recovery_records() {
       rm -f "$f"
       continue
     fi
-    if update_state "$rid" "$rurl" "$rstatus" "$rstarted" "$rcompleted" "$rreport" "$rscore" "$rerror" "$rretries"; then
+    rc=0
+    reconcile_one "$rid" "$rurl" "$rstatus" "$rstarted" "$rcompleted" "$rreport" "$rscore" "$rerror" "$rretries" || rc=$?
+    if (( rc == 0 )); then
       rm -f "$f"
       merged=$((merged + 1))
+    elif (( rc == 3 )); then
+      # Stale by definition, not a failure — the row it targets already
+      # finished. Dropping the file is correct; keeping it would retry the
+      # same rollback on every subsequent run.
+      rm -f "$f"
+      superseded=$((superseded + 1))
     else
       still_failed=$((still_failed + 1))
     fi
   done
 
-  echo "    Merged: $merged | Still unrecovered: $still_failed"
+  echo "    Merged: $merged | Superseded: $superseded | Still unrecovered: $still_failed"
   if (( still_failed > 0 )); then
     echo "    WARN: $still_failed record(s) could not be merged even single-threaded — check $STATE_LOCK_DIR for a genuinely stuck lock. Unmerged records remain in $RECOVERY_DIR." >&2
   else

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -201,6 +201,13 @@ init_state() {
   fi
 }
 
+# A lock held longer than this is assumed abandoned, independent of the
+# PID-liveness check below. This exists because `kill -0 $pid` is unreliable
+# on Git Bash/Windows (MSYS PIDs from $!/$BASHPID don't reliably map to real
+# Windows process IDs), so a genuinely-dead lock holder can otherwise never
+# be recovered there and every other worker times out waiting for it.
+STATE_LOCK_STALE_AGE_SECONDS=15
+
 acquire_state_lock() {
   if [[ "${STATE_LOCK_DISABLED:-0}" -eq 1 ]]; then
     return 0
@@ -211,13 +218,13 @@ acquire_state_lock() {
 
   while true; do
     if mkdir "$STATE_LOCK_DIR" 2>/dev/null; then
-      if printf '%s\n' "${BASHPID:-$$}" > "$STATE_LOCK_PID_FILE"; then
+      if printf '%s\t%s\n' "${BASHPID:-$$}" "$(date +%s)" > "$STATE_LOCK_PID_FILE"; then
         STATE_LOCK_OWNED=1
         return 0
       fi
       rm -f "$STATE_LOCK_PID_FILE" 2>/dev/null || true
       rmdir "$STATE_LOCK_DIR" 2>/dev/null || true
-      echo "ERROR: Failed to initialize state lock metadata at $STATE_LOCK_DIR"
+      echo "ERROR: Failed to initialize state lock metadata at $STATE_LOCK_DIR" >&2
       return 1
     fi
 
@@ -228,25 +235,42 @@ acquire_state_lock() {
         STATE_LOCK_OWNED=0
         return 0
       fi
-      echo "ERROR: Failed to create state lock directory $STATE_LOCK_DIR"
+      echo "ERROR: Failed to create state lock directory $STATE_LOCK_DIR" >&2
       return 1
     fi
 
     if [[ -f "$STATE_LOCK_PID_FILE" ]]; then
-      local lock_pid
-      lock_pid=$(cat "$STATE_LOCK_PID_FILE" 2>/dev/null || true)
+      local lock_pid lock_epoch
+      lock_pid=$(cut -f1 "$STATE_LOCK_PID_FILE" 2>/dev/null || true)
+      lock_epoch=$(cut -f2 "$STATE_LOCK_PID_FILE" 2>/dev/null || true)
+      local stale=false
+      local stale_reason=""
+
       if [[ -n "$lock_pid" ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
+        stale=true
+        stale_reason="PID $lock_pid not running"
+      elif [[ "$lock_epoch" =~ ^[0-9]+$ ]]; then
+        local now age
+        now=$(date +%s)
+        age=$((now - lock_epoch))
+        if (( age >= STATE_LOCK_STALE_AGE_SECONDS )); then
+          stale=true
+          stale_reason="lock age ${age}s >= ${STATE_LOCK_STALE_AGE_SECONDS}s (age-based fallback — PID liveness checks are unreliable on Git Bash/Windows)"
+        fi
+      fi
+
+      if [[ "$stale" == "true" ]]; then
         rm -f "$STATE_LOCK_PID_FILE"
         if rmdir "$STATE_LOCK_DIR" 2>/dev/null; then
-          echo "WARN: Recovered stale state lock (PID $lock_pid not running)."
+          echo "WARN: Recovered stale state lock ($stale_reason)." >&2
           continue
         fi
       fi
     fi
 
     if (( waited >= max_waits )); then
-      echo "ERROR: Timed out waiting for state lock at $STATE_LOCK_DIR"
-      echo "If no batch-runner worker is active, remove the stale lock directory."
+      echo "ERROR: Timed out waiting for state lock at $STATE_LOCK_DIR" >&2
+      echo "If no batch-runner worker is active, remove the stale lock directory." >&2
       return 1
     fi
 
@@ -425,6 +449,30 @@ update_state() {
   run_with_state_lock update_state_unlocked "$@"
 }
 
+# Retry wrapper around update_state. Bare `update_state ...` calls under
+# `set -e` will silently kill the entire background worker subshell if a
+# single lock-timeout failure propagates — this wrapper retries a few times
+# and, if it still fails, logs a clear warning and returns non-zero so the
+# CALLER can decide what to do, instead of the process vanishing with no
+# trace (found under --parallel 5 on Git Bash/Windows: ~47 of 50 jobs
+# silently dropped in one run from exactly this).
+update_state_retrying() {
+  local attempt=0
+  local max_attempts=3
+  while (( attempt < max_attempts )); do
+    if update_state "$@"; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    if (( attempt < max_attempts )); then
+      echo "    ⚠️  State update failed (attempt $attempt/$max_attempts), retrying in 2s..." >&2
+      sleep 2
+    fi
+  done
+  echo "    ❌ State update failed after $max_attempts attempts — offer id=$1 status=$3 was NOT recorded in $STATE_FILE. It will be retried as pending next run." >&2
+  return 1
+}
+
 is_rate_limit_log() {
   local log_file="$1"
   grep -Eiq '(rate limit|rate_limit|too many requests|429|quota exceeded|try again later|temporarily unavailable)' "$log_file"
@@ -441,7 +489,7 @@ mark_paused_rate_limit() {
   completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   local error_msg
   error_msg=$(tail -5 "$log_file" 2>/dev/null | tr '\n' ' ' | cut -c1-200 || echo "session/rate limit reached")
-  update_state "$id" "$url" "paused_rate_limit" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries"
+  update_state_retrying "$id" "$url" "paused_rate_limit" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries" || true
   printf '%s\t%s\t%s\n' "$id" "$report_num" "$error_msg" > "$PAUSE_FILE"
   BATCH_PAUSED=true
 }
@@ -481,6 +529,28 @@ reserve_report_num() {
   run_with_state_lock reserve_report_num_unlocked "$@"
 }
 
+# Retry wrapper — same rationale as update_state_retrying above. A bare
+# `x=$(reserve_report_num ...)` under `set -e` kills the worker subshell
+# silently on a single lock-timeout; this retries and logs instead.
+reserve_report_num_retrying() {
+  local attempt=0
+  local max_attempts=3
+  local result=""
+  while (( attempt < max_attempts )); do
+    if result=$(reserve_report_num "$@"); then
+      printf '%s\n' "$result"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    if (( attempt < max_attempts )); then
+      echo "    ⚠️  Report-number reservation failed (attempt $attempt/$max_attempts), retrying in 2s..." >&2
+      sleep 2
+    fi
+  done
+  echo "    ❌ Report-number reservation failed after $max_attempts attempts for offer id=$1 — leaving it pending for next run." >&2
+  return 1
+}
+
 # Process a single offer
 process_offer() {
   local id="$1" url="$2" source="$3" notes="$4"
@@ -490,7 +560,9 @@ process_offer() {
   local retries
   retries=$(get_retries "$id")
   local report_num
-  report_num=$(reserve_report_num "$id" "$url" "$started_at" "$retries")
+  if ! report_num=$(reserve_report_num_retrying "$id" "$url" "$started_at" "$retries"); then
+    return 1
+  fi
   local date
   date=$(date +%Y-%m-%d)
   # Use mktemp instead of a predictable /tmp path: a fixed name like
@@ -600,7 +672,7 @@ process_offer() {
       retries=$((retries + 1))
       local retry_completed_at
       retry_completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-      update_state "$id" "$url" "rate_limited" "$started_at" "$retry_completed_at" "$report_num" "-" "rate-limit; retrying after ${RATE_LIMIT_SLEEP}s" "$retries"
+      update_state_retrying "$id" "$url" "rate_limited" "$started_at" "$retry_completed_at" "$report_num" "-" "rate-limit; retrying after ${RATE_LIMIT_SLEEP}s" "$retries" || true
       echo "    ⏳ Rate limited (attempt $retries/$MAX_RETRIES). Waiting ${RATE_LIMIT_SLEEP}s before retry..."
       sleep "$RATE_LIMIT_SLEEP"
       continue
@@ -680,7 +752,7 @@ process_offer() {
       if (( retries < MAX_RETRIES )); then
         retries=$((retries + 1))
       fi
-      update_state "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$worker_error_match" "$retries"
+      update_state_retrying "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$worker_error_match" "$retries" || true
       release_report_num "$report_num"
       echo "    ❌ Failed (worker-reported, attempt $retries): $worker_error_match"
       return 0
@@ -697,7 +769,7 @@ process_offer() {
       if (( retries < MAX_RETRIES )); then
         retries=$((retries + 1))
       fi
-      update_state "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "worker exited cleanly but wrote no report file for this report number" "$retries"
+      update_state_retrying "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "worker exited cleanly but wrote no report file for this report number" "$retries" || true
       release_report_num "$report_num"
       echo "    ❌ Failed (no report file on disk, attempt $retries)"
       return 0
@@ -706,14 +778,14 @@ process_offer() {
     # Check min-score gate
     if is_decimal_number "$score" && awk -v min="$MIN_SCORE" 'BEGIN{exit !(min > 0)}'; then
       if awk -v score="$score" -v min="$MIN_SCORE" 'BEGIN{exit !(score < min)}'; then
-        update_state "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries"
+        update_state_retrying "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries" || true
         release_report_num "$report_num"
         echo "    ⏭️  Skipped (score: $score < min-score: $MIN_SCORE)"
         return 0
       fi
     fi
 
-    update_state "$id" "$url" "completed" "$started_at" "$completed_at" "$report_num" "$score" "-" "$retries"
+    update_state_retrying "$id" "$url" "completed" "$started_at" "$completed_at" "$report_num" "$score" "-" "$retries" || true
     release_report_num "$report_num"
     echo "    ✅ Completed (score: $score, report: $report_num)"
   elif [[ "$terminal_failure_recorded" == "false" ]]; then
@@ -722,7 +794,7 @@ process_offer() {
     fi
     local error_msg
     error_msg=$(tail -5 "$log_file" 2>/dev/null | tr '\n' ' ' | cut -c1-200 || echo "Unknown error (exit code $exit_code)")
-    update_state "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries"
+    update_state_retrying "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries" || true
     release_report_num "$report_num"
     echo "    ❌ Failed (attempt $retries, exit code $exit_code)"
   fi

--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -246,19 +246,38 @@ acquire_state_lock() {
       local stale=false
       local stale_reason=""
 
+      # SAFETY INVARIANT: never treat the lock as stale while kill -0
+      # positively confirms the recorded PID is still running — a
+      # confirmed-alive owner may still write update_state_unlocked's
+      # rewrite of STATE_FILE, and reclaiming under it would let two
+      # processes rewrite $STATE_FILE.tmp concurrently (real data loss).
+      # The age-based fallback below only ever fires when the PID check
+      # could NOT confirm liveness (empty/missing PID, or kill -0 itself
+      # reported not-running) — it narrows, but does not replace, the PID
+      # check. This intentionally leaves one Windows/Git-Bash edge case
+      # unhandled: a `kill -0` FALSE POSITIVE (reports alive for a PID
+      # that Windows has actually reused for an unrelated process). That
+      # gap is accepted because the alternative — reclaiming while any
+      # chance remains the owner is genuinely alive — risks silent
+      # concurrent-write corruption, which is worse than this lock
+      # occasionally timing out (recoverable via retry) in that rare case.
+      local pid_confirmed_alive=false
       if [[ -n "$lock_pid" ]] && kill -0 "$lock_pid" 2>/dev/null; then
-        # Lock owner PID is verifiably running — lock is active and MUST NOT be reclaimed.
-        stale=false
-      elif [[ -n "$lock_pid" ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
-        stale=true
-        stale_reason="PID $lock_pid not running"
-      elif [[ "$lock_epoch" =~ ^[0-9]+$ ]]; then
-        local now age
-        now=$(date +%s)
-        age=$((now - lock_epoch))
-        if (( age >= STATE_LOCK_STALE_AGE_SECONDS )); then
+        pid_confirmed_alive=true
+      fi
+
+      if [[ "$pid_confirmed_alive" == "false" ]]; then
+        if [[ -n "$lock_pid" ]]; then
           stale=true
-          stale_reason="unverifiable PID lock age ${age}s >= ${STATE_LOCK_STALE_AGE_SECONDS}s"
+          stale_reason="PID $lock_pid not running"
+        elif [[ "$lock_epoch" =~ ^[0-9]+$ ]]; then
+          local now age
+          now=$(date +%s)
+          age=$((now - lock_epoch))
+          if (( age >= STATE_LOCK_STALE_AGE_SECONDS )); then
+            stale=true
+            stale_reason="lock age ${age}s >= ${STATE_LOCK_STALE_AGE_SECONDS}s (no PID recorded to check liveness against)"
+          fi
         fi
       fi
 
@@ -449,10 +468,84 @@ update_state_unlocked() {
 }
 
 update_state() {
+  run_with_state_lock update_state_unlocked "$@"
+}
+
+# Durable last-resort record of a state transition that could NOT be written
+# into $STATE_FILE (state-lock exhausted its retries). A plain `>>` append is
+# used deliberately instead of the mkdir-based lock: it's a single atomic
+# write syscall for one line, so it doesn't need mutual exclusion the way a
+# full-file read-modify-write does, and it must not itself depend on the
+# lock that just failed. This is the durability half of the fix — a failed
+# write here would mean genuinely losing the transition, so callers of
+# update_state_retrying can trust that once THIS returns success, the
+# transition is recorded somewhere on disk even if not yet merged into
+# $STATE_FILE. reconcile_recovery_records() (called once at the start of the
+# next run, before any lock contention exists) merges these back in.
+RECOVERY_FILE="$BATCH_DIR/batch-state-recovery.tsv"
+
+append_recovery_record() {
+  local id="$1" url="$2" status="$3" started="$4" completed="$5" report_num="$6" score="$7" error="$8" retries="$9"
+  if [[ ! -f "$RECOVERY_FILE" ]]; then
+    printf 'id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries\n' > "$RECOVERY_FILE"
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$id" "$url" "$status" "$started" "$completed" "$report_num" "$score" "$error" "$retries" >> "$RECOVERY_FILE"
+}
+
+# Merge any recovery records left by a prior run into $STATE_FILE. Runs
+# single-threaded at the very start of main(), before any worker is spawned,
+# so there is no lock contention here — this is the one place these records
+# are guaranteed a clean shot at the lock.
+reconcile_recovery_records() {
+  [[ -f "$RECOVERY_FILE" ]] || return 0
+
+  local pending
+  pending=$(tail -n +2 "$RECOVERY_FILE" | grep -c '[^[:space:]]' 2>/dev/null || true)
+  pending="${pending:-0}"
+  (( pending == 0 )) && { rm -f "$RECOVERY_FILE"; return 0; }
+
+  echo "=== Reconciling $pending recovery record(s) from a prior interrupted run ==="
+  local merged=0 still_failed=0
+  local still_failed_file
+  still_failed_file=$(mktemp "${TMPDIR:-/tmp}/batch-recovery-retry.XXXXXX")
+  printf 'id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries\n' > "$still_failed_file"
+
+  while IFS=$'\t' read -r rid rurl rstatus rstarted rcompleted rreport rscore rerror rretries; do
+    [[ "$rid" == "id" ]] && continue
+    [[ -z "$rid" ]] && continue
+    if update_state "$rid" "$rurl" "$rstatus" "$rstarted" "$rcompleted" "$rreport" "$rscore" "$rerror" "$rretries"; then
+      merged=$((merged + 1))
+    else
+      still_failed=$((still_failed + 1))
+      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$rid" "$rurl" "$rstatus" "$rstarted" "$rcompleted" "$rreport" "$rscore" "$rerror" "$rretries" >> "$still_failed_file"
+    fi
+  done < "$RECOVERY_FILE"
+
+  echo "    Merged: $merged | Still unrecovered: $still_failed"
+  if (( still_failed > 0 )); then
+    echo "    WARN: $still_failed record(s) could not be merged even single-threaded — check $STATE_LOCK_DIR for a genuinely stuck lock." >&2
+    mv "$still_failed_file" "$RECOVERY_FILE"
+  else
+    rm -f "$still_failed_file" "$RECOVERY_FILE"
+  fi
+}
+
+# Retry wrapper around update_state. Bare `update_state ...` calls under
+# `set -e` will silently kill the entire background worker subshell if a
+# single lock-timeout failure propagates — this wrapper retries a few times
+# and, if it still fails, falls back to append_recovery_record so the
+# transition is never actually lost (only delayed until the next run's
+# reconcile step), then logs a clear warning and returns non-zero so the
+# CALLER can still decide whether to skip side effects that assumed success
+# (found under --parallel 5 on Git Bash/Windows: ~47 of 50 jobs silently
+# dropped in one run from exactly this before the retry+recovery-log fix).
+update_state_retrying() {
   local attempt=0
   local max_attempts=3
   while (( attempt < max_attempts )); do
-    if run_with_state_lock update_state_unlocked "$@"; then
+    if update_state "$@"; then
       return 0
     fi
     attempt=$((attempt + 1))
@@ -461,8 +554,12 @@ update_state() {
       sleep 2
     fi
   done
-  echo "    ❌ State update failed after $max_attempts attempts — offer id=$1 status=$3 was NOT recorded in $STATE_FILE. It will be retried as pending next run." >&2
-  return 0
+  if append_recovery_record "$@"; then
+    echo "    ⚠️  State update failed after $max_attempts attempts — offer id=$1 status=$3 recorded to $RECOVERY_FILE for reconciliation on next run." >&2
+  else
+    echo "    ❌ State update failed after $max_attempts attempts AND recovery-log append also failed — offer id=$1 status=$3 was NOT recorded anywhere. It will be retried as pending next run." >&2
+  fi
+  return 1
 }
 
 is_rate_limit_log() {
@@ -481,7 +578,7 @@ mark_paused_rate_limit() {
   completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   local error_msg
   error_msg=$(tail -5 "$log_file" 2>/dev/null | tr '\n' ' ' | cut -c1-200 || echo "session/rate limit reached")
-  update_state "$id" "$url" "paused_rate_limit" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries"
+  update_state_retrying "$id" "$url" "paused_rate_limit" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries" || true
   printf '%s\t%s\t%s\n' "$id" "$report_num" "$error_msg" > "$PAUSE_FILE"
   BATCH_PAUSED=true
 }
@@ -518,11 +615,18 @@ release_report_num() {
 }
 
 reserve_report_num() {
+  run_with_state_lock reserve_report_num_unlocked "$@"
+}
+
+# Retry wrapper — same rationale as update_state_retrying above. A bare
+# `x=$(reserve_report_num ...)` under `set -e` kills the worker subshell
+# silently on a single lock-timeout; this retries and logs instead.
+reserve_report_num_retrying() {
   local attempt=0
   local max_attempts=3
   local result=""
   while (( attempt < max_attempts )); do
-    if result=$(run_with_state_lock reserve_report_num_unlocked "$@"); then
+    if result=$(reserve_report_num "$@"); then
       printf '%s\n' "$result"
       return 0
     fi
@@ -545,7 +649,7 @@ process_offer() {
   local retries
   retries=$(get_retries "$id")
   local report_num
-  if ! report_num=$(reserve_report_num "$id" "$url" "$started_at" "$retries"); then
+  if ! report_num=$(reserve_report_num_retrying "$id" "$url" "$started_at" "$retries"); then
     return 1
   fi
   local date
@@ -657,7 +761,7 @@ process_offer() {
       retries=$((retries + 1))
       local retry_completed_at
       retry_completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-      update_state "$id" "$url" "rate_limited" "$started_at" "$retry_completed_at" "$report_num" "-" "rate-limit; retrying after ${RATE_LIMIT_SLEEP}s" "$retries"
+      update_state_retrying "$id" "$url" "rate_limited" "$started_at" "$retry_completed_at" "$report_num" "-" "rate-limit; retrying after ${RATE_LIMIT_SLEEP}s" "$retries" || true
       echo "    ⏳ Rate limited (attempt $retries/$MAX_RETRIES). Waiting ${RATE_LIMIT_SLEEP}s before retry..."
       sleep "$RATE_LIMIT_SLEEP"
       continue
@@ -737,7 +841,7 @@ process_offer() {
       if (( retries < MAX_RETRIES )); then
         retries=$((retries + 1))
       fi
-      update_state "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$worker_error_match" "$retries"
+      update_state_retrying "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$worker_error_match" "$retries" || true
       release_report_num "$report_num"
       echo "    ❌ Failed (worker-reported, attempt $retries): $worker_error_match"
       return 0
@@ -754,7 +858,7 @@ process_offer() {
       if (( retries < MAX_RETRIES )); then
         retries=$((retries + 1))
       fi
-      update_state "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "worker exited cleanly but wrote no report file for this report number" "$retries"
+      update_state_retrying "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "worker exited cleanly but wrote no report file for this report number" "$retries" || true
       release_report_num "$report_num"
       echo "    ❌ Failed (no report file on disk, attempt $retries)"
       return 0
@@ -763,14 +867,14 @@ process_offer() {
     # Check min-score gate
     if is_decimal_number "$score" && awk -v min="$MIN_SCORE" 'BEGIN{exit !(min > 0)}'; then
       if awk -v score="$score" -v min="$MIN_SCORE" 'BEGIN{exit !(score < min)}'; then
-        update_state "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries"
+        update_state_retrying "$id" "$url" "skipped" "$started_at" "$completed_at" "$report_num" "$score" "below-min-score" "$retries" || true
         release_report_num "$report_num"
         echo "    ⏭️  Skipped (score: $score < min-score: $MIN_SCORE)"
         return 0
       fi
     fi
 
-    update_state "$id" "$url" "completed" "$started_at" "$completed_at" "$report_num" "$score" "-" "$retries"
+    update_state_retrying "$id" "$url" "completed" "$started_at" "$completed_at" "$report_num" "$score" "-" "$retries" || true
     release_report_num "$report_num"
     echo "    ✅ Completed (score: $score, report: $report_num)"
   elif [[ "$terminal_failure_recorded" == "false" ]]; then
@@ -779,7 +883,7 @@ process_offer() {
     fi
     local error_msg
     error_msg=$(tail -5 "$log_file" 2>/dev/null | tr '\n' ' ' | cut -c1-200 || echo "Unknown error (exit code $exit_code)")
-    update_state "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries"
+    update_state_retrying "$id" "$url" "failed" "$started_at" "$completed_at" "$report_num" "-" "$error_msg" "$retries" || true
     release_report_num "$report_num"
     echo "    ❌ Failed (attempt $retries, exit code $exit_code)"
   fi
@@ -973,6 +1077,10 @@ main() {
   fi
 
   init_state
+
+  if [[ "$DRY_RUN" == "false" ]]; then
+    reconcile_recovery_records
+  fi
 
   # Count input offers (skip header, ignore blank lines)
   local total_input

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9347,6 +9347,78 @@ try {
   fail(`Recovery-record reconcile test crashed: ${e.message}`);
 }
 
+// ── 13c. RECOVERY-RECORD RECONCILE MUST NOT SHIFT FIELDS ON EMPTY COLUMNS ──
+
+console.log('\n13c. Recovery-record reconcile field alignment (empty interior columns)');
+
+try {
+  const tmp = mkdtempSync(join(tmpdir(), 'co-batch-recon2-'));
+  const batchDir = join(tmp, 'batch');
+  const recoveryDir = join(batchDir, 'batch-state-recovery.d');
+  const fakeBin = join(tmp, 'bin');
+  mkdirSync(recoveryDir, { recursive: true });
+  mkdirSync(join(tmp, 'reports'), { recursive: true });
+  mkdirSync(join(tmp, 'data'), { recursive: true });
+  mkdirSync(fakeBin, { recursive: true });
+
+  writeFileSync(join(batchDir, 'batch-runner.sh'), readFileSync(join(ROOT, 'batch/batch-runner.sh'), 'utf-8').replace(/\r\n/g, '\n'));
+  if (process.platform === 'win32') {
+    try { execFileSync(getBash(), ['-c', 'chmod +x batch/batch-runner.sh'], { cwd: tmp }); } catch {}
+  } else {
+    execFileSync('chmod', ['+x', join(batchDir, 'batch-runner.sh')]);
+  }
+  writeFileSync(join(tmp, 'merge-tracker.mjs'), 'console.log("merge fixture");\n');
+  writeFileSync(join(tmp, 'verify-pipeline.mjs'), 'console.log("verify fixture");\n');
+  writeFileSync(join(batchDir, 'batch-prompt.md'), 'URL={{URL}}\nJD={{JD_FILE}}\nREPORT={{REPORT_NUM}}\n');
+  // Same claude stub as test 13/13b: check_prerequisites() aborts before
+  // reconcile runs when claude is absent (CI has no claude). Offer 42 is
+  // terminal, so no worker invokes it.
+  writeFileSync(join(fakeBin, 'claude'), '#!/usr/bin/env bash\nexit 0\n');
+  if (process.platform === 'win32') {
+    try { execFileSync(getBash(), ['-c', 'chmod +x bin/claude'], { cwd: tmp }); } catch {}
+  } else {
+    execFileSync('chmod', ['+x', join(fakeBin, 'claude')]);
+  }
+  // Only a terminal offer is in the input, so main() processes nothing and the
+  // merged row below is written solely by reconcile_recovery_records().
+  writeFileSync(join(batchDir, 'batch-input.tsv'), [
+    'id\turl\tsource\tnotes',
+    '42\thttps://example.com/forty-two\tfixture\t-',
+  ].join('\n') + '\n');
+
+  // Offer 99 is NON-terminal (failed), so its recovery record takes the merge
+  // path (not the superseded path). The record has an empty completed_at
+  // (column 5) and an empty score (column 7) — exactly the interior columns a
+  // tab-collapsing `IFS=$'\t' read` would drop, shifting every later field left.
+  writeFileSync(join(batchDir, 'batch-state.tsv'), [
+    'id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries',
+    '42\thttps://example.com/forty-two\tcompleted\t2026-08-07T00:00:00Z\t2026-08-07T00:05:00Z\t900\t8.5\t\t1',
+    '99\thttps://example.com/99\tfailed\t2026-08-06T00:00:00Z\t\t800\t\tolderr\t1',
+  ].join('\n') + '\n');
+  writeFileSync(join(recoveryDir, 'rec-shift1'),
+    '99\thttps://example.com/99\tfailed\t2026-08-07T09:00:00Z\t\t901\t\trate limited\t2\n');
+
+  run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1', '--rate-limit-sleep', '0'], {
+    cwd: tmp,
+    env: { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}` },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const stateLines = readFileSync(join(batchDir, 'batch-state.tsv'), 'utf-8').trim().split('\n');
+  const row = (stateLines.find(l => l.startsWith('99\t')) || '').split('\t');
+  const [, , status99, , completed99, report99, score99, error99, retries99] = row;
+
+  if (status99 === 'failed' && completed99 === '' && report99 === '901' && score99 === '' && error99 === 'rate limited' && retries99 === '2') {
+    pass('reconcile merges a record with empty interior columns without shifting fields');
+  } else {
+    fail(`reconcile shifted fields on empty columns: status=${status99} completed_at=${completed99} report=${report99} score=${score99} error=${error99} retries=${retries99}`);
+  }
+
+  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+} catch (e) {
+  fail(`Recovery-record field-alignment test crashed: ${e.message}`);
+}
+
 // ── 14. BATCH SPEND TIER MODEL ROUTING ───────────────────────────
 
 console.log('\n14. Batch spend_tier model routing');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9276,9 +9276,11 @@ try {
   const tmp = mkdtempSync(join(tmpdir(), 'co-batch-recon-'));
   const batchDir = join(tmp, 'batch');
   const recoveryDir = join(batchDir, 'batch-state-recovery.d');
+  const fakeBin = join(tmp, 'bin');
   mkdirSync(recoveryDir, { recursive: true });
   mkdirSync(join(tmp, 'reports'), { recursive: true });
   mkdirSync(join(tmp, 'data'), { recursive: true });
+  mkdirSync(fakeBin, { recursive: true });
 
   writeFileSync(join(batchDir, 'batch-runner.sh'), readFileSync(join(ROOT, 'batch/batch-runner.sh'), 'utf-8').replace(/\r\n/g, '\n'));
   if (process.platform === 'win32') {
@@ -9307,9 +9309,20 @@ try {
   writeFileSync(join(recoveryDir, 'rec-stale1'),
     '42\thttps://example.com/forty-two\trate_limited\t2026-08-07T00:00:00Z\t\t900\t-\trate limited\t1\n');
 
+  // check_prerequisites() aborts main() with "claude CLI not found" before
+  // reconcile_recovery_records() runs when `claude` is absent from PATH, which
+  // is the case on CI runners. Stub it (offer 42 is terminal, so no worker ever
+  // invokes it) so the reconcile path is actually exercised, matching test 13.
+  writeFileSync(join(fakeBin, 'claude'), '#!/usr/bin/env bash\nexit 0\n');
+  if (process.platform === 'win32') {
+    try { execFileSync(getBash(), ['-c', 'chmod +x bin/claude'], { cwd: tmp }); } catch {}
+  } else {
+    execFileSync('chmod', ['+x', join(fakeBin, 'claude')]);
+  }
+
   run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1', '--rate-limit-sleep', '0'], {
     cwd: tmp,
-    env: process.env,
+    env: { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH}` },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1095,9 +1095,18 @@ for (const f of userFiles) {
 }
 
 const batchRunnerSource = readFile('batch/batch-runner.sh');
-const minScoreSkipIndex = batchRunnerSource.indexOf('update_state "$id" "$url" "skipped"');
-const minScoreReturnIndex = batchRunnerSource.indexOf('return 0', minScoreSkipIndex);
-const completedStateIndex = batchRunnerSource.indexOf('update_state "$id" "$url" "completed"', minScoreSkipIndex);
+// Match any update_state entrypoint (bare, _retrying, _unlocked) so this asserts
+// the gate's ordering rather than one spelling of the call.
+const SKIPPED_STATE_WRITE = /update_state(?:_retrying|_unlocked)? "\$id" "\$url" "skipped"/;
+const COMPLETED_STATE_WRITE = /update_state(?:_retrying|_unlocked)? "\$id" "\$url" "completed"/;
+const minScoreSkipIndex = batchRunnerSource.search(SKIPPED_STATE_WRITE);
+let minScoreReturnIndex = -1;
+let completedStateIndex = -1;
+if (minScoreSkipIndex !== -1) {
+  minScoreReturnIndex = batchRunnerSource.indexOf('return 0', minScoreSkipIndex);
+  const completedOffset = batchRunnerSource.slice(minScoreSkipIndex).search(COMPLETED_STATE_WRITE);
+  completedStateIndex = completedOffset === -1 ? -1 : minScoreSkipIndex + completedOffset;
+}
 if (
   minScoreSkipIndex !== -1 &&
   minScoreReturnIndex !== -1 &&

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9268,6 +9268,72 @@ try {
   fail(`Batch rate-limit pause test crashed: ${e.message}`);
 }
 
+// ── 13b. RECOVERY-RECORD RECONCILE MUST NOT ROLL BACK TERMINAL ROWS ──
+
+console.log('\n13b. Recovery-record reconcile vs terminal state');
+
+try {
+  const tmp = mkdtempSync(join(tmpdir(), 'co-batch-recon-'));
+  const batchDir = join(tmp, 'batch');
+  const recoveryDir = join(batchDir, 'batch-state-recovery.d');
+  mkdirSync(recoveryDir, { recursive: true });
+  mkdirSync(join(tmp, 'reports'), { recursive: true });
+  mkdirSync(join(tmp, 'data'), { recursive: true });
+
+  writeFileSync(join(batchDir, 'batch-runner.sh'), readFileSync(join(ROOT, 'batch/batch-runner.sh'), 'utf-8').replace(/\r\n/g, '\n'));
+  if (process.platform === 'win32') {
+    try { execFileSync(getBash(), ['-c', 'chmod +x batch/batch-runner.sh'], { cwd: tmp }); } catch {}
+  } else {
+    execFileSync('chmod', ['+x', join(batchDir, 'batch-runner.sh')]);
+  }
+  writeFileSync(join(tmp, 'merge-tracker.mjs'), 'console.log("merge fixture");\n');
+  writeFileSync(join(tmp, 'verify-pipeline.mjs'), 'console.log("verify fixture");\n');
+  writeFileSync(join(batchDir, 'batch-prompt.md'), 'URL={{URL}}\nJD={{JD_FILE}}\nREPORT={{REPORT_NUM}}\n');
+  writeFileSync(join(batchDir, 'batch-input.tsv'), [
+    'id\turl\tsource\tnotes',
+    '42\thttps://example.com/forty-two\tfixture\t-',
+  ].join('\n') + '\n');
+
+  // The offer already reached a terminal state, with a score and a
+  // completion timestamp worth protecting.
+  writeFileSync(join(batchDir, 'batch-state.tsv'), [
+    'id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries',
+    '42\thttps://example.com/forty-two\tcompleted\t2026-08-07T00:00:00Z\t2026-08-07T00:05:00Z\t900\t8.5\t\t1',
+  ].join('\n') + '\n');
+
+  // A recovery record written EARLIER, while the lock was jammed, carrying
+  // the pre-success rate_limited transition. Merging it blindly would drop
+  // the score and re-queue the offer (rate_limited is not terminal).
+  writeFileSync(join(recoveryDir, 'rec-stale1'),
+    '42\thttps://example.com/forty-two\trate_limited\t2026-08-07T00:00:00Z\t\t900\t-\trate limited\t1\n');
+
+  run(getBash(), [toBashPath(join(batchDir, 'batch-runner.sh')), '--parallel', '1', '--rate-limit-sleep', '0'], {
+    cwd: tmp,
+    env: process.env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const stateLines = readFileSync(join(batchDir, 'batch-state.tsv'), 'utf-8').trim().split('\n');
+  const row = (stateLines.find(l => l.startsWith('42\t')) || '').split('\t');
+  const [, , rowStatus, , rowCompleted, , rowScore] = row;
+
+  if (rowStatus === 'completed' && rowScore === '8.5' && rowCompleted === '2026-08-07T00:05:00Z') {
+    pass('reconcile leaves a terminal row intact when the recovery record is older');
+  } else {
+    fail(`reconcile rolled back a terminal row: status=${rowStatus} score=${rowScore} completed=${rowCompleted}`);
+  }
+
+  if (!existsSync(join(recoveryDir, 'rec-stale1'))) {
+    pass('reconcile discards the superseded recovery record instead of retrying it every run');
+  } else {
+    fail('superseded recovery record was left in place — it would retry the rollback on every subsequent run');
+  }
+
+  try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+} catch (e) {
+  fail(`Recovery-record reconcile test crashed: ${e.message}`);
+}
+
 // ── 14. BATCH SPEND TIER MODEL ROUTING ───────────────────────────
 
 console.log('\n14. Batch spend_tier model routing');


### PR DESCRIPTION
## Problem

Under `--parallel 5` on Git Bash/Windows, ~47 of 50 jobs finished work that never landed in `batch-state.tsv`. Reports were written but never recorded, so the next run re-evaluated them.

Three compounding faults:

1. Bare `update_state` under `set -e` — one lock timeout unwound the whole worker subshell.
2. `acquire_state_lock` trusted `kill -0` alone. MSYS PIDs do not map to Windows PIDs, so a dead holder could never be reclaimed and everyone else timed out on a lock nobody held.
3. A transition that exhausted its retries was simply lost.

## Changes

- **`update_state_retrying` / `reserve_report_num_retrying`** — absorb transient lock failures instead of killing the worker; return non-zero so callers can skip side effects that assumed success.
- **Age-based lock reclaim (`STATE_LOCK_STALE_AGE_SECONDS=15`)** — fires only when `kill -0` could not confirm liveness. A confirmed-alive owner is never reclaimed, since it may be mid-rewrite of `$STATE_FILE.tmp`. Accepted gap: a `kill -0` false positive (Windows PID reuse) is not handled — a stuck lock is recoverable by retry, concurrent-write corruption is not.
- **Per-record recovery files (`batch/batch-state-recovery.d/`)** — one `mktemp` file per failed transition, never a shared append target. These writes are correlated: they fire when the lock is jammed, so all workers try to record at the same instant.
- **`reconcile_recovery_records`** — merges leftovers single-threaded at the start of `main()`.

## Reconcile only fills non-terminal rows (added in review)

A recovery record is always older than the row it targets, so merging blindly rolled finished offers backwards: `completed`/`8.5` was overwritten back to `rate_limited` with no score, and since `rate_limited` is not terminal the offer was evaluated a second time.

`reconcile_one_unlocked` now reads the status **inside** the lock and declines to write over a terminal row (`completed`/`skipped`, mirroring the guard in `main()`). Reading outside the lock would leave a check-then-write gap. Superseded records are discarded, not retained — keeping them would retry the rollback every run.

## Tests

- **New `13b`** — plants a `completed` row plus an older `rate_limited` record, asserts status, score, and `completed_at` all survive and the stale record is dropped.
- **Fixed min-score-gate assertion** — it searched for literal `update_state`, but the runner calls `update_state_retrying`. `indexOf` returned `-1`, and the assertion is guarded by `!== -1`, so it silently skipped instead of failing. Now matches `update_state(_retrying|_unlocked)?`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from stale or abandoned processing locks.
  * Added automatic retries for state updates and report-number reservations.
  * Preserved failed state updates for later reconciliation and recovery.
  * Added startup recovery for previously interrupted state changes.
  * Processing now stops safely when a report number cannot be reserved.
  * Improved visibility of lock-related failures through clearer error reporting.
  * Strengthened validation of state-write ordering across supported processing modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->