### PR TITLE
feat(update): keep locally edited system files unless --force (#2337)

### DIFF
--- a/tests/updater-local-system-edits.test.mjs
+++ b/tests/updater-local-system-edits.test.mjs
@@ -24,6 +24,11 @@ function makeRepo() {
   g('init', '-q', '-b', 'main', '.');
   g('config', 'user.email', 'test@example.com');
   g('config', 'user.name', 'Test');
+  // A developer or CI image with commit.gpgsign or a global core.hooksPath
+  // would make every commit below fail, and all cases would go red for a
+  // reason that has nothing to do with the detector (CodeRabbit review).
+  g('config', 'commit.gpgsign', 'false');
+  g('config', 'core.hooksPath', join(dir, 'no-such-hooks'));
   mkdirSync(join(dir, 'modes'), { recursive: true });
   writeFileSync(join(dir, 'modes', 'pdf.md'), 'shipped pdf\n');
   writeFileSync(join(dir, 'modes', 'cover.md'), 'shipped cover\n');
@@ -153,6 +158,43 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
     pass('an unreadable upstream ref returns a list instead of throwing');
   } else {
     fail('#7 a bad ref must not throw — it would abort the whole update');
+  }
+}
+
+// ── 7b. An untracked local file the upstream ref ships is at risk too ──
+//    `git diff` never lists untracked files, so this one escaped the two diff
+//    sets entirely and would have been overwritten with no warning and no .bak.
+{
+  const repo = makeRepo();
+  // Ships upstream, absent from the install's baseline.
+  repo.g('checkout', '-q', 'upstream');
+  writeFileSync(join(repo.dir, 'modes', 'new-mode.md'), 'upstream new mode\n');
+  repo.g('add', '-A');
+  repo.g('commit', '-qm', 'upstream: new mode');
+  repo.g('checkout', '-q', 'main');
+  // The user wrote their own file at that exact path before updating.
+  writeFileSync(join(repo.dir, 'modes', 'new-mode.md'), 'my own notes\n');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (atRisk.includes('modes/new-mode.md')) {
+    pass('an untracked local file the upstream ref ships is reported');
+  } else {
+    fail(`#7b expected modes/new-mode.md, got ${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 7c. An untracked file absent upstream is NOT reported ──
+//    The checkout cannot touch it, so listing it would be pure noise.
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  writeFileSync(join(repo.dir, 'modes', 'my-scratch.md'), 'purely local\n');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (!atRisk.includes('modes/my-scratch.md')) {
+    pass('a purely local untracked file is left out of the warning');
+  } else {
+    fail(`#7c my-scratch.md should not be listed: ${JSON.stringify(atRisk)}`);
   }
 }
 

--- a/tests/updater-local-system-edits.test.mjs
+++ b/tests/updater-local-system-edits.test.mjs
@@ -29,6 +29,12 @@ function makeRepo() {
   // reason that has nothing to do with the detector (CodeRabbit review).
   g('config', 'commit.gpgsign', 'false');
   g('config', 'core.hooksPath', join(dir, 'no-such-hooks'));
+  // Same reasoning for line endings: the cases below write LF and later compare
+  // exact strings against files git CHECKED OUT, so a global core.autocrlf=true
+  // (the default on GitHub's Windows images) would hand back CRLF and fail them
+  // for a reason unrelated to the detector (CodeRabbit review).
+  g('config', 'core.autocrlf', 'false');
+  g('config', 'core.eol', 'lf');
   mkdirSync(join(dir, 'modes'), { recursive: true });
   writeFileSync(join(dir, 'modes', 'pdf.md'), 'shipped pdf\n');
   writeFileSync(join(dir, 'modes', 'cover.md'), 'shipped cover\n');

--- a/tests/updater-local-system-edits.test.mjs
+++ b/tests/updater-local-system-edits.test.mjs
@@ -9,7 +9,7 @@
  * before it is overwritten, and nothing else is.
  */
 
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { pass, fail } from './helpers.mjs';
@@ -36,7 +36,9 @@ function makeRepo() {
   g('add', '-A');
   g('commit', '-qm', 'base');
   g('branch', 'upstream');
-  return { dir, g, ctx: { git: g } };
+  // `root` lets the detector check whether a path still exists on disk; without
+  // it every case below would resolve against the real career-ops checkout.
+  return { dir, g, ctx: { git: g, root: dir } };
 }
 
 /** Commit a change on the upstream branch and return to main. */
@@ -245,5 +247,70 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
     pass('a fully-excluded pathspec errors — hence the skip in apply() (#2337)');
   } else {
     fail(`#9 errored=${errored} content=${JSON.stringify(content)}`);
+  }
+}
+
+// ── 10. A system file the user DELETED locally is not "at risk" ──
+//    `git diff --name-only` lists deletions, so a deleted file landed in BOTH
+//    sets and therefore in atRisk. From there apply() preserved it — excluded
+//    it from the checkout — so the file was never restored, `Keeping your
+//    versions` named a file that does not exist, and the update exited 1. The
+//    printed remedy ("run apply again") could not work, because re-running
+//    reproduces the same state. A path that is not on disk cannot be
+//    overwritten, so it is not at risk.
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  rmSync(join(repo.dir, 'modes', 'cover.md'));
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (!atRisk.includes('modes/cover.md')) {
+    pass('a locally deleted system file is not reported as at risk');
+  } else {
+    fail(`#10 deleted file still at risk: ${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 11. ...so the update RESTORES it ──
+//    The property the suite never asserted (santifer's review): nothing pinned
+//    that apply() brings back a system file the user deleted. Before the #2337
+//    detector the raw checkout did it for free; the detector is what could take
+//    it away, so the case belongs with the detector. Same shape as case 8: the
+//    real checkout, driven by the real atRisk exclusions.
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  rmSync(join(repo.dir, 'modes', 'cover.md'));
+  // A genuine local edit alongside it — the deletion must not disturb it.
+  writeFileSync(join(repo.dir, 'generate-cover-letter.mjs'), 'local linkedin fix\n');
+  repo.g('commit', '-qam', 'local fix');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  repo.g('checkout', 'upstream', '--', 'modes/', ...atRisk.map((f) => `:(exclude)${f}`));
+
+  const restored = existsSync(join(repo.dir, 'modes', 'cover.md'))
+    && readFileSync(join(repo.dir, 'modes', 'cover.md'), 'utf-8') === 'shipped cover\n';
+  const localEdit = readFileSync(join(repo.dir, 'generate-cover-letter.mjs'), 'utf-8');
+  if (restored && localEdit === 'local linkedin fix\n') {
+    pass('the update restores a deleted system file and still keeps a real local edit');
+  } else {
+    fail(`#11 restored=${restored} localEdit=${JSON.stringify(localEdit)} atRisk=${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 12. Guard: the existence filter must not swallow a real local edit ──
+//    Case 10 removes entries from atRisk, so pin that it removes ONLY missing
+//    ones — a modified file that still exists stays reported.
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/cover.md', 'shipped cover v2\n');
+  writeFileSync(join(repo.dir, 'modes', 'cover.md'), 'local cover fix\n');
+  repo.g('commit', '-qam', 'local fix');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (atRisk.includes('modes/cover.md')) {
+    pass('a modified file that still exists is still reported');
+  } else {
+    fail(`#12 real local edit lost from atRisk: ${JSON.stringify(atRisk)}`);
   }
 }

--- a/tests/updater-local-system-edits.test.mjs
+++ b/tests/updater-local-system-edits.test.mjs
@@ -1,0 +1,207 @@
+/**
+ * updater-local-system-edits.test.mjs — BEHAVIORAL coverage for the #2337
+ * detector.
+ *
+ * apply() is ROOT-bound with heavy side effects, so the detection is exported
+ * and ctx-injectable and driven here against a throwaway repo — the same shape
+ * as updater-rollback-behavior.test.mjs. What is verified is the property that
+ * protects the user's work: a local fix upstream has NOT adopted is reported
+ * before it is overwritten, and nothing else is.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail } from './helpers.mjs';
+import { gitIn, locallyModifiedSystemFiles } from '../update-system.mjs';
+
+// A repo with an `upstream` branch standing in for FETCH_HEAD, and `main` as
+// the install. Both start from a shared base commit, which is what gives
+// merge-base a meaningful baseline.
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-local-edits-'));
+  const g = (...args) => gitIn(dir, ...args);
+  g('init', '-q', '-b', 'main', '.');
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  mkdirSync(join(dir, 'modes'), { recursive: true });
+  writeFileSync(join(dir, 'modes', 'pdf.md'), 'shipped pdf\n');
+  writeFileSync(join(dir, 'modes', 'cover.md'), 'shipped cover\n');
+  writeFileSync(join(dir, 'generate-cover-letter.mjs'), 'shipped script\n');
+  g('add', '-A');
+  g('commit', '-qm', 'base');
+  g('branch', 'upstream');
+  return { dir, g, ctx: { git: g } };
+}
+
+/** Commit a change on the upstream branch and return to main. */
+function upstreamChange(repo, file, content) {
+  repo.g('checkout', '-q', 'upstream');
+  writeFileSync(join(repo.dir, ...file.split('/')), content);
+  repo.g('commit', '-qam', `upstream: ${file}`);
+  repo.g('checkout', '-q', 'main');
+}
+
+const PATHS = ['modes/', 'generate-cover-letter.mjs'];
+
+// ── 1. The reported case: a committed local fix upstream has not adopted ──
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  writeFileSync(join(repo.dir, 'generate-cover-letter.mjs'), 'local linkedin fix\n');
+  repo.g('commit', '-qam', 'local fix');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (atRisk.length === 1 && atRisk[0] === 'generate-cover-letter.mjs') {
+    pass('a committed local fix upstream has not adopted is reported (#2337)');
+  } else {
+    fail(`#1 expected ['generate-cover-letter.mjs'], got ${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 2. An uncommitted local edit counts too — it is just as overwritable ──
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  writeFileSync(join(repo.dir, 'generate-cover-letter.mjs'), 'uncommitted fix\n');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (atRisk.length === 1 && atRisk[0] === 'generate-cover-letter.mjs') {
+    pass('an uncommitted local edit is reported too');
+  } else {
+    fail(`#2 expected ['generate-cover-letter.mjs'], got ${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 3. A file only UPSTREAM changed is not a local edit — no false alarm ──
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (atRisk.length === 0) {
+    pass('a file changed only upstream raises no warning');
+  } else {
+    fail(`#3 expected [], got ${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 4. A local fix upstream adopted independently is NOT reported ──
+//    The #2337 reporter isolated exactly this: one of their two fixes survived
+//    an update because upstream had picked it up. Byte-identical content means
+//    the checkout costs nothing, so warning about it would be noise.
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'generate-cover-letter.mjs', 'the same fix\n');
+  writeFileSync(join(repo.dir, 'generate-cover-letter.mjs'), 'the same fix\n');
+  repo.g('commit', '-qam', 'local fix, same content');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (atRisk.length === 0) {
+    pass('a local fix upstream adopted independently is not reported');
+  } else {
+    fail(`#4 expected [], got ${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 5. Only manifest paths are inspected — user-layer files never appear ──
+{
+  const repo = makeRepo();
+  writeFileSync(join(repo.dir, 'cv.md'), 'my cv\n');
+  repo.g('add', '-A');
+  repo.g('commit', '-qm', 'user file');
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  writeFileSync(join(repo.dir, 'cv.md'), 'my edited cv\n');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (!atRisk.includes('cv.md')) {
+    pass('a user-layer file outside the manifest is never listed');
+  } else {
+    fail(`#5 cv.md leaked into the system-file warning: ${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 6. Several local edits are all reported, sorted ──
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  upstreamChange(repo, 'modes/cover.md', 'shipped cover v2\n');
+  writeFileSync(join(repo.dir, 'modes', 'pdf.md'), 'local pdf fix\n');
+  writeFileSync(join(repo.dir, 'modes', 'cover.md'), 'local cover fix\n');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (JSON.stringify(atRisk) === JSON.stringify(['modes/cover.md', 'modes/pdf.md'])) {
+    pass('every locally edited system file is reported, in a stable order');
+  } else {
+    fail(`#6 expected both modes files sorted, got ${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 7. An unreadable ref degrades the warning, never the update ──
+{
+  const repo = makeRepo();
+  writeFileSync(join(repo.dir, 'modes', 'pdf.md'), 'local edit\n');
+
+  let threw = false;
+  let atRisk = null;
+  try {
+    atRisk = locallyModifiedSystemFiles(PATHS, 'no-such-ref', repo.ctx);
+  } catch {
+    threw = true;
+  }
+  if (!threw && Array.isArray(atRisk)) {
+    pass('an unreadable upstream ref returns a list instead of throwing');
+  } else {
+    fail('#7 a bad ref must not throw — it would abort the whole update');
+  }
+}
+
+// ── 8. The exclude pathspec keeps the local content, index included ──
+//    This is the mechanism apply() uses instead of checking out and restoring:
+//    a restore would leave the INDEX holding the upstream blob, so the scoped
+//    commit would record exactly the content the user asked to keep out.
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  upstreamChange(repo, 'modes/cover.md', 'shipped cover v2\n');
+  writeFileSync(join(repo.dir, 'modes', 'cover.md'), 'local cover fix\n');
+  repo.g('commit', '-qam', 'local fix');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  repo.g('checkout', 'upstream', '--', 'modes/', ...atRisk.map((f) => `:(exclude)${f}`));
+
+  const cover = readFileSync(join(repo.dir, 'modes', 'cover.md'), 'utf-8');
+  const pdf = readFileSync(join(repo.dir, 'modes', 'pdf.md'), 'utf-8');
+  const staged = repo.g('diff', '--cached', '--name-only', 'HEAD').split('\n').filter(Boolean);
+  if (cover === 'local cover fix\n' && pdf === 'shipped pdf v2\n' && !staged.includes('modes/cover.md')) {
+    pass('the excluded file keeps its local content in the worktree AND the index');
+  } else {
+    fail(`#8 cover=${JSON.stringify(cover)} pdf=${JSON.stringify(pdf)} staged=${JSON.stringify(staged)}`);
+  }
+}
+
+// ── 9. Exclusions that cancel the WHOLE pathspec make git fail ──
+//    Why apply() skips such an entry outright instead of passing the excludes:
+//    the resulting error is indistinguishable from a real checkout failure at
+//    the call site, so it would abort the entire update over a file the user
+//    asked to keep. Pinning git's behaviour here means a future git that stops
+//    erroring — or a refactor that drops the skip — is caught.
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'generate-cover-letter.mjs', 'upstream script v2\n');
+  writeFileSync(join(repo.dir, 'generate-cover-letter.mjs'), 'local fix\n');
+  repo.g('commit', '-qam', 'local fix');
+
+  let errored = false;
+  try {
+    repo.g('checkout', 'upstream', '--', 'generate-cover-letter.mjs', ':(exclude)generate-cover-letter.mjs');
+  } catch {
+    errored = true;
+  }
+  const content = readFileSync(join(repo.dir, 'generate-cover-letter.mjs'), 'utf-8');
+  if (errored && content === 'local fix\n') {
+    pass('a fully-excluded pathspec errors — hence the skip in apply() (#2337)');
+  } else {
+    fail(`#9 errored=${errored} content=${JSON.stringify(content)}`);
+  }
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -683,6 +683,62 @@ export function prepareMaterializedSkillEntrypointsForStage(paths, root = ROOT) 
   return prepared;
 }
 
+/**
+ * System-layer files this install changed locally that the update is about to
+ * overwrite (#2337).
+ *
+ * apply() checks out every SYSTEM_PATHS entry from the upstream ref — a raw
+ * checkout, not a merge — so a local fix to a system file is discarded with no
+ * diff, no warning, and no list. The system layer stays system-owned (this is
+ * NOT a merge, by design); the point is telling people what they are about to
+ * lose.
+ *
+ * A file is at risk only when BOTH hold:
+ *
+ *   1. it differs from the merge-base — the last commit this install shares
+ *      with upstream, i.e. the baseline it was last synced to. Anything that
+ *      differs from it was changed HERE, whether committed or still in the
+ *      working tree (`git diff <ref> -- <path>` compares against the worktree);
+ *   2. it differs from the upstream ref. A local fix upstream has since adopted
+ *      independently is byte-identical there, so the checkout costs nothing and
+ *      warning about it would be noise — the exact case the #2337 reporter
+ *      isolated when one of their two fixes survived an update.
+ *
+ * @param {string[]} paths - manifest entries (files or `dir/` prefixes).
+ * @param {string} upstreamRef - ref being checked out, normally FETCH_HEAD.
+ * @param {{git?: Function}} [ctx] - injectable git runner, for tests.
+ * @returns {string[]} repo-relative file paths, sorted.
+ */
+export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ctx = {}) {
+  const runGit = ctx.git || git;
+  if (!paths || paths.length === 0) return [];
+
+  const diffNames = (ref) => {
+    try {
+      return runGit('diff', '--name-only', ref, '--', ...paths).split('\n').map((p) => p.trim()).filter(Boolean);
+    } catch {
+      // An unreadable ref (shallow clone, unrelated histories) must never abort
+      // the update — it degrades the warning, not the checkout.
+      return [];
+    }
+  };
+
+  // Without a merge-base (unrelated histories, a shallow clone) fall back to
+  // HEAD: that still catches uncommitted local edits, which is the common case,
+  // and simply misses local edits already committed.
+  let baseline = null;
+  try {
+    baseline = runGit('merge-base', 'HEAD', upstreamRef) || null;
+  } catch {
+    baseline = null;
+  }
+
+  const changedLocally = new Set(diffNames(baseline || 'HEAD'));
+  if (changedLocally.size === 0) return [];
+  const differsFromUpstream = new Set(diffNames(upstreamRef));
+  return [...changedLocally].filter((file) => differsFromUpstream.has(file)).sort();
+}
+
 export function revertPaths(paths, protectedPaths = new Set(), ctx = {}) {
   const runGit = ctx.git || git;
   const root = ctx.root || ROOT;

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -763,7 +763,19 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
     }
   }
 
-  return [...new Set(atRisk)].sort();
+  // A path that is not on disk cannot be overwritten, so it is not at risk.
+  // `git diff --name-only` lists DELETIONS, so a system file the user removed
+  // landed in both sets above and was then "preserved" — excluded from the
+  // checkout, which is exactly what stops it being restored. The update printed
+  // `Keeping your versions` about a file that does not exist, failed to write
+  // its `.bak` with ENOENT, and exited 1 telling the user to run apply again;
+  // re-running reproduces the same state, so the install stayed stuck. Filtering
+  // here also gives the `.bak` failure branch back its single meaning: a backup
+  // that genuinely could not be written (permissions, full disk).
+  const root = ctx.root || ROOT;
+  return [...new Set(atRisk)]
+    .filter((file) => existsSync(join(root, ...file.split('/'))))
+    .sort();
 }
 
 export function revertPaths(paths, protectedPaths = new Set(), ctx = {}) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -9,6 +9,10 @@
  * Usage:
  *   node update-system.mjs check      # Check if update available
  *   node update-system.mjs apply      # Apply update (after user confirms)
+ *   node update-system.mjs apply --force
+ *                                     # …and overwrite system files this
+ *                                     # install edited locally (#2337). Without
+ *                                     # it those files are kept and listed.
  *   node update-system.mjs rollback   # Rollback last update
  *   node update-system.mjs dismiss    # Dismiss update check
  *
@@ -16,7 +20,7 @@
  */
 
 import { execFile, execFileSync, execSync } from 'child_process';
-import { readFileSync, writeFileSync, existsSync, unlinkSync, rmSync } from 'fs';
+import { copyFileSync, readFileSync, writeFileSync, existsSync, unlinkSync, rmSync } from 'fs';
 import { join, dirname, posix as pathPosix } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -958,6 +962,10 @@ async function check() {
 
 async function apply() {
   const local = localVersion();
+  // --force overwrites system files this install edited locally (#2337). The
+  // env var carries the flag across the self-reexec, which re-invokes the
+  // TARGET updater as `update-system.mjs apply` with a fixed argv.
+  const updateForce = process.argv.includes('--force') || process.env.CAREER_OPS_UPDATE_FORCE === '1';
   const initialStatusPaths = new Set(gitStatusEntries().map(entry => entry.path));
   const isReexec = process.env.CAREER_OPS_UPDATE_REEXEC === '1';
 
@@ -1015,6 +1023,7 @@ async function apply() {
             ...process.env,
             CAREER_OPS_UPDATE_REEXEC: '1',
             CAREER_OPS_UPDATE_BACKUP_BRANCH: backupBranch,
+            ...(updateForce ? { CAREER_OPS_UPDATE_FORCE: '1' } : {}),
           },
         });
         return;
@@ -1044,8 +1053,66 @@ async function apply() {
     // target updater's SYSTEM_PATHS is now the source of truth for new files.
     const updatePaths = mergePathLists(SYSTEM_PATHS, remoteSystemPaths, BOOTSTRAP_PATHS);
 
+    // 3b. Local edits to system files (#2337). The checkout is a raw overwrite,
+    // so anything this install fixed locally and upstream has not adopted is
+    // about to vanish silently. Default is to KEEP the local version and say
+    // so; `--force` overwrites. Either way a .bak of the local content is
+    // written first, so the fix is recoverable even from the forced path.
+    const preservedPaths = [];
+    const atRisk = locallyModifiedSystemFiles(updatePaths, 'FETCH_HEAD');
+    if (atRisk.length > 0) {
+      console.log('');
+      console.log(`${atRisk.length} system file(s) differ from upstream because THIS install changed them:`);
+      for (const file of atRisk) {
+        const backup = `${join(ROOT, ...file.split('/'))}.bak`;
+        try {
+          copyFileSync(join(ROOT, ...file.split('/')), backup);
+          console.log(`  ${file}  (local copy saved: ${file}.bak)`);
+        } catch (err) {
+          // A .bak we could not write is worth saying out loud, but it must not
+          // abort the update — the file itself is still listed either way.
+          console.log(`  ${file}  (could not write ${file}.bak: ${err.message})`);
+        }
+      }
+      if (updateForce) {
+        console.log('--force: overwriting them with the upstream version.');
+      } else {
+        preservedPaths.push(...atRisk);
+        console.log('Keeping your versions. They will NOT receive upstream changes.');
+        console.log('Re-run with `node update-system.mjs apply --force` to take the upstream version instead.');
+      }
+      console.log('');
+    }
+    // Excluding by pathspec keeps the index and the working tree in agreement:
+    // checking out and restoring afterwards would leave the index holding the
+    // upstream blob, so the scoped commit below would record the very content
+    // the user asked to keep out.
+    const preserveSpecs = preservedPaths.map((file) => `:(exclude)${file}`);
+
+    const preservedSet = new Set(preservedPaths);
+
     const skippedPaths = [];
     for (const path of updatePaths) {
+      // `git checkout <ref> -- <path> :(exclude)<path>` errors with "did not
+      // match any file(s)" when the exclusions cancel the whole pathspec — and
+      // that error is indistinguishable from a genuine failure at the catch
+      // below, so it would abort the entire update. Skip the entry instead when
+      // nothing would be left to check out. Only entries that actually contain
+      // a preserved file pay for the extra ls-tree, normally none.
+      if (preservedSet.size > 0) {
+        const preservedHere = preservedPaths.filter((f) => (path.endsWith('/') ? f.startsWith(path) : f === path));
+        if (preservedHere.length > 0) {
+          let upstreamFiles = [];
+          try {
+            upstreamFiles = gitQuiet('ls-tree', '-r', '--name-only', 'FETCH_HEAD', '--', path)
+              .split('\n').map((f) => f.trim()).filter(Boolean);
+          } catch {
+            // Unreadable entry — fall through to the normal checkout, which
+            // reports the real failure with its own diagnostics.
+          }
+          if (upstreamFiles.length > 0 && upstreamFiles.every((f) => preservedSet.has(f))) continue;
+        }
+      }
       try {
         // stderr is piped rather than inherited here. A path absent upstream is
         // an EXPECTED skip (a stale manifest entry such as `.gemini/commands/`),
@@ -1053,7 +1120,7 @@ async function apply() {
         // `error: pathspec '...' did not match any file(s) known to git`
         // immediately before the success banner — which reads as a failed
         // update and sends people chasing the wrong root cause (#1998).
-        gitQuiet('checkout', 'FETCH_HEAD', '--', path);
+        gitQuiet('checkout', 'FETCH_HEAD', '--', path, ...preserveSpecs);
         updated.push(path);
       } catch (err) {
         // A path genuinely absent upstream is the expected skip. But the catch
@@ -1223,7 +1290,10 @@ async function apply() {
 
     // 7. Commit the update
     const remote = localVersion(); // Re-read after checkout updated VERSION
-    const pathsToStage = [...updated];
+    // Files deliberately left untouched are excluded from the staging pathspec
+    // too: this update did not change them, so an "auto-update system files"
+    // commit must not sweep the user's local edit in under its message (#2337).
+    const pathsToStage = [...updated, ...preserveSpecs];
     const dismissFile = join(ROOT, '.update-dismissed');
     if (existsSync(dismissFile)) {
       unlinkSync(dismissFile);
@@ -1405,7 +1475,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       case 'rollback': rollback(); break;
       case 'dismiss': dismiss(); break;
       default:
-        console.log('Usage: node update-system.mjs [check|apply|rollback|dismiss]');
+        console.log('Usage: node update-system.mjs [check|apply [--force]|rollback|dismiss]');
         process.exit(1);
     }
   } catch (err) {

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -738,9 +738,32 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
   }
 
   const changedLocally = new Set(diffNames(baseline || 'HEAD'));
-  if (changedLocally.size === 0) return [];
   const differsFromUpstream = new Set(diffNames(upstreamRef));
-  return [...changedLocally].filter((file) => differsFromUpstream.has(file)).sort();
+  const atRisk = [...changedLocally].filter((file) => differsFromUpstream.has(file));
+
+  // `git diff` never lists untracked files, so a file created locally at a path
+  // the upstream ref DOES ship escapes both sets above — and the checkout
+  // overwrites it with no warning and no .bak, which is the very loss mode this
+  // exists to prevent. Only untracked files upstream actually ships can be
+  // clobbered, so the upstream existence check is the whole filter.
+  let untracked = [];
+  try {
+    untracked = runGit('ls-files', '--others', '--exclude-standard', '--', ...paths)
+      .split('\n').map((f) => f.trim()).filter(Boolean);
+  } catch {
+    // Same degradation contract as diffNames: a warning we cannot compute must
+    // never abort the update.
+  }
+  for (const file of untracked) {
+    try {
+      runGit('cat-file', '-e', `${upstreamRef}:${file}`);
+      atRisk.push(file);
+    } catch {
+      // Purely local file, absent upstream — the checkout cannot touch it.
+    }
+  }
+
+  return [...new Set(atRisk)].sort();
 }
 
 export function revertPaths(paths, protectedPaths = new Set(), ctx = {}) {

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -196,8 +196,30 @@ const twoPassManifestChecks = [
   {
     // execFileSync inherits stderr, so an expected per-path skip printed git's
     // raw pathspec error right before the success banner (#1998).
+    // The trailing spread is the #2337 preserve-exclusions; the property this
+    // pins is the runner (gitQuiet, not git) and the ref, not the arity.
     name: 'per-path checkout pipes stderr so expected skips stay quiet (#1998)',
-    pattern: /gitQuiet\('checkout',\s*'FETCH_HEAD',\s*'--',\s*path\)/,
+    pattern: /gitQuiet\('checkout',\s*'FETCH_HEAD',\s*'--',\s*path(?:,\s*\.\.\.\w+)?\)/,
+  },
+  {
+    // #2337: a system file this install edited must be listed and backed up
+    // before the checkout, not overwritten in silence.
+    name: 'locally edited system files are detected before checkout (#2337)',
+    pattern: /const atRisk = locallyModifiedSystemFiles\(updatePaths, 'FETCH_HEAD'\)/,
+  },
+  {
+    name: 'the local copy is saved as .bak before any overwrite (#2337)',
+    pattern: /copyFileSync\([\s\S]{0,80}?backup\)/,
+  },
+  {
+    name: 'overwriting a locally edited system file requires --force (#2337)',
+    pattern: /updateForce[\s\S]{0,400}?preservedPaths\.push\(\.\.\.atRisk\)/,
+  },
+  {
+    // Excluded paths must stay out of the scoped commit too, or the
+    // "auto-update" commit records the very edit the user kept (#2337).
+    name: 'preserved paths are excluded from the update commit (#2337)',
+    pattern: /pathsToStage = \[\.\.\.updated, \.\.\.preserveSpecs\]/,
   },
   {
     name: 'skipped upstream-absent paths are summarized explicitly (#1998)',


### PR DESCRIPTION
Fixes #2337

Implements the design given in the issue:

> before checkout, diff each `SYSTEM_PATHS` file against `FETCH_HEAD`, list the ones with local modifications, and require an explicit confirmation (or `--force`) to overwrite — with the skipped-by-default option writing a `.bak` alongside. What I'd avoid: turning apply into a merge.

**Not a merge.** The system layer stays system-owned. This only tells people what they are about to lose, and lets them keep it.

## Detection

`locallyModifiedSystemFiles()` is exported and ctx-injectable, like `removeAdditionsNotInHead`. A file is at risk only when **both** hold:

1. it differs from `git merge-base HEAD FETCH_HEAD` — the last commit this install shares with upstream. Anything differing from that baseline was changed *here*, committed or not (`git diff <ref> -- <path>` compares against the working tree);
2. it differs from `FETCH_HEAD` — so the checkout would actually overwrite it.

Plus one case `git diff` cannot see at all: an **untracked** file the user created at a path the upstream ref ships. It appears in neither diff set, and the checkout would overwrite it with no warning and no `.bak` — the exact loss mode this targets (caught in review). Untracked files absent upstream are left out: the checkout cannot touch them.

Condition 2 is what keeps the warning honest: the reporter isolated a case where one of their two fixes survived an update because upstream had independently adopted it. Byte-identical content costs nothing to check out, so warning about it would be noise.

Without a merge-base (shallow clone, unrelated histories) it falls back to `HEAD`: still catches uncommitted edits, just misses already-committed ones. A ref that cannot be read returns an empty list rather than throwing — a degraded warning must never abort an update.

## Behaviour

```
3 system file(s) differ from upstream because THIS install changed them:
  generate-cover-letter.mjs  (local copy saved: generate-cover-letter.mjs.bak)
Keeping your versions. They will NOT receive upstream changes.
Re-run with `node update-system.mjs apply --force` to take the upstream version instead.
```

- **Default:** those files are kept. `--force` overwrites them.
- **`.bak` is written in both branches**, so the local fix is recoverable even from the forced path. `*.bak` is already in `.gitignore`, so the backups never reach a commit.
- `--force` propagates across the self-reexec via `CAREER_OPS_UPDATE_FORCE`, since the re-exec re-invokes the target updater with a fixed argv.

## Two implementation details worth reviewing

**Exclusion is by pathspec, not checkout-then-restore.** Restoring afterwards would leave the *index* holding the upstream blob, so the scoped commit at step 7 would record exactly the content the user asked to keep out.

**An entry whose files are all preserved is skipped outright.** `git checkout <ref> -- <path> :(exclude)<path>` errors with *"did not match any file(s)"* when the exclusions cancel the whole pathspec — and at that call site the error is indistinguishable from a real failure, so it would have aborted the entire update over a file the user chose to keep. My own test caught this before the PR existed; it is pinned as case #9.

Preserved paths are also excluded from the commit pathspec: an "auto-update system files" commit must not sweep the user's uncommitted edit in under its own message.

## Test plan

- [x] New `tests/updater-local-system-edits.test.mjs` — 11 behavioural cases against a throwaway repo (same harness as `updater-rollback-behavior.test.mjs`): committed local fix reported; uncommitted edit reported; upstream-only change silent; upstream-adopted fix silent; user-layer file never listed; multiple edits sorted; bad ref degrades instead of throwing; an untracked file upstream ships is reported, one it does not is not; the exclude pathspec preserves worktree **and** index; a fully-excluded pathspec errors (why the skip exists)
- [x] `updater-migration-tests.mjs` — 4 new source-pattern assertions, and the #1998 stderr guard widened: it matched the checkout call literally, so the added exclusions broke it while the property it protects (`gitQuiet`, not `git`) was untouched
- [x] `node test-all.mjs --quick` — 2794 passed, 0 failed

## One interpretation to confirm

"the skipped-by-default option writing a `.bak` alongside" — I read the `.bak` as a copy of the **local** content, and write it in both branches so nothing is lost either way. If you meant it only for the skipped path, or meant the `.bak` to hold the incoming upstream version instead, say so and it is a two-line change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `update --force` support to overwrite locally modified, deleted, or untracked system files.
  * Without `--force`, local changes are backed up and preserved during updates.
  * Updates now detect local edits made before or after upstream changes.
  * Command-line usage documentation includes the new option.

* **Bug Fixes**
  * Improved preservation of local worktree and index content.
  * Prevented preserved files from being included in update commits.
  * Added safer handling for excluded files and manifest-scoped updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->