### PR TITLE
fix(workable): use the public widget API so large accounts are scanned

### DIFF
--- a/providers/workable.mjs
+++ b/providers/workable.mjs
@@ -1,13 +1,38 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
 
-// Workable provider — hits the public markdown feed at /<slug>/jobs.md.
-// Workable's documented JSON API requires an auth token; the markdown feed
-// is the only no-auth public surface. Auto-detects from careers_url pattern
-// `https://apply.workable.com/<slug>`. A tracked_companies entry can also
-// set `provider: workable` explicitly to bypass detection.
+// Workable provider — public, no-auth account widget API:
+//   GET https://apply.workable.com/api/v1/widget/accounts/<slug>?details=true
+//   → { name, description, jobs: [{ title, shortcode, shortlink, url, department,
+//        city, state, country, telecommuting, published_on, description, … }] }
+//
+// The widget API returns the account's FULL posting list in one request (verified
+// live against a 259-posting account) and ships `description` + `published_on`
+// for free, so scan.mjs's content_filter and the recency logic in
+// scan-ats-full.mjs both work for Workable companies.
+//
+// The older markdown feed at /<slug>/jobs.md is kept as a fallback only. It
+// cannot be the primary path:
+//   · on a large account the bare feed returns a department *summary* instead of
+//     the job table, so there are no rows to parse — a 259-posting account
+//     silently yielded ZERO jobs;
+//   · it is hard-capped at 30 rows and honours no pagination parameter
+//     (page/offset/limit/startrow all return the same first 30);
+//   · segmenting by `?department=` is incomplete (departments listed in the
+//     summary sum to less than the account total, and a department over 30 roles
+//     is itself truncated).
+//
+// Auto-detects from careers_url pattern `https://apply.workable.com/<slug>`. A
+// tracked_companies entry can also set `provider: workable` to bypass detection.
+
+import { decodeEntities } from './_html-entities.mjs';
 
 const ALLOWED_WORKABLE_HOSTS = new Set(['apply.workable.com']);
+
+// Workable account slugs are alphanumerics plus - and _ . Anything else is
+// rejected rather than interpolated, so a crafted careers_url cannot escape the
+// path (e.g. `..%2f..%2f`) when we build the API URL.
+const SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 
 function assertWorkableUrl(url) {
   let parsed;
@@ -23,8 +48,12 @@ function assertWorkableUrl(url) {
   return url;
 }
 
-function resolveFeedUrl(entry) {
-  const raw = typeof entry.careers_url === 'string' ? entry.careers_url : '';
+/**
+ * Extract the account slug from a tracked_companies entry's careers_url.
+ * @returns {string|null}
+ */
+export function resolveWorkableSlug(entry) {
+  const raw = entry && typeof entry.careers_url === 'string' ? entry.careers_url : '';
   if (!raw) return null;
   let parsed;
   try {
@@ -35,33 +64,124 @@ function resolveFeedUrl(entry) {
   if (parsed.protocol !== 'https:') return null;
   if (parsed.hostname !== 'apply.workable.com') return null;
   const slug = parsed.pathname.split('/').filter(Boolean)[0];
-  if (!slug) return null;
-  return `https://apply.workable.com/${slug}/jobs.md`;
+  if (!slug || !SLUG_RE.test(slug)) return null;
+  return slug;
 }
+
+const widgetUrlFor = (slug) => `https://apply.workable.com/api/v1/widget/accounts/${slug}?details=true`;
+const feedUrlFor = (slug) => `https://apply.workable.com/${slug}/jobs.md`;
 
 /** @type {Provider} */
 export default {
   id: 'workable',
 
   detect(entry) {
-    const feedUrl = resolveFeedUrl(entry);
-    return feedUrl ? { url: feedUrl } : null;
+    const slug = resolveWorkableSlug(entry);
+    return slug ? { url: widgetUrlFor(slug) } : null;
   },
 
   async fetch(entry, ctx) {
-    const feedUrl = resolveFeedUrl(entry);
-    if (!feedUrl) throw new Error(`workable: cannot derive feed URL for ${entry.name}`);
-    assertWorkableUrl(feedUrl);
-    // redirect:'error' prevents SSRF via server-side redirects; combined with
-    // assertWorkableUrl above it guarantees the final hostname stays in the allowlist.
+    const slug = resolveWorkableSlug(entry);
+    if (!slug) throw new Error(`workable: cannot derive feed URL for ${entry.name}`);
+
+    // Primary: widget API. assertWorkableUrl + redirect:'error' together
+    // guarantee the final hostname stays in the allowlist (no SSRF via redirect).
+    const apiUrl = assertWorkableUrl(widgetUrlFor(slug));
+    let payload = null;
+    try {
+      payload = await ctx.fetchJson(apiUrl, { redirect: 'error' });
+    } catch {
+      payload = null; // fall through to the markdown feed
+    }
+    if (payload && Array.isArray(payload.jobs)) {
+      return parseWorkableWidget(payload, entry.name);
+    }
+
+    // Fallback: legacy markdown feed (small accounts only — see header note).
+    const feedUrl = assertWorkableUrl(feedUrlFor(slug));
     const text = await ctx.fetchText(feedUrl, { redirect: 'error' });
     return parseWorkableMarkdown(text, entry.name);
   },
 };
 
 /**
- * Parse Workable's public markdown feed. Exported as a named export for unit
- * tests. The feed exposes a table:
+ * Validate a job URL against the Workable allowlist.
+ * @returns {string|null} normalized href, or null when it must be dropped
+ */
+function safeJobUrl(raw) {
+  if (typeof raw !== 'string' || !raw) return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== 'https:') return null;
+    if (!ALLOWED_WORKABLE_HOSTS.has(parsed.hostname)) return null;
+    return parsed.href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the location string. The markdown feed rendered "<city>, <country>"; we
+ * match that shape so location_filter behaves identically across both paths.
+ */
+function formatLocation(job) {
+  const parts = [job?.city, job?.country].filter(v => typeof v === 'string' && v.trim());
+  const joined = parts.map(v => v.trim()).join(', ');
+  if (joined) return joined;
+  return job?.telecommuting ? 'Remote' : '';
+}
+
+/** Strip HTML tags/entities from the widget's rich-text description. */
+function toPlainText(html) {
+  if (typeof html !== 'string' || !html) return '';
+  return decodeEntities(
+    html
+      .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ')
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/(p|div|li|h[1-6])>/gi, '\n')
+      .replace(/<[^>]+>/g, ' '),
+  ).replace(/[ \t ]+/g, ' ').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+/**
+ * Parse the widget API payload. Exported for unit tests.
+ *
+ * @param {any} payload — parsed JSON body of the widget endpoint
+ * @param {string} companyName — value to write into job.company
+ * @returns {Array<{title: string, url: string, company: string, location: string, description?: string, postedAt?: number}>}
+ */
+export function parseWorkableWidget(payload, companyName) {
+  if (!payload || !Array.isArray(payload.jobs)) return [];
+  const jobs = [];
+  const seen = new Set();
+  for (const raw of payload.jobs) {
+    const title = typeof raw?.title === 'string' ? raw.title.trim() : '';
+    if (!title) continue;
+
+    // shortlink is the canonical public permalink; url is the same host. Either
+    // is fine, both are validated. Off-domain or non-https entries are dropped.
+    const url = safeJobUrl(raw?.shortlink) || safeJobUrl(raw?.url);
+    if (!url || seen.has(url)) continue;
+    seen.add(url);
+
+    /** @type {any} */
+    const job = { title, url, location: formatLocation(raw), company: companyName };
+
+    const description = toPlainText(raw?.description);
+    if (description) job.description = description;
+
+    const stamp = Date.parse(raw?.published_on || raw?.created_at || '');
+    if (Number.isFinite(stamp)) job.postedAt = stamp;
+
+    jobs.push(job);
+  }
+  return jobs;
+}
+
+/**
+ * Parse Workable's public markdown feed. Fallback path — see the header note on
+ * why this can't be primary. Exported as a named export for unit tests. The feed
+ * exposes a table:
  *   | Title | Department | Location | Type | Salary | Posted | Details |
  * where `Details` holds a markdown link
  *   [View](https://apply.workable.com/<slug>/jobs/view/<id>.md)
@@ -88,16 +208,10 @@ export function parseWorkableMarkdown(text, companyName) {
     if (url.endsWith('.md')) url = url.slice(0, -3);
     if (!url) continue;  // skip rows with no resolvable URL (e.g., malformed [View] link)
 
-    // Validate the extracted URL — must parse as https://apply.workable.com/...
-    try {
-      const parsedUrl = new URL(url);
-      if (parsedUrl.protocol !== 'https:' || parsedUrl.hostname !== 'apply.workable.com') continue;
-      url = parsedUrl.href;
-    } catch {
-      continue;
-    }
+    const safe = safeJobUrl(url);
+    if (!safe) continue;
 
-    jobs.push({ title, url, location, company: companyName });
+    jobs.push({ title, url: safe, location, company: companyName });
   }
   return jobs;
 }

--- a/tests/providers/workable.test.mjs
+++ b/tests/providers/workable.test.mjs
@@ -8,15 +8,15 @@ console.log('\nProvider — workable');
 try {
   const workableModule = await import(pathToFileURL(join(ROOT, 'providers/workable.mjs')).href);
   const workable = workableModule.default;
-  const { parseWorkableMarkdown } = workableModule;
+  const { parseWorkableMarkdown, parseWorkableWidget } = workableModule;
 
   // detect() — auto-detection from careers_url
   if (workable.id === 'workable') pass('workable.id is "workable"');
   else fail(`workable.id is ${JSON.stringify(workable.id)}`);
 
   const hit = workable.detect({ name: 'TestCo', careers_url: 'https://apply.workable.com/optimile' });
-  if (hit && hit.url === 'https://apply.workable.com/optimile/jobs.md') {
-    pass('workable.detect() resolves apply.workable.com/<slug> → /jobs.md feed');
+  if (hit && hit.url === 'https://apply.workable.com/api/v1/widget/accounts/optimile?details=true') {
+    pass('workable.detect() resolves apply.workable.com/<slug> → widget API');
   } else {
     fail(`workable.detect() returned ${JSON.stringify(hit)}`);
   }
@@ -58,21 +58,96 @@ try {
   if (parseWorkableMarkdown(null, 'X').length === 0) pass('null input → empty result (no crash)');
   else fail('null input should yield empty result without crashing');
 
-  // fetch() reaches the http context on the happy path (allowed hostname).
-  await workable.fetch(
+  // -- widget API (primary path) ------------------------------------------
+  const widgetPayload = {
+    name: 'Optimile',
+    jobs: [
+      {
+        title: 'Senior AI PM',
+        shortlink: 'https://apply.workable.com/j/ABC123',
+        url: 'https://apply.workable.com/j/ABC123',
+        city: 'Ghent', country: 'Belgium',
+        published_on: '2026-04-01',
+        description: '<p>Own the <b>roadmap</b>.</p><script>alert(1)</script>',
+      },
+      {
+        title: 'Tech Lead',
+        shortlink: 'https://apply.workable.com/j/DEF456',
+        telecommuting: true,
+        published_on: '2026-03-25',
+      },
+      // dropped: off-domain permalink
+      { title: 'Evil Role', shortlink: 'https://evil.example/j/X', url: 'https://evil.example/j/X' },
+      // dropped: no title
+      { title: '   ', shortlink: 'https://apply.workable.com/j/NOPE' },
+    ],
+  };
+  const widgetJobs = parseWorkableWidget(widgetPayload, 'Optimile');
+  if (widgetJobs.length === 2) pass('parseWorkableWidget keeps only valid, on-domain, titled jobs');
+  else fail(`parseWorkableWidget returned ${widgetJobs.length} jobs, expected 2: ${JSON.stringify(widgetJobs.map(j => j.title))}`);
+
+  if (widgetJobs[0]?.location === 'Ghent, Belgium' && widgetJobs[1]?.location === 'Remote') {
+    pass('parseWorkableWidget formats location (city, country / Remote)');
+  } else {
+    fail(`locations were ${JSON.stringify(widgetJobs.map(j => j.location))}`);
+  }
+
+  if (widgetJobs[0]?.postedAt === Date.parse('2026-04-01')) pass('parseWorkableWidget maps published_on → postedAt');
+  else fail(`postedAt was ${widgetJobs[0]?.postedAt}`);
+
+  const desc = widgetJobs[0]?.description || '';
+  if (desc.includes('Own the roadmap') && !desc.includes('<') && !desc.includes('alert(1)')) {
+    pass('parseWorkableWidget strips HTML tags and script bodies from description');
+  } else {
+    fail(`description was ${JSON.stringify(desc)}`);
+  }
+
+  if (parseWorkableWidget(null, 'X').length === 0 && parseWorkableWidget({}, 'X').length === 0) {
+    pass('parseWorkableWidget tolerates null / jobs-less payloads');
+  } else {
+    fail('parseWorkableWidget should return [] for null and {} payloads');
+  }
+
+  // fetch() prefers the widget API and never touches the markdown feed when it works.
+  const apiJobs = await workable.fetch(
     { name: 'Smoke', careers_url: 'https://apply.workable.com/optimile' },
     {
       transport: 'http',
-      fetchText: async (url) => {
-        if (!url.startsWith('https://apply.workable.com/')) {
-          throw new Error('fetchText called with unexpected URL');
+      fetchJson: async (url) => {
+        if (url !== 'https://apply.workable.com/api/v1/widget/accounts/optimile?details=true') {
+          throw new Error(`fetchJson called with unexpected URL: ${url}`);
         }
-        return '| Title | Department | Location | Type | Salary | Posted | Details |\n|---|---|---|---|---|---|---|\n';
+        return widgetPayload;
       },
-      fetchJson: async () => { throw new Error('fetchJson should not be called'); },
+      fetchText: async () => { throw new Error('markdown feed should not be used when the API succeeds'); },
     },
   );
-  pass('workable.fetch() reaches fetchText on the happy path (allowed hostname)');
+  if (apiJobs.length === 2) pass('workable.fetch() uses the widget API as the primary path');
+  else fail(`workable.fetch() via API returned ${apiJobs.length} jobs, expected 2`);
+
+  // fetch() falls back to the markdown feed when the API fails.
+  const fallbackJobs = await workable.fetch(
+    { name: 'Smoke', careers_url: 'https://apply.workable.com/optimile' },
+    {
+      transport: 'http',
+      fetchJson: async () => { throw new Error('HTTP 503'); },
+      fetchText: async (url) => {
+        if (url !== 'https://apply.workable.com/optimile/jobs.md') {
+          throw new Error(`fetchText called with unexpected URL: ${url}`);
+        }
+        return [
+          '| Title | Department | Location | Type | Salary | Posted | Details |',
+          '|---|---|---|---|---|---|---|',
+          '| Fallback Role | Product | Remote | Full-time | — | 2026-04-01 | [View](https://apply.workable.com/optimile/jobs/view/ZZZ.md) |',
+        ].join('\n');
+      },
+    },
+  );
+  if (fallbackJobs.length === 1 && fallbackJobs[0].title === 'Fallback Role') {
+    pass('workable.fetch() falls back to the markdown feed when the widget API fails');
+  } else {
+    fail(`fallback returned ${JSON.stringify(fallbackJobs)}`);
+  }
 
   // fetch() rejects an unresolvable careers_url (no apply.workable.com match in URL).
   let rejected = false;


### PR DESCRIPTION
## What does this PR do?

`providers/workable.mjs` silently returned **zero jobs** for any Workable account large enough to trigger Workable's summary view — the bare `/<slug>/jobs.md` feed renders a department roll-up instead of the job table, so there are no rows to parse. This switches the provider to Workable's public, no-auth **account widget API**, which returns the account's full posting list in one request, and keeps the markdown feed as a fallback.

Found live: a tracked company with 259 open postings was reported as `live but empty` on every scan. After the fix the same account contributes its full listing (34 postings survived my `title_filter`/`location_filter`).

## Related issue

None — the template exempts bug fixes and scanner providers from issue-first, so sending it straight in.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Why the markdown feed can't be salvaged

I tried to page around it before replacing it:

- **Hard-capped at 30 rows**, and it honours no pagination parameter — `page`, `offset`, `limit` and `startrow` all return the same first 30 rows.
- **Segmenting by `?department=` is incomplete.** The departments listed in the summary sum to *less* than the account total (237 of 259 on the account I tested), so 22 postings are unreachable that way — and a department with more than 30 roles is itself truncated, which one was.

## The replacement

```
GET https://apply.workable.com/api/v1/widget/accounts/<slug>?details=true
→ { name, description, jobs: [ { title, shortlink, url, department, city,
    state, country, telecommuting, published_on, description, … } ] }
```

No auth, no pagination, complete. It also carries two fields the markdown feed never had:

- `description` → so `scan.mjs`'s `content_filter` now works for Workable companies
- `published_on` → so the recency filtering in `scan-ats-full.mjs` now works too (it dropped 34 stale postings on my first run, which it previously could not see)

The markdown feed remains as a fallback when the API call fails, so existing setups degrade rather than break.

## Security

Existing properties are preserved on **both** paths — the `apply.workable.com` host allowlist, `redirect: 'error'` against SSRF-by-redirect, and per-job URL re-validation before a job is emitted.

One property is added: the account slug is now charset-guarded (`/^[A-Za-z0-9][A-Za-z0-9_-]*$/`) before it is interpolated into the API URL, so a crafted `careers_url` can't escape the path.

## Tests

`detect()` now reports the widget API URL it actually fetches; the existing assertion is updated to match. Seven cases added for the new path:

- location formatting (`city, country`, and `Remote` for telecommuting entries)
- `published_on` → `postedAt`
- HTML tag and `<script>` body stripping from descriptions
- off-domain / non-HTTPS permalink rejection
- `null` and `jobs`-less payloads
- widget API used as primary (markdown feed untouched when it succeeds)
- fallback to the markdown feed when the API throws

**`node test-all.mjs`: 2754 passed, 1 failed.** In the interest of being straight about it, the failure is *not* from this change:

```
❌ analyze() appDateSource end-to-end check crashed: EPERM: operation not
   permitted, symlink 'C:\...\node_modules' -> 'C:\...\co-cadence-e2e-XXXX\node_modules'
```

That's `followup-cadence`'s e2e test symlinking `node_modules`, which Windows blocks without Developer Mode or elevation. I stashed this branch's changes and reproduced the identical failure on a clean `main`, so it's a pre-existing platform limitation. Everything else, including the full provider suite, passes.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass — *with the one pre-existing Windows-only failure documented above*
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files — only `providers/` and `tests/`)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Workable job listing retrieval using the public widget API.
  * Added automatic fallback to the legacy feed when widget data is unavailable.
  * Job listings now include validated locations, publication dates, deduplicated results, and plain-text descriptions.

* **Bug Fixes**
  * Improved validation of Workable account links and job URLs.
  * Handled malformed API responses more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->