### PR TITLE
fix(batch-runner): tab-IFS collapse records score "-" for every successful offer

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -658,14 +658,21 @@ process_offer() {
             const status = typeof obj.status === "string" ? obj.status : "";
             const error = typeof obj.error === "string" ? obj.error : "";
             const score = typeof obj.score === "number" ? String(obj.score) : "";
-            process.stdout.write(status + "\t" + error + "\t" + score);
+            process.stdout.write(status + "\x1f" + error + "\x1f" + score);
           } catch {
             process.stdout.write("");
           }
         });
       ' 2>/dev/null || true)
       if [[ -n "$parsed" ]]; then
-        IFS=$'\t' read -r parsed_status parsed_error parsed_score <<< "$parsed"
+        # \x1f (US), not \t: tab is IFS *whitespace*, so bash collapses runs of it
+        # and strips leading/trailing ones. On the common path -- a worker that
+        # succeeded, so `error` is empty -- the two tabs around that empty field
+        # collapse into one, `score` slides into parsed_error, and parsed_score
+        # comes back empty. The `elif` below then never fires and every
+        # successful offer records score "-". A non-whitespace delimiter gets
+        # one-field-per-unit splitting with empty fields preserved.
+        IFS=$'\x1f' read -r parsed_status parsed_error parsed_score <<< "$parsed"
         if [[ "$parsed_status" == "failed" ]]; then
           worker_failed_match="failed"
           worker_error_match="$parsed_error"

--- a/tests/batch-runner-score-delimiter.test.mjs
+++ b/tests/batch-runner-score-delimiter.test.mjs
@@ -1,0 +1,111 @@
+// tests/batch-runner-score-delimiter.test.mjs — the worker payload is split on a
+// delimiter that preserves empty fields.
+//
+// THE BUG THIS PINS
+//
+// batch-runner.sh serialises the worker's final JSON into three fields and reads
+// them back with `read -r parsed_status parsed_error parsed_score`. When those
+// fields were joined and split on TAB, the common path broke:
+//
+//   a successful worker has status="completed", error EMPTY, score=3.4
+//   emitted:  completed \t \t 3.4
+//
+// Tab is IFS *whitespace*, so bash collapses runs of it and strips leading and
+// trailing occurrences. The two tabs around the empty `error` collapse into one:
+//
+//   parsed_status="completed"  parsed_error="3.4"  parsed_score=""
+//
+// The `elif [[ -n "$parsed_score" ]]` branch then never fires, and EVERY
+// successful offer records score "-".
+//
+// It is silent and self-consistent: exit code 0, status `completed`, a real
+// report on disk, and a score column that is uniformly useless. Nothing in the
+// run summary shows it.
+//
+// This test extracts the REAL emitter out of batch/batch-runner.sh and runs it,
+// rather than restating it, so the two cannot drift apart.
+import { pass, fail, getBash } from './helpers.mjs';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = readFileSync(join(ROOT, 'batch/batch-runner.sh'), 'utf-8').replace(/\r\n/g, '\n');
+
+console.log('\nbatch-runner.sh — worker payload delimiter');
+
+// --- the two halves must agree -------------------------------------------
+// Emitter: the node -e program's `process.stdout.write(status + <D> + error ...)`
+const emit = SRC.match(/process\.stdout\.write\(status \+ "([^"]+)" \+ error \+ "([^"]+)" \+ score\)/);
+// Reader: `IFS=$'<D>' read -r parsed_status parsed_error parsed_score`
+const read = SRC.match(/IFS=\$'([^']+)' read -r parsed_status parsed_error parsed_score/);
+
+if (!emit) {
+  fail('could not find the worker-payload emitter in batch/batch-runner.sh — this test needs updating');
+} else if (!read) {
+  fail('could not find the worker-payload reader in batch/batch-runner.sh — this test needs updating');
+} else {
+  if (emit[1] === emit[2] && emit[1] === read[1]) {
+    pass(`emitter and reader use the same delimiter (${JSON.stringify(read[1])})`);
+  } else {
+    fail(`delimiter mismatch: emitter ${JSON.stringify(emit[1])}/${JSON.stringify(emit[2])}, reader ${JSON.stringify(read[1])}`);
+  }
+
+  // IFS whitespace (space, tab, newline) collapses runs and drops empty fields.
+  // Any of the three reintroduces the bug regardless of how the code reads.
+  if (!/^\\?[tn]$/.test(read[1]) && read[1] !== ' ') {
+    pass('the delimiter is not IFS whitespace, so empty fields survive the split');
+  } else {
+    fail(`delimiter ${JSON.stringify(read[1])} is IFS whitespace — empty fields collapse and score is lost`);
+  }
+}
+
+// --- end to end, using the real emitter ----------------------------------
+// A successful worker: error is empty and score is present. That is the exact
+// shape that broke, and the only one worth asserting.
+if (emit && read) {
+  const nodeProg = SRC.match(/parsed=\$\(printf '%s' "\$worker_result_json" \| node -e '([\s\S]*?)'\s*2>\/dev\/null/);
+  if (!nodeProg) {
+    fail('could not extract the node -e payload parser from batch-runner.sh');
+  } else {
+    const work = mkdtempSync(join(tmpdir(), 'cops-delim-'));
+    try {
+      const script = join(work, 'check.sh');
+      writeFileSync(script, [
+        '#!/usr/bin/env bash',
+        `worker_result_json='{"status":"completed","error":null,"score":3.4}'`,
+        `parsed=$(printf '%s' "$worker_result_json" | node -e '${nodeProg[1]}' 2>/dev/null || true)`,
+        `IFS=$'${read[1]}' read -r parsed_status parsed_error parsed_score <<< "$parsed"`,
+        'score="-"',
+        'if [[ "$parsed_status" == "failed" ]]; then :',
+        'elif [[ -n "$parsed_score" ]]; then score="$parsed_score"; fi',
+        'printf "%s|%s|%s\\n" "$parsed_status" "$parsed_error" "$score"',
+      ].join('\n'));
+
+      const out = execFileSync(getBash(), [script], { encoding: 'utf-8', timeout: 30000 }).trim();
+      const [status, error, score] = out.split('|');
+
+      if (score === '3.4') {
+        pass('a successful worker records its real score (not "-")');
+      } else {
+        fail(`score was recorded as "${score}" instead of 3.4 — the empty error field collapsed the split`);
+      }
+
+      if (error === '') {
+        pass('the empty error field stays empty rather than absorbing the score');
+      } else {
+        fail(`error absorbed the next field: "${error}"`);
+      }
+
+      if (status === 'completed') {
+        pass('status is still parsed correctly');
+      } else {
+        fail(`status parsed as "${status}"`);
+      }
+    } finally {
+      rmSync(work, { recursive: true, force: true });
+    }
+  }
+}


### PR DESCRIPTION
## The bug

`batch-runner.sh` serialises the worker's final JSON into three fields and reads them back with `read -r parsed_status parsed_error parsed_score`. Joined and split on **TAB**, the common path breaks.

A *successful* worker has `status="completed"`, `error` **empty**, `score=3.4`:

```
emitted:  completed \t \t 3.4
```

Tab is IFS **whitespace**, so bash collapses runs of it and strips leading/trailing occurrences. The two tabs around the empty `error` collapse into one:

```
parsed_status="completed"   parsed_error="3.4"   parsed_score=""
```

The `elif [[ -n "$parsed_score" ]]` branch never fires, `score` keeps its `"-"` default, and **every successful offer is recorded unscored**.

## Reproduction

Independent of the runner — this is the same emitter, lifted out:

```bash
$ json='{"status":"completed","error":null,"score":3.4}'
$ parsed=$(printf '%s' "$json" | node -e '
    let d="";process.stdin.on("data",x=>d+=x);
    process.stdin.on("end",()=>{const o=JSON.parse(d);
      process.stdout.write((o.status||"")+"\t"+(o.error||"")+"\t"+(typeof o.score==="number"?String(o.score):""));});')

$ printf '%s' "$parsed" | cat -A
completed^I^I3.4

$ IFS=$'\t' read -r s e sc <<< "$parsed"
$ echo "status='$s' error='$e' score='$sc'"
status='completed' error='3.4' score=''      # score landed in error
```

## Why it is worth fixing

It is silent and internally consistent: exit code 0, status `completed`, a real report on disk, and a score column that is uniformly useless. Nothing in the run summary surfaces it — you notice only when scores stop driving whatever consumes them downstream.

It affects the **success** path specifically, because that is the path where `error` is empty. A *failed* worker (non-empty error) splits correctly, which is why the existing behaviour looks fine whenever you go looking at failures.

## The fix

Join and split on `\x1f` (ASCII US) instead. A non-whitespace delimiter gets one-field-per-unit splitting with empty fields preserved, which is what this code actually needs. Emitter and reader are changed together.

Two lines of real change; the rest is a comment explaining the hazard so it does not get "tidied" back to `\t`.

## Test

`tests/batch-runner-score-delimiter.test.mjs` (auto-discovered).

It **extracts the real emitter and reader out of `batch/batch-runner.sh`** and runs them, rather than restating them, so the test and the code cannot drift apart. It asserts:

- emitter and reader use the same delimiter
- the delimiter is not IFS whitespace
- a successful worker records `3.4`, not `-`
- the empty `error` field stays empty instead of absorbing the score
- `status` still parses

Verified in both directions:

| tree | result |
|---|---|
| `upstream/main` (unpatched) | **3 assertions fail** — `score was recorded as "-" instead of 3.4`, `error absorbed the next field: "3.4"`, `delimiter "\t" is IFS whitespace` |
| with this patch | all 5 pass |

Full suite, run in a clean worktree so no local state could influence it:

| tree | result |
|---|---|
| `upstream/main` | 2756 passed, 0 failed |
| `upstream/main` + this PR | 2761 passed, 0 failed |

`+5` is exactly this PR's new assertions; nothing else moves.

## Notes

Found while merging upstream into a fork. Happy to adjust the delimiter choice, the comment, or the test's shape — and to split the test into its own PR if you'd rather take the one-line fix on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch result parsing to preserve empty error fields and correctly retain status and score values.

* **Tests**
  * Added end-to-end coverage verifying reliable parsing when the error field is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->