### PR TITLE
fix(providers): a16z speedrun feed silently truncates to 50 jobs (PER_PAGE is 50, not 100)

### DIFF
--- a/providers/a16z-speedrun-talent.mjs
+++ b/providers/a16z-speedrun-talent.mjs
@@ -8,7 +8,7 @@
 // Response shape: { jobs: [ { id, title, company, url, location, remote,
 //   published_at, ... } ], total, page, page_size, total_pages, facets }
 //
-// Paginated 100/page via `?page=N` (0-indexed); the response carries
+// Paginated 50/page via `?page=N` (0-indexed); the response carries
 // `total_pages`, so iteration is bounded by min(total_pages, max_pages).
 // Default cap is modest; the board is several thousand roles, so either
 // raise `max_pages` on the entry or narrow server-side with `q:` (the feed
@@ -22,7 +22,7 @@
 
 const FEED_BASE = 'https://speedrun-talent-network.com/api/v1/jobs';
 const TRUSTED_HOST = 'speedrun-talent-network.com';
-const PER_PAGE = 100;
+const PER_PAGE = 50;
 const DEFAULT_MAX_PAGES = 3;
 const MAX_PAGES_CAP = 120;
 

--- a/tests/providers/a16z-speedrun-talent.test.mjs
+++ b/tests/providers/a16z-speedrun-talent.test.mjs
@@ -82,8 +82,8 @@ try {
 
   // fetch(): 0-based pagination with source tag, stop on short page; q passthrough.
   const mk = (i) => ({ title: `Role ${i}`, url: `https://speedrun-talent-network.com/jobs/x${i}`, company: `Co ${i}`, location: 'New York, NY', remote: false, published_at: '2026-07-01T00:00:00.000Z' });
-  const page0 = { jobs: Array.from({ length: 100 }, (_, i) => mk(i)), total: 133, page: 0, page_size: 100, total_pages: 2 };
-  const page1 = { jobs: [mk(100), mk(101), { title: '', url: 'https://speedrun-talent-network.com/jobs/bad' }], total: 133, page: 1, page_size: 100, total_pages: 2 };
+  const page0 = { jobs: Array.from({ length: 50 }, (_, i) => mk(i)), total: 53, page: 0, page_size: 50, total_pages: 2 };
+  const page1 = { jobs: [mk(50), mk(51), { title: '', url: 'https://speedrun-talent-network.com/jobs/bad' }], total: 53, page: 1, page_size: 50, total_pages: 2 };
   const calls = [];
   const ctx = {
     fetchJson: async (url) => {
@@ -99,7 +99,7 @@ try {
     && calls.every((u) => new URL(u).searchParams.get('q') === 'engineer')
     && new URL(calls[0]).searchParams.get('page') === '0'
     && new URL(calls[1]).searchParams.get('page') === '1';
-  if (urlsOk && jobs.length === 102 && jobs[0].title === 'Role 0' && jobs[101].title === 'Role 101') {
+  if (urlsOk && jobs.length === 52 && jobs[0].title === 'Role 0' && jobs[51].title === 'Role 51') {
     pass('fetch() paginates 0-based with source=career-ops + q passthrough, stops after total_pages, drops invalid rows');
   } else {
     fail(`fetch() = ${JSON.stringify({ calls, count: jobs.length })}`);
@@ -107,10 +107,59 @@ try {
 
   // fetch(): max_pages caps ahead of total_pages.
   const capCalls = [];
-  const capCtx = { fetchJson: async (url) => { capCalls.push(url); return { jobs: Array.from({ length: 100 }, (_, i) => mk(i)), total_pages: 50 }; } };
+  const capCtx = { fetchJson: async (url) => { capCalls.push(url); return { jobs: Array.from({ length: 50 }, (_, i) => mk(i)), total_pages: 50 }; } };
   const capped = await provider.fetch({ max_pages: 2 }, capCtx);
-  if (capCalls.length === 2 && capped.length === 200) pass('fetch() honors max_pages ahead of total_pages');
+  if (capCalls.length === 2 && capped.length === 100) pass('fetch() honors max_pages ahead of total_pages');
   else fail(`fetch() cap = ${JSON.stringify({ calls: capCalls.length, jobs: capped.length })}`);
+
+  // Regression: the live feed serves exactly 50 jobs/page. A full 50-row page
+  // must NOT be mistaken for a short page — the old hardcoded PER_PAGE=100
+  // made 50 < 100 true, broke after page 0, and silently truncated a
+  // 16k-job board to its newest 50 rows.
+  const liveShapeCalls = [];
+  const liveShapeCtx = {
+    fetchJson: async (url) => {
+      liveShapeCalls.push(url);
+      return { jobs: Array.from({ length: 50 }, (_, i) => mk(i)), total: 16830, page: liveShapeCalls.length - 1, page_size: 50, total_pages: 337 };
+    },
+  };
+  const liveWarnings = [];
+  const liveRealConsoleError = console.error;
+  let liveShape;
+  try {
+    console.error = (...args) => liveWarnings.push(args.join(' '));
+    liveShape = await provider.fetch({ max_pages: 2 }, liveShapeCtx);
+  } finally {
+    console.error = liveRealConsoleError;
+  }
+  const livePagesOk = liveShapeCalls.length === 2
+    && new URL(liveShapeCalls[0]).searchParams.get('page') === '0'
+    && new URL(liveShapeCalls[1]).searchParams.get('page') === '1';
+  if (livePagesOk && liveShape.length === 100) pass('fetch() keeps paginating past a full 50-row page (live feed shape)');
+  else fail(`live-shape pagination = ${JSON.stringify({ calls: liveShapeCalls, jobs: liveShape?.length })}`);
+  if (liveWarnings.some((w) => w.includes('truncated at max_pages=2'))) pass('fetch() warns when max_pages truncates the live-shape feed');
+  else fail(`live-shape truncation warning missing; captured = ${JSON.stringify(liveWarnings)}`);
+
+  // PER_PAGE fallback pinned from both directions when the response omits
+  // page_size/total_pages: a full 50-row page continues (fails if PER_PAGE
+  // regresses above 50), a 30-row page stops (fails if it regresses below 31).
+  const bareCalls = [];
+  const bareCtx = {
+    fetchJson: async (url) => {
+      bareCalls.push(url);
+      return { jobs: Array.from({ length: bareCalls.length === 1 ? 50 : 30 }, (_, i) => mk(i)) };
+    },
+  };
+  const bare = await provider.fetch({ max_pages: 5 }, bareCtx);
+  if (bareCalls.length === 2 && bare.length === 80) pass('fetch() stops on a short page via the PER_PAGE=50 fallback when page_size is absent');
+  else fail(`bare fallback = ${JSON.stringify({ calls: bareCalls.length, jobs: bare.length })}`);
+
+  // Empty feed (e.g. a q: with no matches) returns [] after one call.
+  const emptyCalls = [];
+  const emptyCtx = { fetchJson: async (url) => { emptyCalls.push(url); return { jobs: [], total: 0, page: 0, page_size: 50, total_pages: 0 }; } };
+  const empty = await provider.fetch({ max_pages: 3 }, emptyCtx);
+  if (emptyCalls.length === 1 && empty.length === 0) pass('fetch() returns [] after one call on an empty feed');
+  else fail(`empty feed = ${JSON.stringify({ calls: emptyCalls.length, jobs: empty.length })}`);
 
   // resolveQuery: keywords[] fallback when q: is absent.
   const kwCalls = [];
@@ -122,7 +171,7 @@ try {
   // MAX_PAGES_CAP: an oversized max_pages is clamped to 120, and the
   // truncation warning fires (spied via console.error, restored in finally).
   const bigCalls = [];
-  const bigCtx = { fetchJson: async (url) => { bigCalls.push(url); return { jobs: Array.from({ length: 100 }, (_, i) => mk(i)), total_pages: 500 }; } };
+  const bigCtx = { fetchJson: async (url) => { bigCalls.push(url); return { jobs: Array.from({ length: 50 }, (_, i) => mk(i)), total_pages: 500 }; } };
   const warnings = [];
   const realConsoleError = console.error;
   try {

--- a/tests/providers/a16z-speedrun-talent.test.mjs
+++ b/tests/providers/a16z-speedrun-talent.test.mjs
@@ -142,16 +142,16 @@ try {
 
   // PER_PAGE fallback pinned from both directions when the response omits
   // page_size/total_pages: a full 50-row page continues (fails if PER_PAGE
-  // regresses above 50), a 30-row page stops (fails if it regresses below 31).
+  // regresses above 50), a 49-row page stops (fails if it regresses below 50).
   const bareCalls = [];
   const bareCtx = {
     fetchJson: async (url) => {
       bareCalls.push(url);
-      return { jobs: Array.from({ length: bareCalls.length === 1 ? 50 : 30 }, (_, i) => mk(i)) };
+      return { jobs: Array.from({ length: bareCalls.length === 1 ? 50 : 49 }, (_, i) => mk(i)) };
     },
   };
   const bare = await provider.fetch({ max_pages: 5 }, bareCtx);
-  if (bareCalls.length === 2 && bare.length === 80) pass('fetch() stops on a short page via the PER_PAGE=50 fallback when page_size is absent');
+  if (bareCalls.length === 2 && bare.length === 99) pass('fetch() stops on a short page via the PER_PAGE=50 fallback when page_size is absent');
   else fail(`bare fallback = ${JSON.stringify({ calls: bareCalls.length, jobs: bare.length })}`);
 
   // Empty feed (e.g. a q: with no matches) returns [] after one call.


### PR DESCRIPTION
## What does this PR do?

Fixes silent feed truncation in the a16z speedrun talent provider: the live API serves **50 jobs/page**, but `PER_PAGE` was hardcoded to 100, so the short-page stop (`jobs.length < PER_PAGE`) treated every full 50-row page as the last page and broke after page 0. Every scan returned only the newest 50 of ~16,800 jobs, regardless of `max_pages`. This PR corrects the constant (and the header comment claiming 100/page) and adds regression tests that fail under the old constant.

## Related issue

None — bug fix, sent straight in per CONTRIBUTING.md.

**Reproduction evidence** (2026-08-01):

```
GET https://speedrun-talent-network.com/api/v1/jobs?page=0&source=career-ops
→ jobs: 50 | total: 16830 | page_size: 50 | total_pages: 337
```

Observed in a real install: `node scan.mjs` with a `max_pages: 6` entry fetched exactly 50 jobs (1 page); after this fix it fetches 300 (6 pages, with the truncation warning firing correctly).

**Test changes:** fixtures updated from 100-row to 50-row pages so the full-page fixture length matches the provider constant (same convention as the thehub/4dayweek tests), plus three new cases: live-shape regression (full 50-row page must keep paginating; asserts page params and the `max_pages` truncation warning via the existing console.error spy pattern), `PER_PAGE` pinned from both directions through a `page_size`-less response (50-row page continues, 30-row page stops), and an empty feed returning `[]` after one call. Against the old provider these fail 7 ways; with the fix the file passes 17/17.

**Deliberately out of scope** (pre-existing behavior, flagged during review — happy to follow up in a separate issue if wanted): the short-page break fires before the `total_pages` check, so a churn-shortened mid-scan page can still end iteration early; and `DEFAULT_MAX_PAGES`/`MAX_PAGES_CAP` were presumably sized against 100/page (the cap now bounds coverage at 6,000 of ~16.8k jobs). This PR intentionally stays minimal: constant + comment + tests.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (2751 passed; 1 pre-existing failure unrelated to this change — the funnel-velocity cadence e2e crashes with `EPERM: symlink` on non-elevated Windows, identical on a pristine `main` checkout)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job listing pagination by processing results in batches of 50.
  * Ensured pagination correctly stops when fewer than 50 listings remain.
  * Added handling for empty feeds, truncated results, and continued retrieval across full pages.
  * Improved safeguards to prevent incomplete or excessive pagination when listings reach the maximum retrieval limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->