### PR TITLE
fix(verify-pipeline): Unicode-aware keys for company/role/Via grouping

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7705,6 +7705,112 @@ try {
   fail(`dedup blind-via channel key tests crashed (#2393): ${e.message}`);
 }
 
+// ── VERIFY-PIPELINE GROUPING KEYS: NON-LATIN COMPANIES AND ROLES (#2393) ──
+// Same root cause as the blind-via key above, one layer up. verify-pipeline
+// keyed Check 2 (duplicate tracker rows), Check 9 (duplicate report files) and
+// Check 11 (Via channels) by stripping [^a-z0-9], which erases CJK outright.
+// On a Japanese pipeline every company AND every role keyed to '', so unrelated
+// rows were reported as one "possible duplicates" cluster and the real signal
+// drowned — while Check 11 saw every non-Latin agency as 'direct' and never
+// fired. Controls: genuine same-company+same-role pairs must still be flagged.
+console.log('\n🧪 Testing verify-pipeline grouping keys with non-Latin text (#2393)...');
+try {
+  const vpKeyTmp = mkdtempSync(join(tmpdir(), 'career-ops-verify-unicode-'));
+  try {
+    const vpKeyReports = join(vpKeyTmp, 'reports');
+    mkdirSync(vpKeyReports, { recursive: true });
+    const vpKeyTracker = join(vpKeyTmp, 'applications.md');
+    const vpKeyEnv = {
+      ...process.env, CAREER_OPS_TRACKER: vpKeyTracker, CAREER_OPS_REPORTS: vpKeyReports,
+    };
+    const jaReport = (company, role) =>
+      `# Evaluación: ${company} — ${role}\n\n## Machine Summary\n\n\`\`\`yaml\ncompany: "${company}"\nrole: "${role}"\nscore: 4.0\n\`\`\`\n`;
+
+    // Two different roles at one non-Latin company: not duplicate reports.
+    writeFileSync(join(vpKeyReports, '001-yamabuki-2026-01-04.md'), jaReport('株式会社ヤマブキ', 'データアナリスト'));
+    writeFileSync(join(vpKeyReports, '002-yamabuki-2026-01-05.md'), jaReport('株式会社ヤマブキ', 'バックエンドエンジニア（アプリ基盤）'));
+    // Control: the same non-Latin role twice must still be caught.
+    writeFileSync(join(vpKeyReports, '003-kogane-2026-01-06.md'), jaReport('株式会社コガネ', 'プロダクトエンジニア'));
+    writeFileSync(join(vpKeyReports, '004-kogane-2026-01-07.md'), jaReport('株式会社コガネ', 'プロダクトエンジニア'));
+
+    writeFileSync(vpKeyTracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Via | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|-----|------|-------|--------|-----|--------|-------|\n' +
+      // (a) Different non-Latin companies AND different non-Latin roles.
+      '| 1 | 2026-01-04 | 株式会社アカネ | — | バックエンドエンジニア（自社サービス「配膳便」） | 4.1/5 | Evaluated | ❌ | [1](reports/001-yamabuki-2026-01-04.md) | ok |\n' +
+      '| 2 | 2026-01-05 | 株式会社コガネ | — | プロダクトエンジニア（サーバサイド/フロントエンド両面） | 4.1/5 | Evaluated | ❌ | [2](reports/002-yamabuki-2026-01-05.md) | ok |\n' +
+      // (b) One company, two genuinely different non-Latin roles.
+      '| 3 | 2026-01-06 | 株式会社ヤマブキ | — | データアナリスト | 3.2/5 | Evaluated | ❌ | [3](reports/003-kogane-2026-01-06.md) | ok |\n' +
+      '| 4 | 2026-01-07 | 株式会社ヤマブキ | — | バックエンドエンジニア（アプリ基盤） | 4.4/5 | Evaluated | ❌ | [4](reports/004-kogane-2026-01-07.md) | ok |\n' +
+      // (c) Control: identical non-Latin company+role is a real duplicate.
+      '| 5 | 2026-01-08 | 株式会社ミドリ | — | フルスタックエンジニア | 4.3/5 | Evaluated | ❌ | — | first |\n' +
+      '| 6 | 2026-01-09 | 株式会社ミドリ | — | フルスタックエンジニア | 4.3/5 | Evaluated | ❌ | — | second |\n' +
+      // (d) Check 11: one role reached through two non-Latin agencies.
+      '| 7 | 2026-01-10 | 株式会社アオゾラ | リクルート | 会計プロダクトエンジニア | 4.0/5 | Applied | ❌ | — | via A |\n' +
+      '| 8 | 2026-01-11 | 株式会社アオゾラ | パーソル | 会計プロダクトエンジニア | 4.0/5 | Applied | ❌ | — | via B |\n' +
+      // (e) Combining marks: Devanagari matras carry meaning and have no
+      // precomposed form, so NFKC cannot fold them into the base letter.
+      // Dropping \p{M} would key कंपनी and कपनी identically — the same
+      // collision as (a), one script over, and modes/hi ships a Hindi market.
+      '| 9 | 2026-01-12 | कंपनी सॉफ्टवेयर | — | बैकएंड इंजीनियर | 4.0/5 | Evaluated | ❌ | — | with matras |\n' +
+      '| 10 | 2026-01-13 | कपनी सफटवयर | — | बकएड इजीनियर | 4.0/5 | Evaluated | ❌ | — | matras stripped |\n');
+
+    const vpKeyOut = run(NODE, ['verify-pipeline.mjs'], { env: vpKeyEnv, stdio: ['pipe', 'pipe', 'pipe'] });
+    if (vpKeyOut === null) {
+      fail('verify-pipeline crashed on non-Latin grouping fixture (#2393)');
+    } else {
+      const dupLines = vpKeyOut.split('\n').filter(l => l.includes('Possible duplicates'));
+
+      if (!dupLines.some(l => /#1\b/.test(l) && /#2\b/.test(l))) {
+        pass('verify-pipeline keeps distinct non-Latin companies apart (#2393)');
+      } else {
+        fail(`verify-pipeline clustered unrelated non-Latin companies: ${dupLines.join(' | ')}`);
+      }
+
+      if (!dupLines.some(l => /#3\b/.test(l) && /#4\b/.test(l))) {
+        pass('verify-pipeline keeps distinct non-Latin roles at one company apart (#2393)');
+      } else {
+        fail(`verify-pipeline clustered distinct non-Latin roles: ${dupLines.join(' | ')}`);
+      }
+
+      if (dupLines.some(l => /#5\b/.test(l) && /#6\b/.test(l))) {
+        pass('verify-pipeline still flags a genuine non-Latin duplicate row pair (#2393)');
+      } else {
+        fail('verify-pipeline missed a genuine duplicate with identical non-Latin company+role');
+      }
+
+      const dupReportLines = vpKeyOut.split('\n').filter(l => l.includes('Duplicate reports for same company+role'));
+      if (!dupReportLines.some(l => l.includes('001-yamabuki') && l.includes('002-yamabuki'))) {
+        pass('verify-pipeline keeps two non-Latin roles under one company slug apart (#2393)');
+      } else {
+        fail(`verify-pipeline clustered distinct non-Latin report roles: ${dupReportLines.join(' | ')}`);
+      }
+      if (dupReportLines.some(l => l.includes('003-kogane') && l.includes('004-kogane'))) {
+        pass('verify-pipeline still flags two reports for one non-Latin company+role (#2393)');
+      } else {
+        fail('verify-pipeline missed a genuine duplicate report pair with a non-Latin role');
+      }
+
+      if (vpKeyOut.includes('Cross-channel duplicate') && vpKeyOut.includes('リクルート') && vpKeyOut.includes('パーソル')) {
+        pass('verify-pipeline flags one role reached via two non-Latin agencies (#2393)');
+      } else {
+        fail('verify-pipeline missed a cross-channel duplicate between two non-Latin agencies');
+      }
+
+      if (!dupLines.some(l => /#9\b/.test(l) && /#10\b/.test(l))) {
+        pass('verify-pipeline keeps Devanagari names differing only by combining marks apart');
+      } else {
+        fail(`verify-pipeline collapsed Devanagari names that differ by matras: ${dupLines.join(' | ')}`);
+      }
+    }
+  } finally {
+    rmSync(vpKeyTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`verify-pipeline non-Latin grouping key tests crashed (#2393): ${e.message}`);
+}
+
 // dedup-tracker / normalize-statuses rebuilt promoted rows with
 // `parts.slice(1, -1)`, which assumes the closing `|` produced a trailing empty
 // cell. A valid row written WITHOUT a trailing pipe keeps its real last cell

--- a/tracker-parse.mjs
+++ b/tracker-parse.mjs
@@ -356,5 +356,30 @@ export function extractTrackerReportNumbers(reportCell) {
  * @returns {string} Case-folded, punctuation-free, script-preserving key.
  */
 export function normalizeVia(name) {
-  return String(name).normalize('NFKC').toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
+  return normalizeTextKey(name);
+}
+
+/**
+ * Unicode-aware grouping key for any free-text tracker/report field.
+ *
+ * Same rule as normalizeVia(), generalized because Via is not the only field
+ * keyed this way: verify-pipeline groups tracker rows and report files by
+ * company+role with the same [a-z0-9] strip, so for a non-Latin pipeline every
+ * company keys to '' and every role keys to '' — three unrelated 株式会社X all
+ * land in one "possible duplicates" cluster (#2393). Keep letters and digits of
+ * any script; NFKC first so full-width/half-width variants compare equal.
+ *
+ * Combining marks are kept too (\p{M}): NFKC composes Latin diacritics into
+ * single code points, but Indic matras have no precomposed form, so stripping
+ * marks would make Devanagari कंपनी and कपनी — or क and का — the same key and
+ * re-introduce the exact collision this function exists to prevent.
+ *
+ * This is the one key every grouping consumer should share, so company/role
+ * identity cannot drift between scripts the way Via identity did.
+ *
+ * @param {string} value - Raw cell value (company, role, agency, slug, …).
+ * @returns {string} Case-folded, punctuation-free, script-preserving key.
+ */
+export function normalizeTextKey(value) {
+  return String(value).normalize('NFKC').toLowerCase().replace(/[^\p{L}\p{M}\p{N}]/gu, '');
 }

--- a/verify-pipeline.mjs
+++ b/verify-pipeline.mjs
@@ -22,7 +22,10 @@
 import { readFileSync, readdirSync, existsSync, mkdirSync, unlinkSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { looksLikeScoreCell, isSeparatorRow, isHeaderRow, resolveColumns } from './tracker-parse.mjs';
+import {
+  looksLikeScoreCell, isSeparatorRow, isHeaderRow, resolveColumns,
+  normalizeTextKey, normalizeVia,
+} from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md (original).
@@ -144,8 +147,10 @@ if (badStatuses === 0) ok('All statuses are canonical');
 const companyRoleMap = new Map();
 let dupes = 0;
 for (const e of entries) {
-  const key = e.company.toLowerCase().replace(/[^a-z0-9]/g, '') + '::' +
-    e.role.toLowerCase().replace(/[^a-z0-9 ]/g, '');
+  // Unicode-aware (#2393): an [a-z0-9] strip erases non-Latin scripts outright,
+  // so every Japanese company and every Japanese role keyed to '' and unrelated
+  // rows were reported as "possible duplicates".
+  const key = normalizeTextKey(e.company) + '::' + normalizeTextKey(e.role);
   if (!companyRoleMap.has(key)) companyRoleMap.set(key, []);
   companyRoleMap.get(key).push(e);
 }
@@ -251,7 +256,9 @@ if (staleSentinels === 0) ok('No stale reservation sentinels');
 // Warning-level, not error: duplicates can be legitimate (re-evaluation
 // after a JD change).
 const REPORT_FILE_RE = /^(\d+)-(.+)-\d{4}-\d{2}-\d{2}\.md$/;
-const normalizeKey = s => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+// Shares normalizeTextKey with Check 2 so a report pair and a tracker pair
+// can never disagree about whether two roles are the same (#2393).
+const normalizeKey = normalizeTextKey;
 
 // Role comes from the report body: the Machine Summary YAML fence when
 // present (field names are exact by contract), else the title line
@@ -351,10 +358,12 @@ for (const e of entries) {
 }
 // Same company+role reached through different channels: both submissions are
 // real, so this is a warning to the human (double-submission risk), never an
-// auto-merge. Channel identity is normalized the same way merge-tracker.mjs
-// normalizes companies (strip non-alphanumerics, lowercase), so "Hays" and
-// "HAYS " read as one channel; the raw spelling is kept for the message.
-const normalizeChannel = (v) => String(v ?? '').toLowerCase().replace(/[^a-z0-9]/g, '') || 'direct';
+// auto-merge. Channel identity uses the shared normalizeVia() that merge-tracker
+// and dedup-tracker key agencies with (#2397), so "Hays" and "HAYS " read as one
+// channel while リクルート and パーソル stay two; the raw spelling is kept for
+// the message. Before this, both non-Latin agencies normalized to '' and fell
+// back to 'direct', hiding exactly the double-submission this check exists for.
+const normalizeChannel = (v) => normalizeVia(v ?? '') || 'direct';
 const channelsByRole = new Map();
 for (const e of entries) {
   const company = String(e.company || '').trim();


### PR DESCRIPTION
## What does this PR do?

Routes the three grouping keys in `verify-pipeline.mjs` through a Unicode-aware normalizer instead of a `[^a-z0-9]` strip, which erased non-Latin scripts entirely. This is the follow-up to #2397: that PR gave `dedup-tracker.mjs` a Unicode-aware Via key, but the same class of key in `verify-pipeline.mjs` was never touched.

## Related issue

Refs #2393, #2397 — same root cause, different call sites. No new issue opened: per the template, bug fixes go straight in.

## The bug

On a non-Latin pipeline (Japanese, in my case), `normalizeKey('株式会社アカネ')` returns `''`. So does every other CJK company and role. Three checks were affected:

**Check 2 — duplicate tracker rows.** Every CJK company *and* every CJK role normalized to `''`, collapsing unrelated rows into one bucket. Real output from my tracker before the fix:

```
⚠️  Possible duplicates: #31, #73, #72, #67, #64, #61, #43 (… — …)
```

Seven different companies, seven different roles. Meanwhile the one genuine duplicate in that tracker was indistinguishable from the noise — the check was effectively off for the entire non-Latin user base.

**Check 9 — duplicate report files.** Same key, so two genuinely different roles filed under one company slug read as a duplicate pair.

**Check 11 — Via channels.** Every non-Latin agency normalized to `''` and then fell back to `'direct'`, so two different agencies submitting the same role never tripped the cross-channel warning. That is precisely the double-submission the check exists to catch, and it also drifts from the key #2397 just standardized — the comment there says the two scripts "cannot drift on agency identity", but `verify-pipeline` was still using the old one.

## The fix

Generalize `normalizeVia()` into `normalizeTextKey()` in `tracker-parse.mjs` (NFKC, then keep `\p{L}\p{N}`) and route all three call sites through it. `normalizeVia()` now delegates to it and is behaviourally unchanged for its existing callers (`merge-tracker`, `analyze-patterns`, `dedup-tracker`).

One shared key means tracker rows, report files and agency channels cannot disagree about identity — which is the property #2397 was reaching for.

## Testing

`node test-all.mjs` → **2790 passed, 0 failed**.

Six new assertions, covering both directions:

- distinct non-Latin companies stay apart
- distinct non-Latin roles at one company stay apart
- distinct non-Latin roles under one report slug stay apart
- **control:** identical non-Latin company+role is still flagged as a duplicate row pair
- **control:** two reports for one non-Latin company+role are still flagged
- one role reached via two non-Latin agencies now trips the cross-channel warning

I verified the tests are not vacuous: reverting only the source change (keeping the tests) fails the four discrimination assertions, while both controls still pass.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data) — test fixtures use invented company names
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)
