### PR TITLE
fix(web): strip the author letter from any lettered block, not just A-G (#2324)

### DIFF
--- a/web/src/components/report-view.tsx
+++ b/web/src/components/report-view.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 import type { Application } from "@/lib/career-ops";
 import { Badge } from "@/components/ui/badge";
 import { scoreTone, scoreNum, legitimacyTone, parseReport } from "@/lib/format";
+import { cleanHeading, splitSections } from "@/lib/report-sections.mjs";
 import { StatusSelect } from "@/components/status-select";
 import { CompanyLogo } from "@/components/company-logo";
 import { ScoreMethodology } from "@/components/score-methodology";
@@ -14,22 +15,17 @@ import { DeleteFromTracker } from "@/components/delete-from-tracker";
 
 // Progressive disclosure of the report. The core writes prose blocks
 // "## F) Verdict (lead)", "## A) Role Summary", "## B) Match with CV", then
-// C–G + machine artifacts (Machine Summary YAML, Application Answers, submit
-// log). A mainstream user deciding "should I apply?" needs the verdict + fit;
-// the rest is depth-on-demand. We lead with the verdict as a callout, keep A/B
-// expanded, collapse C–G as content, and drop machine artifacts to a dimmer
-// "Technical" tier — and strip the bare "F)" author-letters from headings
-// (native <details>, no client JS — this stays a server component).
-
-type Section = { heading: string; letter: string | null; content: string };
-
-function cleanHeading(h: string): string {
-  const stripped = h
-    .replace(/^\s*(?:Block\s+)?[A-G][).:]\s*/i, "")
-    .replace(/\s*\((?:lead|verdict)\)\s*$/i, "")
-    .trim();
-  return stripped || h.trim();
-}
+// the remaining lettered blocks + machine artifacts (Machine Summary YAML,
+// Application Answers, submit log). A mainstream user deciding "should I
+// apply?" needs the verdict + fit; the rest is depth-on-demand. We lead with
+// the verdict as a callout, keep A/B expanded, collapse the other lettered
+// blocks as content, and drop machine artifacts to a dimmer "Technical" tier —
+// and strip the bare "F)" author-letters from headings (native <details>, no
+// client JS — this stays a server component).
+//
+// Splitting and heading cleanup live in lib/report-sections.mjs so the
+// author-letter range has one definition; duplicating it here is what left
+// "H) Draft Application Answers" rendering with its letter attached (#2324).
 
 // Machine artifacts (collapsed because they're for devs, not the mainstream) vs
 // human content C–G (collapsed only for length) — ux's "honest for devs" tier.
@@ -48,27 +44,6 @@ function preview(md: string): string {
     .trim();
   const sentence = text.split(/(?<=[.!?])\s/)[0] ?? text;
   return sentence.length > 96 ? sentence.slice(0, 96).trimEnd() + "…" : sentence;
-}
-
-function splitSections(body: string): { intro: string; sections: Section[] } {
-  const intro: string[] = [];
-  const sections: Section[] = [];
-  let cur: { heading: string; letter: string | null; lines: string[] } | null = null;
-  for (const line of body.split("\n")) {
-    const h = line.match(/^##\s+(.*)$/);
-    if (h) {
-      if (cur) sections.push({ heading: cur.heading, letter: cur.letter, content: cur.lines.join("\n").trim() });
-      const heading = h[1].trim();
-      const letter = heading.match(/^(?:Block\s+)?([A-G])[).:\s]/i)?.[1]?.toUpperCase() ?? null;
-      cur = { heading, letter, lines: [] };
-    } else if (cur) {
-      cur.lines.push(line);
-    } else {
-      intro.push(line);
-    }
-  }
-  if (cur) sections.push({ heading: cur.heading, letter: cur.letter, content: cur.lines.join("\n").trim() });
-  return { intro: intro.join("\n").trim(), sections };
 }
 
 export function ReportView({

--- a/web/src/lib/report-sections.mjs
+++ b/web/src/lib/report-sections.mjs
@@ -26,8 +26,12 @@
  * lettered heading. HEADING_LETTER below already reads that grammar as section
  * A, so leaving the prefix in the rendered heading made this file classify a
  * heading one way and display it another (CodeRabbit review).
+ *
+ * The separator is a RUN of dashes, not one character: modes/ja/kyujin.md and
+ * modes/hi/naukri.md write the ASCII "## Block A -- Role Summary", which left a
+ * stray "- " on every block of every report those modes produce.
  */
-const HEADING_PREFIX = /^\s*(?:Block\s+([A-Z])(?:[).:]\s*|\s+(?:[—–-]\s*)?)|([A-Z])[).:]\s*)/i;
+const HEADING_PREFIX = /^\s*(?:Block\s+([A-Z])(?:[).:]\s*|\s+(?:[—–-]+\s*)?)|([A-Z])[).:]\s*)/i;
 
 /**
  * Reads the letter. A bare letter needs a delimiter, exactly like the display

--- a/web/src/lib/report-sections.mjs
+++ b/web/src/lib/report-sections.mjs
@@ -16,14 +16,20 @@
  * block added past H is handled the day the core writes it.
  */
 
-/** Single source of truth for what an author-letter prefix looks like. */
-const AUTHOR_LETTER = "(?:Block\\s+)?([A-Z])";
-
 /** Strips the prefix for display: needs a real delimiter, never a bare space. */
-const HEADING_PREFIX = new RegExp(`^\\s*${AUTHOR_LETTER}[).:]\\s*`, "i");
+const HEADING_PREFIX = /^\s*(?:Block\s+)?([A-Z])[).:]\s*/i;
 
-/** Reads the letter: also accepts "Block A Role Summary" (spelled-out form). */
-const HEADING_LETTER = new RegExp(`^${AUTHOR_LETTER}[).:\\s]`, "i");
+/**
+ * Reads the letter. A bare letter needs a delimiter, exactly like the display
+ * form above — otherwise "A Recommendation Was Requested" is read as section A
+ * and ReportView expands ordinary prose as if it were Block A.
+ *
+ * The whitespace form is kept for the spelled-out grammar only: oferta.md
+ * writes "## Block A — Role Summary", where nothing follows the letter but a
+ * space. Requiring a delimiter there would lose the F verdict callout and the
+ * A/B expansion on those reports.
+ */
+const HEADING_LETTER = /^(?:Block\s+([A-Z])(?:[).:]|\s)|([A-Z])[).:])/i;
 
 /**
  * @typedef {{ heading: string, letter: string | null, content: string }} Section
@@ -50,7 +56,8 @@ export function cleanHeading(h) {
  * @returns {string | null}
  */
 export function authorLetter(heading) {
-  return heading.match(HEADING_LETTER)?.[1]?.toUpperCase() ?? null;
+  const match = heading.match(HEADING_LETTER);
+  return (match?.[1] ?? match?.[2])?.toUpperCase() ?? null;
 }
 
 /**

--- a/web/src/lib/report-sections.mjs
+++ b/web/src/lib/report-sections.mjs
@@ -16,8 +16,18 @@
  * block added past H is handled the day the core writes it.
  */
 
-/** Strips the prefix for display: needs a real delimiter, never a bare space. */
-const HEADING_PREFIX = /^\s*(?:Block\s+)?([A-Z])[).:]\s*/i;
+/**
+ * Strips the prefix for display. A BARE letter needs a real delimiter, never a
+ * bare space, or ordinary prose loses its first word ("A Recommendation Was
+ * Requested" → "Recommendation Was Requested").
+ *
+ * After `Block` the whitespace form is allowed, because the word itself is the
+ * disambiguator: "## Block A — Role Summary" (oferta.md:47) is unmistakably a
+ * lettered heading. HEADING_LETTER below already reads that grammar as section
+ * A, so leaving the prefix in the rendered heading made this file classify a
+ * heading one way and display it another (CodeRabbit review).
+ */
+const HEADING_PREFIX = /^\s*(?:Block\s+([A-Z])(?:[).:]\s*|\s+(?:[—–-]\s*)?)|([A-Z])[).:]\s*)/i;
 
 /**
  * Reads the letter. A bare letter needs a delimiter, exactly like the display

--- a/web/src/lib/report-sections.mjs
+++ b/web/src/lib/report-sections.mjs
@@ -1,0 +1,83 @@
+/**
+ * report-sections.mjs — splitting a report body into its author-lettered
+ * sections, and cleaning those headings for display.
+ *
+ * Plain .mjs (same pattern as clean-chips.mjs) so test-report-sections.mjs can
+ * import it directly under Node, and so the two places that used to hard-code
+ * the author-letter range can no longer drift apart: they were written as
+ * `[A-G]` in report-view.tsx, which silently mis-handled `## H) Draft
+ * Application Answers` — the heading rendered with its letter still attached
+ * while every other section rendered clean, and splitSections reported
+ * `letter: null` for it (#2324).
+ *
+ * The range is now any single letter. The `)` / `.` / `:` delimiter is what
+ * keeps this from eating ordinary prose ("A Recommendation Was Requested"),
+ * not the narrowness of the range — so widening it costs no safety, and a
+ * block added past H is handled the day the core writes it.
+ */
+
+/** Single source of truth for what an author-letter prefix looks like. */
+const AUTHOR_LETTER = "(?:Block\\s+)?([A-Z])";
+
+/** Strips the prefix for display: needs a real delimiter, never a bare space. */
+const HEADING_PREFIX = new RegExp(`^\\s*${AUTHOR_LETTER}[).:]\\s*`, "i");
+
+/** Reads the letter: also accepts "Block A Role Summary" (spelled-out form). */
+const HEADING_LETTER = new RegExp(`^${AUTHOR_LETTER}[).:\\s]`, "i");
+
+/**
+ * @typedef {{ heading: string, letter: string | null, content: string }} Section
+ */
+
+/**
+ * Display form of a section heading: author-letter prefix and the trailing
+ * "(lead)" / "(verdict)" marker removed. Falls back to the original when
+ * stripping would leave nothing.
+ * @param {string} h
+ * @returns {string}
+ */
+export function cleanHeading(h) {
+  const stripped = h
+    .replace(HEADING_PREFIX, "")
+    .replace(/\s*\((?:lead|verdict)\)\s*$/i, "")
+    .trim();
+  return stripped || h.trim();
+}
+
+/**
+ * The author letter of a heading, uppercased, or null when it carries none.
+ * @param {string} heading
+ * @returns {string | null}
+ */
+export function authorLetter(heading) {
+  return heading.match(HEADING_LETTER)?.[1]?.toUpperCase() ?? null;
+}
+
+/**
+ * Split a report body on `## ` headings. Everything before the first one is
+ * the intro.
+ * @param {string} body
+ * @returns {{ intro: string, sections: Section[] }}
+ */
+export function splitSections(body) {
+  /** @type {string[]} */
+  const intro = [];
+  /** @type {Section[]} */
+  const sections = [];
+  /** @type {{ heading: string, letter: string | null, lines: string[] } | null} */
+  let cur = null;
+  for (const line of body.split("\n")) {
+    const h = line.match(/^##\s+(.*)$/);
+    if (h) {
+      if (cur) sections.push({ heading: cur.heading, letter: cur.letter, content: cur.lines.join("\n").trim() });
+      const heading = h[1].trim();
+      cur = { heading, letter: authorLetter(heading), lines: [] };
+    } else if (cur) {
+      cur.lines.push(line);
+    } else {
+      intro.push(line);
+    }
+  }
+  if (cur) sections.push({ heading: cur.heading, letter: cur.letter, content: cur.lines.join("\n").trim() });
+  return { intro: intro.join("\n").trim(), sections };
+}

--- a/web/tests/lib/report-sections.test.mjs
+++ b/web/tests/lib/report-sections.test.mjs
@@ -50,6 +50,20 @@ test("prose is not eaten: both reads need a real delimiter", () => {
   assert.equal(authorLetter("Risk Summary"), null);
 });
 
+test("the spelled-out Block form is stripped for display too", () => {
+  // authorLetter reads "Block A — Role Summary" as section A, so cleanHeading
+  // must not leave "Block A —" in the rendered heading: classifying a heading
+  // one way and displaying it another is the same inconsistency #2324 is about.
+  assert.equal(cleanHeading("Block A — Role Summary"), "Role Summary");
+  assert.equal(cleanHeading("Block A – Role Summary"), "Role Summary");
+  assert.equal(cleanHeading("Block A - Role Summary"), "Role Summary");
+  assert.equal(cleanHeading("Block A Role Summary"), "Role Summary");
+  assert.equal(cleanHeading("Block C) Red Flags"), "Red Flags");
+  // The word Block is what licenses the whitespace form. A bare letter still
+  // needs a delimiter, or prose loses its first word.
+  assert.equal(cleanHeading("A Recommendation Was Requested"), "A Recommendation Was Requested");
+});
+
 test("the spelled-out Block form keeps its letter without a delimiter", () => {
   // oferta.md:47 writes "## Block A — Role Summary": nothing follows the letter
   // but a space. Losing the letter here would drop the F verdict callout and

--- a/web/tests/lib/report-sections.test.mjs
+++ b/web/tests/lib/report-sections.test.mjs
@@ -1,0 +1,89 @@
+// Tests for the report section splitter using Node's built-in test runner.
+// Imports directly from report-sections.mjs (the single source of truth) so the
+// test and production code can never drift out of sync.
+//
+// Run:  node --test tests/lib/report-sections.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { cleanHeading, authorLetter, splitSections } from "../../src/lib/report-sections.mjs";
+
+test("strips the author letter from the blocks the core has always written", () => {
+  assert.equal(cleanHeading("A) Role Summary"), "Role Summary");
+  assert.equal(cleanHeading("G) Posting Legitimacy"), "Posting Legitimacy");
+});
+
+test("H) is stripped too — the #2324 regression", () => {
+  // oferta.md and auto-pipeline.md write "## H) Draft Application Answers";
+  // the old [A-G] range left this one heading showing its letter.
+  assert.equal(cleanHeading("H) Draft Application Answers"), "Draft Application Answers");
+  assert.equal(authorLetter("H) Draft Application Answers"), "H");
+});
+
+test("a block added past H needs no code change", () => {
+  assert.equal(cleanHeading("I) Something New"), "Something New");
+  assert.equal(authorLetter("Z. Last One"), "Z");
+});
+
+test("the (lead) / (verdict) marker is dropped with the letter", () => {
+  assert.equal(cleanHeading("F) Verdict (lead)"), "Verdict");
+  assert.equal(cleanHeading("F) Verdict (verdict)"), "Verdict");
+});
+
+test("all three delimiters and the spelled-out Block form", () => {
+  assert.equal(cleanHeading("B) Match with CV"), "Match with CV");
+  assert.equal(cleanHeading("B. Match with CV"), "Match with CV");
+  assert.equal(cleanHeading("B: Match with CV"), "Match with CV");
+  assert.equal(cleanHeading("Block H: Draft Application Answers"), "Draft Application Answers");
+  assert.equal(authorLetter("Block C) Red Flags"), "C");
+});
+
+test("prose is not eaten: stripping needs a real delimiter", () => {
+  // The delimiter, not the narrowness of the letter range, is the safety —
+  // which is why widening the range costs nothing.
+  assert.equal(cleanHeading("A Recommendation Was Requested"), "A Recommendation Was Requested");
+  assert.equal(cleanHeading("Machine Summary"), "Machine Summary");
+  assert.equal(authorLetter("Machine Summary"), null);
+  assert.equal(authorLetter("Risk Summary"), null);
+});
+
+test("a heading that is only a letter keeps its original text", () => {
+  assert.equal(cleanHeading("H)"), "H)");
+});
+
+test("case is normalized on the way out", () => {
+  assert.equal(authorLetter("h) draft application answers"), "H");
+});
+
+test("splitSections keeps the intro and letters every section", () => {
+  const body = [
+    "**Score:** 4.2/5",
+    "",
+    "## F) Verdict (lead)",
+    "Apply.",
+    "",
+    "## A) Role Summary",
+    "Senior role.",
+    "",
+    "## H) Draft Application Answers",
+    "Q1: ...",
+  ].join("\n");
+
+  const { intro, sections } = splitSections(body);
+  assert.equal(intro, "**Score:** 4.2/5");
+  assert.deepEqual(
+    sections.map((s) => [s.letter, cleanHeading(s.heading)]),
+    [
+      ["F", "Verdict"],
+      ["A", "Role Summary"],
+      ["H", "Draft Application Answers"],
+    ],
+  );
+  assert.equal(sections[2].content, "Q1: ...");
+});
+
+test("a body with no headings is all intro", () => {
+  const { intro, sections } = splitSections("just prose\nand more");
+  assert.equal(intro, "just prose\nand more");
+  assert.deepEqual(sections, []);
+});

--- a/web/tests/lib/report-sections.test.mjs
+++ b/web/tests/lib/report-sections.test.mjs
@@ -38,13 +38,25 @@ test("all three delimiters and the spelled-out Block form", () => {
   assert.equal(authorLetter("Block C) Red Flags"), "C");
 });
 
-test("prose is not eaten: stripping needs a real delimiter", () => {
+test("prose is not eaten: both reads need a real delimiter", () => {
   // The delimiter, not the narrowness of the letter range, is the safety —
-  // which is why widening the range costs nothing.
+  // which is why widening the range costs nothing. A bare letter followed by a
+  // space is prose: reading it as a section would make ReportView expand it as
+  // if it were Block A.
   assert.equal(cleanHeading("A Recommendation Was Requested"), "A Recommendation Was Requested");
+  assert.equal(authorLetter("A Recommendation Was Requested"), null);
   assert.equal(cleanHeading("Machine Summary"), "Machine Summary");
   assert.equal(authorLetter("Machine Summary"), null);
   assert.equal(authorLetter("Risk Summary"), null);
+});
+
+test("the spelled-out Block form keeps its letter without a delimiter", () => {
+  // oferta.md:47 writes "## Block A — Role Summary": nothing follows the letter
+  // but a space. Losing the letter here would drop the F verdict callout and
+  // the A/B expansion on those reports.
+  assert.equal(authorLetter("Block A — Role Summary"), "A");
+  assert.equal(authorLetter("Block F -- Interview Plan"), "F");
+  assert.equal(authorLetter("Block G Posting Legitimacy"), "G");
 });
 
 test("a heading that is only a letter keeps its original text", () => {

--- a/web/tests/lib/report-sections.test.mjs
+++ b/web/tests/lib/report-sections.test.mjs
@@ -113,3 +113,17 @@ test("a body with no headings is all intro", () => {
   assert.equal(intro, "just prose\nand more");
   assert.deepEqual(sections, []);
 });
+
+test("the ASCII double-hyphen Block form is stripped whole", () => {
+  // modes/ja/kyujin.md and modes/hi/naukri.md write "## Block A -- Role Summary"
+  // for every block. The separator matched a SINGLE dash character, so each of
+  // those headings rendered with a stray leading hyphen ("- Role Summary") —
+  // every block of every report produced by the Japanese or Hindi mode.
+  assert.equal(cleanHeading("Block A -- Role Summary"), "Role Summary");
+  assert.equal(cleanHeading("Block F -- Interview Plan"), "Interview Plan");
+  assert.equal(cleanHeading("Block G -- Posting Legitimacy"), "Posting Legitimacy");
+  assert.equal(authorLetter("Block F -- Interview Plan"), "F");
+  // A heading whose text legitimately starts with a hyphen keeps it: only the
+  // separator run is consumed, and it must be attached to the letter.
+  assert.equal(cleanHeading("Block A) -- keep this"), "-- keep this");
+});


### PR DESCRIPTION
Fixes #2324

## Problem

`report-view.tsx` hard-coded the author-letter range in two adjacent places:

```js
.replace(/^\s*(?:Block\s+)?[A-G][).:]\s*/i, "")            // cleanHeading
heading.match(/^(?:Block\s+)?([A-G])[).:\s]/i)             // splitSections
```

`oferta.md:513` and `auto-pipeline.md:64` write `## H) Draft Application Answers`, which falls outside that range — so that one heading renders with its letter still attached while the other seven render clean, and `splitSections()` hands it `letter: null`. In the reporter's 411-report corpus, 29 reports show the inconsistency.

## Fix

The range is now any single letter, and both call sites read one definition.

- **Root cause first:** the two regexes were the same assumption written twice, which is how they drifted. `cleanHeading`, `authorLetter` and `splitSections` moved to `web/src/lib/report-sections.mjs` — plain `.mjs`, the `clean-chips.mjs` / `tracker-table.mjs` pattern, so Node can test the real code and the component imports it rather than re-deriving it.
- **Widening costs no safety.** The `)` / `.` / `:` delimiter is what keeps ordinary prose intact: `"A Recommendation Was Requested"` is untouched before and after. The narrow range was not carrying that weight.
- **No tier change.** `letter` only drives three decisions — the `F` verdict callout, and `A`/`B` staying expanded. An `H` section was collapsed content before and is collapsed content now; only its heading changed. Verified against the current call sites in `report-view.tsx`.
- A block added past `H` is handled the day the core writes it, with no code change.

## Test plan

- [x] `npm test` in `web/` — 72 passing (60 existing + 12 new)
- [x] New `web/test-report-sections.mjs` pins: `H)` stripped and lettered; `I)`/`Z.` handled; all three delimiters plus the spelled-out `Block H:` form; the `(lead)`/`(verdict)` marker; prose left alone without a delimiter; a letter-only heading keeping its text; `splitSections` intro/letter/content output
- [x] The suite lands in `web/tests/lib/`, picked up by the existing `tests/**/*.test.mjs` glob — no `package.json` change needed
- [x] `npx tsc --noEmit` clean, `npm run build` succeeds
- [x] `node test-all.mjs --quick` — 2754 passed, 0 failed

## Also fixed, on review

`authorLetter` accepted whitespace after any letter, so a prose heading like `"A Recommendation Was Requested"` was read as section A and `ReportView` expanded it as if it were Block A. Pre-existing on `main`, but preserving it was a choice rather than a constraint, so it is tightened here: a **bare** letter now needs the same `)` / `.` / `:` delimiter that `cleanHeading` already required.

The whitespace form is kept for the spelled-out grammar only — `modes/oferta.md:47` writes `## Block A — Role Summary`, where nothing follows the letter but a space. Requiring a delimiter there would set `letter: null` and drop the `F` verdict callout and the `A`/`B` expansion on those reports. Both grammars are pinned in the tests.

**The spelled-out form is now stripped for display too.** I first left `cleanHeading("Block A — Role Summary")` alone as a different grammar. CodeRabbit pointed out the resulting inconsistency inside this very PR: `authorLetter` reads that heading as section A, so the file classified it one way and displayed it another, prefix included. After the word `Block` the whitespace form (with an optional dash) is now stripped; a **bare** letter still requires a delimiter, or ordinary prose loses its first word.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report section recognition for lettered headings, optional “Block” prefixes, and varied delimiter formats.
  * Preserved introductory text and ordinary prose more reliably during report processing.
  * Improved heading cleanup and letter normalization for clearer report display.

* **Tests**
  * Added coverage for heading formats, malformed headings, prose protection, section extraction, and reports without headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->