### PR TITLE
fix(doctor): detect Playwright MCP in JSONC OpenCode configs (#2252)

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -12,6 +12,7 @@ import yaml from 'js-yaml';
 import dotenv from 'dotenv';
 import { discoverPlugins, pluginRoots, pluginStatus } from './plugins/_engine.mjs';
 import { resolveExtractorMode } from './browser-extract.mjs';
+import { parseConfigByExtension } from './jsonc-parse.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const argv = process.argv.slice(2);
@@ -108,7 +109,10 @@ async function checkPlaywright() {
 // Per-CLI MCP config registry.
 const MCP_CONFIGS = [
   { cli: 'claude',   files: ['.mcp.json', '.claude/settings.json', '.claude/settings.local.json'] },
-  { cli: 'opencode', files: ['opencode.json'] },
+  // opencode.jsonc is JSONC: OpenCode accepts comments and trailing commas
+  // there, and JSON.parse throwing on them used to read as "no MCP server
+  // configured" (#2252).
+  { cli: 'opencode', files: ['opencode.json', 'opencode.jsonc'] },
 ];
 
 // Server qualifies if its definition references the @playwright/mcp package.
@@ -125,7 +129,7 @@ function isPlaywrightMcpConfigured(root, activeCli) {
     const file = join(root, ...rel.split('/'));
     if (!existsSync(file)) return false;
     try {
-      const cfg = JSON.parse(readFileSync(file, 'utf8')) ?? {};
+      const cfg = parseConfigByExtension(file, readFileSync(file, 'utf8')) ?? {};
       const buckets = [cfg.mcpServers, cfg.mcp].filter((b) => b && typeof b === 'object');
       return buckets.some((servers) => Object.values(servers).some(isPlaywrightServer));
     } catch {

--- a/jsonc-parse.mjs
+++ b/jsonc-parse.mjs
@@ -1,0 +1,116 @@
+/**
+ * jsonc-parse.mjs — JSON.parse for config files written in JSONC.
+ *
+ * OpenCode accepts JSONC for its project config (`opencode.jsonc`): `//` and
+ * comments, plus trailing commas before a closing brace or bracket. Feeding
+ * that to `JSON.parse` throws, and doctor.mjs read the throw as "the Playwright
+ * MCP server is not configured" — a commented-out config reported as a missing
+ * one (#2252).
+ *
+ * Deliberately not a full JSON5 implementation: only the two JSONC extensions
+ * above are handled, and the result still goes through `JSON.parse`, so an
+ * actually-malformed file still throws exactly as before.
+ */
+
+/**
+ * Remove JSONC comments and trailing commas from a source string.
+ *
+ * The scan is string-aware, which is the whole difficulty: `//` inside a JSON
+ * string is content, not a comment — `"url": "https://example.com"` and
+ * `"path": "C:\\a\\b"` must survive, escaped quotes included. Same for a comma
+ * inside a string value ("a, }"), which a naive regex would eat.
+ *
+ * @param {string} source
+ * @returns {string} the same document as plain JSON
+ */
+export function stripJsoncSyntax(source) {
+  let out = '';
+  let inString = false;
+  let escaped = false;
+  /** @type {'line' | 'block' | null} */
+  let comment = null;
+
+  for (let index = 0; index < source.length; index++) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (comment === 'line') {
+      // Keep the newline: it terminates the comment and preserves line numbers
+      // in whatever error JSON.parse throws afterwards.
+      if (char === '\n') {
+        comment = null;
+        out += char;
+      }
+      continue;
+    }
+    if (comment === 'block') {
+      if (char === '*' && next === '/') {
+        comment = null;
+        index++;
+      }
+      continue;
+    }
+
+    if (inString) {
+      out += char;
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      out += char;
+      continue;
+    }
+    if (char === '/' && next === '/') {
+      comment = 'line';
+      index++;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      comment = 'block';
+      index++;
+      continue;
+    }
+
+    // A closing brace/bracket outside a string: drop the comma that precedes
+    // it, if any. Walking back over the ALREADY-EMITTED output is what makes
+    // this safe — a comma inside a string was emitted as string content and is
+    // never the character found here, and nesting needs no extra state.
+    if (char === '}' || char === ']') {
+      let back = out.length - 1;
+      while (back >= 0 && /\s/.test(out[back])) back--;
+      if (back >= 0 && out[back] === ',') out = out.slice(0, back) + out.slice(back + 1);
+    }
+
+    out += char;
+  }
+
+  return out;
+}
+
+/**
+ * Parse a JSONC document. Throws the same way `JSON.parse` does when the
+ * document is malformed beyond the two tolerated extensions.
+ *
+ * @param {string} source
+ * @returns {any}
+ */
+export function parseJsonc(source) {
+  return JSON.parse(stripJsoncSyntax(source));
+}
+
+/**
+ * Parse a config file by extension: `.jsonc` tolerates comments and trailing
+ * commas, everything else stays strict JSON so existing `.json` behaviour is
+ * untouched.
+ *
+ * @param {string} filePath
+ * @param {string} source
+ * @returns {any}
+ */
+export function parseConfigByExtension(filePath, source) {
+  return filePath.toLowerCase().endsWith('.jsonc') ? parseJsonc(source) : JSON.parse(source);
+}

--- a/tests/jsonc-parse.test.mjs
+++ b/tests/jsonc-parse.test.mjs
@@ -1,0 +1,84 @@
+// tests/jsonc-parse.test.mjs — the JSONC tolerance used for OpenCode configs
+// (#2252). doctor.mjs's end-to-end detection lives in
+// tests/playwright-mcp-detection.test.mjs; this file owns the parser itself,
+// where the interesting cases are the ones a naive regex stripper corrupts:
+// "//" inside a string, an escaped quote, a comma inside a string value.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\njsonc-parse.mjs — comment and trailing-comma tolerance');
+
+try {
+  const { parseJsonc, parseConfigByExtension } = await import(
+    pathToFileURL(join(ROOT, 'jsonc-parse.mjs')).href
+  );
+
+  const check = (label, actual, expected) => {
+    const got = JSON.stringify(actual);
+    const want = JSON.stringify(expected);
+    if (got === want) pass(label);
+    else fail(`${label} => ${got}, expected ${want}`);
+  };
+
+  // Plain JSON must survive untouched — the tolerance is additive.
+  check('plain JSON is unchanged', parseJsonc('{"a":1,"b":[2,3]}'), { a: 1, b: [2, 3] });
+
+  check('line comments are dropped', parseJsonc('{\n // why\n "a": 1 // trailing\n}'), { a: 1 });
+  check('block comments are dropped', parseJsonc('{ /* why */ "a": /* mid */ 1 }'), { a: 1 });
+  check('a block comment spanning lines is dropped', parseJsonc('{\n/*\n multi\n*/\n"a": 1}'), { a: 1 });
+
+  check('a trailing comma before } is dropped', parseJsonc('{"a": 1,}'), { a: 1 });
+  check('a trailing comma before ] is dropped', parseJsonc('{"a": [1, 2,]}'), { a: [1, 2] });
+  check('nested trailing commas are dropped', parseJsonc('{"a": {"b": [1,],},}'), { a: { b: [1] } });
+  check('a trailing comma with whitespace and a comment', parseJsonc('{"a": 1, // note\n}'), { a: 1 });
+
+  // The cases a regex-based stripper gets wrong.
+  check('// inside a string is content, not a comment',
+    parseJsonc('{"url": "https://example.com/a"}'), { url: 'https://example.com/a' });
+  check('/* inside a string is content',
+    parseJsonc('{"glob": "src/*/index.mjs"}'), { glob: 'src/*/index.mjs' });
+  check('an escaped quote does not end the string',
+    parseJsonc('{"say": "a \\" // b"}'), { say: 'a " // b' });
+  check('a backslash-heavy Windows path survives',
+    parseJsonc('{"path": "C:\\\\tmp\\\\a"}'), { path: 'C:\\tmp\\a' });
+  check('a comma before } inside a string is not touched',
+    parseJsonc('{"a": "x, }"}'), { a: 'x, }' });
+  check('a brace inside a string does not trigger comma removal',
+    parseJsonc('{"a": "}", "b": 1,}'), { a: '}', b: 1 });
+
+  // Realistic OpenCode config: comments, trailing commas, and a URL.
+  check('an OpenCode-shaped JSONC config parses',
+    parseJsonc([
+      '{',
+      '  // MCP servers',
+      '  "mcp": {',
+      '    "playwright": {',
+      '      "type": "local",',
+      '      "command": ["npx", "@playwright/mcp"], /* headless by default */',
+      '      "docs": "https://example.com//mcp",',
+      '    },',
+      '  },',
+      '}',
+    ].join('\n')),
+    { mcp: { playwright: { type: 'local', command: ['npx', '@playwright/mcp'], docs: 'https://example.com//mcp' } } });
+
+  // Malformed beyond the two tolerated extensions still throws.
+  let threw = false;
+  try { parseJsonc('{ "a": [ }'); } catch { threw = true; }
+  if (threw) pass('a genuinely malformed document still throws');
+  else fail('malformed JSONC should throw, not silently parse');
+
+  // Extension routing: .jsonc tolerates, everything else stays strict.
+  check('.jsonc is parsed tolerantly',
+    parseConfigByExtension('opencode.jsonc', '{"a": 1,}'), { a: 1 });
+  check('.JSONC is matched case-insensitively',
+    parseConfigByExtension('/tmp/OPENCODE.JSONC', '{"a": 1,}'), { a: 1 });
+
+  let strictThrew = false;
+  try { parseConfigByExtension('opencode.json', '{"a": 1,}'); } catch { strictThrew = true; }
+  if (strictThrew) pass('.json keeps strict parsing — a trailing comma still throws');
+  else fail('.json must not gain JSONC tolerance');
+} catch (e) {
+  fail(`jsonc-parse tests crashed: ${e.message}`);
+}

--- a/tests/playwright-mcp-detection.test.mjs
+++ b/tests/playwright-mcp-detection.test.mjs
@@ -336,6 +336,96 @@ try {
     } finally { rmSync(dir, { recursive: true, force: true }); }
   }
 
+  // 15. opencode.jsonc with comments AND a trailing comma → detected (#2252).
+  //     OpenCode accepts JSONC; JSON.parse throwing on it used to be swallowed
+  //     by the catch and reported as "no Playwright MCP server configured".
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-15-'));
+    try {
+      writeFileSync(join(dir, 'opencode.jsonc'), [
+        '{',
+        '  // Playwright drives the SPA job boards',
+        '  "mcp": {',
+        '    "playwright": {',
+        '      "type": "local",',
+        '      "command": ["npx", "@playwright/mcp", "--headless"], /* inline */',
+        '      "enabled": true,',
+        '    },',
+        '  },',
+        '}',
+      ].join('\n'));
+      const state = runDoctor(dir, ['--cli', 'opencode'], {});
+      if (!expectWarn(state, '#15 opencode.jsonc')) {
+        // already failed
+      } else if (state.playwright_mcp?.opencode === true
+          && Array.isArray(state.warnings)
+          && !state.warnings.some((w) => PLAYWRIGHT_RE.test(w))) {
+        pass('opencode.jsonc with comments + trailing commas → detected (#2252)');
+      } else {
+        fail(`#15 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  }
+
+  // 16. A .json file keeps STRICT parsing: comments there are still malformed,
+  //     so the config reads as unconfigured exactly as before. The tolerance is
+  //     scoped to the extension that declares it, not granted repo-wide.
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-16-'));
+    try {
+      writeFileSync(join(dir, 'opencode.json'),
+        '{\n  // not valid JSON\n  "mcp": { "playwright": { "command": ["npx", "@playwright/mcp"] } }\n}');
+      const state = runDoctor(dir, ['--cli', 'opencode'], {});
+      if (!expectWarn(state, '#16 commented .json')) {
+        // already failed
+      } else if (state.playwright_mcp?.opencode === false
+          && Array.isArray(state.warnings)
+          && state.warnings.some((w) => PLAYWRIGHT_RE.test(w))) {
+        pass('a commented opencode.json still reads as unconfigured — .json stays strict');
+      } else {
+        fail(`#16 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  }
+
+  // 17. opencode.json still wins when both files exist and only it is valid —
+  //     adding .jsonc to the list must not shadow the original filename.
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-17-'));
+    try {
+      writeFileSync(join(dir, 'opencode.json'),
+        JSON.stringify({ mcp: { playwright: { type: 'local', command: ['npx', '@playwright/mcp'] } } }));
+      writeFileSync(join(dir, 'opencode.jsonc'), '{ "mcp": {} }');
+      const state = runDoctor(dir, ['--cli', 'opencode'], {});
+      if (!expectWarn(state, '#17 both files')) {
+        // already failed
+      } else if (state.playwright_mcp?.opencode === true
+          && !state.warnings.some((w) => PLAYWRIGHT_RE.test(w))) {
+        pass('opencode.json is still read when an unrelated opencode.jsonc sits next to it');
+      } else {
+        fail(`#17 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  }
+
+  // 18. A .jsonc that is malformed beyond comments/trailing commas must stay
+  //     unconfigured — the parser tolerates two extensions, it does not guess.
+  {
+    const dir = mkdtempSync(join(tmpdir(), 'co-mcp-18-'));
+    try {
+      writeFileSync(join(dir, 'opencode.jsonc'), '{ "mcp": { "playwright": { "command": [ }');
+      const state = runDoctor(dir, ['--cli', 'opencode'], {});
+      if (!expectWarn(state, '#18 malformed .jsonc')) {
+        // already failed
+      } else if (state.playwright_mcp?.opencode === false
+          && state.warnings.some((w) => PLAYWRIGHT_RE.test(w))) {
+        pass('a genuinely malformed opencode.jsonc still reads as unconfigured');
+      } else {
+        fail(`#18 unexpected state: ${JSON.stringify(state)}`);
+      }
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  }
+
 } catch (e) {
   fail(`opencode-mcp-detection tests crashed: ${e.message}`);
 }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -183,6 +183,9 @@ const SYSTEM_PATHS = [
   'seeds/',
   'tests/',
   'doctor.mjs',
+  // doctor.mjs imports this one: an install that receives the new doctor
+  // without it would crash on startup.
+  'jsonc-parse.mjs',
   'check-liveness.mjs',
   'liveness-core.mjs',
   'liveness-api.mjs',


### PR DESCRIPTION
Fixes #2252

## Problem

OpenCode accepts JSONC for its project config. `doctor.mjs` only looked at `opencode.json` and parsed it with `JSON.parse`, inside a `catch` that treats any throw as "not configured":

```js
{ cli: 'opencode', files: ['opencode.json'] },
…
const cfg = JSON.parse(readFileSync(file, 'utf8')) ?? {};
```

So a user whose `opencode.jsonc` registers `@playwright/mcp` — or whose `opencode.json` carries a comment — is told the Playwright MCP server is not configured, and SPA job boards keep failing for a reason the doctor just misdiagnosed.

## Fix

- `opencode.jsonc` joins the opencode file list.
- `.jsonc` files parse through a new `jsonc-parse.mjs`; **`.json` keeps strict `JSON.parse`**, per the acceptance criteria.
- Only the two extensions OpenCode configs actually use are tolerated (comments, trailing commas), and the result still goes through `JSON.parse` — a genuinely malformed file throws exactly as before and stays "unconfigured".

**The parser is string-aware, which is the whole difficulty.** A regex stripper corrupts real configs: `"https://example.com"` is not a comment, `"src/*/index.mjs"` is not a block comment, `"a \" // b"` does not end where it looks like it does, and `{"a": "x, }"}` has no trailing comma. The scan tracks string state and escapes, and removes a trailing comma by walking back over *already-emitted* output — so a comma inside a string is never the one it finds, and nesting needs no extra state.

`jsonc-parse.mjs` is added to `SYSTEM_PATHS` in `update-system.mjs`: `doctor.mjs` imports it, so an install that received the new doctor without the module would crash on startup (the #2235 failure mode).

## Test plan

- [x] `tests/jsonc-parse.test.mjs` — 19 assertions, weighted toward what a naive stripper breaks: `//` and `/*` inside strings, escaped quotes, Windows paths, a comma before `}` inside a string value, nested trailing commas, a realistic OpenCode config, malformed input still throwing, and the extension routing (`.jsonc` tolerant, `.JSONC` case-insensitive, `.json` strict)
- [x] `tests/playwright-mcp-detection.test.mjs` — 4 new end-to-end cases: JSONC with comments + trailing comma is detected; a commented `.json` still reads as unconfigured; `opencode.json` is not shadowed by a sibling `.jsonc`; a malformed `.jsonc` stays unconfigured
- [x] `node test-all.mjs --quick` — 2807 passed, 0 failed

## Note on scope

A commented `opencode.json` (no `c`) still reads as unconfigured. That is the issue's explicit acceptance criterion ("Retain normal JSON parsing for `.json` files"), so it is left as-is rather than widened — say the word if OpenCode's own loader tolerates comments there too and you want the tolerance keyed on the CLI instead of the extension.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `opencode.jsonc` MCP configuration files.
  * JSONC files now support comments and trailing commas.
  * Standard `.json` files continue to use strict JSON parsing.

* **Bug Fixes**
  * Improved handling of malformed configuration files.
  * Preserved comment-like text inside strings and paths during parsing.

* **Tests**
  * Added coverage for JSONC parsing, file precedence, malformed configurations, and realistic MCP settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->