### PR TITLE
fix(verify-cv-facts): stop the modifier count from deciding whether a claim exists (#2279)

### DIFF
--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -37,8 +37,27 @@ const METRIC_NOUNS = [
   'servers', 'guides', 'articles', 'datasets', 'examples', 'deployments',
   'services', 'downloads', 'stars', 'lines', 'projects', 'integrations', 'tests',
 ];
+// How many words may sit between a number and the noun it counts. The same
+// regex parses the generated CV and the sources, so the window is symmetric by
+// construction — but a window still decides WHETHER a claim exists, and the CV
+// and its source rarely word a fact identically. At {0,2}, "~5 live Cloud Run
+// deployments" (three modifiers) yielded no claim while the paraphrase
+// "~5 Cloud Run deployments" (two) did, which broke the gate in both
+// directions (#2279):
+//
+//   - a truthful CV failed, because the claim existed on the CV side only;
+//   - a CHANGED number passed, because a 3-modifier phrasing on the CV side
+//     produced no claim to compare — and catching invented numbers is the
+//     entire point of this script.
+//
+// Four covers the phrasings seen in real CVs ("live Cloud Run deployments",
+// "active monthly paying customers"). Widening cannot hide an invented number:
+// it only ever extracts MORE claims, on both sides. A number is a hard barrier
+// for the chain — modifiers are alphabetic only — so a wider window still
+// cannot jump across an intervening figure to bind an unrelated noun.
+const MODIFIER_WINDOW = 4;
 const COUNT_CLAIM_RE = new RegExp(
-  String.raw`\b(\d[\d,.]*)\s*\+?\s*(?:[A-Za-z][A-Za-z-]*\s+){0,2}(${METRIC_NOUNS.join('|')})\b`,
+  String.raw`\b(\d[\d,.]*)\s*\+?\s*(?:[A-Za-z][A-Za-z-]*\s+){0,${MODIFIER_WINDOW}}(${METRIC_NOUNS.join('|')})\b`,
   'gi'
 );
 const NOUN_SYNONYMS = new Map([

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -430,6 +430,46 @@ function runSelfTest() {
   // A four-digit left part is a year, not a group: nothing is joined.
   equal('a year is not glued to the next number', auditClaims('Joined in 2026 100 users', foldSource).invented, ['100 users']);
 
+  // #2279 — the modifier count must never decide whether a claim exists. The
+  // source words the fact with three modifiers, the CV with two: at the old
+  // {0,2} window the claim was extracted from the CV side only, and a true
+  // statement failed the gate.
+  const modifierSource = 'Consolidated 25+ services down to ~5 live Cloud Run deployments.';
+  equal(
+    'same number, fewer modifiers in the CV',
+    auditClaims('25+ services consolidated to ~5 Cloud Run deployments', modifierSource).invented,
+    []
+  );
+  equal(
+    'same number, more modifiers in the CV',
+    auditClaims('Consolidated to ~5 live production Cloud Run deployments', modifierSource).invented,
+    []
+  );
+  // The direction that matters: a CHANGED number hid behind the 3-modifier
+  // phrasing, because the CV side yielded no claim to compare at all.
+  equal(
+    'changed number behind three modifiers is caught',
+    auditClaims('Consolidated to ~9 live Cloud Run deployments', modifierSource).invented,
+    ['9 deployments']
+  );
+  equal(
+    'changed number with the plain phrasing is still caught',
+    auditClaims('Consolidated to ~9 Cloud Run deployments', modifierSource).invented,
+    ['9 deployments']
+  );
+  // A wider window must not let the chain jump over an intervening figure to
+  // bind a number to a noun it does not count.
+  equal(
+    'a figure still blocks the chain',
+    auditClaims('Ran 7 experiments over 40 hours', 'Ran 7 experiments over 40 hours').invented,
+    []
+  );
+  equal(
+    'no cross-number binding invents evidence',
+    auditClaims('Shipped 3 integrations', 'Shipped 3 features across 12 integrations').invented,
+    ['3 integrations']
+  );
+
   console.log(`verify-cv-facts self-test: ${passed} passed, ${failed} failed`);
   return failed ? 1 : 0;
 }

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -458,10 +458,16 @@ function runSelfTest() {
     ['9 deployments']
   );
   // A wider window must not let the chain jump over an intervening figure to
-  // bind a number to a noun it does not count.
+  // bind a number to a noun it does not count. The source states the two facts
+  // in SEPARATE sentences on purpose: with identical text on both sides, a
+  // wrong "7 hours" extraction would appear on both and cancel itself out, so
+  // the assertion would pass while proving nothing. Both nouns are metric
+  // nouns, so each real claim is independently evidenced and the only thing
+  // that can surface as invented is a cross-number binding.
+  const numericBarrierSource = 'Ran 7 tests. Logged 40 hours.';
   equal(
     'a figure still blocks the chain',
-    auditClaims('Ran 7 experiments over 40 hours', 'Ran 7 experiments over 40 hours').invented,
+    auditClaims('Ran 7 tests over 40 hours', numericBarrierSource).invented,
     []
   );
   equal(


### PR DESCRIPTION
Fixes #2279

## Problem

`COUNT_CLAIM_RE` allowed at most two words between a number and the noun it counts. The same regex parses the generated CV and the sources, so the window is symmetric — but a window still decides **whether a claim exists at all**, and a CV rarely words a fact exactly like its source.

Reproduced on `main` with the reporter's example:

```
source: "Consolidated 25+ services down to ~5 live Cloud Run deployments"
        → claims: ["25 services"]                    ← "5 deployments" missing (3 modifiers)

CV:     "25+ services consolidated to ~5 Cloud Run deployments"
        → claims: ["25 services", "5 deployments"]   ← extracted (2 modifiers)
        → invented: ["5 deployments"]                ← a TRUE statement fails the gate
```

And the direction the maintainer flagged as the serious one:

```
CV:     "25+ services consolidated to ~9 live Cloud Run deployments"   (5 → 9)
        → claims: ["25 services"]
        → invented: []                               ← a CHANGED number passes silently
```

`modes/pdf.md` Step 18 makes this a hard gate, and its failure message pushes the user toward editing `cv.md` or adding a `config/cv-facts.json` exception for a fact that was already correct — weakening the guard that exists to catch real fabrications.

## Fix

The window becomes a named `MODIFIER_WINDOW = 4`, used by the one shared regex.

Widening is safe in the direction that matters: it only ever extracts **more** claims, on both sides, so it cannot hide an invented number — it can only surface more of them. And a figure remains a hard barrier for the chain (modifiers are alphabetic only), so a wider window still cannot jump over an intervening number to bind a noun it does not count. That last property is pinned by a test: `"Shipped 3 features across 12 integrations"` must not become evidence for a CV claiming `"3 integrations"`.

Four covers the phrasings that appear in real CVs (`live Cloud Run deployments`, `active monthly paying customers`).

## Test plan

- [x] `node verify-cv-facts.mjs --self-test` — 16 passed, 0 failed (10 existing + 6 new), and it is already wired into `test-all.mjs:218` with `expectExit: 0`
- [x] The two asymmetry cases were verified to **fail at the old `{0,2}`** and pass at `{0,4}` — reverting the constant produces exactly the two documented failures, so the guard has value rather than just describing current behaviour
- [x] New cases: same number with fewer modifiers than the source; same number with more; a changed number caught behind either phrasing; a figure still blocking the chain; no cross-number binding inventing evidence
- [x] `node test-all.mjs --quick` — 2783 passed, 0 failed

## Residual limit, stated plainly

Any finite window has a cliff — this moves it from 3 modifiers to 5, it does not remove it. Removing it entirely means changing the model: extract candidate numbers, then look for the nearest metric noun in the same clause on both sides, or keep strict extraction on the CV side while matching evidence generously on the source side. Both are bigger changes than this issue asks for; happy to follow up with either if you want the cliff gone rather than pushed out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of metric claims with multiple descriptive modifiers between numbers and counted nouns.
  * Prevented incorrect associations across separate numeric claims.
  * Improved detection of changed metric values in longer phrases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->