### PR TITLE
docs(SCRIPTS): document set-status --role/--on/--json flags & bare-number vs explicit selector usage (#2355)

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -836,16 +836,16 @@ Canonical tracker write path: strict `states.yml` validation, shared lock, atomi
 node set-status.mjs <report#|company> <state> [--note "..."] [--on YYYY-MM-DD] [--force] [--dry-run] [--json]
 node set-status.mjs --row N <state> [--note "..."]          # explicit tracker row ID
 node set-status.mjs --report N <state> [--note "..."]       # row whose Report cell links report #N
-node set-status.mjs --role "Role Name" <state>              # filter by role fragment
+node set-status.mjs "Company Name" Applied --role "Role"    # narrow match by role fragment
 node set-status.mjs --row 12 Applied
 node set-status.mjs --report 345 Applied --on 2026-08-01
 ```
 
-A bare number or company name is convenient, but becomes ambiguous once tracker row IDs and report IDs diverge or when multiple applications share a company. Explicit selectors disambiguate the target row and number space:
+A bare number or company name is convenient, but becomes ambiguous when multiple tracker rows exist for a company or when tracker row IDs and report IDs diverge. Base selectors resolve the main target, while explicit selectors and filters disambiguate the target row:
 
 - `--row N`: Selects the row whose `#` cell is `N`.
 - `--report N`: Selects the row whose `Report` cell links report `N`.
-- `--role <role>`: Disambiguates by role fragment when multiple tracker rows exist for a single company.
+- `--role <role>`: Narrowing selector that refines a company, report, row, or bare-number match when multiple tracker rows exist for a single target.
 - `--on <date>`: Specifies an explicit transition date (YYYY-MM-DD) for status logs and notes.
 - `--json`: Formats command output as structured JSON.
 
@@ -854,7 +854,7 @@ A bare number or company name is convenient, but becomes ambiguous once tracker 
 ### Bare numbers vs. explicit selectors
 
 - **Use a bare number** when tracker row IDs and report IDs are identical or when querying interactively.
-- **Use `--row N` or `--report N`** in automated scripts, modes, or whenever row IDs and report IDs have diverged to avoid ambiguous updates.
+- **Use `--row N` or `--report N`** in automated scripts, modes, or whenever row IDs and report IDs have diverged to avoid triggering report-number mismatch guards or ambiguous updates. Use `--role` alongside a base selector to narrow down multiple matching roles for a company.
 
 Exit codes:
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -833,19 +833,28 @@ These have no `npm run` binding — modes and agents call them with
 Canonical tracker write path: strict `states.yml` validation, shared lock, atomic write. Modes and agents call this instead of hand-editing `applications.md`.
 
 ```bash
-node set-status.mjs <report#|company> <state> [--note "..."] [--force] [--dry-run]
+node set-status.mjs <report#|company> <state> [--note "..."] [--on YYYY-MM-DD] [--force] [--dry-run] [--json]
 node set-status.mjs --row N <state> [--note "..."]          # explicit tracker row ID
 node set-status.mjs --report N <state> [--note "..."]       # row whose Report cell links report #N
+node set-status.mjs --role "Role Name" <state>              # filter by role fragment
 node set-status.mjs --row 12 Applied
-node set-status.mjs --report 345 Applied
+node set-status.mjs --report 345 Applied --on 2026-08-01
 ```
 
-A bare number is ambiguous once tracker row IDs and report IDs diverge, so an explicit selector disambiguates which number space you mean:
+A bare number or company name is convenient, but becomes ambiguous once tracker row IDs and report IDs diverge or when multiple applications share a company. Explicit selectors disambiguate the target row and number space:
 
-- `--row N` selects the row whose `#` cell is `N`.
-- `--report N` selects the row whose `Report` cell links report `N`.
+- `--row N`: Selects the row whose `#` cell is `N`.
+- `--report N`: Selects the row whose `Report` cell links report `N`.
+- `--role <role>`: Disambiguates by role fragment when multiple tracker rows exist for a single company.
+- `--on <date>`: Specifies an explicit transition date (YYYY-MM-DD) for status logs and notes.
+- `--json`: Formats command output as structured JSON.
 
 `--row` and `--report` are mutually exclusive. Because an explicit selector answers the report-mismatch guard rather than overriding it, `--row` bypasses that guard without needing `--force` (which silences the check while the ambiguity is still real).
+
+### Bare numbers vs. explicit selectors
+
+- **Use a bare number** when tracker row IDs and report IDs are identical or when querying interactively.
+- **Use `--row N` or `--report N`** in automated scripts, modes, or whenever row IDs and report IDs have diverged to avoid ambiguous updates.
 
 Exit codes:
 


### PR DESCRIPTION
## Summary
Follow-up to #2359. As requested in PR #2391 review, this adds the remaining documentation pieces for `set-status.mjs` on top of current `main`:

1. Documented the `--role <role>`, `--on <date>`, and `--json` flags.
2. Added explicit guidance comparing when a bare number is sufficient vs when to use explicit selectors (`--row`, `--report`, `--role`).
3. Cleaned up example usage to use canonical `Applied`.

Closes #2355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated status-setting command documentation with `--on`, `--json`, and `--role` options.
  * Added company-based examples and role-based selection guidance.
  * Clarified transition-date behavior and structured output.
  * Added guidance for resolving ambiguous company or numeric selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->