### PR TITLE
test(followup): pin the cadence profile so a customized install isn't red (#2268)

### DIFF
--- a/followup-cadence.test.mjs
+++ b/followup-cadence.test.mjs
@@ -7,7 +7,25 @@
  * Run: node followup-cadence.test.mjs
  */
 
-import {
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CADENCE_PROFILE = join(ROOT, 'tests', 'fixtures', 'profile-default-cadence.yml');
+const CUSTOM_CADENCE_PROFILE = join(ROOT, 'tests', 'fixtures', 'profile-custom-cadence.yml');
+
+// Pin the cadence source BEFORE followup-cadence.mjs is evaluated. Its
+// module-level `CADENCE = resolveCadenceConfig()` reads CAREER_OPS_PROFILE at
+// import time and otherwise falls back to the USER's config/profile.yml — so
+// on a machine where the user customized followup_cadence, assertions written
+// against DEFAULT_CADENCE failed on a perfectly healthy install (#2268).
+//
+// The import below must stay DYNAMIC: ESM hoists static imports above every
+// statement in this file, so a static import would run the module before this
+// assignment and the pin would do nothing.
+process.env.CAREER_OPS_PROFILE = DEFAULT_CADENCE_PROFILE;
+
+const {
   computeNextFollowupDate,
   addDays,
   parseDate,
@@ -15,7 +33,9 @@ import {
   parseFollowups,
   analyzeFromContent,
   normalizeStatus,
-} from './followup-cadence.mjs';
+  resolveCadenceConfig,
+  loadProfileCadence,
+} = await import('./followup-cadence.mjs');
 
 let passed = 0;
 let failed = 0;
@@ -172,6 +192,32 @@ eq(
 for (const raw of ['Hired', 'Accepted', 'accept', 'Contratado', 'contratada']) {
   eq(`normalizeStatus('${raw}') canonicalizes to hired`, normalizeStatus(raw), 'hired');
 }
+
+// #2268 — the suite pins the profile so a user's own followup_cadence can't
+// turn a healthy install red. These two guard the pin from the opposite
+// failure: pinning must not degrade into ignoring the profile altogether.
+eq(
+  'a fixture profile with no followup_cadence yields the defaults',
+  loadProfileCadence(DEFAULT_CADENCE_PROFILE),
+  {},
+);
+eq(
+  'a customized profile is still read through profilePath',
+  resolveCadenceConfig({ profilePath: CUSTOM_CADENCE_PROFILE, appliedDays: null }),
+  {
+    applied_first: 3,
+    applied_subsequent: 30,
+    applied_max_followups: 5,
+    responded_initial: 2,
+    responded_subsequent: 9,
+    interview_thankyou: 4,
+  },
+);
+eq(
+  'the pinned default profile resolves to DEFAULT_CADENCE',
+  resolveCadenceConfig({ profilePath: DEFAULT_CADENCE_PROFILE, appliedDays: null }),
+  DEFAULT_CADENCE,
+);
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) {

--- a/followup-seed-tests.mjs
+++ b/followup-seed-tests.mjs
@@ -17,9 +17,22 @@ import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, existsSync
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { parseNextOverrides, resolveNextOverride, normalizeStatus, addDays, parseDate } from './followup-cadence.mjs';
-
 const ROOT = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CADENCE_PROFILE = join(ROOT, 'tests', 'fixtures', 'profile-default-cadence.yml');
+
+// Pin the cadence source BEFORE followup-cadence.mjs is evaluated: it resolves
+// its cadence at module load from CAREER_OPS_PROFILE and otherwise falls back
+// to the USER's config/profile.yml, so a customized followup_cadence turned
+// these date assertions red on a healthy install (#2268). The spawned
+// followup-seed.mjs inherits the same pin through run()'s env.
+//
+// The import below must stay DYNAMIC: ESM hoists static imports above every
+// statement here, so a static one would run the module first and the pin would
+// do nothing.
+process.env.CAREER_OPS_PROFILE = DEFAULT_CADENCE_PROFILE;
+
+const { parseNextOverrides, resolveNextOverride, normalizeStatus, addDays, parseDate } =
+  await import('./followup-cadence.mjs');
 const NODE = process.execPath;
 const SCRIPT = join(ROOT, 'followup-seed.mjs');
 
@@ -64,6 +77,9 @@ function run(args, sandbox, extraEnv = {}) {
     ...process.env,
     CAREER_OPS_TRACKER: sandbox.tracker,
     CAREER_OPS_FOLLOWUPS: sandbox.followups,
+    // Explicit, not inherited: the child resolves its cadence from this or
+    // falls back to the user's real config/profile.yml (#2268).
+    CAREER_OPS_PROFILE: DEFAULT_CADENCE_PROFILE,
     CAREER_OPS_FOLLOWUPS_LOCK: sandbox.lock,
     ...extraEnv,
   };

--- a/tests/fixtures/profile-custom-cadence.yml
+++ b/tests/fixtures/profile-custom-cadence.yml
@@ -1,0 +1,16 @@
+# Fixture profile with a CUSTOMIZED cadence (#2268).
+#
+# The counterpart to profile-default-cadence.yml: it proves the suites pin the
+# profile rather than ignore it. If a future change made the cadence hard-coded
+# instead of profile-driven, the assertions built on this file fail — which is
+# the failure the #2268 fix must not introduce while making the suites
+# deterministic.
+name: Test Fixture
+email: fixture@example.test
+followup_cadence:
+  applied_first_days: 3
+  applied_subsequent_days: 30
+  applied_max_followups: 5
+  responded_initial_days: 2
+  responded_subsequent_days: 9
+  interview_thankyou_days: 4

--- a/tests/fixtures/profile-default-cadence.yml
+++ b/tests/fixtures/profile-default-cadence.yml
@@ -1,0 +1,13 @@
+# Fixture profile for the follow-up suites (#2268).
+#
+# followup-cadence.mjs resolves its cadence at module load from
+# CAREER_OPS_PROFILE, falling back to the user's own config/profile.yml. The
+# suites assert against DEFAULT_CADENCE, so on a machine where the user
+# customized followup_cadence they went red on a healthy install.
+#
+# This file deliberately carries NO followup_cadence block: every key falls
+# back to DEFAULT_CADENCE, which is exactly what those assertions encode. The
+# other keys are here only so the fixture parses as a realistic profile.
+name: Test Fixture
+email: fixture@example.test
+location: Test City


### PR DESCRIPTION
Part of #2268

## Problem

`followup-cadence.mjs` resolves its cadence **at module load**:

```js
const PROFILE_FILE = process.env.CAREER_OPS_PROFILE || join(CAREER_OPS, 'config/profile.yml');
…
const CADENCE = resolveCadenceConfig();
```

Neither follow-up suite set `CAREER_OPS_PROFILE`, so both fell through to the **user's own** `config/profile.yml` while asserting the 7-day `applied_first` default. Any user who customized `followup_cadence` saw a red `test-all.mjs` on a completely healthy install — and maintainers never see it, because dev machines don't customize.

`followup-seed-tests.mjs` had the same hole twice over: its in-process import, and the `followup-seed.mjs` child it spawns, whose env inherited `process.env` and therefore resolved the real user profile too.

## Fix

Both suites pin `CAREER_OPS_PROFILE` to a fixture before the module is evaluated, and `run()` passes the same pin explicitly to the spawned child.

**The import has to become dynamic.** ESM hoists static imports above every statement in the file, so `process.env.CAREER_OPS_PROFILE = …` followed by a static import would run the module *first* and the pin would silently do nothing. That is called out in a comment at both sites, because it is exactly the kind of thing a later "tidy the imports" commit undoes.

Two fixtures, not one:

- `tests/fixtures/profile-default-cadence.yml` — no `followup_cadence` block, so every key falls back to `DEFAULT_CADENCE`, which is what the assertions already encode.
- `tests/fixtures/profile-custom-cadence.yml` — a customized cadence, used by three new assertions that guard the pin from degrading into *ignoring* the profile. Making the suites deterministic by hard-coding the cadence would pass every existing test while breaking the feature; those assertions fail if that happens.

## Test plan

Reproduced with a profile carrying `applied_first_days: 14`, `responded_initial_days: 5` (the shape of the reporter's customization):

| Suite | Before | After |
|---|---|---|
| `followup-cadence.test.mjs` | 15 passed, **3 failed** | 21 passed, 0 failed |
| `followup-seed-tests.mjs` | 41 passed, **1 failed** | 42 passed, 0 failed |

- [x] Both suites pass standalone with no `CAREER_OPS_PROFILE` set, and with a hostile one set
- [x] `node test-all.mjs --quick` — 2783 passed, 0 failed
- [x] New assertions: a fixture with no `followup_cadence` yields `{}`; a customized profile still resolves through `profilePath`; the pinned fixture resolves to exactly `DEFAULT_CADENCE`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for default and custom follow-up cadence profiles.
  - Ensured cadence and date-based tests produce consistent results regardless of local profile settings.
  - Verified child processes use the intended test profile.

- **Fixtures**
  - Added default and customized profile fixtures to validate cadence fallback and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
