### PR TITLE
docs(i18n): add the French interview README (#2426)

### DIFF
--- a/modes/fr/interview/README.md
+++ b/modes/fr/interview/README.md
@@ -1,0 +1,33 @@
+# Compétences d'entretien
+
+Un ensemble de compétences réutilisables pour préparer un entretien de bout en bout.
+
+## Compétences
+
+| Compétence | Fichier | Quand l'utiliser |
+|---|---|---|
+| Planificateur de préparation | `plan.md` | À partir d'une description de poste et d'une date d'entretien, construire un plan de préparation structuré par blocs de temps |
+| Interviewer d'entraînement | `practice.md` | Dérouler des questions d'entretien d'entraînement avec un retour structuré |
+| Débriefing post-entretien | `debrief.md` | Après un véritable entretien, combler les lacunes et mettre à jour la banque de questions |
+
+## Compétences associées (dans le dossier parent `modes/`)
+
+| Compétence | Fichier | Quand l'utiliser |
+|---|---|---|
+| Recherche entreprise | `../../interview-prep.md` | Se renseigner sur une entreprise et un poste précis avant l'entretien |
+
+## Conventions de fichiers
+
+Ces compétences supposent l'existence des fichiers suivants (valeurs par défaut de career-ops) :
+
+| Fichier | Rôle |
+|---|---|
+| `cv.md` | CV du candidat — source de vérité pour l'expérience et les points de preuve |
+| `article-digest.md` | Points de preuve condensés issus du portfolio (optionnel) |
+| `config/profile.yml` | Profil du candidat — postes visés, rémunération, narratif |
+| `modes/_profile.md` | Archétypes du candidat, narratif et critères rédhibitoires |
+| `interview-prep/story-bank.md` | Banque d'histoires STAR+R accumulées |
+| `interview-prep/question-bank.md` | Banque de questions avec suivi des lacunes (créée à la première utilisation) |
+| `interview-prep/interview-prep-guide.md` | Principes généraux d'entretien (optionnel) |
+| `interview-prep/{company}-{role}.md` | Fichier de préparation propre au poste |
+| `interview-prep/retracted-claims.md` | Affirmations que le candidat a écartées comme indéfendables — barrière stricte en entraînement comme en débriefing (format : `**"[claim]"** ([context]). Reason: [raison en une ligne + reformulation correcte le cas échéant].`) |


### PR DESCRIPTION
Part of #2426 — French (`fr`) only, per the one-language-per-PR rule. `es`, `de`, `pt` and `zh` stay open for other contributors.

Every language ships `plan.md`, `practice.md` and `debrief.md`, but the folder index a reader lands on first existed only in Italian. This adds `modes/fr/interview/README.md`.

## Acceptance

- **Natural prose, not machine-literal.** The terminology comes from the existing French modes rather than being re-invented, so the index and the files it points at speak the same language: *Planificateur de préparation* (`fr/interview/plan.md`), *Interviewer d'entraînement* (`practice.md`), *Débriefing post-entretien* (`debrief.md`), *banque d'histoires*, *banque de questions*, *points de preuve*.
- **Structure matches the original.** Verified rather than eyeballed: same 4 headings in the same order, identical table shapes row for row, and the same 15 backticked tokens in the same positions.

Exactly two of those tokens differ from the English, both deliberately:

| English | French | Why |
|---|---|---|
| `../interview-prep.md` | `../../interview-prep.md` | The translated READMEs sit one level deeper (`modes/fr/interview/`), so the parent link needs the extra hop — the same correction `modes/it/interview/README.md` made. Resolved and checked: it lands on `modes/interview-prep.md`. |
| `Reason: [one-line reason + correct framing if applicable]` | `Reason: [raison en une ligne + reformulation correcte le cas échéant]` | Descriptive text inside the `retracted-claims.md` format example. The literal keys (`**"[claim]"**`, `([context])`, `Reason:`) are untouched, matching the Italian treatment. |

## Test plan

- [x] Structural parity checked programmatically against `modes/interview/README.md` (headings, table rows, backticked tokens)
- [x] `../../interview-prep.md` resolves to `modes/interview-prep.md`
- [x] `node test-all.mjs --quick` — 2783 passed, 0 failed
- [x] Mirrors `modes/it/interview/README.md` (#2335), the pattern named in the issue

## Note

I am a native French speaker and this is the language I use career-ops in daily, which is why I took `fr` rather than one of the other four.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added French-language documentation for reusable interview-preparation skills.
  * Described associated files, usage scenarios, shared skills, and required file conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
