### PR TITLE
fix(tracker): non-Latin company names all keyed to "", silently overwriting each other

### DIFF
--- a/company-history.mjs
+++ b/company-history.mjs
@@ -581,12 +581,15 @@ async function runSelfTest() {
   const NOW = new Date('2026-07-09T00:00:00Z');
   const row = (num, company, status, date, notes = '') => ({ num, date, company, role: 'Engineer', score: '4/5', status, pdf: '✅', report: `reports/${num}.md`, notes });
 
-  // --- join fixtures: case/punct variants meet under one key; "" excluded -> unjoinable ---
+  // --- join fixtures: case/punct variants meet under one key; only a genuinely
+  // keyless company is unjoinable. A non-Latin name is NOT keyless (#2429):
+  // normalizeCompany() folds script-preserving, so 株式会社 keys as itself and
+  // gets a real card instead of being discarded as unparseable data. ---
   {
     const rows = [
       row(1, 'Acme Inc.', 'Applied', '2026-01-01'),
       row(2, 'ACME, INC', 'Applied', '2026-01-02'),
-      row(3, '株式会社', 'Applied', '2026-01-03'), // normalizeCompany -> "" (non a-z0-9)
+      row(3, '?', 'Applied', '2026-01-03'), // punctuation only -> genuinely keyless
     ];
     const result = buildCompanyCards(
       { trackerRows: rows, followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
@@ -594,7 +597,7 @@ async function runSelfTest() {
     );
     check(result.companies.length === 1, 'case/punct company variants join under one key');
     check(result.companies[0].responsiveness.facts.length === 2, 'both joined rows contribute facts to the single card');
-    check(result.dataQuality.unjoinable === 1, 'empty-key company (non-Latin, strips to "") is excluded and counted as unjoinable');
+    check(result.dataQuality.unjoinable === 1, 'a punctuation-only company key is excluded and counted as unjoinable');
   }
 
   // --- label goldens ---

--- a/company-history.mjs
+++ b/company-history.mjs
@@ -600,6 +600,21 @@ async function runSelfTest() {
     check(result.dataQuality.unjoinable === 1, 'a punctuation-only company key is excluded and counted as unjoinable');
   }
 
+  // --- non-Latin companies are first-class, and distinct from each other (#2429) ---
+  {
+    const rows = [
+      row(4, 'アクメ株式会社', 'Applied', '2026-01-01'),
+      row(5, 'グロベックス合同会社', 'Applied', '2026-01-02'),
+      row(6, 'Яндекс', 'Applied', '2026-01-03'),
+    ];
+    const result = buildCompanyCards(
+      { trackerRows: rows, followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    check(result.companies.length === 3, 'three different non-Latin companies produce three cards, not one');
+    check(result.dataQuality.unjoinable === 0, 'a non-Latin company name is joinable, not a data-quality defect');
+  }
+
   // --- label goldens ---
   {
     // silent-on-you: one Applied row well past the window, nothing else.

--- a/company-history.test.mjs
+++ b/company-history.test.mjs
@@ -90,8 +90,11 @@ console.log('\n--- 1. multi-source 3-company scenario ---');
     row(1, 'Responsive Corp', 'Rejected', '2026-06-01'),
     // Company B: Silent Systems — old Applied row, applied date from notes.
     row(2, 'Silent Systems', 'Applied', '2026-03-01', 'Applied 2026-03-10'),
-    // Company C: unjoinable non-Latin name -> excluded from companies, counted unjoinable.
-    row(3, '株式会社テスト', 'Applied', '2026-01-01'),
+    // Company C: genuinely keyless company (`?`, punctuation only) -> excluded
+    // from companies, counted unjoinable. A non-Latin name is NOT keyless
+    // (#2429) — it folds script-preserving and gets a real card, so it can't
+    // stand in for the unjoinable case any more.
+    row(3, '?', 'Applied', '2026-01-01'),
   ];
   const followupRows = [
     followup(1, 2, '2026-03-20', 'Silent Systems'),
@@ -120,7 +123,7 @@ console.log('\n--- 1. multi-source 3-company scenario ---');
   eq('metadata.sources reflects sourcesLoaded', result.metadata.sources, { tracker: true, followups: true, scanHistory: true, statusLog: false });
 
   // --- data quality ---
-  eq('dataQuality.unjoinable counts the non-Latin company', result.dataQuality.unjoinable, 1);
+  eq('dataQuality.unjoinable counts the keyless (punctuation-only) company', result.dataQuality.unjoinable, 1);
 
   // --- card ordering (alphabetical by company name) ---
   eq('cards ordered alphabetically: Responsive Corp first', result.companies[0].company, 'Responsive Corp');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8551,6 +8551,89 @@ try {
   fail(`non-Latin via guard tests crashed: ${e.message}`);
 }
 
+// ── MERGE-TRACKER: DISTINCT NON-LATIN COMPANIES (#2429) ───────────
+// Sibling of the #1603 via guard, one column over. normalizeCompany() stripped
+// [^a-z0-9], so EVERY non-Latin company name folded to '' and compared equal to
+// every other one — merge-tracker's company+role fallback then treated
+// applications at two different companies as the same row and silently
+// overwrote one. applications.md is gitignored with no .bak, so the losing
+// evaluation was unrecoverable.
+console.log('\n🧪 Testing merge-tracker with distinct non-Latin companies (#2429)...');
+try {
+  const { normalizeCompany } = await import(pathToFileURL(join(ROOT, 'tracker-utils.mjs')).href);
+
+  // Unit: distinct scripts must produce distinct, non-empty keys.
+  const keys = ['アクメ株式会社', 'グロベックス合同会社', 'Яндекс', '北京字节跳动'].map(normalizeCompany);
+  if (keys.every(k => k !== '') && new Set(keys).size === keys.length) {
+    pass('normalizeCompany gives every non-Latin company a distinct non-empty key (#2429)');
+  } else {
+    fail(`non-Latin company keys collapsed: ${JSON.stringify(keys)}`);
+  }
+  // The `?` unknown-employer marker MUST still fold to '' — the #1596
+  // cross-channel guard depends on those rows sharing one key.
+  if (normalizeCompany('?') === '' && normalizeCompany('—') === '') {
+    pass('punctuation-only company still folds to the empty key, preserving the #1596 guard (#2429)');
+  } else {
+    fail('punctuation-only company no longer folds to empty — the #1596 cross-channel guard is broken');
+  }
+  // NFKC: full-width and half-width spellings are the same company.
+  if (normalizeCompany('ＡＣＭＥ') === normalizeCompany('ACME')) {
+    pass('NFKC folds full-width and half-width company spellings together (#2429)');
+  } else {
+    fail('full-width company name did not fold to its half-width spelling');
+  }
+  // Latin path unchanged.
+  if (normalizeCompany('Acme Inc.') === 'acmeinc' && normalizeCompany('ACME, INC') === 'acmeinc') {
+    pass('Latin company keys are unchanged by the Unicode-aware fold (#2429)');
+  } else {
+    fail('Latin company key changed — existing dedup/selector behaviour would shift');
+  }
+
+  // End-to-end: two different non-Latin companies, fuzzy-matching role titles.
+  const coTmp = mkdtempSync(join(tmpdir(), 'career-ops-nonlatin-co-'));
+  try {
+    mkdirSync(join(coTmp, 'data'));
+    mkdirSync(join(coTmp, 'reports'));
+    const additionsDir = join(coTmp, 'additions');
+    mkdirSync(additionsDir);
+    const tracker = join(coTmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 1 | 2026-01-04 | アクメ株式会社 | Backend Engineer, Payments Platform | 4.0/5 | Evaluated | ❌ | [1](../reports/001-acme-2026-01-04.md) | first company |\n');
+    for (const n of ['001-acme-2026-01-04', '002-globex-2026-01-05']) {
+      writeFileSync(join(coTmp, 'reports', `${n}.md`), '# fixture\n');
+    }
+    // DIFFERENT company, same role title → a real second application that must
+    // be ADDED, not silently merged over the first.
+    writeFileSync(join(additionsDir, '002-globex.tsv'),
+      '2\t2026-01-05\tグロベックス合同会社\tBackend Engineer, Payments Platform\tEvaluated\t4.1/5\t❌\t[2](reports/002-globex-2026-01-05.md)\tsecond company\n');
+
+    const coResult = run(NODE, ['merge-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: additionsDir } });
+    if (coResult === null) {
+      fail('merge-tracker.mjs crashed during non-Latin company test (#2429)');
+    } else {
+      const merged = readFileSync(tracker, 'utf-8');
+      if (merged.includes('アクメ株式会社') && merged.includes('グロベックス合同会社')) {
+        pass('two different non-Latin companies stay two rows (#2429)');
+      } else {
+        fail('a non-Latin company was silently overwritten by a different one — the evaluation is unrecoverable (#2429)');
+      }
+      const rows = merged.split('\n').filter(l => l.startsWith('| ') && /\| \d+ \|/.test(l));
+      if (rows.length === 2) {
+        pass('merge-tracker added the second non-Latin company instead of merging (#2429)');
+      } else {
+        fail(`expected 2 tracker rows after merge, got ${rows.length}`);
+      }
+    }
+  } finally {
+    rmSync(coTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`non-Latin company tests crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER TSV COLUMN-ORDER TOLERANCE (#1427) ─────────────
 // Batch TSVs write (status, score); applications.md is (score, status). A
 // generator that swaps the two must not merge silently — the score column is

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8569,6 +8569,18 @@ try {
   } else {
     fail(`non-Latin company keys collapsed: ${JSON.stringify(keys)}`);
   }
+  // Combining marks must SURVIVE the fold. Indic matras have no precomposed
+  // form, so a key that strips \p{M} makes Devanagari कंपनी and कपनी (and क
+  // and का) identical — re-introducing, for the shipped hi/ar locales, exactly
+  // the collision this fix removes for ja/zh/ru. This is why normalizeCompany
+  // delegates to normalizeTextKey (which keeps \p{M}) rather than to a
+  // company-local fold (#2429 review, #2445).
+  const markPairs = [['कंपनी', 'कपनी'], ['क', 'का']];
+  if (markPairs.every(([a, b]) => normalizeCompany(a) !== normalizeCompany(b))) {
+    pass('company keys keep combining marks, so Devanagari names differing only in matras stay distinct (#2429)');
+  } else {
+    fail('combining marks stripped from the company key — Indic names differing only in matras now collide');
+  }
   // The `?` unknown-employer marker MUST still fold to '' — the #1596
   // cross-channel guard depends on those rows sharing one key.
   if (normalizeCompany('?') === '' && normalizeCompany('—') === '') {

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -13,6 +13,7 @@ import { join, dirname, basename, resolve, relative, isAbsolute, sep } from 'pat
 import { createHash, randomUUID } from 'crypto';
 import { tmpdir } from 'os';
 import yaml from 'js-yaml';
+import { normalizeTextKey } from './tracker-parse.mjs';
 
 /**
  * Minimum age before directory age alone may condemn an ownerless lock or
@@ -45,15 +46,23 @@ export function rebuildRow(parts) {
  * Normalize company names for same-company lookups across tracker scripts.
  *
  * Company names can contain spaces, punctuation, or branding variants in the
- * tracker and incoming rows. Removing non-alphanumeric characters gives every
- * consumer (merge-tracker dedup, set-status row resolution) the same stable
- * company key, so a row one script would match is never missed by another.
+ * tracker and incoming rows. Folding them gives every consumer (merge-tracker
+ * dedup, set-status/outcome row resolution, company-history grouping, the
+ * scan blacklist) the same stable company key, so a row one script would match
+ * is never missed by another.
+ *
+ * Script-preserving via the shared normalizeTextKey(): the previous
+ * `[^a-z0-9]` filter DELETED every non-Latin name, so アクメ株式会社,
+ * グロベックス合同会社 and Яндекс all produced `''` and compared equal to each
+ * other — merge-tracker then treated applications at different companies as
+ * the same row and silently overwrote one (#2429). `?` still folds to `''`,
+ * which is what the #1596 cross-channel Via guard depends on.
  *
  * @param {string} name - Company name from the tracker or an input row.
- * @returns {string} Lowercase alphanumeric company key.
+ * @returns {string} Case-folded, punctuation-free, script-preserving key.
  */
 export function normalizeCompany(name) {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return normalizeTextKey(name);
 }
 
 /**


### PR DESCRIPTION
Closes #2429.

`normalizeCompany()` stripped everything outside `[a-z0-9]`, so **every** company name written in a non-Latin script folded to `''` and compared equal to every other one. `merge-tracker`'s company+role fallback then treated applications at two *different* companies as the same row and silently overwrote one — and `applications.md` is gitignored with no `.bak`, so the losing evaluation was unrecoverable.

Took **route 2** from the issue (Unicode-aware key) rather than the raw-equality special case, as discussed on the thread.

## Fix

This is the #1603 Via bug one column over, so it takes the #1603 remedy: NFKC, case-fold, keep `\p{L}\p{N}` of any script. Rather than copy that expression a second time, I lifted it into a shared `foldIdentityKey()` in `tracker-parse.mjs` that **both** `normalizeVia()` and `normalizeCompany()` delegate to — a second hand-maintained copy is how these two drifted apart in the first place. (`tracker-parse.mjs` imports only `fs`, so no cycle.)

```
"アクメ株式会社"       → "アクメ株式会社"    (was "")
"グロベックス合同会社"   → "グロベックス合同会社" (was "")
"Яндекс"              → "яндекс"          (was "")
"ＡＣＭＥ"             → "acme"            (was "")   ← NFKC
"Acme Inc."           → "acmeinc"         unchanged
"?"                   → ""                unchanged  ← #1596 depends on this
```

Because the key is shared, this also repairs the other five call sites: the scan blacklist (a blacklisted non-Latin company matched *every* other non-Latin company), `set-status`/`outcome` selector resolution, and `company-history` grouping.

## Tests

Unit + end-to-end, in `test-all.mjs`. Verified they fail against the old implementation:

```
❌ non-Latin company keys collapsed: ["","","",""]
❌ full-width company name did not fold to its half-width spelling
❌ a non-Latin company was silently overwritten by a different one
❌ expected 2 tracker rows after merge, got 1        ← the data loss itself
✅ punctuation-only company still folds to the empty key (#1596 guard intact)
✅ Latin company keys are unchanged
```

`node test-all.mjs --quick` → **2787 passed, 0 failed**.

## Two behavioural deltas, reported rather than shipped quietly

As promised on the issue:

**1. `company-history` no longer treats non-Latin companies as a data-quality defect.** Both suites used a non-Latin name *as* the "unjoinable" fixture, precisely because it folded to `''`. That conflated "a name this tool cannot key" with "a name written in another script". Those companies now get real cards, appear in `metadata.companies`, and show up in `hygiene.agedApplied` when they've gone silent — where they were previously invisible. I retargeted the fixtures onto `?` (punctuation-only, genuinely keyless) in a **separate first commit** that is green both before and after the fix, so the fixture correction and the behaviour change are reviewable apart.

**2. Accented Latin names now keep their accents.** `Café` keys as `café` (was `caf`). Strictly more correct — `Café` and `Caf` are no longer the same company — but it is a change, and I'd rather you see it than find it. Accent-*folding* (so `Café` and `Cafe` match) is a separate question I haven't touched.

3 commits (fixture decoupling → fix → regressions), each green on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved company-name matching for non-Latin names while keeping distinct companies separate.
  - Punctuation-only names continue to be treated as unknown or unjoinable.
  - Standardized equivalent full-width and ASCII Latin spellings.
  - Preserved existing Latin-name normalization behavior.

- **Tests**
  - Added regression coverage for Unicode names, punctuation-only entries, and merge tracking.
  - Updated data-quality and multi-source scenarios to reflect corrected matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->