### PR TITLE
fix(test): use a junction on Windows for the node_modules link

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6282,7 +6282,17 @@ try {
       copyFileSync(join(ROOT, 'followup-cadence.mjs'), join(e2eTmp, 'followup-cadence.mjs'));
       copyFileSync(join(ROOT, 'tracker-parse.mjs'), join(e2eTmp, 'tracker-parse.mjs'));
       copyFileSync(join(ROOT, 'tracker-aliases.json'), join(e2eTmp, 'tracker-aliases.json'));
-      symlinkSync(join(ROOT, 'node_modules'), join(e2eTmp, 'node_modules'), 'dir');
+      // 'junction' on Windows, not 'dir': a directory symlink needs
+      // SeCreateSymbolicLinkPrivilege, which a normal shell lacks unless
+      // Developer Mode is on, so this threw EPERM and failed the test on an
+      // ordinary Windows checkout. Junctions need no privilege, and the two
+      // constraints they add are already met — the target is absolute and is a
+      // directory on a local volume. The type argument is ignored off Windows.
+      symlinkSync(
+        join(ROOT, 'node_modules'),
+        join(e2eTmp, 'node_modules'),
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
       mkdirSync(join(e2eTmp, 'data'), { recursive: true });
       writeFileSync(join(e2eTmp, 'data', 'applications.md'), [
         '# Applications Tracker',


### PR DESCRIPTION
## Problem

`test-all.mjs` fails on an ordinary Windows checkout, in a place where nothing is actually wrong:

```
❌ analyze() appDateSource end-to-end check crashed: EPERM: operation not permitted,
   symlink 'D:\Career Ops\node_modules' -> 'C:\Users\...\Temp\co-cadence-e2e-j0oB4r\node_modules'
```

The `appDateSource` end-to-end check links `node_modules` into a temp directory so the copied `followup-cadence.mjs` can resolve its imports. It asks for type `'dir'`, and a **directory symlink on Windows requires `SeCreateSymbolicLinkPrivilege`** — which a normal shell does not hold unless Developer Mode is enabled.

CI never sees this, because the `windows-latest` runner has the privilege. It only shows up for contributors running the suite locally on Windows.

It also fails *hard*. The other two symlink sites in this file are wrapped in `try/catch` and degrade through `warn()` when the filesystem refuses. This one reports through `fail()`, so the entire suite goes red.

## Fix

Use a junction on Windows:

```js
symlinkSync(
  join(ROOT, 'node_modules'),
  join(e2eTmp, 'node_modules'),
  process.platform === 'win32' ? 'junction' : 'dir',
);
```

Junctions need no special privilege. They add two constraints, both already satisfied at this call site: the target must be an absolute path, and it must be a directory on a local volume. The `type` argument is ignored off Windows, so POSIX behaviour is unchanged.

## Verification

On Windows 11, same machine that produced the failure:

| symlink type | result |
|---|---|
| `'dir'` | `EPERM` |
| `'junction'` | created, and `followup-cadence.mjs` runs through the linked `node_modules` |

Full suite with the fix applied: **2781 passed, 0 failed, 2 warnings**. The three `appDateSource` assertions pass rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test compatibility on Windows by using the appropriate link type for temporary dependencies.
  * Preserved existing behavior on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->