### PR TITLE
fix(tailor): prompt-cache the openai-tailor.mjs static system prefix

### DIFF
--- a/openai-tailor.mjs
+++ b/openai-tailor.mjs
@@ -239,6 +239,25 @@ IMPORTANT OPERATING RULES FOR THIS SESSION
 6. Do NOT include markdown formatting like \`\`\`html or conversational filler. Output the raw HTML starting with <!DOCTYPE html> and ending with </html>.`;
 
 // ---------------------------------------------------------------------------
+// Prompt caching (#1709, closing the gap in #2432) — same shape as
+// openai-eval.mjs. This system prompt (shared + writing + pdf mode + HTML
+// template + cv + profile, ~15K+ tokens) is byte-identical across every
+// offer, yet was re-sent and re-billed each call.
+//
+// Host-gated on purpose: OpenAI-compatible gateways (OpenRouter, DeepSeek, …)
+// honor an ephemeral `cache_control` breakpoint on the prefix and reuse it
+// across back-to-back calls within the cache TTL. api.openai.com instead caches
+// long prefixes automatically and may reject the non-standard field, so it gets
+// a plain-string system message. Either way the prompt TEXT is unchanged.
+export function buildSystemMessage(prompt, host) {
+  if (host === 'api.openai.com') return { role: 'system', content: prompt };
+  return {
+    role: 'system',
+    content: [{ type: 'text', text: prompt, cache_control: { type: 'ephemeral' } }],
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Call the OpenAI-compatible endpoint
 // ---------------------------------------------------------------------------
 const timeoutMs = parseInt(process.env.OPENAI_TIMEOUT_MS || '300000', 10);
@@ -261,7 +280,7 @@ try {
     body: JSON.stringify({
       model:    modelName,
       messages: [
-        { role: 'system', content: systemPrompt },
+        buildSystemMessage(systemPrompt, endpointHost),
         { role: 'user',   content: `EVALUATION REPORT:\n\n${reportText}\n\nJOB DESCRIPTION:\n\n${jdText}\n\nNow, generate and output the fully filled HTML CV matching the rules above. Output ONLY raw HTML.` },
       ],
       stream:      false,

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -10406,6 +10406,28 @@ try {
   fail(`gemini-eval systemInstruction source test crashed: ${e.message}`);
 }
 
+// ── 44f. openai-tailor — host-gated prompt-cache breakpoint (#1709, #2432) ──
+// openai-tailor.mjs runs on import (arg parse + fetch), so it can't be imported
+// to unit-test the helper — assert the host-gated shape at the source level,
+// same approach as 44c for its sibling openai-eval.mjs.
+console.log('\n44f. openai-tailor — host-gated prompt-cache breakpoint (#1709, #2432)');
+try {
+  const src = readFileSync(join(ROOT, 'openai-tailor.mjs'), 'utf-8');
+  const checks = [
+    // api.openai.com gets a plain-string system message (auto-caches; may reject the field)
+    { name: 'openai-tailor gates cache_control off for api.openai.com', re: /host === 'api\.openai\.com'\)\s*return\s*\{\s*role:\s*'system',\s*content:\s*prompt\s*\}/ },
+    // other OpenAI-compatible hosts get the ephemeral cache_control breakpoint, text preserved
+    { name: 'openai-tailor sends an ephemeral cache_control breakpoint to compatible gateways', re: /text:\s*prompt,\s*cache_control:\s*\{\s*type:\s*'ephemeral'\s*\}/ },
+    // and it's actually wired into the request, keyed on the resolved endpoint host
+    { name: 'openai-tailor builds the system message via buildSystemMessage(systemPrompt, endpointHost)', re: /buildSystemMessage\(systemPrompt,\s*endpointHost\)/ },
+  ];
+  const missing = checks.filter((c) => !c.re.test(src));
+  if (missing.length === 0) pass('openai-tailor host-gates the #1709 prompt-cache breakpoint and wires it into the request');
+  else fail(`openai-tailor prompt-cache wiring missing: ${missing.map((m) => m.name).join('; ')}`);
+} catch (e) {
+  fail(`openai-tailor prompt-cache source test crashed: ${e.message}`);
+}
+
 // ── 44e. ollama-eval — temperature must live in options ────────
 // Ollama's /api/chat reads generation params from `options` only; a top-level
 // `temperature` is silently ignored (defaulting to 0.8). Assert it sits in


### PR DESCRIPTION
## Summary

- `openai-tailor.mjs` was the one `#1709` sibling engine (alongside `openai-eval.mjs`, `gemini-eval.mjs`, `openrouter-runner.mjs`) that never got the `cache_control` breakpoint, so its ~15K-token static prefix (shared + writing + pdf mode + cv template + cv + profile) was re-billed on every tailoring call to OpenAI-compatible gateways.
- Adds `buildSystemMessage(prompt, host)` to `openai-tailor.mjs`, mirroring `openai-eval.mjs`'s host-gated shape: plain-string system message for `api.openai.com` (auto-caches, may reject the field), ephemeral `cache_control` breakpoint for every other OpenAI-compatible host (OpenRouter, DeepSeek, …). Prompt text is unchanged.
- Adds a matching source-level `#1709` regression test in `test-all.mjs` (§44f), following the same pattern as the existing 44b/c/d tests for the other three engines.

Closes #2432.

## Test plan

- [x] `node --check openai-tailor.mjs`
- [x] `node test-all.mjs` — new 44f test passes; full suite at 2747 passed / 11 failed, with the 11 failures pre-existing and unrelated (dashboard canonical-state drift #2249, `generate-pdf --max-pages` Node module-resolution issue, a `.claude` git-add hint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved compatibility for system prompts across supported API hosts.
  - Enabled prompt caching for compatible gateways while preserving standard formatting for `api.openai.com`.

- **Bug Fixes**
  - Ensured prompt handling is based on the configured endpoint host, improving behavior with alternate gateways.

- **Tests**
  - Added coverage verifying host-specific prompt formatting and caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->