### PR TITLE
feat(scan): add --since, a relative posted-date bound that also stops paging early

### DIFF
--- a/modes/scan.md
+++ b/modes/scan.md
@@ -331,10 +331,11 @@ node scan.mjs --posted-after 2026-07-25 # equivalent on 2026-08-01
 It **filters**, exactly like `--posted-after` does — same semantics as
 `scan-ats-full.mjs`, so the flag means one thing across both scripts.
 
-Unlike `--posted-after`, it is also passed to providers as an **early-stop
-hint**. Providers that return postings newest-first (currently `workday.mjs`)
-can stop paginating once a page's oldest dated posting is past the bound instead
-of grinding to their `max_pages` cap.
+The bound is also passed to providers as an **early-stop hint** — whichever
+lower bound ends up in effect, so `--posted-after` unlocks this too. Providers
+that return postings newest-first (currently `workday.mjs`) can stop paginating
+once a page's oldest dated posting is past that bound instead of grinding to
+their `max_pages` cap.
 
 How much that saves depends on how far the cap sits beyond the window. One
 measured run against an ~18,000-posting Workday tenant at `max_pages: 300`:

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -318,6 +318,44 @@ missing data" rule as every other date/location filter here) — this bounds
 what's filterable, not what's returned. For a relative "N days old" cutoff
 instead of an absolute window, use `max_posting_age_days` in `portals.yml`.
 
+### `--since` — stop paginating stale pages (speed, not filtering)
+
+`--posted-after` filters jobs *after* they are fetched. `--since <days>` is
+different: it is a hint to the **provider**, telling it to stop paginating once
+a page is entirely older than the window.
+
+```bash
+node scan.mjs --since 7        # don't page deeper than ~7 days of history
+```
+
+Only providers that return postings newest-first can act on it — currently
+`workday.mjs`. On a large Workday tenant this is the difference between paging
+to the `max_pages` cap on every run and stopping as soon as the postings go
+stale, which on an 18,000-posting board is minutes of wall-clock and thousands
+of requests spent re-fetching rows the scanner then discards as duplicates.
+
+**It never changes which postings are eligible** — only how deep the scanner
+digs to find them. A posting inside the window is returned either way.
+
+Notes:
+
+- **Off by default.** Pagination depth is configured per-entry with `max_pages`
+  in `portals.yml`, so a default window would silently shorten every existing
+  config. (`scan-ats-full.mjs` *does* default `--since` to 3 days — it has no
+  per-entry depth setting to respect.)
+- **`--posted-after` is used as the window when `--since` is absent.** It
+  already says "nothing older than this date", which is exactly the bound the
+  early-stop needs, so the two never disagree.
+- **Undated postings are unaffected.** Providers are explicitly told not to skip
+  tenants that expose no posting date; `scan.mjs` decides what to do with those
+  downstream, where they pass.
+- A window of 30 days or more effectively never triggers the early stop —
+  Workday's age labels top out at an unbounded "30+ Days Ago" bucket, which is
+  deliberately never treated as an unambiguous age.
+
+Rule of thumb: set `--since` a little wider than your scan interval. Scanning
+weekly, `--since 10` keeps a margin for a skipped run.
+
 ### Cross-listing detection
 
 The `jd_fingerprint` column exists to catch a specific double-submission hazard: the same role posted by the direct employer **and** by a recruitment agency, often with the employer name stripped from the agency listing. URL dedup and company+role dedup both miss this pair because the URLs and company names are different — but agencies rarely rewrite the requirements text, so a near-identical JD body is a reliable signal.

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -333,8 +333,8 @@ It **filters**, exactly like `--posted-after` does — same semantics as
 
 Unlike `--posted-after`, it is also passed to providers as an **early-stop
 hint**. Providers that return postings newest-first (currently `workday.mjs`)
-can stop paginating once a page is entirely past the bound instead of grinding
-to their `max_pages` cap.
+can stop paginating once a page's oldest dated posting is past the bound instead
+of grinding to their `max_pages` cap.
 
 How much that saves depends on how far the cap sits beyond the window. One
 measured run against an ~18,000-posting Workday tenant at `max_pages: 300`:
@@ -346,8 +346,8 @@ result.
 Bounds combine the way you would expect: `--posted-after`, `--since`, and the
 config-level `max_posting_age_days` all set lower bounds, they AND together, and
 **the newest one decides**. The early stop is derived from that same combined
-bound, so pagination never stops while a posting the filters would accept is
-still unfetched.
+bound, so pagination never stops while a *dated* posting the filters would
+accept is still unfetched. Undated postings are the one exception — see below.
 
 Notes:
 
@@ -358,9 +358,16 @@ Notes:
 - **`max_posting_age_days` alone does not enable early stopping.** It constrains
   the bound when a CLI window is present, but on its own it leaves pagination
   depth exactly as it is today.
-- **Undated postings are unaffected.** A posting whose provider exposes no date
-  passes every date filter here, and providers are explicitly told not to skip
-  tenants that expose no dates at all.
+- **Undated postings pass the filters, but the early stop can still cut them
+  off.** A posting whose provider exposes no date passes every date filter here,
+  and a tenant that exposes no dates *at all* is protected — providers are
+  explicitly told not to skip it. A tenant that **mixes** dated and undated
+  postings is not: `workday.mjs` decides the early stop from the page's dated
+  postings only, so once those are past the bound pagination halts and undated
+  postings on later pages are never fetched. This is the one case where the
+  early stop narrows results instead of only saving time. If a tenant's undated
+  postings matter, scan it without a CLI date window — `max_posting_age_days`
+  on its own never enables the early stop.
 - **Invalid values fail immediately** — `--since` with no number, `--since=`,
   zero, negative, and non-finite values all exit rather than silently scanning
   without a window.

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -318,40 +318,49 @@ missing data" rule as every other date/location filter here) — this bounds
 what's filterable, not what's returned. For a relative "N days old" cutoff
 instead of an absolute window, use `max_posting_age_days` in `portals.yml`.
 
-### `--since` — stop paginating stale pages (speed, not filtering)
+### `--since` — a relative posted-date bound that also stops paging early
 
-`--posted-after` filters jobs *after* they are fetched. `--since <days>` is
-different: it is a hint to the **provider**, telling it to stop paginating once
-a page is entirely older than the window.
+`--posted-after` states a lower bound on the posting date absolutely.
+`--since <days>` states the same bound relatively:
 
 ```bash
-node scan.mjs --since 7        # don't page deeper than ~7 days of history
+node scan.mjs --since 7                 # nothing older than 7 days
+node scan.mjs --posted-after 2026-07-25 # equivalent on 2026-08-01
 ```
 
-Only providers that return postings newest-first can act on it — currently
-`workday.mjs`. On a large Workday tenant this is the difference between paging
-to the `max_pages` cap on every run and stopping as soon as the postings go
-stale, which on an 18,000-posting board is minutes of wall-clock and thousands
-of requests spent re-fetching rows the scanner then discards as duplicates.
+It **filters**, exactly like `--posted-after` does — same semantics as
+`scan-ats-full.mjs`, so the flag means one thing across both scripts.
 
-**It never changes which postings are eligible** — only how deep the scanner
-digs to find them. A posting inside the window is returned either way.
+Unlike `--posted-after`, it is also passed to providers as an **early-stop
+hint**. Providers that return postings newest-first (currently `workday.mjs`)
+can stop paginating once a page is entirely past the bound instead of grinding
+to their `max_pages` cap. On a large Workday tenant that is minutes of
+wall-clock and thousands of requests saved per run.
+
+Bounds combine the way you would expect: `--posted-after`, `--since`, and the
+config-level `max_posting_age_days` all set lower bounds, they AND together, and
+**the newest one decides**. The early stop is derived from that same combined
+bound, so pagination never stops while a posting the filters would accept is
+still unfetched.
 
 Notes:
 
-- **Off by default.** Pagination depth is configured per-entry with `max_pages`
-  in `portals.yml`, so a default window would silently shorten every existing
-  config. (`scan-ats-full.mjs` *does* default `--since` to 3 days — it has no
-  per-entry depth setting to respect.)
-- **`--posted-after` is used as the window when `--since` is absent.** It
-  already says "nothing older than this date", which is exactly the bound the
-  early-stop needs, so the two never disagree.
-- **Undated postings are unaffected.** Providers are explicitly told not to skip
-  tenants that expose no posting date; `scan.mjs` decides what to do with those
-  downstream, where they pass.
-- A window of 30 days or more effectively never triggers the early stop —
+- **Off by default.** Pagination depth is otherwise configured per-entry with
+  `max_pages` in `portals.yml`, so a default window would silently shorten every
+  existing config. (`scan-ats-full.mjs` *does* default `--since` to 3 days — it
+  has no per-entry depth setting to respect.)
+- **`max_posting_age_days` alone does not enable early stopping.** It constrains
+  the bound when a CLI window is present, but on its own it leaves pagination
+  depth exactly as it is today.
+- **Undated postings are unaffected.** A posting whose provider exposes no date
+  passes every date filter here, and providers are explicitly told not to skip
+  tenants that expose no dates at all.
+- **Invalid values fail immediately** — `--since` with no number, `--since=`,
+  zero, negative, and non-finite values all exit rather than silently scanning
+  without a window.
+- A window of 30 days or more effectively never triggers the early stop:
   Workday's age labels top out at an unbounded "30+ Days Ago" bucket, which is
-  deliberately never treated as an unambiguous age.
+  deliberately never read as an unambiguous age.
 
 Rule of thumb: set `--since` a little wider than your scan interval. Scanning
 weekly, `--since 10` keeps a margin for a skipped run.

--- a/modes/scan.md
+++ b/modes/scan.md
@@ -334,8 +334,14 @@ It **filters**, exactly like `--posted-after` does — same semantics as
 Unlike `--posted-after`, it is also passed to providers as an **early-stop
 hint**. Providers that return postings newest-first (currently `workday.mjs`)
 can stop paginating once a page is entirely past the bound instead of grinding
-to their `max_pages` cap. On a large Workday tenant that is minutes of
-wall-clock and thousands of requests saved per run.
+to their `max_pages` cap.
+
+How much that saves depends on how far the cap sits beyond the window. One
+measured run against an ~18,000-posting Workday tenant at `max_pages: 300`:
+172s fetching 6,000 postings to the cap, versus 140s fetching 4,880 with
+`--since 3`. The saving grows with the gap — the same entry at its previous
+`max_pages: 700` would have paged nearly three times as deep for the same
+result.
 
 Bounds combine the way you would expect: `--posted-after`, `--since`, and the
 config-level `max_posting_age_days` all set lower bounds, they AND together, and

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -109,8 +109,17 @@ async function fetchPageWithRetry(ctx, api, opts) {
   throw lastErr;
 }
 
-/** True once a page's oldest unambiguously-dated posting is past the --since window. */
-function pageIsPastWindow(pageJobs, sinceMs) {
+/**
+ * True once a page's oldest unambiguously-dated posting is past the --since window.
+ *
+ * Undated postings are invisible here. A page of nothing but undated postings
+ * never stops pagination (the `dated.length === 0` guard), but a page that
+ * mixes stale dated postings with undated ones does — and the undated ones on
+ * later pages are then never fetched, even though scan.mjs's date filters
+ * would have accepted them. Exported for test-all.mjs, which pins that
+ * behaviour so it can't drift without the docs drifting too.
+ */
+export function pageIsPastWindow(pageJobs, sinceMs) {
   if (typeof sinceMs !== 'number') return false;
   const dated = pageJobs.map((j) => j.postedAt).filter((v) => typeof v === 'number');
   if (dated.length === 0) return false;

--- a/scan.mjs
+++ b/scan.mjs
@@ -316,6 +316,51 @@ export function buildPostingAgeFilter(maxAgeDays, now = Date.now()) {
   };
 }
 
+// ── Posted-date lower bound (shared by the filter and the early-stop) ──
+// --posted-after states a lower bound absolutely; --since <days> states the
+// same thing relatively. They AND together with each other and with
+// max_posting_age_days, so the NEWEST bound is what actually decides
+// eligibility. Both consumers must agree on it: the downstream filter and the
+// provider early-stop hint. Kept as one function so they cannot drift.
+
+/**
+ * Collapse --posted-after and --since into a single absolute lower bound.
+ *
+ * @param {string|null} postedAfter - YYYY-MM-DD from --posted-after, or null.
+ * @param {number|null} sinceDays - Positive day count from --since, or null.
+ * @param {number} [now] - Injectable clock for tests.
+ * @returns {string|null} YYYY-MM-DD, the newer of the two, or null if neither.
+ */
+export function resolveEffectiveAfter(postedAfter, sinceDays, now = Date.now()) {
+  // Truncating --since to a date rather than an exact timestamp makes it
+  // marginally more permissive, which is the safe direction for a bound that
+  // also stops pagination.
+  const sinceIso = Number.isFinite(sinceDays) && sinceDays > 0
+    ? new Date(now - sinceDays * 86_400_000).toISOString().slice(0, 10)
+    : null;
+  return [postedAfter, sinceIso].filter(Boolean).reduce((a, b) => (a > b ? a : b), null);
+}
+
+/**
+ * The oldest posting the filters would still accept — the early-stop floor.
+ *
+ * Stopping pagination any NEWER than this would leave eligible postings
+ * unfetched, which is the one thing the optimisation must never do. Returns
+ * null when no CLI window is active: max_posting_age_days constrains the floor
+ * but must not by itself switch early stopping on for configs that never asked.
+ *
+ * @param {string|null} effectiveAfter - Output of resolveEffectiveAfter.
+ * @param {*} maxAgeDays - config.max_posting_age_days (may be absent/invalid).
+ * @param {number} [now] - Injectable clock for tests.
+ * @returns {number|null} Epoch ms floor, or null to disable early stopping.
+ */
+export function resolveEarlyStopMs(effectiveAfter, maxAgeDays, now = Date.now()) {
+  if (!effectiveAfter) return null;
+  const max = Number(maxAgeDays);
+  const ageFloor = Number.isInteger(max) && max > 0 ? now - max * 86_400_000 : -Infinity;
+  return Math.max(Date.parse(`${effectiveAfter}T00:00:00Z`), ageFloor);
+}
+
 // ── Absolute posted-date filter ─────────────────────────────────────
 // CLI-only (--posted-after / --posted-before), unlike the config-driven
 // relative max_posting_age_days above. Both bounds optional and inclusive
@@ -1893,36 +1938,39 @@ async function main() {
     process.exit(1);
   }
 
-  // --since <days>: a lower bound on posting age, passed to providers as an
-  // EARLY-STOP HINT rather than a filter. providers/workday.mjs returns postings
-  // newest-first and can stop paginating once a page is entirely past the window
-  // — but that only fires when ctx carries sinceMs, and scan.mjs never set it, so
-  // every Workday tenant paginated to its max_pages cap on every run regardless
-  // of how stale the deep pages were. On a large tenant that is minutes of
-  // wall-clock and thousands of requests spent re-fetching postings the scanner
-  // then discards as duplicates.
+  // --since <days>: a RELATIVE lower bound on the employer's posting date —
+  // the same thing --posted-after expresses absolutely, and it filters exactly
+  // like it does. Matches scan-ats-full.mjs, which has always treated --since
+  // as a filter; one flag name should not mean two different things.
   //
-  // OFF BY DEFAULT. scan-ats-full.mjs defaults --since to 3 days; scan.mjs must
-  // not, because pagination depth here is configured per-entry via max_pages and
-  // a default window would silently shorten every existing portals.yml.
+  // It additionally unlocks an optimisation. providers/workday.mjs returns
+  // postings newest-first and can stop paginating once a page is entirely past
+  // the window, but that only fires when ctx carries sinceMs — and scan.mjs
+  // built a bare makeHttpCtx(), so every Workday tenant paginated to its
+  // max_pages cap on every run however stale the deep pages were.
   //
-  // --posted-after is honoured as a source when --since is absent: it already
-  // states "nothing older than this date", which is exactly the bound the
-  // early-stop needs. Reusing it keeps one concept instead of two that can
-  // disagree.
+  // Flag presence is tracked separately from its operand. `--since` with no
+  // value, `--since=`, and `--since --posted-after X` must all fail rather than
+  // silently degrade to "no window", which would look like a fast scan that
+  // simply found less — indistinguishable from success. Number.isFinite also
+  // rejects Infinity and 1e309, which pass a bare `> 0` test and would yield an
+  // -Infinity cutoff.
+  const sinceKv = args.find((a) => a.startsWith('--since='));
   const sinceIdx = args.indexOf('--since');
-  const sinceRaw = sinceIdx !== -1 && args[sinceIdx + 1] && !args[sinceIdx + 1].startsWith('--')
-    ? args[sinceIdx + 1]
-    : (args.find((a) => a.startsWith('--since=')) || '').split('=')[1] || null;
-  if (sinceRaw != null && !(Number(sinceRaw) > 0)) {
-    // Gated like --posted-after: a silently-ignored window would look like a
-    // fast scan that simply found less, which is indistinguishable from success.
-    console.error(`Error: --since expects a positive number of days, got "${sinceRaw}"`);
-    process.exit(1);
+  let sinceDays = null;
+  if (sinceIdx !== -1 || sinceKv) {
+    const raw = sinceKv
+      ? sinceKv.slice('--since='.length)
+      : (args[sinceIdx + 1] != null && !args[sinceIdx + 1].startsWith('--') ? args[sinceIdx + 1] : null);
+    const n = raw == null || raw === '' ? NaN : Number(raw);
+    if (!Number.isFinite(n) || n <= 0) {
+      console.error(`Error: --since expects a positive number of days, got ${raw == null || raw === '' ? '(no value)' : `"${raw}"`}`);
+      process.exit(1);
+    }
+    sinceDays = n;
   }
-  const earlyStopSinceMs = sinceRaw != null
-    ? Date.now() - Number(sinceRaw) * 86_400_000
-    : (postedAfter ? Date.parse(`${postedAfter}T00:00:00Z`) : null);
+
+  const effectiveAfter = resolveEffectiveAfter(postedAfter, sinceDays);
 
   // 1. Load providers
   const providers = await loadProviders(PROVIDERS_DIR);
@@ -1965,7 +2013,11 @@ async function main() {
 
   const locationFilter = buildLocationFilter(config.location_filter);
   const postingAgeFilter = buildPostingAgeFilter(config.max_posting_age_days);
-  const postedDateFilter = buildPostedDateFilter(postedAfter, postedBefore);
+  const postedDateFilter = buildPostedDateFilter(effectiveAfter, postedBefore);
+
+  // Same bound the filter above uses, widened by max_posting_age_days when set.
+  // Derived by the same helper so the hint and the filter cannot disagree.
+  const earlyStopSinceMs = resolveEarlyStopMs(effectiveAfter, config.max_posting_age_days);
   const salaryFilter = buildSalaryFilter(config.salary_filter);
   const trustValidator = buildTrustValidator(config.trust_filter);
   const contentFilter = buildContentFilter(config.content_filter);
@@ -2309,7 +2361,9 @@ async function main() {
   if (config.max_posting_age_days != null || totalFilteredPostingAge > 0) {
     console.log(`Filtered by age:       ${totalFilteredPostingAge} removed`);
   }
-  if (postedAfter || postedBefore) {
+  // effectiveAfter, not postedAfter — --since sets a lower bound too, and a
+  // scan that filtered by date should say so regardless of which flag set it.
+  if (effectiveAfter || postedBefore) {
     console.log(`Filtered by posted date: ${totalFilteredPostedDate} removed`);
   }
   if (config.salary_filter || totalFilteredSalary > 0) {

--- a/scan.mjs
+++ b/scan.mjs
@@ -1893,6 +1893,37 @@ async function main() {
     process.exit(1);
   }
 
+  // --since <days>: a lower bound on posting age, passed to providers as an
+  // EARLY-STOP HINT rather than a filter. providers/workday.mjs returns postings
+  // newest-first and can stop paginating once a page is entirely past the window
+  // — but that only fires when ctx carries sinceMs, and scan.mjs never set it, so
+  // every Workday tenant paginated to its max_pages cap on every run regardless
+  // of how stale the deep pages were. On a large tenant that is minutes of
+  // wall-clock and thousands of requests spent re-fetching postings the scanner
+  // then discards as duplicates.
+  //
+  // OFF BY DEFAULT. scan-ats-full.mjs defaults --since to 3 days; scan.mjs must
+  // not, because pagination depth here is configured per-entry via max_pages and
+  // a default window would silently shorten every existing portals.yml.
+  //
+  // --posted-after is honoured as a source when --since is absent: it already
+  // states "nothing older than this date", which is exactly the bound the
+  // early-stop needs. Reusing it keeps one concept instead of two that can
+  // disagree.
+  const sinceIdx = args.indexOf('--since');
+  const sinceRaw = sinceIdx !== -1 && args[sinceIdx + 1] && !args[sinceIdx + 1].startsWith('--')
+    ? args[sinceIdx + 1]
+    : (args.find((a) => a.startsWith('--since=')) || '').split('=')[1] || null;
+  if (sinceRaw != null && !(Number(sinceRaw) > 0)) {
+    // Gated like --posted-after: a silently-ignored window would look like a
+    // fast scan that simply found less, which is indistinguishable from success.
+    console.error(`Error: --since expects a positive number of days, got "${sinceRaw}"`);
+    process.exit(1);
+  }
+  const earlyStopSinceMs = sinceRaw != null
+    ? Date.now() - Number(sinceRaw) * 86_400_000
+    : (postedAfter ? Date.parse(`${postedAfter}T00:00:00Z`) : null);
+
   // 1. Load providers
   const providers = await loadProviders(PROVIDERS_DIR);
   // Opt-in: merge enabled keyed/auth-gated provider plugins. Returns immediately
@@ -2037,7 +2068,15 @@ async function main() {
 
   const tasks = targets.map(company => async () => {
     let provider = company._provider;
-    const ctx = makeHttpCtx();
+    // includeUndated is deliberately ALWAYS true, independent of the window.
+    // It does not mean "include undated postings in the results" — scan.mjs
+    // already decides that downstream, where buildPostedDateFilter passes a
+    // posting with no parseable date. It means "provider, do not pre-empt that
+    // decision": without it, workday.mjs's no-date-skip returns page 0 only for
+    // any tenant whose CXS payload omits postedOn entirely, silently dropping
+    // postings this scanner would have kept. The early-stop is an optimisation
+    // and must never change which postings are eligible.
+    const ctx = { ...makeHttpCtx(), sinceMs: earlyStopSinceMs, includeUndated: true };
     let sourceName = provider.id === 'local-parser' ? 'local-parser' : `${provider.id}-api`;
     try {
       let jobs;

--- a/scan.mjs
+++ b/scan.mjs
@@ -2147,8 +2147,14 @@ async function main() {
     // posting with no parseable date. It means "provider, do not pre-empt that
     // decision": without it, workday.mjs's no-date-skip returns page 0 only for
     // any tenant whose CXS payload omits postedOn entirely, silently dropping
-    // postings this scanner would have kept. The early-stop is an optimisation
-    // and must never change which postings are eligible.
+    // postings this scanner would have kept.
+    //
+    // It covers the all-undated tenant, not the mixed one. workday.mjs's
+    // pageIsPastWindow reads dated postings only, so on a page mixing stale
+    // dated postings with undated ones the early-stop still fires and undated
+    // postings on later pages go unfetched. Documented in modes/scan.md; the
+    // fix belongs in workday.mjs, where closing it costs the optimisation on
+    // every tenant that mixes.
     const ctx = { ...makeHttpCtx(), sinceMs: earlyStopSinceMs, includeUndated: true };
     let sourceName = provider.id === 'local-parser' ? 'local-parser' : `${provider.id}-api`;
     try {

--- a/scan.mjs
+++ b/scan.mjs
@@ -335,8 +335,13 @@ export function resolveEffectiveAfter(postedAfter, sinceDays, now = Date.now()) 
   // Truncating --since to a date rather than an exact timestamp makes it
   // marginally more permissive, which is the safe direction for a bound that
   // also stops pagination.
-  const sinceIso = Number.isFinite(sinceDays) && sinceDays > 0
-    ? new Date(now - sinceDays * 86_400_000).toISOString().slice(0, 10)
+  // Guarded rather than assumed valid: this is exported and unit-tested, so it
+  // must not throw for any input. A day count large enough to push the cutoff
+  // outside the representable Date range yields an Invalid Date, and
+  // toISOString() would throw RangeError on it.
+  const cutoff = Number.isFinite(sinceDays) && sinceDays > 0 ? new Date(now - sinceDays * 86_400_000) : null;
+  const sinceIso = cutoff && !Number.isNaN(cutoff.getTime())
+    ? cutoff.toISOString().slice(0, 10)
     : null;
   return [postedAfter, sinceIso].filter(Boolean).reduce((a, b) => (a > b ? a : b), null);
 }
@@ -1955,16 +1960,32 @@ async function main() {
   // simply found less — indistinguishable from success. Number.isFinite also
   // rejects Infinity and 1e309, which pass a bare `> 0` test and would yield an
   // -Infinity cutoff.
-  const sinceKv = args.find((a) => a.startsWith('--since='));
-  const sinceIdx = args.indexOf('--since');
+  // Every occurrence is collected, not just the first match of either form:
+  // picking one and ignoring the rest means `--since=7 --since` succeeds while
+  // an occurrence with no value goes unread.
+  const sinceOccurrences = args.filter((a) => a === '--since' || a.startsWith('--since='));
+  if (sinceOccurrences.length > 1) {
+    console.error(`Error: --since given ${sinceOccurrences.length} times; pass it once`);
+    process.exit(1);
+  }
   let sinceDays = null;
-  if (sinceIdx !== -1 || sinceKv) {
-    const raw = sinceKv
-      ? sinceKv.slice('--since='.length)
-      : (args[sinceIdx + 1] != null && !args[sinceIdx + 1].startsWith('--') ? args[sinceIdx + 1] : null);
+  if (sinceOccurrences.length === 1) {
+    const occ = sinceOccurrences[0];
+    const next = args[args.indexOf('--since') + 1];
+    const raw = occ.startsWith('--since=')
+      ? occ.slice('--since='.length)
+      : (next != null && !next.startsWith('--') ? next : null);
     const n = raw == null || raw === '' ? NaN : Number(raw);
     if (!Number.isFinite(n) || n <= 0) {
       console.error(`Error: --since expects a positive number of days, got ${raw == null || raw === '' ? '(no value)' : `"${raw}"`}`);
+      process.exit(1);
+    }
+    // Finite and positive is not enough: 1e300 days lands outside the ±8.64e15ms
+    // range a Date can represent, so the derived cutoff is an Invalid Date and
+    // toISOString() throws. Reject it here rather than let it surface as an
+    // unhandled "Invalid time value" mid-scan.
+    if (Number.isNaN(new Date(Date.now() - n * 86_400_000).getTime())) {
+      console.error(`Error: --since ${raw} is too large to express as a date`);
       process.exit(1);
     }
     sinceDays = n;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4966,6 +4966,8 @@ try {
     buildContentFilter,
     buildPostingAgeFilter,
     buildPostedDateFilter,
+    resolveEffectiveAfter,
+    resolveEarlyStopMs,
     buildVisaFilter,
     buildCountryEligibilityFilter,
     shouldDedupScanHistoryRow,
@@ -5022,6 +5024,75 @@ try {
     pass('posted-date filter gates on an absolute after/before window; missing dates always pass');
   } else {
     fail('posted-date filter did not gate on absolute posted-date bounds correctly');
+  }
+
+  // ── --since as a lower bound, and the early-stop floor derived from it ──
+  // The invariant: the early-stop floor must never be NEWER than the oldest
+  // posting the filters still accept, or pagination stops with eligible
+  // postings unfetched.
+  const SINCE_NOW = Date.parse('2026-08-01T00:00:00Z');
+  const SINCE_DAY = 86_400_000;
+  if (
+    resolveEffectiveAfter(null, null, SINCE_NOW) === null && // neither bound → no filtering
+    resolveEffectiveAfter('2026-07-01', null, SINCE_NOW) === '2026-07-01' && // --posted-after alone
+    resolveEffectiveAfter(null, 7, SINCE_NOW) === '2026-07-25' && // --since alone, relative to now
+    // Both set: bounds AND, so the NEWER one decides. This is the case that
+    // silently dropped eligible postings when --since was hint-only — the hint
+    // stopped at Jul 25 while the filter still accepted back to Jul 1.
+    resolveEffectiveAfter('2026-07-01', 7, SINCE_NOW) === '2026-07-25' &&
+    resolveEffectiveAfter('2026-07-30', 7, SINCE_NOW) === '2026-07-30' && // absolute newer than relative
+    resolveEffectiveAfter(null, 0, SINCE_NOW) === null && // invalid day counts contribute nothing
+    resolveEffectiveAfter(null, Number.POSITIVE_INFINITY, SINCE_NOW) === null
+  ) {
+    pass('--since resolves to an absolute lower bound; the newest active bound wins');
+  } else {
+    fail('effective posted-after bound is not the newest of --posted-after and --since');
+  }
+
+  if (
+    resolveEarlyStopMs(null, null, SINCE_NOW) === null && // no CLI window → early stop disabled
+    resolveEarlyStopMs(null, 30, SINCE_NOW) === null && // config alone must not enable it
+    resolveEarlyStopMs('2026-07-25', null, SINCE_NOW) === Date.parse('2026-07-25T00:00:00Z') &&
+    // max_posting_age_days is the newer bound here (Jul 27 vs Jul 25), so it
+    // decides — stopping at Jul 25 would page deeper than eligibility requires,
+    // which is merely wasteful; stopping NEWER than the filter would be a bug.
+    resolveEarlyStopMs('2026-07-25', 5, SINCE_NOW) === SINCE_NOW - 5 * SINCE_DAY &&
+    // ...and when the CLI window is the newer bound, it wins.
+    resolveEarlyStopMs('2026-07-25', 60, SINCE_NOW) === Date.parse('2026-07-25T00:00:00Z') &&
+    resolveEarlyStopMs('2026-07-25', 0, SINCE_NOW) === Date.parse('2026-07-25T00:00:00Z') && // invalid config ignored
+    resolveEarlyStopMs('2026-07-25', 'abc', SINCE_NOW) === Date.parse('2026-07-25T00:00:00Z')
+  ) {
+    pass('early-stop floor is the newest active lower bound, and stays off without a CLI window');
+  } else {
+    fail('early-stop floor is not derived from every active lower bound');
+  }
+
+  // The contract, stated as one assertion: for a range of bound combinations,
+  // nothing the early-stop skips would have survived the filter anyway.
+  {
+    const cases = [
+      { after: null, since: 7, maxAge: null },
+      { after: '2026-07-01', since: 7, maxAge: null },
+      { after: '2026-07-01', since: null, maxAge: 30 },
+      { after: '2026-07-20', since: 3, maxAge: 10 },
+      { after: null, since: 14, maxAge: 5 },
+    ];
+    const violations = cases.filter(({ after, since, maxAge }) => {
+      const eff = resolveEffectiveAfter(after, since, SINCE_NOW);
+      const floor = resolveEarlyStopMs(eff, maxAge, SINCE_NOW);
+      if (floor === null) return false;
+      const dateOk = buildPostedDateFilter(eff, null);
+      const ageOk = buildPostingAgeFilter(maxAge, SINCE_NOW);
+      // One second older than the floor: the first posting pagination would
+      // skip. It must already be ineligible.
+      const justOutside = floor - 1000;
+      return dateOk(justOutside) && ageOk(justOutside);
+    });
+    if (violations.length === 0) {
+      pass('early stop never skips a posting the filters would have accepted');
+    } else {
+      fail(`early stop would skip eligible postings for: ${JSON.stringify(violations)}`);
+    }
   }
 
   const filter = buildLocationFilter({

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5131,6 +5131,48 @@ try {
     }
   }
 
+  // The assertions above exercise the resolver in-process. --since is rejected
+  // earlier than that, in main()'s argv parsing, so nothing above would catch a
+  // regression there — hence the real binary. Each case fails before scan.mjs
+  // loads config or opens a socket, so these stay offline and quick.
+  //
+  // stderr is matched, not just the exit code: every one of these paths exits 1,
+  // and so would an unrelated startup failure. The message is what proves the
+  // flag was read and refused.
+  {
+    const sinceCli = (...argv) => spawnSync(NODE, [join(ROOT, 'scan.mjs'), ...argv], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      timeout: 30000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const NO_VALUE = '--since expects a positive number of days, got (no value)';
+    const sinceCases = [
+      { argv: ['--since'], want: NO_VALUE, why: 'flag with no operand' },
+      { argv: ['--since='], want: NO_VALUE, why: 'empty inline operand' },
+      // The next token is a flag, not a value. Consuming it would scan the full
+      // window while looking like it had honoured --since.
+      { argv: ['--since', '--posted-after', '2026-07-01'], want: NO_VALUE, why: 'operand stealing' },
+      { argv: ['--since', '0'], want: 'got "0"', why: 'zero days' },
+      { argv: ['--since', '-3'], want: 'got "-3"', why: 'negative days' },
+      // Passes a bare `> 0` test; only Number.isFinite rejects it.
+      { argv: ['--since', 'Infinity'], want: 'got "Infinity"', why: 'non-finite' },
+      // Finite and positive, but the derived cutoff is outside Date's range.
+      { argv: ['--since', '1e300'], want: 'is too large to express as a date', why: 'out-of-range cutoff' },
+      // Reading only the first occurrence would let this one through.
+      { argv: ['--since=7', '--since'], want: '--since given 2 times; pass it once', why: 'repeated flag' },
+    ];
+    const badCases = sinceCases.filter(({ argv, want }) => {
+      const r = sinceCli(...argv);
+      return r.status !== 1 || !String(r.stderr).includes(want);
+    });
+    if (badCases.length === 0) {
+      pass('scan.mjs --since rejects bad input at the CLI (exit 1, with the reason named)');
+    } else {
+      fail(`scan.mjs --since accepted or misreported: ${badCases.map((c) => c.why).join(', ')}`);
+    }
+  }
+
   const filter = buildLocationFilter({
     always_allow: ['belgium', 'brussels'],
     allow: ['europe', 'emea', 'remote'],

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5042,7 +5042,12 @@ try {
     resolveEffectiveAfter('2026-07-01', 7, SINCE_NOW) === '2026-07-25' &&
     resolveEffectiveAfter('2026-07-30', 7, SINCE_NOW) === '2026-07-30' && // absolute newer than relative
     resolveEffectiveAfter(null, 0, SINCE_NOW) === null && // invalid day counts contribute nothing
-    resolveEffectiveAfter(null, Number.POSITIVE_INFINITY, SINCE_NOW) === null
+    resolveEffectiveAfter(null, Number.POSITIVE_INFINITY, SINCE_NOW) === null &&
+    // Finite and positive is not sufficient: a day count this large pushes the
+    // cutoff outside the representable Date range, where toISOString() throws.
+    // The helper is exported, so it must return rather than raise.
+    resolveEffectiveAfter(null, 1e300, SINCE_NOW) === null &&
+    resolveEffectiveAfter('2026-07-01', 1e300, SINCE_NOW) === '2026-07-01'
   ) {
     pass('--since resolves to an absolute lower bound; the newest active bound wins');
   } else {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5094,9 +5094,40 @@ try {
       return dateOk(justOutside) && ageOk(justOutside);
     });
     if (violations.length === 0) {
-      pass('early stop never skips a posting the filters would have accepted');
+      pass('early stop never skips a dated posting the filters would have accepted');
     } else {
       fail(`early stop would skip eligible postings for: ${JSON.stringify(violations)}`);
+    }
+  }
+
+  // The contract above holds for dated postings only. Undated ones pass every
+  // date filter, so the early stop CAN narrow results — pinned here so the
+  // behaviour and modes/scan.md can't drift apart. Change this test only
+  // alongside the doc.
+  {
+    const { pageIsPastWindow } = await import(pathToFileURL(join(ROOT, 'providers', 'workday.mjs')).href);
+    const floor = SINCE_NOW - 7 * SINCE_DAY;
+    const stale = floor - 30 * SINCE_DAY; // well past the 2-day jitter margin
+    const fresh = SINCE_NOW - SINCE_DAY;
+    const undated = { postedAt: undefined };
+
+    if (
+      // No window → the hint is inert, whatever the page holds.
+      pageIsPastWindow([{ postedAt: stale }], null) === false &&
+      // Tenants like adventhealth: no dates anywhere. Protected — this is what
+      // scan.mjs's includeUndated:true keeps alive downstream.
+      pageIsPastWindow([undated, undated], floor) === false &&
+      // A fresh dated posting holds pagination open.
+      pageIsPastWindow([{ postedAt: fresh }, undated], floor) === false &&
+      // KNOWN LIMITATION: the dated postings are stale, the undated ones are
+      // eligible, and pagination stops anyway. Undated postings on later pages
+      // are lost. Fixing it lives in workday.mjs and costs the optimisation on
+      // every mixed tenant.
+      pageIsPastWindow([{ postedAt: stale }, undated], floor) === true
+    ) {
+      pass('early stop ignores undated postings — all-undated pages are safe, mixed pages are not');
+    } else {
+      fail('workday early-stop no longer matches the undated-posting behaviour documented in modes/scan.md');
     }
   }
 


### PR DESCRIPTION
## Summary

`--since <days>` becomes a **relative form of `--posted-after`** — a lower bound on the employer's posting date that filters like `--posted-after` does, and additionally lets providers stop paginating once a page is entirely past it.

> ⚠️ **Revised after review.** The first version of this PR made `--since` a hint-only flag that filtered nothing. That was incoherent — see "What changed after review" below. The description now reflects what the branch actually does.

## The gap

`providers/workday.mjs` returns postings newest-first and can stop paginating once a page is entirely past a window:

> *"Workday returns postings newest-first, so pagination can stop once a page's oldest dated posting is well past `--since` — no point paying for (and rate-limit-risking) pages that are entirely stale."*

That logic exists and is well-tuned, including a 2-day margin for the day-label jitter some tenants show. But **only `scan-ats-full.mjs` ever passes `sinceMs`.** `scan.mjs` built its provider context as a bare `makeHttpCtx()`, so the early stop could never fire there — every Workday tenant paginated to its `max_pages` cap on every run, however stale the deep pages were.

It also meant `--since` meant one thing in `scan-ats-full.mjs` (a filter) and did not exist in `scan.mjs`.

## Why it matters

On a large tenant this is minutes of wall-clock and thousands of requests spent re-fetching postings the scanner then discards as duplicates. It also pushes `portals.yml` maintainers toward hand-measuring pagination depth per entry — an entry in my own config carries this:

```yaml
# max_pages sized from measured posting age, not guessed. This tenant posts ~1,000/day, so:
#   page 100 (the default cap) = 2 days of history   page 300 =  9 days
#   page 500 = 16 days                               page 700 = 30+ Days Ago
```

That is careful work and it should not be necessary. A date window adapts on its own; a page cap must be re-measured whenever a tenant's posting rate changes.

There is also a UX wrinkle: when a tenant hits its cap the warning says *"raise `max_pages` on this entry for more."* For anyone scanning on a schedule that points the wrong way — they don't want more history, they want to stop sooner.

## How bounds combine

`--posted-after`, `--since`, and the config-level `max_posting_age_days` all set lower bounds. They AND together, so **the newest one decides eligibility**, and the early-stop floor is derived from the same set:

```js
const effectiveAfter   = resolveEffectiveAfter(postedAfter, sinceDays);
const earlyStopSinceMs = resolveEarlyStopMs(effectiveAfter, config.max_posting_age_days);
```

Both consumers come from one function, so the filter and the hint cannot drift apart.

One deliberate asymmetry: `max_posting_age_days` **constrains** that floor but does not by itself enable early stopping. A config-only setting silently changing pagination depth would alter behaviour for users who never asked for it.

`--since` is also off by default, unlike `scan-ats-full.mjs`'s 3-day default — pagination depth here is configured per-entry via `max_pages`, and a default window would silently shorten every existing `portals.yml`. `scan-ats-full.mjs` has no per-entry depth setting to respect, which is why the defaults differ.

## Measured

A ~18,000-posting Workday tenant, `max_pages: 300`, same machine, sequential runs:

| | Time | Jobs fetched | Stop reason |
|---|---|---|---|
| baseline | 172s | 6,000 | hit `max_pages` (truncation warning) |
| `--since 3` | **140s** | 4,880 | **early stop, no warning** |

The absent warning is the load-bearing detail: it stopped because postings went stale, not because it ran out of pages. 4,880 postings ≈ 244 pages ≈ ~5 days at that tenant's rate — the 3-day window plus the provider's 2-day jitter margin, exactly as documented.

The 19% is measured against an already-tightened cap; against the 700-page cap the same entry previously used, `--since 3` cuts ~14,000 fetched postings to the same 4,880.

## What changed after review

Both findings were valid and neither was cosmetic.

**Validation.** `--since` with no operand, `--since=`, and `--since --posted-after X` all collapsed to the same `null` used for "flag absent", so they were accepted silently — the opposite of the "fails loudly" behaviour this description claimed. `Infinity` and `1e309` also passed a bare `> 0` test and produced an `-Infinity` cutoff. Flag presence is now tracked separately from its operand, and the value must be finite and positive. All eight forms exit non-zero.

**Correctness.** The hint-only design was incoherent. With `--since 7 --posted-after 2026-07-01` the hint stopped pagination at ~Jul 25 while the filter still accepted postings back to Jul 1 — eligible postings never fetched. Chasing that showed `--since` *alone* had the same hole: with no filter active every posting is eligible, so any early stop dropped eligible postings. Making `--since` a real filter closes both, and matches how `scan-ats-full.mjs` has always treated the flag.

## Verification

- `node test-all.mjs`: **2750 passed, 1 failed.** The single failure is `analyze() appDateSource end-to-end` with `EPERM: symlink`, a Windows symlink-permission issue in the harness; unmodified `origin/main` in the same environment produces the identical result.
- Three new cases in `test-all.mjs`, including a property test that walks a range of bound combinations and asserts the first posting the early stop would skip is already ineligible.
- **Negative control:** injecting an early-stop floor newer than the filter bound fails both the bound test and the property test, with the property failure naming all five combinations. Restored and hash-verified against the commit before continuing — a refactor test that cannot fail proves nothing.
- All eight invalid `--since` forms exercised directly against the CLI.
- Timings are from real runs against a live tenant, not estimates.

## Docs

`modes/scan.md` — where `scan.mjs`'s other CLI flags live — documents `--since`, how the bounds combine, that `max_posting_age_days` alone does not enable early stopping, and that invalid values fail immediately. `docs/SCRIPTS.md` covers `--since` for `scan-ats-full.mjs` and needs no change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the optional `--since <days>` scan filter for limiting results by relative posting date.
  - Combines with `--posted-after` by applying the newer date boundary.
  - Keeps undated postings included and can stop pagination earlier when safe.

- **Bug Fixes**
  - Added validation for missing, invalid, duplicate, or unsupported `--since` values.

- **Documentation**
  - Documented filtering behavior, defaults, validation, and pagination guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->