### PR TITLE
docs(modes): cover and email load the shared writing module (#2006)

### DIFF
--- a/modes/cover.md
+++ b/modes/cover.md
@@ -38,7 +38,9 @@ Read `cv.md` for:
 
 Read `article-digest.md` if it exists — supplementary proof points and metrics take precedence over cv.md where they overlap.
 
-Read `modes/_profile.md` if it exists — the candidate's personalization file. It captures their target roles, adaptive framing and archetypes, exit narrative, cross-cutting advantage, proof points, comp targets, negotiation scripts, location policy, and any voice or writing-style rules they have added. Its rules **govern the letter's voice and structure and override the generic defaults in this mode**, so the candidate's personalization is never lost.
+Read `modes/_writing.md` — the shared writing guidance (Voice DNA guardrail, Writing Style calibration, Professional Writing & ATS rules). A cover letter is candidate-facing prose, the same category that module governs, so it gets the same standard as the report and apply outputs instead of a thinner local one (#2006).
+
+Read `modes/_profile.md` if it exists — the candidate's personalization file. It captures their target roles, adaptive framing and archetypes, exit narrative, cross-cutting advantage, proof points, comp targets, negotiation scripts, location policy, and any voice or writing-style rules they have added. Its rules **govern the letter's voice and structure and override the generic defaults in this mode and in `_writing.md`**, so the candidate's personalization is never lost.
 
 ---
 
@@ -254,10 +256,16 @@ End the draft with: "How does this read? Once you approve I'll generate the PDF.
 
 ## Language rules (enforced in every sentence)
 
+`_writing.md` → Professional Writing & ATS Compatibility is the base: its cliché
+list, em-dash rule, sentence variation and specifics-over-abstractions guidance
+apply here in full, and `voice-dna.md` §3 supersedes that list when the user has
+the file. The rules below are what this mode adds on top — letter-specific
+contracts, plus the bans that are stricter than the shared list.
+
 1. **Active voice only** — never "was delivered", "has been built", "were led"
 2. **No abbreviations unless JD used them first** — write the full term on first use with abbreviation in brackets. After that, abbreviation is fine.
-3. **No em dashes** — replace with a comma, full stop, or rewrite the sentence
-4. **No buzzwords** — hard ban: leverage, synergy, seamless, holistic, robust, cutting-edge, spearheaded, championed, orchestrated, passionate, excited, stakeholder alignment, data-driven (say what the data drove instead), actionable insights, move the needle, north star, unique opportunity, perfect fit, strong track record
+3. **No em dashes** — a hard ban here, not just an ATS normalization concern: the letter is read as prose before any parser sees it.
+4. **Buzzwords beyond the shared list** — also hard-banned in a cover letter: holistic, championed, orchestrated, excited, stakeholder alignment, data-driven (say what the data drove instead), actionable insights, move the needle, north star, unique opportunity, perfect fit, strong track record
 5. **No filler openers** — never "I am pleased to", "I am writing to express", "I am excited to"
 6. **Concrete over abstract** — every claim needs a number, system name, or specific outcome. "Improved performance" is banned. "Cut latency from 2s to 380ms" is fine.
 7. **350-420 words** total body (header + credentials not counted)

--- a/modes/email.md
+++ b/modes/email.md
@@ -66,6 +66,7 @@ Read:
 - `config/profile.yml`
 - `cv.md`
 - `article-digest.md` if it exists
+- `modes/_writing.md` — shared writing guidance (Voice DNA guardrail, Writing Style calibration, Professional Writing rules). An application email is candidate-facing prose, the same category that module governs (#2006)
 - `modes/_profile.md` if it exists
 - `modes/_custom.md` if it exists
 - `voice-dna.md` if it exists, for writing style only
@@ -78,7 +79,14 @@ the email should be. It must never introduce contact details, work experience,
 or other factual claims.
 
 Use `voice-dna.md` only as a writing guardrail. It must never introduce factual
-claims.
+claims. Precedence for voice is unchanged: `modes/_profile.md` wins over
+`voice-dna.md`, which wins over the generic defaults in `_writing.md`. Loading
+the module adds a standard where this mode had none; it never overrides the
+user's own rules.
+
+`_writing.md` governs wording only. This mode's output contract — variants,
+attachment checklist, subject/body structure, the draft-only rule — is set here
+and is not affected by it.
 
 ### Profile fields
 
@@ -472,8 +480,12 @@ extra emphasis -- it should read as a practical note, not a demand.
 
 ## Style Rules
 
+`_writing.md` → Professional Writing & ATS Compatibility carries the shared
+cliché list and specifics-over-abstractions rule. These are the email-specific
+additions.
+
 - No corporate-speak.
-- No "passionate about", "perfect fit", "unique opportunity", or vague praise.
+- No "perfect fit", "unique opportunity", or vague praise (the shared list covers "passionate about" and its relatives).
 - No exaggerated authorship claims.
 - Short paragraphs. Prefer 150-250 words for HR applications.
 - Keep the proof easy to scan.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1927,6 +1927,42 @@ if (shared.includes('_profile.md')) {
   } else {
     fail(`modes still reference _shared.md for writing sections (should be _writing.md): ${stale.join(', ')}`);
   }
+
+  // #2006 — cover.md and email.md produce candidate-facing prose, so they load
+  // the shared module rather than carrying a thinner local standard. A mode
+  // that DELEGATES part of its wording rules to _writing.md and then loses the
+  // read directive silently drops those rules: the delegating prose stays,
+  // pointing at a file nobody opens. Assert the read, not just the mention.
+  //
+  // Two shapes count as a read directive, because both are used in modes/:
+  // inline ("Read `modes/_writing.md` — …", cover.md) and a bullet inside a
+  // "Read:" list (email.md). Matching only the inline form would have called
+  // email.md non-compliant while it reads the file perfectly well.
+  const WRITING_CONSUMERS = ['modes/cover.md', 'modes/email.md'];
+  const READS_WRITING = /(?:^|\n)\s*(?:[-*]\s*)?(?:Read|read)?[^.\n]{0,60}`modes\/_writing\.md`/;
+  const missingRead = WRITING_CONSUMERS.filter((path) => !READS_WRITING.test(readFile(path)));
+  if (missingRead.length === 0) {
+    pass('cover.md and email.md load modes/_writing.md (#2006)');
+  } else {
+    fail(`these modes delegate wording to _writing.md but never read it: ${missingRead.join(', ')} (#2006)`);
+  }
+
+  // The delegation must not have taken the mode-specific contracts with it:
+  // those are set locally and _writing.md says nothing about them.
+  const coverSrc = readFile('modes/cover.md');
+  const emailSrc = readFile('modes/email.md');
+  const contractsIntact =
+    /350-420 words/.test(coverSrc) &&
+    /Bullet format/.test(coverSrc) &&
+    /Self-check/.test(coverSrc) &&
+    /Tone consistency/.test(coverSrc) &&
+    /Attachment checklist/i.test(emailSrc) &&
+    /Do not write files unless the user explicitly asks/.test(emailSrc);
+  if (contractsIntact) {
+    pass('cover/email output contracts survived the _writing.md delegation (#2006)');
+  } else {
+    fail('a cover/email output contract (word count, bullet format, self-check, tone, attachments, draft-only) went missing (#2006)');
+  }
 }
 
 // --- _custom.md must be READ, not just written (#1388): Sources of Truth row +

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1939,8 +1939,25 @@ if (shared.includes('_profile.md')) {
   // "Read:" list (email.md). Matching only the inline form would have called
   // email.md non-compliant while it reads the file perfectly well.
   const WRITING_CONSUMERS = ['modes/cover.md', 'modes/email.md'];
-  const READS_WRITING = /(?:^|\n)\s*(?:[-*]\s*)?(?:Read|read)?[^.\n]{0,60}`modes\/_writing\.md`/;
-  const missingRead = WRITING_CONSUMERS.filter((path) => !READS_WRITING.test(readFile(path)));
+  // The two directive shapes are matched SEPARATELY, and the verb is required
+  // in both. Making `Read` optional would let a bare mention satisfy the guard
+  // — "Do not read `modes/_writing.md`", or a path in a table cell — so the
+  // assertion could stay green after the actual read was deleted, which is the
+  // one thing it exists to catch.
+  const readsWritingModule = (source) => {
+    let inReadList = false;
+    for (const line of source.split(/\r?\n/)) {
+      // Inline: "Read `modes/_writing.md` — …" (cover.md).
+      if (/^\s*Read\b[^\n]*`modes\/_writing\.md`/i.test(line)) return true;
+      // Bullet under a "Read:" header (email.md). The list ends at the first
+      // non-bullet, non-blank line.
+      if (/^\s*Read:\s*$/i.test(line)) { inReadList = true; continue; }
+      if (inReadList && /^\s*[-*]\s*`modes\/_writing\.md`/.test(line)) return true;
+      if (inReadList && line.trim() && !/^\s*[-*]/.test(line)) inReadList = false;
+    }
+    return false;
+  };
+  const missingRead = WRITING_CONSUMERS.filter((path) => !readsWritingModule(readFile(path)));
   if (missingRead.length === 0) {
     pass('cover.md and email.md load modes/_writing.md (#2006)');
   } else {


### PR DESCRIPTION
Fixes #2006

Implements the answer given in the issue:

> the answer is yes in principle: cover.md and email.md predate `modes/_writing.md` and duplicate guidance it now owns; loading it and deleting the duplicated prose is the thin-wrapper direction this repo already follows for agent files. One caution: those modes' output contracts (fact gates, structure) must not change as a side effect — a diff that only swaps duplicated prose for the module reference would merge easily.

## What changed

Both modes now read `modes/_writing.md`, and **only strictly duplicated prose** was swapped for the reference.

- **`cover.md`** — read directive in Step 1, next to `cv.md` / `article-digest.md` / `_profile.md`. Its "Language rules" list keeps every mode-specific contract and now names `_writing.md` → Professional Writing as the base.
- **`email.md`** — `modes/_writing.md` added to the Step 1 `Read:` list; the "Style Rules" section points at the shared cliché list for the entries it already carried.

## No rule is lost

The bans removed from `cover.md`'s inline list are exactly the ones `_writing.md` already carries: *leverage(d), synergy/synergies, seamless, robust, cutting-edge, spearheaded, passionate*. Everything stricter than the shared list stays inline: *holistic, championed, orchestrated, excited, stakeholder alignment, data-driven, actionable insights, move the needle, north star, unique opportunity, perfect fit, strong track record*. Same for `email.md`: "passionate about" now comes from the shared list, "perfect fit" and "unique opportunity" stay local because the shared list does not have them.

`cover.md`'s "No em dashes" is deliberately kept inline rather than delegated: `_writing.md` frames em-dashes as an ATS normalization concern, while in a letter it is a prose rule that applies before any parser is involved.

## Output contracts untouched

Word count (350-420), bullet format, self-check, tone consistency, variants, attachment checklist, subject/body structure, the draft-only rule and the fact-validator gate are all unchanged — and now pinned by a test, so a future edit cannot quietly take them along with the delegated prose.

Precedence is stated explicitly in both modes: `_profile.md` > `voice-dna.md` > `_writing.md`. The module adds a standard where these modes had a thinner local one; it never overrides the user's own rules.

## Test plan

- [x] Extended the #1710 stale-reference guard as the issue proposed: both modes must actually **read** `_writing.md`, not merely mention it — a mode that delegates its wording rules and then loses the directive drops them silently, with the delegating prose still pointing at a file nobody opens
- [x] The guard accepts both directive shapes used in `modes/` (inline, and a bullet inside a `Read:` list). Matching only the inline form flagged `email.md` while it reads the file correctly — caught by the guard itself before this PR was opened
- [x] Both shapes **require the verb**. An earlier version made `Read` optional, so a bare mention — `Do not read \`modes/_writing.md\``, a path in a table cell — satisfied it, and the assertion could have stayed green after the real read was deleted (CodeRabbit review). Verified against both real modes plus six bypass shapes: bare mention, negation, bullet outside a `Read:` list, bullet after the list has ended, and a table cell
- [x] Verified it fails closed: removing either directive turns the assertion red
- [x] Second assertion pins the mode-specific contracts `_writing.md` says nothing about
- [x] `node test-all.mjs --quick` — 2785 passed, 0 failed

## Scope note

The issue also raises the ~2.1K-token cost per run and asks whether `email.md` should be in or out. This PR takes **both**, on the consistency argument in the issue. If you would rather scope it to `cover.md` only, dropping the `email.md` hunk is a two-line revert and the guard's consumer list is one line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Cover letters and emails now follow consistent shared writing and professional communication guidance.
  * Candidate-specific voice and profile preferences take precedence where available.
  * Cover-letter guidance includes stricter formatting and language rules, including expanded cliché and buzzword avoidance.
  * Email guidance more clearly separates writing style from required output safeguards.

* **Quality**
  * Added validation to ensure required writing guidance and mode-specific output requirements remain in place.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->